### PR TITLE
chore(linter): bump globals from ^15.9.0 to ^17.0.0

### DIFF
--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -42,7 +42,7 @@
     "@typescript-eslint/utils": "^8.0.0",
     "chalk": "catalog:",
     "confusing-browser-globals": "^1.0.9",
-    "globals": "^15.9.0",
+    "globals": "^17.0.0",
     "jsonc-eslint-parser": "^2.1.0",
     "semver": "catalog:",
     "tslib": "catalog:typescript"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2802,8 +2802,8 @@ importers:
         specifier: ^10.0.0
         version: 10.1.2(eslint@9.39.4(jiti@2.6.1))
       globals:
-        specifier: ^15.9.0
-        version: 15.15.0
+        specifier: ^17.0.0
+        version: 17.5.0
       jsonc-eslint-parser:
         specifier: ^2.1.0
         version: 2.4.0


### PR DESCRIPTION
## Current Behavior

`@nx/eslint-plugin` declares `globals: ^15.9.0`. Per the bulk-dependency-update sweep (NXC-4329), this dependency is due for a major-version bump.

## Expected Behavior

Bumped to `globals@^17.0.0`. The published v17 package is still CommonJS (`module.exports = require('./globals.json')`); no ESM migration required. Engine floor moves to `node >= 18` (which Nx's own floor already exceeds).

## Validation

The three call sites in `@nx/eslint-plugin` use only stable environment keys that are unchanged across `15 → 16 → 17`:

```ts
// packages/eslint-plugin/src/flat-configs/javascript.ts
import globals from 'globals';
{ ...globals.browser, ...globals.node }

// packages/eslint-plugin/src/flat-configs/react-base.ts
{ ...globals.browser, ...globals.commonjs, ...globals.es2015, ...globals.jest, ...globals.node }

// packages/eslint-plugin/src/flat-configs/angular.ts
{ ...globals.browser, ...globals.es2015, ...globals.node }
```

`pnpm nx run eslint-plugin:build` — passes.
`pnpm nx run eslint-plugin:test` — passes.

Lockfile delta: 2 lines (specifier + resolved version), no peer-hash churn.

## Related Issue(s)

Part of [NXC-4329](https://linear.app/nxdev/issue/NXC-4329) bulk-dependency-update sweep.