### PR TITLE
fix(misc): adopt PluginCache across createNodes plugins to prevent flaky cache parse errors

### DIFF
--- a/packages/angular/src/plugins/plugin.ts
+++ b/packages/angular/src/plugins/plugin.ts
@@ -1,6 +1,7 @@
 import {
   calculateHashForCreateNodes,
   getNamedInputs,
+  PluginCache,
 } from '@nx/devkit/internal';
 import {
   type CreateNodesContextV2,
@@ -13,7 +14,6 @@ import {
   readJsonFile,
   type Target,
   type TargetConfiguration,
-  writeJsonFile,
 } from '@nx/devkit';
 import { getLockFileName } from '@nx/js';
 import { existsSync, readdirSync, statSync } from 'node:fs';
@@ -82,17 +82,6 @@ const knownExecutors = {
   ]),
 };
 
-function readProjectsCache(cachePath: string): Record<string, AngularProjects> {
-  return existsSync(cachePath) ? readJsonFile(cachePath) : {};
-}
-
-function writeProjectsToCache(
-  cachePath: string,
-  results: Record<string, AngularProjects>
-) {
-  writeJsonFile(cachePath, results);
-}
-
 export const createNodesV2: CreateNodesV2<AngularPluginOptions> = [
   '**/angular.json',
   async (configFiles, options, context) => {
@@ -101,7 +90,7 @@ export const createNodesV2: CreateNodesV2<AngularPluginOptions> = [
       workspaceDataDirectory,
       `angular-${optionsHash}.hash`
     );
-    const projectsCache = readProjectsCache(cachePath);
+    const projectsCache = new PluginCache<AngularProjects>(cachePath);
     const pmc = getPackageManagerCommand(
       detectPackageManager(context.workspaceRoot)
     );
@@ -114,7 +103,7 @@ export const createNodesV2: CreateNodesV2<AngularPluginOptions> = [
         context
       );
     } finally {
-      writeProjectsToCache(cachePath, projectsCache);
+      projectsCache.writeToDisk(cachePath);
     }
   },
 ];
@@ -123,7 +112,7 @@ async function createNodesInternal(
   configFilePath: string,
   options: {} | undefined,
   context: CreateNodesContextV2,
-  projectsCache: Record<string, AngularProjects>,
+  projectsCache: PluginCache<AngularProjects>,
   pmc: ReturnType<typeof getPackageManagerCommand>
 ): Promise<CreateNodesResult> {
   const angularWorkspaceRoot = dirname(configFilePath);
@@ -143,15 +132,20 @@ async function createNodesInternal(
     [getLockFileName(detectPackageManager(context.workspaceRoot))]
   );
 
-  projectsCache[hash] ??= await buildAngularProjects(
-    configFilePath,
-    options,
-    angularWorkspaceRoot,
-    context,
-    pmc
-  );
+  if (!projectsCache.has(hash)) {
+    projectsCache.set(
+      hash,
+      await buildAngularProjects(
+        configFilePath,
+        options,
+        angularWorkspaceRoot,
+        context,
+        pmc
+      )
+    );
+  }
 
-  return { projects: projectsCache[hash] };
+  return { projects: projectsCache.get(hash) };
 }
 
 async function buildAngularProjects(

--- a/packages/detox/src/plugins/plugin.ts
+++ b/packages/detox/src/plugins/plugin.ts
@@ -1,6 +1,7 @@
 import {
   getNamedInputs,
   calculateHashForCreateNodes,
+  PluginCache,
 } from '@nx/devkit/internal';
 import {
   CreateNodesContextV2,
@@ -10,13 +11,10 @@ import {
   detectPackageManager,
   getPackageManagerCommand,
   NxJsonConfiguration,
-  readJsonFile,
   TargetConfiguration,
-  writeJsonFile,
 } from '@nx/devkit';
 import { dirname, join } from 'path';
 import { getLockFileName } from '@nx/js';
-import { existsSync } from 'fs';
 import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
 import { hashObject } from 'nx/src/devkit-internals';
 import { addBuildAndWatchDepsTargets } from '@nx/js/src/plugins/typescript/util';
@@ -29,32 +27,14 @@ export interface DetoxPluginOptions {
   watchDepsTargetName?: string;
 }
 
-function readTargetsCache(
-  cachePath: string
-): Record<string, Record<string, TargetConfiguration<DetoxPluginOptions>>> {
-  return existsSync(cachePath) ? readJsonFile(cachePath) : {};
-}
-
-function writeTargetsToCache(
-  cachePath: string,
-  targetsCache: Record<
-    string,
-    Record<string, TargetConfiguration<DetoxPluginOptions>>
-  >
-) {
-  const oldCache = readTargetsCache(cachePath);
-  writeJsonFile(cachePath, {
-    ...oldCache,
-    targetsCache,
-  });
-}
+type DetoxTargets = Record<string, TargetConfiguration<DetoxPluginOptions>>;
 
 export const createNodes: CreateNodesV2<DetoxPluginOptions> = [
   '**/{detox.config,.detoxrc}.{json,js}',
   async (configFiles, options, context) => {
     const optionsHash = hashObject(options);
-    const cachePath = join(workspaceDataDirectory, `expo-${optionsHash}.hash`);
-    const targetsCache = readTargetsCache(cachePath);
+    const cachePath = join(workspaceDataDirectory, `detox-${optionsHash}.hash`);
+    const targetsCache = new PluginCache<DetoxTargets>(cachePath);
     const pmc = getPackageManagerCommand(
       detectPackageManager(context.workspaceRoot)
     );
@@ -68,7 +48,7 @@ export const createNodes: CreateNodesV2<DetoxPluginOptions> = [
         context
       );
     } finally {
-      writeTargetsToCache(cachePath, targetsCache);
+      targetsCache.writeToDisk(cachePath);
     }
   },
 ];
@@ -79,10 +59,7 @@ async function createNodesInternal(
   configFile: string,
   options: DetoxPluginOptions,
   context: CreateNodesContextV2,
-  targetsCache: Record<
-    string,
-    Record<string, TargetConfiguration<DetoxPluginOptions>>
-  >,
+  targetsCache: PluginCache<DetoxTargets>,
   pmc: ReturnType<typeof getPackageManagerCommand>
 ): Promise<CreateNodesResult> {
   options = normalizeOptions(options);
@@ -95,12 +72,17 @@ async function createNodesInternal(
     [getLockFileName(detectPackageManager(context.workspaceRoot))]
   );
 
-  targetsCache[hash] ??= buildDetoxTargets(projectRoot, options, context, pmc);
+  if (!targetsCache.has(hash)) {
+    targetsCache.set(
+      hash,
+      buildDetoxTargets(projectRoot, options, context, pmc)
+    );
+  }
 
   return {
     projects: {
       [projectRoot]: {
-        targets: targetsCache[hash],
+        targets: targetsCache.get(hash),
       },
     },
   };

--- a/packages/docker/src/plugins/plugin.ts
+++ b/packages/docker/src/plugins/plugin.ts
@@ -1,6 +1,7 @@
 import {
   calculateHashesForCreateNodes,
   getNamedInputs,
+  PluginCache,
 } from '@nx/devkit/internal';
 import {
   type CreateNodesV2,
@@ -8,7 +9,6 @@ import {
   type TargetConfiguration,
   createNodesFromFiles,
   readJsonFile,
-  writeJsonFile,
   CreateNodesContextV2,
   workspaceRoot,
 } from '@nx/devkit';
@@ -54,17 +54,6 @@ interface NormalizedDockerPluginOptions {
 
 type DockerTargets = Pick<ProjectConfiguration, 'targets' | 'metadata'>;
 
-function readTargetsCache(cachePath: string): Record<string, DockerTargets> {
-  return existsSync(cachePath) ? readJsonFile(cachePath) : {};
-}
-
-function writeTargetsCache(
-  cachePath: string,
-  results?: Record<string, DockerTargets>
-) {
-  writeJsonFile(cachePath, results ?? {});
-}
-
 const dockerfileGlob = '**/Dockerfile';
 
 export const createNodesV2: CreateNodesV2<DockerPluginOptions> = [
@@ -75,7 +64,7 @@ export const createNodesV2: CreateNodesV2<DockerPluginOptions> = [
       workspaceDataDirectory,
       `docker-${optionsHash}.hash`
     );
-    const targetsCache = readTargetsCache(cachePath);
+    const targetsCache = new PluginCache<DockerTargets>(cachePath);
     const projectRoots = configFilePaths.map((c) => dirname(c));
     const normalizedOptions = normalizePluginOptions(options);
     // TODO(colum): investigate hashing only the dockerfile
@@ -99,7 +88,7 @@ export const createNodesV2: CreateNodesV2<DockerPluginOptions> = [
         context
       );
     } finally {
-      writeTargetsCache(cachePath, targetsCache);
+      targetsCache.writeToDisk(cachePath);
     }
   },
 ];
@@ -109,17 +98,18 @@ async function createNodesInternal(
   hash: string,
   normalizedOptions: NormalizedDockerPluginOptions,
   context: CreateNodesContextV2,
-  targetsCache: Record<string, DockerTargets>
+  targetsCache: PluginCache<DockerTargets>
 ) {
   const projectRoot = dirname(configFilePath);
 
-  targetsCache[hash] ??= await createDockerTargets(
-    projectRoot,
-    normalizedOptions,
-    context
-  );
+  if (!targetsCache.has(hash)) {
+    targetsCache.set(
+      hash,
+      await createDockerTargets(projectRoot, normalizedOptions, context)
+    );
+  }
 
-  const { targets, metadata } = targetsCache[hash];
+  const { targets, metadata } = targetsCache.get(hash);
 
   return {
     projects: {

--- a/packages/eslint/src/plugins/plugin.ts
+++ b/packages/eslint/src/plugins/plugin.ts
@@ -1,4 +1,7 @@
-import { calculateHashesForCreateNodes } from '@nx/devkit/internal';
+import {
+  calculateHashesForCreateNodes,
+  PluginCache,
+} from '@nx/devkit/internal';
 import {
   CreateNodesContextV2,
   createNodesFromFiles,
@@ -6,9 +9,7 @@ import {
   CreateNodesV2,
   detectPackageManager,
   getPackageManagerCommand,
-  readJsonFile,
   TargetConfiguration,
-  writeJsonFile,
 } from '@nx/devkit';
 import { getLockFileName, getRootTsConfigFileName } from '@nx/js';
 import {
@@ -55,20 +56,7 @@ const ESLINT_CONFIG_GLOB_V2 = combineGlobPatterns([
   ...PROJECT_CONFIG_FILENAMES.map((f) => `**/${f}`),
 ]);
 
-function readTargetsCache(
-  cachePath: string
-): Record<string, CreateNodesResult['projects']> {
-  return process.env.NX_CACHE_PROJECT_GRAPH !== 'false' && existsSync(cachePath)
-    ? readJsonFile(cachePath)
-    : {};
-}
-
-function writeTargetsToCache(
-  cachePath: string,
-  results: Record<string, CreateNodesResult['projects']>
-) {
-  writeJsonFile(cachePath, results);
-}
+type EslintProjects = CreateNodesResult['projects'];
 
 const internalCreateNodesV2 = async (
   ESLint: typeof ESLintType,
@@ -78,7 +66,7 @@ const internalCreateNodesV2 = async (
   projectRootsByEslintRoots: Map<string, string[]>,
   lintableFilesPerProjectRoot: Map<string, string[]>,
   tsconfigChainsByProjectRoot: Map<string, string[]>,
-  projectsCache: Record<string, CreateNodesResult['projects']>,
+  projectsCache: PluginCache<EslintProjects>,
   hashByRoot: Map<string, string>,
   pmc: ReturnType<typeof getPackageManagerCommand>
 ): Promise<CreateNodesResult> => {
@@ -101,9 +89,10 @@ const internalCreateNodesV2 = async (
     projectRootsByEslintRoots.get(configDir).map(async (projectRoot) => {
       const hash = hashByRoot.get(projectRoot);
 
-      if (projectsCache[hash]) {
+      const cached = projectsCache.get(hash);
+      if (cached) {
         // We can reuse the projects in the cache.
-        Object.assign(projects, projectsCache[hash]);
+        Object.assign(projects, cached);
         return;
       }
 
@@ -124,7 +113,7 @@ const internalCreateNodesV2 = async (
 
       if (!hasNonIgnoredLintableFiles) {
         // No lintable files in the project, store in the cache and skip further processing
-        projectsCache[hash] = {};
+        projectsCache.set(hash, {});
         return;
       }
 
@@ -141,10 +130,10 @@ const internalCreateNodesV2 = async (
       if (project) {
         projects[projectRoot] = project;
         // Store project into the cache
-        projectsCache[hash] = { [projectRoot]: project };
+        projectsCache.set(hash, { [projectRoot]: project });
       } else {
         // No project found, store in the cache
-        projectsCache[hash] = {};
+        projectsCache.set(hash, {});
       }
     })
   );
@@ -166,7 +155,7 @@ export const createNodes: CreateNodesV2<EslintPluginOptions> = [
       workspaceDataDirectory,
       `eslint-${optionsHash}.hash`
     );
-    const targetsCache = readTargetsCache(cachePath);
+    const targetsCache = new PluginCache<EslintProjects>(cachePath);
 
     const { eslintConfigFiles, projectRoots, projectRootsByEslintRoots } =
       splitConfigFiles(configFiles);
@@ -235,7 +224,7 @@ export const createNodes: CreateNodesV2<EslintPluginOptions> = [
         context
       );
     } finally {
-      writeTargetsToCache(cachePath, targetsCache);
+      targetsCache.writeToDisk(cachePath);
     }
   },
 ];

--- a/packages/expo/plugins/plugin.ts
+++ b/packages/expo/plugins/plugin.ts
@@ -2,6 +2,7 @@ import {
   getNamedInputs,
   calculateHashForCreateNodes,
   loadConfigFile,
+  PluginCache,
 } from '@nx/devkit/internal';
 import {
   CreateNodesContextV2,
@@ -13,11 +14,10 @@ import {
   NxJsonConfiguration,
   readJsonFile,
   TargetConfiguration,
-  writeJsonFile,
 } from '@nx/devkit';
 import { dirname, join } from 'path';
 import { getLockFileName } from '@nx/js';
-import { existsSync, readdirSync } from 'fs';
+import { readdirSync } from 'fs';
 import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
 import { hashObject } from 'nx/src/devkit-internals';
 import { addBuildAndWatchDepsTargets } from '@nx/js/src/plugins/typescript/util';
@@ -36,32 +36,14 @@ export interface ExpoPluginOptions {
   watchDepsTargetName?: string;
 }
 
-function readTargetsCache(
-  cachePath: string
-): Record<string, Record<string, TargetConfiguration<ExpoPluginOptions>>> {
-  return existsSync(cachePath) ? readJsonFile(cachePath) : {};
-}
-
-function writeTargetsToCache(
-  cachePath: string,
-  targetsCache: Record<
-    string,
-    Record<string, TargetConfiguration<ExpoPluginOptions>>
-  >
-) {
-  const oldCache = readTargetsCache(cachePath);
-  writeJsonFile(cachePath, {
-    ...oldCache,
-    targetsCache,
-  });
-}
+type ExpoTargets = Record<string, TargetConfiguration<ExpoPluginOptions>>;
 
 export const createNodes: CreateNodesV2<ExpoPluginOptions> = [
   '**/app.{json,config.js,config.ts}',
   async (configFiles, options, context) => {
     const optionsHash = hashObject(options);
     const cachePath = join(workspaceDataDirectory, `expo-${optionsHash}.hash`);
-    const targetsCache = readTargetsCache(cachePath);
+    const targetsCache = new PluginCache<ExpoTargets>(cachePath);
     const pmc = getPackageManagerCommand(
       detectPackageManager(context.workspaceRoot)
     );
@@ -75,7 +57,7 @@ export const createNodes: CreateNodesV2<ExpoPluginOptions> = [
         context
       );
     } finally {
-      writeTargetsToCache(cachePath, targetsCache);
+      targetsCache.writeToDisk(cachePath);
     }
   },
 ];
@@ -86,10 +68,7 @@ async function createNodesInternal(
   configFile: string,
   options: ExpoPluginOptions,
   context: CreateNodesContextV2,
-  targetsCache: Record<
-    string,
-    Record<string, TargetConfiguration<ExpoPluginOptions>>
-  >,
+  targetsCache: PluginCache<ExpoTargets>,
   pmc: ReturnType<typeof getPackageManagerCommand>
 ): Promise<CreateNodesResult> {
   options = normalizeOptions(options);
@@ -124,12 +103,17 @@ async function createNodesInternal(
     [getLockFileName(detectPackageManager(context.workspaceRoot))]
   );
 
-  targetsCache[hash] ??= buildExpoTargets(projectRoot, options, context, pmc);
+  if (!targetsCache.has(hash)) {
+    targetsCache.set(
+      hash,
+      buildExpoTargets(projectRoot, options, context, pmc)
+    );
+  }
 
   return {
     projects: {
       [projectRoot]: {
-        targets: targetsCache[hash],
+        targets: targetsCache.get(hash),
       },
     },
   };

--- a/packages/jest/src/plugins/plugin.ts
+++ b/packages/jest/src/plugins/plugin.ts
@@ -3,6 +3,7 @@ import {
   clearRequireCache,
   loadConfigFile,
   getNamedInputs,
+  PluginCache,
 } from '@nx/devkit/internal';
 import {
   CreateNodesContextV2,
@@ -14,9 +15,7 @@ import {
   normalizePath,
   NxJsonConfiguration,
   ProjectConfiguration,
-  readJsonFile,
   TargetConfiguration,
-  writeJsonFile,
 } from '@nx/devkit';
 import { minimatch } from 'minimatch';
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
@@ -77,19 +76,6 @@ type IsolatedModulesResult = {
 
 type JestTargets = Awaited<ReturnType<typeof buildJestTargets>>;
 
-function readTargetsCache(cachePath: string): Record<string, JestTargets> {
-  return process.env.NX_CACHE_PROJECT_GRAPH !== 'false' && existsSync(cachePath)
-    ? readJsonFile(cachePath)
-    : {};
-}
-
-function writeTargetsToCache(
-  cachePath: string,
-  results: Record<string, JestTargets>
-) {
-  writeJsonFile(cachePath, results);
-}
-
 const jestConfigGlob = '**/jest.config.{cjs,mjs,js,cts,mts,ts}';
 
 export const createNodes: CreateNodesV2<JestPluginOptions> = [
@@ -97,7 +83,7 @@ export const createNodes: CreateNodesV2<JestPluginOptions> = [
   async (configFiles, options, context) => {
     const optionsHash = hashObject(options);
     const cachePath = join(workspaceDataDirectory, `jest-${optionsHash}.hash`);
-    const targetsCache = readTargetsCache(cachePath);
+    const targetsCache = new PluginCache<JestTargets>(cachePath);
     // Cache jest preset(s) to avoid penalties of module load times. Most of jest configs will use the same preset.
     const presetCache: Record<string, unknown> = {};
     // Cache tsconfig reads + isolatedModules resolution. Many projects share
@@ -203,18 +189,23 @@ export const createNodes: CreateNodesV2<JestPluginOptions> = [
           const hash = hashes[idx];
           const { rawConfig, needsDtsInputs } = loadedConfigs[idx];
 
-          targetsCache[hash] ??= await buildJestTargets(
-            rawConfig,
-            needsDtsInputs,
-            configFilePath,
-            projectRoot,
-            options,
-            context,
-            presetCache,
-            pmc
-          );
+          if (!targetsCache.has(hash)) {
+            targetsCache.set(
+              hash,
+              await buildJestTargets(
+                rawConfig,
+                needsDtsInputs,
+                configFilePath,
+                projectRoot,
+                options,
+                context,
+                presetCache,
+                pmc
+              )
+            );
+          }
 
-          const { targets, metadata } = targetsCache[hash];
+          const { targets, metadata } = targetsCache.get(hash);
 
           return {
             projects: {
@@ -231,7 +222,7 @@ export const createNodes: CreateNodesV2<JestPluginOptions> = [
         context
       );
     } finally {
-      writeTargetsToCache(cachePath, targetsCache);
+      targetsCache.writeToDisk(cachePath);
     }
   },
 ];

--- a/packages/next/src/plugins/plugin.ts
+++ b/packages/next/src/plugins/plugin.ts
@@ -2,6 +2,7 @@ import {
   calculateHashForCreateNodes,
   loadConfigFile,
   getNamedInputs,
+  PluginCache,
 } from '@nx/devkit/internal';
 import {
   CreateDependencies,
@@ -11,14 +12,12 @@ import {
   detectPackageManager,
   getPackageManagerCommand,
   NxJsonConfiguration,
-  readJsonFile,
   TargetConfiguration,
-  writeJsonFile,
 } from '@nx/devkit';
 import { getLockFileName } from '@nx/js';
 import { addBuildAndWatchDepsTargets } from '@nx/js/src/plugins/typescript/util';
 import { isUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
-import { existsSync, readdirSync } from 'fs';
+import { readdirSync } from 'fs';
 import { hashObject } from 'nx/src/devkit-internals';
 import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
 import { dirname, join } from 'path';
@@ -37,22 +36,7 @@ export interface NextPluginOptions {
 
 const nextConfigBlob = '**/next.config.{ts,js,cjs,mjs}';
 
-function readTargetsCache(
-  cachePath: string
-): Record<string, Record<string, TargetConfiguration<NextPluginOptions>>> {
-  return existsSync(cachePath) ? readJsonFile(cachePath) : {};
-}
-
-function writeTargetsToCache(
-  cachePath: string,
-  targetsCache: Record<string, TargetConfiguration<NextPluginOptions>>
-) {
-  const oldCache = readTargetsCache(cachePath);
-  writeJsonFile(cachePath, {
-    ...oldCache,
-    ...targetsCache,
-  });
-}
+type NextTargets = Record<string, TargetConfiguration<NextPluginOptions>>;
 
 /**
  * @deprecated The 'createDependencies' function is now a no-op. This functionality is included in 'createNodesV2'.
@@ -66,7 +50,7 @@ export const createNodes: CreateNodesV2<NextPluginOptions> = [
   async (configFiles, options, context) => {
     const optionsHash = hashObject(options);
     const cachePath = join(workspaceDataDirectory, `next-${optionsHash}.json`);
-    const targetsCache = readTargetsCache(cachePath);
+    const targetsCache = new PluginCache<NextTargets>(cachePath);
     const isTsSolutionSetup = isUsingTsSolutionSetup();
     const pmc = getPackageManagerCommand(
       detectPackageManager(context.workspaceRoot)
@@ -88,7 +72,7 @@ export const createNodes: CreateNodesV2<NextPluginOptions> = [
         context
       );
     } finally {
-      writeTargetsToCache(cachePath, targetsCache);
+      targetsCache.writeToDisk(cachePath);
     }
   },
 ];
@@ -99,10 +83,7 @@ async function createNodesInternal(
   configFilePath: string,
   options: NextPluginOptions,
   context: CreateNodesContextV2,
-  targetsCache: Record<
-    string,
-    Record<string, TargetConfiguration<NextPluginOptions>>
-  >,
+  targetsCache: PluginCache<NextTargets>,
   isTsSolutionSetup: boolean,
   pmc: ReturnType<typeof getPackageManagerCommand>
 ) {
@@ -125,20 +106,25 @@ async function createNodesInternal(
     [getLockFileName(detectPackageManager(context.workspaceRoot))]
   );
 
-  targetsCache[hash] ??= await buildNextTargets(
-    configFilePath,
-    projectRoot,
-    options,
-    context,
-    isTsSolutionSetup,
-    pmc
-  );
+  if (!targetsCache.has(hash)) {
+    targetsCache.set(
+      hash,
+      await buildNextTargets(
+        configFilePath,
+        projectRoot,
+        options,
+        context,
+        isTsSolutionSetup,
+        pmc
+      )
+    );
+  }
 
   return {
     projects: {
       [projectRoot]: {
         root: projectRoot,
-        targets: targetsCache[hash],
+        targets: targetsCache.get(hash),
       },
     },
   };

--- a/packages/nuxt/src/plugins/plugin.ts
+++ b/packages/nuxt/src/plugins/plugin.ts
@@ -2,6 +2,7 @@ import {
   loadConfigFile,
   getNamedInputs,
   calculateHashForCreateNodes,
+  PluginCache,
 } from '@nx/devkit/internal';
 import type { NuxtOptions } from '@nuxt/schema';
 import {
@@ -12,35 +13,20 @@ import {
   detectPackageManager,
   getPackageManagerCommand,
   joinPathFragments,
-  readJsonFile,
   TargetConfiguration,
   workspaceRoot,
-  writeJsonFile,
 } from '@nx/devkit';
 import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
 import { getLockFileName } from '@nx/js';
 import { dirname, isAbsolute, join, relative } from 'path';
-import { existsSync, readdirSync } from 'fs';
+import { readdirSync } from 'fs';
 import { loadNuxtKitDynamicImport } from '../utils/executor-utils';
 import { addBuildAndWatchDepsTargets } from '@nx/js/src/plugins/typescript/util';
 
+type NuxtTargets = Record<string, TargetConfiguration>;
+
 const cachePath = join(workspaceDataDirectory, 'nuxt.hash');
-const targetsCache = readTargetsCache();
-
-function readTargetsCache(): Record<
-  string,
-  Record<string, TargetConfiguration>
-> {
-  return existsSync(cachePath) ? readJsonFile(cachePath) : {};
-}
-
-function writeTargetsToCache() {
-  const oldCache = readTargetsCache();
-  writeJsonFile(cachePath, {
-    ...oldCache,
-    ...targetsCache,
-  });
-}
+const targetsCache = new PluginCache<NuxtTargets>(cachePath);
 
 export interface NuxtPluginOptions {
   buildTargetName?: string;
@@ -61,7 +47,7 @@ export const createNodes: CreateNodesV2<NuxtPluginOptions> = [
       options,
       context
     );
-    writeTargetsToCache();
+    targetsCache.writeToDisk(cachePath);
     return result;
   },
 ];
@@ -95,19 +81,18 @@ async function createNodesInternal(
     context,
     [getLockFileName(detectPackageManager(context.workspaceRoot))]
   );
-  targetsCache[hash] ??= await buildNuxtTargets(
-    configFilePath,
-    projectRoot,
-    options,
-    context,
-    pmc
-  );
+  if (!targetsCache.has(hash)) {
+    targetsCache.set(
+      hash,
+      await buildNuxtTargets(configFilePath, projectRoot, options, context, pmc)
+    );
+  }
 
   return {
     projects: {
       [projectRoot]: {
         root: projectRoot,
-        targets: targetsCache[hash],
+        targets: targetsCache.get(hash),
       },
     },
   };

--- a/packages/react-native/plugins/plugin.ts
+++ b/packages/react-native/plugins/plugin.ts
@@ -2,6 +2,7 @@ import {
   getNamedInputs,
   calculateHashForCreateNodes,
   loadConfigFile,
+  PluginCache,
 } from '@nx/devkit/internal';
 import {
   CreateNodesContextV2,
@@ -13,11 +14,10 @@ import {
   NxJsonConfiguration,
   readJsonFile,
   TargetConfiguration,
-  writeJsonFile,
 } from '@nx/devkit';
 import { dirname, join } from 'path';
 import { getLockFileName } from '@nx/js';
-import { existsSync, readdirSync } from 'fs';
+import { readdirSync } from 'fs';
 import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
 import { hashObject } from 'nx/src/devkit-internals';
 
@@ -33,28 +33,10 @@ export interface ReactNativePluginOptions {
   upgradeTargetName?: string;
 }
 
-function readTargetsCache(
-  cachePath: string
-): Record<
+type ReactNativeTargets = Record<
   string,
-  Record<string, TargetConfiguration<ReactNativePluginOptions>>
-> {
-  return existsSync(cachePath) ? readJsonFile(cachePath) : {};
-}
-
-function writeTargetsToCache(
-  cachePath: string,
-  targetsCache: Record<
-    string,
-    Record<string, TargetConfiguration<ReactNativePluginOptions>>
-  >
-) {
-  const oldCache = readTargetsCache(cachePath);
-  writeJsonFile(cachePath, {
-    ...oldCache,
-    targetsCache,
-  });
-}
+  TargetConfiguration<ReactNativePluginOptions>
+>;
 
 export const createNodes: CreateNodesV2<ReactNativePluginOptions> = [
   '**/app.{json,config.js,config.ts}',
@@ -64,7 +46,7 @@ export const createNodes: CreateNodesV2<ReactNativePluginOptions> = [
       workspaceDataDirectory,
       `react-native-${optionsHash}.hash`
     );
-    const targetsCache = readTargetsCache(cachePath);
+    const targetsCache = new PluginCache<ReactNativeTargets>(cachePath);
 
     try {
       return await createNodesFromFiles(
@@ -75,7 +57,7 @@ export const createNodes: CreateNodesV2<ReactNativePluginOptions> = [
         context
       );
     } finally {
-      writeTargetsToCache(cachePath, targetsCache);
+      targetsCache.writeToDisk(cachePath);
     }
   },
 ];
@@ -86,10 +68,7 @@ async function createNodesInternal(
   configFile: string,
   options: ReactNativePluginOptions,
   context: CreateNodesContextV2,
-  targetsCache: Record<
-    string,
-    Record<string, TargetConfiguration<ReactNativePluginOptions>>
-  >
+  targetsCache: PluginCache<ReactNativeTargets>
 ): Promise<CreateNodesResult> {
   options = normalizeOptions(options);
   const projectRoot = dirname(configFile);
@@ -123,12 +102,17 @@ async function createNodesInternal(
     [getLockFileName(detectPackageManager(context.workspaceRoot))]
   );
 
-  targetsCache[hash] ??= buildReactNativeTargets(projectRoot, options, context);
+  if (!targetsCache.has(hash)) {
+    targetsCache.set(
+      hash,
+      buildReactNativeTargets(projectRoot, options, context)
+    );
+  }
 
   return {
     projects: {
       [projectRoot]: {
-        targets: targetsCache[hash],
+        targets: targetsCache.get(hash),
       },
     },
   };

--- a/packages/react/src/plugins/router-plugin.ts
+++ b/packages/react/src/plugins/router-plugin.ts
@@ -3,14 +3,13 @@ import {
   calculateHashesForCreateNodes,
   clearRequireCache,
   loadConfigFile,
+  PluginCache,
 } from '@nx/devkit/internal';
 import {
   type CreateNodesV2,
   type CreateNodesContextV2,
   detectPackageManager,
-  readJsonFile,
   type TargetConfiguration,
-  writeJsonFile,
   createNodesFromFiles,
   getPackageManagerCommand,
   joinPathFragments,
@@ -18,7 +17,7 @@ import {
 } from '@nx/devkit';
 
 import { dirname, join } from 'path';
-import { existsSync, readdirSync } from 'fs';
+import { readdirSync } from 'fs';
 import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
 import { getLockFileName } from '@nx/js';
 import { hashObject } from 'nx/src/devkit-internals';
@@ -42,21 +41,6 @@ type ReactRouterTargets = Pick<
 const pmCommand = getPackageManagerCommand();
 const reactRouterConfigBlob = '**/react-router.config.{ts,js,cjs,cts,mjs,mts}';
 
-function readTargetsCache(
-  cachePath: string
-): Record<string, ReactRouterTargets> {
-  return process.env.NX_CACHE_PROJECT_GRAPH !== 'false' && existsSync(cachePath)
-    ? readJsonFile(cachePath)
-    : {};
-}
-
-function writeTargetsToCache(
-  cachePath: string,
-  results: Record<string, ReactRouterTargets>
-) {
-  writeJsonFile(cachePath, results);
-}
-
 export const createNodesV2: CreateNodesV2<ReactRouterPluginOptions> = [
   reactRouterConfigBlob,
   async (configFiles, options, context) => {
@@ -66,7 +50,7 @@ export const createNodesV2: CreateNodesV2<ReactRouterPluginOptions> = [
       workspaceDataDirectory,
       `react-router-${optionsHash}.hash`
     );
-    const targetsCache = readTargetsCache(cachePath);
+    const targetsCache = new PluginCache<ReactRouterTargets>(cachePath);
 
     const isUsingTsSolutionSetup = _isUsingTsSolutionSetup();
 
@@ -109,15 +93,20 @@ export const createNodesV2: CreateNodesV2<ReactRouterPluginOptions> = [
           );
 
           const hash = hashes[idx] + configFile;
-          const { projectType, metadata, targets } = (targetsCache[hash] ??=
-            await buildReactRouterTargets(
-              configFile,
-              projectRoot,
-              normalizedOptions,
-              context,
-              siblingFiles,
-              isUsingTsSolutionSetup
-            ));
+          if (!targetsCache.has(hash)) {
+            targetsCache.set(
+              hash,
+              await buildReactRouterTargets(
+                configFile,
+                projectRoot,
+                normalizedOptions,
+                context,
+                siblingFiles,
+                isUsingTsSolutionSetup
+              )
+            );
+          }
+          const { projectType, metadata, targets } = targetsCache.get(hash);
 
           const project: ProjectConfiguration = {
             root: projectRoot,
@@ -140,7 +129,7 @@ export const createNodesV2: CreateNodesV2<ReactRouterPluginOptions> = [
         context
       );
     } finally {
-      writeTargetsToCache(cachePath, targetsCache);
+      targetsCache.writeToDisk(cachePath);
     }
   },
 ];

--- a/packages/remix/src/plugins/plugin.ts
+++ b/packages/remix/src/plugins/plugin.ts
@@ -2,6 +2,7 @@ import {
   calculateHashForCreateNodes,
   getNamedInputs,
   loadConfigFile,
+  PluginCache,
 } from '@nx/devkit/internal';
 import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
 import { hashObject } from 'nx/src/hasher/file-hasher';
@@ -16,7 +17,6 @@ import {
   ProjectConfiguration,
   readJsonFile,
   type TargetConfiguration,
-  writeJsonFile,
 } from '@nx/devkit';
 import { getLockFileName } from '@nx/js';
 import { type AppConfig } from '@remix-run/dev';
@@ -38,19 +38,6 @@ export interface RemixPluginOptions {
 
 type RemixTargets = Pick<ProjectConfiguration, 'targets' | 'metadata'>;
 
-function readTargetsCache(
-  cachePath: string
-): Record<string, Record<string, TargetConfiguration>> {
-  return existsSync(cachePath) ? readJsonFile(cachePath) : {};
-}
-
-function writeTargetsToCache(
-  cachePath: string,
-  results: Record<string, RemixTargets>
-) {
-  writeJsonFile(cachePath, results);
-}
-
 /**
  * @deprecated The 'createDependencies' function is now a no-op. This functionality is included in 'createNodesV2'.
  */
@@ -65,7 +52,7 @@ export const createNodes: CreateNodesV2<RemixPluginOptions> = [
   async (configFilePaths, options, context) => {
     const optionsHash = hashObject(options);
     const cachePath = join(workspaceDataDirectory, `remix-${optionsHash}.hash`);
-    const targetsCache = readTargetsCache(cachePath);
+    const targetsCache = new PluginCache<RemixTargets>(cachePath);
     const pmc = getPackageManagerCommand(
       detectPackageManager(context.workspaceRoot)
     );
@@ -85,7 +72,7 @@ export const createNodes: CreateNodesV2<RemixPluginOptions> = [
         context
       );
     } finally {
-      writeTargetsToCache(cachePath, targetsCache);
+      targetsCache.writeToDisk(cachePath);
     }
   },
 ];
@@ -96,7 +83,7 @@ async function createNodesInternal(
   configFilePath: string,
   options: RemixPluginOptions,
   context: CreateNodesContextV2,
-  targetsCache: Record<string, RemixTargets>,
+  targetsCache: PluginCache<RemixTargets>,
   isUsingTsSolutionSetup: boolean,
   pmc: ReturnType<typeof getPackageManagerCommand>
 ) {
@@ -130,18 +117,23 @@ async function createNodesInternal(
       [getLockFileName(detectPackageManager(context.workspaceRoot))]
     )) + configFilePath;
 
-  targetsCache[hash] ??= await buildRemixTargets(
-    configFilePath,
-    projectRoot,
-    options,
-    context,
-    siblingFiles,
-    remixCompiler,
-    isUsingTsSolutionSetup,
-    pmc
-  );
+  if (!targetsCache.has(hash)) {
+    targetsCache.set(
+      hash,
+      await buildRemixTargets(
+        configFilePath,
+        projectRoot,
+        options,
+        context,
+        siblingFiles,
+        remixCompiler,
+        isUsingTsSolutionSetup,
+        pmc
+      )
+    );
+  }
 
-  const { targets, metadata } = targetsCache[hash];
+  const { targets, metadata } = targetsCache.get(hash);
 
   const project: ProjectConfiguration = {
     root: projectRoot,

--- a/packages/rollup/src/plugins/plugin.ts
+++ b/packages/rollup/src/plugins/plugin.ts
@@ -1,6 +1,7 @@
 import {
   calculateHashForCreateNodes,
   getNamedInputs,
+  PluginCache,
 } from '@nx/devkit/internal';
 import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
 import { basename, dirname, join } from 'path';
@@ -13,9 +14,7 @@ import {
   detectPackageManager,
   getPackageManagerCommand,
   joinPathFragments,
-  readJsonFile,
   type TargetConfiguration,
-  writeJsonFile,
 } from '@nx/devkit';
 import { getLockFileName } from '@nx/js';
 import { type RollupOptions } from 'rollup';
@@ -25,25 +24,6 @@ import {
   TS_SOLUTION_SETUP_TSCONFIG_INPUT,
 } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { addBuildAndWatchDepsTargets } from '@nx/js/src/plugins/typescript/util';
-
-function readTargetsCache(
-  cachePath: string
-): Record<string, Record<string, TargetConfiguration>> {
-  try {
-    return process.env.NX_CACHE_PROJECT_GRAPH !== 'false'
-      ? readJsonFile(cachePath)
-      : {};
-  } catch {
-    return {};
-  }
-}
-
-function writeTargetsToCache(
-  cachePath: string,
-  results: Record<string, Record<string, TargetConfiguration>>
-) {
-  writeJsonFile(cachePath, results);
-}
 
 /**
  * @deprecated The 'createDependencies' function is now a no-op. This functionality is included in 'createNodesV2'.
@@ -58,6 +38,8 @@ export interface RollupPluginOptions {
   watchDepsTargetName?: string;
 }
 
+type RollupTargets = Record<string, TargetConfiguration>;
+
 const rollupConfigGlob = '**/rollup.config.{js,cjs,mjs,ts,cts,mts}';
 
 export const createNodes: CreateNodesV2<RollupPluginOptions> = [
@@ -69,7 +51,7 @@ export const createNodes: CreateNodesV2<RollupPluginOptions> = [
       workspaceDataDirectory,
       `rollup-${optionsHash}.hash`
     );
-    const targetsCache = readTargetsCache(cachePath);
+    const targetsCache = new PluginCache<RollupTargets>(cachePath);
     const isTsSolutionSetup = isUsingTsSolutionSetup();
     const pmc = getPackageManagerCommand(
       detectPackageManager(context.workspaceRoot)
@@ -91,7 +73,7 @@ export const createNodes: CreateNodesV2<RollupPluginOptions> = [
         context
       );
     } finally {
-      writeTargetsToCache(cachePath, targetsCache);
+      targetsCache.writeToDisk(cachePath);
     }
   },
 ];
@@ -102,7 +84,7 @@ async function createNodesInternal(
   configFilePath: string,
   options: Required<RollupPluginOptions>,
   context: CreateNodesContextV2,
-  targetsCache: Record<string, Record<string, TargetConfiguration>>,
+  targetsCache: PluginCache<RollupTargets>,
   isTsSolutionSetup: boolean,
   pmc: ReturnType<typeof getPackageManagerCommand>
 ) {
@@ -125,20 +107,25 @@ async function createNodesInternal(
     [getLockFileName(detectPackageManager(context.workspaceRoot))]
   );
 
-  targetsCache[hash] ??= await buildRollupTarget(
-    configFilePath,
-    projectRoot,
-    options,
-    context,
-    isTsSolutionSetup,
-    pmc
-  );
+  if (!targetsCache.has(hash)) {
+    targetsCache.set(
+      hash,
+      await buildRollupTarget(
+        configFilePath,
+        projectRoot,
+        options,
+        context,
+        isTsSolutionSetup,
+        pmc
+      )
+    );
+  }
 
   return {
     projects: {
       [projectRoot]: {
         root: projectRoot,
-        targets: targetsCache[hash],
+        targets: targetsCache.get(hash),
       },
     },
   };

--- a/packages/rsbuild/src/plugins/plugin.ts
+++ b/packages/rsbuild/src/plugins/plugin.ts
@@ -1,12 +1,11 @@
 import {
   getNamedInputs,
   calculateHashForCreateNodes,
+  PluginCache,
 } from '@nx/devkit/internal';
 import {
   type ProjectConfiguration,
   type TargetConfiguration,
-  readJsonFile,
-  writeJsonFile,
   CreateNodesV2,
   CreateNodesContextV2,
   createNodesFromFiles,
@@ -18,7 +17,7 @@ import { hashObject } from 'nx/src/hasher/file-hasher';
 import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
 import { isUsingTsSolutionSetup as _isUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { getLockFileName } from '@nx/js';
-import { existsSync, readdirSync } from 'fs';
+import { readdirSync } from 'fs';
 import { join, dirname, isAbsolute, relative } from 'path';
 import { minimatch } from 'minimatch';
 import { loadConfig, type RsbuildConfig } from '@rsbuild/core';
@@ -36,17 +35,6 @@ export interface RsbuildPluginOptions {
 
 type RsbuildTargets = Pick<ProjectConfiguration, 'targets' | 'metadata'>;
 
-function readTargetsCache(cachePath: string): Record<string, RsbuildTargets> {
-  return existsSync(cachePath) ? readJsonFile(cachePath) : {};
-}
-
-function writeTargetsCache(
-  cachePath,
-  results?: Record<string, RsbuildTargets>
-) {
-  writeJsonFile(cachePath, results);
-}
-
 const rsbuildConfigGlob = '**/rsbuild.config.{js,ts,mjs,mts,cjs,cts}';
 
 export const createNodesV2: CreateNodesV2<RsbuildPluginOptions> = [
@@ -57,7 +45,7 @@ export const createNodesV2: CreateNodesV2<RsbuildPluginOptions> = [
       workspaceDataDirectory,
       `rsbuild-${optionsHash}.hash`
     );
-    const targetsCache = readTargetsCache(cachePath);
+    const targetsCache = new PluginCache<RsbuildTargets>(cachePath);
     const isUsingTsSolutionSetup = _isUsingTsSolutionSetup();
     const pmc = getPackageManagerCommand(
       detectPackageManager(context.workspaceRoot)
@@ -78,7 +66,7 @@ export const createNodesV2: CreateNodesV2<RsbuildPluginOptions> = [
         context
       );
     } finally {
-      writeTargetsCache(cachePath, targetsCache);
+      targetsCache.writeToDisk(cachePath);
     }
   },
 ];
@@ -87,7 +75,7 @@ async function createNodesInternal(
   configFilePath: string,
   options: RsbuildPluginOptions,
   context: CreateNodesContextV2,
-  targetsCache: Record<string, RsbuildTargets>,
+  targetsCache: PluginCache<RsbuildTargets>,
   isUsingTsSolutionSetup: boolean,
   pmc: ReturnType<typeof getPackageManagerCommand>
 ) {
@@ -112,17 +100,22 @@ async function createNodesInternal(
     [getLockFileName(detectPackageManager(context.workspaceRoot))]
   );
 
-  targetsCache[hash] ??= await createRsbuildTargets(
-    configFilePath,
-    projectRoot,
-    normalizedOptions,
-    tsConfigFiles,
-    isUsingTsSolutionSetup,
-    context,
-    pmc
-  );
+  if (!targetsCache.has(hash)) {
+    targetsCache.set(
+      hash,
+      await createRsbuildTargets(
+        configFilePath,
+        projectRoot,
+        normalizedOptions,
+        tsConfigFiles,
+        isUsingTsSolutionSetup,
+        context,
+        pmc
+      )
+    );
+  }
 
-  const { targets, metadata } = targetsCache[hash];
+  const { targets, metadata } = targetsCache.get(hash);
 
   return {
     projects: {

--- a/packages/rspack/src/plugins/plugin.ts
+++ b/packages/rspack/src/plugins/plugin.ts
@@ -1,4 +1,4 @@
-import { getNamedInputs } from '@nx/devkit/internal';
+import { getNamedInputs, PluginCache } from '@nx/devkit/internal';
 import {
   CreateDependencies,
   CreateNodesContextV2,
@@ -8,7 +8,6 @@ import {
   ProjectConfiguration,
   readJsonFile,
   workspaceRoot,
-  writeJsonFile,
 } from '@nx/devkit';
 import { getLockFileName, getRootTsConfigPath } from '@nx/js';
 import { isUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
@@ -32,23 +31,6 @@ export interface RspackPluginOptions {
 
 type RspackTargets = Pick<ProjectConfiguration, 'targets' | 'metadata'>;
 
-function readTargetsCache(cachePath: string): Record<string, RspackTargets> {
-  try {
-    return process.env.NX_CACHE_PROJECT_GRAPH !== 'false'
-      ? readJsonFile(cachePath)
-      : {};
-  } catch {
-    return {};
-  }
-}
-
-function writeTargetsToCache(
-  cachePath: string,
-  results?: Record<string, RspackTargets>
-) {
-  writeJsonFile(cachePath, results);
-}
-
 export const createDependencies: CreateDependencies = () => {
   return [];
 };
@@ -63,7 +45,7 @@ export const createNodesV2: CreateNodesV2<RspackPluginOptions> = [
       workspaceDataDirectory,
       `rspack-${optionsHash}.hash`
     );
-    const targetsCache = readTargetsCache(cachePath);
+    const targetsCache = new PluginCache<RspackTargets>(cachePath);
     const isTsSolutionSetup = isUsingTsSolutionSetup();
     const pmc = getPackageManagerCommand(
       detectPackageManager(context.workspaceRoot)
@@ -84,7 +66,7 @@ export const createNodesV2: CreateNodesV2<RspackPluginOptions> = [
         context
       );
     } finally {
-      writeTargetsToCache(cachePath, targetsCache);
+      targetsCache.writeToDisk(cachePath);
     }
   },
 ];
@@ -93,7 +75,7 @@ async function createNodesInternal(
   configFilePath: string,
   options: RspackPluginOptions,
   context: CreateNodesContextV2,
-  targetsCache: Record<string, RspackTargets>,
+  targetsCache: PluginCache<RspackTargets>,
   isTsSolutionSetup: boolean,
   pmc: ReturnType<typeof getPackageManagerCommand>
 ) {
@@ -134,16 +116,21 @@ async function createNodesInternal(
   // to prevent vite/vitest files overwriting the target cache created by the other
   const hash = `${nodeHash}_${configFilePath}`;
 
-  targetsCache[hash] ??= await createRspackTargets(
-    configFilePath,
-    projectRoot,
-    normalizedOptions,
-    context,
-    isTsSolutionSetup,
-    pmc
-  );
+  if (!targetsCache.has(hash)) {
+    targetsCache.set(
+      hash,
+      await createRspackTargets(
+        configFilePath,
+        projectRoot,
+        normalizedOptions,
+        context,
+        isTsSolutionSetup,
+        pmc
+      )
+    );
+  }
 
-  const { targets, metadata } = targetsCache[hash];
+  const { targets, metadata } = targetsCache.get(hash);
 
   return {
     projects: {

--- a/packages/storybook/src/plugins/plugin.ts
+++ b/packages/storybook/src/plugins/plugin.ts
@@ -2,6 +2,7 @@ import {
   getNamedInputs,
   calculateHashForCreateNodes,
   loadConfigFile,
+  PluginCache,
 } from '@nx/devkit/internal';
 import {
   CreateDependencies,
@@ -12,9 +13,7 @@ import {
   getPackageManagerCommand,
   joinPathFragments,
   parseJson,
-  readJsonFile,
   TargetConfiguration,
-  writeJsonFile,
 } from '@nx/devkit';
 import { dirname, join } from 'path';
 import { existsSync, readdirSync, readFileSync } from 'fs';
@@ -34,18 +33,7 @@ export interface StorybookPluginOptions {
   watchDepsTargetName?: string;
 }
 
-function readTargetsCache(
-  cachePath: string
-): Record<string, Record<string, TargetConfiguration>> {
-  return existsSync(cachePath) ? readJsonFile(cachePath) : {};
-}
-
-function writeTargetsToCache(
-  cachePath: string,
-  results: Record<string, Record<string, TargetConfiguration>>
-) {
-  writeJsonFile(cachePath, results);
-}
+type StorybookTargets = Record<string, TargetConfiguration>;
 
 /**
  * @deprecated The 'createDependencies' function is now a no-op. This functionality is included in 'createNodesV2'.
@@ -65,7 +53,7 @@ export const createNodes: CreateNodesV2<StorybookPluginOptions> = [
       workspaceDataDirectory,
       `storybook-${optionsHash}.hash`
     );
-    const targetsCache = readTargetsCache(cachePath);
+    const targetsCache = new PluginCache<StorybookTargets>(cachePath);
     const pmc = getPackageManagerCommand(
       detectPackageManager(context.workspaceRoot)
     );
@@ -85,7 +73,7 @@ export const createNodes: CreateNodesV2<StorybookPluginOptions> = [
         context
       );
     } finally {
-      writeTargetsToCache(cachePath, targetsCache);
+      targetsCache.writeToDisk(cachePath);
     }
   },
 ];
@@ -96,7 +84,7 @@ async function createNodesInternal(
   configFilePath: string,
   options: Required<StorybookPluginOptions>,
   context: CreateNodesContextV2,
-  targetsCache: Record<string, Record<string, TargetConfiguration>>,
+  targetsCache: PluginCache<StorybookTargets>,
   pmc: ReturnType<typeof getPackageManagerCommand>
 ) {
   let projectRoot = '';
@@ -128,20 +116,25 @@ async function createNodesInternal(
 
   const projectName = buildProjectName(projectRoot, context.workspaceRoot);
 
-  targetsCache[hash] ??= await buildStorybookTargets(
-    configFilePath,
-    projectRoot,
-    options,
-    context,
-    projectName,
-    pmc
-  );
+  if (!targetsCache.has(hash)) {
+    targetsCache.set(
+      hash,
+      await buildStorybookTargets(
+        configFilePath,
+        projectRoot,
+        options,
+        context,
+        projectName,
+        pmc
+      )
+    );
+  }
 
   const result = {
     projects: {
       [projectRoot]: {
         root: projectRoot,
-        targets: targetsCache[hash],
+        targets: targetsCache.get(hash),
       },
     },
   };

--- a/packages/vite/src/plugins/plugin.ts
+++ b/packages/vite/src/plugins/plugin.ts
@@ -1,6 +1,7 @@
 import {
   calculateHashesForCreateNodes,
   getNamedInputs,
+  PluginCache,
 } from '@nx/devkit/internal';
 import {
   CreateDependencies,
@@ -12,9 +13,7 @@ import {
   joinPathFragments,
   normalizePath,
   ProjectConfiguration,
-  readJsonFile,
   TargetConfiguration,
-  writeJsonFile,
 } from '@nx/devkit';
 import { getLockFileName, getRootTsConfigFileName } from '@nx/js';
 import {
@@ -68,16 +67,6 @@ type ViteTargets = Pick<
   'targets' | 'metadata' | 'projectType'
 >;
 
-function readTargetsCache(cachePath: string): Record<string, ViteTargets> {
-  return process.env.NX_CACHE_PROJECT_GRAPH !== 'false' && existsSync(cachePath)
-    ? readJsonFile(cachePath)
-    : {};
-}
-
-function writeTargetsToCache(cachePath, results?: Record<string, ViteTargets>) {
-  writeJsonFile(cachePath, results);
-}
-
 /**
  * @deprecated The 'createDependencies' function is now a no-op. This functionality is included in 'createNodesV2'.
  */
@@ -93,7 +82,7 @@ export const createNodes: CreateNodesV2<VitePluginOptions> = [
     const optionsHash = hashObject(options);
     const normalizedOptions = normalizeOptions(options);
     const cachePath = join(workspaceDataDirectory, `vite-${optionsHash}.hash`);
-    const targetsCache = readTargetsCache(cachePath);
+    const targetsCache = new PluginCache<ViteTargets>(cachePath);
     const isUsingTsSolutionSetup = _isUsingTsSolutionSetup();
 
     const { roots: projectRoots, configFiles: validConfigFiles } =
@@ -160,18 +149,23 @@ export const createNodes: CreateNodesV2<VitePluginOptions> = [
           // Adding the config file path to the hash ensures that the final hash value is different
           // for different config files.
           const hash = hashes[idx] + configFile;
-          const { projectType, metadata, targets } = (targetsCache[hash] ??=
-            await buildViteTargets(
-              configFile,
-              projectRoot,
-              normalizedOptions,
-              tsConfigFiles,
-              hasReactRouterConfig,
-              isUsingTsSolutionSetup,
-              context,
-              pmc,
-              tsconfigChainsByProjectRoot.get(projectRoot) ?? []
-            ));
+          if (!targetsCache.has(hash)) {
+            targetsCache.set(
+              hash,
+              await buildViteTargets(
+                configFile,
+                projectRoot,
+                normalizedOptions,
+                tsConfigFiles,
+                hasReactRouterConfig,
+                isUsingTsSolutionSetup,
+                context,
+                pmc,
+                tsconfigChainsByProjectRoot.get(projectRoot) ?? []
+              )
+            );
+          }
+          const { projectType, metadata, targets } = targetsCache.get(hash);
 
           const project: ProjectConfiguration = {
             root: projectRoot,
@@ -196,7 +190,7 @@ export const createNodes: CreateNodesV2<VitePluginOptions> = [
         context
       );
     } finally {
-      writeTargetsToCache(cachePath, targetsCache);
+      targetsCache.writeToDisk(cachePath);
     }
   },
 ];

--- a/packages/vitest/src/plugins/plugin.ts
+++ b/packages/vitest/src/plugins/plugin.ts
@@ -1,6 +1,7 @@
 import {
   calculateHashesForCreateNodes,
   getNamedInputs,
+  PluginCache,
 } from '@nx/devkit/internal';
 import {
   CreateDependencies,
@@ -12,9 +13,7 @@ import {
   joinPathFragments,
   normalizePath,
   ProjectConfiguration,
-  readJsonFile,
   TargetConfiguration,
-  writeJsonFile,
 } from '@nx/devkit';
 import { getLockFileName, getRootTsConfigFileName } from '@nx/js';
 import {
@@ -51,19 +50,6 @@ type VitestTargets = Pick<
   'targets' | 'metadata' | 'projectType'
 >;
 
-function readTargetsCache(cachePath: string): Record<string, VitestTargets> {
-  return process.env.NX_CACHE_PROJECT_GRAPH !== 'false' && existsSync(cachePath)
-    ? readJsonFile(cachePath)
-    : {};
-}
-
-function writeTargetsToCache(
-  cachePath,
-  results?: Record<string, VitestTargets>
-) {
-  writeJsonFile(cachePath, results);
-}
-
 /**
  * @deprecated The 'createDependencies' function is now a no-op. This functionality is included in 'createNodesV2'.
  */
@@ -85,7 +71,7 @@ export const createNodes: CreateNodesV2<VitestPluginOptions> = [
       workspaceDataDirectory,
       `vitest-${optionsHash}.hash`
     );
-    const targetsCache = readTargetsCache(cachePath);
+    const targetsCache = new PluginCache<VitestTargets>(cachePath);
 
     const { roots: projectRoots, configFiles: validConfigFiles } =
       configFilePaths.reduce(
@@ -133,15 +119,20 @@ export const createNodes: CreateNodesV2<VitestPluginOptions> = [
           // Adding the config file path to the hash ensures that the final hash value is different
           // for different config files.
           const hash = hashes[idx] + configFile;
-          const { projectType, metadata, targets } = (targetsCache[hash] ??=
-            await buildVitestTargets(
-              configFile,
-              projectRoot,
-              normalizedOptions,
-              context,
-              pmc,
-              tsconfigChainsByProjectRoot.get(projectRoot) ?? []
-            ));
+          if (!targetsCache.has(hash)) {
+            targetsCache.set(
+              hash,
+              await buildVitestTargets(
+                configFile,
+                projectRoot,
+                normalizedOptions,
+                context,
+                pmc,
+                tsconfigChainsByProjectRoot.get(projectRoot) ?? []
+              )
+            );
+          }
+          const { projectType, metadata, targets } = targetsCache.get(hash);
 
           const project: ProjectConfiguration = {
             root: projectRoot,
@@ -161,7 +152,7 @@ export const createNodes: CreateNodesV2<VitestPluginOptions> = [
         context
       );
     } finally {
-      writeTargetsToCache(cachePath, targetsCache);
+      targetsCache.writeToDisk(cachePath);
     }
   },
 ];

--- a/packages/webpack/src/plugins/plugin.ts
+++ b/packages/webpack/src/plugins/plugin.ts
@@ -1,6 +1,7 @@
 import {
   calculateHashForCreateNodes,
   getNamedInputs,
+  PluginCache,
 } from '@nx/devkit/internal';
 import {
   CreateDependencies,
@@ -12,10 +13,8 @@ import {
   getPackageManagerCommand,
   joinPathFragments,
   ProjectConfiguration,
-  readJsonFile,
   TargetConfiguration,
   workspaceRoot,
-  writeJsonFile,
 } from '@nx/devkit';
 import { getLockFileName, getRootTsConfigPath } from '@nx/js';
 import {
@@ -41,23 +40,6 @@ export interface WebpackPluginOptions {
 
 type WebpackTargets = Pick<ProjectConfiguration, 'targets' | 'metadata'>;
 
-function readTargetsCache(cachePath: string): Record<string, WebpackTargets> {
-  try {
-    return process.env.NX_CACHE_PROJECT_GRAPH !== 'false'
-      ? readJsonFile(cachePath)
-      : {};
-  } catch {
-    return {};
-  }
-}
-
-function writeTargetsToCache(
-  cachePath: string,
-  results?: Record<string, WebpackTargets>
-) {
-  writeJsonFile(cachePath, results);
-}
-
 /**
  * @deprecated The 'createDependencies' function is now a no-op. This functionality is included in 'createNodesV2'.
  */
@@ -75,7 +57,7 @@ export const createNodes: CreateNodesV2<WebpackPluginOptions> = [
       workspaceDataDirectory,
       `webpack-${optionsHash}.hash`
     );
-    const targetsCache = readTargetsCache(cachePath);
+    const targetsCache = new PluginCache<WebpackTargets>(cachePath);
     const normalizedOptions = normalizeOptions(options);
     const isTsSolutionSetup = isUsingTsSolutionSetup();
     const pmc = getPackageManagerCommand(
@@ -97,7 +79,7 @@ export const createNodes: CreateNodesV2<WebpackPluginOptions> = [
         context
       );
     } finally {
-      writeTargetsToCache(cachePath, targetsCache);
+      targetsCache.writeToDisk(cachePath);
     }
   },
 ];
@@ -108,7 +90,7 @@ async function createNodesInternal(
   configFilePath: string,
   options: Required<WebpackPluginOptions>,
   context: CreateNodesContextV2,
-  targetsCache: Record<string, WebpackTargets>,
+  targetsCache: PluginCache<WebpackTargets>,
   isTsSolutionSetup: boolean,
   pmc: ReturnType<typeof getPackageManagerCommand>
 ): Promise<CreateNodesResult> {
@@ -130,16 +112,21 @@ async function createNodesInternal(
     [getLockFileName(detectPackageManager(context.workspaceRoot))]
   );
 
-  targetsCache[hash] ??= await createWebpackTargets(
-    configFilePath,
-    projectRoot,
-    options,
-    context,
-    isTsSolutionSetup,
-    pmc
-  );
+  if (!targetsCache.has(hash)) {
+    targetsCache.set(
+      hash,
+      await createWebpackTargets(
+        configFilePath,
+        projectRoot,
+        options,
+        context,
+        isTsSolutionSetup,
+        pmc
+      )
+    );
+  }
 
-  const { targets, metadata } = targetsCache[hash];
+  const { targets, metadata } = targetsCache.get(hash);
 
   return {
     projects: {


### PR DESCRIPTION
## Current Behavior

Unit tests intermittently fail with `ValueExpected` JSON parse errors against `.nx/workspace-data/<plugin>-<hash>.hash` files, e.g.:

```
Error: ValueExpected in /home/workflows/workspace/.nx/workspace-data/jest-7930610538513362720.hash at 1:1
> 1 |
    | ^
```

Each createNodes plugin (jest, next, vite, vitest, storybook, docker, rsbuild, rspack, webpack, rollup, react-native, expo, detox, eslint, remix, react/router, nuxt, angular) maintains its own targets cache via a roughly identical `readTargetsCache` / `writeTargetsToCache` pair built on `readJsonFile` / `writeJsonFile`. The write is non-atomic (`writeFileSync`); when two callers race on the same cache path, a reader can observe the empty truncated file mid-write, and `readJsonFile` throws `ValueExpected`.

A few drive-by issues uncovered along the way:

- `detox` was reading from `expo-${hash}.hash` (wrong filename copy/paste).
- `detox`, `expo`, `react-native` writes were `{ ...oldCache, targetsCache }` without spread — storing the cache object literally under the key `targetsCache` instead of merging entries, so on-disk cache was effectively useless across runs.

## Expected Behavior

All createNodes plugins now use the shared `PluginCache` utility from `@nx/devkit/internal` (already in use by Gradle and the .NET analyzer). `PluginCache`:

- Wraps the cache read in `try/catch`, treating empty/corrupt files as a cache miss instead of throwing — eliminates the `ValueExpected` flake.
- Wipes the cache file on write error so corruption can't persist across runs.
- Tracks LRU access order and evicts entries when serialization hits `RangeError`.

Per-plugin pattern change:

```ts
// before
const targetsCache = readTargetsCache(cachePath);
targetsCache[hash] ??= await buildTargets(...);
const result = targetsCache[hash];
// later:
writeTargetsToCache(cachePath, targetsCache);
```

```ts
// after
const targetsCache = new PluginCache<TargetsType>(cachePath);
if (!targetsCache.has(hash)) {
  targetsCache.set(hash, await buildTargets(...));
}
const result = targetsCache.get(hash);
// later:
targetsCache.writeToDisk(cachePath);
```

Plugins migrated: `angular`, `detox`, `docker`, `eslint`, `expo`, `jest`, `next`, `nuxt`, `react-native`, `react` (router-plugin), `remix`, `rollup`, `rsbuild`, `rspack`, `storybook`, `vite`, `vitest`, `webpack`.

Skipped:

- `packages/dotnet/src/utils/cache.ts` — orphaned dead code with no callers; `dotnet/src/analyzer/analyzer-client.ts` already uses `PluginCache`.
- `packages/js/src/plugins/typescript/plugin.ts` — already has its own resilient read (try/catch) and atomic temp+rename write; migrating would regress on the write side.

### On-disk cache format change

`PluginCache` stores `{ entries, accessOrder }` instead of a flat record. Stale caches written by older versions are simply discarded on read — perf-only impact, no correctness implication.

## Validation

`pnpm nx run-many -t test --parallel=8 --skip-nx-cache` produces the same set of failed tasks on this branch as on `master` (24 tasks, all pre-existing snapshot/env issues unrelated to this change). Net new failures introduced: 0.

## Related Issue(s)

N/A — addresses observed flake during unit tests; no specific issue tracked.