### PR TITLE
fix(release): scope ambiguous-scope check to active release group's projects

### DIFF
--- a/packages/nx/src/command-line/release/utils/resolve-semver-specifier.ts
+++ b/packages/nx/src/command-line/release/utils/resolve-semver-specifier.ts
@@ -13,7 +13,12 @@ export async function resolveSemverSpecifierFromConventionalCommits(
   projectGraph: ProjectGraph,
   projectNames: string[],
   releaseConfig: NxReleaseConfig,
-  releaseGraph: ReleaseGraph
+  releaseGraph: ReleaseGraph,
+  // The full set of projects in the active release group. For independent
+  // release groups, `projectNames` only contains the single project being
+  // processed, so this is forwarded separately to keep scope matching
+  // accurate against the whole group. Defaults to `projectNames`.
+  releaseGroupProjects: string[] = projectNames
 ): // Map of projectName to semver bump type
 Promise<Map<string, SemverSpecifier | null>> {
   const commits = await getGitDiff(from);
@@ -23,7 +28,8 @@ Promise<Map<string, SemverSpecifier | null>> {
     parsedCommits,
     projectNames,
     releaseConfig,
-    releaseGraph
+    releaseGraph,
+    releaseGroupProjects
   );
   return determineSemverChange(
     relevantCommits,

--- a/packages/nx/src/command-line/release/utils/shared.spec.ts
+++ b/packages/nx/src/command-line/release/utils/shared.spec.ts
@@ -1406,6 +1406,67 @@ describe('shared', () => {
       expect(result.get('@foo/graph')?.[0].isProjectScopedCommit).toBe(true);
     });
 
+    it('should detect intra-group ambiguity for independent release groups even when a single project is being processed', async () => {
+      // For independent release groups, only the single project being
+      // processed is passed as `projects`, but the full release group is
+      // forwarded as `releaseGroupProjects`. The scope `graph` matches
+      // both @foo/graph and @bar/graph, which both live in the active
+      // release group, so this is a genuine in-group ambiguity and must
+      // still throw. See https://github.com/nrwl/nx/issues/35744.
+      const commits: GitCommit[] = [
+        createMockCommit(
+          'indep1',
+          ['foo/graph/src/index.ts'],
+          'feat(graph): ambiguous within independent group',
+          'graph'
+        ),
+      ];
+
+      await expect(
+        getCommitsRelevantToProjects(
+          mockProjectGraph,
+          commits,
+          // only the single independent project currently being processed
+          ['@foo/graph'],
+          mockReleaseConfig!,
+          mockReleaseGraph,
+          // the full release group (both siblings)
+          ['@foo/graph', '@bar/graph']
+        )
+      ).rejects.toThrow(/Ambiguous scope "graph"/);
+    });
+
+    it('should NOT throw for independent release groups when the ambiguous scope collides only with projects outside the group', async () => {
+      // The independent project @foo/graph is released on its own (its
+      // release group contains only itself). The scope `graph` also
+      // matches @bar/graph, but that project lives in a different release
+      // group, so there is no in-group ambiguity. The commit should be
+      // treated as scoped to @foo/graph.
+      const commits: GitCommit[] = [
+        createMockCommit(
+          'indep2',
+          ['foo/graph/src/index.ts'],
+          'feat(graph): only collides outside the group',
+          'graph'
+        ),
+      ];
+
+      const result = await getCommitsRelevantToProjects(
+        mockProjectGraph,
+        commits,
+        ['@foo/graph'],
+        mockReleaseConfig!,
+        mockReleaseGraph,
+        // release group only contains the single independent project
+        ['@foo/graph']
+      );
+
+      expect(result.size).toBe(1);
+      expect(result.get('@foo/graph')).toHaveLength(1);
+      expect(result.get('@foo/graph')?.[0].commit.shortHash).toBe('indep2');
+      expect(result.get('@foo/graph')?.[0].isProjectScopedCommit).toBe(true);
+    });
+
     function createMockCommit(
       shortHash: string,
       affectedFiles: string[],

--- a/packages/nx/src/command-line/release/utils/shared.spec.ts
+++ b/packages/nx/src/command-line/release/utils/shared.spec.ts
@@ -1331,27 +1331,86 @@ describe('shared', () => {
         createMockCommit(
           'ghi789',
           ['libs/lib-a/src/index.ts'],
-          'feat(graph): ambiguous scope'
+          'feat(graph): ambiguous scope',
+          'graph'
         ),
       ];
 
-      try {
-        await getCommitsRelevantToProjects(
+      await expect(
+        getCommitsRelevantToProjects(
           mockProjectGraph,
           commits,
           ['@foo/graph', '@bar/graph'],
           mockReleaseConfig!,
           mockReleaseGraph
-        );
-      } catch (err: any) {
-        expect(err.message).toContain('Ambiguous scope "graph"');
-      }
+        )
+      ).rejects.toThrow(/Ambiguous scope "graph"/);
+    });
+
+    it('should NOT throw when ambiguous scope only collides with projects outside the active release group', async () => {
+      // The commit's `graph` scope matches @foo/graph + @bar/graph
+      // (both outside the active release group). The active group is
+      // ['lib-a'] and the commit touches libs/lib-a. The cross-group
+      // ambiguity is irrelevant to lib-a's release and should not
+      // block it. See https://github.com/nrwl/nx/issues/35744.
+      const commits: GitCommit[] = [
+        createMockCommit(
+          'cross1',
+          ['libs/lib-a/src/index.ts'],
+          'feat(graph): cross-group ambiguous scope',
+          'graph'
+        ),
+      ];
+
+      const result = await getCommitsRelevantToProjects(
+        mockProjectGraph,
+        commits,
+        ['lib-a'],
+        mockReleaseConfig!,
+        mockReleaseGraph
+      );
+
+      // lib-a is included via file-affectedness path, treated as
+      // non-scoped for this group (mirrors the empty-scope behavior).
+      expect(result.size).toBe(1);
+      expect(result.get('lib-a')).toHaveLength(1);
+      expect(result.get('lib-a')?.[0].commit.shortHash).toBe('cross1');
+      expect(result.get('lib-a')?.[0].isProjectScopedCommit).toBe(false);
+    });
+
+    it('should treat partially-ambiguous scope as scoped when filtered to a single in-group match', async () => {
+      // Scope `graph` matches @foo/graph + @bar/graph globally, but
+      // only @foo/graph is in the active release group. The filtered
+      // match set has one element, so no throw, and the commit is
+      // treated as scoped to @foo/graph.
+      const commits: GitCommit[] = [
+        createMockCommit(
+          'partial1',
+          ['foo/graph/src/index.ts'],
+          'feat(graph): partial cross-group match',
+          'graph'
+        ),
+      ];
+
+      const result = await getCommitsRelevantToProjects(
+        mockProjectGraph,
+        commits,
+        ['@foo/graph'],
+        mockReleaseConfig!,
+        mockReleaseGraph
+      );
+
+      expect(result.size).toBe(1);
+      expect(result.get('@foo/graph')).toHaveLength(1);
+      expect(result.get('@foo/graph')?.[0].commit.shortHash).toBe('partial1');
+      expect(result.get('@foo/graph')?.[0].isProjectScopedCommit).toBe(true);
     });
 
     function createMockCommit(
       shortHash: string,
       affectedFiles: string[],
-      message?: string
+      message?: string,
+      scope: string = ''
     ): GitCommit {
       return {
         message: message || `feat: commit ${shortHash}`,
@@ -1360,7 +1419,7 @@ describe('shared', () => {
         author: { name: 'Test Author', email: 'test@example.com' },
         description: `commit ${shortHash}`,
         type: 'feat',
-        scope: '',
+        scope,
         references: [],
         authors: [{ name: 'Test Author', email: 'test@example.com' }],
         isBreaking: false,

--- a/packages/nx/src/command-line/release/utils/shared.ts
+++ b/packages/nx/src/command-line/release/utils/shared.ts
@@ -489,22 +489,32 @@ Promise<Map<string, { commit: GitCommit; isProjectScopedCommit: boolean }[]>> {
     if (scopePatterns.length > 0) {
       const matches = findMatchingProjects(scopePatterns, projectGraph.nodes);
 
-      // detect ambiguity
+      // Detect ambiguity, but only within the active release group's
+      // projects. A scope that resolves ambiguously against projects
+      // outside the group is irrelevant to this group — fall through
+      // to the file-affectedness path used when a commit has no scope
+      // at all. See https://github.com/nrwl/nx/issues/35744.
       for (const pattern of scopePatterns) {
         const perPatternMatches = findMatchingProjects(
           [pattern],
           projectGraph.nodes
         );
+        const inGroupMatches = perPatternMatches.filter((p) =>
+          projectSet.has(p)
+        );
 
-        if (perPatternMatches.length > 1) {
+        if (inGroupMatches.length > 1) {
           throw new Error(
             `Ambiguous scope "${pattern}" in commit "${commit.message}". ` +
-              `Matches: ${perPatternMatches.join(', ')}`
+              `Matches: ${inGroupMatches.join(', ')}`
           );
         }
       }
 
-      scopedProjects = new Set(matches);
+      // Restrict the scoped-projects set to projects in the active
+      // release group so cross-group matches don't bleed into the
+      // isProjectScopedCommit determination below.
+      scopedProjects = new Set(matches.filter((p) => projectSet.has(p)));
     }
 
     for (const projectName of Object.keys(affectedGraph.nodes)) {

--- a/packages/nx/src/command-line/release/utils/shared.ts
+++ b/packages/nx/src/command-line/release/utils/shared.ts
@@ -456,10 +456,18 @@ export async function getCommitsRelevantToProjects(
   commits: GitCommit[],
   projects: string[],
   nxReleaseConfig: NxReleaseConfig,
-  releaseGraph: ReleaseGraph
+  releaseGraph: ReleaseGraph,
+  // The full set of projects in the active release group. For release
+  // groups with `projectsRelationship: 'independent'`, `projects` only
+  // contains the single project currently being processed, so the scope
+  // matching/ambiguity check below would not see its sibling projects.
+  // `releaseGroupProjects` lets us match scopes against the whole group
+  // regardless of relationship. Defaults to `projects` for fixed groups.
+  releaseGroupProjects: string[] = projects
 ): // Map of projectName to GitCommit[]
 Promise<Map<string, { commit: GitCommit; isProjectScopedCommit: boolean }[]>> {
   const projectSet = new Set(projects);
+  const releaseGroupProjectSet = new Set(releaseGroupProjects);
   const relevantCommits: Map<
     string,
     { commit: GitCommit; isProjectScopedCommit: boolean }[]
@@ -500,7 +508,7 @@ Promise<Map<string, { commit: GitCommit; isProjectScopedCommit: boolean }[]>> {
           projectGraph.nodes
         );
         const inGroupMatches = perPatternMatches.filter((p) =>
-          projectSet.has(p)
+          releaseGroupProjectSet.has(p)
         );
 
         if (inGroupMatches.length > 1) {
@@ -514,7 +522,9 @@ Promise<Map<string, { commit: GitCommit; isProjectScopedCommit: boolean }[]>> {
       // Restrict the scoped-projects set to projects in the active
       // release group so cross-group matches don't bleed into the
       // isProjectScopedCommit determination below.
-      scopedProjects = new Set(matches.filter((p) => projectSet.has(p)));
+      scopedProjects = new Set(
+        matches.filter((p) => releaseGroupProjectSet.has(p))
+      );
     }
 
     for (const projectName of Object.keys(affectedGraph.nodes)) {

--- a/packages/nx/src/command-line/release/version/derive-specifier-from-conventional-commits.ts
+++ b/packages/nx/src/command-line/release/version/derive-specifier-from-conventional-commits.ts
@@ -58,7 +58,11 @@ export async function deriveSpecifierFromConventionalCommits(
       projectGraph,
       affectedProjects,
       nxReleaseConfig,
-      releaseGraph
+      releaseGraph,
+      // Always match conventional-commit scopes against the full release
+      // group, even when only a single (independent) project is being
+      // processed, so genuine intra-group ambiguity is still detected.
+      releaseGroup.projects
     );
 
   const getHighestSemverChange = (


### PR DESCRIPTION
## Current Behavior

`nx release --group=<group>` walks the full commit range since the last matching tag and resolves each commit's conventional-commit scope against the **entire** project graph (`findMatchingProjects` over `projectGraph.nodes`). If a scope is ambiguous against *any* projects in the workspace, Nx throws unconditionally — even when those projects aren't in the release group currently being processed.

In workspaces with slash-style subpath project names (e.g. a meta package `@scope/cui` plus subpath packages `@scope/cui/forms`, `@scope/cui/select`, …), a single commit with a short-form scope like `fix(cui): …` permanently blocks every release group whose tag-range includes it — including unrelated groups that don't contain any of the matching projects.

Closes #35744.

## Expected Behavior

The ambiguity check should be scoped to the active release group's projects. A scope that only collides with projects *outside* the group should fall through to the file-affectedness path that's already used when a commit has no scope at all.

## Fix

In `getCommitsRelevantToProjects`, `projects: string[]` (already in the function signature as the active release group's projects, materialized as `projectSet` at the top) is now applied to the per-pattern ambiguity check and to the `scopedProjects` set:

1. **Per-pattern check filters to the group.** `inGroupMatches = perPatternMatches.filter(p => projectSet.has(p))`. Throw only when `inGroupMatches.length > 1` — ambiguity *within* the group is still a real error.
2. **`scopedProjects` is intersected with the group.** Cross-group matches no longer bleed into `isProjectScopedCommit` downstream.

When the filtered set is empty or singleton, the commit is treated identically to a commit with no scope for this group's processing — `isProjectScopedCommit` falls back to `false` for projects whose `affectedGraph` includes them via files, matching the existing scope-less behavior.

## Tests

`packages/nx/src/command-line/release/utils/shared.spec.ts`:

- **Existing test for in-group ambiguity** (`should throw when commit scope matches multiple projects (ambiguous scope)`) — converted from a `try { … } catch (err) { expect(…) }` pattern (which silently passed if no throw happened) to `await expect(…).rejects.toThrow(…)`. Existing behavior preserved: throws when `@foo/graph` + `@bar/graph` are both in the active group with scope `graph`.
- **New test for cross-group ambiguity** — active group `['lib-a']`, scope `graph` matches `@foo/graph` + `@bar/graph` (both outside the group). No throw. Commit is included via file-affectedness, `isProjectScopedCommit: false`.
- **New test for partial cross-group ambiguity** — active group `['@foo/graph']`, scope `graph` matches `@foo/graph` (in group) + `@bar/graph` (out). Filtered to one match. No throw, treated as scoped to `@foo/graph` (`isProjectScopedCommit: true`).

Also extended `createMockCommit` to accept an explicit `scope` argument so tests actually exercise the scope-parsing path. The existing ambiguity test relied on `feat(graph): …` in the commit *message*, but `commit.scope` itself was hardcoded to `''`, so `scopePatterns` was always empty and the throw never fired in the test — the assertion lived in a catch block that was never reached. The conversion to `rejects.toThrow` plus the explicit `scope` argument makes the original test actually verify what its name says.

## Verification

```
pnpm exec nx test nx --testPathPatterns=shared.spec
# Tests: 38 passed, 38 total

pnpm exec nx test nx --testPathPatterns="release"
# Tests: 1 skipped, 503 passed, 504 total

pnpm exec nx lint nx
# 0 errors (2 pre-existing warnings, unrelated)
```

Minimal real-world repro repo: https://github.com/jmclellan-crexi/nx-release-scope-ambiguity-repro

## PR Checklist

- [x] Bug-fix only — no API surface changes
- [x] Tests added for new behavior + existing test converted to assert what it claims
- [x] Backwards compatible — in-group ambiguity still throws; scope-less commits unchanged; unambiguous scopes unchanged
- [x] No documentation changes needed (behavior is now closer to what the existing docs imply)
