### PR TITLE
fix(misc): publish migration prompt files and report the real migrate fetch error

### DIFF
--- a/packages/next/assets.json
+++ b/packages/next/assets.json
@@ -6,6 +6,7 @@
     { "glob": "@(package|executors|generators|migrations).json" },
     { "glob": "src/**/schema.json" },
     { "glob": "src/**/schema.d.ts" },
+    { "glob": "src/migrations/**/*.md" },
     { "glob": "typings/**/*.d.ts" },
     "LICENSE"
   ]

--- a/packages/nuxt/assets.json
+++ b/packages/nuxt/assets.json
@@ -6,6 +6,7 @@
     { "glob": "@(package|executors|generators|migrations).json" },
     { "glob": "src/**/schema.json" },
     { "glob": "src/**/schema.d.ts" },
+    { "glob": "src/migrations/**/*.md" },
     "LICENSE"
   ]
 }

--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -1833,13 +1833,22 @@ async function getPackageMigrationsUsingInstallImpl(
   }
 
   try {
-    await execAsync(`${pmc.add} ${packageName}@${packageVersion}`, {
-      cwd: dir,
-      env: {
-        ...process.env,
-        npm_config_legacy_peer_deps: 'true',
-      },
-    });
+    const addCommand = `${pmc.add} ${packageName}@${packageVersion}`;
+    try {
+      await execAsync(addCommand, {
+        cwd: dir,
+        env: {
+          ...process.env,
+          npm_config_legacy_peer_deps: 'true',
+        },
+      });
+    } catch (e) {
+      // Only the install command failed; format it as a command failure so the
+      // user sees the package manager's stderr. Errors from the later steps
+      // (reading/validating migrations, resolving prompt files) are surfaced
+      // as-is by the outer catch instead of being mislabeled as install failures.
+      throw new Error(formatCommandFailure(addCommand, e as CommandFailure));
+    }
 
     const {
       migrations: migrationsFilePath,
@@ -1870,10 +1879,7 @@ async function getPackageMigrationsUsingInstallImpl(
     throw new Error(
       [
         `Failed to fetch migrations for ${packageName}@${packageVersion}`,
-        formatCommandFailure(
-          `${pmc.add} ${packageName}@${packageVersion}`,
-          e as CommandFailure
-        ),
+        e instanceof Error ? e.message : String(e),
       ].join('\n')
     );
   } finally {

--- a/packages/storybook/assets.json
+++ b/packages/storybook/assets.json
@@ -6,6 +6,7 @@
     { "glob": "@(package|executors|generators|migrations).json" },
     { "glob": "src/**/schema.json" },
     { "glob": "src/**/schema.d.ts" },
+    { "glob": "src/migrations/**/*.md" },
     "LICENSE"
   ]
 }


### PR DESCRIPTION
## Current Behavior

First-party plugins can attach an AI `prompt` markdown file to a migration in `migrations.json`. `@nx/next` and `@nx/nuxt` reference prompt files under `src/migrations/**/*.md`, but their build `assets.json` only copied `migrations.json` — not the `.md` files it points at. Those prompt files were therefore **missing from the published packages**.

As a result, `nx migrate` to a version that contains such a migration fails while fetching migrations:

```
NX   Failed to fetch migrations for @nx/next@23.0.0-beta.23

Command failed: pnpm add -w @nx/next@23.0.0-beta.23
Could not find prompt file "./src/migrations/update-22-2-0/ai-instructions-for-next-16.md"
  for migration "update-22-2-0-create-ai-instructions-for-next-16" in package "@nx/next@23.0.0-beta.23".
```

The message is also misleading: the install (`pnpm add -w`) actually succeeded — the missing prompt file is the real cause. The fetch-via-install helper wrapped **every** failure (the install, reading/validating migrations, and resolving prompt files) as a `Command failed: <pm> add <pkg>` error, so non-install failures were attributed to the install command.

## Expected Behavior

- Migration prompt markdown files are now included in the published packages. Added `{ "glob": "src/migrations/**/*.md" }` to `@nx/next` and `@nx/nuxt` (the affected packages), and to `@nx/storybook` for consistency (its prompt currently ships via the existing `**/files/**` glob). `@nx/vite`, `@nx/vitest`, and `@nx/expo` already had the glob.
- `nx migrate` no longer fails to fetch migrations for these packages.
- When fetching migrations via install fails, the error reports the **actual** cause. Only genuine install failures are labeled `Command failed: <pm> add <pkg>`; errors from reading/validating migrations or resolving prompt files are surfaced as-is under `Failed to fetch migrations for <pkg>`.

### Verification

Built `@nx/next` and `@nx/nuxt` and confirmed the prompt files now land in the package output (`dist/packages/<pkg>/src/migrations/update-22-2-0/ai-instructions-*.md`). `@nx/storybook` still builds and continues to ship its prompt via `**/files/**`. Existing `formatCommandFailure` unit tests pass.

## Related Issue(s)

Found while dogfooding `nx migrate` to `23.0.0-beta.23`; no existing issue.
