### PR TITLE
fix(core): account for FSEvents callback latency in force_flush_pending

### DIFF
--- a/packages/nx/src/native/watch/watcher.rs
+++ b/packages/nx/src/native/watch/watcher.rs
@@ -25,6 +25,16 @@ const IDLE_WINDOW: Duration = Duration::from_millis(100);
 /// Starvation cap from the start of a burst — flush even if events keep
 /// arriving faster than IDLE_WINDOW.
 const MAX_WAIT: Duration = Duration::from_millis(500);
+/// How long the force-flush handler waits for an in-flight notify-thread
+/// send to land before draining and snapshotting. inotify and
+/// ReadDirectoryChangesW forward in microseconds; FSEvents dispatches
+/// callbacks via a Core Foundation runloop with 5–50ms+ jitter, so macOS
+/// needs a longer wait or `force_flush_pending` snapshots a stale
+/// accumulator after a write.
+#[cfg(target_os = "macos")]
+const FORCE_FLUSH_INFLIGHT_WAIT: Duration = Duration::from_millis(50);
+#[cfg(not(target_os = "macos"))]
+const FORCE_FLUSH_INFLIGHT_WAIT: Duration = Duration::from_millis(5);
 
 #[cfg(not(target_os = "macos"))]
 fn build_ignore_glob_set() -> Arc<NxGlobSet> {
@@ -298,10 +308,7 @@ impl WatchPipeline {
 
                         // Wait briefly for notify-crate sends that are
                         // mid-flight — a bare try_recv would miss them.
-                        match self
-                            .notify_rx
-                            .recv_timeout(Duration::from_millis(5))
-                        {
+                        match self.notify_rx.recv_timeout(FORCE_FLUSH_INFLIGHT_WAIT) {
                             Ok(event) => {
                                 if let Err(msg) = self.ingest_event(event) {
                                     fatal = Some(msg);


### PR DESCRIPTION
## Current Behavior

On macOS, calling the daemon's `force_flush_pending` immediately after writing a file may snapshot a stale accumulator (event missed). Downstream this surfaces as the daemon serving a project graph computed against the pre-write workspace state.

## Expected Behavior

`force_flush_pending` reliably captures in-flight notify events on all supported platforms, so an immediate post-write call sees the new event.

## Implementation Details

The 5ms in-flight wait added in #35646 was tuned for the inotify case described in that PR — the notify-crate worker thread reads the kernel event and forwards it on `notify_rx` in microseconds, so 5ms covers the scheduling-pressure window. ReadDirectoryChangesW on Windows has the same shape.

macOS uses FSEvents, which dispatches callbacks via a Core Foundation runloop with 5–50ms+ jitter. The 5ms `recv_timeout` consistently expires before the just-written file's event reaches the channel, so the handler snapshots the (empty) accumulator and the caller never sees the event. The new Rust regression test `force_flush_pending_captures_in_flight_writes` makes this visible — it fails reliably on macOS local runs but passes in (Linux) CI.

This change makes the in-flight wait per-OS:

- macOS: 50ms (covers FSEvents runloop dispatch jitter)
- Linux / Windows: 5ms (unchanged — keeps the original tuning)

The cost is only paid when `force_flush_pending` is called and the channel is empty at that moment; the burst case (active editing) returns immediately on the first `Ok(event)` and is unaffected.