### PR TITLE
feat(nx-dev): track docs analytics for code copy, LLM prompt, YouTube

### DIFF
--- a/astro-docs/public/global-scripts.js
+++ b/astro-docs/public/global-scripts.js
@@ -211,11 +211,38 @@
     });
   }
 
+  function deriveCodeId(text) {
+    return (text || '')
+      .toLowerCase()
+      .replace(/[^a-z0-9]+/g, '')
+      .slice(0, 60);
+  }
+
+  function setupCodeBlockCopyTracking() {
+    document.addEventListener('click', (e) => {
+      const target = e.target;
+      if (!(target instanceof Element)) return;
+      const button = target.closest('figure.frame .copy button[data-code]');
+      if (!button) return;
+      // Expressive Code encodes newlines as DEL (0x7F) in the data-code attribute.
+      const code = (button.getAttribute('data-code') || '').replace(
+        /\x7F/g,
+        '\n'
+      );
+      pushGtmEvent('code_block_copy', {
+        event_category: 'docs_interaction',
+        event_label: window.location.pathname,
+        code_id: deriveCodeId(code),
+      });
+    });
+  }
+
   const initializeAnalytics = () => {
     if (!gtmMeasurementId) return;
     loadGTM();
     setupSearchTracking();
     setupScrollTracking();
+    setupCodeBlockCopyTracking();
   };
 
   // Add GTM noscript iframe to body

--- a/astro-docs/src/components/markdoc/LlmCopyPrompt.astro
+++ b/astro-docs/src/components/markdoc/LlmCopyPrompt.astro
@@ -16,7 +16,7 @@ const id = `llm-prompt-${Math.random().toString(36).slice(2, 9)}`;
 const promptLines = finalPrompt.split('\n').filter((l) => l.length > 0);
 ---
 
-<llm-copy-prompt data-content-id={id}>
+<llm-copy-prompt data-content-id={id} data-prompt-title={title}>
   <details class="llm-prompt-card">
     <summary>
       <div class="llm-prompt-header">
@@ -284,6 +284,8 @@ const promptLines = finalPrompt.split('\n').filter((l) => l.length > 0);
 </style>
 
 <script>
+  import { sendCustomEventViaGtm } from '@nx/nx-dev-feature-analytics';
+
   class LlmCopyPromptElement extends HTMLElement {
     private button: HTMLButtonElement | null = null;
     private collapseCaret: HTMLElement | null = null;
@@ -335,10 +337,21 @@ const promptLines = finalPrompt.split('\n').filter((l) => l.length > 0);
       try {
         await navigator.clipboard.writeText(this.content);
         this.showCopiedState();
+        this.trackCopy();
       } catch (err) {
         console.error('Failed to copy:', err);
       }
     };
+
+    private trackCopy() {
+      sendCustomEventViaGtm(
+        'llm_prompt_copy',
+        'docs_interaction',
+        window.location.pathname,
+        undefined,
+        { prompt_title: this.dataset.promptTitle ?? '' }
+      );
+    }
 
     private showCopiedState() {
       this.button?.classList.add('copied');

--- a/astro-docs/src/components/markdoc/Youtube.astro
+++ b/astro-docs/src/components/markdoc/Youtube.astro
@@ -6,119 +6,27 @@ import {
 type Props = YouTubeProps;
 ---
 
-<youtube-tracker data-title={Astro.props.title} data-src={Astro.props.src}>
+<youtube-jsapi>
   <Default {...Astro.props} />
-</youtube-tracker>
+</youtube-jsapi>
 
 <script>
-  import { sendCustomEventViaGtm } from '@nx/nx-dev-feature-analytics';
-
-  // YT IFrame API states (https://developers.google.com/youtube/iframe_api_reference#Playback_status)
-  const YT_STATE_ENDED = 0;
-  const YT_STATE_PLAYING = 1;
-  const YT_STATE_PAUSED = 2;
-
-  let ytApiPromise: Promise<unknown> | null = null;
-
-  function loadYouTubeIframeApi(): Promise<unknown> {
-    if (typeof window === 'undefined') return Promise.resolve(null);
-    const w = window as unknown as {
-      YT?: { Player?: unknown };
-      onYouTubeIframeAPIReady?: () => void;
-    };
-    if (w.YT && w.YT.Player) return Promise.resolve(w.YT);
-    if (ytApiPromise) return ytApiPromise;
-
-    ytApiPromise = new Promise((resolve) => {
-      const previous = w.onYouTubeIframeAPIReady;
-      w.onYouTubeIframeAPIReady = () => {
-        if (typeof previous === 'function') previous();
-        resolve(w.YT);
-      };
-      const tag = document.createElement('script');
-      tag.src = 'https://www.youtube.com/iframe_api';
-      tag.async = true;
-      document.head.appendChild(tag);
-    });
-    return ytApiPromise;
-  }
-
-  class YouTubeTrackerElement extends HTMLElement {
-    private player: { destroy?: () => void } | null = null;
-    private link: HTMLAnchorElement | null = null;
-
+  // Patch iframe src with enablejsapi=1 so GA4 enhanced measurement
+  // (video_start, video_progress, video_complete) can hook into the player.
+  class YouTubeJsapiElement extends HTMLElement {
     connectedCallback() {
       const iframe = this.querySelector('iframe');
-      this.link = this.querySelector('a');
-      if (this.link) {
-        this.link.addEventListener('click', this.handleThumbnailClick);
-        return;
-      }
-      if (iframe instanceof HTMLIFrameElement) this.setupIframe(iframe);
-    }
-
-    disconnectedCallback() {
-      this.link?.removeEventListener('click', this.handleThumbnailClick);
-      this.player?.destroy?.();
-      this.player = null;
-    }
-
-    private handleThumbnailClick = () => {
-      this.track('youtube_thumbnail_click');
-    };
-
-    private setupIframe(iframe: HTMLIFrameElement) {
+      if (!(iframe instanceof HTMLIFrameElement)) return;
       try {
         const url = new URL(iframe.src);
-        if (url.searchParams.get('enablejsapi') !== '1') {
-          url.searchParams.set('enablejsapi', '1');
-          iframe.src = url.toString();
-        }
+        if (url.searchParams.get('enablejsapi') === '1') return;
+        url.searchParams.set('enablejsapi', '1');
+        iframe.src = url.toString();
       } catch {
-        return;
+        // Ignore malformed URLs.
       }
-      loadYouTubeIframeApi().then((yt) => {
-        const YT = yt as {
-          Player: new (
-            iframe: HTMLIFrameElement,
-            opts: { events: { onStateChange: (e: { data: number }) => void } }
-          ) => { destroy?: () => void };
-        } | null;
-        if (!YT) return;
-        this.player = new YT.Player(iframe, {
-          events: { onStateChange: this.onStateChange },
-        });
-      });
-    }
-
-    private playFired = false;
-
-    private onStateChange = (event: { data: number }) => {
-      if (event.data === YT_STATE_PLAYING) {
-        // Only fire the first play to avoid noise from buffering -> play cycles.
-        if (this.playFired) return;
-        this.playFired = true;
-        this.track('youtube_play');
-      } else if (event.data === YT_STATE_PAUSED) {
-        this.track('youtube_pause');
-      } else if (event.data === YT_STATE_ENDED) {
-        this.track('youtube_end');
-      }
-    };
-
-    private track(action: string) {
-      sendCustomEventViaGtm(
-        action,
-        'docs_interaction',
-        window.location.pathname,
-        undefined,
-        {
-          video_title: this.dataset.title ?? '',
-          video_src: this.dataset.src ?? '',
-        }
-      );
     }
   }
 
-  customElements.define('youtube-tracker', YouTubeTrackerElement);
+  customElements.define('youtube-jsapi', YouTubeJsapiElement);
 </script>

--- a/astro-docs/src/components/markdoc/Youtube.astro
+++ b/astro-docs/src/components/markdoc/Youtube.astro
@@ -1,6 +1,124 @@
 ---
-import { type YouTubeProps, YouTube as Default } from '@nx/nx-dev-ui-common/src/lib/youtube.component'
+import {
+  type YouTubeProps,
+  YouTube as Default,
+} from '@nx/nx-dev-ui-common/src/lib/youtube.component';
 type Props = YouTubeProps;
 ---
 
-<Default {...Astro.props} />
+<youtube-tracker data-title={Astro.props.title} data-src={Astro.props.src}>
+  <Default {...Astro.props} />
+</youtube-tracker>
+
+<script>
+  import { sendCustomEventViaGtm } from '@nx/nx-dev-feature-analytics';
+
+  // YT IFrame API states (https://developers.google.com/youtube/iframe_api_reference#Playback_status)
+  const YT_STATE_ENDED = 0;
+  const YT_STATE_PLAYING = 1;
+  const YT_STATE_PAUSED = 2;
+
+  let ytApiPromise: Promise<unknown> | null = null;
+
+  function loadYouTubeIframeApi(): Promise<unknown> {
+    if (typeof window === 'undefined') return Promise.resolve(null);
+    const w = window as unknown as {
+      YT?: { Player?: unknown };
+      onYouTubeIframeAPIReady?: () => void;
+    };
+    if (w.YT && w.YT.Player) return Promise.resolve(w.YT);
+    if (ytApiPromise) return ytApiPromise;
+
+    ytApiPromise = new Promise((resolve) => {
+      const previous = w.onYouTubeIframeAPIReady;
+      w.onYouTubeIframeAPIReady = () => {
+        if (typeof previous === 'function') previous();
+        resolve(w.YT);
+      };
+      const tag = document.createElement('script');
+      tag.src = 'https://www.youtube.com/iframe_api';
+      tag.async = true;
+      document.head.appendChild(tag);
+    });
+    return ytApiPromise;
+  }
+
+  class YouTubeTrackerElement extends HTMLElement {
+    private player: { destroy?: () => void } | null = null;
+    private link: HTMLAnchorElement | null = null;
+
+    connectedCallback() {
+      const iframe = this.querySelector('iframe');
+      this.link = this.querySelector('a');
+      if (this.link) {
+        this.link.addEventListener('click', this.handleThumbnailClick);
+        return;
+      }
+      if (iframe instanceof HTMLIFrameElement) this.setupIframe(iframe);
+    }
+
+    disconnectedCallback() {
+      this.link?.removeEventListener('click', this.handleThumbnailClick);
+      this.player?.destroy?.();
+      this.player = null;
+    }
+
+    private handleThumbnailClick = () => {
+      this.track('youtube_thumbnail_click');
+    };
+
+    private setupIframe(iframe: HTMLIFrameElement) {
+      try {
+        const url = new URL(iframe.src);
+        if (url.searchParams.get('enablejsapi') !== '1') {
+          url.searchParams.set('enablejsapi', '1');
+          iframe.src = url.toString();
+        }
+      } catch {
+        return;
+      }
+      loadYouTubeIframeApi().then((yt) => {
+        const YT = yt as {
+          Player: new (
+            iframe: HTMLIFrameElement,
+            opts: { events: { onStateChange: (e: { data: number }) => void } }
+          ) => { destroy?: () => void };
+        } | null;
+        if (!YT) return;
+        this.player = new YT.Player(iframe, {
+          events: { onStateChange: this.onStateChange },
+        });
+      });
+    }
+
+    private playFired = false;
+
+    private onStateChange = (event: { data: number }) => {
+      if (event.data === YT_STATE_PLAYING) {
+        // Only fire the first play to avoid noise from buffering -> play cycles.
+        if (this.playFired) return;
+        this.playFired = true;
+        this.track('youtube_play');
+      } else if (event.data === YT_STATE_PAUSED) {
+        this.track('youtube_pause');
+      } else if (event.data === YT_STATE_ENDED) {
+        this.track('youtube_end');
+      }
+    };
+
+    private track(action: string) {
+      sendCustomEventViaGtm(
+        action,
+        'docs_interaction',
+        window.location.pathname,
+        undefined,
+        {
+          video_title: this.dataset.title ?? '',
+          video_src: this.dataset.src ?? '',
+        }
+      );
+    }
+  }
+
+  customElements.define('youtube-tracker', YouTubeTrackerElement);
+</script>


### PR DESCRIPTION
## Current Behavior
Astro docs site tracks header nav, search, scroll depth, and 404s. Code block copies and LLM prompt copies are not tracked. YouTube embeds lack `enablejsapi=1`, so GA4 enhanced measurement cannot hook the player.

## Expected Behavior
Two new GTM dataLayer events: `code_block_copy` (with derived alphanumeric `code_id`) and `llm_prompt_copy` (with `prompt_title`). Both gated by existing production-only check. YouTube iframes get `enablejsapi=1` patched on the client so GA4 enhanced measurement fires `video_start` / `video_progress` / `video_complete` natively. GTM container needs tags wired for the two new event names to forward to GA4.

## Examples

Copy code block:
<img width="932" height="335" alt="image" src="https://github.com/user-attachments/assets/e21e8979-0bf2-4e94-a1f6-d832897ad392" />

Copy LLM prompt:
<img width="1140" height="250" alt="image" src="https://github.com/user-attachments/assets/ef4a558c-895d-49ed-8429-ead0997b9fed" />

Youtube play/pause/end
<img width="947" height="573" alt="image" src="https://github.com/user-attachments/assets/dc73cea5-6bb2-4131-a545-45239a80ecc9" />


## Related Issue(s)
Fixes DOC-497