### PR TITLE
fix(gradle): exclude batch-runner from jest haste-map crawl

### DIFF
--- a/packages/gradle/jest.config.cts
+++ b/packages/gradle/jest.config.cts
@@ -4,4 +4,5 @@ module.exports = {
   globals: {},
   displayName: 'gradle',
   preset: '../../jest.preset.js',
+  modulePathIgnorePatterns: ['<rootDir>/batch-runner/'],
 };


### PR DESCRIPTION
## Current Behavior

Running `nx test gradle` in a sandboxed CI environment produces sandbox violations: jest is observed reading files that belong to a sibling Nx project (`:gradle-batch-runner`), e.g.:

- `packages/gradle/batch-runner/build/reports/tests/test/index.html`
- `packages/gradle/batch-runner/build/reports/tests/test/js/report.js`

Root cause: jest's `rootDir` defaults to `packages/gradle/` (the dir of `jest.config.cts`). With `moduleFileExtensions` including `.html` and `.js`, `jest-haste-map` walks the entire tree under `rootDir` and reads matching files to build its module map. `packages/gradle/batch-runner/` is a separate Nx project whose root happens to be a subdirectory, so its gradle build output gets pulled into haste-map.

These files are not — and should not be — declared as inputs to `gradle:test`; they belong to a different project.

## Expected Behavior

`jest-haste-map` skips the `batch-runner/` subtree, so `gradle:test` no longer reads files owned by the `:gradle-batch-runner` project, eliminating the sandbox violations.

Fix: add `modulePathIgnorePatterns: ['<rootDir>/batch-runner/']` to `packages/gradle/jest.config.cts`. `modulePathIgnorePatterns` (vs `testPathIgnorePatterns`) is the correct knob — it excludes the path from the haste map entirely so it's never read; `testPathIgnorePatterns` only filters which files run as tests.

## Related Issue(s)

N/A — surfaced by Nx Cloud sandbox report on `gradle:test`.
