### PR TITLE
feat(angular-rspack): add persistent tsbuild cache to speed up incremental building

### DIFF
--- a/packages/angular-rspack-compiler/src/compilation/setup-compilation.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-compilation.ts
@@ -27,6 +27,7 @@ export interface SetupCompilationOptions {
   hasServer?: boolean;
   includePaths?: string[];
   sass?: Sass;
+  watch?: boolean;
 }
 
 export const DEFAULT_NG_COMPILER_OPTIONS: ts.CompilerOptions = {
@@ -113,7 +114,7 @@ export async function setupCompilation(
       tailwindConfiguration,
     },
     options.inlineStyleLanguage,
-    false
+    !!options.watch
   );
 
   return {

--- a/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.ts
@@ -1,4 +1,7 @@
 import type { RsbuildConfig } from '@rsbuild/core';
+import { join } from 'path';
+import { mkdir } from 'fs/promises';
+
 import {
   createAngularCompilation,
   AngularCompilation,
@@ -20,6 +23,21 @@ export async function setupCompilationWithAngularCompilation(
 ) {
   const { rootNames, compilerOptions, componentStylesheetBundler } =
     await setupCompilation(config, options);
+
+  // When a persistent cache directory is available, enable TypeScript's
+  // incremental program and persist its `.tsbuildinfo` to that directory.
+  if (
+    sourceFileCache?.persistentCachePath &&
+    compilerOptions['incremental'] !== false
+  ) {
+    // ensure path exists
+    await mkdir(sourceFileCache.persistentCachePath, { recursive: true });
+    compilerOptions['incremental'] = true;
+    compilerOptions['tsBuildInfoFile'] = join(
+      sourceFileCache.persistentCachePath,
+      '.tsbuildinfo'
+    );
+  }
   angularCompilation ??= await createAngularCompilation(
     !options.aot,
     options.hasServer,

--- a/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.ts
@@ -43,6 +43,14 @@ export async function setupCompilationWithAngularCompilation(
     options.hasServer,
     false
   );
+
+  // Drop the bundler's cached results for files the watcher reported as
+  // modified so dependent stylesheets get rebuilt; skipped on the initial
+  // build when there's nothing to invalidate.
+  if (modifiedFiles) {
+    componentStylesheetBundler.invalidate(modifiedFiles);
+  }
+
   modifiedFiles ??= new Set(rootNames);
 
   const fileReplacements: Record<string, string> =

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
@@ -150,7 +150,8 @@ export class AngularRspackPlugin implements RspackPluginInstance {
                 compiler.options.resolve.tsConfig,
                 watchingModifiedFiles.size > 0
                   ? watchingModifiedFiles
-                  : undefined
+                  : undefined,
+                true
               );
 
               await buildAndAnalyze(
@@ -289,6 +290,13 @@ export class AngularRspackPlugin implements RspackPluginInstance {
         }
       }
 
+      callback();
+    });
+
+    // Tear down the JavaScriptTransformer worker pool only when the compiler
+    // shuts down. Doing it per-build would respawn workers on every rebuild
+    // and discard their warm in-memory state.
+    compiler.hooks.shutdown.tapAsync(PLUGIN_NAME, async (callback) => {
       await this.#javascriptTransformer.close();
       callback();
     });
@@ -434,7 +442,8 @@ export class AngularRspackPlugin implements RspackPluginInstance {
   private async setupCompilation(
     root: string,
     tsConfig: RspackOptionsNormalized['resolve']['tsConfig'],
-    modifiedFiles?: Set<string>
+    modifiedFiles?: Set<string>,
+    watch = false
   ) {
     const tsconfigPath = tsConfig
       ? typeof tsConfig === 'string'
@@ -457,6 +466,7 @@ export class AngularRspackPlugin implements RspackPluginInstance {
         hasServer: this.#_options.hasServer,
         includePaths: this.#_options.stylePreprocessorOptions?.includePaths,
         sass: this.#_options.stylePreprocessorOptions?.sass,
+        watch,
       },
       this.#sourceFileCache,
       this.#angularCompilation,

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
@@ -21,6 +21,7 @@ import {
   type RspackPluginInstance,
   sources,
 } from '@rspack/core';
+import { createRequire } from 'module';
 import { dirname, join, normalize, resolve } from 'node:path';
 import {
   type I18nOptions,
@@ -37,6 +38,26 @@ import { getStatsOptions } from '../config/config-utils/get-stats-options';
 const PLUGIN_NAME = 'AngularRspackPlugin';
 type ResolvedJavascriptTransformer = Parameters<typeof buildAndAnalyze>[2];
 
+// Create a persistent cache directory for the Angular TypeScript program's
+// `.tsbuildinfo`, matching the location used by Angular's esbuild pipeline.
+
+function getPersistentCachePath(
+  options: NormalizedAngularRspackPluginOptions
+): string | undefined {
+  if (!options.projectName) {
+    return undefined;
+  }
+  const { version } = createRequire(__filename)('@angular/build/package.json');
+  const cachePath = join(
+    workspaceRoot,
+    '.angular',
+    'cache',
+    version,
+    options.projectName
+  );
+  return cachePath;
+}
+
 export class AngularRspackPlugin implements RspackPluginInstance {
   #_options: NormalizedAngularRspackPluginOptions;
   #i18n: I18nOptions | undefined;
@@ -52,7 +73,9 @@ export class AngularRspackPlugin implements RspackPluginInstance {
   ) {
     this.#_options = options;
     this.#i18n = i18nOptions;
-    this.#sourceFileCache = new SourceFileCache();
+    this.#sourceFileCache = new SourceFileCache(
+      getPersistentCachePath(options)
+    );
     this.#javascriptTransformer = new JavaScriptTransformer(
       {
         /**


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->
Clean improvements from https://github.com/nrwl/nx/pull/35282 also included in this PR

## Current Behavior
Angular-rspack is taking longer than esbuild on incremental loads when in in a "watch" state (build --watch and serve). Esbuild is managing its own tsbuild cache to assist transformations on subsequent builds.
While we could set "incremental" and "tsbuildinfo" manually in our tsconfig files, the Angular team has chosen (perhaps wisely so) to segment the tsbuild cache by Angular version, so I've replicated this function.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Tsbuildinfo matching esbuild plugin will be saved in .angular folder
Cold-starts will improve after first build/serve; incremental rebuilds as well

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
** possible fix
Fixes #34936 
