### PR TITLE
fix(core): restore deprecated allWorkspaceFiles on WorkspaceFileMap

### DIFF
--- a/packages/nx/src/project-graph/file-map-utils.ts
+++ b/packages/nx/src/project-graph/file-map-utils.ts
@@ -15,6 +15,7 @@ import {
 } from '../utils/workspace-context';
 import { workspaceRoot } from '../utils/workspace-root';
 import { readProjectsConfigurationFromProjectGraph } from './project-graph';
+import { buildAllWorkspaceFiles } from './utils/build-all-workspace-files';
 import {
   createProjectRootMappingsFromProjectConfigurations,
   findProjectForPath,
@@ -22,6 +23,11 @@ import {
 
 export interface WorkspaceFileMap {
   fileMap: FileMap;
+  /**
+   * @deprecated Derived from `fileMap.projectFileMap` + `fileMap.nonProjectFiles`.
+   * Will be removed in a future major. Compute it locally if needed.
+   */
+  allWorkspaceFiles?: FileData[];
 }
 
 export async function createProjectFileMapUsingProjectGraph(
@@ -66,12 +72,23 @@ export function createFileMap(
       nonProjectFiles.push(f);
     }
   }
-  return {
+  const result: WorkspaceFileMap = {
     fileMap: {
       projectFileMap,
       nonProjectFiles,
     },
   };
+  Object.defineProperty(result, 'allWorkspaceFiles', {
+    enumerable: false,
+    configurable: true,
+    get() {
+      return buildAllWorkspaceFiles(
+        result.fileMap.projectFileMap,
+        result.fileMap.nonProjectFiles
+      );
+    },
+  });
+  return result;
 }
 
 export function updateFileMap(


### PR DESCRIPTION
## Current Behavior

#34425 ("remove redundant `allWorkspaceFiles` from the project graph pipeline") dropped `allWorkspaceFiles` from the `WorkspaceFileMap` interface without a deprecation cycle.

Plugins that import `createFileMapUsingProjectGraph` from the deep path `nx/src/project-graph/file-map-utils` — e.g. `@nx/owners` — fail to type-check against the beta release:

```
src/plugin/plugin.ts(73,20): error TS2339: Property 'allWorkspaceFiles' does not exist on type 'WorkspaceFileMap'.
src/plugin/plugin.spec.ts(799,5): error TS2353: Object literal may only specify known properties, and 'allWorkspaceFiles' does not exist in type 'WorkspaceFileMap'.
```

The path is technically internal (not exported from `@nx/devkit`), but real consumers (including cached nx-cloud workers — see #35502) reach in there, and #35502 already established the pattern of restoring removed members as `@deprecated` shims rather than breaking them outright.

## Expected Behavior

`allWorkspaceFiles` is restored on `WorkspaceFileMap` as `@deprecated` and exposed from `createFileMap` via a **non-enumerable lazy getter**:

- **Lazy** — derived from `fileMap.projectFileMap` + `fileMap.nonProjectFiles` only when read. Zero allocation for callers that don't touch it.
- **Non-enumerable** — stays out of `JSON.stringify` / `Object.keys`, so the daemon-serialization wins from #34425 are preserved if a `WorkspaceFileMap` ever ends up on the wire.
- **Optional** — daemon-internal call sites (`updateFileMap`) that never set the field still satisfy the type.

The hot-path improvements from #34425 stay intact:

- No `allWorkspaceFiles` on `SerializedProjectGraph` going across the daemon wire
- No `copyFileData()` on every graph serialization
- No `buildAllWorkspaceFiles()` on incremental updates
- No `storedAllWorkspaceFiles` retained in `build-project-graph` state
- `updateFileMap` return value unchanged

The shim only sits at the plugin boundary — `createFileMapUsingProjectGraph`, which runs in the plugin's process, not the daemon.

Same back-compat pattern as #35502 (`hydrateFileMap` 3-arg overload). Both can be removed in a future major once known consumers (ocean, cached cloud workers) age out.

## Related Issue(s)

<!-- Reported via internal channels (ocean) — no public issue. -->
