### PR TITLE
fix(misc): multi-version support compliance for rollup, webpack, and module-federation

### DIFF
--- a/astro-docs/src/content/docs/technologies/build-tools/rollup/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/rollup/introduction.mdoc
@@ -15,7 +15,7 @@ The `@nx/rollup` plugin supports the following package versions.
 
 | Package  | Supported Versions |
 | -------- | ------------------ |
-| `rollup` | ^4.14.0            |
+| `rollup` | ^3.0.0 \|\| ^4.0.0 |
 
 [Nx generators](/docs/features/generate-code) install the latest supported versions automatically when scaffolding new projects.
 

--- a/astro-docs/src/content/docs/technologies/build-tools/webpack/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/webpack/introduction.mdoc
@@ -17,9 +17,11 @@ You can [customize your webpack configuration](/docs/technologies/build-tools/we
 
 The `@nx/webpack` plugin supports the following package versions.
 
-| Package   | Supported Versions |
-| --------- | ------------------ |
-| `webpack` | >=5.0.0            |
+| Package              | Supported Versions             |
+| -------------------- | ------------------------------ |
+| `webpack`            | ^5.0.0                         |
+| `webpack-dev-server` | ^5.0.0                         |
+| `webpack-cli`        | ^5.0.0 \|\| ^6.0.0 \|\| ^7.0.0 |
 
 [Nx generators](/docs/features/generate-code) install the latest supported versions automatically when scaffolding new projects.
 

--- a/astro-docs/src/content/docs/technologies/module-federation/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/module-federation/introduction.mdoc
@@ -13,10 +13,12 @@ The `NxModuleFederationPlugin` is a [Rspack](https://rspack.dev) plugin that han
 
 The `@nx/module-federation` plugin supports the following package versions.
 
-| Package        | Supported Versions |
-| -------------- | ------------------ |
-| `webpack`      | ^5.0.0             |
-| `@rspack/core` | ^1.6.0             |
+| Package                       | Supported Versions |
+| ----------------------------- | ------------------ |
+| `webpack`                     | ^5.0.0             |
+| `@rspack/core`                | ^1.6.0             |
+| `@module-federation/enhanced` | ^2.0.0             |
+| `@module-federation/node`     | ^2.0.0             |
 
 [Nx generators](/docs/features/generate-code) install the latest supported versions automatically when scaffolding new projects.
 

--- a/e2e/nx/src/__snapshots__/misc.test.ts.snap
+++ b/e2e/nx/src/__snapshots__/misc.test.ts.snap
@@ -84,10 +84,10 @@ Outputs:
   - {workspaceRoot}/dist/apps/<APP>
 Options:
   cwd: "apps/<APP>"
-  args:
-    [
-      "--node-env=production"
-    ]
+  env:
+    {
+      "NODE_ENV": "production"
+    }
 Configurations: production
 
 "

--- a/e2e/web/src/web.test.ts
+++ b/e2e/web/src/web.test.ts
@@ -333,7 +333,7 @@ describe('CLI - Environment Variables', () => {
       'optimization',
       false
     );
-    runCLI(`run-many --target build --node-env=test`);
+    runCLI(`run-many --target build --config-node-env=test`);
     expect(readFile(`dist/apps/${appName}/main.js`)).toContain(
       'const envVars = ["test", "ws-base", "ws-env-local", "ws-local-env", "app-base", "app-env-local", "app-local-env", "shared-in-app-env-local"];'
     );

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "smol-toml": "1.6.1",
     "@module-federation/runtime": "2.3.3",
     "@module-federation/enhanced": "catalog:",
+    "@module-federation/node": "^2.7.21",
     "@module-federation/sdk": "^2.1.0",
     "@monodon/rust": "3.0.0",
     "@napi-rs/cli": "3.5.1",

--- a/packages/module-federation/migrations.json
+++ b/packages/module-federation/migrations.json
@@ -2,6 +2,9 @@
   "packageJsonUpdates": {
     "20.4.0": {
       "version": "20.4.0-beta.0",
+      "requires": {
+        "@module-federation/enhanced": "<0.8.0"
+      },
       "packages": {
         "@module-federation/enhanced": {
           "version": "^0.8.8",
@@ -23,6 +26,9 @@
     },
     "20.5.0": {
       "version": "20.5.0-beta.5",
+      "requires": {
+        "@module-federation/enhanced": ">=0.8.0 <0.9.0"
+      },
       "packages": {
         "@module-federation/enhanced": {
           "version": "^0.9.0",
@@ -44,6 +50,9 @@
     },
     "21.2.0": {
       "version": "21.2.0-beta.6",
+      "requires": {
+        "@module-federation/enhanced": ">=0.9.0 <0.15.0"
+      },
       "packages": {
         "@module-federation/enhanced": {
           "version": "^0.15.0",
@@ -61,6 +70,9 @@
     },
     "21.3.0": {
       "version": "21.3.0-beta.8",
+      "requires": {
+        "@module-federation/enhanced": ">=0.15.0 <0.17.0"
+      },
       "packages": {
         "@module-federation/enhanced": {
           "version": "^0.17.0",
@@ -78,11 +90,10 @@
     },
     "21.4.0": {
       "version": "21.4.0-beta.8",
+      "requires": {
+        "@module-federation/enhanced": ">=0.17.0 <0.18.0"
+      },
       "packages": {
-        "http-proxy-middleware": {
-          "version": "^3.0.5",
-          "alwaysAddToPackageJson": false
-        },
         "@module-federation/sdk": {
           "version": "^0.18.0",
           "alwaysAddToPackageJson": false
@@ -101,8 +112,23 @@
         }
       }
     },
+    "21.4.0-http-proxy-middleware": {
+      "version": "21.4.0-beta.8",
+      "requires": {
+        "http-proxy-middleware": ">=2.0.0 <3.0.0"
+      },
+      "packages": {
+        "http-proxy-middleware": {
+          "version": "^3.0.5",
+          "alwaysAddToPackageJson": false
+        }
+      }
+    },
     "22.2.0": {
       "version": "22.2.0-beta.0",
+      "requires": {
+        "@module-federation/enhanced": ">=0.18.0 <0.21.0"
+      },
       "packages": {
         "@module-federation/enhanced": {
           "version": "^0.21.2",
@@ -125,6 +151,9 @@
     "22.6.0": {
       "version": "22.6.0-beta.10",
       "x-prompt": "Bump @module-federation packages to v2.x to resolve koa CVE-2026-27959 (via dts-plugin)",
+      "requires": {
+        "@module-federation/enhanced": ">=0.21.0 <2.0.0"
+      },
       "packages": {
         "@module-federation/enhanced": {
           "version": "^2.1.0",

--- a/packages/module-federation/package.json
+++ b/packages/module-federation/package.json
@@ -97,9 +97,6 @@
   },
   "executors": "./executors.json",
   "dependencies": {
-    "@module-federation/enhanced": "catalog:",
-    "@module-federation/node": "^2.7.21",
-    "@module-federation/sdk": "^2.1.0",
     "@nx/devkit": "workspace:*",
     "@nx/js": "workspace:*",
     "@nx/web": "workspace:*",
@@ -109,6 +106,18 @@
     "picocolors": "catalog:",
     "tslib": "catalog:typescript",
     "webpack": "catalog:"
+  },
+  "peerDependencies": {
+    "@module-federation/enhanced": "^2.0.0",
+    "@module-federation/node": "^2.0.0"
+  },
+  "peerDependenciesMeta": {
+    "@module-federation/enhanced": {
+      "optional": true
+    },
+    "@module-federation/node": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "nx": "workspace:*"

--- a/packages/module-federation/src/utils/models/index.ts
+++ b/packages/module-federation/src/utils/models/index.ts
@@ -1,4 +1,4 @@
-import type { moduleFederationPlugin } from '@module-federation/sdk';
+import type { moduleFederationPlugin } from '@module-federation/enhanced';
 import { NormalModuleReplacementPlugin as RspackNormalModuleReplacementPlugin } from '@rspack/core';
 
 export type ModuleFederationLibrary = { type: string; name: string };

--- a/packages/nest/src/generators/application/application.spec.ts
+++ b/packages/nest/src/generators/application/application.spec.ts
@@ -40,18 +40,18 @@ describe('application generator', () => {
           "build": {
             "configurations": {
               "development": {
-                "args": [
-                  "--node-env=development",
-                ],
+                "env": {
+                  "NODE_ENV": "development",
+                },
               },
             },
             "executor": "nx:run-commands",
             "options": {
-              "args": [
-                "--node-env=production",
-              ],
               "command": "webpack-cli build",
               "cwd": "my-node-app",
+              "env": {
+                "NODE_ENV": "production",
+              },
             },
           },
           "copy-workspace-modules": {
@@ -288,18 +288,18 @@ describe('application generator', () => {
               "build": {
                 "configurations": {
                   "development": {
-                    "args": [
-                      "--node-env=development",
-                    ],
+                    "env": {
+                      "NODE_ENV": "development",
+                    },
                   },
                 },
                 "executor": "nx:run-commands",
                 "options": {
-                  "args": [
-                    "--node-env=production",
-                  ],
                   "command": "webpack-cli build",
                   "cwd": "myapp",
+                  "env": {
+                    "NODE_ENV": "production",
+                  },
                 },
               },
               "copy-workspace-modules": {
@@ -493,18 +493,18 @@ describe('application generator', () => {
             "build": {
               "configurations": {
                 "development": {
-                  "args": [
-                    "--node-env=development",
-                  ],
+                  "env": {
+                    "NODE_ENV": "development",
+                  },
                 },
               },
               "executor": "nx:run-commands",
               "options": {
-                "args": [
-                  "--node-env=production",
-                ],
                 "command": "webpack-cli build",
                 "cwd": "myapp",
+                "env": {
+                  "NODE_ENV": "production",
+                },
               },
             },
             "copy-workspace-modules": {

--- a/packages/node/src/generators/application/application.spec.ts
+++ b/packages/node/src/generators/application/application.spec.ts
@@ -1152,11 +1152,11 @@ describe('app', () => {
 
       expect(buildTarget.executor).toBe('nx:run-commands');
       expect(buildTarget.options.command).toBe('webpack-cli build');
-      expect(buildTarget.options.args).toEqual(['--node-env=production']);
+      expect(buildTarget.options.env).toEqual({ NODE_ENV: 'production' });
       expect(buildTarget.options.cwd).toEqual(project.root);
-      expect(buildTarget.configurations.development.args).toEqual([
-        '--node-env=development',
-      ]);
+      expect(buildTarget.configurations.development.env).toEqual({
+        NODE_ENV: 'development',
+      });
     });
   });
 });

--- a/packages/node/src/generators/application/lib/create-project.ts
+++ b/packages/node/src/generators/application/lib/create-project.ts
@@ -44,7 +44,7 @@ export function addProject(
       project.targets.build = getWebpackBuildConfig(tree, project, options);
     } else if (options.isNest) {
       // If we are using Nest that has the webpack plugin we need to override the
-      // build target so that node-env can be set to production or development so the serve target can be run in development mode
+      // build target so that NODE_ENV can be set to production or development so the serve target can be run in development mode
       project.targets.build = getNestWebpackBuildConfig(project);
     }
   }

--- a/packages/node/src/generators/application/lib/create-targets.ts
+++ b/packages/node/src/generators/application/lib/create-targets.ts
@@ -121,12 +121,12 @@ export function getNestWebpackBuildConfig(
     executor: 'nx:run-commands',
     options: {
       command: 'webpack-cli build',
-      args: ['--node-env=production'],
+      env: { NODE_ENV: 'production' },
       cwd: project.root,
     },
     configurations: {
       development: {
-        args: ['--node-env=development'],
+        env: { NODE_ENV: 'development' },
       },
     },
   };

--- a/packages/rollup/migrations.json
+++ b/packages/rollup/migrations.json
@@ -8,5 +8,15 @@
       "documentation": "./src/migrations/update-23-0-0/remove-use-legacy-typescript-plugin.md"
     }
   },
-  "packageJsonUpdates": {}
+  "packageJsonUpdates": {
+    "23.0.0": {
+      "version": "23.0.0-beta.24",
+      "packages": {
+        "rollup": {
+          "version": "^4.14.0",
+          "alwaysAddToPackageJson": true
+        }
+      }
+    }
+  }
 }

--- a/packages/rollup/package.json
+++ b/packages/rollup/package.json
@@ -45,8 +45,15 @@
     "picomatch": "catalog:",
     "postcss": "catalog:css",
     "postcss-modules": "^6.0.1",
-    "rollup": "^4.14.0",
     "tslib": "catalog:typescript"
+  },
+  "peerDependencies": {
+    "rollup": "^3.0.0 || ^4.0.0"
+  },
+  "peerDependenciesMeta": {
+    "rollup": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "nx": "workspace:*",

--- a/packages/rollup/src/executors/rollup/rollup.impl.ts
+++ b/packages/rollup/src/executors/rollup/rollup.impl.ts
@@ -1,4 +1,4 @@
-import * as rollup from 'rollup';
+import type * as Rollup from 'rollup';
 import { parse, resolve } from 'path';
 import { type ExecutorContext, logger } from '@nx/devkit';
 import { loadConfigFile, createAsyncIterable } from '@nx/devkit/internal';
@@ -18,6 +18,9 @@ export async function* rollupExecutor(
   context: ExecutorContext
 ) {
   warnRollupExecutorDeprecation();
+
+  // Lazy-loaded: `rollup` is an optional peer, absent at project-graph discovery time.
+  const rollup = require('rollup') as typeof import('rollup');
 
   process.env.NODE_ENV ??= 'production';
   const options = normalizeRollupExecutorOptions(rawOptions, context);
@@ -90,7 +93,7 @@ export async function* rollupExecutor(
 export async function createRollupOptions(
   options: NormalizedRollupExecutorOptions,
   context: ExecutorContext
-): Promise<rollup.RollupOptions | rollup.RollupOptions[]> {
+): Promise<Rollup.RollupOptions | Rollup.RollupOptions[]> {
   const { dependencies } = calculateProjectBuildableDependencies(
     context.taskGraph,
     context.projectGraph,
@@ -114,7 +117,7 @@ export async function createRollupOptions(
   const userDefinedRollupConfigs = options.rollupConfig.map((plugin) =>
     loadConfigFile(plugin)
   );
-  let finalConfig: rollup.RollupOptions = rollupConfig;
+  let finalConfig: Rollup.RollupOptions = rollupConfig;
   for (const _config of userDefinedRollupConfigs) {
     const config = await _config;
     if (typeof config === 'function') {

--- a/packages/rollup/src/generators/configuration/configuration.ts
+++ b/packages/rollup/src/generators/configuration/configuration.ts
@@ -32,6 +32,7 @@ import { RollupWithNxPluginOptions } from '../../plugins/with-nx/with-nx-options
 import { ensureDependencies } from '../../utils/ensure-dependencies';
 import { hasPlugin } from '../../utils/has-plugin';
 import { warnRollupExecutorGenerating } from '../../utils/deprecation';
+import { assertSupportedRollupVersion } from '../../utils/versions';
 import { rollupInitGenerator } from '../init/init';
 import { RollupProjectSchema } from './schema';
 
@@ -41,6 +42,8 @@ export async function configurationGenerator(
   tree: Tree,
   options: RollupProjectSchema
 ) {
+  assertSupportedRollupVersion(tree);
+
   const tasks: GeneratorCallback[] = [];
   const nxJson = readNxJson(tree);
   const addPluginDefault =

--- a/packages/rollup/src/generators/convert-to-inferred/convert-to-inferred.ts
+++ b/packages/rollup/src/generators/convert-to-inferred/convert-to-inferred.ts
@@ -14,6 +14,7 @@ import type { RollupExecutorOptions } from '../../executors/rollup/schema';
 import type { RollupPluginOptions } from '../../plugins/plugin';
 import { extractRollupConfigFromExecutorOptions } from './lib/extract-rollup-config-from-executor-options';
 import { addPluginRegistrations } from './lib/add-plugin-registrations';
+import { assertSupportedRollupVersion } from '../../utils/versions';
 
 interface Schema {
   project?: string;
@@ -21,6 +22,8 @@ interface Schema {
 }
 
 export async function convertToInferred(tree: Tree, options: Schema) {
+  assertSupportedRollupVersion(tree);
+
   const migratedProjects = new Map<string, RollupPluginOptions>();
   let projects = getProjects(tree);
 

--- a/packages/rollup/src/generators/init/init.ts
+++ b/packages/rollup/src/generators/init/init.ts
@@ -7,11 +7,17 @@ import {
   readNxJson,
   Tree,
 } from '@nx/devkit';
-import { nxVersion, rollupVersion } from '../../utils/versions';
+import {
+  nxVersion,
+  rollupVersion,
+  assertSupportedRollupVersion,
+} from '../../utils/versions';
 import { Schema } from './schema';
 import { createNodesV2 } from '../../plugins/plugin';
 
 export async function rollupInitGenerator(tree: Tree, schema: Schema) {
+  assertSupportedRollupVersion(tree);
+
   let task: GeneratorCallback = () => {};
   const nxJson = readNxJson(tree);
   schema.addPlugin ??=
@@ -19,17 +25,18 @@ export async function rollupInitGenerator(tree: Tree, schema: Schema) {
     nxJson.useInferencePlugins !== false;
 
   if (!schema.skipPackageJson) {
-    const devDependencies = { '@nx/rollup': nxVersion };
-    if (schema.addPlugin) {
-      // Ensure user can run Rollup CLI.
-      devDependencies['rollup'] = rollupVersion;
-    }
+    // Rollup is a peer dependency, so ensure it is installed for both the
+    // inferred-plugin (CLI) path and the executor (programmatic) path.
+    const devDependencies = {
+      '@nx/rollup': nxVersion,
+      rollup: rollupVersion,
+    };
     task = addDependenciesToPackageJson(
       tree,
       {},
       devDependencies,
       undefined,
-      schema.keepExistingVersions
+      schema.keepExistingVersions ?? true
     );
   }
 

--- a/packages/rollup/src/generators/init/schema.json
+++ b/packages/rollup/src/generators/init/schema.json
@@ -20,7 +20,7 @@
       "type": "boolean",
       "x-priority": "internal",
       "description": "Keep existing dependencies versions",
-      "default": false
+      "default": true
     },
     "updatePackageScripts": {
       "type": "boolean",

--- a/packages/rollup/src/utils/ensure-dependencies.ts
+++ b/packages/rollup/src/utils/ensure-dependencies.ts
@@ -23,7 +23,9 @@ export function ensureDependencies(
           '@swc/helpers': swcHelpersVersion,
           '@swc/core': swcCoreVersion,
           'swc-loader': swcLoaderVersion,
-        }
+        },
+        undefined,
+        true
       );
     case 'babel':
       return addDependenciesToPackageJson(
@@ -32,9 +34,17 @@ export function ensureDependencies(
         {
           'core-js': coreJsVersion, // needed for preset-env to work
           tslib: tsLibVersion,
-        }
+        },
+        undefined,
+        true
       );
     default:
-      return addDependenciesToPackageJson(tree, {}, { tslib: tsLibVersion });
+      return addDependenciesToPackageJson(
+        tree,
+        {},
+        { tslib: tsLibVersion },
+        undefined,
+        true
+      );
   }
 }

--- a/packages/rollup/src/utils/versions.ts
+++ b/packages/rollup/src/utils/versions.ts
@@ -1,5 +1,16 @@
+import { type Tree } from '@nx/devkit';
+import { assertSupportedPackageVersion } from '@nx/devkit/internal';
+
 export const nxVersion = require('../../package.json').version;
 export const coreJsVersion = '^3.36.1';
+// Floor for the generator-level support check. The plugin's runtime code only
+// uses Rollup APIs available since v3, so v3 and v4 are both supported.
+export const minSupportedRollupVersion = '3.0.0';
+// Fresh-install version written when Rollup is not already present.
 export const rollupVersion = '^4.14.0';
 export const swcLoaderVersion = '0.1.15';
 export const tsLibVersion = '^2.3.0';
+
+export function assertSupportedRollupVersion(tree: Tree): void {
+  assertSupportedPackageVersion(tree, 'rollup', minSupportedRollupVersion);
+}

--- a/packages/webpack/eslint.config.mjs
+++ b/packages/webpack/eslint.config.mjs
@@ -36,6 +36,10 @@ export default [
             'nx',
             'typescript',
             'eslint',
+            // Declared as an optional peer because the inferred plugin emits
+            // targets that run the `webpack-cli` binary; it is never imported,
+            // so the dependency check can't detect the usage statically.
+            'webpack-cli',
             '@babel/core',
             'css-loader',
             'less',

--- a/packages/webpack/migrations.json
+++ b/packages/webpack/migrations.json
@@ -24,6 +24,9 @@
   "packageJsonUpdates": {
     "20.5.0": {
       "version": "20.5.0-beta.3",
+      "requires": {
+        "sass-loader": "^12.0.0"
+      },
       "packages": {
         "sass-loader": {
           "version": "^16.0.4",
@@ -50,6 +53,23 @@
         "webpack": {
           "version": "5.101.3",
           "alwaysAddToPackageJson": false
+        }
+      }
+    },
+    "23.0.0": {
+      "version": "23.0.0-beta.24",
+      "packages": {
+        "webpack": {
+          "version": "^5.101.3",
+          "alwaysAddToPackageJson": true
+        },
+        "webpack-dev-server": {
+          "version": "^5.2.1",
+          "alwaysAddToPackageJson": true
+        },
+        "webpack-cli": {
+          "version": "^7.0.0",
+          "alwaysAddToPackageJson": true
         }
       }
     }

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -61,12 +61,26 @@
     "ts-loader": "^9.3.1",
     "tsconfig-paths-webpack-plugin": "4.2.0",
     "tslib": "catalog:typescript",
-    "webpack": "catalog:",
-    "webpack-dev-server": "catalog:",
     "webpack-node-externals": "^3.0.0",
     "webpack-subresource-integrity": "^5.1.0",
     "@nx/devkit": "workspace:*",
     "@nx/js": "workspace:*"
+  },
+  "peerDependencies": {
+    "webpack": "^5.0.0",
+    "webpack-cli": "^5.0.0 || ^6.0.0 || ^7.0.0",
+    "webpack-dev-server": "^5.0.0"
+  },
+  "peerDependenciesMeta": {
+    "webpack": {
+      "optional": true
+    },
+    "webpack-cli": {
+      "optional": true
+    },
+    "webpack-dev-server": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "nx": "workspace:*"

--- a/packages/webpack/src/executors/dev-server/dev-server.impl.ts
+++ b/packages/webpack/src/executors/dev-server/dev-server.impl.ts
@@ -1,5 +1,4 @@
 import { eachValueFrom } from '@nx/devkit/internal';
-import webpack from 'webpack';
 import {
   ExecutorContext,
   parseTargetString,
@@ -7,7 +6,6 @@ import {
 } from '@nx/devkit';
 
 import { map, tap } from 'rxjs/operators';
-import WebpackDevServer from 'webpack-dev-server';
 
 import { getDevServerOptions } from './lib/get-dev-server-config';
 import {
@@ -113,6 +111,11 @@ export async function* devServerExecutor(
       config.devServer ??= devServer;
     }
   }
+
+  // Lazy-loaded: optional peers absent during project-graph discovery.
+  const webpack = require('webpack') as typeof import('webpack');
+  const WebpackDevServer =
+    require('webpack-dev-server') as typeof import('webpack-dev-server');
 
   return yield* eachValueFrom(
     runWebpackDevServer(config, webpack, WebpackDevServer).pipe(

--- a/packages/webpack/src/executors/webpack/lib/run-webpack.ts
+++ b/packages/webpack/src/executors/webpack/lib/run-webpack.ts
@@ -1,15 +1,17 @@
-import webpack from 'webpack';
+import type webpack from 'webpack';
 import { Observable } from 'rxjs';
 
 // TODO(jack): move to dev-server executor
 export function runWebpack(
   config: webpack.Configuration
 ): Observable<webpack.Stats> {
+  // Lazy-loaded: `webpack` is an optional peer, absent during project-graph discovery.
+  const webpackImpl = require('webpack') as typeof import('webpack');
   return new Observable((subscriber) => {
     // Passing `watch` option here will result in a warning due to missing callback.
     // We manually call `.watch` or `.run` later so this option isn't needed here.
     const { watch, ...normalizedConfig } = config;
-    const webpackCompiler = webpack(normalizedConfig);
+    const webpackCompiler = webpackImpl(normalizedConfig);
 
     const callback = (err: Error, stats: webpack.Stats) => {
       if (err) {

--- a/packages/webpack/src/generators/configuration/configuration.ts
+++ b/packages/webpack/src/generators/configuration/configuration.ts
@@ -19,6 +19,7 @@ import { hasPlugin } from '../../utils/has-plugin';
 import { warnWebpackExecutorGenerating } from '../../utils/deprecation';
 import { TS_SOLUTION_SETUP_TSCONFIG_INPUT } from '@nx/js/internal';
 import { ensureDependencies } from '../../utils/ensure-dependencies';
+import { assertSupportedWebpackVersion } from '../../utils/versions';
 
 export function configurationGenerator(
   tree: Tree,
@@ -31,6 +32,8 @@ export async function configurationGeneratorInternal(
   tree: Tree,
   options: ConfigurationGeneratorSchema
 ) {
+  assertSupportedWebpackVersion(tree);
+
   const tasks: GeneratorCallback[] = [];
   const nxJson = readNxJson(tree);
   const addPluginDefault =

--- a/packages/webpack/src/generators/convert-config-to-webpack-plugin/convert-config-to-webpack-plugin.ts
+++ b/packages/webpack/src/generators/convert-config-to-webpack-plugin/convert-config-to-webpack-plugin.ts
@@ -13,6 +13,7 @@ import { extractWebpackOptions } from './lib/extract-webpack-options';
 import { normalizePathOptions } from './lib/normalize-path-options';
 import { parse } from 'path';
 import { validateProject } from './lib/validate-project';
+import { assertSupportedWebpackVersion } from '../../utils/versions';
 
 interface Schema {
   project?: string;
@@ -32,6 +33,8 @@ export async function convertConfigToWebpackPluginGenerator(
   tree: Tree,
   options: Schema
 ) {
+  assertSupportedWebpackVersion(tree);
+
   let migrated = 0;
 
   const projects = getProjects(tree);

--- a/packages/webpack/src/generators/convert-to-inferred/convert-to-inferred.ts
+++ b/packages/webpack/src/generators/convert-to-inferred/convert-to-inferred.ts
@@ -14,7 +14,10 @@ import {
 import { ast, query } from '@phenomnomnominal/tsquery';
 import * as ts from 'typescript';
 import { createNodesV2, type WebpackPluginOptions } from '../../plugins/plugin';
-import { webpackCliVersion } from '../../utils/versions';
+import {
+  webpackCliVersion,
+  assertSupportedWebpackVersion,
+} from '../../utils/versions';
 import {
   buildPostTargetTransformerFactory,
   servePostTargetTransformerFactory,
@@ -28,6 +31,8 @@ interface Schema {
 }
 
 export async function convertToInferred(tree: Tree, options: Schema) {
+  assertSupportedWebpackVersion(tree);
+
   const projectGraph = await createProjectGraphAsync();
   const migrationContext: MigrationContext = {
     logger: new AggregatedLog(),

--- a/packages/webpack/src/generators/init/init.legacy.spec.ts
+++ b/packages/webpack/src/generators/init/init.legacy.spec.ts
@@ -10,7 +10,7 @@ describe('webpackInitGenerator (legacy)', () => {
     tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
   });
 
-  it('should not install webpack dependencies', async () => {
+  it('should install webpack and webpack-dev-server (they are peer dependencies)', async () => {
     await webpackInitGenerator(tree, {
       addPlugin: false,
     });
@@ -22,6 +22,8 @@ describe('webpackInitGenerator (legacy)', () => {
       devDependencies: {
         '@nx/web': expect.any(String),
         '@nx/webpack': expect.any(String),
+        webpack: expect.any(String),
+        'webpack-dev-server': expect.any(String),
       },
     });
   });

--- a/packages/webpack/src/generators/init/init.spec.ts
+++ b/packages/webpack/src/generators/init/init.spec.ts
@@ -1,6 +1,6 @@
 import 'nx/src/internal-testing-utils/mock-project-graph';
 
-import { readJson, Tree } from '@nx/devkit';
+import { readJson, Tree, updateJson } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 
 import { webpackInitGenerator } from './init';
@@ -12,7 +12,7 @@ describe('webpackInitGenerator', () => {
     tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
   });
 
-  it('should install plugin and webpack-cli', async () => {
+  it('should install plugin, webpack, webpack-dev-server, and webpack-cli', async () => {
     await webpackInitGenerator(tree, {
       addPlugin: true,
     });
@@ -24,8 +24,27 @@ describe('webpackInitGenerator', () => {
       devDependencies: {
         '@nx/webpack': expect.any(String),
         '@nx/web': expect.any(String),
+        webpack: expect.any(String),
+        'webpack-dev-server': expect.any(String),
         'webpack-cli': expect.any(String),
       },
     });
+  });
+
+  it('should not overwrite an already-installed webpack version', async () => {
+    updateJson(tree, 'package.json', (json) => {
+      json.devDependencies = {
+        ...(json.devDependencies ?? {}),
+        webpack: '5.50.0',
+      };
+      return json;
+    });
+
+    await webpackInitGenerator(tree, {
+      addPlugin: true,
+    });
+
+    const packageJson = readJson(tree, 'package.json');
+    expect(packageJson.devDependencies['webpack']).toBe('5.50.0');
   });
 });

--- a/packages/webpack/src/generators/init/init.ts
+++ b/packages/webpack/src/generators/init/init.ts
@@ -8,7 +8,13 @@ import {
   Tree,
 } from '@nx/devkit';
 import { createNodesV2 } from '../../plugins/plugin';
-import { nxVersion, webpackCliVersion } from '../../utils/versions';
+import {
+  nxVersion,
+  webpackCliVersion,
+  webpackDevServerVersion,
+  webpackVersion,
+  assertSupportedWebpackVersion,
+} from '../../utils/versions';
 import { Schema } from './schema';
 
 export function webpackInitGenerator(tree: Tree, schema: Schema) {
@@ -16,6 +22,8 @@ export function webpackInitGenerator(tree: Tree, schema: Schema) {
 }
 
 export async function webpackInitGeneratorInternal(tree: Tree, schema: Schema) {
+  assertSupportedWebpackVersion(tree);
+
   const nxJson = readNxJson(tree);
   const addPluginDefault =
     process.env.NX_ADD_PLUGINS !== 'false' &&
@@ -74,12 +82,18 @@ export async function webpackInitGeneratorInternal(tree: Tree, schema: Schema) {
 
   let installTask: GeneratorCallback = () => {};
   if (!schema.skipPackageJson) {
+    // webpack and webpack-dev-server are peer dependencies, so ensure they are
+    // installed (both the executor and inferred-plugin paths need them at the
+    // user's runtime).
     const devDependencies = {
       '@nx/webpack': nxVersion,
       '@nx/web': nxVersion,
+      webpack: webpackVersion,
+      'webpack-dev-server': webpackDevServerVersion,
     };
 
     if (schema.addPlugin) {
+      // The inferred plugin runs the `webpack-cli` binary.
       devDependencies['webpack-cli'] = webpackCliVersion;
     }
 
@@ -88,7 +102,7 @@ export async function webpackInitGeneratorInternal(tree: Tree, schema: Schema) {
       {},
       devDependencies,
       undefined,
-      schema.keepExistingVersions
+      schema.keepExistingVersions ?? true
     );
   }
 

--- a/packages/webpack/src/generators/init/schema.json
+++ b/packages/webpack/src/generators/init/schema.json
@@ -20,7 +20,7 @@
       "type": "boolean",
       "x-priority": "internal",
       "description": "Keep existing dependencies versions",
-      "default": false
+      "default": true
     },
     "updatePackageScripts": {
       "type": "boolean",

--- a/packages/webpack/src/plugins/plugin.spec.ts
+++ b/packages/webpack/src/plugins/plugin.spec.ts
@@ -130,10 +130,10 @@ describe('@nx/webpack/plugin', () => {
                       ],
                     },
                     "options": {
-                      "args": [
-                        "--node-env=production",
-                      ],
                       "cwd": "my-app",
+                      "env": {
+                        "NODE_ENV": "production",
+                      },
                     },
                     "outputs": [
                       "{projectRoot}/dist/foo",
@@ -160,10 +160,10 @@ describe('@nx/webpack/plugin', () => {
                       ],
                     },
                     "options": {
-                      "args": [
-                        "--node-env=development",
-                      ],
                       "cwd": "my-app",
+                      "env": {
+                        "NODE_ENV": "development",
+                      },
                     },
                   },
                   "preview-site": {
@@ -187,10 +187,10 @@ describe('@nx/webpack/plugin', () => {
                       ],
                     },
                     "options": {
-                      "args": [
-                        "--node-env=production",
-                      ],
                       "cwd": "my-app",
+                      "env": {
+                        "NODE_ENV": "production",
+                      },
                     },
                   },
                   "serve-static": {

--- a/packages/webpack/src/plugins/plugin.ts
+++ b/packages/webpack/src/plugins/plugin.ts
@@ -185,7 +185,7 @@ async function createWebpackTargets(
 
   targets[options.buildTargetName] = {
     command: `webpack-cli build`,
-    options: { cwd: projectRoot, args: ['--node-env=production'] },
+    options: { cwd: projectRoot, env: { NODE_ENV: 'production' } },
     cache: true,
     dependsOn: [`^${options.buildTargetName}`],
     inputs:
@@ -227,7 +227,7 @@ async function createWebpackTargets(
     command: `webpack-cli serve`,
     options: {
       cwd: projectRoot,
-      args: ['--node-env=development'],
+      env: { NODE_ENV: 'development' },
     },
     metadata: {
       technologies: ['webpack'],
@@ -248,7 +248,7 @@ async function createWebpackTargets(
     command: `webpack-cli serve`,
     options: {
       cwd: projectRoot,
-      args: ['--node-env=production'],
+      env: { NODE_ENV: 'production' },
     },
     metadata: {
       technologies: ['webpack'],

--- a/packages/webpack/src/utils/ensure-dependencies.ts
+++ b/packages/webpack/src/utils/ensure-dependencies.ts
@@ -42,7 +42,9 @@ export function ensureDependencies(
     devDependencies['react-refresh'] = reactRefreshVersion;
   }
 
-  tasks.push(addDependenciesToPackageJson(tree, {}, devDependencies));
+  tasks.push(
+    addDependenciesToPackageJson(tree, {}, devDependencies, undefined, true)
+  );
 
   return runTasksInSerial(...tasks);
 }

--- a/packages/webpack/src/utils/run-webpack.ts
+++ b/packages/webpack/src/utils/run-webpack.ts
@@ -1,4 +1,3 @@
-import * as webpack from 'webpack';
 import type { Configuration as WebpackDevServerConfiguration } from 'webpack-dev-server';
 import { Observable } from 'rxjs';
 

--- a/packages/webpack/src/utils/versions.ts
+++ b/packages/webpack/src/utils/versions.ts
@@ -1,11 +1,26 @@
+import { type Tree } from '@nx/devkit';
+import { assertSupportedPackageVersion } from '@nx/devkit/internal';
+
 export const nxVersion = require('../../package.json').version;
 
 export const swcLoaderVersion = '0.1.15';
 export const tsLibVersion = '^2.3.0';
 
-export const webpackCliVersion = '^5.1.4';
+// Floor for the generator-level support check. The plugin's runtime code uses
+// webpack 5-only APIs (e.g. `ids.HashedModuleIdsPlugin`, `webpack.sources`,
+// `experiments.cacheUnaffected`), so webpack 5 is the supported floor.
+export const minSupportedWebpackVersion = '5.0.0';
+
+// Fresh-install versions written when the package is not already present.
+export const webpackVersion = '^5.101.3';
+export const webpackDevServerVersion = '^5.2.1';
+export const webpackCliVersion = '^7.0.0';
 
 // React apps
 export const reactRefreshWebpackPluginVersion = '^0.5.7';
 export const svgrWebpackVersion = '^8.0.1';
 export const reactRefreshVersion = '^0.10.0';
+
+export function assertSupportedWebpackVersion(tree: Tree): void {
+  assertSupportedPackageVersion(tree, 'webpack', minSupportedWebpackVersion);
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -594,6 +594,9 @@ importers:
       '@module-federation/enhanced':
         specifier: 'catalog:'
         version: 2.3.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(node-fetch@3.3.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2)(vue-tsc@2.2.12(typescript@5.9.2))(webpack@5.105.2)
+      '@module-federation/node':
+        specifier: ^2.7.21
+        version: 2.7.21(@rspack/core@1.6.8(@swc/helpers@0.5.18))(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.60.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2)(vue-tsc@2.2.12(typescript@5.9.2))(webpack@5.105.2)
       '@module-federation/runtime':
         specifier: 2.3.3
         version: 2.3.3(node-fetch@3.3.2)
@@ -1337,10 +1340,10 @@ importers:
         version: 4.1.2(@types/node@24.12.2)(jsdom@26.1.0)(vite@8.0.0(@types/node@24.12.2)(esbuild@0.25.0)(jiti@2.6.1)(less@4.5.1)(sass-embedded@1.97.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.20.5)(yaml@2.8.0))
       webpack:
         specifier: 'catalog:'
-        version: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
+        version: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
       webpack-dev-server:
         specifier: 'catalog:'
-        version: 5.2.3(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))(webpack@5.105.2)
+        version: 5.2.3(webpack-cli@5.1.4)(webpack@5.105.2)
       webpack-merge:
         specifier: ^5.8.0
         version: 5.10.0
@@ -3122,14 +3125,11 @@ importers:
   packages/module-federation:
     dependencies:
       '@module-federation/enhanced':
-        specifier: 'catalog:'
+        specifier: ^2.0.0
         version: 2.3.3(@rspack/core@1.6.8(@swc/helpers@0.5.18))(node-fetch@3.3.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2)(vue-tsc@2.2.12(typescript@5.9.2))(webpack@5.105.2)
       '@module-federation/node':
-        specifier: ^2.7.21
+        specifier: ^2.0.0
         version: 2.7.21(@rspack/core@1.6.8(@swc/helpers@0.5.18))(next@14.2.35(@babel/core@7.29.0)(@playwright/test@1.60.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(typescript@5.9.2)(vue-tsc@2.2.12(typescript@5.9.2))(webpack@5.105.2)
-      '@module-federation/sdk':
-        specifier: ^2.1.0
-        version: 2.1.0
       '@nx/devkit':
         specifier: workspace:*
         version: link:../devkit
@@ -3156,7 +3156,7 @@ importers:
         version: 2.8.1
       webpack:
         specifier: 'catalog:'
-        version: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
+        version: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
     devDependencies:
       nx:
         specifier: workspace:*
@@ -3716,22 +3716,22 @@ importers:
         version: 6.2.0(typescript@5.9.2)
       '@rollup/plugin-babel':
         specifier: ^6.0.4
-        version: 6.0.4(@babel/core@7.29.0)(@types/babel__core@7.20.5)(rollup@4.44.2)
+        version: 6.0.4(@babel/core@7.29.0)(@types/babel__core@7.20.5)(rollup@4.59.0)
       '@rollup/plugin-commonjs':
         specifier: ^25.0.7
-        version: 25.0.8(rollup@4.44.2)
+        version: 25.0.8(rollup@4.59.0)
       '@rollup/plugin-image':
         specifier: ^3.0.3
-        version: 3.0.3(rollup@4.44.2)
+        version: 3.0.3(rollup@4.59.0)
       '@rollup/plugin-json':
         specifier: ^6.1.0
-        version: 6.1.0(rollup@4.44.2)
+        version: 6.1.0(rollup@4.59.0)
       '@rollup/plugin-node-resolve':
         specifier: ^15.2.3
-        version: 15.3.1(rollup@4.44.2)
+        version: 15.3.1(rollup@4.59.0)
       '@rollup/plugin-typescript':
         specifier: ^12.1.0
-        version: 12.1.4(rollup@4.44.2)(tslib@2.8.1)(typescript@5.9.2)
+        version: 12.1.4(rollup@4.59.0)(tslib@2.8.1)(typescript@5.9.2)
       autoprefixer:
         specifier: catalog:css
         version: 10.4.27(postcss@8.5.8)
@@ -3751,8 +3751,8 @@ importers:
         specifier: ^6.0.1
         version: 6.0.1(postcss@8.5.8)
       rollup:
-        specifier: ^4.14.0
-        version: 4.44.2
+        specifier: ^3.0.0 || ^4.0.0
+        version: 4.59.0
       tslib:
         specifier: catalog:typescript
         version: 2.8.1
@@ -3889,7 +3889,7 @@ importers:
         version: 2.8.1
       webpack:
         specifier: 'catalog:'
-        version: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
+        version: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
       webpack-node-externals:
         specifier: ^3.0.0
         version: 3.0.0
@@ -4212,11 +4212,14 @@ importers:
         specifier: catalog:typescript
         version: 2.8.1
       webpack:
-        specifier: 'catalog:'
-        version: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
+        specifier: ^5.0.0
+        version: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
+      webpack-cli:
+        specifier: ^5.0.0 || ^6.0.0 || ^7.0.0
+        version: 5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2)
       webpack-dev-server:
-        specifier: 'catalog:'
-        version: 5.2.3(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))(webpack@5.105.2)
+        specifier: ^5.0.0
+        version: 5.2.3(webpack-cli@5.1.4)(webpack@5.105.2)
       webpack-node-externals:
         specifier: ^3.0.0
         version: 3.0.0
@@ -25097,7 +25100,7 @@ snapshots:
       typescript: 5.9.2
       webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.27.3)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
       webpack-dev-middleware: 7.4.5(webpack@5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2)))
-      webpack-dev-server: 5.2.3(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))(webpack@5.105.2)
+      webpack-dev-server: 5.2.3(webpack-cli@5.1.4)(webpack@5.105.2)
       webpack-merge: 6.0.1
       webpack-subresource-integrity: 5.1.0(html-webpack-plugin@5.5.0(webpack@5.105.2))(webpack@5.105.2)
     optionalDependencies:
@@ -25138,8 +25141,8 @@ snapshots:
     dependencies:
       '@angular-devkit/architect': 0.2102.0(chokidar@3.6.0)
       rxjs: 7.8.2
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
-      webpack-dev-server: 5.2.3(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))(webpack@5.105.2)
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
+      webpack-dev-server: 5.2.3(webpack-cli@5.1.4)(webpack@5.105.2)
     transitivePeerDependencies:
       - chokidar
 
@@ -25148,7 +25151,7 @@ snapshots:
       '@angular-devkit/architect': 0.2102.0(chokidar@5.0.0)
       rxjs: 7.8.2
       webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.27.3)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
-      webpack-dev-server: 5.2.3(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))(webpack@5.105.2)
+      webpack-dev-server: 5.2.3(webpack-cli@5.1.4)(webpack@5.105.2)
     transitivePeerDependencies:
       - chokidar
 
@@ -29292,7 +29295,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.2
       vue-tsc: 2.2.12(typescript@5.9.2)
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -29322,7 +29325,7 @@ snapshots:
     optionalDependencies:
       typescript: 5.9.2
       vue-tsc: 2.2.12(typescript@5.9.2)
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - '@rspack/core'
       - bufferutil
@@ -29394,7 +29397,7 @@ snapshots:
       btoa: 1.2.1
       encoding: 0.1.13
       node-fetch: 2.7.0(encoding@0.1.13)
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
     optionalDependencies:
       next: 14.2.35(@babel/core@7.29.0)(@playwright/test@1.60.0)(babel-plugin-macros@3.1.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3)
       react: 18.3.1
@@ -30474,7 +30477,7 @@ snapshots:
     dependencies:
       '@angular/compiler-cli': 21.2.0(@angular/compiler@21.2.0)(typescript@5.9.2)
       typescript: 5.9.2
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
 
   '@noble/hashes@1.4.0': {}
 
@@ -31542,7 +31545,7 @@ snapshots:
       http-proxy-middleware: 3.0.5
       picocolors: 1.1.1
       tslib: 2.8.1
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - '@babel/traverse'
       - '@nx/cypress'
@@ -31951,7 +31954,7 @@ snapshots:
       style-loader: 3.3.4(webpack@5.105.2)
       ts-checker-rspack-plugin: 1.1.4(@rspack/core@1.6.8(@swc/helpers@0.5.18))(typescript@5.9.2)
       tslib: 2.8.1
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
       webpack-node-externals: 3.0.0
     optionalDependencies:
       '@rspack/cli': 1.6.8(@rspack/core@1.6.8(@swc/helpers@0.5.18))(@types/express@4.17.23)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))(webpack@5.105.2)
@@ -32122,8 +32125,8 @@ snapshots:
       ts-loader: 9.5.2(typescript@5.9.2)(webpack@5.105.2)
       tsconfig-paths-webpack-plugin: 4.2.0
       tslib: 2.8.1
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
-      webpack-dev-server: 5.2.3(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))(webpack@5.105.2)
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
+      webpack-dev-server: 5.2.3(webpack-cli@5.1.4)(webpack@5.105.2)
       webpack-node-externals: 3.0.0
       webpack-subresource-integrity: 5.1.0(html-webpack-plugin@5.5.0(webpack@5.105.2))(webpack@5.105.2)
     transitivePeerDependencies:
@@ -32882,10 +32885,10 @@ snapshots:
       react-refresh: 0.10.0
       schema-utils: 4.3.2
       source-map: 0.7.6
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
     optionalDependencies:
       type-fest: 4.41.0
-      webpack-dev-server: 5.2.3(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))(webpack@5.105.2)
+      webpack-dev-server: 5.2.3(webpack-cli@5.1.4)(webpack@5.105.2)
       webpack-hot-middleware: 2.26.1
 
   '@pnpm/lockfile-types@6.0.0':
@@ -34017,7 +34020,7 @@ snapshots:
       style-loader: 4.0.0(webpack@5.105.2)
       terser-webpack-plugin: 5.3.16(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack@5.105.2)
       ts-dedent: 2.2.0
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
       webpack-dev-middleware: 6.1.3(webpack@5.105.2)
       webpack-hot-middleware: 2.26.1
       webpack-virtual-modules: 0.6.2
@@ -34051,7 +34054,7 @@ snapshots:
       esbuild: 0.25.0
       rollup: 4.44.2
       vite: 8.0.0(@types/node@24.12.2)(esbuild@0.25.0)(jiti@2.6.1)(less@4.5.1)(sass-embedded@1.97.2)(sass@1.97.3)(terser@5.46.0)(tsx@4.20.5)(yaml@2.8.0)
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
 
   '@storybook/global@5.0.0': {}
 
@@ -34082,7 +34085,7 @@ snapshots:
       semver: 7.7.4
       storybook: 10.2.10(@testing-library/dom@10.4.0)(prettier@3.6.2)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       tsconfig-paths: 4.2.0
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
     optionalDependencies:
       typescript: 5.9.2
     transitivePeerDependencies:
@@ -34102,7 +34105,7 @@ snapshots:
       react-docgen-typescript: 2.4.0(typescript@5.9.2)
       tslib: 2.8.1
       typescript: 5.9.2
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - supports-color
 
@@ -36040,22 +36043,22 @@ snapshots:
 
   '@webgpu/types@0.1.21': {}
 
-  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))(webpack@5.105.2)':
+  '@webpack-cli/configtest@2.1.1(webpack-cli@5.1.4)(webpack@5.105.2)':
     dependencies:
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2)
 
-  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))(webpack@5.105.2)':
+  '@webpack-cli/info@2.0.2(webpack-cli@5.1.4)(webpack@5.105.2)':
     dependencies:
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2)
 
-  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))(webpack-dev-server@5.2.3)(webpack@5.105.2)':
+  '@webpack-cli/serve@2.0.5(webpack-cli@5.1.4)(webpack-dev-server@5.2.3)(webpack@5.105.2)':
     dependencies:
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2)
     optionalDependencies:
-      webpack-dev-server: 5.2.3(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))(webpack@5.105.2)
+      webpack-dev-server: 5.2.3(webpack-cli@5.1.4)(webpack@5.105.2)
 
   '@whatwg-node/disposablestack@0.0.6':
     dependencies:
@@ -36831,14 +36834,14 @@ snapshots:
     dependencies:
       '@babel/core': 7.29.0
       find-up: 5.0.0
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
 
   babel-loader@9.2.1(@babel/core@7.29.0)(webpack@5.105.2):
     dependencies:
       '@babel/core': 7.29.0
       find-cache-dir: 4.0.0
       schema-utils: 4.3.2
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
 
   babel-plugin-const-enum@1.2.0(@babel/core@7.29.0):
     dependencies:
@@ -37846,7 +37849,7 @@ snapshots:
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
       tinyglobby: 0.2.15
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
 
   copy-webpack-plugin@14.0.0(webpack@5.105.2):
     dependencies:
@@ -37855,7 +37858,7 @@ snapshots:
       schema-utils: 4.3.3
       serialize-javascript: 7.0.4
       tinyglobby: 0.2.15
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
 
   core-js-compat@3.44.0:
     dependencies:
@@ -37984,7 +37987,7 @@ snapshots:
       semver: 7.7.4
     optionalDependencies:
       '@rspack/core': 1.6.8(@swc/helpers@0.5.18)
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
 
   css-loader@7.1.2(@rspack/core@1.6.8(@swc/helpers@0.5.18))(webpack@5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.27.3)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))):
     dependencies:
@@ -38026,7 +38029,7 @@ snapshots:
       semver: 7.7.4
     optionalDependencies:
       '@rspack/core': 1.6.8(@swc/helpers@0.5.18)
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
 
   css-minimizer-webpack-plugin@8.0.0(esbuild@0.25.0)(lightningcss@1.32.0)(webpack@5.105.2):
     dependencies:
@@ -38036,7 +38039,7 @@ snapshots:
       postcss: 8.5.8
       schema-utils: 4.3.3
       serialize-javascript: 7.0.4
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
     optionalDependencies:
       esbuild: 0.25.0
       lightningcss: 1.32.0
@@ -40306,7 +40309,7 @@ snapshots:
       semver: 7.7.4
       tapable: 2.3.0
       typescript: 5.9.2
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
 
   form-data-encoder@1.7.2: {}
 
@@ -41119,7 +41122,7 @@ snapshots:
       lodash: 4.17.21
       pretty-error: 4.0.0
       tapable: 2.2.2
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
 
   html-whitespace-sensitive-tag-names@3.0.1: {}
 
@@ -42704,7 +42707,7 @@ snapshots:
       less: 4.4.2
     optionalDependencies:
       '@rspack/core': 1.6.8(@swc/helpers@0.5.18)
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
 
   less-loader@12.3.1(@rspack/core@1.6.8(@swc/helpers@0.5.18))(less@4.5.1)(webpack@5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.27.3)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))):
     dependencies:
@@ -42718,7 +42721,7 @@ snapshots:
       less: 4.5.1
     optionalDependencies:
       '@rspack/core': 1.6.8(@swc/helpers@0.5.18)
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
 
   less@4.4.2:
     dependencies:
@@ -42780,7 +42783,7 @@ snapshots:
     dependencies:
       webpack-sources: 3.3.3
     optionalDependencies:
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
 
   light-my-request@6.6.0:
     dependencies:
@@ -44308,12 +44311,12 @@ snapshots:
     dependencies:
       schema-utils: 4.3.3
       tapable: 2.3.0
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
 
   mini-css-extract-plugin@2.4.7(webpack@5.105.2):
     dependencies:
       schema-utils: 4.3.2
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
 
   mini-svg-data-uri@1.4.4: {}
 
@@ -46297,7 +46300,7 @@ snapshots:
       semver: 7.7.4
     optionalDependencies:
       '@rspack/core': 1.6.8(@swc/helpers@0.5.18)
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - typescript
 
@@ -46321,7 +46324,7 @@ snapshots:
       semver: 7.7.4
     optionalDependencies:
       '@rspack/core': 1.6.8(@swc/helpers@0.5.18)
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - typescript
 
@@ -47806,7 +47809,7 @@ snapshots:
       '@rspack/core': 1.6.8(@swc/helpers@0.5.18)
       sass: 1.97.3
       sass-embedded: 1.97.2
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
 
   sass@1.97.2:
     dependencies:
@@ -48328,7 +48331,7 @@ snapshots:
     dependencies:
       iconv-lite: 0.6.3
       source-map-js: 1.2.1
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
 
   source-map-support@0.5.13:
     dependencies:
@@ -48716,11 +48719,11 @@ snapshots:
 
   style-loader@3.3.4(webpack@5.105.2):
     dependencies:
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
 
   style-loader@4.0.0(webpack@5.105.2):
     dependencies:
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
 
   style-to-js@1.1.17:
     dependencies:
@@ -48912,7 +48915,7 @@ snapshots:
       schema-utils: 4.3.2
       serialize-javascript: 6.0.2
       terser: 5.43.1
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
     optionalDependencies:
       '@swc/core': 1.15.10(@swc/helpers@0.5.18)
       esbuild: 0.25.0
@@ -48924,7 +48927,7 @@ snapshots:
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
       terser: 5.46.0
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
     optionalDependencies:
       '@swc/core': 1.15.10(@swc/helpers@0.5.18)
       esbuild: 0.25.0
@@ -48948,7 +48951,7 @@ snapshots:
       schema-utils: 4.3.3
       serialize-javascript: 6.0.2
       terser: 5.46.0
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
     optionalDependencies:
       '@swc/core': 1.15.10(@swc/helpers@0.5.18)
       esbuild: 0.27.3
@@ -49206,7 +49209,7 @@ snapshots:
       semver: 7.7.4
       source-map: 0.7.6
       typescript: 5.9.2
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
 
   ts-morph@27.0.2:
     dependencies:
@@ -50777,21 +50780,21 @@ snapshots:
   webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2):
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))(webpack@5.105.2)
-      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))(webpack@5.105.2)
-      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))(webpack-dev-server@5.2.3)(webpack@5.105.2)
+      '@webpack-cli/configtest': 2.1.1(webpack-cli@5.1.4)(webpack@5.105.2)
+      '@webpack-cli/info': 2.0.2(webpack-cli@5.1.4)(webpack@5.105.2)
+      '@webpack-cli/serve': 2.0.5(webpack-cli@5.1.4)(webpack-dev-server@5.2.3)(webpack@5.105.2)
       colorette: 2.0.20
       commander: 10.0.1
       cross-spawn: 7.0.6
-      envinfo: 7.14.0
+      envinfo: 7.21.0
       fastest-levenshtein: 1.0.16
       import-local: 3.2.0
       interpret: 3.1.1
       rechoir: 0.8.0
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
       webpack-merge: 5.10.0
     optionalDependencies:
-      webpack-dev-server: 5.2.3(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))(webpack@5.105.2)
+      webpack-dev-server: 5.2.3(webpack-cli@5.1.4)(webpack@5.105.2)
 
   webpack-dev-middleware@6.1.3(webpack@5.105.2):
     dependencies:
@@ -50801,7 +50804,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
 
   webpack-dev-middleware@7.4.5(webpack@5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))):
     dependencies:
@@ -50812,7 +50815,7 @@ snapshots:
       range-parser: 1.2.1
       schema-utils: 4.3.3
     optionalDependencies:
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
 
   webpack-dev-middleware@7.4.5(webpack@5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.27.3)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))):
     dependencies:
@@ -50856,7 +50859,7 @@ snapshots:
       webpack-dev-middleware: 7.4.5(webpack@5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2)))
       ws: 8.19.0
     optionalDependencies:
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2)
     transitivePeerDependencies:
       - bufferutil
@@ -50903,7 +50906,7 @@ snapshots:
       - supports-color
       - utf-8-validate
 
-  webpack-dev-server@5.2.3(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))(webpack@5.105.2):
+  webpack-dev-server@5.2.3(webpack-cli@5.1.4)(webpack@5.105.2):
     dependencies:
       '@types/bonjour': 3.5.13
       '@types/connect-history-api-fallback': 1.5.4
@@ -50934,7 +50937,7 @@ snapshots:
       webpack-dev-middleware: 7.4.5(webpack@5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2)))
       ws: 8.19.0
     optionalDependencies:
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
       webpack-cli: 5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2)
     transitivePeerDependencies:
       - bufferutil
@@ -50974,13 +50977,13 @@ snapshots:
   webpack-subresource-integrity@5.1.0(html-webpack-plugin@5.5.0(webpack@5.105.2))(webpack@5.105.2):
     dependencies:
       typed-assert: 1.0.9
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2))
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4)
     optionalDependencies:
       html-webpack-plugin: 5.5.0(webpack@5.105.2)
 
   webpack-virtual-modules@0.6.2: {}
 
-  webpack@5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4(webpack-dev-server@5.2.3)(webpack@5.105.2)):
+  webpack@5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack-cli@5.1.4):
     dependencies:
       '@types/eslint-scope': 3.7.7
       '@types/estree': 1.0.8


### PR DESCRIPTION
## Current Behavior

`@nx/rollup`, `@nx/webpack`, and `@nx/module-federation` pin their primary third-party packages as **bundled `dependencies`**:

- `@nx/rollup` → `rollup` (`^4.14.0`)
- `@nx/webpack` → `webpack`, `webpack-dev-server` (v5)
- `@nx/module-federation` → `@module-federation/enhanced`, `@module-federation/node`, `@module-federation/sdk` (v2)

This causes version conflicts with the version a workspace actually has installed, prevents `nx migrate --first-party-only` from upgrading Nx without dragging these along, and lets generators silently overwrite a user's pinned version. Several cross-version `packageJsonUpdates` migrations also bump packages **without `requires` gates**, so they fire on workspaces outside the intended source range (e.g. the `@nx/webpack` `sass-loader` v12 → v16 bump, and all of `@nx/module-federation`'s `@module-federation/*` bumps).

## Expected Behavior

Each plugin declares the packages it invokes at runtime as **optional peer dependencies** matching its real support window, so the workspace controls the version:

- `@nx/rollup` → `rollup` `^3.0.0 || ^4.0.0`
- `@nx/webpack` → `webpack` / `webpack-dev-server` / `webpack-cli` `^5.0.0` (the effective floor — the plugin already calls webpack-5-only APIs such as `ids.HashedModuleIdsPlugin`, `webpack.sources`, and `experiments.cacheUnaffected`)
- `@nx/module-federation` → `@module-federation/enhanced` / `@module-federation/node` `^2.0.0` (`@module-federation/sdk` stays a dependency — it is a type-only import surfaced in the public `.d.ts`)

Generators assert the supported floor (with a parameterized `all-generators-enforce-floor` spec), preserve user-pinned versions (`keepExistingVersions` now defaults to `true`), and install the now-peer build tool for new workspaces. Because every workspace that uses these tools already has the corresponding `@nx/*` plugin as a direct dependency, a `packageJsonUpdates` bridge in each plugin installs the peer into existing workspaces on `nx migrate` (and correctly skips workspaces that only carry the plugin transitively). Cross-version migrations are gated on their source range.

### Changes per plugin

- **`@nx/rollup` (NXC-4403)** — `rollup` → optional peer; floor assert (v3) in all generators; `keepExistingVersions` default `true`; install `rollup` on both the inferred-plugin and executor paths; bridge migration for existing workspaces. No runtime branching/version map is needed — the plugin's Rollup usage is already v2/v3/v4-agnostic.
- **`@nx/webpack` (NXC-4410)** — `webpack`/`webpack-dev-server`/`webpack-cli` → optional peers (`^5`); floor assert (v5) in all generators; `keepExistingVersions` default `true`; gate the `sass-loader` v12 → v16 migration on `^12`; install `webpack`/`webpack-dev-server` for new workspaces; bridge migration for existing ones.
- **`@nx/module-federation` (NXC-4393)** — `@module-federation/enhanced`/`node` → optional peers (`^2`); add `requires` gates (on the `@module-federation/enhanced` source range, mirroring the existing `@nx/angular` MF migrations) to every `packageJsonUpdates` entry, and split the independent `http-proxy-middleware` v2 → v3 bump into its own gated entry. This is a runtime-only library (no generators/executors), so there is no floor assert/spec.

## Related Issue(s)

Tracked in Linear under the "Multi-version supported across plugins" milestone:

- NXC-4403 — `@nx/rollup`
- NXC-4410 — `@nx/webpack`
- NXC-4393 — `@nx/module-federation`

No GitHub issue to auto-close.
