### PR TITLE
feat(testing): add migration for Jest 30 snapshot guide link

### DIFF
--- a/e2e/nx/src/__snapshots__/extras.test.ts.snap
+++ b/e2e/nx/src/__snapshots__/extras.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Extra Nx Misc Tests task graph inputs should correctly expand default task inputs 1`] = `
 {

--- a/e2e/webpack/src/__snapshots__/webpack.legacy.test.ts.snap
+++ b/e2e/webpack/src/__snapshots__/webpack.legacy.test.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Webpack Plugin (legacy) ConvertConfigToWebpackPlugin, should convert withNx webpack config to a standard config using NxWebpackPlugin 1`] = `
 "const { NxAppWebpackPlugin } = require('@nx/webpack/app-plugin');

--- a/packages/angular/src/generators/component-story/__snapshots__/component-story.spec.ts.snap
+++ b/packages/angular/src/generators/component-story/__snapshots__/component-story.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`componentStory generator should generate the right props 1`] = `
 "import type { Meta, StoryObj } from '@storybook/angular';

--- a/packages/angular/src/generators/component-test/__snapshots__/component-test.spec.ts.snap
+++ b/packages/angular/src/generators/component-test/__snapshots__/component-test.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Angular Cypress Component Test Generator should generate a component test 1`] = `
 "import { TestBed } from '@angular/core/testing';

--- a/packages/angular/src/generators/convert-to-with-mf/__snapshots__/convert-to-with-mf.spec.ts.snap
+++ b/packages/angular/src/generators/convert-to-with-mf/__snapshots__/convert-to-with-mf.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`convertToWithMF should migrate a standard previous generated host config correctly 1`] = `
 "const { withModuleFederation } = require('@nx/module-federation/angular');

--- a/packages/angular/src/generators/convert-to-with-mf/lib/__snapshots__/is-host-remote-config.spec.ts.snap
+++ b/packages/angular/src/generators/convert-to-with-mf/lib/__snapshots__/is-host-remote-config.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`isHostRemoteConfig should return remote when correct remote config found 1`] = `
 "{

--- a/packages/angular/src/generators/convert-to-with-mf/lib/__snapshots__/write-new-webpack-config.spec.ts.snap
+++ b/packages/angular/src/generators/convert-to-with-mf/lib/__snapshots__/write-new-webpack-config.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`writeNewWebpackConfig should convert config that is both remote and host correctly 1`] = `
 [

--- a/packages/angular/src/generators/directive/__snapshots__/directive.spec.ts.snap
+++ b/packages/angular/src/generators/directive/__snapshots__/directive.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`directive generator --no-standalone should export the directive correctly when directory is nested deeper 1`] = `
 "import { NgModule } from '@angular/core';

--- a/packages/angular/src/generators/ng-add/__snapshots__/migrate-from-angular-cli.spec.ts.snap
+++ b/packages/angular/src/generators/ng-add/__snapshots__/migrate-from-angular-cli.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`workspace move to nx layout should create a root eslint config 1`] = `
 {

--- a/packages/angular/src/generators/pipe/__snapshots__/pipe.spec.ts.snap
+++ b/packages/angular/src/generators/pipe/__snapshots__/pipe.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`pipe generator --no-standalone should export the pipe correctly when directory is nested deeper 1`] = `
 "import { NgModule } from '@angular/core';

--- a/packages/angular/src/generators/setup-mf/lib/__snapshots__/add-remote-to-host.spec.ts.snap
+++ b/packages/angular/src/generators/setup-mf/lib/__snapshots__/add-remote-to-host.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Add remote to host should add remote correctly even in multiline 1`] = `
 "const obj = {

--- a/packages/angular/src/generators/stories/__snapshots__/stories-app.spec.ts.snap
+++ b/packages/angular/src/generators/stories/__snapshots__/stories-app.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`angularStories generator: applications should generate stories file for inline scam component 1`] = `
 "import type { Meta, StoryObj } from '@storybook/angular';

--- a/packages/angular/src/generators/stories/__snapshots__/stories-lib.spec.ts.snap
+++ b/packages/angular/src/generators/stories/__snapshots__/stories-lib.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`angularStories generator: libraries Stories for non-empty Angular library should generate stories file for standalone components 1`] = `
 "import type { Meta, StoryObj } from '@storybook/angular';

--- a/packages/cypress/src/generators/component-configuration/__snapshots__/component-configuration.spec.ts.snap
+++ b/packages/cypress/src/generators/component-configuration/__snapshots__/component-configuration.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Cypress Component Configuration should not error when rerunning on an existing project 1`] = `
 {

--- a/packages/devkit/src/generators/__snapshots__/generate-files.spec.ts.snap
+++ b/packages/devkit/src/generators/__snapshots__/generate-files.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`generateFiles should copy files from a directory into a tree 1`] = `
 "file contents

--- a/packages/eslint/src/generators/workspace-rule/__snapshots__/workspace-rule.spec.ts.snap
+++ b/packages/eslint/src/generators/workspace-rule/__snapshots__/workspace-rule.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`@nx/eslint:workspace-rule --dir should support creating the rule in a nested directory 1`] = `
 "/**

--- a/packages/gradle/src/plugin/__snapshots__/nodes.spec.ts.snap
+++ b/packages/gradle/src/plugin/__snapshots__/nodes.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`@nx/gradle/plugin/nodes should create nodes based on gradle 1`] = `
 [

--- a/packages/jest/migrations.json
+++ b/packages/jest/migrations.json
@@ -42,6 +42,14 @@
       },
       "description": "Replace removed matcher aliases in Jest v30 with their corresponding matcher",
       "implementation": "./src/migrations/update-21-3-0/replace-removed-matcher-aliases"
+    },
+    "update-snapshot-guide-link": {
+      "version": "23.0.0-beta.6",
+      "requires": {
+        "jest": ">=30.0.0"
+      },
+      "description": "Update the Jest snapshot guide link in `.snap` files from the legacy `https://goo.gl/fbAQLP` URL to `https://jestjs.io/docs/snapshot-testing`, which Jest v30 now requires.",
+      "implementation": "./src/migrations/update-23-0-0/update-snapshot-guide-link"
     }
   },
   "packageJsonUpdates": {

--- a/packages/jest/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
+++ b/packages/jest/src/generators/configuration/__snapshots__/configuration.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`jestProject --babelJest should generate proper jest.transform when --compiler=swc and supportTsx is true 1`] = `
 "export default {

--- a/packages/jest/src/generators/configuration/lib/__snapshots__/create-jest-config.spec.ts.snap
+++ b/packages/jest/src/generators/configuration/lib/__snapshots__/create-jest-config.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`createJestConfig should generate files  1`] = `
 "import type { Config } from 'jest';

--- a/packages/jest/src/migrations/update-23-0-0/update-snapshot-guide-link.md
+++ b/packages/jest/src/migrations/update-23-0-0/update-snapshot-guide-link.md
@@ -1,0 +1,21 @@
+#### Update Jest Snapshot Guide Link
+
+Updates the snapshot guide link at the top of every `.snap` file from the legacy `https://goo.gl/fbAQLP` to `https://jestjs.io/docs/snapshot-testing`. Jest v30 errors out at test setup time if it sees the old link, so existing snapshot files need to be rewritten before tests can run. Read more at the [Jest v30 migration notes](https://jestjs.io/docs/upgrading-to-jest30).
+
+#### Examples
+
+##### Before
+
+```text title="apps/myapp/src/__snapshots__/example.spec.ts.snap"
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`renders correctly 1`] = `"hello"`;
+```
+
+##### After
+
+```text title="apps/myapp/src/__snapshots__/example.spec.ts.snap"
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
+
+exports[`renders correctly 1`] = `"hello"`;
+```

--- a/packages/jest/src/migrations/update-23-0-0/update-snapshot-guide-link.spec.ts
+++ b/packages/jest/src/migrations/update-23-0-0/update-snapshot-guide-link.spec.ts
@@ -1,0 +1,104 @@
+import { type Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migration from './update-snapshot-guide-link';
+
+const OLD_HEADER = '// Jest Snapshot v1, https://goo.gl/fbAQLP';
+const NEW_HEADER =
+  '// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing';
+
+describe('update-snapshot-guide-link migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('should rewrite the legacy snapshot guide link to the new URL', async () => {
+    tree.write(
+      'apps/app1/src/__snapshots__/example.spec.ts.snap',
+      `${OLD_HEADER}
+
+exports[\`renders correctly 1\`] = \`"hello"\`;
+`
+    );
+
+    await migration(tree);
+
+    expect(
+      tree.read('apps/app1/src/__snapshots__/example.spec.ts.snap', 'utf-8')
+    ).toBe(
+      `${NEW_HEADER}
+
+exports[\`renders correctly 1\`] = \`"hello"\`;
+`
+    );
+  });
+
+  it('should leave snapshot files that already use the new URL untouched', async () => {
+    const path = 'apps/app1/src/__snapshots__/already-new.spec.ts.snap';
+    const original = `${NEW_HEADER}
+
+exports[\`renders correctly 1\`] = \`"hello"\`;
+`;
+    tree.write(path, original);
+
+    await migration(tree);
+
+    expect(tree.read(path, 'utf-8')).toBe(original);
+  });
+
+  it('should not rewrite content past the first line', async () => {
+    tree.write(
+      'libs/lib1/src/__snapshots__/keep-body.spec.ts.snap',
+      `${OLD_HEADER}
+
+// the URL https://goo.gl/fbAQLP also appears in this snapshot body
+exports[\`keeps body 1\`] = \`"https://goo.gl/fbAQLP"\`;
+`
+    );
+
+    await migration(tree);
+
+    const updated = tree.read(
+      'libs/lib1/src/__snapshots__/keep-body.spec.ts.snap',
+      'utf-8'
+    );
+    expect(updated).toBe(
+      `${NEW_HEADER}
+
+// the URL https://goo.gl/fbAQLP also appears in this snapshot body
+exports[\`keeps body 1\`] = \`"https://goo.gl/fbAQLP"\`;
+`
+    );
+  });
+
+  it('should ignore non-snapshot files that contain the legacy URL', async () => {
+    const path = 'apps/app1/src/notes.md';
+    const original = `Some doc that happens to mention ${OLD_HEADER}.\n`;
+    tree.write(path, original);
+
+    await migration(tree);
+
+    expect(tree.read(path, 'utf-8')).toBe(original);
+  });
+
+  it('should update multiple snapshot files in a single run', async () => {
+    tree.write(
+      'apps/app1/src/__snapshots__/a.spec.ts.snap',
+      `${OLD_HEADER}\n\nexports[\`a 1\`] = \`"a"\`;\n`
+    );
+    tree.write(
+      'libs/lib1/src/__snapshots__/b.spec.ts.snap',
+      `${OLD_HEADER}\n\nexports[\`b 1\`] = \`"b"\`;\n`
+    );
+
+    await migration(tree);
+
+    expect(
+      tree.read('apps/app1/src/__snapshots__/a.spec.ts.snap', 'utf-8')
+    ).toContain(NEW_HEADER);
+    expect(
+      tree.read('libs/lib1/src/__snapshots__/b.spec.ts.snap', 'utf-8')
+    ).toContain(NEW_HEADER);
+  });
+});

--- a/packages/jest/src/migrations/update-23-0-0/update-snapshot-guide-link.ts
+++ b/packages/jest/src/migrations/update-23-0-0/update-snapshot-guide-link.ts
@@ -1,0 +1,34 @@
+import { formatFiles, globAsync, type Tree } from '@nx/devkit';
+
+const OLD_HEADER = '// Jest Snapshot v1, https://goo.gl/fbAQLP';
+const NEW_HEADER =
+  '// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing';
+
+export default async function updateSnapshotGuideLink(tree: Tree) {
+  const snapshotFiles = await globAsync(tree, ['**/__snapshots__/*.snap']);
+
+  for (const snapshotFile of snapshotFiles) {
+    const content = tree.read(snapshotFile, 'utf-8');
+    if (!content) {
+      continue;
+    }
+
+    const newlineMatch = content.match(/\r?\n/);
+    if (!newlineMatch) {
+      continue;
+    }
+
+    const newline = newlineMatch[0];
+    const firstNewlineIndex = content.indexOf(newline);
+    const firstLine = content.slice(0, firstNewlineIndex);
+
+    if (firstLine !== OLD_HEADER) {
+      continue;
+    }
+
+    const updated = NEW_HEADER + content.slice(firstNewlineIndex);
+    tree.write(snapshotFile, updated);
+  }
+
+  await formatFiles(tree);
+}

--- a/packages/jest/src/utils/config/__snapshots__/functions.spec.ts.snap
+++ b/packages/jest/src/utils/config/__snapshots__/functions.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`jestConfigObject export default should handle spread assignments 1`] = `
 "{

--- a/packages/nuxt/src/generators/storybook-configuration/__snapshots__/configuration.spec.ts.snap
+++ b/packages/nuxt/src/generators/storybook-configuration/__snapshots__/configuration.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`nuxt:storybook-configuration should configure with vue3 framework and styles import 1`] = `
 "import type { StorybookConfig } from '@storybook/vue3-vite';

--- a/packages/nuxt/src/utils/__snapshots__/update-gitignore.spec.ts.snap
+++ b/packages/nuxt/src/utils/__snapshots__/update-gitignore.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`update gitignore should add entries to .gitignore if they do not exist 1`] = `
 "

--- a/packages/nx/src/generators/utils/__snapshots__/generate-files.spec.ts.snap
+++ b/packages/nx/src/generators/utils/__snapshots__/generate-files.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`generateFiles should copy files from a directory into a tree 1`] = `
 "file contents

--- a/packages/react/src/generators/component-test/__snapshots__/component-test.spec.ts.snap
+++ b/packages/react/src/generators/component-test/__snapshots__/component-test.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`componentTestGenerator multiple components per file should handle default export 1`] = `
 "import * as React from 'react'

--- a/packages/react/src/generators/stories/__snapshots__/stories.app.spec.ts.snap
+++ b/packages/react/src/generators/stories/__snapshots__/stories.app.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`react:stories for applications should create the stories with interaction tests 1`] = `
 "import type { Meta, StoryObj } from '@storybook/react-webpack5';

--- a/packages/react/src/generators/stories/__snapshots__/stories.lib.spec.ts.snap
+++ b/packages/react/src/generators/stories/__snapshots__/stories.lib.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`react:stories for libraries should create the stories with interaction tests 1`] = `
 "import type { Meta, StoryObj } from '@storybook/react-vite';

--- a/packages/react/src/generators/stories/__snapshots__/stories.nextjs.spec.ts.snap
+++ b/packages/react/src/generators/stories/__snapshots__/stories.nextjs.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`nextjs:stories for applications should create the stories with interaction tests 1`] = `true`;
 

--- a/packages/remix/src/generators/error-boundary/__snapshots__/error-boundary.impl.spec.ts.snap
+++ b/packages/remix/src/generators/error-boundary/__snapshots__/error-boundary.impl.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`ErrorBoundary --apiVersion=2 should correctly add the ErrorBoundary to the route file 1`] = `
 "import { useRouteError, isRouteErrorResponse } from '@remix-run/react';

--- a/packages/remix/src/generators/resource-route/__snapshots__/resource-route.impl.spec.ts.snap
+++ b/packages/remix/src/generators/resource-route/__snapshots__/resource-route.impl.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`resource route should error if it detects a possible missing route param because of un-escaped dollar sign 1`] = `[Error: Your route path has an indicator of an un-escaped dollar sign for a route param. If this was intended, include the --skipChecks flag.]`;
 

--- a/packages/remix/src/generators/route/__snapshots__/route.impl.spec.ts.snap
+++ b/packages/remix/src/generators/route/__snapshots__/route.impl.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`route should add route component 1`] = `
 "import { useLoaderData, useActionData } from '@remix-run/react';

--- a/packages/rollup/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/rollup/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`@nx/rollup/plugin non-root project should create nodes 1`] = `
 [

--- a/packages/rspack/src/generators/convert-to-inferred/__snapshots__/convert-to-inferred.spec.ts.snap
+++ b/packages/rspack/src/generators/convert-to-inferred/__snapshots__/convert-to-inferred.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`convert-to-inferred all projects should migrate all projects using the rspack executors 1`] = `
 "const { NxAppRspackPlugin } = require('@nx/rspack/app-plugin');

--- a/packages/storybook/src/generators/init/__snapshots__/init.spec.ts.snap
+++ b/packages/storybook/src/generators/init/__snapshots__/init.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`@nx/storybook:init should not add storybook-static to .gitignore if it already exists 1`] = `
 "

--- a/packages/storybook/src/generators/migrate-8/__snapshots__/helper-functions.spec.ts.snap
+++ b/packages/storybook/src/generators/migrate-8/__snapshots__/helper-functions.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`Helper functions for the Storybook 8 migration generator getAllStorybookInfo and onlyShowGuide should return all info for all projects with Storybook 1`] = `
 {

--- a/packages/vite/src/generators/convert-to-inferred/lib/__snapshots__/build-post-target-transformer.spec.ts.snap
+++ b/packages/vite/src/generators/convert-to-inferred/lib/__snapshots__/build-post-target-transformer.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`buildPostTargetTransformer moveBuildLibsFromSourceToViteConfig should add buildLibsFromSource to existing nxViteTsPaths plugin with existing options 1`] = `
 "/// <reference types='vitest' />

--- a/packages/vue/src/generators/init/__snapshots__/init.spec.ts.snap
+++ b/packages/vue/src/generators/init/__snapshots__/init.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`init should add vue dependencies 1`] = `
 {

--- a/packages/vue/src/generators/stories/__snapshots__/stories.app.spec.ts.snap
+++ b/packages/vue/src/generators/stories/__snapshots__/stories.app.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`vue:stories for applications should create the stories with interaction tests 1`] = `
 "import type { Meta, StoryObj } from '@storybook/vue3-vite';

--- a/packages/vue/src/generators/stories/__snapshots__/stories.lib.spec.ts.snap
+++ b/packages/vue/src/generators/stories/__snapshots__/stories.lib.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`vue:stories for libraries should create the stories with interaction tests 1`] = `
 "import type { Meta, StoryObj } from '@storybook/vue3-vite';

--- a/packages/vue/src/generators/stories/lib/__snapshots__/component-story.spec.ts.snap
+++ b/packages/vue/src/generators/stories/lib/__snapshots__/component-story.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`vue:component-story default setup component with other syntax of props defined should create a story with controls 1`] = `
 "import type { Meta, StoryObj } from '@storybook/vue3-vite';

--- a/packages/vue/src/generators/storybook-configuration/__snapshots__/configuration.spec.ts.snap
+++ b/packages/vue/src/generators/storybook-configuration/__snapshots__/configuration.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`vue:storybook-configuration should configure everything and install correct dependencies 1`] = `
 "import type { StorybookConfig } from '@storybook/vue3-vite';

--- a/packages/webpack/src/generators/convert-to-inferred/__snapshots__/convert-to-inferred.spec.ts.snap
+++ b/packages/webpack/src/generators/convert-to-inferred/__snapshots__/convert-to-inferred.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`convert-to-inferred all projects should migrate all projects using the webpack executors 1`] = `
 "const { NxAppWebpackPlugin } = require('@nx/webpack/app-plugin');

--- a/packages/workspace/src/generators/move/lib/__snapshots__/create-project-configuration-in-new-destination.spec.ts.snap
+++ b/packages/workspace/src/generators/move/lib/__snapshots__/create-project-configuration-in-new-destination.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`moveProjectConfiguration should rename the project 1`] = `
 {

--- a/packages/workspace/src/generators/move/lib/__snapshots__/update-imports.spec.ts.snap
+++ b/packages/workspace/src/generators/move/lib/__snapshots__/update-imports.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`updateImports should correctly update deep imports 1`] = `
 "

--- a/packages/workspace/src/generators/new/__snapshots__/new.spec.ts.snap
+++ b/packages/workspace/src/generators/new/__snapshots__/new.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`new --preset should generate necessary npm dependencies for empty preset 1`] = `
 {

--- a/packages/workspace/src/generators/remove/lib/__snapshots__/update-jest-config.spec.ts.snap
+++ b/packages/workspace/src/generators/remove/lib/__snapshots__/update-jest-config.spec.ts.snap
@@ -1,4 +1,4 @@
-// Jest Snapshot v1, https://goo.gl/fbAQLP
+// Jest Snapshot v1, https://jestjs.io/docs/snapshot-testing
 
 exports[`updateRootJestConfig should delete lib project ref from root jest config 1`] = `
 "module.exports = {


### PR DESCRIPTION
## Current Behavior

Jest 30 enforces that every `.snap` file's first-line guide link points at the current snapshot-testing docs URL. Snapshot files generated under earlier Jest versions begin with the legacy short link:

```
// Jest Snapshot v1, https://goo.gl/fbAQLP
```

When users upgrade to Jest 30 (already supported as of `@nx/jest` 21.3 / 22.3), every project that has pre-existing `.snap` files fails at test setup with:

```
Outdated guide link: The snapshot guide link at the top of this snapshot is outdated.
Please update all snapshots during this upgrade of Jest.
Expected: https://jestjs.io/docs/snapshot-testing
Received: https://goo.gl/fbAQLP
```

There is currently no `nx migrate` step that rewrites these headers, so users have to do it by hand or run `jest -u` per project.

## Expected Behavior

`nx migrate` runs a new Jest migration (gated on `jest >= 30.0.0`) that walks every `**/__snapshots__/*.snap` file in the workspace and rewrites the first-line guide link from `https://goo.gl/fbAQLP` to `https://jestjs.io/docs/snapshot-testing`. Snapshot bodies and files that already use the new URL are left untouched.

This PR also brings the 45 outdated `.snap` files inside this repo onto the new URL so the workspace's own test suites pass under Jest 30.

### What's in this PR

- New migration `update-snapshot-guide-link` registered in `packages/jest/migrations.json` at `23.0.0-beta.6` with `requires: { jest: ">=30.0.0" }`.
- Migration implementation, `.md` doc, and unit tests under `packages/jest/src/migrations/update-23-0-0/`.
- Bulk rewrite of the 45 `.snap` files in this repo that still carried the legacy link.

## Related Issue(s)

N/A — surfaced while running unit tests against Jest 30 in this workspace.