### PR TITLE
fix(repo): use import type for type-only @nx/devkit imports in copy-a…

### DIFF
--- a/tools/workspace-plugin/src/conformance-rules/no-ignored-tracked-files/index.ts
+++ b/tools/workspace-plugin/src/conformance-rules/no-ignored-tracked-files/index.ts
@@ -1,4 +1,5 @@
-import { createConformanceRule, ConformanceViolation } from '@nx/conformance';
+import { createConformanceRule } from '@nx/conformance';
+import type { ConformanceViolation } from '@nx/conformance';
 import { execSync } from 'child_process';
 
 export default createConformanceRule({

--- a/tools/workspace-plugin/src/conformance-rules/relative-image-imports/index.ts
+++ b/tools/workspace-plugin/src/conformance-rules/relative-image-imports/index.ts
@@ -1,4 +1,5 @@
-import { ConformanceViolation, createConformanceRule } from '@nx/conformance';
+import { createConformanceRule } from '@nx/conformance';
+import type { ConformanceViolation } from '@nx/conformance';
 import { workspaceRoot } from '@nx/devkit';
 import { readFileSync, existsSync } from 'node:fs';
 import { dirname, join, resolve, relative, isAbsolute } from 'node:path';

--- a/tools/workspace-plugin/src/executors/copy-assets/executor.ts
+++ b/tools/workspace-plugin/src/executors/copy-assets/executor.ts
@@ -1,4 +1,5 @@
-import { ExecutorContext, logger, workspaceRoot } from '@nx/devkit';
+import { logger, workspaceRoot } from '@nx/devkit';
+import type { ExecutorContext } from '@nx/devkit';
 import { CopyAssetsHandler } from '@nx/js/src/utils/assets/copy-assets-handler';
 import * as path from 'path';
 import * as fs from 'fs';

--- a/tools/workspace-plugin/src/generators/bump-maven-version/generator.ts
+++ b/tools/workspace-plugin/src/generators/bump-maven-version/generator.ts
@@ -1,4 +1,5 @@
-import { formatFiles, logger, readJson, Tree, updateJson } from '@nx/devkit';
+import { formatFiles, logger, readJson, updateJson } from '@nx/devkit';
+import type { Tree } from '@nx/devkit';
 import { DOMParser, XMLSerializer } from '@xmldom/xmldom';
 import * as path from 'path';
 

--- a/tools/workspace-plugin/src/generators/remove-migrations/generator.ts
+++ b/tools/workspace-plugin/src/generators/remove-migrations/generator.ts
@@ -1,10 +1,10 @@
 import {
   formatFiles,
   readJson,
-  Tree,
   updateJson,
   visitNotIgnoredFiles,
 } from '@nx/devkit';
+import type { Tree } from '@nx/devkit';
 import { basename, dirname, join } from 'path';
 import { major } from 'semver';
 

--- a/tools/workspace-plugin/src/plugins/copy-assets-plugin.ts
+++ b/tools/workspace-plugin/src/plugins/copy-assets-plugin.ts
@@ -1,9 +1,5 @@
-import {
-  createNodesFromFiles,
-  CreateNodesV2,
-  readJsonFile,
-  TargetConfiguration,
-} from '@nx/devkit';
+import { createNodesFromFiles, readJsonFile } from '@nx/devkit';
+import type { CreateNodesV2, TargetConfiguration } from '@nx/devkit';
 import {
   getAssetOutputPath,
   normalizeAssets,

--- a/tools/workspace-plugin/tsconfig.lib.json
+++ b/tools/workspace-plugin/tsconfig.lib.json
@@ -7,7 +7,14 @@
     "composite": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    // The package is `type: module`; align the build with ESM and enable
+    // verbatimModuleSyntax so a type imported as a value (which Node's native
+    // type stripping can't erase, breaking plugin loads on e.g. FreeBSD) fails
+    // the build instead of only at runtime.
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
+    "verbatimModuleSyntax": true
   },
   "include": ["src/**/*.ts", "src/**/*.json"],
   "exclude": [

--- a/tools/workspace-plugin/tsconfig.lib.json
+++ b/tools/workspace-plugin/tsconfig.lib.json
@@ -8,10 +8,6 @@
     "esModuleInterop": true,
     "skipLibCheck": true,
     "resolveJsonModule": true,
-    // The package is `type: module`; align the build with ESM and enable
-    // verbatimModuleSyntax so a type imported as a value (which Node's native
-    // type stripping can't erase, breaking plugin loads on e.g. FreeBSD) fails
-    // the build instead of only at runtime.
     "module": "nodenext",
     "moduleResolution": "nodenext",
     "verbatimModuleSyntax": true


### PR DESCRIPTION
…ssets plugin

CreateNodesV2 and TargetConfiguration are types but were imported as values. The @nx/workspace-plugin package is type: module, so under Node's native TypeScript stripping (Node >= 22.18) those names are left as runtime imports. @nx/devkit is CommonJS with no such runtime exports, so the plugin fails to load -- surfacing on the FreeBSD publish job as the misleading "imported again after being required. Status = 0" Node error. Marking them import type lets native strip erase them so the plugin loads on any Node.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
