### PR TITLE
fix(core): detect changes to files inside directories with unicode names

### DIFF
--- a/e2e/nx/src/affected-graph.test.ts
+++ b/e2e/nx/src/affected-graph.test.ts
@@ -296,6 +296,19 @@ describe('Nx Affected and Graph Tests', () => {
       expect(affectedProjects).toContain(myapp);
       expect(affectedProjects).toContain(myapp2);
     });
+
+    it('should detect changes to files inside directories with unicode names', () => {
+      generateAll();
+      // Explicitly set core.quotepath=true (the default) to reproduce the
+      // original bug where git-quoted octal-encoded paths were not decoded.
+      runCommand(`git config core.quotepath true`);
+
+      // Add a file whose parent directory contains a non-ASCII character (ä).
+      updateFile(`apps/${myapp}/src/app/Einkäufe/test.ts`, `export const x = 1;`);
+
+      const affectedProjects = runCLI('show projects --affected --uncommitted');
+      expect(affectedProjects).toContain(myapp);
+    });
   });
 
   describe('graph', () => {

--- a/packages/nx/src/utils/command-line-utils.ts
+++ b/packages/nx/src/utils/command-line-utils.ts
@@ -277,11 +277,13 @@ export function parseFiles(options: NxArgs): { files: string[] } {
 }
 
 function getUncommittedFiles(): string[] {
-  return parseGitOutput(`git diff --name-only --no-renames --relative HEAD .`);
+  return parseGitOutput(
+    `git diff -z --name-only --no-renames --relative HEAD .`
+  );
 }
 
 function getUntrackedFiles(): string[] {
-  return parseGitOutput(`git ls-files --others --exclude-standard`);
+  return parseGitOutput(`git ls-files -z --others --exclude-standard`);
 }
 
 function getMergeBase(base: string, head: string = 'HEAD') {
@@ -312,7 +314,7 @@ function getMergeBase(base: string, head: string = 'HEAD') {
 
 function getFilesUsingBaseAndHead(base: string, head: string): string[] {
   return parseGitOutput(
-    `git diff --name-only --no-renames --relative "${base}" "${head}"`
+    `git diff -z --name-only --no-renames --relative "${base}" "${head}"`
   );
 }
 
@@ -324,8 +326,7 @@ function parseGitOutput(command: string): string[] {
     windowsHide: true,
   })
     .toString('utf-8')
-    .split('\n')
-    .map((a) => a.trim())
+    .split('\0')
     .filter((a) => a.length > 0);
 }
 


### PR DESCRIPTION
When making changes to files inside directories with unicode names (e.g. German Umlaute), affected projects are now determined correctly.

Closes #35722

## Current Behavior
When making changes to a file containing special characters in its path (e.g. `apps/cart/src/app/Einkäufe/test.tsx` in my [repro project](https://github.com/chrstnbrn/nx-umlaut-repro)) and running `nx show projects --affected`, nothing is returned.

## Expected Behavior
Changes in such files are detected correctly.

## Related Issue(s)

Fixes #35722
