### PR TITLE
feat(core): add --trustThirdPartyPreset flag to skip confirmation prompt

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -290,6 +290,11 @@ export const commandsObject: yargs.Argv<Arguments> = yargs
           .option('template', {
             describe: chalk.dim`GitHub template repository to use. Available templates: nrwl/empty-template, nrwl/react-template, nrwl/angular-template, nrwl/typescript-template`,
             type: 'string',
+          })
+          .option('trustThirdPartyPreset', {
+            describe: chalk.dim`Skip the confirmation prompt when installing a third-party preset. Use this when you trust the preset publisher.`,
+            type: 'boolean',
+            default: false,
           }),
         withNxCloud,
         withUseGitHub,

--- a/packages/create-nx-workspace/src/create-workspace-options.ts
+++ b/packages/create-nx-workspace/src/create-workspace-options.ts
@@ -65,6 +65,12 @@ export interface CreateWorkspaceOptions {
    * @description Enable or disable usage analytics
    */
   analytics?: boolean;
+  /**
+   * @description Trust third-party presets without prompting for confirmation.
+   * Useful for automated workflows where the preset publisher is already trusted.
+   * @default false
+   */
+  trustThirdPartyPreset?: boolean;
 }
 
 export const supportedAgents = [

--- a/packages/create-nx-workspace/src/create-workspace.ts
+++ b/packages/create-nx-workspace/src/create-workspace.ts
@@ -172,7 +172,8 @@ export async function createWorkspace<T extends CreateWorkspaceOptions>(
     if (thirdPartyPackageName) {
       const confirmed = await confirmThirdPartyPreset(
         thirdPartyPackageName,
-        options.interactive
+        options.interactive,
+        options.trustThirdPartyPreset
       );
       if (!confirmed) {
         throw new CnwError(

--- a/packages/create-nx-workspace/src/internal-utils/prompts.spec.ts
+++ b/packages/create-nx-workspace/src/internal-utils/prompts.spec.ts
@@ -18,6 +18,10 @@ jest.mock('enquirer', () => ({
   default: { prompt: jest.fn() },
 }));
 
+jest.mock('../utils/output', () => ({
+  output: { warn: jest.fn(), log: jest.fn() },
+}));
+
 describe('determineTemplate', () => {
   describe('non-interactive mode', () => {
     it('should return nrwl/empty-template when no preset or template is provided', async () => {
@@ -109,5 +113,22 @@ describe('confirmThirdPartyPreset', () => {
       confirmThirdPartyPreset('@my-org/nx-plugin', true)
     ).resolves.toBe(true);
     expect(enquirer.prompt).not.toHaveBeenCalled();
+  });
+
+  it('skips prompt and warning when trusted flag is set', async () => {
+    const { output } = require('../utils/output');
+    await expect(
+      confirmThirdPartyPreset('@my-org/nx-plugin', true, true)
+    ).resolves.toBe(true);
+    expect(enquirer.prompt).not.toHaveBeenCalled();
+    expect(output.warn).not.toHaveBeenCalled();
+  });
+
+  it('still prompts when trusted flag is false', async () => {
+    (enquirer.prompt as jest.Mock).mockResolvedValueOnce({ confirm: 'Yes' });
+    await expect(
+      confirmThirdPartyPreset('@my-org/nx-plugin', true, false)
+    ).resolves.toBe(true);
+    expect(enquirer.prompt).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/create-nx-workspace/src/internal-utils/prompts.ts
+++ b/packages/create-nx-workspace/src/internal-utils/prompts.ts
@@ -253,8 +253,13 @@ export async function determineDefaultBase(
  */
 export async function confirmThirdPartyPreset(
   packageName: string,
-  interactive: boolean | undefined
+  interactive: boolean | undefined,
+  trusted?: boolean
 ): Promise<boolean> {
+  if (trusted) {
+    return true;
+  }
+
   output.warn({
     title: `About to install '${packageName}' from the npm registry as a preset.`,
     bodyLines: [


### PR DESCRIPTION
## Current Behavior

When `create-nx-workspace` is invoked with a third-party preset (e.g. `--preset=@aws/nx-plugin`), a warning and interactive confirmation prompt are always shown — even when the caller is a wrapper CLI that has already established trust on behalf of the user. The only way to bypass this today is `--no-interactive`, which suppresses *all* prompts and still emits the warning to stdout.

## Expected Behavior

Callers that wrap `create-nx-workspace` (such as `pnpm create @aws/nx-workspace`) can pass `--trustThirdPartyPreset` to skip the third-party preset warning and confirmation entirely, without affecting any other interactive prompts.

```bash
npx create-nx-workspace my-project \
  --preset=@aws/nx-plugin \
  --trustThirdPartyPreset
```

## Related Issue(s)

Fixes #35826