### PR TITLE
docs(nx-dev): determinism requirement for inferred plugins

### DIFF
--- a/astro-docs/src/content/docs/concepts/inferred-tasks.mdoc
+++ b/astro-docs/src/content/docs/concepts/inferred-tasks.mdoc
@@ -47,17 +47,10 @@ A typical workspace will have many plugins inferring tasks. Nx processes all the
 
 Plugins are processed in the order that they appear in the `plugins` array in `nx.json`. So, if multiple plugins create a task with the same name, the plugin listed last will win. If, for some reason, you have a project with both a `vite.config.js` file and a `webpack.config.js` file, both the `@nx/vite` plugin and the `@nx/webpack` plugin will try to create a `build` task. The `build` task that is executed will be the task that belongs to the plugin listed lower in the `plugins` array.
 
-#### Plugin output must be deterministic
+Nx hashes the project graph node produced by each plugin to determine whether cached task results can be reused. If your plugin's `createNodes`/`createNodesV2` function returns different output on different runs or machines, Nx will compute a different hash and treat unchanged code as a cache miss. Keep output stable by following two rules:
 
-Nx hashes the project graph node produced by each plugin to determine whether cached task results can be reused. If your plugin's `createNodes`/`createNodesV2` function returns different output on different runs or machines, Nx will compute a different hash and treat unchanged code as a cache miss.
-
-To keep output stable:
-
-- **Sort arrays deterministically.** The order of `inputs`, `outputs`, `dependsOn`, and `metadata.targetGroups` entries must be the same every time. Arrays built by iterating over object keys or `Set` values are not guaranteed to be stable—sort them explicitly before returning.
-- **Avoid run-specific or machine-specific values.** Do not leak `process.env` variables, absolute paths, timestamps, or random IDs into target `options`, `env`, or `inputs`. Prefer workspace-relative tokens (e.g. `{workspaceRoot}`) over absolute paths.
-- **`Set` does not deduplicate by structure.** Two distinct object literals with identical contents are different `Set` members, so spreading a `Set<object>` into an array can produce duplicate entries whose order varies. Use value-based deduplication and sort the result instead.
-
-Following these rules ensures that every invocation of your plugin produces byte-for-byte identical configuration for the same source files, keeping the cache effective.
+- **Sort arrays deterministically.** The order of `targets`, `inputs`, `outputs`, `dependsOn`, and `metadata.targetGroups` entries must be the same every time—sort them explicitly before returning.
+- **Avoid machine-specific or run-specific values.** Do not leak `process.env` variables, absolute paths, timestamps, or random IDs into target configuration. Prefer workspace-relative tokens (e.g. `{workspaceRoot}`) over absolute paths.
 
 ### Scope plugins to specific projects
 

--- a/astro-docs/src/content/docs/concepts/inferred-tasks.mdoc
+++ b/astro-docs/src/content/docs/concepts/inferred-tasks.mdoc
@@ -43,9 +43,21 @@ Nx plugins infer the following properties by analyzing the tool configuration.
 
 A typical workspace will have many plugins inferring tasks. Nx processes all the plugins registered in `nx.json` to create project configuration for individual projects and a project and task graph that shows the connections between them all.
 
-### Plugin order matters
+### Order matters
 
 Plugins are processed in the order that they appear in the `plugins` array in `nx.json`. So, if multiple plugins create a task with the same name, the plugin listed last will win. If, for some reason, you have a project with both a `vite.config.js` file and a `webpack.config.js` file, both the `@nx/vite` plugin and the `@nx/webpack` plugin will try to create a `build` task. The `build` task that is executed will be the task that belongs to the plugin listed lower in the `plugins` array.
+
+#### Plugin output must be deterministic
+
+Nx hashes the project graph node produced by each plugin to determine whether cached task results can be reused. If your plugin's `createNodes`/`createNodesV2` function returns different output on different runs or machines, Nx will compute a different hash and treat unchanged code as a cache miss.
+
+To keep output stable:
+
+- **Sort arrays deterministically.** The order of `inputs`, `outputs`, `dependsOn`, and `metadata.targetGroups` entries must be the same every time. Arrays built by iterating over object keys or `Set` values are not guaranteed to be stable—sort them explicitly before returning.
+- **Avoid run-specific or machine-specific values.** Do not leak `process.env` variables, absolute paths, timestamps, or random IDs into target `options`, `env`, or `inputs`. Prefer workspace-relative tokens (e.g. `{workspaceRoot}`) over absolute paths.
+- **`Set` does not deduplicate by structure.** Two distinct object literals with identical contents are different `Set` members, so spreading a `Set<object>` into an array can produce duplicate entries whose order varies. Use value-based deduplication and sort the result instead.
+
+Following these rules ensures that every invocation of your plugin produces byte-for-byte identical configuration for the same source files, keeping the cache effective.
 
 ### Scope plugins to specific projects
 


### PR DESCRIPTION
Add a subsection explaining that createNodes/createNodesV2 output must be deterministic. covers stable array ordering, avoiding run-specific values; explains the consequences of cache misses.

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
