### PR TITLE
docs(misc): update nx-cloud-workflows references from v5 to v6

### DIFF
--- a/.nx/workflows/agents.yaml
+++ b/.nx/workflows/agents.yaml
@@ -11,10 +11,10 @@ common-env-vars: &common-env-vars
 
 common-init-steps: &common-init-steps
   - name: Checkout
-    uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/checkout/main.yaml'
+    uses: 'nrwl/nx-cloud-workflows/v6/workflow-steps/checkout/main.yaml'
 
   - name: Cache restore
-    uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/cache/main.yaml'
+    uses: 'nrwl/nx-cloud-workflows/v6/workflow-steps/cache/main.yaml'
     inputs:
       key: 'pnpm-lock.yaml'
       paths: ~/.local/share/pnpm/store
@@ -22,7 +22,7 @@ common-init-steps: &common-init-steps
 
   # reads mise.toml and installs toolchains needed for repo
   - name: Setup toolchains
-    uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/install-mise/main.yaml'
+    uses: 'nrwl/nx-cloud-workflows/v6/workflow-steps/install-mise/main.yaml'
 
   - name: Verify toolchain versions
     script: |

--- a/astro-docs/src/content/docs/guides/Nx Cloud/use-bun.mdoc
+++ b/astro-docs/src/content/docs/guides/Nx Cloud/use-bun.mdoc
@@ -128,10 +128,10 @@ Add `.nx/workflows/agents.yaml` to your workspace:
 // .nx/workflows/agents.yaml
 common-init-steps: &common-init-steps
   - name: Checkout
-    uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/checkout/main.yaml'
+    uses: 'nrwl/nx-cloud-workflows/v6/workflow-steps/checkout/main.yaml'
 
   - name: Setup toolchains
-    uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/install-mise/main.yaml'
+    uses: 'nrwl/nx-cloud-workflows/v6/workflow-steps/install-mise/main.yaml'
 
   - name: Install dependencies
     script: |

--- a/astro-docs/src/content/docs/reference/Nx Cloud/launch-template-examples.mdoc
+++ b/astro-docs/src/content/docs/reference/Nx Cloud/launch-template-examples.mdoc
@@ -17,9 +17,9 @@ common-js-init-steps: &common-js-init-steps
   # using a reusable step in an external GitHub repo,
   # this step is provided by Nx Cloud: https://github.com/nrwl/nx-cloud-workflows/tree/main/workflow-steps
   - name: Checkout
-    uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/checkout/main.yaml'
+    uses: 'nrwl/nx-cloud-workflows/v6/workflow-steps/checkout/main.yaml'
   - name: Restore Node Modules Cache
-    uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/cache/main.yaml'
+    uses: 'nrwl/nx-cloud-workflows/v6/workflow-steps/cache/main.yaml'
     # the cache step requires configuration via env vars
     # https://github.com/nrwl/nx-cloud-workflows/tree/main/workflow-steps/cache#options
     inputs:
@@ -32,16 +32,16 @@ common-js-init-steps: &common-js-init-steps
         # or ~/.local/share/pnpm/store
       base-branch: 'main'
   - name: Restore Browser Binary Cache
-    uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/cache/main.yaml'
+    uses: 'nrwl/nx-cloud-workflows/v6/workflow-steps/cache/main.yaml'
     inputs:
       key: 'package-lock.json|yarn.lock|pnpm-lock.yaml|"browsers"'
       paths: |
         '~/.cache/Cypress'
       base-branch: 'main'
   - name: Install Node Modules
-    uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/install-node-modules/main.yaml'
+    uses: 'nrwl/nx-cloud-workflows/v6/workflow-steps/install-node-modules/main.yaml'
   - name: Install Browsers (if needed)
-    uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/install-browsers/main.yaml'
+    uses: 'nrwl/nx-cloud-workflows/v6/workflow-steps/install-browsers/main.yaml'
     # You can also run a custom script to configure various things on the agent machine
   - name: Run a custom script
     script: |
@@ -55,7 +55,7 @@ common-js-init-steps: &common-js-init-steps
 
 common-rust-init-steps: &common-rust-init-steps
   - name: Checkout
-    uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/checkout/main.yaml'
+    uses: 'nrwl/nx-cloud-workflows/v6/workflow-steps/checkout/main.yaml'
 
   # add Rust-specific steps
   - name: Install Rust
@@ -156,7 +156,7 @@ launch-templates:
     image: 'ubuntu22.04-node24.14-v1'
     init-steps:
       - name: Checkout
-        uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/checkout/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v6/workflow-steps/checkout/main.yaml'
       - name: Auth to Registry
         script: |
           # we recommend add to the 'user' level npmrc file
@@ -165,7 +165,7 @@ launch-templates:
           npm config set -L user "@myorg:registry" "https://npm.pkg.github.com"
           npm config set -L user "//npm.pkg.github.com/:_authToken" "${SOME_AUTH_TOKEN}"
       - name: Install Node Modules
-        uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/install-node-modules/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v6/workflow-steps/install-node-modules/main.yaml'
 ```
 
 Pass `SOME_AUTH_TOKEN` via `--with-env-vars`
@@ -192,15 +192,15 @@ launch-templates:
     image: 'ubuntu22.04-node24.14-v1'
     init-steps:
       - name: Checkout
-        uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/checkout/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v6/workflow-steps/checkout/main.yaml'
       - name: Install mise
-        uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/install-mise/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v6/workflow-steps/install-mise/main.yaml'
         inputs:
           # you can also define a mise.toml in your repo instead of inline tools
           tools: |
             node=21
       - name: Install Node Modules
-        uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/install-node-modules/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v6/workflow-steps/install-node-modules/main.yaml'
 ```
 
 {% /tabitem %}
@@ -218,10 +218,10 @@ launch-templates:
     image: 'ubuntu22.04-node24.14-v1'
     init-steps:
       - name: Checkout
-        uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/checkout/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v6/workflow-steps/checkout/main.yaml'
       - name: Install Node
         # note the step is only released as of v4 of the workflow steps
-        uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/install-node/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v6/workflow-steps/install-node/main.yaml'
         inputs:
           # can omit value if a '.nvmrc' file is within the root of the repo
           node_version: '21'
@@ -246,7 +246,7 @@ launch-templates:
     image: 'ubuntu22.04-node24.14-v1'
     init-steps:
       - name: Checkout
-        uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/checkout/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v6/workflow-steps/checkout/main.yaml'
       - name: Install nvm
         script: |
           # run nvm install script
@@ -261,7 +261,7 @@ launch-templates:
         # confirm that the node version has changed
         script: node -v
       - name: Install Node Modules
-        uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/install-node-modules/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v6/workflow-steps/install-node-modules/main.yaml'
       # Continue setup steps as needed
 ```
 
@@ -326,11 +326,11 @@ launch-templates:
     image: 'ubuntu22.04-node24.14-v1'
     init-steps:
       - name: Checkout
-        uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/checkout/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v6/workflow-steps/checkout/main.yaml'
       - name: Install mise
-        uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/install-mise/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v6/workflow-steps/install-mise/main.yaml'
       - name: Install Node Modules
-        uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/install-node-modules/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v6/workflow-steps/install-node-modules/main.yaml'
 ```
 
 {% /tabitem %}
@@ -346,16 +346,16 @@ launch-templates:
     image: 'ubuntu22.04-node24.14-v1'
     init-steps:
       - name: Checkout
-        uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/checkout/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v6/workflow-steps/checkout/main.yaml'
       - name: Install mise
-        uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/install-mise/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v6/workflow-steps/install-mise/main.yaml'
         inputs:
           tools: |
             node=22
             rust=1.90
             python=3.12
       - name: Install Node Modules
-        uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/install-node-modules/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v6/workflow-steps/install-node-modules/main.yaml'
 ```
 
 {% aside type="caution" %}
@@ -391,7 +391,7 @@ launch-templates:
     image: 'ubuntu22.04-node24.14-v1'
     init-steps:
       - name: Install AWS CLI
-        uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/install-aws-cli/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v6/workflow-steps/install-aws-cli/main.yaml'
         # no additional inputs required, as all configuration is via environment variables via --with-env-vars
 ```
 

--- a/astro-docs/src/content/docs/reference/Nx Cloud/launch-templates.mdoc
+++ b/astro-docs/src/content/docs/reference/Nx Cloud/launch-templates.mdoc
@@ -191,9 +191,9 @@ You can find the [list of Nx Cloud reusable steps here](https://github.com/nrwl/
 launch-templates:
   template-one:
     init-steps:
-      - uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/checkout/main.yaml'
+      - uses: 'nrwl/nx-cloud-workflows/v6/workflow-steps/checkout/main.yaml'
       - name: 'Install Node Modules'
-        uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/install-node-modules/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v6/workflow-steps/install-node-modules/main.yaml'
 ```
 
 ### `launch-templates.<template-name>.init-steps[*].script`
@@ -239,7 +239,7 @@ launch-templates:
   template-one:
     init-steps:
       - name: Restore Node Modules Cache
-        uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/cache/main.yaml'
+        uses: 'nrwl/nx-cloud-workflows/v6/workflow-steps/cache/main.yaml'
         inputs:
           # Include patches directories to ensure cache is busted when patches change
           key: 'package-lock.json|yarn.lock|pnpm-lock.yaml|patches/**|.yarn/patches/**|pnpm-patches/**'
@@ -320,7 +320,7 @@ grouped together logically. The below cache steps will also be collapsed togethe
 - group-name: Restore Cache
   steps:
     - name: Restore Node Modules Cache
-      uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/cache/main.yaml'
+      uses: 'nrwl/nx-cloud-workflows/v6/workflow-steps/cache/main.yaml'
       inputs:
         # Include patches directories to ensure cache is busted when patches change
         key: 'package-lock.json|patches/**|.yarn/patches/**|pnpm-patches/**'
@@ -328,7 +328,7 @@ grouped together logically. The below cache steps will also be collapsed togethe
           ~/.npm
         base-branch: 'main'
     - name: Restore Browser Binary Cache
-      uses: 'nrwl/nx-cloud-workflows/v5/workflow-steps/cache/main.yaml'
+      uses: 'nrwl/nx-cloud-workflows/v6/workflow-steps/cache/main.yaml'
       inputs:
         # Include patches directories to ensure cache is busted when patches change
         key: 'package-lock.json|patches/**|.yarn/patches/**|pnpm-patches/**|"browsers"'


### PR DESCRIPTION
Bumps `nrwl/nx-cloud-workflows` references in launch template docs and agents config from `v5` to `v6`.