### PR TITLE
docs(nx-dev): document nx migrate agentic flow and modes

### DIFF
--- a/astro-docs/astro.config.mjs
+++ b/astro-docs/astro.config.mjs
@@ -42,6 +42,8 @@ export default defineConfig({
   },
   trailingSlash: 'never',
   redirects: {
+    '/knowledge-base/installation':
+      '/docs/knowledge-base/installation-and-updates',
     '/guides/nx-cloud/ci-resource-usage':
       '/docs/features/ci-features/resource-usage',
     '/reference/remote-cache-plugins':

--- a/astro-docs/netlify.toml
+++ b/astro-docs/netlify.toml
@@ -140,6 +140,11 @@ to = "/docs/getting-started/setup-ci"
 from = "/docs/guides/nx-cloud/ci-resource-usage"
 to = "/docs/features/ci-features/resource-usage"
 
+# NXC-4453: Knowledge Base "Installation" section renamed to "Installation and updates"
+[[redirects]]
+from = "/docs/knowledge-base/installation"
+to = "/docs/knowledge-base/installation-and-updates"
+
 # Rewrite for base path handling (keeps URL the same)
 [[redirects]]
 from = "/docs/*"

--- a/astro-docs/sidebar.mts
+++ b/astro-docs/sidebar.mts
@@ -303,10 +303,6 @@ const learnGroups: SidebarItems = [
             link: 'features/automate-updating-dependencies',
           },
           {
-            label: 'Nx Console migration assistance',
-            link: 'guides/nx-console/console-migrate-ui',
-          },
-          {
             label: 'Advanced update process',
             link: 'guides/tips-n-tricks/advanced-update',
           },
@@ -710,7 +706,7 @@ const knowledgeBaseGroups: SidebarItems = [
         ],
       },
       {
-        label: 'Installation',
+        label: 'Installation and updates',
         collapsed: true,
         items: [
           {
@@ -720,6 +716,10 @@ const knowledgeBaseGroups: SidebarItems = [
           {
             label: 'Update global installation',
             link: 'guides/installation/update-global-installation',
+          },
+          {
+            label: 'Nx Console migration assistance',
+            link: 'guides/nx-console/console-migrate-ui',
           },
         ],
       },

--- a/astro-docs/src/content/docs/features/automate-updating-dependencies.mdoc
+++ b/astro-docs/src/content/docs/features/automate-updating-dependencies.mdoc
@@ -12,91 +12,129 @@ src="https://youtu.be/A0FjwsTlZ8A"
 title="How Automated Code Migrations Work"
 /%}
 
-Keeping your tooling up to date is crucial for the health of your project. Tooling maintenance work can be tedious and time consuming, though. The **Nx migrate** functionality provides a way for you to
+Keeping your tooling up to date is a tedious and time-consuming part of maintaining any project. The `nx migrate` command automates that work by:
 
-- automatically update your **`package.json` dependencies**
-- migrate your **configuration files** (e.g. Jest, ESLint, Nx config)
-- **adjust your source code** to match the new versions of packages (e.g., migrating across breaking changes)
+- Updating your `package.json` dependencies.
+- Updating your configuration files (e.g. Vite, Playwright, Nx config).
+- Updating your source code to match the new versions of packages (e.g., migrating across breaking changes).
 
-To update your workspace, run:
-
-```shell
-npx nx@latest migrate latest
-```
-
-{% aside type="note" title="Visual migration tool from Nx Console" %}
-Want a more visual and guided way to migrate? Check out the [Migrate UI](/docs/guides/nx-console/console-migrate-ui) that comes with the [Nx Console extension](/docs/getting-started/editor-setup).
-{% /aside %}
-
-## How does it work?
-
-Nx knows where its configuration files are located and ensures they match the expected format. This automated update process, commonly referred to as "migration," becomes even **more powerful when you leverage [Nx plugins](/docs/plugin-registry)**. Each plugin can provide migrations for its area of competency.
-
-For example, the [Nx React plugin](/docs/technologies/react/introduction) knows where to look for React and Nx specific configuration files and knows how to apply certain changes when updating to a given version of React.
-
-In the example below, the React plugin defines a migration script (`./src/migrations/.../add-babel-core`) that runs when upgrading to Nx `16.7.0-beta.2` (or higher).
-
-```json {% meta="{7,8}" %}
-// migrations.json
-{
-  "generators": {
-    ...
-    "add-babel-core": {
-       ...
-      "version": "16.7.0-beta.2",
-      "implementation": "./src/migrations/update-16-7-0/add-babel-core"
-    },
-  },
-}
-```
-
-When running `nx migrate latest`, Nx parses all the available plugins and their migration files and applies the necessary changes to your workspace.
-
-## How do i upgrade my Nx workspace?
-
-Updating your Nx workspace happens in three steps:
-
-1. The **installed dependencies**, including the `package.json` and `node_modules`, are updated.
-2. Nx produces a `migrations.json` file containing the **migrations to be run** based on your workspace configuration. You can inspect and adjust the file. Run the migrations to update your configuration files and source code.
-3. Optionally, you can remove the `migrations.json` file or keep it to re-run the migration in different Git branches.
-
-You can intervene at each step and make adjustments as needed for your specific workspaces. This is especially important in large codebases where you might want to control the changes more granularly.
-
-### Step 1: update dependencies and generate migrations
-
-First, run the `migrate` command:
+The command guides you through the update interactively:
 
 ```shell
-nx migrate latest
+nx migrate
 ```
 
-Note you can also specify an exact version by replacing `latest` with `nx@<version>`.
+## How Nx migrate works
 
-{% aside title="Update One Major Version at a Time" %}
-To avoid potential issues, it is [recommended to update one major version of Nx at a time](/docs/guides/tips-n-tricks/advanced-update#one-major-version-at-a-time-small-steps).
-{% /aside %}
+Nx knows where its configuration files are located and ensures they match the expected format. This automated update process is commonly referred to as "migration." Each [Nx plugin](/docs/plugin-registry) can provide migrations for its area of competency. For example, the Vite plugin ships migrations that update Vite configuration files across breaking changes. When you run `nx migrate`, Nx collects the pending migrations from all the plugins you have installed and applies the necessary changes to your workspace.
+
+## Migration steps
+
+Updating your Nx workspace happens in two phases:
+
+1. **Generate** - `nx migrate` applies the package version updates to your `package.json` and writes a `migrations.json` file. No source code is touched yet.
+2. **Run** - `nx migrate --run-migrations` runs the generated migrations to update your configuration files and source code.
+
+You can intervene between the phases and make adjustments as needed for your specific workspaces. This is especially important in large codebases where you might want to control the changes more granularly.
+
+### Step 1: Generate migrations
+
+Run the `migrate` command and follow the prompts:
+
+```shell
+nx migrate
+```
+
+Nx resolves the latest version and, when the update crosses more than one major version, asks how far to jump. Updating [one major version at a time](/docs/guides/tips-n-tricks/advanced-update#one-major-version-at-a-time-small-steps) is the safest path and is what Nx recommends.
+
+Nx also asks which package versions to migrate. The answer maps to the `--include` flag:
+
+- `required` - the target package and the packages it ships with. For example, Nx itself and its plugins such as `@nx/vite`.
+- `optional` - the dependency updates those packages recommend. For example, `vite` itself rather than `@nx/vite`.
+- `all` - both of the above.
+
+When unsure, choose `required`. Updating only Nx and its plugins keeps the PR scope small and has less chance of introducing issues, which matters most in large workspaces. Follow up with `nx migrate --include=optional` to catch up on the rest. If you're okay with doing everything in one PR, use `--include=all`.
+
+In some cases you can scope the optional catch-up to a single plugin's dependencies, such as `nx migrate @nx/vite --include=optional` - see [choosing which packages to migrate](/docs/guides/tips-n-tricks/advanced-update#choosing-which-packages-to-migrate) for the caveat.
 
 This results in:
 
-- The `package.json` being updated
+- The `package.json` being updated with the new package versions
 - A `migrations.json` being generated if there are pending migrations.
 
 At this point, no packages have been installed, and no other files have been touched.
 
-Now, you can **inspect `package.json` to see if the changes make sense**. Sometimes the migration can update a package to a version that is either not allowed or conflicts with another package. Feel free to manually apply the desired adjustments. Also look at the `migrations.json` for the type of migrations that are going to be applied.
+Now, inspect `package.json` to see if the changes make sense. Sometimes the migration can update a package to a version that is either not allowed or conflicts with another package. You are free to adjust versions before running install.
+
+{% tabs syncKey="install-type" %}
+{% tabitem label="npm" %}
+
+```shell
+npm install
+```
+
+{% /tabitem %}
+{% tabitem label="yarn" %}
+
+```shell
+yarn install
+```
+
+{% /tabitem %}
+{% tabitem label="pnpm" %}
+
+```shell
+pnpm install
+```
+
+{% /tabitem %}
+{% tabitem label="bun" %}
+
+```shell
+bun install
+```
+
+{% /tabitem %}
+{% /tabs %}
+
+Also, look at the `migrations.json` file for the type of migrations that are going to be applied. If this file does not exist, then there are no migrations to run.
 
 ### Step 2: Run migrations
 
-You can now run the actual code migrations that were generated in the `migrations.json` in the previous step.
+Run the migrations that were generated in the previous step (`migrations.json`):
 
 ```shell
 nx migrate --run-migrations
 ```
 
-Depending on the migrations that ran, this might **update your source code** and **configuration files** in your workspace. All the changes will be unstaged ready for you to review and commit yourself.
+#### What's in a migration?
+
+Migrations run one at a time and contain two types of changes:
+
+1. **Generator-based** ("script-based"): programmatic config or code changes (e.g. `rollupOptions` becomes `rolldownOptions` in `vite.config.ts` for Vite 8).
+2. **Prompt-based**: AI-aided changes that can't be expressed deterministically and need judgment about your specific code.
+
+A migration can be **generator-only**, **prompt-only**, or a **hybrid** (a generator followed by AI-aided changes).
+
+#### Running the migrations
+
+Generator-only migrations run automatically. All the changes are unstaged ready for you to review.
+
+When prompt-only or hybrid migrations are queued and a supported AI agent is installed (Claude Code, OpenAI Codex, or OpenCode), Nx asks whether to continue with an agentic flow. You can answer for this run only, or have Nx remember your choice in `nx.json`. With the agentic flow enabled:
+
+- Generator-based changes run first, and the agent validates the results.
+- The agent then applies the prompt-based changes as instructed in the prompt.
+
+Nx creates a commit for each migration while the agentic flow is enabled, so the agent reviews each migration's changes in isolation.
+
+Without an agent, generator-only migrations and the generator half of hybrid migrations still run. The skipped prompt files are listed in the next-steps output, in order, so you can apply them yourself.
+
+{% aside type="note" title="Running inside an AI agent" %}
+If you run `nx migrate --run-migrations` from within an AI agent's terminal, Nx defers the prompt-based migrations to that agent instead of spawning another one.
+{% /aside %}
 
 {% aside type="tip" title="Migrations are version specific" %}
-Note that each Nx plugin is able to provide a set of migrations which are relevant to particular versions of the package. Hence `migrations.json` will only contain migrations which are appropriate for the update you are currently applying.
+Each Nx plugin provides migrations that are relevant to particular versions of the package. The generated `migrations.json` only contains the migrations appropriate for the update you are currently applying.
 {% /aside %}
 
 ### Step 3: Clean up
@@ -119,14 +157,31 @@ For a list of all the plugins you currently have installed, run:
 nx report
 ```
 
+## Configure migrate defaults
+
+Set workspace-wide defaults for `nx migrate` in the `migrate` section of `nx.json` instead of passing the same flags on every run. You can control commit behavior, package selection, multi-major version handling, and the agentic flow:
+
+```json
+// nx.json
+{
+  "migrate": {
+    "agentic": "claude-code",
+    "createCommits": true,
+    "commitPrefix": "chore(repo): apply nx migration "
+  }
+}
+```
+
+For all available options, see the [`migrate` section of the `nx.json` reference](/docs/reference/nx-json#migrate).
+
 ## Keep Nx packages on the same version
 
 When you run `nx migrate`, the `nx` package and all the `@nx/` packages get updated to the same version. It is important to [keep these versions in sync](/docs/guides/tips-n-tricks/keep-nx-versions-in-sync) to have Nx work properly.
 
 As long as you run `nx migrate` instead of manually changing the version numbers, you shouldn't have to worry about it. Also, when you add a new plugin, use `nx add <plugin>` to automatically install the version that matches your repository's version of Nx.
 
-## Need to opt-out of some migrations?
+## Need more control?
 
-Sometimes you need to temporarily opt-out from some migrations because your workspace is not ready yet. You can manually adjust the `migrations.json` or run the update with the `--interactive` flag to choose which migrations you accept.
+Sometimes you need to deviate from the defaults: skip optional package updates and catch them up later, pin a specific AI agent or disable the agentic flow, run migrations one at a time, or opt out of specific migrations by adjusting `migrations.json`.
 
-Find more details in our [Advanced Update Process](/docs/guides/tips-n-tricks/advanced-update) guide.
+Find all of these in our [Advanced Update Process](/docs/guides/tips-n-tricks/advanced-update) guide.

--- a/astro-docs/src/content/docs/getting-started/installation.mdoc
+++ b/astro-docs/src/content/docs/getting-started/installation.mdoc
@@ -109,10 +109,12 @@ You can also manually install the [`nx` NPM package](https://www.npmjs.com/packa
 
 ### Update Nx in your repository
 
-When you update Nx in your repository, it will also [automatically update your dependencies](/docs/features/automate-updating-dependencies) if you have an [Nx plugin](/docs/concepts/nx-plugins) installed for that dependency. To update Nx, run:
+When you update Nx in your repository, it will also [automatically update your dependencies](/docs/features/automate-updating-dependencies) if you have an [Nx plugin](/docs/concepts/nx-plugins) installed for that dependency.
+
+To update Nx, run `nx migrate`. It guides you through the update interactively:
 
 ```shell
-nx migrate latest
+nx migrate
 ```
 
 This creates a `migrations.json` file with any update scripts that need to be run. Run them with:
@@ -120,6 +122,8 @@ This creates a `migrations.json` file with any update scripts that need to be ru
 ```shell
 nx migrate --run-migrations
 ```
+
+For the full walkthrough, including the AI-assisted agentic flow, see [Automate Updating Dependencies](/docs/features/automate-updating-dependencies).
 
 {% aside type="note" title="Update One Major Version at a Time" %}
 To avoid potential issues, it is [recommended to update one major version of Nx at a time](/docs/guides/tips-n-tricks/advanced-update#one-major-version-at-a-time-small-steps).

--- a/astro-docs/src/content/docs/guides/Nx Console/console-migrate-ui.mdoc
+++ b/astro-docs/src/content/docs/guides/Nx Console/console-migrate-ui.mdoc
@@ -16,7 +16,7 @@ When an update to Nx is available, a badge will appear on the Nx Console icon in
 
 ![](../../../../assets/guides/nx-console/console-migrate-1-start.avif)
 
-By default, clicking the migration button starts the migration process by upgrading to the recommended Nx version — the latest version of the next major release. This method ensures you upgrade one major version at a time in order to [avoid breakages](/docs/guides/tips-n-tricks/advanced-update#one-major-version-at-a-time-small-steps). To customize the version, click the pencil icon to provide a specific version to update to. You may also provide additional CLI options such as `--to` or `--from`.
+By default, clicking the migration button starts the migration process by upgrading to the recommended Nx version — the latest version of the next major release. This method ensures you upgrade one major version at a time in order to [avoid breakages](/docs/guides/tips-n-tricks/advanced-update#one-major-version-at-a-time-small-steps). To customize the version, click the pencil icon to provide a specific version to update to. You may also provide additional CLI options such as `--include`.
 
 ![](../../../../assets/guides/nx-console/console-migrate-2-customize-version.avif)
 
@@ -41,6 +41,19 @@ If a migration step encounters an error, the process pauses so you can inspect t
 You can click through to view the migration source code, giving you the opportunity to patch it for your specific use-case or make necessary adjustments to your repository before rerunning the migration.
 
 Alternatively, you may choose to skip a problematic migration.
+
+### Migrations that use an AI prompt
+
+Some migrations ship an AI prompt instead of (or in addition to) a deterministic script - see [what's in a migration](/docs/features/automate-updating-dependencies#whats-in-a-migration). The Migrate UI marks these with an **AI** badge and handles them without running an agent itself:
+
+- **Prompt-only** migrations can't run automatically. The card shows **"AI prompt pending"** with a hint pointing at the prompt file, and **View Source** opens that prompt. Apply the prompt yourself - for example, with your AI agent - then click **Mark as Run** to record it and move on.
+- **Hybrid** migrations run their generator automatically, then the card shows **Generator complete** alongside **AI prompt pending**. Click **Approve Changes** to accept the generator's edits and advance, or **Mark as Run** if the generator made no changes.
+
+Your acknowledgment is remembered across editor reloads, so reopening a session brings you back to any prompt migrations you still need to finish.
+
+{% aside type="note" title="Requires a recent Nx and Nx Console" %}
+The AI badge and prompt handling require Nx 23.0.0-beta.24 or later and an up-to-date Nx Console extension. On older versions the Migrate UI still works without these controls.
+{% /aside %}
 
 ## Finalizing the migration
 

--- a/astro-docs/src/content/docs/guides/Tips-n-Tricks/advanced-update.mdoc
+++ b/astro-docs/src/content/docs/guides/Tips-n-Tricks/advanced-update.mdoc
@@ -15,7 +15,7 @@ The following steps are a summary of the [standard update process](/docs/feature
 First, run the `migrate` command:
 
 ```shell
-nx migrate latest # same as nx migrate nx@latest
+nx migrate
 ```
 
 This performs the following changes:
@@ -43,15 +43,62 @@ After you run all the migrations, you can remove `migrations.json` and commit an
 
 Migrating Jest, Cypress, ESLint, React, Angular, Next, and more is a difficult task. All the tools change at different rates, and they can conflict with each other. In addition, every workspace is different. Even though our goal is for you to update any version of Nx to a newer version of Nx in a single go, sometimes it doesn't work. The recommended process is to update, at most, one major version at a time.
 
-Say you want to migrate from Nx 17.1.0 to Nx 18.2.4. The following steps are more likely to work comparing to `nx migrate 18.2.4`.
+Say you want to migrate from Nx 22.1.0 to Nx 23.0.0. The following steps are more likely to work comparing to `nx migrate 23.0.0`.
 
-- Run `nx migrate 17.3.2` to update the latest version in the 17.x branch.
+- Run `nx migrate 22.7.5` to update the latest version in the 22.x branch.
 - Run `nx migrate --run-migrations`.
-- Next, run `nx migrate 18.2.4`.
+- Next, run `nx migrate 23.0.0`.
 - Run `nx migrate --run-migrations`.
 
 {% aside type="caution" title="Angular updates" %}
 If your workspace uses Angular, this becomes a requirement rather than a recommendation. The Angular packages maintain migrations for a single major version at a time. If you try to update over multiple major versions, only the migrations for the latest major version will be applied. This can lead to issues in your workspace.
+{% /aside %}
+
+## Crossing multiple major versions
+
+When the target is more than one major version ahead of your installed version, `nx migrate` prompts you to choose how far to jump: migrate to the latest in your current major (recommended), step into the next major, or go directly to the target. To skip the prompt, use `--multi-major-mode`:
+
+- `--multi-major-mode=gradual` migrates to the smallest recommended step (typically the latest in your current major), then tells you to re-run to continue.
+- `--multi-major-mode=direct` migrates straight to the target.
+
+The `NX_MULTI_MAJOR_MODE` environment variable is equivalent and takes precedence over a `multiMajorMode` value set in `nx.json`. In non-interactive environments there is no prompt - Nx warns that updating one major at a time is recommended and proceeds directly to the target.
+
+## Choosing which packages to migrate
+
+While in most cases you want to be up to date with Nx and the dependencies it manages, sometimes you might need to stay on an older version of such a dependency. For example, you might want to update Nx to the latest version but keep Angular on **v21.x.x** and not update it to **v22.x.x**.
+
+The `--include` flag controls which packages are updated: `required` (the target package and the packages it ships with), `optional` (the dependency updates those packages recommend), or `all` (the default). The interactive `nx migrate` flow prompts for this. Pass `--include` to set it ahead of time.
+
+`--include` applies only when the target package opts into package selection. Nx and its official plugins do starting in Nx 23, and other plugin authors can opt in as well. For targets that don't, Nx uses `all` without prompting, and passing `--include` explicitly errors. Non-interactive runs also default to `all`.
+
+When unsure, prefer `--include=required` and follow up with `--include=optional`. Updating only Nx and its plugins keeps the PR scope small and has less chance of introducing issues, which matters most in large workspaces. Use `--include=all` when you're okay with doing everything in one PR.
+
+{% aside type="note" title="Optional package updates" %}
+You can't choose to skip any arbitrary package update. To ensure that a plugin works well with older versions of a given package, the plugin must support it. Therefore, Nx plugin authors define what package updates are optional.
+{% /aside %}
+
+{% aside type="caution" title="Taking control of package updates" %}
+While opting out of applying some package updates is supported by Nx, please keep in mind that you are effectively taking control of those package updates and opting out of Nx managing them. This means you'll need to keep up with the version requirements for those packages and those that depend on them. You'll also need to consider more things when updating them at some point [as explained later](#updating-dependencies-that-are-behind-the-versions-nx-manages).
+{% /aside %}
+
+### Skipping optional package updates
+
+To skip the optional package updates, generate the migration with `--include=required`:
+
+```shell
+nx migrate --include=required
+```
+
+Only the target package and the packages it ships with are updated. The `package.json` and the `migrations.json` are generated without the optional dependency updates, and you can catch up on those later.
+
+### Updating dependencies that are behind the versions Nx manages
+
+Once you have skipped some optional updates, there'll come a time when you'll want to update those packages. Run `nx migrate --include=optional` to collect the optional dependency updates recommended for your installed version. It anchors to your installed version, so the target package must be installed and you can't migrate to a version higher than what's installed.
+
+The catch-up can be scoped to a single plugin by naming it as the target. For example, `nx migrate @nx/vite --include=optional` collects only the optional updates `@nx/vite` recommends, such as `vite` itself.
+
+{% aside type="caution" title="Scoping to a single plugin" %}
+Some plugin updates depend on other plugins running their updates too. For example, `@nx/angular` sometimes requires the `@nx/js` updates for TypeScript. Scoping the catch-up to a single plugin skips those, so prefer the full `nx migrate --include=optional` when unsure.
 {% /aside %}
 
 ## Managing migration steps
@@ -129,107 +176,20 @@ You can even provide a custom location for the migrations file if you wish, you 
 nx migrate --run-migrations=migrations.json
 ```
 
-## Choosing optional package updates to apply
+## Using an AI agent to apply migrations
 
-While in most cases you want to be up to date with Nx and the dependencies it manages, sometimes you might need to stay on an older version of such a dependency. For example, you might want to update Nx to the latest version but keep Angular on **v15.x.x** and not update it to **v16.x.x**. For such scenarios, `nx migrate` allows you to choose what to update using the `--interactive` flag.
+Some migrations ship an AI prompt that an installed agent applies for you. The [agentic flow](/docs/features/automate-updating-dependencies#step-2-run-migrations) is interactive by default, but you can control it with flags:
 
-{% aside type="note" title="Optional package updates" %}
-You can't choose to skip any arbitrary package update. To ensure that a plugin works well with older versions of a given package, the plugin must support it. Therefore, Nx plugin authors define what package updates are optional.
-{% /aside %}
+- `--agentic` enables it and resolves the installed agent. Use `--agentic=claude-code` (or `codex`, `opencode`) to pin one, or `--no-agentic` to disable it.
+- `--validate` / `--no-validate` toggles agent validation of generator-only migrations - on by default when the agentic flow is enabled.
 
-{% aside type="caution" title="Taking control of package updates" %}
-While opting out of applying some package updates is supported by Nx, please keep in mind that you are effectively taking control of those package updates and opting out of Nx managing them. This means you'll need to keep up with the version requirements for those packages and those that depend on them. You'll also need to consider more things when updating them at some point [as explained later](#updating-dependencies-that-are-behind-the-versions-nx-manages).
-{% /aside %}
+A non-interactive `--agentic` run warns and continues without the agent, since the flow requires an interactive terminal. When the flow is enabled, Nx commits each migration separately by default so the agent can review an isolated diff.
 
-### Interactively opting out of package updates
+To always use the agentic flow (or a specific agent) without passing the flag, set the `agentic` and `validate` options in the [`migrate` section of `nx.json`](/docs/reference/nx-json#migrate).
 
-To opt out of package updates, you need to run the migration in interactive mode:
+## Workspace-wide migrate defaults
 
-```shell
-nx migrate latest --interactive
-```
-
-As the migration runs and collects the package updates, you'll be prompted to apply optional package updates, and you can choose what to do based on your needs. The `package.json` will be updated and the `migrations.json` will be generated considering your responses to those prompts.
-
-### Updating dependencies that are behind the versions Nx manages
-
-Once you have skipped some optional updates, there'll come a time when you'll want to update those packages. To do so, you'll need to generate the package updates and migrations from the Nx version that contained those skipped updates.
-
-Say you skipped updating Angular to **v16.x.x**. That package update was meant to happen as part of the `@nx/angular@16.1.0` update, but you decided to skip it at the time. The recommended way to collect the migrations from such an older version is to run the following:
-
-```shell
-nx migrate latest --from=nx@16.0.0 --exclude-applied-migrations
-```
-
-A couple of things are happening there:
-
-- The `--from=nx@16.0.0` flag tells the `migrate` command to use the version **16.0.0** as the installed version for the `nx` package and all the first-party Nx plugins. Note we use a version lower than the one where the update was meant to happen. This is to account for the fact that the update is normally targeted to a prerelease version for testing it before the final release.
-- The `--exclude-applied-migrations` flag tells the `migrate` command not to collect migrations that should have been applied on previous updates.
-
-So, the above command will effectively collect any package update and migration meant to run if your workspace had `nx@16.0.0` installed while excluding those that should have been applied before. You can provide a different older version to collect migrations from.
-
-{% aside type="caution" title="Automatically excluding previously applied migrations" %}
-Automatically excluding previously applied migrations doesn't consider migrations manually removed from the `migrations.json` in previous updates. If you've manually removed migrations in the past and want to run them, don't pass the `--exclude-applied-migrations` and collect all previous migrations.
-{% /aside %}
-
-### Identifying the Nx version to migrate from to collect previously skipped updates
-
-After running the migrations in interactive mode and opting-out of some package updates, a message is printed to the terminal with the command to run later to collect and apply those skipped updates. For example, if you skipped updating Angular to **v16.0.0**, this is the output you'll see (simplified for brevity):
-
-```shell
-nx migrate latest --interactive
-Fetching meta data about packages.
-It may take a few minutes.
-...
-✔ Do you want to update to TypeScript v5.0? (Y/n) · false
-✔ Do you want to update the Angular version to v16? (Y/n) · false
-
-NX   The migrate command has run successfully.
-
-- package.json has been updated.
-- migrations.json has been generated.
-
-NX   Next steps:
-
-- Make sure package.json changes make sense and then run 'pnpm install --no-frozen-lockfile',
-- Run 'pnpm exec nx migrate --run-migrations'
-- You opted out of some migrations for now. Write the following command down somewhere to apply these migrations later:
-- nx migrate 16.5.3 --from nx@16.1.0-beta.0 --exclude-applied-migrations
-- To learn more go to https://nx.dev/recipes/other/advanced-update
-```
-
-You can see in the "Next steps" section a suggested command to run to apply the skipped package updates. Make sure to store that information somewhere so you can later remember from which version you need to run the migration to apply the skipped package updates.
-
-Please note the suggested command is only based on a particular run of the `nx migrate` command. If you've skipped package updates in previous runs, you'll need to use the oldest version you've stored that you haven't yet run the migration from.
-
-If you don't have the command and need to find out from which version to run the migration, you can take a look at the `migrations.json` file of the relevant package. For example, if you skipped updating Angular to **v16.0.0**, you can take a look at the `migrations.json` file of the `@nx/angular` package and you'll find the following:
-
-```jsonc
-// node_modules/@nx/angular/migrations.json
-{
-  // ...
-  "packageJsonUpdates": {
-    // ...
-    "16.1.0": {
-      "version": "16.1.0-beta.1",
-      "x-prompt": "Do you want to update the Angular version to v16?",
-      "requires": {
-        "@angular/core": ">=15.2.0 <16.0.0",
-      },
-      "packages": {
-        "@angular/core": {
-          "version": "~16.0.0",
-          "alwaysAddToPackageJson": true,
-        },
-        // ...
-      },
-    },
-    // ...
-  },
-}
-```
-
-You can see the `16.1.0-beta.1` version is the one that contains the update for `@angular/core` to **~16.0.0**. That's the version you need to run the migration from to apply the package update.
+To avoid passing the same flags on every run, set defaults in the [`migrate` section of `nx.json`](/docs/reference/nx-json#migrate) - `createCommits`, `commitPrefix`, `include`, `multiMajorMode`, `agentic`, and `validate`. A command-line flag always overrides the `nx.json` value, which in turn overrides the built-in Nx defaults.
 
 ## Other advanced capabilities
 
@@ -238,13 +198,13 @@ You can see the `16.1.0-beta.1` version is the one that contains the update for 
 Sometimes, you may want to use a different version of a package than what Nx recommends. To do that, specify the package and version:
 
 ```shell
-nx migrate latest --to="jest@22.0.0,cypress@3.4.0"
+nx migrate --to="jest@22.0.0,cypress@3.4.0"
 ```
 
 By default, Nx uses currently installed packages to calculate what migrations need to run. To override them, override the version:
 
 ```shell
-nx migrate latest --to="@nx/jest@12.0.0"
+nx migrate --to="@nx/jest@12.0.0"
 ```
 
 {% aside type="caution" title="Overriding versions" %}

--- a/astro-docs/src/content/docs/knowledge-base/installation-and-updates/index.mdoc
+++ b/astro-docs/src/content/docs/knowledge-base/installation-and-updates/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Installation and updates
+description: Installation and update guides for Nx
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Knowledge Base/Installation and updates" /%}

--- a/astro-docs/src/content/docs/knowledge-base/installation/index.mdoc
+++ b/astro-docs/src/content/docs/knowledge-base/installation/index.mdoc
@@ -1,9 +1,0 @@
----
-title: Installation
-description: Installation guides for Nx
-sidebar:
-  hidden: true
-pagefind: false
----
-
-{% sidebar_group_cards group="Knowledge Base/Installation" /%}

--- a/astro-docs/src/content/docs/technologies/angular/Guides/nx-and-angular.mdoc
+++ b/astro-docs/src/content/docs/technologies/angular/Guides/nx-and-angular.mdoc
@@ -197,7 +197,7 @@ What's the difference?
 - Fix migrations that "almost work".
 - Commit a partially migrated state.
 - Change versions of packages to match org requirements.
-- [Opt out of Angular updates when updating Nx versions](/docs/guides/tips-n-tricks/advanced-update#choosing-optional-package-updates-to-apply) as long as [the Angular version is still supported](/docs/technologies/angular/guides/angular-nx-version-matrix)
+- [Opt out of Angular updates when updating Nx versions](/docs/guides/tips-n-tricks/advanced-update#choosing-which-packages-to-migrate) as long as [the Angular version is still supported](/docs/technologies/angular/guides/angular-nx-version-matrix)
 
 `nx migrate` does this by splitting the process into two steps. `nx migrate latest` creates a `migrations.json` file with a list of all the migrations needed by Nx, Angular, and other packages. You can then modify that file before running `nx migrate --run-migrations` to execute those migrations.
 


### PR DESCRIPTION
This PR updates our docs to include new `nx migrate` features from v23.

Recommend running bare `nx migrate` (Nx 23+) and document the new behavior:

- **Installation** lead with `nx migrate` and point to `Automate updating dependencies` feature page.
- **Automate updating dependencies** adds the `--include=required|optional|all` flag and agentic flow.
- **Advanced Update** documents `--include`, `--multi-major-mode`, `--agentic` / `--validate`, and the `nx.json` `migrate` defaults.
- **Nx Console Migrate UI** documents the AI badge and the prompt-only / hybrid card states.

Also moved advanced guide and Nx Console Migrate UI to Knowledge Base as to not clutter up the feature sidebar section. The advanced guide is linked to from the migrate feature page.

<img width="498" height="389" alt="image" src="https://github.com/user-attachments/assets/6d828555-4cfc-4be0-9ac4-4b36258781c4" />

## Preview

- https://deploy-preview-35917--nx-docs.netlify.app/docs/getting-started/installation
- https://deploy-preview-35917--nx-docs.netlify.app/docs/features/automate-updating-dependencies
- https://deploy-preview-35917--nx-docs.netlify.app/docs/guides/tips-n-tricks/advanced-update
- https://deploy-preview-35917--nx-docs.netlify.app/docs/guides/nx-console/console-migrate-ui

## Related Issue(s)

NXC-4453

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/docs-agentic--migrate-de6a34c5)
<!-- polygraph-session-end -->