### PR TITLE
chore(core): bump detect-port from ^1.5.1 to ^2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -191,7 +191,7 @@
     "cytoscape-popper": "^2.0.0",
     "cz-git": "^1.4.0",
     "czg": "^1.4.0",
-    "detect-port": "^1.5.1",
+    "detect-port": "^2.1.0",
     "dotenv": "~16.4.5",
     "dotenv-expand": "~12.0.3",
     "ejs": "5.0.1",

--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -41,7 +41,7 @@
     "@nx/eslint": "workspace:*",
     "@nx/js": "workspace:*",
     "@phenomnomnominal/tsquery": "catalog:typescript",
-    "detect-port": "^1.5.1",
+    "detect-port": "^2.1.0",
     "semver": "catalog:",
     "tree-kill": "1.2.2",
     "tslib": "catalog:typescript"

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -48,7 +48,7 @@
     "babel-plugin-transform-typescript-metadata": "^0.3.1",
     "chalk": "catalog:",
     "columnify": "^1.6.0",
-    "detect-port": "^1.5.1",
+    "detect-port": "^2.1.0",
     "ignore": "^7.0.5",
     "js-tokens": "^4.0.0",
     "jsonc-parser": "3.2.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -32,7 +32,7 @@
     "migrations": "./migrations.json"
   },
   "dependencies": {
-    "detect-port": "^1.5.1",
+    "detect-port": "^2.1.0",
     "http-server": "^14.1.0",
     "picocolors": "catalog:",
     "tslib": "catalog:typescript",

--- a/packages/web/src/executors/file-server/file-server.impl.ts
+++ b/packages/web/src/executors/file-server/file-server.impl.ts
@@ -15,7 +15,7 @@ import { readModulePackageJson } from 'nx/src/utils/package-json';
 import { daemonClient } from 'nx/src/daemon/client/client';
 import { interpolate } from 'nx/src/tasks-runner/utils';
 import { stripGlobToBaseDir } from '@nx/js/src/utils/strip-glob-to-base-dir';
-const detectPort = require('detect-port');
+import detectPort from 'detect-port';
 
 // platform specific command name
 const pmCmd = platform() === 'win32' ? `npx.cmd` : 'npx';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2582,8 +2582,8 @@ importers:
         specifier: '>= 13 < 16'
         version: 14.3.0
       detect-port:
-        specifier: ^1.5.1
-        version: 1.6.1
+        specifier: ^2.1.0
+        version: 2.1.0
       semver:
         specifier: 'catalog:'
         version: 7.7.4
@@ -2999,8 +2999,8 @@ importers:
         specifier: ^1.6.0
         version: 1.6.0
       detect-port:
-        specifier: ^1.5.1
-        version: 1.6.1
+        specifier: ^2.1.0
+        version: 2.1.0
       ignore:
         specifier: ^7.0.5
         version: 7.0.5
@@ -4006,8 +4006,8 @@ importers:
         specifier: workspace:*
         version: link:../webpack
       detect-port:
-        specifier: ^1.5.1
-        version: 1.6.1
+        specifier: ^2.1.0
+        version: 2.1.0
       http-server:
         specifier: ^14.1.0
         version: 14.1.0
@@ -14199,6 +14199,10 @@ packages:
     resolution: {integrity: sha512-4B/qKCfeE/ODUaAUpSwfzazo5x29WD4r3vXiWsB7I2mSDAihwEqKO+g8GELZUQSSAo5e1XTYh3ZVfLyxBc12nA==}
     engines: {node: '>= 10.0.0'}
 
+  address@2.0.3:
+    resolution: {integrity: sha512-XNAb/a6TCqou+TufU8/u11HCu9x1gYvOoxLwtlXgIqmkrYQADVv6ljyW2zwiPhHz9R1gItAWpuDrdJMmrOBFEA==}
+    engines: {node: '>= 16.0.0'}
+
   adjust-sourcemap-loader@4.0.0:
     resolution: {integrity: sha512-OXwN5b9pCUXNQHJpwwD2qP40byEmSgzj8B4ydSN0uMNYWiFmJ6x6KwUllMmfk8Rwu/HJDFR7U8ubsWBoN0Xp0A==}
     engines: {node: '>=8.9'}
@@ -16461,6 +16465,11 @@ packages:
   detect-port@1.6.1:
     resolution: {integrity: sha512-CmnVc+Hek2egPx1PeTFVta2W78xy2K/9Rkf6cC4T59S50tVnzKj+tnx5mmx5lwvCkujZ4uRrpRSuV+IVs3f90Q==}
     engines: {node: '>= 4.0.0'}
+    hasBin: true
+
+  detect-port@2.1.0:
+    resolution: {integrity: sha512-epZuWb/6Q62L+nDHJc/hQAqf8pylsqgk3BpZXVBx1CDnr3nkrVNn73Uu1rXcFzkNcc+hkP3whuOg7JZYaQB65Q==}
+    engines: {node: '>= 16.0.0'}
     hasBin: true
 
   detective-amd@6.0.1:
@@ -41776,6 +41785,8 @@ snapshots:
 
   address@1.2.2: {}
 
+  address@2.0.3: {}
+
   adjust-sourcemap-loader@4.0.0:
     dependencies:
       loader-utils: 2.0.3
@@ -44787,6 +44798,10 @@ snapshots:
       debug: 4.4.1(supports-color@8.1.1)
     transitivePeerDependencies:
       - supports-color
+
+  detect-port@2.1.0:
+    dependencies:
+      address: 2.0.3
 
   detective-amd@6.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -915,8 +915,8 @@ importers:
         specifier: ^1.4.0
         version: 1.12.0
       detect-port:
-        specifier: ^1.5.1
-        version: 1.6.1
+        specifier: ^2.1.0
+        version: 2.1.0
       dotenv:
         specifier: ~16.4.5
         version: 16.4.7


### PR DESCRIPTION
## Current Behavior

`@nx/web`, `@nx/js`, and `@nx/cypress` declare `detect-port: ^1.5.1`. Per the bulk-dependency-update sweep (NXC-4329), this is due for a major bump. The queue task initially flagged this as ESM-only — that was stale info; v2 is actually dual-published.

## Expected Behavior

Bumped to `detect-port@^2.1.0`.

## Validation

`detect-port@2.1.0` ships both ESM and CJS builds via the package.json exports map:

```jsonc
{
  "type": "module",
  "main": "./dist/commonjs/index.js",
  "exports": {
    ".": {
      "import": { "types": "./dist/esm/index.d.ts", "default": "./dist/esm/index.js" },
      "require": { "types": "./dist/commonjs/index.d.ts", "default": "./dist/commonjs/index.js" }
    }
  },
  "engines": { "node": ">= 16.0.0" }
}
```

The three call sites in this repo:

```ts
// packages/web/src/executors/file-server/file-server.impl.ts
const detectPort = require('detect-port');                  // CJS path

// packages/js/src/executors/verdaccio/verdaccio.impl.ts
import detectPort from 'detect-port';                       // compiles to require → CJS

// packages/cypress/src/utils/start-dev-server.ts
import detectPort from 'detect-port';                       // compiles to require → CJS
```

All three resolve to `./dist/commonjs/index.js` — no code changes needed. The default-export function shape (`detect(port, callback?) → Promise<number>`) is unchanged across v1 → v2.

`pnpm nx run-many -t build -p web,js,cypress` — passes.

## Related Issue(s)

Part of [NXC-4329](https://linear.app/nxdev/issue/NXC-4329) bulk-dependency-update sweep.