### PR TITLE
fix(core): do not drop target defaults in 23.0.0 array migration

### DIFF
--- a/packages/nx/src/migrations/update-23-0-0/convert-target-defaults-to-array.spec.ts
+++ b/packages/nx/src/migrations/update-23-0-0/convert-target-defaults-to-array.spec.ts
@@ -2,7 +2,16 @@ import { createTreeWithEmptyWorkspace } from '../../generators/testing-utils/cre
 import type { Tree } from '../../generators/tree';
 import type { ProjectGraph } from '../../config/project-graph';
 import { readNxJson, updateNxJson } from '../../generators/utils/nx-json';
-import convertTargetDefaultsToArray from './convert-target-defaults-to-array';
+
+jest.mock('../../project-graph/project-graph', () => ({
+  createProjectGraphAsync: jest.fn(),
+}));
+import { createProjectGraphAsync } from '../../project-graph/project-graph';
+import convertTargetDefaultsToArray, {
+  convertTargetDefaultsRecordToArray,
+} from './convert-target-defaults-to-array';
+
+const createProjectGraphAsyncMock = createProjectGraphAsync as jest.Mock;
 
 function graphWithTargets(
   projects: Record<
@@ -22,7 +31,6 @@ function graphWithTargets(
 }
 
 describe('convert-target-defaults-to-array migration', () => {
-  let tree: Tree;
   const originalSkipFormat = process.env.NX_SKIP_FORMAT;
 
   beforeAll(() => {
@@ -36,148 +44,227 @@ describe('convert-target-defaults-to-array migration', () => {
     }
   });
 
-  beforeEach(() => {
-    tree = createTreeWithEmptyWorkspace();
-  });
+  // The migration entry point — nx.json handling. It takes only a `Tree`:
+  // the migration runner never passes a project graph, so the signature
+  // must not pretend otherwise. Graph-dependent disambiguation is tested
+  // separately against `convertTargetDefaultsRecordToArray`.
+  describe('convertTargetDefaultsToArray', () => {
+    let tree: Tree;
 
-  it('is a no-op when nx.json does not exist', async () => {
-    tree.delete('nx.json');
-    await expect(convertTargetDefaultsToArray(tree)).resolves.toEqual([]);
-  });
-
-  it('is a no-op when targetDefaults is absent', async () => {
-    const nxJson = readNxJson(tree);
-    delete nxJson.targetDefaults;
-    updateNxJson(tree, nxJson);
-    await convertTargetDefaultsToArray(tree);
-    expect(readNxJson(tree).targetDefaults).toBeUndefined();
-  });
-
-  it('is a no-op when targetDefaults is already an array', async () => {
-    const nxJson = readNxJson(tree);
-    nxJson.targetDefaults = [
-      { target: 'build', cache: true },
-      { target: 'test', inputs: ['default', '^production'] },
-    ];
-    updateNxJson(tree, nxJson);
-    await convertTargetDefaultsToArray(tree);
-    expect(readNxJson(tree).targetDefaults).toEqual([
-      { target: 'build', cache: true },
-      { target: 'test', inputs: ['default', '^production'] },
-    ]);
-  });
-
-  it('converts record-shape to array preserving insertion order', async () => {
-    const nxJson = readNxJson(tree);
-    nxJson.targetDefaults = {
-      build: { cache: true, dependsOn: ['^build'] },
-      test: { inputs: ['default', '^production'] },
-    };
-    updateNxJson(tree, nxJson);
-    const graph = graphWithTargets({
-      app: { build: { command: 'echo build' }, test: { command: 'echo test' } },
-    });
-    await convertTargetDefaultsToArray(tree, graph);
-    expect(readNxJson(tree).targetDefaults).toEqual([
-      { target: 'build', cache: true, dependsOn: ['^build'] },
-      { target: 'test', inputs: ['default', '^production'] },
-    ]);
-  });
-
-  it('moves executor-style keys to `executor`, leaving `target` unset', async () => {
-    const nxJson = readNxJson(tree);
-    nxJson.targetDefaults = {
-      '@nx/vite:test': { inputs: ['default'] },
-      'nx:run-commands': { cache: true },
-    };
-    updateNxJson(tree, nxJson);
-    const graph = graphWithTargets({
-      app: {
-        test: { executor: '@nx/vite:test' },
-        run: { executor: 'nx:run-commands' },
-      },
-    });
-    await convertTargetDefaultsToArray(tree, graph);
-    expect(readNxJson(tree).targetDefaults).toEqual([
-      { executor: '@nx/vite:test', inputs: ['default'] },
-      { executor: 'nx:run-commands', cache: true },
-    ]);
-  });
-
-  it('keeps glob keys as `target` strings', async () => {
-    const nxJson = readNxJson(tree);
-    nxJson.targetDefaults = {
-      'e2e-ci--*': { dependsOn: ['build'] },
-      'test:*': { cache: true },
-    };
-    updateNxJson(tree, nxJson);
-    await convertTargetDefaultsToArray(tree);
-    expect(readNxJson(tree).targetDefaults).toEqual([
-      { target: 'e2e-ci--*', dependsOn: ['build'] },
-      { target: 'test:*', cache: true },
-    ]);
-  });
-
-  describe('with project graph', () => {
-    it('emits `target` when a `:` key is only used as a target name', async () => {
-      const nxJson = readNxJson(tree);
-      nxJson.targetDefaults = {
-        'foo:bar': { cache: true },
-      };
-      updateNxJson(tree, nxJson);
-      const graph = graphWithTargets({
-        app: { 'foo:bar': { command: 'echo hi' } },
+    beforeEach(() => {
+      tree = createTreeWithEmptyWorkspace();
+      createProjectGraphAsyncMock.mockReset();
+      createProjectGraphAsyncMock.mockResolvedValue({
+        nodes: {},
+        dependencies: {},
       });
-      await convertTargetDefaultsToArray(tree, graph);
+    });
+
+    it('is a no-op when nx.json does not exist', async () => {
+      tree.delete('nx.json');
+      await expect(convertTargetDefaultsToArray(tree)).resolves.toEqual([]);
+    });
+
+    it('is a no-op when targetDefaults is absent', async () => {
+      const nxJson = readNxJson(tree);
+      delete nxJson.targetDefaults;
+      updateNxJson(tree, nxJson);
+      await convertTargetDefaultsToArray(tree);
+      expect(readNxJson(tree).targetDefaults).toBeUndefined();
+    });
+
+    it('is a no-op when targetDefaults is already an array', async () => {
+      const nxJson = readNxJson(tree);
+      nxJson.targetDefaults = [
+        { target: 'build', cache: true },
+        { target: 'test', inputs: ['default', '^production'] },
+      ];
+      updateNxJson(tree, nxJson);
+      await convertTargetDefaultsToArray(tree);
       expect(readNxJson(tree).targetDefaults).toEqual([
-        { target: 'foo:bar', cache: true },
+        { target: 'build', cache: true },
+        { target: 'test', inputs: ['default', '^production'] },
       ]);
     });
 
-    it('emits `executor` when a `:` key is only used as an executor', async () => {
+    it('converts a record-shape targetDefaults in nx.json to array shape', async () => {
       const nxJson = readNxJson(tree);
       nxJson.targetDefaults = {
-        '@nx/vite:test': { inputs: ['default'] },
+        build: { cache: true, dependsOn: ['^build'] },
+        test: { inputs: ['default', '^production'] },
       };
       updateNxJson(tree, nxJson);
-      const graph = graphWithTargets({
-        app: { test: { executor: '@nx/vite:test' } },
-      });
-      await convertTargetDefaultsToArray(tree, graph);
+      await convertTargetDefaultsToArray(tree);
       expect(readNxJson(tree).targetDefaults).toEqual([
-        { executor: '@nx/vite:test', inputs: ['default'] },
+        { target: 'build', cache: true, dependsOn: ['^build'] },
+        { target: 'test', inputs: ['default', '^production'] },
       ]);
     });
 
-    it('duplicates the entry when a `:` key matches both a target name and an executor', async () => {
+    it('does not build a project graph when no keys are executor-ambiguous', async () => {
       const nxJson = readNxJson(tree);
       nxJson.targetDefaults = {
-        'foo:bar': { cache: true },
+        build: { cache: true },
+        'e2e-ci--*': { cache: true },
       };
       updateNxJson(tree, nxJson);
-      const graph = graphWithTargets({
-        app: { 'foo:bar': { command: 'echo hi' } },
-        lib: { build: { executor: 'foo:bar' } },
+      await convertTargetDefaultsToArray(tree);
+      expect(createProjectGraphAsyncMock).not.toHaveBeenCalled();
+    });
+
+    // Regression: the migration runner invokes migrations as `fn(tree, {})`.
+    // The migration must never treat a missing/empty graph as evidence that
+    // a default is dead — every legacy entry has to survive the conversion.
+    it('keeps every entry when the graph yields no matches', async () => {
+      const nxJson = readNxJson(tree);
+      nxJson.targetDefaults = {
+        build: { dependsOn: ['^build', 'build-base'] },
+        test: {
+          options: { env: { NODE_OPTIONS: '--experimental-vm-modules' } },
+        },
+        lint: { cache: true },
+        '@nx/esbuild:esbuild': { cache: true },
+      };
+      updateNxJson(tree, nxJson);
+      createProjectGraphAsyncMock.mockResolvedValue({
+        nodes: {},
+        dependencies: {},
       });
-      await convertTargetDefaultsToArray(tree, graph);
+      await convertTargetDefaultsToArray(tree);
       expect(readNxJson(tree).targetDefaults).toEqual([
-        { target: 'foo:bar', cache: true },
-        { executor: 'foo:bar', cache: true },
+        { target: 'build', dependsOn: ['^build', 'build-base'] },
+        {
+          target: 'test',
+          options: { env: { NODE_OPTIONS: '--experimental-vm-modules' } },
+        },
+        { target: 'lint', cache: true },
+        { executor: '@nx/esbuild:esbuild', cache: true },
       ]);
     });
 
-    it('drops entries when no project matches the key', async () => {
+    it('reports a next step when the project graph cannot be built', async () => {
       const nxJson = readNxJson(tree);
-      nxJson.targetDefaults = {
-        '@nx/unused:executor': { cache: true },
-        unused: { inputs: ['default'] },
-      };
+      nxJson.targetDefaults = { '@nx/vite:test': { cache: true } };
       updateNxJson(tree, nxJson);
-      const graph = graphWithTargets({
-        app: { build: { executor: '@nx/something-else:build' } },
+      createProjectGraphAsyncMock.mockRejectedValue(new Error('graph boom'));
+      const nextSteps = await convertTargetDefaultsToArray(tree);
+      expect(nextSteps.join('\n')).toContain(
+        'project graph could not be built'
+      );
+      // The entry still survives via the syntactic fallback.
+      expect(readNxJson(tree).targetDefaults).toEqual([
+        { executor: '@nx/vite:test', cache: true },
+      ]);
+    });
+  });
+
+  // The pure conversion + `:`-key disambiguation. Graphs are injected
+  // directly, so no workspace or migration runner is involved.
+  describe('convertTargetDefaultsRecordToArray', () => {
+    it('preserves insertion order', () => {
+      expect(
+        convertTargetDefaultsRecordToArray({
+          build: { cache: true, dependsOn: ['^build'] },
+          test: { inputs: ['default', '^production'] },
+        })
+      ).toEqual([
+        { target: 'build', cache: true, dependsOn: ['^build'] },
+        { target: 'test', inputs: ['default', '^production'] },
+      ]);
+    });
+
+    it('treats plain (non-":") keys as target names', () => {
+      expect(
+        convertTargetDefaultsRecordToArray({ 'build-base': { cache: true } })
+      ).toEqual([{ target: 'build-base', cache: true }]);
+    });
+
+    it('keeps glob keys as `target` strings', () => {
+      expect(
+        convertTargetDefaultsRecordToArray({
+          'e2e-ci--*': { dependsOn: ['build'] },
+          'test:*': { cache: true },
+        })
+      ).toEqual([
+        { target: 'e2e-ci--*', dependsOn: ['build'] },
+        { target: 'test:*', cache: true },
+      ]);
+    });
+
+    describe('with a project graph', () => {
+      it('emits `target` when a `:` key is only used as a target name', () => {
+        const graph = graphWithTargets({
+          app: { 'foo:bar': { command: 'echo hi' } },
+        });
+        expect(
+          convertTargetDefaultsRecordToArray(
+            { 'foo:bar': { cache: true } },
+            graph
+          )
+        ).toEqual([{ target: 'foo:bar', cache: true }]);
       });
-      await convertTargetDefaultsToArray(tree, graph);
-      expect(readNxJson(tree).targetDefaults).toEqual([]);
+
+      it('emits `executor` when a `:` key is only used as an executor', () => {
+        const graph = graphWithTargets({
+          app: { test: { executor: '@nx/vite:test' } },
+        });
+        expect(
+          convertTargetDefaultsRecordToArray(
+            { '@nx/vite:test': { inputs: ['default'] } },
+            graph
+          )
+        ).toEqual([{ executor: '@nx/vite:test', inputs: ['default'] }]);
+      });
+
+      it('duplicates the entry when a `:` key matches both a target name and an executor', () => {
+        const graph = graphWithTargets({
+          app: { 'foo:bar': { command: 'echo hi' } },
+          lib: { build: { executor: 'foo:bar' } },
+        });
+        expect(
+          convertTargetDefaultsRecordToArray(
+            { 'foo:bar': { cache: true } },
+            graph
+          )
+        ).toEqual([
+          { target: 'foo:bar', cache: true },
+          { executor: 'foo:bar', cache: true },
+        ]);
+      });
+
+      it('keeps the entry via the syntactic fallback when the graph has no match', () => {
+        const graph = graphWithTargets({
+          app: { build: { executor: '@nx/something-else:build' } },
+        });
+        expect(
+          convertTargetDefaultsRecordToArray(
+            {
+              '@nx/unused:executor': { cache: true },
+              unused: { inputs: ['default'] },
+            },
+            graph
+          )
+        ).toEqual([
+          { executor: '@nx/unused:executor', cache: true },
+          { target: 'unused', inputs: ['default'] },
+        ]);
+      });
+    });
+
+    describe('without a project graph', () => {
+      it('falls back to the syntactic heuristic — `:` keys become executors', () => {
+        expect(
+          convertTargetDefaultsRecordToArray({
+            '@nx/vite:test': { inputs: ['default'] },
+            'nx:run-commands': { cache: true },
+            build: { cache: true },
+          })
+        ).toEqual([
+          { executor: '@nx/vite:test', inputs: ['default'] },
+          { executor: 'nx:run-commands', cache: true },
+          { target: 'build', cache: true },
+        ]);
+      });
     });
   });
 });

--- a/packages/nx/src/migrations/update-23-0-0/convert-target-defaults-to-array.ts
+++ b/packages/nx/src/migrations/update-23-0-0/convert-target-defaults-to-array.ts
@@ -14,19 +14,16 @@ import { isGlobPattern } from '../../utils/globs';
  * array shape introduced in Nx 23. No-op when `targetDefaults` is absent
  * or already an array.
  *
- * Disambiguation strategy for record keys (highest precedence first):
- * 1. Glob → `{ target: key }`.
- * 2. Project graph available: replicate legacy lookup by checking whether
- *    the key matches a target name and/or an executor string anywhere in
- *    the workspace. Emit one entry, or both when it matches both
- *    (genuinely ambiguous; safer to duplicate than drop a default).
- *    If neither matches, the default is dead and we drop the entry.
- * 3. No graph: fall back to the syntactic heuristic — `:` (and not a
- *    glob) → executor; otherwise target.
+ * This is a pure shape conversion: every legacy key produces at least one
+ * array entry, nothing is ever dropped. A key that looks unused at
+ * migration time may still be a live default — the target can be added
+ * later, and the project graph at migration time can be incomplete.
+ *
+ * A project graph is built internally (and only when needed) to
+ * disambiguate `:`-style keys; see {@link convertTargetDefaultsRecordToArray}.
  */
 export default async function convertTargetDefaultsToArray(
-  tree: Tree,
-  projectGraph?: ProjectGraph
+  tree: Tree
 ): Promise<string[]> {
   if (!tree.exists('nx.json')) {
     return [];
@@ -39,17 +36,16 @@ export default async function convertTargetDefaultsToArray(
   if (!targetDefaults) return [];
   if (Array.isArray(targetDefaults)) return [];
 
-  const nextSteps: string[] = [];
-  const graph = projectGraph ?? (await tryCreateProjectGraph(nextSteps));
-
   const legacy = targetDefaults as TargetDefaultsRecord;
-  const entries: TargetDefaultEntry[] = [];
-  for (const key of Object.keys(legacy)) {
-    const value = legacy[key] ?? {};
-    entries.push(...legacyKeyToEntries(key, value, graph));
-  }
+  const nextSteps: string[] = [];
 
-  nxJson.targetDefaults = entries;
+  // The graph is only consulted to disambiguate `:`-style keys (target name
+  // vs `pkg:executor` id). Skip building it entirely when there are none.
+  const graph = Object.keys(legacy).some(isExecutorAmbiguousKey)
+    ? await tryCreateProjectGraph(nextSteps)
+    : undefined;
+
+  nxJson.targetDefaults = convertTargetDefaultsRecordToArray(legacy, graph);
   updateNxJson(tree, nxJson);
 
   await formatChangedFilesWithPrettierIfAvailable(tree);
@@ -57,12 +53,41 @@ export default async function convertTargetDefaultsToArray(
 }
 
 /**
- * Treat a legacy record key as an executor when it contains `:` and is
- * not a glob (executor strings are `pkg:name`; globs would also contain
- * `*` / `{` / etc., which `isGlobPattern` catches). Used only as a
- * syntactic fallback when no graph signal is available.
+ * Pure conversion from the legacy record shape to the array shape.
+ *
+ * Kept separate from the migration entry point — and accepting the graph
+ * as an explicit argument — so the disambiguation logic can be unit tested
+ * directly with synthetic graphs. The migration runner never hands a
+ * migration a project graph, so this seam is what keeps that behaviour
+ * testable without standing up a real workspace.
+ *
+ * Disambiguation per key:
+ * - A glob, or a plain key with no `:`, is unambiguously a target name.
+ * - A `:` key is ambiguous (target name vs `pkg:executor` id). When the
+ *   graph shows it used as a target name, an executor, or both, the
+ *   matching entry/entries are emitted. With no graph signal, it falls
+ *   back to the syntactic heuristic (`:` → executor). Either way an entry
+ *   is always emitted.
  */
-export function isExecutorLikeKey(key: string): boolean {
+export function convertTargetDefaultsRecordToArray(
+  legacy: TargetDefaultsRecord,
+  graph?: ProjectGraph
+): TargetDefaultEntry[] {
+  const entries: TargetDefaultEntry[] = [];
+  for (const key of Object.keys(legacy)) {
+    const value = legacy[key] ?? {};
+    entries.push(...legacyKeyToEntries(key, value, graph));
+  }
+  return entries;
+}
+
+/**
+ * A legacy record key is ambiguous between a target name and an executor
+ * id only when it contains `:` and is not a glob (executor ids are
+ * `pkg:name`; globs would also contain `*` / `{` / etc., which
+ * `isGlobPattern` catches). These are the only keys the graph helps with.
+ */
+function isExecutorAmbiguousKey(key: string): boolean {
   return key.includes(':') && !isGlobPattern(key);
 }
 
@@ -71,10 +96,13 @@ function legacyKeyToEntries(
   value: Partial<TargetDefaultEntry>,
   graph: ProjectGraph | undefined
 ): TargetDefaultEntry[] {
-  if (isGlobPattern(key)) {
+  // Globs and plain (no `:`) keys are unambiguously target names.
+  if (!isExecutorAmbiguousKey(key)) {
     return [{ target: key, ...value }];
   }
 
+  // A `:` key could be a target name or a `pkg:executor` id. Use the graph
+  // to disambiguate when it has something to say.
   if (graph) {
     const { matchesTargetName, matchesExecutor } = classifyKeyAgainstGraph(
       key,
@@ -88,15 +116,12 @@ function legacyKeyToEntries(
     }
     if (matchesTargetName) return [{ target: key, ...value }];
     if (matchesExecutor) return [{ executor: key, ...value }];
-    // Graph evidence said no target and no executor in the workspace
-    // uses this key — the default is dead. Drop it rather than guess.
-    return [];
+    // Graph had no signal for this key — fall through to the syntactic
+    // heuristic rather than dropping the entry.
   }
 
-  // No graph available; fall back to the syntactic heuristic.
-  return isExecutorLikeKey(key)
-    ? [{ executor: key, ...value }]
-    : [{ target: key, ...value }];
+  // Syntactic fallback: a `:` key that is not a glob is an executor id.
+  return [{ executor: key, ...value }];
 }
 
 function classifyKeyAgainstGraph(


### PR DESCRIPTION
## Current Behavior

The `convert-target-defaults-to-array` migration (Nx 23) converts the legacy
record-shape `targetDefaults` in `nx.json` to the new array shape.

It declared a `projectGraph` parameter and classified each record key against
the graph, dropping any key whose target name / executor wasn't found in the
workspace. But the migration runner always invokes migrations as `fn(tree, {})`
— the second argument is an empty object, never a project graph.

`{}` is truthy, so it was treated as a real (but empty) graph. Every non-glob
key then matched neither a target name nor an executor, and the migration
dropped it. As a result, upgrading to Nx 23 deletes every named `targetDefaults`
entry (`build`, `test`, `lint`, …) and keeps only glob entries — silently
breaking `build` (lost `dependsOn`) and `test` (lost env/options) across the
workspace.

## Expected Behavior

The migration is a pure shape conversion and never drops entries:

- The entry point takes an honest `(tree)` signature — it no longer pretends to
  receive a project graph it is never given.
- Every legacy key produces at least one array entry. Globs and plain (non-`:`)
  keys become `{ target: key }`; `:` keys are disambiguated by the project graph
  (`target`, `executor`, or both), falling back to the syntactic heuristic
  (`:` → executor) when the graph has no signal.
- The project graph is built internally, and only when a `:`-style key actually
  needs disambiguating.
- The pure conversion is exposed as `convertTargetDefaultsRecordToArray` so the
  disambiguation logic is unit-testable with injected graphs, without standing
  up a workspace or the migration runner.

## Related Issue(s)

N/A — caught while upgrading the Nx repo itself to `23.0.0-beta.13`.
