### PR TITLE
fix(core): support local plugins using NodeNext .js import specifiers

### DIFF
--- a/e2e/plugin/src/nx-plugin-ts-solution.test.ts
+++ b/e2e/plugin/src/nx-plugin-ts-solution.test.ts
@@ -316,6 +316,124 @@ describe('Nx Plugin (TS solution)', () => {
     expect(configuration.tags).toContain('cypress-tag');
   });
 
+  // Regression: a subpath plugin whose TS source uses NodeNext `.js` relative
+  // imports (TS resolves them to the sibling `.ts` at compile time) needs
+  // `.js -> .ts` rewriting on whichever resolver layer applies:
+  //   - type: module   -> loads as ESM; native type stripping loads the `.ts`
+  //     and Nx's self-contained ESM resolve hook rewrites the specifier (no
+  //     ts-node/swc-node required).
+  //   - type: commonjs -> native strip can't run ESM `import` syntax in a CJS
+  //     module, so Nx falls back to swc/ts-node to transpile, then the
+  //     `Module._resolveFilename` patch rewrites the emitted `require('./x.js')`.
+  // Both shapes must load correctly.
+  for (const moduleType of ['module', 'commonjs'] as const) {
+    it(`should load local plugin subpath imports whose TS sources use NodeNext-style .js import specifiers (type: ${moduleType})`, async () => {
+      const plugin = uniq('plugin');
+      runCLI(`generate @nx/plugin:plugin packages/${plugin}`);
+      const sourceCondition =
+        readJson('tsconfig.base.json').compilerOptions.customConditions[0];
+      expect(sourceCondition).not.toBe('development');
+
+      // Plugin entry imports a sibling helper via NodeNext `.js` specifier
+      // (which TS resolves to the sibling `.ts` file at compile time).
+      updateFile(
+        `packages/${plugin}/src/plugins/docker/index.ts`,
+        `import { dockerCreateNodes, dockerCreateMetadata } from './nodes.js';
+import type { CreateNodesV2, CreateMetadata } from '@nx/devkit';
+type PluginOptions = { inferredTags: string[] };
+export const createNodesV2: CreateNodesV2<PluginOptions> = [
+  '**/my-project-file',
+  dockerCreateNodes,
+];
+export const createMetadata: CreateMetadata = dockerCreateMetadata;
+`
+      );
+      updateFile(
+        `packages/${plugin}/src/plugins/docker/nodes.ts`,
+        `import { basename, dirname } from 'path';
+import type { CreateMetadata, ProjectsMetadata } from '@nx/devkit';
+
+type PluginOptions = { inferredTags: string[] };
+
+export const dockerCreateMetadata: CreateMetadata = (graph) => {
+  const metadata: ProjectsMetadata = {};
+  for (const projectNode of Object.values(graph.nodes)) {
+    metadata[projectNode.name] = {
+      metadata: { technologies: ['my-plugin'] },
+    };
+  }
+  return metadata;
+};
+
+export const dockerCreateNodes = (files: string[], options: PluginOptions) => {
+  const results: any[] = [];
+  for (const f of files) {
+    const root = dirname(f);
+    const name = basename(root);
+    results.push([
+      f,
+      {
+        projects: {
+          [root]: {
+            root,
+            name,
+            targets: {
+              build: {
+                executor: 'nx:run-commands',
+                options: { command: "echo 'custom registered target'" },
+              },
+            },
+            tags: options.inferredTags,
+          },
+        },
+      },
+    ]);
+  }
+  return results;
+};
+`
+      );
+
+      updateJson(`packages/${plugin}/package.json`, (pkg) => {
+        pkg.type = moduleType;
+        pkg.exports = {
+          ...pkg.exports,
+          './docker': {
+            [sourceCondition]: './src/plugins/docker/index.ts',
+            types: './dist/plugins/docker/index.d.ts',
+            import: './dist/plugins/docker/index.js',
+            default: './dist/plugins/docker/index.js',
+          },
+        };
+        return pkg;
+      });
+
+      updateJson(`nx.json`, (nxJson) => {
+        nxJson.plugins ??= [];
+        nxJson.plugins.push({
+          plugin: `@${workspaceName}/${plugin}/docker`,
+          options: { inferredTags: ['docker-tag'] },
+        });
+        return nxJson;
+      });
+
+      const inferredProject = uniq('docker-inferred');
+      createFile(
+        `packages/${inferredProject}/package.json`,
+        JSON.stringify({ name: inferredProject, version: '0.0.1' })
+      );
+      createFile(`packages/${inferredProject}/my-project-file`);
+
+      expect(runCLI(`build ${inferredProject}`)).toContain(
+        'custom registered target'
+      );
+      const configuration = JSON.parse(
+        runCLI(`show project ${inferredProject} --json`)
+      );
+      expect(configuration.tags).toContain('docker-tag');
+    });
+  }
+
   it('should load local plugin subpath imports from dist when no source condition is declared', async () => {
     const plugin = uniq('plugin');
     runCLI(`generate @nx/plugin:plugin packages/${plugin}`);

--- a/packages/nx/src/plugins/js/utils/register.spec.ts
+++ b/packages/nx/src/plugins/js/utils/register.spec.ts
@@ -6,6 +6,7 @@ import {
   isRequireInEsmScopeError,
   isTsEsmNamedExportLinkageError,
   isTsEsmSyntaxError,
+  NODENEXT_ESM_RESOLVER_SOURCE,
 } from './register';
 
 describe('getTsNodeCompilerOptions', () => {
@@ -204,5 +205,123 @@ describe('isTsEsmNamedExportLinkageError', () => {
       false
     );
     expect(isTsEsmNamedExportLinkageError(null, '/x.ts')).toBe(false);
+  });
+});
+
+describe('NodeNext ESM resolve hook (NODENEXT_ESM_RESOLVER_SOURCE)', () => {
+  type ResolveHook = (
+    specifier: string,
+    context: { parentURL?: string },
+    nextResolve: (specifier: string, context?: unknown) => Promise<any>
+  ) => Promise<{ url: string }>;
+
+  let resolve: ResolveHook;
+
+  beforeAll(() => {
+    // Exercise the exact shipped hook source. It's authored as an ESM module
+    // (registered as a `data:` module at runtime), so evaluate it as CommonJS
+    // here - Jest's VM can't honor a `data:` dynamic import without
+    // --experimental-vm-modules.
+    const cjs =
+      NODENEXT_ESM_RESOLVER_SOURCE.replace(
+        'export async function resolve',
+        'async function resolve'
+      ) + '\nmodule.exports = { resolve };';
+    const mod: { exports: { resolve?: ResolveHook } } = { exports: {} };
+    new Function('module', 'exports', cjs)(mod, mod.exports);
+    resolve = mod.exports.resolve!;
+  });
+
+  const TS_PARENT = 'file:///ws/src/index.ts';
+
+  // Mimics Node's default resolver: resolves specifiers in `existing`, throws
+  // ERR_MODULE_NOT_FOUND otherwise. Records every specifier it was asked for.
+  function makeNextResolve(existing: string[]) {
+    const set = new Set(existing);
+    const calls: string[] = [];
+    const nextResolve = async (specifier: string) => {
+      calls.push(specifier);
+      if (set.has(specifier)) {
+        return { url: `file:///resolved/${specifier}`, shortCircuit: true };
+      }
+      throw Object.assign(new Error(`Cannot find module '${specifier}'`), {
+        code: 'ERR_MODULE_NOT_FOUND',
+      });
+    };
+    return { nextResolve, calls };
+  }
+
+  it('rewrites a NodeNext .js specifier to .ts from a TypeScript parent', async () => {
+    const { nextResolve, calls } = makeNextResolve(['./nodes.ts']);
+    const result = await resolve(
+      './nodes.js',
+      { parentURL: TS_PARENT },
+      nextResolve
+    );
+    expect(result.url).toBe('file:///resolved/./nodes.ts');
+    // Tried the original first, then the .ts fallback.
+    expect(calls).toEqual(['./nodes.js', './nodes.ts']);
+  });
+
+  it('rewrites .mjs -> .mts and .cjs -> .cts', async () => {
+    const mjs = makeNextResolve(['./a.mts']);
+    expect(
+      (await resolve('./a.mjs', { parentURL: TS_PARENT }, mjs.nextResolve)).url
+    ).toBe('file:///resolved/./a.mts');
+
+    const cjs = makeNextResolve(['./b.cts']);
+    expect(
+      (await resolve('./b.cjs', { parentURL: TS_PARENT }, cjs.nextResolve)).url
+    ).toBe('file:///resolved/./b.cts');
+  });
+
+  it('does not hijack when the real .js file resolves', async () => {
+    const { nextResolve, calls } = makeNextResolve(['./nodes.js']);
+    const result = await resolve(
+      './nodes.js',
+      { parentURL: TS_PARENT },
+      nextResolve
+    );
+    expect(result.url).toBe('file:///resolved/./nodes.js');
+    // No .ts fallback attempt when the .js resolves.
+    expect(calls).toEqual(['./nodes.js']);
+  });
+
+  it('does not rewrite when the parent is not a TypeScript file', async () => {
+    const { nextResolve, calls } = makeNextResolve(['./nodes.ts']);
+    await expect(
+      resolve(
+        './nodes.js',
+        { parentURL: 'file:///ws/src/index.js' },
+        nextResolve
+      )
+    ).rejects.toMatchObject({ code: 'ERR_MODULE_NOT_FOUND' });
+    expect(calls).toEqual(['./nodes.js']);
+  });
+
+  it('ignores bare (non-relative) specifiers', async () => {
+    const { nextResolve, calls } = makeNextResolve(['pkg/nodes.ts']);
+    await expect(
+      resolve('pkg/nodes.js', { parentURL: TS_PARENT }, nextResolve)
+    ).rejects.toMatchObject({ code: 'ERR_MODULE_NOT_FOUND' });
+    expect(calls).toEqual(['pkg/nodes.js']);
+  });
+
+  it('only rewrites .js/.mjs/.cjs, leaving other extensions untouched', async () => {
+    const { nextResolve, calls } = makeNextResolve(['./data.ts']);
+    await expect(
+      resolve('./data.json', { parentURL: TS_PARENT }, nextResolve)
+    ).rejects.toMatchObject({ code: 'ERR_MODULE_NOT_FOUND' });
+    expect(calls).toEqual(['./data.json']);
+  });
+
+  it('rethrows non-MODULE_NOT_FOUND errors untouched', async () => {
+    const boom = Object.assign(new SyntaxError('boom'), { code: 'ERR_OTHER' });
+    const nextResolve = async () => {
+      throw boom;
+    };
+    await expect(
+      resolve('./nodes.js', { parentURL: TS_PARENT }, nextResolve)
+    ).rejects.toBe(boom);
   });
 });

--- a/packages/nx/src/plugins/js/utils/register.ts
+++ b/packages/nx/src/plugins/js/utils/register.ts
@@ -87,6 +87,212 @@ function ensureEsmLoaderRegistered(opts: { required: boolean }): void {
   isTsEsmLoaderRegistered = true;
 }
 
+/**
+ * Source of a minimal ESM resolution hook that rewrites TypeScript NodeNext
+ * `.js`/`.mjs`/`.cjs` relative specifiers to their `.ts`/`.mts`/`.cts` sources.
+ * Inlined as a string so it can be registered as a self-contained `data:`
+ * module - it relies only on Node's default resolver (no ts-node/swc-node) and
+ * defers loading to Node's native TypeScript stripping. The ESM counterpart to
+ * the CJS `ensureCjsResolverPatched`.
+ *
+ * Only rewrites when the default resolution fails with ERR_MODULE_NOT_FOUND,
+ * the importing module is itself TypeScript, and the specifier is relative, so
+ * it never hijacks resolution that would otherwise succeed.
+ *
+ * Exported so the hook can be exercised directly in unit tests.
+ */
+export const NODENEXT_ESM_RESOLVER_SOURCE = `
+const EXT_FALLBACK = { '.js': ['.ts', '.tsx'], '.mjs': ['.mts'], '.cjs': ['.cts'] };
+const TS_PARENT_RE = /\\.(?:ts|tsx|mts|cts)(?:$|\\?)/;
+export async function resolve(specifier, context, nextResolve) {
+  try {
+    return await nextResolve(specifier, context);
+  } catch (err) {
+    if (err?.code !== 'ERR_MODULE_NOT_FOUND') throw err;
+    const parent = context.parentURL;
+    if (!parent || !TS_PARENT_RE.test(parent)) throw err;
+    if (!(specifier.startsWith('./') || specifier.startsWith('../') || specifier.startsWith('file:'))) throw err;
+    const m = specifier.match(/(\\.(?:js|mjs|cjs))($|\\?)/);
+    if (!m) throw err;
+    const fallbacks = EXT_FALLBACK[m[1]];
+    if (!fallbacks) throw err;
+    const base = specifier.slice(0, m.index);
+    const suffix = specifier.slice(m.index + m[1].length);
+    for (const ext of fallbacks) {
+      try { return await nextResolve(base + ext + suffix, context); } catch {}
+    }
+    throw err;
+  }
+}
+`;
+
+let nodeNextEsmResolverRegistered = false;
+
+/**
+ * Register a self-contained ESM resolution hook (via `Module.register`) that
+ * rewrites TypeScript NodeNext-style `.js`/`.mjs`/`.cjs` relative specifiers to
+ * their `.ts`/`.mts`/`.cts` sources. This is the ESM counterpart to
+ * `ensureCjsResolverPatched`: Node's native type stripping loads the `.ts`
+ * file, but neither native strip nor Node's ESM resolver rewrites the
+ * extension, so `import './foo.js'` from a `.ts` source where only `foo.ts`
+ * exists fails with ERR_MODULE_NOT_FOUND without it.
+ *
+ * The hook is inlined as a `data:` module (see `NODENEXT_ESM_RESOLVER_SOURCE`)
+ * and relies only on Node's default resolver, so it needs no ts-node/swc-node.
+ *
+ * Idempotent and best-effort: a no-op when `Module.register` is unavailable,
+ * when a TypeScript transpiler is already preloaded (see
+ * `isTsTranspilerPreloaded`), or if registration fails.
+ */
+export function ensureNodeNextEsmResolverRegistered(): void {
+  if (nodeNextEsmResolverRegistered) return;
+  nodeNextEsmResolverRegistered = true;
+
+  const module = require('node:module') as typeof import('node:module');
+  if (typeof module.register !== 'function') return;
+
+  // Skip when a transpiler was preloaded via `--require`/`--import` (e.g.
+  // `--require ts-node/register`, which Nx uses only when it runs from `.ts`
+  // source). `module.register()` spins up a loader-hook worker thread on which
+  // Node re-runs those preloads, resolved relative to the *current* working
+  // directory - and Nx plugin workers `chdir()` into the analyzed workspace
+  // first. If that workspace can't resolve the preloaded module, the loader
+  // worker throws and can leave module resolution in a bad state, so we must
+  // avoid the call entirely; catching it is not a clean recovery.
+  //
+  // Consequence: in that from-`.ts`-source invocation a `type: module` plugin
+  // using NodeNext `.js` specifiers won't get this resolver (a preloaded
+  // `ts-node` does NOT rewrite `.js` -> `.ts` for ESM). Published Nx is
+  // unaffected - its workers run compiled `.js` with no preload.
+  if (isTsTranspilerPreloaded()) return;
+
+  try {
+    module.register(
+      'data:text/javascript,' + encodeURIComponent(NODENEXT_ESM_RESOLVER_SOURCE)
+    );
+  } catch {
+    // Best-effort: leave Node's native handling in place for the
+    // dynamic-import path rather than failing the load.
+  }
+}
+
+/**
+ * Whether this process was started with a TypeScript transpiler preloaded via
+ * a `--require`/`--import`/`--loader` flag (e.g. `--require ts-node/register`),
+ * either directly in `process.execArgv` or through `NODE_OPTIONS`. Used to skip
+ * a redundant ESM loader registration that would otherwise crash a loader-hook
+ * worker re-running the preload from a `chdir()`'d cwd - see
+ * `ensureNodeNextEsmResolverRegistered`.
+ */
+function isTsTranspilerPreloaded(): boolean {
+  const PRELOAD_FLAGS = [
+    '-r',
+    '--require',
+    '--import',
+    '--loader',
+    '--experimental-loader',
+  ];
+  const TRANSPILER_RE = /(?:ts-node|@?swc-node)/;
+
+  // Flags passed directly (e.g. spawn(..., ['--require', 'ts-node/register'])).
+  const execArgv = process.execArgv ?? [];
+  for (let i = 0; i < execArgv.length; i++) {
+    const arg = execArgv[i];
+    const eqIdx = arg.indexOf('=');
+    if (eqIdx !== -1) {
+      if (
+        PRELOAD_FLAGS.includes(arg.slice(0, eqIdx)) &&
+        TRANSPILER_RE.test(arg.slice(eqIdx + 1))
+      ) {
+        return true;
+      }
+    } else if (
+      PRELOAD_FLAGS.includes(arg) &&
+      TRANSPILER_RE.test(execArgv[i + 1] ?? '')
+    ) {
+      return true;
+    }
+  }
+
+  // Preloads passed via NODE_OPTIONS don't surface in execArgv.
+  const nodeOptions = process.env.NODE_OPTIONS;
+  if (
+    nodeOptions &&
+    TRANSPILER_RE.test(nodeOptions) &&
+    PRELOAD_FLAGS.some((flag) => nodeOptions.includes(flag))
+  ) {
+    return true;
+  }
+
+  return false;
+}
+
+let cjsResolverPatched = false;
+
+/**
+ * Patches Node's CJS resolver to fall back from `.js`/`.mjs`/`.cjs` to the
+ * corresponding TypeScript source extension (`.ts`/`.tsx`, `.mts`, `.cts`)
+ * when the requesting file is itself a `.ts`/`.tsx`/`.mts`/`.cts` source.
+ *
+ * Required for TypeScript NodeNext-style relative imports: `import './foo.js'`
+ * inside a `.ts` file resolves to `./foo.ts` at compile time, but the `.js`
+ * specifier survives transpilation to CJS. Node's native CJS resolver doesn't
+ * rewrite extensions and there is no officially-supported Node API for this —
+ * Node's native strip-types deliberately doesn't either — so a resolver patch
+ * is the prevailing solution in the ecosystem (used by `tsx` and ts-node's
+ * `experimentalResolver`).
+ *
+ * Patches `Module._resolveFilename` (not `_findPath`, matching tsx's narrower
+ * surface). Gates on the requesting file being TS so vanilla `.js` code
+ * requesting missing `.js` files keeps failing — no silent hijack. Only fires
+ * the fallback on `MODULE_NOT_FOUND` so existing `.js` resolution is
+ * unaffected when both files exist. Idempotent on repeat calls.
+ */
+export function ensureCjsResolverPatched(): void {
+  if (cjsResolverPatched) return;
+  cjsResolverPatched = true;
+
+  const Module = require('node:module') as typeof import('node:module');
+  const original = (Module as any)._resolveFilename;
+  if (typeof original !== 'function') return;
+
+  const TS_PARENT_RE = /\.(?:ts|tsx|mts|cts)$/;
+  const EXT_FALLBACK: Record<string, string[]> = {
+    '.js': ['.ts', '.tsx'],
+    '.mjs': ['.mts'],
+    '.cjs': ['.cts'],
+  };
+
+  (Module as any)._resolveFilename = function (
+    this: unknown,
+    request: string,
+    parent: { filename?: string } | undefined,
+    ...rest: unknown[]
+  ): string {
+    try {
+      return original.call(this, request, parent, ...rest);
+    } catch (err: any) {
+      if (err?.code !== 'MODULE_NOT_FOUND') throw err;
+      if (!parent?.filename || !TS_PARENT_RE.test(parent.filename)) throw err;
+
+      const match = request.match(/(\.(?:js|mjs|cjs))$/);
+      if (!match) throw err;
+      const fallbacks = EXT_FALLBACK[match[1]];
+      if (!fallbacks) throw err;
+
+      const base = request.slice(0, -match[1].length);
+      for (const ext of fallbacks) {
+        try {
+          return original.call(this, base + ext, parent, ...rest);
+        } catch {
+          // try the next fallback
+        }
+      }
+      throw err;
+    }
+  };
+}
+
 function tryResolveLoader(specifier: string): string | null {
   try {
     return require.resolve(specifier);
@@ -207,6 +413,9 @@ export function registerTsProject(tsConfigPath: string): () => void {
   // files goes through a transpiler. No-op if no ESM loader package is
   // installed.
   ensureEsmLoaderRegistered({ required: false });
+  // CJS-side fallback so NodeNext `.js` specifiers in `.ts` sources resolve
+  // to the matching `.ts` file when require()'d.
+  ensureCjsResolverPatched();
 
   return () => {
     for (const fn of cleanupFunctions) {

--- a/packages/nx/src/project-graph/plugins/transpiler.ts
+++ b/packages/nx/src/project-graph/plugins/transpiler.ts
@@ -2,6 +2,8 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path/posix';
 import type * as ts from 'typescript';
 import {
+  ensureCjsResolverPatched,
+  ensureNodeNextEsmResolverRegistered,
   isNativeStripPreferred,
   registerTranspiler,
   registerTsConfigPaths,
@@ -28,6 +30,14 @@ export function registerPluginTSTranspiler() {
   }
 
   if (isNativeStripPreferred()) {
+    // Native strip handles `.ts` syntax but doesn't rewrite NodeNext-style
+    // `.js` relative specifiers to their `.ts` sources. Patch the CJS resolver
+    // so `require('./foo.js')` from a `.ts` plugin source falls back to
+    // `./foo.ts`, and register an ESM resolution hook so the same rewrite
+    // happens on the dynamic-import path (the CJS patch can't reach ESM
+    // resolution). Both are idempotent and best-effort.
+    ensureCjsResolverPatched();
+    ensureNodeNextEsmResolverRegistered();
     // Sentinel so pluginTranspilerIsRegistered() reports true and callers
     // don't keep retrying. The actual transpiler stays unregistered until
     // a fallback forces it.
@@ -81,6 +91,9 @@ function doRegisterPluginTSTranspiler() {
       tsConfig.raw
     ),
   ];
+  // Fall back from NodeNext `.js` specifiers to their `.ts` sources when a
+  // `.ts` plugin source require()s a sibling. Idempotent.
+  ensureCjsResolverPatched();
   unregisterPluginTSTranspiler = () => {
     cleanupFns.forEach((fn) => fn?.());
   };


### PR DESCRIPTION
## Current Behavior

Loading a local Nx plugin from its TypeScript source (via the `development`/source export condition, including secondary entry points) fails when the source uses NodeNext-style explicit `.js` relative imports — `import './nodes.js'` where the file on disk is `nodes.ts`. Any `nx` command that builds the project graph errors with `Cannot find module './nodes.js'`.

Node's native TypeScript stripping loads the `.ts` source but does not rewrite the explicit `.js` specifier to its `.ts` sibling, and nothing in the plugin-loading path did either.

## Expected Behavior

Local plugins whose TypeScript sources use NodeNext `.js` import specifiers load correctly from source, for both `type: module` (ESM) and `type: commonjs` packages.

## Implementation Details

Add dependency-free `.js` → `.ts` resolution on the native-strip plugin-loading path, mirroring how `tsx` / `ts-node`'s `experimentalResolver` patch module resolution:

- **CJS:** a `Module._resolveFilename` fallback that rewrites `.js`/`.mjs`/`.cjs` → `.ts`/`.tsx`/`.mts`/`.cts` when the requesting module is itself TypeScript and the `.js` file doesn't exist.
- **ESM:** a self-contained inline `module.register` resolve hook (no `ts-node`/`swc-node` dependency) that does the same on the dynamic-import path, leaving Node's native stripping to load the resolved `.ts` — preserving true ESM semantics.

Both are best-effort, fire only on a not-found error, and never alter resolutions that already succeed. `type: commonjs` sources still rely on the existing swc/ts-node fallback to transpile their `import` syntax (native strip can't run ESM syntax in a CJS module), after which the CJS resolver patch handles the emitted `require('./x.js')`.

> [!NOTE]
> The ESM resolve hook is skipped when a transpiler is preloaded via `--require`/`--import` (e.g. `--require ts-node/register`), which only happens when Nx itself runs from `.ts` source — registering it there would crash the `module.register` loader-hook worker. Published Nx (compiled `.js` workers, no preload) is unaffected.
