### PR TITLE
fix(remix): correct migration implementation path for flat-build packages

### DIFF
--- a/packages/devkit/src/migrations/update-23-0-0/rename-create-nodes-v2-types.spec.ts
+++ b/packages/devkit/src/migrations/update-23-0-0/rename-create-nodes-v2-types.spec.ts
@@ -100,6 +100,62 @@ describe('rename-create-nodes-v2-types migration', () => {
       expect(rewriteCreateNodesV2Types(input)).toBe(input);
     });
 
+    it('renames in-body usages of a renamed non-aliased import', () => {
+      const input =
+        `import type { CreateNodesV2 } from '@nx/devkit';\n` +
+        `export const createNodesV2: CreateNodesV2 = ['**/x', () => ({})];\n`;
+      expect(rewriteCreateNodesV2Types(input)).toBe(
+        `import type { CreateNodes } from '@nx/devkit';\n` +
+          `export const createNodesV2: CreateNodes = ['**/x', () => ({})];\n`
+      );
+    });
+
+    it('renames every in-body usage of a renamed type', () => {
+      const input =
+        `import type { CreateNodesV2 } from '@nx/devkit';\n` +
+        `let a: CreateNodesV2;\n` +
+        `let b: Array<CreateNodesV2>;\n`;
+      expect(rewriteCreateNodesV2Types(input)).toBe(
+        `import type { CreateNodes } from '@nx/devkit';\n` +
+          `let a: CreateNodes;\n` +
+          `let b: Array<CreateNodes>;\n`
+      );
+    });
+
+    it('renames generic type usages and parameter annotations (php plugin shape)', () => {
+      const input =
+        `import { CreateNodesV2, CreateNodesContextV2 } from '@nx/devkit';\n` +
+        `export const createNodesV2: CreateNodesV2<ComposerPluginOptions> = ['x', () => ({})];\n` +
+        `async function fn(context: CreateNodesContextV2) {}\n`;
+      expect(rewriteCreateNodesV2Types(input)).toBe(
+        `import { CreateNodes, CreateNodesContext } from '@nx/devkit';\n` +
+          `export const createNodesV2: CreateNodes<ComposerPluginOptions> = ['x', () => ({})];\n` +
+          `async function fn(context: CreateNodesContext) {}\n`
+      );
+    });
+
+    it('does not rename in-body usages when the local binding is aliased', () => {
+      const input =
+        `import type { CreateNodesV2 as CN } from '@nx/devkit';\n` +
+        `let a: CN;\n`;
+      expect(rewriteCreateNodesV2Types(input)).toBe(
+        `import type { CreateNodes as CN } from '@nx/devkit';\n` +
+          `let a: CN;\n`
+      );
+    });
+
+    it('does not rename member positions that merely share the name', () => {
+      const input =
+        `import type { NxPluginV2 } from '@nx/devkit';\n` +
+        `let a: NxPluginV2;\n` +
+        `const x = foo.NxPluginV2;\n`;
+      expect(rewriteCreateNodesV2Types(input)).toBe(
+        `import type { NxPlugin } from '@nx/devkit';\n` +
+          `let a: NxPlugin;\n` +
+          `const x = foo.NxPluginV2;\n`
+      );
+    });
+
     it('leaves the V2 names in strings and comments alone', () => {
       const input =
         `// import { CreateNodesV2 } from '@nx/devkit';\n` +

--- a/packages/devkit/src/migrations/update-23-0-0/rename-create-nodes-v2-types.ts
+++ b/packages/devkit/src/migrations/update-23-0-0/rename-create-nodes-v2-types.ts
@@ -2,10 +2,12 @@ import { logger, type Tree } from 'nx/src/devkit-exports';
 import type {
   ExportDeclaration,
   ExportSpecifier,
+  Identifier,
   ImportDeclaration,
   ImportSpecifier,
   NamedExports,
   NamedImports,
+  Node,
   SourceFile,
 } from 'typescript';
 import { formatFiles } from '../../generators/format-files';
@@ -85,12 +87,21 @@ export function rewriteCreateNodesV2Types(source: string): string {
   );
 
   const changes: StringChange[] = [];
+  // Local bindings whose name changes as a result of rewriting a non-aliased
+  // import specifier (e.g. `import { CreateNodesV2 }` -> `import { CreateNodes }`).
+  // Every in-body reference to such a binding must be renamed too, otherwise the
+  // rewritten import leaves a dangling reference to the old name.
+  const localRenames = new Map<string, string>();
   for (const stmt of sourceFile.statements) {
     if (ts.isImportDeclaration(stmt)) {
-      collectImportRewrite(sourceFile, stmt, changes);
+      collectImportRewrite(sourceFile, stmt, changes, localRenames);
     } else if (ts.isExportDeclaration(stmt)) {
       collectExportRewrite(sourceFile, stmt, changes);
     }
+  }
+
+  if (localRenames.size > 0) {
+    collectUsageRewrites(sourceFile, localRenames, changes);
   }
 
   return changes.length > 0 ? applyChangesToString(source, changes) : source;
@@ -105,7 +116,8 @@ function isDevkitSpecifier(
 function collectImportRewrite(
   sourceFile: SourceFile,
   stmt: ImportDeclaration,
-  changes: StringChange[]
+  changes: StringChange[],
+  localRenames: Map<string, string>
 ): void {
   if (!isDevkitSpecifier(stmt.moduleSpecifier)) {
     return;
@@ -114,7 +126,72 @@ function collectImportRewrite(
   if (!namedBindings || !ts!.isNamedImports(namedBindings)) {
     return;
   }
+  // A non-aliased specifier (`{ CreateNodesV2 }`) renames the local binding, so
+  // its in-body references must be rewritten as well. An aliased specifier
+  // (`{ CreateNodesV2 as Foo }`) keeps the local name `Foo`, so it does not.
+  for (const el of namedBindings.elements) {
+    if (el.propertyName) {
+      continue;
+    }
+    const canonical = CREATE_NODES_V2_TYPE_RENAMES.get(el.name.text);
+    if (canonical) {
+      localRenames.set(el.name.text, canonical);
+    }
+  }
   rewriteNamedBindings(sourceFile, namedBindings, changes);
+}
+
+/**
+ * Renames in-body references (type annotations, value usages) of bindings that
+ * were renamed by an import rewrite. References inside import/export
+ * declarations are left to the binding rewrite, and member positions
+ * (`foo.CreateNodesV2`, `NS.CreateNodesV2`) are not standalone references to the
+ * imported binding, so they are skipped.
+ */
+function collectUsageRewrites(
+  sourceFile: SourceFile,
+  localRenames: Map<string, string>,
+  changes: StringChange[]
+): void {
+  const visit = (node: Node): void => {
+    if (
+      ts!.isIdentifier(node) &&
+      localRenames.has(node.text) &&
+      isRenameableReference(node)
+    ) {
+      const start = node.getStart(sourceFile);
+      changes.push(
+        { type: ChangeType.Delete, start, length: node.getEnd() - start },
+        {
+          type: ChangeType.Insert,
+          index: start,
+          text: localRenames.get(node.text)!,
+        }
+      );
+    }
+    ts!.forEachChild(node, visit);
+  };
+  ts!.forEachChild(sourceFile, visit);
+}
+
+function isRenameableReference(id: Identifier): boolean {
+  const parent = id.parent;
+  // `foo.CreateNodesV2` — the member name is not the imported binding.
+  if (ts!.isPropertyAccessExpression(parent) && parent.name === id) {
+    return false;
+  }
+  // `NS.CreateNodesV2` in a type position — same reasoning.
+  if (ts!.isQualifiedName(parent) && parent.right === id) {
+    return false;
+  }
+  // Anything inside an import/export declaration is handled by the binding
+  // rewrite; skip it here to avoid touching the specifier twice.
+  for (let n: Node | undefined = id; n; n = n.parent) {
+    if (ts!.isImportDeclaration(n) || ts!.isExportDeclaration(n)) {
+      return false;
+    }
+  }
+  return true;
 }
 
 function collectExportRewrite(

--- a/packages/nuxt/migrations.json
+++ b/packages/nuxt/migrations.json
@@ -8,8 +8,8 @@
     "update-23-0-0-migrate-create-nodes-v2-import": {
       "version": "23.0.0-beta.24",
       "description": "Rename imports of `createNodesV2` from `@nx/nuxt/plugin` to the canonical `createNodes` export.",
-      "implementation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
-      "documentation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"
+      "implementation": "./src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
+      "documentation": "./src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"
     }
   },
   "packageJsonUpdates": {

--- a/packages/remix/migrations.json
+++ b/packages/remix/migrations.json
@@ -3,8 +3,8 @@
     "update-23-0-0-migrate-create-nodes-v2-import": {
       "version": "23.0.0-beta.24",
       "description": "Rename imports of `createNodesV2` from `@nx/remix/plugin` to the canonical `createNodes` export.",
-      "implementation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
-      "documentation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"
+      "implementation": "./src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
+      "documentation": "./src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"
     }
   },
   "packageJsonUpdates": {


### PR DESCRIPTION
## Current Behavior

The `createNodesV2` → `createNodes` rename migrations added in #35893 registered the `update-23-0-0-migrate-create-nodes-v2-import` migration for **@nx/remix** and **@nx/nuxt** with a `./dist/src/migrations/...` implementation path.

Both are flat-build packages (`main: ./index.js`) whose files are published at the package root, not under a `dist/` directory. As a result, `nx migrate` fails when it reaches these migrations:

```
NX   Could not resolve implementation for migration
"update-23-0-0-migrate-create-nodes-v2-import" from .../node_modules/@nx/remix/migrations.json
```

## Expected Behavior

The migration resolves and runs. The implementation/documentation paths for the flat-build packages point to `./src/migrations/...`, matching the published package layout — consistent with the other flat-build plugins (angular, next, expo, react-native, react), which already use the `./src/...` prefix.

Audited all 23 plugins touched by #35893: only `@nx/remix` and `@nx/nuxt` were mismatched. Dist-build packages (webpack, vite, jest, etc.) correctly keep the `./dist/src/...` prefix.

## Related Issue(s)

Follow-up fix to #35893.