### PR TITLE
fix(core): use workspace root for package manager detection in script targets

### DIFF
--- a/packages/angular/src/plugins/plugin.ts
+++ b/packages/angular/src/plugins/plugin.ts
@@ -91,13 +91,20 @@ export const createNodesV2: CreateNodesV2<AngularPluginOptions> = [
       `angular-${optionsHash}.hash`
     );
     const projectsCache = new PluginCache<AngularProjects>(cachePath);
-    const pmc = getPackageManagerCommand(
-      detectPackageManager(context.workspaceRoot)
-    );
+    const packageManager = detectPackageManager(context.workspaceRoot);
+    const pmc = getPackageManagerCommand(packageManager);
+    const lockFileName = getLockFileName(packageManager);
     try {
       return await createNodesFromFiles(
         (configFile, options, context) =>
-          createNodesInternal(configFile, options, context, projectsCache, pmc),
+          createNodesInternal(
+            configFile,
+            options,
+            context,
+            projectsCache,
+            pmc,
+            lockFileName
+          ),
         configFiles,
         options,
         context
@@ -113,7 +120,8 @@ async function createNodesInternal(
   options: {} | undefined,
   context: CreateNodesContextV2,
   projectsCache: PluginCache<AngularProjects>,
-  pmc: ReturnType<typeof getPackageManagerCommand>
+  pmc: ReturnType<typeof getPackageManagerCommand>,
+  lockFileName: string
 ): Promise<CreateNodesResult> {
   const angularWorkspaceRoot = dirname(configFilePath);
 
@@ -129,7 +137,7 @@ async function createNodesInternal(
     angularWorkspaceRoot,
     options,
     context,
-    [getLockFileName(detectPackageManager(context.workspaceRoot))]
+    [lockFileName]
   );
 
   if (!projectsCache.has(hash)) {

--- a/packages/cypress/src/plugins/plugin.ts
+++ b/packages/cypress/src/plugins/plugin.ts
@@ -53,13 +53,20 @@ export const createNodes: CreateNodesV2<CypressPluginOptions> = [
       `cypress-${optionsHash}.hash`
     );
     const pluginCache = new PluginCache<CypressTargets>(cachePath);
-    const pmc = getPackageManagerCommand(
-      detectPackageManager(context.workspaceRoot)
-    );
+    const packageManager = detectPackageManager(context.workspaceRoot);
+    const pmc = getPackageManagerCommand(packageManager);
+    const lockFileName = getLockFileName(packageManager);
     try {
       return await createNodesFromFiles(
         (configFile, options, context) =>
-          createNodesInternal(configFile, options, context, pluginCache, pmc),
+          createNodesInternal(
+            configFile,
+            options,
+            context,
+            pluginCache,
+            pmc,
+            lockFileName
+          ),
         configFiles,
         options,
         context
@@ -77,7 +84,8 @@ async function createNodesInternal(
   options: CypressPluginOptions,
   context: CreateNodesContextV2,
   pluginCache: PluginCache<CypressTargets>,
-  pmc: ReturnType<typeof getPackageManagerCommand>
+  pmc: ReturnType<typeof getPackageManagerCommand>,
+  lockFileName: string
 ) {
   options = normalizeOptions(options);
   const projectRoot = dirname(configFilePath);
@@ -93,7 +101,7 @@ async function createNodesInternal(
 
   const hash =
     (await calculateHashForCreateNodes(projectRoot, options, context, [
-      getLockFileName(detectPackageManager(context.workspaceRoot)),
+      lockFileName,
     ])) + configFilePath;
 
   if (!pluginCache.has(hash)) {

--- a/packages/detox/src/plugins/plugin.ts
+++ b/packages/detox/src/plugins/plugin.ts
@@ -35,14 +35,21 @@ export const createNodes: CreateNodesV2<DetoxPluginOptions> = [
     const optionsHash = hashObject(options);
     const cachePath = join(workspaceDataDirectory, `detox-${optionsHash}.hash`);
     const targetsCache = new PluginCache<DetoxTargets>(cachePath);
-    const pmc = getPackageManagerCommand(
-      detectPackageManager(context.workspaceRoot)
-    );
+    const packageManager = detectPackageManager(context.workspaceRoot);
+    const pmc = getPackageManagerCommand(packageManager);
+    const lockFileName = getLockFileName(packageManager);
 
     try {
       return await createNodesFromFiles(
         (configFile, options, context) =>
-          createNodesInternal(configFile, options, context, targetsCache, pmc),
+          createNodesInternal(
+            configFile,
+            options,
+            context,
+            targetsCache,
+            pmc,
+            lockFileName
+          ),
         configFiles,
         options,
         context
@@ -60,7 +67,8 @@ async function createNodesInternal(
   options: DetoxPluginOptions,
   context: CreateNodesContextV2,
   targetsCache: PluginCache<DetoxTargets>,
-  pmc: ReturnType<typeof getPackageManagerCommand>
+  pmc: ReturnType<typeof getPackageManagerCommand>,
+  lockFileName: string
 ): Promise<CreateNodesResult> {
   options = normalizeOptions(options);
   const projectRoot = dirname(configFile);
@@ -69,7 +77,7 @@ async function createNodesInternal(
     projectRoot,
     options,
     context,
-    [getLockFileName(detectPackageManager(context.workspaceRoot))]
+    [lockFileName]
   );
 
   if (!targetsCache.has(hash)) {

--- a/packages/expo/plugins/plugin.ts
+++ b/packages/expo/plugins/plugin.ts
@@ -44,14 +44,21 @@ export const createNodes: CreateNodesV2<ExpoPluginOptions> = [
     const optionsHash = hashObject(options);
     const cachePath = join(workspaceDataDirectory, `expo-${optionsHash}.hash`);
     const targetsCache = new PluginCache<ExpoTargets>(cachePath);
-    const pmc = getPackageManagerCommand(
-      detectPackageManager(context.workspaceRoot)
-    );
+    const packageManager = detectPackageManager(context.workspaceRoot);
+    const pmc = getPackageManagerCommand(packageManager);
+    const lockFileName = getLockFileName(packageManager);
 
     try {
       return await createNodesFromFiles(
         (configFile, options, context) =>
-          createNodesInternal(configFile, options, context, targetsCache, pmc),
+          createNodesInternal(
+            configFile,
+            options,
+            context,
+            targetsCache,
+            pmc,
+            lockFileName
+          ),
         configFiles,
         options,
         context
@@ -69,7 +76,8 @@ async function createNodesInternal(
   options: ExpoPluginOptions,
   context: CreateNodesContextV2,
   targetsCache: PluginCache<ExpoTargets>,
-  pmc: ReturnType<typeof getPackageManagerCommand>
+  pmc: ReturnType<typeof getPackageManagerCommand>,
+  lockFileName: string
 ): Promise<CreateNodesResult> {
   options = normalizeOptions(options);
   const projectRoot = dirname(configFile);
@@ -100,7 +108,7 @@ async function createNodesInternal(
     projectRoot,
     options,
     context,
-    [getLockFileName(detectPackageManager(context.workspaceRoot))]
+    [lockFileName]
   );
 
   if (!targetsCache.has(hash)) {

--- a/packages/js/src/plugins/typescript/plugin.ts
+++ b/packages/js/src/plugins/typescript/plugin.ts
@@ -268,9 +268,9 @@ export const createNodesV2: CreateNodesV2<TscPluginOptions> = [
     initializeTsConfigCache(configFilePaths, context.workspaceRoot, cache);
 
     const normalizedOptions = normalizePluginOptions(options);
-    const pmc = getPackageManagerCommand(
-      detectPackageManager(context.workspaceRoot)
-    );
+    const packageManager = detectPackageManager(context.workspaceRoot);
+    const pmc = getPackageManagerCommand(packageManager);
+    const lockFileName = getLockFileName(packageManager);
 
     const {
       configFilePaths: validConfigFilePaths,
@@ -281,7 +281,8 @@ export const createNodesV2: CreateNodesV2<TscPluginOptions> = [
       normalizedOptions,
       optionsHash,
       context,
-      cache
+      cache,
+      lockFileName
     );
 
     try {
@@ -344,19 +345,15 @@ async function resolveValidConfigFilesAndHashes(
   options: NormalizedPluginOptions,
   optionsHash: string,
   context: CreateNodesContextV2,
-  cache: InvocationCache
+  cache: InvocationCache,
+  lockFileName: string
 ): Promise<{
   configFilePaths: string[];
   hashes: string[];
   projectRoots: string[];
 }> {
   const lockFileHash =
-    hashFile(
-      join(
-        context.workspaceRoot,
-        getLockFileName(detectPackageManager(context.workspaceRoot))
-      )
-    ) ?? '';
+    hashFile(join(context.workspaceRoot, lockFileName)) ?? '';
 
   const validConfigFilePaths: string[] = [];
   const hashes: string[] = [];

--- a/packages/next/src/plugins/plugin.ts
+++ b/packages/next/src/plugins/plugin.ts
@@ -52,9 +52,9 @@ export const createNodes: CreateNodesV2<NextPluginOptions> = [
     const cachePath = join(workspaceDataDirectory, `next-${optionsHash}.json`);
     const targetsCache = new PluginCache<NextTargets>(cachePath);
     const isTsSolutionSetup = isUsingTsSolutionSetup();
-    const pmc = getPackageManagerCommand(
-      detectPackageManager(context.workspaceRoot)
-    );
+    const packageManager = detectPackageManager(context.workspaceRoot);
+    const pmc = getPackageManagerCommand(packageManager);
+    const lockFileName = getLockFileName(packageManager);
 
     try {
       return await createNodesFromFiles(
@@ -65,7 +65,8 @@ export const createNodes: CreateNodesV2<NextPluginOptions> = [
             context,
             targetsCache,
             isTsSolutionSetup,
-            pmc
+            pmc,
+            lockFileName
           ),
         configFiles,
         options,
@@ -85,7 +86,8 @@ async function createNodesInternal(
   context: CreateNodesContextV2,
   targetsCache: PluginCache<NextTargets>,
   isTsSolutionSetup: boolean,
-  pmc: ReturnType<typeof getPackageManagerCommand>
+  pmc: ReturnType<typeof getPackageManagerCommand>,
+  lockFileName: string
 ) {
   const projectRoot = dirname(configFilePath);
 
@@ -103,7 +105,7 @@ async function createNodesInternal(
     projectRoot,
     options,
     context,
-    [getLockFileName(detectPackageManager(context.workspaceRoot))]
+    [lockFileName]
   );
 
   if (!targetsCache.has(hash)) {

--- a/packages/nuxt/src/plugins/plugin.ts
+++ b/packages/nuxt/src/plugins/plugin.ts
@@ -41,8 +41,12 @@ export const createNodes: CreateNodesV2<NuxtPluginOptions> = [
   '**/nuxt.config.{js,ts,mjs,mts,cjs,cts}',
   async (files, options, context) => {
     //TODO(@nrwl/nx-vue-reviewers): This should batch hashing like our other plugins.
+    const packageManager = detectPackageManager(context.workspaceRoot);
+    const pmc = getPackageManagerCommand(packageManager);
+    const lockFileName = getLockFileName(packageManager);
     const result = await createNodesFromFiles(
-      createNodesInternal,
+      (configFile, opts, ctx) =>
+        createNodesInternal(configFile, opts, ctx, pmc, lockFileName),
       files,
       options,
       context
@@ -57,7 +61,9 @@ export const createNodesV2 = createNodes;
 async function createNodesInternal(
   configFilePath: string,
   options: NuxtPluginOptions,
-  context: CreateNodesContextV2
+  context: CreateNodesContextV2,
+  pmc: ReturnType<typeof getPackageManagerCommand>,
+  lockFileName: string
 ) {
   const projectRoot = dirname(configFilePath);
   // Do not create a project if package.json and project.json isn't there.
@@ -71,15 +77,11 @@ async function createNodesInternal(
 
   options = normalizeOptions(options);
 
-  const pmc = getPackageManagerCommand(
-    detectPackageManager(context.workspaceRoot)
-  );
-
   const hash = await calculateHashForCreateNodes(
     projectRoot,
     options,
     context,
-    [getLockFileName(detectPackageManager(context.workspaceRoot))]
+    [lockFileName]
   );
   if (!targetsCache.has(hash)) {
     targetsCache.set(

--- a/packages/nx/plugins/package-json.ts
+++ b/packages/nx/plugins/package-json.ts
@@ -10,6 +10,10 @@ import { join } from 'path';
 import { ProjectConfiguration } from '../src/config/workspace-json-project-json';
 import { readJsonFile } from '../src/utils/fileutils';
 import { PluginCache } from '../src/utils/plugin-cache-utils';
+import {
+  detectPackageManager,
+  getPackageManagerCommand,
+} from '../src/utils/package-manager';
 
 export type PackageJsonConfigurationCache = PluginCache<ProjectConfiguration>;
 
@@ -41,13 +45,19 @@ const plugin: NxPluginV2 = {
       const isInPackageJsonWorkspaces =
         buildPackageJsonWorkspacesMatcher(patterns);
 
+      const packageManagerCommand = getPackageManagerCommand(
+        detectPackageManager(context.workspaceRoot),
+        context.workspaceRoot
+      );
+
       const result = createNodesFromFiles(
         (packageJsonPath) =>
           createNodeFromPackageJson(
             packageJsonPath,
             workspaceRoot,
             cache,
-            isInPackageJsonWorkspaces(packageJsonPath)
+            isInPackageJsonWorkspaces(packageJsonPath),
+            packageManagerCommand
           ),
         configFiles,
         options,

--- a/packages/nx/src/plugins/package-json/create-nodes.spec.ts
+++ b/packages/nx/src/plugins/package-json/create-nodes.spec.ts
@@ -14,6 +14,10 @@ describe('nx package.json workspaces plugin', () => {
     nxJsonConfiguration: {},
   };
 
+  const packageManagerCommand = {
+    run: (script: string) => `npm run ${script}`,
+  } as any;
+
   beforeEach(() => {
     // Ensure deterministic package manager detection: without a lockfile the
     // detector falls back to npm_config_user_agent, which makes test output
@@ -64,7 +68,8 @@ describe('nx package.json workspaces plugin', () => {
         'package.json',
         '/root',
         new PluginCache(packageJsonCachePath),
-        false
+        false,
+        packageManagerCommand
       )
     ).toMatchInlineSnapshot(`
       {
@@ -118,7 +123,8 @@ describe('nx package.json workspaces plugin', () => {
         'packages/lib-a/package.json',
         '/root',
         new PluginCache(packageJsonCachePath),
-        false
+        false,
+        packageManagerCommand
       )
     ).toMatchInlineSnapshot(`
       {
@@ -172,7 +178,8 @@ describe('nx package.json workspaces plugin', () => {
         'packages/lib-b/package.json',
         '/root',
         new PluginCache(packageJsonCachePath),
-        false
+        false,
+        packageManagerCommand
       )
     ).toMatchInlineSnapshot(`
       {
@@ -816,7 +823,8 @@ describe('nx package.json workspaces plugin', () => {
         'apps/myapp/package.json',
         '/root',
         new PluginCache(packageJsonCachePath),
-        false
+        false,
+        packageManagerCommand
       ).projects['apps/myapp'].projectType
     ).toEqual('application');
 
@@ -825,7 +833,8 @@ describe('nx package.json workspaces plugin', () => {
         'packages/mylib/package.json',
         '/root',
         new PluginCache(packageJsonCachePath),
-        false
+        false,
+        packageManagerCommand
       ).projects['packages/mylib'].projectType
     ).toEqual('library');
   });
@@ -852,7 +861,8 @@ describe('nx package.json workspaces plugin', () => {
         'package.json',
         '/root',
         new PluginCache(packageJsonCachePath),
-        false
+        false,
+        packageManagerCommand
       ).projects['.'].projectType
     ).toEqual('library');
   });
@@ -882,7 +892,8 @@ describe('nx package.json workspaces plugin', () => {
         'packages/mylib/package.json',
         '/root',
         new PluginCache(packageJsonCachePath),
-        false
+        false,
+        packageManagerCommand
       ).projects['packages/mylib'].projectType
     ).toEqual('library');
     expect(
@@ -890,7 +901,8 @@ describe('nx package.json workspaces plugin', () => {
         'example/package.json',
         '/root',
         new PluginCache(packageJsonCachePath),
-        false
+        false,
+        packageManagerCommand
       ).projects['example'].projectType
     ).toBeUndefined();
   });

--- a/packages/nx/src/plugins/package-json/create-nodes.spec.ts
+++ b/packages/nx/src/plugins/package-json/create-nodes.spec.ts
@@ -14,6 +14,13 @@ describe('nx package.json workspaces plugin', () => {
     nxJsonConfiguration: {},
   };
 
+  beforeEach(() => {
+    // Ensure deterministic package manager detection: without a lockfile the
+    // detector falls back to npm_config_user_agent, which makes test output
+    // depend on whoever invoked jest (npm vs pnpm vs yarn).
+    vol.fromJSON({ 'package-lock.json': '{}' }, '/root');
+  });
+
   afterEach(() => {
     vol.reset();
   });

--- a/packages/nx/src/plugins/package-json/create-nodes.ts
+++ b/packages/nx/src/plugins/package-json/create-nodes.ts
@@ -15,6 +15,11 @@ import {
   getTagsFromPackageJson,
   readTargetsFromPackageJson,
 } from '../../utils/package-json';
+import {
+  detectPackageManager,
+  getPackageManagerCommand,
+  PackageManagerCommands,
+} from '../../utils/package-manager';
 import { joinPathFragments } from '../../utils/path';
 import { nxVersion } from '../../utils/versions';
 import {
@@ -59,6 +64,11 @@ export const createNodesV2: CreateNodesV2 = [
 
     const cache = readPackageJsonConfigurationCache();
 
+    const packageManagerCommand = getPackageManagerCommand(
+      detectPackageManager(context.workspaceRoot),
+      context.workspaceRoot
+    );
+
     return createNodesFromFiles(
       (packageJsonPath, options, context) => {
         const isInPackageManagerWorkspaces =
@@ -75,7 +85,8 @@ export const createNodesV2: CreateNodesV2 = [
           packageJsonPath,
           context.workspaceRoot,
           cache,
-          isInPackageManagerWorkspaces
+          isInPackageManagerWorkspaces,
+          packageManagerCommand
         );
       },
       packageJsons,
@@ -173,7 +184,8 @@ export function createNodeFromPackageJson(
   pkgJsonPath: string,
   workspaceRoot: string,
   cache: PackageJsonConfigurationCache,
-  isInPackageManagerWorkspaces: boolean
+  isInPackageManagerWorkspaces: boolean,
+  packageManagerCommand: PackageManagerCommands
 ) {
   const json: PackageJson = readJsonFile(join(workspaceRoot, pkgJsonPath));
 
@@ -200,7 +212,8 @@ export function createNodeFromPackageJson(
     workspaceRoot,
     pkgJsonPath,
     readNxJson(workspaceRoot),
-    isInPackageManagerWorkspaces
+    isInPackageManagerWorkspaces,
+    packageManagerCommand
   );
 
   cache.set(hash, project);
@@ -216,7 +229,8 @@ export function buildProjectConfigurationFromPackageJson(
   workspaceRoot: string,
   packageJsonPath: string,
   nxJson: NxJsonConfiguration,
-  isInPackageManagerWorkspaces: boolean
+  isInPackageManagerWorkspaces: boolean,
+  packageManagerCommand: PackageManagerCommands
 ): ProjectConfiguration & { name: string } {
   const normalizedPath = packageJsonPath.split('\\').join('/');
   const projectRoot = dirname(normalizedPath);
@@ -256,7 +270,8 @@ export function buildProjectConfigurationFromPackageJson(
       packageJson,
       nxJson,
       projectRoot,
-      workspaceRoot
+      workspaceRoot,
+      packageManagerCommand
     ),
     tags: getTagsFromPackageJson(packageJson),
     metadata: getMetadataFromPackageJson(

--- a/packages/nx/src/utils/child-process.ts
+++ b/packages/nx/src/utils/child-process.ts
@@ -21,8 +21,8 @@ export function getRunNxBaseCommand(
 ): string {
   if (existsSync(join(workspaceRoot, 'package.json'))) {
     if (!packageManagerCommand) {
-      const pm = detectPackageManager();
-      packageManagerCommand = getPackageManagerCommand(pm);
+      const pm = detectPackageManager(workspaceRoot);
+      packageManagerCommand = getPackageManagerCommand(pm, workspaceRoot);
     }
     return `${packageManagerCommand.exec} nx`;
   } else {

--- a/packages/nx/src/utils/package-json.spec.ts
+++ b/packages/nx/src/utils/package-json.spec.ts
@@ -76,15 +76,9 @@ describe('installPackageToTmp', () => {
 });
 
 describe('readTargetsFromPackageJson', () => {
-  beforeEach(() => {
-    jest
-      .spyOn(pacakgeManager, 'getPackageManagerCommand')
-      .mockReturnValue({ run: (script) => `npm run ${script}` } as any);
-  });
-
-  afterEach(() => {
-    jest.restoreAllMocks();
-  });
+  const packageManagerCommand = {
+    run: (script: string) => `npm run ${script}`,
+  } as any;
 
   const packageJson: PackageJson = {
     name: 'my-app',
@@ -117,7 +111,8 @@ describe('readTargetsFromPackageJson', () => {
       packageJson,
       nxJson1,
       workspaceRoot,
-      '/root'
+      '/root',
+      packageManagerCommand
     );
     expect(result1['nx-release-publish']).toMatchInlineSnapshot(`
       {
@@ -143,7 +138,8 @@ describe('readTargetsFromPackageJson', () => {
       packageJson,
       nxJson2,
       workspaceRoot,
-      '/root'
+      '/root',
+      packageManagerCommand
     );
     expect(result2['nx-release-publish']).toMatchInlineSnapshot(`
       {
@@ -162,7 +158,8 @@ describe('readTargetsFromPackageJson', () => {
       packageJson,
       {},
       workspaceRoot,
-      '/root'
+      '/root',
+      packageManagerCommand
     );
     expect(result).toMatchInlineSnapshot(`
       {
@@ -205,7 +202,8 @@ describe('readTargetsFromPackageJson', () => {
       },
       {},
       workspaceRoot,
-      '/root'
+      '/root',
+      packageManagerCommand
     );
     expect(result).toEqual({
       build: { ...packageJsonBuildTarget, outputs: ['custom'] },
@@ -232,7 +230,8 @@ describe('readTargetsFromPackageJson', () => {
       },
       {},
       workspaceRoot,
-      '/root'
+      '/root',
+      packageManagerCommand
     );
     expect(result).toMatchInlineSnapshot(`
       {
@@ -275,7 +274,8 @@ describe('readTargetsFromPackageJson', () => {
       },
       {},
       workspaceRoot,
-      '/root'
+      '/root',
+      packageManagerCommand
     );
     expect(result.build).toMatchInlineSnapshot(`
       {
@@ -315,7 +315,8 @@ describe('readTargetsFromPackageJson', () => {
       },
       {},
       workspaceRoot,
-      '/root'
+      '/root',
+      packageManagerCommand
     );
     expect(result.build).toMatchInlineSnapshot(`
       {
@@ -347,7 +348,8 @@ describe('readTargetsFromPackageJson', () => {
       },
       {},
       workspaceRoot,
-      '/root'
+      '/root',
+      packageManagerCommand
     );
     expect(result.build).toMatchInlineSnapshot(`
       {
@@ -377,7 +379,8 @@ describe('readTargetsFromPackageJson', () => {
       },
       {},
       workspaceRoot,
-      '/root'
+      '/root',
+      packageManagerCommand
     );
     expect(result.build).toMatchInlineSnapshot(`
       {
@@ -407,7 +410,8 @@ describe('readTargetsFromPackageJson', () => {
       },
       {},
       workspaceRoot,
-      '/root'
+      '/root',
+      packageManagerCommand
     );
     expect(result.build).toMatchInlineSnapshot(`
       {
@@ -476,7 +480,8 @@ describe('readTargetsFromPackageJson', () => {
       },
       {},
       workspaceRoot,
-      '/root'
+      '/root',
+      packageManagerCommand
     );
     expect(result.test).toMatchInlineSnapshot(`
       {

--- a/packages/nx/src/utils/package-json.ts
+++ b/packages/nx/src/utils/package-json.ts
@@ -370,12 +370,12 @@ function preparePackageInstallation(pkg: string, requiredVersion: string) {
   };
 
   console.log(`Fetching ${pkg}...`);
-  const packageManager = detectPackageManager();
+  const packageManager = detectPackageManager(workspaceRoot);
   const isVerbose = process.env.NX_VERBOSE_LOGGING === 'true';
   generatePackageManagerFiles(tempDir, packageManager);
 
-  const preInstallCommand = getPackageManagerCommand(packageManager).preInstall;
   const pmCommands = getPackageManagerCommand(packageManager);
+  const preInstallCommand = pmCommands.preInstall;
   let addCommand = pmCommands.addDev;
   if (packageManager === 'pnpm') {
     addCommand = 'pnpm add -D'; // we need to ensure that we are not using workspace command

--- a/packages/nx/src/utils/package-json.ts
+++ b/packages/nx/src/utils/package-json.ts
@@ -187,8 +187,6 @@ export function buildTargetFromScript(
   };
 }
 
-let packageManagerCommand: PackageManagerCommands | undefined;
-
 export function getMetadataFromPackageJson(
   packageJson: PackageJson,
   isInPackageManagerWorkspaces: boolean
@@ -231,9 +229,18 @@ export function readTargetsFromPackageJson(
   const { scripts, nx, private: isPrivate } = packageJson ?? {};
   const res: Record<string, TargetConfiguration> = {};
   const includedScripts = nx?.includedScripts || Object.keys(scripts ?? {});
-  for (const script of includedScripts) {
-    packageManagerCommand ??= getPackageManagerCommand();
-    res[script] = buildTargetFromScript(script, scripts, packageManagerCommand);
+  if (includedScripts.length > 0) {
+    const packageManagerCommand = getPackageManagerCommand(
+      detectPackageManager(workspaceRoot),
+      workspaceRoot
+    );
+    for (const script of includedScripts) {
+      res[script] = buildTargetFromScript(
+        script,
+        scripts,
+        packageManagerCommand
+      );
+    }
   }
   for (const targetName in nx?.targets) {
     const nxTarget = nx.targets[targetName];

--- a/packages/nx/src/utils/package-json.ts
+++ b/packages/nx/src/utils/package-json.ts
@@ -224,23 +224,14 @@ export function readTargetsFromPackageJson(
   packageJson: PackageJson,
   nxJson: NxJsonConfiguration,
   projectRoot: string,
-  workspaceRoot: string
+  workspaceRoot: string,
+  packageManagerCommand: PackageManagerCommands
 ) {
   const { scripts, nx, private: isPrivate } = packageJson ?? {};
   const res: Record<string, TargetConfiguration> = {};
   const includedScripts = nx?.includedScripts || Object.keys(scripts ?? {});
-  if (includedScripts.length > 0) {
-    const packageManagerCommand = getPackageManagerCommand(
-      detectPackageManager(workspaceRoot),
-      workspaceRoot
-    );
-    for (const script of includedScripts) {
-      res[script] = buildTargetFromScript(
-        script,
-        scripts,
-        packageManagerCommand
-      );
-    }
+  for (const script of includedScripts) {
+    res[script] = buildTargetFromScript(script, scripts, packageManagerCommand);
   }
   for (const targetName in nx?.targets) {
     const nxTarget = nx.targets[targetName];

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -50,13 +50,20 @@ export const createNodes: CreateNodesV2<PlaywrightPluginOptions> = [
       `playwright-${optionsHash}.hash`
     );
     const pluginCache = new PluginCache<PlaywrightTargets>(cachePath);
-    const pmc = getPackageManagerCommand(
-      detectPackageManager(context.workspaceRoot)
-    );
+    const packageManager = detectPackageManager(context.workspaceRoot);
+    const pmc = getPackageManagerCommand(packageManager);
+    const lockFileName = getLockFileName(packageManager);
     try {
       return await createNodesFromFiles(
         (configFile, options, context) =>
-          createNodesInternal(configFile, options, context, pluginCache, pmc),
+          createNodesInternal(
+            configFile,
+            options,
+            context,
+            pluginCache,
+            pmc,
+            lockFileName
+          ),
         configFilePaths,
         options,
         context
@@ -74,7 +81,8 @@ async function createNodesInternal(
   options: PlaywrightPluginOptions,
   context: CreateNodesContextV2,
   pluginCache: PluginCache<PlaywrightTargets>,
-  pmc: ReturnType<typeof getPackageManagerCommand>
+  pmc: ReturnType<typeof getPackageManagerCommand>,
+  lockFileName: string
 ) {
   const projectRoot = dirname(configFilePath);
 
@@ -101,10 +109,7 @@ async function createNodesInternal(
       CI: process.env.CI,
     },
     context,
-    [
-      getLockFileName(detectPackageManager(context.workspaceRoot)),
-      ...externalTsconfigInputs,
-    ]
+    [lockFileName, ...externalTsconfigInputs]
   );
 
   if (!pluginCache.has(hash)) {

--- a/packages/react-native/plugins/plugin.ts
+++ b/packages/react-native/plugins/plugin.ts
@@ -47,11 +47,20 @@ export const createNodes: CreateNodesV2<ReactNativePluginOptions> = [
       `react-native-${optionsHash}.hash`
     );
     const targetsCache = new PluginCache<ReactNativeTargets>(cachePath);
+    const lockFileName = getLockFileName(
+      detectPackageManager(context.workspaceRoot)
+    );
 
     try {
       return await createNodesFromFiles(
         (configFile, options, context) =>
-          createNodesInternal(configFile, options, context, targetsCache),
+          createNodesInternal(
+            configFile,
+            options,
+            context,
+            targetsCache,
+            lockFileName
+          ),
         configFiles,
         options,
         context
@@ -68,7 +77,8 @@ async function createNodesInternal(
   configFile: string,
   options: ReactNativePluginOptions,
   context: CreateNodesContextV2,
-  targetsCache: PluginCache<ReactNativeTargets>
+  targetsCache: PluginCache<ReactNativeTargets>,
+  lockFileName: string
 ): Promise<CreateNodesResult> {
   options = normalizeOptions(options);
   const projectRoot = dirname(configFile);
@@ -99,7 +109,7 @@ async function createNodesInternal(
     projectRoot,
     options,
     context,
-    [getLockFileName(detectPackageManager(context.workspaceRoot))]
+    [lockFileName]
   );
 
   if (!targetsCache.has(hash)) {

--- a/packages/remix/src/plugins/plugin.ts
+++ b/packages/remix/src/plugins/plugin.ts
@@ -53,9 +53,9 @@ export const createNodes: CreateNodesV2<RemixPluginOptions> = [
     const optionsHash = hashObject(options);
     const cachePath = join(workspaceDataDirectory, `remix-${optionsHash}.hash`);
     const targetsCache = new PluginCache<RemixTargets>(cachePath);
-    const pmc = getPackageManagerCommand(
-      detectPackageManager(context.workspaceRoot)
-    );
+    const packageManager = detectPackageManager(context.workspaceRoot);
+    const pmc = getPackageManagerCommand(packageManager);
+    const lockFileName = getLockFileName(packageManager);
     try {
       return await createNodesFromFiles(
         (configFile, options, context) =>
@@ -65,7 +65,8 @@ export const createNodes: CreateNodesV2<RemixPluginOptions> = [
             context,
             targetsCache,
             _isUsingTsSolutionSetup(),
-            pmc
+            pmc,
+            lockFileName
           ),
         configFilePaths,
         options,
@@ -85,7 +86,8 @@ async function createNodesInternal(
   context: CreateNodesContextV2,
   targetsCache: PluginCache<RemixTargets>,
   isUsingTsSolutionSetup: boolean,
-  pmc: ReturnType<typeof getPackageManagerCommand>
+  pmc: ReturnType<typeof getPackageManagerCommand>,
+  lockFileName: string
 ) {
   const projectRoot = dirname(configFilePath);
   const fullyQualifiedProjectRoot = join(context.workspaceRoot, projectRoot);
@@ -114,7 +116,7 @@ async function createNodesInternal(
       projectRoot,
       { ...options, isUsingTsSolutionSetup },
       context,
-      [getLockFileName(detectPackageManager(context.workspaceRoot))]
+      [lockFileName]
     )) + configFilePath;
 
   if (!targetsCache.has(hash)) {

--- a/packages/rollup/src/plugins/plugin.ts
+++ b/packages/rollup/src/plugins/plugin.ts
@@ -53,9 +53,9 @@ export const createNodes: CreateNodesV2<RollupPluginOptions> = [
     );
     const targetsCache = new PluginCache<RollupTargets>(cachePath);
     const isTsSolutionSetup = isUsingTsSolutionSetup();
-    const pmc = getPackageManagerCommand(
-      detectPackageManager(context.workspaceRoot)
-    );
+    const packageManager = detectPackageManager(context.workspaceRoot);
+    const pmc = getPackageManagerCommand(packageManager);
+    const lockFileName = getLockFileName(packageManager);
 
     try {
       return await createNodesFromFiles(
@@ -66,7 +66,8 @@ export const createNodes: CreateNodesV2<RollupPluginOptions> = [
             context,
             targetsCache,
             isTsSolutionSetup,
-            pmc
+            pmc,
+            lockFileName
           ),
         configFilePaths,
         normalizedOptions,
@@ -86,7 +87,8 @@ async function createNodesInternal(
   context: CreateNodesContextV2,
   targetsCache: PluginCache<RollupTargets>,
   isTsSolutionSetup: boolean,
-  pmc: ReturnType<typeof getPackageManagerCommand>
+  pmc: ReturnType<typeof getPackageManagerCommand>,
+  lockFileName: string
 ) {
   const projectRoot = dirname(configFilePath);
   const fullyQualifiedProjectRoot = join(context.workspaceRoot, projectRoot);
@@ -104,7 +106,7 @@ async function createNodesInternal(
     projectRoot,
     options,
     context,
-    [getLockFileName(detectPackageManager(context.workspaceRoot))]
+    [lockFileName]
   );
 
   if (!targetsCache.has(hash)) {

--- a/packages/rsbuild/src/plugins/plugin.ts
+++ b/packages/rsbuild/src/plugins/plugin.ts
@@ -47,9 +47,9 @@ export const createNodesV2: CreateNodesV2<RsbuildPluginOptions> = [
     );
     const targetsCache = new PluginCache<RsbuildTargets>(cachePath);
     const isUsingTsSolutionSetup = _isUsingTsSolutionSetup();
-    const pmc = getPackageManagerCommand(
-      detectPackageManager(context.workspaceRoot)
-    );
+    const packageManager = detectPackageManager(context.workspaceRoot);
+    const pmc = getPackageManagerCommand(packageManager);
+    const lockFileName = getLockFileName(packageManager);
     try {
       return await createNodesFromFiles(
         (configFile, options, context) =>
@@ -59,7 +59,8 @@ export const createNodesV2: CreateNodesV2<RsbuildPluginOptions> = [
             context,
             targetsCache,
             isUsingTsSolutionSetup,
-            pmc
+            pmc,
+            lockFileName
           ),
         configFilePaths,
         options,
@@ -77,7 +78,8 @@ async function createNodesInternal(
   context: CreateNodesContextV2,
   targetsCache: PluginCache<RsbuildTargets>,
   isUsingTsSolutionSetup: boolean,
-  pmc: ReturnType<typeof getPackageManagerCommand>
+  pmc: ReturnType<typeof getPackageManagerCommand>,
+  lockFileName: string
 ) {
   const projectRoot = dirname(configFilePath);
   // Do not create a project if package.json and project.json isn't there.
@@ -97,7 +99,7 @@ async function createNodesInternal(
     projectRoot,
     { ...normalizedOptions, isUsingTsSolutionSetup },
     context,
-    [getLockFileName(detectPackageManager(context.workspaceRoot))]
+    [lockFileName]
   );
 
   if (!targetsCache.has(hash)) {

--- a/packages/rspack/src/plugins/plugin.ts
+++ b/packages/rspack/src/plugins/plugin.ts
@@ -47,9 +47,9 @@ export const createNodesV2: CreateNodesV2<RspackPluginOptions> = [
     );
     const targetsCache = new PluginCache<RspackTargets>(cachePath);
     const isTsSolutionSetup = isUsingTsSolutionSetup();
-    const pmc = getPackageManagerCommand(
-      detectPackageManager(context.workspaceRoot)
-    );
+    const packageManager = detectPackageManager(context.workspaceRoot);
+    const pmc = getPackageManagerCommand(packageManager);
+    const lockFileName = getLockFileName(packageManager);
     try {
       return await createNodesFromFiles(
         (configFile, options, context) =>
@@ -59,7 +59,8 @@ export const createNodesV2: CreateNodesV2<RspackPluginOptions> = [
             context,
             targetsCache,
             isTsSolutionSetup,
-            pmc
+            pmc,
+            lockFileName
           ),
         configFilePaths,
         options,
@@ -77,7 +78,8 @@ async function createNodesInternal(
   context: CreateNodesContextV2,
   targetsCache: PluginCache<RspackTargets>,
   isTsSolutionSetup: boolean,
-  pmc: ReturnType<typeof getPackageManagerCommand>
+  pmc: ReturnType<typeof getPackageManagerCommand>,
+  lockFileName: string
 ) {
   const projectRoot = dirname(configFilePath);
   // Do not create a project if package.json and project.json isn't there.
@@ -99,12 +101,7 @@ async function createNodesInternal(
   const normalizedOptions = normalizeOptions(options);
 
   const lockFileHash =
-    hashFile(
-      join(
-        context.workspaceRoot,
-        getLockFileName(detectPackageManager(context.workspaceRoot))
-      )
-    ) ?? '';
+    hashFile(join(context.workspaceRoot, lockFileName)) ?? '';
 
   const nodeHash = hashArray([
     hashFile(join(context.workspaceRoot, configFilePath)),

--- a/packages/storybook/src/plugins/plugin.ts
+++ b/packages/storybook/src/plugins/plugin.ts
@@ -54,9 +54,9 @@ export const createNodes: CreateNodesV2<StorybookPluginOptions> = [
       `storybook-${optionsHash}.hash`
     );
     const targetsCache = new PluginCache<StorybookTargets>(cachePath);
-    const pmc = getPackageManagerCommand(
-      detectPackageManager(context.workspaceRoot)
-    );
+    const packageManager = detectPackageManager(context.workspaceRoot);
+    const pmc = getPackageManagerCommand(packageManager);
+    const lockFileName = getLockFileName(packageManager);
 
     try {
       return await createNodesFromFiles(
@@ -66,7 +66,8 @@ export const createNodes: CreateNodesV2<StorybookPluginOptions> = [
             normalizedOptions,
             context,
             targetsCache,
-            pmc
+            pmc,
+            lockFileName
           ),
         configFilePaths,
         normalizedOptions,
@@ -85,7 +86,8 @@ async function createNodesInternal(
   options: Required<StorybookPluginOptions>,
   context: CreateNodesContextV2,
   targetsCache: PluginCache<StorybookTargets>,
-  pmc: ReturnType<typeof getPackageManagerCommand>
+  pmc: ReturnType<typeof getPackageManagerCommand>,
+  lockFileName: string
 ) {
   let projectRoot = '';
   if (configFilePath.includes('/.storybook')) {
@@ -111,7 +113,7 @@ async function createNodesInternal(
     projectRoot,
     options,
     context,
-    [getLockFileName(detectPackageManager(context.workspaceRoot))]
+    [lockFileName]
   );
 
   const projectName = buildProjectName(projectRoot, context.workspaceRoot);

--- a/packages/webpack/src/plugins/plugin.ts
+++ b/packages/webpack/src/plugins/plugin.ts
@@ -60,9 +60,9 @@ export const createNodes: CreateNodesV2<WebpackPluginOptions> = [
     const targetsCache = new PluginCache<WebpackTargets>(cachePath);
     const normalizedOptions = normalizeOptions(options);
     const isTsSolutionSetup = isUsingTsSolutionSetup();
-    const pmc = getPackageManagerCommand(
-      detectPackageManager(context.workspaceRoot)
-    );
+    const packageManager = detectPackageManager(context.workspaceRoot);
+    const pmc = getPackageManagerCommand(packageManager);
+    const lockFileName = getLockFileName(packageManager);
     try {
       return await createNodesFromFiles(
         (configFile, options, context) =>
@@ -72,7 +72,8 @@ export const createNodes: CreateNodesV2<WebpackPluginOptions> = [
             context,
             targetsCache,
             isTsSolutionSetup,
-            pmc
+            pmc,
+            lockFileName
           ),
         configFilePaths,
         normalizedOptions,
@@ -92,7 +93,8 @@ async function createNodesInternal(
   context: CreateNodesContextV2,
   targetsCache: PluginCache<WebpackTargets>,
   isTsSolutionSetup: boolean,
-  pmc: ReturnType<typeof getPackageManagerCommand>
+  pmc: ReturnType<typeof getPackageManagerCommand>,
+  lockFileName: string
 ): Promise<CreateNodesResult> {
   const projectRoot = dirname(configFilePath);
 
@@ -109,7 +111,7 @@ async function createNodesInternal(
     projectRoot,
     options,
     context,
-    [getLockFileName(detectPackageManager(context.workspaceRoot))]
+    [lockFileName]
   );
 
   if (!targetsCache.has(hash)) {


### PR DESCRIPTION
## Current Behavior

`readTargetsFromPackageJson` (in `packages/nx/src/utils/package-json.ts`) receives a `workspaceRoot` argument but never passes it to package manager detection:

```ts
for (const script of includedScripts) {
  packageManagerCommand ??= getPackageManagerCommand(); // ← no workspaceRoot
  res[script] = buildTargetFromScript(script, scripts, packageManagerCommand);
}
```

Two consequences:

1. **Wrong package manager** — `detectPackageManager()` defaults `dir = ''`, so the lockfile probe runs in the CWD, not the workspace. When that finds nothing it falls back to `npm_config_user_agent`, so the inferred `runCommand` (`npm run X` vs `pnpm run X` vs `yarn X`) on script targets ends up depending on whoever invoked the nx process rather than on the workspace's actual lockfile.

2. **Module-level cache** — `let packageManagerCommand` (cleared with `??=`) memoizes the first detection result across all subsequent calls in the process. So even if the first call had the right `workspaceRoot`, every later call inherits that detection regardless of *its* `workspaceRoot`. This is also why `packages/nx/src/plugins/package-json/create-nodes.spec.ts` had four pre-existing snapshot failures locally (`pnpm run …` instead of the expected `npm run …`) — the first test in any process locked detection to the host's PM.

This is a follow-up to #35116, which moved package manager detection into the `createNodes` callback for the inferred plugins but missed this code path.

## Expected Behavior

- Drop the module-level cache.
- Thread `workspaceRoot` into both `detectPackageManager` and `getPackageManagerCommand`, so the lockfile probe runs in the right directory.

```ts
if (includedScripts.length > 0) {
  const packageManagerCommand = getPackageManagerCommand(
    detectPackageManager(workspaceRoot),
    workspaceRoot
  );
  for (const script of includedScripts) {
    res[script] = buildTargetFromScript(script, scripts, packageManagerCommand);
  }
}
```

The `packages/nx/src/plugins/package-json/create-nodes.spec.ts` fixture now seeds `package-lock.json` into memfs in a `beforeEach`, matching the pattern #35116 established for plugin specs. Without the lockfile the detector still falls back to the env var; with it, every test deterministically picks `npm`, matching the existing snapshots.

## Verification

Before this PR: 4 failures in `packages/nx/src/plugins/package-json/create-nodes.spec.ts`:

```
✕ should build projects from package.json files
✕ should store js package metadata
✕ should add a script target if the sibling project.json file does not exist
✕ should add a script target if the sibling project.json exists but does not have a conflicting target

Tests: 4 failed, 7 passed, 11 total
```

After this PR:

```
Tests: 11 passed, 11 total
```

## Related Issue(s)

Follow-up to #35116.
