### PR TITLE
fix(core): disallow nx migrate --interactive for Nx v23+ targets

### DIFF
--- a/packages/nx/src/command-line/examples.ts
+++ b/packages/nx/src/command-line/examples.ts
@@ -327,7 +327,7 @@ export const examples: Record<string, Example[]> = {
     {
       command: 'migrate latest --interactive',
       description:
-        'Collect package updates and migrations in interactive mode. In this mode, the user will be prompted whether to apply any optional package update and migration',
+        'Collect package updates and migrations in interactive mode. In this mode, the user will be prompted whether to apply any optional package update and migration. Only supported when migrating to Nx versions lower than v23',
     },
     {
       command: 'migrate latest --from=nx@14.5.0 --exclude-applied-migrations',

--- a/packages/nx/src/command-line/migrate/command-object.ts
+++ b/packages/nx/src/command-line/migrate/command-object.ts
@@ -127,7 +127,7 @@ function withMigrationOptions(yargs: Argv) {
     })
     .option('interactive', {
       describe:
-        'Enable prompts to confirm whether to collect optional package updates and migrations.',
+        "Enable prompts to confirm whether to collect optional package updates and migrations. Not supported when migrating to Nx v23 or later: use '--mode' to choose which packages to migrate.",
       type: 'boolean',
     })
     .option('excludeAppliedMigrations', {

--- a/packages/nx/src/command-line/migrate/migrate.spec.ts
+++ b/packages/nx/src/command-line/migrate/migrate.spec.ts
@@ -2211,6 +2211,132 @@ describe('Migration', () => {
       });
     });
 
+    it('should reject --interactive when migrating to v23+', async () => {
+      mockGetInstalledNxVersion.mockReturnValue('22.0.0');
+      await expect(() =>
+        parseMigrationsOptions({
+          packageAndVersion: 'nx@23.0.0',
+          interactive: true,
+        })
+      ).rejects.toThrow(
+        `Error: '--interactive' is not supported when migrating to Nx v23 or later. Use '--mode' to choose which packages to migrate.`
+      );
+    });
+
+    it('should reject --interactive for a bare invocation resolving to a v23+ target', async () => {
+      mockGetInstalledNxVersion.mockReturnValue('22.0.0');
+      jest
+        .spyOn(packageMgrUtils, 'resolvePackageVersionUsingRegistry')
+        .mockResolvedValue('23.1.0');
+      await expect(() =>
+        parseMigrationsOptions({ interactive: true })
+      ).rejects.toThrow(
+        `Error: '--interactive' is not supported when migrating to Nx v23 or later. Use '--mode' to choose which packages to migrate.`
+      );
+    });
+
+    it('should reject --interactive for a bare invocation when the registry is unavailable (assumed v23+)', async () => {
+      mockGetInstalledNxVersion.mockReturnValue('22.0.0');
+      jest
+        .spyOn(packageMgrUtils, 'resolvePackageVersionUsingRegistry')
+        .mockRejectedValue(new Error('registry down'));
+      await expect(() =>
+        parseMigrationsOptions({ interactive: true })
+      ).rejects.toThrow(
+        `Error: '--interactive' is not supported when migrating to Nx v23 or later. Use '--mode' to choose which packages to migrate.`
+      );
+    });
+
+    it('should reject --mode=first-party combined with --interactive', async () => {
+      mockGetInstalledNxVersion.mockReturnValue('22.0.0');
+      await expect(() =>
+        parseMigrationsOptions({
+          packageAndVersion: 'nx@23.0.0',
+          mode: 'first-party',
+          interactive: true,
+        })
+      ).rejects.toThrow(
+        `Error: '--interactive' is not supported when migrating to Nx v23 or later. Use '--mode' to choose which packages to migrate.`
+      );
+    });
+
+    it('should reject --mode=third-party combined with --interactive', async () => {
+      await expect(() =>
+        parseMigrationsOptions({ mode: 'third-party', interactive: true })
+      ).rejects.toThrow(
+        `Error: '--mode=third-party' cannot be combined with '--interactive'.`
+      );
+    });
+
+    it('should reject the nx.json third-party mode combined with --interactive', async () => {
+      mockGetInstalledNxVersion.mockReturnValue('23.0.0');
+      await expect(() =>
+        parseMigrationsOptions({
+          packageAndVersion: 'nx@22.5.0',
+          modeFromConfig: 'third-party',
+          interactive: true,
+        })
+      ).rejects.toThrow(
+        `Error: '--mode=third-party' cannot be combined with '--interactive'.`
+      );
+    });
+
+    it('should reject --interactive when the nx.json mode is first-party and migrating to v23+', async () => {
+      mockGetInstalledNxVersion.mockReturnValue('22.0.0');
+      await expect(() =>
+        parseMigrationsOptions({
+          packageAndVersion: 'nx@23.0.0',
+          modeFromConfig: 'first-party',
+          interactive: true,
+        })
+      ).rejects.toThrow(
+        `Error: '--interactive' is not supported when migrating to Nx v23 or later. Use '--mode' to choose which packages to migrate.`
+      );
+    });
+
+    it('should allow --interactive when migrating to a pre-v23 target', async () => {
+      mockGetInstalledNxVersion.mockReturnValue('22.0.0');
+      const r = await parseMigrationsOptions({
+        packageAndVersion: 'nx@22.7.0',
+        interactive: true,
+      });
+      expect(r).toMatchObject({
+        type: 'generateMigrations',
+        targetPackage: 'nx',
+        targetVersion: '22.7.0',
+        interactive: true,
+        mode: 'all',
+      });
+    });
+
+    it('should allow --no-interactive when migrating to v23+', async () => {
+      mockGetInstalledNxVersion.mockReturnValue('22.0.0');
+      const r = await parseMigrationsOptions({
+        packageAndVersion: 'nx@23.0.0',
+        interactive: false,
+      });
+      expect(r).toMatchObject({
+        type: 'generateMigrations',
+        targetPackage: 'nx',
+        targetVersion: '23.0.0',
+        interactive: false,
+      });
+    });
+
+    it('should allow --interactive for non-nx-equivalent targets', async () => {
+      const r = await parseMigrationsOptions({
+        packageAndVersion: 'mypackage@2.0.0',
+        interactive: true,
+      });
+      expect(r).toMatchObject({
+        type: 'generateMigrations',
+        targetPackage: 'mypackage',
+        targetVersion: '2.0.0',
+        interactive: true,
+        mode: 'all',
+      });
+    });
+
     it('should handle different variations of the target package', async () => {
       const packageRegistryViewSpy = jest
         .spyOn(packageMgrUtils, 'resolvePackageVersionUsingRegistry')
@@ -2986,6 +3112,65 @@ describe('Migration', () => {
         'first-party',
         'all',
       ]);
+    });
+
+    it('should reject --interactive when migrating to v23+', async () => {
+      await expect(() =>
+        resolveMode(undefined, 'nx', '23.0.0', {
+          ...v23Context,
+          interactive: true,
+        })
+      ).rejects.toThrow(
+        `Error: '--interactive' is not supported when migrating to Nx v23 or later. Use '--mode' to choose which packages to migrate.`
+      );
+    });
+
+    it('should reject --interactive combined with an explicit mode when migrating to v23+', async () => {
+      await expect(() =>
+        resolveMode('all', 'nx', '23.0.0', {
+          ...v23Context,
+          interactive: true,
+        })
+      ).rejects.toThrow(
+        `Error: '--interactive' is not supported when migrating to Nx v23 or later. Use '--mode' to choose which packages to migrate.`
+      );
+    });
+
+    it('should allow --interactive when not migrating to v23+', async () => {
+      const result = await resolveMode(undefined, 'nx', '22.7.0', {
+        hasFrom: false,
+        hasExcludeAppliedMigrations: false,
+        installedMajor: 22,
+        isV23Plus: false,
+        interactive: true,
+      });
+      expect(result).toBe('all');
+      expect(mockPrompt).not.toHaveBeenCalled();
+    });
+
+    it('should not apply the --interactive gate to non-nx-equivalent targets', async () => {
+      const result = await resolveMode(undefined, '@nx/react', '23.0.0', {
+        ...v23Context,
+        interactive: true,
+      });
+      expect(result).toBe('all');
+    });
+
+    it('should not offer third-party nor prompt when --interactive is provided and only third-party would be available', async () => {
+      Object.defineProperty(process.stdin, 'isTTY', {
+        value: true,
+        configurable: true,
+      });
+      process.env.CI = 'false';
+      const result = await resolveMode(undefined, 'nx', '22.7.0', {
+        hasFrom: false,
+        hasExcludeAppliedMigrations: false,
+        installedMajor: 23,
+        isV23Plus: false,
+        interactive: true,
+      });
+      expect(result).toBe('all');
+      expect(mockPrompt).not.toHaveBeenCalled();
     });
 
     it('uses the nx.json configured mode for an nx target without prompting', async () => {

--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -955,6 +955,7 @@ export async function resolveMode(
     hasExcludeAppliedMigrations: boolean;
     installedMajor?: number | null;
     isV23Plus?: boolean;
+    interactive?: boolean;
   } = {
     hasFrom: false,
     hasExcludeAppliedMigrations: false,
@@ -971,6 +972,18 @@ export async function resolveMode(
     installedMajor >= 22 &&
     context.isV23Plus === true;
   const thirdPartyAvailable = installedMajor !== null && installedMajor >= 23;
+
+  // `--interactive` x-prompts let users skip optional third-party updates; the
+  // modes supersede that choice, so it is disallowed behind the same v23+ gate.
+  if (
+    context.interactive === true &&
+    context.isV23Plus === true &&
+    isNxEquivalentTarget(targetPackage, targetVersion)
+  ) {
+    throw new Error(
+      `Error: '--interactive' is not supported when migrating to Nx v23 or later. Use '--mode' to choose which packages to migrate.`
+    );
+  }
 
   if (mode) {
     if (isNxEquivalentTarget(targetPackage, targetVersion)) {
@@ -1030,7 +1043,8 @@ export async function resolveMode(
   if (
     thirdPartyAvailable &&
     !context.hasFrom &&
-    !context.hasExcludeAppliedMigrations
+    !context.hasExcludeAppliedMigrations &&
+    context.interactive !== true
   ) {
     choices.push({
       name: 'third-party',
@@ -1224,6 +1238,7 @@ export async function parseMigrationsOptions(options: {
       mode,
       from: options.from,
       excludeAppliedMigrations: options.excludeAppliedMigrations,
+      interactive: options.interactive,
     });
     assertThirdPartyTargetBounds({
       targetPackage,
@@ -1251,6 +1266,7 @@ function assertThirdPartyModeFlagCompatibility(options: {
   mode?: string;
   from?: string;
   excludeAppliedMigrations?: boolean;
+  interactive?: boolean;
 }): void {
   if (options.mode !== 'third-party') return;
   if (options.from) {
@@ -1261,6 +1277,11 @@ function assertThirdPartyModeFlagCompatibility(options: {
   if (options.excludeAppliedMigrations === true) {
     throw new Error(
       `Error: '--mode=third-party' cannot be combined with '--exclude-applied-migrations'.`
+    );
+  }
+  if (options.interactive === true) {
+    throw new Error(
+      `Error: '--mode=third-party' cannot be combined with '--interactive'.`
     );
   }
 }
@@ -1277,6 +1298,7 @@ async function resolveTargetAndMode(args: {
     mode?: MigrateMode;
     modeFromConfig?: MigrateMode;
     excludeAppliedMigrations?: boolean;
+    interactive?: boolean;
   };
 }): Promise<{
   targetPackage: string;
@@ -1352,6 +1374,7 @@ async function resolveTargetAndMode(args: {
       hasExcludeAppliedMigrations: options.excludeAppliedMigrations === true,
       installedMajor,
       isV23Plus,
+      interactive: options.interactive,
     },
     options.modeFromConfig
   );


### PR DESCRIPTION
## Current Behavior

`nx migrate --interactive` enables the per-package `x-prompt` confirmations regardless of the target version. This conflicts with the new `--mode` functionality: `--mode=third-party --interactive` still fires the prompts, and the legacy opt-out flow runs for v23+ migrations where `--mode` supersedes it.

## Expected Behavior

`--interactive` is gated behind the same v23+ availability gate as the first-party/third-party modes: passing it for a v23+ Nx-equivalent target throws with a pointer to `--mode`, and combining it with `--mode=third-party` is rejected. Pre-v23 and non-Nx targets keep the legacy interactive behavior.

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/nxc-4412-766d87a4)
<!-- polygraph-session-end -->