### PR TITLE
chore(repo): set pnpm minimumReleaseAge with nx exclusions

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -10,6 +10,13 @@ packages:
   - 'examples/angular-rspack/module-federation/host'
   - 'examples/angular-rspack/module-federation/remote'
   - 'packages/nx/native-packages/*'
+minimumReleaseAge: 1440
+minimumReleaseAgeExclude:
+  - nx
+  - '@nx/*'
+  - '@nrwl/*'
+  - create-nx-workspace
+  - create-nx-plugin
 overrides:
   minimist: '^1.2.6'
   underscore: '^1.12.1'


### PR DESCRIPTION
## Current Behavior

  `pnpm install` will happily resolve and install package versions that were published seconds ago. This is the supply-chain attack window — when a popular package gets compromised (e.g. the recent `node-ipc` incident), any CI/dev install during
  that window can pick up the malicious version before the registry / community has a chance to react.

  ## Expected Behavior

  `pnpm install` enforces a minimum release age of 1 day (1440 minutes), so packages published within the last 24 hours are not eligible to be installed. Nx-published packages (`nx`, `@nx/*`, `@nrwl/*`, `create-nx-workspace`, `create-nx-plugin`)
  are excluded so freshly released Nx packages don't block installs or e2e flows.

  Configured via `pnpm-workspace.yaml`:

  ```yaml
  minimumReleaseAge: 1440
  minimumReleaseAgeExclude:
    - nx
    - '@nx/*'
    - '@nrwl/*'
    - create-nx-workspace
    - create-nx-plugin
  ```

  ## Related Issue(s)

  Refs [NXC-4466](https://linear.app/nxdev/issue/NXC-4466/set-minimum-release-age-in-ci-with-nx-exclusions)