### PR TITLE
fix(nextjs): multi-version support compliance (NXC-4395)

### DIFF
--- a/packages/next/migrations.json
+++ b/packages/next/migrations.json
@@ -19,6 +19,9 @@
   "packageJsonUpdates": {
     "20.7.1-beta.0": {
       "version": "20.7.1-beta.0",
+      "requires": {
+        "next": "^15.0.0"
+      },
       "packages": {
         "eslint-config-next": {
           "version": "^15.2.4",

--- a/packages/next/src/generators/application/application.spec.ts
+++ b/packages/next/src/generators/application/application.spec.ts
@@ -434,8 +434,8 @@ describe('app', () => {
         const packageJson = readJson(tree, '/package.json');
         expect(packageJson).toMatchObject({
           devDependencies: {
-            'eslint-config-next': '^15.2.4',
-            '@next/eslint-plugin-next': '^15.2.4',
+            'eslint-config-next': '^15.5.18',
+            '@next/eslint-plugin-next': '^15.5.18',
           },
         });
       });
@@ -461,8 +461,8 @@ describe('app', () => {
         const packageJson = readJson(tree, '/package.json');
         expect(packageJson).toMatchObject({
           devDependencies: {
-            'eslint-config-next': '~14.2.26',
-            '@next/eslint-plugin-next': '~14.2.26',
+            'eslint-config-next': '~14.2.35',
+            '@next/eslint-plugin-next': '~14.2.35',
           },
         });
       });

--- a/packages/next/src/generators/application/application.ts
+++ b/packages/next/src/generators/application/application.ts
@@ -7,6 +7,7 @@ import {
   runTasksInSerial,
   Tree,
 } from '@nx/devkit';
+import { assertSupportedNextVersion } from '../../utils/assert-supported-next-version';
 import { initGenerator as jsInitGenerator } from '@nx/js';
 import {
   testingLibraryDomVersion,
@@ -46,6 +47,8 @@ export async function applicationGenerator(host: Tree, schema: Schema) {
 }
 
 export async function applicationGeneratorInternal(host: Tree, schema: Schema) {
+  assertSupportedNextVersion(host);
+
   const tasks: GeneratorCallback[] = [];
 
   const addTsPlugin = shouldConfigureTsSolutionSetup(
@@ -128,7 +131,9 @@ export async function applicationGeneratorInternal(host: Tree, schema: Schema) {
       addDependenciesToPackageJson(
         host,
         { tslib: tsLibVersion },
-        devDependencies
+        devDependencies,
+        undefined,
+        true
       )
     );
   }

--- a/packages/next/src/generators/application/lib/add-linting.ts
+++ b/packages/next/src/generators/application/lib/add-linting.ts
@@ -115,11 +115,17 @@ export async function addLinting(
       await getEslintConfigNextDependenciesVersionsToInstall(host);
 
     tasks.push(
-      addDependenciesToPackageJson(host, extraEslintDependencies.dependencies, {
-        ...extraEslintDependencies.devDependencies,
-        'eslint-config-next': eslintConfigNextVersion,
-        '@next/eslint-plugin-next': eslintConfigNextVersion,
-      })
+      addDependenciesToPackageJson(
+        host,
+        extraEslintDependencies.dependencies,
+        {
+          ...extraEslintDependencies.devDependencies,
+          'eslint-config-next': eslintConfigNextVersion,
+          '@next/eslint-plugin-next': eslintConfigNextVersion,
+        },
+        undefined,
+        true
+      )
     );
   }
 

--- a/packages/next/src/generators/component/component.ts
+++ b/packages/next/src/generators/component/component.ts
@@ -9,6 +9,7 @@ import {
 import type { SupportedStyles } from '@nx/react';
 import { componentGenerator as reactComponentGenerator } from '@nx/react';
 import { addStyleDependencies } from '../../utils/styles';
+import { assertSupportedNextVersion } from '../../utils/assert-supported-next-version';
 
 interface Schema {
   path: string;
@@ -22,6 +23,7 @@ interface Schema {
  * extra dependencies for css, sass, less style options.
  */
 export async function componentGenerator(host: Tree, options: Schema) {
+  assertSupportedNextVersion(host);
   // we only need to provide the path to get the project, we let the react
   // generator handle the rest
   const { project: projectName } =

--- a/packages/next/src/generators/convert-to-inferred/convert-to-inferred.ts
+++ b/packages/next/src/generators/convert-to-inferred/convert-to-inferred.ts
@@ -7,6 +7,7 @@ import {
 import { createNodesV2 } from '../../plugins/plugin';
 import { buildPostTargetTransformer } from './lib/build-post-target-transformer';
 import { servePosTargetTransformer } from './lib/serve-post-target-tranformer';
+import { assertSupportedNextVersion } from '../../utils/assert-supported-next-version';
 
 interface Schema {
   project?: string;
@@ -14,6 +15,7 @@ interface Schema {
 }
 
 export async function convertToInferred(tree: Tree, options: Schema) {
+  assertSupportedNextVersion(tree);
   const projectGraph = await createProjectGraphAsync();
   const migrationLogs = new AggregatedLog();
 

--- a/packages/next/src/generators/custom-server/custom-server.ts
+++ b/packages/next/src/generators/custom-server/custom-server.ts
@@ -14,11 +14,13 @@ import { CustomServerSchema } from './schema';
 import { join } from 'path';
 import { configureForSwc } from '../../utils/add-swc-to-custom-server';
 import { isUsingTsSolutionSetup } from '@nx/js/internal';
+import { assertSupportedNextVersion } from '../../utils/assert-supported-next-version';
 
 export async function customServerGenerator(
   host: Tree,
   options: CustomServerSchema
 ) {
+  assertSupportedNextVersion(host);
   const project = readProjectConfiguration(host, options.project);
   const swcServerName = '.server.swcrc';
 

--- a/packages/next/src/generators/cypress-component-configuration/cypress-component-configuration.ts
+++ b/packages/next/src/generators/cypress-component-configuration/cypress-component-configuration.ts
@@ -15,6 +15,7 @@ import { componentTestGenerator } from '@nx/react';
 import { isComponent } from '@nx/react/src/utils/ct-utils';
 import { relative } from 'path';
 import { nxVersion } from '../../utils/versions';
+import { assertSupportedNextVersion } from '../../utils/assert-supported-next-version';
 import { CypressComponentConfigurationGeneratorSchema } from './schema';
 
 export function cypressComponentConfiguration(
@@ -31,6 +32,8 @@ export async function cypressComponentConfigurationInternal(
   tree: Tree,
   options: CypressComponentConfigurationGeneratorSchema
 ) {
+  assertSupportedNextVersion(tree);
+
   const tasks: GeneratorCallback[] = [];
 
   const { componentConfigurationGenerator: baseCyCtConfig } = ensurePackage<

--- a/packages/next/src/generators/init/init.ts
+++ b/packages/next/src/generators/init/init.ts
@@ -15,6 +15,7 @@ import {
 import { addGitIgnoreEntry } from '../../utils/add-gitignore-entry';
 import { nxVersion } from '../../utils/versions';
 import { getNextDependenciesVersionsToInstall } from '../../utils/version-utils';
+import { assertSupportedNextVersion } from '../../utils/assert-supported-next-version';
 import type { InitSchema } from './schema';
 
 async function updateDependencies(host: Tree, schema: InitSchema) {
@@ -40,7 +41,7 @@ async function updateDependencies(host: Tree, schema: InitSchema) {
         '@nx/next': nxVersion,
       },
       undefined,
-      schema.keepExistingVersions
+      schema.keepExistingVersions ?? true
     )
   );
 
@@ -55,6 +56,8 @@ export async function nextInitGeneratorInternal(
   host: Tree,
   schema: InitSchema
 ) {
+  assertSupportedNextVersion(host);
+
   const nxJson = readNxJson(host);
   const addPluginDefault =
     process.env.NX_ADD_PLUGINS !== 'false' &&

--- a/packages/next/src/generators/init/schema.json
+++ b/packages/next/src/generators/init/schema.json
@@ -21,7 +21,7 @@
       "type": "boolean",
       "x-priority": "internal",
       "description": "Keep existing dependencies versions",
-      "default": false
+      "default": true
     },
     "updatePackageScripts": {
       "type": "boolean",

--- a/packages/next/src/generators/library/library.ts
+++ b/packages/next/src/generators/library/library.ts
@@ -15,6 +15,7 @@ import {
 } from '@nx/react/src/utils/versions';
 
 import { nextInitGenerator } from '../init/init';
+import { assertSupportedNextVersion } from '../../utils/assert-supported-next-version';
 import { Schema } from './schema';
 import { normalizeOptions } from './lib/normalize-options';
 import { updateViteConfigForServerEntry } from './lib/update-vite-config';
@@ -36,6 +37,8 @@ export async function libraryGenerator(host: Tree, rawOptions: Schema) {
 }
 
 export async function libraryGeneratorInternal(host: Tree, rawOptions: Schema) {
+  assertSupportedNextVersion(host);
+
   const tasks: GeneratorCallback[] = [];
 
   const addTsPlugin = shouldConfigureTsSolutionSetup(
@@ -79,7 +82,9 @@ export async function libraryGeneratorInternal(host: Tree, rawOptions: Schema) {
       addDependenciesToPackageJson(
         host,
         { tslib: tsLibVersion },
-        devDependencies
+        devDependencies,
+        undefined,
+        true
       )
     );
   }

--- a/packages/next/src/generators/page/page.ts
+++ b/packages/next/src/generators/page/page.ts
@@ -12,6 +12,7 @@ import {
 } from '@nx/devkit';
 
 import { addStyleDependencies } from '../../utils/styles';
+import { assertSupportedNextVersion } from '../../utils/assert-supported-next-version';
 import { Schema } from './schema';
 
 /*
@@ -20,6 +21,7 @@ import { Schema } from './schema';
  * it is under `pages` folder.
  */
 export async function pageGenerator(host: Tree, schema: Schema) {
+  assertSupportedNextVersion(host);
   const options = await normalizeOptions(host, schema);
   const componentTask = await reactComponentGenerator(host, {
     ...options,

--- a/packages/next/src/plugins/plugin.ts
+++ b/packages/next/src/plugins/plugin.ts
@@ -210,8 +210,10 @@ async function getBuildTargetConfig(
     outputs: [`${nextOutputPath}/!(cache)/**/*`, `${nextOutputPath}/!(cache)`],
   };
 
-  // TODO(ndcunningham): Update this to be consider different versions of next.js which is running
-  // This doesn't actually need to be tty, but next.js has a bug, https://github.com/vercel/next.js/issues/62906, where it exits 0 when SIGINT is sent.
+  // v14/v15/v16 all emit the same `next build` inferred target shape - no per-major branch needed.
+  // The tty=false is not version-specific: Next.js exits 0 on SIGINT regardless of major
+  // (https://github.com/vercel/next.js/issues/62906). Turbopack-default-on (v16+) and other
+  // bundler differences live at the executor / runtime layer, not here.
   targetConfig.options.tty = false;
 
   if (isTsSolutionSetup) {

--- a/packages/next/src/utils/add-swc-to-custom-server.ts
+++ b/packages/next/src/utils/add-swc-to-custom-server.ts
@@ -53,6 +53,8 @@ function addSwcDependencies(tree: Tree) {
       '@swc-node/register': swcNodeVersion,
       '@swc/cli': swcCliVersion,
       '@swc/core': swcCoreVersion,
-    }
+    },
+    undefined,
+    true
   );
 }

--- a/packages/next/src/utils/all-generators-enforce-floor.spec.ts
+++ b/packages/next/src/utils/all-generators-enforce-floor.spec.ts
@@ -1,0 +1,10 @@
+import { assertGeneratorsEnforceVersionFloor } from '@nx/devkit/internal-testing-utils';
+import { join } from 'node:path';
+
+describe('@nx/next generators enforce supported version floor', () => {
+  assertGeneratorsEnforceVersionFloor({
+    packageRoot: join(__dirname, '..', '..'),
+    packageName: 'next',
+    subFloorVersion: '~13.5.0',
+  });
+});

--- a/packages/next/src/utils/assert-supported-next-version.ts
+++ b/packages/next/src/utils/assert-supported-next-version.ts
@@ -1,0 +1,7 @@
+import { type Tree } from '@nx/devkit';
+import { assertSupportedPackageVersion } from '@nx/devkit/internal';
+import { minSupportedNextVersion } from './versions';
+
+export function assertSupportedNextVersion(tree: Tree): void {
+  assertSupportedPackageVersion(tree, 'next', minSupportedNextVersion);
+}

--- a/packages/next/src/utils/styles.ts
+++ b/packages/next/src/utils/styles.ts
@@ -27,7 +27,9 @@ export function addStyleDependencies(
     ? addDependenciesToPackageJson(
         host,
         extraDependencies.dependencies,
-        extraDependencies.devDependencies
+        extraDependencies.devDependencies,
+        undefined,
+        true
       )
     : () => {};
 }

--- a/packages/next/src/utils/versions.ts
+++ b/packages/next/src/utils/versions.ts
@@ -1,12 +1,14 @@
 export const nxVersion = require('../../package.json').version;
 
+export const minSupportedNextVersion = '14.0.0';
+
 export const next16Version = '~16.1.6';
-export const next15Version = '~15.2.4';
-export const next14Version = '~14.2.26';
+export const next15Version = '~15.5.18';
+export const next14Version = '~14.2.35';
 export const nextVersion = next16Version;
 export const eslintConfigNext16Version = '^16.1.6';
-export const eslintConfigNext15Version = '^15.2.4';
-export const eslintConfigNext14Version = '~14.2.26';
+export const eslintConfigNext15Version = '^15.5.18';
+export const eslintConfigNext14Version = '~14.2.35';
 export const eslintConfigNextVersion = eslintConfigNext16Version;
 export const sassVersion = '1.97.2';
 export const tsLibVersion = '^2.3.0';


### PR DESCRIPTION
## Current Behavior

`@nx/next` has no below-floor guard; generators silently fall back to latest install constants on unsupported Next versions. The base `20.7.1-beta.0` migration bumps `eslint-config-next` ungated, hitting v14 users.

## Expected Behavior

`assertSupportedNextVersion` (floor Next 14) throws on sub-floor and is the first statement in every generator. The base `20.7.1-beta.0` migration is gated to `>=15` so v14 users keep the v14 eslint-config lane. Support window kept at v14+v15+v16.

## Related Issue(s)

Fixes NXC-4395

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/multi-4395-ae050ce9)
<!-- polygraph-session-end -->