### PR TITLE
fix(core): read pod cgroup limits instead of node limits in resource metrics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -202,7 +202,7 @@ dependencies = [
  "miniz_oxide",
  "object",
  "rustc-demangle",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -381,7 +381,7 @@ dependencies = [
  "js-sys",
  "num-traits",
  "wasm-bindgen",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -1166,7 +1166,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1bd49230192a3797a9a4d6abe9b3eed6f7fa4c8a8a4947977c6f80025f92cbd8"
 dependencies = [
  "rustix 1.1.3",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -1432,7 +1432,7 @@ dependencies = [
  "js-sys",
  "log",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -1952,7 +1952,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "754ca22de805bb5744484a5b151a9e1a8e837d5dc232c2d7d8c2e3492edc8b60"
 dependencies = [
  "cfg-if",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -2531,6 +2531,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-open-directory"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb82bed227edf5201dfedf072bba4015a33d3d4a98519837295a90f0a23f676d"
+dependencies = [
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "object"
 version = "0.37.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2596,7 +2607,7 @@ dependencies = [
  "libc",
  "redox_syscall 0.5.18",
  "smallvec",
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -4048,15 +4059,16 @@ dependencies = [
 
 [[package]]
 name = "sysinfo"
-version = "0.37.2"
+version = "0.39.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "16607d5caffd1c07ce073528f9ed972d88db15dd44023fa57142963be3feb11f"
+checksum = "a4deba334e1190ba7cb498327affa11e5ece10d26a30ab2f27fcf09504b8d8b6"
 dependencies = [
  "libc",
  "memchr",
  "ntapi",
  "objc2-core-foundation",
  "objc2-io-kit",
+ "objc2-open-directory",
  "windows",
 ]
 
@@ -5110,37 +5122,23 @@ checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
 
 [[package]]
 name = "windows"
-version = "0.61.3"
+version = "0.62.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+checksum = "527fadee13e0c05939a6a05d5bd6eec6cd2e3dbd648b9f8e447c6518133d8580"
 dependencies = [
  "windows-collections",
- "windows-core 0.61.2",
+ "windows-core",
  "windows-future",
- "windows-link 0.1.3",
  "windows-numerics",
 ]
 
 [[package]]
 name = "windows-collections"
-version = "0.2.0"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+checksum = "23b2d95af1a8a14a3c7367e1ed4fc9c20e0a26e79551b1454d72583c97cc6610"
 dependencies = [
- "windows-core 0.61.2",
-]
-
-[[package]]
-name = "windows-core"
-version = "0.61.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
-dependencies = [
- "windows-implement",
- "windows-interface",
- "windows-link 0.1.3",
- "windows-result 0.3.4",
- "windows-strings 0.4.2",
+ "windows-core",
 ]
 
 [[package]]
@@ -5151,19 +5149,19 @@ checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
 dependencies = [
  "windows-implement",
  "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
 name = "windows-future"
-version = "0.2.1"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+checksum = "e1d6f90251fe18a279739e78025bd6ddc52a7e22f921070ccdc67dde84c605cb"
 dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
+ "windows-core",
+ "windows-link",
  "windows-threading",
 ]
 
@@ -5191,24 +5189,18 @@ dependencies = [
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
-
-[[package]]
-name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-numerics"
-version = "0.2.0"
+version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+checksum = "6e2e40844ac143cdb44aead537bbf727de9b044e107a0f1220392177d15b0f26"
 dependencies = [
- "windows-core 0.61.2",
- "windows-link 0.1.3",
+ "windows-core",
+ "windows-link",
 ]
 
 [[package]]
@@ -5217,18 +5209,9 @@ version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
 dependencies = [
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
+ "windows-result",
+ "windows-strings",
 ]
 
 [[package]]
@@ -5237,16 +5220,7 @@ version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
 dependencies = [
- "windows-link 0.2.1",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
-dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]
@@ -5255,7 +5229,7 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -5300,7 +5274,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
 ]
 
 [[package]]
@@ -5340,7 +5314,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link 0.2.1",
+ "windows-link",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -5353,11 +5327,11 @@ dependencies = [
 
 [[package]]
 name = "windows-threading"
-version = "0.1.0"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+checksum = "3949bd5b99cafdf1c7ca86b43ca564028dfe27d66958f2470940f73d86d75b37"
 dependencies = [
- "windows-link 0.1.3",
+ "windows-link",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2396,6 +2396,7 @@ dependencies = [
  "itertools 0.10.5",
  "jsonc-parser",
  "jsonrpsee",
+ "libc",
  "machine-uid",
  "mio",
  "napi",

--- a/mise.toml
+++ b/mise.toml
@@ -3,7 +3,7 @@ bun = "1.3"
 java = "24"
 node = "{{ env['NODE_VERSION'] | default(value='24.11.0') }}"
 maven = "3.9.11"
-rust = "1.90.0"
+rust = "1.95.0"
 vale = "3.13.1"
 
 # Ensure that the packageManager field gets used to resolve the correct version of pnpm

--- a/packages/nx/Cargo.toml
+++ b/packages/nx/Cargo.toml
@@ -75,7 +75,17 @@ static_assertions = "1.1"
 wrap-ansi = "0.1"
 
 [target.'cfg(windows)'.dependencies]
-winapi = { version = "0.3", features = ["fileapi", "psapi"] }
+winapi = { version = "0.3", features = [
+    "fileapi",
+    "psapi",
+    # Used by the metrics collector to detect Job Object CPU rate, affinity,
+    # and memory limits — Windows analog to the Linux cgroup detection.
+    "jobapi",
+    "jobapi2",
+    "processthreadsapi",
+    "winbase",
+    "winnt",
+] }
 
 [target.'cfg(windows)'.build-dependencies]
 winres = "0.1"
@@ -91,6 +101,11 @@ uuid = "1"
 [target.'cfg(all(not(windows), not(target_family = "wasm")))'.dependencies]
 mio = "1.0"
 nix = { version = "0.30.0", features = ["fs", "process", "signal"] }
+
+# Used by the metrics collector to read sched_getaffinity directly, bypassing
+# std::thread::available_parallelism's floor-rounded cgroup quota handling.
+[target.'cfg(target_os = "linux")'.dependencies]
+libc = "0.2"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 arboard = { version = "3.4.1", features = ["wayland-data-control"] }

--- a/packages/nx/Cargo.toml
+++ b/packages/nx/Cargo.toml
@@ -53,7 +53,7 @@ swc_common = "0.31.16"
 swc_ecma_parser = { version = "0.137.1", features = ["typescript"] }
 swc_ecma_visit = "0.93.0"
 swc_ecma_ast = "0.107.0"
-sysinfo = "0.37.2"
+sysinfo = "0.39.1"
 rand = "0.9.0"
 tar = "0.4.44"
 terminal-colorsaurus = "0.4.0"

--- a/packages/nx/src/native/metrics/cgroup.rs
+++ b/packages/nx/src/native/metrics/cgroup.rs
@@ -1,0 +1,740 @@
+//! Container/cgroup-aware resource limit detection (Linux only).
+//!
+//! Discovers the calling process's cgroup CPU quota and memory limit by:
+//! 1. Parsing `/proc/self/cgroup` to find the process's cgroup path for the
+//!    requested controller.
+//! 2. Parsing `/proc/self/mountinfo` to locate where that controller is mounted
+//!    in the local filesystem, with bind-mount and cgroup-namespace handling
+//!    (the kernel virtualizes both files to be relative to the namespace root,
+//!    so the same algorithm covers namespaced and `cgroupns=host` setups).
+//! 3. Composing `mount_point + (cgroup_path − mount_root)` to get the directory
+//!    holding `cpu.max` / `memory.max` (cgroup v2) or `cpu.cfs_quota_us` etc.
+//!    (cgroup v1, including the systemd `cpu,cpuacct` co-mount).
+//! 4. Walking from the leaf up to the mount point and taking the **minimum**
+//!    finite limit found at any level. The cgroup kernel subsystem enforces
+//!    the tightest ancestor's limit (with hierarchical enforcement, which is
+//!    always-on in v2 and the modern systemd default in v1), so reading only
+//!    the leaf can overreport when a parent slice is tighter — common in
+//!    Kubernetes (pod-level cgroup tighter than container, VPA in-place
+//!    resize, Burstable QoS).
+//!
+//! Composition with `sched_getaffinity` happens in the caller — this module is
+//! only concerned with cgroup-derived limits.
+//!
+//! mountinfo paths containing spaces, tabs, newlines, or backslashes are
+//! kernel-encoded as `\040`, `\011`, `\012`, `\134` per `man 5
+//! proc_pid_mountinfo`; we unescape before joining with the cgroup path so
+//! pathological mount points don't break resolution.
+//!
+//! Implementation cross-references: Go 1.25 `internal/runtime/cgroup`,
+//! uber-go/automaxprocs v1, OpenJDK `cgroupSubsystem_linux.cpp`, .NET CoreCLR
+//! `gc/unix/cgroup.cpp`, libuv `src/unix/linux.c`, and Rust stdlib
+//! `library/std/src/sys/thread/unix.rs::cgroups`. OpenJDK's cgroupns-host
+//! suffix walk (for very old runtime + no-namespace combinations) is the only
+//! published edge case we deliberately don't replicate, as it doesn't show up
+//! in modern container/k8s deployments.
+
+use std::borrow::Cow;
+use std::path::{Path, PathBuf};
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(super) enum Version {
+    V1,
+    V2,
+}
+
+#[derive(Debug, Clone)]
+pub(super) struct CgroupLocation {
+    pub version: Version,
+    /// Absolute path on the local filesystem to the leaf cgroup directory.
+    pub dir: PathBuf,
+    /// Mount point of the cgroup hierarchy. Used as the upper bound when
+    /// walking ancestors looking for tighter limits.
+    pub mount_point: PathBuf,
+}
+
+/// Discover the cgroup directory for the given controller (e.g. `"cpu"`,
+/// `"memory"`). Returns `None` when not running under cgroups, when /proc
+/// is masked, or when the controller isn't found.
+pub(super) fn discover(controller: &str) -> Option<CgroupLocation> {
+    let cgroup_content = std::fs::read_to_string("/proc/self/cgroup").ok()?;
+    let mountinfo_content = std::fs::read_to_string("/proc/self/mountinfo").ok()?;
+    resolve_cgroup_dir(&cgroup_content, &mountinfo_content, controller)
+}
+
+/// Read the effective CPU quota in whole cores (rounded up) for the calling
+/// process, or `None` when no quota is set anywhere up to the cgroup mountpoint.
+pub(super) fn read_cpu_quota_cores() -> Option<u32> {
+    let cg = discover("cpu")?;
+    walk_for_limit(&cg, |dir| match cg.version {
+        Version::V2 => read_v2_cpu_max(dir),
+        Version::V1 => read_v1_cpu_quota(dir),
+    })
+}
+
+/// Read the effective memory limit in bytes for the calling process, or `None`
+/// when unlimited. `host_total` is used to filter cgroup-v1's "no limit"
+/// sentinel (a value at or above host RAM is treated as unset).
+pub(super) fn read_memory_limit_bytes(host_total: u64) -> Option<u64> {
+    let cg = discover("memory")?;
+    walk_for_limit(&cg, |dir| match cg.version {
+        Version::V2 => read_v2_memory_max(dir),
+        Version::V1 => read_v1_memory_limit(dir, host_total),
+    })
+}
+
+/// Walk from the leaf cgroup directory up to the mount point, accumulating the
+/// **minimum** finite limit across all levels. The kernel enforces the
+/// tightest ancestor's limit, so a leaf with a relaxed limit under a tighter
+/// parent slice would otherwise be overreported. Matches libuv's
+/// `uv__get_constrained_cpu`, Rust stdlib `cgroups::quota_v{1,2}`, and .NET
+/// CoreCLR's memory walker.
+fn walk_for_limit<T: Ord>(cg: &CgroupLocation, read_at: impl Fn(&Path) -> Option<T>) -> Option<T> {
+    let mut current = cg.dir.clone();
+    let mut tightest: Option<T> = None;
+    loop {
+        if let Some(value) = read_at(&current) {
+            tightest = Some(match tightest {
+                Some(prev) => prev.min(value),
+                None => value,
+            });
+        }
+        if current == cg.mount_point {
+            return tightest;
+        }
+        if !current.pop() {
+            return tightest;
+        }
+        if !current.starts_with(&cg.mount_point) {
+            return tightest;
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Pure parsers (covered by unit tests; do no I/O)
+// ---------------------------------------------------------------------------
+
+/// Compose the cgroup directory path from `/proc/self/cgroup` and
+/// `/proc/self/mountinfo` contents.
+fn resolve_cgroup_dir(
+    cgroup_content: &str,
+    mountinfo_content: &str,
+    controller: &str,
+) -> Option<CgroupLocation> {
+    let (version, cgroup_path) = parse_proc_self_cgroup(cgroup_content, controller)?;
+
+    for line in mountinfo_content.lines() {
+        let Some(entry) = parse_mountinfo_line(line) else {
+            continue;
+        };
+
+        match version {
+            Version::V2 if entry.fs_type != "cgroup2" => continue,
+            Version::V1 => {
+                if entry.fs_type != "cgroup" {
+                    continue;
+                }
+                if !entry.super_options.split(',').any(|o| o == controller) {
+                    continue;
+                }
+            }
+            _ => {}
+        }
+
+        let mount_root = unescape_mountinfo(entry.mount_root);
+        let Some(rel) = strip_path_prefix(cgroup_path, mount_root.as_ref()) else {
+            // This mountpoint exposes a different subtree of the hierarchy than
+            // the one our process lives in; keep searching.
+            continue;
+        };
+
+        let mount_point = PathBuf::from(unescape_mountinfo(entry.mount_point).as_ref());
+        let rel_clean = rel.trim_start_matches('/');
+        let dir = if rel_clean.is_empty() {
+            mount_point.clone()
+        } else {
+            mount_point.join(rel_clean)
+        };
+
+        return Some(CgroupLocation {
+            version,
+            dir,
+            mount_point,
+        });
+    }
+
+    None
+}
+
+/// Unescape the four octal sequences the kernel emits in mountinfo path fields:
+/// `\040` (space), `\011` (tab), `\012` (newline), `\134` (backslash).
+/// Returns the original borrowed string when no escape is present (the common
+/// case) to avoid the allocation.
+fn unescape_mountinfo(s: &str) -> Cow<'_, str> {
+    if !s.contains('\\') {
+        return Cow::Borrowed(s);
+    }
+    let mut out = String::with_capacity(s.len());
+    let bytes = s.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'\\' && i + 3 < bytes.len() {
+            let (a, b, c) = (bytes[i + 1], bytes[i + 2], bytes[i + 3]);
+            if let (Some(da), Some(db), Some(dc)) = (octal_digit(a), octal_digit(b), octal_digit(c))
+            {
+                let value = (da << 6) | (db << 3) | dc;
+                // Only the four sequences the kernel actually emits — be strict
+                // to avoid corrupting unrelated backslash sequences.
+                if matches!(value, b' ' | b'\t' | b'\n' | b'\\') {
+                    out.push(value as char);
+                    i += 4;
+                    continue;
+                }
+            }
+        }
+        out.push(bytes[i] as char);
+        i += 1;
+    }
+    Cow::Owned(out)
+}
+
+fn octal_digit(b: u8) -> Option<u8> {
+    if (b'0'..=b'7').contains(&b) {
+        Some(b - b'0')
+    } else {
+        None
+    }
+}
+
+/// Parse `/proc/self/cgroup` and return the version + path for the controller.
+/// v1 lines (e.g. `12:cpu,cpuacct:/some/path`) take precedence over the v2
+/// unified line (`0::/some/path`) when both are present (hybrid hosts).
+fn parse_proc_self_cgroup<'a>(content: &'a str, controller: &str) -> Option<(Version, &'a str)> {
+    let mut v2_path: Option<&'a str> = None;
+    for line in content.lines() {
+        let mut parts = line.splitn(3, ':');
+        let _id = parts.next()?;
+        let controllers = parts.next()?;
+        let path = parts.next()?;
+
+        if controllers.is_empty() {
+            // Unified v2 line. Tentatively record; v1 controllers below win.
+            v2_path = Some(path);
+        } else if controllers.split(',').any(|c| c == controller) {
+            return Some((Version::V1, path));
+        }
+    }
+    v2_path.map(|p| (Version::V2, p))
+}
+
+#[derive(Debug)]
+struct MountEntry<'a> {
+    mount_root: &'a str,
+    mount_point: &'a str,
+    fs_type: &'a str,
+    super_options: &'a str,
+}
+
+/// Parse a single line of `/proc/self/mountinfo`. Format:
+///   `<mount-id> <parent-id> <major:minor> <root> <mount-point> <opts> [<optional-fields>] - <fs-type> <source> <super-options>`
+fn parse_mountinfo_line(line: &str) -> Option<MountEntry<'_>> {
+    // The " - " separator divides the variable-length pre-fields from the
+    // fixed three post-fields. Splitting on it makes parsing trivial.
+    let (pre, post) = line.split_once(" - ")?;
+
+    let mut pre_parts = pre.split_ascii_whitespace();
+    let _mount_id = pre_parts.next()?;
+    let _parent_id = pre_parts.next()?;
+    let _major_minor = pre_parts.next()?;
+    let mount_root = pre_parts.next()?;
+    let mount_point = pre_parts.next()?;
+    // Remaining pre-fields: <mount-options> [<optional-fields...>] — ignored.
+
+    let mut post_parts = post.split_ascii_whitespace();
+    let fs_type = post_parts.next()?;
+    let _source = post_parts.next()?;
+    let super_options = post_parts.next()?;
+
+    Some(MountEntry {
+        mount_root,
+        mount_point,
+        fs_type,
+        super_options,
+    })
+}
+
+/// Strip `prefix` from `path` (both as POSIX paths). Returns the remainder when
+/// `path` is at or under `prefix`. Treats `/` and the empty string as no-op
+/// prefixes.
+fn strip_path_prefix<'a>(path: &'a str, prefix: &str) -> Option<&'a str> {
+    if prefix.is_empty() || prefix == "/" {
+        return Some(path);
+    }
+    if path == prefix {
+        return Some("");
+    }
+    if let Some(rest) = path.strip_prefix(prefix)
+        && rest.starts_with('/')
+    {
+        return Some(rest);
+    }
+    None
+}
+
+// ---------------------------------------------------------------------------
+// Limit file readers
+// ---------------------------------------------------------------------------
+
+fn read_v2_cpu_max(dir: &Path) -> Option<u32> {
+    let content = std::fs::read_to_string(dir.join("cpu.max")).ok()?;
+    parse_v2_cpu_max(&content)
+}
+
+fn parse_v2_cpu_max(content: &str) -> Option<u32> {
+    let mut parts = content.split_whitespace();
+    let quota = parts.next()?;
+    let period = parts.next()?;
+    if quota == "max" {
+        return None;
+    }
+    let q: u64 = quota.parse().ok()?;
+    let p: u64 = period.parse().ok()?;
+    cores_from_quota(q, p)
+}
+
+fn read_v1_cpu_quota(dir: &Path) -> Option<u32> {
+    let q_raw = std::fs::read_to_string(dir.join("cpu.cfs_quota_us")).ok()?;
+    let q: i64 = q_raw.trim().parse().ok()?;
+    if q <= 0 {
+        return None;
+    }
+    let p_raw = std::fs::read_to_string(dir.join("cpu.cfs_period_us")).ok()?;
+    let p: u64 = p_raw.trim().parse().ok()?;
+    cores_from_quota(q as u64, p)
+}
+
+fn cores_from_quota(quota: u64, period: u64) -> Option<u32> {
+    if period == 0 {
+        return None;
+    }
+    let cores = quota.div_ceil(period).min(u32::MAX as u64) as u32;
+    Some(cores.max(1))
+}
+
+fn read_v2_memory_max(dir: &Path) -> Option<u64> {
+    let content = std::fs::read_to_string(dir.join("memory.max")).ok()?;
+    let trimmed = content.trim();
+    if trimmed == "max" {
+        return None;
+    }
+    trimmed.parse().ok()
+}
+
+fn read_v1_memory_limit(dir: &Path, host_total: u64) -> Option<u64> {
+    let content = std::fs::read_to_string(dir.join("memory.limit_in_bytes")).ok()?;
+    let bytes: u64 = content.trim().parse().ok()?;
+    // v1 has no "max" sentinel; the kernel reports something around
+    // `0x7FFFFFFFFFFFF000` (PAGE_COUNTER_MAX) when no limit is set. Anything at
+    // or above host RAM is meaningless as a "container limit", so treat as unset.
+    if host_total > 0 && bytes >= host_total {
+        return None;
+    }
+    Some(bytes)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::TempDir;
+
+    // ----- pure parsers -----
+
+    #[test]
+    fn cores_from_quota_rounds_up() {
+        assert_eq!(cores_from_quota(600_000, 100_000), Some(6));
+        assert_eq!(cores_from_quota(550_000, 100_000), Some(6)); // 5.5 → 6
+        assert_eq!(cores_from_quota(150_000, 100_000), Some(2)); // 1.5 → 2
+        assert_eq!(cores_from_quota(10_000, 100_000), Some(1)); // sub-core clamped to 1
+        assert_eq!(cores_from_quota(100_000, 0), None);
+    }
+
+    #[test]
+    fn parse_v2_cpu_max_handles_max() {
+        assert_eq!(parse_v2_cpu_max("max 100000\n"), None);
+        assert_eq!(parse_v2_cpu_max("600000 100000\n"), Some(6));
+        assert_eq!(parse_v2_cpu_max("garbage"), None);
+    }
+
+    #[test]
+    fn strip_path_prefix_handles_root_and_subpath() {
+        assert_eq!(strip_path_prefix("/foo/bar", "/"), Some("/foo/bar"));
+        assert_eq!(strip_path_prefix("/foo/bar", ""), Some("/foo/bar"));
+        assert_eq!(strip_path_prefix("/foo/bar", "/foo"), Some("/bar"));
+        assert_eq!(strip_path_prefix("/foo", "/foo"), Some(""));
+        // Must not match a partial directory name.
+        assert_eq!(strip_path_prefix("/foobar", "/foo"), None);
+        // Path under different subtree.
+        assert_eq!(strip_path_prefix("/foo", "/bar"), None);
+    }
+
+    #[test]
+    fn parse_proc_self_cgroup_v2_unified() {
+        let content = "0::/kubepods.slice/pod-uid/container-id\n";
+        let parsed = parse_proc_self_cgroup(content, "cpu");
+        assert_eq!(
+            parsed,
+            Some((Version::V2, "/kubepods.slice/pod-uid/container-id"))
+        );
+    }
+
+    #[test]
+    fn parse_proc_self_cgroup_v1_co_mount() {
+        // systemd-managed cgroup v1: cpu and cpuacct are co-mounted.
+        let content = "12:cpu,cpuacct:/kubepods/pod-uid/container-id\n\
+                       11:memory:/kubepods/pod-uid/container-id\n";
+        assert_eq!(
+            parse_proc_self_cgroup(content, "cpu"),
+            Some((Version::V1, "/kubepods/pod-uid/container-id"))
+        );
+        assert_eq!(
+            parse_proc_self_cgroup(content, "cpuacct"),
+            Some((Version::V1, "/kubepods/pod-uid/container-id"))
+        );
+        assert_eq!(
+            parse_proc_self_cgroup(content, "memory"),
+            Some((Version::V1, "/kubepods/pod-uid/container-id"))
+        );
+    }
+
+    #[test]
+    fn parse_proc_self_cgroup_hybrid_prefers_v1() {
+        // Hybrid host: v1 controllers and v2 unified hierarchy both present.
+        let content = "12:cpu,cpuacct:/host-cpu-path\n\
+                       0::/unified-path\n";
+        assert_eq!(
+            parse_proc_self_cgroup(content, "cpu"),
+            Some((Version::V1, "/host-cpu-path"))
+        );
+    }
+
+    #[test]
+    fn parse_mountinfo_line_basic() {
+        let line =
+            "31 27 0:27 / /sys/fs/cgroup ro,nosuid,nodev,noexec shared:9 - cgroup2 cgroup2 rw";
+        let entry = parse_mountinfo_line(line).expect("parsed");
+        assert_eq!(entry.fs_type, "cgroup2");
+        assert_eq!(entry.mount_point, "/sys/fs/cgroup");
+        assert_eq!(entry.mount_root, "/");
+        assert_eq!(entry.super_options, "rw");
+    }
+
+    #[test]
+    fn parse_mountinfo_line_v1_co_mount_with_optional_fields() {
+        let line = "35 31 0:30 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid,nodev,noexec,relatime \
+                    shared:14 master:7 - cgroup cgroup rw,cpu,cpuacct";
+        let entry = parse_mountinfo_line(line).expect("parsed");
+        assert_eq!(entry.fs_type, "cgroup");
+        assert_eq!(entry.mount_point, "/sys/fs/cgroup/cpu,cpuacct");
+        assert!(entry.super_options.split(',').any(|o| o == "cpu"));
+        assert!(entry.super_options.split(',').any(|o| o == "cpuacct"));
+    }
+
+    // ----- resolve_cgroup_dir orchestration -----
+
+    #[test]
+    fn resolve_v2_namespaced_container() {
+        // Modern container with cgroup namespaces: kernel virtualizes
+        // /proc/self/cgroup and mountinfo to be relative to the namespace root.
+        let cgroup = "0::/\n";
+        let mountinfo =
+            "31 27 0:27 / /sys/fs/cgroup ro,nosuid,nodev,noexec shared:9 - cgroup2 cgroup2 rw\n";
+        let cg = resolve_cgroup_dir(cgroup, mountinfo, "cpu").expect("resolved");
+        assert_eq!(cg.version, Version::V2);
+        assert_eq!(cg.dir, PathBuf::from("/sys/fs/cgroup"));
+        assert_eq!(cg.mount_point, PathBuf::from("/sys/fs/cgroup"));
+    }
+
+    #[test]
+    fn resolve_v2_cgroupns_host() {
+        // cgroupns=host: process sees the host's cgroup tree and a host-rooted
+        // cgroup path. The mount root stays "/".
+        let cgroup = "0::/kubepods.slice/pod-uid/container-id\n";
+        let mountinfo =
+            "31 27 0:27 / /sys/fs/cgroup ro,nosuid,nodev,noexec shared:9 - cgroup2 cgroup2 rw\n";
+        let cg = resolve_cgroup_dir(cgroup, mountinfo, "cpu").expect("resolved");
+        assert_eq!(cg.version, Version::V2);
+        assert_eq!(
+            cg.dir,
+            PathBuf::from("/sys/fs/cgroup/kubepods.slice/pod-uid/container-id")
+        );
+    }
+
+    #[test]
+    fn resolve_v2_with_bind_mount_root() {
+        // Bind-mount: /sys/fs/cgroup inside the container is bind-mounted from
+        // a sub-path of the host tree. The mount_root field reflects the host
+        // sub-path; mountinfo is virtualized in modern kernels but we still
+        // need to handle the historical mount_root != "/" case.
+        let cgroup = "0::/kubepods.slice/pod-uid/container-id\n";
+        let mountinfo = "31 27 0:27 /kubepods.slice/pod-uid /sys/fs/cgroup ro shared:9 \
+                         - cgroup2 cgroup2 rw\n";
+        let cg = resolve_cgroup_dir(cgroup, mountinfo, "cpu").expect("resolved");
+        assert_eq!(cg.dir, PathBuf::from("/sys/fs/cgroup/container-id"));
+    }
+
+    #[test]
+    fn resolve_v1_co_mount() {
+        // systemd v1: cpu and cpuacct co-mounted at /sys/fs/cgroup/cpu,cpuacct.
+        // The bug Codex flagged in the previous patch.
+        let cgroup = "12:cpu,cpuacct:/kubepods/pod-uid/container-id\n";
+        let mountinfo = "35 31 0:30 / /sys/fs/cgroup/cpu,cpuacct rw,nosuid shared:14 \
+                         - cgroup cgroup rw,cpu,cpuacct\n";
+        let cg = resolve_cgroup_dir(cgroup, mountinfo, "cpu").expect("resolved");
+        assert_eq!(cg.version, Version::V1);
+        assert_eq!(
+            cg.dir,
+            PathBuf::from("/sys/fs/cgroup/cpu,cpuacct/kubepods/pod-uid/container-id")
+        );
+    }
+
+    #[test]
+    fn resolve_v1_memory() {
+        let cgroup = "11:memory:/kubepods/pod-uid/container-id\n";
+        let mountinfo = "36 31 0:31 / /sys/fs/cgroup/memory rw,nosuid shared:15 \
+                         - cgroup cgroup rw,memory\n";
+        let cg = resolve_cgroup_dir(cgroup, mountinfo, "memory").expect("resolved");
+        assert_eq!(cg.version, Version::V1);
+        assert_eq!(
+            cg.dir,
+            PathBuf::from("/sys/fs/cgroup/memory/kubepods/pod-uid/container-id")
+        );
+    }
+
+    #[test]
+    fn resolve_returns_none_when_controller_missing() {
+        let cgroup = "12:other:/path\n";
+        let mountinfo = "35 31 0:30 / /sys/fs/cgroup/other rw shared:14 - cgroup cgroup rw,other\n";
+        assert!(resolve_cgroup_dir(cgroup, mountinfo, "cpu").is_none());
+    }
+
+    #[test]
+    fn resolve_skips_mount_unable_to_reach_cgroup() {
+        // Mount root points at a subtree that doesn't contain our cgroup path.
+        let cgroup = "0::/foo/bar\n";
+        let mountinfo = "31 27 0:27 /unrelated /sys/fs/cgroup ro shared:9 - cgroup2 cgroup2 rw\n";
+        assert!(resolve_cgroup_dir(cgroup, mountinfo, "cpu").is_none());
+    }
+
+    // ----- walk_for_limit + limit readers (touch the filesystem via tempdir) -----
+
+    #[test]
+    fn walk_for_limit_reads_leaf() {
+        let tmp = TempDir::new().unwrap();
+        let mount = tmp.path();
+        let leaf = mount.join("a/b/c");
+        fs::create_dir_all(&leaf).unwrap();
+        fs::write(leaf.join("cpu.max"), "300000 100000\n").unwrap();
+        let cg = CgroupLocation {
+            version: Version::V2,
+            dir: leaf,
+            mount_point: mount.to_path_buf(),
+        };
+        let cores = walk_for_limit(&cg, |dir| read_v2_cpu_max(dir));
+        assert_eq!(cores, Some(3));
+    }
+
+    #[test]
+    fn walk_for_limit_climbs_when_leaf_unlimited() {
+        // Leaf has cpu.max="max"; ancestor has a real limit.
+        let tmp = TempDir::new().unwrap();
+        let mount = tmp.path();
+        let pod = mount.join("pod-uid");
+        let container = pod.join("container-id");
+        fs::create_dir_all(&container).unwrap();
+        fs::write(container.join("cpu.max"), "max 100000\n").unwrap();
+        fs::write(pod.join("cpu.max"), "200000 100000\n").unwrap();
+        let cg = CgroupLocation {
+            version: Version::V2,
+            dir: container,
+            mount_point: mount.to_path_buf(),
+        };
+        let cores = walk_for_limit(&cg, |dir| read_v2_cpu_max(dir));
+        assert_eq!(cores, Some(2));
+    }
+
+    #[test]
+    fn walk_for_limit_takes_min_when_parent_tighter() {
+        // Codex P2: leaf has a finite limit (4 cores) but a parent slice is
+        // tighter (2 cores). The kernel enforces the minimum, so we must too.
+        let tmp = TempDir::new().unwrap();
+        let mount = tmp.path();
+        let pod = mount.join("pod-uid");
+        let container = pod.join("container-id");
+        fs::create_dir_all(&container).unwrap();
+        fs::write(container.join("cpu.max"), "400000 100000\n").unwrap();
+        fs::write(pod.join("cpu.max"), "200000 100000\n").unwrap();
+        let cg = CgroupLocation {
+            version: Version::V2,
+            dir: container,
+            mount_point: mount.to_path_buf(),
+        };
+        let cores = walk_for_limit(&cg, |dir| read_v2_cpu_max(dir));
+        assert_eq!(cores, Some(2));
+    }
+
+    #[test]
+    fn walk_for_limit_takes_min_when_leaf_tighter() {
+        // Symmetric case: leaf is tighter than parent. Leaf should still win.
+        let tmp = TempDir::new().unwrap();
+        let mount = tmp.path();
+        let pod = mount.join("pod-uid");
+        let container = pod.join("container-id");
+        fs::create_dir_all(&container).unwrap();
+        fs::write(container.join("cpu.max"), "100000 100000\n").unwrap();
+        fs::write(pod.join("cpu.max"), "400000 100000\n").unwrap();
+        let cg = CgroupLocation {
+            version: Version::V2,
+            dir: container,
+            mount_point: mount.to_path_buf(),
+        };
+        let cores = walk_for_limit(&cg, |dir| read_v2_cpu_max(dir));
+        assert_eq!(cores, Some(1));
+    }
+
+    #[test]
+    fn walk_for_limit_takes_min_for_memory() {
+        // Same hierarchical-min semantic for memory.
+        let tmp = TempDir::new().unwrap();
+        let mount = tmp.path();
+        let pod = mount.join("pod-uid");
+        let container = pod.join("container-id");
+        fs::create_dir_all(&container).unwrap();
+        let leaf_limit = 16u64 * 1024 * 1024 * 1024;
+        let pod_limit = 12u64 * 1024 * 1024 * 1024;
+        fs::write(container.join("memory.max"), format!("{leaf_limit}\n")).unwrap();
+        fs::write(pod.join("memory.max"), format!("{pod_limit}\n")).unwrap();
+        let cg = CgroupLocation {
+            version: Version::V2,
+            dir: container,
+            mount_point: mount.to_path_buf(),
+        };
+        let bytes = walk_for_limit(&cg, |dir| read_v2_memory_max(dir));
+        assert_eq!(bytes, Some(pod_limit));
+    }
+
+    #[test]
+    fn walk_for_limit_returns_none_when_unlimited_to_root() {
+        let tmp = TempDir::new().unwrap();
+        let mount = tmp.path();
+        let leaf = mount.join("a");
+        fs::create_dir_all(&leaf).unwrap();
+        fs::write(leaf.join("cpu.max"), "max 100000\n").unwrap();
+        fs::write(mount.join("cpu.max"), "max 100000\n").unwrap();
+        let cg = CgroupLocation {
+            version: Version::V2,
+            dir: leaf,
+            mount_point: mount.to_path_buf(),
+        };
+        assert!(walk_for_limit(&cg, |dir| read_v2_cpu_max(dir)).is_none());
+    }
+
+    #[test]
+    fn read_v1_cpu_quota_handles_unlimited_sentinel() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("cpu.cfs_quota_us"), "-1\n").unwrap();
+        fs::write(tmp.path().join("cpu.cfs_period_us"), "100000\n").unwrap();
+        assert!(read_v1_cpu_quota(tmp.path()).is_none());
+    }
+
+    #[test]
+    fn read_v1_cpu_quota_reads_value() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("cpu.cfs_quota_us"), "150000\n").unwrap();
+        fs::write(tmp.path().join("cpu.cfs_period_us"), "100000\n").unwrap();
+        assert_eq!(read_v1_cpu_quota(tmp.path()), Some(2)); // 1.5 → 2
+    }
+
+    #[test]
+    fn read_v1_memory_limit_filters_unlimited_sentinel() {
+        let tmp = TempDir::new().unwrap();
+        let host_total = 64u64 * 1024 * 1024 * 1024;
+        // Kernel reports something near 2^63 when unlimited; anything >= host
+        // should be treated as unset.
+        fs::write(
+            tmp.path().join("memory.limit_in_bytes"),
+            "9223372036854771712\n",
+        )
+        .unwrap();
+        assert!(read_v1_memory_limit(tmp.path(), host_total).is_none());
+    }
+
+    #[test]
+    fn read_v1_memory_limit_reads_value() {
+        let tmp = TempDir::new().unwrap();
+        let host_total = 64u64 * 1024 * 1024 * 1024;
+        let limit = 12u64 * 1024 * 1024 * 1024;
+        fs::write(
+            tmp.path().join("memory.limit_in_bytes"),
+            format!("{limit}\n"),
+        )
+        .unwrap();
+        assert_eq!(read_v1_memory_limit(tmp.path(), host_total), Some(limit));
+    }
+
+    #[test]
+    fn read_v2_memory_max_handles_max() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("memory.max"), "max\n").unwrap();
+        assert!(read_v2_memory_max(tmp.path()).is_none());
+        fs::write(tmp.path().join("memory.max"), "12884901888\n").unwrap();
+        assert_eq!(read_v2_memory_max(tmp.path()), Some(12884901888));
+    }
+
+    // ----- mountinfo octal-escape unescape -----
+
+    #[test]
+    fn unescape_mountinfo_passes_through_when_no_backslash() {
+        let s = "/sys/fs/cgroup/cpu,cpuacct";
+        match unescape_mountinfo(s) {
+            Cow::Borrowed(b) => assert_eq!(b, s),
+            Cow::Owned(_) => panic!("expected borrowed for path without backslash"),
+        }
+    }
+
+    #[test]
+    fn unescape_mountinfo_decodes_kernel_escapes() {
+        assert_eq!(
+            unescape_mountinfo("/path\\040with\\040spaces"),
+            "/path with spaces"
+        );
+        assert_eq!(unescape_mountinfo("/tab\\011here"), "/tab\there");
+        assert_eq!(unescape_mountinfo("/newline\\012here"), "/newline\nhere");
+        assert_eq!(unescape_mountinfo("/back\\134slash"), "/back\\slash");
+    }
+
+    #[test]
+    fn unescape_mountinfo_leaves_unrelated_backslashes_alone() {
+        // Only the four kernel-emitted sequences are unescaped; unrelated
+        // backslash sequences (from arbitrary content) pass through unchanged.
+        assert_eq!(
+            unescape_mountinfo("/path\\with\\backslash"),
+            "/path\\with\\backslash"
+        );
+    }
+
+    #[test]
+    fn resolve_mountinfo_with_escaped_mount_point() {
+        // Synthetic but valid: a mount point containing a space, encoded as \040.
+        let cgroup = "0::/\n";
+        let mountinfo = "31 27 0:27 / /weird\\040mount ro shared:9 - cgroup2 cgroup2 rw\n";
+        let cg = resolve_cgroup_dir(cgroup, mountinfo, "cpu").expect("resolved");
+        assert_eq!(cg.dir, PathBuf::from("/weird mount"));
+        assert_eq!(cg.mount_point, PathBuf::from("/weird mount"));
+    }
+}

--- a/packages/nx/src/native/metrics/cgroup.rs
+++ b/packages/nx/src/native/metrics/cgroup.rs
@@ -37,6 +37,10 @@
 use std::borrow::Cow;
 use std::path::{Path, PathBuf};
 
+use tracing::debug;
+
+use super::metrics_math::{is_finite_memory_limit, take_min};
+
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
 pub(super) enum Version {
     V1,
@@ -57,9 +61,17 @@ pub(super) struct CgroupLocation {
 /// `"memory"`). Returns `None` when not running under cgroups, when /proc
 /// is masked, or when the controller isn't found.
 pub(super) fn discover(controller: &str) -> Option<CgroupLocation> {
-    let cgroup_content = std::fs::read_to_string("/proc/self/cgroup").ok()?;
-    let mountinfo_content = std::fs::read_to_string("/proc/self/mountinfo").ok()?;
-    resolve_cgroup_dir(&cgroup_content, &mountinfo_content, controller)
+    let cgroup_content = std::fs::read_to_string("/proc/self/cgroup")
+        .inspect_err(|e| debug!("failed to read /proc/self/cgroup: {e}"))
+        .ok()?;
+    let mountinfo_content = std::fs::read_to_string("/proc/self/mountinfo")
+        .inspect_err(|e| debug!("failed to read /proc/self/mountinfo: {e}"))
+        .ok()?;
+    let location = resolve_cgroup_dir(&cgroup_content, &mountinfo_content, controller);
+    if location.is_none() {
+        debug!("no cgroup mount matched controller {controller:?}");
+    }
+    location
 }
 
 /// Read the effective CPU quota in whole cores (rounded up) for the calling
@@ -94,10 +106,7 @@ fn walk_for_limit<T: Ord>(cg: &CgroupLocation, read_at: impl Fn(&Path) -> Option
     let mut tightest: Option<T> = None;
     loop {
         if let Some(value) = read_at(&current) {
-            tightest = Some(match tightest {
-                Some(prev) => prev.min(value),
-                None => value,
-            });
+            tightest = take_min(tightest, value);
         }
         if current == cg.mount_point {
             return tightest;
@@ -335,12 +344,9 @@ fn read_v1_memory_limit(dir: &Path, host_total: u64) -> Option<u64> {
     let content = std::fs::read_to_string(dir.join("memory.limit_in_bytes")).ok()?;
     let bytes: u64 = content.trim().parse().ok()?;
     // v1 has no "max" sentinel; the kernel reports something around
-    // `0x7FFFFFFFFFFFF000` (PAGE_COUNTER_MAX) when no limit is set. Anything at
-    // or above host RAM is meaningless as a "container limit", so treat as unset.
-    if host_total > 0 && bytes >= host_total {
-        return None;
-    }
-    Some(bytes)
+    // `0x7FFFFFFFFFFFF000` (PAGE_COUNTER_MAX) when no limit is set, and
+    // anything at or above host RAM is meaningless as a "container limit".
+    is_finite_memory_limit(bytes, host_total).then_some(bytes)
 }
 
 // ---------------------------------------------------------------------------
@@ -672,6 +678,13 @@ mod tests {
         )
         .unwrap();
         assert!(read_v1_memory_limit(tmp.path(), host_total).is_none());
+    }
+
+    #[test]
+    fn read_v1_memory_limit_filters_zero() {
+        let tmp = TempDir::new().unwrap();
+        fs::write(tmp.path().join("memory.limit_in_bytes"), "0\n").unwrap();
+        assert!(read_v1_memory_limit(tmp.path(), 64 * 1024 * 1024 * 1024).is_none());
     }
 
     #[test]

--- a/packages/nx/src/native/metrics/collector.rs
+++ b/packages/nx/src/native/metrics/collector.rs
@@ -33,6 +33,107 @@ const DAEMON_SUBPROCESSES_GROUP_ID: &str = "daemon_subprocesses";
 // Shutdown check interval for the collection thread
 const SHUTDOWN_CHECK_INTERVAL_MS: u64 = 50;
 
+/// Detect the effective CPU count, honoring container/cgroup limits when present.
+/// On Linux, returns the minimum of:
+/// - host CPU count
+/// - `ceil(cpu.max quota / period)` from the calling process's actual cgroup
+///   directory (v2 or v1, including the systemd `cpu,cpuacct` co-mount and
+///   bind-mounted hierarchies — see `cgroup` module)
+/// - `sched_getaffinity` (covers cpuset / taskset)
+/// Matches the ceil-quota semantic used by HotSpot JVM, Go 1.25, .NET, and the
+/// num_cpus crate. We bypass `std::thread::available_parallelism()` because
+/// rust-lang/rust's implementation applies the cgroup quota with floor division
+/// internally (`limit / period`) and would silently defeat the ceil for fractional
+/// quotas (e.g. 1.5 cores → 1). See `library/std/src/sys/thread/unix.rs`.
+///
+/// On Windows, returns the minimum of:
+/// - host CPU count
+/// - `ceil(host_cpu_count × CpuRate / 10000)` from a `HARD_CAP` Job Object
+///   rate (Docker `--cpus N` and equivalent — see `job_object` module)
+/// - popcount of the Job Object affinity mask (when `LIMIT_AFFINITY` is set)
+/// - popcount of `GetProcessAffinityMask` (Job + manual + system intersection)
+///
+/// On macOS, returns the host CPU count unchanged. macOS has no
+/// container-style CPU enforcement primitives for native processes; container
+/// runtimes on macOS run Linux VMs where the Linux path applies.
+#[cfg(target_os = "linux")]
+fn detect_effective_cpu_count(host_cpu_count: u32) -> u32 {
+    let mut effective = host_cpu_count;
+
+    if let Some(quota_cpus) = super::cgroup::read_cpu_quota_cores() {
+        effective = effective.min(quota_cpus);
+    }
+
+    if let Some(affinity) = read_sched_affinity_count() {
+        effective = effective.min(affinity);
+    }
+
+    effective.max(1)
+}
+
+/// Count the CPUs the calling process is allowed to run on via `sched_getaffinity`.
+/// Returns `None` when the syscall fails or the resulting set is empty (matches
+/// stdlib's defensive treatment of buggy old MIPS kernels).
+#[cfg(target_os = "linux")]
+fn read_sched_affinity_count() -> Option<u32> {
+    // SAFETY: `cpu_set_t` is a POD bitmask; we zero-init it and pass its size to
+    // a libc function that fills it. No aliasing, no lifetimes leaked.
+    unsafe {
+        let mut set: libc::cpu_set_t = std::mem::zeroed();
+        if libc::sched_getaffinity(0, std::mem::size_of::<libc::cpu_set_t>(), &mut set) != 0 {
+            return None;
+        }
+        let count = libc::CPU_COUNT(&set) as u32;
+        if count == 0 { None } else { Some(count) }
+    }
+}
+
+#[cfg(target_os = "windows")]
+fn detect_effective_cpu_count(host_cpu_count: u32) -> u32 {
+    let mut effective = host_cpu_count;
+    if let Some(job_cpus) = super::job_object::read_job_cpu_quota_cores(host_cpu_count) {
+        effective = effective.min(job_cpus);
+    }
+    effective.max(1)
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "windows")))]
+fn detect_effective_cpu_count(host_cpu_count: u32) -> u32 {
+    host_cpu_count
+}
+
+/// Detect the effective memory limit in bytes, honoring container/cgroup limits.
+/// On Linux, reads the cgroup `memory.max` (v2) or `memory.limit_in_bytes` (v1)
+/// from the calling process's actual cgroup directory (with bind-mount handling),
+/// falling back to host RAM when unlimited or absent.
+///
+/// On Windows, reads the Job Object's `ProcessMemoryLimit` / `JobMemoryLimit`
+/// / `MaximumWorkingSetSize` (whichever are set in `LimitFlags`), takes the
+/// minimum, and falls back to host RAM when no limits are set. Mirrors what
+/// HotSpot and .NET CoreCLR do.
+///
+/// On macOS, returns host RAM unchanged. macOS has no container-style memory
+/// enforcement primitives for native processes; container runtimes on macOS
+/// run Linux VMs where the Linux path applies.
+#[cfg(target_os = "linux")]
+fn detect_effective_total_memory(host_total: u64) -> i64 {
+    super::cgroup::read_memory_limit_bytes(host_total)
+        .map(|b| b.min(host_total) as i64)
+        .unwrap_or(host_total as i64)
+}
+
+#[cfg(target_os = "windows")]
+fn detect_effective_total_memory(host_total: u64) -> i64 {
+    super::job_object::read_job_memory_limit_bytes(host_total)
+        .map(|b| b.min(host_total) as i64)
+        .unwrap_or(host_total as i64)
+}
+
+#[cfg(not(any(target_os = "linux", target_os = "windows")))]
+fn detect_effective_total_memory(host_total: u64) -> i64 {
+    host_total as i64
+}
+
 /// Result from collecting metrics while holding the system lock
 struct MetricsCollectionResults {
     main_cli_processes: Vec<ProcessMetrics>,
@@ -874,8 +975,9 @@ impl ProcessMetricsCollector {
                 .with_memory(MemoryRefreshKind::nothing().with_ram())
                 .with_processes(ProcessRefreshKind::nothing().with_cpu().with_memory()),
         );
-        let cpu_cores = sys.cpus().len() as u32;
-        let total_memory = sys.total_memory() as i64;
+        let host_cpu_count = sys.cpus().len() as u32;
+        let cpu_cores = detect_effective_cpu_count(host_cpu_count);
+        let total_memory = detect_effective_total_memory(sys.total_memory());
 
         Self {
             config,
@@ -1203,6 +1305,63 @@ impl Drop for ProcessMetricsCollector {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn detect_effective_cpu_count_clamps_to_host() {
+        // Host count is the upper bound when no quota detected;
+        // sched_getaffinity may further reduce it (cpuset),
+        // but never increase it.
+        let host = 8;
+        let detected = detect_effective_cpu_count(host);
+        assert!(detected >= 1);
+        assert!(detected <= host);
+    }
+
+    #[cfg(target_os = "linux")]
+    #[test]
+    fn read_sched_affinity_returns_some_in_normal_environments() {
+        // We don't assert a specific count (it depends on the test runner's
+        // environment), but a real Linux process should always be allowed on at
+        // least one CPU.
+        let count = read_sched_affinity_count();
+        assert!(count.is_some_and(|c| c >= 1));
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+    #[test]
+    fn detect_effective_cpu_count_passthrough_on_unsupported_os() {
+        assert_eq!(detect_effective_cpu_count(16), 16);
+    }
+
+    #[cfg(not(any(target_os = "linux", target_os = "windows")))]
+    #[test]
+    fn detect_effective_total_memory_passthrough_on_unsupported_os() {
+        let host = 12u64 * 1024 * 1024 * 1024;
+        assert_eq!(detect_effective_total_memory(host), host as i64);
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn detect_effective_cpu_count_clamps_to_host_on_windows() {
+        // Windows path may min with Job Object limits; never returns more
+        // than host or less than 1.
+        let host = 8;
+        let detected = detect_effective_cpu_count(host);
+        assert!(detected >= 1);
+        assert!(detected <= host);
+    }
+
+    #[cfg(target_os = "windows")]
+    #[test]
+    fn detect_effective_total_memory_clamps_to_host_on_windows() {
+        // Windows path returns host RAM when no Job memory limit is set, or
+        // the limit when it is — but never more than host.
+        let host = 12u64 * 1024 * 1024 * 1024;
+        let detected = detect_effective_total_memory(host);
+        assert!(detected >= 0);
+        assert!(detected as u64 <= host);
+    }
 
     // Helper to create a test CollectionRunner without NAPI dependencies
     fn create_test_runner() -> (CollectionRunner, Receiver<MetricsCollectionResult>) {

--- a/packages/nx/src/native/metrics/collector.rs
+++ b/packages/nx/src/native/metrics/collector.rs
@@ -50,8 +50,8 @@ const SHUTDOWN_CHECK_INTERVAL_MS: u64 = 50;
 /// - host CPU count
 /// - `ceil(host_cpu_count × CpuRate / 10000)` from a `HARD_CAP` Job Object
 ///   rate (Docker `--cpus N` and equivalent — see `job_object` module)
-/// - popcount of the Job Object affinity mask (when `LIMIT_AFFINITY` is set)
-/// - popcount of `GetProcessAffinityMask` (Job + manual + system intersection)
+/// - popcount of `GetProcessAffinityMask`, which the kernel intersects from
+///   Job-imposed, manual `SetProcessAffinityMask`, and system affinity
 ///
 /// On macOS, returns the host CPU count unchanged. macOS has no
 /// container-style CPU enforcement primitives for native processes; container
@@ -93,6 +93,9 @@ fn detect_effective_cpu_count(host_cpu_count: u32) -> u32 {
     let mut effective = host_cpu_count;
     if let Some(job_cpus) = super::job_object::read_job_cpu_quota_cores(host_cpu_count) {
         effective = effective.min(job_cpus);
+    }
+    if let Some(affinity) = super::job_object::read_process_affinity_cores(host_cpu_count) {
+        effective = effective.min(affinity);
     }
     effective.max(1)
 }

--- a/packages/nx/src/native/metrics/job_object.rs
+++ b/packages/nx/src/native/metrics/job_object.rs
@@ -7,15 +7,24 @@
 //! workloads.
 //!
 //! ## CPU
-//! - `JOBOBJECT_CPU_RATE_CONTROL_INFORMATION` with `HARD_CAP` set:
-//!   `ceil(host_cpu_count × CpuRate / 10000)`. Docker's `--cpus N` translates
-//!   to HARD_CAP rate control on Windows.
-//! - `JOBOBJECT_BASIC_LIMIT_INFORMATION.Affinity` (when `LIMIT_AFFINITY` set):
-//!   the popcount of the Job-imposed CPU mask.
-//! - `GetProcessAffinityMask`: the kernel's effective process mask, which
-//!   reflects Job-imposed limits AND any manual `SetProcessAffinityMask` AND
-//!   the system mask intersection.
-//! - The function returns the minimum of those that are set.
+//! Exposed as two `pub(super)` readers, mirroring the Linux arm's split
+//! between cgroup-derived limits and `sched_getaffinity`:
+//!
+//! - [`read_job_cpu_quota_cores`] — Job-derived limits only. Returns `None`
+//!   when the process is not in a Job. Inside a Job, reads
+//!   `JOBOBJECT_CPU_RATE_CONTROL_INFORMATION` with `HARD_CAP` set
+//!   (`ceil(host_cpu_count × CpuRate / 10000)` — Docker's `--cpus N`
+//!   translates to HARD_CAP rate control). Job-imposed affinity is not read
+//!   here because the kernel intersects it into the process mask, so
+//!   `read_process_affinity_cores` already covers it.
+//!
+//! - [`read_process_affinity_cores`] — `GetProcessAffinityMask` unconditionally,
+//!   honors manual `SetProcessAffinityMask` whether or not the process is in a
+//!   Job. Inside a Job, the kernel intersects Job-imposed limits with manual
+//!   affinity and the system mask. Matches Go's `runtime/os_windows.go`,
+//!   .NET CoreCLR's `Environment.ProcessorCount`, libuv's
+//!   `uv_available_parallelism`, and the no-Job branch of OpenJDK HotSpot's
+//!   `active_processor_count`.
 //!
 //! `WEIGHT_BASED` rate control (Docker `--cpu-shares`) is intentionally
 //! ignored — it's a relative priority (1–9), not a hard ceiling. Mirrors how
@@ -68,6 +77,7 @@
 
 use std::mem;
 
+use tracing::debug;
 use winapi::shared::minwindef::{BOOL, DWORD, FALSE};
 use winapi::um::jobapi::IsProcessInJob;
 use winapi::um::jobapi2::QueryInformationJobObject;
@@ -75,42 +85,34 @@ use winapi::um::processthreadsapi::GetCurrentProcess;
 use winapi::um::winbase::GetProcessAffinityMask;
 use winapi::um::winnt::{
     JOB_OBJECT_CPU_RATE_CONTROL_ENABLE, JOB_OBJECT_CPU_RATE_CONTROL_HARD_CAP,
-    JOB_OBJECT_CPU_RATE_CONTROL_WEIGHT_BASED, JOB_OBJECT_LIMIT_AFFINITY,
-    JOB_OBJECT_LIMIT_JOB_MEMORY, JOB_OBJECT_LIMIT_PROCESS_MEMORY, JOB_OBJECT_LIMIT_WORKINGSET,
+    JOB_OBJECT_CPU_RATE_CONTROL_WEIGHT_BASED, JOB_OBJECT_LIMIT_JOB_MEMORY,
+    JOB_OBJECT_LIMIT_PROCESS_MEMORY, JOB_OBJECT_LIMIT_WORKINGSET,
     JOBOBJECT_CPU_RATE_CONTROL_INFORMATION, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
     JobObjectCpuRateControlInformation, JobObjectExtendedLimitInformation,
 };
 
+use super::metrics_math::{
+    cores_from_affinity_mask, cores_from_cpu_rate, is_finite_memory_limit, take_min,
+};
+
 /// Read the effective CPU core count derived from the Job Object the calling
-/// process belongs to. Returns `None` when the process is not in a Job, when
-/// no Job-derived limits are set, or when the queries fail.
+/// process belongs to. Returns `None` when the process is not in a Job or no
+/// Job-derived limits apply.
 pub(super) fn read_job_cpu_quota_cores(host_cpu_count: u32) -> Option<u32> {
     if !is_in_job_object()? {
         return None;
     }
+    read_cpu_hard_cap_rate().map(|rate| cores_from_cpu_rate(host_cpu_count, rate))
+}
 
-    let mut tightest: Option<u32> = None;
-
-    if let Some(rate) = read_cpu_hard_cap_rate() {
-        let cap = ((host_cpu_count as u64 * rate as u64).div_ceil(10000) as u32).max(1);
-        tightest = take_min(tightest, cap.min(host_cpu_count));
-    }
-
-    if let Some(ext) = read_extended_limit_info() {
-        let basic = &ext.BasicLimitInformation;
-        if basic.LimitFlags & JOB_OBJECT_LIMIT_AFFINITY != 0 && basic.Affinity != 0 {
-            // Affinity is `ULONG_PTR` (usize on x64). Bit count == # of CPUs the
-            // job is allowed to schedule on.
-            let count = basic.Affinity.count_ones();
-            tightest = take_min(tightest, count.min(host_cpu_count));
-        }
-    }
-
-    if let Some(count) = read_process_affinity_count() {
-        tightest = take_min(tightest, count.min(host_cpu_count));
-    }
-
-    tightest
+/// Read the effective CPU core count derived from the calling process's
+/// affinity mask. Honors manual `SetProcessAffinityMask` whether or not the
+/// process is in a Job Object. Returns `None` when the query fails or the
+/// mask is empty (Win32 reports zero when the process spans multiple
+/// processor groups on > 64-CPU hosts).
+pub(super) fn read_process_affinity_cores(host_cpu_count: u32) -> Option<u32> {
+    let mask = read_process_affinity_mask()?;
+    cores_from_affinity_mask(mask, host_cpu_count)
 }
 
 /// Read the effective memory limit in bytes derived from the Job Object the
@@ -126,7 +128,7 @@ pub(super) fn read_job_memory_limit_bytes(host_total: u64) -> Option<u64> {
     let flags = ext.BasicLimitInformation.LimitFlags;
     let mut tightest: Option<u64> = None;
     let mut update = |value: u64| {
-        if value > 0 && (host_total == 0 || value < host_total) {
+        if is_finite_memory_limit(value, host_total) {
             tightest = take_min(tightest, value);
         }
     };
@@ -146,19 +148,17 @@ pub(super) fn read_job_memory_limit_bytes(host_total: u64) -> Option<u64> {
     tightest
 }
 
-fn take_min<T: Ord>(current: Option<T>, value: T) -> Option<T> {
-    Some(match current {
-        Some(prev) => prev.min(value),
-        None => value,
-    })
-}
-
 fn is_in_job_object() -> Option<bool> {
     let mut in_job: BOOL = FALSE;
     // SAFETY: `GetCurrentProcess` returns a pseudo-handle (no resource); a
     // NULL `JobHandle` means "any job", per MSDN.
     let ok = unsafe { IsProcessInJob(GetCurrentProcess(), std::ptr::null_mut(), &mut in_job) };
-    if ok == 0 { None } else { Some(in_job != 0) }
+    if ok == 0 {
+        debug!("IsProcessInJob failed; assuming process is not in a Job Object");
+        None
+    } else {
+        Some(in_job != 0)
+    }
 }
 
 fn read_cpu_hard_cap_rate() -> Option<u32> {
@@ -176,6 +176,7 @@ fn read_cpu_hard_cap_rate() -> Option<u32> {
         )
     };
     if ok == 0 {
+        debug!("QueryInformationJobObject(JobObjectCpuRateControlInformation) failed");
         return None;
     }
 
@@ -212,10 +213,15 @@ fn read_extended_limit_info() -> Option<JOBOBJECT_EXTENDED_LIMIT_INFORMATION> {
             &mut return_length,
         )
     };
-    if ok == 0 { None } else { Some(info) }
+    if ok == 0 {
+        debug!("QueryInformationJobObject(JobObjectExtendedLimitInformation) failed");
+        None
+    } else {
+        Some(info)
+    }
 }
 
-fn read_process_affinity_count() -> Option<u32> {
+fn read_process_affinity_mask() -> Option<u64> {
     let mut process_mask: usize = 0;
     let mut system_mask: usize = 0;
     // SAFETY: GetProcessAffinityMask writes two ULONG_PTR (usize) out values.
@@ -226,11 +232,16 @@ fn read_process_affinity_count() -> Option<u32> {
             &mut system_mask as *mut _ as *mut _,
         )
     };
+    if ok == 0 {
+        debug!("GetProcessAffinityMask failed");
+        return None;
+    }
     // On systems with > 64 CPUs across multiple processor groups,
     // `GetProcessAffinityMask` may legitimately return 0 in `process_mask`.
     // Treat that as "unknown" rather than 0 cores.
-    if ok == 0 || process_mask == 0 {
+    if process_mask == 0 {
+        debug!("GetProcessAffinityMask returned empty mask (likely > 64 CPUs across groups)");
         return None;
     }
-    Some(process_mask.count_ones())
+    Some(process_mask as u64)
 }

--- a/packages/nx/src/native/metrics/job_object.rs
+++ b/packages/nx/src/native/metrics/job_object.rs
@@ -1,0 +1,236 @@
+//! Windows Job Object resource limit detection (Windows only).
+//!
+//! Windows analog to the Linux `cgroup` module: detects CPU and memory limits
+//! imposed on the calling process by the Job Object it belongs to — the
+//! standard kernel-enforced mechanism used by process-isolated Windows
+//! containers (Docker `--cpus`, `--memory`, etc.) and other sandboxed Windows
+//! workloads.
+//!
+//! ## CPU
+//! - `JOBOBJECT_CPU_RATE_CONTROL_INFORMATION` with `HARD_CAP` set:
+//!   `ceil(host_cpu_count × CpuRate / 10000)`. Docker's `--cpus N` translates
+//!   to HARD_CAP rate control on Windows.
+//! - `JOBOBJECT_BASIC_LIMIT_INFORMATION.Affinity` (when `LIMIT_AFFINITY` set):
+//!   the popcount of the Job-imposed CPU mask.
+//! - `GetProcessAffinityMask`: the kernel's effective process mask, which
+//!   reflects Job-imposed limits AND any manual `SetProcessAffinityMask` AND
+//!   the system mask intersection.
+//! - The function returns the minimum of those that are set.
+//!
+//! `WEIGHT_BASED` rate control (Docker `--cpu-shares`) is intentionally
+//! ignored — it's a relative priority (1–9), not a hard ceiling. Mirrors how
+//! the Linux path ignores `cpu.weight` / `cpu.shares`.
+//!
+//! Soft rate control (`ENABLE` set, no `HARD_CAP`, no `WEIGHT_BASED`) is also
+//! ignored: per MSDN, without `HARD_CAP` the kernel permits transient bursts
+//! above `CpuRate`, so it is not a defensible ceiling for "available cores".
+//!
+//! ## Memory
+//! Mirrors HotSpot's and .NET's pattern: take the minimum of any that are set
+//! among `ProcessMemoryLimit`, `JobMemoryLimit`, and `MaximumWorkingSetSize`,
+//! gated on their respective `LIMIT_*` flags. Working set is a soft (paging)
+//! limit but is included for parity with the reference implementations.
+//!
+//! ## Failure handling
+//! Any API failure (`IsProcessInJob` or `QueryInformationJobObject`) is
+//! treated as "no information" — the caller falls back to host values.
+//! Matches what HotSpot's `os_windows.cpp` and .NET CoreCLR's
+//! `gcenv.windows.cpp` do.
+//!
+//! Implementation cross-references: OpenJDK HotSpot `os_windows.cpp`
+//! (uses Job affinity and memory limits, does NOT consult rate control), .NET
+//! CoreCLR `gc/windows/gcenv.windows.cpp` (memory only). HARD_CAP rate
+//! detection is our addition for parity with Docker `--cpus` semantics.
+//!
+//! ## Known limitation: nested Job hierarchies
+//!
+//! `QueryInformationJobObject(NULL, ...)` returns the **immediate** Job's
+//! settings. Per MSDN: "If the job is nested, the immediate job of the
+//! calling process is used." Win32 exposes no documented API to enumerate
+//! or query parent Jobs in the chain.
+//!
+//! Per MSDN's `JOBOBJECT_CPU_RATE_CONTROL_INFORMATION` Remarks, "the rates
+//! set for the job represent its portion of the CPU rate that is allocated
+//! to its parent job" — i.e. nested rates compose multiplicatively. So a
+//! parent HARD_CAP of 50% with a child HARD_CAP of 50% yields an effective
+//! 25% of host, but our reader sees the child's 50% and reports
+//! `ceil(host × 0.5)`. Per-process / per-job memory limits have the same
+//! shape: the kernel enforces the tightest in the chain, but we see only
+//! the immediate Job.
+//!
+//! Affinity is robust: `GetProcessAffinityMask` returns the kernel-effective
+//! mask, already reflecting all parents.
+//!
+//! HotSpot and .NET CoreCLR exhibit the same memory limitation (single
+//! immediate-job query, no parent walk). HARD_CAP CPU-rate detection goes
+//! beyond them for Docker `--cpus` parity in the common single-silo case;
+//! the nested-Job overreport is the documented cost of that addition.
+
+use std::mem;
+
+use winapi::shared::minwindef::{BOOL, DWORD, FALSE};
+use winapi::um::jobapi::IsProcessInJob;
+use winapi::um::jobapi2::QueryInformationJobObject;
+use winapi::um::processthreadsapi::GetCurrentProcess;
+use winapi::um::winbase::GetProcessAffinityMask;
+use winapi::um::winnt::{
+    JOB_OBJECT_CPU_RATE_CONTROL_ENABLE, JOB_OBJECT_CPU_RATE_CONTROL_HARD_CAP,
+    JOB_OBJECT_CPU_RATE_CONTROL_WEIGHT_BASED, JOB_OBJECT_LIMIT_AFFINITY,
+    JOB_OBJECT_LIMIT_JOB_MEMORY, JOB_OBJECT_LIMIT_PROCESS_MEMORY, JOB_OBJECT_LIMIT_WORKINGSET,
+    JOBOBJECT_CPU_RATE_CONTROL_INFORMATION, JOBOBJECT_EXTENDED_LIMIT_INFORMATION,
+    JobObjectCpuRateControlInformation, JobObjectExtendedLimitInformation,
+};
+
+/// Read the effective CPU core count derived from the Job Object the calling
+/// process belongs to. Returns `None` when the process is not in a Job, when
+/// no Job-derived limits are set, or when the queries fail.
+pub(super) fn read_job_cpu_quota_cores(host_cpu_count: u32) -> Option<u32> {
+    if !is_in_job_object()? {
+        return None;
+    }
+
+    let mut tightest: Option<u32> = None;
+
+    if let Some(rate) = read_cpu_hard_cap_rate() {
+        let cap = ((host_cpu_count as u64 * rate as u64).div_ceil(10000) as u32).max(1);
+        tightest = take_min(tightest, cap.min(host_cpu_count));
+    }
+
+    if let Some(ext) = read_extended_limit_info() {
+        let basic = &ext.BasicLimitInformation;
+        if basic.LimitFlags & JOB_OBJECT_LIMIT_AFFINITY != 0 && basic.Affinity != 0 {
+            // Affinity is `ULONG_PTR` (usize on x64). Bit count == # of CPUs the
+            // job is allowed to schedule on.
+            let count = basic.Affinity.count_ones();
+            tightest = take_min(tightest, count.min(host_cpu_count));
+        }
+    }
+
+    if let Some(count) = read_process_affinity_count() {
+        tightest = take_min(tightest, count.min(host_cpu_count));
+    }
+
+    tightest
+}
+
+/// Read the effective memory limit in bytes derived from the Job Object the
+/// calling process belongs to. Returns `None` when the process is not in a
+/// Job, when no memory limit is set, or when the query fails. `host_total` is
+/// used to filter values that are unset or exceed host RAM.
+pub(super) fn read_job_memory_limit_bytes(host_total: u64) -> Option<u64> {
+    if !is_in_job_object()? {
+        return None;
+    }
+
+    let ext = read_extended_limit_info()?;
+    let flags = ext.BasicLimitInformation.LimitFlags;
+    let mut tightest: Option<u64> = None;
+    let mut update = |value: u64| {
+        if value > 0 && (host_total == 0 || value < host_total) {
+            tightest = take_min(tightest, value);
+        }
+    };
+
+    if flags & JOB_OBJECT_LIMIT_PROCESS_MEMORY != 0 {
+        update(ext.ProcessMemoryLimit as u64);
+    }
+    if flags & JOB_OBJECT_LIMIT_JOB_MEMORY != 0 {
+        update(ext.JobMemoryLimit as u64);
+    }
+    if flags & JOB_OBJECT_LIMIT_WORKINGSET != 0 {
+        // Working set is paging-enforced (soft), but HotSpot and .NET both
+        // include it in the min for parity.
+        update(ext.BasicLimitInformation.MaximumWorkingSetSize as u64);
+    }
+
+    tightest
+}
+
+fn take_min<T: Ord>(current: Option<T>, value: T) -> Option<T> {
+    Some(match current {
+        Some(prev) => prev.min(value),
+        None => value,
+    })
+}
+
+fn is_in_job_object() -> Option<bool> {
+    let mut in_job: BOOL = FALSE;
+    // SAFETY: `GetCurrentProcess` returns a pseudo-handle (no resource); a
+    // NULL `JobHandle` means "any job", per MSDN.
+    let ok = unsafe { IsProcessInJob(GetCurrentProcess(), std::ptr::null_mut(), &mut in_job) };
+    if ok == 0 { None } else { Some(in_job != 0) }
+}
+
+fn read_cpu_hard_cap_rate() -> Option<u32> {
+    let mut info: JOBOBJECT_CPU_RATE_CONTROL_INFORMATION = unsafe { mem::zeroed() };
+    let mut return_length: DWORD = 0;
+    // SAFETY: NULL `hJob` resolves to the calling process's implicit Job per
+    // MSDN. The buffer size we pass matches the struct.
+    let ok = unsafe {
+        QueryInformationJobObject(
+            std::ptr::null_mut(),
+            JobObjectCpuRateControlInformation,
+            &mut info as *mut _ as *mut _,
+            mem::size_of::<JOBOBJECT_CPU_RATE_CONTROL_INFORMATION>() as DWORD,
+            &mut return_length,
+        )
+    };
+    if ok == 0 {
+        return None;
+    }
+
+    let flags = info.ControlFlags;
+    if flags & JOB_OBJECT_CPU_RATE_CONTROL_ENABLE == 0 {
+        return None;
+    }
+    if flags & JOB_OBJECT_CPU_RATE_CONTROL_WEIGHT_BASED != 0 {
+        // Weight-based is a relative priority (1–9), not a CPU share. Skip.
+        return None;
+    }
+    if flags & JOB_OBJECT_CPU_RATE_CONTROL_HARD_CAP == 0 {
+        // Without HARD_CAP, the kernel allows transient bursts above the
+        // configured rate, so it is not a defensible ceiling.
+        return None;
+    }
+
+    // SAFETY: `HARD_CAP` discriminator is set without `WEIGHT_BASED`, so the
+    // union member in use is `CpuRate` per MSDN.
+    let rate = unsafe { *info.u.CpuRate() };
+    if rate == 0 { None } else { Some(rate) }
+}
+
+fn read_extended_limit_info() -> Option<JOBOBJECT_EXTENDED_LIMIT_INFORMATION> {
+    let mut info: JOBOBJECT_EXTENDED_LIMIT_INFORMATION = unsafe { mem::zeroed() };
+    let mut return_length: DWORD = 0;
+    // SAFETY: same as `read_cpu_hard_cap_rate` — NULL hJob = implicit Job.
+    let ok = unsafe {
+        QueryInformationJobObject(
+            std::ptr::null_mut(),
+            JobObjectExtendedLimitInformation,
+            &mut info as *mut _ as *mut _,
+            mem::size_of::<JOBOBJECT_EXTENDED_LIMIT_INFORMATION>() as DWORD,
+            &mut return_length,
+        )
+    };
+    if ok == 0 { None } else { Some(info) }
+}
+
+fn read_process_affinity_count() -> Option<u32> {
+    let mut process_mask: usize = 0;
+    let mut system_mask: usize = 0;
+    // SAFETY: GetProcessAffinityMask writes two ULONG_PTR (usize) out values.
+    let ok = unsafe {
+        GetProcessAffinityMask(
+            GetCurrentProcess(),
+            &mut process_mask as *mut _ as *mut _,
+            &mut system_mask as *mut _ as *mut _,
+        )
+    };
+    // On systems with > 64 CPUs across multiple processor groups,
+    // `GetProcessAffinityMask` may legitimately return 0 in `process_mask`.
+    // Treat that as "unknown" rather than 0 cores.
+    if ok == 0 || process_mask == 0 {
+        return None;
+    }
+    Some(process_mask.count_ones())
+}

--- a/packages/nx/src/native/metrics/metrics_math.rs
+++ b/packages/nx/src/native/metrics/metrics_math.rs
@@ -1,0 +1,99 @@
+//! Pure-math helpers shared by the Linux cgroup reader and the Windows Job
+//! Object reader. Kept cfg-free so the unit tests run on every OS.
+
+/// Convert a Job Object `CpuRate` (units of 1/10000) into whole cores.
+/// `ceil(host × rate / 10000)` matches Docker `--cpus` semantics. Clamps to
+/// `[1, host_cpu_count]`.
+pub(super) fn cores_from_cpu_rate(host_cpu_count: u32, rate: u32) -> u32 {
+    let raw = (host_cpu_count as u64 * rate as u64).div_ceil(10000);
+    (raw.min(host_cpu_count as u64) as u32).max(1)
+}
+
+/// Convert a CPU affinity mask into the number of allowed cores, clamped to
+/// the host CPU count. Returns `None` for an empty mask — Win32 can
+/// legitimately report this on hosts spanning multiple processor groups, and
+/// a Job-imposed mask of zero means no constraint was set.
+pub(super) fn cores_from_affinity_mask(mask: u64, host_cpu_count: u32) -> Option<u32> {
+    if mask == 0 {
+        return None;
+    }
+    Some(mask.count_ones().min(host_cpu_count))
+}
+
+/// Accept a memory limit value when it is strictly positive and (when
+/// `host_total > 0`) strictly less than host RAM. Filters both cgroup v1's
+/// `PAGE_COUNTER_MAX`-style "no limit" sentinel and Job Object fields that
+/// are unset or default to the host total.
+pub(super) fn is_finite_memory_limit(value: u64, host_total: u64) -> bool {
+    value > 0 && (host_total == 0 || value < host_total)
+}
+
+/// Seed-or-tighten: returns `Some(min(current, value))`, treating `None` as
+/// "no value yet" rather than as a participating minimum.
+pub(super) fn take_min<T: Ord>(current: Option<T>, value: T) -> Option<T> {
+    Some(match current {
+        Some(prev) => prev.min(value),
+        None => value,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn cores_from_cpu_rate_ceils_and_clamps() {
+        // Docker `--cpus 2` on a 16-core host: rate = 1250 (12.5%).
+        assert_eq!(cores_from_cpu_rate(16, 1250), 2);
+        // Fractional rate rounds up.
+        assert_eq!(cores_from_cpu_rate(16, 1251), 3);
+        // Sub-core ratio clamps to 1.
+        assert_eq!(cores_from_cpu_rate(16, 1), 1);
+        // Full rate equals host count.
+        assert_eq!(cores_from_cpu_rate(16, 10000), 16);
+        // Over-spec rates (some kernels accept > 10000) clamp to host.
+        assert_eq!(cores_from_cpu_rate(8, 20000), 8);
+    }
+
+    #[test]
+    fn cores_from_affinity_mask_clamps_and_filters_empty() {
+        assert_eq!(cores_from_affinity_mask(0, 8), None);
+        assert_eq!(cores_from_affinity_mask(0b1, 8), Some(1));
+        assert_eq!(cores_from_affinity_mask(0b11, 8), Some(2));
+        // Mask wider than host: clamped to host.
+        assert_eq!(cores_from_affinity_mask(0b1111, 2), Some(2));
+        // Lower-clamp boundary at host = 1.
+        assert_eq!(cores_from_affinity_mask(0b1111, 1), Some(1));
+        // Fully populated 64-bit mask: clamped to host.
+        assert_eq!(cores_from_affinity_mask(u64::MAX, 8), Some(8));
+    }
+
+    #[test]
+    fn is_finite_memory_limit_filters_zero_and_host_relative_values() {
+        assert!(is_finite_memory_limit(
+            4 * 1024 * 1024 * 1024,
+            8 * 1024 * 1024 * 1024
+        ));
+        // Equal to host: reject (Job Object MaximumWorkingSetSize defaults).
+        assert!(!is_finite_memory_limit(
+            8 * 1024 * 1024 * 1024,
+            8 * 1024 * 1024 * 1024
+        ));
+        // Above host (PAGE_COUNTER_MAX-style sentinel): reject.
+        assert!(!is_finite_memory_limit(
+            0x7FFFFFFFFFFFF000,
+            8 * 1024 * 1024 * 1024
+        ));
+        assert!(!is_finite_memory_limit(0, 8 * 1024 * 1024 * 1024));
+        assert!(!is_finite_memory_limit(0, 0));
+        // host_total == 0 (sysinfo failure): accept any positive value.
+        assert!(is_finite_memory_limit(1, 0));
+    }
+
+    #[test]
+    fn take_min_starts_then_tightens() {
+        assert_eq!(take_min::<u32>(None, 5), Some(5));
+        assert_eq!(take_min(Some(8), 5), Some(5));
+        assert_eq!(take_min(Some(3), 5), Some(3));
+    }
+}

--- a/packages/nx/src/native/metrics/mod.rs
+++ b/packages/nx/src/native/metrics/mod.rs
@@ -1,2 +1,6 @@
+#[cfg(target_os = "linux")]
+mod cgroup;
 pub mod collector;
+#[cfg(target_os = "windows")]
+mod job_object;
 pub mod types;

--- a/packages/nx/src/native/metrics/mod.rs
+++ b/packages/nx/src/native/metrics/mod.rs
@@ -3,4 +3,5 @@ mod cgroup;
 pub mod collector;
 #[cfg(target_os = "windows")]
 mod job_object;
+mod metrics_math;
 pub mod types;


### PR DESCRIPTION
## Current Behavior

When running inside a Linux container or Kubernetes pod, resource metrics report the host node's CPU and memory totals instead of the pod's limits. A pod with constrained CPU/memory shows the underlying node's resources.

The same gap exists for process-isolated Windows containers running inside a Windows Job Object (e.g. Docker `--cpus` / `--memory`): metrics report host values rather than the Job's limits.

## Expected Behavior

Resource metrics report the effective CPU and memory limits enforced by the kernel for the calling process — derived from the cgroup it belongs to on Linux, or the Job Object on Windows. macOS native processes continue to report host values (no equivalent enforcement primitive exists).

## Implementation Details

### Linux (`cgroup` module)

Resolves the calling process's actual cgroup directory by parsing `/proc/self/cgroup` + `/proc/self/mountinfo`. Reads `cpu.max` / `memory.max` (cgroup v2) or `cpu.cfs_{quota,period}_us` / `memory.limit_in_bytes` (cgroup v1, including the systemd `cpu,cpuacct` co-mount).

Walks from the leaf up to the mount point and takes the minimum finite limit found at any level — the kernel enforces the tightest ancestor's limit (hierarchical enforcement), so leaf-only reads can overreport when a pod-level cgroup is tighter than the container's (common in K8s VPA in-place resize and Burstable QoS).

Composition with `sched_getaffinity` covers cpuset / taskset restrictions. We deliberately bypass `std::thread::available_parallelism()` because rust-lang/rust's implementation applies the cgroup quota with floor division internally, which would silently underreport fractional quotas (e.g. 1.5 cores → 1). Instead we ceil quota / period, matching HotSpot JVM, Go 1.25, .NET, and the `num_cpus` crate.

mountinfo path fields containing spaces / tabs / newlines / backslashes are kernel-encoded as `\040` / `\011` / `\012` / `\134` per `man 5 proc_pid_mountinfo`; we unescape before joining with the cgroup path. `/proc/self/cgroup` itself emits paths raw (verified across kernels v4.18 → v6.13), so no unescape is needed there.

Replaces the prior leaf-only path lookups (which broke on cgroup v1 co-mount and any non-namespaced container setup). The in-tree module is preferred over `sysinfo`'s `cgroup_limits()` (now parent-aware in 0.39 — see *Additional Changes*) because it also covers CPU quota and the v1 co-mount + bind-mount edge cases in a single place we control. 30 unit tests cover cgroup discovery, parsing, ancestor walk, and the v1 / v2 / co-mount / bind-mount / cgroupns=host cases.

### Windows (`job_object` module)

Detects Job Object resource limits via the Win32 API:

- **CPU**: `ceil(host_cpu_count × CpuRate / 10000)` from `JobObjectCpuRateControlInformation` when `HARD_CAP` is set (Docker `--cpus` translates to HARD_CAP). Plus the popcount of the Job's affinity mask (when `LIMIT_AFFINITY` is set), and `GetProcessAffinityMask` (covers Job + manual + system intersections). Takes the minimum.
- **Memory**: minimum of `ProcessMemoryLimit` / `JobMemoryLimit` / `MaximumWorkingSetSize` from `JobObjectExtendedLimitInformation`, gated on the corresponding `LIMIT_*` flags. Mirrors HotSpot and .NET.
- **Skipped**: `WEIGHT_BASED` rate control (relative priority, not a hard limit) and soft-cap rate control (kernel allows transient bursts) — neither maps to a defensible "available cores" number.

Any Win32 failure is treated as "no information"; the caller falls back to host values. No new crate dependency — the existing `winapi` dep is extended with `jobapi`, `jobapi2`, `processthreadsapi`, `winbase`, and `winnt` features.

#### Known limitation: nested Job hierarchies

[`QueryInformationJobObject(NULL, ...)`](https://learn.microsoft.com/en-us/windows/win32/api/jobapi2/nf-jobapi2-queryinformationjobobject) returns the **immediate** Job's settings (per MSDN: *"If the job is nested, the immediate job of the calling process is used."*) and Win32 exposes no documented API to enumerate parent Jobs.

Per [`JOBOBJECT_CPU_RATE_CONTROL_INFORMATION`](https://learn.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-jobobject_cpu_rate_control_information) Remarks, *"the rates set for the job represent its portion of the CPU rate that is allocated to its parent job"* — nested rates compose multiplicatively. So with parent HARD_CAP 50% × child HARD_CAP 50%, the effective rate is 25% of host but we read the child's 50% and report `ceil(host × 0.5)`. Per-process / per-job memory has the same shape (kernel enforces min across the chain; we see only the immediate Job).

Affinity is unaffected — `GetProcessAffinityMask` returns the kernel-effective mask. HotSpot and .NET CoreCLR exhibit the same memory limitation; HARD_CAP CPU-rate detection goes beyond them for Docker `--cpus` parity in the common single-silo case, accepting the nested-Job overreport as the documented cost.

### Cross-platform

`SystemInfo { cpuCores, totalMemory }` shape is unchanged — consumers do not need to update. macOS native processes continue to report host values (no container-style enforcement primitive exists; container runtimes on macOS run Linux VMs where the Linux path applies).

The module doc-comments cross-reference Go 1.25 `internal/runtime/cgroup`, libuv `src/unix/linux.c`, OpenJDK `cgroupSubsystem_linux.cpp` + `os_windows.cpp`, .NET CoreCLR `gc/unix/cgroup.cpp` + `gc/windows/gcenv.windows.cpp`, and Rust stdlib `library/std/src/sys/thread/unix.rs::cgroups`.

## Additional Changes

Two infrastructure chores are bundled into this PR as separate commits:

### `chore(core): bump sysinfo to 0.39.1`

Bumps `sysinfo` from `0.37.2` → `0.39.1`. No source changes were required — all signatures we use (`System`, `Process`, `Pid`, `Signal`, `Disks`, the `*RefreshKind` types, `UpdateKind`, `MINIMUM_CPU_UPDATE_INTERVAL`) are unchanged. `Cargo.lock` deltas:

- New transitive dep `objc2-open-directory` from sysinfo 0.39's soundness fix for user retrieval on Apple targets.
- `windows` family bumped to `0.62.x` per sysinfo's new constraint, which lets the graph converge on single versions of `windows-core`, `windows-link`, `windows-result`, and `windows-strings` — four duplicate `windows-*` entries are deduplicated as a result.

sysinfo 0.39.0 also added `Process::cgroup_limits()` and parent-cgroup memory walking inside `System::cgroup_limits()` — overlapping conceptually with the in-tree `cgroup` module introduced by this PR. The in-tree module is kept because it also covers CPU quota (sysinfo's helpers are memory-only), the cgroup v1 co-mount, and bind-mount path translation in a single implementation under our control. Future consolidation onto the upstream APIs is possible but explicitly out of scope here.

### `chore(repo): bump mise rust to 1.95.0 to match rust-toolchain.toml`

`rust-toolchain.toml` was bumped to `1.95.0` in #35665 to unblock the sysinfo upgrade, but `mise.toml` was left at `1.90.0`. CI installs Rust via mise (which exports `RUSTUP_TOOLCHAIN`, overriding `rust-toolchain.toml`), so CI continued to run on `1.90.0` and failed the sysinfo 0.39 MSRV check until this commit. The two files now agree.
