### PR TITLE
fix(devkit): exclude dist from jest module path scan

### DIFF
--- a/packages/devkit/jest.config.cts
+++ b/packages/devkit/jest.config.cts
@@ -4,6 +4,7 @@ module.exports = {
   globals: {},
   displayName: 'cli',
   preset: '../../jest.preset.js',
+  modulePathIgnorePatterns: ['<rootDir>/dist/'],
   moduleNameMapper: {
     // Map Angular schematics to node_modules
     '^@schematics/angular/collection.json$':


### PR DESCRIPTION
## Current Behavior

`devkit:test` (the Jest target for `packages/devkit`) reads every `.js` and `.d.ts` file under `packages/devkit/dist/` — 160+ files paired across the entire emitted tree — that are not declared as task inputs. The sandbox flags them as unexpected reads.

Root cause: `jest-haste-map` crawls `<rootDir>` to build a module map and indexes any file matching `moduleFileExtensions` (`ts`, `tsx`, `js`, `jsx`, `html` from devkit's config). When `packages/devkit/dist/` happens to exist on the agent (e.g. a prior task in the pipeline restored a `^build-base` cache), every emitted `.js`/`.d.ts` pair gets stat'd by haste-map. `dist/` is gitignored — so it's correctly excluded from Nx's `{projectRoot}/**/*` input glob — but Jest doesn't honor `.gitignore`.

Sandbox report:
https://staging.nx.app/runs/Izc7sHvgl8/task/devkit%3Atest

## Expected Behavior

Jest does not scan into `packages/devkit/dist/`. The `devkit:test` task no longer produces unexpected reads from that directory.

## Related Issue(s)

Same pattern as #35609 (gradle).