### PR TITLE
feat(release): allow customizing dependent bump types via version.dependentBumpType

### DIFF
--- a/packages/nx/src/command-line/release/utils/release-graph.ts
+++ b/packages/nx/src/command-line/release/utils/release-graph.ts
@@ -46,6 +46,7 @@ export interface FinalConfigForProject {
   preserveMatchingDependencyRanges: NxReleaseVersionConfiguration['preserveMatchingDependencyRanges'];
   adjustSemverBumpsForZeroMajorVersion: NxReleaseVersionConfiguration['adjustSemverBumpsForZeroMajorVersion'];
   applyPreidToDependents: NxReleaseVersionConfiguration['applyPreidToDependents'];
+  dependentBumpType: NxReleaseVersionConfiguration['dependentBumpType'];
   versionActionsOptions: NxReleaseVersionConfiguration['versionActionsOptions'];
   manifestRootsToUpdate: Array<
     Exclude<
@@ -931,6 +932,17 @@ Valid values are: ${validReleaseVersionPrefixes
       false;
 
     /**
+     * dependentBumpType
+     *
+     * Controls the semver bump type applied to dependents when a dependency
+     * is versioned. Defaults to 'patch' for backward compatibility.
+     */
+    const dependentBumpType =
+      projectVersionConfig?.dependentBumpType ??
+      releaseGroupVersionConfig?.dependentBumpType ??
+      'patch';
+
+    /**
      * fallbackCurrentVersionResolver, defaults to disk when performing a first release, otherwise undefined
      */
     const fallbackCurrentVersionResolver =
@@ -976,6 +988,7 @@ Valid values are: ${validReleaseVersionPrefixes
       preserveMatchingDependencyRanges,
       adjustSemverBumpsForZeroMajorVersion,
       applyPreidToDependents,
+      dependentBumpType,
       versionActionsOptions,
       manifestRootsToUpdate,
       dockerOptions,

--- a/packages/nx/src/command-line/release/version/release-group-processor.spec.ts
+++ b/packages/nx/src/command-line/release/version/release-group-processor.spec.ts
@@ -1485,6 +1485,380 @@ describe('ReleaseGroupProcessor', () => {
     });
   });
 
+  describe('dependentBumpType', () => {
+    let processor: any;
+
+    afterEach(() => {
+      processor = null;
+    });
+
+    it('should default to patch bump for dependents (backward compatible)', async () => {
+      const { nxReleaseConfig, projectGraph, filters } =
+        await createNxReleaseConfigAndPopulateWorkspace(
+          tree,
+          `
+          __default__ ({ "projectsRelationship": "independent" }):
+            - projectA@1.0.0 [js]
+              -> depends on projectB
+            - projectB@2.0.0 [js]
+        `,
+          {
+            version: {
+              conventionalCommits: true,
+            },
+          },
+          mockResolveCurrentVersion
+        );
+
+      processor = await createTestReleaseGroupProcessor(
+        tree,
+        projectGraph,
+        nxReleaseConfig,
+        filters
+      );
+
+      mockDeriveSpecifierFromConventionalCommits.mockImplementation(
+        (_, __, ___, ____, { name: projectName }) => {
+          if (projectName === 'projectB') return 'major';
+          return 'none';
+        }
+      );
+      await processor.processGroups();
+
+      // projectA should be bumped by patch (default), not major
+      expect(readJson(tree, 'projectA/package.json')).toMatchInlineSnapshot(`
+        {
+          "dependencies": {
+            "projectB": "3.0.0",
+          },
+          "name": "projectA",
+          "version": "1.0.1",
+        }
+      `);
+
+      expect(readJson(tree, 'projectB/package.json')).toMatchInlineSnapshot(`
+        {
+          "name": "projectB",
+          "version": "3.0.0",
+        }
+      `);
+    });
+
+    it('should bump dependents by minor when dependentBumpType is "minor"', async () => {
+      const { nxReleaseConfig, projectGraph, filters } =
+        await createNxReleaseConfigAndPopulateWorkspace(
+          tree,
+          `
+          __default__ ({ "projectsRelationship": "independent" }):
+            - projectA@1.0.0 [js]
+              -> depends on projectB
+            - projectB@2.0.0 [js]
+        `,
+          {
+            version: {
+              conventionalCommits: true,
+              dependentBumpType: 'minor',
+            },
+          },
+          mockResolveCurrentVersion
+        );
+
+      processor = await createTestReleaseGroupProcessor(
+        tree,
+        projectGraph,
+        nxReleaseConfig,
+        filters
+      );
+
+      mockDeriveSpecifierFromConventionalCommits.mockImplementation(
+        (_, __, ___, ____, { name: projectName }) => {
+          if (projectName === 'projectB') return 'major';
+          return 'none';
+        }
+      );
+      await processor.processGroups();
+
+      // projectA should be bumped by minor
+      expect(readJson(tree, 'projectA/package.json')).toMatchInlineSnapshot(`
+        {
+          "dependencies": {
+            "projectB": "3.0.0",
+          },
+          "name": "projectA",
+          "version": "1.1.0",
+        }
+      `);
+    });
+
+    it('should bump dependents by major when dependentBumpType is "major"', async () => {
+      const { nxReleaseConfig, projectGraph, filters } =
+        await createNxReleaseConfigAndPopulateWorkspace(
+          tree,
+          `
+          __default__ ({ "projectsRelationship": "independent" }):
+            - projectA@1.0.0 [js]
+              -> depends on projectB
+            - projectB@2.0.0 [js]
+        `,
+          {
+            version: {
+              conventionalCommits: true,
+              dependentBumpType: 'major',
+            },
+          },
+          mockResolveCurrentVersion
+        );
+
+      processor = await createTestReleaseGroupProcessor(
+        tree,
+        projectGraph,
+        nxReleaseConfig,
+        filters
+      );
+
+      mockDeriveSpecifierFromConventionalCommits.mockImplementation(
+        (_, __, ___, ____, { name: projectName }) => {
+          if (projectName === 'projectB') return 'patch';
+          return 'none';
+        }
+      );
+      await processor.processGroups();
+
+      // projectA should be bumped by major
+      expect(readJson(tree, 'projectA/package.json')).toMatchInlineSnapshot(`
+        {
+          "dependencies": {
+            "projectB": "2.0.1",
+          },
+          "name": "projectA",
+          "version": "2.0.0",
+        }
+      `);
+    });
+
+    it('should match the dependency bump type when dependentBumpType is "match"', async () => {
+      const { nxReleaseConfig, projectGraph, filters } =
+        await createNxReleaseConfigAndPopulateWorkspace(
+          tree,
+          `
+          __default__ ({ "projectsRelationship": "independent" }):
+            - projectA@1.0.0 [js]
+              -> depends on projectB
+            - projectB@2.0.0 [js]
+        `,
+          {
+            version: {
+              conventionalCommits: true,
+              dependentBumpType: 'match',
+            },
+          },
+          mockResolveCurrentVersion
+        );
+
+      processor = await createTestReleaseGroupProcessor(
+        tree,
+        projectGraph,
+        nxReleaseConfig,
+        filters
+      );
+
+      mockDeriveSpecifierFromConventionalCommits.mockImplementation(
+        (_, __, ___, ____, { name: projectName }) => {
+          if (projectName === 'projectB') return 'minor';
+          return 'none';
+        }
+      );
+      await processor.processGroups();
+
+      // projectA should be bumped by minor (matching projectB's bump type)
+      expect(readJson(tree, 'projectA/package.json')).toMatchInlineSnapshot(`
+        {
+          "dependencies": {
+            "projectB": "2.1.0",
+          },
+          "name": "projectA",
+          "version": "1.1.0",
+        }
+      `);
+    });
+
+    it('should apply dependentBumpType across release groups with updateDependents "always"', async () => {
+      const { nxReleaseConfig, projectGraph, filters } =
+        await createNxReleaseConfigAndPopulateWorkspace(
+          tree,
+          `
+          group1 ({ "projectsRelationship": "independent" }):
+            - projectA@1.0.0 [js]
+              -> depends on projectB
+          group2 ({ "projectsRelationship": "independent" }):
+            - projectB@2.0.0 [js]
+        `,
+          {
+            version: {
+              conventionalCommits: true,
+              updateDependents: 'always',
+              dependentBumpType: 'minor',
+            },
+          },
+          mockResolveCurrentVersion
+        );
+
+      processor = await createTestReleaseGroupProcessor(
+        tree,
+        projectGraph,
+        nxReleaseConfig,
+        filters
+      );
+
+      mockDeriveSpecifierFromConventionalCommits.mockImplementation(
+        (_, __, ___, ____, { name: projectName }) => {
+          if (projectName === 'projectB') return 'major';
+          return 'none';
+        }
+      );
+      await processor.processGroups();
+
+      // projectA should be bumped by minor (not patch) across groups
+      expect(readJson(tree, 'projectA/package.json')).toMatchInlineSnapshot(`
+        {
+          "dependencies": {
+            "projectB": "3.0.0",
+          },
+          "name": "projectA",
+          "version": "1.1.0",
+        }
+      `);
+    });
+
+    it('should apply dependentBumpType with cascading dependencies', async () => {
+      const { nxReleaseConfig, projectGraph, filters } =
+        await createNxReleaseConfigAndPopulateWorkspace(
+          tree,
+          `
+          __default__ ({ "projectsRelationship": "independent" }):
+            - projectA@1.0.0 [js]
+              -> depends on projectB
+            - projectB@2.0.0 [js]
+              -> depends on projectC
+            - projectC@3.0.0 [js]
+        `,
+          {
+            version: {
+              conventionalCommits: true,
+              dependentBumpType: 'minor',
+            },
+          },
+          mockResolveCurrentVersion
+        );
+
+      processor = await createTestReleaseGroupProcessor(
+        tree,
+        projectGraph,
+        nxReleaseConfig,
+        filters
+      );
+
+      mockDeriveSpecifierFromConventionalCommits.mockImplementation(
+        (_, __, ___, ____, { name: projectName }) => {
+          if (projectName === 'projectC') return 'major';
+          return 'none';
+        }
+      );
+      await processor.processGroups();
+
+      // projectC bumped by major
+      expect(readJson(tree, 'projectC/package.json')).toMatchInlineSnapshot(`
+        {
+          "name": "projectC",
+          "version": "4.0.0",
+        }
+      `);
+      // projectB bumped by minor (dependentBumpType)
+      expect(readJson(tree, 'projectB/package.json')).toMatchInlineSnapshot(`
+        {
+          "dependencies": {
+            "projectC": "4.0.0",
+          },
+          "name": "projectB",
+          "version": "2.1.0",
+        }
+      `);
+      // projectA bumped by minor (cascading dependentBumpType)
+      expect(readJson(tree, 'projectA/package.json')).toMatchInlineSnapshot(`
+        {
+          "dependencies": {
+            "projectB": "2.1.0",
+          },
+          "name": "projectA",
+          "version": "1.1.0",
+        }
+      `);
+    });
+
+    it('should apply dependentBumpType in a fixed release group bumped by cross-group dependency', async () => {
+      const { nxReleaseConfig, projectGraph, filters } =
+        await createNxReleaseConfigAndPopulateWorkspace(
+          tree,
+          `
+          group1 ({ "projectsRelationship": "fixed" }):
+            - projectA@1.0.0 [js]
+              -> depends on projectC
+            - projectB@1.0.0 [js]
+          group2 ({ "projectsRelationship": "independent" }):
+            - projectC@2.0.0 [js]
+        `,
+          {
+            version: {
+              conventionalCommits: true,
+              updateDependents: 'always',
+              dependentBumpType: 'minor',
+            },
+          },
+          mockResolveCurrentVersion
+        );
+
+      processor = await createTestReleaseGroupProcessor(
+        tree,
+        projectGraph,
+        nxReleaseConfig,
+        filters
+      );
+
+      mockDeriveSpecifierFromConventionalCommits.mockImplementation(
+        (_, __, ___, ____, { name: projectName }) => {
+          if (projectName === 'projectC') return 'major';
+          return 'none';
+        }
+      );
+      await processor.processGroups();
+
+      // projectC bumped by major
+      expect(readJson(tree, 'projectC/package.json')).toMatchInlineSnapshot(`
+        {
+          "name": "projectC",
+          "version": "3.0.0",
+        }
+      `);
+      // projectA bumped by minor (dependentBumpType across groups)
+      expect(readJson(tree, 'projectA/package.json')).toMatchInlineSnapshot(`
+        {
+          "dependencies": {
+            "projectC": "3.0.0",
+          },
+          "name": "projectA",
+          "version": "1.1.0",
+        }
+      `);
+      // projectB also bumped by minor (fixed group, OTHER_PROJECT_IN_FIXED_GROUP_WAS_BUMPED_DUE_TO_DEPENDENCY)
+      expect(readJson(tree, 'projectB/package.json')).toMatchInlineSnapshot(`
+        {
+          "name": "projectB",
+          "version": "1.1.0",
+        }
+      `);
+    });
+  });
+
   /**
    * NOTE: Fundamental issues with filters, like trying to filter to a single project within a fixed release group,
    * will have already been caught and handled by the release graph construction, so that is not repeated here.

--- a/packages/nx/src/command-line/release/version/release-group-processor.ts
+++ b/packages/nx/src/command-line/release/version/release-group-processor.ts
@@ -404,9 +404,10 @@ export class ReleaseGroupProcessor {
         // Update all projects in topological order
         for (const project of sortedProjects) {
           if (!this.bumpedProjects.has(project)) {
+            const baseBump = this.resolveDependentBumpType(project, 'patch');
             await this.bumpVersionForProject(
               project,
-              this.applyPreidToBumpType('patch', project),
+              this.applyPreidToBumpType(baseBump, project),
               'OTHER_PROJECT_IN_FIXED_GROUP_WAS_BUMPED_DUE_TO_DEPENDENCY',
               {}
             );
@@ -892,9 +893,13 @@ export class ReleaseGroupProcessor {
 
       for (const dependent of dependentsToProcess) {
         if (!this.bumpedProjects.has(dependent)) {
+          const baseBump = this.resolveDependentBumpType(
+            dependent,
+            bumpType as SemverBumpType
+          );
           await this.bumpVersionForProject(
             dependent,
-            this.applyPreidToBumpType('patch', dependent),
+            this.applyPreidToBumpType(baseBump, dependent),
             'DEPENDENCY_WAS_BUMPED',
             {}
           );
@@ -955,15 +960,18 @@ export class ReleaseGroupProcessor {
       .newVersionInput;
   }
 
-  // TODO: Support influencing the side effect bump in a future version, always patch for now like in legacy versioning
   private determineSideEffectBump(
     releaseGroup: ReleaseGroupWithName,
     dependencyBumpType: SemverBumpType
   ): SemverBumpType {
-    // Any project in the group can be used to resolve the applyPreidToDependents
-    // setting, since it is a group/workspace level option.
+    // Any project in the group can be used to resolve the dependentBumpType
+    // and applyPreidToDependents settings, since they are group/workspace level options.
     const anyProject = releaseGroup.projects[0];
-    return this.applyPreidToBumpType('patch', anyProject);
+    const baseBump = this.resolveDependentBumpType(
+      anyProject,
+      dependencyBumpType
+    );
+    return this.applyPreidToBumpType(baseBump, anyProject);
   }
 
   /**
@@ -998,6 +1006,28 @@ export class ReleaseGroupProcessor {
       default:
         return bumpType;
     }
+  }
+
+  /**
+   * Resolves the base bump type to apply to a dependent project based on the
+   * configured dependentBumpType setting. When set to 'match', the bump type
+   * of the dependency that triggered the bump is used instead of a fixed type.
+   */
+  private resolveDependentBumpType(
+    projectName: string,
+    dependencyBumpType: SemverBumpType
+  ): SemverBumpType {
+    const finalConfig = this.getCachedFinalConfigForProject(projectName);
+    const configuredBumpType = finalConfig.dependentBumpType ?? 'patch';
+    if (configuredBumpType === 'match') {
+      // Strip any 'pre' prefix from the dependency bump type so that
+      // 'prepatch' becomes 'patch', 'preminor' becomes 'minor', etc.
+      if (dependencyBumpType.startsWith('pre')) {
+        return dependencyBumpType.replace(/^pre/, '') as SemverBumpType;
+      }
+      return dependencyBumpType;
+    }
+    return configuredBumpType;
   }
 
   private getProjectDependents(project: string): Set<string> {

--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -240,6 +240,16 @@ export interface NxReleaseVersionConfiguration {
    * dependency does not necessarily mean the consumer itself is an RC.
    */
   applyPreidToDependents?: boolean;
+  /**
+   * Controls the semver bump type applied to dependents when a dependency is versioned.
+   * - 'patch' (default): always bump dependents by a patch version
+   * - 'minor': always bump dependents by a minor version
+   * - 'major': always bump dependents by a major version
+   * - 'match': use the same bump type as the dependency that triggered the bump
+   *
+   * This is 'patch' by default for backward compatibility.
+   */
+  dependentBumpType?: 'patch' | 'minor' | 'major' | 'match';
 }
 
 export interface NxReleaseChangelogConfiguration {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

Hi guys,

I did a quick attempt at the following in `release-group-processor.ts`:
```
// TODO: Support influencing the side effect bump in a future version, always patch for now like in legacy versioning
```

It might not be perfect, but I think it'll be easier to iterate from something.

## Current Behavior
<!-- This is the behavior we have today -->

Hardcoded `patch` bump.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

User can decide.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
