### PR TITLE
fix(core): show agentic migration prompt descriptions only for the focused choice

### DIFF
--- a/packages/docker/src/release/version-utils.spec.ts
+++ b/packages/docker/src/release/version-utils.spec.ts
@@ -115,6 +115,39 @@ describe('handleDockerVersion {versionActionsVersion} integration', () => {
     expect(newVersion).toBe('my-app-0.0.0');
   });
 
+  it("surfaces only the focused scheme's pattern via the footer", async () => {
+    const finalConfigForProject: any = {
+      dockerOptions: {
+        repositoryName: 'repo',
+        registryUrl: undefined,
+        versionSchemes: {
+          prod: '{projectName}-{versionActionsVersion}',
+          dev: '{projectName}-0.0.0',
+        },
+      },
+    };
+    jest.mocked(prompt).mockResolvedValueOnce({ versionScheme: 'dev' });
+
+    await handleDockerVersion(
+      process.cwd(),
+      mockProjectNode,
+      finalConfigForProject,
+      undefined,
+      undefined,
+      versionActionsVersion
+    );
+
+    const call = jest.mocked(prompt).mock.calls[0][0] as any;
+    const styles = { muted: (s: string) => s };
+    const prodChoice = call.choices.find((c: any) => c.name === 'prod');
+    expect(call.footer.call({ focused: prodChoice, styles })).toContain(
+      prodChoice.description
+    );
+    expect(
+      call.footer.call({ focused: { description: undefined }, styles })
+    ).toBe('');
+  });
+
   it('falls back to env NX_DOCKER_IMAGE_REF tag if provided (extracting version)', async () => {
     process.env.NX_DOCKER_IMAGE_REF = 'registry.example.com/repo:9.9.9';
     const finalConfigForProject: any = {

--- a/packages/docker/src/release/version-utils.ts
+++ b/packages/docker/src/release/version-utils.ts
@@ -85,9 +85,18 @@ async function promptForNewVersion(
       name: vs,
       message: vs,
       value: vs,
-      hint: interpolateVersionPattern(versionSchemes[vs], { projectName }),
+      description: interpolateVersionPattern(versionSchemes[vs], {
+        projectName,
+      }),
     })),
-  });
+    // Show only the focused scheme's resolved pattern, not every row's at once.
+    footer: function () {
+      const focused = this.focused as { description?: string };
+      return focused?.description
+        ? this.styles.muted(`  ${focused.description}`)
+        : '';
+    },
+  } as any);
 
   return versionScheme;
 }

--- a/packages/nx/src/command-line/migrate/agentic/select.spec.ts
+++ b/packages/nx/src/command-line/migrate/agentic/select.spec.ts
@@ -199,9 +199,25 @@ describe('resolveAgentic', () => {
       'no-once',
       'no-never',
     ]);
-    expect(call.choices[0].hint).toBe(
+    expect(call.choices[0].description).toBe(
       'Apply 2 prompt migrations and validate generator output with an AI agent'
     );
+  });
+
+  it("surfaces only the focused choice's description via the footer", async () => {
+    mockDetect.mockResolvedValue([detected('claude-code')]);
+    mockPrompt.mockResolvedValueOnce({ choice: 'no-once' });
+    await resolveAgentic({
+      agentic: undefined,
+      migrations: [{ prompt: 'a.md' }],
+    });
+    const call = mockPrompt.mock.calls[0][0];
+    const footer = call.footer as (this: { focused: unknown }) => string;
+    const skipChoice = call.choices.find((c: any) => c.name === 'no-once');
+    expect(footer.call({ focused: skipChoice })).toContain(
+      'Skip prompts and run generators without AI validation'
+    );
+    expect(footer.call({ focused: { description: undefined } })).toBe('');
   });
 
   it('adds the "pin the agent" choice when multiple agents are installed', async () => {
@@ -229,7 +245,7 @@ describe('resolveAgentic', () => {
       migrations: [{ prompt: 'only.md' }],
     });
     const call = mockPrompt.mock.calls[0][0];
-    expect(call.choices[0].hint).toBe(
+    expect(call.choices[0].description).toBe(
       'Apply 1 prompt migration and validate generator output with an AI agent'
     );
   });

--- a/packages/nx/src/command-line/migrate/agentic/select.ts
+++ b/packages/nx/src/command-line/migrate/agentic/select.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { applyEdits, modify } from 'jsonc-parser';
 import { join } from 'path';
+import * as pc from 'picocolors';
 import { output } from '../../../utils/output';
 import { workspaceRoot } from '../../../utils/workspace-root';
 import { migratePrompt } from '../safe-prompt';
@@ -165,38 +166,45 @@ async function firePromptForAgentic(
   // pin option is dropped.
   const multipleAgents = detected.length > 1;
   const choices = [
-    { name: 'yes-once', message: 'Yes, just this time', hint: applyHint },
+    {
+      name: 'yes-once',
+      message: 'Yes, just this time',
+      description: applyHint,
+    },
     {
       name: 'yes-flex',
       message: multipleAgents
         ? "Yes, always (I'll pick the agent each run)"
         : 'Yes, always',
-      hint: rememberHint,
+      description: rememberHint,
     },
     ...(multipleAgents
       ? [
           {
             name: 'yes-pin',
             message: 'Yes, always with the same agent',
-            hint: rememberHint,
+            description: rememberHint,
           },
         ]
       : []),
-    { name: 'no-once', message: 'No, just this time', hint: skipHint },
-    { name: 'no-never', message: 'No, never', hint: rememberHint },
+    { name: 'no-once', message: 'No, just this time', description: skipHint },
+    { name: 'no-never', message: 'No, never', description: rememberHint },
   ];
 
   // Blank line keeps the prompt from gluing to the previous `npm install`
   // output or any earlier orchestrator line.
   console.log();
-  // `as any` because enquirer's TS types lag the runtime (per-choice `hint`
-  // is supported but not in the .d.ts).
+  // `as any`: `footer` and per-choice `description` aren't in enquirer's .d.ts.
   const response = await migratePrompt<{ choice: string }>({
     name: 'choice',
     type: 'select',
     message: 'Enable the agentic flow?',
     choices,
     initial: 0,
+    footer: function () {
+      const focused = this.focused as { description?: string };
+      return focused?.description ? pc.dim(`  ${focused.description}`) : '';
+    },
   } as any);
 
   switch (response.choice) {


### PR DESCRIPTION
## Current Behavior

During `nx migrate`, the up-front **"Enable the agentic flow?"** prompt rendered every choice's description at once (via enquirer's built-in per-choice `hint`), producing a wall of muted text beside the options.

## Expected Behavior

Each choice's description is shown **only when that option is focused** — as a single dimmed line in the prompt footer that updates as you arrow through the list. This mirrors the focused-description pattern already used in `configure-ai-agents`.

Implementation: the per-choice blurb moved from enquirer's `hint` field (which auto-renders on every row) to a plain `description` field that enquirer ignores, and a `footer` function surfaces `this.focused.description`.

## Related Issue(s)

N/A
