### PR TITLE
fix(core): skip handleimport miss path when nx key packages are absent

### DIFF
--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -28,7 +28,11 @@ import { NxArgs } from '../utils/command-line-utils';
 import { handleErrors } from '../utils/handle-errors';
 import { isCI } from '../utils/is-ci';
 import { isNxCloudDisabled, isNxCloudUsed } from '../utils/nx-cloud-utils';
-import { printNxKey } from '../utils/nx-key';
+import { logger } from '../utils/logger';
+import {
+  createNxKeyLicenseeInformation,
+  getNxKeyInformation,
+} from '../utils/nx-key';
 import { output } from '../utils/output';
 import {
   collectEnabledTaskSyncGeneratorsFromTaskGraph,
@@ -505,6 +509,11 @@ export async function runCommandForTasks(
   extraTargetDependencies: Record<string, (TargetDependencyConfig | string)[]>,
   extraOptions: { excludeTaskDependencies: boolean; loadDotEnvFiles: boolean }
 ): Promise<{ taskResults: TaskResults; completed: boolean }> {
+  // Kick off the license lookup in the background so it overlaps with task
+  // execution. The log itself is deferred to the print site below so it
+  // never lands in the middle of task output.
+  const nxKeyPromise = getNxKeyInformation().catch(() => null);
+
   const projectNames = projectsToRun.map((t) => t.name);
   const projectNameSet = new Set(projectNames);
 
@@ -559,7 +568,8 @@ export async function runCommandForTasks(
 
     await printConfigureAiAgentsDisclaimer();
 
-    await printNxKey();
+    const nxKey = await nxKeyPromise;
+    if (nxKey) logger.log(createNxKeyLicenseeInformation(nxKey));
 
     return {
       taskResults,

--- a/packages/nx/src/utils/nx-key.ts
+++ b/packages/nx/src/utils/nx-key.ts
@@ -1,5 +1,4 @@
 import { getNxRequirePaths } from './installation-directory';
-import { logger } from './logger';
 import { getPackageManagerCommand } from './package-manager';
 import { workspaceRoot } from './workspace-root';
 import type { NxKey } from '@nx/key';
@@ -16,15 +15,6 @@ export function createNxKeyLicenseeInformation(nxKey: NxKey) {
   } else {
     return `Licensed to ${nxKey.organizationName}.`;
   }
-}
-
-export async function printNxKey() {
-  try {
-    const key = await getNxKeyInformation();
-    if (key) {
-      logger.log(createNxKeyLicenseeInformation(key));
-    }
-  } catch {}
 }
 
 // `await handleImport` walks node_modules and pays ~25ms per miss; `resolve`

--- a/packages/nx/src/utils/nx-key.ts
+++ b/packages/nx/src/utils/nx-key.ts
@@ -1,3 +1,4 @@
+import { getNxRequirePaths } from './installation-directory';
 import { logger } from './logger';
 import { getPackageManagerCommand } from './package-manager';
 import { workspaceRoot } from './workspace-root';
@@ -30,7 +31,7 @@ export async function printNxKey() {
 // is just the filesystem lookup and is microseconds when the package is absent.
 function packageInstalled(name: string): boolean {
   try {
-    require.resolve(name, { paths: [workspaceRoot] });
+    require.resolve(name, { paths: getNxRequirePaths() });
     return true;
   } catch {
     return false;

--- a/packages/nx/src/utils/nx-key.ts
+++ b/packages/nx/src/utils/nx-key.ts
@@ -38,6 +38,10 @@ function packageInstalled(name: string): boolean {
 }
 
 export async function getNxKeyInformation(): Promise<NxKey | null> {
+  if (packageInstalled('@nx/key')) {
+    const { getNxKeyInformationAsync } = await import('@nx/key');
+    return getNxKeyInformationAsync(workspaceRoot);
+  }
   if (packageInstalled('@nx/powerpack-license')) {
     const {
       getPowerpackLicenseInformation,
@@ -46,10 +50,6 @@ export async function getNxKeyInformation(): Promise<NxKey | null> {
     return (
       getPowerpackLicenseInformationAsync ?? getPowerpackLicenseInformation
     )(workspaceRoot);
-  }
-  if (packageInstalled('@nx/key')) {
-    const { getNxKeyInformationAsync } = await import('@nx/key');
-    return getNxKeyInformationAsync(workspaceRoot);
   }
   throw new NxKeyNotInstalledError(new Error('MODULE_NOT_FOUND'));
 }

--- a/packages/nx/src/utils/nx-key.ts
+++ b/packages/nx/src/utils/nx-key.ts
@@ -1,7 +1,6 @@
 import { logger } from './logger';
 import { getPackageManagerCommand } from './package-manager';
 import { workspaceRoot } from './workspace-root';
-import { handleImport } from './handle-import';
 import type { NxKey } from '@nx/key';
 
 export function createNxKeyLicenseeInformation(nxKey: NxKey) {
@@ -27,30 +26,32 @@ export async function printNxKey() {
   } catch {}
 }
 
-export async function getNxKeyInformation(): Promise<NxKey | null> {
+// `await handleImport` walks node_modules and pays ~25ms per miss; `resolve`
+// is just the filesystem lookup and is microseconds when the package is absent.
+function packageInstalled(name: string): boolean {
   try {
+    require.resolve(name, { paths: [workspaceRoot] });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export async function getNxKeyInformation(): Promise<NxKey | null> {
+  if (packageInstalled('@nx/powerpack-license')) {
     const {
       getPowerpackLicenseInformation,
       getPowerpackLicenseInformationAsync,
-    } = (await handleImport(
-      '@nx/powerpack-license'
-    )) as typeof import('@nx/powerpack-license');
+    } = await import('@nx/powerpack-license');
     return (
       getPowerpackLicenseInformationAsync ?? getPowerpackLicenseInformation
     )(workspaceRoot);
-  } catch (e) {
-    try {
-      const { getNxKeyInformationAsync } = (await handleImport(
-        '@nx/key'
-      )) as typeof import('@nx/key');
-      return getNxKeyInformationAsync(workspaceRoot);
-    } catch (e) {
-      if ('code' in e && e.code === 'MODULE_NOT_FOUND') {
-        throw new NxKeyNotInstalledError(e);
-      }
-      throw e;
-    }
   }
+  if (packageInstalled('@nx/key')) {
+    const { getNxKeyInformationAsync } = await import('@nx/key');
+    return getNxKeyInformationAsync(workspaceRoot);
+  }
+  throw new NxKeyNotInstalledError(new Error('MODULE_NOT_FOUND'));
 }
 
 export class NxKeyNotInstalledError extends Error {

--- a/packages/nx/src/utils/nx-key.ts
+++ b/packages/nx/src/utils/nx-key.ts
@@ -19,12 +19,15 @@ export function createNxKeyLicenseeInformation(nxKey: NxKey) {
 
 // `await handleImport` walks node_modules and pays ~25ms per miss; `resolve`
 // is just the filesystem lookup and is microseconds when the package is absent.
+// Only treat MODULE_NOT_FOUND as "not installed" so unrelated errors (permission,
+// corrupt package.json, etc.) still surface instead of being silently hidden.
 function packageInstalled(name: string): boolean {
   try {
     require.resolve(name, { paths: getNxRequirePaths() });
     return true;
-  } catch {
-    return false;
+  } catch (e: any) {
+    if (e?.code === 'MODULE_NOT_FOUND') return false;
+    throw e;
   }
 }
 


### PR DESCRIPTION
## Current Behavior

\`printNxKey()\` runs at the end of every \`nx run-many\` / \`nx run\` invocation. It calls \`handleImport('@nx/powerpack-license')\` and \`handleImport('@nx/key')\` to dynamically discover whichever optional license package the workspace has installed. When neither package is installed (the common case for OSS users), both calls walk \`node_modules\` and miss, costing roughly 50 ms per nx command.

## Expected Behavior

Cheaply probe whether either package is resolvable from the workspace root (\`require.resolve(name, { paths: [workspaceRoot] })\`) before attempting the dynamic import. The probe is microseconds when the package is absent, so the wasted ~50 ms goes away.

While here, kick the lookup off at the very top of \`runCommandForTasks\` so it overlaps with task execution, and split the log out to the existing late call site so output ordering is unchanged — the licensee line still lands after task output, never mid-task.

Measured on a hot-cache \`run-many --parallel 10\` over 5 next.js apps:

|        | median wall time |
| ------ | ---------------- |
| before | 350 ms           |
| after  | 310 ms           |

## Related Issue(s)

Fixes #