### PR TITLE
chore(core): rename supportsOptionalUpdates to supportsOptionalMigrations

### DIFF
--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -68,7 +68,7 @@
   "ng-update": {
     "requirements": {},
     "migrations": "./migrations.json",
-    "supportsOptionalUpdates": true
+    "supportsOptionalMigrations": true
   },
   "dependencies": {
     "@nx/devkit": "workspace:*",

--- a/packages/cypress/package.json
+++ b/packages/cypress/package.json
@@ -82,7 +82,7 @@
   "ng-update": {
     "requirements": {},
     "migrations": "./migrations.json",
-    "supportsOptionalUpdates": true
+    "supportsOptionalMigrations": true
   },
   "dependencies": {
     "@nx/devkit": "workspace:*",

--- a/packages/detox/package.json
+++ b/packages/detox/package.json
@@ -59,7 +59,7 @@
   "ng-update": {
     "requirements": {},
     "migrations": "./migrations.json",
-    "supportsOptionalUpdates": true
+    "supportsOptionalMigrations": true
   },
   "generators": "./generators.json",
   "publishConfig": {

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -70,7 +70,7 @@
   },
   "nx-migrations": {
     "migrations": "./migrations.json",
-    "supportsOptionalUpdates": true
+    "supportsOptionalMigrations": true
   },
   "exports": {
     ".": {

--- a/packages/docker/package.json
+++ b/packages/docker/package.json
@@ -81,7 +81,7 @@
   },
   "nx-migrations": {
     "migrations": "./migrations.json",
-    "supportsOptionalUpdates": true
+    "supportsOptionalMigrations": true
   },
   "executors": "./executors.json",
   "generators": "./generators.json",

--- a/packages/dotnet/package.json
+++ b/packages/dotnet/package.json
@@ -68,6 +68,6 @@
   "generators": "./generators.json",
   "nx-migrations": {
     "migrations": "./migrations.json",
-    "supportsOptionalUpdates": true
+    "supportsOptionalMigrations": true
   }
 }

--- a/packages/esbuild/package.json
+++ b/packages/esbuild/package.json
@@ -38,7 +38,7 @@
   "ng-update": {
     "requirements": {},
     "migrations": "./migrations.json",
-    "supportsOptionalUpdates": true
+    "supportsOptionalMigrations": true
   },
   "dependencies": {
     "@nx/devkit": "workspace:*",

--- a/packages/eslint-plugin/package.json
+++ b/packages/eslint-plugin/package.json
@@ -49,7 +49,7 @@
   "homepage": "https://nx.dev",
   "nx-migrations": {
     "migrations": "./migrations.json",
-    "supportsOptionalUpdates": true
+    "supportsOptionalMigrations": true
   },
   "exports": {
     ".": {

--- a/packages/eslint/package.json
+++ b/packages/eslint/package.json
@@ -46,7 +46,7 @@
   "ng-update": {
     "requirements": {},
     "migrations": "./migrations.json",
-    "supportsOptionalUpdates": true
+    "supportsOptionalMigrations": true
   },
   "generators": "./generators.json",
   "executors": "./executors.json",

--- a/packages/expo/package.json
+++ b/packages/expo/package.json
@@ -88,7 +88,7 @@
   "ng-update": {
     "requirements": {},
     "migrations": "./migrations.json",
-    "supportsOptionalUpdates": true
+    "supportsOptionalMigrations": true
   },
   "generators": "./generators.json",
   "publishConfig": {

--- a/packages/express/package.json
+++ b/packages/express/package.json
@@ -37,7 +37,7 @@
   "ng-update": {
     "requirements": {},
     "migrations": "./migrations.json",
-    "supportsOptionalUpdates": true
+    "supportsOptionalMigrations": true
   },
   "dependencies": {
     "@nx/devkit": "workspace:*",

--- a/packages/gradle/package.json
+++ b/packages/gradle/package.json
@@ -73,7 +73,7 @@
   },
   "nx-migrations": {
     "migrations": "./migrations.json",
-    "supportsOptionalUpdates": true
+    "supportsOptionalMigrations": true
   },
   "dependencies": {
     "@nx/devkit": "workspace:*",

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -58,7 +58,7 @@
   "ng-update": {
     "requirements": {},
     "migrations": "./migrations.json",
-    "supportsOptionalUpdates": true
+    "supportsOptionalMigrations": true
   },
   "exports": {
     ".": {

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -65,7 +65,7 @@
   "ng-update": {
     "requirements": {},
     "migrations": "./migrations.json",
-    "supportsOptionalUpdates": true
+    "supportsOptionalMigrations": true
   },
   "generators": "./generators.json",
   "executors": "./executors.json",

--- a/packages/maven/package.json
+++ b/packages/maven/package.json
@@ -30,7 +30,7 @@
   "executors": "./executors.json",
   "nx-migrations": {
     "migrations": "./migrations.json",
-    "supportsOptionalUpdates": true
+    "supportsOptionalMigrations": true
   },
   "files": [
     "dist",

--- a/packages/module-federation/package.json
+++ b/packages/module-federation/package.json
@@ -152,7 +152,7 @@
   },
   "nx-migrations": {
     "migrations": "./migrations.json",
-    "supportsOptionalUpdates": true
+    "supportsOptionalMigrations": true
   },
   "publishConfig": {
     "access": "public"

--- a/packages/nest/package.json
+++ b/packages/nest/package.json
@@ -37,7 +37,7 @@
   "ng-update": {
     "requirements": {},
     "migrations": "./migrations.json",
-    "supportsOptionalUpdates": true
+    "supportsOptionalMigrations": true
   },
   "exports": {
     ".": {

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -65,7 +65,7 @@
   "ng-update": {
     "requirements": {},
     "migrations": "./migrations.json",
-    "supportsOptionalUpdates": true
+    "supportsOptionalMigrations": true
   },
   "peerDependencies": {
     "next": ">=14.0.0 <17.0.0"

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -47,7 +47,7 @@
   "ng-update": {
     "requirements": {},
     "migrations": "./migrations.json",
-    "supportsOptionalUpdates": true
+    "supportsOptionalMigrations": true
   },
   "exports": {
     ".": {

--- a/packages/nuxt/package.json
+++ b/packages/nuxt/package.json
@@ -56,7 +56,7 @@
   },
   "nx-migrations": {
     "migrations": "./migrations.json",
-    "supportsOptionalUpdates": true
+    "supportsOptionalMigrations": true
   },
   "dependencies": {
     "tslib": "catalog:typescript",

--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -160,7 +160,7 @@
         "version": "latest"
       }
     ],
-    "supportsOptionalUpdates": true
+    "supportsOptionalMigrations": true
   },
   "generators": "./generators.json",
   "executors": "./executors.json",

--- a/packages/nx/src/command-line/migrate/migrate.spec.ts
+++ b/packages/nx/src/command-line/migrate/migrate.spec.ts
@@ -86,12 +86,12 @@ const createPackageJson = (
   ...overrides,
 });
 
-// Stub fetcher driving the `--include` supportsOptionalUpdates gate without the
-// registry/install round-trip. `supportsOptionalUpdates` defaults to true; pass a
+// Stub fetcher driving the `--include` supportsOptionalMigrations gate without the
+// registry/install round-trip. `supportsOptionalMigrations` defaults to true; pass a
 // predicate to mark specific (package, version) targets unsupported.
 const includeGateFetch =
   (
-    supportsOptionalUpdates:
+    supportsOptionalMigrations:
       | boolean
       | ((pkg: string, version: string) => boolean) = true
   ): ((
@@ -102,10 +102,10 @@ const includeGateFetch =
     Promise.resolve({
       name: pkg,
       version,
-      supportsOptionalUpdates:
-        typeof supportsOptionalUpdates === 'function'
-          ? supportsOptionalUpdates(pkg, version)
-          : supportsOptionalUpdates,
+      supportsOptionalMigrations:
+        typeof supportsOptionalMigrations === 'function'
+          ? supportsOptionalMigrations(pkg, version)
+          : supportsOptionalMigrations,
     });
 
 describe('Migration', () => {
@@ -2645,7 +2645,7 @@ describe('Migration', () => {
     });
 
     it('should gate --include=optional on the installed version, not the older explicit target', async () => {
-      // Catch-up reads `supportsOptionalUpdates` at the INSTALLED version (what you
+      // Catch-up reads `supportsOptionalMigrations` at the INSTALLED version (what you
       // have), not the older explicit target. The stub only marks 23.0.0 as
       // supporting optional updates, so eligibility proves the gate read installed 23,
       // even though the target 22 predates the flag.
@@ -2684,7 +2684,7 @@ describe('Migration', () => {
     });
 
     it('should surface a fetch failure instead of reporting the target as unsupported', async () => {
-      // The gate resolves `supportsOptionalUpdates` through the shared fetcher (registry,
+      // The gate resolves `supportsOptionalMigrations` through the shared fetcher (registry,
       // then install). A genuine fetch failure must surface as-is, not be
       // swallowed into a misleading "does not support optional updates" rejection.
       mockGetInstalledNxVersion.mockReturnValue('23.0.0');
@@ -3047,7 +3047,7 @@ describe('Migration', () => {
       });
     });
 
-    const supportsOptionalUpdatesContext = {
+    const supportsOptionalMigrationsContext = {
       hasFrom: false,
       hasExcludeAppliedMigrations: false,
       targetSupportsOptionalUpdates: true,
@@ -3061,14 +3061,14 @@ describe('Migration', () => {
       process.env.CI = 'false';
       const result = await resolveInclude(
         'required',
-        supportsOptionalUpdatesContext
+        supportsOptionalMigrationsContext
       );
       expect(result).toBe('required');
       expect(mockPrompt).not.toHaveBeenCalled();
     });
 
     it('should return the provided include even when the target does not support optional updates', async () => {
-      // The `supportsOptionalUpdates` gate is enforced in `resolveTargetAndInclude`;
+      // The `supportsOptionalMigrations` gate is enforced in `resolveTargetAndInclude`;
       // `resolveInclude` honors an explicit include as-is.
       const result = await resolveInclude('required', {
         hasFrom: false,
@@ -3086,7 +3086,7 @@ describe('Migration', () => {
       process.env.CI = 'false';
       const result = await resolveInclude(
         undefined,
-        supportsOptionalUpdatesContext
+        supportsOptionalMigrationsContext
       );
       expect(result).toBe('all');
       expect(mockPrompt).not.toHaveBeenCalled();
@@ -3100,7 +3100,7 @@ describe('Migration', () => {
       process.env.CI = 'true';
       const result = await resolveInclude(
         undefined,
-        supportsOptionalUpdatesContext
+        supportsOptionalMigrationsContext
       );
       expect(result).toBe('all');
       expect(mockPrompt).not.toHaveBeenCalled();
@@ -3113,7 +3113,7 @@ describe('Migration', () => {
       });
       process.env.CI = 'false';
       const result = await resolveInclude(undefined, {
-        ...supportsOptionalUpdatesContext,
+        ...supportsOptionalMigrationsContext,
         interactive: false,
       });
       expect(result).toBe('all');
@@ -3144,7 +3144,7 @@ describe('Migration', () => {
       mockPrompt.mockReturnValueOnce(Promise.resolve({ include: 'required' }));
       const result = await resolveInclude(
         undefined,
-        supportsOptionalUpdatesContext
+        supportsOptionalMigrationsContext
       );
       expect(result).toBe('required');
       expect(mockPrompt).toHaveBeenCalled();
@@ -3157,7 +3157,7 @@ describe('Migration', () => {
       });
       process.env.CI = 'false';
       mockPrompt.mockReturnValueOnce(Promise.resolve({ include: 'all' }));
-      await resolveInclude(undefined, supportsOptionalUpdatesContext);
+      await resolveInclude(undefined, supportsOptionalMigrationsContext);
       const choices = mockPrompt.mock.calls[0][0].choices;
       expect(choices.map((c: { name: string }) => c.name)).toEqual([
         'required',
@@ -3212,7 +3212,7 @@ describe('Migration', () => {
       process.env.CI = 'false';
       mockPrompt.mockReturnValueOnce(Promise.resolve({ include: 'all' }));
       await resolveInclude(undefined, {
-        ...supportsOptionalUpdatesContext,
+        ...supportsOptionalMigrationsContext,
         interactive: true,
       });
       const choices = mockPrompt.mock.calls[0][0].choices;
@@ -3230,7 +3230,7 @@ describe('Migration', () => {
       process.env.CI = 'false';
       const result = await resolveInclude(
         undefined,
-        supportsOptionalUpdatesContext,
+        supportsOptionalMigrationsContext,
         'required'
       );
       expect(result).toBe('required');
@@ -3245,7 +3245,7 @@ describe('Migration', () => {
       process.env.CI = 'true';
       const result = await resolveInclude(
         undefined,
-        supportsOptionalUpdatesContext,
+        supportsOptionalMigrationsContext,
         'required'
       );
       expect(result).toBe('required');
@@ -3260,7 +3260,7 @@ describe('Migration', () => {
       process.env.CI = 'false';
       const result = await resolveInclude(
         'all',
-        supportsOptionalUpdatesContext,
+        supportsOptionalMigrationsContext,
         'required'
       );
       expect(result).toBe('all');

--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -156,8 +156,8 @@ export { normalizeVersion };
 
 export interface ResolvedMigrationConfiguration extends MigrationsJson {
   packageGroup?: ArrayPackageGroup;
-  /** Mirrors the package's `nx-migrations`/`ng-update` `supportsOptionalUpdates` flag. */
-  supportsOptionalUpdates?: boolean;
+  /** Mirrors the package's `nx-migrations`/`ng-update` `supportsOptionalMigrations` flag. */
+  supportsOptionalMigrations?: boolean;
   /** Prompt file contents keyed by the `prompt` value as it appears on the migration entry. */
   resolvedPromptFiles?: Record<string, string>;
 }
@@ -975,12 +975,12 @@ export async function resolveInclude(
   },
   configuredInclude?: MigrateInclude
 ): Promise<MigrateInclude> {
-  // An explicit `--include` is validated against the target's `supportsOptionalUpdates` in
+  // An explicit `--include` is validated against the target's `supportsOptionalMigrations` in
   // `resolveTargetAndInclude`, so honor it directly here.
   if (include) {
     return include;
   }
-  // Targets that don't declare `supportsOptionalUpdates` only ever run the full
+  // Targets that don't declare `supportsOptionalMigrations` only ever run the full
   // migration; there is nothing to pick between.
   if (!context.targetSupportsOptionalUpdates) {
     if (configuredInclude && configuredInclude !== 'all') {
@@ -1182,7 +1182,7 @@ export async function parseMigrationsOptions(
       : Promise.resolve({} as Record<string, string>),
   ]);
 
-  // The gate reads `supportsOptionalUpdates` through this fetcher (registry-first, install
+  // The gate reads `supportsOptionalMigrations` through this fetcher (registry-first, install
   // fallback) so private registries don't fail closed. In production the caller
   // shares its fetcher; standalone callers (tests) get a fresh one.
   const resolvedFetch = fetch ?? createFetcher(getPackageManagerCommand());
@@ -1315,7 +1315,7 @@ async function resolveTargetAndInclude(args: {
     targetVersion = 'latest';
   }
 
-  // Resolve dist-tags to a concrete version so the `supportsOptionalUpdates` gate and the
+  // Resolve dist-tags to a concrete version so the `supportsOptionalMigrations` gate and the
   // downstream cascade read a real semver. Explicit dist-tags arrive already
   // resolved from `parseTargetPackageAndVersion`; only bare invocations and
   // bare package names (`nx migrate nx`) reach here unresolved.
@@ -1336,13 +1336,13 @@ async function resolveTargetAndInclude(args: {
     }
   }
 
-  // `--include` is only available for targets that opt in via `supportsOptionalUpdates`.
+  // `--include` is only available for targets that opt in via `supportsOptionalMigrations`.
   // required/all/prompt/nx.json read the flag at the version being migrated
   // to. Skipped when the include value can't depend on it (no `--include`, no nx.json
   // default, no interactive prompt) and for the explicit `optional` value, which
   // anchors to the installed target and reads at that version below.
   let targetSupportsOptionalUpdates = false;
-  // The package/version whose `supportsOptionalUpdates` flag the gate actually read,
+  // The package/version whose `supportsOptionalMigrations` flag the gate actually read,
   // surfaced verbatim in the rejection message below.
   let eligibilityPackage = targetPackage;
   let eligibilityVersion = targetVersion;
@@ -1435,7 +1435,7 @@ async function resolveTargetAndInclude(args: {
   };
 }
 
-// `--include` is opt-in per package via `supportsOptionalUpdates` in the target's
+// `--include` is opt-in per package via `supportsOptionalMigrations` in the target's
 // `nx-migrations`/`ng-update` config. Read it through the shared fetcher
 // (registry-first, install fallback) so registries that can't serve metadata
 // via `npm view` resolve it from an install rather than failing the gate.
@@ -1445,7 +1445,7 @@ async function fetchSupportsOptionalUpdates(
   packageVersion: string
 ): Promise<boolean> {
   const config = await fetch(packageName, packageVersion);
-  return config.supportsOptionalUpdates === true;
+  return config.supportsOptionalMigrations === true;
 }
 
 // `--include=optional` upper-bound gate. The optional walk catches up from
@@ -1695,7 +1695,7 @@ async function getPackageMigrationsUsingRegistry(
       name: packageName,
       version: packageVersion,
       packageGroup: migrationsConfig.packageGroup,
-      supportsOptionalUpdates: migrationsConfig.supportsOptionalUpdates,
+      supportsOptionalMigrations: migrationsConfig.supportsOptionalMigrations,
     };
   }
 
@@ -1751,7 +1751,7 @@ async function downloadPackageMigrationsFromRegistry(
   {
     migrations: migrationsFilePath,
     packageGroup,
-    supportsOptionalUpdates,
+    supportsOptionalMigrations,
   }: NxMigrationsConfiguration & { packageGroup?: ArrayPackageGroup }
 ): Promise<ResolvedMigrationConfiguration> {
   const { dir, cleanup } = createTempNpmDirectory();
@@ -1794,7 +1794,7 @@ async function downloadPackageMigrationsFromRegistry(
     result = {
       ...migrations,
       packageGroup,
-      supportsOptionalUpdates,
+      supportsOptionalMigrations,
       version: packageVersion,
       ...(resolvedPromptFiles ? { resolvedPromptFiles } : {}),
     };
@@ -1884,7 +1884,7 @@ async function getPackageMigrationsUsingInstallImpl(
     const {
       migrations: migrationsFilePath,
       packageGroup,
-      supportsOptionalUpdates,
+      supportsOptionalMigrations,
       packageJson,
     } = readPackageMigrationConfig(packageName, dir);
 
@@ -1904,7 +1904,7 @@ async function getPackageMigrationsUsingInstallImpl(
     result = {
       ...migrations,
       packageGroup,
-      supportsOptionalUpdates,
+      supportsOptionalMigrations,
       version: packageJson.version,
       ...(resolvedPromptFiles ? { resolvedPromptFiles } : {}),
     };
@@ -1951,14 +1951,14 @@ function readPackageMigrationConfig(
       packageJson: json,
       migrations: migrationFile,
       packageGroup: config.packageGroup,
-      supportsOptionalUpdates: config.supportsOptionalUpdates,
+      supportsOptionalMigrations: config.supportsOptionalMigrations,
     };
   } catch {
     return {
       packageJson: json,
       migrations: null,
       packageGroup: config.packageGroup,
-      supportsOptionalUpdates: config.supportsOptionalUpdates,
+      supportsOptionalMigrations: config.supportsOptionalMigrations,
     };
   }
 }

--- a/packages/nx/src/utils/package-json.spec.ts
+++ b/packages/nx/src/utils/package-json.spec.ts
@@ -886,50 +886,50 @@ catalogs:
 });
 
 describe('readNxMigrateConfig', () => {
-  it('should carry supportsOptionalUpdates from the nx-migrations config', () => {
+  it('should carry supportsOptionalMigrations from the nx-migrations config', () => {
     const config = readNxMigrateConfig({
       'nx-migrations': {
         migrations: './migrations.json',
-        supportsOptionalUpdates: true,
+        supportsOptionalMigrations: true,
       },
     });
 
     expect(config).toMatchObject({
       migrations: './migrations.json',
-      supportsOptionalUpdates: true,
+      supportsOptionalMigrations: true,
     });
   });
 
-  it('should carry supportsOptionalUpdates from the ng-update config', () => {
+  it('should carry supportsOptionalMigrations from the ng-update config', () => {
     const config = readNxMigrateConfig({
       'ng-update': {
         migrations: './migrations.json',
-        supportsOptionalUpdates: true,
+        supportsOptionalMigrations: true,
       },
     });
 
     expect(config).toMatchObject({
       migrations: './migrations.json',
-      supportsOptionalUpdates: true,
+      supportsOptionalMigrations: true,
     });
   });
 
-  it('should not set supportsOptionalUpdates when the config omits it', () => {
+  it('should not set supportsOptionalMigrations when the config omits it', () => {
     const config = readNxMigrateConfig({
       'nx-migrations': { migrations: './migrations.json' },
     });
 
-    expect(config.supportsOptionalUpdates).toBeUndefined();
+    expect(config.supportsOptionalMigrations).toBeUndefined();
   });
 
-  it('should not set supportsOptionalUpdates when the config sets it to false', () => {
+  it('should not set supportsOptionalMigrations when the config sets it to false', () => {
     const config = readNxMigrateConfig({
       'nx-migrations': {
         migrations: './migrations.json',
-        supportsOptionalUpdates: false,
+        supportsOptionalMigrations: false,
       },
     });
 
-    expect(config.supportsOptionalUpdates).toBeUndefined();
+    expect(config.supportsOptionalMigrations).toBeUndefined();
   });
 });

--- a/packages/nx/src/utils/package-json.ts
+++ b/packages/nx/src/utils/package-json.ts
@@ -54,7 +54,7 @@ export interface NxMigrationsConfiguration {
   migrations?: string;
   packageGroup?: PackageGroup;
   /** Signals the package supports `nx migrate --include`. */
-  supportsOptionalUpdates?: boolean;
+  supportsOptionalMigrations?: boolean;
 }
 
 type PackageOverride = { [key: string]: string | PackageOverride };
@@ -132,7 +132,7 @@ export interface NxPackageJson extends PackageJson {
   'nx-migrations'?: {
     migrations?: string;
     packageGroup?: (string | { package: string; version: string })[];
-    supportsOptionalUpdates?: boolean;
+    supportsOptionalMigrations?: boolean;
   };
 }
 
@@ -167,8 +167,8 @@ export function readNxMigrateConfig(
       ...(fromJson.packageGroup
         ? { packageGroup: normalizePackageGroup(fromJson.packageGroup) }
         : {}),
-      ...(fromJson.supportsOptionalUpdates
-        ? { supportsOptionalUpdates: true }
+      ...(fromJson.supportsOptionalMigrations
+        ? { supportsOptionalMigrations: true }
         : {}),
     };
   };

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -73,7 +73,7 @@
   "generators": "./generators.json",
   "nx-migrations": {
     "migrations": "./migrations.json",
-    "supportsOptionalUpdates": true
+    "supportsOptionalMigrations": true
   },
   "dependencies": {
     "@nx/devkit": "workspace:*",

--- a/packages/plugin/package.json
+++ b/packages/plugin/package.json
@@ -33,7 +33,7 @@
   "ng-update": {
     "requirements": {},
     "migrations": "./migrations.json",
-    "supportsOptionalUpdates": true
+    "supportsOptionalMigrations": true
   },
   "dependencies": {
     "tslib": "catalog:typescript",

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -90,7 +90,7 @@
   "ng-update": {
     "requirements": {},
     "migrations": "./migrations.json",
-    "supportsOptionalUpdates": true
+    "supportsOptionalMigrations": true
   },
   "generators": "./generators.json",
   "publishConfig": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -89,7 +89,7 @@
   "ng-update": {
     "requirements": {},
     "migrations": "./migrations.json",
-    "supportsOptionalUpdates": true
+    "supportsOptionalMigrations": true
   },
   "peerDependencies": {
     "babel-plugin-react-compiler": "^1.0.0",

--- a/packages/remix/package.json
+++ b/packages/remix/package.json
@@ -52,7 +52,7 @@
   "executors": "./executors.json",
   "nx-migrations": {
     "migrations": "./migrations.json",
-    "supportsOptionalUpdates": true
+    "supportsOptionalMigrations": true
   },
   "dependencies": {
     "@nx/devkit": "workspace:*",

--- a/packages/rollup/package.json
+++ b/packages/rollup/package.json
@@ -49,7 +49,7 @@
   "ng-update": {
     "requirements": {},
     "migrations": "./migrations.json",
-    "supportsOptionalUpdates": true
+    "supportsOptionalMigrations": true
   },
   "exports": {
     ".": {

--- a/packages/rsbuild/package.json
+++ b/packages/rsbuild/package.json
@@ -74,7 +74,7 @@
   },
   "nx-migrations": {
     "migrations": "./migrations.json",
-    "supportsOptionalUpdates": true
+    "supportsOptionalMigrations": true
   },
   "exports": {
     ".": {

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -184,7 +184,7 @@
   },
   "nx-migrations": {
     "migrations": "./migrations.json",
-    "supportsOptionalUpdates": true
+    "supportsOptionalMigrations": true
   },
   "publishConfig": {
     "access": "public"

--- a/packages/storybook/package.json
+++ b/packages/storybook/package.json
@@ -56,7 +56,7 @@
   "ng-update": {
     "requirements": {},
     "migrations": "./migrations.json",
-    "supportsOptionalUpdates": true
+    "supportsOptionalMigrations": true
   },
   "exports": {
     ".": {

--- a/packages/vite/package.json
+++ b/packages/vite/package.json
@@ -92,7 +92,7 @@
   "ng-update": {
     "requirements": {},
     "migrations": "./migrations.json",
-    "supportsOptionalUpdates": true
+    "supportsOptionalMigrations": true
   },
   "dependencies": {
     "@nx/devkit": "workspace:*",

--- a/packages/vitest/package.json
+++ b/packages/vitest/package.json
@@ -66,7 +66,7 @@
   },
   "nx-migrations": {
     "migrations": "./migrations.json",
-    "supportsOptionalUpdates": true
+    "supportsOptionalMigrations": true
   },
   "executors": "./executors.json",
   "generators": "./generators.json",

--- a/packages/vue/package.json
+++ b/packages/vue/package.json
@@ -43,7 +43,7 @@
   "executors": "./executors.json",
   "nx-migrations": {
     "migrations": "./migrations.json",
-    "supportsOptionalUpdates": true
+    "supportsOptionalMigrations": true
   },
   "exports": {
     ".": {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -48,7 +48,7 @@
   "ng-update": {
     "requirements": {},
     "migrations": "./migrations.json",
-    "supportsOptionalUpdates": true
+    "supportsOptionalMigrations": true
   },
   "exports": {
     ".": {

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -53,7 +53,7 @@
   "ng-update": {
     "requirements": {},
     "migrations": "./migrations.json",
-    "supportsOptionalUpdates": true
+    "supportsOptionalMigrations": true
   },
   "exports": {
     ".": {

--- a/packages/workspace/package.json
+++ b/packages/workspace/package.json
@@ -52,7 +52,7 @@
       "nx-cloud": "latest",
       "nx": "*"
     },
-    "supportsOptionalUpdates": true
+    "supportsOptionalMigrations": true
   },
   "exports": {
     ".": {


### PR DESCRIPTION
## Current Behavior

The migration config flag that opts a package into `nx migrate --include`
(optional migrations) is named `supportsOptionalUpdates`. It is read from a
package's `nx-migrations` / `ng-update` config and threaded through the migrate
command. The name says "updates", but the feature it gates is optional
**migrations**, so the name is misleading.

## Expected Behavior

The flag is renamed to `supportsOptionalMigrations` everywhere it is defined and
consumed:

- The `NxMigrationsConfiguration` / `NxPackageJson` type field and the
  `readNxMigrateConfig` parsing in `packages/nx/src/utils/package-json.ts`
- The `--include` gate and related plumbing in
  `packages/nx/src/command-line/migrate/migrate.ts`
- The `"supportsOptionalMigrations": true` flag in every first-party plugin's
  `package.json`
- The associated unit tests

This is a purely internal rename — the flag is both defined and consumed inside
the nx repo, so no backwards-compat shim is required. Behavior is unchanged.

## Related Issue(s)

N/A — internal naming cleanup.
