### PR TITLE
fix(core): isolate NX_PARALLEL env var in parallel-related specs

### DIFF
--- a/packages/nx/src/command-line/yargs-utils/shared-options.spec.ts
+++ b/packages/nx/src/command-line/yargs-utils/shared-options.spec.ts
@@ -335,6 +335,17 @@ describe('shared-options', () => {
 });
 
 describe('readParallelFromArgsAndEnv', () => {
+  let originalParallel: string;
+
+  beforeEach(() => {
+    originalParallel = process.env.NX_PARALLEL;
+    delete process.env.NX_PARALLEL;
+  });
+
+  afterEach(() => {
+    process.env.NX_PARALLEL = originalParallel;
+  });
+
   it('default parallel should be 3', () => {
     const result = readParallelFromArgsAndEnv({ parallel: 'true' });
     expect(result).toEqual(3);

--- a/packages/nx/src/command-line/yargs-utils/shared-options.spec.ts
+++ b/packages/nx/src/command-line/yargs-utils/shared-options.spec.ts
@@ -343,7 +343,11 @@ describe('readParallelFromArgsAndEnv', () => {
   });
 
   afterEach(() => {
-    process.env.NX_PARALLEL = originalParallel;
+    if (originalParallel === undefined) {
+      delete process.env.NX_PARALLEL;
+    } else {
+      process.env.NX_PARALLEL = originalParallel;
+    }
   });
 
   it('default parallel should be 3', () => {

--- a/packages/nx/src/utils/command-line-utils.spec.ts
+++ b/packages/nx/src/utils/command-line-utils.spec.ts
@@ -6,18 +6,22 @@ jest.mock('../project-graph/file-utils');
 describe('splitArgs', () => {
   let originalBase: string;
   let originalHead: string;
+  let originalParallel: string;
 
   beforeEach(() => {
     originalBase = process.env.NX_BASE;
     originalHead = process.env.NX_HEAD;
+    originalParallel = process.env.NX_PARALLEL;
 
     delete process.env.NX_BASE;
     delete process.env.NX_HEAD;
+    delete process.env.NX_PARALLEL;
   });
 
   afterEach(() => {
     process.env.NX_BASE = originalBase;
     process.env.NX_HEAD = originalHead;
+    process.env.NX_PARALLEL = originalParallel;
   });
 
   it('should split nx specific arguments into nxArgs', () => {

--- a/packages/nx/src/utils/command-line-utils.spec.ts
+++ b/packages/nx/src/utils/command-line-utils.spec.ts
@@ -21,7 +21,11 @@ describe('splitArgs', () => {
   afterEach(() => {
     process.env.NX_BASE = originalBase;
     process.env.NX_HEAD = originalHead;
-    process.env.NX_PARALLEL = originalParallel;
+    if (originalParallel === undefined) {
+      delete process.env.NX_PARALLEL;
+    } else {
+      process.env.NX_PARALLEL = originalParallel;
+    }
   });
 
   it('should split nx specific arguments into nxArgs', () => {


### PR DESCRIPTION
## Current Behavior

`readParallelFromArgsAndEnv` reads `process.env.NX_PARALLEL` as a fallback before the hardcoded `'3'` default. When developers set `NX_PARALLEL` in their workspace `.env` (or shell), that value bleeds into the test suite and breaks several specs that assume the default is `3`:

- `packages/nx/src/utils/command-line-utils.spec.ts` — multiple `splitArgs` cases plus the `--parallel` defaults.
- `packages/nx/src/command-line/yargs-utils/shared-options.spec.ts` — `default parallel should be 3`.

CI doesn't set `NX_PARALLEL`, so the failures only show up locally.

## Expected Behavior

The specs should pass regardless of whether `NX_PARALLEL` is set in the surrounding environment.

Both spec files now save/clear/restore `process.env.NX_PARALLEL` in their relevant `beforeEach`/`afterEach`, mirroring the pattern already used for `NX_BASE` and `NX_HEAD`.

## Related Issue(s)

N/A