### PR TITLE
fix(react-native): fix TS2742 build error and retarget rollup/webpack migrations to beta.24

### DIFF
--- a/packages/react-native/src/utils/add-jest.ts
+++ b/packages/react-native/src/utils/add-jest.ts
@@ -1,4 +1,9 @@
-import { Tree, ensurePackage, offsetFromRoot } from '@nx/devkit';
+import {
+  GeneratorCallback,
+  Tree,
+  ensurePackage,
+  offsetFromRoot,
+} from '@nx/devkit';
 import { nxVersion } from './versions';
 
 export async function addJest(
@@ -10,7 +15,7 @@ export async function addJest(
   skipPackageJson: boolean,
   addPlugin: boolean,
   runtimeTsconfigFileName: string
-) {
+): Promise<GeneratorCallback> {
   if (unitTestRunner !== 'jest') {
     return () => {};
   }

--- a/packages/rollup/migrations.json
+++ b/packages/rollup/migrations.json
@@ -8,7 +8,7 @@
       "documentation": "./dist/src/migrations/update-23-0-0/remove-use-legacy-typescript-plugin.md"
     },
     "rewrite-rollup-internal-subpath-imports": {
-      "version": "23.0.0-beta.25",
+      "version": "23.0.0-beta.24",
       "description": "Rewrites `@nx/rollup/src/*` subpath imports now that the `./src/*` subpath is no longer exposed by `@nx/rollup`'s exports map. Named imports/exports of public symbols are routed to `@nx/rollup` and the rest to the new `@nx/rollup/internal` entry; `require`, dynamic `import` and `jest.mock` calls reference the whole module and are routed to `@nx/rollup/internal`.",
       "implementation": "./dist/src/migrations/update-23-0-0/rewrite-internal-subpath-imports"
     },

--- a/packages/webpack/migrations.json
+++ b/packages/webpack/migrations.json
@@ -21,7 +21,7 @@
       "documentation": "./dist/src/migrations/update-23-0-0/remove-nx-tsconfig-paths-webpack-plugin-import.md"
     },
     "rewrite-webpack-internal-subpath-imports": {
-      "version": "23.0.0-beta.25",
+      "version": "23.0.0-beta.24",
       "description": "Rewrites `@nx/webpack/src/*` subpath imports now that the `./src/*` subpath is no longer exposed by `@nx/webpack`'s exports map. Named imports/exports of public symbols are routed to `@nx/webpack` and the rest to the new `@nx/webpack/internal` entry; `require`, dynamic `import` and `jest.mock` calls reference the whole module and are routed to `@nx/webpack/internal`.",
       "implementation": "./dist/src/migrations/update-23-0-0/rewrite-internal-subpath-imports"
     },


### PR DESCRIPTION
## Current Behavior

- The `@nx/react-native` library build (`tsc --build tsconfig.lib.json`) fails with **TS2742**. The exported `addJest` helper has no explicit return type, so TypeScript infers `GeneratorCallback` and can only name it through a non-portable, pnpm-hashed `@nx/devkit` path when emitting the declaration file.
- The `rewrite-rollup-internal-subpath-imports` and `rewrite-webpack-internal-subpath-imports` migrations are scheduled to run at `23.0.0-beta.25`.

## Expected Behavior

- `addJest` is explicitly annotated as `Promise<GeneratorCallback>` (imported from `@nx/devkit`), giving `tsc` a portable name to emit. The library now builds cleanly.
- Both internal-subpath-import migrations are retargeted to `23.0.0-beta.24` to align with the rest of the `23.0.0` migration batch.

## Related Issue(s)

N/A
