### PR TITLE
fix(core): respect --no-interactive across all nx migrate prompts

### DIFF
--- a/packages/nx/src/command-line/migrate/agentic/select.spec.ts
+++ b/packages/nx/src/command-line/migrate/agentic/select.spec.ts
@@ -515,4 +515,36 @@ describe('resolveAgentic', () => {
     expect(result.kind).toBe('disabled');
     expect(mockPrompt).not.toHaveBeenCalled();
   });
+
+  it.each([
+    ['--agentic=true', true],
+    ['--agentic=<id>', 'claude-code'],
+  ])(
+    'warns and runs without the agentic flow when %s is combined with --no-interactive in a TTY',
+    async (_label, agentic) => {
+      mockDetect.mockResolvedValue([detected('claude-code')]);
+      const result = await resolveAgentic({
+        agentic,
+        migrations: [{ prompt: 'x.md' }],
+        interactive: false,
+      });
+      expect(result).toEqual({ kind: 'disabled' });
+      expect(mockPrompt).not.toHaveBeenCalled();
+      expect(mockOutputWarn).toHaveBeenCalled();
+      expect(mockOutputWarn.mock.calls[0][0].title).toMatch(
+        /interactive-only/i
+      );
+    }
+  );
+
+  it('skips the up-front prompt when --no-interactive is passed in a TTY', async () => {
+    mockDetect.mockResolvedValue([detected('claude-code')]);
+    const result = await resolveAgentic({
+      agentic: undefined,
+      migrations: [{ prompt: 'x.md' }],
+      interactive: false,
+    });
+    expect(result.kind).toBe('disabled');
+    expect(mockPrompt).not.toHaveBeenCalled();
+  });
 });

--- a/packages/nx/src/command-line/migrate/agentic/select.ts
+++ b/packages/nx/src/command-line/migrate/agentic/select.ts
@@ -20,6 +20,8 @@ const INSTALL_SUPPORTED_AGENTS_HINT = [
 export interface ResolveAgenticInput {
   agentic: AgenticArg;
   migrations: ReadonlyArray<{ prompt?: string }>;
+  /** The `--interactive` flag; `false` (`--no-interactive`) disables all prompting. */
+  interactive?: boolean;
 }
 
 /**
@@ -39,7 +41,10 @@ export async function resolveAgentic(
     return { kind: 'inside-agent' };
   }
 
-  const isInteractive = !!process.stdin.isTTY && !!process.stdout.isTTY;
+  const isInteractive =
+    !!process.stdin.isTTY &&
+    !!process.stdout.isTTY &&
+    input.interactive !== false;
 
   // Skip detection for the one case where the result is unused: explicit
   // `--agentic=false`. For every other path (explicit enable, explicit id, or
@@ -134,7 +139,7 @@ function requireInteractiveOrAbort(isInteractive: boolean): void {
 function warnAgenticInteractiveOnly(): void {
   output.warn({
     title:
-      'Skipping the agentic flow: it is interactive-only in this release and this is a non-interactive terminal.',
+      'Skipping the agentic flow: it is interactive-only in this release and this run is non-interactive.',
     bodyLines: [
       'Continuing the migration without the agentic flow. Re-run in an interactive terminal to use it.',
     ],

--- a/packages/nx/src/command-line/migrate/migrate.spec.ts
+++ b/packages/nx/src/command-line/migrate/migrate.spec.ts
@@ -2104,6 +2104,18 @@ describe('Migration', () => {
       });
     });
 
+    it('should propagate the interactive value when running migrations', async () => {
+      const r = await parseMigrationsOptions({
+        runMigrations: '',
+        ifExists: true,
+        interactive: false,
+      });
+      expect(r).toMatchObject({
+        type: 'runMigrations',
+        interactive: false,
+      });
+    });
+
     it('should default to nx@latest when no packageAndVersion is provided', async () => {
       jest
         .spyOn(packageMgrUtils, 'resolvePackageVersionUsingRegistry')
@@ -2219,7 +2231,7 @@ describe('Migration', () => {
           interactive: true,
         })
       ).rejects.toThrow(
-        `Error: '--interactive' is not supported when migrating to Nx v23 or later. Use '--mode' to choose which packages to migrate.`
+        `Error: '--interactive' is not supported when migrating to Nx v23 or later. Use '--mode' to choose which packages to migrate: 'first-party' migrates only Nx and its plugins, 'third-party' migrates only the third-party dependencies referenced by Nx, 'all' migrates everything.`
       );
     });
 
@@ -2231,7 +2243,7 @@ describe('Migration', () => {
       await expect(() =>
         parseMigrationsOptions({ interactive: true })
       ).rejects.toThrow(
-        `Error: '--interactive' is not supported when migrating to Nx v23 or later. Use '--mode' to choose which packages to migrate.`
+        `Error: '--interactive' is not supported when migrating to Nx v23 or later. Use '--mode' to choose which packages to migrate: 'first-party' migrates only Nx and its plugins, 'third-party' migrates only the third-party dependencies referenced by Nx, 'all' migrates everything.`
       );
     });
 
@@ -2243,7 +2255,7 @@ describe('Migration', () => {
       await expect(() =>
         parseMigrationsOptions({ interactive: true })
       ).rejects.toThrow(
-        `Error: '--interactive' is not supported when migrating to Nx v23 or later. Use '--mode' to choose which packages to migrate.`
+        `Error: '--interactive' is not supported when migrating to Nx v23 or later. Use '--mode' to choose which packages to migrate: 'first-party' migrates only Nx and its plugins, 'third-party' migrates only the third-party dependencies referenced by Nx, 'all' migrates everything.`
       );
     });
 
@@ -2256,7 +2268,7 @@ describe('Migration', () => {
           interactive: true,
         })
       ).rejects.toThrow(
-        `Error: '--interactive' is not supported when migrating to Nx v23 or later. Use '--mode' to choose which packages to migrate.`
+        `Error: '--interactive' is not supported when migrating to Nx v23 or later. Use '--mode' to choose which packages to migrate: 'first-party' migrates only Nx and its plugins, 'third-party' migrates only the third-party dependencies referenced by Nx, 'all' migrates everything.`
       );
     });
 
@@ -2290,7 +2302,7 @@ describe('Migration', () => {
           interactive: true,
         })
       ).rejects.toThrow(
-        `Error: '--interactive' is not supported when migrating to Nx v23 or later. Use '--mode' to choose which packages to migrate.`
+        `Error: '--interactive' is not supported when migrating to Nx v23 or later. Use '--mode' to choose which packages to migrate: 'first-party' migrates only Nx and its plugins, 'third-party' migrates only the third-party dependencies referenced by Nx, 'all' migrates everything.`
       );
     });
 
@@ -2994,6 +3006,20 @@ describe('Migration', () => {
       expect(mockPrompt).not.toHaveBeenCalled();
     });
 
+    it('should default to "all" without prompting when --no-interactive is passed in a TTY', async () => {
+      Object.defineProperty(process.stdin, 'isTTY', {
+        value: true,
+        configurable: true,
+      });
+      process.env.CI = 'false';
+      const result = await resolveMode(undefined, 'nx', '23.0.0', {
+        ...v23Context,
+        interactive: false,
+      });
+      expect(result).toBe('all');
+      expect(mockPrompt).not.toHaveBeenCalled();
+    });
+
     it('should default to "all" without prompting for non-nx-equivalent target', async () => {
       Object.defineProperty(process.stdin, 'isTTY', {
         value: true,
@@ -3121,7 +3147,7 @@ describe('Migration', () => {
           interactive: true,
         })
       ).rejects.toThrow(
-        `Error: '--interactive' is not supported when migrating to Nx v23 or later. Use '--mode' to choose which packages to migrate.`
+        `Error: '--interactive' is not supported when migrating to Nx v23 or later. Use '--mode' to choose which packages to migrate: 'first-party' migrates only Nx and its plugins, 'third-party' migrates only the third-party dependencies referenced by Nx, 'all' migrates everything.`
       );
     });
 
@@ -3132,7 +3158,7 @@ describe('Migration', () => {
           interactive: true,
         })
       ).rejects.toThrow(
-        `Error: '--interactive' is not supported when migrating to Nx v23 or later. Use '--mode' to choose which packages to migrate.`
+        `Error: '--interactive' is not supported when migrating to Nx v23 or later. Use '--mode' to choose which packages to migrate: 'first-party' migrates only Nx and its plugins, 'third-party' migrates only the third-party dependencies referenced by Nx, 'all' migrates everything.`
       );
     });
 
@@ -3747,6 +3773,22 @@ describe('Migration', () => {
       const r = await parseMigrationsOptions({
         packageAndVersion: 'latest',
         mode: 'all',
+      });
+
+      expect(mockPrompt).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalled();
+      expect(r).toMatchObject({ targetVersion: '23.1.0' });
+    });
+
+    it('should warn (not prompt) when --no-interactive is passed in a TTY', async () => {
+      setTty(true);
+      mockRegistry({ latest: '23.1.0' });
+      const warnSpy = spyWarn();
+
+      const r = await parseMigrationsOptions({
+        packageAndVersion: 'latest',
+        mode: 'all',
+        interactive: false,
       });
 
       expect(mockPrompt).not.toHaveBeenCalled();

--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -1,6 +1,6 @@
 import * as pc from 'picocolors';
 import { exec, execSync, spawn, type StdioOptions } from 'child_process';
-import { migratePrompt } from './safe-prompt';
+import { canPrompt, migratePrompt } from './safe-prompt';
 import { handleImport } from '../../utils/handle-import';
 import { dirname, join, relative } from 'path';
 import { createRequire } from 'module';
@@ -981,7 +981,7 @@ export async function resolveMode(
     isNxEquivalentTarget(targetPackage, targetVersion)
   ) {
     throw new Error(
-      `Error: '--interactive' is not supported when migrating to Nx v23 or later. Use '--mode' to choose which packages to migrate.`
+      `Error: '--interactive' is not supported when migrating to Nx v23 or later. Use '--mode' to choose which packages to migrate: 'first-party' migrates only Nx and its plugins, 'third-party' migrates only the third-party dependencies referenced by Nx, 'all' migrates everything.`
     );
   }
 
@@ -1054,7 +1054,7 @@ export async function resolveMode(
   if (!choices.length) {
     return 'all';
   }
-  if (!process.stdin.isTTY || isCI()) {
+  if (!canPrompt(context.interactive)) {
     return 'all';
   }
   choices.push({
@@ -1175,6 +1175,7 @@ type RunMigrations = {
   ifExists: boolean;
   agentic: AgenticArg;
   validate?: boolean;
+  interactive?: boolean;
 };
 
 export async function parseMigrationsOptions(options: {
@@ -1202,6 +1203,7 @@ export async function parseMigrationsOptions(options: {
       ifExists: options.ifExists as boolean,
       agentic: options.agentic as AgenticArg,
       validate: options.validate as boolean | undefined,
+      interactive: options.interactive as boolean | undefined,
     };
   }
 
@@ -3201,6 +3203,7 @@ async function runMigrations(
     ifExists: boolean;
     agentic: AgenticArg;
     validate?: boolean;
+    interactive?: boolean;
   },
   args: string[],
   isVerbose: boolean,
@@ -3253,6 +3256,7 @@ async function runMigrations(
   const agentic = await resolveAgentic({
     agentic: opts.agentic,
     migrations,
+    interactive: opts.interactive,
   });
 
   const {

--- a/packages/nx/src/command-line/migrate/multi-major.ts
+++ b/packages/nx/src/command-line/migrate/multi-major.ts
@@ -1,6 +1,5 @@
-import { migratePrompt } from './safe-prompt';
+import { canPrompt, migratePrompt } from './safe-prompt';
 import { gt, major, minor, valid } from 'semver';
-import { isCI } from '../../utils/is-ci';
 import { getInstalledNxVersion } from '../../utils/installed-nx-version';
 import { output } from '../../utils/output';
 import { resolvePackageVersionUsingRegistry } from '../../utils/package-manager';
@@ -164,7 +163,7 @@ export type MultiMajorResult = {
 
 export async function maybePromptOrWarnMultiMajorMigration(args: {
   mode: MigrateMode;
-  options: { multiMajorMode?: MultiMajorMode };
+  options: { multiMajorMode?: MultiMajorMode; interactive?: boolean };
   targetPackage: string;
   targetVersion: string;
 }): Promise<MultiMajorResult> {
@@ -210,9 +209,10 @@ export async function maybePromptOrWarnMultiMajorMigration(args: {
     return { chosen: targetVersion };
   }
 
-  const interactive = !!process.stdin.isTTY && !isCI();
-  // Non-TTY without gradual opt-in stays on the warn-only path; avoid the
-  // registry round-trip used to look up incremental migration options.
+  const interactive = canPrompt(options.interactive);
+  // Non-interactive (non-TTY, CI, or --no-interactive) without gradual opt-in
+  // stays on the warn-only path; avoid the registry round-trip used to look
+  // up incremental migration options.
   if (!interactive && multiMajorMode !== 'gradual') {
     warnMultiMajorMigration(targetPackage, installed, targetVersion);
     return { chosen: targetVersion };

--- a/packages/nx/src/command-line/migrate/safe-prompt.ts
+++ b/packages/nx/src/command-line/migrate/safe-prompt.ts
@@ -1,5 +1,14 @@
 import { prompt as enquirerPrompt } from 'enquirer';
+import { isCI } from '../../utils/is-ci';
 import { output } from '../../utils/output';
+
+/**
+ * Whether `nx migrate` may show interactive prompts: requires a TTY on stdin,
+ * not running in CI, and the user not having passed `--no-interactive`.
+ */
+export function canPrompt(interactive: boolean | undefined): boolean {
+  return !!process.stdin.isTTY && !isCI() && interactive !== false;
+}
 
 /**
  * Drop-in replacement for enquirer's `prompt()` that hardens cancel


### PR DESCRIPTION
## Current Behavior

`nx migrate` shows interactive prompts even when `--no-interactive` is passed: the mode selection prompt ("Which packages would you like to migrate?"), the multi-major migration prompt, and the agentic flow prompts in `--run-migrations` only check for a TTY and CI.

## Expected Behavior

`--no-interactive` suppresses all prompting: the mode prompt silently defaults to `all`, the multi-major check falls back to the warn-only path, and the agentic flow is skipped (with a warning when it was explicitly requested).

## Related Issue(s)

Fixes NXC-4513

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/fix-nx-migrate-no-interactive-23fbc4b0)
<!-- polygraph-session-end -->