### PR TITLE
docs(core): fix show target examples

### DIFF
--- a/packages/nx/src/command-line/examples.ts
+++ b/packages/nx/src/command-line/examples.ts
@@ -435,25 +435,25 @@ export const examples: Record<string, Example[]> = {
     },
 
     {
-      command: 'show target my-app:build inputs',
+      command: 'show target inputs my-app:build',
       description: 'Prints the resolved inputs for `my-app:build`',
     },
 
     {
       command:
-        'show target my-app:build inputs --check packages/my-app/index.html',
+        'show target inputs my-app:build --check packages/my-app/index.html',
       description:
         'Checks if `packages/my-app/index.html` is an input for `my-app:build`',
     },
 
     {
-      command: 'show target my-app:build outputs',
+      command: 'show target outputs my-app:build',
       description: 'Prints the outputs detected on disk for `my-app:build`',
     },
 
     {
       command:
-        'show target my-app:build outputs --check packages/my-app/dist/index.html',
+        'show target outputs my-app:build --check packages/my-app/dist/index.html',
       description:
         'Checks if `packages/my-app/dist/index.html` is an output for `my-app:build`',
     },


### PR DESCRIPTION
## Current Behavior

The shared CLI examples for `nx show target` document input and output inspection with the target before the subcommand, for example `nx show target my-app:build inputs`.

## Expected Behavior

The examples use the canonical subcommand-first syntax shown in the command help and intended for the Nx 22.7 sandboxing blog correction: `nx show target inputs my-app:build` and `nx show target outputs my-app:build`.

## Related Issue(s)

N/A - reported directly in Polygraph session `fix-sandboxing-code-example-3443d65b`.

## Validation

- `npx prettier --write -- packages/nx/src/command-line/examples.ts`
- `git diff --check`
- Focused `pnpm exec tsx` metadata check confirming the stale target-first examples are absent and the subcommand-first examples are present.

Full `nx prepush` has not been run.

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/fix-sandboxing-code-example-3443d65b)
<!-- polygraph-session-end -->