### PR TITLE
fix(core): keep daemon alive when a recompute's plugin load fails

### DIFF
--- a/e2e/nx/src/spread.test.ts
+++ b/e2e/nx/src/spread.test.ts
@@ -1099,5 +1099,48 @@ describe('Spread Token Merging', () => {
         ]);
       }
     });
+
+    /**
+     * Mirrors the shape of the flaky single-shot test
+     * ("...with target defaults overriding"): per iteration a plugin
+     * file, nx.json (plugins + targetDefaults) and project.json all
+     * change together, then a single `show project` query. A stale
+     * daemon graph here surfaces as build being undefined entirely —
+     * the plugin set the graph was built against never ran.
+     */
+    it('reflects a plugin + nx.json + project.json change applied together, repeatedly', () => {
+      for (let i = 0; i < 4; i++) {
+        const lib = uniq('lib');
+        runCLI(`generate @nx/js:lib libs/${lib}`);
+
+        createPlugin(
+          `combo-infer-${i}`,
+          `{
+          build: {
+            executor: 'nx:run-commands',
+            options: { command: 'echo build' },
+            inputs: ['inferred-${i}'],
+          }
+        }`
+        );
+        updateJson('nx.json', (json) => {
+          json.plugins = [`./tools/combo-infer-${i}`];
+          json.targetDefaults = { build: { inputs: [`defaults-${i}`] } };
+          return json;
+        });
+        updateJson(`libs/${lib}/project.json`, (c) => {
+          c.targets = { build: { inputs: [`project-${i}`, '...'] } };
+          return c;
+        });
+
+        const project = getResolvedProject(lib);
+        // Target defaults (no spread) replace the inferred inputs, then
+        // project.json spreads against the resolved defaults.
+        expect(project.targets.build.inputs).toEqual([
+          `project-${i}`,
+          `defaults-${i}`,
+        ]);
+      }
+    });
   });
 });

--- a/e2e/nx/src/spread.test.ts
+++ b/e2e/nx/src/spread.test.ts
@@ -26,10 +26,8 @@ describe('Spread Token Merging', () => {
     existingNxJson = readJson('nx.json');
   });
   afterEach(() => {
-    // Print the daemon log into the test's stdout BEFORE reset (which
-    // stops the daemon and may rotate the file). CI captures stdout
-    // per test so the [watcher] lines end up alongside the failure
-    // assertion in the build output.
+    // Dump the daemon log to stdout BEFORE reset (which stops the daemon and
+    // may rotate the file), so CI shows it next to the failing assertion.
     try {
       const daemonLog = join(
         tmpProjPath(),
@@ -39,8 +37,7 @@ describe('Spread Token Merging', () => {
         'daemon.log'
       );
       if (existsSync(daemonLog)) {
-        // Trimmed to the diagnostic lines — see trimDaemonLog. The raw log
-        // is thousands of watcher/message lines per test.
+        // Trimmed — see trimDaemonLog; the raw log is thousands of lines.
         const contents = trimDaemonLog(readFileSync(daemonLog, 'utf-8'));
         console.log(
           `\n========== daemon.log (trimmed) for "${
@@ -959,20 +956,11 @@ describe('Spread Token Merging', () => {
   });
 
   /**
-   * Race-condition stress.
-   *
-   * These tests deliberately mutate nx.json (and tools/*) in tight loops
-   * with no settle time between the write and the `show project` query,
-   * and without a `reset` in between — so the long-lived daemon must pick
-   * up every change through its file watcher before it serves the graph.
-   *
-   * If the daemon answers from a stale cached graph (the watcher event
-   * for the latest nx.json write has not landed yet), the resolved
-   * build.inputs will not match the expectation and the test fails.
-   * Each loop iteration is a fresh chance to hit that window, so a flake
-   * that shows up ~1-in-20 in a single-shot test shows up far more often
-   * here. The restored daemon.log dump (afterEach) captures the
-   * [watcher]/recompute lines so a failure is diagnosable on CI.
+   * Race-condition stress. Each test mutates nx.json (and tools/*) in tight
+   * loops with no settle time and no `reset`, so the long-lived daemon must
+   * pick up every change via its watcher before serving the graph. A stale
+   * cached graph surfaces as the wrong build.inputs; looping multiplies the
+   * odds of hitting the window a single-shot test flakes on ~1-in-20.
    */
   describe('rapid reconfiguration (race-condition stress)', () => {
     it('reflects the latest specified plugin after rapid nx.json swaps', () => {
@@ -1104,12 +1092,10 @@ describe('Spread Token Merging', () => {
     });
 
     /**
-     * Mirrors the shape of the flaky single-shot test
-     * ("...with target defaults overriding"): per iteration a plugin
-     * file, nx.json (plugins + targetDefaults) and project.json all
-     * change together, then a single `show project` query. A stale
-     * daemon graph here surfaces as build being undefined entirely —
-     * the plugin set the graph was built against never ran.
+     * Mirrors the flaky single-shot test ("...with target defaults
+     * overriding"): per iteration a plugin file, nx.json and project.json
+     * all change together, then one `show project`. A stale graph surfaces
+     * as build being undefined — the plugin set it was built against never ran.
      */
     it('reflects a plugin + nx.json + project.json change applied together, repeatedly', () => {
       for (let i = 0; i < 4; i++) {

--- a/e2e/nx/src/spread.test.ts
+++ b/e2e/nx/src/spread.test.ts
@@ -4,6 +4,7 @@ import {
   readJson,
   runCLI,
   tmpProjPath,
+  trimDaemonLog,
   uniq,
   updateFile,
   updateJson,
@@ -38,9 +39,11 @@ describe('Spread Token Merging', () => {
         'daemon.log'
       );
       if (existsSync(daemonLog)) {
-        const contents = readFileSync(daemonLog, 'utf-8');
+        // Trimmed to the diagnostic lines — see trimDaemonLog. The raw log
+        // is thousands of watcher/message lines per test.
+        const contents = trimDaemonLog(readFileSync(daemonLog, 'utf-8'));
         console.log(
-          `\n========== daemon.log for "${
+          `\n========== daemon.log (trimmed) for "${
             expect.getState().currentTestName ?? 'unknown'
           }" ==========\n${contents}\n========== end daemon.log ==========\n`
         );

--- a/e2e/nx/src/spread.test.ts
+++ b/e2e/nx/src/spread.test.ts
@@ -3,10 +3,13 @@ import {
   newProject,
   readJson,
   runCLI,
+  tmpProjPath,
   uniq,
   updateFile,
   updateJson,
 } from '@nx/e2e-utils';
+import { existsSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
 
 describe('Spread Token Merging', () => {
   let proj: string;
@@ -22,6 +25,32 @@ describe('Spread Token Merging', () => {
     existingNxJson = readJson('nx.json');
   });
   afterEach(() => {
+    // Print the daemon log into the test's stdout BEFORE reset (which
+    // stops the daemon and may rotate the file). CI captures stdout
+    // per test so the [watcher] lines end up alongside the failure
+    // assertion in the build output.
+    try {
+      const daemonLog = join(
+        tmpProjPath(),
+        '.nx',
+        'workspace-data',
+        'd',
+        'daemon.log'
+      );
+      if (existsSync(daemonLog)) {
+        const contents = readFileSync(daemonLog, 'utf-8');
+        console.log(
+          `\n========== daemon.log for "${
+            expect.getState().currentTestName ?? 'unknown'
+          }" ==========\n${contents}\n========== end daemon.log ==========\n`
+        );
+      } else {
+        console.log(`[spread-debug] no daemon log at ${daemonLog}`);
+      }
+    } catch (e) {
+      console.log(`[spread-debug] failed to read daemon log: ${e}`);
+    }
+
     updateFile('nx.json', JSON.stringify(existingNxJson, null, 2));
     // Reset daemon cache so the next test does not see stale plugin-inferred
     // project graph data.  The PR enabling NX_DAEMON=true in runCLI means the
@@ -923,6 +952,152 @@ describe('Spread Token Merging', () => {
 
       const project = getResolvedProject(lib);
       expect(project.targets.echo.dependsOn).toEqual(['prebuild', '^build']);
+    });
+  });
+
+  /**
+   * Race-condition stress.
+   *
+   * These tests deliberately mutate nx.json (and tools/*) in tight loops
+   * with no settle time between the write and the `show project` query,
+   * and without a `reset` in between — so the long-lived daemon must pick
+   * up every change through its file watcher before it serves the graph.
+   *
+   * If the daemon answers from a stale cached graph (the watcher event
+   * for the latest nx.json write has not landed yet), the resolved
+   * build.inputs will not match the expectation and the test fails.
+   * Each loop iteration is a fresh chance to hit that window, so a flake
+   * that shows up ~1-in-20 in a single-shot test shows up far more often
+   * here. The restored daemon.log dump (afterEach) captures the
+   * [watcher]/recompute lines so a failure is diagnosable on CI.
+   */
+  describe('rapid reconfiguration (race-condition stress)', () => {
+    it('reflects the latest specified plugin after rapid nx.json swaps', () => {
+      const lib = uniq('lib');
+      runCLI(`generate @nx/js:lib libs/${lib}`);
+      updateJson(`libs/${lib}/project.json`, (c) => {
+        c.targets = {};
+        return c;
+      });
+
+      // Pre-create a pool of plugins, each stamping a distinct input.
+      const pluginCount = 6;
+      for (let i = 0; i < pluginCount; i++) {
+        createPlugin(
+          `race-plugin-${i}`,
+          `{
+          build: {
+            executor: 'nx:run-commands',
+            options: { command: 'echo build' },
+            inputs: ['from-plugin-${i}'],
+          }
+        }`
+        );
+      }
+
+      // Swap the active plugin and query immediately, no settle time.
+      // A stale daemon graph surfaces as the previous iteration's input.
+      for (let i = 0; i < pluginCount; i++) {
+        updateJson('nx.json', (json) => {
+          json.plugins = [`./tools/race-plugin-${i}`];
+          return json;
+        });
+        const project = getResolvedProject(lib);
+        expect(project.targets.build.inputs).toEqual([`from-plugin-${i}`]);
+      }
+    });
+
+    it('reflects plugin-list growth and shrink across rapid nx.json edits', () => {
+      const lib = uniq('lib');
+      runCLI(`generate @nx/js:lib libs/${lib}`);
+      updateJson(`libs/${lib}/project.json`, (c) => {
+        c.targets = {};
+        return c;
+      });
+
+      createPlugin(
+        'race-base',
+        `{
+        build: {
+          executor: 'nx:run-commands',
+          options: { command: 'echo build' },
+          inputs: ['base'],
+        }
+      }`
+      );
+      createPlugin(
+        'race-spread',
+        `{
+        build: {
+          executor: 'nx:run-commands',
+          options: { command: 'echo build' },
+          inputs: ['spread', '...'],
+        }
+      }`
+      );
+
+      // Alternate between one plugin and two (with spread). The resolved
+      // inputs differ each step, so a stale graph is caught immediately.
+      const steps: { plugins: string[]; inputs: string[] }[] = [
+        { plugins: ['./tools/race-base'], inputs: ['base'] },
+        {
+          plugins: ['./tools/race-base', './tools/race-spread'],
+          inputs: ['spread', 'base'],
+        },
+        { plugins: ['./tools/race-spread'], inputs: ['spread'] },
+        {
+          plugins: ['./tools/race-base', './tools/race-spread'],
+          inputs: ['spread', 'base'],
+        },
+        { plugins: ['./tools/race-base'], inputs: ['base'] },
+      ];
+      for (const { plugins, inputs } of steps) {
+        updateJson('nx.json', (json) => {
+          json.plugins = plugins;
+          return json;
+        });
+        const project = getResolvedProject(lib);
+        expect(project.targets.build.inputs).toEqual(inputs);
+      }
+    });
+
+    it('reflects rapid project.json edits against a stable plugin base', () => {
+      const lib = uniq('lib');
+      runCLI(`generate @nx/js:lib libs/${lib}`);
+
+      createPlugin(
+        'race-infer',
+        `{
+        build: {
+          executor: 'nx:run-commands',
+          options: { command: 'echo build' },
+          inputs: ['inferred'],
+        }
+      }`
+      );
+      updateJson('nx.json', (json) => {
+        json.plugins = ['./tools/race-infer'];
+        return json;
+      });
+
+      // Plugin set is fixed; only project.json changes each round. The
+      // daemon must observe that file change before answering — a stale
+      // graph surfaces as a previous iteration's project input.
+      for (let i = 0; i < 6; i++) {
+        updateJson(`libs/${lib}/project.json`, (c) => {
+          c.targets = {
+            build: {
+              inputs: [`project-${i}`, '...'],
+            },
+          };
+          return c;
+        });
+        const project = getResolvedProject(lib);
+        expect(project.targets.build.inputs).toEqual([
+          `project-${i}`,
+          'inferred',
+        ]);
+      }
     });
   });
 });

--- a/e2e/plugin/src/nx-plugin.test.ts
+++ b/e2e/plugin/src/nx-plugin.test.ts
@@ -10,12 +10,14 @@ import {
   runCLI,
   runCLIAsync,
   runCommand,
+  tmpProjPath,
   uniq,
   updateFile,
   updateJson,
 } from '@nx/e2e-utils';
 import type { PackageJson } from 'nx/src/utils/package-json';
 
+import { existsSync, readFileSync } from 'node:fs';
 import { join } from 'path';
 import {
   ASYNC_GENERATOR_EXECUTOR_CONTENTS,
@@ -29,7 +31,35 @@ describe('Nx Plugin', () => {
     workspaceName = newProject({ packages: ['@nx/plugin'] });
   });
 
-  afterAll(() => cleanupProject());
+  afterAll(() => {
+    // The whole suite shares one long-lived daemon (no `reset` between
+    // tests), so dump its log once before teardown. CI captures it, so a
+    // failure — e.g. a daemon crash on plugin load — is diagnosable;
+    // locate a given test by its `Run Command` / [REQUEST] lines.
+    try {
+      const daemonLog = join(
+        tmpProjPath(),
+        '.nx',
+        'workspace-data',
+        'd',
+        'daemon.log'
+      );
+      if (existsSync(daemonLog)) {
+        console.log(
+          `\n========== daemon.log ==========\n${readFileSync(
+            daemonLog,
+            'utf-8'
+          )}\n========== end daemon.log ==========\n`
+        );
+      } else {
+        console.log(`[plugin-debug] no daemon log at ${daemonLog}`);
+      }
+    } catch (e) {
+      console.log(`[plugin-debug] failed to read daemon log: ${e}`);
+    }
+
+    cleanupProject();
+  });
 
   it('should be able to generate a Nx Plugin ', async () => {
     const plugin = uniq('plugin');

--- a/e2e/plugin/src/nx-plugin.test.ts
+++ b/e2e/plugin/src/nx-plugin.test.ts
@@ -11,6 +11,7 @@ import {
   runCLIAsync,
   runCommand,
   tmpProjPath,
+  trimDaemonLog,
   uniq,
   updateFile,
   updateJson,
@@ -45,10 +46,11 @@ describe('Nx Plugin', () => {
         'daemon.log'
       );
       if (existsSync(daemonLog)) {
+        // Trimmed to the diagnostic lines — see trimDaemonLog. The raw log
+        // is thousands of watcher/message lines that bury a plugin crash.
         console.log(
-          `\n========== daemon.log ==========\n${readFileSync(
-            daemonLog,
-            'utf-8'
+          `\n========== daemon.log (trimmed) ==========\n${trimDaemonLog(
+            readFileSync(daemonLog, 'utf-8')
           )}\n========== end daemon.log ==========\n`
         );
       } else {

--- a/e2e/plugin/src/nx-plugin.test.ts
+++ b/e2e/plugin/src/nx-plugin.test.ts
@@ -33,10 +33,8 @@ describe('Nx Plugin', () => {
   });
 
   afterAll(() => {
-    // The whole suite shares one long-lived daemon (no `reset` between
-    // tests), so dump its log once before teardown. CI captures it, so a
-    // failure — e.g. a daemon crash on plugin load — is diagnosable;
-    // locate a given test by its `Run Command` / [REQUEST] lines.
+    // The suite shares one long-lived daemon (no `reset`), so dump its log
+    // once before teardown — CI shows it for a daemon crash on plugin load.
     try {
       const daemonLog = join(
         tmpProjPath(),
@@ -46,8 +44,7 @@ describe('Nx Plugin', () => {
         'daemon.log'
       );
       if (existsSync(daemonLog)) {
-        // Trimmed to the diagnostic lines — see trimDaemonLog. The raw log
-        // is thousands of watcher/message lines that bury a plugin crash.
+        // Trimmed — see trimDaemonLog; the raw log is thousands of lines.
         console.log(
           `\n========== daemon.log (trimmed) ==========\n${trimDaemonLog(
             readFileSync(daemonLog, 'utf-8')

--- a/e2e/utils/log-utils.ts
+++ b/e2e/utils/log-utils.ts
@@ -39,3 +39,37 @@ export function logSuccess(title: string, body?: string) {
   )} ${styleText(['bold', 'green'], title)}`;
   return e2eConsoleLogger(message, body);
 }
+
+/**
+ * The Nx daemon log is mostly per-file watcher events and per-message
+ * bookkeeping — thousands of lines that bury the handful that explain a
+ * failure. Keep only the lines useful for diagnosing daemon/plugin issues
+ * (daemon restarts, plugin loads, stale-graph discards, errors) plus the
+ * tail, and mark where runs of noise were removed so the gaps are visible.
+ *
+ * Use when dumping `daemon.log` from an e2e test so CI output stays small
+ * while a failing run is still debuggable.
+ */
+export function trimDaemonLog(contents: string, tailLines = 30): string {
+  const signal =
+    /New daemon|Server stopped|Restarting daemon|Started new daemon|Daemon outdated|lock file hash|loadSpecifiedNxPlugins|loadDefaultNxPlugins|Load Nx Plugin:|Failed to load|AggregateError|Unable to find local plugin|Discarding stale|No in-memory cached project graph|Graph recompute necessary|recomputing project graph|Cannot find module|with an error|Error:/;
+  const lines = contents.split('\n');
+  const tailStart = Math.max(0, lines.length - tailLines);
+  const out: string[] = [];
+  let dropped = 0;
+  lines.forEach((line, i) => {
+    if (signal.test(line) || i >= tailStart) {
+      if (dropped > 0) {
+        out.push(`  … ${dropped} line(s) trimmed …`);
+        dropped = 0;
+      }
+      out.push(line);
+    } else {
+      dropped++;
+    }
+  });
+  if (dropped > 0) {
+    out.push(`  … ${dropped} line(s) trimmed …`);
+  }
+  return out.join('\n');
+}

--- a/e2e/utils/log-utils.ts
+++ b/e2e/utils/log-utils.ts
@@ -41,14 +41,9 @@ export function logSuccess(title: string, body?: string) {
 }
 
 /**
- * The Nx daemon log is mostly per-file watcher events and per-message
- * bookkeeping — thousands of lines that bury the handful that explain a
- * failure. Keep only the lines useful for diagnosing daemon/plugin issues
- * (daemon restarts, plugin loads, stale-graph discards, errors) plus the
- * tail, and mark where runs of noise were removed so the gaps are visible.
- *
- * Use when dumping `daemon.log` from an e2e test so CI output stays small
- * while a failing run is still debuggable.
+ * Trims a daemon.log to the lines useful for diagnosing daemon/plugin issues
+ * (restarts, plugin loads, stale-graph discards, errors) plus the tail,
+ * marking where noise was dropped. Keeps e2e CI output small but debuggable.
  */
 export function trimDaemonLog(contents: string, tailLines = 30): string {
   const signal =

--- a/packages/nx/src/daemon/server/project-graph-incremental-recomputation.spec.ts
+++ b/packages/nx/src/daemon/server/project-graph-incremental-recomputation.spec.ts
@@ -154,17 +154,10 @@ describe('getCachedSerializedProjectGraphPromise — watcher race coverage', () 
     });
   });
 
-  // The daemon-crash regression: scheduleProjectGraphRecomputation calls
-  // kickOffRecompute() fire-and-forget, so nothing awaits the promise it
-  // stores. When the recompute prologue (readNxJson / getPluginsSeparated)
-  // rejected, that orphaned rejection was unhandled and took the whole
-  // daemon process down. The fix wraps the IIFE body so it always resolves
-  // to an errorResult instead.
-  //
-  // A requester's own try/catch in getCachedSerializedProjectGraphPromise
-  // masks the difference, so the ONLY observable that distinguishes fixed
-  // from broken is whether the orphaned promise rejects unhandled — hence
-  // the process listener rather than an awaited assertion.
+  // kickOffRecompute() runs fire-and-forget, so a rejecting prologue used to
+  // crash the daemon with an unhandled rejection. A requester's own try/catch
+  // hides that, so the only observable distinguishing fixed from broken is
+  // whether the orphaned promise rejects unhandled — hence the process listener.
   it('keeps the daemon alive when a recompute plugin load rejects', async () => {
     fs.createFilesSync({
       'nx.json': JSON.stringify({ plugins: ['./tools/plugin-a'] }),
@@ -196,19 +189,15 @@ describe('getCachedSerializedProjectGraphPromise — watcher race coverage', () 
       process.on('unhandledRejection', onUnhandled);
 
       try {
-        // Watcher-driven, fire-and-forget kickoff — nobody awaits the
-        // promise kickOffRecompute stores.
+        // Fire-and-forget kickoff — nobody awaits the stored promise.
         scheduleProjectGraphRecomputation([], ['__trigger.txt'], []);
 
-        // Let the IIFE run its prologue, reject in getPluginsSeparated,
-        // and give Node room to flag an unhandled rejection before any
-        // requester attaches a handler.
+        // Let the IIFE reject and give Node room to flag an unhandled rejection.
         await new Promise((r) => setImmediate(r));
         await new Promise((r) => setImmediate(r));
         await new Promise((r) => setImmediate(r));
 
-        // The smoking gun: without the fix the orphaned recompute promise
-        // rejects unhandled here, which is what crashed the daemon.
+        // Without the fix this orphaned rejection is unhandled — the crash.
         expect(
           unhandled.filter(
             (r) =>
@@ -217,15 +206,12 @@ describe('getCachedSerializedProjectGraphPromise — watcher race coverage', () 
           )
         ).toEqual([]);
 
-        // A requester surfaces the failure as an errorResult (null graph,
-        // error set) rather than throwing.
+        // A requester gets an errorResult, not a throw.
         const result = await getCachedSerializedProjectGraphPromise();
         expect(result.projectGraph).toBeNull();
         expect(result.error).toBeDefined();
 
-        // The errored result clears the cached promise, so the next
-        // request retries the recompute instead of serving the error
-        // forever.
+        // Errored result clears the cache, so the next request retries.
         const callsBeforeRetry = pluginsCallCount;
         await getCachedSerializedProjectGraphPromise();
         expect(pluginsCallCount).toBeGreaterThan(callsBeforeRetry);

--- a/packages/nx/src/daemon/server/project-graph-incremental-recomputation.spec.ts
+++ b/packages/nx/src/daemon/server/project-graph-incremental-recomputation.spec.ts
@@ -153,4 +153,85 @@ describe('getCachedSerializedProjectGraphPromise — watcher race coverage', () 
       expect(pluginsCallCount).toBeGreaterThanOrEqual(2);
     });
   });
+
+  // The daemon-crash regression: scheduleProjectGraphRecomputation calls
+  // kickOffRecompute() fire-and-forget, so nothing awaits the promise it
+  // stores. When the recompute prologue (readNxJson / getPluginsSeparated)
+  // rejected, that orphaned rejection was unhandled and took the whole
+  // daemon process down. The fix wraps the IIFE body so it always resolves
+  // to an errorResult instead.
+  //
+  // A requester's own try/catch in getCachedSerializedProjectGraphPromise
+  // masks the difference, so the ONLY observable that distinguishes fixed
+  // from broken is whether the orphaned promise rejects unhandled — hence
+  // the process listener rather than an awaited assertion.
+  it('keeps the daemon alive when a recompute plugin load rejects', async () => {
+    fs.createFilesSync({
+      'nx.json': JSON.stringify({ plugins: ['./tools/plugin-a'] }),
+      'package.json': JSON.stringify({ name: 'root' }),
+    });
+
+    await jest.isolateModulesAsync(async () => {
+      const { setWorkspaceRoot } = require('../../utils/workspace-root');
+      setWorkspaceRoot(fs.tempDir);
+
+      const pluginLoadError = new Error('plugin boom');
+      let pluginsCallCount = 0;
+      jest.doMock('../../project-graph/plugins/get-plugins', () => ({
+        __esModule: true,
+        getPlugins: jest.fn(async () => []),
+        getPluginsSeparated: jest.fn(async () => {
+          pluginsCallCount++;
+          throw pluginLoadError;
+        }),
+      }));
+
+      const {
+        scheduleProjectGraphRecomputation,
+        getCachedSerializedProjectGraphPromise,
+      } = require('./project-graph-incremental-recomputation');
+
+      const unhandled: unknown[] = [];
+      const onUnhandled = (reason: unknown) => unhandled.push(reason);
+      process.on('unhandledRejection', onUnhandled);
+
+      try {
+        // Watcher-driven, fire-and-forget kickoff — nobody awaits the
+        // promise kickOffRecompute stores.
+        scheduleProjectGraphRecomputation([], ['__trigger.txt'], []);
+
+        // Let the IIFE run its prologue, reject in getPluginsSeparated,
+        // and give Node room to flag an unhandled rejection before any
+        // requester attaches a handler.
+        await new Promise((r) => setImmediate(r));
+        await new Promise((r) => setImmediate(r));
+        await new Promise((r) => setImmediate(r));
+
+        // The smoking gun: without the fix the orphaned recompute promise
+        // rejects unhandled here, which is what crashed the daemon.
+        expect(
+          unhandled.filter(
+            (r) =>
+              r === pluginLoadError ||
+              (r instanceof Error && r.message.includes('plugin boom'))
+          )
+        ).toEqual([]);
+
+        // A requester surfaces the failure as an errorResult (null graph,
+        // error set) rather than throwing.
+        const result = await getCachedSerializedProjectGraphPromise();
+        expect(result.projectGraph).toBeNull();
+        expect(result.error).toBeDefined();
+
+        // The errored result clears the cached promise, so the next
+        // request retries the recompute instead of serving the error
+        // forever.
+        const callsBeforeRetry = pluginsCallCount;
+        await getCachedSerializedProjectGraphPromise();
+        expect(pluginsCallCount).toBeGreaterThan(callsBeforeRetry);
+      } finally {
+        process.removeListener('unhandledRejection', onUnhandled);
+      }
+    });
+  });
 });

--- a/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
+++ b/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
@@ -107,12 +107,9 @@ let cacheHasBeenPersisted = false;
 function kickOffRecompute() {
   let myPromise: Promise<SerializedProjectGraph>;
   myPromise = (async () => {
-    // The whole body must resolve, never reject: scheduleProjectGraphRecomputation
-    // calls kickOffRecompute() fire-and-forget, so a rejected myPromise has no
-    // awaiter and crashes the daemon with an unhandled rejection. The prologue
-    // (readNxJson / getPluginsSeparated) can throw — e.g. a plugin fails to
-    // load — so a failure here is turned into an errorResult the next requester
-    // surfaces, same as processFilesAndCreateAndSerializeProjectGraph already does.
+    // Must resolve, never reject: kickOffRecompute() runs fire-and-forget, so
+    // a rejected myPromise crashes the daemon (unhandled rejection). A throwing
+    // prologue (e.g. plugin load fails) becomes an errorResult the next requester surfaces.
     try {
       // Single read shared with getPluginsSeparated below. This collapses
       // what would otherwise be two independent nx.json reads (our snap +

--- a/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
+++ b/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
@@ -107,35 +107,46 @@ let cacheHasBeenPersisted = false;
 function kickOffRecompute() {
   let myPromise: Promise<SerializedProjectGraph>;
   myPromise = (async () => {
-    // Single read shared with getPluginsSeparated below. This collapses
-    // what would otherwise be two independent nx.json reads (our snap +
-    // the plugin loader's) into one, so the snap hash and the plugin
-    // set the compute uses always reflect the same disk state.
-    const nxJson = readNxJson(workspaceRoot);
-    const myPluginsHash = hashObject(nxJson.plugins ?? []);
+    // The whole body must resolve, never reject: scheduleProjectGraphRecomputation
+    // calls kickOffRecompute() fire-and-forget, so a rejected myPromise has no
+    // awaiter and crashes the daemon with an unhandled rejection. The prologue
+    // (readNxJson / getPluginsSeparated) can throw — e.g. a plugin fails to
+    // load — so a failure here is turned into an errorResult the next requester
+    // surfaces, same as processFilesAndCreateAndSerializeProjectGraph already does.
+    try {
+      // Single read shared with getPluginsSeparated below. This collapses
+      // what would otherwise be two independent nx.json reads (our snap +
+      // the plugin loader's) into one, so the snap hash and the plugin
+      // set the compute uses always reflect the same disk state.
+      const nxJson = readNxJson(workspaceRoot);
+      const myPluginsHash = hashObject(nxJson.plugins ?? []);
 
-    const plugins = await getPluginsSeparated(nxJson, workspaceRoot);
+      const plugins = await getPluginsSeparated(nxJson, workspaceRoot);
 
-    // Plugin set we just loaded may already be stale vs disk.
-    if (isStale(myPluginsHash)) return chainToSuccessor(myPromise);
+      // Plugin set we just loaded may already be stale vs disk.
+      if (isStale(myPluginsHash)) return chainToSuccessor(myPromise);
 
-    const result = await processFilesAndCreateAndSerializeProjectGraph(plugins);
+      const result =
+        await processFilesAndCreateAndSerializeProjectGraph(plugins);
 
-    // Compute may have run against plugins that are now stale.
-    if (isStale(myPluginsHash)) return chainToSuccessor(myPromise);
+      // Compute may have run against plugins that are now stale.
+      if (isStale(myPluginsHash)) return chainToSuccessor(myPromise);
 
-    if (
-      cachedSerializedProjectGraphPromise === myPromise &&
-      result.projectGraph
-    ) {
-      notifyProjectGraphRecomputationListeners(
-        result.projectGraph,
-        result.sourceMaps,
-        result.error
-      );
-      persistProjectGraphToDisk(result);
+      if (
+        cachedSerializedProjectGraphPromise === myPromise &&
+        result.projectGraph
+      ) {
+        notifyProjectGraphRecomputationListeners(
+          result.projectGraph,
+          result.sourceMaps,
+          result.error
+        );
+        persistProjectGraphToDisk(result);
+      }
+      return result;
+    } catch (e) {
+      return errorResult(e);
     }
-    return result;
   })();
   cachedSerializedProjectGraphPromise = myPromise;
 }

--- a/packages/nx/src/native/watch/watcher.rs
+++ b/packages/nx/src/native/watch/watcher.rs
@@ -266,12 +266,13 @@ impl WatchPipeline {
             return Ok(());
         }
 
-        // Trace only events that survive the filter — Access reads and
+        // Log only events that survive the filter — Access reads and
         // other floods are dropped above, so we don't pollute the log
         // with their misleading age_ms (mtime there is the prior write,
-        // not the event).
+        // not the event). At debug so age_ms lands in the daemon log
+        // next to the idle-window/force-flush lines without needing trace.
         for (path, metadata) in raw.paths() {
-            trace!(
+            debug!(
                 ?path,
                 kind = ?raw.kind(),
                 age_ms = event_age_ms(metadata),

--- a/packages/nx/src/native/watch/watcher.rs
+++ b/packages/nx/src/native/watch/watcher.rs
@@ -266,13 +266,12 @@ impl WatchPipeline {
             return Ok(());
         }
 
-        // Log only events that survive the filter — Access reads and
+        // Trace only events that survive the filter — Access reads and
         // other floods are dropped above, so we don't pollute the log
         // with their misleading age_ms (mtime there is the prior write,
-        // not the event). At debug so age_ms lands in the daemon log
-        // next to the idle-window/force-flush lines without needing trace.
+        // not the event).
         for (path, metadata) in raw.paths() {
-            debug!(
+            trace!(
                 ?path,
                 kind = ?raw.kind(),
                 age_ms = event_age_ms(metadata),

--- a/packages/nx/src/project-graph/plugins/get-plugins.spec.ts
+++ b/packages/nx/src/project-graph/plugins/get-plugins.spec.ts
@@ -1,6 +1,20 @@
 import { createSerializableError } from '../../utils/serializable-error';
 import { reasonToError } from './get-plugins';
 
+// Isolation off so loadingMethod() routes to loadNxPlugin, which we mock.
+jest.mock('./isolation/enabled', () => ({
+  isIsolationEnabled: () => false,
+}));
+jest.mock('./isolation', () => ({
+  loadIsolatedNxPlugin: jest.fn(),
+}));
+jest.mock('../../adapter/angular-json', () => ({
+  shouldMergeAngularProjects: () => false,
+}));
+jest.mock('./in-process-loader', () => ({
+  loadNxPlugin: jest.fn(),
+}));
+
 describe('reasonToError', () => {
   it('should return the same Error instance when given a real Error', () => {
     const error = new Error('real error');
@@ -32,5 +46,81 @@ describe('reasonToError', () => {
     expect(reasonToError(42).message).toBe('42');
     expect(reasonToError(null).message).toBe('null');
     expect(reasonToError(undefined).message).toBe('undefined');
+  });
+});
+
+describe('getPluginsSeparated', () => {
+  let getPluginsSeparated: typeof import('./get-plugins').getPluginsSeparated;
+  let loadNxPlugin: jest.Mock;
+  // Resolver for each deferred specified-plugin load, keyed by plugin name.
+  let pendingPluginLoads: Map<string, (plugin: unknown) => void>;
+
+  beforeEach(() => {
+    // Fresh module state per test — getPluginsSeparated caches at module
+    // level, so a stale cache would mask the behavior under test.
+    jest.resetModules();
+    pendingPluginLoads = new Map();
+
+    ({ loadNxPlugin } = require('./in-process-loader'));
+    loadNxPlugin.mockImplementation((plugin: unknown) => {
+      const name = typeof plugin === 'string' ? plugin : (plugin as any).plugin;
+      // Default plugins load from absolute paths — resolve them immediately.
+      // Only the `test-*` specified plugins are deferred, so a test controls
+      // which load finishes first.
+      if (!name.startsWith('test-')) {
+        return [Promise.resolve({ name }), () => {}];
+      }
+      const promise = new Promise((resolve) => {
+        pendingPluginLoads.set(name, resolve);
+      });
+      return [promise, () => {}];
+    });
+
+    ({ getPluginsSeparated } = require('./get-plugins'));
+  });
+
+  function finishLoading(pluginName: string) {
+    const resolve = pendingPluginLoads.get(pluginName);
+    if (!resolve) {
+      throw new Error(`No pending load for plugin "${pluginName}"`);
+    }
+    resolve({ name: pluginName });
+  }
+
+  it('does not poison the cache when an older recompute finishes after a newer one', async () => {
+    // Two recomputes race — as happens when a daemon restart fires an
+    // initial recompute and a watcher recompute together — each snapshotting
+    // a different nx.json plugin set.
+    const olderCall = getPluginsSeparated({ plugins: ['test-a'] });
+    const newerCall = getPluginsSeparated({ plugins: ['test-b'] });
+
+    // The newer recompute (test-b) finishes first and commits the cache.
+    finishLoading('test-b');
+    const newerResult = await newerCall;
+    expect(newerResult.specifiedPlugins.map((p) => p.name)).toEqual(['test-b']);
+
+    // The older recompute (test-a) finishes last. It must NOT overwrite the
+    // cache the newer recompute committed.
+    finishLoading('test-a');
+    await olderCall;
+
+    // A later recompute reading the newer nx.json must get the newer plugin
+    // set — not the stale set the older recompute loaded.
+    const afterRace = await getPluginsSeparated({ plugins: ['test-b'] });
+    expect(afterRace.specifiedPlugins.map((p) => p.name)).toEqual(['test-b']);
+  });
+
+  it('shares a single load between concurrent calls for the same plugin set', async () => {
+    const first = getPluginsSeparated({ plugins: ['test-a'] });
+    const second = getPluginsSeparated({ plugins: ['test-a'] });
+
+    finishLoading('test-a');
+    await Promise.all([first, second]);
+
+    // test-a was loaded once, not once per caller.
+    const testALoads = loadNxPlugin.mock.calls.filter(
+      ([plugin]) => plugin === 'test-a'
+    );
+    expect(testALoads).toHaveLength(1);
   });
 });

--- a/packages/nx/src/project-graph/plugins/get-plugins.spec.ts
+++ b/packages/nx/src/project-graph/plugins/get-plugins.spec.ts
@@ -14,6 +14,12 @@ jest.mock('../../adapter/angular-json', () => ({
 jest.mock('./in-process-loader', () => ({
   loadNxPlugin: jest.fn(),
 }));
+// Resolution of local plugins relies on a cached workspace snapshot;
+// loadSpecifiedNxPlugins must drop it on every reload. Mocked so the test can
+// assert that wiring without touching the real filesystem-backed resolver.
+jest.mock('./resolve-plugin', () => ({
+  resetResolvePluginCache: jest.fn(),
+}));
 
 describe('reasonToError', () => {
   it('should return the same Error instance when given a real Error', () => {
@@ -122,5 +128,20 @@ describe('getPluginsSeparated', () => {
       ([plugin]) => plugin === 'test-a'
     );
     expect(testALoads).toHaveLength(1);
+  });
+
+  it('drops the cached local-plugin resolution snapshot when loading the specified plugins', async () => {
+    const { resetResolvePluginCache } = require('./resolve-plugin');
+    expect(resetResolvePluginCache).not.toHaveBeenCalled();
+
+    const load = getPluginsSeparated({ plugins: ['test-a'] });
+    finishLoading('test-a');
+    await load;
+
+    // Loading the specified plugins must reset the resolver's workspace
+    // snapshot. Without this a plugin added to nx.json after an earlier
+    // resolution would be resolved against a stale project layout — missing
+    // its own project — and collapse to the workspace root.
+    expect(resetResolvePluginCache).toHaveBeenCalled();
   });
 });

--- a/packages/nx/src/project-graph/plugins/get-plugins.ts
+++ b/packages/nx/src/project-graph/plugins/get-plugins.ts
@@ -28,19 +28,16 @@ let cachedSeparatedPlugins: SeparatedPlugins;
 let pendingPluginsPromise: Promise<LoadedNxPlugin[]> | undefined;
 let cleanupSpecifiedPlugins: () => void | undefined;
 
-// Hash of the plugin set the most recent getPluginsSeparated call asked
-// for. The cache commit is gated on it: a load writes cachedSeparatedPlugins
-// and currentPluginsConfigurationHash only if its hash is still the latest
-// requested when it finishes. Two recomputes can run at once — a daemon
-// restart fires an initial recompute and a watcher recompute together — and
-// without this gate a slower load for an older nx.json could overwrite the
-// cache of a newer one, leaving the hash key and the cached plugin set
-// describing different plugin sets (so a later cache hit serves the wrong
-// plugins).
-let latestRequestedPluginsHash: string | undefined;
-// In-flight separated-plugins load, tagged with the hash it is loading, so
-// concurrent callers asking for the same plugin set share one load instead
-// of starting a second that races the module-level cache state.
+// In-flight separated-plugins load, tagged with the hash it is loading.
+// Serves two roles: (1) a concurrent caller asking for the same plugin set
+// shares this one load instead of starting a second that races the
+// module-level cache state, and (2) it is the commit gate — a load writes
+// cachedSeparatedPlugins / currentPluginsConfigurationHash only if it is
+// still the registered load when it finishes. Two recomputes can run at once
+// (a daemon restart fires an initial recompute and a watcher recompute
+// together); without the gate a slower load for an older nx.json could
+// overwrite a newer one's cache, leaving the hash key and the cached plugin
+// set describing different plugin sets.
 let pendingSeparatedPlugins:
   | { hash: string; promise: Promise<SeparatedPlugins> }
   | undefined;
@@ -106,11 +103,6 @@ export async function getPluginsSeparated(
     return pendingSeparatedPlugins.promise;
   }
 
-  // This call now owns the most recent plugin configuration. The commit at
-  // the end of the load checks this, so an older load that finishes later
-  // cannot clobber a newer one's cache.
-  latestRequestedPluginsHash = pluginsConfigurationHash;
-
   // Plugins config changed (e.g. `nx add @nx/maven` updated nx.json). The
   // cached SeparatedPlugins is invalidated by the early-return above, but
   // pendingPluginsPromise — the in-flight load — would otherwise be reused
@@ -150,10 +142,11 @@ export async function getPluginsSeparated(
       defaultPlugins,
     };
 
-    // Commit the cache only if a newer request has not superseded us, so
-    // currentPluginsConfigurationHash and cachedSeparatedPlugins are always
-    // written together, by the same call, and describe the same plugin set.
-    if (latestRequestedPluginsHash === pluginsConfigurationHash) {
+    // Commit the cache only if a newer request has not superseded us — i.e.
+    // we are still the registered in-flight load. currentPluginsConfigurationHash
+    // and cachedSeparatedPlugins are then always written together, by the same
+    // call, and describe the same plugin set.
+    if (pendingSeparatedPlugins?.promise === loadPromise) {
       cachedSeparatedPlugins = separatedPlugins;
       currentPluginsConfigurationHash = pluginsConfigurationHash;
       loadedPlugins = specifiedPlugins.concat(defaultPlugins);
@@ -222,10 +215,10 @@ export function cleanupPlugins() {
   pendingPluginsPromise = undefined;
   pendingDefaultPluginPromise = undefined;
   cachedSeparatedPlugins = undefined;
-  // Drop the in-flight load and the latest-requested marker too — the
-  // workers it would commit have just been torn down, so it must not
-  // populate the cache once it resolves.
-  latestRequestedPluginsHash = undefined;
+  // Drop the in-flight load too — the workers it would commit have just been
+  // torn down, so it must not populate the cache once it resolves. Clearing
+  // the marker also flips its commit gate (pendingSeparatedPlugins?.promise
+  // === loadPromise) to false, so a load resolving after teardown is a no-op.
   pendingSeparatedPlugins = undefined;
 }
 

--- a/packages/nx/src/project-graph/plugins/get-plugins.ts
+++ b/packages/nx/src/project-graph/plugins/get-plugins.ts
@@ -28,16 +28,11 @@ let cachedSeparatedPlugins: SeparatedPlugins;
 let pendingPluginsPromise: Promise<LoadedNxPlugin[]> | undefined;
 let cleanupSpecifiedPlugins: () => void | undefined;
 
-// In-flight separated-plugins load, tagged with the hash it is loading.
-// Serves two roles: (1) a concurrent caller asking for the same plugin set
-// shares this one load instead of starting a second that races the
-// module-level cache state, and (2) it is the commit gate — a load writes
-// cachedSeparatedPlugins / currentPluginsConfigurationHash only if it is
-// still the registered load when it finishes. Two recomputes can run at once
-// (a daemon restart fires an initial recompute and a watcher recompute
-// together); without the gate a slower load for an older nx.json could
-// overwrite a newer one's cache, leaving the hash key and the cached plugin
-// set describing different plugin sets.
+// In-flight separated-plugins load, tagged with its hash. Two roles: a
+// concurrent caller for the same set shares this load instead of racing a
+// second one, and it gates the cache commit — a load writes the cache only if
+// it's still the registered load when it finishes, so a slow older load can't
+// clobber a newer one's result (two recomputes can overlap).
 let pendingSeparatedPlugins:
   | { hash: string; promise: Promise<SeparatedPlugins> }
   | undefined;
@@ -142,10 +137,8 @@ export async function getPluginsSeparated(
       defaultPlugins,
     };
 
-    // Commit the cache only if a newer request has not superseded us — i.e.
-    // we are still the registered in-flight load. currentPluginsConfigurationHash
-    // and cachedSeparatedPlugins are then always written together, by the same
-    // call, and describe the same plugin set.
+    // Commit only if we're still the registered load — so the hash and the
+    // cached set are always written together and describe the same plugins.
     if (pendingSeparatedPlugins?.promise === loadPromise) {
       cachedSeparatedPlugins = separatedPlugins;
       currentPluginsConfigurationHash = pluginsConfigurationHash;
@@ -215,10 +208,8 @@ export function cleanupPlugins() {
   pendingPluginsPromise = undefined;
   pendingDefaultPluginPromise = undefined;
   cachedSeparatedPlugins = undefined;
-  // Drop the in-flight load too — the workers it would commit have just been
-  // torn down, so it must not populate the cache once it resolves. Clearing
-  // the marker also flips its commit gate (pendingSeparatedPlugins?.promise
-  // === loadPromise) to false, so a load resolving after teardown is a no-op.
+  // Drop the in-flight load too: clearing the marker flips its commit gate to
+  // false, so a load resolving after teardown can't repopulate the torn-down cache.
   pendingSeparatedPlugins = undefined;
 }
 
@@ -313,13 +304,9 @@ async function loadSpecifiedNxPlugins(
 
   pluginsConfigurations ??= [];
 
-  // Local plugin paths are resolved against a snapshot of the workspace's
-  // project layout that is cached for the life of the process. In a
-  // long-lived daemon that snapshot can predate a newly added local plugin,
-  // resolving it to the workspace root instead of its source. Drop the
-  // snapshot here — this runs only when the plugin set changed, which is
-  // exactly when a new local plugin may have appeared — so resolution below
-  // sees the current state of disk.
+  // Drop the cached workspace-layout snapshot local-plugin resolution uses:
+  // in a long-lived daemon it can predate a newly added local plugin and
+  // resolve it to the workspace root. Runs only when the plugin set changed.
   resetResolvePluginCache();
 
   const cleanupFunctions: Array<() => void> = [];

--- a/packages/nx/src/project-graph/plugins/get-plugins.ts
+++ b/packages/nx/src/project-graph/plugins/get-plugins.ts
@@ -10,6 +10,7 @@ import { hashObject } from '../../hasher/file-hasher';
 import { workspaceRoot } from '../../utils/workspace-root';
 import { loadNxPlugin } from './in-process-loader';
 import { loadIsolatedNxPlugin } from './isolation';
+import { resetResolvePluginCache } from './resolve-plugin';
 
 import { isIsolationEnabled } from './isolation/enabled';
 import type { LoadedNxPlugin } from './loaded-nx-plugin';
@@ -318,6 +319,15 @@ async function loadSpecifiedNxPlugins(
   performance.mark('loadSpecifiedNxPlugins:start');
 
   pluginsConfigurations ??= [];
+
+  // Local plugin paths are resolved against a snapshot of the workspace's
+  // project layout that is cached for the life of the process. In a
+  // long-lived daemon that snapshot can predate a newly added local plugin,
+  // resolving it to the workspace root instead of its source. Drop the
+  // snapshot here — this runs only when the plugin set changed, which is
+  // exactly when a new local plugin may have appeared — so resolution below
+  // sees the current state of disk.
+  resetResolvePluginCache();
 
   const cleanupFunctions: Array<() => void> = [];
   const results = await Promise.allSettled(

--- a/packages/nx/src/project-graph/plugins/get-plugins.ts
+++ b/packages/nx/src/project-graph/plugins/get-plugins.ts
@@ -27,6 +27,23 @@ let cachedSeparatedPlugins: SeparatedPlugins;
 let pendingPluginsPromise: Promise<LoadedNxPlugin[]> | undefined;
 let cleanupSpecifiedPlugins: () => void | undefined;
 
+// Hash of the plugin set the most recent getPluginsSeparated call asked
+// for. The cache commit is gated on it: a load writes cachedSeparatedPlugins
+// and currentPluginsConfigurationHash only if its hash is still the latest
+// requested when it finishes. Two recomputes can run at once — a daemon
+// restart fires an initial recompute and a watcher recompute together — and
+// without this gate a slower load for an older nx.json could overwrite the
+// cache of a newer one, leaving the hash key and the cached plugin set
+// describing different plugin sets (so a later cache hit serves the wrong
+// plugins).
+let latestRequestedPluginsHash: string | undefined;
+// In-flight separated-plugins load, tagged with the hash it is loading, so
+// concurrent callers asking for the same plugin set share one load instead
+// of starting a second that races the module-level cache state.
+let pendingSeparatedPlugins:
+  | { hash: string; promise: Promise<SeparatedPlugins> }
+  | undefined;
+
 export interface SeparatedPlugins {
   specifiedPlugins: LoadedNxPlugin[];
   defaultPlugins: LoadedNxPlugin[];
@@ -81,6 +98,18 @@ export async function getPluginsSeparated(
     return cachedSeparatedPlugins;
   }
 
+  // A concurrent call is already loading this exact plugin set — share its
+  // load rather than starting a second one that would race the module-level
+  // cache state below.
+  if (pendingSeparatedPlugins?.hash === pluginsConfigurationHash) {
+    return pendingSeparatedPlugins.promise;
+  }
+
+  // This call now owns the most recent plugin configuration. The commit at
+  // the end of the load checks this, so an older load that finishes later
+  // cannot clobber a newer one's cache.
+  latestRequestedPluginsHash = pluginsConfigurationHash;
+
   // Plugins config changed (e.g. `nx add @nx/maven` updated nx.json). The
   // cached SeparatedPlugins is invalidated by the early-return above, but
   // pendingPluginsPromise — the in-flight load — would otherwise be reused
@@ -88,36 +117,64 @@ export async function getPluginsSeparated(
   // down the old workers and force a fresh load.
   cleanupSpecifiedPlugins?.();
   pendingPluginsPromise = undefined;
-  currentPluginsConfigurationHash = pluginsConfigurationHash;
-  const results = await Promise.allSettled([
-    getOnlyDefaultPlugins(root),
-    (pendingPluginsPromise ??= loadSpecifiedNxPlugins(
-      pluginsConfiguration,
-      root
-    )),
-  ]);
 
-  const errors: Error[] = [];
-  const defaultPlugins: LoadedNxPlugin[] = [];
-  const specifiedPlugins: LoadedNxPlugin[] = [];
+  const loadPromise = (async (): Promise<SeparatedPlugins> => {
+    const results = await Promise.allSettled([
+      getOnlyDefaultPlugins(root),
+      (pendingPluginsPromise ??= loadSpecifiedNxPlugins(
+        pluginsConfiguration,
+        root
+      )),
+    ]);
 
-  for (let i = 0; i < results.length; i++) {
-    const result = results[i];
-    if (result.status === 'fulfilled') {
-      (i === 0 ? defaultPlugins : specifiedPlugins).push(...result.value);
-    } else {
-      errors.push(reasonToError(result.reason));
+    const errors: Error[] = [];
+    const defaultPlugins: LoadedNxPlugin[] = [];
+    const specifiedPlugins: LoadedNxPlugin[] = [];
+
+    for (let i = 0; i < results.length; i++) {
+      const result = results[i];
+      if (result.status === 'fulfilled') {
+        (i === 0 ? defaultPlugins : specifiedPlugins).push(...result.value);
+      } else {
+        errors.push(reasonToError(result.reason));
+      }
+    }
+
+    if (errors.length > 0) {
+      throw new AggregateError(errors, errors.map((e) => e.message).join('\n'));
+    }
+
+    const separatedPlugins: SeparatedPlugins = {
+      specifiedPlugins,
+      defaultPlugins,
+    };
+
+    // Commit the cache only if a newer request has not superseded us, so
+    // currentPluginsConfigurationHash and cachedSeparatedPlugins are always
+    // written together, by the same call, and describe the same plugin set.
+    if (latestRequestedPluginsHash === pluginsConfigurationHash) {
+      cachedSeparatedPlugins = separatedPlugins;
+      currentPluginsConfigurationHash = pluginsConfigurationHash;
+      loadedPlugins = specifiedPlugins.concat(defaultPlugins);
+    }
+
+    return separatedPlugins;
+  })();
+
+  pendingSeparatedPlugins = {
+    hash: pluginsConfigurationHash,
+    promise: loadPromise,
+  };
+
+  try {
+    return await loadPromise;
+  } finally {
+    // Clear the in-flight marker, but only if it still points at our load —
+    // a newer call may have already replaced it.
+    if (pendingSeparatedPlugins?.promise === loadPromise) {
+      pendingSeparatedPlugins = undefined;
     }
   }
-
-  if (errors.length > 0) {
-    throw new AggregateError(errors, errors.map((e) => e.message).join('\n'));
-  }
-
-  cachedSeparatedPlugins = { specifiedPlugins, defaultPlugins };
-  loadedPlugins = specifiedPlugins.concat(defaultPlugins);
-
-  return cachedSeparatedPlugins;
 }
 
 /**
@@ -164,6 +221,11 @@ export function cleanupPlugins() {
   pendingPluginsPromise = undefined;
   pendingDefaultPluginPromise = undefined;
   cachedSeparatedPlugins = undefined;
+  // Drop the in-flight load and the latest-requested marker too — the
+  // workers it would commit have just been torn down, so it must not
+  // populate the cache once it resolves.
+  latestRequestedPluginsHash = undefined;
+  pendingSeparatedPlugins = undefined;
 }
 
 /**

--- a/packages/nx/src/project-graph/plugins/resolve-plugin.ts
+++ b/packages/nx/src/project-graph/plugins/resolve-plugin.ts
@@ -15,7 +15,10 @@ import {
   findProjectForPath,
   ProjectRootMappings,
 } from '../utils/find-project-for-path';
-import { retrieveProjectConfigurationsWithoutPluginInference } from '../utils/retrieve-workspace-files';
+import {
+  clearProjectsWithoutPluginInferenceCache,
+  retrieveProjectConfigurationsWithoutPluginInference,
+} from '../utils/retrieve-workspace-files';
 
 import type { ProjectConfiguration } from '../../config/workspace-json-project-json';
 
@@ -380,4 +383,26 @@ function readTsConfigPaths(root: string = workspaceRoot) {
     tsconfigPaths = compilerOptions?.paths;
   }
   return tsconfigPaths ?? {};
+}
+
+/**
+ * Drops the cached snapshot of the workspace's project layout that local Nx
+ * plugin resolution relies on — project configs, tsconfig path mappings, and
+ * package entry points.
+ *
+ * These snapshots are taken lazily the first time a plugin must be resolved
+ * and then kept for the life of the process. In a long-lived daemon that is
+ * stale once a *new* local plugin is added: the snapshot has no entry for the
+ * plugin's own project, so `findProjectForPath` falls back to the catch-all
+ * root project and the plugin resolves to the workspace root — a directory,
+ * which then fails to import. Reloading the specified plugins calls this so
+ * resolution runs against the current state of disk.
+ */
+export function resetResolvePluginCache(): void {
+  projectsWithoutInference = undefined;
+  projectsWithoutInferencePromise = null;
+  packageEntryPointsToProjectMap = undefined;
+  wildcardEntryPointsToProjectMap = undefined;
+  tsconfigPaths = undefined;
+  clearProjectsWithoutPluginInferenceCache();
 }

--- a/packages/nx/src/project-graph/plugins/resolve-plugin.ts
+++ b/packages/nx/src/project-graph/plugins/resolve-plugin.ts
@@ -386,17 +386,10 @@ function readTsConfigPaths(root: string = workspaceRoot) {
 }
 
 /**
- * Drops the cached snapshot of the workspace's project layout that local Nx
- * plugin resolution relies on — project configs, tsconfig path mappings, and
- * package entry points.
- *
- * These snapshots are taken lazily the first time a plugin must be resolved
- * and then kept for the life of the process. In a long-lived daemon that is
- * stale once a *new* local plugin is added: the snapshot has no entry for the
- * plugin's own project, so `findProjectForPath` falls back to the catch-all
- * root project and the plugin resolves to the workspace root — a directory,
- * which then fails to import. Reloading the specified plugins calls this so
- * resolution runs against the current state of disk.
+ * Drops the cached workspace-layout snapshot local-plugin resolution relies on
+ * (project configs, tsconfig paths, package entry points). Kept for the life
+ * of the process, it goes stale when a new local plugin is added — the plugin
+ * then resolves to the workspace root (a directory) and fails to import.
  */
 export function resetResolvePluginCache(): void {
   projectsWithoutInference = undefined;

--- a/packages/nx/src/project-graph/utils/retrieve-workspace-files.ts
+++ b/packages/nx/src/project-graph/utils/retrieve-workspace-files.ts
@@ -180,11 +180,9 @@ export async function retrieveProjectConfigurationsWithoutPluginInference(
 }
 
 /**
- * Clears the cache backing `retrieveProjectConfigurationsWithoutPluginInference`.
- *
- * The daemon reuses one process across many recomputes. Without this, the very
- * first snapshot of the workspace's projects would be served forever — even
- * after new projects (e.g. a freshly generated local plugin) appear on disk.
+ * Clears the cache backing `retrieveProjectConfigurationsWithoutPluginInference`,
+ * so a long-lived daemon picks up projects (e.g. a new local plugin) added
+ * after the first snapshot instead of serving it forever.
  */
 export function clearProjectsWithoutPluginInferenceCache(): void {
   projectsWithoutPluginCache.clear();

--- a/packages/nx/src/project-graph/utils/retrieve-workspace-files.ts
+++ b/packages/nx/src/project-graph/utils/retrieve-workspace-files.ts
@@ -179,6 +179,17 @@ export async function retrieveProjectConfigurationsWithoutPluginInference(
   return projects;
 }
 
+/**
+ * Clears the cache backing `retrieveProjectConfigurationsWithoutPluginInference`.
+ *
+ * The daemon reuses one process across many recomputes. Without this, the very
+ * first snapshot of the workspace's projects would be served forever — even
+ * after new projects (e.g. a freshly generated local plugin) appear on disk.
+ */
+export function clearProjectsWithoutPluginInferenceCache(): void {
+  projectsWithoutPluginCache.clear();
+}
+
 export function getGlobPatternsOfPlugins(
   plugins: Array<LoadedNxPlugin>
 ): string[] {


### PR DESCRIPTION
## Current Behavior

A watcher-driven project-graph recompute that fails while loading plugins
takes the **whole Nx daemon down**.

`kickOffRecompute` (`project-graph-incremental-recomputation.ts`) builds
`cachedSerializedProjectGraphPromise` from an async IIFE.
`processFilesAndCreateAndSerializeProjectGraph` is wrapped in `try/catch`
and always resolves to an `errorResult` — but the prologue hoisted in
front of it for the freshness gate (`readNxJson`, `getPluginsSeparated`,
`isStale`) is not. `getPluginsSeparated` **rejects** when a plugin fails
to load.

`scheduleProjectGraphRecomputation` calls `kickOffRecompute()`
fire-and-forget, so a rejected `myPromise` has no awaiter — Node reports
an unhandled promise rejection and the daemon process exits. (The request
path, `getCachedSerializedProjectGraphPromise`, `try/catch`es its `await`,
so only watcher-driven recomputes hit this.)

Observed downstream as a flaky `e2e/nx/src/spread.test.ts`: a test mutates
`nx.json` / `tools/*` / `project.json`, the watcher-driven recompute hits
a transient plugin-load failure, the daemon crashes mid-test, and the
following `show project` races a restarting daemon — surfacing as
`project.targets.build` being `undefined` (a graph whose plugin set never
ran). The captured `daemon.log` shows the `AggregateError` from
`getPluginsSeparated` followed by a fresh daemon process starting.

## Expected Behavior

A plugin-load failure during a recompute resolves to a graph **error**
that the next requester surfaces — the daemon stays up. The IIFE body is
wrapped so it always resolves (never rejects), turning a prologue failure
into an `errorResult`, the same contract
`processFilesAndCreateAndSerializeProjectGraph` already honors. The next
`getCachedSerializedProjectGraphPromise` reads `result.error`, returns it
to the client, and clears the cached promise so the recompute retries.

Also in this PR (diagnostics / regression coverage for the flake):

- Restored the `afterEach` daemon-log dump in `spread.test.ts` (removed in
  `2f261d6903`) so a failing run prints `.nx/workspace-data/d/daemon.log`
  next to the assertion in CI output.
- Added a `describe('rapid reconfiguration (race-condition stress)')`
  block that mutates `nx.json` / `project.json` / `tools/*` in tight
  loops with no settle time and no `reset` between iterations, so the
  long-lived daemon is exercised hard — regression coverage for the crash.

## Related Issue(s)

Follow-up to PR #35650 (https://github.com/nrwl/nx/pull/35650), which
hoisted `getPluginsSeparated` out of the `try/catch`ed compute and into
the bare IIFE prologue for the freshness gate.

No separate issue number.
