### PR TITLE
fix(js): include transitive workspace modules in pnpm prune

### DIFF
--- a/packages/nx/src/plugins/js/lock-file/pnpm-parser.spec.ts
+++ b/packages/nx/src/plugins/js/lock-file/pnpm-parser.spec.ts
@@ -1113,6 +1113,108 @@ describe('pnpm LockFile utility', () => {
       );
       expect(Object.keys(externalNodes).length).toEqual(5);
     });
+
+    it('should include transitive workspace dependency importers in the pruned lockfile', () => {
+      const rootLockFile = `lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      '@proj/api':
+        specifier: workspace:*
+        version: link:apps/api
+
+  apps/api:
+    dependencies:
+      '@proj/lib-a':
+        specifier: workspace:*
+        version: link:../../libs/lib-a
+
+  libs/lib-a:
+    dependencies:
+      '@proj/lib-b':
+        specifier: workspace:*
+        version: link:../lib-b
+
+  libs/lib-b:
+    dependencies:
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
+
+packages:
+
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaBf6QTuZ7GkLtJGQmRvR9dFRJlcpNKWPr3L1fq5dJSpE0QdRfwYHksG0lWvS3s9G1u7x0MxA==}
+
+snapshots:
+
+  lodash@4.17.21: {}
+`;
+      const graph: ProjectGraph = {
+        nodes: {
+          api: {
+            name: 'api',
+            type: 'app',
+            data: {
+              root: 'apps/api',
+              metadata: { js: { packageName: '@proj/api' } },
+            },
+          },
+          'lib-a': {
+            name: 'lib-a',
+            type: 'lib',
+            data: {
+              root: 'libs/lib-a',
+              metadata: { js: { packageName: '@proj/lib-a' } },
+            },
+          },
+          'lib-b': {
+            name: 'lib-b',
+            type: 'lib',
+            data: {
+              root: 'libs/lib-b',
+              metadata: { js: { packageName: '@proj/lib-b' } },
+            },
+          },
+        },
+        dependencies: {
+          api: [{ source: 'api', target: 'lib-a', type: 'static' }],
+          'lib-a': [{ source: 'lib-a', target: 'lib-b', type: 'static' }],
+          'lib-b': [{ source: 'lib-b', target: 'npm:lodash', type: 'static' }],
+          'npm:lodash': [],
+        },
+        externalNodes: {
+          'npm:lodash': {
+            type: 'npm',
+            name: 'npm:lodash',
+            data: { packageName: 'lodash', version: '4.17.21' },
+          },
+        },
+      };
+
+      const result = stringifyPnpmLockfile(
+        pruneProjectGraph(graph, {
+          dependencies: { '@proj/lib-a': 'workspace:*' },
+        }),
+        rootLockFile,
+        {
+          dependencies: { '@proj/lib-a': 'workspace:*' },
+        },
+        '/virtual'
+      );
+
+      expect(result).toContain('workspace_modules/@proj/lib-a:');
+      expect(result).toContain('workspace_modules/@proj/lib-b:');
+      expect(result).toContain('specifier: file:../lib-b');
+      expect(result).toContain('version: link:../lib-b');
+      expect(result).toContain('lodash@4.17.21:');
+    });
   });
 
   describe('mixed keys', () => {

--- a/packages/nx/src/plugins/js/lock-file/pnpm-parser.ts
+++ b/packages/nx/src/plugins/js/lock-file/pnpm-parser.ts
@@ -28,7 +28,7 @@ import { hashArray } from '../../../hasher/file-hasher';
 import { CreateDependenciesContext } from '../../../project-graph/plugins';
 import { getCatalogManager } from '../../../utils/catalog';
 import { findNodeMatchingVersion } from './project-graph-pruning';
-import { join } from 'path';
+import { join, relative, sep } from 'path';
 import { getWorkspacePackagesFromGraph } from '../utils/get-workspace-packages-from-graph';
 import { satisfies, validRange } from 'semver';
 let currentLockFileHash: string;
@@ -589,14 +589,11 @@ export function stringifyPnpmLockfile(
     +lockfileVersion
   );
 
-  const workspaceDependencyImporters: Record<string, ProjectSnapshot> = {};
-  for (const [packageName, importerPath] of Object.entries(requiredImporters)) {
-    const baseImporter = importers[importerPath];
-    if (baseImporter) {
-      workspaceDependencyImporters[`workspace_modules/${packageName}`] =
-        baseImporter;
-    }
-  }
+  const workspaceDependencyImporters = mapWorkspaceDependencyImporters(
+    requiredImporters,
+    importers,
+    graph
+  );
 
   const output: Lockfile = {
     ...data,
@@ -609,6 +606,112 @@ export function stringifyPnpmLockfile(
   };
 
   return stringifyToPnpmYaml(output);
+}
+
+function mapWorkspaceDependencyImporters(
+  requiredImporters: Record<string, string>,
+  importers: Record<string, ProjectSnapshot>,
+  graph: ProjectGraph
+): Record<string, ProjectSnapshot> {
+  const workspaceModules = getWorkspacePackagesFromGraph(graph);
+  const workspaceDependencyImporters: Record<string, ProjectSnapshot> = {};
+  const pendingImporters = Object.entries(requiredImporters);
+
+  for (let i = 0; i < pendingImporters.length; i++) {
+    const [packageName, importerPath] = pendingImporters[i];
+    const workspaceModulesPath = `workspace_modules/${packageName}`;
+    if (workspaceDependencyImporters[workspaceModulesPath]) {
+      continue;
+    }
+
+    const baseImporter = importers[importerPath];
+    if (baseImporter) {
+      workspaceDependencyImporters[workspaceModulesPath] =
+        remapWorkspaceDependencies(baseImporter, packageName, workspaceModules);
+
+      collectWorkspaceDependencyImporters(
+        baseImporter,
+        importerPath,
+        workspaceModules,
+        pendingImporters
+      );
+    }
+  }
+
+  return workspaceDependencyImporters;
+}
+
+function collectWorkspaceDependencyImporters(
+  importer: ProjectSnapshot,
+  importerPath: string,
+  workspaceModules: Map<string, unknown>,
+  pendingImporters: [string, string][]
+) {
+  ['dependencies', 'optionalDependencies', 'devDependencies'].forEach(
+    (depType) => {
+      if (!importer[depType]) {
+        return;
+      }
+
+      for (const [dependencyName, dependencyRef] of Object.entries(
+        importer[depType]
+      )) {
+        if (!workspaceModules.has(dependencyName)) {
+          continue;
+        }
+
+        pendingImporters.push([
+          dependencyName,
+          join(importerPath, dependencyRef.replace(/^(link:|file:)/, '')),
+        ]);
+      }
+    }
+  );
+}
+
+function remapWorkspaceDependencies(
+  importer: ProjectSnapshot,
+  packageName: string,
+  workspaceModules: Map<string, unknown>
+): ProjectSnapshot {
+  const snapshot: ProjectSnapshot = { ...importer };
+
+  ['dependencies', 'optionalDependencies', 'devDependencies'].forEach(
+    (depType) => {
+      if (!snapshot[depType]) {
+        return;
+      }
+
+      snapshot[depType] = { ...snapshot[depType] };
+      for (const dependencyName of Object.keys(snapshot[depType])) {
+        if (!workspaceModules.has(dependencyName)) {
+          continue;
+        }
+
+        snapshot[depType][dependencyName] =
+          `link:${getWorkspaceModuleRelativePath(packageName, dependencyName)}`;
+      }
+    }
+  );
+
+  if (snapshot.specifiers) {
+    snapshot.specifiers = { ...snapshot.specifiers };
+    for (const dependencyName of Object.keys(snapshot.specifiers)) {
+      if (workspaceModules.has(dependencyName)) {
+        snapshot.specifiers[dependencyName] =
+          `file:${getWorkspaceModuleRelativePath(packageName, dependencyName)}`;
+      }
+    }
+  }
+
+  return snapshot;
+}
+
+function getWorkspaceModuleRelativePath(
+  fromPackageName: string,
+  toPackageName: string
+): string {
+  return relative(fromPackageName, toPackageName).split(sep).join('/');
 }
 
 function mapSnapshots(

--- a/packages/nx/src/plugins/js/lock-file/project-graph-pruning.spec.ts
+++ b/packages/nx/src/plugins/js/lock-file/project-graph-pruning.spec.ts
@@ -488,6 +488,18 @@ describe('project-graph-pruning', () => {
               },
             },
           },
+          'workspace-lib-dependency': {
+            name: 'workspace-lib-dependency',
+            type: 'lib',
+            data: {
+              root: 'packages/workspace-lib-dependency',
+              metadata: {
+                js: {
+                  packageName: 'workspace-lib-dependency',
+                },
+              },
+            },
+          },
         },
         dependencies: {
           'npm:lodash': [
@@ -509,6 +521,13 @@ describe('project-graph-pruning', () => {
           'workspace-lib': [
             {
               source: 'workspace-lib',
+              target: 'npm:lodash',
+              type: 'static',
+            },
+          ],
+          'workspace-lib-dependency': [
+            {
+              source: 'workspace-lib-dependency',
               target: 'npm:lodash',
               type: 'static',
             },
@@ -600,6 +619,46 @@ describe('project-graph-pruning', () => {
       const prunedGraph = pruneProjectGraph(graph, prunedPackageJson);
 
       expect(prunedGraph.nodes['workspace-lib']).toBeDefined();
+    });
+
+    it('should include external dependencies from transitive workspace dependencies', () => {
+      graph.dependencies['workspace-lib'] = [
+        {
+          source: 'workspace-lib',
+          target: 'transitive-workspace-lib',
+          type: 'static',
+        },
+      ];
+      graph.nodes['transitive-workspace-lib'] = {
+        name: 'transitive-workspace-lib',
+        type: 'lib',
+        data: {
+          root: 'packages/transitive-workspace-lib',
+          metadata: {
+            js: {
+              packageName: 'transitive-workspace-lib',
+            },
+          },
+        },
+      };
+      graph.dependencies['transitive-workspace-lib'] = [
+        {
+          source: 'transitive-workspace-lib',
+          target: 'npm:lodash',
+          type: 'static',
+        },
+      ];
+      const prunedPackageJson: PackageJson = {
+        name: 'test',
+        version: '1.0.0',
+        dependencies: {
+          'workspace-lib': '*',
+        },
+      };
+
+      const prunedGraph = pruneProjectGraph(graph, prunedPackageJson);
+
+      expect(prunedGraph.externalNodes?.['npm:lodash']).toBeDefined();
     });
 
     it('should handle devDependencies', () => {

--- a/packages/nx/src/plugins/js/lock-file/project-graph-pruning.ts
+++ b/packages/nx/src/plugins/js/lock-file/project-graph-pruning.ts
@@ -188,12 +188,29 @@ function traverseNode(
 function traverseWorkspaceNode(
   graph: ProjectGraph,
   builder: ProjectGraphBuilder,
-  node: ProjectGraphProjectNode
+  node: ProjectGraphProjectNode,
+  seenWorkspaceNodes = new Set<string>()
 ) {
+  if (seenWorkspaceNodes.has(node.name)) {
+    return;
+  }
+  seenWorkspaceNodes.add(node.name);
+
   graph.dependencies[node.name]?.forEach((dep) => {
     const depNode = graph.externalNodes[dep.target];
     if (depNode) {
       traverseNode(graph, builder, depNode);
+      return;
+    }
+
+    const workspaceDepNode = graph.nodes[dep.target];
+    if (workspaceDepNode?.data?.metadata?.js?.packageName) {
+      traverseWorkspaceNode(
+        graph,
+        builder,
+        workspaceDepNode,
+        seenWorkspaceNodes
+      );
     }
   });
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Current Behavior

`@nx/js:prune-lockfile` only emits pnpm importer entries for direct workspace package dependencies. When a copied workspace package depends on another workspace package, the pruned lockfile can omit the transitive workspace importer, omit that transitive module's npm dependencies from the packages section, and leave workspace dependency references using the original workspace layout rather than the flat `workspace_modules` layout used by `@nx/js:copy-workspace-modules`.

## Expected Behavior

`@nx/js:prune-lockfile` recursively follows workspace package dependencies, includes external dependencies reached through transitive workspace modules, emits importer entries for each required workspace module, and rewrites workspace dependency references to the relative `workspace_modules` paths expected after copying workspace modules.

## Related Issue(s)

Fixes #34655
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-9dd34ec7-1072-4cf1-b59a-ac836b17d9ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-9dd34ec7-1072-4cf1-b59a-ac836b17d9ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

