### PR TITLE
fix(devkit): drop build-base outputs override

### DIFF
--- a/.claude/skills/dist-build-migration/SKILL.md
+++ b/.claude/skills/dist-build-migration/SKILL.md
@@ -156,17 +156,12 @@ Add these sections:
       "options": {
         "packageRoot": "packages/{projectName}"
       }
-    },
-    "build-base": {
-      "outputs": [
-        "{projectRoot}/dist/**/*.{js,cjs,mjs,d.ts}",
-        "{projectRoot}/*.d.ts",
-        "{projectRoot}/src/**/*.d.ts"
-      ]
     }
   }
 }
 ```
+
+Do **not** override `build-base.outputs` in `project.json`. The `@nx/js/typescript` plugin reads `outDir` and `tsBuildInfoFile` from `tsconfig.lib.json` and infers the correct outputs (including the tsbuildinfo and the full set of file extensions). A hand-written override is almost always less complete than the inferred set.
 
 Update the existing `build` target's `outputs` if they reference `{workspaceRoot}/dist/packages/<name>` — they should now reference `{projectRoot}/dist/`.
 

--- a/packages/devkit/project.json
+++ b/packages/devkit/project.json
@@ -16,13 +16,6 @@
         "packageRoot": "packages/{projectName}"
       }
     },
-    "build-base": {
-      "outputs": [
-        "{projectRoot}/dist/**/*.{js,cjs,mjs,d.ts}",
-        "{projectRoot}/*.d.ts",
-        "{projectRoot}/src/**/*.d.ts"
-      ]
-    },
     "build": {
       "outputs": ["{projectRoot}/README.md"],
       "command": "node ./scripts/copy-readme.js devkit packages/devkit/readme-template.md packages/devkit/README.md",


### PR DESCRIPTION
## Current Behavior

`@nx/devkit`'s `build-base` target overrode `outputs` in `project.json`:

```json
"outputs": [
  "{projectRoot}/dist/**/*.{js,cjs,mjs,d.ts}",
  "{projectRoot}/*.d.ts",
  "{projectRoot}/src/**/*.d.ts"
]
```

This override is missing `tsconfig.tsbuildinfo`. Any downstream task whose inputs include `dependentTasksOutputFiles: "**/*.{d.ts,d.cts,d.mts,tsbuildinfo}"` (e.g. `docker:build-base`) trips a sandbox violation: when `tsc --build` walks project references it reads devkit's tsbuildinfo, but Nx never registered that file as a dep output, so the read isn't covered by any declared input.

The same gap exists in the `dist-build-migration` Claude skill, so every package migrated with that playbook would reproduce the violation.

Sandbox report that surfaced this: https://staging.nx.app/runs/HNBpzgdeNi/task/docker%3Abuild-base/sandbox-report-raw?sandboxReportId=10b903d8-b860-41c7-80b2-756b0541e690

## Expected Behavior

Drop the override entirely. The `@nx/js/typescript` plugin already reads `outDir` and `tsBuildInfoFile` from `tsconfig.lib.json` and infers a strictly more complete set of outputs:

```
{projectRoot}/dist/**/*.{js,cjs,mjs,jsx,json,d.ts,d.cts,d.mts}{,.map}
{projectRoot}/dist/tsconfig.tsbuildinfo
```

The inferred set picks up the tsbuildinfo plus `.cjs`/`.mjs`/`.json`/`.d.cts`/`.d.mts`/`.map` that the manual override was missing. Verified the violation is resolved:

```
$ pnpm nx show target inputs docker:build-base --check packages/devkit/dist/tsconfig.tsbuildinfo
✓ packages/devkit/dist/tsconfig.tsbuildinfo is an input for docker:build-base (depOutputs)
```

The `dist-build-migration` skill is updated to tell future migrations to leave `build-base.outputs` to the plugin.

## Related Issue(s)

Follow-up to #34946.