### PR TITLE
fix(release): require docker config for docker versioning

### DIFF
--- a/packages/nx/src/command-line/release/version.spec.ts
+++ b/packages/nx/src/command-line/release/version.spec.ts
@@ -1,0 +1,142 @@
+import type { ProjectGraph } from '../../config/project-graph';
+import type { NxReleaseConfig } from './config/config';
+import { ReleaseGraph } from './utils/release-graph';
+import { hasDockerReleaseConfiguration } from './version';
+
+describe('hasDockerReleaseConfiguration', () => {
+  it('should be false when a project has a docker target but no docker release configuration', () => {
+    const releaseGraph = createReleaseGraph(['app']);
+    const projectGraph = createProjectGraph({
+      app: {
+        targets: {
+          'docker:build': {
+            metadata: {
+              technologies: ['docker'],
+            },
+          },
+        },
+      },
+    });
+
+    expect(
+      hasDockerReleaseConfiguration(
+        {} as NxReleaseConfig,
+        releaseGraph,
+        projectGraph
+      )
+    ).toBe(false);
+  });
+
+  it('should be true when docker is configured at the root release level', () => {
+    const releaseGraph = createReleaseGraph(['app']);
+    const projectGraph = createProjectGraph({
+      app: {},
+    });
+
+    expect(
+      hasDockerReleaseConfiguration(
+        { docker: {} } as NxReleaseConfig,
+        releaseGraph,
+        projectGraph
+      )
+    ).toBe(true);
+  });
+
+  it('should be true when docker is configured at the release group level', () => {
+    const releaseGraph = createReleaseGraph(['app'], { docker: {} });
+    const projectGraph = createProjectGraph({
+      app: {},
+    });
+
+    expect(
+      hasDockerReleaseConfiguration(
+        {} as NxReleaseConfig,
+        releaseGraph,
+        projectGraph
+      )
+    ).toBe(true);
+  });
+
+  it('should be true when docker is configured at the project level', () => {
+    const releaseGraph = createReleaseGraph(['app']);
+    const projectGraph = createProjectGraph({
+      app: {
+        release: {
+          docker: {
+            repositoryName: 'acme/app',
+          },
+        },
+      },
+    });
+
+    expect(
+      hasDockerReleaseConfiguration(
+        {} as NxReleaseConfig,
+        releaseGraph,
+        projectGraph
+      )
+    ).toBe(true);
+  });
+
+  it('should ignore project level docker configuration for projects that are not being processed', () => {
+    const releaseGraph = createReleaseGraph(['app']);
+    const projectGraph = createProjectGraph({
+      app: {},
+      skipped: {
+        release: {
+          docker: {
+            repositoryName: 'acme/skipped',
+          },
+        },
+      },
+    });
+
+    expect(
+      hasDockerReleaseConfiguration(
+        {} as NxReleaseConfig,
+        releaseGraph,
+        projectGraph
+      )
+    ).toBe(false);
+  });
+});
+
+function createReleaseGraph(
+  projects: string[],
+  releaseGroupOverrides: Record<string, unknown> = {}
+): ReleaseGraph {
+  const releaseGroup = {
+    name: 'default',
+    projects,
+    projectsRelationship: 'independent',
+    ...releaseGroupOverrides,
+  } as any;
+  const releaseGraph = new ReleaseGraph([releaseGroup], {});
+  releaseGraph.allProjectsToProcess = new Set(projects);
+  releaseGraph.releaseGroupToFilteredProjects.set(
+    releaseGroup,
+    new Set(projects)
+  );
+  return releaseGraph;
+}
+
+function createProjectGraph(
+  projects: Record<string, Record<string, unknown>>
+): ProjectGraph {
+  return {
+    nodes: Object.fromEntries(
+      Object.entries(projects).map(([name, data]) => [
+        name,
+        {
+          name,
+          type: 'app',
+          data: {
+            root: name,
+            ...data,
+          },
+        },
+      ])
+    ),
+    dependencies: {},
+  };
+}

--- a/packages/nx/src/command-line/release/version.ts
+++ b/packages/nx/src/command-line/release/version.ts
@@ -11,6 +11,7 @@ import { formatChangedFilesWithPrettierIfAvailable } from '../../generators/inte
 import { FsTree, Tree, flushChanges } from '../../generators/tree';
 import { createProjectFileMapUsingProjectGraph } from '../../project-graph/file-map-utils';
 import { createProjectGraphAsync } from '../../project-graph/project-graph';
+import type { ProjectGraph } from '../../config/project-graph';
 import { handleErrors } from '../../utils/handle-errors';
 import { orange, output } from '../../utils/output';
 import { joinPathFragments } from '../../utils/path';
@@ -19,6 +20,7 @@ import { VersionOptions } from './command-object';
 import {
   createNxReleaseConfig,
   handleNxReleaseConfigError,
+  type NxReleaseConfig,
 } from './config/config';
 import { deepMergeJson } from './config/deep-merge-json';
 import { ReleaseGroupWithName } from './config/filter-release-groups';
@@ -321,22 +323,24 @@ export function createAPI(
       }
     }
 
+    const shouldProcessDockerProjects = hasDockerReleaseConfiguration(
+      nxReleaseConfig,
+      releaseGraph,
+      projectGraph
+    );
     // TODO(colum): Remove when Docker support is no longer experimental
-    if (
-      nxReleaseConfig.docker ||
-      releaseGraph.releaseGroups.some((rg) => rg.docker)
-    ) {
+    if (shouldProcessDockerProjects) {
       output.warn({
         title: 'Warning',
         bodyLines: [
           `Docker support is experimental. Breaking changes may occur and not adhere to semver versioning.`,
         ],
       });
+      await processor.processDockerProjects(
+        args.dockerVersionScheme,
+        args.dockerVersion
+      );
     }
-    await processor.processDockerProjects(
-      args.dockerVersionScheme,
-      args.dockerVersion
-    );
 
     const versionData = processor.getVersionData();
 
@@ -436,6 +440,23 @@ export function createAPI(
       releaseGraph,
     };
   };
+}
+
+export function hasDockerReleaseConfiguration(
+  nxReleaseConfig: NxReleaseConfig,
+  releaseGraph: ReleaseGraph,
+  projectGraph: ProjectGraph
+): boolean {
+  if (nxReleaseConfig.docker) {
+    return true;
+  }
+  if (releaseGraph.releaseGroups.some((rg) => rg.docker)) {
+    return true;
+  }
+  return Array.from(releaseGraph.allProjectsToProcess).some(
+    (projectName) =>
+      projectGraph.nodes[projectName]?.data.release?.docker !== undefined
+  );
 }
 
 function printAndFlushChanges(tree: Tree, isDryRun: boolean) {


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
Calling `nx release version` currently runs docker build, due to detection of Dockerfile in the project. Users using docker outside of nx/docker have no way of preventing this.

## Expected Behavior
Running `nx release version` should not trigger docker build unless, docker use is explicitly enabled.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
