### PR TITLE
fix(js): handle already-published version errors in release-publish executor

### DIFF
--- a/packages/js/src/executors/release-publish/release-publish.impl.spec.ts
+++ b/packages/js/src/executors/release-publish/release-publish.impl.spec.ts
@@ -40,6 +40,7 @@ describe('release-publish executor', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    mockDetectPackageManager.mockReturnValue('npm');
     jest.spyOn(console, 'log').mockImplementation();
     jest.spyOn(console, 'warn').mockImplementation();
     jest.spyOn(console, 'error').mockImplementation();
@@ -88,6 +89,98 @@ describe('release-publish executor', () => {
 
   afterEach(() => {
     jest.restoreAllMocks();
+  });
+
+  describe('already published error handling', () => {
+    function mockNpmViewNotFound() {
+      mockExecSync.mockImplementationOnce(() => {
+        const error: any = new Error('npm view failed');
+        error.stdout = Buffer.from(
+          JSON.stringify({
+            error: {
+              code: 'E404',
+              summary: 'Not found',
+            },
+          })
+        );
+        error.stderr = Buffer.from('npm ERR! 404 Not Found');
+        throw error;
+      });
+    }
+
+    it('should skip publishing when pnpm reports that the version was previously published', async () => {
+      mockDetectPackageManager.mockReturnValue('pnpm');
+      mockNpmViewNotFound();
+      mockExecSync.mockImplementationOnce(() => {
+        const error: any = new Error('pnpm publish failed');
+        error.stdout = Buffer.from(
+          JSON.stringify({
+            error: {
+              code: 'E403',
+              message:
+                'You cannot publish over the previously published versions: 1.0.0.',
+            },
+          })
+        );
+        error.stderr = Buffer.from('');
+        throw error;
+      });
+
+      const result = await runExecutor(options, context);
+
+      expect(result.success).toBe(true);
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('has already been published')
+      );
+      expect(console.error).not.toHaveBeenCalledWith('pnpm publish error:');
+    });
+
+    it('should skip publishing when raw publish output says the version was previously published', async () => {
+      mockDetectPackageManager.mockReturnValue('pnpm');
+      mockNpmViewNotFound();
+      mockExecSync.mockImplementationOnce(() => {
+        const error: any = new Error('pnpm publish failed');
+        error.stdout = Buffer.from('not json');
+        error.stderr = Buffer.from(
+          'ERR_PNPM_PUBLISH_CONFLICT 403 Forbidden - You cannot publish over the previously published versions: 1.0.0.'
+        );
+        throw error;
+      });
+
+      const result = await runExecutor(options, context);
+
+      expect(result.success).toBe(true);
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('has already been published')
+      );
+      expect(console.error).not.toHaveBeenCalledWith('pnpm publish error:');
+    });
+
+    it('should fail when pnpm publish returns a generic 403 error', async () => {
+      mockDetectPackageManager.mockReturnValue('pnpm');
+      mockNpmViewNotFound();
+      mockExecSync.mockImplementationOnce(() => {
+        const error: any = new Error('pnpm publish failed');
+        error.stdout = Buffer.from(
+          JSON.stringify({
+            error: {
+              code: 'E403',
+              message: '403 Forbidden - You do not have permission to publish',
+            },
+          })
+        );
+        error.stderr = Buffer.from('');
+        throw error;
+      });
+
+      const result = await runExecutor(options, context);
+
+      expect(result.success).toBe(false);
+      expect(console.error).toHaveBeenCalledWith('pnpm publish error:');
+      expect(console.warn).not.toHaveBeenCalledWith(
+        expect.stringContaining('has already been published')
+      );
+    });
   });
 
   describe('nxReleaseVersionData skip behavior', () => {

--- a/packages/js/src/executors/release-publish/release-publish.impl.ts
+++ b/packages/js/src/executors/release-publish/release-publish.impl.ts
@@ -28,6 +28,33 @@ function processEnv(color: boolean) {
   return env;
 }
 
+function isAlreadyPublishedPublishError(
+  stdoutData?: any,
+  stderr = '',
+  stdout = ''
+): boolean {
+  const error = stdoutData?.error;
+  const errorMessage = [
+    error?.summary,
+    error?.detail,
+    error?.message,
+    error?.body?.error,
+    stderr,
+    stdout,
+  ]
+    .filter(Boolean)
+    .join('\n');
+
+  return (
+    error?.code === 'EPUBLISHCONFLICT' ||
+    errorMessage.includes(
+      'You cannot publish over the previously published versions'
+    ) ||
+    (error?.code === 'E409' &&
+      errorMessage.includes('this package is already present'))
+  );
+}
+
 export default async function runExecutor(
   options: PublishExecutorSchema,
   context: ExecutorContext
@@ -359,6 +386,7 @@ Please update the local dependency on "${depName}" to be a valid semantic versio
     tag,
     isDryRun,
     isNpmInstalled,
+    packageTxt,
   });
 }
 
@@ -373,6 +401,7 @@ interface RunPublishContext {
   tag: string;
   isDryRun: boolean;
   isNpmInstalled: boolean;
+  packageTxt: string;
 }
 
 function runPublish(ctx: RunPublishContext): { success: boolean } {
@@ -387,6 +416,7 @@ function runPublish(ctx: RunPublishContext): { success: boolean } {
     tag,
     isDryRun,
     isNpmInstalled,
+    packageTxt,
   } = ctx;
   const pmCommand = getPackageManagerCommand(pm);
   const publishCommandSegments = [
@@ -518,10 +548,35 @@ function runPublish(ctx: RunPublishContext): { success: boolean } {
       try {
         stdoutData = JSON.parse(err.stdout?.toString() || '{}');
       } catch {
+        const stderr = err.stderr?.toString() || '';
+        const stdout = err.stdout?.toString() || '';
+        if (isAlreadyPublishedPublishError(undefined, stderr, stdout)) {
+          console.warn(
+            `Skipped ${packageTxt}, as v${packageJson.version} has already been published to ${registry} with tag "${tag}"`
+          );
+          return {
+            success: true,
+          };
+        }
         console.error(err.stderr?.toString() || '');
         console.error(err.stdout?.toString() || '');
         return {
           success: false,
+        };
+      }
+
+      if (
+        isAlreadyPublishedPublishError(
+          stdoutData,
+          err.stderr?.toString() || '',
+          err.stdout?.toString() || ''
+        )
+      ) {
+        console.warn(
+          `Skipped ${packageTxt}, as v${packageJson.version} has already been published to ${registry} with tag "${tag}"`
+        );
+        return {
+          success: true,
         };
       }
 


### PR DESCRIPTION
## Current Behavior

When using `nx release publish` with pnpm (or other package managers), if a package version has already been published to the registry, the executor fails with an error instead of gracefully handling it.

## Expected Behavior

The release-publish executor should detect "already published" errors (E403 with 'previously published versions', EPUBLISHCONFLICT, E409 conflicts) and skip the publish gracefully with a warning, rather than failing the entire release process.

## Related Issue(s)

Closes #35235
