### PR TITLE
feat(vite)!: deprecate the nxViteTsPaths and nxCopyAssetsPlugin helpers

### DIFF
--- a/astro-docs/src/content/docs/technologies/build-tools/vite/Guides/configure-vite.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/vite/Guides/configure-vite.mdoc
@@ -169,7 +169,7 @@ Add a `vite.config.ts` file to the root of your project. If you are not using Re
 /// <reference types='vitest' />
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
-import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
   root: __dirname,
@@ -191,7 +191,7 @@ export default defineConfig({
     host: 'localhost',
   },
 
-  plugins: [react(), nxViteTsPaths()],
+  plugins: [react(), tsconfigPaths()],
 
   test: {
     reporters: ['default'],
@@ -220,14 +220,14 @@ import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
 import dts from 'vite-plugin-dts';
 import * as path from 'path';
-import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import tsconfigPaths from 'vite-tsconfig-paths';
 
 export default defineConfig({
   root: __dirname,
   cacheDir: '../node_modules/.vite/my-lib',
   plugins: [
     react(),
-    nxViteTsPaths(),
+    tsconfigPaths(),
     dts({
       entryRoot: 'src',
       tsConfigFilePath: path.join(__dirname, 'tsconfig.lib.json'),

--- a/astro-docs/src/content/docs/technologies/build-tools/vite/Guides/configure-vite.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/vite/Guides/configure-vite.mdoc
@@ -14,7 +14,23 @@ The `@nx/vite` plugin generators take care of configuring Vite for you. However,
 
 ## TypeScript paths
 
-You need to use the `nxViteTsPaths()` plugin to make sure that your TypeScript paths are resolved correctly in your monorepo.
+Use the [`vite-tsconfig-paths`](https://www.npmjs.com/package/vite-tsconfig-paths) plugin so Vite resolves the TypeScript path aliases declared in your workspace's base `tsconfig`:
+
+```ts
+// vite.config.ts
+import { defineConfig } from 'vite';
+import tsconfigPaths from 'vite-tsconfig-paths';
+
+export default defineConfig({
+  plugins: [tsconfigPaths()],
+});
+```
+
+The inferred `@nx/vite/plugin` automatically ensures each project extends the workspace base `tsconfig`, so the community plugin handles path resolution end-to-end.
+
+{% aside type="caution" title="`nxViteTsPaths` is deprecated" %}
+The `nxViteTsPaths()` plugin from `@nx/vite/plugins/nx-tsconfig-paths.plugin` is deprecated and will be removed in Nx v24. It still works in v23, but using it logs a deprecation warning. Swap it for `tsconfigPaths()` from `vite-tsconfig-paths` as shown above.
+{% /aside %}
 
 ## Framework plugins
 
@@ -84,22 +100,27 @@ You can read more about the configuration options in the [`vite-plugin-dts` plug
 
 ## Copying assets
 
-If you have assets outside of [`publicDir`](https://vite.dev/config/shared-options.html#publicdir) that need to be copied the output folder, then you can use `nxCopyAssetsPlugin` from `@nx/vite`.
+For most cases, drop static assets into Vite's [`publicDir`](https://vite.dev/config/shared-options.html#publicdir) and they will be copied to the output folder automatically.
+
+When you need glob-based copying (for example, picking up `*.md` files from your project root), use [`vite-plugin-static-copy`](https://www.npmjs.com/package/vite-plugin-static-copy):
 
 ```ts
 // vite.config.ts
 /// <reference types='vitest' />
 import { defineConfig } from 'vite';
+import tsconfigPaths from 'vite-tsconfig-paths';
+import { viteStaticCopy } from 'vite-plugin-static-copy';
 // ...
-import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
 
 export default defineConfig({
   root: __dirname,
   cacheDir: '../../node_modules/.vite/libs/testlib',
 
   plugins: [
-    nxViteTsPaths(),
-    nxCopyAssetsPlugin(['*.md']),
+    tsconfigPaths(),
+    viteStaticCopy({
+      targets: [{ src: '*.md', dest: '.' }],
+    }),
     dts({
       entryRoot: 'src',
       tsconfigPath: path.join(__dirname, 'tsconfig.lib.json'),
@@ -108,6 +129,10 @@ export default defineConfig({
   // ...
 });
 ```
+
+{% aside type="caution" title="`nxCopyAssetsPlugin` is deprecated" %}
+The `nxCopyAssetsPlugin` plugin from `@nx/vite/plugins/nx-copy-assets.plugin` is deprecated and will be removed in Nx v24. It still works in v23, but using it logs a deprecation warning. Use Vite's native `publicDir` option or `vite-plugin-static-copy` as shown above.
+{% /aside %}
 
 ## For testing
 

--- a/astro-docs/src/content/docs/technologies/react/Guides/adding-assets-react.mdoc
+++ b/astro-docs/src/content/docs/technologies/react/Guides/adding-assets-react.mdoc
@@ -341,7 +341,7 @@ Then, configure Vite as follows:
 /// <reference types='vitest' />
 import { defineConfig } from 'vite';
 import react from '@vitejs/plugin-react';
-import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import tsconfigPaths from 'vite-tsconfig-paths';
 import svgr from 'vite-plugin-svgr';
 
 export default defineConfig({
@@ -357,7 +357,7 @@ export default defineConfig({
       include: '**/*.svg',
     }),
     react(),
-    nxViteTsPaths(),
+    tsconfigPaths(),
     // ...
   ],
   //...

--- a/astro-docs/src/content/docs/technologies/test-tools/storybook/Guides/one-storybook-for-all.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/storybook/Guides/one-storybook-for-all.mdoc
@@ -50,7 +50,7 @@ Here is a sample `libs/storybook-host/.storybook/main.ts` file:
 ```javascript {% meta="{6}" %}
 // libs/storybook-host/.storybook/main.ts
 import type { StorybookConfig } from '@storybook/react-vite';
-import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import tsconfigPaths from 'vite-tsconfig-paths';
 import { mergeConfig } from 'vite';
 
 const config: StorybookConfig = {
@@ -63,7 +63,7 @@ const config: StorybookConfig = {
 
   viteFinal: async (config) =>
     mergeConfig(config, {
-      plugins: [nxViteTsPaths()],
+      plugins: [tsconfigPaths()],
     }),
 };
 

--- a/astro-docs/src/content/docs/technologies/test-tools/storybook/Guides/one-storybook-with-composition.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/storybook/Guides/one-storybook-with-composition.mdoc
@@ -94,7 +94,7 @@ Update the `libs/storybook-host/.storybook/main.ts` file as shown below:
 ```javascript {% meta="{14-23}" %}
 // libs/storybook-host/.storybook/main.ts
 import type { StorybookConfig } from '@storybook/react-vite';
-import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import tsconfigPaths from 'vite-tsconfig-paths';
 import { mergeConfig } from 'vite';
 
 const config: StorybookConfig = {
@@ -118,7 +118,7 @@ const config: StorybookConfig = {
 
   viteFinal: async (config) =>
     mergeConfig(config, {
-      plugins: [nxViteTsPaths()],
+      plugins: [tsconfigPaths()],
     }),
 };
 
@@ -167,7 +167,7 @@ and then change the host Storybook's `main.ts` file to point to these URLs accor
 ```javascript
 // libs/storybook-host/.storybook/main.ts
 import type { StorybookConfig } from '@storybook/react-vite';
-import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import tsconfigPaths from 'vite-tsconfig-paths';
 import { mergeConfig } from 'vite';
 
 const config: StorybookConfig = {
@@ -191,7 +191,7 @@ const config: StorybookConfig = {
 
   viteFinal: async (config) =>
     mergeConfig(config, {
-      plugins: [nxViteTsPaths()],
+      plugins: [tsconfigPaths()],
     }),
 };
 

--- a/astro-docs/src/content/docs/technologies/typescript/Guides/switch-to-workspaces-project-references.mdoc
+++ b/astro-docs/src/content/docs/technologies/typescript/Guides/switch-to-workspaces-project-references.mdoc
@@ -737,11 +737,10 @@ If your `vitest.config.ts` or `vitest.config.mts` also uses `nxViteTsPaths`, rem
 ```ts
 // libs/ui/vite.config.ts
 import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
-import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
 
 export default defineConfig({
   // ...
-  plugins: [react(), nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
+  plugins: [react(), nxViteTsPaths()],
   build: {
     outDir: '../../dist/libs/ui',
     // ...
@@ -754,11 +753,10 @@ export default defineConfig({
 
 ```ts
 // libs/ui/vite.config.ts
-import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
 
 export default defineConfig({
   // ...
-  plugins: [react(), nxCopyAssetsPlugin(['*.md'])],
+  plugins: [react()],
   resolve: {
     conditions: ['@myorg/source'],
   },

--- a/astro-docs/src/content/docs/technologies/vue/nuxt/Guides/deploy-nuxt-to-vercel.mdoc
+++ b/astro-docs/src/content/docs/technologies/vue/nuxt/Guides/deploy-nuxt-to-vercel.mdoc
@@ -43,7 +43,7 @@ So, your entire `nuxt.config.ts` file may look something like this:
 
 ```ts
 // apps/my-app/nuxt.config.ts
-import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+import tsconfigPaths from 'vite-tsconfig-paths';
 import { defineNuxtConfig } from 'nuxt/config';
 
 export default defineNuxtConfig({
@@ -66,7 +66,7 @@ export default defineNuxtConfig({
   },
   css: ['~/assets/css/styles.css'],
   vite: {
-    plugins: [nxViteTsPaths()],
+    plugins: [tsconfigPaths()],
   },
   nitro: {
     preset: 'vercel',

--- a/packages/vite/plugins/nx-copy-assets.plugin.ts
+++ b/packages/vite/plugins/nx-copy-assets.plugin.ts
@@ -2,7 +2,17 @@ import { join, relative } from 'node:path';
 import type { Plugin, ResolvedConfig } from 'vite';
 import { isDaemonEnabled, joinPathFragments, workspaceRoot } from '@nx/devkit';
 import { AssetGlob, CopyAssetsHandler } from '@nx/js/internal';
+import { CopyAssetsHandler } from '@nx/js/src/utils/assets/copy-assets-handler';
+import { warnNxCopyAssetsPluginDeprecation } from '../src/utils/deprecation';
+
+/**
+ * @deprecated Will be removed in Nx v24. Use Vite's native `publicDir` option
+ * for static assets, or the `vite-plugin-static-copy` package for anything
+ * that needs glob-based copying. See
+ * https://nx.dev/docs/technologies/build-tools/vite/configure-vite for details.
+ */
 export function nxCopyAssetsPlugin(_assets: (string | AssetGlob)[]): Plugin {
+  warnNxCopyAssetsPluginDeprecation();
   let config: ResolvedConfig;
   let handler: CopyAssetsHandler;
   let dispose: () => void;

--- a/packages/vite/plugins/nx-copy-assets.plugin.ts
+++ b/packages/vite/plugins/nx-copy-assets.plugin.ts
@@ -2,7 +2,6 @@ import { join, relative } from 'node:path';
 import type { Plugin, ResolvedConfig } from 'vite';
 import { isDaemonEnabled, joinPathFragments, workspaceRoot } from '@nx/devkit';
 import { AssetGlob, CopyAssetsHandler } from '@nx/js/internal';
-import { CopyAssetsHandler } from '@nx/js/src/utils/assets/copy-assets-handler';
 import { warnNxCopyAssetsPluginDeprecation } from '../src/utils/deprecation';
 
 /**

--- a/packages/vite/plugins/nx-tsconfig-paths.plugin.ts
+++ b/packages/vite/plugins/nx-tsconfig-paths.plugin.ts
@@ -18,6 +18,7 @@ import {
   MatchPath,
 } from 'tsconfig-paths';
 import { Plugin } from 'vite';
+import { warnNxViteTsPathsDeprecation } from '../src/utils/deprecation';
 import { findFile } from '../src/utils/nx-tsconfig-paths-find-file';
 import { getProjectTsConfigPath } from '../src/utils/options-utils';
 import { nxViteBuildCoordinationPlugin } from './nx-vite-build-coordination.plugin';
@@ -49,7 +50,15 @@ export interface nxViteTsPathsOptions {
   buildLibsFromSource?: boolean;
 }
 
+/**
+ * @deprecated Will be removed in Nx v24. Replace with `tsconfigPaths()` from
+ * the `vite-tsconfig-paths` package. The inferred `@nx/vite/plugin` already
+ * ensures projects extend the workspace base tsconfig, so the community
+ * plugin handles monorepo path resolution end-to-end. See
+ * https://nx.dev/docs/technologies/build-tools/vite/configure-vite for details.
+ */
 export function nxViteTsPaths(options: nxViteTsPathsOptions = {}) {
+  warnNxViteTsPathsDeprecation();
   let foundTsConfigPath: string;
   let matchTsPathEsm: MatchPath;
   let matchTsPathFallback: MatchPath | undefined;

--- a/packages/vite/src/generators/configuration/configuration.spec.ts
+++ b/packages/vite/src/generators/configuration/configuration.spec.ts
@@ -499,7 +499,7 @@ describe('@nx/vite:configuration', () => {
               // Don't forget to update your package.json as well.
               formats: ['es' as const],
             },
-            rollupOptions: {
+            rolldownOptions: {
               // External packages that should not be bundled into your library.
               external: [],
             },
@@ -571,7 +571,7 @@ describe('@nx/vite:configuration', () => {
               // Don't forget to update your package.json as well.
               formats: ['es' as const],
             },
-            rollupOptions: {
+            rolldownOptions: {
               // External packages that should not be bundled into your library.
               external: ['react', 'react-dom', 'react/jsx-runtime'],
             },

--- a/packages/vite/src/generators/configuration/configuration.spec.ts
+++ b/packages/vite/src/generators/configuration/configuration.spec.ts
@@ -337,6 +337,13 @@ describe('@nx/vite:configuration', () => {
         json.workspaces = ['packages/*', 'apps/*'];
         return json;
       });
+      // detectPackageManager() resolves to pnpm in the test env, so
+      // isWorkspacesEnabled requires pnpm-workspace.yaml to recognise this
+      // tree as using package-manager workspaces.
+      tree.write(
+        'pnpm-workspace.yaml',
+        `packages:\n  - 'packages/*'\n  - 'apps/*'\n`
+      );
       writeJson(tree, 'tsconfig.base.json', {
         compilerOptions: {
           composite: true,

--- a/packages/vite/src/generators/configuration/configuration.spec.ts
+++ b/packages/vite/src/generators/configuration/configuration.spec.ts
@@ -443,5 +443,142 @@ describe('@nx/vite:configuration', () => {
         }
       `);
     });
+
+    it('should generate a vite config without the deprecated helpers', async () => {
+      addProjectConfiguration(tree, 'my-lib', {
+        root: 'packages/my-lib',
+      });
+      writeJson(tree, 'packages/my-lib/tsconfig.lib.json', {});
+      writeJson(tree, 'packages/my-lib/tsconfig.json', {});
+      tree.write('packages/my-lib/src/index.ts', '');
+
+      await viteConfigurationGenerator(tree, {
+        addPlugin: true,
+        uiFramework: 'none',
+        project: 'my-lib',
+        projectType: 'library',
+        includeLib: true,
+        newProject: false,
+      });
+
+      expect(tree.read('packages/my-lib/vite.config.mts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "/// <reference types='vitest' />
+        import { defineConfig } from 'vite';
+        import dts from 'vite-plugin-dts';
+        import * as path from 'path';
+
+        export default defineConfig(() => ({
+          root: import.meta.dirname,
+          cacheDir: '../../node_modules/.vite/packages/my-lib',
+          plugins: [
+            dts({
+              entryRoot: 'src',
+              tsconfigPath: path.join(import.meta.dirname, 'tsconfig.lib.json'),
+            }),
+          ],
+          // Uncomment this if you are using workers.
+          // worker: {
+          //  plugins: [],
+          // },
+          // Configuration for building your library.
+          // See: https://vite.dev/guide/build.html#library-mode
+          build: {
+            outDir: './dist',
+            emptyOutDir: true,
+            reportCompressedSize: true,
+            commonjsOptions: {
+              transformMixedEsModules: true,
+            },
+            lib: {
+              // Could also be a dictionary or array of multiple entry points.
+              entry: 'src/index.ts',
+              name: 'my-lib',
+              fileName: 'index',
+              // Change this to the formats you want to support.
+              // Don't forget to update your package.json as well.
+              formats: ['es' as const],
+            },
+            rollupOptions: {
+              // External packages that should not be bundled into your library.
+              external: [],
+            },
+          },
+        }));
+        "
+      `);
+    });
+  });
+
+  // TODO(v24): swap to vite-tsconfig-paths in the non-ts-solution branch.
+  describe('legacy non-ts-solution plugin emit', () => {
+    beforeEach(() => {
+      tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    });
+
+    it('should still emit the deprecated helpers for non-ts-solution libraries', async () => {
+      mockReactLibNonBuildableJestTestRunnerGenerator(tree);
+
+      await viteConfigurationGenerator(tree, {
+        addPlugin: true,
+        uiFramework: 'react',
+        includeLib: true,
+        project: 'react-lib-nonb-jest',
+      });
+
+      expect(tree.read('libs/react-lib-nonb-jest/vite.config.mts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "/// <reference types='vitest' />
+        import { defineConfig } from 'vite';
+        import react from '@vitejs/plugin-react';
+        import dts from 'vite-plugin-dts';
+        import * as path from 'path';
+        import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+        import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
+
+        export default defineConfig(() => ({
+          root: import.meta.dirname,
+          cacheDir: '../../node_modules/.vite/libs/react-lib-nonb-jest',
+          plugins: [
+            react(),
+            nxViteTsPaths(),
+            nxCopyAssetsPlugin(['*.md']),
+            dts({
+              entryRoot: 'src',
+              tsconfigPath: path.join(import.meta.dirname, 'tsconfig.lib.json'),
+              pathsToAliases: false,
+            }),
+          ],
+          // Uncomment this if you are using workers.
+          // worker: {
+          //   plugins: () => [ nxViteTsPaths() ],
+          // },
+          // Configuration for building your library.
+          // See: https://vite.dev/guide/build.html#library-mode
+          build: {
+            outDir: '../../dist/libs/react-lib-nonb-jest',
+            emptyOutDir: true,
+            reportCompressedSize: true,
+            commonjsOptions: {
+              transformMixedEsModules: true,
+            },
+            lib: {
+              // Could also be a dictionary or array of multiple entry points.
+              entry: 'src/index.ts',
+              name: 'react-lib-nonb-jest',
+              fileName: 'index',
+              // Change this to the formats you want to support.
+              // Don't forget to update your package.json as well.
+              formats: ['es' as const],
+            },
+            rollupOptions: {
+              // External packages that should not be bundled into your library.
+              external: ['react', 'react-dom', 'react/jsx-runtime'],
+            },
+          },
+        }));
+        "
+      `);
+    });
   });
 });

--- a/packages/vite/src/utils/deprecation.ts
+++ b/packages/vite/src/utils/deprecation.ts
@@ -34,3 +34,31 @@ export function warnViteExecutorGenerating(): void {
     'Generating targets that use the deprecated `@nx/vite:build`, `@nx/vite:dev-server`, and `@nx/vite:preview-server` executors. These executors will be removed in Nx v24. Run `nx g @nx/vite:convert-to-inferred` next to migrate these targets to the `@nx/vite/plugin` inferred plugin and prevent future generators from emitting executor targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.'
   );
 }
+
+// TODO(v24): Remove `nxViteTsPaths` and `nxCopyAssetsPlugin` helpers.
+// The inferred `@nx/vite/plugin` already ensures projects extend the base
+// tsconfig, so the community `vite-tsconfig-paths` package handles path
+// resolution end-to-end. Asset copying is covered by Vite's native
+// `publicDir` option or the `vite-plugin-static-copy` package.
+export const NX_VITE_TS_PATHS_DEPRECATION_MESSAGE =
+  'The `nxViteTsPaths` plugin from `@nx/vite/plugins/nx-tsconfig-paths.plugin` is deprecated and will be removed in Nx v24. Replace it with `tsconfigPaths()` from the `vite-tsconfig-paths` package. See https://nx.dev/docs/technologies/build-tools/vite/configure-vite for details.';
+
+export const NX_COPY_ASSETS_PLUGIN_DEPRECATION_MESSAGE =
+  "The `nxCopyAssetsPlugin` plugin from `@nx/vite/plugins/nx-copy-assets.plugin` is deprecated and will be removed in Nx v24. Use Vite's native `publicDir` option or the `vite-plugin-static-copy` package instead. See https://nx.dev/docs/technologies/build-tools/vite/configure-vite for details.";
+
+let nxViteTsPathsWarned = false;
+let nxCopyAssetsPluginWarned = false;
+
+// Warn-once per process so users don't see the message repeated on every
+// dev-server HMR reload or vitest run within the same Node process.
+export function warnNxViteTsPathsDeprecation(): void {
+  if (nxViteTsPathsWarned) return;
+  nxViteTsPathsWarned = true;
+  logger.warn(NX_VITE_TS_PATHS_DEPRECATION_MESSAGE);
+}
+
+export function warnNxCopyAssetsPluginDeprecation(): void {
+  if (nxCopyAssetsPluginWarned) return;
+  nxCopyAssetsPluginWarned = true;
+  logger.warn(NX_COPY_ASSETS_PLUGIN_DEPRECATION_MESSAGE);
+}

--- a/packages/vite/src/utils/generator-utils.spec.ts
+++ b/packages/vite/src/utils/generator-utils.spec.ts
@@ -255,6 +255,10 @@ describe('generator utils', () => {
         json.workspaces = ['apps/*'];
         return json;
       });
+      // detectPackageManager() resolves to pnpm in the test env, so
+      // isWorkspacesEnabled requires pnpm-workspace.yaml to recognise this
+      // tree as using package-manager workspaces.
+      tree.write('pnpm-workspace.yaml', `packages:\n  - 'apps/*'\n`);
       writeJson(tree, 'tsconfig.base.json', {
         compilerOptions: {
           composite: true,

--- a/packages/vite/src/utils/generator-utils.ts
+++ b/packages/vite/src/utils/generator-utils.ts
@@ -402,6 +402,8 @@ export function createOrEditViteConfig(
   }
 
   if (!isTsSolutionSetup) {
+    // TODO(v24): drop this branch; emit `tsconfigPaths()` from
+    // `vite-tsconfig-paths` instead of the deprecated nx helpers.
     imports.push(
       `import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin'`,
       `import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin'`


### PR DESCRIPTION
## Current Behavior

`nxViteTsPaths` and `nxCopyAssetsPlugin` from `@nx/vite/plugins/*` run silently. New TS-solution workspaces never emit them; new non-ts-solution workspaces still do.

## Expected Behavior

Both helpers log a one-time deprecation warning on call and carry `@deprecated` JSDoc tags. Behavior unchanged in v23; removal candidate for v24.

- TS-solution: helpers are unused (package-manager workspaces handle path resolution; the project root is the publishable folder so no `package.json` copy is needed). Generator output is helper-free and a spec test locks that in.
- Non-ts-solution: workspaces still need both helpers, so generator output is unchanged for now. A spec test locks in the current emit with a TODO(v24) for the swap to `vite-tsconfig-paths`.

Configure-Vite docs lead with `vite-tsconfig-paths` and `publicDir` / `vite-plugin-static-copy` and flag the helpers as deprecated.

## Related Issue(s)

NXC-4316