### PR TITLE
chore(repo): add multi-version-compliance skill

### DIFF
--- a/.claude/skills/multi-version-compliance/SKILL.md
+++ b/.claude/skills/multi-version-compliance/SKILL.md
@@ -1,0 +1,399 @@
+---
+name: multi-version-compliance
+description: >
+  Apply or review multi-version support compliance for first-party Nx
+  plugins. Primary entry point: a Linear task ID (NXC-XXXX) from the
+  "Multi-version supported across plugins" milestone — the task carries the
+  resolved support window, findings, and "Needs human decision" items. Falls
+  back to self-discovery when no task exists. Use when asked to "fix
+  multi-version compliance for @nx/X", "do NXC-XXXX", "review this
+  compliance PR", or when working on a branch / PR titled "multi-version
+  support compliance for @nx/X". Covers the canonical shape
+  (assertSupportedPackageVersion, all-generators-enforce-floor.spec.ts,
+  peer dep alignment, requires-gate auditing, user-pin preservation,
+  executor / inferred-plugin feature gating).
+argument-hint: '[<NXC-XXXX> | @nx/<plugin> | review #<PR>]'
+allowed-tools: Bash, Read, Edit, Write, Glob, Grep, Agent, mcp__linear-server__get_issue, mcp__linear-server__list_comments, mcp__linear-server__get_milestone, mcp__linear-server__list_issues
+---
+
+# Multi-version compliance for Nx plugins
+
+## What this is
+
+The `nx migrate --first-party-only` flag lets users upgrade Nx without
+dragging the managed third-party ecosystems (Angular, Cypress, Playwright,
+Jest, Vitest, ESLint, etc.) along. For that to be safe, every first-party
+plugin must keep working across its declared support window — not silently
+fall through to the latest install constants on older workspaces, not
+silently break on newer ones.
+
+**Source-of-truth split:**
+
+| Source                                                                       | Owns                                                                                                                      |
+| ---------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------- |
+| Linear milestone "Multi-version supported across plugins" (project NXC-4072) | What's wrong per plugin, the resolved support window, open human decisions. Per-plugin tasks NXC-4381..NXC-4410 (P1–P29). |
+| This skill                                                                   | How to implement the canonical shape, code-level anti-patterns, gotchas, findings doc shape (no-task case).               |
+
+The skill is the gap-closer: it accepts a Linear task, parses it, drives
+the fix. When no task exists for the plugin, fix mode runs discovery in
+Phase 1–2 and produces a findings doc that mirrors a Linear task body —
+so the user can file it as a new task before proceeding.
+
+**Reference PRs (the canonical shape):**
+
+- `#35587` — `@nx/angular` — merged. Set the precedent. Introduced
+  `throwForUnsupportedVersion`.
+- `#35642` — `@nx/playwright` — merged. Generalized the shared helpers
+  into `@nx/devkit/internal`. Established executor / runtime feature-
+  gating.
+- `#35670` — `@nx/cypress` — merged. Added `excludeGenerators` to the
+  parameterized test helper.
+- `#35671` — `@nx/vitest` — open at time of writing. Demonstrates
+  "drop phantom peer-range claim" and "declared floor < effective floor"
+  patterns.
+
+Before citing any PR by number, verify state — these go stale:
+`gh pr view <N> --repo nrwl/nx --json state`. Verify any unmerged PR's
+contents via `gh pr diff <N> --repo nrwl/nx`.
+
+## Entry points
+
+| Invocation                                            | Mode              | Behavior                                                                                                                                                                                                                            |
+| ----------------------------------------------------- | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `multi-version-compliance <NXC-XXXX>`                 | Fix (primary)     | Fetch task, surface findings + decisions in Phase 2, wait for user OK before Phase 3 edits.                                                                                                                                         |
+| `multi-version-compliance` (no arg)                   | Ask for task ID   | Prompt for NXC-XXXX.                                                                                                                                                                                                                |
+| `multi-version-compliance @nx/<plugin>` (bare plugin) | Fix (task lookup) | Look up the per-plugin task in milestone NXC-4072. If found, confirm with user and enter fix mode. If not found, run discovery in Phase 1–2 (rubric against code), present findings, suggest filing as a new task before any edits. |
+| `multi-version-compliance review #<N>`                | Review            | Fetch PR, derive Linear task from branch name if possible, compare diff vs. task findings (or run pure code-level review if no task).                                                                                               |
+
+**Stop-after-Phase-2 (audit-equivalent):** if you want findings without
+edits, decline to approve at the end of Phase 2. The skill stops, no
+branch, no commits.
+
+**On a branch matching `nxc-NNNN` with no explicit arg:** before
+asking the user, suggest "Use NXC-NNNN?" inferred from the branch name.
+
+## Linear-fetching protocol
+
+Before any code-level work in Linear-driven mode, the skill MUST:
+
+1. **Check Linear MCP availability.** If `mcp__linear-server__get_issue`
+   isn't available (MCP server not installed / not connected), tell the
+   user and fall through to the no-task discovery path (fix mode Phase 1
+   step 2). Don't pretend to fetch.
+2. **Fetch the task.** `mcp__linear-server__get_issue id="NXC-XXXX"`.
+   If the call errors (invalid ID, network), halt and ask the user to
+   verify the ID.
+3. **Verify shape.** Confirm:
+   - Title matches `[multi-version][P##] \`@nx/<plugin>\` — multi-version support compliance`(per-plugin) or`[multi-version][W#] ...` (cross-cutting). If the pattern doesn't match, halt and ask the user to confirm this is the right task.
+   - Status. `Done` → ask whether re-audit or follow-up. `Canceled` → halt and ask.
+4. **Read description sections.** Every per-plugin task has:
+   - **Plugin:** — path, upstream support, peerDep declarations, per-major install map, paired secondaries.
+   - **Needs human decision** — open items blocking implementation.
+   - **Findings** — `(high|medium|low)` items with `[file:line]` and a suggested fix per item.
+   - **Verification checklist** — Sections A (Support window declarations) / B (Generator inputs) / C (Generator outputs) / D (Migrations) / E (Runtime) / F (Out-of-window UX).
+5. **Fetch comments.** `mcp__linear-server__list_comments issueId="..."`.
+   Audits attached as files / linked uploads may carry additional
+   context.
+6. **Surface "Needs human decision" as a batch.** Restate every decision
+   item in chat. The user can resolve all, defer some, or override.
+   Block until the user has acknowledged the set — don't proceed silently.
+7. **Translate findings → code changes.** Map each finding to a canonical
+   pattern in `references/canonical-shape.md`. The Linear task's
+   suggested fix is the authoritative scope; the skill verifies it
+   conforms to the canonical shape and flags any deviation.
+8. **Run the A–F checklist** against the final code state. The task's
+   checklist is the agreed scope. The skill verifies code-level
+   conformance.
+
+**Default to the task's resolved support window.** Don't re-derive it
+from code unless the user explicitly overrides. If the user overrides:
+restate the new window and confirm before applying.
+
+**Don't expand scope beyond the task's Findings without asking.** If you
+spot a new issue mid-fix: stop, present it, ask whether to (a) add it to
+this PR, (b) defer as a follow-up, or (c) update the Linear task as a
+comment.
+
+## Mode workflows
+
+### Fix mode (primary)
+
+**Phase 1 — Read.**
+
+1. If a Linear task ID was provided, fetch it per the Linear-fetching
+   protocol. If only a plugin name was provided, look up the per-plugin
+   task in milestone NXC-4072.
+2. **No task case.** If no task exists for this plugin: run discovery
+   instead — apply the policy ladder for the support window
+   (Rule 1: upstream LTS for Angular/React/ESLint/Next/Expo; Rule 2:
+   N & N-1; widen to existing supported set if larger), inventory the
+   plugin's code against the A–F rubric, find the effective floor by
+   walking imports, classify all results as new findings. The skill is
+   producing audit-quality output for a plugin that wasn't ticketed.
+3. If on a branch matching `nxc-NNNN`, read recent commits to understand
+   prior scope decisions.
+4. Read `references/canonical-shape.md` and `references/anti-patterns.md`.
+
+**Phase 2 — Align.**
+
+5. **(task case)** Surface every "Needs human decision" item from the
+   task as a batch. Wait for resolutions.
+6. **(task case)** Restate the Findings list with severity tags. Confirm
+   scope.
+7. **(no-task case)** Surface findings discovered from the rubric
+   inventory + decisions the rubric surfaces (floor raise/drop, peer
+   declarations, optional-vs-required peer, one-sided gates, etc.).
+   Suggest filing them as a new Linear task in milestone NXC-4072
+   before proceeding to Phase 3.
+8. **User OK gate.** Wait for explicit "proceed" before Phase 3.
+   Declining stops the skill — no branch, no edits. (This is the
+   audit-equivalent.)
+
+**Phase 3 — Implement** (per `canonical-shape.md`).
+
+9. Branch from `master` if needed using the repo's `nxc-NNNN` convention.
+10. Order: any shared-helper extension lands first; plugin changes land
+    after. Commit/PR titling defers to the user's conventions.
+11. For each Finding category, apply the canonical pattern:
+    - Section A → peer ranges + version map + install constants. Every
+      third-party package the plugin **invokes at runtime** (TS import,
+      executor spawning the CLI binary, or inferred-plugin emitting a
+      target with `command: '<bin>'`) gets a peer entry. Default to
+      `optional: true` via `peerDependenciesMeta` for gated surfaces
+      (executor opt-in, inferred plugin gated on config file presence).
+      Non-optional peers are reserved for packages every workspace using
+      the plugin needs.
+    - Section B → generator entry asserts, `keepExistingVersions`,
+      fresh-install branch.
+    - Section C → templates, schema stubs with runtime throws,
+      version-map coverage.
+    - Section D → `requires` gates per package per AND-semantics; split
+      mixed entries; retain intentional pre-floor entries. **Default to
+      bilateral bounds** (`>=N <M`) when writing a cross-major gate.
+      One-sided gates (`<N` with no lower, `>=N` with no upper) need a
+      justified reason (legacy cleanup, undefined source, v0→v1 bridge)
+      — record the reason in the findings doc or as a code comment.
+    - Section E → executor and inferred-plugin feature gates.
+    - Section F → below-floor throw via shared util.
+    - **Cross-cutting:** if the fix changes runtime behavior, update any
+      in-codebase docs (`astro-docs/`, `docs/`, inline `.md`) that
+      describe the changed behavior. Docs that contradict the code are a
+      correctness bug, not a PR-body concern.
+12. If during implementation you spot something not in the task's
+    Findings: stop, surface it, ask whether to (a) add to this PR, (b)
+    defer as a follow-up, or (c) update the Linear task as a comment.
+
+**Phase 4 — Tests** (same commit as Phase 3 usually).
+
+13. Add `all-generators-enforce-floor.spec.ts` — parameterized via
+    `assertGeneratorsEnforceVersionFloor`. This exercises every
+    generator's floor assert and is the high-value spec.
+14. Footgun: assert calls must be in place in every generator BEFORE
+    running the parameterized spec, or every untouched generator fails
+    and you'll restart.
+15. Optional: a per-plugin `assert-supported-<pkg>-version.spec.ts`
+    with the 5 canonical cases. The shared `assertSupportedPackageVersion`
+    already has full coverage in devkit, so this is mostly symmetry
+    across the PR series — skip unless the user asks.
+
+**Phase 5 — Verify locally.**
+
+16. `npx nx test <plugin> --testPathPattern="all-generators-enforce-floor"`
+    (add `assert-supported-` if you added the optional wrapper spec).
+17. `npx nx test <plugin> --testPathPattern="<modified-generator>"` per
+    touched generator.
+18. `npx nx format`.
+
+**Phase 6 — Hand off.** Code changes complete. The user drives
+commit/push/PR per their own conventions (loaded globally from
+`~/.claude/memory/workflow/git/`). This skill does not enforce PR title,
+body, commit shape, or related-issues format.
+
+### Review mode
+
+1. **Fetch PR.** `gh pr view <N> --repo nrwl/nx` and
+   `gh pr diff <N> --repo nrwl/nx`. For a local branch:
+   `git diff master...HEAD`.
+2. **Derive the Linear task.** Branch name `nxc-NNNN` → `NXC-NNNN`. If
+   no match: ask the user.
+3. **Fetch the task** (if derivable). Compare diff vs. task Findings:
+   every Finding addressed; nothing extra without justification. Flag
+   scope drift.
+   **If no task and the user has none:** skip task-comparison; run pure
+   code-level review against `canonical-shape.md` and `anti-patterns.md`.
+4. **Code-level checks.** Run the "Code-level verification (review-mode
+   lens)" section of `canonical-shape.md`. Cross-reference
+   `anti-patterns.md`. For each finding, anchor at `file:line` and cite
+   which reference PR / file demonstrates the correct pattern.
+   **Scope:** code, configs, migrations, and in-codebase docs that claim
+   runtime behavior. NOT PR title / body / commit shape — those defer to
+   the user's PR conventions.
+5. **Classify each finding.**
+   - **Only two inline categories:** `[blocker]` and `[non-blocker]`. No
+     "open question," "ask," or other inline tags. Questions for the
+     author surface in the closing "Open questions for author" block,
+     drawn from non-blocker findings — list each question once.
+   - **Severity is independent of scope-drift.** A finding can be both a
+     blocker AND not in the Linear task. Flag it as a blocker in the
+     code-level section AND list it under "in PR but not in Linear task"
+     in scope drift. Don't hedge with "in this PR or follow-up?" — if
+     it's a blocker, the answer is "this PR."
+   - **Group related non-blockers.** When multiple non-blockers describe
+     symptoms of one blocker (e.g., five symptoms of a single
+     `version-utils.ts` duplication), list them as sub-bullets under
+     the blocker with "(resolved when §X is fixed)" rather than as N
+     separate top-level non-blockers.
+   - **Be terse on passes.** A section with no findings gets a single
+     summary line ("Pass — all 7 generator entries assert at first
+     statement"), not a per-file enumeration. Detail is reserved for
+     blockers and non-blockers. The reviewer's audience skims for
+     actionable items; passing checks should not eat reading budget.
+6. **Output.** Markdown checklist of blockers / non-blockers anchored at
+   `file:line`, followed by the structured verdict block from
+   `canonical-shape.md` §"Verdict template". The verdict block is the
+   skimmable index — produce it, don't substitute a free-form prose
+   summary. Do not post via `gh pr review` unless the user explicitly
+   asks.
+
+## Which references to load (context hygiene)
+
+| Mode                         | Required                                                                                    | Optional                                                                                                        |
+| ---------------------------- | ------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------------------------------- |
+| Fix                          | `canonical-shape.md`, `anti-patterns.md`                                                    | `gotchas.md` (effective floor, ecosystem lockstep, cypress inline tree), `examples.md` (when copying a pattern) |
+| Review                       | `anti-patterns.md`, `canonical-shape.md` (especially the "Code-level verification" section) | `gotchas.md` (cross-plugin coordination, lockstep), `examples.md` (when citing)                                 |
+| "What is compliance?" answer | none                                                                                        | answer from SKILL.md alone                                                                                      |
+
+References are ~100–500 lines each. Don't pull all of them just because
+you're invoked. Match the load to the mode.
+
+## Critical rules (apply in every mode)
+
+1. **Linear task is the source of truth for scope** (ratified decisions
+   and Findings).
+   - (a) Don't produce a parallel scope document. The task IS the scope.
+     Fix mode runs against the task as input — drift checks, new
+     findings, and decisions feed back to the task (via comments or as
+     deferred items), not into a competing source of truth.
+   - (b) Don't expand a fix beyond the task's Findings without
+     surfacing the new issue.
+   - (c) Don't second-guess the task's resolved support window without
+     an explicit user override.
+2. **Do not create or duplicate shared helpers.** They live in
+   `@nx/devkit/internal` (`assertSupportedPackageVersion`,
+   `getInstalledPackageVersion`, `getDeclaredPackageVersion`,
+   `throwForUnsupportedVersion`, `normalizeSemver`, `isNonSemverDistTag`)
+   and `@nx/devkit/internal-testing-utils`
+   (`assertGeneratorsEnforceVersionFloor`). Reject any local
+   re-implementation (`cleanVersion`, `getInstalled<Pkg>VersionRuntime`,
+   private `throwBelowFloor`, etc.). See `canonical-shape.md`.
+3. **Above-ceiling is silent fallthrough.** Do not warn, do not throw,
+   do not branch. Reject `throwAboveWindow`, `warnAboveCeiling`,
+   `versions()` with `switch + throw default:`. The only throw is below
+   the declared floor.
+4. **`keepExistingVersions: true` is for generators only.** Migration
+   generators (`src/migrations/`) are exempt — their job is to bump.
+   Do not flag missing flags in migration code.
+5. **Floor assert is the first statement in the function doing the
+   actual work.** Wrapper/internal split (cypress, playwright): in
+   `*Internal`. Single-function generators (angular): in the function
+   itself. Not conditional, not inside an install branch, not after a
+   tree read.
+6. **Phase 1–2 never writes, never branches.** Discovery, finding
+   classification, and decision-surfacing happen on the current branch
+   with no edits. Any working artifact (e.g., a findings doc for a
+   no-task case, multi-plugin scratch notes) goes in `tmp/` (gitignored)
+   and stays uncommitted. No `TRIAGE-REPORT.md` / `AUDIT.md` at repo
+   root. Branch creation and edits start at Phase 3, after the user OK.
+7. **PR / commit conventions are out of scope.** Title format, body shape,
+   commit-message structure, related-issues handling, push flags, etc.
+   are governed by the user's global memory (`pr-creation-shorthand.md`,
+   `push-conventions.md`, `explain-before-committing.md`,
+   `chore-not-fix-non-prod.md`). Don't enforce or flag these from this
+   skill — defer to whatever the user's conventions resolve to at PR time.
+
+## Findings doc template (Phase 2 output, used when no Linear task exists)
+
+When fix mode hits the no-task case (Phase 1 step 2), produce
+`tmp/<plugin>-findings.md` shaped to mirror a Linear task body so the
+user can file it as a new task in milestone NXC-4072 before proceeding
+to Phase 3.
+
+For plugins managing multiple primary packages, repeat the install-map
+/ decisions / findings bullets per primary.
+
+```md
+# @nx/<plugin> — multi-version support compliance findings
+
+> No Linear task in milestone NXC-4072. This doc is filing-ready —
+> create the task with this body before proceeding to fix.
+
+## Plugin
+
+- Path: packages/<plugin>
+- Upstream support: <official policy if any, else "no formal LTS">
+- peerDep declarations: <list>
+- Per-major install (`<file>` branches on installed `<package>` major):
+  - v<N-1>: <constants>
+  - v<N>: <constants> (default)
+- Paired secondaries: <list of ecosystem-locked siblings>
+
+## Needs human decision
+
+1. <decision 1 — e.g., raise floor to vN.0.0 vs keep current>
+2. <decision 2 — e.g., drop ^1.0.0 from peer (no v1 install lane)>
+
+## Findings
+
+- **(high) <one-line summary>** [file:line]
+  _Suggested fix_: <one-line>
+- **(medium) ...**
+- **(low) ...**
+
+## Verification checklist (A–F)
+
+### A. Support window declarations
+
+- [ ] peerDep ranges match the support window
+- [ ] Version map / runtime branching covers every supported major
+- [ ] Every third-party package the plugin **invokes at runtime** has a peerDep entry. "Invokes" = TS import/`require` OR executor spawns its CLI binary OR inferred plugin emits a target whose `command` invokes its CLI (look for `externalDependencies: ['<pkg>']` in emitted target inputs). Packages the generator installs for the user to consume independently (ESLint plugins loaded by the user's eslintrc, `@types/*`) don't need peer-declaration.
+- [ ] Peers needed only when a user opts into a specific surface (executor opt-in, inferred plugin gated on config file presence, opt-in preset) are declared **optional** via `peerDependenciesMeta: { "<pkg>": { "optional": true } }`. Required-non-optional peers are reserved for packages every workspace using the plugin needs.
+
+### B. Generator inputs
+
+- [ ] Generators don't overwrite installed third-party versions
+  - [ ] `addDependenciesToPackageJson` passes `keepExistingVersions=true` or branches on detected version
+- [ ] Fresh-install path installs the latest supported version
+
+### C. Generator outputs
+
+- [ ] Templates compile and run on every supported version
+- [ ] Generated `project.json` target shape valid on every major
+- [ ] Default option values valid on every major
+- [ ] Version map covers every managed third-party dep — no gaps
+- [ ] Schema accepts union of options; runtime throws when inapplicable
+
+### D. Migrations (migrations.json + packageJsonUpdates)
+
+- [ ] Cross-major `packageJsonUpdates` declare `requires` per bumped package
+- [ ] `requires` ranges are bilateral (`>=N <M`) by default. One-sided ranges (`<N` with no lower, `>=N` with no upper) are intentional (legacy cleanup, undefined source major, v0→v1 bridge) — flagged in "Needs human decision" or noted in the Findings.
+- [ ] Every migration declares `requires` against the touched package
+- [ ] Nx-only migrations have no third-party `requires`
+- [ ] No silent gap in `packageJsonUpdates` across the support window
+
+### E. Runtime
+
+- [ ] Executors branch on installed version where behavior diverges
+- [ ] Inferred plugin (createNodes/V2) parses configs across every major
+
+### F. Out-of-window UX
+
+- [ ] Below-floor: throws via shared util naming package + installed + floor; no silent fall-through
+
+## Out-of-scope (deferred follow-ups)
+
+- <e.g., consolidate ... across plugins — separate PR>
+```
+
+## References
+
+See "Which references to load" near the top. Don't pull all of them.

--- a/.claude/skills/multi-version-compliance/references/anti-patterns.md
+++ b/.claude/skills/multi-version-compliance/references/anti-patterns.md
@@ -1,0 +1,315 @@
+# Anti-patterns
+
+Patterns to reject in your own work and flag in reviews. Each entry: what it looks like, why it's wrong, what to do instead, and a reference.
+
+## 1. Local re-implementation of the shared helpers
+
+**Looks like:** A new file in the plugin defining any of:
+
+- `throwBelowFloor` / `throwAboveWindow` / `assertVersion` / `checkMinimumVersion` — duplicates `throwForUnsupportedVersion` / `assertSupportedPackageVersion`.
+- `function cleanVersion(v) { return clean(v) ?? coerce(v)?.version ?? undefined; }` — duplicates `normalizeSemver`.
+- `getInstalledRsbuildVersionRuntime` / `getInstalled<X>FromFs` reading `require('<pkg>/package.json')` directly — duplicates `getInstalledPackageVersion`.
+- Inline `clean(declared) ?? coerce(declared)` chain at a generator entry point — duplicates `getDeclaredPackageVersion`.
+
+**Why wrong:** The shared helpers in `@nx/devkit/internal` and `@nx/devkit/internal-testing-utils` already exist. Duplicates create drift — one will get the `latest`/`next` handling, the other won't; one will use `getNxRequirePaths()` for pnpm-strict resolution, the other won't.
+
+**Do instead:** Call `assertSupportedPackageVersion(tree, pkg, floor)` via the per-plugin wrapper (`assertSupportedXVersion`). For executor-side reads: `getInstalledPackageVersion(pkg)`. For tree-side normalization: `getDeclaredPackageVersion(tree, pkg, latestKnown)`. For raw semver cleaning: `normalizeSemver(v)`.
+
+**Reference:** Compliant — `packages/cypress/src/utils/assert-supported-cypress-version.ts` (7 lines). Concrete anti-pattern — PR `#35676` introduces `function cleanVersion` (`packages/rsbuild/src/utils/versions.ts`) and `getInstalledRsbuildVersionRuntime` reading `require('@rsbuild/core/package.json')`. Both should call the shared helpers instead.
+
+## 2. Above-ceiling throw or warn
+
+**Looks like:** `if (major > maxKnown) throw …`, `if (major > maxKnown) logger.warn …`, `versions()` with a `switch + throw default:`, any `warnAboveCeiling` / `throwAboveWindow` helper.
+
+**Why wrong:** Explicit policy. Above-ceiling falls through silently to `latestVersions`. Throwing breaks users on newer versions of third-party packages, which is the opposite of the initiative's intent. The angular reference implementation does not warn or branch above the highest known major, and every subsequent plugin compliance PR follows that convention.
+
+**Do instead:** `versionMap[major] ?? latestVersions`. Below-floor is caught by the generator-level assert; the `versions()` function is just a lookup.
+
+**Reference:** Compliant — `packages/cypress/src/utils/versions.ts` after `#35670` rewrite. Anti-pattern (before fix) — same file before `#35670` had `switch + throw default:`.
+
+## 3. Hardcoded third-party version in generator body
+
+**Looks like:**
+
+```ts
+addDependenciesToPackageJson(tree, {}, { rspack: '^1.1.10' });
+```
+
+in a generator.
+
+**Why wrong:** Bypasses the `versions(tree)` routing and the install-lane logic. New majors will not be picked up; older workspaces get the wrong version.
+
+**Do instead:** Route through `versions(tree)` and reference the per-major entry. If you genuinely have a version that's the same across all majors, still put it in the map for consistency.
+
+## 4. Init generator overwriting pinned versions
+
+**Looks like:** `addDependenciesToPackageJson(tree, …, …, undefined, options.keepExistingVersions)` where the schema default is `false`. Or no fifth argument at all (defaults to `false`).
+
+**Known-incomplete reference:** `@nx/angular`'s `init/schema.json` currently has `default: false` and `init.ts` passes `options.keepExistingVersions` directly — PR `#35587` did not fix this. The angular init generator therefore still has this bug. Flagging it in a non-angular compliance PR is correct; fixing it in passing during another angular PR is also appropriate.
+
+**Why wrong:** Generators bump packages = the user's pinned version is silently overwritten on re-run. Bumping is the job of migrations, not generators.
+
+**Do instead:** Pass `keepExistingVersions: true` (positional 5th arg) or `options.keepExistingVersions ?? true`. Flip the schema default to `true`.
+
+**Reference:** Compliant — `packages/cypress/src/generators/init/init.ts` and `init/schema.json` after `#35670`. Anti-pattern — the same files before `#35670` had schema default `false`.
+
+## 5. `requires` gate on an Nx-only migration
+
+**Looks like:**
+
+```json
+{
+  "update-unit-test-runner-option": {
+    "requires": { "@angular/core": ">=21.0.0" },
+    "description": "Update 'vitest' unit test runner option to 'vitest-analog' in generator defaults."
+  }
+}
+```
+
+when the migration only writes to `nx.json`.
+
+**Why wrong:** The migration applies regardless of third-party version — it's rewriting an Nx-owned generator default. The gate causes pre-v21 workspaces with the stale default to silently skip the migration and stay broken.
+
+**Do instead:** Remove the `requires` entry entirely. Nx-only migrations have no third-party gate.
+
+**Reference:** Anti-pattern (before fix) — `packages/angular/migrations.json` `update-unit-test-runner-option`. Fix — `#35587` removed the gate.
+
+## 6. Cross-major `packageJsonUpdates` with no `requires`
+
+**Looks like:**
+
+```json
+{
+  "21.3.0": {
+    "packages": {
+      "jest": { "version": "^30.0.0" }
+    }
+  }
+}
+```
+
+with no `requires` gate, when this is a v29 → v30 bump.
+
+**Why wrong:** The bump fires for every workspace — including workspaces already on v30 (idempotent best case) or workspaces on v28 or below (which would silently land on v30 without going through any v29 → v30 codemods). Source-major gate ensures the bump only fires for workspaces actually in the source range.
+
+**Do instead:**
+
+```json
+{
+  "21.3.0": {
+    "requires": { "jest": ">=29.0.0 <30.0.0" },
+    "packages": { "jest": { "version": "^30.0.0" } }
+  }
+}
+```
+
+**Reference:** Compliant — `packages/angular/migrations.json` MF entries after `#35587`. Anti-pattern examples on master at time of writing — `@nx/jest` `21.3.0`, `@nx/eslint` `20.7.0`, `@nx/vite` `20.5.0` (verify by inspecting each plugin's `migrations.json` for cross-major `packageJsonUpdates` entries lacking `requires`).
+
+## 7. Gating ecosystem-locked siblings on the primary's major alone
+
+**Looks like:** A migration that bumps `@ngrx/store` from v18 to v19 with `requires: { "@angular/core": ">=19.0.0" }` only — no `@ngrx/store` entry.
+
+**Why wrong:** `@ngrx/store` is independent of `@angular/core` versioning. A workspace can be on `@angular/core: 19` without having `@ngrx/store: 18` (might not use ngrx at all, or might be on v17). Gating on `@angular/core` fires the migration in workspaces where it has nothing to do.
+
+**Do instead:** Add the sibling to `requires`: `{ "@angular/core": ">=19.0.0", "@ngrx/store": ">=18.0.0 <19.0.0" }`. For Angular ecosystem siblings: `@angular/cli`, `@angular/ssr`, `@angular-devkit/build-angular` (v20+) are peer-locked via `@angular/core` and don't need their own gate. `@ngrx/*`, `@angular-eslint/*`, `zone.js`, `jest-preset-angular` are independent and do.
+
+**How to verify pairing:** read the sibling package's `peerDependencies` at the version range being bumped from. If it pins the primary's major, the primary's `requires` covers it. If it doesn't, the sibling is independent and needs its own gate.
+
+## 8. Peer dep claiming a major with no install branch (phantom claim)
+
+**Looks like:**
+
+```json
+{
+  "peerDependencies": {
+    "vitest": "^1.0.0 || ^2.0.0 || ^3.0.0 || ^4.0.0"
+  }
+}
+```
+
+when `versions.ts` has no v1 entry and no `isVitestV1` branch anywhere.
+
+**Why wrong:** The plugin advertises support for a version it doesn't honor. v1 workspaces silently fall through to v4 install constants.
+
+**Do instead:** Drop the unsupported major from the peer. `vitest: "^2.0.0 || ^3.0.0 || ^4.0.0"`. If the support is desired, add the install lane.
+
+**Reference:** Pattern demonstrated in open PR `#35671` (`@nx/vitest`) — drops `^1.0.0` from the `vitest` peer because there's no v1 install lane in the plugin's `versions.ts`. Inspect via `gh pr diff 35671 --repo nrwl/nx -- packages/vitest/package.json`. Verify state first.
+
+**Related — drop EOL major (different reasoning, same action):** the major HAS an install lane but is EOL upstream (e.g., Storybook's official policy is "top 3 majors only"; v7 is EOL). Drop it from the peer because it's upstream-unsupported, not because the plugin doesn't honor it. Concrete example: NXC-4406 calls out dropping Storybook v7 from `@nx/storybook`'s peer per Storybook's top-3-majors policy.
+
+## 8a. PeerDep range wider than the runtime dep pin
+
+**Looks like:**
+
+```json
+{
+  "peerDependencies": {
+    "@typescript-eslint/parser": "^6.0.0 || ^7.0.0 || ^8.0.0"
+  },
+  "dependencies": {
+    "@typescript-eslint/parser": "^8.0.0"
+  }
+}
+```
+
+The plugin's own runtime dep pins ^8, but the peer claims ^6/^7/^8.
+
+**Why wrong:** Distinct from §8 — here the install lane exists (in `dependencies`), but the lane only ships one major. The peer is over-promising relative to what the plugin actually runs against. A workspace on ^6 will satisfy the peer but won't get a compatible runtime once `@typescript-eslint/parser@^8` resolves.
+
+**Do instead:** Tighten the peer to the actually-supported runtime range, or widen the runtime dep + add the install/branch lanes for the additional majors.
+
+**Reference:** NXC-4388 (`@nx/eslint-plugin`).
+
+## 9. Top-level `require()` of an optional peer in an executor
+
+**Looks like:**
+
+```ts
+// at the top of executor.impl.ts
+const cypress = require('cypress');
+```
+
+**Why wrong:** When cypress is absent (not yet installed, peer mismatch, etc.), the executor throws `MODULE_NOT_FOUND` at module load time, before any user-friendly error. Especially bad for deprecated executors that should fail with a deprecation message.
+
+**Do instead:** `require` inside the function body, after the version detection / clear error.
+
+## 10. Anything-but-`requires` as substitute for `requires`
+
+**Looks like (variant A — `incompatibleWith` standing in):**
+
+```json
+{
+  "21.0.0-source-bump": {
+    "incompatibleWith": { "@angular-devkit/build-angular": "<21.0.0" },
+    "packages": { "...": { "version": "..." } }
+  }
+}
+```
+
+to "gate" a bump to v21+ source workspaces.
+
+**Looks like (variant B — runtime per-package guard):**
+
+```ts
+// inside the migration function body
+const installed = getInstalledVersion('@typescript-eslint/parser');
+if (gte(installed, '8.0.0') && lt(installed, '8.13.0')) {
+  // run the migration
+}
+return; // otherwise skip
+```
+
+with no `requires` block on the migration entry in `migrations.json`.
+
+**Why wrong:** Neither approach is a source-major gate.
+
+- `incompatibleWith` blocks running on workspaces that have the matching version — it doesn't gate to a source-major range. A workspace on `@angular-devkit/build-angular: 22.0.0` will still pass the `incompatibleWith` check.
+- A runtime per-package guard runs the migration _body_ on every workspace and skips internally. The migration record still appears as "executed" to the migrate runner, and any side effects (logging, partial work) leak. The `nx migrate` runner uses `requires` as the source-major filter; bypassing it means the migration isn't filtered at the right layer.
+
+**Do instead:** `requires: { "<pkg>": ">=N.0.0 <(N+1).0.0" }` — the actual source-major gate at the migration-entry level. Drop the in-body guard once the `requires` is in place.
+
+**Reference:** Anti-pattern (variant B) — `@nx/eslint` `update-typescript-eslint-v8.13.0` (NXC-4387) has runtime `gte('8.0.0') + lt('8.13.0')` per-package guards but no `requires` block. `@nx/jest` similar with `incompatibleWith` (NXC-4391).
+
+## 11. Naming a specific plugin in shared helper docstrings
+
+**Looks like:** A JSDoc in `assert-generators-enforce-version-floor.ts` referencing `migrate-to-cypress-11` as the example use case for `excludeGenerators`.
+
+**Why wrong:** The helper is shared across plugins. Naming one plugin in its docstring is leaky.
+
+**Do instead:** Generic phrasing — "generators that must run below the floor by design (e.g., migrators that lift sub-floor workspaces onto a supported version)".
+
+**Reference:** an early draft of `#35670`'s test helper had the plugin-specific JSDoc; the merged version uses generic phrasing.
+
+## 12. Both schema `"default": true` AND `options.keepExistingVersions ?? true`
+
+**Looks like:**
+
+```json
+{ "keepExistingVersions": { "default": true } }
+```
+
+combined with
+
+```ts
+addDependenciesToPackageJson(tree, …, …, undefined, options.keepExistingVersions ?? true);
+```
+
+**Why wrong:** Two sources of truth. Either the schema default does the job (and `options.keepExistingVersions` will always be `true`) or the `?? true` fallback handles it (and the schema default is redundant).
+
+**Do instead:** Pick one. Schema default is sufficient when the call site uses `options.keepExistingVersions` directly. The `?? true` fallback is only needed if the schema can be bypassed (programmatic invocation without schema validation).
+
+## 13. Manual `RegExp` matching in tests instead of substring `toThrow`
+
+**Looks like:**
+
+```ts
+.rejects.toThrow(new RegExp(`Unsupported version of \\\`${packageName}\\\` detected`));
+```
+
+**Why wrong:** Escape bugs. The backtick and the `${}` are easy to get wrong. The shared helper uses substring matching for a reason.
+
+**Do instead:**
+
+```ts
+.rejects.toThrow(`Unsupported version of \`${packageName}\` detected`);
+```
+
+**Reference:** see how `assertGeneratorsEnforceVersionFloor` itself does the match in `packages/nx/src/internal-testing-utils/assert-generators-enforce-version-floor.ts` (grep for `Unsupported version of`).
+
+## 14. Validating only at install sites instead of generator entry
+
+**Looks like:** A `if (installedVersion < floor) throw …` check guarding only the `addDependenciesToPackageJson` call inside a generator, while the rest of the generator runs unconditionally.
+
+**Why wrong:** The generator may write configuration or templates incompatible with the sub-floor third-party version before reaching the install branch. The assert must be at the entry point so nothing else runs.
+
+**Do instead:** `assertSupportedXVersion(tree)` as the first statement in the generator's working function (`*Internal` for plugins with the wrapper/internal split; the function itself for single-function generators). The install branch can then assume the floor is met.
+
+## 15. Per-major version aliases alongside the bundle map
+
+**Looks like:**
+
+```ts
+export const vitestV4Version = '~4.1.0';
+export const vitestV3Version = '^3.0.0';
+export const vitestV2Version = '^2.1.8';
+export const vitestVersion = vitestV4Version;
+
+export const vitestV4CoverageV8Version = '~4.1.0';
+export const vitestV3CoverageV8Version = '^3.0.5';
+// ...etc
+
+const versionMap = {
+  3: { vitestVersion: '^3.0.0', vitestCoverageV8Version: '^3.0.5' },
+  4: { vitestVersion: '~4.1.0', vitestCoverageV8Version: '~4.1.0' },
+};
+```
+
+**Why wrong:** The aliases (`vitestV3Version`, `vitestV3CoverageV8Version`, etc.) duplicate the `versionMap` entries. They drift over time — someone bumps the map but forgets the alias (or vice versa), and the plugin starts installing one version via generators and another via tests/runtime. Also: every dropped major (e.g., when raising the floor) becomes three or four delete lines instead of one map entry.
+
+**Do instead:** Keep the bundle pattern — the per-major `versionMap` is the only place those values live. Stable (cross-version-identical) deps stay as top-level `export const`s; varying deps are accessed via `versions(tree).<key>` or directly from the top-level `latestVersions` bundle.
+
+**Reference:** Open PR `#35671` initially carried `vitestV2Version` / `vitestV3Version` / `vitestV4Version` aliases. A follow-up commit (`chore(testing): adopt cypress version-resolution pattern in @nx/vitest`) dropped them in favor of the bundle pattern. Inspect via `gh pr view 35671 --repo nrwl/nx --json commits`.
+
+## 16. Declared floor below the effective floor
+
+**Looks like:** `peerDependencies` lists `"vitest": "^2.0.0 || ^3.0.0 || ^4.0.0"` and `versions.ts` has a `versionMap` entry for `2`, but somewhere in the plugin's executor / runtime / plugin code there's an import of a third-party API that only exists in v3+:
+
+```ts
+// In a runtime helper used by the executor:
+import { getRelevantTestSpecifications } from 'vitest/node';
+// ^ This API only exists in vitest >= 3.0.0.
+```
+
+**Why wrong:** A workspace on v2 will pass the floor assert (peer + versionMap claim support), then crash at runtime with `getRelevantTestSpecifications is not a function`. The peer is lying.
+
+**Do instead:** Raise the floor to the lowest major where every called third-party API exists. Drop the now-unsupported entries from `versionMap`, `peerDependencies`, and the per-major version aliases (if any). The `assert-supported-<pkg>-version.spec.ts` sub-floor test now covers the dropped major.
+
+**Reference:** Open PR `#35671`'s second commit (`fix(testing): drop vitest v2 support from @nx/vitest`) — originally proposed a v2 floor matching the lowest install lane, then raised to v3 after audit caught the `getRelevantTestSpecifications` usage. Inspect via `gh pr view 35671 --repo nrwl/nx --json commits`.
+
+## 17. Creating a branch during Phase 1–2 (discovery / read-only)
+
+**Looks like:** `git checkout -b <some-branch>` before the user has approved Phase 3 edits.
+
+**Why wrong:** Phase 1–2 produces findings, not commits. Creating a branch creates pressure to commit something. Any working artifact (e.g., `tmp/<plugin>-findings.md` for the no-task case) goes in `tmp/` (gitignored) — for the user to read and scope from, not to commit.
+
+**Do instead:** Run Phase 1–2 on the current branch (typically `master`). Output to `tmp/<plugin>-findings.md` if you wrote one. Branch creation belongs in Phase 3, after explicit user approval to proceed with edits.

--- a/.claude/skills/multi-version-compliance/references/canonical-shape.md
+++ b/.claude/skills/multi-version-compliance/references/canonical-shape.md
@@ -1,0 +1,646 @@
+# Canonical shape
+
+What a compliant plugin looks like. Don't deviate without a documented reason.
+
+The first half of this file ("How to write") describes the canonical structure
+you produce in fix mode. The tail section ("Code-level verification") is the
+review-mode lens — markers to look for in a diff.
+
+## Shared helpers (already merged — use, don't duplicate)
+
+### `@nx/devkit/internal`
+
+Source: `packages/devkit/src/utils/version-floor.ts` and `packages/devkit/src/utils/installed-version.ts`.
+
+```ts
+// version-floor.ts
+function throwForUnsupportedVersion(
+  packageName: string,
+  installedVersion: string,
+  floor: string
+): never;
+
+function assertSupportedPackageVersion(
+  tree: Tree,
+  packageName: string,
+  minSupportedVersion: string
+): void;
+```
+
+```ts
+// installed-version.ts
+function getInstalledPackageVersion(packageName: string): string | null;
+
+function getDeclaredPackageVersion(
+  tree: Tree,
+  packageName: string,
+  latestKnownVersion?: string
+): string | null;
+
+const NON_SEMVER_DIST_TAGS = ['latest', 'next'] as const;
+function isNonSemverDistTag(version: string): version is NonSemverDistTag;
+function normalizeSemver(version: string): string | null;
+```
+
+When to use which:
+
+| Context                          | Function                                                                            |
+| -------------------------------- | ----------------------------------------------------------------------------------- |
+| Generator entry (assert floor)   | `assertSupportedPackageVersion(tree, pkg, floor)`                                   |
+| Generator-time version branching | `getDeclaredPackageVersion(tree, pkg, latestKnownVersion)`                          |
+| Executor / runtime / preset      | `getInstalledPackageVersion(pkg)`                                                   |
+| Anywhere                         | `isNonSemverDistTag`, `normalizeSemver`                                             |
+| Never                            | `throwForUnsupportedVersion` directly — it's an implementation detail of the assert |
+
+### `@nx/devkit/internal-testing-utils`
+
+Source: `packages/nx/src/internal-testing-utils/assert-generators-enforce-version-floor.ts`.
+
+```ts
+function assertGeneratorsEnforceVersionFloor(options: {
+  packageRoot: string;
+  packageName: string;
+  subFloorVersion: string;
+  excludeGenerators?: string[];
+}): void;
+```
+
+Behavior: reads `generators.json` from `packageRoot`, iterates every entry, loads its factory, calls it against a tree with `{ [packageName]: subFloorVersion }` in `package.json`, expects a throw matching `Unsupported version of \`${packageName}\` detected`.
+
+`excludeGenerators` is only for intentional sub-floor migrators (e.g., `migrate-to-cypress-11`). Comment the reason next to the array.
+
+## Finding the existing floor (audit input)
+
+When auditing a plugin you haven't touched before, the floor may not be declared in one place. Check, in order of authority:
+
+1. **`minSupported<Pkg>Version` constant in `versions.ts`** — if it exists, that's the declared floor.
+2. **`peerDependencies` lowest range in `package.json`** — what the plugin advertises supporting.
+3. **Lowest major in `versionMap` / `backwardCompatibleVersions` / `supportedVersions`** — what the plugin has install lanes for.
+4. **Lowest `packageJsonUpdates` entry that touches the third-party package** — historical evidence of the supported range.
+5. **Highest API requirement in the plugin's own code (the _effective_ floor).** Grep for every `import` / `require` from the third-party package and identify which APIs are called. Cross-reference each against the third-party's changelog. The plugin's effective floor is the lowest major where **all** called APIs exist. **This trumps the declared floor** — if `versions.ts` claims v2 but the plugin imports an API only available in v3+, the declared floor is wrong.
+
+These should agree. When they don't, the disagreement is the finding (phantom peer claim, drifted versionMap, declared floor below effective floor).
+
+**Worked example:** During open PR `#35671`, the audit initially landed on a `v2.0.0` floor (matching the lowest install lane). Then a follow-up commit dropped the floor to `v3.0.0` after noticing the plugin's atomization code calls `getRelevantTestSpecifications`, which is a vitest v3+ API. Lesson: step 5 above is not optional. Always check what APIs the plugin's own runtime code uses — `versions()` having a v2 lane doesn't mean the plugin actually works on v2.
+
+## The plugin wrapper (one per plugin)
+
+Path: `packages/<plugin>/src/utils/assert-supported-<pkg>-version.ts`.
+
+Two canonical shapes:
+
+### Single-major floor (most plugins)
+
+```ts
+import { type Tree } from '@nx/devkit';
+import { assertSupportedPackageVersion } from '@nx/devkit/internal';
+import { minSupportedCypressVersion } from './versions';
+
+export function assertSupportedCypressVersion(tree: Tree): void {
+  assertSupportedPackageVersion(tree, 'cypress', minSupportedCypressVersion);
+}
+```
+
+Reference: `packages/cypress/src/utils/assert-supported-cypress-version.ts`, `packages/playwright/src/utils/assert-supported-playwright-version.ts`.
+
+### Floor derived from supported-versions list (angular)
+
+```ts
+import { type Tree } from '@nx/devkit';
+import { assertSupportedPackageVersion } from '@nx/devkit/internal';
+import { supportedVersions } from './backward-compatible-versions';
+
+const minSupportedAngularMajor = Math.min(...supportedVersions);
+
+export function assertSupportedAngularVersion(tree: Tree): void {
+  assertSupportedPackageVersion(
+    tree,
+    '@angular/core',
+    `${minSupportedAngularMajor}.0.0`
+  );
+}
+```
+
+Reference: `packages/angular/src/utils/assert-supported-angular-version.ts`.
+
+Pick the shape that matches whether the plugin already has a `supportedVersions` list (angular does; cypress/playwright/vitest don't).
+
+### Plugins managing multiple primary packages
+
+`@nx/jest` manages `jest`, `ts-jest`, `@types/jest`. `@nx/eslint` manages `eslint`, `@typescript-eslint/parser`, `@typescript-eslint/eslint-plugin`, `eslint-config-prettier`. The canonical wrapper signature takes one package; with multiple, decisions are needed:
+
+- **Gate on the primary only** when the others are peer-locked (e.g., angular's strategy with `@angular/core` covering `@angular/cli`, `@angular/ssr`, etc.). This is sufficient when the siblings' peer-deps tie them to the primary's major.
+- **Gate on each independently** when the siblings can be installed at any major regardless of the primary (typescript-eslint pair vs eslint; ts-jest vs jest). In that case, the wrapper makes multiple `assertSupportedPackageVersion` calls in sequence:
+
+```ts
+export function assertSupportedJestVersion(tree: Tree): void {
+  assertSupportedPackageVersion(tree, 'jest', minSupportedJestVersion);
+  // ts-jest is independent — declare and assert it separately.
+  assertSupportedPackageVersion(tree, 'ts-jest', minSupportedTsJestVersion);
+}
+```
+
+When in doubt: read each sibling's `peerDependencies` block at the version range being supported. If it pins the primary, it's covered by the primary's gate. If it doesn't (or pins something else), it needs its own.
+
+## Skip writing the install constant when the package is already detected
+
+Init generators that add the third-party package to `package.json` should NOT overwrite an already-installed minor/patch. The `keepExistingVersions: true` flag handles this at the `addDependenciesToPackageJson` level. But for code paths that compute the version to write (e.g., picking the major-specific value from `versionMap`), the rule is the same: read what's installed first; only write the fresh-install constant when nothing is detected.
+
+Reference: `packages/cypress/src/generators/init/init.ts` `updateDependencies` — calls `getInstalledCypressVersion(tree)` first, then routes through `versions(tree)` which short-circuits to existing-version paths. The `keepExistingVersions ?? true` flag at the `addDependenciesToPackageJson` call site is the final safety net.
+
+## The versions module
+
+Path: `packages/<plugin>/src/utils/versions.ts`.
+
+### Required exports
+
+```ts
+// Plain string, no caret. Used as the floor for assertSupportedPackageVersion.
+export const minSupportedCypressVersion = '13.0.0';
+
+// Fresh-install constants — may be HIGHER than minSupported when the feature
+// surface at the floor is incomplete. Playwright peer is ^1.36.0 but
+// fresh-install is ^1.37.0 so blob reporter + merge-reports work out of the
+// box.
+export const playwrightVersion = '^1.37.0';
+
+// Optional: feature-gate thresholds for runtime/executor code.
+export const minPlaywrightVersionForBlobReports = '1.37.0';
+```
+
+### Stable deps stay top-level; per-major-varying deps go in the bundle
+
+A plugin typically manages one primary package whose version map drives several siblings. Deps that vary per major go into a typed bundle; deps that are version-stable stay as plain `export const`s.
+
+```ts
+// Stable across all supported majors of the primary → plain exports.
+export const viteVersion = '^8.0.0';
+export const jsdomVersion = '^27.1.0';
+export const vitePluginReactVersion = '^6.0.0';
+
+// Vary with the primary's major → bundle.
+export const vitestVersion = '~4.1.0';
+export const vitestCoverageV8Version = '~4.1.0';
+export const vitestCoverageIstanbulVersion = '~4.1.0';
+
+type VitestVersions = {
+  vitestVersion: string;
+  vitestCoverageV8Version: string;
+  vitestCoverageIstanbulVersion: string;
+};
+
+// latestVersions reuses the top-level exports so import { vitestVersion }
+// stays valid for the fresh-install path while versions(tree).vitestVersion
+// is the route-aware version.
+const latestVersions: VitestVersions = {
+  vitestVersion,
+  vitestCoverageV8Version,
+  vitestCoverageIstanbulVersion,
+};
+
+type CompatVersions = 3;
+const versionMap: Record<CompatVersions, VitestVersions> = {
+  3: {
+    vitestVersion: '^3.0.0',
+    vitestCoverageV8Version: '^3.0.5',
+    vitestCoverageIstanbulVersion: '^3.0.5',
+  },
+};
+```
+
+**Do not** keep per-major aliases like `vitestV3Version = '^3.0.0'` alongside the bundle — they duplicate the map entries and drift over time. See `anti-patterns.md` §15.
+
+### The `versions(tree)` function
+
+Falls through to latest on unknown majors — no `switch + throw default:`.
+
+```ts
+export function versions(tree: Tree): VitestVersions {
+  const installedVitestVersion = getInstalledVitestVersion(tree);
+  if (!installedVitestVersion) {
+    return latestVersions;
+  }
+  const vitestMajorVersion = major(installedVitestVersion);
+  return versionMap[vitestMajorVersion as CompatVersions] ?? latestVersions;
+}
+```
+
+### The `getInstalled<Pkg>Version(tree?)` helper
+
+Optional `tree` parameter — with tree, reads declared from `package.json` (normalizing `latest`/`next` to the fresh-install constant); without tree, routes through the shared `getInstalledPackageVersion` from `@nx/devkit/internal` (FS resolution via `getNxRequirePaths()`).
+
+```ts
+export function getInstalledVitestVersion(tree?: Tree): string | null {
+  if (!tree) {
+    return getInstalledPackageVersion('vitest');
+  }
+
+  const installedVersion = getDependencyVersionFromPackageJson(tree, 'vitest');
+  if (!installedVersion) {
+    return null;
+  }
+  if (installedVersion === 'latest' || installedVersion === 'next') {
+    return clean(vitestVersion) ?? coerce(vitestVersion)?.version ?? null;
+  }
+  return clean(installedVersion) ?? coerce(installedVersion)?.version ?? null;
+}
+
+export function getInstalledVitestMajorVersion(tree?: Tree): number | null {
+  const installedVitestVersion = getInstalledVitestVersion(tree);
+  return installedVitestVersion ? major(installedVitestVersion) : null;
+}
+```
+
+This is the cypress/playwright/vitest pattern. Reference: `packages/cypress/src/utils/versions.ts`.
+
+## Generator entry points
+
+The assert goes in the function that does the actual work — first statement of the function body, before any other tree access or sub-generator call. (The assert itself reads the tree, of course; the rule is that nothing else in the generator runs against an unsupported version.)
+
+### Plugins with a `<gen>` / `<gen>Internal` split (cypress, playwright)
+
+The public wrapper merges defaults and delegates. Assert lives in `*Internal`:
+
+```ts
+// Public wrapper — no assert, just default merging.
+export async function cypressInitGenerator(tree: Tree, options: Schema) {
+  return cypressInitGeneratorInternal(tree, { addPlugin: false, ...options });
+}
+
+// Working function — assert is the first statement.
+export async function cypressInitGeneratorInternal(
+  tree: Tree,
+  options: Schema
+) {
+  assertSupportedCypressVersion(tree);
+
+  updateProductionFileset(tree);
+  // ...
+}
+```
+
+Reference: `packages/cypress/src/generators/init/init.ts`, `packages/playwright/src/generators/init/init.ts`.
+
+### Plugins with a single-function generator (angular)
+
+No wrapper/internal split. The function itself asserts:
+
+```ts
+export async function angularInitGenerator(tree: Tree, options: Schema) {
+  assertSupportedAngularVersion(tree);
+  // ...
+}
+```
+
+Reference: `packages/angular/src/generators/init/init.ts`.
+
+### Double-asserts are established convention, not an edge case
+
+When `configurationGenerator` calls `initGenerator` internally, both call their respective `assertSupportedXVersion`. This is the angular precedent (29 `generators.json` entries → 58 assert call sites). The assert is idempotent (one tree read + one semver comparison) and the parameterized floor spec treats every entry point as independent — both must throw on sub-floor. Don't refactor away.
+
+## User-pin preservation
+
+### `addDependenciesToPackageJson` call sites
+
+Every call from a generator (NOT a migration) must pass `keepExistingVersions: true` as the fifth positional argument or via the `?? true` pattern.
+
+```ts
+// Pattern A — explicit at the call site
+addDependenciesToPackageJson(
+  tree,
+  {},
+  { 'eslint-plugin-cypress': pkgVersions.eslintPluginCypressVersion },
+  undefined,
+  true
+);
+
+// Pattern B — driven by schema (init generators only)
+addDependenciesToPackageJson(
+  tree,
+  {},
+  devDependencies,
+  undefined,
+  options.keepExistingVersions ?? true
+);
+```
+
+Reference: `packages/cypress/src/generators/init/init.ts`, `packages/cypress/src/utils/add-linter.ts`, `packages/angular/src/generators/add-linting/lib/add-angular-eslint-dependencies.ts`.
+
+### init schema
+
+```json
+{
+  "keepExistingVersions": {
+    "type": "boolean",
+    "x-priority": "internal",
+    "description": "Keep existing dependencies versions",
+    "default": true
+  }
+}
+```
+
+Reference (on master): `packages/cypress/src/generators/init/schema.json`, `packages/playwright/src/generators/init/schema.json`. (`@nx/vitest` follows the same pattern in its open PR — verify via `gh pr diff 35671`.)
+
+## Migrations.json gates
+
+Three categories of migration:
+
+| Category                         | Touches                                           | `requires`                                                                  |
+| -------------------------------- | ------------------------------------------------- | --------------------------------------------------------------------------- |
+| Nx-only                          | `nx.json`, executor options, generator defaults   | none                                                                        |
+| Codemod                          | source files / config tied to a third-party major | `{ "<pkg>": ">=N <N+1" }` (or open upper bound for legacy-cleanup codemods) |
+| `packageJsonUpdates` cross-major | bumps `<pkg>` from major N to N+1                 | `{ "<pkg>": ">=N.0.0 <(N+1).0.0" }` (source-major gate)                     |
+| `packageJsonUpdates` same-major  | bumps minor/patch                                 | none required                                                               |
+
+### Sibling packages
+
+Ecosystem-locked siblings whose peer-on-the-primary covers them: no separate `requires`. Examples in Angular: `@angular/cli`, `@angular/ssr`, `@angular-devkit/build-angular` (from v20+, NOT v19).
+
+Independent siblings: each needs its own `requires` entry. Examples in Angular: `@ngrx/*`, `@angular-eslint/*`, `zone.js`, `jest-preset-angular`.
+
+### Reference examples
+
+- `packages/angular/migrations.json` `20.2.0-module-federation`, `22.2.0`, `22.6.0-module-federation` — Module Federation entries gating on `@module-federation/enhanced` source range. Added in `#35587`.
+- `@nx/vitest`'s `update-22-1-0` and `update-22-3-2` migrations gating on `vitest: ">=4.0.0"` (Vitest-4-specific AI-instructions) — pattern proposed in open PR `#35671`. Inspect via `gh pr diff 35671 --repo nrwl/nx -- packages/vitest/migrations.json`.
+- `packages/angular/migrations.json` `update-unit-test-runner-option` — Nx-only migration with the over-gating `@angular/core` `requires` **removed** in `#35587`.
+
+## Test specs
+
+### Parameterized floor spec (one per plugin)
+
+Path: `packages/<plugin>/src/utils/all-generators-enforce-floor.spec.ts`.
+
+```ts
+import { assertGeneratorsEnforceVersionFloor } from '@nx/devkit/internal-testing-utils';
+import { join } from 'node:path';
+
+describe('@nx/<plugin> generators enforce supported version floor', () => {
+  assertGeneratorsEnforceVersionFloor({
+    packageRoot: join(__dirname, '..', '..'),
+    packageName: '<pkg>',
+    subFloorVersion: '~<floor-minus-one>',
+    // Required only when a generator must run below the floor by design.
+    // excludeGenerators: ['migrate-to-cypress-11'],
+  });
+});
+```
+
+Pick `subFloorVersion` such that `lt(coerce(it).version, floor)` is true. No pre-release identifiers. Reference values used in the repo: `~18.2.0` (angular, v19 floor), `~12.17.0` (cypress, v13 floor), `~1.35.0` (playwright, v1.36 floor).
+
+### Plugin assert spec (optional, one per plugin)
+
+Path: `packages/<plugin>/src/utils/assert-supported-<pkg>-version.spec.ts`.
+
+`assertSupportedPackageVersion` is already fully tested in `@nx/devkit`,
+so a per-plugin spec mostly re-tests the shared helper. The early
+compliance PRs (`#35587` angular onward) ship one for symmetry, but it
+isn't required. If you add one, five canonical cases is the shape used:
+
+```ts
+describe('assertSupportedCypressVersion', () => {
+  it('throws when cypress is below the supported floor');
+  it('does not throw when cypress is not installed (fresh-install path)');
+  it('does not throw when cypress is `latest`');
+  it('does not throw when cypress is `next`');
+  it('does not throw when cypress is within the supported window');
+});
+```
+
+Reference: `packages/angular/src/utils/assert-supported-angular-version.spec.ts` (originally landed in `#35587`).
+
+### Test message matching
+
+Use substring match on the error message:
+
+```ts
+.rejects.toThrow(`Unsupported version of \`${packageName}\` detected`)
+```
+
+Not a hand-rolled RegExp (avoid escape bugs). Reference: see how the shared `assertGeneratorsEnforceVersionFloor` itself does the match — search for `Unsupported version of` in `packages/nx/src/internal-testing-utils/assert-generators-enforce-version-floor.ts`.
+
+## Standardized error format
+
+```
+Unsupported version of `<pkg>` detected.
+
+  Installed: <declared-range-as-written-in-package.json>
+  Supported: >= <floor>
+
+Update `<pkg>` to <floor> or higher.
+```
+
+Two notes:
+
+- The `Installed:` line preserves the **original declared range** (e.g., `~18.2.0`), not the cleaned semver. `assertSupportedPackageVersion` passes `declared` through to `throwForUnsupportedVersion`.
+- Do not add an "above ceiling" branch to this message. Above-ceiling is silent fallthrough.
+
+## Peer dep alignment
+
+### What belongs in `peerDependencies`
+
+The test: _would the plugin still work if this package were absent from the workspace, with the plugin's code paths unchanged?_
+
+A package is required-peer if **any** of these is true:
+
+- The plugin's TypeScript imports / `require`s it (executor, preset, runtime helper).
+- The plugin's executor spawns its CLI binary (`spawn('cypress')`, etc.).
+- The plugin's inferred plugin (`createNodes`/`createNodesV2`) **emits a target whose `command` invokes the package's CLI** (e.g., `command: 'rspack build'` → `@rspack/cli` is required). The `externalDependencies: ['<pkg>']` declaration in such targets is itself an admission of the runtime dependency.
+
+A package is **not** required-peer when:
+
+- The plugin's generator installs it into the user's workspace for the user to consume independently, and no plugin code (TypeScript, executor binary spawn, or inferred-plugin emitted command) ever invokes it. Example: ESLint plugins written into the user's eslintrc — `@nx/cypress` installs `eslint-plugin-cypress`, but its lint executor uses generic ESLint loading; the cypress plugin is loaded by ESLint per the user's config, not by `@nx/cypress`. Example: `@types/*` packages installed for the user's TS compilation but never imported by plugin code.
+
+**Ecosystem-signal peer** (Angular's full `@angular/*` peer list) → judgment call, not a compliance requirement. Documents lockstep compatibility but isn't enforced by the multi-version rules.
+
+### Required vs. optional peer
+
+Most Nx plugin peers should be **optional** (`peerDependenciesMeta: { "<pkg>": { "optional": true } }`):
+
+- Required peer: every user of the plugin needs this package, regardless of which surface they use. Example: `@angular-devkit/core`, `rxjs` in `@nx/angular` — every Angular Nx workspace uses them.
+- **Optional peer (the common case for inferred-plugin / executor surfaces):** the package is only needed when the user opts into a specific surface — an executor they have to write into `project.json`, an inferred plugin gated on the presence of a config file, a preset that auto-injects. Users who don't use that surface shouldn't see an unmet-peer warning. Examples: `@playwright/test` in `@nx/playwright`, `cypress` in `@nx/cypress`, `vitest` / `vite` in `@nx/vitest`, `@angular/build` / `@angular-devkit/build-angular` / `ng-packagr` in `@nx/angular`.
+
+For `@rspack/cli` / `@rspack/core` in `@nx/rspack`: both surfaces (executor, inferred plugin) are gated — executor opt-in via `project.json`, inferred plugin gated on `rspack.config.{ts,js}` presence. Compliance fix should peer-declare both with `optional: true`.
+
+Concrete examples:
+
+| Package                 | Plugin           | Plugin invokes?                                                                                                                                                  | Peer?   | Optional?                                             |
+| ----------------------- | ---------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- | ----------------------------------------------------- |
+| `cypress`               | `@nx/cypress`    | yes (executor spawns binary; inferred plugin emits `cypress run` commands)                                                                                       | **yes** | optional (executor + inferred plugin are both opt-in) |
+| `@playwright/test`      | `@nx/playwright` | yes (executor + preset + inferred plugin)                                                                                                                        | **yes** | optional                                              |
+| `vitest`                | `@nx/vitest`     | yes (executor + inferred plugin emits `vitest` commands)                                                                                                         | **yes** | optional                                              |
+| `@rspack/cli`           | `@nx/rspack`     | yes — inferred plugin emits `command: 'rspack build'` (`packages/rspack/src/plugins/plugin.ts:182,196`). Not imported in TS, but invoked via emitted CLI target. | **yes** | optional (both surfaces gated)                        |
+| `@angular-devkit/core`  | `@nx/angular`    | yes (used by every Angular Nx workspace)                                                                                                                         | **yes** | **not optional**                                      |
+| `@angular/build`        | `@nx/angular`    | yes (only when user uses the @angular/build builder)                                                                                                             | **yes** | optional                                              |
+| `eslint-plugin-cypress` | `@nx/cypress`    | no (generator writes it into user's eslintrc; ESLint loads it, not the plugin)                                                                                   | **no**  | n/a                                                   |
+| `@types/node`           | various          | no (generator install only; types are build-time)                                                                                                                | **no**  | n/a                                                   |
+
+### Range / version alignment
+
+For packages that ARE peer-declared: the range must match the install lanes the code ships. If the code has no `isV1Installed` branch and no v1 entry in `versionMap`, do not list `^1.0.0` in the peer range.
+
+Reference: open PR `#35671` (`@nx/vitest`) drops `^1.0.0` from the `vitest` peer range because there is no v1 install lane. Inspect via `gh pr diff 35671 --repo nrwl/nx -- packages/vitest/package.json`. Verify state — may have merged or closed since.
+
+## Executor / runtime feature gating
+
+Features introduced after the floor must gate at call time on the installed version, not on the floor. Use `getInstalledPackageVersion` + `lt` from `semver`.
+
+```ts
+import { getInstalledPackageVersion } from '@nx/devkit/internal';
+import { lt } from 'semver';
+import { minPlaywrightVersionForBlobReports } from './versions';
+
+const installed = getInstalledPackageVersion('@playwright/test');
+if (installed && lt(installed, minPlaywrightVersionForBlobReports)) {
+  throw new Error(
+    `The "@nx/playwright:merge-reports" executor requires "@playwright/test" version ${minPlaywrightVersionForBlobReports} or greater (the version that introduced the "blob" reporter and the "merge-reports" CLI). You are currently using version ${installed}.`
+  );
+}
+```
+
+Reference: `packages/playwright/src/executors/merge-reports/merge-reports.impl.ts`, `packages/playwright/src/utils/preset.ts`. Both added in `#35642`.
+
+Two distinct cases:
+
+- **Auto-injected feature** (preset's auto-blob in CI): skip injection silently when installed < threshold. Only throw when the user explicitly opted in (`generateBlobReports: true`) on an unsupported version.
+- **Direct invocation** (executor CLI subcommand): throw immediately with a clear "requires >= X.Y.Z (the version that introduced …)" message.
+
+## File-layout summary
+
+For plugin `@nx/<plugin>` managing `<pkg>` with floor `X.Y.Z`:
+
+```
+packages/<plugin>/
+  src/
+    utils/
+      versions.ts                                # add minSupportedXVersion
+      assert-supported-<pkg>-version.ts          # NEW — 7-line wrapper
+      assert-supported-<pkg>-version.spec.ts     # OPTIONAL — 5 cases (mostly re-tests shared helper)
+      all-generators-enforce-floor.spec.ts       # NEW — parameterized
+    generators/
+      <each>/
+        <each>.ts                                # assert as first statement
+      init/
+        schema.json                              # keepExistingVersions default: true
+        init.ts                                  # keepExistingVersions ?? true
+    executors/                                   # feature-gate via getInstalledPackageVersion
+    plugins/                                     # same
+  migrations.json                                # tighten / remove `requires` gates per audit
+  package.json                                   # align peer; add "semver": "catalog:" if newly used
+```
+
+---
+
+# Code-level verification (review-mode lens)
+
+In review mode, walk these markers against the diff.
+
+Output rules:
+
+- **Inline categories are `[blocker]` and `[non-blocker]` only.** No "open question," "ask," or other ad-hoc tags. Author-directed questions emerge from non-blocker findings and surface in the closing "Open questions for author" block.
+- **For each blocker / non-blocker:** anchor at `file:line` and cite which reference PR / file demonstrates the correct pattern. Cross-reference `anti-patterns.md` when the finding matches a numbered pattern.
+- **Sections without findings get a single summary line**, not a per-file enumeration. `"Pass — all 7 generator entries assert at first statement"` is right; listing seven file:lines is wrong. Reviewer time is spent on actionable items; passing checks should not eat reading budget.
+- **Produce the verdict block** at the end (see §"Verdict template"). The block is the skimmable index — produce it, don't substitute a free-form summary.
+
+Scope:
+
+- **In scope:** the diff's code, configs, schemas, migrations, and **in-codebase documentation that describes runtime behavior** (e.g., `.mdoc` / `.md` files under `astro-docs/` or `docs/` that claim how the plugin behaves). A docs claim that contradicts the code is a correctness issue and belongs here.
+- **Out of scope:** PR title, PR body shape, commit message format, related-issues section, branch naming. Defer to the user's PR/commit conventions (loaded globally from `~/.claude/memory/workflow/git/`). Don't flag PR/commit shape in this skill's review output.
+
+## 1. Peer dep & install constants
+
+- [blocker] `package.json` peer dep range matches the install lanes implemented in `versions.ts`. No phantom version claims. → If `versionMap` has no v1 entry, peer must not list `^1.0.0`. Reference correction: `#35671` (`@nx/vitest`). Anti-pattern: §8.
+- [blocker] **Declared floor matches the effective floor.** Grep every `import` / `require` from the third-party package in plugin code. If any imported API only exists at version >N, the declared floor must be >=N. Anti-pattern: §16. Reference correction: `#35671` second commit raised vitest from v2 to v3 after catching a `getRelevantTestSpecifications` import (v3+ only).
+- [blocker] Fresh-install constant exposes the **full feature surface**, not just the peer floor. → Playwright peer stayed `^1.36.0` but fresh-install moved to `^1.37.0` because blob reporter + `merge-reports` CLI both require 1.37. Reference: `#35642` `packages/playwright/src/utils/versions.ts`.
+- [blocker] No per-major version aliases (`<pkg>V3Version`, `<pkg>V4Version`, etc.) alongside a `versionMap` — pick one source of truth. Anti-pattern: §15. Reference: `#35671`'s third commit dropped these aliases.
+- [blocker] `versions.ts` exports `minSupportedXVersion = 'X.Y.Z'` as a plain string (no caret, no range markers). The wrapper passes this verbatim to `assertSupportedPackageVersion`.
+- [blocker] `versionMap[major]` lookup is `versionMap[major] ?? latestVersions`. No `switch + throw default:` or other above-ceiling throw. Anti-pattern: §2. Reference correction: `#35670` (`@nx/cypress` `versions()` rewrite).
+- [blocker] Every third-party package the **plugin invokes at runtime** has a `peerDependencies` entry. "Invokes" covers: (a) TypeScript `import`/`require`, (b) executor spawning the package's CLI binary, (c) inferred-plugin (`createNodes`/`createNodesV2`) emitting a target whose `command` invokes the package's CLI (the `externalDependencies: ['<pkg>']` field on such targets confirms the dependency). See §"Peer dep alignment" for the full categorization.
+  - **Don't flag** packages the plugin's generator installs into the user's workspace for the user to consume independently, with no plugin codepath invoking them (e.g., ESLint plugins like `eslint-plugin-cypress` that ESLint loads from the user's eslintrc; `@types/*` packages).
+  - Plugins flagged at time of writing for actually-invoked packages without a peer entry: `@nx/webpack`, `@nx/rollup`, `@nx/angular-rspack-compiler` (primary listed under `dependencies`); `@nx/jest`, `@nx/nest`, `@nx/module-federation`, `@nx/react`, `@nx/vue`, `@nx/expo`, `@nx/react-native`, `@nx/node`, `@nx/js` (verify per plugin — TS imports, binary spawns, AND inferred-plugin emitted commands all count).
+- [blocker] Peers that are only used when the user opts into a specific surface (executor opt-in, inferred plugin gated on config file presence, opt-in preset) are declared **optional** via `peerDependenciesMeta: { "<pkg>": { "optional": true } }`. Pattern is established across reference plugins — `@playwright/test`, `cypress`, `vitest`, `vite`, `@angular/build`, `ng-packagr` are all optional. Required-non-optional peers (`@angular-devkit/core`, `rxjs` in `@nx/angular`) are reserved for packages every workspace using the plugin needs. See §"Required vs. optional peer".
+- [non-blocker] If the PR introduces `semver` usage in the plugin, `package.json` `dependencies` lists `"semver": "catalog:"`. Reference: `#35642` added it to `packages/playwright/package.json`.
+
+## 2. Generator entry points
+
+- [blocker] **Every** entry in `generators.json` has its working function calling `assertSupported<Pkg>Version(tree)` as the **first statement** — before any tree reads, writes, or sub-generator calls. For wrapper/internal-split plugins (cypress, playwright): assert is in `*Internal`. For single-function generators (angular): in the function itself. Anti-pattern: §14.
+- [blocker] Plugin wrapper file `assert-supported-<pkg>-version.ts` imports `assertSupportedPackageVersion` from `@nx/devkit/internal`. No direct call to `throwForUnsupportedVersion`. No bespoke `throwBelowFloor` / `throwAboveWindow` / `assertVersion` / local `cleanVersion = clean(v) ?? coerce(v)?.version` helpers (use `normalizeSemver` / `getInstalledPackageVersion` / `getDeclaredPackageVersion`). Anti-pattern: §1. Concrete example: PR `#35676` introduces a local `cleanVersion` and `getInstalledRsbuildVersionRuntime` — both already exist as shared helpers.
+- [blocker] If `all-generators-enforce-floor.spec.ts` uses `excludeGenerators`, each excluded name has a code comment explaining why the generator must run sub-floor (e.g., `migrate-to-cypress-11` lifts v8–v10 workspaces onto v11).
+- [non-blocker] Double-assert chains (`configurationInternal` calls `initInternal`, both assert) are OK. Idempotent. Don't refactor away.
+
+## 3. Generator outputs
+
+- [blocker] Templates the generator writes (project files, configs, schemas) compile and run on every major in the support window. Verify with a quick mental walk: for each template referenced from the generator, identify any per-major-version conditional and confirm it's accurate.
+- [blocker] Generated `project.json` target shape (executor, options, schema) is valid on every supported major. If the executor's option schema differs across the support window, the generator branches or uses the union shape.
+- [blocker] Default option values are valid on every supported major. A default that's only valid above a specific major must be conditional.
+- [blocker] Version map covers every managed third-party dep. If the runtime later branches on a sibling's version (e.g., `@vitest/ui`), the version map must have an entry for that sibling per major — no gaps where the generator picks a constant the runtime then can't reconcile.
+- [blocker] Generator schema accepts the **union of options across the support window**. Options removed in a newer major still validate at schema level (with description-notice); runtime throws when inapplicable on the installed major. See `gotchas.md` §"Schema-level deprecated-option stubs with runtime throws".
+
+## 4. `keepExistingVersions` (user-pin preservation)
+
+- [blocker] Every `addDependenciesToPackageJson` call from a **generator** passes `keepExistingVersions: true` (positionally as the 5th arg) or `options.keepExistingVersions ?? true`.
+- [blocker] `init/schema.json` has `"keepExistingVersions": { "default": true }`. Not `false`. Not absent. **Known gap:** `@nx/angular`'s init schema currently has `default: false` and was NOT addressed in `#35587` — flagging in a non-angular PR is correct; fixing in passing in an angular PR is also correct. Anti-pattern: §4.
+- [blocker] Linter / sub-generator helpers (`add-linter.ts`, `add-angular-eslint-dependencies.ts`, equivalents) also pass `true`.
+- [non-blocker] If both schema `"default": true` AND `options.keepExistingVersions ?? true` are present, that's two sources of truth. Anti-pattern: §12.
+- **Migration generators are exempt.** Do not flag missing flags in code under `src/migrations/`.
+
+## 5. `migrations.json` gates
+
+- [blocker] Every `packageJsonUpdates` entry that bumps across a major version has `requires: { "<pkg>": ">=N.0.0 <(N+1).0.0" }`. Source-major gate, not target. Anti-pattern: §6. Reference: `#35587` Module Federation entries.
+  - **Read the actual range strings; don't tick this by counting split entries.**
+  - [non-blocker / ask author] One-sided gates (`<X` with no lower bound, or `>=Y` with no upper bound) may be intentional or accidental. Legitimate cases: legacy-cleanup codemods that should apply on every source major below the target; a v0→v1 bridge where every v0.x workspace should migrate; bumping a package introduced at vN from `undefined`. Illegitimate cases: a v1→v2 bump expressed as `<2.x` would fire for v0 workspaces too; a `>=N` with no upper bound would fire for future majors. **When you see a one-sided gate, ask the author to confirm intent** — don't auto-flag as blocker.
+- [blocker] Codemod migrations that only make sense at/above a specific third-party major have a `requires` entry. Open upper bound is intentional when the codemod cleans up legacy flags. Runtime per-package guards (`gte`/`lt` inside the migration body) are NOT a substitute for `requires`.
+- [blocker] **Nx-only migrations have NO `requires` gate.** A migration that only writes to `nx.json`, executor options, or generator defaults applies regardless of third-party version. Anti-pattern: §5. Reference correction: `#35587` removed the over-gating `@angular/core: >=21.0.0` from `update-unit-test-runner-option`.
+- [blocker] For independent siblings (Angular: `@ngrx/*`, `@angular-eslint/*`, `zone.js`, `jest-preset-angular`), gating on the primary's major is **not sufficient** — each needs its own `requires` entry. Anti-pattern: §7. Verify pairing by reading the sibling's `peerDependencies` at the version range being bumped from.
+- [blocker] A single `packageJsonUpdates` entry must not mix mutually-exclusive cross-major bumps under one `requires` (AND-semantics). Split into separate entries each with its own gate. Concrete example: React PR's `22.3.4` entry mixed `react-router 7.12.0` (cross-major) with `react-router-dom 6.30.3` (v6 patch) — must split.
+- [non-blocker] `incompatibleWith` is not a substitute for `requires`. Anti-pattern: §10. If you see `incompatibleWith` standing in for a source-major gate, ask for a `requires` instead.
+- [non-blocker] Sibling `packageJsonUpdates` entries within the same block that depend on a peer's post-bump version are fine — tier-1 chaining evaluates against post-bump state. Reference: Storybook 21.2.0 chains on the prior 21.1.0 bump.
+- [non-blocker] Pre-floor `packageJsonUpdates` entries targeting source majors below the current support floor are intentionally retained for users on older Nx versions. Don't _add_ a bridge entry without explicit decision, and don't _remove_ a legitimately-pre-floor entry mid-audit.
+
+## 6. Executor / runtime / inferred-plugin feature gating
+
+- [blocker] Executor code that invokes a CLI subcommand or uses an API introduced after the floor calls `getInstalledPackageVersion('<pkg>')` + `lt(installed, threshold)` from `semver` and throws a clear "requires >= X.Y.Z (the version that introduced …)" message. Reference: `packages/playwright/src/executors/merge-reports/merge-reports.impl.ts` (`#35642`).
+- [blocker] Preset / config builders that auto-inject feature-version-coupled config skip injection silently when installed < threshold, and only throw when the user **explicitly** opted in on an unsupported version. Reference: `packages/playwright/src/utils/preset.ts` (`#35642` — `generateBlobReports` logic).
+- [blocker] **Inferred plugins** (`createNodes`/`createNodesV2`) parse configs across every major in the support window. The plugin emits the same target shape regardless of the installed major (or branches if shapes diverge). Don't hardcode helper imports against one major.
+- [blocker] **Above-ceiling is silent fallthrough.** No warn, no throw, no branch. Anti-pattern: §2.
+- [non-blocker] Executors don't enforce the plugin floor. Floor enforcement is generator-only. Don't suggest adding an executor-level floor assert unless the user asks.
+- [non-blocker] `require('<pkg>')` for optional peers should live inside the function body, after version detection. Anti-pattern: §9.
+
+## 7. Tests
+
+- [blocker] `all-generators-enforce-floor.spec.ts` exists at `packages/<plugin>/src/utils/all-generators-enforce-floor.spec.ts`, calls `assertGeneratorsEnforceVersionFloor` from `@nx/devkit/internal-testing-utils`. This is the parameterized spec that exercises every generator's floor assert.
+- [blocker] `subFloorVersion` is a semver range where `lt(coerce(it).version, floor)` is true. No pre-release identifiers. Reference values: `~18.2.0` (angular, v19 floor), `~12.17.0` (cypress, v13 floor), `~1.35.0` (playwright, v1.36 floor).
+- [non-blocker] Plugins establishing the pattern (`#35587` angular) ship a `assert-supported-<pkg>-version.spec.ts` with the 5 canonical cases (sub-floor / fresh-install / `latest` / `next` / in-range). The underlying `assertSupportedPackageVersion` already has full coverage in `@nx/devkit`, so the per-plugin spec largely re-tests the shared helper. Useful for symmetry across the PR series but not required — don't block on missing.
+- [non-blocker] Runtime/executor feature-gate throw tests are nice-to-have, not required — reference PRs (`#35587`, `#35642`, `#35670`) do not have them today.
+- [non-blocker] Error message matching uses substring (`toThrow('Unsupported version of \`<pkg>\` detected')`) instead of hand-rolled `RegExp`. Anti-pattern: §13.
+- [non-blocker] FS-side helper migrated to `getInstalledPackageVersion`; tree-side helper may stay inline. The two helpers' `null` vs. fallback semantics differ. Reference: `#35670` `packages/cypress/src/utils/versions.ts` rewrite.
+
+## Open questions to raise (when missing from the PR / Linear task)
+
+1. **Floor:** deliberate raise from the previous declared peer, or matching the existing peer? If raise: do sub-floor users get a `packageJsonUpdates` bridge or manual bump?
+2. **Peer-range tightening:** dropping a major because there's no install lane (legitimate, `#35671` pattern) or because tests fail (regression risk — investigate)?
+3. **`requires` removals on Nx-only migrations:** genuinely Nx-only, or sneaking through a third-party-touching change?
+4. **Pruned migrations gaps:** if floor is being raised by N+ majors and prior `packageJsonUpdates` entries were removed, do sub-floor users have any auto-bump path? `git log --all -- packages/<plugin>/migrations.json`.
+5. **Runtime feature gates:** threshold verified against third-party release notes, or guessed?
+6. **Sibling classification:** ecosystem-locked vs. independent. Read the sibling's `peerDependencies` at the bumped-from range. `@angular-devkit/build-angular` is the gotcha — peer-locked from v20+, NOT v19.
+7. **Cross-plugin coordination:** if the plugin pins a third-party that another plugin also manages (e.g., `@nx/cypress` pinning vite for cypress v13/v14+; `@nx/vite` supporting vite v5–v8), confirm the windows stay aligned. If `@nx/vite` drops v5, `@nx/cypress` carries an orphaned install lane.
+
+## Verdict template
+
+```
+Blockers: <N>
+Non-blockers: <N>
+
+1. Peer dep & install constants: [pass | <findings>]
+2. Generator entry points: [pass | <findings>]
+3. Generator outputs: [pass | <findings>]
+4. keepExistingVersions: [pass | <findings>]
+5. Migration gates: [pass | <findings>]
+6. Executor / runtime / inferred-plugin: [pass | <findings>]
+7. Tests: [pass | <findings>]
+
+Open questions for author: [list]
+
+Scope drift vs. Linear task (if applicable):
+- Findings in task NOT addressed: <list>
+- Changes in PR NOT in task: <list>
+```

--- a/.claude/skills/multi-version-compliance/references/examples.md
+++ b/.claude/skills/multi-version-compliance/references/examples.md
@@ -1,0 +1,115 @@
+# Examples & references
+
+Concrete files, commits, and PRs to grep when you need a model.
+
+## Reference PRs (in order of arrival)
+
+| PR       | Plugin           | Branch     | State                   | Why notable                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                               |
+| -------- | ---------------- | ---------- | ----------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `#35587` | `@nx/angular`    | `nxc-4381` | merged                  | First compliance PR. Established `throwForUnsupportedVersion`, the `assertSupported*Version` wrapper pattern, the `all-generators-enforce-floor.spec.ts` shape, the MF `requires`-gate pattern, the Nx-only-migration over-gate removal pattern.                                                                                                                                                                                                                                                                                                                                                                                                                                          |
+| `#35642` | `@nx/playwright` | `nxc-4398` | merged                  | Generalized the helpers into `version-floor.ts`/`installed-version.ts`. Added `assertGeneratorsEnforceVersionFloor` in `internal-testing-utils`. Established executor/runtime feature-gating pattern (blob reporter / `merge-reports`). Demonstrated the "fresh-install constant higher than peer floor" pattern.                                                                                                                                                                                                                                                                                                                                                                         |
+| `#35670` | `@nx/cypress`    | `nxc-4384` | merged                  | Established `excludeGenerators` in the shared test helper for intentional sub-floor migrators (`migrate-to-cypress-11`). Demonstrated `versions()` switch-to-fallthrough rewrite. Demonstrated keeping the tree-side inline helper while migrating only the FS side to the shared helper.                                                                                                                                                                                                                                                                                                                                                                                                 |
+| `#35671` | `@nx/vitest`     | `nxc-4408` | open at time of writing | Three commits. (1) Establishes "drop phantom peer-range claim" (removes `^1.0.0` from peer); migration `requires` tightening for Vitest-4-only AI-instructions migrations. (2) Raises floor v2 → v3 after audit catches `getRelevantTestSpecifications` import (v3+ API) — establishes the **effective-floor-vs-declared-floor** pattern (see `anti-patterns.md` §16). (3) Adopts the cypress version-resolution pattern (bundle-of-varying-deps `versions(tree)`, `getInstalled<Pkg>Version(tree?)`, no per-major aliases — see `anti-patterns.md` §15). To inspect: `gh pr view 35671 --repo nrwl/nx --json commits` then `gh pr diff 35671`. Verify state — may have merged or closed. |
+
+Always verify state with `gh pr view <N> --repo nrwl/nx --json state` before citing — this table goes stale.
+
+## Reference commits (for `git show` inspection)
+
+When the same change exists as both a pre-squash branch commit AND a merged squash on master, prefer the merged squash — it's the authoritative final state. Pre-squash SHAs are listed because they're easier to read in isolation (smaller diffs) when investigating one specific aspect.
+
+**Merged on master (authoritative):**
+
+| SHA          | Subject                                                                      |
+| ------------ | ---------------------------------------------------------------------------- |
+| `75578724fa` | `cleanup(core): add throwForUnsupportedVersion util to @nx/devkit/internal`  |
+| `484ce6e5d5` | `fix(angular): multi-version support compliance (#35587)`                    |
+| `78f908d015` | `cleanup(angular): adopt shared version-floor helpers`                       |
+| `e2ef134645` | `fix(testing): multi-version support compliance for @nx/playwright (#35642)` |
+| `5d8b1bab7e` | `cleanup(devkit): allow excluding generators from version floor test helper` |
+| `bc35b484e3` | `fix(testing): multi-version support compliance for @nx/cypress (#35670)`    |
+
+Pre-squash branch SHAs are available via `gh pr view <N> --json commits` even after the branch is deleted; useful when inspecting one specific aspect of a merged PR in isolation. Example:
+
+```bash
+gh pr view 35642 --repo nrwl/nx --json commits | jq -r '.commits[] | "\(.oid[:10]) \(.messageHeadline)"'
+```
+
+## Shared helpers — current locations
+
+| File                                                                                | Exports                                                                                                                    |
+| ----------------------------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
+| `packages/devkit/src/utils/version-floor.ts`                                        | `throwForUnsupportedVersion` (internal-only), `assertSupportedPackageVersion`                                              |
+| `packages/devkit/src/utils/installed-version.ts`                                    | `getInstalledPackageVersion`, `getDeclaredPackageVersion`, `isNonSemverDistTag`, `normalizeSemver`, `NON_SEMVER_DIST_TAGS` |
+| `packages/devkit/internal.ts`                                                       | re-exports from above (this is `@nx/devkit/internal`)                                                                      |
+| `packages/nx/src/internal-testing-utils/assert-generators-enforce-version-floor.ts` | `assertGeneratorsEnforceVersionFloor`                                                                                      |
+| `packages/devkit/internal-testing-utils.ts`                                         | re-exports `assertGeneratorsEnforceVersionFloor` (this is `@nx/devkit/internal-testing-utils`)                             |
+
+## Per-plugin compliant files (grep for the pattern)
+
+### `@nx/angular` (most extensive — has the `supportedVersions` list pattern)
+
+- `packages/angular/src/utils/assert-supported-angular-version.ts` — wrapper using `Math.min(...supportedVersions)`
+- `packages/angular/src/utils/assert-supported-angular-version.spec.ts` — the canonical 5-case spec
+- `packages/angular/src/utils/all-generators-enforce-floor.spec.ts` — the parameterized floor spec
+- `packages/angular/src/generators/add-linting/lib/add-angular-eslint-dependencies.ts` — `keepExistingVersions: true` pattern
+- `packages/angular/migrations.json` — MF `requires` gates and the over-gate removal
+
+### `@nx/playwright` (the helpers were generalized here)
+
+- `packages/playwright/src/utils/assert-supported-playwright-version.ts` — wrapper using a `minSupportedPlaywrightVersion` constant
+- `packages/playwright/src/utils/all-generators-enforce-floor.spec.ts`
+- `packages/playwright/src/utils/preset.ts` — runtime feature gating (blob reporter)
+- `packages/playwright/src/executors/merge-reports/merge-reports.impl.ts` — executor feature gating
+- `packages/playwright/src/utils/versions.ts` — `minSupportedPlaywrightVersion`, `minPlaywrightVersionForBlobReports`, `playwrightVersion = '^1.37.0'` (fresh install higher than peer)
+- `packages/playwright/src/utils/add-linter.ts` — `keepExistingVersions: true` in linter helper
+- `packages/playwright/package.json` — peer `^1.36.0` (unchanged), added `"semver": "catalog:"`
+
+### `@nx/cypress` (excludeGenerators + versions() rewrite)
+
+- `packages/cypress/src/utils/assert-supported-cypress-version.ts`
+- `packages/cypress/src/utils/all-generators-enforce-floor.spec.ts` — uses `excludeGenerators: ['migrate-to-cypress-11']` with code comment
+- `packages/cypress/src/utils/versions.ts` — `versions()` rewritten to `versionMap[major] ?? latestVersions`; `getInstalledCypressVersion` FS-path migrated to shared helper, tree-path kept inline
+
+## Finding current work-in-progress
+
+To enumerate all compliance PRs (merged + open) without relying on out-of-tree tracking docs:
+
+```bash
+# Open + merged compliance PRs
+gh pr list --repo nrwl/nx --search "multi-version compliance" --state all --limit 30 \
+  --json number,title,state,headRefName,author
+
+# Just open ones
+gh pr list --repo nrwl/nx --search "multi-version compliance" --state open
+```
+
+This is the authoritative list. Plugins covered to date can be derived by inspecting which packages each merged PR touched.
+
+To check which plugins still have known anti-patterns (e.g., phantom peer claims, missing floor assert), grep on master:
+
+```bash
+# Plugins WITHOUT an assert-supported-<pkg>-version wrapper
+for d in packages/*/src/utils; do
+  pkg=$(dirname "$d" | xargs basename)
+  if [ ! -f "$d/assert-supported-$pkg-version.ts" ] && \
+     [ ! -f "$d/assert-supported-${pkg/_/-}-version.ts" ]; then
+    echo "$pkg: no assert-supported wrapper"
+  fi
+done
+
+# Plugins missing the parameterized floor spec
+find packages -name "all-generators-enforce-floor.spec.ts" -not -path "*/dist/*"
+```
+
+Cross-reference with the third-party packages each plugin manages (peer deps in `package.json`).
+
+## How to use these examples
+
+When auditing a new plugin, before writing anything:
+
+1. Read the PR body of `#35642` (`@nx/playwright`) — it's the most comprehensive description of the canonical shape.
+2. Read the four files from `@nx/playwright`: `versions.ts`, `assert-supported-playwright-version.ts`, `all-generators-enforce-floor.spec.ts`, and `preset.ts`. Five minutes.
+3. If your plugin has a `migrations.json` of any complexity, also read `packages/angular/migrations.json` MF entries and the `update-unit-test-runner-option` entry for the gate patterns.
+4. If the plugin has runtime feature gates, also read `packages/playwright/src/executors/merge-reports/merge-reports.impl.ts`.
+
+When reviewing a compliance PR, the diff should look very similar to one of these reference PRs. Differences should be justifiable by the plugin's specifics (different floor, different feature gates, different migration shape) — not by departing from the canonical patterns.

--- a/.claude/skills/multi-version-compliance/references/gotchas.md
+++ b/.claude/skills/multi-version-compliance/references/gotchas.md
@@ -1,0 +1,241 @@
+# Gotchas & edge cases
+
+Non-obvious behavior. Load these into your model before auditing or reviewing.
+
+## `latest` / `next` dist-tags
+
+When a workspace declares `"<pkg>": "latest"` or `"next"` in its `package.json`:
+
+- `assertSupportedPackageVersion` no-ops via `isNonSemverDistTag` (NON_SEMVER_DIST_TAGS = `['latest', 'next']`). The floor check is skipped entirely.
+- `getDeclaredPackageVersion` falls back to the cleaned `latestKnownVersion` argument (if provided) or returns `null`.
+- `versions(tree)` returns `latestVersions` (the fresh-install path).
+
+Tests must include `latest` and `next` cases. Both are no-ops; neither throws.
+
+## pnpm `catalog:` references
+
+Declared versions may be `"catalog:default"`, `"catalog:typescript"`, etc. (since pnpm 9.5):
+
+- `getDependencyVersionFromPackageJson` (via the catalog manager in devkit) resolves these before the helper sees them. Don't call `clean`/`coerce` on raw values.
+- `normalizeSemver` behavior on a raw `catalog:` string is not explicitly tested (open question — verify if you encounter it).
+
+Reference: PR `#35459` (`fix(misc): resolve pnpm catalog: refs in version lookups`) — landed catalog ref handling.
+
+## Fresh-install path (package not declared)
+
+When `<pkg>` is missing from the workspace's `package.json` entirely:
+
+- `assertSupportedPackageVersion` no-ops.
+- `versions(tree)` returns `latestVersions`.
+- The generator proceeds with the fresh-install constant (e.g., `playwrightVersion = '^1.37.0'`).
+
+This is intentional — the generator is being run on a new workspace or one that's adding this package for the first time.
+
+## Error message preserves declared range, not cleaned semver
+
+```
+  Installed: ~18.2.0
+  Supported: >= 19.0.0
+```
+
+`Installed:` shows what's in `package.json` verbatim. Don't try to normalize it in the error message — it tells the user exactly what they typed, which helps them find it.
+
+The argument flow: `assertSupportedPackageVersion` calls `throwForUnsupportedVersion(packageName, declared, minSupportedVersion)` with the raw `declared` value.
+
+## Cypress's `getCypressVersionFromTree` stays inline
+
+The shared `getDeclaredPackageVersion` falls back to `latestKnownVersion` when the declared value is `latest`/`next` or missing. Cypress's tree path returns `null` on missing. These semantics differ enough that the helper can't be consolidated without changing behavior.
+
+The FS path (`getCypressVersionFromFileSystem`) was migrated to `getInstalledPackageVersion` (better resolution for pnpm strict / nested installs). The tree path stayed inline.
+
+Reference: `packages/cypress/src/utils/versions.ts` after `#35670`.
+
+## Double-asserts are fine
+
+When `configurationInternal` calls `initInternal` (or any generator chain), both call their respective `assertSupportedXVersion(tree)`. The assert is idempotent and cheap (one tree read + one semver comparison). Don't refactor away.
+
+The `assertGeneratorsEnforceVersionFloor` test treats both entry points as separate generators and asserts each throws — which is what we want.
+
+## Angular ecosystem lockstep — what `@angular/core >=N` covers
+
+Peer-locked to `@angular/core` (one `requires` on the primary is sufficient):
+
+- `@angular/cli`
+- `@angular/ssr`
+- `@angular-devkit/build-angular` **from v20+** (NOT v19 — `@angular-devkit/build-angular@19` does not peer-on `@angular/core`)
+- `@angular/material`, `@angular/cdk`, all `@angular/*` framework packages
+- `@schematics/angular`
+
+Independent (need their own `requires`):
+
+- `@ngrx/*`
+- `@angular-eslint/*`
+- `zone.js`
+- `jest-preset-angular`
+- `karma`, `karma-*`
+- `protractor` (deprecated)
+- `tailwindcss` and CSS-tooling siblings
+
+Always verify pairing at the actual version range being bumped from — `@angular-devkit/build-angular` is the classic gotcha (peers on `@angular/core` in some versions, not others).
+
+## Pruned migrations leave no trace in `migrations.json`
+
+Older `packageJsonUpdates` entries (e.g., `12.x` migrations) are removed during normal Nx version cleanup waves. They don't show up in the current `migrations.json` but their absence is meaningful — users on an old floor have no auto-bump path to the new floor.
+
+Check via:
+
+```sh
+git log --all --oneline -p -- packages/<plugin>/migrations.json | head -200
+git log --all --diff-filter=D --name-only -- packages/<plugin>/migrations.json
+```
+
+When raising a floor by N+ majors, decide whether to:
+
+1. Add a `packageJsonUpdates` entry bridging sub-floor → floor (the user gets auto-bumped on `nx migrate`).
+2. Leave the gap (the user sees the floor-assert error and has to bump manually).
+
+The Cypress v12 → v13 gap was left intentionally — users get the assert error and bump manually. Don't add a bridge entry without explicit agreement.
+
+## Pre-floor `packageJsonUpdates` entries are intentionally retained
+
+Distinct from the pruned-history case above: a plugin may carry `packageJsonUpdates` entries targeting source majors **below** the current support floor. Example: `@nx/react-native`'s entries `20.3.0` and `21.4.0` target RN versions below the current ~0.79.3 floor. These are intentionally retained for users on older Nx versions that supported older RN.
+
+Don't _add_ a bridge entry without explicit decision. Don't _remove_ a legitimately-pre-floor entry as part of a compliance pass. The W1/W4 audit window only covers entries that target source majors **inside** the current support window.
+
+## `subFloorVersion` must satisfy `lt(clean(it), floor)`
+
+For the parameterized floor spec, pick a value that's actually below the floor after `clean()`. Examples:
+
+| Floor    | Valid `subFloorVersion`        | Invalid                                                                                                                          |
+| -------- | ------------------------------ | -------------------------------------------------------------------------------------------------------------------------------- |
+| `19.0.0` | `~18.2.0`, `^18.0.0`, `18.2.0` | `~19.0.0-beta.0` (clean strips the pre-release; in some cases this still satisfies `lt`, but it's confusing — avoid pre-release) |
+| `13.0.0` | `~12.17.0`, `^12.0.0`          | `^13.0.0-rc.0`                                                                                                                   |
+| `1.36.0` | `~1.35.0`, `^1.35.0`           | `1.36.0-beta.5`                                                                                                                  |
+
+Use a stable minor-or-patch range below floor. Don't use pre-release identifiers.
+
+## Declared floor vs. effective floor
+
+The declared floor (peer dep + `minSupported<Pkg>Version` + `versionMap` lowest entry) is what the plugin advertises. The **effective floor** is the lowest major where every third-party API the plugin's code actually calls is available. When they diverge, the declared floor is lying.
+
+How this happens: someone bumps the plugin to use a new API (e.g., `getRelevantTestSpecifications` introduced in vitest v3) without raising the floor. The plugin compiles, generators pass tests against the latest install lane, but workspaces on sub-effective-floor versions crash at runtime with `... is not a function`.
+
+How to detect: in the audit's runtime/executor inventory step, every `import` / `require` from the third-party package goes into a list. Cross-reference each named export against the third-party's release notes / API docs. The effective floor is the highest "introduced in" version across that list.
+
+How to fix: raise the declared floor to match the effective floor. Drop the now-unsupported entries from `versionMap`, peer, and any per-major aliases. The parameterized floor spec's `subFloorVersion` shifts up accordingly.
+
+Reference: open PR `#35671` (`@nx/vitest`) — proposed v2 floor initially; raised to v3 in a follow-up commit after spotting `getRelevantTestSpecifications` usage. See `anti-patterns.md` §16.
+
+## `versions()` fall-through above ceiling, not throw
+
+Before `#35670`, cypress's `versions()` had a `switch + throw default:`. This is wrong for two reasons:
+
+1. New majors that don't yet have a `versionMap` entry should silently use `latestVersions` — the plugin hasn't been updated to know about them, but the user should still be able to use them.
+2. Below-floor is already caught by the generator-level assert. The `versions()` throw is redundant for the in-range/sub-floor case, and wrong for the above-ceiling case.
+
+The pattern is always:
+
+```ts
+return versionMap[major as CompatVersions] ?? latestVersions;
+```
+
+## Tier-1 chaining in `packageJsonUpdates`
+
+Within a single `packageJsonUpdates` entry (single block), if entry A bumps package X and entry B has `requires: { X: ">=N" }` that depends on the post-bump value of X, B's gate evaluates against the post-bump state. This is **deliberate design**, not a bug.
+
+Concrete example: Storybook's `21.2.0-migrate-storybook-v9` migration is gated on `storybook >=9.0.0` even though the prior state was v8 — the sibling `packageJsonUpdates` `21.1.0` bumps Storybook to v9 first, so the v9 gate evaluates against post-bump state.
+
+This means you can have one block bump X then chain a sibling bump gated on X's new version, without splitting into separate `packageJsonUpdates` keys.
+
+## Cross-plugin coordination of shared third-party windows
+
+Some third-party packages are managed by multiple Nx plugins. Concrete example:
+
+- `@nx/cypress` pins `vite` v5 (for cypress v13) and v6 (for cypress v14+).
+- `@nx/vite` supports `vite` v5–v8.
+
+If `@nx/vite` drops v5 from its supported window, `@nx/cypress`'s v5 pin becomes an orphaned install lane — workspaces using both plugins are now in conflict.
+
+When raising / lowering a third-party's support window in one plugin, check every other plugin that manages the same package. The Linear milestone tasks call this out per-plugin (e.g., NXC-4384 cypress flags vite coordination with NXC-4407 vite).
+
+### Sibling declaration consistency
+
+When the same third-party package appears in multiple plugins, the declaration _kind_ (peerDependencies vs dependencies vs devDependencies) should be consistent unless the plugins genuinely have different roles for the package. Concrete inconsistency on master at time of writing: `@module-federation/enhanced ^2.3.3` is in `dependencies` in `@nx/module-federation` but `peerDependencies` in `@nx/rspack`. Pick one rule per package across the plugin family and document the exception when one plugin must differ.
+
+## Plugin must own its primary third-party's pin
+
+A plugin's install constants for its primary third-party must live in the plugin's own `packages/<plugin>/src/utils/versions.ts` — not in another plugin. Cross-plugin imports of install constants create governance drift (the owning plugin can't change the pin without breaking the borrower).
+
+Example anti-pattern: `@nx/esbuild`'s `esbuild` install constant living in `@nx/js`. Flagged in NXC-4386.
+
+## Schema-level deprecated-option stubs with runtime throws
+
+Established Angular pattern (also called out in NXC-4391 jest, NXC-4395 next, NXC-4408 vitest): when an option is deprecated/removed in a newer third-party major but the plugin still supports an older major where it's valid, **retain the option in the schema with a description-notice and throw at runtime when inapplicable to the installed major**.
+
+This keeps the schema accepting the union of options across the support window. Runtime branches on installed version and throws a clear message if the user passes an option that's only valid on a major they're not running.
+
+Reference: search the angular generators for `removed in Angular vN` style schema descriptions paired with `assertSupportedAngularVersion`-aware option handling.
+
+## Known-incomplete plugins
+
+These were touched by a compliance PR but the work is incomplete. Useful for review and for future PRs.
+
+- **`@nx/angular` init `keepExistingVersions`**: `packages/angular/src/generators/init/schema.json` has `default: false` and `packages/angular/src/generators/init/init.ts` passes `options.keepExistingVersions` directly (no `?? true`). PR `#35587` fixed `add-linting` but NOT the init generator. Flag in non-angular PRs as a reference to the pattern; fix in passing in any future angular PR. (Verify state on current master before citing.)
+- **`@nx/jest` peer-dep block missing entirely.** When adopting the floor assert, add `peerDependencies` first declaring `jest` / `ts-jest` / `@types/jest` ranges. Without the peer block, `getDependencyVersionFromPackageJson` for `jest` may return `undefined` on installed workspaces because pnpm catalog refs and certain other patterns rely on the peer being declared.
+- **Cypress v12→v13 migration gap**: when `#35670` raised the floor to v13, prior v12-cleanup `packageJsonUpdates` entries were already pruned. Decision was to leave it — v12 workspaces see the assert error and bump manually. Reference for the "raise floor, no bridge" pattern.
+- **`getInstalled<Pkg>Version` consolidation deferred**: each plugin still has its own near-identical helper (the FS-side has been migrated to the shared helper in some plugins, but a full unification across cypress/playwright/vitest/next/expo/angular is pending). Don't bundle that refactor into a compliance PR.
+
+## `migrate-to-cypress-11` and other intentional sub-floor migrators
+
+A generator whose purpose is to lift sub-floor workspaces onto a supported version must run on sub-floor workspaces. If it had the floor assert, it could never run.
+
+For these generators:
+
+- Do NOT add `assertSupportedXVersion(tree)` to them.
+- Keep their existing version checks (e.g., `assertMinimumCypressVersion(8)` in `migrate-to-cypress-11`).
+- Add them to `excludeGenerators` in `all-generators-enforce-floor.spec.ts` with a code comment explaining why.
+
+There are usually 0 or 1 of these per plugin. Greater than 1 is suspicious — review carefully.
+
+## `getInstalledPackageVersion` vs. `require('<pkg>/package.json')`
+
+Bare `require('<pkg>/package.json')` resolves from the plugin's own install location, which in pnpm strict mode or nested installs may not match the workspace's resolved version. `readModulePackageJson` (used by `getInstalledPackageVersion`) goes through `getNxRequirePaths()` for correct workspace-rooted resolution.
+
+Anywhere you read an installed version at runtime: prefer `getInstalledPackageVersion('<pkg>')`. Don't `require('<pkg>/package.json')`.
+
+## "Above ceiling" is NOT in the task spec
+
+Repeating because this gets re-introduced: above-ceiling handling is explicitly out of scope for these compliance tasks. If you find yourself adding it, you've drifted from the spec.
+
+The behavior we want above the highest known major: silent fall-through to `latestVersions`. The plugin will be updated to add a `versionMap` entry for the new major in a future PR. Until then, the user gets the latest install constants and may run into incompatibilities, which is the existing pre-compliance behavior. We are NOT trying to detect future majors and warn — that's a different feature.
+
+## Decisions you cannot make alone
+
+Pause and ask when:
+
+- **Peer-range drop:** dropping a major from the peer might be a regression if tests pass on that version. Verify whether the absence of an install lane reflects "we never supported it" (legitimate drop) or "we shipped support and quietly broke it" (regression — investigate before dropping).
+- **Floor raise without a bridging migration:** raising the floor by N+ majors means users on the lowest sub-floor major see the assert error and must manually bump. Confirm with the user: acceptable, or add a `packageJsonUpdates` bridge?
+- **`requires` removal on a borderline migration:** the diff says the migration is Nx-only (no third-party config touched), but it reads a config file that only exists at certain third-party versions. The third-party dependency is indirect but real. Don't remove the gate without verifying.
+- **Peer floor and fresh-install constant diverge** (playwright pattern — peer `^1.36.0`, fresh-install `^1.37.0`). Confirm the gap is justified by feature surface (1.37 introduced the blob reporter + merge-reports CLI) and not an oversight.
+- **Ecosystem-locked vs. independent sibling classification:** before adding or removing a sibling's `requires` entry, read its `peerDependencies` block at the version range being bumped from. `@angular-devkit/build-angular` is the gotcha — only peer-locked to `@angular/core` from v20+.
+- **Pruned migration gap:** the lowest sub-floor major has no auto-bump path because prior `packageJsonUpdates` entries were removed during cleanup waves. Decide: add a bridge entry, or accept the manual bump? `git log --diff-filter=D -- packages/<plugin>/migrations.json` reveals the gap.
+- **New plugin doesn't fit the canonical shape** (manages multiple primary packages with different floors, runs partially as a Nx-internal-only plugin, etc.). Ask before improvising — see `canonical-shape.md` §"Plugins managing multiple primary packages" for the established multi-primary pattern.
+- **Test fails on `latest`/`next` despite the assert being a no-op.** The no-op behavior is intentional, but if the generator downstream of the assert can't handle the unresolved range, that's a real bug — not something to paper over by tightening the assert.
+
+## Per-plugin decision log
+
+These were decided once for the reference PRs (#35587, #35642, #35670) — apply them as defaults unless explicitly contradicted by the user for a new plugin:
+
+- **Executors do NOT enforce the plugin floor.** Generator-only. Executors gate per-feature, not per-floor.
+- **Above-ceiling: silent fall-through to `latestVersions`.** No warn, no throw, no branch.
+- **Init generators preserve user pins** via `keepExistingVersions: true` (schema default) and the `?? true` safety net at the call site.
+- **Skip writing the install constant when the package is already detected** (cypress + angular pattern — preserves the user's installed minor/patch).
+- **Shared helpers stay in `@nx/devkit/internal`** — not part of the public devkit surface. (The W2 ticket originally proposed adding `throwForUnsupportedVersion` to the public devkit API; the implementation landed under `/internal` instead, matching how other version-related helpers ship.)
+- **Consolidation of per-plugin `getInstalled<Pkg>Version` helpers is deferred** — don't bundle that refactor into a compliance PR.
+
+Plugin-specific decisions that may be pending or have settled differently (check the live PR state via `gh pr list --repo nrwl/nx --search "multi-version compliance"`):
+
+- `@nx/jest` — needs a `peerDependencies` block for `jest`/`ts-jest`/`@types/jest` before the floor assert can rely on `getDependencyVersionFromPackageJson`.
+- `@nx/eslint` — historically gated on an ESLint v8 EOL decision. If you're touching it, confirm the decision is settled.
+- `@nx/eslint-plugin` — historically coupled to the eslint v8 decision (typescript-eslint v6/v7 only support eslint v8). Confirm before proceeding.
+- `@nx/rspack` / `@nx/rsbuild` — there is an open PR (`#35676` at time of writing). Inspect for the local-helper-duplication anti-pattern (`anti-patterns.md` §1).


### PR DESCRIPTION
## Current Behavior

The Nx repo has no Claude Code skill for multi-version support compliance work on first-party plugins. Each fix or audit reapplies the canonical shape from scratch by reading prior PRs, which is slow and inconsistent.

## Expected Behavior

A reusable Claude Code skill lives under `.claude/skills/multi-version-compliance/` and provides:

- **Fix mode**: drive a per-plugin compliance fix from a tracked task (primary), with discovery fallback when no task exists.
- **Review mode**: code-level review of a compliance PR against the canonical shape, with scope-drift check vs. the corresponding tracked task.

## Implementation Details

Files added under `.claude/skills/multi-version-compliance/`:

- `SKILL.md` — entry points, mode workflows, critical rules, findings doc template.
- `references/canonical-shape.md` — how a compliant plugin looks, plus the code-level verification rubric used in review mode.
- `references/anti-patterns.md` — 18 numbered anti-patterns with file:line citations.
- `references/gotchas.md` — edge cases (dist-tags, pnpm catalogs, ecosystem lockstep, effective floor, cross-plugin coordination).
- `references/examples.md` — reference files, commits, and PRs to grep.

Reference PRs the skill models on: #35587 (`@nx/angular`), #35642 (`@nx/playwright`), #35670 (`@nx/cypress`), #35671 (`@nx/vitest`).