### PR TITLE
fix(js): align tsconfig include and exclude inputs inference with TypeScript behavior

### DIFF
--- a/packages/js/src/plugins/typescript/plugin.spec.ts
+++ b/packages/js/src/plugins/typescript/plugin.spec.ts
@@ -1334,6 +1334,242 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         `);
       });
 
+      it('should normalize and expand "." in `include` with the ts extensions', async () => {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
+          'libs/my-lib/tsconfig.json': JSON.stringify({
+            include: ['.'],
+            // set this to keep outputs smaller
+            compilerOptions: { outDir: 'dist' },
+          }),
+          'libs/my-lib/package.json': `{}`,
+        });
+
+        expect(await invokeCreateNodesOnMatchingFiles(configFiles, context, {}))
+          .toMatchInlineSnapshot(`
+          {
+            "projects": {
+              "libs/my-lib": {
+                "targets": {
+                  "typecheck": {
+                    "cache": true,
+                    "command": "tsc --build tsconfig.json --emitDeclarationOnly",
+                    "dependsOn": [
+                      "^typecheck",
+                    ],
+                    "inputs": [
+                      "{projectRoot}/package.json",
+                      "{projectRoot}/tsconfig.json",
+                      "{projectRoot}/**/*.ts",
+                      "{projectRoot}/**/*.tsx",
+                      "{projectRoot}/**/*.d.ts",
+                      "{projectRoot}/**/*.cts",
+                      "{projectRoot}/**/*.d.cts",
+                      "{projectRoot}/**/*.mts",
+                      "{projectRoot}/**/*.d.mts",
+                      {
+                        "dependentTasksOutputFiles": "**/*.{d.ts,d.cts,d.mts,tsbuildinfo}",
+                        "transitive": true,
+                      },
+                      {
+                        "dependencies": true,
+                        "fileset": "{projectRoot}/**/*.{d.ts,d.cts,d.mts}",
+                      },
+                    ],
+                    "metadata": {
+                      "description": "Runs type-checking for the project.",
+                      "help": {
+                        "command": "npx tsc --build --help",
+                        "example": {
+                          "args": [
+                            "--force",
+                          ],
+                        },
+                      },
+                      "technologies": [
+                        "typescript",
+                      ],
+                    },
+                    "options": {
+                      "cwd": "libs/my-lib",
+                    },
+                    "outputs": [
+                      "{projectRoot}/dist/**/*.{d.ts,d.cts,d.mts}",
+                      "{projectRoot}/dist/tsconfig.tsbuildinfo",
+                    ],
+                    "syncGenerators": [
+                      "@nx/js:typescript-sync",
+                    ],
+                  },
+                },
+              },
+            },
+          }
+        `);
+      });
+
+      it('should normalize and expand ".." in `include` with the ts extensions', async () => {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
+          'libs/my-lib/tsconfig.json': JSON.stringify({
+            include: ['..'],
+            // set this to keep outputs smaller
+            compilerOptions: { outDir: 'dist' },
+          }),
+          'libs/my-lib/package.json': `{}`,
+        });
+
+        const result = await invokeCreateNodesOnMatchingFiles(
+          configFiles,
+          context,
+          {}
+        );
+        expect(result.projects['libs/my-lib'].targets.typecheck.inputs)
+          .toMatchInlineSnapshot(`
+          [
+            "{projectRoot}/package.json",
+            "{projectRoot}/tsconfig.json",
+            "{workspaceRoot}/libs/**/*.ts",
+            "{workspaceRoot}/libs/**/*.tsx",
+            "{workspaceRoot}/libs/**/*.d.ts",
+            "{workspaceRoot}/libs/**/*.cts",
+            "{workspaceRoot}/libs/**/*.d.cts",
+            "{workspaceRoot}/libs/**/*.mts",
+            "{workspaceRoot}/libs/**/*.d.mts",
+            {
+              "dependentTasksOutputFiles": "**/*.{d.ts,d.cts,d.mts,tsbuildinfo}",
+              "transitive": true,
+            },
+            {
+              "dependencies": true,
+              "fileset": "{projectRoot}/**/*.{d.ts,d.cts,d.mts}",
+            },
+          ]
+        `);
+      });
+
+      it('should not expand "." in `include` when the project directory name contains a dot, matching TypeScript', async () => {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
+          'libs/my.lib/tsconfig.json': JSON.stringify({
+            include: ['.'],
+            // set this to keep outputs smaller
+            compilerOptions: { outDir: 'dist' },
+          }),
+          'libs/my.lib/package.json': `{}`,
+        });
+
+        const result = await invokeCreateNodesOnMatchingFiles(
+          configFiles,
+          context,
+          {}
+        );
+        expect(result.projects['libs/my.lib'].targets.typecheck.inputs)
+          .toMatchInlineSnapshot(`
+          [
+            "{projectRoot}/package.json",
+            "{projectRoot}/tsconfig.json",
+            "{projectRoot}",
+            {
+              "dependentTasksOutputFiles": "**/*.{d.ts,d.cts,d.mts,tsbuildinfo}",
+              "transitive": true,
+            },
+            {
+              "dependencies": true,
+              "fileset": "{projectRoot}/**/*.{d.ts,d.cts,d.mts}",
+            },
+          ]
+        `);
+      });
+
+      it('should not add exclude paths that are covered by non-glob include paths of other tsconfig files', async () => {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
+          'libs/my-lib/tsconfig.json': JSON.stringify({
+            include: ['.'],
+            references: [{ path: './tsconfig.lib.json' }],
+          }),
+          'libs/my-lib/tsconfig.lib.json': JSON.stringify({
+            include: ['src'],
+            exclude: ['src/**/*.spec.ts'], // should be ignored because the root include "." covers it
+          }),
+          'libs/my-lib/package.json': `{}`,
+        });
+
+        const result = await invokeCreateNodesOnMatchingFiles(
+          configFiles,
+          context,
+          {}
+        );
+        expect(result.projects['libs/my-lib'].targets.typecheck.inputs)
+          .toMatchInlineSnapshot(`
+          [
+            "{projectRoot}/package.json",
+            "{projectRoot}/tsconfig.json",
+            "{projectRoot}/tsconfig.lib.json",
+            "{projectRoot}/**/*.ts",
+            "{projectRoot}/**/*.tsx",
+            "{projectRoot}/**/*.d.ts",
+            "{projectRoot}/**/*.cts",
+            "{projectRoot}/**/*.d.cts",
+            "{projectRoot}/**/*.mts",
+            "{projectRoot}/**/*.d.mts",
+            "{projectRoot}/src/**/*.ts",
+            "{projectRoot}/src/**/*.tsx",
+            "{projectRoot}/src/**/*.d.ts",
+            "{projectRoot}/src/**/*.cts",
+            "{projectRoot}/src/**/*.d.cts",
+            "{projectRoot}/src/**/*.mts",
+            "{projectRoot}/src/**/*.d.mts",
+            {
+              "dependentTasksOutputFiles": "**/*.{d.ts,d.cts,d.mts,tsbuildinfo}",
+              "transitive": true,
+            },
+            {
+              "dependencies": true,
+              "fileset": "{projectRoot}/**/*.{d.ts,d.cts,d.mts}",
+            },
+          ]
+        `);
+      });
+
+      it('should expand directory paths in `exclude` to cover their whole subtree', async () => {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
+          'libs/my-lib/tsconfig.json': JSON.stringify({
+            include: ['src'],
+            exclude: ['tools'],
+            // set this to keep outputs smaller
+            compilerOptions: { outDir: 'dist' },
+          }),
+          'libs/my-lib/package.json': `{}`,
+        });
+
+        const result = await invokeCreateNodesOnMatchingFiles(
+          configFiles,
+          context,
+          {}
+        );
+        expect(result.projects['libs/my-lib'].targets.typecheck.inputs)
+          .toMatchInlineSnapshot(`
+          [
+            "{projectRoot}/package.json",
+            "{projectRoot}/tsconfig.json",
+            "{projectRoot}/src/**/*.ts",
+            "{projectRoot}/src/**/*.tsx",
+            "{projectRoot}/src/**/*.d.ts",
+            "{projectRoot}/src/**/*.cts",
+            "{projectRoot}/src/**/*.d.cts",
+            "{projectRoot}/src/**/*.mts",
+            "{projectRoot}/src/**/*.d.mts",
+            "!{projectRoot}/tools/**/*",
+            {
+              "dependentTasksOutputFiles": "**/*.{d.ts,d.cts,d.mts,tsbuildinfo}",
+              "transitive": true,
+            },
+            {
+              "dependencies": true,
+              "fileset": "{projectRoot}/**/*.{d.ts,d.cts,d.mts}",
+            },
+          ]
+        `);
+      });
+
       it('should normalize and add directories in `include` with the ts and js extensions when `allowJs` is true', async () => {
         configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.json': JSON.stringify({
@@ -1604,8 +1840,8 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
                       "{workspaceRoot}/tsconfig.base.json",
                       "{projectRoot}/tsconfig.json",
                       "{projectRoot}/src/**/*.ts",
-                      "!{workspaceRoot}/node_modules",
-                      "!{workspaceRoot}/tmp",
+                      "!{workspaceRoot}/node_modules/**/*",
+                      "!{workspaceRoot}/tmp/**/*",
                       {
                         "dependentTasksOutputFiles": "**/*.{d.ts,d.cts,d.mts,tsbuildinfo}",
                         "transitive": true,
@@ -1684,8 +1920,8 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
                       "{workspaceRoot}/tsconfig.foo.json",
                       "{projectRoot}/tsconfig.json",
                       "{projectRoot}/src/**/*.ts",
-                      "!{workspaceRoot}/node_modules",
-                      "!{workspaceRoot}/dist",
+                      "!{workspaceRoot}/node_modules/**/*",
+                      "!{workspaceRoot}/dist/**/*",
                       {
                         "dependentTasksOutputFiles": "**/*.{d.ts,d.cts,d.mts,tsbuildinfo}",
                         "transitive": true,
@@ -1777,8 +2013,8 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
                       "{workspaceRoot}/libs/my-package/tsconfig.base.json",
                       "{projectRoot}/tsconfig.json",
                       "{projectRoot}/src/**/*.ts",
-                      "!{workspaceRoot}/node_modules",
-                      "!{workspaceRoot}/tmp",
+                      "!{workspaceRoot}/node_modules/**/*",
+                      "!{workspaceRoot}/tmp/**/*",
                       {
                         "dependentTasksOutputFiles": "**/*.{d.ts,d.cts,d.mts,tsbuildinfo}",
                         "transitive": true,
@@ -4341,6 +4577,83 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
         `);
       });
 
+      it('should normalize and expand "." in `include` with the ts extensions', async () => {
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
+          'libs/my-lib/tsconfig.lib.json': JSON.stringify({
+            compilerOptions: { outDir: 'dist' },
+            include: ['.'],
+          }),
+          'libs/my-lib/tsconfig.json': `{}`,
+          'libs/my-lib/package.json': `{"main": "dist/index.js"}`,
+        });
+
+        expect(
+          await invokeCreateNodesOnMatchingFiles(configFiles, context, {
+            typecheck: false,
+            build: true,
+          })
+        ).toMatchInlineSnapshot(`
+          {
+            "projects": {
+              "libs/my-lib": {
+                "targets": {
+                  "build": {
+                    "cache": true,
+                    "command": "tsc --build tsconfig.lib.json",
+                    "dependsOn": [
+                      "^build",
+                    ],
+                    "inputs": [
+                      "{projectRoot}/package.json",
+                      "{projectRoot}/tsconfig.lib.json",
+                      "{projectRoot}/**/*.ts",
+                      "{projectRoot}/**/*.tsx",
+                      "{projectRoot}/**/*.d.ts",
+                      "{projectRoot}/**/*.cts",
+                      "{projectRoot}/**/*.d.cts",
+                      "{projectRoot}/**/*.mts",
+                      "{projectRoot}/**/*.d.mts",
+                      {
+                        "dependentTasksOutputFiles": "**/*.{d.ts,d.cts,d.mts,tsbuildinfo}",
+                        "transitive": true,
+                      },
+                      {
+                        "dependencies": true,
+                        "fileset": "{projectRoot}/**/*.{d.ts,d.cts,d.mts}",
+                      },
+                    ],
+                    "metadata": {
+                      "description": "Builds the project with \`tsc\`.",
+                      "help": {
+                        "command": "npx tsc --build --help",
+                        "example": {
+                          "args": [
+                            "--force",
+                          ],
+                        },
+                      },
+                      "technologies": [
+                        "typescript",
+                      ],
+                    },
+                    "options": {
+                      "cwd": "libs/my-lib",
+                    },
+                    "outputs": [
+                      "{projectRoot}/dist/**/*.{js,cjs,mjs,jsx,d.ts,d.cts,d.mts}{,.map}",
+                      "{projectRoot}/dist/tsconfig.lib.tsbuildinfo",
+                    ],
+                    "syncGenerators": [
+                      "@nx/js:typescript-sync",
+                    ],
+                  },
+                },
+              },
+            },
+          }
+        `);
+      });
+
       it('should normalize and add directories in `include` with the ts and js extensions when `allowJs` is true', async () => {
         configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
           'libs/my-lib/tsconfig.lib.json': JSON.stringify({
@@ -4626,8 +4939,8 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
                       "{workspaceRoot}/tsconfig.base.json",
                       "{projectRoot}/tsconfig.lib.json",
                       "{projectRoot}/src/**/*.ts",
-                      "!{workspaceRoot}/node_modules",
-                      "!{workspaceRoot}/tmp",
+                      "!{workspaceRoot}/node_modules/**/*",
+                      "!{workspaceRoot}/tmp/**/*",
                       {
                         "dependentTasksOutputFiles": "**/*.{d.ts,d.cts,d.mts,tsbuildinfo}",
                         "transitive": true,
@@ -4710,8 +5023,8 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
                       "{workspaceRoot}/tsconfig.foo.json",
                       "{projectRoot}/tsconfig.lib.json",
                       "{projectRoot}/src/**/*.ts",
-                      "!{workspaceRoot}/node_modules",
-                      "!{workspaceRoot}/dist",
+                      "!{workspaceRoot}/node_modules/**/*",
+                      "!{workspaceRoot}/dist/**/*",
                       {
                         "dependentTasksOutputFiles": "**/*.{d.ts,d.cts,d.mts,tsbuildinfo}",
                         "transitive": true,
@@ -4809,8 +5122,8 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
                       "{workspaceRoot}/libs/my-package/tsconfig.base.json",
                       "{projectRoot}/tsconfig.lib.json",
                       "{projectRoot}/src/**/*.ts",
-                      "!{workspaceRoot}/node_modules",
-                      "!{workspaceRoot}/tmp",
+                      "!{workspaceRoot}/node_modules/**/*",
+                      "!{workspaceRoot}/tmp/**/*",
                       {
                         "dependentTasksOutputFiles": "**/*.{d.ts,d.cts,d.mts,tsbuildinfo}",
                         "transitive": true,

--- a/packages/js/src/plugins/typescript/plugin.ts
+++ b/packages/js/src/plugins/typescript/plugin.ts
@@ -24,6 +24,7 @@ import {
 import {
   basename,
   dirname,
+  isAbsolute,
   join,
   normalize,
   relative,
@@ -768,6 +769,14 @@ function getInputs(
     ts.Extension.Mjs,
   ];
 
+  // A spec is an implicit glob over a directory if its last component has no
+  // extension and no glob characters. TypeScript normalizes the path before
+  // checking its last component, so specs like "." and ".." resolve to a
+  // directory name first.
+  // https://github.com/microsoft/TypeScript/blob/19b777260b26aac5707b1efd34202054164d4a9d/src/compiler/utilities.ts#L9577-L9585
+  const isImplicitGlobSpec = (spec: string): boolean =>
+    !/[.*?]/.test(basename(resolve(absoluteProjectRoot, spec)));
+
   const normalizeInput = (
     input: string,
     config: ParsedTsconfigData
@@ -779,13 +788,9 @@ function getInputs(
       extensions.push(ts.Extension.Json);
     }
 
-    const segments = input.split('/');
-    // An "includes" path "foo" is implicitly a glob "foo/**/*" if its last
-    // segment has no extension, and does not contain any glob characters
-    // itself.
-    // https://github.com/microsoft/TypeScript/blob/19b777260b26aac5707b1efd34202054164d4a9d/src/compiler/utilities.ts#L9577-L9585
-    if (!/[.*?]/.test(segments.at(-1))) {
-      return extensions.map((ext) => `${segments.join('/')}/**/*${ext}`);
+    // An "includes" path "foo" is implicitly a glob "foo/**/*"
+    if (isImplicitGlobSpec(input)) {
+      return extensions.map((ext) => `${input}/**/*${ext}`);
     }
 
     return [input];
@@ -829,6 +834,30 @@ function getInputs(
         }
       });
       const normalize = (p: string) => (p.startsWith('./') ? p.slice(2) : p);
+      // Static (non-glob) prefix of a spec, used for subtree coverage checks.
+      const staticPrefix = (p: string): string => {
+        const segments = normalize(p).split('/');
+        const firstGlobSegment = segments.findIndex((s) => /[*?]/.test(s));
+        return firstGlobSegment === -1
+          ? segments.join('/')
+          : segments.slice(0, firstGlobSegment).join('/');
+      };
+      // A non-glob include spec (an implicit directory glob like "." or "src",
+      // or a literal file path) covers an exclude spec if the exclude's static
+      // prefix falls within the include's subtree.
+      const includeCoversExclude = (
+        includePath: string,
+        excludePath: string
+      ): boolean => {
+        if (/[*?]/.test(includePath)) {
+          return false;
+        }
+        const rel = relative(
+          resolve(absoluteProjectRoot, normalize(includePath)),
+          resolve(absoluteProjectRoot, staticPrefix(excludePath))
+        );
+        return !rel.startsWith('..') && !isAbsolute(rel);
+      };
       tsconfig.raw.exclude.forEach((e: string) => {
         const excludePath = substituteConfigDir(e);
         const normalizedExclude = normalize(excludePath);
@@ -840,11 +869,18 @@ function getInputs(
             const includeMatcher = getOrCreateMatcher(normalizedInclude);
             return (
               excludeMatcher(normalizedInclude) ||
-              includeMatcher(normalizedExclude)
+              includeMatcher(normalizedExclude) ||
+              includeCoversExclude(includePath, excludePath)
             );
           })
         ) {
-          excludePaths.add(excludePath);
+          // TS treats an implicit-glob exclude like "dist" as excluding the
+          // whole subtree, so emit it as "dist/**/*".
+          excludePaths.add(
+            isImplicitGlobSpec(excludePath)
+              ? `${excludePath}/**/*`
+              : excludePath
+          );
         }
       });
     }


### PR DESCRIPTION
## Current Behavior

tsconfig `include` entries like `"."` produce a bare `{projectRoot}` task input that matches no files, so source changes don't invalidate the cache for the inferred `typecheck`/`build` tasks. Directory `exclude` entries (e.g. `"dist"`) are emitted as literal negations that match nothing, and excludes from sibling tsconfigs can suppress files covered by another tsconfig's include.

## Expected Behavior

Include and exclude entries are interpreted the way TypeScript interprets them: `include: ["."]` expands to the project's source files, directory excludes cover their whole subtree, and excludes covered by another tsconfig's non-glob include are not emitted as negations.

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/ts-plugin-include-dot-issue-7fb1ea4f)
<!-- polygraph-session-end -->