### PR TITLE
chore(repo): deprecate executors with inferred-plugin replacements

### DIFF
--- a/packages/cypress/src/generators/component-configuration/component-configuration.ts
+++ b/packages/cypress/src/generators/component-configuration/component-configuration.ts
@@ -18,7 +18,7 @@ import {
 } from '@nx/devkit';
 import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { coerce, major } from 'semver';
-import { warnCypressExecutorScaffolding } from '../../utils/deprecation';
+import { warnCypressExecutorGenerating } from '../../utils/deprecation';
 import {
   getInstalledCypressMajorVersion,
   versions,
@@ -86,7 +86,7 @@ export async function componentConfigurationGeneratorInternal(
 
   addProjectFiles(tree, projectConfig, opts);
   if (!hasPlugin || opts.addExplicitTargets) {
-    warnCypressExecutorScaffolding();
+    warnCypressExecutorGenerating();
     addTargetToProject(tree, projectConfig, opts);
   }
   updateNxJsonConfiguration(tree, hasPlugin);

--- a/packages/cypress/src/generators/configuration/configuration.ts
+++ b/packages/cypress/src/generators/configuration/configuration.ts
@@ -35,7 +35,7 @@ import { PackageJson } from 'nx/src/utils/package-json';
 import { join } from 'path';
 import { addLinterToCyProject } from '../../utils/add-linter';
 import { addDefaultE2EConfig } from '../../utils/config';
-import { warnCypressExecutorScaffolding } from '../../utils/deprecation';
+import { warnCypressExecutorGenerating } from '../../utils/deprecation';
 import {
   getInstalledCypressMajorVersion,
   versions,
@@ -105,7 +105,7 @@ export async function configurationGeneratorInternal(
 
   await addFiles(tree, opts, projectGraph, hasPlugin);
   if (!hasPlugin) {
-    warnCypressExecutorScaffolding();
+    warnCypressExecutorGenerating();
     addTarget(tree, opts, projectGraph);
   }
 

--- a/packages/cypress/src/utils/deprecation.ts
+++ b/packages/cypress/src/utils/deprecation.ts
@@ -10,11 +10,11 @@ export function warnCypressExecutorDeprecation(): void {
 }
 
 // Fired when the @nx/cypress:configuration or :component-configuration
-// generator is about to scaffold a target that uses the deprecated executor —
+// generator is about to generate a target that uses the deprecated executor —
 // i.e. when @nx/cypress/plugin isn't registered in nx.json. Surfaces the
-// deprecation at scaffold time rather than only when the user later runs the
+// deprecation at generation time rather than only when the user later runs the
 // generated target.
-export function warnCypressExecutorScaffolding(): void {
+export function warnCypressExecutorGenerating(): void {
   logger.warn(
     'Generating a target that uses the deprecated `@nx/cypress:cypress` executor. The executor will be removed in Nx v24. Run `nx g @nx/cypress:convert-to-inferred` next to migrate this target to the `@nx/cypress/plugin` inferred plugin and prevent future generators from emitting executor targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.'
   );

--- a/packages/cypress/src/utils/deprecation.ts
+++ b/packages/cypress/src/utils/deprecation.ts
@@ -16,6 +16,6 @@ export function warnCypressExecutorDeprecation(): void {
 // generated target.
 export function warnCypressExecutorScaffolding(): void {
   logger.warn(
-    'Scaffolding a target that uses the deprecated `@nx/cypress:cypress` executor. The executor will be removed in Nx v24. Run `nx g @nx/cypress:convert-to-inferred` after this scaffold to migrate the generated target to the `@nx/cypress/plugin` inferred plugin. To skip emitting executor targets entirely on future scaffolds, register `@nx/cypress/plugin` in `nx.json` first (`nx add @nx/cypress` or a manual plugin entry). See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.'
+    'Generating a target that uses the deprecated `@nx/cypress:cypress` executor. The executor will be removed in Nx v24. Run `nx g @nx/cypress:convert-to-inferred` next to migrate this target to the `@nx/cypress/plugin` inferred plugin and prevent future generators from emitting executor targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.'
   );
 }

--- a/packages/detox/src/generators/application/lib/add-project.ts
+++ b/packages/detox/src/generators/application/lib/add-project.ts
@@ -14,7 +14,7 @@ import {
 } from './get-targets';
 import { NormalizedSchema } from './normalize-options';
 import type { PackageJson } from 'nx/src/utils/package-json';
-import { warnDetoxExecutorsScaffolding } from '../../../utils/deprecation';
+import { warnDetoxExecutorsGenerating } from '../../../utils/deprecation';
 
 export function addProject(host: Tree, options: NormalizedSchema) {
   const nxJson = readNxJson(host);
@@ -25,7 +25,7 @@ export function addProject(host: Tree, options: NormalizedSchema) {
   );
 
   if (!hasPlugin) {
-    warnDetoxExecutorsScaffolding();
+    warnDetoxExecutorsGenerating();
   }
 
   const packageJson: PackageJson = {

--- a/packages/detox/src/utils/deprecation.ts
+++ b/packages/detox/src/utils/deprecation.ts
@@ -10,12 +10,12 @@ export function warnDetoxExecutorsDeprecation(): void {
   logger.warn(DETOX_EXECUTORS_DEPRECATION_MESSAGE);
 }
 
-// Fired when the @nx/detox:application generator is about to scaffold
+// Fired when the @nx/detox:application generator is about to generate
 // build-ios/test-ios/build-android/test-android targets that use the deprecated
 // executors — i.e. when @nx/detox/plugin isn't registered in nx.json. Surfaces
-// the deprecation at scaffold time rather than only when the user later runs
+// the deprecation at generation time rather than only when the user later runs
 // the generated targets.
-export function warnDetoxExecutorsScaffolding(): void {
+export function warnDetoxExecutorsGenerating(): void {
   logger.warn(
     'Generating `build-ios`, `test-ios`, `build-android`, and `test-android` targets that use the deprecated `@nx/detox:build` and `@nx/detox:test` executors. These executors will be removed in Nx v24. Run `nx g @nx/detox:convert-to-inferred` next to migrate these targets to the `@nx/detox/plugin` inferred plugin and prevent future generators from emitting executor targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.'
   );

--- a/packages/detox/src/utils/deprecation.ts
+++ b/packages/detox/src/utils/deprecation.ts
@@ -17,6 +17,6 @@ export function warnDetoxExecutorsDeprecation(): void {
 // the generated targets.
 export function warnDetoxExecutorsScaffolding(): void {
   logger.warn(
-    'Scaffolding `build-ios`, `test-ios`, `build-android`, and `test-android` targets that use the deprecated `@nx/detox:build` and `@nx/detox:test` executors. These executors will be removed in Nx v24. Run `nx g @nx/detox:convert-to-inferred` after this scaffold to migrate the generated targets to the `@nx/detox/plugin` inferred plugin. To skip emitting executor targets entirely on future scaffolds, register `@nx/detox/plugin` in `nx.json` first (`nx add @nx/detox` or a manual plugin entry). See https://nx.dev/docs/technologies/test-tools/detox/introduction for details.'
+    'Generating `build-ios`, `test-ios`, `build-android`, and `test-android` targets that use the deprecated `@nx/detox:build` and `@nx/detox:test` executors. These executors will be removed in Nx v24. Run `nx g @nx/detox:convert-to-inferred` next to migrate these targets to the `@nx/detox/plugin` inferred plugin and prevent future generators from emitting executor targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.'
   );
 }

--- a/packages/eslint/src/executors/lint/lint.impl.ts
+++ b/packages/eslint/src/executors/lint/lint.impl.ts
@@ -6,11 +6,14 @@ import { dirname, posix, relative, resolve } from 'path';
 import { findFlatConfigFile, findOldConfigFile } from '../../utils/config-file';
 import type { Schema } from './schema';
 import { resolveAndInstantiateESLint } from './utility/eslint-utils';
+import { warnEslintExecutorDeprecation } from '../../utils/deprecation';
 
 export default async function run(
   options: Schema,
   context: ExecutorContext
 ): Promise<{ success: boolean }> {
+  warnEslintExecutorDeprecation();
+
   // hasTypeAwareRules is deprecated and no longer used, delete it so it's not passed to ESLint
   delete options.hasTypeAwareRules;
 

--- a/packages/eslint/src/executors/lint/schema.json
+++ b/packages/eslint/src/executors/lint/schema.json
@@ -6,6 +6,7 @@
   "description": "ESLint Lint Target.",
   "cli": "nx",
   "type": "object",
+  "x-deprecated": "The `@nx/eslint:lint` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/eslint:convert-to-inferred` to migrate to the `@nx/eslint/plugin` inferred plugin. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.",
   "properties": {
     "eslintConfig": {
       "type": "string",

--- a/packages/eslint/src/generators/lint-project/lint-project.ts
+++ b/packages/eslint/src/generators/lint-project/lint-project.ts
@@ -23,7 +23,7 @@ import {
 } from '../utils/eslint-file';
 import { extname, join } from 'path';
 import { lintInitGenerator } from '../init/init';
-import { warnEslintExecutorScaffolding } from '../../utils/deprecation';
+import { warnEslintExecutorGenerating } from '../../utils/deprecation';
 import type { Linter } from 'eslint';
 import { migrateConfigToMonorepoStyle } from '../init/init-migration';
 import { getProjects } from 'nx/src/generators/utils/project-configuration';
@@ -124,7 +124,7 @@ export async function lintProjectGeneratorInternal(
       };
     }
   } else {
-    warnEslintExecutorScaffolding();
+    warnEslintExecutorGenerating();
     projectConfig.targets ??= {};
     projectConfig.targets['lint'] = {
       executor: '@nx/eslint:lint',

--- a/packages/eslint/src/generators/lint-project/lint-project.ts
+++ b/packages/eslint/src/generators/lint-project/lint-project.ts
@@ -23,6 +23,7 @@ import {
 } from '../utils/eslint-file';
 import { extname, join } from 'path';
 import { lintInitGenerator } from '../init/init';
+import { warnEslintExecutorScaffolding } from '../../utils/deprecation';
 import type { Linter } from 'eslint';
 import { migrateConfigToMonorepoStyle } from '../init/init-migration';
 import { getProjects } from 'nx/src/generators/utils/project-configuration';
@@ -123,6 +124,7 @@ export async function lintProjectGeneratorInternal(
       };
     }
   } else {
+    warnEslintExecutorScaffolding();
     projectConfig.targets ??= {};
     projectConfig.targets['lint'] = {
       executor: '@nx/eslint:lint',

--- a/packages/eslint/src/utils/deprecation.ts
+++ b/packages/eslint/src/utils/deprecation.ts
@@ -9,7 +9,7 @@ export function warnEslintExecutorDeprecation(): void {
   logger.warn(ESLINT_EXECUTOR_DEPRECATION_MESSAGE);
 }
 
-export function warnEslintExecutorScaffolding(): void {
+export function warnEslintExecutorGenerating(): void {
   logger.warn(
     'Generating a target that uses the deprecated `@nx/eslint:lint` executor. The executor will be removed in Nx v24. Run `nx g @nx/eslint:convert-to-inferred` next to migrate this target to the `@nx/eslint/plugin` inferred plugin and prevent future generators from emitting executor targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.'
   );

--- a/packages/eslint/src/utils/deprecation.ts
+++ b/packages/eslint/src/utils/deprecation.ts
@@ -1,0 +1,16 @@
+import { logger } from '@nx/devkit';
+
+// TODO(v24): Remove the @nx/eslint:lint executor. The inferred plugin
+// (@nx/eslint/plugin) and the convert-to-inferred generator stay supported.
+export const ESLINT_EXECUTOR_DEPRECATION_MESSAGE =
+  'The `@nx/eslint:lint` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/eslint:convert-to-inferred` to migrate to the `@nx/eslint/plugin` inferred targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.';
+
+export function warnEslintExecutorDeprecation(): void {
+  logger.warn(ESLINT_EXECUTOR_DEPRECATION_MESSAGE);
+}
+
+export function warnEslintExecutorScaffolding(): void {
+  logger.warn(
+    'Generating a target that uses the deprecated `@nx/eslint:lint` executor. The executor will be removed in Nx v24. Run `nx g @nx/eslint:convert-to-inferred` next to migrate this target to the `@nx/eslint/plugin` inferred plugin and prevent future generators from emitting executor targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.'
+  );
+}

--- a/packages/expo/src/executors/build/build.impl.ts
+++ b/packages/expo/src/executors/build/build.impl.ts
@@ -15,6 +15,7 @@ import { resolve as pathResolve } from 'path';
 import type { PackageJson } from 'nx/src/utils/package-json';
 
 import { resolveEas } from '../../utils/resolve-eas';
+import { warnExpoExecutorDeprecation } from '../../utils/deprecation';
 
 import { ExpoEasBuildOptions } from './schema';
 
@@ -28,6 +29,8 @@ export default async function* buildExecutor(
   options: ExpoEasBuildOptions,
   context: ExecutorContext
 ): AsyncGenerator<ReactNativeBuildOutput> {
+  warnExpoExecutorDeprecation('build');
+
   const projectRoot =
     context.projectsConfigurations.projects[context.projectName].root;
 

--- a/packages/expo/src/executors/build/schema.json
+++ b/packages/expo/src/executors/build/schema.json
@@ -7,6 +7,7 @@
   "title": "Expo EAS Build executor",
   "description": "Start an EAS build for your expo project.",
   "type": "object",
+  "x-deprecated": "The `@nx/expo:build` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/expo:convert-to-inferred` to migrate to the `@nx/expo/plugin` inferred plugin. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.",
   "presets": [
     {
       "name": "Build for a specific platform",

--- a/packages/expo/src/executors/export/export.impl.ts
+++ b/packages/expo/src/executors/export/export.impl.ts
@@ -9,6 +9,7 @@ import { ChildProcess, fork } from 'child_process';
 import { resolve as pathResolve } from 'path';
 
 import { ExportExecutorSchema } from './schema';
+import { warnExpoExecutorDeprecation } from '../../utils/deprecation';
 
 export interface ExpoExportOutput {
   success: boolean;
@@ -20,6 +21,8 @@ export default async function* exportExecutor(
   options: ExportExecutorSchema,
   context: ExecutorContext
 ): AsyncGenerator<ExpoExportOutput> {
+  warnExpoExecutorDeprecation('export');
+
   const projectRoot =
     context.projectsConfigurations.projects[context.projectName].root;
 

--- a/packages/expo/src/executors/export/schema.json
+++ b/packages/expo/src/executors/export/schema.json
@@ -7,6 +7,7 @@
   "title": "Expo Export",
   "description": "Export the JavaScript and assets for your app using Metro/webpack bundler.",
   "type": "object",
+  "x-deprecated": "The `@nx/expo:export` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/expo:convert-to-inferred` to migrate to the `@nx/expo/plugin` inferred plugin. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.",
   "properties": {
     "platform": {
       "description": "Choose the platform to compile for",

--- a/packages/expo/src/executors/install/install.impl.ts
+++ b/packages/expo/src/executors/install/install.impl.ts
@@ -8,6 +8,7 @@ import {
   displayNewlyAddedDepsMessage,
   syncDeps,
 } from '../sync-deps/sync-deps.impl';
+import { warnExpoExecutorDeprecation } from '../../utils/deprecation';
 
 export interface ExpoInstallOutput {
   success: boolean;
@@ -19,6 +20,8 @@ export default async function* installExecutor(
   options: ExpoInstallOptions,
   context: ExecutorContext
 ): AsyncGenerator<ExpoInstallOutput> {
+  warnExpoExecutorDeprecation('install');
+
   try {
     await installAndUpdatePackageJson(context, options);
     yield {

--- a/packages/expo/src/executors/install/schema.json
+++ b/packages/expo/src/executors/install/schema.json
@@ -7,6 +7,7 @@
   "title": "Expo Install",
   "description": "Install a module or other package to a project.",
   "type": "object",
+  "x-deprecated": "The `@nx/expo:install` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/expo:convert-to-inferred` to migrate to the `@nx/expo/plugin` inferred plugin. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.",
   "properties": {
     "packages": {
       "type": "array",

--- a/packages/expo/src/executors/prebuild/prebuild.impl.ts
+++ b/packages/expo/src/executors/prebuild/prebuild.impl.ts
@@ -5,6 +5,7 @@ import { join } from 'path';
 
 import { podInstall } from '../../utils/pod-install-task';
 import { ExpoPrebuildOptions } from './schema';
+import { warnExpoExecutorDeprecation } from '../../utils/deprecation';
 
 export interface ExpoPrebuildOutput {
   success: boolean;
@@ -16,6 +17,8 @@ export default async function* prebuildExecutor(
   options: ExpoPrebuildOptions,
   context: ExecutorContext
 ): AsyncGenerator<ExpoPrebuildOutput> {
+  warnExpoExecutorDeprecation('prebuild');
+
   const projectRoot =
     context.projectsConfigurations.projects[context.projectName].root;
 

--- a/packages/expo/src/executors/prebuild/schema.json
+++ b/packages/expo/src/executors/prebuild/schema.json
@@ -7,6 +7,7 @@
   "title": "Expo Prebuild",
   "description": "Create native iOS and Android project files for building natively.",
   "type": "object",
+  "x-deprecated": "The `@nx/expo:prebuild` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/expo:convert-to-inferred` to migrate to the `@nx/expo/plugin` inferred plugin. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.",
   "properties": {
     "clean": {
       "type": "boolean",

--- a/packages/expo/src/executors/run/run.impl.ts
+++ b/packages/expo/src/executors/run/run.impl.ts
@@ -8,6 +8,7 @@ import { join, resolve as pathResolve } from 'path';
 import { ExpoRunOptions } from './schema';
 import { prebuildAsync } from '../prebuild/prebuild.impl';
 import { podInstall } from '../../utils/pod-install-task';
+import { warnExpoExecutorDeprecation } from '../../utils/deprecation';
 
 export interface ExpoRunOutput {
   success: boolean;
@@ -19,6 +20,8 @@ export default async function* runExecutor(
   options: ExpoRunOptions,
   context: ExecutorContext
 ): AsyncGenerator<ExpoRunOutput> {
+  warnExpoExecutorDeprecation('run');
+
   if (platform() !== 'darwin' && options.platform === 'ios') {
     throw new Error(`The run-ios build requires Mac to run`);
   }

--- a/packages/expo/src/executors/run/schema.json
+++ b/packages/expo/src/executors/run/schema.json
@@ -8,6 +8,7 @@
   "title": "Run iOS or Android application",
   "description": "Run Expo target options.",
   "type": "object",
+  "x-deprecated": "The `@nx/expo:run` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/expo:convert-to-inferred` to migrate to the `@nx/expo/plugin` inferred plugin. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.",
   "properties": {
     "platform": {
       "description": "Platform to run for (ios, android).",

--- a/packages/expo/src/executors/serve/schema.json
+++ b/packages/expo/src/executors/serve/schema.json
@@ -8,6 +8,7 @@
   "title": "Serve web app for Expo",
   "description": "Packager Server target options.",
   "type": "object",
+  "x-deprecated": "The `@nx/expo:serve` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/expo:convert-to-inferred` to migrate to the `@nx/expo/plugin` inferred plugin. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.",
   "properties": {
     "port": {
       "type": "number",

--- a/packages/expo/src/executors/serve/serve.impl.ts
+++ b/packages/expo/src/executors/serve/serve.impl.ts
@@ -4,6 +4,7 @@ import { ChildProcess, fork } from 'child_process';
 import { resolve as pathResolve } from 'path';
 import { isPackagerRunning } from './lib/is-packager-running';
 import { ExpoServeExecutorSchema } from './schema';
+import { warnExpoExecutorDeprecation } from '../../utils/deprecation';
 
 export interface ExpoServeOutput {
   port?: number;
@@ -15,6 +16,8 @@ export default async function* serveExecutor(
   options: ExpoServeExecutorSchema,
   context: ExecutorContext
 ): AsyncGenerator<ExpoServeOutput> {
+  warnExpoExecutorDeprecation('serve');
+
   const projectRoot =
     context.projectsConfigurations.projects[context.projectName].root;
 

--- a/packages/expo/src/executors/start/schema.json
+++ b/packages/expo/src/executors/start/schema.json
@@ -8,6 +8,7 @@
   "title": "Packager Server for Expo",
   "description": "Packager Server target options.",
   "type": "object",
+  "x-deprecated": "The `@nx/expo:start` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/expo:convert-to-inferred` to migrate to the `@nx/expo/plugin` inferred plugin. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.",
   "properties": {
     "forceManifestType": {
       "type": "string",

--- a/packages/expo/src/executors/start/start.impl.ts
+++ b/packages/expo/src/executors/start/start.impl.ts
@@ -5,6 +5,7 @@ import { ChildProcess, fork } from 'child_process';
 import { resolve as pathResolve } from 'path';
 
 import { ExpoStartOptions } from './schema';
+import { warnExpoExecutorDeprecation } from '../../utils/deprecation';
 
 export interface ExpoStartOutput {
   baseUrl?: string;
@@ -17,6 +18,8 @@ export default async function* startExecutor(
   options: ExpoStartOptions,
   context: ExecutorContext
 ): AsyncGenerator<ExpoStartOutput> {
+  warnExpoExecutorDeprecation('start');
+
   const projectRoot =
     context.projectsConfigurations.projects[context.projectName].root;
 

--- a/packages/expo/src/executors/submit/schema.json
+++ b/packages/expo/src/executors/submit/schema.json
@@ -4,6 +4,7 @@
   "title": "EXPO EAS Submit Executor",
   "description": "Submit app binary to App Store and/or Play Store.",
   "type": "object",
+  "x-deprecated": "The `@nx/expo:submit` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/expo:convert-to-inferred` to migrate to the `@nx/expo/plugin` inferred plugin. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.",
   "presets": [
     {
       "name": "Submit for a specific platform",

--- a/packages/expo/src/executors/submit/submit.impl.ts
+++ b/packages/expo/src/executors/submit/submit.impl.ts
@@ -6,6 +6,7 @@ import { ChildProcess, fork } from 'child_process';
 import { resolveEas } from '../../utils/resolve-eas';
 
 import { SubmitExecutorSchema } from './schema';
+import { warnExpoExecutorDeprecation } from '../../utils/deprecation';
 
 export interface ReactNativeSubmitOutput {
   success: boolean;
@@ -17,6 +18,8 @@ export default async function* submitExecutor(
   options: SubmitExecutorSchema,
   context: ExecutorContext
 ): AsyncGenerator<ReactNativeSubmitOutput> {
+  warnExpoExecutorDeprecation('submit');
+
   const projectRoot =
     context.projectsConfigurations.projects[context.projectName].root;
 

--- a/packages/expo/src/generators/application/lib/add-project.ts
+++ b/packages/expo/src/generators/application/lib/add-project.ts
@@ -10,12 +10,14 @@ import {
 } from '@nx/devkit';
 import type { PackageJson } from 'nx/src/utils/package-json';
 import { hasExpoPlugin } from '../../../utils/has-expo-plugin';
+import { warnExpoExecutorScaffolding } from '../../../utils/deprecation';
 import { NormalizedSchema } from './normalize-options';
 
 export function addProject(host: Tree, options: NormalizedSchema) {
   const hasPlugin = hasExpoPlugin(host);
 
   if (!hasPlugin) {
+    warnExpoExecutorScaffolding();
     addBuildTargetDefaults(host, '@nx/expo:build');
   }
 

--- a/packages/expo/src/generators/application/lib/add-project.ts
+++ b/packages/expo/src/generators/application/lib/add-project.ts
@@ -10,14 +10,14 @@ import {
 } from '@nx/devkit';
 import type { PackageJson } from 'nx/src/utils/package-json';
 import { hasExpoPlugin } from '../../../utils/has-expo-plugin';
-import { warnExpoExecutorScaffolding } from '../../../utils/deprecation';
+import { warnExpoExecutorGenerating } from '../../../utils/deprecation';
 import { NormalizedSchema } from './normalize-options';
 
 export function addProject(host: Tree, options: NormalizedSchema) {
   const hasPlugin = hasExpoPlugin(host);
 
   if (!hasPlugin) {
-    warnExpoExecutorScaffolding();
+    warnExpoExecutorGenerating();
     addBuildTargetDefaults(host, '@nx/expo:build');
   }
 

--- a/packages/expo/src/utils/deprecation.ts
+++ b/packages/expo/src/utils/deprecation.ts
@@ -18,7 +18,7 @@ export function expoSchemaDeprecationMessage(executorName: string): string {
   return buildMessage(executorName);
 }
 
-export function warnExpoExecutorScaffolding(): void {
+export function warnExpoExecutorGenerating(): void {
   logger.warn(
     'Generating targets that use the deprecated `@nx/expo:build`, `@nx/expo:export`, `@nx/expo:install`, `@nx/expo:prebuild`, `@nx/expo:run`, `@nx/expo:serve`, `@nx/expo:start`, and `@nx/expo:submit` executors. These executors will be removed in Nx v24. Run `nx g @nx/expo:convert-to-inferred` next to migrate these targets to the `@nx/expo/plugin` inferred plugin and prevent future generators from emitting executor targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.'
   );

--- a/packages/expo/src/utils/deprecation.ts
+++ b/packages/expo/src/utils/deprecation.ts
@@ -1,0 +1,25 @@
+import { logger } from '@nx/devkit';
+
+// TODO(v24): Remove the @nx/expo:build, :export, :install, :prebuild, :run,
+// :serve, :start, and :submit executors. The inferred plugin
+// (@nx/expo/plugin) and the convert-to-inferred generator stay supported.
+// (`@nx/expo:build-list`, `:sync-deps`, `:update`, and `:ensure-symlink`
+// are not covered by `convert-to-inferred` and stay as-is.)
+
+function buildMessage(executorName: string): string {
+  return `The \`@nx/expo:${executorName}\` executor is deprecated and will be removed in Nx v24. Run \`nx g @nx/expo:convert-to-inferred\` to migrate to the \`@nx/expo/plugin\` inferred targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.`;
+}
+
+export function warnExpoExecutorDeprecation(executorName: string): void {
+  logger.warn(buildMessage(executorName));
+}
+
+export function expoSchemaDeprecationMessage(executorName: string): string {
+  return buildMessage(executorName);
+}
+
+export function warnExpoExecutorScaffolding(): void {
+  logger.warn(
+    'Generating targets that use the deprecated `@nx/expo:build`, `@nx/expo:export`, `@nx/expo:install`, `@nx/expo:prebuild`, `@nx/expo:run`, `@nx/expo:serve`, `@nx/expo:start`, and `@nx/expo:submit` executors. These executors will be removed in Nx v24. Run `nx g @nx/expo:convert-to-inferred` next to migrate these targets to the `@nx/expo/plugin` inferred plugin and prevent future generators from emitting executor targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.'
+  );
+}

--- a/packages/jest/src/executors/jest/jest.impl.ts
+++ b/packages/jest/src/executors/jest/jest.impl.ts
@@ -15,12 +15,15 @@ import {
 import { getSummary } from './summary';
 import { readFileSync } from 'fs';
 import type { BatchResults } from 'nx/src/tasks-runner/batch/batch-messages';
+import { warnJestExecutorDeprecation } from '../../utils/deprecation';
 process.env.NODE_ENV ??= 'test';
 
 export async function jestExecutor(
   options: JestExecutorOptions,
   context: ExecutorContext
 ): Promise<{ success: boolean }> {
+  warnJestExecutorDeprecation();
+
   // Jest registers ts-node with module CJS https://github.com/SimenB/jest/blob/v29.6.4/packages/jest-config/src/readConfigFileAndSetRootDir.ts#L117-L119
   // We want to support of ESM via 'module':'nodenext', we need to override the resolution until Jest supports it.
   const existingValue = process.env['TS_NODE_COMPILER_OPTIONS'];

--- a/packages/jest/src/executors/jest/schema.json
+++ b/packages/jest/src/executors/jest/schema.json
@@ -5,6 +5,7 @@
   "description": "Jest target options for Build Facade.",
   "cli": "nx",
   "type": "object",
+  "x-deprecated": "The `@nx/jest:jest` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/jest:convert-to-inferred` to migrate to the `@nx/jest/plugin` inferred plugin. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.",
   "presets": [
     {
       "name": "Pass Without Tests",

--- a/packages/jest/src/generators/configuration/configuration.ts
+++ b/packages/jest/src/generators/configuration/configuration.ts
@@ -16,7 +16,7 @@ import {
   getPresetExt,
 } from '../../utils/config/config-file';
 import { jestInitGenerator } from '../init/init';
-import { warnJestExecutorScaffolding } from '../../utils/deprecation';
+import { warnJestExecutorGenerating } from '../../utils/deprecation';
 import { checkForTestTarget } from './lib/check-for-test-target';
 import { createFiles } from './lib/create-files';
 import { createJestConfig } from './lib/create-jest-config';
@@ -129,7 +129,7 @@ export async function configurationGeneratorInternal(
   });
 
   if (!hasPlugin || options.addExplicitTargets) {
-    warnJestExecutorScaffolding();
+    warnJestExecutorGenerating();
     updateWorkspace(tree, options);
   }
 

--- a/packages/jest/src/generators/configuration/configuration.ts
+++ b/packages/jest/src/generators/configuration/configuration.ts
@@ -16,6 +16,7 @@ import {
   getPresetExt,
 } from '../../utils/config/config-file';
 import { jestInitGenerator } from '../init/init';
+import { warnJestExecutorScaffolding } from '../../utils/deprecation';
 import { checkForTestTarget } from './lib/check-for-test-target';
 import { createFiles } from './lib/create-files';
 import { createJestConfig } from './lib/create-jest-config';
@@ -128,6 +129,7 @@ export async function configurationGeneratorInternal(
   });
 
   if (!hasPlugin || options.addExplicitTargets) {
+    warnJestExecutorScaffolding();
     updateWorkspace(tree, options);
   }
 

--- a/packages/jest/src/utils/deprecation.ts
+++ b/packages/jest/src/utils/deprecation.ts
@@ -1,0 +1,16 @@
+import { logger } from '@nx/devkit';
+
+// TODO(v24): Remove the @nx/jest:jest executor. The inferred plugin
+// (@nx/jest/plugin) and the convert-to-inferred generator stay supported.
+export const JEST_EXECUTOR_DEPRECATION_MESSAGE =
+  'The `@nx/jest:jest` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/jest:convert-to-inferred` to migrate to the `@nx/jest/plugin` inferred targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.';
+
+export function warnJestExecutorDeprecation(): void {
+  logger.warn(JEST_EXECUTOR_DEPRECATION_MESSAGE);
+}
+
+export function warnJestExecutorScaffolding(): void {
+  logger.warn(
+    'Generating a target that uses the deprecated `@nx/jest:jest` executor. The executor will be removed in Nx v24. Run `nx g @nx/jest:convert-to-inferred` next to migrate this target to the `@nx/jest/plugin` inferred plugin and prevent future generators from emitting executor targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.'
+  );
+}

--- a/packages/jest/src/utils/deprecation.ts
+++ b/packages/jest/src/utils/deprecation.ts
@@ -9,7 +9,7 @@ export function warnJestExecutorDeprecation(): void {
   logger.warn(JEST_EXECUTOR_DEPRECATION_MESSAGE);
 }
 
-export function warnJestExecutorScaffolding(): void {
+export function warnJestExecutorGenerating(): void {
   logger.warn(
     'Generating a target that uses the deprecated `@nx/jest:jest` executor. The executor will be removed in Nx v24. Run `nx g @nx/jest:convert-to-inferred` next to migrate this target to the `@nx/jest/plugin` inferred plugin and prevent future generators from emitting executor targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.'
   );

--- a/packages/next/src/executors/build/build.impl.ts
+++ b/packages/next/src/executors/build/build.impl.ts
@@ -20,6 +20,7 @@ import { ChildProcess, fork } from 'child_process';
 import { createCliOptions } from '../../utils/create-cli-options';
 import { signalToCode, checkAndCleanWithSemver } from '@nx/devkit/internal';
 import { getInstalledNextVersionRuntime } from '../../utils/runtime-version-utils';
+import { warnNextBuildExecutorDeprecation } from '../../utils/deprecation';
 
 let childProcess: ChildProcess;
 
@@ -27,6 +28,8 @@ export default async function buildExecutor(
   options: NextBuildBuilderOptions,
   context: ExecutorContext
 ) {
+  warnNextBuildExecutorDeprecation();
+
   // Cast to any to overwrite NODE_ENV
   (process.env as any).NODE_ENV ||= 'production';
 

--- a/packages/next/src/executors/build/schema.json
+++ b/packages/next/src/executors/build/schema.json
@@ -6,6 +6,7 @@
   "title": "Next Build",
   "description": "Build a Next.js app.",
   "type": "object",
+  "x-deprecated": "The `@nx/next:build` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/next:convert-to-inferred` to migrate to the `@nx/next/plugin` inferred plugin. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.",
   "properties": {
     "outputPath": {
       "type": "string",

--- a/packages/next/src/executors/server/schema.json
+++ b/packages/next/src/executors/server/schema.json
@@ -6,6 +6,7 @@
   "title": "Next Serve",
   "description": "Serve a Next.js app.",
   "type": "object",
+  "x-deprecated": "The `@nx/next:server` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/next:convert-to-inferred` to migrate to the `@nx/next/plugin` inferred plugin. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.",
   "properties": {
     "dev": {
       "type": "boolean",

--- a/packages/next/src/executors/server/server.impl.ts
+++ b/packages/next/src/executors/server/server.impl.ts
@@ -16,11 +16,14 @@ import customServer from './custom-server.impl';
 import { createCliOptions } from '../../utils/create-cli-options';
 import { waitForPortOpen } from '@nx/web/src/utils/wait-for-port-open';
 import { getInstalledNextVersionRuntime } from '../../utils/runtime-version-utils';
+import { warnNextServerExecutorDeprecation } from '../../utils/deprecation';
 
 export default async function* serveExecutor(
   options: NextServeBuilderOptions,
   context: ExecutorContext
 ) {
+  warnNextServerExecutorDeprecation();
+
   const buildOptions = readTargetOptions<NextBuildBuilderOptions>(
     parseTargetString(options.buildTarget, context),
     context

--- a/packages/next/src/generators/application/lib/add-project.ts
+++ b/packages/next/src/generators/application/lib/add-project.ts
@@ -10,6 +10,7 @@ import {
 } from '@nx/devkit';
 import { isUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { nextVersion } from '../../../utils/versions';
+import { warnNextExecutorScaffolding } from '../../../utils/deprecation';
 import { reactDomVersion, reactVersion } from '@nx/react';
 import type { PackageJson } from 'nx/src/utils/package-json';
 
@@ -27,6 +28,7 @@ export function addProject(host: Tree, options: NormalizedSchema) {
   );
 
   if (!hasPlugin) {
+    warnNextExecutorScaffolding();
     addBuildTargetDefaults(host, '@nx/next:build');
 
     targets.build = {

--- a/packages/next/src/generators/application/lib/add-project.ts
+++ b/packages/next/src/generators/application/lib/add-project.ts
@@ -10,7 +10,7 @@ import {
 } from '@nx/devkit';
 import { isUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { nextVersion } from '../../../utils/versions';
-import { warnNextExecutorScaffolding } from '../../../utils/deprecation';
+import { warnNextExecutorGenerating } from '../../../utils/deprecation';
 import { reactDomVersion, reactVersion } from '@nx/react';
 import type { PackageJson } from 'nx/src/utils/package-json';
 
@@ -28,7 +28,7 @@ export function addProject(host: Tree, options: NormalizedSchema) {
   );
 
   if (!hasPlugin) {
-    warnNextExecutorScaffolding();
+    warnNextExecutorGenerating();
     addBuildTargetDefaults(host, '@nx/next:build');
 
     targets.build = {

--- a/packages/next/src/utils/deprecation.ts
+++ b/packages/next/src/utils/deprecation.ts
@@ -23,6 +23,6 @@ export function warnNextServerExecutorDeprecation(): void {
 // than only when the user later runs the generated targets.
 export function warnNextExecutorScaffolding(): void {
   logger.warn(
-    'Scaffolding targets that use the deprecated `@nx/next:build` and `@nx/next:server` executors. These executors will be removed in Nx v24. Run `nx g @nx/next:convert-to-inferred` after this scaffold to migrate these targets to the `@nx/next/plugin` inferred plugin and stop emitting executor targets on future scaffolds. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.'
+    'Generating targets that use the deprecated `@nx/next:build` and `@nx/next:server` executors. These executors will be removed in Nx v24. Run `nx g @nx/next:convert-to-inferred` next to migrate these targets to the `@nx/next/plugin` inferred plugin and prevent future generators from emitting executor targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.'
   );
 }

--- a/packages/next/src/utils/deprecation.ts
+++ b/packages/next/src/utils/deprecation.ts
@@ -17,11 +17,11 @@ export function warnNextServerExecutorDeprecation(): void {
   logger.warn(NEXT_SERVER_EXECUTOR_DEPRECATION_MESSAGE);
 }
 
-// Fired when the @nx/next:application generator is about to scaffold targets
+// Fired when the @nx/next:application generator is about to generate targets
 // that use the deprecated executors — i.e. when @nx/next/plugin isn't
-// registered in nx.json. Surfaces the deprecation at scaffold time rather
+// registered in nx.json. Surfaces the deprecation at generation time rather
 // than only when the user later runs the generated targets.
-export function warnNextExecutorScaffolding(): void {
+export function warnNextExecutorGenerating(): void {
   logger.warn(
     'Generating targets that use the deprecated `@nx/next:build` and `@nx/next:server` executors. These executors will be removed in Nx v24. Run `nx g @nx/next:convert-to-inferred` next to migrate these targets to the `@nx/next/plugin` inferred plugin and prevent future generators from emitting executor targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.'
   );

--- a/packages/next/src/utils/deprecation.ts
+++ b/packages/next/src/utils/deprecation.ts
@@ -1,0 +1,28 @@
+import { logger } from '@nx/devkit';
+
+// TODO(v24): Remove the @nx/next:build and @nx/next:server executors. The
+// inferred plugin (@nx/next/plugin) and the convert-to-inferred generator
+// stay supported.
+export const NEXT_BUILD_EXECUTOR_DEPRECATION_MESSAGE =
+  'The `@nx/next:build` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/next:convert-to-inferred` to migrate to the `@nx/next/plugin` inferred targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.';
+
+export const NEXT_SERVER_EXECUTOR_DEPRECATION_MESSAGE =
+  'The `@nx/next:server` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/next:convert-to-inferred` to migrate to the `@nx/next/plugin` inferred targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.';
+
+export function warnNextBuildExecutorDeprecation(): void {
+  logger.warn(NEXT_BUILD_EXECUTOR_DEPRECATION_MESSAGE);
+}
+
+export function warnNextServerExecutorDeprecation(): void {
+  logger.warn(NEXT_SERVER_EXECUTOR_DEPRECATION_MESSAGE);
+}
+
+// Fired when the @nx/next:application generator is about to scaffold targets
+// that use the deprecated executors — i.e. when @nx/next/plugin isn't
+// registered in nx.json. Surfaces the deprecation at scaffold time rather
+// than only when the user later runs the generated targets.
+export function warnNextExecutorScaffolding(): void {
+  logger.warn(
+    'Scaffolding targets that use the deprecated `@nx/next:build` and `@nx/next:server` executors. These executors will be removed in Nx v24. Run `nx g @nx/next:convert-to-inferred` after this scaffold to migrate these targets to the `@nx/next/plugin` inferred plugin and stop emitting executor targets on future scaffolds. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.'
+  );
+}

--- a/packages/playwright/src/executors/playwright/playwright.impl.ts
+++ b/packages/playwright/src/executors/playwright/playwright.impl.ts
@@ -6,6 +6,7 @@ import {
   workspaceRoot,
 } from '@nx/devkit';
 import { execSync, fork } from 'child_process';
+import { warnPlaywrightExecutorDeprecation } from '../../utils/deprecation';
 
 export interface PlaywrightExecutorSchema {
   /*
@@ -64,6 +65,8 @@ export async function playwrightExecutor(
   options: PlaywrightExecutorSchema,
   context: ExecutorContext
 ) {
+  warnPlaywrightExecutorDeprecation();
+
   const projectRoot =
     context.projectGraph?.nodes?.[context?.projectName]?.data?.root;
 

--- a/packages/playwright/src/generators/configuration/configuration.ts
+++ b/packages/playwright/src/generators/configuration/configuration.ts
@@ -28,7 +28,7 @@ import {
 } from '@nx/js/src/utils/package-manager-workspaces';
 import { ensureTypescript } from '@nx/js/src/utils/typescript/ensure-typescript';
 import { isUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
-import { warnPlaywrightExecutorScaffolding } from '../../utils/deprecation';
+import { warnPlaywrightExecutorGenerating } from '../../utils/deprecation';
 import { execSync } from 'child_process';
 import { PackageJson } from 'nx/src/utils/package-json';
 import * as path from 'path';
@@ -197,7 +197,7 @@ export async function configurationGeneratorInternal(
   );
 
   if (!hasPlugin) {
-    warnPlaywrightExecutorScaffolding();
+    warnPlaywrightExecutorGenerating();
     addE2eTarget(tree, options);
     setupE2ETargetDefaults(tree);
   }

--- a/packages/playwright/src/generators/configuration/configuration.ts
+++ b/packages/playwright/src/generators/configuration/configuration.ts
@@ -28,6 +28,7 @@ import {
 } from '@nx/js/src/utils/package-manager-workspaces';
 import { ensureTypescript } from '@nx/js/src/utils/typescript/ensure-typescript';
 import { isUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
+import { warnPlaywrightExecutorScaffolding } from '../../utils/deprecation';
 import { execSync } from 'child_process';
 import { PackageJson } from 'nx/src/utils/package-json';
 import * as path from 'path';
@@ -196,6 +197,7 @@ export async function configurationGeneratorInternal(
   );
 
   if (!hasPlugin) {
+    warnPlaywrightExecutorScaffolding();
     addE2eTarget(tree, options);
     setupE2ETargetDefaults(tree);
   }

--- a/packages/playwright/src/utils/deprecation.ts
+++ b/packages/playwright/src/utils/deprecation.ts
@@ -10,7 +10,7 @@ export function warnPlaywrightExecutorDeprecation(): void {
   logger.warn(PLAYWRIGHT_EXECUTOR_DEPRECATION_MESSAGE);
 }
 
-export function warnPlaywrightExecutorScaffolding(): void {
+export function warnPlaywrightExecutorGenerating(): void {
   logger.warn(
     'Generating a target that uses the deprecated `@nx/playwright:playwright` executor. The executor will be removed in Nx v24. Run `nx g @nx/playwright:convert-to-inferred` next to migrate this target to the `@nx/playwright/plugin` inferred plugin and prevent future generators from emitting executor targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.'
   );

--- a/packages/playwright/src/utils/deprecation.ts
+++ b/packages/playwright/src/utils/deprecation.ts
@@ -1,0 +1,17 @@
+import { logger } from '@nx/devkit';
+
+// TODO(v24): Remove the @nx/playwright:playwright executor. The inferred
+// plugin (@nx/playwright/plugin) and the convert-to-inferred generator stay
+// supported.
+export const PLAYWRIGHT_EXECUTOR_DEPRECATION_MESSAGE =
+  'The `@nx/playwright:playwright` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/playwright:convert-to-inferred` to migrate to the `@nx/playwright/plugin` inferred targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.';
+
+export function warnPlaywrightExecutorDeprecation(): void {
+  logger.warn(PLAYWRIGHT_EXECUTOR_DEPRECATION_MESSAGE);
+}
+
+export function warnPlaywrightExecutorScaffolding(): void {
+  logger.warn(
+    'Generating a target that uses the deprecated `@nx/playwright:playwright` executor. The executor will be removed in Nx v24. Run `nx g @nx/playwright:convert-to-inferred` next to migrate this target to the `@nx/playwright/plugin` inferred plugin and prevent future generators from emitting executor targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.'
+  );
+}

--- a/packages/react-native/src/executors/build-android/build-android.impl.ts
+++ b/packages/react-native/src/executors/build-android/build-android.impl.ts
@@ -5,6 +5,7 @@ import { ChildProcess, fork } from 'child_process';
 import { ReactNativeBuildAndroidOptions } from './schema';
 import { chmodAndroidGradlewFiles } from '../../utils/chmod-android-gradle-files';
 import { getCliOptions } from '../../utils/get-cli-options';
+import { warnReactNativeExecutorDeprecation } from '../../utils/deprecation';
 
 export interface ReactNativeBuildOutput {
   success: boolean;
@@ -14,6 +15,8 @@ export default async function* buildAndroidExecutor(
   options: ReactNativeBuildAndroidOptions,
   context: ExecutorContext
 ): AsyncGenerator<ReactNativeBuildOutput> {
+  warnReactNativeExecutorDeprecation('build-android');
+
   const projectRoot =
     context.projectsConfigurations.projects[context.projectName].root;
   chmodAndroidGradlewFiles(join(context.root, projectRoot, 'android'));

--- a/packages/react-native/src/executors/build-android/schema.json
+++ b/packages/react-native/src/executors/build-android/schema.json
@@ -7,6 +7,7 @@
   "title": "Release Build for Android",
   "description": "Build target options for Android.",
   "type": "object",
+  "x-deprecated": "The `@nx/react-native:build-android` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/react-native:convert-to-inferred` to migrate to the `@nx/react-native/plugin` inferred plugin. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.",
   "presets": [
     {
       "name": "Build Android for current device architecture",

--- a/packages/react-native/src/executors/build-ios/build-ios.impl.ts
+++ b/packages/react-native/src/executors/build-ios/build-ios.impl.ts
@@ -6,6 +6,7 @@ import { platform } from 'os';
 
 import { ReactNativeBuildIosOptions } from './schema';
 import { getCliOptions } from '../../utils/get-cli-options';
+import { warnReactNativeExecutorDeprecation } from '../../utils/deprecation';
 
 export interface ReactNativeBuildIosOutput {
   success: boolean;
@@ -15,6 +16,8 @@ export default async function* buildIosExecutor(
   options: ReactNativeBuildIosOptions,
   context: ExecutorContext
 ): AsyncGenerator<ReactNativeBuildIosOutput> {
+  warnReactNativeExecutorDeprecation('build-ios');
+
   if (platform() !== 'darwin') {
     throw new Error(`The run-ios build requires Mac to run`);
   }

--- a/packages/react-native/src/executors/build-ios/schema.json
+++ b/packages/react-native/src/executors/build-ios/schema.json
@@ -5,6 +5,7 @@
   "title": "React Native Build iOS executor",
   "description": "Build iOS app.",
   "type": "object",
+  "x-deprecated": "The `@nx/react-native:build-ios` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/react-native:convert-to-inferred` to migrate to the `@nx/react-native/plugin` inferred plugin. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.",
   "presets": [
     {
       "name": "Build iOS for a simulator",

--- a/packages/react-native/src/executors/bundle/bundle.impl.ts
+++ b/packages/react-native/src/executors/bundle/bundle.impl.ts
@@ -5,6 +5,7 @@ import { ChildProcess, fork } from 'child_process';
 
 import { ReactNativeBundleOptions } from './schema';
 import { mkdirSync } from 'fs';
+import { warnReactNativeExecutorDeprecation } from '../../utils/deprecation';
 
 export interface ReactNativeBundleOutput {
   success: boolean;
@@ -14,6 +15,8 @@ export default async function* bundleExecutor(
   options: ReactNativeBundleOptions,
   context: ExecutorContext
 ): AsyncGenerator<ReactNativeBundleOutput> {
+  warnReactNativeExecutorDeprecation('bundle');
+
   const projectRoot =
     context.projectsConfigurations.projects[context.projectName].root;
 

--- a/packages/react-native/src/executors/bundle/schema.json
+++ b/packages/react-native/src/executors/bundle/schema.json
@@ -7,6 +7,7 @@
   "title": "Offline JS Bundle for React Native",
   "description": "JS Bundle target options.",
   "type": "object",
+  "x-deprecated": "The `@nx/react-native:bundle` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/react-native:convert-to-inferred` to migrate to the `@nx/react-native/plugin` inferred plugin. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.",
   "presets": [
     {
       "name": "Bundle for a specific platform",

--- a/packages/react-native/src/executors/pod-install/pod-install.impl.ts
+++ b/packages/react-native/src/executors/pod-install/pod-install.impl.ts
@@ -3,6 +3,7 @@ import { ExecutorContext } from '@nx/devkit';
 
 import { runPodInstall } from '../../utils/pod-install-task';
 import { ReactNativePodInstallOptions } from './schema';
+import { warnReactNativeExecutorDeprecation } from '../../utils/deprecation';
 
 export interface ReactNativePodInstallOutput {
   success: boolean;
@@ -12,6 +13,8 @@ export default async function* podInstall(
   options: ReactNativePodInstallOptions,
   context: ExecutorContext
 ): AsyncGenerator<ReactNativePodInstallOutput> {
+  warnReactNativeExecutorDeprecation('pod-install');
+
   const projectRoot =
     context.projectsConfigurations.projects[context.projectName].root;
   const iosDirectory = join(context.root, projectRoot, 'ios');

--- a/packages/react-native/src/executors/pod-install/schema.json
+++ b/packages/react-native/src/executors/pod-install/schema.json
@@ -7,6 +7,7 @@
   "title": "Run Pod Install for React Native iOS Project",
   "description": "Run `pod install` for React Native iOS Project.",
   "type": "object",
+  "x-deprecated": "The `@nx/react-native:pod-install` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/react-native:convert-to-inferred` to migrate to the `@nx/react-native/plugin` inferred plugin. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.",
   "properties": {
     "buildFolder": {
       "description": "Location for iOS build artifacts. Corresponds to Xcode's \"-derivedDataPath\". Relative to ios directory.",

--- a/packages/react-native/src/executors/run-android/run-android.impl.ts
+++ b/packages/react-native/src/executors/run-android/run-android.impl.ts
@@ -7,6 +7,7 @@ import { ReactNativeRunAndroidOptions } from './schema';
 import { runCliStart } from '../start/start.impl';
 import { chmodAndroidGradlewFiles } from '../../utils/chmod-android-gradle-files';
 import { getCliOptions } from '../../utils/get-cli-options';
+import { warnReactNativeExecutorDeprecation } from '../../utils/deprecation';
 
 export interface ReactNativeRunAndroidOutput {
   success: boolean;
@@ -18,6 +19,8 @@ export default async function* runAndroidExecutor(
   options: ReactNativeRunAndroidOptions,
   context: ExecutorContext
 ): AsyncGenerator<ReactNativeRunAndroidOutput> {
+  warnReactNativeExecutorDeprecation('run-android');
+
   const projectRoot =
     context.projectsConfigurations.projects[context.projectName].root;
   chmodAndroidGradlewFiles(join(context.root, projectRoot, 'android'));

--- a/packages/react-native/src/executors/run-android/schema.json
+++ b/packages/react-native/src/executors/run-android/schema.json
@@ -8,6 +8,7 @@
   "title": "Run Android application",
   "description": "Run Android target options.",
   "type": "object",
+  "x-deprecated": "The `@nx/react-native:run-android` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/react-native:convert-to-inferred` to migrate to the `@nx/react-native/plugin` inferred plugin. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.",
   "presets": [
     {
       "name": "Run Android for the current device architecture",

--- a/packages/react-native/src/executors/run-ios/run-ios.impl.ts
+++ b/packages/react-native/src/executors/run-ios/run-ios.impl.ts
@@ -6,6 +6,7 @@ import { platform } from 'os';
 
 import { runCliStart } from '../start/start.impl';
 import { getCliOptions } from '../../utils/get-cli-options';
+import { warnReactNativeExecutorDeprecation } from '../../utils/deprecation';
 
 import { ReactNativeRunIosOptions } from './schema';
 export interface ReactNativeRunIosOutput {
@@ -16,6 +17,8 @@ export default async function* runIosExecutor(
   options: ReactNativeRunIosOptions,
   context: ExecutorContext
 ): AsyncGenerator<ReactNativeRunIosOutput> {
+  warnReactNativeExecutorDeprecation('run-ios');
+
   if (platform() !== 'darwin') {
     throw new Error(`The run-ios build requires Mac to run`);
   }

--- a/packages/react-native/src/executors/run-ios/schema.json
+++ b/packages/react-native/src/executors/run-ios/schema.json
@@ -8,6 +8,7 @@
   "title": "Run iOS application",
   "description": "Run iOS target options.",
   "type": "object",
+  "x-deprecated": "The `@nx/react-native:run-ios` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/react-native:convert-to-inferred` to migrate to the `@nx/react-native/plugin` inferred plugin. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.",
   "presets": [
     {
       "name": "Run iOS on a simulator",

--- a/packages/react-native/src/executors/start/schema.json
+++ b/packages/react-native/src/executors/start/schema.json
@@ -8,6 +8,7 @@
   "title": "Packager Server for React Native",
   "description": "Packager Server target options.",
   "type": "object",
+  "x-deprecated": "The `@nx/react-native:start` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/react-native:convert-to-inferred` to migrate to the `@nx/react-native/plugin` inferred plugin. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.",
   "properties": {
     "port": {
       "type": "number",

--- a/packages/react-native/src/executors/start/start.impl.ts
+++ b/packages/react-native/src/executors/start/start.impl.ts
@@ -4,6 +4,7 @@ import { ChildProcess, fork } from 'child_process';
 import { resolve as pathResolve } from 'path';
 import { isPackagerRunning } from './lib/is-packager-running';
 import { ReactNativeStartOptions } from './schema';
+import { warnReactNativeExecutorDeprecation } from '../../utils/deprecation';
 
 export interface ReactNativeStartOutput {
   port?: number;
@@ -14,6 +15,8 @@ export default async function* startExecutor(
   options: ReactNativeStartOptions,
   context: ExecutorContext
 ): AsyncGenerator<ReactNativeStartOutput> {
+  warnReactNativeExecutorDeprecation('start');
+
   const projectRoot =
     context.projectsConfigurations.projects[context.projectName].root;
 

--- a/packages/react-native/src/executors/storybook/schema.json
+++ b/packages/react-native/src/executors/storybook/schema.json
@@ -5,6 +5,7 @@
   "cli": "nx",
   "description": "Load stories for react native.",
   "type": "object",
+  "x-deprecated": "The `@nx/react-native:storybook` executor is deprecated and will be removed in Nx v24. There is no inferred-plugin replacement for the on-device React Native Storybook flow; run the `@storybook/react-native` CLI directly via `nx:run-commands` instead.",
   "properties": {
     "searchDir": {
       "type": "array",

--- a/packages/react-native/src/executors/storybook/schema.json
+++ b/packages/react-native/src/executors/storybook/schema.json
@@ -5,7 +5,6 @@
   "cli": "nx",
   "description": "Load stories for react native.",
   "type": "object",
-  "x-deprecated": "The `@nx/react-native:storybook` executor is deprecated and will be removed in Nx v24. There is no inferred-plugin replacement for the on-device React Native Storybook flow; run the `@storybook/react-native` CLI directly via `nx:run-commands` instead.",
   "properties": {
     "searchDir": {
       "type": "array",

--- a/packages/react-native/src/executors/storybook/storybook.impl.ts
+++ b/packages/react-native/src/executors/storybook/storybook.impl.ts
@@ -9,16 +9,18 @@ import {
   displayNewlyAddedDepsMessage,
   syncDeps,
 } from '../sync-deps/sync-deps.impl';
+import { warnReactNativeStorybookDeprecation } from '../../utils/deprecation';
 import { PackageJson } from 'nx/src/utils/package-json';
 
-/**
- * TODO (@xiongemi): remove this function in v20.
- * @deprecated Going to use the default react storybook target. Use @nx/react:storybook executor instead.
- */
+// TODO(v24): Remove this executor. There is no inferred-plugin replacement
+// for the on-device React Native Storybook flow; users should run the
+// `@storybook/react-native` CLI directly via `nx:run-commands` instead.
 export default async function* reactNativeStorybookExecutor(
   options: ReactNativeStorybookOptions,
   context: ExecutorContext
 ): AsyncGenerator<{ success: boolean }> {
+  warnReactNativeStorybookDeprecation();
+
   const { syncDeps: isSyncDepsEnabled = true } = options;
 
   const projectRoot =

--- a/packages/react-native/src/executors/storybook/storybook.impl.ts
+++ b/packages/react-native/src/executors/storybook/storybook.impl.ts
@@ -9,18 +9,12 @@ import {
   displayNewlyAddedDepsMessage,
   syncDeps,
 } from '../sync-deps/sync-deps.impl';
-import { warnReactNativeStorybookDeprecation } from '../../utils/deprecation';
 import { PackageJson } from 'nx/src/utils/package-json';
 
-// TODO(v24): Remove this executor. There is no inferred-plugin replacement
-// for the on-device React Native Storybook flow; users should run the
-// `@storybook/react-native` CLI directly via `nx:run-commands` instead.
 export default async function* reactNativeStorybookExecutor(
   options: ReactNativeStorybookOptions,
   context: ExecutorContext
 ): AsyncGenerator<{ success: boolean }> {
-  warnReactNativeStorybookDeprecation();
-
   const { syncDeps: isSyncDepsEnabled = true } = options;
 
   const projectRoot =

--- a/packages/react-native/src/executors/upgrade/schema.json
+++ b/packages/react-native/src/executors/upgrade/schema.json
@@ -6,6 +6,7 @@
   "title": "React Native Upgrade Executor",
   "description": "Upgrade React Native code for project.",
   "type": "object",
+  "x-deprecated": "The `@nx/react-native:upgrade` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/react-native:convert-to-inferred` to migrate to the `@nx/react-native/plugin` inferred plugin. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.",
   "properties": {},
   "required": []
 }

--- a/packages/react-native/src/executors/upgrade/upgrade.impl.ts
+++ b/packages/react-native/src/executors/upgrade/upgrade.impl.ts
@@ -4,6 +4,7 @@ import { resolve as pathResolve } from 'path';
 import { ChildProcess, fork } from 'child_process';
 
 import { UpgradeExecutorSchema } from './schema';
+import { warnReactNativeExecutorDeprecation } from '../../utils/deprecation';
 
 export interface ReactNativeUpgradeOutput {
   success: boolean;
@@ -17,6 +18,8 @@ export default async function* upgradeExecutor(
   options: UpgradeExecutorSchema,
   context: ExecutorContext
 ): AsyncGenerator<ReactNativeUpgradeOutput> {
+  warnReactNativeExecutorDeprecation('upgrade');
+
   const projectRoot =
     context.projectsConfigurations.projects[context.projectName].root;
 

--- a/packages/react-native/src/generators/application/lib/add-project.ts
+++ b/packages/react-native/src/generators/application/lib/add-project.ts
@@ -10,7 +10,7 @@ import {
 } from '@nx/devkit';
 import { NormalizedSchema } from './normalize-options';
 import type { PackageJson } from 'nx/src/utils/package-json';
-import { warnReactNativeExecutorScaffolding } from '../../../utils/deprecation';
+import { warnReactNativeExecutorGenerating } from '../../../utils/deprecation';
 
 export function addProject(host: Tree, options: NormalizedSchema) {
   const nxJson = readNxJson(host);
@@ -21,7 +21,7 @@ export function addProject(host: Tree, options: NormalizedSchema) {
   );
 
   if (!hasPlugin) {
-    warnReactNativeExecutorScaffolding();
+    warnReactNativeExecutorGenerating();
   }
 
   const project: ProjectConfiguration = {

--- a/packages/react-native/src/generators/application/lib/add-project.ts
+++ b/packages/react-native/src/generators/application/lib/add-project.ts
@@ -10,6 +10,7 @@ import {
 } from '@nx/devkit';
 import { NormalizedSchema } from './normalize-options';
 import type { PackageJson } from 'nx/src/utils/package-json';
+import { warnReactNativeExecutorScaffolding } from '../../../utils/deprecation';
 
 export function addProject(host: Tree, options: NormalizedSchema) {
   const nxJson = readNxJson(host);
@@ -18,6 +19,10 @@ export function addProject(host: Tree, options: NormalizedSchema) {
       ? p === '@nx/react-native/plugin'
       : p.plugin === '@nx/react-native/plugin'
   );
+
+  if (!hasPlugin) {
+    warnReactNativeExecutorScaffolding();
+  }
 
   const project: ProjectConfiguration = {
     root: options.appProjectRoot,

--- a/packages/react-native/src/generators/web-configuration/web-configuration.ts
+++ b/packages/react-native/src/generators/web-configuration/web-configuration.ts
@@ -6,6 +6,7 @@ import {
   generateFiles,
   GeneratorCallback,
   joinPathFragments,
+  logger,
   readProjectConfiguration,
   runTasksInSerial,
   Tree,
@@ -145,6 +146,12 @@ async function addBundlerConfiguration(
     }
 
     if (!hasWebpackPlugin(tree)) {
+      // Mirrors warnWebpackExecutorScaffolding from @nx/webpack/src/utils/deprecation.
+      // Inlined to avoid a cross-package import where react-native does not
+      // declare a TypeScript project reference to webpack.
+      logger.warn(
+        'Scaffolding targets that use the deprecated `@nx/webpack:webpack` and `@nx/webpack:dev-server` executors. These executors will be removed in Nx v24. Run `nx g @nx/webpack:convert-to-inferred` after this scaffold to migrate the generated targets to the `@nx/webpack/plugin` inferred plugin. To skip emitting executor targets entirely on future scaffolds, register `@nx/webpack/plugin` in `nx.json` first (`nx add @nx/webpack` or a manual plugin entry). See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.'
+      );
       const projectConfiguration = readProjectConfiguration(
         tree,
         normalizedSchema.project

--- a/packages/react-native/src/generators/web-configuration/web-configuration.ts
+++ b/packages/react-native/src/generators/web-configuration/web-configuration.ts
@@ -150,7 +150,7 @@ async function addBundlerConfiguration(
       // Inlined to avoid a cross-package import where react-native does not
       // declare a TypeScript project reference to webpack.
       logger.warn(
-        'Scaffolding targets that use the deprecated `@nx/webpack:webpack` and `@nx/webpack:dev-server` executors. These executors will be removed in Nx v24. Run `nx g @nx/webpack:convert-to-inferred` after this scaffold to migrate the generated targets to the `@nx/webpack/plugin` inferred plugin. To skip emitting executor targets entirely on future scaffolds, register `@nx/webpack/plugin` in `nx.json` first (`nx add @nx/webpack` or a manual plugin entry). See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.'
+        'Generating targets that use the deprecated `@nx/webpack:webpack` and `@nx/webpack:dev-server` executors. These executors will be removed in Nx v24. Run `nx g @nx/webpack:convert-to-inferred` next to migrate these targets to the `@nx/webpack/plugin` inferred plugin and prevent future generators from emitting executor targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.'
       );
       const projectConfiguration = readProjectConfiguration(
         tree,

--- a/packages/react-native/src/generators/web-configuration/web-configuration.ts
+++ b/packages/react-native/src/generators/web-configuration/web-configuration.ts
@@ -146,7 +146,7 @@ async function addBundlerConfiguration(
     }
 
     if (!hasWebpackPlugin(tree)) {
-      // Mirrors warnWebpackExecutorScaffolding from @nx/webpack/src/utils/deprecation.
+      // Mirrors warnWebpackExecutorGenerating from @nx/webpack/src/utils/deprecation.
       // Inlined to avoid a cross-package import where react-native does not
       // declare a TypeScript project reference to webpack.
       logger.warn(

--- a/packages/react-native/src/utils/deprecation.ts
+++ b/packages/react-native/src/utils/deprecation.ts
@@ -1,19 +1,32 @@
 import { logger } from '@nx/devkit';
 
 // TODO(v24): Remove the @nx/react-native:build-android, :build-ios, :bundle,
-// :pod-install, :run-android, :run-ios, :start, and :upgrade executors. The
-// inferred plugin (@nx/react-native/plugin) and the convert-to-inferred
-// generator stay supported. (`@nx/react-native:storybook`, `:sync-deps`,
-// and `:ensure-symlink` are not covered by `convert-to-inferred` and stay
-// as-is.)
+// :pod-install, :run-android, :run-ios, :start, :storybook, and :upgrade
+// executors. The inferred plugin (@nx/react-native/plugin) and the
+// convert-to-inferred generator stay supported. (`:sync-deps` and
+// `:ensure-symlink` are Nx-specific glue with no inferred replacement and
+// stay as-is.)
 
 function buildMessage(executorName: string): string {
   return `The \`@nx/react-native:${executorName}\` executor is deprecated and will be removed in Nx v24. Run \`nx g @nx/react-native:convert-to-inferred\` to migrate to the \`@nx/react-native/plugin\` inferred targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.`;
 }
 
+// Storybook has no inferred-plugin replacement in @nx/react-native/plugin and
+// is not handled by the convert-to-inferred generator. Run the
+// @storybook/react-native CLI directly via `nx:run-commands` instead.
+const STORYBOOK_DEPRECATION_MESSAGE =
+  'The `@nx/react-native:storybook` executor is deprecated and will be removed in Nx v24. There is no inferred-plugin replacement for the on-device React Native Storybook flow; run the `@storybook/react-native` CLI directly via `nx:run-commands` instead.';
+
 export function warnReactNativeExecutorDeprecation(executorName: string): void {
   logger.warn(buildMessage(executorName));
 }
+
+export function warnReactNativeStorybookDeprecation(): void {
+  logger.warn(STORYBOOK_DEPRECATION_MESSAGE);
+}
+
+export const reactNativeStorybookDeprecationMessage =
+  STORYBOOK_DEPRECATION_MESSAGE;
 
 export function reactNativeSchemaDeprecationMessage(
   executorName: string

--- a/packages/react-native/src/utils/deprecation.ts
+++ b/packages/react-native/src/utils/deprecation.ts
@@ -1,0 +1,28 @@
+import { logger } from '@nx/devkit';
+
+// TODO(v24): Remove the @nx/react-native:build-android, :build-ios, :bundle,
+// :pod-install, :run-android, :run-ios, :start, and :upgrade executors. The
+// inferred plugin (@nx/react-native/plugin) and the convert-to-inferred
+// generator stay supported. (`@nx/react-native:storybook`, `:sync-deps`,
+// and `:ensure-symlink` are not covered by `convert-to-inferred` and stay
+// as-is.)
+
+function buildMessage(executorName: string): string {
+  return `The \`@nx/react-native:${executorName}\` executor is deprecated and will be removed in Nx v24. Run \`nx g @nx/react-native:convert-to-inferred\` to migrate to the \`@nx/react-native/plugin\` inferred targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.`;
+}
+
+export function warnReactNativeExecutorDeprecation(executorName: string): void {
+  logger.warn(buildMessage(executorName));
+}
+
+export function reactNativeSchemaDeprecationMessage(
+  executorName: string
+): string {
+  return buildMessage(executorName);
+}
+
+export function warnReactNativeExecutorScaffolding(): void {
+  logger.warn(
+    'Generating targets that use the deprecated `@nx/react-native:build-android`, `@nx/react-native:build-ios`, `@nx/react-native:bundle`, `@nx/react-native:pod-install`, `@nx/react-native:run-android`, `@nx/react-native:run-ios`, `@nx/react-native:start`, and `@nx/react-native:upgrade` executors. These executors will be removed in Nx v24. Run `nx g @nx/react-native:convert-to-inferred` next to migrate these targets to the `@nx/react-native/plugin` inferred plugin and prevent future generators from emitting executor targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.'
+  );
+}

--- a/packages/react-native/src/utils/deprecation.ts
+++ b/packages/react-native/src/utils/deprecation.ts
@@ -1,37 +1,17 @@
 import { logger } from '@nx/devkit';
 
 // TODO(v24): Remove the @nx/react-native:build-android, :build-ios, :bundle,
-// :pod-install, :run-android, :run-ios, :start, :storybook, and :upgrade
-// executors. The inferred plugin (@nx/react-native/plugin) and the
-// convert-to-inferred generator stay supported. (`:sync-deps` and
-// `:ensure-symlink` are Nx-specific glue with no inferred replacement and
-// stay as-is.)
+// :pod-install, :run-android, :run-ios, :start, and :upgrade executors. The
+// inferred plugin (@nx/react-native/plugin) and the convert-to-inferred
+// generator stay supported. (`:storybook`, `:sync-deps`, and `:ensure-symlink`
+// are Nx-specific glue with no inferred replacement and stay as-is.)
 
 function buildMessage(executorName: string): string {
   return `The \`@nx/react-native:${executorName}\` executor is deprecated and will be removed in Nx v24. Run \`nx g @nx/react-native:convert-to-inferred\` to migrate to the \`@nx/react-native/plugin\` inferred targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.`;
 }
 
-// Storybook has no inferred-plugin replacement in @nx/react-native/plugin and
-// is not handled by the convert-to-inferred generator. Run the
-// @storybook/react-native CLI directly via `nx:run-commands` instead.
-const STORYBOOK_DEPRECATION_MESSAGE =
-  'The `@nx/react-native:storybook` executor is deprecated and will be removed in Nx v24. There is no inferred-plugin replacement for the on-device React Native Storybook flow; run the `@storybook/react-native` CLI directly via `nx:run-commands` instead.';
-
 export function warnReactNativeExecutorDeprecation(executorName: string): void {
   logger.warn(buildMessage(executorName));
-}
-
-export function warnReactNativeStorybookDeprecation(): void {
-  logger.warn(STORYBOOK_DEPRECATION_MESSAGE);
-}
-
-export const reactNativeStorybookDeprecationMessage =
-  STORYBOOK_DEPRECATION_MESSAGE;
-
-export function reactNativeSchemaDeprecationMessage(
-  executorName: string
-): string {
-  return buildMessage(executorName);
 }
 
 export function warnReactNativeExecutorGenerating(): void {

--- a/packages/react-native/src/utils/deprecation.ts
+++ b/packages/react-native/src/utils/deprecation.ts
@@ -34,7 +34,7 @@ export function reactNativeSchemaDeprecationMessage(
   return buildMessage(executorName);
 }
 
-export function warnReactNativeExecutorScaffolding(): void {
+export function warnReactNativeExecutorGenerating(): void {
   logger.warn(
     'Generating targets that use the deprecated `@nx/react-native:build-android`, `@nx/react-native:build-ios`, `@nx/react-native:bundle`, `@nx/react-native:pod-install`, `@nx/react-native:run-android`, `@nx/react-native:run-ios`, `@nx/react-native:start`, and `@nx/react-native:upgrade` executors. These executors will be removed in Nx v24. Run `nx g @nx/react-native:convert-to-inferred` next to migrate these targets to the `@nx/react-native/plugin` inferred plugin and prevent future generators from emitting executor targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.'
   );

--- a/packages/react/src/generators/application/lib/add-project.ts
+++ b/packages/react/src/generators/application/lib/add-project.ts
@@ -12,7 +12,7 @@ import {
 import { hasWebpackPlugin } from '../../../utils/has-webpack-plugin';
 import { maybeJs } from '../../../utils/maybe-js';
 import { hasRspackPlugin } from '../../../utils/has-rspack-plugin';
-import { warnWebpackExecutorScaffolding } from '@nx/webpack/src/utils/deprecation';
+import { warnWebpackExecutorGenerating } from '@nx/webpack/src/utils/deprecation';
 import type { PackageJson } from 'nx/src/utils/package-json';
 
 export function addProject(host: Tree, options: NormalizedSchema) {
@@ -26,7 +26,7 @@ export function addProject(host: Tree, options: NormalizedSchema) {
 
   if (options.bundler === 'webpack') {
     if (!hasWebpackPlugin(host) || !options.addPlugin) {
-      warnWebpackExecutorScaffolding();
+      warnWebpackExecutorGenerating();
       project.targets = {
         build: createBuildTarget(options),
         serve: createServeTarget(options),
@@ -36,7 +36,7 @@ export function addProject(host: Tree, options: NormalizedSchema) {
     options.bundler === 'rspack' &&
     (!hasRspackPlugin(host) || !options.addPlugin)
   ) {
-    // Mirrors warnRspackExecutorScaffolding from @nx/rspack/src/utils/deprecation.
+    // Mirrors warnRspackExecutorGenerating from @nx/rspack/src/utils/deprecation.
     // Inlined to avoid a cross-package import where react does not declare a
     // TypeScript project reference to rspack.
     logger.warn(

--- a/packages/react/src/generators/application/lib/add-project.ts
+++ b/packages/react/src/generators/application/lib/add-project.ts
@@ -2,6 +2,7 @@ import { NormalizedSchema } from '../schema';
 import {
   addProjectConfiguration,
   joinPathFragments,
+  logger,
   ProjectConfiguration,
   TargetConfiguration,
   Tree,
@@ -35,6 +36,12 @@ export function addProject(host: Tree, options: NormalizedSchema) {
     options.bundler === 'rspack' &&
     (!hasRspackPlugin(host) || !options.addPlugin)
   ) {
+    // Mirrors warnRspackExecutorScaffolding from @nx/rspack/src/utils/deprecation.
+    // Inlined to avoid a cross-package import where react does not declare a
+    // TypeScript project reference to rspack.
+    logger.warn(
+      'Generating targets that use the deprecated `@nx/rspack:rspack` and `@nx/rspack:dev-server` executors. These executors will be removed in Nx v24. Run `nx g @nx/rspack:convert-to-inferred` next to migrate these targets to the `@nx/rspack/plugin` inferred plugin and prevent future generators from emitting executor targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.'
+    );
     project.targets = {
       build: createRspackBuildTarget(options),
       serve: createRspackServeTarget(options),

--- a/packages/react/src/generators/application/lib/add-project.ts
+++ b/packages/react/src/generators/application/lib/add-project.ts
@@ -11,6 +11,7 @@ import {
 import { hasWebpackPlugin } from '../../../utils/has-webpack-plugin';
 import { maybeJs } from '../../../utils/maybe-js';
 import { hasRspackPlugin } from '../../../utils/has-rspack-plugin';
+import { warnWebpackExecutorScaffolding } from '@nx/webpack/src/utils/deprecation';
 import type { PackageJson } from 'nx/src/utils/package-json';
 
 export function addProject(host: Tree, options: NormalizedSchema) {
@@ -24,6 +25,7 @@ export function addProject(host: Tree, options: NormalizedSchema) {
 
   if (options.bundler === 'webpack') {
     if (!hasWebpackPlugin(host) || !options.addPlugin) {
+      warnWebpackExecutorScaffolding();
       project.targets = {
         build: createBuildTarget(options),
         serve: createServeTarget(options),

--- a/packages/react/src/generators/application/lib/add-project.ts
+++ b/packages/react/src/generators/application/lib/add-project.ts
@@ -12,7 +12,6 @@ import {
 import { hasWebpackPlugin } from '../../../utils/has-webpack-plugin';
 import { maybeJs } from '../../../utils/maybe-js';
 import { hasRspackPlugin } from '../../../utils/has-rspack-plugin';
-import { warnWebpackExecutorGenerating } from '@nx/webpack/src/utils/deprecation';
 import type { PackageJson } from 'nx/src/utils/package-json';
 
 export function addProject(host: Tree, options: NormalizedSchema) {
@@ -26,7 +25,14 @@ export function addProject(host: Tree, options: NormalizedSchema) {
 
   if (options.bundler === 'webpack') {
     if (!hasWebpackPlugin(host) || !options.addPlugin) {
-      warnWebpackExecutorGenerating();
+      // Mirrors warnWebpackExecutorGenerating from @nx/webpack/src/utils/deprecation.
+      // Inlined to avoid a cross-package deep import; @nx/webpack's package
+      // exports field doesn't expose internal `src/...` paths, so the import
+      // works at compile time (via tsconfig project refs) but fails at runtime
+      // in published packages.
+      logger.warn(
+        'Generating targets that use the deprecated `@nx/webpack:webpack` and `@nx/webpack:dev-server` executors. These executors will be removed in Nx v24. Run `nx g @nx/webpack:convert-to-inferred` next to migrate these targets to the `@nx/webpack/plugin` inferred plugin and prevent future generators from emitting executor targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.'
+      );
       project.targets = {
         build: createBuildTarget(options),
         serve: createServeTarget(options),

--- a/packages/react/src/generators/library/lib/add-rollup-build-target.ts
+++ b/packages/react/src/generators/library/lib/add-rollup-build-target.ts
@@ -103,10 +103,10 @@ module.exports = withNx(
     );
   } else {
     // Legacy behavior, there is a target in project.json using rollup executor.
-    const { warnRollupExecutorScaffolding } = await import(
+    const { warnRollupExecutorGenerating } = await import(
       '@nx/rollup/src/utils/deprecation'
     );
-    warnRollupExecutorScaffolding();
+    warnRollupExecutorGenerating();
     const { targets } = readProjectConfiguration(host, options.name);
     targets.build = {
       executor: '@nx/rollup:rollup',

--- a/packages/react/src/generators/library/lib/add-rollup-build-target.ts
+++ b/packages/react/src/generators/library/lib/add-rollup-build-target.ts
@@ -103,6 +103,10 @@ module.exports = withNx(
     );
   } else {
     // Legacy behavior, there is a target in project.json using rollup executor.
+    const { warnRollupExecutorScaffolding } = await import(
+      '@nx/rollup/src/utils/deprecation'
+    );
+    warnRollupExecutorScaffolding();
     const { targets } = readProjectConfiguration(host, options.name);
     targets.build = {
       executor: '@nx/rollup:rollup',

--- a/packages/react/src/generators/library/lib/add-rollup-build-target.ts
+++ b/packages/react/src/generators/library/lib/add-rollup-build-target.ts
@@ -4,6 +4,7 @@ import {
   ensurePackage,
   GeneratorCallback,
   joinPathFragments,
+  logger,
   offsetFromRoot,
   readNxJson,
   readProjectConfiguration,
@@ -103,10 +104,14 @@ module.exports = withNx(
     );
   } else {
     // Legacy behavior, there is a target in project.json using rollup executor.
-    const { warnRollupExecutorGenerating } = await import(
-      '@nx/rollup/src/utils/deprecation'
+    // Mirrors warnRollupExecutorGenerating from @nx/rollup/src/utils/deprecation.
+    // Inlined to avoid a cross-package deep import; @nx/rollup's package
+    // exports field doesn't expose internal `src/...` paths, so the import
+    // works at compile time (via tsconfig project refs) but fails at runtime
+    // in published packages.
+    logger.warn(
+      'The `@nx/rollup:rollup` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/rollup:convert-to-inferred` to migrate to the `@nx/rollup/plugin` inferred targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.'
     );
-    warnRollupExecutorGenerating();
     const { targets } = readProjectConfiguration(host, options.name);
     targets.build = {
       executor: '@nx/rollup:rollup',

--- a/packages/remix/src/executors/build/build.impl.ts
+++ b/packages/remix/src/executors/build/build.impl.ts
@@ -12,6 +12,7 @@ import { copySync, mkdir, writeFileSync } from 'fs-extra';
 import { type PackageJson } from 'nx/src/utils/package-json';
 import { join } from 'path';
 import { type RemixBuildSchema } from './schema';
+import { warnRemixBuildExecutorDeprecation } from '../../utils/deprecation';
 
 function buildRemixBuildArgs(options: RemixBuildSchema) {
   const args = ['build'];
@@ -46,6 +47,8 @@ export default async function buildExecutor(
   options: RemixBuildSchema,
   context: ExecutorContext
 ) {
+  warnRemixBuildExecutorDeprecation();
+
   const projectRoot = context.projectGraph.nodes[context.projectName].data.root;
 
   try {

--- a/packages/remix/src/executors/build/schema.json
+++ b/packages/remix/src/executors/build/schema.json
@@ -6,6 +6,7 @@
   "title": "Remix Build",
   "description": "Build a Remix app.",
   "type": "object",
+  "x-deprecated": "The `@nx/remix:build` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/remix:convert-to-inferred` to migrate to the `@nx/remix/plugin` inferred plugin. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.",
   "properties": {
     "outputPath": {
       "type": "string",

--- a/packages/remix/src/executors/serve/schema.json
+++ b/packages/remix/src/executors/serve/schema.json
@@ -6,6 +6,7 @@
   "title": "Remix Serve",
   "description": "Serve a Remix app.",
   "type": "object",
+  "x-deprecated": "The `@nx/remix:serve` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/remix:convert-to-inferred` to migrate to the `@nx/remix/plugin` inferred plugin. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.",
   "properties": {
     "port": {
       "type": "number",

--- a/packages/remix/src/executors/serve/serve.impl.ts
+++ b/packages/remix/src/executors/serve/serve.impl.ts
@@ -4,6 +4,7 @@ import { waitForPortOpen } from '@nx/web/src/utils/wait-for-port-open';
 import { fork } from 'node:child_process';
 import { join } from 'node:path';
 import { type RemixServeSchema } from './schema';
+import { warnRemixServeExecutorDeprecation } from '../../utils/deprecation';
 
 function normalizeOptions(schema: RemixServeSchema) {
   return {
@@ -48,6 +49,8 @@ export default async function* serveExecutor(
   schema: RemixServeSchema,
   context: ExecutorContext
 ) {
+  warnRemixServeExecutorDeprecation();
+
   const options = normalizeOptions(schema);
   const projectRoot =
     context.projectsConfigurations.projects[context.projectName].root;

--- a/packages/remix/src/utils/deprecation.ts
+++ b/packages/remix/src/utils/deprecation.ts
@@ -1,0 +1,18 @@
+import { logger } from '@nx/devkit';
+
+// TODO(v24): Remove the @nx/remix:build and @nx/remix:serve executors. The
+// inferred plugin (@nx/remix/plugin) and the convert-to-inferred generator
+// stay supported.
+export const REMIX_BUILD_EXECUTOR_DEPRECATION_MESSAGE =
+  'The `@nx/remix:build` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/remix:convert-to-inferred` to migrate to the `@nx/remix/plugin` inferred targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.';
+
+export const REMIX_SERVE_EXECUTOR_DEPRECATION_MESSAGE =
+  'The `@nx/remix:serve` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/remix:convert-to-inferred` to migrate to the `@nx/remix/plugin` inferred targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.';
+
+export function warnRemixBuildExecutorDeprecation(): void {
+  logger.warn(REMIX_BUILD_EXECUTOR_DEPRECATION_MESSAGE);
+}
+
+export function warnRemixServeExecutorDeprecation(): void {
+  logger.warn(REMIX_SERVE_EXECUTOR_DEPRECATION_MESSAGE);
+}

--- a/packages/rollup/src/executors/rollup/rollup.impl.ts
+++ b/packages/rollup/src/executors/rollup/rollup.impl.ts
@@ -11,11 +11,14 @@ import {
 import { withNx } from '../../plugins/with-nx/with-nx';
 import { pluginName as generatePackageJsonPluginName } from '../../plugins/package-json/generate-package-json';
 import { calculateProjectBuildableDependencies } from '@nx/js/src/utils/buildable-libs-utils';
+import { warnRollupExecutorDeprecation } from '../../utils/deprecation';
 
 export async function* rollupExecutor(
   rawOptions: RollupExecutorOptions,
   context: ExecutorContext
 ) {
+  warnRollupExecutorDeprecation();
+
   process.env.NODE_ENV ??= 'production';
   const options = normalizeRollupExecutorOptions(rawOptions, context);
   const rollupOptions = await createRollupOptions(options, context);

--- a/packages/rollup/src/executors/rollup/schema.json
+++ b/packages/rollup/src/executors/rollup/schema.json
@@ -5,6 +5,7 @@
   "description": "Packages a library for different web usages (ESM, CommonJS).",
   "cli": "nx",
   "type": "object",
+  "x-deprecated": "The `@nx/rollup:rollup` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/rollup:convert-to-inferred` to migrate to the `@nx/rollup/plugin` inferred plugin. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.",
   "properties": {
     "project": {
       "type": "string",

--- a/packages/rollup/src/generators/configuration/configuration.ts
+++ b/packages/rollup/src/generators/configuration/configuration.ts
@@ -28,7 +28,7 @@ import { RollupExecutorOptions } from '../../executors/rollup/schema';
 import { RollupWithNxPluginOptions } from '../../plugins/with-nx/with-nx-options';
 import { ensureDependencies } from '../../utils/ensure-dependencies';
 import { hasPlugin } from '../../utils/has-plugin';
-import { warnRollupExecutorScaffolding } from '../../utils/deprecation';
+import { warnRollupExecutorGenerating } from '../../utils/deprecation';
 import { rollupInitGenerator } from '../init/init';
 import { RollupProjectSchema } from './schema';
 
@@ -56,7 +56,7 @@ export async function configurationGenerator(
   if (hasPlugin(tree)) {
     outputConfig = createRollupConfig(tree, options, isTsSolutionSetup);
   } else {
-    warnRollupExecutorScaffolding();
+    warnRollupExecutorGenerating();
     options.buildTarget ??= 'build';
     checkForTargetConflicts(tree, options);
     addBuildTarget(tree, options, isTsSolutionSetup);

--- a/packages/rollup/src/generators/configuration/configuration.ts
+++ b/packages/rollup/src/generators/configuration/configuration.ts
@@ -28,6 +28,7 @@ import { RollupExecutorOptions } from '../../executors/rollup/schema';
 import { RollupWithNxPluginOptions } from '../../plugins/with-nx/with-nx-options';
 import { ensureDependencies } from '../../utils/ensure-dependencies';
 import { hasPlugin } from '../../utils/has-plugin';
+import { warnRollupExecutorScaffolding } from '../../utils/deprecation';
 import { rollupInitGenerator } from '../init/init';
 import { RollupProjectSchema } from './schema';
 
@@ -55,6 +56,7 @@ export async function configurationGenerator(
   if (hasPlugin(tree)) {
     outputConfig = createRollupConfig(tree, options, isTsSolutionSetup);
   } else {
+    warnRollupExecutorScaffolding();
     options.buildTarget ??= 'build';
     checkForTargetConflicts(tree, options);
     addBuildTarget(tree, options, isTsSolutionSetup);

--- a/packages/rollup/src/utils/deprecation.ts
+++ b/packages/rollup/src/utils/deprecation.ts
@@ -15,6 +15,6 @@ export function warnRollupExecutorDeprecation(): void {
 // rather than only when the user later runs the generated target.
 export function warnRollupExecutorScaffolding(): void {
   logger.warn(
-    'Scaffolding a target that uses the deprecated `@nx/rollup:rollup` executor. The executor will be removed in Nx v24. Run `nx g @nx/rollup:convert-to-inferred` after this scaffold to migrate the generated target to the `@nx/rollup/plugin` inferred plugin. To skip emitting executor targets entirely on future scaffolds, register `@nx/rollup/plugin` in `nx.json` first (`nx add @nx/rollup` or a manual plugin entry). See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.'
+    'Generating a target that uses the deprecated `@nx/rollup:rollup` executor. The executor will be removed in Nx v24. Run `nx g @nx/rollup:convert-to-inferred` next to migrate this target to the `@nx/rollup/plugin` inferred plugin and prevent future generators from emitting executor targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.'
   );
 }

--- a/packages/rollup/src/utils/deprecation.ts
+++ b/packages/rollup/src/utils/deprecation.ts
@@ -1,0 +1,20 @@
+import { logger } from '@nx/devkit';
+
+// TODO(v24): Remove the @nx/rollup:rollup executor. The inferred plugin
+// (@nx/rollup/plugin) and the convert-to-inferred generator stay supported.
+export const ROLLUP_EXECUTOR_DEPRECATION_MESSAGE =
+  'The `@nx/rollup:rollup` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/rollup:convert-to-inferred` to migrate to the `@nx/rollup/plugin` inferred targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.';
+
+export function warnRollupExecutorDeprecation(): void {
+  logger.warn(ROLLUP_EXECUTOR_DEPRECATION_MESSAGE);
+}
+
+// Fired when the @nx/rollup:configuration generator is about to scaffold a
+// target that uses the deprecated executor — i.e. when @nx/rollup/plugin
+// isn't registered in nx.json. Surfaces the deprecation at scaffold time
+// rather than only when the user later runs the generated target.
+export function warnRollupExecutorScaffolding(): void {
+  logger.warn(
+    'Scaffolding a target that uses the deprecated `@nx/rollup:rollup` executor. The executor will be removed in Nx v24. Run `nx g @nx/rollup:convert-to-inferred` after this scaffold to migrate the generated target to the `@nx/rollup/plugin` inferred plugin. To skip emitting executor targets entirely on future scaffolds, register `@nx/rollup/plugin` in `nx.json` first (`nx add @nx/rollup` or a manual plugin entry). See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.'
+  );
+}

--- a/packages/rollup/src/utils/deprecation.ts
+++ b/packages/rollup/src/utils/deprecation.ts
@@ -9,11 +9,11 @@ export function warnRollupExecutorDeprecation(): void {
   logger.warn(ROLLUP_EXECUTOR_DEPRECATION_MESSAGE);
 }
 
-// Fired when the @nx/rollup:configuration generator is about to scaffold a
+// Fired when the @nx/rollup:configuration generator is about to generate a
 // target that uses the deprecated executor — i.e. when @nx/rollup/plugin
-// isn't registered in nx.json. Surfaces the deprecation at scaffold time
+// isn't registered in nx.json. Surfaces the deprecation at generation time
 // rather than only when the user later runs the generated target.
-export function warnRollupExecutorScaffolding(): void {
+export function warnRollupExecutorGenerating(): void {
   logger.warn(
     'Generating a target that uses the deprecated `@nx/rollup:rollup` executor. The executor will be removed in Nx v24. Run `nx g @nx/rollup:convert-to-inferred` next to migrate this target to the `@nx/rollup/plugin` inferred plugin and prevent future generators from emitting executor targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.'
   );

--- a/packages/rspack/src/executors/dev-server/dev-server.impl.ts
+++ b/packages/rspack/src/executors/dev-server/dev-server.impl.ts
@@ -13,12 +13,15 @@ import { isMode } from '../../utils/mode-utils';
 import { normalizeOptions } from '../rspack/lib/normalize-options';
 import { getDevServerOptions } from './lib/get-dev-server-config';
 import { DevServerExecutorSchema } from './schema';
+import { warnRspackDevServerExecutorDeprecation } from '../../utils/deprecation';
 
 type DevServer = Configuration['devServer'];
 export default async function* runExecutor(
   options: DevServerExecutorSchema,
   context: ExecutorContext
 ): AsyncIterableIterator<{ success: boolean; baseUrl?: string }> {
+  warnRspackDevServerExecutorDeprecation();
+
   process.env.NODE_ENV ??= options.mode ?? 'development';
 
   if (isMode(process.env.NODE_ENV)) {

--- a/packages/rspack/src/executors/dev-server/schema.json
+++ b/packages/rspack/src/executors/dev-server/schema.json
@@ -5,6 +5,7 @@
   "description": "Run @rspack/dev-server to serve a project.",
   "continuous": true,
   "type": "object",
+  "x-deprecated": "The `@nx/rspack:dev-server` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/rspack:convert-to-inferred` to migrate to the `@nx/rspack/plugin` inferred plugin. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.",
   "properties": {
     "buildTarget": {
       "type": "string",

--- a/packages/rspack/src/executors/rspack/rspack.impl.ts
+++ b/packages/rspack/src/executors/rspack/rspack.impl.ts
@@ -16,11 +16,14 @@ import { createCompiler, isMultiCompiler } from '../../utils/create-compiler';
 import { isMode } from '../../utils/mode-utils';
 import { normalizeOptions } from './lib/normalize-options';
 import { RspackExecutorSchema } from './schema';
+import { warnRspackExecutorDeprecation } from '../../utils/deprecation';
 
 export default async function* runExecutor(
   options: RspackExecutorSchema,
   context: ExecutorContext
 ) {
+  warnRspackExecutorDeprecation();
+
   process.env.NODE_ENV ??= options.mode ?? 'production';
   options.target ??= 'web';
 

--- a/packages/rspack/src/executors/rspack/schema.json
+++ b/packages/rspack/src/executors/rspack/schema.json
@@ -4,6 +4,7 @@
   "title": "Rspack build executor",
   "description": "Run Rspack via an executor for a project.",
   "type": "object",
+  "x-deprecated": "The `@nx/rspack:rspack` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/rspack:convert-to-inferred` to migrate to the `@nx/rspack/plugin` inferred plugin. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.",
   "properties": {
     "target": {
       "type": "string",

--- a/packages/rspack/src/generators/configuration/configuration.ts
+++ b/packages/rspack/src/generators/configuration/configuration.ts
@@ -24,7 +24,7 @@ import rspackInitGenerator from '../init/init';
 import { ConfigurationSchema } from './schema';
 import { getProjectType } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { Framework } from '../init/schema';
-import { warnRspackExecutorScaffolding } from '../../utils/deprecation';
+import { warnRspackExecutorGenerating } from '../../utils/deprecation';
 
 function projectIsRootProjectInStandaloneWorkspace(projectRoot: string) {
   return relative(workspaceRoot, projectRoot).length === 0;
@@ -194,7 +194,7 @@ export async function configurationGenerator(
       options.framework !== 'nest' &&
       !projectAlreadyHasRspackTargets.serve);
   if (willScaffoldExecutorTargets) {
-    warnRspackExecutorScaffolding();
+    warnRspackExecutorGenerating();
   }
 
   if (!projectAlreadyHasRspackTargets.build) {

--- a/packages/rspack/src/generators/configuration/configuration.ts
+++ b/packages/rspack/src/generators/configuration/configuration.ts
@@ -190,9 +190,9 @@ export async function configurationGenerator(
 
   const willScaffoldExecutorTargets =
     !projectAlreadyHasRspackTargets.build ||
-    (options.framework !== 'none' || options.devServer) &&
+    ((options.framework !== 'none' || options.devServer) &&
       options.framework !== 'nest' &&
-      !projectAlreadyHasRspackTargets.serve;
+      !projectAlreadyHasRspackTargets.serve);
   if (willScaffoldExecutorTargets) {
     warnRspackExecutorScaffolding();
   }

--- a/packages/rspack/src/generators/configuration/configuration.ts
+++ b/packages/rspack/src/generators/configuration/configuration.ts
@@ -24,6 +24,7 @@ import rspackInitGenerator from '../init/init';
 import { ConfigurationSchema } from './schema';
 import { getProjectType } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { Framework } from '../init/schema';
+import { warnRspackExecutorScaffolding } from '../../utils/deprecation';
 
 function projectIsRootProjectInStandaloneWorkspace(projectRoot: string) {
   return relative(workspaceRoot, projectRoot).length === 0;
@@ -185,6 +186,15 @@ export async function configurationGenerator(
       options.framework,
       joinPathFragments(offsetFromRoot(root), 'tsconfig.base.json')
     );
+  }
+
+  const willScaffoldExecutorTargets =
+    !projectAlreadyHasRspackTargets.build ||
+    (options.framework !== 'none' || options.devServer) &&
+      options.framework !== 'nest' &&
+      !projectAlreadyHasRspackTargets.serve;
+  if (willScaffoldExecutorTargets) {
+    warnRspackExecutorScaffolding();
   }
 
   if (!projectAlreadyHasRspackTargets.build) {

--- a/packages/rspack/src/utils/deprecation.ts
+++ b/packages/rspack/src/utils/deprecation.ts
@@ -1,0 +1,24 @@
+import { logger } from '@nx/devkit';
+
+// TODO(v24): Remove the @nx/rspack:rspack and @nx/rspack:dev-server
+// executors. The inferred plugin (@nx/rspack/plugin) and the
+// convert-to-inferred generator stay supported.
+export const RSPACK_EXECUTOR_DEPRECATION_MESSAGE =
+  'The `@nx/rspack:rspack` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/rspack:convert-to-inferred` to migrate to the `@nx/rspack/plugin` inferred targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.';
+
+export const RSPACK_DEV_SERVER_EXECUTOR_DEPRECATION_MESSAGE =
+  'The `@nx/rspack:dev-server` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/rspack:convert-to-inferred` to migrate to the `@nx/rspack/plugin` inferred targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.';
+
+export function warnRspackExecutorDeprecation(): void {
+  logger.warn(RSPACK_EXECUTOR_DEPRECATION_MESSAGE);
+}
+
+export function warnRspackDevServerExecutorDeprecation(): void {
+  logger.warn(RSPACK_DEV_SERVER_EXECUTOR_DEPRECATION_MESSAGE);
+}
+
+export function warnRspackExecutorScaffolding(): void {
+  logger.warn(
+    'Generating targets that use the deprecated `@nx/rspack:rspack` and `@nx/rspack:dev-server` executors. These executors will be removed in Nx v24. Run `nx g @nx/rspack:convert-to-inferred` next to migrate these targets to the `@nx/rspack/plugin` inferred plugin and prevent future generators from emitting executor targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.'
+  );
+}

--- a/packages/rspack/src/utils/deprecation.ts
+++ b/packages/rspack/src/utils/deprecation.ts
@@ -17,7 +17,7 @@ export function warnRspackDevServerExecutorDeprecation(): void {
   logger.warn(RSPACK_DEV_SERVER_EXECUTOR_DEPRECATION_MESSAGE);
 }
 
-export function warnRspackExecutorScaffolding(): void {
+export function warnRspackExecutorGenerating(): void {
   logger.warn(
     'Generating targets that use the deprecated `@nx/rspack:rspack` and `@nx/rspack:dev-server` executors. These executors will be removed in Nx v24. Run `nx g @nx/rspack:convert-to-inferred` next to migrate these targets to the `@nx/rspack/plugin` inferred plugin and prevent future generators from emitting executor targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.'
   );

--- a/packages/storybook/src/executors/build-storybook/build-storybook.impl.ts
+++ b/packages/storybook/src/executors/build-storybook/build-storybook.impl.ts
@@ -7,11 +7,14 @@ import {
   getInstalledStorybookVersion,
 } from '../../utils/utilities';
 import { gte } from 'semver';
+import { warnStorybookBuildExecutorDeprecation } from '../../utils/deprecation';
 
 export default async function buildStorybookExecutor(
   options: CLIOptions,
   context: ExecutorContext
 ) {
+  warnStorybookBuildExecutorDeprecation();
+
   storybookConfigExistsCheck(options.configDir, context.projectName);
   const storybookMajor = storybookMajorVersion();
   if (storybookMajor > 0 && storybookMajor <= 7) {

--- a/packages/storybook/src/executors/build-storybook/schema.json
+++ b/packages/storybook/src/executors/build-storybook/schema.json
@@ -5,6 +5,7 @@
   "cli": "nx",
   "description": "Build storybook in production mode.",
   "type": "object",
+  "x-deprecated": "The `@nx/storybook:build` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/storybook:convert-to-inferred` to migrate to the `@nx/storybook/plugin` inferred plugin. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.",
   "presets": [
     {
       "name": "Default minimum setup",

--- a/packages/storybook/src/executors/storybook/schema.json
+++ b/packages/storybook/src/executors/storybook/schema.json
@@ -6,6 +6,7 @@
   "cli": "nx",
   "description": "Serve up Storybook in development mode.",
   "type": "object",
+  "x-deprecated": "The `@nx/storybook:storybook` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/storybook:convert-to-inferred` to migrate to the `@nx/storybook/plugin` inferred plugin. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.",
   "presets": [
     {
       "name": "Default minimum setup",

--- a/packages/storybook/src/executors/storybook/storybook.impl.ts
+++ b/packages/storybook/src/executors/storybook/storybook.impl.ts
@@ -7,6 +7,7 @@ import {
 } from '../../utils/utilities';
 import type { CLIOptions } from 'storybook/internal/types';
 import { gte } from 'semver';
+import { warnStorybookExecutorDeprecation } from '../../utils/deprecation';
 
 export default async function* storybookExecutor(
   options: CLIOptions,
@@ -15,6 +16,8 @@ export default async function* storybookExecutor(
   success: boolean;
   info?: { port: number; baseUrl?: string };
 }> {
+  warnStorybookExecutorDeprecation();
+
   const storybookMajor = storybookMajorVersion();
   if (storybookMajor > 0 && storybookMajor <= 7) {
     throw pleaseUpgrade();

--- a/packages/storybook/src/generators/configuration/configuration.ts
+++ b/packages/storybook/src/generators/configuration/configuration.ts
@@ -12,6 +12,7 @@ import { initGenerator as jsInitGenerator } from '@nx/js';
 
 import { StorybookConfigureSchema } from './schema';
 import { initGenerator } from '../init/init';
+import { warnStorybookExecutorScaffolding } from '../../utils/deprecation';
 
 import {
   addAngularStorybookTarget,
@@ -179,6 +180,7 @@ export async function configurationGeneratorInternal(
   let devDeps = {};
 
   if (!hasPlugin || schema.addExplicitTargets) {
+    warnStorybookExecutorScaffolding();
     if (schema.uiFramework === '@storybook/angular') {
       addAngularStorybookTarget(tree, schema.project, schema.interactionTests);
     } else {

--- a/packages/storybook/src/generators/configuration/configuration.ts
+++ b/packages/storybook/src/generators/configuration/configuration.ts
@@ -12,7 +12,7 @@ import { initGenerator as jsInitGenerator } from '@nx/js';
 
 import { StorybookConfigureSchema } from './schema';
 import { initGenerator } from '../init/init';
-import { warnStorybookExecutorScaffolding } from '../../utils/deprecation';
+import { warnStorybookExecutorGenerating } from '../../utils/deprecation';
 
 import {
   addAngularStorybookTarget,
@@ -180,7 +180,7 @@ export async function configurationGeneratorInternal(
   let devDeps = {};
 
   if (!hasPlugin || schema.addExplicitTargets) {
-    warnStorybookExecutorScaffolding();
+    warnStorybookExecutorGenerating();
     if (schema.uiFramework === '@storybook/angular') {
       addAngularStorybookTarget(tree, schema.project, schema.interactionTests);
     } else {

--- a/packages/storybook/src/utils/deprecation.ts
+++ b/packages/storybook/src/utils/deprecation.ts
@@ -1,0 +1,24 @@
+import { logger } from '@nx/devkit';
+
+// TODO(v24): Remove the @nx/storybook:storybook and @nx/storybook:build
+// executors. The inferred plugin (@nx/storybook/plugin) and the
+// convert-to-inferred generator stay supported.
+export const STORYBOOK_EXECUTOR_DEPRECATION_MESSAGE =
+  'The `@nx/storybook:storybook` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/storybook:convert-to-inferred` to migrate to the `@nx/storybook/plugin` inferred targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.';
+
+export const STORYBOOK_BUILD_EXECUTOR_DEPRECATION_MESSAGE =
+  'The `@nx/storybook:build` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/storybook:convert-to-inferred` to migrate to the `@nx/storybook/plugin` inferred targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.';
+
+export function warnStorybookExecutorDeprecation(): void {
+  logger.warn(STORYBOOK_EXECUTOR_DEPRECATION_MESSAGE);
+}
+
+export function warnStorybookBuildExecutorDeprecation(): void {
+  logger.warn(STORYBOOK_BUILD_EXECUTOR_DEPRECATION_MESSAGE);
+}
+
+export function warnStorybookExecutorScaffolding(): void {
+  logger.warn(
+    'Generating targets that use the deprecated `@nx/storybook:storybook` and `@nx/storybook:build` executors. These executors will be removed in Nx v24. Run `nx g @nx/storybook:convert-to-inferred` next to migrate these targets to the `@nx/storybook/plugin` inferred plugin and prevent future generators from emitting executor targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.'
+  );
+}

--- a/packages/storybook/src/utils/deprecation.ts
+++ b/packages/storybook/src/utils/deprecation.ts
@@ -17,7 +17,7 @@ export function warnStorybookBuildExecutorDeprecation(): void {
   logger.warn(STORYBOOK_BUILD_EXECUTOR_DEPRECATION_MESSAGE);
 }
 
-export function warnStorybookExecutorScaffolding(): void {
+export function warnStorybookExecutorGenerating(): void {
   logger.warn(
     'Generating targets that use the deprecated `@nx/storybook:storybook` and `@nx/storybook:build` executors. These executors will be removed in Nx v24. Run `nx g @nx/storybook:convert-to-inferred` next to migrate these targets to the `@nx/storybook/plugin` inferred plugin and prevent future generators from emitting executor targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.'
   );

--- a/packages/vite/src/executors/build/build.impl.ts
+++ b/packages/vite/src/executors/build/build.impl.ts
@@ -29,6 +29,7 @@ import {
   loadViteDynamicImport,
   validateTypes,
 } from '../../utils/executor-utils';
+import { warnViteBuildExecutorDeprecation } from '../../utils/deprecation';
 import { type Plugin } from 'vite';
 import { isUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 
@@ -36,6 +37,8 @@ export async function* viteBuildExecutor(
   options: Record<string, any> & ViteBuildExecutorOptions,
   context: ExecutorContext
 ) {
+  warnViteBuildExecutorDeprecation();
+
   process.env.VITE_CJS_IGNORE_WARNING = 'true';
   // Allows ESM to be required in CJS modules. Vite will be published as ESM in the future.
   const { mergeConfig, build, resolveConfig, createBuilder } =

--- a/packages/vite/src/executors/build/schema.json
+++ b/packages/vite/src/executors/build/schema.json
@@ -5,6 +5,7 @@
   "cli": "nx",
   "description": "Builds a Vite application for production.",
   "type": "object",
+  "x-deprecated": "The `@nx/vite:build` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/vite:convert-to-inferred` to migrate to the `@nx/vite/plugin` inferred plugin. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.",
   "presets": [
     {
       "name": "Default minimum setup",

--- a/packages/vite/src/executors/dev-server/dev-server.impl.ts
+++ b/packages/vite/src/executors/dev-server/dev-server.impl.ts
@@ -14,6 +14,7 @@ import {
   createBuildableTsConfig,
   loadViteDynamicImport,
 } from '../../utils/executor-utils';
+import { warnViteDevServerExecutorDeprecation } from '../../utils/deprecation';
 import { relative } from 'path';
 import { getBuildExtraArgs } from '../build/build.impl';
 
@@ -21,6 +22,8 @@ export async function* viteDevServerExecutor(
   options: ViteDevServerExecutorOptions,
   context: ExecutorContext
 ): AsyncGenerator<{ success: boolean; baseUrl: string }> {
+  warnViteDevServerExecutorDeprecation();
+
   process.env.VITE_CJS_IGNORE_WARNING = 'true';
   // Allows ESM to be required in CJS modules. Vite will be published as ESM in the future.
   const { mergeConfig, createServer, resolveConfig } =

--- a/packages/vite/src/executors/dev-server/schema.json
+++ b/packages/vite/src/executors/dev-server/schema.json
@@ -6,6 +6,7 @@
   "cli": "nx",
   "description": "Starts a dev server using Vite.",
   "type": "object",
+  "x-deprecated": "The `@nx/vite:dev-server` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/vite:convert-to-inferred` to migrate to the `@nx/vite/plugin` inferred plugin. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.",
   "presets": [
     {
       "name": "Default minimum setup",

--- a/packages/vite/src/executors/preview-server/preview-server.impl.ts
+++ b/packages/vite/src/executors/preview-server/preview-server.impl.ts
@@ -15,11 +15,14 @@ import { VitePreviewServerExecutorOptions } from './schema';
 import { relative } from 'path';
 import { getBuildExtraArgs } from '../build/build.impl';
 import { loadViteDynamicImport } from '../../utils/executor-utils';
+import { warnVitePreviewServerExecutorDeprecation } from '../../utils/deprecation';
 
 export async function* vitePreviewServerExecutor(
   options: VitePreviewServerExecutorOptions,
   context: ExecutorContext
 ) {
+  warnVitePreviewServerExecutorDeprecation();
+
   process.env.VITE_CJS_IGNORE_WARNING = 'true';
   // Allows ESM to be required in CJS modules. Vite will be published as ESM in the future.
   const { mergeConfig, preview, resolveConfig } = await loadViteDynamicImport();

--- a/packages/vite/src/executors/preview-server/schema.json
+++ b/packages/vite/src/executors/preview-server/schema.json
@@ -6,6 +6,7 @@
   "description": "Preview Server for Vite.",
   "continuous": true,
   "type": "object",
+  "x-deprecated": "The `@nx/vite:preview-server` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/vite:convert-to-inferred` to migrate to the `@nx/vite/plugin` inferred plugin. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.",
   "presets": [
     {
       "name": "Default minimum setup",

--- a/packages/vite/src/generators/configuration/configuration.ts
+++ b/packages/vite/src/generators/configuration/configuration.ts
@@ -24,7 +24,7 @@ import {
 import { join } from 'node:path/posix';
 import type { PackageJson } from 'nx/src/utils/package-json';
 import { ensureDependencies } from '../../utils/ensure-dependencies';
-import { warnViteExecutorScaffolding } from '../../utils/deprecation';
+import { warnViteExecutorGenerating } from '../../utils/deprecation';
 import {
   addBuildTarget,
   addPreviewTarget,
@@ -111,7 +111,7 @@ export async function viteConfigurationGeneratorInternal(
         (!projectAlreadyHasViteTargets.serve ||
           !projectAlreadyHasViteTargets.preview));
     if (willScaffoldExecutorTargets) {
-      warnViteExecutorScaffolding();
+      warnViteExecutorGenerating();
     }
 
     if (!projectAlreadyHasViteTargets.build) {

--- a/packages/vite/src/generators/configuration/configuration.ts
+++ b/packages/vite/src/generators/configuration/configuration.ts
@@ -24,6 +24,7 @@ import {
 import { join } from 'node:path/posix';
 import type { PackageJson } from 'nx/src/utils/package-json';
 import { ensureDependencies } from '../../utils/ensure-dependencies';
+import { warnViteExecutorScaffolding } from '../../utils/deprecation';
 import {
   addBuildTarget,
   addPreviewTarget,
@@ -104,6 +105,15 @@ export async function viteConfigurationGeneratorInternal(
   );
 
   if (!hasPlugin) {
+    const willScaffoldExecutorTargets =
+      !projectAlreadyHasViteTargets.build ||
+      (!schema.includeLib &&
+        (!projectAlreadyHasViteTargets.serve ||
+          !projectAlreadyHasViteTargets.preview));
+    if (willScaffoldExecutorTargets) {
+      warnViteExecutorScaffolding();
+    }
+
     if (!projectAlreadyHasViteTargets.build) {
       addBuildTarget(tree, schema, 'build');
     }

--- a/packages/vite/src/utils/deprecation.ts
+++ b/packages/vite/src/utils/deprecation.ts
@@ -31,6 +31,6 @@ export function warnVitePreviewServerExecutorDeprecation(): void {
 // rather than only when the user later runs the generated targets.
 export function warnViteExecutorScaffolding(): void {
   logger.warn(
-    'Scaffolding targets that use the deprecated `@nx/vite:build`, `@nx/vite:dev-server`, and `@nx/vite:preview-server` executors. These executors will be removed in Nx v24. Run `nx g @nx/vite:convert-to-inferred` after this scaffold to migrate the generated targets to the `@nx/vite/plugin` inferred plugin. To skip emitting executor targets entirely on future scaffolds, register `@nx/vite/plugin` in `nx.json` first (`nx add @nx/vite` or a manual plugin entry). See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.'
+    'Generating targets that use the deprecated `@nx/vite:build`, `@nx/vite:dev-server`, and `@nx/vite:preview-server` executors. These executors will be removed in Nx v24. Run `nx g @nx/vite:convert-to-inferred` next to migrate these targets to the `@nx/vite/plugin` inferred plugin and prevent future generators from emitting executor targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.'
   );
 }

--- a/packages/vite/src/utils/deprecation.ts
+++ b/packages/vite/src/utils/deprecation.ts
@@ -25,11 +25,11 @@ export function warnVitePreviewServerExecutorDeprecation(): void {
   logger.warn(VITE_PREVIEW_SERVER_EXECUTOR_DEPRECATION_MESSAGE);
 }
 
-// Fired when the @nx/vite:configuration generator is about to scaffold
+// Fired when the @nx/vite:configuration generator is about to generate
 // targets that use the deprecated executors — i.e. when @nx/vite/plugin
-// isn't registered in nx.json. Surfaces the deprecation at scaffold time
+// isn't registered in nx.json. Surfaces the deprecation at generation time
 // rather than only when the user later runs the generated targets.
-export function warnViteExecutorScaffolding(): void {
+export function warnViteExecutorGenerating(): void {
   logger.warn(
     'Generating targets that use the deprecated `@nx/vite:build`, `@nx/vite:dev-server`, and `@nx/vite:preview-server` executors. These executors will be removed in Nx v24. Run `nx g @nx/vite:convert-to-inferred` next to migrate these targets to the `@nx/vite/plugin` inferred plugin and prevent future generators from emitting executor targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.'
   );

--- a/packages/vite/src/utils/deprecation.ts
+++ b/packages/vite/src/utils/deprecation.ts
@@ -1,0 +1,36 @@
+import { logger } from '@nx/devkit';
+
+// TODO(v24): Remove the @nx/vite:build, @nx/vite:dev-server, and
+// @nx/vite:preview-server executors. The inferred plugin (@nx/vite/plugin)
+// and the convert-to-inferred generator stay supported. (`@nx/vite:test`
+// is being deprecated in a separate change for the test-runner batch.)
+export const VITE_BUILD_EXECUTOR_DEPRECATION_MESSAGE =
+  'The `@nx/vite:build` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/vite:convert-to-inferred` to migrate to the `@nx/vite/plugin` inferred targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.';
+
+export const VITE_DEV_SERVER_EXECUTOR_DEPRECATION_MESSAGE =
+  'The `@nx/vite:dev-server` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/vite:convert-to-inferred` to migrate to the `@nx/vite/plugin` inferred targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.';
+
+export const VITE_PREVIEW_SERVER_EXECUTOR_DEPRECATION_MESSAGE =
+  'The `@nx/vite:preview-server` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/vite:convert-to-inferred` to migrate to the `@nx/vite/plugin` inferred targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.';
+
+export function warnViteBuildExecutorDeprecation(): void {
+  logger.warn(VITE_BUILD_EXECUTOR_DEPRECATION_MESSAGE);
+}
+
+export function warnViteDevServerExecutorDeprecation(): void {
+  logger.warn(VITE_DEV_SERVER_EXECUTOR_DEPRECATION_MESSAGE);
+}
+
+export function warnVitePreviewServerExecutorDeprecation(): void {
+  logger.warn(VITE_PREVIEW_SERVER_EXECUTOR_DEPRECATION_MESSAGE);
+}
+
+// Fired when the @nx/vite:configuration generator is about to scaffold
+// targets that use the deprecated executors — i.e. when @nx/vite/plugin
+// isn't registered in nx.json. Surfaces the deprecation at scaffold time
+// rather than only when the user later runs the generated targets.
+export function warnViteExecutorScaffolding(): void {
+  logger.warn(
+    'Scaffolding targets that use the deprecated `@nx/vite:build`, `@nx/vite:dev-server`, and `@nx/vite:preview-server` executors. These executors will be removed in Nx v24. Run `nx g @nx/vite:convert-to-inferred` after this scaffold to migrate the generated targets to the `@nx/vite/plugin` inferred plugin. To skip emitting executor targets entirely on future scaffolds, register `@nx/vite/plugin` in `nx.json` first (`nx add @nx/vite` or a manual plugin entry). See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.'
+  );
+}

--- a/packages/vitest/src/executors/test/schema.json
+++ b/packages/vitest/src/executors/test/schema.json
@@ -5,6 +5,7 @@
   "title": "Vitest executor",
   "description": "Test using Vitest.",
   "type": "object",
+  "x-deprecated": "The `@nx/vitest:test` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/vitest:convert-to-inferred` to migrate to the `@nx/vitest/plugin` inferred plugin. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.",
   "properties": {
     "configFile": {
       "type": "string",

--- a/packages/vitest/src/executors/test/vitest.impl.ts
+++ b/packages/vitest/src/executors/test/vitest.impl.ts
@@ -5,11 +5,14 @@ import { registerTsConfigPaths } from '@nx/js/src/internal';
 import { NxReporter } from './lib/nx-reporter';
 import { getOptions } from './lib/utils';
 import { loadVitestDynamicImport } from '../../utils/executor-utils';
+import { warnVitestTestExecutorDeprecation } from '../../utils/deprecation';
 
 export async function* vitestExecutor(
   options: VitestExecutorOptions,
   context: ExecutorContext
 ) {
+  warnVitestTestExecutorDeprecation();
+
   const projectRoot =
     context.projectsConfigurations.projects[context.projectName].root;
 

--- a/packages/vitest/src/utils/deprecation.ts
+++ b/packages/vitest/src/utils/deprecation.ts
@@ -9,12 +9,12 @@ export function warnVitestTestExecutorDeprecation(): void {
   logger.warn(VITEST_TEST_EXECUTOR_DEPRECATION_MESSAGE);
 }
 
-// Fired when the @nx/vitest:configuration generator is about to scaffold a
+// Fired when the @nx/vitest:configuration generator is about to generate a
 // target that uses the deprecated executor — i.e. when @nx/vitest/plugin
-// isn't registered in nx.json. Surfaces the deprecation at scaffold time
+// isn't registered in nx.json. Surfaces the deprecation at generation time
 // rather than only when the user later runs the generated target.
-export function warnVitestExecutorScaffolding(): void {
+export function warnVitestExecutorGenerating(): void {
   logger.warn(
-    'Scaffolding a target that uses the deprecated `@nx/vitest:test` executor. This executor will be removed in Nx v24. Run `nx g @nx/vitest:convert-to-inferred` after this scaffold to migrate the generated target to the `@nx/vitest/plugin` inferred plugin. To skip emitting executor targets entirely on future scaffolds, register `@nx/vitest/plugin` in `nx.json` first (`nx add @nx/vitest` or a manual plugin entry). See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.'
+    'Generating a target that uses the deprecated `@nx/vitest:test` executor. This executor will be removed in Nx v24. Run `nx g @nx/vitest:convert-to-inferred` next to migrate this target to the `@nx/vitest/plugin` inferred plugin and prevent future generators from emitting executor targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.'
   );
 }

--- a/packages/vitest/src/utils/deprecation.ts
+++ b/packages/vitest/src/utils/deprecation.ts
@@ -1,0 +1,20 @@
+import { logger } from '@nx/devkit';
+
+// TODO(v24): Remove the @nx/vitest:test executor. The inferred plugin
+// (@nx/vitest/plugin) and the convert-to-inferred generator stay supported.
+export const VITEST_TEST_EXECUTOR_DEPRECATION_MESSAGE =
+  'The `@nx/vitest:test` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/vitest:convert-to-inferred` to migrate to the `@nx/vitest/plugin` inferred targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.';
+
+export function warnVitestTestExecutorDeprecation(): void {
+  logger.warn(VITEST_TEST_EXECUTOR_DEPRECATION_MESSAGE);
+}
+
+// Fired when the @nx/vitest:configuration generator is about to scaffold a
+// target that uses the deprecated executor — i.e. when @nx/vitest/plugin
+// isn't registered in nx.json. Surfaces the deprecation at scaffold time
+// rather than only when the user later runs the generated target.
+export function warnVitestExecutorScaffolding(): void {
+  logger.warn(
+    'Scaffolding a target that uses the deprecated `@nx/vitest:test` executor. This executor will be removed in Nx v24. Run `nx g @nx/vitest:convert-to-inferred` after this scaffold to migrate the generated target to the `@nx/vitest/plugin` inferred plugin. To skip emitting executor targets entirely on future scaffolds, register `@nx/vitest/plugin` in `nx.json` first (`nx add @nx/vitest` or a manual plugin entry). See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.'
+  );
+}

--- a/packages/vitest/src/utils/generator-utils.ts
+++ b/packages/vitest/src/utils/generator-utils.ts
@@ -14,6 +14,7 @@ import {
 import { isUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { VitestExecutorOptions } from '../executors/test/schema';
 import { ensureViteConfigIsCorrect } from './vite-config-edit-utils';
+import { warnVitestExecutorScaffolding } from './deprecation';
 import { nxVersion } from './versions';
 
 export type Target = 'build' | 'serve' | 'test' | 'preview';
@@ -67,6 +68,7 @@ export function addOrChangeTestTarget(
   if (project.targets[target]) {
     throw new Error(`Target "${target}" already exists in the project.`);
   } else {
+    warnVitestExecutorScaffolding();
     project.targets[target] = {
       executor: '@nx/vitest:test',
       outputs: ['{options.reportsDirectory}'],

--- a/packages/vitest/src/utils/generator-utils.ts
+++ b/packages/vitest/src/utils/generator-utils.ts
@@ -14,7 +14,7 @@ import {
 import { isUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { VitestExecutorOptions } from '../executors/test/schema';
 import { ensureViteConfigIsCorrect } from './vite-config-edit-utils';
-import { warnVitestExecutorScaffolding } from './deprecation';
+import { warnVitestExecutorGenerating } from './deprecation';
 import { nxVersion } from './versions';
 
 export type Target = 'build' | 'serve' | 'test' | 'preview';
@@ -68,7 +68,7 @@ export function addOrChangeTestTarget(
   if (project.targets[target]) {
     throw new Error(`Target "${target}" already exists in the project.`);
   } else {
-    warnVitestExecutorScaffolding();
+    warnVitestExecutorGenerating();
     project.targets[target] = {
       executor: '@nx/vitest:test',
       outputs: ['{options.reportsDirectory}'],

--- a/packages/webpack/src/executors/dev-server/dev-server.impl.ts
+++ b/packages/webpack/src/executors/dev-server/dev-server.impl.ts
@@ -16,6 +16,7 @@ import {
 } from '@nx/js/src/utils/buildable-libs-utils';
 import { runWebpackDevServer } from '../../utils/run-webpack';
 import { resolveUserDefinedWebpackConfig } from '../../utils/webpack/resolve-user-defined-webpack-config';
+import { warnWebpackDevServerExecutorDeprecation } from '../../utils/deprecation';
 import { normalizeOptions } from '../webpack/lib/normalize-options';
 import { WebpackExecutorOptions } from '../webpack/schema';
 import { WebDevServerOptions } from './schema';
@@ -26,6 +27,8 @@ export async function* devServerExecutor(
   serveOptions: WebDevServerOptions,
   context: ExecutorContext
 ) {
+  warnWebpackDevServerExecutorDeprecation();
+
   // Default to dev mode so builds are faster and HMR mode works better.
   (process.env as any).NODE_ENV ??= 'development';
 

--- a/packages/webpack/src/executors/dev-server/schema.json
+++ b/packages/webpack/src/executors/dev-server/schema.json
@@ -6,6 +6,7 @@
   "description": "Serve an application using webpack.",
   "cli": "nx",
   "type": "object",
+  "x-deprecated": "The `@nx/webpack:dev-server` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/webpack:convert-to-inferred` to migrate to the `@nx/webpack/plugin` inferred plugin. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.",
   "properties": {
     "buildTarget": {
       "type": "string",

--- a/packages/webpack/src/executors/webpack/schema.json
+++ b/packages/webpack/src/executors/webpack/schema.json
@@ -5,6 +5,7 @@
   "description": "Build a project using webpack.",
   "cli": "nx",
   "type": "object",
+  "x-deprecated": "The `@nx/webpack:webpack` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/webpack:convert-to-inferred` to migrate to the `@nx/webpack/plugin` inferred plugin. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.",
   "properties": {
     "crossOrigin": {
       "type": "string",

--- a/packages/webpack/src/executors/webpack/webpack.impl.ts
+++ b/packages/webpack/src/executors/webpack/webpack.impl.ts
@@ -19,6 +19,7 @@ import {
 import type { Configuration, Stats } from 'webpack';
 import { isNxWebpackComposablePlugin } from '../../utils/config';
 import { resolveUserDefinedWebpackConfig } from '../../utils/webpack/resolve-user-defined-webpack-config';
+import { warnWebpackExecutorDeprecation } from '../../utils/deprecation';
 import { normalizeOptions } from './lib/normalize-options';
 import { runWebpack } from './lib/run-webpack';
 import type {
@@ -85,6 +86,8 @@ export async function* webpackExecutor(
   _options: WebpackExecutorOptions,
   context: ExecutorContext
 ): AsyncGenerator<WebpackExecutorEvent, WebpackExecutorEvent, undefined> {
+  warnWebpackExecutorDeprecation();
+
   // Default to production build.
   process.env['NODE_ENV'] ||= 'production';
 

--- a/packages/webpack/src/generators/configuration/configuration.ts
+++ b/packages/webpack/src/generators/configuration/configuration.ts
@@ -16,6 +16,7 @@ import { webpackInitGenerator } from '../init/init';
 import { ConfigurationGeneratorSchema } from './schema';
 import { WebpackExecutorOptions } from '../../executors/webpack/schema';
 import { hasPlugin } from '../../utils/has-plugin';
+import { warnWebpackExecutorScaffolding } from '../../utils/deprecation';
 import { TS_SOLUTION_SETUP_TSCONFIG_INPUT } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { ensureDependencies } from '../../utils/ensure-dependencies';
 
@@ -51,6 +52,7 @@ export async function configurationGeneratorInternal(
   checkForTargetConflicts(tree, options);
 
   if (!hasPlugin(tree)) {
+    warnWebpackExecutorScaffolding();
     addBuildTarget(tree, options);
     if (options.devServer) {
       addServeTarget(tree, options);

--- a/packages/webpack/src/generators/configuration/configuration.ts
+++ b/packages/webpack/src/generators/configuration/configuration.ts
@@ -16,7 +16,7 @@ import { webpackInitGenerator } from '../init/init';
 import { ConfigurationGeneratorSchema } from './schema';
 import { WebpackExecutorOptions } from '../../executors/webpack/schema';
 import { hasPlugin } from '../../utils/has-plugin';
-import { warnWebpackExecutorScaffolding } from '../../utils/deprecation';
+import { warnWebpackExecutorGenerating } from '../../utils/deprecation';
 import { TS_SOLUTION_SETUP_TSCONFIG_INPUT } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { ensureDependencies } from '../../utils/ensure-dependencies';
 
@@ -52,7 +52,7 @@ export async function configurationGeneratorInternal(
   checkForTargetConflicts(tree, options);
 
   if (!hasPlugin(tree)) {
-    warnWebpackExecutorScaffolding();
+    warnWebpackExecutorGenerating();
     addBuildTarget(tree, options);
     if (options.devServer) {
       addServeTarget(tree, options);

--- a/packages/webpack/src/utils/deprecation.ts
+++ b/packages/webpack/src/utils/deprecation.ts
@@ -17,11 +17,11 @@ export function warnWebpackDevServerExecutorDeprecation(): void {
   logger.warn(WEBPACK_DEV_SERVER_EXECUTOR_DEPRECATION_MESSAGE);
 }
 
-// Fired when the @nx/webpack:configuration generator is about to scaffold
+// Fired when the @nx/webpack:configuration generator is about to generate
 // targets that use the deprecated executors — i.e. when @nx/webpack/plugin
-// isn't registered in nx.json. Surfaces the deprecation at scaffold time
+// isn't registered in nx.json. Surfaces the deprecation at generation time
 // rather than only when the user later runs the generated targets.
-export function warnWebpackExecutorScaffolding(): void {
+export function warnWebpackExecutorGenerating(): void {
   logger.warn(
     'Generating targets that use the deprecated `@nx/webpack:webpack` and `@nx/webpack:dev-server` executors. These executors will be removed in Nx v24. Run `nx g @nx/webpack:convert-to-inferred` next to migrate these targets to the `@nx/webpack/plugin` inferred plugin and prevent future generators from emitting executor targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.'
   );

--- a/packages/webpack/src/utils/deprecation.ts
+++ b/packages/webpack/src/utils/deprecation.ts
@@ -23,6 +23,6 @@ export function warnWebpackDevServerExecutorDeprecation(): void {
 // rather than only when the user later runs the generated targets.
 export function warnWebpackExecutorScaffolding(): void {
   logger.warn(
-    'Scaffolding targets that use the deprecated `@nx/webpack:webpack` and `@nx/webpack:dev-server` executors. These executors will be removed in Nx v24. Run `nx g @nx/webpack:convert-to-inferred` after this scaffold to migrate the generated targets to the `@nx/webpack/plugin` inferred plugin. To skip emitting executor targets entirely on future scaffolds, register `@nx/webpack/plugin` in `nx.json` first (`nx add @nx/webpack` or a manual plugin entry). See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.'
+    'Generating targets that use the deprecated `@nx/webpack:webpack` and `@nx/webpack:dev-server` executors. These executors will be removed in Nx v24. Run `nx g @nx/webpack:convert-to-inferred` next to migrate these targets to the `@nx/webpack/plugin` inferred plugin and prevent future generators from emitting executor targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.'
   );
 }

--- a/packages/webpack/src/utils/deprecation.ts
+++ b/packages/webpack/src/utils/deprecation.ts
@@ -1,0 +1,28 @@
+import { logger } from '@nx/devkit';
+
+// TODO(v24): Remove the @nx/webpack:webpack and @nx/webpack:dev-server
+// executors. The inferred plugin (@nx/webpack/plugin) and the
+// convert-to-inferred generator stay supported.
+export const WEBPACK_EXECUTOR_DEPRECATION_MESSAGE =
+  'The `@nx/webpack:webpack` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/webpack:convert-to-inferred` to migrate to the `@nx/webpack/plugin` inferred targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.';
+
+export const WEBPACK_DEV_SERVER_EXECUTOR_DEPRECATION_MESSAGE =
+  'The `@nx/webpack:dev-server` executor is deprecated and will be removed in Nx v24. Run `nx g @nx/webpack:convert-to-inferred` to migrate to the `@nx/webpack/plugin` inferred targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.';
+
+export function warnWebpackExecutorDeprecation(): void {
+  logger.warn(WEBPACK_EXECUTOR_DEPRECATION_MESSAGE);
+}
+
+export function warnWebpackDevServerExecutorDeprecation(): void {
+  logger.warn(WEBPACK_DEV_SERVER_EXECUTOR_DEPRECATION_MESSAGE);
+}
+
+// Fired when the @nx/webpack:configuration generator is about to scaffold
+// targets that use the deprecated executors — i.e. when @nx/webpack/plugin
+// isn't registered in nx.json. Surfaces the deprecation at scaffold time
+// rather than only when the user later runs the generated targets.
+export function warnWebpackExecutorScaffolding(): void {
+  logger.warn(
+    'Scaffolding targets that use the deprecated `@nx/webpack:webpack` and `@nx/webpack:dev-server` executors. These executors will be removed in Nx v24. Run `nx g @nx/webpack:convert-to-inferred` after this scaffold to migrate the generated targets to the `@nx/webpack/plugin` inferred plugin. To skip emitting executor targets entirely on future scaffolds, register `@nx/webpack/plugin` in `nx.json` first (`nx add @nx/webpack` or a manual plugin entry). See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.'
+  );
+}


### PR DESCRIPTION
## Current Behavior

Most Nx executors that have an inferred-plugin alternative (`@nx/<pkg>/plugin`) and a `convert-to-inferred` generator are still wired up like first-class citizens. There is no signal — at scaffold time, schema browsing, or task execution — that they are on a path to removal, and the existing `cypress`/`detox` deprecation messages are inconsistent with the canonical pattern shipped most recently.

## Expected Behavior

Every executor that has an inferred-plugin migration target is now deprecated through three surfaces, matching the canonical pattern:

- **Runtime warning.** The executor logs that it is deprecated, will be removed in Nx v24, and points at `nx g @nx/<pkg>:convert-to-inferred`.
- **Schema-root `x-deprecated`.** Surfaces in editor / Nx Console / `nx show project` views.
- **Generation-time warning.** When a generator is about to scaffold a target that uses one of these executors because the corresponding inferred plugin isn't registered, it warns at generation time and points at the same migration path.

All warnings link to <https://nx.dev/docs/guides/tasks--caching/convert-to-inferred>.

### Executors deprecated in this PR

| Package | Executors |
|---|---|
| `@nx/webpack` | `webpack`, `dev-server` |
| `@nx/vite` | `build`, `dev-server`, `preview-server` |
| `@nx/rollup` | `rollup` |
| `@nx/next` | `build`, `server` |
| `@nx/remix` | `build`, `serve` |
| `@nx/jest` | `jest` |
| `@nx/playwright` | `playwright` |
| `@nx/eslint` | `lint` |
| `@nx/storybook` | `storybook`, `build` |
| `@nx/rspack` | `rspack`, `dev-server` |
| `@nx/expo` | `build`, `export`, `install`, `prebuild`, `run`, `serve`, `start`, `submit` |
| `@nx/react-native` | `build-android`, `build-ios`, `bundle`, `pod-install`, `run-android`, `run-ios`, `start`, `upgrade` |
| `@nx/vitest` | `test` |

### Generation-time warnings wired in

- `@nx/<pkg>:configuration` for webpack, vite, rollup, jest, playwright, storybook, rspack, vitest
- `@nx/<pkg>:application` for next, expo, react-native
- `@nx/eslint:lint-project` legacy fallback path
- `@nx/react:application` (webpack, rspack branches) and `@nx/react:library` (rollup legacy fallback) — warning text is inlined rather than imported. Two distinct reasons:
  - **rspack:** `@nx/react` does not declare a tsconfig project reference to `@nx/rspack`, so the deep import would not even type-check.
  - **webpack and rollup:** the project reference exists, so the deep import compiles, but `@nx/webpack` and `@nx/rollup` only expose `./index.js` in their package `exports` field. The import would resolve in source but throw `Cannot find module '@nx/<pkg>/src/utils/deprecation'` at runtime in published packages.
- `@nx/react-native:web-configuration` (webpack) — inline for the same reason as the rspack case (no project reference).

### Scope notes

- `@nx/vite:test` is intentionally **not** included — it is being removed entirely by PR #35517 (deprecation messaging would ship as dead code). `@nx/vitest:test` is now in scope: the `convert-to-inferred` generator for `@nx/vitest` is in place, so the deprecation has a real migration target.
- `@nx/cypress`/`@nx/detox` already shipped earlier; this PR retitles their generation-time messages to the new wording (drop the redundant "register the plugin first" guidance, swap "Scaffolding" for "Generating") and points the detox URL at the general convert-to-inferred guide.
- `@nx/react-native:storybook` is intentionally **not** included. The companion `@nx/react-native:storybook-configuration` generator was already removed in v21 and no generator has emitted this target since Jan 2024 (RN 0.73 upgrade). It will be removed outright in a follow-up PR rather than going through the deprecate-now / remove-in-v24 cycle.
- `@nx/webpack:ssr-dev-server`, `@nx/expo:build-list`, `@nx/expo:sync-deps`, `@nx/expo:update`, `@nx/expo:ensure-symlink`, `@nx/react-native:sync-deps`, and `@nx/react-native:ensure-symlink` are intentionally left as-is — none are covered by `convert-to-inferred` and they have no clean replacement (Nx-specific glue or non-migrating utilities).
- `@nx/esbuild:esbuild` and `@nx/nuxt:*` ship neither an inferred plugin nor a `convert-to-inferred` generator yet, so they're out of scope.
- Per-package READMEs, introduction-doc banners, per-package "migration recipe" pages, and `migrations.json` entries are intentionally skipped per the canonical pattern (NXC-4422). The runtime warning carries the migration story.

## Related Issue(s)

Fixes NXC-4423.
Fixes NXC-4296.
Fixes NXC-4294.
Fixes NXC-4290.
Fixes NXC-4285.
Fixes NXC-4283.
Fixes NXC-4286.
Fixes NXC-4297.
Fixes NXC-4293.
Fixes NXC-4292.
Fixes NXC-4282.
Fixes NXC-4287.
Fixes NXC-4295.
Fixes NXC-4447.
