### PR TITLE
feat(angular-rspack): emit subresource integrity for lazy chunks on Angular v22

### DIFF
--- a/examples/angular-rspack/csr-css/src/app/app.routes.ts
+++ b/examples/angular-rspack/csr-css/src/app/app.routes.ts
@@ -1,3 +1,11 @@
 import { Route } from '@angular/router';
 
-export const appRoutes: Route[] = [];
+export const appRoutes: Route[] = [
+  // Lazy route so the build emits a non-initial chunk; with
+  // subresourceIntegrity enabled this exercises the SRI importmap.
+  {
+    path: 'lazy',
+    loadComponent: () =>
+      import('./lazy/lazy.component').then((m) => m.LazyComponent),
+  },
+];

--- a/examples/angular-rspack/csr-css/src/app/lazy/lazy.component.ts
+++ b/examples/angular-rspack/csr-css/src/app/lazy/lazy.component.ts
@@ -1,0 +1,8 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-lazy',
+  template: `<h1>Lazy</h1>`,
+  styles: [],
+})
+export class LazyComponent {}

--- a/examples/angular-rspack/ssg-css/rspack.config.js
+++ b/examples/angular-rspack/ssg-css/rspack.config.js
@@ -11,6 +11,7 @@ module.exports = () => {
           polyfills: ['zone.js'],
           ssr: { entry: './src/server.ts' },
           prerender: true,
+          subresourceIntegrity: true,
           assets: [
             {
               glob: '**/*',

--- a/packages/angular-rspack/src/lib/plugins/index-html-plugin.ts
+++ b/packages/angular-rspack/src/lib/plugins/index-html-plugin.ts
@@ -3,7 +3,9 @@ import {
   type FileInfo,
   type IndexHtmlGeneratorOptions,
 } from '@angular/build/private';
+import { VERSION } from '@angular/core';
 import { Compilation, RspackPluginInstance, type Compiler } from '@rspack/core';
+import { createHash } from 'node:crypto';
 import { basename, extname, join } from 'node:path';
 import type { I18nOptions, IndexExpandedDefinition } from '../models';
 import { addEventDispatchContract } from '../utils/index-file/add-event-dispatch-contract';
@@ -72,6 +74,45 @@ export class IndexHtmlPlugin
                   file,
                   extension: extname(file),
                 });
+              }
+            }
+
+            // v22+ emits an importmap with per-lazy-chunk SRI. Fill the map the
+            // augment plugin captured at construction (allocated in ng-rspack on
+            // SRI builds). Eager chunks already carry an integrity attribute on
+            // their <script> tag; a chunk is initial when any of its groups is
+            // (entrypoint.getFiles() is deep and would wrongly include lazy files).
+            const chunksIntegrity = this.options.chunksIntegrity as
+              | Map<string, string>
+              | undefined;
+            if (chunksIntegrity && +VERSION.major >= 22) {
+              chunksIntegrity.clear();
+
+              const initialFiles = new Set<string>();
+              for (const chunk of compilation.chunks) {
+                let isInitial = false;
+                for (const group of chunk.groupsIterable) {
+                  if (group.isInitial()) {
+                    isInitial = true;
+                    break;
+                  }
+                }
+                if (isInitial) {
+                  for (const file of chunk.files) {
+                    initialFiles.add(file);
+                  }
+                }
+              }
+
+              for (const { file, extension } of files) {
+                if (extension !== '.js' || initialFiles.has(file)) {
+                  continue;
+                }
+
+                const hash = createHash('sha384')
+                  .update(compilation.assets[file].buffer())
+                  .digest('base64');
+                chunksIntegrity.set(file, `sha384-${hash}`);
               }
             }
 

--- a/packages/angular-rspack/src/lib/plugins/ng-rspack.ts
+++ b/packages/angular-rspack/src/lib/plugins/ng-rspack.ts
@@ -146,6 +146,12 @@ export class NgRspackPlugin implements RspackPluginInstance {
         deployUrl: this.pluginOptions.deployUrl,
         crossOrigin: this.pluginOptions.crossOrigin,
         sri: this.pluginOptions.subresourceIntegrity,
+        // The augment plugin captures this map at construction; IndexHtmlPlugin
+        // fills it during the build so SRI builds emit a lazy-chunk integrity
+        // importmap (on the Angular versions that support it).
+        chunksIntegrity: this.pluginOptions.subresourceIntegrity
+          ? new Map()
+          : undefined,
       }).apply(compiler);
     }
     if (


### PR DESCRIPTION
## Current Behavior

`@nx/angular-rspack` exposes `subresourceIntegrity`, but only initial scripts receive an integrity attribute. Under Angular v22 - whose `@angular/build` emits an integrity importmap for dynamically imported chunks - lazy chunks built with `@nx/angular-rspack` ship without subresource integrity protection.

## Expected Behavior

On Angular v22+, SRI builds emit a `<script type="importmap">` block carrying a sha384 hash for every lazy chunk, matching `@angular/build`'s application builder, so dynamically imported chunks are validated by the browser. Behavior on Angular 20/21 is unchanged.

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/angular-v22-76d725d8)
<!-- polygraph-session-end -->