### PR TITLE
fix(misc): stop inferring `projects: 'self'` in `dependsOn` entries

### DIFF
--- a/packages/cypress/src/plugins/plugin.spec.ts
+++ b/packages/cypress/src/plugins/plugin.spec.ts
@@ -368,7 +368,6 @@ describe('@nx/cypress/plugin', () => {
                       {
                         "options": "forward",
                         "params": "forward",
-                        "projects": "self",
                         "target": "e2e-ci--src/test.cy.ts",
                       },
                     ],
@@ -573,7 +572,6 @@ describe('@nx/cypress/plugin', () => {
                       {
                         "options": "forward",
                         "params": "forward",
-                        "projects": "self",
                         "target": "e2e-ci--src/test.cy.ts",
                       },
                     ],
@@ -780,7 +778,6 @@ describe('@nx/cypress/plugin', () => {
                       {
                         "options": "forward",
                         "params": "forward",
-                        "projects": "self",
                         "target": "e2e-ci--src/test.cy.ts",
                       },
                     ],
@@ -975,13 +972,11 @@ describe('@nx/cypress/plugin', () => {
                       {
                         "options": "forward",
                         "params": "forward",
-                        "projects": "self",
                         "target": "component-test-ci--src/test-2.cy.ts",
                       },
                       {
                         "options": "forward",
                         "params": "forward",
-                        "projects": "self",
                         "target": "component-test-ci--src/test.cy.ts",
                       },
                     ],
@@ -1207,7 +1202,6 @@ describe('@nx/cypress/plugin', () => {
                       {
                         "options": "forward",
                         "params": "forward",
-                        "projects": "self",
                         "target": "e2e-ci--src/test.cy.ts",
                       },
                     ],
@@ -1401,13 +1395,11 @@ describe('@nx/cypress/plugin', () => {
                       {
                         "options": "forward",
                         "params": "forward",
-                        "projects": "self",
                         "target": "component-test-ci--src/test-2.cy.ts",
                       },
                       {
                         "options": "forward",
                         "params": "forward",
-                        "projects": "self",
                         "target": "component-test-ci--src/test.cy.ts",
                       },
                     ],
@@ -1645,7 +1637,6 @@ describe('@nx/cypress/plugin', () => {
                       {
                         "options": "forward",
                         "params": "forward",
-                        "projects": "self",
                         "target": "e2e-ci--src/test.cy.ts",
                       },
                     ],

--- a/packages/cypress/src/plugins/plugin.ts
+++ b/packages/cypress/src/plugins/plugin.ts
@@ -465,7 +465,6 @@ async function buildCypressTargets(
         };
         dependsOn.push({
           target: targetName,
-          projects: 'self',
           params: 'forward',
           options: 'forward',
         });
@@ -615,7 +614,6 @@ async function buildCypressTargets(
         };
         dependsOn.push({
           target: targetName,
-          projects: 'self',
           params: 'forward',
           options: 'forward',
         });

--- a/packages/gradle/src/plugin-v1/nodes.spec.ts
+++ b/packages/gradle/src/plugin-v1/nodes.spec.ts
@@ -447,17 +447,14 @@ describe('@nx/gradle/plugin-v1/nodes', () => {
                       "dependsOn": [
                         {
                           "params": "forward",
-                          "projects": "self",
                           "target": "test-ci--aTest",
                         },
                         {
                           "params": "forward",
-                          "projects": "self",
                           "target": "test-ci--bTest",
                         },
                         {
                           "params": "forward",
-                          "projects": "self",
                           "target": "test-ci--cTests",
                         },
                       ],

--- a/packages/gradle/src/plugin-v1/nodes.ts
+++ b/packages/gradle/src/plugin-v1/nodes.ts
@@ -370,7 +370,6 @@ function getTestCiTargets(
     targetGroups[targetGroupName].push(targetName);
     dependsOn.push({
       target: targetName,
-      projects: 'self',
       params: 'forward',
     });
   });

--- a/packages/gradle/src/plugin/__snapshots__/nodes.spec.ts.snap
+++ b/packages/gradle/src/plugin/__snapshots__/nodes.spec.ts.snap
@@ -110,52 +110,42 @@ exports[`@nx/gradle/plugin/nodes should create nodes with atomized tests targets
               "dependsOn": [
                 {
                   "params": "forward",
-                  "projects": "self",
                   "target": "ci--DemoApplicationTest10",
                 },
                 {
                   "params": "forward",
-                  "projects": "self",
                   "target": "ci--DemoApplicationTest7",
                 },
                 {
                   "params": "forward",
-                  "projects": "self",
                   "target": "ci--DemoApplicationTest6",
                 },
                 {
                   "params": "forward",
-                  "projects": "self",
                   "target": "ci--DemoApplicationTest3",
                 },
                 {
                   "params": "forward",
-                  "projects": "self",
                   "target": "ci--DemoApplicationTest2",
                 },
                 {
                   "params": "forward",
-                  "projects": "self",
                   "target": "ci--DemoApplicationTest9",
                 },
                 {
                   "params": "forward",
-                  "projects": "self",
                   "target": "ci--DemoApplicationTest",
                 },
                 {
                   "params": "forward",
-                  "projects": "self",
                   "target": "ci--DemoApplicationTest5",
                 },
                 {
                   "params": "forward",
-                  "projects": "self",
                   "target": "ci--DemoApplicationTest4",
                 },
                 {
                   "params": "forward",
-                  "projects": "self",
                   "target": "ci--DemoApplicationTest8",
                 },
               ],
@@ -529,52 +519,42 @@ exports[`@nx/gradle/plugin/nodes should not create nodes with atomized tests tar
               "dependsOn": [
                 {
                   "params": "forward",
-                  "projects": "self",
                   "target": "ci--DemoApplicationTest10",
                 },
                 {
                   "params": "forward",
-                  "projects": "self",
                   "target": "ci--DemoApplicationTest7",
                 },
                 {
                   "params": "forward",
-                  "projects": "self",
                   "target": "ci--DemoApplicationTest6",
                 },
                 {
                   "params": "forward",
-                  "projects": "self",
                   "target": "ci--DemoApplicationTest3",
                 },
                 {
                   "params": "forward",
-                  "projects": "self",
                   "target": "ci--DemoApplicationTest2",
                 },
                 {
                   "params": "forward",
-                  "projects": "self",
                   "target": "ci--DemoApplicationTest9",
                 },
                 {
                   "params": "forward",
-                  "projects": "self",
                   "target": "ci--DemoApplicationTest",
                 },
                 {
                   "params": "forward",
-                  "projects": "self",
                   "target": "ci--DemoApplicationTest5",
                 },
                 {
                   "params": "forward",
-                  "projects": "self",
                   "target": "ci--DemoApplicationTest4",
                 },
                 {
                   "params": "forward",
-                  "projects": "self",
                   "target": "ci--DemoApplicationTest8",
                 },
               ],

--- a/packages/gradle/src/plugin/utils/__mocks__/gradle_nx_list.json
+++ b/packages/gradle/src/plugin/utils/__mocks__/gradle_nx_list.json
@@ -195,12 +195,10 @@
       "dependsOn": [
         {
           "target": "ci--LinkedListTest",
-          "projects": "self",
           "params": "forward"
         },
         {
           "target": "ci--LinkedList2Test",
-          "projects": "self",
           "params": "forward"
         }
       ],

--- a/packages/gradle/src/plugin/utils/__mocks__/gradle_tutorial.json
+++ b/packages/gradle/src/plugin/utils/__mocks__/gradle_tutorial.json
@@ -276,52 +276,42 @@
           "dependsOn": [
             {
               "target": "ci--DemoApplicationTest10",
-              "projects": "self",
               "params": "forward"
             },
             {
               "target": "ci--DemoApplicationTest7",
-              "projects": "self",
               "params": "forward"
             },
             {
               "target": "ci--DemoApplicationTest6",
-              "projects": "self",
               "params": "forward"
             },
             {
               "target": "ci--DemoApplicationTest3",
-              "projects": "self",
               "params": "forward"
             },
             {
               "target": "ci--DemoApplicationTest2",
-              "projects": "self",
               "params": "forward"
             },
             {
               "target": "ci--DemoApplicationTest9",
-              "projects": "self",
               "params": "forward"
             },
             {
               "target": "ci--DemoApplicationTest",
-              "projects": "self",
               "params": "forward"
             },
             {
               "target": "ci--DemoApplicationTest5",
-              "projects": "self",
               "params": "forward"
             },
             {
               "target": "ci--DemoApplicationTest4",
-              "projects": "self",
               "params": "forward"
             },
             {
               "target": "ci--DemoApplicationTest8",
-              "projects": "self",
               "params": "forward"
             }
           ],

--- a/packages/jest/src/plugins/plugin.spec.ts
+++ b/packages/jest/src/plugins/plugin.spec.ts
@@ -192,7 +192,6 @@ describe.each([true, false])('@nx/jest/plugin', (disableJestRuntime) => {
                       {
                         "options": "forward",
                         "params": "forward",
-                        "projects": "self",
                         "target": "test-ci--src/unit.spec.ts",
                       },
                     ],
@@ -500,7 +499,6 @@ describe.each([true, false])('@nx/jest/plugin', (disableJestRuntime) => {
                         {
                           "options": "forward",
                           "params": "forward",
-                          "projects": "self",
                           "target": "test-ci--src/unit.spec.ts",
                         },
                       ],
@@ -655,7 +653,6 @@ describe.each([true, false])('@nx/jest/plugin', (disableJestRuntime) => {
                         {
                           "options": "forward",
                           "params": "forward",
-                          "projects": "self",
                           "target": "test-ci--src/unit.spec.ts",
                         },
                       ],
@@ -810,7 +807,6 @@ describe.each([true, false])('@nx/jest/plugin', (disableJestRuntime) => {
                         {
                           "options": "forward",
                           "params": "forward",
-                          "projects": "self",
                           "target": "testci--src/unit.spec.ts",
                         },
                       ],

--- a/packages/jest/src/plugins/plugin.ts
+++ b/packages/jest/src/plugins/plugin.ts
@@ -415,7 +415,6 @@ async function buildJestTargets(
         const targetName = `${options.ciTargetName}--${relativePath}`;
         dependsOn.push({
           target: targetName,
-          projects: 'self',
           params: 'forward',
           options: 'forward',
         });
@@ -556,7 +555,6 @@ async function buildJestTargets(
           const targetName = `${options.ciTargetName}--${relativePath}`;
           dependsOn.push({
             target: targetName,
-            projects: 'self',
             params: 'forward',
             options: 'forward',
           });

--- a/packages/playwright/src/plugins/plugin.spec.ts
+++ b/packages/playwright/src/plugins/plugin.spec.ts
@@ -366,13 +366,11 @@ describe('@nx/playwright/plugin', () => {
           {
             "options": "forward",
             "params": "forward",
-            "projects": "self",
             "target": "e2e-ci--tests/run-me-2.spec.ts",
           },
           {
             "options": "forward",
             "params": "forward",
-            "projects": "self",
             "target": "e2e-ci--tests/run-me.spec.ts",
           },
         ],
@@ -547,13 +545,11 @@ describe('@nx/playwright/plugin', () => {
           {
             "options": "forward",
             "params": "forward",
-            "projects": "self",
             "target": "e2e-ci--tests/run-me-2.spec.ts",
           },
           {
             "options": "forward",
             "params": "forward",
-            "projects": "self",
             "target": "e2e-ci--tests/run-me.spec.ts",
           },
         ],
@@ -790,13 +786,11 @@ describe('@nx/playwright/plugin', () => {
           {
             "options": "forward",
             "params": "forward",
-            "projects": "self",
             "target": "e2e-ci--tests/run-me-2.spec.ts",
           },
           {
             "options": "forward",
             "params": "forward",
-            "projects": "self",
             "target": "e2e-ci--tests/run-me.spec.ts",
           },
         ],
@@ -1016,13 +1010,11 @@ describe('@nx/playwright/plugin', () => {
           {
             "options": "forward",
             "params": "forward",
-            "projects": "self",
             "target": "e2e-ci--tests/run-me-2.spec.ts",
           },
           {
             "options": "forward",
             "params": "forward",
-            "projects": "self",
             "target": "e2e-ci--tests/run-me.spec.ts",
           },
         ],

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -319,7 +319,6 @@ async function buildPlaywrightTargets(
 
       dependsOn.push({
         target: targetName,
-        projects: 'self',
         params: 'forward',
         options: 'forward',
       });


### PR DESCRIPTION
## Current Behavior

The `@nx/cypress`, `@nx/jest`, `@nx/playwright` and `@nx/gradle` plugins infer atomized CI `dependsOn` entries that include `projects: 'self'`. That value is the default for `projects` and is no longer supported as an explicit value.

## Expected Behavior

The plugins infer the same atomized CI `dependsOn` entries without setting `projects: 'self'`.