### PR TITLE
chore(core): update misc e2e target info snapshot for tsconfig solution input

### DIFF
--- a/e2e/nx/src/__snapshots__/misc.test.ts.snap
+++ b/e2e/nx/src/__snapshots__/misc.test.ts.snap
@@ -79,6 +79,7 @@ Inputs:
   - default
   - ^production
   - {"externalDependencies":["webpack-cli"]}
+  - {"json":"{workspaceRoot}/tsconfig.json","fields":["extends","files","include"]}
 Outputs:
   - {workspaceRoot}/dist/apps/<APP>
 Options:


### PR DESCRIPTION
## Current Behavior

The `Nx Commands show show target human-readable output should render target info` snapshot test in `e2e/nx/src/misc.test.ts` fails on master. Recent changes that include the tsconfig solution input for webpack added a new input entry (`{"json":"{workspaceRoot}/tsconfig.json","fields":["extends","files","include"]}`) to the resolved target info, but the snapshot was not updated.

## Expected Behavior

Snapshot reflects the new tsconfig solution input so the e2e test passes.

## Related Issue(s)

N/A — follow-up to 7a6f796047 / ca7671afd6 which added the tsconfig solution input to webpack/rollup.