### PR TITLE
fix(core): shell-escape __unparsed__ args in nx:run-script executor

### DIFF
--- a/packages/nx/src/executors/run-commands/run-commands.impl.ts
+++ b/packages/nx/src/executors/run-commands/run-commands.impl.ts
@@ -9,7 +9,7 @@ import {
   runSingleCommandWithPseudoTerminal,
   SeriallyRunningTasks,
 } from './running-tasks';
-import { isAlreadyQuoted, needsShellQuoting } from '../../utils/shell-quoting';
+import { wrapArgIntoQuotesIfNeeded } from '../../utils/shell-quoting';
 
 export const LARGE_BUFFER = 1024 * 1000000;
 export type Json = {
@@ -438,29 +438,4 @@ function filterPropKeysFromUnParsedOptions(
     }
   }
   return parsedOptions;
-}
-
-function wrapArgIntoQuotesIfNeeded(arg: string): string {
-  if (arg.includes('=')) {
-    // Split only on first '=' to handle values containing '='
-    const eqIndex = arg.indexOf('=');
-    const key = arg.substring(0, eqIndex);
-    const value = arg.substring(eqIndex + 1);
-    if (
-      key.startsWith('--') &&
-      needsShellQuoting(value) &&
-      !isAlreadyQuoted(value)
-    ) {
-      // Escape any existing double quotes in the value before wrapping
-      const escaped = value.replace(/"/g, '\\"');
-      return `${key}="${escaped}"`;
-    }
-    return arg;
-  } else if (needsShellQuoting(arg) && !isAlreadyQuoted(arg)) {
-    // Escape any existing double quotes in the value before wrapping
-    const escaped = arg.replace(/"/g, '\\"');
-    return `"${escaped}"`;
-  } else {
-    return arg;
-  }
 }

--- a/packages/nx/src/executors/run-script/run-script.impl.ts
+++ b/packages/nx/src/executors/run-script/run-script.impl.ts
@@ -7,6 +7,7 @@ import {
   PseudoTerminal,
 } from '../../tasks-runner/pseudo-terminal';
 import { getPackageManagerCommand } from '../../utils/package-manager';
+import { wrapArgIntoQuotesIfNeeded } from '../../utils/shell-quoting';
 
 export interface RunScriptOptions {
   script: string;
@@ -19,7 +20,12 @@ export default async function (
 ) {
   const pm = getPackageManagerCommand();
   try {
-    let command = pm.run(options.script, options.__unparsed__.join(' '));
+    // Args run via `shell: true`; quote so metachars like `{}` in JSON values
+    // are not reinterpreted by the shell.
+    let command = pm.run(
+      options.script,
+      options.__unparsed__.map(wrapArgIntoQuotesIfNeeded).join(' ')
+    );
     let cwd = path.join(
       context.root,
       context.projectsConfigurations.projects[context.projectName].root

--- a/packages/nx/src/utils/shell-quoting.spec.ts
+++ b/packages/nx/src/utils/shell-quoting.spec.ts
@@ -1,4 +1,4 @@
-import { needsShellQuoting } from './shell-quoting';
+import { needsShellQuoting, wrapArgIntoQuotesIfNeeded } from './shell-quoting';
 
 describe('needsShellQuoting', () => {
   it.each([
@@ -39,5 +39,30 @@ describe('needsShellQuoting', () => {
     ['empty string', ''],
   ])('returns false for %s: %j', (_, value) => {
     expect(needsShellQuoting(value)).toBe(false);
+  });
+});
+
+describe('wrapArgIntoQuotesIfNeeded', () => {
+  it('preserves a JSON value containing braces, commas, and double quotes', () => {
+    expect(
+      wrapArgIntoQuotesIfNeeded('{"slug":"test","displayName":"Test"}')
+    ).toBe('"{\\"slug\\":\\"test\\",\\"displayName\\":\\"Test\\"}"');
+  });
+
+  it('preserves a JSON value passed as --key=value', () => {
+    expect(wrapArgIntoQuotesIfNeeded('--data={"a":1}')).toBe(
+      '--data="{\\"a\\":1}"'
+    );
+  });
+
+  it('leaves plain args untouched', () => {
+    expect(wrapArgIntoQuotesIfNeeded('--name')).toBe('--name');
+    expect(wrapArgIntoQuotesIfNeeded('value')).toBe('value');
+  });
+
+  it('does not re-quote args that are already quoted', () => {
+    expect(wrapArgIntoQuotesIfNeeded("'already quoted'")).toBe(
+      "'already quoted'"
+    );
   });
 });

--- a/packages/nx/src/utils/shell-quoting.ts
+++ b/packages/nx/src/utils/shell-quoting.ts
@@ -39,3 +39,30 @@ export function isAlreadyQuoted(str: string): boolean {
       (str[0] === '"' && str[str.length - 1] === '"'))
   );
 }
+
+/**
+ * Wrap a CLI arg in double quotes when it contains shell metacharacters,
+ * so it survives being passed to `spawn(..., { shell: true })`. For
+ * `--key=value` form, only the value side is quoted.
+ */
+export function wrapArgIntoQuotesIfNeeded(arg: string): string {
+  if (arg.includes('=')) {
+    const eqIndex = arg.indexOf('=');
+    const key = arg.substring(0, eqIndex);
+    const value = arg.substring(eqIndex + 1);
+    if (
+      key.startsWith('--') &&
+      needsShellQuoting(value) &&
+      !isAlreadyQuoted(value)
+    ) {
+      const escaped = value.replace(/"/g, '\\"');
+      return `${key}="${escaped}"`;
+    }
+    return arg;
+  } else if (needsShellQuoting(arg) && !isAlreadyQuoted(arg)) {
+    const escaped = arg.replace(/"/g, '\\"');
+    return `"${escaped}"`;
+  } else {
+    return arg;
+  }
+}


### PR DESCRIPTION
## Current Behavior

`nx:run-script` joins `__unparsed__` args with a space and passes the result to `spawn(..., { shell: true })`. Shell metacharacters in arg values — `{}` in JSON, quotes, etc. — get re-interpreted (brace expansion strips braces and splits on commas), mangling the value before it reaches the
underlying script.

## Expected Behavior

Each `__unparsed__` element is shell-quoted via the existing `wrapArgIntoQuotesIfNeeded` helper (already used by `nx:run-commands`) before joining, so JSON and other metachar-bearing values reach the underlying script intact.

## Related Issue(s)

Fixes #34717
