### PR TITLE
fix(js): multi-version support compliance

### DIFF
--- a/packages/js/migrations.json
+++ b/packages/js/migrations.json
@@ -59,6 +59,9 @@
     },
     "20.7.1-beta.0": {
       "version": "20.7.1-beta.0",
+      "requires": {
+        "@swc/cli": ">=0.3.0 <0.6.0"
+      },
       "packages": {
         "@swc/cli": {
           "version": "~0.6.0",
@@ -99,10 +102,6 @@
           "version": "^1.15.5",
           "alwaysAddToPackageJson": false
         },
-        "@swc/cli": {
-          "version": "^0.7.10",
-          "alwaysAddToPackageJson": false
-        },
         "@swc/helpers": {
           "version": "^0.5.18",
           "alwaysAddToPackageJson": false
@@ -113,11 +112,35 @@
         }
       }
     },
+    "22.5.0-swc-cli": {
+      "version": "22.5.0-beta.1",
+      "requires": {
+        "@swc/cli": ">=0.6.0 <0.7.0"
+      },
+      "packages": {
+        "@swc/cli": {
+          "version": "^0.7.10",
+          "alwaysAddToPackageJson": false
+        }
+      }
+    },
     "22.6.4": {
       "version": "22.6.4",
       "packages": {
         "verdaccio": {
           "version": "^6.3.2",
+          "alwaysAddToPackageJson": false
+        }
+      }
+    },
+    "23.0.0-swc-cli": {
+      "version": "23.0.0-beta.17",
+      "requires": {
+        "@swc/cli": ">=0.7.0 <0.8.0"
+      },
+      "packages": {
+        "@swc/cli": {
+          "version": "~0.8.0",
           "alwaysAddToPackageJson": false
         }
       }

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -143,7 +143,7 @@
     "nx": "workspace:*"
   },
   "peerDependencies": {
-    "typescript": ">=5.4.0",
+    "typescript": ">=5.4.0 <6.0.0",
     "@swc/cli": ">=0.6.0 <0.9.0",
     "verdaccio": "^6.0.5"
   },

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -143,7 +143,7 @@
     "nx": "workspace:*"
   },
   "peerDependencies": {
-    "typescript": ">=5.4.0 <6.0.0",
+    "typescript": ">=5.4.0 <7.0.0",
     "@swc/cli": ">=0.6.0 <0.9.0",
     "verdaccio": "^6.0.5"
   },

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -143,9 +143,14 @@
     "nx": "workspace:*"
   },
   "peerDependencies": {
+    "typescript": ">=5.4.0",
+    "@swc/cli": ">=0.6.0 <0.9.0",
     "verdaccio": "^6.0.5"
   },
   "peerDependenciesMeta": {
+    "@swc/cli": {
+      "optional": true
+    },
     "verdaccio": {
       "optional": true
     }

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -143,7 +143,6 @@
     "nx": "workspace:*"
   },
   "peerDependencies": {
-    "typescript": ">=5.4.0 <7.0.0",
     "@swc/cli": ">=0.6.0 <0.9.0",
     "verdaccio": "^6.0.5"
   },

--- a/packages/js/src/generators/convert-to-swc/convert-to-swc.ts
+++ b/packages/js/src/generators/convert-to-swc/convert-to-swc.ts
@@ -8,6 +8,7 @@ import {
   updateProjectConfiguration,
 } from '@nx/devkit';
 import { join } from 'path';
+import { assertSupportedTypescriptVersion } from '../../utils/assert-supported-typescript-version';
 import { addSwcConfig } from '../../utils/swc/add-swc-config';
 import { addSwcDependencies } from '../../utils/swc/add-swc-dependencies';
 import { swcHelpersVersion } from '../../utils/versions';
@@ -17,6 +18,8 @@ export async function convertToSwcGenerator(
   tree: Tree,
   schema: ConvertToSwcGeneratorSchema
 ) {
+  assertSupportedTypescriptVersion(tree);
+
   const options = normalizeOptions(schema);
   const projectConfiguration = readProjectConfiguration(tree, options.project);
 
@@ -99,7 +102,8 @@ function checkSwcDependencies(
       tree,
       { '@swc/helpers': swcHelpersVersion },
       {},
-      projectPackageJsonPath
+      projectPackageJsonPath,
+      true
     );
   }
 

--- a/packages/js/src/generators/init/init.spec.ts
+++ b/packages/js/src/generators/init/init.spec.ts
@@ -94,16 +94,15 @@ describe('js init generator', () => {
     expect(packageJson.devDependencies['typescript']).toBeDefined();
   });
 
-  it('should overwrite installed typescript version when is not a supported version', async () => {
+  it('should throw when the installed typescript version is below the supported floor', async () => {
     updateJson(tree, 'package.json', (json) => {
       json.devDependencies = { ...json.devDependencies, typescript: '~4.5.0' };
       return json;
     });
 
-    await init(tree, {});
-
-    const packageJson = readJson(tree, 'package.json');
-    expect(packageJson.devDependencies['typescript']).toBe(typescriptVersion);
+    await expect(init(tree, {})).rejects.toThrow(
+      'Unsupported version of `typescript` detected'
+    );
   });
 
   it('should not overwrite installed typescript version when is a supported version', async () => {

--- a/packages/js/src/generators/init/init.ts
+++ b/packages/js/src/generators/init/init.ts
@@ -1,4 +1,4 @@
-import { addPlugin, checkAndCleanWithSemver } from '@nx/devkit/internal';
+import { addPlugin } from '@nx/devkit/internal';
 import {
   addDependenciesToPackageJson,
   createProjectGraphAsync,
@@ -6,16 +6,14 @@ import {
   formatFiles,
   generateFiles,
   GeneratorCallback,
-  getDependencyVersionFromPackageJson,
   readJson,
   readNxJson,
   runTasksInSerial,
   Tree,
 } from '@nx/devkit';
-import { readModulePackageJson } from 'nx/src/utils/package-json';
 import { join } from 'path';
-import { satisfies, valid } from 'semver';
 import { createNodesV2 } from '../../plugins/typescript/plugin';
+import { assertSupportedTypescriptVersion } from '../../utils/assert-supported-typescript-version';
 import { generatePrettierSetup } from '../../utils/prettier';
 import { getRootTsConfigFileName } from '../../utils/typescript/ts-config';
 import {
@@ -25,50 +23,11 @@ import {
 import {
   nxVersion,
   prettierVersion,
-  supportedTypescriptVersions,
   swcHelpersVersion,
   tsLibVersion,
   typescriptVersion,
 } from '../../utils/versions';
 import { InitSchema } from './schema';
-
-async function getInstalledTypescriptVersion(
-  tree: Tree
-): Promise<string | null> {
-  const tsVersionInRootPackageJson = getDependencyVersionFromPackageJson(
-    tree,
-    'typescript'
-  );
-
-  if (!tsVersionInRootPackageJson) {
-    return null;
-  }
-  if (valid(tsVersionInRootPackageJson)) {
-    // it's a pinned version, return it
-    return tsVersionInRootPackageJson;
-  }
-
-  // it's a version range, check whether the installed version matches it
-  try {
-    const tsPackageJson = readModulePackageJson('typescript').packageJson;
-    const installedTsVersion =
-      tsPackageJson.devDependencies?.['typescript'] ??
-      tsPackageJson.dependencies?.['typescript'];
-    // the installed version matches the package.json version range
-    if (
-      installedTsVersion &&
-      satisfies(installedTsVersion, tsVersionInRootPackageJson)
-    ) {
-      return installedTsVersion;
-    }
-  } finally {
-    return checkAndCleanWithSemver(
-      tree,
-      'typescript',
-      tsVersionInRootPackageJson
-    );
-  }
-}
 
 export async function initGenerator(
   tree: Tree,
@@ -88,6 +47,8 @@ export async function initGeneratorInternal(
   tree: Tree,
   schema: InitSchema
 ): Promise<GeneratorCallback> {
+  assertSupportedTypescriptVersion(tree);
+
   const tasks: GeneratorCallback[] = [];
 
   const nxJson = readNxJson(tree);
@@ -162,17 +123,8 @@ export async function initGeneratorInternal(
   // with --experimental-strip-types). loadTsFile registers swc/ts-node lazily
   // when a config uses syntax native strip can't handle.
 
-  if (!schema.js && !schema.keepExistingVersions) {
-    const installedTsVersion = await getInstalledTypescriptVersion(tree);
-
-    if (
-      !installedTsVersion ||
-      !satisfies(installedTsVersion, supportedTypescriptVersions, {
-        includePrerelease: true,
-      })
-    ) {
-      devDependencies['typescript'] = typescriptVersion;
-    }
+  if (!schema.js) {
+    devDependencies['typescript'] = typescriptVersion;
   }
 
   if (schema.formatter === 'prettier') {
@@ -198,7 +150,7 @@ export async function initGeneratorInternal(
         {},
         devDependencies,
         undefined,
-        schema.keepExistingVersions
+        schema.keepExistingVersions ?? true
       )
     : () => {};
   tasks.push(installTask);

--- a/packages/js/src/generators/init/schema.json
+++ b/packages/js/src/generators/init/schema.json
@@ -31,7 +31,7 @@
       "type": "boolean",
       "x-priority": "internal",
       "description": "Keep existing dependencies versions",
-      "default": false
+      "default": true
     },
     "addTsConfigBase": {
       "type": "boolean",

--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -31,6 +31,7 @@ import {
 import { type PackageJson } from 'nx/src/utils/package-json';
 import { join } from 'path';
 import type { CompilerOptions } from 'typescript';
+import { assertSupportedTypescriptVersion } from '../../utils/assert-supported-typescript-version';
 import { normalizeLinterOption } from '../../utils/generator-prompts';
 import { sortPackageJsonFields } from '../../utils/package-json/sort-fields';
 import { getUpdatedPackageJsonContent } from '../../utils/package-json/update-package-json';
@@ -89,6 +90,8 @@ export async function libraryGeneratorInternal(
   tree: Tree,
   schema: LibraryGeneratorSchema
 ) {
+  assertSupportedTypescriptVersion(tree);
+
   const tasks: GeneratorCallback[] = [];
 
   const addTsPlugin = shouldConfigureTsSolutionSetup(tree, schema.addPlugin);
@@ -934,7 +937,9 @@ function addProjectDependencies(
         esbuild:
           getDependencyVersionFromPackageJson(tree, 'esbuild') ??
           esbuildVersion,
-      }
+      },
+      undefined,
+      true
     );
   } else if (options.bundler == 'rollup') {
     const { dependencies, devDependencies } = getSwcDependencies();
@@ -945,26 +950,34 @@ function addProjectDependencies(
         ...devDependencies,
         '@nx/rollup': nxVersion,
         '@types/node': typesNodeVersion,
-      }
+      },
+      undefined,
+      true
     );
   } else if (options.bundler === 'tsc') {
     return addDependenciesToPackageJson(
       tree,
       {},
-      { tslib: tsLibVersion, '@types/node': typesNodeVersion }
+      { tslib: tsLibVersion, '@types/node': typesNodeVersion },
+      undefined,
+      true
     );
   } else if (options.bundler === 'swc') {
     const { dependencies, devDependencies } = getSwcDependencies();
     return addDependenciesToPackageJson(
       tree,
       { ...dependencies },
-      { ...devDependencies, '@types/node': typesNodeVersion }
+      { ...devDependencies, '@types/node': typesNodeVersion },
+      undefined,
+      true
     );
   } else {
     return addDependenciesToPackageJson(
       tree,
       {},
-      { '@types/node': typesNodeVersion }
+      { '@types/node': typesNodeVersion },
+      undefined,
+      true
     );
   }
 

--- a/packages/js/src/generators/setup-build/generator.ts
+++ b/packages/js/src/generators/setup-build/generator.ts
@@ -20,6 +20,7 @@ import {
 import { basename, dirname, join } from 'node:path/posix';
 import { mergeTargetConfigurations } from 'nx/src/devkit-internals';
 import type { PackageJson } from 'nx/src/utils/package-json';
+import { assertSupportedTypescriptVersion } from '../../utils/assert-supported-typescript-version';
 import { getImportPath } from '../../utils/get-import-path';
 import {
   getUpdatedPackageJsonContent,
@@ -44,6 +45,8 @@ export async function setupBuildGenerator(
   tree: Tree,
   options: SetupBuildGeneratorSchema
 ): Promise<GeneratorCallback> {
+  assertSupportedTypescriptVersion(tree);
+
   const tasks: GeneratorCallback[] = [];
   const project = readProjectConfiguration(tree, options.project);
   options.buildTarget ??= 'build';

--- a/packages/js/src/generators/setup-prettier/generator.ts
+++ b/packages/js/src/generators/setup-prettier/generator.ts
@@ -4,6 +4,7 @@ import {
   type GeneratorCallback,
   type Tree,
 } from '@nx/devkit';
+import { assertSupportedTypescriptVersion } from '../../utils/assert-supported-typescript-version';
 import { generatePrettierSetup } from '../../utils/prettier';
 import { prettierVersion } from '../../utils/versions';
 import type { GeneratorOptions } from './schema';
@@ -12,6 +13,8 @@ export async function setupPrettierGenerator(
   tree: Tree,
   options: GeneratorOptions
 ): Promise<GeneratorCallback> {
+  assertSupportedTypescriptVersion(tree);
+
   const prettierTask = generatePrettierSetup(tree, {
     skipPackageJson: options.skipPackageJson,
   });

--- a/packages/js/src/generators/setup-verdaccio/generator.ts
+++ b/packages/js/src/generators/setup-verdaccio/generator.ts
@@ -11,6 +11,7 @@ import {
 } from '@nx/devkit';
 import * as path from 'path';
 import { SetupVerdaccioGeneratorSchema } from './schema';
+import { assertSupportedTypescriptVersion } from '../../utils/assert-supported-typescript-version';
 import { isUsingTsSolutionSetup } from '../../utils/typescript/ts-solution-setup';
 import { verdaccioVersion } from '../../utils/versions';
 import { getNpmRegistry } from '../../utils/npm-config';
@@ -19,6 +20,8 @@ export async function setupVerdaccio(
   tree: Tree,
   options: SetupVerdaccioGeneratorSchema
 ) {
+  assertSupportedTypescriptVersion(tree);
+
   if (!tree.exists('.verdaccio/config.yml')) {
     generateFiles(tree, path.join(__dirname, 'files'), '.verdaccio', {
       npmUplinkRegistry:
@@ -73,7 +76,9 @@ export async function setupVerdaccio(
   return addDependenciesToPackageJson(
     tree,
     {},
-    { verdaccio: verdaccioVersion }
+    { verdaccio: verdaccioVersion },
+    undefined,
+    true
   );
 }
 

--- a/packages/js/src/generators/typescript-sync/typescript-sync.ts
+++ b/packages/js/src/generators/typescript-sync/typescript-sync.ts
@@ -17,6 +17,7 @@ import {
   type SyncGeneratorResult,
 } from 'nx/src/utils/sync-generators';
 import * as ts from 'typescript';
+import { assertSupportedTypescriptVersion } from '../../utils/assert-supported-typescript-version';
 
 interface Tsconfig {
   references?: Array<{ path: string }>;
@@ -60,6 +61,8 @@ type ChangedFileDetails = {
 type ChangeType = keyof ChangedFileDetails;
 
 export async function syncGenerator(tree: Tree): Promise<SyncGeneratorResult> {
+  assertSupportedTypescriptVersion(tree);
+
   // Ensure that the plugin has been wired up in nx.json
   const nxJson = readNxJson(tree);
 

--- a/packages/js/src/utils/all-generators-enforce-floor.spec.ts
+++ b/packages/js/src/utils/all-generators-enforce-floor.spec.ts
@@ -1,0 +1,10 @@
+import { assertGeneratorsEnforceVersionFloor } from '@nx/devkit/internal-testing-utils';
+import { join } from 'node:path';
+
+describe('@nx/js generators enforce supported version floor', () => {
+  assertGeneratorsEnforceVersionFloor({
+    packageRoot: join(__dirname, '..', '..'),
+    packageName: 'typescript',
+    subFloorVersion: '~5.3.0',
+  });
+});

--- a/packages/js/src/utils/assert-supported-typescript-version.spec.ts
+++ b/packages/js/src/utils/assert-supported-typescript-version.spec.ts
@@ -1,0 +1,52 @@
+import { updateJson } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { assertSupportedTypescriptVersion } from './assert-supported-typescript-version';
+
+describe('assertSupportedTypescriptVersion', () => {
+  it('throws when typescript is below the supported floor', () => {
+    const tree = createTreeWithEmptyWorkspace();
+    updateJson(tree, 'package.json', (json) => ({
+      ...json,
+      devDependencies: { typescript: '~5.3.0' },
+    }));
+
+    expect(() => assertSupportedTypescriptVersion(tree)).toThrow(
+      'Unsupported version of `typescript` detected'
+    );
+  });
+
+  it('does not throw when typescript is not installed (fresh-install path)', () => {
+    const tree = createTreeWithEmptyWorkspace();
+    expect(() => assertSupportedTypescriptVersion(tree)).not.toThrow();
+  });
+
+  it('does not throw when typescript is `latest`', () => {
+    const tree = createTreeWithEmptyWorkspace();
+    updateJson(tree, 'package.json', (json) => ({
+      ...json,
+      devDependencies: { typescript: 'latest' },
+    }));
+
+    expect(() => assertSupportedTypescriptVersion(tree)).not.toThrow();
+  });
+
+  it('does not throw when typescript is `next`', () => {
+    const tree = createTreeWithEmptyWorkspace();
+    updateJson(tree, 'package.json', (json) => ({
+      ...json,
+      devDependencies: { typescript: 'next' },
+    }));
+
+    expect(() => assertSupportedTypescriptVersion(tree)).not.toThrow();
+  });
+
+  it('does not throw when typescript is within the supported window', () => {
+    const tree = createTreeWithEmptyWorkspace();
+    updateJson(tree, 'package.json', (json) => ({
+      ...json,
+      devDependencies: { typescript: '~5.9.2' },
+    }));
+
+    expect(() => assertSupportedTypescriptVersion(tree)).not.toThrow();
+  });
+});

--- a/packages/js/src/utils/assert-supported-typescript-version.ts
+++ b/packages/js/src/utils/assert-supported-typescript-version.ts
@@ -1,0 +1,11 @@
+import { type Tree } from '@nx/devkit';
+import { assertSupportedPackageVersion } from '@nx/devkit/internal';
+import { minSupportedTypescriptVersion } from './versions';
+
+export function assertSupportedTypescriptVersion(tree: Tree): void {
+  assertSupportedPackageVersion(
+    tree,
+    'typescript',
+    minSupportedTypescriptVersion
+  );
+}

--- a/packages/js/src/utils/swc/add-swc-dependencies.ts
+++ b/packages/js/src/utils/swc/add-swc-dependencies.ts
@@ -24,13 +24,21 @@ export function getSwcDependencies(): {
 export function addSwcDependencies(tree: Tree) {
   const { dependencies, devDependencies } = getSwcDependencies();
 
-  return addDependenciesToPackageJson(tree, dependencies, devDependencies);
+  return addDependenciesToPackageJson(
+    tree,
+    dependencies,
+    devDependencies,
+    undefined,
+    true
+  );
 }
 
 export function addSwcRegisterDependencies(tree: Tree) {
   return addDependenciesToPackageJson(
     tree,
     {},
-    { '@swc-node/register': swcNodeVersion, '@swc/core': swcCoreVersion }
+    { '@swc-node/register': swcNodeVersion, '@swc/core': swcCoreVersion },
+    undefined,
+    true
   );
 }

--- a/packages/js/src/utils/versions.ts
+++ b/packages/js/src/utils/versions.ts
@@ -19,4 +19,4 @@ export const typescriptVersion = '~5.9.2';
  * that's supported by the lowest Angular supported version, e.g.
  * `npm view @angular/compiler-cli@18.0.0 peerDependencies.typescript`
  */
-export const supportedTypescriptVersions = '>=5.4.0';
+export const minSupportedTypescriptVersion = '5.4.0';

--- a/packages/nx/src/internal-testing-utils/assert-generators-enforce-version-floor.ts
+++ b/packages/nx/src/internal-testing-utils/assert-generators-enforce-version-floor.ts
@@ -38,7 +38,9 @@ export function assertGeneratorsEnforceVersionFloor(options: {
       const [factoryRelative, exportName] = def.factory
         .replace(/^\.\//, '')
         .split('#');
-      const factoryModule = require(join(packageRoot, factoryRelative));
+      // Local-dist plugins point factories at `./dist/src/...`; Jest loads from `./src/...`.
+      const sourceRelative = factoryRelative.replace(/^dist\//, '');
+      const factoryModule = require(join(packageRoot, sourceRelative));
       const factory = exportName
         ? factoryModule[exportName]
         : (factoryModule.default ?? factoryModule);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3044,7 +3044,7 @@ importers:
         specifier: catalog:typescript
         version: 2.8.1
       typescript:
-        specifier: '>=5.4.0 <6.0.0'
+        specifier: '>=5.4.0 <7.0.0'
         version: 5.9.2
       verdaccio:
         specifier: ^6.0.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3044,7 +3044,7 @@ importers:
         specifier: catalog:typescript
         version: 2.8.1
       typescript:
-        specifier: '>=5.4.0'
+        specifier: '>=5.4.0 <6.0.0'
         version: 5.9.2
       verdaccio:
         specifier: ^6.0.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2989,6 +2989,9 @@ importers:
       '@nx/workspace':
         specifier: workspace:*
         version: link:../workspace
+      '@swc/cli':
+        specifier: '>=0.6.0 <0.9.0'
+        version: 0.8.0(@swc/core@1.15.10(@swc/helpers@0.5.18))(chokidar@5.0.0)
       '@zkochan/js-yaml':
         specifier: 'catalog:'
         version: 0.0.7
@@ -3040,6 +3043,9 @@ importers:
       tslib:
         specifier: catalog:typescript
         version: 2.8.1
+      typescript:
+        specifier: '>=5.4.0'
+        version: 5.9.2
       verdaccio:
         specifier: ^6.0.5
         version: 6.0.5(encoding@0.1.13)(typanion@3.14.0)
@@ -34510,6 +34516,21 @@ snapshots:
       tinyglobby: 0.2.15
     optionalDependencies:
       chokidar: 3.6.0
+
+  '@swc/cli@0.8.0(@swc/core@1.15.10(@swc/helpers@0.5.18))(chokidar@5.0.0)':
+    dependencies:
+      '@swc/core': 1.15.10(@swc/helpers@0.5.18)
+      '@swc/counter': 0.1.3
+      '@xhmikosr/bin-wrapper': 13.0.5
+      commander: 8.3.0
+      minimatch: 9.0.9
+      piscina: 4.9.2
+      semver: 7.7.4
+      slash: 3.0.0
+      source-map: 0.7.6
+      tinyglobby: 0.2.15
+    optionalDependencies:
+      chokidar: 5.0.0
 
   '@swc/core-darwin-arm64@1.15.10':
     optional: true

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3043,9 +3043,6 @@ importers:
       tslib:
         specifier: catalog:typescript
         version: 2.8.1
-      typescript:
-        specifier: '>=5.4.0 <7.0.0'
-        version: 5.9.2
       verdaccio:
         specifier: ^6.0.5
         version: 6.0.5(encoding@0.1.13)(typanion@3.14.0)


### PR DESCRIPTION
## Current Behavior

`@nx/js` has several multi-version compliance gaps:

- The `20.7.1-beta.0` and `22.5.0` migrations bump `@swc/cli` across SemVer-breaking 0.x minor boundaries without a source-range `requires` gate. Workspaces that missed an intermediate bump (e.g. via `--mode=first-party`) can be jumped to the target lane in one write, skipping the bridge. The `22.5.0` entry also mixes the cross-minor `@swc/cli` jump with same-major patches under one combined gate.
- No migration path past `@swc/cli@^0.7.10` exists, so migrated workspaces stay behind the fresh-install constant (`~0.8.0`).
- `@swc/cli` is not declared as a peer dependency, so the supported window isn't visible from `package.json` and the SWC executor doesn't surface an unmet-peer signal.
- Generators silently fall through to the latest install constants when TypeScript is below the supported floor — no floor assert.
- Several `addDependenciesToPackageJson` call sites (`init`, `library`, `convert-to-swc`, `setup-verdaccio`, SWC helpers) don't pass `keepExistingVersions: true` and can overwrite pinned versions; `init`'s schema defaults the flag to `false`.

## Expected Behavior

- `@swc/cli` migration entries gate on their source range; the previously-mixed `22.5.0` entry is split so same-major patches still apply on any same-major source.
- A `23.0.0-swc-cli` migration bridges `~0.7.x` to `~0.8.0`.
- `package.json` declares `@swc/cli: ">=0.6.0 <0.9.0"` as an optional peer (via `peerDependenciesMeta`).
- All generators throw a clear "Unsupported version" message when TypeScript is below `5.4.0`, naming the package, installed version, and supported floor.
- Generators preserve user-pinned versions; `init`'s schema defaults `keepExistingVersions` to `true`.

## Implementation Details

- Added bilateral `requires: { "@swc/cli": ">=N <M" }` gates on the cross-breaking entries. `nx migrate`'s `filterDowngradedUpdates` already handles past-target downgrades natively, so the gates are load-bearing for stepwise chaining: a workspace at `0.3.12` running `nx migrate --mode=all` against a newer Nx won't have the latest entry jump it directly to `~0.8.0` — it must catch up stepwise via `nx migrate --mode=third-party`, which walks each gated bridge in order.
- Split `22.5.0`: ungated entry keeps `@swc/core`/`@swc/helpers`/`@swc-node/register` patches; new `22.5.0-swc-cli` gates the `@swc/cli` jump separately so the patch bumps still apply on workspaces outside the `@swc/cli` source range.
- Added `packages/js/src/utils/assert-supported-typescript-version.ts` delegating to `assertSupportedPackageVersion` from `@nx/devkit/internal`. Called as the first statement of `initGeneratorInternal`, `libraryGeneratorInternal`, `convertToSwcGenerator`, `setupVerdaccio`, `setupBuildGenerator`, `setupPrettierGenerator`, and `syncGenerator`.
- Simplified `initGeneratorInternal`: removed the now-redundant `getInstalledTypescriptVersion` helper and `!satisfies(supportedTypescriptVersions, ...)` check. The floor assert covers sub-floor; `addDependenciesToPackageJson` with `keepExistingVersions: true` covers user-pin preservation.
- Renamed `supportedTypescriptVersions = '>=5.4.0'` to `minSupportedTypescriptVersion = '5.4.0'` in `versions.ts` to match the canonical floor-constant shape consumed by `assertSupportedPackageVersion`. Constant was not exported from `@nx/js/internal` so no public-API impact.
- `typescript` is intentionally **not** declared as a peer dep in this PR. With a peer cap of `<7.0.0`, pnpm auto-resolves `@nx/js`'s typescript subgraph to the highest matching version (e.g. `6.0.x`) even when the workspace pins a direct `typescript: ~5.9.2`, so the `@nx/js` executor loads a different typescript than the workspace `tsc`. Capping at `<6.0.0` avoids that but warns users already on TS 6 + TS-solution. Resolving implicitly (no peer declared, same as pre-compliance) keeps the executor on the user's workspace typescript and matches prior behavior. Deferred to a follow-up that resolves the subgraph divergence properly.
- Added `all-generators-enforce-floor.spec.ts` (parameterized via `assertGeneratorsEnforceVersionFloor`) and `assert-supported-typescript-version.spec.ts` (5 canonical cases: sub-floor / fresh-install / `latest` / `next` / in-range).
- Extended `assertGeneratorsEnforceVersionFloor` to strip a leading `./dist/` from `generators.json` factory paths so plugins built to local dist (like `@nx/js`, and `@nx/jest` going forward) load factories from source under Jest. Backward-compatible — non-dist plugins are unaffected.