### PR TITLE
fix(ci): respect prerelease for MatchingDependencyRange

### DIFF
--- a/packages/js/src/release/utils/semver.spec.ts
+++ b/packages/js/src/release/utils/semver.spec.ts
@@ -82,6 +82,27 @@ describe('semver utils', () => {
       expect(isMatchingDependencyRange('1.0.0-alpha', '^1.0.0')).toBe(false);
     });
 
+    it('should return true when a prerelease version satisfies a broad range', () => {
+      // Canary/dev versions of a release that is within the range should be considered matching.
+      // e.g. "3.0.6-dev.abc.0" is a prerelease of 3.0.6 which satisfies ">=2"
+      expect(isMatchingDependencyRange('3.0.6-dev.abc.0', '>=2')).toBe(true);
+      expect(isMatchingDependencyRange('3.0.6-dev.abc.0', '>=2.0.0-0')).toBe(
+        true
+      );
+      expect(isMatchingDependencyRange('3.0.6-rc.0', '>=2')).toBe(true);
+      expect(isMatchingDependencyRange('1.1.0-rc.0', '^1.0.0')).toBe(true);
+      expect(isMatchingDependencyRange('1.0.1-alpha.0', '~1.0.0')).toBe(true);
+    });
+
+    it('should return false when a prerelease version does not satisfy the range', () => {
+      // Breaking changes must still be detected even for prereleases
+      expect(isMatchingDependencyRange('2.0.0-rc.0', '^1.0.0')).toBe(false);
+      expect(isMatchingDependencyRange('3.0.0-dev.abc.0', '^2.0.0')).toBe(
+        false
+      );
+      expect(isMatchingDependencyRange('1.9.9-rc.0', '>=2')).toBe(false);
+    });
+
     it('should handle build metadata', () => {
       expect(isMatchingDependencyRange('1.0.0+build.1', '^1.0.0')).toBe(true);
       expect(isMatchingDependencyRange('1.2.3+20230101', '^1.0.0')).toBe(true);

--- a/packages/js/src/release/utils/semver.ts
+++ b/packages/js/src/release/utils/semver.ts
@@ -8,5 +8,8 @@ export function isValidRange(range: string) {
 
 export function isMatchingDependencyRange(version: string, range: string) {
   const coercedVersion = coerce(version, { includePrerelease: true })?.version;
-  return isValidRange(range) && satisfies(coercedVersion, range);
+  return (
+    isValidRange(range) &&
+    satisfies(coercedVersion, range, { includePrerelease: true })
+  );
 }


### PR DESCRIPTION
## Summary

`isMatchingDependencyRange` in `@nx/js` incorrectly rejects prerelease versions
against ranges that logically cover them, causing `preserveMatchingDependencyRanges`
to throw a false-positive error during canary/prerelease releases.

## Context

`preserveMatchingDependencyRanges` exists precisely to support a common pattern
in publishable monorepos: packages declare **semver ranges** in `peerDependencies`
rather than exact versions, so that external consumers (outside the monorepo) have
flexibility in what version they install.

For example, a library `consumer` that depends on `api-client` might declare:

```json
{
  "peerDependencies": {
    "@my/api-client": ">=2"
  },
  "devDependencies": {
    "@my/api-client": "workspace:*"
  }
}
```

`workspace:*` keeps the monorepo's internal dependency graph correct, while `>=2`
is the contract published to the npm registry for external consumers.

When this monorepo also publishes **canary/prerelease** versions (e.g. via
`nx release version prepatch --preid dev`), the new version becomes something like
`3.0.6-dev.abc123.0`. The range `>=2` logically covers this version — yet Nx
throws an error and blocks the release. Updating `peerDependencies` to the exact
prerelease version on every canary release is not acceptable, as it would publish
a tight prerelease constraint to the npm registry for all external consumers.

## Problem

```
"preserveMatchingDependencyRanges" is enabled for "peerDependencies" and
the new version "3.0.6-dev.abc123.0" is outside the current range for
"@my/api-client" in manifest "packages/consumer/package.json".
Please update the range before releasing.
```

This error occurs even with `>=2.0.0-0` (the semver-idiomatic way to opt into
prerelease versions for a range), because the bug is not in the range itself but
in how Nx evaluates it.

### Root cause

In `packages/js/src/release/utils/semver.ts`, `isMatchingDependencyRange` is
internally inconsistent:

```ts
// coerce is called WITH { includePrerelease: true }
// → coercedVersion retains the full prerelease tag: "3.0.6-dev.abc123.0"
const coercedVersion = coerce(version, { includePrerelease: true })?.version;

// satisfies is called WITHOUT { includePrerelease: true }
// → the semver library excludes prerelease versions from ranges by default
// → "3.0.6-dev.abc123.0" does NOT satisfy ">=2", even though 3.0.6 does
return isValidRange(range) && satisfies(coercedVersion, range);
```

Per the `semver` library spec, without `{ includePrerelease: true }`, a prerelease
version is excluded from any range unless the range explicitly lists a prerelease
tag on the **same** `[major, minor, patch]` tuple. So `3.0.6-dev.abc123.0` never
satisfies `>=2` (or even `>=2.0.0-0`) without the flag, even though its stable
equivalent `3.0.6` clearly does.

## Behavior after the fix

| version | range | before | after | correct? |
|---|---|---|---|---|
| `3.0.6-dev.abc.0` | `>=2` | ❌ error | ✅ preserved | ✅ |
| `3.0.6-dev.abc.0` | `>=2.0.0-0` | ❌ error | ✅ preserved | ✅ |
| `1.1.0-rc.0` | `^1.0.0` | ❌ error | ✅ preserved | ✅ |
| `1.0.1-alpha.0` | `~1.0.0` | ❌ error | ✅ preserved | ✅ |
| `2.0.0-rc.0` | `^1.0.0` | ❌ error | ❌ error | ✅ correctly rejected |
| `3.0.0-dev.abc.0` | `^2.0.0` | ❌ error | ❌ error | ✅ correctly rejected |
| `1.0.0-alpha` | `^1.0.0` | ❌ error | ❌ error | ✅ prerelease before the range floor, correctly rejected |
| `1.1.0` | `^1.0.0` | ✅ preserved | ✅ preserved | ✅ no change for stable |

All existing unit tests pass unchanged. Two new test cases are added to cover
the prerelease scenarios.