### PR TITLE
fix(gradle): add transitive:true to all tasks

### DIFF
--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -287,7 +287,7 @@ private fun getInputsForTaskImpl(
 
     // Add consolidated dependentTasksOutputFiles entries using glob patterns by extension
     dependentTaskOutputExtensions.forEach { extension ->
-      inputs.add(mapOf("dependentTasksOutputFiles" to "**/*.$extension"))
+      inputs.add(mapOf("dependentTasksOutputFiles" to "**/*.$extension", "transitive" to true))
     }
 
     if (externalDependencies.isNotEmpty()) {

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
@@ -160,7 +160,12 @@ class ProcessTaskUtilsTest {
       assertNotNull(result)
 
       // Should contain consolidated dependentTasksOutputFiles glob pattern for jar extension
-      assertTrue(result!!.any { it is Map<*, *> && it["dependentTasksOutputFiles"] == "**/*.jar" })
+      assertTrue(
+          result!!.any {
+            it is Map<*, *> &&
+                it["dependentTasksOutputFiles"] == "**/*.jar" &&
+                it["transitive"] == true
+          })
 
       // Should contain the non-conflicting input file
       assertTrue(result.any { it == Path("{projectRoot}", "src", "main.kt").toString() })
@@ -187,8 +192,18 @@ class ProcessTaskUtilsTest {
       assertNotNull(result)
 
       // Should have consolidated glob patterns by extension
-      assertTrue(result!!.any { it is Map<*, *> && it["dependentTasksOutputFiles"] == "**/*.jar" })
-      assertTrue(result.any { it is Map<*, *> && it["dependentTasksOutputFiles"] == "**/*.class" })
+      assertTrue(
+          result!!.any {
+            it is Map<*, *> &&
+                it["dependentTasksOutputFiles"] == "**/*.jar" &&
+                it["transitive"] == true
+          })
+      assertTrue(
+          result.any {
+            it is Map<*, *> &&
+                it["dependentTasksOutputFiles"] == "**/*.class" &&
+                it["transitive"] == true
+          })
 
       // Should only have 2 dependentTasksOutputFiles entries (one per extension)
       val dependentTasksOutputFilesCount =
@@ -238,11 +253,15 @@ class ProcessTaskUtilsTest {
       // Should contain consolidated dependentTasksOutputFiles glob pattern
       assertTrue(
           resultWithPreComputed.any {
-            it is Map<*, *> && it["dependentTasksOutputFiles"] == "**/*.jar"
+            it is Map<*, *> &&
+                it["dependentTasksOutputFiles"] == "**/*.jar" &&
+                it["transitive"] == true
           })
       assertTrue(
           resultWithoutPreComputed.any {
-            it is Map<*, *> && it["dependentTasksOutputFiles"] == "**/*.jar"
+            it is Map<*, *> &&
+                it["dependentTasksOutputFiles"] == "**/*.jar" &&
+                it["transitive"] == true
           })
 
       // Should contain the input file
@@ -335,9 +354,24 @@ class ProcessTaskUtilsTest {
       assertNotNull(result)
 
       // Should have consolidated glob patterns by extension
-      assertTrue(result!!.any { it is Map<*, *> && it["dependentTasksOutputFiles"] == "**/*.jar" })
-      assertTrue(result.any { it is Map<*, *> && it["dependentTasksOutputFiles"] == "**/*.class" })
-      assertTrue(result.any { it is Map<*, *> && it["dependentTasksOutputFiles"] == "**/*.xml" })
+      assertTrue(
+          result!!.any {
+            it is Map<*, *> &&
+                it["dependentTasksOutputFiles"] == "**/*.jar" &&
+                it["transitive"] == true
+          })
+      assertTrue(
+          result.any {
+            it is Map<*, *> &&
+                it["dependentTasksOutputFiles"] == "**/*.class" &&
+                it["transitive"] == true
+          })
+      assertTrue(
+          result.any {
+            it is Map<*, *> &&
+                it["dependentTasksOutputFiles"] == "**/*.xml" &&
+                it["transitive"] == true
+          })
 
       // Should contain regular input files
       assertTrue(result.any { it == Path("{projectRoot}", "src", "main.kt").toString() })
@@ -398,10 +432,20 @@ class ProcessTaskUtilsTest {
       assertTrue(result.any { it == Path("{projectRoot}", "config", "app.properties").toString() })
 
       // Build file (class extension) should be consolidated into dependentTasksOutputFiles glob
-      assertTrue(result.any { it is Map<*, *> && it["dependentTasksOutputFiles"] == "**/*.class" })
+      assertTrue(
+          result.any {
+            it is Map<*, *> &&
+                it["dependentTasksOutputFiles"] == "**/*.class" &&
+                it["transitive"] == true
+          })
 
       // Log file should be consolidated into dependentTasksOutputFiles glob
-      assertTrue(result.any { it is Map<*, *> && it["dependentTasksOutputFiles"] == "**/*.log" })
+      assertTrue(
+          result.any {
+            it is Map<*, *> &&
+                it["dependentTasksOutputFiles"] == "**/*.log" &&
+                it["transitive"] == true
+          })
     }
 
     @Test
@@ -439,9 +483,19 @@ class ProcessTaskUtilsTest {
       assertTrue(result!!.any { it == Path("{projectRoot}", "src", "Main.java").toString() })
 
       // Both ignored files should be consolidated into glob patterns by extension
-      assertTrue(result.any { it is Map<*, *> && it["dependentTasksOutputFiles"] == "**/*.class" })
+      assertTrue(
+          result.any {
+            it is Map<*, *> &&
+                it["dependentTasksOutputFiles"] == "**/*.class" &&
+                it["transitive"] == true
+          })
 
-      assertTrue(result.any { it is Map<*, *> && it["dependentTasksOutputFiles"] == "**/*.jar" })
+      assertTrue(
+          result.any {
+            it is Map<*, *> &&
+                it["dependentTasksOutputFiles"] == "**/*.jar" &&
+                it["transitive"] == true
+          })
     }
   }
 
@@ -496,7 +550,12 @@ class ProcessTaskUtilsTest {
     val inputs = result["inputs"] as? List<*>
     assertNotNull(inputs)
     assertTrue(inputs!!.any { it == Path("{projectRoot}", "src", "test.kt").toString() })
-    assertTrue(inputs.any { it is Map<*, *> && it["dependentTasksOutputFiles"] == "**/*.class" })
+    assertTrue(
+        inputs.any {
+          it is Map<*, *> &&
+              it["dependentTasksOutputFiles"] == "**/*.class" &&
+              it["transitive"] == true
+        })
   }
 
   @Nested


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

Currently our input globs are set without transitive: true, this means during hashing the input only walks one hop by default — it looks at the direct dependents, not the chain.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Add `transitive: true` to all dependent task output files.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #NXC-4461
