### PR TITLE
chore(repo): preserve preset dist ignore in graph jest configs

### DIFF
--- a/graph/client/jest.config.cts
+++ b/graph/client/jest.config.cts
@@ -13,6 +13,7 @@ module.exports = {
   // The mock for widnow.matchMedia has to be in a separete file and imported before the components to test
   // for more info check : // https://jestjs.io/docs/manual-mocks#mocking-methods-which-are-not-implemented-in-jsdom
   modulePathIgnorePatterns: [
+    ...(nxPreset.modulePathIgnorePatterns ?? []),
     '/graph/client/src/app/machines/match-media-mock.spec.ts',
   ],
 };

--- a/graph/migrate/jest.config.cts
+++ b/graph/migrate/jest.config.cts
@@ -13,6 +13,7 @@ module.exports = {
   // The mock for widnow.matchMedia has to be in a separete file and imported before the components to test
   // for more info check : // https://jestjs.io/docs/manual-mocks#mocking-methods-which-are-not-implemented-in-jsdom
   modulePathIgnorePatterns: [
+    ...(nxPreset.modulePathIgnorePatterns ?? []),
     '/graph/client/src/app/machines/match-media-mock.spec.ts',
   ],
 };


### PR DESCRIPTION
## Current Behavior

`graph/migrate/jest.config.cts` and `graph/client/jest.config.cts` build their config by spreading `...nxPreset` and then re-declaring `modulePathIgnorePatterns`:

```js
module.exports = {
  ...nxPreset,
  // ...
  modulePathIgnorePatterns: [
    '/graph/client/src/app/machines/match-media-mock.spec.ts',
  ],
};
```

Object spread is a shallow merge, so this **replaces** the preset's `modulePathIgnorePatterns` (`['<rootDir>/dist/', '<rootDir>/out-tsc/']`) rather than extending it. With `dist/` no longer ignored, `jest-haste-map` crawls each project's own build output. After `typecheck`/`build` emits declaration files into the project's `dist/`, the `test` target reads those `.d.ts` files (they match the `ts` module extension), producing **undeclared-input sandbox violations**.

Observed in a sandbox report for `graph-migrate:test`: 15 unexpected reads, all `graph/migrate/dist/src/**/*.d.ts`, read by `jest-worker` processes during the haste-map crawl — even though the only spec (`machine.spec.ts`) imports none of those files.

Note: configs that use jest's native `preset:` field (e.g. `packages/devkit`, `packages/gradle`) are unaffected, because jest's `mergeOptionWithPreset` concatenates `modulePathIgnorePatterns` from the preset. Only the configs that inline the preset via object spread were affected.

## Expected Behavior

The preset's `modulePathIgnorePatterns` are preserved, so `jest-haste-map` keeps ignoring `<rootDir>/dist/` (and `<rootDir>/out-tsc/`) and never reads the project's own build output during tests. The fix spreads the preset's patterns ahead of the project-specific one:

```js
modulePathIgnorePatterns: [
  ...(nxPreset.modulePathIgnorePatterns ?? []),
  '/graph/client/src/app/machines/match-media-mock.spec.ts',
],
```

Verified: both configs now resolve to `['<rootDir>/dist/', '<rootDir>/out-tsc/', '/graph/client/.../match-media-mock.spec.ts']`, and `graph-migrate:test` still passes (11/11).

## Related Issue(s)

N/A — surfaced by an Nx Cloud sandbox report.