### PR TITLE
docs(nx-dev): show spread token for extending target defaults

### DIFF
--- a/astro-docs/src/content/docs/getting-started/Tutorials/caching.mdoc
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/caching.mdoc
@@ -53,7 +53,7 @@ Caching is opt-in per task. The recommended approach is to set `cache: true` in 
 
 You can also enable caching per-project in `package.json` or `project.json`:
 
-{% tabs %}
+{% tabs syncKey="project-config-file" %}
 {% tabitem label="package.json" %}
 
 ```jsonc
@@ -154,6 +154,45 @@ Local cache is stored in `.nx/cache` by default. Run `nx reset` to clear all loc
   },
 }
 ```
+
+When a single project needs an extra input on top of the shared defaults, add it per project with the spread token (`"..."`):
+
+{% tabs syncKey="project-config-file" %}
+{% tabitem label="package.json" %}
+
+```jsonc
+// apps/my-app/package.json
+{
+  "nx": {
+    "targets": {
+      "build": {
+        "inputs": ["...", "{projectRoot}/src/**/*.json"],
+        "outputs": ["{projectRoot}/dist"],
+      },
+    },
+  },
+}
+```
+
+{% /tabitem %}
+{% tabitem label="project.json" %}
+
+```jsonc
+// apps/my-app/project.json
+{
+  "targets": {
+    "build": {
+      "inputs": ["...", "{projectRoot}/src/**/*.json"],
+      "outputs": ["{projectRoot}/dist"],
+    },
+  },
+}
+```
+
+{% /tabitem %}
+{% /tabs %}
+
+The `"..."` in `inputs` expands to the inputs already set in `targetDefaults`, so this project keeps `{projectRoot}/src/**/*` and `{projectRoot}/tsconfig.json` and adds `{projectRoot}/src/**/*.json`. The `outputs` array has no spread token, so it replaces the default. For the full reference, see [spread token](/docs/reference/project-configuration#spread-token).
 
 ### Smart defaults
 

--- a/astro-docs/src/content/docs/getting-started/Tutorials/configuring-tasks.mdoc
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/configuring-tasks.mdoc
@@ -113,7 +113,7 @@ The `^` prefix means "the same task on projects this project depends on." So `nx
 
 You can also define dependencies without `^` for tasks within the same project:
 
-{% tabs %}
+{% tabs syncKey="project-config-file" %}
 {% tabitem label="package.json" %}
 
 ```jsonc
@@ -160,7 +160,7 @@ Here, `build` always runs `generate-api-types` first within the same project.
 
 Some tasks, like development servers, never exit. If another task depends on a long-running process, it would wait forever. Mark these tasks as `continuous` so Nx starts them alongside their dependents instead of waiting for them to finish:
 
-{% tabs %}
+{% tabs syncKey="project-config-file" %}
 {% tabitem label="package.json" %}
 
 ```jsonc
@@ -227,6 +227,47 @@ When many projects share the same task configuration, defining it in every `proj
 ```
 
 Individual projects can still override these defaults when needed. The cascade order is: project-level config > target defaults > defaults.
+
+### Extending target defaults for a project
+
+By default, when a project redefines a property it replaces the target default entirely. So if `build` defaults to `dependsOn: ["^build"]` and a project sets its own `dependsOn`, the `^build` entry is lost.
+
+Use the spread token (`"..."`) to extend that configuration rather than replace it:
+
+{% tabs syncKey="project-config-file" %}
+{% tabitem label="package.json" %}
+
+```jsonc
+// apps/my-app/package.json
+{
+  "nx": {
+    "targets": {
+      "build": {
+        "dependsOn": ["...", "generate-api-types"],
+      },
+    },
+  },
+}
+```
+
+{% /tabitem %}
+{% tabitem label="project.json" %}
+
+```jsonc
+// apps/my-app/project.json
+{
+  "targets": {
+    "build": {
+      "dependsOn": ["...", "generate-api-types"],
+    },
+  },
+}
+```
+
+{% /tabitem %}
+{% /tabs %}
+
+The `"..."` expands to whatever configuration the target already has, so here `my-app`'s `build` keeps `^build` and adds `generate-api-types`. That existing configuration can come from `targetDefaults` or a plugin's inferred task, not only from target defaults. The token also works in objects and configurations. For the full reference, see [spread token](/docs/reference/project-configuration#spread-token).
 
 For more on reducing configuration, see [Reducing Configuration Boilerplate](/docs/getting-started/tutorials/reducing-configuration-boilerplate).
 

--- a/astro-docs/src/content/docs/getting-started/Tutorials/reducing-configuration-boilerplate.mdoc
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/reducing-configuration-boilerplate.mdoc
@@ -40,7 +40,7 @@ This tutorial assumes you have an Nx workspace with configured tasks. If you're 
 
 Consider a workspace with 20 libraries, each with verbose task configuration:
 
-{% tabs %}
+{% tabs syncKey="project-config-file" %}
 {% tabitem label="package.json" %}
 
 ```jsonc
@@ -126,7 +126,7 @@ Move shared configuration to `nx.json` so projects inherit defaults:
 
 Now each project only needs to specify what's unique:
 
-{% tabs %}
+{% tabs syncKey="project-config-file" %}
 {% tabitem label="package.json" %}
 
 ```jsonc
@@ -355,6 +355,43 @@ Task configuration can come from three sources, applied in this order:
 3. **Project-level**: explicit `project.json` or `package.json` config (highest priority)
 
 Each layer can override the previous one. This means you can use plugins for sensible defaults and only add project-level config when a project needs something different.
+
+Overriding replaces the inherited value. When a project needs to add to that configuration instead, whether it comes from `targetDefaults` or an inferred plugin task, use the spread token (`"..."`):
+
+{% tabs syncKey="project-config-file" %}
+{% tabitem label="package.json" %}
+
+```jsonc
+// packages/my-lib/package.json
+{
+  "nx": {
+    "targets": {
+      "build": {
+        "inputs": ["...", "{projectRoot}/extra.config.ts"],
+      },
+    },
+  },
+}
+```
+
+{% /tabitem %}
+{% tabitem label="project.json" %}
+
+```jsonc
+// packages/my-lib/project.json
+{
+  "targets": {
+    "build": {
+      "inputs": ["...", "{projectRoot}/extra.config.ts"],
+    },
+  },
+}
+```
+
+{% /tabitem %}
+{% /tabs %}
+
+Here `"..."` expands to the `inputs` already inferred for `build`, so the project keeps them and adds `{projectRoot}/extra.config.ts`. For the full reference, see [spread token](/docs/reference/project-configuration#spread-token).
 
 ## This is optional
 


### PR DESCRIPTION
## Current Behavior

The Configuring Tasks tutorial only covers overriding `targetDefaults`.

## Expected Behavior

Adds a section showing the `"..."` spread token to extend a target default for a project instead of replacing it.

Preview: https://deploy-preview-35871--nx-docs.netlify.app/docs/getting-started/tutorials/configuring-tasks#extending-target-defaults-for-a-project

## Related Issue(s)

DOC-509

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/docs-spread-6df4621c)
<!-- polygraph-session-end -->