### PR TITLE
cleanup(angular): avoid project-graph cache writes inside the angular project during plugin spec

### DIFF
--- a/packages/angular/src/plugins/plugin.spec.ts
+++ b/packages/angular/src/plugins/plugin.spec.ts
@@ -1,5 +1,4 @@
 import type { CreateNodesContextV2 } from '@nx/devkit';
-import { mkdirSync, rmSync } from 'node:fs';
 import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
 import { createNodesV2, type AngularProjectConfiguration } from './plugin';
 import { loadVite } from './utils/vitest';
@@ -18,10 +17,12 @@ describe('@nx/angular/plugin', () => {
   let createNodesFunction = createNodesV2[1];
   let context: CreateNodesContextV2;
   let tempFs: TempFs;
+  let cwd: string;
 
   beforeEach(async () => {
-    mkdirSync('tmp/project-graph-cache', { recursive: true });
     tempFs = new TempFs('angular-plugin');
+    cwd = process.cwd();
+    process.chdir(tempFs.tempDir);
     context = {
       nxJsonConfiguration: {
         namedInputs: {
@@ -37,7 +38,7 @@ describe('@nx/angular/plugin', () => {
   afterEach(() => {
     jest.resetModules();
     tempFs.cleanup();
-    rmSync('tmp/project-graph-cache', { recursive: true, force: true });
+    process.chdir(cwd);
   });
 
   it('should infer tasks from multiple projects in angular.json', async () => {


### PR DESCRIPTION
## Current Behavior

`packages/angular/src/plugins/plugin.spec.ts` mocks `nx/src/utils/cache-directory.workspaceDataDirectory` to the relative string `'tmp/project-graph-cache'`. The spec doesn't `chdir` away from the project root, so when `@nx/angular/plugin`'s `createNodesV2` calls `PluginCache.writeToDisk`, the hash file lands at `packages/angular/tmp/project-graph-cache/angular-<hash>.hash` — inside the angular project tree. This shows up as a sandbox violation on the `angular:test` task.

## Expected Behavior

The plugin cache file lands outside the project tree, like in the other plugin specs (`jest`, `docker`, `react`) that already follow this pattern. `packages/angular/tmp/` is no longer created during `angular:test`.

The fix mirrors `packages/jest/src/plugins/plugin.spec.ts`: `process.chdir(tempFs.tempDir)` in `beforeEach` and restore the original cwd in `afterEach`. The relative `'tmp/project-graph-cache'` then resolves under the `tempFs` directory (which is in `os.tmpdir()`), and `tempFs.cleanup()` already removes it. The explicit `mkdirSync`/`rmSync` of `'tmp/project-graph-cache'` is redundant — `PluginCache.writeToDisk` does its own `mkdirSync(dirname(cachePath), { recursive: true })` — and has been removed.