### PR TITLE
fix(repo): run dotnet restore before publish

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -80,10 +80,11 @@ jobs:
         id: brew-install-python-setuptools
         run: brew install python-setuptools
 
-      - name: Install packages
-        run: |
-          pnpm install --frozen-lockfile
-          pnpm playwright install --with-deps
+      - name: Install pnpm packages
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright
+        run: pnpm playwright install --with-deps
 
       - name: Restore .NET packages
         run: dotnet restore nx.sln
@@ -168,10 +169,11 @@ jobs:
           corepack enable
           corepack prepare --activate
 
-      - name: Install packages
-        run: |
-          pnpm install --frozen-lockfile
-          pnpm playwright install --with-deps
+      - name: Install pnpm packages
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright
+        run: pnpm playwright install --with-deps
 
       - name: Restore .NET packages
         run: dotnet restore nx.sln

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -85,6 +85,9 @@ jobs:
           pnpm install --frozen-lockfile
           pnpm playwright install --with-deps
 
+      - name: Restore .NET packages
+        run: dotnet restore nx.sln
+
       - name: Homebrew cache directory path
         if: ${{ matrix.os == 'macos-latest' }}
         id: homebrew-cache-dir-path
@@ -169,6 +172,9 @@ jobs:
         run: |
           pnpm install --frozen-lockfile
           pnpm playwright install --with-deps
+
+      - name: Restore .NET packages
+        run: dotnet restore nx.sln
 
       - name: Cleanup
         if: ${{ matrix.os == 'ubuntu-latest' }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -600,6 +600,9 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      - name: Restore .NET packages
+        run: dotnet restore nx.sln
+
       - name: Download all artifacts
         uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5.0.0
         with:

--- a/.nx/workflows/agents.yaml
+++ b/.nx/workflows/agents.yaml
@@ -74,7 +74,7 @@ common-init-steps: &common-init-steps
 
   - name: Restore .NET analyzer projects
     script: |
-      dotnet restore packages/dotnet/analyzer.Tests/MsbuildAnalyzer.Tests.csproj
+      dotnet restore nx.sln
 
   - name: Configure git metadata (needed for lerna smoke tests)
     script: |


### PR DESCRIPTION
  ## Current Behavior

  Publish workflow fails when building MsbuildAnalyzer because the `@nx/dotnet` plugin's inferred `build` target runs
  `dotnet build --no-restore --no-dependencies --configuration Release`, but no restore has happened, so
  `project.assets.json` is missing:

  error NETSDK1004: Assets file '.../packages/dotnet/analyzer/obj/project.assets.json' not found.

  ## Expected Behavior

  Run `dotnet restore nx.sln` once in the publish job (right after `pnpm install`) so all .NET projects have assets files
   before any inferred build runs with `--no-restore`.

  ## Related Issue(s)

  N/A