### PR TITLE
fix(repo): set workspace-plugin type to module to silence Node strip-types warning

### DIFF
--- a/tools/workspace-plugin/package.json
+++ b/tools/workspace-plugin/package.json
@@ -14,7 +14,7 @@
     "tinyglobby": "catalog:",
     "tslib": "catalog:typescript"
   },
-  "type": "commonjs",
+  "type": "module",
   "main": "./src/index.js",
   "typings": "./src/index.d.ts",
   "devDependencies": {}


### PR DESCRIPTION
## Current Behavior

Running any `nx` command in this repo prints a warning on Node versions with native TypeScript stripping:

```
Warning: Failed to load the ES module:
.../tools/workspace-plugin/src/plugins/copy-assets-plugin.ts.
Make sure to set "type": "module" in the nearest package.json file or use the .mjs extension.
```

The `copy-assets` plugin is registered in `nx.json` as a source `.ts` file and is authored in ESM (`import`/`export`). The nearest `package.json` (`tools/workspace-plugin/package.json`) declares `"type": "commonjs"`, so Node classifies the file as CommonJS, hits the ESM syntax, emits the warning, and fails the native load. Nx then recovers via its swc fallback — so the plugin still works, but the warning is printed as noise on every command.

## Expected Behavior

No warning. `tools/workspace-plugin` is `private` (never published) and its sources are authored in ESM, so declaring `"type": "module"` is accurate and lets Node load the plugin without the spurious CommonJS-parse warning.

Verified with `"type": "module"`:

- `nx show projects --affected` — exit 0, **0 warnings**, project graph builds
- `nx build workspace-plugin` — passes
- `nx test workspace-plugin` — 38/38 pass
- `nx lint workspace-plugin` — passes
- `nx conformance` — all 7 rules pass, no violations

## Related Issue(s)

N/A — internal developer-experience fix (no linked issue).
