### PR TITLE
feat(core): rename nx watch --includeDependentProjects to --includeDependencies

### DIFF
--- a/astro-docs/src/content/docs/guides/Tasks & Caching/workspace-watching.mdoc
+++ b/astro-docs/src/content/docs/guides/Tasks & Caching/workspace-watching.mdoc
@@ -155,22 +155,22 @@ To watch for specific projects and echo the changed files, run this command:
 nx watch --projects=app1,app2 -- echo \$NX_FILE_CHANGES
 ```
 
-### Watching for dependent projects
+### Watching a project and its dependencies
 
-To watch for a project and it's dependencies, run this command:
+To watch a project and the projects it depends on, run this command:
 
 ```shell
-nx watch --projects=app1 --includeDependentProjects -- echo \$NX_PROJECT_NAME
+nx watch --projects=app1 --includeDependencies -- echo \$NX_PROJECT_NAME
 ```
 
-### Rebuilding dependent projects while developing an application
+### Rebuilding an application's dependencies while developing it
 
 In a monorepo setup, your application might rely on several libraries that need to be built before they can be used in the application. While the [task pipeline](/docs/guides/tasks--caching/defining-task-pipeline) automatically handles this during builds, you'd want the same behavior during development when serving your application with a dev server.
 
-To watch and rebuild the dependent libraries of an application, use the following command:
+To watch and rebuild the libraries an application depends on, use the following command:
 
 ```shell
-nx watch --projects=my-app --includeDependentProjects -- nx run-many -t build -p \$NX_PROJECT_NAME --exclude=my-app
+nx watch --projects=my-app --includeDependencies -- nx run-many -t build -p \$NX_PROJECT_NAME --exclude=my-app
 ```
 
-`--includeDependentProjects` ensures that any changes to projects your application depends on trigger a rebuild, while `--exclude=my-app` skips rebuilding the app itself since it's already being served by the development server.
+`--includeDependencies` ensures that any changes to projects your application depends on trigger a rebuild, while `--exclude=my-app` skips rebuilding the app itself since it's already being served by the development server.

--- a/e2e/nx/src/help-output.test.ts
+++ b/e2e/nx/src/help-output.test.ts
@@ -247,7 +247,7 @@ xdescribe('--help output', () => {
       expect(output).toContain('nx watch');
       expect(output).toMatch(/watch.*changes|file.*changes/i);
       expect(output).toContain('Options:');
-      expect(output).toMatch(/--projects|--includeDependentProjects/);
+      expect(output).toMatch(/--projects|--includeDependencies/);
 
       // Should NOT be a file watcher tool
       expect(output).not.toContain('inotify');

--- a/e2e/nx/src/watch.test.ts
+++ b/e2e/nx/src/watch.test.ts
@@ -150,7 +150,7 @@ describe('Nx Watch', () => {
     });
 
     const getOutput = await runWatch(
-      `--projects=${proj3} --includeDependentProjects -- echo \\$NX_PROJECT_NAME`
+      `--projects=${proj3} --includeDependencies -- echo \\$NX_PROJECT_NAME`
     );
     await writeFileForWatcher(`libs/${proj1}/newfile.txt`, 'content');
     await writeFileForWatcher(`libs/${proj2}/newfile.txt`, 'content');

--- a/packages/js/src/executors/node/node.impl.ts
+++ b/packages/js/src/executors/node/node.impl.ts
@@ -322,7 +322,7 @@ export async function* nodeExecutor(
         additionalExitHandler = await daemonClient.registerFileWatcher(
           {
             watchProjects: [context.projectName],
-            includeDependentProjects: true,
+            includeDependencies: true,
           },
           async (err, data) => {
             if (err === 'reconnecting') {

--- a/packages/js/src/executors/tsc/lib/batch/watch.ts
+++ b/packages/js/src/executors/tsc/lib/batch/watch.ts
@@ -52,7 +52,7 @@ export async function watchTaskProjectsFileChangesForAssets(
   const unregisterFileWatcher = await daemonClient.registerFileWatcher(
     {
       watchProjects: taskInfos.map((t) => t.context.projectName),
-      includeDependentProjects: true,
+      includeDependencies: true,
       includeGlobalWorkspaceFiles: true,
     },
     (err, data) => {

--- a/packages/js/src/plugins/typescript/plugin.spec.ts
+++ b/packages/js/src/plugins/typescript/plugin.spec.ts
@@ -3627,7 +3627,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
                   ],
                 },
                 "watch-deps": {
-                  "command": "npx nx watch --projects my-lib --includeDependentProjects -- npx nx build-deps my-lib",
+                  "command": "npx nx watch --projects my-lib --includeDependencies -- npx nx build-deps my-lib",
                   "continuous": true,
                   "dependsOn": [
                     "build-deps",
@@ -3705,7 +3705,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
                   ],
                 },
                 "watch-deps": {
-                  "command": "npx nx watch --projects my-lib --includeDependentProjects -- npx nx build-deps my-lib",
+                  "command": "npx nx watch --projects my-lib --includeDependencies -- npx nx build-deps my-lib",
                   "continuous": true,
                   "dependsOn": [
                     "build-deps",
@@ -3798,7 +3798,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
                   ],
                 },
                 "watch-deps": {
-                  "command": "npx nx watch --projects my-lib --includeDependentProjects -- npx nx build-deps my-lib",
+                  "command": "npx nx watch --projects my-lib --includeDependencies -- npx nx build-deps my-lib",
                   "continuous": true,
                   "dependsOn": [
                     "build-deps",
@@ -3877,7 +3877,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
                   ],
                 },
                 "watch-deps": {
-                  "command": "npx nx watch --projects my-lib --includeDependentProjects -- npx nx build-deps my-lib",
+                  "command": "npx nx watch --projects my-lib --includeDependencies -- npx nx build-deps my-lib",
                   "continuous": true,
                   "dependsOn": [
                     "build-deps",

--- a/packages/js/src/plugins/typescript/util.ts
+++ b/packages/js/src/plugins/typescript/util.ts
@@ -53,7 +53,7 @@ export function addBuildAndWatchDepsTargets(
     targets[options.watchDepsTargetName ?? 'watch-deps'] = {
       continuous: true,
       dependsOn: [buildDepsTargetName],
-      command: `${pmc.exec} nx watch --projects ${projectName} --includeDependentProjects -- ${pmc.exec} nx ${buildDepsTargetName} ${projectName}`,
+      command: `${pmc.exec} nx watch --projects ${projectName} --includeDependencies -- ${pmc.exec} nx ${buildDepsTargetName} ${projectName}`,
     };
   }
 }

--- a/packages/next/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/next/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -76,7 +76,7 @@ exports[`@nx/next/plugin integrated projects should create nodes 1`] = `
               },
             },
             "watch-deps": {
-              "command": "npx nx watch --projects my-app --includeDependentProjects -- npx nx build-deps my-app",
+              "command": "npx nx watch --projects my-app --includeDependencies -- npx nx build-deps my-app",
               "continuous": true,
               "dependsOn": [
                 "build-deps",
@@ -166,7 +166,7 @@ exports[`@nx/next/plugin root projects should create nodes 1`] = `
               },
             },
             "watch-deps": {
-              "command": "npx nx watch --projects next --includeDependentProjects -- npx nx build-deps next",
+              "command": "npx nx watch --projects next --includeDependencies -- npx nx build-deps next",
               "continuous": true,
               "dependsOn": [
                 "build-deps",

--- a/packages/nuxt/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/nuxt/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -81,7 +81,7 @@ exports[`@nx/nuxt/plugin not root project should create nodes 1`] = `
               },
             },
             "watch-deps": {
-              "command": "npx nx watch --projects my-app --includeDependentProjects -- npx nx build-deps my-app",
+              "command": "npx nx watch --projects my-app --includeDependencies -- npx nx build-deps my-app",
               "continuous": true,
               "dependsOn": [
                 "build-deps",
@@ -176,7 +176,7 @@ exports[`@nx/nuxt/plugin root project should create nodes 1`] = `
               },
             },
             "watch-deps": {
-              "command": "npx nx watch --projects nuxt --includeDependentProjects -- npx nx build-deps nuxt",
+              "command": "npx nx watch --projects nuxt --includeDependencies -- npx nx build-deps nuxt",
               "continuous": true,
               "dependsOn": [
                 "build-deps",

--- a/packages/nx/src/command-line/examples.ts
+++ b/packages/nx/src/command-line/examples.ts
@@ -467,7 +467,7 @@ export const examples: Record<string, Example[]> = {
     },
     {
       command:
-        'watch --projects=app1,app2 --includeDependentProjects -- echo \\$NX_PROJECT_NAME',
+        'watch --projects=app1,app2 --includeDependencies -- echo \\$NX_PROJECT_NAME',
       description:
         'Watch "app1" and "app2" and echo the project name whenever a specified project or its dependencies change',
     },

--- a/packages/nx/src/command-line/watch/command-object.ts
+++ b/packages/nx/src/command-line/watch/command-object.ts
@@ -16,62 +16,90 @@ export const yargsWatchCommand: CommandModule = {
 };
 
 function withWatchOptions(yargs: Argv) {
-  return withVerbose(yargs)
-    .parserConfiguration({
-      'strip-dashed': true,
-      'populate--': true,
-    })
-    .option('projects', {
-      type: 'string',
-      alias: 'p',
-      coerce: parseCSV,
-      description: 'Projects to watch (comma/space delimited).',
-    })
-    .option('all', {
-      type: 'boolean',
-      description: 'Watch all projects.',
-    })
-    .option('includeDependentProjects', {
-      type: 'boolean',
-      description:
-        'When watching selected projects, include dependent projects as well.',
-      alias: 'd',
-    })
-    .option('includeGlobalWorkspaceFiles', {
-      type: 'boolean',
-      description:
-        'Include global workspace files that are not part of a project. For example, the root eslint, or tsconfig file.',
-      alias: 'g',
-      hidden: true,
-    })
-    .option('command', { type: 'string', hidden: true })
-    .option('verbose', {
-      type: 'boolean',
-      description:
-        'Run watch mode in verbose mode, where commands are logged before execution.',
-    })
-    .option('initialRun', {
-      type: 'boolean',
-      description: 'Run the command once before watching for changes.',
-      alias: 'i',
-      default: false,
-    })
-    .conflicts({
-      all: 'projects',
-    })
-    .check((args) => {
-      if (!args.all && !args.projects) {
-        throw Error('Please specify either --all or --projects');
-      }
+  return (
+    withVerbose(yargs)
+      .parserConfiguration({
+        'strip-dashed': true,
+        'populate--': true,
+      })
+      .option('projects', {
+        type: 'string',
+        alias: 'p',
+        coerce: parseCSV,
+        description: 'Projects to watch (comma/space delimited).',
+      })
+      .option('all', {
+        type: 'boolean',
+        description: 'Watch all projects.',
+      })
+      .option('includeDependencies', {
+        type: 'boolean',
+        description:
+          'When watching selected projects, also include the projects they depend on.',
+        alias: 'd',
+      })
+      // TODO(v24): remove the deprecated --includeDependentProjects alias
+      .option('includeDependentProjects', {
+        type: 'boolean',
+        hidden: true,
+        describe:
+          "Deprecated in favor of --includeDependencies; will be removed in Nx 24. The flag name was misleading since it includes the watched project's dependencies, not its dependents. The new flag is functionally identical.",
+      })
+      .option('includeGlobalWorkspaceFiles', {
+        type: 'boolean',
+        description:
+          'Include global workspace files that are not part of a project. For example, the root eslint, or tsconfig file.',
+        alias: 'g',
+        hidden: true,
+      })
+      .option('command', { type: 'string', hidden: true })
+      .option('verbose', {
+        type: 'boolean',
+        description:
+          'Run watch mode in verbose mode, where commands are logged before execution.',
+      })
+      .option('initialRun', {
+        type: 'boolean',
+        description: 'Run the command once before watching for changes.',
+        alias: 'i',
+        default: false,
+      })
+      .conflicts({
+        all: 'projects',
+      })
+      .check((args) => {
+        if (!args.all && !args.projects) {
+          throw Error('Please specify either --all or --projects');
+        }
 
-      return true;
-    })
-    .middleware((args) => {
-      const { '--': doubledash } = args;
-      if (doubledash && Array.isArray(doubledash)) {
-        args.command = (doubledash as string[]).join(' ');
-      } else {
-        throw Error('No command specified for watch mode.');
-      }
-    }, true);
+        return true;
+      })
+      .middleware((args) => {
+        const { '--': doubledash } = args;
+        if (doubledash && Array.isArray(doubledash)) {
+          args.command = (doubledash as string[]).join(' ');
+        } else {
+          throw Error('No command specified for watch mode.');
+        }
+
+        // --includeDependentProjects was renamed to --includeDependencies in
+        // Nx 23 because the original name was misleading: it includes the
+        // watched project's *dependencies*, not its dependents. The new flag
+        // is functionally identical — only the name changed. Map the legacy
+        // name through so existing scripts keep working during the
+        // deprecation window.
+        // TODO(v24): remove the legacy includeDependentProjects pass-through
+        const a = args as Record<string, unknown>;
+        if (
+          a.includeDependentProjects !== undefined &&
+          a.includeDependencies === undefined
+        ) {
+          a.includeDependencies = a.includeDependentProjects;
+          // eslint-disable-next-line no-console
+          console.warn(
+            "--includeDependentProjects is deprecated in favor of --includeDependencies and will be removed in Nx 24. The flag name was misleading since it includes the watched project's dependencies, not its dependents. The new flag is functionally identical."
+          );
+        }
+      }, true)
+  );
 }

--- a/packages/nx/src/command-line/watch/watch.ts
+++ b/packages/nx/src/command-line/watch/watch.ts
@@ -6,6 +6,14 @@ import { output } from '../../utils/output';
 export interface WatchArguments {
   projects?: string[];
   all?: boolean;
+  includeDependencies?: boolean;
+  /**
+   * @deprecated Renamed to {@link WatchArguments.includeDependencies}; will be
+   * removed in Nx 24. The original name was misleading: this flag includes
+   * the watched project's dependencies, not its dependents. The new property
+   * is functionally identical — only the name changed.
+   */
+  // TODO(v24): remove this property
   includeDependentProjects?: boolean;
   includeGlobalWorkspaceFiles?: boolean;
   verbose?: boolean;
@@ -207,7 +215,8 @@ export async function watch(args: WatchArguments) {
   await daemonClient.registerFileWatcher(
     {
       watchProjects: whatToWatch,
-      includeDependentProjects: args.includeDependentProjects,
+      includeDependencies:
+        args.includeDependencies ?? args.includeDependentProjects,
       includeGlobalWorkspaceFiles: args.includeGlobalWorkspaceFiles,
     },
     async (err, data) => {

--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -194,7 +194,7 @@ export class DaemonClient {
     {
       watchProjects: string[] | 'all';
       includeGlobalWorkspaceFiles?: boolean;
-      includeDependentProjects?: boolean;
+      includeDependencies?: boolean;
       allowPartialGraph?: boolean;
     }
   > = new Map();
@@ -361,7 +361,7 @@ export class DaemonClient {
     config: {
       watchProjects: string[] | 'all';
       includeGlobalWorkspaceFiles?: boolean;
-      includeDependentProjects?: boolean;
+      includeDependencies?: boolean;
       allowPartialGraph?: boolean;
     },
     callback: (

--- a/packages/nx/src/daemon/server/file-watching/file-watcher-sockets.ts
+++ b/packages/nx/src/daemon/server/file-watching/file-watcher-sockets.ts
@@ -13,7 +13,7 @@ export let registeredFileWatcherSockets: {
   config: {
     watchProjects: string[] | 'all';
     includeGlobalWorkspaceFiles: boolean;
-    includeDependentProjects: boolean;
+    includeDependencies: boolean;
   };
 }[] = [];
 
@@ -62,7 +62,7 @@ export function notifyFileWatcherSockets(
             )
           );
 
-          if (config.includeDependentProjects) {
+          if (config.includeDependencies) {
             for (const project of watchedProjects) {
               for (const dep of findAllProjectNodeDependencies(
                 project,

--- a/packages/react/src/plugins/__snapshots__/router-plugin.spec.ts.snap
+++ b/packages/react/src/plugins/__snapshots__/router-plugin.spec.ts.snap
@@ -87,7 +87,7 @@ exports[`@nx/react/react-router-plugin React Router should create nodes by defau
               },
             },
             "watch-deps": {
-              "command": "npx nx watch --projects acme --includeDependentProjects -- npx nx build-deps acme",
+              "command": "npx nx watch --projects acme --includeDependencies -- npx nx build-deps acme",
               "continuous": true,
               "dependsOn": [
                 "build-deps",
@@ -177,7 +177,7 @@ exports[`@nx/react/react-router-plugin React Router should create nodes without 
               },
             },
             "watch-deps": {
-              "command": "npx nx watch --projects acme --includeDependentProjects -- npx nx build-deps acme",
+              "command": "npx nx watch --projects acme --includeDependencies -- npx nx build-deps acme",
               "continuous": true,
               "dependsOn": [
                 "build-deps",

--- a/packages/remix/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/remix/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -96,7 +96,7 @@ exports[`@nx/remix/plugin Remix Classic Compiler non-root project should create 
               },
             },
             "watch-deps": {
-              "command": "npx nx watch --projects my-app --includeDependentProjects -- npx nx build-deps my-app",
+              "command": "npx nx watch --projects my-app --includeDependencies -- npx nx build-deps my-app",
               "continuous": true,
               "dependsOn": [
                 "build-deps",
@@ -206,7 +206,7 @@ exports[`@nx/remix/plugin Remix Classic Compiler non-root project should infer w
               },
             },
             "watch-deps": {
-              "command": "npx nx watch --projects my-app --includeDependentProjects -- npx nx build-deps my-app",
+              "command": "npx nx watch --projects my-app --includeDependencies -- npx nx build-deps my-app",
               "continuous": true,
               "dependsOn": [
                 "build-deps",
@@ -413,7 +413,7 @@ exports[`@nx/remix/plugin Remix Vite Compiler non-root project should create nod
               },
             },
             "watch-deps": {
-              "command": "npx nx watch --projects my-app --includeDependentProjects -- npx nx build-deps my-app",
+              "command": "npx nx watch --projects my-app --includeDependencies -- npx nx build-deps my-app",
               "continuous": true,
               "dependsOn": [
                 "build-deps",

--- a/packages/rollup/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/rollup/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -61,7 +61,7 @@ exports[`@nx/rollup/plugin non-root project should create nodes 1`] = `
               ],
             },
             "watch-deps": {
-              "command": "npx nx watch --projects mylib --includeDependentProjects -- npx nx build-deps mylib",
+              "command": "npx nx watch --projects mylib --includeDependencies -- npx nx build-deps mylib",
               "continuous": true,
               "dependsOn": [
                 "build-deps",
@@ -136,7 +136,7 @@ exports[`@nx/rollup/plugin non-root project should create nodes 2`] = `
               ],
             },
             "watch-deps": {
-              "command": "npx nx watch --projects mylib --includeDependentProjects -- npx nx build-deps mylib",
+              "command": "npx nx watch --projects mylib --includeDependencies -- npx nx build-deps mylib",
               "continuous": true,
               "dependsOn": [
                 "build-deps",
@@ -210,7 +210,7 @@ exports[`@nx/rollup/plugin root project should create nodes 1`] = `
               ],
             },
             "watch-deps": {
-              "command": "npx nx watch --projects mylib --includeDependentProjects -- npx nx build-deps mylib",
+              "command": "npx nx watch --projects mylib --includeDependencies -- npx nx build-deps mylib",
               "continuous": true,
               "dependsOn": [
                 "build-deps",
@@ -284,7 +284,7 @@ exports[`@nx/rollup/plugin root project should create nodes 2`] = `
               ],
             },
             "watch-deps": {
-              "command": "npx nx watch --projects mylib --includeDependentProjects -- npx nx build-deps mylib",
+              "command": "npx nx watch --projects mylib --includeDependencies -- npx nx build-deps mylib",
               "continuous": true,
               "dependsOn": [
                 "build-deps",

--- a/packages/rsbuild/src/plugins/plugin.spec.ts
+++ b/packages/rsbuild/src/plugins/plugin.spec.ts
@@ -145,7 +145,7 @@ describe('@nx/rsbuild', () => {
                     },
                   },
                   "watch-deps": {
-                    "command": "npx nx watch --projects my-app --includeDependentProjects -- npx nx build-deps my-app",
+                    "command": "npx nx watch --projects my-app --includeDependencies -- npx nx build-deps my-app",
                     "continuous": true,
                     "dependsOn": [
                       "build-deps",

--- a/packages/rspack/src/plugins/plugin.spec.ts
+++ b/packages/rspack/src/plugins/plugin.spec.ts
@@ -139,7 +139,7 @@ describe('@nx/rspack', () => {
                     },
                   },
                   "watch-deps": {
-                    "command": "npx nx watch --projects my-app --includeDependentProjects -- npx nx build-deps my-app",
+                    "command": "npx nx watch --projects my-app --includeDependencies -- npx nx build-deps my-app",
                     "continuous": true,
                     "dependsOn": [
                       "build-deps",

--- a/packages/storybook/src/plugins/plugin.spec.ts
+++ b/packages/storybook/src/plugins/plugin.spec.ts
@@ -120,7 +120,7 @@ describe('@nx/storybook/plugin', () => {
                     },
                   },
                   "watch-deps": {
-                    "command": "npx nx watch --projects my-app --includeDependentProjects -- npx nx build-deps my-app",
+                    "command": "npx nx watch --projects my-app --includeDependencies -- npx nx build-deps my-app",
                     "continuous": true,
                     "dependsOn": [
                       "build-deps",
@@ -220,7 +220,7 @@ describe('@nx/storybook/plugin', () => {
                     },
                   },
                   "watch-deps": {
-                    "command": "npx nx watch --projects my-ng-app --includeDependentProjects -- npx nx build-deps my-ng-app",
+                    "command": "npx nx watch --projects my-ng-app --includeDependencies -- npx nx build-deps my-ng-app",
                     "continuous": true,
                     "dependsOn": [
                       "build-deps",
@@ -318,7 +318,7 @@ describe('@nx/storybook/plugin', () => {
                     },
                   },
                   "watch-deps": {
-                    "command": "npx nx watch --projects my-react-lib --includeDependentProjects -- npx nx build-deps my-react-lib",
+                    "command": "npx nx watch --projects my-react-lib --includeDependencies -- npx nx build-deps my-react-lib",
                     "continuous": true,
                     "dependsOn": [
                       "build-deps",

--- a/packages/vite/src/plugins/__snapshots__/plugin.spec.ts.snap
+++ b/packages/vite/src/plugins/__snapshots__/plugin.spec.ts.snap
@@ -54,7 +54,7 @@ exports[`@nx/vite/plugin Library mode should exclude serve and preview targets w
               ],
             },
             "watch-deps": {
-              "command": "npx nx watch --projects my-lib --includeDependentProjects -- npx nx build-deps my-lib",
+              "command": "npx nx watch --projects my-lib --includeDependencies -- npx nx build-deps my-lib",
               "continuous": true,
               "dependsOn": [
                 "build-deps",
@@ -197,7 +197,7 @@ exports[`@nx/vite/plugin not root project should create nodes 1`] = `
               },
             },
             "watch-deps": {
-              "command": "npx nx watch --projects my-app --includeDependentProjects -- npx nx build-deps my-app",
+              "command": "npx nx watch --projects my-app --includeDependencies -- npx nx build-deps my-app",
               "continuous": true,
               "dependsOn": [
                 "build-deps",

--- a/packages/vite/src/plugins/plugin.spec.ts
+++ b/packages/vite/src/plugins/plugin.spec.ts
@@ -602,7 +602,7 @@ describe('@nx/vite/plugin', () => {
                       },
                     },
                     "watch-deps": {
-                      "command": "npx nx watch --projects my-lib --includeDependentProjects -- npx nx build-deps my-lib",
+                      "command": "npx nx watch --projects my-lib --includeDependencies -- npx nx build-deps my-lib",
                       "continuous": true,
                       "dependsOn": [
                         "build-deps",

--- a/packages/web/src/executors/file-server/file-server.impl.ts
+++ b/packages/web/src/executors/file-server/file-server.impl.ts
@@ -130,7 +130,7 @@ function createFileWatcher(
     {
       watchProjects: project ? [project] : 'all',
       includeGlobalWorkspaceFiles: true,
-      includeDependentProjects: true,
+      includeDependencies: true,
     },
     async (error, val) => {
       if (error === 'reconnecting') {

--- a/packages/webpack/src/plugins/plugin.spec.ts
+++ b/packages/webpack/src/plugins/plugin.spec.ts
@@ -206,7 +206,7 @@ describe('@nx/webpack/plugin', () => {
                     },
                   },
                   "watch-deps": {
-                    "command": "npx nx watch --projects my-app --includeDependentProjects -- npx nx build-deps my-app",
+                    "command": "npx nx watch --projects my-app --includeDependencies -- npx nx build-deps my-app",
                     "continuous": true,
                     "dependsOn": [
                       "build-deps",


### PR DESCRIPTION
## Current Behavior

The `nx watch` command exposes a flag called `--includeDependentProjects`. The name is misleading: despite suggesting *dependents*, the flag actually includes the watched project's *dependencies*. This has been a source of confusion for people and agents.

## Expected Behavior

The flag is renamed to `--includeDependencies` (alias `-d`). The new flag is **functionally identical** — only the name changed.

The legacy `--includeDependentProjects` flag is kept as a hidden, deprecated alias for the Nx 23 deprecation window. When used, it forwards its value through to `--includeDependencies` and prints a deprecation warning that explains the rename and confirms the new flag is functionally identical. `TODO(v24)` comments mark every back-compat code path; the alias will be removed in Nx 24.

Internal call sites that pass the flag programmatically (`@nx/js` tsc batch watcher, `@nx/js` node executor, `@nx/web` file-server) have been updated to the new name, along with the generated `watch-deps` command in the `@nx/js` typescript plugin, the `nx watch` CLI example, the workspace-watching docs page, and every plugin snapshot that asserts on the generated command.

## Related Issue(s)

N/A — internal naming cleanup ahead of Nx 24.