### PR TITLE
chore(repo): provision build toolchain via mise in publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -130,6 +130,7 @@ jobs:
           - host: windows-latest
             setup: |-
               choco install openjdk --version=21.0.0 -y
+              choco install dotnet-9.0-sdk -y
               rustup target add aarch64-pc-windows-msvc
             build: |
               export JAVA_HOME="C:\Program Files\OpenJDK\jdk-21"
@@ -148,22 +149,23 @@ jobs:
             build: |
               set -e
               apt-get update
+              apt-get install -y curl ca-certificates git xz-utils gpg
 
-              # Install Java 21
-              apt-get install -y openjdk-21-jdk
-              export JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
-              export PATH="$JAVA_HOME/bin:$PATH"
-              java --version
+              # Install mise from the signed apt repo
+              install -dm 755 /etc/apt/keyrings
+              curl -fsSL https://mise.jdx.dev/gpg-key.pub | gpg --dearmor -o /etc/apt/keyrings/mise-archive-keyring.gpg
+              echo "deb [signed-by=/etc/apt/keyrings/mise-archive-keyring.gpg arch=$(dpkg --print-architecture)] https://mise.jdx.dev/deb stable main" > /etc/apt/sources.list.d/mise.list
+              apt-get update
+              apt-get install -y mise
 
-              curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
-              apt-get install -y nodejs=22.16.0-1nodesource1
+              # Provision Node, Java, .NET, Maven, corepack from mise.toml
+              cd /build
+              mise trust mise.toml
+              mise install
+              eval "$(mise env -s bash)"
 
-              export PATH="/usr/local/bin:$PATH"
-              node --version
-              npm --version
-
-              npm i -g pnpm@${PNPM_VERSION} --force
-              pnpm --version
+              corepack enable
+              corepack prepare --activate
 
               pnpm install --frozen-lockfile
               rustup target add x86_64-unknown-linux-gnu
@@ -175,31 +177,21 @@ jobs:
               bash -c "
                 set -e
                 echo 'https://dl-cdn.alpinelinux.org/alpine/edge/community' >> /etc/apk/repositories
-                apk add --no-cache curl xz openjdk21 build-base lld
-
-                # Set up Java 21
-                export JAVA_HOME=/usr/lib/jvm/java-21-openjdk
-                export PATH=\"\$JAVA_HOME/bin:\$PATH\"
-                java --version
-
-                curl -fsSL https://unofficial-builds.nodejs.org/download/release/v22.16.0/node-v22.16.0-linux-x64-musl.tar.xz -o node.tar.xz
-                tar -xJf node.tar.xz
-                mv node-v22.16.0-linux-x64-musl /usr/local/node
-
-                export PATH=\"/usr/local/node/bin:\$PATH\"
-
-                echo Node: \$(node -v)
-                echo NPM: \$(npm -v)
-
-                # Install PNPM
-                npm i -g pnpm@${PNPM_VERSION} --force
-                pnpm --version
+                apk add --no-cache curl ca-certificates git xz build-base lld mise
 
                 # Help clang find GCC runtime (crtbeginS.o, libgcc) and use lld for jemalloc build
                 GCC_DIR=\$(dirname \$(find /usr/lib/gcc -name crtbeginS.o | head -1))
                 export CFLAGS=\"\${CFLAGS} -fuse-ld=lld --gcc-install-dir=\${GCC_DIR}\"
 
-                # Install deps and run native build
+                # Provision Node, Java, .NET, Maven, corepack from mise.toml
+                cd /build
+                mise trust mise.toml
+                mise install
+                eval \"\$(mise env -s bash)\"
+
+                corepack enable
+                corepack prepare --activate
+
                 pnpm install --frozen-lockfile
                 rustup target add x86_64-unknown-linux-musl
                 pnpm nx run-many --verbose --target=build-native -- --target=x86_64-unknown-linux-musl
@@ -221,19 +213,20 @@ jobs:
             build: |
               set -e
               apt-get update
+              apt-get install -y curl ca-certificates git xz-utils gpg
 
-              # Install Java 21
-              apt-get install -y openjdk-21-jdk
-              export JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64
-              export PATH="$JAVA_HOME/bin:$PATH"
-              java --version
+              # Install mise from the signed apt repo
+              install -dm 755 /etc/apt/keyrings
+              curl -fsSL https://mise.jdx.dev/gpg-key.pub | gpg --dearmor -o /etc/apt/keyrings/mise-archive-keyring.gpg
+              echo "deb [signed-by=/etc/apt/keyrings/mise-archive-keyring.gpg arch=$(dpkg --print-architecture)] https://mise.jdx.dev/deb stable main" > /etc/apt/sources.list.d/mise.list
+              apt-get update
+              apt-get install -y mise
 
-              curl -fsSL https://deb.nodesource.com/setup_22.x | bash -
-              apt-get install -y nodejs=22.16.0-1nodesource1
-
-              export PATH="/usr/local/bin:$PATH"
-              node --version
-              npm --version
+              # Provision Node, Java, .NET, Maven, corepack from mise.toml
+              cd /build
+              mise trust mise.toml
+              mise install
+              eval "$(mise env -s bash)"
 
               # Help clang find GCC runtime (crtbeginS.o, libgcc) and use lld for jemalloc build
               export CFLAGS="${CFLAGS} -fuse-ld=lld --gcc-toolchain=/usr/aarch64-unknown-linux-gnu"
@@ -242,8 +235,8 @@ jobs:
               # Linux kernels with 4K/16K/64K pages (Asahi, Ampere, Graviton, etc.).
               export JEMALLOC_SYS_WITH_LG_PAGE=16
 
-              npm i -g pnpm@${PNPM_VERSION} --force
-              pnpm --version
+              corepack enable
+              corepack prepare --activate
 
               pnpm install --frozen-lockfile
               rustup target add aarch64-unknown-linux-gnu
@@ -272,25 +265,7 @@ jobs:
               bash -c "
                 set -e
                 echo 'https://dl-cdn.alpinelinux.org/alpine/edge/community' >> /etc/apk/repositories
-                apk add --no-cache curl xz openjdk21 build-base lld
-
-                # Set up Java 21
-                export JAVA_HOME=/usr/lib/jvm/java-21-openjdk
-                export PATH=\"\$JAVA_HOME/bin:\$PATH\"
-                java --version
-
-                curl -fsSL https://unofficial-builds.nodejs.org/download/release/v22.16.0/node-v22.16.0-linux-x64-musl.tar.xz -o node.tar.xz
-                tar -xJf node.tar.xz
-                mv node-v22.16.0-linux-x64-musl /usr/local/node
-
-                export PATH=\"/usr/local/node/bin:\$PATH\"
-
-                echo Node: \$(node -v)
-                echo NPM: \$(npm -v)
-
-                # Install PNPM
-                npm i -g pnpm@${PNPM_VERSION} --force
-                pnpm --version
+                apk add --no-cache curl ca-certificates git xz build-base lld mise
 
                 # Help clang find GCC runtime (crtbeginS.o, libgcc) and use lld for jemalloc build
                 GCC_DIR=\$(dirname \$(find /aarch64-linux-musl-cross/lib/gcc -name crtbeginS.o | head -1))
@@ -300,7 +275,15 @@ jobs:
                 # Linux kernels with 4K/16K/64K pages (Asahi, Ampere, Graviton, etc.).
                 export JEMALLOC_SYS_WITH_LG_PAGE=16
 
-                # Install deps and run native build
+                # Provision Node, Java, .NET, Maven, corepack from mise.toml
+                cd /build
+                mise trust mise.toml
+                mise install
+                eval \"\$(mise env -s bash)\"
+
+                corepack enable
+                corepack prepare --activate
+
                 pnpm install --frozen-lockfile
                 rustup target add aarch64-unknown-linux-musl
                 pnpm nx run-many --verbose --target=build-native -- --target=aarch64-unknown-linux-musl
@@ -309,6 +292,7 @@ jobs:
             target: aarch64-pc-windows-msvc
             setup: |-
               choco install openjdk --version=21.0.0 -y
+              choco install dotnet-9.0-sdk -y
               rustup target add aarch64-pc-windows-msvc
             build: |
               export JAVA_HOME="C:\Program Files\OpenJDK\jdk-21"
@@ -387,6 +371,7 @@ jobs:
           echo "$BUILD_SCRIPT" > "$SCRIPT_FILE"
           docker run --rm \
             --user 0:0 \
+            -e NODE_VERSION \
             -e PNPM_VERSION \
             -e NX_GRADLE_PROJECT_GRAPH_TIMEOUT \
             -e NX_VERBOSE_LOGGING \
@@ -435,12 +420,13 @@ jobs:
           PLAYWRIGHT_BROWSERS_PATH: 0
           NODE_VERSION: 22.16.0
           NX_GRADLE_DISABLE: 'true'
+          NX_DOTNET_DISABLE: 'true'
           NODE_OPTIONS: '--max-old-space-size=4096'
         with:
           operating_system: freebsd
           version: '14.0'
           architecture: x86-64
-          environment_variables: DEBUG RUSTUP_IO_THREADS CI NX_PREFER_TS_NODE PLAYWRIGHT_BROWSERS_PATH NODE_VERSION NX_GRADLE_DISABLE NODE_OPTIONS
+          environment_variables: DEBUG RUSTUP_IO_THREADS CI NX_PREFER_TS_NODE PLAYWRIGHT_BROWSERS_PATH NODE_VERSION NX_GRADLE_DISABLE NX_DOTNET_DISABLE NODE_OPTIONS
           shell: bash
           run: |
             env

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -176,21 +176,31 @@ jobs:
             build: |
               bash -c "
                 set -e
+                # mise's core node/java backends don't ship musl binaries and fall back to
+                # compile-from-source on Alpine, which fails. Install via apk + tarball instead.
                 echo 'https://dl-cdn.alpinelinux.org/alpine/edge/community' >> /etc/apk/repositories
-                apk add --no-cache curl ca-certificates git xz build-base lld mise
+                apk add --no-cache curl xz openjdk21 build-base lld dotnet9-sdk
+
+                # Java 21
+                export JAVA_HOME=/usr/lib/jvm/java-21-openjdk
+                export PATH=\"\$JAVA_HOME/bin:\$PATH\"
+                java --version
+
+                # .NET 9 SDK (needed by @nx/dotnet plugin)
+                dotnet --version
+
+                # Node.js musl build from unofficial-builds.nodejs.org
+                curl -fsSL https://unofficial-builds.nodejs.org/download/release/v22.16.0/node-v22.16.0-linux-x64-musl.tar.xz -o node.tar.xz
+                tar -xJf node.tar.xz
+                mv node-v22.16.0-linux-x64-musl /usr/local/node
+                export PATH=\"/usr/local/node/bin:\$PATH\"
+                node --version
+
+                npm i -g pnpm@\${PNPM_VERSION} --force
 
                 # Help clang find GCC runtime (crtbeginS.o, libgcc) and use lld for jemalloc build
                 GCC_DIR=\$(dirname \$(find /usr/lib/gcc -name crtbeginS.o | head -1))
                 export CFLAGS=\"\${CFLAGS} -fuse-ld=lld --gcc-install-dir=\${GCC_DIR}\"
-
-                # Provision Node, Java, .NET, Maven, corepack from mise.toml
-                cd /build
-                mise trust mise.toml
-                mise install
-                eval \"\$(mise env -s bash)\"
-
-                corepack enable
-                corepack prepare --activate
 
                 pnpm install --frozen-lockfile
                 rustup target add x86_64-unknown-linux-musl
@@ -264,8 +274,29 @@ jobs:
             build: |
               bash -c "
                 set -e
+                # mise's core node/java backends don't ship musl binaries and fall back to
+                # compile-from-source on Alpine, which fails. Install via apk + tarball instead.
                 echo 'https://dl-cdn.alpinelinux.org/alpine/edge/community' >> /etc/apk/repositories
-                apk add --no-cache curl ca-certificates git xz build-base lld mise
+                apk add --no-cache curl xz openjdk21 build-base lld dotnet9-sdk
+
+                # Java 21
+                export JAVA_HOME=/usr/lib/jvm/java-21-openjdk
+                export PATH=\"\$JAVA_HOME/bin:\$PATH\"
+                java --version
+
+                # .NET 9 SDK (needed by @nx/dotnet plugin)
+                dotnet --version
+
+                # Node.js musl build from unofficial-builds.nodejs.org. Container is x64;
+                # rust cross-compiles to aarch64-unknown-linux-musl, so the host node binary
+                # is x64-musl regardless of the build target.
+                curl -fsSL https://unofficial-builds.nodejs.org/download/release/v22.16.0/node-v22.16.0-linux-x64-musl.tar.xz -o node.tar.xz
+                tar -xJf node.tar.xz
+                mv node-v22.16.0-linux-x64-musl /usr/local/node
+                export PATH=\"/usr/local/node/bin:\$PATH\"
+                node --version
+
+                npm i -g pnpm@\${PNPM_VERSION} --force
 
                 # Help clang find GCC runtime (crtbeginS.o, libgcc) and use lld for jemalloc build
                 GCC_DIR=\$(dirname \$(find /aarch64-linux-musl-cross/lib/gcc -name crtbeginS.o | head -1))
@@ -274,15 +305,6 @@ jobs:
                 # Build jemalloc with 64 KiB allocator page so the binary works on aarch64
                 # Linux kernels with 4K/16K/64K pages (Asahi, Ampere, Graviton, etc.).
                 export JEMALLOC_SYS_WITH_LG_PAGE=16
-
-                # Provision Node, Java, .NET, Maven, corepack from mise.toml
-                cd /build
-                mise trust mise.toml
-                mise install
-                eval \"\$(mise env -s bash)\"
-
-                corepack enable
-                corepack prepare --activate
 
                 pnpm install --frozen-lockfile
                 rustup target add aarch64-unknown-linux-musl

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -354,11 +354,6 @@ jobs:
             target/
           key: ${{ matrix.settings.target }}-cargo-registry
 
-      - uses: goto-bus-stop/setup-zig@abea47f85e598557f500fa1fd2ab7464fcb39406 # v2.2.1
-        if: ${{ matrix.settings.target == 'armv7-unknown-linux-gnueabihf' }}
-        with:
-          version: 0.10.0
-
       - name: Setup toolchain
         run: ${{ matrix.settings.setup }}
         if: ${{ matrix.settings.setup }}


### PR DESCRIPTION
## Current Behavior

The `publish` workflow's matrix builds (Linux/macOS/Windows native binaries via N-API) install Java, Node.js, and pnpm manually inside each runner/container. With `@nx/dotnet` now in `nx.json`, these builds also need .NET to be available before the project graph can be loaded — and there's no .NET install on any of the matrix entries today, so the workflow fails at the `pnpm nx run-many --target=build-native` step.

The macOS and `armv7-unknown-linux-gnueabihf` matrix entries already use `mise-action` and `mise.toml`, but the four Linux *docker* entries (Debian + Alpine, x64 + arm64) bypass mise entirely and provision tools through hand-rolled `apt-get` / `apk` / `nodesource` / `npm i -g pnpm` steps.

## Expected Behavior

- All four Linux docker matrix entries now install `mise` from a signed/distro source (apt repo at `https://mise.jdx.dev/deb` for Debian, `apk add mise` from Alpine `community` for Alpine) and provision their entire toolchain — Node.js, Java, .NET, Maven, corepack — from `mise.toml`. This drops ~30 lines of bespoke install logic per entry and keeps versions in lockstep with the non-docker matrix entries, which already use `mise-action`.
- Windows entries gain `choco install dotnet-9.0-sdk -y` alongside the existing OpenJDK install (mise's Windows .NET path is broken upstream — see [jdx/mise#4738](https://github.com/jdx/mise/discussions/4738)).
- The FreeBSD build sets `NX_DOTNET_DISABLE=true` (added to both the `env:` block and the `cross-platform-actions/action` `environment_variables` allowlist so the var actually crosses into the FreeBSD VM) to opt out of the plugin entirely.
- `NODE_VERSION` is now forwarded into `docker run` so containers honor the workflow's pinned Node version through `mise.toml`'s tera template instead of falling back to its `24.11.0` default.
- `mise` itself is installed only via signed repositories — no `curl https://mise.run | sh` — so a hijacked DNS lookup against `mise.run` cannot drop a malicious script into our publish pipeline.

## Related Issue(s)

N/A — workflow fix triggered by `@nx/dotnet` being added to `nx.json`.