### PR TITLE
fix(dotnet)!: graduate @nx/dotnet — drop experimental banner and the /plugin export

### DIFF
--- a/astro-docs/src/content/docs/technologies/dotnet/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/dotnet/introduction.mdoc
@@ -7,10 +7,6 @@ weight: 2
 filter: 'type:References'
 ---
 
-{% aside type="caution" title="Experimental Plugin" %}
-The `@nx/dotnet` plugin is currently experimental. Features and APIs may change.
-{% /aside %}
-
 [.NET](https://dotnet.microsoft.com/) is a free, cross-platform, open-source developer platform for building many different types of applications. With .NET, you can use multiple languages, editors, and libraries to build for web, mobile, desktop, games, IoT, and more.
 
 The Nx plugin for .NET registers .NET projects in your Nx workspace. It allows MSBuild tasks to be run through Nx. Nx effortlessly makes your [CI faster](/docs/guides/nx-cloud/setup-ci).

--- a/packages/dotnet/migrations.json
+++ b/packages/dotnet/migrations.json
@@ -1,4 +1,11 @@
 {
-  "generators": {},
+  "generators": {
+    "update-23-0-0-migrate-dotnet-plugin-path": {
+      "cli": "nx",
+      "version": "23.0.0-beta.23",
+      "description": "Update `nx.json` plugin registrations that use the removed `@nx/dotnet/plugin` subpath to the bare `@nx/dotnet` specifier.",
+      "implementation": "./dist/migrations/update-23-0-0/update-plugin-path"
+    }
+  },
   "packageJsonUpdates": {}
 }

--- a/packages/dotnet/migrations.json
+++ b/packages/dotnet/migrations.json
@@ -2,7 +2,7 @@
   "generators": {
     "update-23-0-0-migrate-dotnet-plugin-path": {
       "cli": "nx",
-      "version": "23.0.0-beta.23",
+      "version": "23.0.0-beta.24",
       "description": "Update `nx.json` plugin registrations that use the removed `@nx/dotnet/plugin` subpath to the bare `@nx/dotnet` specifier.",
       "implementation": "./dist/migrations/update-23-0-0/update-plugin-path"
     }

--- a/packages/dotnet/package.json
+++ b/packages/dotnet/package.json
@@ -29,10 +29,6 @@
       "default": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
-    "./plugin": {
-      "default": "./dist/plugin.js",
-      "types": "./dist/plugin.d.ts"
-    },
     "./generators/*/schema.json": "./dist/generators/*/schema.json",
     "./generators/*/schema": "./dist/generators/*/schema.d.ts",
     "./generators.json": "./generators.json",

--- a/packages/dotnet/readme-template.md
+++ b/packages/dotnet/readme-template.md
@@ -9,8 +9,6 @@
 
 <hr>
 
-> Note: The `@nx/dotnet` plugin is currently experimental. Features and APIs may change.
-
 # Nx: Smart Monorepos · Fast Builds
 
 Get to green PRs in half the time. Nx optimizes your builds, scales your CI, and fixes failed PRs. Built for developers and AI agents.

--- a/packages/dotnet/src/index.ts
+++ b/packages/dotnet/src/index.ts
@@ -1,3 +1,7 @@
-export * from './plugin';
+export {
+  createNodes,
+  createNodesV2,
+  createDependencies,
+} from './plugins/plugin';
 
 export { DotNetPluginOptions } from './plugins/create-nodes';

--- a/packages/dotnet/src/migrations/update-23-0-0/update-plugin-path.spec.ts
+++ b/packages/dotnet/src/migrations/update-23-0-0/update-plugin-path.spec.ts
@@ -49,18 +49,7 @@ describe('update-plugin-path migration', () => {
     ]);
   });
 
-  it('should not create a duplicate when both the old and new paths are registered', () => {
-    tree.write(
-      'nx.json',
-      JSON.stringify({
-        plugins: ['@nx/dotnet', '@nx/dotnet/plugin'],
-      })
-    );
-    update(tree);
-    expect(readNxJson(tree)?.plugins).toEqual(['@nx/dotnet']);
-  });
-
-  it('should leave other plugins untouched', () => {
+  it('should update the entry in place, preserving the position of other plugins', () => {
     tree.write(
       'nx.json',
       JSON.stringify({

--- a/packages/dotnet/src/migrations/update-23-0-0/update-plugin-path.spec.ts
+++ b/packages/dotnet/src/migrations/update-23-0-0/update-plugin-path.spec.ts
@@ -1,0 +1,77 @@
+import { readNxJson, Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import update from './update-plugin-path';
+
+describe('update-plugin-path migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('should do nothing when there are no plugins', () => {
+    tree.write('nx.json', JSON.stringify({ namedInputs: {} }));
+    update(tree);
+    expect(readNxJson(tree)).toMatchInlineSnapshot(`
+      {
+        "namedInputs": {},
+      }
+    `);
+  });
+
+  it('should leave the bare @nx/dotnet plugin untouched', () => {
+    tree.write('nx.json', JSON.stringify({ plugins: ['@nx/dotnet'] }));
+    update(tree);
+    expect(readNxJson(tree)?.plugins).toEqual(['@nx/dotnet']);
+  });
+
+  it('should rewrite the string @nx/dotnet/plugin entry to @nx/dotnet', () => {
+    tree.write('nx.json', JSON.stringify({ plugins: ['@nx/dotnet/plugin'] }));
+    update(tree);
+    expect(readNxJson(tree)?.plugins).toEqual(['@nx/dotnet']);
+  });
+
+  it('should rewrite the object @nx/dotnet/plugin entry while preserving options', () => {
+    tree.write(
+      'nx.json',
+      JSON.stringify({
+        plugins: [
+          {
+            plugin: '@nx/dotnet/plugin',
+            options: { build: { targetName: 'compile' } },
+          },
+        ],
+      })
+    );
+    update(tree);
+    expect(readNxJson(tree)?.plugins).toEqual([
+      { plugin: '@nx/dotnet', options: { build: { targetName: 'compile' } } },
+    ]);
+  });
+
+  it('should not create a duplicate when both the old and new paths are registered', () => {
+    tree.write(
+      'nx.json',
+      JSON.stringify({
+        plugins: ['@nx/dotnet', '@nx/dotnet/plugin'],
+      })
+    );
+    update(tree);
+    expect(readNxJson(tree)?.plugins).toEqual(['@nx/dotnet']);
+  });
+
+  it('should leave other plugins untouched', () => {
+    tree.write(
+      'nx.json',
+      JSON.stringify({
+        plugins: ['@nx/js', '@nx/dotnet/plugin', { plugin: '@nx/eslint' }],
+      })
+    );
+    update(tree);
+    expect(readNxJson(tree)?.plugins).toEqual([
+      '@nx/js',
+      '@nx/dotnet',
+      { plugin: '@nx/eslint' },
+    ]);
+  });
+});

--- a/packages/dotnet/src/migrations/update-23-0-0/update-plugin-path.ts
+++ b/packages/dotnet/src/migrations/update-23-0-0/update-plugin-path.ts
@@ -1,0 +1,46 @@
+import { readNxJson, Tree, updateNxJson } from '@nx/devkit';
+
+const OLD_PATH = '@nx/dotnet/plugin';
+const NEW_PATH = '@nx/dotnet';
+
+/**
+ * The `@nx/dotnet/plugin` subpath export has been removed in favor of the bare
+ * `@nx/dotnet` specifier. This migration rewrites any `nx.json` plugin entries
+ * that still register the plugin via the old `@nx/dotnet/plugin` path.
+ */
+export default function update(tree: Tree) {
+  const nxJson = readNxJson(tree);
+  if (!nxJson?.plugins?.length) {
+    return;
+  }
+
+  const usesOldPath = nxJson.plugins.some((p) =>
+    typeof p === 'string' ? p === OLD_PATH : p.plugin === OLD_PATH
+  );
+  if (!usesOldPath) {
+    return;
+  }
+
+  const hasBarePlugin = nxJson.plugins.some((p) =>
+    typeof p === 'string' ? p === NEW_PATH : p.plugin === NEW_PATH
+  );
+
+  nxJson.plugins = nxJson.plugins
+    // If `@nx/dotnet` is already registered, drop the old-path entry instead of
+    // registering the same plugin twice.
+    .filter(
+      (p) =>
+        !(
+          hasBarePlugin &&
+          (typeof p === 'string' ? p === OLD_PATH : p.plugin === OLD_PATH)
+        )
+    )
+    .map((p) => {
+      if (typeof p === 'string') {
+        return p === OLD_PATH ? NEW_PATH : p;
+      }
+      return p.plugin === OLD_PATH ? { ...p, plugin: NEW_PATH } : p;
+    });
+
+  updateNxJson(tree, nxJson);
+}

--- a/packages/dotnet/src/migrations/update-23-0-0/update-plugin-path.ts
+++ b/packages/dotnet/src/migrations/update-23-0-0/update-plugin-path.ts
@@ -6,7 +6,8 @@ const NEW_PATH = '@nx/dotnet';
 /**
  * The `@nx/dotnet/plugin` subpath export has been removed in favor of the bare
  * `@nx/dotnet` specifier. This migration rewrites any `nx.json` plugin entries
- * that still register the plugin via the old `@nx/dotnet/plugin` path.
+ * that still register the plugin via the old `@nx/dotnet/plugin` path, updating
+ * each entry in place so the order of the `plugins` array is preserved.
  */
 export default function update(tree: Tree) {
   const nxJson = readNxJson(tree);
@@ -14,33 +15,21 @@ export default function update(tree: Tree) {
     return;
   }
 
-  const usesOldPath = nxJson.plugins.some((p) =>
-    typeof p === 'string' ? p === OLD_PATH : p.plugin === OLD_PATH
-  );
-  if (!usesOldPath) {
-    return;
+  let updated = false;
+  for (let i = 0; i < nxJson.plugins.length; i++) {
+    const plugin = nxJson.plugins[i];
+    if (typeof plugin === 'string') {
+      if (plugin === OLD_PATH) {
+        nxJson.plugins[i] = NEW_PATH;
+        updated = true;
+      }
+    } else if (plugin.plugin === OLD_PATH) {
+      plugin.plugin = NEW_PATH;
+      updated = true;
+    }
   }
 
-  const hasBarePlugin = nxJson.plugins.some((p) =>
-    typeof p === 'string' ? p === NEW_PATH : p.plugin === NEW_PATH
-  );
-
-  nxJson.plugins = nxJson.plugins
-    // If `@nx/dotnet` is already registered, drop the old-path entry instead of
-    // registering the same plugin twice.
-    .filter(
-      (p) =>
-        !(
-          hasBarePlugin &&
-          (typeof p === 'string' ? p === OLD_PATH : p.plugin === OLD_PATH)
-        )
-    )
-    .map((p) => {
-      if (typeof p === 'string') {
-        return p === OLD_PATH ? NEW_PATH : p;
-      }
-      return p.plugin === OLD_PATH ? { ...p, plugin: NEW_PATH } : p;
-    });
-
-  updateNxJson(tree, nxJson);
+  if (updated) {
+    updateNxJson(tree, nxJson);
+  }
 }

--- a/packages/dotnet/src/plugin.ts
+++ b/packages/dotnet/src/plugin.ts
@@ -1,5 +1,0 @@
-export {
-  createNodesV2,
-  createNodes,
-  createDependencies,
-} from './plugins/plugin';

--- a/packages/dotnet/src/plugins/plugin.ts
+++ b/packages/dotnet/src/plugins/plugin.ts
@@ -1,19 +1,17 @@
-import { createNodes, type DotNetPluginOptions } from './create-nodes';
-import { createDependencies } from './create-dependencies';
-import { NxPlugin } from '@nx/devkit';
+import { createNodes as createDotNetNodes } from './create-nodes';
+import { createDependencies as createDotNetDependencies } from './create-dependencies';
 
-const regularPlugin: NxPlugin<DotNetPluginOptions> = {
-  name: '@nx/dotnet',
-  createNodes,
-  createNodesV2: createNodes,
-  createDependencies,
-};
+// The plugin can be fully disabled (e.g. to debug graph issues) via the
+// NX_DOTNET_DISABLE environment variable. When disabled, no nodes or
+// dependencies are created so Nx effectively ignores .NET projects.
+const disabled = process.env.NX_DOTNET_DISABLE === 'true';
 
-const noopPlugin: NxPlugin = {
-  name: '@nx/dotnet [disabled]',
-};
+export const name = disabled ? '@nx/dotnet [disabled]' : '@nx/dotnet';
 
-const plugin: NxPlugin<DotNetPluginOptions> =
-  process.env.NX_DOTNET_DISABLE === 'true' ? noopPlugin : regularPlugin;
+export const createNodes = disabled ? undefined : createDotNetNodes;
 
-export = plugin;
+export const createNodesV2 = disabled ? undefined : createDotNetNodes;
+
+export const createDependencies = disabled
+  ? undefined
+  : createDotNetDependencies;


### PR DESCRIPTION
## Current Behavior

<!-- This is the behavior we have today -->

- The `@nx/dotnet` plugin is labeled **experimental** in two user-facing places: the docs site introduction page (a `caution` aside) and the published npm README (generated from `readme-template.md`).
- The package exposes the plugin via **two** specifiers: the bare `@nx/dotnet` and the `@nx/dotnet/plugin` subpath. Both resolve to the same plugin implementation, which is redundant and confusing.

## Expected Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

- The experimental banner/warning is removed from both the docs page and the npm README. (Factual asides — .NET SDK compatibility, minimum Nx version — are kept.)
- The `@nx/dotnet/plugin` subpath export is removed. The plugin is registered solely via the bare `@nx/dotnet` specifier (already what `nx add @nx/dotnet` / the init generator writes).
- A migration rewrites any existing `nx.json` plugin entries from `@nx/dotnet/plugin` to `@nx/dotnet`, handling both the string and object (`{ plugin, options }`) registration forms and de-duplicating if both paths are present.

### Implementation notes

- Removed the `./plugin` entry from the package `exports` map.
- Inlined the plugin re-export into `src/index.ts`, converted the internal plugin module to named exports, and deleted the now-redundant `src/plugin.ts` shim. The bare `@nx/dotnet` public surface is unchanged.
- Added the `update-23-0-0-migrate-dotnet-plugin-path` migration with unit tests (6 cases, all passing).

**BREAKING CHANGE:** the `@nx/dotnet/plugin` entry point has been removed; use `@nx/dotnet`. The included migration updates `nx.json` automatically.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

N/A
