### PR TITLE
fix(core): resolve local plugin subpath imports from source

### DIFF
--- a/e2e/plugin/src/nx-plugin-ts-solution.test.ts
+++ b/e2e/plugin/src/nx-plugin-ts-solution.test.ts
@@ -266,6 +266,53 @@ describe('Nx Plugin (TS solution)', () => {
     expect(() => runCLI(`execute ${generatedProject}`)).not.toThrow();
   });
 
+  it('should load local plugins registered via subpath imports', async () => {
+    const plugin = uniq('plugin');
+    runCLI(`generate @nx/plugin:plugin packages/${plugin}`);
+
+    // expose a subpath plugin from a non-default location to ensure resolution
+    // goes through the package.json exports condition rather than any heuristic
+    updateFile(
+      `packages/${plugin}/src/plugins/cypress/plugin.ts`,
+      NX_PLUGIN_V2_CONTENTS
+    );
+
+    updateJson(`packages/${plugin}/package.json`, (pkg) => {
+      pkg.exports = {
+        ...pkg.exports,
+        './cypress': {
+          development: './src/plugins/cypress/plugin.ts',
+          default: './dist/plugins/cypress/plugin.js',
+        },
+      };
+      return pkg;
+    });
+
+    updateJson(`nx.json`, (nxJson) => {
+      nxJson.plugins ??= [];
+      nxJson.plugins.push({
+        plugin: `@${workspaceName}/${plugin}/cypress`,
+        options: { inferredTags: ['cypress-tag'] },
+      });
+      return nxJson;
+    });
+
+    const inferredProject = uniq('subpath-inferred');
+    createFile(
+      `packages/${inferredProject}/package.json`,
+      JSON.stringify({ name: inferredProject, version: '0.0.1' })
+    );
+    createFile(`packages/${inferredProject}/my-project-file`);
+
+    expect(runCLI(`build ${inferredProject}`)).toContain(
+      'custom registered target'
+    );
+    const configuration = JSON.parse(
+      runCLI(`show project ${inferredProject} --json`)
+    );
+    expect(configuration.tags).toContain('cypress-tag');
+  });
+
   it('should respect and support generating plugins with a name different than the import path', async () => {
     const plugin = uniq('plugin');
 

--- a/e2e/plugin/src/nx-plugin-ts-solution.test.ts
+++ b/e2e/plugin/src/nx-plugin-ts-solution.test.ts
@@ -269,9 +269,12 @@ describe('Nx Plugin (TS solution)', () => {
   it('should load local plugins registered via subpath imports', async () => {
     const plugin = uniq('plugin');
     runCLI(`generate @nx/plugin:plugin packages/${plugin}`);
+    const sourceCondition =
+      readJson('tsconfig.base.json').compilerOptions.customConditions[0];
+    expect(sourceCondition).not.toBe('development');
 
     // expose a subpath plugin from a non-default location to ensure resolution
-    // goes through the package.json exports condition rather than any heuristic
+    // goes through the workspace custom condition rather than any heuristic
     updateFile(
       `packages/${plugin}/src/plugins/cypress/plugin.ts`,
       NX_PLUGIN_V2_CONTENTS
@@ -281,7 +284,7 @@ describe('Nx Plugin (TS solution)', () => {
       pkg.exports = {
         ...pkg.exports,
         './cypress': {
-          development: './src/plugins/cypress/plugin.ts',
+          [sourceCondition]: './src/plugins/cypress/plugin.ts',
           default: './dist/plugins/cypress/plugin.js',
         },
       };
@@ -311,6 +314,80 @@ describe('Nx Plugin (TS solution)', () => {
       runCLI(`show project ${inferredProject} --json`)
     );
     expect(configuration.tags).toContain('cypress-tag');
+  });
+
+  it('should not load local plugin subpath imports from dist', async () => {
+    const plugin = uniq('plugin');
+    runCLI(`generate @nx/plugin:plugin packages/${plugin}`);
+
+    updateFile(
+      `packages/${plugin}/src/plugins/cypress/plugin.ts`,
+      NX_PLUGIN_V2_CONTENTS
+    );
+    createFile(
+      `packages/${plugin}/dist/plugins/cypress/plugin.js`,
+      `const { basename, dirname } = require("path");
+
+exports.createNodesV2 = [
+  "**/my-project-file",
+  (files, options) =>
+    files.map((f) => {
+      const root = dirname(f);
+      const name = basename(root);
+      return [
+        f,
+        {
+          projects: {
+            [root]: {
+              root,
+              name,
+              targets: {
+                build: {
+                  executor: "nx:run-commands",
+                  options: {
+                    command: "echo 'dist registered target'",
+                  },
+                },
+              },
+              tags: options.inferredTags,
+            },
+          },
+        },
+      ];
+    }),
+];
+`
+    );
+
+    updateJson(`packages/${plugin}/package.json`, (pkg) => {
+      pkg.exports = {
+        ...pkg.exports,
+        './cypress': {
+          default: './dist/plugins/cypress/plugin.js',
+        },
+      };
+      return pkg;
+    });
+
+    updateJson(`nx.json`, (nxJson) => {
+      nxJson.plugins ??= [];
+      nxJson.plugins.push({
+        plugin: `@${workspaceName}/${plugin}/cypress`,
+        options: { inferredTags: ['cypress-tag'] },
+      });
+      return nxJson;
+    });
+
+    const inferredProject = uniq('subpath-inferred');
+    createFile(
+      `packages/${inferredProject}/package.json`,
+      JSON.stringify({ name: inferredProject, version: '0.0.1' })
+    );
+    createFile(`packages/${inferredProject}/my-project-file`);
+
+    expect(() => runCLI(`show project ${inferredProject} --json`)).toThrow(
+      /resolvable source-pointing condition/
+    );
   });
 
   it('should respect and support generating plugins with a name different than the import path', async () => {

--- a/e2e/plugin/src/nx-plugin-ts-solution.test.ts
+++ b/e2e/plugin/src/nx-plugin-ts-solution.test.ts
@@ -388,6 +388,16 @@ exports.createNodesV2 = [
     expect(() => runCLI(`show project ${inferredProject} --json`)).toThrow(
       /resolvable source-pointing condition/
     );
+
+    // Clean up the broken plugin registration so subsequent tests are not affected
+    updateJson(`nx.json`, (nxJson) => {
+      nxJson.plugins = (nxJson.plugins ?? []).filter(
+        (p) =>
+          typeof p === 'string' ||
+          p.plugin !== `@${workspaceName}/${plugin}/cypress`
+      );
+      return nxJson;
+    });
   });
 
   it('should respect and support generating plugins with a name different than the import path', async () => {

--- a/packages/nx/src/config/schema-utils.ts
+++ b/packages/nx/src/config/schema-utils.ts
@@ -6,6 +6,7 @@ import {
   requireWithTsconfigFallback,
 } from '../plugins/js/utils/register';
 import { getWorkspacePackagesMetadata } from '../plugins/js/utils/packages';
+import { getRootTsConfigResolveExportsConditions } from '../plugins/js/utils/typescript';
 import { normalizePath } from '../utils/path';
 import type { ProjectConfiguration } from './workspace-json-project-json';
 
@@ -148,7 +149,7 @@ function tryResolveFromSource(
         exports: localProject.metadata!.js!.packageExports,
       },
       path,
-      { conditions: ['development'] }
+      { conditions: getRootTsConfigResolveExportsConditions() }
     );
     if (fromExports && fromExports.length) {
       for (const exportPath of fromExports) {

--- a/packages/nx/src/plugins/js/utils/typescript.ts
+++ b/packages/nx/src/plugins/js/utils/typescript.ts
@@ -112,6 +112,52 @@ export function getRootTsConfigPath(): string | null {
   return tsConfigFileName ? join(workspaceRoot, tsConfigFileName) : null;
 }
 
+const customConditionsCache = new Map<string, string[]>();
+export function getRootTsConfigCustomConditions(
+  root: string = workspaceRoot
+): string[] {
+  if (customConditionsCache.has(root)) {
+    return customConditionsCache.get(root)!;
+  }
+
+  // Resolve via the TypeScript API rather than a raw JSON read so that
+  // `customConditions` inherited through `extends` chains are honored —
+  // matches what TypeScript itself sees when resolving package exports.
+  let conditions: string[] = [];
+  for (const name of ['tsconfig.base.json', 'tsconfig.json']) {
+    const tsConfigPath = join(root, name);
+    if (!existsSync(tsConfigPath)) {
+      continue;
+    }
+    try {
+      const options = readTsConfigOptions(tsConfigPath);
+      if (Array.isArray(options.customConditions)) {
+        conditions = options.customConditions.filter(
+          (c): c is string => typeof c === 'string'
+        );
+      }
+    } catch {}
+    break;
+  }
+
+  customConditionsCache.set(root, conditions);
+  return conditions;
+}
+
+/**
+ * Conditions list for `resolve.exports`: workspace `customConditions` plus
+ * `development` as backward-compat for workspaces not yet migrated by
+ * `migrate-development-custom-condition` (21.5).
+ */
+export function getRootTsConfigResolveExportsConditions(
+  root: string = workspaceRoot
+): string[] {
+  const conditions = getRootTsConfigCustomConditions(root);
+  return conditions.includes('development')
+    ? conditions
+    : [...conditions, 'development'];
+}
+
 export function findNodes(
   node: Node,
   kind: SyntaxKind | SyntaxKind[],

--- a/packages/nx/src/project-graph/plugins/resolve-plugin.ts
+++ b/packages/nx/src/project-graph/plugins/resolve-plugin.ts
@@ -95,6 +95,13 @@ function isWorkspaceLocalResolution(
   );
 }
 
+function isPackageResolutionError(e: unknown): boolean {
+  const code = (e as { code?: string }).code;
+  return (
+    code === 'MODULE_NOT_FOUND' || code === 'ERR_PACKAGE_PATH_NOT_EXPORTED'
+  );
+}
+
 function readPluginMainFromProjectConfiguration(
   plugin: ProjectConfiguration
 ): string | null {
@@ -141,12 +148,18 @@ export function getPluginPathAndName(
     : null;
   if (localPlugin) {
     pluginPath = tryResolveLocalPluginFromSource(moduleName, localPlugin, root);
+    if (!pluginPath && getSubpathOfLocalPackage(moduleName, localPlugin)) {
+      throwUnresolvableLocalPluginError(moduleName, localPlugin, root);
+    }
   }
 
   if (!pluginPath) {
     try {
       pluginPath = require.resolve(moduleName, { paths });
     } catch (e) {
+      if (localPlugin && isPackageResolutionError(e)) {
+        throwUnresolvableLocalPluginError(moduleName, localPlugin, root);
+      }
       if (e.code !== 'MODULE_NOT_FOUND') {
         throw e;
       }
@@ -222,9 +235,8 @@ function throwUnresolvableLocalPluginError(
       `Unable to resolve local plugin "${moduleName}". The import targets ` +
         `the subpath "${subpath}" of the local package "${packageName}", but ` +
         `the package's "exports" entry for "${subpath}" does not declare a ` +
-        `source-pointing condition recognized by Nx and Node could not ` +
-        `resolve it either. Add a custom condition pointing to the source ` +
-        `file for that subpath in ` +
+        `resolvable source-pointing condition recognized by Nx. Add a custom ` +
+        `condition pointing to the source file for that subpath in ` +
         `"${path.relative(root, path.join(plugin.path, 'package.json'))}", ` +
         `e.g. "${subpath}": { "${exampleCondition}": "<path/to/source>" }, and ` +
         `ensure the condition name is listed in ` +

--- a/packages/nx/src/project-graph/plugins/resolve-plugin.ts
+++ b/packages/nx/src/project-graph/plugins/resolve-plugin.ts
@@ -1,10 +1,15 @@
 import * as path from 'node:path';
 import { existsSync } from 'node:fs';
+import { resolve as resolveExports } from 'resolve.exports';
 
 import {
   getWorkspacePackagesMetadata,
   matchImportToWildcardEntryPointsToProjectMap,
 } from '../../plugins/js/utils/packages';
+import {
+  getRootTsConfigCustomConditions,
+  getRootTsConfigResolveExportsConditions,
+} from '../../plugins/js/utils/typescript';
 import { readJsonFile } from '../../utils/fileutils';
 import { logger } from '../../utils/logger';
 import { normalizePath } from '../../utils/path';
@@ -17,6 +22,18 @@ import { retrieveProjectConfigurationsWithoutPluginInference } from '../utils/re
 
 import type { ProjectConfiguration } from '../../config/workspace-json-project-json';
 
+type LocalPluginMatch = {
+  path: string;
+  projectConfig: ProjectConfiguration;
+  // Set only when a tsconfig `paths` entry maps the import to an existing
+  // file with an extension. Directory and extensionless mappings are left
+  // for the downstream `main`/exports-condition flow to resolve, since they
+  // require full module resolution to load.
+  resolvedFile?: string;
+};
+
+const TS_SOURCE_EXTENSIONS = new Set(['.ts', '.tsx', '.cts', '.mts']);
+
 let projectsWithoutInference: Record<string, ProjectConfiguration>;
 let projectsWithoutInferencePromise: Promise<
   typeof projectsWithoutInference
@@ -27,14 +44,30 @@ export async function resolveNxPlugin(
   root: string,
   paths: string[]
 ) {
-  try {
-    require.resolve(moduleName, { paths });
-  } catch {
-    // If a plugin cannot be resolved, we will need projects to resolve it
-    projectsWithoutInferencePromise ??=
-      retrieveProjectConfigurationsWithoutPluginInference(root);
-    projectsWithoutInference ??= await projectsWithoutInferencePromise;
+  // Default plugins (see `getDefaultPlugins` in `get-plugins.ts`) are passed
+  // as absolute file paths to compiled bundles inside `nx` itself; they are
+  // never workspace-local. Skip the project load entirely for them to avoid
+  // recursing through `retrieveProjectConfigurationsWithoutPluginInference`,
+  // which itself triggers default-plugin loading.
+  if (!path.isAbsolute(moduleName)) {
+    let resolvedFromNode: string | undefined;
+    try {
+      resolvedFromNode = require.resolve(moduleName, { paths });
+    } catch {}
+
+    // Load projects if Node couldn't resolve (so the local fallback can run)
+    // OR if Node resolved to a workspace-internal path (a symlinked workspace
+    // package whose source-first lookup should win over the symlinked dist).
+    if (
+      !resolvedFromNode ||
+      isWorkspaceLocalResolution(resolvedFromNode, root)
+    ) {
+      projectsWithoutInferencePromise ??=
+        retrieveProjectConfigurationsWithoutPluginInference(root);
+      projectsWithoutInference ??= await projectsWithoutInferencePromise;
+    }
   }
+
   const { pluginPath, name, shouldRegisterTSTranspiler } = getPluginPathAndName(
     moduleName,
     paths,
@@ -42,6 +75,24 @@ export async function resolveNxPlugin(
     root
   );
   return { pluginPath, name, shouldRegisterTSTranspiler };
+}
+
+/**
+ * Distinguishes a symlinked workspace package (where `require.resolve`
+ * follows the package-manager symlink into the workspace source tree) from
+ * a truly-installed dependency under `node_modules/`. The former needs the
+ * source-first lookup to bypass the dist that Node would otherwise return.
+ */
+function isWorkspaceLocalResolution(
+  resolvedPath: string,
+  root: string
+): boolean {
+  const normalizedRoot = path.normalize(root);
+  const normalizedPath = path.normalize(resolvedPath);
+  return (
+    normalizedPath.startsWith(normalizedRoot + path.sep) &&
+    !normalizedPath.includes(path.sep + 'node_modules' + path.sep)
+  );
 }
 
 function readPluginMainFromProjectConfiguration(
@@ -67,7 +118,7 @@ export function resolveLocalNxPlugin(
   importPath: string,
   projects: Record<string, ProjectConfiguration>,
   root = workspaceRoot
-): { path: string; projectConfig: ProjectConfiguration } | null {
+): LocalPluginMatch | null {
   return lookupLocalPlugin(importPath, projects, root);
 }
 
@@ -77,33 +128,44 @@ export function getPluginPathAndName(
   projects: Record<string, ProjectConfiguration>,
   root: string
 ) {
-  let pluginPath: string;
-  let shouldRegisterTSTranspiler = false;
-  try {
-    pluginPath = require.resolve(moduleName, {
-      paths,
-    });
-    const extension = path.extname(pluginPath);
-    shouldRegisterTSTranspiler = extension === '.ts';
-  } catch (e) {
-    if (e.code === 'MODULE_NOT_FOUND') {
-      const plugin = resolveLocalNxPlugin(moduleName, projects, root);
-      if (plugin) {
-        shouldRegisterTSTranspiler = true;
-        const main = readPluginMainFromProjectConfiguration(
-          plugin.projectConfig
-        );
-        pluginPath = main ? path.join(root, main) : plugin.path;
-      } else {
-        logger.error(`Plugin listed in \`nx.json\` not found: ${moduleName}`);
+  let pluginPath: string | undefined;
+
+  // Resolve local workspace plugins from source first so the workspace's
+  // `customConditions`/`development` exports condition wins over the built
+  // `dist` artifact that Node's resolver would otherwise pick up via the
+  // `default` condition (Node ignores TypeScript custom conditions). Skipped
+  // when `projects` weren't loaded — the caller already determined that the
+  // import isn't a workspace package.
+  const localPlugin = projects
+    ? resolveLocalNxPlugin(moduleName, projects, root)
+    : null;
+  if (localPlugin) {
+    pluginPath = tryResolveLocalPluginFromSource(moduleName, localPlugin, root);
+  }
+
+  if (!pluginPath) {
+    try {
+      pluginPath = require.resolve(moduleName, { paths });
+    } catch (e) {
+      if (e.code !== 'MODULE_NOT_FOUND') {
         throw e;
       }
-    } else {
+      if (localPlugin) {
+        throwUnresolvableLocalPluginError(moduleName, localPlugin, root);
+      }
+      logger.error(`Plugin listed in \`nx.json\` not found: ${moduleName}`);
       throw e;
     }
   }
-  const packageJsonPath = path.join(pluginPath, 'package.json');
 
+  const ext = path.extname(pluginPath);
+  // Directory paths fall through to Node's `package.json` `main` resolution
+  // which may land on a TS file; only opt out of TS transpiler registration
+  // when the resolved path is unambiguously JS.
+  const shouldRegisterTSTranspiler =
+    ext === '' || TS_SOURCE_EXTENSIONS.has(ext);
+
+  const packageJsonPath = path.join(pluginPath, 'package.json');
   const { name } =
     !['.ts', '.js'].some((x) => path.extname(moduleName) === x) && // Not trying to point to a ts or js file
     existsSync(packageJsonPath) // plugin has a package.json
@@ -112,17 +174,151 @@ export function getPluginPathAndName(
   return { pluginPath, name, shouldRegisterTSTranspiler };
 }
 
+function getSubpathOfLocalPackage(
+  moduleName: string,
+  plugin: LocalPluginMatch
+): string | null {
+  const packageName = plugin.projectConfig.metadata?.js?.packageName;
+  if (!packageName || !moduleName.startsWith(packageName + '/')) {
+    return null;
+  }
+  return '.' + moduleName.slice(packageName.length);
+}
+
+function tryResolveLocalPluginFromSource(
+  moduleName: string,
+  plugin: LocalPluginMatch,
+  root: string
+): string | null {
+  if (plugin.resolvedFile) {
+    return plugin.resolvedFile;
+  }
+
+  const subpath = getSubpathOfLocalPackage(moduleName, plugin);
+  if (subpath) {
+    return resolveSubpathFromExports(
+      plugin.projectConfig,
+      plugin.path,
+      subpath,
+      root
+    );
+  }
+
+  const main = readPluginMainFromProjectConfiguration(plugin.projectConfig);
+  return main ? path.join(root, main) : null;
+}
+
+function throwUnresolvableLocalPluginError(
+  moduleName: string,
+  plugin: LocalPluginMatch,
+  root: string
+): never {
+  const subpath = getSubpathOfLocalPackage(moduleName, plugin);
+  const packageName = plugin.projectConfig.metadata?.js?.packageName;
+  if (subpath) {
+    const conditions = getRootTsConfigCustomConditions(root);
+    const exampleCondition = conditions[0] ?? 'development';
+    throw new Error(
+      `Unable to resolve local plugin "${moduleName}". The import targets ` +
+        `the subpath "${subpath}" of the local package "${packageName}", but ` +
+        `the package's "exports" entry for "${subpath}" does not declare a ` +
+        `source-pointing condition recognized by Nx and Node could not ` +
+        `resolve it either. Add a custom condition pointing to the source ` +
+        `file for that subpath in ` +
+        `"${path.relative(root, path.join(plugin.path, 'package.json'))}", ` +
+        `e.g. "${subpath}": { "${exampleCondition}": "<path/to/source>" }, and ` +
+        `ensure the condition name is listed in ` +
+        `"compilerOptions.customConditions" in your root tsconfig.`
+    );
+  }
+
+  throw new Error(
+    `Unable to resolve local plugin "${moduleName}". The local package ` +
+      `"${packageName ?? moduleName}" does not declare a build target with ` +
+      `a "main" source path, and Node could not resolve it either.`
+  );
+}
+
+function resolveSubpathFromExports(
+  projectConfig: ProjectConfiguration,
+  projectPath: string,
+  subpath: string,
+  root: string
+): string | null {
+  const packageExports = projectConfig.metadata?.js?.packageExports;
+  if (!packageExports) {
+    return null;
+  }
+
+  const pkg = {
+    name: projectConfig.metadata!.js!.packageName,
+    exports: packageExports,
+  };
+
+  try {
+    const matches = resolveExports(pkg, subpath, {
+      conditions: getRootTsConfigResolveExportsConditions(root),
+    });
+    if (!matches || !matches.length) {
+      return null;
+    }
+
+    // resolve.exports doesn't report which condition matched. If running with
+    // an empty conditions list (only `default`/`import`/`require` fallbacks)
+    // produces the same result, none of our source conditions matched —
+    // signal "no source-pointing condition" so the caller hard-fails instead
+    // of silently loading the package's built/dist target.
+    let fallbackMatches: string[] | void;
+    try {
+      fallbackMatches = resolveExports(pkg, subpath, { conditions: [] });
+    } catch {}
+    if (
+      fallbackMatches &&
+      fallbackMatches.length &&
+      fallbackMatches[0] === matches[0]
+    ) {
+      return null;
+    }
+
+    for (const match of matches) {
+      const candidate = path.join(projectPath, match);
+      if (existsSync(candidate)) {
+        return candidate;
+      }
+    }
+  } catch (e) {
+    logger.verbose(
+      `Failed to resolve subpath "${subpath}" of local plugin via package.json exports`,
+      e
+    );
+  }
+
+  return null;
+}
+
 function lookupLocalPlugin(
   importPath: string,
   projects: Record<string, ProjectConfiguration>,
   root = workspaceRoot
-) {
-  const projectConfig = findNxProjectForImportPath(importPath, projects, root);
-  if (!projectConfig) {
+): LocalPluginMatch | null {
+  const match = findNxProjectForImportPath(importPath, projects, root);
+  if (!match) {
     return null;
   }
 
-  return { path: path.join(root, projectConfig.root), projectConfig };
+  let resolvedFile: string | undefined;
+  if (match.tsPathFile) {
+    const candidate = path.join(root, match.tsPathFile);
+    if (path.extname(candidate) && existsSync(candidate)) {
+      resolvedFile = candidate;
+    }
+  }
+
+  return {
+    path: path.join(root, match.projectConfig.root),
+    projectConfig: match.projectConfig,
+    resolvedFile,
+  };
 }
 
 let packageEntryPointsToProjectMap: Record<string, ProjectConfiguration>;
@@ -131,7 +327,7 @@ function findNxProjectForImportPath(
   importPath: string,
   projects: Record<string, ProjectConfiguration>,
   root = workspaceRoot
-): ProjectConfiguration | null {
+): { projectConfig: ProjectConfiguration; tsPathFile?: string } | null {
   const tsConfigPaths: Record<string, string[]> = readTsConfigPaths(root);
   const possibleTsPaths =
     tsConfigPaths[importPath]?.map((p) =>
@@ -149,7 +345,10 @@ function findNxProjectForImportPath(
     for (const tsConfigPath of possibleTsPaths) {
       const nxProject = findProjectForPath(tsConfigPath, projectRootMappings);
       if (nxProject) {
-        return projectNameMap.get(nxProject);
+        return {
+          projectConfig: projectNameMap.get(nxProject)!,
+          tsPathFile: tsConfigPath,
+        };
       }
     }
   }
@@ -161,7 +360,7 @@ function findNxProjectForImportPath(
     } = getWorkspacePackagesMetadata(projects));
   }
   if (packageEntryPointsToProjectMap[importPath]) {
-    return packageEntryPointsToProjectMap[importPath];
+    return { projectConfig: packageEntryPointsToProjectMap[importPath] };
   }
 
   const project = matchImportToWildcardEntryPointsToProjectMap(
@@ -169,7 +368,7 @@ function findNxProjectForImportPath(
     importPath
   );
   if (project) {
-    return project;
+    return { projectConfig: project };
   }
 
   logger.verbose(
@@ -177,9 +376,7 @@ function findNxProjectForImportPath(
     possibleTsPaths,
     projectRootMappings
   );
-  throw new Error(
-    'Unable to resolve local plugin with import path ' + importPath
-  );
+  return null;
 }
 
 let tsconfigPaths: Record<string, string[]>;


### PR DESCRIPTION
## Current Behavior

Local Nx plugins imported via subpath exports (e.g. `@scope/pkg/cypress`) cannot be resolved from source. The loader collapses every subpath onto the project's build-target `main`, ignoring the imported subpath, so plugins either ship as committed `dist` artifacts (workaround) or fail to load with an empty entry point.

Additionally, even for non-subpath imports of workspace plugins symlinked into `node_modules`, Node's resolver picks the built `dist` artifact via the `default` exports condition (Node doesn't honor TypeScript `customConditions`), so source edits are ignored until the plugin is rebuilt.

## Expected Behavior

Subpath imports of local plugins resolve to source via `package.json` `exports` using the workspace-defined `customConditions`. Workspace-local plugins (subpath or bare) prefer their source-pointing condition over the built `dist` so source edits take effect without rebuilding.

## Implementation Details

- New `getRootTsConfigCustomConditions` helper reads `compilerOptions.customConditions` from the root tsconfig via the TypeScript API, honoring `extends` chains.
- `resolveSubpathFromExports` invokes `resolve.exports` with the workspace's conditions plus `development` as a backward-compat fallback for pre-21.5 setups. A second `resolve.exports` call with `conditions: []` detects when only `default`/`import`/`require` matched, signaling "no source-pointing condition" so the loader hard-fails with guidance instead of silently loading dist.
- Hoists local-source resolution ahead of `require.resolve` in `getPluginPathAndName` so symlinked workspace packages prefer source over dist. Default plugins (absolute paths) and external installed packages skip the local branch to avoid recursing through `retrieveProjectConfigurationsWithoutPluginInference`.
- Updates `schema-utils` (executors/generators) to use the same workspace conditions when resolving implementations from source.
- Adds an e2e test covering subpath plugin loading via the exports condition.