### PR TITLE
feat(core): suggest available targets and closest task id on run-one errors

### DIFF
--- a/e2e/nx/src/run.test.ts
+++ b/e2e/nx/src/run.test.ts
@@ -195,11 +195,13 @@ describe('Nx Running Tests', () => {
         expect(stdout).toMatch(/ECHOED positional --a=123 --no-b/);
       }
 
-      expect(
-        runCLI(`echo:fail ${mylib}`, {
-          silenceError: true,
-        })
-      ).toContain(`Cannot find configuration for task ${mylib}:echo:fail`);
+      const echoFailOutput = runCLI(`echo:fail ${mylib}`, {
+        silenceError: true,
+      });
+      // The target does not exist, so run-one reports the available targets
+      // (the only included script) instead of a cryptic task graph error.
+      expect(echoFailOutput).toContain(`Cannot find target "echo:fail"`);
+      expect(echoFailOutput).toContain(`echo:dev`);
 
       updateJson(`libs/${mylib}/project.json`, (c) => original);
     }, 1000000);

--- a/e2e/nx/src/run.test.ts
+++ b/e2e/nx/src/run.test.ts
@@ -200,7 +200,9 @@ describe('Nx Running Tests', () => {
       });
       // The target does not exist, so run-one reports the available targets
       // (the only included script) instead of a cryptic task graph error.
-      expect(echoFailOutput).toContain(`Cannot find target "echo:fail"`);
+      expect(echoFailOutput).toContain(
+        `Cannot find target "echo:fail" for project "${mylib}"`
+      );
       expect(echoFailOutput).toContain(`echo:dev`);
 
       updateJson(`libs/${mylib}/project.json`, (c) => original);

--- a/e2e/nx/src/run.test.ts
+++ b/e2e/nx/src/run.test.ts
@@ -206,11 +206,13 @@ describe('Nx Running Tests', () => {
         expect(stdout).toMatch(/ECHOED positional --a=123 --no-b/);
       }
 
-      expect(
-        runCLI(`echo:fail ${mylib}`, {
-          silenceError: true,
-        })
-      ).toContain(`Cannot find configuration for task ${mylib}:echo:fail`);
+      const echoFailOutput = runCLI(`echo:fail ${mylib}`, {
+        silenceError: true,
+      });
+      // The target does not exist, so run-one reports the available targets
+      // (the only included script) instead of a cryptic task graph error.
+      expect(echoFailOutput).toContain(`Cannot find target "echo:fail"`);
+      expect(echoFailOutput).toContain(`echo:dev`);
 
       updateJson(`libs/${mylib}/project.json`, (c) => original);
     }, 1000000);

--- a/e2e/nx/src/run.test.ts
+++ b/e2e/nx/src/run.test.ts
@@ -211,10 +211,14 @@ describe('Nx Running Tests', () => {
       });
       // The target does not exist, so run-one reports the available targets
       // (the only included script) instead of a cryptic task graph error.
+      // "echo:dev" is too far from "echo:fail" to be offered as a "did you
+      // mean", so it can only reach the output via the available-targets list.
       expect(echoFailOutput).toContain(
         `Cannot find target "echo:fail" for project "${mylib}"`
       );
-      expect(echoFailOutput).toContain(`echo:dev`);
+      expect(echoFailOutput).toContain(`Available targets:`);
+      expect(echoFailOutput).toContain(`- echo:dev`);
+      expect(echoFailOutput).not.toContain(`Did you mean`);
 
       updateJson(`libs/${mylib}/project.json`, (c) => original);
     }, 1000000);

--- a/e2e/nx/src/run.test.ts
+++ b/e2e/nx/src/run.test.ts
@@ -211,7 +211,9 @@ describe('Nx Running Tests', () => {
       });
       // The target does not exist, so run-one reports the available targets
       // (the only included script) instead of a cryptic task graph error.
-      expect(echoFailOutput).toContain(`Cannot find target "echo:fail"`);
+      expect(echoFailOutput).toContain(
+        `Cannot find target "echo:fail" for project "${mylib}"`
+      );
       expect(echoFailOutput).toContain(`echo:dev`);
 
       updateJson(`libs/${mylib}/project.json`, (c) => original);

--- a/packages/nx/src/command-line/run/run-one.spec.ts
+++ b/packages/nx/src/command-line/run/run-one.spec.ts
@@ -507,7 +507,9 @@ describe('parseRunOneOptions', () => {
         'Cannot find target "biuld" for project "my-app"'
       );
       expect(error.bodyLines).toContain('Did you mean "build"?');
-      expect(error.bodyLines).toContain('  - build');
+      // The closest match is already surfaced as the suggestion, so it is not
+      // repeated in the available targets list.
+      expect(error.bodyLines).not.toContain('  - build');
       expect(error.bodyLines).toContain('  - serve');
       expect(error.bodyLines).toContain('  - run');
     });

--- a/packages/nx/src/command-line/run/run-one.spec.ts
+++ b/packages/nx/src/command-line/run/run-one.spec.ts
@@ -1,6 +1,10 @@
 import { ProjectGraph } from '../../config/project-graph';
 import { NxJsonConfiguration } from '../../config/nx-json';
-import { parseRunOneOptions } from './run-one';
+import {
+  getCannotFindProjectError,
+  getRunOneTargetError,
+  parseRunOneOptions,
+} from './run-one';
 
 describe('parseRunOneOptions', () => {
   let projectGraph: ProjectGraph;
@@ -41,6 +45,16 @@ describe('parseRunOneOptions', () => {
             targets: {
               build: { executor: '@nx/js:tsc' },
               serve: { executor: '@nx/webpack:dev-server' },
+            },
+          },
+        },
+        'colon-proj': {
+          name: 'colon-proj',
+          type: 'lib',
+          data: {
+            root: 'libs/colon-proj',
+            targets: {
+              'zzcustom:variant': { executor: 'nx:run-commands' },
             },
           },
         },
@@ -473,6 +487,149 @@ describe('parseRunOneOptions', () => {
         customFlag: 'value',
         target: 'build',
       });
+    });
+  });
+
+  describe('getRunOneTargetError', () => {
+    it('should return null when the target exists on the project', () => {
+      expect(
+        getRunOneTargetError(projectGraph.nodes['my-app'], 'build')
+      ).toBeNull();
+    });
+
+    it('should list available targets and suggest the closest one for a typo', () => {
+      const error = getRunOneTargetError(
+        projectGraph.nodes['my-app'],
+        'biuld'
+      )!;
+
+      expect(error.title).toBe(
+        'Cannot find target "biuld" for project "my-app"'
+      );
+      expect(error.bodyLines).toContain('Did you mean "build"?');
+      expect(error.bodyLines).toContain('  - build');
+      expect(error.bodyLines).toContain('  - serve');
+      expect(error.bodyLines).toContain('  - run');
+    });
+
+    it('should omit the suggestion when no target is close enough', () => {
+      const error = getRunOneTargetError(
+        projectGraph.nodes['my-app'],
+        'nonsense'
+      )!;
+
+      expect(
+        error.bodyLines.some((line: string) => line.startsWith('Did you mean'))
+      ).toBe(false);
+      expect(error.bodyLines).toContain('  - build');
+    });
+
+    it('should report when the project has no targets', () => {
+      const error = getRunOneTargetError(
+        {
+          name: 'empty',
+          type: 'lib',
+          data: { root: 'libs/empty', targets: {} },
+        },
+        'build'
+      )!;
+
+      expect(error.title).toBe(
+        'Cannot find target "build" for project "empty"'
+      );
+      expect(error.bodyLines).toContain(
+        'The project "empty" does not have any targets configured.'
+      );
+    });
+
+    it('should suggest a colon-containing target even though its tail is parsed as a configuration', () => {
+      // `nx run colon-proj:zzcustom:variantt` splits to target "zzcustom",
+      // configuration "variantt"; the real target name contains the colon.
+      const error = getRunOneTargetError(
+        projectGraph.nodes['colon-proj'],
+        'zzcustom',
+        'variantt'
+      )!;
+
+      expect(error.title).toBe(
+        'Cannot find target "zzcustom" for project "colon-proj"'
+      );
+      expect(error.bodyLines).toContain('Did you mean "zzcustom:variant"?');
+    });
+
+    it('should still suggest the target for a genuine target + configuration typo', () => {
+      // Here "production" is a real configuration name, not part of the target,
+      // so the bare target form must still win.
+      const error = getRunOneTargetError(
+        projectGraph.nodes['my-app'],
+        'biuld',
+        'production'
+      )!;
+
+      expect(error.bodyLines).toContain('Did you mean "build"?');
+    });
+
+    it('should cap the listed targets to five and report the remainder', () => {
+      const error = getRunOneTargetError(
+        {
+          name: 'many',
+          type: 'lib',
+          data: {
+            root: 'libs/many',
+            targets: {
+              build: {},
+              test: {},
+              lint: {},
+              serve: {},
+              e2e: {},
+              docs: {},
+              deploy: {},
+            },
+          },
+        },
+        'nope'
+      )!;
+
+      const targetLines = error.bodyLines.filter((line: string) =>
+        line.startsWith('  - ')
+      );
+      expect(targetLines).toHaveLength(5);
+      expect(error.bodyLines).toContain('  ...and 2 more');
+    });
+  });
+
+  describe('getCannotFindProjectError', () => {
+    it('should suggest the closest task id when the project name has a typo', () => {
+      const error = getCannotFindProjectError(projectGraph, 'my-ap', 'serve');
+
+      expect(error.title).toBe("Cannot find project 'my-ap'");
+      expect(error.bodyLines).toContain('Did you mean one of these?');
+      expect(error.bodyLines).toContain('  - my-app:serve');
+    });
+
+    it('should omit suggestions when nothing is close enough', () => {
+      const error = getCannotFindProjectError(
+        projectGraph,
+        'completely-unrelated',
+        'whatever'
+      );
+
+      expect(error.title).toBe("Cannot find project 'completely-unrelated'");
+      expect(error.bodyLines).toEqual([]);
+    });
+
+    it('should suggest the full task id for a project typo on a colon target', () => {
+      // `nx run colon-pro:zzcustom:variant` -> project "colon-pro" (typo),
+      // target "zzcustom", configuration "variant".
+      const error = getCannotFindProjectError(
+        projectGraph,
+        'colon-pro',
+        'zzcustom',
+        'variant'
+      );
+
+      expect(error.title).toBe("Cannot find project 'colon-pro'");
+      expect(error.bodyLines).toContain('  - colon-proj:zzcustom:variant');
     });
   });
 

--- a/packages/nx/src/command-line/run/run-one.spec.ts
+++ b/packages/nx/src/command-line/run/run-one.spec.ts
@@ -556,7 +556,48 @@ describe('parseRunOneOptions', () => {
       expect(error.title).toBe(
         'Cannot find target "zzcustom" for project "colon-proj"'
       );
-      expect(error.bodyLines).toContain('Did you mean "zzcustom:variant"?');
+      // The only target is the suggestion, so there is nothing left to list --
+      // the "Available targets:" header must not be printed on its own.
+      expect(error.bodyLines).toEqual(['Did you mean "zzcustom:variant"?']);
+    });
+
+    it('should omit the available targets block when the suggestion was the only target', () => {
+      const error = getRunOneTargetError(
+        {
+          name: 'solo',
+          type: 'lib',
+          data: { root: 'libs/solo', targets: { build: {} } },
+        },
+        'buld'
+      )!;
+
+      expect(error.bodyLines).toEqual(['Did you mean "build"?']);
+    });
+
+    it('should prefer a closer bare-target match over a further rejoined one', () => {
+      // `nx run app:buld:storybook` splits to target "buld" + configuration
+      // "storybook". The rejoined form matches "build-storybook" at distance 2,
+      // but the bare target matches "build" at distance 1 -- the closer of the
+      // two must win rather than whichever form is tried first.
+      const error = getRunOneTargetError(
+        {
+          name: 'app',
+          type: 'app',
+          data: {
+            root: 'apps/app',
+            targets: { build: {}, 'build-storybook': {} },
+          },
+        },
+        'buld',
+        'storybook'
+      )!;
+
+      expect(error.bodyLines).toEqual([
+        'Did you mean "build"?',
+        '',
+        'Available targets:',
+        '  - build-storybook',
+      ]);
     });
 
     it('should still suggest the target for a genuine target + configuration typo', () => {
@@ -632,6 +673,68 @@ describe('parseRunOneOptions', () => {
 
       expect(error.title).toBe("Cannot find project 'colon-pro'");
       expect(error.bodyLines).toContain('  - colon-proj:zzcustom:variant');
+    });
+
+    it('should prefer a closer shorter-form specifier over a further rejoined one', () => {
+      // `nx run shp:build:production` -> project "shp" (typo), target "build",
+      // configuration "production". The rejoined specifier matches
+      // "shop:build-production" at distance 2, but dropping the configuration
+      // matches "shop:build" at distance 1.
+      const graph: ProjectGraph = {
+        nodes: {
+          shop: {
+            name: 'shop',
+            type: 'app',
+            data: {
+              root: 'apps/shop',
+              targets: { build: {}, 'build-production': {} },
+            },
+          },
+          'shop-e2e': {
+            name: 'shop-e2e',
+            type: 'e2e',
+            data: { root: 'apps/shop-e2e', targets: { e2e: {} } },
+          },
+        },
+        dependencies: {},
+      };
+
+      const error = getCannotFindProjectError(
+        graph,
+        'shp',
+        'build',
+        'production'
+      );
+
+      expect(error.bodyLines).toEqual([
+        'Did you mean one of these?',
+        '  - shop:build',
+      ]);
+    });
+
+    it('should not suggest task ids that only match on the target the user typed correctly', () => {
+      // "zzz" shares no character with any project, but the correctly typed
+      // ":build" suffix must not buy the project segment a bigger typo budget.
+      const graph: ProjectGraph = {
+        nodes: Object.fromEntries(
+          ['web', 'api', 'docs', 'admin', 'mobile'].map((name) => [
+            name,
+            {
+              name,
+              type: 'app' as const,
+              data: {
+                root: `apps/${name}`,
+                targets: { build: {}, test: {}, lint: {} },
+              },
+            },
+          ])
+        ),
+        dependencies: {},
+      };
+
+      const error = getCannotFindProjectError(graph, 'zzz', 'build');
+
+      expect(error.bodyLines).toEqual([]);
     });
   });
 

--- a/packages/nx/src/command-line/run/run-one.ts
+++ b/packages/nx/src/command-line/run/run-one.ts
@@ -19,7 +19,10 @@ import {
 import { findMatchingProjects } from '../../utils/find-matching-projects';
 import { output } from '../../utils/output';
 import { splitTarget } from '../../utils/split-target';
-import { findClosestMatches } from '../../utils/string-similarity';
+import {
+  findClosestMatches,
+  levenshteinDistance,
+} from '../../utils/string-similarity';
 import { workspaceRoot } from '../../utils/workspace-root';
 import { generateGraph } from '../graph/graph';
 import { connectToNxCloudIfExplicitlyAsked } from '../nx-cloud/connect/connect-to-nx-cloud';
@@ -216,11 +219,22 @@ function findClosestSpecifier(
 }
 
 /**
- * Lists up to `MAX_LISTED_TARGETS` targets, appending a "...and N more" line
- * when the project has more targets than we show.
+ * Lists up to `MAX_LISTED_TARGETS` targets, ordered by how closely they resemble
+ * the target the user typed (closest first, ties broken alphabetically) so the
+ * most likely intended targets surface first. `closestMatch` is omitted because
+ * it is already surfaced separately as the "Did you mean" suggestion. Appends a
+ * "...and N more" line when the project has more targets than we show.
  */
-function formatAvailableTargets(availableTargets: string[]): string[] {
-  const sorted = [...availableTargets].sort();
+function formatAvailableTargets(
+  availableTargets: string[],
+  target: string,
+  closestMatch?: string
+): string[] {
+  const sorted = availableTargets
+    .filter((t) => t !== closestMatch)
+    .map((t) => ({ target: t, distance: levenshteinDistance(target, t) }))
+    .sort((a, b) => a.distance - b.distance || a.target.localeCompare(b.target))
+    .map(({ target }) => target);
   const shown = sorted.slice(0, MAX_LISTED_TARGETS);
   const lines = ['Available targets:', ...shown.map((t) => `  - ${t}`)];
   if (sorted.length > shown.length) {
@@ -285,7 +299,9 @@ export function getRunOneTargetError(
   }
 
   if (availableTargets.length) {
-    bodyLines.push(...formatAvailableTargets(availableTargets));
+    bodyLines.push(
+      ...formatAvailableTargets(availableTargets, target, closestMatch)
+    );
   } else {
     bodyLines.push(
       `The project "${project.name}" does not have any targets configured.`

--- a/packages/nx/src/command-line/run/run-one.ts
+++ b/packages/nx/src/command-line/run/run-one.ts
@@ -21,7 +21,8 @@ import { output } from '../../utils/output';
 import { splitTarget } from '../../utils/split-target';
 import {
   findClosestMatches,
-  levenshteinDistance,
+  isWithinSuggestionThreshold,
+  rankByDistance,
 } from '../../utils/string-similarity';
 import { workspaceRoot } from '../../utils/workspace-root';
 import { generateGraph } from '../graph/graph';
@@ -219,26 +220,55 @@ function findClosestSpecifier(
 }
 
 /**
- * Lists up to `MAX_LISTED_TARGETS` targets, ordered by how closely they resemble
- * the target the user typed (closest first, ties broken alphabetically) so the
- * most likely intended targets surface first. `closestMatch` is omitted because
- * it is already surfaced separately as the "Did you mean" suggestion. Appends a
- * "...and N more" line when the project has more targets than we show.
+ * Finds the closest available target to what the user typed, staying
+ * config-aware. When a configuration was parsed off the specifier, the rejoined
+ * `target:configuration` is tried first so a colon-containing real target name
+ * (e.g. `zzcustom:variant`) still matches. The bare-`target` tier reuses the
+ * precomputed `ranked` list (its head, gated by the suggestion threshold)
+ * instead of recomputing distances, matching `findClosestSpecifier`'s
+ * progressive-join preference order for these two tiers.
+ */
+function findClosestTarget(
+  target: string,
+  configuration: string | undefined,
+  availableTargets: readonly string[],
+  ranked: { candidate: string; distance: number }[]
+): string | undefined {
+  if (configuration) {
+    const [rejoined] = findClosestMatches(
+      `${target}:${configuration}`,
+      availableTargets,
+      1
+    );
+    if (rejoined) {
+      return rejoined;
+    }
+  }
+  const nearest = ranked[0];
+  return nearest && isWithinSuggestionThreshold(target, nearest.distance)
+    ? nearest.candidate
+    : undefined;
+}
+
+/**
+ * Lists up to `MAX_LISTED_TARGETS` targets from a list already ranked by how
+ * closely they resemble the target the user typed (closest first, ties broken
+ * alphabetically) so the most likely intended targets surface first.
+ * `closestMatch` is dropped because it is already surfaced separately as the
+ * "Did you mean" suggestion. Appends a "...and N more" line when the project has
+ * more targets than we show.
  */
 function formatAvailableTargets(
-  availableTargets: string[],
-  target: string,
+  ranked: { candidate: string; distance: number }[],
   closestMatch?: string
 ): string[] {
-  const sorted = availableTargets
-    .filter((t) => t !== closestMatch)
-    .map((t) => ({ target: t, distance: levenshteinDistance(target, t) }))
-    .sort((a, b) => a.distance - b.distance || a.target.localeCompare(b.target))
-    .map(({ target }) => target);
-  const shown = sorted.slice(0, MAX_LISTED_TARGETS);
+  const targets = ranked
+    .map(({ candidate }) => candidate)
+    .filter((candidate) => candidate !== closestMatch);
+  const shown = targets.slice(0, MAX_LISTED_TARGETS);
   const lines = ['Available targets:', ...shown.map((t) => `  - ${t}`)];
-  if (sorted.length > shown.length) {
-    lines.push(`  ...and ${sorted.length - shown.length} more`);
+  if (targets.length > shown.length) {
+    lines.push(`  ...and ${targets.length - shown.length} more`);
   }
   return lines;
 }
@@ -290,18 +320,22 @@ export function getRunOneTargetError(
   }
 
   const bodyLines: string[] = [];
-  const [closestMatch] = findClosestSpecifier(
-    [target, configuration],
-    availableTargets
+  // Rank the available targets by distance to the bare target ONCE. This drives
+  // the ordered "Available targets" block and doubles as the bare-target tier of
+  // the closest-match lookup, so distances are not computed twice.
+  const ranked = rankByDistance(target, availableTargets);
+  const closestMatch = findClosestTarget(
+    target,
+    configuration,
+    availableTargets,
+    ranked
   );
   if (closestMatch) {
     bodyLines.push(`Did you mean "${closestMatch}"?`, '');
   }
 
   if (availableTargets.length) {
-    bodyLines.push(
-      ...formatAvailableTargets(availableTargets, target, closestMatch)
-    );
+    bodyLines.push(...formatAvailableTargets(ranked, closestMatch));
   } else {
     bodyLines.push(
       `The project "${project.name}" does not have any targets configured.`

--- a/packages/nx/src/command-line/run/run-one.ts
+++ b/packages/nx/src/command-line/run/run-one.ts
@@ -19,6 +19,7 @@ import {
 import { findMatchingProjects } from '../../utils/find-matching-projects';
 import { output } from '../../utils/output';
 import { splitTarget } from '../../utils/split-target';
+import { findClosestMatches } from '../../utils/string-similarity';
 import { workspaceRoot } from '../../utils/workspace-root';
 import { generateGraph } from '../graph/graph';
 import { connectToNxCloudIfExplicitlyAsked } from '../nx-cloud/connect/connect-to-nx-cloud';
@@ -57,7 +58,22 @@ export async function runOne(
     nxJson
   );
 
-  const { projects, projectName } = getProjects(projectGraph, opts.project);
+  const { projects, projectName } = getProjects(
+    projectGraph,
+    opts.project,
+    opts.target,
+    opts.configuration
+  );
+
+  const targetError = getRunOneTargetError(
+    projects[0],
+    opts.target,
+    opts.configuration
+  );
+  if (targetError) {
+    output.error(targetError);
+    process.exit(1);
+  }
 
   if (nxArgs.help) {
     await (
@@ -106,7 +122,9 @@ export async function runOne(
 
 function getProjects(
   projectGraph: ProjectGraph,
-  projectName: string
+  projectName: string,
+  target: string,
+  configuration?: string
 ): {
   projectName: string;
   projects: ProjectGraphProjectNode[];
@@ -142,10 +160,142 @@ function getProjects(
     }
   }
 
-  output.error({
-    title: `Cannot find project '${projectName}'`,
-  });
+  output.error(
+    getCannotFindProjectError(projectGraph, projectName, target, configuration)
+  );
   process.exit(1);
+}
+
+// Keep error output scannable: only show a handful of targets/suggestions.
+const MAX_LISTED_TARGETS = 5;
+const MAX_SUGGESTIONS = 3;
+
+/**
+ * Builds the list of all runnable `project:target` task ids in the workspace,
+ * used to suggest the right invocation when a project or target can't be found.
+ */
+function getProjectTargetIds(projectGraph: ProjectGraph): string[] {
+  const ids: string[] = [];
+  for (const projectName of Object.keys(projectGraph.nodes)) {
+    const targets = projectGraph.nodes[projectName].data.targets ?? {};
+    for (const targetName of Object.keys(targets)) {
+      ids.push(`${projectName}:${targetName}`);
+    }
+  }
+  return ids;
+}
+
+/**
+ * A target (and even a configuration) name can legally contain ':'. When the
+ * user typos such a name, `splitTarget` splits on every ':' and parses the
+ * trailing segment(s) as separate parts (e.g. `nx:zzcustom:variantt` becomes
+ * project `nx`, target `zzcustom`, configuration `variantt`).
+ *
+ * To match the real name we therefore try the fully-rejoined specifier first,
+ * then progressively shorter forms. Rejoining wins for colon-containing names,
+ * while the shorter forms keep matching genuine `target` + `configuration`
+ * typos (where the real target name does not carry the configuration suffix).
+ */
+function findClosestSpecifier(
+  parts: (string | undefined)[],
+  candidates: readonly string[],
+  limit = 1
+): string[] {
+  const present = parts.filter((part): part is string => !!part);
+  for (let end = present.length; end >= 1; end--) {
+    const matches = findClosestMatches(
+      present.slice(0, end).join(':'),
+      candidates,
+      limit
+    );
+    if (matches.length) {
+      return matches;
+    }
+  }
+  return [];
+}
+
+/**
+ * Lists up to `MAX_LISTED_TARGETS` targets, appending a "...and N more" line
+ * when the project has more targets than we show.
+ */
+function formatAvailableTargets(availableTargets: string[]): string[] {
+  const sorted = [...availableTargets].sort();
+  const shown = sorted.slice(0, MAX_LISTED_TARGETS);
+  const lines = ['Available targets:', ...shown.map((t) => `  - ${t}`)];
+  if (sorted.length > shown.length) {
+    lines.push(`  ...and ${sorted.length - shown.length} more`);
+  }
+  return lines;
+}
+
+/**
+ * Builds the error shown when the project itself can't be found. Matches the
+ * attempted `project:target[:configuration]` against every runnable task id so
+ * a project typo (e.g. `webpai:build`) still surfaces the intended task
+ * (`webapi:build`).
+ */
+export function getCannotFindProjectError(
+  projectGraph: ProjectGraph,
+  projectName: string,
+  target: string,
+  configuration?: string
+): { title: string; bodyLines: string[] } {
+  const bodyLines: string[] = [];
+  const suggestions = findClosestSpecifier(
+    [projectName, target, configuration],
+    getProjectTargetIds(projectGraph),
+    MAX_SUGGESTIONS
+  );
+  if (suggestions.length) {
+    bodyLines.push(
+      'Did you mean one of these?',
+      ...suggestions.map((id) => `  - ${id}`)
+    );
+  }
+
+  return {
+    title: `Cannot find project '${projectName}'`,
+    bodyLines,
+  };
+}
+
+/**
+ * Validates that `target` exists on the resolved project. When it does not,
+ * returns an error describing the available targets (and the closest match, if
+ * any) so the user can recover from a typo or discover what they can run.
+ */
+export function getRunOneTargetError(
+  project: ProjectGraphProjectNode,
+  target: string,
+  configuration?: string
+): { title: string; bodyLines: string[] } | null {
+  const availableTargets = Object.keys(project.data.targets ?? {});
+  if (availableTargets.includes(target)) {
+    return null;
+  }
+
+  const bodyLines: string[] = [];
+  const [closestMatch] = findClosestSpecifier(
+    [target, configuration],
+    availableTargets
+  );
+  if (closestMatch) {
+    bodyLines.push(`Did you mean "${closestMatch}"?`, '');
+  }
+
+  if (availableTargets.length) {
+    bodyLines.push(...formatAvailableTargets(availableTargets));
+  } else {
+    bodyLines.push(
+      `The project "${project.name}" does not have any targets configured.`
+    );
+  }
+
+  return {
+    title: `Cannot find target "${target}" for project "${project.name}"`,
+    bodyLines,
+  };
 }
 
 const targetAliases = {

--- a/packages/nx/src/command-line/run/run-one.ts
+++ b/packages/nx/src/command-line/run/run-one.ts
@@ -21,7 +21,8 @@ import { output } from '../../utils/output';
 import { splitTarget } from '../../utils/split-target';
 import {
   findClosestMatches,
-  levenshteinDistance,
+  isWithinSuggestionThreshold,
+  rankByDistance,
 } from '../../utils/string-similarity';
 import { workspaceRoot } from '../../utils/workspace-root';
 import { generateGraph } from '../graph/graph';
@@ -220,26 +221,55 @@ function findClosestSpecifier(
 }
 
 /**
- * Lists up to `MAX_LISTED_TARGETS` targets, ordered by how closely they resemble
- * the target the user typed (closest first, ties broken alphabetically) so the
- * most likely intended targets surface first. `closestMatch` is omitted because
- * it is already surfaced separately as the "Did you mean" suggestion. Appends a
- * "...and N more" line when the project has more targets than we show.
+ * Finds the closest available target to what the user typed, staying
+ * config-aware. When a configuration was parsed off the specifier, the rejoined
+ * `target:configuration` is tried first so a colon-containing real target name
+ * (e.g. `zzcustom:variant`) still matches. The bare-`target` tier reuses the
+ * precomputed `ranked` list (its head, gated by the suggestion threshold)
+ * instead of recomputing distances, matching `findClosestSpecifier`'s
+ * progressive-join preference order for these two tiers.
+ */
+function findClosestTarget(
+  target: string,
+  configuration: string | undefined,
+  availableTargets: readonly string[],
+  ranked: { candidate: string; distance: number }[]
+): string | undefined {
+  if (configuration) {
+    const [rejoined] = findClosestMatches(
+      `${target}:${configuration}`,
+      availableTargets,
+      1
+    );
+    if (rejoined) {
+      return rejoined;
+    }
+  }
+  const nearest = ranked[0];
+  return nearest && isWithinSuggestionThreshold(target, nearest.distance)
+    ? nearest.candidate
+    : undefined;
+}
+
+/**
+ * Lists up to `MAX_LISTED_TARGETS` targets from a list already ranked by how
+ * closely they resemble the target the user typed (closest first, ties broken
+ * alphabetically) so the most likely intended targets surface first.
+ * `closestMatch` is dropped because it is already surfaced separately as the
+ * "Did you mean" suggestion. Appends a "...and N more" line when the project has
+ * more targets than we show.
  */
 function formatAvailableTargets(
-  availableTargets: string[],
-  target: string,
+  ranked: { candidate: string; distance: number }[],
   closestMatch?: string
 ): string[] {
-  const sorted = availableTargets
-    .filter((t) => t !== closestMatch)
-    .map((t) => ({ target: t, distance: levenshteinDistance(target, t) }))
-    .sort((a, b) => a.distance - b.distance || a.target.localeCompare(b.target))
-    .map(({ target }) => target);
-  const shown = sorted.slice(0, MAX_LISTED_TARGETS);
+  const targets = ranked
+    .map(({ candidate }) => candidate)
+    .filter((candidate) => candidate !== closestMatch);
+  const shown = targets.slice(0, MAX_LISTED_TARGETS);
   const lines = ['Available targets:', ...shown.map((t) => `  - ${t}`)];
-  if (sorted.length > shown.length) {
-    lines.push(`  ...and ${sorted.length - shown.length} more`);
+  if (targets.length > shown.length) {
+    lines.push(`  ...and ${targets.length - shown.length} more`);
   }
   return lines;
 }
@@ -291,18 +321,22 @@ export function getRunOneTargetError(
   }
 
   const bodyLines: string[] = [];
-  const [closestMatch] = findClosestSpecifier(
-    [target, configuration],
-    availableTargets
+  // Rank the available targets by distance to the bare target ONCE. This drives
+  // the ordered "Available targets" block and doubles as the bare-target tier of
+  // the closest-match lookup, so distances are not computed twice.
+  const ranked = rankByDistance(target, availableTargets);
+  const closestMatch = findClosestTarget(
+    target,
+    configuration,
+    availableTargets,
+    ranked
   );
   if (closestMatch) {
     bodyLines.push(`Did you mean "${closestMatch}"?`, '');
   }
 
   if (availableTargets.length) {
-    bodyLines.push(
-      ...formatAvailableTargets(availableTargets, target, closestMatch)
-    );
+    bodyLines.push(...formatAvailableTargets(ranked, closestMatch));
   } else {
     bodyLines.push(
       `The project "${project.name}" does not have any targets configured.`

--- a/packages/nx/src/command-line/run/run-one.ts
+++ b/packages/nx/src/command-line/run/run-one.ts
@@ -19,7 +19,10 @@ import {
 import { findMatchingProjects } from '../../utils/find-matching-projects';
 import { output } from '../../utils/output';
 import { splitTarget } from '../../utils/split-target';
-import { findClosestMatches } from '../../utils/string-similarity';
+import {
+  findClosestMatches,
+  levenshteinDistance,
+} from '../../utils/string-similarity';
 import { workspaceRoot } from '../../utils/workspace-root';
 import { generateGraph } from '../graph/graph';
 import { connectToNxCloudIfExplicitlyAsked } from '../nx-cloud/connect/connect-to-nx-cloud';
@@ -217,11 +220,22 @@ function findClosestSpecifier(
 }
 
 /**
- * Lists up to `MAX_LISTED_TARGETS` targets, appending a "...and N more" line
- * when the project has more targets than we show.
+ * Lists up to `MAX_LISTED_TARGETS` targets, ordered by how closely they resemble
+ * the target the user typed (closest first, ties broken alphabetically) so the
+ * most likely intended targets surface first. `closestMatch` is omitted because
+ * it is already surfaced separately as the "Did you mean" suggestion. Appends a
+ * "...and N more" line when the project has more targets than we show.
  */
-function formatAvailableTargets(availableTargets: string[]): string[] {
-  const sorted = [...availableTargets].sort();
+function formatAvailableTargets(
+  availableTargets: string[],
+  target: string,
+  closestMatch?: string
+): string[] {
+  const sorted = availableTargets
+    .filter((t) => t !== closestMatch)
+    .map((t) => ({ target: t, distance: levenshteinDistance(target, t) }))
+    .sort((a, b) => a.distance - b.distance || a.target.localeCompare(b.target))
+    .map(({ target }) => target);
   const shown = sorted.slice(0, MAX_LISTED_TARGETS);
   const lines = ['Available targets:', ...shown.map((t) => `  - ${t}`)];
   if (sorted.length > shown.length) {
@@ -286,7 +300,9 @@ export function getRunOneTargetError(
   }
 
   if (availableTargets.length) {
-    bodyLines.push(...formatAvailableTargets(availableTargets));
+    bodyLines.push(
+      ...formatAvailableTargets(availableTargets, target, closestMatch)
+    );
   } else {
     bodyLines.push(
       `The project "${project.name}" does not have any targets configured.`

--- a/packages/nx/src/command-line/run/run-one.ts
+++ b/packages/nx/src/command-line/run/run-one.ts
@@ -19,6 +19,7 @@ import {
 import { findMatchingProjects } from '../../utils/find-matching-projects';
 import { output } from '../../utils/output';
 import { splitTarget } from '../../utils/split-target';
+import { findClosestMatches } from '../../utils/string-similarity';
 import { workspaceRoot } from '../../utils/workspace-root';
 import { generateGraph } from '../graph/graph';
 import { connectToNxCloudIfExplicitlyAsked } from '../nx-cloud/connect/connect-to-nx-cloud';
@@ -57,7 +58,22 @@ export async function runOne(
     nxJson
   );
 
-  const { projects, projectName } = getProjects(projectGraph, opts.project);
+  const { projects, projectName } = getProjects(
+    projectGraph,
+    opts.project,
+    opts.target,
+    opts.configuration
+  );
+
+  const targetError = getRunOneTargetError(
+    projects[0],
+    opts.target,
+    opts.configuration
+  );
+  if (targetError) {
+    output.error(targetError);
+    process.exit(1);
+  }
 
   if (nxArgs.help) {
     await (
@@ -107,7 +123,9 @@ export async function runOne(
 
 function getProjects(
   projectGraph: ProjectGraph,
-  projectName: string
+  projectName: string,
+  target: string,
+  configuration?: string
 ): {
   projectName: string;
   projects: ProjectGraphProjectNode[];
@@ -143,10 +161,142 @@ function getProjects(
     }
   }
 
-  output.error({
-    title: `Cannot find project '${projectName}'`,
-  });
+  output.error(
+    getCannotFindProjectError(projectGraph, projectName, target, configuration)
+  );
   process.exit(1);
+}
+
+// Keep error output scannable: only show a handful of targets/suggestions.
+const MAX_LISTED_TARGETS = 5;
+const MAX_SUGGESTIONS = 3;
+
+/**
+ * Builds the list of all runnable `project:target` task ids in the workspace,
+ * used to suggest the right invocation when a project or target can't be found.
+ */
+function getProjectTargetIds(projectGraph: ProjectGraph): string[] {
+  const ids: string[] = [];
+  for (const projectName of Object.keys(projectGraph.nodes)) {
+    const targets = projectGraph.nodes[projectName].data.targets ?? {};
+    for (const targetName of Object.keys(targets)) {
+      ids.push(`${projectName}:${targetName}`);
+    }
+  }
+  return ids;
+}
+
+/**
+ * A target (and even a configuration) name can legally contain ':'. When the
+ * user typos such a name, `splitTarget` splits on every ':' and parses the
+ * trailing segment(s) as separate parts (e.g. `nx:zzcustom:variantt` becomes
+ * project `nx`, target `zzcustom`, configuration `variantt`).
+ *
+ * To match the real name we therefore try the fully-rejoined specifier first,
+ * then progressively shorter forms. Rejoining wins for colon-containing names,
+ * while the shorter forms keep matching genuine `target` + `configuration`
+ * typos (where the real target name does not carry the configuration suffix).
+ */
+function findClosestSpecifier(
+  parts: (string | undefined)[],
+  candidates: readonly string[],
+  limit = 1
+): string[] {
+  const present = parts.filter((part): part is string => !!part);
+  for (let end = present.length; end >= 1; end--) {
+    const matches = findClosestMatches(
+      present.slice(0, end).join(':'),
+      candidates,
+      limit
+    );
+    if (matches.length) {
+      return matches;
+    }
+  }
+  return [];
+}
+
+/**
+ * Lists up to `MAX_LISTED_TARGETS` targets, appending a "...and N more" line
+ * when the project has more targets than we show.
+ */
+function formatAvailableTargets(availableTargets: string[]): string[] {
+  const sorted = [...availableTargets].sort();
+  const shown = sorted.slice(0, MAX_LISTED_TARGETS);
+  const lines = ['Available targets:', ...shown.map((t) => `  - ${t}`)];
+  if (sorted.length > shown.length) {
+    lines.push(`  ...and ${sorted.length - shown.length} more`);
+  }
+  return lines;
+}
+
+/**
+ * Builds the error shown when the project itself can't be found. Matches the
+ * attempted `project:target[:configuration]` against every runnable task id so
+ * a project typo (e.g. `webpai:build`) still surfaces the intended task
+ * (`webapi:build`).
+ */
+export function getCannotFindProjectError(
+  projectGraph: ProjectGraph,
+  projectName: string,
+  target: string,
+  configuration?: string
+): { title: string; bodyLines: string[] } {
+  const bodyLines: string[] = [];
+  const suggestions = findClosestSpecifier(
+    [projectName, target, configuration],
+    getProjectTargetIds(projectGraph),
+    MAX_SUGGESTIONS
+  );
+  if (suggestions.length) {
+    bodyLines.push(
+      'Did you mean one of these?',
+      ...suggestions.map((id) => `  - ${id}`)
+    );
+  }
+
+  return {
+    title: `Cannot find project '${projectName}'`,
+    bodyLines,
+  };
+}
+
+/**
+ * Validates that `target` exists on the resolved project. When it does not,
+ * returns an error describing the available targets (and the closest match, if
+ * any) so the user can recover from a typo or discover what they can run.
+ */
+export function getRunOneTargetError(
+  project: ProjectGraphProjectNode,
+  target: string,
+  configuration?: string
+): { title: string; bodyLines: string[] } | null {
+  const availableTargets = Object.keys(project.data.targets ?? {});
+  if (availableTargets.includes(target)) {
+    return null;
+  }
+
+  const bodyLines: string[] = [];
+  const [closestMatch] = findClosestSpecifier(
+    [target, configuration],
+    availableTargets
+  );
+  if (closestMatch) {
+    bodyLines.push(`Did you mean "${closestMatch}"?`, '');
+  }
+
+  if (availableTargets.length) {
+    bodyLines.push(...formatAvailableTargets(availableTargets));
+  } else {
+    bodyLines.push(
+      `The project "${project.name}" does not have any targets configured.`
+    );
+  }
+
+  return {
+    title: `Cannot find target "${target}" for project "${project.name}"`,
+    bodyLines,
+  };
 }
 
 const targetAliases = {

--- a/packages/nx/src/command-line/run/run-one.ts
+++ b/packages/nx/src/command-line/run/run-one.ts
@@ -20,9 +20,9 @@ import { findMatchingProjects } from '../../utils/find-matching-projects';
 import { output } from '../../utils/output';
 import { splitTarget } from '../../utils/split-target';
 import {
-  findClosestMatches,
   isWithinSuggestionThreshold,
   rankByDistance,
+  rankSuggestions,
 } from '../../utils/string-similarity';
 import { workspaceRoot } from '../../utils/workspace-root';
 import { generateGraph } from '../graph/graph';
@@ -196,10 +196,12 @@ function getProjectTargetIds(projectGraph: ProjectGraph): string[] {
  * trailing segment(s) as separate parts (e.g. `nx:zzcustom:variantt` becomes
  * project `nx`, target `zzcustom`, configuration `variantt`).
  *
- * To match the real name we therefore try the fully-rejoined specifier first,
- * then progressively shorter forms. Rejoining wins for colon-containing names,
- * while the shorter forms keep matching genuine `target` + `configuration`
- * typos (where the real target name does not carry the configuration suffix).
+ * To match the real name we therefore score the fully-rejoined specifier and
+ * every progressively shorter form, and keep whichever produced the closest
+ * candidate. Rejoining wins for colon-containing names, while the shorter forms
+ * keep matching genuine `target` + `configuration` typos (where the real target
+ * name does not carry the configuration suffix). Ties go to the longer form,
+ * which is the one that reproduces the name the user actually typed.
  */
 function findClosestSpecifier(
   parts: (string | undefined)[],
@@ -207,27 +209,31 @@ function findClosestSpecifier(
   limit = 1
 ): string[] {
   const present = parts.filter((part): part is string => !!part);
+  let best: { candidate: string; distance: number }[] = [];
   for (let end = present.length; end >= 1; end--) {
-    const matches = findClosestMatches(
+    const matches = rankSuggestions(
       present.slice(0, end).join(':'),
-      candidates,
-      limit
+      candidates
     );
-    if (matches.length) {
-      return matches;
+    if (
+      matches.length &&
+      (!best.length || matches[0].distance < best[0].distance)
+    ) {
+      best = matches;
     }
   }
-  return [];
+  return best.slice(0, limit).map(({ candidate }) => candidate);
 }
 
 /**
  * Finds the closest available target to what the user typed, staying
  * config-aware. When a configuration was parsed off the specifier, the rejoined
- * `target:configuration` is tried first so a colon-containing real target name
- * (e.g. `zzcustom:variant`) still matches. The bare-`target` tier reuses the
+ * `target:configuration` is scored too, so a colon-containing real target name
+ * (e.g. `zzcustom:variant`) still matches. Both forms are scored and the closest
+ * candidate wins, ties going to the rejoined form -- mirroring
+ * `findClosestSpecifier`'s preference order. The bare-`target` tier reuses the
  * precomputed `ranked` list (its head, gated by the suggestion threshold)
- * instead of recomputing distances, matching `findClosestSpecifier`'s
- * progressive-join preference order for these two tiers.
+ * instead of recomputing distances.
  */
 function findClosestTarget(
   target: string,
@@ -235,20 +241,19 @@ function findClosestTarget(
   availableTargets: readonly string[],
   ranked: { candidate: string; distance: number }[]
 ): string | undefined {
+  let best: { candidate: string; distance: number } | undefined;
   if (configuration) {
-    const [rejoined] = findClosestMatches(
-      `${target}:${configuration}`,
-      availableTargets,
-      1
-    );
-    if (rejoined) {
-      return rejoined;
-    }
+    [best] = rankSuggestions(`${target}:${configuration}`, availableTargets);
   }
   const nearest = ranked[0];
-  return nearest && isWithinSuggestionThreshold(target, nearest.distance)
-    ? nearest.candidate
-    : undefined;
+  if (
+    nearest &&
+    isWithinSuggestionThreshold(target, nearest.candidate, nearest.distance) &&
+    (!best || nearest.distance < best.distance)
+  ) {
+    best = nearest;
+  }
+  return best?.candidate;
 }
 
 /**
@@ -257,7 +262,9 @@ function findClosestTarget(
  * alphabetically) so the most likely intended targets surface first.
  * `closestMatch` is dropped because it is already surfaced separately as the
  * "Did you mean" suggestion. Appends a "...and N more" line when the project has
- * more targets than we show.
+ * more targets than we show, and returns no lines at all when the suggestion was
+ * the project's only target -- a bare "Available targets:" header reads as "this
+ * project has none".
  */
 function formatAvailableTargets(
   ranked: { candidate: string; distance: number }[],
@@ -266,6 +273,9 @@ function formatAvailableTargets(
   const targets = ranked
     .map(({ candidate }) => candidate)
     .filter((candidate) => candidate !== closestMatch);
+  if (!targets.length) {
+    return [];
+  }
   const shown = targets.slice(0, MAX_LISTED_TARGETS);
   const lines = ['Available targets:', ...shown.map((t) => `  - ${t}`)];
   if (targets.length > shown.length) {
@@ -332,15 +342,21 @@ export function getRunOneTargetError(
     ranked
   );
   if (closestMatch) {
-    bodyLines.push(`Did you mean "${closestMatch}"?`, '');
+    bodyLines.push(`Did you mean "${closestMatch}"?`);
   }
 
-  if (availableTargets.length) {
-    bodyLines.push(...formatAvailableTargets(ranked, closestMatch));
-  } else {
+  if (!availableTargets.length) {
     bodyLines.push(
       `The project "${project.name}" does not have any targets configured.`
     );
+  } else {
+    const targetLines = formatAvailableTargets(ranked, closestMatch);
+    if (targetLines.length) {
+      if (bodyLines.length) {
+        bodyLines.push('');
+      }
+      bodyLines.push(...targetLines);
+    }
   }
 
   return {

--- a/packages/nx/src/utils/string-similarity.spec.ts
+++ b/packages/nx/src/utils/string-similarity.spec.ts
@@ -1,4 +1,9 @@
-import { findClosestMatch, findClosestMatches } from './string-similarity';
+import {
+  findClosestMatch,
+  findClosestMatches,
+  isWithinSuggestionThreshold,
+  rankByDistance,
+} from './string-similarity';
 
 describe('findClosestMatch', () => {
   it('should return the closest candidate for a small typo', () => {
@@ -52,12 +57,47 @@ describe('findClosestMatches', () => {
   });
 });
 
+describe('rankByDistance', () => {
+  it('sorts candidates by ascending edit distance', () => {
+    const ranked = rankByDistance('build', ['built', 'xxxxx', 'build']);
+
+    expect(ranked.map((r) => r.candidate)).toEqual(['build', 'built', 'xxxxx']);
+    expect(ranked[0].distance).toBe(0);
+  });
+
+  it('breaks ties alphabetically', () => {
+    // "serve" and "clean" are both edit distance 5 from "build"; the
+    // alphabetical tie-break puts "clean" first regardless of input order.
+    const ranked = rankByDistance('build', ['serve', 'clean']);
+
+    expect(ranked.map((r) => r.candidate)).toEqual(['clean', 'serve']);
+    expect(ranked[0].distance).toBe(ranked[1].distance);
+  });
+
+  it('returns an empty array when there are no candidates', () => {
+    expect(rankByDistance('build', [])).toEqual([]);
+  });
+});
+
+describe('isWithinSuggestionThreshold', () => {
+  it('accepts distances up to the length-scaled threshold', () => {
+    // "biuld" (length 5) -> threshold = max(2, ceil(5 * 0.4)) = 2.
+    expect(isWithinSuggestionThreshold('biuld', 2)).toBe(true);
+    expect(isWithinSuggestionThreshold('biuld', 3)).toBe(false);
+  });
+
+  it('never drops below a floor of 2 for short inputs', () => {
+    // "ab" (length 2) -> ceil(0.8) = 1, but the floor keeps it at 2.
+    expect(isWithinSuggestionThreshold('ab', 2)).toBe(true);
+  });
+});
+
 describe('suggestion performance', () => {
-  it('stays fast when suggesting against a massive workspace', () => {
+  it('stays fast when ranking against a massive workspace', () => {
     // Simulate a very large workspace: thousands of projects, each with a
     // handful of targets, producing tens of thousands of candidate task ids.
     // Target suggestions only run once per failed command, but a huge workspace
-    // must not make that computation noticeably slow.
+    // must not make ranking (the shared hot path) noticeably slow.
     const targetNames = ['build', 'test', 'lint', 'serve', 'e2e'];
     const candidates: string[] = [];
     for (let i = 0; i < 5000; i++) {
@@ -68,14 +108,14 @@ describe('suggestion performance', () => {
     expect(candidates.length).toBe(25000);
 
     const start = performance.now();
-    const matches = findClosestMatches('project-1234:biuld', candidates);
+    const ranked = rankByDistance('project-1234:biuld', candidates);
     const durationMs = performance.now() - start;
 
     // Generous bound: the computation is trivial in practice (well under
     // 100ms), so approaching this bound signals a real algorithmic regression
     // rather than a loaded CI machine.
     expect(durationMs).toBeLessThan(2000);
-    // Sanity check that it still surfaces the intended task id at scale.
-    expect(matches).toContain('project-1234:build');
+    // Sanity check that the intended task id ranks first at scale.
+    expect(ranked[0].candidate).toBe('project-1234:build');
   });
 });

--- a/packages/nx/src/utils/string-similarity.spec.ts
+++ b/packages/nx/src/utils/string-similarity.spec.ts
@@ -51,3 +51,31 @@ describe('findClosestMatches', () => {
     expect(findClosestMatches('build', [])).toEqual([]);
   });
 });
+
+describe('suggestion performance', () => {
+  it('stays fast when suggesting against a massive workspace', () => {
+    // Simulate a very large workspace: thousands of projects, each with a
+    // handful of targets, producing tens of thousands of candidate task ids.
+    // Target suggestions only run once per failed command, but a huge workspace
+    // must not make that computation noticeably slow.
+    const targetNames = ['build', 'test', 'lint', 'serve', 'e2e'];
+    const candidates: string[] = [];
+    for (let i = 0; i < 5000; i++) {
+      for (const targetName of targetNames) {
+        candidates.push(`project-${i}:${targetName}`);
+      }
+    }
+    expect(candidates.length).toBe(25000);
+
+    const start = performance.now();
+    const matches = findClosestMatches('project-1234:biuld', candidates);
+    const durationMs = performance.now() - start;
+
+    // Generous bound: the computation is trivial in practice (well under
+    // 100ms), so approaching this bound signals a real algorithmic regression
+    // rather than a loaded CI machine.
+    expect(durationMs).toBeLessThan(2000);
+    // Sanity check that it still surfaces the intended task id at scale.
+    expect(matches).toContain('project-1234:build');
+  });
+});

--- a/packages/nx/src/utils/string-similarity.spec.ts
+++ b/packages/nx/src/utils/string-similarity.spec.ts
@@ -1,0 +1,53 @@
+import { findClosestMatch, findClosestMatches } from './string-similarity';
+
+describe('findClosestMatch', () => {
+  it('should return the closest candidate for a small typo', () => {
+    expect(findClosestMatch('biuld', ['build', 'serve', 'test'])).toBe('build');
+  });
+
+  it('should return the closest candidate for a missing character', () => {
+    expect(findClosestMatch('serv', ['build', 'serve', 'test'])).toBe('serve');
+  });
+
+  it('should return undefined when nothing is reasonably close', () => {
+    expect(findClosestMatch('xyz', ['build', 'serve', 'test'])).toBeUndefined();
+  });
+
+  it('should return undefined when there are no candidates', () => {
+    expect(findClosestMatch('build', [])).toBeUndefined();
+  });
+
+  it('should return an exact match', () => {
+    expect(findClosestMatch('build', ['build', 'serve'])).toBe('build');
+  });
+
+  it('should prefer the closer of two candidates', () => {
+    expect(findClosestMatch('tes', ['test', 'lint'])).toBe('test');
+  });
+});
+
+describe('findClosestMatches', () => {
+  it('should match the right project:target task id despite a project typo', () => {
+    expect(
+      findClosestMatches('webpai:build', [
+        'webapi:build',
+        'webapi:serve',
+        'other:test',
+      ])
+    ).toEqual(['webapi:build']);
+  });
+
+  it('should return matches sorted by closeness and capped to the limit', () => {
+    expect(
+      findClosestMatches('buil', ['build', 'built', 'bull', 'xxxx'], 2)
+    ).toEqual(['build', 'built']);
+  });
+
+  it('should return an empty array when nothing is close enough', () => {
+    expect(findClosestMatches('xyz', ['build', 'serve', 'test'])).toEqual([]);
+  });
+
+  it('should return an empty array when there are no candidates', () => {
+    expect(findClosestMatches('build', [])).toEqual([]);
+  });
+});

--- a/packages/nx/src/utils/string-similarity.spec.ts
+++ b/packages/nx/src/utils/string-similarity.spec.ts
@@ -1,37 +1,38 @@
 import {
-  findClosestMatch,
   findClosestMatches,
   isWithinSuggestionThreshold,
   rankByDistance,
 } from './string-similarity';
 
-describe('findClosestMatch', () => {
+describe('findClosestMatches', () => {
   it('should return the closest candidate for a small typo', () => {
-    expect(findClosestMatch('biuld', ['build', 'serve', 'test'])).toBe('build');
+    expect(findClosestMatches('biuld', ['build', 'serve', 'test'], 1)).toEqual([
+      'build',
+    ]);
   });
 
   it('should return the closest candidate for a missing character', () => {
-    expect(findClosestMatch('serv', ['build', 'serve', 'test'])).toBe('serve');
+    expect(findClosestMatches('serv', ['build', 'serve', 'test'], 1)).toEqual([
+      'serve',
+    ]);
   });
 
-  it('should return undefined when nothing is reasonably close', () => {
-    expect(findClosestMatch('xyz', ['build', 'serve', 'test'])).toBeUndefined();
-  });
-
-  it('should return undefined when there are no candidates', () => {
-    expect(findClosestMatch('build', [])).toBeUndefined();
+  it('should return nothing when nothing is reasonably close', () => {
+    expect(findClosestMatches('xyz', ['build', 'serve', 'test'], 1)).toEqual(
+      []
+    );
   });
 
   it('should return an exact match', () => {
-    expect(findClosestMatch('build', ['build', 'serve'])).toBe('build');
+    expect(findClosestMatches('build', ['build', 'serve'], 1)).toEqual([
+      'build',
+    ]);
   });
 
   it('should prefer the closer of two candidates', () => {
-    expect(findClosestMatch('tes', ['test', 'lint'])).toBe('test');
+    expect(findClosestMatches('tes', ['test', 'lint'], 1)).toEqual(['test']);
   });
-});
 
-describe('findClosestMatches', () => {
   it('should match the right project:target task id despite a project typo', () => {
     expect(
       findClosestMatches('webpai:build', [
@@ -54,6 +55,14 @@ describe('findClosestMatches', () => {
 
   it('should return an empty array when there are no candidates', () => {
     expect(findClosestMatches('build', [])).toEqual([]);
+  });
+
+  it('should not suggest task ids that differ only in the segment the user typed correctly', () => {
+    // "zzz" has nothing in common with any of the projects; the shared ":build"
+    // must not buy the project segment a bigger typo budget.
+    expect(
+      findClosestMatches('zzz:build', ['api:build', 'web:build', 'docs:build'])
+    ).toEqual([]);
   });
 });
 
@@ -81,14 +90,48 @@ describe('rankByDistance', () => {
 
 describe('isWithinSuggestionThreshold', () => {
   it('accepts distances up to the length-scaled threshold', () => {
-    // "biuld" (length 5) -> threshold = max(2, ceil(5 * 0.4)) = 2.
-    expect(isWithinSuggestionThreshold('biuld', 2)).toBe(true);
-    expect(isWithinSuggestionThreshold('biuld', 3)).toBe(false);
+    // "biuld"/"build" share "b" and "ld", leaving 2 differing characters ->
+    // threshold = max(2, ceil(2 * 0.4)) = 2.
+    expect(isWithinSuggestionThreshold('biuld', 'build', 2)).toBe(true);
+    expect(isWithinSuggestionThreshold('biuld', 'build', 3)).toBe(false);
+  });
+
+  it('scales the tolerance with the length of the differing part', () => {
+    // Nothing is shared at either end, so the whole 18-character input differs
+    // -> threshold = max(2, ceil(18 * 0.4)) = 8.
+    expect(
+      isWithinSuggestionThreshold(
+        'documentation-site',
+        'legacy-admin-portal',
+        8
+      )
+    ).toBe(true);
+    expect(
+      isWithinSuggestionThreshold(
+        'documentation-site',
+        'legacy-admin-portal',
+        9
+      )
+    ).toBe(false);
+  });
+
+  it('sizes the tolerance from the differing part, not the whole input', () => {
+    // "zzz:build" and "api:build" are 3 edits apart, but only the 3-character
+    // project segment differs. Budgeting on the full 9-character length would
+    // allow 4 edits and suggest a project with no character in common.
+    expect(isWithinSuggestionThreshold('zzz:build', 'api:build', 3)).toBe(
+      false
+    );
+    // Same input, same distance, but now nothing is shared at either end, so
+    // the length-scaled tolerance genuinely applies.
+    expect(isWithinSuggestionThreshold('zzz:build', 'qwertyuio', 3)).toBe(true);
   });
 
   it('never drops below a floor of 2 for short inputs', () => {
-    // "ab" (length 2) -> ceil(0.8) = 1, but the floor keeps it at 2.
-    expect(isWithinSuggestionThreshold('ab', 2)).toBe(true);
+    // "ab"/"cd" differ over 2 characters -> ceil(0.8) = 1, but the floor keeps
+    // it at 2.
+    expect(isWithinSuggestionThreshold('ab', 'cd', 2)).toBe(true);
+    expect(isWithinSuggestionThreshold('ab', 'cd', 3)).toBe(false);
   });
 });
 
@@ -111,9 +154,10 @@ describe('suggestion performance', () => {
     const ranked = rankByDistance('project-1234:biuld', candidates);
     const durationMs = performance.now() - start;
 
-    // Generous bound: the computation is trivial in practice (well under
-    // 100ms), so approaching this bound signals a real algorithmic regression
-    // rather than a loaded CI machine.
+    // Generous bound. The ranking itself takes ~60ms of real work, but under
+    // the test runner's transpiled/instrumented execution the same call is
+    // measured at ~1s, so the bound has to leave room for that overhead --
+    // do not tighten it towards the raw number.
     expect(durationMs).toBeLessThan(2000);
     // Sanity check that the intended task id ranks first at scale.
     expect(ranked[0].candidate).toBe('project-1234:build');

--- a/packages/nx/src/utils/string-similarity.ts
+++ b/packages/nx/src/utils/string-similarity.ts
@@ -1,0 +1,68 @@
+/**
+ * Computes the Levenshtein edit distance between two strings, i.e. the minimum
+ * number of single-character insertions, deletions, or substitutions required
+ * to turn `a` into `b`.
+ */
+export function levenshteinDistance(a: string, b: string): number {
+  if (a === b) {
+    return 0;
+  }
+  if (a.length === 0) {
+    return b.length;
+  }
+  if (b.length === 0) {
+    return a.length;
+  }
+
+  let previousRow = Array.from({ length: b.length + 1 }, (_, i) => i);
+  let currentRow = new Array<number>(b.length + 1);
+
+  for (let i = 0; i < a.length; i++) {
+    currentRow[0] = i + 1;
+    for (let j = 0; j < b.length; j++) {
+      const cost = a[i] === b[j] ? 0 : 1;
+      currentRow[j + 1] = Math.min(
+        currentRow[j] + 1, // insertion
+        previousRow[j + 1] + 1, // deletion
+        previousRow[j] + cost // substitution
+      );
+    }
+    [previousRow, currentRow] = [currentRow, previousRow];
+  }
+
+  return previousRow[b.length];
+}
+
+/**
+ * Returns up to `limit` candidates that most closely resemble `input`, sorted
+ * from closest to furthest. Candidates that are not similar enough to be a
+ * useful suggestion are excluded. The tolerance scales with the length of
+ * `input` so that longer words allow for more typos.
+ */
+export function findClosestMatches(
+  input: string,
+  candidates: readonly string[],
+  limit = 3
+): string[] {
+  const threshold = Math.max(2, Math.ceil(input.length * 0.4));
+  return candidates
+    .map((candidate) => ({
+      candidate,
+      distance: levenshteinDistance(input, candidate),
+    }))
+    .filter(({ distance }) => distance <= threshold)
+    .sort((a, b) => a.distance - b.distance)
+    .slice(0, limit)
+    .map(({ candidate }) => candidate);
+}
+
+/**
+ * Returns the candidate that most closely resembles `input`, or `undefined`
+ * when no candidate is similar enough to be a useful suggestion.
+ */
+export function findClosestMatch(
+  input: string,
+  candidates: readonly string[]
+): string | undefined {
+  return findClosestMatches(input, candidates, 1)[0];
+}

--- a/packages/nx/src/utils/string-similarity.ts
+++ b/packages/nx/src/utils/string-similarity.ts
@@ -34,6 +34,40 @@ export function levenshteinDistance(a: string, b: string): number {
 }
 
 /**
+ * Ranks every candidate by how closely it resembles `input`, from closest to
+ * furthest, tie-broken alphabetically so the order is deterministic. Each entry
+ * keeps its computed distance so callers can reuse it (e.g. to both pick the
+ * closest match and order a list) without recomputing.
+ */
+export function rankByDistance(
+  input: string,
+  candidates: readonly string[]
+): { candidate: string; distance: number }[] {
+  return candidates
+    .map((candidate) => ({
+      candidate,
+      distance: levenshteinDistance(input, candidate),
+    }))
+    .sort(
+      (a, b) =>
+        a.distance - b.distance || a.candidate.localeCompare(b.candidate)
+    );
+}
+
+/**
+ * Whether a candidate at edit `distance` from `input` is close enough to be a
+ * useful suggestion. The tolerance scales with the length of `input` so that
+ * longer words allow for more typos. Exposed so callers that already have a
+ * distance (e.g. from `rankByDistance`) can gate on it without recomputing.
+ */
+export function isWithinSuggestionThreshold(
+  input: string,
+  distance: number
+): boolean {
+  return distance <= Math.max(2, Math.ceil(input.length * 0.4));
+}
+
+/**
  * Returns up to `limit` candidates that most closely resemble `input`, sorted
  * from closest to furthest. Candidates that are not similar enough to be a
  * useful suggestion are excluded. The tolerance scales with the length of
@@ -44,14 +78,8 @@ export function findClosestMatches(
   candidates: readonly string[],
   limit = 3
 ): string[] {
-  const threshold = Math.max(2, Math.ceil(input.length * 0.4));
-  return candidates
-    .map((candidate) => ({
-      candidate,
-      distance: levenshteinDistance(input, candidate),
-    }))
-    .filter(({ distance }) => distance <= threshold)
-    .sort((a, b) => a.distance - b.distance)
+  return rankByDistance(input, candidates)
+    .filter(({ distance }) => isWithinSuggestionThreshold(input, distance))
     .slice(0, limit)
     .map(({ candidate }) => candidate);
 }

--- a/packages/nx/src/utils/string-similarity.ts
+++ b/packages/nx/src/utils/string-similarity.ts
@@ -55,42 +55,77 @@ export function rankByDistance(
 }
 
 /**
+ * The number of edits tolerated before `candidate` stops being a useful
+ * suggestion for `input`.
+ *
+ * The tolerance scales with length so longer words allow for more typos, but it
+ * scales with the length of the part that actually *differs* — the shared
+ * prefix and suffix are stripped first. Scaling on the raw length lets text the
+ * user typed correctly buy a bigger budget for the part they got wrong, which
+ * matters because these inputs are joined `project:target[:configuration]`
+ * specifiers: `zzz:build` and `api:build` are 3 edits apart, but the shared
+ * `:build` inflates the raw-length budget to 4 and a project name with no
+ * character in common gets suggested.
+ *
+ * Stripping a common prefix and suffix does not change the Levenshtein
+ * distance, so a caller's precomputed `distance` remains directly comparable.
+ */
+function suggestionThreshold(input: string, candidate: string): number {
+  const shortest = Math.min(input.length, candidate.length);
+  let prefix = 0;
+  while (prefix < shortest && input[prefix] === candidate[prefix]) {
+    prefix++;
+  }
+  let suffix = 0;
+  while (
+    suffix < shortest - prefix &&
+    input[input.length - 1 - suffix] ===
+      candidate[candidate.length - 1 - suffix]
+  ) {
+    suffix++;
+  }
+  return Math.max(2, Math.ceil((input.length - prefix - suffix) * 0.4));
+}
+
+/**
  * Whether a candidate at edit `distance` from `input` is close enough to be a
- * useful suggestion. The tolerance scales with the length of `input` so that
- * longer words allow for more typos. Exposed so callers that already have a
- * distance (e.g. from `rankByDistance`) can gate on it without recomputing.
+ * useful suggestion. Exposed so callers that already have a distance (e.g. from
+ * `rankByDistance`) can gate on it without recomputing.
  */
 export function isWithinSuggestionThreshold(
   input: string,
+  candidate: string,
   distance: number
 ): boolean {
-  return distance <= Math.max(2, Math.ceil(input.length * 0.4));
+  return distance <= suggestionThreshold(input, candidate);
+}
+
+/**
+ * Ranks the candidates that are similar enough to `input` to be worth
+ * suggesting, closest first (ties broken alphabetically). Each entry keeps its
+ * distance so callers can compare suggestions found for different forms of the
+ * same input without recomputing.
+ */
+export function rankSuggestions(
+  input: string,
+  candidates: readonly string[]
+): { candidate: string; distance: number }[] {
+  return rankByDistance(input, candidates).filter(({ candidate, distance }) =>
+    isWithinSuggestionThreshold(input, candidate, distance)
+  );
 }
 
 /**
  * Returns up to `limit` candidates that most closely resemble `input`, sorted
  * from closest to furthest. Candidates that are not similar enough to be a
- * useful suggestion are excluded. The tolerance scales with the length of
- * `input` so that longer words allow for more typos.
+ * useful suggestion are excluded.
  */
 export function findClosestMatches(
   input: string,
   candidates: readonly string[],
   limit = 3
 ): string[] {
-  return rankByDistance(input, candidates)
-    .filter(({ distance }) => isWithinSuggestionThreshold(input, distance))
+  return rankSuggestions(input, candidates)
     .slice(0, limit)
     .map(({ candidate }) => candidate);
-}
-
-/**
- * Returns the candidate that most closely resembles `input`, or `undefined`
- * when no candidate is similar enough to be a useful suggestion.
- */
-export function findClosestMatch(
-  input: string,
-  candidates: readonly string[]
-): string | undefined {
-  return findClosestMatches(input, candidates, 1)[0];
 }


### PR DESCRIPTION
## Current Behavior

When `nx run` can't resolve the project or target, the error gives no guidance:

- Unknown target on a real project surfaces deep inside the task graph builder as a bare `Cannot find configuration for task <project>:<target>` — no list of what *is* available, no spelling help.
- Unknown project just prints `Cannot find project '<name>'` with no suggestion of what the user might have meant.
- A typo in a target/configuration that happens to contain a `:` (a legal target name in Nx) gets parsed into separate `target` + `configuration` parts by `splitTarget`, so any naive similarity match against the bare `target` can never find the real colon-containing name.

## Expected Behavior

`run-one` now validates the project and target up front and produces a friendly error before reaching the task-graph stage.

**Unknown target:**
```
 NX   Cannot find target "biuld" for project "my-app"

   Did you mean "build"?

   Available targets:
     - run
     - serve
```
- The suggested target is *not* repeated in the "Available targets" list — it is already surfaced on the `Did you mean` line. When the suggestion was the project's only target, the list is omitted entirely rather than printing a bare header.
- The available-targets list is capped at 5 with a `...and N more` line so output stays scannable on big projects.
- The `Did you mean` suggestion uses Levenshtein distance with a tolerance that scales with the length of the part of the input that actually differs from the candidate, so it stays silent for total nonsense — including the case where only one segment of a `project:target` id is wrong (`nx run zzz:build` suggests nothing rather than `api:build`).

**Unknown project — including a colon target:**
```
 NX   Cannot find project 'nxx'

   Did you mean one of these?
     - nx:zzcustom:variant
```
The attempted `project:target[:configuration]` is matched against every `project:target` task id in the graph, so project typos surface the real invocation (`webpai:build` → `webapi:build`), and project typos against colon-named targets still resolve (`nxx:zzcustom:variant` → `nx:zzcustom:variant`).

**Colon-containing target/configuration names:**
Because `splitTarget` parses the trailing segment off into a configuration, both error builders score the **fully rejoined** specifier *and* every progressively shorter form, then keep whichever produced the closest candidate (ties go to the longer form). So `nx:zzcustom:variantt` suggests `zzcustom:variant`, while genuine `target` + `configuration` typos (`biuld:production` → `build`) still match via the shorter form — and a near-exact shorter match is never demoted behind a worse rejoined one (`app:buld:storybook` suggests `build`, not `build-storybook`).

**Out of scope:** a typo in the *configuration* of a target that does exist (`nx run app:build:prodcution`) still falls through to the existing error — the target resolves, so this code path is never reached.

### Implementation notes
- New `packages/nx/src/utils/string-similarity.ts` with `rankByDistance` / `rankSuggestions` / `findClosestMatches` (Levenshtein + a tolerance scaled to the differing portion of the input).
- `run-one.ts` adds exported, unit-testable helpers `getRunOneTargetError` and `getCannotFindProjectError`, a shared `findClosestSpecifier` that scores every progressive join, and `formatAvailableTargets` for the capped list.
- Unit tests cover the new helpers (including the colon-target scenarios, the genuine target+config-typo fallback, the empty-list case, and the cross-form ranking). The existing `echo:fail` e2e is updated to assert the new message.
- Verified end-to-end against this repo's CLI with a temporary colon target.

## Related Issue(s)

<!-- No tracked issue; addresses a long-standing UX papercut around the run-one error. -->
