### PR TITLE
fix(core): skip target-defaults synthesis when defaults are incompatible with the specified target

### DIFF
--- a/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
@@ -716,6 +716,140 @@ describe('project-configuration-utils', () => {
       expect(buildTarget.inputs).toEqual(['explicit', 'inferred']);
     });
 
+    it('should not let a target-name-keyed default with a foreign executor replace an inferred command target', () => {
+      // Repro: a polyglot workspace has a target-name keyed default
+      // (`test-native`) configured for the rust plugin's executor, and
+      // another plugin (e.g. the dotnet plugin) infers a target with the
+      // same name using the `command` shorthand. The two are incompatible
+      // (run-commands vs @monodon/rust:test), so the inferred target should
+      // win — but currently the synthetic target-defaults entry layers on
+      // top and replaces the executor + options with the rust ones.
+      const specifiedResults = [
+        [
+          [
+            '@nx/dotnet',
+            'libs/dotnet-lib/MyLib.Tests.csproj',
+            {
+              projects: {
+                'libs/dotnet-lib': {
+                  name: 'dotnet-lib',
+                  root: 'libs/dotnet-lib',
+                  targets: {
+                    'test-native': {
+                      command: 'dotnet test',
+                      options: { cwd: '{projectRoot}' },
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        ],
+      ] as const;
+
+      const errors = [];
+      const result = mergeCreateNodesResults(
+        specifiedResults as any,
+        [],
+        {
+          targetDefaults: {
+            'test-native': {
+              executor: '@monodon/rust:test',
+              options: {},
+              cache: true,
+            },
+          },
+        },
+        '/tmp/test',
+        errors
+      );
+
+      const testTarget =
+        result.projectRootMap['libs/dotnet-lib'].targets!['test-native'];
+      // The inferred target should still be the run-commands invocation
+      // for `dotnet test` — the rust default's executor is incompatible
+      // and must not silently take over.
+      expect(testTarget.executor).toEqual('nx:run-commands');
+      expect(testTarget.options).toEqual(
+        expect.objectContaining({ command: 'dotnet test' })
+      );
+      expect(errors).toEqual([]);
+    });
+
+    it('should not apply a target-name-keyed default with a foreign executor when project.json declares an empty target alongside an inferred command target', () => {
+      // Same incompatibility, but project.json declares `{}` for the
+      // target — historically the trigger that asks target-defaults to
+      // fill the target in. The fill-in still shouldn't pull a
+      // foreign-executor default on top of the inferred command target.
+      const specifiedResults = [
+        [
+          [
+            '@nx/dotnet',
+            'libs/dotnet-lib/MyLib.Tests.csproj',
+            {
+              projects: {
+                'libs/dotnet-lib': {
+                  name: 'dotnet-lib',
+                  root: 'libs/dotnet-lib',
+                  targets: {
+                    'test-native': {
+                      command: 'dotnet test',
+                      options: { cwd: '{projectRoot}' },
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        ],
+      ] as const;
+
+      const defaultResults = [
+        [
+          [
+            'nx/core/project-json',
+            'libs/dotnet-lib/project.json',
+            {
+              projects: {
+                'libs/dotnet-lib': {
+                  name: 'dotnet-lib',
+                  root: 'libs/dotnet-lib',
+                  targets: {
+                    'test-native': {},
+                  },
+                },
+              },
+            },
+          ],
+        ],
+      ] as const;
+
+      const errors = [];
+      const result = mergeCreateNodesResults(
+        specifiedResults as any,
+        defaultResults as any,
+        {
+          targetDefaults: {
+            'test-native': {
+              executor: '@monodon/rust:test',
+              options: {},
+              cache: true,
+            },
+          },
+        },
+        '/tmp/test',
+        errors
+      );
+
+      const testTarget =
+        result.projectRootMap['libs/dotnet-lib'].targets!['test-native'];
+      expect(testTarget.executor).toEqual('nx:run-commands');
+      expect(testTarget.options).toEqual(
+        expect.objectContaining({ command: 'dotnet test' })
+      );
+      expect(errors).toEqual([]);
+    });
+
     it('should merge multiple specified plugins contributing to the same project', () => {
       const specifiedResults = [
         [

--- a/packages/nx/src/project-graph/utils/project-configuration/target-defaults.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-defaults.ts
@@ -96,15 +96,26 @@ function buildSyntheticTargetForRoot(
     ? resolveCommandSyntacticSugar(defaultTarget, root)
     : undefined;
 
-  // Specified-only: layer defaults on top; the downstream merge handles
-  // executor mismatches by replacing.
+  // Specified-only: layer defaults on top, but only when the resulting
+  // synthetic is compatible with the specified target. An incompatible
+  // synthetic (e.g. `targetDefaults['test-native'] = { executor:
+  // '@monodon/rust:test' }` while a polyglot plugin infers `test-native`
+  // with `nx:run-commands`) would otherwise replace the specified target
+  // wholesale during the downstream merge.
   if (resolvedSpecified && !resolvedDefault) {
-    return readAndPrepareTargetDefaults(
+    const targetDefaults = readAndPrepareTargetDefaults(
       targetName,
       resolvedSpecified.executor,
       root,
       targetDefaultsConfig
     );
+    if (
+      targetDefaults &&
+      !isCompatibleTarget(resolvedSpecified, targetDefaults)
+    ) {
+      return undefined;
+    }
+    return targetDefaults;
   }
 
   // Default-only.
@@ -120,13 +131,24 @@ function buildSyntheticTargetForRoot(
   if (!resolvedSpecified || !resolvedDefault) return undefined;
 
   // Both compatible: use the default plugin's executor for the lookup.
+  // The same incompatibility check applies — a project.json `{}` entry
+  // asks defaults to fill in the target, but the lookup can still fall
+  // back to a target-name keyed default with a foreign executor that
+  // would replace the inferred target. Skip the synthetic in that case.
   if (isCompatibleTarget(resolvedSpecified, resolvedDefault)) {
-    return readAndPrepareTargetDefaults(
+    const targetDefaults = readAndPrepareTargetDefaults(
       targetName,
       resolvedDefault.executor || resolvedSpecified.executor,
       root,
       targetDefaultsConfig
     );
+    if (
+      targetDefaults &&
+      !isCompatibleTarget(resolvedSpecified, targetDefaults)
+    ) {
+      return undefined;
+    }
+    return targetDefaults;
   }
 
   // Incompatible: default plugin will replace specified; only defaults


### PR DESCRIPTION
When a `targetDefaults` entry keyed by target name carries an executor that differs from an inferred (specified-plugin) target's executor, the synthetic plugin built by `createTargetDefaultsResults` would be merged on top of the specified target. The downstream "incompatible executor" branch in `mergeTargetConfigurations` then dropped the specified target's options/configurations and let the synthetic's executor win, silently replacing the inferred command with the unrelated default executor.

Skip synthesis in the specified-only branch when the resolved default is incompatible with the specified target. The default was authored for a different executor and shouldn't apply.

Surfaces in polyglot workspaces — e.g. a `targetDefaults['test-native']` configured for `@monodon/rust:test` was overriding a dotnet plugin's inferred `test-native` (`command: 'dotnet test'`), causing CI to run `cargo test` against C# projects.
