### PR TITLE
fix(release): restore packages/devkit/package.json after release

### DIFF
--- a/.claude/skills/dist-build-migration/SKILL.md
+++ b/.claude/skills/dist-build-migration/SKILL.md
@@ -235,7 +235,11 @@ For example, `devkit-generation.ts` had to be updated to look for `packages/devk
 
 ### 13. Update `scripts/nx-release.ts`
 
-If the package has special release handling in `scripts/nx-release.ts` (like devkit's `hackFixForDevkitPeerDependencies`), update any paths from `./dist/packages/<name>/` to `./packages/<name>/`.
+Two things to do here:
+
+1. **Add the package to `packagesToReset`.** That array (around `scripts/nx-release.ts:76`) is the snapshot/restore list — every package whose source `package.json` gets mutated by `nx release` (because it now publishes from `packages/<name>/` directly, not `dist/packages/<name>/`) must be in this list. Otherwise the release will leave `packages/<name>/package.json` dirty in the working tree after running. **Easy to forget — and there is no test that catches it.**
+
+2. **Update any package-specific paths.** If the package has special release handling (like devkit's `hackFixForDevkitPeerDependencies`), update any paths from `./dist/packages/<name>/` to `./packages/<name>/`.
 
 ### 14. Update imports across the workspace
 

--- a/scripts/nx-release.ts
+++ b/scripts/nx-release.ts
@@ -76,6 +76,7 @@ const VALID_AUTHORS_FOR_LATEST = [
   const packagesToReset = [
     'packages/angular-rspack',
     'packages/angular-rspack-compiler',
+    'packages/devkit',
     'packages/dotnet',
     'packages/maven',
     'packages/nx',


### PR DESCRIPTION
## Current Behavior

After running `nx-release` locally, `packages/devkit/package.json` is left modified in the working tree.

The `nx-release.ts` script snapshots and restores the source `package.json` for every package whose source folder is the publish root (so the temporary edits made during `nx release version` — real version, expanded `workspace:*` deps, etc. — don't leak into the working tree). The list of those packages lives in `packagesToReset` near the top of `scripts/nx-release.ts`.

When `@nx/devkit` was migrated to publish from its source folder in #34946, it was not added to that list, so its source `package.json` is no longer restored.

## Expected Behavior

`packages/devkit/package.json` is restored to its committed contents after `nx-release` finishes (or is interrupted), matching the behavior already in place for `nx`, `dotnet`, `maven`, `angular-rspack`, and `angular-rspack-compiler`.

## Related Issue(s)

N/A — internal release-tooling fix.