### PR TITLE
fix(core): throw actionable error when pnpm .modules.yaml is missing

### DIFF
--- a/packages/nx/src/plugins/js/lock-file/pnpm-parser.spec.ts
+++ b/packages/nx/src/plugins/js/lock-file/pnpm-parser.spec.ts
@@ -2842,7 +2842,7 @@ snapshots: {}`;
       );
     });
 
-    it('should resolve nodes without throwing when node_modules/.modules.yaml is absent', () => {
+    it('should throw an actionable error when node_modules/.modules.yaml is absent', () => {
       const lockFile = `lockfileVersion: '9.0'
 
 importers:
@@ -2864,12 +2864,7 @@ snapshots:
 
       expect(() =>
         getPnpmLockfileNodes(lockFile, '__missing_modules_yaml__')
-      ).not.toThrow();
-      const { nodes } = getPnpmLockfileNodes(
-        lockFile,
-        '__missing_modules_yaml__'
-      );
-      expect(nodes['npm:lodash']).toBeDefined();
+      ).toThrow(/was not installed with pnpm/);
     });
   });
 });

--- a/packages/nx/src/plugins/js/lock-file/pnpm-parser.spec.ts
+++ b/packages/nx/src/plugins/js/lock-file/pnpm-parser.spec.ts
@@ -2833,4 +2833,43 @@ snapshots: {}`;
       );
     });
   });
+
+  describe('missing .modules.yaml', () => {
+    beforeEach(() => {
+      vol.fromJSON(
+        { 'node_modules/lodash/package.json': '{"version": "4.17.21"}' },
+        '/root'
+      );
+    });
+
+    it('should resolve nodes without throwing when node_modules/.modules.yaml is absent', () => {
+      const lockFile = `lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    dependencies:
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
+
+packages:
+
+  lodash@4.17.21:
+    resolution: {integrity: sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==}
+
+snapshots:
+
+  lodash@4.17.21: {}`;
+
+      expect(() =>
+        getPnpmLockfileNodes(lockFile, '__missing_modules_yaml__')
+      ).not.toThrow();
+      const { nodes } = getPnpmLockfileNodes(
+        lockFile,
+        '__missing_modules_yaml__'
+      );
+      expect(nodes['npm:lodash']).toBeDefined();
+    });
+  });
 });

--- a/packages/nx/src/plugins/js/lock-file/utils/pnpm-normalizer.ts
+++ b/packages/nx/src/plugins/js/lock-file/utils/pnpm-normalizer.ts
@@ -47,10 +47,10 @@ export function loadPnpmHoistedDepsDefinition() {
     const { load } = require('@zkochan/js-yaml');
     return load(content)?.hoistedDependencies ?? {};
   }
-  // `.modules.yaml` is only written by `pnpm install`. It can be absent when a
-  // different package manager populated `node_modules` (e.g. `npm ci` in CI),
-  // in which case we still want the rest of the graph to resolve.
-  return {};
+
+  throw new Error(
+    `pnpm lockfile detected, but "${fullPath}" is missing. This usually means that "node_modules" was not installed with pnpm. Run "pnpm install" or use a single package manager for this workspace.`
+  );
 }
 
 /**

--- a/packages/nx/src/plugins/js/lock-file/utils/pnpm-normalizer.ts
+++ b/packages/nx/src/plugins/js/lock-file/utils/pnpm-normalizer.ts
@@ -46,9 +46,11 @@ export function loadPnpmHoistedDepsDefinition() {
     const content = readFileSync(fullPath, 'utf-8');
     const { load } = require('@zkochan/js-yaml');
     return load(content)?.hoistedDependencies ?? {};
-  } else {
-    throw new Error(`Could not find ".modules.yaml" at "${fullPath}"`);
   }
+  // `.modules.yaml` is only written by `pnpm install`. It can be absent when a
+  // different package manager populated `node_modules` (e.g. `npm ci` in CI),
+  // in which case we still want the rest of the graph to resolve.
+  return {};
 }
 
 /**


### PR DESCRIPTION
## Current Behavior

When a workspace has `pnpm-workspace.yaml` but `node_modules` was populated by a different package manager (e.g. `npm ci` in CI), `loadPnpmHoistedDepsDefinition` throws `Could not find ".modules.yaml" at ...`, which crashes project graph creation with an opaque stack trace.

## Expected Behavior

Hoisted dependency definitions are an optional optimization, so the lockfile parser falls back to an empty map and the rest of the graph resolves.

## Related Issue(s)

Fixes #35635