### PR TITLE
chore(repo): exclude .NET assets cache from writes tracking

### DIFF
--- a/.nx/workflows/sandboxing-config.yaml
+++ b/.nx/workflows/sandboxing-config.yaml
@@ -2,6 +2,7 @@ exclude-reads:
   - packages/nx/src/native/*.node
   - packages/nx/dist/src/native/*.node
   - 'dist/target/**'
+  - 'packages/dotnet/**/*.assets.cache'
 exclude-writes:
   - '**/.swc/**'
   - 'dist/target/**'


### PR DESCRIPTION
## Current Behavior
When the .net unit tests projects miss the cache, but the base project hits it there can be a stale assets.cache in the intermediate outputs that is overwritten... this is flagged as a sandboxing violation but is known to be fine.

## Expected Behavior
The violation is not present.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #NXC-4521
