### PR TITLE
fix(core): treat undefined task parallelism as parallel when scheduling

### DIFF
--- a/packages/nx/src/tasks-runner/tasks-schedule.ts
+++ b/packages/nx/src/tasks-runner/tasks-schedule.ts
@@ -358,7 +358,7 @@ export class TasksSchedule {
       return false;
     } else {
       // if all running tasks support parallelism, can only schedule task with parallelism
-      return this.taskGraph.tasks[taskId].parallelism === true;
+      return this.taskGraph.tasks[taskId].parallelism !== false;
     }
   }
 

--- a/packages/nx/src/tasks-runner/tasks-schedule.ts
+++ b/packages/nx/src/tasks-runner/tasks-schedule.ts
@@ -319,10 +319,10 @@ export class TasksSchedule {
     task: Task,
     batchTaskGraph: TaskGraph | undefined
   ): boolean {
-    // task self needs to have parallelism true
+    // task self needs to support parallelism (undefined defaults to parallel)
     // all deps have either completed or belong to the same batch
     return (
-      task.parallelism === true &&
+      task.parallelism !== false &&
       this.taskGraph.dependencies[task.id].every(
         (id) => this.completedTasks.has(id) || !!batchTaskGraph?.tasks[id]
       )


### PR DESCRIPTION
## Current Behavior

When deciding whether a task can be scheduled, `TasksSchedule` checked `task.parallelism === true` in two places:

- `canBeScheduled` — gating a task against already-running parallel tasks
- `canBatchTaskBeScheduled` — gating a task for batch scheduling

A task whose `parallelism` is `undefined` failed both checks and was blocked, even though `undefined` is meant to mean "parallel". This was also inconsistent with the running-tasks check, which uses `parallelism === false` — treating `undefined` as parallel-capable.

## Expected Behavior

A task with `parallelism === undefined` is treated as parallel in both the regular and batch scheduling checks. Both now use `parallelism !== false`, matching the convention used elsewhere and the documented default.

## Related Issue(s)

N/A
