### PR TITLE
docs(core): document the convert-target-defaults-to-array migration

### DIFF
--- a/packages/devkit/assets.json
+++ b/packages/devkit/assets.json
@@ -2,6 +2,9 @@
   "outDir": "packages/devkit/dist",
   "assets": [
     {
+      "glob": "src/migrations/**/*.md"
+    },
+    {
       "glob": "**/files/**"
     },
     {

--- a/packages/eslint/assets.json
+++ b/packages/eslint/assets.json
@@ -1,6 +1,7 @@
 {
   "outDir": "packages/eslint/dist",
   "assets": [
+    { "glob": "src/migrations/**/*.md" },
     { "glob": "**/files/**" },
     { "glob": "**/files/**/.gitkeep" },
     { "glob": "src/**/schema.json" },

--- a/packages/jest/assets.json
+++ b/packages/jest/assets.json
@@ -1,6 +1,7 @@
 {
   "outDir": "packages/jest/dist",
   "assets": [
+    { "glob": "src/migrations/**/*.md" },
     { "glob": "**/@(files|files-angular)/**" },
     { "glob": "src/**/schema.json" },
     { "glob": "src/**/schema.d.ts" },

--- a/packages/js/assets.json
+++ b/packages/js/assets.json
@@ -2,6 +2,9 @@
   "outDir": "packages/js/dist",
   "assets": [
     {
+      "glob": "src/migrations/**/*.md"
+    },
+    {
       "glob": "**/files/**"
     },
     {

--- a/packages/nx/assets.json
+++ b/packages/nx/assets.json
@@ -2,6 +2,7 @@
   "outDir": "packages/nx/dist",
   "assets": [
     { "glob": "presets/*.json" },
+    { "glob": "src/migrations/**/*.md" },
     { "glob": "src/command-line/migrate/run-migration-process.js" },
     { "glob": "src/ai/set-up-ai-agents/schema.d.ts" },
     { "glob": "src/utils/perf-hooks.d.ts" },

--- a/packages/nx/src/migrations/update-23-0-0/convert-target-defaults-to-array.md
+++ b/packages/nx/src/migrations/update-23-0-0/convert-target-defaults-to-array.md
@@ -1,0 +1,66 @@
+#### Convert `targetDefaults` to Array Shape
+
+In Nx v23, the `targetDefaults` entry in `nx.json` moves from the legacy record (object-keyed) shape to a new array shape. The array shape lets a single default match by `target`, `executor`, `plugin`, or `projects` — combinations that the record key could not express on its own.
+
+This migration is a pure shape conversion: every legacy key produces at least one array entry, and nothing is ever dropped. The order of entries in the resulting array matches the insertion order of the original record keys.
+
+#### Key Disambiguation
+
+The legacy record key could mean either a target name (`build`) or a `pkg:executor` id (`@nx/vite:build`). The new array shape requires that distinction up front, so the migration disambiguates each key as follows:
+
+- A glob pattern (e.g. `e2e-ci--*`) or a plain key without `:` is always treated as a `target` name.
+- A `:` key is ambiguous. The migration builds the project graph and emits:
+  - `{ target: <key> }` if the key matches only a target name in the graph,
+  - `{ executor: <key> }` if it matches only an executor,
+  - **both** entries if it matches both (the graph cannot tell you which one you meant — keeping both preserves behavior).
+- If the project graph cannot be built, or has no signal for a `:` key, the migration falls back to the syntactic heuristic: `:` keys become `executor` entries. A note is added to the migration's next steps so you can review.
+
+#### Sample Code Changes
+
+##### Before
+
+```json title="nx.json"
+{
+  "targetDefaults": {
+    "build": {
+      "cache": true,
+      "dependsOn": ["^build"]
+    },
+    "test": {
+      "inputs": ["default", "^production"]
+    },
+    "e2e-ci--*": {
+      "dependsOn": ["^build"]
+    },
+    "@nx/vite:build": {
+      "cache": true
+    }
+  }
+}
+```
+
+##### After
+
+```json title="nx.json"
+{
+  "targetDefaults": [
+    {
+      "target": "build",
+      "cache": true,
+      "dependsOn": ["^build"]
+    },
+    {
+      "target": "test",
+      "inputs": ["default", "^production"]
+    },
+    {
+      "target": "e2e-ci--*",
+      "dependsOn": ["^build"]
+    },
+    {
+      "executor": "@nx/vite:build",
+      "cache": true
+    }
+  ]
+}
+```


### PR DESCRIPTION
## Current Behavior

The `23-0-0-convert-target-defaults-to-array` migration (which converts `nx.json` `targetDefaults` from the legacy record shape to the new array shape) has no co-located documentation, so on the docs site it renders only its JSON-derived heading, version, and one-line description.

More broadly: several first-party packages build **in-place** to `packages/<pkg>/dist` and their `migrations.json` `implementation`/`factory` paths point at `./dist/src/migrations/...`. The docs loader locates a migration's companion `.md` by appending `".md"` to that resolved path — i.e. it looks under `dist`. None of these packages' `assets.json` copied migration `.md` files into `dist`, so every affected migration's example body was silently dropped on the docs site. This affects `nx`, `@nx/devkit`, `@nx/eslint`, `@nx/jest`, and `@nx/js`.

(Packages that reference `./src/migrations/...` directly — e.g. `@nx/angular`, `@nx/react`, `@nx/vite` — are unaffected because the loader reads their docs straight from source.)

## Expected Behavior

- Adds `packages/nx/src/migrations/update-23-0-0/convert-target-defaults-to-array.md` documenting the migration: the record → array shape change (nothing dropped, insertion order preserved), the `:`-key disambiguation rules (target vs executor, the duplicate-entry case, and the syntactic fallback when the project graph is unavailable), and before/after `nx.json` samples covering target, glob, and `pkg:executor` keys.
- Adds a `src/migrations/**/*.md` asset glob to the `assets.json` of `nx`, `@nx/devkit`, `@nx/eslint`, `@nx/jest`, and `@nx/js` so their migration docs are copied into `dist` alongside the compiled implementations, where the docs loader reads them. This fixes rendering for this migration and for the existing migration docs in those packages that were also missing from `dist` (13 existing docs across the four sibling packages).

## Related Issue(s)

N/A