### PR TITLE
feat(devkit)!: deprecate the standalone parameter of addProjectConfiguration

### DIFF
--- a/packages/angular/src/generators/ng-add/migrators/projects/e2e.migrator.ts
+++ b/packages/angular/src/generators/ng-add/migrators/projects/e2e.migrator.ts
@@ -288,14 +288,9 @@ export class E2eMigrator extends ProjectMigrator<SupportedTargets> {
     });
 
     // add e2e project config
-    addProjectConfiguration(
-      this.tree,
-      this.project.name,
-      {
-        ...this.projectConfig,
-      },
-      true
-    );
+    addProjectConfiguration(this.tree, this.project.name, {
+      ...this.projectConfig,
+    });
 
     if (this.isProjectUsingEsLint) {
       await lintProjectGenerator(this.tree, {

--- a/packages/expo/src/generators/application/lib/add-project.ts
+++ b/packages/expo/src/generators/application/lib/add-project.ts
@@ -54,12 +54,7 @@ export function addProject(host: Tree, options: NormalizedSchema) {
       packageJson.nx.tags = options.parsedTags;
     }
   } else {
-    addProjectConfiguration(
-      host,
-      options.projectName,
-      projectConfiguration,
-      options.standaloneConfig
-    );
+    addProjectConfiguration(host, options.projectName, projectConfiguration);
   }
 
   if (!options.useProjectJson || options.isTsSolutionSetup) {

--- a/packages/expo/src/generators/application/schema.d.ts
+++ b/packages/expo/src/generators/application/schema.d.ts
@@ -13,7 +13,6 @@ export interface Schema {
   linter: Linter | LinterType; // default is eslint
   setParserOptionsProject?: boolean; // default is false
   e2eTestRunner: 'cypress' | 'playwright' | 'detox' | 'none'; // default is none
-  standaloneConfig?: boolean;
   skipPackageJson?: boolean; // default is false
   // Internal options
   addPlugin?: boolean;

--- a/packages/expo/src/generators/application/schema.json
+++ b/packages/expo/src/generators/application/schema.json
@@ -78,12 +78,6 @@
       "default": "none",
       "x-priority": "important"
     },
-    "standaloneConfig": {
-      "description": "Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.",
-      "type": "boolean",
-      "default": true,
-      "x-deprecated": "Nx only supports standaloneConfig"
-    },
     "skipPackageJson": {
       "type": "boolean",
       "description": "Do not add dependencies to `package.json`.",

--- a/packages/express/src/generators/application/schema.d.ts
+++ b/packages/express/src/generators/application/schema.d.ts
@@ -14,7 +14,6 @@ export interface Schema {
   /** @deprecated use `swcJest` instead */
   babelJest?: boolean;
   js: boolean;
-  standaloneConfig?: boolean;
   setParserOptionsProject?: boolean;
   addPlugin?: boolean;
   useProjectJson?: boolean;

--- a/packages/nest/src/generators/application/lib/normalize-options.ts
+++ b/packages/nest/src/generators/application/lib/normalize-options.ts
@@ -49,7 +49,6 @@ export function toNodeApplicationGeneratorOptions(
     linter: options.linter,
     skipFormat: true,
     skipPackageJson: options.skipPackageJson,
-    standaloneConfig: options.standaloneConfig,
     tags: options.tags,
     unitTestRunner: options.unitTestRunner,
     e2eTestRunner: options.e2eTestRunner,

--- a/packages/nest/src/generators/application/schema.d.ts
+++ b/packages/nest/src/generators/application/schema.d.ts
@@ -7,7 +7,6 @@ export interface ApplicationGeneratorOptions {
   linter?: Linter | LinterType;
   skipFormat?: boolean;
   skipPackageJson?: boolean;
-  standaloneConfig?: boolean;
   tags?: string;
   unitTestRunner?: 'jest' | 'none';
   e2eTestRunner?: 'jest' | 'none';

--- a/packages/nest/src/generators/application/schema.json
+++ b/packages/nest/src/generators/application/schema.json
@@ -63,12 +63,6 @@
       "type": "string",
       "x-priority": "important"
     },
-    "standaloneConfig": {
-      "description": "Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.",
-      "type": "boolean",
-      "default": true,
-      "x-deprecated": "Nx only supports standaloneConfig"
-    },
     "setParserOptionsProject": {
       "type": "boolean",
       "description": "Whether or not to configure the ESLint `parserOptions.project` option. We do not do this by default for lint performance reasons.",

--- a/packages/node/src/generators/application/lib/create-project.ts
+++ b/packages/node/src/generators/application/lib/create-project.ts
@@ -68,12 +68,7 @@ export function addProject(
       tags: project.tags?.length ? project.tags : undefined,
     };
   } else {
-    addProjectConfiguration(
-      tree,
-      options.name,
-      project,
-      options.standaloneConfig
-    );
+    addProjectConfiguration(tree, options.name, project);
   }
 
   if (!options.useProjectJson || options.isUsingTsSolutionConfig) {

--- a/packages/node/src/generators/application/schema.d.ts
+++ b/packages/node/src/generators/application/schema.d.ts
@@ -16,7 +16,6 @@ export interface Schema {
   babelJest?: boolean;
   js?: boolean;
   setParserOptionsProject?: boolean;
-  standaloneConfig?: boolean;
   bundler?: 'esbuild' | 'webpack';
   framework?: NodeJsFrameWorks;
   port?: number;

--- a/packages/node/src/generators/application/schema.json
+++ b/packages/node/src/generators/application/schema.json
@@ -87,12 +87,6 @@
       "description": "Whether or not to configure the ESLint `parserOptions.project` option. We do not do this by default for lint performance reasons.",
       "default": false
     },
-    "standaloneConfig": {
-      "description": "Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.",
-      "type": "boolean",
-      "default": true,
-      "x-deprecated": "Nx only supports standaloneConfig"
-    },
     "bundler": {
       "description": "Bundler which is used to package the application",
       "type": "string",

--- a/packages/node/src/generators/library/schema.d.ts
+++ b/packages/node/src/generators/library/schema.d.ts
@@ -17,7 +17,6 @@ export interface Schema {
   babelJest?: boolean;
   js?: boolean;
   strict?: boolean;
-  standaloneConfig?: boolean;
   setParserOptionsProject?: boolean;
   compiler: 'tsc' | 'swc';
   addPlugin?: boolean;

--- a/packages/node/src/generators/library/schema.json
+++ b/packages/node/src/generators/library/schema.json
@@ -113,12 +113,6 @@
       "description": "Whether to enable tsconfig strict mode or not.",
       "default": false
     },
-    "standaloneConfig": {
-      "description": "Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.",
-      "type": "boolean",
-      "default": true,
-      "x-deprecated": "Nx only supports standaloneConfig"
-    },
     "setParserOptionsProject": {
       "type": "boolean",
       "description": "Whether or not to configure the ESLint `parserOptions.project`. We do not do this by default for lint performance reasons.",

--- a/packages/nx/src/generators/utils/project-configuration.ts
+++ b/packages/nx/src/generators/utils/project-configuration.ts
@@ -30,8 +30,27 @@ export { readNxJson, updateNxJson } from './nx-json';
  * @param tree - the file system tree
  * @param projectName - unique name. Often directories are part of the name (e.g., mydir-mylib)
  * @param projectConfiguration - project configuration
- * @param standalone - whether the project is configured in workspace.json or not
  */
+export function addProjectConfiguration(
+  tree: Tree,
+  projectName: string,
+  projectConfiguration: ProjectConfiguration
+): void;
+/**
+ * Adds project configuration to the Nx workspace.
+ *
+ * @param tree - the file system tree
+ * @param projectName - unique name. Often directories are part of the name (e.g., mydir-mylib)
+ * @param projectConfiguration - project configuration
+ * @param standalone - whether the project is configured in workspace.json or not
+ * @deprecated Nx only supports standalone projects. The `standalone` parameter is ignored and will be removed in a future version. Use the 3-argument overload instead.
+ */
+export function addProjectConfiguration(
+  tree: Tree,
+  projectName: string,
+  projectConfiguration: ProjectConfiguration,
+  standalone: boolean
+): void;
 export function addProjectConfiguration(
   tree: Tree,
   projectName: string,

--- a/packages/plugin/src/generators/plugin/schema.json
+++ b/packages/plugin/src/generators/plugin/schema.json
@@ -75,12 +75,6 @@
       "type": "string",
       "description": "A directory where the plugin E2E project is placed."
     },
-    "standaloneConfig": {
-      "description": "Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.",
-      "type": "boolean",
-      "default": true,
-      "x-deprecated": "Nx only supports standaloneConfig"
-    },
     "setParserOptionsProject": {
       "type": "boolean",
       "description": "Whether or not to configure the ESLint `parserOptions.project` option. We do not do this by default for lint performance reasons.",

--- a/packages/storybook/src/generators/configuration/configuration.spec.ts
+++ b/packages/storybook/src/generators/configuration/configuration.spec.ts
@@ -73,7 +73,6 @@ describe('@nx/storybook:configuration', () => {
 
         await configurationGenerator(tree, {
           project: 'test-ui-lib',
-          standaloneConfig: false,
           uiFramework: '@storybook/angular',
           addPlugin: true,
         });
@@ -431,7 +430,6 @@ describe('@nx/storybook:configuration', () => {
       it('should generate TypeScript Configuration files by default', async () => {
         await configurationGenerator(tree, {
           project: 'test-ui-lib',
-          standaloneConfig: false,
           uiFramework: '@storybook/angular',
           addPlugin: true,
         });
@@ -446,7 +444,6 @@ describe('@nx/storybook:configuration', () => {
       it('should update `tsconfig.lib.json` file', async () => {
         await configurationGenerator(tree, {
           project: 'test-ui-lib',
-          standaloneConfig: false,
           uiFramework: '@storybook/react-webpack5',
           addPlugin: true,
         });
@@ -464,7 +461,6 @@ describe('@nx/storybook:configuration', () => {
       it('should update `tsconfig.json` file', async () => {
         await configurationGenerator(tree, {
           project: 'test-ui-lib',
-          standaloneConfig: false,
           uiFramework: '@storybook/react-webpack5',
         });
         const tsconfigJson = readJson<TsConfig>(
@@ -503,7 +499,6 @@ describe('@nx/storybook:configuration', () => {
 
         await configurationGenerator(tree, {
           project: 'test-ui-lib2',
-          standaloneConfig: false,
           uiFramework: '@storybook/react-webpack5',
           addPlugin: true,
         });
@@ -527,7 +522,6 @@ describe('@nx/storybook:configuration', () => {
 
         await configurationGenerator(tree, {
           project: 'test-ui-lib2',
-          standaloneConfig: false,
           uiFramework: '@storybook/react-webpack5',
           addPlugin: true,
         });
@@ -544,7 +538,6 @@ describe('@nx/storybook:configuration', () => {
       it('should generate TS config for project by default', async () => {
         await configurationGenerator(tree, {
           project: 'test-ui-lib',
-          standaloneConfig: false,
           uiFramework: '@storybook/angular',
           addPlugin: true,
         });
@@ -829,7 +822,6 @@ describe('@nx/storybook:configuration', () => {
 
         await configurationGenerator(tree, {
           project: '@proj/mylib',
-          standaloneConfig: false,
           uiFramework: '@storybook/react-vite',
           addPlugin: true,
         });
@@ -946,7 +938,6 @@ describe('@nx/storybook:configuration', () => {
 
         await configurationGenerator(tree, {
           project: 'test-ui-lib',
-          standaloneConfig: false,
           uiFramework: '@storybook/angular',
           addPlugin: true,
         });
@@ -1304,7 +1295,6 @@ describe('@nx/storybook:configuration', () => {
       it('should generate TypeScript Configuration files by default', async () => {
         await configurationGenerator(tree, {
           project: 'test-ui-lib',
-          standaloneConfig: false,
           uiFramework: '@storybook/angular',
           addPlugin: true,
         });
@@ -1319,7 +1309,6 @@ describe('@nx/storybook:configuration', () => {
       it('should update `tsconfig.lib.json` file', async () => {
         await configurationGenerator(tree, {
           project: 'test-ui-lib',
-          standaloneConfig: false,
           uiFramework: '@storybook/react-webpack5',
           addPlugin: true,
         });
@@ -1337,7 +1326,6 @@ describe('@nx/storybook:configuration', () => {
       it('should update `tsconfig.json` file', async () => {
         await configurationGenerator(tree, {
           project: 'test-ui-lib',
-          standaloneConfig: false,
           uiFramework: '@storybook/react-webpack5',
         });
         const tsconfigJson = readJson<TsConfig>(
@@ -1376,7 +1364,6 @@ describe('@nx/storybook:configuration', () => {
 
         await configurationGenerator(tree, {
           project: 'test-ui-lib2',
-          standaloneConfig: false,
           uiFramework: '@storybook/react-webpack5',
           addPlugin: true,
         });
@@ -1400,7 +1387,6 @@ describe('@nx/storybook:configuration', () => {
 
         await configurationGenerator(tree, {
           project: 'test-ui-lib2',
-          standaloneConfig: false,
           uiFramework: '@storybook/react-webpack5',
           addPlugin: true,
         });
@@ -1417,7 +1403,6 @@ describe('@nx/storybook:configuration', () => {
       it('should generate TS config for project by default', async () => {
         await configurationGenerator(tree, {
           project: 'test-ui-lib',
-          standaloneConfig: false,
           uiFramework: '@storybook/angular',
           addPlugin: true,
         });
@@ -1702,7 +1687,6 @@ describe('@nx/storybook:configuration', () => {
 
         await configurationGenerator(tree, {
           project: '@proj/mylib',
-          standaloneConfig: false,
           uiFramework: '@storybook/react-vite',
           addPlugin: true,
         });

--- a/packages/storybook/src/generators/configuration/schema.d.ts
+++ b/packages/storybook/src/generators/configuration/schema.d.ts
@@ -8,7 +8,6 @@ export interface StorybookConfigureSchema {
   js?: boolean;
   interactionTests?: boolean;
   tsConfiguration?: boolean;
-  standaloneConfig?: boolean;
   configureStaticServe?: boolean;
   skipFormat?: boolean;
   addPlugin?: boolean;

--- a/packages/storybook/src/generators/configuration/schema.json
+++ b/packages/storybook/src/generators/configuration/schema.json
@@ -42,12 +42,6 @@
       "default": true,
       "x-priority": "important"
     },
-    "standaloneConfig": {
-      "description": "Split the project configuration into `<projectRoot>/project.json` rather than including it inside `workspace.json`.",
-      "type": "boolean",
-      "default": true,
-      "x-deprecated": "Nx only supports standaloneConfig"
-    },
     "configureStaticServe": {
       "type": "boolean",
       "description": "Add a static-storybook to serve the static storybook built files.",

--- a/packages/workspace/src/generators/preset/preset.ts
+++ b/packages/workspace/src/generators/preset/preset.ts
@@ -335,7 +335,6 @@ async function createPreset(tree: Tree, options: Schema) {
       name: options.workspaces ? undefined : options.name,
       directory: '.',
       linter: options.linter,
-      standaloneConfig: options.standaloneConfig,
       framework: options.framework,
       docker: options.docker,
       rootProject: true,

--- a/packages/workspace/src/generators/preset/schema.d.ts
+++ b/packages/workspace/src/generators/preset/schema.d.ts
@@ -8,7 +8,6 @@ export interface Schema {
   linter?: string;
   formatter?: string;
   workspaces?: boolean;
-  standaloneConfig?: boolean;
   framework?: string;
   packageManager?: string;
   bundler?: string;

--- a/packages/workspace/src/generators/preset/schema.json
+++ b/packages/workspace/src/generators/preset/schema.json
@@ -54,12 +54,6 @@
       "type": "boolean",
       "default": false
     },
-    "standaloneConfig": {
-      "description": "Split the project configurations into `<projectRoot>/project.json` rather than including it inside `workspace.json`.",
-      "type": "boolean",
-      "default": true,
-      "x-deprecated": "Nx only supports standaloneConfig"
-    },
     "packageManager": {
       "description": "The package manager used to install dependencies.",
       "type": "string"


### PR DESCRIPTION
## Current Behavior

`addProjectConfiguration` exposes a 4th `standalone` parameter (defaulting to `true`). Nx only supports standalone projects, so any value other than `true` is ignored — passing `standalone: false` simply prints a warning and otherwise has no effect. Despite being a no-op, the parameter is still part of the public signature, and a number of first-party generators expose a matching `standaloneConfig` schema option whose only job is to feed this dead parameter.

## Expected Behavior

`addProjectConfiguration` now presents two TypeScript overloads:

- a clean 3-argument signature (`tree`, `projectName`, `projectConfiguration`), and
- a `@deprecated` 4-argument signature that still accepts `standalone` for backwards compatibility (the runtime behavior is unchanged — it continues to warn when set to `false`).

Existing callers keep compiling, but new ones are steered onto the 3-argument form and editors surface a deprecation strikethrough on the old one.

The vestigial `standaloneConfig` option has been removed from the affected generator schemas (`schema.json` + `schema.d.ts`) across `expo`, `node` (application + library), `nest`, `storybook`, `workspace` preset, `plugin`, and `express`, since it only ever populated the ignored parameter. The remaining internal 4-argument call sites (`expo`, `node`, and the `angular` ng-add e2e migrator) were reduced to the 3-argument overload, the `nest`/`workspace` passthroughs were cleaned up, and the storybook generator specs no longer pass `standaloneConfig`.

Verified locally: `lint` passes for the 9 touched projects, `build` (typecheck) passes for `nx`, `node`, `expo`, `nest`, and `workspace`, and the storybook `configuration` spec passes.

## Related Issue(s)

N/A