### PR TITLE
fix(js): fall back to npm publish when bun publish fails with auth error

### DIFF
--- a/packages/js/src/executors/release-publish/release-publish.impl.spec.ts
+++ b/packages/js/src/executors/release-publish/release-publish.impl.spec.ts
@@ -273,6 +273,151 @@ describe('release-publish executor', () => {
       );
     });
 
+    it('should fall back to npm publish when bun publish fails with an authentication error and npm is installed', async () => {
+      mockDetectPackageManager.mockReturnValue('bun');
+      mockExecSync.mockReset();
+
+      mockExecSync
+        // npm --version succeeds (npm is installed)
+        .mockReturnValueOnce('11.5.1' as any)
+        // bun info (view) call
+        .mockReturnValueOnce(
+          Buffer.from(
+            JSON.stringify({
+              versions: ['0.9.0'],
+              'dist-tags': { latest: '0.9.0' },
+            })
+          )
+        )
+        // bun publish fails with missing authentication
+        .mockImplementationOnce(() => {
+          const error: any = new Error('bun publish failed');
+          error.stdout = Buffer.from('');
+          error.stderr = Buffer.from(
+            'error: missing authentication (run `bunx npm login`)'
+          );
+          throw error;
+        })
+        // npm publish (fallback) succeeds
+        .mockReturnValueOnce(Buffer.from('{}') as any);
+
+      jest.spyOn(extractModule, 'extractNpmPublishJsonData').mockReturnValue({
+        beforeJsonData: '',
+        jsonData: {
+          id: '@scope/test-package@1.0.0',
+          name: '@scope/test-package',
+          version: '1.0.0',
+          size: 100,
+          unpackedSize: 200,
+          shasum: 'abc123',
+          integrity: 'sha512-abc',
+          filename: 'test-package-1.0.0.tgz',
+          files: [],
+          entryCount: 1,
+          bundled: [],
+        },
+        afterJsonData: '',
+      } as any);
+
+      const result = await runExecutor(options, context);
+
+      expect(result.success).toBe(true);
+      // bun publish was tried first
+      expect(mockExecSync).toHaveBeenCalledWith(
+        expect.stringContaining('bun publish'),
+        expect.anything()
+      );
+      // npm publish was tried after bun failed
+      expect(mockExecSync).toHaveBeenCalledWith(
+        expect.stringContaining('npm publish'),
+        expect.anything()
+      );
+      // the user-facing fallback warning was logged
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('falling back to npm publish')
+      );
+    });
+
+    it('should not fall back to npm publish when bun publish fails with a non-auth error', async () => {
+      mockDetectPackageManager.mockReturnValue('bun');
+      mockExecSync.mockReset();
+
+      mockExecSync
+        // npm --version succeeds (npm is installed)
+        .mockReturnValueOnce('11.5.1' as any)
+        // bun info (view) call
+        .mockReturnValueOnce(
+          Buffer.from(
+            JSON.stringify({
+              versions: ['0.9.0'],
+              'dist-tags': { latest: '0.9.0' },
+            })
+          )
+        )
+        // bun publish fails with a non-auth error (e.g., version conflict)
+        .mockImplementationOnce(() => {
+          const error: any = new Error('bun publish failed');
+          error.stdout = Buffer.from('');
+          error.stderr = Buffer.from(
+            'error: version 1.0.0 already exists in the registry'
+          );
+          throw error;
+        });
+
+      const result = await runExecutor(options, context);
+
+      expect(result.success).toBe(false);
+      expect(console.error).toHaveBeenCalledWith('bun publish error:');
+      // npm publish must NOT be attempted for non-auth bun errors
+      expect(mockExecSync).not.toHaveBeenCalledWith(
+        expect.stringContaining('npm publish'),
+        expect.anything()
+      );
+      // the fallback warning must NOT have been logged
+      expect(console.warn).not.toHaveBeenCalledWith(
+        expect.stringContaining('falling back to npm publish')
+      );
+    });
+
+    it('should not fall back to npm publish when bun publish fails with an authentication error but npm is not installed', async () => {
+      mockDetectPackageManager.mockReturnValue('bun');
+      mockExecSync.mockReset();
+
+      mockExecSync
+        // npm --version throws (npm not installed)
+        .mockImplementationOnce(() => {
+          throw new Error('Command not found: npm');
+        })
+        // bun info (view) call
+        .mockReturnValueOnce(
+          Buffer.from(
+            JSON.stringify({
+              versions: ['0.9.0'],
+              'dist-tags': { latest: '0.9.0' },
+            })
+          )
+        )
+        // bun publish fails with an auth error — but npm is unavailable, so no fallback
+        .mockImplementationOnce(() => {
+          const error: any = new Error('bun publish failed');
+          error.stdout = Buffer.from('');
+          error.stderr = Buffer.from(
+            'error: missing authentication (run `bunx npm login`)'
+          );
+          throw error;
+        });
+
+      const result = await runExecutor(options, context);
+
+      expect(result.success).toBe(false);
+      expect(console.error).toHaveBeenCalledWith('bun publish error:');
+      // npm publish must NOT be attempted when npm is unavailable
+      expect(mockExecSync).not.toHaveBeenCalledWith(
+        expect.stringContaining('npm publish'),
+        expect.anything()
+      );
+    });
+
     it('should return failure when pm is not bun and npm is not installed', async () => {
       mockDetectPackageManager.mockReturnValue('pnpm');
       mockExecSync.mockReset();

--- a/packages/js/src/executors/release-publish/release-publish.impl.ts
+++ b/packages/js/src/executors/release-publish/release-publish.impl.ts
@@ -348,6 +348,46 @@ Please update the local dependency on "${depName}" to be a valid semantic versio
    * to running from the package root directly), then special attention should be paid to the fact that npm/pnpm publish will nest its
    * JSON output under the name of the package in that case (and it would need to be handled below).
    */
+  return runPublish({
+    pm,
+    options,
+    context,
+    packageRoot,
+    packageJson,
+    registry,
+    registryConfigKey,
+    tag,
+    isDryRun,
+    isNpmInstalled,
+  });
+}
+
+interface RunPublishContext {
+  pm: ReturnType<typeof detectPackageManager>;
+  options: PublishExecutorSchema;
+  context: ExecutorContext;
+  packageRoot: string;
+  packageJson: any;
+  registry: string;
+  registryConfigKey: string;
+  tag: string;
+  isDryRun: boolean;
+  isNpmInstalled: boolean;
+}
+
+function runPublish(ctx: RunPublishContext): { success: boolean } {
+  const {
+    pm,
+    options,
+    context,
+    packageRoot,
+    packageJson,
+    registry,
+    registryConfigKey,
+    tag,
+    isDryRun,
+    isNpmInstalled,
+  } = ctx;
   const pmCommand = getPackageManagerCommand(pm);
   const publishCommandSegments = [
     pmCommand.publish(packageRoot, registry, registryConfigKey, tag),
@@ -448,9 +488,25 @@ Please update the local dependency on "${depName}" to be a valid semantic versio
     try {
       // bun publish does not support outputting JSON, so we cannot perform any further processing
       if (pm === 'bun') {
+        const bunStderr = err.stderr?.toString() || '';
+        const bunStdout = err.stdout?.toString() || '';
+        // bun publish does not yet support npm's OIDC trusted publishing flow. If the failure
+        // looks like an authentication error and npm is available, retry via npm to recover.
+        // Other failures (e.g. version conflict, 403) would produce the same error from npm,
+        // so we surface bun's error directly instead.
+        const looksLikeAuthError =
+          /missing authentication|bunx npm login|unauthorized|\b401\b/i.test(
+            bunStderr + bunStdout
+          );
+        if (isNpmInstalled && looksLikeAuthError) {
+          console.warn(
+            `bun publish failed with an authentication error; falling back to npm publish (bun does not support npm OIDC trusted publishing).`
+          );
+          return runPublish({ ...ctx, pm: 'npm' });
+        }
         console.error(`bun publish error:`);
-        console.error(err.stderr?.toString() || '');
-        console.error(err.stdout?.toString() || '');
+        console.error(bunStderr);
+        console.error(bunStdout);
         return {
           success: false,
         };


### PR DESCRIPTION
## Current Behavior

`nx release publish` detects the workspace package manager and uses it to run the publish command. In bun workspaces it runs `bun publish`. However, `bun publish` doesn't support npm's OIDC trusted publishing — where GitHub Actions exchanges a short-lived OIDC token with the npm registry so you can publish without storing a static `NPM_TOKEN` secret. Only `npm publish` (and modern pnpm/yarn) perform that token exchange automatically.

The result is that a bun workspace configured for OIDC trusted publishing fails with:

```
bun publish error:
error: missing authentication (run `bunx npm login`)
```

even when the workflow has `id-token: write` set up correctly.

## Expected Behavior

When `bun publish` fails with an authentication-shaped error and `npm` is available, the executor falls back to `npm publish` to recover. This lets bun workspaces use OIDC trusted publishing (and provenance, if requested) transparently — no config changes needed.

Other bun failures (version conflicts, 5xx responses, generic errors) still surface bun's error directly so we don't hide unrelated problems behind an unnecessary npm retry.

Implementation:
- The publish step is extracted into a `runPublish(ctx)` helper so the fallback can re-enter the existing publish + output-handling code with just `pm` swapped to `'npm'`.
- The fallback is gated by a regex on bun's stderr/stdout: `missing authentication | bunx npm login | unauthorized | 401`. Misses are soft — the user gets bun's error as today, not a worse outcome.

## Related Issue(s)

Fixes #