### PR TITLE
feat(core): surface graph-extension in core plugin capabilities

### DIFF
--- a/packages/nx/src/utils/plugins/core-plugins.ts
+++ b/packages/nx/src/utils/plugins/core-plugins.ts
@@ -1,116 +1,121 @@
+export type CorePluginCapability =
+  | 'executors'
+  | 'generators'
+  | 'graph-extension';
+
 export interface CorePlugin {
   name: string;
-  capabilities: 'executors' | 'generators' | 'executors,generators' | 'graph';
+  capabilities: CorePluginCapability[];
   link?: string;
 }
 
 export const CORE_PLUGINS: CorePlugin[] = [
   {
     name: '@nx/angular',
-    capabilities: 'executors,generators',
+    capabilities: ['executors', 'generators'],
   },
   {
     name: '@nx/cypress',
-    capabilities: 'executors,generators',
+    capabilities: ['executors', 'generators'],
   },
   {
     name: '@nx/detox',
-    capabilities: 'executors,generators',
+    capabilities: ['executors', 'generators'],
   },
   {
     name: '@nx/esbuild',
-    capabilities: 'executors,generators',
+    capabilities: ['executors', 'generators'],
   },
   {
     name: '@nx/expo',
-    capabilities: 'executors,generators',
+    capabilities: ['executors', 'generators'],
   },
   {
     name: '@nx/express',
-    capabilities: 'generators',
+    capabilities: ['generators'],
   },
   {
     name: '@nx/gradle',
-    capabilities: 'graph',
+    capabilities: ['graph-extension'],
   },
   {
     name: '@nx/jest',
-    capabilities: 'executors,generators',
+    capabilities: ['executors', 'generators'],
   },
   {
     name: '@nx/js',
-    capabilities: 'executors,generators',
+    capabilities: ['executors', 'generators', 'graph-extension'],
   },
   {
     name: '@nx/eslint',
-    capabilities: 'executors,generators',
+    capabilities: ['executors', 'generators'],
   },
   {
     name: '@nx/nest',
-    capabilities: 'generators',
+    capabilities: ['generators'],
   },
   {
     name: '@nx/next',
-    capabilities: 'executors,generators',
+    capabilities: ['executors', 'generators'],
   },
   {
     name: '@nx/node',
-    capabilities: 'executors,generators',
+    capabilities: ['executors', 'generators'],
   },
   {
     name: '@nx/nuxt',
-    capabilities: 'generators',
+    capabilities: ['generators'],
   },
   {
     name: 'nx',
-    capabilities: 'executors',
+    capabilities: ['executors'],
   },
   {
     name: '@nx/plugin',
-    capabilities: 'executors,generators',
+    capabilities: ['executors', 'generators'],
   },
   {
     name: '@nx/react',
-    capabilities: 'executors,generators',
+    capabilities: ['executors', 'generators'],
   },
   {
     name: '@nx/react-native',
-    capabilities: 'executors,generators',
+    capabilities: ['executors', 'generators'],
   },
   {
     name: '@nx/remix',
-    capabilities: 'executors,generators',
+    capabilities: ['executors', 'generators'],
   },
   {
     name: '@nx/rollup',
-    capabilities: 'executors,generators',
+    capabilities: ['executors', 'generators'],
   },
   {
     name: '@nx/rspack',
-    capabilities: 'executors,generators',
+    capabilities: ['executors', 'generators'],
   },
   {
     name: '@nx/storybook',
-    capabilities: 'executors,generators',
+    capabilities: ['executors', 'generators'],
   },
   {
     name: '@nx/vite',
-    capabilities: 'executors,generators',
+    capabilities: ['executors', 'generators'],
   },
   {
     name: '@nx/vue',
-    capabilities: 'generators',
+    capabilities: ['generators'],
   },
   {
     name: '@nx/web',
-    capabilities: 'executors,generators',
+    capabilities: ['executors', 'generators'],
   },
   {
     name: '@nx/webpack',
-    capabilities: 'executors,generators',
+    capabilities: ['executors', 'generators'],
   },
   {
     name: '@nx/workspace',
-    capabilities: 'executors,generators',
+    capabilities: ['executors', 'generators'],
   },
 ];

--- a/packages/nx/src/utils/plugins/output.spec.ts
+++ b/packages/nx/src/utils/plugins/output.spec.ts
@@ -2,6 +2,7 @@ import { PluginCapabilities } from './plugin-capabilities';
 import {
   formatPluginCapabilitiesAsJson,
   formatPluginsAsJson,
+  listAlsoAvailableCorePlugins,
   listPluginCapabilities,
 } from './output';
 
@@ -173,6 +174,36 @@ describe('formatPluginCapabilitiesAsJson', () => {
     expect(result.path).toBeNull();
     expect(result.generators['gen'].path).toBeNull();
     expect(result.generators['gen'].schema).toBeNull();
+  });
+});
+
+describe('listAlsoAvailableCorePlugins', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should advertise graph capability for graph-extending core plugins', () => {
+    listAlsoAvailableCorePlugins(new Map());
+
+    const alsoAvailableCall = output.log.mock.calls.find(
+      ([arg]) => arg.title === 'Also available:'
+    );
+
+    expect(alsoAvailableCall).toBeDefined();
+    expect(
+      alsoAvailableCall[0].bodyLines.some(
+        (line: string) =>
+          line.includes('@nx/js') &&
+          line.includes('(executors,generators,graph-extension)')
+      )
+    ).toBe(true);
+    expect(
+      alsoAvailableCall[0].bodyLines.some(
+        (line: string) =>
+          line.includes('@nx/gradle') &&
+          line.includes('(graph-extension)')
+      )
+    ).toBe(true);
   });
 });
 

--- a/packages/nx/src/utils/plugins/output.ts
+++ b/packages/nx/src/utils/plugins/output.ts
@@ -8,7 +8,7 @@ import { ProjectConfiguration } from '../../config/workspace-json-project-json';
 import { output } from '../output';
 import { getPackageManagerCommand } from '../package-manager';
 import { workspaceRoot } from '../workspace-root';
-import { CORE_PLUGINS } from './core-plugins';
+import { CORE_PLUGINS, CorePluginCapability } from './core-plugins';
 import {
   PluginCapabilities,
   getPluginCapabilities,
@@ -37,9 +37,7 @@ export function listPlugins(
       capabilities.push('project-inference');
     }
     bodyLines.push(
-      `${pc.bold(p.name)} ${
-        capabilities.length >= 1 ? `(${capabilities.join()})` : ''
-      }`
+      `${pc.bold(p.name)} ${formatCapabilityList(capabilities)}`
     );
   }
 
@@ -60,10 +58,16 @@ export function listAlsoAvailableCorePlugins(
     output.log({
       title: `Also available:`,
       bodyLines: alsoAvailable.map((p) => {
-        return `${pc.bold(p.name)} (${p.capabilities})`;
+        return `${pc.bold(p.name)} ${formatCapabilityList(p.capabilities)}`;
       }),
     });
   }
+}
+
+function formatCapabilityList(
+  capabilities: Array<CorePluginCapability | 'project-inference'>
+): string {
+  return capabilities.length >= 1 ? `(${capabilities.join()})` : '';
 }
 
 export function listPowerpackPlugins(): void {


### PR DESCRIPTION
## Summary

Surface graph extension as a first-class capability in the core plugin metadata and `nx list` output.

## Why

This was initially going to be folded into #35788, but that PR's implementation moved tree-shaken dependency narrowing into the core JS graph pipeline instead of keeping a separate `@nx/node` graph authority.

That design change still leaves value in exposing graph hooks explicitly as a plugin capability. Nx plugins can participate in project-graph behavior through `createNodes`, `createNodesV2`, `createDependencies`, and related graph hooks, and the static core-plugin listing should model that in the same terms as the installed-plugin capability pipeline.

## What Changes

- changes `packages/nx/src/utils/plugins/core-plugins.ts` to model core plugin capabilities as first-class capability arrays instead of pre-joined strings
- represents graph participation with the existing `graph-extension` capability label
- updates the list output to format static core-plugin capabilities through the same capability-list path used elsewhere in plugin output
- marks graph-extending core plugins in the static list, including `@nx/js` and `@nx/gradle`
- adds coverage for the static core-plugin listing output

## Validation

Focused Node 22 validation in this fork:

- `packages/nx/src/utils/plugins/output.spec.ts`: 15 passed, 15 total