### PR TITLE
fix(react): withSvgr migration preserves other properties

### DIFF
--- a/packages/react/src/migrations/update-22-0-0/add-svgr-to-webpack-config.spec.ts
+++ b/packages/react/src/migrations/update-22-0-0/add-svgr-to-webpack-config.spec.ts
@@ -691,6 +691,165 @@ export default composePlugins(
       `);
     });
 
+    it('should preserve other withReact options when removing svgr: false', async () => {
+      tree.write(
+        'apps/my-app/project.json',
+        JSON.stringify({
+          root: 'apps/my-app',
+          targets: {
+            build: {
+              executor: '@nx/webpack:webpack',
+              options: {
+                webpackConfig: 'apps/my-app/webpack.config.js',
+              },
+            },
+          },
+        })
+      );
+
+      tree.write(
+        'apps/my-app/webpack.config.js',
+        `const { composePlugins, withNx } = require('@nx/webpack');
+const { withReact } = require('@nx/react');
+
+module.exports = composePlugins(
+  withNx(),
+  withReact({
+    svgr: false,
+    stylePreprocessorOptions: { sassOptions: { quietDeps: true } },
+  }),
+  (config) => {
+    return config;
+  }
+);
+`
+      );
+
+      await addSvgrToWebpackConfig(tree);
+
+      const content = tree.read('apps/my-app/webpack.config.js', 'utf-8');
+      expect(content).toMatchInlineSnapshot(`
+        "const { composePlugins, withNx } = require('@nx/webpack');
+        const { withReact } = require('@nx/react');
+
+        module.exports = composePlugins(
+          withNx(),
+          withReact({
+            stylePreprocessorOptions: { sassOptions: { quietDeps: true } },
+          }),
+          (config) => {
+            return config;
+          },
+        );
+        "
+      `);
+    });
+
+    it('should preserve other withReact options when migrating svgr: true', async () => {
+      tree.write(
+        'apps/my-app/project.json',
+        JSON.stringify({
+          root: 'apps/my-app',
+          targets: {
+            build: {
+              executor: '@nx/webpack:webpack',
+              options: {
+                webpackConfig: 'apps/my-app/webpack.config.js',
+              },
+            },
+          },
+        })
+      );
+
+      tree.write(
+        'apps/my-app/webpack.config.js',
+        `const { composePlugins, withNx } = require('@nx/webpack');
+const { withReact } = require('@nx/react');
+
+module.exports = composePlugins(
+  withNx(),
+  withReact({
+    svgr: true,
+    stylePreprocessorOptions: { sassOptions: { quietDeps: true } },
+  }),
+  (config) => {
+    return config;
+  }
+);
+`
+      );
+
+      await addSvgrToWebpackConfig(tree);
+
+      const content = tree.read('apps/my-app/webpack.config.js', 'utf-8');
+      expect(content).toMatchInlineSnapshot(`
+        "const { composePlugins, withNx } = require('@nx/webpack');
+        const { withReact } = require('@nx/react');
+
+        // SVGR support function (migrated from svgr option in withReact/NxReactWebpackPlugin)
+        function withSvgr(svgrOptions = {}) {
+          const defaultOptions = {
+            svgo: false,
+            titleProp: true,
+            ref: true,
+          };
+
+          const options = { ...defaultOptions, ...svgrOptions };
+
+          return function configure(config) {
+            // Remove existing SVG loader if present
+            const svgLoaderIdx = config.module.rules.findIndex(
+              (rule) =>
+                typeof rule === 'object' &&
+                typeof rule.test !== 'undefined' &&
+                rule.test.toString().includes('svg'),
+            );
+
+            if (svgLoaderIdx !== -1) {
+              config.module.rules.splice(svgLoaderIdx, 1);
+            }
+
+            // Add SVGR loader with webpack 5 asset modules
+            config.module.rules.push({
+              test: /\\.svg$/,
+              oneOf: [
+                {
+                  resourceQuery: /url/,
+                  type: 'asset/resource',
+                  generator: {
+                    filename: '[name].[hash][ext]',
+                  },
+                },
+                {
+                  issuer: /\\.(js|ts|md)x?$/,
+                  use: [
+                    {
+                      loader: require.resolve('@svgr/webpack'),
+                      options,
+                    },
+                  ],
+                },
+              ],
+            });
+
+            return config;
+          };
+        }
+
+        module.exports = composePlugins(
+          withNx(),
+          withReact({
+            stylePreprocessorOptions: { sassOptions: { quietDeps: true } },
+          }),
+          withSvgr(),
+          (config) => {
+            return config;
+          },
+        );
+        "
+      `);
+    });
+
     it('should remove svgr: false from withReact', async () => {
       tree.write(
         'apps/my-app/project.json',

--- a/packages/react/src/migrations/update-22-0-0/add-svgr-to-webpack-config.ts
+++ b/packages/react/src/migrations/update-22-0-0/add-svgr-to-webpack-config.ts
@@ -322,11 +322,43 @@ export default async function addSvgrToWebpackConfig(tree: Tree) {
             ) as ts.PropertyAssignment | undefined;
 
             if (svgrProp) {
-              changes.push({
-                type: ChangeType.Delete,
-                start: arg.getStart(),
-                length: arg.getEnd() - arg.getStart(),
-              });
+              const hasOnlySvgrProperty = arg.properties.length === 1;
+
+              if (hasOnlySvgrProperty) {
+                changes.push({
+                  type: ChangeType.Delete,
+                  start: arg.getStart(),
+                  length: arg.getEnd() - arg.getStart(),
+                });
+              } else {
+                const propIndex = arg.properties.indexOf(svgrProp);
+                const isLastProp = propIndex === arg.properties.length - 1;
+                const isFirstProp = propIndex === 0;
+
+                let removeStart = svgrProp.getFullStart();
+                let removeEnd = svgrProp.getEnd();
+
+                if (!isLastProp) {
+                  const nextProp = arg.properties[propIndex + 1];
+                  removeEnd = nextProp.getFullStart();
+                } else if (!isFirstProp) {
+                  const prevProp = arg.properties[propIndex - 1];
+                  const textBetween = content.substring(
+                    prevProp.getEnd(),
+                    svgrProp.getFullStart()
+                  );
+                  const commaIndex = textBetween.indexOf(',');
+                  if (commaIndex !== -1) {
+                    removeStart = prevProp.getEnd() + commaIndex;
+                  }
+                }
+
+                changes.push({
+                  type: ChangeType.Delete,
+                  start: removeStart,
+                  length: removeEnd - removeStart,
+                });
+              }
 
               if (config.svgrOptions) {
                 const composePluginsCalls = query(


### PR DESCRIPTION
The current migration erroneously removes all withReact properties. This will be copied for the Rspack migration for v23 as well.

Closes NXC-3982