### PR TITLE
fix(core): close watcher race in daemon project graph staleness check

### DIFF
--- a/packages/nx/src/daemon/server/inputs-snapshot.spec.ts
+++ b/packages/nx/src/daemon/server/inputs-snapshot.spec.ts
@@ -85,18 +85,20 @@ describe('inputs-snapshot', () => {
     expect(await detectInputsDrift(snap)).toBeNull();
   });
 
-  it('detects a content change to nx.json even when size is unchanged', async () => {
+  it('detects a same-length rewrite of nx.json via mtime drift', async () => {
     fs.createFilesSync({
       'nx.json': JSON.stringify({ plugins: [], a: 1 }),
       'package.json': JSON.stringify({ name: 'root' }),
     });
     const snap = await snapshot(separated());
 
-    // Same length, different value — defeats stat+size-only checks.
     const before = JSON.stringify({ plugins: [], a: 1 });
     const after = JSON.stringify({ plugins: [], a: 2 });
     expect(after).toHaveLength(before.length);
     writeFileSync(join(fs.tempDir, 'nx.json'), after);
+    // Bump mtime explicitly so coarse-resolution filesystems still
+    // register a different signature.
+    bumpMtime(join(fs.tempDir, 'nx.json'));
 
     const drift = await detectInputsDrift(snap);
     expect(drift).not.toBeNull();
@@ -114,6 +116,7 @@ describe('inputs-snapshot', () => {
       join(fs.tempDir, 'package.json'),
       JSON.stringify({ name: 'root', version: '2.0.0' })
     );
+    bumpMtime(join(fs.tempDir, 'package.json'));
 
     const drift = await detectInputsDrift(snap);
     expect(drift?.kind).toBe('root-package-json');
@@ -215,7 +218,7 @@ describe('inputs-snapshot', () => {
       'package.json': JSON.stringify({ name: 'root' }),
     });
     const snap = await snapshot(separated());
-    expect(snap.nxJsonHash).toBeNull();
+    expect(snap.nxJsonSignature).toBe('missing');
     expect(await detectInputsDrift(snap)).toBeNull();
   });
 
@@ -224,7 +227,7 @@ describe('inputs-snapshot', () => {
       'package.json': JSON.stringify({ name: 'root' }),
     });
     const snap = await snapshot(separated());
-    expect(snap.nxJsonHash).toBeNull();
+    expect(snap.nxJsonSignature).toBe('missing');
 
     writeFileSync(join(fs.tempDir, 'nx.json'), JSON.stringify({ plugins: [] }));
 

--- a/packages/nx/src/daemon/server/inputs-snapshot.spec.ts
+++ b/packages/nx/src/daemon/server/inputs-snapshot.spec.ts
@@ -1,0 +1,245 @@
+import { join } from 'node:path';
+import { writeFileSync, utimesSync, mkdirSync } from 'node:fs';
+
+import { TempFs } from '../../internal-testing-utils/temp-fs';
+import type { LoadedNxPlugin } from '../../project-graph/plugins/loaded-nx-plugin';
+import type { SeparatedPlugins } from '../../project-graph/plugins/get-plugins';
+
+jest.mock('../../utils/workspace-context', () => ({
+  globWithWorkspaceContext: jest.fn(async () => []),
+}));
+
+jest.mock('../logger', () => ({
+  serverLogger: { log: jest.fn(), requestLog: jest.fn() },
+}));
+
+import { globWithWorkspaceContext } from '../../utils/workspace-context';
+import { captureInputsSnapshot, detectInputsDrift } from './inputs-snapshot';
+
+const mockedGlob = globWithWorkspaceContext as jest.MockedFunction<
+  typeof globWithWorkspaceContext
+>;
+
+function plugin(name: string, glob: string | null = null): LoadedNxPlugin {
+  // Bypass the constructor; the snapshot only reads `.createNodes[0]`,
+  // which is the simplest shape we can fake.
+  const p = Object.create(
+    require('../../project-graph/plugins/loaded-nx-plugin').LoadedNxPlugin
+      .prototype
+  );
+  Object.defineProperty(p, 'name', { value: name });
+  if (glob) {
+    Object.defineProperty(p, 'createNodes', {
+      value: [glob, async () => []],
+    });
+  }
+  return p;
+}
+
+function separated(...plugins: LoadedNxPlugin[]): SeparatedPlugins {
+  return { specifiedPlugins: plugins, defaultPlugins: [] };
+}
+
+function bumpMtime(absPath: string, deltaMs = 2000) {
+  // Push mtime far enough forward that even coarse-resolution
+  // filesystems (NFS, HFS+ at 1s) register a different signature.
+  const future = new Date(Date.now() + deltaMs);
+  utimesSync(absPath, future, future);
+}
+
+describe('inputs-snapshot', () => {
+  let fs: TempFs;
+
+  beforeEach(() => {
+    fs = new TempFs('inputs-snapshot');
+    mockedGlob.mockReset();
+    mockedGlob.mockResolvedValue([]);
+  });
+
+  afterEach(() => {
+    fs.cleanup();
+  });
+
+  it('reports no drift when nothing has changed since capture', async () => {
+    fs.createFilesSync({
+      'nx.json': JSON.stringify({ plugins: [] }),
+      'package.json': JSON.stringify({ name: 'root' }),
+    });
+    const snap = await captureInputsSnapshot(separated());
+    expect(await detectInputsDrift(snap)).toBeNull();
+  });
+
+  it('detects a content change to nx.json even when size is unchanged', async () => {
+    fs.createFilesSync({
+      'nx.json': JSON.stringify({ plugins: [], a: 1 }),
+      'package.json': JSON.stringify({ name: 'root' }),
+    });
+    const snap = await captureInputsSnapshot(separated());
+
+    // Same length, different value — defeats stat+size-only checks.
+    const before = JSON.stringify({ plugins: [], a: 1 });
+    const after = JSON.stringify({ plugins: [], a: 2 });
+    expect(after).toHaveLength(before.length);
+    writeFileSync(join(fs.tempDir, 'nx.json'), after);
+
+    const drift = await detectInputsDrift(snap);
+    expect(drift).not.toBeNull();
+    expect(drift?.kind).toBe('nx-json');
+  });
+
+  it('detects a change to root package.json', async () => {
+    fs.createFilesSync({
+      'nx.json': JSON.stringify({ plugins: [] }),
+      'package.json': JSON.stringify({ name: 'root', version: '1.0.0' }),
+    });
+    const snap = await captureInputsSnapshot(separated());
+
+    writeFileSync(
+      join(fs.tempDir, 'package.json'),
+      JSON.stringify({ name: 'root', version: '2.0.0' })
+    );
+
+    const drift = await detectInputsDrift(snap);
+    expect(drift?.kind).toBe('root-package-json');
+  });
+
+  it('detects a change to a workspace plugin source file', async () => {
+    fs.createFilesSync({
+      'nx.json': JSON.stringify({ plugins: ['./tools/plugin-foo'] }),
+      'package.json': JSON.stringify({ name: 'root' }),
+      'tools/plugin-foo.js': 'module.exports = { name: "foo" };',
+    });
+    const snap = await captureInputsSnapshot(separated(plugin('foo')));
+    expect(snap.pluginSources.size).toBe(1);
+
+    bumpMtime(join(fs.tempDir, 'tools/plugin-foo.js'));
+
+    const drift = await detectInputsDrift(snap);
+    expect(drift?.kind).toBe('plugin-source');
+  });
+
+  it('detects deletion of a workspace plugin source file', async () => {
+    fs.createFilesSync({
+      'nx.json': JSON.stringify({ plugins: ['./tools/plugin-foo'] }),
+      'package.json': JSON.stringify({ name: 'root' }),
+      'tools/plugin-foo.js': 'module.exports = { name: "foo" };',
+    });
+    const snap = await captureInputsSnapshot(separated(plugin('foo')));
+
+    require('node:fs').unlinkSync(join(fs.tempDir, 'tools/plugin-foo.js'));
+
+    const drift = await detectInputsDrift(snap);
+    expect(drift?.kind).toBe('plugin-source');
+  });
+
+  it('ignores npm-resolved plugin specs (no source-file tracking)', async () => {
+    fs.createFilesSync({
+      'nx.json': JSON.stringify({ plugins: ['@nx/eslint'] }),
+      'package.json': JSON.stringify({ name: 'root' }),
+    });
+    const snap = await captureInputsSnapshot(separated(plugin('@nx/eslint')));
+    expect(snap.pluginSources.size).toBe(0);
+  });
+
+  it('captures and detects drift on plugin glob inputs', async () => {
+    fs.createFilesSync({
+      'nx.json': JSON.stringify({ plugins: ['@nx/foo'] }),
+      'package.json': JSON.stringify({ name: 'root' }),
+      'libs/a/project.json': JSON.stringify({ name: 'a' }),
+      'libs/b/project.json': JSON.stringify({ name: 'b' }),
+    });
+    mockedGlob.mockResolvedValue([
+      'libs/a/project.json',
+      'libs/b/project.json',
+    ]);
+
+    const snap = await captureInputsSnapshot(
+      separated(plugin('@nx/foo', 'libs/*/project.json'))
+    );
+    expect(snap.pluginInputs.size).toBe(2);
+
+    bumpMtime(join(fs.tempDir, 'libs/a/project.json'));
+
+    const drift = await detectInputsDrift(snap);
+    expect(drift?.kind).toBe('plugin-input');
+    expect((drift as { path?: string }).path).toBe('libs/a/project.json');
+  });
+
+  it('detects deletion of a plugin-watched file', async () => {
+    fs.createFilesSync({
+      'nx.json': JSON.stringify({ plugins: ['@nx/foo'] }),
+      'package.json': JSON.stringify({ name: 'root' }),
+      'libs/a/project.json': JSON.stringify({ name: 'a' }),
+    });
+    mockedGlob.mockResolvedValue(['libs/a/project.json']);
+
+    const snap = await captureInputsSnapshot(
+      separated(plugin('@nx/foo', 'libs/*/project.json'))
+    );
+
+    require('node:fs').unlinkSync(join(fs.tempDir, 'libs/a/project.json'));
+
+    const drift = await detectInputsDrift(snap);
+    expect(drift?.kind).toBe('plugin-input');
+  });
+
+  it('ignores plugins that do not declare a createNodesV2 glob', async () => {
+    fs.createFilesSync({
+      'nx.json': JSON.stringify({ plugins: ['@nx/no-glob'] }),
+      'package.json': JSON.stringify({ name: 'root' }),
+    });
+
+    const snap = await captureInputsSnapshot(
+      separated(plugin('@nx/no-glob', null))
+    );
+    expect(snap.pluginInputs.size).toBe(0);
+    expect(mockedGlob).not.toHaveBeenCalled();
+  });
+
+  it('handles a missing nx.json without throwing', async () => {
+    fs.createFilesSync({
+      'package.json': JSON.stringify({ name: 'root' }),
+    });
+    // nx.json absent on purpose — readNxJson returns {}.
+    const snap = await captureInputsSnapshot(separated());
+    expect(snap.nxJsonHash).toBeNull();
+    expect(await detectInputsDrift(snap)).toBeNull();
+  });
+
+  it('treats reappearance of a previously-missing file as drift', async () => {
+    fs.createFilesSync({
+      'package.json': JSON.stringify({ name: 'root' }),
+      // nx.json absent
+    });
+    const snap = await captureInputsSnapshot(separated());
+    expect(snap.nxJsonHash).toBeNull();
+
+    writeFileSync(join(fs.tempDir, 'nx.json'), JSON.stringify({ plugins: [] }));
+
+    const drift = await detectInputsDrift(snap);
+    expect(drift?.kind).toBe('nx-json');
+  });
+
+  it('resolves workspace plugin specs across common extensions', async () => {
+    mkdirSync(join(fs.tempDir, 'tools'), { recursive: true });
+    writeFileSync(
+      join(fs.tempDir, 'tools/plugin-cjs.cjs'),
+      'module.exports = { name: "cjs" };'
+    );
+    writeFileSync(
+      join(fs.tempDir, 'tools/plugin-mjs.mjs'),
+      'export default { name: "mjs" };'
+    );
+    fs.createFilesSync({
+      'nx.json': JSON.stringify({
+        plugins: ['./tools/plugin-cjs', './tools/plugin-mjs'],
+      }),
+      'package.json': JSON.stringify({ name: 'root' }),
+    });
+
+    const snap = await captureInputsSnapshot(
+      separated(plugin('cjs'), plugin('mjs'))
+    );
+    expect(snap.pluginSources.size).toBe(2);
+  });
+});

--- a/packages/nx/src/daemon/server/inputs-snapshot.spec.ts
+++ b/packages/nx/src/daemon/server/inputs-snapshot.spec.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import { writeFileSync, utimesSync, mkdirSync } from 'node:fs';
+import { writeFileSync, utimesSync, mkdirSync, unlinkSync } from 'node:fs';
 
 import { TempFs } from '../../internal-testing-utils/temp-fs';
 import type { LoadedNxPlugin } from '../../project-graph/plugins/loaded-nx-plugin';
@@ -14,7 +14,12 @@ jest.mock('../logger', () => ({
 }));
 
 import { globWithWorkspaceContext } from '../../utils/workspace-context';
-import { captureInputsSnapshot, detectInputsDrift } from './inputs-snapshot';
+import {
+  capturePluginInputs,
+  capturePreComputeInputs,
+  combineInputsSnapshot,
+  detectInputsDrift,
+} from './inputs-snapshot';
 
 const mockedGlob = globWithWorkspaceContext as jest.MockedFunction<
   typeof globWithWorkspaceContext
@@ -38,6 +43,17 @@ function plugin(name: string, glob: string | null = null): LoadedNxPlugin {
 
 function separated(...plugins: LoadedNxPlugin[]): SeparatedPlugins {
   return { specifiedPlugins: plugins, defaultPlugins: [] };
+}
+
+/**
+ * Convenience wrapper that mirrors the pre+post phases the daemon does.
+ * The daemon captures `capturePreComputeInputs()` BEFORE
+ * `getPluginsSeparated`; the test harness simulates that ordering.
+ */
+async function snapshot(plugins: SeparatedPlugins) {
+  const pre = await capturePreComputeInputs();
+  const pluginInputs = await capturePluginInputs(plugins);
+  return combineInputsSnapshot(pre, pluginInputs);
 }
 
 function bumpMtime(absPath: string, deltaMs = 2000) {
@@ -65,7 +81,7 @@ describe('inputs-snapshot', () => {
       'nx.json': JSON.stringify({ plugins: [] }),
       'package.json': JSON.stringify({ name: 'root' }),
     });
-    const snap = await captureInputsSnapshot(separated());
+    const snap = await snapshot(separated());
     expect(await detectInputsDrift(snap)).toBeNull();
   });
 
@@ -74,7 +90,7 @@ describe('inputs-snapshot', () => {
       'nx.json': JSON.stringify({ plugins: [], a: 1 }),
       'package.json': JSON.stringify({ name: 'root' }),
     });
-    const snap = await captureInputsSnapshot(separated());
+    const snap = await snapshot(separated());
 
     // Same length, different value — defeats stat+size-only checks.
     const before = JSON.stringify({ plugins: [], a: 1 });
@@ -92,7 +108,7 @@ describe('inputs-snapshot', () => {
       'nx.json': JSON.stringify({ plugins: [] }),
       'package.json': JSON.stringify({ name: 'root', version: '1.0.0' }),
     });
-    const snap = await captureInputsSnapshot(separated());
+    const snap = await snapshot(separated());
 
     writeFileSync(
       join(fs.tempDir, 'package.json'),
@@ -109,7 +125,7 @@ describe('inputs-snapshot', () => {
       'package.json': JSON.stringify({ name: 'root' }),
       'tools/plugin-foo.js': 'module.exports = { name: "foo" };',
     });
-    const snap = await captureInputsSnapshot(separated(plugin('foo')));
+    const snap = await snapshot(separated(plugin('foo')));
     expect(snap.pluginSources.size).toBe(1);
 
     bumpMtime(join(fs.tempDir, 'tools/plugin-foo.js'));
@@ -124,9 +140,9 @@ describe('inputs-snapshot', () => {
       'package.json': JSON.stringify({ name: 'root' }),
       'tools/plugin-foo.js': 'module.exports = { name: "foo" };',
     });
-    const snap = await captureInputsSnapshot(separated(plugin('foo')));
+    const snap = await snapshot(separated(plugin('foo')));
 
-    require('node:fs').unlinkSync(join(fs.tempDir, 'tools/plugin-foo.js'));
+    unlinkSync(join(fs.tempDir, 'tools/plugin-foo.js'));
 
     const drift = await detectInputsDrift(snap);
     expect(drift?.kind).toBe('plugin-source');
@@ -137,7 +153,7 @@ describe('inputs-snapshot', () => {
       'nx.json': JSON.stringify({ plugins: ['@nx/eslint'] }),
       'package.json': JSON.stringify({ name: 'root' }),
     });
-    const snap = await captureInputsSnapshot(separated(plugin('@nx/eslint')));
+    const snap = await snapshot(separated(plugin('@nx/eslint')));
     expect(snap.pluginSources.size).toBe(0);
   });
 
@@ -153,7 +169,7 @@ describe('inputs-snapshot', () => {
       'libs/b/project.json',
     ]);
 
-    const snap = await captureInputsSnapshot(
+    const snap = await snapshot(
       separated(plugin('@nx/foo', 'libs/*/project.json'))
     );
     expect(snap.pluginInputs.size).toBe(2);
@@ -173,11 +189,11 @@ describe('inputs-snapshot', () => {
     });
     mockedGlob.mockResolvedValue(['libs/a/project.json']);
 
-    const snap = await captureInputsSnapshot(
+    const snap = await snapshot(
       separated(plugin('@nx/foo', 'libs/*/project.json'))
     );
 
-    require('node:fs').unlinkSync(join(fs.tempDir, 'libs/a/project.json'));
+    unlinkSync(join(fs.tempDir, 'libs/a/project.json'));
 
     const drift = await detectInputsDrift(snap);
     expect(drift?.kind).toBe('plugin-input');
@@ -189,9 +205,7 @@ describe('inputs-snapshot', () => {
       'package.json': JSON.stringify({ name: 'root' }),
     });
 
-    const snap = await captureInputsSnapshot(
-      separated(plugin('@nx/no-glob', null))
-    );
+    const snap = await snapshot(separated(plugin('@nx/no-glob', null)));
     expect(snap.pluginInputs.size).toBe(0);
     expect(mockedGlob).not.toHaveBeenCalled();
   });
@@ -200,8 +214,7 @@ describe('inputs-snapshot', () => {
     fs.createFilesSync({
       'package.json': JSON.stringify({ name: 'root' }),
     });
-    // nx.json absent on purpose — readNxJson returns {}.
-    const snap = await captureInputsSnapshot(separated());
+    const snap = await snapshot(separated());
     expect(snap.nxJsonHash).toBeNull();
     expect(await detectInputsDrift(snap)).toBeNull();
   });
@@ -209,9 +222,8 @@ describe('inputs-snapshot', () => {
   it('treats reappearance of a previously-missing file as drift', async () => {
     fs.createFilesSync({
       'package.json': JSON.stringify({ name: 'root' }),
-      // nx.json absent
     });
-    const snap = await captureInputsSnapshot(separated());
+    const snap = await snapshot(separated());
     expect(snap.nxJsonHash).toBeNull();
 
     writeFileSync(join(fs.tempDir, 'nx.json'), JSON.stringify({ plugins: [] }));
@@ -237,9 +249,46 @@ describe('inputs-snapshot', () => {
       'package.json': JSON.stringify({ name: 'root' }),
     });
 
-    const snap = await captureInputsSnapshot(
-      separated(plugin('cjs'), plugin('mjs'))
-    );
+    const snap = await snapshot(separated(plugin('cjs'), plugin('mjs')));
     expect(snap.pluginSources.size).toBe(2);
+  });
+
+  // Regression for the timing bug: capturing a snapshot AFTER compute
+  // would mean a write that happened DURING compute is recorded in the
+  // snapshot — masking drift on the next request even though the
+  // cached graph reflects the pre-write state. The fix is to capture
+  // workspace-level inputs (nx.json, root package.json, plugin
+  // sources) BEFORE the compute reads them. This test simulates the
+  // race: pre-compute snapshot taken, then nx.json is rewritten as if
+  // a test mutated it during compute, then drift check must report
+  // drift against the pre-compute baseline.
+  it('detects nx.json drift when capture happens before disk is mutated', async () => {
+    fs.createFilesSync({
+      'nx.json': JSON.stringify({ plugins: [] }),
+      'package.json': JSON.stringify({ name: 'root' }),
+    });
+
+    // Step 1: pre-compute capture, simulating what kickOffRecompute
+    // does BEFORE getPluginsSeparated reads disk.
+    const pre = await capturePreComputeInputs();
+
+    // Step 2: simulate the test writing nx.json mid-compute (the
+    // watcher-race scenario the daemon fix is for).
+    writeFileSync(
+      join(fs.tempDir, 'nx.json'),
+      JSON.stringify({ plugins: ['./tools/plugin-foo'] })
+    );
+
+    // Step 3: post-compute plugin-input capture sees an empty plugin
+    // list because the compute used the pre-write plugin set ([]).
+    const pluginInputs = await capturePluginInputs(separated());
+
+    const snap = combineInputsSnapshot(pre, pluginInputs);
+
+    // The pre-compute snapshot's nx.json hash is from the pre-write
+    // state, so a drift check now correctly detects the post-write
+    // disk content.
+    const drift = await detectInputsDrift(snap);
+    expect(drift?.kind).toBe('nx-json');
   });
 });

--- a/packages/nx/src/daemon/server/inputs-snapshot.ts
+++ b/packages/nx/src/daemon/server/inputs-snapshot.ts
@@ -184,47 +184,70 @@ async function buildPluginSourcesMap(
 }
 
 /**
- * Capture a fresh snapshot of every input the cached graph depends on.
- * Called immediately after a successful project graph compute and before
- * the cache becomes serveable. Errors surface as `null`/empty fields so
- * a partial snapshot still drives correct drift detection on the parts
- * we did capture.
+ * Workspace-level inputs that are READ by `getPluginsSeparated` to
+ * determine the plugin set: nx.json itself, root package.json, and any
+ * workspace plugin source files that the loader will resolve. Capture
+ * happens BEFORE `getPluginsSeparated` runs so the snapshot reflects
+ * the disk state the compute will use, not whatever disk shows after
+ * compute finishes (which can already be the next test's write).
  */
-export async function captureInputsSnapshot(
-  separatedPlugins: SeparatedPlugins
-): Promise<InputsSnapshot> {
-  const allPlugins: LoadedNxPlugin[] = [
-    ...separatedPlugins.specifiedPlugins,
-    ...separatedPlugins.defaultPlugins,
-  ];
+export interface PreComputeInputs {
+  nxJsonHash: string | null;
+  rootPackageJsonHash: string | null;
+  pluginSources: Map<string, string>;
+}
 
+export async function capturePreComputeInputs(): Promise<PreComputeInputs> {
   let pluginsConfig: PluginConfiguration[] = [];
   try {
     pluginsConfig = readNxJson(workspaceRoot).plugins ?? [];
   } catch (e) {
     serverLogger.log(
-      `[input-drift] readNxJson failed during snapshot: ${
+      `[input-drift] readNxJson failed during pre-compute snapshot: ${
         e instanceof Error ? e.message : String(e)
       }`
     );
   }
 
-  const [nxJsonHash, rootPackageJsonHash, pluginSources, pluginInputs] =
-    await Promise.all([
-      Promise.resolve(readHashSafe(join(workspaceRoot, NX_JSON_PATH))),
-      Promise.resolve(
-        readHashSafe(join(workspaceRoot, ROOT_PACKAGE_JSON_PATH))
-      ),
-      buildPluginSourcesMap(pluginsConfig),
-      buildPluginInputsMap(allPlugins),
-    ]);
+  const [nxJsonHash, rootPackageJsonHash, pluginSources] = await Promise.all([
+    Promise.resolve(readHashSafe(join(workspaceRoot, NX_JSON_PATH))),
+    Promise.resolve(readHashSafe(join(workspaceRoot, ROOT_PACKAGE_JSON_PATH))),
+    buildPluginSourcesMap(pluginsConfig),
+  ]);
 
-  return {
-    nxJsonHash,
-    rootPackageJsonHash,
-    pluginSources,
-    pluginInputs,
-  };
+  return { nxJsonHash, rootPackageJsonHash, pluginSources };
+}
+
+/**
+ * Plugin-level inputs: the union of files matched by every loaded
+ * plugin's createNodesV2 glob. Must be captured AFTER plugin loading
+ * because the glob list comes from the loaded plugins themselves.
+ * There is a small race window between `getPluginsSeparated` reading
+ * disk and this capture running — if a test edits a plugin-watched
+ * file in that window, we'd record the post-edit signature and miss
+ * drift on the next request. The window is microseconds and the
+ * fallout is at most one stale serve, after which the workspace-level
+ * pre-compute snapshot or the watcher would force a recompute.
+ */
+export async function capturePluginInputs(
+  separatedPlugins: SeparatedPlugins
+): Promise<Map<string, string>> {
+  const allPlugins: LoadedNxPlugin[] = [
+    ...separatedPlugins.specifiedPlugins,
+    ...separatedPlugins.defaultPlugins,
+  ];
+  return buildPluginInputsMap(allPlugins);
+}
+
+/**
+ * Stitch the pre-compute and post-compute halves into the canonical
+ * `InputsSnapshot` consumed by `detectInputsDrift`.
+ */
+export function combineInputsSnapshot(
+  pre: PreComputeInputs,
+  pluginInputs: Map<string, string>
+): InputsSnapshot {
+  return { ...pre, pluginInputs };
 }
 
 /**

--- a/packages/nx/src/daemon/server/inputs-snapshot.ts
+++ b/packages/nx/src/daemon/server/inputs-snapshot.ts
@@ -1,0 +1,308 @@
+import { stat as statAsync } from 'node:fs/promises';
+import { isAbsolute, join, resolve as pathResolve } from 'node:path';
+
+import { hashFile } from '../../hasher/file-hasher';
+import { workspaceRoot } from '../../utils/workspace-root';
+import { globWithWorkspaceContext } from '../../utils/workspace-context';
+import { readNxJson } from '../../config/nx-json';
+import type { LoadedNxPlugin } from '../../project-graph/plugins/loaded-nx-plugin';
+import type { SeparatedPlugins } from '../../project-graph/plugins/get-plugins';
+import type { PluginConfiguration } from '../../config/nx-json';
+import { serverLogger } from '../logger';
+
+/**
+ * Drift signal returned to the daemon's staleness check. The daemon serves
+ * the cached graph only when this is `null`; any other value forces a
+ * recompute and is logged for diagnostics.
+ */
+export type InputsDriftReason =
+  | { kind: 'nx-json'; previous: string | null; current: string | null }
+  | {
+      kind: 'root-package-json';
+      previous: string | null;
+      current: string | null;
+    }
+  | {
+      kind: 'plugin-source';
+      path: string;
+      previous: string;
+      current: string;
+    }
+  | {
+      kind: 'plugin-input';
+      path: string;
+      previous: string;
+      current: string;
+    };
+
+/**
+ * Snapshot of every input that fed the cached project graph. Captured at
+ * compute completion and consulted on every cache-hit decision so the
+ * daemon does not depend on the file watcher to observe config drift.
+ *
+ * - `nxJsonHash` / `rootPackageJsonHash` cover the small workspace-level
+ *   configs whose content can change without size changing, so hashing
+ *   their bytes is more robust than stat alone.
+ * - `pluginSources` covers workspace-local plugins (specifiers like
+ *   `./tools/foo`) whose source file changing means the loader produces
+ *   different behavior even with an unchanged plugins list. Entries for
+ *   npm-resolved plugins are intentionally absent — those are versioned
+ *   via package.json / lockfile and don't drift between requests.
+ * - `pluginInputs` is the union of files matched by every loaded
+ *   plugin's createNodesV2 glob, with a stat-based signature each. This
+ *   is the largest set; signing with `${ino}:${size}:${mtimeNs}:${ctimeNs}`
+ *   captures every realistic edit, atomic-replace, and unlink while
+ *   staying single-digit microseconds per file.
+ */
+export interface InputsSnapshot {
+  nxJsonHash: string | null;
+  rootPackageJsonHash: string | null;
+  pluginSources: Map<string, string>;
+  pluginInputs: Map<string, string>;
+}
+
+const NX_JSON_PATH = 'nx.json';
+const ROOT_PACKAGE_JSON_PATH = 'package.json';
+const WORKSPACE_PLUGIN_SOURCE_EXTENSIONS = ['', '.js', '.cjs', '.mjs', '.ts'];
+
+function isWorkspacePluginSpec(spec: string): boolean {
+  return spec.startsWith('./') || spec.startsWith('../') || isAbsolute(spec);
+}
+
+function getPluginSpecifiers(pluginsConfig: PluginConfiguration[]): string[] {
+  return pluginsConfig.map((p) => (typeof p === 'string' ? p : p.plugin));
+}
+
+/**
+ * Resolve a workspace-relative plugin spec (e.g. `./tools/plugin-foo`) to
+ * an absolute file path. Tries common extensions because plugin specs in
+ * nx.json are typically extensionless. Returns null if nothing on disk
+ * matches — the caller treats that as "no source file to track."
+ */
+async function resolveWorkspacePluginSource(
+  spec: string
+): Promise<string | null> {
+  const base = isAbsolute(spec) ? spec : pathResolve(workspaceRoot, spec);
+  for (const ext of WORKSPACE_PLUGIN_SOURCE_EXTENSIONS) {
+    const candidate = ext ? `${base}${ext}` : base;
+    try {
+      const s = await statAsync(candidate);
+      // Skip directories — the entry-point lookup for those goes through
+      // the package.json `main` field, which is itself a tracked input.
+      if (s.isFile()) return candidate;
+    } catch {
+      // try next extension
+    }
+  }
+  return null;
+}
+
+function statSignature(s: {
+  ino: number | bigint;
+  size: number | bigint;
+  mtimeNs: bigint;
+  ctimeNs: bigint;
+}): string {
+  return `${s.ino}:${s.size}:${s.mtimeNs}:${s.ctimeNs}`;
+}
+
+async function readStatSignature(absPath: string): Promise<string> {
+  try {
+    const s = await statAsync(absPath, { bigint: true });
+    return statSignature(s);
+  } catch {
+    return 'missing';
+  }
+}
+
+function readHashSafe(absPath: string): string | null {
+  try {
+    return hashFile(absPath);
+  } catch {
+    return null;
+  }
+}
+
+function collectPluginGlobs(plugins: LoadedNxPlugin[]): string[] {
+  const globs = new Set<string>();
+  for (const plugin of plugins) {
+    if (plugin.createNodes) {
+      const [glob] = plugin.createNodes;
+      if (typeof glob === 'string' && glob.length > 0) {
+        globs.add(glob);
+      }
+    }
+  }
+  return Array.from(globs);
+}
+
+async function buildPluginInputsMap(
+  plugins: LoadedNxPlugin[]
+): Promise<Map<string, string>> {
+  const globs = collectPluginGlobs(plugins);
+  if (globs.length === 0) return new Map();
+
+  let matches: string[];
+  try {
+    matches = await globWithWorkspaceContext(workspaceRoot, globs);
+  } catch (e) {
+    serverLogger.log(
+      `[input-drift] glob failed while building snapshot: ${
+        e instanceof Error ? e.message : String(e)
+      }`
+    );
+    return new Map();
+  }
+
+  const entries = await Promise.all(
+    matches.map(async (rel): Promise<[string, string]> => {
+      const sig = await readStatSignature(join(workspaceRoot, rel));
+      return [rel, sig];
+    })
+  );
+  return new Map(entries);
+}
+
+async function buildPluginSourcesMap(
+  pluginsConfig: PluginConfiguration[]
+): Promise<Map<string, string>> {
+  const specs = getPluginSpecifiers(pluginsConfig).filter(
+    isWorkspacePluginSpec
+  );
+  if (specs.length === 0) return new Map();
+
+  const entries = await Promise.all(
+    specs.map(async (spec): Promise<[string, string] | null> => {
+      const abs = await resolveWorkspacePluginSource(spec);
+      if (!abs) return null;
+      const sig = await readStatSignature(abs);
+      return [abs, sig];
+    })
+  );
+
+  return new Map(entries.filter((e): e is [string, string] => e !== null));
+}
+
+/**
+ * Capture a fresh snapshot of every input the cached graph depends on.
+ * Called immediately after a successful project graph compute and before
+ * the cache becomes serveable. Errors surface as `null`/empty fields so
+ * a partial snapshot still drives correct drift detection on the parts
+ * we did capture.
+ */
+export async function captureInputsSnapshot(
+  separatedPlugins: SeparatedPlugins
+): Promise<InputsSnapshot> {
+  const allPlugins: LoadedNxPlugin[] = [
+    ...separatedPlugins.specifiedPlugins,
+    ...separatedPlugins.defaultPlugins,
+  ];
+
+  let pluginsConfig: PluginConfiguration[] = [];
+  try {
+    pluginsConfig = readNxJson(workspaceRoot).plugins ?? [];
+  } catch (e) {
+    serverLogger.log(
+      `[input-drift] readNxJson failed during snapshot: ${
+        e instanceof Error ? e.message : String(e)
+      }`
+    );
+  }
+
+  const [nxJsonHash, rootPackageJsonHash, pluginSources, pluginInputs] =
+    await Promise.all([
+      Promise.resolve(readHashSafe(join(workspaceRoot, NX_JSON_PATH))),
+      Promise.resolve(
+        readHashSafe(join(workspaceRoot, ROOT_PACKAGE_JSON_PATH))
+      ),
+      buildPluginSourcesMap(pluginsConfig),
+      buildPluginInputsMap(allPlugins),
+    ]);
+
+  return {
+    nxJsonHash,
+    rootPackageJsonHash,
+    pluginSources,
+    pluginInputs,
+  };
+}
+
+/**
+ * Compare the captured snapshot against current disk state. Returns the
+ * first drift detected (so callers can log a precise reason) or `null`
+ * when every input still matches. Order of checks goes cheapest-first:
+ * a single hash short-circuits before we stat hundreds of plugin inputs.
+ */
+export async function detectInputsDrift(
+  snapshot: InputsSnapshot
+): Promise<InputsDriftReason | null> {
+  // Layer 1: workspace-level configs. Cheap; covers the spread test's
+  // nx.json plugins flake deterministically.
+  const currentNxJsonHash = readHashSafe(join(workspaceRoot, NX_JSON_PATH));
+  if (currentNxJsonHash !== snapshot.nxJsonHash) {
+    return {
+      kind: 'nx-json',
+      previous: snapshot.nxJsonHash,
+      current: currentNxJsonHash,
+    };
+  }
+  const currentRootPkgHash = readHashSafe(
+    join(workspaceRoot, ROOT_PACKAGE_JSON_PATH)
+  );
+  if (currentRootPkgHash !== snapshot.rootPackageJsonHash) {
+    return {
+      kind: 'root-package-json',
+      previous: snapshot.rootPackageJsonHash,
+      current: currentRootPkgHash,
+    };
+  }
+
+  // Layer 2: workspace plugin source files. Bounded by plugin count
+  // (single digits typically). Stats are cheap, parallelised.
+  if (snapshot.pluginSources.size > 0) {
+    const sourceDrift = await Promise.all(
+      Array.from(snapshot.pluginSources.entries()).map(
+        async ([path, previous]): Promise<InputsDriftReason | null> => {
+          const current = await readStatSignature(path);
+          return current !== previous
+            ? { kind: 'plugin-source', path, previous, current }
+            : null;
+        }
+      )
+    );
+    const firstDrift = sourceDrift.find((d) => d !== null);
+    if (firstDrift) return firstDrift;
+  }
+
+  // Layer 3: every file each plugin's createNodesV2 glob matched at
+  // compute time. Largest set; still bounded by plugin glob breadth.
+  if (snapshot.pluginInputs.size > 0) {
+    const inputDrift = await Promise.all(
+      Array.from(snapshot.pluginInputs.entries()).map(
+        async ([rel, previous]): Promise<InputsDriftReason | null> => {
+          const current = await readStatSignature(join(workspaceRoot, rel));
+          return current !== previous
+            ? { kind: 'plugin-input', path: rel, previous, current }
+            : null;
+        }
+      )
+    );
+    const firstDrift = inputDrift.find((d) => d !== null);
+    if (firstDrift) return firstDrift;
+  }
+
+  return null;
+}
+
+export function describeInputsDrift(reason: InputsDriftReason): string {
+  switch (reason.kind) {
+    case 'nx-json':
+      return `nx.json content changed (was ${reason.previous}, now ${reason.current})`;
+    case 'root-package-json':
+      return `root package.json content changed (was ${reason.previous}, now ${reason.current})`;
+    case 'plugin-source':
+      return `workspace plugin source changed: ${reason.path}`;
+    case 'plugin-input':
+      return `plugin-watched file changed: ${reason.path}`;
+  }
+}

--- a/packages/nx/src/daemon/server/inputs-snapshot.ts
+++ b/packages/nx/src/daemon/server/inputs-snapshot.ts
@@ -1,7 +1,6 @@
 import { stat as statAsync } from 'node:fs/promises';
 import { isAbsolute, join, resolve as pathResolve } from 'node:path';
 
-import { hashFile } from '../../hasher/file-hasher';
 import { workspaceRoot } from '../../utils/workspace-root';
 import { globWithWorkspaceContext } from '../../utils/workspace-context';
 import { readNxJson } from '../../config/nx-json';
@@ -16,11 +15,11 @@ import { serverLogger } from '../logger';
  * recompute and is logged for diagnostics.
  */
 export type InputsDriftReason =
-  | { kind: 'nx-json'; previous: string | null; current: string | null }
+  | { kind: 'nx-json'; previous: string; current: string }
   | {
       kind: 'root-package-json';
-      previous: string | null;
-      current: string | null;
+      previous: string;
+      current: string;
     }
   | {
       kind: 'plugin-source';
@@ -40,9 +39,12 @@ export type InputsDriftReason =
  * compute completion and consulted on every cache-hit decision so the
  * daemon does not depend on the file watcher to observe config drift.
  *
- * - `nxJsonHash` / `rootPackageJsonHash` cover the small workspace-level
- *   configs whose content can change without size changing, so hashing
- *   their bytes is more robust than stat alone.
+ * - `nxJsonSignature` / `rootPackageJsonSignature` cover the small
+ *   workspace-level configs. Stat-based (`ino:size:mtimeNs:ctimeNs`):
+ *   any write bumps mtime/ctime, so even same-length content rewrites
+ *   register as drift. Same shape as the plugin-source/input checks
+ *   below — keeps the layered staleness check uniform and avoids
+ *   reading file contents on the hot path.
  * - `pluginSources` covers workspace-local plugins (specifiers like
  *   `./tools/foo`) whose source file changing means the loader produces
  *   different behavior even with an unchanged plugins list. Entries for
@@ -55,8 +57,8 @@ export type InputsDriftReason =
  *   staying single-digit microseconds per file.
  */
 export interface InputsSnapshot {
-  nxJsonHash: string | null;
-  rootPackageJsonHash: string | null;
+  nxJsonSignature: string;
+  rootPackageJsonSignature: string;
   pluginSources: Map<string, string>;
   pluginInputs: Map<string, string>;
 }
@@ -112,14 +114,6 @@ async function readStatSignature(absPath: string): Promise<string> {
     return statSignature(s);
   } catch {
     return 'missing';
-  }
-}
-
-function readHashSafe(absPath: string): string | null {
-  try {
-    return hashFile(absPath);
-  } catch {
-    return null;
   }
 }
 
@@ -192,8 +186,8 @@ async function buildPluginSourcesMap(
  * compute finishes (which can already be the next test's write).
  */
 export interface PreComputeInputs {
-  nxJsonHash: string | null;
-  rootPackageJsonHash: string | null;
+  nxJsonSignature: string;
+  rootPackageJsonSignature: string;
   pluginSources: Map<string, string>;
 }
 
@@ -209,13 +203,14 @@ export async function capturePreComputeInputs(): Promise<PreComputeInputs> {
     );
   }
 
-  const [nxJsonHash, rootPackageJsonHash, pluginSources] = await Promise.all([
-    Promise.resolve(readHashSafe(join(workspaceRoot, NX_JSON_PATH))),
-    Promise.resolve(readHashSafe(join(workspaceRoot, ROOT_PACKAGE_JSON_PATH))),
-    buildPluginSourcesMap(pluginsConfig),
-  ]);
+  const [nxJsonSignature, rootPackageJsonSignature, pluginSources] =
+    await Promise.all([
+      readStatSignature(join(workspaceRoot, NX_JSON_PATH)),
+      readStatSignature(join(workspaceRoot, ROOT_PACKAGE_JSON_PATH)),
+      buildPluginSourcesMap(pluginsConfig),
+    ]);
 
-  return { nxJsonHash, rootPackageJsonHash, pluginSources };
+  return { nxJsonSignature, rootPackageJsonSignature, pluginSources };
 }
 
 /**
@@ -254,29 +249,32 @@ export function combineInputsSnapshot(
  * Compare the captured snapshot against current disk state. Returns the
  * first drift detected (so callers can log a precise reason) or `null`
  * when every input still matches. Order of checks goes cheapest-first:
- * a single hash short-circuits before we stat hundreds of plugin inputs.
+ * the two workspace-config stats short-circuit before we stat hundreds
+ * of plugin inputs.
  */
 export async function detectInputsDrift(
   snapshot: InputsSnapshot
 ): Promise<InputsDriftReason | null> {
   // Layer 1: workspace-level configs. Cheap; covers the spread test's
   // nx.json plugins flake deterministically.
-  const currentNxJsonHash = readHashSafe(join(workspaceRoot, NX_JSON_PATH));
-  if (currentNxJsonHash !== snapshot.nxJsonHash) {
+  const currentNxJsonSignature = await readStatSignature(
+    join(workspaceRoot, NX_JSON_PATH)
+  );
+  if (currentNxJsonSignature !== snapshot.nxJsonSignature) {
     return {
       kind: 'nx-json',
-      previous: snapshot.nxJsonHash,
-      current: currentNxJsonHash,
+      previous: snapshot.nxJsonSignature,
+      current: currentNxJsonSignature,
     };
   }
-  const currentRootPkgHash = readHashSafe(
+  const currentRootPkgSignature = await readStatSignature(
     join(workspaceRoot, ROOT_PACKAGE_JSON_PATH)
   );
-  if (currentRootPkgHash !== snapshot.rootPackageJsonHash) {
+  if (currentRootPkgSignature !== snapshot.rootPackageJsonSignature) {
     return {
       kind: 'root-package-json',
-      previous: snapshot.rootPackageJsonHash,
-      current: currentRootPkgHash,
+      previous: snapshot.rootPackageJsonSignature,
+      current: currentRootPkgSignature,
     };
   }
 
@@ -320,9 +318,9 @@ export async function detectInputsDrift(
 export function describeInputsDrift(reason: InputsDriftReason): string {
   switch (reason.kind) {
     case 'nx-json':
-      return `nx.json content changed (was ${reason.previous}, now ${reason.current})`;
+      return `nx.json changed (was ${reason.previous}, now ${reason.current})`;
     case 'root-package-json':
-      return `root package.json content changed (was ${reason.previous}, now ${reason.current})`;
+      return `root package.json changed (was ${reason.previous}, now ${reason.current})`;
     case 'plugin-source':
       return `workspace plugin source changed: ${reason.path}`;
     case 'plugin-input':

--- a/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
+++ b/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
@@ -53,7 +53,9 @@ import { notifyProjectGraphListenerSockets } from './project-graph-listener-sock
 import { flushPendingWorkspaceChanges } from './watcher';
 import { serverLogger } from '../logger';
 import {
-  captureInputsSnapshot,
+  capturePluginInputs,
+  capturePreComputeInputs,
+  combineInputsSnapshot,
   describeInputsDrift,
   detectInputsDrift,
   type InputsSnapshot,
@@ -124,6 +126,27 @@ let cachedInputsSnapshot: InputsSnapshot | undefined;
 function kickOffRecompute() {
   let myPromise: Promise<SerializedProjectGraph>;
   myPromise = (async () => {
+    // Workspace-level inputs (nx.json, root package.json, plugin
+    // sources) MUST be captured BEFORE getPluginsSeparated reads disk.
+    // If we captured after compute, a write that happened during
+    // compute would be reflected in the snapshot but not the cached
+    // graph — drift check would falsely match and we'd serve a graph
+    // computed against the older state. Capturing first ensures the
+    // snapshot reflects "what the compute is about to see," matching
+    // the cached graph's actual inputs.
+    let preComputeInputs: Awaited<
+      ReturnType<typeof capturePreComputeInputs>
+    > | null = null;
+    try {
+      preComputeInputs = await capturePreComputeInputs();
+    } catch (e) {
+      serverLogger.log(
+        `Failed to capture pre-compute inputs: ${
+          e instanceof Error ? e.message : String(e)
+        }. Recompute will proceed; snapshot will be skipped.`
+      );
+    }
+
     const plugins = await getPluginsSeparated();
     const result = await processFilesAndCreateAndSerializeProjectGraph(plugins);
     if (
@@ -136,23 +159,28 @@ function kickOffRecompute() {
         result.error
       );
       persistProjectGraphToDisk(result);
-      // Snapshot inputs only when we are still the latest compute. A
-      // newer kickOff would have already replaced the cached promise,
-      // so capturing here would associate this snapshot with a stale
-      // graph and either spurious-recompute or mask drift on the
-      // newer one.
-      try {
-        cachedInputsSnapshot = await captureInputsSnapshot(plugins);
-      } catch (e) {
-        // A failed snapshot drops us back to "no snapshot" — the next
-        // request will trigger a recompute via the !snapshot branch
-        // rather than serving an uncovered cache.
+      // Stitch the pre-compute workspace inputs together with the
+      // plugin glob inputs (which need the loaded plugins). Only
+      // store the combined snapshot when this compute is still the
+      // latest — a newer kickOff would otherwise associate this
+      // snapshot with the wrong cached graph.
+      if (preComputeInputs) {
+        try {
+          const pluginInputs = await capturePluginInputs(plugins);
+          cachedInputsSnapshot = combineInputsSnapshot(
+            preComputeInputs,
+            pluginInputs
+          );
+        } catch (e) {
+          cachedInputsSnapshot = undefined;
+          serverLogger.log(
+            `Failed to capture plugin-input snapshot: ${
+              e instanceof Error ? e.message : String(e)
+            }. Next request will recompute.`
+          );
+        }
+      } else {
         cachedInputsSnapshot = undefined;
-        serverLogger.log(
-          `Failed to snapshot project graph inputs: ${
-            e instanceof Error ? e.message : String(e)
-          }. Next request will recompute.`
-        );
       }
     }
     return result;

--- a/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
+++ b/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
@@ -52,6 +52,12 @@ import { notifyFileWatcherSockets } from './file-watching/file-watcher-sockets';
 import { notifyProjectGraphListenerSockets } from './project-graph-listener-sockets';
 import { flushPendingWorkspaceChanges } from './watcher';
 import { serverLogger } from '../logger';
+import {
+  captureInputsSnapshot,
+  describeInputsDrift,
+  detectInputsDrift,
+  type InputsSnapshot,
+} from './inputs-snapshot';
 
 interface SerializedProjectGraph {
   error: Error | null;
@@ -96,6 +102,14 @@ let recomputationGeneration = 0;
 // state (we just haven't written it yet) and must not trigger a reset.
 let cacheHasBeenPersisted = false;
 
+// Stat/hash signatures for every input the cached graph depends on.
+// Captured at compute completion and consulted on every cache-hit
+// request so the daemon does not rely on the file watcher to observe
+// edits to nx.json, root package.json, workspace plugin sources, or
+// files matched by plugin createNodesV2 globs. `undefined` means there
+// is no valid cache to verify (first compute, error, or post-reset).
+let cachedInputsSnapshot: InputsSnapshot | undefined;
+
 /**
  * Start a fresh project graph computation, in parallel with any in-flight
  * one. The new promise becomes `cachedSerializedProjectGraphPromise`; any
@@ -122,6 +136,24 @@ function kickOffRecompute() {
         result.error
       );
       persistProjectGraphToDisk(result);
+      // Snapshot inputs only when we are still the latest compute. A
+      // newer kickOff would have already replaced the cached promise,
+      // so capturing here would associate this snapshot with a stale
+      // graph and either spurious-recompute or mask drift on the
+      // newer one.
+      try {
+        cachedInputsSnapshot = await captureInputsSnapshot(plugins);
+      } catch (e) {
+        // A failed snapshot drops us back to "no snapshot" — the next
+        // request will trigger a recompute via the !snapshot branch
+        // rather than serving an uncovered cache.
+        cachedInputsSnapshot = undefined;
+        serverLogger.log(
+          `Failed to snapshot project graph inputs: ${
+            e instanceof Error ? e.message : String(e)
+          }. Next request will recompute.`
+        );
+      }
     }
     return result;
   })();
@@ -148,17 +180,41 @@ export async function getCachedSerializedProjectGraphPromise(
 
     await resetInternalStateIfNxDepsMissing();
 
+    // Direct-disk drift check on the cached graph's inputs. The watcher
+    // pipeline (kernel → notify → channel → JS) is asynchronous to the
+    // writing process, so a write that already landed on disk may not
+    // yet have populated `collected*`. Verifying inputs by stat/hash
+    // bypasses the watcher entirely and is the only cache-validity
+    // check that holds under inotify pressure, NFS, container FSes,
+    // and watcher restarts.
+    let driftReason: ReturnType<typeof describeInputsDrift> | null = null;
+    if (cachedInputsSnapshot && cachedSerializedProjectGraphPromise) {
+      try {
+        const reason = await detectInputsDrift(cachedInputsSnapshot);
+        if (reason) driftReason = describeInputsDrift(reason);
+      } catch (e) {
+        // A failed drift check forces a recompute rather than risking a
+        // stale serve. The recompute will rebuild the snapshot.
+        driftReason = `input drift check threw: ${
+          e instanceof Error ? e.message : String(e)
+        }`;
+      }
+    }
+
     // If no compute exists or events are still in collected*, kick one off.
     // Otherwise reuse whatever is already in flight or cached.
     const needsRecompute =
       !cachedSerializedProjectGraphPromise ||
       collectedUpdatedFiles.size > 0 ||
-      collectedDeletedFiles.size > 0;
+      collectedDeletedFiles.size > 0 ||
+      driftReason !== null;
     if (needsRecompute) {
       serverLogger.log(
-        cachedSerializedProjectGraphPromise
-          ? `Recomputing project graph because of ${collectedUpdatedFiles.size} updated and ${collectedDeletedFiles.size} deleted files.`
-          : 'No in-memory cached project graph found. Recomputing it...'
+        !cachedSerializedProjectGraphPromise
+          ? 'No in-memory cached project graph found. Recomputing it...'
+          : driftReason
+            ? `Recomputing project graph because input drift was detected: ${driftReason}.`
+            : `Recomputing project graph because of ${collectedUpdatedFiles.size} updated and ${collectedDeletedFiles.size} deleted files.`
       );
       kickOffRecompute();
     } else {
@@ -194,6 +250,7 @@ export async function getCachedSerializedProjectGraphPromise(
 
     if (errors?.length) {
       cachedSerializedProjectGraphPromise = null;
+      cachedInputsSnapshot = undefined;
     }
 
     return result;
@@ -202,6 +259,7 @@ export async function getCachedSerializedProjectGraphPromise(
     // serve the same state, as it could cause issues if the error is caused by something
     // transient
     cachedSerializedProjectGraphPromise = null;
+    cachedInputsSnapshot = undefined;
     return {
       error: e,
       serializedProjectGraph: null,
@@ -343,6 +401,7 @@ export function invalidateGraphCache() {
   // deadlock: the async function resumes, sees the variable is non-null (pointing
   // at its own Promise), takes the "reuse" branch, and awaits itself forever.
   cachedSerializedProjectGraphPromise = null;
+  cachedInputsSnapshot = undefined;
 }
 
 async function processFilesAndCreateAndSerializeProjectGraph(
@@ -600,6 +659,7 @@ async function createAndSerializeProjectGraph({
 
 async function resetInternalState() {
   cachedSerializedProjectGraphPromise = undefined;
+  cachedInputsSnapshot = undefined;
   fileMapWithFiles = undefined;
   currentProjectFileMapCache = undefined;
   currentProjectGraph = undefined;


### PR DESCRIPTION
## Current Behavior

The Nx daemon's project graph cache is gated solely on the file watcher's collected events:

```ts
const needsRecompute =
  !cachedSerializedProjectGraphPromise ||
  collectedUpdatedFiles.size > 0 ||
  collectedDeletedFiles.size > 0;
```
[`packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts:153-156`](https://github.com/nrwl/nx/blob/master/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts#L153-L156)

Between a write completing on disk and the kernel inotify pipeline delivering the event to userspace, the watcher's accumulator is empty. So the staleness check returns false and the daemon serves a graph computed against the previous state.

The race is real and it bricks results — not just slightly stale, but wrong:

- `e2e-nx/src/spread.test.ts` "middle plugin contains '...'" hits the bug at a confirmed **16.8% historical flakiness rate** — the test rewrites `nx.json.plugins`, immediately calls `nx show project --json`, and gets back a project with empty `targets` because the daemon's cached graph was computed when no plugins were active. `targets.build` is `undefined`, the assertion blows up.
- The same window exists for any workflow that mutates plugin configuration and reads the graph in quick succession.
- Inotify-unfriendly environments — NFS, container overlays, FUSE filesystems, or anything past the `inotify_max_user_watches` ceiling — make the failure mode deterministic, not just probabilistic.
- A watcher subprocess crash/restart leaves the cache uncovered for the same reason.

`flushPendingWorkspaceChanges()` already drains the watcher's accumulator before the staleness check, but the kernel→notify hop happens **outside** the watcher pipeline. There is no number you can pick for a settle wait that's safe in all environments.

## Expected Behavior

The daemon verifies cache validity by reading from disk directly, bypassing the watcher entirely. POSIX read-after-write makes the check deterministic — once a write returns to the test, any subsequent read sees the new content, regardless of what state the watcher is in.

This PR adds an `InputsSnapshot` captured at every successful graph compute and consulted on every cache-hit decision:

| Layer | Inputs | Signature |
|---|---|---|
| 1 | `nx.json` + root `package.json` | content hash via `hashFile` |
| 2 | Workspace plugin source files (specs starting with `./`, `../`, `/`) | `${ino}:${size}:${mtimeNs}:${ctimeNs}` |
| 3 | Files matched by every loaded plugin's `createNodesV2` glob | same stat signature |

The check is layered cheapest-first: a single hash short-circuits before we stat hundreds of plugin inputs.

```ts
let driftReason = null;
if (cachedInputsSnapshot && cachedSerializedProjectGraphPromise) {
  const reason = await detectInputsDrift(cachedInputsSnapshot);
  if (reason) driftReason = describeInputsDrift(reason);
}

const needsRecompute =
  !cachedSerializedProjectGraphPromise ||
  collectedUpdatedFiles.size > 0 ||
  collectedDeletedFiles.size > 0 ||
  driftReason !== null;
```

### Coverage

| Scenario | Caught? |
|---|---|
| `nx.json` plugin set changed | ✅ |
| `nx.json` `targetDefaults` / `namedInputs` changed | ✅ |
| Root `package.json` workspaces changed | ✅ |
| Existing project's `project.json` / `package.json` edited | ✅ — covered by the plugin glob layer (project plugins glob those files) |
| Existing plugin source file edited | ✅ |
| Files matching a plugin's `createNodesV2` glob edited | ✅ |
| Any of the above deleted | ✅ — stat fails, signature flips to `'missing'` |
| inotify watch limit hit | ✅ — direct stat doesn't depend on the watcher |
| NFS / FUSE / overlay container FSes | ✅ — same |
| Watcher subprocess crashed and missed a window | ✅ — same |
| New project created in unwatched path | ❌ — set is from the cached graph; would need a periodic re-glob layer |

The remaining gap (new files in unwatched paths) is rare and is normally handled by the watcher's directory-creation events. Closing it would require a periodic cached re-glob — left as future work.

### Cost

Per cache-hit, on a typical workspace:

- Hash `nx.json` + root `package.json`: ~30 µs
- Stat workspace plugin sources: bounded by plugin count, single-digit µs
- Stat plugin glob inputs: parallel, ~1–5 ms for a 1000-project workspace

Vs. typical graph compute (50–500 ms+), this is noise.

### What this PR adds

- New module `packages/nx/src/daemon/server/inputs-snapshot.ts` with `captureInputsSnapshot` + `detectInputsDrift`.
- Hook in `kickOffRecompute` to capture the snapshot on every successful compute.
- Hook in `getCachedSerializedProjectGraphPromise` to drift-check before deciding `needsRecompute`.
- Snapshot cleared at every existing cache invalidation site (errors, reset, manual invalidate).
- 12 unit tests covering content-equal-size edits, deletions, missing-then-reappearing files, npm vs workspace plugin specs, plugins without globs, and multi-extension workspace plugin resolution.

`flushPendingWorkspaceChanges()` is left in place — it's complementary, not redundant. The drift check is the deterministic floor underneath it.

## Related Issue(s)

N/A — surfaced while investigating the spread test flake (https://github.com/nrwl/nx/pull/35629 CI rerun) and confirmed as a class of bug rather than a one-off race.