### PR TITLE
fix(core): warn instead of silently dropping legacy 'self'/'dependencies' dependsOn values

### DIFF
--- a/packages/nx/src/tasks-runner/legacy-depends-on-warning.spec.ts
+++ b/packages/nx/src/tasks-runner/legacy-depends-on-warning.spec.ts
@@ -6,6 +6,7 @@ jest.mock('../project-graph/nx-deps-cache', () => ({
 }));
 
 import {
+  __resetForTests,
   flushLegacyDependsOnViolations,
   LegacyDependsOnViolation,
   warnLegacyDependsOnMagicString,
@@ -14,23 +15,11 @@ import {
 const { output } = require('../utils/output');
 const { readSourceMapsCache } = require('../project-graph/nx-deps-cache');
 
-// The warned-keys set lives in module scope. We re-require to get a fresh
-// module between tests so dedupe state doesn't leak between assertions.
-function resetModule() {
-  jest.resetModules();
-  jest.doMock('../utils/output', () => ({ output: { warn: jest.fn() } }));
-  jest.doMock('../project-graph/nx-deps-cache', () => ({
-    readSourceMapsCache: jest.fn(),
-  }));
-  return {
-    warning: require('./legacy-depends-on-warning'),
-    output: require('../utils/output').output,
-    cache: require('../project-graph/nx-deps-cache'),
-  };
-}
+const selfEntry = (target: string) => ({ projects: 'self', target }) as const;
 
 describe('legacy-depends-on-warning', () => {
   beforeEach(() => {
+    __resetForTests();
     (output.warn as jest.Mock).mockReset();
     (readSourceMapsCache as jest.Mock).mockReset();
   });
@@ -42,8 +31,7 @@ describe('legacy-depends-on-warning', () => {
     });
 
     it('emits a single warning for hand-authored entries from a config file', () => {
-      const { warning, output: out, cache } = resetModule();
-      (cache.readSourceMapsCache as jest.Mock).mockReturnValue({
+      (readSourceMapsCache as jest.Mock).mockReturnValue({
         'libs/p': {
           'targets.build.dependsOn.0': [
             'libs/p/project.json',
@@ -52,20 +40,11 @@ describe('legacy-depends-on-warning', () => {
         },
       });
       const violations: LegacyDependsOnViolation[] = [
-        {
-          value: 'self',
-          index: 0,
-          originalEntry: { projects: 'self', target: 'compile' },
-        },
+        { index: 0, originalEntry: selfEntry('compile') },
       ];
-      warning.flushLegacyDependsOnViolations(
-        'p',
-        'build',
-        violations,
-        'libs/p'
-      );
-      expect(out.warn).toHaveBeenCalledTimes(1);
-      const arg = (out.warn as jest.Mock).mock.calls[0][0];
+      flushLegacyDependsOnViolations('p', 'build', violations, 'libs/p');
+      expect(output.warn).toHaveBeenCalledTimes(1);
+      const arg = (output.warn as jest.Mock).mock.calls[0][0];
       expect(arg.title).toContain('libs/p/project.json defines p:build');
       expect(arg.title).toContain("projects: 'self'");
       expect(arg.title).toContain("'nx repair'");
@@ -75,8 +54,7 @@ describe('legacy-depends-on-warning', () => {
     });
 
     it('emits one workspace-wide warning per external plugin (no body)', () => {
-      const { warning, output: out, cache } = resetModule();
-      (cache.readSourceMapsCache as jest.Mock).mockReturnValue({
+      (readSourceMapsCache as jest.Mock).mockReturnValue({
         'libs/a': {
           'targets.e2e.dependsOn.0': [
             'libs/a/jest.config.cts',
@@ -95,27 +73,20 @@ describe('legacy-depends-on-warning', () => {
         },
       });
       const make = (index: number): LegacyDependsOnViolation => ({
-        value: 'self',
         index,
-        originalEntry: { projects: 'self', target: `e2e--file${index}` },
+        originalEntry: selfEntry(`e2e--file${index}`),
       });
-      warning.flushLegacyDependsOnViolations(
-        'a',
-        'e2e',
-        [make(0), make(1)],
-        'libs/a'
-      );
-      warning.flushLegacyDependsOnViolations('b', 'e2e', [make(0)], 'libs/b');
-      expect(out.warn).toHaveBeenCalledTimes(1);
-      const arg = (out.warn as jest.Mock).mock.calls[0][0];
+      flushLegacyDependsOnViolations('a', 'e2e', [make(0), make(1)], 'libs/a');
+      flushLegacyDependsOnViolations('b', 'e2e', [make(0)], 'libs/b');
+      expect(output.warn).toHaveBeenCalledTimes(1);
+      const arg = (output.warn as jest.Mock).mock.calls[0][0];
       expect(arg.title).toContain('The @nx/jest/plugin plugin infers');
       expect(arg.title).toContain('please upgrade @nx/jest/plugin');
       expect(arg.bodyLines).toEqual([]);
     });
 
     it('falls back to mixed-source advice when sources differ', () => {
-      const { warning, output: out, cache } = resetModule();
-      (cache.readSourceMapsCache as jest.Mock).mockReturnValue({
+      (readSourceMapsCache as jest.Mock).mockReturnValue({
         'libs/p': {
           'targets.build.dependsOn.0': [
             'libs/p/project.json',
@@ -128,24 +99,11 @@ describe('legacy-depends-on-warning', () => {
         },
       });
       const violations: LegacyDependsOnViolation[] = [
-        {
-          value: 'self',
-          index: 0,
-          originalEntry: { projects: 'self', target: 'compile' },
-        },
-        {
-          value: 'self',
-          index: 1,
-          originalEntry: { projects: 'self', target: 'e2e--file' },
-        },
+        { index: 0, originalEntry: selfEntry('compile') },
+        { index: 1, originalEntry: selfEntry('e2e--file') },
       ];
-      warning.flushLegacyDependsOnViolations(
-        'p',
-        'build',
-        violations,
-        'libs/p'
-      );
-      const arg = (out.warn as jest.Mock).mock.calls[0][0];
+      flushLegacyDependsOnViolations('p', 'build', violations, 'libs/p');
+      const arg = (output.warn as jest.Mock).mock.calls[0][0];
       expect(arg.title).toContain('p:build has 2 dependsOn entries');
       expect(arg.title).toContain("run 'nx repair' for hand-authored");
       expect(arg.title).toContain('upgrade @nx/jest/plugin');
@@ -154,55 +112,31 @@ describe('legacy-depends-on-warning', () => {
     });
 
     it('reports a count breakdown when values are mixed', () => {
-      const { warning, output: out, cache } = resetModule();
-      (cache.readSourceMapsCache as jest.Mock).mockReturnValue({
+      (readSourceMapsCache as jest.Mock).mockReturnValue({
         'libs/p': {
-          'targets.build.dependsOn.0': [
-            'libs/p/project.json',
-            'nx/core/project-json',
-          ],
-          'targets.build.dependsOn.1': [
-            'libs/p/project.json',
-            'nx/core/project-json',
-          ],
-          'targets.build.dependsOn.2': [
+          'targets.build.dependsOn': [
             'libs/p/project.json',
             'nx/core/project-json',
           ],
         },
       });
       const violations: LegacyDependsOnViolation[] = [
+        { index: 0, originalEntry: selfEntry('a') },
+        { index: 1, originalEntry: selfEntry('b') },
         {
-          value: 'self',
-          index: 0,
-          originalEntry: { projects: 'self', target: 'a' },
-        },
-        {
-          value: 'self',
-          index: 1,
-          originalEntry: { projects: 'self', target: 'b' },
-        },
-        {
-          value: 'dependencies',
           index: 2,
           originalEntry: { projects: 'dependencies', target: 'c' },
         },
       ];
-      warning.flushLegacyDependsOnViolations(
-        'p',
-        'build',
-        violations,
-        'libs/p'
-      );
-      const arg = (out.warn as jest.Mock).mock.calls[0][0];
+      flushLegacyDependsOnViolations('p', 'build', violations, 'libs/p');
+      const arg = (output.warn as jest.Mock).mock.calls[0][0];
       expect(arg.title).toContain(
         "legacy projects values (2 'self', 1 'dependencies')"
       );
     });
 
     it('dedupes per (project, target) for hand-authored cases', () => {
-      const { warning, output: out, cache } = resetModule();
-      (cache.readSourceMapsCache as jest.Mock).mockReturnValue({
+      (readSourceMapsCache as jest.Mock).mockReturnValue({
         'libs/p': {
           'targets.build.dependsOn.0': [
             'libs/p/project.json',
@@ -211,55 +145,32 @@ describe('legacy-depends-on-warning', () => {
         },
       });
       const violations: LegacyDependsOnViolation[] = [
-        {
-          value: 'self',
-          index: 0,
-          originalEntry: { projects: 'self', target: 'a' },
-        },
+        { index: 0, originalEntry: selfEntry('a') },
       ];
-      warning.flushLegacyDependsOnViolations(
-        'p',
-        'build',
-        violations,
-        'libs/p'
-      );
-      warning.flushLegacyDependsOnViolations(
-        'p',
-        'build',
-        violations,
-        'libs/p'
-      );
-      expect(out.warn).toHaveBeenCalledTimes(1);
+      flushLegacyDependsOnViolations('p', 'build', violations, 'libs/p');
+      flushLegacyDependsOnViolations('p', 'build', violations, 'libs/p');
+      expect(output.warn).toHaveBeenCalledTimes(1);
     });
   });
 
   describe('warnLegacyDependsOnMagicString', () => {
     it('appends to a collector when provided', () => {
       const collector: LegacyDependsOnViolation[] = [];
-      warnLegacyDependsOnMagicString(
-        'self',
-        'p',
-        { projects: 'self', target: 't' },
-        { ownerTarget: 'build', index: 2, legacyViolations: collector }
-      );
-      expect(collector).toHaveLength(1);
-      expect(collector[0]).toEqual({
-        value: 'self',
+      warnLegacyDependsOnMagicString('p', selfEntry('t'), {
+        ownerTarget: 'build',
         index: 2,
-        originalEntry: { projects: 'self', target: 't' },
+        legacyViolations: collector,
       });
+      expect(collector).toEqual([{ index: 2, originalEntry: selfEntry('t') }]);
       expect(output.warn).not.toHaveBeenCalled();
     });
 
     it('emits immediately when no collector is provided', () => {
-      const { warning, output: out } = resetModule();
-      warning.warnLegacyDependsOnMagicString(
-        'self',
-        'p',
-        { projects: 'self', target: 't' },
-        { ownerTarget: 'build', index: 0 }
-      );
-      expect(out.warn).toHaveBeenCalledTimes(1);
+      warnLegacyDependsOnMagicString('p', selfEntry('t'), {
+        ownerTarget: 'build',
+        index: 0,
+      });
+      expect(output.warn).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/nx/src/tasks-runner/legacy-depends-on-warning.spec.ts
+++ b/packages/nx/src/tasks-runner/legacy-depends-on-warning.spec.ts
@@ -1,0 +1,265 @@
+jest.mock('../utils/output', () => ({
+  output: { warn: jest.fn() },
+}));
+jest.mock('../project-graph/nx-deps-cache', () => ({
+  readSourceMapsCache: jest.fn(),
+}));
+
+import {
+  flushLegacyDependsOnViolations,
+  LegacyDependsOnViolation,
+  warnLegacyDependsOnMagicString,
+} from './legacy-depends-on-warning';
+
+const { output } = require('../utils/output');
+const { readSourceMapsCache } = require('../project-graph/nx-deps-cache');
+
+// The warned-keys set lives in module scope. We re-require to get a fresh
+// module between tests so dedupe state doesn't leak between assertions.
+function resetModule() {
+  jest.resetModules();
+  jest.doMock('../utils/output', () => ({ output: { warn: jest.fn() } }));
+  jest.doMock('../project-graph/nx-deps-cache', () => ({
+    readSourceMapsCache: jest.fn(),
+  }));
+  return {
+    warning: require('./legacy-depends-on-warning'),
+    output: require('../utils/output').output,
+    cache: require('../project-graph/nx-deps-cache'),
+  };
+}
+
+describe('legacy-depends-on-warning', () => {
+  beforeEach(() => {
+    (output.warn as jest.Mock).mockReset();
+    (readSourceMapsCache as jest.Mock).mockReset();
+  });
+
+  describe('flushLegacyDependsOnViolations', () => {
+    it('emits nothing when there are no violations', () => {
+      flushLegacyDependsOnViolations('p', 't', [], undefined);
+      expect(output.warn).not.toHaveBeenCalled();
+    });
+
+    it('emits a single warning for hand-authored entries from a config file', () => {
+      const { warning, output: out, cache } = resetModule();
+      (cache.readSourceMapsCache as jest.Mock).mockReturnValue({
+        'libs/p': {
+          'targets.build.dependsOn.0': [
+            'libs/p/project.json',
+            'nx/core/project-json',
+          ],
+        },
+      });
+      const violations: LegacyDependsOnViolation[] = [
+        {
+          value: 'self',
+          index: 0,
+          originalEntry: { projects: 'self', target: 'compile' },
+        },
+      ];
+      warning.flushLegacyDependsOnViolations(
+        'p',
+        'build',
+        violations,
+        'libs/p'
+      );
+      expect(out.warn).toHaveBeenCalledTimes(1);
+      const arg = (out.warn as jest.Mock).mock.calls[0][0];
+      expect(arg.title).toContain('libs/p/project.json defines p:build');
+      expect(arg.title).toContain("projects: 'self'");
+      expect(arg.title).toContain("'nx repair'");
+      expect(arg.bodyLines).toEqual([
+        `  - {"projects":"self","target":"compile"} (0)`,
+      ]);
+    });
+
+    it('emits one workspace-wide warning per external plugin (no body)', () => {
+      const { warning, output: out, cache } = resetModule();
+      (cache.readSourceMapsCache as jest.Mock).mockReturnValue({
+        'libs/a': {
+          'targets.e2e.dependsOn.0': [
+            'libs/a/jest.config.cts',
+            '@nx/jest/plugin',
+          ],
+          'targets.e2e.dependsOn.1': [
+            'libs/a/jest.config.cts',
+            '@nx/jest/plugin',
+          ],
+        },
+        'libs/b': {
+          'targets.e2e.dependsOn.0': [
+            'libs/b/jest.config.cts',
+            '@nx/jest/plugin',
+          ],
+        },
+      });
+      const make = (index: number): LegacyDependsOnViolation => ({
+        value: 'self',
+        index,
+        originalEntry: { projects: 'self', target: `e2e--file${index}` },
+      });
+      warning.flushLegacyDependsOnViolations(
+        'a',
+        'e2e',
+        [make(0), make(1)],
+        'libs/a'
+      );
+      warning.flushLegacyDependsOnViolations('b', 'e2e', [make(0)], 'libs/b');
+      expect(out.warn).toHaveBeenCalledTimes(1);
+      const arg = (out.warn as jest.Mock).mock.calls[0][0];
+      expect(arg.title).toContain('The @nx/jest/plugin plugin infers');
+      expect(arg.title).toContain('please upgrade @nx/jest/plugin');
+      expect(arg.bodyLines).toEqual([]);
+    });
+
+    it('falls back to mixed-source advice when sources differ', () => {
+      const { warning, output: out, cache } = resetModule();
+      (cache.readSourceMapsCache as jest.Mock).mockReturnValue({
+        'libs/p': {
+          'targets.build.dependsOn.0': [
+            'libs/p/project.json',
+            'nx/core/project-json',
+          ],
+          'targets.build.dependsOn.1': [
+            'libs/p/jest.config.cts',
+            '@nx/jest/plugin',
+          ],
+        },
+      });
+      const violations: LegacyDependsOnViolation[] = [
+        {
+          value: 'self',
+          index: 0,
+          originalEntry: { projects: 'self', target: 'compile' },
+        },
+        {
+          value: 'self',
+          index: 1,
+          originalEntry: { projects: 'self', target: 'e2e--file' },
+        },
+      ];
+      warning.flushLegacyDependsOnViolations(
+        'p',
+        'build',
+        violations,
+        'libs/p'
+      );
+      const arg = (out.warn as jest.Mock).mock.calls[0][0];
+      expect(arg.title).toContain('p:build has 2 dependsOn entries');
+      expect(arg.title).toContain("run 'nx repair' for hand-authored");
+      expect(arg.title).toContain('upgrade @nx/jest/plugin');
+      expect(arg.bodyLines).toHaveLength(2);
+      expect(arg.bodyLines[1]).toContain('from @nx/jest/plugin');
+    });
+
+    it('reports a count breakdown when values are mixed', () => {
+      const { warning, output: out, cache } = resetModule();
+      (cache.readSourceMapsCache as jest.Mock).mockReturnValue({
+        'libs/p': {
+          'targets.build.dependsOn.0': [
+            'libs/p/project.json',
+            'nx/core/project-json',
+          ],
+          'targets.build.dependsOn.1': [
+            'libs/p/project.json',
+            'nx/core/project-json',
+          ],
+          'targets.build.dependsOn.2': [
+            'libs/p/project.json',
+            'nx/core/project-json',
+          ],
+        },
+      });
+      const violations: LegacyDependsOnViolation[] = [
+        {
+          value: 'self',
+          index: 0,
+          originalEntry: { projects: 'self', target: 'a' },
+        },
+        {
+          value: 'self',
+          index: 1,
+          originalEntry: { projects: 'self', target: 'b' },
+        },
+        {
+          value: 'dependencies',
+          index: 2,
+          originalEntry: { projects: 'dependencies', target: 'c' },
+        },
+      ];
+      warning.flushLegacyDependsOnViolations(
+        'p',
+        'build',
+        violations,
+        'libs/p'
+      );
+      const arg = (out.warn as jest.Mock).mock.calls[0][0];
+      expect(arg.title).toContain(
+        "legacy projects values (2 'self', 1 'dependencies')"
+      );
+    });
+
+    it('dedupes per (project, target) for hand-authored cases', () => {
+      const { warning, output: out, cache } = resetModule();
+      (cache.readSourceMapsCache as jest.Mock).mockReturnValue({
+        'libs/p': {
+          'targets.build.dependsOn.0': [
+            'libs/p/project.json',
+            'nx/core/project-json',
+          ],
+        },
+      });
+      const violations: LegacyDependsOnViolation[] = [
+        {
+          value: 'self',
+          index: 0,
+          originalEntry: { projects: 'self', target: 'a' },
+        },
+      ];
+      warning.flushLegacyDependsOnViolations(
+        'p',
+        'build',
+        violations,
+        'libs/p'
+      );
+      warning.flushLegacyDependsOnViolations(
+        'p',
+        'build',
+        violations,
+        'libs/p'
+      );
+      expect(out.warn).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('warnLegacyDependsOnMagicString', () => {
+    it('appends to a collector when provided', () => {
+      const collector: LegacyDependsOnViolation[] = [];
+      warnLegacyDependsOnMagicString(
+        'self',
+        'p',
+        { projects: 'self', target: 't' },
+        { ownerTarget: 'build', index: 2, legacyViolations: collector }
+      );
+      expect(collector).toHaveLength(1);
+      expect(collector[0]).toEqual({
+        value: 'self',
+        index: 2,
+        originalEntry: { projects: 'self', target: 't' },
+      });
+      expect(output.warn).not.toHaveBeenCalled();
+    });
+
+    it('emits immediately when no collector is provided', () => {
+      const { warning, output: out } = resetModule();
+      warning.warnLegacyDependsOnMagicString(
+        'self',
+        'p',
+        { projects: 'self', target: 't' },
+        { ownerTarget: 'build', index: 0 }
+      );
+      expect(out.warn).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/nx/src/tasks-runner/legacy-depends-on-warning.ts
+++ b/packages/nx/src/tasks-runner/legacy-depends-on-warning.ts
@@ -1,0 +1,205 @@
+// TODO(v24): Remove this file along with the `'self'` / `'dependencies'`
+// magic-string branch in `normalizeTargetDependencyWithStringProjects`. The
+// v16 `update-depends-on-to-tokens` migration already rewrites these to the
+// modern shape, and `nx repair` will re-run it on demand.
+import { TargetDependencyConfig } from '../config/workspace-json-project-json';
+import { output } from '../utils/output';
+
+export interface LegacyDependsOnViolation {
+  value: 'self' | 'dependencies';
+  index: number;
+  // Snapshot of the entry as authored, before normalization rewrites
+  // `projects` / `dependencies`. Used to display the user-facing form.
+  originalEntry: TargetDependencyConfig;
+}
+
+export interface LegacyDependsOnLocation {
+  ownerTarget?: string;
+  index?: number;
+  legacyViolations?: LegacyDependsOnViolation[];
+}
+
+export function warnLegacyDependsOnMagicString(
+  value: 'self' | 'dependencies',
+  currentProject: string | undefined,
+  dependencyConfig: TargetDependencyConfig,
+  location: LegacyDependsOnLocation | undefined
+): void {
+  const violation: LegacyDependsOnViolation = {
+    value,
+    index: location?.index ?? -1,
+    originalEntry: { ...dependencyConfig },
+  };
+  // Collector-aware caller (`getDependencyConfigs`) batches violations so the
+  // warning can group all offending entries for a single target. External
+  // callers without a collector fall through to an immediate per-entry warning.
+  if (location?.legacyViolations) {
+    location.legacyViolations.push(violation);
+    return;
+  }
+  flushLegacyDependsOnViolations(
+    currentProject ?? '<unknown>',
+    location?.ownerTarget ?? '<unknown>',
+    [violation],
+    undefined
+  );
+}
+
+export function flushLegacyDependsOnViolations(
+  project: string,
+  ownerTarget: string,
+  violations: LegacyDependsOnViolation[],
+  projectRoot: string | undefined
+): void {
+  if (violations.length === 0) return;
+  const annotated = annotateLegacyViolations(
+    ownerTarget,
+    projectRoot,
+    violations
+  );
+  const sharedPlugin = sharedField(annotated, 'plugin');
+  // External-plugin warnings are workspace-wide (the plugin's behavior, not a
+  // specific config): dedupe per (plugin, value) so the user sees one warning
+  // per offending plugin, not one per affected target.
+  const sharedValue = sharedField(annotated, 'value');
+  const dedupeKey =
+    sharedPlugin && !isInternalPlugin(sharedPlugin) && sharedValue
+      ? `plugin::${sharedPlugin}::${sharedValue}`
+      : `target::${project}::${ownerTarget}`;
+  if (warnedLegacyDependsOnMagicStrings.has(dedupeKey)) return;
+  warnedLegacyDependsOnMagicStrings.add(dedupeKey);
+
+  const { title, suppressBody } = buildLegacyDependsOnWarning(
+    project,
+    ownerTarget,
+    annotated
+  );
+  const bodyLines = suppressBody
+    ? []
+    : annotated.map((v) => formatLegacyDependsOnBodyLine(v, sharedPlugin));
+
+  output.warn({ title, bodyLines });
+}
+
+const warnedLegacyDependsOnMagicStrings = new Set<string>();
+
+let cachedSourceMaps:
+  | import('../project-graph/utils/project-configuration/source-maps').ConfigurationSourceMaps
+  | null
+  | undefined = undefined;
+function getSourceMapsLazy() {
+  if (cachedSourceMaps !== undefined) return cachedSourceMaps;
+  try {
+    const { readSourceMapsCache } = require('../project-graph/nx-deps-cache');
+    cachedSourceMaps = readSourceMapsCache();
+  } catch {
+    cachedSourceMaps = null;
+  }
+  return cachedSourceMaps;
+}
+
+interface AnnotatedLegacyDependsOnViolation extends LegacyDependsOnViolation {
+  plugin?: string;
+  file?: string;
+}
+
+function isInternalPlugin(plugin: string | undefined): boolean {
+  return !plugin || plugin.startsWith('nx/');
+}
+
+function annotateLegacyViolations(
+  ownerTarget: string,
+  projectRoot: string | undefined,
+  violations: LegacyDependsOnViolation[]
+): AnnotatedLegacyDependsOnViolation[] {
+  const sourceMaps = getSourceMapsLazy();
+  const projectSourceMap =
+    projectRoot && sourceMaps ? sourceMaps[projectRoot] : undefined;
+  return violations.map((v) => {
+    const sourceInfo =
+      projectSourceMap?.[`targets.${ownerTarget}.dependsOn.${v.index}`] ??
+      projectSourceMap?.[`targets.${ownerTarget}.dependsOn`];
+    return {
+      ...v,
+      plugin: sourceInfo?.[1],
+      file: sourceInfo?.[0] ?? undefined,
+    };
+  });
+}
+
+// Returns the value shared by every annotated violation, or `null` if values
+// differ. Used to collapse repeated information into the title.
+function sharedField<T, K extends keyof T>(items: T[], key: K): T[K] | null {
+  const first = items[0][key];
+  return items.every((item) => item[key] === first) ? first : null;
+}
+
+function describeLegacyValuePhrase(
+  annotated: AnnotatedLegacyDependsOnViolation[]
+): string {
+  const sharedValue = sharedField(annotated, 'value');
+  if (sharedValue) return `projects: '${sharedValue}'`;
+  const selfCount = annotated.filter((v) => v.value === 'self').length;
+  const depCount = annotated.length - selfCount;
+  return `legacy projects values (${selfCount} 'self', ${depCount} 'dependencies')`;
+}
+
+function buildLegacyDependsOnWarning(
+  project: string,
+  ownerTarget: string,
+  annotated: AnnotatedLegacyDependsOnViolation[]
+): { title: string; suppressBody: boolean } {
+  const sharedPlugin = sharedField(annotated, 'plugin');
+  const sharedFile = sharedField(annotated, 'file');
+  const valuePhrase = describeLegacyValuePhrase(annotated);
+  const entryWord = annotated.length === 1 ? 'entry' : 'entries';
+  const deprecation = 'This is deprecated and will be removed in Nx v24 —';
+
+  // Single external plugin: the same plugin typically emits the same legacy
+  // value on every project it touches, so a single workspace-wide warning is
+  // more useful than one per target.
+  if (sharedPlugin && !isInternalPlugin(sharedPlugin)) {
+    return {
+      title: `The ${sharedPlugin} plugin infers dependsOn entries using ${valuePhrase}. ${deprecation} please upgrade ${sharedPlugin} to a version that doesn't emit this.`,
+      suppressBody: true,
+    };
+  }
+
+  // Single hand-authored config file — lead with the file path.
+  if (sharedPlugin && isInternalPlugin(sharedPlugin) && sharedFile) {
+    return {
+      title: `${sharedFile} defines ${project}:${ownerTarget} with ${annotated.length} dependsOn ${entryWord} using ${valuePhrase}. ${deprecation} run 'nx repair' to fix this.`,
+      suppressBody: false,
+    };
+  }
+
+  // Mixed sources, or no source-map info — tailor advice to what's offending.
+  const offendingPlugins = Array.from(
+    new Set(
+      annotated
+        .filter((v) => v.plugin && !isInternalPlugin(v.plugin))
+        .map((v) => v.plugin as string)
+    )
+  );
+  const origin = sharedPlugin
+    ? ` (set by ${sharedPlugin}${sharedFile ? ` in ${sharedFile}` : ''})`
+    : '';
+  const advice = offendingPlugins.length
+    ? `run 'nx repair' for hand-authored entries and upgrade ${offendingPlugins.join(', ')} for plugin-inferred entries`
+    : `run 'nx repair' to fix`;
+  return {
+    title: `${project}:${ownerTarget} has ${annotated.length} dependsOn ${entryWord} using ${valuePhrase}${origin}. ${deprecation} ${advice}.`,
+    suppressBody: false,
+  };
+}
+
+function formatLegacyDependsOnBodyLine(
+  v: AnnotatedLegacyDependsOnViolation,
+  sharedPlugin: string | null
+): string {
+  const showSource = v.plugin && !sharedPlugin;
+  const sourcePart = showSource
+    ? ` from ${v.plugin}${v.file ? ` in ${v.file}` : ''}`
+    : '';
+  return `  - ${JSON.stringify(v.originalEntry)} (${v.index}${sourcePart})`;
+}

--- a/packages/nx/src/tasks-runner/legacy-depends-on-warning.ts
+++ b/packages/nx/src/tasks-runner/legacy-depends-on-warning.ts
@@ -4,15 +4,16 @@
 // modern shape, and `nx repair` will re-run it on demand.
 import { TargetDependencyConfig } from '../config/workspace-json-project-json';
 import { readSourceMapsCache } from '../project-graph/nx-deps-cache';
-import { ConfigurationSourceMaps } from '../project-graph/utils/project-configuration/source-maps';
+import { readArrayItemSourceInfo } from '../project-graph/utils/project-configuration/source-maps';
 import { output } from '../utils/output';
 
 export interface LegacyDependsOnViolation {
-  value: 'self' | 'dependencies';
   index: number;
   // Snapshot of the entry as authored, before normalization rewrites
   // `projects` / `dependencies`. Used to display the user-facing form.
-  originalEntry: TargetDependencyConfig;
+  originalEntry: TargetDependencyConfig & {
+    projects: 'self' | 'dependencies';
+  };
 }
 
 export interface LegacyDependsOnLocation {
@@ -22,13 +23,13 @@ export interface LegacyDependsOnLocation {
 }
 
 export function warnLegacyDependsOnMagicString(
-  value: 'self' | 'dependencies',
   currentProject: string | undefined,
-  dependencyConfig: TargetDependencyConfig,
+  dependencyConfig: TargetDependencyConfig & {
+    projects: 'self' | 'dependencies';
+  },
   location: LegacyDependsOnLocation | undefined
 ): void {
   const violation: LegacyDependsOnViolation = {
-    value,
     index: location?.index ?? -1,
     originalEntry: { ...dependencyConfig },
   };
@@ -59,11 +60,11 @@ export function flushLegacyDependsOnViolations(
     projectRoot,
     violations
   );
-  const sharedPlugin = sharedField(annotated, 'plugin');
+  const { sharedValue, sharedPlugin, sharedFile } =
+    computeSharedFields(annotated);
   // External-plugin warnings are workspace-wide (the plugin's behavior, not a
   // specific config): dedupe per (plugin, value) so the user sees one warning
   // per offending plugin, not one per affected target.
-  const sharedValue = sharedField(annotated, 'value');
   const dedupeKey =
     sharedPlugin && !isInternalPlugin(sharedPlugin) && sharedValue
       ? `plugin::${sharedPlugin}::${sharedValue}`
@@ -74,7 +75,8 @@ export function flushLegacyDependsOnViolations(
   const { title, suppressBody } = buildLegacyDependsOnWarning(
     project,
     ownerTarget,
-    annotated
+    annotated,
+    { sharedValue, sharedPlugin, sharedFile }
   );
   const bodyLines = suppressBody
     ? []
@@ -83,20 +85,16 @@ export function flushLegacyDependsOnViolations(
   output.warn({ title, bodyLines });
 }
 
-const warnedLegacyDependsOnMagicStrings = new Set<string>();
-
-let cachedSourceMaps: ConfigurationSourceMaps | null | undefined = undefined;
-function getSourceMapsLazy(): ConfigurationSourceMaps | null {
-  if (cachedSourceMaps !== undefined) return cachedSourceMaps;
-  try {
-    cachedSourceMaps = readSourceMapsCache();
-  } catch {
-    cachedSourceMaps = null;
-  }
-  return cachedSourceMaps;
+// Test-only: clears the process-wide dedupe set so each test sees a fresh
+// emission state.
+export function __resetForTests(): void {
+  warnedLegacyDependsOnMagicStrings.clear();
 }
 
+const warnedLegacyDependsOnMagicStrings = new Set<string>();
+
 interface AnnotatedLegacyDependsOnViolation extends LegacyDependsOnViolation {
+  value: 'self' | 'dependencies';
   plugin?: string;
   file?: string;
 }
@@ -110,32 +108,55 @@ function annotateLegacyViolations(
   projectRoot: string | undefined,
   violations: LegacyDependsOnViolation[]
 ): AnnotatedLegacyDependsOnViolation[] {
-  const sourceMaps = getSourceMapsLazy();
+  // Read fresh each flush so daemon-cached source maps don't go stale across
+  // graph rebuilds. Flush is gated on having violations, so this only runs on
+  // a workspace that actually still has legacy values.
+  let sourceMaps: ReturnType<typeof readSourceMapsCache> = null;
+  try {
+    sourceMaps = readSourceMapsCache();
+  } catch {
+    // Source maps are best-effort context for the warning; absence is fine.
+  }
   const projectSourceMap =
     projectRoot && sourceMaps ? sourceMaps[projectRoot] : undefined;
+  const dependsOnKey = `targets.${ownerTarget}.dependsOn`;
   return violations.map((v) => {
-    const sourceInfo =
-      projectSourceMap?.[`targets.${ownerTarget}.dependsOn.${v.index}`] ??
-      projectSourceMap?.[`targets.${ownerTarget}.dependsOn`];
+    const sourceInfo = projectSourceMap
+      ? readArrayItemSourceInfo(projectSourceMap, dependsOnKey, v.index)
+      : undefined;
     return {
       ...v,
+      value: v.originalEntry.projects,
       plugin: sourceInfo?.[1],
       file: sourceInfo?.[0] ?? undefined,
     };
   });
 }
 
-// Returns the value shared by every annotated violation, or `null` if values
-// differ. Used to collapse repeated information into the title.
-function sharedField<T, K extends keyof T>(items: T[], key: K): T[K] | null {
-  const first = items[0][key];
-  return items.every((item) => item[key] === first) ? first : null;
+// Single pass over the annotated violations to find any field that's
+// uniform across every entry (or `null` if values differ).
+function computeSharedFields(annotated: AnnotatedLegacyDependsOnViolation[]): {
+  sharedValue: 'self' | 'dependencies' | null;
+  sharedPlugin: string | undefined | null;
+  sharedFile: string | undefined | null;
+} {
+  const first = annotated[0];
+  let sharedValue: 'self' | 'dependencies' | null = first.value;
+  let sharedPlugin: string | undefined | null = first.plugin;
+  let sharedFile: string | undefined | null = first.file;
+  for (let i = 1; i < annotated.length; i++) {
+    const v = annotated[i];
+    if (sharedValue !== null && v.value !== sharedValue) sharedValue = null;
+    if (sharedPlugin !== null && v.plugin !== sharedPlugin) sharedPlugin = null;
+    if (sharedFile !== null && v.file !== sharedFile) sharedFile = null;
+  }
+  return { sharedValue, sharedPlugin, sharedFile };
 }
 
 function describeLegacyValuePhrase(
-  annotated: AnnotatedLegacyDependsOnViolation[]
+  annotated: AnnotatedLegacyDependsOnViolation[],
+  sharedValue: 'self' | 'dependencies' | null
 ): string {
-  const sharedValue = sharedField(annotated, 'value');
   if (sharedValue) return `projects: '${sharedValue}'`;
   const selfCount = annotated.filter((v) => v.value === 'self').length;
   const depCount = annotated.length - selfCount;
@@ -145,11 +166,15 @@ function describeLegacyValuePhrase(
 function buildLegacyDependsOnWarning(
   project: string,
   ownerTarget: string,
-  annotated: AnnotatedLegacyDependsOnViolation[]
+  annotated: AnnotatedLegacyDependsOnViolation[],
+  shared: {
+    sharedValue: 'self' | 'dependencies' | null;
+    sharedPlugin: string | undefined | null;
+    sharedFile: string | undefined | null;
+  }
 ): { title: string; suppressBody: boolean } {
-  const sharedPlugin = sharedField(annotated, 'plugin');
-  const sharedFile = sharedField(annotated, 'file');
-  const valuePhrase = describeLegacyValuePhrase(annotated);
+  const { sharedPlugin, sharedFile, sharedValue } = shared;
+  const valuePhrase = describeLegacyValuePhrase(annotated, sharedValue);
   const entryWord = annotated.length === 1 ? 'entry' : 'entries';
   const deprecation = 'This is deprecated and will be removed in Nx v24 —';
 
@@ -193,7 +218,7 @@ function buildLegacyDependsOnWarning(
 
 function formatLegacyDependsOnBodyLine(
   v: AnnotatedLegacyDependsOnViolation,
-  sharedPlugin: string | null
+  sharedPlugin: string | undefined | null
 ): string {
   const showSource = v.plugin && !sharedPlugin;
   const sourcePart = showSource

--- a/packages/nx/src/tasks-runner/legacy-depends-on-warning.ts
+++ b/packages/nx/src/tasks-runner/legacy-depends-on-warning.ts
@@ -8,16 +8,12 @@ import { readArrayItemSourceInfo } from '../project-graph/utils/project-configur
 import { output } from '../utils/output';
 
 type LegacyValue = 'self' | 'dependencies';
-
-type LegacyDependsOnEntry = TargetDependencyConfig & {
-  projects: LegacyValue;
-};
+type LegacyEntry = TargetDependencyConfig & { projects: LegacyValue };
 
 export interface LegacyDependsOnViolation {
   index: number;
-  // Snapshot of the entry as authored, before normalization rewrites
-  // `projects` / `dependencies`. Used to display the user-facing form.
-  originalEntry: LegacyDependsOnEntry;
+  // Snapshot before normalization rewrites `projects`/`dependencies`.
+  originalEntry: LegacyEntry;
 }
 
 export interface LegacyDependsOnLocation {
@@ -26,8 +22,11 @@ export interface LegacyDependsOnLocation {
   legacyViolations?: LegacyDependsOnViolation[];
 }
 
-// Callers gate this on `dependencyConfig.projects` already being a legacy
-// value; the cast snapshots that runtime guarantee into the type system.
+const warned = new Set<string>();
+const isInternal = (p: string | undefined) => !p || p.startsWith('nx/');
+
+// Callers gate this on `dependencyConfig.projects` already being a legacy value;
+// the inner cast snapshots that runtime guarantee into the type system.
 export function warnLegacyDependsOnMagicString(
   currentProject: string | undefined,
   dependencyConfig: TargetDependencyConfig,
@@ -35,15 +34,13 @@ export function warnLegacyDependsOnMagicString(
 ): void {
   const violation: LegacyDependsOnViolation = {
     index: location?.index ?? -1,
-    originalEntry: { ...dependencyConfig } as LegacyDependsOnEntry,
+    originalEntry: { ...dependencyConfig } as LegacyEntry,
   };
   // Collector-aware caller (`getDependencyConfigs`) batches violations so the
   // warning can group all offending entries for a single target. External
-  // callers without a collector fall through to an immediate per-entry warning.
-  if (location?.legacyViolations) {
-    location.legacyViolations.push(violation);
-    return;
-  }
+  // callers fall through to an immediate per-entry warning.
+  if (location?.legacyViolations)
+    return void location.legacyViolations.push(violation);
   flushLegacyDependsOnViolations(
     currentProject ?? '<unknown>',
     location?.ownerTarget ?? '<unknown>',
@@ -59,176 +56,95 @@ export function flushLegacyDependsOnViolations(
   projectRoot: string | undefined
 ): void {
   if (violations.length === 0) return;
-  const annotated = annotateLegacyViolations(
-    ownerTarget,
-    projectRoot,
-    violations
-  );
-  const { sharedValue, sharedPlugin, sharedFile } =
-    computeSharedFields(annotated);
-  // External-plugin warnings are workspace-wide (the plugin's behavior, not a
-  // specific config): dedupe per (plugin, value) so the user sees one warning
-  // per offending plugin, not one per affected target.
-  const dedupeKey =
-    sharedPlugin && !isInternalPlugin(sharedPlugin) && sharedValue
-      ? `plugin::${sharedPlugin}::${sharedValue}`
-      : `target::${project}::${ownerTarget}`;
-  if (warnedLegacyDependsOnMagicStrings.has(dedupeKey)) return;
-  warnedLegacyDependsOnMagicStrings.add(dedupeKey);
 
-  const { title, suppressBody } = buildLegacyDependsOnWarning(
-    project,
-    ownerTarget,
-    annotated,
-    { sharedValue, sharedPlugin, sharedFile }
-  );
-  const bodyLines = suppressBody
-    ? []
-    : annotated.map((v) => formatLegacyDependsOnBodyLine(v, sharedPlugin));
-
-  output.warn({ title, bodyLines });
-}
-
-// Test-only: clears the process-wide dedupe set so each test sees a fresh
-// emission state.
-export function __resetForTests(): void {
-  warnedLegacyDependsOnMagicStrings.clear();
-}
-
-const warnedLegacyDependsOnMagicStrings = new Set<string>();
-
-interface AnnotatedLegacyDependsOnViolation extends LegacyDependsOnViolation {
-  value: LegacyValue;
-  plugin?: string;
-  file?: string;
-}
-
-// Each `Shared*` field is the value that every annotated violation agrees on,
-// or `null` if values differ.
-interface SharedFields {
-  sharedValue: LegacyValue | null;
-  sharedPlugin: string | undefined | null;
-  sharedFile: string | undefined | null;
-}
-
-function isInternalPlugin(plugin: string | undefined): boolean {
-  return !plugin || plugin.startsWith('nx/');
-}
-
-function annotateLegacyViolations(
-  ownerTarget: string,
-  projectRoot: string | undefined,
-  violations: LegacyDependsOnViolation[]
-): AnnotatedLegacyDependsOnViolation[] {
-  // Read fresh each flush so daemon-cached source maps don't go stale across
-  // graph rebuilds. Flush is gated on having violations, so this only runs on
-  // a workspace that actually still has legacy values.
+  // Read source maps fresh each flush so daemon-cached maps don't go stale;
+  // only runs when violations exist, which is rare.
   let sourceMaps: ReturnType<typeof readSourceMapsCache> = null;
   try {
     sourceMaps = readSourceMapsCache();
-  } catch {
-    // Source maps are best-effort context for the warning; absence is fine.
-  }
-  const projectSourceMap =
-    projectRoot && sourceMaps ? sourceMaps[projectRoot] : undefined;
-  const dependsOnKey = `targets.${ownerTarget}.dependsOn`;
-  return violations.map((v) => {
-    const sourceInfo = projectSourceMap
-      ? readArrayItemSourceInfo(projectSourceMap, dependsOnKey, v.index)
+  } catch {} // best-effort context
+  const map = projectRoot && sourceMaps ? sourceMaps[projectRoot] : undefined;
+  const arrayKey = `targets.${ownerTarget}.dependsOn`;
+  const items = violations.map((v) => {
+    const info = map
+      ? readArrayItemSourceInfo(map, arrayKey, v.index)
       : undefined;
     return {
       ...v,
       value: v.originalEntry.projects,
-      plugin: sourceInfo?.[1],
-      file: sourceInfo?.[0] ?? undefined,
+      plugin: info?.[1],
+      file: info?.[0] ?? undefined,
     };
   });
-}
+  type Item = (typeof items)[number];
 
-// Single pass over the annotated violations to find any field that's
-// uniform across every entry (or `null` if values differ).
-function computeSharedFields(
-  annotated: AnnotatedLegacyDependsOnViolation[]
-): SharedFields {
-  const first = annotated[0];
-  let sharedValue: SharedFields['sharedValue'] = first.value;
-  let sharedPlugin: SharedFields['sharedPlugin'] = first.plugin;
-  let sharedFile: SharedFields['sharedFile'] = first.file;
-  for (let i = 1; i < annotated.length; i++) {
-    const v = annotated[i];
-    if (sharedValue !== null && v.value !== sharedValue) sharedValue = null;
-    if (sharedPlugin !== null && v.plugin !== sharedPlugin) sharedPlugin = null;
-    if (sharedFile !== null && v.file !== sharedFile) sharedFile = null;
-  }
-  return { sharedValue, sharedPlugin, sharedFile };
-}
+  const shared = <K extends keyof Item>(key: K): Item[K] | null =>
+    items.every((i) => i[key] === items[0][key]) ? items[0][key] : null;
+  const value = shared('value');
+  const plugin = shared('plugin');
+  const file = shared('file');
 
-function describeLegacyValuePhrase(
-  annotated: AnnotatedLegacyDependsOnViolation[],
-  sharedValue: LegacyValue | null
-): string {
-  if (sharedValue) return `projects: '${sharedValue}'`;
-  const selfCount = annotated.filter((v) => v.value === 'self').length;
-  const depCount = annotated.length - selfCount;
-  return `legacy projects values (${selfCount} 'self', ${depCount} 'dependencies')`;
-}
+  // External-plugin warnings are workspace-wide (the plugin's behavior, not a
+  // specific config): dedupe per (plugin, value) so the user sees one warning
+  // per offending plugin, not one per affected target.
+  const dedupeKey =
+    plugin && !isInternal(plugin) && value
+      ? `plugin::${plugin}::${value}`
+      : `target::${project}::${ownerTarget}`;
+  if (warned.has(dedupeKey)) return;
+  warned.add(dedupeKey);
 
-function buildLegacyDependsOnWarning(
-  project: string,
-  ownerTarget: string,
-  annotated: AnnotatedLegacyDependsOnViolation[],
-  shared: SharedFields
-): { title: string; suppressBody: boolean } {
-  const { sharedPlugin, sharedFile, sharedValue } = shared;
-  const valuePhrase = describeLegacyValuePhrase(annotated, sharedValue);
-  const entryWord = annotated.length === 1 ? 'entry' : 'entries';
+  const n = items.length;
+  const word = n === 1 ? 'entry' : 'entries';
   const deprecation = 'This is deprecated and will be removed in Nx v24 —';
-
-  // Single external plugin: the same plugin typically emits the same legacy
-  // value on every project it touches, so a single workspace-wide warning is
-  // more useful than one per target.
-  if (sharedPlugin && !isInternalPlugin(sharedPlugin)) {
-    return {
-      title: `The ${sharedPlugin} plugin infers dependsOn entries using ${valuePhrase}. ${deprecation} please upgrade ${sharedPlugin} to a version that doesn't emit this.`,
-      suppressBody: true,
-    };
+  let phrase: string;
+  if (value) {
+    phrase = `projects: '${value}'`;
+  } else {
+    const self = items.filter((i) => i.value === 'self').length;
+    phrase = `legacy projects values (${self} 'self', ${n - self} 'dependencies')`;
   }
 
-  // Single hand-authored config file — lead with the file path.
-  if (sharedPlugin && isInternalPlugin(sharedPlugin) && sharedFile) {
-    return {
-      title: `${sharedFile} defines ${project}:${ownerTarget} with ${annotated.length} dependsOn ${entryWord} using ${valuePhrase}. ${deprecation} run 'nx repair' to fix this.`,
-      suppressBody: false,
-    };
+  let title: string;
+  let suppressBody = false;
+  if (plugin && !isInternal(plugin)) {
+    // Single external plugin: same plugin emits the same value across projects.
+    title = `The ${plugin} plugin infers dependsOn entries using ${phrase}. ${deprecation} please upgrade ${plugin} to a version that doesn't emit this.`;
+    suppressBody = true;
+  } else if (plugin && isInternal(plugin) && file) {
+    // Single hand-authored config file — lead with the file path.
+    title = `${file} defines ${project}:${ownerTarget} with ${n} dependsOn ${word} using ${phrase}. ${deprecation} run 'nx repair' to fix this.`;
+  } else {
+    // Mixed sources or no source-map info — tailor advice to what's offending.
+    const offending = Array.from(
+      new Set(
+        items
+          .filter((i) => i.plugin && !isInternal(i.plugin))
+          .map((i) => i.plugin!)
+      )
+    );
+    const origin = plugin
+      ? ` (set by ${plugin}${file ? ` in ${file}` : ''})`
+      : '';
+    const advice = offending.length
+      ? `run 'nx repair' for hand-authored entries and upgrade ${offending.join(', ')} for plugin-inferred entries`
+      : `run 'nx repair' to fix`;
+    title = `${project}:${ownerTarget} has ${n} dependsOn ${word} using ${phrase}${origin}. ${deprecation} ${advice}.`;
   }
 
-  // Mixed sources, or no source-map info — tailor advice to what's offending.
-  const offendingPlugins = Array.from(
-    new Set(
-      annotated
-        .filter((v) => v.plugin && !isInternalPlugin(v.plugin))
-        .map((v) => v.plugin as string)
-    )
-  );
-  const origin = sharedPlugin
-    ? ` (set by ${sharedPlugin}${sharedFile ? ` in ${sharedFile}` : ''})`
-    : '';
-  const advice = offendingPlugins.length
-    ? `run 'nx repair' for hand-authored entries and upgrade ${offendingPlugins.join(', ')} for plugin-inferred entries`
-    : `run 'nx repair' to fix`;
-  return {
-    title: `${project}:${ownerTarget} has ${annotated.length} dependsOn ${entryWord} using ${valuePhrase}${origin}. ${deprecation} ${advice}.`,
-    suppressBody: false,
-  };
+  const bodyLines = suppressBody
+    ? []
+    : items.map((i) => {
+        const src =
+          i.plugin && !plugin
+            ? ` from ${i.plugin}${i.file ? ` in ${i.file}` : ''}`
+            : '';
+        return `  - ${JSON.stringify(i.originalEntry)} (${i.index}${src})`;
+      });
+  output.warn({ title, bodyLines });
 }
 
-function formatLegacyDependsOnBodyLine(
-  v: AnnotatedLegacyDependsOnViolation,
-  sharedPlugin: string | undefined | null
-): string {
-  const showSource = v.plugin && !sharedPlugin;
-  const sourcePart = showSource
-    ? ` from ${v.plugin}${v.file ? ` in ${v.file}` : ''}`
-    : '';
-  return `  - ${JSON.stringify(v.originalEntry)} (${v.index}${sourcePart})`;
+// Test-only: clears the process-wide dedupe set.
+export function __resetForTests(): void {
+  warned.clear();
 }

--- a/packages/nx/src/tasks-runner/legacy-depends-on-warning.ts
+++ b/packages/nx/src/tasks-runner/legacy-depends-on-warning.ts
@@ -7,13 +7,17 @@ import { readSourceMapsCache } from '../project-graph/nx-deps-cache';
 import { readArrayItemSourceInfo } from '../project-graph/utils/project-configuration/source-maps';
 import { output } from '../utils/output';
 
+type LegacyValue = 'self' | 'dependencies';
+
+type LegacyDependsOnEntry = TargetDependencyConfig & {
+  projects: LegacyValue;
+};
+
 export interface LegacyDependsOnViolation {
   index: number;
   // Snapshot of the entry as authored, before normalization rewrites
   // `projects` / `dependencies`. Used to display the user-facing form.
-  originalEntry: TargetDependencyConfig & {
-    projects: 'self' | 'dependencies';
-  };
+  originalEntry: LegacyDependsOnEntry;
 }
 
 export interface LegacyDependsOnLocation {
@@ -22,16 +26,16 @@ export interface LegacyDependsOnLocation {
   legacyViolations?: LegacyDependsOnViolation[];
 }
 
+// Callers gate this on `dependencyConfig.projects` already being a legacy
+// value; the cast snapshots that runtime guarantee into the type system.
 export function warnLegacyDependsOnMagicString(
   currentProject: string | undefined,
-  dependencyConfig: TargetDependencyConfig & {
-    projects: 'self' | 'dependencies';
-  },
+  dependencyConfig: TargetDependencyConfig,
   location: LegacyDependsOnLocation | undefined
 ): void {
   const violation: LegacyDependsOnViolation = {
     index: location?.index ?? -1,
-    originalEntry: { ...dependencyConfig },
+    originalEntry: { ...dependencyConfig } as LegacyDependsOnEntry,
   };
   // Collector-aware caller (`getDependencyConfigs`) batches violations so the
   // warning can group all offending entries for a single target. External
@@ -94,9 +98,17 @@ export function __resetForTests(): void {
 const warnedLegacyDependsOnMagicStrings = new Set<string>();
 
 interface AnnotatedLegacyDependsOnViolation extends LegacyDependsOnViolation {
-  value: 'self' | 'dependencies';
+  value: LegacyValue;
   plugin?: string;
   file?: string;
+}
+
+// Each `Shared*` field is the value that every annotated violation agrees on,
+// or `null` if values differ.
+interface SharedFields {
+  sharedValue: LegacyValue | null;
+  sharedPlugin: string | undefined | null;
+  sharedFile: string | undefined | null;
 }
 
 function isInternalPlugin(plugin: string | undefined): boolean {
@@ -135,15 +147,13 @@ function annotateLegacyViolations(
 
 // Single pass over the annotated violations to find any field that's
 // uniform across every entry (or `null` if values differ).
-function computeSharedFields(annotated: AnnotatedLegacyDependsOnViolation[]): {
-  sharedValue: 'self' | 'dependencies' | null;
-  sharedPlugin: string | undefined | null;
-  sharedFile: string | undefined | null;
-} {
+function computeSharedFields(
+  annotated: AnnotatedLegacyDependsOnViolation[]
+): SharedFields {
   const first = annotated[0];
-  let sharedValue: 'self' | 'dependencies' | null = first.value;
-  let sharedPlugin: string | undefined | null = first.plugin;
-  let sharedFile: string | undefined | null = first.file;
+  let sharedValue: SharedFields['sharedValue'] = first.value;
+  let sharedPlugin: SharedFields['sharedPlugin'] = first.plugin;
+  let sharedFile: SharedFields['sharedFile'] = first.file;
   for (let i = 1; i < annotated.length; i++) {
     const v = annotated[i];
     if (sharedValue !== null && v.value !== sharedValue) sharedValue = null;
@@ -155,7 +165,7 @@ function computeSharedFields(annotated: AnnotatedLegacyDependsOnViolation[]): {
 
 function describeLegacyValuePhrase(
   annotated: AnnotatedLegacyDependsOnViolation[],
-  sharedValue: 'self' | 'dependencies' | null
+  sharedValue: LegacyValue | null
 ): string {
   if (sharedValue) return `projects: '${sharedValue}'`;
   const selfCount = annotated.filter((v) => v.value === 'self').length;
@@ -167,11 +177,7 @@ function buildLegacyDependsOnWarning(
   project: string,
   ownerTarget: string,
   annotated: AnnotatedLegacyDependsOnViolation[],
-  shared: {
-    sharedValue: 'self' | 'dependencies' | null;
-    sharedPlugin: string | undefined | null;
-    sharedFile: string | undefined | null;
-  }
+  shared: SharedFields
 ): { title: string; suppressBody: boolean } {
   const { sharedPlugin, sharedFile, sharedValue } = shared;
   const valuePhrase = describeLegacyValuePhrase(annotated, sharedValue);

--- a/packages/nx/src/tasks-runner/legacy-depends-on-warning.ts
+++ b/packages/nx/src/tasks-runner/legacy-depends-on-warning.ts
@@ -3,6 +3,8 @@
 // v16 `update-depends-on-to-tokens` migration already rewrites these to the
 // modern shape, and `nx repair` will re-run it on demand.
 import { TargetDependencyConfig } from '../config/workspace-json-project-json';
+import { readSourceMapsCache } from '../project-graph/nx-deps-cache';
+import { ConfigurationSourceMaps } from '../project-graph/utils/project-configuration/source-maps';
 import { output } from '../utils/output';
 
 export interface LegacyDependsOnViolation {
@@ -83,14 +85,10 @@ export function flushLegacyDependsOnViolations(
 
 const warnedLegacyDependsOnMagicStrings = new Set<string>();
 
-let cachedSourceMaps:
-  | import('../project-graph/utils/project-configuration/source-maps').ConfigurationSourceMaps
-  | null
-  | undefined = undefined;
-function getSourceMapsLazy() {
+let cachedSourceMaps: ConfigurationSourceMaps | null | undefined = undefined;
+function getSourceMapsLazy(): ConfigurationSourceMaps | null {
   if (cachedSourceMaps !== undefined) return cachedSourceMaps;
   try {
-    const { readSourceMapsCache } = require('../project-graph/nx-deps-cache');
     cachedSourceMaps = readSourceMapsCache();
   } catch {
     cachedSourceMaps = null;

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -346,13 +346,17 @@ function flushLegacyDependsOnViolations(
     ? annotated[0].file
     : null;
 
-  const titleValue = sharedValue
-    ? `projects: '${sharedValue}'`
-    : `legacy projects values`;
-  const origin =
-    sharedPlugin && sharedValue
-      ? ` (set by ${sharedPlugin}${sharedFile ? ` in ${sharedFile}` : ''})`
-      : '';
+  let titleValue: string;
+  if (sharedValue) {
+    titleValue = `projects: '${sharedValue}'`;
+  } else {
+    const selfCount = annotated.filter((v) => v.value === 'self').length;
+    const depCount = annotated.length - selfCount;
+    titleValue = `legacy projects values (${selfCount} 'self', ${depCount} 'dependencies')`;
+  }
+  const origin = sharedPlugin
+    ? ` (set by ${sharedPlugin}${sharedFile ? ` in ${sharedFile}` : ''})`
+    : '';
   const title = `${project}:${ownerTarget} has ${annotated.length} dependsOn ${
     annotated.length === 1 ? 'entry' : 'entries'
   } using ${titleValue}${origin}. This will be removed in Nx v24 — run 'nx repair' to fix.`;

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -20,6 +20,7 @@ import {
 import { isRelativePath } from '../utils/fileutils';
 import { findMatchingProjects } from '../utils/find-matching-projects';
 import {
+  LegacyDependsOnLocation,
   LegacyDependsOnViolation,
   flushLegacyDependsOnViolations,
   warnLegacyDependsOnMagicString,
@@ -56,20 +57,18 @@ export function getDependencyConfigs(
       { ownerTarget: target, index, legacyViolations }
     )
   );
-  flushLegacyDependsOnViolations(
-    project,
-    target,
-    legacyViolations,
-    projectGraph.nodes[project]?.data?.root
-  );
+  if (legacyViolations.length) {
+    flushLegacyDependsOnViolations(
+      project,
+      target,
+      legacyViolations,
+      projectGraph.nodes[project]?.data?.root
+    );
+  }
   return dependencyConfigs;
 }
 
-export interface DependsOnEntryLocation {
-  ownerTarget?: string;
-  index?: number;
-  legacyViolations?: LegacyDependsOnViolation[];
-}
+export type DependsOnEntryLocation = LegacyDependsOnLocation;
 
 export function normalizeDependencyConfigDefinition(
   definition: string | TargetDependencyConfig,
@@ -237,17 +236,17 @@ export function normalizeTargetDependencyWithStringProjects(
     // these to the modern shape, and `nx repair` will re-run it on demand.
     if (dependencyConfig.projects === 'self') {
       warnLegacyDependsOnMagicString(
-        'self',
         currentProject,
-        dependencyConfig,
+        dependencyConfig as TargetDependencyConfig & { projects: 'self' },
         location
       );
       delete dependencyConfig.projects;
     } else if (dependencyConfig.projects === 'dependencies') {
       warnLegacyDependsOnMagicString(
-        'dependencies',
         currentProject,
-        dependencyConfig,
+        dependencyConfig as TargetDependencyConfig & {
+          projects: 'dependencies';
+        },
         location
       );
       dependencyConfig.dependencies = true;

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -37,6 +37,7 @@ export function getDependencyConfigs(
   projectGraph: ProjectGraph,
   allTargetNames: string[]
 ): NormalizedTargetDependencyConfig[] | undefined {
+  const legacyViolations: LegacyDependsOnViolation[] = [];
   const dependencyConfigs = (
     projectGraph.nodes[project].data?.targets[target]?.dependsOn ??
     // This is passed into `run-command` from programmatic invocations
@@ -48,15 +49,23 @@ export function getDependencyConfigs(
       project,
       projectGraph,
       allTargetNames,
-      { ownerTarget: target, index }
+      { ownerTarget: target, index, legacyViolations }
     )
   );
+  flushLegacyDependsOnViolations(project, target, legacyViolations);
   return dependencyConfigs;
+}
+
+interface LegacyDependsOnViolation {
+  value: 'self' | 'dependencies';
+  index: number;
+  depTarget: string;
 }
 
 export interface DependsOnEntryLocation {
   ownerTarget?: string;
   index?: number;
+  legacyViolations?: LegacyDependsOnViolation[];
 }
 
 export function normalizeDependencyConfigDefinition(
@@ -256,6 +265,17 @@ function warnLegacyDependsOnMagicString(
   dependencyConfig: TargetDependencyConfig,
   location: DependsOnEntryLocation | undefined
 ): void {
+  // If a collector is provided, defer — `getDependencyConfigs` emits a single
+  // consolidated warning per target after all entries are processed.
+  if (location?.legacyViolations) {
+    location.legacyViolations.push({
+      value,
+      index: location.index ?? -1,
+      depTarget: dependencyConfig.target ?? '<unknown>',
+    });
+    return;
+  }
+  // Fallback path: external callers without a collector get a per-entry warning.
   const project = currentProject ?? '<unknown>';
   const ownerTarget = location?.ownerTarget ?? '<unknown>';
   const index = location?.index ?? -1;
@@ -269,6 +289,26 @@ function warnLegacyDependsOnMagicString(
     bodyLines: [
       `The entry targets \`${depTarget}\`. To fix, run \`nx repair\`.`,
     ],
+  });
+}
+
+function flushLegacyDependsOnViolations(
+  project: string,
+  ownerTarget: string,
+  violations: LegacyDependsOnViolation[]
+): void {
+  if (violations.length === 0) return;
+  const key = `${project}::${ownerTarget}`;
+  if (warnedLegacyDependsOnMagicStrings.has(key)) return;
+  warnedLegacyDependsOnMagicStrings.add(key);
+  const bodyLines = violations.map(
+    (v) =>
+      `  - \`dependsOn[${v.index}]\` (\`projects: '${v.value}'\`, targets \`${v.depTarget}\`)`
+  );
+  bodyLines.push(`To fix, run \`nx repair\`.`);
+  output.warn({
+    title: `\`${project}:${ownerTarget}\` has \`dependsOn\` entries using legacy \`projects: 'self' | 'dependencies'\` values, which will be removed in Nx v24.`,
+    bodyLines,
   });
 }
 

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -38,12 +38,12 @@ export function getDependencyConfigs(
   allTargetNames: string[]
 ): NormalizedTargetDependencyConfig[] | undefined {
   const legacyViolations: LegacyDependsOnViolation[] = [];
-  const dependsOnEntries =
+  const dependencyConfigs = (
     projectGraph.nodes[project].data?.targets[target]?.dependsOn ??
     // This is passed into `run-command` from programmatic invocations
     extraTargetDependencies[target] ??
-    [];
-  const dependencyConfigs = dependsOnEntries.flatMap((config, index) =>
+    []
+  ).flatMap((config, index) =>
     normalizeDependencyConfigDefinition(
       config,
       project,
@@ -56,8 +56,7 @@ export function getDependencyConfigs(
     project,
     target,
     legacyViolations,
-    projectGraph.nodes[project]?.data?.root,
-    dependsOnEntries
+    projectGraph.nodes[project]?.data?.root
   );
   return dependencyConfigs;
 }
@@ -66,6 +65,9 @@ interface LegacyDependsOnViolation {
   value: 'self' | 'dependencies';
   index: number;
   depTarget: string;
+  // Snapshot of the entry as authored, before normalization rewrites
+  // `projects` / `dependencies`. Used to display the user-facing form.
+  originalEntry: TargetDependencyConfig;
 }
 
 export interface DependsOnEntryLocation {
@@ -278,6 +280,7 @@ function warnLegacyDependsOnMagicString(
       value,
       index: location.index ?? -1,
       depTarget: dependencyConfig.target ?? '<unknown>',
+      originalEntry: { ...dependencyConfig },
     });
     return;
   }
@@ -317,8 +320,7 @@ function flushLegacyDependsOnViolations(
   project: string,
   ownerTarget: string,
   violations: LegacyDependsOnViolation[],
-  projectRoot: string | undefined,
-  dependsOnEntries: ReadonlyArray<string | TargetDependencyConfig>
+  projectRoot: string | undefined
 ): void {
   if (violations.length === 0) return;
   const key = `${project}::${ownerTarget}`;
@@ -396,7 +398,7 @@ function flushLegacyDependsOnViolations(
         ? ''
         : ` from ${v.plugin}${v.file ? ` in ${v.file}` : ''}`
       : '';
-    return `  - ${JSON.stringify(dependsOnEntries[v.index])} (${v.index}${sourcePart})`;
+    return `  - ${JSON.stringify(v.originalEntry)} (${v.index}${sourcePart})`;
   });
 
   output.warn({ title, bodyLines });

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -360,15 +360,15 @@ function flushLegacyDependsOnViolations(
   // `nx repair` only rewrites hand-authored config (nx.json/project.json). For
   // plugin-inferred entries, the user needs to upgrade the plugin.
   const allFromCore = annotated.every(
-    (v) => !v.plugin || v.plugin.startsWith('nx/core/')
+    (v) => !v.plugin || v.plugin.startsWith('nx/')
   );
   const anyFromCore = annotated.some(
-    (v) => !v.plugin || v.plugin.startsWith('nx/core/')
+    (v) => !v.plugin || v.plugin.startsWith('nx/')
   );
   const offendingPlugins = Array.from(
     new Set(
       annotated
-        .filter((v) => v.plugin && !v.plugin.startsWith('nx/core/'))
+        .filter((v) => v.plugin && !v.plugin.startsWith('nx/'))
         .map((v) => v.plugin as string)
     )
   );

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -243,15 +243,11 @@ function warnLegacyDependsOnMagicString(
   const key = `${project}::${target}::${value}`;
   if (warnedLegacyDependsOnMagicStrings.has(key)) return;
   warnedLegacyDependsOnMagicStrings.add(key);
-  const replacement =
-    value === 'self'
-      ? 'omit the `projects` field (the current project is the default)'
-      : 'use `{ dependencies: true }`';
   output.warn({
     title: `\`dependsOn\` entry uses the legacy \`projects: '${value}'\` value, which will be removed in Nx v24.`,
     bodyLines: [
       `Found on project \`${project}\` in a \`dependsOn\` entry targeting \`${target}\`.`,
-      `To fix: ${replacement}, or run \`nx repair\` to update your configuration automatically.`,
+      `To fix, run \`nx repair\`.`,
     ],
   });
 }

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -64,7 +64,6 @@ export function getDependencyConfigs(
 interface LegacyDependsOnViolation {
   value: 'self' | 'dependencies';
   index: number;
-  depTarget: string;
   // Snapshot of the entry as authored, before normalization rewrites
   // `projects` / `dependencies`. Used to display the user-facing form.
   originalEntry: TargetDependencyConfig;
@@ -279,7 +278,6 @@ function warnLegacyDependsOnMagicString(
     location.legacyViolations.push({
       value,
       index: location.index ?? -1,
-      depTarget: dependencyConfig.target ?? '<unknown>',
       originalEntry: { ...dependencyConfig },
     });
     return;

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -365,6 +365,9 @@ function flushLegacyDependsOnViolations(
     // at upgrading that plugin.
     const fromFile = sharedFile ? ` from ${sharedFile}` : '';
     title = `The ${sharedPlugin} plugin inferred ${project}:${ownerTarget} with ${annotated.length} invalid dependsOn ${entryWord} using ${valuePhrase}${fromFile}. This is deprecated and will be removed in Nx v24 — please upgrade ${sharedPlugin} to a version that doesn't emit this.`;
+  } else if (sharedPlugin && isInternal(sharedPlugin) && sharedFile) {
+    // Hand-authored entries from a single config file — lead with the file.
+    title = `${sharedFile} defines ${project}:${ownerTarget} with ${annotated.length} dependsOn ${entryWord} using ${valuePhrase}. This is deprecated and will be removed in Nx v24 — run 'nx repair' to fix this.`;
   } else {
     // Mixed sources, or only internal/hand-authored sources — `nx repair`
     // handles hand-authored entries; any external plugins still need an

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -65,6 +65,7 @@ interface LegacyDependsOnViolation {
   value: 'self' | 'dependencies';
   index: number;
   depTarget: string;
+  entry: TargetDependencyConfig;
 }
 
 export interface DependsOnEntryLocation {
@@ -273,10 +274,13 @@ function warnLegacyDependsOnMagicString(
   // If a collector is provided, defer — `getDependencyConfigs` emits a single
   // consolidated warning per target after all entries are processed.
   if (location?.legacyViolations) {
+    // Snapshot before the caller mutates `dependencyConfig` (deletes `projects`,
+    // sets `dependencies`) so the warning can show the original entry as authored.
     location.legacyViolations.push({
       value,
       index: location.index ?? -1,
       depTarget: dependencyConfig.target ?? '<unknown>',
+      entry: { ...dependencyConfig },
     });
     return;
   }
@@ -394,8 +398,7 @@ function flushLegacyDependsOnViolations(
         ? ''
         : ` from ${v.plugin}${v.file ? ` in ${v.file}` : ''}`
       : '';
-    const valuePrefix = sharedValue ? '' : `'${v.value}' — `;
-    return `  - ${valuePrefix}${v.depTarget} (dependsOn[${v.index}]${sourcePart})`;
+    return `  - ${JSON.stringify(v.entry)} (dependsOn[${v.index}]${sourcePart})`;
   });
 
   output.warn({ title, bodyLines });

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -357,9 +357,36 @@ function flushLegacyDependsOnViolations(
   const origin = sharedPlugin
     ? ` (set by ${sharedPlugin}${sharedFile ? ` in ${sharedFile}` : ''})`
     : '';
+  // `nx repair` only rewrites hand-authored config (nx.json/project.json). For
+  // plugin-inferred entries, the user needs to upgrade the plugin.
+  const allFromCore = annotated.every(
+    (v) => !v.plugin || v.plugin.startsWith('nx/core/')
+  );
+  const anyFromCore = annotated.some(
+    (v) => !v.plugin || v.plugin.startsWith('nx/core/')
+  );
+  const offendingPlugins = Array.from(
+    new Set(
+      annotated
+        .filter((v) => v.plugin && !v.plugin.startsWith('nx/core/'))
+        .map((v) => v.plugin as string)
+    )
+  );
+  let advice: string;
+  if (allFromCore) {
+    advice = `run 'nx repair' to fix`;
+  } else if (anyFromCore) {
+    advice = `run 'nx repair' for hand-authored entries and upgrade ${offendingPlugins.join(
+      ', '
+    )} for plugin-inferred entries`;
+  } else {
+    advice = `upgrade ${offendingPlugins.join(
+      ', '
+    )} to a version that doesn't emit this`;
+  }
   const title = `${project}:${ownerTarget} has ${annotated.length} dependsOn ${
     annotated.length === 1 ? 'entry' : 'entries'
-  } using ${titleValue}${origin}. This will be removed in Nx v24 — run 'nx repair' to fix.`;
+  } using ${titleValue}${origin}. This will be removed in Nx v24 — ${advice}.`;
 
   const bodyLines = annotated.map((v) => {
     const sourcePart = v.plugin

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -19,6 +19,7 @@ import {
 } from '../native';
 import { isRelativePath } from '../utils/fileutils';
 import { findMatchingProjects } from '../utils/find-matching-projects';
+import { output } from '../utils/output';
 import { isGlobPattern } from '../utils/globs';
 import { joinPathFragments } from '../utils/path';
 import { serializeOverridesIntoCommandLine } from '../utils/serialize-overrides-into-command-line';
@@ -205,11 +206,39 @@ export function normalizeTargetDependencyWithStringProjects(
   dependencyConfig: TargetDependencyConfig
 ): Omit<TargetDependencyConfig, 'projects'> & { projects: string[] } {
   if (typeof dependencyConfig.projects === 'string') {
-    dependencyConfig.projects = [dependencyConfig.projects];
+    // TODO(v24): Remove the `self` / `dependencies` magic-string shim.
+    // The v16 `update-depends-on-to-tokens` migration already rewrites
+    // these to the modern shape, and `nx repair` will re-run it on demand.
+    if (dependencyConfig.projects === 'self') {
+      warnLegacyDependsOnMagicString('self');
+      delete dependencyConfig.projects;
+    } else if (dependencyConfig.projects === 'dependencies') {
+      warnLegacyDependsOnMagicString('dependencies');
+      dependencyConfig.dependencies = true;
+      delete dependencyConfig.projects;
+    } else {
+      dependencyConfig.projects = [dependencyConfig.projects];
+    }
   }
   return dependencyConfig as Omit<TargetDependencyConfig, 'projects'> & {
     projects: string[];
   };
+}
+
+const warnedLegacyDependsOnMagicStrings = new Set<string>();
+function warnLegacyDependsOnMagicString(value: 'self' | 'dependencies'): void {
+  if (warnedLegacyDependsOnMagicStrings.has(value)) return;
+  warnedLegacyDependsOnMagicStrings.add(value);
+  const replacement =
+    value === 'self'
+      ? 'omit the `projects` field (the current project is the default)'
+      : 'use `{ dependencies: true }`';
+  output.warn({
+    title: `\`dependsOn\` entry uses the legacy \`projects: '${value}'\` value, which will be removed in Nx v24.`,
+    bodyLines: [
+      `To fix: ${replacement}, or run \`nx repair\` to update your configuration automatically.`,
+    ],
+  });
 }
 
 class InvalidOutputsError extends Error {

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -237,16 +237,14 @@ export function normalizeTargetDependencyWithStringProjects(
     if (dependencyConfig.projects === 'self') {
       warnLegacyDependsOnMagicString(
         currentProject,
-        dependencyConfig as TargetDependencyConfig & { projects: 'self' },
+        dependencyConfig,
         location
       );
       delete dependencyConfig.projects;
     } else if (dependencyConfig.projects === 'dependencies') {
       warnLegacyDependsOnMagicString(
         currentProject,
-        dependencyConfig as TargetDependencyConfig & {
-          projects: 'dependencies';
-        },
+        dependencyConfig,
         location
       );
       dependencyConfig.dependencies = true;

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -42,28 +42,36 @@ export function getDependencyConfigs(
     // This is passed into `run-command` from programmatic invocations
     extraTargetDependencies[target] ??
     []
-  ).flatMap((config) =>
+  ).flatMap((config, index) =>
     normalizeDependencyConfigDefinition(
       config,
       project,
       projectGraph,
-      allTargetNames
+      allTargetNames,
+      { ownerTarget: target, index }
     )
   );
   return dependencyConfigs;
+}
+
+export interface DependsOnEntryLocation {
+  ownerTarget?: string;
+  index?: number;
 }
 
 export function normalizeDependencyConfigDefinition(
   definition: string | TargetDependencyConfig,
   currentProject: string,
   graph: ProjectGraph,
-  allTargetNames: string[]
+  allTargetNames: string[],
+  location?: DependsOnEntryLocation
 ): NormalizedTargetDependencyConfig[] {
   return expandWildcardTargetConfiguration(
     normalizeDependencyConfigProjects(
       expandDependencyConfigSyntaxSugar(definition, graph, currentProject),
       currentProject,
-      graph
+      graph,
+      location
     ),
     allTargetNames
   );
@@ -72,11 +80,13 @@ export function normalizeDependencyConfigDefinition(
 export function normalizeDependencyConfigProjects(
   dependencyConfig: TargetDependencyConfig,
   currentProject: string,
-  graph: ProjectGraph
+  graph: ProjectGraph,
+  location?: DependsOnEntryLocation
 ): NormalizedTargetDependencyConfig {
   const noStringConfig = normalizeTargetDependencyWithStringProjects(
     dependencyConfig,
-    currentProject
+    currentProject,
+    location
   );
 
   if (noStringConfig.projects) {
@@ -206,20 +216,27 @@ export function getOutputs(
 
 export function normalizeTargetDependencyWithStringProjects(
   dependencyConfig: TargetDependencyConfig,
-  currentProject?: string
+  currentProject?: string,
+  location?: DependsOnEntryLocation
 ): Omit<TargetDependencyConfig, 'projects'> & { projects: string[] } {
   if (typeof dependencyConfig.projects === 'string') {
     // TODO(v24): Remove the `self` / `dependencies` magic-string shim.
     // The v16 `update-depends-on-to-tokens` migration already rewrites
     // these to the modern shape, and `nx repair` will re-run it on demand.
     if (dependencyConfig.projects === 'self') {
-      warnLegacyDependsOnMagicString('self', currentProject, dependencyConfig);
+      warnLegacyDependsOnMagicString(
+        'self',
+        currentProject,
+        dependencyConfig,
+        location
+      );
       delete dependencyConfig.projects;
     } else if (dependencyConfig.projects === 'dependencies') {
       warnLegacyDependsOnMagicString(
         'dependencies',
         currentProject,
-        dependencyConfig
+        dependencyConfig,
+        location
       );
       dependencyConfig.dependencies = true;
       delete dependencyConfig.projects;
@@ -236,17 +253,21 @@ const warnedLegacyDependsOnMagicStrings = new Set<string>();
 function warnLegacyDependsOnMagicString(
   value: 'self' | 'dependencies',
   currentProject: string | undefined,
-  dependencyConfig: TargetDependencyConfig
+  dependencyConfig: TargetDependencyConfig,
+  location: DependsOnEntryLocation | undefined
 ): void {
-  const target = dependencyConfig.target ?? '<unknown>';
   const project = currentProject ?? '<unknown>';
-  const key = `${project}::${target}::${value}`;
+  const ownerTarget = location?.ownerTarget ?? '<unknown>';
+  const index = location?.index ?? -1;
+  const depTarget = dependencyConfig.target ?? '<unknown>';
+  const key = `${project}::${ownerTarget}::${index}::${value}`;
   if (warnedLegacyDependsOnMagicStrings.has(key)) return;
   warnedLegacyDependsOnMagicStrings.add(key);
+  const indexLabel = index >= 0 ? ` at index ${index}` : '';
   output.warn({
     title: `\`dependsOn\` entry uses the legacy \`projects: '${value}'\` value, which will be removed in Nx v24.`,
     bodyLines: [
-      `Found on project \`${project}\` in a \`dependsOn\` entry targeting \`${target}\`.`,
+      `Found on \`${project}:${ownerTarget}\` — \`dependsOn\`${indexLabel} (targeting \`${depTarget}\`).`,
       `To fix, run \`nx repair\`.`,
     ],
   });

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -74,8 +74,10 @@ export function normalizeDependencyConfigProjects(
   currentProject: string,
   graph: ProjectGraph
 ): NormalizedTargetDependencyConfig {
-  const noStringConfig =
-    normalizeTargetDependencyWithStringProjects(dependencyConfig);
+  const noStringConfig = normalizeTargetDependencyWithStringProjects(
+    dependencyConfig,
+    currentProject
+  );
 
   if (noStringConfig.projects) {
     dependencyConfig.projects = findMatchingProjects(
@@ -203,17 +205,22 @@ export function getOutputs(
 }
 
 export function normalizeTargetDependencyWithStringProjects(
-  dependencyConfig: TargetDependencyConfig
+  dependencyConfig: TargetDependencyConfig,
+  currentProject?: string
 ): Omit<TargetDependencyConfig, 'projects'> & { projects: string[] } {
   if (typeof dependencyConfig.projects === 'string') {
     // TODO(v24): Remove the `self` / `dependencies` magic-string shim.
     // The v16 `update-depends-on-to-tokens` migration already rewrites
     // these to the modern shape, and `nx repair` will re-run it on demand.
     if (dependencyConfig.projects === 'self') {
-      warnLegacyDependsOnMagicString('self');
+      warnLegacyDependsOnMagicString('self', currentProject, dependencyConfig);
       delete dependencyConfig.projects;
     } else if (dependencyConfig.projects === 'dependencies') {
-      warnLegacyDependsOnMagicString('dependencies');
+      warnLegacyDependsOnMagicString(
+        'dependencies',
+        currentProject,
+        dependencyConfig
+      );
       dependencyConfig.dependencies = true;
       delete dependencyConfig.projects;
     } else {
@@ -226,9 +233,16 @@ export function normalizeTargetDependencyWithStringProjects(
 }
 
 const warnedLegacyDependsOnMagicStrings = new Set<string>();
-function warnLegacyDependsOnMagicString(value: 'self' | 'dependencies'): void {
-  if (warnedLegacyDependsOnMagicStrings.has(value)) return;
-  warnedLegacyDependsOnMagicStrings.add(value);
+function warnLegacyDependsOnMagicString(
+  value: 'self' | 'dependencies',
+  currentProject: string | undefined,
+  dependencyConfig: TargetDependencyConfig
+): void {
+  const target = dependencyConfig.target ?? '<unknown>';
+  const project = currentProject ?? '<unknown>';
+  const key = `${project}::${target}::${value}`;
+  if (warnedLegacyDependsOnMagicStrings.has(key)) return;
+  warnedLegacyDependsOnMagicStrings.add(key);
   const replacement =
     value === 'self'
       ? 'omit the `projects` field (the current project is the default)'
@@ -236,6 +250,7 @@ function warnLegacyDependsOnMagicString(value: 'self' | 'dependencies'): void {
   output.warn({
     title: `\`dependsOn\` entry uses the legacy \`projects: '${value}'\` value, which will be removed in Nx v24.`,
     bodyLines: [
+      `Found on project \`${project}\` in a \`dependsOn\` entry targeting \`${target}\`.`,
       `To fix: ${replacement}, or run \`nx repair\` to update your configuration automatically.`,
     ],
   });

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -52,7 +52,12 @@ export function getDependencyConfigs(
       { ownerTarget: target, index, legacyViolations }
     )
   );
-  flushLegacyDependsOnViolations(project, target, legacyViolations);
+  flushLegacyDependsOnViolations(
+    project,
+    target,
+    legacyViolations,
+    projectGraph.nodes[project]?.data?.root
+  );
   return dependencyConfigs;
 }
 
@@ -292,19 +297,45 @@ function warnLegacyDependsOnMagicString(
   });
 }
 
+let cachedSourceMaps:
+  | import('../project-graph/utils/project-configuration/source-maps').ConfigurationSourceMaps
+  | null
+  | undefined = undefined;
+function getSourceMapsLazy() {
+  if (cachedSourceMaps !== undefined) return cachedSourceMaps;
+  try {
+    const { readSourceMapsCache } = require('../project-graph/nx-deps-cache');
+    cachedSourceMaps = readSourceMapsCache();
+  } catch {
+    cachedSourceMaps = null;
+  }
+  return cachedSourceMaps;
+}
+
 function flushLegacyDependsOnViolations(
   project: string,
   ownerTarget: string,
-  violations: LegacyDependsOnViolation[]
+  violations: LegacyDependsOnViolation[],
+  projectRoot: string | undefined
 ): void {
   if (violations.length === 0) return;
   const key = `${project}::${ownerTarget}`;
   if (warnedLegacyDependsOnMagicStrings.has(key)) return;
   warnedLegacyDependsOnMagicStrings.add(key);
-  const bodyLines = violations.map(
-    (v) =>
-      `  - \`dependsOn[${v.index}]\` (\`projects: '${v.value}'\`, targets \`${v.depTarget}\`)`
-  );
+  const sourceMaps = getSourceMapsLazy();
+  const projectSourceMap =
+    projectRoot && sourceMaps ? sourceMaps[projectRoot] : undefined;
+  const bodyLines = violations.map((v) => {
+    const sourceInfo =
+      projectSourceMap?.[`targets.${ownerTarget}.dependsOn.${v.index}`] ??
+      projectSourceMap?.[`targets.${ownerTarget}.dependsOn`];
+    const origin = sourceInfo
+      ? ` — set by \`${sourceInfo[1]}\`${
+          sourceInfo[0] ? ` (\`${sourceInfo[0]}\`)` : ''
+        }`
+      : '';
+    return `  - \`dependsOn[${v.index}]\` (\`projects: '${v.value}'\`, targets \`${v.depTarget}\`)${origin}`;
+  });
   bodyLines.push(`To fix, run \`nx repair\`.`);
   output.warn({
     title: `\`${project}:${ownerTarget}\` has \`dependsOn\` entries using legacy \`projects: 'self' | 'dependencies'\` values, which will be removed in Nx v24.`,

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -229,7 +229,7 @@ export function normalizeTargetDependencyWithStringProjects(
   dependencyConfig: TargetDependencyConfig,
   currentProject?: string,
   location?: DependsOnEntryLocation
-): Omit<TargetDependencyConfig, 'projects'> & { projects: string[] } {
+): Omit<TargetDependencyConfig, 'projects'> & { projects?: string[] } {
   if (typeof dependencyConfig.projects === 'string') {
     // TODO(v24): Remove the `self` / `dependencies` magic-string shim.
     // The v16 `update-depends-on-to-tokens` migration already rewrites
@@ -254,7 +254,7 @@ export function normalizeTargetDependencyWithStringProjects(
     }
   }
   return dependencyConfig as Omit<TargetDependencyConfig, 'projects'> & {
-    projects: string[];
+    projects?: string[];
   };
 }
 

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -325,22 +325,48 @@ function flushLegacyDependsOnViolations(
   const sourceMaps = getSourceMapsLazy();
   const projectSourceMap =
     projectRoot && sourceMaps ? sourceMaps[projectRoot] : undefined;
-  const bodyLines = violations.map((v) => {
+  const annotated = violations.map((v) => {
     const sourceInfo =
       projectSourceMap?.[`targets.${ownerTarget}.dependsOn.${v.index}`] ??
       projectSourceMap?.[`targets.${ownerTarget}.dependsOn`];
-    const origin = sourceInfo
-      ? ` — set by \`${sourceInfo[1]}\`${
-          sourceInfo[0] ? ` (\`${sourceInfo[0]}\`)` : ''
-        }`
+    return {
+      ...v,
+      plugin: sourceInfo?.[1],
+      file: sourceInfo?.[0] ?? undefined,
+    };
+  });
+
+  const sharedValue = annotated.every((v) => v.value === annotated[0].value)
+    ? annotated[0].value
+    : null;
+  const sharedPlugin = annotated.every((v) => v.plugin === annotated[0].plugin)
+    ? annotated[0].plugin
+    : null;
+  const sharedFile = annotated.every((v) => v.file === annotated[0].file)
+    ? annotated[0].file
+    : null;
+
+  const titleValue = sharedValue
+    ? `projects: '${sharedValue}'`
+    : `legacy projects values`;
+  const origin =
+    sharedPlugin && sharedValue
+      ? ` (set by ${sharedPlugin}${sharedFile ? ` in ${sharedFile}` : ''})`
       : '';
-    return `  - \`dependsOn[${v.index}]\` (\`projects: '${v.value}'\`, targets \`${v.depTarget}\`)${origin}`;
+  const title = `${project}:${ownerTarget} has ${annotated.length} dependsOn ${
+    annotated.length === 1 ? 'entry' : 'entries'
+  } using ${titleValue}${origin}. This will be removed in Nx v24 — run 'nx repair' to fix.`;
+
+  const bodyLines = annotated.map((v) => {
+    const valuePart = sharedValue ? '' : ` projects '${v.value}',`;
+    const perOrigin =
+      !sharedPlugin && v.plugin
+        ? ` — set by ${v.plugin}${v.file ? ` in ${v.file}` : ''}`
+        : '';
+    return `  - dependsOn[${v.index}]:${valuePart} targets '${v.depTarget}'${perOrigin}`;
   });
-  bodyLines.push(`To fix, run \`nx repair\`.`);
-  output.warn({
-    title: `\`${project}:${ownerTarget}\` has \`dependsOn\` entries using legacy \`projects: 'self' | 'dependencies'\` values, which will be removed in Nx v24.`,
-    bodyLines,
-  });
+
+  output.warn({ title, bodyLines });
 }
 
 class InvalidOutputsError extends Error {

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -358,12 +358,13 @@ function flushLegacyDependsOnViolations(
   } using ${titleValue}${origin}. This will be removed in Nx v24 — run 'nx repair' to fix.`;
 
   const bodyLines = annotated.map((v) => {
-    const valuePart = sharedValue ? '' : ` projects '${v.value}',`;
-    const perOrigin =
-      !sharedPlugin && v.plugin
-        ? ` — set by ${v.plugin}${v.file ? ` in ${v.file}` : ''}`
-        : '';
-    return `  - dependsOn[${v.index}]:${valuePart} targets '${v.depTarget}'${perOrigin}`;
+    const sourcePart = v.plugin
+      ? sharedPlugin
+        ? ''
+        : ` from ${v.plugin}${v.file ? ` in ${v.file}` : ''}`
+      : '';
+    const valuePrefix = sharedValue ? '' : `'${v.value}' — `;
+    return `  - ${valuePrefix}${v.depTarget} (dependsOn[${v.index}]${sourcePart})`;
   });
 
   output.warn({ title, bodyLines });

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -38,12 +38,12 @@ export function getDependencyConfigs(
   allTargetNames: string[]
 ): NormalizedTargetDependencyConfig[] | undefined {
   const legacyViolations: LegacyDependsOnViolation[] = [];
-  const dependencyConfigs = (
+  const dependsOnEntries =
     projectGraph.nodes[project].data?.targets[target]?.dependsOn ??
     // This is passed into `run-command` from programmatic invocations
     extraTargetDependencies[target] ??
-    []
-  ).flatMap((config, index) =>
+    [];
+  const dependencyConfigs = dependsOnEntries.flatMap((config, index) =>
     normalizeDependencyConfigDefinition(
       config,
       project,
@@ -56,7 +56,8 @@ export function getDependencyConfigs(
     project,
     target,
     legacyViolations,
-    projectGraph.nodes[project]?.data?.root
+    projectGraph.nodes[project]?.data?.root,
+    dependsOnEntries
   );
   return dependencyConfigs;
 }
@@ -65,7 +66,6 @@ interface LegacyDependsOnViolation {
   value: 'self' | 'dependencies';
   index: number;
   depTarget: string;
-  entry: TargetDependencyConfig;
 }
 
 export interface DependsOnEntryLocation {
@@ -274,13 +274,10 @@ function warnLegacyDependsOnMagicString(
   // If a collector is provided, defer — `getDependencyConfigs` emits a single
   // consolidated warning per target after all entries are processed.
   if (location?.legacyViolations) {
-    // Snapshot before the caller mutates `dependencyConfig` (deletes `projects`,
-    // sets `dependencies`) so the warning can show the original entry as authored.
     location.legacyViolations.push({
       value,
       index: location.index ?? -1,
       depTarget: dependencyConfig.target ?? '<unknown>',
-      entry: { ...dependencyConfig },
     });
     return;
   }
@@ -320,7 +317,8 @@ function flushLegacyDependsOnViolations(
   project: string,
   ownerTarget: string,
   violations: LegacyDependsOnViolation[],
-  projectRoot: string | undefined
+  projectRoot: string | undefined,
+  dependsOnEntries: ReadonlyArray<string | TargetDependencyConfig>
 ): void {
   if (violations.length === 0) return;
   const key = `${project}::${ownerTarget}`;
@@ -398,7 +396,9 @@ function flushLegacyDependsOnViolations(
         ? ''
         : ` from ${v.plugin}${v.file ? ` in ${v.file}` : ''}`
       : '';
-    return `  - ${JSON.stringify(v.entry)} (dependsOn[${v.index}]${sourcePart})`;
+    return `  - dependsOn[${v.index}] = ${JSON.stringify(
+      dependsOnEntries[v.index]
+    )}${sourcePart}`;
   });
 
   output.warn({ title, bodyLines });

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -263,12 +263,11 @@ function warnLegacyDependsOnMagicString(
   const key = `${project}::${ownerTarget}::${index}::${value}`;
   if (warnedLegacyDependsOnMagicStrings.has(key)) return;
   warnedLegacyDependsOnMagicStrings.add(key);
-  const indexLabel = index >= 0 ? ` at index ${index}` : '';
+  const indexLabel = index >= 0 ? `[${index}]` : '';
   output.warn({
-    title: `\`dependsOn\` entry uses the legacy \`projects: '${value}'\` value, which will be removed in Nx v24.`,
+    title: `\`${project}:${ownerTarget}\` \`dependsOn${indexLabel}\` uses the legacy \`projects: '${value}'\` value, which will be removed in Nx v24.`,
     bodyLines: [
-      `Found on \`${project}:${ownerTarget}\` — \`dependsOn\`${indexLabel} (targeting \`${depTarget}\`).`,
-      `To fix, run \`nx repair\`.`,
+      `The entry targets \`${depTarget}\`. To fix, run \`nx repair\`.`,
     ],
   });
 }

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -348,47 +348,47 @@ function flushLegacyDependsOnViolations(
     ? annotated[0].file
     : null;
 
-  let titleValue: string;
+  const isInternal = (p: string | undefined) => !p || p.startsWith('nx/');
+  const entryWord = annotated.length === 1 ? 'entry' : 'entries';
+  let valuePhrase: string;
   if (sharedValue) {
-    titleValue = `projects: '${sharedValue}'`;
+    valuePhrase = `projects: '${sharedValue}'`;
   } else {
     const selfCount = annotated.filter((v) => v.value === 'self').length;
     const depCount = annotated.length - selfCount;
-    titleValue = `legacy projects values (${selfCount} 'self', ${depCount} 'dependencies')`;
+    valuePhrase = `legacy projects values (${selfCount} 'self', ${depCount} 'dependencies')`;
   }
-  const origin = sharedPlugin
-    ? ` (set by ${sharedPlugin}${sharedFile ? ` in ${sharedFile}` : ''})`
-    : '';
-  // `nx repair` only rewrites hand-authored config (nx.json/project.json). For
-  // plugin-inferred entries, the user needs to upgrade the plugin.
-  const allFromCore = annotated.every(
-    (v) => !v.plugin || v.plugin.startsWith('nx/')
-  );
-  const anyFromCore = annotated.some(
-    (v) => !v.plugin || v.plugin.startsWith('nx/')
-  );
-  const offendingPlugins = Array.from(
-    new Set(
-      annotated
-        .filter((v) => v.plugin && !v.plugin.startsWith('nx/'))
-        .map((v) => v.plugin as string)
-    )
-  );
-  let advice: string;
-  if (allFromCore) {
-    advice = `run 'nx repair' to fix`;
-  } else if (anyFromCore) {
-    advice = `run 'nx repair' for hand-authored entries and upgrade ${offendingPlugins.join(
-      ', '
-    )} for plugin-inferred entries`;
+
+  let title: string;
+  if (sharedPlugin && !isInternal(sharedPlugin)) {
+    // Single external plugin inferred all offending entries — point the user
+    // at upgrading that plugin.
+    const fromFile = sharedFile ? ` from ${sharedFile}` : '';
+    title = `The ${sharedPlugin} plugin inferred ${project}:${ownerTarget} with ${annotated.length} invalid dependsOn ${entryWord} using ${valuePhrase}${fromFile}. This is deprecated and will be removed in Nx v24 — please upgrade ${sharedPlugin} to a version that doesn't emit this.`;
   } else {
-    advice = `upgrade ${offendingPlugins.join(
-      ', '
-    )} to a version that doesn't emit this`;
+    // Mixed sources, or only internal/hand-authored sources — `nx repair`
+    // handles hand-authored entries; any external plugins still need an
+    // upgrade.
+    const offendingPlugins = Array.from(
+      new Set(
+        annotated
+          .filter((v) => v.plugin && !isInternal(v.plugin))
+          .map((v) => v.plugin as string)
+      )
+    );
+    const origin = sharedPlugin
+      ? ` (set by ${sharedPlugin}${sharedFile ? ` in ${sharedFile}` : ''})`
+      : '';
+    let advice: string;
+    if (offendingPlugins.length === 0) {
+      advice = `run 'nx repair' to fix`;
+    } else {
+      advice = `run 'nx repair' for hand-authored entries and upgrade ${offendingPlugins.join(
+        ', '
+      )} for plugin-inferred entries`;
+    }
+    title = `${project}:${ownerTarget} has ${annotated.length} dependsOn ${entryWord} using ${valuePhrase}${origin}. This is deprecated and will be removed in Nx v24 — ${advice}.`;
   }
-  const title = `${project}:${ownerTarget} has ${annotated.length} dependsOn ${
-    annotated.length === 1 ? 'entry' : 'entries'
-  } using ${titleValue}${origin}. This will be removed in Nx v24 — ${advice}.`;
 
   const bodyLines = annotated.map((v) => {
     const sourcePart = v.plugin

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -396,9 +396,7 @@ function flushLegacyDependsOnViolations(
         ? ''
         : ` from ${v.plugin}${v.file ? ` in ${v.file}` : ''}`
       : '';
-    return `  - dependsOn[${v.index}] = ${JSON.stringify(
-      dependsOnEntries[v.index]
-    )}${sourcePart}`;
+    return `  - ${JSON.stringify(dependsOnEntries[v.index])} (${v.index}${sourcePart})`;
   });
 
   output.warn({ title, bodyLines });

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -266,37 +266,31 @@ export function normalizeTargetDependencyWithStringProjects(
 }
 
 const warnedLegacyDependsOnMagicStrings = new Set<string>();
+
 function warnLegacyDependsOnMagicString(
   value: 'self' | 'dependencies',
   currentProject: string | undefined,
   dependencyConfig: TargetDependencyConfig,
   location: DependsOnEntryLocation | undefined
 ): void {
-  // If a collector is provided, defer — `getDependencyConfigs` emits a single
-  // consolidated warning per target after all entries are processed.
+  const violation: LegacyDependsOnViolation = {
+    value,
+    index: location?.index ?? -1,
+    originalEntry: { ...dependencyConfig },
+  };
+  // Collector-aware caller (`getDependencyConfigs`) batches violations so the
+  // warning can group all offending entries for a single target. External
+  // callers without a collector fall through to an immediate per-entry warning.
   if (location?.legacyViolations) {
-    location.legacyViolations.push({
-      value,
-      index: location.index ?? -1,
-      originalEntry: { ...dependencyConfig },
-    });
+    location.legacyViolations.push(violation);
     return;
   }
-  // Fallback path: external callers without a collector get a per-entry warning.
-  const project = currentProject ?? '<unknown>';
-  const ownerTarget = location?.ownerTarget ?? '<unknown>';
-  const index = location?.index ?? -1;
-  const depTarget = dependencyConfig.target ?? '<unknown>';
-  const key = `${project}::${ownerTarget}::${index}::${value}`;
-  if (warnedLegacyDependsOnMagicStrings.has(key)) return;
-  warnedLegacyDependsOnMagicStrings.add(key);
-  const indexLabel = index >= 0 ? `[${index}]` : '';
-  output.warn({
-    title: `\`${project}:${ownerTarget}\` \`dependsOn${indexLabel}\` uses the legacy \`projects: '${value}'\` value, which will be removed in Nx v24.`,
-    bodyLines: [
-      `The entry targets \`${depTarget}\`. To fix, run \`nx repair\`.`,
-    ],
-  });
+  flushLegacyDependsOnViolations(
+    currentProject ?? '<unknown>',
+    location?.ownerTarget ?? '<unknown>',
+    [violation],
+    undefined
+  );
 }
 
 let cachedSourceMaps:
@@ -314,20 +308,24 @@ function getSourceMapsLazy() {
   return cachedSourceMaps;
 }
 
-function flushLegacyDependsOnViolations(
-  project: string,
+interface AnnotatedLegacyDependsOnViolation extends LegacyDependsOnViolation {
+  plugin?: string;
+  file?: string;
+}
+
+function isInternalPlugin(plugin: string | undefined): boolean {
+  return !plugin || plugin.startsWith('nx/');
+}
+
+function annotateLegacyViolations(
   ownerTarget: string,
-  violations: LegacyDependsOnViolation[],
-  projectRoot: string | undefined
-): void {
-  if (violations.length === 0) return;
-  const key = `${project}::${ownerTarget}`;
-  if (warnedLegacyDependsOnMagicStrings.has(key)) return;
-  warnedLegacyDependsOnMagicStrings.add(key);
+  projectRoot: string | undefined,
+  violations: LegacyDependsOnViolation[]
+): AnnotatedLegacyDependsOnViolation[] {
   const sourceMaps = getSourceMapsLazy();
   const projectSourceMap =
     projectRoot && sourceMaps ? sourceMaps[projectRoot] : undefined;
-  const annotated = violations.map((v) => {
+  return violations.map((v) => {
     const sourceInfo =
       projectSourceMap?.[`targets.${ownerTarget}.dependsOn.${v.index}`] ??
       projectSourceMap?.[`targets.${ownerTarget}.dependsOn`];
@@ -337,77 +335,117 @@ function flushLegacyDependsOnViolations(
       file: sourceInfo?.[0] ?? undefined,
     };
   });
+}
 
-  const sharedValue = annotated.every((v) => v.value === annotated[0].value)
-    ? annotated[0].value
-    : null;
-  const sharedPlugin = annotated.every((v) => v.plugin === annotated[0].plugin)
-    ? annotated[0].plugin
-    : null;
-  const sharedFile = annotated.every((v) => v.file === annotated[0].file)
-    ? annotated[0].file
-    : null;
+// Returns the value shared by every annotated violation, or `null` if values
+// differ. Used to collapse repeated information into the title.
+function sharedField<T, K extends keyof T>(items: T[], key: K): T[K] | null {
+  const first = items[0][key];
+  return items.every((item) => item[key] === first) ? first : null;
+}
 
-  const isInternal = (p: string | undefined) => !p || p.startsWith('nx/');
+function describeLegacyValuePhrase(
+  annotated: AnnotatedLegacyDependsOnViolation[]
+): string {
+  const sharedValue = sharedField(annotated, 'value');
+  if (sharedValue) return `projects: '${sharedValue}'`;
+  const selfCount = annotated.filter((v) => v.value === 'self').length;
+  const depCount = annotated.length - selfCount;
+  return `legacy projects values (${selfCount} 'self', ${depCount} 'dependencies')`;
+}
+
+function buildLegacyDependsOnWarning(
+  project: string,
+  ownerTarget: string,
+  annotated: AnnotatedLegacyDependsOnViolation[]
+): { title: string; suppressBody: boolean } {
+  const sharedPlugin = sharedField(annotated, 'plugin');
+  const sharedFile = sharedField(annotated, 'file');
+  const valuePhrase = describeLegacyValuePhrase(annotated);
   const entryWord = annotated.length === 1 ? 'entry' : 'entries';
-  let valuePhrase: string;
-  if (sharedValue) {
-    valuePhrase = `projects: '${sharedValue}'`;
-  } else {
-    const selfCount = annotated.filter((v) => v.value === 'self').length;
-    const depCount = annotated.length - selfCount;
-    valuePhrase = `legacy projects values (${selfCount} 'self', ${depCount} 'dependencies')`;
+  const deprecation = 'This is deprecated and will be removed in Nx v24 —';
+
+  // Single external plugin: the same plugin typically emits the same legacy
+  // value on every project it touches, so a single workspace-wide warning is
+  // more useful than one per target.
+  if (sharedPlugin && !isInternalPlugin(sharedPlugin)) {
+    return {
+      title: `The ${sharedPlugin} plugin infers dependsOn entries using ${valuePhrase}. ${deprecation} please upgrade ${sharedPlugin} to a version that doesn't emit this.`,
+      suppressBody: true,
+    };
   }
 
-  let title: string;
-  // When a single external plugin is the source, the user can't fix entries
-  // individually — only upgrading the plugin helps. Skip the per-entry body
-  // listing to avoid drowning them in noise (some plugins emit dozens).
-  let suppressBody = false;
-  if (sharedPlugin && !isInternal(sharedPlugin)) {
-    // Single external plugin inferred all offending entries — point the user
-    // at upgrading that plugin.
-    const fromFile = sharedFile ? ` from ${sharedFile}` : '';
-    title = `The ${sharedPlugin} plugin inferred ${project}:${ownerTarget} with ${annotated.length} invalid dependsOn ${entryWord} using ${valuePhrase}${fromFile}. This is deprecated and will be removed in Nx v24 — please upgrade ${sharedPlugin} to a version that doesn't emit this.`;
-    suppressBody = true;
-  } else if (sharedPlugin && isInternal(sharedPlugin) && sharedFile) {
-    // Hand-authored entries from a single config file — lead with the file.
-    title = `${sharedFile} defines ${project}:${ownerTarget} with ${annotated.length} dependsOn ${entryWord} using ${valuePhrase}. This is deprecated and will be removed in Nx v24 — run 'nx repair' to fix this.`;
-  } else {
-    // Mixed sources, or only internal/hand-authored sources — `nx repair`
-    // handles hand-authored entries; any external plugins still need an
-    // upgrade.
-    const offendingPlugins = Array.from(
-      new Set(
-        annotated
-          .filter((v) => v.plugin && !isInternal(v.plugin))
-          .map((v) => v.plugin as string)
-      )
-    );
-    const origin = sharedPlugin
-      ? ` (set by ${sharedPlugin}${sharedFile ? ` in ${sharedFile}` : ''})`
-      : '';
-    let advice: string;
-    if (offendingPlugins.length === 0) {
-      advice = `run 'nx repair' to fix`;
-    } else {
-      advice = `run 'nx repair' for hand-authored entries and upgrade ${offendingPlugins.join(
-        ', '
-      )} for plugin-inferred entries`;
-    }
-    title = `${project}:${ownerTarget} has ${annotated.length} dependsOn ${entryWord} using ${valuePhrase}${origin}. This is deprecated and will be removed in Nx v24 — ${advice}.`;
+  // Single hand-authored config file — lead with the file path.
+  if (sharedPlugin && isInternalPlugin(sharedPlugin) && sharedFile) {
+    return {
+      title: `${sharedFile} defines ${project}:${ownerTarget} with ${annotated.length} dependsOn ${entryWord} using ${valuePhrase}. ${deprecation} run 'nx repair' to fix this.`,
+      suppressBody: false,
+    };
   }
 
+  // Mixed sources, or no source-map info — tailor advice to what's offending.
+  const offendingPlugins = Array.from(
+    new Set(
+      annotated
+        .filter((v) => v.plugin && !isInternalPlugin(v.plugin))
+        .map((v) => v.plugin as string)
+    )
+  );
+  const origin = sharedPlugin
+    ? ` (set by ${sharedPlugin}${sharedFile ? ` in ${sharedFile}` : ''})`
+    : '';
+  const advice = offendingPlugins.length
+    ? `run 'nx repair' for hand-authored entries and upgrade ${offendingPlugins.join(', ')} for plugin-inferred entries`
+    : `run 'nx repair' to fix`;
+  return {
+    title: `${project}:${ownerTarget} has ${annotated.length} dependsOn ${entryWord} using ${valuePhrase}${origin}. ${deprecation} ${advice}.`,
+    suppressBody: false,
+  };
+}
+
+function formatLegacyDependsOnBodyLine(
+  v: AnnotatedLegacyDependsOnViolation,
+  sharedPlugin: string | null
+): string {
+  const showSource = v.plugin && !sharedPlugin;
+  const sourcePart = showSource
+    ? ` from ${v.plugin}${v.file ? ` in ${v.file}` : ''}`
+    : '';
+  return `  - ${JSON.stringify(v.originalEntry)} (${v.index}${sourcePart})`;
+}
+
+function flushLegacyDependsOnViolations(
+  project: string,
+  ownerTarget: string,
+  violations: LegacyDependsOnViolation[],
+  projectRoot: string | undefined
+): void {
+  if (violations.length === 0) return;
+  const annotated = annotateLegacyViolations(
+    ownerTarget,
+    projectRoot,
+    violations
+  );
+  const sharedPlugin = sharedField(annotated, 'plugin');
+  // External-plugin warnings are workspace-wide (the plugin's behavior, not a
+  // specific config): dedupe per (plugin, value) so the user sees one warning
+  // per offending plugin, not one per affected target.
+  const sharedValue = sharedField(annotated, 'value');
+  const dedupeKey =
+    sharedPlugin && !isInternalPlugin(sharedPlugin) && sharedValue
+      ? `plugin::${sharedPlugin}::${sharedValue}`
+      : `target::${project}::${ownerTarget}`;
+  if (warnedLegacyDependsOnMagicStrings.has(dedupeKey)) return;
+  warnedLegacyDependsOnMagicStrings.add(dedupeKey);
+
+  const { title, suppressBody } = buildLegacyDependsOnWarning(
+    project,
+    ownerTarget,
+    annotated
+  );
   const bodyLines = suppressBody
     ? []
-    : annotated.map((v) => {
-        const sourcePart = v.plugin
-          ? sharedPlugin
-            ? ''
-            : ` from ${v.plugin}${v.file ? ` in ${v.file}` : ''}`
-          : '';
-        return `  - ${JSON.stringify(v.originalEntry)} (${v.index}${sourcePart})`;
-      });
+    : annotated.map((v) => formatLegacyDependsOnBodyLine(v, sharedPlugin));
 
   output.warn({ title, bodyLines });
 }

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -360,11 +360,16 @@ function flushLegacyDependsOnViolations(
   }
 
   let title: string;
+  // When a single external plugin is the source, the user can't fix entries
+  // individually — only upgrading the plugin helps. Skip the per-entry body
+  // listing to avoid drowning them in noise (some plugins emit dozens).
+  let suppressBody = false;
   if (sharedPlugin && !isInternal(sharedPlugin)) {
     // Single external plugin inferred all offending entries — point the user
     // at upgrading that plugin.
     const fromFile = sharedFile ? ` from ${sharedFile}` : '';
     title = `The ${sharedPlugin} plugin inferred ${project}:${ownerTarget} with ${annotated.length} invalid dependsOn ${entryWord} using ${valuePhrase}${fromFile}. This is deprecated and will be removed in Nx v24 — please upgrade ${sharedPlugin} to a version that doesn't emit this.`;
+    suppressBody = true;
   } else if (sharedPlugin && isInternal(sharedPlugin) && sharedFile) {
     // Hand-authored entries from a single config file — lead with the file.
     title = `${sharedFile} defines ${project}:${ownerTarget} with ${annotated.length} dependsOn ${entryWord} using ${valuePhrase}. This is deprecated and will be removed in Nx v24 — run 'nx repair' to fix this.`;
@@ -393,14 +398,16 @@ function flushLegacyDependsOnViolations(
     title = `${project}:${ownerTarget} has ${annotated.length} dependsOn ${entryWord} using ${valuePhrase}${origin}. This is deprecated and will be removed in Nx v24 — ${advice}.`;
   }
 
-  const bodyLines = annotated.map((v) => {
-    const sourcePart = v.plugin
-      ? sharedPlugin
-        ? ''
-        : ` from ${v.plugin}${v.file ? ` in ${v.file}` : ''}`
-      : '';
-    return `  - ${JSON.stringify(v.originalEntry)} (${v.index}${sourcePart})`;
-  });
+  const bodyLines = suppressBody
+    ? []
+    : annotated.map((v) => {
+        const sourcePart = v.plugin
+          ? sharedPlugin
+            ? ''
+            : ` from ${v.plugin}${v.file ? ` in ${v.file}` : ''}`
+          : '';
+        return `  - ${JSON.stringify(v.originalEntry)} (${v.index}${sourcePart})`;
+      });
 
   output.warn({ title, bodyLines });
 }

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -19,7 +19,11 @@ import {
 } from '../native';
 import { isRelativePath } from '../utils/fileutils';
 import { findMatchingProjects } from '../utils/find-matching-projects';
-import { output } from '../utils/output';
+import {
+  LegacyDependsOnViolation,
+  flushLegacyDependsOnViolations,
+  warnLegacyDependsOnMagicString,
+} from './legacy-depends-on-warning';
 import { isGlobPattern } from '../utils/globs';
 import { joinPathFragments } from '../utils/path';
 import { serializeOverridesIntoCommandLine } from '../utils/serialize-overrides-into-command-line';
@@ -59,14 +63,6 @@ export function getDependencyConfigs(
     projectGraph.nodes[project]?.data?.root
   );
   return dependencyConfigs;
-}
-
-interface LegacyDependsOnViolation {
-  value: 'self' | 'dependencies';
-  index: number;
-  // Snapshot of the entry as authored, before normalization rewrites
-  // `projects` / `dependencies`. Used to display the user-facing form.
-  originalEntry: TargetDependencyConfig;
 }
 
 export interface DependsOnEntryLocation {
@@ -263,191 +259,6 @@ export function normalizeTargetDependencyWithStringProjects(
   return dependencyConfig as Omit<TargetDependencyConfig, 'projects'> & {
     projects: string[];
   };
-}
-
-const warnedLegacyDependsOnMagicStrings = new Set<string>();
-
-function warnLegacyDependsOnMagicString(
-  value: 'self' | 'dependencies',
-  currentProject: string | undefined,
-  dependencyConfig: TargetDependencyConfig,
-  location: DependsOnEntryLocation | undefined
-): void {
-  const violation: LegacyDependsOnViolation = {
-    value,
-    index: location?.index ?? -1,
-    originalEntry: { ...dependencyConfig },
-  };
-  // Collector-aware caller (`getDependencyConfigs`) batches violations so the
-  // warning can group all offending entries for a single target. External
-  // callers without a collector fall through to an immediate per-entry warning.
-  if (location?.legacyViolations) {
-    location.legacyViolations.push(violation);
-    return;
-  }
-  flushLegacyDependsOnViolations(
-    currentProject ?? '<unknown>',
-    location?.ownerTarget ?? '<unknown>',
-    [violation],
-    undefined
-  );
-}
-
-let cachedSourceMaps:
-  | import('../project-graph/utils/project-configuration/source-maps').ConfigurationSourceMaps
-  | null
-  | undefined = undefined;
-function getSourceMapsLazy() {
-  if (cachedSourceMaps !== undefined) return cachedSourceMaps;
-  try {
-    const { readSourceMapsCache } = require('../project-graph/nx-deps-cache');
-    cachedSourceMaps = readSourceMapsCache();
-  } catch {
-    cachedSourceMaps = null;
-  }
-  return cachedSourceMaps;
-}
-
-interface AnnotatedLegacyDependsOnViolation extends LegacyDependsOnViolation {
-  plugin?: string;
-  file?: string;
-}
-
-function isInternalPlugin(plugin: string | undefined): boolean {
-  return !plugin || plugin.startsWith('nx/');
-}
-
-function annotateLegacyViolations(
-  ownerTarget: string,
-  projectRoot: string | undefined,
-  violations: LegacyDependsOnViolation[]
-): AnnotatedLegacyDependsOnViolation[] {
-  const sourceMaps = getSourceMapsLazy();
-  const projectSourceMap =
-    projectRoot && sourceMaps ? sourceMaps[projectRoot] : undefined;
-  return violations.map((v) => {
-    const sourceInfo =
-      projectSourceMap?.[`targets.${ownerTarget}.dependsOn.${v.index}`] ??
-      projectSourceMap?.[`targets.${ownerTarget}.dependsOn`];
-    return {
-      ...v,
-      plugin: sourceInfo?.[1],
-      file: sourceInfo?.[0] ?? undefined,
-    };
-  });
-}
-
-// Returns the value shared by every annotated violation, or `null` if values
-// differ. Used to collapse repeated information into the title.
-function sharedField<T, K extends keyof T>(items: T[], key: K): T[K] | null {
-  const first = items[0][key];
-  return items.every((item) => item[key] === first) ? first : null;
-}
-
-function describeLegacyValuePhrase(
-  annotated: AnnotatedLegacyDependsOnViolation[]
-): string {
-  const sharedValue = sharedField(annotated, 'value');
-  if (sharedValue) return `projects: '${sharedValue}'`;
-  const selfCount = annotated.filter((v) => v.value === 'self').length;
-  const depCount = annotated.length - selfCount;
-  return `legacy projects values (${selfCount} 'self', ${depCount} 'dependencies')`;
-}
-
-function buildLegacyDependsOnWarning(
-  project: string,
-  ownerTarget: string,
-  annotated: AnnotatedLegacyDependsOnViolation[]
-): { title: string; suppressBody: boolean } {
-  const sharedPlugin = sharedField(annotated, 'plugin');
-  const sharedFile = sharedField(annotated, 'file');
-  const valuePhrase = describeLegacyValuePhrase(annotated);
-  const entryWord = annotated.length === 1 ? 'entry' : 'entries';
-  const deprecation = 'This is deprecated and will be removed in Nx v24 —';
-
-  // Single external plugin: the same plugin typically emits the same legacy
-  // value on every project it touches, so a single workspace-wide warning is
-  // more useful than one per target.
-  if (sharedPlugin && !isInternalPlugin(sharedPlugin)) {
-    return {
-      title: `The ${sharedPlugin} plugin infers dependsOn entries using ${valuePhrase}. ${deprecation} please upgrade ${sharedPlugin} to a version that doesn't emit this.`,
-      suppressBody: true,
-    };
-  }
-
-  // Single hand-authored config file — lead with the file path.
-  if (sharedPlugin && isInternalPlugin(sharedPlugin) && sharedFile) {
-    return {
-      title: `${sharedFile} defines ${project}:${ownerTarget} with ${annotated.length} dependsOn ${entryWord} using ${valuePhrase}. ${deprecation} run 'nx repair' to fix this.`,
-      suppressBody: false,
-    };
-  }
-
-  // Mixed sources, or no source-map info — tailor advice to what's offending.
-  const offendingPlugins = Array.from(
-    new Set(
-      annotated
-        .filter((v) => v.plugin && !isInternalPlugin(v.plugin))
-        .map((v) => v.plugin as string)
-    )
-  );
-  const origin = sharedPlugin
-    ? ` (set by ${sharedPlugin}${sharedFile ? ` in ${sharedFile}` : ''})`
-    : '';
-  const advice = offendingPlugins.length
-    ? `run 'nx repair' for hand-authored entries and upgrade ${offendingPlugins.join(', ')} for plugin-inferred entries`
-    : `run 'nx repair' to fix`;
-  return {
-    title: `${project}:${ownerTarget} has ${annotated.length} dependsOn ${entryWord} using ${valuePhrase}${origin}. ${deprecation} ${advice}.`,
-    suppressBody: false,
-  };
-}
-
-function formatLegacyDependsOnBodyLine(
-  v: AnnotatedLegacyDependsOnViolation,
-  sharedPlugin: string | null
-): string {
-  const showSource = v.plugin && !sharedPlugin;
-  const sourcePart = showSource
-    ? ` from ${v.plugin}${v.file ? ` in ${v.file}` : ''}`
-    : '';
-  return `  - ${JSON.stringify(v.originalEntry)} (${v.index}${sourcePart})`;
-}
-
-function flushLegacyDependsOnViolations(
-  project: string,
-  ownerTarget: string,
-  violations: LegacyDependsOnViolation[],
-  projectRoot: string | undefined
-): void {
-  if (violations.length === 0) return;
-  const annotated = annotateLegacyViolations(
-    ownerTarget,
-    projectRoot,
-    violations
-  );
-  const sharedPlugin = sharedField(annotated, 'plugin');
-  // External-plugin warnings are workspace-wide (the plugin's behavior, not a
-  // specific config): dedupe per (plugin, value) so the user sees one warning
-  // per offending plugin, not one per affected target.
-  const sharedValue = sharedField(annotated, 'value');
-  const dedupeKey =
-    sharedPlugin && !isInternalPlugin(sharedPlugin) && sharedValue
-      ? `plugin::${sharedPlugin}::${sharedValue}`
-      : `target::${project}::${ownerTarget}`;
-  if (warnedLegacyDependsOnMagicStrings.has(dedupeKey)) return;
-  warnedLegacyDependsOnMagicStrings.add(dedupeKey);
-
-  const { title, suppressBody } = buildLegacyDependsOnWarning(
-    project,
-    ownerTarget,
-    annotated
-  );
-  const bodyLines = suppressBody
-    ? []
-    : annotated.map((v) => formatLegacyDependsOnBodyLine(v, sharedPlugin));
-
-  output.warn({ title, bodyLines });
 }
 
 class InvalidOutputsError extends Error {

--- a/packages/nx/tsconfig.lib.json
+++ b/packages/nx/tsconfig.lib.json
@@ -10,6 +10,7 @@
     "composite": true,
     "module": "nodenext",
     "moduleResolution": "nodenext",
+    "customConditions": ["@nx/nx-source"],
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true
   },


### PR DESCRIPTION
## Current Behavior

#35648 dropped the compat shim in `normalizeTargetDependencyWithStringProjects` that handled the legacy `projects: 'self'` and `projects: 'dependencies'` magic strings. Without the shim, those configs fall through to `findMatchingProjects(['self'], …)` which returns `[]`, so the `dependsOn` task is **silently dropped** — no warning, no error, broken task graph.

Separately, building `packages/nx` with `nodenext` resolution triggered TS5055 ("would overwrite input file") because `@nx/key`'s `.d.ts` transitively imports `@nx/devkit` which uses a bare `nx/src/devkit-exports` specifier. The exports map fell through to dist `.d.ts`, pulling nx's own emit outputs back in as inputs.

## Expected Behavior

**Shim restored, with deprecation warning.** Legacy values keep working (`projects: 'self'` → owner project, `projects: 'dependencies'` → `{ dependencies: true }`). A `TODO(v24)` marks the shim for clean removal next major.

The warning uses the project graph source maps to attribute each offending entry to its origin, then collapses output by source:

- **Single external plugin** (e.g. `@nx/jest/plugin` emitting `'self'`): one workspace-wide warning per plugin pointing at upgrading it.
- **Single config file** (`nx.json` / `project.json` / `package.json`): one per `project:target`, lists the offending entries, advises `nx repair`.
- **Mixed**: per-target warning with tailored advice (both `nx repair` and plugin upgrade where applicable).

### How the warning is constructed

1. **Snapshot**: when normalization sees `projects: 'self'` or `'dependencies'`, `warnLegacyDependsOnMagicString` pushes a shallow-cloned violation `{ index, originalEntry }` into a per-target collector array (or fires inline if no collector).
2. **Annotate**: at flush, each violation is looked up in the project-graph source maps to get `plugin` and `file` (which plugin/config emitted that `dependsOn[i]`).
3. **Shared fields**: a local `shared()` helper returns the value every annotated item agrees on (or `null` if mixed) for `value`, `plugin`, and `file` — these drive the variant choice.
4. **Dedupe**: external-plugin warnings key on `plugin::<name>::<value>` (one per plugin workspace-wide); everything else keys on `target::<project>::<target>`. A module-level Set ensures each key fires once per process.
5. **Title + body**: one of three title templates (plugin / file / mixed) plus, unless it's the external-plugin case, one body line per entry rendered as `  - <JSON> (<index>[ from <plugin>...])`.

**`customConditions` added** to `packages/nx/tsconfig.lib.json` so nodenext resolves nx's self-referencing bare imports to source instead of dist, fixing the TS5055 cascade.

## Related Issue(s)

Partially reverts behavioral break from #35648.
