### PR TITLE
fix(core): correct 'occured' typo to 'occurred' in error messages

### DIFF
--- a/packages/nx/src/command-line/graph/graph.ts
+++ b/packages/nx/src/command-line/graph/graph.ts
@@ -301,7 +301,7 @@ export async function generateGraph(
       output.warn({
         title: `${
           errors?.length > 1 ? `${errors.length} errors` : `An error`
-        } occured while processing the project graph. Showing partial graph.`,
+        } occurred while processing the project graph. Showing partial graph.`,
       });
     }
   }

--- a/packages/nx/src/plugins/js/lock-file/lock-file.ts
+++ b/packages/nx/src/plugins/js/lock-file/lock-file.ts
@@ -341,7 +341,7 @@ export function createLockFile(
         );
       }
       output.error({
-        title: 'An error occured while creating pruned lockfile',
+        title: 'An error occurred while creating pruned lockfile',
         bodyLines: errorBodyLines(e, additionalInfo),
       });
     }

--- a/packages/nx/src/project-graph/error-types.ts
+++ b/packages/nx/src/project-graph/error-types.ts
@@ -88,7 +88,7 @@ export class ProjectGraphError extends Error {
   }
 
   /**
-   * This gets the partial project graph despite the errors which occured.
+   * This gets the partial project graph despite the errors which occurred.
    * This partial project graph may be missing nodes, properties of nodes, or dependencies.
    * This is useful mostly for visualization/debugging. It should not be used for running tasks.
    */


### PR DESCRIPTION
## Current Behavior

Three error/diagnostic messages in the `nx` package misspell "occurred" as "occured":

- `packages/nx/src/plugins/js/lock-file/lock-file.ts` — `title: 'An error occured while creating pruned lockfile'` (shown to users on lockfile pruning failure)
- `packages/nx/src/command-line/graph/graph.ts` — `"... occured while processing the project graph. Showing partial graph."` (console output)
- `packages/nx/src/project-graph/error-types.ts` — doc comment `"... errors which occured."`

## Expected Behavior

The word is spelled "occurred" in all three places.

## Related Issue(s)

N/A — spelling-only fix, no behavior change.
