### PR TITLE
fix(js): use TypeScript readConfigFile instead of JSON.parse in resolvePathsBaseUrl

### DIFF
--- a/packages/js/src/utils/typescript/ts-config.spec.ts
+++ b/packages/js/src/utils/typescript/ts-config.spec.ts
@@ -206,6 +206,38 @@ describe('resolvePathsBaseUrl', () => {
     );
   });
 
+  it('should handle tsconfig files with // comments (JSONC) in extends chain', () => {
+    tempFs.createFileSync(
+      'tsconfig.base.json',
+      JSON.stringify({
+        compilerOptions: {
+          baseUrl: '.',
+          paths: { '@lib/*': ['libs/*/src/index.ts'] },
+        },
+      })
+    );
+    tempFs.createFileSync(
+      'tsconfig.intermediate.json',
+      `{
+  "extends": "./tsconfig.base.json",
+  "compilerOptions": {
+    // TODO: fix this later
+    "strictPropertyInitialization": false
+  }
+}`
+    );
+    tempFs.createFileSync(
+      'project/tsconfig.json',
+      JSON.stringify({
+        extends: '../tsconfig.intermediate.json',
+      })
+    );
+
+    expect(
+      resolvePathsBaseUrl(join(tempFs.tempDir, 'project', 'tsconfig.json'))
+    ).toBe(tempFs.tempDir);
+  });
+
   it('should return tsconfig directory when no paths or baseUrl exist', () => {
     tempFs.createFileSync(
       'tsconfig.json',

--- a/packages/js/src/utils/typescript/ts-config.ts
+++ b/packages/js/src/utils/typescript/ts-config.ts
@@ -1,5 +1,5 @@
 import { offsetFromRoot, Tree, updateJson, workspaceRoot } from '@nx/devkit';
-import { existsSync, readFileSync } from 'fs';
+import { existsSync } from 'fs';
 import { dirname, isAbsolute, join, resolve } from 'path';
 import type * as ts from 'typescript';
 import { ensureTypescript } from './ensure-typescript';
@@ -120,13 +120,20 @@ function ensureRelativePath(p: string): string {
  * tsconfig that defines `paths`.
  */
 export function resolvePathsBaseUrl(tsconfigPath: string): string {
+  if (!tsModule) {
+    tsModule = require('typescript');
+  }
+
   const chain: { dir: string; raw: any }[] = [];
   const queue: string[] = [tsconfigPath];
   while (queue.length > 0) {
     const absolute = resolve(queue.shift()!);
     const dir = dirname(absolute);
     try {
-      const raw = JSON.parse(readFileSync(absolute, 'utf-8'));
+      const { config: raw } = tsModule.readConfigFile(
+        absolute,
+        tsModule.sys.readFile
+      );
       chain.push({ dir, raw });
       const exts: string[] = raw.extends
         ? Array.isArray(raw.extends)

--- a/packages/js/src/utils/typescript/ts-config.ts
+++ b/packages/js/src/utils/typescript/ts-config.ts
@@ -1,4 +1,10 @@
-import { offsetFromRoot, Tree, updateJson, workspaceRoot } from '@nx/devkit';
+import {
+  offsetFromRoot,
+  readJsonFile,
+  Tree,
+  updateJson,
+  workspaceRoot,
+} from '@nx/devkit';
 import { existsSync } from 'fs';
 import { dirname, isAbsolute, join, resolve } from 'path';
 import type * as ts from 'typescript';
@@ -120,20 +126,13 @@ function ensureRelativePath(p: string): string {
  * tsconfig that defines `paths`.
  */
 export function resolvePathsBaseUrl(tsconfigPath: string): string {
-  if (!tsModule) {
-    tsModule = require('typescript');
-  }
-
   const chain: { dir: string; raw: any }[] = [];
   const queue: string[] = [tsconfigPath];
   while (queue.length > 0) {
     const absolute = resolve(queue.shift()!);
     const dir = dirname(absolute);
     try {
-      const { config: raw } = tsModule.readConfigFile(
-        absolute,
-        tsModule.sys.readFile
-      );
+      const raw = readJsonFile(absolute);
       chain.push({ dir, raw });
       const exts: string[] = raw.extends
         ? Array.isArray(raw.extends)


### PR DESCRIPTION
## Current Behavior

`resolvePathsBaseUrl` in `packages/js/src/utils/typescript/ts-config.ts` walks the tsconfig `extends` chain using `JSON.parse(readFileSync(...))` to find where `paths` is defined. `JSON.parse` cannot handle `//` or `/* */` comments (JSONC), which are extremely common in tsconfig files. When parsing fails, the `catch` block silently skips the file, breaking the extends chain walk. The function never reaches `tsconfig.base.json` (where `paths` and `baseUrl` are defined), so it falls back to the project's own directory as the resolution base, producing incorrect path mappings like `{workspaceRoot}/libs/my-lib/dist/libs/data-layer` instead of `{workspaceRoot}/dist/libs/data-layer`.

This is a regression introduced in v22.7.0 by PR #34965.

## Expected Behavior

Buildable library builds should resolve workspace dependencies correctly, even when tsconfig files in the extends chain contain JSONC comments (`//` or `/* */`). The fix uses TypeScript's `readConfigFile` (which handles JSONC) — the same approach already used by `readTsConfig` in the same file.

## Related Issue(s)

Fixes #35537
Fixes #35824