### PR TITLE
chore(testing): pin vite resolution on yarn for vite 7 downgrade

### DIFF
--- a/e2e/cypress/src/cypress-legacy.test.ts
+++ b/e2e/cypress/src/cypress-legacy.test.ts
@@ -1,6 +1,7 @@
 import {
   cleanupProject,
   getPackageManagerCommand,
+  getSelectedPackageManager,
   killPort,
   newProject,
   runCLI,
@@ -58,10 +59,19 @@ describe('Cypress E2E Test runner (legacy)', () => {
       );
       // Cypress CT (@cypress/vite-dev-server) does not support Vite 8 yet.
       // Downgrade the workspace to Vite 7 before configuring Cypress CT.
+      const isYarn = getSelectedPackageManager() === 'yarn';
       updateJson('package.json', (json) => {
         json.devDependencies ??= {};
         json.devDependencies['vite'] = '^7.0.0';
         json.devDependencies['@vitejs/plugin-react'] = '^4.2.0';
+        // Yarn classic's linker bombs ("could not find a copy of vite to link
+        // in node_modules/vitest/node_modules") when intersecting a
+        // top-level `^7.0.0` range with vitest's vite dep+peer combo. Pin
+        // vite via `resolutions` so yarn commits to a single version up
+        // front and skips the buggy hoisting path.
+        if (isYarn) {
+          json.resolutions = { ...(json.resolutions ?? {}), vite: '^7.0.0' };
+        }
         return json;
       });
       runCommand(getPackageManagerCommand().install);

--- a/e2e/vite/src/vite.test.ts
+++ b/e2e/vite/src/vite.test.ts
@@ -1,6 +1,7 @@
 import {
   cleanupProject,
   getPackageManagerCommand,
+  getSelectedPackageManager,
   killProcessAndPorts,
   newProject,
   readJson,
@@ -326,9 +327,18 @@ describe('@nx/vite/plugin', () => {
       );
 
       // Downgrade to Vite 7 and @vitejs/plugin-react v4 (v6 only supports Vite 8)
+      const isYarn = getSelectedPackageManager() === 'yarn';
       updateJson('package.json', (json) => {
         json.devDependencies['vite'] = '^7.0.0';
         json.devDependencies['@vitejs/plugin-react'] = '^4.2.0';
+        // Yarn classic's linker bombs ("could not find a copy of vite to link
+        // in node_modules/vitest/node_modules") when intersecting a
+        // top-level `^7.0.0` range with vitest's vite dep+peer combo. Pin
+        // vite via `resolutions` so yarn commits to a single version up
+        // front and skips the buggy hoisting path.
+        if (isYarn) {
+          json.resolutions = { ...(json.resolutions ?? {}), vite: '^7.0.0' };
+        }
         return json;
       });
       runCommand(getPackageManagerCommand().install);


### PR DESCRIPTION
## Current Behavior

The `cypress-legacy` and `vite` e2e tests downgrade `vite` + `@vitejs/plugin-react` in `package.json` and then run `install` to verify backward compatibility with Vite 7. On yarn classic this trips a linker bug:

```
error Invariant Violation: could not find a copy of vite to link in
    .../node_modules/vitest/node_modules
```

Root cause: `vitest@~4.1.0` declares `vite` as both a regular `dependency` AND a `peerDependency`. yarn 1's hoisting algorithm fails when intersecting a top-level `^7.0.0` range with that combo (the bug does not fire for `^8.0.0`, exact versions, or differently-formatted ranges like `7.x`). It is not specific to the in-test downgrade — the same setup fails from a completely empty directory.

`Linux/yarn/20 e2e-cypress` and `Linux/yarn/20 e2e-vite` have been failing every nightly since the in-test Vite 7 downgrade was introduced in #34850.

## Expected Behavior

The `cypress-legacy` and `vite` e2e tests pass on yarn classic again with Vite 7.

The fix adds a yarn-only `resolutions` entry pinning `vite` so yarn commits to a single version up front and skips the buggy hoisting code path. npm/pnpm don't have the bug and ignore the field.

## Validation

Verified via a manually-dispatched e2e nightly run on this branch (with the matrix temporarily narrowed to `Linux/yarn/20 × {e2e-cypress, e2e-vite}`, the matrices that fail on master): https://github.com/nrwl/nx/actions/runs/25431401390 — both jobs passed.