### PR TITLE
docs(nx-cloud): simplify resource class specifications in credits pricing

### DIFF
--- a/astro-docs/src/content/docs/reference/Nx Cloud/credits-pricing.mdoc
+++ b/astro-docs/src/content/docs/reference/Nx Cloud/credits-pricing.mdoc
@@ -28,20 +28,20 @@ Credits represent the computational resources consumed during CI/CD operations. 
 
 #### Docker / Linux AMD64
 
-| Resource Class | Specifications    | Credits/min |
-| -------------- | ----------------- | ----------- |
-| Small          | 1 vCPU            | 5           |
-| Medium         | 2 vCPU            | 10          |
-| Large          | 4 vCPU            | 20          |
-| Extra large    | 8 vCPU            | 40          |
+| Resource Class | Specifications | Credits/min |
+| -------------- | -------------- | ----------- |
+| Small          | 1 vCPU         | 5           |
+| Medium         | 2 vCPU         | 10          |
+| Large          | 4 vCPU         | 20          |
+| Extra large    | 8 vCPU         | 40          |
 
 #### Docker / Linux ARM64
 
-| Resource Class | Specifications   | Credits/min |
-| -------------- | ---------------- | ----------- |
-| Medium         | 2 vCPU           | 13          |
-| Large          | 4 vCPU           | 26          |
-| Extra large    | 8 vCPU           | 52          |
+| Resource Class | Specifications | Credits/min |
+| -------------- | -------------- | ----------- |
+| Medium         | 2 vCPU         | 13          |
+| Large          | 4 vCPU         | 26          |
+| Extra large    | 8 vCPU         | 52          |
 
 _Note: Linux resource classes have memory available in an approximate 1:4 ratio per vCPU core._
 

--- a/astro-docs/src/content/docs/reference/Nx Cloud/credits-pricing.mdoc
+++ b/astro-docs/src/content/docs/reference/Nx Cloud/credits-pricing.mdoc
@@ -30,21 +30,20 @@ Credits represent the computational resources consumed during CI/CD operations. 
 
 | Resource Class | Specifications    | Credits/min |
 | -------------- | ----------------- | ----------- |
-| Small          | 1 vCPU, 2GB RAM   | 5           |
-| Medium         | 2 vCPU, 4GB RAM   | 10          |
-| Medium +       | 3 vCPU, 6GB RAM   | 15          |
-| Large          | 4 vCPU, 8GB RAM   | 20          |
-| Large +        | 4 vCPU, 10GB RAM  | 30          |
-| Extra large    | 8 vCPU, 16GB RAM  | 40          |
-| Extra large +  | 10 vCPU, 20GB RAM | 60          |
+| Small          | 1 vCPU            | 5           |
+| Medium         | 2 vCPU            | 10          |
+| Large          | 4 vCPU            | 20          |
+| Extra large    | 8 vCPU            | 40          |
 
 #### Docker / Linux ARM64
 
 | Resource Class | Specifications   | Credits/min |
 | -------------- | ---------------- | ----------- |
-| Medium         | 2 vCPU, 8GB RAM  | 13          |
-| Large          | 4 vCPU, 16GB RAM | 26          |
-| Extra large    | 8 vCPU, 32GB RAM | 52          |
+| Medium         | 2 vCPU           | 13          |
+| Large          | 4 vCPU           | 26          |
+| Extra large    | 8 vCPU           | 52          |
+
+_Note: Linux resource classes have memory available in an approximate 1:4 ratio per vCPU core._
 
 #### Docker / Windows
 


### PR DESCRIPTION
Updates the credits pricing reference to show only vCPU counts instead of full RAM specs. Removes the intermediate resource classes (Medium+, Large+, Extra large+) to simplify the table. Added a note explaining that memory is available in approximate 1:4 ratio per vCPU core.