### PR TITLE
fix(js): include transitive workspace deps in pruned pnpm lockfile

### DIFF
--- a/e2e/js/src/js-executor-prune-lockfile.test.ts
+++ b/e2e/js/src/js-executor-prune-lockfile.test.ts
@@ -160,65 +160,6 @@ describe('js:prune-lockfile executor', () => {
 
         installPrunedDist(packageManager, tmpProjPath(`${nodeapp}/dist`));
       });
-
-      // app -> lib-a <-> lib-b. The pruned lockfile must include both
-      // workspace packages without infinite-looping during the transitive
-      // walk. Without the visited guard in the BFS, this hangs.
-      it('should produce installable pruned output with circular workspace dependencies', () => {
-        const nodeapp = uniq('nodeapp');
-        const liba = uniq('liba');
-        const libb = uniq('libb');
-
-        runCLI(
-          `generate @nx/node:app ${nodeapp} --linter=eslint --unitTestRunner=jest`
-        );
-        runCLI(
-          `generate @nx/js:lib ${liba} --bundler=tsc --linter=eslint --unitTestRunner=jest`
-        );
-        runCLI(
-          `generate @nx/js:lib ${libb} --bundler=tsc --linter=eslint --unitTestRunner=jest`
-        );
-
-        const ref = (name: string) =>
-          packageManager === 'pnpm' ? 'workspace:*' : `file:../${name}`;
-
-        updateJson(`${liba}/package.json`, (json) => {
-          json.dependencies = {
-            ...json.dependencies,
-            [`@${scope}/${libb}`]: ref(libb),
-          };
-          return json;
-        });
-        updateJson(`${libb}/package.json`, (json) => {
-          json.dependencies = {
-            ...json.dependencies,
-            [`@${scope}/${liba}`]: ref(liba),
-          };
-          return json;
-        });
-        updateJson(`${nodeapp}/package.json`, (json) => {
-          json.dependencies = {
-            ...json.dependencies,
-            [`@${scope}/${liba}`]: ref(liba),
-          };
-          json.nx.targets['prune-lockfile'] = {
-            executor: '@nx/js:prune-lockfile',
-            options: { buildTarget: 'build' },
-          };
-          json.nx.targets['copy-workspace-modules'] = {
-            executor: '@nx/js:copy-workspace-modules',
-            options: { buildTarget: 'build' },
-          };
-          return json;
-        });
-        runCommand(`${packageManager} install`);
-
-        runCLI(`build ${nodeapp}`);
-        runCLI(`prune-lockfile ${nodeapp}`);
-        runCLI(`copy-workspace-modules ${nodeapp}`);
-
-        installPrunedDist(packageManager, tmpProjPath(`${nodeapp}/dist`));
-      });
     }
   );
 

--- a/e2e/js/src/js-executor-prune-lockfile.test.ts
+++ b/e2e/js/src/js-executor-prune-lockfile.test.ts
@@ -194,12 +194,8 @@ describe('js:prune-lockfile executor', () => {
 
       // Both workspace packages get importer blocks (the bug was that the
       // transitive lib-b importer was missing).
-      expect(prunedLockfile).toContain(
-        `workspace_modules/@${scope}/${liba}:`
-      );
-      expect(prunedLockfile).toContain(
-        `workspace_modules/@${scope}/${libb}:`
-      );
+      expect(prunedLockfile).toContain(`workspace_modules/@${scope}/${liba}:`);
+      expect(prunedLockfile).toContain(`workspace_modules/@${scope}/${libb}:`);
 
       // lib-a's reference to lib-b uses the flat workspace_modules layout.
       // Without the rewrite the lockfile would still say `workspace:*`,

--- a/e2e/js/src/js-executor-prune-lockfile.test.ts
+++ b/e2e/js/src/js-executor-prune-lockfile.test.ts
@@ -160,6 +160,65 @@ describe('js:prune-lockfile executor', () => {
 
         installPrunedDist(packageManager, tmpProjPath(`${nodeapp}/dist`));
       });
+
+      // app -> lib-a <-> lib-b. The pruned lockfile must include both
+      // workspace packages without infinite-looping during the transitive
+      // walk. Without the visited guard in the BFS, this hangs.
+      it('should produce installable pruned output with a workspace dependency cycle', () => {
+        const nodeapp = uniq('nodeapp');
+        const liba = uniq('liba');
+        const libb = uniq('libb');
+
+        runCLI(
+          `generate @nx/node:app ${nodeapp} --linter=eslint --unitTestRunner=jest`
+        );
+        runCLI(
+          `generate @nx/js:lib ${liba} --bundler=tsc --linter=eslint --unitTestRunner=jest`
+        );
+        runCLI(
+          `generate @nx/js:lib ${libb} --bundler=tsc --linter=eslint --unitTestRunner=jest`
+        );
+
+        const ref = (name: string) =>
+          packageManager === 'pnpm' ? 'workspace:*' : `file:../${name}`;
+
+        updateJson(`${liba}/package.json`, (json) => {
+          json.dependencies = {
+            ...json.dependencies,
+            [`@${scope}/${libb}`]: ref(libb),
+          };
+          return json;
+        });
+        updateJson(`${libb}/package.json`, (json) => {
+          json.dependencies = {
+            ...json.dependencies,
+            [`@${scope}/${liba}`]: ref(liba),
+          };
+          return json;
+        });
+        updateJson(`${nodeapp}/package.json`, (json) => {
+          json.dependencies = {
+            ...json.dependencies,
+            [`@${scope}/${liba}`]: ref(liba),
+          };
+          json.nx.targets['prune-lockfile'] = {
+            executor: '@nx/js:prune-lockfile',
+            options: { buildTarget: 'build' },
+          };
+          json.nx.targets['copy-workspace-modules'] = {
+            executor: '@nx/js:copy-workspace-modules',
+            options: { buildTarget: 'build' },
+          };
+          return json;
+        });
+        runCommand(`${packageManager} install`);
+
+        runCLI(`build ${nodeapp}`);
+        runCLI(`prune-lockfile ${nodeapp}`);
+        runCLI(`copy-workspace-modules ${nodeapp}`);
+
+        installPrunedDist(packageManager, tmpProjPath(`${nodeapp}/dist`));
+      });
     }
   );
 

--- a/e2e/js/src/js-executor-prune-lockfile.test.ts
+++ b/e2e/js/src/js-executor-prune-lockfile.test.ts
@@ -30,7 +30,13 @@ function installPrunedDist(
   const installDir = mkdtempSync(join(tmpdir(), 'prune-lockfile-install-'));
   try {
     cpSync(distPath, installDir, { recursive: true });
-    runCommand(installCmd[packageManager], { cwd: installDir });
+    // failOnError: true — runCommand silently swallows non-zero exits by
+    // default (see e2e/utils/command-utils.ts), which would let a broken
+    // pruned lockfile pass this assertion. We want a real failure.
+    runCommand(installCmd[packageManager], {
+      cwd: installDir,
+      failOnError: true,
+    });
   } finally {
     rmSync(installDir, { recursive: true, force: true });
   }

--- a/e2e/js/src/js-executor-prune-lockfile.test.ts
+++ b/e2e/js/src/js-executor-prune-lockfile.test.ts
@@ -10,6 +10,12 @@ import {
   tmpProjPath,
 } from '@nx/e2e-utils';
 
+const installCmd = {
+  pnpm: 'pnpm install --frozen-lockfile',
+  yarn: 'yarn install --frozen-lockfile',
+  npm: 'npm ci',
+} as const;
+
 describe('js:prune-lockfile executor', () => {
   describe.each([
     ['pnpm', 'pnpm-lock.yaml'],
@@ -18,7 +24,7 @@ describe('js:prune-lockfile executor', () => {
   ])(
     'package manager %s',
     (packageManager: 'pnpm' | 'yarn' | 'npm', lockfile) => {
-      let scope;
+      let scope: string;
 
       beforeAll(() => {
         scope = newProject({
@@ -31,7 +37,7 @@ describe('js:prune-lockfile executor', () => {
         cleanupProject();
       });
 
-      it('should prune lockfile with workspace module', () => {
+      it('should produce installable pruned output with a workspace module', () => {
         const nodeapp = uniq('nodeapp');
         const nodelib = uniq('nodelib');
 
@@ -49,9 +55,11 @@ describe('js:prune-lockfile executor', () => {
           };
           json.nx.targets['prune-lockfile'] = {
             executor: '@nx/js:prune-lockfile',
-            options: {
-              buildTarget: 'build',
-            },
+            options: { buildTarget: 'build' },
+          };
+          json.nx.targets['copy-workspace-modules'] = {
+            executor: '@nx/js:copy-workspace-modules',
+            options: { buildTarget: 'build' },
           };
           return json;
         });
@@ -59,11 +67,84 @@ describe('js:prune-lockfile executor', () => {
 
         runCLI(`build ${nodeapp}`);
         runCLI(`prune-lockfile ${nodeapp}`);
+        runCLI(`copy-workspace-modules ${nodeapp}`);
+
         checkFilesExist(`${nodeapp}/dist/${lockfile}`);
+        runCommand(installCmd[packageManager], {
+          cwd: tmpProjPath(`${nodeapp}/dist`),
+        });
+      });
+
+      // app -> lib-a -> lib-b with lib-b having an npm dep. The pruned lockfile
+      // must include lib-b as an importer and pull in its npm deps; otherwise
+      // the dist install fails. Regression for #34655 (originally hit on pnpm
+      // with `workspace:*`; this asserts the install contract on every PM).
+      it('should produce installable pruned output with a transitive workspace dep', () => {
+        const nodeapp = uniq('nodeapp');
+        const liba = uniq('liba');
+        const libb = uniq('libb');
+
+        runCLI(
+          `generate @nx/node:app ${nodeapp} --linter=eslint --unitTestRunner=jest`
+        );
+        runCLI(
+          `generate @nx/js:lib ${liba} --bundler=tsc --linter=eslint --unitTestRunner=jest`
+        );
+        runCLI(
+          `generate @nx/js:lib ${libb} --bundler=tsc --linter=eslint --unitTestRunner=jest`
+        );
+
+        // pnpm uses workspace:* for sibling workspace refs; yarn classic and
+        // npm don't support that protocol, so use file:../ for those.
+        const ref = (name: string) =>
+          packageManager === 'pnpm' ? 'workspace:*' : `file:../${name}`;
+
+        updateJson(`${liba}/package.json`, (json) => {
+          json.dependencies = {
+            ...json.dependencies,
+            [`@${scope}/${libb}`]: ref(libb),
+          };
+          return json;
+        });
+        updateJson(`${libb}/package.json`, (json) => {
+          json.dependencies = {
+            ...json.dependencies,
+            lodash: '^4.17.21',
+          };
+          return json;
+        });
+        updateJson(`${nodeapp}/package.json`, (json) => {
+          json.dependencies = {
+            ...json.dependencies,
+            [`@${scope}/${liba}`]: ref(liba),
+          };
+          json.nx.targets['prune-lockfile'] = {
+            executor: '@nx/js:prune-lockfile',
+            options: { buildTarget: 'build' },
+          };
+          json.nx.targets['copy-workspace-modules'] = {
+            executor: '@nx/js:copy-workspace-modules',
+            options: { buildTarget: 'build' },
+          };
+          return json;
+        });
+        runCommand(`${packageManager} install`);
+
+        runCLI(`build ${nodeapp}`);
+        runCLI(`prune-lockfile ${nodeapp}`);
+        runCLI(`copy-workspace-modules ${nodeapp}`);
+
+        runCommand(installCmd[packageManager], {
+          cwd: tmpProjPath(`${nodeapp}/dist`),
+        });
       });
     }
   );
 
+  // Plain semver workspace refs (e.g. "*" or "0.0.1") are an npm/yarn-classic
+  // thing — pnpm requires the `workspace:` protocol — so this scenario stays
+  // npm-only. The executor must recognize the sibling and rewrite the dep
+  // to point at workspace_modules. Regression test for #33523.
   describe('package manager npm (plain semver workspace dependency)', () => {
     let scope: string;
 
@@ -78,11 +159,7 @@ describe('js:prune-lockfile executor', () => {
       cleanupProject();
     });
 
-    // npm workspaces reference sibling packages with plain semver (e.g. "*" or
-    // "0.0.1") rather than a `workspace:`/`file:`/`link:` protocol prefix. The
-    // executor must still recognize these as workspace modules and rewrite
-    // them to point at `workspace_modules`. Regression test for #33523.
-    it('should rewrite dependency to workspace_modules when version is plain semver', () => {
+    it('should rewrite dependency to workspace_modules and install cleanly', () => {
       const nodeapp = uniq('nodeapp');
       const nodelib = uniq('nodelib');
 
@@ -100,82 +177,6 @@ describe('js:prune-lockfile executor', () => {
         };
         json.nx.targets['prune-lockfile'] = {
           executor: '@nx/js:prune-lockfile',
-          options: {
-            buildTarget: 'build',
-          },
-        };
-        return json;
-      });
-      runCommand(`npm install`);
-
-      runCLI(`build ${nodeapp}`);
-      runCLI(`prune-lockfile ${nodeapp}`);
-
-      checkFilesExist(`${nodeapp}/dist/package-lock.json`);
-      const prunedPackageJson = JSON.parse(
-        readFile(`${nodeapp}/dist/package.json`)
-      );
-      expect(prunedPackageJson.dependencies[`@${scope}/${nodelib}`]).toBe(
-        `file:./workspace_modules/@${scope}/${nodelib}`
-      );
-    });
-  });
-
-  describe('package manager pnpm (transitive workspace dependency)', () => {
-    let scope: string;
-
-    beforeAll(() => {
-      scope = newProject({
-        packages: ['@nx/node', '@nx/js'],
-        preset: 'ts',
-        packageManager: 'pnpm',
-      });
-    });
-    afterAll(() => {
-      cleanupProject();
-    });
-
-    // When app -> lib-a -> lib-b, the pruned lockfile must include an importer
-    // block for lib-b (the transitive workspace dep), include lib-b's npm deps
-    // in the packages section, and rewrite lib-a's reference to lib-b from
-    // `workspace:*` to `file:../lib-b` so it matches what copy-workspace-modules
-    // writes to lib-a/package.json. Regression test for #34655.
-    it('should include transitive workspace deps in pruned lockfile', () => {
-      const nodeapp = uniq('nodeapp');
-      const liba = uniq('liba');
-      const libb = uniq('libb');
-
-      runCLI(
-        `generate @nx/node:app ${nodeapp} --linter=eslint --unitTestRunner=jest`
-      );
-      runCLI(
-        `generate @nx/js:lib ${liba} --bundler=tsc --linter=eslint --unitTestRunner=jest`
-      );
-      runCLI(
-        `generate @nx/js:lib ${libb} --bundler=tsc --linter=eslint --unitTestRunner=jest`
-      );
-
-      updateJson(`${liba}/package.json`, (json) => {
-        json.dependencies = {
-          ...json.dependencies,
-          [`@${scope}/${libb}`]: 'workspace:*',
-        };
-        return json;
-      });
-      updateJson(`${libb}/package.json`, (json) => {
-        json.dependencies = {
-          ...json.dependencies,
-          lodash: '^4.17.21',
-        };
-        return json;
-      });
-      updateJson(`${nodeapp}/package.json`, (json) => {
-        json.dependencies = {
-          ...json.dependencies,
-          [`@${scope}/${liba}`]: 'workspace:*',
-        };
-        json.nx.targets['prune-lockfile'] = {
-          executor: '@nx/js:prune-lockfile',
           options: { buildTarget: 'build' },
         };
         json.nx.targets['copy-workspace-modules'] = {
@@ -184,31 +185,21 @@ describe('js:prune-lockfile executor', () => {
         };
         return json;
       });
-      runCommand(`pnpm install`);
+      runCommand(`npm install`);
 
       runCLI(`build ${nodeapp}`);
       runCLI(`prune-lockfile ${nodeapp}`);
       runCLI(`copy-workspace-modules ${nodeapp}`);
 
-      const prunedLockfile = readFile(`${nodeapp}/dist/pnpm-lock.yaml`);
-
-      // Both workspace packages get importer blocks (the bug was that the
-      // transitive lib-b importer was missing).
-      expect(prunedLockfile).toContain(`workspace_modules/@${scope}/${liba}:`);
-      expect(prunedLockfile).toContain(`workspace_modules/@${scope}/${libb}:`);
-
-      // lib-a's reference to lib-b uses the flat workspace_modules layout.
-      // Without the rewrite the lockfile would still say `workspace:*`,
-      // mismatching what copy-workspace-modules writes to lib-a/package.json
-      // (`file:../lib-b`) and causing ERR_PNPM_OUTDATED_LOCKFILE.
-      expect(prunedLockfile).toMatch(
-        new RegExp(
-          `'@${scope}\\/${libb}':\\s+specifier: file:\\.\\.\\/${libb}\\s+version: link:\\.\\.\\/${libb}`
-        )
+      checkFilesExist(`${nodeapp}/dist/package-lock.json`);
+      const prunedPackageJson = JSON.parse(
+        readFile(`${nodeapp}/dist/package.json`)
+      );
+      expect(prunedPackageJson.dependencies[`@${scope}/${nodelib}`]).toBe(
+        `file:./workspace_modules/@${scope}/${nodelib}`
       );
 
-      // lib-b's transitive npm dep (lodash) made it into the packages section.
-      expect(prunedLockfile).toMatch(/lodash@4\.\d+\.\d+:/);
+      runCommand('npm ci', { cwd: tmpProjPath(`${nodeapp}/dist`) });
     });
   });
 });

--- a/e2e/js/src/js-executor-prune-lockfile.test.ts
+++ b/e2e/js/src/js-executor-prune-lockfile.test.ts
@@ -9,12 +9,32 @@ import {
   runCommand,
   tmpProjPath,
 } from '@nx/e2e-utils';
+import { cpSync, mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 
 const installCmd = {
   pnpm: 'pnpm install --frozen-lockfile',
   yarn: 'yarn install --frozen-lockfile',
   npm: 'npm ci',
 } as const;
+
+// Copy the pruned dist to a fresh tmp dir outside the e2e workspace and run
+// install there. This isolates the install from the surrounding workspace
+// (pnpm-workspace.yaml, parent node_modules) so the assertion is really
+// "the pruned dist is self-sufficient" — i.e. the actual deployment contract.
+function installPrunedDist(
+  packageManager: 'pnpm' | 'yarn' | 'npm',
+  distPath: string
+) {
+  const installDir = mkdtempSync(join(tmpdir(), 'prune-lockfile-install-'));
+  try {
+    cpSync(distPath, installDir, { recursive: true });
+    runCommand(installCmd[packageManager], { cwd: installDir });
+  } finally {
+    rmSync(installDir, { recursive: true, force: true });
+  }
+}
 
 describe('js:prune-lockfile executor', () => {
   describe.each([
@@ -70,9 +90,7 @@ describe('js:prune-lockfile executor', () => {
         runCLI(`copy-workspace-modules ${nodeapp}`);
 
         checkFilesExist(`${nodeapp}/dist/${lockfile}`);
-        runCommand(installCmd[packageManager], {
-          cwd: tmpProjPath(`${nodeapp}/dist`),
-        });
+        installPrunedDist(packageManager, tmpProjPath(`${nodeapp}/dist`));
       });
 
       // app -> lib-a -> lib-b with lib-b having an npm dep. The pruned lockfile
@@ -134,9 +152,7 @@ describe('js:prune-lockfile executor', () => {
         runCLI(`prune-lockfile ${nodeapp}`);
         runCLI(`copy-workspace-modules ${nodeapp}`);
 
-        runCommand(installCmd[packageManager], {
-          cwd: tmpProjPath(`${nodeapp}/dist`),
-        });
+        installPrunedDist(packageManager, tmpProjPath(`${nodeapp}/dist`));
       });
     }
   );
@@ -199,7 +215,7 @@ describe('js:prune-lockfile executor', () => {
         `file:./workspace_modules/@${scope}/${nodelib}`
       );
 
-      runCommand('npm ci', { cwd: tmpProjPath(`${nodeapp}/dist`) });
+      installPrunedDist('npm', tmpProjPath(`${nodeapp}/dist`));
     });
   });
 });

--- a/e2e/js/src/js-executor-prune-lockfile.test.ts
+++ b/e2e/js/src/js-executor-prune-lockfile.test.ts
@@ -164,7 +164,7 @@ describe('js:prune-lockfile executor', () => {
       // app -> lib-a <-> lib-b. The pruned lockfile must include both
       // workspace packages without infinite-looping during the transitive
       // walk. Without the visited guard in the BFS, this hangs.
-      it('should produce installable pruned output with a workspace dependency cycle', () => {
+      it('should produce installable pruned output with circular workspace dependencies', () => {
         const nodeapp = uniq('nodeapp');
         const liba = uniq('liba');
         const libb = uniq('libb');

--- a/e2e/js/src/js-executor-prune-lockfile.test.ts
+++ b/e2e/js/src/js-executor-prune-lockfile.test.ts
@@ -120,4 +120,99 @@ describe('js:prune-lockfile executor', () => {
       );
     });
   });
+
+  describe('package manager pnpm (transitive workspace dependency)', () => {
+    let scope: string;
+
+    beforeAll(() => {
+      scope = newProject({
+        packages: ['@nx/node', '@nx/js'],
+        preset: 'ts',
+        packageManager: 'pnpm',
+      });
+    });
+    afterAll(() => {
+      cleanupProject();
+    });
+
+    // When app -> lib-a -> lib-b, the pruned lockfile must include an importer
+    // block for lib-b (the transitive workspace dep), include lib-b's npm deps
+    // in the packages section, and rewrite lib-a's reference to lib-b from
+    // `workspace:*` to `file:../lib-b` so it matches what copy-workspace-modules
+    // writes to lib-a/package.json. Regression test for #34655.
+    it('should include transitive workspace deps in pruned lockfile', () => {
+      const nodeapp = uniq('nodeapp');
+      const liba = uniq('liba');
+      const libb = uniq('libb');
+
+      runCLI(
+        `generate @nx/node:app ${nodeapp} --linter=eslint --unitTestRunner=jest`
+      );
+      runCLI(
+        `generate @nx/js:lib ${liba} --bundler=tsc --linter=eslint --unitTestRunner=jest`
+      );
+      runCLI(
+        `generate @nx/js:lib ${libb} --bundler=tsc --linter=eslint --unitTestRunner=jest`
+      );
+
+      updateJson(`${liba}/package.json`, (json) => {
+        json.dependencies = {
+          ...json.dependencies,
+          [`@${scope}/${libb}`]: 'workspace:*',
+        };
+        return json;
+      });
+      updateJson(`${libb}/package.json`, (json) => {
+        json.dependencies = {
+          ...json.dependencies,
+          lodash: '^4.17.21',
+        };
+        return json;
+      });
+      updateJson(`${nodeapp}/package.json`, (json) => {
+        json.dependencies = {
+          ...json.dependencies,
+          [`@${scope}/${liba}`]: 'workspace:*',
+        };
+        json.nx.targets['prune-lockfile'] = {
+          executor: '@nx/js:prune-lockfile',
+          options: { buildTarget: 'build' },
+        };
+        json.nx.targets['copy-workspace-modules'] = {
+          executor: '@nx/js:copy-workspace-modules',
+          options: { buildTarget: 'build' },
+        };
+        return json;
+      });
+      runCommand(`pnpm install`);
+
+      runCLI(`build ${nodeapp}`);
+      runCLI(`prune-lockfile ${nodeapp}`);
+      runCLI(`copy-workspace-modules ${nodeapp}`);
+
+      const prunedLockfile = readFile(`${nodeapp}/dist/pnpm-lock.yaml`);
+
+      // Both workspace packages get importer blocks (the bug was that the
+      // transitive lib-b importer was missing).
+      expect(prunedLockfile).toContain(
+        `workspace_modules/@${scope}/${liba}:`
+      );
+      expect(prunedLockfile).toContain(
+        `workspace_modules/@${scope}/${libb}:`
+      );
+
+      // lib-a's reference to lib-b uses the flat workspace_modules layout.
+      // Without the rewrite the lockfile would still say `workspace:*`,
+      // mismatching what copy-workspace-modules writes to lib-a/package.json
+      // (`file:../lib-b`) and causing ERR_PNPM_OUTDATED_LOCKFILE.
+      expect(prunedLockfile).toMatch(
+        new RegExp(
+          `'@${scope}\\/${libb}':\\s+specifier: file:\\.\\.\\/${libb}\\s+version: link:\\.\\.\\/${libb}`
+        )
+      );
+
+      // lib-b's transitive npm dep (lodash) made it into the packages section.
+      expect(prunedLockfile).toMatch(/lodash@4\.\d+\.\d+:/);
+    });
+  });
 });

--- a/packages/nx/src/plugins/js/lock-file/npm-parser.spec.ts
+++ b/packages/nx/src/plugins/js/lock-file/npm-parser.spec.ts
@@ -1623,19 +1623,11 @@ describe('NPM lock file utility', () => {
         stringifyNpmLockfile(prunedGraph, JSON.stringify(lockFile), packageJson)
       );
 
-      // Both workspace packages (direct + transitive) get link + workspace
-      // entries. Without the BFS fix, only lib-a would appear and `npm ci`
-      // would fail with "Missing: @myorg/lib-b from lock file".
       expect(result.packages).toHaveProperty('node_modules/@myorg/lib-a');
       expect(result.packages).toHaveProperty('workspace_modules/@myorg/lib-a');
       expect(result.packages).toHaveProperty('node_modules/@myorg/lib-b');
       expect(result.packages).toHaveProperty('workspace_modules/@myorg/lib-b');
-
-      // Transitive npm dep (lodash) reaches the pruned packages section.
       expect(result.packages).toHaveProperty('node_modules/lodash');
-
-      // The workspace entry for lib-a still records the dependency on lib-b
-      // so npm can resolve the chain.
       expect(
         result.packages['workspace_modules/@myorg/lib-a'].dependencies
       ).toEqual({ '@myorg/lib-b': 'file:../lib-b' });

--- a/packages/nx/src/plugins/js/lock-file/npm-parser.spec.ts
+++ b/packages/nx/src/plugins/js/lock-file/npm-parser.spec.ts
@@ -1506,6 +1506,208 @@ describe('NPM lock file utility', () => {
       );
     });
   });
+
+  describe('transitive workspace dependencies', () => {
+    function makeGraph(
+      workspaceProjects: Array<{
+        projectName: string;
+        packageName: string;
+        root: string;
+      }>,
+      workspaceDeps: Record<string, string[]>,
+      externalNodes: ProjectGraph['externalNodes'],
+      externalDeps: Record<string, string[]> = {}
+    ): ProjectGraph {
+      const nodes: ProjectGraph['nodes'] = {};
+      const dependencies: ProjectGraph['dependencies'] = {};
+      for (const { projectName, packageName, root } of workspaceProjects) {
+        nodes[projectName] = {
+          name: projectName,
+          type: 'lib',
+          data: {
+            root,
+            metadata: { js: { packageName } },
+          },
+        } as any;
+        dependencies[projectName] = [
+          ...(workspaceDeps[projectName] ?? []).map((target) => ({
+            source: projectName,
+            target,
+            type: 'static' as any,
+          })),
+          ...(externalDeps[projectName] ?? []).map((target) => ({
+            source: projectName,
+            target,
+            type: 'static' as any,
+          })),
+        ];
+      }
+      return { nodes, dependencies, externalNodes };
+    }
+
+    it('should include node_modules and workspace_modules entries for transitive workspace deps', () => {
+      // app -> @myorg/lib-a -> @myorg/lib-b -> lodash
+      const lockFile = {
+        name: 'test-app',
+        version: '1.0.0',
+        lockfileVersion: 3,
+        packages: {
+          '': {
+            name: 'test-app',
+            version: '1.0.0',
+            dependencies: { '@myorg/lib-a': 'file:libs/lib-a' },
+          },
+          'libs/lib-a': {
+            name: '@myorg/lib-a',
+            version: '0.0.1',
+            dependencies: { '@myorg/lib-b': 'file:../lib-b' },
+          },
+          'node_modules/@myorg/lib-a': {
+            resolved: 'libs/lib-a',
+            link: true,
+          },
+          'libs/lib-b': {
+            name: '@myorg/lib-b',
+            version: '0.0.1',
+            dependencies: { lodash: '^4.17.21' },
+          },
+          'node_modules/@myorg/lib-b': {
+            resolved: 'libs/lib-b',
+            link: true,
+          },
+          'node_modules/lodash': {
+            version: '4.17.21',
+            resolved: 'https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz',
+            integrity:
+              'sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==',
+          },
+        },
+      };
+
+      const packageJson = {
+        name: 'test-app',
+        version: '1.0.0',
+        dependencies: { '@myorg/lib-a': 'file:libs/lib-a' },
+      };
+
+      const graph = makeGraph(
+        [
+          {
+            projectName: '@myorg/lib-a',
+            packageName: '@myorg/lib-a',
+            root: 'libs/lib-a',
+          },
+          {
+            projectName: '@myorg/lib-b',
+            packageName: '@myorg/lib-b',
+            root: 'libs/lib-b',
+          },
+        ],
+        { '@myorg/lib-a': ['@myorg/lib-b'] },
+        {
+          'npm:lodash': {
+            type: 'npm',
+            name: 'npm:lodash',
+            data: {
+              version: '4.17.21',
+              packageName: 'lodash',
+              hash: 'sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==',
+            },
+          },
+        },
+        { '@myorg/lib-b': ['npm:lodash'] }
+      );
+
+      const prunedGraph = pruneProjectGraph(graph, packageJson);
+      const result = JSON.parse(
+        stringifyNpmLockfile(prunedGraph, JSON.stringify(lockFile), packageJson)
+      );
+
+      // Both workspace packages (direct + transitive) get link + workspace
+      // entries. Without the BFS fix, only lib-a would appear and `npm ci`
+      // would fail with "Missing: @myorg/lib-b from lock file".
+      expect(result.packages).toHaveProperty('node_modules/@myorg/lib-a');
+      expect(result.packages).toHaveProperty('workspace_modules/@myorg/lib-a');
+      expect(result.packages).toHaveProperty('node_modules/@myorg/lib-b');
+      expect(result.packages).toHaveProperty('workspace_modules/@myorg/lib-b');
+
+      // Transitive npm dep (lodash) reaches the pruned packages section.
+      expect(result.packages).toHaveProperty('node_modules/lodash');
+
+      // The workspace entry for lib-a still records the dependency on lib-b
+      // so npm can resolve the chain.
+      expect(
+        result.packages['workspace_modules/@myorg/lib-a'].dependencies
+      ).toEqual({ '@myorg/lib-b': 'file:../lib-b' });
+    });
+
+    it('should not infinite-loop on workspace dependency cycles', () => {
+      const lockFile = {
+        name: 'test-app',
+        version: '1.0.0',
+        lockfileVersion: 3,
+        packages: {
+          '': {
+            name: 'test-app',
+            version: '1.0.0',
+            dependencies: { '@myorg/lib-a': 'file:libs/lib-a' },
+          },
+          'libs/lib-a': {
+            name: '@myorg/lib-a',
+            version: '0.0.1',
+            dependencies: { '@myorg/lib-b': 'file:../lib-b' },
+          },
+          'node_modules/@myorg/lib-a': {
+            resolved: 'libs/lib-a',
+            link: true,
+          },
+          'libs/lib-b': {
+            name: '@myorg/lib-b',
+            version: '0.0.1',
+            dependencies: { '@myorg/lib-a': 'file:../lib-a' },
+          },
+          'node_modules/@myorg/lib-b': {
+            resolved: 'libs/lib-b',
+            link: true,
+          },
+        },
+      };
+
+      const packageJson = {
+        name: 'test-app',
+        version: '1.0.0',
+        dependencies: { '@myorg/lib-a': 'file:libs/lib-a' },
+      };
+
+      const graph = makeGraph(
+        [
+          {
+            projectName: '@myorg/lib-a',
+            packageName: '@myorg/lib-a',
+            root: 'libs/lib-a',
+          },
+          {
+            projectName: '@myorg/lib-b',
+            packageName: '@myorg/lib-b',
+            root: 'libs/lib-b',
+          },
+        ],
+        {
+          '@myorg/lib-a': ['@myorg/lib-b'],
+          '@myorg/lib-b': ['@myorg/lib-a'],
+        },
+        {}
+      );
+
+      const prunedGraph = pruneProjectGraph(graph, packageJson);
+      const result = JSON.parse(
+        stringifyNpmLockfile(prunedGraph, JSON.stringify(lockFile), packageJson)
+      );
+
+      expect(result.packages).toHaveProperty('workspace_modules/@myorg/lib-a');
+      expect(result.packages).toHaveProperty('workspace_modules/@myorg/lib-b');
+    });
+  });
 });
 
 function uniq(str: string) {

--- a/packages/nx/src/plugins/js/lock-file/npm-parser.spec.ts
+++ b/packages/nx/src/plugins/js/lock-file/npm-parser.spec.ts
@@ -1641,7 +1641,7 @@ describe('NPM lock file utility', () => {
       ).toEqual({ '@myorg/lib-b': 'file:../lib-b' });
     });
 
-    it('should not infinite-loop on workspace dependency cycles', () => {
+    it('should not infinite-loop on circular workspace dependencies', () => {
       const lockFile = {
         name: 'test-app',
         version: '1.0.0',

--- a/packages/nx/src/plugins/js/lock-file/npm-parser.ts
+++ b/packages/nx/src/plugins/js/lock-file/npm-parser.ts
@@ -485,10 +485,14 @@ function mapWorkspaceModules(
       dependencies: workspaceModuleDefinition?.dependencies,
     };
 
-    if (workspaceModuleDefinition?.dependencies) {
-      for (const depName of Object.keys(
-        workspaceModuleDefinition.dependencies
-      )) {
+    for (const depType of [
+      'dependencies',
+      'optionalDependencies',
+      'peerDependencies',
+    ] as const) {
+      const deps = workspaceModuleDefinition?.[depType];
+      if (!deps) continue;
+      for (const depName of Object.keys(deps)) {
         queue.push(depName);
       }
     }

--- a/packages/nx/src/plugins/js/lock-file/npm-parser.ts
+++ b/packages/nx/src/plugins/js/lock-file/npm-parser.ts
@@ -444,35 +444,36 @@ export function stringifyNpmLockfile(
   return JSON.stringify(output, null, 2);
 }
 
+const WORKSPACE_DEP_TYPES = [
+  'dependencies',
+  'optionalDependencies',
+  'peerDependencies',
+] as const;
+
 function mapWorkspaceModules(
   packageJson: NormalizedPackageJson,
   rootLockFile: NpmLockFile,
   workspaceModules: Map<string, ProjectGraphProjectNode>
 ) {
   const output: Record<string, NpmDependencyV3 & NpmDependencyV1> = {};
+  const snapshotsByName = new Map<string, NpmDependencyV3 & NpmDependencyV1>();
+  for (const snapshot of Object.values(
+    rootLockFile.packages || rootLockFile.dependencies || {}
+  )) {
+    if (snapshot.name) snapshotsByName.set(snapshot.name, snapshot);
+  }
 
-  // BFS through workspace deps so transitive workspace packages also get
-  // included. Without this, app -> liba -> libb would only emit liba and
-  // `npm ci` would fail with "Missing: <libb> from lock file".
+  // Walk transitive workspace deps so every workspace package
+  // copy-workspace-modules writes to disk has matching lockfile entries.
+  // Without this, `npm ci` errors with "Missing: <pkg> from lock file".
   const queue: string[] = Object.keys(packageJson.dependencies ?? {});
   const visited = new Set<string>();
-
   while (queue.length > 0) {
     const pkgName = queue.shift()!;
-    if (visited.has(pkgName) || !workspaceModules.has(pkgName)) {
-      continue;
-    }
+    if (visited.has(pkgName) || !workspaceModules.has(pkgName)) continue;
     visited.add(pkgName);
 
-    let workspaceModuleDefinition: NpmDependencyV3 & NpmDependencyV1;
-    for (const [, depSnapshot] of Object.entries(
-      rootLockFile.packages || rootLockFile.dependencies
-    )) {
-      if (depSnapshot.name === pkgName) {
-        workspaceModuleDefinition = depSnapshot;
-        break;
-      }
-    }
+    const snapshot = snapshotsByName.get(pkgName);
 
     output[`node_modules/${pkgName}`] = {
       version: `file:./workspace_modules/${pkgName}`,
@@ -482,19 +483,13 @@ function mapWorkspaceModules(
     output[`workspace_modules/${pkgName}`] = {
       name: pkgName,
       version: `0.0.1`,
-      dependencies: workspaceModuleDefinition?.dependencies,
+      dependencies: snapshot?.dependencies,
     };
 
-    for (const depType of [
-      'dependencies',
-      'optionalDependencies',
-      'peerDependencies',
-    ] as const) {
-      const deps = workspaceModuleDefinition?.[depType];
+    for (const depType of WORKSPACE_DEP_TYPES) {
+      const deps = snapshot?.[depType];
       if (!deps) continue;
-      for (const depName of Object.keys(deps)) {
-        queue.push(depName);
-      }
+      for (const depName of Object.keys(deps)) queue.push(depName);
     }
   }
   return output;

--- a/packages/nx/src/plugins/js/lock-file/npm-parser.ts
+++ b/packages/nx/src/plugins/js/lock-file/npm-parser.ts
@@ -450,30 +450,47 @@ function mapWorkspaceModules(
   workspaceModules: Map<string, ProjectGraphProjectNode>
 ) {
   const output: Record<string, NpmDependencyV3 & NpmDependencyV1> = {};
-  for (const [pkgName, pkgVersion] of Object.entries(
-    packageJson.dependencies ?? {}
-  )) {
-    if (workspaceModules.has(pkgName)) {
-      let workspaceModuleDefinition: NpmDependencyV3 & NpmDependencyV1;
-      for (const [depName, depSnapshot] of Object.entries(
-        rootLockFile.packages || rootLockFile.dependencies
-      )) {
-        if (depSnapshot.name === pkgName) {
-          workspaceModuleDefinition = depSnapshot;
-          break;
-        }
-      }
 
-      output[`node_modules/${pkgName}`] = {
-        version: `file:./workspace_modules/${pkgName}`,
-        resolved: `workspace_modules/${pkgName}`,
-        link: true,
-      };
-      output[`workspace_modules/${pkgName}`] = {
-        name: pkgName,
-        version: `0.0.1`,
-        dependencies: workspaceModuleDefinition.dependencies,
-      };
+  // BFS through workspace deps so transitive workspace packages also get
+  // included. Without this, app -> liba -> libb would only emit liba and
+  // `npm ci` would fail with "Missing: <libb> from lock file".
+  const queue: string[] = Object.keys(packageJson.dependencies ?? {});
+  const visited = new Set<string>();
+
+  while (queue.length > 0) {
+    const pkgName = queue.shift()!;
+    if (visited.has(pkgName) || !workspaceModules.has(pkgName)) {
+      continue;
+    }
+    visited.add(pkgName);
+
+    let workspaceModuleDefinition: NpmDependencyV3 & NpmDependencyV1;
+    for (const [, depSnapshot] of Object.entries(
+      rootLockFile.packages || rootLockFile.dependencies
+    )) {
+      if (depSnapshot.name === pkgName) {
+        workspaceModuleDefinition = depSnapshot;
+        break;
+      }
+    }
+
+    output[`node_modules/${pkgName}`] = {
+      version: `file:./workspace_modules/${pkgName}`,
+      resolved: `workspace_modules/${pkgName}`,
+      link: true,
+    };
+    output[`workspace_modules/${pkgName}`] = {
+      name: pkgName,
+      version: `0.0.1`,
+      dependencies: workspaceModuleDefinition?.dependencies,
+    };
+
+    if (workspaceModuleDefinition?.dependencies) {
+      for (const depName of Object.keys(
+        workspaceModuleDefinition.dependencies
+      )) {
+        queue.push(depName);
+      }
     }
   }
   return output;

--- a/packages/nx/src/plugins/js/lock-file/pnpm-parser.spec.ts
+++ b/packages/nx/src/plugins/js/lock-file/pnpm-parser.spec.ts
@@ -2668,22 +2668,16 @@ snapshots:
         '/virtual'
       );
 
-      // Both workspace packages (direct + transitive) get importer blocks.
       expect(result).toContain(`workspace_modules/@myorg/lib-a:`);
       expect(result).toContain(`workspace_modules/@myorg/lib-b:`);
-
-      // lib-a's importer references lib-b via the flat workspace_modules layout.
-      // The specifier must be `file:../lib-b` (matching what copy-workspace-modules
-      // writes to lib-a/package.json) — `workspace:*` would produce
-      // ERR_PNPM_OUTDATED_LOCKFILE on `pnpm install --frozen-lockfile`.
+      // Specifier must be `file:` to match what copy-workspace-modules writes
+      // to package.json — `workspace:*` would produce ERR_PNPM_OUTDATED_LOCKFILE.
       expect(result).toMatch(
         /'@myorg\/lib-a':\s+specifier: file:\.\/workspace_modules\/@myorg\/lib-a/
       );
       expect(result).toMatch(
         /'@myorg\/lib-b':\s+specifier: file:\.\.\/lib-b\s+version: link:\.\.\/lib-b/
       );
-
-      // lib-b's transitive npm dep (lodash) made it into the packages section.
       expect(result).toContain(`lodash@4.17.21:`);
     });
 

--- a/packages/nx/src/plugins/js/lock-file/pnpm-parser.spec.ts
+++ b/packages/nx/src/plugins/js/lock-file/pnpm-parser.spec.ts
@@ -2687,7 +2687,7 @@ snapshots:
       expect(result).toContain(`lodash@4.17.21:`);
     });
 
-    it('should not infinite-loop on workspace dependency cycles', () => {
+    it('should not infinite-loop on circular workspace dependencies', () => {
       const lockFile = `lockfileVersion: '9.0'
 
 importers:

--- a/packages/nx/src/plugins/js/lock-file/pnpm-parser.spec.ts
+++ b/packages/nx/src/plugins/js/lock-file/pnpm-parser.spec.ts
@@ -2543,4 +2543,250 @@ snapshots:
       `);
     });
   });
+
+  describe('transitive workspace dependencies', () => {
+    beforeEach(() => {
+      vol.fromJSON(
+        { 'node_modules/.modules.yaml': `hoistedDependencies: {}` },
+        '/root'
+      );
+    });
+
+    function makeGraph(
+      workspaceProjects: Array<{
+        projectName: string;
+        packageName: string;
+        root: string;
+      }>,
+      workspaceDeps: Record<string, string[]>,
+      externalNodes: Record<string, ProjectGraphExternalNode>,
+      externalDeps: Record<string, string[]> = {}
+    ): ProjectGraph {
+      const nodes: ProjectGraph['nodes'] = {};
+      const dependencies: ProjectGraph['dependencies'] = {};
+      for (const { projectName, packageName, root } of workspaceProjects) {
+        nodes[projectName] = {
+          name: projectName,
+          type: 'lib',
+          data: {
+            root,
+            metadata: { js: { packageName } },
+          },
+        } as any;
+        dependencies[projectName] = [
+          ...(workspaceDeps[projectName] ?? []).map((target) => ({
+            source: projectName,
+            target,
+            type: 'static' as any,
+          })),
+          ...(externalDeps[projectName] ?? []).map((target) => ({
+            source: projectName,
+            target,
+            type: 'static' as any,
+          })),
+        ];
+      }
+      return { nodes, dependencies, externalNodes };
+    }
+
+    it('should include importer blocks and npm packages for transitive workspace deps', () => {
+      // app -> @myorg/lib-a (workspace:*) -> @myorg/lib-b (workspace:*) -> lodash
+      const lockFile = `lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    dependencies:
+      '@myorg/lib-a':
+        specifier: workspace:*
+        version: link:libs/lib-a
+
+  libs/lib-a:
+    dependencies:
+      '@myorg/lib-b':
+        specifier: workspace:*
+        version: link:../lib-b
+
+  libs/lib-b:
+    dependencies:
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
+
+packages:
+
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+
+snapshots:
+
+  lodash@4.17.21: {}`;
+
+      const packageJson = {
+        name: 'test-app',
+        version: '1.0.0',
+        dependencies: { '@myorg/lib-a': 'workspace:*' },
+      };
+
+      const graph = makeGraph(
+        [
+          { projectName: '@myorg/lib-a', packageName: '@myorg/lib-a', root: 'libs/lib-a' },
+          { projectName: '@myorg/lib-b', packageName: '@myorg/lib-b', root: 'libs/lib-b' },
+        ],
+        {
+          '@myorg/lib-a': ['@myorg/lib-b'],
+        },
+        {
+          'npm:lodash': {
+            type: 'npm',
+            name: 'npm:lodash',
+            data: {
+              version: '4.17.21',
+              packageName: 'lodash',
+              hash: 'sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==',
+            },
+          },
+        },
+        {
+          '@myorg/lib-b': ['npm:lodash'],
+        }
+      );
+
+      const prunedGraph = pruneProjectGraph(graph, packageJson);
+      const result = stringifyPnpmLockfile(prunedGraph, lockFile, packageJson, '/virtual');
+
+      // Both workspace packages (direct + transitive) get importer blocks.
+      expect(result).toContain(`workspace_modules/@myorg/lib-a:`);
+      expect(result).toContain(`workspace_modules/@myorg/lib-b:`);
+
+      // lib-a's importer references lib-b via the flat workspace_modules layout.
+      // The specifier must be `file:../lib-b` (matching what copy-workspace-modules
+      // writes to lib-a/package.json) — `workspace:*` would produce
+      // ERR_PNPM_OUTDATED_LOCKFILE on `pnpm install --frozen-lockfile`.
+      expect(result).toMatch(/'@myorg\/lib-a':\s+specifier: file:\.\/workspace_modules\/@myorg\/lib-a/);
+      expect(result).toMatch(/'@myorg\/lib-b':\s+specifier: file:\.\.\/lib-b\s+version: link:\.\.\/lib-b/);
+
+      // lib-b's transitive npm dep (lodash) made it into the packages section.
+      expect(result).toContain(`lodash@4.17.21:`);
+    });
+
+    it('should not infinite-loop on workspace dependency cycles', () => {
+      const lockFile = `lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    dependencies:
+      '@myorg/lib-a':
+        specifier: workspace:*
+        version: link:libs/lib-a
+
+  libs/lib-a:
+    dependencies:
+      '@myorg/lib-b':
+        specifier: workspace:*
+        version: link:../lib-b
+
+  libs/lib-b:
+    dependencies:
+      '@myorg/lib-a':
+        specifier: workspace:*
+        version: link:../lib-a
+
+packages: {}
+
+snapshots: {}`;
+
+      const packageJson = {
+        name: 'test-app',
+        version: '1.0.0',
+        dependencies: { '@myorg/lib-a': 'workspace:*' },
+      };
+
+      const graph = makeGraph(
+        [
+          { projectName: '@myorg/lib-a', packageName: '@myorg/lib-a', root: 'libs/lib-a' },
+          { projectName: '@myorg/lib-b', packageName: '@myorg/lib-b', root: 'libs/lib-b' },
+        ],
+        {
+          '@myorg/lib-a': ['@myorg/lib-b'],
+          '@myorg/lib-b': ['@myorg/lib-a'],
+        },
+        {}
+      );
+
+      const prunedGraph = pruneProjectGraph(graph, packageJson);
+      const result = stringifyPnpmLockfile(prunedGraph, lockFile, packageJson, '/virtual');
+
+      expect(result).toContain(`workspace_modules/@myorg/lib-a:`);
+      expect(result).toContain(`workspace_modules/@myorg/lib-b:`);
+    });
+
+    it('should produce a single importer for diamond workspace dependency shapes', () => {
+      // app -> lib-a -> shared
+      // app -> lib-b -> shared
+      const lockFile = `lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    dependencies:
+      '@myorg/lib-a':
+        specifier: workspace:*
+        version: link:libs/lib-a
+      '@myorg/lib-b':
+        specifier: workspace:*
+        version: link:libs/lib-b
+
+  libs/lib-a:
+    dependencies:
+      '@myorg/shared':
+        specifier: workspace:*
+        version: link:../shared
+
+  libs/lib-b:
+    dependencies:
+      '@myorg/shared':
+        specifier: workspace:*
+        version: link:../shared
+
+  libs/shared:
+    dependencies: {}
+
+packages: {}
+
+snapshots: {}`;
+
+      const packageJson = {
+        name: 'test-app',
+        version: '1.0.0',
+        dependencies: {
+          '@myorg/lib-a': 'workspace:*',
+          '@myorg/lib-b': 'workspace:*',
+        },
+      };
+
+      const graph = makeGraph(
+        [
+          { projectName: '@myorg/lib-a', packageName: '@myorg/lib-a', root: 'libs/lib-a' },
+          { projectName: '@myorg/lib-b', packageName: '@myorg/lib-b', root: 'libs/lib-b' },
+          { projectName: '@myorg/shared', packageName: '@myorg/shared', root: 'libs/shared' },
+        ],
+        {
+          '@myorg/lib-a': ['@myorg/shared'],
+          '@myorg/lib-b': ['@myorg/shared'],
+        },
+        {}
+      );
+
+      const prunedGraph = pruneProjectGraph(graph, packageJson);
+      const result = stringifyPnpmLockfile(prunedGraph, lockFile, packageJson, '/virtual');
+
+      // Exactly one importer block for shared.
+      const sharedImporters = result.match(/workspace_modules\/@myorg\/shared:/g) ?? [];
+      expect(sharedImporters).toHaveLength(1);
+      // Both consumers point at it via the flat layout.
+      expect(result).toMatch(/'@myorg\/shared':\s+specifier: file:\.\.\/shared\s+version: link:\.\.\/shared/);
+    });
+  });
 });

--- a/packages/nx/src/plugins/js/lock-file/pnpm-parser.spec.ts
+++ b/packages/nx/src/plugins/js/lock-file/pnpm-parser.spec.ts
@@ -2630,8 +2630,16 @@ snapshots:
 
       const graph = makeGraph(
         [
-          { projectName: '@myorg/lib-a', packageName: '@myorg/lib-a', root: 'libs/lib-a' },
-          { projectName: '@myorg/lib-b', packageName: '@myorg/lib-b', root: 'libs/lib-b' },
+          {
+            projectName: '@myorg/lib-a',
+            packageName: '@myorg/lib-a',
+            root: 'libs/lib-a',
+          },
+          {
+            projectName: '@myorg/lib-b',
+            packageName: '@myorg/lib-b',
+            root: 'libs/lib-b',
+          },
         ],
         {
           '@myorg/lib-a': ['@myorg/lib-b'],
@@ -2653,7 +2661,12 @@ snapshots:
       );
 
       const prunedGraph = pruneProjectGraph(graph, packageJson);
-      const result = stringifyPnpmLockfile(prunedGraph, lockFile, packageJson, '/virtual');
+      const result = stringifyPnpmLockfile(
+        prunedGraph,
+        lockFile,
+        packageJson,
+        '/virtual'
+      );
 
       // Both workspace packages (direct + transitive) get importer blocks.
       expect(result).toContain(`workspace_modules/@myorg/lib-a:`);
@@ -2663,8 +2676,12 @@ snapshots:
       // The specifier must be `file:../lib-b` (matching what copy-workspace-modules
       // writes to lib-a/package.json) — `workspace:*` would produce
       // ERR_PNPM_OUTDATED_LOCKFILE on `pnpm install --frozen-lockfile`.
-      expect(result).toMatch(/'@myorg\/lib-a':\s+specifier: file:\.\/workspace_modules\/@myorg\/lib-a/);
-      expect(result).toMatch(/'@myorg\/lib-b':\s+specifier: file:\.\.\/lib-b\s+version: link:\.\.\/lib-b/);
+      expect(result).toMatch(
+        /'@myorg\/lib-a':\s+specifier: file:\.\/workspace_modules\/@myorg\/lib-a/
+      );
+      expect(result).toMatch(
+        /'@myorg\/lib-b':\s+specifier: file:\.\.\/lib-b\s+version: link:\.\.\/lib-b/
+      );
 
       // lib-b's transitive npm dep (lodash) made it into the packages section.
       expect(result).toContain(`lodash@4.17.21:`);
@@ -2705,8 +2722,16 @@ snapshots: {}`;
 
       const graph = makeGraph(
         [
-          { projectName: '@myorg/lib-a', packageName: '@myorg/lib-a', root: 'libs/lib-a' },
-          { projectName: '@myorg/lib-b', packageName: '@myorg/lib-b', root: 'libs/lib-b' },
+          {
+            projectName: '@myorg/lib-a',
+            packageName: '@myorg/lib-a',
+            root: 'libs/lib-a',
+          },
+          {
+            projectName: '@myorg/lib-b',
+            packageName: '@myorg/lib-b',
+            root: 'libs/lib-b',
+          },
         ],
         {
           '@myorg/lib-a': ['@myorg/lib-b'],
@@ -2716,7 +2741,12 @@ snapshots: {}`;
       );
 
       const prunedGraph = pruneProjectGraph(graph, packageJson);
-      const result = stringifyPnpmLockfile(prunedGraph, lockFile, packageJson, '/virtual');
+      const result = stringifyPnpmLockfile(
+        prunedGraph,
+        lockFile,
+        packageJson,
+        '/virtual'
+      );
 
       expect(result).toContain(`workspace_modules/@myorg/lib-a:`);
       expect(result).toContain(`workspace_modules/@myorg/lib-b:`);
@@ -2768,9 +2798,21 @@ snapshots: {}`;
 
       const graph = makeGraph(
         [
-          { projectName: '@myorg/lib-a', packageName: '@myorg/lib-a', root: 'libs/lib-a' },
-          { projectName: '@myorg/lib-b', packageName: '@myorg/lib-b', root: 'libs/lib-b' },
-          { projectName: '@myorg/shared', packageName: '@myorg/shared', root: 'libs/shared' },
+          {
+            projectName: '@myorg/lib-a',
+            packageName: '@myorg/lib-a',
+            root: 'libs/lib-a',
+          },
+          {
+            projectName: '@myorg/lib-b',
+            packageName: '@myorg/lib-b',
+            root: 'libs/lib-b',
+          },
+          {
+            projectName: '@myorg/shared',
+            packageName: '@myorg/shared',
+            root: 'libs/shared',
+          },
         ],
         {
           '@myorg/lib-a': ['@myorg/shared'],
@@ -2780,13 +2822,21 @@ snapshots: {}`;
       );
 
       const prunedGraph = pruneProjectGraph(graph, packageJson);
-      const result = stringifyPnpmLockfile(prunedGraph, lockFile, packageJson, '/virtual');
+      const result = stringifyPnpmLockfile(
+        prunedGraph,
+        lockFile,
+        packageJson,
+        '/virtual'
+      );
 
       // Exactly one importer block for shared.
-      const sharedImporters = result.match(/workspace_modules\/@myorg\/shared:/g) ?? [];
+      const sharedImporters =
+        result.match(/workspace_modules\/@myorg\/shared:/g) ?? [];
       expect(sharedImporters).toHaveLength(1);
       // Both consumers point at it via the flat layout.
-      expect(result).toMatch(/'@myorg\/shared':\s+specifier: file:\.\.\/shared\s+version: link:\.\.\/shared/);
+      expect(result).toMatch(
+        /'@myorg\/shared':\s+specifier: file:\.\.\/shared\s+version: link:\.\.\/shared/
+      );
     });
   });
 });

--- a/packages/nx/src/plugins/js/lock-file/pnpm-parser.ts
+++ b/packages/nx/src/plugins/js/lock-file/pnpm-parser.ts
@@ -626,7 +626,7 @@ export function stringifyPnpmLockfile(
   )) {
     const baseImporter = importers[importerPath];
     if (!baseImporter) continue;
-    const importer: ProjectSnapshot = JSON.parse(JSON.stringify(baseImporter));
+    const importer: ProjectSnapshot = structuredClone(baseImporter);
 
     for (const depType of WORKSPACE_DEP_TYPES) {
       const deps = importer[depType] as Record<string, string> | undefined;

--- a/packages/nx/src/plugins/js/lock-file/pnpm-parser.ts
+++ b/packages/nx/src/plugins/js/lock-file/pnpm-parser.ts
@@ -28,7 +28,7 @@ import { hashArray } from '../../../hasher/file-hasher';
 import { CreateDependenciesContext } from '../../../project-graph/plugins';
 import { getCatalogManager } from '../../../utils/catalog';
 import { findNodeMatchingVersion } from './project-graph-pruning';
-import { join } from 'path';
+import { join, relative, sep } from 'path';
 import { getWorkspacePackagesFromGraph } from '../utils/get-workspace-packages-from-graph';
 import { satisfies, validRange } from 'semver';
 let currentLockFileHash: string;
@@ -589,13 +589,68 @@ export function stringifyPnpmLockfile(
     +lockfileVersion
   );
 
-  const workspaceDependencyImporters: Record<string, ProjectSnapshot> = {};
-  for (const [packageName, importerPath] of Object.entries(requiredImporters)) {
-    const baseImporter = importers[importerPath];
-    if (baseImporter) {
-      workspaceDependencyImporters[`workspace_modules/${packageName}`] =
-        baseImporter;
+  const workspaceModules = getWorkspacePackagesFromGraph(graph);
+
+  // BFS over transitive workspace dependencies so that every package
+  // copy-workspace-modules writes to disk has a corresponding importer block.
+  // mapRootSnapshot only collects direct workspace deps of the root package;
+  // without this pass, an `app -> lib-a -> lib-b` chain produces a lockfile
+  // missing lib-b's importer, and pnpm fails with ERR_PNPM_OUTDATED_LOCKFILE.
+  const allRequiredImporters: Record<string, string> = { ...requiredImporters };
+  const queue = Object.keys(requiredImporters);
+  while (queue.length > 0) {
+    const pkgName = queue.shift()!;
+    const importerPath = allRequiredImporters[pkgName];
+    const importer = importers[importerPath];
+    if (!importer) continue;
+    for (const depType of ['dependencies', 'optionalDependencies'] as const) {
+      const deps = importer[depType];
+      if (!deps) continue;
+      for (const depName of Object.keys(deps)) {
+        if (workspaceModules.has(depName) && !allRequiredImporters[depName]) {
+          const wsMod = workspaceModules.get(depName);
+          if (wsMod) {
+            allRequiredImporters[depName] = wsMod.data.root;
+            queue.push(depName);
+          }
+        }
+      }
     }
+  }
+
+  const workspaceDependencyImporters: Record<string, ProjectSnapshot> = {};
+  for (const [packageName, importerPath] of Object.entries(
+    allRequiredImporters
+  )) {
+    const baseImporter = importers[importerPath];
+    if (!baseImporter) continue;
+    // Deep-clone so we don't mutate the parsed lockfile data.
+    const importer: ProjectSnapshot = JSON.parse(JSON.stringify(baseImporter));
+
+    // Rewrite workspace-package references to the flat `workspace_modules/`
+    // layout that copy-workspace-modules produces. The original lockfile's
+    // `link:` paths are relative to the package's source location in the
+    // monorepo, so they must be recomputed.
+    for (const depType of ['dependencies', 'optionalDependencies'] as const) {
+      const deps = importer[depType] as Record<string, string> | undefined;
+      if (!deps) continue;
+      for (const depName of Object.keys(deps)) {
+        if (workspaceModules.has(depName)) {
+          // All workspace modules are siblings under workspace_modules/, so
+          // the relative path between them is just relative(packageName, depName).
+          const rel = relative(packageName, depName).split(sep).join('/');
+          // Specifier must match the file: ref that copy-workspace-modules
+          // writes to the package's package.json on disk; otherwise pnpm sees
+          // a mismatch and reports ERR_PNPM_OUTDATED_LOCKFILE.
+          if (importer.specifiers) {
+            importer.specifiers[depName] = `file:${rel}`;
+          }
+          deps[depName] = `link:${rel}`;
+        }
+      }
+    }
+
+    workspaceDependencyImporters[`workspace_modules/${packageName}`] = importer;
   }
 
   const output: Lockfile = {

--- a/packages/nx/src/plugins/js/lock-file/pnpm-parser.ts
+++ b/packages/nx/src/plugins/js/lock-file/pnpm-parser.ts
@@ -31,6 +31,13 @@ import { findNodeMatchingVersion } from './project-graph-pruning';
 import { join, relative, sep } from 'path';
 import { getWorkspacePackagesFromGraph } from '../utils/get-workspace-packages-from-graph';
 import { satisfies, validRange } from 'semver';
+
+const WORKSPACE_DEP_TYPES = [
+  'dependencies',
+  'optionalDependencies',
+  'peerDependencies',
+] as const;
+
 let currentLockFileHash: string;
 
 let parsedLockFile: Lockfile;
@@ -591,32 +598,23 @@ export function stringifyPnpmLockfile(
 
   const workspaceModules = getWorkspacePackagesFromGraph(graph);
 
-  // BFS over transitive workspace dependencies so that every package
-  // copy-workspace-modules writes to disk has a corresponding importer block.
-  // mapRootSnapshot only collects direct workspace deps of the root package;
-  // without this pass, an `app -> lib-a -> lib-b` chain produces a lockfile
-  // missing lib-b's importer, and pnpm fails with ERR_PNPM_OUTDATED_LOCKFILE.
+  // Walk transitive workspace deps so every package copy-workspace-modules
+  // writes to disk has a matching importer block. Without this, pnpm errors
+  // with ERR_PNPM_OUTDATED_LOCKFILE on transitive workspace chains.
   const allRequiredImporters: Record<string, string> = { ...requiredImporters };
   const queue = Object.keys(requiredImporters);
   while (queue.length > 0) {
     const pkgName = queue.shift()!;
-    const importerPath = allRequiredImporters[pkgName];
-    const importer = importers[importerPath];
+    const importer = importers[allRequiredImporters[pkgName]];
     if (!importer) continue;
-    for (const depType of [
-      'dependencies',
-      'optionalDependencies',
-      'peerDependencies',
-    ] as const) {
+    for (const depType of WORKSPACE_DEP_TYPES) {
       const deps = importer[depType];
       if (!deps) continue;
       for (const depName of Object.keys(deps)) {
         if (workspaceModules.has(depName) && !allRequiredImporters[depName]) {
-          const wsMod = workspaceModules.get(depName);
-          if (wsMod) {
-            allRequiredImporters[depName] = wsMod.data.root;
-            queue.push(depName);
-          }
+          allRequiredImporters[depName] =
+            workspaceModules.get(depName)!.data.root;
+          queue.push(depName);
         }
       }
     }
@@ -628,33 +626,21 @@ export function stringifyPnpmLockfile(
   )) {
     const baseImporter = importers[importerPath];
     if (!baseImporter) continue;
-    // Deep-clone so we don't mutate the parsed lockfile data.
     const importer: ProjectSnapshot = JSON.parse(JSON.stringify(baseImporter));
 
-    // Rewrite workspace-package references to the flat `workspace_modules/`
-    // layout that copy-workspace-modules produces. The original lockfile's
-    // `link:` paths are relative to the package's source location in the
-    // monorepo, so they must be recomputed.
-    for (const depType of [
-      'dependencies',
-      'optionalDependencies',
-      'peerDependencies',
-    ] as const) {
+    for (const depType of WORKSPACE_DEP_TYPES) {
       const deps = importer[depType] as Record<string, string> | undefined;
       if (!deps) continue;
       for (const depName of Object.keys(deps)) {
-        if (workspaceModules.has(depName)) {
-          // All workspace modules are siblings under workspace_modules/, so
-          // the relative path between them is just relative(packageName, depName).
-          const rel = relative(packageName, depName).split(sep).join('/');
-          // Specifier must match the file: ref that copy-workspace-modules
-          // writes to the package's package.json on disk; otherwise pnpm sees
-          // a mismatch and reports ERR_PNPM_OUTDATED_LOCKFILE. Lockfile v6+
-          // may omit `specifiers`, so initialize when missing.
-          if (!importer.specifiers) importer.specifiers = {};
-          importer.specifiers[depName] = `file:${rel}`;
-          deps[depName] = `link:${rel}`;
-        }
+        if (!workspaceModules.has(depName)) continue;
+        // All workspace modules are siblings under workspace_modules/, so the
+        // relative path between them is relative(packageName, depName).
+        // Specifier must match the file: ref copy-workspace-modules writes
+        // to the package's package.json — pnpm errors on a mismatch.
+        const rel = relative(packageName, depName).split(sep).join('/');
+        if (!importer.specifiers) importer.specifiers = {};
+        importer.specifiers[depName] = `file:${rel}`;
+        deps[depName] = `link:${rel}`;
       }
     }
 

--- a/packages/nx/src/plugins/js/lock-file/pnpm-parser.ts
+++ b/packages/nx/src/plugins/js/lock-file/pnpm-parser.ts
@@ -603,7 +603,11 @@ export function stringifyPnpmLockfile(
     const importerPath = allRequiredImporters[pkgName];
     const importer = importers[importerPath];
     if (!importer) continue;
-    for (const depType of ['dependencies', 'optionalDependencies'] as const) {
+    for (const depType of [
+      'dependencies',
+      'optionalDependencies',
+      'peerDependencies',
+    ] as const) {
       const deps = importer[depType];
       if (!deps) continue;
       for (const depName of Object.keys(deps)) {
@@ -631,7 +635,11 @@ export function stringifyPnpmLockfile(
     // layout that copy-workspace-modules produces. The original lockfile's
     // `link:` paths are relative to the package's source location in the
     // monorepo, so they must be recomputed.
-    for (const depType of ['dependencies', 'optionalDependencies'] as const) {
+    for (const depType of [
+      'dependencies',
+      'optionalDependencies',
+      'peerDependencies',
+    ] as const) {
       const deps = importer[depType] as Record<string, string> | undefined;
       if (!deps) continue;
       for (const depName of Object.keys(deps)) {
@@ -641,10 +649,10 @@ export function stringifyPnpmLockfile(
           const rel = relative(packageName, depName).split(sep).join('/');
           // Specifier must match the file: ref that copy-workspace-modules
           // writes to the package's package.json on disk; otherwise pnpm sees
-          // a mismatch and reports ERR_PNPM_OUTDATED_LOCKFILE.
-          if (importer.specifiers) {
-            importer.specifiers[depName] = `file:${rel}`;
-          }
+          // a mismatch and reports ERR_PNPM_OUTDATED_LOCKFILE. Lockfile v6+
+          // may omit `specifiers`, so initialize when missing.
+          if (!importer.specifiers) importer.specifiers = {};
+          importer.specifiers[depName] = `file:${rel}`;
           deps[depName] = `link:${rel}`;
         }
       }

--- a/packages/nx/src/plugins/js/lock-file/project-graph-pruning.ts
+++ b/packages/nx/src/plugins/js/lock-file/project-graph-pruning.ts
@@ -188,12 +188,25 @@ function traverseNode(
 function traverseWorkspaceNode(
   graph: ProjectGraph,
   builder: ProjectGraphBuilder,
-  node: ProjectGraphProjectNode
+  node: ProjectGraphProjectNode,
+  visited: Set<string> = new Set()
 ) {
+  if (visited.has(node.name)) {
+    return;
+  }
+  visited.add(node.name);
   graph.dependencies[node.name]?.forEach((dep) => {
-    const depNode = graph.externalNodes[dep.target];
-    if (depNode) {
-      traverseNode(graph, builder, depNode);
+    const externalDepNode = graph.externalNodes[dep.target];
+    if (externalDepNode) {
+      traverseNode(graph, builder, externalDepNode);
+      return;
+    }
+    // Recurse into workspace → workspace deps so that transitive workspace
+    // packages' npm deps reach the pruned graph (and therefore the lockfile's
+    // packages: section).
+    const workspaceDepNode = graph.nodes[dep.target];
+    if (workspaceDepNode) {
+      traverseWorkspaceNode(graph, builder, workspaceDepNode, visited);
     }
   });
 }

--- a/packages/nx/src/plugins/js/lock-file/project-graph-pruning.ts
+++ b/packages/nx/src/plugins/js/lock-file/project-graph-pruning.ts
@@ -191,9 +191,7 @@ function traverseWorkspaceNode(
   node: ProjectGraphProjectNode,
   visited: Set<string> = new Set()
 ) {
-  if (visited.has(node.name)) {
-    return;
-  }
+  if (visited.has(node.name)) return;
   visited.add(node.name);
   graph.dependencies[node.name]?.forEach((dep) => {
     const externalDepNode = graph.externalNodes[dep.target];
@@ -201,9 +199,6 @@ function traverseWorkspaceNode(
       traverseNode(graph, builder, externalDepNode);
       return;
     }
-    // Recurse into workspace → workspace deps so that transitive workspace
-    // packages' npm deps reach the pruned graph (and therefore the lockfile's
-    // packages: section).
     const workspaceDepNode = graph.nodes[dep.target];
     if (workspaceDepNode) {
       traverseWorkspaceNode(graph, builder, workspaceDepNode, visited);


### PR DESCRIPTION
## Current Behavior

`@nx/js:prune-lockfile` does not recursively walk workspace→workspace dependencies. Given an `app → @myorg/lib-a → @myorg/lib-b → lodash` chain (where `lib-a` and `lib-b` are workspace packages), the executor produces a pruned `pnpm-lock.yaml` that:

1. **Misses the importer block** for `workspace_modules/@myorg/lib-b` (the transitive workspace dep).
2. **Misses `lodash`** (lib-b's npm dep) from the `packages:` section.
3. **Keeps `specifier: workspace:*`** for `lib-b` inside `lib-a`'s importer block, even though `@nx/js:copy-workspace-modules` rewrites `lib-a/package.json` to `"@myorg/lib-b": "file:../lib-b"`.

The specifier mismatch causes `pnpm install --frozen-lockfile` to fail in the deployed output:

```
ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because
pnpm-lock.yaml is not up to date with workspace_modules/@myorg/lib-a/package.json
  - @myorg/lib-b (lockfile: workspace:*, manifest: file:../lib-b)
```

## Expected Behavior

`@nx/js:prune-lockfile` recursively discovers transitive workspace dependencies and produces a lockfile that:

1. Contains an `importers` block for every workspace module that `copy-workspace-modules` writes to disk.
2. Includes the npm dependencies of all transitive workspace modules in the `packages:` section.
3. Rewrites workspace-package references inside nested importers to the flat `workspace_modules/` layout (`specifier: file:<rel>` / `version: link:<rel>`), matching what `copy-workspace-modules` writes to each package's `package.json`.

`pnpm install --frozen-lockfile` succeeds in the pruned output directory.

### Implementation

Two coordinated changes in lockfile-side code:

- **`project-graph-pruning.ts`** — `traverseWorkspaceNode` now recurses into workspace→workspace dependency edges with a `visited` set, so transitive workspace npm deps reach the pruned graph.
- **`pnpm-parser.ts`** — `stringifyPnpmLockfile` BFS-collects transitive workspace importers, deep-clones each importer block, and rewrites workspace-package references to the flat `workspace_modules/` layout.

### Tests

- 3 new unit tests in `pnpm-parser.spec.ts` covering the canonical chain, dependency cycles, and diamond shapes.
- 1 new e2e test in `e2e/js/src/js-executor-prune-lockfile.test.ts` exercising the canonical chain end-to-end.
- Verified end-to-end against the reported reproduction repo: `pnpm install --frozen-lockfile` now succeeds in the pruned output where it previously failed with `ERR_PNPM_OUTDATED_LOCKFILE`.

### Credit

Diagnosis and original fix sketch by @estevaolucas in #35347 — this PR carries forward the recursion + specifier rewrite portions in a focused change. The other concerns from #35347 (devDep/peerDep stripping, catalog reference resolution in `copy-workspace-modules`) are real but separable and intentionally left for follow-up issues.

## Related Issue(s)

Fixes #34655
