### PR TITLE
feat(core): avoid redundant rematch in findMatchingConfigFiles

### DIFF
--- a/packages/devkit/src/generators/target-defaults-utils.ts
+++ b/packages/devkit/src/generators/target-defaults-utils.ts
@@ -17,6 +17,7 @@ import {
   normalizeTargetDefaultsAgainstRootMaps,
   readTargetDefaultsForTarget as readTargetDefaultsForTargetFromNx,
 } from 'nx/src/devkit-internals';
+import { minimatch } from 'minimatch';
 import { major, valid } from 'semver';
 import { NX_VERSION } from '../utils/package-json';
 import {
@@ -293,6 +294,12 @@ export async function addE2eCiTargetDefaults(
   } = await import(e2ePlugin);
   const e2ePluginGlob =
     resolvedE2ePlugin.createNodesV2?.[0] ?? resolvedE2ePlugin.createNodes?.[0];
+  // The e2e config file must be one this plugin actually processes (its path
+  // matches the plugin's createNodes glob) before the registration's
+  // include/exclude filters are applied.
+  const e2eConfigMatchesPluginGlob =
+    !e2ePluginGlob ||
+    minimatch(pathToE2EConfigFile, e2ePluginGlob, { dot: true });
 
   let foundPluginForApplication: PluginConfiguration;
   for (let i = 0; i < e2ePluginRegistrations.length; i++) {
@@ -302,12 +309,13 @@ export async function addE2eCiTargetDefaults(
       break;
     }
 
-    const matchingConfigFiles = findMatchingConfigFiles(
-      [pathToE2EConfigFile],
-      e2ePluginGlob,
-      candidatePluginForApplication.include,
-      candidatePluginForApplication.exclude
-    );
+    const matchingConfigFiles = e2eConfigMatchesPluginGlob
+      ? findMatchingConfigFiles(
+          [pathToE2EConfigFile],
+          candidatePluginForApplication.include,
+          candidatePluginForApplication.exclude
+        )
+      : [];
 
     if (matchingConfigFiles.length) {
       foundPluginForApplication = candidatePluginForApplication;

--- a/packages/devkit/src/utils/find-plugin-for-config-file.ts
+++ b/packages/devkit/src/utils/find-plugin-for-config-file.ts
@@ -5,6 +5,7 @@ import {
   CreateNodesV2,
 } from 'nx/src/devkit-exports';
 import { findMatchingConfigFiles } from 'nx/src/devkit-internals';
+import { minimatch } from 'minimatch';
 export async function findPluginForConfigFile(
   tree: Tree,
   pluginName: string,
@@ -35,12 +36,17 @@ export async function findPluginForConfigFile(
       } = await import(pluginName);
       const pluginGlob =
         resolvedPlugin.createNodesV2?.[0] ?? resolvedPlugin.createNodes?.[0];
-      const matchingConfigFile = findMatchingConfigFiles(
-        [pathToConfigFile],
-        pluginGlob,
-        plugin.include,
-        plugin.exclude
-      );
+      // The file must be one this plugin actually processes (its path matches
+      // the plugin's createNodes glob) before the registration's include/exclude
+      // filters are applied.
+      const matchingConfigFile =
+        !pluginGlob || minimatch(pathToConfigFile, pluginGlob, { dot: true })
+          ? findMatchingConfigFiles(
+              [pathToConfigFile],
+              plugin.include,
+              plugin.exclude
+            )
+          : [];
       if (matchingConfigFile.length) {
         return plugin;
       }

--- a/packages/js/src/utils/typescript/plugin.ts
+++ b/packages/js/src/utils/typescript/plugin.ts
@@ -3,6 +3,7 @@ import type {
   NxJsonConfiguration,
 } from '@nx/devkit';
 import { findMatchingConfigFiles } from 'nx/src/devkit-internals';
+import picomatch = require('picomatch');
 import type { TscPluginOptions } from '../../plugins/typescript/plugin';
 
 export function ensureProjectIsIncludedInPluginRegistrations(
@@ -32,12 +33,19 @@ export function ensureProjectIsIncludedInPluginRegistrations(
       }
     } else {
       // check if the project would be included by the plugin registration
-      const matchingConfigFiles = findMatchingConfigFiles(
-        [`${projectRoot}/tsconfig.json`],
-        '**/tsconfig.json',
-        registration.include,
-        registration.exclude
-      );
+      // Only consider the tsconfig if the @nx/js/typescript plugin would
+      // actually process it (its path matches the plugin's createNodes glob)
+      // before the registration's include/exclude filters are applied.
+      const tsconfigPath = `${projectRoot}/tsconfig.json`;
+      const matchingConfigFiles = picomatch('**/tsconfig.json', { dot: true })(
+        tsconfigPath
+      )
+        ? findMatchingConfigFiles(
+            [tsconfigPath],
+            registration.include,
+            registration.exclude
+          )
+        : [];
       if (matchingConfigFiles.length) {
         // it's included by the plugin registration, check if the user-specified options would result
         // in the appropriate build task being inferred, if not, we need to exclude it

--- a/packages/nx/src/project-graph/project-graph.spec.ts
+++ b/packages/nx/src/project-graph/project-graph.spec.ts
@@ -10,7 +10,8 @@ import * as plugins from './plugins/get-plugins';
 jest.mock('../utils/workspace-context', () => {
   return {
     globWithWorkspaceContext: jest.fn().mockReturnValue(['file']),
-    multiGlobWithWorkspaceContext: jest.fn().mockReturnValue(['file']),
+    // multiGlob returns one file list per glob group (string[][]).
+    multiGlobWithWorkspaceContext: jest.fn().mockReturnValue([['file']]),
     getNxWorkspaceFilesFromContext: jest.fn().mockReturnValue({
       projectFileMap: {},
       globalFiles: [],

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
@@ -9,6 +9,7 @@ import { LoadedNxPlugin } from '../plugins/loaded-nx-plugin';
 import {
   createProjectConfigurationsWithPlugins,
   CreateNodesResultEntry,
+  findMatchingConfigFiles,
   MergeError,
   mergeCreateNodesResults,
 } from './project-configuration-utils';
@@ -21,6 +22,47 @@ import type {
   ConfigurationSourceMaps,
   SourceInformation,
 } from './project-configuration/source-maps';
+
+describe('findMatchingConfigFiles', () => {
+  const files = [
+    'libs/a/project.json',
+    'libs/a/extra/project.json',
+    'libs/a/ignored/project.json',
+    'libs/b/project.json',
+    'libs/b/project.spec.json',
+  ];
+
+  it('should apply include and exclude filters after pattern match', () => {
+    const result = findMatchingConfigFiles(
+      files,
+      '**/project.json',
+      ['libs/a/**', 'libs/b/**'],
+      ['**/ignored/**']
+    );
+
+    expect(result).toEqual([
+      'libs/a/project.json',
+      'libs/a/extra/project.json',
+      'libs/b/project.json',
+    ]);
+  });
+
+  it('should honor include negation patterns', () => {
+    const result = findMatchingConfigFiles(
+      files,
+      '**/project*.json',
+      ['libs/**', '!**/*.spec.json'],
+      []
+    );
+
+    expect(result).toEqual([
+      'libs/a/project.json',
+      'libs/a/extra/project.json',
+      'libs/a/ignored/project.json',
+      'libs/b/project.json',
+    ]);
+  });
+});
 
 describe('project-configuration-utils', () => {
   describe('mergeCreateNodesResults', () => {

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
@@ -29,13 +29,11 @@ describe('findMatchingConfigFiles', () => {
     'libs/a/extra/project.json',
     'libs/a/ignored/project.json',
     'libs/b/project.json',
-    'libs/b/project.spec.json',
   ];
 
-  it('should apply include and exclude filters after pattern match', () => {
+  it('should apply include and exclude filters to the pre-matched project file list', () => {
     const result = findMatchingConfigFiles(
       files,
-      '**/project.json',
       ['libs/a/**', 'libs/b/**'],
       ['**/ignored/**']
     );
@@ -50,15 +48,13 @@ describe('findMatchingConfigFiles', () => {
   it('should honor include negation patterns', () => {
     const result = findMatchingConfigFiles(
       files,
-      '**/project*.json',
-      ['libs/**', '!**/*.spec.json'],
+      ['libs/**', '!libs/a/ignored/**'],
       []
     );
 
     expect(result).toEqual([
       'libs/a/project.json',
       'libs/a/extra/project.json',
-      'libs/a/ignored/project.json',
       'libs/b/project.json',
     ]);
   });

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -157,7 +157,6 @@ export async function createProjectConfigurationsWithPlugins(
 
     const matchingConfigFiles: string[] = findMatchingConfigFiles(
       allProjectFiles[index],
-      pattern,
       include,
       exclude
     );
@@ -548,30 +547,28 @@ function createMatcher(
 
 export function findMatchingConfigFiles(
   projectFiles: string[],
-  pattern: string,
   include: string[],
   exclude: string[]
 ): string[] {
   const matchingConfigFiles: string[] = [];
-  const patternMatcher = new Minimatch(pattern, { dot: true });
 
+  // projectFiles already comes from multiGlobWithWorkspaceContext for the
+  // plugin's createNodes pattern, so only include/exclude filters remain here.
   // Create matchers once, outside the loop
   // Empty include means include everything, empty exclude means exclude nothing
   const includes = createMatcher(include, true);
   const excludes = createMatcher(exclude, false);
 
   for (const file of projectFiles) {
-    if (patternMatcher.match(file)) {
-      if (!includes(file)) {
-        continue;
-      }
-
-      if (excludes(file)) {
-        continue;
-      }
-
-      matchingConfigFiles.push(file);
+    if (!includes(file)) {
+      continue;
     }
+
+    if (excludes(file)) {
+      continue;
+    }
+
+    matchingConfigFiles.push(file);
   }
 
   return matchingConfigFiles;

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -9,7 +9,7 @@ import {
 } from './project-configuration/project-nodes-manager';
 import { validateAndNormalizeProjectRootMap } from './project-configuration/target-normalization';
 
-import { minimatch } from 'minimatch';
+import { Minimatch, minimatch } from 'minimatch';
 import { performance } from 'perf_hooks';
 
 import { DelayedSpinner } from '../../utils/delayed-spinner';
@@ -553,6 +553,7 @@ export function findMatchingConfigFiles(
   exclude: string[]
 ): string[] {
   const matchingConfigFiles: string[] = [];
+  const patternMatcher = new Minimatch(pattern, { dot: true });
 
   // Create matchers once, outside the loop
   // Empty include means include everything, empty exclude means exclude nothing
@@ -560,7 +561,7 @@ export function findMatchingConfigFiles(
   const excludes = createMatcher(exclude, false);
 
   for (const file of projectFiles) {
-    if (minimatch(file, pattern, { dot: true })) {
+    if (patternMatcher.match(file)) {
       if (!includes(file)) {
         continue;
       }

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -9,7 +9,7 @@ import {
 } from './project-configuration/project-nodes-manager';
 import { validateAndNormalizeProjectRootMap } from './project-configuration/target-normalization';
 
-import { Minimatch, minimatch } from 'minimatch';
+import { minimatch } from 'minimatch';
 import { performance } from 'perf_hooks';
 
 import { DelayedSpinner } from '../../utils/delayed-spinner';
@@ -153,7 +153,7 @@ export async function createProjectConfigurationsWithPlugins(
       name: pluginName,
     },
   ] of allCreateNodesPlugins.entries()) {
-    const [pattern, createNodes] = createNodesTuple;
+    const [, createNodes] = createNodesTuple;
 
     const matchingConfigFiles: string[] = findMatchingConfigFiles(
       allProjectFiles[index],
@@ -550,26 +550,11 @@ export function findMatchingConfigFiles(
   include: string[],
   exclude: string[]
 ): string[] {
-  const matchingConfigFiles: string[] = [];
-
   // projectFiles already comes from multiGlobWithWorkspaceContext for the
   // plugin's createNodes pattern, so only include/exclude filters remain here.
-  // Create matchers once, outside the loop
   // Empty include means include everything, empty exclude means exclude nothing
   const includes = createMatcher(include, true);
   const excludes = createMatcher(exclude, false);
 
-  for (const file of projectFiles) {
-    if (!includes(file)) {
-      continue;
-    }
-
-    if (excludes(file)) {
-      continue;
-    }
-
-    matchingConfigFiles.push(file);
-  }
-
-  return matchingConfigFiles;
+  return projectFiles.filter((file) => includes(file) && !excludes(file));
 }


### PR DESCRIPTION
## Current Behavior

`findMatchingConfigFiles` still rematches every candidate file against the plugin glob even though `multiGlobWithWorkspaceContext` already returned the file list for that exact glob. The previous branch revision only precompiled the minimatch pattern, which reduced some overhead but still kept the redundant rematch in the hot path.

## Expected Behavior

Once `projectFiles` already comes from `multiGlobWithWorkspaceContext` for a plugin's `createNodes` pattern, `findMatchingConfigFiles` should only apply include/exclude filtering and should not rematch against the same glob again.

This change removes the redundant rematch entirely and updates the unit tests to reflect the actual contract of `findMatchingConfigFiles`: it operates on a pre-matched file list plus include/exclude filters.

Benchmark and reproduction evidence:
- Repro issue: https://github.com/nrwl/nx/issues/35792
- Public repro repo: https://github.com/cw-alexcroteau/nx-find-matching-config-files-repro-20260525
- Successful cross-platform perf summary: https://github.com/cw-alexcroteau/nx-find-matching-config-files-repro-20260525/actions/runs/26409870118/attempts/1#summary-77741892587

## Related Issue(s)

Fixes #35792
