### PR TITLE
fix(core): use gethostuuid(3) instead of ioreg on macOS

### DIFF
--- a/packages/nx/Cargo.toml
+++ b/packages/nx/Cargo.toml
@@ -85,6 +85,9 @@ winres = "0.1"
 [target.'cfg(any(target_os = "linux", target_os = "macos"))'.dependencies]
 tikv-jemallocator = { version = "0.6", features = ["disable_initial_exec_tls"] }
 
+[target.'cfg(target_os = "macos")'.dependencies]
+uuid = "1"
+
 [target.'cfg(all(not(windows), not(target_family = "wasm")))'.dependencies]
 mio = "1.0"
 nix = { version = "0.30.0", features = ["fs", "process", "signal"] }

--- a/packages/nx/src/native/machine_id/mod.rs
+++ b/packages/nx/src/native/machine_id/mod.rs
@@ -1,5 +1,43 @@
+/// Returns the system UUID via the BSD `gethostuuid(3)` syscall.
+/// This is the same value `ioreg -c IOPlatformExpertDevice` prints,
+/// but ~9000× faster (~10µs vs ~90ms) since it skips the subprocess.
+#[cfg(target_os = "macos")]
+fn macos_host_uuid() -> Option<String> {
+    use std::os::raw::c_int;
+
+    #[repr(C)]
+    struct Timespec {
+        tv_sec: i64,
+        tv_nsec: i64,
+    }
+
+    unsafe extern "C" {
+        fn gethostuuid(id: *mut u8, wait: *const Timespec) -> c_int;
+    }
+
+    let mut uuid = [0u8; 16];
+    let wait = Timespec {
+        tv_sec: 0,
+        tv_nsec: 0,
+    };
+    if unsafe { gethostuuid(uuid.as_mut_ptr(), &wait) } != 0 {
+        return None;
+    }
+    Some(
+        uuid::Uuid::from_bytes(uuid)
+            .hyphenated()
+            .to_string()
+            .to_uppercase(),
+    )
+}
+
 #[cfg_attr(target_arch = "wasm32", allow(dead_code))]
 pub fn get_machine_id() -> String {
+    #[cfg(target_os = "macos")]
+    if let Some(s) = macos_host_uuid() {
+        return s;
+    }
+
     #[cfg(not(target_arch = "wasm32"))]
     return machine_uid::get().unwrap_or(String::from("machine"));
 
@@ -29,5 +67,40 @@ pub fn get_machine_id() -> String {
                 .unwrap_or(String::from("machine"))
                 .as_bytes(),
         )
+    }
+}
+
+#[cfg(all(test, target_os = "macos"))]
+mod tests {
+    use super::*;
+
+    /// Confirm that the syscall-backed `macos_host_uuid()` returns the exact
+    /// same string `ioreg` does — same value, same hyphenation, same casing.
+    /// If this drifts the workspace DB filename would diverge from existing
+    /// caches, so this is a behavioral guarantee, not a perf claim.
+    #[test]
+    fn macos_host_uuid_matches_ioreg() {
+        use std::process::Command;
+
+        let output = Command::new("ioreg")
+            .args(["-rd1", "-c", "IOPlatformExpertDevice"])
+            .output()
+            .expect("ioreg invocation failed");
+        assert!(output.status.success(), "ioreg returned non-zero");
+
+        let stdout = String::from_utf8(output.stdout).expect("ioreg output not UTF-8");
+        let from_ioreg = stdout
+            .lines()
+            .find(|l| l.contains("IOPlatformUUID"))
+            .and_then(|l| l.split('"').nth(3))
+            .expect("IOPlatformUUID line not found")
+            .to_string();
+
+        let from_syscall = macos_host_uuid().expect("gethostuuid failed");
+
+        assert_eq!(
+            from_syscall, from_ioreg,
+            "gethostuuid drifted from ioreg's IOPlatformUUID"
+        );
     }
 }


### PR DESCRIPTION
## Current Behavior

`get_machine_id()` is invoked from `connect_to_nx_db()` to derive the workspace DB filename, so every `nx` invocation hits it. On macOS the underlying `machine_uid::get()` shells out to `ioreg -rd1 -c IOPlatformExpertDevice` and parses its output. The fork+exec, dyld, code-signature verification, and IOKit framework init together cost **~90ms per call**, and the result is identical for every run on the same machine.

## Expected Behavior

Use `libc::gethostuuid(3)` on macOS, which is the BSD syscall the same kernel data is fronted by. It returns the same 16-byte `uuid_t` that `ioreg` prints — bit-for-bit identical, same hyphenation, same casing — but in **~10µs** (about 9000× faster) because it skips the subprocess entirely.

```
ioreg:        398DA1D5-608C-58D6-BA32-FAE0E01A0ED3
gethostuuid:  398DA1D5-608C-58D6-BA32-FAE0E01A0ED3
```

Other platforms are untouched: `machine_uid::get()` already uses fast direct file/registry reads on Linux and Windows; only macOS was paying the subprocess tax.

Measured on a hot-cache `run-many --parallel 10` over 5 next.js apps:

|        | median wall time |
| ------ | ---------------- |
| before | 290 ms           |
| after  | 200 ms           |

## Related Issue(s)

Fixes #