### PR TITLE
fix(core): use workspace package manager when fetching migrations via install

### DIFF
--- a/packages/devkit/src/utils/package-json.ts
+++ b/packages/devkit/src/utils/package-json.ts
@@ -1,6 +1,7 @@
 import { existsSync } from 'fs';
 import { Module } from 'module';
 import {
+  detectPackageManager,
   type GeneratorCallback,
   output,
   readJson,
@@ -908,7 +909,11 @@ export function ensurePackage<T extends any = any>(
     );
   }
 
-  const { tempDir } = installPackageToTmp(pkg, requiredVersion);
+  const { tempDir } = installPackageToTmp(
+    pkg,
+    requiredVersion,
+    detectPackageManager(workspaceRoot)
+  );
 
   addToNodePath(join(workspaceRoot, 'node_modules'));
   addToNodePath(join(tempDir, 'node_modules'));

--- a/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.ts
+++ b/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.ts
@@ -17,6 +17,7 @@ import {
   CLINoteMessageConfig,
 } from '../../utils/output';
 import { installPackageToTmp } from '../../utils/package-json';
+import { detectPackageManager } from '../../utils/package-manager';
 import { addEntryToGitIgnore } from '../../utils/ignore';
 import { ensurePackageHasProvenance } from '../../utils/provenance';
 import { workspaceRoot } from '../../utils/workspace-root';
@@ -88,7 +89,8 @@ export async function setupAiAgentsGenerator(
 
     const { tempDir, cleanup } = installPackageToTmp(
       'nx',
-      normalizedOptions.packageVersion
+      normalizedOptions.packageVersion,
+      detectPackageManager(tree.root)
     );
 
     let modulePath = join(

--- a/packages/nx/src/command-line/configure-ai-agents/configure-ai-agents.ts
+++ b/packages/nx/src/command-line/configure-ai-agents/configure-ai-agents.ts
@@ -15,7 +15,10 @@ import {
 import { daemonClient } from '../../daemon/client/client';
 import { installPackageToTmp } from '../../devkit-internals';
 import { output } from '../../utils/output';
-import { resolvePackageVersionUsingRegistry } from '../../utils/package-manager';
+import {
+  detectPackageManager,
+  resolvePackageVersionUsingRegistry,
+} from '../../utils/package-manager';
 import { ensurePackageHasProvenance } from '../../utils/provenance';
 import { nxVersion } from '../../utils/versions';
 import { workspaceRoot } from '../../utils/workspace-root';
@@ -58,7 +61,11 @@ export async function configureAiAgentsHandler(
   let cleanup: () => void | undefined;
   try {
     await ensurePackageHasProvenance('nx', 'latest');
-    const packageInstallResults = installPackageToTmp('nx', 'latest');
+    const packageInstallResults = installPackageToTmp(
+      'nx',
+      'latest',
+      detectPackageManager(workspaceRoot)
+    );
     cleanup = packageInstallResults.cleanup;
 
     let modulePath = require.resolve(

--- a/packages/nx/src/command-line/init/init-v2.ts
+++ b/packages/nx/src/command-line/init/init-v2.ts
@@ -75,7 +75,11 @@ export async function initHandler(
   let cleanup: () => void | undefined;
   try {
     await ensurePackageHasProvenance('nx', 'latest');
-    const packageInstallResults = installPackageToTmp('nx', 'latest');
+    const packageInstallResults = installPackageToTmp(
+      'nx',
+      'latest',
+      detectPackageManager(process.cwd())
+    );
     cleanup = packageInstallResults.cleanup;
 
     let modulePath = require.resolve('nx/src/command-line/init/init-v2.js', {

--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -59,6 +59,7 @@ import {
   createTempNpmDirectory,
   detectPackageManager,
   getPackageManagerCommand,
+  PackageManagerCommands,
   packageRegistryPack,
   packageRegistryView,
   resolvePackageVersionUsingRegistry,
@@ -1528,7 +1529,7 @@ function createInstalledPackageVersionsResolver(
 }
 
 // testing-fetch-start
-function createFetcher() {
+function createFetcher(pmc: PackageManagerCommands) {
   const migrationsCache: Record<
     string,
     Promise<ResolvedMigrationConfiguration>
@@ -1543,7 +1544,7 @@ function createFetcher() {
     if (process.env.NX_MIGRATE_SKIP_REGISTRY_FETCH === 'true') {
       // Skip registry fetch and use installation method directly
       logger.info(`Fetching ${packageName}@${packageVersion}`);
-      return getPackageMigrationsUsingInstall(packageName, packageVersion);
+      return getPackageMigrationsUsingInstall(packageName, packageVersion, pmc);
     }
 
     const cacheKey = packageName + '-' + packageVersion;
@@ -1575,7 +1576,11 @@ function createFetcher() {
         );
         logger.info(`Fetching ${packageName}@${packageVersion}`);
 
-        return getPackageMigrationsUsingInstall(packageName, packageVersion);
+        return getPackageMigrationsUsingInstall(
+          packageName,
+          packageVersion,
+          pmc
+        );
       });
   }
 
@@ -1783,16 +1788,18 @@ const installConcurrencyLimit = process.env.NX_MIGRATE_INSTALL_CONCURRENCY
 
 async function getPackageMigrationsUsingInstall(
   packageName: string,
-  packageVersion: string
+  packageVersion: string,
+  pmc: PackageManagerCommands
 ): Promise<ResolvedMigrationConfiguration> {
   const run = () =>
-    getPackageMigrationsUsingInstallImpl(packageName, packageVersion);
+    getPackageMigrationsUsingInstallImpl(packageName, packageVersion, pmc);
   return installConcurrencyLimit ? installConcurrencyLimit(run) : run();
 }
 
 async function getPackageMigrationsUsingInstallImpl(
   packageName: string,
-  packageVersion: string
+  packageVersion: string,
+  pmc: PackageManagerCommands
 ): Promise<ResolvedMigrationConfiguration> {
   const { dir, cleanup } = createTempNpmDirectory();
 
@@ -1803,8 +1810,6 @@ async function getPackageMigrationsUsingInstallImpl(
   }
 
   try {
-    const pmc = getPackageManagerCommand(detectPackageManager(dir), dir);
-
     await execAsync(`${pmc.add} ${packageName}@${packageVersion}`, {
       cwd: dir,
       env: {
@@ -1839,8 +1844,6 @@ async function getPackageMigrationsUsingInstallImpl(
       ...(resolvedPromptFiles ? { resolvedPromptFiles } : {}),
     };
   } catch (e) {
-    const pmc = getPackageManagerCommand(detectPackageManager(dir), dir);
-
     throw new Error(
       [
         `Failed to fetch migrations for ${packageName}@${packageVersion}`,
@@ -2108,7 +2111,7 @@ async function generateMigrationsJsonAndUpdatePackageJson(
     logger.info(`Fetching meta data about packages.`);
     logger.info(`It may take a few minutes.`);
 
-    const fetch = createFetcher();
+    const fetch = createFetcher(pmc);
     let firstPartyPackages: ReadonlySet<string> | undefined;
     if (mode === 'first-party' || mode === 'third-party') {
       // `@nx/workspace` is version-synced with `nx` and declares an

--- a/packages/nx/src/daemon/server/latest-nx.ts
+++ b/packages/nx/src/daemon/server/latest-nx.ts
@@ -1,5 +1,7 @@
 import { installPackageToTmpAsync } from '../../devkit-internals';
+import { detectPackageManager } from '../../utils/package-manager';
 import { ensurePackageHasProvenance } from '../../utils/provenance';
+import { workspaceRoot } from '../../utils/workspace-root';
 import { serverLogger } from '../logger';
 
 // Module-level state - persists across invocations within daemon lifecycle
@@ -29,7 +31,11 @@ export async function getLatestNxTmpPath(): Promise<string> {
     try {
       serverLogger.log('[LATEST-NX]: Pulling latest Nx...');
       await ensurePackageHasProvenance('nx', 'latest');
-      const result = await installPackageToTmpAsync('nx', 'latest');
+      const result = await installPackageToTmpAsync(
+        'nx',
+        'latest',
+        detectPackageManager(workspaceRoot)
+      );
       latestNxTmpPath = result.tempDir;
       cleanupFn = result.cleanup;
       serverLogger.log(

--- a/packages/nx/src/utils/package-json.spec.ts
+++ b/packages/nx/src/utils/package-json.spec.ts
@@ -34,6 +34,7 @@ describe('buildTargetFromScript', () => {
 describe('installPackageToTmp', () => {
   afterEach(() => {
     jest.restoreAllMocks();
+    jest.clearAllMocks();
   });
 
   it('should always disable lifecycle scripts via environment variables', () => {
@@ -45,7 +46,6 @@ describe('installPackageToTmp', () => {
       dir: tempDir,
       cleanup,
     });
-    jest.spyOn(pacakgeManager, 'detectPackageManager').mockReturnValue('yarn');
     jest
       .spyOn(pacakgeManager, 'getPackageManagerVersion')
       .mockReturnValue('4.0.0');
@@ -58,7 +58,7 @@ describe('installPackageToTmp', () => {
       .spyOn(childProcess, 'execSync')
       .mockReturnValue('' as any);
 
-    installPackageToTmp('nx', 'latest');
+    installPackageToTmp('nx', 'latest', 'yarn');
 
     expect(execSyncSpy).toHaveBeenCalledTimes(2);
     for (const [, options] of execSyncSpy.mock.calls) {
@@ -70,6 +70,36 @@ describe('installPackageToTmp', () => {
         })
       );
     }
+
+    cleanup();
+  });
+
+  it('should use the workspace `addDev` verbatim for pnpm (preserves `-w` when pnpm-workspace.yaml is present)', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'nx-install-test-'));
+    const cleanup = jest.fn(() =>
+      rmSync(tempDir, { recursive: true, force: true })
+    );
+    jest.spyOn(pacakgeManager, 'createTempNpmDirectory').mockReturnValue({
+      dir: tempDir,
+      cleanup,
+    });
+    jest
+      .spyOn(pacakgeManager, 'getPackageManagerVersion')
+      .mockReturnValue('9.0.0');
+    jest.spyOn(pacakgeManager, 'getPackageManagerCommand').mockReturnValue({
+      addDev: 'pnpm add -Dw',
+      ignoreScriptsFlag: '--ignore-scripts',
+    } as any);
+    const execSyncSpy = jest
+      .spyOn(childProcess, 'execSync')
+      .mockReturnValue('' as any);
+
+    installPackageToTmp('nx', 'latest', 'pnpm');
+
+    expect(execSyncSpy).toHaveBeenCalledTimes(1);
+    expect(execSyncSpy.mock.calls[0][0]).toBe(
+      'pnpm add -Dw nx@latest --ignore-scripts'
+    );
 
     cleanup();
   });

--- a/packages/nx/src/utils/package-json.ts
+++ b/packages/nx/src/utils/package-json.ts
@@ -405,25 +405,26 @@ export function readModulePackageJson(
  * Prepares all necessary information for installing a package to a temporary directory.
  * This is used by both sync and async installation functions.
  */
-function preparePackageInstallation(pkg: string, requiredVersion: string) {
+function preparePackageInstallation(
+  pkg: string,
+  requiredVersion: string,
+  packageManager: PackageManager
+) {
   const { dir: tempDir, cleanup } = createTempNpmDirectory?.() ?? {
     dir: dirSync().name,
     cleanup: () => {},
   };
 
   console.log(`Fetching ${pkg}...`);
-  const packageManager = detectPackageManager(workspaceRoot);
   const isVerbose = process.env.NX_VERBOSE_LOGGING === 'true';
   generatePackageManagerFiles(tempDir, packageManager);
 
+  // For pnpm, `addDev` is `pnpm add -Dw` when the workspace has a
+  // pnpm-workspace.yaml. `createTempNpmDirectory` copies a sanitized copy of
+  // it into the temp dir, so the `-w` here resolves to the temp dir.
   const pmCommands = getPackageManagerCommand(packageManager);
   const preInstallCommand = pmCommands.preInstall;
-  let addCommand = pmCommands.addDev;
-  if (packageManager === 'pnpm') {
-    addCommand = 'pnpm add -D'; // we need to ensure that we are not using workspace command
-  }
-
-  const installCommand = `${addCommand} ${pkg}@${requiredVersion} ${
+  const installCommand = `${pmCommands.addDev} ${pkg}@${requiredVersion} ${
     pmCommands.ignoreScriptsFlag ?? ''
   }`;
 
@@ -450,13 +451,14 @@ function preparePackageInstallation(pkg: string, requiredVersion: string) {
 
 export function installPackageToTmp(
   pkg: string,
-  requiredVersion: string
+  requiredVersion: string,
+  packageManager: PackageManager
 ): {
   tempDir: string;
   cleanup: () => void;
 } {
   const { tempDir, cleanup, preInstallCommand, installCommand, execOptions } =
-    preparePackageInstallation(pkg, requiredVersion);
+    preparePackageInstallation(pkg, requiredVersion, packageManager);
 
   if (preInstallCommand) {
     // ensure package.json and repo in tmp folder is set to a proper package manager state
@@ -473,13 +475,14 @@ export function installPackageToTmp(
 
 export async function installPackageToTmpAsync(
   pkg: string,
-  requiredVersion: string
+  requiredVersion: string,
+  packageManager: PackageManager
 ): Promise<{
   tempDir: string;
   cleanup: () => void;
 }> {
   const { tempDir, cleanup, preInstallCommand, installCommand, execOptions } =
-    preparePackageInstallation(pkg, requiredVersion);
+    preparePackageInstallation(pkg, requiredVersion, packageManager);
 
   try {
     if (preInstallCommand) {

--- a/packages/nx/src/utils/package-manager.spec.ts
+++ b/packages/nx/src/utils/package-manager.spec.ts
@@ -23,6 +23,7 @@ import {
   getPackageManagerVersion,
   getPackageWorkspaces,
   isWorkspacesEnabled,
+  modifyPnpmWorkspaceYamlToFitNewDirectory,
   modifyYarnRcToFitNewDirectory,
   modifyYarnRcYmlToFitNewDirectory,
   parseVersionFromPackageManagerField,
@@ -409,6 +410,39 @@ describe('package-manager', () => {
           ['yarn-path ./bin/yarn.js', 'enableProgressBars false'].join('\n')
         )
       ).toEqual('enableProgressBars false');
+    });
+  });
+
+  describe('modifyPnpmWorkspaceYamlToFitNewDirectory', () => {
+    it('should drop workspace packages but keep settings', () => {
+      const result = modifyPnpmWorkspaceYamlToFitNewDirectory(
+        [
+          'packages:',
+          "  - 'packages/*'",
+          'minimumReleaseAge: 1440',
+          'registry: https://example.com/',
+        ].join('\n')
+      );
+      expect(result).not.toContain('packages');
+      expect(result).toContain('minimumReleaseAge: 1440');
+      expect(result).toContain('registry: https://example.com/');
+    });
+
+    it('should drop patchedDependencies pointing at relative paths', () => {
+      const result = modifyPnpmWorkspaceYamlToFitNewDirectory(
+        [
+          'patchedDependencies:',
+          '  foo@1.0.0: patches/foo@1.0.0.patch',
+          'minimumReleaseAge: 1440',
+        ].join('\n')
+      );
+      expect(result).not.toContain('patchedDependencies');
+      expect(result).not.toContain('patches/foo');
+      expect(result).toContain('minimumReleaseAge: 1440');
+    });
+
+    it('should not throw on an empty file', () => {
+      expect(() => modifyPnpmWorkspaceYamlToFitNewDirectory('')).not.toThrow();
     });
   });
 

--- a/packages/nx/src/utils/package-manager.ts
+++ b/packages/nx/src/utils/package-manager.ts
@@ -400,6 +400,29 @@ export function modifyYarnRcToFitNewDirectory(contents: string): string {
   return lines.join('\n');
 }
 
+/**
+ * We copy pnpm-workspace.yaml to the temporary directory so the workspace's
+ * registry, auth and release-age settings still apply, and so `pnpm add -w`
+ * recognizes the directory as a workspace root. `packages` (member globs) and
+ * `patchedDependencies` (relative patch paths) only resolve in the real
+ * workspace, so they are dropped.
+ *
+ * Exported for testing - not meant to be used outside of this file.
+ *
+ * @param contents The string contents of the pnpm-workspace.yaml file
+ * @returns Updated string contents of the pnpm-workspace.yaml file
+ */
+export function modifyPnpmWorkspaceYamlToFitNewDirectory(
+  contents: string
+): string {
+  const doc = parseDocument(contents);
+  if (doc.contents) {
+    doc.delete('packages');
+    doc.delete('patchedDependencies');
+  }
+  return doc.toString();
+}
+
 export function copyPackageManagerConfigurationFiles(
   root: string,
   destination: string
@@ -409,6 +432,7 @@ export function copyPackageManagerConfigurationFiles(
     '.yarnrc',
     '.yarnrc.yml',
     'bunfig.toml',
+    'pnpm-workspace.yaml',
   ]) {
     // f is an absolute path, including the {workspaceRoot}.
     const f = findFileInPackageJsonDirectory(packageManagerConfigFile, root);
@@ -436,6 +460,13 @@ export function copyPackageManagerConfigurationFiles(
         }
         case 'bunfig.toml': {
           copyFileSync(f, destinationPath);
+          break;
+        }
+        case 'pnpm-workspace.yaml': {
+          const updated = modifyPnpmWorkspaceYamlToFitNewDirectory(
+            readFileIfExisting(f)
+          );
+          writeFileSync(destinationPath, updated);
           break;
         }
       }


### PR DESCRIPTION
  ## Current Behavior

  When `nx migrate` can't read a package's migrations from the registry, it falls back to installing the
  package in a temporary directory to read them. That fallback detected the package manager from the
  temp directory itself — which has no lock file — so detection fell back to npm even in yarn / pnpm /
  bun workspaces. The fetch then ran `npm install`, ignoring the workspace package manager's registry,
  auth, and release-age configuration (for example, a private registry configured in `.yarnrc.yml`, or
  pnpm's `minimumReleaseAge`), which can break migrations that resolve through a private registry.

  ## Expected Behavior

  The package manager is already resolved once in `generateMigrationsJsonAndUpdatePackageJson` (before
  the fetcher is created). That value is now threaded through `createFetcher` into the install fallback,
  so the temporary install uses the workspace's package manager. The fetch helper no longer detects the
  package manager at all, so it can't resolve it against the empty temp directory.

  For pnpm workspaces the install runs `pnpm add -w`, which requires a `pnpm-workspace.yaml` to be
  present in the directory (otherwise it fails with `--workspace-root may only be used inside a
  workspace`). A **sanitized** copy is now placed in the temp dir: `packages` (workspace member globs)
  and `patchedDependencies` (relative patch-file paths) are dropped because they only resolve in the
  real workspace, while `registry`, auth, and `minimumReleaseAge` are kept. This fixes the `-w` failure
  and lets the install honor the workspace's registry/auth and release-age settings.

  The install still runs in the temp directory; only the configuration and package-manager *choice* now
  come from the workspace. `createTempNpmDirectory` already copied `.npmrc` / `.yarnrc` / `.yarnrc.yml`
  / `bunfig.toml`; this adds the sanitized `pnpm-workspace.yaml` alongside them.

  ## Related Issue(s)

  Relates to NXC-4499.