### PR TITLE
feat(angular): support ng-packagr v22 browserslist baseline in stylesheet processor

### DIFF
--- a/packages/angular/src/executors/utilities/ng-packagr/stylesheet-processor.ts
+++ b/packages/angular/src/executors/utilities/ng-packagr/stylesheet-processor.ts
@@ -44,7 +44,9 @@ export function getStylesheetProcessor(): new (
       protected readonly cacheDirectory?: string | false,
       protected readonly watch?: boolean
     ) {
-      if (ngPackagrMajorVersion === 21) {
+      if (ngPackagrMajorVersion === 22) {
+        browserslist.defaults = ['baseline widely available on 2026-05-07'];
+      } else if (ngPackagrMajorVersion === 21) {
         browserslist.defaults = ['baseline widely available on 2025-10-20'];
       } else if (ngPackagrMajorVersion === 20) {
         (browserslist.defaults as string[]) = browserslist(undefined, {


### PR DESCRIPTION
## Current Behavior

Nx's custom ng-packagr `StylesheetProcessor` sets the browserslist baseline only for ng-packagr v20 and v21. Under ng-packagr v22 no branch applies, so it falls back to the generic `browserslist` default and compiles component CSS for the wrong browser targets.

## Expected Behavior

The processor applies ng-packagr v22's browserslist baseline (`2026-05-07`), so libraries built with `@nx/angular:package` and `@nx/angular:ng-packagr-lite` target the same browsers as ng-packagr's own build pipeline.

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/angular-v22-76d725d8)
<!-- polygraph-session-end -->