### PR TITLE
chore(repo): use apt mirror+file failover for ubuntu sources

### DIFF
--- a/.nx/workflows/agents.yaml
+++ b/.nx/workflows/agents.yaml
@@ -36,12 +36,16 @@ common-init-steps: &common-init-steps
 
   - name: Install system deps
     script: |
-      # archive.ubuntu.com periodically serves a Packages.gz that doesn't
-      # match its own InRelease metadata while the canonical mirror is
-      # mid-sync, breaking apt-get update across all agents at once.
-      # Azure's mirror has a better SLA and is what GitHub Actions runners use.
+      # Prefer Azure's mirror because the canonical archive.ubuntu.com periodically
+      # serves a Packages.gz that doesn't match its own InRelease metadata while
+      # mid-sync. Fall back to the canonical mirror if Azure is unreachable, since
+      # connectivity to Azure's mirror has itself been flaky.
       sudo sed -i 's|http://archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g; s|http://security.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list
-      sudo apt-get update
+      if ! sudo apt-get update -o Acquire::http::Timeout=15 -o Acquire::Retries=2; then
+        echo "Azure mirror unreachable, falling back to canonical archive.ubuntu.com"
+        sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list
+        sudo apt-get update
+      fi
       sudo apt-get install -y ca-certificates lsof libvips-dev libglib2.0-dev libgirepository1.0-dev zip unzip
 
   - name: Pnpm Install from lockfile

--- a/.nx/workflows/agents.yaml
+++ b/.nx/workflows/agents.yaml
@@ -36,16 +36,18 @@ common-init-steps: &common-init-steps
 
   - name: Install system deps
     script: |
-      # Prefer Azure's mirror because the canonical archive.ubuntu.com periodically
-      # serves a Packages.gz that doesn't match its own InRelease metadata while
-      # mid-sync. Fall back to the canonical mirror if Azure is unreachable, since
-      # connectivity to Azure's mirror has itself been flaky.
-      sudo sed -i 's|http://archive.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g; s|http://security.ubuntu.com/ubuntu|http://azure.archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list
-      if ! sudo apt-get update -o Acquire::http::Timeout=15 -o Acquire::Retries=2; then
-        echo "Azure mirror unreachable, falling back to canonical archive.ubuntu.com"
-        sudo sed -i 's|http://azure.archive.ubuntu.com/ubuntu|http://archive.ubuntu.com/ubuntu|g' /etc/apt/sources.list
-        sudo apt-get update
-      fi
+      # apt mirror+file failover: tab-separated; printf preserves \t (YAML heredocs don't).
+      printf 'https://archive.ubuntu.com/ubuntu/\tpriority:1\n'       | sudo tee /etc/apt/apt-mirrors.txt > /dev/null
+      printf 'https://security.ubuntu.com/ubuntu/\tpriority:2\n'      | sudo tee -a /etc/apt/apt-mirrors.txt > /dev/null
+      printf 'http://azure.archive.ubuntu.com/ubuntu/\tpriority:3\n'  | sudo tee -a /etc/apt/apt-mirrors.txt > /dev/null
+      # Retries=0: mirror+file already retries via failover; apt-level retries multiply stall on a dead mirror.
+      sudo tee /etc/apt/apt.conf.d/80-nx-mirror-failover > /dev/null <<'EOF'
+      Acquire::http::Timeout "5";
+      Acquire::https::Timeout "5";
+      Acquire::Retries "0";
+      EOF
+      sudo sed -i 's|http://archive.ubuntu.com/ubuntu|mirror+file:/etc/apt/apt-mirrors.txt|g; s|http://security.ubuntu.com/ubuntu|mirror+file:/etc/apt/apt-mirrors.txt|g' /etc/apt/sources.list
+      sudo apt-get update
       sudo apt-get install -y ca-certificates lsof libvips-dev libglib2.0-dev libgirepository1.0-dev zip unzip
 
   - name: Pnpm Install from lockfile


### PR DESCRIPTION
## Current Behavior

The `Install system deps` step in `.nx/workflows/agents.yaml` rewrites `/etc/apt/sources.list` to point exclusively at `azure.archive.ubuntu.com`, then runs `apt-get update && apt-get install` for the system packages every Nx Agent needs (`ca-certificates`, `lsof`, `libvips-dev`, `libglib2.0-dev`, `libgirepository1.0-dev`, `zip`, `unzip`).

When Azure's Ubuntu mirror is unreachable from the agents — which started happening today — every pipeline fails on init with:

```
Could not connect to azure.archive.ubuntu.com:80, connection timed out
E: Unable to locate package lsof
E: Unable to locate package libvips-dev
E: Package 'libgirepository1.0-dev' has no installation candidate
```

The original switch to Azure's mirror was made because the canonical `archive.ubuntu.com` periodically serves a `Packages.gz` that doesn't match its own `InRelease` metadata while mid-sync. So the previous design traded one flaky upstream for another with no fallback between them.

## Expected Behavior

Use apt's native `mirror+file://` failover, configured the same way GitHub Actions runner-images sets up its hosted Ubuntu runners. A single `/etc/apt/apt-mirrors.txt` lists mirrors in priority order, and `sources.list` points at `mirror+file:/etc/apt/apt-mirrors.txt`. Apt itself handles priority ordering and transparent failover.

The mirror order in this PR (canonical first) was chosen based on what the diagnostic probes actually showed (see findings below):

```
https://archive.ubuntu.com/ubuntu/        priority:1
https://security.ubuntu.com/ubuntu/       priority:2
http://azure.archive.ubuntu.com/ubuntu/   priority:3
```

Plus a small apt config drop-in (`/etc/apt/apt.conf.d/80-nx-mirror-failover`) with:

- `Acquire::http::Timeout "5"` / `Acquire::https::Timeout "5"` — cap each per-fetch stall at 5s instead of the 120s default.
- `Acquire::Retries "0"` — mirror+file already provides retry-via-failover; apt-level retries on top multiplied the stall when Azure was consistently dead (60s × dozens of fetched files = double-digit minutes per agent boot).

## Investigation findings

We probed every mirror from three different vantage points to figure out what was actually broken:

| Mirror | From your laptop (residential) | From a GitHub-hosted runner (inside Azure) | From an Nx Agent (GCP) |
| --- | --- | --- | --- |
| `archive.ubuntu.com` (Cloudflare) | ✅ HTTP & HTTPS, sub-second | ✅ | ✅ HTTP & HTTPS, sub-second |
| `security.ubuntu.com` (Cloudflare) | ✅ HTTP & HTTPS, sub-second | ✅ | ✅ HTTP & HTTPS, sub-second |
| `azure.archive.ubuntu.com` HTTP (port 80) | ❌ TCP timeout | ✅ HTTP 200, fast | ❌ TCP timeout |
| `azure.archive.ubuntu.com` HTTPS (port 443) | ❌ TCP timeout | ❌ TCP timeout | ❌ TCP timeout |

Several things fall out of this:

1. **Azure mirror's HTTPS endpoint is broken in multiple regions** — even from inside Azure (the GitHub-hosted runner) port 443 times out. This is why we use `http://` for the Azure entry, matching GitHub's `configure-apt-sources.sh`.
2. **From our agents' GCP egress, both ports are unreachable** to the Azure mirror — TCP handshake never completes against `52.154.174.208` (centralus). This is a path-level issue between Google's network and Microsoft's edge for the geo-DNS region the agents resolve to.
3. **Canonical mirrors are fully healthy from every vantage point**, including from agents. Both are CDN-fronted by Cloudflare, which is why response times are consistent across networks.
4. **`azure.archive.ubuntu.com` is documented as publicly accessible** (Microsoft Q&A confirms) but historically flaky for non-Azure consumers — multiple Microsoft Q&A threads and a notable 2020 incident where the entire `pool/` disappeared. Treating it as best-effort rather than load-bearing matches what GitHub does.

That's why this PR puts Azure last instead of first. With mirror+file failover, apt tries `archive.ubuntu.com` first, succeeds in milliseconds, and never has to touch Azure. The 5s timeout and 0 retries make the worst case (canonical down + Azure has to be tried) bounded.

A "what about ocean?" datapoint: the ocean agents don't apply the Azure rewrite at all and have been working fine. This PR effectively converges on that behavior for normal operation while keeping the original mismatched-metadata-mid-sync escape hatch via Azure-as-fallback.

## Related Issue(s)

N/A — addresses ongoing CI flakiness from Azure mirror reachability issues.