### PR TITLE
test(release): cover v23 adjustSemverBumpsForZeroMajorVersion default

### DIFF
--- a/e2e/release/src/adjust-semver-bumps-zero-major.test.ts
+++ b/e2e/release/src/adjust-semver-bumps-zero-major.test.ts
@@ -1,0 +1,64 @@
+import { NxJsonConfiguration } from '@nx/devkit';
+import {
+  cleanupProject,
+  newProject,
+  runCLI,
+  uniq,
+  updateJson,
+} from '@nx/e2e-utils';
+
+/**
+ * End-to-end coverage for the v23 default flip of
+ * `release.version.adjustSemverBumpsForZeroMajorVersion`.
+ *
+ * The full bump-shifting matrix is covered exhaustively by the unit tests in
+ * `packages/nx/src/command-line/release/utils/semver.spec.ts`. The goal here is
+ * narrower: confirm the default actually wires through the full
+ * `nx release version` pipeline (config defaults → resolver → versioning), and
+ * that explicitly opting out restores the original SemVer behavior.
+ */
+describe('nx release adjustSemverBumpsForZeroMajorVersion default', () => {
+  let pkg: string;
+
+  beforeAll(() => {
+    newProject({ packages: ['@nx/js'] });
+    pkg = uniq('my-pkg');
+    runCLI(`generate @nx/workspace:npm-package ${pkg}`);
+  });
+
+  afterAll(() => cleanupProject());
+
+  it('shifts a "major" bump down to a minor for 0.x projects by default', () => {
+    setStartingVersion('0.1.0');
+    setReleaseConfig({});
+    expect(runCLI(`release version major -d`)).toMatch(/new version 0\.2\.0/);
+  });
+
+  it('leaves bumps unadjusted for 1.x+ projects regardless of the default', () => {
+    setStartingVersion('1.0.0');
+    setReleaseConfig({});
+    expect(runCLI(`release version major -d`)).toMatch(/new version 2\.0\.0/);
+  });
+
+  it('restores the original SemVer behavior when opted out with adjustSemverBumpsForZeroMajorVersion: false', () => {
+    setStartingVersion('0.1.0');
+    setReleaseConfig({
+      version: { adjustSemverBumpsForZeroMajorVersion: false },
+    });
+    expect(runCLI(`release version major -d`)).toMatch(/new version 1\.0\.0/);
+  });
+
+  function setStartingVersion(version: string) {
+    updateJson<{ version: string }>(`${pkg}/package.json`, (json) => ({
+      ...json,
+      version,
+    }));
+  }
+
+  function setReleaseConfig(release: NxJsonConfiguration['release']) {
+    updateJson<NxJsonConfiguration>('nx.json', (json) => ({
+      ...json,
+      release,
+    }));
+  }
+});


### PR DESCRIPTION
> **Depends on #35694.** That PR flips the runtime default of
> `release.version.adjustSemverBumpsForZeroMajorVersion` from `false` to `true`.
> CI on this branch will be red until #35694 lands on master; once it does, this
> branch fast-forwards onto master with no rebase needed.

## Current Behavior

The bump-shifting matrix that the v23 default flip activates is covered exhaustively at the unit level by `packages/nx/src/command-line/release/utils/semver.spec.ts`, but there is no e2e coverage proving the default actually wires through the full `nx release version` pipeline (config defaults → resolver → versioning). When the existing e2e suite started failing after the default flip in #35694, every affected test was opted back to `false` to preserve their original expectations — leaving no e2e that actually exercises the new default.

## Expected Behavior

A new `e2e/release/src/adjust-semver-bumps-zero-major.test.ts` adds focused coverage for the wiring:

- A 0.x project with default config bumps from `0.1.0 → 0.2.0` on `nx release version major` (proving the new default kicks in).
- A 1.x project with default config bumps from `1.0.0 → 2.0.0` on `nx release version major` (proving the adjustment only applies to 0.x).
- A 0.x project that explicitly sets `adjustSemverBumpsForZeroMajorVersion: false` bumps from `0.1.0 → 1.0.0` (proving the opt-out path).

The test uses `nx release version <specifier> -d` (dry-run with an explicit relative keyword) for determinism — no conventional-commits fixtures, no inline snapshots, just `toContain` assertions on the resolved-version log line.

## Related Issue(s)

N/A — internal v23 release coverage. Stacked on #35694.