### PR TITLE
fix(core): preserve hydrateFileMap back-compat for cached nx-cloud workers

### DIFF
--- a/packages/nx/src/project-graph/build-project-graph.spec.ts
+++ b/packages/nx/src/project-graph/build-project-graph.spec.ts
@@ -1,0 +1,37 @@
+import { getFileMap, hydrateFileMap } from './build-project-graph';
+import type { NxWorkspaceFilesExternals } from '../native';
+
+describe('hydrateFileMap', () => {
+  const fileMap = {
+    projectFileMap: { app: [{ file: 'app/index.ts', hash: 'h1' }] },
+    nonProjectFiles: [{ file: 'package.json', hash: 'h2' }],
+  };
+  // Real nx-cloud workers pass napi `External<...>` instances; for unit-test
+  // purposes any non-array sentinel verifies it lands in the rustReferences slot.
+  const rustReferences = {
+    __sentinel: 'externals',
+  } as unknown as NxWorkspaceFilesExternals;
+
+  it('stores rustReferences from the new 2-arg form', () => {
+    hydrateFileMap(fileMap, rustReferences);
+    expect(getFileMap().rustReferences).toBe(rustReferences);
+  });
+
+  // Pre-#34425 nx-cloud V4 workers (cached at .nx/cache/cloud/<ver>/.../discrete-task-worker.js)
+  // call hydrateFileMap(fileMap, allWorkspaceFiles, rustReferences). Without back-compat
+  // this poisons storedRustReferences with the FileData[] array, which later trips
+  // "Failed to get external value" inside NativeTaskHasherImpl.
+  it('survives legacy 3-arg form from cached nx-cloud workers', () => {
+    const legacyAllWorkspaceFiles = [
+      { file: 'app/index.ts', hash: 'h1' },
+      { file: 'package.json', hash: 'h2' },
+    ];
+    (hydrateFileMap as any)(fileMap, legacyAllWorkspaceFiles, rustReferences);
+    expect(getFileMap().rustReferences).toBe(rustReferences);
+  });
+
+  it('exposes allWorkspaceFiles on getFileMap so legacy destructuring callers see []', () => {
+    hydrateFileMap(fileMap, rustReferences);
+    expect((getFileMap() as any).allWorkspaceFiles).toEqual([]);
+  });
+});

--- a/packages/nx/src/project-graph/build-project-graph.spec.ts
+++ b/packages/nx/src/project-graph/build-project-graph.spec.ts
@@ -6,8 +6,7 @@ describe('hydrateFileMap', () => {
     projectFileMap: { app: [{ file: 'app/index.ts', hash: 'h1' }] },
     nonProjectFiles: [{ file: 'package.json', hash: 'h2' }],
   };
-  // Real nx-cloud workers pass napi `External<...>` instances; for unit-test
-  // purposes any non-array sentinel verifies it lands in the rustReferences slot.
+  // Sentinel stands in for a napi External — only its identity is asserted.
   const rustReferences = {
     __sentinel: 'externals',
   } as unknown as NxWorkspaceFilesExternals;
@@ -17,10 +16,6 @@ describe('hydrateFileMap', () => {
     expect(getFileMap().rustReferences).toBe(rustReferences);
   });
 
-  // Pre-#34425 nx-cloud V4 workers (cached at .nx/cache/cloud/<ver>/.../discrete-task-worker.js)
-  // call hydrateFileMap(fileMap, allWorkspaceFiles, rustReferences). Without back-compat
-  // this poisons storedRustReferences with the FileData[] array, which later trips
-  // "Failed to get external value" inside NativeTaskHasherImpl.
   it('survives legacy 3-arg form from cached nx-cloud workers', () => {
     const legacyAllWorkspaceFiles = [
       { file: 'app/index.ts', hash: 'h1' },

--- a/packages/nx/src/project-graph/build-project-graph.ts
+++ b/packages/nx/src/project-graph/build-project-graph.ts
@@ -53,11 +53,14 @@ let storedRustReferences: NxWorkspaceFilesExternals | null = null;
 export function getFileMap(): {
   fileMap: FileMap;
   rustReferences: NxWorkspaceFilesExternals | null;
+  /** @deprecated derivable from `fileMap`; retained for prebuilt nx-cloud workers that destructure it. */
+  allWorkspaceFiles: FileData[];
 } {
   if (!!storedFileMap) {
     return {
       fileMap: storedFileMap,
       rustReferences: storedRustReferences,
+      allWorkspaceFiles: [],
     };
   } else {
     return {
@@ -66,16 +69,25 @@ export function getFileMap(): {
         projectFileMap: {},
       },
       rustReferences: null,
+      allWorkspaceFiles: [],
     };
   }
 }
 
+// Pre-#34425 nx-cloud workers (e.g. cached v4 distributed-agent at `.nx/cache/cloud/<ver>/.../discrete-task-worker.js`)
+// call `hydrateFileMap(fileMap, allWorkspaceFiles, rustReferences)` via
+// `require('nx/src/project-graph/build-project-graph')`. Detect that legacy
+// 3-arg shape by the type of the 2nd arg so the cached workers keep functioning
+// during the v23 transition. See tmp/notes/nx-cloud-hydrate-file-map-regression.md.
 export function hydrateFileMap(
   fileMap: FileMap,
-  rustReferences: NxWorkspaceFilesExternals
+  rustReferencesOrLegacyAllFiles: NxWorkspaceFilesExternals | FileData[],
+  legacyRustReferences?: NxWorkspaceFilesExternals
 ) {
   storedFileMap = fileMap;
-  storedRustReferences = rustReferences;
+  storedRustReferences = Array.isArray(rustReferencesOrLegacyAllFiles)
+    ? (legacyRustReferences ?? null)
+    : rustReferencesOrLegacyAllFiles;
 }
 
 export async function buildProjectGraphUsingProjectFileMap(

--- a/packages/nx/src/project-graph/build-project-graph.ts
+++ b/packages/nx/src/project-graph/build-project-graph.ts
@@ -53,7 +53,7 @@ let storedRustReferences: NxWorkspaceFilesExternals | null = null;
 export function getFileMap(): {
   fileMap: FileMap;
   rustReferences: NxWorkspaceFilesExternals | null;
-  /** @deprecated derivable from `fileMap`; retained for prebuilt nx-cloud workers that destructure it. */
+  /** @deprecated always `[]`; kept so cached nx-cloud workers that destructure it don't see `undefined`. */
   allWorkspaceFiles: FileData[];
 } {
   if (!!storedFileMap) {
@@ -74,20 +74,25 @@ export function getFileMap(): {
   }
 }
 
-// Pre-#34425 nx-cloud workers (e.g. cached v4 distributed-agent at `.nx/cache/cloud/<ver>/.../discrete-task-worker.js`)
-// call `hydrateFileMap(fileMap, allWorkspaceFiles, rustReferences)` via
-// `require('nx/src/project-graph/build-project-graph')`. Detect that legacy
-// 3-arg shape by the type of the 2nd arg so the cached workers keep functioning
-// during the v23 transition. See tmp/notes/nx-cloud-hydrate-file-map-regression.md.
 export function hydrateFileMap(
   fileMap: FileMap,
-  rustReferencesOrLegacyAllFiles: NxWorkspaceFilesExternals | FileData[],
-  legacyRustReferences?: NxWorkspaceFilesExternals
-) {
+  rustReferences: NxWorkspaceFilesExternals
+): void;
+/** @deprecated pass `(fileMap, rustReferences)`. Kept for cached nx-cloud workers still on the 3-arg form. */
+export function hydrateFileMap(
+  fileMap: FileMap,
+  allWorkspaceFiles: FileData[],
+  rustReferences: NxWorkspaceFilesExternals
+): void;
+export function hydrateFileMap(
+  fileMap: FileMap,
+  rustReferencesOrAllFiles: NxWorkspaceFilesExternals | FileData[],
+  maybeRustReferences?: NxWorkspaceFilesExternals
+): void {
   storedFileMap = fileMap;
-  storedRustReferences = Array.isArray(rustReferencesOrLegacyAllFiles)
-    ? (legacyRustReferences ?? null)
-    : rustReferencesOrLegacyAllFiles;
+  storedRustReferences = Array.isArray(rustReferencesOrAllFiles)
+    ? (maybeRustReferences ?? null)
+    : rustReferencesOrAllFiles;
 }
 
 export async function buildProjectGraphUsingProjectFileMap(


### PR DESCRIPTION
## Current Behavior

`nx@23.0.0-beta.2` Nx Cloud V4 distributed-agent workers crash on every task with:

```
Failed to get external value
  at new NativeTaskHasherImpl (.../native-task-hasher-impl.js:25:23)
  at new InProcessTaskHasher (.../task-hasher.js:68:27)
  at createTaskHasher (.../create-task-hasher.js:13:16)
  at createOrchestrator (.../init-tasks-runner.js:86:60)
  at runDiscreteTasks (.../init-tasks-runner.js:114:32)
  at executeAndStoreTask (.../discrete-task-worker.js:1:832861)
```

#34425 ("remove redundant `allWorkspaceFiles` from the project graph pipeline") changed two helpers in `packages/nx/src/project-graph/build-project-graph.ts`:

- `hydrateFileMap(fileMap, allWorkspaceFiles, rustReferences)` → `hydrateFileMap(fileMap, rustReferences)`
- `getFileMap()` no longer returns `allWorkspaceFiles`

Cached Nx Cloud V4 workers (e.g. `.nx/cache/cloud/2604.29.7/lib/core/runners/distributed-agent/v4/discrete-task-worker.js`) `require('nx/src/project-graph/build-project-graph')` directly and still call the 3-arg form:

```js
hydrateFileMap(
  { projectFileMap, nonProjectFiles },
  allWorkspaceFiles,    // lands in rustReferences slot on beta.2
  rustReferences        // silently dropped
);
```

The `FileData[]` array poisons `storedRustReferences`. Later `createTaskHasher` reads `.projectFiles` / `.allWorkspaceFiles` off the array (both `undefined`), passes them to `new TaskHasher(...)`, and napi-rs throws `"Failed to get external value"` trying to coerce `undefined` into `&External<Arc<…>>`.

## Expected Behavior

`hydrateFileMap` accepts both the new 2-arg shape and the legacy 3-arg shape, detected by `Array.isArray()` on the 2nd argument. `getFileMap()` re-exposes `allWorkspaceFiles: []` so cached workers that destructure it (for telemetry / `v4log`) see the property instead of `undefined`. Both surfaces are flagged `@deprecated` so we can remove them in a later major once cached V4 workers age out.

A regression test pins both arities — verified red on the pre-fix code and green with the fix.

## Related Issue(s)

<!-- Reported via internal channels (ocean) — no public issue. -->