### PR TITLE
feat(core): add migrations for createNodesV2 -> createNodes rename

### DIFF
--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -312,7 +312,7 @@
       "documentation": "./src/migrations/update-23-0-0/migrate-ngrx-generator-defaults.md"
     },
     "update-23-0-0-migrate-create-nodes-v2-import": {
-      "version": "23.0.0-beta.5",
+      "version": "23.0.0-beta.24",
       "description": "Rename imports of `createNodesV2` from `@nx/angular/plugin` to the canonical `createNodes` export.",
       "implementation": "./src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
       "documentation": "./src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"

--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -310,6 +310,12 @@
       "description": "Split @nx/angular:ngrx generator defaults in nx.json across the @nx/angular:ngrx-root-store and @nx/angular:ngrx-feature-store generators.",
       "factory": "./src/migrations/update-23-0-0/migrate-ngrx-generator-defaults",
       "documentation": "./src/migrations/update-23-0-0/migrate-ngrx-generator-defaults.md"
+    },
+    "update-23-0-0-migrate-create-nodes-v2-import": {
+      "version": "23.0.0-beta.5",
+      "description": "Rename imports of `createNodesV2` from `@nx/angular/plugin` to the canonical `createNodes` export.",
+      "implementation": "./src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
+      "documentation": "./src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"
     }
   },
   "packageJsonUpdates": {

--- a/packages/angular/plugin.ts
+++ b/packages/angular/plugin.ts
@@ -1,1 +1,1 @@
-export { createNodesV2 } from './src/plugins/plugin';
+export { createNodes, createNodesV2 } from './src/plugins/plugin';

--- a/packages/angular/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md
+++ b/packages/angular/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md
@@ -1,0 +1,25 @@
+#### Rename `createNodesV2` imports to `createNodes`
+
+`@nx/angular` renamed its primary inferred-plugin export from `createNodesV2` to `createNodes`. The `createNodesV2` name is preserved as a deprecated alias for now, but new code should use `createNodes`.
+
+This migration scans every `.ts`, `.tsx`, `.cts`, and `.mts` file in your workspace and rewrites named imports and re-exports of `createNodesV2` from `@nx/angular/plugin` to `createNodes`.
+
+#### Sample Code Changes
+
+##### Before
+
+```ts
+import { createNodesV2 } from '@nx/angular/plugin';
+```
+
+##### After
+
+```ts
+import { createNodes } from '@nx/angular/plugin';
+```
+
+Aliases are preserved (`createNodesV2 as cn` becomes `createNodes as cn`), and if a file already imports both names (`{ createNodes, createNodesV2 }`) the redundant binding is dropped.
+
+#### What is not rewritten
+
+Only static `import`/`export` named bindings from `@nx/angular/plugin` are rewritten. Namespace imports, dynamic `import(...)`, `require(...)` destructuring, and property access such as `plugin.createNodesV2` are left untouched — they keep working through the `createNodesV2` runtime alias. Update those by hand if you want to drop the deprecated name everywhere.

--- a/packages/angular/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.spec.ts
+++ b/packages/angular/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.spec.ts
@@ -1,0 +1,191 @@
+import { type Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migration, {
+  rewriteCreateNodesV2Imports,
+} from './migrate-create-nodes-v2-to-create-nodes';
+
+const SPECIFIERS = new Set(['@nx/angular/plugin']);
+const rewrite = (source: string) =>
+  rewriteCreateNodesV2Imports(source, SPECIFIERS);
+
+describe('migrate-create-nodes-v2-to-create-nodes migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  describe('rewriteCreateNodesV2Imports', () => {
+    it('renames a lone createNodesV2 named import', () => {
+      const input = `import { createNodesV2 } from '@nx/angular/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/angular/plugin';\n`
+      );
+    });
+
+    it('preserves other named imports while renaming createNodesV2', () => {
+      const input = `import { createNodesV2, SomeOtherExport } from '@nx/angular/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes, SomeOtherExport } from '@nx/angular/plugin';\n`
+      );
+    });
+
+    it('rewrites the original name in `as` aliases', () => {
+      const input = `import { createNodesV2 as cn } from '@nx/angular/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes as cn } from '@nx/angular/plugin';\n`
+      );
+    });
+
+    it('collapses a redundant `createNodesV2 as createNodes` alias', () => {
+      const input = `import { createNodesV2 as createNodes } from '@nx/angular/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/angular/plugin';\n`
+      );
+    });
+
+    it('dedupes when both createNodes and createNodesV2 are imported', () => {
+      const input = `import { createNodes, createNodesV2 } from '@nx/angular/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/angular/plugin';\n`
+      );
+    });
+
+    it('dedupes when createNodesV2 precedes createNodes', () => {
+      const input = `import { createNodesV2, createNodes } from '@nx/angular/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/angular/plugin';\n`
+      );
+    });
+
+    it('handles multi-line named imports', () => {
+      const input = `import {\n  createNodes,\n  createNodesV2,\n  SomeOtherExport,\n} from '@nx/angular/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes, SomeOtherExport } from '@nx/angular/plugin';\n`
+      );
+    });
+
+    it('preserves a default import alongside the renamed binding', () => {
+      const input = `import def, { createNodesV2 } from '@nx/angular/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import def, { createNodes } from '@nx/angular/plugin';\n`
+      );
+    });
+
+    it('handles `import type` declarations', () => {
+      const input = `import type { createNodesV2 } from '@nx/angular/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import type { createNodes } from '@nx/angular/plugin';\n`
+      );
+    });
+
+    it('preserves inline `type` modifiers', () => {
+      const input = `import { type createNodesV2 } from '@nx/angular/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { type createNodes } from '@nx/angular/plugin';\n`
+      );
+    });
+
+    it('rewrites named re-exports', () => {
+      const input = `export { createNodesV2 } from '@nx/angular/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `export { createNodes } from '@nx/angular/plugin';\n`
+      );
+    });
+
+    it('rewrites aliased named re-exports', () => {
+      const input = `export { createNodesV2 as cn } from '@nx/angular/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `export { createNodes as cn } from '@nx/angular/plugin';\n`
+      );
+    });
+
+    it('does not touch createNodesV2 from a different specifier', () => {
+      const input = `import { createNodesV2 } from '@nx/other-plugin/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not touch createNodesV2 from a relative specifier', () => {
+      const input = `import { createNodesV2 } from './plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not touch unrelated imports from the target specifier', () => {
+      const input = `import { createNodes } from '@nx/angular/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not rewrite `export * from` declarations', () => {
+      const input = `export * from '@nx/angular/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('leaves createNodesV2 in strings and comments alone', () => {
+      const input =
+        `// import { createNodesV2 } from '@nx/angular/plugin';\n` +
+        `const s = "createNodesV2";\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not rewrite require() destructuring (still valid via alias)', () => {
+      const input = `const { createNodesV2 } = require('@nx/angular/plugin');\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+  });
+
+  describe('migration runner', () => {
+    it('rewrites imports across .ts/.tsx/.cts/.mts files', async () => {
+      tree.write(
+        'libs/foo/src/a.ts',
+        `import { createNodesV2 } from '@nx/angular/plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/b.tsx',
+        `import { createNodesV2 as cn } from '@nx/angular/plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/c.cts',
+        `export { createNodesV2 } from '@nx/angular/plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/d.mts',
+        `import { createNodesV2, SomeOtherExport } from '@nx/angular/plugin';\n`
+      );
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/a.ts', 'utf-8')).toContain(
+        `import { createNodes } from '@nx/angular/plugin';`
+      );
+      expect(tree.read('libs/foo/src/b.tsx', 'utf-8')).toContain(
+        `import { createNodes as cn } from '@nx/angular/plugin';`
+      );
+      expect(tree.read('libs/foo/src/c.cts', 'utf-8')).toContain(
+        `export { createNodes } from '@nx/angular/plugin';`
+      );
+      expect(tree.read('libs/foo/src/d.mts', 'utf-8')).toContain(
+        `import { createNodes, SomeOtherExport } from '@nx/angular/plugin';`
+      );
+    });
+
+    it('does not touch files without the deprecated name', async () => {
+      const content = `import { createNodes } from '@nx/angular/plugin';\n`;
+      tree.write('libs/foo/src/index.ts', content);
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/index.ts', 'utf-8')).toBe(content);
+    });
+
+    it('does not rewrite non-TS files', async () => {
+      const md = `Example: \`import { createNodesV2 } from '@nx/angular/plugin';\`\n`;
+      tree.write('docs/example.md', md);
+
+      await migration(tree);
+
+      expect(tree.read('docs/example.md', 'utf-8')).toContain(
+        `import { createNodesV2 } from '@nx/angular/plugin';`
+      );
+    });
+  });
+});

--- a/packages/angular/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.ts
+++ b/packages/angular/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.ts
@@ -1,0 +1,206 @@
+import {
+  applyChangesToString,
+  ChangeType,
+  ensurePackage,
+  formatFiles,
+  logger,
+  type StringChange,
+  type Tree,
+  visitNotIgnoredFiles,
+} from '@nx/devkit';
+import type {
+  ExportDeclaration,
+  ExportSpecifier,
+  ImportDeclaration,
+  ImportSpecifier,
+  NamedExports,
+  NamedImports,
+  SourceFile,
+} from 'typescript';
+
+const TS_EXTENSIONS = ['.ts', '.tsx', '.cts', '.mts'] as const;
+const DEPRECATED_NAME = 'createNodesV2';
+const CANONICAL_NAME = 'createNodes';
+
+// Module specifiers from which `@nx/angular` publicly exposes `createNodesV2`.
+// A named import or re-export of `createNodesV2` from one of these is rewritten
+// to the canonical `createNodes` export.
+const TARGET_SPECIFIERS: ReadonlySet<string> = new Set(['@nx/angular/plugin']);
+
+let ts: typeof import('typescript') | undefined;
+
+export default async function migrateCreateNodesV2ToCreateNodes(
+  tree: Tree
+): Promise<void> {
+  let touchedCount = 0;
+
+  visitNotIgnoredFiles(tree, '.', (filePath) => {
+    if (!TS_EXTENSIONS.some((ext) => filePath.endsWith(ext))) {
+      return;
+    }
+    const original = tree.read(filePath, 'utf-8');
+    if (!original || !original.includes(DEPRECATED_NAME)) {
+      return;
+    }
+    const updated = rewriteCreateNodesV2Imports(original, TARGET_SPECIFIERS);
+    if (updated !== original) {
+      tree.write(filePath, updated);
+      touchedCount += 1;
+    }
+  });
+
+  if (touchedCount > 0) {
+    logger.info(
+      `Renamed \`${DEPRECATED_NAME}\` imports to \`${CANONICAL_NAME}\` in ${touchedCount} file(s).`
+    );
+  }
+
+  await formatFiles(tree);
+}
+
+/**
+ * Rewrites named imports and re-exports of `createNodesV2` to `createNodes`
+ * when they come from one of the given module specifiers. Only the named
+ * bindings are touched — the module specifier, the `import`/`export` keyword,
+ * any `type` modifier, and any default import are left untouched.
+ */
+export function rewriteCreateNodesV2Imports(
+  source: string,
+  specifiers: ReadonlySet<string>
+): string {
+  ts ??= ensurePackage<typeof import('typescript')>('typescript', '*');
+  const sourceFile = ts.createSourceFile(
+    'tmp.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TSX
+  );
+
+  const changes: StringChange[] = [];
+  for (const stmt of sourceFile.statements) {
+    if (ts.isImportDeclaration(stmt)) {
+      collectImportRewrite(sourceFile, stmt, specifiers, changes);
+    } else if (ts.isExportDeclaration(stmt)) {
+      collectExportRewrite(sourceFile, stmt, specifiers, changes);
+    }
+  }
+
+  return changes.length > 0 ? applyChangesToString(source, changes) : source;
+}
+
+function isTargetSpecifier(
+  node: ImportDeclaration['moduleSpecifier'],
+  specifiers: ReadonlySet<string>
+): boolean {
+  return ts!.isStringLiteral(node) && specifiers.has(node.text);
+}
+
+function collectImportRewrite(
+  sourceFile: SourceFile,
+  stmt: ImportDeclaration,
+  specifiers: ReadonlySet<string>,
+  changes: StringChange[]
+): void {
+  if (!isTargetSpecifier(stmt.moduleSpecifier, specifiers)) {
+    return;
+  }
+  const namedBindings = stmt.importClause?.namedBindings;
+  // Only `import { ... }` carries renameable named bindings. `import x`,
+  // `import * as ns`, and side-effect imports reference the module wholesale
+  // and keep working through the `createNodesV2` runtime alias, so we leave
+  // them be. A mixed `import def, { createNodesV2 }` still has its named
+  // bindings rewritten below — the default binding is untouched.
+  if (!namedBindings || !ts!.isNamedImports(namedBindings)) {
+    return;
+  }
+  rewriteNamedBindings(sourceFile, namedBindings, changes);
+}
+
+function collectExportRewrite(
+  sourceFile: SourceFile,
+  stmt: ExportDeclaration,
+  specifiers: ReadonlySet<string>,
+  changes: StringChange[]
+): void {
+  if (
+    !stmt.moduleSpecifier ||
+    !isTargetSpecifier(stmt.moduleSpecifier, specifiers)
+  ) {
+    return;
+  }
+  // `export { ... } from '...'` can be rewritten; `export * from '...'` has no
+  // named bindings to rename.
+  if (!stmt.exportClause || !ts!.isNamedExports(stmt.exportClause)) {
+    return;
+  }
+  rewriteNamedBindings(sourceFile, stmt.exportClause, changes);
+}
+
+/**
+ * Re-renders the `{ ... }` of a named import/export, renaming any
+ * `createNodesV2` specifier to `createNodes`. If renaming would collide with a
+ * `createNodes` that is already present (e.g. `{ createNodes, createNodesV2 }`),
+ * the duplicate is dropped. Returns without recording a change when the binding
+ * list contains no `createNodesV2`.
+ */
+function rewriteNamedBindings(
+  sourceFile: SourceFile,
+  namedBindings: NamedImports | NamedExports,
+  changes: StringChange[]
+): void {
+  const elements = namedBindings.elements as readonly (
+    | ImportSpecifier
+    | ExportSpecifier
+  )[];
+  const hasDeprecated = elements.some(
+    (el) => (el.propertyName ?? el.name).text === DEPRECATED_NAME
+  );
+  if (!hasDeprecated) {
+    return;
+  }
+
+  const seen = new Set<string>();
+  const rendered: string[] = [];
+  for (const el of elements) {
+    const text = renderSpecifier(el);
+    if (!seen.has(text)) {
+      seen.add(text);
+      rendered.push(text);
+    }
+  }
+
+  const start = namedBindings.getStart(sourceFile);
+  changes.push(
+    {
+      type: ChangeType.Delete,
+      start,
+      length: namedBindings.getEnd() - start,
+    },
+    {
+      type: ChangeType.Insert,
+      index: start,
+      text: `{ ${rendered.join(', ')} }`,
+    }
+  );
+}
+
+function renderSpecifier(el: ImportSpecifier | ExportSpecifier): string {
+  const typePrefix = el.isTypeOnly ? 'type ' : '';
+  const rename = (name: string) =>
+    name === DEPRECATED_NAME ? CANONICAL_NAME : name;
+
+  // `{ name }` — no alias, so the local binding follows the rename.
+  if (!el.propertyName) {
+    return `${typePrefix}${rename(el.name.text)}`;
+  }
+
+  // `{ propertyName as name }` — only the imported (left) side is renamed; the
+  // local alias is preserved. A now-redundant alias such as
+  // `createNodesV2 as createNodes` collapses to `createNodes`.
+  const canonicalImported = rename(el.propertyName.text);
+  const localName = el.name.text;
+  return canonicalImported === localName
+    ? `${typePrefix}${localName}`
+    : `${typePrefix}${canonicalImported} as ${localName}`;
+}

--- a/packages/cypress/migrations.json
+++ b/packages/cypress/migrations.json
@@ -88,7 +88,7 @@
       "implementation": "./dist/src/migrations/update-23-0-0/rewrite-internal-subpath-imports"
     },
     "update-23-0-0-migrate-create-nodes-v2-import": {
-      "version": "23.0.0-beta.5",
+      "version": "23.0.0-beta.24",
       "description": "Rename imports of `createNodesV2` from `@nx/cypress/plugin` to the canonical `createNodes` export.",
       "implementation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
       "documentation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"

--- a/packages/cypress/migrations.json
+++ b/packages/cypress/migrations.json
@@ -86,6 +86,12 @@
       "version": "23.0.0-beta.19",
       "description": "Rewrites imports from `@nx/cypress/src/*` to either the public `@nx/cypress` entry (for re-exported symbols) or `@nx/cypress/internal` (for everything else). The `./src/*` wildcard was removed from the package's exports map.",
       "implementation": "./dist/src/migrations/update-23-0-0/rewrite-internal-subpath-imports"
+    },
+    "update-23-0-0-migrate-create-nodes-v2-import": {
+      "version": "23.0.0-beta.5",
+      "description": "Rename imports of `createNodesV2` from `@nx/cypress/plugin` to the canonical `createNodes` export.",
+      "implementation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
+      "documentation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"
     }
   },
   "packageJsonUpdates": {

--- a/packages/cypress/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md
+++ b/packages/cypress/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md
@@ -1,0 +1,25 @@
+#### Rename `createNodesV2` imports to `createNodes`
+
+`@nx/cypress` renamed its primary inferred-plugin export from `createNodesV2` to `createNodes`. The `createNodesV2` name is preserved as a deprecated alias for now, but new code should use `createNodes`.
+
+This migration scans every `.ts`, `.tsx`, `.cts`, and `.mts` file in your workspace and rewrites named imports and re-exports of `createNodesV2` from `@nx/cypress/plugin` to `createNodes`.
+
+#### Sample Code Changes
+
+##### Before
+
+```ts
+import { createNodesV2 } from '@nx/cypress/plugin';
+```
+
+##### After
+
+```ts
+import { createNodes } from '@nx/cypress/plugin';
+```
+
+Aliases are preserved (`createNodesV2 as cn` becomes `createNodes as cn`), and if a file already imports both names (`{ createNodes, createNodesV2 }`) the redundant binding is dropped.
+
+#### What is not rewritten
+
+Only static `import`/`export` named bindings from `@nx/cypress/plugin` are rewritten. Namespace imports, dynamic `import(...)`, `require(...)` destructuring, and property access such as `plugin.createNodesV2` are left untouched — they keep working through the `createNodesV2` runtime alias. Update those by hand if you want to drop the deprecated name everywhere.

--- a/packages/cypress/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.spec.ts
+++ b/packages/cypress/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.spec.ts
@@ -1,0 +1,191 @@
+import { type Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migration, {
+  rewriteCreateNodesV2Imports,
+} from './migrate-create-nodes-v2-to-create-nodes';
+
+const SPECIFIERS = new Set(['@nx/cypress/plugin']);
+const rewrite = (source: string) =>
+  rewriteCreateNodesV2Imports(source, SPECIFIERS);
+
+describe('migrate-create-nodes-v2-to-create-nodes migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  describe('rewriteCreateNodesV2Imports', () => {
+    it('renames a lone createNodesV2 named import', () => {
+      const input = `import { createNodesV2 } from '@nx/cypress/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/cypress/plugin';\n`
+      );
+    });
+
+    it('preserves other named imports while renaming createNodesV2', () => {
+      const input = `import { createNodesV2, SomeOtherExport } from '@nx/cypress/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes, SomeOtherExport } from '@nx/cypress/plugin';\n`
+      );
+    });
+
+    it('rewrites the original name in `as` aliases', () => {
+      const input = `import { createNodesV2 as cn } from '@nx/cypress/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes as cn } from '@nx/cypress/plugin';\n`
+      );
+    });
+
+    it('collapses a redundant `createNodesV2 as createNodes` alias', () => {
+      const input = `import { createNodesV2 as createNodes } from '@nx/cypress/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/cypress/plugin';\n`
+      );
+    });
+
+    it('dedupes when both createNodes and createNodesV2 are imported', () => {
+      const input = `import { createNodes, createNodesV2 } from '@nx/cypress/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/cypress/plugin';\n`
+      );
+    });
+
+    it('dedupes when createNodesV2 precedes createNodes', () => {
+      const input = `import { createNodesV2, createNodes } from '@nx/cypress/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/cypress/plugin';\n`
+      );
+    });
+
+    it('handles multi-line named imports', () => {
+      const input = `import {\n  createNodes,\n  createNodesV2,\n  SomeOtherExport,\n} from '@nx/cypress/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes, SomeOtherExport } from '@nx/cypress/plugin';\n`
+      );
+    });
+
+    it('preserves a default import alongside the renamed binding', () => {
+      const input = `import def, { createNodesV2 } from '@nx/cypress/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import def, { createNodes } from '@nx/cypress/plugin';\n`
+      );
+    });
+
+    it('handles `import type` declarations', () => {
+      const input = `import type { createNodesV2 } from '@nx/cypress/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import type { createNodes } from '@nx/cypress/plugin';\n`
+      );
+    });
+
+    it('preserves inline `type` modifiers', () => {
+      const input = `import { type createNodesV2 } from '@nx/cypress/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { type createNodes } from '@nx/cypress/plugin';\n`
+      );
+    });
+
+    it('rewrites named re-exports', () => {
+      const input = `export { createNodesV2 } from '@nx/cypress/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `export { createNodes } from '@nx/cypress/plugin';\n`
+      );
+    });
+
+    it('rewrites aliased named re-exports', () => {
+      const input = `export { createNodesV2 as cn } from '@nx/cypress/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `export { createNodes as cn } from '@nx/cypress/plugin';\n`
+      );
+    });
+
+    it('does not touch createNodesV2 from a different specifier', () => {
+      const input = `import { createNodesV2 } from '@nx/other-plugin/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not touch createNodesV2 from a relative specifier', () => {
+      const input = `import { createNodesV2 } from './plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not touch unrelated imports from the target specifier', () => {
+      const input = `import { createNodes } from '@nx/cypress/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not rewrite `export * from` declarations', () => {
+      const input = `export * from '@nx/cypress/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('leaves createNodesV2 in strings and comments alone', () => {
+      const input =
+        `// import { createNodesV2 } from '@nx/cypress/plugin';\n` +
+        `const s = "createNodesV2";\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not rewrite require() destructuring (still valid via alias)', () => {
+      const input = `const { createNodesV2 } = require('@nx/cypress/plugin');\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+  });
+
+  describe('migration runner', () => {
+    it('rewrites imports across .ts/.tsx/.cts/.mts files', async () => {
+      tree.write(
+        'libs/foo/src/a.ts',
+        `import { createNodesV2 } from '@nx/cypress/plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/b.tsx',
+        `import { createNodesV2 as cn } from '@nx/cypress/plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/c.cts',
+        `export { createNodesV2 } from '@nx/cypress/plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/d.mts',
+        `import { createNodesV2, SomeOtherExport } from '@nx/cypress/plugin';\n`
+      );
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/a.ts', 'utf-8')).toContain(
+        `import { createNodes } from '@nx/cypress/plugin';`
+      );
+      expect(tree.read('libs/foo/src/b.tsx', 'utf-8')).toContain(
+        `import { createNodes as cn } from '@nx/cypress/plugin';`
+      );
+      expect(tree.read('libs/foo/src/c.cts', 'utf-8')).toContain(
+        `export { createNodes } from '@nx/cypress/plugin';`
+      );
+      expect(tree.read('libs/foo/src/d.mts', 'utf-8')).toContain(
+        `import { createNodes, SomeOtherExport } from '@nx/cypress/plugin';`
+      );
+    });
+
+    it('does not touch files without the deprecated name', async () => {
+      const content = `import { createNodes } from '@nx/cypress/plugin';\n`;
+      tree.write('libs/foo/src/index.ts', content);
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/index.ts', 'utf-8')).toBe(content);
+    });
+
+    it('does not rewrite non-TS files', async () => {
+      const md = `Example: \`import { createNodesV2 } from '@nx/cypress/plugin';\`\n`;
+      tree.write('docs/example.md', md);
+
+      await migration(tree);
+
+      expect(tree.read('docs/example.md', 'utf-8')).toContain(
+        `import { createNodesV2 } from '@nx/cypress/plugin';`
+      );
+    });
+  });
+});

--- a/packages/cypress/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.ts
+++ b/packages/cypress/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.ts
@@ -1,0 +1,206 @@
+import {
+  applyChangesToString,
+  ChangeType,
+  ensurePackage,
+  formatFiles,
+  logger,
+  type StringChange,
+  type Tree,
+  visitNotIgnoredFiles,
+} from '@nx/devkit';
+import type {
+  ExportDeclaration,
+  ExportSpecifier,
+  ImportDeclaration,
+  ImportSpecifier,
+  NamedExports,
+  NamedImports,
+  SourceFile,
+} from 'typescript';
+
+const TS_EXTENSIONS = ['.ts', '.tsx', '.cts', '.mts'] as const;
+const DEPRECATED_NAME = 'createNodesV2';
+const CANONICAL_NAME = 'createNodes';
+
+// Module specifiers from which `@nx/cypress` publicly exposes `createNodesV2`.
+// A named import or re-export of `createNodesV2` from one of these is rewritten
+// to the canonical `createNodes` export.
+const TARGET_SPECIFIERS: ReadonlySet<string> = new Set(['@nx/cypress/plugin']);
+
+let ts: typeof import('typescript') | undefined;
+
+export default async function migrateCreateNodesV2ToCreateNodes(
+  tree: Tree
+): Promise<void> {
+  let touchedCount = 0;
+
+  visitNotIgnoredFiles(tree, '.', (filePath) => {
+    if (!TS_EXTENSIONS.some((ext) => filePath.endsWith(ext))) {
+      return;
+    }
+    const original = tree.read(filePath, 'utf-8');
+    if (!original || !original.includes(DEPRECATED_NAME)) {
+      return;
+    }
+    const updated = rewriteCreateNodesV2Imports(original, TARGET_SPECIFIERS);
+    if (updated !== original) {
+      tree.write(filePath, updated);
+      touchedCount += 1;
+    }
+  });
+
+  if (touchedCount > 0) {
+    logger.info(
+      `Renamed \`${DEPRECATED_NAME}\` imports to \`${CANONICAL_NAME}\` in ${touchedCount} file(s).`
+    );
+  }
+
+  await formatFiles(tree);
+}
+
+/**
+ * Rewrites named imports and re-exports of `createNodesV2` to `createNodes`
+ * when they come from one of the given module specifiers. Only the named
+ * bindings are touched — the module specifier, the `import`/`export` keyword,
+ * any `type` modifier, and any default import are left untouched.
+ */
+export function rewriteCreateNodesV2Imports(
+  source: string,
+  specifiers: ReadonlySet<string>
+): string {
+  ts ??= ensurePackage<typeof import('typescript')>('typescript', '*');
+  const sourceFile = ts.createSourceFile(
+    'tmp.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TSX
+  );
+
+  const changes: StringChange[] = [];
+  for (const stmt of sourceFile.statements) {
+    if (ts.isImportDeclaration(stmt)) {
+      collectImportRewrite(sourceFile, stmt, specifiers, changes);
+    } else if (ts.isExportDeclaration(stmt)) {
+      collectExportRewrite(sourceFile, stmt, specifiers, changes);
+    }
+  }
+
+  return changes.length > 0 ? applyChangesToString(source, changes) : source;
+}
+
+function isTargetSpecifier(
+  node: ImportDeclaration['moduleSpecifier'],
+  specifiers: ReadonlySet<string>
+): boolean {
+  return ts!.isStringLiteral(node) && specifiers.has(node.text);
+}
+
+function collectImportRewrite(
+  sourceFile: SourceFile,
+  stmt: ImportDeclaration,
+  specifiers: ReadonlySet<string>,
+  changes: StringChange[]
+): void {
+  if (!isTargetSpecifier(stmt.moduleSpecifier, specifiers)) {
+    return;
+  }
+  const namedBindings = stmt.importClause?.namedBindings;
+  // Only `import { ... }` carries renameable named bindings. `import x`,
+  // `import * as ns`, and side-effect imports reference the module wholesale
+  // and keep working through the `createNodesV2` runtime alias, so we leave
+  // them be. A mixed `import def, { createNodesV2 }` still has its named
+  // bindings rewritten below — the default binding is untouched.
+  if (!namedBindings || !ts!.isNamedImports(namedBindings)) {
+    return;
+  }
+  rewriteNamedBindings(sourceFile, namedBindings, changes);
+}
+
+function collectExportRewrite(
+  sourceFile: SourceFile,
+  stmt: ExportDeclaration,
+  specifiers: ReadonlySet<string>,
+  changes: StringChange[]
+): void {
+  if (
+    !stmt.moduleSpecifier ||
+    !isTargetSpecifier(stmt.moduleSpecifier, specifiers)
+  ) {
+    return;
+  }
+  // `export { ... } from '...'` can be rewritten; `export * from '...'` has no
+  // named bindings to rename.
+  if (!stmt.exportClause || !ts!.isNamedExports(stmt.exportClause)) {
+    return;
+  }
+  rewriteNamedBindings(sourceFile, stmt.exportClause, changes);
+}
+
+/**
+ * Re-renders the `{ ... }` of a named import/export, renaming any
+ * `createNodesV2` specifier to `createNodes`. If renaming would collide with a
+ * `createNodes` that is already present (e.g. `{ createNodes, createNodesV2 }`),
+ * the duplicate is dropped. Returns without recording a change when the binding
+ * list contains no `createNodesV2`.
+ */
+function rewriteNamedBindings(
+  sourceFile: SourceFile,
+  namedBindings: NamedImports | NamedExports,
+  changes: StringChange[]
+): void {
+  const elements = namedBindings.elements as readonly (
+    | ImportSpecifier
+    | ExportSpecifier
+  )[];
+  const hasDeprecated = elements.some(
+    (el) => (el.propertyName ?? el.name).text === DEPRECATED_NAME
+  );
+  if (!hasDeprecated) {
+    return;
+  }
+
+  const seen = new Set<string>();
+  const rendered: string[] = [];
+  for (const el of elements) {
+    const text = renderSpecifier(el);
+    if (!seen.has(text)) {
+      seen.add(text);
+      rendered.push(text);
+    }
+  }
+
+  const start = namedBindings.getStart(sourceFile);
+  changes.push(
+    {
+      type: ChangeType.Delete,
+      start,
+      length: namedBindings.getEnd() - start,
+    },
+    {
+      type: ChangeType.Insert,
+      index: start,
+      text: `{ ${rendered.join(', ')} }`,
+    }
+  );
+}
+
+function renderSpecifier(el: ImportSpecifier | ExportSpecifier): string {
+  const typePrefix = el.isTypeOnly ? 'type ' : '';
+  const rename = (name: string) =>
+    name === DEPRECATED_NAME ? CANONICAL_NAME : name;
+
+  // `{ name }` — no alias, so the local binding follows the rename.
+  if (!el.propertyName) {
+    return `${typePrefix}${rename(el.name.text)}`;
+  }
+
+  // `{ propertyName as name }` — only the imported (left) side is renamed; the
+  // local alias is preserved. A now-redundant alias such as
+  // `createNodesV2 as createNodes` collapses to `createNodes`.
+  const canonicalImported = rename(el.propertyName.text);
+  const localName = el.name.text;
+  return canonicalImported === localName
+    ? `${typePrefix}${localName}`
+    : `${typePrefix}${canonicalImported} as ${localName}`;
+}

--- a/packages/detox/migrations.json
+++ b/packages/detox/migrations.json
@@ -10,7 +10,7 @@
       "factory": "./src/migrations/update-22-0-0/remove-config-plugins-detox-for-expo-54"
     },
     "update-23-0-0-migrate-create-nodes-v2-import": {
-      "version": "23.0.0-beta.5",
+      "version": "23.0.0-beta.24",
       "description": "Rename imports of `createNodesV2` from `@nx/detox/plugin` to the canonical `createNodes` export.",
       "implementation": "./src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
       "documentation": "./src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"

--- a/packages/detox/migrations.json
+++ b/packages/detox/migrations.json
@@ -8,6 +8,12 @@
       "cli": "nx",
       "description": "Remove @config-plugins/detox for Expo 54+ projects (package discontinued)",
       "factory": "./src/migrations/update-22-0-0/remove-config-plugins-detox-for-expo-54"
+    },
+    "update-23-0-0-migrate-create-nodes-v2-import": {
+      "version": "23.0.0-beta.5",
+      "description": "Rename imports of `createNodesV2` from `@nx/detox/plugin` to the canonical `createNodes` export.",
+      "implementation": "./src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
+      "documentation": "./src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"
     }
   },
   "packageJsonUpdates": {

--- a/packages/detox/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md
+++ b/packages/detox/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md
@@ -1,0 +1,25 @@
+#### Rename `createNodesV2` imports to `createNodes`
+
+`@nx/detox` renamed its primary inferred-plugin export from `createNodesV2` to `createNodes`. The `createNodesV2` name is preserved as a deprecated alias for now, but new code should use `createNodes`.
+
+This migration scans every `.ts`, `.tsx`, `.cts`, and `.mts` file in your workspace and rewrites named imports and re-exports of `createNodesV2` from `@nx/detox/plugin` to `createNodes`.
+
+#### Sample Code Changes
+
+##### Before
+
+```ts
+import { createNodesV2 } from '@nx/detox/plugin';
+```
+
+##### After
+
+```ts
+import { createNodes } from '@nx/detox/plugin';
+```
+
+Aliases are preserved (`createNodesV2 as cn` becomes `createNodes as cn`), and if a file already imports both names (`{ createNodes, createNodesV2 }`) the redundant binding is dropped.
+
+#### What is not rewritten
+
+Only static `import`/`export` named bindings from `@nx/detox/plugin` are rewritten. Namespace imports, dynamic `import(...)`, `require(...)` destructuring, and property access such as `plugin.createNodesV2` are left untouched — they keep working through the `createNodesV2` runtime alias. Update those by hand if you want to drop the deprecated name everywhere.

--- a/packages/detox/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.spec.ts
+++ b/packages/detox/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.spec.ts
@@ -1,0 +1,191 @@
+import { type Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migration, {
+  rewriteCreateNodesV2Imports,
+} from './migrate-create-nodes-v2-to-create-nodes';
+
+const SPECIFIERS = new Set(['@nx/detox/plugin']);
+const rewrite = (source: string) =>
+  rewriteCreateNodesV2Imports(source, SPECIFIERS);
+
+describe('migrate-create-nodes-v2-to-create-nodes migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  describe('rewriteCreateNodesV2Imports', () => {
+    it('renames a lone createNodesV2 named import', () => {
+      const input = `import { createNodesV2 } from '@nx/detox/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/detox/plugin';\n`
+      );
+    });
+
+    it('preserves other named imports while renaming createNodesV2', () => {
+      const input = `import { createNodesV2, SomeOtherExport } from '@nx/detox/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes, SomeOtherExport } from '@nx/detox/plugin';\n`
+      );
+    });
+
+    it('rewrites the original name in `as` aliases', () => {
+      const input = `import { createNodesV2 as cn } from '@nx/detox/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes as cn } from '@nx/detox/plugin';\n`
+      );
+    });
+
+    it('collapses a redundant `createNodesV2 as createNodes` alias', () => {
+      const input = `import { createNodesV2 as createNodes } from '@nx/detox/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/detox/plugin';\n`
+      );
+    });
+
+    it('dedupes when both createNodes and createNodesV2 are imported', () => {
+      const input = `import { createNodes, createNodesV2 } from '@nx/detox/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/detox/plugin';\n`
+      );
+    });
+
+    it('dedupes when createNodesV2 precedes createNodes', () => {
+      const input = `import { createNodesV2, createNodes } from '@nx/detox/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/detox/plugin';\n`
+      );
+    });
+
+    it('handles multi-line named imports', () => {
+      const input = `import {\n  createNodes,\n  createNodesV2,\n  SomeOtherExport,\n} from '@nx/detox/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes, SomeOtherExport } from '@nx/detox/plugin';\n`
+      );
+    });
+
+    it('preserves a default import alongside the renamed binding', () => {
+      const input = `import def, { createNodesV2 } from '@nx/detox/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import def, { createNodes } from '@nx/detox/plugin';\n`
+      );
+    });
+
+    it('handles `import type` declarations', () => {
+      const input = `import type { createNodesV2 } from '@nx/detox/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import type { createNodes } from '@nx/detox/plugin';\n`
+      );
+    });
+
+    it('preserves inline `type` modifiers', () => {
+      const input = `import { type createNodesV2 } from '@nx/detox/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { type createNodes } from '@nx/detox/plugin';\n`
+      );
+    });
+
+    it('rewrites named re-exports', () => {
+      const input = `export { createNodesV2 } from '@nx/detox/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `export { createNodes } from '@nx/detox/plugin';\n`
+      );
+    });
+
+    it('rewrites aliased named re-exports', () => {
+      const input = `export { createNodesV2 as cn } from '@nx/detox/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `export { createNodes as cn } from '@nx/detox/plugin';\n`
+      );
+    });
+
+    it('does not touch createNodesV2 from a different specifier', () => {
+      const input = `import { createNodesV2 } from '@nx/other-plugin/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not touch createNodesV2 from a relative specifier', () => {
+      const input = `import { createNodesV2 } from './plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not touch unrelated imports from the target specifier', () => {
+      const input = `import { createNodes } from '@nx/detox/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not rewrite `export * from` declarations', () => {
+      const input = `export * from '@nx/detox/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('leaves createNodesV2 in strings and comments alone', () => {
+      const input =
+        `// import { createNodesV2 } from '@nx/detox/plugin';\n` +
+        `const s = "createNodesV2";\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not rewrite require() destructuring (still valid via alias)', () => {
+      const input = `const { createNodesV2 } = require('@nx/detox/plugin');\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+  });
+
+  describe('migration runner', () => {
+    it('rewrites imports across .ts/.tsx/.cts/.mts files', async () => {
+      tree.write(
+        'libs/foo/src/a.ts',
+        `import { createNodesV2 } from '@nx/detox/plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/b.tsx',
+        `import { createNodesV2 as cn } from '@nx/detox/plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/c.cts',
+        `export { createNodesV2 } from '@nx/detox/plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/d.mts',
+        `import { createNodesV2, SomeOtherExport } from '@nx/detox/plugin';\n`
+      );
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/a.ts', 'utf-8')).toContain(
+        `import { createNodes } from '@nx/detox/plugin';`
+      );
+      expect(tree.read('libs/foo/src/b.tsx', 'utf-8')).toContain(
+        `import { createNodes as cn } from '@nx/detox/plugin';`
+      );
+      expect(tree.read('libs/foo/src/c.cts', 'utf-8')).toContain(
+        `export { createNodes } from '@nx/detox/plugin';`
+      );
+      expect(tree.read('libs/foo/src/d.mts', 'utf-8')).toContain(
+        `import { createNodes, SomeOtherExport } from '@nx/detox/plugin';`
+      );
+    });
+
+    it('does not touch files without the deprecated name', async () => {
+      const content = `import { createNodes } from '@nx/detox/plugin';\n`;
+      tree.write('libs/foo/src/index.ts', content);
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/index.ts', 'utf-8')).toBe(content);
+    });
+
+    it('does not rewrite non-TS files', async () => {
+      const md = `Example: \`import { createNodesV2 } from '@nx/detox/plugin';\`\n`;
+      tree.write('docs/example.md', md);
+
+      await migration(tree);
+
+      expect(tree.read('docs/example.md', 'utf-8')).toContain(
+        `import { createNodesV2 } from '@nx/detox/plugin';`
+      );
+    });
+  });
+});

--- a/packages/detox/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.ts
+++ b/packages/detox/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.ts
@@ -1,0 +1,206 @@
+import {
+  applyChangesToString,
+  ChangeType,
+  ensurePackage,
+  formatFiles,
+  logger,
+  type StringChange,
+  type Tree,
+  visitNotIgnoredFiles,
+} from '@nx/devkit';
+import type {
+  ExportDeclaration,
+  ExportSpecifier,
+  ImportDeclaration,
+  ImportSpecifier,
+  NamedExports,
+  NamedImports,
+  SourceFile,
+} from 'typescript';
+
+const TS_EXTENSIONS = ['.ts', '.tsx', '.cts', '.mts'] as const;
+const DEPRECATED_NAME = 'createNodesV2';
+const CANONICAL_NAME = 'createNodes';
+
+// Module specifiers from which `@nx/detox` publicly exposes `createNodesV2`.
+// A named import or re-export of `createNodesV2` from one of these is rewritten
+// to the canonical `createNodes` export.
+const TARGET_SPECIFIERS: ReadonlySet<string> = new Set(['@nx/detox/plugin']);
+
+let ts: typeof import('typescript') | undefined;
+
+export default async function migrateCreateNodesV2ToCreateNodes(
+  tree: Tree
+): Promise<void> {
+  let touchedCount = 0;
+
+  visitNotIgnoredFiles(tree, '.', (filePath) => {
+    if (!TS_EXTENSIONS.some((ext) => filePath.endsWith(ext))) {
+      return;
+    }
+    const original = tree.read(filePath, 'utf-8');
+    if (!original || !original.includes(DEPRECATED_NAME)) {
+      return;
+    }
+    const updated = rewriteCreateNodesV2Imports(original, TARGET_SPECIFIERS);
+    if (updated !== original) {
+      tree.write(filePath, updated);
+      touchedCount += 1;
+    }
+  });
+
+  if (touchedCount > 0) {
+    logger.info(
+      `Renamed \`${DEPRECATED_NAME}\` imports to \`${CANONICAL_NAME}\` in ${touchedCount} file(s).`
+    );
+  }
+
+  await formatFiles(tree);
+}
+
+/**
+ * Rewrites named imports and re-exports of `createNodesV2` to `createNodes`
+ * when they come from one of the given module specifiers. Only the named
+ * bindings are touched — the module specifier, the `import`/`export` keyword,
+ * any `type` modifier, and any default import are left untouched.
+ */
+export function rewriteCreateNodesV2Imports(
+  source: string,
+  specifiers: ReadonlySet<string>
+): string {
+  ts ??= ensurePackage<typeof import('typescript')>('typescript', '*');
+  const sourceFile = ts.createSourceFile(
+    'tmp.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TSX
+  );
+
+  const changes: StringChange[] = [];
+  for (const stmt of sourceFile.statements) {
+    if (ts.isImportDeclaration(stmt)) {
+      collectImportRewrite(sourceFile, stmt, specifiers, changes);
+    } else if (ts.isExportDeclaration(stmt)) {
+      collectExportRewrite(sourceFile, stmt, specifiers, changes);
+    }
+  }
+
+  return changes.length > 0 ? applyChangesToString(source, changes) : source;
+}
+
+function isTargetSpecifier(
+  node: ImportDeclaration['moduleSpecifier'],
+  specifiers: ReadonlySet<string>
+): boolean {
+  return ts!.isStringLiteral(node) && specifiers.has(node.text);
+}
+
+function collectImportRewrite(
+  sourceFile: SourceFile,
+  stmt: ImportDeclaration,
+  specifiers: ReadonlySet<string>,
+  changes: StringChange[]
+): void {
+  if (!isTargetSpecifier(stmt.moduleSpecifier, specifiers)) {
+    return;
+  }
+  const namedBindings = stmt.importClause?.namedBindings;
+  // Only `import { ... }` carries renameable named bindings. `import x`,
+  // `import * as ns`, and side-effect imports reference the module wholesale
+  // and keep working through the `createNodesV2` runtime alias, so we leave
+  // them be. A mixed `import def, { createNodesV2 }` still has its named
+  // bindings rewritten below — the default binding is untouched.
+  if (!namedBindings || !ts!.isNamedImports(namedBindings)) {
+    return;
+  }
+  rewriteNamedBindings(sourceFile, namedBindings, changes);
+}
+
+function collectExportRewrite(
+  sourceFile: SourceFile,
+  stmt: ExportDeclaration,
+  specifiers: ReadonlySet<string>,
+  changes: StringChange[]
+): void {
+  if (
+    !stmt.moduleSpecifier ||
+    !isTargetSpecifier(stmt.moduleSpecifier, specifiers)
+  ) {
+    return;
+  }
+  // `export { ... } from '...'` can be rewritten; `export * from '...'` has no
+  // named bindings to rename.
+  if (!stmt.exportClause || !ts!.isNamedExports(stmt.exportClause)) {
+    return;
+  }
+  rewriteNamedBindings(sourceFile, stmt.exportClause, changes);
+}
+
+/**
+ * Re-renders the `{ ... }` of a named import/export, renaming any
+ * `createNodesV2` specifier to `createNodes`. If renaming would collide with a
+ * `createNodes` that is already present (e.g. `{ createNodes, createNodesV2 }`),
+ * the duplicate is dropped. Returns without recording a change when the binding
+ * list contains no `createNodesV2`.
+ */
+function rewriteNamedBindings(
+  sourceFile: SourceFile,
+  namedBindings: NamedImports | NamedExports,
+  changes: StringChange[]
+): void {
+  const elements = namedBindings.elements as readonly (
+    | ImportSpecifier
+    | ExportSpecifier
+  )[];
+  const hasDeprecated = elements.some(
+    (el) => (el.propertyName ?? el.name).text === DEPRECATED_NAME
+  );
+  if (!hasDeprecated) {
+    return;
+  }
+
+  const seen = new Set<string>();
+  const rendered: string[] = [];
+  for (const el of elements) {
+    const text = renderSpecifier(el);
+    if (!seen.has(text)) {
+      seen.add(text);
+      rendered.push(text);
+    }
+  }
+
+  const start = namedBindings.getStart(sourceFile);
+  changes.push(
+    {
+      type: ChangeType.Delete,
+      start,
+      length: namedBindings.getEnd() - start,
+    },
+    {
+      type: ChangeType.Insert,
+      index: start,
+      text: `{ ${rendered.join(', ')} }`,
+    }
+  );
+}
+
+function renderSpecifier(el: ImportSpecifier | ExportSpecifier): string {
+  const typePrefix = el.isTypeOnly ? 'type ' : '';
+  const rename = (name: string) =>
+    name === DEPRECATED_NAME ? CANONICAL_NAME : name;
+
+  // `{ name }` — no alias, so the local binding follows the rename.
+  if (!el.propertyName) {
+    return `${typePrefix}${rename(el.name.text)}`;
+  }
+
+  // `{ propertyName as name }` — only the imported (left) side is renamed; the
+  // local alias is preserved. A now-redundant alias such as
+  // `createNodesV2 as createNodes` collapses to `createNodes`.
+  const canonicalImported = rename(el.propertyName.text);
+  const localName = el.name.text;
+  return canonicalImported === localName
+    ? `${typePrefix}${localName}`
+    : `${typePrefix}${canonicalImported} as ${localName}`;
+}

--- a/packages/devkit/migrations.json
+++ b/packages/devkit/migrations.json
@@ -7,7 +7,7 @@
       "documentation": "./dist/src/migrations/update-23-0-0/update-deep-imports.md"
     },
     "update-23-0-0-rename-create-nodes-v2-types": {
-      "version": "23.0.0-beta.5",
+      "version": "23.0.0-beta.24",
       "description": "Rename deprecated CreateNodes `V2` type imports (CreateNodesV2, CreateNodesContextV2, CreateNodesResultV2, CreateNodesFunctionV2, NxPluginV2) from `@nx/devkit` to their canonical names.",
       "implementation": "./dist/src/migrations/update-23-0-0/rename-create-nodes-v2-types",
       "documentation": "./dist/src/migrations/update-23-0-0/rename-create-nodes-v2-types.md"

--- a/packages/devkit/migrations.json
+++ b/packages/devkit/migrations.json
@@ -5,6 +5,12 @@
       "description": "Rewrite imports from `@nx/devkit/src/...` to `@nx/devkit` (for public symbols) or `@nx/devkit/internal` (for the rest), since deep imports are no longer reachable through the package's `exports` map.",
       "implementation": "./dist/src/migrations/update-23-0-0/update-deep-imports",
       "documentation": "./dist/src/migrations/update-23-0-0/update-deep-imports.md"
+    },
+    "update-23-0-0-rename-create-nodes-v2-types": {
+      "version": "23.0.0-beta.5",
+      "description": "Rename deprecated CreateNodes `V2` type imports (CreateNodesV2, CreateNodesContextV2, CreateNodesResultV2, CreateNodesFunctionV2, NxPluginV2) from `@nx/devkit` to their canonical names.",
+      "implementation": "./dist/src/migrations/update-23-0-0/rename-create-nodes-v2-types",
+      "documentation": "./dist/src/migrations/update-23-0-0/rename-create-nodes-v2-types.md"
     }
   },
   "packageJsonUpdates": {},

--- a/packages/devkit/src/migrations/update-23-0-0/rename-create-nodes-v2-types.md
+++ b/packages/devkit/src/migrations/update-23-0-0/rename-create-nodes-v2-types.md
@@ -1,0 +1,29 @@
+#### Rename deprecated CreateNodes `V2` types from `@nx/devkit`
+
+The canonical plugin API types lost their `V2` suffix in Nx 23. The `V2` names are kept as `@deprecated` aliases, but new code should use the canonical names:
+
+| Deprecated (`@nx/devkit`) | Canonical                |
+| ------------------------- | ------------------------ |
+| `CreateNodesV2`           | `CreateNodes`            |
+| `CreateNodesContextV2`    | `CreateNodesContext`     |
+| `CreateNodesResultV2`     | `CreateNodesResultArray` |
+| `CreateNodesFunctionV2`   | `CreateNodesFunction`    |
+| `NxPluginV2`              | `NxPlugin`               |
+
+This migration scans every `.ts`, `.tsx`, `.cts`, and `.mts` file in your workspace and rewrites named imports and re-exports of these types from `@nx/devkit` to their canonical names.
+
+#### Sample Code Changes
+
+##### Before
+
+```ts
+import type { CreateNodesV2, CreateNodesContextV2 } from '@nx/devkit';
+```
+
+##### After
+
+```ts
+import type { CreateNodes, CreateNodesContext } from '@nx/devkit';
+```
+
+Aliases are preserved (`CreateNodesV2 as CN` becomes `CreateNodes as CN`), and if a file already imports both names (`{ CreateNodes, CreateNodesV2 }`) the redundant binding is dropped. The unrelated `CreateNodesResult` type is left untouched.

--- a/packages/devkit/src/migrations/update-23-0-0/rename-create-nodes-v2-types.spec.ts
+++ b/packages/devkit/src/migrations/update-23-0-0/rename-create-nodes-v2-types.spec.ts
@@ -1,0 +1,157 @@
+import { type Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migration, {
+  CREATE_NODES_V2_TYPE_RENAMES,
+  rewriteCreateNodesV2Types,
+} from './rename-create-nodes-v2-types';
+
+describe('rename-create-nodes-v2-types migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  describe('rewriteCreateNodesV2Types', () => {
+    it('renames each deprecated type to its canonical name', () => {
+      for (const [from, to] of CREATE_NODES_V2_TYPE_RENAMES) {
+        const input = `import type { ${from} } from '@nx/devkit';\n`;
+        expect(rewriteCreateNodesV2Types(input)).toBe(
+          `import type { ${to} } from '@nx/devkit';\n`
+        );
+      }
+    });
+
+    it('renames value-position imports too', () => {
+      const input = `import { NxPluginV2 } from '@nx/devkit';\n`;
+      expect(rewriteCreateNodesV2Types(input)).toBe(
+        `import { NxPlugin } from '@nx/devkit';\n`
+      );
+    });
+
+    it('renames CreateNodesResultV2 to CreateNodesResultArray', () => {
+      const input = `import type { CreateNodesResultV2 } from '@nx/devkit';\n`;
+      expect(rewriteCreateNodesV2Types(input)).toBe(
+        `import type { CreateNodesResultArray } from '@nx/devkit';\n`
+      );
+    });
+
+    it('leaves the unrelated CreateNodesResult type alone', () => {
+      const input = `import type { CreateNodesResult } from '@nx/devkit';\n`;
+      expect(rewriteCreateNodesV2Types(input)).toBe(input);
+    });
+
+    it('renames several types in one import and preserves others', () => {
+      const input = `import type { CreateNodesV2, CreateNodesContextV2, Tree } from '@nx/devkit';\n`;
+      expect(rewriteCreateNodesV2Types(input)).toBe(
+        `import type { CreateNodes, CreateNodesContext, Tree } from '@nx/devkit';\n`
+      );
+    });
+
+    it('preserves `as` aliases', () => {
+      const input = `import type { CreateNodesV2 as CN } from '@nx/devkit';\n`;
+      expect(rewriteCreateNodesV2Types(input)).toBe(
+        `import type { CreateNodes as CN } from '@nx/devkit';\n`
+      );
+    });
+
+    it('collapses a redundant `CreateNodesV2 as CreateNodes` alias', () => {
+      const input = `import type { CreateNodesV2 as CreateNodes } from '@nx/devkit';\n`;
+      expect(rewriteCreateNodesV2Types(input)).toBe(
+        `import type { CreateNodes } from '@nx/devkit';\n`
+      );
+    });
+
+    it('dedupes when both the V2 and canonical names are imported', () => {
+      const input = `import type { CreateNodes, CreateNodesV2 } from '@nx/devkit';\n`;
+      expect(rewriteCreateNodesV2Types(input)).toBe(
+        `import type { CreateNodes } from '@nx/devkit';\n`
+      );
+    });
+
+    it('handles inline `type` modifiers in a value import', () => {
+      const input = `import { type NxPluginV2, readJson } from '@nx/devkit';\n`;
+      expect(rewriteCreateNodesV2Types(input)).toBe(
+        `import { type NxPlugin, readJson } from '@nx/devkit';\n`
+      );
+    });
+
+    it('handles multi-line imports', () => {
+      const input = `import type {\n  NxPluginV2,\n  CreateNodesFunctionV2,\n} from '@nx/devkit';\n`;
+      expect(rewriteCreateNodesV2Types(input)).toBe(
+        `import type { NxPlugin, CreateNodesFunction } from '@nx/devkit';\n`
+      );
+    });
+
+    it('rewrites named re-exports', () => {
+      const input = `export type { CreateNodesV2 } from '@nx/devkit';\n`;
+      expect(rewriteCreateNodesV2Types(input)).toBe(
+        `export type { CreateNodes } from '@nx/devkit';\n`
+      );
+    });
+
+    it('does not touch the types when imported from another specifier', () => {
+      const input = `import type { CreateNodesV2 } from '@nx/devkit/internal';\n`;
+      expect(rewriteCreateNodesV2Types(input)).toBe(input);
+    });
+
+    it('does not touch unrelated @nx/devkit imports', () => {
+      const input = `import { Tree, readJson } from '@nx/devkit';\n`;
+      expect(rewriteCreateNodesV2Types(input)).toBe(input);
+    });
+
+    it('leaves the V2 names in strings and comments alone', () => {
+      const input =
+        `// import { CreateNodesV2 } from '@nx/devkit';\n` +
+        `const s = 'CreateNodesV2';\n`;
+      expect(rewriteCreateNodesV2Types(input)).toBe(input);
+    });
+  });
+
+  describe('migration runner', () => {
+    it('rewrites type imports across .ts/.tsx/.cts/.mts files', async () => {
+      tree.write(
+        'libs/foo/src/a.ts',
+        `import type { CreateNodesV2 } from '@nx/devkit';\n`
+      );
+      tree.write(
+        'libs/foo/src/b.tsx',
+        `import { NxPluginV2 } from '@nx/devkit';\n`
+      );
+      tree.write(
+        'libs/foo/src/c.cts',
+        `export type { CreateNodesContextV2 } from '@nx/devkit';\n`
+      );
+      tree.write(
+        'libs/foo/src/d.mts',
+        `import type { CreateNodesResultV2 } from '@nx/devkit';\n`
+      );
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/a.ts', 'utf-8')).toContain(
+        `import type { CreateNodes } from '@nx/devkit';`
+      );
+      expect(tree.read('libs/foo/src/b.tsx', 'utf-8')).toContain(
+        `import { NxPlugin } from '@nx/devkit';`
+      );
+      expect(tree.read('libs/foo/src/c.cts', 'utf-8')).toContain(
+        `export type { CreateNodesContext } from '@nx/devkit';`
+      );
+      expect(tree.read('libs/foo/src/d.mts', 'utf-8')).toContain(
+        `import type { CreateNodesResultArray } from '@nx/devkit';`
+      );
+    });
+
+    it('does not rewrite non-TS files', async () => {
+      const md = `Example: \`import type { CreateNodesV2 } from '@nx/devkit';\`\n`;
+      tree.write('docs/example.md', md);
+
+      await migration(tree);
+
+      expect(tree.read('docs/example.md', 'utf-8')).toContain(
+        `import type { CreateNodesV2 } from '@nx/devkit';`
+      );
+    });
+  });
+});

--- a/packages/devkit/src/migrations/update-23-0-0/rename-create-nodes-v2-types.ts
+++ b/packages/devkit/src/migrations/update-23-0-0/rename-create-nodes-v2-types.ts
@@ -1,0 +1,199 @@
+import { logger, type Tree } from 'nx/src/devkit-exports';
+import type {
+  ExportDeclaration,
+  ExportSpecifier,
+  ImportDeclaration,
+  ImportSpecifier,
+  NamedExports,
+  NamedImports,
+  SourceFile,
+} from 'typescript';
+import { formatFiles } from '../../generators/format-files';
+import { visitNotIgnoredFiles } from '../../generators/visit-not-ignored-files';
+import { ensurePackage } from '../../utils/package-json';
+import {
+  applyChangesToString,
+  ChangeType,
+  type StringChange,
+} from '../../utils/string-change';
+import { typescriptVersion } from '../../utils/versions';
+
+const TS_EXTENSIONS = ['.ts', '.tsx', '.cts', '.mts'] as const;
+const DEVKIT_SPECIFIER = '@nx/devkit';
+
+// The `*V2` plugin types were renamed to their canonical un-suffixed names in
+// Nx 23. The `V2` names remain as `@deprecated` aliases, so this migration only
+// moves callers onto the canonical names. (`CreateNodesResultV2` is renamed to
+// `CreateNodesResultArray`, not `CreateNodesResult`, which is an unrelated type.)
+export const CREATE_NODES_V2_TYPE_RENAMES: ReadonlyMap<string, string> =
+  new Map([
+    ['CreateNodesV2', 'CreateNodes'],
+    ['CreateNodesContextV2', 'CreateNodesContext'],
+    ['CreateNodesResultV2', 'CreateNodesResultArray'],
+    ['CreateNodesFunctionV2', 'CreateNodesFunction'],
+    ['NxPluginV2', 'NxPlugin'],
+  ]);
+
+let ts: typeof import('typescript') | undefined;
+
+export default async function renameCreateNodesV2Types(
+  tree: Tree
+): Promise<void> {
+  let touchedCount = 0;
+
+  visitNotIgnoredFiles(tree, '.', (filePath) => {
+    if (!TS_EXTENSIONS.some((ext) => filePath.endsWith(ext))) {
+      return;
+    }
+    const original = tree.read(filePath, 'utf-8');
+    if (!original || !original.includes('V2')) {
+      return;
+    }
+    const updated = rewriteCreateNodesV2Types(original);
+    if (updated !== original) {
+      tree.write(filePath, updated);
+      touchedCount += 1;
+    }
+  });
+
+  if (touchedCount > 0) {
+    logger.info(
+      `Renamed deprecated CreateNodes V2 type imports from @nx/devkit in ${touchedCount} file(s).`
+    );
+  }
+
+  await formatFiles(tree);
+}
+
+/**
+ * Rewrites named imports and re-exports of the deprecated `*V2` plugin types
+ * from `@nx/devkit` to their canonical names. Only the named bindings are
+ * touched — the module specifier, the `import`/`export` keyword, any `type`
+ * modifier, and any default import are left untouched.
+ */
+export function rewriteCreateNodesV2Types(source: string): string {
+  ts ??= ensurePackage<typeof import('typescript')>(
+    'typescript',
+    typescriptVersion
+  );
+  const sourceFile = ts.createSourceFile(
+    'tmp.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TSX
+  );
+
+  const changes: StringChange[] = [];
+  for (const stmt of sourceFile.statements) {
+    if (ts.isImportDeclaration(stmt)) {
+      collectImportRewrite(sourceFile, stmt, changes);
+    } else if (ts.isExportDeclaration(stmt)) {
+      collectExportRewrite(sourceFile, stmt, changes);
+    }
+  }
+
+  return changes.length > 0 ? applyChangesToString(source, changes) : source;
+}
+
+function isDevkitSpecifier(
+  node: ImportDeclaration['moduleSpecifier']
+): boolean {
+  return ts!.isStringLiteral(node) && node.text === DEVKIT_SPECIFIER;
+}
+
+function collectImportRewrite(
+  sourceFile: SourceFile,
+  stmt: ImportDeclaration,
+  changes: StringChange[]
+): void {
+  if (!isDevkitSpecifier(stmt.moduleSpecifier)) {
+    return;
+  }
+  const namedBindings = stmt.importClause?.namedBindings;
+  if (!namedBindings || !ts!.isNamedImports(namedBindings)) {
+    return;
+  }
+  rewriteNamedBindings(sourceFile, namedBindings, changes);
+}
+
+function collectExportRewrite(
+  sourceFile: SourceFile,
+  stmt: ExportDeclaration,
+  changes: StringChange[]
+): void {
+  if (!stmt.moduleSpecifier || !isDevkitSpecifier(stmt.moduleSpecifier)) {
+    return;
+  }
+  if (!stmt.exportClause || !ts!.isNamedExports(stmt.exportClause)) {
+    return;
+  }
+  rewriteNamedBindings(sourceFile, stmt.exportClause, changes);
+}
+
+/**
+ * Re-renders the `{ ... }` of a named import/export, renaming any deprecated
+ * `*V2` type to its canonical name. If renaming would collide with a canonical
+ * name that is already present, the duplicate is dropped. Returns without
+ * recording a change when the binding list contains none of the renamed types.
+ */
+function rewriteNamedBindings(
+  sourceFile: SourceFile,
+  namedBindings: NamedImports | NamedExports,
+  changes: StringChange[]
+): void {
+  const elements = namedBindings.elements as readonly (
+    | ImportSpecifier
+    | ExportSpecifier
+  )[];
+  const hasRenamed = elements.some((el) =>
+    CREATE_NODES_V2_TYPE_RENAMES.has((el.propertyName ?? el.name).text)
+  );
+  if (!hasRenamed) {
+    return;
+  }
+
+  const seen = new Set<string>();
+  const rendered: string[] = [];
+  for (const el of elements) {
+    const text = renderSpecifier(el);
+    if (!seen.has(text)) {
+      seen.add(text);
+      rendered.push(text);
+    }
+  }
+
+  const start = namedBindings.getStart(sourceFile);
+  changes.push(
+    {
+      type: ChangeType.Delete,
+      start,
+      length: namedBindings.getEnd() - start,
+    },
+    {
+      type: ChangeType.Insert,
+      index: start,
+      text: `{ ${rendered.join(', ')} }`,
+    }
+  );
+}
+
+function renderSpecifier(el: ImportSpecifier | ExportSpecifier): string {
+  const typePrefix = el.isTypeOnly ? 'type ' : '';
+  const rename = (name: string) =>
+    CREATE_NODES_V2_TYPE_RENAMES.get(name) ?? name;
+
+  // `{ name }` — no alias, so the local binding follows the rename.
+  if (!el.propertyName) {
+    return `${typePrefix}${rename(el.name.text)}`;
+  }
+
+  // `{ propertyName as name }` — only the imported (left) side is renamed; the
+  // local alias is preserved. A now-redundant alias such as
+  // `CreateNodesV2 as CreateNodes` collapses to `CreateNodes`.
+  const canonicalImported = rename(el.propertyName.text);
+  const localName = el.name.text;
+  return canonicalImported === localName
+    ? `${typePrefix}${localName}`
+    : `${typePrefix}${canonicalImported} as ${localName}`;
+}

--- a/packages/docker/migrations.json
+++ b/packages/docker/migrations.json
@@ -1,7 +1,7 @@
 {
   "generators": {
     "update-23-0-0-migrate-create-nodes-v2-import": {
-      "version": "23.0.0-beta.5",
+      "version": "23.0.0-beta.24",
       "description": "Rename imports of `createNodesV2` from `@nx/docker` to the canonical `createNodes` export.",
       "implementation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
       "documentation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"

--- a/packages/docker/migrations.json
+++ b/packages/docker/migrations.json
@@ -1,1 +1,10 @@
-{}
+{
+  "generators": {
+    "update-23-0-0-migrate-create-nodes-v2-import": {
+      "version": "23.0.0-beta.5",
+      "description": "Rename imports of `createNodesV2` from `@nx/docker` to the canonical `createNodes` export.",
+      "implementation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
+      "documentation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"
+    }
+  }
+}

--- a/packages/docker/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md
+++ b/packages/docker/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md
@@ -1,0 +1,25 @@
+#### Rename `createNodesV2` imports to `createNodes`
+
+`@nx/docker` renamed its primary inferred-plugin export from `createNodesV2` to `createNodes`. The `createNodesV2` name is preserved as a deprecated alias for now, but new code should use `createNodes`.
+
+This migration scans every `.ts`, `.tsx`, `.cts`, and `.mts` file in your workspace and rewrites named imports and re-exports of `createNodesV2` from `@nx/docker` to `createNodes`.
+
+#### Sample Code Changes
+
+##### Before
+
+```ts
+import { createNodesV2 } from '@nx/docker';
+```
+
+##### After
+
+```ts
+import { createNodes } from '@nx/docker';
+```
+
+Aliases are preserved (`createNodesV2 as cn` becomes `createNodes as cn`), and if a file already imports both names (`{ createNodes, createNodesV2 }`) the redundant binding is dropped.
+
+#### What is not rewritten
+
+Only static `import`/`export` named bindings from `@nx/docker` are rewritten. Namespace imports, dynamic `import(...)`, `require(...)` destructuring, and property access such as `plugin.createNodesV2` are left untouched — they keep working through the `createNodesV2` runtime alias. Update those by hand if you want to drop the deprecated name everywhere.

--- a/packages/docker/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.spec.ts
+++ b/packages/docker/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.spec.ts
@@ -1,0 +1,191 @@
+import { type Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migration, {
+  rewriteCreateNodesV2Imports,
+} from './migrate-create-nodes-v2-to-create-nodes';
+
+const SPECIFIERS = new Set(['@nx/docker']);
+const rewrite = (source: string) =>
+  rewriteCreateNodesV2Imports(source, SPECIFIERS);
+
+describe('migrate-create-nodes-v2-to-create-nodes migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  describe('rewriteCreateNodesV2Imports', () => {
+    it('renames a lone createNodesV2 named import', () => {
+      const input = `import { createNodesV2 } from '@nx/docker';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/docker';\n`
+      );
+    });
+
+    it('preserves other named imports while renaming createNodesV2', () => {
+      const input = `import { createNodesV2, SomeOtherExport } from '@nx/docker';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes, SomeOtherExport } from '@nx/docker';\n`
+      );
+    });
+
+    it('rewrites the original name in `as` aliases', () => {
+      const input = `import { createNodesV2 as cn } from '@nx/docker';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes as cn } from '@nx/docker';\n`
+      );
+    });
+
+    it('collapses a redundant `createNodesV2 as createNodes` alias', () => {
+      const input = `import { createNodesV2 as createNodes } from '@nx/docker';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/docker';\n`
+      );
+    });
+
+    it('dedupes when both createNodes and createNodesV2 are imported', () => {
+      const input = `import { createNodes, createNodesV2 } from '@nx/docker';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/docker';\n`
+      );
+    });
+
+    it('dedupes when createNodesV2 precedes createNodes', () => {
+      const input = `import { createNodesV2, createNodes } from '@nx/docker';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/docker';\n`
+      );
+    });
+
+    it('handles multi-line named imports', () => {
+      const input = `import {\n  createNodes,\n  createNodesV2,\n  SomeOtherExport,\n} from '@nx/docker';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes, SomeOtherExport } from '@nx/docker';\n`
+      );
+    });
+
+    it('preserves a default import alongside the renamed binding', () => {
+      const input = `import def, { createNodesV2 } from '@nx/docker';\n`;
+      expect(rewrite(input)).toBe(
+        `import def, { createNodes } from '@nx/docker';\n`
+      );
+    });
+
+    it('handles `import type` declarations', () => {
+      const input = `import type { createNodesV2 } from '@nx/docker';\n`;
+      expect(rewrite(input)).toBe(
+        `import type { createNodes } from '@nx/docker';\n`
+      );
+    });
+
+    it('preserves inline `type` modifiers', () => {
+      const input = `import { type createNodesV2 } from '@nx/docker';\n`;
+      expect(rewrite(input)).toBe(
+        `import { type createNodes } from '@nx/docker';\n`
+      );
+    });
+
+    it('rewrites named re-exports', () => {
+      const input = `export { createNodesV2 } from '@nx/docker';\n`;
+      expect(rewrite(input)).toBe(
+        `export { createNodes } from '@nx/docker';\n`
+      );
+    });
+
+    it('rewrites aliased named re-exports', () => {
+      const input = `export { createNodesV2 as cn } from '@nx/docker';\n`;
+      expect(rewrite(input)).toBe(
+        `export { createNodes as cn } from '@nx/docker';\n`
+      );
+    });
+
+    it('does not touch createNodesV2 from a different specifier', () => {
+      const input = `import { createNodesV2 } from '@nx/other-plugin/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not touch createNodesV2 from a relative specifier', () => {
+      const input = `import { createNodesV2 } from './plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not touch unrelated imports from the target specifier', () => {
+      const input = `import { createNodes } from '@nx/docker';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not rewrite `export * from` declarations', () => {
+      const input = `export * from '@nx/docker';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('leaves createNodesV2 in strings and comments alone', () => {
+      const input =
+        `// import { createNodesV2 } from '@nx/docker';\n` +
+        `const s = "createNodesV2";\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not rewrite require() destructuring (still valid via alias)', () => {
+      const input = `const { createNodesV2 } = require('@nx/docker');\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+  });
+
+  describe('migration runner', () => {
+    it('rewrites imports across .ts/.tsx/.cts/.mts files', async () => {
+      tree.write(
+        'libs/foo/src/a.ts',
+        `import { createNodesV2 } from '@nx/docker';\n`
+      );
+      tree.write(
+        'libs/foo/src/b.tsx',
+        `import { createNodesV2 as cn } from '@nx/docker';\n`
+      );
+      tree.write(
+        'libs/foo/src/c.cts',
+        `export { createNodesV2 } from '@nx/docker';\n`
+      );
+      tree.write(
+        'libs/foo/src/d.mts',
+        `import { createNodesV2, SomeOtherExport } from '@nx/docker';\n`
+      );
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/a.ts', 'utf-8')).toContain(
+        `import { createNodes } from '@nx/docker';`
+      );
+      expect(tree.read('libs/foo/src/b.tsx', 'utf-8')).toContain(
+        `import { createNodes as cn } from '@nx/docker';`
+      );
+      expect(tree.read('libs/foo/src/c.cts', 'utf-8')).toContain(
+        `export { createNodes } from '@nx/docker';`
+      );
+      expect(tree.read('libs/foo/src/d.mts', 'utf-8')).toContain(
+        `import { createNodes, SomeOtherExport } from '@nx/docker';`
+      );
+    });
+
+    it('does not touch files without the deprecated name', async () => {
+      const content = `import { createNodes } from '@nx/docker';\n`;
+      tree.write('libs/foo/src/index.ts', content);
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/index.ts', 'utf-8')).toBe(content);
+    });
+
+    it('does not rewrite non-TS files', async () => {
+      const md = `Example: \`import { createNodesV2 } from '@nx/docker';\`\n`;
+      tree.write('docs/example.md', md);
+
+      await migration(tree);
+
+      expect(tree.read('docs/example.md', 'utf-8')).toContain(
+        `import { createNodesV2 } from '@nx/docker';`
+      );
+    });
+  });
+});

--- a/packages/docker/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.ts
+++ b/packages/docker/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.ts
@@ -1,0 +1,206 @@
+import {
+  applyChangesToString,
+  ChangeType,
+  ensurePackage,
+  formatFiles,
+  logger,
+  type StringChange,
+  type Tree,
+  visitNotIgnoredFiles,
+} from '@nx/devkit';
+import type {
+  ExportDeclaration,
+  ExportSpecifier,
+  ImportDeclaration,
+  ImportSpecifier,
+  NamedExports,
+  NamedImports,
+  SourceFile,
+} from 'typescript';
+
+const TS_EXTENSIONS = ['.ts', '.tsx', '.cts', '.mts'] as const;
+const DEPRECATED_NAME = 'createNodesV2';
+const CANONICAL_NAME = 'createNodes';
+
+// Module specifiers from which `@nx/docker` publicly exposes `createNodesV2`.
+// A named import or re-export of `createNodesV2` from one of these is rewritten
+// to the canonical `createNodes` export.
+const TARGET_SPECIFIERS: ReadonlySet<string> = new Set(['@nx/docker']);
+
+let ts: typeof import('typescript') | undefined;
+
+export default async function migrateCreateNodesV2ToCreateNodes(
+  tree: Tree
+): Promise<void> {
+  let touchedCount = 0;
+
+  visitNotIgnoredFiles(tree, '.', (filePath) => {
+    if (!TS_EXTENSIONS.some((ext) => filePath.endsWith(ext))) {
+      return;
+    }
+    const original = tree.read(filePath, 'utf-8');
+    if (!original || !original.includes(DEPRECATED_NAME)) {
+      return;
+    }
+    const updated = rewriteCreateNodesV2Imports(original, TARGET_SPECIFIERS);
+    if (updated !== original) {
+      tree.write(filePath, updated);
+      touchedCount += 1;
+    }
+  });
+
+  if (touchedCount > 0) {
+    logger.info(
+      `Renamed \`${DEPRECATED_NAME}\` imports to \`${CANONICAL_NAME}\` in ${touchedCount} file(s).`
+    );
+  }
+
+  await formatFiles(tree);
+}
+
+/**
+ * Rewrites named imports and re-exports of `createNodesV2` to `createNodes`
+ * when they come from one of the given module specifiers. Only the named
+ * bindings are touched — the module specifier, the `import`/`export` keyword,
+ * any `type` modifier, and any default import are left untouched.
+ */
+export function rewriteCreateNodesV2Imports(
+  source: string,
+  specifiers: ReadonlySet<string>
+): string {
+  ts ??= ensurePackage<typeof import('typescript')>('typescript', '*');
+  const sourceFile = ts.createSourceFile(
+    'tmp.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TSX
+  );
+
+  const changes: StringChange[] = [];
+  for (const stmt of sourceFile.statements) {
+    if (ts.isImportDeclaration(stmt)) {
+      collectImportRewrite(sourceFile, stmt, specifiers, changes);
+    } else if (ts.isExportDeclaration(stmt)) {
+      collectExportRewrite(sourceFile, stmt, specifiers, changes);
+    }
+  }
+
+  return changes.length > 0 ? applyChangesToString(source, changes) : source;
+}
+
+function isTargetSpecifier(
+  node: ImportDeclaration['moduleSpecifier'],
+  specifiers: ReadonlySet<string>
+): boolean {
+  return ts!.isStringLiteral(node) && specifiers.has(node.text);
+}
+
+function collectImportRewrite(
+  sourceFile: SourceFile,
+  stmt: ImportDeclaration,
+  specifiers: ReadonlySet<string>,
+  changes: StringChange[]
+): void {
+  if (!isTargetSpecifier(stmt.moduleSpecifier, specifiers)) {
+    return;
+  }
+  const namedBindings = stmt.importClause?.namedBindings;
+  // Only `import { ... }` carries renameable named bindings. `import x`,
+  // `import * as ns`, and side-effect imports reference the module wholesale
+  // and keep working through the `createNodesV2` runtime alias, so we leave
+  // them be. A mixed `import def, { createNodesV2 }` still has its named
+  // bindings rewritten below — the default binding is untouched.
+  if (!namedBindings || !ts!.isNamedImports(namedBindings)) {
+    return;
+  }
+  rewriteNamedBindings(sourceFile, namedBindings, changes);
+}
+
+function collectExportRewrite(
+  sourceFile: SourceFile,
+  stmt: ExportDeclaration,
+  specifiers: ReadonlySet<string>,
+  changes: StringChange[]
+): void {
+  if (
+    !stmt.moduleSpecifier ||
+    !isTargetSpecifier(stmt.moduleSpecifier, specifiers)
+  ) {
+    return;
+  }
+  // `export { ... } from '...'` can be rewritten; `export * from '...'` has no
+  // named bindings to rename.
+  if (!stmt.exportClause || !ts!.isNamedExports(stmt.exportClause)) {
+    return;
+  }
+  rewriteNamedBindings(sourceFile, stmt.exportClause, changes);
+}
+
+/**
+ * Re-renders the `{ ... }` of a named import/export, renaming any
+ * `createNodesV2` specifier to `createNodes`. If renaming would collide with a
+ * `createNodes` that is already present (e.g. `{ createNodes, createNodesV2 }`),
+ * the duplicate is dropped. Returns without recording a change when the binding
+ * list contains no `createNodesV2`.
+ */
+function rewriteNamedBindings(
+  sourceFile: SourceFile,
+  namedBindings: NamedImports | NamedExports,
+  changes: StringChange[]
+): void {
+  const elements = namedBindings.elements as readonly (
+    | ImportSpecifier
+    | ExportSpecifier
+  )[];
+  const hasDeprecated = elements.some(
+    (el) => (el.propertyName ?? el.name).text === DEPRECATED_NAME
+  );
+  if (!hasDeprecated) {
+    return;
+  }
+
+  const seen = new Set<string>();
+  const rendered: string[] = [];
+  for (const el of elements) {
+    const text = renderSpecifier(el);
+    if (!seen.has(text)) {
+      seen.add(text);
+      rendered.push(text);
+    }
+  }
+
+  const start = namedBindings.getStart(sourceFile);
+  changes.push(
+    {
+      type: ChangeType.Delete,
+      start,
+      length: namedBindings.getEnd() - start,
+    },
+    {
+      type: ChangeType.Insert,
+      index: start,
+      text: `{ ${rendered.join(', ')} }`,
+    }
+  );
+}
+
+function renderSpecifier(el: ImportSpecifier | ExportSpecifier): string {
+  const typePrefix = el.isTypeOnly ? 'type ' : '';
+  const rename = (name: string) =>
+    name === DEPRECATED_NAME ? CANONICAL_NAME : name;
+
+  // `{ name }` — no alias, so the local binding follows the rename.
+  if (!el.propertyName) {
+    return `${typePrefix}${rename(el.name.text)}`;
+  }
+
+  // `{ propertyName as name }` — only the imported (left) side is renamed; the
+  // local alias is preserved. A now-redundant alias such as
+  // `createNodesV2 as createNodes` collapses to `createNodes`.
+  const canonicalImported = rename(el.propertyName.text);
+  const localName = el.name.text;
+  return canonicalImported === localName
+    ? `${typePrefix}${localName}`
+    : `${typePrefix}${canonicalImported} as ${localName}`;
+}

--- a/packages/eslint/migrations.json
+++ b/packages/eslint/migrations.json
@@ -29,7 +29,7 @@
       "implementation": "./dist/src/migrations/update-23-0-0/rewrite-internal-subpath-imports"
     },
     "update-23-0-0-migrate-create-nodes-v2-import": {
-      "version": "23.0.0-beta.5",
+      "version": "23.0.0-beta.24",
       "description": "Rename imports of `createNodesV2` from `@nx/eslint/plugin` to the canonical `createNodes` export.",
       "implementation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
       "documentation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"

--- a/packages/eslint/migrations.json
+++ b/packages/eslint/migrations.json
@@ -27,6 +27,12 @@
       "version": "23.0.0-beta.17",
       "description": "Rewrites `@nx/eslint/src/*` subpath imports now that the `./src/*` subpath is no longer exposed by `@nx/eslint`'s exports map. Named imports/exports of public symbols are routed to `@nx/eslint` and the rest to the new `@nx/eslint/internal` entry; `require`, dynamic `import` and `jest.mock` calls reference the whole module and are routed to `@nx/eslint/internal`.",
       "implementation": "./dist/src/migrations/update-23-0-0/rewrite-internal-subpath-imports"
+    },
+    "update-23-0-0-migrate-create-nodes-v2-import": {
+      "version": "23.0.0-beta.5",
+      "description": "Rename imports of `createNodesV2` from `@nx/eslint/plugin` to the canonical `createNodes` export.",
+      "implementation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
+      "documentation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"
     }
   },
   "packageJsonUpdates": {

--- a/packages/eslint/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md
+++ b/packages/eslint/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md
@@ -1,0 +1,25 @@
+#### Rename `createNodesV2` imports to `createNodes`
+
+`@nx/eslint` renamed its primary inferred-plugin export from `createNodesV2` to `createNodes`. The `createNodesV2` name is preserved as a deprecated alias for now, but new code should use `createNodes`.
+
+This migration scans every `.ts`, `.tsx`, `.cts`, and `.mts` file in your workspace and rewrites named imports and re-exports of `createNodesV2` from `@nx/eslint/plugin` to `createNodes`.
+
+#### Sample Code Changes
+
+##### Before
+
+```ts
+import { createNodesV2 } from '@nx/eslint/plugin';
+```
+
+##### After
+
+```ts
+import { createNodes } from '@nx/eslint/plugin';
+```
+
+Aliases are preserved (`createNodesV2 as cn` becomes `createNodes as cn`), and if a file already imports both names (`{ createNodes, createNodesV2 }`) the redundant binding is dropped.
+
+#### What is not rewritten
+
+Only static `import`/`export` named bindings from `@nx/eslint/plugin` are rewritten. Namespace imports, dynamic `import(...)`, `require(...)` destructuring, and property access such as `plugin.createNodesV2` are left untouched — they keep working through the `createNodesV2` runtime alias. Update those by hand if you want to drop the deprecated name everywhere.

--- a/packages/eslint/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.spec.ts
+++ b/packages/eslint/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.spec.ts
@@ -1,0 +1,191 @@
+import { type Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migration, {
+  rewriteCreateNodesV2Imports,
+} from './migrate-create-nodes-v2-to-create-nodes';
+
+const SPECIFIERS = new Set(['@nx/eslint/plugin']);
+const rewrite = (source: string) =>
+  rewriteCreateNodesV2Imports(source, SPECIFIERS);
+
+describe('migrate-create-nodes-v2-to-create-nodes migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  describe('rewriteCreateNodesV2Imports', () => {
+    it('renames a lone createNodesV2 named import', () => {
+      const input = `import { createNodesV2 } from '@nx/eslint/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/eslint/plugin';\n`
+      );
+    });
+
+    it('preserves other named imports while renaming createNodesV2', () => {
+      const input = `import { createNodesV2, SomeOtherExport } from '@nx/eslint/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes, SomeOtherExport } from '@nx/eslint/plugin';\n`
+      );
+    });
+
+    it('rewrites the original name in `as` aliases', () => {
+      const input = `import { createNodesV2 as cn } from '@nx/eslint/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes as cn } from '@nx/eslint/plugin';\n`
+      );
+    });
+
+    it('collapses a redundant `createNodesV2 as createNodes` alias', () => {
+      const input = `import { createNodesV2 as createNodes } from '@nx/eslint/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/eslint/plugin';\n`
+      );
+    });
+
+    it('dedupes when both createNodes and createNodesV2 are imported', () => {
+      const input = `import { createNodes, createNodesV2 } from '@nx/eslint/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/eslint/plugin';\n`
+      );
+    });
+
+    it('dedupes when createNodesV2 precedes createNodes', () => {
+      const input = `import { createNodesV2, createNodes } from '@nx/eslint/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/eslint/plugin';\n`
+      );
+    });
+
+    it('handles multi-line named imports', () => {
+      const input = `import {\n  createNodes,\n  createNodesV2,\n  SomeOtherExport,\n} from '@nx/eslint/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes, SomeOtherExport } from '@nx/eslint/plugin';\n`
+      );
+    });
+
+    it('preserves a default import alongside the renamed binding', () => {
+      const input = `import def, { createNodesV2 } from '@nx/eslint/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import def, { createNodes } from '@nx/eslint/plugin';\n`
+      );
+    });
+
+    it('handles `import type` declarations', () => {
+      const input = `import type { createNodesV2 } from '@nx/eslint/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import type { createNodes } from '@nx/eslint/plugin';\n`
+      );
+    });
+
+    it('preserves inline `type` modifiers', () => {
+      const input = `import { type createNodesV2 } from '@nx/eslint/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { type createNodes } from '@nx/eslint/plugin';\n`
+      );
+    });
+
+    it('rewrites named re-exports', () => {
+      const input = `export { createNodesV2 } from '@nx/eslint/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `export { createNodes } from '@nx/eslint/plugin';\n`
+      );
+    });
+
+    it('rewrites aliased named re-exports', () => {
+      const input = `export { createNodesV2 as cn } from '@nx/eslint/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `export { createNodes as cn } from '@nx/eslint/plugin';\n`
+      );
+    });
+
+    it('does not touch createNodesV2 from a different specifier', () => {
+      const input = `import { createNodesV2 } from '@nx/other-plugin/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not touch createNodesV2 from a relative specifier', () => {
+      const input = `import { createNodesV2 } from './plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not touch unrelated imports from the target specifier', () => {
+      const input = `import { createNodes } from '@nx/eslint/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not rewrite `export * from` declarations', () => {
+      const input = `export * from '@nx/eslint/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('leaves createNodesV2 in strings and comments alone', () => {
+      const input =
+        `// import { createNodesV2 } from '@nx/eslint/plugin';\n` +
+        `const s = "createNodesV2";\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not rewrite require() destructuring (still valid via alias)', () => {
+      const input = `const { createNodesV2 } = require('@nx/eslint/plugin');\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+  });
+
+  describe('migration runner', () => {
+    it('rewrites imports across .ts/.tsx/.cts/.mts files', async () => {
+      tree.write(
+        'libs/foo/src/a.ts',
+        `import { createNodesV2 } from '@nx/eslint/plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/b.tsx',
+        `import { createNodesV2 as cn } from '@nx/eslint/plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/c.cts',
+        `export { createNodesV2 } from '@nx/eslint/plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/d.mts',
+        `import { createNodesV2, SomeOtherExport } from '@nx/eslint/plugin';\n`
+      );
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/a.ts', 'utf-8')).toContain(
+        `import { createNodes } from '@nx/eslint/plugin';`
+      );
+      expect(tree.read('libs/foo/src/b.tsx', 'utf-8')).toContain(
+        `import { createNodes as cn } from '@nx/eslint/plugin';`
+      );
+      expect(tree.read('libs/foo/src/c.cts', 'utf-8')).toContain(
+        `export { createNodes } from '@nx/eslint/plugin';`
+      );
+      expect(tree.read('libs/foo/src/d.mts', 'utf-8')).toContain(
+        `import { createNodes, SomeOtherExport } from '@nx/eslint/plugin';`
+      );
+    });
+
+    it('does not touch files without the deprecated name', async () => {
+      const content = `import { createNodes } from '@nx/eslint/plugin';\n`;
+      tree.write('libs/foo/src/index.ts', content);
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/index.ts', 'utf-8')).toBe(content);
+    });
+
+    it('does not rewrite non-TS files', async () => {
+      const md = `Example: \`import { createNodesV2 } from '@nx/eslint/plugin';\`\n`;
+      tree.write('docs/example.md', md);
+
+      await migration(tree);
+
+      expect(tree.read('docs/example.md', 'utf-8')).toContain(
+        `import { createNodesV2 } from '@nx/eslint/plugin';`
+      );
+    });
+  });
+});

--- a/packages/eslint/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.ts
+++ b/packages/eslint/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.ts
@@ -1,0 +1,206 @@
+import {
+  applyChangesToString,
+  ChangeType,
+  ensurePackage,
+  formatFiles,
+  logger,
+  type StringChange,
+  type Tree,
+  visitNotIgnoredFiles,
+} from '@nx/devkit';
+import type {
+  ExportDeclaration,
+  ExportSpecifier,
+  ImportDeclaration,
+  ImportSpecifier,
+  NamedExports,
+  NamedImports,
+  SourceFile,
+} from 'typescript';
+
+const TS_EXTENSIONS = ['.ts', '.tsx', '.cts', '.mts'] as const;
+const DEPRECATED_NAME = 'createNodesV2';
+const CANONICAL_NAME = 'createNodes';
+
+// Module specifiers from which `@nx/eslint` publicly exposes `createNodesV2`.
+// A named import or re-export of `createNodesV2` from one of these is rewritten
+// to the canonical `createNodes` export.
+const TARGET_SPECIFIERS: ReadonlySet<string> = new Set(['@nx/eslint/plugin']);
+
+let ts: typeof import('typescript') | undefined;
+
+export default async function migrateCreateNodesV2ToCreateNodes(
+  tree: Tree
+): Promise<void> {
+  let touchedCount = 0;
+
+  visitNotIgnoredFiles(tree, '.', (filePath) => {
+    if (!TS_EXTENSIONS.some((ext) => filePath.endsWith(ext))) {
+      return;
+    }
+    const original = tree.read(filePath, 'utf-8');
+    if (!original || !original.includes(DEPRECATED_NAME)) {
+      return;
+    }
+    const updated = rewriteCreateNodesV2Imports(original, TARGET_SPECIFIERS);
+    if (updated !== original) {
+      tree.write(filePath, updated);
+      touchedCount += 1;
+    }
+  });
+
+  if (touchedCount > 0) {
+    logger.info(
+      `Renamed \`${DEPRECATED_NAME}\` imports to \`${CANONICAL_NAME}\` in ${touchedCount} file(s).`
+    );
+  }
+
+  await formatFiles(tree);
+}
+
+/**
+ * Rewrites named imports and re-exports of `createNodesV2` to `createNodes`
+ * when they come from one of the given module specifiers. Only the named
+ * bindings are touched — the module specifier, the `import`/`export` keyword,
+ * any `type` modifier, and any default import are left untouched.
+ */
+export function rewriteCreateNodesV2Imports(
+  source: string,
+  specifiers: ReadonlySet<string>
+): string {
+  ts ??= ensurePackage<typeof import('typescript')>('typescript', '*');
+  const sourceFile = ts.createSourceFile(
+    'tmp.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TSX
+  );
+
+  const changes: StringChange[] = [];
+  for (const stmt of sourceFile.statements) {
+    if (ts.isImportDeclaration(stmt)) {
+      collectImportRewrite(sourceFile, stmt, specifiers, changes);
+    } else if (ts.isExportDeclaration(stmt)) {
+      collectExportRewrite(sourceFile, stmt, specifiers, changes);
+    }
+  }
+
+  return changes.length > 0 ? applyChangesToString(source, changes) : source;
+}
+
+function isTargetSpecifier(
+  node: ImportDeclaration['moduleSpecifier'],
+  specifiers: ReadonlySet<string>
+): boolean {
+  return ts!.isStringLiteral(node) && specifiers.has(node.text);
+}
+
+function collectImportRewrite(
+  sourceFile: SourceFile,
+  stmt: ImportDeclaration,
+  specifiers: ReadonlySet<string>,
+  changes: StringChange[]
+): void {
+  if (!isTargetSpecifier(stmt.moduleSpecifier, specifiers)) {
+    return;
+  }
+  const namedBindings = stmt.importClause?.namedBindings;
+  // Only `import { ... }` carries renameable named bindings. `import x`,
+  // `import * as ns`, and side-effect imports reference the module wholesale
+  // and keep working through the `createNodesV2` runtime alias, so we leave
+  // them be. A mixed `import def, { createNodesV2 }` still has its named
+  // bindings rewritten below — the default binding is untouched.
+  if (!namedBindings || !ts!.isNamedImports(namedBindings)) {
+    return;
+  }
+  rewriteNamedBindings(sourceFile, namedBindings, changes);
+}
+
+function collectExportRewrite(
+  sourceFile: SourceFile,
+  stmt: ExportDeclaration,
+  specifiers: ReadonlySet<string>,
+  changes: StringChange[]
+): void {
+  if (
+    !stmt.moduleSpecifier ||
+    !isTargetSpecifier(stmt.moduleSpecifier, specifiers)
+  ) {
+    return;
+  }
+  // `export { ... } from '...'` can be rewritten; `export * from '...'` has no
+  // named bindings to rename.
+  if (!stmt.exportClause || !ts!.isNamedExports(stmt.exportClause)) {
+    return;
+  }
+  rewriteNamedBindings(sourceFile, stmt.exportClause, changes);
+}
+
+/**
+ * Re-renders the `{ ... }` of a named import/export, renaming any
+ * `createNodesV2` specifier to `createNodes`. If renaming would collide with a
+ * `createNodes` that is already present (e.g. `{ createNodes, createNodesV2 }`),
+ * the duplicate is dropped. Returns without recording a change when the binding
+ * list contains no `createNodesV2`.
+ */
+function rewriteNamedBindings(
+  sourceFile: SourceFile,
+  namedBindings: NamedImports | NamedExports,
+  changes: StringChange[]
+): void {
+  const elements = namedBindings.elements as readonly (
+    | ImportSpecifier
+    | ExportSpecifier
+  )[];
+  const hasDeprecated = elements.some(
+    (el) => (el.propertyName ?? el.name).text === DEPRECATED_NAME
+  );
+  if (!hasDeprecated) {
+    return;
+  }
+
+  const seen = new Set<string>();
+  const rendered: string[] = [];
+  for (const el of elements) {
+    const text = renderSpecifier(el);
+    if (!seen.has(text)) {
+      seen.add(text);
+      rendered.push(text);
+    }
+  }
+
+  const start = namedBindings.getStart(sourceFile);
+  changes.push(
+    {
+      type: ChangeType.Delete,
+      start,
+      length: namedBindings.getEnd() - start,
+    },
+    {
+      type: ChangeType.Insert,
+      index: start,
+      text: `{ ${rendered.join(', ')} }`,
+    }
+  );
+}
+
+function renderSpecifier(el: ImportSpecifier | ExportSpecifier): string {
+  const typePrefix = el.isTypeOnly ? 'type ' : '';
+  const rename = (name: string) =>
+    name === DEPRECATED_NAME ? CANONICAL_NAME : name;
+
+  // `{ name }` — no alias, so the local binding follows the rename.
+  if (!el.propertyName) {
+    return `${typePrefix}${rename(el.name.text)}`;
+  }
+
+  // `{ propertyName as name }` — only the imported (left) side is renamed; the
+  // local alias is preserved. A now-redundant alias such as
+  // `createNodesV2 as createNodes` collapses to `createNodes`.
+  const canonicalImported = rename(el.propertyName.text);
+  const localName = el.name.text;
+  return canonicalImported === localName
+    ? `${typePrefix}${localName}`
+    : `${typePrefix}${canonicalImported} as ${localName}`;
+}

--- a/packages/expo/migrations.json
+++ b/packages/expo/migrations.json
@@ -38,6 +38,12 @@
       "cli": "nx",
       "description": "Update Jest configuration for Expo SDK 54",
       "factory": "./src/migrations/update-22-2-0/update-jest-for-expo-54"
+    },
+    "update-23-0-0-migrate-create-nodes-v2-import": {
+      "version": "23.0.0-beta.5",
+      "description": "Rename imports of `createNodesV2` from `@nx/expo/plugin` to the canonical `createNodes` export.",
+      "implementation": "./src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
+      "documentation": "./src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"
     }
   },
   "packageJsonUpdates": {

--- a/packages/expo/migrations.json
+++ b/packages/expo/migrations.json
@@ -40,7 +40,7 @@
       "factory": "./src/migrations/update-22-2-0/update-jest-for-expo-54"
     },
     "update-23-0-0-migrate-create-nodes-v2-import": {
-      "version": "23.0.0-beta.5",
+      "version": "23.0.0-beta.24",
       "description": "Rename imports of `createNodesV2` from `@nx/expo/plugin` to the canonical `createNodes` export.",
       "implementation": "./src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
       "documentation": "./src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"

--- a/packages/expo/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md
+++ b/packages/expo/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md
@@ -1,0 +1,25 @@
+#### Rename `createNodesV2` imports to `createNodes`
+
+`@nx/expo` renamed its primary inferred-plugin export from `createNodesV2` to `createNodes`. The `createNodesV2` name is preserved as a deprecated alias for now, but new code should use `createNodes`.
+
+This migration scans every `.ts`, `.tsx`, `.cts`, and `.mts` file in your workspace and rewrites named imports and re-exports of `createNodesV2` from `@nx/expo/plugin` to `createNodes`.
+
+#### Sample Code Changes
+
+##### Before
+
+```ts
+import { createNodesV2 } from '@nx/expo/plugin';
+```
+
+##### After
+
+```ts
+import { createNodes } from '@nx/expo/plugin';
+```
+
+Aliases are preserved (`createNodesV2 as cn` becomes `createNodes as cn`), and if a file already imports both names (`{ createNodes, createNodesV2 }`) the redundant binding is dropped.
+
+#### What is not rewritten
+
+Only static `import`/`export` named bindings from `@nx/expo/plugin` are rewritten. Namespace imports, dynamic `import(...)`, `require(...)` destructuring, and property access such as `plugin.createNodesV2` are left untouched — they keep working through the `createNodesV2` runtime alias. Update those by hand if you want to drop the deprecated name everywhere.

--- a/packages/expo/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.spec.ts
+++ b/packages/expo/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.spec.ts
@@ -1,0 +1,191 @@
+import { type Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migration, {
+  rewriteCreateNodesV2Imports,
+} from './migrate-create-nodes-v2-to-create-nodes';
+
+const SPECIFIERS = new Set(['@nx/expo/plugin']);
+const rewrite = (source: string) =>
+  rewriteCreateNodesV2Imports(source, SPECIFIERS);
+
+describe('migrate-create-nodes-v2-to-create-nodes migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  describe('rewriteCreateNodesV2Imports', () => {
+    it('renames a lone createNodesV2 named import', () => {
+      const input = `import { createNodesV2 } from '@nx/expo/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/expo/plugin';\n`
+      );
+    });
+
+    it('preserves other named imports while renaming createNodesV2', () => {
+      const input = `import { createNodesV2, SomeOtherExport } from '@nx/expo/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes, SomeOtherExport } from '@nx/expo/plugin';\n`
+      );
+    });
+
+    it('rewrites the original name in `as` aliases', () => {
+      const input = `import { createNodesV2 as cn } from '@nx/expo/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes as cn } from '@nx/expo/plugin';\n`
+      );
+    });
+
+    it('collapses a redundant `createNodesV2 as createNodes` alias', () => {
+      const input = `import { createNodesV2 as createNodes } from '@nx/expo/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/expo/plugin';\n`
+      );
+    });
+
+    it('dedupes when both createNodes and createNodesV2 are imported', () => {
+      const input = `import { createNodes, createNodesV2 } from '@nx/expo/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/expo/plugin';\n`
+      );
+    });
+
+    it('dedupes when createNodesV2 precedes createNodes', () => {
+      const input = `import { createNodesV2, createNodes } from '@nx/expo/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/expo/plugin';\n`
+      );
+    });
+
+    it('handles multi-line named imports', () => {
+      const input = `import {\n  createNodes,\n  createNodesV2,\n  SomeOtherExport,\n} from '@nx/expo/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes, SomeOtherExport } from '@nx/expo/plugin';\n`
+      );
+    });
+
+    it('preserves a default import alongside the renamed binding', () => {
+      const input = `import def, { createNodesV2 } from '@nx/expo/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import def, { createNodes } from '@nx/expo/plugin';\n`
+      );
+    });
+
+    it('handles `import type` declarations', () => {
+      const input = `import type { createNodesV2 } from '@nx/expo/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import type { createNodes } from '@nx/expo/plugin';\n`
+      );
+    });
+
+    it('preserves inline `type` modifiers', () => {
+      const input = `import { type createNodesV2 } from '@nx/expo/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { type createNodes } from '@nx/expo/plugin';\n`
+      );
+    });
+
+    it('rewrites named re-exports', () => {
+      const input = `export { createNodesV2 } from '@nx/expo/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `export { createNodes } from '@nx/expo/plugin';\n`
+      );
+    });
+
+    it('rewrites aliased named re-exports', () => {
+      const input = `export { createNodesV2 as cn } from '@nx/expo/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `export { createNodes as cn } from '@nx/expo/plugin';\n`
+      );
+    });
+
+    it('does not touch createNodesV2 from a different specifier', () => {
+      const input = `import { createNodesV2 } from '@nx/other-plugin/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not touch createNodesV2 from a relative specifier', () => {
+      const input = `import { createNodesV2 } from './plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not touch unrelated imports from the target specifier', () => {
+      const input = `import { createNodes } from '@nx/expo/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not rewrite `export * from` declarations', () => {
+      const input = `export * from '@nx/expo/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('leaves createNodesV2 in strings and comments alone', () => {
+      const input =
+        `// import { createNodesV2 } from '@nx/expo/plugin';\n` +
+        `const s = "createNodesV2";\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not rewrite require() destructuring (still valid via alias)', () => {
+      const input = `const { createNodesV2 } = require('@nx/expo/plugin');\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+  });
+
+  describe('migration runner', () => {
+    it('rewrites imports across .ts/.tsx/.cts/.mts files', async () => {
+      tree.write(
+        'libs/foo/src/a.ts',
+        `import { createNodesV2 } from '@nx/expo/plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/b.tsx',
+        `import { createNodesV2 as cn } from '@nx/expo/plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/c.cts',
+        `export { createNodesV2 } from '@nx/expo/plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/d.mts',
+        `import { createNodesV2, SomeOtherExport } from '@nx/expo/plugin';\n`
+      );
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/a.ts', 'utf-8')).toContain(
+        `import { createNodes } from '@nx/expo/plugin';`
+      );
+      expect(tree.read('libs/foo/src/b.tsx', 'utf-8')).toContain(
+        `import { createNodes as cn } from '@nx/expo/plugin';`
+      );
+      expect(tree.read('libs/foo/src/c.cts', 'utf-8')).toContain(
+        `export { createNodes } from '@nx/expo/plugin';`
+      );
+      expect(tree.read('libs/foo/src/d.mts', 'utf-8')).toContain(
+        `import { createNodes, SomeOtherExport } from '@nx/expo/plugin';`
+      );
+    });
+
+    it('does not touch files without the deprecated name', async () => {
+      const content = `import { createNodes } from '@nx/expo/plugin';\n`;
+      tree.write('libs/foo/src/index.ts', content);
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/index.ts', 'utf-8')).toBe(content);
+    });
+
+    it('does not rewrite non-TS files', async () => {
+      const md = `Example: \`import { createNodesV2 } from '@nx/expo/plugin';\`\n`;
+      tree.write('docs/example.md', md);
+
+      await migration(tree);
+
+      expect(tree.read('docs/example.md', 'utf-8')).toContain(
+        `import { createNodesV2 } from '@nx/expo/plugin';`
+      );
+    });
+  });
+});

--- a/packages/expo/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.ts
+++ b/packages/expo/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.ts
@@ -1,0 +1,206 @@
+import {
+  applyChangesToString,
+  ChangeType,
+  ensurePackage,
+  formatFiles,
+  logger,
+  type StringChange,
+  type Tree,
+  visitNotIgnoredFiles,
+} from '@nx/devkit';
+import type {
+  ExportDeclaration,
+  ExportSpecifier,
+  ImportDeclaration,
+  ImportSpecifier,
+  NamedExports,
+  NamedImports,
+  SourceFile,
+} from 'typescript';
+
+const TS_EXTENSIONS = ['.ts', '.tsx', '.cts', '.mts'] as const;
+const DEPRECATED_NAME = 'createNodesV2';
+const CANONICAL_NAME = 'createNodes';
+
+// Module specifiers from which `@nx/expo` publicly exposes `createNodesV2`.
+// A named import or re-export of `createNodesV2` from one of these is rewritten
+// to the canonical `createNodes` export.
+const TARGET_SPECIFIERS: ReadonlySet<string> = new Set(['@nx/expo/plugin']);
+
+let ts: typeof import('typescript') | undefined;
+
+export default async function migrateCreateNodesV2ToCreateNodes(
+  tree: Tree
+): Promise<void> {
+  let touchedCount = 0;
+
+  visitNotIgnoredFiles(tree, '.', (filePath) => {
+    if (!TS_EXTENSIONS.some((ext) => filePath.endsWith(ext))) {
+      return;
+    }
+    const original = tree.read(filePath, 'utf-8');
+    if (!original || !original.includes(DEPRECATED_NAME)) {
+      return;
+    }
+    const updated = rewriteCreateNodesV2Imports(original, TARGET_SPECIFIERS);
+    if (updated !== original) {
+      tree.write(filePath, updated);
+      touchedCount += 1;
+    }
+  });
+
+  if (touchedCount > 0) {
+    logger.info(
+      `Renamed \`${DEPRECATED_NAME}\` imports to \`${CANONICAL_NAME}\` in ${touchedCount} file(s).`
+    );
+  }
+
+  await formatFiles(tree);
+}
+
+/**
+ * Rewrites named imports and re-exports of `createNodesV2` to `createNodes`
+ * when they come from one of the given module specifiers. Only the named
+ * bindings are touched — the module specifier, the `import`/`export` keyword,
+ * any `type` modifier, and any default import are left untouched.
+ */
+export function rewriteCreateNodesV2Imports(
+  source: string,
+  specifiers: ReadonlySet<string>
+): string {
+  ts ??= ensurePackage<typeof import('typescript')>('typescript', '*');
+  const sourceFile = ts.createSourceFile(
+    'tmp.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TSX
+  );
+
+  const changes: StringChange[] = [];
+  for (const stmt of sourceFile.statements) {
+    if (ts.isImportDeclaration(stmt)) {
+      collectImportRewrite(sourceFile, stmt, specifiers, changes);
+    } else if (ts.isExportDeclaration(stmt)) {
+      collectExportRewrite(sourceFile, stmt, specifiers, changes);
+    }
+  }
+
+  return changes.length > 0 ? applyChangesToString(source, changes) : source;
+}
+
+function isTargetSpecifier(
+  node: ImportDeclaration['moduleSpecifier'],
+  specifiers: ReadonlySet<string>
+): boolean {
+  return ts!.isStringLiteral(node) && specifiers.has(node.text);
+}
+
+function collectImportRewrite(
+  sourceFile: SourceFile,
+  stmt: ImportDeclaration,
+  specifiers: ReadonlySet<string>,
+  changes: StringChange[]
+): void {
+  if (!isTargetSpecifier(stmt.moduleSpecifier, specifiers)) {
+    return;
+  }
+  const namedBindings = stmt.importClause?.namedBindings;
+  // Only `import { ... }` carries renameable named bindings. `import x`,
+  // `import * as ns`, and side-effect imports reference the module wholesale
+  // and keep working through the `createNodesV2` runtime alias, so we leave
+  // them be. A mixed `import def, { createNodesV2 }` still has its named
+  // bindings rewritten below — the default binding is untouched.
+  if (!namedBindings || !ts!.isNamedImports(namedBindings)) {
+    return;
+  }
+  rewriteNamedBindings(sourceFile, namedBindings, changes);
+}
+
+function collectExportRewrite(
+  sourceFile: SourceFile,
+  stmt: ExportDeclaration,
+  specifiers: ReadonlySet<string>,
+  changes: StringChange[]
+): void {
+  if (
+    !stmt.moduleSpecifier ||
+    !isTargetSpecifier(stmt.moduleSpecifier, specifiers)
+  ) {
+    return;
+  }
+  // `export { ... } from '...'` can be rewritten; `export * from '...'` has no
+  // named bindings to rename.
+  if (!stmt.exportClause || !ts!.isNamedExports(stmt.exportClause)) {
+    return;
+  }
+  rewriteNamedBindings(sourceFile, stmt.exportClause, changes);
+}
+
+/**
+ * Re-renders the `{ ... }` of a named import/export, renaming any
+ * `createNodesV2` specifier to `createNodes`. If renaming would collide with a
+ * `createNodes` that is already present (e.g. `{ createNodes, createNodesV2 }`),
+ * the duplicate is dropped. Returns without recording a change when the binding
+ * list contains no `createNodesV2`.
+ */
+function rewriteNamedBindings(
+  sourceFile: SourceFile,
+  namedBindings: NamedImports | NamedExports,
+  changes: StringChange[]
+): void {
+  const elements = namedBindings.elements as readonly (
+    | ImportSpecifier
+    | ExportSpecifier
+  )[];
+  const hasDeprecated = elements.some(
+    (el) => (el.propertyName ?? el.name).text === DEPRECATED_NAME
+  );
+  if (!hasDeprecated) {
+    return;
+  }
+
+  const seen = new Set<string>();
+  const rendered: string[] = [];
+  for (const el of elements) {
+    const text = renderSpecifier(el);
+    if (!seen.has(text)) {
+      seen.add(text);
+      rendered.push(text);
+    }
+  }
+
+  const start = namedBindings.getStart(sourceFile);
+  changes.push(
+    {
+      type: ChangeType.Delete,
+      start,
+      length: namedBindings.getEnd() - start,
+    },
+    {
+      type: ChangeType.Insert,
+      index: start,
+      text: `{ ${rendered.join(', ')} }`,
+    }
+  );
+}
+
+function renderSpecifier(el: ImportSpecifier | ExportSpecifier): string {
+  const typePrefix = el.isTypeOnly ? 'type ' : '';
+  const rename = (name: string) =>
+    name === DEPRECATED_NAME ? CANONICAL_NAME : name;
+
+  // `{ name }` — no alias, so the local binding follows the rename.
+  if (!el.propertyName) {
+    return `${typePrefix}${rename(el.name.text)}`;
+  }
+
+  // `{ propertyName as name }` — only the imported (left) side is renamed; the
+  // local alias is preserved. A now-redundant alias such as
+  // `createNodesV2 as createNodes` collapses to `createNodes`.
+  const canonicalImported = rename(el.propertyName.text);
+  const localName = el.name.text;
+  return canonicalImported === localName
+    ? `${typePrefix}${localName}`
+    : `${typePrefix}${canonicalImported} as ${localName}`;
+}

--- a/packages/gradle/eslint.config.mjs
+++ b/packages/gradle/eslint.config.mjs
@@ -11,7 +11,7 @@ export default [
         'error',
         {
           buildTargets: ['build-base'],
-          ignoredDependencies: ['nx'],
+          ignoredDependencies: ['nx', 'typescript'],
         },
       ],
     },

--- a/packages/gradle/migrations.json
+++ b/packages/gradle/migrations.json
@@ -160,6 +160,12 @@
       "description": "Change dev.nx.gradle.project-graph to version 0.1.21 in build file",
       "factory": "./dist/src/migrations/23-0-0/change-plugin-version-0-1-21",
       "documentation": "./dist/src/migrations/23-0-0/change-plugin-version-0-1-21.md"
+    },
+    "update-23-0-0-migrate-create-nodes-v2-import": {
+      "version": "23.0.0-beta.5",
+      "description": "Rename imports of `createNodesV2` from `@nx/gradle` and `@nx/gradle/plugin-v1` to the canonical `createNodes` export.",
+      "implementation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
+      "documentation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"
     }
   },
   "packageJsonUpdates": {}

--- a/packages/gradle/migrations.json
+++ b/packages/gradle/migrations.json
@@ -162,7 +162,7 @@
       "documentation": "./dist/src/migrations/23-0-0/change-plugin-version-0-1-21.md"
     },
     "update-23-0-0-migrate-create-nodes-v2-import": {
-      "version": "23.0.0-beta.5",
+      "version": "23.0.0-beta.24",
       "description": "Rename imports of `createNodesV2` from `@nx/gradle` and `@nx/gradle/plugin-v1` to the canonical `createNodes` export.",
       "implementation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
       "documentation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"

--- a/packages/gradle/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md
+++ b/packages/gradle/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md
@@ -1,0 +1,25 @@
+#### Rename `createNodesV2` imports to `createNodes`
+
+`@nx/gradle` renamed its primary inferred-plugin export from `createNodesV2` to `createNodes`. The `createNodesV2` name is preserved as a deprecated alias for now, but new code should use `createNodes`.
+
+This migration scans every `.ts`, `.tsx`, `.cts`, and `.mts` file in your workspace and rewrites named imports and re-exports of `createNodesV2` from `@nx/gradle` and `@nx/gradle/plugin-v1` to `createNodes`.
+
+#### Sample Code Changes
+
+##### Before
+
+```ts
+import { createNodesV2 } from '@nx/gradle';
+```
+
+##### After
+
+```ts
+import { createNodes } from '@nx/gradle';
+```
+
+Aliases are preserved (`createNodesV2 as cn` becomes `createNodes as cn`), and if a file already imports both names (`{ createNodes, createNodesV2 }`) the redundant binding is dropped.
+
+#### What is not rewritten
+
+Only static `import`/`export` named bindings from `@nx/gradle` and `@nx/gradle/plugin-v1` are rewritten. Namespace imports, dynamic `import(...)`, `require(...)` destructuring, and property access such as `plugin.createNodesV2` are left untouched — they keep working through the `createNodesV2` runtime alias. Update those by hand if you want to drop the deprecated name everywhere.

--- a/packages/gradle/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.spec.ts
+++ b/packages/gradle/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.spec.ts
@@ -1,0 +1,197 @@
+import { type Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migration, {
+  rewriteCreateNodesV2Imports,
+} from './migrate-create-nodes-v2-to-create-nodes';
+
+const SPECIFIERS = new Set(['@nx/gradle', '@nx/gradle/plugin-v1']);
+const rewrite = (source: string) =>
+  rewriteCreateNodesV2Imports(source, SPECIFIERS);
+
+describe('migrate-create-nodes-v2-to-create-nodes migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  describe('rewriteCreateNodesV2Imports', () => {
+    it('renames a lone createNodesV2 named import', () => {
+      const input = `import { createNodesV2 } from '@nx/gradle';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/gradle';\n`
+      );
+    });
+
+    it('preserves other named imports while renaming createNodesV2', () => {
+      const input = `import { createNodesV2, SomeOtherExport } from '@nx/gradle';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes, SomeOtherExport } from '@nx/gradle';\n`
+      );
+    });
+
+    it('rewrites the original name in `as` aliases', () => {
+      const input = `import { createNodesV2 as cn } from '@nx/gradle';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes as cn } from '@nx/gradle';\n`
+      );
+    });
+
+    it('collapses a redundant `createNodesV2 as createNodes` alias', () => {
+      const input = `import { createNodesV2 as createNodes } from '@nx/gradle';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/gradle';\n`
+      );
+    });
+
+    it('dedupes when both createNodes and createNodesV2 are imported', () => {
+      const input = `import { createNodes, createNodesV2 } from '@nx/gradle';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/gradle';\n`
+      );
+    });
+
+    it('dedupes when createNodesV2 precedes createNodes', () => {
+      const input = `import { createNodesV2, createNodes } from '@nx/gradle';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/gradle';\n`
+      );
+    });
+
+    it('handles multi-line named imports', () => {
+      const input = `import {\n  createNodes,\n  createNodesV2,\n  SomeOtherExport,\n} from '@nx/gradle';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes, SomeOtherExport } from '@nx/gradle';\n`
+      );
+    });
+
+    it('preserves a default import alongside the renamed binding', () => {
+      const input = `import def, { createNodesV2 } from '@nx/gradle';\n`;
+      expect(rewrite(input)).toBe(
+        `import def, { createNodes } from '@nx/gradle';\n`
+      );
+    });
+
+    it('handles `import type` declarations', () => {
+      const input = `import type { createNodesV2 } from '@nx/gradle';\n`;
+      expect(rewrite(input)).toBe(
+        `import type { createNodes } from '@nx/gradle';\n`
+      );
+    });
+
+    it('preserves inline `type` modifiers', () => {
+      const input = `import { type createNodesV2 } from '@nx/gradle';\n`;
+      expect(rewrite(input)).toBe(
+        `import { type createNodes } from '@nx/gradle';\n`
+      );
+    });
+
+    it('rewrites named re-exports', () => {
+      const input = `export { createNodesV2 } from '@nx/gradle';\n`;
+      expect(rewrite(input)).toBe(
+        `export { createNodes } from '@nx/gradle';\n`
+      );
+    });
+
+    it('rewrites aliased named re-exports', () => {
+      const input = `export { createNodesV2 as cn } from '@nx/gradle';\n`;
+      expect(rewrite(input)).toBe(
+        `export { createNodes as cn } from '@nx/gradle';\n`
+      );
+    });
+
+    it('does not touch createNodesV2 from a different specifier', () => {
+      const input = `import { createNodesV2 } from '@nx/other-plugin/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not touch createNodesV2 from a relative specifier', () => {
+      const input = `import { createNodesV2 } from './plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not touch unrelated imports from the target specifier', () => {
+      const input = `import { createNodes } from '@nx/gradle';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not rewrite `export * from` declarations', () => {
+      const input = `export * from '@nx/gradle';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('leaves createNodesV2 in strings and comments alone', () => {
+      const input =
+        `// import { createNodesV2 } from '@nx/gradle';\n` +
+        `const s = "createNodesV2";\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not rewrite require() destructuring (still valid via alias)', () => {
+      const input = `const { createNodesV2 } = require('@nx/gradle');\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+  });
+
+  it('rewrites imports from @nx/gradle/plugin-v1', () => {
+    expect(
+      rewrite(`import { createNodesV2 } from '@nx/gradle/plugin-v1';\n`)
+    ).toBe(`import { createNodes } from '@nx/gradle/plugin-v1';\n`);
+  });
+
+  describe('migration runner', () => {
+    it('rewrites imports across .ts/.tsx/.cts/.mts files', async () => {
+      tree.write(
+        'libs/foo/src/a.ts',
+        `import { createNodesV2 } from '@nx/gradle';\n`
+      );
+      tree.write(
+        'libs/foo/src/b.tsx',
+        `import { createNodesV2 as cn } from '@nx/gradle';\n`
+      );
+      tree.write(
+        'libs/foo/src/c.cts',
+        `export { createNodesV2 } from '@nx/gradle';\n`
+      );
+      tree.write(
+        'libs/foo/src/d.mts',
+        `import { createNodesV2, SomeOtherExport } from '@nx/gradle';\n`
+      );
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/a.ts', 'utf-8')).toContain(
+        `import { createNodes } from '@nx/gradle';`
+      );
+      expect(tree.read('libs/foo/src/b.tsx', 'utf-8')).toContain(
+        `import { createNodes as cn } from '@nx/gradle';`
+      );
+      expect(tree.read('libs/foo/src/c.cts', 'utf-8')).toContain(
+        `export { createNodes } from '@nx/gradle';`
+      );
+      expect(tree.read('libs/foo/src/d.mts', 'utf-8')).toContain(
+        `import { createNodes, SomeOtherExport } from '@nx/gradle';`
+      );
+    });
+
+    it('does not touch files without the deprecated name', async () => {
+      const content = `import { createNodes } from '@nx/gradle';\n`;
+      tree.write('libs/foo/src/index.ts', content);
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/index.ts', 'utf-8')).toBe(content);
+    });
+
+    it('does not rewrite non-TS files', async () => {
+      const md = `Example: \`import { createNodesV2 } from '@nx/gradle';\`\n`;
+      tree.write('docs/example.md', md);
+
+      await migration(tree);
+
+      expect(tree.read('docs/example.md', 'utf-8')).toContain(
+        `import { createNodesV2 } from '@nx/gradle';`
+      );
+    });
+  });
+});

--- a/packages/gradle/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.ts
+++ b/packages/gradle/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.ts
@@ -1,0 +1,209 @@
+import {
+  applyChangesToString,
+  ChangeType,
+  ensurePackage,
+  formatFiles,
+  logger,
+  type StringChange,
+  type Tree,
+  visitNotIgnoredFiles,
+} from '@nx/devkit';
+import type {
+  ExportDeclaration,
+  ExportSpecifier,
+  ImportDeclaration,
+  ImportSpecifier,
+  NamedExports,
+  NamedImports,
+  SourceFile,
+} from 'typescript';
+
+const TS_EXTENSIONS = ['.ts', '.tsx', '.cts', '.mts'] as const;
+const DEPRECATED_NAME = 'createNodesV2';
+const CANONICAL_NAME = 'createNodes';
+
+// Module specifiers from which `@nx/gradle` publicly exposes `createNodesV2`.
+// A named import or re-export of `createNodesV2` from one of these is rewritten
+// to the canonical `createNodes` export.
+const TARGET_SPECIFIERS: ReadonlySet<string> = new Set([
+  '@nx/gradle',
+  '@nx/gradle/plugin-v1',
+]);
+
+let ts: typeof import('typescript') | undefined;
+
+export default async function migrateCreateNodesV2ToCreateNodes(
+  tree: Tree
+): Promise<void> {
+  let touchedCount = 0;
+
+  visitNotIgnoredFiles(tree, '.', (filePath) => {
+    if (!TS_EXTENSIONS.some((ext) => filePath.endsWith(ext))) {
+      return;
+    }
+    const original = tree.read(filePath, 'utf-8');
+    if (!original || !original.includes(DEPRECATED_NAME)) {
+      return;
+    }
+    const updated = rewriteCreateNodesV2Imports(original, TARGET_SPECIFIERS);
+    if (updated !== original) {
+      tree.write(filePath, updated);
+      touchedCount += 1;
+    }
+  });
+
+  if (touchedCount > 0) {
+    logger.info(
+      `Renamed \`${DEPRECATED_NAME}\` imports to \`${CANONICAL_NAME}\` in ${touchedCount} file(s).`
+    );
+  }
+
+  await formatFiles(tree);
+}
+
+/**
+ * Rewrites named imports and re-exports of `createNodesV2` to `createNodes`
+ * when they come from one of the given module specifiers. Only the named
+ * bindings are touched — the module specifier, the `import`/`export` keyword,
+ * any `type` modifier, and any default import are left untouched.
+ */
+export function rewriteCreateNodesV2Imports(
+  source: string,
+  specifiers: ReadonlySet<string>
+): string {
+  ts ??= ensurePackage<typeof import('typescript')>('typescript', '*');
+  const sourceFile = ts.createSourceFile(
+    'tmp.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TSX
+  );
+
+  const changes: StringChange[] = [];
+  for (const stmt of sourceFile.statements) {
+    if (ts.isImportDeclaration(stmt)) {
+      collectImportRewrite(sourceFile, stmt, specifiers, changes);
+    } else if (ts.isExportDeclaration(stmt)) {
+      collectExportRewrite(sourceFile, stmt, specifiers, changes);
+    }
+  }
+
+  return changes.length > 0 ? applyChangesToString(source, changes) : source;
+}
+
+function isTargetSpecifier(
+  node: ImportDeclaration['moduleSpecifier'],
+  specifiers: ReadonlySet<string>
+): boolean {
+  return ts!.isStringLiteral(node) && specifiers.has(node.text);
+}
+
+function collectImportRewrite(
+  sourceFile: SourceFile,
+  stmt: ImportDeclaration,
+  specifiers: ReadonlySet<string>,
+  changes: StringChange[]
+): void {
+  if (!isTargetSpecifier(stmt.moduleSpecifier, specifiers)) {
+    return;
+  }
+  const namedBindings = stmt.importClause?.namedBindings;
+  // Only `import { ... }` carries renameable named bindings. `import x`,
+  // `import * as ns`, and side-effect imports reference the module wholesale
+  // and keep working through the `createNodesV2` runtime alias, so we leave
+  // them be. A mixed `import def, { createNodesV2 }` still has its named
+  // bindings rewritten below — the default binding is untouched.
+  if (!namedBindings || !ts!.isNamedImports(namedBindings)) {
+    return;
+  }
+  rewriteNamedBindings(sourceFile, namedBindings, changes);
+}
+
+function collectExportRewrite(
+  sourceFile: SourceFile,
+  stmt: ExportDeclaration,
+  specifiers: ReadonlySet<string>,
+  changes: StringChange[]
+): void {
+  if (
+    !stmt.moduleSpecifier ||
+    !isTargetSpecifier(stmt.moduleSpecifier, specifiers)
+  ) {
+    return;
+  }
+  // `export { ... } from '...'` can be rewritten; `export * from '...'` has no
+  // named bindings to rename.
+  if (!stmt.exportClause || !ts!.isNamedExports(stmt.exportClause)) {
+    return;
+  }
+  rewriteNamedBindings(sourceFile, stmt.exportClause, changes);
+}
+
+/**
+ * Re-renders the `{ ... }` of a named import/export, renaming any
+ * `createNodesV2` specifier to `createNodes`. If renaming would collide with a
+ * `createNodes` that is already present (e.g. `{ createNodes, createNodesV2 }`),
+ * the duplicate is dropped. Returns without recording a change when the binding
+ * list contains no `createNodesV2`.
+ */
+function rewriteNamedBindings(
+  sourceFile: SourceFile,
+  namedBindings: NamedImports | NamedExports,
+  changes: StringChange[]
+): void {
+  const elements = namedBindings.elements as readonly (
+    | ImportSpecifier
+    | ExportSpecifier
+  )[];
+  const hasDeprecated = elements.some(
+    (el) => (el.propertyName ?? el.name).text === DEPRECATED_NAME
+  );
+  if (!hasDeprecated) {
+    return;
+  }
+
+  const seen = new Set<string>();
+  const rendered: string[] = [];
+  for (const el of elements) {
+    const text = renderSpecifier(el);
+    if (!seen.has(text)) {
+      seen.add(text);
+      rendered.push(text);
+    }
+  }
+
+  const start = namedBindings.getStart(sourceFile);
+  changes.push(
+    {
+      type: ChangeType.Delete,
+      start,
+      length: namedBindings.getEnd() - start,
+    },
+    {
+      type: ChangeType.Insert,
+      index: start,
+      text: `{ ${rendered.join(', ')} }`,
+    }
+  );
+}
+
+function renderSpecifier(el: ImportSpecifier | ExportSpecifier): string {
+  const typePrefix = el.isTypeOnly ? 'type ' : '';
+  const rename = (name: string) =>
+    name === DEPRECATED_NAME ? CANONICAL_NAME : name;
+
+  // `{ name }` — no alias, so the local binding follows the rename.
+  if (!el.propertyName) {
+    return `${typePrefix}${rename(el.name.text)}`;
+  }
+
+  // `{ propertyName as name }` — only the imported (left) side is renamed; the
+  // local alias is preserved. A now-redundant alias such as
+  // `createNodesV2 as createNodes` collapses to `createNodes`.
+  const canonicalImported = rename(el.propertyName.text);
+  const localName = el.name.text;
+  return canonicalImported === localName
+    ? `${typePrefix}${localName}`
+    : `${typePrefix}${canonicalImported} as ${localName}`;
+}

--- a/packages/jest/migrations.json
+++ b/packages/jest/migrations.json
@@ -80,7 +80,7 @@
       "implementation": "./dist/src/migrations/update-23-0-0/migrate-jest-configuration-skip-setup-file"
     },
     "update-23-0-0-migrate-create-nodes-v2-import": {
-      "version": "23.0.0-beta.5",
+      "version": "23.0.0-beta.24",
       "description": "Rename imports of `createNodesV2` from `@nx/jest/plugin` to the canonical `createNodes` export.",
       "implementation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
       "documentation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"

--- a/packages/jest/migrations.json
+++ b/packages/jest/migrations.json
@@ -78,6 +78,12 @@
       "version": "23.0.0-beta.22",
       "description": "Migrate the deprecated `skipSetupFile` option of the `@nx/jest:configuration` generator stored as a default in `nx.json` or per-project `project.json` to `setupFile: 'none'` (when `true`) or remove it (when `false`).",
       "implementation": "./dist/src/migrations/update-23-0-0/migrate-jest-configuration-skip-setup-file"
+    },
+    "update-23-0-0-migrate-create-nodes-v2-import": {
+      "version": "23.0.0-beta.5",
+      "description": "Rename imports of `createNodesV2` from `@nx/jest/plugin` to the canonical `createNodes` export.",
+      "implementation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
+      "documentation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"
     }
   },
   "packageJsonUpdates": {

--- a/packages/jest/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md
+++ b/packages/jest/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md
@@ -1,0 +1,25 @@
+#### Rename `createNodesV2` imports to `createNodes`
+
+`@nx/jest` renamed its primary inferred-plugin export from `createNodesV2` to `createNodes`. The `createNodesV2` name is preserved as a deprecated alias for now, but new code should use `createNodes`.
+
+This migration scans every `.ts`, `.tsx`, `.cts`, and `.mts` file in your workspace and rewrites named imports and re-exports of `createNodesV2` from `@nx/jest/plugin` to `createNodes`.
+
+#### Sample Code Changes
+
+##### Before
+
+```ts
+import { createNodesV2 } from '@nx/jest/plugin';
+```
+
+##### After
+
+```ts
+import { createNodes } from '@nx/jest/plugin';
+```
+
+Aliases are preserved (`createNodesV2 as cn` becomes `createNodes as cn`), and if a file already imports both names (`{ createNodes, createNodesV2 }`) the redundant binding is dropped.
+
+#### What is not rewritten
+
+Only static `import`/`export` named bindings from `@nx/jest/plugin` are rewritten. Namespace imports, dynamic `import(...)`, `require(...)` destructuring, and property access such as `plugin.createNodesV2` are left untouched — they keep working through the `createNodesV2` runtime alias. Update those by hand if you want to drop the deprecated name everywhere.

--- a/packages/jest/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.spec.ts
+++ b/packages/jest/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.spec.ts
@@ -1,0 +1,191 @@
+import { type Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migration, {
+  rewriteCreateNodesV2Imports,
+} from './migrate-create-nodes-v2-to-create-nodes';
+
+const SPECIFIERS = new Set(['@nx/jest/plugin']);
+const rewrite = (source: string) =>
+  rewriteCreateNodesV2Imports(source, SPECIFIERS);
+
+describe('migrate-create-nodes-v2-to-create-nodes migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  describe('rewriteCreateNodesV2Imports', () => {
+    it('renames a lone createNodesV2 named import', () => {
+      const input = `import { createNodesV2 } from '@nx/jest/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/jest/plugin';\n`
+      );
+    });
+
+    it('preserves other named imports while renaming createNodesV2', () => {
+      const input = `import { createNodesV2, SomeOtherExport } from '@nx/jest/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes, SomeOtherExport } from '@nx/jest/plugin';\n`
+      );
+    });
+
+    it('rewrites the original name in `as` aliases', () => {
+      const input = `import { createNodesV2 as cn } from '@nx/jest/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes as cn } from '@nx/jest/plugin';\n`
+      );
+    });
+
+    it('collapses a redundant `createNodesV2 as createNodes` alias', () => {
+      const input = `import { createNodesV2 as createNodes } from '@nx/jest/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/jest/plugin';\n`
+      );
+    });
+
+    it('dedupes when both createNodes and createNodesV2 are imported', () => {
+      const input = `import { createNodes, createNodesV2 } from '@nx/jest/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/jest/plugin';\n`
+      );
+    });
+
+    it('dedupes when createNodesV2 precedes createNodes', () => {
+      const input = `import { createNodesV2, createNodes } from '@nx/jest/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/jest/plugin';\n`
+      );
+    });
+
+    it('handles multi-line named imports', () => {
+      const input = `import {\n  createNodes,\n  createNodesV2,\n  SomeOtherExport,\n} from '@nx/jest/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes, SomeOtherExport } from '@nx/jest/plugin';\n`
+      );
+    });
+
+    it('preserves a default import alongside the renamed binding', () => {
+      const input = `import def, { createNodesV2 } from '@nx/jest/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import def, { createNodes } from '@nx/jest/plugin';\n`
+      );
+    });
+
+    it('handles `import type` declarations', () => {
+      const input = `import type { createNodesV2 } from '@nx/jest/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import type { createNodes } from '@nx/jest/plugin';\n`
+      );
+    });
+
+    it('preserves inline `type` modifiers', () => {
+      const input = `import { type createNodesV2 } from '@nx/jest/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { type createNodes } from '@nx/jest/plugin';\n`
+      );
+    });
+
+    it('rewrites named re-exports', () => {
+      const input = `export { createNodesV2 } from '@nx/jest/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `export { createNodes } from '@nx/jest/plugin';\n`
+      );
+    });
+
+    it('rewrites aliased named re-exports', () => {
+      const input = `export { createNodesV2 as cn } from '@nx/jest/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `export { createNodes as cn } from '@nx/jest/plugin';\n`
+      );
+    });
+
+    it('does not touch createNodesV2 from a different specifier', () => {
+      const input = `import { createNodesV2 } from '@nx/other-plugin/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not touch createNodesV2 from a relative specifier', () => {
+      const input = `import { createNodesV2 } from './plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not touch unrelated imports from the target specifier', () => {
+      const input = `import { createNodes } from '@nx/jest/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not rewrite `export * from` declarations', () => {
+      const input = `export * from '@nx/jest/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('leaves createNodesV2 in strings and comments alone', () => {
+      const input =
+        `// import { createNodesV2 } from '@nx/jest/plugin';\n` +
+        `const s = "createNodesV2";\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not rewrite require() destructuring (still valid via alias)', () => {
+      const input = `const { createNodesV2 } = require('@nx/jest/plugin');\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+  });
+
+  describe('migration runner', () => {
+    it('rewrites imports across .ts/.tsx/.cts/.mts files', async () => {
+      tree.write(
+        'libs/foo/src/a.ts',
+        `import { createNodesV2 } from '@nx/jest/plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/b.tsx',
+        `import { createNodesV2 as cn } from '@nx/jest/plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/c.cts',
+        `export { createNodesV2 } from '@nx/jest/plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/d.mts',
+        `import { createNodesV2, SomeOtherExport } from '@nx/jest/plugin';\n`
+      );
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/a.ts', 'utf-8')).toContain(
+        `import { createNodes } from '@nx/jest/plugin';`
+      );
+      expect(tree.read('libs/foo/src/b.tsx', 'utf-8')).toContain(
+        `import { createNodes as cn } from '@nx/jest/plugin';`
+      );
+      expect(tree.read('libs/foo/src/c.cts', 'utf-8')).toContain(
+        `export { createNodes } from '@nx/jest/plugin';`
+      );
+      expect(tree.read('libs/foo/src/d.mts', 'utf-8')).toContain(
+        `import { createNodes, SomeOtherExport } from '@nx/jest/plugin';`
+      );
+    });
+
+    it('does not touch files without the deprecated name', async () => {
+      const content = `import { createNodes } from '@nx/jest/plugin';\n`;
+      tree.write('libs/foo/src/index.ts', content);
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/index.ts', 'utf-8')).toBe(content);
+    });
+
+    it('does not rewrite non-TS files', async () => {
+      const md = `Example: \`import { createNodesV2 } from '@nx/jest/plugin';\`\n`;
+      tree.write('docs/example.md', md);
+
+      await migration(tree);
+
+      expect(tree.read('docs/example.md', 'utf-8')).toContain(
+        `import { createNodesV2 } from '@nx/jest/plugin';`
+      );
+    });
+  });
+});

--- a/packages/jest/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.ts
+++ b/packages/jest/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.ts
@@ -1,0 +1,206 @@
+import {
+  applyChangesToString,
+  ChangeType,
+  ensurePackage,
+  formatFiles,
+  logger,
+  type StringChange,
+  type Tree,
+  visitNotIgnoredFiles,
+} from '@nx/devkit';
+import type {
+  ExportDeclaration,
+  ExportSpecifier,
+  ImportDeclaration,
+  ImportSpecifier,
+  NamedExports,
+  NamedImports,
+  SourceFile,
+} from 'typescript';
+
+const TS_EXTENSIONS = ['.ts', '.tsx', '.cts', '.mts'] as const;
+const DEPRECATED_NAME = 'createNodesV2';
+const CANONICAL_NAME = 'createNodes';
+
+// Module specifiers from which `@nx/jest` publicly exposes `createNodesV2`.
+// A named import or re-export of `createNodesV2` from one of these is rewritten
+// to the canonical `createNodes` export.
+const TARGET_SPECIFIERS: ReadonlySet<string> = new Set(['@nx/jest/plugin']);
+
+let ts: typeof import('typescript') | undefined;
+
+export default async function migrateCreateNodesV2ToCreateNodes(
+  tree: Tree
+): Promise<void> {
+  let touchedCount = 0;
+
+  visitNotIgnoredFiles(tree, '.', (filePath) => {
+    if (!TS_EXTENSIONS.some((ext) => filePath.endsWith(ext))) {
+      return;
+    }
+    const original = tree.read(filePath, 'utf-8');
+    if (!original || !original.includes(DEPRECATED_NAME)) {
+      return;
+    }
+    const updated = rewriteCreateNodesV2Imports(original, TARGET_SPECIFIERS);
+    if (updated !== original) {
+      tree.write(filePath, updated);
+      touchedCount += 1;
+    }
+  });
+
+  if (touchedCount > 0) {
+    logger.info(
+      `Renamed \`${DEPRECATED_NAME}\` imports to \`${CANONICAL_NAME}\` in ${touchedCount} file(s).`
+    );
+  }
+
+  await formatFiles(tree);
+}
+
+/**
+ * Rewrites named imports and re-exports of `createNodesV2` to `createNodes`
+ * when they come from one of the given module specifiers. Only the named
+ * bindings are touched — the module specifier, the `import`/`export` keyword,
+ * any `type` modifier, and any default import are left untouched.
+ */
+export function rewriteCreateNodesV2Imports(
+  source: string,
+  specifiers: ReadonlySet<string>
+): string {
+  ts ??= ensurePackage<typeof import('typescript')>('typescript', '*');
+  const sourceFile = ts.createSourceFile(
+    'tmp.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TSX
+  );
+
+  const changes: StringChange[] = [];
+  for (const stmt of sourceFile.statements) {
+    if (ts.isImportDeclaration(stmt)) {
+      collectImportRewrite(sourceFile, stmt, specifiers, changes);
+    } else if (ts.isExportDeclaration(stmt)) {
+      collectExportRewrite(sourceFile, stmt, specifiers, changes);
+    }
+  }
+
+  return changes.length > 0 ? applyChangesToString(source, changes) : source;
+}
+
+function isTargetSpecifier(
+  node: ImportDeclaration['moduleSpecifier'],
+  specifiers: ReadonlySet<string>
+): boolean {
+  return ts!.isStringLiteral(node) && specifiers.has(node.text);
+}
+
+function collectImportRewrite(
+  sourceFile: SourceFile,
+  stmt: ImportDeclaration,
+  specifiers: ReadonlySet<string>,
+  changes: StringChange[]
+): void {
+  if (!isTargetSpecifier(stmt.moduleSpecifier, specifiers)) {
+    return;
+  }
+  const namedBindings = stmt.importClause?.namedBindings;
+  // Only `import { ... }` carries renameable named bindings. `import x`,
+  // `import * as ns`, and side-effect imports reference the module wholesale
+  // and keep working through the `createNodesV2` runtime alias, so we leave
+  // them be. A mixed `import def, { createNodesV2 }` still has its named
+  // bindings rewritten below — the default binding is untouched.
+  if (!namedBindings || !ts!.isNamedImports(namedBindings)) {
+    return;
+  }
+  rewriteNamedBindings(sourceFile, namedBindings, changes);
+}
+
+function collectExportRewrite(
+  sourceFile: SourceFile,
+  stmt: ExportDeclaration,
+  specifiers: ReadonlySet<string>,
+  changes: StringChange[]
+): void {
+  if (
+    !stmt.moduleSpecifier ||
+    !isTargetSpecifier(stmt.moduleSpecifier, specifiers)
+  ) {
+    return;
+  }
+  // `export { ... } from '...'` can be rewritten; `export * from '...'` has no
+  // named bindings to rename.
+  if (!stmt.exportClause || !ts!.isNamedExports(stmt.exportClause)) {
+    return;
+  }
+  rewriteNamedBindings(sourceFile, stmt.exportClause, changes);
+}
+
+/**
+ * Re-renders the `{ ... }` of a named import/export, renaming any
+ * `createNodesV2` specifier to `createNodes`. If renaming would collide with a
+ * `createNodes` that is already present (e.g. `{ createNodes, createNodesV2 }`),
+ * the duplicate is dropped. Returns without recording a change when the binding
+ * list contains no `createNodesV2`.
+ */
+function rewriteNamedBindings(
+  sourceFile: SourceFile,
+  namedBindings: NamedImports | NamedExports,
+  changes: StringChange[]
+): void {
+  const elements = namedBindings.elements as readonly (
+    | ImportSpecifier
+    | ExportSpecifier
+  )[];
+  const hasDeprecated = elements.some(
+    (el) => (el.propertyName ?? el.name).text === DEPRECATED_NAME
+  );
+  if (!hasDeprecated) {
+    return;
+  }
+
+  const seen = new Set<string>();
+  const rendered: string[] = [];
+  for (const el of elements) {
+    const text = renderSpecifier(el);
+    if (!seen.has(text)) {
+      seen.add(text);
+      rendered.push(text);
+    }
+  }
+
+  const start = namedBindings.getStart(sourceFile);
+  changes.push(
+    {
+      type: ChangeType.Delete,
+      start,
+      length: namedBindings.getEnd() - start,
+    },
+    {
+      type: ChangeType.Insert,
+      index: start,
+      text: `{ ${rendered.join(', ')} }`,
+    }
+  );
+}
+
+function renderSpecifier(el: ImportSpecifier | ExportSpecifier): string {
+  const typePrefix = el.isTypeOnly ? 'type ' : '';
+  const rename = (name: string) =>
+    name === DEPRECATED_NAME ? CANONICAL_NAME : name;
+
+  // `{ name }` — no alias, so the local binding follows the rename.
+  if (!el.propertyName) {
+    return `${typePrefix}${rename(el.name.text)}`;
+  }
+
+  // `{ propertyName as name }` — only the imported (left) side is renamed; the
+  // local alias is preserved. A now-redundant alias such as
+  // `createNodesV2 as createNodes` collapses to `createNodes`.
+  const canonicalImported = rename(el.propertyName.text);
+  const localName = el.name.text;
+  return canonicalImported === localName
+    ? `${typePrefix}${localName}`
+    : `${typePrefix}${canonicalImported} as ${localName}`;
+}

--- a/packages/js/migrations.json
+++ b/packages/js/migrations.json
@@ -24,7 +24,7 @@
       "factory": "./dist/src/migrations/update-23-0-0/rewrite-internal-subpath-imports"
     },
     "update-23-0-0-migrate-create-nodes-v2-import": {
-      "version": "23.0.0-beta.5",
+      "version": "23.0.0-beta.24",
       "description": "Rename imports of `createNodesV2` from `@nx/js/typescript` to the canonical `createNodes` export.",
       "implementation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
       "documentation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"

--- a/packages/js/migrations.json
+++ b/packages/js/migrations.json
@@ -22,6 +22,12 @@
       "version": "23.0.0-beta.14",
       "description": "Rewrites `@nx/js/src/*` subpath imports to the new `@nx/js/internal` entry. The `./src/*` wildcard has been removed from `@nx/js`'s exports map; `@nx/js/src/release/version-actions` is preserved as a non-wildcard entry for back-compat with existing nx.json release configs. If a rewritten import resolves to a symbol that lives on the public `@nx/js` entry (e.g. `libraryGenerator`, `extractTsConfigBase`, `resolvePathsBaseUrl`), change the specifier to `@nx/js`.",
       "factory": "./dist/src/migrations/update-23-0-0/rewrite-internal-subpath-imports"
+    },
+    "update-23-0-0-migrate-create-nodes-v2-import": {
+      "version": "23.0.0-beta.5",
+      "description": "Rename imports of `createNodesV2` from `@nx/js/typescript` to the canonical `createNodes` export.",
+      "implementation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
+      "documentation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"
     }
   },
   "packageJsonUpdates": {

--- a/packages/js/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md
+++ b/packages/js/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md
@@ -1,0 +1,25 @@
+#### Rename `createNodesV2` imports to `createNodes`
+
+`@nx/js` renamed its primary inferred-plugin export from `createNodesV2` to `createNodes`. The `createNodesV2` name is preserved as a deprecated alias for now, but new code should use `createNodes`.
+
+This migration scans every `.ts`, `.tsx`, `.cts`, and `.mts` file in your workspace and rewrites named imports and re-exports of `createNodesV2` from `@nx/js/typescript` to `createNodes`.
+
+#### Sample Code Changes
+
+##### Before
+
+```ts
+import { createNodesV2 } from '@nx/js/typescript';
+```
+
+##### After
+
+```ts
+import { createNodes } from '@nx/js/typescript';
+```
+
+Aliases are preserved (`createNodesV2 as cn` becomes `createNodes as cn`), and if a file already imports both names (`{ createNodes, createNodesV2 }`) the redundant binding is dropped.
+
+#### What is not rewritten
+
+Only static `import`/`export` named bindings from `@nx/js/typescript` are rewritten. Namespace imports, dynamic `import(...)`, `require(...)` destructuring, and property access such as `plugin.createNodesV2` are left untouched — they keep working through the `createNodesV2` runtime alias. Update those by hand if you want to drop the deprecated name everywhere.

--- a/packages/js/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.spec.ts
+++ b/packages/js/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.spec.ts
@@ -1,0 +1,191 @@
+import { type Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migration, {
+  rewriteCreateNodesV2Imports,
+} from './migrate-create-nodes-v2-to-create-nodes';
+
+const SPECIFIERS = new Set(['@nx/js/typescript']);
+const rewrite = (source: string) =>
+  rewriteCreateNodesV2Imports(source, SPECIFIERS);
+
+describe('migrate-create-nodes-v2-to-create-nodes migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  describe('rewriteCreateNodesV2Imports', () => {
+    it('renames a lone createNodesV2 named import', () => {
+      const input = `import { createNodesV2 } from '@nx/js/typescript';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/js/typescript';\n`
+      );
+    });
+
+    it('preserves other named imports while renaming createNodesV2', () => {
+      const input = `import { createNodesV2, SomeOtherExport } from '@nx/js/typescript';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes, SomeOtherExport } from '@nx/js/typescript';\n`
+      );
+    });
+
+    it('rewrites the original name in `as` aliases', () => {
+      const input = `import { createNodesV2 as cn } from '@nx/js/typescript';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes as cn } from '@nx/js/typescript';\n`
+      );
+    });
+
+    it('collapses a redundant `createNodesV2 as createNodes` alias', () => {
+      const input = `import { createNodesV2 as createNodes } from '@nx/js/typescript';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/js/typescript';\n`
+      );
+    });
+
+    it('dedupes when both createNodes and createNodesV2 are imported', () => {
+      const input = `import { createNodes, createNodesV2 } from '@nx/js/typescript';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/js/typescript';\n`
+      );
+    });
+
+    it('dedupes when createNodesV2 precedes createNodes', () => {
+      const input = `import { createNodesV2, createNodes } from '@nx/js/typescript';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/js/typescript';\n`
+      );
+    });
+
+    it('handles multi-line named imports', () => {
+      const input = `import {\n  createNodes,\n  createNodesV2,\n  SomeOtherExport,\n} from '@nx/js/typescript';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes, SomeOtherExport } from '@nx/js/typescript';\n`
+      );
+    });
+
+    it('preserves a default import alongside the renamed binding', () => {
+      const input = `import def, { createNodesV2 } from '@nx/js/typescript';\n`;
+      expect(rewrite(input)).toBe(
+        `import def, { createNodes } from '@nx/js/typescript';\n`
+      );
+    });
+
+    it('handles `import type` declarations', () => {
+      const input = `import type { createNodesV2 } from '@nx/js/typescript';\n`;
+      expect(rewrite(input)).toBe(
+        `import type { createNodes } from '@nx/js/typescript';\n`
+      );
+    });
+
+    it('preserves inline `type` modifiers', () => {
+      const input = `import { type createNodesV2 } from '@nx/js/typescript';\n`;
+      expect(rewrite(input)).toBe(
+        `import { type createNodes } from '@nx/js/typescript';\n`
+      );
+    });
+
+    it('rewrites named re-exports', () => {
+      const input = `export { createNodesV2 } from '@nx/js/typescript';\n`;
+      expect(rewrite(input)).toBe(
+        `export { createNodes } from '@nx/js/typescript';\n`
+      );
+    });
+
+    it('rewrites aliased named re-exports', () => {
+      const input = `export { createNodesV2 as cn } from '@nx/js/typescript';\n`;
+      expect(rewrite(input)).toBe(
+        `export { createNodes as cn } from '@nx/js/typescript';\n`
+      );
+    });
+
+    it('does not touch createNodesV2 from a different specifier', () => {
+      const input = `import { createNodesV2 } from '@nx/other-plugin/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not touch createNodesV2 from a relative specifier', () => {
+      const input = `import { createNodesV2 } from './plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not touch unrelated imports from the target specifier', () => {
+      const input = `import { createNodes } from '@nx/js/typescript';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not rewrite `export * from` declarations', () => {
+      const input = `export * from '@nx/js/typescript';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('leaves createNodesV2 in strings and comments alone', () => {
+      const input =
+        `// import { createNodesV2 } from '@nx/js/typescript';\n` +
+        `const s = "createNodesV2";\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not rewrite require() destructuring (still valid via alias)', () => {
+      const input = `const { createNodesV2 } = require('@nx/js/typescript');\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+  });
+
+  describe('migration runner', () => {
+    it('rewrites imports across .ts/.tsx/.cts/.mts files', async () => {
+      tree.write(
+        'libs/foo/src/a.ts',
+        `import { createNodesV2 } from '@nx/js/typescript';\n`
+      );
+      tree.write(
+        'libs/foo/src/b.tsx',
+        `import { createNodesV2 as cn } from '@nx/js/typescript';\n`
+      );
+      tree.write(
+        'libs/foo/src/c.cts',
+        `export { createNodesV2 } from '@nx/js/typescript';\n`
+      );
+      tree.write(
+        'libs/foo/src/d.mts',
+        `import { createNodesV2, SomeOtherExport } from '@nx/js/typescript';\n`
+      );
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/a.ts', 'utf-8')).toContain(
+        `import { createNodes } from '@nx/js/typescript';`
+      );
+      expect(tree.read('libs/foo/src/b.tsx', 'utf-8')).toContain(
+        `import { createNodes as cn } from '@nx/js/typescript';`
+      );
+      expect(tree.read('libs/foo/src/c.cts', 'utf-8')).toContain(
+        `export { createNodes } from '@nx/js/typescript';`
+      );
+      expect(tree.read('libs/foo/src/d.mts', 'utf-8')).toContain(
+        `import { createNodes, SomeOtherExport } from '@nx/js/typescript';`
+      );
+    });
+
+    it('does not touch files without the deprecated name', async () => {
+      const content = `import { createNodes } from '@nx/js/typescript';\n`;
+      tree.write('libs/foo/src/index.ts', content);
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/index.ts', 'utf-8')).toBe(content);
+    });
+
+    it('does not rewrite non-TS files', async () => {
+      const md = `Example: \`import { createNodesV2 } from '@nx/js/typescript';\`\n`;
+      tree.write('docs/example.md', md);
+
+      await migration(tree);
+
+      expect(tree.read('docs/example.md', 'utf-8')).toContain(
+        `import { createNodesV2 } from '@nx/js/typescript';`
+      );
+    });
+  });
+});

--- a/packages/js/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.ts
+++ b/packages/js/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.ts
@@ -1,0 +1,206 @@
+import {
+  applyChangesToString,
+  ChangeType,
+  ensurePackage,
+  formatFiles,
+  logger,
+  type StringChange,
+  type Tree,
+  visitNotIgnoredFiles,
+} from '@nx/devkit';
+import type {
+  ExportDeclaration,
+  ExportSpecifier,
+  ImportDeclaration,
+  ImportSpecifier,
+  NamedExports,
+  NamedImports,
+  SourceFile,
+} from 'typescript';
+
+const TS_EXTENSIONS = ['.ts', '.tsx', '.cts', '.mts'] as const;
+const DEPRECATED_NAME = 'createNodesV2';
+const CANONICAL_NAME = 'createNodes';
+
+// Module specifiers from which `@nx/js` publicly exposes `createNodesV2`.
+// A named import or re-export of `createNodesV2` from one of these is rewritten
+// to the canonical `createNodes` export.
+const TARGET_SPECIFIERS: ReadonlySet<string> = new Set(['@nx/js/typescript']);
+
+let ts: typeof import('typescript') | undefined;
+
+export default async function migrateCreateNodesV2ToCreateNodes(
+  tree: Tree
+): Promise<void> {
+  let touchedCount = 0;
+
+  visitNotIgnoredFiles(tree, '.', (filePath) => {
+    if (!TS_EXTENSIONS.some((ext) => filePath.endsWith(ext))) {
+      return;
+    }
+    const original = tree.read(filePath, 'utf-8');
+    if (!original || !original.includes(DEPRECATED_NAME)) {
+      return;
+    }
+    const updated = rewriteCreateNodesV2Imports(original, TARGET_SPECIFIERS);
+    if (updated !== original) {
+      tree.write(filePath, updated);
+      touchedCount += 1;
+    }
+  });
+
+  if (touchedCount > 0) {
+    logger.info(
+      `Renamed \`${DEPRECATED_NAME}\` imports to \`${CANONICAL_NAME}\` in ${touchedCount} file(s).`
+    );
+  }
+
+  await formatFiles(tree);
+}
+
+/**
+ * Rewrites named imports and re-exports of `createNodesV2` to `createNodes`
+ * when they come from one of the given module specifiers. Only the named
+ * bindings are touched — the module specifier, the `import`/`export` keyword,
+ * any `type` modifier, and any default import are left untouched.
+ */
+export function rewriteCreateNodesV2Imports(
+  source: string,
+  specifiers: ReadonlySet<string>
+): string {
+  ts ??= ensurePackage<typeof import('typescript')>('typescript', '*');
+  const sourceFile = ts.createSourceFile(
+    'tmp.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TSX
+  );
+
+  const changes: StringChange[] = [];
+  for (const stmt of sourceFile.statements) {
+    if (ts.isImportDeclaration(stmt)) {
+      collectImportRewrite(sourceFile, stmt, specifiers, changes);
+    } else if (ts.isExportDeclaration(stmt)) {
+      collectExportRewrite(sourceFile, stmt, specifiers, changes);
+    }
+  }
+
+  return changes.length > 0 ? applyChangesToString(source, changes) : source;
+}
+
+function isTargetSpecifier(
+  node: ImportDeclaration['moduleSpecifier'],
+  specifiers: ReadonlySet<string>
+): boolean {
+  return ts!.isStringLiteral(node) && specifiers.has(node.text);
+}
+
+function collectImportRewrite(
+  sourceFile: SourceFile,
+  stmt: ImportDeclaration,
+  specifiers: ReadonlySet<string>,
+  changes: StringChange[]
+): void {
+  if (!isTargetSpecifier(stmt.moduleSpecifier, specifiers)) {
+    return;
+  }
+  const namedBindings = stmt.importClause?.namedBindings;
+  // Only `import { ... }` carries renameable named bindings. `import x`,
+  // `import * as ns`, and side-effect imports reference the module wholesale
+  // and keep working through the `createNodesV2` runtime alias, so we leave
+  // them be. A mixed `import def, { createNodesV2 }` still has its named
+  // bindings rewritten below — the default binding is untouched.
+  if (!namedBindings || !ts!.isNamedImports(namedBindings)) {
+    return;
+  }
+  rewriteNamedBindings(sourceFile, namedBindings, changes);
+}
+
+function collectExportRewrite(
+  sourceFile: SourceFile,
+  stmt: ExportDeclaration,
+  specifiers: ReadonlySet<string>,
+  changes: StringChange[]
+): void {
+  if (
+    !stmt.moduleSpecifier ||
+    !isTargetSpecifier(stmt.moduleSpecifier, specifiers)
+  ) {
+    return;
+  }
+  // `export { ... } from '...'` can be rewritten; `export * from '...'` has no
+  // named bindings to rename.
+  if (!stmt.exportClause || !ts!.isNamedExports(stmt.exportClause)) {
+    return;
+  }
+  rewriteNamedBindings(sourceFile, stmt.exportClause, changes);
+}
+
+/**
+ * Re-renders the `{ ... }` of a named import/export, renaming any
+ * `createNodesV2` specifier to `createNodes`. If renaming would collide with a
+ * `createNodes` that is already present (e.g. `{ createNodes, createNodesV2 }`),
+ * the duplicate is dropped. Returns without recording a change when the binding
+ * list contains no `createNodesV2`.
+ */
+function rewriteNamedBindings(
+  sourceFile: SourceFile,
+  namedBindings: NamedImports | NamedExports,
+  changes: StringChange[]
+): void {
+  const elements = namedBindings.elements as readonly (
+    | ImportSpecifier
+    | ExportSpecifier
+  )[];
+  const hasDeprecated = elements.some(
+    (el) => (el.propertyName ?? el.name).text === DEPRECATED_NAME
+  );
+  if (!hasDeprecated) {
+    return;
+  }
+
+  const seen = new Set<string>();
+  const rendered: string[] = [];
+  for (const el of elements) {
+    const text = renderSpecifier(el);
+    if (!seen.has(text)) {
+      seen.add(text);
+      rendered.push(text);
+    }
+  }
+
+  const start = namedBindings.getStart(sourceFile);
+  changes.push(
+    {
+      type: ChangeType.Delete,
+      start,
+      length: namedBindings.getEnd() - start,
+    },
+    {
+      type: ChangeType.Insert,
+      index: start,
+      text: `{ ${rendered.join(', ')} }`,
+    }
+  );
+}
+
+function renderSpecifier(el: ImportSpecifier | ExportSpecifier): string {
+  const typePrefix = el.isTypeOnly ? 'type ' : '';
+  const rename = (name: string) =>
+    name === DEPRECATED_NAME ? CANONICAL_NAME : name;
+
+  // `{ name }` — no alias, so the local binding follows the rename.
+  if (!el.propertyName) {
+    return `${typePrefix}${rename(el.name.text)}`;
+  }
+
+  // `{ propertyName as name }` — only the imported (left) side is renamed; the
+  // local alias is preserved. A now-redundant alias such as
+  // `createNodesV2 as createNodes` collapses to `createNodes`.
+  const canonicalImported = rename(el.propertyName.text);
+  const localName = el.name.text;
+  return canonicalImported === localName
+    ? `${typePrefix}${localName}`
+    : `${typePrefix}${canonicalImported} as ${localName}`;
+}

--- a/packages/next/migrations.json
+++ b/packages/next/migrations.json
@@ -16,7 +16,7 @@
       "prompt": "./src/migrations/update-22-2-0/ai-instructions-for-next-16.md"
     },
     "update-23-0-0-migrate-create-nodes-v2-import": {
-      "version": "23.0.0-beta.5",
+      "version": "23.0.0-beta.24",
       "description": "Rename imports of `createNodesV2` from `@nx/next/plugin` to the canonical `createNodes` export.",
       "implementation": "./src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
       "documentation": "./src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"

--- a/packages/next/migrations.json
+++ b/packages/next/migrations.json
@@ -14,6 +14,12 @@
       },
       "description": "Create AI Instructions to help migrate users workspaces to Next.js 16.",
       "prompt": "./src/migrations/update-22-2-0/ai-instructions-for-next-16.md"
+    },
+    "update-23-0-0-migrate-create-nodes-v2-import": {
+      "version": "23.0.0-beta.5",
+      "description": "Rename imports of `createNodesV2` from `@nx/next/plugin` to the canonical `createNodes` export.",
+      "implementation": "./src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
+      "documentation": "./src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"
     }
   },
   "packageJsonUpdates": {

--- a/packages/next/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md
+++ b/packages/next/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md
@@ -1,0 +1,25 @@
+#### Rename `createNodesV2` imports to `createNodes`
+
+`@nx/next` renamed its primary inferred-plugin export from `createNodesV2` to `createNodes`. The `createNodesV2` name is preserved as a deprecated alias for now, but new code should use `createNodes`.
+
+This migration scans every `.ts`, `.tsx`, `.cts`, and `.mts` file in your workspace and rewrites named imports and re-exports of `createNodesV2` from `@nx/next/plugin` to `createNodes`.
+
+#### Sample Code Changes
+
+##### Before
+
+```ts
+import { createNodesV2 } from '@nx/next/plugin';
+```
+
+##### After
+
+```ts
+import { createNodes } from '@nx/next/plugin';
+```
+
+Aliases are preserved (`createNodesV2 as cn` becomes `createNodes as cn`), and if a file already imports both names (`{ createNodes, createNodesV2 }`) the redundant binding is dropped.
+
+#### What is not rewritten
+
+Only static `import`/`export` named bindings from `@nx/next/plugin` are rewritten. Namespace imports, dynamic `import(...)`, `require(...)` destructuring, and property access such as `plugin.createNodesV2` are left untouched — they keep working through the `createNodesV2` runtime alias. Update those by hand if you want to drop the deprecated name everywhere.

--- a/packages/next/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.spec.ts
+++ b/packages/next/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.spec.ts
@@ -1,0 +1,191 @@
+import { type Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migration, {
+  rewriteCreateNodesV2Imports,
+} from './migrate-create-nodes-v2-to-create-nodes';
+
+const SPECIFIERS = new Set(['@nx/next/plugin']);
+const rewrite = (source: string) =>
+  rewriteCreateNodesV2Imports(source, SPECIFIERS);
+
+describe('migrate-create-nodes-v2-to-create-nodes migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  describe('rewriteCreateNodesV2Imports', () => {
+    it('renames a lone createNodesV2 named import', () => {
+      const input = `import { createNodesV2 } from '@nx/next/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/next/plugin';\n`
+      );
+    });
+
+    it('preserves other named imports while renaming createNodesV2', () => {
+      const input = `import { createNodesV2, SomeOtherExport } from '@nx/next/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes, SomeOtherExport } from '@nx/next/plugin';\n`
+      );
+    });
+
+    it('rewrites the original name in `as` aliases', () => {
+      const input = `import { createNodesV2 as cn } from '@nx/next/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes as cn } from '@nx/next/plugin';\n`
+      );
+    });
+
+    it('collapses a redundant `createNodesV2 as createNodes` alias', () => {
+      const input = `import { createNodesV2 as createNodes } from '@nx/next/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/next/plugin';\n`
+      );
+    });
+
+    it('dedupes when both createNodes and createNodesV2 are imported', () => {
+      const input = `import { createNodes, createNodesV2 } from '@nx/next/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/next/plugin';\n`
+      );
+    });
+
+    it('dedupes when createNodesV2 precedes createNodes', () => {
+      const input = `import { createNodesV2, createNodes } from '@nx/next/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/next/plugin';\n`
+      );
+    });
+
+    it('handles multi-line named imports', () => {
+      const input = `import {\n  createNodes,\n  createNodesV2,\n  SomeOtherExport,\n} from '@nx/next/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes, SomeOtherExport } from '@nx/next/plugin';\n`
+      );
+    });
+
+    it('preserves a default import alongside the renamed binding', () => {
+      const input = `import def, { createNodesV2 } from '@nx/next/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import def, { createNodes } from '@nx/next/plugin';\n`
+      );
+    });
+
+    it('handles `import type` declarations', () => {
+      const input = `import type { createNodesV2 } from '@nx/next/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import type { createNodes } from '@nx/next/plugin';\n`
+      );
+    });
+
+    it('preserves inline `type` modifiers', () => {
+      const input = `import { type createNodesV2 } from '@nx/next/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { type createNodes } from '@nx/next/plugin';\n`
+      );
+    });
+
+    it('rewrites named re-exports', () => {
+      const input = `export { createNodesV2 } from '@nx/next/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `export { createNodes } from '@nx/next/plugin';\n`
+      );
+    });
+
+    it('rewrites aliased named re-exports', () => {
+      const input = `export { createNodesV2 as cn } from '@nx/next/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `export { createNodes as cn } from '@nx/next/plugin';\n`
+      );
+    });
+
+    it('does not touch createNodesV2 from a different specifier', () => {
+      const input = `import { createNodesV2 } from '@nx/other-plugin/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not touch createNodesV2 from a relative specifier', () => {
+      const input = `import { createNodesV2 } from './plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not touch unrelated imports from the target specifier', () => {
+      const input = `import { createNodes } from '@nx/next/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not rewrite `export * from` declarations', () => {
+      const input = `export * from '@nx/next/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('leaves createNodesV2 in strings and comments alone', () => {
+      const input =
+        `// import { createNodesV2 } from '@nx/next/plugin';\n` +
+        `const s = "createNodesV2";\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not rewrite require() destructuring (still valid via alias)', () => {
+      const input = `const { createNodesV2 } = require('@nx/next/plugin');\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+  });
+
+  describe('migration runner', () => {
+    it('rewrites imports across .ts/.tsx/.cts/.mts files', async () => {
+      tree.write(
+        'libs/foo/src/a.ts',
+        `import { createNodesV2 } from '@nx/next/plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/b.tsx',
+        `import { createNodesV2 as cn } from '@nx/next/plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/c.cts',
+        `export { createNodesV2 } from '@nx/next/plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/d.mts',
+        `import { createNodesV2, SomeOtherExport } from '@nx/next/plugin';\n`
+      );
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/a.ts', 'utf-8')).toContain(
+        `import { createNodes } from '@nx/next/plugin';`
+      );
+      expect(tree.read('libs/foo/src/b.tsx', 'utf-8')).toContain(
+        `import { createNodes as cn } from '@nx/next/plugin';`
+      );
+      expect(tree.read('libs/foo/src/c.cts', 'utf-8')).toContain(
+        `export { createNodes } from '@nx/next/plugin';`
+      );
+      expect(tree.read('libs/foo/src/d.mts', 'utf-8')).toContain(
+        `import { createNodes, SomeOtherExport } from '@nx/next/plugin';`
+      );
+    });
+
+    it('does not touch files without the deprecated name', async () => {
+      const content = `import { createNodes } from '@nx/next/plugin';\n`;
+      tree.write('libs/foo/src/index.ts', content);
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/index.ts', 'utf-8')).toBe(content);
+    });
+
+    it('does not rewrite non-TS files', async () => {
+      const md = `Example: \`import { createNodesV2 } from '@nx/next/plugin';\`\n`;
+      tree.write('docs/example.md', md);
+
+      await migration(tree);
+
+      expect(tree.read('docs/example.md', 'utf-8')).toContain(
+        `import { createNodesV2 } from '@nx/next/plugin';`
+      );
+    });
+  });
+});

--- a/packages/next/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.ts
+++ b/packages/next/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.ts
@@ -1,0 +1,206 @@
+import {
+  applyChangesToString,
+  ChangeType,
+  ensurePackage,
+  formatFiles,
+  logger,
+  type StringChange,
+  type Tree,
+  visitNotIgnoredFiles,
+} from '@nx/devkit';
+import type {
+  ExportDeclaration,
+  ExportSpecifier,
+  ImportDeclaration,
+  ImportSpecifier,
+  NamedExports,
+  NamedImports,
+  SourceFile,
+} from 'typescript';
+
+const TS_EXTENSIONS = ['.ts', '.tsx', '.cts', '.mts'] as const;
+const DEPRECATED_NAME = 'createNodesV2';
+const CANONICAL_NAME = 'createNodes';
+
+// Module specifiers from which `@nx/next` publicly exposes `createNodesV2`.
+// A named import or re-export of `createNodesV2` from one of these is rewritten
+// to the canonical `createNodes` export.
+const TARGET_SPECIFIERS: ReadonlySet<string> = new Set(['@nx/next/plugin']);
+
+let ts: typeof import('typescript') | undefined;
+
+export default async function migrateCreateNodesV2ToCreateNodes(
+  tree: Tree
+): Promise<void> {
+  let touchedCount = 0;
+
+  visitNotIgnoredFiles(tree, '.', (filePath) => {
+    if (!TS_EXTENSIONS.some((ext) => filePath.endsWith(ext))) {
+      return;
+    }
+    const original = tree.read(filePath, 'utf-8');
+    if (!original || !original.includes(DEPRECATED_NAME)) {
+      return;
+    }
+    const updated = rewriteCreateNodesV2Imports(original, TARGET_SPECIFIERS);
+    if (updated !== original) {
+      tree.write(filePath, updated);
+      touchedCount += 1;
+    }
+  });
+
+  if (touchedCount > 0) {
+    logger.info(
+      `Renamed \`${DEPRECATED_NAME}\` imports to \`${CANONICAL_NAME}\` in ${touchedCount} file(s).`
+    );
+  }
+
+  await formatFiles(tree);
+}
+
+/**
+ * Rewrites named imports and re-exports of `createNodesV2` to `createNodes`
+ * when they come from one of the given module specifiers. Only the named
+ * bindings are touched — the module specifier, the `import`/`export` keyword,
+ * any `type` modifier, and any default import are left untouched.
+ */
+export function rewriteCreateNodesV2Imports(
+  source: string,
+  specifiers: ReadonlySet<string>
+): string {
+  ts ??= ensurePackage<typeof import('typescript')>('typescript', '*');
+  const sourceFile = ts.createSourceFile(
+    'tmp.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TSX
+  );
+
+  const changes: StringChange[] = [];
+  for (const stmt of sourceFile.statements) {
+    if (ts.isImportDeclaration(stmt)) {
+      collectImportRewrite(sourceFile, stmt, specifiers, changes);
+    } else if (ts.isExportDeclaration(stmt)) {
+      collectExportRewrite(sourceFile, stmt, specifiers, changes);
+    }
+  }
+
+  return changes.length > 0 ? applyChangesToString(source, changes) : source;
+}
+
+function isTargetSpecifier(
+  node: ImportDeclaration['moduleSpecifier'],
+  specifiers: ReadonlySet<string>
+): boolean {
+  return ts!.isStringLiteral(node) && specifiers.has(node.text);
+}
+
+function collectImportRewrite(
+  sourceFile: SourceFile,
+  stmt: ImportDeclaration,
+  specifiers: ReadonlySet<string>,
+  changes: StringChange[]
+): void {
+  if (!isTargetSpecifier(stmt.moduleSpecifier, specifiers)) {
+    return;
+  }
+  const namedBindings = stmt.importClause?.namedBindings;
+  // Only `import { ... }` carries renameable named bindings. `import x`,
+  // `import * as ns`, and side-effect imports reference the module wholesale
+  // and keep working through the `createNodesV2` runtime alias, so we leave
+  // them be. A mixed `import def, { createNodesV2 }` still has its named
+  // bindings rewritten below — the default binding is untouched.
+  if (!namedBindings || !ts!.isNamedImports(namedBindings)) {
+    return;
+  }
+  rewriteNamedBindings(sourceFile, namedBindings, changes);
+}
+
+function collectExportRewrite(
+  sourceFile: SourceFile,
+  stmt: ExportDeclaration,
+  specifiers: ReadonlySet<string>,
+  changes: StringChange[]
+): void {
+  if (
+    !stmt.moduleSpecifier ||
+    !isTargetSpecifier(stmt.moduleSpecifier, specifiers)
+  ) {
+    return;
+  }
+  // `export { ... } from '...'` can be rewritten; `export * from '...'` has no
+  // named bindings to rename.
+  if (!stmt.exportClause || !ts!.isNamedExports(stmt.exportClause)) {
+    return;
+  }
+  rewriteNamedBindings(sourceFile, stmt.exportClause, changes);
+}
+
+/**
+ * Re-renders the `{ ... }` of a named import/export, renaming any
+ * `createNodesV2` specifier to `createNodes`. If renaming would collide with a
+ * `createNodes` that is already present (e.g. `{ createNodes, createNodesV2 }`),
+ * the duplicate is dropped. Returns without recording a change when the binding
+ * list contains no `createNodesV2`.
+ */
+function rewriteNamedBindings(
+  sourceFile: SourceFile,
+  namedBindings: NamedImports | NamedExports,
+  changes: StringChange[]
+): void {
+  const elements = namedBindings.elements as readonly (
+    | ImportSpecifier
+    | ExportSpecifier
+  )[];
+  const hasDeprecated = elements.some(
+    (el) => (el.propertyName ?? el.name).text === DEPRECATED_NAME
+  );
+  if (!hasDeprecated) {
+    return;
+  }
+
+  const seen = new Set<string>();
+  const rendered: string[] = [];
+  for (const el of elements) {
+    const text = renderSpecifier(el);
+    if (!seen.has(text)) {
+      seen.add(text);
+      rendered.push(text);
+    }
+  }
+
+  const start = namedBindings.getStart(sourceFile);
+  changes.push(
+    {
+      type: ChangeType.Delete,
+      start,
+      length: namedBindings.getEnd() - start,
+    },
+    {
+      type: ChangeType.Insert,
+      index: start,
+      text: `{ ${rendered.join(', ')} }`,
+    }
+  );
+}
+
+function renderSpecifier(el: ImportSpecifier | ExportSpecifier): string {
+  const typePrefix = el.isTypeOnly ? 'type ' : '';
+  const rename = (name: string) =>
+    name === DEPRECATED_NAME ? CANONICAL_NAME : name;
+
+  // `{ name }` — no alias, so the local binding follows the rename.
+  if (!el.propertyName) {
+    return `${typePrefix}${rename(el.name.text)}`;
+  }
+
+  // `{ propertyName as name }` — only the imported (left) side is renamed; the
+  // local alias is preserved. A now-redundant alias such as
+  // `createNodesV2 as createNodes` collapses to `createNodes`.
+  const canonicalImported = rename(el.propertyName.text);
+  const localName = el.name.text;
+  return canonicalImported === localName
+    ? `${typePrefix}${localName}`
+    : `${typePrefix}${canonicalImported} as ${localName}`;
+}

--- a/packages/nuxt/migrations.json
+++ b/packages/nuxt/migrations.json
@@ -6,7 +6,7 @@
       "prompt": "./src/migrations/update-22-2-0/ai-instructions-for-nuxt-4.md"
     },
     "update-23-0-0-migrate-create-nodes-v2-import": {
-      "version": "23.0.0-beta.5",
+      "version": "23.0.0-beta.24",
       "description": "Rename imports of `createNodesV2` from `@nx/nuxt/plugin` to the canonical `createNodes` export.",
       "implementation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
       "documentation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"

--- a/packages/nuxt/migrations.json
+++ b/packages/nuxt/migrations.json
@@ -4,6 +4,12 @@
       "version": "22.2.0-beta.0",
       "description": "Create AI Instructions to help migrate workspaces to Nuxt 4.",
       "prompt": "./src/migrations/update-22-2-0/ai-instructions-for-nuxt-4.md"
+    },
+    "update-23-0-0-migrate-create-nodes-v2-import": {
+      "version": "23.0.0-beta.5",
+      "description": "Rename imports of `createNodesV2` from `@nx/nuxt/plugin` to the canonical `createNodes` export.",
+      "implementation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
+      "documentation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"
     }
   },
   "packageJsonUpdates": {

--- a/packages/nuxt/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md
+++ b/packages/nuxt/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md
@@ -1,0 +1,25 @@
+#### Rename `createNodesV2` imports to `createNodes`
+
+`@nx/nuxt` renamed its primary inferred-plugin export from `createNodesV2` to `createNodes`. The `createNodesV2` name is preserved as a deprecated alias for now, but new code should use `createNodes`.
+
+This migration scans every `.ts`, `.tsx`, `.cts`, and `.mts` file in your workspace and rewrites named imports and re-exports of `createNodesV2` from `@nx/nuxt/plugin` to `createNodes`.
+
+#### Sample Code Changes
+
+##### Before
+
+```ts
+import { createNodesV2 } from '@nx/nuxt/plugin';
+```
+
+##### After
+
+```ts
+import { createNodes } from '@nx/nuxt/plugin';
+```
+
+Aliases are preserved (`createNodesV2 as cn` becomes `createNodes as cn`), and if a file already imports both names (`{ createNodes, createNodesV2 }`) the redundant binding is dropped.
+
+#### What is not rewritten
+
+Only static `import`/`export` named bindings from `@nx/nuxt/plugin` are rewritten. Namespace imports, dynamic `import(...)`, `require(...)` destructuring, and property access such as `plugin.createNodesV2` are left untouched — they keep working through the `createNodesV2` runtime alias. Update those by hand if you want to drop the deprecated name everywhere.

--- a/packages/nuxt/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.spec.ts
+++ b/packages/nuxt/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.spec.ts
@@ -1,0 +1,191 @@
+import { type Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migration, {
+  rewriteCreateNodesV2Imports,
+} from './migrate-create-nodes-v2-to-create-nodes';
+
+const SPECIFIERS = new Set(['@nx/nuxt/plugin']);
+const rewrite = (source: string) =>
+  rewriteCreateNodesV2Imports(source, SPECIFIERS);
+
+describe('migrate-create-nodes-v2-to-create-nodes migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  describe('rewriteCreateNodesV2Imports', () => {
+    it('renames a lone createNodesV2 named import', () => {
+      const input = `import { createNodesV2 } from '@nx/nuxt/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/nuxt/plugin';\n`
+      );
+    });
+
+    it('preserves other named imports while renaming createNodesV2', () => {
+      const input = `import { createNodesV2, SomeOtherExport } from '@nx/nuxt/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes, SomeOtherExport } from '@nx/nuxt/plugin';\n`
+      );
+    });
+
+    it('rewrites the original name in `as` aliases', () => {
+      const input = `import { createNodesV2 as cn } from '@nx/nuxt/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes as cn } from '@nx/nuxt/plugin';\n`
+      );
+    });
+
+    it('collapses a redundant `createNodesV2 as createNodes` alias', () => {
+      const input = `import { createNodesV2 as createNodes } from '@nx/nuxt/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/nuxt/plugin';\n`
+      );
+    });
+
+    it('dedupes when both createNodes and createNodesV2 are imported', () => {
+      const input = `import { createNodes, createNodesV2 } from '@nx/nuxt/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/nuxt/plugin';\n`
+      );
+    });
+
+    it('dedupes when createNodesV2 precedes createNodes', () => {
+      const input = `import { createNodesV2, createNodes } from '@nx/nuxt/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/nuxt/plugin';\n`
+      );
+    });
+
+    it('handles multi-line named imports', () => {
+      const input = `import {\n  createNodes,\n  createNodesV2,\n  SomeOtherExport,\n} from '@nx/nuxt/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes, SomeOtherExport } from '@nx/nuxt/plugin';\n`
+      );
+    });
+
+    it('preserves a default import alongside the renamed binding', () => {
+      const input = `import def, { createNodesV2 } from '@nx/nuxt/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import def, { createNodes } from '@nx/nuxt/plugin';\n`
+      );
+    });
+
+    it('handles `import type` declarations', () => {
+      const input = `import type { createNodesV2 } from '@nx/nuxt/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import type { createNodes } from '@nx/nuxt/plugin';\n`
+      );
+    });
+
+    it('preserves inline `type` modifiers', () => {
+      const input = `import { type createNodesV2 } from '@nx/nuxt/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { type createNodes } from '@nx/nuxt/plugin';\n`
+      );
+    });
+
+    it('rewrites named re-exports', () => {
+      const input = `export { createNodesV2 } from '@nx/nuxt/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `export { createNodes } from '@nx/nuxt/plugin';\n`
+      );
+    });
+
+    it('rewrites aliased named re-exports', () => {
+      const input = `export { createNodesV2 as cn } from '@nx/nuxt/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `export { createNodes as cn } from '@nx/nuxt/plugin';\n`
+      );
+    });
+
+    it('does not touch createNodesV2 from a different specifier', () => {
+      const input = `import { createNodesV2 } from '@nx/other-plugin/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not touch createNodesV2 from a relative specifier', () => {
+      const input = `import { createNodesV2 } from './plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not touch unrelated imports from the target specifier', () => {
+      const input = `import { createNodes } from '@nx/nuxt/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not rewrite `export * from` declarations', () => {
+      const input = `export * from '@nx/nuxt/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('leaves createNodesV2 in strings and comments alone', () => {
+      const input =
+        `// import { createNodesV2 } from '@nx/nuxt/plugin';\n` +
+        `const s = "createNodesV2";\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not rewrite require() destructuring (still valid via alias)', () => {
+      const input = `const { createNodesV2 } = require('@nx/nuxt/plugin');\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+  });
+
+  describe('migration runner', () => {
+    it('rewrites imports across .ts/.tsx/.cts/.mts files', async () => {
+      tree.write(
+        'libs/foo/src/a.ts',
+        `import { createNodesV2 } from '@nx/nuxt/plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/b.tsx',
+        `import { createNodesV2 as cn } from '@nx/nuxt/plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/c.cts',
+        `export { createNodesV2 } from '@nx/nuxt/plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/d.mts',
+        `import { createNodesV2, SomeOtherExport } from '@nx/nuxt/plugin';\n`
+      );
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/a.ts', 'utf-8')).toContain(
+        `import { createNodes } from '@nx/nuxt/plugin';`
+      );
+      expect(tree.read('libs/foo/src/b.tsx', 'utf-8')).toContain(
+        `import { createNodes as cn } from '@nx/nuxt/plugin';`
+      );
+      expect(tree.read('libs/foo/src/c.cts', 'utf-8')).toContain(
+        `export { createNodes } from '@nx/nuxt/plugin';`
+      );
+      expect(tree.read('libs/foo/src/d.mts', 'utf-8')).toContain(
+        `import { createNodes, SomeOtherExport } from '@nx/nuxt/plugin';`
+      );
+    });
+
+    it('does not touch files without the deprecated name', async () => {
+      const content = `import { createNodes } from '@nx/nuxt/plugin';\n`;
+      tree.write('libs/foo/src/index.ts', content);
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/index.ts', 'utf-8')).toBe(content);
+    });
+
+    it('does not rewrite non-TS files', async () => {
+      const md = `Example: \`import { createNodesV2 } from '@nx/nuxt/plugin';\`\n`;
+      tree.write('docs/example.md', md);
+
+      await migration(tree);
+
+      expect(tree.read('docs/example.md', 'utf-8')).toContain(
+        `import { createNodesV2 } from '@nx/nuxt/plugin';`
+      );
+    });
+  });
+});

--- a/packages/nuxt/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.ts
+++ b/packages/nuxt/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.ts
@@ -1,0 +1,206 @@
+import {
+  applyChangesToString,
+  ChangeType,
+  ensurePackage,
+  formatFiles,
+  logger,
+  type StringChange,
+  type Tree,
+  visitNotIgnoredFiles,
+} from '@nx/devkit';
+import type {
+  ExportDeclaration,
+  ExportSpecifier,
+  ImportDeclaration,
+  ImportSpecifier,
+  NamedExports,
+  NamedImports,
+  SourceFile,
+} from 'typescript';
+
+const TS_EXTENSIONS = ['.ts', '.tsx', '.cts', '.mts'] as const;
+const DEPRECATED_NAME = 'createNodesV2';
+const CANONICAL_NAME = 'createNodes';
+
+// Module specifiers from which `@nx/nuxt` publicly exposes `createNodesV2`.
+// A named import or re-export of `createNodesV2` from one of these is rewritten
+// to the canonical `createNodes` export.
+const TARGET_SPECIFIERS: ReadonlySet<string> = new Set(['@nx/nuxt/plugin']);
+
+let ts: typeof import('typescript') | undefined;
+
+export default async function migrateCreateNodesV2ToCreateNodes(
+  tree: Tree
+): Promise<void> {
+  let touchedCount = 0;
+
+  visitNotIgnoredFiles(tree, '.', (filePath) => {
+    if (!TS_EXTENSIONS.some((ext) => filePath.endsWith(ext))) {
+      return;
+    }
+    const original = tree.read(filePath, 'utf-8');
+    if (!original || !original.includes(DEPRECATED_NAME)) {
+      return;
+    }
+    const updated = rewriteCreateNodesV2Imports(original, TARGET_SPECIFIERS);
+    if (updated !== original) {
+      tree.write(filePath, updated);
+      touchedCount += 1;
+    }
+  });
+
+  if (touchedCount > 0) {
+    logger.info(
+      `Renamed \`${DEPRECATED_NAME}\` imports to \`${CANONICAL_NAME}\` in ${touchedCount} file(s).`
+    );
+  }
+
+  await formatFiles(tree);
+}
+
+/**
+ * Rewrites named imports and re-exports of `createNodesV2` to `createNodes`
+ * when they come from one of the given module specifiers. Only the named
+ * bindings are touched — the module specifier, the `import`/`export` keyword,
+ * any `type` modifier, and any default import are left untouched.
+ */
+export function rewriteCreateNodesV2Imports(
+  source: string,
+  specifiers: ReadonlySet<string>
+): string {
+  ts ??= ensurePackage<typeof import('typescript')>('typescript', '*');
+  const sourceFile = ts.createSourceFile(
+    'tmp.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TSX
+  );
+
+  const changes: StringChange[] = [];
+  for (const stmt of sourceFile.statements) {
+    if (ts.isImportDeclaration(stmt)) {
+      collectImportRewrite(sourceFile, stmt, specifiers, changes);
+    } else if (ts.isExportDeclaration(stmt)) {
+      collectExportRewrite(sourceFile, stmt, specifiers, changes);
+    }
+  }
+
+  return changes.length > 0 ? applyChangesToString(source, changes) : source;
+}
+
+function isTargetSpecifier(
+  node: ImportDeclaration['moduleSpecifier'],
+  specifiers: ReadonlySet<string>
+): boolean {
+  return ts!.isStringLiteral(node) && specifiers.has(node.text);
+}
+
+function collectImportRewrite(
+  sourceFile: SourceFile,
+  stmt: ImportDeclaration,
+  specifiers: ReadonlySet<string>,
+  changes: StringChange[]
+): void {
+  if (!isTargetSpecifier(stmt.moduleSpecifier, specifiers)) {
+    return;
+  }
+  const namedBindings = stmt.importClause?.namedBindings;
+  // Only `import { ... }` carries renameable named bindings. `import x`,
+  // `import * as ns`, and side-effect imports reference the module wholesale
+  // and keep working through the `createNodesV2` runtime alias, so we leave
+  // them be. A mixed `import def, { createNodesV2 }` still has its named
+  // bindings rewritten below — the default binding is untouched.
+  if (!namedBindings || !ts!.isNamedImports(namedBindings)) {
+    return;
+  }
+  rewriteNamedBindings(sourceFile, namedBindings, changes);
+}
+
+function collectExportRewrite(
+  sourceFile: SourceFile,
+  stmt: ExportDeclaration,
+  specifiers: ReadonlySet<string>,
+  changes: StringChange[]
+): void {
+  if (
+    !stmt.moduleSpecifier ||
+    !isTargetSpecifier(stmt.moduleSpecifier, specifiers)
+  ) {
+    return;
+  }
+  // `export { ... } from '...'` can be rewritten; `export * from '...'` has no
+  // named bindings to rename.
+  if (!stmt.exportClause || !ts!.isNamedExports(stmt.exportClause)) {
+    return;
+  }
+  rewriteNamedBindings(sourceFile, stmt.exportClause, changes);
+}
+
+/**
+ * Re-renders the `{ ... }` of a named import/export, renaming any
+ * `createNodesV2` specifier to `createNodes`. If renaming would collide with a
+ * `createNodes` that is already present (e.g. `{ createNodes, createNodesV2 }`),
+ * the duplicate is dropped. Returns without recording a change when the binding
+ * list contains no `createNodesV2`.
+ */
+function rewriteNamedBindings(
+  sourceFile: SourceFile,
+  namedBindings: NamedImports | NamedExports,
+  changes: StringChange[]
+): void {
+  const elements = namedBindings.elements as readonly (
+    | ImportSpecifier
+    | ExportSpecifier
+  )[];
+  const hasDeprecated = elements.some(
+    (el) => (el.propertyName ?? el.name).text === DEPRECATED_NAME
+  );
+  if (!hasDeprecated) {
+    return;
+  }
+
+  const seen = new Set<string>();
+  const rendered: string[] = [];
+  for (const el of elements) {
+    const text = renderSpecifier(el);
+    if (!seen.has(text)) {
+      seen.add(text);
+      rendered.push(text);
+    }
+  }
+
+  const start = namedBindings.getStart(sourceFile);
+  changes.push(
+    {
+      type: ChangeType.Delete,
+      start,
+      length: namedBindings.getEnd() - start,
+    },
+    {
+      type: ChangeType.Insert,
+      index: start,
+      text: `{ ${rendered.join(', ')} }`,
+    }
+  );
+}
+
+function renderSpecifier(el: ImportSpecifier | ExportSpecifier): string {
+  const typePrefix = el.isTypeOnly ? 'type ' : '';
+  const rename = (name: string) =>
+    name === DEPRECATED_NAME ? CANONICAL_NAME : name;
+
+  // `{ name }` — no alias, so the local binding follows the rename.
+  if (!el.propertyName) {
+    return `${typePrefix}${rename(el.name.text)}`;
+  }
+
+  // `{ propertyName as name }` — only the imported (left) side is renamed; the
+  // local alias is preserved. A now-redundant alias such as
+  // `createNodesV2 as createNodes` collapses to `createNodes`.
+  const canonicalImported = rename(el.propertyName.text);
+  const localName = el.name.text;
+  return canonicalImported === localName
+    ? `${typePrefix}${localName}`
+    : `${typePrefix}${canonicalImported} as ${localName}`;
+}

--- a/packages/playwright/migrations.json
+++ b/packages/playwright/migrations.json
@@ -1,7 +1,7 @@
 {
   "generators": {
     "update-23-0-0-migrate-create-nodes-v2-import": {
-      "version": "23.0.0-beta.5",
+      "version": "23.0.0-beta.24",
       "description": "Rename imports of `createNodesV2` from `@nx/playwright/plugin` to the canonical `createNodes` export.",
       "implementation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
       "documentation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"

--- a/packages/playwright/migrations.json
+++ b/packages/playwright/migrations.json
@@ -1,3 +1,10 @@
 {
-  "generators": {}
+  "generators": {
+    "update-23-0-0-migrate-create-nodes-v2-import": {
+      "version": "23.0.0-beta.5",
+      "description": "Rename imports of `createNodesV2` from `@nx/playwright/plugin` to the canonical `createNodes` export.",
+      "implementation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
+      "documentation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"
+    }
+  }
 }

--- a/packages/playwright/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md
+++ b/packages/playwright/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md
@@ -1,0 +1,25 @@
+#### Rename `createNodesV2` imports to `createNodes`
+
+`@nx/playwright` renamed its primary inferred-plugin export from `createNodesV2` to `createNodes`. The `createNodesV2` name is preserved as a deprecated alias for now, but new code should use `createNodes`.
+
+This migration scans every `.ts`, `.tsx`, `.cts`, and `.mts` file in your workspace and rewrites named imports and re-exports of `createNodesV2` from `@nx/playwright/plugin` to `createNodes`.
+
+#### Sample Code Changes
+
+##### Before
+
+```ts
+import { createNodesV2 } from '@nx/playwright/plugin';
+```
+
+##### After
+
+```ts
+import { createNodes } from '@nx/playwright/plugin';
+```
+
+Aliases are preserved (`createNodesV2 as cn` becomes `createNodes as cn`), and if a file already imports both names (`{ createNodes, createNodesV2 }`) the redundant binding is dropped.
+
+#### What is not rewritten
+
+Only static `import`/`export` named bindings from `@nx/playwright/plugin` are rewritten. Namespace imports, dynamic `import(...)`, `require(...)` destructuring, and property access such as `plugin.createNodesV2` are left untouched — they keep working through the `createNodesV2` runtime alias. Update those by hand if you want to drop the deprecated name everywhere.

--- a/packages/playwright/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.spec.ts
+++ b/packages/playwright/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.spec.ts
@@ -1,0 +1,191 @@
+import { type Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migration, {
+  rewriteCreateNodesV2Imports,
+} from './migrate-create-nodes-v2-to-create-nodes';
+
+const SPECIFIERS = new Set(['@nx/playwright/plugin']);
+const rewrite = (source: string) =>
+  rewriteCreateNodesV2Imports(source, SPECIFIERS);
+
+describe('migrate-create-nodes-v2-to-create-nodes migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  describe('rewriteCreateNodesV2Imports', () => {
+    it('renames a lone createNodesV2 named import', () => {
+      const input = `import { createNodesV2 } from '@nx/playwright/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/playwright/plugin';\n`
+      );
+    });
+
+    it('preserves other named imports while renaming createNodesV2', () => {
+      const input = `import { createNodesV2, SomeOtherExport } from '@nx/playwright/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes, SomeOtherExport } from '@nx/playwright/plugin';\n`
+      );
+    });
+
+    it('rewrites the original name in `as` aliases', () => {
+      const input = `import { createNodesV2 as cn } from '@nx/playwright/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes as cn } from '@nx/playwright/plugin';\n`
+      );
+    });
+
+    it('collapses a redundant `createNodesV2 as createNodes` alias', () => {
+      const input = `import { createNodesV2 as createNodes } from '@nx/playwright/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/playwright/plugin';\n`
+      );
+    });
+
+    it('dedupes when both createNodes and createNodesV2 are imported', () => {
+      const input = `import { createNodes, createNodesV2 } from '@nx/playwright/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/playwright/plugin';\n`
+      );
+    });
+
+    it('dedupes when createNodesV2 precedes createNodes', () => {
+      const input = `import { createNodesV2, createNodes } from '@nx/playwright/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/playwright/plugin';\n`
+      );
+    });
+
+    it('handles multi-line named imports', () => {
+      const input = `import {\n  createNodes,\n  createNodesV2,\n  SomeOtherExport,\n} from '@nx/playwright/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes, SomeOtherExport } from '@nx/playwright/plugin';\n`
+      );
+    });
+
+    it('preserves a default import alongside the renamed binding', () => {
+      const input = `import def, { createNodesV2 } from '@nx/playwright/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import def, { createNodes } from '@nx/playwright/plugin';\n`
+      );
+    });
+
+    it('handles `import type` declarations', () => {
+      const input = `import type { createNodesV2 } from '@nx/playwright/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import type { createNodes } from '@nx/playwright/plugin';\n`
+      );
+    });
+
+    it('preserves inline `type` modifiers', () => {
+      const input = `import { type createNodesV2 } from '@nx/playwright/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { type createNodes } from '@nx/playwright/plugin';\n`
+      );
+    });
+
+    it('rewrites named re-exports', () => {
+      const input = `export { createNodesV2 } from '@nx/playwright/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `export { createNodes } from '@nx/playwright/plugin';\n`
+      );
+    });
+
+    it('rewrites aliased named re-exports', () => {
+      const input = `export { createNodesV2 as cn } from '@nx/playwright/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `export { createNodes as cn } from '@nx/playwright/plugin';\n`
+      );
+    });
+
+    it('does not touch createNodesV2 from a different specifier', () => {
+      const input = `import { createNodesV2 } from '@nx/other-plugin/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not touch createNodesV2 from a relative specifier', () => {
+      const input = `import { createNodesV2 } from './plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not touch unrelated imports from the target specifier', () => {
+      const input = `import { createNodes } from '@nx/playwright/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not rewrite `export * from` declarations', () => {
+      const input = `export * from '@nx/playwright/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('leaves createNodesV2 in strings and comments alone', () => {
+      const input =
+        `// import { createNodesV2 } from '@nx/playwright/plugin';\n` +
+        `const s = "createNodesV2";\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not rewrite require() destructuring (still valid via alias)', () => {
+      const input = `const { createNodesV2 } = require('@nx/playwright/plugin');\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+  });
+
+  describe('migration runner', () => {
+    it('rewrites imports across .ts/.tsx/.cts/.mts files', async () => {
+      tree.write(
+        'libs/foo/src/a.ts',
+        `import { createNodesV2 } from '@nx/playwright/plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/b.tsx',
+        `import { createNodesV2 as cn } from '@nx/playwright/plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/c.cts',
+        `export { createNodesV2 } from '@nx/playwright/plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/d.mts',
+        `import { createNodesV2, SomeOtherExport } from '@nx/playwright/plugin';\n`
+      );
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/a.ts', 'utf-8')).toContain(
+        `import { createNodes } from '@nx/playwright/plugin';`
+      );
+      expect(tree.read('libs/foo/src/b.tsx', 'utf-8')).toContain(
+        `import { createNodes as cn } from '@nx/playwright/plugin';`
+      );
+      expect(tree.read('libs/foo/src/c.cts', 'utf-8')).toContain(
+        `export { createNodes } from '@nx/playwright/plugin';`
+      );
+      expect(tree.read('libs/foo/src/d.mts', 'utf-8')).toContain(
+        `import { createNodes, SomeOtherExport } from '@nx/playwright/plugin';`
+      );
+    });
+
+    it('does not touch files without the deprecated name', async () => {
+      const content = `import { createNodes } from '@nx/playwright/plugin';\n`;
+      tree.write('libs/foo/src/index.ts', content);
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/index.ts', 'utf-8')).toBe(content);
+    });
+
+    it('does not rewrite non-TS files', async () => {
+      const md = `Example: \`import { createNodesV2 } from '@nx/playwright/plugin';\`\n`;
+      tree.write('docs/example.md', md);
+
+      await migration(tree);
+
+      expect(tree.read('docs/example.md', 'utf-8')).toContain(
+        `import { createNodesV2 } from '@nx/playwright/plugin';`
+      );
+    });
+  });
+});

--- a/packages/playwright/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.ts
+++ b/packages/playwright/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.ts
@@ -1,0 +1,208 @@
+import {
+  applyChangesToString,
+  ChangeType,
+  ensurePackage,
+  formatFiles,
+  logger,
+  type StringChange,
+  type Tree,
+  visitNotIgnoredFiles,
+} from '@nx/devkit';
+import type {
+  ExportDeclaration,
+  ExportSpecifier,
+  ImportDeclaration,
+  ImportSpecifier,
+  NamedExports,
+  NamedImports,
+  SourceFile,
+} from 'typescript';
+
+const TS_EXTENSIONS = ['.ts', '.tsx', '.cts', '.mts'] as const;
+const DEPRECATED_NAME = 'createNodesV2';
+const CANONICAL_NAME = 'createNodes';
+
+// Module specifiers from which `@nx/playwright` publicly exposes `createNodesV2`.
+// A named import or re-export of `createNodesV2` from one of these is rewritten
+// to the canonical `createNodes` export.
+const TARGET_SPECIFIERS: ReadonlySet<string> = new Set([
+  '@nx/playwright/plugin',
+]);
+
+let ts: typeof import('typescript') | undefined;
+
+export default async function migrateCreateNodesV2ToCreateNodes(
+  tree: Tree
+): Promise<void> {
+  let touchedCount = 0;
+
+  visitNotIgnoredFiles(tree, '.', (filePath) => {
+    if (!TS_EXTENSIONS.some((ext) => filePath.endsWith(ext))) {
+      return;
+    }
+    const original = tree.read(filePath, 'utf-8');
+    if (!original || !original.includes(DEPRECATED_NAME)) {
+      return;
+    }
+    const updated = rewriteCreateNodesV2Imports(original, TARGET_SPECIFIERS);
+    if (updated !== original) {
+      tree.write(filePath, updated);
+      touchedCount += 1;
+    }
+  });
+
+  if (touchedCount > 0) {
+    logger.info(
+      `Renamed \`${DEPRECATED_NAME}\` imports to \`${CANONICAL_NAME}\` in ${touchedCount} file(s).`
+    );
+  }
+
+  await formatFiles(tree);
+}
+
+/**
+ * Rewrites named imports and re-exports of `createNodesV2` to `createNodes`
+ * when they come from one of the given module specifiers. Only the named
+ * bindings are touched — the module specifier, the `import`/`export` keyword,
+ * any `type` modifier, and any default import are left untouched.
+ */
+export function rewriteCreateNodesV2Imports(
+  source: string,
+  specifiers: ReadonlySet<string>
+): string {
+  ts ??= ensurePackage<typeof import('typescript')>('typescript', '*');
+  const sourceFile = ts.createSourceFile(
+    'tmp.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TSX
+  );
+
+  const changes: StringChange[] = [];
+  for (const stmt of sourceFile.statements) {
+    if (ts.isImportDeclaration(stmt)) {
+      collectImportRewrite(sourceFile, stmt, specifiers, changes);
+    } else if (ts.isExportDeclaration(stmt)) {
+      collectExportRewrite(sourceFile, stmt, specifiers, changes);
+    }
+  }
+
+  return changes.length > 0 ? applyChangesToString(source, changes) : source;
+}
+
+function isTargetSpecifier(
+  node: ImportDeclaration['moduleSpecifier'],
+  specifiers: ReadonlySet<string>
+): boolean {
+  return ts!.isStringLiteral(node) && specifiers.has(node.text);
+}
+
+function collectImportRewrite(
+  sourceFile: SourceFile,
+  stmt: ImportDeclaration,
+  specifiers: ReadonlySet<string>,
+  changes: StringChange[]
+): void {
+  if (!isTargetSpecifier(stmt.moduleSpecifier, specifiers)) {
+    return;
+  }
+  const namedBindings = stmt.importClause?.namedBindings;
+  // Only `import { ... }` carries renameable named bindings. `import x`,
+  // `import * as ns`, and side-effect imports reference the module wholesale
+  // and keep working through the `createNodesV2` runtime alias, so we leave
+  // them be. A mixed `import def, { createNodesV2 }` still has its named
+  // bindings rewritten below — the default binding is untouched.
+  if (!namedBindings || !ts!.isNamedImports(namedBindings)) {
+    return;
+  }
+  rewriteNamedBindings(sourceFile, namedBindings, changes);
+}
+
+function collectExportRewrite(
+  sourceFile: SourceFile,
+  stmt: ExportDeclaration,
+  specifiers: ReadonlySet<string>,
+  changes: StringChange[]
+): void {
+  if (
+    !stmt.moduleSpecifier ||
+    !isTargetSpecifier(stmt.moduleSpecifier, specifiers)
+  ) {
+    return;
+  }
+  // `export { ... } from '...'` can be rewritten; `export * from '...'` has no
+  // named bindings to rename.
+  if (!stmt.exportClause || !ts!.isNamedExports(stmt.exportClause)) {
+    return;
+  }
+  rewriteNamedBindings(sourceFile, stmt.exportClause, changes);
+}
+
+/**
+ * Re-renders the `{ ... }` of a named import/export, renaming any
+ * `createNodesV2` specifier to `createNodes`. If renaming would collide with a
+ * `createNodes` that is already present (e.g. `{ createNodes, createNodesV2 }`),
+ * the duplicate is dropped. Returns without recording a change when the binding
+ * list contains no `createNodesV2`.
+ */
+function rewriteNamedBindings(
+  sourceFile: SourceFile,
+  namedBindings: NamedImports | NamedExports,
+  changes: StringChange[]
+): void {
+  const elements = namedBindings.elements as readonly (
+    | ImportSpecifier
+    | ExportSpecifier
+  )[];
+  const hasDeprecated = elements.some(
+    (el) => (el.propertyName ?? el.name).text === DEPRECATED_NAME
+  );
+  if (!hasDeprecated) {
+    return;
+  }
+
+  const seen = new Set<string>();
+  const rendered: string[] = [];
+  for (const el of elements) {
+    const text = renderSpecifier(el);
+    if (!seen.has(text)) {
+      seen.add(text);
+      rendered.push(text);
+    }
+  }
+
+  const start = namedBindings.getStart(sourceFile);
+  changes.push(
+    {
+      type: ChangeType.Delete,
+      start,
+      length: namedBindings.getEnd() - start,
+    },
+    {
+      type: ChangeType.Insert,
+      index: start,
+      text: `{ ${rendered.join(', ')} }`,
+    }
+  );
+}
+
+function renderSpecifier(el: ImportSpecifier | ExportSpecifier): string {
+  const typePrefix = el.isTypeOnly ? 'type ' : '';
+  const rename = (name: string) =>
+    name === DEPRECATED_NAME ? CANONICAL_NAME : name;
+
+  // `{ name }` — no alias, so the local binding follows the rename.
+  if (!el.propertyName) {
+    return `${typePrefix}${rename(el.name.text)}`;
+  }
+
+  // `{ propertyName as name }` — only the imported (left) side is renamed; the
+  // local alias is preserved. A now-redundant alias such as
+  // `createNodesV2 as createNodes` collapses to `createNodes`.
+  const canonicalImported = rename(el.propertyName.text);
+  const localName = el.name.text;
+  return canonicalImported === localName
+    ? `${typePrefix}${localName}`
+    : `${typePrefix}${canonicalImported} as ${localName}`;
+}

--- a/packages/react-native/migrations.json
+++ b/packages/react-native/migrations.json
@@ -13,7 +13,7 @@
       "factory": "./src/migrations/update-21-4-0/upgrade-react-native-projects"
     },
     "update-23-0-0-migrate-create-nodes-v2-import": {
-      "version": "23.0.0-beta.5",
+      "version": "23.0.0-beta.24",
       "description": "Rename imports of `createNodesV2` from `@nx/react-native/plugin` to the canonical `createNodes` export.",
       "implementation": "./src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
       "documentation": "./src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"

--- a/packages/react-native/migrations.json
+++ b/packages/react-native/migrations.json
@@ -11,6 +11,12 @@
       "cli": "nx",
       "description": "Run nx upgrade for each React Native project",
       "factory": "./src/migrations/update-21-4-0/upgrade-react-native-projects"
+    },
+    "update-23-0-0-migrate-create-nodes-v2-import": {
+      "version": "23.0.0-beta.5",
+      "description": "Rename imports of `createNodesV2` from `@nx/react-native/plugin` to the canonical `createNodes` export.",
+      "implementation": "./src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
+      "documentation": "./src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"
     }
   },
   "packageJsonUpdates": {

--- a/packages/react-native/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md
+++ b/packages/react-native/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md
@@ -1,0 +1,25 @@
+#### Rename `createNodesV2` imports to `createNodes`
+
+`@nx/react-native` renamed its primary inferred-plugin export from `createNodesV2` to `createNodes`. The `createNodesV2` name is preserved as a deprecated alias for now, but new code should use `createNodes`.
+
+This migration scans every `.ts`, `.tsx`, `.cts`, and `.mts` file in your workspace and rewrites named imports and re-exports of `createNodesV2` from `@nx/react-native/plugin` to `createNodes`.
+
+#### Sample Code Changes
+
+##### Before
+
+```ts
+import { createNodesV2 } from '@nx/react-native/plugin';
+```
+
+##### After
+
+```ts
+import { createNodes } from '@nx/react-native/plugin';
+```
+
+Aliases are preserved (`createNodesV2 as cn` becomes `createNodes as cn`), and if a file already imports both names (`{ createNodes, createNodesV2 }`) the redundant binding is dropped.
+
+#### What is not rewritten
+
+Only static `import`/`export` named bindings from `@nx/react-native/plugin` are rewritten. Namespace imports, dynamic `import(...)`, `require(...)` destructuring, and property access such as `plugin.createNodesV2` are left untouched — they keep working through the `createNodesV2` runtime alias. Update those by hand if you want to drop the deprecated name everywhere.

--- a/packages/react-native/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.spec.ts
+++ b/packages/react-native/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.spec.ts
@@ -1,0 +1,191 @@
+import { type Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migration, {
+  rewriteCreateNodesV2Imports,
+} from './migrate-create-nodes-v2-to-create-nodes';
+
+const SPECIFIERS = new Set(['@nx/react-native/plugin']);
+const rewrite = (source: string) =>
+  rewriteCreateNodesV2Imports(source, SPECIFIERS);
+
+describe('migrate-create-nodes-v2-to-create-nodes migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  describe('rewriteCreateNodesV2Imports', () => {
+    it('renames a lone createNodesV2 named import', () => {
+      const input = `import { createNodesV2 } from '@nx/react-native/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/react-native/plugin';\n`
+      );
+    });
+
+    it('preserves other named imports while renaming createNodesV2', () => {
+      const input = `import { createNodesV2, SomeOtherExport } from '@nx/react-native/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes, SomeOtherExport } from '@nx/react-native/plugin';\n`
+      );
+    });
+
+    it('rewrites the original name in `as` aliases', () => {
+      const input = `import { createNodesV2 as cn } from '@nx/react-native/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes as cn } from '@nx/react-native/plugin';\n`
+      );
+    });
+
+    it('collapses a redundant `createNodesV2 as createNodes` alias', () => {
+      const input = `import { createNodesV2 as createNodes } from '@nx/react-native/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/react-native/plugin';\n`
+      );
+    });
+
+    it('dedupes when both createNodes and createNodesV2 are imported', () => {
+      const input = `import { createNodes, createNodesV2 } from '@nx/react-native/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/react-native/plugin';\n`
+      );
+    });
+
+    it('dedupes when createNodesV2 precedes createNodes', () => {
+      const input = `import { createNodesV2, createNodes } from '@nx/react-native/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/react-native/plugin';\n`
+      );
+    });
+
+    it('handles multi-line named imports', () => {
+      const input = `import {\n  createNodes,\n  createNodesV2,\n  SomeOtherExport,\n} from '@nx/react-native/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes, SomeOtherExport } from '@nx/react-native/plugin';\n`
+      );
+    });
+
+    it('preserves a default import alongside the renamed binding', () => {
+      const input = `import def, { createNodesV2 } from '@nx/react-native/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import def, { createNodes } from '@nx/react-native/plugin';\n`
+      );
+    });
+
+    it('handles `import type` declarations', () => {
+      const input = `import type { createNodesV2 } from '@nx/react-native/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import type { createNodes } from '@nx/react-native/plugin';\n`
+      );
+    });
+
+    it('preserves inline `type` modifiers', () => {
+      const input = `import { type createNodesV2 } from '@nx/react-native/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { type createNodes } from '@nx/react-native/plugin';\n`
+      );
+    });
+
+    it('rewrites named re-exports', () => {
+      const input = `export { createNodesV2 } from '@nx/react-native/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `export { createNodes } from '@nx/react-native/plugin';\n`
+      );
+    });
+
+    it('rewrites aliased named re-exports', () => {
+      const input = `export { createNodesV2 as cn } from '@nx/react-native/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `export { createNodes as cn } from '@nx/react-native/plugin';\n`
+      );
+    });
+
+    it('does not touch createNodesV2 from a different specifier', () => {
+      const input = `import { createNodesV2 } from '@nx/other-plugin/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not touch createNodesV2 from a relative specifier', () => {
+      const input = `import { createNodesV2 } from './plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not touch unrelated imports from the target specifier', () => {
+      const input = `import { createNodes } from '@nx/react-native/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not rewrite `export * from` declarations', () => {
+      const input = `export * from '@nx/react-native/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('leaves createNodesV2 in strings and comments alone', () => {
+      const input =
+        `// import { createNodesV2 } from '@nx/react-native/plugin';\n` +
+        `const s = "createNodesV2";\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not rewrite require() destructuring (still valid via alias)', () => {
+      const input = `const { createNodesV2 } = require('@nx/react-native/plugin');\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+  });
+
+  describe('migration runner', () => {
+    it('rewrites imports across .ts/.tsx/.cts/.mts files', async () => {
+      tree.write(
+        'libs/foo/src/a.ts',
+        `import { createNodesV2 } from '@nx/react-native/plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/b.tsx',
+        `import { createNodesV2 as cn } from '@nx/react-native/plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/c.cts',
+        `export { createNodesV2 } from '@nx/react-native/plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/d.mts',
+        `import { createNodesV2, SomeOtherExport } from '@nx/react-native/plugin';\n`
+      );
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/a.ts', 'utf-8')).toContain(
+        `import { createNodes } from '@nx/react-native/plugin';`
+      );
+      expect(tree.read('libs/foo/src/b.tsx', 'utf-8')).toContain(
+        `import { createNodes as cn } from '@nx/react-native/plugin';`
+      );
+      expect(tree.read('libs/foo/src/c.cts', 'utf-8')).toContain(
+        `export { createNodes } from '@nx/react-native/plugin';`
+      );
+      expect(tree.read('libs/foo/src/d.mts', 'utf-8')).toContain(
+        `import { createNodes, SomeOtherExport } from '@nx/react-native/plugin';`
+      );
+    });
+
+    it('does not touch files without the deprecated name', async () => {
+      const content = `import { createNodes } from '@nx/react-native/plugin';\n`;
+      tree.write('libs/foo/src/index.ts', content);
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/index.ts', 'utf-8')).toBe(content);
+    });
+
+    it('does not rewrite non-TS files', async () => {
+      const md = `Example: \`import { createNodesV2 } from '@nx/react-native/plugin';\`\n`;
+      tree.write('docs/example.md', md);
+
+      await migration(tree);
+
+      expect(tree.read('docs/example.md', 'utf-8')).toContain(
+        `import { createNodesV2 } from '@nx/react-native/plugin';`
+      );
+    });
+  });
+});

--- a/packages/react-native/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.ts
+++ b/packages/react-native/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.ts
@@ -1,0 +1,208 @@
+import {
+  applyChangesToString,
+  ChangeType,
+  ensurePackage,
+  formatFiles,
+  logger,
+  type StringChange,
+  type Tree,
+  visitNotIgnoredFiles,
+} from '@nx/devkit';
+import type {
+  ExportDeclaration,
+  ExportSpecifier,
+  ImportDeclaration,
+  ImportSpecifier,
+  NamedExports,
+  NamedImports,
+  SourceFile,
+} from 'typescript';
+
+const TS_EXTENSIONS = ['.ts', '.tsx', '.cts', '.mts'] as const;
+const DEPRECATED_NAME = 'createNodesV2';
+const CANONICAL_NAME = 'createNodes';
+
+// Module specifiers from which `@nx/react-native` publicly exposes `createNodesV2`.
+// A named import or re-export of `createNodesV2` from one of these is rewritten
+// to the canonical `createNodes` export.
+const TARGET_SPECIFIERS: ReadonlySet<string> = new Set([
+  '@nx/react-native/plugin',
+]);
+
+let ts: typeof import('typescript') | undefined;
+
+export default async function migrateCreateNodesV2ToCreateNodes(
+  tree: Tree
+): Promise<void> {
+  let touchedCount = 0;
+
+  visitNotIgnoredFiles(tree, '.', (filePath) => {
+    if (!TS_EXTENSIONS.some((ext) => filePath.endsWith(ext))) {
+      return;
+    }
+    const original = tree.read(filePath, 'utf-8');
+    if (!original || !original.includes(DEPRECATED_NAME)) {
+      return;
+    }
+    const updated = rewriteCreateNodesV2Imports(original, TARGET_SPECIFIERS);
+    if (updated !== original) {
+      tree.write(filePath, updated);
+      touchedCount += 1;
+    }
+  });
+
+  if (touchedCount > 0) {
+    logger.info(
+      `Renamed \`${DEPRECATED_NAME}\` imports to \`${CANONICAL_NAME}\` in ${touchedCount} file(s).`
+    );
+  }
+
+  await formatFiles(tree);
+}
+
+/**
+ * Rewrites named imports and re-exports of `createNodesV2` to `createNodes`
+ * when they come from one of the given module specifiers. Only the named
+ * bindings are touched — the module specifier, the `import`/`export` keyword,
+ * any `type` modifier, and any default import are left untouched.
+ */
+export function rewriteCreateNodesV2Imports(
+  source: string,
+  specifiers: ReadonlySet<string>
+): string {
+  ts ??= ensurePackage<typeof import('typescript')>('typescript', '*');
+  const sourceFile = ts.createSourceFile(
+    'tmp.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TSX
+  );
+
+  const changes: StringChange[] = [];
+  for (const stmt of sourceFile.statements) {
+    if (ts.isImportDeclaration(stmt)) {
+      collectImportRewrite(sourceFile, stmt, specifiers, changes);
+    } else if (ts.isExportDeclaration(stmt)) {
+      collectExportRewrite(sourceFile, stmt, specifiers, changes);
+    }
+  }
+
+  return changes.length > 0 ? applyChangesToString(source, changes) : source;
+}
+
+function isTargetSpecifier(
+  node: ImportDeclaration['moduleSpecifier'],
+  specifiers: ReadonlySet<string>
+): boolean {
+  return ts!.isStringLiteral(node) && specifiers.has(node.text);
+}
+
+function collectImportRewrite(
+  sourceFile: SourceFile,
+  stmt: ImportDeclaration,
+  specifiers: ReadonlySet<string>,
+  changes: StringChange[]
+): void {
+  if (!isTargetSpecifier(stmt.moduleSpecifier, specifiers)) {
+    return;
+  }
+  const namedBindings = stmt.importClause?.namedBindings;
+  // Only `import { ... }` carries renameable named bindings. `import x`,
+  // `import * as ns`, and side-effect imports reference the module wholesale
+  // and keep working through the `createNodesV2` runtime alias, so we leave
+  // them be. A mixed `import def, { createNodesV2 }` still has its named
+  // bindings rewritten below — the default binding is untouched.
+  if (!namedBindings || !ts!.isNamedImports(namedBindings)) {
+    return;
+  }
+  rewriteNamedBindings(sourceFile, namedBindings, changes);
+}
+
+function collectExportRewrite(
+  sourceFile: SourceFile,
+  stmt: ExportDeclaration,
+  specifiers: ReadonlySet<string>,
+  changes: StringChange[]
+): void {
+  if (
+    !stmt.moduleSpecifier ||
+    !isTargetSpecifier(stmt.moduleSpecifier, specifiers)
+  ) {
+    return;
+  }
+  // `export { ... } from '...'` can be rewritten; `export * from '...'` has no
+  // named bindings to rename.
+  if (!stmt.exportClause || !ts!.isNamedExports(stmt.exportClause)) {
+    return;
+  }
+  rewriteNamedBindings(sourceFile, stmt.exportClause, changes);
+}
+
+/**
+ * Re-renders the `{ ... }` of a named import/export, renaming any
+ * `createNodesV2` specifier to `createNodes`. If renaming would collide with a
+ * `createNodes` that is already present (e.g. `{ createNodes, createNodesV2 }`),
+ * the duplicate is dropped. Returns without recording a change when the binding
+ * list contains no `createNodesV2`.
+ */
+function rewriteNamedBindings(
+  sourceFile: SourceFile,
+  namedBindings: NamedImports | NamedExports,
+  changes: StringChange[]
+): void {
+  const elements = namedBindings.elements as readonly (
+    | ImportSpecifier
+    | ExportSpecifier
+  )[];
+  const hasDeprecated = elements.some(
+    (el) => (el.propertyName ?? el.name).text === DEPRECATED_NAME
+  );
+  if (!hasDeprecated) {
+    return;
+  }
+
+  const seen = new Set<string>();
+  const rendered: string[] = [];
+  for (const el of elements) {
+    const text = renderSpecifier(el);
+    if (!seen.has(text)) {
+      seen.add(text);
+      rendered.push(text);
+    }
+  }
+
+  const start = namedBindings.getStart(sourceFile);
+  changes.push(
+    {
+      type: ChangeType.Delete,
+      start,
+      length: namedBindings.getEnd() - start,
+    },
+    {
+      type: ChangeType.Insert,
+      index: start,
+      text: `{ ${rendered.join(', ')} }`,
+    }
+  );
+}
+
+function renderSpecifier(el: ImportSpecifier | ExportSpecifier): string {
+  const typePrefix = el.isTypeOnly ? 'type ' : '';
+  const rename = (name: string) =>
+    name === DEPRECATED_NAME ? CANONICAL_NAME : name;
+
+  // `{ name }` — no alias, so the local binding follows the rename.
+  if (!el.propertyName) {
+    return `${typePrefix}${rename(el.name.text)}`;
+  }
+
+  // `{ propertyName as name }` — only the imported (left) side is renamed; the
+  // local alias is preserved. A now-redundant alias such as
+  // `createNodesV2 as createNodes` collapses to `createNodes`.
+  const canonicalImported = rename(el.propertyName.text);
+  const localName = el.name.text;
+  return canonicalImported === localName
+    ? `${typePrefix}${localName}`
+    : `${typePrefix}${canonicalImported} as ${localName}`;
+}

--- a/packages/react/migrations.json
+++ b/packages/react/migrations.json
@@ -47,6 +47,12 @@
       "description": "Rewrites imports of NxReactWebpackPlugin from '@nx/react' to the sub-path '@nx/react/webpack-plugin'.",
       "factory": "./src/migrations/update-23-0-0/remove-nx-react-webpack-plugin-import",
       "documentation": "./src/migrations/update-23-0-0/remove-nx-react-webpack-plugin-import.md"
+    },
+    "update-23-0-0-migrate-create-nodes-v2-import": {
+      "version": "23.0.0-beta.5",
+      "description": "Rename imports of `createNodesV2` from `@nx/react/router-plugin` to the canonical `createNodes` export.",
+      "implementation": "./src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
+      "documentation": "./src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"
     }
   },
   "packageJsonUpdates": {

--- a/packages/react/migrations.json
+++ b/packages/react/migrations.json
@@ -49,7 +49,7 @@
       "documentation": "./src/migrations/update-23-0-0/remove-nx-react-webpack-plugin-import.md"
     },
     "update-23-0-0-migrate-create-nodes-v2-import": {
-      "version": "23.0.0-beta.5",
+      "version": "23.0.0-beta.24",
       "description": "Rename imports of `createNodesV2` from `@nx/react/router-plugin` to the canonical `createNodes` export.",
       "implementation": "./src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
       "documentation": "./src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"

--- a/packages/react/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md
+++ b/packages/react/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md
@@ -1,0 +1,25 @@
+#### Rename `createNodesV2` imports to `createNodes`
+
+`@nx/react` renamed its primary inferred-plugin export from `createNodesV2` to `createNodes`. The `createNodesV2` name is preserved as a deprecated alias for now, but new code should use `createNodes`.
+
+This migration scans every `.ts`, `.tsx`, `.cts`, and `.mts` file in your workspace and rewrites named imports and re-exports of `createNodesV2` from `@nx/react/router-plugin` to `createNodes`.
+
+#### Sample Code Changes
+
+##### Before
+
+```ts
+import { createNodesV2 } from '@nx/react/router-plugin';
+```
+
+##### After
+
+```ts
+import { createNodes } from '@nx/react/router-plugin';
+```
+
+Aliases are preserved (`createNodesV2 as cn` becomes `createNodes as cn`), and if a file already imports both names (`{ createNodes, createNodesV2 }`) the redundant binding is dropped.
+
+#### What is not rewritten
+
+Only static `import`/`export` named bindings from `@nx/react/router-plugin` are rewritten. Namespace imports, dynamic `import(...)`, `require(...)` destructuring, and property access such as `plugin.createNodesV2` are left untouched — they keep working through the `createNodesV2` runtime alias. Update those by hand if you want to drop the deprecated name everywhere.

--- a/packages/react/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.spec.ts
+++ b/packages/react/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.spec.ts
@@ -1,0 +1,191 @@
+import { type Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migration, {
+  rewriteCreateNodesV2Imports,
+} from './migrate-create-nodes-v2-to-create-nodes';
+
+const SPECIFIERS = new Set(['@nx/react/router-plugin']);
+const rewrite = (source: string) =>
+  rewriteCreateNodesV2Imports(source, SPECIFIERS);
+
+describe('migrate-create-nodes-v2-to-create-nodes migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  describe('rewriteCreateNodesV2Imports', () => {
+    it('renames a lone createNodesV2 named import', () => {
+      const input = `import { createNodesV2 } from '@nx/react/router-plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/react/router-plugin';\n`
+      );
+    });
+
+    it('preserves other named imports while renaming createNodesV2', () => {
+      const input = `import { createNodesV2, SomeOtherExport } from '@nx/react/router-plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes, SomeOtherExport } from '@nx/react/router-plugin';\n`
+      );
+    });
+
+    it('rewrites the original name in `as` aliases', () => {
+      const input = `import { createNodesV2 as cn } from '@nx/react/router-plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes as cn } from '@nx/react/router-plugin';\n`
+      );
+    });
+
+    it('collapses a redundant `createNodesV2 as createNodes` alias', () => {
+      const input = `import { createNodesV2 as createNodes } from '@nx/react/router-plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/react/router-plugin';\n`
+      );
+    });
+
+    it('dedupes when both createNodes and createNodesV2 are imported', () => {
+      const input = `import { createNodes, createNodesV2 } from '@nx/react/router-plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/react/router-plugin';\n`
+      );
+    });
+
+    it('dedupes when createNodesV2 precedes createNodes', () => {
+      const input = `import { createNodesV2, createNodes } from '@nx/react/router-plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/react/router-plugin';\n`
+      );
+    });
+
+    it('handles multi-line named imports', () => {
+      const input = `import {\n  createNodes,\n  createNodesV2,\n  SomeOtherExport,\n} from '@nx/react/router-plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes, SomeOtherExport } from '@nx/react/router-plugin';\n`
+      );
+    });
+
+    it('preserves a default import alongside the renamed binding', () => {
+      const input = `import def, { createNodesV2 } from '@nx/react/router-plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import def, { createNodes } from '@nx/react/router-plugin';\n`
+      );
+    });
+
+    it('handles `import type` declarations', () => {
+      const input = `import type { createNodesV2 } from '@nx/react/router-plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import type { createNodes } from '@nx/react/router-plugin';\n`
+      );
+    });
+
+    it('preserves inline `type` modifiers', () => {
+      const input = `import { type createNodesV2 } from '@nx/react/router-plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { type createNodes } from '@nx/react/router-plugin';\n`
+      );
+    });
+
+    it('rewrites named re-exports', () => {
+      const input = `export { createNodesV2 } from '@nx/react/router-plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `export { createNodes } from '@nx/react/router-plugin';\n`
+      );
+    });
+
+    it('rewrites aliased named re-exports', () => {
+      const input = `export { createNodesV2 as cn } from '@nx/react/router-plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `export { createNodes as cn } from '@nx/react/router-plugin';\n`
+      );
+    });
+
+    it('does not touch createNodesV2 from a different specifier', () => {
+      const input = `import { createNodesV2 } from '@nx/other-plugin/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not touch createNodesV2 from a relative specifier', () => {
+      const input = `import { createNodesV2 } from './plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not touch unrelated imports from the target specifier', () => {
+      const input = `import { createNodes } from '@nx/react/router-plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not rewrite `export * from` declarations', () => {
+      const input = `export * from '@nx/react/router-plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('leaves createNodesV2 in strings and comments alone', () => {
+      const input =
+        `// import { createNodesV2 } from '@nx/react/router-plugin';\n` +
+        `const s = "createNodesV2";\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not rewrite require() destructuring (still valid via alias)', () => {
+      const input = `const { createNodesV2 } = require('@nx/react/router-plugin');\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+  });
+
+  describe('migration runner', () => {
+    it('rewrites imports across .ts/.tsx/.cts/.mts files', async () => {
+      tree.write(
+        'libs/foo/src/a.ts',
+        `import { createNodesV2 } from '@nx/react/router-plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/b.tsx',
+        `import { createNodesV2 as cn } from '@nx/react/router-plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/c.cts',
+        `export { createNodesV2 } from '@nx/react/router-plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/d.mts',
+        `import { createNodesV2, SomeOtherExport } from '@nx/react/router-plugin';\n`
+      );
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/a.ts', 'utf-8')).toContain(
+        `import { createNodes } from '@nx/react/router-plugin';`
+      );
+      expect(tree.read('libs/foo/src/b.tsx', 'utf-8')).toContain(
+        `import { createNodes as cn } from '@nx/react/router-plugin';`
+      );
+      expect(tree.read('libs/foo/src/c.cts', 'utf-8')).toContain(
+        `export { createNodes } from '@nx/react/router-plugin';`
+      );
+      expect(tree.read('libs/foo/src/d.mts', 'utf-8')).toContain(
+        `import { createNodes, SomeOtherExport } from '@nx/react/router-plugin';`
+      );
+    });
+
+    it('does not touch files without the deprecated name', async () => {
+      const content = `import { createNodes } from '@nx/react/router-plugin';\n`;
+      tree.write('libs/foo/src/index.ts', content);
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/index.ts', 'utf-8')).toBe(content);
+    });
+
+    it('does not rewrite non-TS files', async () => {
+      const md = `Example: \`import { createNodesV2 } from '@nx/react/router-plugin';\`\n`;
+      tree.write('docs/example.md', md);
+
+      await migration(tree);
+
+      expect(tree.read('docs/example.md', 'utf-8')).toContain(
+        `import { createNodesV2 } from '@nx/react/router-plugin';`
+      );
+    });
+  });
+});

--- a/packages/react/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.ts
+++ b/packages/react/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.ts
@@ -1,0 +1,208 @@
+import {
+  applyChangesToString,
+  ChangeType,
+  ensurePackage,
+  formatFiles,
+  logger,
+  type StringChange,
+  type Tree,
+  visitNotIgnoredFiles,
+} from '@nx/devkit';
+import type {
+  ExportDeclaration,
+  ExportSpecifier,
+  ImportDeclaration,
+  ImportSpecifier,
+  NamedExports,
+  NamedImports,
+  SourceFile,
+} from 'typescript';
+
+const TS_EXTENSIONS = ['.ts', '.tsx', '.cts', '.mts'] as const;
+const DEPRECATED_NAME = 'createNodesV2';
+const CANONICAL_NAME = 'createNodes';
+
+// Module specifiers from which `@nx/react` publicly exposes `createNodesV2`.
+// A named import or re-export of `createNodesV2` from one of these is rewritten
+// to the canonical `createNodes` export.
+const TARGET_SPECIFIERS: ReadonlySet<string> = new Set([
+  '@nx/react/router-plugin',
+]);
+
+let ts: typeof import('typescript') | undefined;
+
+export default async function migrateCreateNodesV2ToCreateNodes(
+  tree: Tree
+): Promise<void> {
+  let touchedCount = 0;
+
+  visitNotIgnoredFiles(tree, '.', (filePath) => {
+    if (!TS_EXTENSIONS.some((ext) => filePath.endsWith(ext))) {
+      return;
+    }
+    const original = tree.read(filePath, 'utf-8');
+    if (!original || !original.includes(DEPRECATED_NAME)) {
+      return;
+    }
+    const updated = rewriteCreateNodesV2Imports(original, TARGET_SPECIFIERS);
+    if (updated !== original) {
+      tree.write(filePath, updated);
+      touchedCount += 1;
+    }
+  });
+
+  if (touchedCount > 0) {
+    logger.info(
+      `Renamed \`${DEPRECATED_NAME}\` imports to \`${CANONICAL_NAME}\` in ${touchedCount} file(s).`
+    );
+  }
+
+  await formatFiles(tree);
+}
+
+/**
+ * Rewrites named imports and re-exports of `createNodesV2` to `createNodes`
+ * when they come from one of the given module specifiers. Only the named
+ * bindings are touched — the module specifier, the `import`/`export` keyword,
+ * any `type` modifier, and any default import are left untouched.
+ */
+export function rewriteCreateNodesV2Imports(
+  source: string,
+  specifiers: ReadonlySet<string>
+): string {
+  ts ??= ensurePackage<typeof import('typescript')>('typescript', '*');
+  const sourceFile = ts.createSourceFile(
+    'tmp.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TSX
+  );
+
+  const changes: StringChange[] = [];
+  for (const stmt of sourceFile.statements) {
+    if (ts.isImportDeclaration(stmt)) {
+      collectImportRewrite(sourceFile, stmt, specifiers, changes);
+    } else if (ts.isExportDeclaration(stmt)) {
+      collectExportRewrite(sourceFile, stmt, specifiers, changes);
+    }
+  }
+
+  return changes.length > 0 ? applyChangesToString(source, changes) : source;
+}
+
+function isTargetSpecifier(
+  node: ImportDeclaration['moduleSpecifier'],
+  specifiers: ReadonlySet<string>
+): boolean {
+  return ts!.isStringLiteral(node) && specifiers.has(node.text);
+}
+
+function collectImportRewrite(
+  sourceFile: SourceFile,
+  stmt: ImportDeclaration,
+  specifiers: ReadonlySet<string>,
+  changes: StringChange[]
+): void {
+  if (!isTargetSpecifier(stmt.moduleSpecifier, specifiers)) {
+    return;
+  }
+  const namedBindings = stmt.importClause?.namedBindings;
+  // Only `import { ... }` carries renameable named bindings. `import x`,
+  // `import * as ns`, and side-effect imports reference the module wholesale
+  // and keep working through the `createNodesV2` runtime alias, so we leave
+  // them be. A mixed `import def, { createNodesV2 }` still has its named
+  // bindings rewritten below — the default binding is untouched.
+  if (!namedBindings || !ts!.isNamedImports(namedBindings)) {
+    return;
+  }
+  rewriteNamedBindings(sourceFile, namedBindings, changes);
+}
+
+function collectExportRewrite(
+  sourceFile: SourceFile,
+  stmt: ExportDeclaration,
+  specifiers: ReadonlySet<string>,
+  changes: StringChange[]
+): void {
+  if (
+    !stmt.moduleSpecifier ||
+    !isTargetSpecifier(stmt.moduleSpecifier, specifiers)
+  ) {
+    return;
+  }
+  // `export { ... } from '...'` can be rewritten; `export * from '...'` has no
+  // named bindings to rename.
+  if (!stmt.exportClause || !ts!.isNamedExports(stmt.exportClause)) {
+    return;
+  }
+  rewriteNamedBindings(sourceFile, stmt.exportClause, changes);
+}
+
+/**
+ * Re-renders the `{ ... }` of a named import/export, renaming any
+ * `createNodesV2` specifier to `createNodes`. If renaming would collide with a
+ * `createNodes` that is already present (e.g. `{ createNodes, createNodesV2 }`),
+ * the duplicate is dropped. Returns without recording a change when the binding
+ * list contains no `createNodesV2`.
+ */
+function rewriteNamedBindings(
+  sourceFile: SourceFile,
+  namedBindings: NamedImports | NamedExports,
+  changes: StringChange[]
+): void {
+  const elements = namedBindings.elements as readonly (
+    | ImportSpecifier
+    | ExportSpecifier
+  )[];
+  const hasDeprecated = elements.some(
+    (el) => (el.propertyName ?? el.name).text === DEPRECATED_NAME
+  );
+  if (!hasDeprecated) {
+    return;
+  }
+
+  const seen = new Set<string>();
+  const rendered: string[] = [];
+  for (const el of elements) {
+    const text = renderSpecifier(el);
+    if (!seen.has(text)) {
+      seen.add(text);
+      rendered.push(text);
+    }
+  }
+
+  const start = namedBindings.getStart(sourceFile);
+  changes.push(
+    {
+      type: ChangeType.Delete,
+      start,
+      length: namedBindings.getEnd() - start,
+    },
+    {
+      type: ChangeType.Insert,
+      index: start,
+      text: `{ ${rendered.join(', ')} }`,
+    }
+  );
+}
+
+function renderSpecifier(el: ImportSpecifier | ExportSpecifier): string {
+  const typePrefix = el.isTypeOnly ? 'type ' : '';
+  const rename = (name: string) =>
+    name === DEPRECATED_NAME ? CANONICAL_NAME : name;
+
+  // `{ name }` — no alias, so the local binding follows the rename.
+  if (!el.propertyName) {
+    return `${typePrefix}${rename(el.name.text)}`;
+  }
+
+  // `{ propertyName as name }` — only the imported (left) side is renamed; the
+  // local alias is preserved. A now-redundant alias such as
+  // `createNodesV2 as createNodes` collapses to `createNodes`.
+  const canonicalImported = rename(el.propertyName.text);
+  const localName = el.name.text;
+  return canonicalImported === localName
+    ? `${typePrefix}${localName}`
+    : `${typePrefix}${canonicalImported} as ${localName}`;
+}

--- a/packages/remix/migrations.json
+++ b/packages/remix/migrations.json
@@ -1,5 +1,12 @@
 {
-  "generators": {},
+  "generators": {
+    "update-23-0-0-migrate-create-nodes-v2-import": {
+      "version": "23.0.0-beta.5",
+      "description": "Rename imports of `createNodesV2` from `@nx/remix/plugin` to the canonical `createNodes` export.",
+      "implementation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
+      "documentation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"
+    }
+  },
   "packageJsonUpdates": {
     "20.1.0": {
       "version": "20.1.0-beta.5",

--- a/packages/remix/migrations.json
+++ b/packages/remix/migrations.json
@@ -1,7 +1,7 @@
 {
   "generators": {
     "update-23-0-0-migrate-create-nodes-v2-import": {
-      "version": "23.0.0-beta.5",
+      "version": "23.0.0-beta.24",
       "description": "Rename imports of `createNodesV2` from `@nx/remix/plugin` to the canonical `createNodes` export.",
       "implementation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
       "documentation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"

--- a/packages/remix/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md
+++ b/packages/remix/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md
@@ -1,0 +1,25 @@
+#### Rename `createNodesV2` imports to `createNodes`
+
+`@nx/remix` renamed its primary inferred-plugin export from `createNodesV2` to `createNodes`. The `createNodesV2` name is preserved as a deprecated alias for now, but new code should use `createNodes`.
+
+This migration scans every `.ts`, `.tsx`, `.cts`, and `.mts` file in your workspace and rewrites named imports and re-exports of `createNodesV2` from `@nx/remix/plugin` to `createNodes`.
+
+#### Sample Code Changes
+
+##### Before
+
+```ts
+import { createNodesV2 } from '@nx/remix/plugin';
+```
+
+##### After
+
+```ts
+import { createNodes } from '@nx/remix/plugin';
+```
+
+Aliases are preserved (`createNodesV2 as cn` becomes `createNodes as cn`), and if a file already imports both names (`{ createNodes, createNodesV2 }`) the redundant binding is dropped.
+
+#### What is not rewritten
+
+Only static `import`/`export` named bindings from `@nx/remix/plugin` are rewritten. Namespace imports, dynamic `import(...)`, `require(...)` destructuring, and property access such as `plugin.createNodesV2` are left untouched — they keep working through the `createNodesV2` runtime alias. Update those by hand if you want to drop the deprecated name everywhere.

--- a/packages/remix/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.spec.ts
+++ b/packages/remix/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.spec.ts
@@ -1,0 +1,191 @@
+import { type Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migration, {
+  rewriteCreateNodesV2Imports,
+} from './migrate-create-nodes-v2-to-create-nodes';
+
+const SPECIFIERS = new Set(['@nx/remix/plugin']);
+const rewrite = (source: string) =>
+  rewriteCreateNodesV2Imports(source, SPECIFIERS);
+
+describe('migrate-create-nodes-v2-to-create-nodes migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  describe('rewriteCreateNodesV2Imports', () => {
+    it('renames a lone createNodesV2 named import', () => {
+      const input = `import { createNodesV2 } from '@nx/remix/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/remix/plugin';\n`
+      );
+    });
+
+    it('preserves other named imports while renaming createNodesV2', () => {
+      const input = `import { createNodesV2, SomeOtherExport } from '@nx/remix/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes, SomeOtherExport } from '@nx/remix/plugin';\n`
+      );
+    });
+
+    it('rewrites the original name in `as` aliases', () => {
+      const input = `import { createNodesV2 as cn } from '@nx/remix/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes as cn } from '@nx/remix/plugin';\n`
+      );
+    });
+
+    it('collapses a redundant `createNodesV2 as createNodes` alias', () => {
+      const input = `import { createNodesV2 as createNodes } from '@nx/remix/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/remix/plugin';\n`
+      );
+    });
+
+    it('dedupes when both createNodes and createNodesV2 are imported', () => {
+      const input = `import { createNodes, createNodesV2 } from '@nx/remix/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/remix/plugin';\n`
+      );
+    });
+
+    it('dedupes when createNodesV2 precedes createNodes', () => {
+      const input = `import { createNodesV2, createNodes } from '@nx/remix/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/remix/plugin';\n`
+      );
+    });
+
+    it('handles multi-line named imports', () => {
+      const input = `import {\n  createNodes,\n  createNodesV2,\n  SomeOtherExport,\n} from '@nx/remix/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes, SomeOtherExport } from '@nx/remix/plugin';\n`
+      );
+    });
+
+    it('preserves a default import alongside the renamed binding', () => {
+      const input = `import def, { createNodesV2 } from '@nx/remix/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import def, { createNodes } from '@nx/remix/plugin';\n`
+      );
+    });
+
+    it('handles `import type` declarations', () => {
+      const input = `import type { createNodesV2 } from '@nx/remix/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import type { createNodes } from '@nx/remix/plugin';\n`
+      );
+    });
+
+    it('preserves inline `type` modifiers', () => {
+      const input = `import { type createNodesV2 } from '@nx/remix/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { type createNodes } from '@nx/remix/plugin';\n`
+      );
+    });
+
+    it('rewrites named re-exports', () => {
+      const input = `export { createNodesV2 } from '@nx/remix/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `export { createNodes } from '@nx/remix/plugin';\n`
+      );
+    });
+
+    it('rewrites aliased named re-exports', () => {
+      const input = `export { createNodesV2 as cn } from '@nx/remix/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `export { createNodes as cn } from '@nx/remix/plugin';\n`
+      );
+    });
+
+    it('does not touch createNodesV2 from a different specifier', () => {
+      const input = `import { createNodesV2 } from '@nx/other-plugin/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not touch createNodesV2 from a relative specifier', () => {
+      const input = `import { createNodesV2 } from './plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not touch unrelated imports from the target specifier', () => {
+      const input = `import { createNodes } from '@nx/remix/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not rewrite `export * from` declarations', () => {
+      const input = `export * from '@nx/remix/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('leaves createNodesV2 in strings and comments alone', () => {
+      const input =
+        `// import { createNodesV2 } from '@nx/remix/plugin';\n` +
+        `const s = "createNodesV2";\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not rewrite require() destructuring (still valid via alias)', () => {
+      const input = `const { createNodesV2 } = require('@nx/remix/plugin');\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+  });
+
+  describe('migration runner', () => {
+    it('rewrites imports across .ts/.tsx/.cts/.mts files', async () => {
+      tree.write(
+        'libs/foo/src/a.ts',
+        `import { createNodesV2 } from '@nx/remix/plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/b.tsx',
+        `import { createNodesV2 as cn } from '@nx/remix/plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/c.cts',
+        `export { createNodesV2 } from '@nx/remix/plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/d.mts',
+        `import { createNodesV2, SomeOtherExport } from '@nx/remix/plugin';\n`
+      );
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/a.ts', 'utf-8')).toContain(
+        `import { createNodes } from '@nx/remix/plugin';`
+      );
+      expect(tree.read('libs/foo/src/b.tsx', 'utf-8')).toContain(
+        `import { createNodes as cn } from '@nx/remix/plugin';`
+      );
+      expect(tree.read('libs/foo/src/c.cts', 'utf-8')).toContain(
+        `export { createNodes } from '@nx/remix/plugin';`
+      );
+      expect(tree.read('libs/foo/src/d.mts', 'utf-8')).toContain(
+        `import { createNodes, SomeOtherExport } from '@nx/remix/plugin';`
+      );
+    });
+
+    it('does not touch files without the deprecated name', async () => {
+      const content = `import { createNodes } from '@nx/remix/plugin';\n`;
+      tree.write('libs/foo/src/index.ts', content);
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/index.ts', 'utf-8')).toBe(content);
+    });
+
+    it('does not rewrite non-TS files', async () => {
+      const md = `Example: \`import { createNodesV2 } from '@nx/remix/plugin';\`\n`;
+      tree.write('docs/example.md', md);
+
+      await migration(tree);
+
+      expect(tree.read('docs/example.md', 'utf-8')).toContain(
+        `import { createNodesV2 } from '@nx/remix/plugin';`
+      );
+    });
+  });
+});

--- a/packages/remix/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.ts
+++ b/packages/remix/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.ts
@@ -1,0 +1,206 @@
+import {
+  applyChangesToString,
+  ChangeType,
+  ensurePackage,
+  formatFiles,
+  logger,
+  type StringChange,
+  type Tree,
+  visitNotIgnoredFiles,
+} from '@nx/devkit';
+import type {
+  ExportDeclaration,
+  ExportSpecifier,
+  ImportDeclaration,
+  ImportSpecifier,
+  NamedExports,
+  NamedImports,
+  SourceFile,
+} from 'typescript';
+
+const TS_EXTENSIONS = ['.ts', '.tsx', '.cts', '.mts'] as const;
+const DEPRECATED_NAME = 'createNodesV2';
+const CANONICAL_NAME = 'createNodes';
+
+// Module specifiers from which `@nx/remix` publicly exposes `createNodesV2`.
+// A named import or re-export of `createNodesV2` from one of these is rewritten
+// to the canonical `createNodes` export.
+const TARGET_SPECIFIERS: ReadonlySet<string> = new Set(['@nx/remix/plugin']);
+
+let ts: typeof import('typescript') | undefined;
+
+export default async function migrateCreateNodesV2ToCreateNodes(
+  tree: Tree
+): Promise<void> {
+  let touchedCount = 0;
+
+  visitNotIgnoredFiles(tree, '.', (filePath) => {
+    if (!TS_EXTENSIONS.some((ext) => filePath.endsWith(ext))) {
+      return;
+    }
+    const original = tree.read(filePath, 'utf-8');
+    if (!original || !original.includes(DEPRECATED_NAME)) {
+      return;
+    }
+    const updated = rewriteCreateNodesV2Imports(original, TARGET_SPECIFIERS);
+    if (updated !== original) {
+      tree.write(filePath, updated);
+      touchedCount += 1;
+    }
+  });
+
+  if (touchedCount > 0) {
+    logger.info(
+      `Renamed \`${DEPRECATED_NAME}\` imports to \`${CANONICAL_NAME}\` in ${touchedCount} file(s).`
+    );
+  }
+
+  await formatFiles(tree);
+}
+
+/**
+ * Rewrites named imports and re-exports of `createNodesV2` to `createNodes`
+ * when they come from one of the given module specifiers. Only the named
+ * bindings are touched — the module specifier, the `import`/`export` keyword,
+ * any `type` modifier, and any default import are left untouched.
+ */
+export function rewriteCreateNodesV2Imports(
+  source: string,
+  specifiers: ReadonlySet<string>
+): string {
+  ts ??= ensurePackage<typeof import('typescript')>('typescript', '*');
+  const sourceFile = ts.createSourceFile(
+    'tmp.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TSX
+  );
+
+  const changes: StringChange[] = [];
+  for (const stmt of sourceFile.statements) {
+    if (ts.isImportDeclaration(stmt)) {
+      collectImportRewrite(sourceFile, stmt, specifiers, changes);
+    } else if (ts.isExportDeclaration(stmt)) {
+      collectExportRewrite(sourceFile, stmt, specifiers, changes);
+    }
+  }
+
+  return changes.length > 0 ? applyChangesToString(source, changes) : source;
+}
+
+function isTargetSpecifier(
+  node: ImportDeclaration['moduleSpecifier'],
+  specifiers: ReadonlySet<string>
+): boolean {
+  return ts!.isStringLiteral(node) && specifiers.has(node.text);
+}
+
+function collectImportRewrite(
+  sourceFile: SourceFile,
+  stmt: ImportDeclaration,
+  specifiers: ReadonlySet<string>,
+  changes: StringChange[]
+): void {
+  if (!isTargetSpecifier(stmt.moduleSpecifier, specifiers)) {
+    return;
+  }
+  const namedBindings = stmt.importClause?.namedBindings;
+  // Only `import { ... }` carries renameable named bindings. `import x`,
+  // `import * as ns`, and side-effect imports reference the module wholesale
+  // and keep working through the `createNodesV2` runtime alias, so we leave
+  // them be. A mixed `import def, { createNodesV2 }` still has its named
+  // bindings rewritten below — the default binding is untouched.
+  if (!namedBindings || !ts!.isNamedImports(namedBindings)) {
+    return;
+  }
+  rewriteNamedBindings(sourceFile, namedBindings, changes);
+}
+
+function collectExportRewrite(
+  sourceFile: SourceFile,
+  stmt: ExportDeclaration,
+  specifiers: ReadonlySet<string>,
+  changes: StringChange[]
+): void {
+  if (
+    !stmt.moduleSpecifier ||
+    !isTargetSpecifier(stmt.moduleSpecifier, specifiers)
+  ) {
+    return;
+  }
+  // `export { ... } from '...'` can be rewritten; `export * from '...'` has no
+  // named bindings to rename.
+  if (!stmt.exportClause || !ts!.isNamedExports(stmt.exportClause)) {
+    return;
+  }
+  rewriteNamedBindings(sourceFile, stmt.exportClause, changes);
+}
+
+/**
+ * Re-renders the `{ ... }` of a named import/export, renaming any
+ * `createNodesV2` specifier to `createNodes`. If renaming would collide with a
+ * `createNodes` that is already present (e.g. `{ createNodes, createNodesV2 }`),
+ * the duplicate is dropped. Returns without recording a change when the binding
+ * list contains no `createNodesV2`.
+ */
+function rewriteNamedBindings(
+  sourceFile: SourceFile,
+  namedBindings: NamedImports | NamedExports,
+  changes: StringChange[]
+): void {
+  const elements = namedBindings.elements as readonly (
+    | ImportSpecifier
+    | ExportSpecifier
+  )[];
+  const hasDeprecated = elements.some(
+    (el) => (el.propertyName ?? el.name).text === DEPRECATED_NAME
+  );
+  if (!hasDeprecated) {
+    return;
+  }
+
+  const seen = new Set<string>();
+  const rendered: string[] = [];
+  for (const el of elements) {
+    const text = renderSpecifier(el);
+    if (!seen.has(text)) {
+      seen.add(text);
+      rendered.push(text);
+    }
+  }
+
+  const start = namedBindings.getStart(sourceFile);
+  changes.push(
+    {
+      type: ChangeType.Delete,
+      start,
+      length: namedBindings.getEnd() - start,
+    },
+    {
+      type: ChangeType.Insert,
+      index: start,
+      text: `{ ${rendered.join(', ')} }`,
+    }
+  );
+}
+
+function renderSpecifier(el: ImportSpecifier | ExportSpecifier): string {
+  const typePrefix = el.isTypeOnly ? 'type ' : '';
+  const rename = (name: string) =>
+    name === DEPRECATED_NAME ? CANONICAL_NAME : name;
+
+  // `{ name }` — no alias, so the local binding follows the rename.
+  if (!el.propertyName) {
+    return `${typePrefix}${rename(el.name.text)}`;
+  }
+
+  // `{ propertyName as name }` — only the imported (left) side is renamed; the
+  // local alias is preserved. A now-redundant alias such as
+  // `createNodesV2 as createNodes` collapses to `createNodes`.
+  const canonicalImported = rename(el.propertyName.text);
+  const localName = el.name.text;
+  return canonicalImported === localName
+    ? `${typePrefix}${localName}`
+    : `${typePrefix}${canonicalImported} as ${localName}`;
+}

--- a/packages/rollup/migrations.json
+++ b/packages/rollup/migrations.json
@@ -11,6 +11,12 @@
       "version": "23.0.0-beta.25",
       "description": "Rewrites `@nx/rollup/src/*` subpath imports now that the `./src/*` subpath is no longer exposed by `@nx/rollup`'s exports map. Named imports/exports of public symbols are routed to `@nx/rollup` and the rest to the new `@nx/rollup/internal` entry; `require`, dynamic `import` and `jest.mock` calls reference the whole module and are routed to `@nx/rollup/internal`.",
       "implementation": "./dist/src/migrations/update-23-0-0/rewrite-internal-subpath-imports"
+    },
+    "update-23-0-0-migrate-create-nodes-v2-import": {
+      "version": "23.0.0-beta.5",
+      "description": "Rename imports of `createNodesV2` from `@nx/rollup/plugin` to the canonical `createNodes` export.",
+      "implementation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
+      "documentation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"
     }
   },
   "packageJsonUpdates": {

--- a/packages/rollup/migrations.json
+++ b/packages/rollup/migrations.json
@@ -13,7 +13,7 @@
       "implementation": "./dist/src/migrations/update-23-0-0/rewrite-internal-subpath-imports"
     },
     "update-23-0-0-migrate-create-nodes-v2-import": {
-      "version": "23.0.0-beta.5",
+      "version": "23.0.0-beta.24",
       "description": "Rename imports of `createNodesV2` from `@nx/rollup/plugin` to the canonical `createNodes` export.",
       "implementation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
       "documentation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"

--- a/packages/rollup/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md
+++ b/packages/rollup/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md
@@ -1,0 +1,25 @@
+#### Rename `createNodesV2` imports to `createNodes`
+
+`@nx/rollup` renamed its primary inferred-plugin export from `createNodesV2` to `createNodes`. The `createNodesV2` name is preserved as a deprecated alias for now, but new code should use `createNodes`.
+
+This migration scans every `.ts`, `.tsx`, `.cts`, and `.mts` file in your workspace and rewrites named imports and re-exports of `createNodesV2` from `@nx/rollup/plugin` to `createNodes`.
+
+#### Sample Code Changes
+
+##### Before
+
+```ts
+import { createNodesV2 } from '@nx/rollup/plugin';
+```
+
+##### After
+
+```ts
+import { createNodes } from '@nx/rollup/plugin';
+```
+
+Aliases are preserved (`createNodesV2 as cn` becomes `createNodes as cn`), and if a file already imports both names (`{ createNodes, createNodesV2 }`) the redundant binding is dropped.
+
+#### What is not rewritten
+
+Only static `import`/`export` named bindings from `@nx/rollup/plugin` are rewritten. Namespace imports, dynamic `import(...)`, `require(...)` destructuring, and property access such as `plugin.createNodesV2` are left untouched — they keep working through the `createNodesV2` runtime alias. Update those by hand if you want to drop the deprecated name everywhere.

--- a/packages/rollup/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.spec.ts
+++ b/packages/rollup/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.spec.ts
@@ -1,0 +1,191 @@
+import { type Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migration, {
+  rewriteCreateNodesV2Imports,
+} from './migrate-create-nodes-v2-to-create-nodes';
+
+const SPECIFIERS = new Set(['@nx/rollup/plugin']);
+const rewrite = (source: string) =>
+  rewriteCreateNodesV2Imports(source, SPECIFIERS);
+
+describe('migrate-create-nodes-v2-to-create-nodes migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  describe('rewriteCreateNodesV2Imports', () => {
+    it('renames a lone createNodesV2 named import', () => {
+      const input = `import { createNodesV2 } from '@nx/rollup/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/rollup/plugin';\n`
+      );
+    });
+
+    it('preserves other named imports while renaming createNodesV2', () => {
+      const input = `import { createNodesV2, SomeOtherExport } from '@nx/rollup/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes, SomeOtherExport } from '@nx/rollup/plugin';\n`
+      );
+    });
+
+    it('rewrites the original name in `as` aliases', () => {
+      const input = `import { createNodesV2 as cn } from '@nx/rollup/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes as cn } from '@nx/rollup/plugin';\n`
+      );
+    });
+
+    it('collapses a redundant `createNodesV2 as createNodes` alias', () => {
+      const input = `import { createNodesV2 as createNodes } from '@nx/rollup/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/rollup/plugin';\n`
+      );
+    });
+
+    it('dedupes when both createNodes and createNodesV2 are imported', () => {
+      const input = `import { createNodes, createNodesV2 } from '@nx/rollup/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/rollup/plugin';\n`
+      );
+    });
+
+    it('dedupes when createNodesV2 precedes createNodes', () => {
+      const input = `import { createNodesV2, createNodes } from '@nx/rollup/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/rollup/plugin';\n`
+      );
+    });
+
+    it('handles multi-line named imports', () => {
+      const input = `import {\n  createNodes,\n  createNodesV2,\n  SomeOtherExport,\n} from '@nx/rollup/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes, SomeOtherExport } from '@nx/rollup/plugin';\n`
+      );
+    });
+
+    it('preserves a default import alongside the renamed binding', () => {
+      const input = `import def, { createNodesV2 } from '@nx/rollup/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import def, { createNodes } from '@nx/rollup/plugin';\n`
+      );
+    });
+
+    it('handles `import type` declarations', () => {
+      const input = `import type { createNodesV2 } from '@nx/rollup/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import type { createNodes } from '@nx/rollup/plugin';\n`
+      );
+    });
+
+    it('preserves inline `type` modifiers', () => {
+      const input = `import { type createNodesV2 } from '@nx/rollup/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { type createNodes } from '@nx/rollup/plugin';\n`
+      );
+    });
+
+    it('rewrites named re-exports', () => {
+      const input = `export { createNodesV2 } from '@nx/rollup/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `export { createNodes } from '@nx/rollup/plugin';\n`
+      );
+    });
+
+    it('rewrites aliased named re-exports', () => {
+      const input = `export { createNodesV2 as cn } from '@nx/rollup/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `export { createNodes as cn } from '@nx/rollup/plugin';\n`
+      );
+    });
+
+    it('does not touch createNodesV2 from a different specifier', () => {
+      const input = `import { createNodesV2 } from '@nx/other-plugin/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not touch createNodesV2 from a relative specifier', () => {
+      const input = `import { createNodesV2 } from './plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not touch unrelated imports from the target specifier', () => {
+      const input = `import { createNodes } from '@nx/rollup/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not rewrite `export * from` declarations', () => {
+      const input = `export * from '@nx/rollup/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('leaves createNodesV2 in strings and comments alone', () => {
+      const input =
+        `// import { createNodesV2 } from '@nx/rollup/plugin';\n` +
+        `const s = "createNodesV2";\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not rewrite require() destructuring (still valid via alias)', () => {
+      const input = `const { createNodesV2 } = require('@nx/rollup/plugin');\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+  });
+
+  describe('migration runner', () => {
+    it('rewrites imports across .ts/.tsx/.cts/.mts files', async () => {
+      tree.write(
+        'libs/foo/src/a.ts',
+        `import { createNodesV2 } from '@nx/rollup/plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/b.tsx',
+        `import { createNodesV2 as cn } from '@nx/rollup/plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/c.cts',
+        `export { createNodesV2 } from '@nx/rollup/plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/d.mts',
+        `import { createNodesV2, SomeOtherExport } from '@nx/rollup/plugin';\n`
+      );
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/a.ts', 'utf-8')).toContain(
+        `import { createNodes } from '@nx/rollup/plugin';`
+      );
+      expect(tree.read('libs/foo/src/b.tsx', 'utf-8')).toContain(
+        `import { createNodes as cn } from '@nx/rollup/plugin';`
+      );
+      expect(tree.read('libs/foo/src/c.cts', 'utf-8')).toContain(
+        `export { createNodes } from '@nx/rollup/plugin';`
+      );
+      expect(tree.read('libs/foo/src/d.mts', 'utf-8')).toContain(
+        `import { createNodes, SomeOtherExport } from '@nx/rollup/plugin';`
+      );
+    });
+
+    it('does not touch files without the deprecated name', async () => {
+      const content = `import { createNodes } from '@nx/rollup/plugin';\n`;
+      tree.write('libs/foo/src/index.ts', content);
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/index.ts', 'utf-8')).toBe(content);
+    });
+
+    it('does not rewrite non-TS files', async () => {
+      const md = `Example: \`import { createNodesV2 } from '@nx/rollup/plugin';\`\n`;
+      tree.write('docs/example.md', md);
+
+      await migration(tree);
+
+      expect(tree.read('docs/example.md', 'utf-8')).toContain(
+        `import { createNodesV2 } from '@nx/rollup/plugin';`
+      );
+    });
+  });
+});

--- a/packages/rollup/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.ts
+++ b/packages/rollup/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.ts
@@ -1,0 +1,206 @@
+import {
+  applyChangesToString,
+  ChangeType,
+  ensurePackage,
+  formatFiles,
+  logger,
+  type StringChange,
+  type Tree,
+  visitNotIgnoredFiles,
+} from '@nx/devkit';
+import type {
+  ExportDeclaration,
+  ExportSpecifier,
+  ImportDeclaration,
+  ImportSpecifier,
+  NamedExports,
+  NamedImports,
+  SourceFile,
+} from 'typescript';
+
+const TS_EXTENSIONS = ['.ts', '.tsx', '.cts', '.mts'] as const;
+const DEPRECATED_NAME = 'createNodesV2';
+const CANONICAL_NAME = 'createNodes';
+
+// Module specifiers from which `@nx/rollup` publicly exposes `createNodesV2`.
+// A named import or re-export of `createNodesV2` from one of these is rewritten
+// to the canonical `createNodes` export.
+const TARGET_SPECIFIERS: ReadonlySet<string> = new Set(['@nx/rollup/plugin']);
+
+let ts: typeof import('typescript') | undefined;
+
+export default async function migrateCreateNodesV2ToCreateNodes(
+  tree: Tree
+): Promise<void> {
+  let touchedCount = 0;
+
+  visitNotIgnoredFiles(tree, '.', (filePath) => {
+    if (!TS_EXTENSIONS.some((ext) => filePath.endsWith(ext))) {
+      return;
+    }
+    const original = tree.read(filePath, 'utf-8');
+    if (!original || !original.includes(DEPRECATED_NAME)) {
+      return;
+    }
+    const updated = rewriteCreateNodesV2Imports(original, TARGET_SPECIFIERS);
+    if (updated !== original) {
+      tree.write(filePath, updated);
+      touchedCount += 1;
+    }
+  });
+
+  if (touchedCount > 0) {
+    logger.info(
+      `Renamed \`${DEPRECATED_NAME}\` imports to \`${CANONICAL_NAME}\` in ${touchedCount} file(s).`
+    );
+  }
+
+  await formatFiles(tree);
+}
+
+/**
+ * Rewrites named imports and re-exports of `createNodesV2` to `createNodes`
+ * when they come from one of the given module specifiers. Only the named
+ * bindings are touched — the module specifier, the `import`/`export` keyword,
+ * any `type` modifier, and any default import are left untouched.
+ */
+export function rewriteCreateNodesV2Imports(
+  source: string,
+  specifiers: ReadonlySet<string>
+): string {
+  ts ??= ensurePackage<typeof import('typescript')>('typescript', '*');
+  const sourceFile = ts.createSourceFile(
+    'tmp.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TSX
+  );
+
+  const changes: StringChange[] = [];
+  for (const stmt of sourceFile.statements) {
+    if (ts.isImportDeclaration(stmt)) {
+      collectImportRewrite(sourceFile, stmt, specifiers, changes);
+    } else if (ts.isExportDeclaration(stmt)) {
+      collectExportRewrite(sourceFile, stmt, specifiers, changes);
+    }
+  }
+
+  return changes.length > 0 ? applyChangesToString(source, changes) : source;
+}
+
+function isTargetSpecifier(
+  node: ImportDeclaration['moduleSpecifier'],
+  specifiers: ReadonlySet<string>
+): boolean {
+  return ts!.isStringLiteral(node) && specifiers.has(node.text);
+}
+
+function collectImportRewrite(
+  sourceFile: SourceFile,
+  stmt: ImportDeclaration,
+  specifiers: ReadonlySet<string>,
+  changes: StringChange[]
+): void {
+  if (!isTargetSpecifier(stmt.moduleSpecifier, specifiers)) {
+    return;
+  }
+  const namedBindings = stmt.importClause?.namedBindings;
+  // Only `import { ... }` carries renameable named bindings. `import x`,
+  // `import * as ns`, and side-effect imports reference the module wholesale
+  // and keep working through the `createNodesV2` runtime alias, so we leave
+  // them be. A mixed `import def, { createNodesV2 }` still has its named
+  // bindings rewritten below — the default binding is untouched.
+  if (!namedBindings || !ts!.isNamedImports(namedBindings)) {
+    return;
+  }
+  rewriteNamedBindings(sourceFile, namedBindings, changes);
+}
+
+function collectExportRewrite(
+  sourceFile: SourceFile,
+  stmt: ExportDeclaration,
+  specifiers: ReadonlySet<string>,
+  changes: StringChange[]
+): void {
+  if (
+    !stmt.moduleSpecifier ||
+    !isTargetSpecifier(stmt.moduleSpecifier, specifiers)
+  ) {
+    return;
+  }
+  // `export { ... } from '...'` can be rewritten; `export * from '...'` has no
+  // named bindings to rename.
+  if (!stmt.exportClause || !ts!.isNamedExports(stmt.exportClause)) {
+    return;
+  }
+  rewriteNamedBindings(sourceFile, stmt.exportClause, changes);
+}
+
+/**
+ * Re-renders the `{ ... }` of a named import/export, renaming any
+ * `createNodesV2` specifier to `createNodes`. If renaming would collide with a
+ * `createNodes` that is already present (e.g. `{ createNodes, createNodesV2 }`),
+ * the duplicate is dropped. Returns without recording a change when the binding
+ * list contains no `createNodesV2`.
+ */
+function rewriteNamedBindings(
+  sourceFile: SourceFile,
+  namedBindings: NamedImports | NamedExports,
+  changes: StringChange[]
+): void {
+  const elements = namedBindings.elements as readonly (
+    | ImportSpecifier
+    | ExportSpecifier
+  )[];
+  const hasDeprecated = elements.some(
+    (el) => (el.propertyName ?? el.name).text === DEPRECATED_NAME
+  );
+  if (!hasDeprecated) {
+    return;
+  }
+
+  const seen = new Set<string>();
+  const rendered: string[] = [];
+  for (const el of elements) {
+    const text = renderSpecifier(el);
+    if (!seen.has(text)) {
+      seen.add(text);
+      rendered.push(text);
+    }
+  }
+
+  const start = namedBindings.getStart(sourceFile);
+  changes.push(
+    {
+      type: ChangeType.Delete,
+      start,
+      length: namedBindings.getEnd() - start,
+    },
+    {
+      type: ChangeType.Insert,
+      index: start,
+      text: `{ ${rendered.join(', ')} }`,
+    }
+  );
+}
+
+function renderSpecifier(el: ImportSpecifier | ExportSpecifier): string {
+  const typePrefix = el.isTypeOnly ? 'type ' : '';
+  const rename = (name: string) =>
+    name === DEPRECATED_NAME ? CANONICAL_NAME : name;
+
+  // `{ name }` — no alias, so the local binding follows the rename.
+  if (!el.propertyName) {
+    return `${typePrefix}${rename(el.name.text)}`;
+  }
+
+  // `{ propertyName as name }` — only the imported (left) side is renamed; the
+  // local alias is preserved. A now-redundant alias such as
+  // `createNodesV2 as createNodes` collapses to `createNodes`.
+  const canonicalImported = rename(el.propertyName.text);
+  const localName = el.name.text;
+  return canonicalImported === localName
+    ? `${typePrefix}${localName}`
+    : `${typePrefix}${canonicalImported} as ${localName}`;
+}

--- a/packages/rsbuild/migrations.json
+++ b/packages/rsbuild/migrations.json
@@ -1,1 +1,10 @@
-{}
+{
+  "generators": {
+    "update-23-0-0-migrate-create-nodes-v2-import": {
+      "version": "23.0.0-beta.5",
+      "description": "Rename imports of `createNodesV2` from `@nx/rsbuild` to the canonical `createNodes` export.",
+      "implementation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
+      "documentation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"
+    }
+  }
+}

--- a/packages/rsbuild/migrations.json
+++ b/packages/rsbuild/migrations.json
@@ -1,7 +1,7 @@
 {
   "generators": {
     "update-23-0-0-migrate-create-nodes-v2-import": {
-      "version": "23.0.0-beta.5",
+      "version": "23.0.0-beta.24",
       "description": "Rename imports of `createNodesV2` from `@nx/rsbuild` to the canonical `createNodes` export.",
       "implementation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
       "documentation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"

--- a/packages/rsbuild/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md
+++ b/packages/rsbuild/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md
@@ -1,0 +1,25 @@
+#### Rename `createNodesV2` imports to `createNodes`
+
+`@nx/rsbuild` renamed its primary inferred-plugin export from `createNodesV2` to `createNodes`. The `createNodesV2` name is preserved as a deprecated alias for now, but new code should use `createNodes`.
+
+This migration scans every `.ts`, `.tsx`, `.cts`, and `.mts` file in your workspace and rewrites named imports and re-exports of `createNodesV2` from `@nx/rsbuild` to `createNodes`.
+
+#### Sample Code Changes
+
+##### Before
+
+```ts
+import { createNodesV2 } from '@nx/rsbuild';
+```
+
+##### After
+
+```ts
+import { createNodes } from '@nx/rsbuild';
+```
+
+Aliases are preserved (`createNodesV2 as cn` becomes `createNodes as cn`), and if a file already imports both names (`{ createNodes, createNodesV2 }`) the redundant binding is dropped.
+
+#### What is not rewritten
+
+Only static `import`/`export` named bindings from `@nx/rsbuild` are rewritten. Namespace imports, dynamic `import(...)`, `require(...)` destructuring, and property access such as `plugin.createNodesV2` are left untouched — they keep working through the `createNodesV2` runtime alias. Update those by hand if you want to drop the deprecated name everywhere.

--- a/packages/rsbuild/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.spec.ts
+++ b/packages/rsbuild/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.spec.ts
@@ -1,0 +1,191 @@
+import { type Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migration, {
+  rewriteCreateNodesV2Imports,
+} from './migrate-create-nodes-v2-to-create-nodes';
+
+const SPECIFIERS = new Set(['@nx/rsbuild']);
+const rewrite = (source: string) =>
+  rewriteCreateNodesV2Imports(source, SPECIFIERS);
+
+describe('migrate-create-nodes-v2-to-create-nodes migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  describe('rewriteCreateNodesV2Imports', () => {
+    it('renames a lone createNodesV2 named import', () => {
+      const input = `import { createNodesV2 } from '@nx/rsbuild';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/rsbuild';\n`
+      );
+    });
+
+    it('preserves other named imports while renaming createNodesV2', () => {
+      const input = `import { createNodesV2, SomeOtherExport } from '@nx/rsbuild';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes, SomeOtherExport } from '@nx/rsbuild';\n`
+      );
+    });
+
+    it('rewrites the original name in `as` aliases', () => {
+      const input = `import { createNodesV2 as cn } from '@nx/rsbuild';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes as cn } from '@nx/rsbuild';\n`
+      );
+    });
+
+    it('collapses a redundant `createNodesV2 as createNodes` alias', () => {
+      const input = `import { createNodesV2 as createNodes } from '@nx/rsbuild';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/rsbuild';\n`
+      );
+    });
+
+    it('dedupes when both createNodes and createNodesV2 are imported', () => {
+      const input = `import { createNodes, createNodesV2 } from '@nx/rsbuild';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/rsbuild';\n`
+      );
+    });
+
+    it('dedupes when createNodesV2 precedes createNodes', () => {
+      const input = `import { createNodesV2, createNodes } from '@nx/rsbuild';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/rsbuild';\n`
+      );
+    });
+
+    it('handles multi-line named imports', () => {
+      const input = `import {\n  createNodes,\n  createNodesV2,\n  SomeOtherExport,\n} from '@nx/rsbuild';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes, SomeOtherExport } from '@nx/rsbuild';\n`
+      );
+    });
+
+    it('preserves a default import alongside the renamed binding', () => {
+      const input = `import def, { createNodesV2 } from '@nx/rsbuild';\n`;
+      expect(rewrite(input)).toBe(
+        `import def, { createNodes } from '@nx/rsbuild';\n`
+      );
+    });
+
+    it('handles `import type` declarations', () => {
+      const input = `import type { createNodesV2 } from '@nx/rsbuild';\n`;
+      expect(rewrite(input)).toBe(
+        `import type { createNodes } from '@nx/rsbuild';\n`
+      );
+    });
+
+    it('preserves inline `type` modifiers', () => {
+      const input = `import { type createNodesV2 } from '@nx/rsbuild';\n`;
+      expect(rewrite(input)).toBe(
+        `import { type createNodes } from '@nx/rsbuild';\n`
+      );
+    });
+
+    it('rewrites named re-exports', () => {
+      const input = `export { createNodesV2 } from '@nx/rsbuild';\n`;
+      expect(rewrite(input)).toBe(
+        `export { createNodes } from '@nx/rsbuild';\n`
+      );
+    });
+
+    it('rewrites aliased named re-exports', () => {
+      const input = `export { createNodesV2 as cn } from '@nx/rsbuild';\n`;
+      expect(rewrite(input)).toBe(
+        `export { createNodes as cn } from '@nx/rsbuild';\n`
+      );
+    });
+
+    it('does not touch createNodesV2 from a different specifier', () => {
+      const input = `import { createNodesV2 } from '@nx/other-plugin/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not touch createNodesV2 from a relative specifier', () => {
+      const input = `import { createNodesV2 } from './plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not touch unrelated imports from the target specifier', () => {
+      const input = `import { createNodes } from '@nx/rsbuild';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not rewrite `export * from` declarations', () => {
+      const input = `export * from '@nx/rsbuild';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('leaves createNodesV2 in strings and comments alone', () => {
+      const input =
+        `// import { createNodesV2 } from '@nx/rsbuild';\n` +
+        `const s = "createNodesV2";\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not rewrite require() destructuring (still valid via alias)', () => {
+      const input = `const { createNodesV2 } = require('@nx/rsbuild');\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+  });
+
+  describe('migration runner', () => {
+    it('rewrites imports across .ts/.tsx/.cts/.mts files', async () => {
+      tree.write(
+        'libs/foo/src/a.ts',
+        `import { createNodesV2 } from '@nx/rsbuild';\n`
+      );
+      tree.write(
+        'libs/foo/src/b.tsx',
+        `import { createNodesV2 as cn } from '@nx/rsbuild';\n`
+      );
+      tree.write(
+        'libs/foo/src/c.cts',
+        `export { createNodesV2 } from '@nx/rsbuild';\n`
+      );
+      tree.write(
+        'libs/foo/src/d.mts',
+        `import { createNodesV2, SomeOtherExport } from '@nx/rsbuild';\n`
+      );
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/a.ts', 'utf-8')).toContain(
+        `import { createNodes } from '@nx/rsbuild';`
+      );
+      expect(tree.read('libs/foo/src/b.tsx', 'utf-8')).toContain(
+        `import { createNodes as cn } from '@nx/rsbuild';`
+      );
+      expect(tree.read('libs/foo/src/c.cts', 'utf-8')).toContain(
+        `export { createNodes } from '@nx/rsbuild';`
+      );
+      expect(tree.read('libs/foo/src/d.mts', 'utf-8')).toContain(
+        `import { createNodes, SomeOtherExport } from '@nx/rsbuild';`
+      );
+    });
+
+    it('does not touch files without the deprecated name', async () => {
+      const content = `import { createNodes } from '@nx/rsbuild';\n`;
+      tree.write('libs/foo/src/index.ts', content);
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/index.ts', 'utf-8')).toBe(content);
+    });
+
+    it('does not rewrite non-TS files', async () => {
+      const md = `Example: \`import { createNodesV2 } from '@nx/rsbuild';\`\n`;
+      tree.write('docs/example.md', md);
+
+      await migration(tree);
+
+      expect(tree.read('docs/example.md', 'utf-8')).toContain(
+        `import { createNodesV2 } from '@nx/rsbuild';`
+      );
+    });
+  });
+});

--- a/packages/rsbuild/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.ts
+++ b/packages/rsbuild/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.ts
@@ -1,0 +1,206 @@
+import {
+  applyChangesToString,
+  ChangeType,
+  ensurePackage,
+  formatFiles,
+  logger,
+  type StringChange,
+  type Tree,
+  visitNotIgnoredFiles,
+} from '@nx/devkit';
+import type {
+  ExportDeclaration,
+  ExportSpecifier,
+  ImportDeclaration,
+  ImportSpecifier,
+  NamedExports,
+  NamedImports,
+  SourceFile,
+} from 'typescript';
+
+const TS_EXTENSIONS = ['.ts', '.tsx', '.cts', '.mts'] as const;
+const DEPRECATED_NAME = 'createNodesV2';
+const CANONICAL_NAME = 'createNodes';
+
+// Module specifiers from which `@nx/rsbuild` publicly exposes `createNodesV2`.
+// A named import or re-export of `createNodesV2` from one of these is rewritten
+// to the canonical `createNodes` export.
+const TARGET_SPECIFIERS: ReadonlySet<string> = new Set(['@nx/rsbuild']);
+
+let ts: typeof import('typescript') | undefined;
+
+export default async function migrateCreateNodesV2ToCreateNodes(
+  tree: Tree
+): Promise<void> {
+  let touchedCount = 0;
+
+  visitNotIgnoredFiles(tree, '.', (filePath) => {
+    if (!TS_EXTENSIONS.some((ext) => filePath.endsWith(ext))) {
+      return;
+    }
+    const original = tree.read(filePath, 'utf-8');
+    if (!original || !original.includes(DEPRECATED_NAME)) {
+      return;
+    }
+    const updated = rewriteCreateNodesV2Imports(original, TARGET_SPECIFIERS);
+    if (updated !== original) {
+      tree.write(filePath, updated);
+      touchedCount += 1;
+    }
+  });
+
+  if (touchedCount > 0) {
+    logger.info(
+      `Renamed \`${DEPRECATED_NAME}\` imports to \`${CANONICAL_NAME}\` in ${touchedCount} file(s).`
+    );
+  }
+
+  await formatFiles(tree);
+}
+
+/**
+ * Rewrites named imports and re-exports of `createNodesV2` to `createNodes`
+ * when they come from one of the given module specifiers. Only the named
+ * bindings are touched — the module specifier, the `import`/`export` keyword,
+ * any `type` modifier, and any default import are left untouched.
+ */
+export function rewriteCreateNodesV2Imports(
+  source: string,
+  specifiers: ReadonlySet<string>
+): string {
+  ts ??= ensurePackage<typeof import('typescript')>('typescript', '*');
+  const sourceFile = ts.createSourceFile(
+    'tmp.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TSX
+  );
+
+  const changes: StringChange[] = [];
+  for (const stmt of sourceFile.statements) {
+    if (ts.isImportDeclaration(stmt)) {
+      collectImportRewrite(sourceFile, stmt, specifiers, changes);
+    } else if (ts.isExportDeclaration(stmt)) {
+      collectExportRewrite(sourceFile, stmt, specifiers, changes);
+    }
+  }
+
+  return changes.length > 0 ? applyChangesToString(source, changes) : source;
+}
+
+function isTargetSpecifier(
+  node: ImportDeclaration['moduleSpecifier'],
+  specifiers: ReadonlySet<string>
+): boolean {
+  return ts!.isStringLiteral(node) && specifiers.has(node.text);
+}
+
+function collectImportRewrite(
+  sourceFile: SourceFile,
+  stmt: ImportDeclaration,
+  specifiers: ReadonlySet<string>,
+  changes: StringChange[]
+): void {
+  if (!isTargetSpecifier(stmt.moduleSpecifier, specifiers)) {
+    return;
+  }
+  const namedBindings = stmt.importClause?.namedBindings;
+  // Only `import { ... }` carries renameable named bindings. `import x`,
+  // `import * as ns`, and side-effect imports reference the module wholesale
+  // and keep working through the `createNodesV2` runtime alias, so we leave
+  // them be. A mixed `import def, { createNodesV2 }` still has its named
+  // bindings rewritten below — the default binding is untouched.
+  if (!namedBindings || !ts!.isNamedImports(namedBindings)) {
+    return;
+  }
+  rewriteNamedBindings(sourceFile, namedBindings, changes);
+}
+
+function collectExportRewrite(
+  sourceFile: SourceFile,
+  stmt: ExportDeclaration,
+  specifiers: ReadonlySet<string>,
+  changes: StringChange[]
+): void {
+  if (
+    !stmt.moduleSpecifier ||
+    !isTargetSpecifier(stmt.moduleSpecifier, specifiers)
+  ) {
+    return;
+  }
+  // `export { ... } from '...'` can be rewritten; `export * from '...'` has no
+  // named bindings to rename.
+  if (!stmt.exportClause || !ts!.isNamedExports(stmt.exportClause)) {
+    return;
+  }
+  rewriteNamedBindings(sourceFile, stmt.exportClause, changes);
+}
+
+/**
+ * Re-renders the `{ ... }` of a named import/export, renaming any
+ * `createNodesV2` specifier to `createNodes`. If renaming would collide with a
+ * `createNodes` that is already present (e.g. `{ createNodes, createNodesV2 }`),
+ * the duplicate is dropped. Returns without recording a change when the binding
+ * list contains no `createNodesV2`.
+ */
+function rewriteNamedBindings(
+  sourceFile: SourceFile,
+  namedBindings: NamedImports | NamedExports,
+  changes: StringChange[]
+): void {
+  const elements = namedBindings.elements as readonly (
+    | ImportSpecifier
+    | ExportSpecifier
+  )[];
+  const hasDeprecated = elements.some(
+    (el) => (el.propertyName ?? el.name).text === DEPRECATED_NAME
+  );
+  if (!hasDeprecated) {
+    return;
+  }
+
+  const seen = new Set<string>();
+  const rendered: string[] = [];
+  for (const el of elements) {
+    const text = renderSpecifier(el);
+    if (!seen.has(text)) {
+      seen.add(text);
+      rendered.push(text);
+    }
+  }
+
+  const start = namedBindings.getStart(sourceFile);
+  changes.push(
+    {
+      type: ChangeType.Delete,
+      start,
+      length: namedBindings.getEnd() - start,
+    },
+    {
+      type: ChangeType.Insert,
+      index: start,
+      text: `{ ${rendered.join(', ')} }`,
+    }
+  );
+}
+
+function renderSpecifier(el: ImportSpecifier | ExportSpecifier): string {
+  const typePrefix = el.isTypeOnly ? 'type ' : '';
+  const rename = (name: string) =>
+    name === DEPRECATED_NAME ? CANONICAL_NAME : name;
+
+  // `{ name }` — no alias, so the local binding follows the rename.
+  if (!el.propertyName) {
+    return `${typePrefix}${rename(el.name.text)}`;
+  }
+
+  // `{ propertyName as name }` — only the imported (left) side is renamed; the
+  // local alias is preserved. A now-redundant alias such as
+  // `createNodesV2 as createNodes` collapses to `createNodes`.
+  const canonicalImported = rename(el.propertyName.text);
+  const localName = el.name.text;
+  return canonicalImported === localName
+    ? `${typePrefix}${localName}`
+    : `${typePrefix}${canonicalImported} as ${localName}`;
+}

--- a/packages/rspack/migrations.json
+++ b/packages/rspack/migrations.json
@@ -26,6 +26,12 @@
       "description": "Updates rspack configs using React to use the new withSvgr composable function instead of the svgr option in withReact or NxReactRspackPlugin.",
       "factory": "./dist/src/migrations/update-23-0-0/add-svgr-to-rspack-config",
       "documentation": "./dist/src/migrations/update-23-0-0/add-svgr-to-rspack-config.md"
+    },
+    "update-23-0-0-migrate-create-nodes-v2-import": {
+      "version": "23.0.0-beta.5",
+      "description": "Rename imports of `createNodesV2` from `@nx/rspack/plugin` to the canonical `createNodes` export.",
+      "implementation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
+      "documentation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"
     }
   },
   "packageJsonUpdates": {

--- a/packages/rspack/migrations.json
+++ b/packages/rspack/migrations.json
@@ -28,7 +28,7 @@
       "documentation": "./dist/src/migrations/update-23-0-0/add-svgr-to-rspack-config.md"
     },
     "update-23-0-0-migrate-create-nodes-v2-import": {
-      "version": "23.0.0-beta.5",
+      "version": "23.0.0-beta.24",
       "description": "Rename imports of `createNodesV2` from `@nx/rspack/plugin` to the canonical `createNodes` export.",
       "implementation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
       "documentation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"

--- a/packages/rspack/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md
+++ b/packages/rspack/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md
@@ -1,0 +1,25 @@
+#### Rename `createNodesV2` imports to `createNodes`
+
+`@nx/rspack` renamed its primary inferred-plugin export from `createNodesV2` to `createNodes`. The `createNodesV2` name is preserved as a deprecated alias for now, but new code should use `createNodes`.
+
+This migration scans every `.ts`, `.tsx`, `.cts`, and `.mts` file in your workspace and rewrites named imports and re-exports of `createNodesV2` from `@nx/rspack/plugin` to `createNodes`.
+
+#### Sample Code Changes
+
+##### Before
+
+```ts
+import { createNodesV2 } from '@nx/rspack/plugin';
+```
+
+##### After
+
+```ts
+import { createNodes } from '@nx/rspack/plugin';
+```
+
+Aliases are preserved (`createNodesV2 as cn` becomes `createNodes as cn`), and if a file already imports both names (`{ createNodes, createNodesV2 }`) the redundant binding is dropped.
+
+#### What is not rewritten
+
+Only static `import`/`export` named bindings from `@nx/rspack/plugin` are rewritten. Namespace imports, dynamic `import(...)`, `require(...)` destructuring, and property access such as `plugin.createNodesV2` are left untouched — they keep working through the `createNodesV2` runtime alias. Update those by hand if you want to drop the deprecated name everywhere.

--- a/packages/rspack/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.spec.ts
+++ b/packages/rspack/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.spec.ts
@@ -1,0 +1,191 @@
+import { type Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migration, {
+  rewriteCreateNodesV2Imports,
+} from './migrate-create-nodes-v2-to-create-nodes';
+
+const SPECIFIERS = new Set(['@nx/rspack/plugin']);
+const rewrite = (source: string) =>
+  rewriteCreateNodesV2Imports(source, SPECIFIERS);
+
+describe('migrate-create-nodes-v2-to-create-nodes migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  describe('rewriteCreateNodesV2Imports', () => {
+    it('renames a lone createNodesV2 named import', () => {
+      const input = `import { createNodesV2 } from '@nx/rspack/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/rspack/plugin';\n`
+      );
+    });
+
+    it('preserves other named imports while renaming createNodesV2', () => {
+      const input = `import { createNodesV2, SomeOtherExport } from '@nx/rspack/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes, SomeOtherExport } from '@nx/rspack/plugin';\n`
+      );
+    });
+
+    it('rewrites the original name in `as` aliases', () => {
+      const input = `import { createNodesV2 as cn } from '@nx/rspack/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes as cn } from '@nx/rspack/plugin';\n`
+      );
+    });
+
+    it('collapses a redundant `createNodesV2 as createNodes` alias', () => {
+      const input = `import { createNodesV2 as createNodes } from '@nx/rspack/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/rspack/plugin';\n`
+      );
+    });
+
+    it('dedupes when both createNodes and createNodesV2 are imported', () => {
+      const input = `import { createNodes, createNodesV2 } from '@nx/rspack/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/rspack/plugin';\n`
+      );
+    });
+
+    it('dedupes when createNodesV2 precedes createNodes', () => {
+      const input = `import { createNodesV2, createNodes } from '@nx/rspack/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/rspack/plugin';\n`
+      );
+    });
+
+    it('handles multi-line named imports', () => {
+      const input = `import {\n  createNodes,\n  createNodesV2,\n  SomeOtherExport,\n} from '@nx/rspack/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes, SomeOtherExport } from '@nx/rspack/plugin';\n`
+      );
+    });
+
+    it('preserves a default import alongside the renamed binding', () => {
+      const input = `import def, { createNodesV2 } from '@nx/rspack/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import def, { createNodes } from '@nx/rspack/plugin';\n`
+      );
+    });
+
+    it('handles `import type` declarations', () => {
+      const input = `import type { createNodesV2 } from '@nx/rspack/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import type { createNodes } from '@nx/rspack/plugin';\n`
+      );
+    });
+
+    it('preserves inline `type` modifiers', () => {
+      const input = `import { type createNodesV2 } from '@nx/rspack/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { type createNodes } from '@nx/rspack/plugin';\n`
+      );
+    });
+
+    it('rewrites named re-exports', () => {
+      const input = `export { createNodesV2 } from '@nx/rspack/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `export { createNodes } from '@nx/rspack/plugin';\n`
+      );
+    });
+
+    it('rewrites aliased named re-exports', () => {
+      const input = `export { createNodesV2 as cn } from '@nx/rspack/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `export { createNodes as cn } from '@nx/rspack/plugin';\n`
+      );
+    });
+
+    it('does not touch createNodesV2 from a different specifier', () => {
+      const input = `import { createNodesV2 } from '@nx/other-plugin/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not touch createNodesV2 from a relative specifier', () => {
+      const input = `import { createNodesV2 } from './plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not touch unrelated imports from the target specifier', () => {
+      const input = `import { createNodes } from '@nx/rspack/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not rewrite `export * from` declarations', () => {
+      const input = `export * from '@nx/rspack/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('leaves createNodesV2 in strings and comments alone', () => {
+      const input =
+        `// import { createNodesV2 } from '@nx/rspack/plugin';\n` +
+        `const s = "createNodesV2";\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not rewrite require() destructuring (still valid via alias)', () => {
+      const input = `const { createNodesV2 } = require('@nx/rspack/plugin');\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+  });
+
+  describe('migration runner', () => {
+    it('rewrites imports across .ts/.tsx/.cts/.mts files', async () => {
+      tree.write(
+        'libs/foo/src/a.ts',
+        `import { createNodesV2 } from '@nx/rspack/plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/b.tsx',
+        `import { createNodesV2 as cn } from '@nx/rspack/plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/c.cts',
+        `export { createNodesV2 } from '@nx/rspack/plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/d.mts',
+        `import { createNodesV2, SomeOtherExport } from '@nx/rspack/plugin';\n`
+      );
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/a.ts', 'utf-8')).toContain(
+        `import { createNodes } from '@nx/rspack/plugin';`
+      );
+      expect(tree.read('libs/foo/src/b.tsx', 'utf-8')).toContain(
+        `import { createNodes as cn } from '@nx/rspack/plugin';`
+      );
+      expect(tree.read('libs/foo/src/c.cts', 'utf-8')).toContain(
+        `export { createNodes } from '@nx/rspack/plugin';`
+      );
+      expect(tree.read('libs/foo/src/d.mts', 'utf-8')).toContain(
+        `import { createNodes, SomeOtherExport } from '@nx/rspack/plugin';`
+      );
+    });
+
+    it('does not touch files without the deprecated name', async () => {
+      const content = `import { createNodes } from '@nx/rspack/plugin';\n`;
+      tree.write('libs/foo/src/index.ts', content);
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/index.ts', 'utf-8')).toBe(content);
+    });
+
+    it('does not rewrite non-TS files', async () => {
+      const md = `Example: \`import { createNodesV2 } from '@nx/rspack/plugin';\`\n`;
+      tree.write('docs/example.md', md);
+
+      await migration(tree);
+
+      expect(tree.read('docs/example.md', 'utf-8')).toContain(
+        `import { createNodesV2 } from '@nx/rspack/plugin';`
+      );
+    });
+  });
+});

--- a/packages/rspack/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.ts
+++ b/packages/rspack/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.ts
@@ -1,0 +1,206 @@
+import {
+  applyChangesToString,
+  ChangeType,
+  ensurePackage,
+  formatFiles,
+  logger,
+  type StringChange,
+  type Tree,
+  visitNotIgnoredFiles,
+} from '@nx/devkit';
+import type {
+  ExportDeclaration,
+  ExportSpecifier,
+  ImportDeclaration,
+  ImportSpecifier,
+  NamedExports,
+  NamedImports,
+  SourceFile,
+} from 'typescript';
+
+const TS_EXTENSIONS = ['.ts', '.tsx', '.cts', '.mts'] as const;
+const DEPRECATED_NAME = 'createNodesV2';
+const CANONICAL_NAME = 'createNodes';
+
+// Module specifiers from which `@nx/rspack` publicly exposes `createNodesV2`.
+// A named import or re-export of `createNodesV2` from one of these is rewritten
+// to the canonical `createNodes` export.
+const TARGET_SPECIFIERS: ReadonlySet<string> = new Set(['@nx/rspack/plugin']);
+
+let ts: typeof import('typescript') | undefined;
+
+export default async function migrateCreateNodesV2ToCreateNodes(
+  tree: Tree
+): Promise<void> {
+  let touchedCount = 0;
+
+  visitNotIgnoredFiles(tree, '.', (filePath) => {
+    if (!TS_EXTENSIONS.some((ext) => filePath.endsWith(ext))) {
+      return;
+    }
+    const original = tree.read(filePath, 'utf-8');
+    if (!original || !original.includes(DEPRECATED_NAME)) {
+      return;
+    }
+    const updated = rewriteCreateNodesV2Imports(original, TARGET_SPECIFIERS);
+    if (updated !== original) {
+      tree.write(filePath, updated);
+      touchedCount += 1;
+    }
+  });
+
+  if (touchedCount > 0) {
+    logger.info(
+      `Renamed \`${DEPRECATED_NAME}\` imports to \`${CANONICAL_NAME}\` in ${touchedCount} file(s).`
+    );
+  }
+
+  await formatFiles(tree);
+}
+
+/**
+ * Rewrites named imports and re-exports of `createNodesV2` to `createNodes`
+ * when they come from one of the given module specifiers. Only the named
+ * bindings are touched — the module specifier, the `import`/`export` keyword,
+ * any `type` modifier, and any default import are left untouched.
+ */
+export function rewriteCreateNodesV2Imports(
+  source: string,
+  specifiers: ReadonlySet<string>
+): string {
+  ts ??= ensurePackage<typeof import('typescript')>('typescript', '*');
+  const sourceFile = ts.createSourceFile(
+    'tmp.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TSX
+  );
+
+  const changes: StringChange[] = [];
+  for (const stmt of sourceFile.statements) {
+    if (ts.isImportDeclaration(stmt)) {
+      collectImportRewrite(sourceFile, stmt, specifiers, changes);
+    } else if (ts.isExportDeclaration(stmt)) {
+      collectExportRewrite(sourceFile, stmt, specifiers, changes);
+    }
+  }
+
+  return changes.length > 0 ? applyChangesToString(source, changes) : source;
+}
+
+function isTargetSpecifier(
+  node: ImportDeclaration['moduleSpecifier'],
+  specifiers: ReadonlySet<string>
+): boolean {
+  return ts!.isStringLiteral(node) && specifiers.has(node.text);
+}
+
+function collectImportRewrite(
+  sourceFile: SourceFile,
+  stmt: ImportDeclaration,
+  specifiers: ReadonlySet<string>,
+  changes: StringChange[]
+): void {
+  if (!isTargetSpecifier(stmt.moduleSpecifier, specifiers)) {
+    return;
+  }
+  const namedBindings = stmt.importClause?.namedBindings;
+  // Only `import { ... }` carries renameable named bindings. `import x`,
+  // `import * as ns`, and side-effect imports reference the module wholesale
+  // and keep working through the `createNodesV2` runtime alias, so we leave
+  // them be. A mixed `import def, { createNodesV2 }` still has its named
+  // bindings rewritten below — the default binding is untouched.
+  if (!namedBindings || !ts!.isNamedImports(namedBindings)) {
+    return;
+  }
+  rewriteNamedBindings(sourceFile, namedBindings, changes);
+}
+
+function collectExportRewrite(
+  sourceFile: SourceFile,
+  stmt: ExportDeclaration,
+  specifiers: ReadonlySet<string>,
+  changes: StringChange[]
+): void {
+  if (
+    !stmt.moduleSpecifier ||
+    !isTargetSpecifier(stmt.moduleSpecifier, specifiers)
+  ) {
+    return;
+  }
+  // `export { ... } from '...'` can be rewritten; `export * from '...'` has no
+  // named bindings to rename.
+  if (!stmt.exportClause || !ts!.isNamedExports(stmt.exportClause)) {
+    return;
+  }
+  rewriteNamedBindings(sourceFile, stmt.exportClause, changes);
+}
+
+/**
+ * Re-renders the `{ ... }` of a named import/export, renaming any
+ * `createNodesV2` specifier to `createNodes`. If renaming would collide with a
+ * `createNodes` that is already present (e.g. `{ createNodes, createNodesV2 }`),
+ * the duplicate is dropped. Returns without recording a change when the binding
+ * list contains no `createNodesV2`.
+ */
+function rewriteNamedBindings(
+  sourceFile: SourceFile,
+  namedBindings: NamedImports | NamedExports,
+  changes: StringChange[]
+): void {
+  const elements = namedBindings.elements as readonly (
+    | ImportSpecifier
+    | ExportSpecifier
+  )[];
+  const hasDeprecated = elements.some(
+    (el) => (el.propertyName ?? el.name).text === DEPRECATED_NAME
+  );
+  if (!hasDeprecated) {
+    return;
+  }
+
+  const seen = new Set<string>();
+  const rendered: string[] = [];
+  for (const el of elements) {
+    const text = renderSpecifier(el);
+    if (!seen.has(text)) {
+      seen.add(text);
+      rendered.push(text);
+    }
+  }
+
+  const start = namedBindings.getStart(sourceFile);
+  changes.push(
+    {
+      type: ChangeType.Delete,
+      start,
+      length: namedBindings.getEnd() - start,
+    },
+    {
+      type: ChangeType.Insert,
+      index: start,
+      text: `{ ${rendered.join(', ')} }`,
+    }
+  );
+}
+
+function renderSpecifier(el: ImportSpecifier | ExportSpecifier): string {
+  const typePrefix = el.isTypeOnly ? 'type ' : '';
+  const rename = (name: string) =>
+    name === DEPRECATED_NAME ? CANONICAL_NAME : name;
+
+  // `{ name }` — no alias, so the local binding follows the rename.
+  if (!el.propertyName) {
+    return `${typePrefix}${rename(el.name.text)}`;
+  }
+
+  // `{ propertyName as name }` — only the imported (left) side is renamed; the
+  // local alias is preserved. A now-redundant alias such as
+  // `createNodesV2 as createNodes` collapses to `createNodes`.
+  const canonicalImported = rename(el.propertyName.text);
+  const localName = el.name.text;
+  return canonicalImported === localName
+    ? `${typePrefix}${localName}`
+    : `${typePrefix}${canonicalImported} as ${localName}`;
+}

--- a/packages/storybook/migrations.json
+++ b/packages/storybook/migrations.json
@@ -27,6 +27,12 @@
       "description": "Update workspace to use Storybook v10",
       "implementation": "./dist/src/migrations/update-22-1-0/migrate-to-storybook-10",
       "prompt": "./dist/src/generators/migrate-10/files/ai-instructions-for-cjs-esm.md"
+    },
+    "update-23-0-0-migrate-create-nodes-v2-import": {
+      "version": "23.0.0-beta.5",
+      "description": "Rename imports of `createNodesV2` from `@nx/storybook/plugin` to the canonical `createNodes` export.",
+      "implementation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
+      "documentation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"
     }
   },
   "packageJsonUpdates": {

--- a/packages/storybook/migrations.json
+++ b/packages/storybook/migrations.json
@@ -29,7 +29,7 @@
       "prompt": "./dist/src/generators/migrate-10/files/ai-instructions-for-cjs-esm.md"
     },
     "update-23-0-0-migrate-create-nodes-v2-import": {
-      "version": "23.0.0-beta.5",
+      "version": "23.0.0-beta.24",
       "description": "Rename imports of `createNodesV2` from `@nx/storybook/plugin` to the canonical `createNodes` export.",
       "implementation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
       "documentation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"

--- a/packages/storybook/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md
+++ b/packages/storybook/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md
@@ -1,0 +1,25 @@
+#### Rename `createNodesV2` imports to `createNodes`
+
+`@nx/storybook` renamed its primary inferred-plugin export from `createNodesV2` to `createNodes`. The `createNodesV2` name is preserved as a deprecated alias for now, but new code should use `createNodes`.
+
+This migration scans every `.ts`, `.tsx`, `.cts`, and `.mts` file in your workspace and rewrites named imports and re-exports of `createNodesV2` from `@nx/storybook/plugin` to `createNodes`.
+
+#### Sample Code Changes
+
+##### Before
+
+```ts
+import { createNodesV2 } from '@nx/storybook/plugin';
+```
+
+##### After
+
+```ts
+import { createNodes } from '@nx/storybook/plugin';
+```
+
+Aliases are preserved (`createNodesV2 as cn` becomes `createNodes as cn`), and if a file already imports both names (`{ createNodes, createNodesV2 }`) the redundant binding is dropped.
+
+#### What is not rewritten
+
+Only static `import`/`export` named bindings from `@nx/storybook/plugin` are rewritten. Namespace imports, dynamic `import(...)`, `require(...)` destructuring, and property access such as `plugin.createNodesV2` are left untouched — they keep working through the `createNodesV2` runtime alias. Update those by hand if you want to drop the deprecated name everywhere.

--- a/packages/storybook/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.spec.ts
+++ b/packages/storybook/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.spec.ts
@@ -1,0 +1,191 @@
+import { type Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migration, {
+  rewriteCreateNodesV2Imports,
+} from './migrate-create-nodes-v2-to-create-nodes';
+
+const SPECIFIERS = new Set(['@nx/storybook/plugin']);
+const rewrite = (source: string) =>
+  rewriteCreateNodesV2Imports(source, SPECIFIERS);
+
+describe('migrate-create-nodes-v2-to-create-nodes migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  describe('rewriteCreateNodesV2Imports', () => {
+    it('renames a lone createNodesV2 named import', () => {
+      const input = `import { createNodesV2 } from '@nx/storybook/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/storybook/plugin';\n`
+      );
+    });
+
+    it('preserves other named imports while renaming createNodesV2', () => {
+      const input = `import { createNodesV2, SomeOtherExport } from '@nx/storybook/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes, SomeOtherExport } from '@nx/storybook/plugin';\n`
+      );
+    });
+
+    it('rewrites the original name in `as` aliases', () => {
+      const input = `import { createNodesV2 as cn } from '@nx/storybook/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes as cn } from '@nx/storybook/plugin';\n`
+      );
+    });
+
+    it('collapses a redundant `createNodesV2 as createNodes` alias', () => {
+      const input = `import { createNodesV2 as createNodes } from '@nx/storybook/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/storybook/plugin';\n`
+      );
+    });
+
+    it('dedupes when both createNodes and createNodesV2 are imported', () => {
+      const input = `import { createNodes, createNodesV2 } from '@nx/storybook/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/storybook/plugin';\n`
+      );
+    });
+
+    it('dedupes when createNodesV2 precedes createNodes', () => {
+      const input = `import { createNodesV2, createNodes } from '@nx/storybook/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/storybook/plugin';\n`
+      );
+    });
+
+    it('handles multi-line named imports', () => {
+      const input = `import {\n  createNodes,\n  createNodesV2,\n  SomeOtherExport,\n} from '@nx/storybook/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes, SomeOtherExport } from '@nx/storybook/plugin';\n`
+      );
+    });
+
+    it('preserves a default import alongside the renamed binding', () => {
+      const input = `import def, { createNodesV2 } from '@nx/storybook/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import def, { createNodes } from '@nx/storybook/plugin';\n`
+      );
+    });
+
+    it('handles `import type` declarations', () => {
+      const input = `import type { createNodesV2 } from '@nx/storybook/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import type { createNodes } from '@nx/storybook/plugin';\n`
+      );
+    });
+
+    it('preserves inline `type` modifiers', () => {
+      const input = `import { type createNodesV2 } from '@nx/storybook/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { type createNodes } from '@nx/storybook/plugin';\n`
+      );
+    });
+
+    it('rewrites named re-exports', () => {
+      const input = `export { createNodesV2 } from '@nx/storybook/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `export { createNodes } from '@nx/storybook/plugin';\n`
+      );
+    });
+
+    it('rewrites aliased named re-exports', () => {
+      const input = `export { createNodesV2 as cn } from '@nx/storybook/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `export { createNodes as cn } from '@nx/storybook/plugin';\n`
+      );
+    });
+
+    it('does not touch createNodesV2 from a different specifier', () => {
+      const input = `import { createNodesV2 } from '@nx/other-plugin/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not touch createNodesV2 from a relative specifier', () => {
+      const input = `import { createNodesV2 } from './plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not touch unrelated imports from the target specifier', () => {
+      const input = `import { createNodes } from '@nx/storybook/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not rewrite `export * from` declarations', () => {
+      const input = `export * from '@nx/storybook/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('leaves createNodesV2 in strings and comments alone', () => {
+      const input =
+        `// import { createNodesV2 } from '@nx/storybook/plugin';\n` +
+        `const s = "createNodesV2";\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not rewrite require() destructuring (still valid via alias)', () => {
+      const input = `const { createNodesV2 } = require('@nx/storybook/plugin');\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+  });
+
+  describe('migration runner', () => {
+    it('rewrites imports across .ts/.tsx/.cts/.mts files', async () => {
+      tree.write(
+        'libs/foo/src/a.ts',
+        `import { createNodesV2 } from '@nx/storybook/plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/b.tsx',
+        `import { createNodesV2 as cn } from '@nx/storybook/plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/c.cts',
+        `export { createNodesV2 } from '@nx/storybook/plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/d.mts',
+        `import { createNodesV2, SomeOtherExport } from '@nx/storybook/plugin';\n`
+      );
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/a.ts', 'utf-8')).toContain(
+        `import { createNodes } from '@nx/storybook/plugin';`
+      );
+      expect(tree.read('libs/foo/src/b.tsx', 'utf-8')).toContain(
+        `import { createNodes as cn } from '@nx/storybook/plugin';`
+      );
+      expect(tree.read('libs/foo/src/c.cts', 'utf-8')).toContain(
+        `export { createNodes } from '@nx/storybook/plugin';`
+      );
+      expect(tree.read('libs/foo/src/d.mts', 'utf-8')).toContain(
+        `import { createNodes, SomeOtherExport } from '@nx/storybook/plugin';`
+      );
+    });
+
+    it('does not touch files without the deprecated name', async () => {
+      const content = `import { createNodes } from '@nx/storybook/plugin';\n`;
+      tree.write('libs/foo/src/index.ts', content);
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/index.ts', 'utf-8')).toBe(content);
+    });
+
+    it('does not rewrite non-TS files', async () => {
+      const md = `Example: \`import { createNodesV2 } from '@nx/storybook/plugin';\`\n`;
+      tree.write('docs/example.md', md);
+
+      await migration(tree);
+
+      expect(tree.read('docs/example.md', 'utf-8')).toContain(
+        `import { createNodesV2 } from '@nx/storybook/plugin';`
+      );
+    });
+  });
+});

--- a/packages/storybook/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.ts
+++ b/packages/storybook/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.ts
@@ -1,0 +1,208 @@
+import {
+  applyChangesToString,
+  ChangeType,
+  ensurePackage,
+  formatFiles,
+  logger,
+  type StringChange,
+  type Tree,
+  visitNotIgnoredFiles,
+} from '@nx/devkit';
+import type {
+  ExportDeclaration,
+  ExportSpecifier,
+  ImportDeclaration,
+  ImportSpecifier,
+  NamedExports,
+  NamedImports,
+  SourceFile,
+} from 'typescript';
+
+const TS_EXTENSIONS = ['.ts', '.tsx', '.cts', '.mts'] as const;
+const DEPRECATED_NAME = 'createNodesV2';
+const CANONICAL_NAME = 'createNodes';
+
+// Module specifiers from which `@nx/storybook` publicly exposes `createNodesV2`.
+// A named import or re-export of `createNodesV2` from one of these is rewritten
+// to the canonical `createNodes` export.
+const TARGET_SPECIFIERS: ReadonlySet<string> = new Set([
+  '@nx/storybook/plugin',
+]);
+
+let ts: typeof import('typescript') | undefined;
+
+export default async function migrateCreateNodesV2ToCreateNodes(
+  tree: Tree
+): Promise<void> {
+  let touchedCount = 0;
+
+  visitNotIgnoredFiles(tree, '.', (filePath) => {
+    if (!TS_EXTENSIONS.some((ext) => filePath.endsWith(ext))) {
+      return;
+    }
+    const original = tree.read(filePath, 'utf-8');
+    if (!original || !original.includes(DEPRECATED_NAME)) {
+      return;
+    }
+    const updated = rewriteCreateNodesV2Imports(original, TARGET_SPECIFIERS);
+    if (updated !== original) {
+      tree.write(filePath, updated);
+      touchedCount += 1;
+    }
+  });
+
+  if (touchedCount > 0) {
+    logger.info(
+      `Renamed \`${DEPRECATED_NAME}\` imports to \`${CANONICAL_NAME}\` in ${touchedCount} file(s).`
+    );
+  }
+
+  await formatFiles(tree);
+}
+
+/**
+ * Rewrites named imports and re-exports of `createNodesV2` to `createNodes`
+ * when they come from one of the given module specifiers. Only the named
+ * bindings are touched — the module specifier, the `import`/`export` keyword,
+ * any `type` modifier, and any default import are left untouched.
+ */
+export function rewriteCreateNodesV2Imports(
+  source: string,
+  specifiers: ReadonlySet<string>
+): string {
+  ts ??= ensurePackage<typeof import('typescript')>('typescript', '*');
+  const sourceFile = ts.createSourceFile(
+    'tmp.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TSX
+  );
+
+  const changes: StringChange[] = [];
+  for (const stmt of sourceFile.statements) {
+    if (ts.isImportDeclaration(stmt)) {
+      collectImportRewrite(sourceFile, stmt, specifiers, changes);
+    } else if (ts.isExportDeclaration(stmt)) {
+      collectExportRewrite(sourceFile, stmt, specifiers, changes);
+    }
+  }
+
+  return changes.length > 0 ? applyChangesToString(source, changes) : source;
+}
+
+function isTargetSpecifier(
+  node: ImportDeclaration['moduleSpecifier'],
+  specifiers: ReadonlySet<string>
+): boolean {
+  return ts!.isStringLiteral(node) && specifiers.has(node.text);
+}
+
+function collectImportRewrite(
+  sourceFile: SourceFile,
+  stmt: ImportDeclaration,
+  specifiers: ReadonlySet<string>,
+  changes: StringChange[]
+): void {
+  if (!isTargetSpecifier(stmt.moduleSpecifier, specifiers)) {
+    return;
+  }
+  const namedBindings = stmt.importClause?.namedBindings;
+  // Only `import { ... }` carries renameable named bindings. `import x`,
+  // `import * as ns`, and side-effect imports reference the module wholesale
+  // and keep working through the `createNodesV2` runtime alias, so we leave
+  // them be. A mixed `import def, { createNodesV2 }` still has its named
+  // bindings rewritten below — the default binding is untouched.
+  if (!namedBindings || !ts!.isNamedImports(namedBindings)) {
+    return;
+  }
+  rewriteNamedBindings(sourceFile, namedBindings, changes);
+}
+
+function collectExportRewrite(
+  sourceFile: SourceFile,
+  stmt: ExportDeclaration,
+  specifiers: ReadonlySet<string>,
+  changes: StringChange[]
+): void {
+  if (
+    !stmt.moduleSpecifier ||
+    !isTargetSpecifier(stmt.moduleSpecifier, specifiers)
+  ) {
+    return;
+  }
+  // `export { ... } from '...'` can be rewritten; `export * from '...'` has no
+  // named bindings to rename.
+  if (!stmt.exportClause || !ts!.isNamedExports(stmt.exportClause)) {
+    return;
+  }
+  rewriteNamedBindings(sourceFile, stmt.exportClause, changes);
+}
+
+/**
+ * Re-renders the `{ ... }` of a named import/export, renaming any
+ * `createNodesV2` specifier to `createNodes`. If renaming would collide with a
+ * `createNodes` that is already present (e.g. `{ createNodes, createNodesV2 }`),
+ * the duplicate is dropped. Returns without recording a change when the binding
+ * list contains no `createNodesV2`.
+ */
+function rewriteNamedBindings(
+  sourceFile: SourceFile,
+  namedBindings: NamedImports | NamedExports,
+  changes: StringChange[]
+): void {
+  const elements = namedBindings.elements as readonly (
+    | ImportSpecifier
+    | ExportSpecifier
+  )[];
+  const hasDeprecated = elements.some(
+    (el) => (el.propertyName ?? el.name).text === DEPRECATED_NAME
+  );
+  if (!hasDeprecated) {
+    return;
+  }
+
+  const seen = new Set<string>();
+  const rendered: string[] = [];
+  for (const el of elements) {
+    const text = renderSpecifier(el);
+    if (!seen.has(text)) {
+      seen.add(text);
+      rendered.push(text);
+    }
+  }
+
+  const start = namedBindings.getStart(sourceFile);
+  changes.push(
+    {
+      type: ChangeType.Delete,
+      start,
+      length: namedBindings.getEnd() - start,
+    },
+    {
+      type: ChangeType.Insert,
+      index: start,
+      text: `{ ${rendered.join(', ')} }`,
+    }
+  );
+}
+
+function renderSpecifier(el: ImportSpecifier | ExportSpecifier): string {
+  const typePrefix = el.isTypeOnly ? 'type ' : '';
+  const rename = (name: string) =>
+    name === DEPRECATED_NAME ? CANONICAL_NAME : name;
+
+  // `{ name }` — no alias, so the local binding follows the rename.
+  if (!el.propertyName) {
+    return `${typePrefix}${rename(el.name.text)}`;
+  }
+
+  // `{ propertyName as name }` — only the imported (left) side is renamed; the
+  // local alias is preserved. A now-redundant alias such as
+  // `createNodesV2 as createNodes` collapses to `createNodes`.
+  const canonicalImported = rename(el.propertyName.text);
+  const localName = el.name.text;
+  return canonicalImported === localName
+    ? `${typePrefix}${localName}`
+    : `${typePrefix}${canonicalImported} as ${localName}`;
+}

--- a/packages/vite/migrations.json
+++ b/packages/vite/migrations.json
@@ -91,7 +91,7 @@
       "prompt": "./dist/src/migrations/update-23-0-0/ai-instructions-for-vitest-4.md"
     },
     "update-23-0-0-migrate-create-nodes-v2-import": {
-      "version": "23.0.0-beta.5",
+      "version": "23.0.0-beta.24",
       "description": "Rename imports of `createNodesV2` from `@nx/vite/plugin` to the canonical `createNodes` export.",
       "implementation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
       "documentation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"

--- a/packages/vite/migrations.json
+++ b/packages/vite/migrations.json
@@ -89,6 +89,12 @@
       "description": "Migrate workspaces past breaking changes for Vitest 4.",
       "implementation": "./dist/src/migrations/update-23-0-0/migrate-to-vitest-4",
       "prompt": "./dist/src/migrations/update-23-0-0/ai-instructions-for-vitest-4.md"
+    },
+    "update-23-0-0-migrate-create-nodes-v2-import": {
+      "version": "23.0.0-beta.5",
+      "description": "Rename imports of `createNodesV2` from `@nx/vite/plugin` to the canonical `createNodes` export.",
+      "implementation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
+      "documentation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"
     }
   },
   "packageJsonUpdates": {

--- a/packages/vite/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md
+++ b/packages/vite/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md
@@ -1,0 +1,25 @@
+#### Rename `createNodesV2` imports to `createNodes`
+
+`@nx/vite` renamed its primary inferred-plugin export from `createNodesV2` to `createNodes`. The `createNodesV2` name is preserved as a deprecated alias for now, but new code should use `createNodes`.
+
+This migration scans every `.ts`, `.tsx`, `.cts`, and `.mts` file in your workspace and rewrites named imports and re-exports of `createNodesV2` from `@nx/vite/plugin` to `createNodes`.
+
+#### Sample Code Changes
+
+##### Before
+
+```ts
+import { createNodesV2 } from '@nx/vite/plugin';
+```
+
+##### After
+
+```ts
+import { createNodes } from '@nx/vite/plugin';
+```
+
+Aliases are preserved (`createNodesV2 as cn` becomes `createNodes as cn`), and if a file already imports both names (`{ createNodes, createNodesV2 }`) the redundant binding is dropped.
+
+#### What is not rewritten
+
+Only static `import`/`export` named bindings from `@nx/vite/plugin` are rewritten. Namespace imports, dynamic `import(...)`, `require(...)` destructuring, and property access such as `plugin.createNodesV2` are left untouched — they keep working through the `createNodesV2` runtime alias. Update those by hand if you want to drop the deprecated name everywhere.

--- a/packages/vite/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.spec.ts
+++ b/packages/vite/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.spec.ts
@@ -1,0 +1,191 @@
+import { type Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migration, {
+  rewriteCreateNodesV2Imports,
+} from './migrate-create-nodes-v2-to-create-nodes';
+
+const SPECIFIERS = new Set(['@nx/vite/plugin']);
+const rewrite = (source: string) =>
+  rewriteCreateNodesV2Imports(source, SPECIFIERS);
+
+describe('migrate-create-nodes-v2-to-create-nodes migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  describe('rewriteCreateNodesV2Imports', () => {
+    it('renames a lone createNodesV2 named import', () => {
+      const input = `import { createNodesV2 } from '@nx/vite/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/vite/plugin';\n`
+      );
+    });
+
+    it('preserves other named imports while renaming createNodesV2', () => {
+      const input = `import { createNodesV2, SomeOtherExport } from '@nx/vite/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes, SomeOtherExport } from '@nx/vite/plugin';\n`
+      );
+    });
+
+    it('rewrites the original name in `as` aliases', () => {
+      const input = `import { createNodesV2 as cn } from '@nx/vite/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes as cn } from '@nx/vite/plugin';\n`
+      );
+    });
+
+    it('collapses a redundant `createNodesV2 as createNodes` alias', () => {
+      const input = `import { createNodesV2 as createNodes } from '@nx/vite/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/vite/plugin';\n`
+      );
+    });
+
+    it('dedupes when both createNodes and createNodesV2 are imported', () => {
+      const input = `import { createNodes, createNodesV2 } from '@nx/vite/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/vite/plugin';\n`
+      );
+    });
+
+    it('dedupes when createNodesV2 precedes createNodes', () => {
+      const input = `import { createNodesV2, createNodes } from '@nx/vite/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/vite/plugin';\n`
+      );
+    });
+
+    it('handles multi-line named imports', () => {
+      const input = `import {\n  createNodes,\n  createNodesV2,\n  SomeOtherExport,\n} from '@nx/vite/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes, SomeOtherExport } from '@nx/vite/plugin';\n`
+      );
+    });
+
+    it('preserves a default import alongside the renamed binding', () => {
+      const input = `import def, { createNodesV2 } from '@nx/vite/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import def, { createNodes } from '@nx/vite/plugin';\n`
+      );
+    });
+
+    it('handles `import type` declarations', () => {
+      const input = `import type { createNodesV2 } from '@nx/vite/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import type { createNodes } from '@nx/vite/plugin';\n`
+      );
+    });
+
+    it('preserves inline `type` modifiers', () => {
+      const input = `import { type createNodesV2 } from '@nx/vite/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { type createNodes } from '@nx/vite/plugin';\n`
+      );
+    });
+
+    it('rewrites named re-exports', () => {
+      const input = `export { createNodesV2 } from '@nx/vite/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `export { createNodes } from '@nx/vite/plugin';\n`
+      );
+    });
+
+    it('rewrites aliased named re-exports', () => {
+      const input = `export { createNodesV2 as cn } from '@nx/vite/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `export { createNodes as cn } from '@nx/vite/plugin';\n`
+      );
+    });
+
+    it('does not touch createNodesV2 from a different specifier', () => {
+      const input = `import { createNodesV2 } from '@nx/other-plugin/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not touch createNodesV2 from a relative specifier', () => {
+      const input = `import { createNodesV2 } from './plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not touch unrelated imports from the target specifier', () => {
+      const input = `import { createNodes } from '@nx/vite/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not rewrite `export * from` declarations', () => {
+      const input = `export * from '@nx/vite/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('leaves createNodesV2 in strings and comments alone', () => {
+      const input =
+        `// import { createNodesV2 } from '@nx/vite/plugin';\n` +
+        `const s = "createNodesV2";\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not rewrite require() destructuring (still valid via alias)', () => {
+      const input = `const { createNodesV2 } = require('@nx/vite/plugin');\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+  });
+
+  describe('migration runner', () => {
+    it('rewrites imports across .ts/.tsx/.cts/.mts files', async () => {
+      tree.write(
+        'libs/foo/src/a.ts',
+        `import { createNodesV2 } from '@nx/vite/plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/b.tsx',
+        `import { createNodesV2 as cn } from '@nx/vite/plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/c.cts',
+        `export { createNodesV2 } from '@nx/vite/plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/d.mts',
+        `import { createNodesV2, SomeOtherExport } from '@nx/vite/plugin';\n`
+      );
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/a.ts', 'utf-8')).toContain(
+        `import { createNodes } from '@nx/vite/plugin';`
+      );
+      expect(tree.read('libs/foo/src/b.tsx', 'utf-8')).toContain(
+        `import { createNodes as cn } from '@nx/vite/plugin';`
+      );
+      expect(tree.read('libs/foo/src/c.cts', 'utf-8')).toContain(
+        `export { createNodes } from '@nx/vite/plugin';`
+      );
+      expect(tree.read('libs/foo/src/d.mts', 'utf-8')).toContain(
+        `import { createNodes, SomeOtherExport } from '@nx/vite/plugin';`
+      );
+    });
+
+    it('does not touch files without the deprecated name', async () => {
+      const content = `import { createNodes } from '@nx/vite/plugin';\n`;
+      tree.write('libs/foo/src/index.ts', content);
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/index.ts', 'utf-8')).toBe(content);
+    });
+
+    it('does not rewrite non-TS files', async () => {
+      const md = `Example: \`import { createNodesV2 } from '@nx/vite/plugin';\`\n`;
+      tree.write('docs/example.md', md);
+
+      await migration(tree);
+
+      expect(tree.read('docs/example.md', 'utf-8')).toContain(
+        `import { createNodesV2 } from '@nx/vite/plugin';`
+      );
+    });
+  });
+});

--- a/packages/vite/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.ts
+++ b/packages/vite/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.ts
@@ -1,0 +1,206 @@
+import {
+  applyChangesToString,
+  ChangeType,
+  ensurePackage,
+  formatFiles,
+  logger,
+  type StringChange,
+  type Tree,
+  visitNotIgnoredFiles,
+} from '@nx/devkit';
+import type {
+  ExportDeclaration,
+  ExportSpecifier,
+  ImportDeclaration,
+  ImportSpecifier,
+  NamedExports,
+  NamedImports,
+  SourceFile,
+} from 'typescript';
+
+const TS_EXTENSIONS = ['.ts', '.tsx', '.cts', '.mts'] as const;
+const DEPRECATED_NAME = 'createNodesV2';
+const CANONICAL_NAME = 'createNodes';
+
+// Module specifiers from which `@nx/vite` publicly exposes `createNodesV2`.
+// A named import or re-export of `createNodesV2` from one of these is rewritten
+// to the canonical `createNodes` export.
+const TARGET_SPECIFIERS: ReadonlySet<string> = new Set(['@nx/vite/plugin']);
+
+let ts: typeof import('typescript') | undefined;
+
+export default async function migrateCreateNodesV2ToCreateNodes(
+  tree: Tree
+): Promise<void> {
+  let touchedCount = 0;
+
+  visitNotIgnoredFiles(tree, '.', (filePath) => {
+    if (!TS_EXTENSIONS.some((ext) => filePath.endsWith(ext))) {
+      return;
+    }
+    const original = tree.read(filePath, 'utf-8');
+    if (!original || !original.includes(DEPRECATED_NAME)) {
+      return;
+    }
+    const updated = rewriteCreateNodesV2Imports(original, TARGET_SPECIFIERS);
+    if (updated !== original) {
+      tree.write(filePath, updated);
+      touchedCount += 1;
+    }
+  });
+
+  if (touchedCount > 0) {
+    logger.info(
+      `Renamed \`${DEPRECATED_NAME}\` imports to \`${CANONICAL_NAME}\` in ${touchedCount} file(s).`
+    );
+  }
+
+  await formatFiles(tree);
+}
+
+/**
+ * Rewrites named imports and re-exports of `createNodesV2` to `createNodes`
+ * when they come from one of the given module specifiers. Only the named
+ * bindings are touched — the module specifier, the `import`/`export` keyword,
+ * any `type` modifier, and any default import are left untouched.
+ */
+export function rewriteCreateNodesV2Imports(
+  source: string,
+  specifiers: ReadonlySet<string>
+): string {
+  ts ??= ensurePackage<typeof import('typescript')>('typescript', '*');
+  const sourceFile = ts.createSourceFile(
+    'tmp.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TSX
+  );
+
+  const changes: StringChange[] = [];
+  for (const stmt of sourceFile.statements) {
+    if (ts.isImportDeclaration(stmt)) {
+      collectImportRewrite(sourceFile, stmt, specifiers, changes);
+    } else if (ts.isExportDeclaration(stmt)) {
+      collectExportRewrite(sourceFile, stmt, specifiers, changes);
+    }
+  }
+
+  return changes.length > 0 ? applyChangesToString(source, changes) : source;
+}
+
+function isTargetSpecifier(
+  node: ImportDeclaration['moduleSpecifier'],
+  specifiers: ReadonlySet<string>
+): boolean {
+  return ts!.isStringLiteral(node) && specifiers.has(node.text);
+}
+
+function collectImportRewrite(
+  sourceFile: SourceFile,
+  stmt: ImportDeclaration,
+  specifiers: ReadonlySet<string>,
+  changes: StringChange[]
+): void {
+  if (!isTargetSpecifier(stmt.moduleSpecifier, specifiers)) {
+    return;
+  }
+  const namedBindings = stmt.importClause?.namedBindings;
+  // Only `import { ... }` carries renameable named bindings. `import x`,
+  // `import * as ns`, and side-effect imports reference the module wholesale
+  // and keep working through the `createNodesV2` runtime alias, so we leave
+  // them be. A mixed `import def, { createNodesV2 }` still has its named
+  // bindings rewritten below — the default binding is untouched.
+  if (!namedBindings || !ts!.isNamedImports(namedBindings)) {
+    return;
+  }
+  rewriteNamedBindings(sourceFile, namedBindings, changes);
+}
+
+function collectExportRewrite(
+  sourceFile: SourceFile,
+  stmt: ExportDeclaration,
+  specifiers: ReadonlySet<string>,
+  changes: StringChange[]
+): void {
+  if (
+    !stmt.moduleSpecifier ||
+    !isTargetSpecifier(stmt.moduleSpecifier, specifiers)
+  ) {
+    return;
+  }
+  // `export { ... } from '...'` can be rewritten; `export * from '...'` has no
+  // named bindings to rename.
+  if (!stmt.exportClause || !ts!.isNamedExports(stmt.exportClause)) {
+    return;
+  }
+  rewriteNamedBindings(sourceFile, stmt.exportClause, changes);
+}
+
+/**
+ * Re-renders the `{ ... }` of a named import/export, renaming any
+ * `createNodesV2` specifier to `createNodes`. If renaming would collide with a
+ * `createNodes` that is already present (e.g. `{ createNodes, createNodesV2 }`),
+ * the duplicate is dropped. Returns without recording a change when the binding
+ * list contains no `createNodesV2`.
+ */
+function rewriteNamedBindings(
+  sourceFile: SourceFile,
+  namedBindings: NamedImports | NamedExports,
+  changes: StringChange[]
+): void {
+  const elements = namedBindings.elements as readonly (
+    | ImportSpecifier
+    | ExportSpecifier
+  )[];
+  const hasDeprecated = elements.some(
+    (el) => (el.propertyName ?? el.name).text === DEPRECATED_NAME
+  );
+  if (!hasDeprecated) {
+    return;
+  }
+
+  const seen = new Set<string>();
+  const rendered: string[] = [];
+  for (const el of elements) {
+    const text = renderSpecifier(el);
+    if (!seen.has(text)) {
+      seen.add(text);
+      rendered.push(text);
+    }
+  }
+
+  const start = namedBindings.getStart(sourceFile);
+  changes.push(
+    {
+      type: ChangeType.Delete,
+      start,
+      length: namedBindings.getEnd() - start,
+    },
+    {
+      type: ChangeType.Insert,
+      index: start,
+      text: `{ ${rendered.join(', ')} }`,
+    }
+  );
+}
+
+function renderSpecifier(el: ImportSpecifier | ExportSpecifier): string {
+  const typePrefix = el.isTypeOnly ? 'type ' : '';
+  const rename = (name: string) =>
+    name === DEPRECATED_NAME ? CANONICAL_NAME : name;
+
+  // `{ name }` — no alias, so the local binding follows the rename.
+  if (!el.propertyName) {
+    return `${typePrefix}${rename(el.name.text)}`;
+  }
+
+  // `{ propertyName as name }` — only the imported (left) side is renamed; the
+  // local alias is preserved. A now-redundant alias such as
+  // `createNodesV2 as createNodes` collapses to `createNodes`.
+  const canonicalImported = rename(el.propertyName.text);
+  const localName = el.name.text;
+  return canonicalImported === localName
+    ? `${typePrefix}${localName}`
+    : `${typePrefix}${canonicalImported} as ${localName}`;
+}

--- a/packages/vitest/index.ts
+++ b/packages/vitest/index.ts
@@ -1,1 +1,5 @@
-export { createNodesV2, VitestPluginOptions } from './src/plugins/plugin';
+export {
+  createNodes,
+  createNodesV2,
+  VitestPluginOptions,
+} from './src/plugins/plugin';

--- a/packages/vitest/migrations.json
+++ b/packages/vitest/migrations.json
@@ -28,6 +28,12 @@
       "description": "Prefix reportsDirectory with {projectRoot} to maintain correct resolution after workspace-root-relative behavior change.",
       "implementation": "./dist/src/migrations/update-22-6-0/prefix-reports-directory-with-project-root",
       "documentation": "./dist/src/migrations/update-22-6-0/prefix-reports-directory-with-project-root.md"
+    },
+    "update-23-0-0-migrate-create-nodes-v2-import": {
+      "version": "23.0.0-beta.5",
+      "description": "Rename imports of `createNodesV2` from `@nx/vitest` to the canonical `createNodes` export.",
+      "implementation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
+      "documentation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"
     }
   },
   "packageJsonUpdates": {

--- a/packages/vitest/migrations.json
+++ b/packages/vitest/migrations.json
@@ -30,7 +30,7 @@
       "documentation": "./dist/src/migrations/update-22-6-0/prefix-reports-directory-with-project-root.md"
     },
     "update-23-0-0-migrate-create-nodes-v2-import": {
-      "version": "23.0.0-beta.5",
+      "version": "23.0.0-beta.24",
       "description": "Rename imports of `createNodesV2` from `@nx/vitest` to the canonical `createNodes` export.",
       "implementation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
       "documentation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"

--- a/packages/vitest/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md
+++ b/packages/vitest/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md
@@ -1,0 +1,25 @@
+#### Rename `createNodesV2` imports to `createNodes`
+
+`@nx/vitest` renamed its primary inferred-plugin export from `createNodesV2` to `createNodes`. The `createNodesV2` name is preserved as a deprecated alias for now, but new code should use `createNodes`.
+
+This migration scans every `.ts`, `.tsx`, `.cts`, and `.mts` file in your workspace and rewrites named imports and re-exports of `createNodesV2` from `@nx/vitestst` to `createNodes`.
+
+#### Sample Code Changes
+
+##### Before
+
+```ts
+import { createNodesV2 } from '@nx/vitestst';
+```
+
+##### After
+
+```ts
+import { createNodes } from '@nx/vitestst';
+```
+
+Aliases are preserved (`createNodesV2 as cn` becomes `createNodes as cn`), and if a file already imports both names (`{ createNodes, createNodesV2 }`) the redundant binding is dropped.
+
+#### What is not rewritten
+
+Only static `import`/`export` named bindings from `@nx/vitestst` are rewritten. Namespace imports, dynamic `import(...)`, `require(...)` destructuring, and property access such as `plugin.createNodesV2` are left untouched — they keep working through the `createNodesV2` runtime alias. Update those by hand if you want to drop the deprecated name everywhere.

--- a/packages/vitest/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.spec.ts
+++ b/packages/vitest/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.spec.ts
@@ -1,0 +1,191 @@
+import { type Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migration, {
+  rewriteCreateNodesV2Imports,
+} from './migrate-create-nodes-v2-to-create-nodes';
+
+const SPECIFIERS = new Set(['@nx/vitest']);
+const rewrite = (source: string) =>
+  rewriteCreateNodesV2Imports(source, SPECIFIERS);
+
+describe('migrate-create-nodes-v2-to-create-nodes migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  describe('rewriteCreateNodesV2Imports', () => {
+    it('renames a lone createNodesV2 named import', () => {
+      const input = `import { createNodesV2 } from '@nx/vitest';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/vitest';\n`
+      );
+    });
+
+    it('preserves other named imports while renaming createNodesV2', () => {
+      const input = `import { createNodesV2, SomeOtherExport } from '@nx/vitest';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes, SomeOtherExport } from '@nx/vitest';\n`
+      );
+    });
+
+    it('rewrites the original name in `as` aliases', () => {
+      const input = `import { createNodesV2 as cn } from '@nx/vitest';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes as cn } from '@nx/vitest';\n`
+      );
+    });
+
+    it('collapses a redundant `createNodesV2 as createNodes` alias', () => {
+      const input = `import { createNodesV2 as createNodes } from '@nx/vitest';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/vitest';\n`
+      );
+    });
+
+    it('dedupes when both createNodes and createNodesV2 are imported', () => {
+      const input = `import { createNodes, createNodesV2 } from '@nx/vitest';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/vitest';\n`
+      );
+    });
+
+    it('dedupes when createNodesV2 precedes createNodes', () => {
+      const input = `import { createNodesV2, createNodes } from '@nx/vitest';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/vitest';\n`
+      );
+    });
+
+    it('handles multi-line named imports', () => {
+      const input = `import {\n  createNodes,\n  createNodesV2,\n  SomeOtherExport,\n} from '@nx/vitest';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes, SomeOtherExport } from '@nx/vitest';\n`
+      );
+    });
+
+    it('preserves a default import alongside the renamed binding', () => {
+      const input = `import def, { createNodesV2 } from '@nx/vitest';\n`;
+      expect(rewrite(input)).toBe(
+        `import def, { createNodes } from '@nx/vitest';\n`
+      );
+    });
+
+    it('handles `import type` declarations', () => {
+      const input = `import type { createNodesV2 } from '@nx/vitest';\n`;
+      expect(rewrite(input)).toBe(
+        `import type { createNodes } from '@nx/vitest';\n`
+      );
+    });
+
+    it('preserves inline `type` modifiers', () => {
+      const input = `import { type createNodesV2 } from '@nx/vitest';\n`;
+      expect(rewrite(input)).toBe(
+        `import { type createNodes } from '@nx/vitest';\n`
+      );
+    });
+
+    it('rewrites named re-exports', () => {
+      const input = `export { createNodesV2 } from '@nx/vitest';\n`;
+      expect(rewrite(input)).toBe(
+        `export { createNodes } from '@nx/vitest';\n`
+      );
+    });
+
+    it('rewrites aliased named re-exports', () => {
+      const input = `export { createNodesV2 as cn } from '@nx/vitest';\n`;
+      expect(rewrite(input)).toBe(
+        `export { createNodes as cn } from '@nx/vitest';\n`
+      );
+    });
+
+    it('does not touch createNodesV2 from a different specifier', () => {
+      const input = `import { createNodesV2 } from '@nx/other-plugin/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not touch createNodesV2 from a relative specifier', () => {
+      const input = `import { createNodesV2 } from './plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not touch unrelated imports from the target specifier', () => {
+      const input = `import { createNodes } from '@nx/vitest';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not rewrite `export * from` declarations', () => {
+      const input = `export * from '@nx/vitest';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('leaves createNodesV2 in strings and comments alone', () => {
+      const input =
+        `// import { createNodesV2 } from '@nx/vitest';\n` +
+        `const s = "createNodesV2";\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not rewrite require() destructuring (still valid via alias)', () => {
+      const input = `const { createNodesV2 } = require('@nx/vitest');\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+  });
+
+  describe('migration runner', () => {
+    it('rewrites imports across .ts/.tsx/.cts/.mts files', async () => {
+      tree.write(
+        'libs/foo/src/a.ts',
+        `import { createNodesV2 } from '@nx/vitest';\n`
+      );
+      tree.write(
+        'libs/foo/src/b.tsx',
+        `import { createNodesV2 as cn } from '@nx/vitest';\n`
+      );
+      tree.write(
+        'libs/foo/src/c.cts',
+        `export { createNodesV2 } from '@nx/vitest';\n`
+      );
+      tree.write(
+        'libs/foo/src/d.mts',
+        `import { createNodesV2, SomeOtherExport } from '@nx/vitest';\n`
+      );
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/a.ts', 'utf-8')).toContain(
+        `import { createNodes } from '@nx/vitest';`
+      );
+      expect(tree.read('libs/foo/src/b.tsx', 'utf-8')).toContain(
+        `import { createNodes as cn } from '@nx/vitest';`
+      );
+      expect(tree.read('libs/foo/src/c.cts', 'utf-8')).toContain(
+        `export { createNodes } from '@nx/vitest';`
+      );
+      expect(tree.read('libs/foo/src/d.mts', 'utf-8')).toContain(
+        `import { createNodes, SomeOtherExport } from '@nx/vitest';`
+      );
+    });
+
+    it('does not touch files without the deprecated name', async () => {
+      const content = `import { createNodes } from '@nx/vitest';\n`;
+      tree.write('libs/foo/src/index.ts', content);
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/index.ts', 'utf-8')).toBe(content);
+    });
+
+    it('does not rewrite non-TS files', async () => {
+      const md = `Example: \`import { createNodesV2 } from '@nx/vitest';\`\n`;
+      tree.write('docs/example.md', md);
+
+      await migration(tree);
+
+      expect(tree.read('docs/example.md', 'utf-8')).toContain(
+        `import { createNodesV2 } from '@nx/vitest';`
+      );
+    });
+  });
+});

--- a/packages/vitest/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.ts
+++ b/packages/vitest/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.ts
@@ -1,0 +1,206 @@
+import {
+  applyChangesToString,
+  ChangeType,
+  ensurePackage,
+  formatFiles,
+  logger,
+  type StringChange,
+  type Tree,
+  visitNotIgnoredFiles,
+} from '@nx/devkit';
+import type {
+  ExportDeclaration,
+  ExportSpecifier,
+  ImportDeclaration,
+  ImportSpecifier,
+  NamedExports,
+  NamedImports,
+  SourceFile,
+} from 'typescript';
+
+const TS_EXTENSIONS = ['.ts', '.tsx', '.cts', '.mts'] as const;
+const DEPRECATED_NAME = 'createNodesV2';
+const CANONICAL_NAME = 'createNodes';
+
+// Module specifiers from which `@nx/vitest` publicly exposes `createNodesV2`.
+// A named import or re-export of `createNodesV2` from one of these is rewritten
+// to the canonical `createNodes` export.
+const TARGET_SPECIFIERS: ReadonlySet<string> = new Set(['@nx/vitest']);
+
+let ts: typeof import('typescript') | undefined;
+
+export default async function migrateCreateNodesV2ToCreateNodes(
+  tree: Tree
+): Promise<void> {
+  let touchedCount = 0;
+
+  visitNotIgnoredFiles(tree, '.', (filePath) => {
+    if (!TS_EXTENSIONS.some((ext) => filePath.endsWith(ext))) {
+      return;
+    }
+    const original = tree.read(filePath, 'utf-8');
+    if (!original || !original.includes(DEPRECATED_NAME)) {
+      return;
+    }
+    const updated = rewriteCreateNodesV2Imports(original, TARGET_SPECIFIERS);
+    if (updated !== original) {
+      tree.write(filePath, updated);
+      touchedCount += 1;
+    }
+  });
+
+  if (touchedCount > 0) {
+    logger.info(
+      `Renamed \`${DEPRECATED_NAME}\` imports to \`${CANONICAL_NAME}\` in ${touchedCount} file(s).`
+    );
+  }
+
+  await formatFiles(tree);
+}
+
+/**
+ * Rewrites named imports and re-exports of `createNodesV2` to `createNodes`
+ * when they come from one of the given module specifiers. Only the named
+ * bindings are touched — the module specifier, the `import`/`export` keyword,
+ * any `type` modifier, and any default import are left untouched.
+ */
+export function rewriteCreateNodesV2Imports(
+  source: string,
+  specifiers: ReadonlySet<string>
+): string {
+  ts ??= ensurePackage<typeof import('typescript')>('typescript', '*');
+  const sourceFile = ts.createSourceFile(
+    'tmp.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TSX
+  );
+
+  const changes: StringChange[] = [];
+  for (const stmt of sourceFile.statements) {
+    if (ts.isImportDeclaration(stmt)) {
+      collectImportRewrite(sourceFile, stmt, specifiers, changes);
+    } else if (ts.isExportDeclaration(stmt)) {
+      collectExportRewrite(sourceFile, stmt, specifiers, changes);
+    }
+  }
+
+  return changes.length > 0 ? applyChangesToString(source, changes) : source;
+}
+
+function isTargetSpecifier(
+  node: ImportDeclaration['moduleSpecifier'],
+  specifiers: ReadonlySet<string>
+): boolean {
+  return ts!.isStringLiteral(node) && specifiers.has(node.text);
+}
+
+function collectImportRewrite(
+  sourceFile: SourceFile,
+  stmt: ImportDeclaration,
+  specifiers: ReadonlySet<string>,
+  changes: StringChange[]
+): void {
+  if (!isTargetSpecifier(stmt.moduleSpecifier, specifiers)) {
+    return;
+  }
+  const namedBindings = stmt.importClause?.namedBindings;
+  // Only `import { ... }` carries renameable named bindings. `import x`,
+  // `import * as ns`, and side-effect imports reference the module wholesale
+  // and keep working through the `createNodesV2` runtime alias, so we leave
+  // them be. A mixed `import def, { createNodesV2 }` still has its named
+  // bindings rewritten below — the default binding is untouched.
+  if (!namedBindings || !ts!.isNamedImports(namedBindings)) {
+    return;
+  }
+  rewriteNamedBindings(sourceFile, namedBindings, changes);
+}
+
+function collectExportRewrite(
+  sourceFile: SourceFile,
+  stmt: ExportDeclaration,
+  specifiers: ReadonlySet<string>,
+  changes: StringChange[]
+): void {
+  if (
+    !stmt.moduleSpecifier ||
+    !isTargetSpecifier(stmt.moduleSpecifier, specifiers)
+  ) {
+    return;
+  }
+  // `export { ... } from '...'` can be rewritten; `export * from '...'` has no
+  // named bindings to rename.
+  if (!stmt.exportClause || !ts!.isNamedExports(stmt.exportClause)) {
+    return;
+  }
+  rewriteNamedBindings(sourceFile, stmt.exportClause, changes);
+}
+
+/**
+ * Re-renders the `{ ... }` of a named import/export, renaming any
+ * `createNodesV2` specifier to `createNodes`. If renaming would collide with a
+ * `createNodes` that is already present (e.g. `{ createNodes, createNodesV2 }`),
+ * the duplicate is dropped. Returns without recording a change when the binding
+ * list contains no `createNodesV2`.
+ */
+function rewriteNamedBindings(
+  sourceFile: SourceFile,
+  namedBindings: NamedImports | NamedExports,
+  changes: StringChange[]
+): void {
+  const elements = namedBindings.elements as readonly (
+    | ImportSpecifier
+    | ExportSpecifier
+  )[];
+  const hasDeprecated = elements.some(
+    (el) => (el.propertyName ?? el.name).text === DEPRECATED_NAME
+  );
+  if (!hasDeprecated) {
+    return;
+  }
+
+  const seen = new Set<string>();
+  const rendered: string[] = [];
+  for (const el of elements) {
+    const text = renderSpecifier(el);
+    if (!seen.has(text)) {
+      seen.add(text);
+      rendered.push(text);
+    }
+  }
+
+  const start = namedBindings.getStart(sourceFile);
+  changes.push(
+    {
+      type: ChangeType.Delete,
+      start,
+      length: namedBindings.getEnd() - start,
+    },
+    {
+      type: ChangeType.Insert,
+      index: start,
+      text: `{ ${rendered.join(', ')} }`,
+    }
+  );
+}
+
+function renderSpecifier(el: ImportSpecifier | ExportSpecifier): string {
+  const typePrefix = el.isTypeOnly ? 'type ' : '';
+  const rename = (name: string) =>
+    name === DEPRECATED_NAME ? CANONICAL_NAME : name;
+
+  // `{ name }` — no alias, so the local binding follows the rename.
+  if (!el.propertyName) {
+    return `${typePrefix}${rename(el.name.text)}`;
+  }
+
+  // `{ propertyName as name }` — only the imported (left) side is renamed; the
+  // local alias is preserved. A now-redundant alias such as
+  // `createNodesV2 as createNodes` collapses to `createNodes`.
+  const canonicalImported = rename(el.propertyName.text);
+  const localName = el.name.text;
+  return canonicalImported === localName
+    ? `${typePrefix}${localName}`
+    : `${typePrefix}${canonicalImported} as ${localName}`;
+}

--- a/packages/webpack/migrations.json
+++ b/packages/webpack/migrations.json
@@ -24,6 +24,12 @@
       "version": "23.0.0-beta.25",
       "description": "Rewrites `@nx/webpack/src/*` subpath imports now that the `./src/*` subpath is no longer exposed by `@nx/webpack`'s exports map. Named imports/exports of public symbols are routed to `@nx/webpack` and the rest to the new `@nx/webpack/internal` entry; `require`, dynamic `import` and `jest.mock` calls reference the whole module and are routed to `@nx/webpack/internal`.",
       "implementation": "./dist/src/migrations/update-23-0-0/rewrite-internal-subpath-imports"
+    },
+    "update-23-0-0-migrate-create-nodes-v2-import": {
+      "version": "23.0.0-beta.5",
+      "description": "Rename imports of `createNodesV2` from `@nx/webpack/plugin` to the canonical `createNodes` export.",
+      "implementation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
+      "documentation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"
     }
   },
   "packageJsonUpdates": {

--- a/packages/webpack/migrations.json
+++ b/packages/webpack/migrations.json
@@ -26,7 +26,7 @@
       "implementation": "./dist/src/migrations/update-23-0-0/rewrite-internal-subpath-imports"
     },
     "update-23-0-0-migrate-create-nodes-v2-import": {
-      "version": "23.0.0-beta.5",
+      "version": "23.0.0-beta.24",
       "description": "Rename imports of `createNodesV2` from `@nx/webpack/plugin` to the canonical `createNodes` export.",
       "implementation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
       "documentation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"

--- a/packages/webpack/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md
+++ b/packages/webpack/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md
@@ -1,0 +1,25 @@
+#### Rename `createNodesV2` imports to `createNodes`
+
+`@nx/webpack` renamed its primary inferred-plugin export from `createNodesV2` to `createNodes`. The `createNodesV2` name is preserved as a deprecated alias for now, but new code should use `createNodes`.
+
+This migration scans every `.ts`, `.tsx`, `.cts`, and `.mts` file in your workspace and rewrites named imports and re-exports of `createNodesV2` from `@nx/webpack/plugin` to `createNodes`.
+
+#### Sample Code Changes
+
+##### Before
+
+```ts
+import { createNodesV2 } from '@nx/webpack/plugin';
+```
+
+##### After
+
+```ts
+import { createNodes } from '@nx/webpack/plugin';
+```
+
+Aliases are preserved (`createNodesV2 as cn` becomes `createNodes as cn`), and if a file already imports both names (`{ createNodes, createNodesV2 }`) the redundant binding is dropped.
+
+#### What is not rewritten
+
+Only static `import`/`export` named bindings from `@nx/webpack/plugin` are rewritten. Namespace imports, dynamic `import(...)`, `require(...)` destructuring, and property access such as `plugin.createNodesV2` are left untouched — they keep working through the `createNodesV2` runtime alias. Update those by hand if you want to drop the deprecated name everywhere.

--- a/packages/webpack/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.spec.ts
+++ b/packages/webpack/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.spec.ts
@@ -1,0 +1,191 @@
+import { type Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migration, {
+  rewriteCreateNodesV2Imports,
+} from './migrate-create-nodes-v2-to-create-nodes';
+
+const SPECIFIERS = new Set(['@nx/webpack/plugin']);
+const rewrite = (source: string) =>
+  rewriteCreateNodesV2Imports(source, SPECIFIERS);
+
+describe('migrate-create-nodes-v2-to-create-nodes migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  describe('rewriteCreateNodesV2Imports', () => {
+    it('renames a lone createNodesV2 named import', () => {
+      const input = `import { createNodesV2 } from '@nx/webpack/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/webpack/plugin';\n`
+      );
+    });
+
+    it('preserves other named imports while renaming createNodesV2', () => {
+      const input = `import { createNodesV2, SomeOtherExport } from '@nx/webpack/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes, SomeOtherExport } from '@nx/webpack/plugin';\n`
+      );
+    });
+
+    it('rewrites the original name in `as` aliases', () => {
+      const input = `import { createNodesV2 as cn } from '@nx/webpack/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes as cn } from '@nx/webpack/plugin';\n`
+      );
+    });
+
+    it('collapses a redundant `createNodesV2 as createNodes` alias', () => {
+      const input = `import { createNodesV2 as createNodes } from '@nx/webpack/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/webpack/plugin';\n`
+      );
+    });
+
+    it('dedupes when both createNodes and createNodesV2 are imported', () => {
+      const input = `import { createNodes, createNodesV2 } from '@nx/webpack/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/webpack/plugin';\n`
+      );
+    });
+
+    it('dedupes when createNodesV2 precedes createNodes', () => {
+      const input = `import { createNodesV2, createNodes } from '@nx/webpack/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/webpack/plugin';\n`
+      );
+    });
+
+    it('handles multi-line named imports', () => {
+      const input = `import {\n  createNodes,\n  createNodesV2,\n  SomeOtherExport,\n} from '@nx/webpack/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes, SomeOtherExport } from '@nx/webpack/plugin';\n`
+      );
+    });
+
+    it('preserves a default import alongside the renamed binding', () => {
+      const input = `import def, { createNodesV2 } from '@nx/webpack/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import def, { createNodes } from '@nx/webpack/plugin';\n`
+      );
+    });
+
+    it('handles `import type` declarations', () => {
+      const input = `import type { createNodesV2 } from '@nx/webpack/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import type { createNodes } from '@nx/webpack/plugin';\n`
+      );
+    });
+
+    it('preserves inline `type` modifiers', () => {
+      const input = `import { type createNodesV2 } from '@nx/webpack/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `import { type createNodes } from '@nx/webpack/plugin';\n`
+      );
+    });
+
+    it('rewrites named re-exports', () => {
+      const input = `export { createNodesV2 } from '@nx/webpack/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `export { createNodes } from '@nx/webpack/plugin';\n`
+      );
+    });
+
+    it('rewrites aliased named re-exports', () => {
+      const input = `export { createNodesV2 as cn } from '@nx/webpack/plugin';\n`;
+      expect(rewrite(input)).toBe(
+        `export { createNodes as cn } from '@nx/webpack/plugin';\n`
+      );
+    });
+
+    it('does not touch createNodesV2 from a different specifier', () => {
+      const input = `import { createNodesV2 } from '@nx/other-plugin/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not touch createNodesV2 from a relative specifier', () => {
+      const input = `import { createNodesV2 } from './plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not touch unrelated imports from the target specifier', () => {
+      const input = `import { createNodes } from '@nx/webpack/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not rewrite `export * from` declarations', () => {
+      const input = `export * from '@nx/webpack/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('leaves createNodesV2 in strings and comments alone', () => {
+      const input =
+        `// import { createNodesV2 } from '@nx/webpack/plugin';\n` +
+        `const s = "createNodesV2";\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not rewrite require() destructuring (still valid via alias)', () => {
+      const input = `const { createNodesV2 } = require('@nx/webpack/plugin');\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+  });
+
+  describe('migration runner', () => {
+    it('rewrites imports across .ts/.tsx/.cts/.mts files', async () => {
+      tree.write(
+        'libs/foo/src/a.ts',
+        `import { createNodesV2 } from '@nx/webpack/plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/b.tsx',
+        `import { createNodesV2 as cn } from '@nx/webpack/plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/c.cts',
+        `export { createNodesV2 } from '@nx/webpack/plugin';\n`
+      );
+      tree.write(
+        'libs/foo/src/d.mts',
+        `import { createNodesV2, SomeOtherExport } from '@nx/webpack/plugin';\n`
+      );
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/a.ts', 'utf-8')).toContain(
+        `import { createNodes } from '@nx/webpack/plugin';`
+      );
+      expect(tree.read('libs/foo/src/b.tsx', 'utf-8')).toContain(
+        `import { createNodes as cn } from '@nx/webpack/plugin';`
+      );
+      expect(tree.read('libs/foo/src/c.cts', 'utf-8')).toContain(
+        `export { createNodes } from '@nx/webpack/plugin';`
+      );
+      expect(tree.read('libs/foo/src/d.mts', 'utf-8')).toContain(
+        `import { createNodes, SomeOtherExport } from '@nx/webpack/plugin';`
+      );
+    });
+
+    it('does not touch files without the deprecated name', async () => {
+      const content = `import { createNodes } from '@nx/webpack/plugin';\n`;
+      tree.write('libs/foo/src/index.ts', content);
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/index.ts', 'utf-8')).toBe(content);
+    });
+
+    it('does not rewrite non-TS files', async () => {
+      const md = `Example: \`import { createNodesV2 } from '@nx/webpack/plugin';\`\n`;
+      tree.write('docs/example.md', md);
+
+      await migration(tree);
+
+      expect(tree.read('docs/example.md', 'utf-8')).toContain(
+        `import { createNodesV2 } from '@nx/webpack/plugin';`
+      );
+    });
+  });
+});

--- a/packages/webpack/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.ts
+++ b/packages/webpack/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.ts
@@ -1,0 +1,206 @@
+import {
+  applyChangesToString,
+  ChangeType,
+  ensurePackage,
+  formatFiles,
+  logger,
+  type StringChange,
+  type Tree,
+  visitNotIgnoredFiles,
+} from '@nx/devkit';
+import type {
+  ExportDeclaration,
+  ExportSpecifier,
+  ImportDeclaration,
+  ImportSpecifier,
+  NamedExports,
+  NamedImports,
+  SourceFile,
+} from 'typescript';
+
+const TS_EXTENSIONS = ['.ts', '.tsx', '.cts', '.mts'] as const;
+const DEPRECATED_NAME = 'createNodesV2';
+const CANONICAL_NAME = 'createNodes';
+
+// Module specifiers from which `@nx/webpack` publicly exposes `createNodesV2`.
+// A named import or re-export of `createNodesV2` from one of these is rewritten
+// to the canonical `createNodes` export.
+const TARGET_SPECIFIERS: ReadonlySet<string> = new Set(['@nx/webpack/plugin']);
+
+let ts: typeof import('typescript') | undefined;
+
+export default async function migrateCreateNodesV2ToCreateNodes(
+  tree: Tree
+): Promise<void> {
+  let touchedCount = 0;
+
+  visitNotIgnoredFiles(tree, '.', (filePath) => {
+    if (!TS_EXTENSIONS.some((ext) => filePath.endsWith(ext))) {
+      return;
+    }
+    const original = tree.read(filePath, 'utf-8');
+    if (!original || !original.includes(DEPRECATED_NAME)) {
+      return;
+    }
+    const updated = rewriteCreateNodesV2Imports(original, TARGET_SPECIFIERS);
+    if (updated !== original) {
+      tree.write(filePath, updated);
+      touchedCount += 1;
+    }
+  });
+
+  if (touchedCount > 0) {
+    logger.info(
+      `Renamed \`${DEPRECATED_NAME}\` imports to \`${CANONICAL_NAME}\` in ${touchedCount} file(s).`
+    );
+  }
+
+  await formatFiles(tree);
+}
+
+/**
+ * Rewrites named imports and re-exports of `createNodesV2` to `createNodes`
+ * when they come from one of the given module specifiers. Only the named
+ * bindings are touched — the module specifier, the `import`/`export` keyword,
+ * any `type` modifier, and any default import are left untouched.
+ */
+export function rewriteCreateNodesV2Imports(
+  source: string,
+  specifiers: ReadonlySet<string>
+): string {
+  ts ??= ensurePackage<typeof import('typescript')>('typescript', '*');
+  const sourceFile = ts.createSourceFile(
+    'tmp.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TSX
+  );
+
+  const changes: StringChange[] = [];
+  for (const stmt of sourceFile.statements) {
+    if (ts.isImportDeclaration(stmt)) {
+      collectImportRewrite(sourceFile, stmt, specifiers, changes);
+    } else if (ts.isExportDeclaration(stmt)) {
+      collectExportRewrite(sourceFile, stmt, specifiers, changes);
+    }
+  }
+
+  return changes.length > 0 ? applyChangesToString(source, changes) : source;
+}
+
+function isTargetSpecifier(
+  node: ImportDeclaration['moduleSpecifier'],
+  specifiers: ReadonlySet<string>
+): boolean {
+  return ts!.isStringLiteral(node) && specifiers.has(node.text);
+}
+
+function collectImportRewrite(
+  sourceFile: SourceFile,
+  stmt: ImportDeclaration,
+  specifiers: ReadonlySet<string>,
+  changes: StringChange[]
+): void {
+  if (!isTargetSpecifier(stmt.moduleSpecifier, specifiers)) {
+    return;
+  }
+  const namedBindings = stmt.importClause?.namedBindings;
+  // Only `import { ... }` carries renameable named bindings. `import x`,
+  // `import * as ns`, and side-effect imports reference the module wholesale
+  // and keep working through the `createNodesV2` runtime alias, so we leave
+  // them be. A mixed `import def, { createNodesV2 }` still has its named
+  // bindings rewritten below — the default binding is untouched.
+  if (!namedBindings || !ts!.isNamedImports(namedBindings)) {
+    return;
+  }
+  rewriteNamedBindings(sourceFile, namedBindings, changes);
+}
+
+function collectExportRewrite(
+  sourceFile: SourceFile,
+  stmt: ExportDeclaration,
+  specifiers: ReadonlySet<string>,
+  changes: StringChange[]
+): void {
+  if (
+    !stmt.moduleSpecifier ||
+    !isTargetSpecifier(stmt.moduleSpecifier, specifiers)
+  ) {
+    return;
+  }
+  // `export { ... } from '...'` can be rewritten; `export * from '...'` has no
+  // named bindings to rename.
+  if (!stmt.exportClause || !ts!.isNamedExports(stmt.exportClause)) {
+    return;
+  }
+  rewriteNamedBindings(sourceFile, stmt.exportClause, changes);
+}
+
+/**
+ * Re-renders the `{ ... }` of a named import/export, renaming any
+ * `createNodesV2` specifier to `createNodes`. If renaming would collide with a
+ * `createNodes` that is already present (e.g. `{ createNodes, createNodesV2 }`),
+ * the duplicate is dropped. Returns without recording a change when the binding
+ * list contains no `createNodesV2`.
+ */
+function rewriteNamedBindings(
+  sourceFile: SourceFile,
+  namedBindings: NamedImports | NamedExports,
+  changes: StringChange[]
+): void {
+  const elements = namedBindings.elements as readonly (
+    | ImportSpecifier
+    | ExportSpecifier
+  )[];
+  const hasDeprecated = elements.some(
+    (el) => (el.propertyName ?? el.name).text === DEPRECATED_NAME
+  );
+  if (!hasDeprecated) {
+    return;
+  }
+
+  const seen = new Set<string>();
+  const rendered: string[] = [];
+  for (const el of elements) {
+    const text = renderSpecifier(el);
+    if (!seen.has(text)) {
+      seen.add(text);
+      rendered.push(text);
+    }
+  }
+
+  const start = namedBindings.getStart(sourceFile);
+  changes.push(
+    {
+      type: ChangeType.Delete,
+      start,
+      length: namedBindings.getEnd() - start,
+    },
+    {
+      type: ChangeType.Insert,
+      index: start,
+      text: `{ ${rendered.join(', ')} }`,
+    }
+  );
+}
+
+function renderSpecifier(el: ImportSpecifier | ExportSpecifier): string {
+  const typePrefix = el.isTypeOnly ? 'type ' : '';
+  const rename = (name: string) =>
+    name === DEPRECATED_NAME ? CANONICAL_NAME : name;
+
+  // `{ name }` — no alias, so the local binding follows the rename.
+  if (!el.propertyName) {
+    return `${typePrefix}${rename(el.name.text)}`;
+  }
+
+  // `{ propertyName as name }` — only the imported (left) side is renamed; the
+  // local alias is preserved. A now-redundant alias such as
+  // `createNodesV2 as createNodes` collapses to `createNodes`.
+  const canonicalImported = rename(el.propertyName.text);
+  const localName = el.name.text;
+  return canonicalImported === localName
+    ? `${typePrefix}${localName}`
+    : `${typePrefix}${canonicalImported} as ${localName}`;
+}


### PR DESCRIPTION
## Current Behavior

#35386 renamed the canonical plugin API to drop the `V2` suffix — both the exported `createNodesV2` **value** in first-party plugins (now `createNodes`) and the `*V2` **types** in `@nx/devkit` (`CreateNodesV2`, `CreateNodesContextV2`, `CreateNodesResultV2`, `CreateNodesFunctionV2`, `NxPluginV2`). The old names are kept as deprecated aliases, so existing code keeps compiling — but there is no migration to move workspaces onto the canonical names, and `@nx/angular/plugin` / `@nx/vitest` only re-exported `createNodesV2` from their public entry points (the rename was incomplete there).

## Expected Behavior

- **Per-plugin value migration** (`migrate-create-nodes-v2-to-create-nodes`): every first-party plugin that publicly exposes `createNodesV2` ships a migration that rewrites named imports/re-exports of `createNodesV2` from that plugin's public specifier(s) to `createNodes` (22 plugins, incl. `@nx/gradle` + `@nx/gradle/plugin-v1`, `@nx/js/typescript`, `@nx/react/router-plugin`).
- **devkit type migration** (`rename-create-nodes-v2-types`): rewrites imports/re-exports of the deprecated `*V2` types from `@nx/devkit` to their canonical names (`CreateNodesResultV2` → `CreateNodesResultArray`; the unrelated `CreateNodesResult` is left alone).
- `@nx/angular/plugin` and `@nx/vitest` now also re-export `createNodes`, completing the rename so the migration targets resolve.

All migrations are AST-based, modeled on devkit's `update-deep-imports`: they handle `as` aliases, dedupe when both names are already imported, preserve `type` modifiers and default imports, and leave strings/comments, dynamic `import`/`require`, and unrelated specifiers untouched. Each has unit + tree-runner specs and a `.md` doc, registered at `23.0.0-beta.5`.

## Related Issue(s)

Follow-up to #35386. No issue to close.
