### PR TITLE
fix(gradle): exclude project-graph from jest module path scan

### DIFF
--- a/packages/gradle/jest.config.cts
+++ b/packages/gradle/jest.config.cts
@@ -4,5 +4,8 @@ module.exports = {
   globals: {},
   displayName: 'gradle',
   preset: '../../jest.preset.js',
-  modulePathIgnorePatterns: ['<rootDir>/batch-runner/'],
+  modulePathIgnorePatterns: [
+    '<rootDir>/batch-runner/',
+    '<rootDir>/project-graph/',
+  ],
 };


### PR DESCRIPTION
## Current Behavior

`gradle:test` (the Jest target for `packages/gradle`) reads several files under `packages/gradle/project-graph/build/reports/tests/test/` (Gradle test report HTML/JS) that are not declared as task inputs. The sandbox flags them as unexpected reads.

Root cause: jest-haste-map crawls `<rootDir>` to build a module map and indexes any file matching `moduleFileExtensions` (`ts`, `js`, `html` from the preset). The `project-graph/` subdirectory is a separate Kotlin/Gradle sub-project whose `build/` outputs are gitignored — so they're (correctly) excluded from Nx's `{projectRoot}/**/*` input glob — but Jest doesn't honor `.gitignore`. The existing `modulePathIgnorePatterns` covers `<rootDir>/batch-runner/` but not `<rootDir>/project-graph/`.

Sandbox report: https://staging.nx.app/runs/PywWp3NK7G/task/gradle%3Atest

## Expected Behavior

Jest does not scan into `packages/gradle/project-graph/`. The `gradle:test` task no longer produces unexpected reads from that directory.

## Related Issue(s)

Fixes NXC-4444