### PR TITLE
fix(testing): multi-version support compliance for @nx/playwright

### DIFF
--- a/packages/angular/src/executors/utilities/angular-version-utils.ts
+++ b/packages/angular/src/executors/utilities/angular-version-utils.ts
@@ -1,4 +1,4 @@
-import { readModulePackageJson } from 'nx/src/utils/package-json';
+import { getInstalledPackageVersion } from '@nx/devkit/internal';
 import { major } from 'semver';
 
 export type VersionInfo = { major: number; version: string };
@@ -10,13 +10,6 @@ export function getInstalledAngularVersionInfo(): VersionInfo | null {
 export function getInstalledPackageVersionInfo(
   pkgName: string
 ): VersionInfo | null {
-  try {
-    const {
-      packageJson: { version },
-    } = readModulePackageJson(pkgName);
-
-    return { major: major(version), version };
-  } catch {
-    return null;
-  }
+  const version = getInstalledPackageVersion(pkgName);
+  return version ? { major: major(version), version } : null;
 }

--- a/packages/angular/src/generators/utils/version-utils.ts
+++ b/packages/angular/src/generators/utils/version-utils.ts
@@ -1,5 +1,6 @@
 import { getDependencyVersionFromPackageJson, type Tree } from '@nx/devkit';
-import { clean, coerce, major } from 'semver';
+import { getDeclaredPackageVersion } from '@nx/devkit/internal';
+import { coerce, major } from 'semver';
 import {
   backwardCompatibleVersions,
   type PackageCompatVersions,
@@ -20,22 +21,7 @@ export function getInstalledAngularDevkitVersion(tree: Tree): string | null {
 }
 
 export function getInstalledAngularVersion(tree: Tree): string {
-  const installedAngularVersion = getDependencyVersionFromPackageJson(
-    tree,
-    '@angular/core'
-  );
-
-  if (
-    !installedAngularVersion ||
-    installedAngularVersion === 'latest' ||
-    installedAngularVersion === 'next'
-  ) {
-    return clean(angularVersion) ?? coerce(angularVersion).version;
-  }
-
-  return (
-    clean(installedAngularVersion) ?? coerce(installedAngularVersion).version
-  );
+  return getDeclaredPackageVersion(tree, '@angular/core', angularVersion)!;
 }
 
 export function getInstalledAngularMajorVersion(tree: Tree): number {

--- a/packages/angular/src/utils/all-generators-enforce-floor.spec.ts
+++ b/packages/angular/src/utils/all-generators-enforce-floor.spec.ts
@@ -1,35 +1,10 @@
-import { updateJson } from '@nx/devkit';
-import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
-import { readFileSync } from 'node:fs';
+import { assertGeneratorsEnforceVersionFloor } from '@nx/devkit/internal-testing-utils';
 import { join } from 'node:path';
 
-const generatorsJson = JSON.parse(
-  readFileSync(join(__dirname, '..', '..', 'generators.json'), 'utf-8')
-);
-
-const generatorEntries = Object.entries<{ factory: string }>(
-  generatorsJson.generators
-);
-
-describe('all generators enforce supported Angular version floor', () => {
-  it.each(generatorEntries)(
-    '`%s` throws on sub-floor @angular/core',
-    async (_name, def) => {
-      const factoryRelative = def.factory.replace(/^\.\//, '');
-      const factoryModule = require(
-        join(__dirname, '..', '..', factoryRelative)
-      );
-      const factory = factoryModule.default ?? factoryModule;
-
-      const tree = createTreeWithEmptyWorkspace();
-      updateJson(tree, 'package.json', (json) => ({
-        ...json,
-        dependencies: { '@angular/core': '~18.2.0' },
-      }));
-
-      await expect(
-        Promise.resolve().then(() => factory(tree, {}))
-      ).rejects.toThrow(/Unsupported version of `@angular\/core` detected/);
-    }
-  );
+describe('@nx/angular generators enforce supported version floor', () => {
+  assertGeneratorsEnforceVersionFloor({
+    packageRoot: join(__dirname, '..', '..'),
+    packageName: '@angular/core',
+    subFloorVersion: '~18.2.0',
+  });
 });

--- a/packages/angular/src/utils/assert-supported-angular-version.ts
+++ b/packages/angular/src/utils/assert-supported-angular-version.ts
@@ -1,22 +1,13 @@
-import { getDependencyVersionFromPackageJson, type Tree } from '@nx/devkit';
-import { throwForUnsupportedVersion } from '@nx/devkit/internal';
-import { clean, coerce, major } from 'semver';
+import { type Tree } from '@nx/devkit';
+import { assertSupportedPackageVersion } from '@nx/devkit/internal';
 import { supportedVersions } from './backward-compatible-versions';
 
 const minSupportedAngularMajor = Math.min(...supportedVersions);
 
 export function assertSupportedAngularVersion(tree: Tree): void {
-  const detected = getDependencyVersionFromPackageJson(tree, '@angular/core');
-  if (!detected || detected === 'latest' || detected === 'next') {
-    return;
-  }
-
-  const cleaned = clean(detected) ?? coerce(detected)?.version ?? null;
-  if (cleaned && major(cleaned) < minSupportedAngularMajor) {
-    throwForUnsupportedVersion(
-      '@angular/core',
-      detected,
-      `${minSupportedAngularMajor}.0.0`
-    );
-  }
+  assertSupportedPackageVersion(
+    tree,
+    '@angular/core',
+    `${minSupportedAngularMajor}.0.0`
+  );
 }

--- a/packages/devkit/internal-testing-utils.ts
+++ b/packages/devkit/internal-testing-utils.ts
@@ -1,4 +1,5 @@
 /* eslint-disable @typescript-eslint/no-restricted-imports */
+export * from 'nx/src/internal-testing-utils/assert-generators-enforce-version-floor';
 export * from 'nx/src/internal-testing-utils/assert-valid-migrations';
 export * from 'nx/src/internal-testing-utils/run-migration-against-this-workspace';
 export * from 'nx/src/internal-testing-utils/with-environment';

--- a/packages/devkit/internal.ts
+++ b/packages/devkit/internal.ts
@@ -42,7 +42,11 @@ export {
 
 // Utils
 export { addPlugin } from './src/utils/add-plugin';
-export { throwForUnsupportedVersion } from './src/utils/version-floor';
+export {
+  getDeclaredPackageVersion,
+  getInstalledPackageVersion,
+} from './src/utils/installed-version';
+export { assertSupportedPackageVersion } from './src/utils/version-floor';
 export {
   createAsyncIterable,
   combineAsyncIterables,

--- a/packages/devkit/src/utils/installed-version.spec.ts
+++ b/packages/devkit/src/utils/installed-version.spec.ts
@@ -1,0 +1,80 @@
+import { updateJson } from 'nx/src/devkit-exports';
+import { createTreeWithEmptyWorkspace } from '../../testing';
+import {
+  getDeclaredPackageVersion,
+  getInstalledPackageVersion,
+} from './installed-version';
+
+describe('getDeclaredPackageVersion', () => {
+  it('returns the cleaned version for a declared range', () => {
+    const tree = createTreeWithEmptyWorkspace();
+    updateJson(tree, 'package.json', (json) => ({
+      ...json,
+      dependencies: { 'some-pkg': '^1.5.2' },
+    }));
+
+    expect(getDeclaredPackageVersion(tree, 'some-pkg')).toBe('1.5.2');
+  });
+
+  it('returns null when the package is not declared and no fallback is provided', () => {
+    const tree = createTreeWithEmptyWorkspace();
+    expect(getDeclaredPackageVersion(tree, 'some-pkg')).toBeNull();
+  });
+
+  it('falls back to the cleaned `latestKnownVersion` when the package is not declared', () => {
+    const tree = createTreeWithEmptyWorkspace();
+    expect(getDeclaredPackageVersion(tree, 'some-pkg', '^2.3.4')).toBe('2.3.4');
+  });
+
+  it('resolves `latest` to the cleaned `latestKnownVersion`', () => {
+    const tree = createTreeWithEmptyWorkspace();
+    updateJson(tree, 'package.json', (json) => ({
+      ...json,
+      dependencies: { 'some-pkg': 'latest' },
+    }));
+
+    expect(getDeclaredPackageVersion(tree, 'some-pkg', '^2.3.4')).toBe('2.3.4');
+  });
+
+  it('resolves `next` to the cleaned `latestKnownVersion`', () => {
+    const tree = createTreeWithEmptyWorkspace();
+    updateJson(tree, 'package.json', (json) => ({
+      ...json,
+      dependencies: { 'some-pkg': 'next' },
+    }));
+
+    expect(getDeclaredPackageVersion(tree, 'some-pkg', '^2.3.4')).toBe('2.3.4');
+  });
+
+  it('returns null for `latest` when no `latestKnownVersion` is provided', () => {
+    const tree = createTreeWithEmptyWorkspace();
+    updateJson(tree, 'package.json', (json) => ({
+      ...json,
+      dependencies: { 'some-pkg': 'latest' },
+    }));
+
+    expect(getDeclaredPackageVersion(tree, 'some-pkg')).toBeNull();
+  });
+
+  it('returns null when the declared range cannot be normalized', () => {
+    const tree = createTreeWithEmptyWorkspace();
+    updateJson(tree, 'package.json', (json) => ({
+      ...json,
+      dependencies: { 'some-pkg': 'workspace:*' },
+    }));
+
+    expect(getDeclaredPackageVersion(tree, 'some-pkg')).toBeNull();
+  });
+});
+
+describe('getInstalledPackageVersion', () => {
+  it('returns null for an unresolvable package', () => {
+    expect(
+      getInstalledPackageVersion('some-pkg-that-cannot-possibly-exist-xyz')
+    ).toBeNull();
+  });
+
+  it('returns the concrete installed version for a resolvable package', () => {
+    expect(getInstalledPackageVersion('semver')).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});

--- a/packages/devkit/src/utils/installed-version.ts
+++ b/packages/devkit/src/utils/installed-version.ts
@@ -1,0 +1,61 @@
+import { readModulePackageJson } from 'nx/src/devkit-internals';
+import type { Tree } from 'nx/src/devkit-exports';
+import { clean, coerce } from 'semver';
+import { getDependencyVersionFromPackageJson } from './package-json';
+
+/**
+ * Returns the concrete version of a package as resolved by Node module
+ * resolution from the workspace. Reads the installed package's own
+ * `package.json` — not the workspace's declared range.
+ *
+ * Use this from executor / runtime contexts where node_modules is present.
+ * Generator-time code should use `getDeclaredPackageVersion` instead.
+ *
+ * Returns `null` when the package is not resolvable.
+ */
+export function getInstalledPackageVersion(packageName: string): string | null {
+  try {
+    const { packageJson } = readModulePackageJson(packageName);
+    return packageJson.version ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Returns the declared version of a package as read from the workspace's
+ * `package.json`, normalized to a plain semver string (range markers
+ * stripped) suitable for arithmetic comparisons (e.g. `lt(v, '1.37.0')`).
+ *
+ * When the package is missing or declared as `latest`/`next`, falls back to
+ * the cleaned `latestKnownVersion` if provided; otherwise returns `null`.
+ *
+ * Use this from generator-time contexts where node_modules is not assumed
+ * to be present. Executor / runtime code should use
+ * `getInstalledPackageVersion` instead.
+ */
+export function getDeclaredPackageVersion(
+  tree: Tree,
+  packageName: string,
+  latestKnownVersion?: string
+): string | null {
+  const declared = getDependencyVersionFromPackageJson(tree, packageName);
+  if (declared && !isNonSemverDistTag(declared)) {
+    const normalized = normalizeSemver(declared);
+    if (normalized) return normalized;
+  }
+  return latestKnownVersion ? normalizeSemver(latestKnownVersion) : null;
+}
+
+export const NON_SEMVER_DIST_TAGS = ['latest', 'next'] as const;
+export type NonSemverDistTag = (typeof NON_SEMVER_DIST_TAGS)[number];
+
+export function isNonSemverDistTag(
+  version: string
+): version is NonSemverDistTag {
+  return (NON_SEMVER_DIST_TAGS as readonly string[]).includes(version);
+}
+
+export function normalizeSemver(version: string): string | null {
+  return clean(version) ?? coerce(version)?.version ?? null;
+}

--- a/packages/devkit/src/utils/version-floor.spec.ts
+++ b/packages/devkit/src/utils/version-floor.spec.ts
@@ -1,4 +1,9 @@
-import { throwForUnsupportedVersion } from './version-floor';
+import { updateJson } from 'nx/src/devkit-exports';
+import { createTreeWithEmptyWorkspace } from '../../testing';
+import {
+  assertSupportedPackageVersion,
+  throwForUnsupportedVersion,
+} from './version-floor';
 
 describe('throwForUnsupportedVersion', () => {
   it('throws an error naming the package, installed version, and floor', () => {
@@ -13,16 +18,73 @@ describe('throwForUnsupportedVersion', () => {
       Update \`@angular/core\` to 19.0.0 or higher."
     `);
   });
+});
 
-  it('formats messages for unscoped packages too', () => {
-    expect(() => throwForUnsupportedVersion('vite', '5.4.0', '6.0.0'))
-      .toThrowErrorMatchingInlineSnapshot(`
-      "Unsupported version of \`vite\` detected.
+describe('assertSupportedPackageVersion', () => {
+  it('throws when the declared range is below the supported floor', () => {
+    const tree = createTreeWithEmptyWorkspace();
+    updateJson(tree, 'package.json', (json) => ({
+      ...json,
+      dependencies: { 'some-pkg': '~1.5.0' },
+    }));
 
-        Installed: 5.4.0
-        Supported: >= 6.0.0
+    expect(() =>
+      assertSupportedPackageVersion(tree, 'some-pkg', '2.0.0')
+    ).toThrow(/Unsupported version of `some-pkg` detected/);
+  });
 
-      Update \`vite\` to 6.0.0 or higher."
-    `);
+  it('preserves the declared range in the thrown message (not the cleaned form)', () => {
+    const tree = createTreeWithEmptyWorkspace();
+    updateJson(tree, 'package.json', (json) => ({
+      ...json,
+      dependencies: { 'some-pkg': '~1.5.0' },
+    }));
+
+    expect(() =>
+      assertSupportedPackageVersion(tree, 'some-pkg', '2.0.0')
+    ).toThrow(/Installed: ~1\.5\.0/);
+  });
+
+  it('does not throw when the package is not declared (fresh-install path)', () => {
+    const tree = createTreeWithEmptyWorkspace();
+    expect(() =>
+      assertSupportedPackageVersion(tree, 'some-pkg', '2.0.0')
+    ).not.toThrow();
+  });
+
+  it('does not throw when declared as `latest`', () => {
+    const tree = createTreeWithEmptyWorkspace();
+    updateJson(tree, 'package.json', (json) => ({
+      ...json,
+      dependencies: { 'some-pkg': 'latest' },
+    }));
+
+    expect(() =>
+      assertSupportedPackageVersion(tree, 'some-pkg', '2.0.0')
+    ).not.toThrow();
+  });
+
+  it('does not throw when declared as `next`', () => {
+    const tree = createTreeWithEmptyWorkspace();
+    updateJson(tree, 'package.json', (json) => ({
+      ...json,
+      dependencies: { 'some-pkg': 'next' },
+    }));
+
+    expect(() =>
+      assertSupportedPackageVersion(tree, 'some-pkg', '2.0.0')
+    ).not.toThrow();
+  });
+
+  it('does not throw when declared at or above the supported floor', () => {
+    const tree = createTreeWithEmptyWorkspace();
+    updateJson(tree, 'package.json', (json) => ({
+      ...json,
+      dependencies: { 'some-pkg': '^2.5.0' },
+    }));
+
+    expect(() =>
+      assertSupportedPackageVersion(tree, 'some-pkg', '2.0.0')
+    ).not.toThrow();
   });
 });

--- a/packages/devkit/src/utils/version-floor.ts
+++ b/packages/devkit/src/utils/version-floor.ts
@@ -1,12 +1,17 @@
+import type { Tree } from 'nx/src/devkit-exports';
+import { lt } from 'semver';
+import { isNonSemverDistTag, normalizeSemver } from './installed-version';
+import { getDependencyVersionFromPackageJson } from './package-json';
+
 /**
- * Throws a standardized error when a third-party package is installed at a
- * version below a plugin's supported floor.
+ * Throws a standardized error when a package is installed at a version below
+ * a plugin's supported floor.
  *
- * Use this at every site where a plugin determines the installed version of a
- * supported third-party package is below its declared floor, so the message is
+ * Use this at every site where a plugin determines the installed version of
+ * a supported package is below its declared floor, so the message is
  * consistent across plugins.
  *
- * @param packageName Name of the third-party package (e.g. `@angular/core`).
+ * @param packageName Name of the package (e.g. `@angular/core`).
  * @param installedVersion Version detected in the workspace (e.g. `18.2.0`).
  * @param floor Lowest version the plugin supports (e.g. `19.0.0`).
  */
@@ -21,4 +26,29 @@ export function throwForUnsupportedVersion(
       `  Supported: >= ${floor}\n\n` +
       `Update \`${packageName}\` to ${floor} or higher.`
   );
+}
+
+/**
+ * Asserts that a package detected in the workspace is at or above the
+ * plugin's supported floor. No-op when the package is not detected
+ * (fresh-install path) or when declared as `latest`/`next`. Throws via
+ * `throwForUnsupportedVersion` (with the original declared range for
+ * clarity) when below floor.
+ *
+ * Use from generator entry points to fail fast on unsupported workspaces
+ * before writing any incompatible config.
+ */
+export function assertSupportedPackageVersion(
+  tree: Tree,
+  packageName: string,
+  minSupportedVersion: string
+): void {
+  const declared = getDependencyVersionFromPackageJson(tree, packageName);
+  if (!declared || isNonSemverDistTag(declared)) {
+    return;
+  }
+  const cleaned = normalizeSemver(declared);
+  if (cleaned && lt(cleaned, minSupportedVersion)) {
+    throwForUnsupportedVersion(packageName, declared, minSupportedVersion);
+  }
 }

--- a/packages/nx/src/internal-testing-utils/assert-generators-enforce-version-floor.ts
+++ b/packages/nx/src/internal-testing-utils/assert-generators-enforce-version-floor.ts
@@ -1,0 +1,47 @@
+import { join } from 'node:path';
+import { readFileSync } from 'node:fs';
+import { createTreeWithEmptyWorkspace } from '../generators/testing-utils/create-tree-with-empty-workspace';
+import { updateJson } from '../generators/utils/json';
+
+interface GeneratorsJson {
+  generators?: Record<string, { factory: string }>;
+  schematics?: Record<string, { factory: string }>;
+}
+
+export function assertGeneratorsEnforceVersionFloor(options: {
+  packageRoot: string;
+  packageName: string;
+  subFloorVersion: string;
+}): void {
+  const { packageRoot, packageName, subFloorVersion } = options;
+  const generatorsJson: GeneratorsJson = JSON.parse(
+    readFileSync(join(packageRoot, 'generators.json'), 'utf-8')
+  );
+  const entries = Object.entries(generatorsJson.generators ?? {});
+
+  it('has generators registered in generators.json', () => {
+    expect(entries.length).toBeGreaterThan(0);
+  });
+
+  for (const [name, def] of entries) {
+    it(`\`${name}\` throws on sub-floor ${packageName}`, async () => {
+      const [factoryRelative, exportName] = def.factory
+        .replace(/^\.\//, '')
+        .split('#');
+      const factoryModule = require(join(packageRoot, factoryRelative));
+      const factory = exportName
+        ? factoryModule[exportName]
+        : (factoryModule.default ?? factoryModule);
+
+      const tree = createTreeWithEmptyWorkspace();
+      updateJson(tree, 'package.json', (json) => ({
+        ...json,
+        dependencies: { [packageName]: subFloorVersion },
+      }));
+
+      await expect(
+        Promise.resolve().then(() => factory(tree, {}))
+      ).rejects.toThrow(`Unsupported version of \`${packageName}\` detected`);
+    });
+  }
+}

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -38,7 +38,8 @@
     "@nx/eslint": "workspace:*",
     "@nx/js": "workspace:*",
     "tslib": "catalog:typescript",
-    "minimatch": "catalog:"
+    "minimatch": "catalog:",
+    "semver": "catalog:"
   },
   "devDependencies": {
     "nx": "workspace:*"

--- a/packages/playwright/src/executors/merge-reports/merge-reports.impl.ts
+++ b/packages/playwright/src/executors/merge-reports/merge-reports.impl.ts
@@ -1,4 +1,7 @@
-import { loadConfigFile } from '@nx/devkit/internal';
+import {
+  getInstalledPackageVersion,
+  loadConfigFile,
+} from '@nx/devkit/internal';
 import {
   getPackageManagerCommand,
   output,
@@ -8,13 +11,22 @@ import type { PlaywrightTestConfig } from '@playwright/test';
 import { spawnSync } from 'node:child_process';
 import { existsSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
+import { lt } from 'semver';
 import { getReporterOutputs } from '../../utils/reporters';
+import { minPlaywrightVersionForBlobReports } from '../../utils/versions';
 import type { Schema } from './schema';
 
 export async function mergeReportsExecutor(
   options: Schema,
   context: ExecutorContext
 ) {
+  const installed = getInstalledPackageVersion('@playwright/test');
+  if (installed && lt(installed, minPlaywrightVersionForBlobReports)) {
+    throw new Error(
+      `The "@nx/playwright:merge-reports" executor requires "@playwright/test" version ${minPlaywrightVersionForBlobReports} or greater (the version that introduced the "blob" reporter and the "merge-reports" CLI). You are currently using version ${installed}.`
+    );
+  }
+
   const { config, expectedSuites } = options;
 
   const projectRoot = join(

--- a/packages/playwright/src/generators/configuration/configuration.ts
+++ b/packages/playwright/src/generators/configuration/configuration.ts
@@ -33,6 +33,7 @@ import { execSync } from 'child_process';
 import { PackageJson } from 'nx/src/utils/package-json';
 import * as path from 'path';
 import { addLinterToPlaywrightProject } from '../../utils/add-linter';
+import { assertSupportedPlaywrightVersion } from '../../utils/assert-supported-playwright-version';
 import { nxVersion } from '../../utils/versions';
 import { initGenerator } from '../init/init';
 import type {
@@ -52,6 +53,8 @@ export async function configurationGeneratorInternal(
   tree: Tree,
   rawOptions: ConfigurationGeneratorSchema
 ) {
+  assertSupportedPlaywrightVersion(tree);
+
   const options = await normalizeOptions(tree, rawOptions);
 
   const tasks: GeneratorCallback[] = [];

--- a/packages/playwright/src/generators/convert-to-inferred/convert-to-inferred.ts
+++ b/packages/playwright/src/generators/convert-to-inferred/convert-to-inferred.ts
@@ -10,6 +10,7 @@ import {
   type Tree,
 } from '@nx/devkit';
 import { createNodesV2, PlaywrightPluginOptions } from '../../plugins/plugin';
+import { assertSupportedPlaywrightVersion } from '../../utils/assert-supported-playwright-version';
 
 interface Schema {
   project?: string;
@@ -18,6 +19,8 @@ interface Schema {
 }
 
 export async function convertToInferred(tree: Tree, options: Schema) {
+  assertSupportedPlaywrightVersion(tree);
+
   const projectGraph = await createProjectGraphAsync();
   const migratedProjects =
     await migrateProjectExecutorsToPlugin<PlaywrightPluginOptions>(

--- a/packages/playwright/src/generators/init/init.ts
+++ b/packages/playwright/src/generators/init/init.ts
@@ -9,6 +9,7 @@ import {
   Tree,
 } from '@nx/devkit';
 import { createNodesV2 } from '../../plugins/plugin';
+import { assertSupportedPlaywrightVersion } from '../../utils/assert-supported-playwright-version';
 import { nxVersion, playwrightVersion } from '../../utils/versions';
 import { InitGeneratorSchema } from './schema';
 
@@ -20,6 +21,8 @@ export async function initGeneratorInternal(
   tree: Tree,
   options: InitGeneratorSchema
 ) {
+  assertSupportedPlaywrightVersion(tree);
+
   const tasks: GeneratorCallback[] = [];
 
   const nxJson = readNxJson(tree);
@@ -39,7 +42,7 @@ export async function initGeneratorInternal(
           '@playwright/test': playwrightVersion,
         },
         undefined,
-        options.keepExistingVersions
+        options.keepExistingVersions ?? true
       )
     );
   }

--- a/packages/playwright/src/generators/init/schema.json
+++ b/packages/playwright/src/generators/init/schema.json
@@ -21,7 +21,7 @@
       "type": "boolean",
       "x-priority": "internal",
       "description": "Keep existing dependencies versions",
-      "default": false
+      "default": true
     },
     "updatePackageScripts": {
       "type": "boolean",

--- a/packages/playwright/src/utils/add-linter.ts
+++ b/packages/playwright/src/utils/add-linter.ts
@@ -69,7 +69,9 @@ export async function addLinterToPlaywrightProject(
       ? addDependenciesToPackageJson(
           tree,
           {},
-          { 'eslint-plugin-playwright': eslintPluginPlaywrightVersion }
+          { 'eslint-plugin-playwright': eslintPluginPlaywrightVersion },
+          undefined,
+          true
         )
       : () => {}
   );

--- a/packages/playwright/src/utils/all-generators-enforce-floor.spec.ts
+++ b/packages/playwright/src/utils/all-generators-enforce-floor.spec.ts
@@ -1,0 +1,10 @@
+import { assertGeneratorsEnforceVersionFloor } from '@nx/devkit/internal-testing-utils';
+import { join } from 'node:path';
+
+describe('@nx/playwright generators enforce supported version floor', () => {
+  assertGeneratorsEnforceVersionFloor({
+    packageRoot: join(__dirname, '..', '..'),
+    packageName: '@playwright/test',
+    subFloorVersion: '~1.35.0',
+  });
+});

--- a/packages/playwright/src/utils/assert-supported-playwright-version.ts
+++ b/packages/playwright/src/utils/assert-supported-playwright-version.ts
@@ -1,0 +1,11 @@
+import { type Tree } from '@nx/devkit';
+import { assertSupportedPackageVersion } from '@nx/devkit/internal';
+import { minSupportedPlaywrightVersion } from './versions';
+
+export function assertSupportedPlaywrightVersion(tree: Tree): void {
+  assertSupportedPackageVersion(
+    tree,
+    '@playwright/test',
+    minSupportedPlaywrightVersion
+  );
+}

--- a/packages/playwright/src/utils/preset.ts
+++ b/packages/playwright/src/utils/preset.ts
@@ -1,8 +1,11 @@
 import { workspaceRoot } from '@nx/devkit';
+import { getInstalledPackageVersion } from '@nx/devkit/internal';
 import { isUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
 import { defineConfig } from '@playwright/test';
 import { lstatSync } from 'node:fs';
 import { dirname, join, relative } from 'node:path';
+import { lt } from 'semver';
+import { minPlaywrightVersionForBlobReports } from './versions';
 
 export interface NxPlaywrightOptions {
   /**
@@ -72,6 +75,14 @@ export function nxE2EPreset(
       open: options?.openHtmlReport ?? 'on-failure',
     },
   ]);
+  if (options?.generateBlobReports === true) {
+    const installed = getInstalledPackageVersion('@playwright/test');
+    if (installed && lt(installed, minPlaywrightVersionForBlobReports)) {
+      throw new Error(
+        `The "blob" reporter requires "@playwright/test" version ${minPlaywrightVersionForBlobReports} or greater. You are currently using version ${installed}. Either upgrade "@playwright/test" or set "generateBlobReports" to false.`
+      );
+    }
+  }
   const shouldGenerateBlobReports =
     options?.generateBlobReports ?? !!process.env['CI'];
   if (shouldGenerateBlobReports) {

--- a/packages/playwright/src/utils/versions.ts
+++ b/packages/playwright/src/utils/versions.ts
@@ -1,3 +1,5 @@
 export const nxVersion = require('../../package.json').version;
-export const playwrightVersion = '^1.36.0';
+export const minSupportedPlaywrightVersion = '1.36.0';
+export const minPlaywrightVersionForBlobReports = '1.37.0';
+export const playwrightVersion = '^1.37.0';
 export const eslintPluginPlaywrightVersion = '^1.6.2';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3382,6 +3382,9 @@ importers:
       minimatch:
         specifier: 'catalog:'
         version: 10.2.5
+      semver:
+        specifier: 'catalog:'
+        version: 7.7.4
       tslib:
         specifier: catalog:typescript
         version: 2.8.1


### PR DESCRIPTION
## Current Behavior

- `@nx/playwright` generators silently fall through to the latest install constants when a workspace has `@playwright/test` detected below the supported floor (`1.36.0`). Generators write incompatible config rather than failing fast.
- The init generator overwrites already-installed `@playwright/test` versions on re-runs. The configuration generator's linter helper overwrites already-installed `eslint-plugin-playwright` pins.
- `nxE2EPreset` auto-injects the `blob` reporter in CI regardless of installed Playwright version — workspaces on 1.36.x silently pick up a reporter that Playwright doesn't recognize and fail at test run time with an unhelpful error.
- The `@nx/playwright:merge-reports` executor invokes a Playwright CLI subcommand that doesn't exist on 1.36.x and surfaces a confusing CLI error rather than a clear remediation message.
- Fresh installs land on `^1.36.0`, a version that pre-dates the `blob` reporter and `merge-reports` CLI, so users adopting the plugin don't get the full feature surface out of the box.

## Expected Behavior

- Every generator entry point asserts the supported floor up front via a shared `assertSupportedPackageVersion`, throwing a standardized error naming the package, installed version, and supported floor.
- Generators preserve user pins for both `@nx/playwright` and `@playwright/test`. The configuration generator's linter helper preserves a user-pinned `eslint-plugin-playwright`.
- `nxE2EPreset` skips auto-injecting the `blob` reporter on Playwright < 1.37.0 by default; an explicit `generateBlobReports: true` on an unsupported version throws with a clear remediation message.
- The `merge-reports` executor fails fast with a clear "requires Playwright >= 1.37.0" message when invoked against a sub-1.37 workspace.
- Fresh installs land on `^1.37.0` so users get the full feature set (blob reporter + merge-reports CLI). The peer dep stays at the existing `^1.36.0` — no regression for existing workspaces.

## Implementation Details

Bundled into this PR:

- **`@nx/devkit/internal` shared helpers** (consumed by all subsequent plugin compliance PRs):
  - `getInstalledPackageVersion(packageName)` — FS-based, for executor/runtime contexts.
  - `getDeclaredPackageVersion(tree, packageName, latestKnownVersion?)` — tree-based, normalized, with `latest`/`next` fallback support.
  - `assertSupportedPackageVersion(tree, packageName, minSupportedVersion)` — the floor-enforcement guard.
- **`@nx/devkit/internal-testing-utils.assertGeneratorsEnforceVersionFloor`** — parameterized spec helper asserting every generator in a plugin's `generators.json` throws on sub-floor detection.
- **`@nx/angular` adoption** — `assertSupportedAngularVersion`, `getInstalledAngularVersion`, the executor-side `getInstalledAngularVersionInfo`, and the angular all-generators floor spec all delegate to the shared helpers. No behavioral change.
- **`@nx/playwright`** — adopts the helpers, adds the feature-vs-version gates for blob/merge-reports, fixes user-pin preservation.