### PR TITLE
fix(core): warn before installing unknown npm packages as preset

### DIFF
--- a/packages/create-nx-workspace/src/create-workspace.ts
+++ b/packages/create-nx-workspace/src/create-workspace.ts
@@ -35,6 +35,8 @@ import {
   getPackageManagerCommand,
 } from './utils/package-manager';
 import { isAiAgent, logProgress } from './utils/ai/ai-output';
+import { confirmThirdPartyPreset } from './internal-utils/prompts';
+import { CnwError } from './utils/error-utils';
 
 // State for SIGINT handler - only set after workspace is fully installed
 let workspaceDirectory: string | undefined;
@@ -162,6 +164,24 @@ export async function createWorkspace<T extends CreateWorkspaceOptions>(
         'Preset is required when not using a template. Please provide --preset or --template.'
       );
     }
+
+    // If the preset is a third-party preset, warn the user before installing
+    // the npm package. A preset name like "core" silently installs an
+    // unrelated npm package; this confirmation makes that explicit.
+    const thirdPartyPackageName = getPackageNameFromThirdPartyPreset(preset);
+    if (thirdPartyPackageName) {
+      const confirmed = await confirmThirdPartyPreset(
+        thirdPartyPackageName,
+        options.interactive
+      );
+      if (!confirmed) {
+        throw new CnwError(
+          'INVALID_PRESET',
+          `Aborted: not installing third-party preset '${thirdPartyPackageName}'.`
+        );
+      }
+    }
+
     const tmpDir = await createSandbox(packageManager);
     const workspaceGlobs = getWorkspaceGlobsFromPreset(preset);
 
@@ -181,7 +201,6 @@ export async function createWorkspace<T extends CreateWorkspaceOptions>(
     // If the preset is a third-party preset, we need to call createPreset to install it
     // For first-party presets, it will be created by createEmptyWorkspace instead.
     // In createEmptyWorkspace, it will call `nx new` -> `@nx/workspace newGenerator` -> `@nx/workspace generatePreset`.
-    const thirdPartyPackageName = getPackageNameFromThirdPartyPreset(preset);
     if (thirdPartyPackageName) {
       await createPreset(
         thirdPartyPackageName,

--- a/packages/create-nx-workspace/src/internal-utils/prompts.spec.ts
+++ b/packages/create-nx-workspace/src/internal-utils/prompts.spec.ts
@@ -1,4 +1,4 @@
-import { determineTemplate } from './prompts';
+import { confirmThirdPartyPreset, determineTemplate } from './prompts';
 
 jest.mock('../utils/ci/is-ci', () => ({
   isCI: jest.fn(() => false),
@@ -6,6 +6,16 @@ jest.mock('../utils/ci/is-ci', () => ({
 
 jest.mock('../utils/git/git', () => ({
   isGitAvailable: jest.fn(() => true),
+}));
+
+jest.mock('../utils/ai/ai-output', () => ({
+  isAiAgent: jest.fn(() => false),
+  detectAiAgentName: jest.fn(() => null),
+}));
+
+jest.mock('enquirer', () => ({
+  __esModule: true,
+  default: { prompt: jest.fn() },
 }));
 
 describe('determineTemplate', () => {
@@ -52,5 +62,52 @@ describe('determineTemplate', () => {
       });
       expect(result).toBe('nrwl/empty-template');
     });
+  });
+});
+
+describe('confirmThirdPartyPreset', () => {
+  const enquirer = require('enquirer').default;
+  const { isCI } = require('../utils/ci/is-ci');
+  const { isAiAgent } = require('../utils/ai/ai-output');
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (isCI as jest.Mock).mockReturnValue(false);
+    (isAiAgent as jest.Mock).mockReturnValue(false);
+  });
+
+  it('prompts and returns true when user confirms', async () => {
+    (enquirer.prompt as jest.Mock).mockResolvedValueOnce({ confirm: 'Yes' });
+    await expect(confirmThirdPartyPreset('core', true)).resolves.toBe(true);
+    expect(enquirer.prompt).toHaveBeenCalledTimes(1);
+  });
+
+  it('prompts and returns false when user declines', async () => {
+    (enquirer.prompt as jest.Mock).mockResolvedValueOnce({ confirm: 'No' });
+    await expect(confirmThirdPartyPreset('core', true)).resolves.toBe(false);
+    expect(enquirer.prompt).toHaveBeenCalledTimes(1);
+  });
+
+  it('skips prompt and returns true in non-interactive mode', async () => {
+    await expect(
+      confirmThirdPartyPreset('@my-org/nx-plugin', false)
+    ).resolves.toBe(true);
+    expect(enquirer.prompt).not.toHaveBeenCalled();
+  });
+
+  it('skips prompt and returns true in CI', async () => {
+    (isCI as jest.Mock).mockReturnValue(true);
+    await expect(
+      confirmThirdPartyPreset('@my-org/nx-plugin', true)
+    ).resolves.toBe(true);
+    expect(enquirer.prompt).not.toHaveBeenCalled();
+  });
+
+  it('skips prompt and returns true when running as an AI agent', async () => {
+    (isAiAgent as jest.Mock).mockReturnValue(true);
+    await expect(
+      confirmThirdPartyPreset('@my-org/nx-plugin', true)
+    ).resolves.toBe(true);
+    expect(enquirer.prompt).not.toHaveBeenCalled();
   });
 });

--- a/packages/create-nx-workspace/src/internal-utils/prompts.ts
+++ b/packages/create-nx-workspace/src/internal-utils/prompts.ts
@@ -18,8 +18,9 @@ import {
   agentDisplayMap,
   supportedAgents,
 } from '../create-workspace-options';
-import { detectAiAgentName } from '../utils/ai/ai-output';
+import { detectAiAgentName, isAiAgent } from '../utils/ai/ai-output';
 import { CnwError } from '../utils/error-utils';
+import { output } from '../utils/output';
 
 export async function determineNxCloud(
   parsedArgs: yargs.Arguments<{ nxCloud: NxCloud }>
@@ -235,6 +236,48 @@ export async function determineDefaultBase(
       });
   }
   return deduceDefaultBase();
+}
+
+/**
+ * Confirm with the user before installing a third-party preset npm package.
+ *
+ * `--preset=<name>` will install any npm package whose name matches when the
+ * preset is not a known Nx preset. A typo (e.g. `--preset=core`) can silently
+ * install an unrelated package from the registry, which is a supply-chain
+ * risk. This prompt makes that step explicit.
+ *
+ * In non-interactive / CI / AI-agent contexts we cannot prompt, so we emit a
+ * warning and proceed — automated workflows like
+ * `--preset=@my-org/nx-plugin --no-interactive` keep working, but the warning
+ * still appears in the logs.
+ */
+export async function confirmThirdPartyPreset(
+  packageName: string,
+  interactive: boolean | undefined
+): Promise<boolean> {
+  output.warn({
+    title: `About to install '${packageName}' from the npm registry as a preset.`,
+    bodyLines: [
+      `'${packageName}' is not a built-in Nx preset.`,
+      `Nx will download this npm package and run its preset generator.`,
+      `Only proceed if you trust the publisher of '${packageName}'.`,
+    ],
+  });
+
+  if (interactive === false || isCI() || isAiAgent()) {
+    return true;
+  }
+
+  const { confirm } = await enquirer.prompt<{ confirm: 'Yes' | 'No' }>([
+    {
+      name: 'confirm',
+      message: `Install third-party preset '${packageName}'?`,
+      type: 'autocomplete',
+      choices: [{ name: 'No' }, { name: 'Yes' }],
+      initial: 0,
+    },
+  ]);
+  return confirm === 'Yes';
 }
 
 export async function determinePackageManager(


### PR DESCRIPTION
## Current Behavior

`create-nx-workspace --preset=<name>` silently installs any npm package matching the name when the preset is not a built-in Nx preset. A user following a tutorial that suggested `--preset=core` ended up installing [`core`](https://www.npmjs.com/package/core) — an unrelated ancient package — without any warning. This is a supply-chain risk: a typo or malicious preset name could execute untrusted code with no user-visible signal.

The path through the code:

1. `create-workspace.ts` calls `getPackageNameFromThirdPartyPreset(preset)`.
2. If the preset isn't in the built-in `Preset` enum, the helper returns the package name as long as `validateNpmPackage` accepts it.
3. `createPreset` then installs and runs the resolved package — no confirmation, no warning.

## Expected Behavior

Before installing a third-party preset npm package, surface the npm package name and ask the user to confirm.

- **Interactive (TTY) mode**: prompt with `enquirer.autocomplete`, defaulting to **No**, so a reflex `Enter` is safe.
- **`--interactive=false`, CI, or AI-agent contexts**: skip the prompt (we can't read a TTY) but always emit an `output.warn` describing the package about to be installed. Automated workflows like `--preset=@nx-go/nx-go --no-interactive` keep working, but the warning still appears in logs.

The confirmation runs before sandbox creation — declining doesn't waste work.

### Out of scope

The original report also suggests validating that the package is genuinely an Nx plugin. That requires a registry round-trip and a definition of "is an Nx plugin" (peerDeps on `nx`? keyword? presence of a preset generator?). The confirmation step alone closes the silent-install vector; the deeper validation is left as a follow-up.

## Related Issue(s)

Fixes [NXC-3331](https://linear.app/nxdev/issue/NXC-3331/warn-users-before-installing-unknown-npm-packages-with-preset).