### PR TITLE
chore(repo): exclude packages/nx/dist/src/native/*.node from sandbox reads

### DIFF
--- a/.nx/workflows/sandboxing-config.yaml
+++ b/.nx/workflows/sandboxing-config.yaml
@@ -1,5 +1,6 @@
 exclude-reads:
   - packages/nx/src/native/*.node
+  - packages/nx/dist/src/native/*.node
   - 'dist/target/**'
 exclude-writes:
   - '**/.swc/**'


### PR DESCRIPTION
## Current Behavior

Sandbox reads only exclude `packages/nx/src/native/*.node`. The native `.node` binary is also copied to `packages/nx/dist/src/native/` during the nx package build, and reads of that dist copy from other tasks show up as sandbox violations.

## Expected Behavior

Both the source and dist locations of the prebuilt native `.node` binary are excluded from sandbox read tracking.

## Related Issue(s)

N/A