### PR TITLE
fix(core): prevent the TUI from auto-selecting a completed task when a batch finishes

### DIFF
--- a/packages/nx/src/native/tui/action.rs
+++ b/packages/nx/src/native/tui/action.rs
@@ -3,7 +3,7 @@ use crate::native::tasks::types::{Task, TaskResult};
 use super::{
     app::Focus,
     components::{task_selection_manager::SelectionEntry, tasks_list::TaskStatus},
-    lifecycle::{BatchInfo, TuiMode},
+    lifecycle::{BatchInfo, BatchStatus, TuiMode},
 };
 
 #[derive(Debug, Clone, PartialEq)]
@@ -44,6 +44,7 @@ pub enum Action {
     ShowHint(String),
     SwitchMode(TuiMode),
     StartBatch(String, BatchInfo),
+    EndBatch(String, BatchStatus),
     ExpandBatch(String),
     CollapseBatch(String),
 }

--- a/packages/nx/src/native/tui/app.rs
+++ b/packages/nx/src/native/tui/app.rs
@@ -624,8 +624,11 @@ impl App {
             return;
         }
 
-        // Success and failure trigger ungrouping
-        self.handle_batch_complete(batch_id, status);
+        // Success and failure trigger ungrouping. Route through the action queue
+        // (like StartBatch) so completion is applied on the event-loop thread
+        // AFTER the nested tasks' queued status/timing updates — otherwise the
+        // direct call races those updates and ungroups against stale component state.
+        self.dispatch_action(Action::EndBatch(batch_id, status));
     }
 
     pub fn handle_event(
@@ -1487,6 +1490,9 @@ impl App {
             }
             Action::StartBatch(batch_id, batch_info) => {
                 self.handle_batch_start(batch_id.clone(), batch_info.clone());
+            }
+            Action::EndBatch(batch_id, status) => {
+                self.handle_batch_complete(batch_id.clone(), *status);
             }
             _ => {}
         }
@@ -2498,6 +2504,21 @@ impl App {
     fn handle_batch_complete(&mut self, batch_id: String, final_status: BatchStatus) {
         // Early validation
         if batch_id.is_empty() {
+            return;
+        }
+
+        // A batch reports its status on every run iteration, and incomplete
+        // batches are re-run for their remaining tasks. Only complete (ungroup +
+        // clean up) once every nested task has reached a terminal state, so an
+        // intermediate report doesn't prematurely ungroup and then re-group.
+        // Safe to read component state here: EndBatch is processed on the
+        // event-loop thread after the nested tasks' queued status updates.
+        let all_tasks_complete = self
+            .components
+            .iter()
+            .find_map(|c| c.as_any().downcast_ref::<TasksList>())
+            .map_or(false, |tasks_list| tasks_list.is_batch_complete(&batch_id));
+        if !all_tasks_complete {
             return;
         }
 

--- a/packages/nx/src/native/tui/app.rs
+++ b/packages/nx/src/native/tui/app.rs
@@ -2500,7 +2500,8 @@ impl App {
     }
 
     /// Handles batch completion by ungrouping tasks back to individual display.
-    /// This is called when a batch reaches a terminal state (success or failure).
+    /// Invoked on every batch-status report; only ungroups once all nested tasks
+    /// are terminal (see the guard below).
     fn handle_batch_complete(&mut self, batch_id: String, final_status: BatchStatus) {
         // Early validation
         if batch_id.is_empty() {

--- a/packages/nx/src/native/tui/app.rs
+++ b/packages/nx/src/native/tui/app.rs
@@ -455,10 +455,7 @@ impl App {
 
     /// Check if a task status is considered complete
     fn is_status_complete(status: TaskStatus) -> bool {
-        !matches!(
-            status,
-            TaskStatus::NotStarted | TaskStatus::InProgress | TaskStatus::Shared
-        )
+        status.is_terminal()
     }
 
     pub fn print_task_terminal_output(&mut self, task_id: String, output: String) {
@@ -2520,6 +2517,12 @@ impl App {
             .find_map(|c| c.as_any().downcast_ref::<TasksList>())
             .map_or(false, |tasks_list| tasks_list.is_batch_complete(&batch_id));
         if !all_tasks_complete {
+            // A nested task isn't terminal yet (an intermediate re-run report, or
+            // a stuck/aborted task). Breadcrumb if a batch ever stays grouped.
+            trace!(
+                "Deferring batch '{}' completion: nested tasks not all terminal yet",
+                batch_id
+            );
             return;
         }
 

--- a/packages/nx/src/native/tui/app.rs
+++ b/packages/nx/src/native/tui/app.rs
@@ -626,7 +626,7 @@ impl App {
 
         // Success and failure trigger ungrouping. Route through the action queue
         // (like StartBatch) so completion is applied on the event-loop thread
-        // AFTER the nested tasks' queued status/timing updates — otherwise the
+        // AFTER the nested tasks' queued status/timing updates. Otherwise the
         // direct call races those updates and ungroups against stale component state.
         self.dispatch_action(Action::EndBatch(batch_id, status));
     }

--- a/packages/nx/src/native/tui/components/tasks_list.rs
+++ b/packages/nx/src/native/tui/components/tasks_list.rs
@@ -250,7 +250,10 @@ pub struct TasksList {
     run_mode: RunMode,
     column_visibility: Option<ColumnVisibility>, // Cached column visibility result
     terminal_width: Option<u16>, // Cached terminal width for column visibility calculation
-    in_progress_tasks: Vec<String>, // Standalone in-progress tasks for selection (excludes batched)
+    // In-progress selectable entries for selection switching: standalone tasks
+    // and running batch groups, in start order. Excludes tasks nested in a batch
+    // (the batch group represents them).
+    in_progress_entries: Vec<SelectionEntry>,
     needs_sort: bool,            // Deferred sort flag - sort once per render frame
     perf_report_available: bool, // Whether the performance report exists yet (run finished)
 }
@@ -298,7 +301,7 @@ impl TasksList {
             run_mode,
             column_visibility: None,
             terminal_width: None,
-            in_progress_tasks: Vec::new(),
+            in_progress_entries: Vec::new(),
             needs_sort: false,
             perf_report_available: false,
         };
@@ -440,6 +443,49 @@ impl TasksList {
             }
         }
         false
+    }
+
+    /// Returns true if a task is nested under any batch group, expanded or
+    /// collapsed. Unlike [`Self::is_task_nested_in_expanded_batch`] (used for
+    /// rendering), this drives in-progress-list membership: a batched task is
+    /// never an independent selection target — the batch group represents it.
+    fn is_task_in_any_batch(&self, task_id: &str) -> bool {
+        let collections = [&self.display_items, &self.filtered_display_items];
+        for collection in &collections {
+            for display_item in *collection {
+                if let DisplayItem::BatchGroup(batch_group) = display_item {
+                    if batch_group.nested_tasks.contains(&task_id.to_string()) {
+                        return true;
+                    }
+                }
+            }
+        }
+        false
+    }
+
+    /// Returns true if every task in the batch has reached a terminal state.
+    /// Used to defer batch completion until all nested tasks have finished
+    /// (batches report status on intermediate re-run iterations).
+    pub fn is_batch_complete(&self, batch_id: &str) -> bool {
+        match self.get_batch_group_by_id(batch_id) {
+            Some(batch_group) => batch_group.nested_tasks.iter().all(|id| {
+                self.task_lookup.get(id).is_some_and(|task| {
+                    !matches!(
+                        task.status,
+                        TaskStatus::NotStarted | TaskStatus::InProgress | TaskStatus::Shared
+                    )
+                })
+            }),
+            None => false,
+        }
+    }
+
+    /// Whether a completing batch's output is being followed by a focused output
+    /// pane (spacebar mode), in which case selection should stay on the batch's
+    /// last task so its output remains visible — mirroring the standalone
+    /// terminal-pane exception in [`Self::is_terminal_showing_task`].
+    fn is_terminal_showing_batch(&self) -> bool {
+        matches!(self.focus, Focus::MultipleOutput(_)) && self.spacebar_mode
     }
 
     /// Returns true if the task list is currently focused
@@ -1344,7 +1390,7 @@ impl TasksList {
 
         for task in &tasks {
             let task_id = &task.id;
-            let is_in_batch = self.is_task_nested_in_expanded_batch(task_id);
+            let is_in_batch = self.is_task_in_any_batch(task_id);
 
             // Update in task_lookup
             if let Some(task_item) = self.task_lookup.get_mut(task_id) {
@@ -1376,8 +1422,14 @@ impl TasksList {
             }
 
             // Add to in-progress list if standalone task
-            if !is_in_batch && !self.in_progress_tasks.iter().any(|id| id == task_id) {
-                self.in_progress_tasks.push(task_id.to_string());
+            if !is_in_batch
+                && !self
+                    .in_progress_entries
+                    .iter()
+                    .any(|e| matches!(e, SelectionEntry::Task(id) if id == task_id))
+            {
+                self.in_progress_entries
+                    .push(SelectionEntry::Task(task_id.to_string()));
                 has_standalone_change = true;
             }
         }
@@ -1404,45 +1456,56 @@ impl TasksList {
         }
     }
 
-    /// Handles a standalone task finishing by switching selection to another in-progress task.
-    /// Only changes selection if the finished task was the currently selected task.
-    fn handle_standalone_task_finished(&mut self, task_id: &str, old_index: Option<usize>) {
-        // Only switch selection if the finished task was the selected task
-        let is_selected = {
-            let selection_manager = self.selection_manager.lock();
-            matches!(
-                selection_manager.get_selection(),
-                Some(SelectionEntry::Task(name)) if name == task_id
-            )
-        };
+    /// Selection transition when the currently-selected in-progress entry
+    /// (`finished`, a standalone task or a batch group) reaches a terminal state.
+    /// Shared by standalone-task completion and batch completion so both behave
+    /// identically. `finished` must already be removed from `in_progress_entries`;
+    /// `old_index` is its index there before removal. `keep_last` is selected when
+    /// no other work remains (the finished task for a standalone task, the
+    /// last-completed nested task for a batch). `terminal_showing` keeps `keep_last`
+    /// selected when the finished entry's output is being followed by a pane.
+    ///
+    /// Only changes selection if `finished` was the currently selected entry.
+    fn select_after_selected_finished(
+        &mut self,
+        finished: &SelectionEntry,
+        old_index: Option<usize>,
+        keep_last: Option<SelectionEntry>,
+        terminal_showing: bool,
+    ) {
+        let is_selected = self.selection_manager.lock().get_selection() == Some(finished);
         if !is_selected {
             return;
         }
 
-        // Check terminal pane exception
-        if self.is_terminal_showing_task(task_id) {
-            return; // Keep selection on finished task
-        }
-
-        let has_pending = self.has_pending_tasks();
-
-        // No more in-progress tasks?
-        if self.in_progress_tasks.is_empty() {
-            if has_pending {
-                self.selection_manager.lock().await_next_allocation();
+        // Terminal pane exception: keep the finished entry's output visible.
+        if terminal_showing {
+            if let Some(entry) = keep_last {
+                self.selection_manager.lock().select(Some(entry));
             }
-            // else: last task, keep selection (already on finished task)
             return;
         }
 
-        // Switch to task at same/lower position (clamped to valid range)
-        if let Some(old_idx) = old_index {
-            let clamped_idx = old_idx.min(self.in_progress_tasks.len().saturating_sub(1));
-            if let Some(next_task) = self.in_progress_tasks.get(clamped_idx) {
-                self.selection_manager.lock().select_task(next_task);
+        // No more in-progress entries (tasks or batches)?
+        if self.in_progress_entries.is_empty() {
+            if self.has_pending_tasks() {
+                // Wait for the next task/batch to start rather than latching onto
+                // a completed entry.
+                self.selection_manager.lock().await_next_allocation();
+            } else if let Some(entry) = keep_last {
+                // Last work — keep a relevant completed entry selected.
+                self.selection_manager.lock().select(Some(entry));
             }
-        } else if let Some(first) = self.in_progress_tasks.first() {
-            self.selection_manager.lock().select_task(first);
+            return;
+        }
+
+        // Switch to the entry at the same/lower position (clamped to valid range).
+        let target = old_index
+            .map(|idx| idx.min(self.in_progress_entries.len() - 1))
+            .and_then(|idx| self.in_progress_entries.get(idx).cloned())
+            .or_else(|| self.in_progress_entries.first().cloned());
+        if let Some(entry) = target {
+            self.selection_manager.lock().select(Some(entry));
         }
     }
 
@@ -1455,11 +1518,16 @@ impl TasksList {
             .map(|t| t.status)
             .unwrap_or(TaskStatus::NotStarted);
         let old_is_in_progress = matches!(old_status, TaskStatus::InProgress | TaskStatus::Shared);
-        let is_in_batch = self.is_task_nested_in_expanded_batch(task_id);
+        // Rendering nests tasks only under EXPANDED batches; the in-progress
+        // selectable list excludes tasks under ANY batch (the group represents them).
+        let is_in_expanded_batch = self.is_task_nested_in_expanded_batch(task_id);
+        let is_in_any_batch = self.is_task_in_any_batch(task_id);
 
         // Get position BEFORE removing (for position-based selection switching)
-        let old_index = if old_is_in_progress && !is_in_batch {
-            self.in_progress_tasks.iter().position(|id| id == &task_id)
+        let old_index = if old_is_in_progress && !is_in_any_batch {
+            self.in_progress_entries
+                .iter()
+                .position(|e| matches!(e, SelectionEntry::Task(id) if id == task_id))
         } else {
             None
         };
@@ -1487,24 +1555,43 @@ impl TasksList {
         }
 
         // Update in-progress list and handle selection for standalone tasks
-        if !is_in_batch {
+        // (tasks nested in a batch are represented by the batch group).
+        if !is_in_any_batch {
             let new_is_in_progress = matches!(status, TaskStatus::InProgress | TaskStatus::Shared);
 
             if old_is_in_progress && !new_is_in_progress {
-                // Task finished - remove and handle selection
-                if let Some(idx) = self.in_progress_tasks.iter().position(|id| id == task_id) {
-                    self.in_progress_tasks.remove(idx);
+                // Task finished - remove and update selection if it was selected.
+                if let Some(idx) = self
+                    .in_progress_entries
+                    .iter()
+                    .position(|e| matches!(e, SelectionEntry::Task(id) if id == task_id))
+                {
+                    self.in_progress_entries.remove(idx);
                 }
-                self.handle_standalone_task_finished(task_id, old_index);
+                let finished = SelectionEntry::Task(task_id.to_owned());
+                let terminal_showing = self.is_terminal_showing_task(task_id);
+                self.select_after_selected_finished(
+                    &finished,
+                    old_index,
+                    Some(finished.clone()),
+                    terminal_showing,
+                );
             } else if !old_is_in_progress && new_is_in_progress {
                 // Task started - add if not already present
-                if !self.in_progress_tasks.iter().any(|id| id == task_id) {
-                    self.in_progress_tasks.push(task_id.to_owned());
+                if !self
+                    .in_progress_entries
+                    .iter()
+                    .any(|e| matches!(e, SelectionEntry::Task(id) if id == task_id))
+                {
+                    self.in_progress_entries
+                        .push(SelectionEntry::Task(task_id.to_owned()));
                 }
             }
+        }
 
-            // Only re-sort when a standalone task changed — batch-nested task
-            // status changes don't affect display order.
+        // Re-sort unless the change was to a task nested in an expanded batch
+        // (those don't affect standalone display order).
+        if !is_in_expanded_batch {
             self.needs_sort = true;
         }
     }
@@ -1691,10 +1778,24 @@ impl TasksList {
         });
 
         // Add the batch group
+        let nested_tasks = batch_group.nested_tasks.clone();
         let batch_id = batch_group.batch_id.clone();
         self.display_items
             .push(DisplayItem::BatchGroup(batch_group));
         self.needs_sort = true;
+
+        // Reflect the running batch in the in-progress selectable list: drop any
+        // nested tasks tracked individually and represent them by the batch group.
+        self.in_progress_entries
+            .retain(|e| !matches!(e, SelectionEntry::Task(id) if nested_tasks.contains(id)));
+        if !self
+            .in_progress_entries
+            .iter()
+            .any(|e| matches!(e, SelectionEntry::BatchGroup(id) if id == &batch_id))
+        {
+            self.in_progress_entries
+                .push(SelectionEntry::BatchGroup(batch_id.clone()));
+        }
 
         // If selected task is now inside the collapsed batch, select the batch instead
         // Use the just-pushed batch group's nested_tasks for the O(1) contains check.
@@ -1718,26 +1819,52 @@ impl TasksList {
         // Capture current selection before removing batch
         let currently_selected = self.selection_manager.lock().get_selection().cloned();
 
+        // Capture the batch's slot in the in-progress list before removing it, so a
+        // finishing selected batch can hand selection to the neighbouring entry.
+        let batch_old_index = self
+            .in_progress_entries
+            .iter()
+            .position(|e| matches!(e, SelectionEntry::BatchGroup(id) if id == batch_id));
+        if let Some(idx) = batch_old_index {
+            self.in_progress_entries.remove(idx);
+        }
+
         // Remove batch and get its info
         let Some(batch_group) = self.remove_batch_group(batch_id) else {
             return;
         };
 
         // Restore selection based on what was selected before
-        let task_to_select = currently_selected.and_then(|selection| match &selection {
-            SelectionEntry::BatchGroup(id) if id == batch_id => {
-                // Batch was selected - select the last task to complete
-                self.find_last_completed_task(&batch_group.nested_tasks)
+        match currently_selected {
+            Some(SelectionEntry::BatchGroup(ref id)) if id == batch_id => {
+                // The selected batch finished. Mirror a standalone task finishing:
+                // move to the nearest in-progress entry, wait for the next
+                // allocation when only pending tasks remain, or keep the last
+                // completed task when this was the final work.
+                let keep_last = self
+                    .find_last_completed_task(&batch_group.nested_tasks)
                     .or_else(|| batch_group.sorted_tasks.first().cloned())
+                    .map(SelectionEntry::Task);
+                let terminal_showing = self.is_terminal_showing_batch();
+                let finished = SelectionEntry::BatchGroup(batch_id.to_owned());
+                self.select_after_selected_finished(
+                    &finished,
+                    batch_old_index,
+                    keep_last,
+                    terminal_showing,
+                );
             }
-            SelectionEntry::Task(task_id) if batch_group.nested_tasks.contains(task_id) => {
-                Some(task_id.clone())
+            Some(SelectionEntry::Task(ref task_id))
+                if batch_group.nested_tasks.contains(task_id) =>
+            {
+                // A nested task was selected - keep it selected as a standalone.
+                self.selection_manager.lock().select_task(task_id);
             }
-            _ => Some(selection.id().to_string()),
-        });
-
-        if let Some(task_id) = task_to_select {
-            self.selection_manager.lock().select_task(&task_id);
+            Some(other) => {
+                // Unrelated selection (another task or batch) - preserve it.
+                self.selection_manager.lock().select(Some(other));
+            }
+            None => {}
         }
     }
 
@@ -3291,6 +3418,197 @@ mod tests {
                 is_expanded
             );
         }
+    }
+
+    #[test]
+    fn test_selected_batch_finishing_awaits_when_pending_remain() {
+        // Regression for the reported bug: when a selected in-progress batch
+        // group completes while pending tasks remain, selection must enter
+        // AwaitingNextAllocation (no selection) rather than latching onto a
+        // completed batch task — then promote to the next task that starts.
+        let (mut tasks_list, test_tasks) = create_test_tasks_list_with_batches();
+        let mut terminal = create_test_terminal(120, 20);
+        tasks_list.update(Action::StartCommand(Some(2))).unwrap();
+
+        // Batch the first two tasks; the batch is the only in-progress work, so
+        // it auto-selects. standalone:test stays pending.
+        tasks_list
+            .update(Action::StartTasks(vec![
+                test_tasks[0].clone(),
+                test_tasks[1].clone(),
+            ]))
+            .unwrap();
+        tasks_list.start_batch(
+            "batch1".to_string(),
+            "executor".to_string(),
+            vec![test_tasks[0].id.clone(), test_tasks[1].id.clone()],
+            0,
+            false,
+        );
+
+        render_to_test_backend(&mut terminal, &mut tasks_list);
+        assert!(
+            matches!(
+                tasks_list.selection_manager.lock().get_selection(),
+                Some(SelectionEntry::BatchGroup(id)) if id == "batch1"
+            ),
+            "batch group should auto-select while it is the only in-progress work"
+        );
+
+        // Batch tasks reach terminal state, then the batch completes. (Mirrors the
+        // orchestrator setting task statuses before the batch status.)
+        tasks_list.update_task_status(&test_tasks[0].id, TaskStatus::Success);
+        tasks_list.update_task_status(&test_tasks[1].id, TaskStatus::Success);
+        tasks_list.ungroup_batch_tasks("batch1");
+
+        // standalone:test is still pending -> selection waits across renders.
+        render_to_test_backend(&mut terminal, &mut tasks_list);
+        {
+            let manager = tasks_list.selection_manager.lock();
+            assert!(
+                manager.is_awaiting_next_allocation(),
+                "selection should await the next allocation, not a completed batch task"
+            );
+            assert!(manager.get_selection().is_none());
+        }
+
+        // The next task starts -> selection latches onto it.
+        tasks_list
+            .update(Action::StartTasks(vec![test_tasks[2].clone()]))
+            .unwrap();
+        render_to_test_backend(&mut terminal, &mut tasks_list);
+        assert!(matches!(
+            tasks_list.selection_manager.lock().get_selection(),
+            Some(SelectionEntry::Task(name)) if *name == test_tasks[2].id
+        ));
+    }
+
+    #[test]
+    fn test_selected_batch_finishing_selects_other_in_progress_immediately() {
+        // When a selected batch completes while other work is still running,
+        // selection moves immediately to the nearest in-progress entry (no
+        // AwaitingNextAllocation gap).
+        let (mut tasks_list, test_tasks) = create_test_tasks_list_with_batches();
+        let mut terminal = create_test_terminal(120, 20);
+        tasks_list.update(Action::StartCommand(Some(3))).unwrap();
+
+        tasks_list
+            .update(Action::StartTasks(vec![
+                test_tasks[0].clone(),
+                test_tasks[1].clone(),
+            ]))
+            .unwrap();
+        tasks_list.start_batch(
+            "batch1".to_string(),
+            "executor".to_string(),
+            vec![test_tasks[0].id.clone(), test_tasks[1].id.clone()],
+            0,
+            false,
+        );
+        render_to_test_backend(&mut terminal, &mut tasks_list);
+        assert!(matches!(
+            tasks_list.selection_manager.lock().get_selection(),
+            Some(SelectionEntry::BatchGroup(id)) if id == "batch1"
+        ));
+
+        // A standalone task starts running alongside the batch; the explicit
+        // batch selection is preserved.
+        tasks_list
+            .update(Action::StartTasks(vec![test_tasks[2].clone()]))
+            .unwrap();
+        render_to_test_backend(&mut terminal, &mut tasks_list);
+        assert!(matches!(
+            tasks_list.selection_manager.lock().get_selection(),
+            Some(SelectionEntry::BatchGroup(id)) if id == "batch1"
+        ));
+
+        // Batch completes -> selection moves straight to the running standalone task.
+        tasks_list.update_task_status(&test_tasks[0].id, TaskStatus::Success);
+        tasks_list.update_task_status(&test_tasks[1].id, TaskStatus::Success);
+        tasks_list.ungroup_batch_tasks("batch1");
+        {
+            let manager = tasks_list.selection_manager.lock();
+            assert!(!manager.is_awaiting_next_allocation());
+            assert!(matches!(
+                manager.get_selection(),
+                Some(SelectionEntry::Task(name)) if *name == test_tasks[2].id
+            ));
+        }
+    }
+
+    #[test]
+    fn test_selected_batch_finishing_keeps_last_completed_when_no_work_remains() {
+        // When the selected batch is the final work, selection stays on the
+        // last-completed nested task.
+        let (mut tasks_list, test_tasks) = create_test_tasks_list_with_batches();
+        let mut terminal = create_test_terminal(120, 20);
+        tasks_list.update(Action::StartCommand(Some(2))).unwrap();
+
+        // Mark the standalone task done up front so only the batch is left.
+        tasks_list.update_task_status(&test_tasks[2].id, TaskStatus::Success);
+
+        tasks_list
+            .update(Action::StartTasks(vec![
+                test_tasks[0].clone(),
+                test_tasks[1].clone(),
+            ]))
+            .unwrap();
+        tasks_list.start_batch(
+            "batch1".to_string(),
+            "executor".to_string(),
+            vec![test_tasks[0].id.clone(), test_tasks[1].id.clone()],
+            0,
+            false,
+        );
+        render_to_test_backend(&mut terminal, &mut tasks_list);
+
+        tasks_list.update_task_status(&test_tasks[0].id, TaskStatus::Success);
+        tasks_list.update_task_status(&test_tasks[1].id, TaskStatus::Success);
+        // Deterministic last-completed: lib:build finishes after app:build.
+        if let Some(t) = tasks_list.task_lookup.get_mut(&test_tasks[0].id) {
+            t.end_time = Some(100);
+        }
+        if let Some(t) = tasks_list.task_lookup.get_mut(&test_tasks[1].id) {
+            t.end_time = Some(200);
+        }
+        tasks_list.ungroup_batch_tasks("batch1");
+
+        let manager = tasks_list.selection_manager.lock();
+        assert!(!manager.is_awaiting_next_allocation());
+        assert!(
+            matches!(
+                manager.get_selection(),
+                Some(SelectionEntry::Task(name)) if *name == test_tasks[1].id
+            ),
+            "should keep the last-completed batch task selected"
+        );
+    }
+
+    #[test]
+    fn test_is_batch_complete_requires_all_nested_terminal() {
+        // Guards the deferred ungroup: a batch is only "complete" once every
+        // nested task has reached a terminal state.
+        let (mut tasks_list, test_tasks) = create_test_tasks_list_with_batches();
+        tasks_list
+            .update(Action::StartTasks(vec![
+                test_tasks[0].clone(),
+                test_tasks[1].clone(),
+            ]))
+            .unwrap();
+        tasks_list.start_batch(
+            "batch1".to_string(),
+            "executor".to_string(),
+            vec![test_tasks[0].id.clone(), test_tasks[1].id.clone()],
+            0,
+            false,
+        );
+
+        assert!(!tasks_list.is_batch_complete("batch1"), "both in progress");
+        tasks_list.update_task_status(&test_tasks[0].id, TaskStatus::Success);
+        assert!(!tasks_list.is_batch_complete("batch1"), "one still running");
+        tasks_list.update_task_status(&test_tasks[1].id, TaskStatus::Success);
+        assert!(tasks_list.is_batch_complete("batch1"), "all terminal");
+        assert!(!tasks_list.is_batch_complete("nonexistent"));
     }
 
     #[test]

--- a/packages/nx/src/native/tui/components/tasks_list.rs
+++ b/packages/nx/src/native/tui/components/tasks_list.rs
@@ -450,6 +450,8 @@ impl TasksList {
     /// rendering), this drives in-progress-list membership: a batched task is
     /// never an independent selection target; the batch group represents it.
     fn is_task_in_any_batch(&self, task_id: &str) -> bool {
+        // Batch groups live in display_items regardless of any active filter, so
+        // the filtered view is intentionally not scanned here.
         self.display_items.iter().any(|item| {
             matches!(item, DisplayItem::BatchGroup(batch_group)
                 if batch_group.nested_tasks.contains(task_id))
@@ -463,6 +465,8 @@ impl TasksList {
         match self.get_batch_group_by_id(batch_id) {
             Some(batch_group) => batch_group.nested_tasks.iter().all(|id| {
                 self.task_lookup.get(id).is_some_and(|task| {
+                    // Closed-world: any status outside the active set counts as
+                    // terminal. Revisit if a new non-terminal variant is added.
                     !matches!(
                         task.status,
                         TaskStatus::NotStarted | TaskStatus::InProgress | TaskStatus::Shared
@@ -474,9 +478,9 @@ impl TasksList {
     }
 
     /// Whether a completing batch's output is being followed by a focused output
-    /// pane (spacebar mode), in which case selection should stay on the batch's
-    /// last task so its output remains visible, mirroring the standalone
-    /// terminal-pane exception in [`Self::is_terminal_showing_task`].
+    /// pane in spacebar mode, in which case selection should stay on the batch's
+    /// last task so its output remains visible. Only the spacebar case is checked
+    /// here; a pinned batch pane is preserved separately in `handle_batch_complete`.
     fn is_terminal_showing_batch(&self) -> bool {
         matches!(self.focus, Focus::MultipleOutput(_)) && self.spacebar_mode
     }
@@ -1513,8 +1517,11 @@ impl TasksList {
         let old_is_in_progress = matches!(old_status, TaskStatus::InProgress | TaskStatus::Shared);
         // Rendering nests tasks only under EXPANDED batches; the in-progress
         // selectable list excludes tasks under ANY batch (the group represents them).
-        let is_in_expanded_batch = self.is_task_nested_in_expanded_batch(task_id);
+        // A task can only be in an expanded batch if it is batched at all, so the
+        // standalone case (the common one) skips the second scan.
         let is_in_any_batch = self.is_task_in_any_batch(task_id);
+        let is_in_expanded_batch =
+            is_in_any_batch && self.is_task_nested_in_expanded_batch(task_id);
 
         // Get position BEFORE removing (for position-based selection switching)
         let old_index = if old_is_in_progress && !is_in_any_batch {
@@ -3597,10 +3604,14 @@ mod tests {
         );
 
         assert!(!tasks_list.is_batch_complete("batch1"), "both in progress");
-        tasks_list.update_task_status(&test_tasks[0].id, TaskStatus::Success);
+        // Exercise the non-Success terminal variants the guard admits.
+        tasks_list.update_task_status(&test_tasks[0].id, TaskStatus::Failure);
         assert!(!tasks_list.is_batch_complete("batch1"), "one still running");
-        tasks_list.update_task_status(&test_tasks[1].id, TaskStatus::Success);
-        assert!(tasks_list.is_batch_complete("batch1"), "all terminal");
+        tasks_list.update_task_status(&test_tasks[1].id, TaskStatus::Stopped);
+        assert!(
+            tasks_list.is_batch_complete("batch1"),
+            "Failure and Stopped both count as terminal"
+        );
         assert!(!tasks_list.is_batch_complete("nonexistent"));
     }
 

--- a/packages/nx/src/native/tui/components/tasks_list.rs
+++ b/packages/nx/src/native/tui/components/tasks_list.rs
@@ -479,7 +479,7 @@ impl TasksList {
 
     /// Whether a completing batch's output is being followed by a focused output
     /// pane in spacebar mode, in which case selection should stay on the batch's
-    /// last task so its output remains visible. Only the spacebar case is checked
+    /// last-completed task so its output remains visible. Only the spacebar case is checked
     /// here; a pinned batch pane is preserved separately in `handle_batch_complete`.
     fn is_terminal_showing_batch(&self) -> bool {
         matches!(self.focus, Focus::MultipleOutput(_)) && self.spacebar_mode

--- a/packages/nx/src/native/tui/components/tasks_list.rs
+++ b/packages/nx/src/native/tui/components/tasks_list.rs
@@ -448,19 +448,12 @@ impl TasksList {
     /// Returns true if a task is nested under any batch group, expanded or
     /// collapsed. Unlike [`Self::is_task_nested_in_expanded_batch`] (used for
     /// rendering), this drives in-progress-list membership: a batched task is
-    /// never an independent selection target — the batch group represents it.
+    /// never an independent selection target; the batch group represents it.
     fn is_task_in_any_batch(&self, task_id: &str) -> bool {
-        let collections = [&self.display_items, &self.filtered_display_items];
-        for collection in &collections {
-            for display_item in *collection {
-                if let DisplayItem::BatchGroup(batch_group) = display_item {
-                    if batch_group.nested_tasks.contains(&task_id.to_string()) {
-                        return true;
-                    }
-                }
-            }
-        }
-        false
+        self.display_items.iter().any(|item| {
+            matches!(item, DisplayItem::BatchGroup(batch_group)
+                if batch_group.nested_tasks.contains(task_id))
+        })
     }
 
     /// Returns true if every task in the batch has reached a terminal state.
@@ -482,7 +475,7 @@ impl TasksList {
 
     /// Whether a completing batch's output is being followed by a focused output
     /// pane (spacebar mode), in which case selection should stay on the batch's
-    /// last task so its output remains visible — mirroring the standalone
+    /// last task so its output remains visible, mirroring the standalone
     /// terminal-pane exception in [`Self::is_terminal_showing_task`].
     fn is_terminal_showing_batch(&self) -> bool {
         matches!(self.focus, Focus::MultipleOutput(_)) && self.spacebar_mode
@@ -1493,7 +1486,7 @@ impl TasksList {
                 // a completed entry.
                 self.selection_manager.lock().await_next_allocation();
             } else if let Some(entry) = keep_last {
-                // Last work — keep a relevant completed entry selected.
+                // Last work, so keep a relevant completed entry selected.
                 self.selection_manager.lock().select(Some(entry));
             }
             return;
@@ -3425,7 +3418,7 @@ mod tests {
         // Regression for the reported bug: when a selected in-progress batch
         // group completes while pending tasks remain, selection must enter
         // AwaitingNextAllocation (no selection) rather than latching onto a
-        // completed batch task — then promote to the next task that starts.
+        // completed batch task. Selection then promotes to the next task that starts.
         let (mut tasks_list, test_tasks) = create_test_tasks_list_with_batches();
         let mut terminal = create_test_terminal(120, 20);
         tasks_list.update(Action::StartCommand(Some(2))).unwrap();

--- a/packages/nx/src/native/tui/components/tasks_list.rs
+++ b/packages/nx/src/native/tui/components/tasks_list.rs
@@ -176,6 +176,24 @@ pub enum TaskStatus {
     Stopped,
 }
 
+impl TaskStatus {
+    /// Whether the task has reached a terminal state (finished; it will not
+    /// transition again). Exhaustive on purpose: a new non-terminal variant
+    /// won't compile until it is classified here.
+    pub fn is_terminal(&self) -> bool {
+        match self {
+            TaskStatus::Success
+            | TaskStatus::Failure
+            | TaskStatus::Skipped
+            | TaskStatus::LocalCacheKeptExisting
+            | TaskStatus::LocalCache
+            | TaskStatus::RemoteCache
+            | TaskStatus::Stopped => true,
+            TaskStatus::NotStarted | TaskStatus::InProgress | TaskStatus::Shared => false,
+        }
+    }
+}
+
 impl std::str::FromStr for TaskStatus {
     type Err = String;
 
@@ -464,14 +482,9 @@ impl TasksList {
     pub fn is_batch_complete(&self, batch_id: &str) -> bool {
         match self.get_batch_group_by_id(batch_id) {
             Some(batch_group) => batch_group.nested_tasks.iter().all(|id| {
-                self.task_lookup.get(id).is_some_and(|task| {
-                    // Closed-world: any status outside the active set counts as
-                    // terminal. Revisit if a new non-terminal variant is added.
-                    !matches!(
-                        task.status,
-                        TaskStatus::NotStarted | TaskStatus::InProgress | TaskStatus::Shared
-                    )
-                })
+                self.task_lookup
+                    .get(id)
+                    .is_some_and(|task| task.status.is_terminal())
             }),
             None => false,
         }
@@ -681,14 +694,7 @@ impl TasksList {
                     let all_completed = batch_group.nested_tasks.iter().all(|task_id| {
                         self.task_lookup
                             .get(task_id)
-                            .map(|task| {
-                                !matches!(
-                                    task.status,
-                                    TaskStatus::InProgress
-                                        | TaskStatus::Shared
-                                        | TaskStatus::NotStarted
-                                )
-                            })
+                            .map(|task| task.status.is_terminal())
                             .unwrap_or(false)
                     });
 


### PR DESCRIPTION
## Current Behavior

When an in-progress batch group is selected in the TUI and finishes while tasks are still pending, the selection moves onto one of the batch's now-completed tasks instead of clearing. The highlight lands on a finished task rather than waiting for the next task to start running.

## Expected Behavior

When the selected batch finishes, selection behaves the same as a finishing standalone task: it moves to the nearest still-running task/batch, or, when only pending tasks remain, clears to no selection until the next task starts running. The last completed task stays selected only when the batch was the final piece of work.

## Implementation Details

- Batch completion is now dispatched through the TUI action queue (`Action::EndBatch`) and handled on the event-loop thread, ordered after the nested tasks' status/timing updates. Previously it ran directly on the napi thread and could ungroup against stale component state (the completed batch's nested tasks might not yet reflect their terminal statuses), which also made the "last completed task" selection nondeterministic.
- A guard defers batch completion until every nested task has reached a terminal state, so the intermediate status reports emitted while an incomplete batch is re-run don't prematurely ungroup and then re-group it.
- The in-progress selection list now tracks running batch groups alongside standalone tasks, and a single shared handler drives the post-completion selection for both, so batches and standalone tasks behave identically.

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/fix-tui-selection-d32d2129)
<!-- polygraph-session-end -->
