### PR TITLE
fix(core): isolate cache env vars in splitArgs spec

### DIFF
--- a/packages/nx/src/ai/clone-ai-config-repo.ts
+++ b/packages/nx/src/ai/clone-ai-config-repo.ts
@@ -133,17 +133,34 @@ export function getAiConfigRepoPath(): string {
   // 1. Get latest commit hash (first 10 chars)
   const commitHash = getLatestCommitHash();
 
-  // 2. Check if cached version exists
+  // 2. Reuse cached version if it still has content (macOS may have
+  // swept its files but left the directory tree).
   const cachedPath = join(CACHE_DIR, commitHash);
-  if (existsSync(cachedPath)) {
+  if (hasRootFile(cachedPath)) {
     return cachedPath;
   }
 
-  // 3. Clone fresh
+  // 3. Wipe any empty skeleton, then clone fresh
+  if (existsSync(cachedPath)) {
+    rmSync(cachedPath, { recursive: true, force: true });
+  }
   cloneRepo(cachedPath);
 
   // 4. Clean up old cached versions
   cleanupOldCaches(commitHash);
 
   return cachedPath;
+}
+
+/**
+ * The repo always has at least one regular file at its root (e.g. README).
+ * If everything at the root is a directory, the cache was swept by macOS
+ * tmp cleanup and we should re-clone.
+ */
+function hasRootFile(dir: string): boolean {
+  try {
+    return readdirSync(dir, { withFileTypes: true }).some((e) => e.isFile());
+  } catch {
+    return false;
+  }
 }

--- a/packages/nx/src/native/watch/watcher.rs
+++ b/packages/nx/src/native/watch/watcher.rs
@@ -495,7 +495,9 @@ mod tests {
             }
         });
         w.watch_inner(callback).expect("start watch");
-        std::thread::sleep(Duration::from_millis(150));
+        // Drop any startup events FSEvents leaks from before the watch began.
+        std::thread::sleep(Duration::from_millis(300));
+        captured.lock().unwrap().clear();
         (w, captured)
     }
 

--- a/packages/nx/src/utils/command-line-utils.spec.ts
+++ b/packages/nx/src/utils/command-line-utils.spec.ts
@@ -4,49 +4,38 @@ import { withEnvironmentVariables as withEnvironment } from '../internal-testing
 jest.mock('../project-graph/file-utils');
 
 describe('splitArgs', () => {
-  let originalBase: string;
-  let originalHead: string;
-  let originalParallel: string;
-  let originalSkipNxCache: string;
-  let originalDisableNxCache: string;
-  let originalSkipRemoteCache: string;
-  let originalDisableRemoteCache: string;
+  const blockedEnvVars = [
+    'NX_BASE',
+    'NX_HEAD',
+    'NX_PARALLEL',
+    'NX_SKIP_NX_CACHE',
+    'NX_DISABLE_NX_CACHE',
+    'NX_SKIP_REMOTE_CACHE',
+    'NX_DISABLE_REMOTE_CACHE',
+  ];
+  let envVarsToRestore: Record<string, string | undefined> = {};
+
+  function blockParentEnvVar(key: string) {
+    envVarsToRestore[key] = process.env[key];
+    delete process.env[key];
+  }
 
   beforeEach(() => {
-    originalBase = process.env.NX_BASE;
-    originalHead = process.env.NX_HEAD;
-    originalParallel = process.env.NX_PARALLEL;
-    originalSkipNxCache = process.env.NX_SKIP_NX_CACHE;
-    originalDisableNxCache = process.env.NX_DISABLE_NX_CACHE;
-    originalSkipRemoteCache = process.env.NX_SKIP_REMOTE_CACHE;
-    originalDisableRemoteCache = process.env.NX_DISABLE_REMOTE_CACHE;
-
-    delete process.env.NX_BASE;
-    delete process.env.NX_HEAD;
-    delete process.env.NX_PARALLEL;
-    delete process.env.NX_SKIP_NX_CACHE;
-    delete process.env.NX_DISABLE_NX_CACHE;
-    delete process.env.NX_SKIP_REMOTE_CACHE;
-    delete process.env.NX_DISABLE_REMOTE_CACHE;
+    envVarsToRestore = {};
+    for (const key of blockedEnvVars) {
+      blockParentEnvVar(key);
+    }
   });
 
   afterEach(() => {
-    restoreEnv('NX_BASE', originalBase);
-    restoreEnv('NX_HEAD', originalHead);
-    restoreEnv('NX_PARALLEL', originalParallel);
-    restoreEnv('NX_SKIP_NX_CACHE', originalSkipNxCache);
-    restoreEnv('NX_DISABLE_NX_CACHE', originalDisableNxCache);
-    restoreEnv('NX_SKIP_REMOTE_CACHE', originalSkipRemoteCache);
-    restoreEnv('NX_DISABLE_REMOTE_CACHE', originalDisableRemoteCache);
-  });
-
-  function restoreEnv(key: string, value: string | undefined) {
-    if (value === undefined) {
-      delete process.env[key];
-    } else {
-      process.env[key] = value;
+    for (const [key, value] of Object.entries(envVarsToRestore)) {
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
     }
-  }
+  });
 
   it('should split nx specific arguments into nxArgs', () => {
     expect(

--- a/packages/nx/src/utils/command-line-utils.spec.ts
+++ b/packages/nx/src/utils/command-line-utils.spec.ts
@@ -7,26 +7,46 @@ describe('splitArgs', () => {
   let originalBase: string;
   let originalHead: string;
   let originalParallel: string;
+  let originalSkipNxCache: string;
+  let originalDisableNxCache: string;
+  let originalSkipRemoteCache: string;
+  let originalDisableRemoteCache: string;
 
   beforeEach(() => {
     originalBase = process.env.NX_BASE;
     originalHead = process.env.NX_HEAD;
     originalParallel = process.env.NX_PARALLEL;
+    originalSkipNxCache = process.env.NX_SKIP_NX_CACHE;
+    originalDisableNxCache = process.env.NX_DISABLE_NX_CACHE;
+    originalSkipRemoteCache = process.env.NX_SKIP_REMOTE_CACHE;
+    originalDisableRemoteCache = process.env.NX_DISABLE_REMOTE_CACHE;
 
     delete process.env.NX_BASE;
     delete process.env.NX_HEAD;
     delete process.env.NX_PARALLEL;
+    delete process.env.NX_SKIP_NX_CACHE;
+    delete process.env.NX_DISABLE_NX_CACHE;
+    delete process.env.NX_SKIP_REMOTE_CACHE;
+    delete process.env.NX_DISABLE_REMOTE_CACHE;
   });
 
   afterEach(() => {
-    process.env.NX_BASE = originalBase;
-    process.env.NX_HEAD = originalHead;
-    if (originalParallel === undefined) {
-      delete process.env.NX_PARALLEL;
-    } else {
-      process.env.NX_PARALLEL = originalParallel;
-    }
+    restoreEnv('NX_BASE', originalBase);
+    restoreEnv('NX_HEAD', originalHead);
+    restoreEnv('NX_PARALLEL', originalParallel);
+    restoreEnv('NX_SKIP_NX_CACHE', originalSkipNxCache);
+    restoreEnv('NX_DISABLE_NX_CACHE', originalDisableNxCache);
+    restoreEnv('NX_SKIP_REMOTE_CACHE', originalSkipRemoteCache);
+    restoreEnv('NX_DISABLE_REMOTE_CACHE', originalDisableRemoteCache);
   });
+
+  function restoreEnv(key: string, value: string | undefined) {
+    if (value === undefined) {
+      delete process.env[key];
+    } else {
+      process.env[key] = value;
+    }
+  }
 
   it('should split nx specific arguments into nxArgs', () => {
     expect(


### PR DESCRIPTION
## Current Behavior

The `splitArgs` describe block in `packages/nx/src/utils/command-line-utils.spec.ts` saves and clears `NX_BASE`, `NX_HEAD`, and `NX_PARALLEL` so the surrounding shell environment doesn't bleed into assertions. However, the production code in `splitArgsIntoNxArgsAndOverrides` also reads four cache-related env vars as fallbacks for the `skipNxCache` / `skipRemoteCache` defaults:

- `NX_SKIP_NX_CACHE`
- `NX_DISABLE_NX_CACHE`
- `NX_SKIP_REMOTE_CACHE`
- `NX_DISABLE_REMOTE_CACHE`

These are not isolated. When a developer runs the test suite via the outer `nx` invocation with flags like `--skipNxCache`, nx propagates them to spawned child processes as `NX_SKIP_NX_CACHE=true`. That env var leaks into the Jest worker, flips `skipNxCache` to `true`, and breaks every test in the `splitArgs` block that asserts on the defaults — six failures in total (`should split nx specific arguments into nxArgs`, `should default to having a base of main`, `should return configured base branch from nx.json`, `should return a default base branch if not configured in nx.json`, `should split projects when it is a string`, `should set base and head based on environment variables in affected mode`).

## Expected Behavior

The `splitArgs` specs should pass regardless of which cache-related flags or env vars are set in the surrounding environment, just like they already do for `NX_BASE` / `NX_HEAD` / `NX_PARALLEL`.

This PR extends the existing save/clear/restore pattern to cover the four cache env vars and factors the conditional-restore logic (delete when originally unset, otherwise reassign — to avoid Node's `process.env[key] = undefined` coercing to the string `"undefined"`) into a small `restoreEnv` helper.

## Related Issue(s)

N/A