### PR TITLE
fix(core): improve nx migrate multi-major flag handling and feedback

### DIFF
--- a/packages/nx/src/command-line/migrate/command-object.ts
+++ b/packages/nx/src/command-line/migrate/command-object.ts
@@ -86,7 +86,7 @@ function withMigrationOptions(yargs: Argv) {
     })
     .option('mode', {
       describe:
-        "Restrict which packages to migrate. Only applies when migrating Nx itself. 'first-party' processes only Nx and its plugins (the target package plus its nx.packageGroup); 'third-party' processes only the third-party dependencies referenced by Nx packageJsonUpdates entries, catching up on any updates that may have been skipped previously; 'all' processes everything. Defaults to 'all' (or prompts in an interactive terminal when targeting Nx).",
+        "Restrict which packages to migrate. Only applies when migrating Nx itself. 'first-party' processes only Nx and its plugins (the target package plus its nx.packageGroup); 'third-party' processes only the third-party dependencies referenced by Nx packageJsonUpdates entries, catching up on any updates that may have been skipped previously; 'all' processes everything. When targeting Nx in an interactive terminal, prompts for the value if not provided; otherwise defaults to 'all'.",
       type: 'string',
       choices: ['first-party', 'third-party', 'all'],
     })

--- a/packages/nx/src/command-line/migrate/migrate.spec.ts
+++ b/packages/nx/src/command-line/migrate/migrate.spec.ts
@@ -2442,6 +2442,19 @@ describe('Migration', () => {
       );
     });
 
+    it('should reject --mode=third-party with --to @nx/workspace higher than installed', async () => {
+      mockGetInstalledNxVersion.mockReturnValue('22.0.0');
+      await expect(() =>
+        parseMigrationsOptions({
+          packageAndVersion: 'nx@22.0.0',
+          mode: 'third-party',
+          to: '@nx/workspace@23.0.0',
+        })
+      ).rejects.toThrow(
+        `Error: '--mode=third-party' cannot migrate to a version higher than what is currently installed (got '--to @nx/workspace@23.0.0', installed 'nx@22.0.0').`
+      );
+    });
+
     it('should accept --mode=third-party with --to for non-canonical packages', async () => {
       mockGetInstalledNxVersion.mockReturnValue('22.0.0');
       const r = await parseMigrationsOptions({
@@ -2864,6 +2877,66 @@ describe('Migration', () => {
 
       expect(result).toEqual({ pkg: update });
     });
+
+    it('should keep narrowing rewrites when the specifier is a tilde range covering a lower version', () => {
+      // user has `vite: ~6.2.0`, resolved 6.2.5. Cascade proposes `6.2.5` (exact).
+      // Tilde floor is 6.2.0 < resolved 6.2.5 → narrowing → keep.
+      const update = {
+        version: '6.2.5',
+        addToPackageJson: 'devDependencies' as const,
+      };
+      const result = filterDowngradedUpdates(
+        { vite: update },
+        createPackageJson({ devDependencies: { vite: '~6.2.0' } }),
+        () => '6.2.5'
+      );
+
+      expect(result).toEqual({ vite: update });
+    });
+
+    it('should drop no-op rewrites when a tilde range is already pinned to resolved', () => {
+      // user has `vite: ~6.2.5`, resolved 6.2.5. Cascade proposes `6.2.5`.
+      // Tilde floor 6.2.5 === resolved 6.2.5 → no-op → drop.
+      const result = filterDowngradedUpdates(
+        {
+          vite: { version: '6.2.5', addToPackageJson: 'devDependencies' },
+        },
+        createPackageJson({ devDependencies: { vite: '~6.2.5' } }),
+        () => '6.2.5'
+      );
+
+      expect(result).toEqual({});
+    });
+
+    it('should drop downgrades inside a tilde range', () => {
+      // user has `vite: ~6.2.0`, resolved 6.2.7. Cascade proposes `6.2.3`.
+      // Tilde floor 6.2.0 covers 6.2.3, but resolved 6.2.7 > proposed → drop.
+      const result = filterDowngradedUpdates(
+        {
+          vite: { version: '6.2.3', addToPackageJson: 'devDependencies' },
+        },
+        createPackageJson({ devDependencies: { vite: '~6.2.0' } }),
+        () => '6.2.7'
+      );
+
+      expect(result).toEqual({});
+    });
+
+    it('should drop equal-version rewrites for peer-deps-only packages (no dep/devDep specifier)', () => {
+      // `peerDependencies` is intentionally not considered — only direct
+      // dependencies / devDependencies count as a specifier. A package present
+      // only as a peer dep behaves like an unspecified package: equal-version
+      // rewrites become orphan writes and are dropped.
+      const result = filterDowngradedUpdates(
+        {
+          'peer-only': { version: '5.0.0', addToPackageJson: 'dependencies' },
+        },
+        createPackageJson({ peerDependencies: { 'peer-only': '^5.0.0' } }),
+        () => '5.0.0'
+      );
+
+      expect(result).toEqual({});
+    });
   });
 
   describe('isNpmPeerDepsError', () => {
@@ -3164,16 +3237,13 @@ describe('Migration', () => {
       expect(r).toMatchObject({ targetVersion: '22.5.3' });
     });
 
-    it('should fall back silently to the requested target when --multi-major-mode=gradual has no stepwise option', async () => {
+    it('should warn and fall back to the requested target when --multi-major-mode=gradual has no incremental option', async () => {
       setTty(true);
       // Installed at latest of its major → current-major option dropped.
       // Next-major lookup fails → next-major option dropped. Both unavailable.
       mockGetInstalledNxVersion.mockReturnValue('21.5.3');
       mockRegistry({ latest: '23.1.0', '21': '21.5.3' });
       const warnSpy = spyWarn();
-      const logSpy = jest
-        .spyOn(require('../../utils/output').output, 'log')
-        .mockImplementation(() => {});
 
       const r = await parseMigrationsOptions({
         packageAndVersion: 'latest',
@@ -3182,8 +3252,13 @@ describe('Migration', () => {
       });
 
       expect(mockPrompt).not.toHaveBeenCalled();
-      expect(warnSpy).not.toHaveBeenCalled();
-      expect(logSpy).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: expect.stringContaining(
+            'Could not look up incremental migration options for --multi-major-mode=gradual'
+          ),
+        })
+      );
       expect(r).toMatchObject({ targetVersion: '23.1.0' });
     });
 
@@ -3223,6 +3298,30 @@ describe('Migration', () => {
       });
 
       expect(r).toMatchObject({ targetVersion: '23.1.0' });
+    });
+
+    it('should bypass --multi-major-mode=gradual when --mode=third-party', async () => {
+      setTty(true);
+      // third-party anchors at the installed canonical (here 21.0.0) and
+      // must not be redirected to an incremental target. `maybePromptOrWarn…`
+      // early-returns on `mode === 'third-party'` before consulting gradual,
+      // so the flag is accepted but is a no-op.
+      mockRegistry({
+        latest: '23.1.0',
+        '21': '21.5.3',
+        '22': '22.5.3',
+      });
+      const warnSpy = spyWarn();
+
+      const r = await parseMigrationsOptions({
+        packageAndVersion: 'nx@21.0.0',
+        mode: 'third-party',
+        multiMajorMode: 'gradual',
+      });
+
+      expect(mockPrompt).not.toHaveBeenCalled();
+      expect(warnSpy).not.toHaveBeenCalled();
+      expect(r).toMatchObject({ targetVersion: '21.0.0' });
     });
 
     it('should not prompt or warn when delta is exactly 1 major', async () => {

--- a/packages/nx/src/command-line/migrate/migrate.spec.ts
+++ b/packages/nx/src/command-line/migrate/migrate.spec.ts
@@ -3412,5 +3412,152 @@ describe('Migration', () => {
       expect(warnSpy).toHaveBeenCalled();
       expect(r).toMatchObject({ targetVersion: '23.1.0' });
     });
+
+    it('should set originalTargetVersion when gradual mode redirects to an incremental step', async () => {
+      setTty(true);
+      mockRegistry({
+        latest: '23.1.0',
+        '21': '21.5.3',
+        '22': '22.5.3',
+      });
+
+      const r = await parseMigrationsOptions({
+        packageAndVersion: 'latest',
+        mode: 'all',
+        multiMajorMode: 'gradual',
+      });
+
+      expect(r).toMatchObject({
+        targetVersion: '21.5.3',
+        originalTargetVersion: '23.1.0',
+      });
+    });
+
+    it('should set originalTargetVersion when the interactive prompt picks an incremental step', async () => {
+      setTty(true);
+      mockRegistry({
+        latest: '23.1.0',
+        '21': '21.5.3',
+        '22': '22.5.3',
+      });
+      mockPrompt.mockResolvedValue({ chosen: '22.5.3' });
+
+      const r = await parseMigrationsOptions({
+        packageAndVersion: 'latest',
+        mode: 'all',
+      });
+
+      expect(r).toMatchObject({
+        targetVersion: '22.5.3',
+        originalTargetVersion: '23.1.0',
+      });
+    });
+
+    it('should leave originalTargetVersion undefined when the interactive prompt picks the requested target', async () => {
+      setTty(true);
+      mockRegistry({
+        latest: '23.1.0',
+        '21': '21.5.3',
+        '22': '22.5.3',
+      });
+      mockPrompt.mockResolvedValue({ chosen: '23.1.0' });
+
+      const r = await parseMigrationsOptions({
+        packageAndVersion: 'latest',
+        mode: 'all',
+      });
+
+      expect(r).toMatchObject({ targetVersion: '23.1.0' });
+      expect(
+        (r as { originalTargetVersion?: string }).originalTargetVersion
+      ).toBeUndefined();
+    });
+
+    it('should leave originalTargetVersion undefined under --multi-major-mode=direct', async () => {
+      setTty(true);
+      mockRegistry({
+        latest: '23.1.0',
+        '21': '21.5.3',
+        '22': '22.5.3',
+      });
+
+      const r = await parseMigrationsOptions({
+        packageAndVersion: 'latest',
+        mode: 'all',
+        multiMajorMode: 'direct',
+      });
+
+      expect(r).toMatchObject({ targetVersion: '23.1.0' });
+      expect(
+        (r as { originalTargetVersion?: string }).originalTargetVersion
+      ).toBeUndefined();
+    });
+
+    it('should leave originalTargetVersion undefined for bare invocations within a single-major delta', async () => {
+      // Regression guard: dist-tag resolution alone (target == installed
+      // after resolving 'latest') must not be treated as a redirect, or
+      // Next Steps would suggest re-running toward the version the user
+      // already landed on.
+      setTty(true);
+      mockGetInstalledNxVersion.mockReturnValue('22.5.3');
+      mockRegistry({ latest: '22.5.3' });
+
+      const bare = await parseMigrationsOptions({ mode: 'all' });
+      expect(bare).toMatchObject({ targetVersion: '22.5.3' });
+      expect(
+        (bare as { originalTargetVersion?: string }).originalTargetVersion
+      ).toBeUndefined();
+
+      const barePkg = await parseMigrationsOptions({
+        packageAndVersion: 'nx',
+        mode: 'all',
+      });
+      expect(barePkg).toMatchObject({ targetVersion: '22.5.3' });
+      expect(
+        (barePkg as { originalTargetVersion?: string }).originalTargetVersion
+      ).toBeUndefined();
+    });
+
+    it('should propagate gradual to multiMajorMode when gradual mode redirects', async () => {
+      setTty(true);
+      mockRegistry({
+        latest: '23.1.0',
+        '21': '21.5.3',
+        '22': '22.5.3',
+      });
+
+      const r = await parseMigrationsOptions({
+        packageAndVersion: 'latest',
+        mode: 'all',
+        multiMajorMode: 'gradual',
+      });
+
+      expect(r).toMatchObject({
+        targetVersion: '21.5.3',
+        originalTargetVersion: '23.1.0',
+        multiMajorMode: 'gradual',
+      });
+    });
+
+    it('should NOT propagate gradual to multiMajorMode when the interactive prompt picks an incremental step', async () => {
+      setTty(true);
+      mockRegistry({
+        latest: '23.1.0',
+        '21': '21.5.3',
+        '22': '22.5.3',
+      });
+      mockPrompt.mockResolvedValue({ chosen: '22.5.3' });
+
+      const r = await parseMigrationsOptions({
+        packageAndVersion: 'latest',
+        mode: 'all',
+      });
+
+      expect(r).toMatchObject({
+        targetVersion: '22.5.3',
+        originalTargetVersion: '23.1.0',
+      });
+      expect((r as { multiMajorMode?: string }).multiMajorMode).toBeUndefined();
+    });
   });
 });

--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -96,6 +96,7 @@ import { filterDowngradedUpdates } from './update-filters';
 import {
   DIST_TAGS,
   type DistTag,
+  isLegacyEra,
   isNxEquivalentTarget,
   normalizeVersion,
   normalizeVersionWithTagCheck,
@@ -168,6 +169,8 @@ function normalizeSlashes(packageName: string): string {
   return packageName.replace(/\\/g, '/');
 }
 
+export type MigrateMode = 'first-party' | 'third-party' | 'all';
+
 export interface MigratorOptions {
   packageJson?: PackageJson;
   nxInstallation?: NxJsonConfiguration['installation'];
@@ -189,7 +192,7 @@ export interface MigratorOptions {
    * - 'third-party' keeps only packages NOT in `firstPartyPackages`
    * - 'all' / undefined keeps all packages (no filtering)
    */
-  mode?: 'first-party' | 'third-party' | 'all';
+  mode?: MigrateMode;
   /** First-party package names used by `mode` for filtering. */
   firstPartyPackages?: ReadonlySet<string>;
 }
@@ -501,7 +504,7 @@ export class Migrator {
     }
 
     const packageGroup: ArrayPackageGroup =
-      packageName === '@nrwl/workspace' && lt(targetVersion, '14.0.0-beta.0')
+      packageName === '@nrwl/workspace' && isLegacyEra(targetVersion)
         ? LEGACY_NRWL_PACKAGE_GROUP
         : (migrationConfig.packageGroup ?? []);
 
@@ -884,20 +887,18 @@ function resolveFirstPartyPackages(
 export function resolveCanonicalNxPackage(
   targetVersion: string
 ): 'nx' | '@nrwl/workspace' {
-  return valid(targetVersion) && lt(targetVersion, '14.0.0-beta.0')
-    ? '@nrwl/workspace'
-    : 'nx';
+  return isLegacyEra(targetVersion) ? '@nrwl/workspace' : 'nx';
 }
 
 export async function resolveMode(
-  mode: 'first-party' | 'third-party' | 'all' | undefined,
+  mode: MigrateMode | undefined,
   targetPackage: string,
   targetVersion: string,
   context: { hasFrom: boolean; hasExcludeAppliedMigrations: boolean } = {
     hasFrom: false,
     hasExcludeAppliedMigrations: false,
   }
-): Promise<'first-party' | 'third-party' | 'all'> {
+): Promise<MigrateMode> {
   if (mode) {
     return mode;
   }
@@ -924,7 +925,7 @@ export async function resolveMode(
     message: 'All (first-party and third-party)',
   });
   const { mode: selected } = await prompt<{
-    mode: 'first-party' | 'third-party' | 'all';
+    mode: MigrateMode;
   }>({
     type: 'select',
     name: 'mode',
@@ -999,10 +1000,9 @@ async function parseTargetPackageAndVersion(args: string): Promise<{
     // on the registry
     const targetVersion = await normalizeVersionWithTagCheck('nx', args);
     const isDistTag = DIST_TAGS.includes(args as DistTag);
-    const targetPackage =
-      !isDistTag && lt(targetVersion, '14.0.0-beta.0')
-        ? '@nrwl/workspace'
-        : 'nx';
+    const targetPackage = isDistTag
+      ? 'nx'
+      : resolveCanonicalNxPackage(targetVersion);
     return { targetPackage, targetVersion };
   }
 
@@ -1017,7 +1017,7 @@ type GenerateMigrations = {
   to: { [k: string]: string };
   interactive?: boolean;
   excludeAppliedMigrations?: boolean;
-  mode: 'first-party' | 'third-party' | 'all';
+  mode: MigrateMode;
 };
 
 type RunMigrations = {
@@ -1036,6 +1036,11 @@ export async function parseMigrationsOptions(options: {
   if (options.mode && options.runMigrations) {
     throw new Error(
       `Error: '--mode' cannot be combined with '--run-migrations'.`
+    );
+  }
+  if (options.multiMajorMode && options.runMigrations) {
+    throw new Error(
+      `Error: '--multi-major-mode' cannot be combined with '--run-migrations'.`
     );
   }
 
@@ -1120,13 +1125,13 @@ async function resolveTargetAndMode(args: {
   positional: string | undefined;
   from: Record<string, string>;
   options: {
-    mode?: 'first-party' | 'third-party' | 'all';
+    mode?: MigrateMode;
     excludeAppliedMigrations?: boolean;
   };
 }): Promise<{
   targetPackage: string;
   targetVersion: string;
-  mode: 'first-party' | 'third-party' | 'all';
+  mode: MigrateMode;
   installedNxVersion: string | null | undefined;
 }> {
   const { positional, from, options } = args;
@@ -1181,8 +1186,7 @@ async function resolveTargetAndMode(args: {
   }
 
   if (options.mode && !isNxEquivalentTarget(targetPackage!, targetVersion!)) {
-    const isLegacy =
-      valid(targetVersion!) && lt(targetVersion!, '14.0.0-beta.0');
+    const isLegacy = isLegacyEra(targetVersion!);
     const validTargets = isLegacy
       ? `'@nrwl/workspace'`
       : `'nx' or '@nx/workspace'`;
@@ -1261,10 +1265,10 @@ function resolveInstalledCanonical(): {
 } | null {
   const installedNx = getInstalledNxVersion();
   if (installedNx) {
-    if (lt(installedNx, '14.0.0-beta.0')) {
-      return { canonical: '@nrwl/workspace', version: installedNx };
-    }
-    return { canonical: 'nx', version: installedNx };
+    return {
+      canonical: resolveCanonicalNxPackage(installedNx),
+      version: installedNx,
+    };
   }
   const installedLegacy = getInstalledLegacyNrwlWorkspaceVersion();
   if (installedLegacy) {
@@ -1901,8 +1905,7 @@ async function generateMigrationsJsonAndUpdatePackageJson(
       // third-party filter must mirror that set or first-party `@nrwl/*`
       // plugins slip past it.
       const packageGroup =
-        sourcePackage === '@nrwl/workspace' &&
-        lt(opts.targetVersion, '14.0.0-beta.0')
+        sourcePackage === '@nrwl/workspace' && isLegacyEra(opts.targetVersion)
           ? LEGACY_NRWL_PACKAGE_GROUP
           : rootMetadata.packageGroup;
       firstPartyPackages = resolveFirstPartyPackages(

--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -91,7 +91,11 @@ import {
   getNxPackageGroup,
 } from '../../utils/provenance';
 import { type CatalogManager, getCatalogManager } from '../../utils/catalog';
-import { maybePromptOrWarnMultiMajorMigration } from './multi-major';
+import {
+  maybePromptOrWarnMultiMajorMigration,
+  MULTI_MAJOR_MODE_FLAG,
+  type MultiMajorMode,
+} from './multi-major';
 import { filterDowngradedUpdates } from './update-filters';
 import {
   DIST_TAGS,
@@ -1018,6 +1022,18 @@ type GenerateMigrations = {
   interactive?: boolean;
   excludeAppliedMigrations?: boolean;
   mode: MigrateMode;
+  /**
+   * Set when multi-major redirected `targetVersion` to an incremental step
+   * (gradual mode or the interactive prompt picking a smaller jump). Holds
+   * the concrete resolved target so Next Steps can suggest re-running toward
+   * it.
+   */
+  originalTargetVersion?: string;
+  /**
+   * The `--multi-major-mode` value to propagate to a continuation command,
+   * or undefined to omit it. See `MultiMajorResult.gradual` for when it's set.
+   */
+  multiMajorMode?: MultiMajorMode;
 };
 
 type RunMigrations = {
@@ -1071,12 +1087,13 @@ export async function parseMigrationsOptions(options: {
   // Spec §10: prompt or warn when crossing more than one major boundary.
   // Each major's metadata may have pruned migrations from much-older versions,
   // so jumping multiple majors at once can silently skip migrations.
-  targetVersion = await maybePromptOrWarnMultiMajorMigration({
+  const multiMajorResult = await maybePromptOrWarnMultiMajorMigration({
     mode,
     options,
     targetPackage,
     targetVersion,
   });
+  targetVersion = multiMajorResult.chosen;
 
   if (mode === 'third-party') {
     assertThirdPartyTargetBounds({
@@ -1096,6 +1113,8 @@ export async function parseMigrationsOptions(options: {
     interactive: options.interactive,
     excludeAppliedMigrations: options.excludeAppliedMigrations,
     mode,
+    originalTargetVersion: multiMajorResult.originalTarget,
+    multiMajorMode: multiMajorResult.gradual ? 'gradual' : undefined,
   };
 }
 
@@ -2035,6 +2054,15 @@ async function generateMigrationsJsonAndUpdatePackageJson(
           `- Make sure package.json changes make sense and then run '${pmc.install}',`,
           ...(migrations.length > 0
             ? [`- Run '${pmc.exec} nx migrate --run-migrations'`]
+            : []),
+          ...(opts.originalTargetVersion
+            ? [
+                `- After applying these migrations, run '${pmc.exec} nx migrate ${opts.targetPackage}@${opts.originalTargetVersion} --mode=${opts.mode}${
+                  opts.multiMajorMode === 'gradual'
+                    ? ` ${MULTI_MAJOR_MODE_FLAG}=gradual`
+                    : ''
+                }' to continue toward your original target.`,
+              ]
             : []),
           ...(opts.interactive && minVersionWithSkippedUpdates
             ? [

--- a/packages/nx/src/command-line/migrate/multi-major.ts
+++ b/packages/nx/src/command-line/migrate/multi-major.ts
@@ -1,18 +1,21 @@
 import { prompt } from 'enquirer';
-import { gt, lt, major, minor, valid } from 'semver';
+import { gt, major, minor, valid } from 'semver';
 import { isCI } from '../../utils/is-ci';
 import { getInstalledNxVersion } from '../../utils/installed-nx-version';
 import { output } from '../../utils/output';
 import { resolvePackageVersionUsingRegistry } from '../../utils/package-manager';
+import type { MigrateMode } from './migrate';
 import {
   DIST_TAGS,
   type DistTag,
+  isLegacyEra,
   isNxEquivalentTarget,
   normalizeVersionWithTagCheck,
 } from './version-utils';
 
-const STEPWISE_DOC_URL =
+const INCREMENTAL_UPDATE_GUIDE_URL =
   'https://nx.dev/docs/guides/tips-n-tricks/advanced-update#one-major-version-at-a-time-small-steps';
+const MULTI_MAJOR_MODE_FLAG = '--multi-major-mode';
 const MULTI_MAJOR_MODE_ENV = 'NX_MULTI_MAJOR_MODE';
 
 export type MultiMajorMode = 'direct' | 'gradual';
@@ -39,7 +42,7 @@ const multiMajorHeader = (pkg: string, installed: string, target: string) =>
 
 const multiMajorBodyLines = [
   `The recommended process is to update one major version at a time, in small steps.`,
-  `See ${STEPWISE_DOC_URL}`,
+  `See ${INCREMENTAL_UPDATE_GUIDE_URL}`,
 ];
 
 function warnMultiMajorMigration(
@@ -51,7 +54,7 @@ function warnMultiMajorMigration(
     title: multiMajorHeader(targetPackage, installed, target),
     bodyLines: [
       ...multiMajorBodyLines,
-      `Pass --multi-major-mode=direct (or =gradual) or set ${MULTI_MAJOR_MODE_ENV} to silence this warning.`,
+      `Pass ${MULTI_MAJOR_MODE_FLAG}=direct (or =gradual) or set ${MULTI_MAJOR_MODE_ENV} to silence this warning.`,
     ],
   });
 }
@@ -66,6 +69,17 @@ function logGradualStep(
     bodyLines: [
       `Re-run \`nx migrate\` after this completes to continue toward ${targetPackage}@${target}.`,
     ],
+  });
+}
+
+function warnGradualUnavailable(
+  targetPackage: string,
+  target: string,
+  reason: string
+): void {
+  output.warn({
+    title: `Could not look up incremental migration options for ${MULTI_MAJOR_MODE_FLAG}=gradual. Proceeding directly to ${targetPackage}@${target}.`,
+    bodyLines: [reason],
   });
 }
 
@@ -128,7 +142,7 @@ function resolveMultiMajorMode(options: {
 }
 
 export async function maybePromptOrWarnMultiMajorMigration(args: {
-  mode: 'first-party' | 'third-party' | 'all';
+  mode: MigrateMode;
   options: { multiMajorMode?: MultiMajorMode };
   targetPackage: string;
   targetVersion: string;
@@ -151,22 +165,29 @@ export async function maybePromptOrWarnMultiMajorMigration(args: {
         targetVersion
       );
     } catch {
+      if (multiMajorMode === 'gradual') {
+        warnGradualUnavailable(
+          targetPackage,
+          targetVersion,
+          `Failed to resolve the '${targetVersion}' dist-tag against the registry.`
+        );
+      }
       return targetVersion;
     }
   }
-  if (!valid(targetVersion) || lt(targetVersion, '14.0.0-beta.0')) {
+  if (!valid(targetVersion) || isLegacyEra(targetVersion)) {
     return targetVersion;
   }
   const installed = getInstalledNxVersion();
   if (!installed || !valid(installed)) return targetVersion;
   // Legacy-era installs are out of scope for the multi-major check.
-  if (lt(installed, '14.0.0-beta.0')) return targetVersion;
+  if (isLegacyEra(installed)) return targetVersion;
   const installedMajor = major(installed);
   if (major(targetVersion) - installedMajor < 2) return targetVersion;
 
   const interactive = !!process.stdin.isTTY && !isCI();
   // Non-TTY without gradual opt-in stays on the warn-only path; avoid the
-  // registry round-trip used to resolve stepwise options.
+  // registry round-trip used to look up incremental migration options.
   if (!interactive && multiMajorMode !== 'gradual') {
     warnMultiMajorMigration(targetPackage, installed, targetVersion);
     return targetVersion;
@@ -177,8 +198,7 @@ export async function maybePromptOrWarnMultiMajorMigration(args: {
     resolveLatestStableInMajor(targetPackage, installedMajor + 1),
   ]);
   // Only suggest the current-major latest when there's at least a minor
-  // delta — a same-minor patch bump isn't a meaningful "step" in stepwise
-  // migration framing.
+  // delta — a same-minor patch bump isn't a meaningful incremental step.
   const showCurrent =
     latestInCurrent &&
     gt(latestInCurrent, installed) &&
@@ -192,8 +212,17 @@ export async function maybePromptOrWarnMultiMajorMigration(args: {
       logGradualStep(targetPackage, step, targetVersion);
       return step;
     }
-    // No stepwise option resolved → the requested target is effectively the
-    // stepwise pick. Honour `gradual` silently.
+    // Registry returned no eligible incremental version (or the lookup
+    // failed); without a step to land on, gradual silently degrades to direct.
+    // Surface that explicitly so the safety rail the user opted into isn't
+    // invisibly disabled.
+    warnGradualUnavailable(
+      targetPackage,
+      targetVersion,
+      `Could not find an eligible version in major ${installedMajor} or ${
+        installedMajor + 1
+      } (registry lookup returned no result or failed).`
+    );
     return targetVersion;
   }
 

--- a/packages/nx/src/command-line/migrate/multi-major.ts
+++ b/packages/nx/src/command-line/migrate/multi-major.ts
@@ -15,7 +15,7 @@ import {
 
 const INCREMENTAL_UPDATE_GUIDE_URL =
   'https://nx.dev/docs/guides/tips-n-tricks/advanced-update#one-major-version-at-a-time-small-steps';
-const MULTI_MAJOR_MODE_FLAG = '--multi-major-mode';
+export const MULTI_MAJOR_MODE_FLAG = '--multi-major-mode';
 const MULTI_MAJOR_MODE_ENV = 'NX_MULTI_MAJOR_MODE';
 
 export type MultiMajorMode = 'direct' | 'gradual';
@@ -64,11 +64,12 @@ function logGradualStep(
   step: string,
   target: string
 ): void {
+  // Status-only announcement. The follow-up instruction ("re-run `nx migrate`
+  // to continue toward the original target") lives in the Next Steps block at
+  // the end of the run, where it's adjacent to the other re-run guidance and
+  // not scrolled out of view by the migration output.
   output.log({
     title: `Migrating to ${targetPackage}@${step} (one step toward ${targetPackage}@${target}).`,
-    bodyLines: [
-      `Re-run \`nx migrate\` after this completes to continue toward ${targetPackage}@${target}.`,
-    ],
   });
 }
 
@@ -141,18 +142,40 @@ function resolveMultiMajorMode(options: {
   return undefined;
 }
 
+/**
+ * Result of running the multi-major check.
+ *
+ * - `chosen`: the version to actually migrate to (always concrete semver when
+ *   the function ran past the dist-tag resolution; otherwise the input value).
+ * - `originalTarget`: set only when an actual redirect happened (gradual mode
+ *   auto-picked a smaller step, OR the interactive prompt returned a version
+ *   different from the resolved target). Holds the concrete resolved target
+ *   so callers can suggest re-running toward it.
+ * - `gradual`: set only when the redirect came from gradual mode (flag or
+ *   env). Tells callers it's safe to propagate `--multi-major-mode=gradual`
+ *   to a continuation command; left unset when the redirect came from the
+ *   interactive prompt so the user isn't silently locked into gradual.
+ */
+export type MultiMajorResult = {
+  chosen: string;
+  originalTarget?: string;
+  gradual?: boolean;
+};
+
 export async function maybePromptOrWarnMultiMajorMigration(args: {
   mode: MigrateMode;
   options: { multiMajorMode?: MultiMajorMode };
   targetPackage: string;
   targetVersion: string;
-}): Promise<string> {
+}): Promise<MultiMajorResult> {
   const { mode, options, targetPackage } = args;
   let { targetVersion } = args;
-  if (mode === 'third-party') return targetVersion;
+  if (mode === 'third-party') return { chosen: targetVersion };
   const multiMajorMode = resolveMultiMajorMode(options);
-  if (multiMajorMode === 'direct') return targetVersion;
-  if (!isNxEquivalentTarget(targetPackage, targetVersion)) return targetVersion;
+  if (multiMajorMode === 'direct') return { chosen: targetVersion };
+  if (!isNxEquivalentTarget(targetPackage, targetVersion)) {
+    return { chosen: targetVersion };
+  }
   // Bare-package-name positionals (e.g. `nx migrate nx`, `nx migrate
   // @nx/workspace`) leave `targetVersion` as the literal `'latest'` because
   // `parseTargetPackageAndVersion` only resolves dist-tags via the registry
@@ -172,25 +195,27 @@ export async function maybePromptOrWarnMultiMajorMigration(args: {
           `Failed to resolve the '${targetVersion}' dist-tag against the registry.`
         );
       }
-      return targetVersion;
+      return { chosen: targetVersion };
     }
   }
   if (!valid(targetVersion) || isLegacyEra(targetVersion)) {
-    return targetVersion;
+    return { chosen: targetVersion };
   }
   const installed = getInstalledNxVersion();
-  if (!installed || !valid(installed)) return targetVersion;
+  if (!installed || !valid(installed)) return { chosen: targetVersion };
   // Legacy-era installs are out of scope for the multi-major check.
-  if (isLegacyEra(installed)) return targetVersion;
+  if (isLegacyEra(installed)) return { chosen: targetVersion };
   const installedMajor = major(installed);
-  if (major(targetVersion) - installedMajor < 2) return targetVersion;
+  if (major(targetVersion) - installedMajor < 2) {
+    return { chosen: targetVersion };
+  }
 
   const interactive = !!process.stdin.isTTY && !isCI();
   // Non-TTY without gradual opt-in stays on the warn-only path; avoid the
   // registry round-trip used to look up incremental migration options.
   if (!interactive && multiMajorMode !== 'gradual') {
     warnMultiMajorMigration(targetPackage, installed, targetVersion);
-    return targetVersion;
+    return { chosen: targetVersion };
   }
 
   const [latestInCurrent, latestInNext] = await Promise.all([
@@ -210,7 +235,7 @@ export async function maybePromptOrWarnMultiMajorMigration(args: {
     const step = showCurrent ?? latestInNext;
     if (step) {
       logGradualStep(targetPackage, step, targetVersion);
-      return step;
+      return { chosen: step, originalTarget: targetVersion, gradual: true };
     }
     // Registry returned no eligible incremental version (or the lookup
     // failed); without a step to land on, gradual silently degrades to direct.
@@ -223,18 +248,21 @@ export async function maybePromptOrWarnMultiMajorMigration(args: {
         installedMajor + 1
       } (registry lookup returned no result or failed).`
     );
-    return targetVersion;
+    return { chosen: targetVersion };
   }
 
   if (interactive && (showCurrent || latestInNext)) {
-    return promptMultiMajorMigration({
+    const chosen = await promptMultiMajorMigration({
       targetPackage,
       installed,
       target: targetVersion,
       latestInCurrent: showCurrent,
       latestInNext,
     });
+    return chosen !== targetVersion
+      ? { chosen, originalTarget: targetVersion }
+      : { chosen };
   }
   warnMultiMajorMigration(targetPackage, installed, targetVersion);
-  return targetVersion;
+  return { chosen: targetVersion };
 }

--- a/packages/nx/src/command-line/migrate/version-utils.ts
+++ b/packages/nx/src/command-line/migrate/version-utils.ts
@@ -4,6 +4,15 @@ import { resolvePackageVersionUsingRegistry } from '../../utils/package-manager'
 export const DIST_TAGS = ['latest', 'next', 'canary'] as const;
 export type DistTag = (typeof DIST_TAGS)[number];
 
+const LEGACY_ERA_BOUNDARY = '14.0.0-beta.0';
+
+// Pre-14 (legacy) installs used `@nrwl/workspace` as the canonical Nx package.
+// Non-semver values (e.g. dist-tags or the literal `'latest'` sentinel before
+// tag resolution) are treated as modern era.
+export function isLegacyEra(targetVersion: string): boolean {
+  return valid(targetVersion) && lt(targetVersion, LEGACY_ERA_BOUNDARY);
+}
+
 export function normalizeVersion(version: string) {
   const [semver, ...prereleaseTagParts] = version.split('-');
   // Handle versions like 1.0.0-beta-next.2
@@ -55,9 +64,7 @@ export function isNxEquivalentTarget(
   targetPackage: string,
   targetVersion: string
 ): boolean {
-  // Non-semver values (e.g., the literal `'latest'` sentinel used during bare
-  // invocation before tag resolution, or in tests) are treated as modern era.
-  if (valid(targetVersion) && lt(targetVersion, '14.0.0-beta.0')) {
+  if (isLegacyEra(targetVersion)) {
     return targetPackage === '@nrwl/workspace';
   }
   return targetPackage === 'nx' || targetPackage === '@nx/workspace';

--- a/packages/nx/src/utils/installed-nx-version.ts
+++ b/packages/nx/src/utils/installed-nx-version.ts
@@ -2,7 +2,6 @@ import Module, { createRequire } from 'node:module';
 import { readJsonFile } from './fileutils';
 import {
   normalizePackageGroup,
-  readModulePackageJson,
   type PackageGroup,
   type PackageJson,
 } from './package-json';
@@ -72,11 +71,15 @@ export function getInstalledNxPackageGroup(): Set<string> {
  * or `null` if it cannot be resolved from the workspace require paths.
  */
 export function getInstalledLegacyNrwlWorkspaceVersion(): string | null {
+  const path = resolvePackageJsonWithoutCachePollution(
+    '@nrwl/workspace',
+    getNxRequirePaths(workspaceRoot)
+  );
+  if (!path) {
+    return null;
+  }
   try {
-    return (
-      readModulePackageJson('@nrwl/workspace', getNxRequirePaths(workspaceRoot))
-        .packageJson.version ?? null
-    );
+    return readJsonFile<PackageJson>(path).version ?? null;
   } catch {
     return null;
   }


### PR DESCRIPTION
## Current Behavior

Follow-ups to review feedback on the just-merged #35497:

- `--mode` help text reads as if defaults are unconditional — the interactive-prompt exception is buried in a parenthetical.
- `--multi-major-mode` combined with `--run-migrations` is silently ignored (`--mode` correctly throws).
- `--multi-major-mode=gradual` silently degrades to `direct` when the registry can't return an incremental version, hiding the disabled safety rail.
- `getInstalledLegacyNrwlWorkspaceVersion` bypasses the cache-pollution-safe resolver `getInstalledNxVersion` uses (regression risk from #35444).
- After a gradual or interactive incremental redirect, the re-run instruction is logged once at the top of the run and quickly scrolls out of view; the closing "Next steps:" block offers no guidance to continue toward the originally requested target.
- The `MigrateMode` union is re-typed inline in 8 places; the `< 14.0.0-beta.0` era check is duplicated across multiple call sites.
- Internal "stepwise" wording reads awkwardly for non-native English speakers.
- Test gaps: `--to @nx/workspace@higher`, `--mode=third-party` + `--multi-major-mode=gradual`, `filterDowngradedUpdates` with `~` ranges and peer-deps-only, the continuation contract for gradual/prompt redirects.

## Expected Behavior

- `--mode` describe leads with the interactive-prompt behavior; defaults follow.
- `--multi-major-mode` + `--run-migrations` throws symmetrically with `--mode`.
- `--multi-major-mode=gradual` surfaces a `warn` when no incremental option can be looked up before falling through to the requested target.
- `getInstalledLegacyNrwlWorkspaceVersion` routes through `resolvePackageJsonWithoutCachePollution`, consistent with `getInstalledNxVersion`.
- After a gradual or interactive incremental redirect, "Next steps:" prints a continuation command targeting the user's original target, preserving `--mode` (including `--mode=all`) and `--multi-major-mode=gradual` when they were the effective opt-ins.
- `MigrateMode` exported once; era checks route through a new `isLegacyEra` helper and the existing `resolveCanonicalNxPackage`.
- "Stepwise" replaced with "incremental" across copy, comments, and the doc-URL constant.
- New tests for each coverage gap above.

## Implementation Details

- `isLegacyEra(version)` lives in `version-utils.ts`. Four era-check sites in `migrate.ts` plus `isNxEquivalentTarget` and `resolveCanonicalNxPackage` all route through it. The remaining `14.0.0-beta.0` literal mentions are now docstring/inline comments only.
- `MULTI_MAJOR_MODE_FLAG` constant extracted to keep the flag spelling in one place; `STEPWISE_DOC_URL` → `INCREMENTAL_UPDATE_GUIDE_URL`.
- `warnGradualUnavailable` centralizes the warn message; two call sites (dist-tag resolution failure, no-step-resolved branch in gradual) pass distinct reason strings.
- `MigrateMode` exported from `migrate.ts`; `multi-major.ts` imports it as a `type`-only import (erased at emit; no runtime cycle).
- `maybePromptOrWarnMultiMajorMigration` returns `MultiMajorResult = { chosen: string; originalTarget?: string; gradual?: boolean }` so dist-tag resolution alone isn't mistaken for a redirect, and so callers can distinguish gradual-mode redirects (safe to propagate `--multi-major-mode=gradual`) from interactive-prompt picks (don't lock the user in).
- `GenerateMigrations` gains `originalTargetVersion?: string` and `multiMajorMode?: MultiMajorMode` to thread the continuation contract from `parseMigrationsOptions` to the Next Steps composer.
- `logGradualStep` is title-only; the re-run guidance lives in Next Steps where it's adjacent to the other re-run lines and won't scroll out of view.