### PR TITLE
feat(bundling)!: remove SVGR option and provide withSvgr migration

### DIFF
--- a/packages/rspack/migrations.json
+++ b/packages/rspack/migrations.json
@@ -17,6 +17,12 @@
       "version": "22.0.0-beta.1",
       "description": "Remove deprecated deleteOutputPath and sassImplementation options from rspack configurations.",
       "factory": "./src/migrations/update-22-0-0/remove-deprecated-options"
+    },
+    "update-23-0-0-add-svgr-to-rspack-config": {
+      "cli": "nx",
+      "version": "23.0.0-beta.9",
+      "description": "Updates rspack configs using React to use the new withSvgr composable function instead of the svgr option in withReact or NxReactRspackPlugin.",
+      "factory": "./src/migrations/update-23-0-0/add-svgr-to-rspack-config"
     }
   },
   "packageJsonUpdates": {

--- a/packages/rspack/src/generators/convert-config-to-rspack-plugin/convert-config-to-rspack-plugin.spec.ts
+++ b/packages/rspack/src/generators/convert-config-to-rspack-plugin/convert-config-to-rspack-plugin.spec.ts
@@ -77,11 +77,7 @@ describe('convertConfigToRspackPluginGenerator', () => {
       // Nx plugins for rspack.
       module.exports = composePlugins(
         withNx(),
-        withReact({
-          // Uncomment this line if you don't want to use SVGR
-          // See: https://react-svgr.com/
-          // svgr: false
-        }),
+        withReact(),
         (config) => {
           return config;
         }
@@ -98,11 +94,7 @@ describe('convertConfigToRspackPluginGenerator', () => {
       // Nx plugins for rspack.
       module.exports = composePlugins(
         withNx(),
-        withReact({
-          // Uncomment this line if you don't want to use SVGR
-          // See: https://react-svgr.com/
-          // svgr: false
-        }),
+        withReact(),
         (config) => {
           return config;
         }
@@ -129,11 +121,7 @@ describe('convertConfigToRspackPluginGenerator', () => {
       module.exports = async () => ({
         plugins: [
           new NxAppRspackPlugin(),
-          new NxReactRspackPlugin({
-            // Uncomment this line if you don't want to use SVGR
-            // See: https://react-svgr.com/
-            // svgr: false
-          }),
+          new NxReactRspackPlugin(),
           // NOTE: useLegacyNxPlugin ensures that the non-standard Rspack configuration file previously used still works.
           // To remove its usage, move options such as "plugins" into this file as standard Rspack configuration options.
           // To enhance configurations after Nx plugins have applied, you can add a new plugin with the \\\`apply\\\` method.
@@ -161,17 +149,9 @@ describe('convertConfigToRspackPluginGenerator', () => {
       const { withReact } = require('@nx/rspack');
 
       // Nx plugins for rspack.
-      module.exports = composePlugins(
-        withNx(),
-        withReact({
-          // Uncomment this line if you don't want to use SVGR
-          // See: https://react-svgr.com/
-          // svgr: false
-        }),
-        (config) => {
-          return config;
-        },
-      );
+      module.exports = composePlugins(withNx(), withReact(), (config) => {
+        return config;
+      });
       "
     `);
 
@@ -194,11 +174,7 @@ describe('convertConfigToRspackPluginGenerator', () => {
       // Nx plugins for rspack.
       module.exports = composePlugins(
         withNx(),
-        withReact({
-          // Uncomment this line if you don't want to use SVGR
-          // See: https://react-svgr.com/
-          // svgr: false
-        }),
+        withReact(),
         (config) => {
           return config;
         }
@@ -371,11 +347,7 @@ describe('convertConfigToRspackPluginGenerator', () => {
             }
           ]
         }),
-        withReact({
-          // Uncomment this line if you don't want to use SVGR
-          // See: https://react-svgr.com/
-          // svgr: false
-        }),
+        withReact(),
         (config) => {
           return config;
         }
@@ -418,11 +390,7 @@ describe('convertConfigToRspackPluginGenerator', () => {
       module.exports = async () => ({
         plugins: [
           new NxAppRspackPlugin(options),
-          new NxReactRspackPlugin({
-            // Uncomment this line if you don't want to use SVGR
-            // See: https://react-svgr.com/
-            // svgr: false
-          }),
+          new NxReactRspackPlugin(),
           // NOTE: useLegacyNxPlugin ensures that the non-standard Rspack configuration file previously used still works.
           // To remove its usage, move options such as "plugins" into this file as standard Rspack configuration options.
           // To enhance configurations after Nx plugins have applied, you can add a new plugin with the \\\`apply\\\` method.

--- a/packages/rspack/src/generators/convert-config-to-rspack-plugin/convert-config-to-rspack-plugin.ts
+++ b/packages/rspack/src/generators/convert-config-to-rspack-plugin/convert-config-to-rspack-plugin.ts
@@ -105,11 +105,7 @@ export async function convertConfigToRspackPluginGenerator(
                 ${
                   withReactConfig
                     ? `new NxReactRspackPlugin(${withReactConfig.getText()})`
-                    : `new NxReactRspackPlugin({
-                  // Uncomment this line if you don't want to use SVGR
-                  // See: https://react-svgr.com/
-                  // svgr: false
-                  })`
+                    : `new NxReactRspackPlugin()`
                 },
                 // NOTE: useLegacyNxPlugin ensures that the non-standard Rspack configuration file previously used still works.
                 // To remove its usage, move options such as "plugins" into this file as standard Rspack configuration options.

--- a/packages/rspack/src/generators/convert-to-inferred/__snapshots__/convert-to-inferred.spec.ts.snap
+++ b/packages/rspack/src/generators/convert-to-inferred/__snapshots__/convert-to-inferred.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`convert-to-inferred all projects should migrate all projects using the rspack executors 1`] = `
 "const { NxAppRspackPlugin } = require('@nx/rspack/app-plugin');
@@ -77,11 +77,7 @@ module.exports = async () => ({
   devServer: devServerOptions,
   plugins: [
     new NxAppRspackPlugin(buildOptions),
-    new NxReactRspackPlugin({
-      // Uncomment this line if you don't want to use SVGR
-      // See: https://react-svgr.com/
-      // svgr: false
-    }),
+    new NxReactRspackPlugin(),
     // eslint-disable-next-line react-hooks/rules-of-hooks
     await useLegacyNxPlugin(require('./rspack.config.old'), buildOptions),
   ],
@@ -166,11 +162,7 @@ module.exports = async () => ({
   devServer: devServerOptions,
   plugins: [
     new NxAppRspackPlugin(buildOptions),
-    new NxReactRspackPlugin({
-      // Uncomment this line if you don't want to use SVGR
-      // See: https://react-svgr.com/
-      // svgr: false
-    }),
+    new NxReactRspackPlugin(),
     // eslint-disable-next-line react-hooks/rules-of-hooks
     await useLegacyNxPlugin(require('./rspack.config.old'), buildOptions),
   ],
@@ -255,11 +247,7 @@ module.exports = async () => ({
   devServer: devServerOptions,
   plugins: [
     new NxAppRspackPlugin(buildOptions),
-    new NxReactRspackPlugin({
-      // Uncomment this line if you don't want to use SVGR
-      // See: https://react-svgr.com/
-      // svgr: false
-    }),
+    new NxReactRspackPlugin(),
     // eslint-disable-next-line react-hooks/rules-of-hooks
     await useLegacyNxPlugin(require('./rspack.config.old'), buildOptions),
   ],

--- a/packages/rspack/src/generators/convert-to-inferred/convert-to-inferred.spec.ts
+++ b/packages/rspack/src/generators/convert-to-inferred/convert-to-inferred.spec.ts
@@ -144,11 +144,7 @@ const options = {};
 module.exports = async () => ({
   plugins: [
     new NxAppRspackPlugin(options),
-    new NxReactRspackPlugin({
-      // Uncomment this line if you don't want to use SVGR
-      // See: https://react-svgr.com/
-      // svgr: false
-    }),
+    new NxReactRspackPlugin(),
     // eslint-disable-next-line react-hooks/rules-of-hooks
     await useLegacyNxPlugin(require('./rspack.config.old'), options),
   ],
@@ -315,11 +311,7 @@ describe('convert-to-inferred', () => {
         // Nx plugins for rspack.
         module.exports = composePlugins(
           withNx(),
-          withReact({
-            // Uncomment this line if you don't want to use SVGR
-            // See: https://react-svgr.com/
-            // svgr: false
-          }),
+          withReact(),
           (config) => {
             return config;
           }
@@ -562,11 +554,7 @@ describe('convert-to-inferred', () => {
           devServer: devServerOptions,
           plugins: [
             new NxAppRspackPlugin(buildOptions),
-            new NxReactRspackPlugin({
-              // Uncomment this line if you don't want to use SVGR
-              // See: https://react-svgr.com/
-              // svgr: false
-            }),
+            new NxReactRspackPlugin(),
             // eslint-disable-next-line react-hooks/rules-of-hooks
             await useLegacyNxPlugin(require('./rspack.config.old'), buildOptions),
           ],
@@ -617,11 +605,7 @@ describe('convert-to-inferred', () => {
         module.exports = async () => ({
           plugins: [
             new NxAppRspackPlugin(options),
-            new NxReactRspackPlugin({
-              // Uncomment this line if you don't want to use SVGR
-              // See: https://react-svgr.com/
-              // svgr: false
-            }),
+            new NxReactRspackPlugin(),
             // eslint-disable-next-line react-hooks/rules-of-hooks
             await useLegacyNxPlugin(require('./rspack.config.old'), options),
           ],
@@ -716,11 +700,7 @@ describe('convert-to-inferred', () => {
           devServer: devServerOptions,
           plugins: [
             new NxAppRspackPlugin(buildOptions),
-            new NxReactRspackPlugin({
-              // Uncomment this line if you don't want to use SVGR
-              // See: https://react-svgr.com/
-              // svgr: false
-            }),
+            new NxReactRspackPlugin(),
             // eslint-disable-next-line react-hooks/rules-of-hooks
             await useLegacyNxPlugin(require('./rspack.config.old'), buildOptions),
           ],
@@ -758,11 +738,7 @@ describe('convert-to-inferred', () => {
           devServer: { hot: true },
           plugins: [
             new NxAppRspackPlugin(options),
-            new NxReactRspackPlugin({
-              // Uncomment this line if you don't want to use SVGR
-              // See: https://react-svgr.com/
-              // svgr: false
-            }),
+            new NxReactRspackPlugin(),
             // eslint-disable-next-line react-hooks/rules-of-hooks
             await useLegacyNxPlugin(require('./rspack.config.old'), options),
           ],
@@ -867,17 +843,9 @@ describe('convert-to-inferred', () => {
 const { withReact } = require('@nx/react');
 
 // Nx plugins for rspack.
-module.exports = composePlugins(
-  withNx(),
-  withReact({
-    // Uncomment this line if you don't want to use SVGR
-    // See: https://react-svgr.com/
-    // svgr: false
-  }),
-  (config) => {
-    return config;
-  },
-);
+module.exports = composePlugins(withNx(), withReact(), (config) => {
+  return config;
+});
 `;
       writeRspackConfig(
         tree,
@@ -1174,11 +1142,7 @@ module.exports = composePlugins(
           devServer: devServerOptions,
           plugins: [
             new NxAppRspackPlugin(buildOptions),
-            new NxReactRspackPlugin({
-              // Uncomment this line if you don't want to use SVGR
-              // See: https://react-svgr.com/
-              // svgr: false
-            }),
+            new NxReactRspackPlugin(),
             // eslint-disable-next-line react-hooks/rules-of-hooks
             await useLegacyNxPlugin(require('./rspack.config.old'), buildOptions),
           ],
@@ -1265,11 +1229,7 @@ module.exports = composePlugins(
           devServer: devServerOptions,
           plugins: [
             new NxAppRspackPlugin(buildOptions),
-            new NxReactRspackPlugin({
-              // Uncomment this line if you don't want to use SVGR
-              // See: https://react-svgr.com/
-              // svgr: false
-            }),
+            new NxReactRspackPlugin(),
             // eslint-disable-next-line react-hooks/rules-of-hooks
             await useLegacyNxPlugin(require('./rspack.config.old'), buildOptions),
           ],

--- a/packages/rspack/src/generators/convert-webpack/convert-webpack.spec.ts
+++ b/packages/rspack/src/generators/convert-webpack/convert-webpack.spec.ts
@@ -75,28 +75,28 @@ describe('Convert webpack', () => {
       expect(tree.exists('demo/rspack.config.js')).toBeTruthy();
       expect(tree.read('demo/rspack.config.js', 'utf-8'))
         .toMatchInlineSnapshot(`
-              "const { withReact } = require('@nx/rspack');
-              const { withNx } = require('@nx/rspack');
-              const { composePlugins } = require('@nx/rspack');
+        "const { withReact } = require('@nx/rspack');
+        const { withNx } = require('@nx/rspack');
+        const { composePlugins } = require('@nx/rspack');
 
-              // Nx plugins for webpack.
-              module.exports = composePlugins(
-                withNx(),
-                withReact({
-                  useLegacyHtmlPlugin: true,
-                  // Uncomment this line if you don't want to use SVGR
-                  // See: https://react-svgr.com/
-                  // svgr: false
-                }),
-                (config) => {
-                  // Update the webpack config as needed here.
-                  // e.g. \`config.plugins.push(new MyPlugin())\`
-                  config.output.clean = true;
-                  return config;
-                },
-              );
-              "
-          `);
+        // Nx plugins for webpack.
+        module.exports = composePlugins(
+          withNx(),
+          withReact({
+            useLegacyHtmlPlugin: true,
+            // Uncomment this line if you don't want to use SVGR
+            // See: https://react-svgr.com/
+            // svgr: false
+          }),
+          (config) => {
+            // Update the webpack config as needed here.
+            // e.g. \`config.plugins.push(new MyPlugin())\`
+            config.output.clean = true;
+            return config;
+          },
+        );
+        "
+      `);
       expect(project.targets.build).toMatchInlineSnapshot(`
               {
                 "configurations": {

--- a/packages/rspack/src/migrations/update-23-0-0/add-svgr-to-rspack-config.spec.ts
+++ b/packages/rspack/src/migrations/update-23-0-0/add-svgr-to-rspack-config.spec.ts
@@ -1,0 +1,1038 @@
+import { Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import addSvgrToRspackConfig from './add-svgr-to-rspack-config';
+
+describe('add-svgr-to-rspack-config migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  function writeProject(rspackConfigPath: string) {
+    tree.write(
+      'apps/my-app/project.json',
+      JSON.stringify({
+        root: 'apps/my-app',
+        targets: {
+          build: {
+            executor: '@nx/rspack:rspack',
+            options: {
+              rspackConfig: rspackConfigPath,
+            },
+          },
+        },
+      })
+    );
+  }
+
+  describe('withReact configurations', () => {
+    it('should not modify configs without svgr option', async () => {
+      writeProject('apps/my-app/rspack.config.js');
+
+      const configContent = `const { composePlugins, withNx, withReact } = require('@nx/rspack');
+
+module.exports = composePlugins(
+  withNx(),
+  withReact(),
+  (config) => {
+    return config;
+  }
+);
+`;
+
+      tree.write('apps/my-app/rspack.config.js', configContent);
+
+      await addSvgrToRspackConfig(tree);
+
+      const content = tree.read('apps/my-app/rspack.config.js', 'utf-8');
+      expect(content).toEqual(configContent);
+    });
+
+    it('should add withSvgr function and update config when svgr is true', async () => {
+      writeProject('apps/my-app/rspack.config.js');
+
+      tree.write(
+        'apps/my-app/rspack.config.js',
+        `const { composePlugins, withNx, withReact } = require('@nx/rspack');
+
+module.exports = composePlugins(
+  withNx(),
+  withReact({ svgr: true }),
+  (config) => {
+    return config;
+  }
+);
+`
+      );
+
+      await addSvgrToRspackConfig(tree);
+
+      const content = tree.read('apps/my-app/rspack.config.js', 'utf-8');
+      expect(content).toMatchInlineSnapshot(`
+        "const { composePlugins, withNx, withReact } = require('@nx/rspack');
+
+        // SVGR support function (migrated from svgr option in withReact/NxReactRspackPlugin)
+        function withSvgr(svgrOptions = {}) {
+          const defaultOptions = {
+            svgo: false,
+            titleProp: true,
+            ref: true,
+          };
+
+          const options = { ...defaultOptions, ...svgrOptions };
+
+          return function configure(config) {
+            // Remove existing SVG loader if present
+            const svgLoaderIdx = config.module.rules.findIndex(
+              (rule) =>
+                typeof rule === 'object' &&
+                typeof rule.test !== 'undefined' &&
+                rule.test.toString().includes('svg'),
+            );
+
+            if (svgLoaderIdx !== -1) {
+              config.module.rules.splice(svgLoaderIdx, 1);
+            }
+
+            config.module.rules.push(
+              {
+                test: /\\.svg$/i,
+                type: 'asset',
+                resourceQuery: /url/, // *.svg?url
+              },
+              {
+                test: /\\.svg$/i,
+                issuer: /\\.[jt]sx?$/,
+                resourceQuery: { not: [/url/] },
+                use: [{ loader: '@svgr/webpack', options }],
+              },
+            );
+
+            return config;
+          };
+        }
+
+        module.exports = composePlugins(withNx(), withReact(), withSvgr(), (config) => {
+          return config;
+        });
+        "
+      `);
+    });
+
+    it('should handle svgr with custom options', async () => {
+      writeProject('apps/my-app/rspack.config.js');
+
+      tree.write(
+        'apps/my-app/rspack.config.js',
+        `const { composePlugins, withNx, withReact } = require('@nx/rspack');
+
+module.exports = composePlugins(
+  withNx(),
+  withReact({
+    svgr: {
+      svgo: true,
+      titleProp: false,
+      ref: false,
+    },
+  }),
+  (config) => {
+    return config;
+  }
+);
+`
+      );
+
+      await addSvgrToRspackConfig(tree);
+      const content = tree.read('apps/my-app/rspack.config.js', 'utf-8');
+      expect(content).toMatchInlineSnapshot(`
+        "const { composePlugins, withNx, withReact } = require('@nx/rspack');
+
+        // SVGR support function (migrated from svgr option in withReact/NxReactRspackPlugin)
+        function withSvgr(svgrOptions = {}) {
+          const defaultOptions = {
+            svgo: false,
+            titleProp: true,
+            ref: true,
+          };
+
+          const options = { ...defaultOptions, ...svgrOptions };
+
+          return function configure(config) {
+            // Remove existing SVG loader if present
+            const svgLoaderIdx = config.module.rules.findIndex(
+              (rule) =>
+                typeof rule === 'object' &&
+                typeof rule.test !== 'undefined' &&
+                rule.test.toString().includes('svg'),
+            );
+
+            if (svgLoaderIdx !== -1) {
+              config.module.rules.splice(svgLoaderIdx, 1);
+            }
+
+            config.module.rules.push(
+              {
+                test: /\\.svg$/i,
+                type: 'asset',
+                resourceQuery: /url/, // *.svg?url
+              },
+              {
+                test: /\\.svg$/i,
+                issuer: /\\.[jt]sx?$/,
+                resourceQuery: { not: [/url/] },
+                use: [{ loader: '@svgr/webpack', options }],
+              },
+            );
+
+            return config;
+          };
+        }
+
+        module.exports = composePlugins(
+          withNx(),
+          withReact(),
+          withSvgr({
+            svgo: true,
+            titleProp: false,
+            ref: false,
+          }),
+          (config) => {
+            return config;
+          },
+        );
+        "
+      `);
+    });
+
+    it('should remove svgr option when svgr is set to false', async () => {
+      writeProject('apps/my-app/rspack.config.js');
+
+      tree.write(
+        'apps/my-app/rspack.config.js',
+        `const { composePlugins, withNx, withReact } = require('@nx/rspack');
+
+module.exports = composePlugins(
+  withNx(),
+  withReact({
+    svgr: false,
+  }),
+  (config) => {
+    return config;
+  }
+);
+`
+      );
+
+      await addSvgrToRspackConfig(tree);
+
+      const content = tree.read('apps/my-app/rspack.config.js', 'utf-8');
+      expect(content).toMatchInlineSnapshot(`
+        "const { composePlugins, withNx, withReact } = require('@nx/rspack');
+
+        module.exports = composePlugins(withNx(), withReact(), (config) => {
+          return config;
+        });
+        "
+      `);
+    });
+
+    it('should preserve existing imports', async () => {
+      writeProject('apps/my-app/rspack.config.js');
+
+      tree.write(
+        'apps/my-app/rspack.config.js',
+        `const { composePlugins, withNx, withReact } = require('@nx/rspack');
+const someOtherLib = require('some-lib');
+
+// Some comment here
+
+module.exports = composePlugins(
+  withNx(),
+  withReact({ svgr: true }),
+  (config) => {
+    return config;
+  }
+);
+`
+      );
+
+      await addSvgrToRspackConfig(tree);
+
+      const content = tree.read('apps/my-app/rspack.config.js', 'utf-8');
+      expect(content).toMatchInlineSnapshot(`
+        "const { composePlugins, withNx, withReact } = require('@nx/rspack');
+        const someOtherLib = require('some-lib');
+
+        // SVGR support function (migrated from svgr option in withReact/NxReactRspackPlugin)
+        function withSvgr(svgrOptions = {}) {
+          const defaultOptions = {
+            svgo: false,
+            titleProp: true,
+            ref: true,
+          };
+
+          const options = { ...defaultOptions, ...svgrOptions };
+
+          return function configure(config) {
+            // Remove existing SVG loader if present
+            const svgLoaderIdx = config.module.rules.findIndex(
+              (rule) =>
+                typeof rule === 'object' &&
+                typeof rule.test !== 'undefined' &&
+                rule.test.toString().includes('svg'),
+            );
+
+            if (svgLoaderIdx !== -1) {
+              config.module.rules.splice(svgLoaderIdx, 1);
+            }
+
+            config.module.rules.push(
+              {
+                test: /\\.svg$/i,
+                type: 'asset',
+                resourceQuery: /url/, // *.svg?url
+              },
+              {
+                test: /\\.svg$/i,
+                issuer: /\\.[jt]sx?$/,
+                resourceQuery: { not: [/url/] },
+                use: [{ loader: '@svgr/webpack', options }],
+              },
+            );
+
+            return config;
+          };
+        }
+
+        // Some comment here
+
+        module.exports = composePlugins(withNx(), withReact(), withSvgr(), (config) => {
+          return config;
+        });
+        "
+      `);
+    });
+
+    it('should handle module.exports with variable reference', async () => {
+      writeProject('apps/my-app/rspack.config.js');
+
+      tree.write(
+        'apps/my-app/rspack.config.js',
+        `const { composePlugins, withNx, withReact } = require('@nx/rspack');
+
+const config = composePlugins(
+  withNx(),
+  withReact({ svgr: true }),
+  (config) => {
+    return config;
+  }
+);
+
+module.exports = config;
+`
+      );
+
+      await addSvgrToRspackConfig(tree);
+      const content = tree.read('apps/my-app/rspack.config.js', 'utf-8');
+      expect(content).toMatchInlineSnapshot(`
+        "const { composePlugins, withNx, withReact } = require('@nx/rspack');
+
+        // SVGR support function (migrated from svgr option in withReact/NxReactRspackPlugin)
+        function withSvgr(svgrOptions = {}) {
+          const defaultOptions = {
+            svgo: false,
+            titleProp: true,
+            ref: true,
+          };
+
+          const options = { ...defaultOptions, ...svgrOptions };
+
+          return function configure(config) {
+            // Remove existing SVG loader if present
+            const svgLoaderIdx = config.module.rules.findIndex(
+              (rule) =>
+                typeof rule === 'object' &&
+                typeof rule.test !== 'undefined' &&
+                rule.test.toString().includes('svg'),
+            );
+
+            if (svgLoaderIdx !== -1) {
+              config.module.rules.splice(svgLoaderIdx, 1);
+            }
+
+            config.module.rules.push(
+              {
+                test: /\\.svg$/i,
+                type: 'asset',
+                resourceQuery: /url/, // *.svg?url
+              },
+              {
+                test: /\\.svg$/i,
+                issuer: /\\.[jt]sx?$/,
+                resourceQuery: { not: [/url/] },
+                use: [{ loader: '@svgr/webpack', options }],
+              },
+            );
+
+            return config;
+          };
+        }
+
+        const config = composePlugins(withNx(), withReact(), withSvgr(), (config) => {
+          return config;
+        });
+
+        module.exports = config;
+        "
+      `);
+    });
+
+    it('should handle imports and export default (ESM)', async () => {
+      writeProject('apps/my-app/rspack.config.js');
+
+      tree.write(
+        'apps/my-app/rspack.config.js',
+        `import { composePlugins, withNx, withReact } from '@nx/rspack';
+import someOtherLib from 'some-lib';
+
+export default composePlugins(
+  withNx(),
+  withReact({ svgr: true }),
+  (config) => {
+    return config;
+  }
+);
+`
+      );
+
+      await addSvgrToRspackConfig(tree);
+
+      const content = tree.read('apps/my-app/rspack.config.js', 'utf-8');
+      expect(content).toMatchInlineSnapshot(`
+        "import { composePlugins, withNx, withReact } from '@nx/rspack';
+        import someOtherLib from 'some-lib';
+
+        // SVGR support function (migrated from svgr option in withReact/NxReactRspackPlugin)
+        function withSvgr(svgrOptions = {}) {
+          const defaultOptions = {
+            svgo: false,
+            titleProp: true,
+            ref: true,
+          };
+
+          const options = { ...defaultOptions, ...svgrOptions };
+
+          return function configure(config) {
+            // Remove existing SVG loader if present
+            const svgLoaderIdx = config.module.rules.findIndex(
+              (rule) =>
+                typeof rule === 'object' &&
+                typeof rule.test !== 'undefined' &&
+                rule.test.toString().includes('svg'),
+            );
+
+            if (svgLoaderIdx !== -1) {
+              config.module.rules.splice(svgLoaderIdx, 1);
+            }
+
+            config.module.rules.push(
+              {
+                test: /\\.svg$/i,
+                type: 'asset',
+                resourceQuery: /url/, // *.svg?url
+              },
+              {
+                test: /\\.svg$/i,
+                issuer: /\\.[jt]sx?$/,
+                resourceQuery: { not: [/url/] },
+                use: [{ loader: '@svgr/webpack', options }],
+              },
+            );
+
+            return config;
+          };
+        }
+
+        export default composePlugins(withNx(), withReact(), withSvgr(), (config) => {
+          return config;
+        });
+        "
+      `);
+    });
+
+    it('should preserve other withReact options when removing svgr: false', async () => {
+      writeProject('apps/my-app/rspack.config.js');
+
+      tree.write(
+        'apps/my-app/rspack.config.js',
+        `const { composePlugins, withNx, withReact } = require('@nx/rspack');
+
+module.exports = composePlugins(
+  withNx(),
+  withReact({
+    svgr: false,
+    stylePreprocessorOptions: { sassOptions: { quietDeps: true } },
+  }),
+  (config) => {
+    return config;
+  }
+);
+`
+      );
+
+      await addSvgrToRspackConfig(tree);
+
+      const content = tree.read('apps/my-app/rspack.config.js', 'utf-8');
+      expect(content).toMatchInlineSnapshot(`
+        "const { composePlugins, withNx, withReact } = require('@nx/rspack');
+
+        module.exports = composePlugins(
+          withNx(),
+          withReact({
+            stylePreprocessorOptions: { sassOptions: { quietDeps: true } },
+          }),
+          (config) => {
+            return config;
+          },
+        );
+        "
+      `);
+    });
+
+    it('should preserve other withReact options when migrating svgr: true', async () => {
+      writeProject('apps/my-app/rspack.config.js');
+
+      tree.write(
+        'apps/my-app/rspack.config.js',
+        `const { composePlugins, withNx, withReact } = require('@nx/rspack');
+
+module.exports = composePlugins(
+  withNx(),
+  withReact({
+    svgr: true,
+    stylePreprocessorOptions: { sassOptions: { quietDeps: true } },
+  }),
+  (config) => {
+    return config;
+  }
+);
+`
+      );
+
+      await addSvgrToRspackConfig(tree);
+
+      const content = tree.read('apps/my-app/rspack.config.js', 'utf-8');
+      expect(content).toMatchInlineSnapshot(`
+        "const { composePlugins, withNx, withReact } = require('@nx/rspack');
+
+        // SVGR support function (migrated from svgr option in withReact/NxReactRspackPlugin)
+        function withSvgr(svgrOptions = {}) {
+          const defaultOptions = {
+            svgo: false,
+            titleProp: true,
+            ref: true,
+          };
+
+          const options = { ...defaultOptions, ...svgrOptions };
+
+          return function configure(config) {
+            // Remove existing SVG loader if present
+            const svgLoaderIdx = config.module.rules.findIndex(
+              (rule) =>
+                typeof rule === 'object' &&
+                typeof rule.test !== 'undefined' &&
+                rule.test.toString().includes('svg'),
+            );
+
+            if (svgLoaderIdx !== -1) {
+              config.module.rules.splice(svgLoaderIdx, 1);
+            }
+
+            config.module.rules.push(
+              {
+                test: /\\.svg$/i,
+                type: 'asset',
+                resourceQuery: /url/, // *.svg?url
+              },
+              {
+                test: /\\.svg$/i,
+                issuer: /\\.[jt]sx?$/,
+                resourceQuery: { not: [/url/] },
+                use: [{ loader: '@svgr/webpack', options }],
+              },
+            );
+
+            return config;
+          };
+        }
+
+        module.exports = composePlugins(
+          withNx(),
+          withReact({
+            stylePreprocessorOptions: { sassOptions: { quietDeps: true } },
+          }),
+          withSvgr(),
+          (config) => {
+            return config;
+          },
+        );
+        "
+      `);
+    });
+  });
+
+  describe('NxReactRspackPlugin configurations', () => {
+    it('should not modify configs without svgr option', async () => {
+      writeProject('apps/my-app/rspack.config.js');
+
+      const configContent = `const { NxAppRspackPlugin } = require('@nx/rspack/app-plugin');
+const { NxReactRspackPlugin } = require('@nx/rspack/react-plugin');
+
+module.exports = {
+  plugins: [
+    new NxAppRspackPlugin(),
+    new NxReactRspackPlugin({
+      // svgr: false
+    }),
+  ],
+};
+`;
+
+      tree.write('apps/my-app/rspack.config.js', configContent);
+
+      await addSvgrToRspackConfig(tree);
+
+      const content = tree.read('apps/my-app/rspack.config.js', 'utf-8');
+      expect(content).toEqual(configContent);
+    });
+
+    it('should handle svgr: true', async () => {
+      writeProject('apps/my-app/rspack.config.js');
+
+      tree.write(
+        'apps/my-app/rspack.config.js',
+        `
+const { NxAppRspackPlugin } = require('@nx/rspack/app-plugin');
+const { NxReactRspackPlugin } = require('@nx/rspack/react-plugin');
+
+module.exports = {
+  output: {
+    path: join(__dirname, '../dist/apps/my-app'),
+  },
+  plugins: [
+    new NxAppRspackPlugin({
+      tsConfig: './tsconfig.app.json',
+      main: './src/main.tsx',
+      index: './src/index.html',
+    }),
+    new NxReactRspackPlugin({
+      svgr: true
+    }),
+  ],
+};
+`
+      );
+
+      await addSvgrToRspackConfig(tree);
+      const content = tree.read('apps/my-app/rspack.config.js', 'utf-8');
+      expect(content).toMatchInlineSnapshot(`
+        "const { NxAppRspackPlugin } = require('@nx/rspack/app-plugin');
+        const { NxReactRspackPlugin } = require('@nx/rspack/react-plugin');
+
+        // SVGR support function (migrated from svgr option in withReact/NxReactRspackPlugin)
+        function withSvgr(svgrOptions = {}) {
+          const defaultOptions = {
+            svgo: false,
+            titleProp: true,
+            ref: true,
+          };
+
+          const options = { ...defaultOptions, ...svgrOptions };
+
+          return (config) => {
+            config.plugins.push({
+              apply: (compiler) => {
+                // Remove ALL existing SVG loaders
+                compiler.options.module.rules = compiler.options.module.rules.filter(
+                  (rule) =>
+                    !(
+                      rule &&
+                      typeof rule === 'object' &&
+                      rule.test &&
+                      rule.test.toString().includes('svg')
+                    ),
+                );
+
+                compiler.options.module.rules.push(
+                  {
+                    test: /\\.svg$/i,
+                    type: 'asset',
+                    resourceQuery: /url/,
+                  },
+                  {
+                    test: /\\.svg$/i,
+                    issuer: /\\.[jt]sx?$/,
+                    resourceQuery: { not: [/url/] },
+                    use: [{ loader: '@svgr/webpack', options }],
+                  },
+                );
+              },
+            });
+            return config;
+          };
+        }
+
+        module.exports = withSvgr()({
+          output: {
+            path: join(__dirname, '../dist/apps/my-app'),
+          },
+          plugins: [
+            new NxAppRspackPlugin({
+              tsConfig: './tsconfig.app.json',
+              main: './src/main.tsx',
+              index: './src/index.html',
+            }),
+            new NxReactRspackPlugin(),
+          ],
+        });
+        "
+      `);
+    });
+
+    it('should handle svgr options object', async () => {
+      writeProject('apps/my-app/rspack.config.js');
+
+      tree.write(
+        'apps/my-app/rspack.config.js',
+        `const { NxAppRspackPlugin } = require('@nx/rspack/app-plugin');
+const { NxReactRspackPlugin } = require('@nx/rspack/react-plugin');
+
+module.exports = {
+  plugins: [
+    new NxAppRspackPlugin(),
+    new NxReactRspackPlugin({
+      svgr: {
+        svgo: true,
+        titleProp: false,
+        ref: false,
+      },
+    }),
+  ],
+};
+`
+      );
+
+      await addSvgrToRspackConfig(tree);
+      const content = tree.read('apps/my-app/rspack.config.js', 'utf-8');
+      expect(content).toMatchInlineSnapshot(`
+        "const { NxAppRspackPlugin } = require('@nx/rspack/app-plugin');
+        const { NxReactRspackPlugin } = require('@nx/rspack/react-plugin');
+
+        // SVGR support function (migrated from svgr option in withReact/NxReactRspackPlugin)
+        function withSvgr(svgrOptions = {}) {
+          const defaultOptions = {
+            svgo: false,
+            titleProp: true,
+            ref: true,
+          };
+
+          const options = { ...defaultOptions, ...svgrOptions };
+
+          return (config) => {
+            config.plugins.push({
+              apply: (compiler) => {
+                // Remove ALL existing SVG loaders
+                compiler.options.module.rules = compiler.options.module.rules.filter(
+                  (rule) =>
+                    !(
+                      rule &&
+                      typeof rule === 'object' &&
+                      rule.test &&
+                      rule.test.toString().includes('svg')
+                    ),
+                );
+
+                compiler.options.module.rules.push(
+                  {
+                    test: /\\.svg$/i,
+                    type: 'asset',
+                    resourceQuery: /url/,
+                  },
+                  {
+                    test: /\\.svg$/i,
+                    issuer: /\\.[jt]sx?$/,
+                    resourceQuery: { not: [/url/] },
+                    use: [{ loader: '@svgr/webpack', options }],
+                  },
+                );
+              },
+            });
+            return config;
+          };
+        }
+
+        module.exports = withSvgr({
+          svgo: true,
+          titleProp: false,
+          ref: false,
+        })({
+          plugins: [new NxAppRspackPlugin(), new NxReactRspackPlugin()],
+        });
+        "
+      `);
+    });
+
+    it('should handle module.exports with variable reference', async () => {
+      writeProject('apps/my-app/rspack.config.js');
+
+      tree.write(
+        'apps/my-app/rspack.config.js',
+        `const { NxAppRspackPlugin } = require('@nx/rspack/app-plugin');
+const { NxReactRspackPlugin } = require('@nx/rspack/react-plugin');
+
+const config = {
+  plugins: [
+    new NxAppRspackPlugin(),
+    new NxReactRspackPlugin({
+      svgr: true,
+    }),
+  ],
+};
+
+module.exports = config;
+`
+      );
+
+      await addSvgrToRspackConfig(tree);
+      const content = tree.read('apps/my-app/rspack.config.js', 'utf-8');
+      expect(content).toMatchInlineSnapshot(`
+        "const { NxAppRspackPlugin } = require('@nx/rspack/app-plugin');
+        const { NxReactRspackPlugin } = require('@nx/rspack/react-plugin');
+
+        // SVGR support function (migrated from svgr option in withReact/NxReactRspackPlugin)
+        function withSvgr(svgrOptions = {}) {
+          const defaultOptions = {
+            svgo: false,
+            titleProp: true,
+            ref: true,
+          };
+
+          const options = { ...defaultOptions, ...svgrOptions };
+
+          return (config) => {
+            config.plugins.push({
+              apply: (compiler) => {
+                // Remove ALL existing SVG loaders
+                compiler.options.module.rules = compiler.options.module.rules.filter(
+                  (rule) =>
+                    !(
+                      rule &&
+                      typeof rule === 'object' &&
+                      rule.test &&
+                      rule.test.toString().includes('svg')
+                    ),
+                );
+
+                compiler.options.module.rules.push(
+                  {
+                    test: /\\.svg$/i,
+                    type: 'asset',
+                    resourceQuery: /url/,
+                  },
+                  {
+                    test: /\\.svg$/i,
+                    issuer: /\\.[jt]sx?$/,
+                    resourceQuery: { not: [/url/] },
+                    use: [{ loader: '@svgr/webpack', options }],
+                  },
+                );
+              },
+            });
+            return config;
+          };
+        }
+
+        const config = {
+          plugins: [new NxAppRspackPlugin(), new NxReactRspackPlugin()],
+        };
+
+        module.exports = withSvgr()(config);
+        "
+      `);
+    });
+
+    it('should handle export default', async () => {
+      writeProject('apps/my-app/rspack.config.js');
+
+      tree.write(
+        'apps/my-app/rspack.config.js',
+        `import { NxAppRspackPlugin } from '@nx/rspack/app-plugin';
+import { NxReactRspackPlugin } from '@nx/rspack/react-plugin';
+
+export default {
+  plugins: [
+    new NxAppRspackPlugin(),
+    new NxReactRspackPlugin({
+      svgr: true,
+    }),
+  ],
+};
+`
+      );
+
+      await addSvgrToRspackConfig(tree);
+      const content = tree.read('apps/my-app/rspack.config.js', 'utf-8');
+      expect(content).toMatchInlineSnapshot(`
+        "import { NxAppRspackPlugin } from '@nx/rspack/app-plugin';
+        import { NxReactRspackPlugin } from '@nx/rspack/react-plugin';
+
+        // SVGR support function (migrated from svgr option in withReact/NxReactRspackPlugin)
+        function withSvgr(svgrOptions = {}) {
+          const defaultOptions = {
+            svgo: false,
+            titleProp: true,
+            ref: true,
+          };
+
+          const options = { ...defaultOptions, ...svgrOptions };
+
+          return (config) => {
+            config.plugins.push({
+              apply: (compiler) => {
+                // Remove ALL existing SVG loaders
+                compiler.options.module.rules = compiler.options.module.rules.filter(
+                  (rule) =>
+                    !(
+                      rule &&
+                      typeof rule === 'object' &&
+                      rule.test &&
+                      rule.test.toString().includes('svg')
+                    ),
+                );
+
+                compiler.options.module.rules.push(
+                  {
+                    test: /\\.svg$/i,
+                    type: 'asset',
+                    resourceQuery: /url/,
+                  },
+                  {
+                    test: /\\.svg$/i,
+                    issuer: /\\.[jt]sx?$/,
+                    resourceQuery: { not: [/url/] },
+                    use: [{ loader: '@svgr/webpack', options }],
+                  },
+                );
+              },
+            });
+            return config;
+          };
+        }
+
+        export default withSvgr()({
+          plugins: [new NxAppRspackPlugin(), new NxReactRspackPlugin()],
+        });
+        "
+      `);
+    });
+
+    it('should remove svgr: false from plugin options', async () => {
+      writeProject('apps/my-app/rspack.config.js');
+
+      tree.write(
+        'apps/my-app/rspack.config.js',
+        `const { NxAppRspackPlugin } = require('@nx/rspack/app-plugin');
+const { NxReactRspackPlugin } = require('@nx/rspack/react-plugin');
+
+module.exports = {
+  plugins: [
+    new NxAppRspackPlugin(),
+    new NxReactRspackPlugin({
+      svgr: false,
+    }),
+  ],
+};
+`
+      );
+
+      await addSvgrToRspackConfig(tree);
+      const content = tree.read('apps/my-app/rspack.config.js', 'utf-8');
+      expect(content).toMatchInlineSnapshot(`
+        "const { NxAppRspackPlugin } = require('@nx/rspack/app-plugin');
+        const { NxReactRspackPlugin } = require('@nx/rspack/react-plugin');
+
+        module.exports = {
+          plugins: [new NxAppRspackPlugin(), new NxReactRspackPlugin()],
+        };
+        "
+      `);
+    });
+  });
+
+  describe('multiple configs', () => {
+    it('should handle multiple rspack configs in workspace', async () => {
+      tree.write(
+        'apps/app-1/project.json',
+        JSON.stringify({
+          root: 'apps/app-1',
+          targets: {
+            build: {
+              executor: '@nx/rspack:rspack',
+              options: { rspackConfig: 'apps/app-1/rspack.config.js' },
+            },
+          },
+        })
+      );
+      tree.write(
+        'apps/app-2/project.json',
+        JSON.stringify({
+          root: 'apps/app-2',
+          targets: {
+            build: {
+              executor: '@nx/rspack:rspack',
+              options: { rspackConfig: 'apps/app-2/rspack.config.js' },
+            },
+          },
+        })
+      );
+
+      tree.write(
+        'apps/app-1/rspack.config.js',
+        `const { composePlugins, withNx, withReact } = require('@nx/rspack');
+
+module.exports = composePlugins(
+  withNx(),
+  withReact({ svgr: true }),
+  (config) => {
+    return config;
+  }
+);
+`
+      );
+
+      tree.write(
+        'apps/app-2/rspack.config.js',
+        `const { composePlugins, withNx, withReact } = require('@nx/rspack');
+
+module.exports = composePlugins(
+  withNx(),
+  withReact(),
+  (config) => {
+    return config;
+  }
+);
+`
+      );
+
+      await addSvgrToRspackConfig(tree);
+
+      const app1Content = tree.read('apps/app-1/rspack.config.js', 'utf-8');
+      expect(app1Content).toContain('function withSvgr');
+      expect(app1Content).toContain('withSvgr()');
+
+      const app2Content = tree.read('apps/app-2/rspack.config.js', 'utf-8');
+      expect(app2Content).not.toContain('function withSvgr');
+    });
+  });
+});

--- a/packages/rspack/src/migrations/update-23-0-0/add-svgr-to-rspack-config.ts
+++ b/packages/rspack/src/migrations/update-23-0-0/add-svgr-to-rspack-config.ts
@@ -1,0 +1,501 @@
+import { forEachExecutorOptions } from '@nx/devkit/internal';
+import {
+  type Tree,
+  formatFiles,
+  applyChangesToString,
+  ChangeType,
+  type StringChange,
+} from '@nx/devkit';
+import { ast, query } from '@phenomnomnominal/tsquery';
+import * as ts from 'typescript';
+
+const withSvgrFunctionForWithReact = `
+
+// SVGR support function (migrated from svgr option in withReact/NxReactRspackPlugin)
+function withSvgr(svgrOptions = {}) {
+  const defaultOptions = {
+    svgo: false,
+    titleProp: true,
+    ref: true,
+  };
+
+  const options = { ...defaultOptions, ...svgrOptions };
+
+  return function configure(config) {
+    // Remove existing SVG loader if present
+    const svgLoaderIdx = config.module.rules.findIndex(
+      (rule) =>
+        typeof rule === 'object' &&
+        typeof rule.test !== 'undefined' &&
+        rule.test.toString().includes('svg')
+    );
+
+    if (svgLoaderIdx !== -1) {
+      config.module.rules.splice(svgLoaderIdx, 1);
+    }
+
+    config.module.rules.push(
+      {
+        test: /\\.svg$/i,
+        type: 'asset',
+        resourceQuery: /url/, // *.svg?url
+      },
+      {
+        test: /\\.svg$/i,
+        issuer: /\\.[jt]sx?$/,
+        resourceQuery: { not: [/url/] },
+        use: [{ loader: '@svgr/webpack', options }],
+      }
+    );
+
+    return config;
+  };
+}
+`;
+
+const withSvgrFunctionForNxReactRspackPlugin = `
+
+// SVGR support function (migrated from svgr option in withReact/NxReactRspackPlugin)
+function withSvgr(svgrOptions = {}) {
+  const defaultOptions = {
+    svgo: false,
+    titleProp: true,
+    ref: true,
+  };
+
+  const options = { ...defaultOptions, ...svgrOptions };
+
+  return (config) => {
+    config.plugins.push({
+      apply: (compiler) => {
+        // Remove ALL existing SVG loaders
+        compiler.options.module.rules = compiler.options.module.rules.filter(
+          (rule) =>
+            !(
+              rule &&
+              typeof rule === 'object' &&
+              rule.test &&
+              rule.test.toString().includes('svg')
+            )
+        );
+
+        compiler.options.module.rules.push(
+          {
+            test: /\\.svg$/i,
+            type: 'asset',
+            resourceQuery: /url/,
+          },
+          {
+            test: /\\.svg$/i,
+            issuer: /\\.[jt]sx?$/,
+            resourceQuery: { not: [/url/] },
+            use: [{ loader: '@svgr/webpack', options }],
+          }
+        );
+      },
+    });
+    return config;
+  };
+}
+`;
+
+export default async function addSvgrToRspackConfig(tree: Tree) {
+  const projects = new Map<
+    string,
+    { svgrOptions?: any; isWithReact: boolean }
+  >();
+
+  // Find all React rspack projects using either withReact OR NxReactRspackPlugin
+  forEachExecutorOptions(
+    tree,
+    '@nx/rspack:rspack',
+    (options: any, project, target) => {
+      if (!options.rspackConfig) return;
+
+      const rspackConfigPath = options.rspackConfig as string;
+      if (!tree.exists(rspackConfigPath)) return;
+
+      const content = tree.read(rspackConfigPath, 'utf-8');
+
+      const sourceFile = ast(content);
+
+      // Check if this is a withReact setup
+      if (content.includes('withReact')) {
+        const withReactCalls = query(
+          sourceFile,
+          'CallExpression[expression.name=withReact]'
+        );
+
+        if (withReactCalls.length > 0) {
+          const callExpr = withReactCalls[0] as ts.CallExpression;
+          if (callExpr.arguments.length === 0) return;
+
+          const arg = callExpr.arguments[0];
+          if (!ts.isObjectLiteralExpression(arg)) return;
+
+          const svgrProp = arg.properties.find(
+            (prop) =>
+              ts.isPropertyAssignment(prop) &&
+              ts.isIdentifier(prop.name) &&
+              prop.name.text === 'svgr'
+          ) as ts.PropertyAssignment | undefined;
+
+          if (svgrProp) {
+            let svgrValue: boolean | Record<string, unknown> | undefined;
+            if (ts.isObjectLiteralExpression(svgrProp.initializer)) {
+              svgrValue = {};
+              for (const prop of svgrProp.initializer.properties) {
+                if (!ts.isPropertyAssignment(prop)) continue;
+                if (!ts.isIdentifier(prop.name)) continue;
+
+                const key = prop.name.text;
+                if (prop.initializer.kind === ts.SyntaxKind.TrueKeyword) {
+                  svgrValue[key] = true;
+                } else if (
+                  prop.initializer.kind === ts.SyntaxKind.FalseKeyword
+                ) {
+                  svgrValue[key] = false;
+                }
+              }
+            } else {
+              svgrValue =
+                svgrProp.initializer.kind === ts.SyntaxKind.TrueKeyword;
+            }
+
+            projects.set(rspackConfigPath, {
+              svgrOptions: svgrValue,
+              isWithReact: true,
+            });
+          }
+        }
+      }
+      // Otherwise check if this is NxReactRspackPlugin setup
+      else if (content.includes('NxReactRspackPlugin')) {
+        const pluginCalls = query(
+          sourceFile,
+          'NewExpression[expression.name=NxReactRspackPlugin]'
+        );
+
+        if (pluginCalls.length > 0) {
+          const newExpr = pluginCalls[0] as ts.NewExpression;
+          if (!newExpr.arguments || newExpr.arguments.length === 0) return;
+
+          const arg = newExpr.arguments[0];
+          if (!ts.isObjectLiteralExpression(arg)) return;
+
+          const svgrProp = arg.properties.find(
+            (prop) =>
+              ts.isPropertyAssignment(prop) &&
+              ts.isIdentifier(prop.name) &&
+              prop.name.text === 'svgr'
+          ) as ts.PropertyAssignment | undefined;
+
+          if (svgrProp) {
+            let svgrValue: boolean | Record<string, unknown> | undefined;
+            if (ts.isObjectLiteralExpression(svgrProp.initializer)) {
+              svgrValue = {};
+              for (const prop of svgrProp.initializer.properties) {
+                if (!ts.isPropertyAssignment(prop)) continue;
+                if (!ts.isIdentifier(prop.name)) continue;
+
+                const key = prop.name.text;
+                if (prop.initializer.kind === ts.SyntaxKind.TrueKeyword) {
+                  svgrValue[key] = true;
+                } else if (
+                  prop.initializer.kind === ts.SyntaxKind.FalseKeyword
+                ) {
+                  svgrValue[key] = false;
+                }
+              }
+            } else if (
+              svgrProp.initializer.kind === ts.SyntaxKind.TrueKeyword
+            ) {
+              svgrValue = true;
+            } else if (
+              svgrProp.initializer.kind === ts.SyntaxKind.FalseKeyword
+            ) {
+              svgrValue = false;
+            }
+
+            // Add to projects if svgr is explicitly set
+            if (svgrValue !== undefined) {
+              projects.set(rspackConfigPath, {
+                svgrOptions: svgrValue,
+                isWithReact: false,
+              });
+            }
+          }
+        }
+      }
+    }
+  );
+
+  if (projects.size === 0) return;
+
+  // Update rspack configs to add withSvgr function inline
+  for (const [rspackConfigPath, config] of projects.entries()) {
+    let content = tree.read(rspackConfigPath, 'utf-8');
+    const sourceFile = ast(content);
+    const changes: StringChange[] = [];
+
+    // Build the svgr options for this specific config
+    let svgrOptionsStr = '';
+
+    if (config.svgrOptions) {
+      const importStatements = query(sourceFile, 'ImportDeclaration');
+      const requireStatements = query(
+        sourceFile,
+        'VariableStatement:has(CallExpression[expression.name=require])'
+      );
+
+      const allImportRequires = [
+        ...importStatements,
+        ...requireStatements,
+      ].sort((a, b) => a.getEnd() - b.getEnd());
+      const lastImportOrRequire =
+        allImportRequires[allImportRequires.length - 1];
+
+      if (config.svgrOptions === true || config.svgrOptions === undefined) {
+        svgrOptionsStr = '';
+      } else if (typeof config.svgrOptions === 'object') {
+        const options = Object.entries(config.svgrOptions)
+          .map(([key, value]) => `  ${key}: ${value}`)
+          .join(',\n');
+        svgrOptionsStr = `{\n${options}\n}`;
+      }
+
+      if (lastImportOrRequire) {
+        changes.push({
+          type: ChangeType.Insert,
+          index: lastImportOrRequire.getEnd(),
+          text: config.isWithReact
+            ? withSvgrFunctionForWithReact
+            : withSvgrFunctionForNxReactRspackPlugin,
+        });
+      } else {
+        changes.push({
+          type: ChangeType.Insert,
+          index: 0,
+          text:
+            (config.isWithReact
+              ? withSvgrFunctionForWithReact
+              : withSvgrFunctionForNxReactRspackPlugin) + '\n',
+        });
+      }
+    }
+
+    // Remove svgr option based on the style (withReact OR NxReactRspackPlugin)
+    if (config.isWithReact) {
+      const withReactCalls = query(
+        sourceFile,
+        'CallExpression[expression.name=withReact]'
+      );
+      if (withReactCalls.length > 0) {
+        const callExpr = withReactCalls[0] as ts.CallExpression;
+        if (callExpr.arguments.length > 0) {
+          const arg = callExpr.arguments[0];
+          if (ts.isObjectLiteralExpression(arg)) {
+            const svgrProp = arg.properties.find(
+              (prop) =>
+                ts.isPropertyAssignment(prop) &&
+                ts.isIdentifier(prop.name) &&
+                prop.name.text === 'svgr'
+            ) as ts.PropertyAssignment | undefined;
+
+            if (svgrProp) {
+              const hasOnlySvgrProperty = arg.properties.length === 1;
+
+              if (hasOnlySvgrProperty) {
+                changes.push({
+                  type: ChangeType.Delete,
+                  start: arg.getStart(),
+                  length: arg.getEnd() - arg.getStart(),
+                });
+              } else {
+                const propIndex = arg.properties.indexOf(svgrProp);
+                const isLastProp = propIndex === arg.properties.length - 1;
+                const isFirstProp = propIndex === 0;
+
+                let removeStart = svgrProp.getFullStart();
+                let removeEnd = svgrProp.getEnd();
+
+                if (!isLastProp) {
+                  const nextProp = arg.properties[propIndex + 1];
+                  removeEnd = nextProp.getFullStart();
+                } else if (!isFirstProp) {
+                  const prevProp = arg.properties[propIndex - 1];
+                  const textBetween = content.substring(
+                    prevProp.getEnd(),
+                    svgrProp.getFullStart()
+                  );
+                  const commaIndex = textBetween.indexOf(',');
+                  if (commaIndex !== -1) {
+                    removeStart = prevProp.getEnd() + commaIndex;
+                  }
+                }
+
+                changes.push({
+                  type: ChangeType.Delete,
+                  start: removeStart,
+                  length: removeEnd - removeStart,
+                });
+              }
+
+              if (config.svgrOptions) {
+                const composePluginsCalls = query(
+                  sourceFile,
+                  'CallExpression[expression.name=composePlugins]'
+                );
+
+                if (composePluginsCalls.length > 0) {
+                  const composeCall =
+                    composePluginsCalls[0] as ts.CallExpression;
+                  let svgrCallStr = '';
+                  if (
+                    config.svgrOptions === true ||
+                    config.svgrOptions === undefined
+                  ) {
+                    svgrCallStr = 'withSvgr()';
+                  } else if (typeof config.svgrOptions === 'object') {
+                    svgrCallStr = `withSvgr(${svgrOptionsStr})`;
+                  }
+                  const withReactIdx = composeCall.arguments.findIndex((arg) =>
+                    arg.getText().includes('withReact')
+                  );
+                  // Insert withSvgr as the last argument before the closing paren
+                  const argToInsertAfter = composeCall.arguments[withReactIdx];
+                  if (argToInsertAfter) {
+                    changes.push({
+                      type: ChangeType.Insert,
+                      index: argToInsertAfter.getEnd(),
+                      text: `, ${svgrCallStr}`,
+                    });
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    } else {
+      // Remove svgr option from first NxReactRspackPlugin call
+      const pluginCalls = query(
+        sourceFile,
+        'NewExpression[expression.name=NxReactRspackPlugin]'
+      );
+      if (pluginCalls.length > 0) {
+        const newExpr = pluginCalls[0] as ts.NewExpression;
+        if (newExpr.arguments && newExpr.arguments.length > 0) {
+          const arg = newExpr.arguments[0];
+          if (ts.isObjectLiteralExpression(arg)) {
+            const svgrProp = arg.properties.find(
+              (prop) =>
+                ts.isPropertyAssignment(prop) &&
+                ts.isIdentifier(prop.name) &&
+                prop.name.text === 'svgr'
+            ) as ts.PropertyAssignment | undefined;
+
+            if (svgrProp) {
+              const hasOnlySvgrProperty = arg.properties.length === 1;
+
+              if (hasOnlySvgrProperty) {
+                changes.push({
+                  type: ChangeType.Delete,
+                  start: arg.getStart(),
+                  length: arg.getEnd() - arg.getStart(),
+                });
+              } else {
+                const propIndex = arg.properties.indexOf(svgrProp);
+                const isLastProp = propIndex === arg.properties.length - 1;
+                const isFirstProp = propIndex === 0;
+
+                let removeStart = svgrProp.getFullStart();
+                let removeEnd = svgrProp.getEnd();
+
+                if (!isLastProp) {
+                  const nextProp = arg.properties[propIndex + 1];
+                  removeEnd = nextProp.getFullStart();
+                } else if (!isFirstProp) {
+                  const prevProp = arg.properties[propIndex - 1];
+                  const textBetween = content.substring(
+                    prevProp.getEnd(),
+                    svgrProp.getFullStart()
+                  );
+                  const commaIndex = textBetween.indexOf(',');
+                  if (commaIndex !== -1) {
+                    removeStart = prevProp.getEnd() + commaIndex;
+                  }
+                }
+
+                changes.push({
+                  type: ChangeType.Delete,
+                  start: removeStart,
+                  length: removeEnd - removeStart,
+                });
+              }
+            }
+          }
+        }
+      }
+
+      // For NxReactRspackPlugin style, wrap the entire module.exports or export default with withSvgr
+      if (config.svgrOptions) {
+        const allAssignments = query(sourceFile, 'BinaryExpression');
+
+        const moduleExportsAssignment = allAssignments.find((node) => {
+          const binaryExpr = node as ts.BinaryExpression;
+          const left = binaryExpr.left;
+          return (
+            ts.isPropertyAccessExpression(left) &&
+            ts.isIdentifier(left.expression) &&
+            left.expression.text === 'module' &&
+            ts.isIdentifier(left.name) &&
+            left.name.text === 'exports'
+          );
+        }) as ts.BinaryExpression | undefined;
+
+        const exportDefaultStatements = query(sourceFile, 'ExportAssignment');
+        const exportDefaultStatement = exportDefaultStatements[0] as
+          | ts.ExportAssignment
+          | undefined;
+
+        let exportValue: ts.Expression | undefined;
+        if (moduleExportsAssignment) {
+          exportValue = moduleExportsAssignment.right;
+        } else if (exportDefaultStatement) {
+          exportValue = exportDefaultStatement.expression;
+        }
+
+        if (exportValue) {
+          let svgrCallStr = '';
+          if (config.svgrOptions === true || config.svgrOptions === undefined) {
+            svgrCallStr = 'withSvgr()';
+          } else if (typeof config.svgrOptions === 'object') {
+            const options = Object.entries(config.svgrOptions)
+              .map(([key, value]) => `  ${key}: ${value}`)
+              .join(',\n');
+            svgrCallStr = `withSvgr({\n${options}\n})`;
+          }
+
+          changes.push({
+            type: ChangeType.Insert,
+            index: exportValue.getStart(),
+            text: `${svgrCallStr}(`,
+          });
+
+          changes.push({
+            type: ChangeType.Insert,
+            index: exportValue.getEnd(),
+            text: ')',
+          });
+        }
+      }
+    }
+
+    content = applyChangesToString(content, changes);
+
+    tree.write(rspackConfigPath, content);
+  }
+
+  await formatFiles(tree);
+}

--- a/packages/rspack/src/plugins/nx-react-rspack-plugin/nx-react-rspack-plugin.ts
+++ b/packages/rspack/src/plugins/nx-react-rspack-plugin/nx-react-rspack-plugin.ts
@@ -2,15 +2,7 @@ import type { Compiler } from '@rspack/core';
 import { applyReactConfig } from '../utils/apply-react-config';
 
 export class NxReactRspackPlugin {
-  constructor(
-    private options: {
-      /**
-       * @deprecated SVGR support is deprecated and will be removed in Nx 23.
-       * TODO(v23): Remove SVGR support
-       */
-      svgr?: boolean;
-    } = {}
-  ) {}
+  constructor(private options: Record<string, any> = {}) {}
 
   apply(compiler: Compiler) {
     applyReactConfig(this.options, compiler.options);

--- a/packages/rspack/src/plugins/utils/apply-react-config.ts
+++ b/packages/rspack/src/plugins/utils/apply-react-config.ts
@@ -1,65 +1,18 @@
 import { Configuration, RspackOptionsNormalized } from '@rspack/core';
-import { logger } from '@nx/devkit';
-import { SvgrOptions } from './models';
 
-// TODO(v23): Remove SVGR support
 export function applyReactConfig(
-  options: { svgr?: boolean | SvgrOptions },
+  options: Record<string, any> = {},
   config: Partial<RspackOptionsNormalized | Configuration> = {}
 ): void {
   if (global.NX_GRAPH_CREATION) return;
 
   addHotReload(config);
 
-  if (options.svgr !== false || typeof options.svgr === 'object') {
-    // Log deprecation warning when SVGR is used
-    if (options.svgr === true || typeof options.svgr === 'object') {
-      logger.warn(
-        'SVGR support is deprecated and will be removed in Nx 23. Please consider using alternative SVG handling methods.'
-      );
-    }
-
-    removeSvgLoaderIfPresent(config);
-
-    const defaultSvgrOptions = {
-      svgo: false,
-      titleProp: true,
-      ref: true,
-    };
-
-    const svgrOptions =
-      typeof options.svgr === 'object' ? options.svgr : defaultSvgrOptions;
-
-    config.module.rules.push(
-      {
-        test: /\.svg$/i,
-        type: 'asset',
-        resourceQuery: /url/, // *.svg?url
-      },
-      {
-        test: /\.svg$/i,
-        issuer: /\.[jt]sx?$/,
-        resourceQuery: { not: [/url/] }, // exclude react component if not *.svg?url
-        use: [{ loader: '@svgr/webpack', options: svgrOptions }],
-      }
-    );
-  }
-
   // enable rspack node api
   config.node = {
     __dirname: true,
     __filename: true,
   };
-}
-
-function removeSvgLoaderIfPresent(
-  config: Partial<RspackOptionsNormalized | Configuration>
-) {
-  const svgLoaderIdx = config.module.rules.findIndex(
-    (rule) => typeof rule === 'object' && rule.test?.toString().includes('svg')
-  );
-  if (svgLoaderIdx === -1) return;
-  config.module.rules.splice(svgLoaderIdx, 1);
 }
 
 function addHotReload(

--- a/packages/rspack/src/plugins/utils/apply-web-config.ts
+++ b/packages/rspack/src/plugins/utils/apply-web-config.ts
@@ -375,19 +375,9 @@ export function applyWebConfig(
     ...(config.module ?? {}),
     rules: [
       ...(config.module.rules ?? []),
-      // Images: Inline small images, and emit a separate file otherwise.
+      // Images: Inline small images, and emit a separate file otherwise (including SVGs).
       {
-        test: /\.(avif|bmp|gif|ico|jpe?g|png|webp)$/,
-        type: 'asset',
-        parser: {
-          dataUrlCondition: {
-            maxSize: 10_000, // 10 kB
-          },
-        },
-      },
-      // SVG: same as image but we need to separate it so it can be swapped for SVGR in the React plugin.
-      {
-        test: /\.svg$/,
+        test: /\.(avif|bmp|gif|ico|jpe?g|png|svg|webp)$/,
         type: 'asset',
         parser: {
           dataUrlCondition: {

--- a/packages/rspack/src/plugins/utils/models.ts
+++ b/packages/rspack/src/plugins/utils/models.ts
@@ -2,16 +2,6 @@ import type { DevTool, Mode } from '@rspack/core';
 import type { ProjectGraph } from '@nx/devkit';
 import type { AssetGlob } from '@nx/js/src/utils/assets/assets';
 
-/**
- * @deprecated SVGR support is deprecated and will be removed in Nx 23.
- * TODO(v23): Remove SVGR support
- */
-export interface SvgrOptions {
-  svgo?: boolean;
-  titleProp?: boolean;
-  ref?: boolean;
-}
-
 export interface AssetGlobPattern {
   glob: string;
   input: string;

--- a/packages/rspack/src/utils/with-react.ts
+++ b/packages/rspack/src/utils/with-react.ts
@@ -2,15 +2,8 @@ import { Configuration } from '@rspack/core';
 import { NxRspackExecutionContext } from './config';
 import { withWeb, WithWebOptions } from './with-web';
 import { applyReactConfig } from '../plugins/utils/apply-react-config';
-import { SvgrOptions } from '../plugins/utils/models';
 
-export interface WithReactOptions extends WithWebOptions {
-  /**
-   * @deprecated SVGR support is deprecated and will be removed in Nx 23.
-   * TODO(v23): Remove SVGR support
-   */
-  svgr?: boolean | SvgrOptions;
-}
+export interface WithReactOptions extends WithWebOptions {}
 
 export function withReact(opts: WithReactOptions = {}) {
   return function makeConfig(
@@ -22,7 +15,7 @@ export function withReact(opts: WithReactOptions = {}) {
       context,
     });
 
-    applyReactConfig(opts, config);
+    applyReactConfig({}, config);
     return config;
   };
 }


### PR DESCRIPTION
## Current Behavior

`@nx/rspack` exposes an `svgr` option on `withReact` and `NxReactRspackPlugin` that wires `@svgr/webpack`. Slated for removal in v23.

## Expected Behavior

`svgr` removed from the rspack public API. SVG handling consolidated into the images asset rule. New `update-23-0-0-add-svgr-to-rspack-config` migration inlines a `withSvgr` helper into user configs to preserve behavior, mirroring the v22 webpack migration.

## Related Issue(s)

NXC-4156