### PR TITLE
fix(angular-rspack): exclude eslint config from tailwind v4 source scan

### DIFF
--- a/examples/angular-rspack/csr-tailwind/src/styles.css
+++ b/examples/angular-rspack/csr-tailwind/src/styles.css
@@ -1,1 +1,2 @@
 @import 'tailwindcss';
+@source not "../eslint.config.mjs";


### PR DESCRIPTION
## Current Behavior

In `examples-angular-rspack-csr-tailwind:build`, Tailwind v4's automatic source-detection scanner (`@tailwindcss/oxide`) walks the project root and reads every file with a known extension (`.html`, `.js`, `.mjs`, `.cjs`, `.ts`, `.tsx`, `.vue`, …) honoring `.gitignore`.

`eslint.config.mjs` sits at the project root with a scanned extension, so Tailwind reads it looking for utility class names. The Nx build target excludes `eslint.config.@(js|cjs|mjs|ts|cts|mts)` from its inputs, so the read shows up as an undeclared-read sandbox violation:

```
examples/angular-rspack/csr-tailwind/eslint.config.mjs
```

Other root-level files Tailwind also scans (e.g. `rspack.config.js`) don't trigger violations because they are declared as inputs by their respective plugins. `eslint.config.mjs` is unique in being both scanned and excluded.

## Expected Behavior

Tailwind should not scan eslint config. Adding `@source not "../eslint.config.mjs";` to `src/styles.css` tells Tailwind to skip that file during its scan. No more sandbox violation; the eslint config exclusion in the build inputs stays correct (eslint config has no effect on build output).

## Related Issue(s)

N/A — sandbox-report finding, not a tracked issue.