### PR TITLE
chore(linter): bump ignore from ^5.0.4 to ^7.0.5

### DIFF
--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -49,7 +49,7 @@
     "chalk": "catalog:",
     "columnify": "^1.6.0",
     "detect-port": "^1.5.1",
-    "ignore": "^5.0.4",
+    "ignore": "^7.0.5",
     "js-tokens": "^4.0.0",
     "jsonc-parser": "3.2.0",
     "npm-run-path": "^4.0.1",

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -40,7 +40,7 @@
     "@babel/plugin-proposal-decorators": "^7.22.7",
     "@svgr/webpack": "^8.1.0",
     "copy-webpack-plugin": "^14.0.0",
-    "ignore": "^5.0.4",
+    "ignore": "^7.0.5",
     "semver": "catalog:",
     "tslib": "catalog:typescript",
     "webpack-merge": "^5.8.0",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -33,7 +33,7 @@
     "@nx/react": "workspace:*",
     "ajv": "^8.12.0",
     "enhanced-resolve": "^5.8.3",
-    "ignore": "^5.0.4",
+    "ignore": "^7.0.5",
     "picocolors": "catalog:",
     "tinyglobby": "catalog:",
     "tsconfig-paths": "catalog:typescript",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3005,8 +3005,8 @@ importers:
         specifier: ^1.5.1
         version: 1.6.1
       ignore:
-        specifier: ^5.0.4
-        version: 5.3.2
+        specifier: ^7.0.5
+        version: 7.0.5
       js-tokens:
         specifier: ^4.0.0
         version: 4.0.0
@@ -3179,8 +3179,8 @@ importers:
         specifier: ^14.0.0
         version: 14.0.0(webpack@5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.2)(webpack@5.101.3)))
       ignore:
-        specifier: ^5.0.4
-        version: 5.3.2
+        specifier: ^7.0.5
+        version: 7.0.5
       next:
         specifier: '>=14.0.0 <17.0.0'
         version: 14.2.28(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.54.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3)
@@ -3570,8 +3570,8 @@ importers:
         specifier: ^5.8.3
         version: 5.18.2
       ignore:
-        specifier: ^5.0.4
-        version: 5.3.2
+        specifier: ^7.0.5
+        version: 7.0.5
       metro-config:
         specifier: '>= 0.82.0'
         version: 0.82.4


### PR DESCRIPTION
## Current Behavior

`@nx/js`, `@nx/next`, and `@nx/react-native` declare `ignore: ^5.0.4`. The companion packages `@nx/nx` and `@nx/dotnet` are already on `^7.0.5` (queue file flagged not to re-bump those). Per the bulk-dependency-update sweep (NXC-4329), the remaining three packages should align.

## Expected Behavior

Bumped to `ignore@^7.0.5` in all three. ignore@6/7 are API-compatible with v5 — only changes are dropping Node ≤12 support and internal perf improvements.

## Validation

The 5 source-level call sites all use the default-import default-export shape:

```ts
// packages/js/src/utils/generate-globs.ts
// packages/js/src/utils/assets/copy-assets-handler.ts
// packages/js/src/generators/typescript-sync/typescript-sync.ts
// packages/react-native/src/generators/init/lib/add-git-ignore-entry.ts
// packages/next/src/utils/add-gitignore-entry.ts
import ignore from 'ignore';
```

Stable across v5/v6/v7. The `ignore()` constructor + `.add()` + `.filter()` + `.ignores()` chain is unchanged.

`pnpm nx run-many -t build -p js,react-native,next` — passes.

## Related Issue(s)

Part of [NXC-4329](https://linear.app/nxdev/issue/NXC-4329) bulk-dependency-update sweep.