### PR TITLE
fix(nx-dev): short-circuit bot probes in framer rewrite edge function

### DIFF
--- a/netlify/edge-functions/rewrite-framer-urls.ts
+++ b/netlify/edge-functions/rewrite-framer-urls.ts
@@ -111,6 +111,13 @@ async function sendToGA4(
 }
 
 /**
+ * Common WordPress / exploit-scanner probe patterns. Bots hit nx.dev with these
+ * paths constantly; matching upstreams don't exist and we never want to proxy them.
+ */
+const botProbeRegex =
+  /(wp-(includes|admin|content)|xmlrpc\.php|wlwmanifest|\.env|\.git\/)/i;
+
+/**
  * Paths that should be served by the Next.js app instead of Framer.
  * Everything else is proxied to Framer (or the blog site if configured).
  */
@@ -141,7 +148,13 @@ export default async function handler(
   context: Context
 ): Promise<Response> {
   const url = new URL(request.url);
-  const pathname = url.pathname;
+  // Collapse leading `/+` so a bot path like `//wp/...` can't be parsed as a
+  // protocol-relative URL (which would promote `wp` to the upstream host).
+  const pathname = url.pathname.replace(/^\/+/, '/');
+
+  if (botProbeRegex.test(pathname)) {
+    return new Response(null, { status: 404 });
+  }
 
   if (nextjsPaths.has(pathname)) return context.next();
 


### PR DESCRIPTION
Some bots are hitting the server, scanning for wordpress paths. This is resulting in 500 server error, but we should return 404.

This fails in prod (500):

```
 curl -sS -o /dev/null -w "%{http_code}\n" --path-as-is 'https://nx.dev//wp/wp-includes/wlwmanifest.xml'
```

Fixed in preview (404):

```
curl -sS -o /dev/null -w "%{http_code}\n" --path-as-is 'https://deploy-preview-35527--nx-dev.netlify.app//wp/wp-includes/wlwmanifest.xml'
```

## Current Behavior

Bot scanners hit `GET //wp/wp-includes/wlwmanifest.xml` (leading `//`). `new URL(pathname, framerUrl)` parses `//wp/...` as protocol-relative, promoting `wp` to upstream host. Fetch fails with DNS lookup error and the function 500s.

## Expected Behavior

Leading `/+` collapsed before resolving against `framerUrl`. Common WordPress / exploit probes (`wp-includes`, `wp-admin`, `xmlrpc.php`, `wlwmanifest`, `.env`, `.git/`) short-circuit to 404.

## Related Issue(s)

DOC-498