### PR TITLE
fix(vite): enforce multi-version support windows for @nx/vite and @nx/vitest

### DIFF
--- a/astro-docs/src/content/docs/technologies/build-tools/vite/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/vite/introduction.mdoc
@@ -25,6 +25,8 @@ The `@nx/vite` plugin supports the following package versions.
 | ------- | ------------------------------------------ |
 | `vite`  | ^5.0.0 \|\| ^6.0.0 \|\| ^7.0.0 \|\| ^8.0.0 |
 
+For supported `vitest` versions, see the [`@nx/vitest` plugin requirements](/docs/technologies/test-tools/vitest/introduction#requirements).
+
 [Nx generators](/docs/features/generate-code) install the latest supported versions automatically when scaffolding new projects.
 
 ## Setup

--- a/packages/vite/migrations.json
+++ b/packages/vite/migrations.json
@@ -12,11 +12,17 @@
     },
     "update-20-5-0-install-jiti": {
       "version": "20.5.0-beta.2",
+      "requires": {
+        "vite": ">=6.0.0"
+      },
       "description": "Install jiti as a devDependency to allow vite to parse TS postcss files.",
       "implementation": "./dist/src/migrations/update-20-5-0/install-jiti"
     },
     "update-20-5-0-update-resolve-conditions": {
       "version": "20.5.0-beta.3",
+      "requires": {
+        "vite": ">=6.0.0"
+      },
       "description": "Update resolve.conditions to include defaults that are no longer provided by Vite.",
       "implementation": "./dist/src/migrations/update-20-5-0/update-resolve-conditions"
     },
@@ -94,11 +100,22 @@
     },
     "20.5.0": {
       "version": "20.5.0-beta.3",
+      "requires": {
+        "vite": ">=5.0.0 <6.0.0"
+      },
       "packages": {
         "vite": {
           "version": "^6.0.0",
           "alwaysAddToPackageJson": false
-        },
+        }
+      }
+    },
+    "20.5.0-vite-plugin-dts": {
+      "version": "20.5.0-beta.3",
+      "requires": {
+        "vite-plugin-dts": ">=3.0.0 <4.0.0"
+      },
+      "packages": {
         "vite-plugin-dts": {
           "version": "~4.5.0",
           "alwaysAddToPackageJson": false
@@ -142,6 +159,9 @@
     },
     "21.5.0": {
       "version": "21.5.0-beta.0",
+      "requires": {
+        "vite": ">=6.0.0 <7.0.0"
+      },
       "packages": {
         "vite": {
           "version": "^7.1.3",
@@ -178,11 +198,22 @@
     },
     "22.2.0-analog": {
       "version": "22.2.0-beta.3",
+      "requires": {
+        "@analogjs/vite-plugin-angular": ">=1.0.0 <2.0.0"
+      },
       "packages": {
         "@analogjs/vite-plugin-angular": {
           "version": "~2.1.2",
           "alwaysAddToPackageJson": false
-        },
+        }
+      }
+    },
+    "22.2.0-analog-vitest-angular": {
+      "version": "22.2.0-beta.3",
+      "requires": {
+        "@analogjs/vitest-angular": ">=1.0.0 <2.0.0"
+      },
+      "packages": {
         "@analogjs/vitest-angular": {
           "version": "~2.1.2",
           "alwaysAddToPackageJson": false
@@ -191,6 +222,9 @@
     },
     "23.0.0": {
       "version": "23.0.0-beta.10",
+      "requires": {
+        "vite": ">=7.0.0 <8.0.0"
+      },
       "packages": {
         "vite": {
           "version": "^8.0.0",

--- a/packages/vite/migrations.json
+++ b/packages/vite/migrations.json
@@ -66,7 +66,7 @@
       "prompt": "./dist/src/migrations/update-23-0-0/ai-instructions-for-vite-8.md"
     },
     "migrate-to-vitest-3": {
-      "version": "23.0.0-beta.13",
+      "version": "23.0.0-beta.22",
       "requires": {
         "vitest": ">=3.0.0"
       },
@@ -75,7 +75,7 @@
       "prompt": "./dist/src/migrations/update-23-0-0/ai-instructions-for-vitest-3.md"
     },
     "migrate-to-vitest-4": {
-      "version": "23.0.0-beta.13",
+      "version": "23.0.0-beta.22",
       "requires": {
         "vitest": ">=4.0.0"
       },
@@ -240,7 +240,7 @@
       }
     },
     "23.0.0-vitest-v3-floor": {
-      "version": "23.0.0-beta.13",
+      "version": "23.0.0-beta.22",
       "requires": {
         "vitest": "<3.0.0"
       },
@@ -264,7 +264,7 @@
       }
     },
     "23.0.0-vitest-v4": {
-      "version": "23.0.0-beta.13",
+      "version": "23.0.0-beta.22",
       "requires": {
         "vitest": ">=3.0.0 <4.0.0"
       },

--- a/packages/vite/migrations.json
+++ b/packages/vite/migrations.json
@@ -59,20 +59,20 @@
       "description": "Create AI Instructions to help migrate users workspaces past breaking changes for Vite 8.",
       "prompt": "./dist/src/migrations/update-23-0-0/ai-instructions-for-vite-8.md"
     },
-    "create-ai-instructions-for-vitest-3": {
+    "migrate-to-vitest-3": {
       "version": "23.0.0-beta.13",
       "requires": {
         "vitest": ">=3.0.0"
       },
-      "description": "Provide AI Instructions to help migrate users workspaces past breaking changes for Vitest 3.",
+      "description": "Migrate workspaces past breaking changes for Vitest 3.",
       "prompt": "./src/migrations/update-23-0-0/ai-instructions-for-vitest-3.md"
     },
-    "create-ai-instructions-for-vitest-4": {
+    "migrate-to-vitest-4": {
       "version": "23.0.0-beta.13",
       "requires": {
         "vitest": ">=4.0.0"
       },
-      "description": "Provide AI Instructions to help migrate users workspaces past breaking changes for Vitest 4.",
+      "description": "Migrate workspaces past breaking changes for Vitest 4.",
       "prompt": "./src/migrations/update-23-0-0/ai-instructions-for-vitest-4.md"
     }
   },

--- a/packages/vite/migrations.json
+++ b/packages/vite/migrations.json
@@ -58,6 +58,22 @@
       },
       "description": "Create AI Instructions to help migrate users workspaces past breaking changes for Vite 8.",
       "prompt": "./dist/src/migrations/update-23-0-0/ai-instructions-for-vite-8.md"
+    },
+    "create-ai-instructions-for-vitest-3": {
+      "version": "23.0.0-beta.13",
+      "requires": {
+        "vitest": ">=3.0.0"
+      },
+      "description": "Provide AI Instructions to help migrate users workspaces past breaking changes for Vitest 3.",
+      "prompt": "./src/migrations/update-23-0-0/ai-instructions-for-vitest-3.md"
+    },
+    "create-ai-instructions-for-vitest-4": {
+      "version": "23.0.0-beta.13",
+      "requires": {
+        "vitest": ">=4.0.0"
+      },
+      "description": "Provide AI Instructions to help migrate users workspaces past breaking changes for Vitest 4.",
+      "prompt": "./src/migrations/update-23-0-0/ai-instructions-for-vitest-4.md"
     }
   },
   "packageJsonUpdates": {
@@ -185,6 +201,54 @@
       },
       "incompatibleWith": {
         "@remix-run/dev": "*"
+      }
+    },
+    "23.0.0-vitest-v3-floor": {
+      "version": "23.0.0-beta.13",
+      "requires": {
+        "vitest": "<3.0.0"
+      },
+      "packages": {
+        "vitest": {
+          "version": "^3.0.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@vitest/coverage-v8": {
+          "version": "^3.0.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@vitest/coverage-istanbul": {
+          "version": "^3.0.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@vitest/ui": {
+          "version": "^3.0.0",
+          "alwaysAddToPackageJson": false
+        }
+      }
+    },
+    "23.0.0-vitest-v4": {
+      "version": "23.0.0-beta.13",
+      "requires": {
+        "vitest": ">=3.0.0 <4.0.0"
+      },
+      "packages": {
+        "vitest": {
+          "version": "^4.0.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@vitest/coverage-v8": {
+          "version": "^4.0.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@vitest/coverage-istanbul": {
+          "version": "^4.0.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@vitest/ui": {
+          "version": "^4.0.0",
+          "alwaysAddToPackageJson": false
+        }
       }
     }
   }

--- a/packages/vite/migrations.json
+++ b/packages/vite/migrations.json
@@ -65,6 +65,7 @@
         "vitest": ">=3.0.0"
       },
       "description": "Migrate workspaces past breaking changes for Vitest 3.",
+      "implementation": "./src/migrations/update-23-0-0/migrate-to-vitest-3",
       "prompt": "./src/migrations/update-23-0-0/ai-instructions-for-vitest-3.md"
     },
     "migrate-to-vitest-4": {

--- a/packages/vite/migrations.json
+++ b/packages/vite/migrations.json
@@ -65,8 +65,8 @@
         "vitest": ">=3.0.0"
       },
       "description": "Migrate workspaces past breaking changes for Vitest 3.",
-      "implementation": "./src/migrations/update-23-0-0/migrate-to-vitest-3",
-      "prompt": "./src/migrations/update-23-0-0/ai-instructions-for-vitest-3.md"
+      "implementation": "./dist/src/migrations/update-23-0-0/migrate-to-vitest-3",
+      "prompt": "./dist/src/migrations/update-23-0-0/ai-instructions-for-vitest-3.md"
     },
     "migrate-to-vitest-4": {
       "version": "23.0.0-beta.13",
@@ -74,7 +74,8 @@
         "vitest": ">=4.0.0"
       },
       "description": "Migrate workspaces past breaking changes for Vitest 4.",
-      "prompt": "./src/migrations/update-23-0-0/ai-instructions-for-vitest-4.md"
+      "implementation": "./dist/src/migrations/update-23-0-0/migrate-to-vitest-4",
+      "prompt": "./dist/src/migrations/update-23-0-0/ai-instructions-for-vitest-4.md"
     }
   },
   "packageJsonUpdates": {

--- a/packages/vite/src/generators/configuration/configuration.ts
+++ b/packages/vite/src/generators/configuration/configuration.ts
@@ -24,6 +24,7 @@ import {
 import { join } from 'node:path/posix';
 import type { PackageJson } from 'nx/src/utils/package-json';
 import { ensureDependencies } from '../../utils/ensure-dependencies';
+import { assertSupportedViteVersion } from '../../utils/assert-supported-vite-version';
 import { warnViteExecutorGenerating } from '../../utils/deprecation';
 import {
   addBuildTarget,
@@ -51,6 +52,8 @@ export async function viteConfigurationGeneratorInternal(
   tree: Tree,
   schema: ViteConfigurationGeneratorSchema
 ) {
+  assertSupportedViteVersion(tree);
+
   const tasks: GeneratorCallback[] = [];
 
   const projectConfig = readProjectConfiguration(tree, schema.project);

--- a/packages/vite/src/generators/convert-to-inferred/convert-to-inferred.ts
+++ b/packages/vite/src/generators/convert-to-inferred/convert-to-inferred.ts
@@ -8,6 +8,7 @@ import { createNodesV2, VitePluginOptions } from '../../plugins/plugin';
 import { buildPostTargetTransformer } from './lib/build-post-target-transformer';
 import { servePostTargetTransformer } from './lib/serve-post-target-transformer';
 import { previewPostTargetTransformer } from './lib/preview-post-target-transformer';
+import { assertSupportedViteVersion } from '../../utils/assert-supported-vite-version';
 
 interface Schema {
   project?: string;
@@ -15,6 +16,8 @@ interface Schema {
 }
 
 export async function convertToInferred(tree: Tree, options: Schema) {
+  assertSupportedViteVersion(tree);
+
   const projectGraph = await createProjectGraphAsync();
   const migrationLogs = new AggregatedLog();
 

--- a/packages/vite/src/generators/init/init.ts
+++ b/packages/vite/src/generators/init/init.ts
@@ -14,6 +14,7 @@ import { createNodesV2 } from '../../plugins/plugin';
 import { InitGeneratorSchema } from './schema';
 import { checkDependenciesInstalled, moveToDevDependencies } from './lib/utils';
 import { ignoreViteTempFiles } from '../../utils/ignore-vite-temp-files';
+import { assertSupportedViteVersion } from '../../utils/assert-supported-vite-version';
 
 export function updateNxJsonSettings(tree: Tree) {
   const nxJson = readNxJson(tree);
@@ -40,6 +41,8 @@ export async function initGeneratorInternal(
   tree: Tree,
   schema: InitGeneratorSchema
 ) {
+  assertSupportedViteVersion(tree);
+
   const nxJson = readNxJson(tree);
   const addPluginDefault =
     process.env.NX_ADD_PLUGINS !== 'false' &&

--- a/packages/vite/src/generators/init/lib/utils.ts
+++ b/packages/vite/src/generators/init/lib/utils.ts
@@ -89,7 +89,7 @@ export async function checkDependenciesInstalled(
       jiti: jitiVersion,
     },
     undefined,
-    schema.keepExistingVersions
+    schema.keepExistingVersions ?? true
   );
 }
 

--- a/packages/vite/src/generators/init/schema.json
+++ b/packages/vite/src/generators/init/schema.json
@@ -24,7 +24,7 @@
       "type": "boolean",
       "x-priority": "internal",
       "description": "Keep existing dependencies versions",
-      "default": false
+      "default": true
     },
     "updatePackageScripts": {
       "type": "boolean",

--- a/packages/vite/src/generators/setup-paths-plugin/setup-paths-plugin.ts
+++ b/packages/vite/src/generators/setup-paths-plugin/setup-paths-plugin.ts
@@ -6,11 +6,14 @@ import {
   Tree,
 } from '@nx/devkit';
 import type { ArrayLiteralExpression, Node } from 'typescript';
+import { assertSupportedViteVersion } from '../../utils/assert-supported-vite-version';
 
 export async function setupPathsPlugin(
   tree: Tree,
   schema: { skipFormat?: boolean }
 ) {
+  assertSupportedViteVersion(tree);
+
   const files = await globAsync(tree, [
     '**/vite.config.{js,ts,mjs,mts,cjs,cts}',
   ]);

--- a/packages/vite/src/migrations/update-23-0-0/ai-instructions-for-vitest-3.md
+++ b/packages/vite/src/migrations/update-23-0-0/ai-instructions-for-vitest-3.md
@@ -9,7 +9,18 @@ These instructions guide you through migrating an Nx workspace containing multip
 
 Work systematically through each breaking change category.
 
-> **Note**: a deterministic pre-pass has already run before these instructions. It applied the AST-tractable subset of the changes below (e.g. `browser.provider: 'none'` → `'preview'`, `browser.indexScripts` → `orchestratorScripts`, `@vitest/coverage-c8` → `@vitest/coverage-v8`, `SnapshotEnvironment` import path, `--segfault-retry` removal, `vitest typecheck` → `vitest --typecheck`). Anything it could not handle was forwarded as advisory context (look for "Context from the generator phase" above). Skip the corresponding action items below if the pre-pass already covered them; verify the change is present rather than re-applying.
+> **Pre-pass already ran**: a deterministic generator ran before these instructions. It only handles a narrow set of purely-mechanical changes:
+>
+> - `--segfault-retry` removal from `package.json` scripts
+> - `@vitest/coverage-c8` → `@vitest/coverage-v8` package rename (preserving the user's pin)
+> - `vitest typecheck` → `vitest --typecheck` in scripts
+> - `SnapshotEnvironment` import path `'vitest'` → `'vitest/snapshot'` (only when it is the sole named binding)
+> - `browser.provider: 'none'` → `'preview'`
+> - `browser.indexScripts` → `orchestratorScripts`
+>
+> **The vast majority of action items below are NOT covered by the pre-pass** and still require your attention — every section other than the six items above.
+>
+> If a "Files modified by the generator phase" section appears in the prompt above, those files received the items the pre-pass handled — verify the new shape is in place before re-applying. If a "Context from the generator phase" section appears, **every entry there is pending work** the pre-pass detected but could not safely complete: address each one in addition to the relevant section below.
 
 ## Pre-Migration Checklist
 

--- a/packages/vite/src/migrations/update-23-0-0/ai-instructions-for-vitest-3.md
+++ b/packages/vite/src/migrations/update-23-0-0/ai-instructions-for-vitest-3.md
@@ -9,20 +9,31 @@ These instructions guide you through migrating an Nx workspace containing multip
 
 Work systematically through each breaking change category.
 
-> **Pre-pass already ran**: a deterministic generator ran before these instructions. It only handles a narrow set of purely-mechanical changes:
->
-> - `--segfault-retry` removal from `package.json` scripts AND `project.json` `options.{args,command,commands}`
-> - `@vitest/coverage-c8` → `@vitest/coverage-v8` package rename (preserving the user's pin)
-> - `vitest typecheck` → `vitest --typecheck` in `package.json` scripts AND `project.json` `options.{args,command,commands}`
-> - `SnapshotEnvironment` import path `'vitest'` → `'vitest/snapshot'` (only when it is the sole named binding)
-> - `browser.provider: 'none'` → `'preview'` (only when the value is a direct string literal under `test.browser.provider`)
-> - `browser.indexScripts` → `orchestratorScripts` (only as a direct property name)
->
-> The pre-pass **does not** edit CI provider configs (`.github/workflows/*.yml`, `.gitlab-ci.yml`, `azure-pipelines.yml`, `.circleci/config.yml`, `bitbucket-pipelines.yml`) — YAML structure varies too much. Any matches it finds there are forwarded to you to handle.
->
-> **The vast majority of action items below are NOT covered by the pre-pass** and still require your attention — every section other than the six items above.
->
-> If a "Files modified by the generator phase" section appears in the prompt above, those files received the items the pre-pass handled — verify the new shape is in place before re-applying. If a "Context from the generator phase" section appears, **every entry there is pending work** the pre-pass detected but could not safely complete: address each one in addition to the relevant section below.
+<pre_pass_summary note="a deterministic pre-pass already applied these specific edits; verify the new shape is in place rather than redoing them">
+
+The pre-pass handled, mechanically:
+
+- `--segfault-retry` removal from `package.json` scripts AND `project.json` `options.{args,command,commands}`
+- `@vitest/coverage-c8` → `@vitest/coverage-v8` package rename (preserving the user's pin)
+- `vitest typecheck` → `vitest --typecheck` in `package.json` scripts AND `project.json` `options.{args,command,commands}`
+- `SnapshotEnvironment` import path `'vitest'` → `'vitest/snapshot'` (only when it is the sole named binding)
+- `browser.provider: 'none'` → `'preview'` (only when the value is a direct string literal under `test.browser.provider`)
+- `browser.indexScripts` → `orchestratorScripts` (only as a direct property name)
+
+The pre-pass **does not** edit CI provider configs (`.github/workflows/*.yml`, `.gitlab-ci.yml`, `azure-pipelines.yml`, `.circleci/config.yml`, `bitbucket-pipelines.yml`) — YAML structure varies too much. Any matches it finds there are forwarded to you in `<advisory_context>`.
+
+**The vast majority of action items below are NOT covered by the pre-pass** and still require your attention — every section other than the six items above.
+
+How to read the wrapper sections above this file:
+
+- `<files_changed>` lists files the pre-pass already wrote to. Verify the new shape is in place; do not re-apply the same edit.
+- `<advisory_context>` lists detections the pre-pass forwarded because it could not safely complete them. **Every entry is pending work** — address each one in the relevant section below, not as a separate task.
+
+</pre_pass_summary>
+
+<handoff_guidance>
+In your handoff `summary` (1–3 sentences per the system prompt), name the breaking-change categories you applied; explicitly call out any you skipped because they didn't apply (e.g., "no browser-mode configs in this workspace").
+</handoff_guidance>
 
 ## Pre-Migration Checklist
 
@@ -97,6 +108,10 @@ export default defineConfig({
 - [ ] If a project relied on the implicit pool, decide whether to keep `threads` (set `pool: 'threads'` explicitly) or move options to `forks`.
 - [ ] Migrate `poolOptions.threads.singleThread` → `poolOptions.forks.singleFork` if switching.
 - [ ] Migrate `poolOptions.threads.maxThreads/minThreads` → `poolOptions.forks.maxForks/minForks` if switching.
+
+<fail_if note="this decision changes runtime semantics; if you can't determine the project's intent from the workspace, write status: failed and explain in summary">
+You cannot determine whether the workspace intended the v1.x implicit-`threads` behavior (e.g., the codebase uses worker-only APIs like `SharedArrayBuffer`) or expected the v2.x `forks` default. Do not guess.
+</fail_if>
 
 ### 1.2 Hook Execution Order: Now Serial (and Reverse for `after*`)
 
@@ -186,6 +201,10 @@ export default defineConfig({
 
 - [ ] Move every `test.watchExclude` entry to `server.watch.ignored`, adjusting pattern syntax to chokidar conventions.
 - [ ] Remove `watchExclude` from `vitest.config.*`.
+
+<fail_if note="pattern semantics differ between the two options; a blind copy can over- or under-ignore files">
+An existing `watchExclude` entry uses a pattern whose chokidar equivalent is ambiguous (e.g., a relative path without `**` wrapping, an entry that may need both `**/foo/**` and `foo/**`). Write status: failed with the specific patterns you're unsure about; the user should decide.
+</fail_if>
 
 ### 1.6 `--segfault-retry` CLI Flag Removed
 
@@ -554,31 +573,28 @@ export default defineConfig({
 
 ## Post-Migration Verification
 
-1. **Reinstall and rebuild**:
+1. Reinstall: `pnpm install` (or `npm install` / `yarn install`)
+2. Run affected tests: `nx affected -t test`
+3. Re-baseline coverage on key projects: `nx run <project>:test --coverage`
+4. Typecheck custom reporters / sequencers / snapshot tooling: `nx affected -t typecheck`
+5. Watch mode (if applicable): verify `server.watch.ignored` covers what `watchExclude` previously did.
 
-   ```bash
-   pnpm install # or npm install / yarn install
-   ```
+Confirm:
 
-2. **Run affected tests**:
+- All configuration files updated
+- All test files pass (or are flagged in your handoff `summary` if they remain failing — see `<test_integrity_guardrails>` below)
+- Coverage reports generate correctly
+- No deprecated API warnings in console
 
-   ```bash
-   nx affected -t test
-   ```
+<test_integrity_guardrails note="violating any of these masks regressions and defeats the migration's purpose">
 
-3. **Run coverage on key projects** to validate threshold drift:
+- Do NOT force tests to pass by replacing test logic with `expect(true).toBe(true)`.
+- Do NOT remove assertions to silence a failure.
+- Do NOT add mocks that exist solely to make a failing test pass.
 
-   ```bash
-   nx run my-project:test --coverage
-   ```
+If a test cannot be made to pass within the scope of this migration, leave it failing and report it in your handoff `summary`.
 
-4. **Check that custom reporters / sequencers / snapshot tooling** still type-check:
-
-   ```bash
-   nx affected -t typecheck
-   ```
-
-5. **Watch mode**: verify `server.watch.ignored` covers what `watchExclude` previously did (if applicable).
+</test_integrity_guardrails>
 
 ## References
 

--- a/packages/vite/src/migrations/update-23-0-0/ai-instructions-for-vitest-3.md
+++ b/packages/vite/src/migrations/update-23-0-0/ai-instructions-for-vitest-3.md
@@ -25,8 +25,9 @@ Work systematically through each breaking change category.
 
 3. **Locate all Vitest configuration files**:
    - Search for `vitest.config.{ts,js,mjs}`
-   - Search for `vitest.workspace.{ts,js,mjs}` (no longer supported in newer Vitest — see workspace section below)
-   - Check `project.json` files for inline Vitest configuration
+   - Search for `vitest.workspace.{ts,js,mjs}` (deprecated in Vitest 3.2 — see "v3.2 Workspace File Deprecation" below)
+   - Check `project.json` files for `@nx/vitest:test` / `@nx/vite:test` executor options
+   - For workspaces relying on the inferred plugin (`@nx/vitest/plugin`), targets come from inference — inspect them with `nx show project <name> --json | jq .targets`
 
 4. **Identify affected code**:
    - Test files: `**/*.{spec,test}.{ts,js,tsx,jsx}`
@@ -34,6 +35,15 @@ Work systematically through each breaking change category.
    - Coverage configuration references
    - Browser mode configurations
    - Custom reporters, sequencers, and snapshot-related imports
+
+---
+
+## Nx-Specific Notes (read first)
+
+- **Inferred plugin targets**: modern Nx workspaces use `@nx/vitest/plugin` (or `@nx/vite/plugin` historically) to _infer_ the test target from the presence of a `vitest.config.*` file. `project.json` may have no `test` target at all. Renaming or moving `vitest.config.*` invalidates inference. After config edits, run `nx reset && nx show project <name>` on a sample project to confirm the target is still present.
+- **Shared base config pattern**: many Nx workspaces extend a workspace-root `vitest.config.base.ts` via `mergeConfig`. Apply transforms to the BASE config first, then per-project overrides. Otherwise a migrated base may conflict with un-migrated children.
+- **Angular projects using AnalogJS** (`@analogjs/vitest-angular`, `@analogjs/vite-plugin-angular`): the Analog packages are bumped automatically by Nx's `packageJsonUpdates`. Review the Analog-specific setup file (typically `src/test-setup.ts`) and any plugin invocations in the per-project `vitest.config.ts` for changes between Analog `~1.x` and `~2.x` lines.
+- **CI configuration**: when `@nx/vitest/plugin` is configured with `ciTargetName`, per-test-file targets are inferred — your `.github/workflows/*.yml` doesn't need direct reporter changes. CI-side reporter config matters only if you bypass the plugin.
 
 ---
 
@@ -151,9 +161,15 @@ export default defineConfig({
 });
 ```
 
+**Pattern Semantics Note**: `server.watch.ignored` uses **chokidar** patterns, while Vitest 1.x's `watchExclude` accepted simpler relative-path matchers. A literal find-and-replace may over- or under-ignore. Treat each entry as manual review:
+
+- A bare directory name like `'node_modules'` typically needs `'**/node_modules/**'` to match nested occurrences.
+- Glob patterns ending in `/**` are usually portable as-is.
+- After the rewrite, verify watch mode picks up the right files with `nx test <project> --watch`.
+
 **Action Items**:
 
-- [ ] Move every `test.watchExclude` entry to `server.watch.ignored`.
+- [ ] Move every `test.watchExclude` entry to `server.watch.ignored`, adjusting pattern syntax to chokidar conventions.
 - [ ] Remove `watchExclude` from `vitest.config.*`.
 
 ### 1.6 `--segfault-retry` CLI Flag Removed
@@ -285,7 +301,7 @@ A numeric timeout value as the third argument is still accepted (`test('name', (
 
 **Search Pattern**: `browser.name`, `browser.providerOptions` in `vitest.config.*`
 
-**What Changed**: `browser.name` and `browser.providerOptions` are deprecated. Use `browser.instances` instead.
+**What Changed**: `browser.name` and `browser.providerOptions` are **deprecated in v3** (still work, emit warnings) and **removed in v4**. Use `browser.instances` instead. Migrating now silences the v3 warnings and is required before reaching v4.
 
 ```typescript
 // ❌ BEFORE (Vitest 2.x)
@@ -365,7 +381,7 @@ vi.isMockFunction(fooService.foo);
 
 **Search Pattern**: `vi.useFakeTimers()` usages and `fakeTimers.toFake` config
 
-**What Changed**: Vitest no longer ships default `fakeTimers.toFake` values. All timer-related globals (including `performance.now()`) are mocked, except `nextTick`.
+**What Changed**: Vitest now mocks **all** timer-related APIs by default (the previously-restricted built-in subset is gone). This includes `performance.now()`. Only `nextTick` is left unmocked. To restore the prior, narrower subset, configure `fakeTimers.toFake` explicitly.
 
 ```typescript
 // To restore the prior subset:
@@ -443,7 +459,7 @@ expect(() => {
 
 **Action Items**:
 
-- [ ] Replace `import { Custom } from 'vitest'` with `import { RunnerCustomCase, RunnerTestCase } from 'vitest'`.
+- [ ] Replace `import { Custom } from 'vitest'`: most usages should become `RunnerTestCase` (the regular test case type — `Custom` was an alias for `Test`). Only use `RunnerCustomCase` if the workspace explicitly creates tasks via `getCurrentSuite().custom()`.
 - [ ] Replace `WorkspaceSpec` references with `TestSpecification`.
 
 ### 2.10 `resolveConfig()` API Shape Changed
@@ -486,6 +502,39 @@ expect(() => {
 
 - [ ] Most workspaces have nothing to do here. If you maintain custom snapshot tooling against `@vitest/snapshot`, review your usage against the v3 API.
 
+### 2.14 Workspace → Projects (v3.2 option rename, v4 file removal)
+
+**Applies when**: Workspace has `vitest.workspace.{ts,js,mjs}` files, uses `defineWorkspace`, or has `test.workspace` set in `vitest.config.*`.
+
+**What Changed**:
+
+- **Vitest 3.2**: introduced `test.projects` as the config option, with `test.workspace` deprecated in favor of it (the option emits a deprecation warning).
+- **Vitest 4**: the external file form (`vitest.workspace.*` + `defineWorkspace`) is **removed entirely**. Projects must be inlined in the root `vitest.config.*`.
+
+Migrating now (while still on v3) clears the v3.2 deprecation warning and is required before reaching v4.
+
+```typescript
+// ❌ DEPRECATED (Vitest 3.2+)
+// vitest.workspace.ts
+import { defineWorkspace } from 'vitest/config';
+export default defineWorkspace(['apps/*', 'libs/*']);
+
+// ✅ AFTER (inline in root vitest.config.ts)
+import { defineConfig } from 'vitest/config';
+export default defineConfig({
+  test: {
+    projects: ['apps/*', 'libs/*'],
+  },
+});
+```
+
+**Action Items**:
+
+- [ ] Move project list from `vitest.workspace.*` into `test.projects` in the root `vitest.config.*`.
+- [ ] Delete the `vitest.workspace.*` file once migration is complete.
+- [ ] If you import `defineWorkspace` anywhere, replace with `defineConfig` and the inlined shape above.
+- [ ] If you continue to Vitest 4, this step is required, not optional.
+
 ---
 
 ## Post-Migration Verification
@@ -520,4 +569,5 @@ expect(() => {
 
 - Vitest 2.0 migration guide: https://v2.vitest.dev/guide/migration
 - Vitest 3.0 migration guide: https://v3.vitest.dev/guide/migration
+- Vitest 4.0 migration guide (for cascading bumps): https://vitest.dev/guide/migration
 - Vitest releases: https://github.com/vitest-dev/vitest/releases

--- a/packages/vite/src/migrations/update-23-0-0/ai-instructions-for-vitest-3.md
+++ b/packages/vite/src/migrations/update-23-0-0/ai-instructions-for-vitest-3.md
@@ -1,0 +1,523 @@
+# Vitest 3.0 Migration Instructions for LLM
+
+## Overview
+
+These instructions guide you through migrating an Nx workspace containing multiple Vitest projects to Vitest 3.0. The workspace may currently be on Vitest 1.x or Vitest 2.x. This guide covers breaking changes for both upgrade paths:
+
+- **From Vitest 1.x**: apply BOTH the "Vitest 1.x → 2.0" and "Vitest 2.x → 3.0" sections below.
+- **From Vitest 2.x**: apply only the "Vitest 2.x → 3.0" section.
+
+Work systematically through each breaking change category.
+
+## Pre-Migration Checklist
+
+1. **Identify the current Vitest version**:
+
+   ```bash
+   npx vitest --version
+   ```
+
+2. **Identify all Vitest projects**:
+
+   ```bash
+   nx show projects --with-target test
+   ```
+
+3. **Locate all Vitest configuration files**:
+   - Search for `vitest.config.{ts,js,mjs}`
+   - Search for `vitest.workspace.{ts,js,mjs}` (no longer supported in newer Vitest — see workspace section below)
+   - Check `project.json` files for inline Vitest configuration
+
+4. **Identify affected code**:
+   - Test files: `**/*.{spec,test}.{ts,js,tsx,jsx}`
+   - Mock usage: files using `vi.fn()`, `vi.spyOn()`, `vi.mock()`, `vi.useFakeTimers()`
+   - Coverage configuration references
+   - Browser mode configurations
+   - Custom reporters, sequencers, and snapshot-related imports
+
+---
+
+## Vitest 1.x → 2.0 Breaking Changes
+
+Skip this section if your workspace is already on Vitest 2.x.
+
+### 1.1 Default Pool Changed from `threads` to `forks`
+
+**Search Pattern**: `poolOptions` in all `vitest.config.*` files
+
+**What Changed**: The default `pool` switched from `threads` to `forks` for improved stability. Existing `poolOptions.threads` configurations now apply to the non-default pool unless `pool` is explicitly set.
+
+```typescript
+// ❌ BEFORE (Vitest 1.x — relying on implicit `threads` default)
+export default defineConfig({
+  test: {
+    poolOptions: {
+      threads: { singleThread: true },
+    },
+  },
+});
+
+// ✅ AFTER (Vitest 2.0 — either explicitly set the pool or move options to `forks`)
+export default defineConfig({
+  test: {
+    poolOptions: {
+      forks: { singleFork: true },
+    },
+  },
+});
+```
+
+**Action Items**:
+
+- [ ] If a project relied on the implicit pool, decide whether to keep `threads` (set `pool: 'threads'` explicitly) or move options to `forks`.
+- [ ] Migrate `poolOptions.threads.singleThread` → `poolOptions.forks.singleFork` if switching.
+- [ ] Migrate `poolOptions.threads.maxThreads/minThreads` → `poolOptions.forks.maxForks/minForks` if switching.
+
+### 1.2 Hook Execution Order: Now Serial (and Reverse for `after*`)
+
+**Search Pattern**: `beforeAll`, `beforeEach`, `afterAll`, `afterEach` usages relying on parallel execution
+
+**What Changed**: Hooks moved from parallel to serial execution. `afterAll`/`afterEach` now run in reverse declaration order. Tests relying on parallel hook side effects or specific teardown ordering may break.
+
+```typescript
+// To revert to parallel behavior:
+export default defineConfig({
+  test: {
+    sequence: {
+      hooks: 'parallel',
+    },
+  },
+});
+```
+
+**Action Items**:
+
+- [ ] Audit hooks that mutate shared state — they now execute sequentially in declaration order.
+- [ ] Audit `afterAll`/`afterEach` hooks that depend on registration order; their order is now reversed.
+- [ ] Add `sequence.hooks: 'parallel'` only if you cannot otherwise resolve hook-order dependencies.
+
+### 1.3 Concurrent Suites Now Run All Tests Concurrently
+
+**Search Pattern**: `describe.concurrent`, `suite.concurrent`
+
+**What Changed**: Declaring `concurrent` on a suite now runs all its tests concurrently (Jest-aligned) instead of grouping by suite. Bound by `maxConcurrency`.
+
+**Action Items**:
+
+- [ ] Review concurrent suites for shared mutable state that previously serialized through suite grouping.
+- [ ] Adjust `maxConcurrency` if needed.
+
+### 1.4 V8 Coverage: `ignoreEmptyLines` On by Default
+
+**Search Pattern**: `coverage` configuration in `vitest.config.*` (V8 provider)
+
+**What Changed**: `coverage.ignoreEmptyLines` defaults to `true`. Coverage thresholds may shift.
+
+```typescript
+// To restore the previous behavior:
+export default defineConfig({
+  test: {
+    coverage: {
+      ignoreEmptyLines: false,
+    },
+  },
+});
+```
+
+**Action Items**:
+
+- [ ] Re-baseline V8 coverage thresholds if they exist.
+- [ ] Set `coverage.ignoreEmptyLines: false` only if you need the prior numbers exactly.
+
+### 1.5 `watchExclude` Option Removed
+
+**Search Pattern**: `watchExclude` in `vitest.config.*`
+
+```typescript
+// ❌ BEFORE (Vitest 1.x)
+export default defineConfig({
+  test: {
+    watchExclude: ['node_modules', 'custom/path/**'],
+  },
+});
+
+// ✅ AFTER (Vitest 2.0)
+export default defineConfig({
+  server: {
+    watch: {
+      ignored: ['**/node_modules/**', 'custom/path/**'],
+    },
+  },
+});
+```
+
+**Action Items**:
+
+- [ ] Move every `test.watchExclude` entry to `server.watch.ignored`.
+- [ ] Remove `watchExclude` from `vitest.config.*`.
+
+### 1.6 `--segfault-retry` CLI Flag Removed
+
+**What Changed**: The CLI flag was removed; the underlying issue is fixed by switching to the `forks` pool (now the default).
+
+**Action Items**:
+
+- [ ] Remove `--segfault-retry` from scripts, `project.json` test target options, and CI configuration.
+
+### 1.7 Task API: `.suite` Now Optional, `.testPath` Required
+
+**Search Pattern**: Custom reporters and tooling that traverse the task tree
+
+**What Changed**: Top-level task `.suite` is now optional. Use `.file` (available on all tasks) instead. `expect.getState().testPath` is now always populated; `expect.getState().currentTestName` no longer includes the file name.
+
+**Action Items**:
+
+- [ ] In custom reporters / utilities, replace `.suite` chains with `.file` where the top-level task could be a file root.
+- [ ] If you parsed file names out of `currentTestName`, switch to `testPath`.
+
+### 1.8 JSON Reporter Now Includes `task.meta`
+
+**What Changed**: Output shape gained `task.meta` per assertion result.
+
+**Action Items**:
+
+- [ ] If you ingest the JSON reporter output, accept the new `task.meta` field (additive — most consumers will be unaffected).
+
+### 1.9 Mock Generic Types Simplified
+
+**Search Pattern**: `vi.fn<...>(...)`, `Mock<...>`
+
+```typescript
+// ❌ BEFORE (Vitest 1.x)
+import { type Mock, vi } from 'vitest';
+
+const add = (x: number, y: number): number => x + y;
+
+const mockAdd = vi.fn<Parameters<typeof add>, ReturnType<typeof add>>();
+const mockAdd2: Mock<Parameters<typeof add>, ReturnType<typeof add>> = vi.fn();
+
+// ✅ AFTER (Vitest 2.0)
+const mockAdd = vi.fn<typeof add>();
+const mockAdd2: Mock<typeof add> = vi.fn();
+```
+
+**Action Items**:
+
+- [ ] Replace two-generic `vi.fn<Args, Return>()` with single-generic `vi.fn<typeof fn>()` everywhere.
+- [ ] Replace two-generic `Mock<Args, Return>` with single-generic `Mock<typeof fn>` everywhere.
+
+### 1.10 `mock.results` No Longer Auto-Resolves Promises
+
+**Search Pattern**: `.mock.results` accesses on async mocks
+
+**What Changed**: For mocks returning Promises, `mock.results` now contains the Promise itself. Use the new `mock.settledResults` for resolved values.
+
+```typescript
+// ❌ BEFORE (Vitest 1.x)
+const fn = vi.fn().mockResolvedValueOnce('result');
+await fn();
+const result = fn.mock.results[0]; // 'result' (auto-resolved)
+
+// ✅ AFTER (Vitest 2.0)
+const result = fn.mock.results[0]; // a Promise
+const settled = fn.mock.settledResults[0]; // 'result'
+```
+
+**Action Items**:
+
+- [ ] Replace `.mock.results[i]` reads with `.mock.settledResults[i]` for promise-returning mocks.
+- [ ] Consider switching assertions to the new `toHaveResolved*` matchers where appropriate.
+
+### 1.11 Browser Mode Renames
+
+**Search Pattern**: `browser.provider`, `browser.indexScripts` in `vitest.config.*`
+
+**What Changed**: The `none` provider was renamed to `preview` and is now the default. `indexScripts` was renamed to `orchestratorScripts`.
+
+**Action Items**:
+
+- [ ] Rename `browser.provider: 'none'` → `browser.provider: 'preview'`.
+- [ ] Rename `browser.indexScripts` → `browser.orchestratorScripts`.
+
+### 1.12 Deprecated APIs Fully Removed in 2.0
+
+**Action Items**:
+
+- [ ] Replace `vitest typecheck` command usages with `vitest --typecheck`.
+- [ ] Remove `VITEST_JUNIT_CLASSNAME` and `VITEST_JUNIT_SUITE_NAME` env vars; move equivalent values into JUnit reporter options.
+- [ ] If you import `SnapshotEnvironment`, change the import path from `vitest` to `vitest/snapshot`.
+- [ ] Replace any `SpyInstance` type imports with `MockInstance`.
+- [ ] If you still configure `c8` as a coverage provider, switch to `v8` (`@vitest/coverage-v8`).
+
+---
+
+## Vitest 2.x → 3.0 Breaking Changes
+
+### 2.1 Test Options Argument Position
+
+**Search Pattern**: `test('name', () => {...}, { ... })`, `describe('name', () => {...}, { ... })`
+
+**What Changed**: Test/describe options objects must now be passed as the **second** argument, not the third.
+
+```typescript
+// ❌ BEFORE (Vitest 2.x)
+test(
+  'validation works',
+  () => {
+    /* ... */
+  },
+  { retry: 3 }
+);
+
+// ✅ AFTER (Vitest 3.0)
+test('validation works', { retry: 3 }, () => {
+  /* ... */
+});
+```
+
+A numeric timeout value as the third argument is still accepted (`test('name', () => {}, 1000)`).
+
+**Action Items**:
+
+- [ ] Move every options-object argument from third to second position in `test`, `it`, `describe`, and their variants (`.skip`, `.only`, `.each`, etc.).
+
+### 2.2 Browser Configuration: `browser.instances`
+
+**Search Pattern**: `browser.name`, `browser.providerOptions` in `vitest.config.*`
+
+**What Changed**: `browser.name` and `browser.providerOptions` are deprecated. Use `browser.instances` instead.
+
+```typescript
+// ❌ BEFORE (Vitest 2.x)
+export default defineConfig({
+  test: {
+    browser: {
+      name: 'chromium',
+      providerOptions: {
+        launch: { devtools: true },
+      },
+    },
+  },
+});
+
+// ✅ AFTER (Vitest 3.0)
+export default defineConfig({
+  test: {
+    browser: {
+      instances: [
+        {
+          browser: 'chromium',
+          launch: { devtools: true },
+        },
+      ],
+    },
+  },
+});
+```
+
+**Action Items**:
+
+- [ ] Collapse `browser.name` + `browser.providerOptions` into a single entry in `browser.instances`.
+- [ ] Remove `browser.name` and `browser.providerOptions`.
+
+### 2.3 `mockReset()` Restores Original Implementation
+
+**Search Pattern**: `.mockReset()`, `mockReset: true` in `vitest.config.*`
+
+**What Changed**: `spy.mockReset()` now restores the original implementation rather than replacing it with a noop returning `undefined`.
+
+```typescript
+// Behavior change illustration:
+const foo = { bar: () => 'Hello, world!' };
+vi.spyOn(foo, 'bar').mockImplementation(() => 'Hello, mock!');
+foo.bar(); // 'Hello, mock!'
+
+foo.bar.mockReset();
+foo.bar(); // BEFORE: undefined  →  AFTER: 'Hello, world!'
+```
+
+**Action Items**:
+
+- [ ] Audit tests that rely on the post-reset behavior returning `undefined`; explicitly mock to a noop if needed (`vi.spyOn(foo, 'bar').mockReturnValue(undefined)`).
+- [ ] If you set `mockReset: true` globally, expect spied methods to return their original implementation between tests.
+
+### 2.4 `vi.spyOn()` Reuses Existing Mocks
+
+**Search Pattern**: Repeated `vi.spyOn(obj, 'method')` on the same target
+
+**What Changed**: Calling `vi.spyOn()` on an already-mocked method now returns the existing mock rather than creating a new one. After `vi.restoreAllMocks()`, the method is no longer a mock.
+
+```typescript
+vi.spyOn(fooService, 'foo').mockImplementation(() => 'bar');
+vi.spyOn(fooService, 'foo').mockImplementation(() => 'bar');
+vi.restoreAllMocks();
+vi.isMockFunction(fooService.foo);
+// BEFORE: true (the second spy survived restore)
+// AFTER:  false (both calls referenced the same spy)
+```
+
+**Action Items**:
+
+- [ ] Audit tests that double-spied on the same method expecting two independent mocks.
+- [ ] Audit tests that asserted a method remained mocked after `restoreAllMocks` — they will now see the original.
+
+### 2.5 Fake Timers Mock Everything by Default
+
+**Search Pattern**: `vi.useFakeTimers()` usages and `fakeTimers.toFake` config
+
+**What Changed**: Vitest no longer ships default `fakeTimers.toFake` values. All timer-related globals (including `performance.now()`) are mocked, except `nextTick`.
+
+```typescript
+// To restore the prior subset:
+export default defineConfig({
+  test: {
+    fakeTimers: {
+      toFake: [
+        'setTimeout',
+        'clearTimeout',
+        'setInterval',
+        'clearInterval',
+        'setImmediate',
+        'clearImmediate',
+        'Date',
+      ],
+    },
+  },
+});
+```
+
+**Action Items**:
+
+- [ ] Audit tests using `vi.useFakeTimers()` that observe `performance.now()` or other newly-faked APIs.
+- [ ] Restrict `fakeTimers.toFake` if a test should leave specific timer APIs real.
+
+### 2.6 Stricter Error Equality
+
+**Search Pattern**: `toEqual(new Error(...))`, `toThrowError(new Error(...))`
+
+**What Changed**: Error comparisons via `toEqual()` and `toThrowError()` now check `name`, `message`, `cause`, `AggregateError.errors`, and prototype.
+
+```typescript
+// Cause is checked asymmetrically:
+expect(new Error('hi', { cause: 'x' })).toEqual(new Error('hi')); // ✅ passes
+expect(new Error('hi')).toEqual(new Error('hi', { cause: 'x' })); // ❌ fails
+
+// Prototype is checked:
+expect(() => {
+  throw new TypeError('type error');
+})
+  .toThrowError(new Error('type error')) // ❌ fails (Error vs TypeError)
+  .toThrowError(new TypeError('type error')); // ✅ passes
+```
+
+**Action Items**:
+
+- [ ] Update assertions that pass a base `Error` to match a subclassed throw — use the matching subclass.
+- [ ] Update assertions whose expected error has a `cause`/`name` that the actual error lacks.
+
+### 2.7 Vite 6 + Vitest 3: `module` Condition Excluded from `resolve.conditions`
+
+**Applies when**: Workspace is on Vite 6 (and Vitest 3 with Vite 6).
+
+**What Changed**: `module` is excluded from `resolve.conditions` by default to align with the upstream Vite 6 migration.
+
+**Action Items**:
+
+- [ ] If a dependency requires the `module` condition for tests, add it explicitly to `resolve.conditions` in your Vitest config.
+
+### 2.8 Hook Signature: `onTestFinished` / `onTestFailed` Receive Context
+
+**Search Pattern**: `onTestFinished`, `onTestFailed` usages in custom reporters or test utilities
+
+**What Changed**: These hooks now receive a test context as the first argument, matching `beforeEach`/`afterEach`.
+
+**Action Items**:
+
+- [ ] Update `onTestFinished`/`onTestFailed` callbacks to take a context argument and access the previous "result" through it.
+
+### 2.9 `Custom` Type Deprecated; `WorkspaceSpec` Removed
+
+**Search Pattern**: `import { Custom, WorkspaceSpec } from 'vitest'`
+
+**What Changed**: `Custom` is now an alias for `Test`; prefer `RunnerCustomCase` and `RunnerTestCase`. `WorkspaceSpec` is removed — use `TestSpecification` instead. Tasks created via `getCurrentSuite().custom()` now have `type: 'test'`.
+
+**Action Items**:
+
+- [ ] Replace `import { Custom } from 'vitest'` with `import { RunnerCustomCase, RunnerTestCase } from 'vitest'`.
+- [ ] Replace `WorkspaceSpec` references with `TestSpecification`.
+
+### 2.10 `resolveConfig()` API Shape Changed
+
+**Search Pattern**: `import { resolveConfig } from 'vitest/node'` (or similar) used by custom tooling
+
+**What Changed**: `resolveConfig()` now takes user configuration and returns a resolved configuration, rather than taking an already-resolved Vite config.
+
+**Action Items**:
+
+- [ ] If you call `resolveConfig()`, pass user config (not already-resolved Vite config) and consume the resolved return value.
+
+### 2.11 `vitest/reporters` Export Slimmed Down
+
+**Search Pattern**: Type imports from `vitest/reporters`
+
+**What Changed**: `vitest/reporters` now exports only reporter implementations and their option types. Task types (`TestCase`, `TestSuite`, etc.) moved.
+
+**Action Items**:
+
+- [ ] Move task-type imports (`TestCase`, `TestSuite`, related) from `vitest/reporters` to `vitest/node`.
+
+### 2.12 Test Files Always Excluded from Coverage
+
+**Search Pattern**: `coverage.excludes` in `vitest.config.*` attempting to include test files
+
+**What Changed**: Test files are always excluded from coverage, even if `coverage.excludes` is customized.
+
+**Action Items**:
+
+- [ ] Remove any `coverage.excludes` patterns that were trying to surface test files in coverage — they no longer apply.
+
+### 2.13 Snapshot Internal API Restructured
+
+**Applies when**: A workspace consumes `@vitest/snapshot` directly (custom snapshot tooling).
+
+**What Changed**: The public Snapshot API in `@vitest/snapshot` was restructured to support multiple states within a single run. The `.toMatchSnapshot()` matcher API is unchanged.
+
+**Action Items**:
+
+- [ ] Most workspaces have nothing to do here. If you maintain custom snapshot tooling against `@vitest/snapshot`, review your usage against the v3 API.
+
+---
+
+## Post-Migration Verification
+
+1. **Reinstall and rebuild**:
+
+   ```bash
+   pnpm install # or npm install / yarn install
+   ```
+
+2. **Run affected tests**:
+
+   ```bash
+   nx affected -t test
+   ```
+
+3. **Run coverage on key projects** to validate threshold drift:
+
+   ```bash
+   nx run my-project:test --coverage
+   ```
+
+4. **Check that custom reporters / sequencers / snapshot tooling** still type-check:
+
+   ```bash
+   nx affected -t typecheck
+   ```
+
+5. **Watch mode**: verify `server.watch.ignored` covers what `watchExclude` previously did (if applicable).
+
+## References
+
+- Vitest 2.0 migration guide: https://v2.vitest.dev/guide/migration
+- Vitest 3.0 migration guide: https://v3.vitest.dev/guide/migration
+- Vitest releases: https://github.com/vitest-dev/vitest/releases

--- a/packages/vite/src/migrations/update-23-0-0/ai-instructions-for-vitest-3.md
+++ b/packages/vite/src/migrations/update-23-0-0/ai-instructions-for-vitest-3.md
@@ -11,12 +11,14 @@ Work systematically through each breaking change category.
 
 > **Pre-pass already ran**: a deterministic generator ran before these instructions. It only handles a narrow set of purely-mechanical changes:
 >
-> - `--segfault-retry` removal from `package.json` scripts
+> - `--segfault-retry` removal from `package.json` scripts AND `project.json` `options.{args,command,commands}`
 > - `@vitest/coverage-c8` → `@vitest/coverage-v8` package rename (preserving the user's pin)
-> - `vitest typecheck` → `vitest --typecheck` in scripts
+> - `vitest typecheck` → `vitest --typecheck` in `package.json` scripts AND `project.json` `options.{args,command,commands}`
 > - `SnapshotEnvironment` import path `'vitest'` → `'vitest/snapshot'` (only when it is the sole named binding)
-> - `browser.provider: 'none'` → `'preview'`
-> - `browser.indexScripts` → `orchestratorScripts`
+> - `browser.provider: 'none'` → `'preview'` (only when the value is a direct string literal under `test.browser.provider`)
+> - `browser.indexScripts` → `orchestratorScripts` (only as a direct property name)
+>
+> The pre-pass **does not** edit CI provider configs (`.github/workflows/*.yml`, `.gitlab-ci.yml`, `azure-pipelines.yml`, `.circleci/config.yml`, `bitbucket-pipelines.yml`) — YAML structure varies too much. Any matches it finds there are forwarded to you to handle.
 >
 > **The vast majority of action items below are NOT covered by the pre-pass** and still require your attention — every section other than the six items above.
 >

--- a/packages/vite/src/migrations/update-23-0-0/ai-instructions-for-vitest-3.md
+++ b/packages/vite/src/migrations/update-23-0-0/ai-instructions-for-vitest-3.md
@@ -9,6 +9,8 @@ These instructions guide you through migrating an Nx workspace containing multip
 
 Work systematically through each breaking change category.
 
+> **Note**: a deterministic pre-pass has already run before these instructions. It applied the AST-tractable subset of the changes below (e.g. `browser.provider: 'none'` → `'preview'`, `browser.indexScripts` → `orchestratorScripts`, `@vitest/coverage-c8` → `@vitest/coverage-v8`, `SnapshotEnvironment` import path, `--segfault-retry` removal, `vitest typecheck` → `vitest --typecheck`). Anything it could not handle was forwarded as advisory context (look for "Context from the generator phase" above). Skip the corresponding action items below if the pre-pass already covered them; verify the change is present rather than re-applying.
+
 ## Pre-Migration Checklist
 
 1. **Identify the current Vitest version**:

--- a/packages/vite/src/migrations/update-23-0-0/ai-instructions-for-vitest-4.md
+++ b/packages/vite/src/migrations/update-23-0-0/ai-instructions-for-vitest-4.md
@@ -1,0 +1,725 @@
+# Vitest 4.0 Migration Instructions for LLM
+
+## Overview
+
+These instructions guide you through migrating an Nx workspace containing multiple Vitest projects from Vitest 3.x to Vitest 4.0. Work systematically through each breaking change category.
+
+## Pre-Migration Checklist
+
+1. **Identify all Vitest projects**:
+
+   ```bash
+   nx show projects --with-target test
+   ```
+
+2. **Locate all Vitest configuration files**:
+   - Search for `vitest.config.{ts,js,mjs}`
+   - Search for `vitest.workspace.{ts,js,mjs}`
+   - Check `project.json` files for inline Vitest configuration
+
+3. **Identify affected code**:
+   - Test files: `**/*.{spec,test}.{ts,js,tsx,jsx}`
+   - Mock usage: Files using `vi.fn()`, `vi.spyOn()`, `vi.mock()`
+   - Coverage configuration references
+
+## Migration Steps by Category
+
+### 1. Configuration File Updates
+
+#### 1.1 Coverage Configuration
+
+**Search Pattern**: `coverage` in all `vitest.config.*` files and `project.json` test target options
+
+**Changes Required**:
+
+```typescript
+// ❌ BEFORE (Vitest 3.x)
+export default defineConfig({
+  test: {
+    coverage: {
+      all: true,
+      extensions: ['.ts', '.tsx'],
+      ignoreEmptyLines: false,
+      experimentalAstAwareRemapping: true,
+    },
+  },
+});
+
+// ✅ AFTER (Vitest 4.0)
+export default defineConfig({
+  test: {
+    coverage: {
+      // Explicitly define files to include in coverage
+      include: ['src/**/*.{ts,tsx}'],
+      // Remove: all, extensions, ignoreEmptyLines, experimentalAstAwareRemapping
+    },
+  },
+});
+```
+
+**Action Items**:
+
+- [ ] Remove `coverage.all` option
+- [ ] Remove `coverage.extensions` option
+- [ ] Remove `coverage.ignoreEmptyLines` option
+- [ ] Remove `coverage.experimentalAstAwareRemapping` option
+- [ ] Add explicit `coverage.include` patterns based on project structure
+- [ ] Update any documentation referencing these options
+
+#### 1.2 Pool Options Restructuring
+
+**Search Pattern**: `poolOptions`, `maxThreads`, `maxForks`, `singleThread`, `singleFork` in all Vitest config files
+
+**Changes Required**:
+
+```typescript
+// ❌ BEFORE (Vitest 3.x)
+export default defineConfig({
+  test: {
+    maxThreads: 4,
+    maxForks: 2,
+    singleThread: false,
+    poolOptions: {
+      threads: {
+        useAtomics: true,
+      },
+      vmThreads: {
+        memoryLimit: '512MB',
+      },
+    },
+  },
+});
+
+// ✅ AFTER (Vitest 4.0)
+export default defineConfig({
+  test: {
+    maxWorkers: 4, // Consolidates maxThreads and maxForks
+    isolate: true, // Replaces singleThread: false
+    // Remove: poolOptions, threads.useAtomics
+    vmMemoryLimit: '512MB', // Moved to top-level
+  },
+});
+```
+
+**Action Items**:
+
+- [ ] Replace `maxThreads` and `maxForks` with single `maxWorkers` option
+- [ ] Replace `singleThread: true` or `singleFork: true` with `maxWorkers: 1, isolate: false`
+- [ ] Move all `poolOptions.*` nested options to top-level (e.g., `poolOptions.vmThreads.memoryLimit` → `vmMemoryLimit`)
+- [ ] Remove `threads.useAtomics` option
+- [ ] Update CI environment variables: `VITEST_MAX_THREADS` and `VITEST_MAX_FORKS` → `VITEST_MAX_WORKERS`
+
+#### 1.3 Workspace to Projects Rename
+
+**Search Pattern**: `workspace` property in Vitest config files
+
+**Changes Required**:
+
+```typescript
+// ❌ BEFORE (Vitest 3.x)
+export default defineConfig({
+  test: {
+    workspace: ['apps/*', 'libs/*'],
+  },
+});
+
+// ✅ AFTER (Vitest 4.0)
+export default defineConfig({
+  test: {
+    projects: ['apps/*', 'libs/*'],
+  },
+});
+```
+
+**Action Items**:
+
+- [ ] Rename `workspace` property to `projects` in all config files
+- [ ] Remove external workspace file references (must be inline in config)
+- [ ] Update `poolMatchGlobs` to use `projects` pattern matching instead
+- [ ] Update `environmentMatchGlobs` to use `projects` pattern matching instead
+
+#### 1.4 Browser Configuration
+
+**Search Pattern**: `browser.provider`, `browser.testerScripts`, imports from `@vitest/browser`
+
+**Changes Required**:
+
+```typescript
+// ❌ BEFORE (Vitest 3.x)
+export default defineConfig({
+  test: {
+    browser: {
+      enabled: true,
+      provider: 'playwright', // String value
+      testerScripts: ['./setup.js'],
+    },
+  },
+});
+
+// Import changes
+import { page } from '@vitest/browser';
+
+// ✅ AFTER (Vitest 4.0)
+export default defineConfig({
+  test: {
+    browser: {
+      enabled: true,
+      provider: { name: 'playwright' }, // Object value
+      testerHtmlPath: './test-setup.html', // Renamed from testerScripts
+    },
+  },
+});
+
+// Import changes
+import { page } from 'vitest/browser';
+```
+
+**Action Items**:
+
+- [ ] Convert `browser.provider` string values to object format: `{ name: 'provider-name' }`
+- [ ] Replace `browser.testerScripts` with `browser.testerHtmlPath`
+- [ ] Update all imports from `@vitest/browser` to `vitest/browser`
+- [ ] Remove `@vitest/browser` from dependencies if no longer needed
+
+#### 1.5 Deprecated Configuration Options
+
+**Search Pattern**: `deps.external`, `deps.inline`, `deps.fallbackCJS` in config files
+
+**Changes Required**:
+
+```typescript
+// ❌ BEFORE (Vitest 3.x)
+export default defineConfig({
+  test: {
+    deps: {
+      external: ['some-package'],
+      inline: ['inline-package'],
+      fallbackCJS: true,
+    },
+  },
+});
+
+// ✅ AFTER (Vitest 4.0)
+export default defineConfig({
+  test: {
+    server: {
+      deps: {
+        external: ['some-package'],
+        inline: ['inline-package'],
+        fallbackCJS: true,
+      },
+    },
+  },
+});
+```
+
+**Action Items**:
+
+- [ ] Move `deps.*` options under `server.deps` namespace
+- [ ] Remove `poolMatchGlobs` (use `projects` with conditions instead)
+- [ ] Remove `environmentMatchGlobs` (use `projects` with conditions instead)
+
+### 2. Test Code Updates
+
+#### 2.1 Mock Function Name Changes
+
+**Search Pattern**: `.getMockName()` calls in test files
+
+**Changes Required**:
+
+```typescript
+// ❌ BEFORE (Vitest 3.x)
+const mockFn = vi.fn();
+expect(mockFn.getMockName()).toBe('spy'); // Old default
+
+// ✅ AFTER (Vitest 4.0)
+const mockFn = vi.fn();
+expect(mockFn.getMockName()).toBe('vi.fn()'); // New default
+
+// If you need custom names, set them explicitly
+const namedMock = vi.fn().mockName('myCustomName');
+expect(namedMock.getMockName()).toBe('myCustomName');
+```
+
+**Action Items**:
+
+- [ ] Update test assertions checking default mock names from `'spy'` to `'vi.fn()'`
+- [ ] Add explicit `.mockName()` calls where specific names are required
+
+#### 2.2 Mock Invocation Call Order
+
+**Search Pattern**: `.mock.invocationCallOrder` in test files
+
+**Changes Required**:
+
+```typescript
+// ❌ BEFORE (Vitest 3.x)
+const mockFn = vi.fn();
+mockFn();
+expect(mockFn.mock.invocationCallOrder[0]).toBe(0); // Started at 0
+
+// ✅ AFTER (Vitest 4.0)
+const mockFn = vi.fn();
+mockFn();
+expect(mockFn.mock.invocationCallOrder[0]).toBe(1); // Now starts at 1 (Jest-compatible)
+```
+
+**Action Items**:
+
+- [ ] Update assertions on `invocationCallOrder` to account for 1-based indexing
+- [ ] Search for off-by-one errors in call order comparisons
+
+#### 2.3 Constructor Spies and Mocks
+
+**Search Pattern**: `vi.spyOn` on constructors, `vi.fn()` used as constructors
+
+**Changes Required**:
+
+```typescript
+// ❌ BEFORE (Vitest 3.x) - Arrow function constructors might have worked
+const MockConstructor = vi.fn(() => ({ value: 42 }));
+new MockConstructor(); // May have worked in v3
+
+// ✅ AFTER (Vitest 4.0) - Must use function or class
+const MockConstructor = vi.fn(function () {
+  return { value: 42 };
+});
+new MockConstructor(); // Correctly supports 'new'
+
+// Or use class syntax
+class MockClass {
+  value = 42;
+}
+const MockConstructor = vi.fn(MockClass);
+```
+
+**Action Items**:
+
+- [ ] Convert arrow function mocks used as constructors to `function` keyword or `class` syntax
+- [ ] Test all constructor spies to ensure `new` keyword works correctly
+- [ ] Update any mocks that expect constructor behavior
+
+#### 2.4 RestoreAllMocks Behavior
+
+**Search Pattern**: `vi.restoreAllMocks()` in test files
+
+**Changes Required**:
+
+```typescript
+// ❌ BEFORE (Vitest 3.x)
+vi.mock('./module', () => ({ fn: vi.fn() }));
+vi.restoreAllMocks(); // Would restore automocks
+
+// ✅ AFTER (Vitest 4.0)
+vi.mock('./module', () => ({ fn: vi.fn() }));
+vi.restoreAllMocks(); // Only restores manual spies, NOT automocks
+
+// To reset automocks, use:
+vi.unmock('./module');
+// or
+vi.resetModules();
+```
+
+**Action Items**:
+
+- [ ] Review all `vi.restoreAllMocks()` usage
+- [ ] Add explicit `vi.unmock()` or `vi.resetModules()` calls for automocked modules
+- [ ] Ensure test isolation is maintained after this change
+
+#### 2.5 SpyOn Return Value Changes
+
+**Search Pattern**: `vi.spyOn()` on already mocked functions
+
+**Changes Required**:
+
+```typescript
+// ❌ BEFORE (Vitest 3.x)
+const mock = vi.fn();
+const spy = vi.spyOn({ method: mock }, 'method');
+// spy !== mock (created new spy)
+
+// ✅ AFTER (Vitest 4.0)
+const mock = vi.fn();
+const spy = vi.spyOn({ method: mock }, 'method');
+// spy === mock (returns same instance)
+```
+
+**Action Items**:
+
+- [ ] Review code that creates spies on existing mocks
+- [ ] Remove redundant spy creation if same instance is returned
+- [ ] Update assertions that check spy identity
+
+#### 2.6 Automock Behavior Changes
+
+**Search Pattern**: `vi.mock()` with factory functions, `.mockRestore()` on automocks
+
+**Changes Required**:
+
+```typescript
+// ❌ BEFORE (Vitest 3.x)
+vi.mock('./utils', () => ({
+  get value() {
+    return 42;
+  }, // Would call getter
+}));
+
+import { value } from './utils';
+console.log(value); // Would execute getter logic
+
+// Restore might have worked
+const spy = vi.spyOn(obj, 'method');
+spy.mockRestore(); // Might work on automocks
+
+// ✅ AFTER (Vitest 4.0)
+vi.mock('./utils', () => ({
+  get value() {
+    return 42;
+  },
+}));
+
+import { value } from './utils';
+console.log(value); // Returns undefined (doesn't call getter)
+
+// Explicitly return value if needed
+vi.mock('./utils', () => ({
+  value: 42, // Not a getter
+}));
+
+// mockRestore no longer works on automocks
+const spy = vi.spyOn(obj, 'method');
+spy.mockRestore(); // Throws error if method is automocked
+
+// Use unmock instead
+vi.unmock('./module');
+```
+
+**Action Items**:
+
+- [ ] Convert automocked getters to plain property values where needed
+- [ ] Remove `.mockRestore()` calls on automocked methods
+- [ ] Use `vi.unmock()` to clear automocks instead
+- [ ] Test instance method isolation (they now share state with prototype)
+
+#### 2.7 Settled Results Immediate Population
+
+**Search Pattern**: `.mock.settledResults` in test files
+
+**Changes Required**:
+
+```typescript
+// ✅ AFTER (Vitest 4.0)
+const asyncMock = vi.fn(async () => 'result');
+const promise = asyncMock();
+
+// settledResults is immediately populated with 'incomplete' status
+expect(asyncMock.mock.settledResults[0]).toEqual({
+  type: 'incomplete',
+  value: undefined,
+});
+
+// After promise resolves
+await promise;
+expect(asyncMock.mock.settledResults[0]).toEqual({
+  type: 'fulfilled',
+  value: 'result',
+});
+```
+
+**Action Items**:
+
+- [ ] Update tests that check `settledResults` before promise resolution
+- [ ] Handle `'incomplete'` status in assertions
+- [ ] Ensure tests properly await promises before checking settled results
+
+### 3. Reporter and CLI Changes
+
+#### 3.1 Reporter API Changes
+
+**Search Pattern**: Custom reporters, `onCollected`, `onTaskUpdate`, `onFinished`
+
+**Changes Required**:
+
+```typescript
+// ❌ BEFORE (Vitest 3.x)
+export default {
+  onCollected(files) {
+    // Handle collected files
+  },
+  onTaskUpdate(task) {
+    // Handle task update
+  },
+  onFinished(files) {
+    // Handle completion
+  },
+};
+
+// ✅ AFTER (Vitest 4.0)
+// Use new reporter API - consult Vitest 4 docs for replacement methods
+```
+
+**Action Items**:
+
+- [ ] Review custom reporters for removed API usage
+- [ ] Consult Vitest 4 documentation for new reporter API
+- [ ] Update or rewrite custom reporters to use new APIs
+
+#### 3.2 Built-in Reporter Changes
+
+**Search Pattern**: `reporters: ['basic']`, `reporters: ['verbose']`
+
+**Changes Required**:
+
+```typescript
+// ❌ BEFORE (Vitest 3.x)
+export default defineConfig({
+  test: {
+    reporters: ['basic'],
+  },
+});
+
+// ✅ AFTER (Vitest 4.0)
+export default defineConfig({
+  test: {
+    reporters: [['default', { summary: false }]], // Equivalent to 'basic'
+  },
+});
+
+// For verbose (tree output)
+reporters: ['tree']; // Use 'tree' for hierarchical output
+```
+
+**Action Items**:
+
+- [ ] Replace `'basic'` reporter with `['default', { summary: false }]`
+- [ ] Replace `'verbose'` reporter with `'tree'` for hierarchical output
+- [ ] Update CI configuration if reporters are specified there
+
+### 4. Snapshot Changes
+
+#### 4.1 Custom Elements Shadow Root
+
+**Search Pattern**: Snapshot tests involving custom elements or Web Components
+
+**Changes Required**:
+
+```typescript
+// ✅ AFTER (Vitest 4.0)
+// Shadow root contents now printed by default in snapshots
+
+// If you want old behavior (don't print shadow root):
+export default defineConfig({
+  test: {
+    printShadowRoot: false,
+  },
+});
+```
+
+**Action Items**:
+
+- [ ] Review snapshot tests for custom elements
+- [ ] Update snapshots if shadow root contents are now included
+- [ ] Add `printShadowRoot: false` if old behavior is required
+
+### 5. Environment Variable Updates
+
+**Search Pattern**: CI/CD configuration files, `.env` files, documentation
+
+**Changes Required**:
+
+```bash
+# ❌ BEFORE (Vitest 3.x)
+VITEST_MAX_THREADS=4
+VITEST_MAX_FORKS=2
+VITE_NODE_DEPS_MODULE_DIRECTORIES=/custom/path
+
+# ✅ AFTER (Vitest 4.0)
+VITEST_MAX_WORKERS=4
+VITEST_MODULE_DIRECTORIES=/custom/path
+```
+
+**Action Items**:
+
+- [ ] Update CI/CD pipeline environment variables
+- [ ] Update `.env` files
+- [ ] Update documentation referencing old environment variables
+- [ ] Search for `VITEST_MAX_THREADS`, `VITEST_MAX_FORKS`, `VITE_NODE_DEPS_MODULE_DIRECTORIES`
+
+### 6. Advanced: Module Runner Changes
+
+**Search Pattern**: `vitest/execute`, `__vitest_executor`, `vite-node`
+
+**Changes Required**:
+
+```typescript
+// ❌ BEFORE (Vitest 3.x)
+import { execute } from 'vitest/execute';
+// Access to __vitest_executor
+
+// ✅ AFTER (Vitest 4.0)
+// Use Vite's Module Runner API instead
+// Consult Vite Module Runner documentation
+```
+
+**Action Items**:
+
+- [ ] If using `vitest/execute`, migrate to Vite Module Runner
+- [ ] Remove dependencies on `__vitest_executor`
+- [ ] Update custom pool implementations (complete rewrite needed)
+
+### 7. Type Definition Updates
+
+**Search Pattern**: TypeScript imports from `vitest`, type errors after upgrade
+
+**Changes Required**:
+
+```typescript
+// All deprecated type exports removed
+// If you get TypeScript errors about missing types:
+// - Check if you're using deprecated type names
+// - Update to current type names from Vitest 4 API
+// - Remove explicit @types/node if it was only needed due to Vitest bug
+```
+
+**Action Items**:
+
+- [ ] Run TypeScript compilation on all test files
+- [ ] Fix any type errors related to removed Vitest type definitions
+- [ ] Review `@types/node` usage (may no longer be accidentally included)
+
+## Post-Migration Validation
+
+### 1. Run Tests Per Project
+
+```bash
+# Test each project individually
+nx run-many -t test -p PROJECT_NAME
+```
+
+### 2. Run All Tests
+
+```bash
+# Run tests across all affected projects
+nx affected -t test
+```
+
+### 3. Check Coverage
+
+```bash
+# Verify coverage generation works with new config
+nx affected -t test --coverage
+```
+
+### 4. Validate CI Pipeline
+
+```bash
+# Run full CI validation
+nx prepush
+```
+
+### 5. Review Migration Checklist
+
+- [ ] All configuration files updated
+- [ ] All test files pass
+- [ ] Coverage reports generate correctly
+- [ ] CI/CD pipeline runs successfully
+- [ ] Environment variables updated
+- [ ] Documentation updated
+- [ ] No deprecated API warnings in console
+
+## Common Issues and Solutions
+
+### Issue: Coverage includes too many files
+
+**Solution**: Add explicit `coverage.include` patterns to match your source files
+
+### Issue: Tests fail with "arrow function constructors not supported"
+
+**Solution**: Convert arrow functions used as constructors to `function` keyword or `class` syntax
+
+### Issue: Automocks not resetting between tests
+
+**Solution**: Use `vi.unmock()` or `vi.resetModules()` instead of `vi.restoreAllMocks()`
+
+### Issue: Mock call order assertions failing
+
+**Solution**: Update to 1-based indexing for `invocationCallOrder`
+
+### Issue: Browser tests failing after upgrade
+
+**Solution**: Check browser provider is object format and imports use `vitest/browser`
+
+### Issue: TypeScript errors in test files
+
+**Solution**: Update to new type definitions and remove usage of deprecated types
+
+## Files to Review
+
+Create a checklist of all files that need review:
+
+```bash
+# Configuration files
+find . -name "vitest.config.*" -o -name "vitest.workspace.*"
+find . -name "project.json" -exec grep -l "vitest" {} \;
+
+# Test files
+find . -name "*.spec.*" -o -name "*.test.*"
+
+# Files with mock usage
+rg "vi\.(fn|spyOn|mock|restoreAllMocks)" --type ts --type tsx --type js
+
+# Files with coverage config
+rg "coverage\.(all|extensions|ignoreEmptyLines)" --type ts --type js
+
+# CI configuration
+find . -name ".github/workflows/*.yml" -o -name ".gitlab-ci.yml" -o -name "azure-pipelines.yml"
+```
+
+## Migration Strategy for Large Workspaces
+
+1. **Migrate in phases**: Start with a small project, validate, then expand
+2. **Use feature branches**: Create separate branches for different migration aspects
+3. **Run tests frequently**: After each configuration change, run affected tests
+4. **Document issues**: Keep track of project-specific issues and solutions
+5. **Automate where possible**: Create codemods for repetitive changes
+
+## Useful Commands During Migration
+
+```bash
+# Find all vitest configurations
+nx show projects --with-target test
+
+# Test specific project after changes
+nx test PROJECT_NAME
+
+# Test all affected
+nx affected -t test
+
+# View project details
+nx show project PROJECT_NAME --web
+
+# Clear Nx cache if needed
+nx reset
+```
+
+## Guard Rails
+
+DO NOT
+
+- Force tests to pass by removing test logic and replacing it with `expect(true).toBe(true)`
+- Remove assertions
+- Add additional mocks that force tests to pass
+
+---
+
+## Notes for LLM Execution
+
+When executing this migration:
+
+1. **Work systematically**: Complete one category before moving to the next
+2. **Test after each change**: Don't batch all changes without validation
+3. **Keep user informed**: Report progress through each section
+4. **Handle errors promptly**: If tests fail, fix immediately before proceeding
+5. **Update documentation**: Note any workspace-specific patterns or issues
+6. **Create meaningful commits**: Group related changes together with clear messages
+7. **Use TodoWrite tool**: Track migration progress for visibility

--- a/packages/vite/src/migrations/update-23-0-0/ai-instructions-for-vitest-4.md
+++ b/packages/vite/src/migrations/update-23-0-0/ai-instructions-for-vitest-4.md
@@ -4,7 +4,19 @@
 
 These instructions guide you through migrating an Nx workspace containing multiple Vitest projects from Vitest 3.x to Vitest 4.0. Work systematically through each breaking change category.
 
-> **Note**: a deterministic pre-pass has already run before these instructions. It applied the AST-tractable subset of the changes below (e.g. dead `coverage.*` option removal, `test.workspace` → `test.projects` rename, `@vitest/browser/context` → `vitest/browser` import path, `deps.optimizer.web` → `client`, `poolOptions.threads.useAtomics` and `test.minWorkers` removal, `'verbose'`/`'basic'` reporter renames, env-var renames in `package.json` scripts). Anything it could not handle was forwarded as advisory context (look for "Context from the generator phase" above) — focus your effort on those items and on the cross-cutting changes the pre-pass cannot perform safely (pool option flattening, `deps.* → server.deps.*` move, browser provider function-form rewrite, workspace file inlining, custom reporter callback updates).
+> **Pre-pass already ran**: a deterministic generator ran before these instructions. It only handles purely-mechanical changes:
+>
+> - dead `coverage.{all,extensions,ignoreEmptyLines,experimentalAstAwareRemapping}` removal
+> - `test.workspace` → `test.projects` rename (the property only — external `vitest.workspace.*` files are NOT inlined)
+> - `@vitest/browser/context` import-path rewrite to `vitest/browser`
+> - `deps.optimizer.web` → `deps.optimizer.client` rename
+> - `poolOptions.threads.useAtomics` and top-level `test.minWorkers` removal
+> - `'verbose'` → `'tree'` and `'basic'` → `['default', { summary: false }]` inside `test.reporters`
+> - `VITEST_MAX_{THREADS,FORKS}` → `VITEST_MAX_WORKERS` and `VITE_NODE_DEPS_MODULE_DIRECTORIES` → `VITEST_MODULE_DIRECTORIES` env-var renames in `package.json` scripts
+>
+> **The cross-cutting changes below still require your attention** — pool option flattening (`singleThread`/`singleFork`, `maxThreads`/`maxForks`, `poolOptions.<pool>.{execArgv,isolate}`, `poolOptions.vmThreads.memoryLimit`), `test.deps.{external,inline,fallbackCJS}` → `test.server.deps.*` move, `test.{poolMatchGlobs,environmentMatchGlobs}` projects rewrite, browser provider function-form rewrite, `browser.testerScripts` → `testerHtmlPath`, `vitest.workspace.*` file inlining + `defineWorkspace` removal, custom reporter callback API updates, and `@vitest/browser` package replacement with per-provider packages.
+>
+> If a "Files modified by the generator phase" section appears in the prompt above, those files received the items the pre-pass handled — verify the new shape is in place before re-applying. If a "Context from the generator phase" section appears, **every entry there is pending work** the pre-pass detected but could not safely complete: address each one in addition to the relevant section below.
 
 ## Prerequisites
 

--- a/packages/vite/src/migrations/update-23-0-0/ai-instructions-for-vitest-4.md
+++ b/packages/vite/src/migrations/update-23-0-0/ai-instructions-for-vitest-4.md
@@ -4,30 +4,45 @@
 
 These instructions guide you through migrating an Nx workspace containing multiple Vitest projects from Vitest 3.x to Vitest 4.0. Work systematically through each breaking change category.
 
-> **Pre-pass already ran**: a deterministic generator ran before these instructions. It only handles purely-mechanical changes:
->
-> - dead `coverage.{all,extensions,ignoreEmptyLines,experimentalAstAwareRemapping}` removal
-> - `test.workspace` → `test.projects` rename (the property only — external `vitest.workspace.*` files are NOT inlined)
-> - `@vitest/browser/context` import-path rewrite to `vitest/browser`
-> - `deps.optimizer.web` → `deps.optimizer.client` rename
-> - `poolOptions.threads.useAtomics` and top-level `test.minWorkers` removal
-> - `'verbose'` → `'tree'` and `'basic'` → `['default', { summary: false }]` inside `test.reporters`
-> - `VITEST_MAX_{THREADS,FORKS}` → `VITEST_MAX_WORKERS` and `VITE_NODE_DEPS_MODULE_DIRECTORIES` → `VITEST_MODULE_DIRECTORIES` renames in: `package.json` scripts, `.env` / `.env.*` files, `project.json` `options.env` keys, and inline `VAR=value` prefixes inside `project.json` `options.{args,command,commands}`
->
-> The pre-pass **skips the rename when both `VITEST_MAX_THREADS` and `VITEST_MAX_FORKS` appear in the same file/scope** (they collapse to a single `VITEST_MAX_WORKERS` whose value depends on which pool the project uses — a decision the pre-pass can't make safely). It also **does not** edit CI provider configs (`.github/workflows/*.yml`, `.gitlab-ci.yml`, `azure-pipelines.yml`, `.circleci/config.yml`, `bitbucket-pipelines.yml`) — YAML structure varies too much. Any conflicts and any CI matches are forwarded to you.
->
-> **The cross-cutting changes below still require your attention** — pool option flattening (`singleThread`/`singleFork`, `maxThreads`/`maxForks`, `poolOptions.<pool>.{execArgv,isolate}`, `poolOptions.vmThreads.memoryLimit`), `test.deps.{external,inline,fallbackCJS}` → `test.server.deps.*` move, `test.{poolMatchGlobs,environmentMatchGlobs}` projects rewrite, browser provider function-form rewrite, `browser.testerScripts` → `testerHtmlPath`, `vitest.workspace.*` file inlining + `defineWorkspace` removal, custom reporter callback API updates, and `@vitest/browser` package replacement with per-provider packages.
->
-> If a "Files modified by the generator phase" section appears in the prompt above, those files received the items the pre-pass handled — verify the new shape is in place before re-applying. If a "Context from the generator phase" section appears, **every entry there is pending work** the pre-pass detected but could not safely complete: address each one in addition to the relevant section below. A workspace-wide reminder is also emitted as a post-run "next step" about env vars set in CI provider dashboards — those can't be detected from the workspace tree.
+<pre_pass_summary note="a deterministic pre-pass already applied these specific edits; verify the new shape is in place rather than redoing them">
 
-## Prerequisites
+The pre-pass handled, mechanically:
 
-Vitest 4 has hard runtime requirements. Verify these BEFORE editing any config:
+- dead `coverage.{all,extensions,ignoreEmptyLines,experimentalAstAwareRemapping}` removal
+- `test.workspace` → `test.projects` rename (the property only — external `vitest.workspace.*` files are NOT inlined)
+- `@vitest/browser/context` import-path rewrite to `vitest/browser`
+- `deps.optimizer.web` → `deps.optimizer.client` rename
+- `poolOptions.threads.useAtomics` and top-level `test.minWorkers` removal
+- `'verbose'` → `'tree'` and `'basic'` → `['default', { summary: false }]` inside `test.reporters`
+- `VITEST_MAX_{THREADS,FORKS}` → `VITEST_MAX_WORKERS` and `VITE_NODE_DEPS_MODULE_DIRECTORIES` → `VITEST_MODULE_DIRECTORIES` renames in: `package.json` scripts, `.env` / `.env.*` files, `project.json` `options.env` keys, and inline `VAR=value` prefixes inside `project.json` `options.{args,command,commands}`
+
+The pre-pass **skips the rename when both `VITEST_MAX_THREADS` and `VITEST_MAX_FORKS` appear in the same file/scope** (they collapse to a single `VITEST_MAX_WORKERS` whose value depends on which pool the project uses — a decision the pre-pass can't make safely). It also **does not** edit CI provider configs (`.github/workflows/*.yml`, `.gitlab-ci.yml`, `azure-pipelines.yml`, `.circleci/config.yml`, `bitbucket-pipelines.yml`) — YAML structure varies too much. Any conflicts and any CI matches are forwarded to you in `<advisory_context>`.
+
+**The cross-cutting changes below still require your attention** — pool option flattening (`singleThread`/`singleFork`, `maxThreads`/`maxForks`, `poolOptions.<pool>.{execArgv,isolate}`, `poolOptions.vmThreads.memoryLimit`), `test.deps.{external,inline,fallbackCJS}` → `test.server.deps.*` move, `test.{poolMatchGlobs,environmentMatchGlobs}` projects rewrite, browser provider function-form rewrite, `browser.testerScripts` → `testerHtmlPath`, `vitest.workspace.*` file inlining + `defineWorkspace` removal, custom reporter callback API updates, and `@vitest/browser` package replacement with per-provider packages.
+
+How to read the wrapper sections above this file:
+
+- `<files_changed>` lists files the pre-pass already wrote to. Verify the new shape is in place; do not re-apply the same edit.
+- `<advisory_context>` lists detections the pre-pass forwarded because it could not safely complete them. **Every entry is pending work** — address each one in the relevant section below, not as a separate task.
+
+A workspace-wide reminder is also emitted as a post-run "next step" about env vars set in CI provider dashboards — those can't be detected from the workspace tree.
+
+</pre_pass_summary>
+
+<handoff_guidance>
+In your handoff `summary` (1–3 sentences per the system prompt), name the breaking-change categories you applied; explicitly call out any you skipped because they didn't apply (e.g., "no custom reporters in this workspace", "no browser-mode configs").
+</handoff_guidance>
+
+<prerequisites note="hard runtime requirements; do not edit any vitest config until these are satisfied">
+
+Vitest 4 has hard runtime requirements:
 
 - **Vite ≥ 6.0.0** (Vite 5 is unsupported). Check with `npx vite --version`. If on Vite 5, apply the Vite 6 / 7 / 8 migration guides first.
 - **Node.js ≥ 20.0.0** (Node 18 support dropped). Check with `node --version`. Update CI `actions/setup-node` versions, `.nvmrc`, `engines` in `package.json`, and Docker base images.
 
-If either prerequisite is unmet, **stop and resolve them before continuing** — config-level migration on an unsupported runtime will produce confusing errors.
+If either prerequisite is unmet, write status: failed with the unmet requirement in `summary` — config-level migration on an unsupported runtime will produce confusing errors.
+
+</prerequisites>
 
 ## Nx-Specific Notes (read first)
 
@@ -151,6 +166,10 @@ export default defineConfig({
 - [ ] Remove `minWorkers` if present (option removed; behaves as if set to 0 in non-watch mode).
 - [ ] Update CI environment variables: `VITEST_MAX_THREADS` and `VITEST_MAX_FORKS` → `VITEST_MAX_WORKERS`.
 
+<fail_if note="pool flattening is pool-agnostic in v4; picking the wrong value silently changes concurrency">
+Both `maxThreads` and `maxForks` are set with different numbers AND the project has no explicit `test.pool` you can use to decide which value `maxWorkers` should take. Do not guess. Write status: failed and ask the user which pool the project uses.
+</fail_if>
+
 #### 1.3 Workspace to Projects Rename
 
 **Search Pattern**: `workspace` property in Vitest config files
@@ -178,6 +197,10 @@ export default defineConfig({
 - [ ] Rename `workspace` property to `projects` in all config files.
 - [ ] Inline any external `vitest.workspace.*` content into `test.projects` and delete the workspace file (external file references are no longer supported).
 - [ ] If projects need different pool/environment options, set them inside each project entry rather than via the (now-removed) `poolMatchGlobs` / `environmentMatchGlobs` — see section 1.5.
+
+<fail_if note="inlining is a semantic merge, not a copy">
+The `vitest.workspace.*` file imports modules / calls functions / uses spreads that you cannot evaluate at edit time (dynamic project arrays, conditional imports). Write status: failed listing the file path and the dynamic shape that needs human resolution.
+</fail_if>
 
 #### 1.4 Browser Configuration
 
@@ -230,6 +253,10 @@ const { getElementError } = utils;
 - [ ] Replace string `browser.provider: 'name'` with the function-call form: `provider: <providerFn>(<options>)`.
 - [ ] Replace `browser.testerScripts: [...]` with `browser.testerHtmlPath: '<single-file>.html'`. Note: this is a **semantic** change (array of scripts → one HTML file). Move the script contents into a `<script>` block of the HTML file, or load them with `<script src>` references inside it.
 - [ ] Update imports: `@vitest/browser/context` → `vitest/browser`; `@vitest/browser/utils` → `vitest/browser` (named export `utils`).
+
+<fail_if note="provider package selection changes which browser tests actually run against">
+The previous `browser.provider` string is dynamic (variable reference, ternary, or constructed at runtime) so you cannot determine which per-provider package to install. Write status: failed and ask the user which provider the project targets.
+</fail_if>
 
 #### 1.5 Deprecated Configuration Options
 
@@ -328,6 +355,10 @@ export default {
 
 - [ ] If a custom environment file exists, rename its `transformMode` property to `viteEnvironment`.
 - [ ] No change needed for workspaces using only built-in environments (`node`, `jsdom`, `happy-dom`, `edge-runtime`).
+
+<fail_if note="viteEnvironment is not a value-for-value swap from transformMode">
+The custom environment's `transformMode` value is something other than `'ssr'` or `'web'` (or its replacement Vite-environment name isn't obvious from the workspace). Write status: failed listing the file and the current `transformMode` value.
+</fail_if>
 
 ### 2. Test Code Updates
 
@@ -594,6 +625,10 @@ export default {
 - [ ] Consult the v4 reporters API at https://vitest.dev/api/advanced/reporters for the exact replacement method name and signature.
 - [ ] After rewriting, run the reporter in isolation against a small project to verify event delivery before applying workspace-wide.
 
+<fail_if note="custom reporters carry external behavior the migration cannot deduce">
+A reporter callback receives or emits data whose v4 equivalent you can't determine from the v4 reporters API alone (e.g., uses internal task tree shapes, depends on event ordering that has no v4 analogue). Write status: failed naming the reporter file and the callback; do not stub.
+</fail_if>
+
 #### 3.2 Built-in Reporter Changes
 
 **Search Pattern**: `reporters: ['basic']`, `reporters: ['verbose']`
@@ -758,137 +793,25 @@ import { execute } from 'vitest/execute';
 
 ## Post-Migration Validation
 
-### 1. Run Tests Per Project
+1. Run tests per project: `nx test <project>`
+2. Run all affected: `nx affected -t test`
+3. Check coverage: `nx affected -t test --coverage`
+4. Validate CI pipeline: `nx prepush`
 
-```bash
-# Test each project individually
-nx run-many -t test -p PROJECT_NAME
-```
+Confirm:
 
-### 2. Run All Tests
+- All configuration files updated
+- All test files pass (or are flagged in your handoff `summary` if they remain failing — see `<test_integrity_guardrails>` below)
+- Coverage reports generate correctly
+- Environment variables updated
+- No deprecated API warnings in console
 
-```bash
-# Run tests across all affected projects
-nx affected -t test
-```
+<test_integrity_guardrails note="violating any of these masks regressions and defeats the migration's purpose">
 
-### 3. Check Coverage
+- Do NOT force tests to pass by replacing test logic with `expect(true).toBe(true)`.
+- Do NOT remove assertions to silence a failure.
+- Do NOT add mocks that exist solely to make a failing test pass.
 
-```bash
-# Verify coverage generation works with new config
-nx affected -t test --coverage
-```
+If a test cannot be made to pass within the scope of this migration, leave it failing and report it in your handoff `summary`.
 
-### 4. Validate CI Pipeline
-
-```bash
-# Run full CI validation
-nx prepush
-```
-
-### 5. Review Migration Checklist
-
-- [ ] All configuration files updated
-- [ ] All test files pass
-- [ ] Coverage reports generate correctly
-- [ ] CI/CD pipeline runs successfully
-- [ ] Environment variables updated
-- [ ] Documentation updated
-- [ ] No deprecated API warnings in console
-
-## Common Issues and Solutions
-
-### Issue: Coverage includes too many files
-
-**Solution**: Add explicit `coverage.include` patterns to match your source files
-
-### Issue: Tests fail with "arrow function constructors not supported"
-
-**Solution**: Convert arrow functions used as constructors to `function` keyword or `class` syntax
-
-### Issue: Automocks not resetting between tests
-
-**Solution**: Use `vi.unmock()` or `vi.resetModules()` instead of `vi.restoreAllMocks()`
-
-### Issue: Mock call order assertions failing
-
-**Solution**: Update to 1-based indexing for `invocationCallOrder`
-
-### Issue: Browser tests failing after upgrade
-
-**Solution**: Check browser provider is object format and imports use `vitest/browser`
-
-### Issue: TypeScript errors in test files
-
-**Solution**: Update to new type definitions and remove usage of deprecated types
-
-## Files to Review
-
-Create a checklist of all files that need review:
-
-```bash
-# Configuration files
-find . -name "vitest.config.*" -o -name "vitest.workspace.*"
-find . -name "project.json" -exec grep -l "vitest" {} \;
-
-# Test files
-find . -name "*.spec.*" -o -name "*.test.*"
-
-# Files with mock usage
-rg "vi\.(fn|spyOn|mock|restoreAllMocks)" --type ts --type tsx --type js
-
-# Files with coverage config
-rg "coverage\.(all|extensions|ignoreEmptyLines)" --type ts --type js
-
-# CI configuration
-find . -name ".github/workflows/*.yml" -o -name ".gitlab-ci.yml" -o -name "azure-pipelines.yml"
-```
-
-## Migration Strategy for Large Workspaces
-
-1. **Migrate in phases**: Start with a small project, validate, then expand
-2. **Use feature branches**: Create separate branches for different migration aspects
-3. **Run tests frequently**: After each configuration change, run affected tests
-4. **Document issues**: Keep track of project-specific issues and solutions
-5. **Automate where possible**: Create codemods for repetitive changes
-
-## Useful Commands During Migration
-
-```bash
-# Find all vitest configurations
-nx show projects --with-target test
-
-# Test specific project after changes
-nx test PROJECT_NAME
-
-# Test all affected
-nx affected -t test
-
-# View project details
-nx show project PROJECT_NAME --web
-
-# Clear Nx cache if needed
-nx reset
-```
-
-## Guard Rails
-
-DO NOT
-
-- Force tests to pass by removing test logic and replacing it with `expect(true).toBe(true)`
-- Remove assertions
-- Add additional mocks that force tests to pass
-
----
-
-## Notes for LLM Execution
-
-When executing this migration:
-
-1. **Work systematically**: Complete one category before moving to the next
-2. **Test after each change**: Don't batch all changes without validation
-3. **Keep user informed**: Report progress through each section
-4. **Handle errors promptly**: If tests fail, fix immediately before proceeding
-5. **Update documentation**: Note any workspace-specific patterns or issues
-6. **Create meaningful commits**: Group related changes together with clear messages
-7. **Use TodoWrite tool**: Track migration progress for visibility
+</test_integrity_guardrails>

--- a/packages/vite/src/migrations/update-23-0-0/ai-instructions-for-vitest-4.md
+++ b/packages/vite/src/migrations/update-23-0-0/ai-instructions-for-vitest-4.md
@@ -4,6 +4,8 @@
 
 These instructions guide you through migrating an Nx workspace containing multiple Vitest projects from Vitest 3.x to Vitest 4.0. Work systematically through each breaking change category.
 
+> **Note**: a deterministic pre-pass has already run before these instructions. It applied the AST-tractable subset of the changes below (e.g. dead `coverage.*` option removal, `test.workspace` → `test.projects` rename, `@vitest/browser/context` → `vitest/browser` import path, `deps.optimizer.web` → `client`, `poolOptions.threads.useAtomics` and `test.minWorkers` removal, `'verbose'`/`'basic'` reporter renames, env-var renames in `package.json` scripts). Anything it could not handle was forwarded as advisory context (look for "Context from the generator phase" above) — focus your effort on those items and on the cross-cutting changes the pre-pass cannot perform safely (pool option flattening, `deps.* → server.deps.*` move, browser provider function-form rewrite, workspace file inlining, custom reporter callback updates).
+
 ## Prerequisites
 
 Vitest 4 has hard runtime requirements. Verify these BEFORE editing any config:

--- a/packages/vite/src/migrations/update-23-0-0/ai-instructions-for-vitest-4.md
+++ b/packages/vite/src/migrations/update-23-0-0/ai-instructions-for-vitest-4.md
@@ -12,11 +12,13 @@ These instructions guide you through migrating an Nx workspace containing multip
 > - `deps.optimizer.web` → `deps.optimizer.client` rename
 > - `poolOptions.threads.useAtomics` and top-level `test.minWorkers` removal
 > - `'verbose'` → `'tree'` and `'basic'` → `['default', { summary: false }]` inside `test.reporters`
-> - `VITEST_MAX_{THREADS,FORKS}` → `VITEST_MAX_WORKERS` and `VITE_NODE_DEPS_MODULE_DIRECTORIES` → `VITEST_MODULE_DIRECTORIES` env-var renames in `package.json` scripts
+> - `VITEST_MAX_{THREADS,FORKS}` → `VITEST_MAX_WORKERS` and `VITE_NODE_DEPS_MODULE_DIRECTORIES` → `VITEST_MODULE_DIRECTORIES` renames in: `package.json` scripts, `.env` / `.env.*` files, `project.json` `options.env` keys, and inline `VAR=value` prefixes inside `project.json` `options.{args,command,commands}`
+>
+> The pre-pass **skips the rename when both `VITEST_MAX_THREADS` and `VITEST_MAX_FORKS` appear in the same file/scope** (they collapse to a single `VITEST_MAX_WORKERS` whose value depends on which pool the project uses — a decision the pre-pass can't make safely). It also **does not** edit CI provider configs (`.github/workflows/*.yml`, `.gitlab-ci.yml`, `azure-pipelines.yml`, `.circleci/config.yml`, `bitbucket-pipelines.yml`) — YAML structure varies too much. Any conflicts and any CI matches are forwarded to you.
 >
 > **The cross-cutting changes below still require your attention** — pool option flattening (`singleThread`/`singleFork`, `maxThreads`/`maxForks`, `poolOptions.<pool>.{execArgv,isolate}`, `poolOptions.vmThreads.memoryLimit`), `test.deps.{external,inline,fallbackCJS}` → `test.server.deps.*` move, `test.{poolMatchGlobs,environmentMatchGlobs}` projects rewrite, browser provider function-form rewrite, `browser.testerScripts` → `testerHtmlPath`, `vitest.workspace.*` file inlining + `defineWorkspace` removal, custom reporter callback API updates, and `@vitest/browser` package replacement with per-provider packages.
 >
-> If a "Files modified by the generator phase" section appears in the prompt above, those files received the items the pre-pass handled — verify the new shape is in place before re-applying. If a "Context from the generator phase" section appears, **every entry there is pending work** the pre-pass detected but could not safely complete: address each one in addition to the relevant section below.
+> If a "Files modified by the generator phase" section appears in the prompt above, those files received the items the pre-pass handled — verify the new shape is in place before re-applying. If a "Context from the generator phase" section appears, **every entry there is pending work** the pre-pass detected but could not safely complete: address each one in addition to the relevant section below. A workspace-wide reminder is also emitted as a post-run "next step" about env vars set in CI provider dashboards — those can't be detected from the workspace tree.
 
 ## Prerequisites
 

--- a/packages/vite/src/migrations/update-23-0-0/ai-instructions-for-vitest-4.md
+++ b/packages/vite/src/migrations/update-23-0-0/ai-instructions-for-vitest-4.md
@@ -4,6 +4,22 @@
 
 These instructions guide you through migrating an Nx workspace containing multiple Vitest projects from Vitest 3.x to Vitest 4.0. Work systematically through each breaking change category.
 
+## Prerequisites
+
+Vitest 4 has hard runtime requirements. Verify these BEFORE editing any config:
+
+- **Vite ≥ 6.0.0** (Vite 5 is unsupported). Check with `npx vite --version`. If on Vite 5, apply the Vite 6 / 7 / 8 migration guides first.
+- **Node.js ≥ 20.0.0** (Node 18 support dropped). Check with `node --version`. Update CI `actions/setup-node` versions, `.nvmrc`, `engines` in `package.json`, and Docker base images.
+
+If either prerequisite is unmet, **stop and resolve them before continuing** — config-level migration on an unsupported runtime will produce confusing errors.
+
+## Nx-Specific Notes (read first)
+
+- **Inferred plugin targets**: modern Nx workspaces use `@nx/vitest/plugin` (or historically `@nx/vite/plugin`) to _infer_ test targets from `vitest.config.*` presence. `project.json` may have no `test` target. Inspect inferred targets with `nx show project <name> --json | jq .targets`. Renaming/moving `vitest.config.*` invalidates inference; run `nx reset` after structural moves.
+- **`@nx/vitest:test` / `@nx/vite:test` executor options**: when present in `project.json`, the relevant options are `configFile`, `reportsDirectory`, `mode`, `testFiles`, `watch`. Most option-level breaking changes in v4 are inside `vitest.config.*`, not these. The exception: any `--segfault-retry` in the executor `args` is now invalid and must be removed.
+- **Shared base config**: apply transforms to a workspace-root `vitest.config.base.ts` (extended via `mergeConfig`) BEFORE per-project overrides. Otherwise inherited options may shadow the migrated ones.
+- **Angular projects using AnalogJS** (`@analogjs/vitest-angular` / `@analogjs/vite-plugin-angular`): the Analog packages are bumped automatically by Nx's `packageJsonUpdates` (to the `~2.2.x` line). Review `src/test-setup.ts` and Analog plugin invocations in per-project `vitest.config.ts`.
+
 ## Pre-Migration Checklist
 
 1. **Identify all Vitest projects**:
@@ -14,8 +30,9 @@ These instructions guide you through migrating an Nx workspace containing multip
 
 2. **Locate all Vitest configuration files**:
    - Search for `vitest.config.{ts,js,mjs}`
-   - Search for `vitest.workspace.{ts,js,mjs}`
-   - Check `project.json` files for inline Vitest configuration
+   - Search for `vitest.workspace.{ts,js,mjs}` (removed in Vitest 4 — migrate to inline `test.projects`; see section 1.3 below)
+   - Check `project.json` files for `@nx/vitest:test` / `@nx/vite:test` executor options
+   - For workspaces relying on the inferred plugin (`@nx/vitest/plugin`), targets come from inference — inspect them with `nx show project <name> --json | jq .targets`
 
 3. **Identify affected code**:
    - Test files: `**/*.{spec,test}.{ts,js,tsx,jsx}`
@@ -73,13 +90,17 @@ export default defineConfig({
 **Changes Required**:
 
 ```typescript
-// ❌ BEFORE (Vitest 3.x)
+// ❌ BEFORE (Vitest 3.x — pool serialized via singleThread/singleFork)
 export default defineConfig({
   test: {
     maxThreads: 4,
     maxForks: 2,
-    singleThread: false,
+    singleFork: true,
     poolOptions: {
+      forks: {
+        execArgv: ['--expose-gc'],
+        isolate: false,
+      },
       threads: {
         useAtomics: true,
       },
@@ -90,24 +111,29 @@ export default defineConfig({
   },
 });
 
-// ✅ AFTER (Vitest 4.0)
+// ✅ AFTER (Vitest 4.0 — top-level pool config)
 export default defineConfig({
   test: {
-    maxWorkers: 4, // Consolidates maxThreads and maxForks
-    isolate: true, // Replaces singleThread: false
-    // Remove: poolOptions, threads.useAtomics
-    vmMemoryLimit: '512MB', // Moved to top-level
+    maxWorkers: 1, // singleFork: true => maxWorkers: 1, isolate: false
+    isolate: false,
+    execArgv: ['--expose-gc'], // moved from poolOptions.forks
+    vmMemoryLimit: '512MB', // moved from poolOptions.vmThreads.memoryLimit
+    // Remove: poolOptions, threads.useAtomics, minWorkers (also removed in v4)
   },
 });
 ```
 
 **Action Items**:
 
-- [ ] Replace `maxThreads` and `maxForks` with single `maxWorkers` option
-- [ ] Replace `singleThread: true` or `singleFork: true` with `maxWorkers: 1, isolate: false`
-- [ ] Move all `poolOptions.*` nested options to top-level (e.g., `poolOptions.vmThreads.memoryLimit` → `vmMemoryLimit`)
-- [ ] Remove `threads.useAtomics` option
-- [ ] Update CI environment variables: `VITEST_MAX_THREADS` and `VITEST_MAX_FORKS` → `VITEST_MAX_WORKERS`
+- [ ] Replace `maxThreads` and `maxForks` with a single `maxWorkers` option. If both values were set with different numbers (one for threads pool, one for forks pool), pick the value matching the pool the project actually uses — `maxWorkers` is pool-agnostic in v4.
+- [ ] Replace `singleThread: true` or `singleFork: true` with `maxWorkers: 1, isolate: false`.
+- [ ] If `singleThread: false` or `singleFork: false` was set explicitly, just delete — it's the default.
+- [ ] Move `poolOptions.{forks,threads}.execArgv` → top-level `execArgv`.
+- [ ] Move `poolOptions.{forks,threads}.isolate` → top-level `isolate`.
+- [ ] Move `poolOptions.vmThreads.memoryLimit` → top-level `vmMemoryLimit`.
+- [ ] Remove `poolOptions.threads.useAtomics` (option removed).
+- [ ] Remove `minWorkers` if present (option removed; behaves as if set to 0 in non-watch mode).
+- [ ] Update CI environment variables: `VITEST_MAX_THREADS` and `VITEST_MAX_FORKS` → `VITEST_MAX_WORKERS`.
 
 #### 1.3 Workspace to Projects Rename
 
@@ -133,16 +159,19 @@ export default defineConfig({
 
 **Action Items**:
 
-- [ ] Rename `workspace` property to `projects` in all config files
-- [ ] Remove external workspace file references (must be inline in config)
-- [ ] Update `poolMatchGlobs` to use `projects` pattern matching instead
-- [ ] Update `environmentMatchGlobs` to use `projects` pattern matching instead
+- [ ] Rename `workspace` property to `projects` in all config files.
+- [ ] Inline any external `vitest.workspace.*` content into `test.projects` and delete the workspace file (external file references are no longer supported).
+- [ ] If projects need different pool/environment options, set them inside each project entry rather than via the (now-removed) `poolMatchGlobs` / `environmentMatchGlobs` — see section 1.5.
 
 #### 1.4 Browser Configuration
 
-**Search Pattern**: `browser.provider`, `browser.testerScripts`, imports from `@vitest/browser`
+**Search Pattern**: `browser.provider`, `browser.testerScripts`, imports from `@vitest/browser`, `@vitest/browser/context`, `@vitest/browser/utils`
 
-**Changes Required**:
+**Changes Required**: `browser.provider` is no longer a string. It's now the **return value of a provider function** imported from a per-provider package. Official packages:
+
+- `@vitest/browser-playwright` — exports `playwright(options?)`
+- `@vitest/browser-webdriverio` — exports `webdriverio(options?)`
+- `@vitest/browser-preview` — exports `preview(options?)` (dev-only)
 
 ```typescript
 // ❌ BEFORE (Vitest 3.x)
@@ -150,36 +179,41 @@ export default defineConfig({
   test: {
     browser: {
       enabled: true,
-      provider: 'playwright', // String value
-      testerScripts: ['./setup.js'],
+      provider: 'playwright', // string
+      testerScripts: ['./setup.js'], // array of scripts
     },
   },
 });
-
-// Import changes
-import { page } from '@vitest/browser';
+import { page } from '@vitest/browser/context';
+import { getElementError } from '@vitest/browser/utils';
 
 // ✅ AFTER (Vitest 4.0)
+import { defineConfig } from 'vitest/config';
+import { playwright } from '@vitest/browser-playwright';
+
 export default defineConfig({
   test: {
     browser: {
       enabled: true,
-      provider: { name: 'playwright' }, // Object value
-      testerHtmlPath: './test-setup.html', // Renamed from testerScripts
+      provider: playwright({
+        launchOptions: { slowMo: 100 },
+      }),
+      instances: [{ browser: 'chromium' }],
+      testerHtmlPath: './test-setup.html', // single HTML path replaces script array
     },
   },
 });
-
-// Import changes
-import { page } from 'vitest/browser';
+import { page, utils } from 'vitest/browser';
+const { getElementError } = utils;
 ```
 
 **Action Items**:
 
-- [ ] Convert `browser.provider` string values to object format: `{ name: 'provider-name' }`
-- [ ] Replace `browser.testerScripts` with `browser.testerHtmlPath`
-- [ ] Update all imports from `@vitest/browser` to `vitest/browser`
-- [ ] Remove `@vitest/browser` from dependencies if no longer needed
+- [ ] Install the appropriate provider package: `@vitest/browser-playwright`, `@vitest/browser-webdriverio`, or `@vitest/browser-preview`. Match whatever your `browser.provider` string was previously.
+- [ ] Remove `@vitest/browser` from `dependencies`/`devDependencies` — its public surface moved into the main `vitest` package and the per-provider packages.
+- [ ] Replace string `browser.provider: 'name'` with the function-call form: `provider: <providerFn>(<options>)`.
+- [ ] Replace `browser.testerScripts: [...]` with `browser.testerHtmlPath: '<single-file>.html'`. Note: this is a **semantic** change (array of scripts → one HTML file). Move the script contents into a `<script>` block of the HTML file, or load them with `<script src>` references inside it.
+- [ ] Update imports: `@vitest/browser/context` → `vitest/browser`; `@vitest/browser/utils` → `vitest/browser` (named export `utils`).
 
 #### 1.5 Deprecated Configuration Options
 
@@ -215,9 +249,69 @@ export default defineConfig({
 
 **Action Items**:
 
-- [ ] Move `deps.*` options under `server.deps` namespace
-- [ ] Remove `poolMatchGlobs` (use `projects` with conditions instead)
-- [ ] Remove `environmentMatchGlobs` (use `projects` with conditions instead)
+- [ ] Move `deps.*` options under `server.deps` namespace.
+- [ ] Rename `deps.optimizer.web` → `deps.optimizer.client` (separate rename, same area).
+- [ ] Remove `poolMatchGlobs` (use `projects` with conditions instead).
+- [ ] Remove `environmentMatchGlobs` (use `projects` with conditions instead).
+
+#### 1.6 Default Test File Exclusions Narrowed
+
+**Search Pattern**: workspaces that have non-test files in `dist/`, `cypress/`, `.idea/`, `.cache/`, `.output/`, `.temp/`, or root config files (`rollup.config.*`, `prettier.config.*`, etc.) that look like test files.
+
+**What Changed**: Vitest 4 excludes ONLY `node_modules` and `.git` by default. Previously, additional directories and root config files were excluded. Workspaces with `*.{spec,test}.*`-named files in those previously-excluded locations will see them picked up by the test runner in v4 unless an explicit exclusion is added.
+
+```typescript
+// To restore Vitest 3.x default exclusion behavior:
+import { configDefaults, defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    exclude: [
+      ...configDefaults.exclude,
+      '**/dist/**',
+      '**/cypress/**',
+      '**/.{idea,git,cache,output,temp}/**',
+      '**/{karma,rollup,webpack,vite,vitest,jest,ava,babel,nyc,cypress,tsup,build,eslint,prettier}.config.*',
+    ],
+  },
+});
+```
+
+**Recommendation**: prefer `test.dir` to scope discovery for performance, instead of relying on negative exclusions.
+
+**Action Items**:
+
+- [ ] After upgrading, run `nx test <project>` for each affected project. If new test files surface unexpectedly from `dist/`, `cypress/`, etc., apply the snippet above or add a narrower exclude pattern.
+- [ ] Consider setting `test.dir: './src'` (or equivalent) per project to scope discovery to source.
+
+#### 1.7 Custom Environments: `transformMode` → `viteEnvironment`
+
+**Applies when**: A project exports a custom Vitest environment (rare; check for files with `default export` of `{ name, setup, transformMode, ... }` consumed via `test.environment`).
+
+```typescript
+// ❌ BEFORE (Vitest 3.x)
+export default {
+  name: 'my-env',
+  setup() {
+    /* ... */
+  },
+  transformMode: 'ssr',
+};
+
+// ✅ AFTER (Vitest 4.0)
+export default {
+  name: 'my-env',
+  setup() {
+    /* ... */
+  },
+  viteEnvironment: 'custom-env',
+};
+```
+
+**Action Items**:
+
+- [ ] If a custom environment file exists, rename its `transformMode` property to `viteEnvironment`.
+- [ ] No change needed for workspaces using only built-in environments (`node`, `jsdom`, `happy-dom`, `edge-runtime`).
 
 ### 2. Test Code Updates
 
@@ -352,7 +446,7 @@ const spy = vi.spyOn({ method: mock }, 'method');
 
 #### 2.6 Automock Behavior Changes
 
-**Search Pattern**: `vi.mock()` with factory functions, `.mockRestore()` on automocks
+**Search Pattern**: `vi.mock()` factories with getters, instance methods on automocked classes, `vi.restoreAllMocks()` usage when modules are automocked.
 
 **Changes Required**:
 
@@ -361,15 +455,11 @@ const spy = vi.spyOn({ method: mock }, 'method');
 vi.mock('./utils', () => ({
   get value() {
     return 42;
-  }, // Would call getter
+  }, // getter executed
 }));
 
 import { value } from './utils';
-console.log(value); // Would execute getter logic
-
-// Restore might have worked
-const spy = vi.spyOn(obj, 'method');
-spy.mockRestore(); // Might work on automocks
+console.log(value); // executes getter, prints 42
 
 // ✅ AFTER (Vitest 4.0)
 vi.mock('./utils', () => ({
@@ -379,27 +469,40 @@ vi.mock('./utils', () => ({
 }));
 
 import { value } from './utils';
-console.log(value); // Returns undefined (doesn't call getter)
+console.log(value); // getter NOT executed; prints undefined
 
-// Explicitly return value if needed
-vi.mock('./utils', () => ({
-  value: 42, // Not a getter
-}));
+// To spy on the getter explicitly:
+vi.spyOn(utilsModule, 'value', 'get').mockReturnValue(42);
 
-// mockRestore no longer works on automocks
-const spy = vi.spyOn(obj, 'method');
-spy.mockRestore(); // Throws error if method is automocked
-
-// Use unmock instead
-vi.unmock('./module');
+// Or define as a plain property (not a getter):
+vi.mock('./utils', () => ({ value: 42 }));
 ```
+
+Additional behavior changes for automocked instance methods:
+
+```typescript
+// Each instance gets its own mock for the same method name
+const a = new AutoMockedClass();
+const b = new AutoMockedClass();
+a.method.mockReturnValue(42);
+expect(a.method()).toBe(42);
+expect(b.method()).toBeUndefined(); // independent per instance
+
+// But the prototype is shared: a method mocked on the prototype affects all
+// instances that don't have a per-instance mock.
+AutoMockedClass.prototype.method.mockReturnValue(100);
+b.method.mockReset(); // remove per-instance mock if any
+expect(b.method()).toBe(100);
+```
+
+`vi.restoreAllMocks()` no longer touches automocks. Use `vi.unmock(modulePath)` or `vi.resetModules()` to clear an automocked module. **`.mockRestore()` on a single spy still works** (resets its implementation and clears state) regardless of whether the underlying module is automocked.
 
 **Action Items**:
 
-- [ ] Convert automocked getters to plain property values where needed
-- [ ] Remove `.mockRestore()` calls on automocked methods
-- [ ] Use `vi.unmock()` to clear automocks instead
-- [ ] Test instance method isolation (they now share state with prototype)
+- [ ] Replace automocked **getters** that need to return values with plain property definitions, or add an explicit `vi.spyOn(obj, name, 'get').mockReturnValue(...)`.
+- [ ] If a test relied on `vi.restoreAllMocks()` clearing an automocked module, add explicit `vi.unmock('./module')` or `vi.resetModules()` calls.
+- [ ] Audit tests that mock instance methods of an automocked class; the per-instance independence may surface latent bugs.
+- [ ] Do NOT remove `.mockRestore()` calls on single spies — they still work correctly.
 
 #### 2.7 Settled Results Immediate Population
 
@@ -436,7 +539,13 @@ expect(asyncMock.mock.settledResults[0]).toEqual({
 
 #### 3.1 Reporter API Changes
 
-**Search Pattern**: Custom reporters, `onCollected`, `onTaskUpdate`, `onFinished`
+**Search Pattern**: custom reporter classes/objects implementing any of these removed callbacks:
+
+- `onCollected`
+- `onSpecsCollected`
+- `onPathsCollected`
+- `onTaskUpdate`
+- `onFinished`
 
 **Changes Required**:
 
@@ -444,25 +553,30 @@ expect(asyncMock.mock.settledResults[0]).toEqual({
 // ❌ BEFORE (Vitest 3.x)
 export default {
   onCollected(files) {
-    // Handle collected files
+    /* ... */
   },
   onTaskUpdate(task) {
-    // Handle task update
+    /* ... */
   },
   onFinished(files) {
-    // Handle completion
+    /* ... */
   },
 };
 
 // ✅ AFTER (Vitest 4.0)
-// Use new reporter API - consult Vitest 4 docs for replacement methods
+// Use the new test-module / test-case event API. See:
+// https://vitest.dev/api/advanced/reporters
+// Typical replacements:
+//   onCollected      → onTestModuleCollected
+//   onTaskUpdate     → onTestCaseResult / onTestModuleEnd
+//   onFinished       → onTestRunEnd
 ```
 
 **Action Items**:
 
-- [ ] Review custom reporters for removed API usage
-- [ ] Consult Vitest 4 documentation for new reporter API
-- [ ] Update or rewrite custom reporters to use new APIs
+- [ ] Audit every custom reporter file for any of the five removed callbacks listed above. Each one needs replacement.
+- [ ] Consult the v4 reporters API at https://vitest.dev/api/advanced/reporters for the exact replacement method name and signature.
+- [ ] After rewriting, run the reporter in isolation against a small project to verify event delivery before applying workspace-wide.
 
 #### 3.2 Built-in Reporter Changes
 
@@ -510,7 +624,9 @@ reporters: ['tree']; // Use 'tree' for hierarchical output
 // If you want old behavior (don't print shadow root):
 export default defineConfig({
   test: {
-    printShadowRoot: false,
+    snapshotFormat: {
+      printShadowRoot: false,
+    },
   },
 });
 ```
@@ -519,7 +635,44 @@ export default defineConfig({
 
 - [ ] Review snapshot tests for custom elements
 - [ ] Update snapshots if shadow root contents are now included
-- [ ] Add `printShadowRoot: false` if old behavior is required
+- [ ] Add `printShadowRoot: false` to `snapshotFormat` if old behavior is required
+
+#### 4.2 `vi.fn` Snapshot String Changed
+
+**Search Pattern**: `__snapshots__/**/*.snap` files containing `[MockFunction spy]`
+
+**What Changed**: The default rendered string for an unnamed mock function in snapshots changed from `[MockFunction spy]` to `[MockFunction]`. Snapshots of mock objects taken in v3 will mismatch on re-run.
+
+**Action Items**:
+
+- [ ] Run tests with `--update` for projects that snapshot mock objects, then review the diff to confirm only the mock-name string changed.
+- [ ] Where a specific mock name is asserted in snapshots, add explicit `.mockName('...')` calls.
+
+#### 4.3 Custom Snapshot Matchers: Import Path Change
+
+**Applies when**: A workspace defines custom snapshot matchers using `jest-snapshot`.
+
+**What Changed**: Vitest 4 expects custom snapshot matchers to import from `vitest` (the new `Snapshots` namespace), not `jest-snapshot`.
+
+```typescript
+// ❌ BEFORE (Vitest 3.x)
+const { toMatchSnapshot } = require('jest-snapshot');
+
+// ✅ AFTER (Vitest 4.0)
+import { Snapshots } from 'vitest';
+const { toMatchSnapshot } = Snapshots;
+
+expect.extend({
+  toMatchTrimmedSnapshot(received: string, length: number) {
+    return toMatchSnapshot.call(this, received.slice(0, length));
+  },
+});
+```
+
+**Action Items**:
+
+- [ ] Replace `require('jest-snapshot')` / `import 'jest-snapshot'` in custom matcher files with `import { Snapshots } from 'vitest'`.
+- [ ] Remove `jest-snapshot` from `dependencies`/`devDependencies` if it's no longer used elsewhere.
 
 ### 5. Environment Variable Updates
 

--- a/packages/vite/src/migrations/update-23-0-0/lib/ast-edits.ts
+++ b/packages/vite/src/migrations/update-23-0-0/lib/ast-edits.ts
@@ -1,0 +1,59 @@
+import type { Node } from 'typescript';
+
+export interface TextEdit {
+  start: number;
+  end: number;
+  replacement: string;
+}
+
+/**
+ * Apply a list of non-overlapping edits to `contents`. Edits are sorted by
+ * `start` descending so positions stay valid as text is spliced.
+ */
+export function applyTextEdits(contents: string, edits: TextEdit[]): string {
+  if (edits.length === 0) return contents;
+  const sorted = [...edits].sort((a, b) => b.start - a.start);
+  let updated = contents;
+  for (const edit of sorted) {
+    updated =
+      updated.slice(0, edit.start) + edit.replacement + updated.slice(edit.end);
+  }
+  return updated;
+}
+
+/**
+ * Edit that removes `node` and a single trailing comma if present. Designed
+ * for removing a `PropertyAssignment` from an object literal without leaving
+ * a dangling separator.
+ */
+export function removeNodeWithTrailingCommaEdit(
+  contents: string,
+  node: Node
+): TextEdit {
+  const start = node.getStart();
+  let end = node.getEnd();
+  if (contents[end] === ',') end++;
+  return { start, end, replacement: '' };
+}
+
+/**
+ * Edit that replaces the textual range of `node` with `replacement`.
+ */
+export function replaceNodeTextEdit(node: Node, replacement: string): TextEdit {
+  return { start: node.getStart(), end: node.getEnd(), replacement };
+}
+
+/**
+ * Edit that replaces a string literal's content while preserving the user's
+ * original quote style. `node` is expected to be a StringLiteral.
+ */
+export function replaceStringLiteralValueEdit(
+  contents: string,
+  node: Node,
+  newValue: string
+): TextEdit {
+  const start = node.getStart();
+  const end = node.getEnd();
+  const quote = contents[start]; // ' or "
+  return { start, end, replacement: `${quote}${newValue}${quote}` };
+}

--- a/packages/vite/src/migrations/update-23-0-0/lib/ci-files.ts
+++ b/packages/vite/src/migrations/update-23-0-0/lib/ci-files.ts
@@ -1,0 +1,32 @@
+import { visitNotIgnoredFiles, type Tree } from '@nx/devkit';
+import picomatch = require('picomatch');
+
+// Common CI provider configs. Mechanical edits inside YAML are risky
+// (comments, anchors, multi-line strings), so the pre-pass only scans these
+// for legacy tokens and forwards file paths as advisory context.
+const CI_GLOBS = [
+  '**/.github/workflows/*.{yml,yaml}',
+  '**/.gitlab-ci.yml',
+  '**/.gitlab-ci.*.yml',
+  '**/azure-pipelines.{yml,yaml}',
+  '**/azure-pipelines.*.{yml,yaml}',
+  '**/.circleci/config.yml',
+  '**/bitbucket-pipelines.yml',
+];
+
+const ciMatchers = CI_GLOBS.map((g) => picomatch(g));
+
+export function isCiFile(filePath: string): boolean {
+  return ciMatchers.some((m) => m(filePath));
+}
+
+export function visitCiFiles(
+  tree: Tree,
+  callback: (filePath: string, contents: string) => void
+): void {
+  visitNotIgnoredFiles(tree, '', (filePath) => {
+    if (!isCiFile(filePath)) return;
+    const contents = tree.read(filePath, 'utf-8');
+    callback(filePath, contents);
+  });
+}

--- a/packages/vite/src/migrations/update-23-0-0/lib/vitest-config-files.ts
+++ b/packages/vite/src/migrations/update-23-0-0/lib/vitest-config-files.ts
@@ -1,0 +1,48 @@
+import { visitNotIgnoredFiles, type Tree } from '@nx/devkit';
+import picomatch = require('picomatch');
+
+// Vitest options can live in either `vitest.config.*` (dedicated) or
+// `vite.config.*` (the `test:` block consumed by the inferred plugin).
+const CONFIG_GLOBS = [
+  '**/vitest.*config*.{js,ts,mjs,mts,cjs,cts}',
+  '**/vite.*config*.{js,ts,mjs,mts,cjs,cts}',
+];
+const WORKSPACE_GLOB = '**/vitest.workspace.{js,ts,mjs,mts,cjs,cts}';
+
+const configMatchers = CONFIG_GLOBS.map((g) => picomatch(g));
+const workspaceMatcher = picomatch(WORKSPACE_GLOB);
+
+export function isVitestConfigFile(filePath: string): boolean {
+  return configMatchers.some((m) => m(filePath));
+}
+
+export function isVitestWorkspaceFile(filePath: string): boolean {
+  return workspaceMatcher(filePath);
+}
+
+export function visitVitestConfigFiles(
+  tree: Tree,
+  callback: (filePath: string) => void
+): void {
+  visitNotIgnoredFiles(tree, '', (filePath) => {
+    if (isVitestConfigFile(filePath)) {
+      callback(filePath);
+    }
+  });
+}
+
+export function visitVitestWorkspaceFiles(
+  tree: Tree,
+  callback: (filePath: string) => void
+): void {
+  visitNotIgnoredFiles(tree, '', (filePath) => {
+    if (isVitestWorkspaceFile(filePath)) {
+      callback(filePath);
+    }
+  });
+}
+
+const TS_JS_RE = /\.[cm]?[jt]sx?$/;
+export function isJsOrTsFile(filePath: string): boolean {
+  return TS_JS_RE.test(filePath);
+}

--- a/packages/vite/src/migrations/update-23-0-0/lib/vitest-config-files.ts
+++ b/packages/vite/src/migrations/update-23-0-0/lib/vitest-config-files.ts
@@ -31,17 +31,6 @@ export function visitVitestConfigFiles(
   });
 }
 
-export function visitVitestWorkspaceFiles(
-  tree: Tree,
-  callback: (filePath: string) => void
-): void {
-  visitNotIgnoredFiles(tree, '', (filePath) => {
-    if (isVitestWorkspaceFile(filePath)) {
-      callback(filePath);
-    }
-  });
-}
-
 const TS_JS_RE = /\.[cm]?[jt]sx?$/;
 export function isJsOrTsFile(filePath: string): boolean {
   return TS_JS_RE.test(filePath);

--- a/packages/vite/src/migrations/update-23-0-0/migrate-to-vitest-3.spec.ts
+++ b/packages/vite/src/migrations/update-23-0-0/migrate-to-vitest-3.spec.ts
@@ -182,7 +182,7 @@ export default defineConfig({
       const result = await migrateToVitest3(tree);
 
       expect(tree.read('libs/lib/src/snap.ts', 'utf-8')).toBe(before);
-      expect(result?.promptContext?.[0]).toMatch(
+      expect(result?.agentContext?.[0]).toMatch(
         /SnapshotEnvironment.*Split it into a separate/
       );
     });
@@ -391,7 +391,7 @@ export default defineConfig({
 
       const result = await migrateToVitest3(tree);
 
-      const ciEntry = result?.promptContext?.find((s) =>
+      const ciEntry = result?.agentContext?.find((s) =>
         s.startsWith('.github/workflows/test.yml')
       );
       expect(ciEntry).toBeDefined();
@@ -422,7 +422,7 @@ export default defineConfig({
 
       expect(tree.read('vitest.config.ts', 'utf-8')).toBe(before);
       expect(
-        result?.promptContext?.some((s) =>
+        result?.agentContext?.some((s) =>
           /vitest\.config\.ts.*'c8'.*resolves to c8/.test(s)
         )
       ).toBe(true);
@@ -445,7 +445,7 @@ export default defineConfig({
 
       expect(tree.read('vitest.config.ts', 'utf-8')).toBe(before);
       expect(
-        result?.promptContext?.some((s) =>
+        result?.agentContext?.some((s) =>
           /vitest\.config\.ts.*indexScripts.*orchestratorScripts/.test(s)
         )
       ).toBe(true);
@@ -453,7 +453,7 @@ export default defineConfig({
   });
 
   describe('no-op when nothing matches', () => {
-    it('leaves files untouched and returns no promptContext', async () => {
+    it('leaves files untouched and returns no agentContext', async () => {
       const tree = createTreeWithEmptyWorkspace();
       tree.write(
         'vitest.config.ts',

--- a/packages/vite/src/migrations/update-23-0-0/migrate-to-vitest-3.spec.ts
+++ b/packages/vite/src/migrations/update-23-0-0/migrate-to-vitest-3.spec.ts
@@ -303,6 +303,155 @@ export default defineConfig({
     });
   });
 
+  describe('project.json rewrites (V3-1 / V3-3 — extended)', () => {
+    it('strips --segfault-retry from options.args/command/commands', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'apps/app/project.json',
+        JSON.stringify(
+          {
+            name: 'app',
+            targets: {
+              tArgsString: {
+                options: { args: '--segfault-retry=3 --reporter=verbose' },
+              },
+              tArgsArray: {
+                options: {
+                  args: ['--segfault-retry=3', '--reporter=verbose'],
+                },
+              },
+              tCommand: {
+                options: { command: 'vitest run --segfault-retry 5' },
+              },
+              tCommands: {
+                options: { commands: ['vitest run --segfault-retry'] },
+              },
+            },
+          },
+          null,
+          2
+        )
+      );
+
+      await migrateToVitest3(tree);
+
+      const updated = JSON.parse(tree.read('apps/app/project.json', 'utf-8'));
+      expect(updated.targets.tArgsString.options.args).toBe(
+        '--reporter=verbose'
+      );
+      expect(updated.targets.tArgsArray.options.args).toEqual([
+        '--reporter=verbose',
+      ]);
+      expect(updated.targets.tCommand.options.command).toBe('vitest run');
+      expect(updated.targets.tCommands.options.commands).toEqual([
+        'vitest run',
+      ]);
+    });
+
+    it('rewrites `vitest typecheck` to `vitest --typecheck` inside command/commands/args', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'apps/app/project.json',
+        JSON.stringify(
+          {
+            name: 'app',
+            targets: {
+              typecheck: { options: { command: 'vitest typecheck --run' } },
+              typecheckAll: {
+                options: {
+                  commands: ['pnpm exec vitest typecheck'],
+                },
+              },
+            },
+          },
+          null,
+          2
+        )
+      );
+
+      await migrateToVitest3(tree);
+
+      const updated = JSON.parse(tree.read('apps/app/project.json', 'utf-8'));
+      expect(updated.targets.typecheck.options.command).toBe(
+        'vitest --typecheck --run'
+      );
+      expect(updated.targets.typecheckAll.options.commands).toEqual([
+        'pnpm exec vitest --typecheck',
+      ]);
+    });
+  });
+
+  describe('CI YAML scan (V3-1 / V3-3 — extended)', () => {
+    it('logs the file path + tokens found in .github/workflows files', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        '.github/workflows/test.yml',
+        `jobs:\n  test:\n    steps:\n      - run: pnpm vitest typecheck\n      - run: pnpm vitest run --segfault-retry=3\n`
+      );
+
+      const result = await migrateToVitest3(tree);
+
+      const ciEntry = result?.promptContext?.find((s) =>
+        s.startsWith('.github/workflows/test.yml')
+      );
+      expect(ciEntry).toBeDefined();
+      expect(ciEntry).toContain('--segfault-retry');
+      expect(ciEntry).toContain('vitest typecheck');
+      // CI file is not mechanically rewritten.
+      expect(tree.read('.github/workflows/test.yml', 'utf-8')).toContain(
+        '--segfault-retry'
+      );
+    });
+  });
+
+  describe('substring fallback for indirected shapes', () => {
+    it("logs when 'c8' substring appears but no direct coverage.provider AST assignment", async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'vitest.config.ts',
+        `import { defineConfig } from 'vitest/config';
+const PROVIDER = 'c8';
+export default defineConfig({
+  test: { coverage: { provider: PROVIDER } },
+});
+`
+      );
+      const before = tree.read('vitest.config.ts', 'utf-8');
+
+      const result = await migrateToVitest3(tree);
+
+      expect(tree.read('vitest.config.ts', 'utf-8')).toBe(before);
+      expect(
+        result?.promptContext?.some((s) =>
+          /vitest\.config\.ts.*'c8'.*resolves to c8/.test(s)
+        )
+      ).toBe(true);
+    });
+
+    it("logs when 'indexScripts' substring appears but no direct browser.indexScripts AST assignment", async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'vitest.config.ts',
+        `import { defineConfig } from 'vitest/config';
+const SCRIPTS_KEY = 'indexScripts';
+export default defineConfig({
+  test: { browser: { [SCRIPTS_KEY]: ['./s.js'] } },
+});
+`
+      );
+      const before = tree.read('vitest.config.ts', 'utf-8');
+
+      const result = await migrateToVitest3(tree);
+
+      expect(tree.read('vitest.config.ts', 'utf-8')).toBe(before);
+      expect(
+        result?.promptContext?.some((s) =>
+          /vitest\.config\.ts.*indexScripts.*orchestratorScripts/.test(s)
+        )
+      ).toBe(true);
+    });
+  });
+
   describe('no-op when nothing matches', () => {
     it('leaves files untouched and returns no promptContext', async () => {
       const tree = createTreeWithEmptyWorkspace();

--- a/packages/vite/src/migrations/update-23-0-0/migrate-to-vitest-3.spec.ts
+++ b/packages/vite/src/migrations/update-23-0-0/migrate-to-vitest-3.spec.ts
@@ -1,0 +1,325 @@
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migrateToVitest3 from './migrate-to-vitest-3';
+
+describe('migrate-to-vitest-3', () => {
+  describe('--segfault-retry removal (V3-1)', () => {
+    it('strips --segfault-retry with and without numeric arg from package.json scripts', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'package.json',
+        JSON.stringify(
+          {
+            scripts: {
+              a: 'vitest run --segfault-retry=3',
+              b: 'vitest run --segfault-retry 5 --reporter=verbose',
+              c: 'vitest run --segfault-retry',
+              d: 'vitest run',
+            },
+          },
+          null,
+          2
+        )
+      );
+
+      await migrateToVitest3(tree);
+
+      const updated = JSON.parse(tree.read('package.json', 'utf-8'));
+      expect(updated.scripts).toEqual({
+        a: 'vitest run',
+        b: 'vitest run --reporter=verbose',
+        c: 'vitest run',
+        d: 'vitest run',
+      });
+    });
+  });
+
+  describe('coverage-c8 → coverage-v8 (V3-2)', () => {
+    it('renames the package.json dep while preserving the user pin and order', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'package.json',
+        JSON.stringify(
+          {
+            devDependencies: {
+              eslint: '^9.0.0',
+              '@vitest/coverage-c8': '~0.34.6',
+              vitest: '^3.0.0',
+            },
+          },
+          null,
+          2
+        )
+      );
+
+      await migrateToVitest3(tree);
+
+      const updated = JSON.parse(tree.read('package.json', 'utf-8'));
+      expect(Object.keys(updated.devDependencies)).toEqual([
+        'eslint',
+        '@vitest/coverage-v8',
+        'vitest',
+      ]);
+      expect(updated.devDependencies['@vitest/coverage-v8']).toBe('~0.34.6');
+    });
+
+    it('drops the c8 key when v8 is already present (avoids overwriting user pin)', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'package.json',
+        JSON.stringify(
+          {
+            devDependencies: {
+              '@vitest/coverage-c8': '~0.34.6',
+              '@vitest/coverage-v8': '^3.0.0',
+            },
+          },
+          null,
+          2
+        )
+      );
+
+      await migrateToVitest3(tree);
+
+      const updated = JSON.parse(tree.read('package.json', 'utf-8'));
+      expect(updated.devDependencies).toEqual({
+        '@vitest/coverage-v8': '^3.0.0',
+      });
+    });
+
+    it("renames coverage.provider: 'c8' → 'v8' inside vitest config", async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'vitest.config.ts',
+        `import { defineConfig } from 'vitest/config';
+export default defineConfig({
+  test: {
+    coverage: { provider: 'c8', reporter: ['text'] },
+  },
+});
+`
+      );
+
+      await migrateToVitest3(tree);
+
+      expect(tree.read('vitest.config.ts', 'utf-8')).toContain(
+        "provider: 'v8'"
+      );
+    });
+
+    it("does not touch a `provider: 'c8'` outside test.coverage", async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'vitest.config.ts',
+        `import { defineConfig } from 'vitest/config';
+export default defineConfig({
+  // unrelated property happens to mention the same string
+  define: { 'process.env.PROVIDER': "'c8'" },
+  test: { coverage: { provider: 'v8' } },
+});
+`
+      );
+      const before = tree.read('vitest.config.ts', 'utf-8');
+
+      await migrateToVitest3(tree);
+
+      expect(tree.read('vitest.config.ts', 'utf-8')).toBe(before);
+    });
+  });
+
+  describe('vitest typecheck flag (V3-3)', () => {
+    it('rewrites `vitest typecheck` to `vitest --typecheck` in package.json scripts', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'package.json',
+        JSON.stringify(
+          {
+            scripts: {
+              typecheck: 'vitest typecheck',
+              chained: 'vitest typecheck --run && echo done',
+              unrelated: 'echo vitest typecheck-helper',
+            },
+          },
+          null,
+          2
+        )
+      );
+
+      await migrateToVitest3(tree);
+
+      const updated = JSON.parse(tree.read('package.json', 'utf-8'));
+      expect(updated.scripts).toEqual({
+        typecheck: 'vitest --typecheck',
+        chained: 'vitest --typecheck --run && echo done',
+        // word-boundary protects `typecheck-helper`.
+        unrelated: 'echo vitest typecheck-helper',
+      });
+    });
+  });
+
+  describe('SnapshotEnvironment import path (V3-4)', () => {
+    it("rewrites a sole `SnapshotEnvironment` import to 'vitest/snapshot'", async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'libs/lib/src/snap.ts',
+        `import { SnapshotEnvironment } from 'vitest';\nexport default SnapshotEnvironment;\n`
+      );
+
+      await migrateToVitest3(tree);
+
+      expect(tree.read('libs/lib/src/snap.ts', 'utf-8')).toContain(
+        "from 'vitest/snapshot'"
+      );
+    });
+
+    it('logs unhandled when SnapshotEnvironment is mixed with other vitest bindings', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'libs/lib/src/snap.ts',
+        `import { SnapshotEnvironment, vi } from 'vitest';\nexport default SnapshotEnvironment;\nvi.fn();\n`
+      );
+      const before = tree.read('libs/lib/src/snap.ts', 'utf-8');
+
+      const result = await migrateToVitest3(tree);
+
+      expect(tree.read('libs/lib/src/snap.ts', 'utf-8')).toBe(before);
+      expect(result?.promptContext?.[0]).toMatch(
+        /SnapshotEnvironment.*Split it into a separate/
+      );
+    });
+  });
+
+  describe("browser.provider 'none' → 'preview' (V3-5)", () => {
+    it('rewrites only the provider literal inside test.browser', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'vitest.config.ts',
+        `import { defineConfig } from 'vitest/config';
+export default defineConfig({
+  test: {
+    browser: { enabled: true, provider: 'none' },
+  },
+});
+`
+      );
+
+      await migrateToVitest3(tree);
+
+      const updated = tree.read('vitest.config.ts', 'utf-8');
+      expect(updated).toContain("provider: 'preview'");
+      expect(updated).not.toContain("provider: 'none'");
+    });
+  });
+
+  describe('browser.indexScripts → orchestratorScripts (V3-6)', () => {
+    it('renames the identifier inside test.browser', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'vitest.config.ts',
+        `import { defineConfig } from 'vitest/config';
+export default defineConfig({
+  test: {
+    browser: { indexScripts: ['./setup.js'] },
+  },
+});
+`
+      );
+
+      await migrateToVitest3(tree);
+
+      expect(tree.read('vitest.config.ts', 'utf-8')).toContain(
+        'orchestratorScripts: '
+      );
+    });
+  });
+
+  describe('shape-agnostic anchoring', () => {
+    it('applies transforms inside a `mergeConfig`-wrapped, factory-form config', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'vitest.config.base.ts',
+        `import { defineConfig, mergeConfig } from 'vitest/config';
+const base = defineConfig({ test: { coverage: { provider: 'c8' } } });
+export default mergeConfig(
+  base,
+  defineConfig(({ mode }) => ({
+    test: {
+      browser: { provider: 'none', indexScripts: ['./s.js'] },
+    },
+  }))
+);
+`
+      );
+
+      await migrateToVitest3(tree);
+
+      const updated = tree.read('vitest.config.base.ts', 'utf-8');
+      expect(updated).toContain("provider: 'v8'");
+      expect(updated).toContain("provider: 'preview'");
+      expect(updated).toContain('orchestratorScripts:');
+      expect(updated).not.toContain("provider: 'c8'");
+      expect(updated).not.toContain("provider: 'none'");
+      expect(updated).not.toContain('indexScripts');
+    });
+  });
+
+  describe('idempotency', () => {
+    it('is a no-op on a second run', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'package.json',
+        JSON.stringify(
+          {
+            scripts: { test: 'vitest run --segfault-retry=3' },
+            devDependencies: { '@vitest/coverage-c8': '~0.34.6' },
+          },
+          null,
+          2
+        )
+      );
+      tree.write(
+        'vitest.config.ts',
+        `import { defineConfig } from 'vitest/config';
+export default defineConfig({
+  test: {
+    coverage: { provider: 'c8' },
+    browser: { provider: 'none', indexScripts: ['./s.js'] },
+  },
+});
+`
+      );
+
+      await migrateToVitest3(tree);
+      const afterFirst = {
+        pkg: tree.read('package.json', 'utf-8'),
+        cfg: tree.read('vitest.config.ts', 'utf-8'),
+      };
+      await migrateToVitest3(tree);
+      const afterSecond = {
+        pkg: tree.read('package.json', 'utf-8'),
+        cfg: tree.read('vitest.config.ts', 'utf-8'),
+      };
+
+      expect(afterSecond).toEqual(afterFirst);
+    });
+  });
+
+  describe('no-op when nothing matches', () => {
+    it('leaves files untouched and returns no promptContext', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'vitest.config.ts',
+        `import { defineConfig } from 'vitest/config';
+export default defineConfig({
+  test: { coverage: { provider: 'v8' } },
+});
+`
+      );
+      const before = tree.read('vitest.config.ts', 'utf-8');
+
+      const result = await migrateToVitest3(tree);
+
+      expect(tree.read('vitest.config.ts', 'utf-8')).toBe(before);
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/packages/vite/src/migrations/update-23-0-0/migrate-to-vitest-3.ts
+++ b/packages/vite/src/migrations/update-23-0-0/migrate-to-vitest-3.ts
@@ -26,7 +26,7 @@ let ts: typeof import('typescript');
 /**
  * Hybrid migration paired with `ai-instructions-for-vitest-3.md`. Applies the
  * deterministic, AST-tractable Vitest 1.x/2.x → 3.x changes mechanically and
- * returns a `promptContext` describing any shape it could not handle, so the
+ * returns an `agentContext` describing any shape it could not handle, so the
  * paired prompt's agent can finish those by hand.
  */
 export default async function migrateToVitest3(tree: Tree) {
@@ -55,10 +55,10 @@ export default async function migrateToVitest3(tree: Tree) {
 
   await formatFiles(tree);
 
-  // Hybrid migration return shape: `promptContext` (when populated) is
+  // Hybrid migration return shape: `agentContext` (when populated) is
   // forwarded to the paired prompt's agent. When no agent runs, the field is
   // dropped silently per the contract — safe on master and pre-agentic flows.
-  if (unhandled.length > 0) return { promptContext: unhandled };
+  if (unhandled.length > 0) return { agentContext: unhandled };
   return;
 }
 

--- a/packages/vite/src/migrations/update-23-0-0/migrate-to-vitest-3.ts
+++ b/packages/vite/src/migrations/update-23-0-0/migrate-to-vitest-3.ts
@@ -1,0 +1,292 @@
+import { formatFiles, type Tree, visitNotIgnoredFiles } from '@nx/devkit';
+import { ensureTypescript } from '@nx/js/internal';
+import { ast, query } from '@phenomnomnominal/tsquery';
+import type {
+  Identifier,
+  ImportDeclaration,
+  Node,
+  PropertyAssignment,
+  SourceFile,
+  StringLiteral,
+} from 'typescript';
+import {
+  applyTextEdits,
+  replaceNodeTextEdit,
+  replaceStringLiteralValueEdit,
+  type TextEdit,
+} from './lib/ast-edits';
+import {
+  isJsOrTsFile,
+  visitVitestConfigFiles,
+} from './lib/vitest-config-files';
+
+let ts: typeof import('typescript');
+
+/**
+ * Hybrid migration paired with `ai-instructions-for-vitest-3.md`. Applies the
+ * deterministic, AST-tractable Vitest 1.x/2.x → 3.x changes mechanically and
+ * returns a `promptContext` describing any shape it could not handle, so the
+ * paired prompt's agent can finish those by hand.
+ */
+export default async function migrateToVitest3(tree: Tree) {
+  ts ??= ensureTypescript();
+
+  const unhandled: string[] = [];
+
+  visitVitestConfigFiles(tree, (filePath) =>
+    processVitestConfig(tree, filePath, unhandled)
+  );
+
+  visitNotIgnoredFiles(tree, '', (filePath) => {
+    if (!isJsOrTsFile(filePath)) return;
+    processSnapshotEnvironmentImport(tree, filePath, unhandled);
+  });
+
+  visitNotIgnoredFiles(tree, '', (filePath) => {
+    if (!filePath.endsWith('package.json')) return;
+    processPackageJson(tree, filePath);
+  });
+
+  await formatFiles(tree);
+
+  // Hybrid migration return shape: `promptContext` (when populated) is
+  // forwarded to the paired prompt's agent. When no agent runs, the field is
+  // dropped silently per the contract — safe on master and pre-agentic flows.
+  if (unhandled.length > 0) return { promptContext: unhandled };
+  return;
+}
+
+function processVitestConfig(
+  tree: Tree,
+  filePath: string,
+  unhandled: string[]
+): void {
+  const contents = tree.read(filePath, 'utf-8');
+  // Cheap prechecks: skip parsing if none of the v3 targets appear.
+  const hasC8Provider = /['"]c8['"]/.test(contents);
+  const hasNoneProvider = /['"]none['"]/.test(contents);
+  const hasIndexScripts = contents.includes('indexScripts');
+  if (!hasC8Provider && !hasNoneProvider && !hasIndexScripts) return;
+
+  const sourceFile = ast(contents);
+  const edits: TextEdit[] = [];
+
+  if (hasC8Provider) {
+    collectCoverageProviderC8Edits(sourceFile, contents, edits);
+  }
+  if (hasNoneProvider) {
+    collectBrowserProviderNoneEdits(sourceFile, contents, edits);
+  }
+  if (hasIndexScripts) {
+    collectIndexScriptsRenameEdits(sourceFile, edits);
+  }
+
+  if (edits.length === 0) return;
+  tree.write(filePath, applyTextEdits(contents, edits));
+}
+
+/**
+ * `test.coverage.provider: 'c8'` → `'v8'`. Anchored to the `test.coverage`
+ * sub-tree so a coincidental `'c8'` elsewhere isn't rewritten.
+ */
+function collectCoverageProviderC8Edits(
+  sourceFile: SourceFile,
+  contents: string,
+  edits: TextEdit[]
+): void {
+  const literals = query<StringLiteral>(
+    sourceFile,
+    'PropertyAssignment:has(Identifier[name=provider]) > StringLiteral[value=c8]'
+  );
+  for (const lit of literals) {
+    if (!isInsideTestSubProperty(lit, 'coverage')) continue;
+    edits.push(replaceStringLiteralValueEdit(contents, lit, 'v8'));
+  }
+}
+
+/**
+ * `test.browser.provider: 'none'` → `'preview'`. Anchored similarly to v3-2b.
+ */
+function collectBrowserProviderNoneEdits(
+  sourceFile: SourceFile,
+  contents: string,
+  edits: TextEdit[]
+): void {
+  const literals = query<StringLiteral>(
+    sourceFile,
+    'PropertyAssignment:has(Identifier[name=provider]) > StringLiteral[value=none]'
+  );
+  for (const lit of literals) {
+    if (!isInsideTestSubProperty(lit, 'browser')) continue;
+    edits.push(replaceStringLiteralValueEdit(contents, lit, 'preview'));
+  }
+}
+
+/**
+ * `test.browser.indexScripts` → `orchestratorScripts`.
+ */
+function collectIndexScriptsRenameEdits(
+  sourceFile: SourceFile,
+  edits: TextEdit[]
+): void {
+  const identifiers = query<Identifier>(
+    sourceFile,
+    'PropertyAssignment > Identifier[name=indexScripts]'
+  );
+  for (const id of identifiers) {
+    if (!isInsideTestSubProperty(id, 'browser')) continue;
+    edits.push(replaceNodeTextEdit(id, 'orchestratorScripts'));
+  }
+}
+
+/**
+ * `import { SnapshotEnvironment } from 'vitest'` → `from 'vitest/snapshot'`.
+ * Only applied when `SnapshotEnvironment` is the SOLE named binding. Mixed
+ * imports (e.g. `{ SnapshotEnvironment, vi }`) are logged for the agent —
+ * splitting the import is a semantic decision (does the v3.x `SnapshotEnvironment`
+ * still live in `vitest`? — no, it moved in v2).
+ */
+function processSnapshotEnvironmentImport(
+  tree: Tree,
+  filePath: string,
+  unhandled: string[]
+): void {
+  const contents = tree.read(filePath, 'utf-8');
+  if (!contents.includes('SnapshotEnvironment')) return;
+
+  const sourceFile = ast(contents);
+  const importDecls = query<ImportDeclaration>(sourceFile, 'ImportDeclaration');
+  const edits: TextEdit[] = [];
+
+  for (const decl of importDecls) {
+    if (!ts.isStringLiteral(decl.moduleSpecifier)) continue;
+    if (decl.moduleSpecifier.text !== 'vitest') continue;
+
+    const named = decl.importClause?.namedBindings;
+    if (!named || !ts.isNamedImports(named)) continue;
+    const elements = named.elements;
+    const hasSnapshotEnv = elements.some(
+      (el) => el.name.text === 'SnapshotEnvironment'
+    );
+    if (!hasSnapshotEnv) continue;
+
+    if (elements.length === 1 && !decl.importClause?.name) {
+      // Sole named binding, no default import → flip the module specifier.
+      edits.push(
+        replaceStringLiteralValueEdit(
+          contents,
+          decl.moduleSpecifier,
+          'vitest/snapshot'
+        )
+      );
+    } else {
+      unhandled.push(
+        `${filePath}: \`SnapshotEnvironment\` is imported from 'vitest' alongside other bindings. ` +
+          `Split it into a separate \`import { SnapshotEnvironment } from 'vitest/snapshot'\` statement.`
+      );
+    }
+  }
+
+  if (edits.length > 0) {
+    tree.write(filePath, applyTextEdits(contents, edits));
+  }
+}
+
+const SEGFAULT_RETRY_RE = /\s*--segfault-retry(?:[= ]\d+)?(?=\s|$)/g;
+// `\b` between `k` and `-` is still a word boundary, so the v3.x flag form
+// `vitest --typecheck-helper` (hypothetical) would otherwise match. Use a
+// lookahead requiring whitespace or end-of-string after the keyword.
+const VITEST_TYPECHECK_RE = /\bvitest\s+typecheck(?=\s|$)/g;
+
+function processPackageJson(tree: Tree, filePath: string): void {
+  const contents = tree.read(filePath, 'utf-8');
+  let parsed: any;
+  try {
+    parsed = JSON.parse(contents);
+  } catch {
+    return;
+  }
+
+  let changed = false;
+
+  // V3-1: strip `--segfault-retry` from script values.
+  // V3-3: `vitest typecheck` → `vitest --typecheck` in script values.
+  if (parsed.scripts && typeof parsed.scripts === 'object') {
+    for (const [name, value] of Object.entries(parsed.scripts)) {
+      if (typeof value !== 'string') continue;
+      let updated = value;
+      if (updated.includes('--segfault-retry')) {
+        updated = updated.replace(SEGFAULT_RETRY_RE, '').trim();
+      }
+      updated = updated.replace(VITEST_TYPECHECK_RE, 'vitest --typecheck');
+      if (updated !== value) {
+        parsed.scripts[name] = updated;
+        changed = true;
+      }
+    }
+  }
+
+  // V3-2a: `@vitest/coverage-c8` → `@vitest/coverage-v8` in dep buckets,
+  // preserving the user's pin verbatim.
+  for (const bucket of [
+    'dependencies',
+    'devDependencies',
+    'peerDependencies',
+    'optionalDependencies',
+  ]) {
+    const deps = parsed[bucket];
+    if (!deps || typeof deps !== 'object') continue;
+    if (!('@vitest/coverage-c8' in deps)) continue;
+    if ('@vitest/coverage-v8' in deps) {
+      // Both keys present; leave the v8 pin alone and just remove the c8 entry.
+      delete deps['@vitest/coverage-c8'];
+    } else {
+      // Rebuild the bucket to preserve key order with c8 swapped for v8.
+      const rebuilt: Record<string, string> = {};
+      for (const [k, v] of Object.entries(deps)) {
+        if (k === '@vitest/coverage-c8')
+          rebuilt['@vitest/coverage-v8'] = v as string;
+        else rebuilt[k] = v as string;
+      }
+      parsed[bucket] = rebuilt;
+    }
+    changed = true;
+  }
+
+  if (changed) {
+    const trailingNewline = contents.endsWith('\n') ? '\n' : '';
+    tree.write(filePath, JSON.stringify(parsed, null, 2) + trailingNewline);
+  }
+}
+
+/**
+ * Returns true if `node` lives inside a property named `propertyName` whose
+ * own parent is a property named `test` — i.e. anchored to the vitest
+ * `test.<propertyName>` sub-tree of the config.
+ */
+function isInsideTestSubProperty(
+  node: Node,
+  propertyName: 'coverage' | 'browser'
+): boolean {
+  const owningProperty = findEnclosingPropertyAssignment(node, propertyName);
+  if (!owningProperty) return false;
+  return !!findEnclosingPropertyAssignment(owningProperty, 'test');
+}
+
+function findEnclosingPropertyAssignment(
+  node: Node,
+  name: string
+): PropertyAssignment | undefined {
+  let current: Node | undefined = node.parent;
+  while (current) {
+    if (
+      ts.isPropertyAssignment(current) &&
+      ts.isIdentifier(current.name) &&
+      current.name.text === name
+    ) {
+      return current;
+    }
+    current = current.parent;
+  }
+  return undefined;
+}

--- a/packages/vite/src/migrations/update-23-0-0/migrate-to-vitest-3.ts
+++ b/packages/vite/src/migrations/update-23-0-0/migrate-to-vitest-3.ts
@@ -15,6 +15,7 @@ import {
   replaceStringLiteralValueEdit,
   type TextEdit,
 } from './lib/ast-edits';
+import { visitCiFiles } from './lib/ci-files';
 import {
   isJsOrTsFile,
   visitVitestConfigFiles,
@@ -43,9 +44,14 @@ export default async function migrateToVitest3(tree: Tree) {
   });
 
   visitNotIgnoredFiles(tree, '', (filePath) => {
-    if (!filePath.endsWith('package.json')) return;
-    processPackageJson(tree, filePath);
+    if (filePath.endsWith('package.json')) {
+      processPackageJson(tree, filePath);
+    } else if (filePath.endsWith('project.json')) {
+      processProjectJson(tree, filePath);
+    }
   });
+
+  scanCiFiles(tree, unhandled);
 
   await formatFiles(tree);
 
@@ -71,14 +77,33 @@ function processVitestConfig(
   const sourceFile = ast(contents);
   const edits: TextEdit[] = [];
 
+  const c8EditCountBefore = edits.length;
   if (hasC8Provider) {
     collectCoverageProviderC8Edits(sourceFile, contents, edits);
   }
   if (hasNoneProvider) {
     collectBrowserProviderNoneEdits(sourceFile, contents, edits);
   }
+  const indexEditCountBefore = edits.length;
   if (hasIndexScripts) {
     collectIndexScriptsRenameEdits(sourceFile, edits);
+  }
+
+  // Fallback signals: precheck hit a vitest-specific token but the AST didn't
+  // surface a shape we know how to rewrite (variable indirection, template
+  // literal, spread, ternary, etc.). Forward the file path so the agent can
+  // investigate.
+  if (hasC8Provider && edits.length === c8EditCountBefore) {
+    unhandled.push(
+      `${filePath}: found a \`'c8'\` string but no direct \`coverage.provider: 'c8'\` assignment to rewrite. ` +
+        `If this file's coverage provider resolves to c8 via a variable, ternary, or spread, switch it to \`'v8'\`.`
+    );
+  }
+  if (hasIndexScripts && edits.length === indexEditCountBefore) {
+    unhandled.push(
+      `${filePath}: found an \`indexScripts\` reference but no direct \`browser.indexScripts\` assignment to rewrite. ` +
+        `If this is the legacy browser option, rename it to \`orchestratorScripts\`.`
+    );
   }
 
   if (edits.length === 0) return;
@@ -257,6 +282,109 @@ function processPackageJson(tree: Tree, filePath: string): void {
     const trailingNewline = contents.endsWith('\n') ? '\n' : '';
     tree.write(filePath, JSON.stringify(parsed, null, 2) + trailingNewline);
   }
+}
+
+/**
+ * Walk all targets in `project.json` and rewrite the same string-level
+ * concerns we handle in `package.json` scripts: `--segfault-retry` removal
+ * and `vitest typecheck` → `vitest --typecheck`. Applies to `options.args`
+ * (string or array), `options.command` (string), and `options.commands`
+ * (array of strings).
+ */
+function processProjectJson(tree: Tree, filePath: string): void {
+  const contents = tree.read(filePath, 'utf-8');
+  let parsed: any;
+  try {
+    parsed = JSON.parse(contents);
+  } catch {
+    return;
+  }
+
+  let changed = false;
+
+  const targets = parsed?.targets;
+  if (!targets || typeof targets !== 'object') return;
+
+  for (const target of Object.values(targets)) {
+    const options = (target as any)?.options;
+    if (!options || typeof options !== 'object') continue;
+
+    if (typeof options.args === 'string') {
+      const rewritten = rewriteScriptString(options.args);
+      if (rewritten !== options.args) {
+        options.args = rewritten;
+        changed = true;
+      }
+    } else if (Array.isArray(options.args)) {
+      const filtered = options.args.filter(
+        (a: unknown) =>
+          typeof a !== 'string' || !/^--segfault-retry(?:=\d+)?$/.test(a.trim())
+      );
+      if (filtered.length !== options.args.length) {
+        options.args = filtered;
+        changed = true;
+      }
+    }
+
+    if (typeof options.command === 'string') {
+      const rewritten = rewriteScriptString(options.command);
+      if (rewritten !== options.command) {
+        options.command = rewritten;
+        changed = true;
+      }
+    }
+
+    if (Array.isArray(options.commands)) {
+      for (let i = 0; i < options.commands.length; i++) {
+        const entry = options.commands[i];
+        if (typeof entry === 'string') {
+          const rewritten = rewriteScriptString(entry);
+          if (rewritten !== entry) {
+            options.commands[i] = rewritten;
+            changed = true;
+          }
+        }
+      }
+    }
+  }
+
+  if (changed) {
+    const trailingNewline = contents.endsWith('\n') ? '\n' : '';
+    tree.write(filePath, JSON.stringify(parsed, null, 2) + trailingNewline);
+  }
+}
+
+function rewriteScriptString(value: string): string {
+  let updated = value;
+  if (updated.includes('--segfault-retry')) {
+    updated = updated.replace(SEGFAULT_RETRY_RE, '').trim();
+  }
+  updated = updated.replace(VITEST_TYPECHECK_RE, 'vitest --typecheck');
+  return updated;
+}
+
+/**
+ * Scan CI provider configs for the v3 legacy tokens. YAML edits aren't done
+ * mechanically (structure/comment/anchor risk); the file path + tokens are
+ * forwarded to the agent.
+ */
+function scanCiFiles(tree: Tree, unhandled: string[]): void {
+  visitCiFiles(tree, (filePath, contents) => {
+    const tokens: string[] = [];
+    if (contents.includes('--segfault-retry')) {
+      tokens.push('`--segfault-retry`');
+    }
+    if (VITEST_TYPECHECK_RE.test(contents)) {
+      tokens.push('`vitest typecheck`');
+    }
+    // Reset lastIndex because of /g.
+    VITEST_TYPECHECK_RE.lastIndex = 0;
+    if (tokens.length === 0) return;
+    unhandled.push(
+      `${filePath}: found legacy token(s) in this CI config: ${tokens.join(', ')}. ` +
+        `Remove \`--segfault-retry\` (the option was removed in Vitest 2.0) and rewrite \`vitest typecheck\` as \`vitest --typecheck\` (the subcommand was replaced by the flag).`
+    );
+  });
 }
 
 /**

--- a/packages/vite/src/migrations/update-23-0-0/migrate-to-vitest-4.spec.ts
+++ b/packages/vite/src/migrations/update-23-0-0/migrate-to-vitest-4.spec.ts
@@ -1,0 +1,396 @@
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migrateToVitest4 from './migrate-to-vitest-4';
+
+describe('migrate-to-vitest-4', () => {
+  describe('coverage option removals (V4-1)', () => {
+    it('removes `all`, `extensions`, `ignoreEmptyLines`, `experimentalAstAwareRemapping` inside test.coverage', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'vitest.config.ts',
+        `import { defineConfig } from 'vitest/config';
+export default defineConfig({
+  test: {
+    coverage: {
+      provider: 'v8',
+      all: true,
+      extensions: ['.ts', '.tsx'],
+      ignoreEmptyLines: false,
+      experimentalAstAwareRemapping: true,
+      reporter: ['text'],
+    },
+  },
+});
+`
+      );
+
+      await migrateToVitest4(tree);
+
+      const updated = tree.read('vitest.config.ts', 'utf-8');
+      expect(updated).not.toContain('all:');
+      expect(updated).not.toContain('extensions:');
+      expect(updated).not.toContain('ignoreEmptyLines:');
+      expect(updated).not.toContain('experimentalAstAwareRemapping:');
+      // Unrelated coverage options are preserved.
+      expect(updated).toContain("provider: 'v8'");
+      expect(updated).toContain("reporter: ['text']");
+    });
+
+    it('does not touch a property named `all` outside test.coverage', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'vitest.config.ts',
+        `import { defineConfig } from 'vitest/config';
+export default defineConfig({
+  test: { include: { all: true } },
+});
+`
+      );
+      const before = tree.read('vitest.config.ts', 'utf-8');
+
+      await migrateToVitest4(tree);
+
+      expect(tree.read('vitest.config.ts', 'utf-8')).toBe(before);
+    });
+  });
+
+  describe('test.workspace → test.projects (V4-2)', () => {
+    it('renames the identifier inside test', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'vitest.config.ts',
+        `import { defineConfig } from 'vitest/config';
+export default defineConfig({
+  test: { workspace: ['apps/*', 'libs/*'] },
+});
+`
+      );
+
+      await migrateToVitest4(tree);
+
+      expect(tree.read('vitest.config.ts', 'utf-8')).toContain('projects: ');
+    });
+
+    it('logs unhandled when the external vitest.workspace file form is present', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'vitest.workspace.ts',
+        `import { defineWorkspace } from 'vitest/config';\nexport default defineWorkspace(['apps/*']);\n`
+      );
+
+      const result = await migrateToVitest4(tree);
+
+      expect(
+        result?.promptContext?.some((s) => s.includes('vitest.workspace'))
+      ).toBe(true);
+      // The defineWorkspace import is flagged separately.
+      expect(
+        result?.promptContext?.some((s) => s.includes('defineWorkspace'))
+      ).toBe(true);
+    });
+  });
+
+  describe('@vitest/browser/context → vitest/browser import path (V4-3a)', () => {
+    it('rewrites the import path', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'libs/lib/src/setup.ts',
+        `import { page } from '@vitest/browser/context';\nexport { page };\n`
+      );
+
+      await migrateToVitest4(tree);
+
+      expect(tree.read('libs/lib/src/setup.ts', 'utf-8')).toContain(
+        "from 'vitest/browser'"
+      );
+    });
+
+    it('logs unhandled for @vitest/browser/utils imports', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'libs/lib/src/util.ts',
+        `import { getElementError } from '@vitest/browser/utils';\nexport { getElementError };\n`
+      );
+
+      const result = await migrateToVitest4(tree);
+
+      expect(
+        result?.promptContext?.some((s) => s.includes('@vitest/browser/utils'))
+      ).toBe(true);
+    });
+  });
+
+  describe('deps.optimizer.web → client (V4-4)', () => {
+    it('renames inside test.deps.optimizer only', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'vitest.config.ts',
+        `import { defineConfig } from 'vitest/config';
+export default defineConfig({
+  test: {
+    deps: {
+      optimizer: { web: { include: ['x'] } },
+    },
+  },
+});
+`
+      );
+
+      await migrateToVitest4(tree);
+
+      const updated = tree.read('vitest.config.ts', 'utf-8');
+      expect(updated).toContain('client: ');
+      expect(updated).not.toContain('web: ');
+    });
+  });
+
+  describe('remove poolOptions.threads.useAtomics (V4-5)', () => {
+    it('removes the property', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'vitest.config.ts',
+        `import { defineConfig } from 'vitest/config';
+export default defineConfig({
+  test: {
+    poolOptions: { threads: { useAtomics: true, isolate: false } },
+  },
+});
+`
+      );
+
+      await migrateToVitest4(tree);
+
+      const updated = tree.read('vitest.config.ts', 'utf-8');
+      expect(updated).not.toContain('useAtomics');
+      // The detect-and-log path picks up isolate.
+    });
+  });
+
+  describe('remove test.minWorkers (V4-6)', () => {
+    it('removes the top-level property', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'vitest.config.ts',
+        `import { defineConfig } from 'vitest/config';
+export default defineConfig({
+  test: { minWorkers: 1, maxWorkers: 4 },
+});
+`
+      );
+
+      await migrateToVitest4(tree);
+
+      const updated = tree.read('vitest.config.ts', 'utf-8');
+      expect(updated).not.toContain('minWorkers');
+      expect(updated).toContain('maxWorkers: 4');
+    });
+  });
+
+  describe('reporter renames (V4-7)', () => {
+    it("rewrites 'verbose' → 'tree' and 'basic' → ['default', { summary: false }]", async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'vitest.config.ts',
+        `import { defineConfig } from 'vitest/config';
+export default defineConfig({
+  test: { reporters: ['verbose', 'basic', 'json'] },
+});
+`
+      );
+
+      await migrateToVitest4(tree);
+
+      const updated = tree.read('vitest.config.ts', 'utf-8');
+      expect(updated).toContain("'tree'");
+      expect(updated).toContain("['default', { summary: false }]");
+      expect(updated).toContain("'json'");
+      expect(updated).not.toContain("'verbose'");
+      expect(updated).not.toContain("'basic'");
+    });
+  });
+
+  describe('env var renames in package.json (V4-8)', () => {
+    it('renames VITEST_MAX_THREADS / VITEST_MAX_FORKS / VITE_NODE_DEPS_MODULE_DIRECTORIES', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'package.json',
+        JSON.stringify(
+          {
+            scripts: {
+              t1: 'VITEST_MAX_THREADS=4 vitest run',
+              t2: 'VITEST_MAX_FORKS=2 vitest run',
+              t3: 'VITE_NODE_DEPS_MODULE_DIRECTORIES=/x vitest run',
+              t4: 'echo VITEST_MAX_THREADSXYZ', // word-boundary
+            },
+          },
+          null,
+          2
+        )
+      );
+
+      await migrateToVitest4(tree);
+
+      const updated = JSON.parse(tree.read('package.json', 'utf-8'));
+      expect(updated.scripts.t1).toBe('VITEST_MAX_WORKERS=4 vitest run');
+      expect(updated.scripts.t2).toBe('VITEST_MAX_WORKERS=2 vitest run');
+      expect(updated.scripts.t3).toBe(
+        'VITEST_MODULE_DIRECTORIES=/x vitest run'
+      );
+      expect(updated.scripts.t4).toBe('echo VITEST_MAX_THREADSXYZ');
+    });
+  });
+
+  describe('detect-and-log pool/deps/match/browser/reporter cases', () => {
+    it('logs all the v4-only-via-prompt cases when they appear', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'vitest.config.ts',
+        `import { defineConfig } from 'vitest/config';
+export default defineConfig({
+  test: {
+    singleThread: true,
+    maxThreads: 4,
+    poolMatchGlobs: [['**/*.gpu.test.ts', 'threads']],
+    environmentMatchGlobs: [['**/*.dom.test.ts', 'jsdom']],
+    deps: { external: ['pkg'], inline: ['pkg2'] },
+    poolOptions: {
+      forks: { execArgv: ['--expose-gc'], isolate: false },
+      vmThreads: { memoryLimit: '512MB' },
+    },
+    browser: {
+      enabled: true,
+      provider: 'playwright',
+      testerScripts: ['./s.js'],
+    },
+    reporters: [{ onCollected() {}, onFinished() {} }],
+  },
+});
+`
+      );
+
+      const result = await migrateToVitest4(tree);
+      const ctx = (result?.promptContext ?? []).join('\n');
+
+      expect(ctx).toMatch(/singleThread/);
+      expect(ctx).toMatch(/maxThreads/);
+      expect(ctx).toMatch(/poolMatchGlobs/);
+      expect(ctx).toMatch(/environmentMatchGlobs/);
+      expect(ctx).toMatch(/test\.deps\.external/);
+      expect(ctx).toMatch(/test\.deps\.inline/);
+      expect(ctx).toMatch(/poolOptions\.<pool>\.execArgv/);
+      expect(ctx).toMatch(/poolOptions\.<pool>\.isolate/);
+      expect(ctx).toMatch(/poolOptions\.vmThreads\.memoryLimit/);
+      expect(ctx).toMatch(/browser\.provider/);
+      expect(ctx).toMatch(/browser\.testerScripts/);
+      expect(ctx).toMatch(/onCollected/);
+      expect(ctx).toMatch(/onFinished/);
+    });
+
+    it('logs @vitest/browser package.json dep but does not remove it', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'package.json',
+        JSON.stringify(
+          { devDependencies: { '@vitest/browser': '^3.0.0' } },
+          null,
+          2
+        )
+      );
+
+      const result = await migrateToVitest4(tree);
+
+      const updated = JSON.parse(tree.read('package.json', 'utf-8'));
+      expect(updated.devDependencies['@vitest/browser']).toBe('^3.0.0');
+      expect(
+        result?.promptContext?.some((s) => s.includes('@vitest/browser'))
+      ).toBe(true);
+    });
+  });
+
+  describe('shape-agnostic anchoring', () => {
+    it('applies and detects inside mergeConfig + factory-form configs', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'vitest.config.base.ts',
+        `import { defineConfig, mergeConfig } from 'vitest/config';
+const base = defineConfig({ test: { coverage: { all: true } } });
+export default mergeConfig(
+  base,
+  defineConfig(({ mode }) => ({
+    test: { workspace: ['apps/*'], minWorkers: 0 },
+  }))
+);
+`
+      );
+
+      await migrateToVitest4(tree);
+
+      const updated = tree.read('vitest.config.base.ts', 'utf-8');
+      expect(updated).toContain('projects: ');
+      expect(updated).not.toContain('workspace: ');
+      expect(updated).not.toContain('minWorkers');
+      expect(updated).not.toContain('all:');
+    });
+  });
+
+  describe('idempotency', () => {
+    it('is a no-op on a second run', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'package.json',
+        JSON.stringify(
+          { scripts: { t: 'VITEST_MAX_THREADS=4 vitest run' } },
+          null,
+          2
+        )
+      );
+      tree.write(
+        'vitest.config.ts',
+        `import { defineConfig } from 'vitest/config';
+export default defineConfig({
+  test: {
+    coverage: { all: true, provider: 'v8' },
+    workspace: ['apps/*'],
+    minWorkers: 1,
+    deps: { optimizer: { web: { include: ['x'] } } },
+    poolOptions: { threads: { useAtomics: true } },
+    reporters: ['verbose', 'basic'],
+  },
+});
+`
+      );
+
+      await migrateToVitest4(tree);
+      const afterFirst = {
+        pkg: tree.read('package.json', 'utf-8'),
+        cfg: tree.read('vitest.config.ts', 'utf-8'),
+      };
+      await migrateToVitest4(tree);
+      const afterSecond = {
+        pkg: tree.read('package.json', 'utf-8'),
+        cfg: tree.read('vitest.config.ts', 'utf-8'),
+      };
+
+      expect(afterSecond).toEqual(afterFirst);
+    });
+  });
+
+  describe('no-op when nothing matches', () => {
+    it('leaves files untouched and returns no promptContext', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'vitest.config.ts',
+        `import { defineConfig } from 'vitest/config';
+export default defineConfig({
+  test: { globals: true },
+});
+`
+      );
+      const before = tree.read('vitest.config.ts', 'utf-8');
+
+      const result = await migrateToVitest4(tree);
+
+      expect(tree.read('vitest.config.ts', 'utf-8')).toBe(before);
+      expect(result).toBeUndefined();
+    });
+  });
+});

--- a/packages/vite/src/migrations/update-23-0-0/migrate-to-vitest-4.spec.ts
+++ b/packages/vite/src/migrations/update-23-0-0/migrate-to-vitest-4.spec.ts
@@ -80,11 +80,11 @@ export default defineConfig({
       const result = await migrateToVitest4(tree);
 
       expect(
-        result?.promptContext?.some((s) => s.includes('vitest.workspace'))
+        result?.agentContext?.some((s) => s.includes('vitest.workspace'))
       ).toBe(true);
       // The defineWorkspace import is flagged separately.
       expect(
-        result?.promptContext?.some((s) => s.includes('defineWorkspace'))
+        result?.agentContext?.some((s) => s.includes('defineWorkspace'))
       ).toBe(true);
     });
   });
@@ -114,7 +114,7 @@ export default defineConfig({
       const result = await migrateToVitest4(tree);
 
       expect(
-        result?.promptContext?.some((s) => s.includes('@vitest/browser/utils'))
+        result?.agentContext?.some((s) => s.includes('@vitest/browser/utils'))
       ).toBe(true);
     });
   });
@@ -268,7 +268,7 @@ export default defineConfig({
       );
 
       const result = await migrateToVitest4(tree);
-      const ctx = (result?.promptContext ?? []).join('\n');
+      const ctx = (result?.agentContext ?? []).join('\n');
 
       // singleThread: true → value-aware message including the literal.
       expect(ctx).toMatch(/`singleThread: true`/);
@@ -300,7 +300,7 @@ export default defineConfig({
       );
 
       const result = await migrateToVitest4(tree);
-      const ctx = (result?.promptContext ?? []).join('\n');
+      const ctx = (result?.agentContext ?? []).join('\n');
 
       // false-value emits a delete-only instruction.
       expect(ctx).toMatch(/singleFork: false.*Delete the property/);
@@ -316,7 +316,7 @@ export default defineConfig({
       const result = await migrateToVitest4(tree);
 
       expect(
-        result?.promptContext?.some((s) => /bare `@vitest\/browser`/.test(s))
+        result?.agentContext?.some((s) => /bare `@vitest\/browser`/.test(s))
       ).toBe(true);
     });
 
@@ -336,7 +336,7 @@ export default defineConfig({
       const updated = JSON.parse(tree.read('package.json', 'utf-8'));
       expect(updated.devDependencies['@vitest/browser']).toBe('^3.0.0');
       expect(
-        result?.promptContext?.some((s) => s.includes('@vitest/browser'))
+        result?.agentContext?.some((s) => s.includes('@vitest/browser'))
       ).toBe(true);
     });
   });
@@ -427,7 +427,7 @@ export default defineConfig({
       expect(tree.read('vitest.config.ts', 'utf-8')).toBe(before);
       // nextSteps is always emitted — the CI-provider-dashboard reminder.
       expect(result?.nextSteps?.[0]).toMatch(/CI provider/);
-      expect(result?.promptContext).toBeUndefined();
+      expect(result?.agentContext).toBeUndefined();
     });
   });
 
@@ -471,7 +471,7 @@ export default defineConfig({
 
       expect(tree.read('.env', 'utf-8')).toBe(original);
       expect(
-        result?.promptContext?.some(
+        result?.agentContext?.some(
           (s) =>
             s.includes('.env') &&
             s.includes('VITEST_MAX_THREADS') &&
@@ -541,7 +541,7 @@ export default defineConfig({
         VITEST_MAX_FORKS: '2',
       });
       expect(
-        result?.promptContext?.some((s) => s.includes('target `testBoth`'))
+        result?.agentContext?.some((s) => s.includes('target `testBoth`'))
       ).toBe(true);
     });
 
@@ -598,7 +598,7 @@ export default defineConfig({
 
       const result = await migrateToVitest4(tree);
 
-      const ciEntry = result?.promptContext?.find((s) =>
+      const ciEntry = result?.agentContext?.find((s) =>
         s.startsWith('.github/workflows/test.yml')
       );
       expect(ciEntry).toBeDefined();

--- a/packages/vite/src/migrations/update-23-0-0/migrate-to-vitest-4.spec.ts
+++ b/packages/vite/src/migrations/update-23-0-0/migrate-to-vitest-4.spec.ts
@@ -410,7 +410,7 @@ export default defineConfig({
   });
 
   describe('no-op when nothing matches', () => {
-    it('leaves files untouched and returns no promptContext', async () => {
+    it('leaves files untouched and returns only the CI-dashboard nextSteps', async () => {
       const tree = createTreeWithEmptyWorkspace();
       tree.write(
         'vitest.config.ts',
@@ -425,7 +425,206 @@ export default defineConfig({
       const result = await migrateToVitest4(tree);
 
       expect(tree.read('vitest.config.ts', 'utf-8')).toBe(before);
-      expect(result).toBeUndefined();
+      // nextSteps is always emitted — the CI-provider-dashboard reminder.
+      expect(result?.nextSteps?.[0]).toMatch(/CI provider/);
+      expect(result?.promptContext).toBeUndefined();
+    });
+  });
+
+  describe('.env file rewrites (V4-8 — extended)', () => {
+    it('renames the legacy vars when exactly one of THREADS/FORKS is present', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        '.env',
+        `# vitest workers\nVITEST_MAX_THREADS=4\nexport VITE_NODE_DEPS_MODULE_DIRECTORIES=/custom\n`
+      );
+
+      await migrateToVitest4(tree);
+
+      const updated = tree.read('.env', 'utf-8');
+      expect(updated).toContain('VITEST_MAX_WORKERS=4');
+      expect(updated).not.toContain('VITEST_MAX_THREADS');
+      expect(updated).toContain('export VITEST_MODULE_DIRECTORIES=/custom');
+      // Comment preserved.
+      expect(updated).toContain('# vitest workers');
+    });
+
+    it('renames in `.env.local` and `.env.production` too', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write('.env.local', `VITEST_MAX_FORKS=2\n`);
+      tree.write('.env.production', `VITEST_MAX_FORKS=8\n`);
+
+      await migrateToVitest4(tree);
+
+      expect(tree.read('.env.local', 'utf-8')).toBe('VITEST_MAX_WORKERS=2\n');
+      expect(tree.read('.env.production', 'utf-8')).toBe(
+        'VITEST_MAX_WORKERS=8\n'
+      );
+    });
+
+    it('skips rename when both VITEST_MAX_{THREADS,FORKS} are present and logs the conflict', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      const original = `VITEST_MAX_THREADS=4\nVITEST_MAX_FORKS=2\n`;
+      tree.write('.env', original);
+
+      const result = await migrateToVitest4(tree);
+
+      expect(tree.read('.env', 'utf-8')).toBe(original);
+      expect(
+        result?.promptContext?.some(
+          (s) =>
+            s.includes('.env') &&
+            s.includes('VITEST_MAX_THREADS') &&
+            s.includes('VITEST_MAX_FORKS')
+        )
+      ).toBe(true);
+    });
+
+    it('does not touch `.envrc` (direnv has different syntax)', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      const original = `export VITEST_MAX_THREADS=4\n`;
+      tree.write('.envrc', original);
+
+      await migrateToVitest4(tree);
+
+      expect(tree.read('.envrc', 'utf-8')).toBe(original);
+    });
+  });
+
+  describe('project.json rewrites (V4-8 — extended)', () => {
+    it('renames `options.env` keys with conflict guard', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'apps/app/project.json',
+        JSON.stringify(
+          {
+            name: 'app',
+            targets: {
+              test: {
+                executor: 'nx:run-commands',
+                options: {
+                  env: {
+                    VITEST_MAX_THREADS: '4',
+                    VITE_NODE_DEPS_MODULE_DIRECTORIES: '/x',
+                  },
+                  command: 'vitest run',
+                },
+              },
+              testBoth: {
+                executor: 'nx:run-commands',
+                options: {
+                  env: {
+                    VITEST_MAX_THREADS: '4',
+                    VITEST_MAX_FORKS: '2',
+                  },
+                  command: 'vitest run',
+                },
+              },
+            },
+          },
+          null,
+          2
+        )
+      );
+
+      const result = await migrateToVitest4(tree);
+
+      const updated = JSON.parse(tree.read('apps/app/project.json', 'utf-8'));
+      // First target: single rename happens.
+      expect(updated.targets.test.options.env).toEqual({
+        VITEST_MAX_WORKERS: '4',
+        VITEST_MODULE_DIRECTORIES: '/x',
+      });
+      // Second target: conflict → no rename, log emitted.
+      expect(updated.targets.testBoth.options.env).toEqual({
+        VITEST_MAX_THREADS: '4',
+        VITEST_MAX_FORKS: '2',
+      });
+      expect(
+        result?.promptContext?.some((s) => s.includes('target `testBoth`'))
+      ).toBe(true);
+    });
+
+    it('rewrites inline VAR= prefixes inside options.command / options.commands / options.args', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'apps/app/project.json',
+        JSON.stringify(
+          {
+            name: 'app',
+            targets: {
+              t1: {
+                options: { command: 'VITEST_MAX_THREADS=4 vitest run' },
+              },
+              t2: {
+                options: {
+                  commands: [
+                    'VITEST_MAX_FORKS=2 vitest run --shard=1/2',
+                    'VITE_NODE_DEPS_MODULE_DIRECTORIES=/x vitest run',
+                  ],
+                },
+              },
+              t3: {
+                options: { args: 'VITEST_MAX_THREADS=4' },
+              },
+            },
+          },
+          null,
+          2
+        )
+      );
+
+      await migrateToVitest4(tree);
+
+      const updated = JSON.parse(tree.read('apps/app/project.json', 'utf-8'));
+      expect(updated.targets.t1.options.command).toBe(
+        'VITEST_MAX_WORKERS=4 vitest run'
+      );
+      expect(updated.targets.t2.options.commands).toEqual([
+        'VITEST_MAX_WORKERS=2 vitest run --shard=1/2',
+        'VITEST_MODULE_DIRECTORIES=/x vitest run',
+      ]);
+      expect(updated.targets.t3.options.args).toBe('VITEST_MAX_WORKERS=4');
+    });
+  });
+
+  describe('CI YAML scan (V4-8 — extended)', () => {
+    it('logs the file path + tokens found in .github/workflows files', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        '.github/workflows/test.yml',
+        `jobs:\n  test:\n    runs-on: ubuntu-latest\n    env:\n      VITEST_MAX_THREADS: 4\n    steps:\n      - run: pnpm test\n`
+      );
+
+      const result = await migrateToVitest4(tree);
+
+      const ciEntry = result?.promptContext?.find((s) =>
+        s.startsWith('.github/workflows/test.yml')
+      );
+      expect(ciEntry).toBeDefined();
+      expect(ciEntry).toContain('VITEST_MAX_THREADS');
+      // The file is not mechanically edited (YAML structure risk).
+      expect(tree.read('.github/workflows/test.yml', 'utf-8')).toContain(
+        'VITEST_MAX_THREADS'
+      );
+    });
+  });
+
+  describe('CI provider nextSteps (always emitted)', () => {
+    it('appears even when no in-repo env vars were found', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'vitest.config.ts',
+        `import { defineConfig } from 'vitest/config';\nexport default defineConfig({ test: { globals: true } });\n`
+      );
+
+      const result = await migrateToVitest4(tree);
+
+      expect(
+        result?.nextSteps?.some((s) =>
+          s.includes('CI provider stores Vitest env vars')
+        )
+      ).toBe(true);
     });
   });
 });

--- a/packages/vite/src/migrations/update-23-0-0/migrate-to-vitest-4.spec.ts
+++ b/packages/vite/src/migrations/update-23-0-0/migrate-to-vitest-4.spec.ts
@@ -270,19 +270,54 @@ export default defineConfig({
       const result = await migrateToVitest4(tree);
       const ctx = (result?.promptContext ?? []).join('\n');
 
-      expect(ctx).toMatch(/singleThread/);
-      expect(ctx).toMatch(/maxThreads/);
+      // singleThread: true → value-aware message including the literal.
+      expect(ctx).toMatch(/`singleThread: true`/);
+      // maxThreads: 4 → value-aware message including the literal.
+      expect(ctx).toMatch(/`test\.maxThreads` \(current value: 4\)/);
       expect(ctx).toMatch(/poolMatchGlobs/);
       expect(ctx).toMatch(/environmentMatchGlobs/);
       expect(ctx).toMatch(/test\.deps\.external/);
       expect(ctx).toMatch(/test\.deps\.inline/);
-      expect(ctx).toMatch(/poolOptions\.<pool>\.execArgv/);
-      expect(ctx).toMatch(/poolOptions\.<pool>\.isolate/);
-      expect(ctx).toMatch(/poolOptions\.vmThreads\.memoryLimit/);
-      expect(ctx).toMatch(/browser\.provider/);
+      // Pool name is resolved to the exact `forks`/`threads` source, not `<pool>`.
+      expect(ctx).toMatch(/test\.poolOptions\.forks\.execArgv/);
+      expect(ctx).toMatch(/test\.poolOptions\.forks\.isolate/);
+      expect(ctx).toMatch(/test\.poolOptions\.vmThreads\.memoryLimit/);
+      expect(ctx).toMatch(/browser\.provider.*current value: 'playwright'/);
       expect(ctx).toMatch(/browser\.testerScripts/);
       expect(ctx).toMatch(/onCollected/);
       expect(ctx).toMatch(/onFinished/);
+    });
+
+    it('preserves boolean value context for singleThread/singleFork', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'vitest.config.ts',
+        `import { defineConfig } from 'vitest/config';
+export default defineConfig({
+  test: { singleFork: false },
+});
+`
+      );
+
+      const result = await migrateToVitest4(tree);
+      const ctx = (result?.promptContext ?? []).join('\n');
+
+      // false-value emits a delete-only instruction.
+      expect(ctx).toMatch(/singleFork: false.*Delete the property/);
+    });
+
+    it('flags bare `@vitest/browser` imports', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'libs/lib/src/setup.ts',
+        `import { something } from '@vitest/browser';\nexport { something };\n`
+      );
+
+      const result = await migrateToVitest4(tree);
+
+      expect(
+        result?.promptContext?.some((s) => /bare `@vitest\/browser`/.test(s))
+      ).toBe(true);
     });
 
     it('logs @vitest/browser package.json dep but does not remove it', async () => {

--- a/packages/vite/src/migrations/update-23-0-0/migrate-to-vitest-4.ts
+++ b/packages/vite/src/migrations/update-23-0-0/migrate-to-vitest-4.ts
@@ -1,6 +1,7 @@
 import { formatFiles, type Tree, visitNotIgnoredFiles } from '@nx/devkit';
 import { ensureTypescript } from '@nx/js/internal';
 import { ast, query } from '@phenomnomnominal/tsquery';
+import picomatch = require('picomatch');
 import type {
   ArrayLiteralExpression,
   Identifier,
@@ -17,6 +18,7 @@ import {
   replaceStringLiteralValueEdit,
   type TextEdit,
 } from './lib/ast-edits';
+import { visitCiFiles } from './lib/ci-files';
 import {
   isJsOrTsFile,
   isVitestWorkspaceFile,
@@ -62,14 +64,37 @@ export default async function migrateToVitest4(tree: Tree) {
   });
 
   visitNotIgnoredFiles(tree, '', (filePath) => {
-    if (!filePath.endsWith('package.json')) return;
-    processPackageJson(tree, filePath, unhandled);
+    if (filePath.endsWith('package.json')) {
+      processPackageJson(tree, filePath, unhandled);
+    } else if (filePath.endsWith('project.json')) {
+      processProjectJson(tree, filePath, unhandled);
+    } else if (isEnvFile(filePath)) {
+      processEnvFile(tree, filePath, unhandled);
+    }
   });
+
+  scanCiFiles(tree, unhandled);
 
   await formatFiles(tree);
 
-  if (unhandled.length > 0) return { promptContext: unhandled };
-  return;
+  // Always-shown reminder for state we cannot reach from the workspace tree.
+  const nextSteps = [
+    `If your CI provider stores Vitest env vars in its dashboard (GitHub Actions repo/org secrets, GitLab CI/CD variables, Vercel/Netlify env vars, etc.), rename \`VITEST_MAX_THREADS\` and \`VITEST_MAX_FORKS\` to \`VITEST_MAX_WORKERS\`, and \`VITE_NODE_DEPS_MODULE_DIRECTORIES\` to \`VITEST_MODULE_DIRECTORIES\`. The pre-pass only handles in-repo files.`,
+  ];
+
+  const result: { nextSteps?: string[]; promptContext?: string[] } = {
+    nextSteps,
+  };
+  if (unhandled.length > 0) result.promptContext = unhandled;
+  return result;
+}
+
+const ENV_FILE_MATCHERS = [picomatch('**/.env'), picomatch('**/.env.*')];
+function isEnvFile(filePath: string): boolean {
+  const base = filePath.split('/').pop() ?? '';
+  // Skip `.envrc` (direnv) — different syntax surface.
+  if (base === '.envrc') return false;
+  return ENV_FILE_MATCHERS.some((m) => m(filePath));
 }
 
 const COVERAGE_DEAD_OPTIONS = new Set([
@@ -646,6 +671,256 @@ function processPackageJson(
     const trailingNewline = contents.endsWith('\n') ? '\n' : '';
     tree.write(filePath, JSON.stringify(parsed, null, 2) + trailingNewline);
   }
+}
+
+/**
+ * Rewrite `.env` / `.env.*` files: rename the legacy Vitest env vars to the
+ * v4-aware names. `VITEST_MAX_THREADS`/`VITEST_MAX_FORKS` only get renamed
+ * when exactly one of them is present in the file — both map to the same
+ * pool-agnostic `VITEST_MAX_WORKERS`, so a blind rename would produce two
+ * conflicting assignments (the latter would silently win per dotenv
+ * semantics). When both are present the rename is skipped and the conflict
+ * is forwarded to the agent.
+ */
+function processEnvFile(
+  tree: Tree,
+  filePath: string,
+  unhandled: string[]
+): void {
+  const contents = tree.read(filePath, 'utf-8');
+  if (
+    !/(?:VITEST_MAX_THREADS|VITEST_MAX_FORKS|VITE_NODE_DEPS_MODULE_DIRECTORIES)\b/.test(
+      contents
+    )
+  ) {
+    return;
+  }
+
+  const hasThreads = /^(?:\s*(?:export\s+)?)VITEST_MAX_THREADS\b/m.test(
+    contents
+  );
+  const hasForks = /^(?:\s*(?:export\s+)?)VITEST_MAX_FORKS\b/m.test(contents);
+
+  let updated = contents;
+  if (hasThreads && hasForks) {
+    unhandled.push(
+      `${filePath}: both \`VITEST_MAX_THREADS\` and \`VITEST_MAX_FORKS\` are set — both collapse to the single pool-agnostic \`VITEST_MAX_WORKERS\` in Vitest 4. ` +
+        `Decide which value should win based on the pool the project uses (\`test.pool\` in the vitest config) and rename only that line.`
+    );
+  } else if (hasThreads) {
+    updated = updated.replace(
+      /^((?:\s*(?:export\s+)?))VITEST_MAX_THREADS\b/gm,
+      '$1VITEST_MAX_WORKERS'
+    );
+  } else if (hasForks) {
+    updated = updated.replace(
+      /^((?:\s*(?:export\s+)?))VITEST_MAX_FORKS\b/gm,
+      '$1VITEST_MAX_WORKERS'
+    );
+  }
+
+  updated = updated.replace(
+    /^((?:\s*(?:export\s+)?))VITE_NODE_DEPS_MODULE_DIRECTORIES\b/gm,
+    '$1VITEST_MODULE_DIRECTORIES'
+  );
+
+  if (updated !== contents) {
+    tree.write(filePath, updated);
+  }
+}
+
+/**
+ * Walk all targets in `project.json` and apply v4 env-var renames inline:
+ *   - `options.env` keys
+ *   - `options.{args,command,commands}` string content (VAR=value prefixes)
+ * Same conflict guard as `.env` files.
+ */
+function processProjectJson(
+  tree: Tree,
+  filePath: string,
+  unhandled: string[]
+): void {
+  const contents = tree.read(filePath, 'utf-8');
+  let parsed: any;
+  try {
+    parsed = JSON.parse(contents);
+  } catch {
+    return;
+  }
+
+  const targets = parsed?.targets;
+  if (!targets || typeof targets !== 'object') return;
+
+  let changed = false;
+
+  for (const [targetName, target] of Object.entries(targets) as Array<
+    [string, any]
+  >) {
+    const options = target?.options;
+    if (!options || typeof options !== 'object') continue;
+
+    // `options.env`: rename keys, with the same threads/forks conflict guard.
+    if (options.env && typeof options.env === 'object') {
+      const hasThreads = 'VITEST_MAX_THREADS' in options.env;
+      const hasForks = 'VITEST_MAX_FORKS' in options.env;
+      if (hasThreads && hasForks) {
+        unhandled.push(
+          `${filePath} (target \`${targetName}\`): both \`VITEST_MAX_THREADS\` and \`VITEST_MAX_FORKS\` are set in \`options.env\` — both collapse to \`VITEST_MAX_WORKERS\` in Vitest 4. ` +
+            `Decide which value should win and rename only that key.`
+        );
+      } else if (hasThreads) {
+        options.env = renameObjectKey(
+          options.env,
+          'VITEST_MAX_THREADS',
+          'VITEST_MAX_WORKERS'
+        );
+        changed = true;
+      } else if (hasForks) {
+        options.env = renameObjectKey(
+          options.env,
+          'VITEST_MAX_FORKS',
+          'VITEST_MAX_WORKERS'
+        );
+        changed = true;
+      }
+      if ('VITE_NODE_DEPS_MODULE_DIRECTORIES' in options.env) {
+        options.env = renameObjectKey(
+          options.env,
+          'VITE_NODE_DEPS_MODULE_DIRECTORIES',
+          'VITEST_MODULE_DIRECTORIES'
+        );
+        changed = true;
+      }
+    }
+
+    // `options.args` / `options.command` / `options.commands`: in-string renames.
+    if (typeof options.args === 'string') {
+      const rewritten = rewriteInlineEnvVars(
+        options.args,
+        filePath,
+        targetName,
+        unhandled
+      );
+      if (rewritten !== options.args) {
+        options.args = rewritten;
+        changed = true;
+      }
+    } else if (Array.isArray(options.args)) {
+      for (let i = 0; i < options.args.length; i++) {
+        const entry = options.args[i];
+        if (typeof entry !== 'string') continue;
+        const rewritten = rewriteInlineEnvVars(
+          entry,
+          filePath,
+          targetName,
+          unhandled
+        );
+        if (rewritten !== entry) {
+          options.args[i] = rewritten;
+          changed = true;
+        }
+      }
+    }
+
+    if (typeof options.command === 'string') {
+      const rewritten = rewriteInlineEnvVars(
+        options.command,
+        filePath,
+        targetName,
+        unhandled
+      );
+      if (rewritten !== options.command) {
+        options.command = rewritten;
+        changed = true;
+      }
+    }
+
+    if (Array.isArray(options.commands)) {
+      for (let i = 0; i < options.commands.length; i++) {
+        const entry = options.commands[i];
+        if (typeof entry !== 'string') continue;
+        const rewritten = rewriteInlineEnvVars(
+          entry,
+          filePath,
+          targetName,
+          unhandled
+        );
+        if (rewritten !== entry) {
+          options.commands[i] = rewritten;
+          changed = true;
+        }
+      }
+    }
+  }
+
+  if (changed) {
+    const trailingNewline = contents.endsWith('\n') ? '\n' : '';
+    tree.write(filePath, JSON.stringify(parsed, null, 2) + trailingNewline);
+  }
+}
+
+function renameObjectKey(
+  obj: Record<string, unknown>,
+  oldKey: string,
+  newKey: string
+): Record<string, unknown> {
+  const rebuilt: Record<string, unknown> = {};
+  for (const [k, v] of Object.entries(obj)) {
+    rebuilt[k === oldKey ? newKey : k] = v;
+  }
+  return rebuilt;
+}
+
+const VITEST_MAX_THREADS_INLINE = /\bVITEST_MAX_THREADS\b/g;
+const VITEST_MAX_FORKS_INLINE = /\bVITEST_MAX_FORKS\b/g;
+const VITE_NODE_DEPS_INLINE = /\bVITE_NODE_DEPS_MODULE_DIRECTORIES\b/g;
+
+function rewriteInlineEnvVars(
+  value: string,
+  filePath: string,
+  targetName: string,
+  unhandled: string[]
+): string {
+  const hasThreads = /\bVITEST_MAX_THREADS\b/.test(value);
+  const hasForks = /\bVITEST_MAX_FORKS\b/.test(value);
+  let updated = value;
+  if (hasThreads && hasForks) {
+    unhandled.push(
+      `${filePath} (target \`${targetName}\`): \`VITEST_MAX_THREADS\` and \`VITEST_MAX_FORKS\` both appear in the same command — both collapse to \`VITEST_MAX_WORKERS\` in Vitest 4. ` +
+        `Decide which value should win and rename only that occurrence.`
+    );
+  } else if (hasThreads) {
+    updated = updated.replace(VITEST_MAX_THREADS_INLINE, 'VITEST_MAX_WORKERS');
+  } else if (hasForks) {
+    updated = updated.replace(VITEST_MAX_FORKS_INLINE, 'VITEST_MAX_WORKERS');
+  }
+  updated = updated.replace(VITE_NODE_DEPS_INLINE, 'VITEST_MODULE_DIRECTORIES');
+  return updated;
+}
+
+/**
+ * Scan CI provider configs for v4 legacy env-var tokens and forward the file
+ * paths to the agent. YAML structure varies by provider; mechanical edits
+ * risk breaking comments, anchors, and multi-line strings.
+ */
+function scanCiFiles(tree: Tree, unhandled: string[]): void {
+  visitCiFiles(tree, (filePath, contents) => {
+    const tokens: string[] = [];
+    if (/\bVITEST_MAX_THREADS\b/.test(contents)) {
+      tokens.push('`VITEST_MAX_THREADS`');
+    }
+    if (/\bVITEST_MAX_FORKS\b/.test(contents)) {
+      tokens.push('`VITEST_MAX_FORKS`');
+    }
+    if (/\bVITE_NODE_DEPS_MODULE_DIRECTORIES\b/.test(contents)) {
+      tokens.push('`VITE_NODE_DEPS_MODULE_DIRECTORIES`');
+    }
+    if (tokens.length === 0) return;
+    unhandled.push(
+      `${filePath}: found legacy Vitest env-var token(s) in this CI config: ${tokens.join(', ')}. ` +
+        `Rename \`VITEST_MAX_THREADS\` / \`VITEST_MAX_FORKS\` → \`VITEST_MAX_WORKERS\` (pick a single value when both are set), and \`VITE_NODE_DEPS_MODULE_DIRECTORIES\` → \`VITEST_MODULE_DIRECTORIES\`.`
+    );
+  });
 }
 
 /**

--- a/packages/vite/src/migrations/update-23-0-0/migrate-to-vitest-4.ts
+++ b/packages/vite/src/migrations/update-23-0-0/migrate-to-vitest-4.ts
@@ -30,7 +30,7 @@ let ts: typeof import('typescript');
 /**
  * Hybrid migration paired with `ai-instructions-for-vitest-4.md`. Applies the
  * deterministic, AST-tractable Vitest 3.x → 4.0 changes mechanically and
- * forwards a `promptContext` describing any shape it could not handle so the
+ * forwards an `agentContext` describing any shape it could not handle so the
  * paired prompt's agent can finish the rest.
  *
  * The "apply" set is intentionally narrow (renames, deletions of dead options,
@@ -82,10 +82,10 @@ export default async function migrateToVitest4(tree: Tree) {
     `If your CI provider stores Vitest env vars in its dashboard (GitHub Actions repo/org secrets, GitLab CI/CD variables, Vercel/Netlify env vars, etc.), rename \`VITEST_MAX_THREADS\` and \`VITEST_MAX_FORKS\` to \`VITEST_MAX_WORKERS\`, and \`VITE_NODE_DEPS_MODULE_DIRECTORIES\` to \`VITEST_MODULE_DIRECTORIES\`. The pre-pass only handles in-repo files.`,
   ];
 
-  const result: { nextSteps?: string[]; promptContext?: string[] } = {
+  const result: { nextSteps?: string[]; agentContext?: string[] } = {
     nextSteps,
   };
-  if (unhandled.length > 0) result.promptContext = unhandled;
+  if (unhandled.length > 0) result.agentContext = unhandled;
   return result;
 }
 

--- a/packages/vite/src/migrations/update-23-0-0/migrate-to-vitest-4.ts
+++ b/packages/vite/src/migrations/update-23-0-0/migrate-to-vitest-4.ts
@@ -1,0 +1,695 @@
+import { formatFiles, type Tree, visitNotIgnoredFiles } from '@nx/devkit';
+import { ensureTypescript } from '@nx/js/internal';
+import { ast, query } from '@phenomnomnominal/tsquery';
+import type {
+  ArrayLiteralExpression,
+  Identifier,
+  ImportDeclaration,
+  Node,
+  PropertyAssignment,
+  SourceFile,
+  StringLiteral,
+} from 'typescript';
+import {
+  applyTextEdits,
+  removeNodeWithTrailingCommaEdit,
+  replaceNodeTextEdit,
+  replaceStringLiteralValueEdit,
+  type TextEdit,
+} from './lib/ast-edits';
+import {
+  isJsOrTsFile,
+  isVitestWorkspaceFile,
+  visitVitestConfigFiles,
+} from './lib/vitest-config-files';
+
+let ts: typeof import('typescript');
+
+/**
+ * Hybrid migration paired with `ai-instructions-for-vitest-4.md`. Applies the
+ * deterministic, AST-tractable Vitest 3.x → 4.0 changes mechanically and
+ * forwards a `promptContext` describing any shape it could not handle so the
+ * paired prompt's agent can finish the rest.
+ *
+ * The "apply" set is intentionally narrow (renames, deletions of dead options,
+ * single-property string rewrites). Anything requiring cross-cutting surgery
+ * (e.g. pool option flattening, `deps.* → server.deps.*` merge, browser
+ * provider function-form rewrite, workspace file inlining) is detected and
+ * logged for the agent.
+ */
+export default async function migrateToVitest4(tree: Tree) {
+  ts ??= ensureTypescript();
+
+  const unhandled: string[] = [];
+
+  visitVitestConfigFiles(tree, (filePath) =>
+    processVitestConfig(tree, filePath, unhandled)
+  );
+
+  // Workspace files are removed entirely in v4 — their presence is always a
+  // signal that the agent needs to inline them into the root config.
+  visitNotIgnoredFiles(tree, '', (filePath) => {
+    if (!isVitestWorkspaceFile(filePath)) return;
+    unhandled.push(
+      `${filePath}: \`vitest.workspace.*\` files are removed in Vitest 4. ` +
+        `Inline its project list into the root \`vitest.config.*\` under \`test.projects\` and delete this file.`
+    );
+  });
+
+  visitNotIgnoredFiles(tree, '', (filePath) => {
+    if (!isJsOrTsFile(filePath)) return;
+    processImportsAndCustomCode(tree, filePath, unhandled);
+  });
+
+  visitNotIgnoredFiles(tree, '', (filePath) => {
+    if (!filePath.endsWith('package.json')) return;
+    processPackageJson(tree, filePath, unhandled);
+  });
+
+  await formatFiles(tree);
+
+  if (unhandled.length > 0) return { promptContext: unhandled };
+  return;
+}
+
+const COVERAGE_DEAD_OPTIONS = new Set([
+  'all',
+  'extensions',
+  'ignoreEmptyLines',
+  'experimentalAstAwareRemapping',
+]);
+
+const POOL_FLATTEN_OPTIONS = new Set(['execArgv', 'isolate']);
+
+const REMOVED_REPORTER_CALLBACKS = new Set([
+  'onCollected',
+  'onSpecsCollected',
+  'onPathsCollected',
+  'onTaskUpdate',
+  'onFinished',
+]);
+
+function processVitestConfig(
+  tree: Tree,
+  filePath: string,
+  unhandled: string[]
+): void {
+  const contents = tree.read(filePath, 'utf-8');
+
+  // Cheap precheck: skip files that don't mention any v4 target.
+  if (!mightContainV4Targets(contents)) return;
+
+  const sourceFile = ast(contents);
+  const edits: TextEdit[] = [];
+
+  collectCoverageRemovalEdits(sourceFile, contents, edits);
+  collectWorkspaceRenameEdits(sourceFile, edits);
+  collectDepsOptimizerWebEdits(sourceFile, edits);
+  collectUseAtomicsRemovalEdits(sourceFile, contents, edits);
+  collectMinWorkersRemovalEdits(sourceFile, contents, edits);
+  collectReporterRenameEdits(sourceFile, contents, edits);
+
+  collectPoolOptionDetectLogs(sourceFile, filePath, unhandled);
+  collectDepsServerMoveLogs(sourceFile, filePath, unhandled);
+  collectMatchGlobsLogs(sourceFile, filePath, unhandled);
+  collectBrowserStringProviderLogs(sourceFile, filePath, unhandled);
+  collectTesterScriptsLogs(sourceFile, filePath, unhandled);
+  collectCustomReporterCallbackLogs(sourceFile, filePath, unhandled);
+
+  if (edits.length > 0) {
+    tree.write(filePath, applyTextEdits(contents, edits));
+  }
+}
+
+function mightContainV4Targets(contents: string): boolean {
+  // Hit-test: keywords we care about. Cheap string scan to avoid parsing
+  // every config file in the workspace.
+  return /\b(workspace|projects|coverage|useAtomics|minWorkers|reporters|provider|deps|poolOptions|singleFork|singleThread|maxThreads|maxForks|environmentMatchGlobs|poolMatchGlobs|testerScripts|onCollected|onSpecsCollected|onPathsCollected|onTaskUpdate|onFinished|vmThreads)\b/.test(
+    contents
+  );
+}
+
+/**
+ * Coverage option removals (V4-1): `all`, `extensions`, `ignoreEmptyLines`,
+ * `experimentalAstAwareRemapping` are all removed in v4. Anchored to
+ * `test.coverage`.
+ */
+function collectCoverageRemovalEdits(
+  sourceFile: SourceFile,
+  contents: string,
+  edits: TextEdit[]
+): void {
+  for (const optionName of COVERAGE_DEAD_OPTIONS) {
+    const identifiers = query<Identifier>(
+      sourceFile,
+      `PropertyAssignment > Identifier[name=${optionName}]`
+    );
+    for (const id of identifiers) {
+      if (!isInsideTestSubProperty(id, 'coverage')) continue;
+      const owningProperty = id.parent as PropertyAssignment;
+      edits.push(removeNodeWithTrailingCommaEdit(contents, owningProperty));
+    }
+  }
+}
+
+/**
+ * `test.workspace` → `test.projects` (V4-2). The external `vitest.workspace.*`
+ * file form is detected separately at the top level and always logged.
+ */
+function collectWorkspaceRenameEdits(
+  sourceFile: SourceFile,
+  edits: TextEdit[]
+): void {
+  const identifiers = query<Identifier>(
+    sourceFile,
+    'PropertyAssignment > Identifier[name=workspace]'
+  );
+  for (const id of identifiers) {
+    if (!isImmediateChildOfTest(id)) continue;
+    edits.push(replaceNodeTextEdit(id, 'projects'));
+  }
+}
+
+/**
+ * `deps.optimizer.web` → `deps.optimizer.client` (V4-4). Anchored to
+ * `test.deps.optimizer` so the `web` rename only applies to that nesting.
+ */
+function collectDepsOptimizerWebEdits(
+  sourceFile: SourceFile,
+  edits: TextEdit[]
+): void {
+  const identifiers = query<Identifier>(
+    sourceFile,
+    'PropertyAssignment > Identifier[name=web]'
+  );
+  for (const id of identifiers) {
+    if (!isInsideChain(id, ['test', 'deps', 'optimizer'])) continue;
+    edits.push(replaceNodeTextEdit(id, 'client'));
+  }
+}
+
+/**
+ * Remove `poolOptions.threads.useAtomics` (V4-5).
+ */
+function collectUseAtomicsRemovalEdits(
+  sourceFile: SourceFile,
+  contents: string,
+  edits: TextEdit[]
+): void {
+  const identifiers = query<Identifier>(
+    sourceFile,
+    'PropertyAssignment > Identifier[name=useAtomics]'
+  );
+  for (const id of identifiers) {
+    if (!isInsideChain(id, ['test', 'poolOptions', 'threads'])) continue;
+    const owningProperty = id.parent as PropertyAssignment;
+    edits.push(removeNodeWithTrailingCommaEdit(contents, owningProperty));
+  }
+}
+
+/**
+ * Remove top-level `test.minWorkers` (V4-6). Behaves as `0` in non-watch mode
+ * in v4, so dropping the assignment is safe.
+ */
+function collectMinWorkersRemovalEdits(
+  sourceFile: SourceFile,
+  contents: string,
+  edits: TextEdit[]
+): void {
+  const identifiers = query<Identifier>(
+    sourceFile,
+    'PropertyAssignment > Identifier[name=minWorkers]'
+  );
+  for (const id of identifiers) {
+    if (!isImmediateChildOfTest(id)) continue;
+    const owningProperty = id.parent as PropertyAssignment;
+    edits.push(removeNodeWithTrailingCommaEdit(contents, owningProperty));
+  }
+}
+
+/**
+ * Reporter renames inside `test.reporters` (V4-7).
+ *   `'verbose'` → `'tree'`
+ *   `'basic'`   → `['default', { summary: false }]`
+ */
+function collectReporterRenameEdits(
+  sourceFile: SourceFile,
+  contents: string,
+  edits: TextEdit[]
+): void {
+  const reportersProperties = query<PropertyAssignment>(
+    sourceFile,
+    'PropertyAssignment:has(Identifier[name=reporters])'
+  ).filter(
+    (p) =>
+      ts.isIdentifier(p.name) &&
+      p.name.text === 'reporters' &&
+      isImmediateChildOfTest(p.name)
+  );
+
+  for (const property of reportersProperties) {
+    const init = property.initializer;
+    if (!ts.isArrayLiteralExpression(init)) continue;
+    for (const element of (init as ArrayLiteralExpression).elements) {
+      if (!ts.isStringLiteral(element)) continue;
+      if (element.text === 'verbose') {
+        edits.push(replaceStringLiteralValueEdit(contents, element, 'tree'));
+      } else if (element.text === 'basic') {
+        edits.push(
+          replaceNodeTextEdit(element, `['default', { summary: false }]`)
+        );
+      }
+    }
+  }
+}
+
+/**
+ * Detect (but do not modify) pool-related options whose v4 semantics require
+ * cross-cutting surgery: `singleThread`/`singleFork`, `maxThreads`/`maxForks`,
+ * `poolOptions.{forks,threads}.{execArgv,isolate}`,
+ * `poolOptions.vmThreads.memoryLimit`.
+ */
+function collectPoolOptionDetectLogs(
+  sourceFile: SourceFile,
+  filePath: string,
+  unhandled: string[]
+): void {
+  const singleHits = query<Identifier>(
+    sourceFile,
+    'PropertyAssignment > Identifier[name=/^single(Thread|Fork)$/]'
+  );
+  for (const id of singleHits) {
+    unhandled.push(
+      `${filePath}: \`${id.text}\` is removed in Vitest 4. ` +
+        `When set to \`true\`, replace with \`maxWorkers: 1, isolate: false\` at the top of \`test\`. ` +
+        `When set to \`false\`, delete it.`
+    );
+  }
+
+  const maxHits = query<Identifier>(
+    sourceFile,
+    'PropertyAssignment > Identifier[name=/^max(Threads|Forks)$/]'
+  );
+  for (const id of maxHits) {
+    if (!isImmediateChildOfTest(id)) continue;
+    unhandled.push(
+      `${filePath}: \`${id.text}\` is removed in Vitest 4. ` +
+        `Replace with the pool-agnostic \`maxWorkers\` option.`
+    );
+  }
+
+  for (const optionName of POOL_FLATTEN_OPTIONS) {
+    const ids = query<Identifier>(
+      sourceFile,
+      `PropertyAssignment > Identifier[name=${optionName}]`
+    );
+    for (const id of ids) {
+      if (
+        isInsideChain(id, ['test', 'poolOptions', 'forks']) ||
+        isInsideChain(id, ['test', 'poolOptions', 'threads'])
+      ) {
+        unhandled.push(
+          `${filePath}: \`poolOptions.<pool>.${optionName}\` was flattened in Vitest 4. ` +
+            `Move it to the top-level \`test.${optionName}\`.`
+        );
+      }
+    }
+  }
+
+  const memoryLimitIds = query<Identifier>(
+    sourceFile,
+    'PropertyAssignment > Identifier[name=memoryLimit]'
+  );
+  for (const id of memoryLimitIds) {
+    if (!isInsideChain(id, ['test', 'poolOptions', 'vmThreads'])) continue;
+    unhandled.push(
+      `${filePath}: \`poolOptions.vmThreads.memoryLimit\` was renamed and lifted in Vitest 4. ` +
+        `Move it to top-level \`test.vmMemoryLimit\`.`
+    );
+  }
+}
+
+/**
+ * Detect `test.deps.{external,inline,fallbackCJS}`. Moving them under
+ * `test.server.deps` requires conflict-aware merging that we don't attempt
+ * mechanically.
+ */
+function collectDepsServerMoveLogs(
+  sourceFile: SourceFile,
+  filePath: string,
+  unhandled: string[]
+): void {
+  for (const name of ['external', 'inline', 'fallbackCJS']) {
+    const ids = query<Identifier>(
+      sourceFile,
+      `PropertyAssignment > Identifier[name=${name}]`
+    );
+    for (const id of ids) {
+      if (!isInsideChain(id, ['test', 'deps'])) continue;
+      // Don't flag `test.deps.optimizer.<...>` — only direct children of deps.
+      if (!isImmediateChildOfProperty(id, 'deps')) continue;
+      unhandled.push(
+        `${filePath}: \`test.deps.${name}\` moved to \`test.server.deps.${name}\` in Vitest 4. ` +
+          `Move the property, merging with any existing \`server.deps\` block.`
+      );
+    }
+  }
+}
+
+/**
+ * `test.poolMatchGlobs` / `test.environmentMatchGlobs` are removed in v4;
+ * their replacement is per-project conditions inside `test.projects`. Always
+ * a manual rewrite.
+ */
+function collectMatchGlobsLogs(
+  sourceFile: SourceFile,
+  filePath: string,
+  unhandled: string[]
+): void {
+  for (const name of ['poolMatchGlobs', 'environmentMatchGlobs']) {
+    const ids = query<Identifier>(
+      sourceFile,
+      `PropertyAssignment > Identifier[name=${name}]`
+    );
+    for (const id of ids) {
+      if (!isImmediateChildOfTest(id)) continue;
+      unhandled.push(
+        `${filePath}: \`test.${name}\` is removed in Vitest 4. ` +
+          `Express the same per-glob configuration via \`test.projects\` entries with conditions.`
+      );
+    }
+  }
+}
+
+/**
+ * `browser.provider` as a string is no longer valid in v4 — it must be the
+ * return value of a provider function imported from a per-provider package.
+ */
+function collectBrowserStringProviderLogs(
+  sourceFile: SourceFile,
+  filePath: string,
+  unhandled: string[]
+): void {
+  const providers = query<StringLiteral>(
+    sourceFile,
+    'PropertyAssignment:has(Identifier[name=provider]) > StringLiteral'
+  );
+  for (const lit of providers) {
+    if (!isInsideTestSubProperty(lit, 'browser')) continue;
+    unhandled.push(
+      `${filePath}: \`browser.provider\` is no longer a string in Vitest 4 (current value: ${lit.getText()}). ` +
+        `Install the matching \`@vitest/browser-<provider>\` package and use the function form, ` +
+        `e.g. \`provider: playwright(...)\`.`
+    );
+  }
+}
+
+/**
+ * `browser.testerScripts` (array of scripts) was replaced by
+ * `browser.testerHtmlPath` (single HTML file) — a semantic change.
+ */
+function collectTesterScriptsLogs(
+  sourceFile: SourceFile,
+  filePath: string,
+  unhandled: string[]
+): void {
+  const ids = query<Identifier>(
+    sourceFile,
+    'PropertyAssignment > Identifier[name=testerScripts]'
+  );
+  for (const id of ids) {
+    if (!isInsideTestSubProperty(id, 'browser')) continue;
+    unhandled.push(
+      `${filePath}: \`browser.testerScripts\` was removed in Vitest 4 in favor of \`browser.testerHtmlPath\`. ` +
+        `Combine the script contents into a single HTML file and point \`testerHtmlPath\` at it.`
+    );
+  }
+}
+
+/**
+ * Custom reporter callbacks removed in v4: `onCollected`, `onSpecsCollected`,
+ * `onPathsCollected`, `onTaskUpdate`, `onFinished`. They can appear as
+ * `PropertyAssignment` (object literal: `onCollected: () => ...`),
+ * `MethodDeclaration` (shorthand: `onCollected() {}`), or class method on a
+ * reporter class — the search broadens past `PropertyAssignment` to cover
+ * all three.
+ */
+function collectCustomReporterCallbackLogs(
+  sourceFile: SourceFile,
+  filePath: string,
+  unhandled: string[]
+): void {
+  for (const name of REMOVED_REPORTER_CALLBACKS) {
+    const ids = query<Identifier>(sourceFile, `Identifier[name=${name}]`);
+    const matchedAsName = ids.some(isPropertyOrMethodName);
+    if (matchedAsName) {
+      unhandled.push(
+        `${filePath}: custom reporter uses the removed-in-v4 \`${name}\` callback. ` +
+          `Migrate to the v4 \`onTestModuleCollected\` / \`onTestCaseResult\` / \`onTestRunEnd\` API.`
+      );
+    }
+  }
+}
+
+function isPropertyOrMethodName(id: Node): boolean {
+  const parent = id.parent;
+  if (!parent) return false;
+  if (
+    !(
+      ts.isPropertyAssignment(parent) ||
+      ts.isShorthandPropertyAssignment(parent) ||
+      ts.isMethodDeclaration(parent) ||
+      ts.isGetAccessorDeclaration(parent) ||
+      ts.isSetAccessorDeclaration(parent) ||
+      ts.isMethodSignature(parent) ||
+      ts.isPropertySignature(parent)
+    )
+  ) {
+    return false;
+  }
+  // The identifier must be the NAME of the property/method, not an
+  // initializer-side reference.
+  return (parent as any).name === id;
+}
+
+/**
+ * Handles import-side concerns:
+ *   - `@vitest/browser/context` → `vitest/browser` (V4-3a, mechanical when
+ *     the subpath is exactly `/context`).
+ *   - `@vitest/browser/utils` (logged — semantic restructure).
+ *   - `defineWorkspace` from `vitest/config` (logged — file removed in v4).
+ *   - `jest-snapshot` imports inside custom matcher files (logged).
+ */
+function processImportsAndCustomCode(
+  tree: Tree,
+  filePath: string,
+  unhandled: string[]
+): void {
+  const contents = tree.read(filePath, 'utf-8');
+  const hasBrowserCtx = contents.includes('@vitest/browser/context');
+  const hasBrowserUtils = contents.includes('@vitest/browser/utils');
+  const hasDefineWorkspace = contents.includes('defineWorkspace');
+  const hasJestSnapshot = contents.includes('jest-snapshot');
+
+  if (
+    !hasBrowserCtx &&
+    !hasBrowserUtils &&
+    !hasDefineWorkspace &&
+    !hasJestSnapshot
+  ) {
+    return;
+  }
+
+  const sourceFile = ast(contents);
+  const importDecls = query<ImportDeclaration>(sourceFile, 'ImportDeclaration');
+  const edits: TextEdit[] = [];
+
+  for (const decl of importDecls) {
+    if (!ts.isStringLiteral(decl.moduleSpecifier)) continue;
+    const spec = decl.moduleSpecifier.text;
+
+    if (spec === '@vitest/browser/context') {
+      edits.push(
+        replaceStringLiteralValueEdit(
+          contents,
+          decl.moduleSpecifier,
+          'vitest/browser'
+        )
+      );
+    } else if (spec === '@vitest/browser/utils') {
+      unhandled.push(
+        `${filePath}: imports from '@vitest/browser/utils' moved into 'vitest/browser' under a named \`utils\` export in Vitest 4. ` +
+          `Rewrite to \`import { utils } from 'vitest/browser'\` and rebind the used helpers.`
+      );
+    } else if (spec === 'jest-snapshot') {
+      unhandled.push(
+        `${filePath}: custom matcher imports from 'jest-snapshot'. ` +
+          `In Vitest 4, import the snapshot helpers from 'vitest' via the \`Snapshots\` namespace.`
+      );
+    }
+
+    // `defineWorkspace` is named-imported from vitest/config — flag any usage.
+    const named = decl.importClause?.namedBindings;
+    if (named && ts.isNamedImports(named)) {
+      const usesDefineWorkspace = named.elements.some(
+        (el) => el.name.text === 'defineWorkspace'
+      );
+      if (usesDefineWorkspace) {
+        unhandled.push(
+          `${filePath}: \`defineWorkspace\` is removed in Vitest 4 (the external \`vitest.workspace.*\` form is gone). ` +
+            `Replace with \`defineConfig\` and inline the project list under \`test.projects\` in the root vitest config.`
+        );
+      }
+    }
+  }
+
+  if (edits.length > 0) {
+    tree.write(filePath, applyTextEdits(contents, edits));
+  }
+}
+
+const ENV_RENAMES: Array<[RegExp, string]> = [
+  [/\bVITEST_MAX_THREADS\b/g, 'VITEST_MAX_WORKERS'],
+  [/\bVITEST_MAX_FORKS\b/g, 'VITEST_MAX_WORKERS'],
+  [/\bVITE_NODE_DEPS_MODULE_DIRECTORIES\b/g, 'VITEST_MODULE_DIRECTORIES'],
+];
+
+function processPackageJson(
+  tree: Tree,
+  filePath: string,
+  unhandled: string[]
+): void {
+  const contents = tree.read(filePath, 'utf-8');
+  let parsed: any;
+  try {
+    parsed = JSON.parse(contents);
+  } catch {
+    return;
+  }
+
+  let changed = false;
+
+  if (parsed.scripts && typeof parsed.scripts === 'object') {
+    for (const [name, value] of Object.entries(parsed.scripts)) {
+      if (typeof value !== 'string') continue;
+      let updated = value;
+      for (const [re, replacement] of ENV_RENAMES) {
+        updated = updated.replace(re, replacement);
+      }
+      if (updated !== value) {
+        parsed.scripts[name] = updated;
+        changed = true;
+      }
+    }
+  }
+
+  // `@vitest/browser` surface moved into the main `vitest` package and the
+  // per-provider packages. Removing the dep without installing the new
+  // provider package would break browser runs, so log instead of editing.
+  for (const bucket of [
+    'dependencies',
+    'devDependencies',
+    'peerDependencies',
+    'optionalDependencies',
+  ]) {
+    const deps = parsed[bucket];
+    if (!deps || typeof deps !== 'object') continue;
+    if ('@vitest/browser' in deps) {
+      unhandled.push(
+        `${filePath}: \`@vitest/browser\` is no longer needed at the top level in Vitest 4 — ` +
+          `install the matching per-provider package (\`@vitest/browser-playwright\`, \`@vitest/browser-webdriverio\`, ` +
+          `or \`@vitest/browser-preview\`) and remove the \`@vitest/browser\` entry.`
+      );
+      break; // one note per file is enough
+    }
+  }
+
+  if (changed) {
+    const trailingNewline = contents.endsWith('\n') ? '\n' : '';
+    tree.write(filePath, JSON.stringify(parsed, null, 2) + trailingNewline);
+  }
+}
+
+/**
+ * Returns true if `node` lives inside a property whose name is
+ * `propertyName`, whose own parent is a property named `test`.
+ */
+function isInsideTestSubProperty(
+  node: Node,
+  propertyName: 'coverage' | 'browser' | 'deps'
+): boolean {
+  const owning = findEnclosingPropertyAssignment(node, propertyName);
+  if (!owning) return false;
+  return !!findEnclosingPropertyAssignment(owning, 'test');
+}
+
+/**
+ * Returns true if `node`'s identifier sits as a direct property of a
+ * `test:` block (i.e. `test.{name}`, not `test.something.{name}`).
+ */
+function isImmediateChildOfTest(node: Node): boolean {
+  // The Identifier's parent is a PropertyAssignment; that PA's parent is the
+  // ObjectLiteralExpression of `test`; that OLE's parent is the `test:`
+  // PropertyAssignment itself.
+  const pa = node.parent;
+  if (!pa || !ts.isPropertyAssignment(pa)) return false;
+  const ole = pa.parent;
+  if (!ole || !ts.isObjectLiteralExpression(ole)) return false;
+  const testPa = ole.parent;
+  if (!testPa || !ts.isPropertyAssignment(testPa)) return false;
+  return ts.isIdentifier(testPa.name) && testPa.name.text === 'test';
+}
+
+/**
+ * Like `isImmediateChildOfTest` but parameterised on the immediate parent's
+ * property name.
+ */
+function isImmediateChildOfProperty(node: Node, propertyName: string): boolean {
+  const pa = node.parent;
+  if (!pa || !ts.isPropertyAssignment(pa)) return false;
+  const ole = pa.parent;
+  if (!ole || !ts.isObjectLiteralExpression(ole)) return false;
+  const ownerPa = ole.parent;
+  if (!ownerPa || !ts.isPropertyAssignment(ownerPa)) return false;
+  return ts.isIdentifier(ownerPa.name) && ownerPa.name.text === propertyName;
+}
+
+/**
+ * Returns true if `node`'s ancestors include a chain of property names —
+ * outer-most first. So `['test', 'deps', 'optimizer']` matches a node living
+ * inside `test.deps.optimizer.<something>` (any sub-property name, e.g.
+ * `web`).
+ */
+function isInsideChain(node: Node, chain: string[]): boolean {
+  // Walk inner → outer through enclosing properties, expecting names to
+  // match `chain` from the last (innermost) to the first (outermost).
+  let current: Node | undefined = node.parent;
+  let chainIndex = chain.length - 1;
+  while (current && chainIndex >= 0) {
+    if (ts.isPropertyAssignment(current) && ts.isIdentifier(current.name)) {
+      if (current.name.text === chain[chainIndex]) {
+        chainIndex--;
+      }
+    }
+    current = current.parent;
+  }
+  return chainIndex < 0;
+}
+
+function findEnclosingPropertyAssignment(
+  node: Node,
+  name: string
+): PropertyAssignment | undefined {
+  let current: Node | undefined = node.parent;
+  while (current) {
+    if (
+      ts.isPropertyAssignment(current) &&
+      ts.isIdentifier(current.name) &&
+      current.name.text === name
+    ) {
+      return current;
+    }
+    current = current.parent;
+  }
+  return undefined;
+}

--- a/packages/vite/src/migrations/update-23-0-0/migrate-to-vitest-4.ts
+++ b/packages/vite/src/migrations/update-23-0-0/migrate-to-vitest-4.ts
@@ -279,11 +279,26 @@ function collectPoolOptionDetectLogs(
     'PropertyAssignment > Identifier[name=/^single(Thread|Fork)$/]'
   );
   for (const id of singleHits) {
-    unhandled.push(
-      `${filePath}: \`${id.text}\` is removed in Vitest 4. ` +
-        `When set to \`true\`, replace with \`maxWorkers: 1, isolate: false\` at the top of \`test\`. ` +
-        `When set to \`false\`, delete it.`
+    const literalValue = readBooleanLiteralValue(
+      id.parent as PropertyAssignment
     );
+    if (literalValue === true) {
+      unhandled.push(
+        `${filePath}: \`${id.text}: true\` is removed in Vitest 4. ` +
+          `Replace it with \`maxWorkers: 1, isolate: false\` at the top of the \`test\` block, then remove \`${id.text}\`.`
+      );
+    } else if (literalValue === false) {
+      unhandled.push(
+        `${filePath}: \`${id.text}: false\` is removed in Vitest 4 (it was already the default). ` +
+          `Delete the property.`
+      );
+    } else {
+      unhandled.push(
+        `${filePath}: \`${id.text}\` is removed in Vitest 4 and the value here is not a boolean literal. ` +
+          `If it evaluates to \`true\`, replace with \`maxWorkers: 1, isolate: false\` at the top of \`test\` and remove \`${id.text}\`. ` +
+          `If it evaluates to \`false\`, delete it.`
+      );
+    }
   }
 
   const maxHits = query<Identifier>(
@@ -292,9 +307,15 @@ function collectPoolOptionDetectLogs(
   );
   for (const id of maxHits) {
     if (!isImmediateChildOfTest(id)) continue;
+    const literalValue = readNumericLiteralValue(
+      id.parent as PropertyAssignment
+    );
+    const currentValueDescr =
+      literalValue !== undefined ? ` (current value: ${literalValue})` : '';
     unhandled.push(
-      `${filePath}: \`${id.text}\` is removed in Vitest 4. ` +
-        `Replace with the pool-agnostic \`maxWorkers\` option.`
+      `${filePath}: \`test.${id.text}\`${currentValueDescr} is removed in Vitest 4. ` +
+        `Replace with the pool-agnostic \`maxWorkers\` option. ` +
+        `If both \`maxThreads\` and \`maxForks\` are set with different values, pick the one matching the pool the project actually uses.`
     );
   }
 
@@ -304,15 +325,18 @@ function collectPoolOptionDetectLogs(
       `PropertyAssignment > Identifier[name=${optionName}]`
     );
     for (const id of ids) {
-      if (
-        isInsideChain(id, ['test', 'poolOptions', 'forks']) ||
-        isInsideChain(id, ['test', 'poolOptions', 'threads'])
-      ) {
-        unhandled.push(
-          `${filePath}: \`poolOptions.<pool>.${optionName}\` was flattened in Vitest 4. ` +
-            `Move it to the top-level \`test.${optionName}\`.`
-        );
-      }
+      const insideForks = isInsideChain(id, ['test', 'poolOptions', 'forks']);
+      const insideThreads = isInsideChain(id, [
+        'test',
+        'poolOptions',
+        'threads',
+      ]);
+      if (!insideForks && !insideThreads) continue;
+      const pool = insideForks ? 'forks' : 'threads';
+      unhandled.push(
+        `${filePath}: \`test.poolOptions.${pool}.${optionName}\` was flattened in Vitest 4. ` +
+          `Move it to the top-level \`test.${optionName}\` (one value for all pools).`
+      );
     }
   }
 
@@ -323,10 +347,27 @@ function collectPoolOptionDetectLogs(
   for (const id of memoryLimitIds) {
     if (!isInsideChain(id, ['test', 'poolOptions', 'vmThreads'])) continue;
     unhandled.push(
-      `${filePath}: \`poolOptions.vmThreads.memoryLimit\` was renamed and lifted in Vitest 4. ` +
+      `${filePath}: \`test.poolOptions.vmThreads.memoryLimit\` was renamed and lifted in Vitest 4. ` +
         `Move it to top-level \`test.vmMemoryLimit\`.`
     );
   }
+}
+
+function readBooleanLiteralValue(
+  property: PropertyAssignment
+): boolean | undefined {
+  const init = property.initializer;
+  if (init.kind === ts.SyntaxKind.TrueKeyword) return true;
+  if (init.kind === ts.SyntaxKind.FalseKeyword) return false;
+  return undefined;
+}
+
+function readNumericLiteralValue(
+  property: PropertyAssignment
+): number | undefined {
+  const init = property.initializer;
+  if (ts.isNumericLiteral(init)) return Number(init.text);
+  return undefined;
 }
 
 /**
@@ -486,19 +527,11 @@ function processImportsAndCustomCode(
   unhandled: string[]
 ): void {
   const contents = tree.read(filePath, 'utf-8');
-  const hasBrowserCtx = contents.includes('@vitest/browser/context');
-  const hasBrowserUtils = contents.includes('@vitest/browser/utils');
+  const hasBrowserPackage = contents.includes('@vitest/browser');
   const hasDefineWorkspace = contents.includes('defineWorkspace');
   const hasJestSnapshot = contents.includes('jest-snapshot');
 
-  if (
-    !hasBrowserCtx &&
-    !hasBrowserUtils &&
-    !hasDefineWorkspace &&
-    !hasJestSnapshot
-  ) {
-    return;
-  }
+  if (!hasBrowserPackage && !hasDefineWorkspace && !hasJestSnapshot) return;
 
   const sourceFile = ast(contents);
   const importDecls = query<ImportDeclaration>(sourceFile, 'ImportDeclaration');
@@ -520,6 +553,11 @@ function processImportsAndCustomCode(
       unhandled.push(
         `${filePath}: imports from '@vitest/browser/utils' moved into 'vitest/browser' under a named \`utils\` export in Vitest 4. ` +
           `Rewrite to \`import { utils } from 'vitest/browser'\` and rebind the used helpers.`
+      );
+    } else if (spec === '@vitest/browser') {
+      unhandled.push(
+        `${filePath}: bare \`@vitest/browser\` imports — the package's public surface moved into \`vitest/browser\` (and the per-provider packages) in Vitest 4. ` +
+          `Rewrite the import to \`vitest/browser\` and rebind any helpers that moved to the per-provider package.`
       );
     } else if (spec === 'jest-snapshot') {
       unhandled.push(

--- a/packages/vite/src/utils/all-generators-enforce-floor.spec.ts
+++ b/packages/vite/src/utils/all-generators-enforce-floor.spec.ts
@@ -1,0 +1,10 @@
+import { assertGeneratorsEnforceVersionFloor } from '@nx/devkit/internal-testing-utils';
+import { join } from 'node:path';
+
+describe('@nx/vite generators enforce supported version floor', () => {
+  assertGeneratorsEnforceVersionFloor({
+    packageRoot: join(__dirname, '..', '..'),
+    packageName: 'vite',
+    subFloorVersion: '~4.5.0',
+  });
+});

--- a/packages/vite/src/utils/assert-supported-vite-version.ts
+++ b/packages/vite/src/utils/assert-supported-vite-version.ts
@@ -1,0 +1,7 @@
+import { type Tree } from '@nx/devkit';
+import { assertSupportedPackageVersion } from '@nx/devkit/internal';
+import { minSupportedViteVersion } from './versions';
+
+export function assertSupportedViteVersion(tree: Tree): void {
+  assertSupportedPackageVersion(tree, 'vite', minSupportedViteVersion);
+}

--- a/packages/vite/src/utils/ensure-dependencies.ts
+++ b/packages/vite/src/utils/ensure-dependencies.ts
@@ -49,5 +49,11 @@ export function ensureDependencies(
     }
   }
 
-  return addDependenciesToPackageJson(host, {}, devDependencies);
+  return addDependenciesToPackageJson(
+    host,
+    {},
+    devDependencies,
+    undefined,
+    true
+  );
 }

--- a/packages/vite/src/utils/versions.ts
+++ b/packages/vite/src/utils/versions.ts
@@ -6,8 +6,14 @@ export const viteVersion = '^8.0.0';
 export const viteV7Version = '^7.0.0';
 export const viteV6Version = '^6.0.0';
 export const viteV5Version = '^5.0.0';
+// Lowest supported vite major. Kept at v5 because @nx/cypress (v13) still
+// installs vite 5; generators throw below this floor via assertSupportedViteVersion.
+export const minSupportedViteVersion = '5.0.0';
 export const vitePluginReactVersion = '^6.0.0';
 export const vitePluginReactV4Version = '^4.2.0';
+// Single constants: peer ranges span the whole supported vite window
+// (vite-plugin-dts -> `vite: *`, plugin-react-swc -> `vite: ^4..^8`), so no
+// per-major map is needed.
 export const vitePluginReactSwcVersion = '^4.3.0';
 export const vitePluginDtsVersion = '~4.5.0';
 export const ajvVersion = '^8.0.0';

--- a/packages/vitest/migrations.json
+++ b/packages/vitest/migrations.json
@@ -7,13 +7,17 @@
     },
     "update-22-1-0": {
       "version": "22.1.0-beta.8",
+      "requires": {
+        "vitest": ">=4.0.0"
+      },
       "description": "Create AI Instructions to help migrate users workspaces past breaking changes for Vitest 4.",
       "prompt": "./dist/src/migrations/update-22-1-0/ai-instructions-for-vitest-4.md"
     },
     "update-22-3-2": {
       "version": "22.3.2-beta.0",
       "requires": {
-        "@angular/build": ">=21.0.0"
+        "@angular/build": ">=21.0.0",
+        "vitest": ">=4.0.0"
       },
       "description": "Create AI Instructions to help migrate users workspaces past breaking changes for Vitest 4.",
       "prompt": "./dist/src/migrations/update-22-1-0/ai-instructions-for-vitest-4.md"

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -78,7 +78,7 @@
   },
   "peerDependencies": {
     "@nx/eslint": "workspace:*",
-    "vitest": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0",
+    "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0",
     "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
   },
   "peerDependenciesMeta": {

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -78,7 +78,7 @@
   },
   "peerDependencies": {
     "@nx/eslint": "workspace:*",
-    "vitest": "^2.0.0 || ^3.0.0 || ^4.0.0",
+    "vitest": "^3.0.0 || ^4.0.0",
     "vite": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
   },
   "peerDependenciesMeta": {

--- a/packages/vitest/src/generators/configuration/configuration.ts
+++ b/packages/vitest/src/generators/configuration/configuration.ts
@@ -37,6 +37,7 @@ import {
   getInstalledViteMajorVersion,
   getVitestDependenciesVersionsToInstall,
 } from '../../utils/version-utils';
+import { assertSupportedVitestVersion } from '../../utils/assert-supported-vitest-version';
 import { clean, coerce, major } from 'semver';
 
 /**
@@ -86,6 +87,8 @@ export async function configurationGeneratorInternal(
   schema: VitestGeneratorSchema,
   hasPlugin = false
 ) {
+  assertSupportedVitestVersion(tree);
+
   // Setting default to jsdom since it is the most common use case (React, Web).
   // The @nx/js:lib generator specifically sets this to node to be more generic.
   schema.testEnvironment ??= 'jsdom';

--- a/packages/vitest/src/generators/configuration/configuration.ts
+++ b/packages/vitest/src/generators/configuration/configuration.ts
@@ -33,10 +33,8 @@ import {
 import initGenerator from '../init/init';
 import { VitestGeneratorSchema } from './schema';
 import { detectUiFramework } from '../../utils/detect-ui-framework';
-import {
-  getInstalledViteMajorVersion,
-  getVitestDependenciesVersionsToInstall,
-} from '../../utils/version-utils';
+import { getInstalledViteMajorVersion } from '../../utils/version-utils';
+import { versions } from '../../utils/versions';
 import { assertSupportedVitestVersion } from '../../utils/assert-supported-vitest-version';
 import { clean, coerce, major } from 'semver';
 
@@ -438,24 +436,24 @@ function createFiles(
   });
 }
 
-async function getCoverageProviderDependency(
+function getCoverageProviderDependency(
   tree: Tree,
   coverageProvider: VitestGeneratorSchema['coverageProvider']
-): Promise<Record<string, string>> {
-  const { vitestCoverageV8, vitestCoverageIstanbul } =
-    await getVitestDependenciesVersionsToInstall(tree);
+): Record<string, string> {
+  const { vitestCoverageV8Version, vitestCoverageIstanbulVersion } =
+    versions(tree);
   switch (coverageProvider) {
     case 'v8':
       return {
-        '@vitest/coverage-v8': vitestCoverageV8,
+        '@vitest/coverage-v8': vitestCoverageV8Version,
       };
     case 'istanbul':
       return {
-        '@vitest/coverage-istanbul': vitestCoverageIstanbul,
+        '@vitest/coverage-istanbul': vitestCoverageIstanbulVersion,
       };
     default:
       return {
-        '@vitest/coverage-v8': vitestCoverageV8,
+        '@vitest/coverage-v8': vitestCoverageV8Version,
       };
   }
 }

--- a/packages/vitest/src/generators/convert-to-inferred/convert-to-inferred.ts
+++ b/packages/vitest/src/generators/convert-to-inferred/convert-to-inferred.ts
@@ -5,6 +5,7 @@ import {
 } from '@nx/devkit/internal';
 import { createNodesV2, VitestPluginOptions } from '../../plugins/plugin';
 import { testPostTargetTransformer } from './lib/test-post-target-transformer';
+import { assertSupportedVitestVersion } from '../../utils/assert-supported-vitest-version';
 
 interface Schema {
   project?: string;
@@ -12,6 +13,8 @@ interface Schema {
 }
 
 export async function convertToInferred(tree: Tree, options: Schema) {
+  assertSupportedVitestVersion(tree);
+
   const projectGraph = await createProjectGraphAsync();
 
   const migratedProjects =

--- a/packages/vitest/src/generators/init/init.ts
+++ b/packages/vitest/src/generators/init/init.ts
@@ -25,6 +25,7 @@ import {
 import { createNodesV2 } from '../../plugins/plugin';
 import { getInstalledViteMajorVersion } from '../../utils/version-utils';
 import { ignoreVitestTempFiles } from '../../utils/ignore-vitest-temp-files';
+import { assertSupportedVitestVersion } from '../../utils/assert-supported-vitest-version';
 
 export function updateDependencies(tree: Tree, schema: InitGeneratorSchema) {
   // Determine which vite version to install:
@@ -51,7 +52,7 @@ export function updateDependencies(tree: Tree, schema: InitGeneratorSchema) {
       vite: viteVersionToUse,
     },
     undefined,
-    schema.keepExistingVersions
+    schema.keepExistingVersions ?? true
   );
 }
 
@@ -94,6 +95,8 @@ export function updateNxJsonSettings(tree: Tree) {
 }
 
 export async function initGenerator(tree: Tree, schema: InitGeneratorSchema) {
+  assertSupportedVitestVersion(tree);
+
   const nxJson = readNxJson(tree);
   const addPluginDefault =
     process.env.NX_ADD_PLUGINS !== 'false' &&

--- a/packages/vitest/src/generators/init/schema.json
+++ b/packages/vitest/src/generators/init/schema.json
@@ -18,7 +18,7 @@
       "type": "boolean",
       "x-priority": "internal",
       "description": "Keep existing dependencies versions",
-      "default": false
+      "default": true
     },
     "updatePackageScripts": {
       "type": "boolean",

--- a/packages/vitest/src/utils/all-generators-enforce-floor.spec.ts
+++ b/packages/vitest/src/utils/all-generators-enforce-floor.spec.ts
@@ -1,0 +1,10 @@
+import { assertGeneratorsEnforceVersionFloor } from '@nx/devkit/internal-testing-utils';
+import { join } from 'node:path';
+
+describe('@nx/vitest generators enforce supported version floor', () => {
+  assertGeneratorsEnforceVersionFloor({
+    packageRoot: join(__dirname, '..', '..'),
+    packageName: 'vitest',
+    subFloorVersion: '~1.6.0',
+  });
+});

--- a/packages/vitest/src/utils/all-generators-enforce-floor.spec.ts
+++ b/packages/vitest/src/utils/all-generators-enforce-floor.spec.ts
@@ -5,6 +5,6 @@ describe('@nx/vitest generators enforce supported version floor', () => {
   assertGeneratorsEnforceVersionFloor({
     packageRoot: join(__dirname, '..', '..'),
     packageName: 'vitest',
-    subFloorVersion: '~1.6.0',
+    subFloorVersion: '~2.1.8',
   });
 });

--- a/packages/vitest/src/utils/assert-supported-vitest-version.ts
+++ b/packages/vitest/src/utils/assert-supported-vitest-version.ts
@@ -1,0 +1,7 @@
+import { type Tree } from '@nx/devkit';
+import { assertSupportedPackageVersion } from '@nx/devkit/internal';
+import { minSupportedVitestVersion } from './versions';
+
+export function assertSupportedVitestVersion(tree: Tree): void {
+  assertSupportedPackageVersion(tree, 'vitest', minSupportedVitestVersion);
+}

--- a/packages/vitest/src/utils/ensure-dependencies.ts
+++ b/packages/vitest/src/utils/ensure-dependencies.ts
@@ -13,12 +13,12 @@ import {
   edgeRuntimeVmVersion,
   happyDomVersion,
   jsdomVersion,
+  versions,
   vitePluginDtsVersion,
   vitePluginReactSwcVersion,
   vitePluginReactV4Version,
   vitePluginReactVersion,
 } from './versions';
-import { getVitestDependenciesVersionsToInstall } from './version-utils';
 
 export type EnsureDependenciesOptions = {
   uiFramework: 'angular' | 'react' | 'vue' | 'none';
@@ -78,8 +78,7 @@ export async function ensureDependencies(
   }
 
   if (useVitestUi) {
-    const { vitestUi } = await getVitestDependenciesVersionsToInstall(tree);
-    devDependencies['@vitest/ui'] = vitestUi;
+    devDependencies['@vitest/ui'] = versions(tree).vitestVersion;
   }
 
   return addDependenciesToPackageJson(

--- a/packages/vitest/src/utils/version-utils.ts
+++ b/packages/vitest/src/utils/version-utils.ts
@@ -1,71 +1,7 @@
-import {
-  createProjectGraphAsync,
-  getDependencyVersionFromPackageJson,
-} from '@nx/devkit';
+import { getDependencyVersionFromPackageJson } from '@nx/devkit';
 import type { Tree } from 'nx/src/generators/tree';
 import { clean, coerce, major } from 'semver';
-import {
-  vitestCoverageIstanbulVersion,
-  vitestCoverageV8Version,
-  vitestV3CoverageIstanbulVersion,
-  vitestV3CoverageV8Version,
-  vitestV3Version,
-  vitestVersion,
-} from './versions';
-
-type VitestDependenciesVersions = {
-  vitest: string;
-  vitestUi: string;
-  vitestCoverageV8: string;
-  vitestCoverageIstanbul: string;
-};
-
-export async function getVitestDependenciesVersionsToInstall(
-  tree: Tree
-): Promise<VitestDependenciesVersions> {
-  if (await isVitestV3(tree)) {
-    return {
-      vitest: vitestV3Version,
-      vitestUi: vitestV3Version,
-      vitestCoverageV8: vitestV3CoverageV8Version,
-      vitestCoverageIstanbul: vitestV3CoverageIstanbulVersion,
-    };
-  } else {
-    return {
-      vitest: vitestVersion,
-      vitestUi: vitestVersion,
-      vitestCoverageV8: vitestCoverageV8Version,
-      vitestCoverageIstanbul: vitestCoverageIstanbulVersion,
-    };
-  }
-}
-
-export async function isVitestV3(tree: Tree) {
-  let installedVitestVersion = await getInstalledVitestVersionFromGraph();
-  if (!installedVitestVersion) {
-    installedVitestVersion = getInstalledVitestVersion(tree);
-  }
-  return major(installedVitestVersion) === 3;
-}
-
-export function getInstalledVitestVersion(tree: Tree): string {
-  const installedVitestVersion = getDependencyVersionFromPackageJson(
-    tree,
-    'vitest'
-  );
-
-  if (
-    !installedVitestVersion ||
-    installedVitestVersion === 'latest' ||
-    installedVitestVersion === 'beta'
-  ) {
-    return clean(vitestVersion) ?? coerce(vitestVersion).version;
-  }
-
-  return (
-    clean(installedVitestVersion) ?? coerce(installedVitestVersion).version
-  );
-}
+import { vitestVersion } from './versions';
 
 export function getInstalledViteVersion(tree: Tree): string {
   const installedViteVersion = getDependencyVersionFromPackageJson(
@@ -97,15 +33,4 @@ export function getInstalledViteMajorVersion(
     return undefined;
   }
   return installedMajor as 5 | 6 | 7 | 8;
-}
-
-export async function getInstalledVitestVersionFromGraph() {
-  const graph = await createProjectGraphAsync();
-  const vitestDep = graph.externalNodes?.['npm:vitest'];
-  if (!vitestDep) {
-    return undefined;
-  }
-  return (
-    clean(vitestDep.data.version) ?? coerce(vitestDep.data.version).version
-  );
 }

--- a/packages/vitest/src/utils/version-utils.ts
+++ b/packages/vitest/src/utils/version-utils.ts
@@ -10,9 +10,6 @@ import {
   vitestV3CoverageIstanbulVersion,
   vitestV3CoverageV8Version,
   vitestV3Version,
-  vitestV2CoverageIstanbulVersion,
-  vitestV2CoverageV8Version,
-  vitestV2Version,
   vitestVersion,
 } from './versions';
 
@@ -33,15 +30,7 @@ export async function getVitestDependenciesVersionsToInstall(
       vitestCoverageV8: vitestV3CoverageV8Version,
       vitestCoverageIstanbul: vitestV3CoverageIstanbulVersion,
     };
-  } else if (await isVitestV2(tree)) {
-    return {
-      vitest: vitestV2Version,
-      vitestUi: vitestV2Version,
-      vitestCoverageV8: vitestV2CoverageV8Version,
-      vitestCoverageIstanbul: vitestV2CoverageIstanbulVersion,
-    };
   } else {
-    // Default to latest (v3)
     return {
       vitest: vitestVersion,
       vitestUi: vitestVersion,
@@ -57,14 +46,6 @@ export async function isVitestV3(tree: Tree) {
     installedVitestVersion = getInstalledVitestVersion(tree);
   }
   return major(installedVitestVersion) === 3;
-}
-
-export async function isVitestV2(tree: Tree) {
-  let installedVitestVersion = await getInstalledVitestVersionFromGraph();
-  if (!installedVitestVersion) {
-    installedVitestVersion = getInstalledVitestVersion(tree);
-  }
-  return major(installedVitestVersion) === 2;
 }
 
 export function getInstalledVitestVersion(tree: Tree): string {

--- a/packages/vitest/src/utils/versions.ts
+++ b/packages/vitest/src/utils/versions.ts
@@ -2,6 +2,7 @@ import { join } from 'path';
 
 export const nxVersion = require(join('@nx/vitest', 'package.json')).version;
 
+export const minSupportedVitestVersion = '2.0.0';
 export const viteVersion = '^8.0.0';
 export const viteV7Version = '^7.0.0';
 export const viteV6Version = '^6.0.0';

--- a/packages/vitest/src/utils/versions.ts
+++ b/packages/vitest/src/utils/versions.ts
@@ -2,14 +2,13 @@ import { join } from 'path';
 
 export const nxVersion = require(join('@nx/vitest', 'package.json')).version;
 
-export const minSupportedVitestVersion = '2.0.0';
+export const minSupportedVitestVersion = '3.0.0';
 export const viteVersion = '^8.0.0';
 export const viteV7Version = '^7.0.0';
 export const viteV6Version = '^6.0.0';
 export const viteV5Version = '^5.0.0';
 export const vitestV4Version = '~4.1.0';
 export const vitestV3Version = '^3.0.0';
-export const vitestV2Version = '^2.1.8';
 export const vitestVersion = vitestV4Version;
 export const vitePluginReactVersion = '^6.0.0';
 export const vitePluginReactV4Version = '^4.2.0';
@@ -26,9 +25,7 @@ export const analogVitestAngular = '~2.1.2';
 // Coverage providers
 export const vitestV4CoverageV8Version = '~4.1.0';
 export const vitestV3CoverageV8Version = '^3.0.5';
-export const vitestV2CoverageV8Version = '^2.1.8';
 export const vitestCoverageV8Version = vitestV4CoverageV8Version;
 export const vitestV4CoverageIstanbulVersion = '~4.1.0';
 export const vitestV3CoverageIstanbulVersion = '^3.0.5';
-export const vitestV2CoverageIstanbulVersion = '^2.1.8';
 export const vitestCoverageIstanbulVersion = vitestV4CoverageIstanbulVersion;

--- a/packages/vitest/src/utils/versions.ts
+++ b/packages/vitest/src/utils/versions.ts
@@ -1,15 +1,18 @@
+import { getDependencyVersionFromPackageJson, type Tree } from '@nx/devkit';
+import { getInstalledPackageVersion } from '@nx/devkit/internal';
 import { join } from 'path';
+import { clean, coerce, major } from 'semver';
 
 export const nxVersion = require(join('@nx/vitest', 'package.json')).version;
-
 export const minSupportedVitestVersion = '3.0.0';
+
+export const vitestVersion = '~4.1.0';
+export const vitestCoverageV8Version = '~4.1.0';
+export const vitestCoverageIstanbulVersion = '~4.1.0';
 export const viteVersion = '^8.0.0';
 export const viteV7Version = '^7.0.0';
 export const viteV6Version = '^6.0.0';
 export const viteV5Version = '^5.0.0';
-export const vitestV4Version = '~4.1.0';
-export const vitestV3Version = '^3.0.0';
-export const vitestVersion = vitestV4Version;
 export const vitePluginReactVersion = '^6.0.0';
 export const vitePluginReactV4Version = '^4.2.0';
 export const vitePluginReactSwcVersion = '^4.3.0';
@@ -19,13 +22,54 @@ export const ajvVersion = '^8.0.0';
 export const happyDomVersion = '~9.20.3';
 export const edgeRuntimeVmVersion = '~3.0.2';
 export const jitiVersion = '2.4.2';
-
 export const analogVitestAngular = '~2.1.2';
 
-// Coverage providers
-export const vitestV4CoverageV8Version = '~4.1.0';
-export const vitestV3CoverageV8Version = '^3.0.5';
-export const vitestCoverageV8Version = vitestV4CoverageV8Version;
-export const vitestV4CoverageIstanbulVersion = '~4.1.0';
-export const vitestV3CoverageIstanbulVersion = '^3.0.5';
-export const vitestCoverageIstanbulVersion = vitestV4CoverageIstanbulVersion;
+type VitestVersions = {
+  vitestVersion: string;
+  vitestCoverageV8Version: string;
+  vitestCoverageIstanbulVersion: string;
+};
+
+const latestVersions: VitestVersions = {
+  vitestVersion,
+  vitestCoverageV8Version,
+  vitestCoverageIstanbulVersion,
+};
+
+type CompatVersions = 3;
+const versionMap: Record<CompatVersions, VitestVersions> = {
+  3: {
+    vitestVersion: '^3.0.0',
+    vitestCoverageV8Version: '^3.0.5',
+    vitestCoverageIstanbulVersion: '^3.0.5',
+  },
+};
+
+export function versions(tree: Tree): VitestVersions {
+  const installedVitestVersion = getInstalledVitestVersion(tree);
+  if (!installedVitestVersion) {
+    return latestVersions;
+  }
+  const vitestMajorVersion = major(installedVitestVersion);
+  return versionMap[vitestMajorVersion as CompatVersions] ?? latestVersions;
+}
+
+export function getInstalledVitestVersion(tree?: Tree): string | null {
+  if (!tree) {
+    return getInstalledPackageVersion('vitest');
+  }
+
+  const installedVersion = getDependencyVersionFromPackageJson(tree, 'vitest');
+  if (!installedVersion) {
+    return null;
+  }
+  if (installedVersion === 'latest' || installedVersion === 'next') {
+    return clean(vitestVersion) ?? coerce(vitestVersion)?.version ?? null;
+  }
+  return clean(installedVersion) ?? coerce(installedVersion)?.version ?? null;
+}
+
+export function getInstalledVitestMajorVersion(tree?: Tree): number | null {
+  const installedVitestVersion = getInstalledVitestVersion(tree);
+  return installedVitestVersion ? major(installedVitestVersion) : null;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3963,8 +3963,8 @@ importers:
         specifier: ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0
         version: 7.1.3(@types/node@24.12.2)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0)
       vitest:
-        specifier: ^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@24.12.2)(jiti@2.6.1)(jsdom@26.1.0)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0)
+        specifier: ^3.0.0 || ^4.0.0
+        version: 4.1.2(@types/node@24.12.2)(jsdom@26.1.0)(vite@7.1.3(@types/node@24.12.2)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))
     devDependencies:
       nx:
         specifier: workspace:*
@@ -12901,17 +12901,6 @@ packages:
   '@vitest/expect@4.1.2':
     resolution: {integrity: sha512-gbu+7B0YgUJ2nkdsRJrFFW6X7NTP44WlhiclHniUhxADQJH5Szt9mZ9hWnJPJ8YwOK5zUOSSlSvyzRf0u1DSBQ==}
 
-  '@vitest/mocker@3.2.4':
-    resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
-    peerDependencies:
-      msw: ^2.4.9
-      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
-    peerDependenciesMeta:
-      msw:
-        optional: true
-      vite:
-        optional: true
-
   '@vitest/mocker@4.1.2':
     resolution: {integrity: sha512-Ize4iQtEALHDttPRCmN+FKqOl2vxTiNUhzobQFFt/BM1lRUTG7zRCLOykG/6Vo4E4hnUdfVLo5/eqKPukcWW7Q==}
     peerDependencies:
@@ -12932,14 +12921,8 @@ packages:
   '@vitest/pretty-format@4.1.2':
     resolution: {integrity: sha512-dwQga8aejqeuB+TvXCMzSQemvV9hNEtDDpgUKDzOmNQayl2OG241PSWeJwKRH3CiC+sESrmoFd49rfnq7T4RnA==}
 
-  '@vitest/runner@3.2.4':
-    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
-
   '@vitest/runner@4.1.2':
     resolution: {integrity: sha512-Gr+FQan34CdiYAwpGJmQG8PgkyFVmARK8/xSijia3eTFgVfpcpztWLuP6FttGNfPLJhaZVP/euvujeNYar36OQ==}
-
-  '@vitest/snapshot@3.2.4':
-    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
 
   '@vitest/snapshot@4.1.2':
     resolution: {integrity: sha512-g7yfUmxYS4mNxk31qbOYsSt2F4m1E02LFqO53Xpzg3zKMhLAPZAjjfyl9e6z7HrW6LvUdTwAQR3HHfLjpko16A==}
@@ -16103,10 +16086,6 @@ packages:
   expand-tilde@2.0.2:
     resolution: {integrity: sha512-A5EmesHW6rfnZ9ysHQjPdJRni0SRar0tjtG5MNtm9n5TUvsYU8oozprtRD4AqHxcZWWlVuAmQo2nWKfN9oyjTw==}
     engines: {node: '>=0.10.0'}
-
-  expect-type@1.2.2:
-    resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
-    engines: {node: '>=12.0.0'}
 
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
@@ -22728,10 +22707,6 @@ packages:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
-  tinypool@1.1.1:
-    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-
   tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
     engines: {node: '>=14.0.0'}
@@ -23963,34 +23938,6 @@ packages:
       vite: ^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0
     peerDependenciesMeta:
       vite:
-        optional: true
-
-  vitest@3.2.4:
-    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
-    hasBin: true
-    peerDependencies:
-      '@edge-runtime/vm': '*'
-      '@types/debug': ^4.1.12
-      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      '@vitest/browser': 3.2.4
-      '@vitest/ui': 3.2.4
-      happy-dom: '*'
-      jsdom: '*'
-    peerDependenciesMeta:
-      '@edge-runtime/vm':
-        optional: true
-      '@types/debug':
-        optional: true
-      '@types/node':
-        optional: true
-      '@vitest/browser':
-        optional: true
-      '@vitest/ui':
-        optional: true
-      happy-dom:
-        optional: true
-      jsdom:
         optional: true
 
   vitest@4.1.2:
@@ -35316,13 +35263,13 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@3.2.4(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))':
+  '@vitest/mocker@4.1.2(vite@7.1.3(@types/node@24.12.2)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))':
     dependencies:
-      '@vitest/spy': 3.2.4
+      '@vitest/spy': 4.1.2
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 7.3.1(@types/node@24.12.2)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0)
+      vite: 7.1.3(@types/node@24.12.2)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0)
 
   '@vitest/mocker@4.1.2(vite@8.0.0(@types/node@24.12.2)(esbuild@0.25.0)(jiti@2.6.1)(less@4.5.1)(sass-embedded@1.97.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.20.5)(yaml@2.8.0))':
     dependencies:
@@ -35352,21 +35299,9 @@ snapshots:
     dependencies:
       tinyrainbow: 3.1.0
 
-  '@vitest/runner@3.2.4':
-    dependencies:
-      '@vitest/utils': 3.2.4
-      pathe: 2.0.3
-      strip-literal: 3.0.0
-
   '@vitest/runner@4.1.2':
     dependencies:
       '@vitest/utils': 4.1.2
-      pathe: 2.0.3
-
-  '@vitest/snapshot@3.2.4':
-    dependencies:
-      '@vitest/pretty-format': 3.2.4
-      magic-string: 0.30.21
       pathe: 2.0.3
 
   '@vitest/snapshot@4.1.2':
@@ -39394,8 +39329,6 @@ snapshots:
   expand-tilde@2.0.2:
     dependencies:
       homedir-polyfill: 1.0.3
-
-  expect-type@1.2.2: {}
 
   expect-type@1.3.0: {}
 
@@ -48504,8 +48437,6 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.4)
       picomatch: 4.0.4
 
-  tinypool@1.1.1: {}
-
   tinyrainbow@2.0.0: {}
 
   tinyrainbow@3.1.0: {}
@@ -49881,48 +49812,33 @@ snapshots:
     optionalDependencies:
       vite: 6.3.5(@types/node@24.12.2)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0)
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@24.12.2)(jiti@2.6.1)(jsdom@26.1.0)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0):
+  vitest@4.1.2(@types/node@24.12.2)(jsdom@26.1.0)(vite@7.1.3(@types/node@24.12.2)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0)):
     dependencies:
-      '@types/chai': 5.2.2
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.2.1
-      debug: 4.4.1(supports-color@8.1.1)
-      expect-type: 1.2.2
-      magic-string: 0.30.17
+      '@vitest/expect': 4.1.2
+      '@vitest/mocker': 4.1.2(vite@7.1.3(@types/node@24.12.2)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))
+      '@vitest/pretty-format': 4.1.2
+      '@vitest/runner': 4.1.2
+      '@vitest/snapshot': 4.1.2
+      '@vitest/spy': 4.1.2
+      '@vitest/utils': 4.1.2
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
       pathe: 2.0.3
       picomatch: 4.0.4
-      std-env: 3.9.0
+      std-env: 4.0.0
       tinybench: 2.9.0
-      tinyexec: 0.3.2
+      tinyexec: 1.0.4
       tinyglobby: 0.2.15
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
-      vite: 7.3.1(@types/node@24.12.2)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0)
-      vite-node: 3.2.4(@types/node@24.12.2)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0)
+      tinyrainbow: 3.1.0
+      vite: 7.1.3(@types/node@24.12.2)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/debug': 4.1.12
       '@types/node': 24.12.2
       jsdom: 26.1.0
     transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
 
   vitest@4.1.2(@types/node@24.12.2)(jsdom@26.1.0)(vite@8.0.0(@types/node@24.12.2)(esbuild@0.25.0)(jiti@2.6.1)(less@4.5.1)(sass-embedded@1.97.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.20.5)(yaml@2.8.0)):
     dependencies:


### PR DESCRIPTION
## Current Behavior

`@nx/vite` and `@nx/vitest` don't consistently honor their supported version windows. Cross-major `packageJsonUpdates` and version-specific migrations run on workspaces outside their target range, generators can overwrite pinned third-party versions, and unsupported versions silently fall through to the latest install constants instead of erroring.

## Expected Behavior

Both plugins enforce their support windows. Cross-major migrations declare source-major `requires` gates so they only run where they apply, generators throw a clear below-floor error and preserve pinned versions (`keepExistingVersions` defaults to `true`), and peer ranges and version maps match what each plugin actually supports.