### PR TITLE
chore(repo): print PR urls in update-repos script instead of creating PRs via gh

### DIFF
--- a/tools/update-repos/src/update-repo.ts
+++ b/tools/update-repos/src/update-repo.ts
@@ -18,6 +18,13 @@ interface Config {
   repositories: Record<string, RepositoryConfig>;
 }
 
+interface PullRequestInfo {
+  repoName: string;
+  title: string;
+  description: string;
+  url: string;
+}
+
 type PackageManager = 'npm' | 'yarn' | 'pnpm' | 'bun';
 
 const SCRIPT_DIR = __dirname;
@@ -262,74 +269,36 @@ async function getNxVersion(
   }
 }
 
-async function createOrUpdatePullRequest(
+function buildPullRequestInfo(
   repoName: string,
-  repoDir: string,
   updateBranch: string,
   fromVersion: string,
   toVersion: string
-): Promise<void> {
-  try {
-    const config: Config = JSON.parse(fs.readFileSync(CONFIG_FILE, 'utf8'));
-    const repoConfig = config.repositories[repoName];
-    const baseBranch = repoConfig.branch;
+): PullRequestInfo {
+  const config: Config = JSON.parse(fs.readFileSync(CONFIG_FILE, 'utf8'));
+  const repoConfig = config.repositories[repoName];
+  const baseBranch = repoConfig.branch;
 
-    const title = `chore(repo): update nx to ${toVersion}`;
-    const description = `Updating Nx from ${fromVersion} to ${toVersion}`;
+  const title = `chore(repo): update nx to ${toVersion}`;
+  const description = `Updating Nx from ${fromVersion} to ${toVersion}`;
 
-    // Check if an open PR already exists for this branch
-    let openPrExists = false;
-    try {
-      const { stdout } = await execAsync(
-        `gh pr view ${updateBranch} --json state`,
-        {
-          cwd: repoDir,
-        }
-      );
-      const prData = JSON.parse(stdout);
-      if (prData.state === 'OPEN') {
-        openPrExists = true;
-        log(`Open pull request already exists for branch ${updateBranch}`);
-      } else {
-        log(
-          `Pull request exists for branch ${updateBranch} but is ${prData.state.toLowerCase()}, will create new PR`
-        );
-      }
-    } catch {
-      log(`No existing pull request found for branch ${updateBranch}`);
-    }
+  // Build a GitHub "create pull request" URL with the title and body pre-filled.
+  const params = new URLSearchParams({
+    expand: '1',
+    title,
+    body: description,
+  });
+  const url = `https://github.com/${repoConfig.repo}/compare/${baseBranch}...${updateBranch}?${params.toString()}`;
 
-    if (openPrExists) {
-      log(`Updating existing pull request: ${title}`);
+  return { repoName, title, description, url };
+}
 
-      // Update PR title and description
-      const updatePrCommand = `gh pr edit ${updateBranch} --title "${title}" --body "${description}"`;
-      await execAsync(updatePrCommand, { cwd: repoDir });
-
-      log(`Pull request updated successfully with new title and description`);
-    } else {
-      log(`Creating new pull request: ${title}`);
-
-      // Create PR using GitHub CLI
-      const createPrCommand = `gh pr create --title "${title}" --body "${description}" --base ${baseBranch} --head ${updateBranch}`;
-      const { stdout } = await execAsync(createPrCommand, { cwd: repoDir });
-
-      const prUrl = stdout.trim();
-      log(`Pull request created successfully: ${prUrl}`);
-    }
-
-    // Always open PR in browser (for both new and updated PRs)
-    log(`🌐 Opening pull request in browser...`);
-    const openPrCommand = `gh pr view ${updateBranch} --web`;
-    await execAsync(openPrCommand, { cwd: repoDir });
-  } catch (error) {
-    log(
-      `Warning: Failed to create/update pull request for ${repoName}: ${getErrorMessage(
-        error
-      )}`
-    );
-    // Don't throw error here - PR creation/update failure shouldn't fail the entire update
-  }
+function printPullRequestInfo(prInfo: PullRequestInfo): void {
+  console.log('');
+  console.log(`📦 ${prInfo.repoName}`);
+  console.log(`   Title:       ${prInfo.title}`);
+  console.log(`   Description: ${prInfo.description}`);
+  console.log(`   Open PR:     ${prInfo.url}`);
 }
 
 async function checkRequiredTools(): Promise<void> {
@@ -374,7 +343,7 @@ async function setupRepository(
   }
 }
 
-async function updateRepository(repoName: string): Promise<void> {
+async function updateRepository(repoName: string): Promise<PullRequestInfo> {
   const repoDir = path.join(REPOS_DIR, repoName);
 
   log(`Starting update for repository: ${repoName}`);
@@ -542,20 +511,31 @@ async function updateRepository(repoName: string): Promise<void> {
       'Pushing update branch to remote (force, skipping hooks)'
     );
 
-    // Create or update pull request with correct versions
-    log('🔄 Creating or updating pull request...');
-    await createOrUpdatePullRequest(
+    // Build the pull request URL (PRs are created manually from this URL)
+    const prInfo = buildPullRequestInfo(
       repoName,
-      repoDir,
       updateBranch,
       fromVersion,
       toVersion
     );
 
     log(`✅ Update completed successfully for ${repoName}`);
+    return prInfo;
   } catch (error) {
     throw new Error(`Failed to update ${repoName}: ${getErrorMessage(error)}`);
   }
+}
+
+function printPullRequestSummary(prInfos: PullRequestInfo[]): void {
+  if (prInfos.length === 0) {
+    return;
+  }
+  console.log('');
+  console.log('═══════════════════════════════════════════════');
+  console.log(' Pull request(s) to create');
+  console.log('═══════════════════════════════════════════════');
+  prInfos.forEach(printPullRequestInfo);
+  console.log('');
 }
 
 async function updateAllRepositories(): Promise<void> {
@@ -564,14 +544,29 @@ async function updateAllRepositories(): Promise<void> {
 
   log('Starting concurrent updates for all repositories...');
 
-  const updatePromises = repoNames.map((repoName) =>
-    updateRepository(repoName).catch((error) => {
-      log(`ERROR updating ${repoName}: ${getErrorMessage(error)}`);
-      throw error;
-    })
+  const results = await Promise.allSettled(
+    repoNames.map((repoName) => updateRepository(repoName))
   );
 
-  await Promise.all(updatePromises);
+  const prInfos: PullRequestInfo[] = [];
+  const failures: string[] = [];
+  results.forEach((result, index) => {
+    if (result.status === 'fulfilled') {
+      prInfos.push(result.value);
+    } else {
+      const repoName = repoNames[index];
+      log(`ERROR updating ${repoName}: ${getErrorMessage(result.reason)}`);
+      failures.push(repoName);
+    }
+  });
+
+  // Print the PR URLs for the repos that updated successfully.
+  printPullRequestSummary(prInfos);
+
+  if (failures.length > 0) {
+    throw new Error(`Failed to update: ${failures.join(', ')}`);
+  }
+
   log('All repositories updated successfully!');
 }
 
@@ -598,7 +593,8 @@ async function main(): Promise<void> {
         process.exit(1);
       }
 
-      await updateRepository(repoName);
+      const prInfo = await updateRepository(repoName);
+      printPullRequestSummary([prInfo]);
     }
   } catch (error) {
     log(`ERROR: ${getErrorMessage(error)}`);


### PR DESCRIPTION
## Current Behavior

The `update-repos` script (`tools/update-repos/src/update-repo.ts`) pushes the
`upnx` update branch and then tries to create or update a pull request directly
via the GitHub CLI (`gh pr create` / `gh pr edit`), finally opening it in the
browser with `gh pr view --web`. When `gh` PR creation isn't available, the run
fails to surface a usable PR link.

## Expected Behavior

The script still pushes the `upnx` branch, but no longer creates PRs via `gh`.
Instead, at the very end it prints a ready-to-click GitHub "create pull request"
URL with the title and description pre-filled, for each updated repo:

```
📦 nx
   Title:       chore(repo): update nx to <version>
   Description: Updating Nx from <from> to <to>
   Open PR:     https://github.com/nrwl/nx/compare/master...upnx?expand=1&title=...&body=...
```

When updating all repos concurrently, the run now uses `Promise.allSettled` so
the PR URLs for repos that succeeded are still printed even if another repo
fails; the run then reports which repos failed.

## Related Issue(s)

N/A
