### PR TITLE
feat(core): add a migrate configuration section to nx.json

### DIFF
--- a/astro-docs/src/content/docs/reference/nx-json.mdoc
+++ b/astro-docs/src/content/docs/reference/nx-json.mdoc
@@ -71,6 +71,9 @@ The following is an expanded example showing all options. Your `nx.json` will li
   "sync": {
     "globalGenerators": ["my-plugin:my-sync-generator"]
   },
+  "migrate": {
+    "createCommits": true
+  },
   "generators": {
     "@nx/js:library": {
       "buildable": true
@@ -969,6 +972,33 @@ These are global configuration options for the [`nx sync`](/docs/reference/nx-co
 | **globalGenerators**           | Sync generators that are only run when the `nx sync` command is executed. These are not associated with a particular task.                                                                                                                                                                   |
 | **generatorOptions**           | Options to be passed to sync generators                                                                                                                                                                                                                                                      |
 | **disabledTaskSyncGenerators** | Globally disable specific task sync generators                                                                                                                                                                                                                                               |
+
+## Migrate
+
+These are workspace-wide defaults for the [`nx migrate`](/docs/reference/nx-commands#nx-migrate) command. Each option mirrors an `nx migrate` flag, so you can set a value once instead of passing the flag on every run. A flag passed on the command line always takes precedence over the value in `nx.json`.
+
+`mode` and `multiMajorMode` apply when generating migrations (`nx migrate <target>`); the rest apply when running them (`nx migrate --run-migrations`).
+
+```jsonc
+// nx.json
+{
+  "migrate": {
+    "createCommits": true,
+    "commitPrefix": "chore(repo): apply nx migration ",
+    "multiMajorMode": "direct",
+    "agentic": "claude-code",
+  },
+}
+```
+
+| Property           | Description                                                                                                                                                                                                                                                                                 |
+| ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **createCommits**  | Whether to automatically create a git commit after each migration runs. Equivalent to `--create-commits`. Defaults to `false`.                                                                                                                                                              |
+| **commitPrefix**   | Commit message prefix applied to each migration commit when commits are enabled. Equivalent to `--commit-prefix`. Defaults to `"chore: [nx migration] "`.                                                                                                                                   |
+| **mode**           | Restricts which packages to migrate when migrating Nx itself: `first-party` (Nx and its plugins), `third-party` (the third-party dependencies referenced by Nx), or `all`. Equivalent to `--mode`. Defaults to `all`.                                                                       |
+| **multiMajorMode** | How to handle a migration that crosses more than one major version: `direct` (migrate straight to the target) or `gradual` (migrate to the smallest recommended step). Equivalent to `--multi-major-mode`. The `NX_MULTI_MAJOR_MODE` environment variable takes precedence over this value. |
+| **agentic**        | Default for the agentic flow used by `nx migrate --run-migrations`: `false` (never use it), `true` (use it and resolve the installed agent), or an agent id (`"claude-code"`, `"codex"`, `"opencode"`) to always use that agent. Equivalent to `--agentic`.                                 |
+| **validate**       | Whether to run agent-driven validation after generator-only migrations when the agentic flow is enabled. Equivalent to `--validate`. Defaults to `true` when the agentic flow is enabled.                                                                                                   |
 
 ## Generators
 

--- a/e2e/nx/src/misc.test.ts
+++ b/e2e/nx/src/misc.test.ts
@@ -1040,7 +1040,7 @@ describe('migrate', () => {
     );
 
     expect(output).toContain(
-      `Error: Providing a custom commit prefix requires --create-commits to be enabled`
+      `A custom migrate commit prefix requires commits to be enabled`
     );
   });
 

--- a/packages/nx/schemas/nx-schema.json
+++ b/packages/nx/schemas/nx-schema.json
@@ -421,6 +421,47 @@
       },
       "additionalProperties": false
     },
+    "migrate": {
+      "type": "object",
+      "description": "Configuration for the `nx migrate` command",
+      "properties": {
+        "createCommits": {
+          "type": "boolean",
+          "description": "Whether to automatically create a git commit after each migration runs. Equivalent to the `--create-commits` flag. Defaults to `false`."
+        },
+        "commitPrefix": {
+          "type": "string",
+          "description": "Commit message prefix applied to each migration commit when commits are enabled. Equivalent to the `--commit-prefix` flag. Defaults to `\"chore: [nx migration] \"`."
+        },
+        "mode": {
+          "type": "string",
+          "enum": ["first-party", "third-party", "all"],
+          "description": "Restricts which packages to migrate when migrating Nx itself. Equivalent to the `--mode` flag. Defaults to `all`."
+        },
+        "multiMajorMode": {
+          "type": "string",
+          "enum": ["direct", "gradual"],
+          "description": "How to handle a migration that crosses more than one major version. Equivalent to the `--multi-major-mode` flag. The `NX_MULTI_MAJOR_MODE` environment variable takes precedence over this setting."
+        },
+        "agentic": {
+          "oneOf": [
+            {
+              "type": "boolean"
+            },
+            {
+              "type": "string",
+              "enum": ["claude-code", "codex", "opencode"]
+            }
+          ],
+          "description": "Default for the agentic flow used by `nx migrate --run-migrations`. Equivalent to the `--agentic` flag. `false` never uses the agentic flow, `true` uses it and resolves the installed agent, and an agent id always uses that agent."
+        },
+        "validate": {
+          "type": "boolean",
+          "description": "Whether to run agent-driven validation after generator-only migrations when the agentic flow is enabled. Equivalent to the `--validate` flag. Defaults to `true` when the agentic flow is enabled."
+        }
+      },
+      "additionalProperties": false
+    },
     "conformance": {
       "type": "object",
       "description": "Configuration for Nx Conformance",

--- a/packages/nx/src/adapter/compat.ts
+++ b/packages/nx/src/adapter/compat.ts
@@ -83,6 +83,7 @@ export const allowedWorkspaceExtensions = [
   'neverConnectToCloud',
   'analytics',
   'sync',
+  'migrate',
   'useLegacyCache',
   'maxCacheSize',
   'tui',

--- a/packages/nx/src/command-line/migrate/agentic/select.spec.ts
+++ b/packages/nx/src/command-line/migrate/agentic/select.spec.ts
@@ -14,16 +14,12 @@ jest.mock('../../../utils/output', () => ({
     error: jest.fn(),
   },
 }));
-jest.mock('../../../utils/fileutils', () => ({
-  ...jest.requireActual('../../../utils/fileutils'),
-  writeJsonFile: jest.fn(),
-  readJsonFile: jest.fn(() => ({})),
-}));
 
 import { isAiAgent } from '../../../native';
 import { prompt } from 'enquirer';
 import { output } from '../../../utils/output';
-import { readJsonFile, writeJsonFile } from '../../../utils/fileutils';
+import { parseJson } from '../../../utils/json';
+import { TempFs } from '../../../internal-testing-utils/temp-fs';
 import { detectInstalledAgents } from './detect-installed';
 import { resolveAgentic } from './select';
 import { DetectedInstalledAgent } from './types';
@@ -34,8 +30,6 @@ const mockDetect = detectInstalledAgents as unknown as jest.Mock;
 const mockOutputLog = output.log as unknown as jest.Mock;
 const mockOutputError = output.error as unknown as jest.Mock;
 const mockOutputWarn = output.warn as unknown as jest.Mock;
-const mockReadJsonFile = readJsonFile as unknown as jest.Mock;
-const mockWriteJsonFile = writeJsonFile as unknown as jest.Mock;
 
 function detected(
   id: 'claude-code' | 'codex' | 'opencode'
@@ -65,6 +59,8 @@ function setTty(enabled: boolean): void {
 }
 
 describe('resolveAgentic', () => {
+  let tempFs: TempFs;
+
   beforeEach(() => {
     mockIsAiAgent.mockReset();
     mockIsAiAgent.mockReturnValue(false);
@@ -73,13 +69,17 @@ describe('resolveAgentic', () => {
     mockOutputLog.mockReset();
     mockOutputError.mockReset();
     mockOutputWarn.mockReset();
-    mockReadJsonFile.mockReset();
-    mockReadJsonFile.mockReturnValue({});
-    mockWriteJsonFile.mockReset();
+    // Persisting writes to `<workspaceRoot>/nx.json`; TempFs redirects the
+    // workspace root so every fs op hits a throwaway dir, never the real repo.
+    tempFs = new TempFs('migrate-agentic-select');
     // Default to "no agents detected" — the few tests that exercise an enabled
     // flow override this with their own agent list.
     mockDetect.mockResolvedValue([]);
     setTty(true);
+  });
+
+  afterEach(() => {
+    tempFs.cleanup();
   });
 
   afterAll(() => {
@@ -168,6 +168,7 @@ describe('resolveAgentic', () => {
   });
 
   it('enables the agentic flow when the up-front prompt is accepted', async () => {
+    tempFs.createFileSync('nx.json', '{}\n');
     mockPrompt.mockResolvedValueOnce({ choice: 'yes-once' });
     mockDetect.mockResolvedValue([detected('claude-code')]);
     const result = await resolveAgentic({
@@ -179,7 +180,7 @@ describe('resolveAgentic', () => {
       selectedAgent: { id: 'claude-code' },
     });
     // "just this time" persists nothing.
-    expect(mockWriteJsonFile).not.toHaveBeenCalled();
+    expect(await tempFs.readFile('nx.json')).toBe('{}\n');
   });
 
   it('renders the up-front prompt as a select with 4 folded choices when one agent is installed', async () => {
@@ -235,6 +236,7 @@ describe('resolveAgentic', () => {
 
   describe('persisting the up-front prompt decision to nx.json', () => {
     it('does not persist for "Yes, just this time" or "No, just this time"', async () => {
+      tempFs.createFileSync('nx.json', '{}\n');
       mockDetect.mockResolvedValue([detected('claude-code')]);
       mockPrompt.mockResolvedValueOnce({ choice: 'no-once' });
       const result = await resolveAgentic({
@@ -242,10 +244,11 @@ describe('resolveAgentic', () => {
         migrations: [{ prompt: 'x.md' }],
       });
       expect(result.kind).toBe('disabled');
-      expect(mockWriteJsonFile).not.toHaveBeenCalled();
+      expect(await tempFs.readFile('nx.json')).toBe('{}\n');
     });
 
     it('persists `false` for "No, never"', async () => {
+      tempFs.createFileSync('nx.json', '{}\n');
       mockDetect.mockResolvedValue([detected('claude-code')]);
       mockPrompt.mockResolvedValueOnce({ choice: 'no-never' });
       const result = await resolveAgentic({
@@ -253,13 +256,13 @@ describe('resolveAgentic', () => {
         migrations: [{ prompt: 'x.md' }],
       });
       expect(result.kind).toBe('disabled');
-      expect(mockWriteJsonFile).toHaveBeenCalledTimes(1);
-      expect(mockWriteJsonFile.mock.calls[0][1]).toMatchObject({
+      expect(parseJson(await tempFs.readFile('nx.json'))).toMatchObject({
         migrate: { agentic: false },
       });
     });
 
     it('persists `true` for "Yes, always" (flexible agent)', async () => {
+      tempFs.createFileSync('nx.json', '{}\n');
       mockDetect.mockResolvedValue([detected('claude-code')]);
       mockPrompt.mockResolvedValueOnce({ choice: 'yes-flex' });
       const result = await resolveAgentic({
@@ -270,12 +273,13 @@ describe('resolveAgentic', () => {
         kind: 'enabled',
         selectedAgent: { id: 'claude-code' },
       });
-      expect(mockWriteJsonFile.mock.calls[0][1]).toMatchObject({
+      expect(parseJson(await tempFs.readFile('nx.json'))).toMatchObject({
         migrate: { agentic: true },
       });
     });
 
     it('persists the selected agent id for "Yes, always with the same agent"', async () => {
+      tempFs.createFileSync('nx.json', '{}\n');
       mockDetect.mockResolvedValue([
         detected('claude-code'),
         detected('codex'),
@@ -292,28 +296,38 @@ describe('resolveAgentic', () => {
         kind: 'enabled',
         selectedAgent: { id: 'codex' },
       });
-      expect(mockWriteJsonFile.mock.calls[0][1]).toMatchObject({
+      expect(parseJson(await tempFs.readFile('nx.json'))).toMatchObject({
         migrate: { agentic: 'codex' },
       });
     });
 
-    it('preserves existing migrate config when persisting', async () => {
-      mockReadJsonFile.mockReturnValue({ migrate: { createCommits: true } });
+    it('preserves existing migrate config and comments when persisting', async () => {
+      tempFs.createFileSync(
+        'nx.json',
+        [
+          '{',
+          '  // keep me',
+          '  "migrate": { "createCommits": true }',
+          '}',
+          '',
+        ].join('\n')
+      );
       mockDetect.mockResolvedValue([detected('claude-code')]);
       mockPrompt.mockResolvedValueOnce({ choice: 'yes-flex' });
       await resolveAgentic({
         agentic: undefined,
         migrations: [{ prompt: 'x.md' }],
       });
-      expect(mockWriteJsonFile.mock.calls[0][1]).toMatchObject({
+      const written = await tempFs.readFile('nx.json');
+      expect(written).toContain('// keep me');
+      expect(parseJson(written)).toMatchObject({
         migrate: { createCommits: true, agentic: true },
       });
     });
 
     it('warns and continues when saving to nx.json fails', async () => {
-      mockWriteJsonFile.mockImplementation(() => {
-        throw new Error('disk full');
-      });
+      // A directory at the nx.json path makes the read/write throw.
+      tempFs.createDirSync('nx.json');
       mockDetect.mockResolvedValue([detected('claude-code')]);
       mockPrompt.mockResolvedValueOnce({ choice: 'yes-flex' });
       const result = await resolveAgentic({
@@ -327,12 +341,32 @@ describe('resolveAgentic', () => {
       });
       expect(
         mockOutputWarn.mock.calls.some((c) =>
-          /Could not save your agentic choice/i.test(c[0].title)
+          /Could not save your agentic choice to nx.json/i.test(c[0].title)
+        )
+      ).toBe(true);
+    });
+
+    it('warns when there is no nx.json to save to', async () => {
+      // TempFs starts empty, so the workspace root has no nx.json.
+      mockDetect.mockResolvedValue([detected('claude-code')]);
+      mockPrompt.mockResolvedValueOnce({ choice: 'yes-flex' });
+      const result = await resolveAgentic({
+        agentic: undefined,
+        migrations: [{ prompt: 'x.md' }],
+      });
+      expect(result).toMatchObject({
+        kind: 'enabled',
+        selectedAgent: { id: 'claude-code' },
+      });
+      expect(
+        mockOutputWarn.mock.calls.some((c) =>
+          /no nx.json found/i.test(c[0].title)
         )
       ).toBe(true);
     });
 
     it('does not persist when the agentic flow is requested explicitly via the flag', async () => {
+      tempFs.createFileSync('nx.json', '{}\n');
       mockDetect.mockResolvedValue([detected('claude-code')]);
       const result = await resolveAgentic({
         agentic: true,
@@ -340,7 +374,7 @@ describe('resolveAgentic', () => {
       });
       expect(result.kind).toBe('enabled');
       expect(mockPrompt).not.toHaveBeenCalled();
-      expect(mockWriteJsonFile).not.toHaveBeenCalled();
+      expect(await tempFs.readFile('nx.json')).toBe('{}\n');
     });
   });
 

--- a/packages/nx/src/command-line/migrate/agentic/select.spec.ts
+++ b/packages/nx/src/command-line/migrate/agentic/select.spec.ts
@@ -14,10 +14,16 @@ jest.mock('../../../utils/output', () => ({
     error: jest.fn(),
   },
 }));
+jest.mock('../../../utils/fileutils', () => ({
+  ...jest.requireActual('../../../utils/fileutils'),
+  writeJsonFile: jest.fn(),
+  readJsonFile: jest.fn(() => ({})),
+}));
 
 import { isAiAgent } from '../../../native';
 import { prompt } from 'enquirer';
 import { output } from '../../../utils/output';
+import { readJsonFile, writeJsonFile } from '../../../utils/fileutils';
 import { detectInstalledAgents } from './detect-installed';
 import { resolveAgentic } from './select';
 import { DetectedInstalledAgent } from './types';
@@ -28,6 +34,8 @@ const mockDetect = detectInstalledAgents as unknown as jest.Mock;
 const mockOutputLog = output.log as unknown as jest.Mock;
 const mockOutputError = output.error as unknown as jest.Mock;
 const mockOutputWarn = output.warn as unknown as jest.Mock;
+const mockReadJsonFile = readJsonFile as unknown as jest.Mock;
+const mockWriteJsonFile = writeJsonFile as unknown as jest.Mock;
 
 function detected(
   id: 'claude-code' | 'codex' | 'opencode'
@@ -65,6 +73,9 @@ describe('resolveAgentic', () => {
     mockOutputLog.mockReset();
     mockOutputError.mockReset();
     mockOutputWarn.mockReset();
+    mockReadJsonFile.mockReset();
+    mockReadJsonFile.mockReturnValue({});
+    mockWriteJsonFile.mockReset();
     // Default to "no agents detected" — the few tests that exercise an enabled
     // flow override this with their own agent list.
     mockDetect.mockResolvedValue([]);
@@ -137,7 +148,7 @@ describe('resolveAgentic', () => {
 
   it('fires the up-front prompt when --agentic is undefined and prompt migrations are queued', async () => {
     mockDetect.mockResolvedValue([detected('claude-code')]);
-    mockPrompt.mockResolvedValueOnce({ enable: 'no' });
+    mockPrompt.mockResolvedValueOnce({ choice: 'no-once' });
     const result = await resolveAgentic({
       agentic: undefined,
       migrations: [{ prompt: 'x.md' }],
@@ -157,7 +168,7 @@ describe('resolveAgentic', () => {
   });
 
   it('enables the agentic flow when the up-front prompt is accepted', async () => {
-    mockPrompt.mockResolvedValueOnce({ enable: 'yes' });
+    mockPrompt.mockResolvedValueOnce({ choice: 'yes-once' });
     mockDetect.mockResolvedValue([detected('claude-code')]);
     const result = await resolveAgentic({
       agentic: undefined,
@@ -167,38 +178,51 @@ describe('resolveAgentic', () => {
       kind: 'enabled',
       selectedAgent: { id: 'claude-code' },
     });
+    // "just this time" persists nothing.
+    expect(mockWriteJsonFile).not.toHaveBeenCalled();
   });
 
-  it('renders the up-front prompt as an autocomplete with Yes/No choices and per-choice hints', async () => {
+  it('renders the up-front prompt as a select with 4 folded choices when one agent is installed', async () => {
     mockDetect.mockResolvedValue([detected('claude-code')]);
-    mockPrompt.mockResolvedValueOnce({ enable: 'no' });
+    mockPrompt.mockResolvedValueOnce({ choice: 'no-once' });
     await resolveAgentic({
       agentic: undefined,
       migrations: [{ prompt: 'a.md' }, { prompt: 'b.md' }, {}],
     });
-    expect(mockPrompt).toHaveBeenCalledWith(
-      expect.objectContaining({
-        type: 'autocomplete',
-        message: 'Enable the agentic flow?',
-        choices: [
-          {
-            name: 'yes',
-            message: 'Yes',
-            hint: 'Apply 2 prompt migrations and validate generator output with an AI agent',
-          },
-          {
-            name: 'no',
-            message: 'No',
-            hint: 'Skip prompts and run generators without AI validation',
-          },
-        ],
-      })
+    const call = mockPrompt.mock.calls[0][0];
+    expect(call.type).toBe('select');
+    expect(call.message).toBe('Enable the agentic flow?');
+    expect(call.choices.map((c: any) => c.name)).toEqual([
+      'yes-once',
+      'yes-flex',
+      'no-once',
+      'no-never',
+    ]);
+    expect(call.choices[0].hint).toBe(
+      'Apply 2 prompt migrations and validate generator output with an AI agent'
     );
   });
 
-  it('singularizes the "Yes" hint when only one prompt migration is queued', async () => {
+  it('adds the "pin the agent" choice when multiple agents are installed', async () => {
+    mockDetect.mockResolvedValue([detected('claude-code'), detected('codex')]);
+    mockPrompt.mockResolvedValueOnce({ choice: 'no-once' });
+    await resolveAgentic({
+      agentic: undefined,
+      migrations: [{ prompt: 'a.md' }],
+    });
+    const call = mockPrompt.mock.calls[0][0];
+    expect(call.choices.map((c: any) => c.name)).toEqual([
+      'yes-once',
+      'yes-flex',
+      'yes-pin',
+      'no-once',
+      'no-never',
+    ]);
+  });
+
+  it('singularizes the apply hint when only one prompt migration is queued', async () => {
     mockDetect.mockResolvedValue([detected('claude-code')]);
-    mockPrompt.mockResolvedValueOnce({ enable: 'no' });
+    mockPrompt.mockResolvedValueOnce({ choice: 'no-once' });
     await resolveAgentic({
       agentic: undefined,
       migrations: [{ prompt: 'only.md' }],
@@ -207,6 +231,117 @@ describe('resolveAgentic', () => {
     expect(call.choices[0].hint).toBe(
       'Apply 1 prompt migration and validate generator output with an AI agent'
     );
+  });
+
+  describe('persisting the up-front prompt decision to nx.json', () => {
+    it('does not persist for "Yes, just this time" or "No, just this time"', async () => {
+      mockDetect.mockResolvedValue([detected('claude-code')]);
+      mockPrompt.mockResolvedValueOnce({ choice: 'no-once' });
+      const result = await resolveAgentic({
+        agentic: undefined,
+        migrations: [{ prompt: 'x.md' }],
+      });
+      expect(result.kind).toBe('disabled');
+      expect(mockWriteJsonFile).not.toHaveBeenCalled();
+    });
+
+    it('persists `false` for "No, never"', async () => {
+      mockDetect.mockResolvedValue([detected('claude-code')]);
+      mockPrompt.mockResolvedValueOnce({ choice: 'no-never' });
+      const result = await resolveAgentic({
+        agentic: undefined,
+        migrations: [{ prompt: 'x.md' }],
+      });
+      expect(result.kind).toBe('disabled');
+      expect(mockWriteJsonFile).toHaveBeenCalledTimes(1);
+      expect(mockWriteJsonFile.mock.calls[0][1]).toMatchObject({
+        migrate: { agentic: false },
+      });
+    });
+
+    it('persists `true` for "Yes, always" (flexible agent)', async () => {
+      mockDetect.mockResolvedValue([detected('claude-code')]);
+      mockPrompt.mockResolvedValueOnce({ choice: 'yes-flex' });
+      const result = await resolveAgentic({
+        agentic: undefined,
+        migrations: [{ prompt: 'x.md' }],
+      });
+      expect(result).toMatchObject({
+        kind: 'enabled',
+        selectedAgent: { id: 'claude-code' },
+      });
+      expect(mockWriteJsonFile.mock.calls[0][1]).toMatchObject({
+        migrate: { agentic: true },
+      });
+    });
+
+    it('persists the selected agent id for "Yes, always with the same agent"', async () => {
+      mockDetect.mockResolvedValue([
+        detected('claude-code'),
+        detected('codex'),
+      ]);
+      // First prompt: the folded enable choice. Second: the agent picker.
+      mockPrompt
+        .mockResolvedValueOnce({ choice: 'yes-pin' })
+        .mockResolvedValueOnce({ id: 'codex' });
+      const result = await resolveAgentic({
+        agentic: undefined,
+        migrations: [{ prompt: 'x.md' }],
+      });
+      expect(result).toMatchObject({
+        kind: 'enabled',
+        selectedAgent: { id: 'codex' },
+      });
+      expect(mockWriteJsonFile.mock.calls[0][1]).toMatchObject({
+        migrate: { agentic: 'codex' },
+      });
+    });
+
+    it('preserves existing migrate config when persisting', async () => {
+      mockReadJsonFile.mockReturnValue({ migrate: { createCommits: true } });
+      mockDetect.mockResolvedValue([detected('claude-code')]);
+      mockPrompt.mockResolvedValueOnce({ choice: 'yes-flex' });
+      await resolveAgentic({
+        agentic: undefined,
+        migrations: [{ prompt: 'x.md' }],
+      });
+      expect(mockWriteJsonFile.mock.calls[0][1]).toMatchObject({
+        migrate: { createCommits: true, agentic: true },
+      });
+    });
+
+    it('warns and continues when saving to nx.json fails', async () => {
+      mockWriteJsonFile.mockImplementation(() => {
+        throw new Error('disk full');
+      });
+      mockDetect.mockResolvedValue([detected('claude-code')]);
+      mockPrompt.mockResolvedValueOnce({ choice: 'yes-flex' });
+      const result = await resolveAgentic({
+        agentic: undefined,
+        migrations: [{ prompt: 'x.md' }],
+      });
+      // The migration still proceeds; the failed save only warns.
+      expect(result).toMatchObject({
+        kind: 'enabled',
+        selectedAgent: { id: 'claude-code' },
+      });
+      expect(
+        mockOutputWarn.mock.calls.some((c) =>
+          /Could not save your agentic choice/i.test(c[0].title)
+        )
+      ).toBe(true);
+    });
+
+    it('does not persist when the agentic flow is requested explicitly via the flag', async () => {
+      mockDetect.mockResolvedValue([detected('claude-code')]);
+      const result = await resolveAgentic({
+        agentic: true,
+        migrations: [{ prompt: 'x.md' }],
+      });
+      expect(result.kind).toBe('enabled');
+      expect(mockPrompt).not.toHaveBeenCalled();
+      expect(mockWriteJsonFile).not.toHaveBeenCalled();
+    });
   });
 
   it('uses the single detected agent without firing a picker', async () => {

--- a/packages/nx/src/command-line/migrate/agentic/select.spec.ts
+++ b/packages/nx/src/command-line/migrate/agentic/select.spec.ts
@@ -27,6 +27,7 @@ const mockPrompt = prompt as unknown as jest.Mock;
 const mockDetect = detectInstalledAgents as unknown as jest.Mock;
 const mockOutputLog = output.log as unknown as jest.Mock;
 const mockOutputError = output.error as unknown as jest.Mock;
+const mockOutputWarn = output.warn as unknown as jest.Mock;
 
 function detected(
   id: 'claude-code' | 'codex' | 'opencode'
@@ -63,6 +64,7 @@ describe('resolveAgentic', () => {
     mockDetect.mockReset();
     mockOutputLog.mockReset();
     mockOutputError.mockReset();
+    mockOutputWarn.mockReset();
     // Default to "no agents detected" — the few tests that exercise an enabled
     // flow override this with their own agent list.
     mockDetect.mockResolvedValue([]);
@@ -250,40 +252,55 @@ describe('resolveAgentic', () => {
     expect(mockPrompt).not.toHaveBeenCalled();
   });
 
-  it('aborts with an actionable list when --agentic=<id> is set but that agent is not among the other detected agents', async () => {
+  it('warns and falls back to the picker when --agentic=<id> is set but that agent is not installed (others present)', async () => {
     mockDetect.mockResolvedValue([detected('claude-code'), detected('codex')]);
-    await expect(
-      resolveAgentic({
-        agentic: 'opencode',
-        migrations: [{ prompt: 'x.md' }],
-      })
-    ).rejects.toThrow(/requested agent "opencode" is not installed/i);
-    expect(mockPrompt).not.toHaveBeenCalled();
-    const errArg = mockOutputError.mock.calls[0][0];
-    expect(errArg.title).toMatch(/is not installed\./);
-    // The remediation must offer the "drop the explicit flag" path when
-    // there ARE other agents to fall back to.
-    expect(errArg.bodyLines.join('\n')).toMatch(
-      /pass --agentic without an explicit agent/
+    mockPrompt.mockResolvedValueOnce({ id: 'codex' });
+    const result = await resolveAgentic({
+      agentic: 'opencode',
+      migrations: [{ prompt: 'x.md' }],
+    });
+    // The picker fires over the installed agents instead of aborting.
+    expect(mockPrompt).toHaveBeenCalledTimes(1);
+    expect(result).toMatchObject({
+      kind: 'enabled',
+      selectedAgent: { id: 'codex' },
+    });
+    expect(mockOutputError).not.toHaveBeenCalled();
+    expect(mockOutputWarn).toHaveBeenCalled();
+    expect(mockOutputWarn.mock.calls[0][0].title).toMatch(
+      /requested agent "opencode" is not installed/i
     );
   });
 
-  it('aborts without offering the "drop the explicit flag" remediation when --agentic=<id> is set and NO agents are installed', async () => {
+  it('warns and auto-uses the only installed agent when --agentic=<id> is set but that agent is not installed', async () => {
+    mockDetect.mockResolvedValue([detected('claude-code')]);
+    const result = await resolveAgentic({
+      agentic: 'opencode',
+      migrations: [{ prompt: 'x.md' }],
+    });
+    expect(mockPrompt).not.toHaveBeenCalled();
+    expect(result).toMatchObject({
+      kind: 'enabled',
+      selectedAgent: { id: 'claude-code' },
+    });
+    expect(mockOutputError).not.toHaveBeenCalled();
+    expect(mockOutputWarn).toHaveBeenCalled();
+    expect(mockOutputWarn.mock.calls[0][0].title).toMatch(
+      /requested agent "opencode" is not installed/i
+    );
+  });
+
+  it('errors when --agentic=<id> is set and NO agents are installed', async () => {
     mockDetect.mockResolvedValue([]);
     await expect(
       resolveAgentic({
         agentic: 'opencode',
         migrations: [{ prompt: 'x.md' }],
       })
-    ).rejects.toThrow(/requested agent "opencode" is not installed/i);
+    ).rejects.toThrow(/No installed AI agent/);
     expect(mockPrompt).not.toHaveBeenCalled();
     const errArg = mockOutputError.mock.calls[0][0];
     expect(errArg.title).toMatch(/no supported AI agent is installed/i);
-    // The circular "pass --agentic without an explicit agent" remediation
-    // must not appear when there's nothing to fall back to.
-    expect(errArg.bodyLines.join('\n')).not.toMatch(
-      /pass --agentic without an explicit agent/
-    );
     expect(errArg.bodyLines.join('\n')).toMatch(
       /install one of the supported agents/i
     );
@@ -303,15 +320,20 @@ describe('resolveAgentic', () => {
     ['--agentic=true', true],
     ['--agentic=<id>', 'claude-code'],
   ])(
-    'aborts when %s is passed in a non-TTY environment',
+    'warns and runs without the agentic flow when %s is passed in a non-TTY environment',
     async (_label, agentic) => {
       setTty(false);
-      await expect(
-        resolveAgentic({
-          agentic,
-          migrations: [{ prompt: 'x.md' }],
-        })
-      ).rejects.toThrow(/interactive terminal/);
+      mockDetect.mockResolvedValue([detected('claude-code')]);
+      const result = await resolveAgentic({
+        agentic,
+        migrations: [{ prompt: 'x.md' }],
+      });
+      expect(result).toEqual({ kind: 'disabled' });
+      expect(mockPrompt).not.toHaveBeenCalled();
+      expect(mockOutputWarn).toHaveBeenCalled();
+      expect(mockOutputWarn.mock.calls[0][0].title).toMatch(
+        /interactive-only/i
+      );
     }
   );
 

--- a/packages/nx/src/command-line/migrate/agentic/select.ts
+++ b/packages/nx/src/command-line/migrate/agentic/select.ts
@@ -1,4 +1,9 @@
+import { existsSync } from 'fs';
+import { join } from 'path';
 import { output } from '../../../utils/output';
+import type { NxJsonConfiguration } from '../../../config/nx-json';
+import { readJsonFile, writeJsonFile } from '../../../utils/fileutils';
+import { workspaceRoot } from '../../../utils/workspace-root';
 import { migratePrompt } from '../safe-prompt';
 import { detectInstalledAgents } from './detect-installed';
 import { isInsideAgent } from './inception';
@@ -46,26 +51,46 @@ export async function resolveAgentic(
   }
 
   const detected = await detectInstalledAgents(AGENT_DEFINITIONS);
-  const { enabled, explicitId } = await resolveFlag(
+  const { enabled, explicitId, persist } = await resolveFlag(
     input,
     isInteractive,
     detected
   );
 
   if (!enabled) {
+    if (persist === false) {
+      persistAgenticChoice(false);
+    }
     return { kind: 'disabled' };
   }
 
   const selected = await selectAgent(detected, explicitId, isInteractive);
 
+  if (persist === true) {
+    persistAgenticChoice(true);
+  } else if (persist === 'pin') {
+    persistAgenticChoice(selected.id);
+  }
+
   return { kind: 'enabled', selectedAgent: selected };
 }
+
+/**
+ * What to persist to `nx.json` `migrate.agentic` after the up-front prompt:
+ * `undefined` = don't persist, `false` = persist disabled, `true` = persist
+ * enabled (resolve the agent each run), `'pin'` = persist the selected agent id.
+ */
+type PersistChoice = undefined | boolean | 'pin';
 
 async function resolveFlag(
   input: ResolveAgenticInput,
   isInteractive: boolean,
   detected: DetectedInstalledAgent[]
-): Promise<{ enabled: boolean; explicitId?: AgentId }> {
+): Promise<{
+  enabled: boolean;
+  explicitId?: AgentId;
+  persist?: PersistChoice;
+}> {
   if (input.agentic === true) {
     if (!isInteractive) {
       warnAgenticInteractiveOnly();
@@ -93,7 +118,7 @@ async function resolveFlag(
   if (detected.length === 0) {
     return { enabled: false };
   }
-  return { enabled: await firePromptForAgentic(input.migrations) };
+  return firePromptForAgentic(input.migrations, detected);
 }
 
 function requireInteractiveOrAbort(isInteractive: boolean): void {
@@ -118,33 +143,102 @@ function warnAgenticInteractiveOnly(): void {
 }
 
 async function firePromptForAgentic(
-  migrations: ReadonlyArray<{ prompt?: string }>
-): Promise<boolean> {
-  // The "Yes"/"No" hints below assume at least one prompt-bearing migration is
-  // queued. If we later extend the prompt to fire for generator-only runs
-  // (validation-only), the hints need to branch.
+  migrations: ReadonlyArray<{ prompt?: string }>,
+  detected: DetectedInstalledAgent[]
+): Promise<{ enabled: boolean; persist?: PersistChoice }> {
+  // The apply hint assumes at least one prompt-bearing migration is queued. If
+  // we later extend the prompt to fire for generator-only runs (validation-
+  // only), the hint needs to branch.
   const promptCount = migrations.filter((m) => !!m.prompt).length;
-  const yesHint = `Apply ${promptCount} prompt migration${
+  const applyHint = `Apply ${promptCount} prompt migration${
     promptCount === 1 ? '' : 's'
   } and validate generator output with an AI agent`;
-  const noHint = `Skip prompts and run generators without AI validation`;
+  const skipHint = `Skip prompts and run generators without AI validation`;
+  const rememberHint = `Saved to nx.json so Nx won't ask again`;
+
+  // The pin-vs-flexible distinction only matters when more than one agent is
+  // installed. With a single agent, "always" simply persists `true`.
+  const choices =
+    detected.length > 1
+      ? [
+          { name: 'yes-once', message: 'Yes, just this time', hint: applyHint },
+          {
+            name: 'yes-flex',
+            message: "Yes, always (I'll pick the agent each run)",
+            hint: rememberHint,
+          },
+          {
+            name: 'yes-pin',
+            message: 'Yes, always with the same agent',
+            hint: rememberHint,
+          },
+          { name: 'no-once', message: 'No, just this time', hint: skipHint },
+          { name: 'no-never', message: 'No, never', hint: rememberHint },
+        ]
+      : [
+          { name: 'yes-once', message: 'Yes, just this time', hint: applyHint },
+          { name: 'yes-flex', message: 'Yes, always', hint: rememberHint },
+          { name: 'no-once', message: 'No, just this time', hint: skipHint },
+          { name: 'no-never', message: 'No, never', hint: rememberHint },
+        ];
 
   // Blank line keeps the prompt from gluing to the previous `npm install`
   // output or any earlier orchestrator line.
   console.log();
   // `as any` because enquirer's TS types lag the runtime (per-choice `hint`
-  // and `value` are supported but not in the .d.ts).
-  const response = await migratePrompt<{ enable: 'yes' | 'no' }>({
-    name: 'enable',
-    type: 'autocomplete',
+  // is supported but not in the .d.ts).
+  const response = await migratePrompt<{ choice: string }>({
+    name: 'choice',
+    type: 'select',
     message: 'Enable the agentic flow?',
-    choices: [
-      { name: 'yes', message: 'Yes', hint: yesHint },
-      { name: 'no', message: 'No', hint: noHint },
-    ],
+    choices,
     initial: 0,
   } as any);
-  return response.enable === 'yes';
+
+  switch (response.choice) {
+    case 'yes-once':
+      return { enabled: true };
+    case 'yes-flex':
+      return { enabled: true, persist: true };
+    case 'yes-pin':
+      return { enabled: true, persist: 'pin' };
+    case 'no-never':
+      return { enabled: false, persist: false };
+    case 'no-once':
+    default:
+      return { enabled: false };
+  }
+}
+
+// Persists the user's agentic choice to `nx.json` so the up-front prompt is
+// skipped on future runs. Reads and writes the raw `nx.json` file (not the
+// resolved config) so an `extends` preset isn't inlined back into the user's
+// file. JSONC comments are not preserved (writeJsonFile re-serializes). Never
+// throws — a failed write only costs the user the prompt again next time.
+function persistAgenticChoice(value: boolean | AgentId): void {
+  const nxJsonPath = join(workspaceRoot, 'nx.json');
+  if (!existsSync(nxJsonPath)) {
+    output.warn({
+      title: `Could not save your agentic choice: no nx.json found at the workspace root.`,
+    });
+    return;
+  }
+  try {
+    const nxJson = readJsonFile<NxJsonConfiguration>(nxJsonPath);
+    nxJson.migrate = { ...(nxJson.migrate ?? {}), agentic: value };
+    writeJsonFile(nxJsonPath, nxJson);
+    output.log({
+      title: `Saved your choice to nx.json (migrate.agentic = ${JSON.stringify(
+        value
+      )}). Nx won't ask again.`,
+    });
+  } catch (e) {
+    output.warn({
+      title: `Could not save your agentic choice to nx.json: ${
+        e instanceof Error ? e.message : String(e)
+      }`,
+    });
+  }
 }
 
 async function selectAgent(

--- a/packages/nx/src/command-line/migrate/agentic/select.ts
+++ b/packages/nx/src/command-line/migrate/agentic/select.ts
@@ -214,7 +214,7 @@ async function firePromptForAgentic(
 // skipped on future runs. Reads and writes the raw `nx.json` file (not the
 // resolved config) so an `extends` preset isn't inlined back into the user's
 // file. JSONC comments are not preserved (writeJsonFile re-serializes). Never
-// throws — a failed write only costs the user the prompt again next time.
+// throws - a failed write only costs the user the prompt again next time.
 function persistAgenticChoice(value: boolean | AgentId): void {
   const nxJsonPath = join(workspaceRoot, 'nx.json');
   if (!existsSync(nxJsonPath)) {

--- a/packages/nx/src/command-line/migrate/agentic/select.ts
+++ b/packages/nx/src/command-line/migrate/agentic/select.ts
@@ -1,8 +1,7 @@
-import { existsSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { applyEdits, modify } from 'jsonc-parser';
 import { join } from 'path';
 import { output } from '../../../utils/output';
-import type { NxJsonConfiguration } from '../../../config/nx-json';
-import { readJsonFile, writeJsonFile } from '../../../utils/fileutils';
 import { workspaceRoot } from '../../../utils/workspace-root';
 import { migratePrompt } from '../safe-prompt';
 import { detectInstalledAgents } from './detect-installed';
@@ -157,30 +156,30 @@ async function firePromptForAgentic(
   const rememberHint = `Saved to nx.json so Nx won't ask again`;
 
   // The pin-vs-flexible distinction only matters when more than one agent is
-  // installed. With a single agent, "always" simply persists `true`.
-  const choices =
-    detected.length > 1
+  // installed. With a single agent, "always" simply persists `true` and the
+  // pin option is dropped.
+  const multipleAgents = detected.length > 1;
+  const choices = [
+    { name: 'yes-once', message: 'Yes, just this time', hint: applyHint },
+    {
+      name: 'yes-flex',
+      message: multipleAgents
+        ? "Yes, always (I'll pick the agent each run)"
+        : 'Yes, always',
+      hint: rememberHint,
+    },
+    ...(multipleAgents
       ? [
-          { name: 'yes-once', message: 'Yes, just this time', hint: applyHint },
-          {
-            name: 'yes-flex',
-            message: "Yes, always (I'll pick the agent each run)",
-            hint: rememberHint,
-          },
           {
             name: 'yes-pin',
             message: 'Yes, always with the same agent',
             hint: rememberHint,
           },
-          { name: 'no-once', message: 'No, just this time', hint: skipHint },
-          { name: 'no-never', message: 'No, never', hint: rememberHint },
         ]
-      : [
-          { name: 'yes-once', message: 'Yes, just this time', hint: applyHint },
-          { name: 'yes-flex', message: 'Yes, always', hint: rememberHint },
-          { name: 'no-once', message: 'No, just this time', hint: skipHint },
-          { name: 'no-never', message: 'No, never', hint: rememberHint },
-        ];
+      : []),
+    { name: 'no-once', message: 'No, just this time', hint: skipHint },
+    { name: 'no-never', message: 'No, never', hint: rememberHint },
+  ];
 
   // Blank line keeps the prompt from gluing to the previous `npm install`
   // output or any earlier orchestrator line.
@@ -211,10 +210,11 @@ async function firePromptForAgentic(
 }
 
 // Persists the user's agentic choice to `nx.json` so the up-front prompt is
-// skipped on future runs. Reads and writes the raw `nx.json` file (not the
-// resolved config) so an `extends` preset isn't inlined back into the user's
-// file. JSONC comments are not preserved (writeJsonFile re-serializes). Never
-// throws - a failed write only costs the user the prompt again next time.
+// skipped on future runs. Edits the raw file in place via jsonc-parser, so it
+// touches only the `migrate.agentic` key and preserves comments, formatting,
+// and any `extends` preset (the prompt fires mid-migration, so a silent
+// reformat would be surprising). Never throws - a failed write only costs the
+// user the prompt again next time.
 function persistAgenticChoice(value: boolean | AgentId): void {
   const nxJsonPath = join(workspaceRoot, 'nx.json');
   if (!existsSync(nxJsonPath)) {
@@ -224,9 +224,11 @@ function persistAgenticChoice(value: boolean | AgentId): void {
     return;
   }
   try {
-    const nxJson = readJsonFile<NxJsonConfiguration>(nxJsonPath);
-    nxJson.migrate = { ...(nxJson.migrate ?? {}), agentic: value };
-    writeJsonFile(nxJsonPath, nxJson);
+    const content = readFileSync(nxJsonPath, 'utf-8');
+    const edits = modify(content, ['migrate', 'agentic'], value, {
+      formattingOptions: { insertSpaces: true, tabSize: 2 },
+    });
+    writeFileSync(nxJsonPath, applyEdits(content, edits));
     output.log({
       title: `Saved your choice to nx.json (migrate.agentic = ${JSON.stringify(
         value

--- a/packages/nx/src/command-line/migrate/agentic/select.ts
+++ b/packages/nx/src/command-line/migrate/agentic/select.ts
@@ -67,11 +67,17 @@ async function resolveFlag(
   detected: DetectedInstalledAgent[]
 ): Promise<{ enabled: boolean; explicitId?: AgentId }> {
   if (input.agentic === true) {
-    requireInteractiveOrAbort(isInteractive);
+    if (!isInteractive) {
+      warnAgenticInteractiveOnly();
+      return { enabled: false };
+    }
     return { enabled: true };
   }
   if (typeof input.agentic === 'string') {
-    requireInteractiveOrAbort(isInteractive);
+    if (!isInteractive) {
+      warnAgenticInteractiveOnly();
+      return { enabled: false };
+    }
     return { enabled: true, explicitId: input.agentic };
   }
   // undefined — fire the up-front prompt only when we have a TTY, something
@@ -99,6 +105,16 @@ function requireInteractiveOrAbort(isInteractive: boolean): void {
     ],
   });
   throw new Error('Agentic flow requires an interactive terminal.');
+}
+
+function warnAgenticInteractiveOnly(): void {
+  output.warn({
+    title:
+      'Skipping the agentic flow: it is interactive-only in this release and this is a non-interactive terminal.',
+    bodyLines: [
+      'Continuing the migration without the agentic flow. Re-run in an interactive terminal to use it.',
+    ],
+  });
 }
 
 async function firePromptForAgentic(
@@ -141,22 +157,18 @@ async function selectAgent(
     if (match) {
       return match;
     }
-    if (detected.length === 0) {
-      output.error({
-        title: `The agent "${explicitId}" was requested via --agentic but no supported AI agent is installed on this machine.`,
-        bodyLines: INSTALL_SUPPORTED_AGENTS_HINT,
+    // The requested agent isn't installed. Rather than aborting the migration,
+    // warn and fall through to resolve from the agents that ARE installed
+    // (pick when 2+, auto-select the only one, error only when none exist).
+    if (detected.length > 0) {
+      output.warn({
+        title: `The requested agent "${explicitId}" is not installed; using the installed agent(s) instead.`,
+        bodyLines: [
+          'Currently installed agents:',
+          ...detected.map((d) => `  - ${d.displayName} (${d.id})`),
+        ],
       });
-      throw new Error(`The requested agent "${explicitId}" is not installed.`);
     }
-    output.error({
-      title: `The agent "${explicitId}" was requested via --agentic but is not installed.`,
-      bodyLines: [
-        'Install the requested agent and re-run, or pass --agentic without an explicit agent to choose from installed ones.',
-        'Currently installed agents:',
-        ...detected.map((d) => `  - ${d.displayName} (${d.id})`),
-      ],
-    });
-    throw new Error(`The requested agent "${explicitId}" is not installed.`);
   }
 
   if (detected.length === 0) {

--- a/packages/nx/src/command-line/migrate/command-object.ts
+++ b/packages/nx/src/command-line/migrate/command-object.ts
@@ -148,7 +148,14 @@ function withMigrationOptions(yargs: Argv) {
         mode,
         agentic,
       }) => {
+        // Only an explicit `--no-create-commits` is decidable here, before the
+        // nx.json overlay runs: an explicit `false` can't be rescued by nx.json
+        // (the CLI flag wins, and the agentic flow can't enable commits when
+        // they're explicitly off). When `createCommits` is undefined, nx.json
+        // may still enable commits, so defer to the post-overlay
+        // `assertCommitPrefixHasCommits` check.
         if (
+          createCommits === false &&
           customCommitPrefixHasNoEffect({
             createCommits,
             commitPrefix,

--- a/packages/nx/src/command-line/migrate/command-object.ts
+++ b/packages/nx/src/command-line/migrate/command-object.ts
@@ -3,6 +3,7 @@ import { handleImport } from '../../utils/handle-import';
 import { linkToNxDevAndExamples } from '../yargs-utils/documentation';
 import { withVerbose } from '../yargs-utils/shared-options';
 import { AGENT_IDS, coerceAgenticArg } from './agentic/cli-args';
+import type { AgenticArg } from './agentic/select';
 
 export const yargsMigrateCommand: CommandModule = {
   command: 'migrate [packageAndVersion]',
@@ -38,6 +39,30 @@ export type MigrateMode = (typeof MIGRATE_MODES)[number];
 /** Allowed values for `--multi-major-mode` / `migrate.multiMajorMode`. */
 export const MULTI_MAJOR_MODES = ['direct', 'gradual'] as const;
 export type MultiMajorMode = (typeof MULTI_MAJOR_MODES)[number];
+
+/**
+ * The `nx migrate` args bag. Types the keys the nx.json overlay and the
+ * commit-prefix invariant read/write; the index signature keeps the rest of
+ * the yargs args flowing through untouched.
+ */
+export interface MigrateArgs {
+  packageAndVersion?: string;
+  runMigrations?: string;
+  mode?: MigrateMode;
+  /**
+   * nx.json `migrate.mode` default. Consumed by `resolveMode` only when the
+   * target is Nx itself; kept separate from `mode` so it is never mistaken for
+   * an explicit `--mode` (which would hard-fail for non-Nx targets).
+   */
+  modeFromConfig?: MigrateMode;
+  multiMajorMode?: MultiMajorMode;
+  createCommits?: boolean;
+  commitPrefix?: string;
+  agentic?: AgenticArg;
+  validate?: boolean;
+  // The rest of the yargs args bag flows through untyped.
+  [key: string]: any;
+}
 
 /**
  * Whether a custom commit prefix would be silently ignored: commits aren't

--- a/packages/nx/src/command-line/migrate/command-object.ts
+++ b/packages/nx/src/command-line/migrate/command-object.ts
@@ -31,6 +31,39 @@ export const yargsInternalMigrateCommand: CommandModule = {
 
 export const DEFAULT_MIGRATION_COMMIT_PREFIX = 'chore: [nx migration] ';
 
+/** Allowed values for `--mode` / `migrate.mode`. */
+export const MIGRATE_MODES = ['first-party', 'third-party', 'all'] as const;
+export type MigrateMode = (typeof MIGRATE_MODES)[number];
+
+/** Allowed values for `--multi-major-mode` / `migrate.multiMajorMode`. */
+export const MULTI_MAJOR_MODES = ['direct', 'gradual'] as const;
+export type MultiMajorMode = (typeof MULTI_MAJOR_MODES)[number];
+
+/**
+ * Whether a custom commit prefix would be silently ignored: commits aren't
+ * enabled and the agentic flow can't enable them either. Shared by the yargs
+ * `.check()` (CLI args) and the nx.json overlay (merged args) so the rule lives
+ * in one place. `agentic` may flip commits on by default, so a configured
+ * agentic value (other than `false`, and not paired with `--no-create-commits`)
+ * keeps the prefix in play.
+ */
+export function customCommitPrefixHasNoEffect(args: {
+  createCommits: boolean | undefined;
+  commitPrefix: string | undefined;
+  agentic: unknown;
+}): boolean {
+  const agenticMayEnableCommits =
+    args.agentic !== undefined &&
+    args.agentic !== false &&
+    args.createCommits !== false;
+  return (
+    args.createCommits !== true &&
+    !agenticMayEnableCommits &&
+    args.commitPrefix !== undefined &&
+    args.commitPrefix !== DEFAULT_MIGRATION_COMMIT_PREFIX
+  );
+}
+
 function withMigrationOptions(yargs: Argv) {
   return withVerbose(yargs)
     .positional('packageAndVersion', {
@@ -88,13 +121,13 @@ function withMigrationOptions(yargs: Argv) {
       describe:
         "Restrict which packages to migrate. Only applies when migrating Nx itself. 'first-party' processes only Nx and its plugins (the target package plus its nx.packageGroup); 'third-party' processes only the third-party dependencies referenced by Nx packageJsonUpdates entries, catching up on any updates that may have been skipped previously; 'all' processes everything. When targeting Nx in an interactive terminal, prompts for the value if not provided; otherwise defaults to 'all'.",
       type: 'string',
-      choices: ['first-party', 'third-party', 'all'],
+      choices: MIGRATE_MODES,
     })
     .option('multiMajorMode', {
       describe:
         "Skip the multi-major migration prompt/warning and pick how to handle the jump. 'direct' migrates straight to the requested target. 'gradual' migrates to the smallest recommended step (re-run `nx migrate` to continue toward the original target). Equivalent env var: NX_MULTI_MAJOR_MODE=direct|gradual.",
       type: 'string',
-      choices: ['direct', 'gradual'],
+      choices: MULTI_MAJOR_MODES,
     })
     .option('agentic', {
       describe:
@@ -115,12 +148,12 @@ function withMigrationOptions(yargs: Argv) {
         mode,
         agentic,
       }) => {
-        const agenticMayEnableCommits =
-          agentic !== undefined && agentic !== false && createCommits !== false;
         if (
-          createCommits !== true &&
-          !agenticMayEnableCommits &&
-          commitPrefix !== DEFAULT_MIGRATION_COMMIT_PREFIX
+          customCommitPrefixHasNoEffect({
+            createCommits,
+            commitPrefix,
+            agentic,
+          })
         ) {
           throw new Error(
             'Error: Providing a custom commit prefix requires --create-commits to be enabled'

--- a/packages/nx/src/command-line/migrate/migrate-config.spec.ts
+++ b/packages/nx/src/command-line/migrate/migrate-config.spec.ts
@@ -1,4 +1,7 @@
-import { applyNxJsonMigrateDefaults } from './migrate-config';
+import {
+  applyNxJsonMigrateDefaults,
+  assertCommitPrefixHasCommits,
+} from './migrate-config';
 import { DEFAULT_MIGRATION_COMMIT_PREFIX } from './command-object';
 import type { NxMigrateConfiguration } from '../../config/nx-json';
 
@@ -117,7 +120,8 @@ describe('applyNxJsonMigrateDefaults', () => {
       const config: NxMigrateConfiguration = {
         commitPrefix: 'chore: migrate ',
       };
-      expect(() => applyNxJsonMigrateDefaults(base, config, noEnv)).toThrow(
+      const merged = applyNxJsonMigrateDefaults(base, config, noEnv);
+      expect(() => assertCommitPrefixHasCommits(merged)).toThrow(
         /requires commits to be enabled/i
       );
     });
@@ -127,21 +131,21 @@ describe('applyNxJsonMigrateDefaults', () => {
         commitPrefix: 'chore: migrate ',
         createCommits: true,
       };
-      expect(() =>
-        applyNxJsonMigrateDefaults(base, config, noEnv)
-      ).not.toThrow();
+      const merged = applyNxJsonMigrateDefaults(base, config, noEnv);
+      expect(() => assertCommitPrefixHasCommits(merged)).not.toThrow();
     });
 
     it('allows a config commit prefix when createCommits is enabled via the CLI', () => {
       const config: NxMigrateConfiguration = {
         commitPrefix: 'chore: migrate ',
       };
-      const result = applyNxJsonMigrateDefaults(
+      const merged = applyNxJsonMigrateDefaults(
         { ...base, createCommits: true },
         config,
         noEnv
       );
-      expect(result.commitPrefix).toBe('chore: migrate ');
+      expect(merged.commitPrefix).toBe('chore: migrate ');
+      expect(() => assertCommitPrefixHasCommits(merged)).not.toThrow();
     });
 
     it('allows a config commit prefix when the agentic flow may enable commits', () => {
@@ -149,9 +153,40 @@ describe('applyNxJsonMigrateDefaults', () => {
         commitPrefix: 'chore: migrate ',
         agentic: 'claude-code',
       };
-      expect(() =>
-        applyNxJsonMigrateDefaults(base, config, noEnv)
-      ).not.toThrow();
+      const merged = applyNxJsonMigrateDefaults(base, config, noEnv);
+      expect(() => assertCommitPrefixHasCommits(merged)).not.toThrow();
+    });
+
+    it('allows a custom CLI commit prefix when commits are enabled via config', () => {
+      const config: NxMigrateConfiguration = { createCommits: true };
+      const merged = applyNxJsonMigrateDefaults(
+        { ...base, commitPrefix: 'cli prefix ' },
+        config,
+        noEnv
+      );
+      expect(merged.commitPrefix).toBe('cli prefix ');
+      expect(() => assertCommitPrefixHasCommits(merged)).not.toThrow();
+    });
+
+    it('allows a custom CLI commit prefix when agentic is enabled via config', () => {
+      const config: NxMigrateConfiguration = { agentic: 'claude-code' };
+      const merged = applyNxJsonMigrateDefaults(
+        { ...base, commitPrefix: 'cli prefix ' },
+        config,
+        noEnv
+      );
+      expect(() => assertCommitPrefixHasCommits(merged)).not.toThrow();
+    });
+
+    it('errors on a custom CLI commit prefix when there is no migrate config', () => {
+      const merged = applyNxJsonMigrateDefaults(
+        { ...base, commitPrefix: 'cli prefix ' },
+        undefined,
+        noEnv
+      );
+      expect(() => assertCommitPrefixHasCommits(merged)).toThrow(
+        /requires commits to be enabled/i
+      );
     });
 
     it('errors on an invalid config agentic value', () => {

--- a/packages/nx/src/command-line/migrate/migrate-config.spec.ts
+++ b/packages/nx/src/command-line/migrate/migrate-config.spec.ts
@@ -197,18 +197,49 @@ describe('applyNxJsonMigrateDefaults', () => {
         /Invalid nx\.json migrate\.agentic/i
       );
     });
+
+    it('errors on a non-boolean config createCommits', () => {
+      const config = {
+        createCommits: 'false',
+      } as unknown as NxMigrateConfiguration;
+      expect(() => applyNxJsonMigrateDefaults(base, config, noEnv)).toThrow(
+        /Invalid nx\.json migrate\.createCommits .*Expected a boolean/i
+      );
+    });
+
+    it('errors on a non-string config commitPrefix', () => {
+      const config = {
+        createCommits: true,
+        commitPrefix: 123,
+      } as unknown as NxMigrateConfiguration;
+      expect(() => applyNxJsonMigrateDefaults(base, config, noEnv)).toThrow(
+        /Invalid nx\.json migrate\.commitPrefix .*Expected a string/i
+      );
+    });
+
+    it('errors on a non-boolean config validate', () => {
+      const config = {
+        validate: 'true',
+      } as unknown as NxMigrateConfiguration;
+      expect(() => applyNxJsonMigrateDefaults(base, config, noEnv)).toThrow(
+        /Invalid nx\.json migrate\.validate .*Expected a boolean/i
+      );
+    });
   });
 
   describe('generate-migrations phase', () => {
     const base = { packageAndVersion: 'nx@latest' };
 
-    it('fills generate-only options from config when not provided on the CLI', () => {
+    it('carries config mode as modeFromConfig (not mode) and fills other generate-only options', () => {
       const config: NxMigrateConfiguration = {
         mode: 'first-party',
         multiMajorMode: 'gradual',
       };
       const result = applyNxJsonMigrateDefaults(base, config, noEnv);
-      expect(result.mode).toBe('first-party');
+      // Carried separately so it is never treated as an explicit `--mode`,
+      // which would hard-fail `nx migrate <non-nx-pkg>`.
+      expect(result.mode).toBeUndefined();
+      expect(result.modeFromConfig).toBe('first-party');
       expect(result.multiMajorMode).toBe('gradual');
     });
 
@@ -234,6 +265,7 @@ describe('applyNxJsonMigrateDefaults', () => {
       };
       const result = applyNxJsonMigrateDefaults(args, config, noEnv);
       expect(result.mode).toBe('all');
+      expect(result.modeFromConfig).toBeUndefined();
       expect(result.multiMajorMode).toBe('direct');
     });
 

--- a/packages/nx/src/command-line/migrate/migrate-config.spec.ts
+++ b/packages/nx/src/command-line/migrate/migrate-config.spec.ts
@@ -1,0 +1,230 @@
+import { applyNxJsonMigrateDefaults } from './migrate-config';
+import { DEFAULT_MIGRATION_COMMIT_PREFIX } from './command-object';
+import type { NxMigrateConfiguration } from '../../config/nx-json';
+
+// Empty env so NX_MULTI_MAJOR_MODE never leaks in from the host.
+const noEnv: NodeJS.ProcessEnv = {};
+
+describe('applyNxJsonMigrateDefaults', () => {
+  it('returns the args unchanged when there is no migrate config', () => {
+    const args = { runMigrations: 'migrations.json' };
+    expect(applyNxJsonMigrateDefaults(args, undefined, noEnv)).toBe(args);
+  });
+
+  it('does not mutate the input args', () => {
+    const args = { runMigrations: 'migrations.json' };
+    const config: NxMigrateConfiguration = { createCommits: true };
+    const result = applyNxJsonMigrateDefaults(args, config, noEnv);
+    expect(args).toEqual({ runMigrations: 'migrations.json' });
+    expect(result).not.toBe(args);
+  });
+
+  describe('run-migrations phase', () => {
+    const base = { runMigrations: 'migrations.json' };
+
+    it('fills run-phase options from config when not provided on the CLI', () => {
+      const config: NxMigrateConfiguration = {
+        createCommits: true,
+        commitPrefix: 'chore: migrate ',
+        agentic: 'claude-code',
+        validate: false,
+      };
+      const result = applyNxJsonMigrateDefaults(base, config, noEnv);
+      expect(result).toMatchObject({
+        createCommits: true,
+        commitPrefix: 'chore: migrate ',
+        agentic: 'claude-code',
+        validate: false,
+      });
+    });
+
+    it('lets the CLI flag win over config', () => {
+      const args = {
+        ...base,
+        createCommits: false,
+        agentic: 'codex',
+        validate: true,
+      };
+      const config: NxMigrateConfiguration = {
+        createCommits: true,
+        agentic: 'claude-code',
+        validate: false,
+      };
+      const result = applyNxJsonMigrateDefaults(args, config, noEnv);
+      expect(result.createCommits).toBe(false);
+      expect(result.agentic).toBe('codex');
+      expect(result.validate).toBe(true);
+    });
+
+    it('treats the default commit prefix as "not provided" so config can override it', () => {
+      const args = {
+        ...base,
+        createCommits: true,
+        commitPrefix: DEFAULT_MIGRATION_COMMIT_PREFIX,
+      };
+      const config: NxMigrateConfiguration = {
+        commitPrefix: 'chore: migrate ',
+      };
+      const result = applyNxJsonMigrateDefaults(args, config, noEnv);
+      expect(result.commitPrefix).toBe('chore: migrate ');
+    });
+
+    it('keeps a custom CLI commit prefix over config', () => {
+      const args = {
+        ...base,
+        createCommits: true,
+        commitPrefix: 'cli prefix ',
+      };
+      const config: NxMigrateConfiguration = { commitPrefix: 'config prefix ' };
+      const result = applyNxJsonMigrateDefaults(args, config, noEnv);
+      expect(result.commitPrefix).toBe('cli prefix ');
+    });
+
+    it('coerces config agentic booleans', () => {
+      expect(
+        applyNxJsonMigrateDefaults(base, { agentic: true }, noEnv).agentic
+      ).toBe(true);
+      expect(
+        applyNxJsonMigrateDefaults(base, { agentic: false }, noEnv).agentic
+      ).toBe(false);
+    });
+
+    it('does not apply generate-only options in run-migrations mode', () => {
+      const config: NxMigrateConfiguration = {
+        mode: 'first-party',
+        multiMajorMode: 'gradual',
+      };
+      const result = applyNxJsonMigrateDefaults(base, config, noEnv);
+      expect(result.mode).toBeUndefined();
+      expect(result.multiMajorMode).toBeUndefined();
+    });
+
+    it('detects run-migrations mode even when the value is an empty string', () => {
+      const config: NxMigrateConfiguration = {
+        createCommits: true,
+        mode: 'first-party',
+      };
+      const result = applyNxJsonMigrateDefaults(
+        { runMigrations: '' },
+        config,
+        noEnv
+      );
+      expect(result.createCommits).toBe(true);
+      expect(result.mode).toBeUndefined();
+    });
+
+    it('errors when a config commit prefix is set without commits enabled', () => {
+      const config: NxMigrateConfiguration = {
+        commitPrefix: 'chore: migrate ',
+      };
+      expect(() => applyNxJsonMigrateDefaults(base, config, noEnv)).toThrow(
+        /requires commits to be enabled/i
+      );
+    });
+
+    it('allows a config commit prefix when createCommits is enabled via config', () => {
+      const config: NxMigrateConfiguration = {
+        commitPrefix: 'chore: migrate ',
+        createCommits: true,
+      };
+      expect(() =>
+        applyNxJsonMigrateDefaults(base, config, noEnv)
+      ).not.toThrow();
+    });
+
+    it('allows a config commit prefix when createCommits is enabled via the CLI', () => {
+      const config: NxMigrateConfiguration = {
+        commitPrefix: 'chore: migrate ',
+      };
+      const result = applyNxJsonMigrateDefaults(
+        { ...base, createCommits: true },
+        config,
+        noEnv
+      );
+      expect(result.commitPrefix).toBe('chore: migrate ');
+    });
+
+    it('allows a config commit prefix when the agentic flow may enable commits', () => {
+      const config: NxMigrateConfiguration = {
+        commitPrefix: 'chore: migrate ',
+        agentic: 'claude-code',
+      };
+      expect(() =>
+        applyNxJsonMigrateDefaults(base, config, noEnv)
+      ).not.toThrow();
+    });
+
+    it('errors on an invalid config agentic value', () => {
+      const config = {
+        agentic: 'not-an-agent',
+      } as unknown as NxMigrateConfiguration;
+      expect(() => applyNxJsonMigrateDefaults(base, config, noEnv)).toThrow(
+        /Invalid nx\.json migrate\.agentic/i
+      );
+    });
+  });
+
+  describe('generate-migrations phase', () => {
+    const base = { packageAndVersion: 'nx@latest' };
+
+    it('fills generate-only options from config when not provided on the CLI', () => {
+      const config: NxMigrateConfiguration = {
+        mode: 'first-party',
+        multiMajorMode: 'gradual',
+      };
+      const result = applyNxJsonMigrateDefaults(base, config, noEnv);
+      expect(result.mode).toBe('first-party');
+      expect(result.multiMajorMode).toBe('gradual');
+    });
+
+    it('does not apply run-only options in generate-migrations mode', () => {
+      const config: NxMigrateConfiguration = {
+        createCommits: true,
+        commitPrefix: 'chore: migrate ',
+        agentic: 'claude-code',
+        validate: false,
+      };
+      const result = applyNxJsonMigrateDefaults(base, config, noEnv);
+      expect(result.createCommits).toBeUndefined();
+      expect(result.commitPrefix).toBeUndefined();
+      expect(result.agentic).toBeUndefined();
+      expect(result.validate).toBeUndefined();
+    });
+
+    it('lets the CLI flag win over config', () => {
+      const args = { ...base, mode: 'all', multiMajorMode: 'direct' };
+      const config: NxMigrateConfiguration = {
+        mode: 'first-party',
+        multiMajorMode: 'gradual',
+      };
+      const result = applyNxJsonMigrateDefaults(args, config, noEnv);
+      expect(result.mode).toBe('all');
+      expect(result.multiMajorMode).toBe('direct');
+    });
+
+    it('lets NX_MULTI_MAJOR_MODE take precedence over config', () => {
+      const config: NxMigrateConfiguration = { multiMajorMode: 'gradual' };
+      const result = applyNxJsonMigrateDefaults(base, config, {
+        NX_MULTI_MAJOR_MODE: 'direct',
+      });
+      // Not applied from config; the env var is resolved later by the migrator.
+      expect(result.multiMajorMode).toBeUndefined();
+    });
+
+    it('errors on an invalid config mode value', () => {
+      const config = { mode: 'bogus' } as unknown as NxMigrateConfiguration;
+      expect(() => applyNxJsonMigrateDefaults(base, config, noEnv)).toThrow(
+        /Invalid nx\.json migrate\.mode/i
+      );
+    });
+
+    it('errors on an invalid config multiMajorMode value', () => {
+      const config = {
+        multiMajorMode: 'bogus',
+      } as unknown as NxMigrateConfiguration;
+      expect(() => applyNxJsonMigrateDefaults(base, config, noEnv)).toThrow(
+        /Invalid nx\.json migrate\.multiMajorMode/i
+      );
+    });
+  });
+});

--- a/packages/nx/src/command-line/migrate/migrate-config.ts
+++ b/packages/nx/src/command-line/migrate/migrate-config.ts
@@ -1,9 +1,11 @@
 import type { NxMigrateConfiguration } from '../../config/nx-json';
 import { AGENT_IDS, coerceAgenticArg } from './agentic/cli-args';
+import type { AgenticArg } from './agentic/select';
 import {
   customCommitPrefixHasNoEffect,
   DEFAULT_MIGRATION_COMMIT_PREFIX,
   MIGRATE_MODES,
+  type MigrateArgs,
   MULTI_MAJOR_MODES,
 } from './command-object';
 
@@ -19,12 +21,16 @@ const MULTI_MAJOR_MODE_ENV = 'NX_MULTI_MAJOR_MODE';
  * `commitPrefix`, `agentic`, `validate`) only when running migrations. This
  * mirrors where each option is consumed and avoids tripping the "cannot be
  * combined with --run-migrations" guards in `parseMigrationsOptions`.
+ *
+ * `mode` is carried as `modeFromConfig` rather than `mode` so it is never
+ * mistaken for an explicit `--mode`: `resolveMode` applies it only when the
+ * target is Nx itself, leaving `nx migrate <non-nx-pkg>` unaffected.
  */
 export function applyNxJsonMigrateDefaults(
-  args: { [k: string]: any },
+  args: MigrateArgs,
   migrateConfig: NxMigrateConfiguration | undefined,
   env: NodeJS.ProcessEnv = process.env
-): { [k: string]: any } {
+): MigrateArgs {
   if (!migrateConfig) {
     return args;
   }
@@ -39,6 +45,7 @@ export function applyNxJsonMigrateDefaults(
       merged.createCommits === undefined &&
       migrateConfig.createCommits !== undefined
     ) {
+      assertType(migrateConfig.createCommits, 'boolean', 'createCommits');
       merged.createCommits = migrateConfig.createCommits;
     }
     // `commitPrefix` carries a yargs default, so the default value is
@@ -49,19 +56,21 @@ export function applyNxJsonMigrateDefaults(
         merged.commitPrefix === DEFAULT_MIGRATION_COMMIT_PREFIX) &&
       migrateConfig.commitPrefix !== undefined
     ) {
+      assertType(migrateConfig.commitPrefix, 'string', 'commitPrefix');
       merged.commitPrefix = migrateConfig.commitPrefix;
     }
     if (merged.agentic === undefined && migrateConfig.agentic !== undefined) {
       assertValidAgentic(migrateConfig.agentic);
-      merged.agentic = coerceAgenticArg(migrateConfig.agentic);
+      merged.agentic = coerceAgenticArg(migrateConfig.agentic) as AgenticArg;
     }
     if (merged.validate === undefined && migrateConfig.validate !== undefined) {
+      assertType(migrateConfig.validate, 'boolean', 'validate');
       merged.validate = migrateConfig.validate;
     }
   } else {
     if (merged.mode === undefined && migrateConfig.mode !== undefined) {
       assertOneOf(migrateConfig.mode, MIGRATE_MODES, 'mode');
-      merged.mode = migrateConfig.mode;
+      merged.modeFromConfig = migrateConfig.mode;
     }
     // The NX_MULTI_MAJOR_MODE env var is an established per-invocation override,
     // so it takes precedence over nx.json (CLI flag > env > nx.json > default).
@@ -96,6 +105,20 @@ function assertOneOf(
   }
 }
 
+function assertType(
+  value: unknown,
+  type: 'boolean' | 'string',
+  field: string
+): void {
+  if (typeof value !== type) {
+    throw new Error(
+      `Error: Invalid nx.json migrate.${field} ${JSON.stringify(
+        value
+      )}. Expected a ${type}.`
+    );
+  }
+}
+
 function assertValidAgentic(agentic: unknown): void {
   if (typeof agentic === 'boolean') {
     return;
@@ -120,9 +143,7 @@ function assertValidAgentic(agentic: unknown): void {
  * `.check()` only fast-fails the unrescuable explicit `--no-create-commits`
  * case; everything else is decided here.
  */
-export function assertCommitPrefixHasCommits(merged: {
-  [k: string]: any;
-}): void {
+export function assertCommitPrefixHasCommits(merged: MigrateArgs): void {
   const { createCommits, commitPrefix, agentic } = merged;
   if (customCommitPrefixHasNoEffect({ createCommits, commitPrefix, agentic })) {
     throw new Error(

--- a/packages/nx/src/command-line/migrate/migrate-config.ts
+++ b/packages/nx/src/command-line/migrate/migrate-config.ts
@@ -1,0 +1,135 @@
+import type { NxMigrateConfiguration } from '../../config/nx-json';
+import { AGENT_IDS, coerceAgenticArg } from './agentic/cli-args';
+import { DEFAULT_MIGRATION_COMMIT_PREFIX } from './command-object';
+
+const MULTI_MAJOR_MODE_ENV = 'NX_MULTI_MAJOR_MODE';
+const VALID_MODES = ['first-party', 'third-party', 'all'];
+const VALID_MULTI_MAJOR_MODES = ['direct', 'gradual'];
+
+/**
+ * Overlays `nx.json` `migrate` defaults onto the raw `nx migrate` CLI args so a
+ * CLI flag always wins, then `nx.json`, then the built-in default. Returns a new
+ * args object; the input is not mutated.
+ *
+ * Phase-aware: generate-only options (`mode`, `multiMajorMode`) are applied only
+ * when not running migrations; run-only options (`createCommits`,
+ * `commitPrefix`, `agentic`, `validate`) only when running migrations. This
+ * mirrors where each option is consumed and avoids tripping the "cannot be
+ * combined with --run-migrations" guards in `parseMigrationsOptions`.
+ */
+export function applyNxJsonMigrateDefaults(
+  args: { [k: string]: any },
+  migrateConfig: NxMigrateConfiguration | undefined,
+  env: NodeJS.ProcessEnv = process.env
+): { [k: string]: any } {
+  if (!migrateConfig) {
+    return args;
+  }
+
+  const merged = { ...args };
+  // `--run-migrations` with no value is normalized to '' by yargs, so a defined
+  // (even empty-string) value means we're in the run-migrations phase.
+  const isRunMigrations = merged.runMigrations !== undefined;
+
+  if (isRunMigrations) {
+    if (
+      merged.createCommits === undefined &&
+      migrateConfig.createCommits !== undefined
+    ) {
+      merged.createCommits = migrateConfig.createCommits;
+    }
+    // `commitPrefix` carries a yargs default, so the default value is
+    // indistinguishable from "not provided" — treat it as not provided so
+    // nx.json can override it.
+    if (
+      (merged.commitPrefix === undefined ||
+        merged.commitPrefix === DEFAULT_MIGRATION_COMMIT_PREFIX) &&
+      migrateConfig.commitPrefix !== undefined
+    ) {
+      merged.commitPrefix = migrateConfig.commitPrefix;
+    }
+    if (merged.agentic === undefined && migrateConfig.agentic !== undefined) {
+      assertValidAgentic(migrateConfig.agentic);
+      merged.agentic = coerceAgenticArg(migrateConfig.agentic);
+    }
+    if (merged.validate === undefined && migrateConfig.validate !== undefined) {
+      merged.validate = migrateConfig.validate;
+    }
+
+    assertCommitPrefixHasCommits(merged);
+  } else {
+    if (merged.mode === undefined && migrateConfig.mode !== undefined) {
+      assertValidMode(migrateConfig.mode);
+      merged.mode = migrateConfig.mode;
+    }
+    // The NX_MULTI_MAJOR_MODE env var is an established per-invocation override,
+    // so it takes precedence over nx.json (CLI flag > env > nx.json > default).
+    if (
+      merged.multiMajorMode === undefined &&
+      !env[MULTI_MAJOR_MODE_ENV] &&
+      migrateConfig.multiMajorMode !== undefined
+    ) {
+      assertValidMultiMajorMode(migrateConfig.multiMajorMode);
+      merged.multiMajorMode = migrateConfig.multiMajorMode;
+    }
+  }
+
+  return merged;
+}
+
+function assertValidMode(mode: unknown): void {
+  if (!VALID_MODES.includes(mode as string)) {
+    throw new Error(
+      `Error: Invalid nx.json migrate.mode "${mode}". Allowed: ${VALID_MODES.join(
+        ', '
+      )}.`
+    );
+  }
+}
+
+function assertValidMultiMajorMode(multiMajorMode: unknown): void {
+  if (!VALID_MULTI_MAJOR_MODES.includes(multiMajorMode as string)) {
+    throw new Error(
+      `Error: Invalid nx.json migrate.multiMajorMode "${multiMajorMode}". Allowed: ${VALID_MULTI_MAJOR_MODES.join(
+        ', '
+      )}.`
+    );
+  }
+}
+
+function assertValidAgentic(agentic: unknown): void {
+  if (typeof agentic === 'boolean') {
+    return;
+  }
+  if (
+    typeof agentic !== 'string' ||
+    !(AGENT_IDS as readonly string[]).includes(agentic)
+  ) {
+    throw new Error(
+      `Error: Invalid nx.json migrate.agentic "${agentic}". Allowed: ${AGENT_IDS.join(
+        ', '
+      )}, true, false.`
+    );
+  }
+}
+
+// Mirrors the yargs `.check()` guard: a custom commit prefix has no effect
+// unless commits are enabled. Re-checked here because the yargs guard only saw
+// the CLI args, before nx.json defaults were merged in. The
+// `commitPrefix !== DEFAULT` test doubles as the "was it customized" sentinel,
+// matching how the prefix is overlaid above.
+function assertCommitPrefixHasCommits(merged: { [k: string]: any }): void {
+  const { createCommits, commitPrefix, agentic } = merged;
+  const agenticMayEnableCommits =
+    agentic !== undefined && agentic !== false && createCommits !== false;
+  if (
+    createCommits !== true &&
+    !agenticMayEnableCommits &&
+    commitPrefix !== undefined &&
+    commitPrefix !== DEFAULT_MIGRATION_COMMIT_PREFIX
+  ) {
+    throw new Error(
+      'Error: A custom migrate commit prefix requires commits to be enabled. Set `migrate.createCommits` to `true` in nx.json or pass `--create-commits`.'
+    );
+  }
+}

--- a/packages/nx/src/command-line/migrate/migrate-config.ts
+++ b/packages/nx/src/command-line/migrate/migrate-config.ts
@@ -42,7 +42,7 @@ export function applyNxJsonMigrateDefaults(
       merged.createCommits = migrateConfig.createCommits;
     }
     // `commitPrefix` carries a yargs default, so the default value is
-    // indistinguishable from "not provided" — treat it as not provided so
+    // indistinguishable from "not provided" - treat it as not provided so
     // nx.json can override it.
     if (
       (merged.commitPrefix === undefined ||
@@ -58,8 +58,6 @@ export function applyNxJsonMigrateDefaults(
     if (merged.validate === undefined && migrateConfig.validate !== undefined) {
       merged.validate = migrateConfig.validate;
     }
-
-    assertCommitPrefixHasCommits(merged);
   } else {
     if (merged.mode === undefined && migrateConfig.mode !== undefined) {
       assertOneOf(migrateConfig.mode, MIGRATE_MODES, 'mode');
@@ -114,9 +112,17 @@ function assertValidAgentic(agentic: unknown): void {
   }
 }
 
-// Re-runs the shared commit-prefix guard against the merged args: the yargs
-// `.check()` only saw the CLI args, before nx.json defaults were applied.
-function assertCommitPrefixHasCommits(merged: { [k: string]: any }): void {
+/**
+ * The single authority for the "a custom commit prefix needs commits enabled"
+ * invariant. Run it against the final merged args (after
+ * `applyNxJsonMigrateDefaults`): the yargs `.check()` only sees the CLI args,
+ * but nx.json may enable commits via `createCommits` or `agentic`. The CLI
+ * `.check()` only fast-fails the unrescuable explicit `--no-create-commits`
+ * case; everything else is decided here.
+ */
+export function assertCommitPrefixHasCommits(merged: {
+  [k: string]: any;
+}): void {
   const { createCommits, commitPrefix, agentic } = merged;
   if (customCommitPrefixHasNoEffect({ createCommits, commitPrefix, agentic })) {
     throw new Error(

--- a/packages/nx/src/command-line/migrate/migrate-config.ts
+++ b/packages/nx/src/command-line/migrate/migrate-config.ts
@@ -1,10 +1,13 @@
 import type { NxMigrateConfiguration } from '../../config/nx-json';
 import { AGENT_IDS, coerceAgenticArg } from './agentic/cli-args';
-import { DEFAULT_MIGRATION_COMMIT_PREFIX } from './command-object';
+import {
+  customCommitPrefixHasNoEffect,
+  DEFAULT_MIGRATION_COMMIT_PREFIX,
+  MIGRATE_MODES,
+  MULTI_MAJOR_MODES,
+} from './command-object';
 
 const MULTI_MAJOR_MODE_ENV = 'NX_MULTI_MAJOR_MODE';
-const VALID_MODES = ['first-party', 'third-party', 'all'];
-const VALID_MULTI_MAJOR_MODES = ['direct', 'gradual'];
 
 /**
  * Overlays `nx.json` `migrate` defaults onto the raw `nx migrate` CLI args so a
@@ -59,7 +62,7 @@ export function applyNxJsonMigrateDefaults(
     assertCommitPrefixHasCommits(merged);
   } else {
     if (merged.mode === undefined && migrateConfig.mode !== undefined) {
-      assertValidMode(migrateConfig.mode);
+      assertOneOf(migrateConfig.mode, MIGRATE_MODES, 'mode');
       merged.mode = migrateConfig.mode;
     }
     // The NX_MULTI_MAJOR_MODE env var is an established per-invocation override,
@@ -69,7 +72,11 @@ export function applyNxJsonMigrateDefaults(
       !env[MULTI_MAJOR_MODE_ENV] &&
       migrateConfig.multiMajorMode !== undefined
     ) {
-      assertValidMultiMajorMode(migrateConfig.multiMajorMode);
+      assertOneOf(
+        migrateConfig.multiMajorMode,
+        MULTI_MAJOR_MODES,
+        'multiMajorMode'
+      );
       merged.multiMajorMode = migrateConfig.multiMajorMode;
     }
   }
@@ -77,20 +84,14 @@ export function applyNxJsonMigrateDefaults(
   return merged;
 }
 
-function assertValidMode(mode: unknown): void {
-  if (!VALID_MODES.includes(mode as string)) {
+function assertOneOf(
+  value: unknown,
+  allowed: readonly string[],
+  field: string
+): void {
+  if (!allowed.includes(value as string)) {
     throw new Error(
-      `Error: Invalid nx.json migrate.mode "${mode}". Allowed: ${VALID_MODES.join(
-        ', '
-      )}.`
-    );
-  }
-}
-
-function assertValidMultiMajorMode(multiMajorMode: unknown): void {
-  if (!VALID_MULTI_MAJOR_MODES.includes(multiMajorMode as string)) {
-    throw new Error(
-      `Error: Invalid nx.json migrate.multiMajorMode "${multiMajorMode}". Allowed: ${VALID_MULTI_MAJOR_MODES.join(
+      `Error: Invalid nx.json migrate.${field} "${value}". Allowed: ${allowed.join(
         ', '
       )}.`
     );
@@ -113,21 +114,11 @@ function assertValidAgentic(agentic: unknown): void {
   }
 }
 
-// Mirrors the yargs `.check()` guard: a custom commit prefix has no effect
-// unless commits are enabled. Re-checked here because the yargs guard only saw
-// the CLI args, before nx.json defaults were merged in. The
-// `commitPrefix !== DEFAULT` test doubles as the "was it customized" sentinel,
-// matching how the prefix is overlaid above.
+// Re-runs the shared commit-prefix guard against the merged args: the yargs
+// `.check()` only saw the CLI args, before nx.json defaults were applied.
 function assertCommitPrefixHasCommits(merged: { [k: string]: any }): void {
   const { createCommits, commitPrefix, agentic } = merged;
-  const agenticMayEnableCommits =
-    agentic !== undefined && agentic !== false && createCommits !== false;
-  if (
-    createCommits !== true &&
-    !agenticMayEnableCommits &&
-    commitPrefix !== undefined &&
-    commitPrefix !== DEFAULT_MIGRATION_COMMIT_PREFIX
-  ) {
+  if (customCommitPrefixHasNoEffect({ createCommits, commitPrefix, agentic })) {
     throw new Error(
       'Error: A custom migrate commit prefix requires commits to be enabled. Set `migrate.createCommits` to `true` in nx.json or pass `--create-commits`.'
     );

--- a/packages/nx/src/command-line/migrate/migrate.spec.ts
+++ b/packages/nx/src/command-line/migrate/migrate.spec.ts
@@ -37,6 +37,7 @@ import {
   resolveCreateCommits,
   resolveMode,
 } from './migrate';
+import { applyNxJsonMigrateDefaults } from './migrate-config';
 import {
   readPromptFilesFromInstall,
   validateMigrationEntries,
@@ -2654,6 +2655,39 @@ describe('Migration', () => {
         child: { version: '2.0.0', addToPackageJson: false },
       });
     });
+
+    describe('nx.json migrate.mode overlay (integration)', () => {
+      it('does not treat nx.json migrate.mode as an explicit --mode for a non-Nx target', async () => {
+        // The original footgun: a workspace-wide migrate.mode default made
+        // `nx migrate <non-nx-pkg>` hard-fail with a `--mode` error the user
+        // never passed. The overlay must carry it as a default, not a flag.
+        const result = await parseMigrationsOptions(
+          applyNxJsonMigrateDefaults(
+            { packageAndVersion: '@angular/core' },
+            { mode: 'first-party' }
+          )
+        );
+        expect(result).toMatchObject({
+          type: 'generateMigrations',
+          targetPackage: '@angular/core',
+          mode: 'all',
+        });
+      });
+
+      it('applies nx.json migrate.mode through the overlay for an Nx target', async () => {
+        const result = await parseMigrationsOptions(
+          applyNxJsonMigrateDefaults(
+            { packageAndVersion: 'nx@22.0.0' },
+            { mode: 'first-party' }
+          )
+        );
+        expect(result).toMatchObject({
+          type: 'generateMigrations',
+          targetPackage: 'nx',
+          mode: 'first-party',
+        });
+      });
+    });
   });
 
   describe('resolveMode', () => {
@@ -2784,6 +2818,74 @@ describe('Migration', () => {
         'first-party',
         'all',
       ]);
+    });
+
+    it('uses the nx.json configured mode for an nx target without prompting', async () => {
+      Object.defineProperty(process.stdin, 'isTTY', {
+        value: true,
+        configurable: true,
+      });
+      process.env.CI = 'false';
+      const result = await resolveMode(
+        undefined,
+        'nx',
+        '22.0.0',
+        undefined,
+        'first-party'
+      );
+      expect(result).toBe('first-party');
+      expect(mockPrompt).not.toHaveBeenCalled();
+    });
+
+    it('uses the nx.json configured mode for an nx target in CI', async () => {
+      Object.defineProperty(process.stdin, 'isTTY', {
+        value: true,
+        configurable: true,
+      });
+      process.env.CI = 'true';
+      const result = await resolveMode(
+        undefined,
+        'nx',
+        '22.0.0',
+        undefined,
+        'first-party'
+      );
+      expect(result).toBe('first-party');
+      expect(mockPrompt).not.toHaveBeenCalled();
+    });
+
+    it('lets an explicit mode win over the nx.json configured mode', async () => {
+      Object.defineProperty(process.stdin, 'isTTY', {
+        value: true,
+        configurable: true,
+      });
+      process.env.CI = 'false';
+      const result = await resolveMode(
+        'all',
+        'nx',
+        '22.0.0',
+        undefined,
+        'first-party'
+      );
+      expect(result).toBe('all');
+      expect(mockPrompt).not.toHaveBeenCalled();
+    });
+
+    it('ignores the nx.json configured mode for a non-nx-equivalent target', async () => {
+      Object.defineProperty(process.stdin, 'isTTY', {
+        value: true,
+        configurable: true,
+      });
+      process.env.CI = 'false';
+      const result = await resolveMode(
+        undefined,
+        '@nx/react',
+        '22.0.0',
+        undefined,
+        'first-party'
+      );
+      expect(result).toBe('all');
+      expect(mockPrompt).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/nx/src/command-line/migrate/migrate.spec.ts
+++ b/packages/nx/src/command-line/migrate/migrate.spec.ts
@@ -4174,6 +4174,39 @@ describe('Migration', () => {
         });
         expect(result.warning).not.toMatch(/--commit-prefix/);
       });
+
+      it('warns that a configured commit prefix has no effect when commits stay disabled', () => {
+        const result = resolveCreateCommits({
+          createCommits: undefined,
+          agenticKind: 'disabled',
+          isGitRepo: true,
+          commitPrefixIsCustom: true,
+        });
+        expect(result.effective).toBe(false);
+        expect(result.warning).toMatch(/no effect/);
+        expect(result.warning).toMatch(/createCommits/);
+      });
+
+      it('does not warn about the commit prefix when commits are disabled and the prefix is default', () => {
+        const result = resolveCreateCommits({
+          createCommits: undefined,
+          agenticKind: 'disabled',
+          isGitRepo: true,
+          commitPrefixIsCustom: false,
+        });
+        expect(result.warning).toBeUndefined();
+      });
+
+      it('does not warn when commits are enabled even though the agentic flow is disabled', () => {
+        const result = resolveCreateCommits({
+          createCommits: true,
+          agenticKind: 'disabled',
+          isGitRepo: true,
+          commitPrefixIsCustom: true,
+        });
+        expect(result.effective).toBe(true);
+        expect(result.warning).toBeUndefined();
+      });
     });
 
     describe('parseMigrationReturn', () => {

--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -2456,9 +2456,19 @@ export function resolveCreateCommits(args: {
     return { effective: true, agenticHasDiffContext: true };
   }
 
+  // Commits aren't enabled on this path. A custom commit prefix only reaches
+  // here via nx.json (the CLI guard rejects a custom `--commit-prefix` without
+  // commits) — e.g. `migrate.commitPrefix` paired with `migrate.agentic`, when
+  // the agentic flow then resolves to disabled (non-interactive / inside an
+  // agent). Surface that the prefix has no effect instead of dropping it
+  // silently.
   return {
     effective: createCommits === true,
     agenticHasDiffContext: false,
+    warning:
+      commitPrefixIsCustom && createCommits !== true
+        ? 'A custom migrate commit prefix is configured, but commits are not enabled for this run, so it has no effect. Set `migrate.createCommits` to `true` (or pass `--create-commits`) to create a commit per migration.'
+        : undefined,
   };
 }
 

--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -110,6 +110,7 @@ import {
 } from './prompt-files';
 import type { AgenticArg } from './agentic/select';
 import { DEFAULT_MIGRATION_COMMIT_PREFIX } from './command-object';
+import { applyNxJsonMigrateDefaults } from './migrate-config';
 import type { EnabledResolvedAgentic, ResolvedAgentic } from './agentic/types';
 import {
   applyAgenticHandoffGitignoreFallback,
@@ -3329,7 +3330,8 @@ export async function migrate(
   await daemonClient.stop();
 
   return handleErrors(process.env.NX_VERBOSE_LOGGING === 'true', async () => {
-    const opts = await parseMigrationsOptions(args);
+    const mergedArgs = applyNxJsonMigrateDefaults(args, readNxJson().migrate);
+    const opts = await parseMigrationsOptions(mergedArgs);
     if (opts.type === 'generateMigrations') {
       await generateMigrationsJsonAndUpdatePackageJson(root, opts);
     } else {
@@ -3338,10 +3340,10 @@ export async function migrate(
           root,
           opts,
           rawArgs,
-          args['verbose'],
-          args['createCommits'],
-          args['commitPrefix'],
-          args['skipInstall']
+          mergedArgs['verbose'],
+          mergedArgs['createCommits'],
+          mergedArgs['commitPrefix'],
+          mergedArgs['skipInstall']
         );
       } catch (e) {
         // The remediation guidance is already logged by `runInstall`; swallow

--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -952,13 +952,19 @@ export async function resolveMode(
   context: { hasFrom: boolean; hasExcludeAppliedMigrations: boolean } = {
     hasFrom: false,
     hasExcludeAppliedMigrations: false,
-  }
+  },
+  configuredMode?: MigrateMode
 ): Promise<MigrateMode> {
   if (mode) {
     return mode;
   }
   if (!isNxEquivalentTarget(targetPackage, targetVersion)) {
     return 'all';
+  }
+  // nx.json `migrate.mode` pre-selects the value the interactive prompt would
+  // ask for; it applies only to Nx targets (non-Nx returned 'all' above).
+  if (configuredMode) {
+    return configuredMode;
   }
   if (!process.stdin.isTTY || isCI()) {
     return 'all';
@@ -1150,6 +1156,13 @@ export async function parseMigrationsOptions(options: {
   targetVersion = multiMajorResult.chosen;
 
   if (mode === 'third-party') {
+    // `mode` can resolve to third-party via nx.json, which bypasses the early
+    // CLI-only check above; re-assert against the resolved mode.
+    assertThirdPartyModeFlagCompatibility({
+      mode,
+      from: options.from,
+      excludeAppliedMigrations: options.excludeAppliedMigrations,
+    });
     assertThirdPartyTargetBounds({
       targetPackage,
       targetVersion,
@@ -1198,6 +1211,7 @@ async function resolveTargetAndMode(args: {
   from: Record<string, string>;
   options: {
     mode?: MigrateMode;
+    modeFromConfig?: MigrateMode;
     excludeAppliedMigrations?: boolean;
   };
 }): Promise<{
@@ -1227,7 +1241,8 @@ async function resolveTargetAndMode(args: {
     {
       hasFrom: Object.keys(from).length > 0,
       hasExcludeAppliedMigrations: options.excludeAppliedMigrations === true,
-    }
+    },
+    options.modeFromConfig
   );
 
   let installedNxVersion: string | null | undefined;
@@ -3354,7 +3369,7 @@ export async function migrate(
           rawArgs,
           mergedArgs['verbose'],
           mergedArgs['createCommits'],
-          mergedArgs['commitPrefix'],
+          mergedArgs['commitPrefix'] ?? DEFAULT_MIGRATION_COMMIT_PREFIX,
           mergedArgs['skipInstall']
         );
       } catch (e) {

--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -110,7 +110,10 @@ import {
 } from './prompt-files';
 import type { AgenticArg } from './agentic/select';
 import { DEFAULT_MIGRATION_COMMIT_PREFIX } from './command-object';
-import { applyNxJsonMigrateDefaults } from './migrate-config';
+import {
+  applyNxJsonMigrateDefaults,
+  assertCommitPrefixHasCommits,
+} from './migrate-config';
 import type { EnabledResolvedAgentic, ResolvedAgentic } from './agentic/types';
 import {
   applyAgenticHandoffGitignoreFallback,
@@ -2456,12 +2459,10 @@ export function resolveCreateCommits(args: {
     return { effective: true, agenticHasDiffContext: true };
   }
 
-  // Commits aren't enabled on this path. A custom commit prefix only reaches
-  // here via nx.json (the CLI guard rejects a custom `--commit-prefix` without
-  // commits) — e.g. `migrate.commitPrefix` paired with `migrate.agentic`, when
-  // the agentic flow then resolves to disabled (non-interactive / inside an
-  // agent). Surface that the prefix has no effect instead of dropping it
-  // silently.
+  // Commits aren't enabled here. A custom prefix only reaches this path via
+  // nx.json (e.g. `migrate.commitPrefix` + `migrate.agentic` when the agentic
+  // flow resolves to disabled); surface that it has no effect rather than
+  // dropping it silently.
   return {
     effective: createCommits === true,
     agenticHasDiffContext: false,
@@ -3341,6 +3342,7 @@ export async function migrate(
 
   return handleErrors(process.env.NX_VERBOSE_LOGGING === 'true', async () => {
     const mergedArgs = applyNxJsonMigrateDefaults(args, readNxJson().migrate);
+    assertCommitPrefixHasCommits(mergedArgs);
     const opts = await parseMigrationsOptions(mergedArgs);
     if (opts.type === 'generateMigrations') {
       await generateMigrationsJsonAndUpdatePackageJson(root, opts);

--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -707,6 +707,55 @@ export interface NxSyncConfiguration {
   disabledTaskSyncGenerators?: string[];
 }
 
+export interface NxMigrateConfiguration {
+  /**
+   * Whether to automatically create a git commit after each migration runs.
+   * Equivalent to the `--create-commits` flag. Defaults to `false`.
+   */
+  createCommits?: boolean;
+
+  /**
+   * Commit message prefix applied to each migration commit when commits are
+   * enabled (via `createCommits` or `--create-commits`). Equivalent to the
+   * `--commit-prefix` flag. Defaults to `"chore: [nx migration] "`.
+   */
+  commitPrefix?: string;
+
+  /**
+   * Restricts which packages to migrate when migrating Nx itself. Equivalent to
+   * the `--mode` flag.
+   * - `first-party`: only Nx and its plugins.
+   * - `third-party`: only the third-party dependencies referenced by Nx.
+   * - `all`: everything (default).
+   */
+  mode?: 'first-party' | 'third-party' | 'all';
+
+  /**
+   * How to handle a migration that crosses more than one major version.
+   * Equivalent to the `--multi-major-mode` flag. The `NX_MULTI_MAJOR_MODE`
+   * environment variable takes precedence over this setting.
+   * - `direct`: migrate straight to the requested target.
+   * - `gradual`: migrate to the smallest recommended step.
+   */
+  multiMajorMode?: 'direct' | 'gradual';
+
+  /**
+   * Default for the agentic flow used by `nx migrate --run-migrations`.
+   * Equivalent to the `--agentic` flag.
+   * - `false`: never use the agentic flow.
+   * - `true`: use the agentic flow and resolve the installed agent.
+   * - an agent id (`"claude-code"`, `"codex"`, `"opencode"`): always use that agent.
+   */
+  agentic?: boolean | 'claude-code' | 'codex' | 'opencode';
+
+  /**
+   * Whether to run agent-driven validation after generator-only migrations when
+   * the agentic flow is enabled. Equivalent to the `--validate` flag. Defaults
+   * to `true` when the agentic flow is enabled.
+   */
+  validate?: boolean;
+}
+
 /**
  * Nx.json configuration
  *
@@ -879,6 +928,11 @@ export interface NxJsonConfiguration<T = '*' | string[]> {
    * Configuration for the `nx sync` command.
    */
   sync?: NxSyncConfiguration;
+
+  /**
+   * Configuration for the `nx migrate` command.
+   */
+  migrate?: NxMigrateConfiguration;
 
   /**
    * Sets the maximum size of the local cache. Accepts a number followed by a unit (e.g. 100MB). Accepted units are B, KB, MB, and GB.

--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -3,6 +3,11 @@ import { dirname, join } from 'node:path';
 import type ChangelogRenderer from '../../release/changelog-renderer';
 import type { ChangelogRenderOptions } from '../../release/changelog-renderer';
 import type { validReleaseVersionPrefixes } from '../command-line/release/utils/release-graph';
+import type { AgentId } from '../command-line/migrate/agentic/cli-args';
+import type {
+  MigrateMode,
+  MultiMajorMode,
+} from '../command-line/migrate/command-object';
 import { readJsonFile } from '../utils/fileutils';
 import type { PackageManager } from '../utils/package-manager';
 import { workspaceRoot } from '../utils/workspace-root';
@@ -728,7 +733,7 @@ export interface NxMigrateConfiguration {
    * - `third-party`: only the third-party dependencies referenced by Nx.
    * - `all`: everything (default).
    */
-  mode?: 'first-party' | 'third-party' | 'all';
+  mode?: MigrateMode;
 
   /**
    * How to handle a migration that crosses more than one major version.
@@ -737,7 +742,7 @@ export interface NxMigrateConfiguration {
    * - `direct`: migrate straight to the requested target.
    * - `gradual`: migrate to the smallest recommended step.
    */
-  multiMajorMode?: 'direct' | 'gradual';
+  multiMajorMode?: MultiMajorMode;
 
   /**
    * Default for the agentic flow used by `nx migrate --run-migrations`.
@@ -746,7 +751,7 @@ export interface NxMigrateConfiguration {
    * - `true`: use the agentic flow and resolve the installed agent.
    * - an agent id (`"claude-code"`, `"codex"`, `"opencode"`): always use that agent.
    */
-  agentic?: boolean | 'claude-code' | 'codex' | 'opencode';
+  agentic?: boolean | AgentId;
 
   /**
    * Whether to run agent-driven validation after generator-only migrations when


### PR DESCRIPTION
## Current Behavior

`nx migrate` is configured entirely through CLI flags — there's no way to set workspace-wide defaults, so every run repeats the same `--create-commits`, `--commit-prefix`, `--mode`, and so on.

When the agentic flow runs during `nx migrate --run-migrations`:

- The "Enable the agentic flow?" prompt is asked on every run, with no way to remember the answer.
- The flow aborts when it can't start — for example in a non-interactive terminal, or when a requested/pinned agent isn't installed.

## Expected Behavior

A new optional `migrate` section in `nx.json` sets workspace-wide defaults for `nx migrate`. A CLI flag always takes precedence over the `nx.json` value, which takes precedence over the built-in default (for `multiMajorMode`: CLI flag > `NX_MULTI_MAJOR_MODE` > `nx.json` > default).

| Option | Applies to |
| --- | --- |
| `createCommits`, `commitPrefix`, `agentic`, `validate` | running migrations (`nx migrate --run-migrations`) |
| `mode`, `multiMajorMode` | generating migrations (`nx migrate <target>`) |

The agentic flow is also more flexible and resilient:

- The "Enable the agentic flow?" prompt now offers to remember your choice; choosing a "remember" option persists it to `migrate.agentic` so you aren't asked again.
- It degrades gracefully instead of aborting. A non-interactive terminal warns and continues without the agentic flow. A requested or pinned agent that isn't installed warns and resolves from the agents that are installed — prompting when several are present, auto-selecting the only one, and erroring only when none are installed.

## Implementation Details

- Adds `NxMigrateConfiguration` to `NxJsonConfiguration`, the `nx.json` JSON schema, and the `nx-json` docs reference.
- `nx.json` defaults are overlaid onto the parsed args in a phase-aware way, so generate-only and run-only options never trip the existing `--run-migrations` guards. Config values (`mode`, `multiMajorMode`, `agentic`) are validated with the same rules as the CLI flags.
- The agentic enable prompt is a single prompt whose choices adapt to how many agents are installed. Persisting writes the raw `nx.json` (so an `extends` preset is never inlined into the user's file) and never throws — a failed write just means the prompt is shown again next time.
- A custom `migrate.commitPrefix` that can't take effect because commits aren't enabled now warns instead of being silently ignored.
- Option value lists and validation are consolidated into single sources of truth shared by the CLI builder, the `nx.json` overlay, and the config types.
- Covered by unit tests for the config overlay, the agentic prompt and agent resolution, and the commit-prefix warning.

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/nxc-4457-5a746c6e)
<!-- polygraph-session-end -->