### PR TITLE
fix(angular): multi-version support compliance

### DIFF
--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -368,9 +368,6 @@
     },
     "update-unit-test-runner-option": {
       "version": "22.3.0-beta.0",
-      "requires": {
-        "@angular/core": ">=21.0.0"
-      },
       "description": "Update 'vitest' unit test runner option to 'vitest-analog' in generator defaults.",
       "factory": "./src/migrations/update-22-3-0/update-unit-test-runner-option"
     },
@@ -1049,6 +1046,9 @@
     },
     "20.2.0-module-federation": {
       "version": "20.2.0-beta.3",
+      "requires": {
+        "@module-federation/enhanced": ">=0.6.0 <0.7.0"
+      },
       "packages": {
         "@module-federation/enhanced": {
           "version": "0.7.6",
@@ -1988,6 +1988,9 @@
     },
     "22.2.0": {
       "version": "22.2.0-beta.0",
+      "requires": {
+        "@module-federation/enhanced": ">=0.7.0 <0.21.0"
+      },
       "packages": {
         "@module-federation/enhanced": {
           "version": "^0.21.2",
@@ -2413,6 +2416,9 @@
     "22.6.0-module-federation": {
       "version": "22.6.0-beta.10",
       "x-prompt": "Bump @module-federation packages to v2.x to resolve koa CVE-2026-27959 (via dts-plugin)",
+      "requires": {
+        "@module-federation/enhanced": ">=0.21.0 <2.0.0"
+      },
       "packages": {
         "@module-federation/enhanced": {
           "version": "^2.1.0",

--- a/packages/angular/src/generators/add-linting/add-linting.ts
+++ b/packages/angular/src/generators/add-linting/add-linting.ts
@@ -7,6 +7,7 @@ import {
   type Tree,
 } from '@nx/devkit';
 import { lintProjectGenerator } from '@nx/eslint';
+import { assertSupportedAngularVersion } from '../../utils/assert-supported-angular-version';
 import {
   javaScriptOverride,
   typeScriptOverride,
@@ -27,6 +28,7 @@ export async function addLintingGenerator(
   tree: Tree,
   options: AddLintingGeneratorSchema
 ): Promise<GeneratorCallback> {
+  assertSupportedAngularVersion(tree);
   const tasks: GeneratorCallback[] = [];
   const rootProject = options.projectRoot === '.' || options.projectRoot === '';
   const lintTask = await lintProjectGenerator(tree, {

--- a/packages/angular/src/generators/add-linting/lib/add-angular-eslint-dependencies.ts
+++ b/packages/angular/src/generators/add-linting/lib/add-angular-eslint-dependencies.ts
@@ -37,5 +37,11 @@ export function addAngularEsLintDependencies(
     devDependencies['jsonc-eslint-parser'] = jsoncEslintParserVersionToInstall;
   }
 
-  return addDependenciesToPackageJson(tree, {}, devDependencies);
+  return addDependenciesToPackageJson(
+    tree,
+    {},
+    devDependencies,
+    undefined,
+    true
+  );
 }

--- a/packages/angular/src/generators/application/application.ts
+++ b/packages/angular/src/generators/application/application.ts
@@ -12,6 +12,7 @@ import {
   updateNxJson,
 } from '@nx/devkit';
 import { initGenerator as jsInitGenerator } from '@nx/js';
+import { assertSupportedAngularVersion } from '../../utils/assert-supported-angular-version';
 import { convertToRspack } from '../convert-to-rspack/convert-to-rspack';
 import { angularInitGenerator } from '../init/init';
 import { setupSsr } from '../setup-ssr/setup-ssr';
@@ -41,6 +42,7 @@ export async function applicationGenerator(
   tree: Tree,
   schema: Schema
 ): Promise<GeneratorCallback> {
+  assertSupportedAngularVersion(tree);
   assertNotUsingTsSolutionSetup(tree, 'application');
   validateOptions(tree, schema);
 

--- a/packages/angular/src/generators/component-story/component-story.ts
+++ b/packages/angular/src/generators/component-story/component-story.ts
@@ -1,5 +1,6 @@
 import type { Tree } from '@nx/devkit';
 import { formatFiles, generateFiles, joinPathFragments } from '@nx/devkit';
+import { assertSupportedAngularVersion } from '../../utils/assert-supported-angular-version';
 import { getComponentProps } from '../utils/storybook-ast/storybook-inputs';
 import type { ComponentStoryGeneratorOptions } from './schema';
 
@@ -7,6 +8,7 @@ export async function componentStoryGenerator(
   tree: Tree,
   options: ComponentStoryGeneratorOptions
 ): Promise<void> {
+  assertSupportedAngularVersion(tree);
   const { componentFileName, componentName, componentPath, projectPath } =
     options;
 

--- a/packages/angular/src/generators/component-test/component-test.ts
+++ b/packages/angular/src/generators/component-test/component-test.ts
@@ -9,6 +9,7 @@ import {
   type GeneratorCallback,
   type Tree,
 } from '@nx/devkit';
+import { assertSupportedAngularVersion } from '../../utils/assert-supported-angular-version';
 import { nxVersion } from '../../utils/versions';
 import {
   getArgsDefaultValue,
@@ -21,6 +22,7 @@ export async function componentTestGenerator(
   tree: Tree,
   options: ComponentTestSchema
 ) {
+  assertSupportedAngularVersion(tree);
   ensurePackage('@nx/cypress', nxVersion);
   const { root } = readProjectConfiguration(tree, options.project);
   const componentDirPath = joinPathFragments(root, options.componentDir);

--- a/packages/angular/src/generators/component/component.ts
+++ b/packages/angular/src/generators/component/component.ts
@@ -5,6 +5,7 @@ import {
   joinPathFragments,
   readProjectConfiguration,
 } from '@nx/devkit';
+import { assertSupportedAngularVersion } from '../../utils/assert-supported-angular-version';
 import { isZonelessApp } from '../../utils/zoneless';
 import { addToNgModule } from '../utils';
 import { getInstalledAngularVersionInfo } from '../utils/version-utils';
@@ -17,6 +18,7 @@ import {
 import type { Schema } from './schema';
 
 export async function componentGenerator(tree: Tree, rawOptions: Schema) {
+  assertSupportedAngularVersion(tree);
   const options = await normalizeOptions(tree, rawOptions);
 
   const { major: angularMajorVersion } = getInstalledAngularVersionInfo(tree);

--- a/packages/angular/src/generators/convert-to-application-executor/convert-to-application-executor.ts
+++ b/packages/angular/src/generators/convert-to-application-executor/convert-to-application-executor.ts
@@ -11,6 +11,7 @@ import {
   type Tree,
 } from '@nx/devkit';
 import { dirname, join } from 'node:path/posix';
+import { assertSupportedAngularVersion } from '../../utils/assert-supported-angular-version';
 import { allTargetOptions } from '../../utils/targets';
 import { setupSsr } from '../setup-ssr/setup-ssr';
 import { validateProject } from '../utils/validations';
@@ -39,6 +40,7 @@ export async function convertToApplicationExecutor(
   tree: Tree,
   options: GeneratorOptions
 ) {
+  assertSupportedAngularVersion(tree);
   let didAnySucceed = false;
   if (options.project) {
     validateProject(tree, options.project);

--- a/packages/angular/src/generators/convert-to-rspack/convert-to-rspack.ts
+++ b/packages/angular/src/generators/convert-to-rspack/convert-to-rspack.ts
@@ -21,6 +21,7 @@ import type { RspackPluginOptions } from '@nx/rspack/plugin';
 import { prompt } from 'enquirer';
 import { relative, resolve } from 'path';
 import { join } from 'path/posix';
+import { assertSupportedAngularVersion } from '../../utils/assert-supported-angular-version';
 import { nxVersion } from '../../utils/versions';
 import { getAngularRspackVersion, versions } from '../utils/version-utils';
 import { createConfig } from './lib/create-config';
@@ -332,6 +333,7 @@ export async function convertToRspack(
   tree: Tree,
   schema: ConvertToRspackSchema
 ) {
+  assertSupportedAngularVersion(tree);
   let { project: projectName } = schema;
   if (!projectName) {
     projectName = await getProjectToConvert(tree);

--- a/packages/angular/src/generators/convert-to-with-mf/convert-to-with-mf.ts
+++ b/packages/angular/src/generators/convert-to-with-mf/convert-to-with-mf.ts
@@ -7,6 +7,7 @@ import {
   Tree,
 } from '@nx/devkit';
 import type { Schema } from './schema';
+import { assertSupportedAngularVersion } from '../../utils/assert-supported-angular-version';
 import { getMFProjects } from '../../utils/get-mf-projects';
 import { nxVersion } from '../../utils/versions';
 import {
@@ -19,6 +20,7 @@ import {
 } from './lib';
 
 export async function convertToWithMF(tree: Tree, schema: Schema) {
+  assertSupportedAngularVersion(tree);
   const projects = new Set(getMFProjects(tree, { legacy: true }));
 
   if (!projects.has(schema.project)) {

--- a/packages/angular/src/generators/cypress-component-configuration/cypress-component-configuration.ts
+++ b/packages/angular/src/generators/cypress-component-configuration/cypress-component-configuration.ts
@@ -13,6 +13,7 @@ import {
   updateProjectConfiguration,
 } from '@nx/devkit';
 import { relative } from 'path';
+import { assertSupportedAngularVersion } from '../../utils/assert-supported-angular-version';
 import { isZonelessApp } from '../../utils/zoneless';
 import { nxVersion } from '../../utils/versions';
 import { componentTestGenerator } from '../component-test/component-test';
@@ -48,6 +49,7 @@ export async function cypressComponentConfiguration(
   tree: Tree,
   options: CypressComponentConfigSchema
 ): Promise<GeneratorCallback> {
+  assertSupportedAngularVersion(tree);
   const { componentConfigurationGenerator: baseCyCTConfig } = ensurePackage<
     typeof import('@nx/cypress')
   >('@nx/cypress', nxVersion);

--- a/packages/angular/src/generators/directive/directive.ts
+++ b/packages/angular/src/generators/directive/directive.ts
@@ -1,11 +1,13 @@
 import type { Tree } from '@nx/devkit';
 import { formatFiles, generateFiles, joinPathFragments } from '@nx/devkit';
+import { assertSupportedAngularVersion } from '../../utils/assert-supported-angular-version';
 import { addToNgModule, findModule } from '../utils';
 import { getInstalledAngularVersionInfo } from '../utils/version-utils';
 import { normalizeOptions } from './lib';
 import type { Schema } from './schema';
 
 export async function directiveGenerator(tree: Tree, schema: Schema) {
+  assertSupportedAngularVersion(tree);
   const options = await normalizeOptions(tree, schema);
 
   const { major: angularMajorVersion } = getInstalledAngularVersionInfo(tree);

--- a/packages/angular/src/generators/federate-module/federate-module.ts
+++ b/packages/angular/src/generators/federate-module/federate-module.ts
@@ -5,6 +5,7 @@ import {
   stripIndents,
   type Tree,
 } from '@nx/devkit';
+import { assertSupportedAngularVersion } from '../../utils/assert-supported-angular-version';
 import { UnitTestRunner } from '../../utils/test-runners';
 import { getInstalledAngularVersionInfo } from '../utils/version-utils';
 import {
@@ -16,6 +17,7 @@ import {
 import type { Schema } from './schema';
 
 export async function federateModuleGenerator(tree: Tree, schema: Schema) {
+  assertSupportedAngularVersion(tree);
   if (!tree.exists(schema.path)) {
     throw new Error(stripIndents`The "path" provided  does not exist. Please verify the path is correct and pointing to a file that exists in the workspace.
     

--- a/packages/angular/src/generators/host/host.ts
+++ b/packages/angular/src/generators/host/host.ts
@@ -12,6 +12,7 @@ import {
   updateProjectConfiguration,
 } from '@nx/devkit';
 import { isValidVariable } from '@nx/js';
+import { assertSupportedAngularVersion } from '../../utils/assert-supported-angular-version';
 import { E2eTestRunner } from '../../utils/test-runners';
 import applicationGenerator from '../application/application';
 import convertToRspack from '../convert-to-rspack/convert-to-rspack';
@@ -25,6 +26,7 @@ import { updateSsrSetup, validateOptions } from './lib';
 import type { Schema } from './schema';
 
 export async function host(tree: Tree, schema: Schema) {
+  assertSupportedAngularVersion(tree);
   assertNotUsingTsSolutionSetup(tree, 'host');
   validateOptions(tree, schema);
   // TODO: Replace with Rspack when confidence is high enough

--- a/packages/angular/src/generators/init/init.spec.ts
+++ b/packages/angular/src/generators/init/init.spec.ts
@@ -84,7 +84,7 @@ bar
     });
   });
 
-  describe('v15 support', () => {
+  describe('v19 support', () => {
     let tree: Tree;
     beforeEach(() => {
       tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
@@ -92,7 +92,7 @@ bar
         ...json,
         dependencies: {
           ...json.dependencies,
-          '@angular/core': '~15.2.0',
+          '@angular/core': '~19.2.0',
         },
       }));
     });

--- a/packages/angular/src/generators/init/init.ts
+++ b/packages/angular/src/generators/init/init.ts
@@ -11,6 +11,7 @@ import {
   type Tree,
 } from '@nx/devkit';
 import { createNodesV2 } from '../../plugins/plugin';
+import { assertSupportedAngularVersion } from '../../utils/assert-supported-angular-version';
 import { assertNotUsingTsSolutionSetup } from '../utils/validations';
 import {
   getInstalledAngularDevkitVersion,
@@ -22,6 +23,7 @@ export async function angularInitGenerator(
   tree: Tree,
   options: Schema
 ): Promise<GeneratorCallback> {
+  assertSupportedAngularVersion(tree);
   assertNotUsingTsSolutionSetup(tree, 'init');
 
   ignoreAngularCacheDirectory(tree);

--- a/packages/angular/src/generators/library-secondary-entry-point/library-secondary-entry-point.ts
+++ b/packages/angular/src/generators/library-secondary-entry-point/library-secondary-entry-point.ts
@@ -1,4 +1,5 @@
 import { formatFiles, Tree } from '@nx/devkit';
+import { assertSupportedAngularVersion } from '../../utils/assert-supported-angular-version';
 import {
   addFiles,
   addPathMapping,
@@ -11,6 +12,7 @@ export async function librarySecondaryEntryPointGenerator(
   tree: Tree,
   rawOptions: GeneratorOptions
 ) {
+  assertSupportedAngularVersion(tree);
   const options = normalizeOptions(tree, rawOptions);
 
   addFiles(tree, options);

--- a/packages/angular/src/generators/library/library.ts
+++ b/packages/angular/src/generators/library/library.ts
@@ -11,6 +11,7 @@ import {
 import { initGenerator as jsInitGenerator } from '@nx/js';
 import { releaseTasks } from '@nx/js/src/generators/library/utils/add-release-config';
 import init from '../../generators/init/init';
+import { assertSupportedAngularVersion } from '../../utils/assert-supported-angular-version';
 import { UnitTestRunner } from '../../utils/test-runners';
 import addLintingGenerator from '../add-linting/add-linting';
 import { addJest } from '../utils/add-jest';
@@ -35,6 +36,7 @@ export async function libraryGenerator(
   tree: Tree,
   schema: Schema
 ): Promise<GeneratorCallback> {
+  assertSupportedAngularVersion(tree);
   assertNotUsingTsSolutionSetup(tree, 'library');
   validateOptions(tree, schema);
 

--- a/packages/angular/src/generators/ng-add/ng-add.ts
+++ b/packages/angular/src/generators/ng-add/ng-add.ts
@@ -1,8 +1,10 @@
 import type { Tree } from '@nx/devkit';
+import { assertSupportedAngularVersion } from '../../utils/assert-supported-angular-version';
 import { migrateFromAngularCli } from './migrate-from-angular-cli';
 import type { GeneratorOptions } from './schema';
 
 export async function ngAddGenerator(tree: Tree, options: GeneratorOptions) {
+  assertSupportedAngularVersion(tree);
   return await migrateFromAngularCli(tree, options);
 }
 

--- a/packages/angular/src/generators/ngrx-feature-store/ngrx-feature-store.ts
+++ b/packages/angular/src/generators/ngrx-feature-store/ngrx-feature-store.ts
@@ -1,5 +1,6 @@
 import type { Tree } from '@nx/devkit';
 import { formatFiles, GeneratorCallback } from '@nx/devkit';
+import { assertSupportedAngularVersion } from '../../utils/assert-supported-angular-version';
 import type { Schema } from './schema';
 import {
   addExportsToBarrel,
@@ -11,6 +12,7 @@ import {
 } from './lib';
 
 export async function ngrxFeatureStoreGenerator(tree: Tree, schema: Schema) {
+  assertSupportedAngularVersion(tree);
   validateOptions(tree, schema);
   const options = normalizeOptions(tree, schema);
 

--- a/packages/angular/src/generators/ngrx-root-store/ngrx-root-store.ts
+++ b/packages/angular/src/generators/ngrx-root-store/ngrx-root-store.ts
@@ -1,5 +1,6 @@
 import type { Tree } from '@nx/devkit';
 import { formatFiles, GeneratorCallback } from '@nx/devkit';
+import { assertSupportedAngularVersion } from '../../utils/assert-supported-angular-version';
 import type { Schema } from './schema';
 
 import {
@@ -12,6 +13,7 @@ import {
 import ngrxFeatureStoreGenerator from '../ngrx-feature-store/ngrx-feature-store';
 
 export async function ngrxRootStoreGenerator(tree: Tree, schema: Schema) {
+  assertSupportedAngularVersion(tree);
   validateOptions(tree, schema);
   const options = normalizeOptions(tree, schema);
 

--- a/packages/angular/src/generators/pipe/pipe.ts
+++ b/packages/angular/src/generators/pipe/pipe.ts
@@ -5,11 +5,13 @@ import {
   joinPathFragments,
   names,
 } from '@nx/devkit';
+import { assertSupportedAngularVersion } from '../../utils/assert-supported-angular-version';
 import { addToNgModule, findModule } from '../utils';
 import { normalizeOptions } from './lib';
 import type { Schema } from './schema';
 
 export async function pipeGenerator(tree: Tree, rawOptions: Schema) {
+  assertSupportedAngularVersion(tree);
   const options = await normalizeOptions(tree, rawOptions);
 
   const pipeNames = names(options.name);

--- a/packages/angular/src/generators/remote/remote.ts
+++ b/packages/angular/src/generators/remote/remote.ts
@@ -13,6 +13,7 @@ import {
   updateProjectConfiguration,
 } from '@nx/devkit';
 import { swcHelpersVersion } from '@nx/js/src/utils/versions';
+import { assertSupportedAngularVersion } from '../../utils/assert-supported-angular-version';
 import { E2eTestRunner } from '../../utils/test-runners';
 import { applicationGenerator } from '../application/application';
 import convertToRspack from '../convert-to-rspack/convert-to-rspack';
@@ -25,6 +26,7 @@ import { findNextAvailablePort, updateSsrSetup, validateOptions } from './lib';
 import type { Schema } from './schema';
 
 export async function remote(tree: Tree, schema: Schema) {
+  assertSupportedAngularVersion(tree);
   assertNotUsingTsSolutionSetup(tree, 'remote');
   validateOptions(tree, schema);
   // TODO: Replace with Rspack when confidence is high enough

--- a/packages/angular/src/generators/scam-directive/scam-directive.ts
+++ b/packages/angular/src/generators/scam-directive/scam-directive.ts
@@ -1,11 +1,13 @@
 import type { Tree } from '@nx/devkit';
 import { formatFiles } from '@nx/devkit';
+import { assertSupportedAngularVersion } from '../../utils/assert-supported-angular-version';
 import { directiveGenerator } from '../directive/directive';
 import { exportScam } from '../utils/export-scam';
 import { convertDirectiveToScam, normalizeOptions } from './lib';
 import type { Schema } from './schema';
 
 export async function scamDirectiveGenerator(tree: Tree, rawOptions: Schema) {
+  assertSupportedAngularVersion(tree);
   const options = await normalizeOptions(tree, rawOptions);
   await directiveGenerator(tree, {
     ...options,

--- a/packages/angular/src/generators/scam-pipe/scam-pipe.ts
+++ b/packages/angular/src/generators/scam-pipe/scam-pipe.ts
@@ -1,11 +1,13 @@
 import type { Tree } from '@nx/devkit';
 import { formatFiles } from '@nx/devkit';
+import { assertSupportedAngularVersion } from '../../utils/assert-supported-angular-version';
 import { pipeGenerator } from '../pipe/pipe';
 import { exportScam } from '../utils/export-scam';
 import { convertPipeToScam, normalizeOptions } from './lib';
 import type { Schema } from './schema';
 
 export async function scamPipeGenerator(tree: Tree, rawOptions: Schema) {
+  assertSupportedAngularVersion(tree);
   const options = await normalizeOptions(tree, rawOptions);
   await pipeGenerator(tree, {
     ...options,

--- a/packages/angular/src/generators/scam-to-standalone/scam-to-standalone.ts
+++ b/packages/angular/src/generators/scam-to-standalone/scam-to-standalone.ts
@@ -1,5 +1,6 @@
 import type { Tree } from '@nx/devkit';
 import { formatFiles, getProjects, joinPathFragments } from '@nx/devkit';
+import { assertSupportedAngularVersion } from '../../utils/assert-supported-angular-version';
 import type { Schema } from './schema';
 import {
   convertScamToStandalone,
@@ -15,6 +16,7 @@ export async function scamToStandalone(
   tree: Tree,
   { component, project: projectName, skipFormat }: Schema
 ) {
+  assertSupportedAngularVersion(tree);
   const projects = getProjects(tree);
   let project = getTargetProject(projectName, projects);
 

--- a/packages/angular/src/generators/scam/scam.ts
+++ b/packages/angular/src/generators/scam/scam.ts
@@ -1,11 +1,13 @@
 import type { Tree } from '@nx/devkit';
 import { formatFiles } from '@nx/devkit';
+import { assertSupportedAngularVersion } from '../../utils/assert-supported-angular-version';
 import { componentGenerator } from '../component/component';
 import { exportScam } from '../utils/export-scam';
 import { convertComponentToScam, normalizeOptions } from './lib';
 import type { Schema } from './schema';
 
 export async function scamGenerator(tree: Tree, rawOptions: Schema) {
+  assertSupportedAngularVersion(tree);
   const options = await normalizeOptions(tree, rawOptions);
   await componentGenerator(tree, {
     ...options,

--- a/packages/angular/src/generators/setup-mf/setup-mf.ts
+++ b/packages/angular/src/generators/setup-mf/setup-mf.ts
@@ -6,6 +6,7 @@ import {
   type GeneratorCallback,
   type Tree,
 } from '@nx/devkit';
+import { assertSupportedAngularVersion } from '../../utils/assert-supported-angular-version';
 import {
   moduleFederationEnhancedVersion,
   nxVersion,
@@ -35,6 +36,7 @@ import {
 import type { Schema } from './schema';
 
 export async function setupMf(tree: Tree, rawOptions: Schema) {
+  assertSupportedAngularVersion(tree);
   const options = normalizeOptions(tree, rawOptions);
   const projectConfig = readProjectConfiguration(tree, options.appName);
 

--- a/packages/angular/src/generators/setup-ssr/setup-ssr.ts
+++ b/packages/angular/src/generators/setup-ssr/setup-ssr.ts
@@ -4,6 +4,7 @@ import {
   installPackagesTask,
   readProjectConfiguration,
 } from '@nx/devkit';
+import { assertSupportedAngularVersion } from '../../utils/assert-supported-angular-version';
 import {
   addDependencies,
   addHydration,
@@ -20,6 +21,7 @@ import {
 import type { Schema } from './schema';
 
 export async function setupSsr(tree: Tree, schema: Schema) {
+  assertSupportedAngularVersion(tree);
   validateOptions(tree, schema);
   const options = await normalizeOptions(tree, schema);
 

--- a/packages/angular/src/generators/stories/stories.ts
+++ b/packages/angular/src/generators/stories/stories.ts
@@ -8,6 +8,7 @@ import {
   runTasksInSerial,
   Tree,
 } from '@nx/devkit';
+import { assertSupportedAngularVersion } from '../../utils/assert-supported-angular-version';
 import componentStoryGenerator from '../component-story/component-story';
 import type { ComponentInfo } from '../utils/storybook-ast/component-info';
 import {
@@ -24,6 +25,7 @@ export async function angularStoriesGenerator(
   tree: Tree,
   options: StoriesGeneratorOptions
 ) {
+  assertSupportedAngularVersion(tree);
   const entryPoints = getProjectEntryPoints(tree, options.name);
   const componentsInfo: ComponentInfo[] = [];
   for (const entryPoint of entryPoints) {

--- a/packages/angular/src/generators/storybook-configuration/storybook-configuration.ts
+++ b/packages/angular/src/generators/storybook-configuration/storybook-configuration.ts
@@ -4,6 +4,7 @@ import {
   readProjectConfiguration,
   Tree,
 } from '@nx/devkit';
+import { assertSupportedAngularVersion } from '../../utils/assert-supported-angular-version';
 import { updateAppEditorTsConfigExcludedFiles } from '../utils/update-app-editor-tsconfig-excluded-files';
 import { assertCompatibleStorybookVersion } from './lib/assert-compatible-storybook-version';
 import { generateStories } from './lib/generate-stories';
@@ -14,6 +15,7 @@ export async function storybookConfigurationGenerator(
   tree: Tree,
   options: StorybookConfigurationOptions
 ): Promise<GeneratorCallback> {
+  assertSupportedAngularVersion(tree);
   assertCompatibleStorybookVersion();
 
   const storybookGeneratorInstallTask = await generateStorybookConfiguration(

--- a/packages/angular/src/generators/utils/ensure-angular-dependencies.spec.ts
+++ b/packages/angular/src/generators/utils/ensure-angular-dependencies.spec.ts
@@ -66,11 +66,11 @@ describe('ensureAngularDependencies', () => {
       ...json,
       dependencies: {
         ...json.dependencies,
-        '@angular/core': '~15.0.0',
+        '@angular/core': '~19.0.0',
       },
       devDependencies: {
         ...json.devDependencies,
-        '@angular-devkit/build-angular': '~15.0.0',
+        '@angular-devkit/build-angular': '~19.0.0',
       },
     }));
 
@@ -79,9 +79,9 @@ describe('ensureAngularDependencies', () => {
 
     // ASSERT
     const { devDependencies } = readJson(tree, 'package.json');
-    expect(devDependencies['@angular-devkit/build-angular']).toBe('~15.0.0');
-    expect(devDependencies['@angular-devkit/schematics']).toBe('~15.0.0');
-    expect(devDependencies['@schematics/angular']).toBe('~15.0.0');
+    expect(devDependencies['@angular-devkit/build-angular']).toBe('~19.0.0');
+    expect(devDependencies['@angular-devkit/schematics']).toBe('~19.0.0');
+    expect(devDependencies['@schematics/angular']).toBe('~19.0.0');
   });
 
   it('should not overwrite already installed dependencies', () => {
@@ -90,12 +90,12 @@ describe('ensureAngularDependencies', () => {
       ...json,
       dependencies: {
         ...json.dependencies,
-        '@angular/animations': '~15.0.1',
-        '@angular/core': '~15.0.0',
+        '@angular/animations': '~19.0.1',
+        '@angular/core': '~19.0.0',
       },
       devDependencies: {
         ...json.devDependencies,
-        '@angular-devkit/build-angular': '~15.0.1',
+        '@angular-devkit/build-angular': '~19.0.1',
       },
     }));
 
@@ -105,9 +105,9 @@ describe('ensureAngularDependencies', () => {
     // ASSERT
     const { dependencies, devDependencies } = readJson(tree, 'package.json');
 
-    expect(dependencies['@angular/animations']).toBe('~15.0.1');
-    expect(dependencies['@angular/core']).toBe('~15.0.0');
-    expect(devDependencies['@angular-devkit/build-angular']).toBe('~15.0.1');
+    expect(dependencies['@angular/animations']).toBe('~19.0.1');
+    expect(dependencies['@angular/core']).toBe('~19.0.0');
+    expect(devDependencies['@angular-devkit/build-angular']).toBe('~19.0.1');
   });
 
   it('should not add extra runtime dependencies when `@angular/core` is already installed', () => {
@@ -116,7 +116,7 @@ describe('ensureAngularDependencies', () => {
       ...json,
       dependencies: {
         ...json.dependencies,
-        '@angular/core': '~15.0.0',
+        '@angular/core': '~19.0.0',
       },
     }));
 
@@ -126,7 +126,7 @@ describe('ensureAngularDependencies', () => {
     // ASSERT
     const { dependencies } = readJson(tree, 'package.json');
 
-    expect(dependencies['@angular/core']).toBe('~15.0.0');
+    expect(dependencies['@angular/core']).toBe('~19.0.0');
     expect(dependencies['@angular/common']).toBeUndefined();
     expect(dependencies['@angular/compiler']).toBeUndefined();
     expect(dependencies['@angular/platform-browser']).toBeUndefined();

--- a/packages/angular/src/generators/web-worker/web-worker.ts
+++ b/packages/angular/src/generators/web-worker/web-worker.ts
@@ -8,6 +8,7 @@ import {
   readProjectConfiguration,
   updateProjectConfiguration,
 } from '@nx/devkit';
+import { assertSupportedAngularVersion } from '../../utils/assert-supported-angular-version';
 import { addSnippet, normalizeOptions } from './lib';
 import type { WebWorkerGeneratorOptions } from './schema';
 import { getRelativePathToRootTsConfig } from '@nx/js';
@@ -16,6 +17,7 @@ export async function webWorkerGenerator(
   tree: Tree,
   rawOptions: WebWorkerGeneratorOptions
 ): Promise<void> {
+  assertSupportedAngularVersion(tree);
   const options = normalizeOptions(tree, rawOptions);
   const workerNames = names(options.name);
   const projectConfig = readProjectConfiguration(tree, options.project);

--- a/packages/angular/src/utils/all-generators-enforce-floor.spec.ts
+++ b/packages/angular/src/utils/all-generators-enforce-floor.spec.ts
@@ -1,0 +1,35 @@
+import { updateJson } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const generatorsJson = JSON.parse(
+  readFileSync(join(__dirname, '..', '..', 'generators.json'), 'utf-8')
+);
+
+const generatorEntries = Object.entries<{ factory: string }>(
+  generatorsJson.generators
+);
+
+describe('all generators enforce supported Angular version floor', () => {
+  it.each(generatorEntries)(
+    '`%s` throws on sub-floor @angular/core',
+    async (_name, def) => {
+      const factoryRelative = def.factory.replace(/^\.\//, '');
+      const factoryModule = require(
+        join(__dirname, '..', '..', factoryRelative)
+      );
+      const factory = factoryModule.default ?? factoryModule;
+
+      const tree = createTreeWithEmptyWorkspace();
+      updateJson(tree, 'package.json', (json) => ({
+        ...json,
+        dependencies: { '@angular/core': '~18.2.0' },
+      }));
+
+      await expect(
+        Promise.resolve().then(() => factory(tree, {}))
+      ).rejects.toThrow(/Unsupported version of `@angular\/core` detected/);
+    }
+  );
+});

--- a/packages/angular/src/utils/assert-supported-angular-version.spec.ts
+++ b/packages/angular/src/utils/assert-supported-angular-version.spec.ts
@@ -1,0 +1,52 @@
+import { updateJson } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { assertSupportedAngularVersion } from './assert-supported-angular-version';
+
+describe('assertSupportedAngularVersion', () => {
+  it('throws when @angular/core is below the supported floor', () => {
+    const tree = createTreeWithEmptyWorkspace();
+    updateJson(tree, 'package.json', (json) => ({
+      ...json,
+      dependencies: { '@angular/core': '~18.2.0' },
+    }));
+
+    expect(() => assertSupportedAngularVersion(tree)).toThrow(
+      /Unsupported version of `@angular\/core` detected/
+    );
+  });
+
+  it('does not throw when @angular/core is not installed (fresh-install path)', () => {
+    const tree = createTreeWithEmptyWorkspace();
+    expect(() => assertSupportedAngularVersion(tree)).not.toThrow();
+  });
+
+  it('does not throw when @angular/core is `latest`', () => {
+    const tree = createTreeWithEmptyWorkspace();
+    updateJson(tree, 'package.json', (json) => ({
+      ...json,
+      dependencies: { '@angular/core': 'latest' },
+    }));
+
+    expect(() => assertSupportedAngularVersion(tree)).not.toThrow();
+  });
+
+  it('does not throw when @angular/core is `next`', () => {
+    const tree = createTreeWithEmptyWorkspace();
+    updateJson(tree, 'package.json', (json) => ({
+      ...json,
+      dependencies: { '@angular/core': 'next' },
+    }));
+
+    expect(() => assertSupportedAngularVersion(tree)).not.toThrow();
+  });
+
+  it('does not throw when @angular/core is within the supported window', () => {
+    const tree = createTreeWithEmptyWorkspace();
+    updateJson(tree, 'package.json', (json) => ({
+      ...json,
+      dependencies: { '@angular/core': '~19.2.0' },
+    }));
+
+    expect(() => assertSupportedAngularVersion(tree)).not.toThrow();
+  });
+});

--- a/packages/angular/src/utils/assert-supported-angular-version.ts
+++ b/packages/angular/src/utils/assert-supported-angular-version.ts
@@ -1,0 +1,22 @@
+import { getDependencyVersionFromPackageJson, type Tree } from '@nx/devkit';
+import { throwForUnsupportedVersion } from '@nx/devkit/internal';
+import { clean, coerce, major } from 'semver';
+import { supportedVersions } from './backward-compatible-versions';
+
+const minSupportedAngularMajor = Math.min(...supportedVersions);
+
+export function assertSupportedAngularVersion(tree: Tree): void {
+  const detected = getDependencyVersionFromPackageJson(tree, '@angular/core');
+  if (!detected || detected === 'latest' || detected === 'next') {
+    return;
+  }
+
+  const cleaned = clean(detected) ?? coerce(detected)?.version ?? null;
+  if (cleaned && major(cleaned) < minSupportedAngularMajor) {
+    throwForUnsupportedVersion(
+      '@angular/core',
+      detected,
+      `${minSupportedAngularMajor}.0.0`
+    );
+  }
+}

--- a/packages/devkit/internal.ts
+++ b/packages/devkit/internal.ts
@@ -42,6 +42,7 @@ export {
 
 // Utils
 export { addPlugin } from './src/utils/add-plugin';
+export { throwForUnsupportedVersion } from './src/utils/version-floor';
 export {
   createAsyncIterable,
   combineAsyncIterables,

--- a/packages/devkit/src/utils/version-floor.spec.ts
+++ b/packages/devkit/src/utils/version-floor.spec.ts
@@ -1,0 +1,28 @@
+import { throwForUnsupportedVersion } from './version-floor';
+
+describe('throwForUnsupportedVersion', () => {
+  it('throws an error naming the package, installed version, and floor', () => {
+    expect(() =>
+      throwForUnsupportedVersion('@angular/core', '18.2.0', '19.0.0')
+    ).toThrowErrorMatchingInlineSnapshot(`
+      "Unsupported version of \`@angular/core\` detected.
+
+        Installed: 18.2.0
+        Supported: >= 19.0.0
+
+      Update \`@angular/core\` to 19.0.0 or higher."
+    `);
+  });
+
+  it('formats messages for unscoped packages too', () => {
+    expect(() => throwForUnsupportedVersion('vite', '5.4.0', '6.0.0'))
+      .toThrowErrorMatchingInlineSnapshot(`
+      "Unsupported version of \`vite\` detected.
+
+        Installed: 5.4.0
+        Supported: >= 6.0.0
+
+      Update \`vite\` to 6.0.0 or higher."
+    `);
+  });
+});

--- a/packages/devkit/src/utils/version-floor.ts
+++ b/packages/devkit/src/utils/version-floor.ts
@@ -1,0 +1,24 @@
+/**
+ * Throws a standardized error when a third-party package is installed at a
+ * version below a plugin's supported floor.
+ *
+ * Use this at every site where a plugin determines the installed version of a
+ * supported third-party package is below its declared floor, so the message is
+ * consistent across plugins.
+ *
+ * @param packageName Name of the third-party package (e.g. `@angular/core`).
+ * @param installedVersion Version detected in the workspace (e.g. `18.2.0`).
+ * @param floor Lowest version the plugin supports (e.g. `19.0.0`).
+ */
+export function throwForUnsupportedVersion(
+  packageName: string,
+  installedVersion: string,
+  floor: string
+): never {
+  throw new Error(
+    `Unsupported version of \`${packageName}\` detected.\n\n` +
+      `  Installed: ${installedVersion}\n` +
+      `  Supported: >= ${floor}\n\n` +
+      `Update \`${packageName}\` to ${floor} or higher.`
+  );
+}


### PR DESCRIPTION
## Current Behavior

- `@nx/angular` silently falls through to the v21 install constants when a workspace has `@angular/core` detected below the supported floor (v19). Generators add v21 packages incompatible with the user's setup instead of failing fast.
- Three cross-major Module Federation `packageJsonUpdates` entries (`20.2.0-module-federation`, `22.2.0`, `22.6.0-module-federation`) lack `requires` gates, so each bump fires for every workspace regardless of the installed `@module-federation/*` source major.
- The `update-unit-test-runner-option` migration declares `@angular/core: >=21.0.0` despite only rewriting an Nx generator default in `nx.json` (`unitTestRunner: 'vitest'` → `'vitest-analog'`). Pre-v21 workspaces that already have the stale default never run the migration and stay broken (the value is no longer in the generator schema's enum).
- The `add-linting` generator overwrites already-installed third-party versions because it doesn't pass `keepExistingVersions=true` to `addDependenciesToPackageJson`.

## Expected Behavior

- A workspace with `@angular/core` detected below v19 throws with a clear, standardized message naming the package, the installed version, and the supported floor (no silent fall-through). The fresh-install path (no `@angular/core` detected) still resolves to the latest supported version.
- Each MF `packageJsonUpdates` entry gates on the `@module-federation/enhanced` source range it is bumping from, so the bump only fires for workspaces actually in that range.
- The `update-unit-test-runner-option` migration runs for any workspace with the stale generator default, regardless of installed Angular version.
- The `add-linting` generator preserves already-installed dependency pins.

A new internal helper `throwForUnsupportedVersion` is added to `@nx/devkit/internal` so first-party plugins can produce a consistent below-floor error format. It is intentionally not part of the public `@nx/devkit` surface — only first-party plugins will consume it as the rest of the multi-version compliance rollout lands.