### PR TITLE
fix(core): add provenance check in nx console status path

### DIFF
--- a/packages/nx/src/daemon/server/latest-nx.ts
+++ b/packages/nx/src/daemon/server/latest-nx.ts
@@ -1,4 +1,5 @@
 import { installPackageToTmpAsync } from '../../devkit-internals';
+import { ensurePackageHasProvenance } from '../../utils/provenance';
 import { serverLogger } from '../logger';
 
 // Module-level state - persists across invocations within daemon lifecycle
@@ -27,6 +28,7 @@ export async function getLatestNxTmpPath(): Promise<string> {
   installPromise = (async () => {
     try {
       serverLogger.log('[LATEST-NX]: Pulling latest Nx...');
+      await ensurePackageHasProvenance('nx', 'latest');
       const result = await installPackageToTmpAsync('nx', 'latest');
       latestNxTmpPath = result.tempDir;
       cleanupFn = result.cleanup;


### PR DESCRIPTION
## Current Behavior
nx console's status check is missing a provenance check

## Expected Behavior
provenance is validated before installing latest nx

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
