### PR TITLE
fix(maven): widen runCLI timeout for --no-batch maven.test.ts cases

### DIFF
--- a/e2e/maven/src/maven.test.ts
+++ b/e2e/maven/src/maven.test.ts
@@ -47,8 +47,15 @@ describe('Maven', () => {
   });
 
   it('should build Maven project with dependencies without batch mode', () => {
-    // Build app which depends on lib, which depends on utils
-    let buildOutput = runCLI('run app:install --no-batch', { verbose: true });
+    // Build app which depends on lib, which depends on utils.
+    // Without --batch, Nx fans `app:install` out into one task per Maven
+    // lifecycle phase per project (~87 tasks total), each spawning its own
+    // mvn JVM. On loaded CI hosts this routinely runs 220-290s, so the
+    // default 5-minute runCLI timeout is too tight; bump it to 10 minutes.
+    let buildOutput = runCLI('run app:install --no-batch', {
+      verbose: true,
+      timeout: 10 * 60 * 1000,
+    });
 
     // Should build dependencies first
     expect(buildOutput).toContain('BUILD SUCCESS');
@@ -117,8 +124,12 @@ describe('Maven', () => {
     expect(output).toContain('- mvn-package:');
     expect(output).toContain('- mvn-install-ci:');
 
-    // Verify prefixed target works
-    const buildOutput = runCLI('run app:mvn-compile --no-batch');
+    // Verify prefixed target works. Same lifecycle-fan-out concern as the
+    // app:install case above — give it a 10-minute timeout so CI load
+    // doesn't push us past the default 5 minutes.
+    const buildOutput = runCLI('run app:mvn-compile --no-batch', {
+      timeout: 10 * 60 * 1000,
+    });
     expect(buildOutput).toContain('BUILD SUCCESS');
   });
 });


### PR DESCRIPTION
## Current Behavior

`e2e-maven:e2e-ci--src/maven.test.ts` is flaking on CI. Example failed run: https://github.com/nrwl/nx/actions/runs/25398728205

The failure pattern is consistent across the failures we have logs for:

```
FAIL e2e-maven src/maven.test.ts (533.603 s)
  Maven
    ✓ should detect Maven projects (13261 ms)
    ✓ should have proper Maven targets (2190 ms)
    ✕ should build Maven project with dependencies without batch mode (300955 ms)
    ✓ should run tests for Maven project without batch mode (10902 ms)
    ✓ should handle Maven project with complex dependencies (2933 ms)
    ✓ should support targetNamePrefix option (164161 ms)

  Maven › should build Maven project with dependencies without batch mode

    Command timed out after 300s: run app:install --no-batch

    Process output:
    NX   Running target install for project com.example:app and 87 tasks it depends on:
    ...
```

## Root cause

Without `--batch`, Nx expands `app:install` into one task per Maven lifecycle phase per project (`validate, initialize, generate-sources, ..., install` × 4 projects ≈ 87 tasks), and each task spawns its own `mvn` JVM that runs the `nx-maven-plugin:apply` and `:record` mojos.

Sampling `Run Command: run app:install --no-batch (Xs)` across the last few master CI runs:

| Run | Duration |
| --- | --- |
| 25406383967 (passed) | 222.7s |
| 25395898487 (passed) | 261.7s |
| 25393915435 (passed) | 278.9s |
| 25395728023 (passed) | 286.8s |
| 25398728205 (failed) | 300s+ (timeout) |

`runCLI`'s default timeout is `5 * 60 * 1000` ms. On a healthy host the assertion finishes around 220s. On loaded CI runners the same 87 JVM-spawning tasks routinely climb to 285s+, leaving very little headroom — any extra noise puts it past 300s. There is no regression in the underlying graph or in the `cbcd4d552b` / `44ae15eef6` / `04ec111c88` Maven fixes; those commits are pre-existing on every passing run as well.

## Expected Behavior

Pass `timeout: 10 * 60 * 1000` to the two `--no-batch` `runCLI` calls in `e2e/maven/src/maven.test.ts` (the `app:install` case at line 51 and the `app:mvn-compile` case in `should support targetNamePrefix option` at line 121). That gives both calls 5 extra minutes of slack, well clear of the observed 220–290s range, while leaving everything else (including all four other `e2e-maven` test files, which already use `--batch` and are fast) unchanged.

This is the smallest possible fix that addresses the actual root cause (timeout headroom on the slowest run-shape we ship). It is not a workaround for a regression — there is nothing to revert.

## Why not just speed it up?

A real perf fix is possible (e.g. a single batched `mvn` invocation for the lifecycle expansion) but is out of scope for a flake fix. This change only widens the timeout for the two known slow `--no-batch` calls; everything else is untouched.

## Related Issue(s)

N/A — internal CI flake.
