### PR TITLE
docs(nx-dev): link to @nx/owners plugin from code ownership concept page

### DIFF
--- a/astro-docs/src/content/docs/concepts/Decisions/code-ownership.mdoc
+++ b/astro-docs/src/content/docs/concepts/Decisions/code-ownership.mdoc
@@ -43,3 +43,7 @@ the `CODEOWNERS` file for that.
 
 If you want to know more about code ownership on GitHub, please
 check [the documentation on the `CODEOWNERS` file](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners).
+
+{% aside type="tip" title="Define ownership by project" %}
+Maintaining a `CODEOWNERS` file by hand means revisiting it every time a project moves or a new project is added. The [`@nx/owners` plugin](/docs/reference/owners/overview) lets you define code ownership based on projects -- using the same project matcher syntax as [`nx run-many`](/docs/reference/nx-commands#nx-run-many) -- and compiles it into a valid `CODEOWNERS` file for GitHub, Bitbucket, or GitLab.
+{% /aside %}


### PR DESCRIPTION
## Current Behavior

The [Code Ownership concept page](https://nx.dev/docs/concepts/decisions/code-ownership#defining-code-ownership) only describes the raw GitHub `CODEOWNERS` file. It never points readers to the `@nx/owners` plugin, even though that plugin's whole purpose is project-based code ownership.

## Expected Behavior

The "Defining code ownership" section now includes a tip aside linking to the [`@nx/owners` plugin overview](/docs/reference/owners/overview), explaining that the plugin lets you define ownership by project (using `nx run-many` matcher syntax) and compiles it into a valid `CODEOWNERS` file for GitHub, Bitbucket, or GitLab.

## Related Issue(s)

N/A -- follow-up to an internal discussion about cross-linking the codeowners plugin from the general ownership page.