### PR TITLE
fix(core)!: drop legacy 'self'/'dependencies' magic strings in dependsOn

### DIFF
--- a/packages/nx/src/hasher/hash-plan-inspector.spec.ts
+++ b/packages/nx/src/hasher/hash-plan-inspector.spec.ts
@@ -268,7 +268,7 @@ describe('HashPlanInspector', () => {
 
     it('should handle extraTargetDependencies parameter', () => {
       const extraTargetDependencies = {
-        build: [{ target: 'test', projects: 'self' }],
+        build: [{ target: 'test' }],
       };
       const result = inspector.inspectHashPlan(
         ['test-app'],
@@ -368,7 +368,7 @@ describe('HashPlanInspector', () => {
     it('should handle extraTargetDependencies parameter', () => {
       const target = { project: 'test-app', target: 'build' };
       const extraTargetDependencies = {
-        build: [{ target: 'test', projects: 'self' }],
+        build: [{ target: 'test' }],
       };
       const result = inspector.inspectTask(target, {}, extraTargetDependencies);
 

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -205,23 +205,7 @@ export function normalizeTargetDependencyWithStringProjects(
   dependencyConfig: TargetDependencyConfig
 ): Omit<TargetDependencyConfig, 'projects'> & { projects: string[] } {
   if (typeof dependencyConfig.projects === 'string') {
-    /** LERNA SUPPORT START - Remove in v20 */
-    // Lerna uses `dependencies` in `prepNxOptions`, so we need to maintain
-    // support for it until lerna can be updated to use the syntax.
-    //
-    // This should have been removed in v17, but the updates to lerna had not
-    // been made yet.
-    //
-    // TODO(@agentender): Remove this part in v20
-    if (dependencyConfig.projects === 'self') {
-      delete dependencyConfig.projects;
-    } else if (dependencyConfig.projects === 'dependencies') {
-      dependencyConfig.dependencies = true;
-      delete dependencyConfig.projects;
-      /** LERNA SUPPORT END - Remove in v20 */
-    } else {
-      dependencyConfig.projects = [dependencyConfig.projects];
-    }
+    dependencyConfig.projects = [dependencyConfig.projects];
   }
   return dependencyConfig as Omit<TargetDependencyConfig, 'projects'> & {
     projects: string[];


### PR DESCRIPTION
## Current Behavior

`TargetDependencyConfig.projects` accepts the legacy magic strings `'self'` and `'dependencies'` via a compat shim in `packages/nx/src/tasks-runner/utils.ts`. The shim was added for pre-v8.1.4 Lerna's `prepNxOptions` call shape, with a `TODO(@agentender): Remove this part in v20` that has now been deferred twice (originally v17, then v20 — we're on v22.6).

## Expected Behavior

The Lerna-driven case is no longer relevant:

- Lerna switched to the modern `{ dependencies: true }` shape on 2024-06-06 ([lerna/lerna#4017](https://github.com/lerna/lerna/pull/4017), first shipped in v8.1.4).
- Any user-authored `projects: 'self'` / `projects: 'dependencies'` configs (including `{self}`/`{dependencies}` token variants) are already rewritten to the modern form by the existing v16 `update-depends-on-to-tokens` migration.

The shim, the LERNA SUPPORT comment markers, and the stale TODO are removed. The single-project shorthand (`projects: "my-lib"` auto-wrapping to `["my-lib"]`) is preserved.

## Related Issue(s)

Linear: [NXC-4308](https://linear.app/nxdev/issue/NXC-4308/address-stale-todo-v20-in-tasks-runner-utilsts-drop-lerna-compat-for)