### PR TITLE
chore(repo): resolve sandbox violations on nx-dev:next:build task

### DIFF
--- a/nx-dev/nx-dev/project.json
+++ b/nx-dev/nx-dev/project.json
@@ -7,14 +7,11 @@
     "next:build": {
       "dependsOn": ["^build", "^typecheck", "typecheck"],
       "inputs": [
-        "default",
-        "^default",
-        { "dependentTasksOutputFiles": "**/*" },
+        "...",
+        { "dependentTasksOutputFiles": "**/*", "transitive": true },
         { "env": "NEXT_PUBLIC_ASTRO_URL" },
         { "env": "NX_DEV_URL" },
-        { "env": "NEXT_PUBLIC_NO_INDEX" },
-        { "externalDependencies": ["next"] },
-        { "dependentTasksOutputFiles": "**/*.d.ts", "transitive": true }
+        { "env": "NEXT_PUBLIC_NO_INDEX" }
       ],
       "outputs": ["{workspaceRoot}/nx-dev/nx-dev/.next"]
     },

--- a/nx-dev/nx-dev/tailwind.config.js
+++ b/nx-dev/nx-dev/tailwind.config.js
@@ -30,10 +30,7 @@ module.exports = {
       'feature-ai',
       'feature-analytics',
       'feature-search',
-    ].map(
-      (dir) =>
-        `../${dir}/src/**/!(*.stories|*.spec).{js,ts,jsx,tsx}`
-    ),
+    ].map((dir) => `../${dir}/src/**/!(*.stories|*.spec).{js,ts,jsx,tsx}`),
   ],
   theme: {
     extend: {

--- a/nx-dev/nx-dev/tailwind.config.js
+++ b/nx-dev/nx-dev/tailwind.config.js
@@ -10,8 +10,30 @@ module.exports = {
   darkMode: 'class',
   content: [
     path.join(__dirname, '{pages,app}/**/!(*.stories|*.spec).{js,ts,jsx,tsx}'),
-    '../ui-*/src/**/!(*.stories|*.spec).{js,ts,jsx,tsx}',
-    '../feature-*/src/**/!(*.stories|*.spec).{js,ts,jsx,tsx}',
+    // List specific dep projects rather than `../ui-*` / `../feature-*` so
+    // tailwind's dir-dependency (forwarded to webpack via postcss-loader)
+    // doesn't end up snapshotting siblings nx-dev doesn't depend on
+    // (ui-podcast, ui-pricing, feature-feedback) — those would otherwise pull
+    // their project-root files (eslint configs, etc.) into webpack's hash set.
+    ...[
+      'ui-animations',
+      'ui-blog',
+      'ui-common',
+      'ui-courses',
+      'ui-fence',
+      'ui-icons',
+      'ui-markdoc',
+      'ui-primitives',
+      'ui-references',
+      'ui-theme',
+      'ui-video-courses',
+      'feature-ai',
+      'feature-analytics',
+      'feature-search',
+    ].map(
+      (dir) =>
+        `../${dir}/src/**/!(*.stories|*.spec).{js,ts,jsx,tsx}`
+    ),
   ],
   theme: {
     extend: {

--- a/nx-dev/ui-markdoc/src/lib/graphs/task-graph.tsx
+++ b/nx-dev/ui-markdoc/src/lib/graphs/task-graph.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import type { ProjectGraphProjectNode } from 'nx/src/config/project-graph';
-import { TaskGraph } from 'nx/src/config/task-graph';
+import type { TaskGraph } from 'nx/src/config/task-graph';
 import { useCallback, useEffect, useMemo } from 'react';
 import { RenderTheme } from '@nx/graph';
 import { NxGraphTaskGraphProvider, useTaskGraphContext } from '@nx/graph/tasks';


### PR DESCRIPTION
## Current Behavior

The sandbox report for `nx-dev:next:build` flags 563 unexpected reads. All come from webpack's `FileSystemInfo._readFileHash` snapshotting inside `next build`, with three distinct triggers:

1. **`packages/nx/dist/**` (549 files)** — webpack's `buildDependencies` snapshot walks `next.config.js`'s require chain through `@nx/next/plugins/with-nx` → `@nx/devkit` → `nx`. In this workspace, those resolve to the workspace `packages/nx/dist/`. The non-transitive `dependentTasksOutputFiles: '**/*'` rule on `nx-dev:next:build` only walked one level deep and missed `nx:build-base`'s outputs.
2. **13 cross-project files** (sibling `eslint.config.mjs`, `nx-dev-e2e/{playwright.config.ts, project.json, tsconfig.json, src/*.spec.ts}`) — Tailwind CSS emits `dir-dependency` PostCSS messages for every directory matched by its `content` globs. `postcss-loader` forwards those as webpack `addContextDependency` calls; webpack then hashes every file in the snapshotted dirs. The bare `../ui-*` and `../feature-*` wildcards matched siblings nx-dev doesn't depend on (`ui-podcast`, `ui-pricing`, `feature-feedback`), pulling their project roots — including configs and adjacent e2e directories — into webpack's hash set.
3. **`.next/cache/config.json` (1 file)** — Next.js's incremental cache state, read inside the declared output dir.

## Expected Behavior

The principled fix is to declare real inputs where they exist, and stop reading files where the reads are spurious — not to add sandbox-config exclusions.

### Three changes

**`nx-dev/nx-dev/project.json`** — simplify inputs via the `"..."` spread token to inherit the `@nx/next` plugin's defaults (`default`, `^default`, `externalDependencies['next']`, `dependentTasksOutputFiles: '**/*.d.ts' transitive`), then add `transitive: true` to the broader `**/*` rule so it walks past one level and picks up nx's outputs from `nx:build-base`.

**`nx-dev/nx-dev/tailwind.config.js`** — replace bare wildcards with an explicit list of nx-dev's actual dep projects so Tailwind's dir-dep emission no longer pulls in non-deps.

**`nx-dev/ui-markdoc/src/lib/graphs/task-graph.tsx`** — convert `import { TaskGraph }` to `import type` (it's a TS interface used only as a type). The value-import was forcing webpack to resolve `nx`, walking into `packages/nx/**`.

### Verified

| Bucket | Original | After |
| --- | --- | --- |
| `packages/nx/dist/**` (549) | violations | ✓ declared inputs (verified with `nx show target inputs --check`) |
| 13 cross-project files | violations | ✓ no longer read (verified by `fs.readFile` trace) |
| `.next/cache/config.json` (1) | violation | ⚠ read happens inside declared output dir; sandbox-side classifier issue |

Net: **562 of 563 violations resolved by these 3 changes.** The remaining 1 is structurally an output-dir read (Next's own cache state) and would benefit from a sandbox-classifier fix to treat reads-of-own-outputs as legitimate.

### Follow-up considerations (not in this PR)

- **Promote the `transitive: true` rule into `@nx/next/plugin`'s default inputs.** Currently the plugin only emits `dependentTasksOutputFiles: '**/*.d.ts'` transitively — too narrow when bundlers walk the require chain to runtime files. A plugin-level fix would benefit every `@nx/next` consumer but has wider blast radius and warrants a separate PR.
- **Migrate nx-dev to Tailwind CSS v4.** v4 uses `@source` directives in CSS instead of JS glob lists, eliminating the postcss-loader → webpack contextDependency mechanism that caused this whole class of issue. The maintenance burden of keeping the explicit dep list in sync goes away. `@nx/react/tailwind` is deprecated and removed in Nx 24, so this migration is on the roadmap regardless.

## Related Issue(s)

N/A — investigation arose from a sandbox report on staging.nx.app.