### PR TITLE
fix(core): correctly classify same-second in-place updates in macOS watcher

### DIFF
--- a/packages/nx/src/native/watch/types.rs
+++ b/packages/nx/src/native/watch/types.rs
@@ -118,7 +118,7 @@ pub(super) fn transform_event_to_watch_events(
 
     #[cfg(target_os = "macos")]
     {
-        use std::os::macos::fs::MetadataExt;
+        use std::time::Duration;
 
         // Skip directory events
         if meta_is_dir(metadata) {
@@ -136,15 +136,23 @@ pub(super) fn transform_event_to_watch_events(
             // correctly.
             Err(_) => EventType::delete,
             Ok(t) => {
-                let modified_time = t.st_mtime();
-                let birth_time = t.st_birthtime();
-
-                // if a file is created and updated near the same time, we always get a create event
-                // so we need to check the timestamps to see if it was created or updated
-                if modified_time == birth_time {
-                    EventType::create
-                } else {
-                    EventType::update
+                // FSEvents reports Create for in-place updates of recently-active
+                // paths; we disambiguate via inode timestamps. `fs::write` is
+                // O_CREAT (stamps birthtime) + a separate write (stamps mtime)
+                // ~100µs later, so strict ns equality mis-Updates fresh writes
+                // and whole-second equality mis-Creates same-second updates.
+                // Tolerance covers kernel jitter; bursts within IDLE_WINDOW
+                // (100ms) coalesce and the (Create, Update) → Create merge rule
+                // makes the per-event label immaterial inside that window.
+                const FRESH_WRITE_TOLERANCE: Duration = Duration::from_millis(50);
+                let delta = t
+                    .modified()
+                    .ok()
+                    .zip(t.created().ok())
+                    .and_then(|(m, b)| m.duration_since(b).ok());
+                match delta {
+                    Some(d) if d > FRESH_WRITE_TOLERANCE => EventType::update,
+                    _ => EventType::create,
                 }
             }
         };


### PR DESCRIPTION
## Current Behavior

On macOS, `transform_event_to_watch_events` infers Create vs Update from inode timestamps because FSEvents reports a Create flag for in-place updates of recently-active paths. The check compared `st_mtime` and `st_birthtime` at **whole-second** precision:

```rust
if t.st_mtime() == t.st_birthtime() {
    EventType::create
} else {
    EventType::update
}
```

When an in-place update lands in the same wall-clock second as the file's creation, both timestamps round to the same value and the event is mis-classified as `Create`. This:

- Flakes `native::watch::watcher::tests::plain_update_yields_update` ~70% of the time (writes v1, sleeps 150ms, writes v2 — both timestamps in the same second on most runs).
- Mislabels real `nx watch` events when a developer or tool edits a file shortly after it's created/checked-out.

Strict ns-precision equality isn't viable either: `fs::write` is `open(O_CREAT)` (stamps birthtime) followed by a separate `write` syscall (stamps mtime) ~100µs later, so every fresh write would mis-classify as Update.

## Expected Behavior

Same-second in-place updates classify as `Update`; fresh writes still classify as `Create`.

The fix compares `Metadata::modified()` and `Metadata::created()` (`SystemTime`, ns precision) with a 50ms tolerance:

- Below the threshold → `Create`. Covers the kernel's ~100µs `O_CREAT`→`write` gap with comfortable headroom for syscall jitter.
- Above the threshold → `Update`. Real edits separated from creation by anything more than tens of ms classify correctly.

The watcher's accumulator merges events within `IDLE_WINDOW` (100ms) and the `(Create, Update) → Create` rule keeps the first state, so per-event labels inside the tolerance window don't reach consumers — only events in separate bursts do, and those are reliably outside the window.

### Verification

- 10/10 stress runs of `npx nx test-native nx --skip-nx-cache --no-cloud` no longer fail `plain_update_yields_update` (was 7/10 fail rate before).
- All other 351 native tests pass on every run.
- Empirical kernel-timing probe on macOS confirmed: fresh `fs::write` produces `mtime - birthtime ≈ 100µs`; in-place update 150ms after creation produces `mtime - birthtime ≈ 152ms` — comfortably on either side of the 50ms cutoff.