### PR TITLE
docs(core): note that task-specific env vars are not loaded in batch mode

### DIFF
--- a/astro-docs/src/content/docs/guides/Tips-n-Tricks/define-environment-variables.mdoc
+++ b/astro-docs/src/content/docs/guides/Tips-n-Tricks/define-environment-variables.mdoc
@@ -77,9 +77,7 @@ for workspace-specific settings (like the [Nx Cloud token](/docs/guides/nx-cloud
 {% /aside %}
 
 {% aside type="caution" title="Env files are not loaded in batch mode" %}
-The task-specific `.env` files described above are **not** loaded for tasks run with [batch mode](/docs/reference/glossary#batch-mode) (for example `tsc` or Gradle tasks run with `--batch` or `NX_BATCH_MODE=true`). Batch processes only receive the variables present in the current `process.env`, so variables defined in files like `.env.[target-name]` won't be available.
-
-If a batched task depends on these variables, set them in the shell before invoking Nx (or load them with a tool like [`dotenvx`](https://github.com/dotenvx/dotenvx)) so they are present in `process.env`.
+The task-specific `.env` files described above are **not** loaded for tasks run with [batch mode](/docs/reference/glossary#batch-mode) (for example `tsc` or Gradle tasks run with `--batch` or `NX_BATCH_MODE=true`). Batch processes only receive the variables present in the current environment and root .env files, like `.env` and `.env.local`, so variables defined in files like `.env.[target-name]` won't be available.
 {% /aside %}
 
 ### Environment variables for atomized targets

--- a/astro-docs/src/content/docs/guides/Tips-n-Tricks/define-environment-variables.mdoc
+++ b/astro-docs/src/content/docs/guides/Tips-n-Tricks/define-environment-variables.mdoc
@@ -76,6 +76,12 @@ We recommend nesting your **app** specific `env` files in `apps/your-app`, and c
 for workspace-specific settings (like the [Nx Cloud token](/docs/guides/nx-cloud/access-tokens)).
 {% /aside %}
 
+{% aside type="caution" title="Env files are not loaded in batch mode" %}
+The task-specific `.env` files described above are **not** loaded for tasks run with [batch mode](/docs/reference/glossary#batch-mode) (for example `tsc` or Gradle tasks run with `--batch` or `NX_BATCH_MODE=true`). Batch processes only receive the variables present in the current `process.env`, so variables defined in files like `.env.[target-name]` won't be available.
+
+If a batched task depends on these variables, set them in the shell before invoking Nx (or load them with a tool like [`dotenvx`](https://github.com/dotenvx/dotenvx)) so they are present in `process.env`.
+{% /aside %}
+
 ### Environment variables for atomized targets
 
 Atomized targets have their names created dynamically, typically using the file names as a suffix. This makes it difficult to define environment variable files for them.

--- a/astro-docs/src/content/docs/guides/Tips-n-Tricks/define-environment-variables.mdoc
+++ b/astro-docs/src/content/docs/guides/Tips-n-Tricks/define-environment-variables.mdoc
@@ -77,7 +77,7 @@ for workspace-specific settings (like the [Nx Cloud token](/docs/guides/nx-cloud
 {% /aside %}
 
 {% aside type="caution" title="Env files are not loaded in batch mode" %}
-The task-specific `.env` files described above are **not** loaded for tasks run with [batch mode](/docs/reference/glossary#batch-mode) (for example `tsc` or Gradle tasks run with `--batch` or `NX_BATCH_MODE=true`). Batch processes only receive the variables present in the current environment and root .env files, like `.env` and `.env.local`, so variables defined in files like `.env.[target-name]` won't be available.
+The task-specific `.env` files described above are **not** loaded for tasks run with [batch mode](/docs/reference/glossary#batch-mode) (Gradle and Maven tasks run this way be default). Batch processes only receive the variables present in the current environment and root .env files, like `.env` and `.env.local`, so variables defined in files like `.env.[target-name]` won't be available.
 {% /aside %}
 
 ### Environment variables for atomized targets


### PR DESCRIPTION
## Current Behavior

The [Define Environment Variables](https://nx.dev/docs/guides/tips-n-tricks/define-environment-variables) guide describes how Nx loads file-based, task-specific env vars (e.g. `.env.[target-name]`), but it doesn't mention that this loading is skipped for tasks run in batch mode. Internally, batched tasks run with `batchEnv` (built from `getEnvVariablesForBatchProcess()`), which only forwards `process.env` + Nx vars and never calls `getTaskSpecificEnv()`. As a result, the docs make it seem like task-specific `.env` files apply to batched tasks (e.g. `tsc`/Gradle) when they do not.

## Expected Behavior

The guide now includes a caution aside clarifying that task-specific `.env` files are **not** loaded for tasks run in [batch mode](https://nx.dev/docs/reference/glossary#batch-mode) (`--batch` / `NX_BATCH_MODE=true`) — batch processes only receive the variables already present in `process.env`. It also documents the workaround: set the variables in the shell, or load them with a tool like `dotenvx`, before invoking Nx so they're present in `process.env`.

## Related Issue(s)

Addresses the documentation portion of [NXC-4251: Clarify batch task env vars in hashing and docs](https://linear.app/nxdev/issue/NXC-4251/clarify-batch-task-env-vars-in-hashing-and-docs). The hashing/runtime warning options in that issue are out of scope for this docs-only change.