### PR TITLE
fix(core): respect NX_PREFER_TS_NODE over native type stripping

### DIFF
--- a/packages/nx/src/plugins/js/utils/register.spec.ts
+++ b/packages/nx/src/plugins/js/utils/register.spec.ts
@@ -43,6 +43,65 @@ describe('getTsNodeCompilerOptions', () => {
   });
 });
 
+describe('isNativeStripPreferred', () => {
+  const originalEnv = { ...process.env };
+  const featuresDescriptor = Object.getOwnPropertyDescriptor(
+    process.features,
+    'typescript'
+  );
+
+  function setNativeTypescriptSupport(value: 'strip' | 'transform' | false) {
+    Object.defineProperty(process.features, 'typescript', {
+      value,
+      configurable: true,
+    });
+  }
+
+  function loadIsNativeStripPreferred(): boolean {
+    let result: boolean;
+    jest.isolateModules(() => {
+      result = require('./register').isNativeStripPreferred();
+    });
+    return result;
+  }
+
+  afterEach(() => {
+    process.env = { ...originalEnv };
+    if (featuresDescriptor) {
+      Object.defineProperty(process.features, 'typescript', featuresDescriptor);
+    } else {
+      delete (process.features as { typescript?: unknown }).typescript;
+    }
+  });
+
+  it('prefers native strip when the runtime supports it', () => {
+    setNativeTypescriptSupport('strip');
+    delete process.env.NX_PREFER_TS_NODE;
+    delete process.env.NX_PREFER_NODE_STRIP_TYPES;
+    expect(loadIsNativeStripPreferred()).toBe(true);
+  });
+
+  it('does not prefer native strip when the runtime lacks support', () => {
+    setNativeTypescriptSupport(false);
+    delete process.env.NX_PREFER_TS_NODE;
+    delete process.env.NX_PREFER_NODE_STRIP_TYPES;
+    expect(loadIsNativeStripPreferred()).toBe(false);
+  });
+
+  it('does not prefer native strip when NX_PREFER_NODE_STRIP_TYPES is false', () => {
+    setNativeTypescriptSupport('strip');
+    process.env.NX_PREFER_NODE_STRIP_TYPES = 'false';
+    expect(loadIsNativeStripPreferred()).toBe(false);
+  });
+
+  it('does not prefer native strip when NX_PREFER_TS_NODE is true', () => {
+    setNativeTypescriptSupport('strip');
+    process.env.NX_PREFER_TS_NODE = 'true';
+    delete process.env.NX_PREFER_NODE_STRIP_TYPES;
+    expect(loadIsNativeStripPreferred()).toBe(false);
+  });
+});
+
 describe('isNativeTypeStripError', () => {
   it('returns true for ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX', () => {
     const err = Object.assign(new Error('boom'), {

--- a/packages/nx/src/plugins/js/utils/register.ts
+++ b/packages/nx/src/plugins/js/utils/register.ts
@@ -361,10 +361,16 @@ const nodeSupportsNativeTypescript: boolean = !!(process as any).features
  * type stripping. `loadTsFile` catches these failures and falls back to
  * registering swc/ts-node + tsconfig-paths automatically.
  *
+ * Setting NX_PREFER_TS_NODE=true also opts out, since that flag explicitly
+ * requests ts-node for transpilation.
+ *
  * See: https://nodejs.org/api/typescript.html#full-typescript-support
  */
 const preferNodeStripTypes: boolean = (() => {
   if (!nodeSupportsNativeTypescript) {
+    return false;
+  }
+  if (process.env.NX_PREFER_TS_NODE === 'true') {
     return false;
   }
   return process.env.NX_PREFER_NODE_STRIP_TYPES !== 'false';


### PR DESCRIPTION
## Current Behavior

When the Node.js runtime supports native TypeScript type stripping (Node 22.18+ LTS, 23.6+, or 22.6–22.17 with `--experimental-strip-types`), Nx defers to native stripping and skips registering a transpiler entirely.

The `preferNodeStripTypes` gate is evaluated at module load and short-circuits *before* the swc-vs-ts-node decision, where `NX_PREFER_TS_NODE` is consulted. As a result, setting `NX_PREFER_TS_NODE=true` has **no effect** on modern Node — native stripping wins, even though the user explicitly asked for ts-node. This is a problem for workspaces using constructs native stripping can't handle the way ts-node would (e.g. relying on full type-aware transpilation rather than stripping).

## Expected Behavior

Setting `NX_PREFER_TS_NODE=true` now opts out of native type stripping, so the existing ts-node code path is used as intended. The opt-out is added to the authoritative `preferNodeStripTypes` gate, keeping `isNativeStripPreferred()` and `loadTsFile` aligned. Behavior is unchanged when the flag is unset.

Added `isNativeStripPreferred` test coverage across the runtime-support / env-flag combinations.

## Related Issue(s)

N/A