### PR TITLE
fix(angular-rspack): dispose stylesheet bundler so one-shot builds exit

### DIFF
--- a/e2e/angular/project.json
+++ b/e2e/angular/project.json
@@ -3,7 +3,7 @@
   "$schema": "../../node_modules/nx/schemas/project-schema.json",
   "sourceRoot": "e2e/angular",
   "projectType": "application",
-  "implicitDependencies": ["angular"],
+  "implicitDependencies": ["angular", "angular-rspack"],
   "// targets": "to see all targets run: nx show project e2e-angular --web",
   "targets": {
     "lint": {

--- a/packages/angular-rspack-compiler/src/compilation/setup-compilation.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-compilation.ts
@@ -126,6 +126,25 @@ export async function setupCompilation(
   };
 }
 
+/**
+ * Dispose the shared component stylesheet bundler and reset the singleton.
+ *
+ * `@angular/build` >= 21.2.14 backs `ComponentStylesheetBundler` with a
+ * persistent esbuild build context (it previously used a one-shot
+ * `esbuild.build()` for non-incremental bundling). That context keeps an
+ * esbuild service - a child process and its sockets - alive until disposed,
+ * which prevents a one-shot `rspack build` from exiting once the bundle is
+ * written. Angular's own application builder disposes it in a `finally` block;
+ * we must do the same since we drive the bundler directly.
+ */
+export async function disposeComponentStylesheetBundler(): Promise<void> {
+  if (COMPONENT_STYLESHEET_BUNDLER) {
+    const bundler = COMPONENT_STYLESHEET_BUNDLER;
+    COMPONENT_STYLESHEET_BUNDLER = undefined;
+    await bundler.dispose();
+  }
+}
+
 export function styleTransform(
   componentStylesheetBundler: ComponentStylesheetBundler
 ) {

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
@@ -7,6 +7,7 @@ import {
 import {
   buildAndAnalyze,
   DiagnosticModes,
+  disposeComponentStylesheetBundler,
   JavaScriptTransformer,
   SourceFileCache,
   maxWorkers,
@@ -339,6 +340,28 @@ export class AngularRspackPlugin implements RspackPluginInstance {
         process.exit(1);
       }
     });
+
+    // Dispose the shared component stylesheet bundler after a one-shot build so
+    // its esbuild service (a child process and sockets, with @angular/build >=
+    // 21.2.14) is released and `rspack build` can exit. Safe per-compiler: an
+    // SSR build runs the server compiler after the browser one
+    // (`dependencies: ['browser']`), never concurrently, and `setupCompilation`
+    // lazily recreates the singleton if a later compiler needs it again. Watch
+    // builds keep the bundler for incremental rebuilds and tear it down on
+    // process shutdown instead.
+    compiler.hooks.done.tapAsync(
+      `${PLUGIN_NAME}_cleanup`,
+      async (_stats, callback) => {
+        if (!watchRunInitialized) {
+          try {
+            await disposeComponentStylesheetBundler();
+          } catch {
+            // Best-effort cleanup - never fail an otherwise successful build.
+          }
+        }
+        callback();
+      }
+    );
 
     compiler.hooks.normalModuleFactory.tap(
       PLUGIN_NAME,


### PR DESCRIPTION
## Current Behavior

`@angular/build@21.2.14` (published 2026-06-03) changed `ComponentStylesheetBundler` to back its bundling with a persistent esbuild `context()` instead of a one-shot `esbuild.build()`. That context keeps an esbuild service — a child process and its sockets — alive until it is explicitly disposed. `@angular/build`'s own application builder handles this with a `finally { await result.dispose() }`.

`@nx/angular-rspack` drives `ComponentStylesheetBundler` directly (a shared singleton in `setup-compilation.ts`) but never disposed it. With `@angular/build` <= 21.2.13 this was harmless because the one-shot `build()` cleaned up automatically; with >= 21.2.14 the esbuild service leaks and a one-shot `rspack build` never exits after the bundle is written.

Because the catalog/peer range for `@angular/build` allows `< 22.0.0`, a freshly created workspace now resolves `21.2.14`, so the `e2e/angular` "Convert Angular Webpack Project to Rspack" test fails with `Command timed out after 300s: build ...` even though the bundle builds successfully.

## Expected Behavior

After a one-shot build finishes, `@nx/angular-rspack` disposes the stylesheet bundler — releasing the esbuild service so `rspack build` exits cleanly:

- Adds `disposeComponentStylesheetBundler()` to `@nx/angular-rspack-compiler`, which disposes and resets the shared singleton.
- The plugin calls it from the compiler's `done` hook on a one-shot build. This is safe per-compiler: an SSR build runs the server compiler after the browser one (`dependencies: ['browser']`), never concurrently, and `setupCompilation` lazily recreates the singleton (`??=`) if a later compiler needs it again.
- Watch builds keep the bundler for incremental rebuilds and tear it down on process shutdown instead.

Verified directly against `@angular/build@21.2.14`: an undisposed bundler leaves a `ChildProcess` + sockets alive (the process hangs); calling `dispose()` closes them and the process exits.

## Related Issue(s)

Surfaced by the `e2e-angular` `misc.test.ts` regression after `@angular/build@21.2.14` published; no existing GitHub issue.
