### PR TITLE
fix(repo): run dotnet restore before macos e2e job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -316,6 +316,10 @@ jobs:
           pnpm install --frozen-lockfile
           pnpm playwright install --with-deps
 
+      - name: Restore .NET packages
+        if: steps.check-changes.outputs.has_changes == 'true'
+        run: dotnet restore nx.sln
+
       - name: Run E2E Tests for macOS
         if: steps.check-changes.outputs.has_changes == 'true'
         run: |


### PR DESCRIPTION
  ## Current Behavior

  The macOS e2e job in ci.yml runs `pnpm install` but never restores .NET packages, so any e2e test that triggers the `@nx/dotnet` plugin's inferred `build` target (which uses `--no-restore`) fails with NETSDK1004 (missing `project.assets.json`).

  ## Expected Behavior

  Run `dotnet restore nx.sln` after `pnpm install` in the macOS e2e job, matching what `main-linux` already does.

  ## Related Issue(s)

  N/A