### PR TITLE
fix(maven): serialize Maven 4 build state recording

### DIFF
--- a/e2e/maven/src/maven-batch-v4.test.ts
+++ b/e2e/maven/src/maven-batch-v4.test.ts
@@ -47,6 +47,21 @@ wrapperUrl=https://repo.maven.apache.org/maven2/org/apache/maven/wrapper/maven-w
     );
   });
 
+  it('should record build state while running Maven 4 resource phases in parallel', () => {
+    const output = runCLI(
+      'run-many -t resources,after:resources --parallel=3 --skip-nx-cache',
+      {
+        env: { NX_BATCH_MODE: 'true', NX_VERBOSE_LOGGING: 'true' },
+      }
+    );
+
+    expect(output).toContain('Successfully ran targets');
+    expect(output).toContain('resources');
+    expect(output).toContain('after:resources');
+    expect(output).not.toContain('context.terminal');
+    expect(output).not.toContain('Terminal.writer()');
+  });
+
   it('should install successfully after restoring cached package outputs', () => {
     // Step 1: Clean target directories to simulate a clean CI checkout
     runCLI('run-many -t clean');

--- a/packages/maven/batch-runner-adapters/maven4/src/main/kotlin/dev/nx/maven/adapter/maven4/Maven4AdapterInvoker.kt
+++ b/packages/maven/batch-runner-adapters/maven4/src/main/kotlin/dev/nx/maven/adapter/maven4/Maven4AdapterInvoker.kt
@@ -105,6 +105,7 @@ class Maven4AdapterInvoker(
         }
     }
 
+    @Synchronized
     override fun recordBuildStates(projectSelectors: Set<String>) {
         val nxMaven = invoker.getNxMaven()
         if (nxMaven == null) {


### PR DESCRIPTION
## Current Behavior

Maven 4 batch invocations can overlap build-state recording with another resident invocation on the same adapter. When Maven logs from that path, the Maven 4 logging context can have a null terminal and throw a `context.terminal` NPE.

## Expected Behavior

Maven 4 invocation and build-state recording are serialized on the adapter, so build-state logging uses a valid Maven context. The Maven 4 batch e2e spec also exercises parallel `resources` and `after:resources` targets.

## Related Issue(s)

N/A
