### PR TITLE
fix: handle CRLF line endings in extractMainLockfileDocument

### DIFF
--- a/packages/nx/src/plugins/js/lock-file/utils/pnpm-normalizer.ts
+++ b/packages/nx/src/plugins/js/lock-file/utils/pnpm-normalizer.ts
@@ -69,6 +69,12 @@ const YAML_DOCUMENT_SEPARATOR = '\n---\n';
 // always read the workspace document.
 // https://github.com/pnpm/pnpm/blob/main/lockfile/fs/src/yamlDocuments.ts
 function extractMainLockfileDocument(content: string): string {
+  // Normalize line endings to LF to handle Windows CRLF
+  // Lockfile content read on Windows may have 
+ line endings
+  content = content.replace(/
+/g, '
+');
   if (!content.startsWith(YAML_DOCUMENT_START)) {
     return content;
   }


### PR DESCRIPTION
## Problem

On Windows, pnpm lockfile content may have CRLF line endings, but  uses LF-only strings to find YAML document separators. This causes  to fail on Windows.

## Fix

Normalize line endings to LF at the start of .

Fixes #35828