### PR TITLE
fix(repo): rename publish VERSION env var to avoid MSBuild leak

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -620,7 +620,8 @@ jobs:
           pnpm build:wasm
       - name: Publish
         env:
-          VERSION: ${{ needs.resolve-required-data.outputs.version }}
+          # Not named `VERSION` to avoid MSBuild adopting it as $(Version).
+          NX_PUBLISH_VERSION: ${{ needs.resolve-required-data.outputs.version }}
           DRY_RUN: ${{ needs.resolve-required-data.outputs.dry_run_flag }}
           PUBLISH_BRANCH: ${{ needs.resolve-required-data.outputs.publish_branch }}
         run: |
@@ -628,10 +629,10 @@ jobs:
           # Create and check out the publish branch
           git checkout -b $PUBLISH_BRANCH
           echo ""
-          echo "Version set to: $VERSION"
+          echo "Version set to: $NX_PUBLISH_VERSION"
           echo "DRY_RUN set to: $DRY_RUN"
           echo ""
-          pnpm nx-release --local=false $VERSION $DRY_RUN
+          pnpm nx-release --local=false $NX_PUBLISH_VERSION $DRY_RUN
 
       - name: (Stable Release Only) Trigger Docs Release
         # Publish docs only on a full release


### PR DESCRIPTION
## Current Behavior

The canary release pipeline fails while building the `@nx/dotnet` analyzer:

```
error NETSDK1018: Invalid NuGet version string: 'canary'.
[/home/runner/work/nx/nx/packages/dotnet/analyzer/MsbuildAnalyzer.csproj]
```

**Root cause:** the `publish` workflow's `Publish` step exported `VERSION=canary` for the whole step. MSBuild imports environment variables as properties (case-insensitively), so `VERSION` becomes `$(Version)` during the `dotnet build` that runs underneath `nx-release` (the `@nx/dotnet` package ships the compiled `MsbuildAnalyzer.dll`, so building it during publish runs the analyzer build). On canary the value is the non-semver string `canary`, which `GenerateAssemblyInfo` rejects.

This only began failing once `@nx/dotnet` — the repo's first project that runs `GenerateAssemblyInfo` — entered the publish build graph; the `VERSION` env var itself is long-standing and unchanged.

## Expected Behavior

The publish step no longer exposes a generically-named `VERSION` environment variable that MSBuild can adopt as `$(Version)`.

The env var is renamed to `NX_PUBLISH_VERSION`. `nx-release` reads the version as a positional CLI argument (not from the environment), so no script change is required — only the workflow. A comment is added warning against reusing the generic `VERSION` name.

This fixes the leak at its source rather than working around it in each .NET project.

## Related Issue(s)

N/A