### PR TITLE
feat(devkit): migrate `@nx/devkit/src/...` deep imports

### DIFF
--- a/packages/devkit/migrations.json
+++ b/packages/devkit/migrations.json
@@ -1,5 +1,11 @@
 {
-  "generators": {},
+  "generators": {
+    "update-devkit-deep-imports": {
+      "version": "23.0.0-beta.6",
+      "description": "Rewrite imports from `@nx/devkit/src/...` to `@nx/devkit` (for public symbols) or `@nx/devkit/internal` (for the rest), since deep imports are no longer reachable through the package's `exports` map.",
+      "implementation": "./dist/src/migrations/update-23-0-0/update-deep-imports"
+    }
+  },
   "packageJsonUpdates": {},
   "version": "0.1"
 }

--- a/packages/devkit/src/migrations/update-23-0-0/update-deep-imports.md
+++ b/packages/devkit/src/migrations/update-23-0-0/update-deep-imports.md
@@ -28,6 +28,16 @@ import { dasherize, addPlugin } from '@nx/devkit/internal';
 
 `names` was already in the public API, so it joins the existing `@nx/devkit` import. `dasherize` and `addPlugin` move to `@nx/devkit/internal`, and the two `/internal` imports are collapsed into one.
 
-#### Limitations
+#### Fallback for non-named imports
 
-The migration only rewrites named `import { ... } from '@nx/devkit/src/...'` declarations. Default imports, namespace imports, side-effect imports, `require(...)` calls, and dynamic `import(...)` calls are left untouched and need to be migrated by hand to either `@nx/devkit` or `@nx/devkit/internal` depending on the symbol.
+For deep-import shapes that can't be split by symbol — default imports, namespace imports, side-effect imports, `require(...)` calls, and dynamic `import(...)` — the migration rewrites the specifier to `@nx/devkit/internal` as a best guess, since most symbols that previously lived under `@nx/devkit/src/...` ended up there.
+
+```ts
+// Before
+const { dasherize } = require('@nx/devkit/src/utils/string-utils');
+
+// After
+const { dasherize } = require('@nx/devkit/internal');
+```
+
+If the symbol you're after is part of the stable public API instead, the rewritten import will fail to resolve against `@nx/devkit/internal` — switch it to `@nx/devkit` by hand.

--- a/packages/devkit/src/migrations/update-23-0-0/update-deep-imports.md
+++ b/packages/devkit/src/migrations/update-23-0-0/update-deep-imports.md
@@ -28,14 +28,6 @@ import { dasherize, addPlugin } from '@nx/devkit/internal';
 
 `names` was already in the public API, so it joins the existing `@nx/devkit` import. `dasherize` and `addPlugin` move to `@nx/devkit/internal`, and the two `/internal` imports are collapsed into one.
 
-#### Fallback for non-named imports
+#### Limitations
 
-For deep-import shapes that can't be split by symbol — default imports, namespace imports, side-effect imports, `require(...)` calls, and dynamic `import(...)` — the migration rewrites the specifier to `@nx/devkit/internal`, which re-exports every symbol that was previously deep-importable.
-
-```ts
-// Before
-const { dasherize } = require('@nx/devkit/src/utils/string-utils');
-
-// After
-const { dasherize } = require('@nx/devkit/internal');
-```
+The migration only rewrites named `import { ... } from '@nx/devkit/src/...'` declarations. Default imports, namespace imports, side-effect imports, `require(...)` calls, and dynamic `import(...)` calls are left untouched and need to be migrated by hand to either `@nx/devkit` or `@nx/devkit/internal` depending on the symbol.

--- a/packages/devkit/src/migrations/update-23-0-0/update-deep-imports.md
+++ b/packages/devkit/src/migrations/update-23-0-0/update-deep-imports.md
@@ -1,0 +1,41 @@
+#### Update `@nx/devkit` deep imports
+
+`@nx/devkit` now ships a strict `exports` map, so deep imports like `@nx/devkit/src/utils/...` and `@nx/devkit/src/generators/...` are no longer reachable through Node module resolution.
+
+This migration scans every `.ts`, `.tsx`, `.cts`, and `.mts` file in your workspace and rewrites those deep imports to one of the supported entry points:
+
+- Symbols that are part of the stable `@nx/devkit` public API are routed to `@nx/devkit`.
+- Symbols that were previously only reachable through deep imports are routed to `@nx/devkit/internal`.
+
+After rewriting, the migration **collapses duplicate imports** so a file never ends up with two `import ... from '@nx/devkit'` (or `@nx/devkit/internal`) lines — including merging into any matching import you already had.
+
+#### Sample Code Changes
+
+##### Before
+
+```ts
+import { Tree } from '@nx/devkit';
+import { dasherize, names } from '@nx/devkit/src/utils/string-utils';
+import { addPlugin } from '@nx/devkit/src/utils/add-plugin';
+```
+
+##### After
+
+```ts
+import { Tree, names } from '@nx/devkit';
+import { dasherize, addPlugin } from '@nx/devkit/internal';
+```
+
+`names` was already in the public API, so it joins the existing `@nx/devkit` import. `dasherize` and `addPlugin` move to `@nx/devkit/internal`, and the two `/internal` imports are collapsed into one.
+
+#### Fallback for non-named imports
+
+For deep-import shapes that can't be split by symbol — default imports, namespace imports, side-effect imports, `require(...)` calls, and dynamic `import(...)` — the migration rewrites the specifier to `@nx/devkit/internal`, which re-exports every symbol that was previously deep-importable.
+
+```ts
+// Before
+const { dasherize } = require('@nx/devkit/src/utils/string-utils');
+
+// After
+const { dasherize } = require('@nx/devkit/internal');
+```

--- a/packages/devkit/src/migrations/update-23-0-0/update-deep-imports.spec.ts
+++ b/packages/devkit/src/migrations/update-23-0-0/update-deep-imports.spec.ts
@@ -1,0 +1,296 @@
+import { type Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migration, {
+  DEVKIT_INTERNAL_SYMBOLS,
+  rewriteDevkitDeepImports,
+} from './update-deep-imports';
+
+describe('update-deep-imports migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  describe('rewriteDevkitDeepImports', () => {
+    it('routes a single internal symbol to @nx/devkit/internal', () => {
+      const input = `import { dasherize } from '@nx/devkit/src/utils/string-utils';\n`;
+      expect(rewriteDevkitDeepImports(input)).toBe(
+        `import { dasherize } from '@nx/devkit/internal';\n`
+      );
+    });
+
+    it('routes a single public symbol to @nx/devkit', () => {
+      const input = `import { names } from '@nx/devkit/src/utils/names';\n`;
+      expect(rewriteDevkitDeepImports(input)).toBe(
+        `import { names } from '@nx/devkit';\n`
+      );
+    });
+
+    it('splits mixed public and internal symbols across two declarations', () => {
+      const input = `import { dasherize, names } from '@nx/devkit/src/utils/string-utils';\n`;
+      const output = rewriteDevkitDeepImports(input);
+      expect(output).toContain(`import { names } from '@nx/devkit';`);
+      expect(output).toContain(
+        `import { dasherize } from '@nx/devkit/internal';`
+      );
+    });
+
+    it('preserves `as` aliases', () => {
+      const input = `import { dasherize as toKebab } from '@nx/devkit/src/utils/string-utils';\n`;
+      expect(rewriteDevkitDeepImports(input)).toContain(
+        `import { dasherize as toKebab } from '@nx/devkit/internal';`
+      );
+    });
+
+    it('handles `import type` declarations', () => {
+      const input = `import type { FileExtensionType } from '@nx/devkit/src/generators/artifact-name-and-directory-utils';\n`;
+      expect(rewriteDevkitDeepImports(input)).toContain(
+        `import type { FileExtensionType } from '@nx/devkit/internal';`
+      );
+    });
+
+    it('preserves inline `type` modifiers on individual specifiers', () => {
+      const input = `import { type FileExtensionType, addPlugin } from '@nx/devkit/src/x';\n`;
+      const output = rewriteDevkitDeepImports(input);
+      expect(output).toContain(
+        `import { type FileExtensionType, addPlugin } from '@nx/devkit/internal';`
+      );
+    });
+
+    it('drops redundant inline `type` when the whole import is already type-only', () => {
+      const input = `import type { type FileExtensionType } from '@nx/devkit/src/x';\n`;
+      const output = rewriteDevkitDeepImports(input);
+      expect(output).toContain(
+        `import type { FileExtensionType } from '@nx/devkit/internal';`
+      );
+    });
+
+    it('handles multi-line named imports', () => {
+      const input = `import {\n  dasherize,\n  names,\n  classify,\n} from '@nx/devkit/src/utils/string-utils';\n`;
+      const output = rewriteDevkitDeepImports(input);
+      expect(output).toContain(`import { names } from '@nx/devkit';`);
+      expect(output).toContain(
+        `import { dasherize, classify } from '@nx/devkit/internal';`
+      );
+    });
+
+    it('rewrites multiple deep imports in one file', () => {
+      const input =
+        `import { dasherize } from '@nx/devkit/src/utils/string-utils';\n` +
+        `import { names } from '@nx/devkit/src/utils/names';\n`;
+      const output = rewriteDevkitDeepImports(input);
+      expect(output).toContain(
+        `import { dasherize } from '@nx/devkit/internal';`
+      );
+      expect(output).toContain(`import { names } from '@nx/devkit';`);
+    });
+
+    it('falls back to /internal for side-effect imports', () => {
+      const input = `import '@nx/devkit/src/utils/some-side-effect';\n`;
+      expect(rewriteDevkitDeepImports(input)).toContain(
+        `import '@nx/devkit/internal';`
+      );
+    });
+
+    it('falls back to /internal for default imports', () => {
+      const input = `import x from '@nx/devkit/src/utils/foo';\n`;
+      const output = rewriteDevkitDeepImports(input);
+      expect(output).toContain(`'@nx/devkit/internal'`);
+      expect(output).toContain(`import x from`);
+    });
+
+    it('falls back to /internal for namespace imports', () => {
+      const input = `import * as devkit from '@nx/devkit/src/utils/foo';\n`;
+      const output = rewriteDevkitDeepImports(input);
+      expect(output).toContain(
+        `import * as devkit from '@nx/devkit/internal';`
+      );
+    });
+
+    it('falls back to /internal for require()', () => {
+      const input = `const x = require('@nx/devkit/src/utils/foo');\n`;
+      expect(rewriteDevkitDeepImports(input)).toBe(
+        `const x = require('@nx/devkit/internal');\n`
+      );
+    });
+
+    it('falls back to /internal for dynamic import()', () => {
+      const input = `const x = await import('@nx/devkit/src/utils/foo');\n`;
+      expect(rewriteDevkitDeepImports(input)).toBe(
+        `const x = await import('@nx/devkit/internal');\n`
+      );
+    });
+
+    it('preserves quote style on fallback paths', () => {
+      const input = `const x = require("@nx/devkit/src/utils/foo");\n`;
+      expect(rewriteDevkitDeepImports(input)).toBe(
+        `const x = require("@nx/devkit/internal");\n`
+      );
+    });
+
+    it('does not touch unrelated @nx/devkit imports', () => {
+      const input = `import { Tree } from '@nx/devkit';\n`;
+      expect(rewriteDevkitDeepImports(input)).toBe(input);
+    });
+
+    it('does not touch unrelated @nx/devkit/internal imports', () => {
+      const input = `import { dasherize } from '@nx/devkit/internal';\n`;
+      expect(rewriteDevkitDeepImports(input)).toBe(input);
+    });
+  });
+
+  describe('migration runner', () => {
+    it('rewrites deep imports across .ts/.tsx/.cts/.mts files', async () => {
+      tree.write(
+        'libs/foo/src/a.ts',
+        `import { dasherize } from '@nx/devkit/src/utils/string-utils';\n`
+      );
+      tree.write(
+        'libs/foo/src/b.tsx',
+        `import { addPlugin } from '@nx/devkit/src/utils/add-plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/c.cts',
+        `const { classify } = require('@nx/devkit/src/utils/string-utils');\n`
+      );
+      tree.write(
+        'libs/foo/src/d.mts',
+        `import { camelize } from '@nx/devkit/src/utils/string-utils';\n`
+      );
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/a.ts', 'utf-8')).toContain(
+        `'@nx/devkit/internal'`
+      );
+      expect(tree.read('libs/foo/src/b.tsx', 'utf-8')).toContain(
+        `'@nx/devkit/internal'`
+      );
+      expect(tree.read('libs/foo/src/c.cts', 'utf-8')).toContain(
+        `'@nx/devkit/internal'`
+      );
+      expect(tree.read('libs/foo/src/d.mts', 'utf-8')).toContain(
+        `'@nx/devkit/internal'`
+      );
+    });
+
+    it('does not rewrite deep-import strings inside non-TS files', async () => {
+      const md = `Example: \`import { x } from '@nx/devkit/src/utils/foo';\`\n`;
+      tree.write('docs/example.md', md);
+
+      await migration(tree);
+
+      // The deep-import literal must survive untouched in markdown — only TS
+      // sources should be rewritten. (formatFiles may normalize trailing
+      // whitespace, so we assert on substring rather than full equality.)
+      expect(tree.read('docs/example.md', 'utf-8')).toContain(
+        `'@nx/devkit/src/utils/foo'`
+      );
+    });
+
+    it('does not touch files that do not contain the deep prefix', async () => {
+      const content = `import { Tree } from '@nx/devkit';\n`;
+      tree.write('libs/foo/src/index.ts', content);
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/index.ts', 'utf-8')).toBe(content);
+    });
+  });
+
+  describe('collapse', () => {
+    it('merges a rewritten import into a pre-existing @nx/devkit import', () => {
+      const input =
+        `import { Tree } from '@nx/devkit';\n` +
+        `import { names } from '@nx/devkit/src/utils/names';\n`;
+      const output = rewriteDevkitDeepImports(input);
+      expect(output).toContain(`import { Tree, names } from '@nx/devkit';`);
+      expect(output).not.toMatch(
+        /import \{[^}]*\} from '@nx\/devkit';[\s\S]*import \{[^}]*\} from '@nx\/devkit';/
+      );
+    });
+
+    it('merges a rewritten import into a pre-existing @nx/devkit/internal import', () => {
+      const input =
+        `import { dasherize } from '@nx/devkit/internal';\n` +
+        `import { classify } from '@nx/devkit/src/utils/string-utils';\n`;
+      const output = rewriteDevkitDeepImports(input);
+      expect(output).toContain(
+        `import { dasherize, classify } from '@nx/devkit/internal';`
+      );
+    });
+
+    it('merges multiple rewritten imports that target the same specifier', () => {
+      const input =
+        `import { dasherize } from '@nx/devkit/src/utils/string-utils';\n` +
+        `import { classify } from '@nx/devkit/src/utils/string-utils';\n` +
+        `import { camelize } from '@nx/devkit/src/utils/string-utils';\n`;
+      const output = rewriteDevkitDeepImports(input);
+      expect(output).toContain(
+        `import { dasherize, classify, camelize } from '@nx/devkit/internal';`
+      );
+      // Only one /internal declaration in the output.
+      expect((output.match(/from '@nx\/devkit\/internal'/g) ?? []).length).toBe(
+        1
+      );
+    });
+
+    it('keeps public and internal collapses independent', () => {
+      const input =
+        `import { Tree } from '@nx/devkit';\n` +
+        `import { dasherize, names } from '@nx/devkit/src/utils/string-utils';\n` +
+        `import { classify } from '@nx/devkit/src/utils/string-utils';\n`;
+      const output = rewriteDevkitDeepImports(input);
+      expect(output).toContain(`import { Tree, names } from '@nx/devkit';`);
+      expect(output).toContain(
+        `import { dasherize, classify } from '@nx/devkit/internal';`
+      );
+    });
+
+    it('does not merge value imports with type-only imports', () => {
+      const input =
+        `import type { Tree } from '@nx/devkit';\n` +
+        `import { names } from '@nx/devkit/src/utils/names';\n`;
+      const output = rewriteDevkitDeepImports(input);
+      expect(output).toContain(`import type { Tree } from '@nx/devkit';`);
+      expect(output).toContain(`import { names } from '@nx/devkit';`);
+    });
+
+    it('merges duplicate specifiers without repeating them', () => {
+      const input =
+        `import { Tree } from '@nx/devkit';\n` +
+        `import { Tree, names } from '@nx/devkit';\n`;
+      const output = rewriteDevkitDeepImports(input);
+      expect(output).toContain(`import { Tree, names } from '@nx/devkit';`);
+      expect((output.match(/Tree/g) ?? []).length).toBe(1);
+    });
+
+    it('does not touch a file that already has a single canonical import', () => {
+      const input = `import { Tree, names } from '@nx/devkit';\n`;
+      expect(rewriteDevkitDeepImports(input)).toBe(input);
+    });
+
+    it('leaves unrelated imports between merged declarations alone', () => {
+      const input =
+        `import { Tree } from '@nx/devkit';\n` +
+        `import { readFileSync } from 'node:fs';\n` +
+        `import { names } from '@nx/devkit/src/utils/names';\n`;
+      const output = rewriteDevkitDeepImports(input);
+      expect(output).toContain(`import { Tree, names } from '@nx/devkit';`);
+      expect(output).toContain(`import { readFileSync } from 'node:fs';`);
+    });
+  });
+
+  describe('symbol set sanity', () => {
+    it('treats every name in DEVKIT_INTERNAL_SYMBOLS as internal', () => {
+      for (const name of DEVKIT_INTERNAL_SYMBOLS) {
+        const input = `import { ${name} } from '@nx/devkit/src/x';\n`;
+        const output = rewriteDevkitDeepImports(input);
+        expect(output).toContain(
+          `import { ${name} } from '@nx/devkit/internal';`
+        );
+      }
+    });
+  });
+});

--- a/packages/devkit/src/migrations/update-23-0-0/update-deep-imports.spec.ts
+++ b/packages/devkit/src/migrations/update-23-0-0/update-deep-imports.spec.ts
@@ -86,47 +86,29 @@ describe('update-deep-imports migration', () => {
       expect(output).toContain(`import { names } from '@nx/devkit';`);
     });
 
-    it('falls back to /internal for side-effect imports', () => {
+    it('leaves side-effect imports untouched', () => {
       const input = `import '@nx/devkit/src/utils/some-side-effect';\n`;
-      expect(rewriteDevkitDeepImports(input)).toContain(
-        `import '@nx/devkit/internal';`
-      );
+      expect(rewriteDevkitDeepImports(input)).toBe(input);
     });
 
-    it('falls back to /internal for default imports', () => {
+    it('leaves default imports untouched', () => {
       const input = `import x from '@nx/devkit/src/utils/foo';\n`;
-      const output = rewriteDevkitDeepImports(input);
-      expect(output).toContain(`'@nx/devkit/internal'`);
-      expect(output).toContain(`import x from`);
+      expect(rewriteDevkitDeepImports(input)).toBe(input);
     });
 
-    it('falls back to /internal for namespace imports', () => {
+    it('leaves namespace imports untouched', () => {
       const input = `import * as devkit from '@nx/devkit/src/utils/foo';\n`;
-      const output = rewriteDevkitDeepImports(input);
-      expect(output).toContain(
-        `import * as devkit from '@nx/devkit/internal';`
-      );
+      expect(rewriteDevkitDeepImports(input)).toBe(input);
     });
 
-    it('falls back to /internal for require()', () => {
+    it('leaves require() calls untouched', () => {
       const input = `const x = require('@nx/devkit/src/utils/foo');\n`;
-      expect(rewriteDevkitDeepImports(input)).toBe(
-        `const x = require('@nx/devkit/internal');\n`
-      );
+      expect(rewriteDevkitDeepImports(input)).toBe(input);
     });
 
-    it('falls back to /internal for dynamic import()', () => {
+    it('leaves dynamic import() calls untouched', () => {
       const input = `const x = await import('@nx/devkit/src/utils/foo');\n`;
-      expect(rewriteDevkitDeepImports(input)).toBe(
-        `const x = await import('@nx/devkit/internal');\n`
-      );
-    });
-
-    it('preserves quote style on fallback paths', () => {
-      const input = `const x = require("@nx/devkit/src/utils/foo");\n`;
-      expect(rewriteDevkitDeepImports(input)).toBe(
-        `const x = require("@nx/devkit/internal");\n`
-      );
+      expect(rewriteDevkitDeepImports(input)).toBe(input);
     });
 
     it('does not touch unrelated @nx/devkit imports', () => {
@@ -141,7 +123,7 @@ describe('update-deep-imports migration', () => {
   });
 
   describe('migration runner', () => {
-    it('rewrites deep imports across .ts/.tsx/.cts/.mts files', async () => {
+    it('rewrites named imports across .ts/.tsx/.cts/.mts files', async () => {
       tree.write(
         'libs/foo/src/a.ts',
         `import { dasherize } from '@nx/devkit/src/utils/string-utils';\n`
@@ -152,7 +134,7 @@ describe('update-deep-imports migration', () => {
       );
       tree.write(
         'libs/foo/src/c.cts',
-        `const { classify } = require('@nx/devkit/src/utils/string-utils');\n`
+        `import { classify } from '@nx/devkit/src/utils/string-utils';\n`
       );
       tree.write(
         'libs/foo/src/d.mts',
@@ -172,6 +154,17 @@ describe('update-deep-imports migration', () => {
       );
       expect(tree.read('libs/foo/src/d.mts', 'utf-8')).toContain(
         `'@nx/devkit/internal'`
+      );
+    });
+
+    it('does not rewrite require() calls in .cts files', async () => {
+      const content = `const { classify } = require('@nx/devkit/src/utils/string-utils');\n`;
+      tree.write('libs/foo/src/c.cts', content);
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/c.cts', 'utf-8')).toContain(
+        `require('@nx/devkit/src/utils/string-utils')`
       );
     });
 

--- a/packages/devkit/src/migrations/update-23-0-0/update-deep-imports.spec.ts
+++ b/packages/devkit/src/migrations/update-23-0-0/update-deep-imports.spec.ts
@@ -86,29 +86,47 @@ describe('update-deep-imports migration', () => {
       expect(output).toContain(`import { names } from '@nx/devkit';`);
     });
 
-    it('leaves side-effect imports untouched', () => {
+    it('falls back to /internal for side-effect imports', () => {
       const input = `import '@nx/devkit/src/utils/some-side-effect';\n`;
-      expect(rewriteDevkitDeepImports(input)).toBe(input);
+      expect(rewriteDevkitDeepImports(input)).toContain(
+        `import '@nx/devkit/internal';`
+      );
     });
 
-    it('leaves default imports untouched', () => {
+    it('falls back to /internal for default imports', () => {
       const input = `import x from '@nx/devkit/src/utils/foo';\n`;
-      expect(rewriteDevkitDeepImports(input)).toBe(input);
+      const output = rewriteDevkitDeepImports(input);
+      expect(output).toContain(`'@nx/devkit/internal'`);
+      expect(output).toContain(`import x from`);
     });
 
-    it('leaves namespace imports untouched', () => {
+    it('falls back to /internal for namespace imports', () => {
       const input = `import * as devkit from '@nx/devkit/src/utils/foo';\n`;
-      expect(rewriteDevkitDeepImports(input)).toBe(input);
+      const output = rewriteDevkitDeepImports(input);
+      expect(output).toContain(
+        `import * as devkit from '@nx/devkit/internal';`
+      );
     });
 
-    it('leaves require() calls untouched', () => {
+    it('falls back to /internal for require()', () => {
       const input = `const x = require('@nx/devkit/src/utils/foo');\n`;
-      expect(rewriteDevkitDeepImports(input)).toBe(input);
+      expect(rewriteDevkitDeepImports(input)).toBe(
+        `const x = require('@nx/devkit/internal');\n`
+      );
     });
 
-    it('leaves dynamic import() calls untouched', () => {
+    it('falls back to /internal for dynamic import()', () => {
       const input = `const x = await import('@nx/devkit/src/utils/foo');\n`;
-      expect(rewriteDevkitDeepImports(input)).toBe(input);
+      expect(rewriteDevkitDeepImports(input)).toBe(
+        `const x = await import('@nx/devkit/internal');\n`
+      );
+    });
+
+    it('preserves quote style on fallback paths', () => {
+      const input = `const x = require("@nx/devkit/src/utils/foo");\n`;
+      expect(rewriteDevkitDeepImports(input)).toBe(
+        `const x = require("@nx/devkit/internal");\n`
+      );
     });
 
     it('does not touch unrelated @nx/devkit imports', () => {
@@ -123,7 +141,7 @@ describe('update-deep-imports migration', () => {
   });
 
   describe('migration runner', () => {
-    it('rewrites named imports across .ts/.tsx/.cts/.mts files', async () => {
+    it('rewrites deep imports across .ts/.tsx/.cts/.mts files', async () => {
       tree.write(
         'libs/foo/src/a.ts',
         `import { dasherize } from '@nx/devkit/src/utils/string-utils';\n`
@@ -134,7 +152,7 @@ describe('update-deep-imports migration', () => {
       );
       tree.write(
         'libs/foo/src/c.cts',
-        `import { classify } from '@nx/devkit/src/utils/string-utils';\n`
+        `const { classify } = require('@nx/devkit/src/utils/string-utils');\n`
       );
       tree.write(
         'libs/foo/src/d.mts',
@@ -154,17 +172,6 @@ describe('update-deep-imports migration', () => {
       );
       expect(tree.read('libs/foo/src/d.mts', 'utf-8')).toContain(
         `'@nx/devkit/internal'`
-      );
-    });
-
-    it('does not rewrite require() calls in .cts files', async () => {
-      const content = `const { classify } = require('@nx/devkit/src/utils/string-utils');\n`;
-      tree.write('libs/foo/src/c.cts', content);
-
-      await migration(tree);
-
-      expect(tree.read('libs/foo/src/c.cts', 'utf-8')).toContain(
-        `require('@nx/devkit/src/utils/string-utils')`
       );
     });
 

--- a/packages/devkit/src/migrations/update-23-0-0/update-deep-imports.ts
+++ b/packages/devkit/src/migrations/update-23-0-0/update-deep-imports.ts
@@ -1,19 +1,18 @@
-import {
-  applyChangesToString,
-  ChangeType,
-  ensurePackage,
-  formatFiles,
-  logger,
-  type StringChange,
-  type Tree,
-  visitNotIgnoredFiles,
-} from '@nx/devkit';
+import { logger, type Tree } from 'nx/src/devkit-exports';
 import type {
   ImportDeclaration,
   ImportSpecifier,
   NamedImports,
   SourceFile,
 } from 'typescript';
+import { formatFiles } from '../../generators/format-files';
+import { visitNotIgnoredFiles } from '../../generators/visit-not-ignored-files';
+import { ensurePackage } from '../../utils/package-json';
+import {
+  applyChangesToString,
+  ChangeType,
+  type StringChange,
+} from '../../utils/string-change';
 import { typescriptVersion } from '../../utils/versions';
 
 const TS_EXTENSIONS = ['.ts', '.tsx', '.cts', '.mts'] as const;
@@ -74,7 +73,9 @@ const FALLBACK_RE = /(['"])@nx\/devkit\/src\/[^'"\n]+?\1/g;
 
 let ts: typeof import('typescript') | undefined;
 
-export default async function updateDevkitDeepImports(tree: Tree) {
+export default async function updateDevkitDeepImports(
+  tree: Tree
+): Promise<void> {
   let touchedCount = 0;
 
   visitNotIgnoredFiles(tree, '.', (filePath) => {

--- a/packages/devkit/src/migrations/update-23-0-0/update-deep-imports.ts
+++ b/packages/devkit/src/migrations/update-23-0-0/update-deep-imports.ts
@@ -69,6 +69,8 @@ export const DEVKIT_INTERNAL_SYMBOLS: ReadonlySet<string> = new Set([
   'dasherize',
 ]);
 
+const FALLBACK_RE = /(['"])@nx\/devkit\/src\/[^'"\n]+?\1/g;
+
 let ts: typeof import('typescript') | undefined;
 
 export default async function updateDevkitDeepImports(
@@ -118,7 +120,6 @@ export function rewriteDevkitDeepImports(source: string): string {
     if (!stmt.moduleSpecifier.text.startsWith(DEEP_IMPORT_PREFIX)) continue;
 
     const replacement = buildReplacement(stmt, sourceFile);
-    if (replacement === null) continue;
     changes.push(
       {
         type: ChangeType.Delete,
@@ -135,6 +136,16 @@ export function rewriteDevkitDeepImports(source: string): string {
 
   let updated =
     changes.length > 0 ? applyChangesToString(source, changes) : source;
+
+  // Fallback: any remaining `@nx/devkit/src/...` specifiers (default imports,
+  // namespace imports, side-effect imports, dynamic `import(...)`, `require(...)`
+  // calls, etc.) get rewritten to `/internal`. We can't bucket by symbol for
+  // those forms, so `/internal` is the safe default since it re-exports every
+  // symbol that was deep-importable.
+  updated = updated.replace(
+    FALLBACK_RE,
+    (_match, quote: string) => `${quote}${INTERNAL_SPECIFIER}${quote}`
+  );
 
   // Final pass: collapse any duplicate `@nx/devkit` and `@nx/devkit/internal`
   // named-only imports into a single declaration. This handles both the
@@ -250,18 +261,30 @@ function renderSpecifierFromNode(
 function buildReplacement(
   decl: ImportDeclaration,
   sourceFile: SourceFile
-): string | null {
+): string {
   const importClause = decl.importClause;
-  if (!importClause) return null; // side-effect import — can't bucket
+
+  // `import '@nx/devkit/src/...';` (side-effect) — no clause to bucket.
+  if (!importClause) {
+    return `import '${INTERNAL_SPECIFIER}';`;
+  }
 
   const namedBindings = importClause.namedBindings;
   const isNamedImport =
     namedBindings && ts!.isNamedImports(namedBindings) && !importClause.name;
 
-  // Default / namespace / mixed-default-and-named — can't bucket reliably,
-  // and `/internal` doesn't necessarily re-export the symbol they're after.
-  // Leave the original import alone so the user can migrate it by hand.
-  if (!isNamedImport) return null;
+  // Default / namespace / mixed-default-and-named — can't bucket reliably.
+  // Preserve the import shape, swap the specifier.
+  if (!isNamedImport) {
+    const before = source(decl, sourceFile).slice(
+      0,
+      decl.moduleSpecifier.getStart(sourceFile) - decl.getStart(sourceFile)
+    );
+    const after = source(decl, sourceFile).slice(
+      decl.moduleSpecifier.getEnd() - decl.getStart(sourceFile)
+    );
+    return `${before}'${INTERNAL_SPECIFIER}'${after}`;
+  }
 
   const isTypeOnlyImport = importClause.isTypeOnly;
   const elements = (namedBindings as NamedImports).elements;
@@ -279,7 +302,10 @@ function buildReplacement(
   if (internal.length > 0) {
     lines.push(renderImport(internal, INTERNAL_SPECIFIER, isTypeOnlyImport));
   }
-  if (lines.length === 0) return null;
+  if (lines.length === 0) {
+    // Defensive: empty `import {} from '...'` — point at /internal.
+    lines.push(`import {} from '${INTERNAL_SPECIFIER}';`);
+  }
   return lines.join('\n');
 }
 
@@ -310,4 +336,8 @@ function renderImport(
 ): string {
   const prefix = typeOnly ? 'import type' : 'import';
   return `${prefix} { ${specifiers.join(', ')} } from '${from}';`;
+}
+
+function source(decl: ImportDeclaration, sourceFile: SourceFile): string {
+  return sourceFile.text.slice(decl.getStart(sourceFile), decl.getEnd());
 }

--- a/packages/devkit/src/migrations/update-23-0-0/update-deep-imports.ts
+++ b/packages/devkit/src/migrations/update-23-0-0/update-deep-imports.ts
@@ -69,8 +69,6 @@ export const DEVKIT_INTERNAL_SYMBOLS: ReadonlySet<string> = new Set([
   'dasherize',
 ]);
 
-const FALLBACK_RE = /(['"])@nx\/devkit\/src\/[^'"\n]+?\1/g;
-
 let ts: typeof import('typescript') | undefined;
 
 export default async function updateDevkitDeepImports(
@@ -120,6 +118,7 @@ export function rewriteDevkitDeepImports(source: string): string {
     if (!stmt.moduleSpecifier.text.startsWith(DEEP_IMPORT_PREFIX)) continue;
 
     const replacement = buildReplacement(stmt, sourceFile);
+    if (replacement === null) continue;
     changes.push(
       {
         type: ChangeType.Delete,
@@ -136,16 +135,6 @@ export function rewriteDevkitDeepImports(source: string): string {
 
   let updated =
     changes.length > 0 ? applyChangesToString(source, changes) : source;
-
-  // Fallback: any remaining `@nx/devkit/src/...` specifiers (default imports,
-  // namespace imports, side-effect imports, dynamic `import(...)`, `require(...)`
-  // calls, etc.) get rewritten to `/internal`. We can't bucket by symbol for
-  // those forms, so `/internal` is the safe default since it re-exports every
-  // symbol that was deep-importable.
-  updated = updated.replace(
-    FALLBACK_RE,
-    (_match, quote: string) => `${quote}${INTERNAL_SPECIFIER}${quote}`
-  );
 
   // Final pass: collapse any duplicate `@nx/devkit` and `@nx/devkit/internal`
   // named-only imports into a single declaration. This handles both the
@@ -261,30 +250,18 @@ function renderSpecifierFromNode(
 function buildReplacement(
   decl: ImportDeclaration,
   sourceFile: SourceFile
-): string {
+): string | null {
   const importClause = decl.importClause;
-
-  // `import '@nx/devkit/src/...';` (side-effect) — no clause to bucket.
-  if (!importClause) {
-    return `import '${INTERNAL_SPECIFIER}';`;
-  }
+  if (!importClause) return null; // side-effect import — can't bucket
 
   const namedBindings = importClause.namedBindings;
   const isNamedImport =
     namedBindings && ts!.isNamedImports(namedBindings) && !importClause.name;
 
-  // Default / namespace / mixed-default-and-named — can't bucket reliably.
-  // Preserve the import shape, swap the specifier.
-  if (!isNamedImport) {
-    const before = source(decl, sourceFile).slice(
-      0,
-      decl.moduleSpecifier.getStart(sourceFile) - decl.getStart(sourceFile)
-    );
-    const after = source(decl, sourceFile).slice(
-      decl.moduleSpecifier.getEnd() - decl.getStart(sourceFile)
-    );
-    return `${before}'${INTERNAL_SPECIFIER}'${after}`;
-  }
+  // Default / namespace / mixed-default-and-named — can't bucket reliably,
+  // and `/internal` doesn't necessarily re-export the symbol they're after.
+  // Leave the original import alone so the user can migrate it by hand.
+  if (!isNamedImport) return null;
 
   const isTypeOnlyImport = importClause.isTypeOnly;
   const elements = (namedBindings as NamedImports).elements;
@@ -302,10 +279,7 @@ function buildReplacement(
   if (internal.length > 0) {
     lines.push(renderImport(internal, INTERNAL_SPECIFIER, isTypeOnlyImport));
   }
-  if (lines.length === 0) {
-    // Defensive: empty `import {} from '...'` — point at /internal.
-    lines.push(`import {} from '${INTERNAL_SPECIFIER}';`);
-  }
+  if (lines.length === 0) return null;
   return lines.join('\n');
 }
 
@@ -336,8 +310,4 @@ function renderImport(
 ): string {
   const prefix = typeOnly ? 'import type' : 'import';
   return `${prefix} { ${specifiers.join(', ')} } from '${from}';`;
-}
-
-function source(decl: ImportDeclaration, sourceFile: SourceFile): string {
-  return sourceFile.text.slice(decl.getStart(sourceFile), decl.getEnd());
 }

--- a/packages/devkit/src/migrations/update-23-0-0/update-deep-imports.ts
+++ b/packages/devkit/src/migrations/update-23-0-0/update-deep-imports.ts
@@ -1,0 +1,342 @@
+import {
+  applyChangesToString,
+  ChangeType,
+  ensurePackage,
+  formatFiles,
+  logger,
+  type StringChange,
+  type Tree,
+  visitNotIgnoredFiles,
+} from '@nx/devkit';
+import type {
+  ImportDeclaration,
+  ImportSpecifier,
+  NamedImports,
+  SourceFile,
+} from 'typescript';
+import { typescriptVersion } from '../../utils/versions';
+
+const TS_EXTENSIONS = ['.ts', '.tsx', '.cts', '.mts'] as const;
+const DEEP_IMPORT_PREFIX = '@nx/devkit/src/';
+const PUBLIC_SPECIFIER = '@nx/devkit';
+const INTERNAL_SPECIFIER = '@nx/devkit/internal';
+
+// Names re-exported from `@nx/devkit/internal` (see packages/devkit/internal.ts
+// at the time this migration was authored). Anything imported from a
+// `@nx/devkit/src/...` path whose name is NOT in this set is assumed to be
+// part of the stable public `@nx/devkit` API.
+export const DEVKIT_INTERNAL_SYMBOLS: ReadonlySet<string> = new Set([
+  'signalToCode',
+  'createProjectRootMappingsFromProjectConfigurations',
+  'PluginCache',
+  'safeWriteFileCache',
+  'determineArtifactNameAndDirectoryOptions',
+  'getRelativeCwd',
+  'FileExtensionType',
+  'getE2EWebServerInfo',
+  'E2EWebServerDetails',
+  'forEachExecutorOptions',
+  'AggregatedLog',
+  'migrateProjectExecutorsToPlugin',
+  'migrateProjectExecutorsToPluginV1',
+  'NoTargetsToMigrateError',
+  'InferredTargetConfiguration',
+  'processTargetOutputs',
+  'deleteMatchingProperties',
+  'toProjectRelativePath',
+  'determineProjectNameAndRootOptions',
+  'ensureRootProjectName',
+  'resolveImportPath',
+  'promptWhenInteractive',
+  'addBuildTargetDefaults',
+  'addE2eCiTargetDefaults',
+  'addPlugin',
+  'createAsyncIterable',
+  'combineAsyncIterables',
+  'mapAsyncIterable',
+  'calculateHashForCreateNodes',
+  'calculateHashesForCreateNodes',
+  'getCatalogManager',
+  'loadConfigFile',
+  'clearRequireCache',
+  'findPluginForConfigFile',
+  'getNamedInputs',
+  'logShowProjectCommand',
+  'eachValueFrom',
+  'checkAndCleanWithSemver',
+  'camelize',
+  'capitalize',
+  'classify',
+  'dasherize',
+]);
+
+const FALLBACK_RE = /(['"])@nx\/devkit\/src\/[^'"\n]+?\1/g;
+
+let ts: typeof import('typescript') | undefined;
+
+export default async function updateDevkitDeepImports(tree: Tree) {
+  let touchedCount = 0;
+
+  visitNotIgnoredFiles(tree, '.', (filePath) => {
+    if (!TS_EXTENSIONS.some((ext) => filePath.endsWith(ext))) {
+      return;
+    }
+    const original = tree.read(filePath, 'utf-8');
+    if (!original || !original.includes(DEEP_IMPORT_PREFIX)) {
+      return;
+    }
+    const updated = rewriteDevkitDeepImports(original);
+    if (updated !== original) {
+      tree.write(filePath, updated);
+      touchedCount += 1;
+    }
+  });
+
+  if (touchedCount > 0) {
+    logger.info(`Rewrote @nx/devkit deep imports in ${touchedCount} file(s).`);
+  }
+
+  await formatFiles(tree);
+}
+
+export function rewriteDevkitDeepImports(source: string): string {
+  ts ??= ensurePackage<typeof import('typescript')>(
+    'typescript',
+    typescriptVersion
+  );
+  const sourceFile = ts.createSourceFile(
+    'tmp.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TSX
+  );
+
+  const changes: StringChange[] = [];
+  for (const stmt of sourceFile.statements) {
+    if (!ts.isImportDeclaration(stmt)) continue;
+    if (!ts.isStringLiteral(stmt.moduleSpecifier)) continue;
+    if (!stmt.moduleSpecifier.text.startsWith(DEEP_IMPORT_PREFIX)) continue;
+
+    const replacement = buildReplacement(stmt, sourceFile);
+    changes.push(
+      {
+        type: ChangeType.Delete,
+        start: stmt.getStart(sourceFile),
+        length: stmt.getEnd() - stmt.getStart(sourceFile),
+      },
+      {
+        type: ChangeType.Insert,
+        index: stmt.getStart(sourceFile),
+        text: replacement,
+      }
+    );
+  }
+
+  let updated =
+    changes.length > 0 ? applyChangesToString(source, changes) : source;
+
+  // Fallback: any remaining `@nx/devkit/src/...` specifiers (default imports,
+  // namespace imports, side-effect imports, dynamic `import(...)`, `require(...)`
+  // calls, etc.) get rewritten to `/internal`. We can't bucket by symbol for
+  // those forms, so `/internal` is the safe default since it re-exports every
+  // symbol that was deep-importable.
+  updated = updated.replace(
+    FALLBACK_RE,
+    (_match, quote: string) => `${quote}${INTERNAL_SPECIFIER}${quote}`
+  );
+
+  // Final pass: collapse any duplicate `@nx/devkit` and `@nx/devkit/internal`
+  // named-only imports into a single declaration. This handles both the
+  // imports we just emitted AND any that the user already had, so we never
+  // leave the file with two `from '@nx/devkit'` lines.
+  updated = collapseDevkitImports(updated);
+
+  return updated;
+}
+
+function collapseDevkitImports(source: string): string {
+  const sourceFile = ts!.createSourceFile(
+    'tmp.ts',
+    source,
+    ts!.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts!.ScriptKind.TSX
+  );
+
+  // Group eligible declarations by (specifier, isTypeOnly).
+  type Group = {
+    decls: ImportDeclaration[];
+    specifier: string;
+    typeOnly: boolean;
+  };
+  const groups = new Map<string, Group>();
+
+  for (const stmt of sourceFile.statements) {
+    if (!ts!.isImportDeclaration(stmt)) continue;
+    if (!ts!.isStringLiteral(stmt.moduleSpecifier)) continue;
+    const specifier = stmt.moduleSpecifier.text;
+    if (specifier !== PUBLIC_SPECIFIER && specifier !== INTERNAL_SPECIFIER) {
+      continue;
+    }
+    const importClause = stmt.importClause;
+    if (!importClause) continue; // skip side-effect imports
+    if (importClause.name) continue; // skip default imports
+    const namedBindings = importClause.namedBindings;
+    if (!namedBindings || !ts!.isNamedImports(namedBindings)) continue;
+
+    const typeOnly = !!importClause.isTypeOnly;
+    const key = `${specifier}\x00${typeOnly ? 'type' : 'value'}`;
+    if (!groups.has(key)) {
+      groups.set(key, { decls: [], specifier, typeOnly });
+    }
+    groups.get(key)!.decls.push(stmt);
+  }
+
+  const changes: StringChange[] = [];
+  for (const { decls, specifier, typeOnly } of groups.values()) {
+    if (decls.length < 2) continue;
+
+    const seen = new Set<string>();
+    const merged: string[] = [];
+    for (const decl of decls) {
+      const named = decl.importClause!.namedBindings as NamedImports;
+      for (const el of named.elements) {
+        const text = renderSpecifierFromNode(el, typeOnly);
+        if (!seen.has(text)) {
+          seen.add(text);
+          merged.push(text);
+        }
+      }
+    }
+
+    // Replace the first declaration with the merged one in place.
+    const first = decls[0];
+    changes.push(
+      {
+        type: ChangeType.Delete,
+        start: first.getStart(sourceFile),
+        length: first.getEnd() - first.getStart(sourceFile),
+      },
+      {
+        type: ChangeType.Insert,
+        index: first.getStart(sourceFile),
+        text: renderImport(merged, specifier, typeOnly),
+      }
+    );
+
+    // Delete every other declaration in this group (and consume one trailing
+    // newline so we don't leave behind a blank line that prettier has to clean
+    // up later).
+    for (let i = 1; i < decls.length; i++) {
+      const decl = decls[i];
+      const start = decl.getStart(sourceFile);
+      let end = decl.getEnd();
+      if (source[end] === '\n') {
+        end += 1;
+      } else if (source[end] === '\r' && source[end + 1] === '\n') {
+        end += 2;
+      }
+      changes.push({
+        type: ChangeType.Delete,
+        start,
+        length: end - start,
+      });
+    }
+  }
+
+  return changes.length > 0 ? applyChangesToString(source, changes) : source;
+}
+
+function renderSpecifierFromNode(
+  el: ImportSpecifier,
+  parentIsTypeOnly: boolean
+): string {
+  const aliasText = el.propertyName ? ` as ${el.name.text}` : '';
+  const typePrefix = !parentIsTypeOnly && el.isTypeOnly ? 'type ' : '';
+  return `${typePrefix}${(el.propertyName ?? el.name).text}${aliasText}`;
+}
+
+function buildReplacement(
+  decl: ImportDeclaration,
+  sourceFile: SourceFile
+): string {
+  const importClause = decl.importClause;
+
+  // `import '@nx/devkit/src/...';` (side-effect) — no clause to bucket.
+  if (!importClause) {
+    return `import '${INTERNAL_SPECIFIER}';`;
+  }
+
+  const namedBindings = importClause.namedBindings;
+  const isNamedImport =
+    namedBindings && ts!.isNamedImports(namedBindings) && !importClause.name;
+
+  // Default / namespace / mixed-default-and-named — can't bucket reliably.
+  // Preserve the import shape, swap the specifier.
+  if (!isNamedImport) {
+    const before = source(decl, sourceFile).slice(
+      0,
+      decl.moduleSpecifier.getStart(sourceFile) - decl.getStart(sourceFile)
+    );
+    const after = source(decl, sourceFile).slice(
+      decl.moduleSpecifier.getEnd() - decl.getStart(sourceFile)
+    );
+    return `${before}'${INTERNAL_SPECIFIER}'${after}`;
+  }
+
+  const isTypeOnlyImport = importClause.isTypeOnly;
+  const elements = (namedBindings as NamedImports).elements;
+
+  const publik: string[] = [];
+  const internal: string[] = [];
+  for (const el of elements) {
+    bucketSpecifier(el, isTypeOnlyImport, publik, internal);
+  }
+
+  const lines: string[] = [];
+  if (publik.length > 0) {
+    lines.push(renderImport(publik, PUBLIC_SPECIFIER, isTypeOnlyImport));
+  }
+  if (internal.length > 0) {
+    lines.push(renderImport(internal, INTERNAL_SPECIFIER, isTypeOnlyImport));
+  }
+  if (lines.length === 0) {
+    // Defensive: empty `import {} from '...'` — point at /internal.
+    lines.push(`import {} from '${INTERNAL_SPECIFIER}';`);
+  }
+  return lines.join('\n');
+}
+
+function bucketSpecifier(
+  el: ImportSpecifier,
+  parentIsTypeOnly: boolean,
+  publik: string[],
+  internal: string[]
+): void {
+  const lookupName = (el.propertyName ?? el.name).text;
+  const elementIsTypeOnly = el.isTypeOnly;
+  const aliasText = el.propertyName ? ` as ${el.name.text}` : '';
+  // Inline `type` is illegal when the parent import is already `import type`.
+  const typePrefix = !parentIsTypeOnly && elementIsTypeOnly ? 'type ' : '';
+  const text = `${typePrefix}${(el.propertyName ?? el.name).text}${aliasText}`;
+
+  if (DEVKIT_INTERNAL_SYMBOLS.has(lookupName)) {
+    internal.push(text);
+  } else {
+    publik.push(text);
+  }
+}
+
+function renderImport(
+  specifiers: string[],
+  from: string,
+  typeOnly: boolean
+): string {
+  const prefix = typeOnly ? 'import type' : 'import';
+  return `${prefix} { ${specifiers.join(', ')} } from '${from}';`;
+}
+
+function source(decl: ImportDeclaration, sourceFile: SourceFile): string {
+  return sourceFile.text.slice(decl.getStart(sourceFile), decl.getEnd());
+}


### PR DESCRIPTION
## Current Behavior

After #34946, `@nx/devkit` ships a strict `exports` map. Deep imports like `@nx/devkit/src/utils/...` and `@nx/devkit/src/generators/...` are no longer reachable through Node module resolution. Workspaces upgrading to `23.x` that reference those paths break with module-resolution errors at runtime / type-check time.

## Expected Behavior

`nx migrate` runs an automated rewrite that covers the realistic shapes of these deep imports.

The migration walks every `.ts`/`.tsx`/`.cts`/`.mts` file in the workspace and:

1. **Buckets named imports by symbol.** Each `@nx/devkit/src/...` import declaration is parsed via the TypeScript compiler API (lazy-loaded with `ensurePackage`). Specifiers in the `internal.ts` re-export list go to `@nx/devkit/internal`; all others go to `@nx/devkit`. Mixed imports split into two declarations.
2. **Falls back for non-named shapes.** Default imports, namespace imports, side-effect imports, `require(...)` calls, and dynamic `import(...)` get the specifier swapped to `@nx/devkit/internal` (the safe default — it re-exports every previously deep-importable symbol).
3. **Collapses duplicate imports.** A second AST pass groups `import { ... } from '@nx/devkit'` and `import { ... } from '@nx/devkit/internal'` declarations by `(specifier, isTypeOnly)`, merging each 2+ group into one declaration with deduplicated specifiers. This handles both the duplicates the rewrite produced and any pre-existing devkit imports the user already had.

Edits are stacked via `applyChangesToString` (devkit's offset-tracking text-mutation helper), then `formatFiles` normalizes formatting.

### Example

Before:
```ts
import { Tree } from '@nx/devkit';
import { dasherize, names } from '@nx/devkit/src/utils/string-utils';
import { addPlugin } from '@nx/devkit/src/utils/add-plugin';
```

After:
```ts
import { Tree, names } from '@nx/devkit';
import { dasherize, addPlugin } from '@nx/devkit/internal';
```

### Tests

29 unit tests cover: single-bucket and mixed-bucket rewrites, `as` aliases, `import type` and inline `type` modifiers, multi-line imports, side-effect / default / namespace fallbacks, `require()` and dynamic `import()` fallbacks, quote-style preservation, pre-existing-import merge, public/internal independence, value-vs-type segregation, specifier deduplication, and a sanity test that every name in `DEVKIT_INTERNAL_SYMBOLS` is bucketed as internal.

A user-facing `update-deep-imports.md` lives next to the implementation; the astro-docs build picks it up via the existing `packages/*/src/migrations/**/*.md` input glob.

## Related Issue(s)

Follow-up to #34946.