### PR TITLE
fix(js): trust exit code for pnpm >= 11 in release-publish executor

### DIFF
--- a/packages/js/src/executors/release-publish/release-publish.impl.spec.ts
+++ b/packages/js/src/executors/release-publish/release-publish.impl.spec.ts
@@ -2,6 +2,7 @@ import {
   ExecutorContext,
   readJsonFile,
   detectPackageManager,
+  getPackageManagerVersion,
 } from '@nx/devkit';
 import { execSync } from 'child_process';
 import { PublishExecutorSchema } from './schema';
@@ -18,6 +19,7 @@ jest.mock('../../utils/npm-config');
 jest.mock('@nx/devkit', () => ({
   ...jest.requireActual('@nx/devkit'),
   detectPackageManager: jest.fn(() => 'npm'),
+  getPackageManagerVersion: jest.fn(() => '10.0.0'),
   readJsonFile: jest.fn(),
 }));
 jest.mock('./extract-npm-publish-json-data');
@@ -30,6 +32,10 @@ describe('release-publish executor', () => {
   const mockDetectPackageManager = detectPackageManager as jest.MockedFunction<
     typeof detectPackageManager
   >;
+  const mockGetPackageManagerVersion =
+    getPackageManagerVersion as jest.MockedFunction<
+      typeof getPackageManagerVersion
+    >;
   const mockParseRegistryOptions =
     npmConfigModule.parseRegistryOptions as jest.MockedFunction<
       typeof npmConfigModule.parseRegistryOptions
@@ -291,6 +297,129 @@ describe('release-publish executor', () => {
       expect(console.error).toHaveBeenCalledWith(
         expect.stringContaining('"pnpm"')
       );
+    });
+  });
+
+  describe('pnpm 11 publish handling', () => {
+    // pnpm 11 reimplemented `pnpm publish` natively (PR pnpm/pnpm#10591) and `pnpm publish --json`
+    // now writes nothing to stdout on success, breaking `extractNpmPublishJsonData`. Tracked at
+    // pnpm/pnpm#11476. The executor short-circuits on pm==='pnpm' && major>=11 to trust the exit
+    // code instead of parsing stdout.
+    it('should treat exit code 0 as success on pnpm 11 even when stdout is empty', async () => {
+      mockDetectPackageManager.mockReturnValue('pnpm');
+      mockGetPackageManagerVersion.mockReturnValue('11.0.4');
+      mockExecSync.mockReset();
+
+      mockExecSync
+        .mockReturnValueOnce('11.5.1' as any) // npm --version
+        .mockReturnValueOnce(
+          Buffer.from(
+            JSON.stringify({
+              versions: ['0.9.0'],
+              'dist-tags': { latest: '0.9.0' },
+            })
+          )
+        ) // pnpm view
+        .mockReturnValueOnce(Buffer.from('') as any); // pnpm publish (empty stdout)
+
+      const extractSpy = jest.spyOn(extractModule, 'extractNpmPublishJsonData');
+
+      const result = await runExecutor(options, context);
+
+      expect(result.success).toBe(true);
+      // The pnpm 11 short-circuit must not invoke the JSON extraction path (which would otherwise
+      // fail on empty stdout and return success: false).
+      expect(extractSpy).not.toHaveBeenCalled();
+      expect(console.error).not.toHaveBeenCalledWith(
+        expect.stringContaining('could not be extracted')
+      );
+      expect(console.log).toHaveBeenCalledWith(
+        expect.stringContaining('Published to')
+      );
+    });
+
+    it('should fall through to JSON extraction on pnpm 10 (preserves legacy npm-CLI delegated output)', async () => {
+      mockDetectPackageManager.mockReturnValue('pnpm');
+      mockGetPackageManagerVersion.mockReturnValue('10.18.3');
+      mockExecSync.mockReset();
+
+      mockExecSync
+        .mockReturnValueOnce('11.5.1' as any) // npm --version
+        .mockReturnValueOnce(
+          Buffer.from(
+            JSON.stringify({
+              versions: ['0.9.0'],
+              'dist-tags': { latest: '0.9.0' },
+            })
+          )
+        ) // pnpm view
+        .mockReturnValueOnce(Buffer.from('{...}') as any); // pnpm publish
+
+      jest.spyOn(extractModule, 'extractNpmPublishJsonData').mockReturnValue({
+        beforeJsonData: '',
+        jsonData: {
+          id: '@scope/test-package@1.0.0',
+          name: '@scope/test-package',
+          version: '1.0.0',
+          size: 100,
+          unpackedSize: 200,
+          shasum: 'abc123',
+          integrity: 'sha512-abc',
+          filename: 'test-package-1.0.0.tgz',
+          files: [],
+          entryCount: 1,
+          bundled: [],
+        },
+        afterJsonData: '',
+      } as any);
+
+      const result = await runExecutor(options, context);
+
+      expect(result.success).toBe(true);
+      expect(extractModule.extractNpmPublishJsonData).toHaveBeenCalled();
+    });
+
+    it('should fall through to JSON extraction when pnpm version cannot be determined', async () => {
+      mockDetectPackageManager.mockReturnValue('pnpm');
+      mockGetPackageManagerVersion.mockImplementation(() => {
+        throw new Error('Cannot determine the version of pnpm.');
+      });
+      mockExecSync.mockReset();
+
+      mockExecSync
+        .mockReturnValueOnce('11.5.1' as any) // npm --version
+        .mockReturnValueOnce(
+          Buffer.from(
+            JSON.stringify({
+              versions: ['0.9.0'],
+              'dist-tags': { latest: '0.9.0' },
+            })
+          )
+        ) // pnpm view
+        .mockReturnValueOnce(Buffer.from('{...}') as any); // pnpm publish
+
+      jest.spyOn(extractModule, 'extractNpmPublishJsonData').mockReturnValue({
+        beforeJsonData: '',
+        jsonData: {
+          id: '@scope/test-package@1.0.0',
+          name: '@scope/test-package',
+          version: '1.0.0',
+          size: 100,
+          unpackedSize: 200,
+          shasum: 'abc123',
+          integrity: 'sha512-abc',
+          filename: 'test-package-1.0.0.tgz',
+          files: [],
+          entryCount: 1,
+          bundled: [],
+        },
+        afterJsonData: '',
+      } as any);
+
+      const result = await runExecutor(options, context);
+
+      expect(result.success).toBe(true);
+      expect(extractModule.extractNpmPublishJsonData).toHaveBeenCalled();
     });
   });
 });

--- a/packages/js/src/executors/release-publish/release-publish.impl.ts
+++ b/packages/js/src/executors/release-publish/release-publish.impl.ts
@@ -1,9 +1,11 @@
 import {
   detectPackageManager,
   getPackageManagerCommand,
+  getPackageManagerVersion,
   ExecutorContext,
   readJsonFile,
 } from '@nx/devkit';
+import { major } from 'semver';
 import { execSync } from 'child_process';
 import { env as appendLocalEnv } from 'npm-run-path';
 import { join } from 'path';
@@ -396,6 +398,40 @@ Please update the local dependency on "${depName}" to be a valid semantic versio
       return {
         success: true,
       };
+    }
+
+    /**
+     * pnpm 11+ rewrote `pnpm publish` natively (it no longer delegates to the npm CLI; see
+     * https://pnpm.io/blog/releases/11.0#native-publish-flow-no-more-npm-cli-fallback). The new
+     * implementation accepts `--json` but writes nothing to stdout on success — the publish handler
+     * returns `undefined` and `--json` only suppresses the human-readable reporter. As a result,
+     * `extractNpmPublishJsonData` below would always return `{ jsonData: null }` and incorrectly
+     * report a successful publish as failed (silently breaking releases — tarballs reach the
+     * registry, but Nx marks the task failed and `--nx-bail=true` skips remaining packages).
+     *
+     * Until pnpm restores `--json` stdout output (tracked at
+     * https://github.com/pnpm/pnpm/issues/11476), trust the exit code: execSync above already throws
+     * on non-zero exit, so reaching this point with pnpm >= 11 means the publish succeeded.
+     *
+     * This intentionally drops the verbose `=== Tarball Details ===` table for pnpm >= 11 in favor of
+     * a minimal summary line, mirroring the existing `pm === 'bun'` branch above. Once pnpm/pnpm#11476
+     * lands and ships, this branch becomes a no-op (the JSON extraction path will succeed again) and
+     * can be removed.
+     */
+    if (pm === 'pnpm') {
+      let pnpmMajor: number | null = null;
+      try {
+        pnpmMajor = major(getPackageManagerVersion('pnpm', context.root));
+      } catch {
+        // If we can't determine the pnpm version, fall through to JSON parsing.
+      }
+      if (pnpmMajor !== null && pnpmMajor >= 11) {
+        console.log(`📦 ${packageJson.name}@${packageJson.version}`);
+        console.log(publishSummaryMessage);
+        return {
+          success: true,
+        };
+      }
     }
 
     /**


### PR DESCRIPTION
## Current Behavior

`nx release publish` silently fails when the workspace uses **pnpm 11+**:

- pnpm 11 reimplemented `pnpm publish` natively (pnpm/pnpm#10591). It no longer delegates to the npm CLI.
- The new implementation accepts `--json` but writes **nothing to stdout on success** (the publish handler returns `undefined`; `--json` only suppresses the human-readable reporter).
- `release-publish.impl.ts` runs the publish command and parses stdout via `extractNpmPublishJsonData`. With empty stdout the extractor returns `{ jsonData: null }`, the executor logs "The pnpm publish output data could not be extracted" and returns `success: false`.
- Combined with the default `--nx-bail=true`, this aborts the rest of a release after the first parallel batch: tarballs reach the registry for the packages that were attempted, but Nx marks the task failed and skips the remaining packages. Releases look "passed" in CI but are partial.

Tracked at:
- pnpm/pnpm#11476 — `pnpm publish --json produces empty stdout in pnpm 11 (regression from pnpm 10)`
- nrwl/nx#35575 — Nx-side report

## Expected Behavior

When `pm === 'pnpm'` and the detected pnpm major version is `>= 11`, trust the exit code: `execSync` already throws on non-zero exit, so reaching this branch means the publish succeeded. Print a minimal summary line and return `{ success: true }`, matching the existing `pm === 'bun'` branch precedent (added in #34835).

This intentionally drops the verbose `=== Tarball Details ===` table for pnpm >= 11. Once pnpm restores `--json` stdout output (pnpm/pnpm#11476), the JSON extraction path will succeed again and this short-circuit becomes a no-op that can be removed.

The official pnpm-side workaround for users who need the npm-CLI semantics today is `pnpm pack && npm publish *.tgz` (documented in the changeset for pnpm/pnpm#10591).

## Verification of no duplicate PRs

Before opening, I searched open Nx PRs for `extract-npm-publish-json-data`, `release-publish.impl`, and `#35575` — no open PRs touch this code path.

## Related Issue(s)

Refs nrwl/nx#35575
Refs pnpm/pnpm#11476
Refs pnpm/pnpm#10591

🤖 Authored with assistance from Amp.
