### PR TITLE
fix(nx-dev): document nested CLI subcommands beyond two levels

### DIFF
--- a/astro-docs/e2e/cli-subcommand-formatting.spec.ts
+++ b/astro-docs/e2e/cli-subcommand-formatting.spec.ts
@@ -70,6 +70,35 @@ test.describe('CLI sub-command formatting', () => {
     ).toBe(false);
   });
 
+  test('nested sub-commands beyond two levels are documented', async ({
+    page,
+  }) => {
+    const mainContent = page.getByTestId('main-pane');
+
+    // "nx show target inputs" is a third-level command — it should render as h3
+    // alongside other sub-commands and include its usage block.
+    const showTargetInputsHeading = mainContent.getByRole('heading', {
+      name: 'nx show target inputs',
+      level: 3,
+      exact: true,
+    });
+    await expect(showTargetInputsHeading).toBeVisible();
+
+    const showTargetOutputsHeading = mainContent.getByRole('heading', {
+      name: 'nx show target outputs',
+      level: 3,
+      exact: true,
+    });
+    await expect(showTargetOutputsHeading).toBeVisible();
+
+    const codeBlocks = mainContent.locator('pre code');
+    const allCodeTexts = await codeBlocks.allTextContents();
+
+    expect(
+      allCodeTexts.some((text) => text.includes('nx show target inputs'))
+    ).toBe(true);
+  });
+
   test('release sub-commands use correct heading and usage format', async ({
     page,
   }) => {

--- a/astro-docs/src/plugins/utils/nx-cli-generation.ts
+++ b/astro-docs/src/plugins/utils/nx-cli-generation.ts
@@ -110,23 +110,29 @@ function flattenCommands(
 ): FlattenedCommand[] {
   const allCommands: FlattenedCommand[] = [];
 
-  for (const [cmdName, cmd] of Object.entries(commands)) {
-    allCommands.push({ fullName: cmdName, cmd });
+  const visit = (
+    cmd: ParsedCliCommand,
+    fullName: string,
+    parentOptions?: ParsedCliCommand['options']
+  ) => {
+    allCommands.push({ fullName, cmd, parentOptions });
 
-    if (cmd.subcommands) {
-      for (const sub of cmd.subcommands) {
-        // For $0 (default command), use parent name; otherwise, combine parent and sub name
-        const subName =
-          sub.command?.startsWith('$0') || sub.name === '$0'
-            ? cmdName
-            : `${cmdName} ${sub.name}`;
-        allCommands.push({
-          fullName: subName,
-          cmd: sub,
-          parentOptions: cmd.options,
-        });
-      }
+    if (!cmd.subcommands) {
+      return;
     }
+
+    for (const sub of cmd.subcommands) {
+      // For $0 (default command), use parent name; otherwise, combine parent and sub name
+      const subName =
+        sub.command?.startsWith('$0') || sub.name === '$0'
+          ? fullName
+          : `${fullName} ${sub.name}`;
+      visit(sub, subName, cmd.options ?? []);
+    }
+  };
+
+  for (const [cmdName, cmd] of Object.entries(commands)) {
+    visit(cmd, cmdName);
   }
 
   return allCommands.sort((a, b) => a.fullName.localeCompare(b.fullName));


### PR DESCRIPTION
## Current Behavior

The CLI docs generator that produces `/docs/reference/nx-commands` only flattens the top-level command and its direct children. Any subcommand nested deeper than that is silently dropped from the rendered page, even though the underlying yargs parser already produces the full nested tree.

In practice this means commands like `nx show target inputs` and `nx show target outputs` have no public docs entry — users have no way to discover their flags (`--check`, `--target`, `--configuration`, etc.) without running `--help` locally.

## Expected Behavior

The generator walks the full subcommand tree and renders every command. Three-deep commands like `nx show target inputs` appear as `###` headings alongside `nx show target`, with their own usage block and options table.

Verified locally — running the generator before/after this change adds exactly two new sections (`nx show target inputs`, `nx show target outputs`) and changes nothing else.

A new e2e test in `astro-docs/e2e/cli-subcommand-formatting.spec.ts` locks the third-level rendering in so this can't regress silently again.

## Related Issue(s)

Fixes #