### PR TITLE
docs(node): add Node 26 to compat matrix

### DIFF
--- a/astro-docs/src/content/docs/technologies/node/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/node/introduction.mdoc
@@ -19,11 +19,15 @@ The Nx policy is to support the LTS versions (i.e. actively maintained even numb
 Other versions of Node.js **may** still work without issue for these versions of Nx. Those include versions which are already EOL, or odd version numbers (e.g. 23), which Node.js actively discourages using in production.
 {% /aside %}
 
-| Nx Version     | Node Version             |
-| -------------- | ------------------------ |
-| 22.x (current) | 24.x, ^22.12.0, ^20.19.0 |
-| 21.x           | 24.x, ^22.12.0, ^20.19.0 |
-| 20.x           | 22.x, 20.x, 18.x         |
+{% aside type="note" title="Node 26" %}
+Node 26 is on the Current release track and enters LTS in October 2026. Nx tests against it in CI and supports it today.
+{% /aside %}
+
+| Nx Version     | Node Version                   |
+| -------------- | ------------------------------ |
+| 22.x (current) | 26.x, 24.x, ^22.12.0, ^20.19.0 |
+| 21.x           | 24.x, ^22.12.0, ^20.19.0       |
+| 20.x           | 22.x, 20.x, 18.x               |
 
 We intentionally do not include an `"engines"` field in the `package.json` file for Nx in order to allow for user flexibility, but this table should be considered the official compatibility matrix.
 


### PR DESCRIPTION
## Current Behavior

Compat matrix lists Node 24, 22, 20 for Nx 22.x. No mention of Node 26.

## Expected Behavior

Add Node 26 to Nx 22.x row. New aside notes Node 26 is on Current track, hits LTS Oct 2026, supported today via CI.

## Notes

- There are new deprecation warnings for `module.register` usage, which will be removed in Node 28. This is fine for workspace that can use the default Node.js type-stripping (https://github.com/nrwl/nx/pull/35608), and for other workspaces we need swc/ts-node (or something else) to move away from the deprecated API before it goes away.
- Also a deprecation warning for `fs.Stats`, but it's not in our code so it's from a dep or transitive dep.

## Related Issue(s)

NXC-4374