### PR TITLE
chore(core): bump Rust toolchain to 1.95.0

### DIFF
--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.94.0"
+channel = "1.95.0"
 targets = ["wasm32-wasip1-threads"]
 profile = "default"


### PR DESCRIPTION
## Current Behavior

`rust-toolchain.toml` pins Rust to `1.94.0`. This blocks upgrading `sysinfo` to `0.39.x`, which requires Rust `1.95` and brings upstream support for several cgroup limit features that nx currently needs to implement locally.

## Expected Behavior

Toolchain bumped to `1.95.0`. Verified:

- `cargo build -p nx` produces zero new warnings vs. 1.94.
- `cargo build -p nx --all-targets` (compiles tests too) produces zero new warnings vs. 1.94 — identical warning set.
- Clippy delta: +11 new clippy lints (style suggestions only — not gating, none correctness-related).

## Related Issue(s)

N/A — maintenance/hygiene change. Unblocks the sysinfo bump that, in turn, lets PR #35622 drop its memory-side cgroup parsing in favor of upstream `Process::cgroup_limits()` + parent cgroup memory walking (sysinfo PRs [#1643](https://github.com/GuillaumeGomez/sysinfo/pull/1643) and [#1651](https://github.com/GuillaumeGomez/sysinfo/pull/1651)).