### PR TITLE
fix(gradle): pin generated e2e project toolchain to installed JDK

### DIFF
--- a/e2e/gradle/src/utils/create-gradle-project.ts
+++ b/e2e/gradle/src/utils/create-gradle-project.ts
@@ -9,7 +9,9 @@ import { existsSync, readFileSync } from 'fs';
 import { appendFileSync, createFileSync, writeFileSync } from 'fs-extra';
 import { join, resolve } from 'path';
 
-const kotlinVersion = '2.1.20';
+// Kotlin 2.2+ is required to target JVM 24 bytecode; older versions cap at
+// JVM 23 and cause an inconsistent-JVM-target build failure on JDK 24.
+const kotlinVersion = '2.3.21';
 
 export function createGradleProject(
   projectName: string,
@@ -57,7 +59,6 @@ export function createGradleProject(
     )
   );
 
-  // Update Kotlin version to 2.0.21 after project creation
   if (type === 'kotlin') {
     updateKotlinVersion(cwd, type);
     // The Kotlin Gradle Plugin writes session/IPC files under .kotlin/.

--- a/e2e/gradle/src/utils/create-gradle-project.ts
+++ b/e2e/gradle/src/utils/create-gradle-project.ts
@@ -18,7 +18,10 @@ export function createGradleProject(
   packageName: string = 'gradleProject',
   addProjectJsonNamePrefix: string = ''
 ) {
-  e2eConsoleLogger(`Using java version: ${execSync('java -version')}`);
+  // `java -version` prints to stderr, so redirect it to capture the output.
+  const javaVersionOutput = execSync('java -version 2>&1').toString();
+  e2eConsoleLogger(`Using java version: ${javaVersionOutput}`);
+  const javaMajorVersion = parseJavaMajorVersion(javaVersionOutput);
   const gradleCommand = isWindows()
     ? resolve(`${__dirname}/../../../../gradlew.bat`)
     : resolve(`${__dirname}/../../../../gradlew`);
@@ -42,7 +45,12 @@ export function createGradleProject(
   );
   e2eConsoleLogger(
     runCommand(
-      `${gradleCommand} init --type ${type}-application --dsl ${type} --project-name ${projectName} --package ${packageName} --no-incubating --split-project --overwrite --no-daemon`,
+      // Pin the generated project's Java toolchain to the JDK that is
+      // actually installed. Without this, `gradle init` defaults to a fixed
+      // version (e.g. 21); if that differs from the installed JDK, Gradle
+      // falls back to downloading it via the foojay API, which makes the
+      // tests fail whenever foojay is unavailable.
+      `${gradleCommand} init --type ${type}-application --dsl ${type} --project-name ${projectName} --package ${packageName} --java-version ${javaMajorVersion} --no-incubating --split-project --overwrite --no-daemon`,
       {
         cwd,
       }
@@ -94,6 +102,19 @@ export function createGradleProject(
   addSpringBootPlugin(
     join(cwd, `app/build.gradle${type === 'kotlin' ? '.kts' : ''}`)
   );
+}
+
+function parseJavaMajorVersion(javaVersionOutput: string): string {
+  // Matches both modern (`24.0.2`) and legacy (`1.8.0_392`) version strings.
+  const match = javaVersionOutput.match(/version "(\d+)(?:\.(\d+))?/);
+  if (!match) {
+    throw new Error(
+      `Could not determine Java major version from: ${javaVersionOutput}`
+    );
+  }
+  // Legacy versions report as `1.8` etc., where the real major is the second
+  // segment; modern versions report the major directly.
+  return match[1] === '1' && match[2] ? match[2] : match[1];
 }
 
 function appendToGitignore(cwd: string, entry: string) {


### PR DESCRIPTION
## Current Behavior

The Gradle e2e tests (`e2e/gradle/src/`) generate a project with `gradle init`. For a `kotlin-application`, `gradle init` bakes a fixed Java toolchain version (e.g. 21) into the generated build files.

CI machines provision Java via mise (currently Java 24). When the generated project's pinned toolchain version differs from the installed JDK, Gradle cannot find a matching local JDK and falls back to **auto-provisioning** it through the foojay disco API. The e2e tests then fail whenever foojay is slow or unavailable — e.g. the recent `Could not HEAD 'https://api.foojay.io/...' Received status code 400` / `pkg cache is currently be restored` failures, where only the kotlin tests failed (the groovy template doesn't pin a toolchain).

## Expected Behavior

The generated e2e project pins its Java toolchain to the JDK that is actually installed on the machine, so Gradle detects it locally and never needs to download one.

`createGradleProject` now reads `java -version`, derives the installed major version, and passes it to `gradle init` via `--java-version`. This removes the dependency on the foojay API from the Gradle e2e suite.

## Related Issue(s)

N/A — CI flakiness fix.
