### PR TITLE
fix(testing): handle absolute cypress screenshotsFolder/videosFolder paths

### DIFF
--- a/packages/cypress/src/plugins/plugin.spec.ts
+++ b/packages/cypress/src/plugins/plugin.spec.ts
@@ -1127,6 +1127,632 @@ describe('@nx/cypress/plugin', () => {
     `);
   });
 
+  it('should normalize absolute screenshotsFolder and videosFolder for e2e and atomized e2e-ci targets', async () => {
+    mockCypressConfig(
+      defineConfig({
+        e2e: {
+          ...nxE2EPreset(join(tempFs.tempDir, 'cypress.config.js'), {
+            webServerCommands: {
+              default: 'my-app:serve',
+            },
+            ciWebServerCommand: 'my-app:serve-static',
+          }),
+          specPattern: '**/*.cy.ts',
+          videosFolder: join(tempFs.tempDir, 'dist/videos'),
+          screenshotsFolder: join(tempFs.tempDir, 'dist/screenshots'),
+        },
+      })
+    );
+    const nodes = await createNodesFunction(['cypress.config.js'], {}, context);
+
+    expect(nodes).toMatchInlineSnapshot(`
+      [
+        [
+          "cypress.config.js",
+          {
+            "projects": {
+              ".": {
+                "metadata": {
+                  "targetGroups": {
+                    "E2E (CI)": [
+                      "e2e-ci--src/test.cy.ts",
+                      "e2e-ci",
+                    ],
+                  },
+                },
+                "projectType": "application",
+                "targets": {
+                  "e2e": {
+                    "cache": true,
+                    "command": "cypress run",
+                    "inputs": [
+                      "default",
+                      "^production",
+                      {
+                        "externalDependencies": [
+                          "cypress",
+                        ],
+                      },
+                    ],
+                    "metadata": {
+                      "description": "Runs Cypress Tests",
+                      "help": {
+                        "command": "npx cypress run --help",
+                        "example": {
+                          "args": [
+                            "--dev",
+                            "--headed",
+                          ],
+                        },
+                      },
+                      "technologies": [
+                        "cypress",
+                      ],
+                    },
+                    "options": {
+                      "cwd": ".",
+                      "env": {
+                        "TS_NODE_COMPILER_OPTIONS": "{"customConditions":null}",
+                      },
+                    },
+                    "outputs": [
+                      "{projectRoot}/dist/videos",
+                      "{projectRoot}/dist/screenshots",
+                    ],
+                    "parallelism": false,
+                  },
+                  "e2e-ci": {
+                    "cache": true,
+                    "dependsOn": [
+                      {
+                        "options": "forward",
+                        "params": "forward",
+                        "projects": "self",
+                        "target": "e2e-ci--src/test.cy.ts",
+                      },
+                    ],
+                    "executor": "nx:noop",
+                    "inputs": [
+                      "default",
+                      "^production",
+                      {
+                        "externalDependencies": [
+                          "cypress",
+                        ],
+                      },
+                    ],
+                    "metadata": {
+                      "description": "Runs Cypress Tests in CI",
+                      "help": {
+                        "command": "npx cypress run --help",
+                        "example": {
+                          "args": [
+                            "--dev",
+                            "--headed",
+                          ],
+                        },
+                      },
+                      "nonAtomizedTarget": "e2e",
+                      "technologies": [
+                        "cypress",
+                      ],
+                    },
+                    "outputs": [
+                      "{projectRoot}/dist/videos",
+                      "{projectRoot}/dist/screenshots",
+                    ],
+                    "parallelism": false,
+                  },
+                  "e2e-ci--src/test.cy.ts": {
+                    "cache": true,
+                    "command": "cypress run --env webServerCommand="my-app:serve-static" --spec src/test.cy.ts --config="{\\"e2e\\":{\\"videosFolder\\":\\"dist/videos/src-test-cy-ts\\",\\"screenshotsFolder\\":\\"dist/screenshots/src-test-cy-ts\\"}}"",
+                    "inputs": [
+                      "default",
+                      "^production",
+                      {
+                        "externalDependencies": [
+                          "cypress",
+                        ],
+                      },
+                    ],
+                    "metadata": {
+                      "description": "Runs Cypress Tests in src/test.cy.ts in CI",
+                      "help": {
+                        "command": "npx cypress run --help",
+                        "example": {
+                          "args": [
+                            "--dev",
+                            "--headed",
+                          ],
+                        },
+                      },
+                      "technologies": [
+                        "cypress",
+                      ],
+                    },
+                    "options": {
+                      "cwd": ".",
+                      "env": {
+                        "TS_NODE_COMPILER_OPTIONS": "{"customConditions":null}",
+                      },
+                    },
+                    "outputs": [
+                      "{projectRoot}/dist/videos/src-test-cy-ts",
+                      "{projectRoot}/dist/screenshots/src-test-cy-ts",
+                    ],
+                    "parallelism": false,
+                  },
+                  "open-cypress": {
+                    "command": "cypress open",
+                    "metadata": {
+                      "description": "Opens Cypress",
+                      "help": {
+                        "command": "npx cypress open --help",
+                        "example": {
+                          "args": [
+                            "--dev",
+                            "--e2e",
+                          ],
+                        },
+                      },
+                      "technologies": [
+                        "cypress",
+                      ],
+                    },
+                    "options": {
+                      "cwd": ".",
+                      "env": {
+                        "TS_NODE_COMPILER_OPTIONS": "{"customConditions":null}",
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        ],
+      ]
+    `);
+  });
+
+  it('should normalize absolute screenshotsFolder and videosFolder for atomized component-test-ci target', async () => {
+    mockCypressConfig(
+      defineConfig({
+        component: {
+          videosFolder: join(tempFs.tempDir, 'dist/videos'),
+          screenshotsFolder: join(tempFs.tempDir, 'dist/screenshots'),
+          devServer: {
+            framework: 'react',
+            bundler: 'webpack',
+          },
+        },
+      })
+    );
+    await tempFs.createFiles({ 'src/test-2.cy.ts': '' });
+
+    const nodes = await createNodesFunction(
+      ['cypress.config.js'],
+      {
+        componentTestingTargetName: 'component-test',
+        ciComponentTestingTargetName: 'component-test-ci',
+      },
+      context
+    );
+
+    expect(nodes).toMatchInlineSnapshot(`
+      [
+        [
+          "cypress.config.js",
+          {
+            "projects": {
+              ".": {
+                "metadata": {
+                  "targetGroups": {
+                    "Component Testing (CI)": [
+                      "component-test-ci--src/test-2.cy.ts",
+                      "component-test-ci--src/test.cy.ts",
+                      "component-test-ci",
+                    ],
+                  },
+                },
+                "projectType": "application",
+                "targets": {
+                  "component-test": {
+                    "cache": true,
+                    "command": "cypress run --component",
+                    "inputs": [
+                      "default",
+                      "^production",
+                      {
+                        "externalDependencies": [
+                          "cypress",
+                        ],
+                      },
+                    ],
+                    "metadata": {
+                      "description": "Runs Cypress Component Tests",
+                      "help": {
+                        "command": "npx cypress run --help",
+                        "example": {
+                          "args": [
+                            "--dev",
+                            "--headed",
+                          ],
+                        },
+                      },
+                      "technologies": [
+                        "cypress",
+                      ],
+                    },
+                    "options": {
+                      "cwd": ".",
+                      "env": {
+                        "TS_NODE_COMPILER_OPTIONS": "{"customConditions":null}",
+                      },
+                    },
+                    "outputs": [
+                      "{projectRoot}/dist/videos",
+                      "{projectRoot}/dist/screenshots",
+                    ],
+                  },
+                  "component-test-ci": {
+                    "cache": true,
+                    "dependsOn": [
+                      {
+                        "options": "forward",
+                        "params": "forward",
+                        "projects": "self",
+                        "target": "component-test-ci--src/test-2.cy.ts",
+                      },
+                      {
+                        "options": "forward",
+                        "params": "forward",
+                        "projects": "self",
+                        "target": "component-test-ci--src/test.cy.ts",
+                      },
+                    ],
+                    "executor": "nx:noop",
+                    "inputs": [
+                      "default",
+                      "^production",
+                      {
+                        "externalDependencies": [
+                          "cypress",
+                        ],
+                      },
+                    ],
+                    "metadata": {
+                      "description": "Runs Cypress Component Tests in CI",
+                      "help": {
+                        "command": "npx cypress run --help",
+                        "example": {
+                          "args": [
+                            "--dev",
+                            "--headed",
+                          ],
+                        },
+                      },
+                      "nonAtomizedTarget": "component-test",
+                      "technologies": [
+                        "cypress",
+                      ],
+                    },
+                    "outputs": [
+                      "{projectRoot}/dist/videos",
+                      "{projectRoot}/dist/screenshots",
+                    ],
+                  },
+                  "component-test-ci--src/test-2.cy.ts": {
+                    "cache": true,
+                    "command": "cypress run --component --spec src/test-2.cy.ts --config="{\\"component\\":{\\"videosFolder\\":\\"dist/videos/src-test-2-cy-ts\\",\\"screenshotsFolder\\":\\"dist/screenshots/src-test-2-cy-ts\\"}}"",
+                    "inputs": [
+                      "default",
+                      "^production",
+                      {
+                        "externalDependencies": [
+                          "cypress",
+                        ],
+                      },
+                    ],
+                    "metadata": {
+                      "description": "Runs Cypress Component Tests for src/test-2.cy.ts in CI",
+                      "help": {
+                        "command": "npx cypress run --help",
+                        "example": {
+                          "args": [
+                            "--dev",
+                            "--headed",
+                          ],
+                        },
+                      },
+                      "technologies": [
+                        "cypress",
+                      ],
+                    },
+                    "options": {
+                      "cwd": ".",
+                      "env": {
+                        "TS_NODE_COMPILER_OPTIONS": "{"customConditions":null}",
+                      },
+                    },
+                    "outputs": [
+                      "{projectRoot}/dist/videos/src-test-2-cy-ts",
+                      "{projectRoot}/dist/screenshots/src-test-2-cy-ts",
+                    ],
+                    "parallelism": false,
+                  },
+                  "component-test-ci--src/test.cy.ts": {
+                    "cache": true,
+                    "command": "cypress run --component --spec src/test.cy.ts --config="{\\"component\\":{\\"videosFolder\\":\\"dist/videos/src-test-cy-ts\\",\\"screenshotsFolder\\":\\"dist/screenshots/src-test-cy-ts\\"}}"",
+                    "inputs": [
+                      "default",
+                      "^production",
+                      {
+                        "externalDependencies": [
+                          "cypress",
+                        ],
+                      },
+                    ],
+                    "metadata": {
+                      "description": "Runs Cypress Component Tests for src/test.cy.ts in CI",
+                      "help": {
+                        "command": "npx cypress run --help",
+                        "example": {
+                          "args": [
+                            "--dev",
+                            "--headed",
+                          ],
+                        },
+                      },
+                      "technologies": [
+                        "cypress",
+                      ],
+                    },
+                    "options": {
+                      "cwd": ".",
+                      "env": {
+                        "TS_NODE_COMPILER_OPTIONS": "{"customConditions":null}",
+                      },
+                    },
+                    "outputs": [
+                      "{projectRoot}/dist/videos/src-test-cy-ts",
+                      "{projectRoot}/dist/screenshots/src-test-cy-ts",
+                    ],
+                    "parallelism": false,
+                  },
+                  "open-cypress": {
+                    "command": "cypress open",
+                    "metadata": {
+                      "description": "Opens Cypress",
+                      "help": {
+                        "command": "npx cypress open --help",
+                        "example": {
+                          "args": [
+                            "--dev",
+                            "--e2e",
+                          ],
+                        },
+                      },
+                      "technologies": [
+                        "cypress",
+                      ],
+                    },
+                    "options": {
+                      "cwd": ".",
+                      "env": {
+                        "TS_NODE_COMPILER_OPTIONS": "{"customConditions":null}",
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        ],
+      ]
+    `);
+  });
+
+  it('should emit {workspaceRoot} outputs and dotted-relative --config paths when folders sit outside the project root but inside the workspace', async () => {
+    await tempFs.createFiles({
+      'apps/myapp/package.json': '{}',
+      'apps/myapp/cypress.config.js': '',
+      'apps/myapp/src/test.cy.ts': '',
+    });
+
+    const cypressConfig = defineConfig({
+      e2e: {
+        ...nxE2EPreset(join(tempFs.tempDir, 'apps/myapp/cypress.config.js'), {
+          webServerCommands: { default: 'my-app:serve' },
+          ciWebServerCommand: 'my-app:serve-static',
+        }),
+        specPattern: '**/*.cy.ts',
+        videosFolder: join(tempFs.tempDir, 'dist/videos'),
+        screenshotsFolder: join(tempFs.tempDir, 'dist/screenshots'),
+      },
+    });
+    jest.mock(
+      join(tempFs.tempDir, 'apps/myapp/cypress.config.js'),
+      () => ({ default: cypressConfig }),
+      { virtual: true }
+    );
+
+    const nodes = await createNodesFunction(
+      ['apps/myapp/cypress.config.js'],
+      {},
+      context
+    );
+
+    expect(nodes).toMatchInlineSnapshot(`
+      [
+        [
+          "apps/myapp/cypress.config.js",
+          {
+            "projects": {
+              "apps/myapp": {
+                "metadata": {
+                  "targetGroups": {
+                    "E2E (CI)": [
+                      "e2e-ci--src/test.cy.ts",
+                      "e2e-ci",
+                    ],
+                  },
+                },
+                "projectType": "application",
+                "targets": {
+                  "e2e": {
+                    "cache": true,
+                    "command": "cypress run",
+                    "inputs": [
+                      "default",
+                      "^production",
+                      {
+                        "externalDependencies": [
+                          "cypress",
+                        ],
+                      },
+                    ],
+                    "metadata": {
+                      "description": "Runs Cypress Tests",
+                      "help": {
+                        "command": "npx cypress run --help",
+                        "example": {
+                          "args": [
+                            "--dev",
+                            "--headed",
+                          ],
+                        },
+                      },
+                      "technologies": [
+                        "cypress",
+                      ],
+                    },
+                    "options": {
+                      "cwd": "apps/myapp",
+                      "env": {
+                        "TS_NODE_COMPILER_OPTIONS": "{"customConditions":null}",
+                      },
+                    },
+                    "outputs": [
+                      "{workspaceRoot}/dist/videos",
+                      "{workspaceRoot}/dist/screenshots",
+                    ],
+                    "parallelism": false,
+                  },
+                  "e2e-ci": {
+                    "cache": true,
+                    "dependsOn": [
+                      {
+                        "options": "forward",
+                        "params": "forward",
+                        "projects": "self",
+                        "target": "e2e-ci--src/test.cy.ts",
+                      },
+                    ],
+                    "executor": "nx:noop",
+                    "inputs": [
+                      "default",
+                      "^production",
+                      {
+                        "externalDependencies": [
+                          "cypress",
+                        ],
+                      },
+                    ],
+                    "metadata": {
+                      "description": "Runs Cypress Tests in CI",
+                      "help": {
+                        "command": "npx cypress run --help",
+                        "example": {
+                          "args": [
+                            "--dev",
+                            "--headed",
+                          ],
+                        },
+                      },
+                      "nonAtomizedTarget": "e2e",
+                      "technologies": [
+                        "cypress",
+                      ],
+                    },
+                    "outputs": [
+                      "{workspaceRoot}/dist/videos",
+                      "{workspaceRoot}/dist/screenshots",
+                    ],
+                    "parallelism": false,
+                  },
+                  "e2e-ci--src/test.cy.ts": {
+                    "cache": true,
+                    "command": "cypress run --env webServerCommand="my-app:serve-static" --spec src/test.cy.ts --config="{\\"e2e\\":{\\"videosFolder\\":\\"../../dist/videos/src-test-cy-ts\\",\\"screenshotsFolder\\":\\"../../dist/screenshots/src-test-cy-ts\\"}}"",
+                    "inputs": [
+                      "default",
+                      "^production",
+                      {
+                        "externalDependencies": [
+                          "cypress",
+                        ],
+                      },
+                    ],
+                    "metadata": {
+                      "description": "Runs Cypress Tests in src/test.cy.ts in CI",
+                      "help": {
+                        "command": "npx cypress run --help",
+                        "example": {
+                          "args": [
+                            "--dev",
+                            "--headed",
+                          ],
+                        },
+                      },
+                      "technologies": [
+                        "cypress",
+                      ],
+                    },
+                    "options": {
+                      "cwd": "apps/myapp",
+                      "env": {
+                        "TS_NODE_COMPILER_OPTIONS": "{"customConditions":null}",
+                      },
+                    },
+                    "outputs": [
+                      "{workspaceRoot}/dist/videos/src-test-cy-ts",
+                      "{workspaceRoot}/dist/screenshots/src-test-cy-ts",
+                    ],
+                    "parallelism": false,
+                  },
+                  "open-cypress": {
+                    "command": "cypress open",
+                    "metadata": {
+                      "description": "Opens Cypress",
+                      "help": {
+                        "command": "npx cypress open --help",
+                        "example": {
+                          "args": [
+                            "--dev",
+                            "--e2e",
+                          ],
+                        },
+                      },
+                      "technologies": [
+                        "cypress",
+                      ],
+                    },
+                    "options": {
+                      "cwd": "apps/myapp",
+                      "env": {
+                        "TS_NODE_COMPILER_OPTIONS": "{"customConditions":null}",
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          },
+        ],
+      ]
+    `);
+  });
+
   function mockCypressConfig(cypressConfig: Cypress.ConfigOptions) {
     // This isn't JS, but all that really matters here
     // is that the hash is different after updating the

--- a/packages/cypress/src/plugins/plugin.ts
+++ b/packages/cypress/src/plugins/plugin.ts
@@ -21,7 +21,7 @@ import { hashObject } from 'nx/src/devkit-internals';
 import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
 import { PluginCache } from 'nx/src/utils/plugin-cache-utils';
 import { globWithWorkspaceContext } from 'nx/src/utils/workspace-context';
-import { dirname, join, relative } from 'path';
+import { dirname, join, relative, resolve } from 'path';
 import { NX_PLUGIN_OPTIONS } from '../utils/constants';
 
 export interface CypressPluginOptions {
@@ -137,8 +137,35 @@ function getTargetOutputs(outputs: string[], subfolder?: string): string[] {
   );
 }
 
+// Normalize a Cypress config folder (e.g. videosFolder, screenshotsFolder) to a
+// project-root-relative path, then append the per-spec subfolder. Cypress
+// resolves relative folders against the project root (cwd), so this keeps the
+// path Cypress writes to in lockstep with what Nx declares as the target's
+// outputs — regardless of whether the user wrote a relative path or computed
+// an absolute one (e.g. via `path.resolve` / `__dirname`).
+function serializeConfigPath(
+  configPath: string,
+  projectRoot: string,
+  workspaceRoot: string,
+  outputSubfolder: string
+): string {
+  if (!configPath) {
+    return configPath;
+  }
+
+  const fullProjectRoot = resolve(workspaceRoot, projectRoot);
+  const fullConfigPath = resolve(fullProjectRoot, configPath);
+  const relativeConfigPath = normalizePath(
+    relative(fullProjectRoot, fullConfigPath)
+  );
+
+  return normalizePath(join(relativeConfigPath, outputSubfolder));
+}
+
 function getTargetConfig(
   cypressConfig: any,
+  projectRoot: string,
+  workspaceRoot: string,
   outputSubfolder: string,
   ciBaseUrl?: string
 ): string {
@@ -150,21 +177,38 @@ function getTargetConfig(
   const { screenshotsFolder, videosFolder, e2e, component } = cypressConfig;
 
   if (videosFolder) {
-    config['videosFolder'] = join(videosFolder, outputSubfolder);
+    config['videosFolder'] = serializeConfigPath(
+      videosFolder,
+      projectRoot,
+      workspaceRoot,
+      outputSubfolder
+    );
   }
 
   if (screenshotsFolder) {
-    config['screenshotsFolder'] = join(screenshotsFolder, outputSubfolder);
+    config['screenshotsFolder'] = serializeConfigPath(
+      screenshotsFolder,
+      projectRoot,
+      workspaceRoot,
+      outputSubfolder
+    );
   }
 
   if (e2e) {
     config['e2e'] = {};
     if (e2e.videosFolder) {
-      config['e2e']['videosFolder'] = join(e2e.videosFolder, outputSubfolder);
+      config['e2e']['videosFolder'] = serializeConfigPath(
+        e2e.videosFolder,
+        projectRoot,
+        workspaceRoot,
+        outputSubfolder
+      );
     }
     if (e2e.screenshotsFolder) {
-      config['e2e']['screenshotsFolder'] = join(
+      config['e2e']['screenshotsFolder'] = serializeConfigPath(
         e2e.screenshotsFolder,
+        projectRoot,
+        workspaceRoot,
         outputSubfolder
       );
     }
@@ -173,14 +217,18 @@ function getTargetConfig(
   if (component) {
     config['component'] = {};
     if (component.videosFolder) {
-      config['component']['videosFolder'] = join(
+      config['component']['videosFolder'] = serializeConfigPath(
         component.videosFolder,
+        projectRoot,
+        workspaceRoot,
         outputSubfolder
       );
     }
     if (component.screenshotsFolder) {
-      config['component']['screenshotsFolder'] = join(
+      config['component']['screenshotsFolder'] = serializeConfigPath(
         component.screenshotsFolder,
+        projectRoot,
+        workspaceRoot,
         outputSubfolder
       );
     }
@@ -193,14 +241,22 @@ function getTargetConfig(
 function getOutputs(
   projectRoot: string,
   cypressConfig: any,
-  testingType: 'e2e' | 'component'
+  testingType: 'e2e' | 'component',
+  workspaceRoot: string
 ): string[] {
-  function getOutput(path: string): string {
-    if (path.startsWith('..')) {
-      return joinPathFragments('{workspaceRoot}', projectRoot, path);
-    } else {
-      return joinPathFragments('{projectRoot}', path);
+  const fullProjectRoot = resolve(workspaceRoot, projectRoot);
+  function getOutput(outputPath: string): string {
+    const fullPath = resolve(fullProjectRoot, outputPath);
+    const relativeToProjectRoot = normalizePath(
+      relative(fullProjectRoot, fullPath)
+    );
+    if (relativeToProjectRoot.startsWith('..')) {
+      return joinPathFragments(
+        '{workspaceRoot}',
+        relative(workspaceRoot, fullPath)
+      );
     }
+    return joinPathFragments('{projectRoot}', relativeToProjectRoot);
   }
 
   const { screenshotsFolder, videosFolder, e2e, component } = cypressConfig;
@@ -277,7 +333,12 @@ async function buildCypressTargets(
       },
       cache: true,
       inputs: getInputs(namedInputs),
-      outputs: getOutputs(projectRoot, cypressConfig, 'e2e'),
+      outputs: getOutputs(
+        projectRoot,
+        cypressConfig,
+        'e2e',
+        context.workspaceRoot
+      ),
       metadata: {
         technologies: ['cypress'],
         description: 'Runs Cypress Tests',
@@ -334,7 +395,12 @@ async function buildCypressTargets(
       const ciBaseUrl = pluginPresetOptions?.ciBaseUrl;
 
       const dependsOn: TargetConfiguration['dependsOn'] = [];
-      const outputs = getOutputs(projectRoot, cypressConfig, 'e2e');
+      const outputs = getOutputs(
+        projectRoot,
+        cypressConfig,
+        'e2e',
+        context.workspaceRoot
+      );
       const inputs = getInputs(namedInputs);
 
       const groupName = 'E2E (CI)';
@@ -377,6 +443,8 @@ async function buildCypressTargets(
           cache: true,
           command: `cypress run --env webServerCommand="${ciWebServerCommand}" --spec ${relativeSpecFilePath} --config=${getTargetConfig(
             cypressConfig,
+            projectRoot,
+            context.workspaceRoot,
             outputSubfolder,
             ciBaseUrl
           )}`,
@@ -443,7 +511,12 @@ async function buildCypressTargets(
 
   if ('component' in cypressConfig) {
     const inputs = getInputs(namedInputs);
-    const outputs = getOutputs(projectRoot, cypressConfig, 'component');
+    const outputs = getOutputs(
+      projectRoot,
+      cypressConfig,
+      'component',
+      context.workspaceRoot
+    );
 
     // This will not override the e2e target if it is the same
     targets[options.componentTestingTargetName] ??= {
@@ -517,6 +590,8 @@ async function buildCypressTargets(
           cache: true,
           command: `cypress run --component --spec ${relativeSpecFilePath} --config=${getTargetConfig(
             cypressConfig,
+            projectRoot,
+            context.workspaceRoot,
             outputSubfolder
           )}`,
           options: {


### PR DESCRIPTION
## Current Behavior

When a Cypress config produces absolute paths for `screenshotsFolder` or `videosFolder` (e.g. via `path.resolve(__dirname, ...)` or `__dirname`-based composition), the inferred Nx outputs don't match where Cypress actually writes. Caching is broken because Nx scans the wrong location, and per-spec atomized targets compound the mismatch.

## Expected Behavior

Inferred outputs match where Cypress writes, regardless of whether the user's config used relative or absolute paths. The atomized `--config` override is normalized to a project-root-relative form so Cypress (cwd = project root) writes exactly where Nx declares its outputs.

## Implementation Details

- `getOutputs` rewritten to use `resolve(workspaceRoot, projectRoot)` + `relative(fullProjectRoot, fullPath)`. A single branch on whether the relative result starts with `..` chooses between `{projectRoot}/<rel>` (path inside the project) and `{workspaceRoot}/<rel>` (path outside the project but inside the workspace). Matches the canonical pattern used in the playwright plugin and unifies absolute, relative, and `..`-prefixed inputs.
- New `serializeConfigPath` helper applies the same `resolve`+`relative` transformation to rewrite absolute folders to project-root-relative form before appending the per-spec subfolder; used by `getTargetConfig` for top-level and nested (`e2e.*`, `component.*`) folder overrides.
- Three snapshot tests cover: (1) e2e + atomized e2e-ci with absolute paths under a `.` project root, (2) component + atomized component-test-ci with absolute paths under a `.` project root, and (3) e2e + atomized e2e-ci with a deeper project root and absolute paths outside the project but inside the workspace (exercises the `{workspaceRoot}` branch and validates the `--config` override produces dotted-relative paths).