### PR TITLE
fix(dotnet): declare obj output for publish/pack and track vitest dep spec tsconfig input

### DIFF
--- a/packages/dotnet/analyzer.Tests/TargetBuilderOutputPathsTests.cs
+++ b/packages/dotnet/analyzer.Tests/TargetBuilderOutputPathsTests.cs
@@ -223,7 +223,7 @@ public class TargetBuilderOutputPathsTests
         var targets = BuildTargets(properties, projectDirectory, projectName: "foo", isExe: true);
 
         Assert.Equal(
-            new[] { "{projectRoot}/bin/Release/publish" },
+            new[] { "{projectRoot}/bin/Release/publish", "{projectRoot}/obj" },
             targets["publish"].Outputs);
     }
 
@@ -241,7 +241,7 @@ public class TargetBuilderOutputPathsTests
         var targets = BuildTargets(properties, projectDirectory, projectName: "foo", isExe: true);
 
         Assert.Equal(
-            new[] { "{projectRoot}/dist-publish" },
+            new[] { "{projectRoot}/dist-publish", "{projectRoot}/obj" },
             targets["publish"].Outputs);
     }
 
@@ -257,7 +257,39 @@ public class TargetBuilderOutputPathsTests
         var targets = BuildTargets(properties, projectDirectory, projectName: "foo", isExe: true);
 
         Assert.Equal(
-            new[] { "{workspaceRoot}/artifacts/publish/foo" },
+            new[] { "{workspaceRoot}/artifacts/publish/foo", "{workspaceRoot}/artifacts/obj/foo" },
             targets["publish"].Outputs);
+    }
+
+    // --- Pack output: nupkg glob plus the intermediate (obj) directory ------
+
+    [Fact]
+    public void Pack_EmitsNupkgGlobAndIntermediateObj()
+    {
+        // `dotnet pack` writes the .nupkg into the package output directory and
+        // intermediate state into obj, so both must be declared as outputs.
+        var projectDirectory = ProjectDir("libs", "foo");
+
+        var targets = BuildTargets(properties: new Dictionary<string, string>(), projectDirectory, projectName: "foo");
+
+        Assert.Equal(
+            new[] { "{projectRoot}/bin/*.nupkg", "{projectRoot}/obj" },
+            targets["pack"].Outputs);
+    }
+
+    [Fact]
+    public void Pack_ArtifactsLayout_EmitsWorkspaceRootPackageAndObjPaths()
+    {
+        var projectDirectory = ProjectDir("libs", "foo");
+        var properties = new Dictionary<string, string>
+        {
+            ["UseArtifactsOutput"] = "true",
+        };
+
+        var targets = BuildTargets(properties, projectDirectory, projectName: "foo");
+
+        Assert.Equal(
+            new[] { "{workspaceRoot}/artifacts/package/*.nupkg", "{workspaceRoot}/artifacts/obj/foo" },
+            targets["pack"].Outputs);
     }
 }

--- a/packages/dotnet/analyzer/Utilities/TargetBuilder.Pack.cs
+++ b/packages/dotnet/analyzer/Utilities/TargetBuilder.Pack.cs
@@ -25,6 +25,10 @@ public static partial class TargetBuilder
         };
 
         var packageOutputPath = GetPackageOutputPath(releaseProperties, projectName, projectDirectory, workspaceRoot);
+        // `dotnet pack` writes intermediate state into the intermediate (obj)
+        // directory, so it must be declared as an output alongside the package
+        // output, mirroring the build target.
+        var intermediatePath = GetIntermediateOutputPath(releaseProperties, projectName, projectDirectory, workspaceRoot);
 
         var buildReleaseTarget = $"{options.BuildTargetName}:release";
         targets[options.PackTargetName] = new Target
@@ -57,9 +61,13 @@ public static partial class TargetBuilder
                 new { dependentTasksOutputFiles = "**/*" },
                 .. directoryBuildInputs
             ],
-            Outputs = packageOutputPath is null
-                ? []
-                : [$"{packageOutputPath.TrimEnd('/')}/*.nupkg"],
+            Outputs = new[]
+                {
+                    packageOutputPath is null ? null : $"{packageOutputPath.TrimEnd('/')}/*.nupkg",
+                    intermediatePath
+                }
+                .Where(p => p is not null)
+                .ToArray()!,
             Metadata = new TargetMetadata
             {
                 Description = "Create NuGet package",

--- a/packages/dotnet/analyzer/Utilities/TargetBuilder.Publish.cs
+++ b/packages/dotnet/analyzer/Utilities/TargetBuilder.Publish.cs
@@ -26,6 +26,11 @@ public static partial class TargetBuilder
         };
 
         var publishDir = GetPublishDir(releaseProperties, projectName, projectDirectory, workspaceRoot);
+        // `dotnet publish` writes incremental-publish state (e.g.
+        // obj/<Configuration>/PublishOutputs.<hash>.txt) into the intermediate
+        // (obj) directory, so it must be declared as an output alongside the
+        // publish directory, mirroring the build target.
+        var intermediatePath = GetIntermediateOutputPath(releaseProperties, projectName, projectDirectory, workspaceRoot);
 
         string[] defaultFlags = ["--no-build", "--no-dependencies", "--no-restore"];
 
@@ -60,7 +65,9 @@ public static partial class TargetBuilder
                 new { dependentTasksOutputFiles = "**/*" },
                 .. directoryBuildInputs
             ],
-            Outputs = publishDir is null ? [] : [publishDir],
+            Outputs = new[] { publishDir, intermediatePath }
+                .Where(p => p is not null)
+                .ToArray()!,
             Metadata = new TargetMetadata
             {
                 Description = "Publish the .NET application",

--- a/packages/dotnet/analyzer/project.json
+++ b/packages/dotnet/analyzer/project.json
@@ -10,7 +10,7 @@
       "executor": "nx:noop"
     },
     "publish": {
-      "outputs": ["{projectRoot}/bin/Release/publish"]
+      "outputs": ["{projectRoot}/bin/Release/publish", "{projectRoot}/obj"]
     }
   }
 }

--- a/packages/vitest/src/plugins/__snapshots__/plugin-vitest.spec.ts.snap
+++ b/packages/vitest/src/plugins/__snapshots__/plugin-vitest.spec.ts.snap
@@ -18,6 +18,14 @@ exports[`@nx/vitest root project should create nodes 1`] = `
                 "default",
                 "^production",
                 {
+                  "dependencies": true,
+                  "fileset": "{projectRoot}/tsconfig.spec.json",
+                },
+                {
+                  "dependencies": true,
+                  "fileset": "{projectRoot}/tsconfig.storybook.json",
+                },
+                {
                   "externalDependencies": [
                     "vitest",
                   ],
@@ -90,6 +98,14 @@ exports[`@nx/vitest root project should create nodes with ci target name 1`] = `
                 "default",
                 "^production",
                 {
+                  "dependencies": true,
+                  "fileset": "{projectRoot}/tsconfig.spec.json",
+                },
+                {
+                  "dependencies": true,
+                  "fileset": "{projectRoot}/tsconfig.storybook.json",
+                },
+                {
                   "externalDependencies": [
                     "vitest",
                   ],
@@ -127,6 +143,14 @@ exports[`@nx/vitest root project should create nodes with ci target name 1`] = `
               "inputs": [
                 "default",
                 "^production",
+                {
+                  "dependencies": true,
+                  "fileset": "{projectRoot}/tsconfig.spec.json",
+                },
+                {
+                  "dependencies": true,
+                  "fileset": "{projectRoot}/tsconfig.storybook.json",
+                },
                 {
                   "externalDependencies": [
                     "vitest",
@@ -169,6 +193,14 @@ exports[`@nx/vitest root project should create nodes with ci target name 1`] = `
                 "default",
                 "^production",
                 {
+                  "dependencies": true,
+                  "fileset": "{projectRoot}/tsconfig.spec.json",
+                },
+                {
+                  "dependencies": true,
+                  "fileset": "{projectRoot}/tsconfig.storybook.json",
+                },
+                {
                   "externalDependencies": [
                     "vitest",
                   ],
@@ -209,6 +241,14 @@ exports[`@nx/vitest root project should create nodes with ci target name 1`] = `
               "inputs": [
                 "default",
                 "^production",
+                {
+                  "dependencies": true,
+                  "fileset": "{projectRoot}/tsconfig.spec.json",
+                },
+                {
+                  "dependencies": true,
+                  "fileset": "{projectRoot}/tsconfig.storybook.json",
+                },
                 {
                   "externalDependencies": [
                     "vitest",
@@ -282,6 +322,14 @@ exports[`@nx/vitest root project should create nodes with ci target name and ci 
                 "default",
                 "^production",
                 {
+                  "dependencies": true,
+                  "fileset": "{projectRoot}/tsconfig.spec.json",
+                },
+                {
+                  "dependencies": true,
+                  "fileset": "{projectRoot}/tsconfig.storybook.json",
+                },
+                {
                   "externalDependencies": [
                     "vitest",
                   ],
@@ -319,6 +367,14 @@ exports[`@nx/vitest root project should create nodes with ci target name and ci 
               "inputs": [
                 "default",
                 "^production",
+                {
+                  "dependencies": true,
+                  "fileset": "{projectRoot}/tsconfig.spec.json",
+                },
+                {
+                  "dependencies": true,
+                  "fileset": "{projectRoot}/tsconfig.storybook.json",
+                },
                 {
                   "externalDependencies": [
                     "vitest",
@@ -361,6 +417,14 @@ exports[`@nx/vitest root project should create nodes with ci target name and ci 
                 "default",
                 "^production",
                 {
+                  "dependencies": true,
+                  "fileset": "{projectRoot}/tsconfig.spec.json",
+                },
+                {
+                  "dependencies": true,
+                  "fileset": "{projectRoot}/tsconfig.storybook.json",
+                },
+                {
                   "externalDependencies": [
                     "vitest",
                   ],
@@ -401,6 +465,14 @@ exports[`@nx/vitest root project should create nodes with ci target name and ci 
               "inputs": [
                 "default",
                 "^production",
+                {
+                  "dependencies": true,
+                  "fileset": "{projectRoot}/tsconfig.spec.json",
+                },
+                {
+                  "dependencies": true,
+                  "fileset": "{projectRoot}/tsconfig.storybook.json",
+                },
                 {
                   "externalDependencies": [
                     "vitest",

--- a/packages/vitest/src/plugins/plugin.ts
+++ b/packages/vitest/src/plugins/plugin.ts
@@ -363,8 +363,26 @@ async function testTarget(
     options: { cwd: joinPathFragments(projectRoot) },
     cache: true,
     inputs: [
+      // Vitest runs on Vite, which transforms a dependency's sources and
+      // resolves their TypeScript project references. When a dependency's root
+      // tsconfig references its tsconfig.spec.json / tsconfig.storybook.json,
+      // those files are read during resolution, yet the `production` named
+      // input excludes them (so `^production` does not cover them). When
+      // `production` is in use, declare them explicitly so the dependency's
+      // spec/storybook tsconfigs are tracked as inputs.
       ...('production' in namedInputs
-        ? ['default', '^production']
+        ? [
+            'default',
+            '^production',
+            {
+              fileset: '{projectRoot}/tsconfig.spec.json',
+              dependencies: true as const,
+            },
+            {
+              fileset: '{projectRoot}/tsconfig.storybook.json',
+              dependencies: true as const,
+            },
+          ]
         : ['default', '^default']),
       ...tsconfigInputs.map((f) => ({
         json: `{workspaceRoot}/${f}`,


### PR DESCRIPTION
## Current Behavior

Two Nx task-pipeline sandbox violations were reported by Nx Cloud:

1. **`nx publish MsbuildAnalyzer` — unexpected write** at `packages/dotnet/analyzer/obj/Release/PublishOutputs.<hash>.txt`. `dotnet publish` writes its incremental-publish state file into the intermediate (`obj`) directory, but the `@nx/dotnet`-inferred `publish` target only declared the publish directory (`bin/Release/publish`) as an output — `obj` was undeclared. The `pack` target has the same latent gap (it declares only `*.nupkg`).

2. **`nx test angular-rspack` — unexpected read** at `packages/angular-rspack-compiler/tsconfig.spec.json`. Vitest runs on Vite, which transforms a dependency's sources and resolves their TypeScript project references. When a dependency's root `tsconfig.json` references its `tsconfig.spec.json`, that file is read during resolution — but the `production` named input excludes `tsconfig.spec.json` (`!{projectRoot}/tsconfig.spec.json`), so `^production` does not cover it. The dependency edge itself is correctly declared; only this one file was missing from the inputs.

## Expected Behavior

The files the tools genuinely touch are declared, so no sandbox violations:

- **`@nx/dotnet`:** the inferred `publish` and `pack` targets now include the intermediate (`obj`) directory in their outputs, mirroring how the `build` target already declares it. The `MsbuildAnalyzer` `project.json` publish-outputs override is updated too (a project-level `outputs` override *replaces* the inferred value, so it needs `obj` as well). New/updated C# output-path unit tests cover both publish and pack (29/29 passing).
- **`@nx/vitest`:** the inferred `test` target now declares `{ fileset: '{projectRoot}/tsconfig.spec.json', dependencies: true }`, so a dependency's spec tsconfig is tracked as an input. This mirrors the existing dependency-fileset precedent in the `@nx/js/typescript` plugin. Plugin snapshot updated.

Both fixes are systemic (at the plugin layer) so every dotnet/vitest project benefits, not just the two that surfaced the violations.

The two commits are independent and scoped separately (`fix(dotnet)` and `fix(vitest)`) — happy to split into two PRs if preferred.

## Related Issue(s)

Surfaced by Nx Cloud sandbox-violation reports; no standalone GitHub issue.

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/two-sandbox-viols-aefb1b3a)
<!-- polygraph-session-end -->