### PR TITLE
chore(module-federation): re-enable webpack-based react e2e tests (webpack 5.107.1 fix is live)

### DIFF
--- a/e2e/react/src/module-federation/core-webpack-basic-host-remote-generation.test.ts
+++ b/e2e/react/src/module-federation/core-webpack-basic-host-remote-generation.test.ts
@@ -16,10 +16,7 @@ import {
   cleanupCoreWebpackTest,
 } from './core-webpack-setup';
 
-// TODO: re-enable once webpack 5.107.0 / @module-federation/enhanced compatibility is resolved upstream.
-// See https://github.com/webpack/webpack/issues/20985 and https://github.com/module-federation/core/issues/4747.
-// eslint-disable-next-line jest/no-disabled-tests
-describe.skip('React Module Federation - Webpack Basic - Host Remote Generation', () => {
+describe('React Module Federation - Webpack Basic - Host Remote Generation', () => {
   beforeAll(() => {
     setupCoreWebpackTest();
   });

--- a/e2e/react/src/module-federation/core-webpack-basic-playwright.test.ts
+++ b/e2e/react/src/module-federation/core-webpack-basic-playwright.test.ts
@@ -16,10 +16,7 @@ import {
   cleanupCoreWebpackTest,
 } from './core-webpack-setup';
 
-// TODO: re-enable once webpack 5.107.0 / @module-federation/enhanced compatibility is resolved upstream.
-// See https://github.com/webpack/webpack/issues/20985 and https://github.com/module-federation/core/issues/4747.
-// eslint-disable-next-line jest/no-disabled-tests
-describe.skip('React Module Federation - Webpack Basic - Playwright', () => {
+describe('React Module Federation - Webpack Basic - Playwright', () => {
   beforeAll(() => {
     setupCoreWebpackTest();
   });

--- a/e2e/react/src/module-federation/core-webpack-name-and-root.test.ts
+++ b/e2e/react/src/module-federation/core-webpack-name-and-root.test.ts
@@ -10,10 +10,7 @@ import {
   cleanupCoreWebpackTest,
 } from './core-webpack-setup';
 
-// TODO: re-enable once webpack 5.107.0 / @module-federation/enhanced compatibility is resolved upstream.
-// See https://github.com/webpack/webpack/issues/20985 and https://github.com/module-federation/core/issues/4747.
-// eslint-disable-next-line jest/no-disabled-tests
-describe.skip('React Module Federation - Webpack Name and Root Format', () => {
+describe('React Module Federation - Webpack Name and Root Format', () => {
   beforeAll(() => {
     setupCoreWebpackTest();
   });

--- a/e2e/react/src/module-federation/core-webpack-query-params.test.ts
+++ b/e2e/react/src/module-federation/core-webpack-query-params.test.ts
@@ -5,10 +5,7 @@ import {
   cleanupCoreWebpackTest,
 } from './core-webpack-setup';
 
-// TODO: re-enable once webpack 5.107.0 / @module-federation/enhanced compatibility is resolved upstream.
-// See https://github.com/webpack/webpack/issues/20985 and https://github.com/module-federation/core/issues/4747.
-// eslint-disable-next-line jest/no-disabled-tests
-describe.skip('React Module Federation - Webpack Query Params', () => {
+describe('React Module Federation - Webpack Query Params', () => {
   beforeAll(() => {
     setupCoreWebpackTest();
   });

--- a/e2e/react/src/module-federation/core-webpack-ssr.test.ts
+++ b/e2e/react/src/module-federation/core-webpack-ssr.test.ts
@@ -17,10 +17,7 @@ import {
   cleanupCoreWebpackTest,
 } from './core-webpack-setup';
 
-// TODO: re-enable once webpack 5.107.0 / @module-federation/enhanced compatibility is resolved upstream.
-// See https://github.com/webpack/webpack/issues/20985 and https://github.com/module-federation/core/issues/4747.
-// eslint-disable-next-line jest/no-disabled-tests
-describe.skip('React Module Federation - Webpack SSR', () => {
+describe('React Module Federation - Webpack SSR', () => {
   beforeAll(() => {
     setupCoreWebpackTest();
   });

--- a/e2e/react/src/module-federation/dynamic-federation.webpack.test.ts
+++ b/e2e/react/src/module-federation/dynamic-federation.webpack.test.ts
@@ -14,10 +14,7 @@ import {
 } from '@nx/e2e-utils';
 import { runCLI } from './utils';
 
-// TODO: re-enable once webpack 5.107.0 / @module-federation/enhanced compatibility is resolved upstream.
-// See https://github.com/webpack/webpack/issues/20985 and https://github.com/module-federation/core/issues/4747.
-// eslint-disable-next-line jest/no-disabled-tests
-describe.skip('Dynamic Module Federation', () => {
+describe('Dynamic Module Federation', () => {
   beforeAll(() => {
     newProject({ packages: ['@nx/react'] });
   });

--- a/e2e/react/src/module-federation/federate-module.webpack.test.ts
+++ b/e2e/react/src/module-federation/federate-module.webpack.test.ts
@@ -11,10 +11,7 @@ import {
 } from '@nx/e2e-utils';
 import { readPort, runCLI } from './utils';
 
-// TODO: re-enable once webpack 5.107.0 / @module-federation/enhanced compatibility is resolved upstream.
-// See https://github.com/webpack/webpack/issues/20985 and https://github.com/module-federation/core/issues/4747.
-// eslint-disable-next-line jest/no-disabled-tests
-describe.skip('Federate Module', () => {
+describe('Federate Module', () => {
   let proj: string;
 
   beforeAll(() => {

--- a/e2e/react/src/module-federation/independent-deployability.webpack.test.ts
+++ b/e2e/react/src/module-federation/independent-deployability.webpack.test.ts
@@ -12,10 +12,7 @@ import {
 import { stripIndents } from 'nx/src/utils/strip-indents';
 import { readPort, runCLI } from './utils';
 
-// TODO: re-enable once webpack 5.107.0 / @module-federation/enhanced compatibility is resolved upstream.
-// See https://github.com/webpack/webpack/issues/20985 and https://github.com/module-federation/core/issues/4747.
-// eslint-disable-next-line jest/no-disabled-tests
-describe.skip('Independent Deployability', () => {
+describe('Independent Deployability', () => {
   let proj: string;
   beforeAll(() => {
     process.env.NX_ADD_PLUGINS = 'false';

--- a/e2e/react/src/module-federation/misc-rspack-interoperability.test.ts
+++ b/e2e/react/src/module-federation/misc-rspack-interoperability.test.ts
@@ -12,11 +12,7 @@ import {
 import { readPort, runCLI } from './utils';
 import { stripIndents } from 'nx/src/utils/strip-indents';
 
-// TODO: re-enable once webpack 5.107.0 / @module-federation/enhanced compatibility is resolved upstream.
-// Both interop scenarios involve a webpack-built host or remote, so they hit the same module-resolution failure.
-// See https://github.com/webpack/webpack/issues/20985 and https://github.com/module-federation/core/issues/4747.
-// eslint-disable-next-line jest/no-disabled-tests
-describe.skip('React Rspack Module Federation Misc - Interoperability', () => {
+describe('React Rspack Module Federation Misc - Interoperability', () => {
   beforeEach(() => {
     process.env.NX_ADD_PLUGINS = 'false';
     newProject({ packages: ['@nx/react'] });


### PR DESCRIPTION
## Current Behavior

PR #35753 skipped 9 webpack-based React Module Federation e2e suites because webpack 5.107.0 (published 2026-05-20) reorganized its `lib/` directory and removed `lib/ModuleNotFoundError.js`, which `@module-federation/enhanced` deep-imports. Every webpack-based MF build/serve in the affected suites was failing with `Cannot find module 'webpack/lib/ModuleNotFoundError'`.

## Expected Behavior

webpack 5.107.1 (published 2026-05-21) restored the path as a backward-compat shim — `lib/ModuleNotFoundError.js` now re-exports from `./errors/ModuleNotFoundError`. Verified locally that all 21 `webpack/lib/*` paths used by `@module-federation/enhanced` 2.4.0 / 2.5.0 now resolve in 5.107.1.

This PR removes the `describe.skip` + TODO + `// eslint-disable-next-line jest/no-disabled-tests` lines from the 9 affected files, re-enabling:

- `e2e/react/src/module-federation/core-webpack-basic-host-remote-generation.test.ts`
- `e2e/react/src/module-federation/core-webpack-basic-playwright.test.ts`
- `e2e/react/src/module-federation/core-webpack-name-and-root.test.ts`
- `e2e/react/src/module-federation/core-webpack-query-params.test.ts`
- `e2e/react/src/module-federation/core-webpack-ssr.test.ts`
- `e2e/react/src/module-federation/dynamic-federation.webpack.test.ts`
- `e2e/react/src/module-federation/federate-module.webpack.test.ts`
- `e2e/react/src/module-federation/independent-deployability.webpack.test.ts`
- `e2e/react/src/module-federation/misc-rspack-interoperability.test.ts`

## Related Issue(s)

Reverts the skip from #35753. Upstream:
- https://github.com/webpack/webpack/pull/20988 (compat shim, merged)
- https://github.com/webpack/webpack/pull/20989 (webpack 5.107.1 release, merged)
