### PR TITLE
fix(angular): disable vitest watch by default

### DIFF
--- a/packages/angular/src/generators/application/application.spec.ts
+++ b/packages/angular/src/generators/application/application.spec.ts
@@ -863,7 +863,9 @@ describe('app', () => {
         const project = readProjectConfiguration(appTree, 'my-app');
         expect(project.targets.test).toStrictEqual({
           executor: '@angular/build:unit-test',
-          options: {},
+          options: {
+            watch: false,
+          },
         });
         const nxJson = readNxJson(appTree);
         expect(nxJson.targetDefaults['@angular/build:unit-test']).toStrictEqual(

--- a/packages/angular/src/generators/library/library.spec.ts
+++ b/packages/angular/src/generators/library/library.spec.ts
@@ -101,6 +101,21 @@ describe('lib', () => {
     expect(devDependencies['@angular/build']).toBe(angularDevkitVersion);
   });
 
+  it('should setup vitest-angular test target with watch mode disabled', async () => {
+    await runLibraryGeneratorWithOpts({
+      unitTestRunner: UnitTestRunner.VitestAngular,
+      buildable: true,
+    });
+
+    const project = readProjectConfiguration(tree, 'my-lib');
+    expect(project.targets.test).toStrictEqual({
+      executor: '@nx/angular:unit-test',
+      options: {
+        watch: false,
+      },
+    });
+  });
+
   it('should not touch the package.json when run with `--skipPackageJson`', async () => {
     let initialPackageJson;
     updateJson(tree, 'package.json', (json) => {

--- a/packages/angular/src/generators/utils/add-vitest.ts
+++ b/packages/angular/src/generators/utils/add-vitest.ts
@@ -50,7 +50,7 @@ export async function addVitestAngular(
     : '@angular/build:unit-test';
   const project = readProjectConfiguration(tree, options.name);
   project.targets ??= {};
-  project.targets.test = { executor, options: {} };
+  project.targets.test = { executor, options: { watch: false } };
   updateProjectConfiguration(tree, options.name, project);
 
   const nxJson = readNxJson(tree);


### PR DESCRIPTION
## Current Behavior

Generated Angular projects using `vitest-angular` create a test target without an explicit `watch` value. The Angular unit-test builder defaults watch mode to `true` in TTY environments, so running generated projects through monorepo workflows such as `nx run-many` can leave test tasks running instead of exiting.

## Expected Behavior

Generated Angular `vitest-angular` test targets explicitly set `watch: false`, matching Nx Vitest's default non-watch behavior and preserving terminating test tasks for `run-many` and affected workflows. Users can still opt into watch mode with `--watch` or a watch configuration.