### PR TITLE
chore(repo): update pnpm lockfile for @phenomnomnominal/tsquery 6.2.0

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3637,7 +3637,7 @@ importers:
         version: link:../js
       '@phenomnomnominal/tsquery':
         specifier: catalog:typescript
-        version: 6.1.4(typescript@5.9.2)
+        version: 6.2.0(typescript@5.9.2)
       '@rollup/plugin-babel':
         specifier: ^6.0.4
         version: 6.0.4(@babel/core@7.29.0)(@types/babel__core@7.20.5)(rollup@4.44.2)


### PR DESCRIPTION
## Current Behavior

The pnpm lockfile still resolves `@phenomnomnominal/tsquery` to `6.1.4` for the rollup importer, even though the catalog was bumped to `~6.2.0` in #35560.

## Expected Behavior

The lockfile resolves `@phenomnomnominal/tsquery` to `6.2.0`, matching the catalog entry.

## Related Issue(s)

N/A