### PR TITLE
chore(release): stabilize custom-registries e2e by capping npm fetch-retry backoff

### DIFF
--- a/e2e/release/src/custom-registries.test.ts
+++ b/e2e/release/src/custom-registries.test.ts
@@ -65,6 +65,11 @@ describe('nx release - custom npm registries', () => {
       // We can't test overriding the default registry in this file since our e2e tests override it anyway.
       // Instead, we'll just assert that the e2e registry is used anytime we expect the default registry
       '',
+      // Many publishes here target intentionally-unreachable registries. npm still
+      // does a network preflight (even for --dry-run) and retries on failure, so cap
+      // the retry backoff to keep resilience without the default ~70s sleep per call.
+      'fetch-retry-mintimeout=100',
+      'fetch-retry-maxtimeout=1000',
       // Add auth tokens for all registries (required for NPM 11)
       `${e2eRegistryHost}/:_authToken=test-auth-token`,
       '//publish-config-registry.com/:_authToken=test-auth-token',
@@ -237,6 +242,10 @@ describe('nx release - custom npm registries', () => {
       `registry=http://ignored-registry.com`,
       'tag=next',
       '',
+      // Cap retry backoff (see note on npmrcEntries) so unreachable-registry calls
+      // fail fast while reachable verdaccio reads keep their retry resilience.
+      'fetch-retry-mintimeout=100',
+      'fetch-retry-maxtimeout=1000',
       // Add auth tokens for all registries (required for NPM 11)
       `//localhost:${verdaccioPort}/:_authToken=test-auth-token`,
       `${e2eRegistryHost}/:_authToken=test-auth-token`,


### PR DESCRIPTION
## Current Behavior

The single test in `e2e/release/src/custom-registries.test.ts` ("should respect registry configuration for each package") intermittently fails with a jest timeout:

```
thrown: "Exceeded timeout of 1000000 ms for a test."
```

The test runs ~13 sequential `nx release publish --dry-run` commands, most of which target intentionally-unreachable registry hostnames (e.g. `publish-config-registry.com`, `scoped-registry.com`, `ignored-registry.com`). Under npm 11 (Node 24+), `npm publish --dry-run` performs a network preflight to the configured registry. When that host doesn't resolve, npm's default retry backoff (`fetch-retry-mintimeout=10000` + `fetch-retry-maxtimeout=60000`) sleeps ~70s per command before giving up. Across all the unreachable-registry calls this adds up to ~900s of pure idle waiting, pushing the whole test past its `1_000_000` ms budget. Because it sits right on the boundary, the test is flaky — small timing variations tip it over.

## Expected Behavior

The test completes well within its timeout. npm still retries registry requests (preserving resilience for the real verdaccio reads in the second half of the test), but the retry backoff is capped so the wasted sleep per unreachable call drops from ~70s to ~1.1s.

This is done by adding the following to both `.npmrc` blocks the test writes:

```
fetch-retry-mintimeout=100
fetch-retry-maxtimeout=1000
```

The dry-run output and all assertions are unchanged — `npm publish --dry-run` exits 0 with identical output regardless of registry reachability; only the idle backoff time is reduced.

## Related Issue(s)

N/A — test stabilization (flaky e2e fix).
