### PR TITLE
chore(gradle): bump gradle project graph plugin version to 0.1.21

### DIFF
--- a/packages/gradle/migrations.json
+++ b/packages/gradle/migrations.json
@@ -131,6 +131,12 @@
       "cli": "nx",
       "description": "Change dev.nx.gradle.project-graph to version 0.1.20 in build file",
       "factory": "./src/migrations/22-7-0/change-plugin-version-0-1-20"
+    },
+    "change-plugin-version-0-1-21": {
+      "version": "23.0.0-beta.11",
+      "cli": "nx",
+      "description": "Change dev.nx.gradle.project-graph to version 0.1.21 in build file",
+      "factory": "./src/migrations/23-0-0/change-plugin-version-0-1-21"
     }
   },
   "packageJsonUpdates": {}

--- a/packages/gradle/project-graph/build.gradle.kts
+++ b/packages/gradle/project-graph/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 
 group = "dev.nx.gradle"
 
-version = "0.1.20"
+version = "0.1.21"
 
 repositories { mavenCentral() }
 

--- a/packages/gradle/src/migrations/23-0-0/change-plugin-version-0-1-21.md
+++ b/packages/gradle/src/migrations/23-0-0/change-plugin-version-0-1-21.md
@@ -1,0 +1,21 @@
+#### Change dev.nx.gradle.project-graph to version 0.1.21
+
+Change dev.nx.gradle.project-graph to version 0.1.21 in build file
+
+#### Sample Code Changes
+
+##### Before
+
+```text title="build.gradle"
+plugins {
+id "dev.nx.gradle.project-graph" version "0.1.20"
+}
+```
+
+##### After
+
+```text title="build.gradle"
+plugins {
+id "dev.nx.gradle.project-graph" version "0.1.21"
+}
+```

--- a/packages/gradle/src/migrations/23-0-0/change-plugin-version-0-1-21.ts
+++ b/packages/gradle/src/migrations/23-0-0/change-plugin-version-0-1-21.ts
@@ -1,0 +1,24 @@
+import { Tree, readNxJson } from '@nx/devkit';
+import { hasGradlePlugin } from '../../utils/has-gradle-plugin';
+import { addNxProjectGraphPlugin } from '../../generators/init/gradle-project-graph-plugin-utils';
+import { updateNxPluginVersionInCatalogsAst } from '../../utils/version-catalog-ast-utils';
+
+/* Change the plugin version to 0.1.21
+ */
+export default async function update(tree: Tree) {
+  const nxJson = readNxJson(tree);
+  if (!nxJson) {
+    return;
+  }
+  if (!hasGradlePlugin(tree)) {
+    return;
+  }
+
+  const gradlePluginVersionToUpdate = '0.1.21';
+
+  // Update version in version catalogs using AST-based approach to preserve formatting
+  await updateNxPluginVersionInCatalogsAst(tree, gradlePluginVersionToUpdate);
+
+  // Then update in build.gradle(.kts) files
+  await addNxProjectGraphPlugin(tree, gradlePluginVersionToUpdate);
+}

--- a/packages/gradle/src/utils/versions.ts
+++ b/packages/gradle/src/utils/versions.ts
@@ -1,4 +1,4 @@
 export const nxVersion = require('../../package.json').version;
 
 export const gradleProjectGraphPluginName = 'dev.nx.gradle.project-graph';
-export const gradleProjectGraphVersion = '0.1.20';
+export const gradleProjectGraphVersion = '0.1.21';


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
The Gradle project graph plugin is at version 0.1.20.

## Expected Behavior
The Gradle project graph plugin is bumped to version 0.1.21, with the corresponding migration files created
so that users upgrading Nx will automatically get the new plugin version.


## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
