### PR TITLE
fix(angular-rspack): keep root-scoped assets out of per-locale i18n emit

### DIFF
--- a/packages/angular-rspack/src/lib/plugins/i18n-inline-plugin.ts
+++ b/packages/angular-rspack/src/lib/plugins/i18n-inline-plugin.ts
@@ -75,7 +75,7 @@ export class I18nInlinePlugin implements RspackPluginInstance {
           { text: string | Buffer; map: sources.RawSourceMap | null }
         >();
         for (const [filename, { text, map }] of filesToInline.entries()) {
-          if (this.#checkAssetHasBeenProcessed(filename)) {
+          if (this.#shouldSkipPerLocaleEmit(filename)) {
             continue;
           }
           const result = await this.#transformWithBabel(
@@ -96,7 +96,7 @@ export class I18nInlinePlugin implements RspackPluginInstance {
           // TODO: Add support for diagnostics
         }
         for (const [filename, source] of additionalFiles.entries()) {
-          if (this.#checkAssetHasBeenProcessed(filename)) {
+          if (this.#shouldSkipPerLocaleEmit(filename)) {
             continue;
           }
           localeFiles.set(filename, {
@@ -135,8 +135,20 @@ export class I18nInlinePlugin implements RspackPluginInstance {
     });
   }
 
-  #checkAssetHasBeenProcessed(filename: string) {
-    return this.#outputPaths.has(filename.split('/')[0]);
+  // Returns true when an asset must not be duplicated per locale.
+  // - First segment matches a locale subPath: the asset is already inside a
+  //   per-locale dir (re-entrancy guard).
+  // - Path contains a `..` segment: the asset is globally scoped and emits
+  //   outside the per-locale dir (e.g. `LicenseWebpackPlugin`'s
+  //   `../3rdpartylicenses.txt`, which lands at `outputPath.base`). This
+  //   mirrors how Angular's application builder excludes
+  //   `BuildOutputFileType.Root` files from i18n inlining; without the
+  //   guard, every locale's emit would resolve to the same physical path
+  //   and rspack's `compareBeforeEmit` would surface them as undeclared
+  //   reads.
+  #shouldSkipPerLocaleEmit(filename: string) {
+    const segments = filename.split('/');
+    return this.#outputPaths.has(segments[0]) || segments.includes('..');
   }
 
   /**


### PR DESCRIPTION
## Current Behavior

For angular-rspack i18n production builds with `extractLicenses: true`, the third-party license file is written inside the browser bundle dir at `dist/browser/3rdpartylicenses.txt` instead of at the application builder's documented location `dist/3rdpartylicenses.txt`.

The same misbehavior also surfaces sandbox violations on `examples-angular-rspack-csr-i18n:build` (unexpected reads of `dist/browser/<locale>/../3rdpartylicenses.txt`).

## Expected Behavior

The license file is written once at `dist/3rdpartylicenses.txt`, matching Angular CLI's application builder layout. The sandbox report for `examples-angular-rspack-csr-i18n:build` shows no unexpected reads.

## Implementation Details

`LicenseWebpackPlugin` is configured by angular-rspack with an asset name that escapes the browser dir, so it lands at `outputPath.base`:

```ts
outputFilename: posix.join(relative(outputPath.browser, outputPath.base), '3rdpartylicenses.txt')
// → '../3rdpartylicenses.txt'
```

`I18nInlinePlugin` re-emits every non-`$localize` asset under each locale subdirectory. With three locales (`en-GB`, `es-ES`, `fr`) the license asset becomes three asset names:

```
en-GB/../3rdpartylicenses.txt
es-ES/../3rdpartylicenses.txt
fr/../3rdpartylicenses.txt
```

These are different *path strings* but the `<locale>/..` segments cancel out, so all three resolve to the same physical file inside `dist/browser/`. Two consequences:

1. The license file lands at `dist/browser/3rdpartylicenses.txt` (the collision target) instead of `dist/3rdpartylicenses.txt` (the LicenseWebpackPlugin's intent — `outputPath.base`).
2. Rspack's `compareBeforeEmit` (default `true`) writes the file once for the first locale and then opens it `O_RDONLY` to compare contents for the other two. The sandbox tracker captures the literal syscall paths (no `..` canonicalization), so a single physical file appears as one write and two reads under three distinct path strings, and the two reads are flagged as `unexpectedReads`.

The fix updates `I18nInlinePlugin`'s skip predicate so assets whose path contains a `..` segment are not duplicated per locale. This mirrors how Angular CLI's application builder excludes `BuildOutputFileType.Root` files from i18n inlining; the rspack-asset-name analog is detected via the `..` segment.