### PR TITLE
feat(angular): deprecate convert-to-with-mf generator

### DIFF
--- a/packages/angular/generators.json
+++ b/packages/angular/generators.json
@@ -54,7 +54,7 @@
       "schema": "./src/generators/federate-module/schema.json",
       "x-type": "application",
       "description": "Create a federated module, which is exposed by a remote and can be subsequently loaded by a host.",
-      "x-deprecated": "Angular Module Federation in Nx is no longer supported. Use `@angular-architects/native-federation` instead. Removed in Nx v24."
+      "x-deprecated": "Angular Module Federation in Nx is no longer supported. Use `@angular-architects/native-federation` instead. See https://nx.dev/docs/technologies/module-federation/consumer-and-provider for the v23 migration guide. Removed in Nx v24."
     },
     "init": {
       "factory": "./src/generators/init/init",
@@ -81,12 +81,13 @@
       "x-type": "application",
       "description": "Generate a Remote Angular Module Federation Application.",
       "aliases": ["producer"],
-      "x-deprecated": "Angular Module Federation in Nx is no longer supported. Use `@angular-architects/native-federation` instead. Removed in Nx v24."
+      "x-deprecated": "Angular Module Federation in Nx is no longer supported. Use `@angular-architects/native-federation` instead. See https://nx.dev/docs/technologies/module-federation/consumer-and-provider for the v23 migration guide. Removed in Nx v24."
     },
     "convert-to-with-mf": {
       "factory": "./src/generators/convert-to-with-mf/convert-to-with-mf",
       "schema": "./src/generators/convert-to-with-mf/schema.json",
-      "description": "Converts an old micro frontend configuration to use the new withModuleFederation helper. It will run successfully if the following conditions are met: \n - Is either a host or remote application \n - Shared npm package configurations have not been modified \n - Name used to identify the Micro Frontend application matches the project name \n\n{% callout type=\"warning\" title=\"Overrides\" %}This generator will overwrite your webpack config. If you have additional custom configuration in your config file, it will be lost!{% /callout %}"
+      "description": "Converts an old micro frontend configuration to use the new withModuleFederation helper. It will run successfully if the following conditions are met: \n - Is either a host or remote application \n - Shared npm package configurations have not been modified \n - Name used to identify the Micro Frontend application matches the project name \n\n{% callout type=\"warning\" title=\"Overrides\" %}This generator will overwrite your webpack config. If you have additional custom configuration in your config file, it will be lost!{% /callout %}",
+      "x-deprecated": "Angular Module Federation in Nx is no longer supported. Use `@angular-architects/native-federation` instead. See https://nx.dev/docs/technologies/module-federation/consumer-and-provider for the v23 migration guide. Removed in Nx v24."
     },
     "host": {
       "factory": "./src/generators/host/host",
@@ -94,7 +95,7 @@
       "x-type": "application",
       "description": "Generate a Host Angular Module Federation Application.",
       "aliases": ["consumer"],
-      "x-deprecated": "Angular Module Federation in Nx is no longer supported. Use `@angular-architects/native-federation` instead. Removed in Nx v24."
+      "x-deprecated": "Angular Module Federation in Nx is no longer supported. Use `@angular-architects/native-federation` instead. See https://nx.dev/docs/technologies/module-federation/consumer-and-provider for the v23 migration guide. Removed in Nx v24."
     },
     "ng-add": {
       "factory": "./src/generators/ng-add/ng-add",
@@ -142,7 +143,7 @@
       "factory": "./src/generators/setup-mf/setup-mf",
       "schema": "./src/generators/setup-mf/schema.json",
       "description": "Generate a Module Federation configuration for a given Angular application.",
-      "x-deprecated": "Angular Module Federation in Nx is no longer supported. Use `@angular-architects/native-federation` instead. Removed in Nx v24."
+      "x-deprecated": "Angular Module Federation in Nx is no longer supported. Use `@angular-architects/native-federation` instead. See https://nx.dev/docs/technologies/module-federation/consumer-and-provider for the v23 migration guide. Removed in Nx v24."
     },
     "setup-ssr": {
       "factory": "./src/generators/setup-ssr/setup-ssr",

--- a/packages/angular/src/generators/federate-module/federate-module.ts
+++ b/packages/angular/src/generators/federate-module/federate-module.ts
@@ -15,10 +15,8 @@ import {
   addRemote,
 } from './lib';
 import type { Schema } from './schema';
-import { warnAngularFederateModuleGeneratorDeprecation } from '../../utils/module-federation-deprecation';
 
 export async function federateModuleGenerator(tree: Tree, schema: Schema) {
-  warnAngularFederateModuleGeneratorDeprecation();
   assertSupportedAngularVersion(tree);
   if (!tree.exists(schema.path)) {
     throw new Error(stripIndents`The "path" provided  does not exist. Please verify the path is correct and pointing to a file that exists in the workspace.

--- a/packages/angular/src/generators/host/host.ts
+++ b/packages/angular/src/generators/host/host.ts
@@ -24,10 +24,8 @@ import { assertNotUsingTsSolutionSetup } from '../utils/validations';
 import { getInstalledAngularVersionInfo } from '../utils/version-utils';
 import { updateSsrSetup, validateOptions } from './lib';
 import type { Schema } from './schema';
-import { warnAngularHostGeneratorDeprecation } from '../../utils/module-federation-deprecation';
 
 export async function host(tree: Tree, schema: Schema) {
-  warnAngularHostGeneratorDeprecation();
   assertSupportedAngularVersion(tree);
   assertNotUsingTsSolutionSetup(tree, 'host');
   validateOptions(tree, schema);

--- a/packages/angular/src/generators/remote/remote.ts
+++ b/packages/angular/src/generators/remote/remote.ts
@@ -24,10 +24,8 @@ import { assertNotUsingTsSolutionSetup } from '../utils/validations';
 import { getInstalledAngularVersionInfo } from '../utils/version-utils';
 import { findNextAvailablePort, updateSsrSetup, validateOptions } from './lib';
 import type { Schema } from './schema';
-import { warnAngularRemoteGeneratorDeprecation } from '../../utils/module-federation-deprecation';
 
 export async function remote(tree: Tree, schema: Schema) {
-  warnAngularRemoteGeneratorDeprecation();
   assertSupportedAngularVersion(tree);
   assertNotUsingTsSolutionSetup(tree, 'remote');
   validateOptions(tree, schema);

--- a/packages/angular/src/generators/setup-mf/setup-mf.ts
+++ b/packages/angular/src/generators/setup-mf/setup-mf.ts
@@ -35,10 +35,8 @@ import {
   updateTsConfig,
 } from './lib';
 import type { Schema } from './schema';
-import { warnAngularSetupMfGeneratorDeprecation } from '../../utils/module-federation-deprecation';
 
 export async function setupMf(tree: Tree, rawOptions: Schema) {
-  warnAngularSetupMfGeneratorDeprecation();
   assertSupportedAngularVersion(tree);
   const options = normalizeOptions(tree, rawOptions);
   const projectConfig = readProjectConfiguration(tree, options.appName);

--- a/packages/angular/src/utils/module-federation-deprecation.ts
+++ b/packages/angular/src/utils/module-federation-deprecation.ts
@@ -11,33 +11,9 @@ const ANGULAR_NATIVE_FED_URL =
 
 const ANGULAR_MF_TRAILER = `Angular Module Federation in Nx is no longer supported. Use \`@angular-architects/native-federation\` (${ANGULAR_NATIVE_FED_URL}) for the supported Angular path. See ${MIGRATION_URL} for the v23 migration guide.`;
 
-export const ANGULAR_HOST_GENERATOR_DEPRECATION_MESSAGE = `The \`@nx/angular:host\` generator is deprecated and will be removed in Nx v24. ${ANGULAR_MF_TRAILER}`;
-
-export const ANGULAR_REMOTE_GENERATOR_DEPRECATION_MESSAGE = `The \`@nx/angular:remote\` generator is deprecated and will be removed in Nx v24. ${ANGULAR_MF_TRAILER}`;
-
-export const ANGULAR_SETUP_MF_GENERATOR_DEPRECATION_MESSAGE = `The \`@nx/angular:setup-mf\` generator is deprecated and will be removed in Nx v24. ${ANGULAR_MF_TRAILER}`;
-
-export const ANGULAR_FEDERATE_MODULE_GENERATOR_DEPRECATION_MESSAGE = `The \`@nx/angular:federate-module\` generator is deprecated and will be removed in Nx v24. ${ANGULAR_MF_TRAILER}`;
-
 export const ANGULAR_MF_DEV_SERVER_EXECUTOR_DEPRECATION_MESSAGE = `The \`@nx/angular:module-federation-dev-server\` executor is deprecated and will be removed in Nx v24. ${ANGULAR_MF_TRAILER}`;
 
 export const ANGULAR_MF_DEV_SSR_EXECUTOR_DEPRECATION_MESSAGE = `The \`@nx/angular:module-federation-dev-ssr\` executor is deprecated and will be removed in Nx v24. ${ANGULAR_MF_TRAILER}`;
-
-export function warnAngularHostGeneratorDeprecation(): void {
-  logger.warn(ANGULAR_HOST_GENERATOR_DEPRECATION_MESSAGE);
-}
-
-export function warnAngularRemoteGeneratorDeprecation(): void {
-  logger.warn(ANGULAR_REMOTE_GENERATOR_DEPRECATION_MESSAGE);
-}
-
-export function warnAngularSetupMfGeneratorDeprecation(): void {
-  logger.warn(ANGULAR_SETUP_MF_GENERATOR_DEPRECATION_MESSAGE);
-}
-
-export function warnAngularFederateModuleGeneratorDeprecation(): void {
-  logger.warn(ANGULAR_FEDERATE_MODULE_GENERATOR_DEPRECATION_MESSAGE);
-}
 
 // Executor warnings fire once per process to avoid flooding dev-server loops.
 const executorWarned = new Set<string>();


### PR DESCRIPTION
## Current Behavior

The `@nx/angular:convert-to-with-mf` generator wasn't marked deprecated — it was the only Angular Module Federation generator missing the `x-deprecated` marker its siblings (`host`, `remote`, `setup-mf`, `federate-module`) already carry.

Separately, those four siblings emitted their deprecation notice twice: once from the `x-deprecated` manifest marker (printed by `nx generate` and shown in `--help`) and again from a redundant in-body `logger.warn`.

## Expected Behavior

- `@nx/angular:convert-to-with-mf` is now marked deprecated via `x-deprecated` in `generators.json`, so the CLI reports it on `nx g` and in `nx g convert-to-with-mf --help`.
- The redundant in-body `logger.warn` calls are removed from all five Angular MF generators; they rely solely on the declarative `x-deprecated` marker, which already warns on run. The shared `module-federation-deprecation.ts` helper now retains only the executor warnings, which have no `x-deprecated` equivalent.
- All five generator `x-deprecated` messages now include the migration-guide URL.

Angular Module Federation in Nx is no longer supported; users should move to Angular Native Federation (`@angular-architects/native-federation`). These generators will be removed in Nx v24.

## Related Issue(s)

Resolves NXC-3706
