### PR TITLE
fix(core): forward full task graph to batch executors under DTE

### DIFF
--- a/packages/nx/src/tasks-runner/init-tasks-runner.ts
+++ b/packages/nx/src/tasks-runner/init-tasks-runner.ts
@@ -18,7 +18,7 @@ import { TaskResultsLifeCycle } from './life-cycles/task-results-life-cycle';
 async function createOrchestrator(
   tasks: Task[],
   projectGraph: ProjectGraph,
-  taskGraphForHashing: TaskGraph,
+  fullTaskGraph: TaskGraph,
   nxJson: NxJsonConfiguration,
   lifeCycle: LifeCycle
 ) {
@@ -72,7 +72,7 @@ async function createOrchestrator(
     false,
     daemonClient,
     undefined,
-    taskGraphForHashing
+    fullTaskGraph
   );
 
   await orchestrator.init();
@@ -85,14 +85,14 @@ async function createOrchestrator(
 export async function runDiscreteTasks(
   tasks: Task[],
   projectGraph: ProjectGraph,
-  taskGraphForHashing: TaskGraph,
+  fullTaskGraph: TaskGraph,
   nxJson: NxJsonConfiguration,
   lifeCycle: LifeCycle
 ): Promise<Array<Promise<TaskResult[]>>> {
   const orchestrator = await createOrchestrator(
     tasks,
     projectGraph,
-    taskGraphForHashing,
+    fullTaskGraph,
     nxJson,
     lifeCycle
   );
@@ -142,14 +142,14 @@ export async function runDiscreteTasks(
 export async function runContinuousTasks(
   tasks: Task[],
   projectGraph: ProjectGraph,
-  taskGraphForHashing: TaskGraph,
+  fullTaskGraph: TaskGraph,
   nxJson: NxJsonConfiguration,
   lifeCycle: LifeCycle
 ) {
   const orchestrator = await createOrchestrator(
     tasks,
     projectGraph,
-    taskGraphForHashing,
+    fullTaskGraph,
     nxJson,
     lifeCycle
   );

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -175,7 +175,7 @@ export class TaskOrchestrator {
     private readonly bail: boolean,
     private readonly daemon: DaemonClient,
     private readonly outputStyle: string,
-    private readonly taskGraphForHashing: TaskGraph = taskGraph
+    private readonly fullTaskGraph: TaskGraph = taskGraph
   ) {}
 
   async init() {
@@ -306,7 +306,7 @@ export class TaskOrchestrator {
           await hashTasks(
             this.hasher,
             this.projectGraph,
-            this.taskGraphForHashing,
+            this.fullTaskGraph,
             perTaskEnvs,
             this.taskDetails,
             unhashed
@@ -400,7 +400,7 @@ export class TaskOrchestrator {
       await hashTask(
         this.hasher,
         this.projectGraph,
-        this.taskGraphForHashing,
+        this.fullTaskGraph,
         task,
         taskSpecificEnv,
         this.taskDetails
@@ -677,7 +677,7 @@ export class TaskOrchestrator {
     await hashTasks(
       this.hasher,
       this.projectGraph,
-      this.taskGraphForHashing,
+      this.fullTaskGraph,
       perTaskEnvs,
       this.taskDetails,
       tasks
@@ -806,7 +806,7 @@ export class TaskOrchestrator {
         await this.forkedProcessTaskRunner.forkProcessForBatch(
           batch,
           this.projectGraph,
-          this.taskGraph,
+          this.fullTaskGraph,
           env
         );
 


### PR DESCRIPTION
## Current Behavior

Under Distributed Task Execution (DTE), the Nx Cloud agent runs each task via the
programmatic `runDiscreteTasks` API. That path builds the task orchestrator's
schedule graph from the single task assigned to the agent, with its dependency
edges stripped — intentionally, so the scheduler runs only that task without
blocking on dependencies that ran (and were cached) on other agents.

`TaskOrchestrator.runBatch` then forwarded that edge-less schedule graph to batch
executors as `context.taskGraph`. With the edges missing, `@nx/gradle`'s batch
executor could not see that, for example, `:proj:gradle:shadowJar` `dependsOn`
`:proj:gradle:compileKotlin`. It therefore never passed `--exclude-task` for the
dependency, and Gradle re-ran `compileKotlin` itself instead of reusing the
restored cache outputs — which could fail the build.

This only affected the distributed path. A normal `nx run-many` / `nx affected`
already passes a fully-connected task graph, so the exclusion worked there.

## Expected Behavior

`runBatch` now forwards the **full** task graph to batch executors as
`context.taskGraph`, so dependency edges are visible to executors. `@nx/gradle`
can compute `--exclude-task` for transitive Gradle tasks that already ran on
other agents, so they are no longer re-run under DTE.

The orchestrator field previously named `taskGraphForHashing` is renamed to
`fullTaskGraph`, since hashing was only one of its consumers — it is now also the
executor context graph. For non-distributed runs the schedule graph and the full
graph are the same object, so this is a no-op there. Other batch executors
(`maven`, `jest`, `workspace`) don't read `context.taskGraph`; `@nx/js:tsc` reads
it for project references and now receives, under DTE, the same connected graph it
already receives in a normal run.

A regression test asserts that `runBatch` forwards the full (edged) graph rather
than the edge-less schedule graph.

## Related Issue(s)

N/A — surfaced while debugging a Gradle `shadowJar` failure under DTE.
