### PR TITLE
cleanup(core): drop stale @nrwl dedup TODO in nx report

### DIFF
--- a/packages/nx/src/command-line/report/report.ts
+++ b/packages/nx/src/command-line/report/report.ts
@@ -586,7 +586,6 @@ export function findRegisteredPluginsBeingUsed(nxJson: NxJsonConfiguration) {
 
 export function findInstalledPackagesWeCareAbout() {
   const packagesWeMayCareAbout: Record<string, string> = {};
-  // TODO (v20): Remove workaround for hiding @nrwl packages when matching @nx package is found.
 
   for (const pkg of packagesWeCareAbout) {
     const v = readPackageVersion(pkg);


### PR DESCRIPTION
## Current Behavior

`packages/nx/src/command-line/report/report.ts` contains a stale `TODO (v20)` comment referencing a workaround for hiding `@nrwl/*` packages when a matching `@nx/*` package was found. We're on v23 — two majors past the deadline.

The actual workaround was a `packageChangeMap` plus dedup logic inside `findInstalledPackagesWeCareAbout` that compared `@nrwl/*` and `@nx/*` versions and suppressed the `@nrwl/*` entry when both matched. That logic was already removed in #30840 (May 2025). Only the orphaned comment remained.

## Expected Behavior

The stale comment is removed. No runtime behavior change — `findInstalledPackagesWeCareAbout` already lists every installed package from `packagesWeCareAbout` without any `@nrwl/@nx` dedup logic.

Verified `nx report` output is unchanged for workspaces with only `@nx/*` packages and for workspaces that still have legacy `@nrwl/*` packages installed (e.g. `@nrwl/nx-cloud` from `nx-migrations.packageGroup`, or `@nrwl/schematics` from the manual entry on line 53 — both continue to be reported as before).

## Related Issue(s)

Ref: NXC-4300