### PR TITLE
feat(angular)!: remove deprecated @nx/angular/module-federation entry point

### DIFF
--- a/astro-docs/src/content/docs/technologies/build-tools/webpack/Guides/webpack-config-setup.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/webpack/Guides/webpack-config-setup.mdoc
@@ -206,8 +206,8 @@ you can customize your Webpack configuration as follows.
 // apps/my-app/webpack.config.js
 const { composePlugins, withNx } = require('@nx/webpack');
 const { merge } = require('webpack-merge');
-const withModuleFederation = require('@nx/react/module-federation');
-// or `const withModuleFederation = require('@nx/angular/module-federation');`
+const { withModuleFederation } = require('@nx/module-federation/webpack');
+// or `const { withModuleFederation } = require('@nx/module-federation/angular');`
 
 module.exports = composePlugins(
   withNx(),
@@ -222,6 +222,10 @@ module.exports = composePlugins(
   }
 );
 ```
+
+{% aside type="note" title="Install @nx/module-federation" %}
+The `withModuleFederation` plugins live in the `@nx/module-federation` package. Install it with your package manager, or use the Nx Module Federation generators (such as `@nx/angular:host`, `@nx/angular:remote`, `@nx/react:host`, or `@nx/react:remote`), which add the dependency for you.
+{% /aside %}
 
 Reference the [Webpack documentation](https://webpack.js.org/configuration/) for details on the structure of the Webpack
 configuration object.

--- a/astro-docs/src/content/docs/technologies/build-tools/webpack/Guides/webpack-plugins.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/webpack/Guides/webpack-plugins.mdoc
@@ -578,6 +578,10 @@ These plugins use
 For more information, refer to
 the [Module Federation recipe](/docs/technologies/module-federation/concepts/faster-builds-with-module-federation).
 
+{% aside type="note" title="Install @nx/module-federation" %}
+These plugins live in the `@nx/module-federation` package. Install it with your package manager, or use the Nx Module Federation generators (such as `@nx/angular:host`, `@nx/angular:remote`, `@nx/react:host`, or `@nx/react:remote`), which add the dependency for you.
+{% /aside %}
+
 #### Options
 
 Both `withModuleFederation` and `withModuleFederationForSSR` share the same options. The `withModuleFederation` plugin
@@ -640,7 +644,8 @@ match [`ModuleFederationPlugin`'s sharing configuration](https://webpack.js.org/
 
 ```js
 const { composePlugins, withNx } = require('@nx/webpack');
-const { withReact, withModuleFederation } = require('@nx/react');
+const { withReact } = require('@nx/react');
+const { withModuleFederation } = require('@nx/module-federation/webpack');
 
 // Host config
 // e.g. { remotes: ['about', 'dashboard'] }
@@ -661,22 +666,14 @@ module.exports = composePlugins(
 {% tabitem label="Angular Module Federation" %}
 
 ```js
-const {
-  composePlugins,
-  withModuleFederation,
-} = require('@nx/angular/module-federation');
+const { withModuleFederation } = require('@nx/module-federation/angular');
 
 // Host config
 // e.g. { remotes: ['about', 'dashboard'] }
 const moduleFederationConfig = require('./module-federation.config');
 
-module.exports = composePlugins(
-  withModuleFederation(moduleFederationConfig),
-  (config) => {
-    // Further customize webpack config
-    return config;
-  }
-);
+// `dts: false` disables type generation since Nx already provides typing support for module federation.
+module.exports = withModuleFederation(moduleFederationConfig, { dts: false });
 ```
 
 {% /tabitem %}
@@ -684,7 +681,8 @@ module.exports = composePlugins(
 
 ```js
 const { composePlugins, withNx } = require('@nx/webpack');
-const { withReact, withModuleFederatioForSSRn } = require('@nx/react');
+const { withReact } = require('@nx/react');
+const { withModuleFederationForSSR } = require('@nx/module-federation/webpack');
 
 // Host config
 // e.g. { remotes: ['about', 'dashboard'] }
@@ -705,22 +703,16 @@ module.exports = composePlugins(
 {% tabitem label="Angular Module Federation for SSR" %}
 
 ```js
-const {
-  composePlugins,
-  withModuleFederationForSSR,
-} = require('@nx/angular/module-federation');
+const { withModuleFederationForSSR } = require('@nx/module-federation/angular');
 
 // Host config
 // e.g. { remotes: ['about', 'dashboard'] }
 const moduleFederationConfig = require('./module-federation.config');
 
-module.exports = composePlugins(
-  withModuleFederationForSSR(moduleFederationConfig),
-  (config) => {
-    // Further customize webpack config
-    return config;
-  }
-);
+// `dts: false` disables type generation since Nx already provides typing support for module federation.
+module.exports = withModuleFederationForSSR(moduleFederationConfig, {
+  dts: false,
+});
 ```
 
 {% /tabitem %}

--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -389,6 +389,11 @@
       },
       "description": "Replace 'jest-preset-angular/setup-jest' imports with the new 'setupZoneTestEnv' function.",
       "factory": "./src/migrations/update-22-3-0/update-jest-preset-angular-setup"
+    },
+    "update-23-0-0-update-with-module-federation-import": {
+      "version": "23.0.0-beta.0",
+      "description": "Update the @nx/angular/module-federation import to use @nx/module-federation/angular.",
+      "factory": "./src/migrations/update-23-0-0/migrate-with-mf-import-to-new-package"
     }
   },
   "packageJsonUpdates": {

--- a/packages/angular/module-federation/index.ts
+++ b/packages/angular/module-federation/index.ts
@@ -1,9 +1,0 @@
-import {
-  withModuleFederation,
-  withModuleFederationForSSR,
-} from '@nx/module-federation/angular';
-
-/**
- * @deprecated Update the import path to `@nx/module-federation/angular` instead. This import path will be removed in Nx v22.
- */
-export { withModuleFederation, withModuleFederationForSSR };

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -24,7 +24,6 @@
     "./executors": "./executors.js",
     "./plugin": "./plugin.js",
     "./tailwind": "./tailwind.js",
-    "./module-federation": "./module-federation/index.js",
     "./src/utils": "./src/utils/index.js",
     "./plugins/component-testing": "./plugins/component-testing.js",
     "./src/generators/utils": "./src/generators/utils/index.js",

--- a/packages/angular/src/generators/convert-to-with-mf/__snapshots__/convert-to-with-mf.spec.ts.snap
+++ b/packages/angular/src/generators/convert-to-with-mf/__snapshots__/convert-to-with-mf.spec.ts.snap
@@ -1,21 +1,21 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
 exports[`convertToWithMF should migrate a standard previous generated host config correctly 1`] = `
-"const { withModuleFederation } = require('@nx/angular/module-federation');
+"const { withModuleFederation } = require('@nx/module-federation/angular');
 const config = require('./module-federation.config');
 module.exports = withModuleFederation(config);
 "
 `;
 
 exports[`convertToWithMF should migrate a standard previous generated remote config correctly 1`] = `
-"const { withModuleFederation } = require('@nx/angular/module-federation');
+"const { withModuleFederation } = require('@nx/module-federation/angular');
 const config = require('./module-federation.config');
 module.exports = withModuleFederation(config);
 "
 `;
 
 exports[`convertToWithMF should migrate a standard previous generated remote config using object shared syntax correctly 1`] = `
-"const { withModuleFederation } = require('@nx/angular/module-federation');
+"const { withModuleFederation } = require('@nx/module-federation/angular');
 const config = require('./module-federation.config');
 module.exports = withModuleFederation(config);
 "

--- a/packages/angular/src/generators/convert-to-with-mf/convert-to-with-mf.ts
+++ b/packages/angular/src/generators/convert-to-with-mf/convert-to-with-mf.ts
@@ -1,4 +1,5 @@
 import {
+  addDependenciesToPackageJson,
   formatFiles,
   joinPathFragments,
   logger,
@@ -7,6 +8,7 @@ import {
 } from '@nx/devkit';
 import type { Schema } from './schema';
 import { getMFProjects } from '../../utils/get-mf-projects';
+import { nxVersion } from '../../utils/versions';
 import {
   checkOutputNameMatchesProjectName,
   checkSharedNpmPackagesMatchExpected,
@@ -58,9 +60,17 @@ export async function convertToWithMF(tree: Tree, schema: Schema) {
     mfConfig
   );
 
+  const installTask = addDependenciesToPackageJson(
+    tree,
+    {},
+    { '@nx/module-federation': nxVersion }
+  );
+
   if (!schema.skipFormat) {
     await formatFiles(tree);
   }
+
+  return installTask;
 }
 
 export default convertToWithMF;

--- a/packages/angular/src/generators/convert-to-with-mf/lib/__snapshots__/write-new-webpack-config.spec.ts.snap
+++ b/packages/angular/src/generators/convert-to-with-mf/lib/__snapshots__/write-new-webpack-config.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`writeNewWebpackConfig should convert config that is both remote and host correctly 1`] = `
 [
-  "const { withModuleFederation } = require('@nx/angular/module-federation');
+  "const { withModuleFederation } = require('@nx/module-federation/angular');
 const config = require('./module-federation.config');
 module.exports = withModuleFederation(config);
 ",
@@ -19,7 +19,7 @@ module.exports = withModuleFederation(config);
 
 exports[`writeNewWebpackConfig should convert config that is neither remote and host correctly 1`] = `
 [
-  "const { withModuleFederation } = require('@nx/angular/module-federation');
+  "const { withModuleFederation } = require('@nx/module-federation/angular');
 const config = require('./module-federation.config');
 module.exports = withModuleFederation(config);
 ",
@@ -32,7 +32,7 @@ module.exports = withModuleFederation(config);
 
 exports[`writeNewWebpackConfig should convert host config correctly 1`] = `
 [
-  "const { withModuleFederation } = require('@nx/angular/module-federation');
+  "const { withModuleFederation } = require('@nx/module-federation/angular');
 const config = require('./module-federation.config');
 module.exports = withModuleFederation(config);
 ",
@@ -46,7 +46,7 @@ module.exports = withModuleFederation(config);
 
 exports[`writeNewWebpackConfig should convert remote config correctly 1`] = `
 [
-  "const { withModuleFederation } = require('@nx/angular/module-federation');
+  "const { withModuleFederation } = require('@nx/module-federation/angular');
 const config = require('./module-federation.config');
 module.exports = withModuleFederation(config);
 ",

--- a/packages/angular/src/generators/convert-to-with-mf/lib/write-new-webpack-config.ts
+++ b/packages/angular/src/generators/convert-to-with-mf/lib/write-new-webpack-config.ts
@@ -10,7 +10,7 @@ export function writeNewWebpackConfig(
   mfType: IsHostRemoteConfigResult,
   projectName: string
 ) {
-  const webpackConfig = `const { withModuleFederation } = require('@nx/angular/module-federation');
+  const webpackConfig = `const { withModuleFederation } = require('@nx/module-federation/angular');
 const config = require('./module-federation.config');
 module.exports = withModuleFederation(config);
 `;

--- a/packages/angular/src/migrations/update-23-0-0/migrate-with-mf-import-to-new-package.md
+++ b/packages/angular/src/migrations/update-23-0-0/migrate-with-mf-import-to-new-package.md
@@ -1,0 +1,27 @@
+#### Update withModuleFederation Import to New Package
+
+Updates the `withModuleFederation` and `withModuleFederationForSSR` imports to use `@nx/module-federation/angular`. The `@nx/angular/module-federation` re-export path was deprecated in Nx v20.2 and is now removed.
+
+#### Examples
+
+##### Before
+
+```ts title="apps/shell/webpack.config.ts"
+import {
+  withModuleFederation,
+  withModuleFederationForSSR,
+} from '@nx/angular/module-federation';
+```
+
+##### After
+
+```ts title="apps/shell/webpack.config.ts"
+import {
+  withModuleFederation,
+  withModuleFederationForSSR,
+} from '@nx/module-federation/angular';
+```
+
+#### Notes
+
+This migration runs for all projects in the workspace that depend on `@nx/angular`, ensuring imports are updated when migrating to Nx v23.

--- a/packages/angular/src/migrations/update-23-0-0/migrate-with-mf-import-to-new-package.spec.ts
+++ b/packages/angular/src/migrations/update-23-0-0/migrate-with-mf-import-to-new-package.spec.ts
@@ -1,0 +1,232 @@
+import {
+  addProjectConfiguration,
+  type ProjectConfiguration,
+  type ProjectGraph,
+  type Tree,
+} from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migrateWithMfImport from './migrate-with-mf-import-to-new-package';
+
+let projectGraph: ProjectGraph;
+jest.mock('@nx/devkit', () => ({
+  ...jest.requireActual('@nx/devkit'),
+  createProjectGraphAsync: () => Promise.resolve(projectGraph),
+}));
+
+describe('migrate-with-mf-import-to-new-package', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+    projectGraph = { dependencies: {}, nodes: {} };
+    addProject(
+      tree,
+      {
+        name: 'shell',
+        root: 'apps/shell',
+        sourceRoot: 'apps/shell/src',
+        projectType: 'application',
+      },
+      ['npm:@nx/angular']
+    );
+  });
+
+  it('should migrate the import correctly for withMf', async () => {
+    // ARRANGE
+    tree.write(
+      'apps/shell/webpack.config.ts',
+      `import { withModuleFederation } from '@nx/angular/module-federation';`
+    );
+
+    // ACT
+    await migrateWithMfImport(tree);
+
+    // ASSERT
+    expect(tree.read('apps/shell/webpack.config.ts', 'utf-8'))
+      .toMatchInlineSnapshot(`
+      "import { withModuleFederation } from '@nx/module-federation/angular';
+      "
+    `);
+  });
+
+  it('should migrate the require correctly for withMf', async () => {
+    // ARRANGE
+    tree.write(
+      'apps/shell/webpack.config.js',
+      `const { withModuleFederation } = require('@nx/angular/module-federation');`
+    );
+
+    // ACT
+    await migrateWithMfImport(tree);
+
+    // ASSERT
+    expect(tree.read('apps/shell/webpack.config.js', 'utf-8'))
+      .toMatchInlineSnapshot(`
+      "const { withModuleFederation } = require('@nx/module-federation/angular');
+      "
+    `);
+  });
+
+  it('should migrate the import correctly for withMfSSR', async () => {
+    // ARRANGE
+    tree.write(
+      'apps/shell/webpack.config.ts',
+      `import { withModuleFederationForSSR } from '@nx/angular/module-federation';`
+    );
+
+    // ACT
+    await migrateWithMfImport(tree);
+
+    // ASSERT
+    expect(tree.read('apps/shell/webpack.config.ts', 'utf-8'))
+      .toMatchInlineSnapshot(`
+      "import { withModuleFederationForSSR } from '@nx/module-federation/angular';
+      "
+    `);
+  });
+
+  it('should migrate the require correctly for withMfSSR', async () => {
+    // ARRANGE
+    tree.write(
+      'apps/shell/webpack.config.js',
+      `const { withModuleFederationForSSR } = require('@nx/angular/module-federation');`
+    );
+
+    // ACT
+    await migrateWithMfImport(tree);
+
+    // ASSERT
+    expect(tree.read('apps/shell/webpack.config.js', 'utf-8'))
+      .toMatchInlineSnapshot(`
+      "const { withModuleFederationForSSR } = require('@nx/module-federation/angular');
+      "
+    `);
+  });
+
+  it('should rewrite all matching imports in a single file', async () => {
+    // ARRANGE
+    tree.write(
+      'apps/shell/webpack.config.ts',
+      `import { withModuleFederation } from '@nx/angular/module-federation';
+import { withModuleFederationForSSR } from '@nx/angular/module-federation';
+const fallback = require('@nx/angular/module-federation');`
+    );
+
+    // ACT
+    await migrateWithMfImport(tree);
+
+    // ASSERT
+    expect(tree.read('apps/shell/webpack.config.ts', 'utf-8'))
+      .toMatchInlineSnapshot(`
+      "import { withModuleFederation } from '@nx/module-federation/angular';
+      import { withModuleFederationForSSR } from '@nx/module-federation/angular';
+      const fallback = require('@nx/module-federation/angular');
+      "
+    `);
+  });
+
+  it('should skip projects that do not depend on @nx/angular', async () => {
+    // ARRANGE
+    addProject(tree, {
+      name: 'unrelated',
+      root: 'apps/unrelated',
+      sourceRoot: 'apps/unrelated/src',
+      projectType: 'application',
+    });
+    tree.write(
+      'apps/unrelated/webpack.config.ts',
+      `import { withModuleFederation } from '@nx/angular/module-federation';`
+    );
+
+    // ACT
+    await migrateWithMfImport(tree);
+
+    // ASSERT
+    const content = tree.read('apps/unrelated/webpack.config.ts', 'utf-8');
+    expect(content).toContain(`'@nx/angular/module-federation'`);
+    expect(content).not.toContain(`'@nx/module-federation/angular'`);
+  });
+
+  it('should add @nx/module-federation to package.json when files were rewritten', async () => {
+    // ARRANGE
+    tree.write(
+      'apps/shell/webpack.config.ts',
+      `import { withModuleFederation } from '@nx/angular/module-federation';`
+    );
+
+    // ACT
+    await migrateWithMfImport(tree);
+
+    // ASSERT
+    const pkg = JSON.parse(tree.read('package.json', 'utf-8'));
+    expect(pkg.devDependencies?.['@nx/module-federation']).toBeDefined();
+  });
+
+  it('should not add @nx/module-federation to package.json when nothing was rewritten', async () => {
+    // ARRANGE: no file uses the deprecated import path
+    // ACT
+    await migrateWithMfImport(tree);
+
+    // ASSERT
+    const pkg = JSON.parse(tree.read('package.json', 'utf-8'));
+    expect(pkg.devDependencies?.['@nx/module-federation']).toBeUndefined();
+  });
+
+  describe('idempotent', () => {
+    it('should migrate the import correctly for withMf even when run twice', async () => {
+      // ARRANGE
+      tree.write(
+        'apps/shell/webpack.config.ts',
+        `import { withModuleFederation } from '@nx/angular/module-federation';`
+      );
+
+      // ACT
+      await migrateWithMfImport(tree);
+      await migrateWithMfImport(tree);
+
+      // ASSERT
+      expect(tree.read('apps/shell/webpack.config.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "import { withModuleFederation } from '@nx/module-federation/angular';
+        "
+      `);
+    });
+
+    it('should migrate the require correctly for withMfSSR even when run twice', async () => {
+      // ARRANGE
+      tree.write(
+        'apps/shell/webpack.config.js',
+        `const { withModuleFederationForSSR } = require('@nx/angular/module-federation');`
+      );
+
+      // ACT
+      await migrateWithMfImport(tree);
+      await migrateWithMfImport(tree);
+
+      // ASSERT
+      expect(tree.read('apps/shell/webpack.config.js', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "const { withModuleFederationForSSR } = require('@nx/module-federation/angular');
+        "
+      `);
+    });
+  });
+});
+
+function addProject(
+  tree: Tree,
+  config: ProjectConfiguration,
+  dependencies: string[] = []
+): void {
+  projectGraph.nodes[config.name] = {
+    data: config,
+    name: config.name,
+    type: config.projectType === 'library' ? 'lib' : 'app',
+  };
+  projectGraph.dependencies[config.name] = dependencies.map((d) => ({
+    source: config.name,
+    target: d,
+    type: 'static',
+  }));
+  addProjectConfiguration(tree, config.name, config);
+}

--- a/packages/angular/src/migrations/update-23-0-0/migrate-with-mf-import-to-new-package.ts
+++ b/packages/angular/src/migrations/update-23-0-0/migrate-with-mf-import-to-new-package.ts
@@ -1,0 +1,66 @@
+import {
+  type Tree,
+  addDependenciesToPackageJson,
+  formatFiles,
+  visitNotIgnoredFiles,
+} from '@nx/devkit';
+import { ast, query } from '@phenomnomnominal/tsquery';
+import { getProjectsFilteredByDependencies } from '../utils/projects';
+import { nxVersion } from '../../utils/versions';
+
+const NX_ANGULAR_MODULE_FEDERATION_IMPORT_SELECTOR =
+  'ImportDeclaration > StringLiteral[value=@nx/angular/module-federation], VariableStatement CallExpression:has(Identifier[name=require]) > StringLiteral[value=@nx/angular/module-federation]';
+const NEW_IMPORT_PATH = `'@nx/module-federation/angular'`;
+
+export default async function migrateWithMfImport(tree: Tree) {
+  const angularProjects = await getProjectsFilteredByDependencies([
+    'npm:@nx/angular',
+  ]);
+  if (!angularProjects.length) {
+    return;
+  }
+
+  let anyUpdated = false;
+  for (const { data } of angularProjects) {
+    visitNotIgnoredFiles(tree, data.root, (filePath) => {
+      if (!filePath.endsWith('.ts') && !filePath.endsWith('.js')) {
+        return;
+      }
+      let contents = tree.read(filePath, 'utf-8');
+      if (!contents.includes('@nx/angular/module-federation')) {
+        return;
+      }
+
+      const sourceFile = ast(contents);
+      const importNodes = query(
+        sourceFile,
+        NX_ANGULAR_MODULE_FEDERATION_IMPORT_SELECTOR
+      );
+      if (importNodes.length === 0) {
+        return;
+      }
+
+      // Iterate end-to-start so earlier replacements don't shift later offsets.
+      for (let i = importNodes.length - 1; i >= 0; i--) {
+        const node = importNodes[i];
+        contents = `${contents.slice(
+          0,
+          node.getStart()
+        )}${NEW_IMPORT_PATH}${contents.slice(node.getEnd())}`;
+      }
+
+      tree.write(filePath, contents);
+      anyUpdated = true;
+    });
+  }
+
+  if (anyUpdated) {
+    addDependenciesToPackageJson(
+      tree,
+      {},
+      { '@nx/module-federation': nxVersion }
+    );
+  }
+
+  await formatFiles(tree);
+}


### PR DESCRIPTION
## Current Behavior

The `@nx/angular/module-federation` entry point is exposed as a deprecated re-export of `withModuleFederation` and `withModuleFederationForSSR` from `@nx/module-federation/angular`. It was deprecated in Nx v20.2.

## Expected Behavior

The `@nx/angular/module-federation` entry point is removed. Consumers must import from `@nx/module-federation/angular` directly. A migration (`update-23-0-0-update-with-module-federation-import`) rewrites existing imports/requires in webpack configs of projects depending on `@nx/angular` and adds `@nx/module-federation` to `package.json`.

The `@nx/angular:convert-to-with-mf` generator now installs `@nx/module-federation` since the webpack config it emits imports from that package.

The webpack guides (`webpack-config-setup`, `webpack-plugins`) were updated to reflect the recommended import paths and to fix broken Angular MF snippets that wrapped `withModuleFederation` with `composePlugins` (not exported from `@nx/module-federation/angular`).

BREAKING CHANGE: The `@nx/angular/module-federation` entry point is removed. Update imports to use `@nx/module-federation/angular` instead. The `update-23-0-0-update-with-module-federation-import` migration handles this automatically when running `nx migrate`.