### PR TITLE
docs(nx-cloud): remove + variant resource classes from launch templates page

### DIFF
--- a/astro-docs/src/content/docs/reference/Nx Cloud/launch-templates.mdoc
+++ b/astro-docs/src/content/docs/reference/Nx Cloud/launch-templates.mdoc
@@ -56,11 +56,8 @@ The following resource classes are available:
 
 - `docker_linux_amd64/small`
 - `docker_linux_amd64/medium`
-- `docker_linux_amd64/medium+`
 - `docker_linux_amd64/large`
-- `docker_linux_amd64/large+`
 - `docker_linux_amd64/extra_large`
-- `docker_linux_amd64/extra_large+`
 - `docker_linux_arm64/medium`
 - `docker_linux_arm64/large`
 - `docker_linux_arm64/extra_large`


### PR DESCRIPTION
## Current Behavior

The Nx Cloud [Launch Templates](https://nx.dev/docs/reference/nx-cloud/launch-templates#launch-templatestemplate-nameresource-class) reference page lists `+` variant resource classes (`docker_linux_amd64/medium+`, `docker_linux_amd64/large+`, `docker_linux_amd64/extra_large+`) in the `launch-templates.<template-name>.resource-class` section.

## Expected Behavior

The `+` variant resource classes are removed from the list. Only the base resource classes remain.

## Related Issue(s)

Fixes DOC-515