### PR TITLE
fix(core): show flaky-task count in run summary

### DIFF
--- a/packages/nx/src/tasks-runner/life-cycles/task-history-life-cycle-old.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/task-history-life-cycle-old.ts
@@ -86,7 +86,9 @@ export class LegacyTaskHistoryLifeCycle implements LifeCycle {
     if (this.flakyTasks?.length > 0) {
       output.warn({
         title: `Nx detected ${
-          this.flakyTasks.length === 1 ? 'a flaky task' : ' flaky tasks'
+          this.flakyTasks.length === 1
+            ? 'a flaky task'
+            : `${this.flakyTasks.length} flaky tasks`
         }`,
         bodyLines: [
           ,

--- a/packages/nx/src/tasks-runner/life-cycles/task-history-life-cycle-old.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/task-history-life-cycle-old.ts
@@ -84,6 +84,16 @@ export class LegacyTaskHistoryLifeCycle implements LifeCycle {
 
   printFlakyTasksMessage() {
     if (this.flakyTasks?.length > 0) {
+      const MAX_VISIBLE_FLAKY = 5;
+      const visibleFlaky =
+        this.flakyTasks.length > MAX_VISIBLE_FLAKY + 1
+          ? this.flakyTasks.slice(0, MAX_VISIBLE_FLAKY)
+          : this.flakyTasks;
+      const hiddenCount = this.flakyTasks.length - visibleFlaky.length;
+      const flakyRows = visibleFlaky.map((t) => `  ${t}`);
+      if (hiddenCount > 0) {
+        flakyRows.push(`  ${hiddenCount} more...`);
+      }
       output.warn({
         title: `Nx detected ${
           this.flakyTasks.length === 1
@@ -92,7 +102,7 @@ export class LegacyTaskHistoryLifeCycle implements LifeCycle {
         }`,
         bodyLines: [
           ,
-          ...this.flakyTasks.map((t) => `  ${t}`),
+          ...flakyRows,
           ...(isNxCloudUsed(readNxJson())
             ? []
             : [

--- a/packages/nx/src/tasks-runner/life-cycles/task-history-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/task-history-life-cycle.ts
@@ -101,6 +101,23 @@ export class TaskHistoryLifeCycle implements LifeCycle {
 
   printFlakyTasksMessage() {
     if (this.flakyTasks?.length > 0) {
+      const MAX_VISIBLE_FLAKY = 5;
+      const visibleFlaky =
+        this.flakyTasks.length > MAX_VISIBLE_FLAKY + 1
+          ? this.flakyTasks.slice(0, MAX_VISIBLE_FLAKY)
+          : this.flakyTasks;
+      const hiddenCount = this.flakyTasks.length - visibleFlaky.length;
+      const flakyRows = visibleFlaky.map((hash) => {
+        const taskRun = this.taskRuns.get(hash);
+        return `  ${serializeTarget(
+          taskRun.target.project,
+          taskRun.target.target,
+          taskRun.target.configuration
+        )}`;
+      });
+      if (hiddenCount > 0) {
+        flakyRows.push(`  ${hiddenCount} more...`);
+      }
       output.warn({
         title: `Nx detected ${
           this.flakyTasks.length === 1
@@ -109,14 +126,7 @@ export class TaskHistoryLifeCycle implements LifeCycle {
         }`,
         bodyLines: [
           ,
-          ...this.flakyTasks.map((hash) => {
-            const taskRun = this.taskRuns.get(hash);
-            return `  ${serializeTarget(
-              taskRun.target.project,
-              taskRun.target.target,
-              taskRun.target.configuration
-            )}`;
-          }),
+          ...flakyRows,
           ...(isNxCloudUsed(readNxJson())
             ? []
             : [

--- a/packages/nx/src/tasks-runner/life-cycles/task-history-life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/task-history-life-cycle.ts
@@ -103,7 +103,9 @@ export class TaskHistoryLifeCycle implements LifeCycle {
     if (this.flakyTasks?.length > 0) {
       output.warn({
         title: `Nx detected ${
-          this.flakyTasks.length === 1 ? 'a flaky task' : ' flaky tasks'
+          this.flakyTasks.length === 1
+            ? 'a flaky task'
+            : `${this.flakyTasks.length} flaky tasks`
         }`,
         bodyLines: [
           ,


### PR DESCRIPTION
## Current Behavior

Two issues in the task-history life cycle's flaky-task summary:

**1. Missing count** — the plural-case title rendered with two consecutive spaces and no number:

```
> NX  Nx detected  flaky tasks

  myproject:test
  otherproject:e2e
```

(Singular rendered correctly as `Nx detected a flaky task`.)

**2. Unbounded list** — when many tasks were flagged (e.g. a Gradle suite that detects all of its targets as flaky), the full list filled the terminal viewport.

## Expected Behavior

Plural title shows the true count, and long lists truncate to a manageable preview:

```
> NX  Nx detected 8 flaky tasks

  myproject:test
  otherproject:e2e
  thirdproject:lint
  fourthproject:build
  fifthproject:e2e
  3 more...
```

## Root Cause (count fix)

Both `task-history-life-cycle.ts` and the legacy `task-history-life-cycle-old.ts` had:

```ts
title: `Nx detected ${
  this.flakyTasks.length === 1 ? 'a flaky task' : ' flaky tasks'
}`,
```

The plural branch is a literal `' flaky tasks'` string with a leading space and **no count interpolation** — so the template renders `Nx detected ` + `' flaky tasks'` = `Nx detected  flaky tasks` (two spaces, no number).

## Fixes

**1. Title interpolation** — replace the plural literal with `` `${this.flakyTasks.length} flaky tasks` `` so the count appears between the leading space and the word `flaky`. Singular wording is unchanged. Applied symmetrically in both life-cycle files.

**2. List truncation** (per AgentEnder's review feedback) — cap the printed body at 5 entries with a `N more...` collapse row when `flakyTasks.length > 6`. The title still shows the true total. Behavior matrix:

| `flakyTasks.length` | Body rows |
|---|---|
| 1–5 | all task names |
| 6 | all 6 task names (no collapse — a single "1 more..." would be sillier than just printing the row) |
| 7 | 5 task names + `  2 more...` |
| 8 | 5 task names + `  3 more...` |
| N (N≥7) | 5 task names + `  ${N-5} more...` |

Applied symmetrically in both life-cycle files.

## Tests

No existing unit test covers `printFlakyTasksMessage()`'s formatted output (the surrounding life cycles don't have a `*.spec.ts`). Adding one would require mocking the task-history daemon channel and life-cycle hooks — out of scope for a small formatting tweak. The change is small enough to verify by inspection of the diff.

## Related Issue(s)

(reported internally; no public issue)