### PR TITLE
fix(nx-plugin): plugin lint checks should use dependentTasksOutputFiles

### DIFF
--- a/.nx/workflows/agents.yaml
+++ b/.nx/workflows/agents.yaml
@@ -74,7 +74,7 @@ common-init-steps: &common-init-steps
 
   - name: Restore .NET analyzer projects
     script: |
-      dotnet restore packages/dotnet/analyzer.Tests/MsbuildAnalyzer.Tests.csproj
+      dotnet restore nx.sln
 
   - name: Configure git metadata (needed for lerna smoke tests)
     script: |

--- a/nx.json
+++ b/nx.json
@@ -169,7 +169,8 @@
     },
     {
       "target": "lint",
-      "dependsOn": ["build-native", "^build-native"],
+      "dependsOn": ["build-native", "^build-native", "build"],
+      "inputs": ["...", { "dependentTasksOutputFiles": "**/*.{js,json,md}" }],
       "options": {
         "max-warnings": 5
       }

--- a/packages/devkit/internal.ts
+++ b/packages/devkit/internal.ts
@@ -4,6 +4,12 @@ export {
   PluginCache,
   safeWriteFileCache,
   emitPluginWorkerLog,
+  resolveImplementation,
+  resolveSchema,
+  ImplementationResolutionError,
+  SchemaResolutionError,
+  resolvePrompt,
+  PromptResolutionError,
 } from 'nx/src/devkit-internals';
 
 // Generators

--- a/packages/eslint-plugin/src/rules/nx-plugin-checks.ts
+++ b/packages/eslint-plugin/src/rules/nx-plugin-checks.ts
@@ -1,15 +1,21 @@
 import type { TSESLint } from '@typescript-eslint/utils';
 import { ESLintUtils } from '@typescript-eslint/utils';
 import type { AST } from 'jsonc-eslint-parser';
-import { existsSync, readFileSync } from 'fs';
+import { readFileSync } from 'fs';
 import { query } from '@phenomnomnominal/tsquery';
 
 import {
+  ProjectConfiguration,
   ProjectGraphProjectNode,
-  readJsonFile,
   workspaceRoot,
 } from '@nx/devkit';
 import { loadTsFile, requireWithTsconfigFallback } from '@nx/js/internal';
+import {
+  ImplementationResolutionError,
+  resolveImplementation,
+  resolveSchema,
+  SchemaResolutionError,
+} from 'nx/src/config/schema-utils';
 import * as path from 'path';
 import { valid } from 'semver';
 import { readProjectGraph } from '../utils/project-graph-utils';
@@ -29,11 +35,6 @@ export type Options = [
     tsConfig?: string;
   },
 ];
-
-type NormalizedOptions = Options[0] & {
-  rootDir?: string;
-  outDir?: string;
-};
 
 const DEFAULT_OPTIONS: Options[0] = {
   generatorsJson: 'generators.json',
@@ -136,6 +137,11 @@ export default ESLintUtils.RuleCreator(() => ``)<Options, MessageIds>({
 
     const { projectGraph, projectRootMappings } = readProjectGraph(RULE_NAME);
 
+    const projects: Record<string, ProjectConfiguration> = {};
+    for (const [projectName, node] of Object.entries(projectGraph.nodes)) {
+      projects[projectName] = node.data;
+    }
+
     const sourceFilePath = getSourceFilePath(
       context.filename ?? context.getFilename(),
       workspaceRoot
@@ -168,11 +174,11 @@ export default ESLintUtils.RuleCreator(() => ``)<Options, MessageIds>({
         node: AST.JSONObjectExpression
       ) {
         if (sourceFilePath === generatorsJson) {
-          checkCollectionFileNode(node, 'generator', context, options);
+          checkCollectionFileNode(node, 'generator', context, projects);
         } else if (sourceFilePath === migrationsJson) {
-          checkCollectionFileNode(node, 'migration', context, options);
+          checkCollectionFileNode(node, 'migration', context, projects);
         } else if (sourceFilePath === executorsJson) {
-          checkCollectionFileNode(node, 'executor', context, options);
+          checkCollectionFileNode(node, 'executor', context, projects);
         } else if (sourceFilePath === packageJson) {
           validatePackageGroup(node, context);
         }
@@ -184,33 +190,8 @@ export default ESLintUtils.RuleCreator(() => ``)<Options, MessageIds>({
 function normalizeOptions(
   sourceProject: ProjectGraphProjectNode,
   options: Options[0]
-): NormalizedOptions {
-  let rootDir: string;
-  let outDir: string;
+): Options[0] {
   const base = { ...DEFAULT_OPTIONS, ...options };
-  let runtimeTsConfig: string;
-
-  if (sourceProject.data.targets?.build?.executor === '@nx/js:tsc') {
-    rootDir = sourceProject.data.targets.build.options.rootDir;
-    outDir = sourceProject.data.targets.build.options.outputPath;
-  }
-
-  if (!rootDir && !outDir) {
-    try {
-      runtimeTsConfig = require.resolve(
-        path.join(workspaceRoot, sourceProject.data.root, base.tsConfig)
-      );
-      const tsConfig = readJsonFile(runtimeTsConfig);
-      rootDir ??= tsConfig.compilerOptions?.rootDir
-        ? path.join(sourceProject.data.root, tsConfig.compilerOptions.rootDir)
-        : undefined;
-      outDir ??= tsConfig.compilerOptions?.outDir
-        ? path.join(sourceProject.data.root, tsConfig.compilerOptions.outDir)
-        : undefined;
-    } catch {
-      // nothing
-    }
-  }
   const pathPrefix =
     sourceProject.data.root !== '.' ? `${sourceProject.data.root}/` : '';
   return {
@@ -227,8 +208,6 @@ function normalizeOptions(
     packageJson: base.packageJson
       ? `${pathPrefix}${base.packageJson}`
       : undefined,
-    rootDir,
-    outDir,
   };
 }
 
@@ -236,7 +215,7 @@ export function checkCollectionFileNode(
   baseNode: AST.JSONObjectExpression,
   mode: 'migration' | 'generator' | 'executor',
   context: TSESLint.RuleContext<MessageIds, Options>,
-  options: NormalizedOptions
+  projects: Record<string, ProjectConfiguration>
 ) {
   const schematicsRootNode = baseNode.properties.find(
     (x) => x.key.type === 'JSONLiteral' && x.key.value === 'schematics'
@@ -283,7 +262,7 @@ export function checkCollectionFileNode(
         node: schematicsRootNode as any,
       });
     } else {
-      checkCollectionNode(collectionNode.value, mode, context, options);
+      checkCollectionNode(collectionNode.value, mode, context, projects);
     }
   }
 }
@@ -292,7 +271,7 @@ export function checkCollectionNode(
   baseNode: AST.JSONObjectExpression,
   mode: 'migration' | 'generator' | 'executor',
   context: TSESLint.RuleContext<MessageIds, Options>,
-  options: NormalizedOptions
+  projects: Record<string, ProjectConfiguration>
 ) {
   const entries = baseNode.properties;
 
@@ -309,7 +288,7 @@ export function checkCollectionNode(
         entryNode.key.value.toString(),
         mode,
         context,
-        options
+        projects
       );
     }
   }
@@ -320,7 +299,7 @@ export function validateEntry(
   key: string,
   mode: 'migration' | 'generator' | 'executor',
   context: TSESLint.RuleContext<MessageIds, Options>,
-  options: NormalizedOptions
+  projects: Record<string, ProjectConfiguration>
 ): void {
   const schemaNode = baseNode.properties.find(
     (x) => x.key.type === 'JSONLiteral' && x.key.value === 'schema'
@@ -343,29 +322,22 @@ export function validateEntry(
         node: schemaNode.value as any,
       });
     } else {
-      let validJsonFound = false;
-      const schemaFilePath = path.join(
-        path.dirname(context.filename ?? context.getFilename()),
-        schemaNode.value.value
-      );
       try {
-        readJsonFile(schemaFilePath);
-        validJsonFound = true;
-      } catch {
-        try {
-          // Try to map back to source, which will be the case with TS solution setup.
-          readJsonFile(schemaFilePath.replace(options.outDir, options.rootDir));
-          validJsonFound = true;
-        } catch {
-          // nothing, will be reported below
+        resolveSchema(
+          schemaNode.value.value,
+          path.dirname(context.filename ?? context.getFilename()),
+          context.filename ?? context.getFilename(),
+          projects
+        );
+      } catch (e) {
+        if (e instanceof SchemaResolutionError) {
+          context.report({
+            messageId: 'invalidSchemaPath',
+            node: schemaNode.value as any,
+          });
+        } else {
+          throw e;
         }
-      }
-
-      if (!validJsonFound) {
-        context.report({
-          messageId: 'invalidSchemaPath',
-          node: schemaNode.value as any,
-        });
       }
     }
   }
@@ -387,10 +359,10 @@ export function validateEntry(
       node: baseNode as any,
     });
   } else if (implementationNode) {
-    validateImplementationNode(implementationNode, key, context, options);
+    validateImplementationNode(implementationNode, key, context, projects);
   }
   if (mode === 'migration' && promptNode) {
-    validatePromptNode(promptNode, key, context, options);
+    validatePromptNode(promptNode, key, context, projects);
   }
 
   if (mode === 'migration') {
@@ -431,31 +403,11 @@ export function validateEntry(
   }
 }
 
-// Under Node's native TS strip, swc-node isn't registered, so `require.resolve`
-// no longer auto-tries `.ts` extensions. Try them explicitly before giving up.
-const TS_EXTENSIONS = ['.ts', '.tsx', '.cts', '.mts'];
-
-function tryResolveImplementation(modulePath: string): string | undefined {
-  try {
-    return require.resolve(modulePath);
-  } catch {
-    // fall through
-  }
-  for (const ext of TS_EXTENSIONS) {
-    try {
-      return require.resolve(`${modulePath}${ext}`);
-    } catch {
-      // try next
-    }
-  }
-  return undefined;
-}
-
 export function validateImplementationNode(
   implementationNode: AST.JSONProperty,
   key: string,
   context: TSESLint.RuleContext<MessageIds, Options>,
-  options: NormalizedOptions
+  projects: Record<string, ProjectConfiguration>
 ) {
   if (
     implementationNode.value.type !== 'JSONLiteral' ||
@@ -473,29 +425,28 @@ export function validateImplementationNode(
       implementationNode.value.value.split('#');
     let resolvedPath: string;
 
-    const modulePath = path.join(
-      path.dirname(context.filename ?? context.getFilename()),
-      implementationPath
-    );
-
-    resolvedPath = tryResolveImplementation(modulePath);
-    if (!resolvedPath && options.outDir && options.rootDir) {
-      resolvedPath = tryResolveImplementation(
-        modulePath.replace(options.outDir, options.rootDir)
+    try {
+      resolvedPath = resolveImplementation(
+        implementationPath,
+        path.dirname(context.filename ?? context.getFilename()),
+        context.filename ?? context.getFilename(),
+        projects
       );
+    } catch (e) {
+      if (e instanceof ImplementationResolutionError) {
+        context.report({
+          messageId: 'invalidImplementationPath',
+          data: {
+            key,
+          },
+          node: implementationNode.value as any,
+        });
+      } else {
+        throw e;
+      }
     }
 
-    if (!resolvedPath) {
-      context.report({
-        messageId: 'invalidImplementationPath',
-        data: {
-          key,
-        },
-        node: implementationNode.value as any,
-      });
-    }
-
-    if (identifier) {
+    if (resolvedPath && identifier) {
       try {
         if (!checkIfIdentifierIsFunction(resolvedPath, identifier)) {
           context.report({
@@ -525,7 +476,7 @@ export function validatePromptNode(
   promptNode: AST.JSONProperty,
   key: string,
   context: TSESLint.RuleContext<MessageIds, Options>,
-  options: NormalizedOptions
+  projects: Record<string, ProjectConfiguration>
 ) {
   if (
     promptNode.value.type !== 'JSONLiteral' ||
@@ -538,23 +489,18 @@ export function validatePromptNode(
       },
       node: promptNode.value as any,
     });
-  } else {
-    const promptPath = path.join(
+    return;
+  }
+
+  try {
+    resolveSchema(
+      promptNode.value.value,
       path.dirname(context.filename ?? context.getFilename()),
-      promptNode.value.value
+      context.filename ?? context.getFilename(),
+      projects
     );
-    let resolvedPath: string;
-
-    if (existsSync(promptPath)) {
-      resolvedPath = promptPath;
-    } else if (options.outDir && options.rootDir) {
-      const mapped = promptPath.replace(options.outDir, options.rootDir);
-      if (existsSync(mapped)) {
-        resolvedPath = mapped;
-      }
-    }
-
-    if (!resolvedPath) {
+  } catch (e) {
+    if (e instanceof SchemaResolutionError) {
       context.report({
         messageId: 'invalidPromptPath',
         data: {
@@ -562,6 +508,8 @@ export function validatePromptNode(
         },
         node: promptNode.value as any,
       });
+    } else {
+      throw e;
     }
   }
 }

--- a/packages/eslint-plugin/src/rules/nx-plugin-checks.ts
+++ b/packages/eslint-plugin/src/rules/nx-plugin-checks.ts
@@ -12,10 +12,12 @@ import {
 import { loadTsFile, requireWithTsconfigFallback } from '@nx/js/internal';
 import {
   ImplementationResolutionError,
+  PromptResolutionError,
   resolveImplementation,
+  resolvePrompt,
   resolveSchema,
   SchemaResolutionError,
-} from 'nx/src/config/schema-utils';
+} from '@nx/devkit/internal';
 import * as path from 'path';
 import { valid } from 'semver';
 import { readProjectGraph } from '../utils/project-graph-utils';
@@ -362,7 +364,7 @@ export function validateEntry(
     validateImplementationNode(implementationNode, key, context, projects);
   }
   if (mode === 'migration' && promptNode) {
-    validatePromptNode(promptNode, key, context, projects);
+    validatePromptNode(promptNode, key, context);
   }
 
   if (mode === 'migration') {
@@ -475,8 +477,7 @@ export function validateImplementationNode(
 export function validatePromptNode(
   promptNode: AST.JSONProperty,
   key: string,
-  context: TSESLint.RuleContext<MessageIds, Options>,
-  projects: Record<string, ProjectConfiguration>
+  context: TSESLint.RuleContext<MessageIds, Options>
 ) {
   if (
     promptNode.value.type !== 'JSONLiteral' ||
@@ -493,14 +494,12 @@ export function validatePromptNode(
   }
 
   try {
-    resolveSchema(
+    resolvePrompt(
       promptNode.value.value,
-      path.dirname(context.filename ?? context.getFilename()),
-      context.filename ?? context.getFilename(),
-      projects
+      path.dirname(context.filename ?? context.getFilename())
     );
   } catch (e) {
-    if (e instanceof SchemaResolutionError) {
+    if (e instanceof PromptResolutionError) {
       context.report({
         messageId: 'invalidPromptPath',
         data: {

--- a/packages/nx/src/command-line/migrate/prompt-files.spec.ts
+++ b/packages/nx/src/command-line/migrate/prompt-files.spec.ts
@@ -1,0 +1,43 @@
+import 'nx/src/internal-testing-utils/mock-fs';
+import { vol } from 'memfs';
+import { PromptResolutionError, resolvePrompt } from './prompt-files';
+
+describe('resolvePrompt', () => {
+  beforeEach(() => {
+    vol.reset();
+  });
+
+  it('should resolve a prompt file relative to the migrations directory', () => {
+    vol.fromJSON({
+      '/root/migrations/prompts/upgrade.md': '# Upgrade',
+    });
+
+    expect(resolvePrompt('prompts/upgrade.md', '/root/migrations')).toBe(
+      '/root/migrations/prompts/upgrade.md'
+    );
+  });
+
+  it('should throw when the prompt file does not exist', () => {
+    vol.fromJSON({ '/root/migrations/migrations.json': '{}' });
+
+    expect(() =>
+      resolvePrompt('prompts/missing.md', '/root/migrations')
+    ).toThrow(PromptResolutionError);
+  });
+
+  it('should throw when the prompt path escapes the migrations directory', () => {
+    vol.fromJSON({ '/root/secret.md': '# Secret' });
+
+    expect(() => resolvePrompt('../secret.md', '/root/migrations')).toThrow(
+      PromptResolutionError
+    );
+  });
+
+  it('should throw when the prompt path is absolute', () => {
+    vol.fromJSON({ '/root/migrations/prompts/upgrade.md': '# Upgrade' });
+
+    expect(() =>
+      resolvePrompt('/root/migrations/prompts/upgrade.md', '/root/migrations')
+    ).toThrow(PromptResolutionError);
+  });
+});

--- a/packages/nx/src/command-line/migrate/prompt-files.ts
+++ b/packages/nx/src/command-line/migrate/prompt-files.ts
@@ -70,23 +70,69 @@ async function resolvePromptFiles(
     : undefined;
 }
 
+function isPromptPathWithinMigrationsDir(
+  migrationsDir: string,
+  promptRelPath: string
+): boolean {
+  const rel = relative(migrationsDir, join(migrationsDir, promptRelPath));
+  return !(
+    isAbsolute(promptRelPath) ||
+    rel === '..' ||
+    rel.startsWith(`..${sep}`) ||
+    rel.startsWith(`..${posix.sep}`)
+  );
+}
+
 function assertPromptPathWithinMigrationsDir(
   migrationsDir: string,
   promptRelPath: string,
   packageName: string,
   packageVersion: string
 ): void {
-  const rel = relative(migrationsDir, join(migrationsDir, promptRelPath));
-  if (
-    isAbsolute(promptRelPath) ||
-    rel === '..' ||
-    rel.startsWith(`..${sep}`) ||
-    rel.startsWith(`..${posix.sep}`)
-  ) {
+  if (!isPromptPathWithinMigrationsDir(migrationsDir, promptRelPath)) {
     throw new Error(
       `Invalid prompt path "${promptRelPath}" in package "${packageName}@${packageVersion}": prompt paths must be relative and resolve within the package's migrations directory.`
     );
   }
+}
+
+/**
+ * Thrown when the markdown prompt file referenced by a migration cannot be
+ * resolved.
+ */
+export class PromptResolutionError extends Error {
+  constructor(
+    public readonly promptPath: string,
+    public readonly migrationsDir: string,
+    options?: { cause?: unknown }
+  ) {
+    super(
+      `Could not resolve prompt "${promptPath}" from "${migrationsDir}".`,
+      options
+    );
+    this.name = 'PromptResolutionError';
+  }
+}
+
+/**
+ * Resolves a migration prompt file path to an absolute path. Prompt paths are
+ * plain markdown files referenced relative to the directory containing the
+ * `migrations.json` - unlike schemas, they are not resolved through package
+ * exports or `require.resolve`. The path must stay within the migrations
+ * directory and point at an existing file.
+ */
+export function resolvePrompt(
+  promptPath: string,
+  migrationsDir: string
+): string {
+  if (!isPromptPathWithinMigrationsDir(migrationsDir, promptPath)) {
+    throw new PromptResolutionError(promptPath, migrationsDir);
+  }
+  const resolvedPath = join(migrationsDir, promptPath);
+  if (!existsSync(resolvedPath)) {
+    throw new PromptResolutionError(promptPath, migrationsDir);
+  }
+  return resolvedPath;
 }
 
 export function extractPromptFilesFromTarball(

--- a/packages/nx/src/config/schema-utils.ts
+++ b/packages/nx/src/config/schema-utils.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'fs';
-import { join } from 'path';
+import { join, relative } from 'path';
 import { resolve as resolveExports } from 'resolve.exports';
 import {
   loadTsFile,
@@ -7,8 +7,54 @@ import {
 } from '../plugins/js/utils/register';
 import { getWorkspacePackagesMetadata } from '../plugins/js/utils/packages';
 import { getRootTsConfigResolveExportsConditions } from '../plugins/js/utils/typescript';
+import {
+  createProjectRootMappingsFromProjectConfigurations,
+  findProjectForPath,
+} from '../project-graph/utils/find-project-for-path';
+import { readJsonFile } from '../utils/fileutils';
+import {
+  getMetadataFromPackageJson,
+  PackageJsonProjectMetadata,
+  type PackageJson,
+} from '../utils/package-json';
 import { normalizePath } from '../utils/path';
+import { workspaceRoot } from '../utils/workspace-root';
 import type { ProjectConfiguration } from './workspace-json-project-json';
+
+/**
+ * Thrown when the schema file of an executor or generator cannot be resolved.
+ */
+export class SchemaResolutionError extends Error {
+  constructor(
+    public readonly schemaPath: string,
+    public readonly directory: string,
+    options?: { cause?: unknown }
+  ) {
+    super(
+      `Could not resolve schema "${schemaPath}" from "${directory}".`,
+      options
+    );
+    this.name = 'SchemaResolutionError';
+  }
+}
+
+/**
+ * Thrown when the implementation module of an executor or generator cannot be
+ * resolved.
+ */
+export class ImplementationResolutionError extends Error {
+  constructor(
+    public readonly implementationModulePath: string,
+    public readonly directory: string,
+    options?: { cause?: unknown }
+  ) {
+    super(
+      `Could not resolve "${implementationModulePath}" from "${directory}".`,
+      options
+    );
+    this.name = 'ImplementationResolutionError';
+  }
+}
 
 /**
  * This function is used to get the implementation factory of an executor or generator.
@@ -91,9 +137,7 @@ export function resolveImplementation(
     } catch {}
   }
 
-  throw new Error(
-    `Could not resolve "${implementationModulePath}" from "${directory}".`
-  );
+  throw new ImplementationResolutionError(implementationModulePath, directory);
 }
 
 export function resolveSchema(
@@ -122,35 +166,86 @@ export function resolveSchema(
     return maybeSchemaPath;
   }
 
-  return require.resolve(schemaPath, {
-    paths: [directory],
-  });
+  try {
+    return require.resolve(schemaPath, {
+      paths: [directory],
+    });
+  } catch (e) {
+    throw new SchemaResolutionError(schemaPath, directory, { cause: e });
+  }
 }
 
-let packageToProjectMap: Record<string, ProjectConfiguration>;
+let projectRootMappings: Map<string, string>;
+function getProjectForDirectory(
+  directory: string,
+  projects: Record<string, ProjectConfiguration>
+): ProjectConfiguration | null {
+  projectRootMappings ??=
+    createProjectRootMappingsFromProjectConfigurations(projects);
+  const projectName = findProjectForPath(
+    relative(workspaceRoot, directory),
+    projectRootMappings
+  );
+  return projectName ? projects[projectName] : null;
+}
+
+/**
+ * Reads the JS package metadata (package name and exports) for a project
+ * directly from its `package.json`. Used as a fallback when a project's graph
+ * metadata doesn't include the JS metadata.
+ */
+function readJsPackageMetadata(
+  project: ProjectConfiguration
+): PackageJsonProjectMetadata['js'] | null {
+  const packageJsonPath = join(workspaceRoot, project.root, 'package.json');
+  if (!existsSync(packageJsonPath)) {
+    return null;
+  }
+  try {
+    const packageJson = readJsonFile<PackageJson>(packageJsonPath);
+    return (
+      getMetadataFromPackageJson(
+        packageJson,
+        false
+      ) as PackageJsonProjectMetadata
+    ).js;
+  } catch {
+    return null;
+  }
+}
+
+let packageMetadata: ReturnType<
+  typeof getWorkspacePackagesMetadata<ProjectConfiguration>
+>;
 function tryResolveFromSource(
   path: string,
   directory: string,
   packageName: string,
   projects: Record<string, ProjectConfiguration>
 ): string | null {
-  packageToProjectMap ??=
-    getWorkspacePackagesMetadata(projects).packageToProjectMap;
-  const localProject = packageToProjectMap[packageName];
+  packageMetadata ??= getWorkspacePackagesMetadata(projects);
+  let localProject = packageMetadata.packageToProjectMap[packageName];
+  // The `packageName` might be a path to the collection rather than an actual
+  // package name (e.g. when a generator/executor collection is referenced by
+  // path). In that case, `directory` points inside the local project, so we
+  // find the project that contains it.
+  localProject ??= getProjectForDirectory(directory, projects);
   if (!localProject) {
-    // it doesn't match any of the package names from the local projects
     return null;
   }
+  const js =
+    (localProject.metadata as PackageJsonProjectMetadata)?.js ??
+    readJsPackageMetadata(localProject);
+  if (!js) {
+    return null;
+  }
+  const name = js.packageName;
+  const exports = js.packageExports;
 
   try {
-    const fromExports = resolveExports(
-      {
-        name: localProject.metadata!.js!.packageName,
-        exports: localProject.metadata!.js!.packageExports,
-      },
-      path,
-      { conditions: getRootTsConfigResolveExportsConditions() }
-    );
+    const fromExports = resolveExports({ name, exports }, path, {
+      conditions: getRootTsConfigResolveExportsConditions(),
+    });
     if (fromExports && fromExports.length) {
       for (const exportPath of fromExports) {
         if (existsSync(join(directory, exportPath))) {

--- a/packages/nx/src/devkit-internals.ts
+++ b/packages/nx/src/devkit-internals.ts
@@ -57,3 +57,13 @@ export { signalToCode } from './utils/exit-codes';
 export { handleImport } from './utils/handle-import';
 export { PluginCache, safeWriteFileCache } from './utils/plugin-cache-utils';
 export { emitPluginWorkerLog } from './project-graph/plugins/isolation/worker-streaming';
+export {
+  resolveImplementation,
+  resolveSchema,
+  ImplementationResolutionError,
+  SchemaResolutionError,
+} from './config/schema-utils';
+export {
+  resolvePrompt,
+  PromptResolutionError,
+} from './command-line/migrate/prompt-files';

--- a/packages/nx/src/plugins/js/utils/packages.ts
+++ b/packages/nx/src/plugins/js/utils/packages.ts
@@ -1,6 +1,7 @@
 import { join } from 'node:path/posix';
 import type { ProjectGraphProjectNode } from '../../../config/project-graph';
 import type { ProjectConfiguration } from '../../../config/workspace-json-project-json';
+import type { PackageJsonProjectMetadata } from '../../../utils/package-json';
 
 export function getWorkspacePackagesMetadata<
   T extends ProjectGraphProjectNode | ProjectConfiguration,
@@ -15,8 +16,9 @@ export function getWorkspacePackagesMetadata<
   const wildcardEntryPointsToProjectMap: Record<string, T> = {};
   const packageToProjectMap: Record<string, T> = {};
   for (const project of Object.values(projects)) {
-    const metadata =
-      'data' in project ? project.data.metadata : project.metadata;
+    const metadata = (
+      'data' in project ? project.data.metadata : project.metadata
+    ) as PackageJsonProjectMetadata;
 
     if (!metadata?.js) {
       continue;

--- a/packages/nx/src/utils/package-json.ts
+++ b/packages/nx/src/utils/package-json.ts
@@ -192,6 +192,20 @@ export function buildTargetFromScript(
   };
 }
 
+export type PackageJsonProjectMetadata = {
+  targetGroups: {
+    'NPM Scripts'?: Array<string>;
+  };
+  description: string;
+  js: {
+    packageName: PackageJson['name'];
+    packageVersion: PackageJson['version'];
+    packageExports: PackageJson['exports'];
+    packageMain: PackageJson['main'];
+    isInPackageManagerWorkspaces: boolean;
+  };
+};
+
 export function getMetadataFromPackageJson(
   packageJson: PackageJson,
   isInPackageManagerWorkspaces: boolean
@@ -199,10 +213,12 @@ export function getMetadataFromPackageJson(
   const { scripts, nx, description, name, exports, main, version } =
     packageJson;
   const includedScripts = nx?.includedScripts || Object.keys(scripts ?? {});
-  return {
-    targetGroups: {
-      ...(includedScripts.length ? { 'NPM Scripts': includedScripts } : {}),
-    },
+  const metadata: PackageJsonProjectMetadata = {
+    targetGroups: includedScripts.length
+      ? {
+          'NPM Scripts': includedScripts,
+        }
+      : {},
     description,
     js: {
       packageName: name,
@@ -212,6 +228,7 @@ export function getMetadataFromPackageJson(
       isInPackageManagerWorkspaces,
     },
   };
+  return metadata satisfies ProjectMetadata;
 }
 
 export function getTagsFromPackageJson(packageJson: PackageJson): string[] {

--- a/packages/plugin/src/generators/lint-checks/generator.ts
+++ b/packages/plugin/src/generators/lint-checks/generator.ts
@@ -179,6 +179,30 @@ function updateProjectTarget(
       opts.lintFilePatterns.push(`${project.root}/package.json`);
       opts.lintFilePatterns = [...new Set(opts.lintFilePatterns)];
       project.targets[target].options = opts;
+
+      // Plugin checks read schema/implementation files which may live in the
+      // project's build outputs (and migration prompt files copied as assets).
+      // Ensure lint runs after build and includes the relevant build outputs
+      // as inputs so the sandbox allows the reads and the cache invalidates
+      // when those outputs change.
+      const targetConfig = project.targets[target];
+      const dependsOn = new Set(targetConfig.dependsOn ?? []);
+      dependsOn.add('build');
+      targetConfig.dependsOn = Array.from(dependsOn);
+
+      const inputs = targetConfig.inputs ?? ['...'];
+      const hasDependentOutputs = inputs.some(
+        (input) =>
+          typeof input === 'object' &&
+          input !== null &&
+          'dependentTasksOutputFiles' in input
+      );
+      if (!hasDependentOutputs) {
+        inputs.push({
+          dependentTasksOutputFiles: '**/*.{json,d.ts,js,md}',
+        });
+      }
+      targetConfig.inputs = inputs;
     }
   }
   updateProjectConfiguration(host, options.projectName, project);


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
