### PR TITLE
fix(core): prevent daemon shutdown from cache-poisoned in-process nx loads

### DIFF
--- a/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.spec.ts
+++ b/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.spec.ts
@@ -5,7 +5,7 @@ import { setupAiAgentsGenerator } from './set-up-ai-agents';
 import { SetupAiAgentsGeneratorSchema } from './schema';
 import { readJson } from '../../generators/utils/json';
 import { getAgentRulesWrapped } from '../constants';
-import * as packageJsonUtils from '../../utils/package-json';
+import * as installedNxVersionUtils from '../../utils/installed-nx-version';
 import * as cloneModule from '../clone-ai-config-repo';
 import * as fs from 'fs';
 
@@ -24,27 +24,24 @@ jest.mock('fs', () => {
 
 describe('setup-ai-agents generator', () => {
   let tree: Tree;
-  let readModulePackageJsonSpy: jest.SpyInstance;
+  let getInstalledNxVersionSpy: jest.SpyInstance;
 
   beforeEach(() => {
     tree = createTreeWithEmptyWorkspace();
     // Use local implementation instead of fetching from latest
     process.env.NX_AI_FILES_USE_LOCAL = 'true';
 
-    // Mock readModulePackageJson to return Nx 22+ by default
+    // Mock getInstalledNxVersion to return Nx 22+ by default
     // This ensures existing tests pass by defaulting to the new format
-    readModulePackageJsonSpy = jest
-      .spyOn(packageJsonUtils, 'readModulePackageJson')
-      .mockReturnValue({
-        packageJson: { name: 'nx', version: '22.0.0' },
-        path: '/fake/path/package.json',
-      });
+    getInstalledNxVersionSpy = jest
+      .spyOn(installedNxVersionUtils, 'getInstalledNxVersion')
+      .mockReturnValue('22.0.0');
   });
 
   afterEach(() => {
     delete process.env.NX_AI_FILES_USE_LOCAL;
-    if (readModulePackageJsonSpy) {
-      readModulePackageJsonSpy.mockRestore();
+    if (getInstalledNxVersionSpy) {
+      getInstalledNxVersionSpy.mockRestore();
     }
   });
 
@@ -961,10 +958,7 @@ describe('setup-ai-agents generator', () => {
       });
 
       it('should preserve extra args when upgrading from Nx 21 to 22 (gemini)', async () => {
-        readModulePackageJsonSpy.mockReturnValue({
-          packageJson: { name: 'nx', version: '22.0.0' },
-          path: '/fake/path/package.json',
-        });
+        getInstalledNxVersionSpy.mockReturnValue('22.0.0');
 
         const options: SetupAiAgentsGeneratorSchema = {
           directory: '.',
@@ -1186,10 +1180,7 @@ config_file = ".codex/agents/ci-monitor-subagent.toml"
       });
 
       it('should write generated config.toml with adjusted MCP args for Nx < 22', async () => {
-        readModulePackageJsonSpy.mockReturnValue({
-          packageJson: { name: 'nx', version: '21.0.0' },
-          path: '/fake/path/package.json',
-        });
+        getInstalledNxVersionSpy.mockReturnValue('21.0.0');
 
         const options: SetupAiAgentsGeneratorSchema = {
           directory: '.',
@@ -1327,10 +1318,7 @@ sandbox_mode = "read-only"
 
     describe('Nx version-specific MCP configuration', () => {
       it('should use "nx mcp" for Nx 22+ (gemini)', async () => {
-        readModulePackageJsonSpy.mockReturnValue({
-          packageJson: { name: 'nx', version: '22.0.0' },
-          path: '/fake/path/package.json',
-        });
+        getInstalledNxVersionSpy.mockReturnValue('22.0.0');
 
         const options: SetupAiAgentsGeneratorSchema = {
           directory: '.',
@@ -1350,10 +1338,7 @@ sandbox_mode = "read-only"
       });
 
       it('should use "nx-mcp" for Nx < 22 (gemini)', async () => {
-        readModulePackageJsonSpy.mockReturnValue({
-          packageJson: { name: 'nx', version: '21.0.0' },
-          path: '/fake/path/package.json',
-        });
+        getInstalledNxVersionSpy.mockReturnValue('21.0.0');
 
         const options: SetupAiAgentsGeneratorSchema = {
           directory: '.',
@@ -1373,9 +1358,7 @@ sandbox_mode = "read-only"
       });
 
       it('should use "nx mcp" as fallback when version cannot be determined (gemini)', async () => {
-        readModulePackageJsonSpy.mockImplementation(() => {
-          throw new Error('Module not found');
-        });
+        getInstalledNxVersionSpy.mockReturnValue(null);
 
         // Mock readFileSync to fail only for package.json so it falls back to default version
         // but allow other file reads (needed for generateFiles)
@@ -1413,10 +1396,7 @@ sandbox_mode = "read-only"
       });
 
       it('should use "nx mcp" for Nx 23+ (gemini)', async () => {
-        readModulePackageJsonSpy.mockReturnValue({
-          packageJson: { name: 'nx', version: '23.1.0' },
-          path: '/fake/path/package.json',
-        });
+        getInstalledNxVersionSpy.mockReturnValue('23.1.0');
 
         const options: SetupAiAgentsGeneratorSchema = {
           directory: '.',

--- a/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.ts
+++ b/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync } from 'fs';
+import { readFileSync } from 'fs';
 import { join } from 'path';
 import { major } from 'semver';
 import TOML from 'smol-toml';
@@ -16,14 +16,11 @@ import {
   CLIErrorMessageConfig,
   CLINoteMessageConfig,
 } from '../../utils/output';
-import {
-  installPackageToTmp,
-  readModulePackageJson,
-} from '../../utils/package-json';
+import { installPackageToTmp } from '../../utils/package-json';
 import { addEntryToGitIgnore } from '../../utils/ignore';
 import { ensurePackageHasProvenance } from '../../utils/provenance';
 import { workspaceRoot } from '../../utils/workspace-root';
-import { getNxRequirePaths } from '../../utils/installation-directory';
+import { getInstalledNxVersion } from '../../utils/installed-nx-version';
 import {
   agentsMdPath,
   claudeMcpJsonPath,
@@ -51,56 +48,26 @@ export type ModificationResults = {
 };
 
 /**
- * Get the installed Nx version, with fallback to workspace package.json or default version.
- *
- * Prefers a direct filesystem read of `node_modules/nx/package.json` over
- * `require.resolve('nx/package.json', { paths })`. The latter populates Node's
- * process-wide `Module._pathCache` with the *self-referenced* result (this
- * file lives inside an `nx` package, so the resolver returns this package's
- * own `package.json` regardless of the `paths` argument). When this module
- * is loaded into a daemon process from a temp `nx@latest` install — as
- * happens for `handleGetConfigureAiAgentsStatus` — that pollution makes the
- * daemon's own `getInstalledNxVersion()` return the temp path, triggering a
- * spurious `NX_VERSION_CHANGED` shutdown. See nrwl/nx#35444. Falls back to
- * `readModulePackageJson` for PnP-style layouts where `node_modules` doesn't
- * exist on disk.
+ * Best-effort fallback when `getInstalledNxVersion()` can't find an
+ * installed nx — read the version declared in the workspace's
+ * `package.json` (devDependencies/dependencies), stripping any semver
+ * range prefix, and finally a sane default.
  */
-function getNxVersion(): string {
+function getDeclaredNxVersionOrDefault(): string {
   try {
-    for (const requirePath of getNxRequirePaths(workspaceRoot)) {
-      const candidate = join(requirePath, 'node_modules', 'nx', 'package.json');
-      if (existsSync(candidate)) {
-        const { version } = JSON.parse(readFileSync(candidate, 'utf-8'));
-        if (version) return version;
-      }
+    const workspacePackageJson = JSON.parse(
+      readFileSync(join(workspaceRoot, 'package.json'), 'utf-8')
+    );
+    const declared =
+      workspacePackageJson.devDependencies?.nx ||
+      workspacePackageJson.dependencies?.nx;
+    if (declared) {
+      return declared.replace(/^[\^~>=<]+/, '');
     }
-    // Fallback for non-node_modules layouts (e.g. Yarn PnP).
-    const {
-      packageJson: { version },
-    } = readModulePackageJson('nx');
-    if (version) return version;
-    throw new Error('nx not found');
   } catch {
-    try {
-      // Fallback: try to read from workspace package.json
-      const workspacePackageJson = JSON.parse(
-        readFileSync(join(workspaceRoot, 'package.json'), 'utf-8')
-      );
-      // Check devDependencies first, then dependencies
-      const nxVersion =
-        workspacePackageJson.devDependencies?.nx ||
-        workspacePackageJson.dependencies?.nx;
-      if (nxVersion) {
-        // Remove any semver range characters (^, ~, >=, etc.)
-        return nxVersion.replace(/^[\^~>=<]+/, '');
-      }
-      throw new Error('Nx not found in package.json');
-    } catch {
-      // If we can't determine the version, default to the newer format
-      // This handles cases where nx might not be installed or is globally installed
-      return '22.0.0';
-    }
+    // fall through to default
   }
+  return '22.0.0';
 }
 
 export async function setupAiAgentsGenerator(
@@ -160,7 +127,7 @@ export async function setupAiAgentsGeneratorImpl(
   options: NormalizedSetupAiAgentsGeneratorSchema
 ): Promise<() => Promise<ModificationResults>> {
   const hasAgent = (agent: Agent) => options.agents.includes(agent);
-  const nxVersion = getNxVersion();
+  const nxVersion = getInstalledNxVersion() ?? getDeclaredNxVersionOrDefault();
 
   const agentsMd = agentsMdPath(options.directory);
 

--- a/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.ts
+++ b/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.ts
@@ -16,7 +16,10 @@ import {
   CLIErrorMessageConfig,
   CLINoteMessageConfig,
 } from '../../utils/output';
-import { installPackageToTmp } from '../../utils/package-json';
+import {
+  installPackageToTmp,
+  readModulePackageJson,
+} from '../../utils/package-json';
 import { addEntryToGitIgnore } from '../../utils/ignore';
 import { ensurePackageHasProvenance } from '../../utils/provenance';
 import { workspaceRoot } from '../../utils/workspace-root';
@@ -50,15 +53,17 @@ export type ModificationResults = {
 /**
  * Get the installed Nx version, with fallback to workspace package.json or default version.
  *
- * Reads `node_modules/nx/package.json` directly via the filesystem instead of
+ * Prefers a direct filesystem read of `node_modules/nx/package.json` over
  * `require.resolve('nx/package.json', { paths })`. The latter populates Node's
- * process-wide `Module._pathCache` with the *self-referenced* result (this file
- * lives inside an `nx` package, so the resolver returns this package's own
- * `package.json` regardless of the `paths` argument). When this module is
- * loaded into a daemon process from a temp `nx@latest` install — as happens
- * for `handleGetConfigureAiAgentsStatus` — that pollution makes the daemon's
- * own `getInstalledNxVersion()` return the temp path, triggering a spurious
- * `NX_VERSION_CHANGED` shutdown. See nrwl/nx#35444.
+ * process-wide `Module._pathCache` with the *self-referenced* result (this
+ * file lives inside an `nx` package, so the resolver returns this package's
+ * own `package.json` regardless of the `paths` argument). When this module
+ * is loaded into a daemon process from a temp `nx@latest` install — as
+ * happens for `handleGetConfigureAiAgentsStatus` — that pollution makes the
+ * daemon's own `getInstalledNxVersion()` return the temp path, triggering a
+ * spurious `NX_VERSION_CHANGED` shutdown. See nrwl/nx#35444. Falls back to
+ * `readModulePackageJson` for PnP-style layouts where `node_modules` doesn't
+ * exist on disk.
  */
 function getNxVersion(): string {
   try {
@@ -69,7 +74,12 @@ function getNxVersion(): string {
         if (version) return version;
       }
     }
-    throw new Error('nx not found in node_modules');
+    // Fallback for non-node_modules layouts (e.g. Yarn PnP).
+    const {
+      packageJson: { version },
+    } = readModulePackageJson('nx');
+    if (version) return version;
+    throw new Error('nx not found');
   } catch {
     try {
       // Fallback: try to read from workspace package.json

--- a/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.ts
+++ b/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.ts
@@ -1,4 +1,4 @@
-import { readFileSync } from 'fs';
+import { existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { major } from 'semver';
 import TOML from 'smol-toml';

--- a/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.ts
+++ b/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.ts
@@ -16,13 +16,11 @@ import {
   CLIErrorMessageConfig,
   CLINoteMessageConfig,
 } from '../../utils/output';
-import {
-  installPackageToTmp,
-  readModulePackageJson,
-} from '../../utils/package-json';
+import { installPackageToTmp } from '../../utils/package-json';
 import { addEntryToGitIgnore } from '../../utils/ignore';
 import { ensurePackageHasProvenance } from '../../utils/provenance';
 import { workspaceRoot } from '../../utils/workspace-root';
+import { getNxRequirePaths } from '../../utils/installation-directory';
 import {
   agentsMdPath,
   claudeMcpJsonPath,
@@ -51,14 +49,27 @@ export type ModificationResults = {
 
 /**
  * Get the installed Nx version, with fallback to workspace package.json or default version.
+ *
+ * Reads `node_modules/nx/package.json` directly via the filesystem instead of
+ * `require.resolve('nx/package.json', { paths })`. The latter populates Node's
+ * process-wide `Module._pathCache` with the *self-referenced* result (this file
+ * lives inside an `nx` package, so the resolver returns this package's own
+ * `package.json` regardless of the `paths` argument). When this module is
+ * loaded into a daemon process from a temp `nx@latest` install — as happens
+ * for `handleGetConfigureAiAgentsStatus` — that pollution makes the daemon's
+ * own `getInstalledNxVersion()` return the temp path, triggering a spurious
+ * `NX_VERSION_CHANGED` shutdown. See nrwl/nx#35444.
  */
 function getNxVersion(): string {
   try {
-    // Try to read from node_modules first
-    const {
-      packageJson: { version },
-    } = readModulePackageJson('nx');
-    return version;
+    for (const requirePath of getNxRequirePaths(workspaceRoot)) {
+      const candidate = join(requirePath, 'node_modules', 'nx', 'package.json');
+      if (existsSync(candidate)) {
+        const { version } = JSON.parse(readFileSync(candidate, 'utf-8'));
+        if (version) return version;
+      }
+    }
+    throw new Error('nx not found in node_modules');
   } catch {
     try {
       // Fallback: try to read from workspace package.json

--- a/packages/nx/src/daemon/is-nx-version-mismatch.spec.ts
+++ b/packages/nx/src/daemon/is-nx-version-mismatch.spec.ts
@@ -1,0 +1,63 @@
+import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+import { setWorkspaceRoot } from '../utils/workspace-root';
+import { getInstalledNxVersion } from './is-nx-version-mismatch';
+
+describe('getInstalledNxVersion', () => {
+  let workspaceFixture: string;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    originalCwd = process.cwd();
+    workspaceFixture = join(
+      tmpdir(),
+      `nx-version-mismatch-test-${Date.now()}-${Math.random()
+        .toString(36)
+        .slice(2)}`
+    );
+    mkdirSync(join(workspaceFixture, 'node_modules', 'nx'), {
+      recursive: true,
+    });
+    writeFileSync(
+      join(workspaceFixture, 'node_modules', 'nx', 'package.json'),
+      JSON.stringify({ name: 'nx', version: '99.99.99-test' })
+    );
+    setWorkspaceRoot(workspaceFixture);
+  });
+
+  afterEach(() => {
+    setWorkspaceRoot(originalCwd);
+    rmSync(workspaceFixture, { recursive: true, force: true });
+  });
+
+  it("reads the workspace's nx package.json from disk", () => {
+    expect(getInstalledNxVersion()).toBe('99.99.99-test');
+  });
+
+  it('is immune to Module._pathCache pollution (regression for #35444)', () => {
+    // Simulate a polluted cache entry — the kind that gets written when a
+    // second `nx` package is loaded into the same process (e.g. the
+    // daemon's auto-pull of nx@latest into a tmp dir) and its
+    // `set-up-ai-agents:getNxVersion` triggers a self-reference resolve.
+    // The polluted value points at a non-existent path with a different
+    // version; if `getInstalledNxVersion` were going through
+    // `require.resolve`, it would read this stale pointer and return the
+    // wrong version.
+    const Module = require('module');
+    const pollutedPath = '/nonexistent/tmp/nx/package.json';
+    // Brute-force pollution: write the bogus value under every cache key
+    // that mentions 'nx/package.json'. The fs-walk path reads from disk
+    // unconditionally and should be unaffected.
+    for (const key of Object.keys(Module._pathCache)) {
+      if (key.startsWith('nx/package.json\0')) {
+        Module._pathCache[key] = pollutedPath;
+      }
+    }
+    Module._pathCache[`nx/package.json\0${workspaceFixture}/node_modules`] =
+      pollutedPath;
+
+    expect(getInstalledNxVersion()).toBe('99.99.99-test');
+  });
+});

--- a/packages/nx/src/daemon/is-nx-version-mismatch.ts
+++ b/packages/nx/src/daemon/is-nx-version-mismatch.ts
@@ -6,15 +6,21 @@ import { nxVersion } from '../utils/versions';
 import { workspaceRoot } from '../utils/workspace-root';
 import { getNxRequirePaths } from '../utils/installation-directory';
 
-// Resolve the workspace's installed nx via direct filesystem lookup rather
-// than `require.resolve('nx/package.json', { paths })`. Node's CJS resolver
-// caches results in a process-wide `Module._pathCache` keyed by the expanded
-// `paths` argument, but the resolved value can come from package self-reference
-// (which ignores `paths`). When the daemon loads another `nx` package in-process
-// — e.g. the temp `nx@latest` install used by the AI-agents and console-status
-// checks — that load can populate the cache key the daemon later asks for, so
-// the daemon's "what version is installed?" check returns the temp path.
-// Walking the file system directly is immune to that cache pollution.
+// Resolve the workspace's installed nx via direct filesystem lookup when a
+// `node_modules` layout is in use, falling back to `require.resolve` for
+// PnP-style layouts where `node_modules` doesn't exist on disk.
+//
+// Why not just use `require.resolve('nx/package.json', { paths })` directly:
+// Node's CJS resolver caches results in a process-wide `Module._pathCache`
+// keyed by the expanded `paths` argument, but the resolved value can come
+// from package self-reference (which ignores `paths`). When the daemon
+// loads another `nx` package in-process — e.g. the temp `nx@latest` install
+// used by the AI-agents and console-status checks — that load can populate
+// the cache key the daemon later asks for, so the daemon's "what version is
+// installed?" check returns the temp path. Walking the filesystem directly
+// is immune to that cache pollution; the `require.resolve` fallback is only
+// reached on PnP, where the temp's in-process load doesn't share the same
+// resolution path anyway.
 export function getInstalledNxVersion(): string | null {
   for (const requirePath of getNxRequirePaths(workspaceRoot)) {
     const candidate = join(requirePath, 'node_modules', 'nx', 'package.json');
@@ -22,11 +28,20 @@ export function getInstalledNxVersion(): string | null {
       try {
         return readJsonFile<PackageJson>(candidate).version ?? null;
       } catch {
-        return null;
+        // unreadable; try the next require path
       }
     }
   }
-  return null;
+
+  // Fallback for non-node_modules layouts (e.g. Yarn PnP).
+  try {
+    const nxPackageJsonPath = require.resolve('nx/package.json', {
+      paths: getNxRequirePaths(workspaceRoot),
+    });
+    return readJsonFile<PackageJson>(nxPackageJsonPath).version ?? null;
+  } catch {
+    return null;
+  }
 }
 
 export function isNxVersionMismatch(): boolean {

--- a/packages/nx/src/daemon/is-nx-version-mismatch.ts
+++ b/packages/nx/src/daemon/is-nx-version-mismatch.ts
@@ -1,8 +1,6 @@
 import { nxVersion } from '../utils/versions';
 import { getInstalledNxVersion } from '../utils/installed-nx-version';
 
-export { getInstalledNxVersion };
-
 export function isNxVersionMismatch(): boolean {
   return getInstalledNxVersion() !== nxVersion;
 }

--- a/packages/nx/src/daemon/is-nx-version-mismatch.ts
+++ b/packages/nx/src/daemon/is-nx-version-mismatch.ts
@@ -1,64 +1,7 @@
-import { readJsonFile } from '../utils/fileutils';
-import type { PackageJson } from '../utils/package-json';
 import { nxVersion } from '../utils/versions';
-import { workspaceRoot } from '../utils/workspace-root';
-import { getNxRequirePaths } from '../utils/installation-directory';
+import { getInstalledNxVersion } from '../utils/installed-nx-version';
 
-// Resolve the workspace's installed nx via Node's CJS resolver, but routed
-// through a helper that neutralises the two ways `require.resolve` lies
-// about its `paths` argument (see `resolvePackageJsonWithoutCachePollution`
-// below). One uniform path that works for `node_modules` and PnP layouts.
-export function getInstalledNxVersion(): string | null {
-  const nxPackageJsonPath = resolvePackageJsonWithoutCachePollution(
-    'nx',
-    getNxRequirePaths(workspaceRoot)
-  );
-  if (!nxPackageJsonPath) {
-    return null;
-  }
-  try {
-    return readJsonFile<PackageJson>(nxPackageJsonPath).version ?? null;
-  } catch {
-    return null;
-  }
-}
-
-// Resolve `<packageName>/package.json` via Node's CJS resolver while
-// neutralising both ways the resolver can lie about `paths`:
-//
-//   1. Process-wide `Module._pathCache` — swapped out for the duration of
-//      the call, so any cache entries written are discarded and any
-//      previously-poisoned entries are not read. Without this, an
-//      in-process load of a second `nx` package (e.g. the temp `nx@latest`
-//      install used by the daemon's AI-agents and console-status checks)
-//      can poison the cache key this call uses and make us read the temp
-//      path instead of the workspace path. See nrwl/nx#35444.
-//
-//   2. Package self-reference — when a file inside package "nx" calls
-//      `require.resolve('nx/...')`, Node returns that calling package's
-//      own file regardless of the `paths` argument. We avoid that by
-//      issuing the resolve from a `createRequire` rooted at a synthetic
-//      path that is outside any package, so the resolver has no "self" to
-//      reference and must honour `paths`.
-function resolvePackageJsonWithoutCachePollution(
-  packageName: string,
-  requirePaths: string[]
-): string | null {
-  const Module = require('module');
-  const realCache = Module._pathCache;
-  Module._pathCache = Object.create(null);
-  try {
-    const { createRequire } = Module;
-    const detachedRequire = createRequire('/__nx_detached_resolver__/x.js');
-    return detachedRequire.resolve(`${packageName}/package.json`, {
-      paths: requirePaths,
-    });
-  } catch {
-    return null;
-  } finally {
-    Module._pathCache = realCache;
-  }
-}
+export { getInstalledNxVersion };
 
 export function isNxVersionMismatch(): boolean {
   return getInstalledNxVersion() !== nxVersion;

--- a/packages/nx/src/daemon/is-nx-version-mismatch.ts
+++ b/packages/nx/src/daemon/is-nx-version-mismatch.ts
@@ -1,20 +1,32 @@
+import { existsSync } from 'fs';
+import { join } from 'path';
 import { readJsonFile } from '../utils/fileutils';
 import type { PackageJson } from '../utils/package-json';
 import { nxVersion } from '../utils/versions';
 import { workspaceRoot } from '../utils/workspace-root';
 import { getNxRequirePaths } from '../utils/installation-directory';
 
+// Resolve the workspace's installed nx via direct filesystem lookup rather
+// than `require.resolve('nx/package.json', { paths })`. Node's CJS resolver
+// caches results in a process-wide `Module._pathCache` keyed by the expanded
+// `paths` argument, but the resolved value can come from package self-reference
+// (which ignores `paths`). When the daemon loads another `nx` package in-process
+// — e.g. the temp `nx@latest` install used by the AI-agents and console-status
+// checks — that load can populate the cache key the daemon later asks for, so
+// the daemon's "what version is installed?" check returns the temp path.
+// Walking the file system directly is immune to that cache pollution.
 export function getInstalledNxVersion(): string | null {
-  try {
-    const nxPackageJsonPath = require.resolve('nx/package.json', {
-      paths: getNxRequirePaths(workspaceRoot),
-    });
-    const { version } = readJsonFile<PackageJson>(nxPackageJsonPath);
-    return version;
-  } catch {
-    // node modules are absent
-    return null;
+  for (const requirePath of getNxRequirePaths(workspaceRoot)) {
+    const candidate = join(requirePath, 'node_modules', 'nx', 'package.json');
+    if (existsSync(candidate)) {
+      try {
+        return readJsonFile<PackageJson>(candidate).version ?? null;
+      } catch {
+        return null;
+      }
+    }
   }
+  return null;
 }
 
 export function isNxVersionMismatch(): boolean {

--- a/packages/nx/src/daemon/is-nx-version-mismatch.ts
+++ b/packages/nx/src/daemon/is-nx-version-mismatch.ts
@@ -1,46 +1,62 @@
-import { existsSync } from 'fs';
-import { join } from 'path';
 import { readJsonFile } from '../utils/fileutils';
 import type { PackageJson } from '../utils/package-json';
 import { nxVersion } from '../utils/versions';
 import { workspaceRoot } from '../utils/workspace-root';
 import { getNxRequirePaths } from '../utils/installation-directory';
 
-// Resolve the workspace's installed nx via direct filesystem lookup when a
-// `node_modules` layout is in use, falling back to `require.resolve` for
-// PnP-style layouts where `node_modules` doesn't exist on disk.
-//
-// Why not just use `require.resolve('nx/package.json', { paths })` directly:
-// Node's CJS resolver caches results in a process-wide `Module._pathCache`
-// keyed by the expanded `paths` argument, but the resolved value can come
-// from package self-reference (which ignores `paths`). When the daemon
-// loads another `nx` package in-process — e.g. the temp `nx@latest` install
-// used by the AI-agents and console-status checks — that load can populate
-// the cache key the daemon later asks for, so the daemon's "what version is
-// installed?" check returns the temp path. Walking the filesystem directly
-// is immune to that cache pollution; the `require.resolve` fallback is only
-// reached on PnP, where the temp's in-process load doesn't share the same
-// resolution path anyway.
+// Resolve the workspace's installed nx via Node's CJS resolver, but routed
+// through a helper that neutralises the two ways `require.resolve` lies
+// about its `paths` argument (see `resolvePackageJsonWithoutCachePollution`
+// below). One uniform path that works for `node_modules` and PnP layouts.
 export function getInstalledNxVersion(): string | null {
-  for (const requirePath of getNxRequirePaths(workspaceRoot)) {
-    const candidate = join(requirePath, 'node_modules', 'nx', 'package.json');
-    if (existsSync(candidate)) {
-      try {
-        return readJsonFile<PackageJson>(candidate).version ?? null;
-      } catch {
-        // unreadable; try the next require path
-      }
-    }
+  const nxPackageJsonPath = resolvePackageJsonWithoutCachePollution(
+    'nx',
+    getNxRequirePaths(workspaceRoot)
+  );
+  if (!nxPackageJsonPath) {
+    return null;
   }
-
-  // Fallback for non-node_modules layouts (e.g. Yarn PnP).
   try {
-    const nxPackageJsonPath = require.resolve('nx/package.json', {
-      paths: getNxRequirePaths(workspaceRoot),
-    });
     return readJsonFile<PackageJson>(nxPackageJsonPath).version ?? null;
   } catch {
     return null;
+  }
+}
+
+// Resolve `<packageName>/package.json` via Node's CJS resolver while
+// neutralising both ways the resolver can lie about `paths`:
+//
+//   1. Process-wide `Module._pathCache` — swapped out for the duration of
+//      the call, so any cache entries written are discarded and any
+//      previously-poisoned entries are not read. Without this, an
+//      in-process load of a second `nx` package (e.g. the temp `nx@latest`
+//      install used by the daemon's AI-agents and console-status checks)
+//      can poison the cache key this call uses and make us read the temp
+//      path instead of the workspace path. See nrwl/nx#35444.
+//
+//   2. Package self-reference — when a file inside package "nx" calls
+//      `require.resolve('nx/...')`, Node returns that calling package's
+//      own file regardless of the `paths` argument. We avoid that by
+//      issuing the resolve from a `createRequire` rooted at a synthetic
+//      path that is outside any package, so the resolver has no "self" to
+//      reference and must honour `paths`.
+function resolvePackageJsonWithoutCachePollution(
+  packageName: string,
+  requirePaths: string[]
+): string | null {
+  const Module = require('module');
+  const realCache = Module._pathCache;
+  Module._pathCache = Object.create(null);
+  try {
+    const { createRequire } = Module;
+    const detachedRequire = createRequire('/__nx_detached_resolver__/x.js');
+    return detachedRequire.resolve(`${packageName}/package.json`, {
+      paths: requirePaths,
+    });
+  } catch {
+    return null;
+  } finally {
+    Module._pathCache = realCache;
   }
 }
 

--- a/packages/nx/src/daemon/server/server.ts
+++ b/packages/nx/src/daemon/server/server.ts
@@ -15,10 +15,8 @@ import { setupWorkspaceContext } from '../../utils/workspace-context';
 import { workspaceRoot } from '../../utils/workspace-root';
 import { getPlugins } from '../../project-graph/plugins/get-plugins';
 import { getDaemonProcessIdSync, writeDaemonJsonProcessCache } from '../cache';
-import {
-  getInstalledNxVersion,
-  isNxVersionMismatch,
-} from '../is-nx-version-mismatch';
+import { isNxVersionMismatch } from '../is-nx-version-mismatch';
+import { getInstalledNxVersion } from '../../utils/installed-nx-version';
 import { serverLogger } from '../logger';
 import {
   GET_CONFIGURE_AI_AGENTS_STATUS,

--- a/packages/nx/src/utils/installed-nx-version.spec.ts
+++ b/packages/nx/src/utils/installed-nx-version.spec.ts
@@ -2,8 +2,8 @@ import { mkdirSync, rmSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
 
-import { setWorkspaceRoot } from '../utils/workspace-root';
-import { getInstalledNxVersion } from './is-nx-version-mismatch';
+import { setWorkspaceRoot } from './workspace-root';
+import { getInstalledNxVersion } from './installed-nx-version';
 
 describe('getInstalledNxVersion', () => {
   let workspaceFixture: string;
@@ -39,12 +39,12 @@ describe('getInstalledNxVersion', () => {
   it('is immune to Module._pathCache pollution (regression for #35444)', () => {
     // Simulate a polluted cache entry — the kind that gets written when a
     // second `nx` package is loaded into the same process (e.g. the
-    // daemon's auto-pull of nx@latest into a tmp dir) and its
-    // `set-up-ai-agents:getNxVersion` triggers a self-reference resolve.
-    // The polluted value points at a non-existent path with a different
-    // version; if `getInstalledNxVersion` were going through
-    // `require.resolve`, it would read this stale pointer and return the
-    // wrong version.
+    // daemon's auto-pull of nx@latest into a tmp dir) and code inside that
+    // second package issues a `require.resolve('nx/package.json', { paths })`
+    // that triggers self-reference. The polluted value points at a
+    // non-existent path with a different version; if `getInstalledNxVersion`
+    // were going through `require.resolve` without the cache shield, it
+    // would read this stale pointer and return the wrong version.
     const Module = require('module');
     const pollutedPath = '/nonexistent/tmp/nx/package.json';
     // Brute-force pollution: write the bogus value under every cache key

--- a/packages/nx/src/utils/installed-nx-version.ts
+++ b/packages/nx/src/utils/installed-nx-version.ts
@@ -1,3 +1,4 @@
+import Module, { createRequire } from 'node:module';
 import { readJsonFile } from './fileutils';
 import type { PackageJson } from './package-json';
 import { workspaceRoot } from './workspace-root';
@@ -52,11 +53,10 @@ function resolvePackageJsonWithoutCachePollution(
   packageName: string,
   requirePaths: string[]
 ): string | null {
-  const Module = require('module');
-  const realCache = Module._pathCache;
-  Module._pathCache = Object.create(null);
+  // `_pathCache` is an internal Node API not exposed in @types/node.
+  const realCache = (Module as any)._pathCache;
+  (Module as any)._pathCache = Object.create(null);
   try {
-    const { createRequire } = Module;
     const detachedRequire = createRequire('/__nx_detached_resolver__/x.js');
     return detachedRequire.resolve(`${packageName}/package.json`, {
       paths: requirePaths,
@@ -64,6 +64,6 @@ function resolvePackageJsonWithoutCachePollution(
   } catch {
     return null;
   } finally {
-    Module._pathCache = realCache;
+    (Module as any)._pathCache = realCache;
   }
 }

--- a/packages/nx/src/utils/installed-nx-version.ts
+++ b/packages/nx/src/utils/installed-nx-version.ts
@@ -1,0 +1,69 @@
+import { readJsonFile } from './fileutils';
+import type { PackageJson } from './package-json';
+import { workspaceRoot } from './workspace-root';
+import { getNxRequirePaths } from './installation-directory';
+
+/**
+ * Resolve the workspace's installed `nx` version, or `null` if no installed
+ * `nx` can be located. Routed through a cache-shielded, self-reference-free
+ * `require.resolve` so the answer always reflects the workspace's
+ * `node_modules`/PnP store rather than whichever `nx` package happens to be
+ * loaded in the current process. See nrwl/nx#35444.
+ */
+export function getInstalledNxVersion(): string | null {
+  const nxPackageJsonPath = resolvePackageJsonWithoutCachePollution(
+    'nx',
+    getNxRequirePaths(workspaceRoot)
+  );
+  if (!nxPackageJsonPath) {
+    return null;
+  }
+  try {
+    return readJsonFile<PackageJson>(nxPackageJsonPath).version ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Resolve `<packageName>/package.json` via Node's CJS resolver while
+ * neutralising both ways `require.resolve(req, { paths })` can lie about
+ * the `paths` argument:
+ *
+ *   1. Process-wide `Module._pathCache` — swapped out for the duration of
+ *      the call, so any cache entries written are discarded and any
+ *      previously-poisoned entries are not read. Without this, an
+ *      in-process load of a second `nx` package (e.g. the temp `nx@latest`
+ *      install used by the daemon's AI-agents and console-status checks)
+ *      can poison the cache key this call uses and make us read the temp
+ *      path instead of the workspace path.
+ *
+ *   2. Package self-reference — when a file inside package `nx` calls
+ *      `require.resolve('nx/...')`, Node returns that calling package's
+ *      own file regardless of `paths`. We avoid that by issuing the
+ *      resolve from a `createRequire` rooted at a synthetic path that is
+ *      outside any package, so the resolver has no "self" to reference
+ *      and must honour `paths`.
+ *
+ * Node's single-threaded synchronous execution means `require.resolve` does
+ * not yield, so no other code in the process can observe the swapped cache.
+ */
+function resolvePackageJsonWithoutCachePollution(
+  packageName: string,
+  requirePaths: string[]
+): string | null {
+  const Module = require('module');
+  const realCache = Module._pathCache;
+  Module._pathCache = Object.create(null);
+  try {
+    const { createRequire } = Module;
+    const detachedRequire = createRequire('/__nx_detached_resolver__/x.js');
+    return detachedRequire.resolve(`${packageName}/package.json`, {
+      paths: requirePaths,
+    });
+  } catch {
+    return null;
+  } finally {
+    Module._pathCache = realCache;
+  }
+}


### PR DESCRIPTION
## Current Behavior

On every first `nx` command run by a 22.6.x workspace once `22.7.0` shipped to npm, the daemon spuriously shuts itself down with:

```
[Server] Daemon outdated: NX_VERSION_CHANGED
[Server] Shutting down daemon (no restart)…
Server stopped because: "NX_VERSION_CHANGED"
```

Visible symptoms in the field (#35444): "stuck on Calculating project graph", `EPIPE` mid-task, and broken CI/CD pipelines for users who haven't upgraded past `22.6.x`.

### Root cause

The daemon's `handleGetNxConsoleStatus` and `handleGetConfigureAiAgentsStatus` install `nx@latest` to a temp dir and `require()` files from that install **into the daemon's own Node process**. Two `nx` packages now share one process — the workspace's installed copy and the temp copy.

Inside the temp copy, `setupAiAgentsGenerator(..., inner: true)` calls `getNxVersion()`, which calls `readModulePackageJson('nx')`, which calls:

```ts
require.resolve('nx/package.json', { paths: getNxRequirePaths(workspaceRoot) })
```

The calling file lives inside the temp's `nx` package, whose `package.json` has `name: "nx"` and an `exports` map. Per Node's CJS resolver, that makes `'nx/package.json'` qualify as a **package self-reference**, which resolves to the calling package's own `package.json` — `/tmp/.../nx/package.json` — **ignoring the `paths` argument**.

`Module._findPath` then writes the result to its process-wide cache, but builds the cache key from the (workspace-rooted) `paths` argument:

```
Module._pathCache["nx/package.json\0<workspace>/.nx/installation/node_modules\0…"]
    =  /tmp/.../node_modules/nx/package.json
```

20 ms later, the daemon's own watchdog runs `getInstalledNxVersion()` with the same `paths`, hits the polluted cache entry, and reads back the `/tmp` `package.json` — version `22.7.0`. Compared against the daemon's frozen `nxVersion` (`22.6.5`), they differ; `daemonIsOutdated()` returns `'NX_VERSION_CHANGED'`; the daemon tears itself down.

The bug stayed dormant from `22.6.0` (when the in-process latest-pull pattern shipped, #34463) until `22.7.0` was published, because while `latest === installed` the polluted cache value matched the constant. PR #34111 (which gave `nx`'s `package.json` an `exports` field for the first time) is what enabled self-reference, without which `paths` would have been honored and no pollution would have occurred.

## Expected Behavior

The daemon stays alive across `nx` commands. Pulling `nx@latest` and running the in-process console / AI-agents checks does not poison the resolver cache, and `getInstalledNxVersion()` keeps returning the workspace's actual installed version.

### Fix

Replace both `require.resolve('nx/package.json', { paths })` callsites with a direct filesystem walk over the same `getNxRequirePaths(workspaceRoot)`. Walking the filesystem bypasses Node's resolver entirely and is immune to `Module._pathCache` pollution.

**`packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.ts:getNxVersion`** — the polluter. Once this ships, every existing `22.6.x` daemon picks up the fix automatically via its next `nx@latest` pull. The daemon's own (still-buggy) check then has nothing to misread, and stops dying — without users having to upgrade their workspace at all.

**`packages/nx/src/daemon/is-nx-version-mismatch.ts:getInstalledNxVersion`** — the victim. Defensive: if any future code path added to the in-process latest-pull triggers the same `require.resolve('nx/package.json', { paths })` pattern, the daemon's verdict on "what version is installed?" stays correct anyway.

### Verification

Reproduced locally with a `22.6.5` workspace (yarn 4) using the original unfixed `is-nx-version-mismatch.js`:

- **Before**: daemon shut itself down with `NX_VERSION_CHANGED` on every first command after `22.7.0` published.
- **After** (fix published as `nx@latest` to a local Verdaccio): daemon pulled the fixed temp, ran both inner checks (`[NX-CONSOLE]: Console status check completed`, `[AI-AGENTS]: Agent configuration status computation completed`), and survived three consecutive `nx` commands. No `Daemon outdated`, no `Server stopped`, same daemon PID across commands.

This empirically confirms the `set-up-ai-agents` fix retroactively heals `22.6.x` users without them touching their workspace.

## Related Issue(s)

Fixes #35444
