### PR TITLE
fix(core): preserve user-supplied nx.metadata in package.json projects

### DIFF
--- a/packages/nx/src/plugins/package-json/create-nodes.spec.ts
+++ b/packages/nx/src/plugins/package-json/create-nodes.spec.ts
@@ -1062,4 +1062,35 @@ describe('nx package.json workspaces plugin', () => {
       foo: 'bar',
     });
   });
+
+  it('should deeply merge nested objects in user-supplied nx.metadata with auto-generated metadata', () => {
+    vol.fromJSON(
+      {
+        'package.json': JSON.stringify({
+          name: 'lib-a',
+          scripts: { build: 'echo 1' },
+          nx: {
+            metadata: {
+              targetGroups: {
+                Custom: ['lint'],
+              },
+            },
+          },
+        }),
+      },
+      '/root'
+    );
+
+    const result = createNodeFromPackageJson(
+      'package.json',
+      '/root',
+      new PluginCache(),
+      false
+    );
+
+    expect(result.projects['.'].metadata.targetGroups).toEqual({
+      'NPM Scripts': ['build'],
+      Custom: ['lint'],
+    });
+  });
 });

--- a/packages/nx/src/plugins/package-json/create-nodes.spec.ts
+++ b/packages/nx/src/plugins/package-json/create-nodes.spec.ts
@@ -1035,4 +1035,31 @@ describe('nx package.json workspaces plugin', () => {
       ]
     `);
   });
+
+  it('should preserve user-supplied nx.metadata keys alongside auto-generated metadata', () => {
+    vol.fromJSON(
+      {
+        'package.json': JSON.stringify({
+          name: 'lib-a',
+          nx: {
+            metadata: {
+              foo: 'bar',
+            },
+          },
+        }),
+      },
+      '/root'
+    );
+
+    const result = createNodeFromPackageJson(
+      'package.json',
+      '/root',
+      new PluginCache(),
+      false
+    );
+
+    expect(result.projects['.'].metadata).toMatchObject({
+      foo: 'bar',
+    });
+  });
 });

--- a/packages/nx/src/utils/package-json.spec.ts
+++ b/packages/nx/src/utils/package-json.spec.ts
@@ -865,4 +865,26 @@ describe('getMetadataFromPackageJson', () => {
     );
     expect(result.description).toEqual('User description');
   });
+
+  it('should deeply merge nested objects in user-supplied metadata with auto-generated metadata', () => {
+    const result = getMetadataFromPackageJson(
+      {
+        name: 'my-app',
+        version: '0.0.0',
+        scripts: { build: 'echo 1' },
+        nx: {
+          metadata: {
+            targetGroups: {
+              Custom: ['lint'],
+            },
+          } as any,
+        },
+      },
+      false
+    );
+    expect(result.targetGroups).toEqual({
+      'NPM Scripts': ['build'],
+      Custom: ['lint'],
+    });
+  });
 });

--- a/packages/nx/src/utils/package-json.spec.ts
+++ b/packages/nx/src/utils/package-json.spec.ts
@@ -11,6 +11,7 @@ import { readJsonFile } from './fileutils';
 import {
   buildTargetFromScript,
   getDependencyVersionFromPackageJson,
+  getMetadataFromPackageJson,
   installPackageToTmp,
   PackageJson,
   readModulePackageJson,
@@ -807,5 +808,61 @@ catalogs:
       expect(reactVersion).toBe('^18.2.0');
       expect(lodashVersion).toBe('^4.17.21');
     });
+  });
+});
+
+describe('getMetadataFromPackageJson', () => {
+  it('should derive description and targetGroups from the package.json', () => {
+    const result = getMetadataFromPackageJson(
+      {
+        name: 'my-app',
+        version: '0.0.0',
+        description: 'Hello',
+        scripts: { build: 'echo 1' },
+      },
+      false
+    );
+    expect(result).toMatchObject({
+      description: 'Hello',
+      targetGroups: { 'NPM Scripts': ['build'] },
+    });
+  });
+
+  it('should preserve user-supplied keys on nx.metadata', () => {
+    const result = getMetadataFromPackageJson(
+      {
+        name: 'my-app',
+        version: '0.0.0',
+        scripts: { build: 'echo 1' },
+        nx: {
+          metadata: {
+            // arbitrary user-defined key consumed by external tooling
+            foo: 'bar',
+          } as any,
+        },
+      },
+      false
+    );
+    expect(result).toMatchObject({
+      targetGroups: { 'NPM Scripts': ['build'] },
+      foo: 'bar',
+    });
+  });
+
+  it('should let user-supplied metadata override auto-generated keys', () => {
+    const result = getMetadataFromPackageJson(
+      {
+        name: 'my-app',
+        version: '0.0.0',
+        description: 'Auto description',
+        nx: {
+          metadata: {
+            description: 'User description',
+          },
+        },
+      },
+      false
+    );
+    expect(result.description).toEqual('User description');
   });
 });

--- a/packages/nx/src/utils/package-json.ts
+++ b/packages/nx/src/utils/package-json.ts
@@ -13,7 +13,10 @@ import {
 } from '../config/workspace-json-project-json';
 import type { Tree } from '../generators/tree';
 import { readJson } from '../generators/utils/json';
-import { mergeTargetConfigurations } from '../project-graph/utils/project-configuration/target-merging';
+import {
+  mergeMetadata,
+  mergeTargetConfigurations,
+} from '../project-graph/utils/project-configuration/target-merging';
 import { getCatalogManager } from './catalog';
 import { readJsonFile } from './fileutils';
 import { getNxRequirePaths } from './installation-directory';
@@ -195,7 +198,7 @@ export function getMetadataFromPackageJson(
   const { scripts, nx, description, name, exports, main, version } =
     packageJson;
   const includedScripts = nx?.includedScripts || Object.keys(scripts ?? {});
-  return {
+  const inferredMetadata: ProjectMetadata = {
     targetGroups: {
       ...(includedScripts.length ? { 'NPM Scripts': includedScripts } : {}),
     },
@@ -207,8 +210,8 @@ export function getMetadataFromPackageJson(
       packageMain: main,
       isInPackageManagerWorkspaces,
     },
-    ...nx?.metadata,
   };
+  return mergeMetadata(null, null, null, nx?.metadata ?? {}, inferredMetadata);
 }
 
 export function getTagsFromPackageJson(packageJson: PackageJson): string[] {

--- a/packages/nx/src/utils/package-json.ts
+++ b/packages/nx/src/utils/package-json.ts
@@ -207,6 +207,7 @@ export function getMetadataFromPackageJson(
       packageMain: main,
       isInPackageManagerWorkspaces,
     },
+    ...nx?.metadata,
   };
 }
 


### PR DESCRIPTION
## Current Behavior

User-supplied `nx.metadata` keys in a project's `package.json` are discarded by the package-json plugin. Given:

```jsonc
// apps/my-app/package.json
{
  "name": "my-app",
  "description": "my app",
  "nx": {
    "metadata": { "foo": "bar" }
  }
}
```

`nx show project my-app --json | jq .metadata` returns only `{ "targetGroups": {...}, "description": ... }` — the `foo` key is gone.

The cause is in [`getMetadataFromPackageJson`](https://github.com/nrwl/nx/blob/master/packages/nx/src/utils/package-json.ts#L149-L160): the function destructures `nx` from `packageJson` but does not spread `nx?.metadata` into the returned object. That object then replaces (rather than merges with) the user's metadata when the plugin spreads it onto the project configuration in [`buildProjectConfigurationFromPackageJson`](https://github.com/nrwl/nx/blob/master/packages/nx/src/plugins/package-json/create-nodes.ts#L182).

This makes `nx.metadata` unusable as an extension point for user tooling that wants to attach annotations to projects via package.json. 

## Expected Behavior

User-supplied keys on `nx.metadata` are preserved alongside the auto-generated `targetGroups` and `description`. When a key collides, the user-supplied value wins.

After this change:

```
$ nx show project my-app --json | jq .metadata
{
  "targetGroups": { "NPM Scripts": [...] },
  "description": "...",
  "foo": "bar"
}
```

## Related Issue(s)

N/A
