### PR TITLE
fix(core): migrate Gemini CLI contextFileName to context.fileName

### DIFF
--- a/.gemini/settings.json
+++ b/.gemini/settings.json
@@ -6,5 +6,7 @@
       "args": ["nx", "mcp"]
     }
   },
-  "contextFileName": "AGENTS.md"
+  "context": {
+    "fileName": "AGENTS.md"
+  }
 }

--- a/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.spec.ts
+++ b/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.spec.ts
@@ -539,7 +539,7 @@ describe('setup-ai-agents generator', () => {
         });
       });
 
-      it('should NOT set contextFileName to AGENTS.md when GEMINI.md already exists', async () => {
+      it('should NOT set context.fileName to AGENTS.md when GEMINI.md already exists', async () => {
         const options: SetupAiAgentsGeneratorSchema = {
           directory: '.',
         };
@@ -571,8 +571,9 @@ describe('setup-ai-agents generator', () => {
         const config = JSON.parse(
           tree.read('.gemini/settings.json')?.toString() ?? '{}'
         );
-        // Should preserve the existing contextFileName
-        expect(config.contextFileName).toBe('GEMINI.md');
+        // Should migrate the existing contextFileName to the new structure
+        expect(config.context?.fileName).toBe('GEMINI.md');
+        expect(config.contextFileName).toBeUndefined();
         // Should still add nx-mcp server
         expect(config.mcpServers['nx-mcp']).toEqual({
           type: 'stdio',
@@ -581,7 +582,7 @@ describe('setup-ai-agents generator', () => {
         });
       });
 
-      it('should set contextFileName to AGENTS.md when GEMINI.md does NOT exist', async () => {
+      it('should set context.fileName to AGENTS.md when GEMINI.md does NOT exist', async () => {
         const options: SetupAiAgentsGeneratorSchema = {
           directory: '.',
         };
@@ -591,8 +592,8 @@ describe('setup-ai-agents generator', () => {
         const config = JSON.parse(
           tree.read('.gemini/settings.json')?.toString() ?? '{}'
         );
-        // Should set contextFileName to AGENTS.md when GEMINI.md doesn't exist
-        expect(config.contextFileName).toBe('AGENTS.md');
+        // Should set context.fileName to AGENTS.md when GEMINI.md doesn't exist
+        expect(config.context?.fileName).toBe('AGENTS.md');
         expect(config.mcpServers['nx-mcp']).toEqual({
           type: 'stdio',
           command: 'npx',
@@ -600,7 +601,7 @@ describe('setup-ai-agents generator', () => {
         });
       });
 
-      it('should respect existing contextFileName for rule generation', async () => {
+      it('should respect existing context.fileName for rule generation', async () => {
         const options: SetupAiAgentsGeneratorSchema = {
           directory: '.',
           agents: ['gemini'],
@@ -610,7 +611,9 @@ describe('setup-ai-agents generator', () => {
         tree.write(
           '.gemini/settings.json',
           JSON.stringify({
-            contextFileName: 'CUSTOM-GEMINI.md',
+            context: {
+              fileName: 'CUSTOM-GEMINI.md',
+            },
           })
         );
 
@@ -618,9 +621,80 @@ describe('setup-ai-agents generator', () => {
 
         const configAfter = readJson(tree, '.gemini/settings.json');
 
-        expect(configAfter.contextFileName).toBe('CUSTOM-GEMINI.md');
+        expect(configAfter.context?.fileName).toBe('CUSTOM-GEMINI.md');
         const content = tree.read('CUSTOM-GEMINI.md')?.toString();
         expect(content).toContain('Custom Gemini configuration');
+        expect(content).toContain('Nx');
+      });
+
+      it('should migrate contextFileName even if GEMINI.md does not exist', async () => {
+        const options: SetupAiAgentsGeneratorSchema = {
+          directory: '.',
+        };
+
+        tree.write(
+          '.gemini/settings.json',
+          JSON.stringify({
+            contextFileName: 'LEGACY.md',
+          })
+        );
+
+        await setupAiAgentsGenerator(tree, options);
+
+        const config = readJson(tree, '.gemini/settings.json');
+        expect(config.context?.fileName).toBe('LEGACY.md');
+        expect(config.contextFileName).toBeUndefined();
+        expect(tree.exists('LEGACY.md')).toBe(true);
+      });
+
+      it('should prefer nested context.fileName over legacy contextFileName during migration', async () => {
+        const options: SetupAiAgentsGeneratorSchema = {
+          directory: '.',
+        };
+
+        tree.write(
+          '.gemini/settings.json',
+          JSON.stringify({
+            contextFileName: 'OLD.md',
+            context: {
+              fileName: 'NEW.md',
+            },
+          })
+        );
+
+        await setupAiAgentsGenerator(tree, options);
+
+        const config = readJson(tree, '.gemini/settings.json');
+        expect(config.context?.fileName).toBe('NEW.md');
+        expect(config.contextFileName).toBeUndefined();
+      });
+
+      it('should handle context.fileName as string[] and pick the first one for rules', async () => {
+        const options: SetupAiAgentsGeneratorSchema = {
+          directory: '.',
+          agents: ['gemini'],
+        };
+
+        tree.write(
+          '.gemini/settings.json',
+          JSON.stringify({
+            context: {
+              fileName: ['PRIMARY.md', 'SECONDARY.md'],
+            },
+          })
+        );
+
+        await setupAiAgentsGenerator(tree, options);
+
+        const config = readJson(tree, '.gemini/settings.json');
+        expect(config.context?.fileName).toEqual([
+          'PRIMARY.md',
+          'SECONDARY.md',
+        ]);
+
+        // Rules should be written to the primary (first) file
+        expect(tree.exists('PRIMARY.md')).toBe(true);
+        const content = tree.read('PRIMARY.md')?.toString();
         expect(content).toContain('Nx');
       });
 

--- a/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.ts
+++ b/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.ts
@@ -237,27 +237,46 @@ export async function setupAiAgentsGeneratorImpl(
     updateJson(tree, geminiSettingsPath, (json) =>
       mcpConfigUpdater(json, nxVersion)
     );
-
-    const contextFileName: string | undefined = readJson(
-      tree,
-      geminiSettingsPath
-    ).contextFileName;
+    const geminiSettings = readJson(tree, geminiSettingsPath);
+    const contextFileName: string | string[] | undefined =
+      geminiSettings.context?.fileName ?? geminiSettings.contextFileName;
 
     const geminiMd = geminiMdPath(options.directory);
 
-    // Only set contextFileName to AGENTS.md if GEMINI.md doesn't exist already to preserve existing setups
+    // Only set context.fileName to AGENTS.md if GEMINI.md doesn't exist already to preserve existing setups
     if (!contextFileName && !tree.exists(geminiMd)) {
       writeAgentRules(tree, agentsMd, options.writeNxCloudRules);
-      updateJson(tree, geminiSettingsPath, (json) => ({
-        ...json,
-        contextFileName: 'AGENTS.md',
-      }));
+      updateJson(tree, geminiSettingsPath, (json) => {
+        const { contextFileName, ...rest } = json;
+        return {
+          ...rest,
+          context: {
+            ...rest.context,
+            fileName: 'AGENTS.md',
+          },
+        };
+      });
     } else {
-      writeAgentRules(
-        tree,
-        contextFileName ?? geminiMd,
-        options.writeNxCloudRules
-      );
+      // Migrate legacy contextFileName to the new nested structure only if it exists
+      if (geminiSettings.contextFileName) {
+        updateJson(tree, geminiSettingsPath, (json) => {
+          const { contextFileName, ...rest } = json;
+          return {
+            ...rest,
+            context: {
+              ...rest.context,
+              // prefer already-set context.fileName over legacy key
+              fileName: rest.context?.fileName ?? contextFileName,
+            },
+          };
+        });
+      }
+
+      const primaryContextFile =
+        (Array.isArray(contextFileName)
+          ? contextFileName[0]
+          : contextFileName) ?? geminiMd;
+      writeAgentRules(tree, primaryContextFile, options.writeNxCloudRules);
     }
   }
 

--- a/packages/nx/src/ai/utils.ts
+++ b/packages/nx/src/ai/utils.ts
@@ -132,11 +132,18 @@ async function getAgentConfiguration(
       let mcpConfigured: boolean;
 
       const geminiSettings = parseGeminiSettings(workspaceRoot);
-      const customContextFilePath: string | undefined =
-        typeof geminiSettings?.contextFileName === 'string'
-          ? geminiSettings.contextFileName
-          : undefined;
+      const rawFileName =
+        geminiSettings?.context?.fileName ?? geminiSettings?.contextFileName;
 
+      const customContextFilePath: string | undefined = Array.isArray(
+        rawFileName
+      )
+        ? typeof rawFileName[0] === 'string'
+          ? rawFileName[0]
+          : undefined
+        : typeof rawFileName === 'string'
+          ? rawFileName
+          : undefined;
       const customContextFilePathExists = customContextFilePath
         ? existsSync(resolve(workspaceRoot, customContextFilePath))
         : false;


### PR DESCRIPTION
## Current Behavior

Gemini CLI `v0.3.0` and higher ([https://github.com/google-gemini/gemini-cli/pull/7244](https://github.com/google-gemini/gemini-cli/pull/7244) ) no longer supports the top-level `"contextFileName"` key in `.gemini/settings.json`. Workspaces using the `setup-ai-agents` generator or the Nx Gemini integration write and read `contextFileName` in the old flat format, which is silently ignored by newer Gemini versions, causing the context file to not be picked up at all.

Additionally, `context.fileName` can be a `string[]` in the new API, but the existing code only handled `string`, meaning multi-file configurations were not supported.

## Expected Behavior

- The `setup-ai-agents` generator writes context configuration using the new nested format:
```json
  "context": {
    "fileName": "AGENTS.md"
  }
```
- Any existing `contextFileName` key found in `.gemini/settings.json` is automatically migrated to `context.fileName` when the generator runs, without overwriting an already-set `context.fileName`.
- When `context.fileName` is a `string[]`, the first entry is used as the primary file for writing agent rules.
- `utils.ts` resolves the context file path by preferring `context.fileName` over the legacy `contextFileName`, with full support for both `string` and `string[]` values.
- The root `.gemini/settings.json` is updated to use the new format.

## Related Issue(s)

Fixes #