### PR TITLE
fix(testing): correct paths and reserve ports across flaky React MF e2e tests

### DIFF
--- a/e2e/react/src/module-federation/core-rspack-basic-playwright.test.ts
+++ b/e2e/react/src/module-federation/core-rspack-basic-playwright.test.ts
@@ -2,11 +2,13 @@ import { stripIndents } from '@nx/devkit';
 import {
   checkFilesExist,
   killProcessAndPorts,
+  reservePorts,
   runCLIAsync,
   runCommandUntil,
   runE2ETests,
   uniq,
   updateFile,
+  updateJson,
 } from '@nx/e2e-utils';
 import { readPort, runCLI } from './utils';
 import {
@@ -26,10 +28,25 @@ describe('React Rspack Module Federation - Basic - Playwright', () => {
     const remote1 = uniq('remote1');
     const remote2 = uniq('remote2');
     const remote3 = uniq('remote3');
+    const [shellPort, remote1Port, remote2Port, remote3Port] =
+      await reservePorts(4);
 
     runCLI(
-      `generate @nx/react:host apps/${shell} --name=${shell} --remotes=${remote1},${remote2},${remote3} --bundler=rspack --e2eTestRunner=playwright --style=css --no-interactive --skipFormat`
+      `generate @nx/react:host apps/${shell} --name=${shell} --remotes=${remote1},${remote2},${remote3} --bundler=rspack --devServerPort=${shellPort} --e2eTestRunner=playwright --style=css --no-interactive --skipFormat`
     );
+
+    updateJson(`apps/${remote1}/project.json`, (project) => {
+      project.targets.serve.options.port = remote1Port;
+      return project;
+    });
+    updateJson(`apps/${remote2}/project.json`, (project) => {
+      project.targets.serve.options.port = remote2Port;
+      return project;
+    });
+    updateJson(`apps/${remote3}/project.json`, (project) => {
+      project.targets.serve.options.port = remote3Port;
+      return project;
+    });
 
     checkFilesExist(`apps/${shell}/module-federation.config.ts`);
     checkFilesExist(`apps/${remote1}/module-federation.config.ts`);

--- a/e2e/react/src/module-federation/core-webpack-basic-playwright.test.ts
+++ b/e2e/react/src/module-federation/core-webpack-basic-playwright.test.ts
@@ -2,11 +2,13 @@ import { stripIndents } from '@nx/devkit';
 import {
   checkFilesExist,
   killProcessAndPorts,
+  reservePorts,
   runCLIAsync,
   runCommandUntil,
   runE2ETests,
   uniq,
   updateFile,
+  updateJson,
 } from '@nx/e2e-utils';
 import { readPort, runCLI } from './utils';
 import {
@@ -26,10 +28,25 @@ describe('React Module Federation - Webpack Basic - Playwright', () => {
     const remote1 = uniq('remote1');
     const remote2 = uniq('remote2');
     const remote3 = uniq('remote3');
+    const [shellPort, remote1Port, remote2Port, remote3Port] =
+      await reservePorts(4);
 
     runCLI(
-      `generate @nx/react:host apps/${shell} --name=${shell} --remotes=${remote1},${remote2},${remote3} --bundler=webpack --e2eTestRunner=playwright --style=css --no-interactive --skipFormat`
+      `generate @nx/react:host apps/${shell} --name=${shell} --remotes=${remote1},${remote2},${remote3} --bundler=webpack --devServerPort=${shellPort} --e2eTestRunner=playwright --style=css --no-interactive --skipFormat`
     );
+
+    updateJson(`apps/${remote1}/project.json`, (project) => {
+      project.targets.serve.options.port = remote1Port;
+      return project;
+    });
+    updateJson(`apps/${remote2}/project.json`, (project) => {
+      project.targets.serve.options.port = remote2Port;
+      return project;
+    });
+    updateJson(`apps/${remote3}/project.json`, (project) => {
+      project.targets.serve.options.port = remote3Port;
+      return project;
+    });
 
     checkFilesExist(`apps/${shell}/module-federation.config.ts`);
     checkFilesExist(`apps/${remote1}/module-federation.config.ts`);

--- a/e2e/react/src/module-federation/misc-rspack-convert-to-rspack.test.ts
+++ b/e2e/react/src/module-federation/misc-rspack-convert-to-rspack.test.ts
@@ -44,7 +44,7 @@ describe('React Rspack Module Federation Misc - Convert To Rspack', () => {
     );
 
     updateFile(
-      `apps/${shell}-e2e/src/example.spec.ts`,
+      `${shell}-e2e/src/example.spec.ts`,
       stripIndents`
           import { test, expect } from '@playwright/test';
           test('should display welcome message', async ({page}) => {
@@ -62,7 +62,8 @@ describe('React Rspack Module Federation Misc - Convert To Rspack', () => {
     if (runE2ETests()) {
       const e2eResultsSwc = await runCommandUntil(
         `e2e ${shell}-e2e`,
-        (output) => output.includes('Successfully ran target e2e for project')
+        (output) => output.includes('Successfully ran target e2e for project'),
+        { timeout: 120_000 }
       );
 
       await killProcessAndPorts(e2eResultsSwc.pid, readPort(shell));


### PR DESCRIPTION
## Current Behavior

Three React module-federation e2e tests in `e2e/react/src/module-federation/` have been flaking in CI:

### `misc-rspack-convert-to-rspack.test.ts` — silent test gap + 30s timeout

1. **Wrong `updateFile` path.** Line 47 wrote to `apps/${shell}-e2e/src/example.spec.ts`, but `@nx/react:host` (without an `apps/` prefix in the project name) generates the e2e project at workspace root. `updateFile` calls `ensureDirSync(...)` and silently created the file under the wrong path tree, leaving the default Nx-generated 1-test Playwright spec to run instead. The test has been quietly exercising the default Welcome page rather than the convert-to-rspack module-federation remote-loading behavior. Same root cause that `dc9ba49fe3` fixed for the sibling `updateJson` call — the matching `updateFile` was missed.
2. **Missing `runCommandUntil` timeout.** Line 63 omitted the `timeout` option, falling back to the 30s default in `e2e/utils/command-utils.ts:300`. The e2e step needs to bootstrap nx, cold-compile rspack for host + remote, and run the spec across 3 browser projects sequentially with 1 worker — which routinely exceeds 30s. PR #34148 added `{ timeout: 120_000 }` to several sibling MF tests but missed this one because it landed later in #32948.

### `core-rspack-basic-playwright.test.ts` and `core-webpack-basic-playwright.test.ts` — port collisions on parallel agents

Both tests generated their host on the default port **4200** with no reservation. Once #35325 enabled parallel `e2e-ci` execution on the same agent, any other concurrent test that also defaulted to 4200 (another MF test, an `e2e-playwright` test, etc.) collided with this one. Symptoms across recent failures:

- Shell preview server gets SIGKILL'd (`Killed` / `code 137`) mid-run while another test fights for the same port and the OS picks a loser.
- Subsequent Playwright requests fail with `NS_ERROR_CONNECTION_REFUSED` / `Connection refused`.
- On retry the **other** test's dev server answers, so the assertion fails with strings like `Welcome app9409916` or `Welcome pw-react-app6359154` — app names that aren't even in the running test.

This is exactly the gap called out in #35325:
> e2e/cypress, e2e/playwright, and the React module-federation tests still hardcode ports through their generators; those will be addressed in follow-up PRs as CI surfaces collisions.

## Expected Behavior

- `misc-rspack-convert-to-rspack` writes the spec file to the correct path so it actually exercises the convert-to-rspack MF behavior, and gets the same 120s timeout as the sibling MF tests so cold rspack compile + 3 browser runs fit reliably.
- `core-rspack-basic-playwright` and `core-webpack-basic-playwright` use `reservePorts(4)` for shell + 3 remotes, pass `--devServerPort=${shellPort}` to the host generator (which propagates to the host's serve, preview, and the e2e project's playwright `baseUrl` per `packages/react/src/generators/host/`), and `updateJson` each remote's `project.json` to use its reserved port — matching the pattern already in `misc-rspack-convert-to-rspack` and `independent-deployability.webpack`.

## Verification

- **Local** (`NX_E2E_RUN_E2E=true pnpm nx run e2e-react:e2e-ci--src/module-federation/<file> --skip-nx-cache`):
  - `misc-rspack-convert-to-rspack.test.ts` → PASS (~162s wall, ~108s test) with e2e step actually running.
  - `core-rspack-basic-playwright.test.ts` → PASS with the port fix applied.
- **CI**: relying on the PR's `e2e-ci` aggregate and re-runs to confirm the flake is gone.

## Related Issue(s)

N/A — internal flake fix surfaced by repeated `e2e-react:e2e-ci` failures on parallel CI agents. Not tracked as a GitHub issue.
