### PR TITLE
chore(repo): replace glob with tinyglobby

### DIFF
--- a/package.json
+++ b/package.json
@@ -358,7 +358,6 @@
     "form-data": "^4.0.4",
     "framer-motion": "^11.3.0",
     "front-matter": "^4.0.2",
-    "glob": "7.1.4",
     "json-schema-to-typescript": "^10.1.5",
     "jsonpointer": "^5.0.0",
     "license-checker": "^25.0.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -445,9 +445,6 @@ importers:
       front-matter:
         specifier: ^4.0.2
         version: 4.0.2
-      glob:
-        specifier: 7.1.4
-        version: 7.1.4
       json-schema-to-typescript:
         specifier: ^10.1.5
         version: 10.1.5
@@ -4212,15 +4209,15 @@ importers:
       '@xmldom/xmldom':
         specifier: ^0.8.10
         version: 0.8.11
-      glob:
-        specifier: 7.1.4
-        version: 7.1.4
       semver:
         specifier: 'catalog:'
         version: 7.7.4
       shiki:
         specifier: ^4.0.2
         version: 4.0.2
+      tinyglobby:
+        specifier: 'catalog:'
+        version: 0.2.15
       tslib:
         specifier: catalog:typescript
         version: 2.8.1

--- a/scripts/cleanup-tsconfig-files.js
+++ b/scripts/cleanup-tsconfig-files.js
@@ -2,7 +2,7 @@
 
 const fs = require('fs');
 const path = require('path');
-const glob = require('glob');
+const { globSync } = require('tinyglobby');
 
 /**
  * Remove TypeScript configuration and build info files from the dist directory
@@ -23,8 +23,8 @@ function cleanupTsConfigFiles() {
     .join(outputPath, '*/*.tsbuildinfo')
     .replace(/\\/g, '/');
 
-  const tsConfigFiles = glob.sync(tsConfigPattern);
-  const tsBuildInfoFiles = glob.sync(tsBuildInfoPattern);
+  const tsConfigFiles = globSync(tsConfigPattern);
+  const tsBuildInfoFiles = globSync(tsBuildInfoPattern);
 
   const allFiles = [...tsConfigFiles, ...tsBuildInfoFiles];
 

--- a/tools/workspace-plugin/package.json
+++ b/tools/workspace-plugin/package.json
@@ -9,9 +9,9 @@
     "@nx/devkit": "23.0.0-beta.4",
     "@nx/js": "23.0.0-beta.4",
     "@xmldom/xmldom": "^0.8.10",
-    "glob": "7.1.4",
     "semver": "catalog:",
     "shiki": "^4.0.2",
+    "tinyglobby": "catalog:",
     "tslib": "catalog:typescript"
   },
   "type": "commonjs",

--- a/tools/workspace-plugin/src/conformance-rules/codeblock-language/index.ts
+++ b/tools/workspace-plugin/src/conformance-rules/codeblock-language/index.ts
@@ -3,8 +3,6 @@ import {
   type ConformanceViolation,
 } from '@nx/conformance';
 import { workspaceRoot } from '@nx/devkit';
-import { sync as globSync } from 'glob';
-import { join, relative } from 'node:path';
 import { bundledLanguages } from 'shiki';
 // Common mappings for file extensions that don't match language IDs exactly
 const extensionToLang: Record<string, string> = {

--- a/tools/workspace-plugin/src/conformance-rules/relative-image-imports/index.ts
+++ b/tools/workspace-plugin/src/conformance-rules/relative-image-imports/index.ts
@@ -1,8 +1,8 @@
 import { ConformanceViolation, createConformanceRule } from '@nx/conformance';
 import { workspaceRoot } from '@nx/devkit';
-import { sync as globSync } from 'glob';
 import { readFileSync, existsSync } from 'node:fs';
-import { join, dirname, resolve, relative, isAbsolute } from 'node:path';
+import { dirname, join, resolve, relative, isAbsolute } from 'node:path';
+import { globSync } from 'tinyglobby';
 
 const ignorePatterns = ['**/node_modules/**', '**/dist/**', '**/.astro/**'];
 
@@ -17,8 +17,10 @@ export default createConformanceRule({
     const violations: ConformanceViolation[] = [];
 
     // Find all .mdoc files in astro-docs
-    const mdocFiles = globSync(join(workspaceRoot, 'astro-docs/**/*.mdoc'), {
+    const mdocFiles = globSync('astro-docs/**/*.mdoc', {
+      cwd: workspaceRoot,
       ignore: ignorePatterns,
+      absolute: true,
     });
 
     for (const file of mdocFiles) {


### PR DESCRIPTION
## Current Behavior

Workspace depends on `glob@7.1.4` (EOL) for three usages: two `tools/workspace-plugin` conformance rules and one release-pipeline script.

## Expected Behavior

`glob` is dropped from the workspace; the three usages move to `tinyglobby` (already a catalog dep used in 11+ places, and the prevailing replacement enforced by `no-restricted-imports` rules elsewhere in the repo).

## Implementation Details

- `tools/workspace-plugin/src/conformance-rules/codeblock-language/index.ts`: removed dead `globSync`/`join`/`relative` imports (rule reads `fileMapCache.fileMap.projectFileMap` directly).
- `tools/workspace-plugin/src/conformance-rules/relative-image-imports/index.ts`: swapped `glob.sync(join(workspaceRoot, 'astro-docs/**/*.mdoc'), { ignore })` for the idiomatic tinyglobby form (`cwd` + relative pattern + `absolute: true`). Verified the new call returns the identical set of 501 absolute paths.
- `scripts/cleanup-tsconfig-files.js`: `glob.sync(p)` → `globSync(p)`.
- Dropped `glob` from root and `tools/workspace-plugin` `package.json`; added `"tinyglobby": "catalog:"` to the latter.
- Lockfile diff is surgical: -6 / +3 lines (two `glob` importer entries gone, one `tinyglobby` entry added).

### Validation

- `pnpm install` clean.
- `nx run-many -t lint,test,build -p workspace-plugin` — green (38/38 tests).
- `nx conformance` — all 7 rules pass; `image-import-paths` (the migrated one) scans astro-docs `.mdoc` tree end-to-end.
- Side-by-side comparison: `glob@7.1.4` and `tinyglobby` return the **identical 501-file set** for the migrated pattern.
- `scripts/cleanup-tsconfig-files.js` smoke run — removes the expected files.