### PR TITLE
fix(core): unique telemetry user_id; expose workspace_id dimension

### DIFF
--- a/packages/nx/src/analytics/analytics.ts
+++ b/packages/nx/src/analytics/analytics.ts
@@ -17,6 +17,7 @@ import {
 } from '../utils/package-manager';
 import { parse } from 'semver';
 import * as os from 'os';
+import { createHash } from 'crypto';
 import { getCurrentMachineId } from '../utils/machine-id-cache';
 import { isCI } from '../utils/is-ci';
 import { generateWorkspaceId } from '../utils/analytics-prompt';
@@ -69,7 +70,7 @@ export async function startAnalytics() {
     return;
   }
   const isNxCloud = !!(nxJson?.nxCloudId ?? nxJson?.nxCloudAccessToken);
-  const userId = await getCurrentMachineId();
+  const userId = await getTelemetryUserId(workspaceId);
   const packageManagerInfo = getPackageManagerInfo();
 
   const nodeVersion = parse(process.version);
@@ -261,4 +262,13 @@ function getPackageManagerInfo() {
 function isAnalyticsEnabled(): boolean {
   const nxJson = readNxJson(workspaceRoot);
   return nxJson?.analytics === true;
+}
+
+// Mix workspace id in: shared Docker images (Gitpod, Cypress, etc.) bake
+// in /etc/machine-id, so machine-id alone collapses many users into one.
+async function getTelemetryUserId(workspaceId: string): Promise<string> {
+  const machineId = await getCurrentMachineId();
+  return createHash('sha256')
+    .update(`${machineId}|${workspaceId}`)
+    .digest('hex');
 }

--- a/packages/nx/src/native/telemetry/constants.rs
+++ b/packages/nx/src/native/telemetry/constants.rs
@@ -53,6 +53,7 @@ pub mod user_dimension {
 pub mod event_dimension {
     pub const NX_VERSION: &str = "ep.nx_version";
     pub const IS_AI_AGENT: &str = "ep.is_ai_agent";
+    pub const WORKSPACE_ID: &str = "ep.workspace_id";
     pub const COMMAND: &str = "ep.nx_command";
     pub const GENERATOR_NAME: &str = "ep.generator_name";
     pub const PACKAGE_NAME: &str = "ep.package_name";

--- a/packages/nx/src/native/telemetry/service.rs
+++ b/packages/nx/src/native/telemetry/service.rs
@@ -128,6 +128,10 @@ impl TelemetryService {
             event_dimension::IS_AI_AGENT.to_string(),
             is_ai_agent.to_string(),
         );
+        user_parameters.insert(
+            event_dimension::WORKSPACE_ID.to_string(),
+            opts.workspace_id.clone(),
+        );
         user_parameters.insert(user_dimension::IS_CI.to_string(), opts.is_ci.to_string());
         user_parameters.insert(
             user_dimension::NX_CLOUD_ENABLED.to_string(),


### PR DESCRIPTION
## Current Behavior

Nx CLI telemetry derives `user_id` from `/etc/machine-id` (or the platform-equivalent GUID), SHA-256s it, and sends it to GA4 as `uid`. This collides for any environment that bakes `/etc/machine-id` into a shared image, including:

- Gitpod (`gitpod/workspace-full`, `gitpod/workspace-node`)
- Cypress (`cypress/included`, `cypress/base`)
- Playwright (`mcr.microsoft.com/playwright:*`)
- GitHub Codespaces / GH Actions hosted runner AMIs (likely)

I confirmed empirically that both Gitpod images produce the exact same `user_id` hash, which means every Nx invocation across every Gitpod tenant globally was reported to GA as one user. This triggers the GA4 "user_id high cardinality" warning.

Separately, `workspace_id` is currently sent only as the GA4 `cid` (client_id), so it is not queryable as a standard custom dimension in GA Explorations or standard reports — it is only accessible via BigQuery export.

## Expected Behavior

- `user_id` is unique per (machine, workspace) pair so that shared `/etc/machine-id` no longer collides users from different repos. Repeated CI runs of the same workspace stay grouped (no inflation), but different workspaces sharing the same image are no longer collapsed.
- `workspace_id` is available as a standard event-scoped custom dimension (`ep.workspace_id`) so that "how many distinct workspaces ran feature X?" can be answered directly in GA Explorations and reports.

After merge + deploy, the dimension still needs to be registered once in the GA4 property:

- GA Admin → Custom Definitions → Create Custom Dimension
- Name: `workspace_id`
- Scope: `Event`
- Event parameter: `workspace_id`

## Related Issue(s)

No related GitHub issue — discovered while investigating GA4 console warnings.