### PR TITLE
fix(repo): drop node 26 from nightly matrix until playwright/yauzl fix

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -32,7 +32,9 @@ jobs:
         node_version:
           - 22
           - 24
-          - 26
+          # TODO: re-enable once playwright ships the yauzl fix for node 26 extract hang.
+          # See https://github.com/microsoft/playwright/issues/40724
+          # - 26
         exclude:
           # macos skips the oldest node to keep the macos matrix slim
           - os: macos-latest

--- a/.github/workflows/nightly/process-matrix.ts
+++ b/.github/workflows/nightly/process-matrix.ts
@@ -76,13 +76,17 @@ const matrixData: MatrixData = {
       os_name: 'Linux',
       os_timeout: 60,
       package_managers: ['npm', 'pnpm', 'yarn'],
-      node_versions: ['22.13.0', '24.0.0', '26.0.0'],
+      // TODO: re-add '26.0.0' once playwright ships the yauzl fix for node 26 extract hang.
+      // See https://github.com/microsoft/playwright/issues/40724
+      node_versions: ['22.13.0', '24.0.0'],
       excluded: ['e2e-detox', 'e2e-react-native', 'e2e-expo']
     },
     // Docker is not supported on ARM-based macOS runners (no nested virtualization)
     // See: https://github.com/docker/setup-docker-action and https://github.com/douglascamata/setup-docker-macos-action
     // We may want to look into adding intel only for this docker case, at least until vm-in-vm works on latest macos
-    { os: 'macos-latest', os_name: 'MacOS', os_timeout: 90, package_managers: ['npm'], node_versions: ['24.0.0', '26.0.0'], excluded: ['e2e-docker'] }
+    // TODO: re-add '26.0.0' once playwright ships the yauzl fix for node 26 extract hang.
+    // See https://github.com/microsoft/playwright/issues/40724
+    { os: 'macos-latest', os_name: 'MacOS', os_timeout: 90, package_managers: ['npm'], node_versions: ['24.0.0'], excluded: ['e2e-docker'] }
     // TODO (Jack): Fix Windows support as gradle fails when running nx build https://staging.nx.app/runs/LgD4vxGn8w?utm_source=pull-request&utm_medium=comment
     // { os: 'windows-latest', os_name: 'WinOS', os_timeout: 180, package_managers: ['npm'], node_versions: ['24.0.0'], excluded: ['e2e-detox', 'e2e-react-native', 'e2e-expo'] }
   ]


### PR DESCRIPTION
## Current Behavior

Nightly `E2E matrix` jobs on node 26 hang during `pnpm playwright install --with-deps` after Chromium download (zip extract never finishes). 20m job timeout cancels the preinstall, e2e jobs skip, `process-result` fails on missing `outputs/*/matrix.json`.

Root cause: yauzl regression on node 26 ([microsoft/playwright#40724](https://github.com/microsoft/playwright/issues/40724), [thejoshwolfe/yauzl#168](https://github.com/thejoshwolfe/yauzl/pull/168)).

## Expected Behavior

Node 26 commented out of preinstall matrix and `process-matrix.ts` node_versions for both ubuntu + macos. Nightly runs on v22 + v24 only. Re-add when playwright ships the fix.

## Related Issue(s)

NXC-4451