### PR TITLE
docs(misc): relink automate-updating-dependencies in sidebar

### DIFF
--- a/astro-docs/sidebar.mts
+++ b/astro-docs/sidebar.mts
@@ -299,6 +299,10 @@ const learnGroups: SidebarItems = [
         collapsed: true,
         items: [
           {
+            label: 'Automate updating dependencies',
+            link: 'features/automate-updating-dependencies',
+          },
+          {
             label: 'Nx Console migration assistance',
             link: 'guides/nx-console/console-migrate-ui',
           },


### PR DESCRIPTION
## Current Behavior

The [Automate Updating Dependencies](https://nx.dev/docs/features/automate-updating-dependencies) feature page exists as content (`astro-docs/src/content/docs/features/automate-updating-dependencies.mdoc`) but is not referenced anywhere in `sidebar.mts`. It was orphaned during the Astro docs migration: reachable by direct URL, but with no navigation entry pointing to it.

Reported on Discord: https://discord.com/channels/1143497901675401286/1143540600252153946/1512412671599841372

## Expected Behavior

The page is linked in the sidebar under the **Maintenance** section, alongside the related update/migration guides (Advanced update process, Nx Console migration assistance).

Note: the file was **not** moved or renamed, only a sidebar entry was added. The page still serves at the same URL (`/docs/features/automate-updating-dependencies`), so no redirect is needed.

## Related Issue(s)

N/A