### PR TITLE
docs(nx-dev): refresh docs header CTA and star widget styling

### DIFF
--- a/astro-docs/src/components/layout/Header.astro
+++ b/astro-docs/src/components/layout/Header.astro
@@ -472,14 +472,14 @@ const currentVersion = versions.find((v) => v.current);
         Contact
       </a>
       <a
-        id="header-try-nx-cloud-btn"
+        id="header-get-started-btn"
         href="https://cloud.nx.app/get-started?utm_source=nx-dev&utm_medium=documentation-header&utm_campaign=try-nx-cloud"
         target="_blank"
         rel="noopener noreferrer"
-        class="inline-flex items-center justify-center px-2.5 py-1.5 text-sm font-medium rounded-md transition no-underline bg-blue-500 dark:bg-sky-500 text-white hover:bg-blue-600 dark:hover:bg-sky-600 shadow-sm"
-        title="Try Nx Cloud for free"
+        class="inline-flex items-center justify-center px-2.5 py-1.5 text-sm font-medium rounded-md transition no-underline bg-zinc-950 dark:bg-zinc-100 text-white dark:text-zinc-950 hover:bg-zinc-900 dark:hover:bg-white shadow-sm"
+        title="Get started"
       >
-        Try Nx Cloud for free
+        Get started
       </a>
     </div>
     <!-- Social Icons - Hide on screens smaller than 2xl (1536px) -->
@@ -505,7 +505,7 @@ const currentVersion = versions.find((v) => v.current);
     const pricingLink = document.getElementById('header-pricing-link');
     const enterpriseLink = document.getElementById('header-enterprise-link');
     const contactBtn = document.getElementById('header-contact-btn');
-    const tryNxCloudBtn = document.getElementById('header-try-nx-cloud-btn');
+    const getStartedBtn = document.getElementById('header-get-started-btn');
 
     docsHomeLink?.addEventListener('click', () => {
       sendCustomEventViaGtm(
@@ -555,7 +555,7 @@ const currentVersion = versions.find((v) => v.current);
       );
     });
 
-    tryNxCloudBtn?.addEventListener('click', () => {
+    getStartedBtn?.addEventListener('click', () => {
       sendCustomEventViaGtm(
         'login-click',
         'header-cta',

--- a/nx-dev/ui-common/src/lib/github-star-widget.tsx
+++ b/nx-dev/ui-common/src/lib/github-star-widget.tsx
@@ -38,7 +38,7 @@ export function GitHubStarWidget({
   };
 
   return (
-    <div className="relative mx-2 flex items-center justify-center gap-2 rounded-md bg-zinc-950 p-2 text-xs text-white transition hover:bg-zinc-900 dark:bg-zinc-100 dark:text-zinc-950 dark:hover:bg-white print:hidden">
+    <div className="relative mx-2 flex items-center justify-center gap-2 rounded-md border border-slate-300 bg-white p-2 text-xs text-slate-700 transition hover:bg-slate-50 dark:border-slate-700 dark:bg-slate-800 dark:text-slate-200 dark:hover:bg-slate-700 print:hidden">
       <div className="flex items-center gap-2">
         <GithubIcon aria-hidden="true" className="h-4 w-4" />
         <span className="font-semibold">{formatStars(starsCount)}</span>
@@ -47,7 +47,7 @@ export function GitHubStarWidget({
         href="https://github.com/nrwl/nx"
         target="_blank"
         rel="noreferrer noopener"
-        className="flex items-center gap-2 border-transparent font-bold text-white no-underline dark:text-zinc-950"
+        className="flex items-center gap-2 border-transparent font-bold text-slate-700 no-underline dark:text-slate-200"
         onClick={() => handleClick('githubstars_buttonclick')}
       >
         <span className="absolute inset-0" />


### PR DESCRIPTION
Swap the visual hierarchy of the docs header: the call-to-action becomes the primary (black) button labeled "Get started", and the GitHub "Star us" widget moves to a secondary outlined/muted treatment. Link target, target/rel, and the existing GTM event remain unchanged.

Fixes DOC-507
