### PR TITLE
docs(core): explain devkit dependency type and nx exclusion for plugins

### DIFF
--- a/astro-docs/src/content/docs/extending-nx/publish-plugin.mdoc
+++ b/astro-docs/src/content/docs/extending-nx/publish-plugin.mdoc
@@ -21,7 +21,8 @@ nx add nx-cfonts
 Nx provides a utility (`nx list`) that lists both core and community plugins. You can submit your plugin to be added to this list, but it needs to meet a few criteria first:
 
 - Run some kind of automated e2e tests in your repository
-- Include `@nx/devkit` as a `dependency` in the plugin's `package.json`
+- Include `@nx/devkit` as a `dependency` (not a `peerDependency`), so your plugin pins the version it was tested against. `@nx/devkit` itself declares a peer dependency on `nx` spanning its own major plus one before and one after — for example, depending on `@nx/devkit@23` means your plugin works on `nx@22`, `nx@23`, and the upcoming `nx@24`.
+- Do **not** list `nx` itself as a direct `dependency` or `peerDependency` — the user's workspace already provides it, and `@nx/devkit` handles the version range for you.
 - List a `repository.url` in the plugin's `package.json`
 
 ```jsonc


### PR DESCRIPTION
## Current Behavior

The community-plugin submission criteria in `extending-nx/publish-plugin.mdoc` state that `@nx/devkit` must be listed as a `dependency`, but give no rationale. The guide is also silent on whether to list the `nx` package itself — leading some submitters to add it as a `peerDependency`, which the first-party plugins never do.

## Expected Behavior

The publish-plugin guide:

- Explicitly notes that `@nx/devkit` should be a `dependency`, **not** a `peerDependency`.
- States that the `nx` package itself should **not** be listed as a dependency or peer dependency.
- Includes a short aside explaining why: `@nx/devkit` has no singleton state (unlike React/ESLint/Babel ecosystems where peer deps are the norm), and `nx` is always provided by the user's workspace.

This brings the documented criteria in line with what the first-party `@nx/*` plugins already do.

## Related Issue(s)

N/A — drive-by docs improvement noticed while reviewing a community-plugin submission.