### PR TITLE
chore(repo): bump default Node.js version to 26.3.0

### DIFF
--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -36,9 +36,7 @@ jobs:
         node_version:
           - 22
           - 24
-          # TODO: re-enable once playwright ships the yauzl fix for node 26 extract hang.
-          # See https://github.com/microsoft/playwright/issues/40724
-          # - 26
+          - 26
         exclude:
           # macos skips the oldest node to keep the macos matrix slim
           - os: macos-latest

--- a/e2e/gradle/src/gradle-import.test.ts
+++ b/e2e/gradle/src/gradle-import.test.ts
@@ -11,7 +11,7 @@ import {
   runCommand,
   createFile,
 } from '@nx/e2e-utils';
-import { mkdirSync, rmdirSync, writeFileSync } from 'fs';
+import { mkdirSync, rmSync, writeFileSync } from 'fs';
 import { execSync } from 'node:child_process';
 import { join } from 'path';
 import { createGradleProject } from './utils/create-gradle-project';
@@ -41,7 +41,7 @@ describe('Nx Import Gradle', () => {
     createFile('.gitignore', '.kotlin/');
 
     try {
-      rmdirSync(tempImportE2ERoot);
+      rmSync(tempImportE2ERoot, { recursive: true, force: true });
     } catch {}
     mkdirSync(tempImportE2ERoot, { recursive: true });
 
@@ -58,7 +58,7 @@ describe('Nx Import Gradle', () => {
       tempGradleProjectName
     );
     try {
-      rmdirSync(tempGraldeProjectPath);
+      rmSync(tempGraldeProjectPath, { recursive: true, force: true });
     } catch {}
     mkdirSync(tempGraldeProjectPath, { recursive: true });
     createGradleProject(
@@ -113,7 +113,7 @@ describe('Nx Import Gradle', () => {
       tempGradleProjectName
     );
     try {
-      rmdirSync(tempGraldeProjectPath);
+      rmSync(tempGraldeProjectPath, { recursive: true, force: true });
     } catch {}
     mkdirSync(tempGraldeProjectPath, { recursive: true });
     createGradleProject(

--- a/e2e/nx/src/import-ai-agent.test.ts
+++ b/e2e/nx/src/import-ai-agent.test.ts
@@ -9,7 +9,7 @@ import {
   updateFile,
   updateJson,
 } from '@nx/e2e-utils';
-import { rmdirSync } from 'fs';
+import { rmSync } from 'fs';
 import { join } from 'path';
 import {
   createSimpleRepo,
@@ -39,7 +39,7 @@ describe('Nx Import - AI Agent Mode', () => {
     }
 
     try {
-      rmdirSync(tempImportE2ERoot);
+      rmSync(tempImportE2ERoot, { recursive: true, force: true });
     } catch {}
   });
 

--- a/e2e/nx/src/import.test.ts
+++ b/e2e/nx/src/import.test.ts
@@ -11,7 +11,7 @@ import {
   updateFile,
   updateJson,
 } from '@nx/e2e-utils';
-import { mkdirSync, rmdirSync } from 'fs';
+import { mkdirSync, rmSync } from 'fs';
 import { execSync } from 'node:child_process';
 import { join } from 'path';
 import { createMultiPackageRepo } from './import-utils';
@@ -39,7 +39,7 @@ describe('Nx Import', () => {
     }
 
     try {
-      rmdirSync(join(tempImportE2ERoot));
+      rmSync(join(tempImportE2ERoot), { recursive: true, force: true });
     } catch {}
   });
 

--- a/mise.toml
+++ b/mise.toml
@@ -1,7 +1,7 @@
 [tools]
 bun = "1.3"
 java = "24"
-node = "{{ env['NODE_VERSION'] | default(value='24.11.0') }}"
+node = "{{ env['NODE_VERSION'] | default(value='26.3.0') }}"
 maven = "3.9.11"
 rust = "1.95.0"
 vale = "3.13.1"

--- a/packages/angular-rspack/src/lib/utils/misc-helpers.ts
+++ b/packages/angular-rspack/src/lib/utils/misc-helpers.ts
@@ -1,4 +1,6 @@
 import assert from 'node:assert';
+import { isAbsolute } from 'node:path';
+import { pathToFileURL } from 'node:url';
 
 let load: (<T>(modulePath: string | URL) => Promise<T>) | undefined;
 
@@ -8,7 +10,27 @@ export function loadEsmModule<T>(modulePath: string | URL): Promise<T> {
     undefined
   >;
 
+  // The dynamic import lives inside `new Function(...)` to stop TypeScript from
+  // downleveling it to require(). A side effect is that bare specifiers are
+  // resolved against the location of the Function rather than this module, so
+  // under Node >= 26's stricter ESM resolver they fail with ERR_MODULE_NOT_FOUND
+  // even for declared dependencies. Resolve bare specifiers here, where this
+  // package's dependencies are reachable, and hand off an absolute file URL.
+  if (typeof modulePath === 'string' && isBareSpecifier(modulePath)) {
+    modulePath = pathToFileURL(require.resolve(modulePath)).href;
+  }
+
   return load(modulePath);
+}
+
+function isBareSpecifier(specifier: string): boolean {
+  return (
+    !specifier.startsWith('.') &&
+    !isAbsolute(specifier) &&
+    !specifier.includes('://') &&
+    !specifier.startsWith('node:') &&
+    !specifier.startsWith('data:')
+  );
 }
 
 export function assertIsError(

--- a/packages/eslint-plugin/src/utils/runtime-lint-utils.spec.ts
+++ b/packages/eslint-plugin/src/utils/runtime-lint-utils.spec.ts
@@ -385,14 +385,17 @@ describe('dependentsHaveBannedImport + findTransitiveExternalDependencies', () =
 });
 
 describe('is terminal run', () => {
-  const originalProcess = process;
+  const originalArgv = process.argv;
 
+  // Set only process.argv rather than reassigning the whole `process` object.
+  // Under Node >= 26 the jest sandbox global is a Proxy and reassigning the
+  // global `process` binding throws ReferenceError; mutating the property works.
   const mockProcessArgv = (argv: string[]) => {
-    process = Object.assign({}, process, { argv });
+    process.argv = argv;
   };
 
   afterEach(() => {
-    process = originalProcess;
+    process.argv = originalArgv;
   });
 
   it('is a terminal run when the command is started from the nx executor on Mac', () => {

--- a/packages/js/src/executors/release-publish/extract-npm-publish-json-data.spec.ts
+++ b/packages/js/src/executors/release-publish/extract-npm-publish-json-data.spec.ts
@@ -263,6 +263,123 @@ prepublishOnly from package-a
       expect(res.afterJsonData).toMatchInlineSnapshot(`""`);
     });
 
+    it('should extract and unwrap the JSON data when npm >= 11.16 nests the summary under the package name', () => {
+      // npm >= 11.16 (bundled with Node 26) nests the publish summary under the
+      // package name instead of printing it as a flat object.
+      const commandOutput = `{
+  "@scope/package-a": {
+    "id": "@scope/package-a@1.0.0",
+    "name": "@scope/package-a",
+    "version": "1.0.0",
+    "size": 251,
+    "unpackedSize": 233,
+    "shasum": "cf4a6657f230ddf5375102bafc8f5184002a620a",
+    "integrity": "sha512-Qra/YIkAxVavs3tumB/svugHLY5CISujdeUcMd2FfvtVkjEEsVAEYbqZTq0ixnkvjVrLr27mAvH94GjjMKWzIg==",
+    "filename": "scope-package-a-1.0.0.tgz",
+    "files": [
+      {
+        "path": "package.json",
+        "size": 233,
+        "mode": 420
+      }
+    ],
+    "entryCount": 1,
+    "bundled": []
+  }
+}`;
+      const res = extractNpmPublishJsonData(commandOutput);
+
+      // The wrapper braces must not leak into beforeJsonData/afterJsonData.
+      expect(res.beforeJsonData).toMatchInlineSnapshot(`""`);
+      expect(res.jsonData).toMatchInlineSnapshot(`
+        {
+          "bundled": [],
+          "entryCount": 1,
+          "filename": "scope-package-a-1.0.0.tgz",
+          "files": [
+            {
+              "mode": 420,
+              "path": "package.json",
+              "size": 233,
+            },
+          ],
+          "id": "@scope/package-a@1.0.0",
+          "integrity": "sha512-Qra/YIkAxVavs3tumB/svugHLY5CISujdeUcMd2FfvtVkjEEsVAEYbqZTq0ixnkvjVrLr27mAvH94GjjMKWzIg==",
+          "name": "@scope/package-a",
+          "shasum": "cf4a6657f230ddf5375102bafc8f5184002a620a",
+          "size": 251,
+          "unpackedSize": 233,
+          "version": "1.0.0",
+        }
+      `);
+      expect(res.afterJsonData).toMatchInlineSnapshot(`""`);
+    });
+
+    it('should extract and unwrap nested JSON data alongside lifecycle script outputs', () => {
+      const commandOutput = `
+> @scope/package-a@1.0.0 prepublishOnly
+> echo 'prepublishOnly from package-a'
+
+prepublishOnly from package-a
+{
+  "@scope/package-a": {
+    "id": "@scope/package-a@1.0.0",
+    "name": "@scope/package-a",
+    "version": "1.0.0",
+    "size": 206,
+    "unpackedSize": 179,
+    "shasum": "f01c6f5c8d72ed33e70c1c1b1258f46c92360e57",
+    "integrity": "sha512-24/pgfxiTiNB/dw7ZbBZ+I1vidq09KU6n/QgXCtx1y4+ezYpEBSncdrEpDxuMD6YaP8twg3H8zQBLoG8xwygcA==",
+    "filename": "scope-package-a-1.0.0.tgz",
+    "files": [
+      {
+        "path": "package.json",
+        "size": 179,
+        "mode": 420
+      }
+    ],
+    "entryCount": 1,
+    "bundled": []
+  }
+}
+`;
+      const res = extractNpmPublishJsonData(commandOutput);
+
+      expect(res.beforeJsonData).toMatchInlineSnapshot(`
+        "
+        > @scope/package-a@1.0.0 prepublishOnly
+        > echo 'prepublishOnly from package-a'
+
+        prepublishOnly from package-a
+        "
+      `);
+      expect(res.jsonData).toMatchInlineSnapshot(`
+        {
+          "bundled": [],
+          "entryCount": 1,
+          "filename": "scope-package-a-1.0.0.tgz",
+          "files": [
+            {
+              "mode": 420,
+              "path": "package.json",
+              "size": 179,
+            },
+          ],
+          "id": "@scope/package-a@1.0.0",
+          "integrity": "sha512-24/pgfxiTiNB/dw7ZbBZ+I1vidq09KU6n/QgXCtx1y4+ezYpEBSncdrEpDxuMD6YaP8twg3H8zQBLoG8xwygcA==",
+          "name": "@scope/package-a",
+          "shasum": "f01c6f5c8d72ed33e70c1c1b1258f46c92360e57",
+          "size": 206,
+          "unpackedSize": 179,
+          "version": "1.0.0",
+        }
+      `);
+      expect(res.afterJsonData).toMatchInlineSnapshot(`
+        "
+        "
+      `);
+    });
+
     it('should extract the relevant JSON data when formatted JSON data is present alongside the expected npm publish JSON data', () => {
       const exampleCommandOutputWithFormattedJSON = `
       {

--- a/packages/js/src/executors/release-publish/extract-npm-publish-json-data.ts
+++ b/packages/js/src/executors/release-publish/extract-npm-publish-json-data.ts
@@ -6,17 +6,29 @@ const expectedNpmPublishJsonKeys = [
   'filename',
 ];
 
-// Regular expression to match JSON-like objects, including nested objects (which the expected npm publish output will have, e.g. in its "files" array)
-// /{(?:[^{}]|{[^{}]*})*}/g
-// /{                       : Matches the opening brace of a JSON object
-//   (?:              )     : Non-capturing group to apply quantifiers
-//      [^{}]               : Matches any character except for braces
-//           |              : OR
-//            {[^{}]*}      : Matches nested JSON objects
-//                     *    : The non-capturing group (i.e. any character except for braces OR nested JSON objects) can repeat zero or more times
-//                      }   : Matches the closing brace of a JSON object
-//                       /g : Global flag to match all occurrences in the string
-const jsonRegex = /{(?:[^{}]|{[^{}]*})*}/g;
+// Regular expression to match JSON-like objects, including up to two levels of
+// nested objects.
+// /{(?:[^{}]|{(?:[^{}]|{[^{}]*})*})*}/g
+// Two levels of nesting are required to support both shapes of npm/pnpm publish
+// output:
+//   - Older npm (<= 11.13) prints the publish summary as a flat object whose only
+//     nesting is its own "files" array (one level deep).
+//   - Newer npm (>= 11.16, bundled with Node 26) nests that same summary under the
+//     package name, e.g. { "@scope/pkg": { ...id/name/files... } }, adding a
+//     second level. pnpm publish nests the same way when run from the workspace
+//     root. Matching two levels lets us capture the wrapper object in the nested
+//     case so its braces are not left behind in beforeJsonData/afterJsonData.
+const jsonRegex = /{(?:[^{}]|{(?:[^{}]|{[^{}]*})*})*}/g;
+
+function isNpmPublishSummary(value: unknown): value is Record<string, unknown> {
+  return (
+    typeof value === 'object' &&
+    value !== null &&
+    expectedNpmPublishJsonKeys.every(
+      (key) => (value as Record<string, unknown>)[key] !== undefined
+    )
+  );
+}
 
 export function extractNpmPublishJsonData(str: string): {
   beforeJsonData: string;
@@ -31,24 +43,42 @@ export function extractNpmPublishJsonData(str: string): {
         continue;
       }
       // Full JSON parsing to identify the JSON object
+      let parsedJson: unknown;
       try {
-        const parsedJson = JSON.parse(match);
-        if (
-          !expectedNpmPublishJsonKeys.every(
-            (key) => parsedJson[key] !== undefined
-          )
-        ) {
-          continue;
-        }
-        const jsonStartIndex = str.indexOf(match);
-        return {
-          beforeJsonData: str.slice(0, jsonStartIndex),
-          jsonData: parsedJson,
-          afterJsonData: str.slice(jsonStartIndex + match.length),
-        };
+        parsedJson = JSON.parse(match);
       } catch {
         // Ignore parsing errors for unrelated JSON blocks
+        continue;
       }
+
+      // npm <= 11.13 emits the summary as a flat object, while npm >= 11.16 (and
+      // pnpm publish run from the workspace root) nest it one level deep under the
+      // package name. Support both by unwrapping a single level when the matched
+      // object isn't itself the summary.
+      let publishData: Record<string, unknown> | null = null;
+      if (isNpmPublishSummary(parsedJson)) {
+        publishData = parsedJson;
+      } else if (typeof parsedJson === 'object' && parsedJson !== null) {
+        for (const value of Object.values(
+          parsedJson as Record<string, unknown>
+        )) {
+          if (isNpmPublishSummary(value)) {
+            publishData = value;
+            break;
+          }
+        }
+      }
+
+      if (!publishData) {
+        continue;
+      }
+
+      const jsonStartIndex = str.indexOf(match);
+      return {
+        beforeJsonData: str.slice(0, jsonStartIndex),
+        jsonData: publishData,
+        afterJsonData: str.slice(jsonStartIndex + match.length),
+      };
     }
   }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -131,7 +131,7 @@ catalogs:
       version: 2.3.3
     '@playwright/test':
       specifier: ^1.36.0
-      version: 1.54.0
+      version: 1.60.0
     '@svgr/webpack':
       specifier: ^8.0.1
       version: 8.1.0
@@ -448,10 +448,10 @@ importers:
         version: 25.0.1
       next:
         specifier: 14.2.35
-        version: 14.2.35(@babel/core@7.29.0)(@playwright/test@1.54.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3)
+        version: 14.2.35(@babel/core@7.29.0)(@playwright/test@1.60.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3)
       next-seo:
         specifier: 'catalog:'
-        version: 5.15.0(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.54.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 5.15.0(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.60.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       npm-run-path:
         specifier: ^4.0.1
         version: 4.0.1
@@ -641,7 +641,7 @@ importers:
         version: 3.17.6
       '@nx/angular':
         specifier: 23.0.0-beta.22
-        version: 23.0.0-beta.22(f112b2d64c2e812e383874acd4359d24)
+        version: 23.0.0-beta.22(b244141e0d7f98db17f01299582a1d49)
       '@nx/conformance':
         specifier: 5.0.4
         version: 5.0.4(@nx/js@23.0.0-beta.22(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/cli@0.8.0(@swc/core@1.15.10(@swc/helpers@0.5.18))(chokidar@3.6.0))(@swc/core@1.15.10(@swc/helpers@0.5.18))(nx@23.0.0-beta.22(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0)))(nx@23.0.0-beta.22(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))
@@ -677,10 +677,10 @@ importers:
         version: 5.0.4
       '@nx/next':
         specifier: 23.0.0-beta.22
-        version: 23.0.0-beta.22(255c39f68ed4f0e6d409b2b5cfc88e67)
+        version: 23.0.0-beta.22(497387199df6dcd9c0c04ff6d6ba606a)
       '@nx/playwright':
         specifier: 23.0.0-beta.22
-        version: 23.0.0-beta.22(@babel/traverse@7.29.0)(@nx/jest@23.0.0-beta.22(b55ff7bbb18a1cfbe812827163635209))(@playwright/test@1.54.0)(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/cli@0.8.0(@swc/core@1.15.10(@swc/helpers@0.5.18))(chokidar@3.6.0))(@swc/core@1.15.10(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@9.39.4(jiti@2.6.1))(nx@23.0.0-beta.22(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
+        version: 23.0.0-beta.22(@babel/traverse@7.29.0)(@nx/jest@23.0.0-beta.22(b55ff7bbb18a1cfbe812827163635209))(@playwright/test@1.60.0)(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/cli@0.8.0(@swc/core@1.15.10(@swc/helpers@0.5.18))(chokidar@3.6.0))(@swc/core@1.15.10(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@9.39.4(jiti@2.6.1))(nx@23.0.0-beta.22(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
       '@nx/plugin':
         specifier: 23.0.0-beta.22
         version: 23.0.0-beta.22(033c2b984920c13820259a7ad9088c06)
@@ -689,16 +689,16 @@ importers:
         version: 5.0.4
       '@nx/react':
         specifier: 23.0.0-beta.22
-        version: 23.0.0-beta.22(588f901d95320cbb1516f8415716de7b)
+        version: 23.0.0-beta.22(42b3b668fd36508888b5c67cb1871d13)
       '@nx/rsbuild':
         specifier: 23.0.0-beta.22
         version: 23.0.0-beta.22(@babel/traverse@7.29.0)(@rsbuild/core@1.1.8)(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/cli@0.8.0(@swc/core@1.15.10(@swc/helpers@0.5.18))(chokidar@3.6.0))(@swc/core@1.15.10(@swc/helpers@0.5.18))(nx@23.0.0-beta.22(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(typescript@5.9.2)(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
       '@nx/rspack':
         specifier: 23.0.0-beta.22
-        version: 23.0.0-beta.22(f53c7acfd481e95d8bf5f83b04565100)
+        version: 23.0.0-beta.22(18ae061b1c3616c20104676cd471d7e3)
       '@nx/storybook':
         specifier: 23.0.0-beta.22
-        version: 23.0.0-beta.22(@babel/traverse@7.29.0)(@nx/jest@23.0.0-beta.22(b55ff7bbb18a1cfbe812827163635209))(@nx/web@23.0.0-beta.22(c9084ecb9e9291364e948ed3dc72b041))(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/cli@0.8.0(@swc/core@1.15.10(@swc/helpers@0.5.18))(chokidar@3.6.0))(@swc/core@1.15.10(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(cypress@15.15.0)(eslint@9.39.4(jiti@2.6.1))(nx@23.0.0-beta.22(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(storybook@10.2.10(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.2)(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
+        version: 23.0.0-beta.22(@babel/traverse@7.29.0)(@nx/jest@23.0.0-beta.22(b55ff7bbb18a1cfbe812827163635209))(@nx/web@23.0.0-beta.22(d0ef559adb0d561a0653ae5ef92af19e))(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/cli@0.8.0(@swc/core@1.15.10(@swc/helpers@0.5.18))(chokidar@3.6.0))(@swc/core@1.15.10(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(cypress@15.15.0)(eslint@9.39.4(jiti@2.6.1))(nx@23.0.0-beta.22(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(storybook@10.2.10(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.2)(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
       '@nx/vite':
         specifier: 23.0.0-beta.22
         version: 23.0.0-beta.22(82bf88dd19c8404699944c8f88ba56d9)
@@ -707,7 +707,7 @@ importers:
         version: 23.0.0-beta.22(82bf88dd19c8404699944c8f88ba56d9)
       '@nx/web':
         specifier: 23.0.0-beta.22
-        version: 23.0.0-beta.22(c9084ecb9e9291364e948ed3dc72b041)
+        version: 23.0.0-beta.22(d0ef559adb0d561a0653ae5ef92af19e)
       '@nx/webpack':
         specifier: 23.0.0-beta.22
         version: 23.0.0-beta.22(@babel/traverse@7.29.0)(@rspack/core@1.6.8(@swc/helpers@0.5.18))(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/cli@0.8.0(@swc/core@1.15.10(@swc/helpers@0.5.18))(chokidar@3.6.0))(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(html-webpack-plugin@5.5.0(webpack@5.105.2))(lightningcss@1.32.0)(nx@23.0.0-beta.22(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(typescript@5.9.2)(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
@@ -716,7 +716,7 @@ importers:
         version: 6.2.0(typescript@5.9.2)
       '@playwright/test':
         specifier: 'catalog:'
-        version: 1.54.0
+        version: 1.60.0
       '@pmmmwh/react-refresh-webpack-plugin':
         specifier: ^0.5.7
         version: 0.5.17(react-refresh@0.10.0)(type-fest@4.41.0)(webpack-dev-server@5.2.3)(webpack-hot-middleware@2.26.1)(webpack@5.105.2)
@@ -1148,7 +1148,7 @@ importers:
         version: 10.2.5
       next-sitemap:
         specifier: ^3.1.10
-        version: 3.1.55(@next/env@14.2.35)(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.54.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))
+        version: 3.1.55(@next/env@14.2.35)(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.60.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))
       ng-packagr:
         specifier: catalog:angular
         version: 21.2.0(@angular/compiler-cli@21.2.0(@angular/compiler@21.2.0)(typescript@5.9.2))(tailwindcss@4.1.11)(tslib@2.8.1)(typescript@5.9.2)
@@ -2136,10 +2136,10 @@ importers:
         version: 1.1.5
       next:
         specifier: 14.2.35
-        version: 14.2.35(@babel/core@7.29.0)(@playwright/test@1.54.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3)
+        version: 14.2.35(@babel/core@7.29.0)(@playwright/test@1.60.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3)
       next-seo:
         specifier: 'catalog:'
-        version: 5.15.0(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.54.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+        version: 5.15.0(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.60.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       openai:
         specifier: ~4.3.1
         version: 4.3.1(encoding@0.1.13)
@@ -2402,7 +2402,7 @@ importers:
         version: 2.3.0
       '@angular/build':
         specifier: catalog:angular-supported-versions
-        version: 21.2.0(34548aaea574a8d49ef3ef8d9bfa54b4)
+        version: 21.2.0(de19134c5273622bd3ce91befcb71b51)
       '@angular/localize':
         specifier: catalog:angular-supported-versions
         version: 21.2.0(@angular/compiler-cli@21.2.0(@angular/compiler@21.2.0)(typescript@5.9.2))(@angular/compiler@21.2.0)
@@ -2508,7 +2508,7 @@ importers:
     dependencies:
       '@angular/build':
         specifier: catalog:angular-supported-versions
-        version: 21.2.0(34548aaea574a8d49ef3ef8d9bfa54b4)
+        version: 21.2.0(de19134c5273622bd3ce91befcb71b51)
       '@angular/compiler-cli':
         specifier: catalog:angular-supported-versions
         version: 21.2.0(@angular/compiler@21.2.0)(typescript@5.9.2)
@@ -3126,7 +3126,7 @@ importers:
         version: 2.3.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(node-fetch@3.3.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2)(vue-tsc@2.2.12(typescript@5.9.2))(webpack@5.105.2)
       '@module-federation/node':
         specifier: ^2.7.21
-        version: 2.7.21(@rspack/core@1.6.8(@swc/helpers@0.5.18))(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.54.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2)(vue-tsc@2.2.12(typescript@5.9.2))(webpack@5.105.2)
+        version: 2.7.21(@rspack/core@1.6.8(@swc/helpers@0.5.18))(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.60.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2)(vue-tsc@2.2.12(typescript@5.9.2))(webpack@5.105.2)
       '@module-federation/sdk':
         specifier: ^2.1.0
         version: 2.1.0
@@ -3235,7 +3235,7 @@ importers:
         version: 7.0.5
       next:
         specifier: '>=14.0.0 <17.0.0'
-        version: 14.2.28(@babel/core@7.29.0)(@playwright/test@1.54.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3)
+        version: 14.2.28(@babel/core@7.29.0)(@playwright/test@1.60.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3)
       semver:
         specifier: 'catalog:'
         version: 7.7.4
@@ -3514,7 +3514,7 @@ importers:
         version: link:../js
       '@playwright/test':
         specifier: 'catalog:'
-        version: 1.54.0
+        version: 1.60.0
       minimatch:
         specifier: ^10.2.5
         version: 10.2.5
@@ -10690,8 +10690,8 @@ packages:
     resolution: {integrity: sha512-YLT9Zo3oNPJoBjBc4q8G2mjU4tqIbf5CEOORbUUr48dCD9q3umJ3IPlVqOqDakPfd2HuwccBaqlGhN4Gmr5OWg==}
     engines: {node: ^12.20.0 || ^14.18.0 || >=16.0.0}
 
-  '@playwright/test@1.54.0':
-    resolution: {integrity: sha512-6Mnd5daQmLivaLu5kxUg6FxPtXY4sXsS5SUwKjWNy4ISe4pKraNHoFxcsaTFiNUULbjy0Vlb5HT86QuM0Jy1pQ==}
+  '@playwright/test@1.60.0':
+    resolution: {integrity: sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -20467,13 +20467,13 @@ packages:
     resolution: {integrity: sha512-+KD8hJtqQMYoTuL1bbGOqxb4z+nZkTAwVdNtWwe8Tc2xNbEmdJYIYoc6Qt0uF55e6YW6KuTHw1DjQ18gMhzepw==}
     engines: {node: '>=16.0.0'}
 
-  playwright-core@1.54.0:
-    resolution: {integrity: sha512-uiWpWaJh3R3etpJ0QrpligEMl62Dk1iSAB6NUXylvmQz+e3eipXHDHvOvydDAssb5Oqo0E818qdn0L9GcJSTyA==}
+  playwright-core@1.60.0:
+    resolution: {integrity: sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==}
     engines: {node: '>=18'}
     hasBin: true
 
-  playwright@1.54.0:
-    resolution: {integrity: sha512-y9yzHmXRwEUOpghM7XGcA38GjWuTOUMaTIcm/5rHcYVjh5MSp9qQMRRMc/+p1cx+csoPnX4wkxAF61v5VKirxg==}
+  playwright@1.60.0:
+    resolution: {integrity: sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==}
     engines: {node: '>=18'}
     hasBin: true
 
@@ -25337,64 +25337,6 @@ snapshots:
       eslint: 9.39.4(jiti@2.6.1)
       typescript: 5.9.2
 
-  '@angular/build@21.2.0(34548aaea574a8d49ef3ef8d9bfa54b4)':
-    dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@angular-devkit/architect': 0.2102.0(chokidar@3.6.0)
-      '@angular/compiler': 21.2.0
-      '@angular/compiler-cli': 21.2.0(@angular/compiler@21.2.0)(typescript@5.9.2)
-      '@babel/core': 7.29.0
-      '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-split-export-declaration': 7.24.7
-      '@inquirer/confirm': 5.1.21(@types/node@24.12.2)
-      '@vitejs/plugin-basic-ssl': 2.1.4(vite@7.3.1(@types/node@24.12.2)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))
-      beasties: 0.4.1
-      browserslist: 4.28.1
-      esbuild: 0.27.3
-      https-proxy-agent: 7.0.6
-      istanbul-lib-instrument: 6.0.3
-      jsonc-parser: 3.3.1
-      listr2: 9.0.5
-      magic-string: 0.30.21
-      mrmime: 2.0.1
-      parse5-html-rewriting-stream: 8.0.0
-      picomatch: 4.0.3
-      piscina: 5.1.4
-      rolldown: 1.0.0-rc.4
-      sass: 1.97.3
-      semver: 7.7.4
-      source-map-support: 0.5.21
-      tinyglobby: 0.2.15
-      tslib: 2.8.1
-      typescript: 5.9.2
-      undici: 7.22.0
-      vite: 7.3.1(@types/node@24.12.2)(jiti@2.6.1)(less@4.5.1)(lightningcss@1.32.0)(sass-embedded@1.97.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0)
-      watchpack: 2.5.1
-    optionalDependencies:
-      '@angular/core': 21.2.0(@angular/compiler@21.2.0)(rxjs@7.8.2)(zone.js@0.16.0)
-      '@angular/localize': 21.2.0(@angular/compiler-cli@21.2.0(@angular/compiler@21.2.0)(typescript@5.9.2))(@angular/compiler@21.2.0)
-      '@angular/platform-browser': 21.2.0(@angular/common@21.2.0(@angular/core@21.2.0(@angular/compiler@21.2.0)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.2.0(@angular/compiler@21.2.0)(rxjs@7.8.2)(zone.js@0.16.0))
-      '@angular/platform-server': 21.2.0(@angular/common@21.2.0(@angular/core@21.2.0(@angular/compiler@21.2.0)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/compiler@21.2.0)(@angular/core@21.2.0(@angular/compiler@21.2.0)(rxjs@7.8.2)(zone.js@0.16.0))(@angular/platform-browser@21.2.0(@angular/common@21.2.0(@angular/core@21.2.0(@angular/compiler@21.2.0)(rxjs@7.8.2)(zone.js@0.16.0))(rxjs@7.8.2))(@angular/core@21.2.0(@angular/compiler@21.2.0)(rxjs@7.8.2)(zone.js@0.16.0)))(rxjs@7.8.2)
-      '@angular/ssr': 21.2.0(04a10a167fdb5b9e93e7071d2f6d2277)
-      less: 4.5.1
-      lmdb: 3.5.1
-      ng-packagr: 21.2.0(@angular/compiler-cli@21.2.0(@angular/compiler@21.2.0)(typescript@5.9.2))(tailwindcss@4.1.11)(tslib@2.8.1)(typescript@5.9.2)
-      postcss: 8.5.8
-      tailwindcss: 4.1.11
-      vitest: 4.1.2(@types/node@24.12.2)(jsdom@26.1.0)(vite@8.0.0(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(less@4.5.1)(sass-embedded@1.97.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.20.5)(yaml@2.9.0))
-    transitivePeerDependencies:
-      - '@types/node'
-      - chokidar
-      - jiti
-      - lightningcss
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
   '@angular/build@21.2.0(a8859e04184b94f7a58c470e139e255e)':
     dependencies:
       '@ampproject/remapping': 2.3.0
@@ -29449,7 +29391,7 @@ snapshots:
       - utf-8-validate
       - vue-tsc
 
-  '@module-federation/node@2.7.21(@rspack/core@1.6.8(@swc/helpers@0.5.18))(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.54.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2)(vue-tsc@2.2.12(typescript@5.9.2))(webpack@5.105.2)':
+  '@module-federation/node@2.7.21(@rspack/core@1.6.8(@swc/helpers@0.5.18))(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.60.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2)(vue-tsc@2.2.12(typescript@5.9.2))(webpack@5.105.2)':
     dependencies:
       '@module-federation/enhanced': 0.21.2(@rspack/core@1.6.8(@swc/helpers@0.5.18))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2)(vue-tsc@2.2.12(typescript@5.9.2))(webpack@5.105.2)
       '@module-federation/runtime': 0.21.2
@@ -29459,7 +29401,7 @@ snapshots:
       node-fetch: 2.7.0(encoding@0.1.13)
       webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
     optionalDependencies:
-      next: 14.2.35(@babel/core@7.29.0)(@playwright/test@1.54.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3)
+      next: 14.2.35(@babel/core@7.29.0)(@playwright/test@1.60.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
     transitivePeerDependencies:
@@ -31163,16 +31105,16 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@nx/angular@23.0.0-beta.22(f112b2d64c2e812e383874acd4359d24)':
+  '@nx/angular@23.0.0-beta.22(b244141e0d7f98db17f01299582a1d49)':
     dependencies:
       '@angular-devkit/core': 21.2.0(chokidar@3.6.0)
       '@angular-devkit/schematics': 21.2.0(chokidar@3.6.0)
       '@nx/devkit': 23.0.0-beta.22(nx@23.0.0-beta.22(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))
       '@nx/eslint': 23.0.0-beta.22(@babel/traverse@7.29.0)(@nx/jest@23.0.0-beta.22(b55ff7bbb18a1cfbe812827163635209))(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/cli@0.8.0(@swc/core@1.15.10(@swc/helpers@0.5.18))(chokidar@3.6.0))(@swc/core@1.15.10(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@9.39.4(jiti@2.6.1))(nx@23.0.0-beta.22(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
       '@nx/js': 23.0.0-beta.22(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/cli@0.8.0(@swc/core@1.15.10(@swc/helpers@0.5.18))(chokidar@3.6.0))(@swc/core@1.15.10(@swc/helpers@0.5.18))(nx@23.0.0-beta.22(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
-      '@nx/module-federation': 23.0.0-beta.22(8bbbcf9de10ca2b5eebf3acebbceed81)
-      '@nx/rspack': 23.0.0-beta.22(f53c7acfd481e95d8bf5f83b04565100)
-      '@nx/web': 23.0.0-beta.22(c9084ecb9e9291364e948ed3dc72b041)
+      '@nx/module-federation': 23.0.0-beta.22(73e2877424e043e44ef945a142414e1b)
+      '@nx/rspack': 23.0.0-beta.22(18ae061b1c3616c20104676cd471d7e3)
+      '@nx/web': 23.0.0-beta.22(d0ef559adb0d561a0653ae5ef92af19e)
       '@nx/webpack': 23.0.0-beta.22(@babel/traverse@7.29.0)(@rspack/core@1.6.8(@swc/helpers@0.5.18))(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/cli@0.8.0(@swc/core@1.15.10(@swc/helpers@0.5.18))(chokidar@3.6.0))(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(html-webpack-plugin@5.5.0(webpack@5.105.2))(lightningcss@1.32.0)(nx@23.0.0-beta.22(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(typescript@5.9.2)(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
       '@phenomnomnominal/tsquery': 6.2.0(typescript@5.9.2)
       '@schematics/angular': 21.2.0(chokidar@3.6.0)
@@ -31604,14 +31546,14 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@nx/module-federation@23.0.0-beta.22(8bbbcf9de10ca2b5eebf3acebbceed81)':
+  '@nx/module-federation@23.0.0-beta.22(73e2877424e043e44ef945a142414e1b)':
     dependencies:
       '@module-federation/enhanced': 2.3.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(node-fetch@3.3.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2)(vue-tsc@2.2.12(typescript@5.9.2))(webpack@5.105.2)
-      '@module-federation/node': 2.7.21(@rspack/core@1.6.8(@swc/helpers@0.5.18))(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.54.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2)(vue-tsc@2.2.12(typescript@5.9.2))(webpack@5.105.2)
+      '@module-federation/node': 2.7.21(@rspack/core@1.6.8(@swc/helpers@0.5.18))(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.60.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2)(vue-tsc@2.2.12(typescript@5.9.2))(webpack@5.105.2)
       '@module-federation/sdk': 2.3.3(node-fetch@3.3.2)
       '@nx/devkit': 23.0.0-beta.22(nx@23.0.0-beta.22(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))
       '@nx/js': 23.0.0-beta.22(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/cli@0.8.0(@swc/core@1.15.10(@swc/helpers@0.5.18))(chokidar@3.6.0))(@swc/core@1.15.10(@swc/helpers@0.5.18))(nx@23.0.0-beta.22(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
-      '@nx/web': 23.0.0-beta.22(c9084ecb9e9291364e948ed3dc72b041)
+      '@nx/web': 23.0.0-beta.22(d0ef559adb0d561a0653ae5ef92af19e)
       '@rspack/core': 1.6.8(@swc/helpers@0.5.18)
       express: 4.22.1
       http-proxy-middleware: 3.0.5
@@ -31646,20 +31588,20 @@ snapshots:
       - vue-tsc
       - webpack-cli
 
-  '@nx/next@23.0.0-beta.22(255c39f68ed4f0e6d409b2b5cfc88e67)':
+  '@nx/next@23.0.0-beta.22(497387199df6dcd9c0c04ff6d6ba606a)':
     dependencies:
       '@babel/plugin-proposal-decorators': 7.28.0(@babel/core@7.29.0)
       '@nx/devkit': 23.0.0-beta.22(nx@23.0.0-beta.22(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))
       '@nx/eslint': 23.0.0-beta.22(@babel/traverse@7.29.0)(@nx/jest@23.0.0-beta.22(b55ff7bbb18a1cfbe812827163635209))(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/cli@0.8.0(@swc/core@1.15.10(@swc/helpers@0.5.18))(chokidar@3.6.0))(@swc/core@1.15.10(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@9.39.4(jiti@2.6.1))(nx@23.0.0-beta.22(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
       '@nx/js': 23.0.0-beta.22(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/cli@0.8.0(@swc/core@1.15.10(@swc/helpers@0.5.18))(chokidar@3.6.0))(@swc/core@1.15.10(@swc/helpers@0.5.18))(nx@23.0.0-beta.22(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
-      '@nx/react': 23.0.0-beta.22(588f901d95320cbb1516f8415716de7b)
-      '@nx/web': 23.0.0-beta.22(c9084ecb9e9291364e948ed3dc72b041)
+      '@nx/react': 23.0.0-beta.22(42b3b668fd36508888b5c67cb1871d13)
+      '@nx/web': 23.0.0-beta.22(d0ef559adb0d561a0653ae5ef92af19e)
       '@nx/webpack': 23.0.0-beta.22(@babel/traverse@7.29.0)(@rspack/core@1.6.8(@swc/helpers@0.5.18))(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/cli@0.8.0(@swc/core@1.15.10(@swc/helpers@0.5.18))(chokidar@3.6.0))(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(html-webpack-plugin@5.5.0(webpack@5.105.2))(lightningcss@1.32.0)(nx@23.0.0-beta.22(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(typescript@5.9.2)(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
       '@phenomnomnominal/tsquery': 6.2.0(typescript@5.9.2)
       '@svgr/webpack': 8.1.0(typescript@5.9.2)
       copy-webpack-plugin: 14.0.0(webpack@5.105.2)
       ignore: 7.0.5
-      next: 14.2.35(@babel/core@7.29.0)(@playwright/test@1.54.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3)
+      next: 14.2.35(@babel/core@7.29.0)(@playwright/test@1.60.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3)
       semver: 7.7.4
       tslib: 2.8.1
       webpack-merge: 5.10.0
@@ -31839,7 +31781,7 @@ snapshots:
   '@nx/nx-win32-x64-msvc@23.0.0-beta.4':
     optional: true
 
-  '@nx/playwright@23.0.0-beta.22(@babel/traverse@7.29.0)(@nx/jest@23.0.0-beta.22(b55ff7bbb18a1cfbe812827163635209))(@playwright/test@1.54.0)(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/cli@0.8.0(@swc/core@1.15.10(@swc/helpers@0.5.18))(chokidar@3.6.0))(@swc/core@1.15.10(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@9.39.4(jiti@2.6.1))(nx@23.0.0-beta.22(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))':
+  '@nx/playwright@23.0.0-beta.22(@babel/traverse@7.29.0)(@nx/jest@23.0.0-beta.22(b55ff7bbb18a1cfbe812827163635209))(@playwright/test@1.60.0)(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/cli@0.8.0(@swc/core@1.15.10(@swc/helpers@0.5.18))(chokidar@3.6.0))(@swc/core@1.15.10(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@9.39.4(jiti@2.6.1))(nx@23.0.0-beta.22(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))':
     dependencies:
       '@nx/devkit': 23.0.0-beta.22(nx@23.0.0-beta.22(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))
       '@nx/eslint': 23.0.0-beta.22(@babel/traverse@7.29.0)(@nx/jest@23.0.0-beta.22(b55ff7bbb18a1cfbe812827163635209))(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/cli@0.8.0(@swc/core@1.15.10(@swc/helpers@0.5.18))(chokidar@3.6.0))(@swc/core@1.15.10(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@9.39.4(jiti@2.6.1))(nx@23.0.0-beta.22(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
@@ -31848,7 +31790,7 @@ snapshots:
       semver: 7.7.4
       tslib: 2.8.1
     optionalDependencies:
-      '@playwright/test': 1.54.0
+      '@playwright/test': 1.60.0
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@nx/jest'
@@ -31895,14 +31837,14 @@ snapshots:
     transitivePeerDependencies:
       - debug
 
-  '@nx/react@23.0.0-beta.22(588f901d95320cbb1516f8415716de7b)':
+  '@nx/react@23.0.0-beta.22(42b3b668fd36508888b5c67cb1871d13)':
     dependencies:
       '@nx/devkit': 23.0.0-beta.22(nx@23.0.0-beta.22(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))
       '@nx/eslint': 23.0.0-beta.22(@babel/traverse@7.29.0)(@nx/jest@23.0.0-beta.22(b55ff7bbb18a1cfbe812827163635209))(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/cli@0.8.0(@swc/core@1.15.10(@swc/helpers@0.5.18))(chokidar@3.6.0))(@swc/core@1.15.10(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@9.39.4(jiti@2.6.1))(nx@23.0.0-beta.22(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
       '@nx/js': 23.0.0-beta.22(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/cli@0.8.0(@swc/core@1.15.10(@swc/helpers@0.5.18))(chokidar@3.6.0))(@swc/core@1.15.10(@swc/helpers@0.5.18))(nx@23.0.0-beta.22(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
-      '@nx/module-federation': 23.0.0-beta.22(8bbbcf9de10ca2b5eebf3acebbceed81)
+      '@nx/module-federation': 23.0.0-beta.22(73e2877424e043e44ef945a142414e1b)
       '@nx/rollup': 23.0.0-beta.22(@babel/core@7.29.0)(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/cli@0.8.0(@swc/core@1.15.10(@swc/helpers@0.5.18))(chokidar@3.6.0))(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/babel__core@7.20.5)(nx@23.0.0-beta.22(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(typescript@5.9.2)(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
-      '@nx/web': 23.0.0-beta.22(c9084ecb9e9291364e948ed3dc72b041)
+      '@nx/web': 23.0.0-beta.22(d0ef559adb0d561a0653ae5ef92af19e)
       '@phenomnomnominal/tsquery': 6.2.0(typescript@5.9.2)
       '@svgr/webpack': 8.1.0(typescript@5.9.2)
       express: 4.22.1
@@ -31997,12 +31939,12 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/rspack@23.0.0-beta.22(f53c7acfd481e95d8bf5f83b04565100)':
+  '@nx/rspack@23.0.0-beta.22(18ae061b1c3616c20104676cd471d7e3)':
     dependencies:
       '@nx/devkit': 23.0.0-beta.22(nx@23.0.0-beta.22(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))
       '@nx/js': 23.0.0-beta.22(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/cli@0.8.0(@swc/core@1.15.10(@swc/helpers@0.5.18))(chokidar@3.6.0))(@swc/core@1.15.10(@swc/helpers@0.5.18))(nx@23.0.0-beta.22(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
-      '@nx/module-federation': 23.0.0-beta.22(8bbbcf9de10ca2b5eebf3acebbceed81)
-      '@nx/web': 23.0.0-beta.22(c9084ecb9e9291364e948ed3dc72b041)
+      '@nx/module-federation': 23.0.0-beta.22(73e2877424e043e44ef945a142414e1b)
+      '@nx/web': 23.0.0-beta.22(d0ef559adb0d561a0653ae5ef92af19e)
       '@phenomnomnominal/tsquery': 6.2.0(typescript@5.9.2)
       autoprefixer: 10.4.27(postcss@8.5.8)
       browserslist: 4.28.1
@@ -32063,7 +32005,7 @@ snapshots:
       - vue-tsc
       - webpack-cli
 
-  '@nx/storybook@23.0.0-beta.22(@babel/traverse@7.29.0)(@nx/jest@23.0.0-beta.22(b55ff7bbb18a1cfbe812827163635209))(@nx/web@23.0.0-beta.22(c9084ecb9e9291364e948ed3dc72b041))(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/cli@0.8.0(@swc/core@1.15.10(@swc/helpers@0.5.18))(chokidar@3.6.0))(@swc/core@1.15.10(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(cypress@15.15.0)(eslint@9.39.4(jiti@2.6.1))(nx@23.0.0-beta.22(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(storybook@10.2.10(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.2)(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))':
+  '@nx/storybook@23.0.0-beta.22(@babel/traverse@7.29.0)(@nx/jest@23.0.0-beta.22(b55ff7bbb18a1cfbe812827163635209))(@nx/web@23.0.0-beta.22(d0ef559adb0d561a0653ae5ef92af19e))(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/cli@0.8.0(@swc/core@1.15.10(@swc/helpers@0.5.18))(chokidar@3.6.0))(@swc/core@1.15.10(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(cypress@15.15.0)(eslint@9.39.4(jiti@2.6.1))(nx@23.0.0-beta.22(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(storybook@10.2.10(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1))(typescript@5.9.2)(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))':
     dependencies:
       '@nx/cypress': 23.0.0-beta.22(@babel/traverse@7.29.0)(@nx/jest@23.0.0-beta.22(b55ff7bbb18a1cfbe812827163635209))(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/cli@0.8.0(@swc/core@1.15.10(@swc/helpers@0.5.18))(chokidar@3.6.0))(@swc/core@1.15.10(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(cypress@15.15.0)(eslint@9.39.4(jiti@2.6.1))(nx@23.0.0-beta.22(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(typescript@5.9.2)(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
       '@nx/devkit': 23.0.0-beta.22(nx@23.0.0-beta.22(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))
@@ -32074,7 +32016,7 @@ snapshots:
       storybook: 10.2.10(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tslib: 2.8.1
     optionalDependencies:
-      '@nx/web': 23.0.0-beta.22(c9084ecb9e9291364e948ed3dc72b041)
+      '@nx/web': 23.0.0-beta.22(d0ef559adb0d561a0653ae5ef92af19e)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@nx/jest'
@@ -32138,7 +32080,7 @@ snapshots:
       - typescript
       - verdaccio
 
-  '@nx/web@23.0.0-beta.22(c9084ecb9e9291364e948ed3dc72b041)':
+  '@nx/web@23.0.0-beta.22(d0ef559adb0d561a0653ae5ef92af19e)':
     dependencies:
       '@nx/devkit': 23.0.0-beta.22(nx@23.0.0-beta.22(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))
       '@nx/js': 23.0.0-beta.22(@babel/traverse@7.29.0)(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/cli@0.8.0(@swc/core@1.15.10(@swc/helpers@0.5.18))(chokidar@3.6.0))(@swc/core@1.15.10(@swc/helpers@0.5.18))(nx@23.0.0-beta.22(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
@@ -32150,7 +32092,7 @@ snapshots:
       '@nx/cypress': 23.0.0-beta.22(@babel/traverse@7.29.0)(@nx/jest@23.0.0-beta.22(b55ff7bbb18a1cfbe812827163635209))(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/cli@0.8.0(@swc/core@1.15.10(@swc/helpers@0.5.18))(chokidar@3.6.0))(@swc/core@1.15.10(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(cypress@15.15.0)(eslint@9.39.4(jiti@2.6.1))(nx@23.0.0-beta.22(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(typescript@5.9.2)(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
       '@nx/eslint': 23.0.0-beta.22(@babel/traverse@7.29.0)(@nx/jest@23.0.0-beta.22(b55ff7bbb18a1cfbe812827163635209))(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/cli@0.8.0(@swc/core@1.15.10(@swc/helpers@0.5.18))(chokidar@3.6.0))(@swc/core@1.15.10(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@9.39.4(jiti@2.6.1))(nx@23.0.0-beta.22(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
       '@nx/jest': 23.0.0-beta.22(b55ff7bbb18a1cfbe812827163635209)
-      '@nx/playwright': 23.0.0-beta.22(@babel/traverse@7.29.0)(@nx/jest@23.0.0-beta.22(b55ff7bbb18a1cfbe812827163635209))(@playwright/test@1.54.0)(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/cli@0.8.0(@swc/core@1.15.10(@swc/helpers@0.5.18))(chokidar@3.6.0))(@swc/core@1.15.10(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@9.39.4(jiti@2.6.1))(nx@23.0.0-beta.22(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
+      '@nx/playwright': 23.0.0-beta.22(@babel/traverse@7.29.0)(@nx/jest@23.0.0-beta.22(b55ff7bbb18a1cfbe812827163635209))(@playwright/test@1.60.0)(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/cli@0.8.0(@swc/core@1.15.10(@swc/helpers@0.5.18))(chokidar@3.6.0))(@swc/core@1.15.10(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@9.39.4(jiti@2.6.1))(nx@23.0.0-beta.22(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
       '@nx/vite': 23.0.0-beta.22(82bf88dd19c8404699944c8f88ba56d9)
       '@nx/webpack': 23.0.0-beta.22(@babel/traverse@7.29.0)(@rspack/core@1.6.8(@swc/helpers@0.5.18))(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/cli@0.8.0(@swc/core@1.15.10(@swc/helpers@0.5.18))(chokidar@3.6.0))(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(html-webpack-plugin@5.5.0(webpack@5.105.2))(lightningcss@1.32.0)(nx@23.0.0-beta.22(@swc-node/register@1.11.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@5.9.2))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(typescript@5.9.2)(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
     transitivePeerDependencies:
@@ -32943,9 +32885,9 @@ snapshots:
 
   '@pkgr/core@0.2.7': {}
 
-  '@playwright/test@1.54.0':
+  '@playwright/test@1.60.0':
     dependencies:
-      playwright: 1.54.0
+      playwright: 1.60.0
 
   '@pmmmwh/react-refresh-webpack-plugin@0.5.17(react-refresh@0.10.0)(type-fest@4.41.0)(webpack-dev-server@5.2.3)(webpack-hot-middleware@2.26.1)(webpack@5.105.2)':
     dependencies:
@@ -44595,22 +44537,22 @@ snapshots:
 
   netlify-redirector@0.5.0: {}
 
-  next-seo@5.15.0(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.54.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+  next-seo@5.15.0(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.60.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
     dependencies:
-      next: 14.2.35(@babel/core@7.29.0)(@playwright/test@1.54.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3)
+      next: 14.2.35(@babel/core@7.29.0)(@playwright/test@1.60.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3)
       react: 18.3.1
       react-dom: 18.3.1(react@18.3.1)
 
-  next-sitemap@3.1.55(@next/env@14.2.35)(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.54.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3)):
+  next-sitemap@3.1.55(@next/env@14.2.35)(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.60.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3)):
     dependencies:
       '@corex/deepmerge': 4.0.43
       '@next/env': 14.2.35
       minimist: 1.2.8
-      next: 14.2.35(@babel/core@7.29.0)(@playwright/test@1.54.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3)
+      next: 14.2.35(@babel/core@7.29.0)(@playwright/test@1.60.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3)
 
   next-tick@1.1.0: {}
 
-  next@14.2.28(@babel/core@7.29.0)(@playwright/test@1.54.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3):
+  next@14.2.28(@babel/core@7.29.0)(@playwright/test@1.60.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3):
     dependencies:
       '@next/env': 14.2.28
       '@swc/helpers': 0.5.5
@@ -44631,13 +44573,13 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 14.2.28
       '@next/swc-win32-ia32-msvc': 14.2.28
       '@next/swc-win32-x64-msvc': 14.2.28
-      '@playwright/test': 1.54.0
+      '@playwright/test': 1.60.0
       sass: 1.97.3
     transitivePeerDependencies:
       - '@babel/core'
       - babel-plugin-macros
 
-  next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.54.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3):
+  next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.60.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3):
     dependencies:
       '@next/env': 14.2.35
       '@swc/helpers': 0.5.5
@@ -44658,7 +44600,7 @@ snapshots:
       '@next/swc-win32-arm64-msvc': 14.2.33
       '@next/swc-win32-ia32-msvc': 14.2.33
       '@next/swc-win32-x64-msvc': 14.2.33
-      '@playwright/test': 1.54.0
+      '@playwright/test': 1.60.0
       sass: 1.97.3
     transitivePeerDependencies:
       - '@babel/core'
@@ -46256,11 +46198,11 @@ snapshots:
       pvutils: 1.1.5
       tslib: 2.8.1
 
-  playwright-core@1.54.0: {}
+  playwright-core@1.60.0: {}
 
-  playwright@1.54.0:
+  playwright@1.60.0:
     dependencies:
-      playwright-core: 1.54.0
+      playwright-core: 1.60.0
     optionalDependencies:
       fsevents: 2.3.2
 


### PR DESCRIPTION
## Current Behavior

The repo's `mise.toml` defaults the Node.js toolchain to `24.11.0`. Contributors — and the mise-provisioned CI jobs (`ci.yml`, CodeQL) — therefore run on Node 24, which ships npm 11.6.1. That npm is too old to honor the `min-release-age` supply-chain cooldown (added in npm 11.10.0).

## Expected Behavior

`mise.toml` defaults the Node.js toolchain to `26.3.0` (latest Node, ships npm 11.16.0). Local development and the mise-provisioned CI jobs move to Node 26.

Scope / notes:

- The default remains overridable via the `NODE_VERSION` env var — the template is otherwise unchanged.
- `publish.yml` (pinned `NODE_VERSION: 22.16.0` plus hardcoded musl native builds) and `e2e-matrix.yml` (matrix `node_version`) set `NODE_VERSION` explicitly, so they are **unaffected** and stay on Node 22.
- Utility workflows using `actions/setup-node` (`pr-title-validation`, `generate-embeddings`, `banner-monitor`, `issue-notifier`) remain on Node 24 and are out of scope for this change.
- CI on this PR validates that the core build/test/lint suite passes on Node 26.

## Related Issue(s)

N/A — internal toolchain bump.
