### PR TITLE
chore(testing): split NX_E2E_SKIP_CLEANUP into global/project-scoped vars

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -327,7 +327,7 @@ jobs:
           NX_NATIVE_LOGGING: 'false'
           NX_E2E_RUN_E2E: 'true'
           NX_CLOUD_NO_TIMEOUTS: 'true'
-          NX_E2E_SKIP_CLEANUP: 'true'
+          NX_E2E_SKIP_GLOBAL_CLEANUP: 'true'
           NODE_OPTIONS: --max_old_space_size=8192
           SELECTED_PM: ${{ matrix.package_manager }}
           npm_config_registry: http://localhost:4872
@@ -352,7 +352,7 @@ jobs:
           NX_E2E_VERBOSE_LOGGING: 'true'
           NX_NATIVE_LOGGING: 'false'
           NX_E2E_RUN_E2E: 'true'
-          NX_E2E_SKIP_CLEANUP: 'true'
+          NX_E2E_SKIP_GLOBAL_CLEANUP: 'true'
           NODE_OPTIONS: --max_old_space_size=8192
           SELECTED_PM: 'npm'
           npm_config_registry: http://localhost:4872

--- a/e2e/utils/create-project-utils.ts
+++ b/e2e/utils/create-project-utils.ts
@@ -752,7 +752,7 @@ export function cleanupProject({
   skipReset,
   ...opts
 }: RunCmdOpts & { skipReset?: boolean } = {}) {
-  if (process.env.NX_E2E_SKIP_CLEANUP) {
+  if (process.env.NX_E2E_SKIP_PROJECT_CLEANUP) {
     resetWorkspaceContext();
     return;
   }

--- a/e2e/utils/global-setup.ts
+++ b/e2e/utils/global-setup.ts
@@ -79,7 +79,10 @@ export default async function (globalConfig: Config.ConfigGlobals) {
       }
     }
 
-    if (process.env.NX_E2E_SKIP_CLEANUP !== 'true' || !existsSync('./build')) {
+    if (
+      process.env.NX_E2E_SKIP_GLOBAL_CLEANUP !== 'true' ||
+      !existsSync('./build')
+    ) {
       if (!isCI) {
         registerTsConfigPaths(join(__dirname, '../../tsconfig.base.json'));
         const { e2eCwd } = await import('./get-env-info');


### PR DESCRIPTION
## Current Behavior

`NX_E2E_SKIP_CLEANUP` is set to `'true'` in every Linux/macOS e2e matrix entry to gate the build-cache reuse check in `e2e/utils/global-setup.ts` (skip wiping `e2eCwd` + republishing to verdaccio when `./build` already exists).

PR #35042 added an early-return to `cleanupProject` in `e2e/utils/create-project-utils.ts` guarded by the same env var name to expose a *local* debug opt-in (preserve the per-test tmp project for inspection). Because CI already had the var set, the new early-return fires on every CI run, silently disabling the per-test `nx reset` + `tmpProjPath()` removal that previously kept orphan daemons from leaking. Jest hangs after all tests pass and the workflow times out at 60 minutes.

## Expected Behavior

Each lifecycle hook is gated by a distinct, scope-specific env var:

- `NX_E2E_SKIP_GLOBAL_CLEANUP` — global-setup.ts (CI sets it).
- `NX_E2E_SKIP_PROJECT_CLEANUP` — cleanupProject (developer-set locally for debugging only).

Per-test cleanup runs in CI again, jest exits cleanly, and nightly e2e jobs no longer hit the 60-minute cap.

## Validation

Verified via a manually-dispatched e2e nightly run on this branch (with the matrix temporarily narrowed to `Linux/{npm,pnpm,yarn}/20 e2e-node`, the matrix that hung at 60 min on master): https://github.com/nrwl/nx/actions/runs/25375231501 — all 3 jobs passed in ~25 minutes each.