### PR TITLE
fix(react-native): avoid executing unchanged app configs during project graph construction

### DIFF
--- a/packages/expo/plugins/plugin.spec.ts
+++ b/packages/expo/plugins/plugin.spec.ts
@@ -1,0 +1,318 @@
+import { CreateNodesContext } from '@nx/devkit';
+import * as configUtils from '@nx/devkit/internal';
+import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
+import { setupWorkspaceContext } from 'nx/src/utils/workspace-context';
+import { resolve } from 'path';
+import { createNodesV2, ExpoPluginOptions } from './plugin';
+
+jest.mock('nx/src/utils/cache-directory', () => ({
+  ...jest.requireActual('nx/src/utils/cache-directory'),
+  workspaceDataDirectory: 'tmp/project-graph-cache',
+}));
+
+describe('@nx/expo/plugin', () => {
+  const createNodesFunction = createNodesV2[1];
+  const options: ExpoPluginOptions = {};
+  let context: CreateNodesContext;
+  let tempFs: TempFs;
+  let cwd: string;
+  let loadConfigFileSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    tempFs = new TempFs('expo-plugin');
+    cwd = process.cwd();
+    process.chdir(tempFs.tempDir);
+    context = {
+      nxJsonConfiguration: {
+        namedInputs: {
+          default: ['{projectRoot}/**/*'],
+          production: ['!{projectRoot}/**/*.spec.ts'],
+        },
+      },
+      workspaceRoot: tempFs.tempDir,
+    };
+    // Spy with call-through: configs still load, we just count executions.
+    loadConfigFileSpy = jest.spyOn(configUtils, 'loadConfigFile');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.resetModules();
+    tempFs.cleanup();
+    process.chdir(cwd);
+  });
+
+  // Absolute path as the plugin computes it (join(workspaceRoot, file)).
+  const abs = (file: string) => resolve(tempFs.tempDir, file);
+  const loadedConfigPaths = () =>
+    loadConfigFileSpy.mock.calls.map((call) => call[0] as string);
+
+  it('should create nodes for an Expo app config', async () => {
+    await tempFs.createFiles({
+      'package-lock.json': '{}',
+      'apps/mobile/app.json': '{ "expo": { "name": "mobile" } }',
+      'apps/mobile/package.json': '{}',
+      'apps/mobile/metro.config.js': '',
+    });
+    setupWorkspaceContext(tempFs.tempDir);
+
+    const results = await createNodesFunction(
+      ['apps/mobile/app.json'],
+      options,
+      context
+    );
+
+    expect(results).toHaveLength(1);
+    const [configFile, result] = results[0];
+    expect(configFile).toBe('apps/mobile/app.json');
+    expect(Object.keys(result.projects['apps/mobile'].targets)).toEqual([
+      'start',
+      'serve',
+      'run-ios',
+      'run-android',
+      'export',
+      'install',
+      'prebuild',
+      'build',
+      'submit',
+    ]);
+  });
+
+  it('should include a project whose package.json depends on expo even if the app config has no expo key', async () => {
+    await tempFs.createFiles({
+      'package-lock.json': '{}',
+      'apps/mobile/app.json': '{ "name": "mobile" }',
+      'apps/mobile/package.json': '{ "dependencies": { "expo": "*" } }',
+      'apps/mobile/metro.config.js': '',
+    });
+    setupWorkspaceContext(tempFs.tempDir);
+
+    const results = await createNodesFunction(
+      ['apps/mobile/app.json'],
+      options,
+      context
+    );
+
+    expect(results).toHaveLength(1);
+  });
+
+  it('should exclude projects that are not Expo apps', async () => {
+    await tempFs.createFiles({
+      'package-lock.json': '{}',
+      // no expo key and no expo dependency
+      'apps/rn/app.json': '{ "name": "rn" }',
+      'apps/rn/package.json': '{ "dependencies": { "react-native": "*" } }',
+      'apps/rn/metro.config.js': '',
+      // missing metro.config.js
+      'apps/other/app.json': '{ "expo": { "name": "other" } }',
+      'apps/other/package.json': '{}',
+    });
+    setupWorkspaceContext(tempFs.tempDir);
+
+    const results = await createNodesFunction(
+      ['apps/rn/app.json', 'apps/other/app.json'],
+      options,
+      context
+    );
+
+    expect(results).toHaveLength(0);
+  });
+
+  it('should make per-config-file decisions within the same project root', async () => {
+    await tempFs.createFiles({
+      'package-lock.json': '{}',
+      // app.json alone does not qualify; app.config.js does
+      'apps/mobile/app.json': '{ "name": "mobile" }',
+      'apps/mobile/app.config.js':
+        'module.exports = { expo: { name: "mobile" } };',
+      'apps/mobile/package.json': '{}',
+      'apps/mobile/metro.config.js': '',
+    });
+    setupWorkspaceContext(tempFs.tempDir);
+
+    const results = await createNodesFunction(
+      ['apps/mobile/app.json', 'apps/mobile/app.config.js'],
+      options,
+      context
+    );
+
+    expect(results.map(([configFile]) => configFile)).toEqual([
+      'apps/mobile/app.config.js',
+    ]);
+  });
+
+  it('should not execute any app config on a warm cache when nothing changed', async () => {
+    await tempFs.createFiles({
+      'package-lock.json': '{}',
+      'apps/mobile/app.json': '{ "expo": { "name": "mobile" } }',
+      'apps/mobile/package.json': '{}',
+      'apps/mobile/metro.config.js': '',
+    });
+    setupWorkspaceContext(tempFs.tempDir);
+
+    // Cold run populates the on-disk cache.
+    const coldResults = await createNodesFunction(
+      ['apps/mobile/app.json'],
+      options,
+      context
+    );
+    expect(loadedConfigPaths()).toContain(abs('apps/mobile/app.json'));
+
+    // Warm run: cached filter decision and targets -> no load.
+    loadConfigFileSpy.mockClear();
+    const warmResults = await createNodesFunction(
+      ['apps/mobile/app.json'],
+      options,
+      context
+    );
+    expect(loadConfigFileSpy).not.toHaveBeenCalled();
+    expect(warmResults).toEqual(coldResults);
+  });
+
+  it('should cache the exclusion decision as well', async () => {
+    await tempFs.createFiles({
+      'package-lock.json': '{}',
+      'apps/rn/app.json': '{ "name": "rn" }',
+      'apps/rn/package.json': '{ "dependencies": { "react-native": "*" } }',
+      'apps/rn/metro.config.js': '',
+    });
+    setupWorkspaceContext(tempFs.tempDir);
+
+    await createNodesFunction(['apps/rn/app.json'], options, context);
+    expect(loadedConfigPaths()).toContain(abs('apps/rn/app.json'));
+
+    loadConfigFileSpy.mockClear();
+    const warmResults = await createNodesFunction(
+      ['apps/rn/app.json'],
+      options,
+      context
+    );
+    expect(loadConfigFileSpy).not.toHaveBeenCalled();
+    expect(warmResults).toHaveLength(0);
+  });
+
+  it('should re-evaluate only the project that changed', async () => {
+    await tempFs.createFiles({
+      'package-lock.json': '{}',
+      'apps/mobile-a/app.json': '{ "expo": { "name": "mobile-a" } }',
+      'apps/mobile-a/package.json': '{}',
+      'apps/mobile-a/metro.config.js': '',
+      'apps/mobile-b/app.json': '{ "expo": { "name": "mobile-b" } }',
+      'apps/mobile-b/package.json': '{}',
+      'apps/mobile-b/metro.config.js': '',
+    });
+    setupWorkspaceContext(tempFs.tempDir);
+
+    const configFiles = ['apps/mobile-a/app.json', 'apps/mobile-b/app.json'];
+    await createNodesFunction(configFiles, options, context);
+
+    // Change only mobile-a's project files -> only its key moves.
+    loadConfigFileSpy.mockClear();
+    tempFs.writeFile(
+      'apps/mobile-a/app.json',
+      '{ "expo": { "name": "mobile-a-renamed" } }'
+    );
+    setupWorkspaceContext(tempFs.tempDir);
+    await createNodesFunction(configFiles, options, context);
+
+    const reloaded = loadedConfigPaths();
+    expect(reloaded).toContain(abs('apps/mobile-a/app.json'));
+    expect(reloaded).not.toContain(abs('apps/mobile-b/app.json'));
+  });
+
+  it('should re-execute js/ts configs whose decision is not pinned by package.json', async () => {
+    await tempFs.createFiles({
+      'package-lock.json': '{}',
+      // included only because the executed config exports an expo key; that
+      // decision can depend on inputs outside the cache key, so it is
+      // re-evaluated on every run
+      'apps/mobile/app.config.js':
+        'module.exports = { expo: { name: "mobile" } };',
+      'apps/mobile/package.json': '{}',
+      'apps/mobile/metro.config.js': '',
+    });
+    setupWorkspaceContext(tempFs.tempDir);
+
+    const coldResults = await createNodesFunction(
+      ['apps/mobile/app.config.js'],
+      options,
+      context
+    );
+    expect(coldResults).toHaveLength(1);
+
+    loadConfigFileSpy.mockClear();
+    const warmResults = await createNodesFunction(
+      ['apps/mobile/app.config.js'],
+      options,
+      context
+    );
+    expect(loadedConfigPaths()).toContain(abs('apps/mobile/app.config.js'));
+    expect(warmResults).toEqual(coldResults);
+  });
+
+  it('should not re-execute js/ts configs when package.json declares expo', async () => {
+    await tempFs.createFiles({
+      'package-lock.json': '{}',
+      'apps/mobile/app.config.js': 'module.exports = { name: "mobile" };',
+      'apps/mobile/package.json': '{ "dependencies": { "expo": "*" } }',
+      'apps/mobile/metro.config.js': '',
+    });
+    setupWorkspaceContext(tempFs.tempDir);
+
+    const coldResults = await createNodesFunction(
+      ['apps/mobile/app.config.js'],
+      options,
+      context
+    );
+    expect(coldResults).toHaveLength(1);
+
+    // The package.json dependency pins the decision regardless of what the
+    // config exports, so the cached decision is sound and no load happens.
+    loadConfigFileSpy.mockClear();
+    const warmResults = await createNodesFunction(
+      ['apps/mobile/app.config.js'],
+      options,
+      context
+    );
+    expect(loadConfigFileSpy).not.toHaveBeenCalled();
+    expect(warmResults).toEqual(coldResults);
+  });
+
+  it('should not mutate user-provided options', async () => {
+    await tempFs.createFiles({
+      'package-lock.json': '{}',
+      'apps/mobile/app.json': '{ "expo": { "name": "mobile" } }',
+      'apps/mobile/package.json': '{}',
+      'apps/mobile/metro.config.js': '',
+    });
+    setupWorkspaceContext(tempFs.tempDir);
+
+    // The daemon passes the same options object on every invocation; mutating
+    // it would change the option-derived hashes between runs.
+    const userOptions: ExpoPluginOptions = { startTargetName: 'dev' };
+    await createNodesFunction(['apps/mobile/app.json'], userOptions, context);
+
+    expect(userOptions).toEqual({ startTargetName: 'dev' });
+  });
+
+  it('should resurface app config load errors on every run', async () => {
+    await tempFs.createFiles({
+      'package-lock.json': '{}',
+      'apps/mobile/app.config.js': 'throw new Error("broken config");',
+      'apps/mobile/package.json': '{}',
+      'apps/mobile/metro.config.js': '',
+    });
+    setupWorkspaceContext(tempFs.tempDir);
+
+    await expect(
+      createNodesFunction(['apps/mobile/app.config.js'], options, context)
+    ).rejects.toThrow();
+
+    // Errors are not cached: the config is executed and fails again.
+    loadConfigFileSpy.mockClear();
+    await expect(
+      createNodesFunction(['apps/mobile/app.config.js'], options, context)
+    ).rejects.toThrow();
+    expect(loadedConfigPaths()).toContain(abs('apps/mobile/app.config.js'));
+  });
+});

--- a/packages/expo/plugins/plugin.ts
+++ b/packages/expo/plugins/plugin.ts
@@ -17,7 +17,7 @@ import {
   readJsonFile,
   TargetConfiguration,
 } from '@nx/devkit';
-import { dirname, join } from 'path';
+import { basename, dirname, join } from 'path';
 import { getLockFileName } from '@nx/js';
 import { readdirSync } from 'fs';
 import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
@@ -40,28 +40,47 @@ export interface ExpoPluginOptions {
 
 type ExpoTargets = Record<string, TargetConfiguration<ExpoPluginOptions>>;
 
+// Keyed per (project hash, config file) so warm runs can reuse the filter
+// decision without executing the app config. `included` is only stored when
+// the decision derives from inputs covered by the cache key (app.json
+// content, sibling-file existence, or an expo dependency in the project's
+// package.json); decisions resting on executed JS/TS config content are
+// re-evaluated every run. `targets` is set lazily for included entries.
+interface ExpoCacheEntry {
+  included?: boolean;
+  targets?: ExpoTargets;
+}
+
 export const createNodes: CreateNodes<ExpoPluginOptions> = [
   '**/app.{json,config.js,config.ts}',
   async (configFiles, options, context) => {
     const optionsHash = hashObject(options);
     const cachePath = join(workspaceDataDirectory, `expo-${optionsHash}.hash`);
-    const targetsCache = new PluginCache<ExpoTargets>(cachePath);
+    const cache = new PluginCache<ExpoCacheEntry>(cachePath);
     const packageManager = detectPackageManager(context.workspaceRoot);
     const pmc = getPackageManagerCommand(packageManager);
     const lockFileName = getLockFileName(packageManager);
     const normalizedOptions = normalizeOptions(options);
 
     try {
-      const { entries, preErrors } = await filterExpoConfigs(
-        configFiles,
-        context
-      );
-
+      // Per-candidate keys computable without executing configs. Keyed per
+      // config file because two config files in the same root (app.json +
+      // app.config.js) can produce different filter outcomes.
       const projectHashes = await calculateHashesForCreateNodes(
-        entries.map((e) => e.projectRoot),
+        configFiles.map((configFile) => dirname(configFile)),
         normalizedOptions,
         context,
-        entries.map(() => [lockFileName])
+        configFiles.map(() => [lockFileName])
+      );
+      const cacheKeys = configFiles.map(
+        (configFile, idx) => `${projectHashes[idx]}|${configFile}`
+      );
+
+      const { entries, preErrors } = await filterExpoConfigs(
+        configFiles,
+        cacheKeys,
+        cache,
+        context
       );
 
       let results: CreateNodesResultV2 = [];
@@ -73,9 +92,9 @@ export const createNodes: CreateNodes<ExpoPluginOptions> = [
               configFile,
               normalizedOptions,
               ctx,
-              targetsCache,
+              cache,
               pmc,
-              projectHashes[idx]
+              entries[idx].cacheKey
             ),
           entries.map((e) => e.configFile),
           options,
@@ -96,7 +115,7 @@ export const createNodes: CreateNodes<ExpoPluginOptions> = [
       }
       return results;
     } finally {
-      targetsCache.writeToDisk();
+      cache.writeToDisk();
     }
   },
 ];
@@ -107,23 +126,22 @@ async function createNodesInternal(
   configFile: string,
   options: ExpoPluginOptions,
   context: CreateNodesContext,
-  targetsCache: PluginCache<ExpoTargets>,
+  cache: PluginCache<ExpoCacheEntry>,
   pmc: ReturnType<typeof getPackageManagerCommand>,
-  hash: string
+  cacheKey: string
 ): Promise<CreateNodesResult> {
   const projectRoot = dirname(configFile);
 
-  if (!targetsCache.has(hash)) {
-    targetsCache.set(
-      hash,
-      buildExpoTargets(projectRoot, options, context, pmc)
-    );
+  const entry = cache.get(cacheKey) ?? {};
+  if (!entry.targets) {
+    entry.targets = buildExpoTargets(projectRoot, options, context, pmc);
+    cache.set(cacheKey, entry);
   }
 
   return {
     projects: {
       [projectRoot]: {
-        targets: targetsCache.get(hash),
+        targets: entry.targets,
       },
     },
   };
@@ -202,17 +220,25 @@ function getAppConfig(
 
 async function filterExpoConfigs(
   configFiles: readonly string[],
+  cacheKeys: readonly string[],
+  cache: PluginCache<ExpoCacheEntry>,
   context: CreateNodesContext
 ): Promise<{
-  entries: Array<{ configFile: string; projectRoot: string }>;
+  entries: Array<{ configFile: string; cacheKey: string }>;
   preErrors: Array<[string, Error]>;
 }> {
   const preErrors: Array<[string, Error]> = [];
   const candidates = await Promise.all(
     configFiles.map(
       async (
-        configFile
-      ): Promise<{ configFile: string; projectRoot: string } | null> => {
+        configFile,
+        idx
+      ): Promise<{ configFile: string; cacheKey: string } | null> => {
+        const cacheKey = cacheKeys[idx];
+        const cached = cache.get(cacheKey);
+        if (cached?.included !== undefined) {
+          return cached.included ? { configFile, cacheKey } : null;
+        }
         try {
           const projectRoot = dirname(configFile);
           const siblingFiles = readdirSync(
@@ -222,21 +248,27 @@ async function filterExpoConfigs(
             !siblingFiles.includes('package.json') ||
             !siblingFiles.includes('metro.config.js')
           ) {
+            cache.set(cacheKey, { ...cached, included: false });
             return null;
           }
           const packageJson = readJsonFile(
             join(context.workspaceRoot, projectRoot, 'package.json')
           );
+          const pkgHasExpo = !!(
+            packageJson.dependencies?.['expo'] ||
+            packageJson.devDependencies?.['expo']
+          );
           const appConfig = await getAppConfig(configFile, context);
-          if (
-            !appConfig.expo &&
-            !packageJson.dependencies?.['expo'] &&
-            !packageJson.devDependencies?.['expo']
-          ) {
-            return null;
+          const included = !!appConfig.expo || pkgHasExpo;
+          // A decision resting on executed JS/TS config content can depend on
+          // inputs outside the cache key (imports, fs reads, env vars), so it
+          // is only cached when package.json pins it or the config is data.
+          if (pkgHasExpo || basename(configFile) === 'app.json') {
+            cache.set(cacheKey, { ...cached, included });
           }
-          return { configFile, projectRoot };
+          return included ? { configFile, cacheKey } : null;
         } catch (e) {
+          // Not cached: load errors must resurface on every run.
           preErrors.push([configFile, e as Error]);
           return null;
         }
@@ -271,15 +303,19 @@ function getOutputs(projectRoot: string, dir: string) {
 }
 
 function normalizeOptions(options: ExpoPluginOptions): ExpoPluginOptions {
-  options ??= {};
-  options.startTargetName ??= 'start';
-  options.serveTargetName ??= 'serve';
-  options.runIosTargetName ??= 'run-ios';
-  options.runAndroidTargetName ??= 'run-android';
-  options.exportTargetName ??= 'export';
-  options.prebuildTargetName ??= 'prebuild';
-  options.installTargetName ??= 'install';
-  options.buildTargetName ??= 'build';
-  options.submitTargetName ??= 'submit';
-  return options;
+  // Do not mutate the input: the daemon passes the same options object on
+  // every invocation, and mutating it changes the option-derived hashes
+  // between the first and subsequent runs.
+  return {
+    ...options,
+    startTargetName: options?.startTargetName ?? 'start',
+    serveTargetName: options?.serveTargetName ?? 'serve',
+    runIosTargetName: options?.runIosTargetName ?? 'run-ios',
+    runAndroidTargetName: options?.runAndroidTargetName ?? 'run-android',
+    exportTargetName: options?.exportTargetName ?? 'export',
+    prebuildTargetName: options?.prebuildTargetName ?? 'prebuild',
+    installTargetName: options?.installTargetName ?? 'install',
+    buildTargetName: options?.buildTargetName ?? 'build',
+    submitTargetName: options?.submitTargetName ?? 'submit',
+  };
 }

--- a/packages/react-native/plugins/plugin.spec.ts
+++ b/packages/react-native/plugins/plugin.spec.ts
@@ -1,0 +1,273 @@
+import { CreateNodesContext } from '@nx/devkit';
+import * as configUtils from '@nx/devkit/internal';
+import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
+import { setupWorkspaceContext } from 'nx/src/utils/workspace-context';
+import { resolve } from 'path';
+import { createNodesV2, ReactNativePluginOptions } from './plugin';
+
+jest.mock('nx/src/utils/cache-directory', () => ({
+  ...jest.requireActual('nx/src/utils/cache-directory'),
+  workspaceDataDirectory: 'tmp/project-graph-cache',
+}));
+
+describe('@nx/react-native/plugin', () => {
+  const createNodesFunction = createNodesV2[1];
+  const options: ReactNativePluginOptions = {};
+  let context: CreateNodesContext;
+  let tempFs: TempFs;
+  let cwd: string;
+  let loadConfigFileSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    tempFs = new TempFs('react-native-plugin');
+    cwd = process.cwd();
+    process.chdir(tempFs.tempDir);
+    context = {
+      nxJsonConfiguration: {
+        namedInputs: {
+          default: ['{projectRoot}/**/*'],
+          production: ['!{projectRoot}/**/*.spec.ts'],
+        },
+      },
+      workspaceRoot: tempFs.tempDir,
+    };
+    // Spy with call-through: configs still load, we just count executions.
+    loadConfigFileSpy = jest.spyOn(configUtils, 'loadConfigFile');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    jest.resetModules();
+    tempFs.cleanup();
+    process.chdir(cwd);
+  });
+
+  // Absolute path as the plugin computes it (join(workspaceRoot, file)).
+  const abs = (file: string) => resolve(tempFs.tempDir, file);
+  const loadedConfigPaths = () =>
+    loadConfigFileSpy.mock.calls.map((call) => call[0] as string);
+
+  it('should create nodes for a React Native app config', async () => {
+    await tempFs.createFiles({
+      'package-lock.json': '{}',
+      'apps/rn/app.json': '{ "name": "rn" }',
+      'apps/rn/package.json': '{ "dependencies": { "react-native": "*" } }',
+      'apps/rn/metro.config.js': '',
+    });
+    setupWorkspaceContext(tempFs.tempDir);
+
+    const results = await createNodesFunction(
+      ['apps/rn/app.json'],
+      options,
+      context
+    );
+
+    expect(results).toHaveLength(1);
+    const [configFile, result] = results[0];
+    expect(configFile).toBe('apps/rn/app.json');
+    expect(Object.keys(result.projects['apps/rn'].targets)).toEqual([
+      'start',
+      'pod-install',
+      'run-ios',
+      'run-android',
+      'build-ios',
+      'build-android',
+      'bundle',
+      'sync-deps',
+      'upgrade',
+    ]);
+  });
+
+  it('should exclude Expo projects and projects without metro config', async () => {
+    await tempFs.createFiles({
+      'package-lock.json': '{}',
+      // expo key in the app config
+      'apps/expo-a/app.json': '{ "expo": { "name": "expo-a" } }',
+      'apps/expo-a/package.json': '{}',
+      'apps/expo-a/metro.config.js': '',
+      // expo dependency in package.json
+      'apps/expo-b/app.json': '{ "name": "expo-b" }',
+      'apps/expo-b/package.json': '{ "dependencies": { "expo": "*" } }',
+      'apps/expo-b/metro.config.js': '',
+      // missing metro.config.js
+      'apps/other/app.json': '{ "name": "other" }',
+      'apps/other/package.json': '{}',
+    });
+    setupWorkspaceContext(tempFs.tempDir);
+
+    const results = await createNodesFunction(
+      ['apps/expo-a/app.json', 'apps/expo-b/app.json', 'apps/other/app.json'],
+      options,
+      context
+    );
+
+    expect(results).toHaveLength(0);
+  });
+
+  it('should not execute any app config on a warm cache when nothing changed', async () => {
+    await tempFs.createFiles({
+      'package-lock.json': '{}',
+      'apps/rn/app.json': '{ "name": "rn" }',
+      'apps/rn/package.json': '{ "dependencies": { "react-native": "*" } }',
+      'apps/rn/metro.config.js': '',
+    });
+    setupWorkspaceContext(tempFs.tempDir);
+
+    // Cold run populates the on-disk cache.
+    const coldResults = await createNodesFunction(
+      ['apps/rn/app.json'],
+      options,
+      context
+    );
+    expect(loadedConfigPaths()).toContain(abs('apps/rn/app.json'));
+
+    // Warm run: cached filter decision and targets -> no load.
+    loadConfigFileSpy.mockClear();
+    const warmResults = await createNodesFunction(
+      ['apps/rn/app.json'],
+      options,
+      context
+    );
+    expect(loadConfigFileSpy).not.toHaveBeenCalled();
+    expect(warmResults).toEqual(coldResults);
+  });
+
+  it('should cache the exclusion decision as well', async () => {
+    await tempFs.createFiles({
+      'package-lock.json': '{}',
+      'apps/expo/app.json': '{ "expo": { "name": "expo" } }',
+      'apps/expo/package.json': '{}',
+      'apps/expo/metro.config.js': '',
+    });
+    setupWorkspaceContext(tempFs.tempDir);
+
+    await createNodesFunction(['apps/expo/app.json'], options, context);
+    expect(loadedConfigPaths()).toContain(abs('apps/expo/app.json'));
+
+    loadConfigFileSpy.mockClear();
+    const warmResults = await createNodesFunction(
+      ['apps/expo/app.json'],
+      options,
+      context
+    );
+    expect(loadConfigFileSpy).not.toHaveBeenCalled();
+    expect(warmResults).toHaveLength(0);
+  });
+
+  it('should re-evaluate only the project that changed', async () => {
+    await tempFs.createFiles({
+      'package-lock.json': '{}',
+      'apps/rn-a/app.json': '{ "name": "rn-a" }',
+      'apps/rn-a/package.json': '{ "dependencies": { "react-native": "*" } }',
+      'apps/rn-a/metro.config.js': '',
+      'apps/rn-b/app.json': '{ "name": "rn-b" }',
+      'apps/rn-b/package.json': '{ "dependencies": { "react-native": "*" } }',
+      'apps/rn-b/metro.config.js': '',
+    });
+    setupWorkspaceContext(tempFs.tempDir);
+
+    const configFiles = ['apps/rn-a/app.json', 'apps/rn-b/app.json'];
+    await createNodesFunction(configFiles, options, context);
+
+    // Change only rn-a's project files -> only its key moves.
+    loadConfigFileSpy.mockClear();
+    tempFs.writeFile('apps/rn-a/app.json', '{ "name": "rn-a-renamed" }');
+    setupWorkspaceContext(tempFs.tempDir);
+    await createNodesFunction(configFiles, options, context);
+
+    const reloaded = loadedConfigPaths();
+    expect(reloaded).toContain(abs('apps/rn-a/app.json'));
+    expect(reloaded).not.toContain(abs('apps/rn-b/app.json'));
+  });
+
+  it('should re-execute js/ts configs whose decision is not pinned by package.json', async () => {
+    await tempFs.createFiles({
+      'package-lock.json': '{}',
+      // included only because the executed config exports no expo key; that
+      // decision can depend on inputs outside the cache key, so it is
+      // re-evaluated on every run
+      'apps/rn/app.config.js': 'module.exports = { name: "rn" };',
+      'apps/rn/package.json': '{ "dependencies": { "react-native": "*" } }',
+      'apps/rn/metro.config.js': '',
+    });
+    setupWorkspaceContext(tempFs.tempDir);
+
+    const coldResults = await createNodesFunction(
+      ['apps/rn/app.config.js'],
+      options,
+      context
+    );
+    expect(coldResults).toHaveLength(1);
+
+    loadConfigFileSpy.mockClear();
+    const warmResults = await createNodesFunction(
+      ['apps/rn/app.config.js'],
+      options,
+      context
+    );
+    expect(loadedConfigPaths()).toContain(abs('apps/rn/app.config.js'));
+    expect(warmResults).toEqual(coldResults);
+  });
+
+  it('should not re-execute js/ts configs when package.json declares expo', async () => {
+    await tempFs.createFiles({
+      'package-lock.json': '{}',
+      'apps/expo/app.config.js': 'module.exports = { name: "expo" };',
+      'apps/expo/package.json': '{ "dependencies": { "expo": "*" } }',
+      'apps/expo/metro.config.js': '',
+    });
+    setupWorkspaceContext(tempFs.tempDir);
+
+    await createNodesFunction(['apps/expo/app.config.js'], options, context);
+    expect(loadedConfigPaths()).toContain(abs('apps/expo/app.config.js'));
+
+    // The package.json dependency pins the exclusion regardless of what the
+    // config exports, so the cached decision is sound and no load happens.
+    loadConfigFileSpy.mockClear();
+    const warmResults = await createNodesFunction(
+      ['apps/expo/app.config.js'],
+      options,
+      context
+    );
+    expect(loadConfigFileSpy).not.toHaveBeenCalled();
+    expect(warmResults).toHaveLength(0);
+  });
+
+  it('should not mutate user-provided options', async () => {
+    await tempFs.createFiles({
+      'package-lock.json': '{}',
+      'apps/rn/app.json': '{ "name": "rn" }',
+      'apps/rn/package.json': '{ "dependencies": { "react-native": "*" } }',
+      'apps/rn/metro.config.js': '',
+    });
+    setupWorkspaceContext(tempFs.tempDir);
+
+    // The daemon passes the same options object on every invocation; mutating
+    // it would change the option-derived hashes between runs.
+    const userOptions: ReactNativePluginOptions = { startTargetName: 'dev' };
+    await createNodesFunction(['apps/rn/app.json'], userOptions, context);
+
+    expect(userOptions).toEqual({ startTargetName: 'dev' });
+  });
+
+  it('should resurface app config load errors on every run', async () => {
+    await tempFs.createFiles({
+      'package-lock.json': '{}',
+      'apps/rn/app.config.js': 'throw new Error("broken config");',
+      'apps/rn/package.json': '{ "dependencies": { "react-native": "*" } }',
+      'apps/rn/metro.config.js': '',
+    });
+    setupWorkspaceContext(tempFs.tempDir);
+
+    await expect(
+      createNodesFunction(['apps/rn/app.config.js'], options, context)
+    ).rejects.toThrow();
+
+    // Errors are not cached: the config is executed and fails again.
+    loadConfigFileSpy.mockClear();
+    await expect(
+      createNodesFunction(['apps/rn/app.config.js'], options, context)
+    ).rejects.toThrow();
+    expect(loadedConfigPaths()).toContain(abs('apps/rn/app.config.js'));
+  });
+});

--- a/packages/react-native/plugins/plugin.ts
+++ b/packages/react-native/plugins/plugin.ts
@@ -17,7 +17,7 @@ import {
   readJsonFile,
   TargetConfiguration,
 } from '@nx/devkit';
-import { dirname, join } from 'path';
+import { basename, dirname, join } from 'path';
 import { getLockFileName } from '@nx/js';
 import { readdirSync } from 'fs';
 import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
@@ -40,6 +40,17 @@ type ReactNativeTargets = Record<
   TargetConfiguration<ReactNativePluginOptions>
 >;
 
+// Keyed per (project hash, config file) so warm runs can reuse the filter
+// decision without executing the app config. `included` is only stored when
+// the decision derives from inputs covered by the cache key (app.json
+// content, sibling-file existence, or an expo dependency in the project's
+// package.json); decisions resting on executed JS/TS config content are
+// re-evaluated every run. `targets` is set lazily for included entries.
+interface ReactNativeCacheEntry {
+  included?: boolean;
+  targets?: ReactNativeTargets;
+}
+
 export const createNodes: CreateNodes<ReactNativePluginOptions> = [
   '**/app.{json,config.js,config.ts}',
   async (configFiles, options, context) => {
@@ -48,23 +59,31 @@ export const createNodes: CreateNodes<ReactNativePluginOptions> = [
       workspaceDataDirectory,
       `react-native-${optionsHash}.hash`
     );
-    const targetsCache = new PluginCache<ReactNativeTargets>(cachePath);
+    const cache = new PluginCache<ReactNativeCacheEntry>(cachePath);
     const lockFileName = getLockFileName(
       detectPackageManager(context.workspaceRoot)
     );
     const normalizedOptions = normalizeOptions(options);
 
     try {
-      const { entries, preErrors } = await filterReactNativeConfigs(
-        configFiles,
-        context
-      );
-
+      // Per-candidate keys computable without executing configs. Keyed per
+      // config file because two config files in the same root (app.json +
+      // app.config.js) can produce different filter outcomes.
       const projectHashes = await calculateHashesForCreateNodes(
-        entries.map((e) => e.projectRoot),
+        configFiles.map((configFile) => dirname(configFile)),
         normalizedOptions,
         context,
-        entries.map(() => [lockFileName])
+        configFiles.map(() => [lockFileName])
+      );
+      const cacheKeys = configFiles.map(
+        (configFile, idx) => `${projectHashes[idx]}|${configFile}`
+      );
+
+      const { entries, preErrors } = await filterReactNativeConfigs(
+        configFiles,
+        cacheKeys,
+        cache,
+        context
       );
 
       let results: CreateNodesResultV2 = [];
@@ -76,8 +95,8 @@ export const createNodes: CreateNodes<ReactNativePluginOptions> = [
               configFile,
               normalizedOptions,
               ctx,
-              targetsCache,
-              projectHashes[idx]
+              cache,
+              entries[idx].cacheKey
             ),
           entries.map((e) => e.configFile),
           options,
@@ -98,7 +117,7 @@ export const createNodes: CreateNodes<ReactNativePluginOptions> = [
       }
       return results;
     } finally {
-      targetsCache.writeToDisk();
+      cache.writeToDisk();
     }
   },
 ];
@@ -109,22 +128,21 @@ async function createNodesInternal(
   configFile: string,
   options: ReactNativePluginOptions,
   context: CreateNodesContext,
-  targetsCache: PluginCache<ReactNativeTargets>,
-  hash: string
+  cache: PluginCache<ReactNativeCacheEntry>,
+  cacheKey: string
 ): Promise<CreateNodesResult> {
   const projectRoot = dirname(configFile);
 
-  if (!targetsCache.has(hash)) {
-    targetsCache.set(
-      hash,
-      buildReactNativeTargets(projectRoot, options, context)
-    );
+  const entry = cache.get(cacheKey) ?? {};
+  if (!entry.targets) {
+    entry.targets = buildReactNativeTargets(projectRoot, options, context);
+    cache.set(cacheKey, entry);
   }
 
   return {
     projects: {
       [projectRoot]: {
-        targets: targetsCache.get(hash),
+        targets: entry.targets,
       },
     },
   };
@@ -203,17 +221,25 @@ function getAppConfig(
 
 async function filterReactNativeConfigs(
   configFiles: readonly string[],
+  cacheKeys: readonly string[],
+  cache: PluginCache<ReactNativeCacheEntry>,
   context: CreateNodesContext
 ): Promise<{
-  entries: Array<{ configFile: string; projectRoot: string }>;
+  entries: Array<{ configFile: string; cacheKey: string }>;
   preErrors: Array<[string, Error]>;
 }> {
   const preErrors: Array<[string, Error]> = [];
   const candidates = await Promise.all(
     configFiles.map(
       async (
-        configFile
-      ): Promise<{ configFile: string; projectRoot: string } | null> => {
+        configFile,
+        idx
+      ): Promise<{ configFile: string; cacheKey: string } | null> => {
+        const cacheKey = cacheKeys[idx];
+        const cached = cache.get(cacheKey);
+        if (cached?.included !== undefined) {
+          return cached.included ? { configFile, cacheKey } : null;
+        }
         try {
           const projectRoot = dirname(configFile);
           const siblingFiles = readdirSync(
@@ -223,22 +249,28 @@ async function filterReactNativeConfigs(
             !siblingFiles.includes('package.json') ||
             !siblingFiles.includes('metro.config.js')
           ) {
+            cache.set(cacheKey, { ...cached, included: false });
             return null;
           }
           // Skip Expo projects; the @nx/expo plugin handles them.
           const packageJson = readJsonFile(
             join(context.workspaceRoot, projectRoot, 'package.json')
           );
-          const appConfig = await getAppConfig(configFile, context);
-          if (
-            appConfig.expo ||
+          const pkgHasExpo = !!(
             packageJson.dependencies?.['expo'] ||
             packageJson.devDependencies?.['expo']
-          ) {
-            return null;
+          );
+          const appConfig = await getAppConfig(configFile, context);
+          const included = !appConfig.expo && !pkgHasExpo;
+          // A decision resting on executed JS/TS config content can depend on
+          // inputs outside the cache key (imports, fs reads, env vars), so it
+          // is only cached when package.json pins it or the config is data.
+          if (pkgHasExpo || basename(configFile) === 'app.json') {
+            cache.set(cacheKey, { ...cached, included });
           }
-          return { configFile, projectRoot };
+          return included ? { configFile, cacheKey } : null;
         } catch (e) {
+          // Not cached: load errors must resurface on every run.
           preErrors.push([configFile, e as Error]);
           return null;
         }
@@ -275,15 +307,19 @@ function getOutputs(projectRoot: string, dir: string) {
 function normalizeOptions(
   options: ReactNativePluginOptions
 ): ReactNativePluginOptions {
-  options ??= {};
-  options.startTargetName ??= 'start';
-  options.podInstallTargetName ??= 'pod-install';
-  options.runIosTargetName ??= 'run-ios';
-  options.runAndroidTargetName ??= 'run-android';
-  options.buildIosTargetName ??= 'build-ios';
-  options.buildAndroidTargetName ??= 'build-android';
-  options.bundleTargetName ??= 'bundle';
-  options.syncDepsTargetName ??= 'sync-deps';
-  options.upgradeTargetName ??= 'upgrade';
-  return options;
+  // Do not mutate the input: the daemon passes the same options object on
+  // every invocation, and mutating it changes the option-derived hashes
+  // between the first and subsequent runs.
+  return {
+    ...options,
+    startTargetName: options?.startTargetName ?? 'start',
+    podInstallTargetName: options?.podInstallTargetName ?? 'pod-install',
+    runIosTargetName: options?.runIosTargetName ?? 'run-ios',
+    runAndroidTargetName: options?.runAndroidTargetName ?? 'run-android',
+    buildIosTargetName: options?.buildIosTargetName ?? 'build-ios',
+    buildAndroidTargetName: options?.buildAndroidTargetName ?? 'build-android',
+    bundleTargetName: options?.bundleTargetName ?? 'bundle',
+    syncDepsTargetName: options?.syncDepsTargetName ?? 'sync-deps',
+    upgradeTargetName: options?.upgradeTargetName ?? 'upgrade',
+  };
 }


### PR DESCRIPTION
## Current Behavior

`@nx/expo/plugin` and `@nx/react-native/plugin` execute every matched app config (`loadConfigFile`) on every `createNodes` invocation - including fully warm-cache runs and every daemon recompute - just to decide whether the config belongs to an Expo / React Native app. The loaded config is only used as an include/exclude predicate, never for target shape. Both plugins also mutate the user-provided options object, which changes the option-derived cache hashes between the daemon's first and subsequent recomputes and forces a full cache miss.

## Expected Behavior

The include/exclude decision is cached per (project hash, config file), with a key computable without executing configs (project files + lockfile + options) - but only when the decision derives from inputs covered by that key:

- `app.json` content (pure data, cannot import or execute anything),
- sibling-file existence (`package.json` / `metro.config.js` checks),
- an `expo` dependency in the project's own `package.json`, which pins the decision regardless of what the config exports (the `@nx/expo` application generator always writes one).

A decision resting on **executing** an `app.config.js`/`app.config.ts` is never cached - executed config content can depend on inputs outside the cache key (imports from other projects, fs reads, env vars) - so those configs are re-evaluated on every run, exactly as today, while their targets (which are static) are still cached. Load errors are not cached and resurface on every run. `normalizeOptions` no longer mutates the daemon-held options object.

## Benchmarks

Fabricated workspaces, invoking the plugins' `createNodesV2` function directly (no daemon).

**Setup**

- 300 apps per fixture, each with an app config, `package.json` (expo or react-native dependency), `metro.config.js`, `project.json`, and source files.
- Four fixtures: expo with the canonical nx-generated `app.json`; expo with an `app.config.ts` that imports a local helper module (dynamic-config shape, expo dep in the app's `package.json` as generated); react-native with `app.json`; and expo with the same `app.config.ts` but no expo dep in the app's `package.json` - the only shape whose decision cannot be soundly cached.
- Node v24.15.0, Apple M2 Max. 8 interleaved before/after passes; medians (warm rows aggregate 48 samples per cell). `loads` = app config modules actually executed during the call, counted via the require cache.

**Scenarios**

- cold: empty plugin cache (first ever run)
- warm recompute: repeated invocation in the same process with no file changes - what the daemon does on every recomputation
- one project changed: a single project source file modified between invocations
- fresh process, warm disk cache: new process with the on-disk plugin cache populated (non-daemon nx invocations, daemon restarts)

**@nx/expo - `app.json` configs**

| Scenario | Before | After | Speedup |
| --- | --- | --- | --- |
| cold | 260 ms, 300 loads | 264 ms, 300 loads | 1.0x (parity) |
| warm recompute | 140 ms, 300 loads | 95 ms, 0 loads | 1.5x |
| one project changed | 150 ms, 300 loads | 121 ms, 1 load | 1.2x |
| fresh process, warm disk cache | 203 ms, 300 loads | 144 ms, 0 loads | 1.4x |

**@nx/expo - `app.config.ts` configs (with an import, expo dep in package.json)**

| Scenario | Before | After | Speedup |
| --- | --- | --- | --- |
| cold | 1249 ms, 600 loads | 1271 ms, 600 loads | 1.0x (parity) |
| warm recompute | 232 ms, 600 loads | 89 ms, 0 loads | 2.6x |
| one project changed | 242 ms, 600 loads | 121 ms, 2 loads | 2.0x |
| fresh process, warm disk cache | 490 ms, 600 loads | 146 ms, 0 loads | 3.4x |

**@nx/react-native - `app.json` configs**

| Scenario | Before | After | Speedup |
| --- | --- | --- | --- |
| cold | 237 ms, 300 loads | 230 ms, 300 loads | 1.0x (parity) |
| warm recompute | 135 ms, 300 loads | 85 ms, 0 loads | 1.6x |
| one project changed | 147 ms, 300 loads | 119 ms, 1 load | 1.2x |
| fresh process, warm disk cache | 194 ms, 300 loads | 145 ms, 0 loads | 1.3x |

**@nx/expo - `app.config.ts` configs without an expo dep (decision not cacheable)**

| Scenario | Before | After | Ratio |
| --- | --- | --- | --- |
| cold | 1388 ms, 600 loads | 1380 ms, 600 loads | 1.0x (parity) |
| warm recompute | 232 ms, 600 loads | 229 ms, 600 loads | 1.0x (parity) |
| one project changed | 241 ms, 600 loads | 260 ms, 600 loads | 0.9x |
| fresh process, warm disk cache | 546 ms, 600 loads | 533 ms, 600 loads | 1.0x (parity) |

**Takeaways**

- Before executes every app config on every invocation; after executes none on a warm hit and exactly the changed project's config otherwise - for every shape whose decision is soundly cacheable (everything the nx generators produce).
- After's warm cost is flat (~85-95 ms) regardless of config weight - the remainder is shared workspace hashing + cache serialization. Before's cost grows with config weight (140 ms for `app.json` -> 232 ms for `app.config.ts` with a single helper import), so heavier real-world dynamic configs widen the gap further.
- Cold path is at parity: the decision bookkeeping adds no measurable cost when everything must load anyway.
- The non-cacheable shape (js/ts config whose project does not declare expo) keeps master behavior and cost across all scenarios.

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/improve-react-native-warm-cache-perf-fc70c5d9)
<!-- polygraph-session-end -->


