### PR TITLE
fix(testing): multi-version support compliance for @nx/cypress

### DIFF
--- a/packages/cypress/src/generators/component-configuration/component-configuration.ts
+++ b/packages/cypress/src/generators/component-configuration/component-configuration.ts
@@ -16,6 +16,7 @@ import {
   updateProjectConfiguration,
 } from '@nx/devkit';
 import { assertNotUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-setup';
+import { assertSupportedCypressVersion } from '../../utils/assert-supported-cypress-version';
 import { warnCypressExecutorGenerating } from '../../utils/deprecation';
 import {
   getInstalledCypressMajorVersion,
@@ -41,6 +42,8 @@ export async function componentConfigurationGeneratorInternal(
   tree: Tree,
   options: CypressComponentConfigurationSchema
 ) {
+  assertSupportedCypressVersion(tree);
+
   assertNotUsingTsSolutionSetup(tree, 'cypress', 'component-configuration');
 
   const tasks: GeneratorCallback[] = [];

--- a/packages/cypress/src/generators/configuration/configuration.ts
+++ b/packages/cypress/src/generators/configuration/configuration.ts
@@ -34,6 +34,7 @@ import { isUsingTsSolutionSetup } from '@nx/js/src/utils/typescript/ts-solution-
 import { PackageJson } from 'nx/src/utils/package-json';
 import { join } from 'path';
 import { addLinterToCyProject } from '../../utils/add-linter';
+import { assertSupportedCypressVersion } from '../../utils/assert-supported-cypress-version';
 import { addDefaultE2EConfig } from '../../utils/config';
 import { warnCypressExecutorGenerating } from '../../utils/deprecation';
 import {
@@ -80,6 +81,8 @@ export async function configurationGeneratorInternal(
   tree: Tree,
   options: CypressE2EConfigSchema
 ) {
+  assertSupportedCypressVersion(tree);
+
   const opts = await normalizeOptions(tree, options);
   const tasks: GeneratorCallback[] = [];
 

--- a/packages/cypress/src/generators/convert-to-inferred/convert-to-inferred.ts
+++ b/packages/cypress/src/generators/convert-to-inferred/convert-to-inferred.ts
@@ -11,6 +11,7 @@ import {
   type Tree,
 } from '@nx/devkit';
 import { createNodesV2, type CypressPluginOptions } from '../../plugins/plugin';
+import { assertSupportedCypressVersion } from '../../utils/assert-supported-cypress-version';
 import { addDevServerTargetToConfig } from './lib/add-dev-server-target-to-config';
 import { addExcludeSpecPattern } from './lib/add-exclude-spec-pattern';
 import { targetOptionsToCliMap } from './lib/target-options-map';
@@ -23,6 +24,8 @@ interface Schema {
 }
 
 export async function convertToInferred(tree: Tree, options: Schema) {
+  assertSupportedCypressVersion(tree);
+
   const projectGraph = await createProjectGraphAsync();
   const migratedProjects =
     await migrateProjectExecutorsToPlugin<CypressPluginOptions>(

--- a/packages/cypress/src/generators/init/init.ts
+++ b/packages/cypress/src/generators/init/init.ts
@@ -58,7 +58,7 @@ function updateDependencies(tree: Tree, options: Schema) {
       {},
       devDependencies,
       undefined,
-      options.keepExistingVersions
+      options.keepExistingVersions ?? true
     )
   );
 

--- a/packages/cypress/src/generators/init/init.ts
+++ b/packages/cypress/src/generators/init/init.ts
@@ -12,6 +12,7 @@ import {
   updateNxJson,
 } from '@nx/devkit';
 import { createNodesV2 } from '../../plugins/plugin';
+import { assertSupportedCypressVersion } from '../../utils/assert-supported-cypress-version';
 import {
   cypressVersion,
   getInstalledCypressVersion,
@@ -113,6 +114,8 @@ export async function cypressInitGeneratorInternal(
   tree: Tree,
   options: Schema
 ) {
+  assertSupportedCypressVersion(tree);
+
   updateProductionFileset(tree);
 
   const nxJson = readNxJson(tree);

--- a/packages/cypress/src/generators/init/schema.json
+++ b/packages/cypress/src/generators/init/schema.json
@@ -22,7 +22,7 @@
       "type": "boolean",
       "x-priority": "internal",
       "description": "Keep existing dependencies versions",
-      "default": false
+      "default": true
     },
     "updatePackageScripts": {
       "type": "boolean",

--- a/packages/cypress/src/utils/add-linter.ts
+++ b/packages/cypress/src/utils/add-linter.ts
@@ -83,7 +83,9 @@ export async function addLinterToCyProject(
       addDependenciesToPackageJson(
         tree,
         {},
-        { 'eslint-plugin-cypress': pkgVersions.eslintPluginCypressVersion }
+        { 'eslint-plugin-cypress': pkgVersions.eslintPluginCypressVersion },
+        undefined,
+        true
       )
     );
   }

--- a/packages/cypress/src/utils/all-generators-enforce-floor.spec.ts
+++ b/packages/cypress/src/utils/all-generators-enforce-floor.spec.ts
@@ -1,0 +1,13 @@
+import { assertGeneratorsEnforceVersionFloor } from '@nx/devkit/internal-testing-utils';
+import { join } from 'node:path';
+
+describe('@nx/cypress generators enforce supported version floor', () => {
+  assertGeneratorsEnforceVersionFloor({
+    packageRoot: join(__dirname, '..', '..'),
+    packageName: 'cypress',
+    subFloorVersion: '~12.17.0',
+    // Migrate-to-cypress-11 exists to migrate sub-floor (v8-v10) workspaces to
+    // v11; gating it on the current floor (v13) would block its only use case.
+    excludeGenerators: ['migrate-to-cypress-11'],
+  });
+});

--- a/packages/cypress/src/utils/assert-supported-cypress-version.ts
+++ b/packages/cypress/src/utils/assert-supported-cypress-version.ts
@@ -1,0 +1,7 @@
+import { type Tree } from '@nx/devkit';
+import { assertSupportedPackageVersion } from '@nx/devkit/internal';
+import { minSupportedCypressVersion } from './versions';
+
+export function assertSupportedCypressVersion(tree: Tree): void {
+  assertSupportedPackageVersion(tree, 'cypress', minSupportedCypressVersion);
+}

--- a/packages/cypress/src/utils/versions.ts
+++ b/packages/cypress/src/utils/versions.ts
@@ -1,8 +1,9 @@
 import { getDependencyVersionFromPackageJson, type Tree } from '@nx/devkit';
-import type { PackageJson } from 'nx/src/utils/package-json';
+import { getInstalledPackageVersion } from '@nx/devkit/internal';
 import { clean, coerce, major } from 'semver';
 
 export const nxVersion = require('../../package.json').version;
+export const minSupportedCypressVersion = '13.0.0';
 export const eslintPluginCypressVersion = '^3.5.0';
 export const typesNodeVersion = '^22.0.0';
 export const cypressViteDevServerVersion = '^7.3.1';
@@ -15,6 +16,7 @@ export type CypressVersions = Record<
   keyof Omit<
     typeof import('./versions'),
     | 'nxVersion'
+    | 'minSupportedCypressVersion'
     | 'versions'
     | 'getInstalledCypressVersion'
     | 'getInstalledCypressMajorVersion'
@@ -62,39 +64,26 @@ export function versions(tree: Tree): CypressVersions {
   }
 
   const cypressMajorVersion = major(installedCypressVersion);
-  switch (cypressMajorVersion) {
-    case 15:
-      return latestVersions;
-    case 14:
-      return versionMap[14];
-    case 13:
-      return versionMap[13];
-    default:
-      throw new Error(
-        `You're currently using an unsupported Cypress version: ${installedCypressVersion}. Supported versions are v13, v14, and v15.`
-      );
-  }
+  return versionMap[cypressMajorVersion as CompatVersions] ?? latestVersions;
 }
 
 export function getInstalledCypressVersion(tree?: Tree): string | null {
-  try {
-    let version: string | null;
+  if (!tree) {
+    return getInstalledPackageVersion('cypress');
+  }
 
-    if (tree) {
-      version = getCypressVersionFromTree(tree);
-    } else {
-      version = getCypressVersionFromFileSystem();
-    }
-
-    return version;
-  } catch {
+  const installedVersion = getDependencyVersionFromPackageJson(tree, 'cypress');
+  if (!installedVersion) {
     return null;
   }
+  if (installedVersion === 'latest' || installedVersion === 'next') {
+    return clean(cypressVersion) ?? coerce(cypressVersion)?.version ?? null;
+  }
+  return clean(installedVersion) ?? coerce(installedVersion)?.version ?? null;
 }
 
 export function getInstalledCypressMajorVersion(tree?: Tree): number | null {
   const installedCypressVersion = getInstalledCypressVersion(tree);
-
   return installedCypressVersion ? major(installedCypressVersion) : null;
 }
 
@@ -108,31 +97,4 @@ export function assertMinimumCypressVersion(
       `Cypress version of ${minVersion} or higher is not installed. Expected Cypress v${minVersion}+, found Cypress v${version} instead.`
     );
   }
-}
-
-function getCypressVersionFromTree(tree: Tree): string | null {
-  const installedVersion = getDependencyVersionFromPackageJson(tree, 'cypress');
-
-  if (!installedVersion) {
-    return null;
-  }
-
-  if (installedVersion === 'latest' || installedVersion === 'next') {
-    return clean(cypressVersion) ?? coerce(cypressVersion)?.version;
-  }
-
-  return clean(installedVersion) ?? coerce(installedVersion)?.version;
-}
-
-function getCypressVersionFromFileSystem(): string | null {
-  let packageJson: PackageJson | undefined;
-  try {
-    packageJson = <PackageJson>require('cypress/package.json');
-  } catch {}
-
-  if (!packageJson) {
-    return null;
-  }
-
-  return packageJson.version;
 }

--- a/packages/nx/src/internal-testing-utils/assert-generators-enforce-version-floor.ts
+++ b/packages/nx/src/internal-testing-utils/assert-generators-enforce-version-floor.ts
@@ -12,12 +12,22 @@ export function assertGeneratorsEnforceVersionFloor(options: {
   packageRoot: string;
   packageName: string;
   subFloorVersion: string;
+  /**
+   * Generator names to skip from the floor-enforcement assertion. Use for
+   * generators whose purpose is to migrate sub-floor workspaces onto a
+   * supported version (these must run *below* the floor by design).
+   */
+  excludeGenerators?: string[];
 }): void {
-  const { packageRoot, packageName, subFloorVersion } = options;
+  const { packageRoot, packageName, subFloorVersion, excludeGenerators } =
+    options;
   const generatorsJson: GeneratorsJson = JSON.parse(
     readFileSync(join(packageRoot, 'generators.json'), 'utf-8')
   );
-  const entries = Object.entries(generatorsJson.generators ?? {});
+  const excludedSet = new Set(excludeGenerators ?? []);
+  const entries = Object.entries(generatorsJson.generators ?? {}).filter(
+    ([name]) => !excludedSet.has(name)
+  );
 
   it('has generators registered in generators.json', () => {
     expect(entries.length).toBeGreaterThan(0);


### PR DESCRIPTION
## Current Behavior

- `@nx/cypress` does not consistently enforce its declared supported Cypress version range across its generators. Generators run without verifying the installed Cypress version is at or above the supported floor, so sub-floor workspaces can silently land in an unsupported state.
- The init generator overwrites already-installed `cypress` versions on re-runs. The shared `add-linter` helper overwrites already-installed `eslint-plugin-cypress` pins.

## Expected Behavior

- Every generator entry point asserts the installed Cypress version is `>= 13.0.0` before executing. Sub-floor installs are surfaced with an actionable error. Above-known-ceiling installs fall through silently to the latest known install constants (matching the pattern used by `@nx/angular` and `@nx/playwright`), without throwing.
- Generators preserve user pins for both `cypress` (init) and `eslint-plugin-cypress` (configuration's linter helper).

## Implementation Details

- New `assertSupportedCypressVersion(tree)` wrapper around the shared `assertSupportedPackageVersion` devkit helper, called first in `init`, `configuration`, `component-configuration`, and `convert-to-inferred`.
- Parameterized floor spec (`all-generators-enforce-floor.spec.ts`) that asserts every entry in `generators.json` throws on a sub-floor install, with `migrate-to-cypress-11` explicitly excluded — that generator exists to migrate sub-floor (v8–v10) workspaces onto v11 and retains its bespoke `assertMinimumCypressVersion(8)` guard.
- The shared `assertGeneratorsEnforceVersionFloor` test helper gains an `excludeGenerators?: string[]` option for this kind of intentional sub-floor migrator (separate `cleanup(devkit)` commit).
- `versions()` no longer throws on unknown majors; below-floor is caught by the generator-level assert.
- `getInstalledCypressVersion`'s filesystem path now delegates to the shared `getInstalledPackageVersion` from `@nx/devkit/internal` for reliable resolution in pnpm strict mode and nested install layouts. The tree path stays inline because Cypress's "null on missing" semantics differ from the shared helper's fallback-on-missing.
- `init` flips its `keepExistingVersions` schema default to `true` and uses `options.keepExistingVersions ?? true` at the call site; `add-linter` passes `keepExistingVersions: true`. `configuration` and `component-configuration` already pass `true` and are unchanged. Migration generators are intentionally exempt — they exist to bump.