### PR TITLE
fix(react): multi-version support compliance (NXC-4399)

### DIFF
--- a/packages/react/eslint.config.mjs
+++ b/packages/react/eslint.config.mjs
@@ -56,6 +56,7 @@ export default [
             'prettier',
             'typescript',
             'react',
+            'react-dom',
             '@nx/cypress',
             '@nx/playwright',
             '@nx/jest',

--- a/packages/react/migrations.json
+++ b/packages/react/migrations.json
@@ -61,6 +61,9 @@
     },
     "20.1.0": {
       "version": "20.1.0-beta.0",
+      "requires": {
+        "eslint-plugin-react-hooks": ">=4.0.0 <5.0.0"
+      },
       "packages": {
         "eslint-plugin-react-hooks": {
           "version": "5.0.0",
@@ -74,6 +77,9 @@
     },
     "20.2.0": {
       "version": "20.2.0-beta.3",
+      "requires": {
+        "@module-federation/enhanced": ">=0.6.0 <0.7.0"
+      },
       "packages": {
         "@module-federation/enhanced": {
           "version": "0.7.6",
@@ -95,6 +101,9 @@
     },
     "20.3.0": {
       "version": "20.3.0-beta.0",
+      "requires": {
+        "@testing-library/react": ">=15.0.0 <16.0.0"
+      },
       "packages": {
         "@testing-library/react": {
           "version": "16.1.0",
@@ -104,6 +113,9 @@
     },
     "21.4.0": {
       "version": "21.4.0-beta.8",
+      "requires": {
+        "http-proxy-middleware": ">=2.0.0 <3.0.0"
+      },
       "packages": {
         "http-proxy-middleware": {
           "version": "^3.0.5",
@@ -113,6 +125,9 @@
     },
     "22.2.0": {
       "version": "22.2.0-beta.0",
+      "requires": {
+        "@module-federation/enhanced": ">=0.7.0 <0.8.0"
+      },
       "packages": {
         "@module-federation/enhanced": {
           "version": "^0.21.2",
@@ -151,11 +166,22 @@
     },
     "22.3.4": {
       "version": "22.3.4-beta.0",
+      "requires": {
+        "react-router-dom": ">=6.0.0 <7.0.0"
+      },
       "packages": {
         "react-router-dom": {
           "version": "6.30.3",
           "alwaysAddToPackageJson": false
-        },
+        }
+      }
+    },
+    "22.3.4-react-router": {
+      "version": "22.3.4-beta.0",
+      "requires": {
+        "react-router": ">=7.0.0 <8.0.0"
+      },
+      "packages": {
         "react-router": {
           "version": "7.12.0",
           "alwaysAddToPackageJson": false
@@ -196,6 +222,9 @@
     },
     "22.6.0": {
       "version": "22.6.0-beta.10",
+      "requires": {
+        "@module-federation/enhanced": ">=0.21.0 <1.0.0"
+      },
       "x-prompt": "Bump @module-federation packages to v2.x to resolve koa CVE-2026-27959 (via dts-plugin)",
       "packages": {
         "@module-federation/enhanced": {
@@ -210,6 +239,9 @@
     },
     "22.7.0": {
       "version": "22.7.0-beta.18",
+      "requires": {
+        "react-router": ">=7.0.0 <8.0.0"
+      },
       "packages": {
         "react-router": {
           "version": "7.14.2",

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -32,6 +32,10 @@
     "requirements": {},
     "migrations": "./migrations.json"
   },
+  "peerDependencies": {
+    "react": ">=18.0.0 <20.0.0",
+    "react-dom": ">=18.0.0 <20.0.0"
+  },
   "dependencies": {
     "@phenomnomnominal/tsquery": "catalog:typescript",
     "@svgr/webpack": "catalog:",

--- a/packages/react/src/generators/application/application.ts
+++ b/packages/react/src/generators/application/application.ts
@@ -2,6 +2,7 @@ import {
   logShowProjectCommand,
   promptWhenInteractive,
 } from '@nx/devkit/internal';
+import { assertSupportedReactVersion } from '../../utils/assert-supported-react-version';
 import {
   formatFiles,
   GeneratorCallback,
@@ -60,6 +61,8 @@ export async function applicationGeneratorInternal(
   tree: Tree,
   schema: Schema
 ): Promise<GeneratorCallback> {
+  assertSupportedReactVersion(tree);
+
   const tasks = [];
 
   const addTsPlugin = shouldConfigureTsSolutionSetup(

--- a/packages/react/src/generators/application/lib/add-linting.ts
+++ b/packages/react/src/generators/application/lib/add-linting.ts
@@ -63,7 +63,9 @@ export async function addLinting(host: Tree, options: NormalizedSchema) {
       const installTask = addDependenciesToPackageJson(
         host,
         extraEslintDependencies.dependencies,
-        extraEslintDependencies.devDependencies
+        extraEslintDependencies.devDependencies,
+        undefined,
+        true
       );
       const addSwcTask = addSwcDependencies(host);
       tasks.push(installTask, addSwcTask);

--- a/packages/react/src/generators/application/lib/add-routing.ts
+++ b/packages/react/src/generators/application/lib/add-routing.ts
@@ -48,7 +48,9 @@ export function addRouting(host: Tree, options: NormalizedSchema) {
     return addDependenciesToPackageJson(
       host,
       { 'react-router-dom': reactRouterDomVersion },
-      {}
+      {},
+      undefined,
+      true
     );
   }
 

--- a/packages/react/src/generators/application/lib/bundlers/add-rsbuild.ts
+++ b/packages/react/src/generators/application/lib/bundlers/add-rsbuild.ts
@@ -83,5 +83,5 @@ export async function setupRsbuildConfiguration(
   addHtmlTemplatePath(tree, pathToConfigFile, './src/index.html');
   addCopyAssets(tree, pathToConfigFile, './src/assets');
   addCopyAssets(tree, pathToConfigFile, './src/favicon.ico');
-  tasks.push(addDependenciesToPackageJson(tree, {}, deps));
+  tasks.push(addDependenciesToPackageJson(tree, {}, deps, undefined, true));
 }

--- a/packages/react/src/generators/application/lib/install-common-dependencies.ts
+++ b/packages/react/src/generators/application/lib/install-common-dependencies.ts
@@ -8,7 +8,6 @@ import {
   testingLibraryDomVersion,
   tsLibVersion,
   typesNodeVersion,
-  reactRouterVersion,
   reactRouterIsBotVersion,
 } from '../../../utils/versions';
 import { NormalizedSchema } from '../schema';
@@ -31,7 +30,7 @@ export async function installCommonDependencies(
     '@types/node': typesNodeVersion,
     ...(options.useReactRouter
       ? {
-          '@react-router/dev': reactRouterVersion,
+          '@react-router/dev': reactDeps['react-router'],
         }
       : {}),
   };
@@ -41,9 +40,9 @@ export async function installCommonDependencies(
   }
 
   if (options.useReactRouter) {
-    dependencies['react-router'] = reactRouterVersion;
-    dependencies['@react-router/node'] = reactRouterVersion;
-    dependencies['@react-router/serve'] = reactRouterVersion;
+    dependencies['react-router'] = reactDeps['react-router'];
+    dependencies['@react-router/node'] = reactDeps['react-router'];
+    dependencies['@react-router/serve'] = reactDeps['react-router'];
     dependencies['isbot'] = reactRouterIsBotVersion;
   }
 
@@ -71,5 +70,11 @@ export async function installCommonDependencies(
     devDependencies['@testing-library/dom'] = testingLibraryDomVersion;
   }
 
-  return addDependenciesToPackageJson(host, dependencies, devDependencies);
+  return addDependenciesToPackageJson(
+    host,
+    dependencies,
+    devDependencies,
+    undefined,
+    true
+  );
 }

--- a/packages/react/src/generators/component-story/component-story.ts
+++ b/packages/react/src/generators/component-story/component-story.ts
@@ -6,6 +6,7 @@ import {
   normalizePath,
   Tree,
 } from '@nx/devkit';
+import { assertSupportedReactVersion } from '../../utils/assert-supported-react-version';
 import { ensureTypescript, getProjectSourceRoot } from '@nx/js/internal';
 import type * as ts from 'typescript';
 import {
@@ -149,6 +150,8 @@ export async function componentStoryGenerator(
   host: Tree,
   schema: CreateComponentStoriesFileSchema
 ) {
+  assertSupportedReactVersion(host);
+
   createComponentStoriesFile(host, {
     ...schema,
     interactionTests: schema.interactionTests ?? true,

--- a/packages/react/src/generators/component-test/component-test.ts
+++ b/packages/react/src/generators/component-test/component-test.ts
@@ -5,6 +5,7 @@ import {
   readProjectConfiguration,
   Tree,
 } from '@nx/devkit';
+import { assertSupportedReactVersion } from '../../utils/assert-supported-react-version';
 import { ensureTypescript, getProjectSourceRoot } from '@nx/js/internal';
 import { basename, dirname, extname, join, relative } from 'path';
 import {
@@ -21,6 +22,7 @@ export async function componentTestGenerator(
   tree: Tree,
   options: ComponentTestSchema
 ) {
+  assertSupportedReactVersion(tree);
   ensurePackage('@nx/cypress', nxVersion);
   // normalize any windows paths
   options.componentPath = options.componentPath.replace(/\\/g, '/');

--- a/packages/react/src/generators/component/component.ts
+++ b/packages/react/src/generators/component/component.ts
@@ -14,12 +14,15 @@ import { dirname, join, parse, relative } from 'path';
 
 import { addImport } from '../../utils/ast-utils';
 import { getInSourceVitestTestsTemplate } from '../../utils/get-in-source-vitest-tests-template';
-import { reactRouterDomVersion } from '../../utils/versions';
 import { getComponentTests } from './lib/get-component-tests';
 import { NormalizedSchema, Schema } from './schema';
 import { normalizeOptions } from './lib/normalize-options';
+import { reactRouterDomVersion } from '../../utils/versions';
+import { assertSupportedReactVersion } from '../../utils/assert-supported-react-version';
 
 export async function componentGenerator(host: Tree, schema: Schema) {
+  assertSupportedReactVersion(host);
+
   const options = await normalizeOptions(host, schema);
   createComponentFiles(host, options);
 
@@ -31,7 +34,9 @@ export async function componentGenerator(host: Tree, schema: Schema) {
     const routingTask = addDependenciesToPackageJson(
       host,
       { 'react-router-dom': reactRouterDomVersion },
-      {}
+      {},
+      undefined,
+      true
     );
     tasks.push(routingTask);
   }

--- a/packages/react/src/generators/consumer/consumer.ts
+++ b/packages/react/src/generators/consumer/consumer.ts
@@ -9,6 +9,7 @@ import {
   runTasksInSerial,
   Tree,
 } from '@nx/devkit';
+import { assertSupportedReactVersion } from '../../utils/assert-supported-react-version';
 import { typescriptVersion } from '@nx/js/src/utils/versions';
 import {
   reactVersion,
@@ -44,6 +45,8 @@ export async function consumerGenerator(
   tree: Tree,
   schema: ConsumerGeneratorSchema
 ): Promise<GeneratorCallback> {
+  assertSupportedReactVersion(tree);
+
   const opts = await normalizeScaffoldOptions(tree, {
     directory: schema.directory,
     surface: 'consumer',
@@ -171,7 +174,13 @@ export async function consumerGenerator(
   // resolve when nx invokes the generated run-commands serve target.
   const deps = getConsumerDeps(opts.bundler);
   tasks.push(
-    addDependenciesToPackageJson(tree, deps.dependencies, deps.devDependencies)
+    addDependenciesToPackageJson(
+      tree,
+      deps.dependencies,
+      deps.devDependencies,
+      undefined,
+      true
+    )
   );
 
   await formatFiles(tree);

--- a/packages/react/src/generators/cypress-component-configuration/cypress-component-configuration.ts
+++ b/packages/react/src/generators/cypress-component-configuration/cypress-component-configuration.ts
@@ -5,6 +5,7 @@ import {
   readProjectConfiguration,
   Tree,
 } from '@nx/devkit';
+import { assertSupportedReactVersion } from '../../utils/assert-supported-react-version';
 import type { GeneratorCallback } from '@nx/devkit';
 import { nxVersion } from '../../utils/versions';
 import { addFiles } from './lib/add-files';
@@ -30,6 +31,8 @@ export async function cypressComponentConfigGeneratorInternal(
   tree: Tree,
   options: CypressComponentConfigurationSchema
 ): Promise<GeneratorCallback> {
+  assertSupportedReactVersion(tree);
+
   const { componentConfigurationGenerator: baseCyCtConfig } = ensurePackage<
     typeof import('@nx/cypress')
   >('@nx/cypress', nxVersion);

--- a/packages/react/src/generators/cypress-component-configuration/lib/add-files.ts
+++ b/packages/react/src/generators/cypress-component-configuration/lib/add-files.ts
@@ -60,14 +60,26 @@ export async function addFiles(
     options.bundler === 'webpack' ||
     (!options.bundler && actualBundler === 'webpack')
   ) {
-    addDependenciesToPackageJson(tree, {}, { '@nx/webpack': nxVersion });
+    addDependenciesToPackageJson(
+      tree,
+      {},
+      { '@nx/webpack': nxVersion },
+      undefined,
+      true
+    );
   }
 
   if (
     options.bundler === 'vite' ||
     (!options.bundler && actualBundler === 'vite')
   ) {
-    addDependenciesToPackageJson(tree, {}, { '@nx/vite': nxVersion });
+    addDependenciesToPackageJson(
+      tree,
+      {},
+      { '@nx/vite': nxVersion },
+      undefined,
+      true
+    );
   }
 
   if (options.generateTests) {

--- a/packages/react/src/generators/federate-module/federate-module.ts
+++ b/packages/react/src/generators/federate-module/federate-module.ts
@@ -1,4 +1,5 @@
 import { determineProjectNameAndRootOptions } from '@nx/devkit/internal';
+import { assertSupportedReactVersion } from '../../utils/assert-supported-react-version';
 import {
   GeneratorCallback,
   Tree,
@@ -18,6 +19,7 @@ import { addTsConfigPath, getRootTsConfigPathInTree } from '@nx/js';
 import { warnReactFederateModuleGeneratorDeprecation } from '../../utils/module-federation-deprecation';
 
 export async function federateModuleGenerator(tree: Tree, schema: Schema) {
+  assertSupportedReactVersion(tree);
   warnReactFederateModuleGeneratorDeprecation();
   // Check if the file exists
   if (!tree.exists(schema.path)) {

--- a/packages/react/src/generators/hook/hook.ts
+++ b/packages/react/src/generators/hook/hook.ts
@@ -2,6 +2,7 @@ import {
   determineArtifactNameAndDirectoryOptions,
   type FileExtensionType,
 } from '@nx/devkit/internal';
+import { assertSupportedReactVersion } from '../../utils/assert-supported-react-version';
 // TODO(jack): Remove inline renderHook function when RTL releases with its own version
 import {
   applyChangesToString,
@@ -29,6 +30,8 @@ interface NormalizedSchema extends Omit<Schema, 'js'> {
 }
 
 export async function hookGenerator(host: Tree, schema: Schema) {
+  assertSupportedReactVersion(host);
+
   const options = await normalizeOptions(host, schema);
 
   createFiles(host, options);

--- a/packages/react/src/generators/host/host.ts
+++ b/packages/react/src/generators/host/host.ts
@@ -1,4 +1,5 @@
 import { ensureRootProjectName } from '@nx/devkit/internal';
+import { assertSupportedReactVersion } from '../../utils/assert-supported-react-version';
 import {
   addDependenciesToPackageJson,
   detectPackageManager,
@@ -40,6 +41,7 @@ export async function hostGenerator(
   host: Tree,
   schema: Schema
 ): Promise<GeneratorCallback> {
+  assertSupportedReactVersion(host);
   warnReactHostGeneratorDeprecation();
   const tasks: GeneratorCallback[] = [];
   const name = await normalizeHostName(host, schema.directory, schema.name);
@@ -178,7 +180,9 @@ export async function hostGenerator(
     {
       '@nx/web': nxVersion,
       '@nx/module-federation': nxVersion,
-    }
+    },
+    undefined,
+    true
   );
   tasks.push(installTask);
 

--- a/packages/react/src/generators/host/lib/setup-ssr-for-host.ts
+++ b/packages/react/src/generators/host/lib/setup-ssr-for-host.ts
@@ -96,7 +96,9 @@ export async function setupSsrForHost(
       express: expressVersion,
       '@types/express': typesExpressVersion,
     },
-    {}
+    {},
+    undefined,
+    true
   );
   tasks.push(installTask);
 

--- a/packages/react/src/generators/init/init.ts
+++ b/packages/react/src/generators/init/init.ts
@@ -12,9 +12,12 @@ import {
 import { nxVersion } from '../../utils/versions';
 import { InitSchema } from './schema';
 import { getReactDependenciesVersionsToInstall } from '../../utils/version-utils';
+import { assertSupportedReactVersion } from '../../utils/assert-supported-react-version';
 import { createNodes } from '../../plugins/router-plugin';
 
 export async function reactInitGenerator(tree: Tree, schema: InitSchema) {
+  assertSupportedReactVersion(tree);
+
   const tasks: GeneratorCallback[] = [];
 
   if (!schema.skipPackageJson) {
@@ -31,7 +34,7 @@ export async function reactInitGenerator(tree: Tree, schema: InitSchema) {
           '@nx/react': nxVersion,
         },
         undefined,
-        schema.keepExistingVersions
+        schema.keepExistingVersions ?? true
       )
     );
   }

--- a/packages/react/src/generators/init/schema.json
+++ b/packages/react/src/generators/init/schema.json
@@ -20,7 +20,7 @@
       "type": "boolean",
       "x-priority": "internal",
       "description": "Keep existing dependencies versions",
-      "default": false
+      "default": true
     },
     "useReactRouterPlugin": {
       "type": "boolean",

--- a/packages/react/src/generators/library/lib/add-linting.ts
+++ b/packages/react/src/generators/library/lib/add-linting.ts
@@ -71,7 +71,9 @@ export async function addLinting(host: Tree, options: NormalizedSchema) {
       installTask = addDependenciesToPackageJson(
         host,
         extraEslintDependencies.dependencies,
-        extraEslintDependencies.devDependencies
+        extraEslintDependencies.devDependencies,
+        undefined,
+        true
       );
       tasks.push(installTask);
     }

--- a/packages/react/src/generators/library/lib/add-rollup-build-target.ts
+++ b/packages/react/src/generators/library/lib/add-rollup-build-target.ts
@@ -48,7 +48,9 @@ export async function addRollupBuildTarget(
         {
           '@rollup/plugin-url': rollupPluginUrlVersion,
           '@svgr/rollup': svgrRollupVersion,
-        }
+        },
+        undefined,
+        true
       )
     );
   }

--- a/packages/react/src/generators/library/lib/install-common-dependencies.ts
+++ b/packages/react/src/generators/library/lib/install-common-dependencies.ts
@@ -53,7 +53,9 @@ export async function installCommonDependencies(
   const baseInstallTask = addDependenciesToPackageJson(
     host,
     dependencies,
-    devDependencies
+    devDependencies,
+    undefined,
+    true
   );
   tasks.push(baseInstallTask);
 
@@ -67,7 +69,9 @@ export async function installCommonDependencies(
         {
           '@babel/preset-react': babelPresetReactVersion,
           '@babel/core': babelCoreVersion,
-        }
+        },
+        undefined,
+        true
       )
     );
   }

--- a/packages/react/src/generators/library/lib/update-app-routes.ts
+++ b/packages/react/src/generators/library/lib/update-app-routes.ts
@@ -45,7 +45,9 @@ export function updateAppRoutes(host: Tree, options: NormalizedSchema) {
     {
       'react-router-dom': reactRouterDomVersion,
     },
-    {}
+    {},
+    undefined,
+    true
   );
 
   // addBrowserRouterToMain

--- a/packages/react/src/generators/library/library.ts
+++ b/packages/react/src/generators/library/library.ts
@@ -1,4 +1,5 @@
 import { getRelativeCwd, logShowProjectCommand } from '@nx/devkit/internal';
+import { assertSupportedReactVersion } from '../../utils/assert-supported-react-version';
 import {
   addProjectConfiguration,
   ensurePackage,
@@ -52,6 +53,8 @@ export async function libraryGenerator(host: Tree, schema: Schema) {
 }
 
 export async function libraryGeneratorInternal(host: Tree, schema: Schema) {
+  assertSupportedReactVersion(host);
+
   const tasks: GeneratorCallback[] = [];
 
   const addTsPlugin = shouldConfigureTsSolutionSetup(host, schema.addPlugin);

--- a/packages/react/src/generators/provider/provider.ts
+++ b/packages/react/src/generators/provider/provider.ts
@@ -9,6 +9,7 @@ import {
   runTasksInSerial,
   Tree,
 } from '@nx/devkit';
+import { assertSupportedReactVersion } from '../../utils/assert-supported-react-version';
 import { typescriptVersion } from '@nx/js/src/utils/versions';
 import {
   reactVersion,
@@ -39,6 +40,8 @@ export async function providerGenerator(
   tree: Tree,
   schema: ProviderGeneratorSchema
 ): Promise<GeneratorCallback> {
+  assertSupportedReactVersion(tree);
+
   const opts = await normalizeScaffoldOptions(tree, {
     directory: schema.directory,
     surface: 'provider',
@@ -121,7 +124,9 @@ export async function providerGenerator(
   const installTask = addDependenciesToPackageJson(
     tree,
     deps.dependencies,
-    deps.devDependencies
+    deps.devDependencies,
+    undefined,
+    true
   );
 
   await formatFiles(tree);

--- a/packages/react/src/generators/redux/redux.ts
+++ b/packages/react/src/generators/redux/redux.ts
@@ -1,4 +1,5 @@
 import { determineArtifactNameAndDirectoryOptions } from '@nx/devkit/internal';
+import { assertSupportedReactVersion } from '../../utils/assert-supported-react-version';
 import {
   addDependenciesToPackageJson,
   applyChangesToString,
@@ -28,6 +29,8 @@ import { NormalizedSchema, Schema } from './schema';
 let tsModule: typeof import('typescript');
 
 export async function reduxGenerator(host: Tree, schema: Schema) {
+  assertSupportedReactVersion(host);
+
   const options = await normalizeOptions(host, schema);
   generateReduxFiles(host, options);
   addExportsToBarrel(host, options);
@@ -59,7 +62,9 @@ function addReduxPackageDependencies(host: Tree) {
       '@reduxjs/toolkit': reduxjsToolkitVersion,
       'react-redux': reactReduxVersion,
     },
-    {}
+    {},
+    undefined,
+    true
   );
 }
 

--- a/packages/react/src/generators/remote/lib/setup-ssr-for-remote.ts
+++ b/packages/react/src/generators/remote/lib/setup-ssr-for-remote.ts
@@ -108,7 +108,9 @@ export async function setupSsrForRemote(
       express: expressVersion,
       '@types/express': typesExpressVersion,
     },
-    {}
+    {},
+    undefined,
+    true
   );
   tasks.push(installTask);
 

--- a/packages/react/src/generators/remote/remote.ts
+++ b/packages/react/src/generators/remote/remote.ts
@@ -1,4 +1,5 @@
 import { ensureRootProjectName } from '@nx/devkit/internal';
+import { assertSupportedReactVersion } from '../../utils/assert-supported-react-version';
 import {
   addDependenciesToPackageJson,
   formatFiles,
@@ -130,6 +131,7 @@ export function addModuleFederationFiles(
 }
 
 export async function remoteGenerator(host: Tree, schema: Schema) {
+  assertSupportedReactVersion(host);
   warnReactRemoteGeneratorDeprecation();
   const tasks: GeneratorCallback[] = [];
   const name = await normalizeRemoteName(host, schema.name, schema);
@@ -286,7 +288,9 @@ export async function remoteGenerator(host: Tree, schema: Schema) {
       '@module-federation/enhanced': moduleFederationEnhancedVersion,
       '@nx/web': nxVersion,
       '@nx/module-federation': nxVersion,
-    }
+    },
+    undefined,
+    true
   );
   tasks.push(installTask);
 

--- a/packages/react/src/generators/setup-ssr/setup-ssr.ts
+++ b/packages/react/src/generators/setup-ssr/setup-ssr.ts
@@ -13,6 +13,7 @@ import {
   updateProjectConfiguration,
 } from '@nx/devkit';
 import { upsertTargetDefault } from '@nx/devkit/internal';
+import { assertSupportedReactVersion } from '../../utils/assert-supported-react-version';
 import type * as ts from 'typescript';
 
 import { ensureTypescript, getProjectSourceRoot } from '@nx/js/internal';
@@ -69,6 +70,8 @@ async function getProjectConfig(tree: Tree, projectName: string) {
 }
 
 export async function setupSsrGenerator(tree: Tree, options: Schema) {
+  assertSupportedReactVersion(tree);
+
   const projectConfig = await getProjectConfig(tree, options.project);
   const projectRoot = projectConfig.root;
   const appImportCandidates: AppComponentInfo[] = [
@@ -270,7 +273,9 @@ export async function setupSsrGenerator(tree: Tree, options: Schema) {
     {
       '@types/express': typesExpressVersion,
       '@types/cors': typesCorsVersion,
-    }
+    },
+    undefined,
+    true
   );
 
   await formatFiles(tree);

--- a/packages/react/src/generators/stories/stories.ts
+++ b/packages/react/src/generators/stories/stories.ts
@@ -19,6 +19,7 @@ import {
 } from '../../utils/ast-utils';
 import { getUiFramework } from '../../utils/framework';
 import componentStoryGenerator from '../component-story/component-story';
+import { assertSupportedReactVersion } from '../../utils/assert-supported-react-version';
 
 let tsModule: typeof import('typescript');
 
@@ -142,6 +143,8 @@ export async function storiesGenerator(
   host: Tree,
   schema: StorybookStoriesSchema
 ) {
+  assertSupportedReactVersion(host);
+
   const projects = getProjects(host);
   const projectConfiguration = projects.get(schema.project);
   schema.interactionTests = schema.interactionTests ?? true;

--- a/packages/react/src/generators/storybook-configuration/configuration.ts
+++ b/packages/react/src/generators/storybook-configuration/configuration.ts
@@ -7,6 +7,7 @@ import {
   runTasksInSerial,
   type Tree,
 } from '@nx/devkit';
+import { assertSupportedReactVersion } from '../../utils/assert-supported-react-version';
 import { getUiFramework } from '../../utils/framework';
 import { nxVersion, reactViteVersion } from '../../utils/versions';
 import { storiesGenerator } from '../stories/stories';
@@ -26,6 +27,8 @@ export async function storybookConfigurationGeneratorInternal(
   host: Tree,
   schema: StorybookConfigureSchema
 ) {
+  assertSupportedReactVersion(host);
+
   const tasks: GeneratorCallback[] = [];
   const nxJson = readNxJson(host);
   const addPluginDefault =
@@ -43,7 +46,9 @@ export async function storybookConfigurationGeneratorInternal(
       addDependenciesToPackageJson(
         host,
         {},
-        { '@vitejs/plugin-react': reactViteVersion }
+        { '@vitejs/plugin-react': reactViteVersion },
+        undefined,
+        true
       )
     );
   }

--- a/packages/react/src/utils/all-generators-enforce-floor.spec.ts
+++ b/packages/react/src/utils/all-generators-enforce-floor.spec.ts
@@ -1,0 +1,11 @@
+import { assertGeneratorsEnforceVersionFloor } from '@nx/devkit/internal-testing-utils';
+import { join } from 'node:path';
+
+describe('@nx/react generators enforce supported version floor', () => {
+  assertGeneratorsEnforceVersionFloor({
+    packageRoot: join(__dirname, '..', '..'),
+    packageName: 'react',
+    // React 17 is below the supported floor (v18); the last v17 release was 17.0.2.
+    subFloorVersion: '~17.0.0',
+  });
+});

--- a/packages/react/src/utils/assert-supported-react-version.ts
+++ b/packages/react/src/utils/assert-supported-react-version.ts
@@ -1,0 +1,7 @@
+import { type Tree } from '@nx/devkit';
+import { assertSupportedPackageVersion } from '@nx/devkit/internal';
+import { minSupportedReactVersion } from './versions';
+
+export function assertSupportedReactVersion(tree: Tree): void {
+  assertSupportedPackageVersion(tree, 'react', minSupportedReactVersion);
+}

--- a/packages/react/src/utils/version-utils.spec.ts
+++ b/packages/react/src/utils/version-utils.spec.ts
@@ -10,6 +10,7 @@ import {
   reactDomVersion,
   reactIsV18Version,
   reactIsVersion,
+  reactRouterVersion,
   reactV18Version,
   reactVersion,
   typesReactDomV18Version,
@@ -66,6 +67,7 @@ describe('getReactDependenciesVersionsToInstall', () => {
       '@types/react': typesReactV18Version,
       '@types/react-dom': typesReactDomV18Version,
       '@types/react-is': typesReactIsV18Version,
+      'react-router': reactRouterVersion,
     });
   });
 
@@ -94,6 +96,7 @@ describe('getReactDependenciesVersionsToInstall', () => {
       '@types/react': typesReactVersion,
       '@types/react-dom': typesReactDomVersion,
       '@types/react-is': typesReactIsVersion,
+      'react-router': reactRouterVersion,
     });
   });
 
@@ -114,6 +117,7 @@ describe('getReactDependenciesVersionsToInstall', () => {
       '@types/react': typesReactVersion,
       '@types/react-dom': typesReactDomVersion,
       '@types/react-is': typesReactIsVersion,
+      'react-router': reactRouterVersion,
     });
   });
 });

--- a/packages/react/src/utils/version-utils.ts
+++ b/packages/react/src/utils/version-utils.ts
@@ -9,6 +9,7 @@ import {
   reactDomVersion,
   reactIsV18Version,
   reactIsVersion,
+  reactRouterVersion,
   reactV18Version,
   reactVersion,
   typesReactDomV18Version,
@@ -26,6 +27,8 @@ type ReactDependenciesVersions = {
   '@types/react': string;
   '@types/react-dom': string;
   '@types/react-is': string;
+  // react-router: always v7 (SSR and newer workspaces)
+  'react-router': string;
 };
 
 export async function getReactDependenciesVersionsToInstall(
@@ -39,6 +42,8 @@ export async function getReactDependenciesVersionsToInstall(
       '@types/react': typesReactV18Version,
       '@types/react-dom': typesReactDomV18Version,
       '@types/react-is': typesReactIsV18Version,
+      // react-router v7 is the SSR package regardless of React version
+      'react-router': reactRouterVersion,
     };
   } else {
     return {
@@ -48,6 +53,7 @@ export async function getReactDependenciesVersionsToInstall(
       '@types/react': typesReactVersion,
       '@types/react-dom': typesReactDomVersion,
       '@types/react-is': typesReactIsVersion,
+      'react-router': reactRouterVersion,
     };
   }
 }

--- a/packages/react/src/utils/versions.ts
+++ b/packages/react/src/utils/versions.ts
@@ -1,5 +1,7 @@
 export const nxVersion = require('../../package.json').version;
 
+export const minSupportedReactVersion = '18.0.0';
+
 export const reactVersion = '^19.0.0';
 export const reactV18Version = '18.3.1';
 export const reactDomVersion = '^19.0.0';
@@ -28,8 +30,10 @@ export const reactRouterIsBotVersion = '^4.4.0';
 export const testingLibraryReactVersion = '16.3.0';
 export const testingLibraryDomVersion = '10.4.0';
 
-export const reduxjsToolkitVersion = '1.9.3';
-export const reactReduxVersion = '8.0.5';
+// RTK 2 / react-redux 9 peer on react ^18 || ^19 — cover the full support window.
+// react-redux 8.0.5 / RTK 1.9.3 peer-cap at react ^18, breaking `nx g redux` on React 19.
+export const reduxjsToolkitVersion = '^2.5.0';
+export const reactReduxVersion = '^9.2.0';
 
 export const eslintPluginImportVersion = '2.31.0';
 export const eslintPluginJsxA11yVersion = '6.10.1';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3586,6 +3586,12 @@ importers:
       minimatch:
         specifier: ^10.2.5
         version: 10.2.5
+      react:
+        specifier: '>=18.0.0 <20.0.0'
+        version: 18.3.1
+      react-dom:
+        specifier: '>=18.0.0 <20.0.0'
+        version: 18.3.1(react@18.3.1)
       semver:
         specifier: 'catalog:'
         version: 7.7.4


### PR DESCRIPTION
## Current Behavior

`@nx/react` has no `peerDependencies` for `react`/`react-dom`, installs packages unconditionally without preserving user-pinned versions, and `migrations.json` cross-major bumps lack `requires` gates. The `22.3.4` entry mixes a `react-router-dom` v6 patch with a `react-router` v7 cross-major under AND-semantics, which cannot express two mutually-exclusive user states.

## Expected Behavior

- `peerDependencies` `react`/`react-dom` `>=18.0.0 <20.0.0` declared
- `minSupportedReactVersion = '18.0.0'` floor constant + `assertSupportedReactVersion` wrapper
- Floor assert fires as first statement in all 17 generator entry functions
- `addDependenciesToPackageJson` preserves user-pinned versions (`keepExistingVersions: true`) across all generators
- `react-router`/`react-router-dom` resolved per React major from the version map
- `migrations.json` cross-major `packageJsonUpdates` entries gated with bilateral `requires` ranges
- `22.3.4` split into dual lanes (v6 `react-router-dom` / v7 `react-router` + `@react-router/*`)
- `22.7.0` gated to v7 lane
- `all-generators-enforce-floor.spec.ts` parameterized spec (24/24 pass)

## Related Issue(s)

NXC-4399

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/multi-version-jack-398d33f1)
<!-- polygraph-session-end -->