### PR TITLE
fix(testing): exclude dist and out-tsc from default jest module path scan

### DIFF
--- a/packages/jest/preset/jest-preset.ts
+++ b/packages/jest/preset/jest-preset.ts
@@ -25,6 +25,7 @@ export const nxPreset: Config = {
     ],
   },
   testEnvironment: 'jsdom',
+  modulePathIgnorePatterns: ['<rootDir>/dist/', '<rootDir>/out-tsc/'],
   /**
    * manually set the exports names to load in common js, to mimic the behaviors of jest 27
    * before jest didn't fully support package exports and would load in common js code (typically via main field). now jest 28+ will load in the browser esm code, but jest esm support is not fully supported.


### PR DESCRIPTION
## Current Behavior

`jest-haste-map` crawls `<rootDir>` to build a module map and indexes any file matching `moduleFileExtensions`. When build outputs land inside the project (e.g. `<projectRoot>/dist` or `<projectRoot>/out-tsc`, common in TS solution setups but possible in any workspace), those emitted `.js`/`.d.ts` files get stat'd by haste-map. The `@nx/jest` preset doesn't exclude them, so consumers either see redundant filesystem work or — when running under the Nx sandbox — get flagged for unexpected reads from undeclared task inputs.

## Expected Behavior

The `@nx/jest` preset excludes `<rootDir>/dist/` and `<rootDir>/out-tsc/` from `modulePathIgnorePatterns` by default. Both directories are conventional project-local build outputs (Nx's TS solution setup already treats them as the canonical pair to exclude from tsconfig). Consumers that need to scan those directories can override the field in their own jest config.