### PR TITLE
feat(webpack)!: deprecate webpack/rspack config compose helpers

### DIFF
--- a/astro-docs/src/content/docs/technologies/build-tools/webpack/Guides/webpack-config-setup.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/webpack/Guides/webpack-config-setup.mdoc
@@ -90,8 +90,10 @@ For more information, see the [Webpack plugins guide](/docs/technologies/build-t
 
 ### Nx-enhanced configuration with composable plugins
 
-{% aside type="tip" title="Non-standard webpack config" %}
-Nx-enhanced configuration, via `composePlugins` and [`withNx`](/docs/technologies/build-tools/webpack/guides/webpack-plugins#withnx) functions, requires the usage of `@nx/webpack:webpack` executor in your `project.json` file. This flavor of configuration does not work with the Webpack CLI.
+{% aside type="caution" title="`composePlugins`, `withNx`, and `withWeb` are deprecated" %}
+The `composePlugins`, [`withNx`](/docs/technologies/build-tools/webpack/guides/webpack-plugins#withnx), and `withWeb` helpers are deprecated and will be removed in Nx v24. They produce a non-standard config function that only runs under the `@nx/webpack:webpack` executor, so it does not work with the Webpack CLI. They still work in v23, but using them logs a deprecation warning.
+
+Use a standard webpack config built around `NxAppWebpackPlugin` (see [Basic configuration for Nx](#basic-configuration-for-nx) above) under the inferred `@nx/webpack/plugin`. Run `nx g @nx/webpack:convert-to-inferred` to migrate existing projects.
 {% /aside %}
 
 Nx supports a function to be returned from the Webpack configuration file. This function is a composable plugin that is understood by the `@nx/webpack:webpack` executor. The enhanced configuration looks something like this:

--- a/astro-docs/src/content/docs/technologies/build-tools/webpack/Guides/webpack-plugins.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/webpack/Guides/webpack-plugins.mdoc
@@ -383,6 +383,12 @@ module.exports = {
 
 ## Nx-enhanced plugins
 
+{% aside type="caution" title="The compose helpers are deprecated" %}
+The `composePlugins`, `withNx`, `withWeb`, and `withReact` helpers below are deprecated and will be removed in Nx v24. They produce a non-standard config function that only runs under the `@nx/webpack:webpack` executor. They still work in v23, but using them logs a deprecation warning.
+
+Prefer a standard webpack config built around [`NxAppWebpackPlugin`](#nxappwebpackplugin) under the inferred `@nx/webpack/plugin`. Run `nx g @nx/webpack:convert-to-inferred` to migrate existing projects.
+{% /aside %}
+
 The Nx-enhanced plugins work with `@nx/webpack:webpack` executor and receive the target options and context from the
 executor. These are used when using [Module Federation](/docs/technologies/module-federation/concepts/module-federation-and-nx).
 

--- a/astro-docs/src/content/docs/technologies/react/Guides/adding-assets-react.mdoc
+++ b/astro-docs/src/content/docs/technologies/react/Guides/adding-assets-react.mdoc
@@ -115,6 +115,10 @@ module.exports = {
 
 If you're using `composePlugins` with `withNx`, you can create a `withSvgr` helper function:
 
+{% aside type="caution" title="`composePlugins` and `withNx` are deprecated" %}
+The `@nx/webpack` `composePlugins` and `withNx` helpers are deprecated and will be removed in Nx v24. They still work in v23, but using them logs a deprecation warning. Prefer a standard webpack config using `NxAppWebpackPlugin` and run `nx g @nx/webpack:convert-to-inferred` to migrate. See the [webpack config guide](/docs/technologies/build-tools/webpack/guides/webpack-config-setup) for details.
+{% /aside %}
+
 ```javascript frame="none"
 // filename: webpack.config.js
 const { composePlugins, withNx } = require('@nx/webpack');

--- a/packages/next/plugins/component-testing.ts
+++ b/packages/next/plugins/component-testing.ts
@@ -18,12 +18,14 @@ import {
 } from '@nx/devkit';
 import { getProjectSourceRoot } from '@nx/js/internal';
 import { withReact } from '@nx/react';
+import { suppressReactComposeHelperWarnings } from '@nx/react/src/utils/deprecation';
 import {
   AssetGlobPattern,
   composePluginsSync,
   NormalizedWebpackExecutorOptions,
   withNx,
 } from '@nx/webpack';
+import { suppressWebpackComposeHelperWarnings } from '@nx/webpack/src/utils/deprecation';
 import { readNxJson } from 'nx/src/config/configuration';
 import { join } from 'path';
 import { NextBuildBuilderOptions } from '../src/utils/types';
@@ -140,21 +142,27 @@ Able to find CT project, ${!!ctProjectConfig}.`);
       'tsconfig.json'
     ),
   };
-  const configure = composePluginsSync(
-    withNx({
-      target: 'web',
-      styles: [],
-      scripts: [],
-      postcssConfig: ctProjectConfig.root,
-    }),
-    withReact({})
-  );
-  const webpackConfig = configure(
-    {},
-    {
-      options: webpackOptions,
-      context: ctExecutorContext,
-    }
+  // Nx composes these helpers internally for the Cypress CT preset; suppress
+  // their deprecation warning so it fires only for user-authored configs.
+  const webpackConfig = suppressWebpackComposeHelperWarnings(() =>
+    suppressReactComposeHelperWarnings(() => {
+      const configure = composePluginsSync(
+        withNx({
+          target: 'web',
+          styles: [],
+          scripts: [],
+          postcssConfig: ctProjectConfig.root,
+        }),
+        withReact({})
+      );
+      return configure(
+        {},
+        {
+          options: webpackOptions,
+          context: ctExecutorContext,
+        }
+      );
+    })
   );
 
   return {

--- a/packages/react/plugins/storybook/index.ts
+++ b/packages/react/plugins/storybook/index.ts
@@ -8,6 +8,7 @@ import {
 import { getProjectSourceRoot } from '@nx/js/internal';
 import { NormalizedWebpackExecutorOptions } from '@nx/webpack/src/executors/webpack/schema';
 import { composePluginsSync } from '@nx/webpack/src/utils/config';
+import { suppressWebpackComposeHelperWarnings } from '@nx/webpack/src/utils/deprecation';
 import { existsSync } from 'fs';
 import { join } from 'path';
 import {
@@ -17,6 +18,7 @@ import {
   WebpackPluginInstance,
 } from 'webpack';
 import { withReact } from '../with-react';
+import { suppressReactComposeHelperWarnings } from '../../src/utils/deprecation';
 import { mergePlugins } from './merge-plugins';
 
 // This is shamelessly taken from CRA and modified for NX use
@@ -198,15 +200,21 @@ export const webpack = async (
 
   // ESM build for modern browsers.
   let baseWebpackConfig: Configuration = {};
-  const configure = composePluginsSync(
-    withNx({ target: 'web', skipTypeChecking: true }),
-    withReact()
+  // Nx composes these helpers internally for the storybook preset; suppress
+  // their deprecation warning so it fires only for user-authored configs.
+  const finalConfig = suppressWebpackComposeHelperWarnings(() =>
+    suppressReactComposeHelperWarnings(() => {
+      const configure = composePluginsSync(
+        withNx({ target: 'web', skipTypeChecking: true }),
+        withReact()
+      );
+      return configure(baseWebpackConfig, {
+        options: builderOptions,
+        // TODO(JamesHenry): replace as any type assertion with as ExecutorContext once the nx repo is updated to use https://github.com/nrwl/nx/pull/33095
+        context: { root: workspaceRoot } as any, // The context is not used here.
+      });
+    })
   );
-  const finalConfig = configure(baseWebpackConfig, {
-    options: builderOptions,
-    // TODO(JamesHenry): replace as any type assertion with as ExecutorContext once the nx repo is updated to use https://github.com/nrwl/nx/pull/33095
-    context: { root: workspaceRoot } as any, // The context is not used here.
-  });
 
   return {
     ...storybookWebpackConfig,

--- a/packages/react/plugins/with-react.ts
+++ b/packages/react/plugins/with-react.ts
@@ -1,16 +1,22 @@
 import type { Configuration } from 'webpack';
 import type { NxWebpackExecutionContext, WithWebOptions } from '@nx/webpack';
 import { applyReactConfig } from './nx-react-webpack-plugin/lib/apply-react-config';
+import { warnReactWithReactDeprecation } from '../src/utils/deprecation';
 
 const processed = new Set();
 
 export interface WithReactOptions extends WithWebOptions {}
 
 /**
+ * @deprecated Will be removed in Nx v24. Use `NxReactWebpackPlugin` from
+ * `@nx/react/webpack-plugin` in a standard webpack config and run
+ * `nx g @nx/webpack:convert-to-inferred`. See
+ * https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.
  * @param {WithReactOptions} pluginOptions
  * @returns {NxWebpackPlugin}
  */
 export function withReact(pluginOptions: WithReactOptions = {}) {
+  warnReactWithReactDeprecation();
   return function configure(
     config: Configuration,
     context: NxWebpackExecutionContext

--- a/packages/react/src/utils/deprecation.spec.ts
+++ b/packages/react/src/utils/deprecation.spec.ts
@@ -1,0 +1,44 @@
+describe('@nx/react withReact deprecation', () => {
+  function setup() {
+    let warn!: jest.SpyInstance;
+    let mod!: typeof import('./deprecation');
+    jest.isolateModules(() => {
+      const { logger } = require('@nx/devkit');
+      warn = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+      mod = require('./deprecation');
+    });
+    return { warn, mod };
+  }
+
+  it('warns once per process', () => {
+    const { warn, mod } = setup();
+
+    mod.warnReactWithReactDeprecation();
+    mod.warnReactWithReactDeprecation();
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('@nx/react');
+    expect(warn.mock.calls[0][0]).toContain('convert-to-inferred');
+  });
+
+  it('does not warn when called inside a suppression scope', () => {
+    const { warn, mod } = setup();
+
+    mod.suppressReactComposeHelperWarnings(() =>
+      mod.warnReactWithReactDeprecation()
+    );
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('restores warning after the suppression scope exits', () => {
+    const { warn, mod } = setup();
+
+    mod.suppressReactComposeHelperWarnings(() =>
+      mod.warnReactWithReactDeprecation()
+    );
+    mod.warnReactWithReactDeprecation();
+
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/react/src/utils/deprecation.ts
+++ b/packages/react/src/utils/deprecation.ts
@@ -1,0 +1,31 @@
+import { logger } from '@nx/devkit';
+
+// TODO(v24): Remove the webpack `withReact` config helper. It emits an
+// Nx-specific webpack config function that only runs under the
+// @nx/webpack:webpack executor; the inferred @nx/webpack/plugin works with
+// standard webpack configs built around NxReactWebpackPlugin instead.
+export const REACT_WITH_REACT_DEPRECATION_MESSAGE =
+  'The `withReact` config helper from `@nx/react` is deprecated and will be removed in Nx v24. It produces an Nx-specific webpack config function that only runs under the `@nx/webpack:webpack` executor. Migrate to a standard webpack config that uses `NxReactWebpackPlugin` (from `@nx/react/webpack-plugin`) under the inferred `@nx/webpack/plugin` by running `nx g @nx/webpack:convert-to-inferred`. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.';
+
+let withReactWarned = false;
+let suppressDepth = 0;
+
+// Nx-internal entry points compose `withReact` themselves (e.g. the storybook
+// and component-testing presets). They wrap their synchronous composition in
+// this so the warning fires only for user-authored configs.
+export function suppressReactComposeHelperWarnings<T>(fn: () => T): T {
+  suppressDepth++;
+  try {
+    return fn();
+  } finally {
+    suppressDepth--;
+  }
+}
+
+// Warn once per process so HMR reloads and repeated config evaluation don't
+// repeat the message.
+export function warnReactWithReactDeprecation(): void {
+  if (suppressDepth > 0 || withReactWarned) return;
+  withReactWarned = true;
+  logger.warn(REACT_WITH_REACT_DEPRECATION_MESSAGE);
+}

--- a/packages/rspack/src/executors/rspack/lib/config.ts
+++ b/packages/rspack/src/executors/rspack/lib/config.ts
@@ -4,6 +4,7 @@ import {
   composePluginsSync,
   isNxRspackComposablePlugin,
 } from '../../../utils/config';
+import { suppressRspackComposeHelperWarnings } from '../../../utils/deprecation';
 import { resolveUserDefinedRspackConfig } from '../../../utils/resolve-user-defined-rspack-config';
 import { withNx } from '../../../utils/with-nx';
 import { withWeb } from '../../../utils/with-web';
@@ -28,11 +29,13 @@ export async function getRspackConfigs(
     userDefinedConfig = await userDefinedConfig;
   }
 
-  const config = (
-    options.target === 'web'
+  // Nx composes these helpers internally to build the default config; suppress
+  // their deprecation warning so it fires only for user-authored configs.
+  const config = suppressRspackComposeHelperWarnings(() =>
+    (options.target === 'web'
       ? composePluginsSync(withNx(options), withWeb(options))
-      : withNx(options)
-  )({}, { options, context });
+      : withNx(options))({}, { options, context })
+  );
 
   if (
     typeof userDefinedConfig === 'function' &&

--- a/packages/rspack/src/utils/config.ts
+++ b/packages/rspack/src/utils/config.ts
@@ -8,6 +8,7 @@ import { getProjectSourceRoot } from '@nx/js/internal';
 import type { Configuration } from '@rspack/core';
 import { readNxJson } from 'nx/src/config/configuration';
 import { NormalizedRspackExecutorSchema } from '../executors/rspack/schema';
+import { warnRspackComposeHelpersDeprecation } from './deprecation';
 
 export const nxRspackComposablePlugin = 'nxRspackComposablePlugin';
 
@@ -34,6 +35,13 @@ export interface AsyncNxComposableRspackPlugin {
   ): Configuration | Promise<Configuration>;
 }
 
+/**
+ * @deprecated Will be removed in Nx v24. Use `NxAppRspackPlugin` from
+ * `@nx/rspack/app-plugin` (or `NxReactRspackPlugin` from
+ * `@nx/rspack/react-plugin`) in a standard rspack config and run
+ * `nx g @nx/rspack:convert-to-inferred`. See
+ * https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.
+ */
 export function composePlugins(
   ...plugins: (
     | NxComposableRspackPlugin
@@ -41,6 +49,7 @@ export function composePlugins(
     | Promise<NxComposableRspackPlugin | AsyncNxComposableRspackPlugin>
   )[]
 ) {
+  warnRspackComposeHelpersDeprecation();
   return Object.assign(
     async function combined(
       config: Configuration,
@@ -68,7 +77,15 @@ export function composePlugins(
   );
 }
 
+/**
+ * @deprecated Will be removed in Nx v24. Use `NxAppRspackPlugin` from
+ * `@nx/rspack/app-plugin` (or `NxReactRspackPlugin` from
+ * `@nx/rspack/react-plugin`) in a standard rspack config and run
+ * `nx g @nx/rspack:convert-to-inferred`. See
+ * https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.
+ */
 export function composePluginsSync(...plugins: NxComposableRspackPlugin[]) {
+  warnRspackComposeHelpersDeprecation();
   return Object.assign(
     function combined(
       config: Configuration,

--- a/packages/rspack/src/utils/deprecation.spec.ts
+++ b/packages/rspack/src/utils/deprecation.spec.ts
@@ -1,0 +1,44 @@
+describe('@nx/rspack compose helpers deprecation', () => {
+  function setup() {
+    let warn!: jest.SpyInstance;
+    let mod!: typeof import('./deprecation');
+    jest.isolateModules(() => {
+      const { logger } = require('@nx/devkit');
+      warn = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+      mod = require('./deprecation');
+    });
+    return { warn, mod };
+  }
+
+  it('warns once per process even when several helpers are composed', () => {
+    const { warn, mod } = setup();
+
+    mod.warnRspackComposeHelpersDeprecation();
+    mod.warnRspackComposeHelpersDeprecation();
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('@nx/rspack');
+    expect(warn.mock.calls[0][0]).toContain('convert-to-inferred');
+  });
+
+  it('does not warn when called inside a suppression scope', () => {
+    const { warn, mod } = setup();
+
+    mod.suppressRspackComposeHelperWarnings(() =>
+      mod.warnRspackComposeHelpersDeprecation()
+    );
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('restores warning after the suppression scope exits', () => {
+    const { warn, mod } = setup();
+
+    mod.suppressRspackComposeHelperWarnings(() =>
+      mod.warnRspackComposeHelpersDeprecation()
+    );
+    mod.warnRspackComposeHelpersDeprecation();
+
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/rspack/src/utils/deprecation.ts
+++ b/packages/rspack/src/utils/deprecation.ts
@@ -22,3 +22,33 @@ export function warnRspackExecutorGenerating(): void {
     'Generating targets that use the deprecated `@nx/rspack:rspack` and `@nx/rspack:dev-server` executors. These executors will be removed in Nx v24. Run `nx g @nx/rspack:convert-to-inferred` next to migrate these targets to the `@nx/rspack/plugin` inferred plugin and prevent future generators from emitting executor targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.'
   );
 }
+
+// TODO(v24): Remove the composePlugins/withNx/withWeb/withReact config helpers.
+// They emit an Nx-specific config function that only runs under the
+// @nx/rspack:rspack executor; the inferred @nx/rspack/plugin works with standard
+// rspack configs built around NxAppRspackPlugin/NxReactRspackPlugin instead.
+export const RSPACK_COMPOSE_HELPERS_DEPRECATION_MESSAGE =
+  'The `composePlugins`, `withNx`, `withWeb`, and `withReact` config helpers from `@nx/rspack` are deprecated and will be removed in Nx v24. They produce an Nx-specific config function that only runs under the `@nx/rspack:rspack` executor. Migrate to a standard rspack config that uses `NxAppRspackPlugin` (from `@nx/rspack/app-plugin`) or `NxReactRspackPlugin` (from `@nx/rspack/react-plugin`) under the inferred `@nx/rspack/plugin` by running `nx g @nx/rspack:convert-to-inferred`. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.';
+
+let composeHelpersWarned = false;
+let suppressDepth = 0;
+
+// Nx-internal entry points compose these helpers themselves (e.g. the rspack
+// executor). They wrap their synchronous composition in this so the warning
+// fires only for user-authored configs.
+export function suppressRspackComposeHelperWarnings<T>(fn: () => T): T {
+  suppressDepth++;
+  try {
+    return fn();
+  } finally {
+    suppressDepth--;
+  }
+}
+
+// Warn once per process so a `composePlugins(withNx(), withReact())` chain logs
+// a single line, not one per helper, and HMR reloads don't repeat it.
+export function warnRspackComposeHelpersDeprecation(): void {
+  if (suppressDepth > 0 || composeHelpersWarned) return;
+  composeHelpersWarned = true;
+  logger.warn(RSPACK_COMPOSE_HELPERS_DEPRECATION_MESSAGE);
+}

--- a/packages/rspack/src/utils/with-nx.ts
+++ b/packages/rspack/src/utils/with-nx.ts
@@ -3,18 +3,24 @@ import { normalizeAssets } from './normalize-assets';
 import { NxAppRspackPluginOptions } from '../plugins/utils/models';
 import { applyBaseConfig } from '../plugins/utils/apply-base-config';
 import { NxRspackExecutionContext, NxComposableRspackPlugin } from './config';
+import { warnRspackComposeHelpersDeprecation } from './deprecation';
 
 const processed = new Set();
 
 export type WithNxOptions = Partial<NxAppRspackPluginOptions>;
 
 /**
+ * @deprecated Will be removed in Nx v24. Use `NxAppRspackPlugin` from
+ * `@nx/rspack/app-plugin` in a standard rspack config and run
+ * `nx g @nx/rspack:convert-to-inferred`. See
+ * https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.
  * @param {WithNxOptions} pluginOptions
  * @returns {NxComposableRspackPlugin}
  */
 export function withNx(
   pluginOptions: WithNxOptions = {}
 ): NxComposableRspackPlugin {
+  warnRspackComposeHelpersDeprecation();
   return function makeConfig(
     config: Configuration,
     { options, context }: NxRspackExecutionContext

--- a/packages/rspack/src/utils/with-react.ts
+++ b/packages/rspack/src/utils/with-react.ts
@@ -2,10 +2,18 @@ import type { Configuration } from '@rspack/core';
 import { NxRspackExecutionContext } from './config';
 import { withWeb, WithWebOptions } from './with-web';
 import { applyReactConfig } from '../plugins/utils/apply-react-config';
+import { warnRspackComposeHelpersDeprecation } from './deprecation';
 
 export interface WithReactOptions extends WithWebOptions {}
 
+/**
+ * @deprecated Will be removed in Nx v24. Use `NxReactRspackPlugin` from
+ * `@nx/rspack/react-plugin` in a standard rspack config and run
+ * `nx g @nx/rspack:convert-to-inferred`. See
+ * https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.
+ */
 export function withReact(opts: WithReactOptions = {}) {
+  warnRspackComposeHelpersDeprecation();
   return function makeConfig(
     config: Configuration,
     { options, context }: NxRspackExecutionContext

--- a/packages/rspack/src/utils/with-web.ts
+++ b/packages/rspack/src/utils/with-web.ts
@@ -2,6 +2,7 @@ import type { Configuration } from '@rspack/core';
 import { ExtraEntryPointClass } from './model';
 import { applyWebConfig } from '../plugins/utils/apply-web-config';
 import { NxRspackExecutionContext } from './config';
+import { warnRspackComposeHelpersDeprecation } from './deprecation';
 
 export interface WithWebOptions {
   baseHref?: string;
@@ -37,7 +38,14 @@ export interface WithWebOptions {
 
 const processed = new Set();
 
+/**
+ * @deprecated Will be removed in Nx v24. Use `NxAppRspackPlugin` from
+ * `@nx/rspack/app-plugin` in a standard rspack config and run
+ * `nx g @nx/rspack:convert-to-inferred`. See
+ * https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.
+ */
 export function withWeb(pluginOptions: WithWebOptions = {}) {
+  warnRspackComposeHelpersDeprecation();
   return function makeConfig(
     config: Configuration,
     { options, context }: NxRspackExecutionContext

--- a/packages/webpack/src/utils/config.ts
+++ b/packages/webpack/src/utils/config.ts
@@ -8,6 +8,7 @@ import { getProjectSourceRoot } from '@nx/js/internal';
 import { readNxJson } from 'nx/src/config/configuration';
 import { Configuration } from 'webpack';
 import { NormalizedWebpackExecutorOptions } from '../executors/webpack/schema';
+import { warnWebpackComposeHelpersDeprecation } from './deprecation';
 
 export const nxWebpackComposablePlugin = 'nxWebpackComposablePlugin';
 
@@ -34,6 +35,12 @@ export interface AsyncNxComposableWebpackPlugin {
   ): Configuration | Promise<Configuration>;
 }
 
+/**
+ * @deprecated Will be removed in Nx v24. Use `NxAppWebpackPlugin` from
+ * `@nx/webpack/app-plugin` in a standard webpack config and run
+ * `nx g @nx/webpack:convert-to-inferred`. See
+ * https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.
+ */
 export function composePlugins(
   ...plugins: (
     | NxComposableWebpackPlugin
@@ -41,6 +48,7 @@ export function composePlugins(
     | Promise<NxComposableWebpackPlugin | AsyncNxComposableWebpackPlugin>
   )[]
 ) {
+  warnWebpackComposeHelpersDeprecation();
   return Object.assign(
     async function combined(
       config: Configuration,
@@ -68,7 +76,14 @@ export function composePlugins(
   );
 }
 
+/**
+ * @deprecated Will be removed in Nx v24. Use `NxAppWebpackPlugin` from
+ * `@nx/webpack/app-plugin` in a standard webpack config and run
+ * `nx g @nx/webpack:convert-to-inferred`. See
+ * https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.
+ */
 export function composePluginsSync(...plugins: NxComposableWebpackPlugin[]) {
+  warnWebpackComposeHelpersDeprecation();
   return Object.assign(
     function combined(
       config: Configuration,

--- a/packages/webpack/src/utils/deprecation.spec.ts
+++ b/packages/webpack/src/utils/deprecation.spec.ts
@@ -1,0 +1,60 @@
+describe('@nx/webpack compose helpers deprecation', () => {
+  // Each test runs in an isolated module registry so the warn-once flag and the
+  // logger spy resolve to the same fresh instances.
+  function setup() {
+    let warn!: jest.SpyInstance;
+    let mod!: typeof import('./deprecation');
+    jest.isolateModules(() => {
+      const { logger } = require('@nx/devkit');
+      warn = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+      mod = require('./deprecation');
+    });
+    return { warn, mod };
+  }
+
+  it('warns once per process even when several helpers are composed', () => {
+    const { warn, mod } = setup();
+
+    mod.warnWebpackComposeHelpersDeprecation();
+    mod.warnWebpackComposeHelpersDeprecation();
+    mod.warnWebpackComposeHelpersDeprecation();
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('@nx/webpack');
+    expect(warn.mock.calls[0][0]).toContain('convert-to-inferred');
+  });
+
+  it('does not warn when called inside a suppression scope', () => {
+    const { warn, mod } = setup();
+
+    mod.suppressWebpackComposeHelperWarnings(() =>
+      mod.warnWebpackComposeHelpersDeprecation()
+    );
+
+    expect(warn).not.toHaveBeenCalled();
+  });
+
+  it('restores warning after the suppression scope exits', () => {
+    const { warn, mod } = setup();
+
+    mod.suppressWebpackComposeHelperWarnings(() =>
+      mod.warnWebpackComposeHelpersDeprecation()
+    );
+    mod.warnWebpackComposeHelpersDeprecation();
+
+    expect(warn).toHaveBeenCalledTimes(1);
+  });
+
+  it('warns when a user constructs withNx', () => {
+    let warn!: jest.SpyInstance;
+    jest.isolateModules(() => {
+      const { logger } = require('@nx/devkit');
+      warn = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+      const { withNx } = require('./with-nx');
+      withNx();
+    });
+
+    expect(warn).toHaveBeenCalledTimes(1);
+    expect(warn.mock.calls[0][0]).toContain('@nx/webpack');
+  });
+});

--- a/packages/webpack/src/utils/deprecation.ts
+++ b/packages/webpack/src/utils/deprecation.ts
@@ -26,3 +26,34 @@ export function warnWebpackExecutorGenerating(): void {
     'Generating targets that use the deprecated `@nx/webpack:webpack` and `@nx/webpack:dev-server` executors. These executors will be removed in Nx v24. Run `nx g @nx/webpack:convert-to-inferred` next to migrate these targets to the `@nx/webpack/plugin` inferred plugin and prevent future generators from emitting executor targets. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.'
   );
 }
+
+// TODO(v24): Remove the composePlugins/withNx/withWeb config helpers. They emit
+// an Nx-specific config function that only runs under the @nx/webpack:webpack
+// executor; the inferred @nx/webpack/plugin works with standard webpack configs
+// built around NxAppWebpackPlugin instead.
+export const WEBPACK_COMPOSE_HELPERS_DEPRECATION_MESSAGE =
+  'The `composePlugins`, `withNx`, and `withWeb` config helpers from `@nx/webpack` are deprecated and will be removed in Nx v24. They produce an Nx-specific config function that only runs under the `@nx/webpack:webpack` executor. Migrate to a standard webpack config that uses `NxAppWebpackPlugin` (from `@nx/webpack/app-plugin`) under the inferred `@nx/webpack/plugin` by running `nx g @nx/webpack:convert-to-inferred`. See https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.';
+
+let composeHelpersWarned = false;
+let suppressDepth = 0;
+
+// Nx-internal entry points compose these helpers themselves (e.g. the rspack
+// executor, the storybook/component-testing presets). They wrap their
+// synchronous composition in this so the warning fires only for user-authored
+// configs, not for users who never touched the compose helpers.
+export function suppressWebpackComposeHelperWarnings<T>(fn: () => T): T {
+  suppressDepth++;
+  try {
+    return fn();
+  } finally {
+    suppressDepth--;
+  }
+}
+
+// Warn once per process so a `composePlugins(withNx(), withWeb())` chain logs a
+// single line, not one per helper, and HMR reloads don't repeat it.
+export function warnWebpackComposeHelpersDeprecation(): void {
+  if (suppressDepth > 0 || composeHelpersWarned) return;
+  composeHelpersWarned = true;
+  logger.warn(WEBPACK_COMPOSE_HELPERS_DEPRECATION_MESSAGE);
+}

--- a/packages/webpack/src/utils/with-nx.ts
+++ b/packages/webpack/src/utils/with-nx.ts
@@ -3,18 +3,24 @@ import { NxComposableWebpackPlugin, NxWebpackExecutionContext } from './config';
 import { applyBaseConfig } from '../plugins/nx-webpack-plugin/lib/apply-base-config';
 import { NxAppWebpackPluginOptions } from '../plugins/nx-webpack-plugin/nx-app-webpack-plugin-options';
 import { normalizeAssets } from '../plugins/nx-webpack-plugin/lib/normalize-options';
+import { warnWebpackComposeHelpersDeprecation } from './deprecation';
 
 const processed = new Set();
 
 export type WithNxOptions = Partial<NxAppWebpackPluginOptions>;
 
 /**
+ * @deprecated Will be removed in Nx v24. Use `NxAppWebpackPlugin` from
+ * `@nx/webpack/app-plugin` in a standard webpack config and run
+ * `nx g @nx/webpack:convert-to-inferred`. See
+ * https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.
  * @param {WithNxOptions} pluginOptions
  * @returns {NxWebpackPlugin}
  */
 export function withNx(
   pluginOptions: WithNxOptions = {}
 ): NxComposableWebpackPlugin {
+  warnWebpackComposeHelpersDeprecation();
   return function configure(
     config: Configuration,
     { options, context }: NxWebpackExecutionContext

--- a/packages/webpack/src/utils/with-web.ts
+++ b/packages/webpack/src/utils/with-web.ts
@@ -6,6 +6,7 @@ import {
   NormalizedWebpackExecutorOptions,
 } from '../executors/webpack/schema';
 import { applyWebConfig } from '../plugins/nx-webpack-plugin/lib/apply-web-config';
+import { warnWebpackComposeHelpersDeprecation } from './deprecation';
 
 const processed = new Set();
 
@@ -36,12 +37,17 @@ export type MergedOptions = Omit<
   WithWebOptions;
 
 /**
+ * @deprecated Will be removed in Nx v24. Use `NxAppWebpackPlugin` from
+ * `@nx/webpack/app-plugin` in a standard webpack config and run
+ * `nx g @nx/webpack:convert-to-inferred`. See
+ * https://nx.dev/docs/guides/tasks--caching/convert-to-inferred for details.
  * @param {WithWebOptions} pluginOptions
  * @returns {NxWebpackPlugin}
  */
 export function withWeb(
   pluginOptions: WithWebOptions = {}
 ): NxComposableWebpackPlugin {
+  warnWebpackComposeHelpersDeprecation();
   return function configure(
     config: Configuration,
     { options, context }: NxWebpackExecutionContext


### PR DESCRIPTION
## Current Behavior

The `composePlugins`, `withNx`, `withWeb` (`@nx/webpack`, `@nx/rspack`) and `withReact` (`@nx/rspack`, `@nx/react/webpack`) config helpers emit an Nx-specific config function that only runs under the `@nx/webpack:webpack` / `@nx/rspack:rspack` executors. There is no deprecation signal steering users toward the inferred plugins.

## Expected Behavior

The helpers are deprecated for removal in Nx v24. They keep working in v23 but log a warn-once-per-package message pointing at the real plugin classes (`NxAppWebpackPlugin`/`NxAppRspackPlugin`/`NxReactWebpackPlugin`/`NxReactRspackPlugin`) and `nx g @nx/<bundler>:convert-to-inferred`. `@deprecated` JSDoc is added to each helper, plus caution asides on the webpack config/plugins and react asset docs. The warning fires only for user-authored configs: the rspack executor, storybook preset, and next.js component-testing preset compose these helpers internally and are wrapped in a suppression scope. Warn-only, no codemod, no generator changes.

## Related Issue(s)

NXC-4324

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/nxc-4324-2bacd010)
<!-- polygraph-session-end -->