### PR TITLE
chore(repo): migrate remaining 4 packages to nodenext module resolution

### DIFF
--- a/packages/angular-rspack-compiler/eslint.config.mjs
+++ b/packages/angular-rspack-compiler/eslint.config.mjs
@@ -30,6 +30,10 @@ export default [
           ],
           ignoredDependencies: [
             '@angular/core',
+            // Loaded via a dynamic runtime import in load-compiler-cli.ts (its
+            // nodenext-incompatible types are shimmed locally), so static
+            // analysis can't see the usage.
+            '@angular/compiler-cli',
             'jsonc-eslint-parser',
             'semver',
             'vitest',

--- a/packages/angular-rspack-compiler/package.json
+++ b/packages/angular-rspack-compiler/package.json
@@ -32,6 +32,7 @@
   "module": "./dist/index.js",
   "exports": {
     ".": {
+      "@nx/nx-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     }

--- a/packages/angular-rspack-compiler/src/compilation/augments.ts
+++ b/packages/angular-rspack-compiler/src/compilation/augments.ts
@@ -24,10 +24,26 @@
  */
 
 import * as ts from 'typescript';
-import { type CompilerHost as AngularCompilerHost } from '@angular/compiler-cli';
 import { normalize } from 'path';
 import { createHash } from 'node:crypto';
 import { InlineStyleLanguage } from '../models';
+
+/**
+ * Minimal local shape of `@angular/compiler-cli`'s `CompilerHost`. Hand-declared
+ * because the package's `"type": "module"` typings don't resolve those members
+ * under `nodenext`; we only need the resource hooks below.
+ */
+interface AngularCompilerHost extends ts.CompilerHost {
+  readResource?(fileName: string): string | Promise<string>;
+  transformResource?(
+    data: string,
+    context: {
+      type: string;
+      containingFile: string;
+      resourceFile?: string | null;
+    }
+  ): Promise<{ content: string } | null>;
+}
 
 /**
  *

--- a/packages/angular-rspack-compiler/src/utils/load-compiler-cli.ts
+++ b/packages/angular-rspack-compiler/src/utils/load-compiler-cli.ts
@@ -1,7 +1,20 @@
+import type * as ts from 'typescript';
+
+/**
+ * Minimal shape of `@angular/compiler-cli` that we consume. Hand-declared
+ * because the package ships `"type": "module"` typings whose extensionless
+ * `export *` re-exports don't resolve under `nodenext`, so `readConfiguration`
+ * is not visible via `typeof import('@angular/compiler-cli')`.
+ */
+interface AngularCompilerCli {
+  readConfiguration(
+    project: string,
+    existingOptions?: ts.CompilerOptions
+  ): { options: ts.CompilerOptions; rootNames: readonly string[] };
+}
+
 let load;
-export function loadCompilerCli(): Promise<
-  typeof import('@angular/compiler-cli')
-> {
+export function loadCompilerCli(): Promise<AngularCompilerCli> {
   load ??= new Function('', `return import('@angular/compiler-cli');`);
   return load().catch((e) => {
     throw new Error(

--- a/packages/angular-rspack-compiler/tsconfig.lib.json
+++ b/packages/angular-rspack-compiler/tsconfig.lib.json
@@ -1,15 +1,15 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "rootDir": "src",
     "outDir": "dist",
     "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
     "emitDeclarationOnly": false,
     "types": ["node"],
-    "module": "commonjs",
     "target": "ES2020",
-    "moduleResolution": "Node",
+    "composite": true,
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "noImplicitAny": false,
     "importHelpers": true,
     "noUnusedLocals": false,

--- a/packages/angular-rspack/package.json
+++ b/packages/angular-rspack/package.json
@@ -29,18 +29,22 @@
   "typings": "./dist/lib/index.d.ts",
   "exports": {
     ".": {
+      "@nx/nx-source": "./src/lib/index.ts",
       "types": "./dist/lib/index.d.ts",
       "default": "./dist/lib/index.js"
     },
     "./loaders/angular-partial-transform-loader": {
+      "@nx/nx-source": "./src/lib/plugins/loaders/angular-partial-transform.loader.ts",
       "types": "./dist/lib/plugins/loaders/angular-partial-transform.loader.d.ts",
       "default": "./dist/lib/plugins/loaders/angular-partial-transform.loader.js"
     },
     "./loaders/angular-loader": {
+      "@nx/nx-source": "./src/lib/plugins/loaders/angular-transform.loader.ts",
       "types": "./dist/lib/plugins/loaders/angular-transform.loader.d.ts",
       "default": "./dist/lib/plugins/loaders/angular-transform.loader.js"
     },
     "./loaders/platform-server-exports-loader": {
+      "@nx/nx-source": "./src/lib/plugins/loaders/platform-server-exports.loader.ts",
       "types": "./dist/lib/plugins/loaders/platform-server-exports.loader.d.ts",
       "default": "./dist/lib/plugins/loaders/platform-server-exports.loader.js"
     }

--- a/packages/angular-rspack/src/lib/plugins/tools/render-worker.ts
+++ b/packages/angular-rspack/src/lib/plugins/tools/render-worker.ts
@@ -74,13 +74,15 @@ async function render({
   const outputFolderPath = path.join(outputPath, route);
   const outputIndexPath = path.join(outputFolderPath, 'index.html');
 
+  // rspack emits a CommonJS server bundle; load with `require` so its named
+  // exports resolve (a nodenext `import()` would leave them undefined).
   const {
     ɵSERVER_CONTEXT,
     AppServerModule,
     renderModule,
     renderApplication,
     default: bootstrapAppFn,
-  } = (await import(serverBundlePath)) as ServerBundleExports;
+  } = require(serverBundlePath) as ServerBundleExports;
 
   assert(
     ɵSERVER_CONTEXT,

--- a/packages/angular-rspack/src/lib/plugins/tools/routes-extractor-worker.ts
+++ b/packages/angular-rspack/src/lib/plugins/tools/routes-extractor-worker.ts
@@ -35,11 +35,13 @@ const { zonePackage, serverBundlePath, outputPath, indexFile } =
   workerData as RoutesExtractorWorkerData;
 
 async function extract(): Promise<string[]> {
+  // rspack emits a CommonJS server bundle; load with `require` so its named
+  // exports resolve (a nodenext `import()` would leave them undefined).
   const {
     AppServerModule,
     ɵgetRoutesFromAngularRouterConfig: getRoutesFromAngularRouterConfig,
     default: bootstrapAppFn,
-  } = (await import(serverBundlePath)) as ServerBundleExports;
+  } = require(serverBundlePath) as ServerBundleExports;
 
   const browserIndexInputPath = path.join(outputPath, indexFile);
   const document = await fs.promises.readFile(browserIndexInputPath, 'utf8');

--- a/packages/angular-rspack/tsconfig.lib.json
+++ b/packages/angular-rspack/tsconfig.lib.json
@@ -1,14 +1,14 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "rootDir": "src",
     "outDir": "dist",
     "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
     "emitDeclarationOnly": false,
     "types": ["node"],
-    "module": "commonjs",
-    "moduleResolution": "node",
+    "composite": true,
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "noImplicitAny": false,
     "noUnusedLocals": false,
     "esModuleInterop": true,

--- a/packages/dotnet/package.json
+++ b/packages/dotnet/package.json
@@ -26,6 +26,7 @@
   "type": "commonjs",
   "exports": {
     ".": {
+      "@nx/nx-source": "./src/index.ts",
       "default": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
@@ -37,7 +38,7 @@
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
-  "typings": "./dist/src/index.d.ts",
+  "typings": "./dist/index.d.ts",
   "files": [
     "dist",
     "generators.json",

--- a/packages/dotnet/tsconfig.lib.json
+++ b/packages/dotnet/tsconfig.lib.json
@@ -1,15 +1,15 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "rootDir": "src",
     "outDir": "dist",
     "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
     "emitDeclarationOnly": false,
     "declaration": true,
     "types": ["node"],
-    "module": "commonjs",
-    "moduleResolution": "node"
+    "composite": true,
+    "module": "nodenext",
+    "moduleResolution": "nodenext"
   },
   "include": ["src/**/*.ts", "plugin.ts"],
   "exclude": ["**/*.spec.ts", "**/*.test.ts", "dist/**/*"],

--- a/packages/maven/package.json
+++ b/packages/maven/package.json
@@ -17,6 +17,7 @@
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
+      "@nx/nx-source": "./src/index.ts",
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
     },

--- a/packages/maven/tsconfig.lib.json
+++ b/packages/maven/tsconfig.lib.json
@@ -1,14 +1,14 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "baseUrl": ".",
     "rootDir": "src",
     "outDir": "dist",
     "tsBuildInfoFile": "dist/tsconfig.lib.tsbuildinfo",
     "emitDeclarationOnly": false,
     "types": ["node"],
-    "module": "commonjs",
-    "moduleResolution": "node",
+    "composite": true,
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "noImplicitAny": false,
     "noUnusedLocals": false,
     "esModuleInterop": true,


### PR DESCRIPTION
## Current Behavior

The last four publishable packages still on the old layout — `@nx/maven`, `@nx/dotnet`, `@nx/angular-rspack`, and `@nx/angular-rspack-compiler` — build with classic `module: commonjs` / `moduleResolution: node` and inherit `baseUrl`. They were never on the main local-dist migration board, so they're the only first-party packages left on classic resolution. This blocks moving the workspace to a single compiler (tsgo / TS7), which hard-errors on both classic `node10` resolution (`TS5108`) and `baseUrl` (`TS5102`).

## Expected Behavior

All four packages build with `nodenext` module resolution and expose the `@nx/nx-source` export condition, matching the already-migrated packages — so every first-party package is now on `nodenext`. `rootDir: src` is intentionally kept (rather than `.`) so the generators/executors/migrations manifest paths and the `versions.ts` self-reference don't need rewriting; it's functionally identical for the compiler.

Two nodenext-specific fixes were required:

- **`@nx/angular-rspack-compiler`**: `@angular/compiler-cli` ships `"type": "module"` typings whose extensionless `export *` chains don't resolve under nodenext, so `CompilerHost` / `readConfiguration` come back as "no exported member". They're replaced with minimal local type declarations. The package is now only referenced via a dynamic runtime import, so it's added to the dependency-checks `ignoredDependencies`.
- **`@nx/angular-rspack`**: the render and routes-extractor workers loaded the rspack-built CommonJS server bundle via `await import(serverBundlePath)`. Under `commonjs` that downleveled to `require()`, which exposes the bundle's named exports (`ɵSERVER_CONTEXT`, `ɵgetRoutesFromAngularRouterConfig`); under `nodenext` it stays a true ESM import and those resolve as `undefined`, breaking the angular-rspack SSR/SSG example builds. They now load the bundle with `require()`.

Validated with `nx affected -t build,lint,test` — 21 projects / 121 tasks green, including all 14 `@nx/angular-rspack` example apps.

The actual tsgo compiler flip (re-add `@typescript/native-preview`, drop the base `baseUrl`, set `strict: false`, set `compiler: "tsgo"` on the `@nx/js/typescript` plugin) is a separate follow-up.

## Related Issue(s)

Implements Linear NXC-4538 (auto-linked via the branch name). Follow-up: NXC-4539 enables tsgo workspace-wide. No GitHub issue to close.
