### PR TITLE
feat(core): support `prompt` field in migration entries

### DIFF
--- a/packages/nx/src/command-line/migrate/migrate.spec.ts
+++ b/packages/nx/src/command-line/migrate/migrate.spec.ts
@@ -3737,7 +3737,7 @@ describe('Migration', () => {
       rmSync(tmpRoot, { recursive: true, force: true });
     });
 
-    it('should write prompt files using scoped namespace and version-prefixed filenames', () => {
+    it('should write prompt files preserving the relative path under the package directory', () => {
       const migrations = [
         {
           package: '@nx/expo',
@@ -3759,15 +3759,15 @@ describe('Migration', () => {
       );
 
       expect(written).toEqual([
-        'tools/ai-migrations/nx/expo/22.2.0-beta.3-ai-instructions-for-expo-54.md',
+        'tools/ai-migrations/@nx/expo/src/migrations/update-22-2-0/files/ai-instructions-for-expo-54.md',
       ]);
       expect(migrations[0].prompt).toBe(
-        'tools/ai-migrations/nx/expo/22.2.0-beta.3-ai-instructions-for-expo-54.md'
+        'tools/ai-migrations/@nx/expo/src/migrations/update-22-2-0/files/ai-instructions-for-expo-54.md'
       );
       expect(readFileSync(join(tmpRoot, written[0]), 'utf-8')).toBe('EXPO');
     });
 
-    it('should namespace unscoped packages without a scope directory', () => {
+    it('should write under the package directory when unscoped', () => {
       const migrations = [
         {
           package: 'mypackage',
@@ -3784,10 +3784,10 @@ describe('Migration', () => {
         promptContents
       );
 
-      expect(written).toEqual(['tools/ai-migrations/mypackage/1.0.0-foo.md']);
+      expect(written).toEqual(['tools/ai-migrations/mypackage/files/foo.md']);
     });
 
-    it('should write two distinct files when two entries reference the same source .md', () => {
+    it('should write a single file when two entries reference the same source .md', () => {
       const migrations = [
         {
           package: '@nx/vitest',
@@ -3812,37 +3812,12 @@ describe('Migration', () => {
         promptContents
       );
 
-      expect(written).toEqual([
-        'tools/ai-migrations/nx/vitest/22.1.0-beta.8-ai-instructions-for-vitest-4.md',
-        'tools/ai-migrations/nx/vitest/22.3.2-beta.0-ai-instructions-for-vitest-4.md',
-      ]);
-      expect(readFileSync(join(tmpRoot, written[0]), 'utf-8')).toBe('V');
-      expect(readFileSync(join(tmpRoot, written[1]), 'utf-8')).toBe('V');
-    });
-
-    it('should throw when two entries collide on the destination path', () => {
-      const migrations = [
-        {
-          package: '@nx/vitest',
-          name: 'a',
-          version: '22.1.0-beta.8',
-          prompt: './files/ai-instructions-for-vitest-4.md',
-        },
-        {
-          package: '@nx/vitest',
-          name: 'b',
-          version: '22.1.0-beta.8',
-          prompt: './other-dir/ai-instructions-for-vitest-4.md',
-        },
-      ];
-      const promptContents = {
-        '@nx/vitest::./files/ai-instructions-for-vitest-4.md': 'V1',
-        '@nx/vitest::./other-dir/ai-instructions-for-vitest-4.md': 'V2',
-      };
-
-      expect(() =>
-        writePromptMigrationFiles(tmpRoot, migrations, promptContents)
-      ).toThrow(/Conflicting AI migration prompt destination/);
+      const expectedPath =
+        'tools/ai-migrations/@nx/vitest/files/ai-instructions-for-vitest-4.md';
+      expect(written).toEqual([expectedPath]);
+      expect(migrations[0].prompt).toBe(expectedPath);
+      expect(migrations[1].prompt).toBe(expectedPath);
+      expect(readFileSync(join(tmpRoot, expectedPath), 'utf-8')).toBe('V');
     });
 
     it('should ignore entries whose prompt content is missing from the map', () => {
@@ -3868,7 +3843,7 @@ describe('Migration', () => {
         migrations,
         promptContents
       );
-      expect(written).toEqual(['tools/ai-migrations/pkg/1.0.0-x.md']);
+      expect(written).toEqual(['tools/ai-migrations/pkg/x.md']);
     });
   });
 });

--- a/packages/nx/src/command-line/migrate/migrate.spec.ts
+++ b/packages/nx/src/command-line/migrate/migrate.spec.ts
@@ -37,9 +37,16 @@ import {
   validateMigrationEntries,
   writePromptMigrationFiles,
 } from './prompt-files';
-import { mkdtempSync, readFileSync, rmSync } from 'fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'fs';
 import { tmpdir } from 'os';
-import { join } from 'path';
+import { dirname, join } from 'path';
 
 const createPackageJson = (
   overrides: Partial<PackageJson> = {}
@@ -3737,7 +3744,7 @@ describe('Migration', () => {
       rmSync(tmpRoot, { recursive: true, force: true });
     });
 
-    it('should write prompt files preserving the relative path under the package directory', () => {
+    it('should write prompt files under the package and target version directories using the basename', () => {
       const migrations = [
         {
           package: '@nx/expo',
@@ -3755,16 +3762,15 @@ describe('Migration', () => {
       const written = writePromptMigrationFiles(
         tmpRoot,
         migrations,
-        promptContents
+        promptContents,
+        '22.5.0'
       );
 
-      expect(written).toEqual([
-        'tools/ai-migrations/@nx/expo/src/migrations/update-22-2-0/files/ai-instructions-for-expo-54.md',
-      ]);
-      expect(migrations[0].prompt).toBe(
-        'tools/ai-migrations/@nx/expo/src/migrations/update-22-2-0/files/ai-instructions-for-expo-54.md'
-      );
-      expect(readFileSync(join(tmpRoot, written[0]), 'utf-8')).toBe('EXPO');
+      const expectedPath =
+        'tools/ai-migrations/@nx/expo/22.5.0/ai-instructions-for-expo-54.md';
+      expect(written).toEqual([expectedPath]);
+      expect(migrations[0].prompt).toBe(expectedPath);
+      expect(readFileSync(join(tmpRoot, expectedPath), 'utf-8')).toBe('EXPO');
     });
 
     it('should write under the package directory when unscoped', () => {
@@ -3781,10 +3787,11 @@ describe('Migration', () => {
       const written = writePromptMigrationFiles(
         tmpRoot,
         migrations,
-        promptContents
+        promptContents,
+        '1.0.0'
       );
 
-      expect(written).toEqual(['tools/ai-migrations/mypackage/files/foo.md']);
+      expect(written).toEqual(['tools/ai-migrations/mypackage/1.0.0/foo.md']);
     });
 
     it('should write a single file when two entries reference the same source .md', () => {
@@ -3809,15 +3816,157 @@ describe('Migration', () => {
       const written = writePromptMigrationFiles(
         tmpRoot,
         migrations,
-        promptContents
+        promptContents,
+        '22.4.0'
       );
 
       const expectedPath =
-        'tools/ai-migrations/@nx/vitest/files/ai-instructions-for-vitest-4.md';
+        'tools/ai-migrations/@nx/vitest/22.4.0/ai-instructions-for-vitest-4.md';
       expect(written).toEqual([expectedPath]);
       expect(migrations[0].prompt).toBe(expectedPath);
       expect(migrations[1].prompt).toBe(expectedPath);
       expect(readFileSync(join(tmpRoot, expectedPath), 'utf-8')).toBe('V');
+    });
+
+    it('should suffix the basename when two entries have different content but the same basename', () => {
+      const migrations = [
+        {
+          package: 'pkg',
+          name: 'a',
+          version: '1.0.0',
+          prompt: './a/foo.md',
+        },
+        {
+          package: 'pkg',
+          name: 'b',
+          version: '1.0.0',
+          prompt: './b/foo.md',
+        },
+      ];
+      const promptContents = {
+        'pkg::./a/foo.md': 'A',
+        'pkg::./b/foo.md': 'B',
+      };
+
+      const written = writePromptMigrationFiles(
+        tmpRoot,
+        migrations,
+        promptContents,
+        '2.0.0'
+      );
+
+      expect(written).toEqual([
+        'tools/ai-migrations/pkg/2.0.0/foo.md',
+        'tools/ai-migrations/pkg/2.0.0/foo-1.md',
+      ]);
+      expect(migrations[0].prompt).toBe('tools/ai-migrations/pkg/2.0.0/foo.md');
+      expect(migrations[1].prompt).toBe(
+        'tools/ai-migrations/pkg/2.0.0/foo-1.md'
+      );
+      expect(
+        readFileSync(
+          join(tmpRoot, 'tools/ai-migrations/pkg/2.0.0/foo.md'),
+          'utf-8'
+        )
+      ).toBe('A');
+      expect(
+        readFileSync(
+          join(tmpRoot, 'tools/ai-migrations/pkg/2.0.0/foo-1.md'),
+          'utf-8'
+        )
+      ).toBe('B');
+    });
+
+    it('should reuse an existing on-disk file when its content is identical', () => {
+      const existing = join(tmpRoot, 'tools/ai-migrations/pkg/2.0.0/foo.md');
+      mkdirSync(dirname(existing), { recursive: true });
+      writeFileSync(existing, 'SAME');
+
+      const migrations = [
+        {
+          package: 'pkg',
+          name: 'm',
+          version: '1.0.0',
+          prompt: './files/foo.md',
+        },
+      ];
+      const promptContents = { 'pkg::./files/foo.md': 'SAME' };
+
+      const written = writePromptMigrationFiles(
+        tmpRoot,
+        migrations,
+        promptContents,
+        '2.0.0'
+      );
+
+      expect(written).toEqual([]);
+      expect(migrations[0].prompt).toBe('tools/ai-migrations/pkg/2.0.0/foo.md');
+      expect(readFileSync(existing, 'utf-8')).toBe('SAME');
+    });
+
+    it('should suffix when an existing on-disk file has different content', () => {
+      const existing = join(tmpRoot, 'tools/ai-migrations/pkg/2.0.0/foo.md');
+      mkdirSync(dirname(existing), { recursive: true });
+      writeFileSync(existing, 'OLD');
+
+      const migrations = [
+        {
+          package: 'pkg',
+          name: 'm',
+          version: '1.0.0',
+          prompt: './files/foo.md',
+        },
+      ];
+      const promptContents = { 'pkg::./files/foo.md': 'NEW' };
+
+      const written = writePromptMigrationFiles(
+        tmpRoot,
+        migrations,
+        promptContents,
+        '2.0.0'
+      );
+
+      expect(written).toEqual(['tools/ai-migrations/pkg/2.0.0/foo-1.md']);
+      expect(migrations[0].prompt).toBe(
+        'tools/ai-migrations/pkg/2.0.0/foo-1.md'
+      );
+      expect(readFileSync(existing, 'utf-8')).toBe('OLD');
+      expect(
+        readFileSync(
+          join(tmpRoot, 'tools/ai-migrations/pkg/2.0.0/foo-1.md'),
+          'utf-8'
+        )
+      ).toBe('NEW');
+    });
+
+    it('should walk past existing suffixed files until it finds a free or content-matching slot', () => {
+      const dir = join(tmpRoot, 'tools/ai-migrations/pkg/2.0.0');
+      mkdirSync(dir, { recursive: true });
+      writeFileSync(join(dir, 'foo.md'), 'A');
+      writeFileSync(join(dir, 'foo-1.md'), 'B');
+
+      const migrations = [
+        {
+          package: 'pkg',
+          name: 'm',
+          version: '1.0.0',
+          prompt: './files/foo.md',
+        },
+      ];
+      const promptContents = { 'pkg::./files/foo.md': 'C' };
+
+      const written = writePromptMigrationFiles(
+        tmpRoot,
+        migrations,
+        promptContents,
+        '2.0.0'
+      );
+
+      expect(written).toEqual(['tools/ai-migrations/pkg/2.0.0/foo-2.md']);
+      expect(migrations[0].prompt).toBe(
+        'tools/ai-migrations/pkg/2.0.0/foo-2.md'
+      );
+      expect(readFileSync(join(dir, 'foo-2.md'), 'utf-8')).toBe('C');
     });
 
     it('should ignore entries whose prompt content is missing from the map', () => {
@@ -3841,9 +3990,10 @@ describe('Migration', () => {
       const written = writePromptMigrationFiles(
         tmpRoot,
         migrations,
-        promptContents
+        promptContents,
+        '1.0.0'
       );
-      expect(written).toEqual(['tools/ai-migrations/pkg/x.md']);
+      expect(written).toEqual(['tools/ai-migrations/pkg/1.0.0/x.md']);
     });
   });
 });

--- a/packages/nx/src/command-line/migrate/migrate.spec.ts
+++ b/packages/nx/src/command-line/migrate/migrate.spec.ts
@@ -32,6 +32,14 @@ import {
   resolveCanonicalNxPackage,
   resolveMode,
 } from './migrate';
+import {
+  readPromptFilesFromInstall,
+  validateMigrationEntries,
+  writePromptMigrationFiles,
+} from './prompt-files';
+import { mkdtempSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 
 const createPackageJson = (
   overrides: Partial<PackageJson> = {}
@@ -3558,6 +3566,309 @@ describe('Migration', () => {
         originalTargetVersion: '23.1.0',
       });
       expect((r as { multiMajorMode?: string }).multiMajorMode).toBeUndefined();
+    });
+  });
+
+  describe('prompt-bearing migrations', () => {
+    it('should expose resolved prompt content via promptContents keyed by package and prompt path', async () => {
+      const migrator = new Migrator({
+        packageJson: createPackageJson({
+          dependencies: { '@nx/expo': '1.0.0' },
+        }),
+        getInstalledPackageVersion: () => '1.0.0',
+        fetch: () =>
+          Promise.resolve({
+            version: '2.0.0',
+            generators: {
+              'ai-instructions': {
+                version: '2.0.0',
+                description: 'AI prompt only',
+                prompt: './files/ai-instructions.md',
+              },
+            },
+            resolvedPromptFiles: {
+              './files/ai-instructions.md': 'PROMPT BODY',
+            },
+          } as ResolvedMigrationConfiguration),
+        from: {},
+        to: {},
+      });
+
+      const result = await migrator.migrate('@nx/expo', '2.0.0');
+      expect(result.migrations).toEqual([
+        {
+          version: '2.0.0',
+          name: 'ai-instructions',
+          package: '@nx/expo',
+          description: 'AI prompt only',
+          prompt: './files/ai-instructions.md',
+        },
+      ]);
+      expect(result.promptContents).toEqual({
+        '@nx/expo::./files/ai-instructions.md': 'PROMPT BODY',
+      });
+    });
+
+    it('should preserve both prompt and implementation on hybrid entries', async () => {
+      const migrator = new Migrator({
+        packageJson: createPackageJson({ dependencies: { pkg: '1.0.0' } }),
+        getInstalledPackageVersion: () => '1.0.0',
+        fetch: () =>
+          Promise.resolve({
+            version: '2.0.0',
+            generators: {
+              hybrid: {
+                version: '2.0.0',
+                description: 'hybrid',
+                implementation: './migrations/hybrid',
+                prompt: './files/hybrid.md',
+              },
+            },
+            resolvedPromptFiles: {
+              './files/hybrid.md': 'HYBRID',
+            },
+          } as ResolvedMigrationConfiguration),
+        from: {},
+        to: {},
+      });
+
+      const result = await migrator.migrate('pkg', '2.0.0');
+      expect(result.migrations[0]).toMatchObject({
+        implementation: './migrations/hybrid',
+        prompt: './files/hybrid.md',
+      });
+      expect(result.promptContents).toEqual({
+        'pkg::./files/hybrid.md': 'HYBRID',
+      });
+    });
+
+    it('should omit promptContents from the result when no prompts were resolved', async () => {
+      const migrator = new Migrator({
+        packageJson: createPackageJson({ dependencies: { pkg: '1.0.0' } }),
+        getInstalledPackageVersion: () => '1.0.0',
+        fetch: () =>
+          Promise.resolve({
+            version: '2.0.0',
+            generators: {
+              one: {
+                version: '2.0.0',
+                description: 'plain',
+                implementation: './migrations/one',
+              },
+            },
+          } as ResolvedMigrationConfiguration),
+        from: {},
+        to: {},
+      });
+
+      const result = await migrator.migrate('pkg', '2.0.0');
+      expect(result).not.toHaveProperty('promptContents');
+    });
+  });
+
+  describe('validateMigrationEntries', () => {
+    it('should not throw when all entries have at least one of implementation/factory/prompt', () => {
+      expect(() =>
+        validateMigrationEntries('@nx/x', '2.0.0', {
+          generators: {
+            a: { version: '2.0.0', implementation: './a' },
+            b: { version: '2.0.0', factory: './b' },
+            c: { version: '2.0.0', prompt: './c.md' },
+          },
+        })
+      ).not.toThrow();
+    });
+
+    it('should throw when an entry has none of implementation/factory/prompt', () => {
+      expect(() =>
+        validateMigrationEntries('@nx/x', '2.0.0', {
+          generators: {
+            broken: { version: '2.0.0', description: 'oops' },
+          },
+        })
+      ).toThrow(
+        /Invalid migration "broken" in package "@nx\/x@2\.0\.0": migration entries must have at least one of "implementation", "factory", or "prompt"\./
+      );
+    });
+
+    it('should validate entries from both generators and schematics', () => {
+      expect(() =>
+        validateMigrationEntries('pkg', '1.0.0', {
+          schematics: {
+            broken: { version: '1.0.0' },
+          },
+        })
+      ).toThrow(/Invalid migration "broken" in package "pkg@1\.0\.0"/);
+    });
+  });
+
+  describe('prompt path traversal', () => {
+    it.each([
+      ['../../etc/passwd'],
+      ['./safe/../../escape.md'],
+      ['/etc/passwd'],
+    ])(
+      'should reject prompt path %p that escapes the migrations directory',
+      async (badPath) => {
+        await expect(
+          readPromptFilesFromInstall(
+            'pkg',
+            '1.0.0',
+            {
+              generators: {
+                m: { version: '1.0.0', prompt: badPath },
+              },
+            },
+            '/tmp/fake-pkg/migrations.json'
+          )
+        ).rejects.toThrow(/Invalid prompt path/);
+      }
+    );
+  });
+
+  describe('writePromptMigrationFiles', () => {
+    let tmpRoot: string;
+
+    beforeEach(() => {
+      tmpRoot = mkdtempSync(join(tmpdir(), 'nx-prompt-migrations-'));
+    });
+
+    afterEach(() => {
+      rmSync(tmpRoot, { recursive: true, force: true });
+    });
+
+    it('should write prompt files using scoped namespace and version-prefixed filenames', () => {
+      const migrations = [
+        {
+          package: '@nx/expo',
+          name: 'm',
+          version: '22.2.0-beta.3',
+          prompt:
+            './src/migrations/update-22-2-0/files/ai-instructions-for-expo-54.md',
+        },
+      ];
+      const promptContents = {
+        '@nx/expo::./src/migrations/update-22-2-0/files/ai-instructions-for-expo-54.md':
+          'EXPO',
+      };
+
+      const written = writePromptMigrationFiles(
+        tmpRoot,
+        migrations,
+        promptContents
+      );
+
+      expect(written).toEqual([
+        'tools/ai-migrations/nx/expo/22.2.0-beta.3-ai-instructions-for-expo-54.md',
+      ]);
+      expect(migrations[0].prompt).toBe(
+        'tools/ai-migrations/nx/expo/22.2.0-beta.3-ai-instructions-for-expo-54.md'
+      );
+      expect(readFileSync(join(tmpRoot, written[0]), 'utf-8')).toBe('EXPO');
+    });
+
+    it('should namespace unscoped packages without a scope directory', () => {
+      const migrations = [
+        {
+          package: 'mypackage',
+          name: 'm',
+          version: '1.0.0',
+          prompt: './files/foo.md',
+        },
+      ];
+      const promptContents = { 'mypackage::./files/foo.md': 'X' };
+
+      const written = writePromptMigrationFiles(
+        tmpRoot,
+        migrations,
+        promptContents
+      );
+
+      expect(written).toEqual(['tools/ai-migrations/mypackage/1.0.0-foo.md']);
+    });
+
+    it('should write two distinct files when two entries reference the same source .md', () => {
+      const migrations = [
+        {
+          package: '@nx/vitest',
+          name: 'a',
+          version: '22.1.0-beta.8',
+          prompt: './files/ai-instructions-for-vitest-4.md',
+        },
+        {
+          package: '@nx/vitest',
+          name: 'b',
+          version: '22.3.2-beta.0',
+          prompt: './files/ai-instructions-for-vitest-4.md',
+        },
+      ];
+      const promptContents = {
+        '@nx/vitest::./files/ai-instructions-for-vitest-4.md': 'V',
+      };
+
+      const written = writePromptMigrationFiles(
+        tmpRoot,
+        migrations,
+        promptContents
+      );
+
+      expect(written).toEqual([
+        'tools/ai-migrations/nx/vitest/22.1.0-beta.8-ai-instructions-for-vitest-4.md',
+        'tools/ai-migrations/nx/vitest/22.3.2-beta.0-ai-instructions-for-vitest-4.md',
+      ]);
+      expect(readFileSync(join(tmpRoot, written[0]), 'utf-8')).toBe('V');
+      expect(readFileSync(join(tmpRoot, written[1]), 'utf-8')).toBe('V');
+    });
+
+    it('should throw when two entries collide on the destination path', () => {
+      const migrations = [
+        {
+          package: '@nx/vitest',
+          name: 'a',
+          version: '22.1.0-beta.8',
+          prompt: './files/ai-instructions-for-vitest-4.md',
+        },
+        {
+          package: '@nx/vitest',
+          name: 'b',
+          version: '22.1.0-beta.8',
+          prompt: './other-dir/ai-instructions-for-vitest-4.md',
+        },
+      ];
+      const promptContents = {
+        '@nx/vitest::./files/ai-instructions-for-vitest-4.md': 'V1',
+        '@nx/vitest::./other-dir/ai-instructions-for-vitest-4.md': 'V2',
+      };
+
+      expect(() =>
+        writePromptMigrationFiles(tmpRoot, migrations, promptContents)
+      ).toThrow(/Conflicting AI migration prompt destination/);
+    });
+
+    it('should ignore entries whose prompt content is missing from the map', () => {
+      const migrations = [
+        { package: 'pkg', name: 'a', version: '1.0.0' },
+        {
+          package: 'pkg',
+          name: 'b',
+          version: '1.0.0',
+          prompt: './missing.md',
+        },
+        {
+          package: 'pkg',
+          name: 'c',
+          version: '1.0.0',
+          prompt: './x.md',
+        },
+      ];
+      const promptContents = { 'pkg::./x.md': 'X' };
+
+      const written = writePromptMigrationFiles(
+        tmpRoot,
+        migrations,
+        promptContents
+      );
+      expect(written).toEqual(['tools/ai-migrations/pkg/1.0.0-x.md']);
     });
   });
 });

--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -96,6 +96,14 @@ import {
   MULTI_MAJOR_MODE_FLAG,
   type MultiMajorMode,
 } from './multi-major';
+import {
+  AI_MIGRATIONS_DIR,
+  extractPromptFilesFromTarball,
+  promptContentKey,
+  readPromptFilesFromInstall,
+  validateMigrationEntries,
+  writePromptMigrationFiles,
+} from './prompt-files';
 import { filterDowngradedUpdates } from './update-filters';
 import {
   DIST_TAGS,
@@ -110,6 +118,8 @@ export { normalizeVersion };
 
 export interface ResolvedMigrationConfiguration extends MigrationsJson {
   packageGroup?: ArrayPackageGroup;
+  /** Prompt file contents keyed by the `prompt` value as it appears on the migration entry. */
+  resolvedPromptFiles?: Record<string, string>;
 }
 
 const execAsync = promisify(exec);
@@ -258,15 +268,17 @@ export class Migrator {
     });
     this.applyModeFilter();
 
-    const migrations = await this.createMigrateJson();
+    const { migrations, promptContents } = await this.createMigrateJson();
     return {
       packageUpdates: this.packageUpdates,
       migrations,
+      ...(Object.keys(promptContents).length > 0 ? { promptContents } : {}),
       minVersionWithSkippedUpdates: this.minVersionWithSkippedUpdates,
     };
   }
 
   private async createMigrateJson() {
+    const promptContents: Record<string, string> = {};
     const migrations = await Promise.all(
       Object.keys(this.packageUpdates).map(async (packageName) => {
         if (this.packageUpdates[packageName].ignoreMigrations) {
@@ -277,14 +289,20 @@ export class Migrator {
         if (currentVersion === null) return [];
 
         const { version } = this.packageUpdates[packageName];
-        const { generators } = await this.fetchMigrationConfig(
-          packageName,
-          version
-        );
+        const { generators: migrationEntries, resolvedPromptFiles } =
+          await this.fetchMigrationConfig(packageName, version);
 
-        if (!generators) return [];
+        if (!migrationEntries) return [];
 
-        return Object.entries(generators)
+        if (resolvedPromptFiles) {
+          for (const [promptPath, content] of Object.entries(
+            resolvedPromptFiles
+          )) {
+            promptContents[promptContentKey(packageName, promptPath)] = content;
+          }
+        }
+
+        return Object.entries(migrationEntries)
           .filter(
             ([, migration]) =>
               migration.version &&
@@ -300,7 +318,7 @@ export class Migrator {
       })
     );
 
-    return migrations.flat();
+    return { migrations: migrations.flat(), promptContents };
   }
 
   private async buildPackageJsonUpdates(
@@ -1538,17 +1556,38 @@ async function downloadPackageMigrationsFromRegistry(
       packageVersion
     );
 
-    const migrations = await extractFileFromTarball(
-      join(dir, tarballPath),
-      joinPathFragments('package', migrationsFilePath),
-      join(dir, migrationsFilePath)
-    ).then((path) => readJsonFile<MigrationsJson>(path));
+    const fullTarballPath = join(dir, tarballPath);
 
-    result = { ...migrations, packageGroup, version: packageVersion };
-  } catch {
-    throw new Error(
-      `Failed to find migrations file "${migrationsFilePath}" in package "${packageName}@${packageVersion}".`
+    let migrations: MigrationsJson;
+    try {
+      migrations = await extractFileFromTarball(
+        fullTarballPath,
+        joinPathFragments('package', migrationsFilePath),
+        join(dir, migrationsFilePath)
+      ).then((path) => readJsonFile<MigrationsJson>(path));
+    } catch {
+      throw new Error(
+        `Failed to find migrations file "${migrationsFilePath}" in package "${packageName}@${packageVersion}".`
+      );
+    }
+
+    validateMigrationEntries(packageName, packageVersion, migrations);
+
+    const resolvedPromptFiles = await extractPromptFilesFromTarball(
+      packageName,
+      packageVersion,
+      migrations,
+      migrationsFilePath,
+      fullTarballPath,
+      dir
     );
+
+    result = {
+      ...migrations,
+      packageGroup,
+      version: packageVersion,
+      ...(resolvedPromptFiles ? { resolvedPromptFiles } : {}),
+    };
   } finally {
     await cleanup();
   }
@@ -1630,11 +1669,24 @@ async function getPackageMigrationsUsingInstallImpl(
     } = readPackageMigrationConfig(packageName, dir);
 
     let migrations: MigrationsJson = undefined;
+    let resolvedPromptFiles: Record<string, string> | undefined;
     if (migrationsFilePath) {
       migrations = readJsonFile<MigrationsJson>(migrationsFilePath);
+      validateMigrationEntries(packageName, packageVersion, migrations);
+      resolvedPromptFiles = await readPromptFilesFromInstall(
+        packageName,
+        packageVersion,
+        migrations,
+        migrationsFilePath
+      );
     }
 
-    result = { ...migrations, packageGroup, version: packageJson.version };
+    result = {
+      ...migrations,
+      packageGroup,
+      version: packageJson.version,
+      ...(resolvedPromptFiles ? { resolvedPromptFiles } : {}),
+    };
   } catch (e) {
     const pmc = getPackageManagerCommand(detectPackageManager(dir), dir);
 
@@ -1949,8 +2001,12 @@ async function generateMigrationsJsonAndUpdatePackageJson(
       firstPartyPackages,
     });
 
-    const { migrations, packageUpdates, minVersionWithSkippedUpdates } =
-      await migrator.migrate(walkedTargetPackage, opts.targetVersion);
+    const {
+      migrations,
+      packageUpdates,
+      promptContents,
+      minVersionWithSkippedUpdates,
+    } = await migrator.migrate(walkedTargetPackage, opts.targetVersion);
 
     // The cascade collects packageJsonUpdates entries against the cascade
     // root's installed version, but inner per-package pins are only gated
@@ -1969,6 +2025,12 @@ async function generateMigrationsJsonAndUpdatePackageJson(
     const wroteNxJsonInstallation = await updateInstallationDetails(
       root,
       writableUpdates
+    );
+
+    const promptMigrationFiles = writePromptMigrationFiles(
+      root,
+      migrations,
+      promptContents ?? {}
     );
 
     if (migrations.length > 0) {
@@ -2014,6 +2076,11 @@ async function generateMigrationsJsonAndUpdatePackageJson(
         migrations.length > 0
           ? `- migrations.json has been generated.`
           : `- There are no migrations to run, so migrations.json has not been created.`,
+        ...(promptMigrationFiles.length > 0
+          ? [
+              `- ${promptMigrationFiles.length} AI migration prompt(s) have been written to ${AI_MIGRATIONS_DIR}/. You can review and tweak them before running migrations.`,
+            ]
+          : []),
       ],
     });
 

--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -2030,7 +2030,8 @@ async function generateMigrationsJsonAndUpdatePackageJson(
     const promptMigrationFiles = writePromptMigrationFiles(
       root,
       migrations,
-      promptContents ?? {}
+      promptContents ?? {},
+      packageUpdates[walkedTargetPackage].version
     );
 
     if (migrations.length > 0) {

--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -2078,7 +2078,7 @@ async function generateMigrationsJsonAndUpdatePackageJson(
           : `- There are no migrations to run, so migrations.json has not been created.`,
         ...(promptMigrationFiles.length > 0
           ? [
-              `- ${promptMigrationFiles.length} AI migration prompt(s) have been written to ${AI_MIGRATIONS_DIR}/. You can review and tweak them before running migrations.`,
+              `- ${promptMigrationFiles.length} AI migration prompt(s) have been written to ${AI_MIGRATIONS_DIR}/.`,
             ]
           : []),
       ],
@@ -2119,6 +2119,11 @@ async function generateMigrationsJsonAndUpdatePackageJson(
         ]
       : [
           `- Make sure package.json changes make sense and then run '${pmc.install}',`,
+          ...(promptMigrationFiles.length > 0
+            ? [
+                `- Review and tweak the AI migration prompts in ${AI_MIGRATIONS_DIR}/ as needed.`,
+              ]
+            : []),
           ...(migrations.length > 0
             ? [`- Run '${pmc.exec} nx migrate --run-migrations'`]
             : []),

--- a/packages/nx/src/command-line/migrate/prompt-files.ts
+++ b/packages/nx/src/command-line/migrate/prompt-files.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { dirname, isAbsolute, join, posix, relative, sep } from 'path';
 import {
   MigrationsJson,
@@ -144,32 +144,55 @@ export function writePromptMigrationFiles(
     version: string;
     prompt?: string;
   }[],
-  promptContents: Record<string, string>
+  promptContents: Record<string, string>,
+  targetVersion: string
 ): string[] {
-  const writtenPaths = new Set<string>();
+  const sourceToChosen = new Map<string, string>();
   const result: string[] = [];
 
   for (const migration of migrations) {
     if (!migration.prompt) continue;
-    const content =
-      promptContents[promptContentKey(migration.package, migration.prompt)];
+    const sourceKey = promptContentKey(migration.package, migration.prompt);
+    const content = promptContents[sourceKey];
     if (content === undefined) continue;
 
-    const relPath = joinPathFragments(
-      AI_MIGRATIONS_DIR,
-      migration.package,
-      migration.prompt
-    );
-
-    if (!writtenPaths.has(relPath)) {
-      writtenPaths.add(relPath);
-      const absPath = join(root, relPath);
-      mkdirSync(dirname(absPath), { recursive: true });
-      writeFileSync(absPath, content);
-      result.push(relPath);
+    const cached = sourceToChosen.get(sourceKey);
+    if (cached !== undefined) {
+      migration.prompt = cached;
+      continue;
     }
 
-    migration.prompt = relPath;
+    const baseName = posix.basename(migration.prompt);
+    const ext = posix.extname(baseName);
+    const stem = ext ? baseName.slice(0, -ext.length) : baseName;
+    const destDir = joinPathFragments(
+      AI_MIGRATIONS_DIR,
+      migration.package,
+      targetVersion
+    );
+
+    let chosenPath!: string;
+    for (let n = 0; ; n++) {
+      const candidate = joinPathFragments(
+        destDir,
+        n === 0 ? baseName : `${stem}-${n}${ext}`
+      );
+      const absCandidate = join(root, candidate);
+      if (!existsSync(absCandidate)) {
+        mkdirSync(dirname(absCandidate), { recursive: true });
+        writeFileSync(absCandidate, content);
+        result.push(candidate);
+        chosenPath = candidate;
+        break;
+      }
+      if (readFileSync(absCandidate, 'utf-8') === content) {
+        chosenPath = candidate;
+        break;
+      }
+    }
+
+    sourceToChosen.set(sourceKey, chosenPath);
+    migration.prompt = chosenPath;
   }
 
   return result;

--- a/packages/nx/src/command-line/migrate/prompt-files.ts
+++ b/packages/nx/src/command-line/migrate/prompt-files.ts
@@ -1,0 +1,190 @@
+import { mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { dirname, isAbsolute, join, posix, relative, sep } from 'path';
+import {
+  MigrationsJson,
+  MigrationsJsonEntry,
+} from '../../config/misc-interfaces';
+import { extractFileFromTarball } from '../../utils/fileutils';
+import { joinPathFragments } from '../../utils/path';
+
+export const AI_MIGRATIONS_DIR = joinPathFragments('tools', 'ai-migrations');
+
+export function promptContentKey(
+  packageName: string,
+  promptRelPath: string
+): string {
+  return `${packageName}::${promptRelPath}`;
+}
+
+function* iterateMigrationEntries(
+  migrations: MigrationsJson
+): Iterable<[string, MigrationsJsonEntry]> {
+  const merged = { ...migrations.schematics, ...migrations.generators };
+  yield* Object.entries(merged);
+}
+
+export function validateMigrationEntries(
+  packageName: string,
+  packageVersion: string,
+  migrations: MigrationsJson
+): void {
+  for (const [migrationName, entry] of iterateMigrationEntries(migrations)) {
+    if (!entry.implementation && !entry.factory && !entry.prompt) {
+      throw new Error(
+        `Invalid migration "${migrationName}" in package "${packageName}@${packageVersion}": migration entries must have at least one of "implementation", "factory", or "prompt".`
+      );
+    }
+  }
+}
+
+async function resolvePromptFiles(
+  packageName: string,
+  packageVersion: string,
+  migrations: MigrationsJson,
+  migrationsDir: string,
+  resolveContent: (promptRelPath: string) => string | Promise<string>
+): Promise<Record<string, string> | undefined> {
+  const resolvedPromptFiles: Record<string, string> = {};
+  for (const [migrationName, entry] of iterateMigrationEntries(migrations)) {
+    if (!entry.prompt || resolvedPromptFiles[entry.prompt] !== undefined) {
+      continue;
+    }
+    assertPromptPathWithinMigrationsDir(
+      migrationsDir,
+      entry.prompt,
+      packageName,
+      packageVersion
+    );
+    try {
+      resolvedPromptFiles[entry.prompt] = await resolveContent(entry.prompt);
+    } catch (e) {
+      throw new Error(
+        `Could not find prompt file "${entry.prompt}" for migration "${migrationName}" in package "${packageName}@${packageVersion}".`,
+        { cause: e }
+      );
+    }
+  }
+
+  return Object.keys(resolvedPromptFiles).length > 0
+    ? resolvedPromptFiles
+    : undefined;
+}
+
+function assertPromptPathWithinMigrationsDir(
+  migrationsDir: string,
+  promptRelPath: string,
+  packageName: string,
+  packageVersion: string
+): void {
+  const rel = relative(migrationsDir, join(migrationsDir, promptRelPath));
+  if (
+    isAbsolute(promptRelPath) ||
+    rel === '..' ||
+    rel.startsWith(`..${sep}`) ||
+    rel.startsWith(`..${posix.sep}`)
+  ) {
+    throw new Error(
+      `Invalid prompt path "${promptRelPath}" in package "${packageName}@${packageVersion}": prompt paths must be relative and resolve within the package's migrations directory.`
+    );
+  }
+}
+
+export function extractPromptFilesFromTarball(
+  packageName: string,
+  packageVersion: string,
+  migrations: MigrationsJson,
+  migrationsFilePath: string,
+  fullTarballPath: string,
+  destDir: string
+): Promise<Record<string, string> | undefined> {
+  const migrationsDir = dirname(migrationsFilePath);
+  return resolvePromptFiles(
+    packageName,
+    packageVersion,
+    migrations,
+    migrationsDir,
+    async (promptRelPath) => {
+      const promptInTarball = joinPathFragments(
+        'package',
+        migrationsDir,
+        promptRelPath
+      );
+      const promptDest = join(destDir, migrationsDir, promptRelPath);
+      await extractFileFromTarball(
+        fullTarballPath,
+        promptInTarball,
+        promptDest
+      );
+      return readFileSync(promptDest, 'utf-8');
+    }
+  );
+}
+
+export function readPromptFilesFromInstall(
+  packageName: string,
+  packageVersion: string,
+  migrations: MigrationsJson,
+  migrationsFilePath: string
+): Promise<Record<string, string> | undefined> {
+  const migrationsDir = dirname(migrationsFilePath);
+  return resolvePromptFiles(
+    packageName,
+    packageVersion,
+    migrations,
+    migrationsDir,
+    (promptRelPath) => readFileSync(join(migrationsDir, promptRelPath), 'utf-8')
+  );
+}
+
+export function writePromptMigrationFiles(
+  root: string,
+  migrations: {
+    package: string;
+    name: string;
+    version: string;
+    prompt?: string;
+  }[],
+  promptContents: Record<string, string>
+): string[] {
+  const writtenPaths = new Set<string>();
+  const result: string[] = [];
+
+  for (const migration of migrations) {
+    if (!migration.prompt) continue;
+    const content =
+      promptContents[promptContentKey(migration.package, migration.prompt)];
+    if (content === undefined) continue;
+
+    const namespace = packageNameToWorkspaceNamespace(migration.package);
+    const fileName = `${migration.version}-${posix.basename(migration.prompt)}`;
+    const relPath = joinPathFragments(
+      AI_MIGRATIONS_DIR,
+      ...namespace,
+      fileName
+    );
+
+    if (writtenPaths.has(relPath)) {
+      throw new Error(
+        `Conflicting AI migration prompt destination "${relPath}" for migration "${migration.name}" in package "${migration.package}". Two migrations target the same workspace path (same package + version + filename).`
+      );
+    }
+    writtenPaths.add(relPath);
+
+    const absPath = join(root, relPath);
+    mkdirSync(dirname(absPath), { recursive: true });
+    writeFileSync(absPath, content);
+
+    migration.prompt = relPath;
+    result.push(relPath);
+  }
+
+  return result;
+}
+
+function packageNameToWorkspaceNamespace(packageName: string): string[] {
+  if (packageName.startsWith('@')) {
+    const [scope, name] = packageName.slice(1).split('/');
+    return [scope, name];
+  }
+  return [packageName];
+}

--- a/packages/nx/src/command-line/migrate/prompt-files.ts
+++ b/packages/nx/src/command-line/migrate/prompt-files.ts
@@ -155,36 +155,22 @@ export function writePromptMigrationFiles(
       promptContents[promptContentKey(migration.package, migration.prompt)];
     if (content === undefined) continue;
 
-    const namespace = packageNameToWorkspaceNamespace(migration.package);
-    const fileName = `${migration.version}-${posix.basename(migration.prompt)}`;
     const relPath = joinPathFragments(
       AI_MIGRATIONS_DIR,
-      ...namespace,
-      fileName
+      migration.package,
+      migration.prompt
     );
 
-    if (writtenPaths.has(relPath)) {
-      throw new Error(
-        `Conflicting AI migration prompt destination "${relPath}" for migration "${migration.name}" in package "${migration.package}". Two migrations target the same workspace path (same package + version + filename).`
-      );
+    if (!writtenPaths.has(relPath)) {
+      writtenPaths.add(relPath);
+      const absPath = join(root, relPath);
+      mkdirSync(dirname(absPath), { recursive: true });
+      writeFileSync(absPath, content);
+      result.push(relPath);
     }
-    writtenPaths.add(relPath);
-
-    const absPath = join(root, relPath);
-    mkdirSync(dirname(absPath), { recursive: true });
-    writeFileSync(absPath, content);
 
     migration.prompt = relPath;
-    result.push(relPath);
   }
 
   return result;
-}
-
-function packageNameToWorkspaceNamespace(packageName: string): string[] {
-  if (packageName.startsWith('@')) {
-    const [scope, name] = packageName.slice(1).split('/');
-    return [scope, name];
-  }
-  return [packageName];
 }

--- a/packages/nx/src/config/misc-interfaces.ts
+++ b/packages/nx/src/config/misc-interfaces.ts
@@ -86,6 +86,7 @@ export interface MigrationsJsonEntry {
   description?: string;
   implementation?: string;
   factory?: string;
+  prompt?: string;
   requires?: Record<string, string>;
 }
 
@@ -97,7 +98,8 @@ export interface GeneratedMigrationDetails {
   version: string;
   package: string;
   description: string;
-  implementation: string;
+  implementation?: string;
+  prompt?: string;
 }
 
 export interface MigrationsJson {


### PR DESCRIPTION
## Current Behavior

Migration entries in a plugin's `migrations.json` can only declare an `implementation` or `factory` pointing at TypeScript code. To ship a Markdown prompt as the migration content, plugins currently have to write a small generator that calls `tree.write(...)` to drop the `.md` file into the workspace, which adds boilerplate and an extra layer for every prompt-based migration.

## Expected Behavior

A migration entry can declare a `prompt` field — the relative path to a Markdown file shipped with the plugin (resolved from the directory of `migrations.json`) — as an alternative or complement to `implementation`/`factory`.

When `nx migrate` collects migrations:

- The referenced `.md` file is extracted from the package and written to the workspace under `tools/ai-migrations/<package>/<prompt-relative-path>` (e.g., `tools/ai-migrations/@nx/expo/src/migrations/update-22-2-0/files/ai-instructions-for-expo-54.md`), preserving the prompt's location within the package.
- The entry's `prompt` field is rewritten to that workspace-relative path so users can review and edit the prompt before running migrations.
- Hybrid entries (`prompt` together with `implementation` or `factory`) are preserved as-is on the generated entry.
- Each entry must declare at least one of `implementation`, `factory`, or `prompt`; missing prompt files error out at collection time.
- The post-migrate "Next steps" output reminds the user to review and tweak the generated prompts before running migrations.

## Implementation Details

- New `prompt-files.ts` module under `packages/nx/src/command-line/migrate/` contains the new validation, prompt extraction (registry and install paths), and workspace-write logic.
- `MigrationsJsonEntry` gains an optional `prompt` field. `GeneratedMigrationDetails` gains an optional `prompt` field and `implementation` becomes optional to allow prompt-only entries.
- `Migrator.migrate()` returns a `promptContents` map alongside `migrations`, keyed by `<package>::<promptRelPath>`. The workspace-write step looks up content from that map and rewrites each entry's `prompt` to its workspace-relative path.