### PR TITLE
feat(angular): deprecate SCAM generators

### DIFF
--- a/packages/angular/generators.json
+++ b/packages/angular/generators.json
@@ -122,22 +122,26 @@
     "scam-to-standalone": {
       "factory": "./src/generators/scam-to-standalone/scam-to-standalone",
       "schema": "./src/generators/scam-to-standalone/schema.json",
-      "description": "Convert an existing Single Component Angular Module (SCAM) to a Standalone Component."
+      "description": "Convert an existing Single Component Angular Module (SCAM) to a Standalone Component.",
+      "x-deprecated": "SCAMs are superseded by Angular standalone components. Convert any remaining SCAMs before upgrading. It will be removed in Nx v24."
     },
     "scam": {
       "factory": "./src/generators/scam/scam",
       "schema": "./src/generators/scam/schema.json",
-      "description": "Generate a component with an accompanying Single Component Angular Module (SCAM)."
+      "description": "Generate a component with an accompanying Single Component Angular Module (SCAM).",
+      "x-deprecated": "SCAMs are superseded by Angular standalone components. Use the `@nx/angular:component` generator instead. It will be removed in Nx v24."
     },
     "scam-directive": {
       "factory": "./src/generators/scam-directive/scam-directive",
       "schema": "./src/generators/scam-directive/schema.json",
-      "description": "Generate a directive with an accompanying Single Component Angular Module (SCAM)."
+      "description": "Generate a directive with an accompanying Single Component Angular Module (SCAM).",
+      "x-deprecated": "SCAMs are superseded by Angular standalone components. Use the `@nx/angular:directive` generator instead. It will be removed in Nx v24."
     },
     "scam-pipe": {
       "factory": "./src/generators/scam-pipe/scam-pipe",
       "schema": "./src/generators/scam-pipe/schema.json",
-      "description": "Generate a pipe with an accompanying Single Component Angular Module (SCAM)."
+      "description": "Generate a pipe with an accompanying Single Component Angular Module (SCAM).",
+      "x-deprecated": "SCAMs are superseded by Angular standalone components. Use the `@nx/angular:pipe` generator instead. It will be removed in Nx v24."
     },
     "setup-mf": {
       "factory": "./src/generators/setup-mf/setup-mf",

--- a/packages/angular/src/generators/scam-directive/scam-directive.ts
+++ b/packages/angular/src/generators/scam-directive/scam-directive.ts
@@ -6,6 +6,9 @@ import { exportScam } from '../utils/export-scam';
 import { convertDirectiveToScam, normalizeOptions } from './lib';
 import type { Schema } from './schema';
 
+/**
+ * @deprecated SCAMs are superseded by Angular standalone components. Use the `directiveGenerator` instead. It will be removed in Nx v24.
+ */
 export async function scamDirectiveGenerator(tree: Tree, rawOptions: Schema) {
   assertSupportedAngularVersion(tree);
   const options = await normalizeOptions(tree, rawOptions);

--- a/packages/angular/src/generators/scam-pipe/scam-pipe.ts
+++ b/packages/angular/src/generators/scam-pipe/scam-pipe.ts
@@ -6,6 +6,9 @@ import { exportScam } from '../utils/export-scam';
 import { convertPipeToScam, normalizeOptions } from './lib';
 import type { Schema } from './schema';
 
+/**
+ * @deprecated SCAMs are superseded by Angular standalone components. Use the `pipeGenerator` instead. It will be removed in Nx v24.
+ */
 export async function scamPipeGenerator(tree: Tree, rawOptions: Schema) {
   assertSupportedAngularVersion(tree);
   const options = await normalizeOptions(tree, rawOptions);

--- a/packages/angular/src/generators/scam-to-standalone/scam-to-standalone.ts
+++ b/packages/angular/src/generators/scam-to-standalone/scam-to-standalone.ts
@@ -12,6 +12,9 @@ import {
   verifyModuleIsScam,
 } from './lib';
 
+/**
+ * @deprecated SCAMs are superseded by Angular standalone components. Convert any remaining SCAMs before upgrading. It will be removed in Nx v24.
+ */
 export async function scamToStandalone(
   tree: Tree,
   { component, project: projectName, skipFormat }: Schema

--- a/packages/angular/src/generators/scam/scam.ts
+++ b/packages/angular/src/generators/scam/scam.ts
@@ -6,6 +6,9 @@ import { exportScam } from '../utils/export-scam';
 import { convertComponentToScam, normalizeOptions } from './lib';
 import type { Schema } from './schema';
 
+/**
+ * @deprecated SCAMs are superseded by Angular standalone components. Use the `componentGenerator` instead. It will be removed in Nx v24.
+ */
 export async function scamGenerator(tree: Tree, rawOptions: Schema) {
   assertSupportedAngularVersion(tree);
   const options = await normalizeOptions(tree, rawOptions);


### PR DESCRIPTION
## Current Behavior

The `@nx/angular` SCAM generators (`scam`, `scam-directive`, `scam-pipe`, `scam-to-standalone`) are not marked as deprecated, even though SCAMs are superseded by Angular standalone components.

## Expected Behavior

The four SCAM generators are marked as deprecated via `x-deprecated` in `generators.json` (reported by `nx g` and shown in `--help`) and `@deprecated` JSDoc on their programmatic entry points. The messages point to the `component`, `directive`, and `pipe` generators as replacements, and `scam-to-standalone` users are told to convert any remaining SCAMs before upgrading. They will be removed in Nx v24.

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/nxc-4512-9a06eb63)
<!-- polygraph-session-end -->