### PR TITLE
fix(misc): vite migration import fix and ai doc corrections

### DIFF
--- a/packages/cypress/src/migrations/update-23-0-0/remove-experimental-prompt-command.md
+++ b/packages/cypress/src/migrations/update-23-0-0/remove-experimental-prompt-command.md
@@ -1,0 +1,55 @@
+#### Remove the `experimentalPromptCommand` Flag from Cypress Config
+
+Removes the `experimentalPromptCommand` flag from `cypress.config.{ts,js,mjs,cjs}` files. The flag was removed in [Cypress 15.13.0](https://github.com/cypress-io/cypress/releases/tag/v15.13.0); `cy.prompt` is now in beta without configuration. Leaving the flag in place causes Cypress to error at startup.
+
+#### Sample Code Changes
+
+Remove `experimentalPromptCommand` from the top level of `defineConfig`.
+
+##### Before
+
+```ts title="apps/myapp-e2e/cypress.config.ts" {5}
+import { defineConfig } from 'cypress';
+
+export default defineConfig({
+  e2e: { baseUrl: 'http://localhost:4200' },
+  experimentalPromptCommand: true,
+});
+```
+
+##### After
+
+```ts title="apps/myapp-e2e/cypress.config.ts"
+import { defineConfig } from 'cypress';
+
+export default defineConfig({
+  e2e: { baseUrl: 'http://localhost:4200' },
+});
+```
+
+The flag is also removed when nested inside `e2e` or `component`.
+
+##### Before
+
+```ts title="apps/myapp-e2e/cypress.config.ts" {5}
+import { defineConfig } from 'cypress';
+
+export default defineConfig({
+  e2e: {
+    experimentalPromptCommand: true,
+    baseUrl: 'http://localhost:4200',
+  },
+});
+```
+
+##### After
+
+```ts title="apps/myapp-e2e/cypress.config.ts"
+import { defineConfig } from 'cypress';
+
+export default defineConfig({
+  e2e: {
+    baseUrl: 'http://localhost:4200',
+  },
+});
+```

--- a/packages/rspack/src/migrations/update-23-0-0/add-svgr-to-rspack-config.md
+++ b/packages/rspack/src/migrations/update-23-0-0/add-svgr-to-rspack-config.md
@@ -1,0 +1,84 @@
+#### Replace the `svgr` Option with the `withSvgr` Composable in Rspack Configs
+
+Updates rspack configs that use React to use a new `withSvgr` composable function instead of passing an `svgr` option to `withReact` or `NxReactRspackPlugin`. The option was removed; SVG handling is now consolidated into the images asset rule by default. The migration inlines a `withSvgr` helper into each affected config so existing SVGR-as-React-component behavior is preserved.
+
+#### Sample Code Changes
+
+Replace the `svgr` option on `withReact` with a `withSvgr(...)` call composed alongside it.
+
+##### Before
+
+```js title="apps/myapp/rspack.config.js" {5}
+const { composePlugins, withNx, withReact } = require('@nx/rspack');
+
+module.exports = composePlugins(
+  withNx(),
+  withReact({ svgr: { svgo: false, titleProp: true, ref: true } })
+);
+```
+
+##### After
+
+```js title="apps/myapp/rspack.config.js"
+const { composePlugins, withNx, withReact } = require('@nx/rspack');
+
+// SVGR support function (migrated from svgr option in withReact/NxReactRspackPlugin)
+function withSvgr(svgrOptions = {}) {
+  const defaultOptions = { svgo: false, titleProp: true, ref: true };
+  const options = { ...defaultOptions, ...svgrOptions };
+  return function configure(config) {
+    const svgLoaderIdx = config.module.rules.findIndex(
+      (rule) =>
+        typeof rule === 'object' &&
+        typeof rule.test !== 'undefined' &&
+        rule.test.toString().includes('svg')
+    );
+    if (svgLoaderIdx !== -1) {
+      config.module.rules.splice(svgLoaderIdx, 1);
+    }
+    config.module.rules.push(
+      { test: /\.svg$/i, type: 'asset', resourceQuery: /url/ },
+      {
+        test: /\.svg$/i,
+        issuer: /\.[jt]sx?$/,
+        resourceQuery: { not: [/url/] },
+        use: [{ loader: '@svgr/webpack', options }],
+      }
+    );
+    return config;
+  };
+}
+
+module.exports = composePlugins(
+  withNx(),
+  withReact(),
+  withSvgr({ svgo: false, titleProp: true, ref: true })
+);
+```
+
+For the `NxReactRspackPlugin` style, the `svgr` option is removed from the plugin call and the entire `module.exports` is wrapped with a `withSvgr(...)` call that registers the loader rules directly on the compiler.
+
+##### Before
+
+```js title="apps/myapp/rspack.config.js" {5}
+const { NxReactRspackPlugin } = require('@nx/rspack');
+
+module.exports = {
+  plugins: [new NxReactRspackPlugin({ svgr: true, main: './src/main.tsx' })],
+};
+```
+
+##### After
+
+```js title="apps/myapp/rspack.config.js"
+const { NxReactRspackPlugin } = require('@nx/rspack');
+
+// SVGR support function (migrated from svgr option in withReact/NxReactRspackPlugin)
+function withSvgr(svgrOptions = {}) {
+  /* same helper as above, compiler.options.module.rules variant */
+}
+
+module.exports = withSvgr()({
+  plugins: [new NxReactRspackPlugin({ main: './src/main.tsx' })],
+});
+```

--- a/packages/vite/migrations.json
+++ b/packages/vite/migrations.json
@@ -39,7 +39,7 @@
       "implementation": "./src/migrations/update-22-2-0/migrate-vitest-to-vitest-package"
     },
     "ensure-vitest-package-migration-23": {
-      "version": "23.0.0-beta.0",
+      "version": "23.0.0-beta.10",
       "description": "Safety net: ensure any remaining @nx/vite:test executor usages are swapped to @nx/vitest:test and @nx/vitest is installed.",
       "implementation": "./src/migrations/update-23-0-0/ensure-vitest-package-migration"
     },

--- a/packages/vite/src/migrations/update-23-0-0/ensure-vitest-package-migration.ts
+++ b/packages/vite/src/migrations/update-23-0-0/ensure-vitest-package-migration.ts
@@ -11,7 +11,7 @@ import {
   updateNxJson,
   updateProjectConfiguration,
 } from '@nx/devkit';
-import { forEachExecutorOptions } from '@nx/devkit/src/generators/executor-options-utils';
+import { forEachExecutorOptions } from '@nx/devkit/internal';
 import { nxVersion } from '../../utils/versions';
 
 type PluginEntry = ExpandedPluginConfiguration<Record<string, unknown>>;

--- a/packages/vite/src/migrations/update-23-0-0/files/ai-instructions-for-vite-8.md
+++ b/packages/vite/src/migrations/update-23-0-0/files/ai-instructions-for-vite-8.md
@@ -107,7 +107,7 @@ rg "@nx/vitest:test|@nx/vite:test" --type json
 
 ### 4. Type Resolution Under `moduleResolution: "node"`
 
-Vite 8 ships its types as `.d.mts` files, which TypeScript cannot resolve under `moduleResolution: "node"`. Symptoms include type errors on `defineConfig`, `UserConfig`, or plugin return types.
+Vite 8 ships its types only via conditional `exports` (it dropped the top-level `types` field that Vite 7 carried), which TypeScript cannot resolve under `moduleResolution: "node"`. Symptoms include type errors on `defineConfig`, `UserConfig`, or plugin return types.
 
 **Action Items**:
 
@@ -191,7 +191,7 @@ nx prepush
 
 ### Issue: `Cannot find name 'rollupOptions'` or build options ignored
 
-**Solution**: Rename to `rolldownOptions`. Vite 8 ignores `rollupOptions` silently in some paths.
+**Solution**: Rename to `rolldownOptions`. Vite 8 still accepts `rollupOptions` as a deprecated alias (it copies the value to `rolldownOptions` and logs a deprecation warning), but mixing both at the same level may cause precedence surprises (`rolldownOptions` wins).
 
 ### Issue: Babel plugin no longer applied (e.g., styled-components classNames missing)
 

--- a/packages/vite/src/migrations/update-23-0-0/rename-rollup-options-to-rolldown-options.md
+++ b/packages/vite/src/migrations/update-23-0-0/rename-rollup-options-to-rolldown-options.md
@@ -1,0 +1,65 @@
+#### Rename `rollupOptions` to `rolldownOptions` in Vite Config Files
+
+Renames the `rollupOptions` property to `rolldownOptions` inside `vite.config.{js,ts,mjs,mts,cjs,cts}` files. [Vite 8 replaced Rollup with Rolldown](https://vite.dev/blog/announcing-vite8) as its production bundler; `rollupOptions` is accepted as a deprecated alias but logs a warning and may produce precedence surprises when both keys are present. The migration covers top-level usage as well as nested `environments.<env>.build.rollupOptions`.
+
+The migration only touches files matching `vite.*config*.{js,ts,mjs,mts,cjs,cts}`. Helper modules imported by your config and `rollupOptions` declared elsewhere need to be renamed by hand.
+
+#### Sample Code Changes
+
+Top-level rename inside `build`.
+
+##### Before
+
+```ts title="apps/myapp/vite.config.ts" {3}
+export default defineConfig({
+  build: {
+    rollupOptions: {
+      external: ['react'],
+    },
+  },
+});
+```
+
+##### After
+
+```ts title="apps/myapp/vite.config.ts"
+export default defineConfig({
+  build: {
+    rolldownOptions: {
+      external: ['react'],
+    },
+  },
+});
+```
+
+The same rename applies inside `environments.<env>.build`.
+
+##### Before
+
+```ts title="apps/myapp/vite.config.ts" {5}
+export default defineConfig({
+  environments: {
+    ssr: {
+      build: {
+        rollupOptions: { external: ['fs'] },
+      },
+    },
+  },
+});
+```
+
+##### After
+
+```ts title="apps/myapp/vite.config.ts"
+export default defineConfig({
+  environments: {
+    ssr: {
+      build: {
+        rolldownOptions: { external: ['fs'] },
+      },
+    },
+  },
+});
+```
+
+> **Note**: Rolldown is largely Rollup-compatible but a handful of options have different semantics. The most common one to check after this migration: `output.manualChunks` only accepts a function in Rolldown (the object-of-globs form is invalid). See `tools/ai-migrations/MIGRATE_VITE_8.md` (created by a sibling migration) for the full Vite 8 upgrade checklist.


### PR DESCRIPTION

 ## Current Behavior

 `@nx/vite`'s `ensure-vitest-package-migration-23` imports the deep path `@nx/devkit/src/generators/executor-options-utils`, which v23 dropped from the `@nx/devkit` `exports` map. `nx migrate --run-migrations` halts with `ERR_PACKAGE_PATH_NOT_EXPORTED` and skips every subsequent migration. The Vite 8 AI doc also carried two stale upstream claims (`.d.mts` types, "silently ignores `rollupOptions`"), which was true in 8.0.0, but not in subsequent patch releases.

Additionally, three v23 codemods shipped without the per-migration `.md` doc the rest of `update-23-0-0/` provides.

 ## Expected Behavior

 Migration import swapped to `@nx/devkit/internal`. Migration `version` bumped to `23.0.0-beta.10` so prior-beta users get a clean re-run. AI doc corrected. 

Missing `.md` docs added for `cypress/remove-experimental-prompt-command`, `rspack/add-svgr-to-rspack-config`, and
 `vite/rename-rollup-options-to-rolldown-options`.

 ## Related Issue(s)

 Related to NXC-4154
