### PR TITLE
fix(core): gate nx migrate first-party/third-party modes to Nx v23+ targets

### DIFF
--- a/packages/nx/src/command-line/migrate/command-object.ts
+++ b/packages/nx/src/command-line/migrate/command-object.ts
@@ -144,7 +144,7 @@ function withMigrationOptions(yargs: Argv) {
     })
     .option('mode', {
       describe:
-        "Restrict which packages to migrate. Only applies when migrating Nx itself. 'first-party' processes only Nx and its plugins (the target package plus its nx.packageGroup); 'third-party' processes only the third-party dependencies referenced by Nx packageJsonUpdates entries, catching up on any updates that may have been skipped previously; 'all' processes everything. When targeting Nx in an interactive terminal, prompts for the value if not provided; otherwise defaults to 'all'.",
+        "Restrict which packages to migrate. Only applies when migrating Nx itself. 'first-party' processes only Nx and its plugins (the target package plus its nx.packageGroup); 'third-party' processes only the third-party dependencies referenced by Nx packageJsonUpdates entries, catching up on any updates that may have been skipped previously; 'all' processes everything. The 'first-party' and 'third-party' modes are only available on Nx v23+: 'third-party' requires the workspace to already be on v23+, and 'first-party' requires migrating from v22+ into a v23+ target. When targeting Nx in an interactive terminal, prompts for the value if not provided; otherwise defaults to 'all'.",
       type: 'string',
       choices: MIGRATE_MODES,
     })

--- a/packages/nx/src/command-line/migrate/migrate.spec.ts
+++ b/packages/nx/src/command-line/migrate/migrate.spec.ts
@@ -2116,6 +2116,101 @@ describe('Migration', () => {
       });
     });
 
+    it.each([
+      {
+        desc: 'pre-v22 modern install',
+        installedNx: '21.3.0',
+        installedLegacy: null,
+      },
+      {
+        desc: 'legacy nx (<14) install',
+        installedNx: '13.5.0',
+        installedLegacy: null,
+      },
+      {
+        desc: 'legacy @nrwl/workspace install',
+        installedNx: null,
+        installedLegacy: '13.5.0',
+      },
+      { desc: 'nx not installed', installedNx: null, installedLegacy: null },
+    ])(
+      'should throw for a bare invocation on a pre-v22 install: $desc',
+      async ({ installedNx, installedLegacy }) => {
+        mockGetInstalledNxVersion.mockReturnValue(installedNx);
+        mockGetInstalledLegacyNrwlWorkspaceVersion.mockReturnValue(
+          installedLegacy
+        );
+        await expect(() => parseMigrationsOptions({})).rejects.toThrow(
+          'Provide the package and version to migrate to. E.g., `nx migrate nx@<version>`.'
+        );
+      }
+    );
+
+    it('should resolve the latest dist-tag up front for a bare invocation on v22+', async () => {
+      mockGetInstalledNxVersion.mockReturnValue('22.0.0');
+      jest
+        .spyOn(packageMgrUtils, 'resolvePackageVersionUsingRegistry')
+        .mockResolvedValue('23.1.0');
+      const r = await parseMigrationsOptions({});
+      expect(r).toMatchObject({
+        type: 'generateMigrations',
+        targetPackage: 'nx',
+        targetVersion: '23.1.0',
+      });
+    });
+
+    it('should reject --mode=first-party when the target is below v23', async () => {
+      mockGetInstalledNxVersion.mockReturnValue('22.0.0');
+      await expect(() =>
+        parseMigrationsOptions({
+          packageAndVersion: 'nx@22.7.0',
+          mode: 'first-party',
+        })
+      ).rejects.toThrow(
+        `Error: '--mode=first-party' requires migrating to Nx v23 or later.`
+      );
+    });
+
+    it('should accept --mode=first-party when migrating from v22 into v23', async () => {
+      mockGetInstalledNxVersion.mockReturnValue('22.0.0');
+      const r = await parseMigrationsOptions({
+        packageAndVersion: 'nx@23.0.0',
+        mode: 'first-party',
+      });
+      expect(r).toMatchObject({
+        type: 'generateMigrations',
+        targetPackage: 'nx',
+        targetVersion: '23.0.0',
+        mode: 'first-party',
+      });
+    });
+
+    it('should reject --mode=first-party when the install is more than one major below v23', async () => {
+      mockGetInstalledNxVersion.mockReturnValue('21.0.0');
+      await expect(() =>
+        parseMigrationsOptions({
+          packageAndVersion: 'nx@23.0.0',
+          mode: 'first-party',
+        })
+      ).rejects.toThrow(
+        `Error: '--mode=first-party' requires the workspace to be on Nx v22 or later. Migrate to the latest Nx v22 first, then to v23 or later.`
+      );
+    });
+
+    it('should assume v23+ for a bare --mode=first-party run when the registry is unavailable', async () => {
+      mockGetInstalledNxVersion.mockReturnValue('22.0.0');
+      jest
+        .spyOn(packageMgrUtils, 'resolvePackageVersionUsingRegistry')
+        .mockRejectedValue(new Error('registry down'));
+      const r = await parseMigrationsOptions({ mode: 'first-party' });
+      expect(r).toMatchObject({
+        type: 'generateMigrations',
+        targetPackage: 'nx',
+        targetVersion: 'latest',
+        mode: 'first-party',
+      });
+    });
+
     it('should handle different variations of the target package', async () => {
       const packageRegistryViewSpy = jest
         .spyOn(packageMgrUtils, 'resolvePackageVersionUsingRegistry')
@@ -2326,46 +2421,16 @@ describe('Migration', () => {
       {
         desc: 'bare invocation, modern nx installed',
         positional: undefined,
-        installedNx: '22.5.0',
+        installedNx: '23.5.0',
         installedLegacy: null,
-        expected: { targetPackage: 'nx', targetVersion: '22.5.0' },
-      },
-      {
-        desc: 'bare invocation, only legacy @nrwl/workspace installed',
-        positional: undefined,
-        installedNx: null,
-        installedLegacy: '13.5.0',
-        expected: {
-          targetPackage: '@nrwl/workspace',
-          targetVersion: '13.5.0',
-        },
-      },
-      {
-        desc: 'bare invocation, installed nx is legacy (<14)',
-        positional: undefined,
-        installedNx: '13.5.0',
-        installedLegacy: null,
-        expected: {
-          targetPackage: '@nrwl/workspace',
-          targetVersion: '13.5.0',
-        },
+        expected: { targetPackage: 'nx', targetVersion: '23.5.0' },
       },
       {
         desc: 'bare-package-name positional `nx`, modern nx installed',
         positional: 'nx',
-        installedNx: '22.5.0',
+        installedNx: '23.5.0',
         installedLegacy: null,
-        expected: { targetPackage: 'nx', targetVersion: '22.5.0' },
-      },
-      {
-        desc: 'bare-package-name positional `nx`, installed nx is legacy (<14)',
-        positional: 'nx',
-        installedNx: '13.5.0',
-        installedLegacy: null,
-        expected: {
-          targetPackage: '@nrwl/workspace',
-          targetVersion: '13.5.0',
-        },
+        expected: { targetPackage: 'nx', targetVersion: '23.5.0' },
       },
     ])(
       'should anchor --mode=third-party to installed canonical: $desc',
@@ -2386,6 +2451,37 @@ describe('Migration', () => {
       }
     );
 
+    it.each([
+      {
+        desc: 'pre-v23 modern install',
+        installedNx: '22.5.0',
+        installedLegacy: null,
+      },
+      {
+        desc: 'legacy @nrwl/workspace install',
+        installedNx: null,
+        installedLegacy: '13.5.0',
+      },
+      {
+        desc: 'legacy nx (<14) install',
+        installedNx: '13.5.0',
+        installedLegacy: null,
+      },
+    ])(
+      'should reject --mode=third-party on a pre-v23 install: $desc',
+      async ({ installedNx, installedLegacy }) => {
+        mockGetInstalledNxVersion.mockReturnValue(installedNx);
+        mockGetInstalledLegacyNrwlWorkspaceVersion.mockReturnValue(
+          installedLegacy
+        );
+        await expect(() =>
+          parseMigrationsOptions({ mode: 'third-party' })
+        ).rejects.toThrow(
+          `Error: '--mode=third-party' requires the workspace to be on Nx v23 or later.`
+        );
+      }
+    );
+
     it('should reject --mode=third-party when nx is not installed', async () => {
       mockGetInstalledNxVersion.mockReturnValue(null);
       await expect(() =>
@@ -2396,27 +2492,27 @@ describe('Migration', () => {
     });
 
     it('should reject --mode=third-party when target is higher than installed', async () => {
-      mockGetInstalledNxVersion.mockReturnValue('22.0.0');
+      mockGetInstalledNxVersion.mockReturnValue('23.0.0');
       await expect(() =>
         parseMigrationsOptions({
-          packageAndVersion: 'nx@23.0.0',
+          packageAndVersion: 'nx@24.0.0',
           mode: 'third-party',
         })
       ).rejects.toThrow(
-        `Error: '--mode=third-party' cannot migrate to a version higher than what is currently installed (got 'nx@23.0.0', installed 'nx@22.0.0').`
+        `Error: '--mode=third-party' cannot migrate to a version higher than what is currently installed (got 'nx@24.0.0', installed 'nx@23.0.0').`
       );
     });
 
     it('should accept --mode=third-party when target is lower than installed', async () => {
-      mockGetInstalledNxVersion.mockReturnValue('22.5.0');
+      mockGetInstalledNxVersion.mockReturnValue('23.5.0');
       const r = await parseMigrationsOptions({
-        packageAndVersion: 'nx@22.0.0',
+        packageAndVersion: 'nx@23.0.0',
         mode: 'third-party',
       });
       expect(r).toMatchObject({
         type: 'generateMigrations',
         targetPackage: 'nx',
-        targetVersion: '22.0.0',
+        targetVersion: '23.0.0',
         mode: 'third-party',
       });
     });
@@ -2426,15 +2522,15 @@ describe('Migration', () => {
       // silent `@nx/workspace` → `nx` swap happens later in
       // `generateMigrationsJsonAndUpdatePackageJson` via
       // `resolveCanonicalNxPackage`.
-      mockGetInstalledNxVersion.mockReturnValue('22.0.0');
+      mockGetInstalledNxVersion.mockReturnValue('23.0.0');
       const r = await parseMigrationsOptions({
-        packageAndVersion: '@nx/workspace@22.0.0',
+        packageAndVersion: '@nx/workspace@23.0.0',
         mode: 'third-party',
       });
       expect(r).toMatchObject({
         type: 'generateMigrations',
         targetPackage: '@nx/workspace',
-        targetVersion: '22.0.0',
+        targetVersion: '23.0.0',
         mode: 'third-party',
       });
       expect(
@@ -2445,61 +2541,61 @@ describe('Migration', () => {
     });
 
     it('should reject --mode=third-party with --to canonical higher than installed', async () => {
-      mockGetInstalledNxVersion.mockReturnValue('22.0.0');
+      mockGetInstalledNxVersion.mockReturnValue('23.0.0');
       await expect(() =>
         parseMigrationsOptions({
-          packageAndVersion: 'nx@22.0.0',
+          packageAndVersion: 'nx@23.0.0',
           mode: 'third-party',
-          to: 'nx@23.0.0',
+          to: 'nx@24.0.0',
         })
       ).rejects.toThrow(
-        `Error: '--mode=third-party' cannot migrate to a version higher than what is currently installed (got '--to nx@23.0.0', installed 'nx@22.0.0').`
+        `Error: '--mode=third-party' cannot migrate to a version higher than what is currently installed (got '--to nx@24.0.0', installed 'nx@23.0.0').`
       );
     });
 
     it('should reject --mode=third-party with --to for first-party plugins higher than installed', async () => {
-      mockGetInstalledNxVersion.mockReturnValue('22.0.0');
+      mockGetInstalledNxVersion.mockReturnValue('23.0.0');
       await expect(() =>
         parseMigrationsOptions({
-          packageAndVersion: 'nx@22.0.0',
+          packageAndVersion: 'nx@23.0.0',
           mode: 'third-party',
-          to: '@nx/js@22.6.4',
+          to: '@nx/js@23.6.4',
         })
       ).rejects.toThrow(
-        `Error: '--mode=third-party' cannot migrate to a version higher than what is currently installed (got '--to @nx/js@22.6.4', installed 'nx@22.0.0').`
+        `Error: '--mode=third-party' cannot migrate to a version higher than what is currently installed (got '--to @nx/js@23.6.4', installed 'nx@23.0.0').`
       );
     });
 
     it('should reject --mode=third-party with --to create-nx-workspace higher than installed', async () => {
-      mockGetInstalledNxVersion.mockReturnValue('22.0.0');
+      mockGetInstalledNxVersion.mockReturnValue('23.0.0');
       await expect(() =>
         parseMigrationsOptions({
-          packageAndVersion: 'nx@22.0.0',
+          packageAndVersion: 'nx@23.0.0',
           mode: 'third-party',
-          to: 'create-nx-workspace@22.6.4',
+          to: 'create-nx-workspace@23.6.4',
         })
       ).rejects.toThrow(
-        `Error: '--mode=third-party' cannot migrate to a version higher than what is currently installed (got '--to create-nx-workspace@22.6.4', installed 'nx@22.0.0').`
+        `Error: '--mode=third-party' cannot migrate to a version higher than what is currently installed (got '--to create-nx-workspace@23.6.4', installed 'nx@23.0.0').`
       );
     });
 
     it('should reject --mode=third-party with --to @nx/workspace higher than installed', async () => {
-      mockGetInstalledNxVersion.mockReturnValue('22.0.0');
+      mockGetInstalledNxVersion.mockReturnValue('23.0.0');
       await expect(() =>
         parseMigrationsOptions({
-          packageAndVersion: 'nx@22.0.0',
+          packageAndVersion: 'nx@23.0.0',
           mode: 'third-party',
-          to: '@nx/workspace@23.0.0',
+          to: '@nx/workspace@24.0.0',
         })
       ).rejects.toThrow(
-        `Error: '--mode=third-party' cannot migrate to a version higher than what is currently installed (got '--to @nx/workspace@23.0.0', installed 'nx@22.0.0').`
+        `Error: '--mode=third-party' cannot migrate to a version higher than what is currently installed (got '--to @nx/workspace@24.0.0', installed 'nx@23.0.0').`
       );
     });
 
     it('should accept --mode=third-party with --to for non-canonical packages', async () => {
-      mockGetInstalledNxVersion.mockReturnValue('22.0.0');
+      mockGetInstalledNxVersion.mockReturnValue('23.0.0');
       const r = await parseMigrationsOptions({
-        packageAndVersion: 'nx@22.0.0',
+        packageAndVersion: 'nx@23.0.0',
         mode: 'third-party',
         to: 'react@18.0.0',
       });
@@ -2507,32 +2603,6 @@ describe('Migration', () => {
         type: 'generateMigrations',
         mode: 'third-party',
         to: { react: '18.0.0' },
-      });
-    });
-
-    it('should reject --mode=third-party for legacy target when @nrwl/workspace is not installed', async () => {
-      mockGetInstalledLegacyNrwlWorkspaceVersion.mockReturnValue(null);
-      await expect(() =>
-        parseMigrationsOptions({
-          packageAndVersion: '@nrwl/workspace@13.0.0',
-          mode: 'third-party',
-        })
-      ).rejects.toThrow(
-        `Error: '--mode=third-party' requires '@nrwl/workspace' to be installed in your workspace.`
-      );
-    });
-
-    it('should accept --mode=third-party for legacy target when @nrwl/workspace is installed', async () => {
-      mockGetInstalledLegacyNrwlWorkspaceVersion.mockReturnValue('13.5.0');
-      const r = await parseMigrationsOptions({
-        packageAndVersion: '@nrwl/workspace@13.0.0',
-        mode: 'third-party',
-      });
-      expect(r).toMatchObject({
-        type: 'generateMigrations',
-        targetPackage: '@nrwl/workspace',
-        targetVersion: '13.0.0',
-        mode: 'third-party',
       });
     });
 
@@ -2681,7 +2751,7 @@ describe('Migration', () => {
       it('applies nx.json migrate.mode through the overlay for an Nx target', async () => {
         const result = await parseMigrationsOptions(
           applyNxJsonMigrateDefaults(
-            { packageAndVersion: 'nx@22.0.0' },
+            { packageAndVersion: 'nx@23.0.0' },
             { mode: 'first-party' }
           )
         );
@@ -2716,15 +2786,64 @@ describe('Migration', () => {
       });
     });
 
+    const v23Context = {
+      hasFrom: false,
+      hasExcludeAppliedMigrations: false,
+      installedMajor: 23,
+      isV23Plus: true,
+    };
+
     it('should return the provided mode without prompting', async () => {
       Object.defineProperty(process.stdin, 'isTTY', {
         value: true,
         configurable: true,
       });
       process.env.CI = 'false';
-      const result = await resolveMode('first-party', 'nx', '22.0.0');
+      const result = await resolveMode(
+        'first-party',
+        'nx',
+        '23.0.0',
+        v23Context
+      );
       expect(result).toBe('first-party');
       expect(mockPrompt).not.toHaveBeenCalled();
+    });
+
+    it('should reject --mode=first-party when not migrating to v23+', async () => {
+      await expect(() =>
+        resolveMode('first-party', 'nx', '22.7.0', {
+          hasFrom: false,
+          hasExcludeAppliedMigrations: false,
+          installedMajor: 22,
+          isV23Plus: false,
+        })
+      ).rejects.toThrow(
+        `Error: '--mode=first-party' requires migrating to Nx v23 or later.`
+      );
+    });
+
+    it('should reject --mode=third-party when the workspace is below v23', async () => {
+      await expect(() =>
+        resolveMode('third-party', 'nx', '22.0.0', {
+          hasFrom: false,
+          hasExcludeAppliedMigrations: false,
+          installedMajor: 22,
+          isV23Plus: false,
+        })
+      ).rejects.toThrow(
+        `Error: '--mode=third-party' requires the workspace to be on Nx v23 or later.`
+      );
+    });
+
+    it('should not apply the v23 gate to --mode=third-party when the installed version is unknown', async () => {
+      // The downstream "requires nx to be installed" check handles this case.
+      const result = await resolveMode('third-party', 'nx', 'latest', {
+        hasFrom: false,
+        hasExcludeAppliedMigrations: false,
+        installedMajor: null,
+        isV23Plus: false,
+      });
+      expect(result).toBe('third-party');
     });
 
     it('should default to "all" without prompting in non-TTY environments', async () => {
@@ -2733,7 +2852,7 @@ describe('Migration', () => {
         configurable: true,
       });
       process.env.CI = 'false';
-      const result = await resolveMode(undefined, 'nx', '22.0.0');
+      const result = await resolveMode(undefined, 'nx', '23.0.0', v23Context);
       expect(result).toBe('all');
       expect(mockPrompt).not.toHaveBeenCalled();
     });
@@ -2744,7 +2863,7 @@ describe('Migration', () => {
         configurable: true,
       });
       process.env.CI = 'true';
-      const result = await resolveMode(undefined, 'nx', '22.0.0');
+      const result = await resolveMode(undefined, 'nx', '23.0.0', v23Context);
       expect(result).toBe('all');
       expect(mockPrompt).not.toHaveBeenCalled();
     });
@@ -2755,7 +2874,28 @@ describe('Migration', () => {
         configurable: true,
       });
       process.env.CI = 'false';
-      const result = await resolveMode(undefined, '@nx/react', '22.0.0');
+      const result = await resolveMode(
+        undefined,
+        '@nx/react',
+        '23.0.0',
+        v23Context
+      );
+      expect(result).toBe('all');
+      expect(mockPrompt).not.toHaveBeenCalled();
+    });
+
+    it('should default to "all" without prompting when the v23 functionality is unavailable', async () => {
+      Object.defineProperty(process.stdin, 'isTTY', {
+        value: true,
+        configurable: true,
+      });
+      process.env.CI = 'false';
+      const result = await resolveMode(undefined, 'nx', '22.7.0', {
+        hasFrom: false,
+        hasExcludeAppliedMigrations: false,
+        installedMajor: 22,
+        isV23Plus: false,
+      });
       expect(result).toBe('all');
       expect(mockPrompt).not.toHaveBeenCalled();
     });
@@ -2767,7 +2907,7 @@ describe('Migration', () => {
       });
       process.env.CI = 'false';
       mockPrompt.mockReturnValueOnce(Promise.resolve({ mode: 'first-party' }));
-      const result = await resolveMode(undefined, 'nx', '22.0.0');
+      const result = await resolveMode(undefined, 'nx', '23.0.0', v23Context);
       expect(result).toBe('first-party');
       expect(mockPrompt).toHaveBeenCalled();
     });
@@ -2779,11 +2919,31 @@ describe('Migration', () => {
       });
       process.env.CI = 'false';
       mockPrompt.mockReturnValueOnce(Promise.resolve({ mode: 'all' }));
-      await resolveMode(undefined, 'nx', '22.0.0');
+      await resolveMode(undefined, 'nx', '23.0.0', v23Context);
       const choices = mockPrompt.mock.calls[0][0].choices;
       expect(choices.map((c: { name: string }) => c.name)).toEqual([
         'first-party',
         'third-party',
+        'all',
+      ]);
+    });
+
+    it('should omit third-party from prompt choices when the workspace is on v22', async () => {
+      Object.defineProperty(process.stdin, 'isTTY', {
+        value: true,
+        configurable: true,
+      });
+      process.env.CI = 'false';
+      mockPrompt.mockReturnValueOnce(Promise.resolve({ mode: 'all' }));
+      await resolveMode(undefined, 'nx', '23.0.0', {
+        hasFrom: false,
+        hasExcludeAppliedMigrations: false,
+        installedMajor: 22,
+        isV23Plus: true,
+      });
+      const choices = mockPrompt.mock.calls[0][0].choices;
+      expect(choices.map((c: { name: string }) => c.name)).toEqual([
+        'first-party',
         'all',
       ]);
     });
@@ -2795,9 +2955,11 @@ describe('Migration', () => {
       });
       process.env.CI = 'false';
       mockPrompt.mockReturnValueOnce(Promise.resolve({ mode: 'all' }));
-      await resolveMode(undefined, 'nx', '22.0.0', {
+      await resolveMode(undefined, 'nx', '23.0.0', {
         hasFrom: true,
         hasExcludeAppliedMigrations: false,
+        installedMajor: 23,
+        isV23Plus: true,
       });
       const choices = mockPrompt.mock.calls[0][0].choices;
       expect(choices.map((c: { name: string }) => c.name)).toEqual([
@@ -2813,9 +2975,11 @@ describe('Migration', () => {
       });
       process.env.CI = 'false';
       mockPrompt.mockReturnValueOnce(Promise.resolve({ mode: 'all' }));
-      await resolveMode(undefined, 'nx', '22.0.0', {
+      await resolveMode(undefined, 'nx', '23.0.0', {
         hasFrom: false,
         hasExcludeAppliedMigrations: true,
+        installedMajor: 23,
+        isV23Plus: true,
       });
       const choices = mockPrompt.mock.calls[0][0].choices;
       expect(choices.map((c: { name: string }) => c.name)).toEqual([
@@ -2833,8 +2997,8 @@ describe('Migration', () => {
       const result = await resolveMode(
         undefined,
         'nx',
-        '22.0.0',
-        undefined,
+        '23.0.0',
+        v23Context,
         'first-party'
       );
       expect(result).toBe('first-party');
@@ -2850,12 +3014,65 @@ describe('Migration', () => {
       const result = await resolveMode(
         undefined,
         'nx',
-        '22.0.0',
-        undefined,
+        '23.0.0',
+        v23Context,
         'first-party'
       );
       expect(result).toBe('first-party');
       expect(mockPrompt).not.toHaveBeenCalled();
+    });
+
+    it('falls back to "all" and warns when the configured mode is unavailable', async () => {
+      Object.defineProperty(process.stdin, 'isTTY', {
+        value: true,
+        configurable: true,
+      });
+      process.env.CI = 'false';
+      const warnSpy = jest
+        .spyOn(require('../../utils/output').output, 'warn')
+        .mockImplementation(() => {});
+      const result = await resolveMode(
+        undefined,
+        'nx',
+        '22.7.0',
+        {
+          hasFrom: false,
+          hasExcludeAppliedMigrations: false,
+          installedMajor: 22,
+          isV23Plus: false,
+        },
+        'first-party'
+      );
+      expect(result).toBe('all');
+      expect(mockPrompt).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: expect.stringContaining(
+            `nx.json migrate.mode 'first-party' is not available`
+          ),
+        })
+      );
+    });
+
+    it('honors a configured "all" even when first-party/third-party are unavailable', async () => {
+      Object.defineProperty(process.stdin, 'isTTY', {
+        value: true,
+        configurable: true,
+      });
+      process.env.CI = 'false';
+      const warnSpy = jest
+        .spyOn(require('../../utils/output').output, 'warn')
+        .mockImplementation(() => {});
+      const result = await resolveMode(
+        undefined,
+        'nx',
+        '22.0.0',
+        undefined,
+        'all'
+      );
+      expect(result).toBe('all');
+      expect(mockPrompt).not.toHaveBeenCalled();
+      expect(warnSpy).not.toHaveBeenCalled();
     });
 
     it('lets an explicit mode win over the nx.json configured mode', async () => {
@@ -3272,6 +3489,52 @@ describe('Migration', () => {
       expect(choices.map((c) => c.name)).toEqual(['22.5.3', '23.1.0']);
     });
 
+    it('should omit the current-major (v22) step from the multi-major prompt', async () => {
+      setTty(true);
+      mockGetInstalledNxVersion.mockReturnValue('22.0.0');
+      mockRegistry({
+        latest: '24.1.0',
+        '22': '22.5.3',
+        '23': '23.5.3',
+      });
+      mockPrompt.mockResolvedValue({ chosen: '23.5.3' });
+
+      await parseMigrationsOptions({
+        packageAndVersion: 'latest',
+        mode: 'all',
+      });
+
+      const promptArgs = mockPrompt.mock.calls[0][0];
+      const choices = promptArgs.choices as { name: string }[];
+      // The 22.x current-major step is suppressed; only next-major and direct.
+      expect(choices.map((c) => c.name)).toEqual(['23.5.3', '24.1.0']);
+    });
+
+    it('should keep --mode=first-party valid when multi-major redirects to the next major (v22 install)', async () => {
+      // Mode is resolved before multi-major; suppressing the v22 step guarantees
+      // every multi-major option stays >= v23, so a first-party selection can't
+      // be invalidated by the redirect.
+      setTty(true);
+      mockGetInstalledNxVersion.mockReturnValue('22.0.0');
+      mockRegistry({
+        latest: '24.1.0',
+        '22': '22.5.3',
+        '23': '23.5.3',
+      });
+      mockPrompt.mockResolvedValue({ chosen: '23.5.3' });
+
+      const r = await parseMigrationsOptions({
+        packageAndVersion: 'nx@24.0.0',
+        mode: 'first-party',
+      });
+
+      expect(r).toMatchObject({
+        type: 'generateMigrations',
+        mode: 'first-party',
+        targetVersion: '23.5.3',
+      });
+    });
+
     it('should prompt (not warn) when target was explicitly typed as numeric semver', async () => {
       setTty(true);
       mockRegistry({
@@ -3444,26 +3707,27 @@ describe('Migration', () => {
 
     it('should bypass --multi-major-mode=gradual when --mode=third-party', async () => {
       setTty(true);
-      // third-party anchors at the installed canonical (here 21.0.0) and
+      mockGetInstalledNxVersion.mockReturnValue('23.0.0');
+      // third-party anchors at the installed canonical (here 23.0.0) and
       // must not be redirected to an incremental target. `maybePromptOrWarn…`
       // early-returns on `mode === 'third-party'` before consulting gradual,
       // so the flag is accepted but is a no-op.
       mockRegistry({
-        latest: '23.1.0',
-        '21': '21.5.3',
-        '22': '22.5.3',
+        latest: '25.1.0',
+        '23': '23.5.3',
+        '24': '24.5.3',
       });
       const warnSpy = spyWarn();
 
       const r = await parseMigrationsOptions({
-        packageAndVersion: 'nx@21.0.0',
+        packageAndVersion: 'nx@23.0.0',
         mode: 'third-party',
         multiMajorMode: 'gradual',
       });
 
       expect(mockPrompt).not.toHaveBeenCalled();
       expect(warnSpy).not.toHaveBeenCalled();
-      expect(r).toMatchObject({ targetVersion: '21.0.0' });
+      expect(r).toMatchObject({ targetVersion: '23.0.0' });
     });
 
     it('should not prompt or warn when delta is exactly 1 major', async () => {
@@ -3499,6 +3763,7 @@ describe('Migration', () => {
 
     it('should not prompt or warn for --mode=third-party', async () => {
       setTty(true);
+      mockGetInstalledNxVersion.mockReturnValue('23.0.0');
       const warnSpy = spyWarn();
 
       const r = await parseMigrationsOptions({ mode: 'third-party' });

--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -949,37 +949,98 @@ export async function resolveMode(
   mode: MigrateMode | undefined,
   targetPackage: string,
   targetVersion: string,
-  context: { hasFrom: boolean; hasExcludeAppliedMigrations: boolean } = {
+  context: {
+    hasFrom: boolean;
+    hasExcludeAppliedMigrations: boolean;
+    installedMajor?: number | null;
+    isV23Plus?: boolean;
+  } = {
     hasFrom: false,
     hasExcludeAppliedMigrations: false,
   },
   configuredMode?: MigrateMode
 ): Promise<MigrateMode> {
+  // The first-party/third-party split relies on migration metadata that only
+  // exists in Nx v23+. `first-party` needs a v22+ install migrating into a v23+
+  // target; `third-party` catches up deps a prior first-party migration
+  // deferred, so it needs the workspace already on v23+.
+  const installedMajor = context.installedMajor ?? null;
+  const firstPartyAvailable =
+    installedMajor !== null &&
+    installedMajor >= 22 &&
+    context.isV23Plus === true;
+  const thirdPartyAvailable = installedMajor !== null && installedMajor >= 23;
+
   if (mode) {
+    if (isNxEquivalentTarget(targetPackage, targetVersion)) {
+      if (mode === 'first-party' && !firstPartyAvailable) {
+        if (context.isV23Plus !== true) {
+          throw new Error(
+            `Error: '--mode=first-party' requires migrating to Nx v23 or later.`
+          );
+        }
+        throw new Error(
+          `Error: '--mode=first-party' requires the workspace to be on Nx v22 or later. Migrate to the latest Nx v22 first, then to v23 or later.`
+        );
+      }
+      // When the installed version is unknown, defer to the downstream
+      // "requires nx to be installed" check rather than the v23 gate.
+      if (
+        mode === 'third-party' &&
+        installedMajor !== null &&
+        !thirdPartyAvailable
+      ) {
+        throw new Error(
+          `Error: '--mode=third-party' requires the workspace to be on Nx v23 or later.`
+        );
+      }
+    }
     return mode;
   }
   if (!isNxEquivalentTarget(targetPackage, targetVersion)) {
     return 'all';
   }
-  // nx.json `migrate.mode` pre-selects the value the interactive prompt would
-  // ask for; it applies only to Nx targets (non-Nx returned 'all' above).
+  // nx.json `migrate.mode` pre-selects the prompt answer (Nx targets only; non-Nx
+  // returned 'all' above). Honor it only when the v23+ gate makes that mode
+  // available; otherwise warn and fall back to the always-valid 'all'.
   if (configuredMode) {
-    return configuredMode;
-  }
-  if (!process.stdin.isTTY || isCI()) {
+    const configuredAvailable =
+      configuredMode === 'all' ||
+      (configuredMode === 'first-party' && firstPartyAvailable) ||
+      (configuredMode === 'third-party' && thirdPartyAvailable);
+    if (configuredAvailable) {
+      return configuredMode;
+    }
+    output.warn({
+      title: `The configured nx.json migrate.mode '${configuredMode}' is not available for this migration; falling back to 'all'.`,
+      bodyLines: [
+        `The 'first-party' and 'third-party' modes require Nx v23 or later.`,
+      ],
+    });
     return 'all';
   }
-  const choices: { name: string; message: string }[] = [
-    {
+  const choices: { name: string; message: string }[] = [];
+  if (firstPartyAvailable) {
+    choices.push({
       name: 'first-party',
       message: 'First-party only (Nx and its official packages)',
-    },
-  ];
-  if (!context.hasFrom && !context.hasExcludeAppliedMigrations) {
+    });
+  }
+  if (
+    thirdPartyAvailable &&
+    !context.hasFrom &&
+    !context.hasExcludeAppliedMigrations
+  ) {
     choices.push({
       name: 'third-party',
       message: 'Third-party only (deps managed by Nx)',
     });
+  }
+  if (!choices.length) {
+    return 'all';
+  }
+  if (!process.stdin.isTTY || isCI()) {
+    return 'all';
   }
   choices.push({
     name: 'all',
@@ -1203,9 +1264,11 @@ function assertThirdPartyModeFlagCompatibility(options: {
   }
 }
 
-// Defaults target package/version mode-aware (third-party → installed
-// canonical, otherwise nx@latest) and enforces the era gate when --mode
-// is explicit.
+// Resolves the target package/version up front (third-party → installed
+// canonical; otherwise resolves dist-tags so the v23 mode gate reads a concrete
+// major), then resolves the mode and enforces the era gate when --mode is
+// explicit. Bare invocations on a pre-v22 install throw rather than defaulting
+// to `latest` across the major gap into the v23 era.
 async function resolveTargetAndMode(args: {
   positional: string | undefined;
   from: Record<string, string>;
@@ -1229,11 +1292,56 @@ async function resolveTargetAndMode(args: {
     targetVersion = parsed.targetVersion;
   }
 
-  // Resolve mode before defaulting target so the default can depend on the
-  // resolved mode (third-party defaults to nx@<installed>; otherwise nx@latest).
-  // For bare invocation, `targetPackage='nx'` and `targetVersion='latest'` are
-  // safe sentinels: `isNxEquivalentTarget` treats the literal `'latest'` as
-  // modern era (semver `lt('latest', '14.0.0-beta.0')` is false).
+  const installed = resolveInstalledCanonical();
+  const installedMajor =
+    installed && valid(installed.version) ? major(installed.version) : null;
+
+  // `--mode=third-party` anchors the target to the installed version below, so
+  // it never needs a target or dist-tag resolved up front.
+  const isExplicitThirdParty = options.mode === 'third-party';
+
+  // Bare invocation: restore the requirement to specify a target when on a
+  // pre-v23 install. We can't safely default to `latest` across the major gap
+  // into the new era, and the first-party/third-party functionality isn't
+  // available there anyway.
+  if (!positional && !isExplicitThirdParty) {
+    if (installedMajor === null || installedMajor < 22) {
+      throw new Error(
+        `Provide the package and version to migrate to. E.g., \`nx migrate nx@<version>\`.`
+      );
+    }
+    targetPackage = 'nx';
+    targetVersion = 'latest';
+  }
+
+  // Explicit dist-tags arrive already resolved from
+  // `parseTargetPackageAndVersion`; only bare invocations and bare package
+  // names (`nx migrate nx`) reach here unresolved.
+  let isV23Plus = false;
+  if (
+    !isExplicitThirdParty &&
+    isNxEquivalentTarget(targetPackage!, targetVersion!)
+  ) {
+    if (targetVersion && valid(targetVersion)) {
+      isV23Plus = major(targetVersion) >= 23;
+    } else {
+      // Resolving the dist-tag here (rather than only in the multi-major check
+      // as before) just moves the single registry round-trip earlier — the
+      // multi-major check short-circuits on the now-concrete version.
+      const tag = targetVersion!;
+      try {
+        targetVersion = await normalizeVersionWithTagCheck(targetPackage!, tag);
+        isV23Plus = valid(targetVersion) ? major(targetVersion) >= 23 : true;
+      } catch {
+        // Registry unavailable: assume dist-tags resolve to >= v23 (true once
+        // v23 is released) so the gate stays sensible. The retained sentinel
+        // still degrades gracefully downstream (multi-major and the cascade).
+        targetVersion = tag;
+        isV23Plus = true;
+      }
+    }
+  }
+
   const mode = await resolveMode(
     options.mode,
     targetPackage ?? 'nx',
@@ -1241,6 +1349,8 @@ async function resolveTargetAndMode(args: {
     {
       hasFrom: Object.keys(from).length > 0,
       hasExcludeAppliedMigrations: options.excludeAppliedMigrations === true,
+      installedMajor,
+      isV23Plus,
     },
     options.modeFromConfig
   );
@@ -1253,7 +1363,6 @@ async function resolveTargetAndMode(args: {
   // the literal `'latest'` that `parseTargetPackageAndVersion` emits for bare
   // package names.
   if (mode === 'third-party' && (!positional || !valid(targetVersion!))) {
-    const installed = resolveInstalledCanonical();
     if (!installed) {
       throw new Error(
         `Error: '--mode=third-party' requires 'nx' (or '@nrwl/workspace' on Nx <14) to be installed in your workspace. Install dependencies first, then re-run.`
@@ -1262,14 +1371,6 @@ async function resolveTargetAndMode(args: {
     installedNxVersion = installed.version;
     targetPackage = installed.canonical;
     targetVersion = installed.version;
-  } else if (!positional) {
-    // Bare invocation: default to `nx@latest` as a literal sentinel rather
-    // than resolving via the registry here. Multi-major resolves the dist-tag
-    // when needed (and bails gracefully on registry failure), and the cascade
-    // resolves it for the walk (honouring `NX_MIGRATE_SKIP_REGISTRY_FETCH`).
-    // This matches the resilience of `nx migrate nx`.
-    targetPackage = 'nx';
-    targetVersion = 'latest';
   }
 
   if (options.mode && !isNxEquivalentTarget(targetPackage!, targetVersion!)) {

--- a/packages/nx/src/command-line/migrate/multi-major.ts
+++ b/packages/nx/src/command-line/migrate/multi-major.ts
@@ -223,8 +223,11 @@ export async function maybePromptOrWarnMultiMajorMigration(args: {
     resolveLatestStableInMajor(targetPackage, installedMajor + 1),
   ]);
   // Only suggest the current-major latest when there's at least a minor
-  // delta — a same-minor patch bump isn't a meaningful incremental step.
+  // delta — a same-minor patch bump isn't a meaningful incremental step. Skip
+  // major 22 (last pre-v23) entirely: a 22.x step is the only sub-v23 option
+  // and conflicts with the mode gate already decided against the v23+ target.
   const showCurrent =
+    installedMajor !== 22 &&
     latestInCurrent &&
     gt(latestInCurrent, installed) &&
     minor(latestInCurrent) > minor(installed)


### PR DESCRIPTION
## Current Behavior

The recently added `nx migrate --mode` flag (`first-party` / `third-party`) is offered and accepted regardless of the versions involved. These modes rely on migration metadata that only exists in Nx v23+, so running them against pre-v23 targets produces incorrect results. In addition, a bare `nx migrate` defaults to `nx@latest` even from old installs, and the multi-major prompt can offer a v22.x step that would invalidate an already-selected mode.

## Expected Behavior

The modes are gated to where the metadata exists, and the surrounding flow is made safe:

- `first-party` is offered/accepted only when migrating from Nx v22+ into a v23+ target.
- `third-party` only when the workspace is already on v23+.
- The target version (including `latest`/dist-tags) is resolved before the mode is decided, so the gate reads a concrete major.
- A bare `nx migrate` on a pre-v22 install again requires an explicit target instead of defaulting to `latest`.
- The multi-major prompt no longer offers a v22.x step, so a selected mode can't be invalidated by a redirect below v23.

When the functionality isn't available, `nx migrate` falls back to migrating all packages, matching prior behavior.

## Implementation Details

- The gate predicate lives in `resolveMode`: `first-party` requires `installedMajor >= 22` and a v23+ target; `third-party` requires `installedMajor >= 23`. An explicit `--mode` on an unavailable combination throws with an actionable message; the interactive prompt only offers the available modes (and falls back to `all` when none).
- `resolveTargetAndMode` resolves dist-tag targets up front. This moves the single existing registry round-trip earlier — the multi-major check then short-circuits on the concrete version. On registry failure for a bare sentinel it assumes >= v23 so the gate stays sensible and still degrades gracefully downstream.
- `multi-major.ts` suppresses the v22.x current-major step rather than reordering the mode / multi-major flow.

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/nxc-4493-b48693de)
<!-- polygraph-session-end -->