### PR TITLE
fix(testing): avoid executing unchanged jest configs during project graph construction

### DIFF
--- a/e2e/js/src/js-strip-types.test.ts
+++ b/e2e/js/src/js-strip-types.test.ts
@@ -119,6 +119,18 @@ describe('native Node.js TypeScript support', () => {
     // logging, which would make per-test assertions flaky based on
     // `uniq()`-randomized lib ordering. Each test does its own cleanup
     // between graph capture and assertions.
+    //
+    // Each test must also `nx reset` BEFORE writing its broken config:
+    // `runCLI` defaults to NX_DAEMON=true, so the generate call leaves a
+    // daemon watching. If the broken config is written while it's alive, the
+    // daemon recomputes the graph, executes the config in its (detached)
+    // plugin worker, and persists the plugin cache keyed on the broken
+    // content. Resetting after the write doesn't help: reset's daemon stop
+    // doesn't wait for the worker, so its cache write can land after the
+    // wipe. The daemon-less assert run then gets a warm cache hit, never
+    // executes the config, and the fallback log it asserts on is never
+    // emitted. Killing the daemon before the broken config exists makes the
+    // assert run the only process that ever executes it.
 
     it(
       'should fall back to swc/ts-node when a TS config uses an enum',
@@ -127,6 +139,9 @@ describe('native Node.js TypeScript support', () => {
         runCLI(
           `generate @nx/js:lib ${lib} --unitTestRunner=jest --no-interactive`
         );
+
+        // Kill the daemon before writing the broken config (see block comment).
+        runCLI('reset');
 
         // enum is not supported by Node native type stripping - must trigger fallback
         updateFile(
@@ -165,6 +180,9 @@ module.exports = { displayName: '${lib}', mode };
         runCLI(
           `generate @nx/js:lib ${lib} --unitTestRunner=jest --no-interactive`
         );
+
+        // Kill the daemon before writing the broken config (see block comment).
+        runCLI('reset');
 
         // `.cts` + `require()`: keeps the file valid CJS (no SyntaxError, so
         // `isCjsSyntaxError` doesn't short-circuit) but the CJS resolver
@@ -220,6 +238,9 @@ module.exports = { displayName };
           `generate @nx/js:lib ${lib} --unitTestRunner=jest --no-interactive`
         );
 
+        // Kill the daemon before writing the broken config (see block comment).
+        runCLI('reset');
+
         // .cts is forced CJS by Node's native loader, so top-level `export`
         // is a SyntaxError. Pre-v23 this worked because swc-node's hook
         // compiled ESM->CJS regardless of extension; the loader's
@@ -257,6 +278,9 @@ module.exports = { displayName };
         runCLI(
           `generate @nx/js:lib ${lib} --unitTestRunner=jest --no-interactive`
         );
+
+        // Kill the daemon before writing the broken config (see block comment).
+        runCLI('reset');
 
         // .mts with an enum: Node 22.12+ require()s sync ESM, native strip
         // throws ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX, loadTsFile registers

--- a/packages/jest/src/plugins/plugin.spec.ts
+++ b/packages/jest/src/plugins/plugin.spec.ts
@@ -1,6 +1,8 @@
 import { CreateNodesContext } from '@nx/devkit';
+import * as configUtils from '@nx/devkit/internal';
 import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
-import { join } from 'path';
+import { setupWorkspaceContext } from 'nx/src/utils/workspace-context';
+import { join, resolve } from 'path';
 import { createNodesV2 } from './plugin';
 
 jest.mock('nx/src/utils/cache-directory', () => ({
@@ -1678,6 +1680,235 @@ describe('@nx/jest/plugin config file inputs', () => {
     );
     const inputs = getTestInputs(results);
     expect(inputs).toContainEqual('{projectRoot}/local-setup.js');
+  });
+});
+
+describe('@nx/jest/plugin caching', () => {
+  const createNodesFunction = createNodesV2[1];
+  const options = { targetName: 'test', disableJestRuntime: true };
+  let context: CreateNodesContext;
+  let tempFs: TempFs;
+  let cwd: string;
+  let loadConfigFileSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    tempFs = new TempFs('test-jest-cache');
+    cwd = process.cwd();
+    process.chdir(tempFs.tempDir);
+    context = {
+      nxJsonConfiguration: {
+        namedInputs: {
+          default: ['{projectRoot}/**/*'],
+          production: ['!{projectRoot}/**/*.spec.ts'],
+        },
+      },
+      workspaceRoot: tempFs.tempDir,
+    };
+    // Spy with call-through: the config still loads (from the virtual mock),
+    // we just count how many times a config is executed.
+    loadConfigFileSpy = jest.spyOn(configUtils, 'loadConfigFile');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.resetModules();
+    tempFs.cleanup();
+    process.chdir(cwd);
+  });
+
+  // Absolute path as the plugin computes it (resolve(workspaceRoot, file)).
+  const abs = (file: string) => resolve(tempFs.tempDir, file);
+  // jest.mock wrapped in a runtime helper so the dynamic path isn't hoisted.
+  const mockConfigFile = (file: string, config: any) =>
+    jest.mock(abs(file), () => config, { virtual: true });
+  const loadedConfigPaths = () =>
+    loadConfigFileSpy.mock.calls.map((call) => call[0] as string);
+
+  it('should not execute any config on a warm cache when nothing changed', async () => {
+    mockConfigFile('proj/jest.config.js', {});
+    await tempFs.createFiles({
+      'package-lock.json': '{}',
+      'proj/jest.config.js': 'module.exports = {}',
+      'proj/project.json': '{}',
+      'proj/src/unit.spec.ts': '',
+    });
+    setupWorkspaceContext(tempFs.tempDir);
+
+    // Cold run populates the on-disk cache.
+    await createNodesFunction(['proj/jest.config.js'], options, context);
+    expect(loadedConfigPaths()).toContain(abs('proj/jest.config.js'));
+
+    // Warm run: same preliminary key, same external content -> no load.
+    loadConfigFileSpy.mockClear();
+    await createNodesFunction(['proj/jest.config.js'], options, context);
+    expect(loadConfigFileSpy).not.toHaveBeenCalled();
+  });
+
+  it('should reload only the config whose project changed', async () => {
+    mockConfigFile('proj-a/jest.config.js', {});
+    mockConfigFile('proj-b/jest.config.js', {});
+    await tempFs.createFiles({
+      'package-lock.json': '{}',
+      'proj-a/jest.config.js': 'module.exports = {}',
+      'proj-a/project.json': '{}',
+      'proj-a/src/unit.spec.ts': '',
+      'proj-b/jest.config.js': 'module.exports = {}',
+      'proj-b/project.json': '{}',
+      'proj-b/src/unit.spec.ts': '',
+    });
+    setupWorkspaceContext(tempFs.tempDir);
+
+    const configFiles = ['proj-a/jest.config.js', 'proj-b/jest.config.js'];
+    await createNodesFunction(configFiles, options, context);
+
+    // Change only proj-a's config bytes -> only its preliminary key moves.
+    loadConfigFileSpy.mockClear();
+    tempFs.writeFile(
+      'proj-a/jest.config.js',
+      'module.exports = {}; // changed'
+    );
+    setupWorkspaceContext(tempFs.tempDir);
+    await createNodesFunction(configFiles, options, context);
+
+    const reloaded = loadedConfigPaths();
+    expect(reloaded).toContain(abs('proj-a/jest.config.js'));
+    expect(reloaded).not.toContain(abs('proj-b/jest.config.js'));
+  });
+
+  it('should invalidate when an external preset changes', async () => {
+    mockConfigFile('proj/jest.config.js', { preset: '../jest.preset.js' });
+    mockConfigFile('jest.preset.js', {});
+    await tempFs.createFiles({
+      'package-lock.json': '{}',
+      'jest.preset.js': 'module.exports = {}',
+      'proj/jest.config.js': "module.exports = { preset: '../jest.preset.js' }",
+      'proj/project.json': '{}',
+      'proj/src/unit.spec.ts': '',
+    });
+    setupWorkspaceContext(tempFs.tempDir);
+
+    await createNodesFunction(['proj/jest.config.js'], options, context);
+
+    // Project files unchanged (preliminary hit) but the external preset's
+    // content changed -> external-file hash differs -> reload.
+    loadConfigFileSpy.mockClear();
+    tempFs.writeFile('jest.preset.js', 'module.exports = { verbose: true }');
+    setupWorkspaceContext(tempFs.tempDir);
+    await createNodesFunction(['proj/jest.config.js'], options, context);
+
+    expect(loadedConfigPaths()).toContain(abs('proj/jest.config.js'));
+  });
+
+  const dtsInput = { dependentTasksOutputFiles: '**/*.d.ts', transitive: true };
+
+  it('should reflect an ancestor tsconfig appearing outside the project root', async () => {
+    mockConfigFile('proj/jest.config.js', {
+      transform: { '^.+\\.ts$': 'ts-jest' },
+    });
+    await tempFs.createFiles({
+      'package-lock.json': '{}',
+      'proj/jest.config.js':
+        "module.exports = { transform: { '^.+\\.ts$': 'ts-jest' } }",
+      'proj/project.json': '{}',
+      'proj/src/unit.spec.ts': '',
+    });
+    setupWorkspaceContext(tempFs.tempDir);
+
+    // Cold: no tsconfig anywhere -> ts-jest defaults to non-isolated mode.
+    const cold = await createNodesFunction(
+      ['proj/jest.config.js'],
+      options,
+      context
+    );
+    expect(cold[0][1].projects['proj'].targets['test'].inputs).toContainEqual(
+      dtsInput
+    );
+
+    // A root tsconfig appears outside the project root: nearest-tsconfig
+    // discovery now resolves to it (a probed location flips from absent to
+    // present) -> reload -> isolatedModules drops the dts input.
+    tempFs.writeFile(
+      'tsconfig.json',
+      JSON.stringify({ compilerOptions: { isolatedModules: true } })
+    );
+    setupWorkspaceContext(tempFs.tempDir);
+    const warm = await createNodesFunction(
+      ['proj/jest.config.js'],
+      options,
+      context
+    );
+    expect(
+      warm[0][1].projects['proj'].targets['test'].inputs
+    ).not.toContainEqual(dtsInput);
+  });
+
+  it('should reflect a closer ancestor tsconfig overriding the previous one', async () => {
+    mockConfigFile('libs/proj/jest.config.js', {
+      transform: { '^.+\\.ts$': 'ts-jest' },
+    });
+    await tempFs.createFiles({
+      'package-lock.json': '{}',
+      'tsconfig.json': JSON.stringify({
+        compilerOptions: { isolatedModules: true },
+      }),
+      'libs/proj/jest.config.js':
+        "module.exports = { transform: { '^.+\\.ts$': 'ts-jest' } }",
+      'libs/proj/project.json': '{}',
+      'libs/proj/src/unit.spec.ts': '',
+    });
+    setupWorkspaceContext(tempFs.tempDir);
+
+    // Cold: nearest tsconfig is the root one with isolatedModules: true.
+    const cold = await createNodesFunction(
+      ['libs/proj/jest.config.js'],
+      options,
+      context
+    );
+    expect(
+      cold[0][1].projects['libs/proj'].targets['test'].inputs
+    ).not.toContainEqual(dtsInput);
+
+    // A closer ancestor tsconfig appears with isolatedModules: false ->
+    // discovery now resolves to it -> the dts input must be added (missing
+    // it would mean incorrect task-cache hits).
+    tempFs.writeFile(
+      'libs/tsconfig.json',
+      JSON.stringify({ compilerOptions: { isolatedModules: false } })
+    );
+    setupWorkspaceContext(tempFs.tempDir);
+    const warm = await createNodesFunction(
+      ['libs/proj/jest.config.js'],
+      options,
+      context
+    );
+    expect(
+      warm[0][1].projects['libs/proj'].targets['test'].inputs
+    ).toContainEqual(dtsInput);
+  });
+
+  it('should always reload configs whose tsconfig chain has an unresolvable extends', async () => {
+    mockConfigFile('proj/jest.config.js', {
+      transform: {
+        '^.+\\.ts$': ['ts-jest', { tsconfig: 'tsconfig.spec.json' }],
+      },
+    });
+    await tempFs.createFiles({
+      'package-lock.json': '{}',
+      'proj/jest.config.js':
+        "module.exports = { transform: { '^.+\\.ts$': ['ts-jest', { tsconfig: 'tsconfig.spec.json' }] } }",
+      'proj/project.json': '{}',
+      'proj/src/unit.spec.ts': '',
+      'proj/tsconfig.spec.json': JSON.stringify({ extends: './missing.json' }),
+    });
+    setupWorkspaceContext(tempFs.tempDir);
+
+    await createNodesFunction(['proj/jest.config.js'], options, context);
+
+    // The extends target can't be resolved, so the entry's dependencies
+    // can't be enumerated -> the cached entry must not be trusted.
+    loadConfigFileSpy.mockClear();
+    await createNodesFunction(['proj/jest.config.js'], options, context);
+    expect(loadedConfigPaths()).toContain(abs('proj/jest.config.js'));
   });
 });
 

--- a/packages/jest/src/plugins/plugin.ts
+++ b/packages/jest/src/plugins/plugin.ts
@@ -27,7 +27,11 @@ import {
   relative,
   resolve,
 } from 'node:path';
-import { hashObject } from 'nx/src/devkit-internals';
+import {
+  hashObject,
+  hashMultiGlobWithWorkspaceContext,
+} from 'nx/src/devkit-internals';
+import { hashArray } from 'nx/src/devkit-exports';
 import { getGlobPatternsFromPackageManagerWorkspaces } from 'nx/src/plugins/package-json';
 import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
 import { combineGlobPatterns } from 'nx/src/utils/globs';
@@ -71,10 +75,34 @@ export interface JestPluginOptions {
 
 type IsolatedModulesResult = {
   value: boolean | undefined;
-  visitedFiles: ReadonlySet<string>;
+  /**
+   * Every path the tsconfig walk depends on: files it read plus locations it
+   * probed that were missing or unparseable. A change in the existence or
+   * content of any of them can change `value`.
+   */
+  dependencyPaths: ReadonlySet<string>;
+  /**
+   * True when an `extends` value could not be resolved to a file (excluding
+   * bare specifiers, which resolve into node_modules and are covered by the
+   * lockfile). The walk's dependencies can't be precisely enumerated then,
+   * so cached results derived from it must not be trusted.
+   */
+  hasUnresolvableExtends: boolean;
 };
 
 type JestTargets = Awaited<ReturnType<typeof buildJestTargets>>;
+
+// Two-level cache entry: `targets`/`metadata` are the inferred output;
+// `externalFiles` + `externalFilesHash` let a load-free preliminary key hit
+// confirm that the external files the config's inference depends on (preset,
+// ts-jest tsconfig discovery) are unchanged - in content AND existence -
+// without executing the config. `forceReload` marks entries whose external
+// dependencies couldn't be precisely enumerated; they are always recomputed.
+type JestTargetsCacheEntry = JestTargets & {
+  externalFiles: string[];
+  externalFilesHash: string;
+  forceReload?: boolean;
+};
 
 const jestConfigGlob = '**/jest.config.{cjs,mjs,js,cts,mts,ts}';
 
@@ -83,7 +111,7 @@ export const createNodes: CreateNodes<JestPluginOptions> = [
   async (configFiles, options, context) => {
     const optionsHash = hashObject(options);
     const cachePath = join(workspaceDataDirectory, `jest-${optionsHash}.hash`);
-    const targetsCache = new PluginCache<JestTargets>(cachePath);
+    const targetsCache = new PluginCache<JestTargetsCacheEntry>(cachePath);
     // Cache jest preset(s) to avoid penalties of module load times. Most of jest configs will use the same preset.
     const presetCache: Record<string, unknown> = {};
     // Cache tsconfig reads + isolatedModules resolution. Many projects share
@@ -129,18 +157,81 @@ export const createNodes: CreateNodes<JestPluginOptions> = [
 
     const lockFilePattern = getLockFileName(packageManager);
 
-    // Load configs in parallel. `loadConfigFile` calls `registerTsProject`,
-    // whose transpiler dedup is refcounted: serial register/unregister cycles
-    // drop refCount to 0 between iterations and recreate a fresh ts-node
-    // service each time (ts-node has no cleanup — see
+    // Preliminary per-config key - computable WITHOUT loading any config. It
+    // is today's key minus `externalFiles` (the preset path and ts-jest
+    // tsconfig extends chain), which are only knowable after a config is
+    // executed. Their content moves to a second-level hash below, so a warm
+    // cache never has to execute a config just to build its key.
+    const hashes = await calculateHashesForCreateNodes(
+      projectRoots,
+      options,
+      context,
+      projectRoots.map(() => [lockFilePattern])
+    );
+
+    // Second cache level: hash of a config's external files - their content,
+    // and for probed-but-absent paths their (non-)existence. Memoized and
+    // batched so a preset / tsconfig.base.json shared by many projects is
+    // hashed once per run.
+    const externalFileHashCache = new Map<string, string>();
+    const primeExternalFileHashes = async (files: string[]): Promise<void> => {
+      const pending = [...new Set(files)].filter(
+        (file) => !externalFileHashCache.has(file)
+      );
+      if (!pending.length) {
+        return;
+      }
+      const fileHashes = await hashMultiGlobWithWorkspaceContext(
+        context.workspaceRoot,
+        pending.map((file) => [file])
+      );
+      pending.forEach((file, i) =>
+        externalFileHashCache.set(file, fileHashes[i])
+      );
+    };
+    const computeExternalFilesHash = (files: string[]): string =>
+      hashArray(
+        [...files]
+          .sort()
+          .map((file) => `${file}:${externalFileHashCache.get(file)}`)
+      );
+
+    // A preliminary hit still has to confirm its external-file content is
+    // unchanged; a miss or external-content mismatch is the only thing that
+    // executes a config.
+    const cachedEntries = hashes.map((hash) => targetsCache.get(hash));
+    await primeExternalFileHashes(
+      cachedEntries.flatMap((entry) => entry?.externalFiles ?? [])
+    );
+    const indicesToLoad: number[] = [];
+    for (let i = 0; i < validConfigFiles.length; i++) {
+      const entry = cachedEntries[i];
+      // An entry without `externalFiles` predates this cache shape (or is
+      // otherwise foreign) - treat it as a miss so it gets recomputed.
+      if (
+        !entry ||
+        !Array.isArray(entry.externalFiles) ||
+        entry.forceReload ||
+        computeExternalFilesHash(entry.externalFiles) !==
+          entry.externalFilesHash
+      ) {
+        indicesToLoad.push(i);
+      }
+    }
+
+    // Load only the misses. `loadConfigFile` calls `registerTsProject`, whose
+    // transpiler dedup is refcounted: serial register/unregister cycles drop
+    // refCount to 0 between iterations and recreate a fresh ts-node service
+    // each time (ts-node has no cleanup - see
     // packages/nx/src/plugins/js/utils/register.js), stacking N services in
-    // `require.extensions` and OOM'ing under NX_PREFER_TS_NODE. Parallel
-    // loads keep all registrations alive concurrently so the dedup holds and
-    // a single transpiler instance is shared.
+    // `require.extensions` and OOM'ing under NX_PREFER_TS_NODE. Parallel loads
+    // keep all registrations alive concurrently so the dedup holds and a
+    // single transpiler instance is shared.
     let requireCacheCleared = false;
-    const loadedConfigs = await Promise.all(
-      validConfigFiles.map(async (configFilePath, i) => {
-        const projectRoot = projectRoots[i];
+    const built = await Promise.all(
+      indicesToLoad.map(async (idx) => {
+        const configFilePath = validConfigFiles[idx];
+        const projectRoot = projectRoots[idx];
         const absConfigFilePath = resolve(
           context.workspaceRoot,
           configFilePath
@@ -155,7 +246,7 @@ export const createNodes: CreateNodes<JestPluginOptions> = [
           'tsconfig.jest.json',
           'tsconfig.json',
         ]);
-        const { externalFiles, needsDtsInputs } =
+        const { externalFiles, needsDtsInputs, forceReload } =
           await collectExternalFileReferences(
             rawConfig,
             absConfigFilePath,
@@ -168,44 +259,46 @@ export const createNodes: CreateNodes<JestPluginOptions> = [
               isolatedModulesCache,
             }
           );
-        return { rawConfig, externalFiles, needsDtsInputs };
+        const { targets, metadata } = await buildJestTargets(
+          rawConfig,
+          needsDtsInputs,
+          configFilePath,
+          projectRoot,
+          options,
+          context,
+          presetCache,
+          pmc
+        );
+        return { idx, targets, metadata, externalFiles, forceReload };
       })
     );
 
-    const hashes = await calculateHashesForCreateNodes(
-      projectRoots,
-      options,
-      context,
-      loadedConfigs.map(({ externalFiles }) => [
-        lockFilePattern,
-        ...externalFiles,
-      ])
+    // Hash freshly-collected external files (deduped/batched with the hit set
+    // above) and store the widened entries.
+    await primeExternalFileHashes(
+      built.flatMap(({ externalFiles }) => externalFiles)
     );
+    for (const {
+      idx,
+      targets,
+      metadata,
+      externalFiles,
+      forceReload,
+    } of built) {
+      targetsCache.set(hashes[idx], {
+        targets,
+        metadata,
+        externalFiles,
+        externalFilesHash: computeExternalFilesHash(externalFiles),
+        ...(forceReload ? { forceReload } : {}),
+      });
+    }
 
     try {
       return await createNodesFromFiles(
-        async (configFilePath, options, context, idx) => {
+        (_configFilePath, _options, _context, idx) => {
           const projectRoot = projectRoots[idx];
-          const hash = hashes[idx];
-          const { rawConfig, needsDtsInputs } = loadedConfigs[idx];
-
-          if (!targetsCache.has(hash)) {
-            targetsCache.set(
-              hash,
-              await buildJestTargets(
-                rawConfig,
-                needsDtsInputs,
-                configFilePath,
-                projectRoot,
-                options,
-                context,
-                presetCache,
-                pmc
-              )
-            );
-          }
-
-          const { targets, metadata } = targetsCache.get(hash);
+          const { targets, metadata } = targetsCache.get(hashes[idx]);
 
           return {
             projects: {
@@ -1023,19 +1116,23 @@ async function getTestPaths(
 }
 
 /**
- * Collects workspace-relative paths to files whose CONTENT the plugin reads
- * when computing inferred targets and that live OUTSIDE the project root.
- *
- * Only two kinds of files qualify:
+ * Collects workspace-relative paths OUTSIDE the project root whose content
+ * OR existence the plugin's inference depends on:
  *  - The jest preset (loaded to read its `transform`, etc.)
- *  - Tsconfig files in the extends chain referenced by ts-jest (read to
- *    determine `isolatedModules`); only walked when ts-jest is not already
- *    known to be in isolated mode.
+ *  - Tsconfig files consulted for ts-jest's `isolatedModules` resolution -
+ *    both the files read (extends chain) and the locations probed while
+ *    discovering the nearest tsconfig, so a file appearing at a probed
+ *    location still invalidates a cached entry. Only walked when ts-jest is
+ *    not already known to be in isolated mode.
  *
  * Other config references (setup files, custom resolvers, transformers,
  * etc.) are NOT collected — the plugin only resolves their paths and emits
  * them as task inputs; their content is not read by the plugin, so changes
  * to them don't influence inference.
+ *
+ * Returns `forceReload: true` when a dependency cannot be precisely
+ * enumerated (an unresolvable non-bare tsconfig `extends`); cached entries
+ * for such configs must always be recomputed.
  */
 async function collectExternalFileReferences(
   rawConfig: any,
@@ -1048,7 +1145,11 @@ async function collectExternalFileReferences(
     tsconfigExistsCache: Map<string, boolean>;
     isolatedModulesCache: Map<string, IsolatedModulesResult>;
   }
-): Promise<{ externalFiles: string[]; needsDtsInputs: boolean }> {
+): Promise<{
+  externalFiles: string[];
+  needsDtsInputs: boolean;
+  forceReload: boolean;
+}> {
   const {
     presetCache,
     tsconfigJsonCache,
@@ -1092,6 +1193,7 @@ async function collectExternalFileReferences(
     ...(rawConfig.transform ?? {}),
   };
   let needsDtsInputs = false;
+  let forceReload = false;
   for (const value of Object.values(transform)) {
     let transformPath: string;
     let transformOptions: Record<string, any> | undefined;
@@ -1113,24 +1215,37 @@ async function collectExternalFileReferences(
           rootDir,
           replaceRootDirInPath(rootDir, transformOptions.tsconfig)
         )
-      : findNearestTsconfig(rootDir, absWorkspaceRoot, tsconfigExistsCache);
+      : findNearestTsconfig(
+          rootDir,
+          absWorkspaceRoot,
+          tsconfigExistsCache,
+          // Track every probed location: a tsconfig.json appearing at one of
+          // them changes the discovery result without any project file (or
+          // already-known external file) changing.
+          addIfExternal
+        );
     if (!tsconfigAbsPath) {
       // No tsconfig found — ts-jest defaults to non-isolated mode
       needsDtsInputs = true;
       continue;
     }
-    const { value: isolatedValue, visitedFiles } = resolveIsolatedModules(
+    const {
+      value: isolatedValue,
+      dependencyPaths,
+      hasUnresolvableExtends,
+    } = resolveIsolatedModules(
       tsconfigAbsPath,
       tsconfigJsonCache,
       isolatedModulesCache
     );
-    for (const visitedFile of visitedFiles) {
-      addIfExternal(visitedFile);
+    for (const dependencyPath of dependencyPaths) {
+      addIfExternal(dependencyPath);
     }
+    if (hasUnresolvableExtends) forceReload = true;
     if (isolatedValue !== true) needsDtsInputs = true;
   }
 
-  return { externalFiles: [...externalFiles], needsDtsInputs };
+  return { externalFiles: [...externalFiles], needsDtsInputs, forceReload };
 }
 
 async function loadPresetConfig(
@@ -1295,11 +1410,15 @@ async function getConfigFileInputs(
 function findNearestTsconfig(
   startDir: string,
   stopDir: string,
-  existsCache: Map<string, boolean>
+  existsCache: Map<string, boolean>,
+  onProbe?: (candidatePath: string) => void
 ): string | null {
   let dir = startDir;
   while (true) {
     const candidate = join(dir, 'tsconfig.json');
+    // Report regardless of the exists-cache: the discovery result depends on
+    // this candidate even when its existence was checked for another config.
+    onProbe?.(candidate);
     let exists = existsCache.get(candidate);
     if (exists === undefined) {
       exists = existsSync(candidate);
@@ -1340,12 +1459,12 @@ function resolveIsolatedModules(
   if (cached) return cached;
 
   let value: boolean | undefined;
-  const visitedFiles = new Set<string>();
+  const dependencyPaths = new Set<string>();
+  let hasUnresolvableExtends = false;
 
   walkTsconfigExtendsChain(
     tsconfigPath,
     (absPath, rawJson) => {
-      visitedFiles.add(absPath);
       const opts = (rawJson as any)?.compilerOptions;
       if (opts?.isolatedModules !== undefined) {
         value = opts.isolatedModules === true;
@@ -1359,10 +1478,28 @@ function resolveIsolatedModules(
       }
       return 'continue';
     },
-    { jsonCache }
+    {
+      jsonCache,
+      // Superset of the visited files: also includes the entry when it is
+      // missing, and reachable files that fail to parse. Any of them
+      // appearing or changing can change the resolution.
+      onProbedPath: (absPath) => dependencyPaths.add(absPath),
+      onUnresolvableExtends: (extendsValue) => {
+        // Bare specifiers resolve into node_modules, which the lockfile
+        // already covers. Anything else points at a file that could appear
+        // later at locations we cannot precisely enumerate.
+        if (extendsValue.startsWith('.') || isAbsolute(extendsValue)) {
+          hasUnresolvableExtends = true;
+        }
+      },
+    }
   );
 
-  const result: IsolatedModulesResult = { value, visitedFiles };
+  const result: IsolatedModulesResult = {
+    value,
+    dependencyPaths,
+    hasUnresolvableExtends,
+  };
   resultCache.set(tsconfigPath, result);
   return result;
 }

--- a/packages/js/src/utils/typescript/raw-tsconfig.ts
+++ b/packages/js/src/utils/typescript/raw-tsconfig.ts
@@ -18,6 +18,26 @@ import { dirname } from 'node:path';
  */
 export type RawTsconfigJsonCache = Map<string, unknown | null>;
 
+export interface WalkTsconfigExtendsChainOptions {
+  /**
+   * Optional shared cache of parsed tsconfig contents. When omitted, the
+   * walker uses a fresh internal cache.
+   */
+  jsonCache?: RawTsconfigJsonCache;
+  /**
+   * Invoked for every path the walk attempts to read, including files that
+   * fail to parse (`visit` only sees parseable files). The traversal outcome
+   * depends on the existence and content of each reported path, so callers
+   * deriving cache-invalidation inputs should track all of them.
+   */
+  onProbedPath?: (absolutePath: string) => void;
+  /**
+   * Invoked when an `extends` value cannot be resolved to a file. The
+   * traversal outcome may change if the target later becomes resolvable.
+   */
+  onUnresolvableExtends?: (extendsValue: string, fromDir: string) => void;
+}
+
 /**
  * Walks the `extends` chain of a tsconfig, invoking `visit` for each unique
  * reachable file (entry first, then recursively). Cycle-safe. Files that
@@ -32,26 +52,28 @@ export type RawTsconfigJsonCache = Map<string, unknown | null>;
  * @param entryAbsolutePath Absolute, canonical path of the tsconfig to
  *   start from. Pass through `path.resolve()` if unsure.
  * @param visit Invoked once per unique reachable tsconfig.
- * @param options.jsonCache Optional shared cache of parsed tsconfig
- *   contents. When omitted, the walker uses a fresh internal cache.
+ * @param options See {@link WalkTsconfigExtendsChainOptions}.
  */
 export function walkTsconfigExtendsChain(
   entryAbsolutePath: string,
   visit: (absolutePath: string, rawJson: unknown) => 'continue' | 'stop',
-  options?: { jsonCache?: RawTsconfigJsonCache }
+  options?: WalkTsconfigExtendsChainOptions
 ): void {
   const jsonCache: RawTsconfigJsonCache = options?.jsonCache ?? new Map();
-  walk(entryAbsolutePath, visit, jsonCache, new Set());
+  walk(entryAbsolutePath, visit, jsonCache, new Set(), options);
 }
 
 function walk(
   absolutePath: string,
   visit: (absolutePath: string, rawJson: unknown) => 'continue' | 'stop',
   jsonCache: RawTsconfigJsonCache,
-  visited: Set<string>
+  visited: Set<string>,
+  options?: WalkTsconfigExtendsChainOptions
 ): 'continue' | 'stop' {
   if (visited.has(absolutePath)) return 'continue';
   visited.add(absolutePath);
+
+  options?.onProbedPath?.(absolutePath);
 
   const json = readCachedJson(absolutePath, jsonCache);
   if (json === null) return 'continue';
@@ -71,8 +93,13 @@ function walk(
     const ext = extendsList[i];
     if (typeof ext !== 'string' || !ext) continue;
     const childPath = resolveExtendsPath(ext, fromDir);
-    if (childPath === null) continue;
-    if (walk(childPath, visit, jsonCache, visited) === 'stop') return 'stop';
+    if (childPath === null) {
+      options?.onUnresolvableExtends?.(ext, fromDir);
+      continue;
+    }
+    if (walk(childPath, visit, jsonCache, visited, options) === 'stop') {
+      return 'stop';
+    }
   }
 
   return 'continue';


### PR DESCRIPTION
## Current Behavior

`@nx/jest/plugin` executes every matched jest config (`loadConfigFile`) on every `createNodes` invocation - including fully warm-cache runs and every daemon recompute - because the cache key embeds external files (preset, ts-jest tsconfig chain) that are only knowable after executing the config. Executing a config is the dominant cost, so project graph computation pays it for all configs every time.

## Expected Behavior

The cache key is computable without executing configs: a preliminary key (project files + lockfile + options) plus a second-level content/existence hash of the external files the inference depends on, including the locations probed during ts-jest tsconfig discovery. On a warm cache no configs are executed; only configs with a genuine miss are loaded. Invalidation semantics are unchanged.

## Benchmarks

Fabricated workspace, invoking the plugin's `createNodesV2` function directly (no daemon).

**Setup**

- 300 ts-jest projects, each with a `jest.config.ts` (relative preset `../../jest.preset.js`, `ts-jest` transform pointing at a `tsconfig.spec.json` that extends the root `tsconfig.base.json`), `project.json`, and source/spec files.
- The workspace `jest.preset.js` requires the real `jest`/`jest-config` packages to mirror the module-graph weight of `@nx/jest/preset`. node_modules modules stay require-cached across invocations, exactly as in production (`clearRequireCache` only evicts workspace files).
- Two fixtures: "canonical" (config is a single object literal, the nx-generated shape) and "with imports" (each config additionally imports a local helper module).
- Config loading mechanism: Node v24.15.0 native TypeScript type stripping - no swc/ts-node loader registration, no tsconfig-paths hooks. That is the fastest config-loading path available today, so the "before" column is measured with the best-case loader; older Node versions or configs requiring full transpilation/path mapping make every "before" load more expensive, while "after" is unaffected since it does not execute configs on warm hits.
- Apple M2 Max. 3 interleaved before/after passes; medians (warm rows aggregate 18 samples per cell, spread below +/-4%). `loads` = config modules actually executed during the call, counted via the require cache.

**Scenarios**

- cold: empty plugin cache (first ever run)
- warm recompute: repeated invocation in the same process with no file changes - what the daemon does on every recomputation
- one project changed: a single project source file modified between invocations
- fresh process, warm disk cache: new process with the on-disk plugin cache populated (non-daemon nx invocations, daemon restarts)

**Canonical configs**

| Scenario | Before | After | Speedup |
| --- | --- | --- | --- |
| cold | 687 ms, 300 loads | 665 ms, 300 loads | 1.0x (parity) |
| warm recompute | 187 ms, 300 loads | 115 ms, 0 loads | 1.6x |
| one project changed | 206 ms, 300 loads | 136 ms, 1 load | 1.5x |
| fresh process, warm disk cache | 328 ms, 300 loads | 186 ms, 0 loads | 1.8x |

**Configs with imports**

| Scenario | Before | After | Speedup |
| --- | --- | --- | --- |
| cold | 1156 ms, 600 loads | 1159 ms, 600 loads | 1.0x (parity) |
| warm recompute | 260 ms, 600 loads | 120 ms, 0 loads | 2.2x |
| one project changed | 288 ms, 600 loads | 144 ms, 2 loads | 2.0x |
| fresh process, warm disk cache | 494 ms, 600 loads | 185 ms, 0 loads | 2.7x |

**Takeaways**

- Before executes every config on every invocation; after executes none on a warm hit and exactly the changed one otherwise.
- After's warm cost is flat (~115-120 ms) regardless of config weight - the remainder is shared workspace hashing + cache serialization. Before's cost grows with config weight (187 ms -> 260 ms warm from a single extra helper import per config), so heavier real-world configs widen the gap further.
- Cold path is at parity: the two-level bookkeeping adds no measurable cost when everything must load anyway.

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/improve-jest-plugin-warm-cache-perf-cfc1bd22)
<!-- polygraph-session-end -->
