### PR TITLE
chore(misc): pin corepack default pnpm to packageManager version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ env:
   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
   NX_CLOUD_ENABLE_METRICS_COLLECTION: 'true'
   PNPM_HOME: ~/.pnpm
+  # Pin corepack to the pnpm version from packageManager. Without this, corepack
+  # falls back to "latest" in directories that have no packageManager field
+  # (e.g. e2e temp dirs), pulling pnpm 11 and breaking install.
+  COREPACK_DEFAULT_TO_LATEST: '0'
 
 jobs:
   main-linux:

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -13,6 +13,10 @@ on:
 
 env:
   CYPRESS_CACHE_FOLDER: ${{ github.workspace }}/.cypress
+  # Pin corepack to the pnpm version from packageManager. Without this, corepack
+  # falls back to "latest" in directories that have no packageManager field
+  # (e.g. e2e temp dirs), pulling pnpm 11 and breaking install.
+  COREPACK_DEFAULT_TO_LATEST: '0'
 
 permissions: {}
 jobs:

--- a/nx.json
+++ b/nx.json
@@ -402,7 +402,7 @@
   "nxCloudId": "62d013ea0852fe0a2df74438",
   "nxCloudUrl": "https://staging.nx.app",
   "parallel": 1,
-  "bust": 3234,
+  "bust": 3235,
   "defaultBase": "master",
   "sync": {
     "applyChanges": true


### PR DESCRIPTION
## Current Behavior

Corepack on CI defaults to the latest published pnpm whenever it runs in a directory without a `packageManager` field. Our e2e tests create temp workspaces (via `create-nx-workspace`) in `/tmp/...` and run `pnpm install` there before the field is written. Corepack picks pnpm 11.x, which fails installs across the e2e matrix.

## Expected Behavior

Corepack reuses the pnpm version activated from the repo's `packageManager` field (pnpm 10.x today) regardless of the working directory. Setting `COREPACK_DEFAULT_TO_LATEST=0` at the workflow `env:` level tells corepack to keep the activated default instead of auto-upgrading.

Also bumps the cache bust value in `nx.json` so the CI Nx Cache rolls.

## Related Issue(s)

N/A — internal CI fix.