### PR TITLE
fix(vite): improve vitest 4 migration to better handle vitest workspace config

### DIFF
--- a/packages/vite/src/migrations/update-23-0-0/ai-instructions-for-vitest-4.md
+++ b/packages/vite/src/migrations/update-23-0-0/ai-instructions-for-vitest-4.md
@@ -9,7 +9,10 @@ These instructions guide you through migrating an Nx workspace containing multip
 The pre-pass handled, mechanically:
 
 - dead `coverage.{all,extensions,ignoreEmptyLines,experimentalAstAwareRemapping}` removal
-- `test.workspace` → `test.projects` rename (the property only — external `vitest.workspace.*` files are NOT inlined)
+- `test.workspace` → `test.projects` rename (the property form)
+- inlining of static `vitest.workspace.*` files (a plain array of glob strings) into the root `vitest.config.*` under `test.projects`, deleting the workspace file. Workspace files the pre-pass could not safely inline are forwarded to you: dynamic content (imports, spreads, object entries), or a sibling config it could not merge into (an existing `test.projects`/`test.workspace`, a non-object-literal config, or a directory that only has a `vite.config.*`)
+- when the inlined globs matched both a `vite.config.*` and a `vitest.config.*` in the same directory resolving to the same project name, a negative glob excluding the `vite.config.*` was appended (avoids vitest's duplicate-project-name startup error)
+- minimal local `vitest.config.*` files for packages that run vitest via a package.json script but had no local config. Without one, Vitest 4 climbs from the package directory to the root `test.projects` config, resolves the globs relative to the package directory, and fails with "No projects were found"
 - `@vitest/browser/context` import-path rewrite to `vitest/browser`
 - `deps.optimizer.web` → `deps.optimizer.client` rename
 - `poolOptions.threads.useAtomics` and top-level `test.minWorkers` removal
@@ -18,7 +21,7 @@ The pre-pass handled, mechanically:
 
 The pre-pass **skips the rename when both `VITEST_MAX_THREADS` and `VITEST_MAX_FORKS` appear in the same file/scope** (they collapse to a single `VITEST_MAX_WORKERS` whose value depends on which pool the project uses — a decision the pre-pass can't make safely). It also **does not** edit CI provider configs (`.github/workflows/*.yml`, `.gitlab-ci.yml`, `azure-pipelines.yml`, `.circleci/config.yml`, `bitbucket-pipelines.yml`) — YAML structure varies too much. Any conflicts and any CI matches are forwarded to you in `<advisory_context>`.
 
-**The cross-cutting changes below still require your attention** — pool option flattening (`singleThread`/`singleFork`, `maxThreads`/`maxForks`, `poolOptions.<pool>.{execArgv,isolate}`, `poolOptions.vmThreads.memoryLimit`), `test.deps.{external,inline,fallbackCJS}` → `test.server.deps.*` move, `test.{poolMatchGlobs,environmentMatchGlobs}` projects rewrite, browser provider function-form rewrite, `browser.testerScripts` → `testerHtmlPath`, `vitest.workspace.*` file inlining + `defineWorkspace` removal, custom reporter callback API updates, and `@vitest/browser` package replacement with per-provider packages.
+**The cross-cutting changes below still require your attention** — pool option flattening (`singleThread`/`singleFork`, `maxThreads`/`maxForks`, `poolOptions.<pool>.{execArgv,isolate}`, `poolOptions.vmThreads.memoryLimit`), `test.deps.{external,inline,fallbackCJS}` → `test.server.deps.*` move, `test.{poolMatchGlobs,environmentMatchGlobs}` projects rewrite, browser provider function-form rewrite, `browser.testerScripts` → `testerHtmlPath`, inlining of `vitest.workspace.*` files the pre-pass could not inline automatically (+ `defineWorkspace` removal), custom reporter callback API updates, and `@vitest/browser` package replacement with per-provider packages.
 
 How to read the wrapper sections above this file:
 
@@ -195,8 +198,24 @@ export default defineConfig({
 **Action Items**:
 
 - [ ] Rename `workspace` property to `projects` in all config files.
-- [ ] Inline any external `vitest.workspace.*` content into `test.projects` and delete the workspace file (external file references are no longer supported).
+- [ ] Inline any external `vitest.workspace.*` content into `test.projects` and delete the workspace file (external file references are no longer supported). The pre-pass already inlined workspace files containing a plain static array of glob strings; the ones you see in `<advisory_context>` were skipped because of dynamic content or because the sibling config could not be merged into mechanically (existing `test.projects`/`test.workspace`, non-object-literal config, or a directory with only a `vite.config.*`). For an existing `test.projects`, merge the workspace entries into it; for a `vite.config.*`-only directory, decide whether its `test` block (if any) and the project list belong in that file or a new `vitest.config.*`.
 - [ ] If projects need different pool/environment options, set them inside each project entry rather than via the (now-removed) `poolMatchGlobs` / `environmentMatchGlobs` — see section 1.5.
+
+When you inline a workspace file yourself, also apply these two checks (the pre-pass applies them for the files it inlines):
+
+- [ ] **Config-less packages**: a root config with `test.projects` breaks `vitest` invocations from package directories that have no `vite.config.*`/`vitest.config.*` of their own (common for packages with a package.json `"test": "vitest run"` script). Vitest 4 finds the root config by walking up from the package directory, but resolves the `test.projects` globs relative to the package directory, so it errors with "No projects were found". For each such package, create a minimal local config so vitest stops at it and `@nx/vitest` infers the test target:
+
+  ```typescript
+  import { defineConfig } from 'vitest/config';
+
+  export default defineConfig({
+    test: {},
+  });
+  ```
+
+  Do NOT "fix" this by anchoring the root globs to the workspace root instead: that makes the package-directory invocation run every project in the workspace while still skipping the config-less package's own tests. Skip packages whose vitest script already passes an explicit `--config`/`-c`/`--root`; those don't rely on config discovery.
+
+- [ ] **Duplicate project names**: when the inlined globs match both a `vite.config.*` and a `vitest.config.*` in the same directory and both resolve to the same project name (the default name is the directory's package.json name, so two name-less configs always collide), vitest errors at startup with "Project name ... is not unique". Append a negative glob excluding the `vite.config.*` file (e.g. `'!packages/foo/vite.config.ts'`), matching vitest's own vitest-over-vite preference. Leave directories whose configs have distinct explicit `test.name` values alone; those are intentionally separate projects.
 
 <fail_if note="inlining is a semantic merge, not a copy">
 The `vitest.workspace.*` file imports modules / calls functions / uses spreads that you cannot evaluate at edit time (dynamic project arrays, conditional imports). Write status: failed listing the file path and the dynamic shape that needs human resolution.

--- a/packages/vite/src/migrations/update-23-0-0/ai-instructions-for-vitest-4.md
+++ b/packages/vite/src/migrations/update-23-0-0/ai-instructions-for-vitest-4.md
@@ -10,8 +10,8 @@ The pre-pass handled, mechanically:
 
 - dead `coverage.{all,extensions,ignoreEmptyLines,experimentalAstAwareRemapping}` removal
 - `test.workspace` → `test.projects` rename (the property form)
-- inlining of static `vitest.workspace.*` files (a plain array of glob strings) into the root `vitest.config.*` under `test.projects`, deleting the workspace file. Workspace files the pre-pass could not safely inline are forwarded to you: dynamic content (imports, spreads, object entries), or a sibling config it could not merge into (an existing `test.projects`/`test.workspace`, a non-object-literal config, or a directory that only has a `vite.config.*`)
-- when the inlined globs matched both a `vite.config.*` and a `vitest.config.*` in the same directory resolving to the same project name, a negative glob excluding the `vite.config.*` was appended (avoids vitest's duplicate-project-name startup error)
+- inlining of static `vitest.workspace.*` files (a plain array of glob strings) into the root `vitest.config.*` under `test.projects`, deleting the workspace file. Workspace files the pre-pass could not safely inline are forwarded to you: dynamic content (imports, spreads, object entries), an empty project list, or a sibling config it could not merge into (an existing `test.projects`/`test.workspace`, a non-object-literal config, or a directory that only has a `vite.config.*`)
+- when the inlined globs matched both a `vite.config.*` and a `vitest.config.*` in the same directory resolving to the same project name, a negative glob excluding the `vite.config.*` was appended (avoids vitest's duplicate-project-name startup error). When either config's project name could not be statically determined, an advisory was forwarded to you instead
 - minimal local `vitest.config.*` files for packages that run vitest via a package.json script but had no local config. Without one, Vitest 4 climbs from the package directory to the root `test.projects` config, resolves the globs relative to the package directory, and fails with "No projects were found"
 - `@vitest/browser/context` import-path rewrite to `vitest/browser`
 - `deps.optimizer.web` → `deps.optimizer.client` rename
@@ -213,7 +213,7 @@ When you inline a workspace file yourself, also apply these two checks (the pre-
   });
   ```
 
-  Do NOT "fix" this by anchoring the root globs to the workspace root instead: that makes the package-directory invocation run every project in the workspace while still skipping the config-less package's own tests. Skip packages whose vitest script already passes an explicit `--config`/`-c`/`--root`; those don't rely on config discovery.
+  Do NOT "fix" this by anchoring the root globs to the workspace root instead: that makes the package-directory invocation run every project in the workspace while still skipping the config-less package's own tests. Skip packages whose vitest script already passes an explicit `--config`/`-c`/`--root` (space- or `=`-joined); those don't rely on config discovery.
 
 - [ ] **Duplicate project names**: when the inlined globs match both a `vite.config.*` and a `vitest.config.*` in the same directory and both resolve to the same project name (the default name is the directory's package.json name, so two name-less configs always collide), vitest errors at startup with "Project name ... is not unique". Append a negative glob excluding the `vite.config.*` file (e.g. `'!packages/foo/vite.config.ts'`), matching vitest's own vitest-over-vite preference. Leave directories whose configs have distinct explicit `test.name` values alone; those are intentionally separate projects.
 

--- a/packages/vite/src/migrations/update-23-0-0/lib/generate-local-vitest-configs.ts
+++ b/packages/vite/src/migrations/update-23-0-0/lib/generate-local-vitest-configs.ts
@@ -1,0 +1,116 @@
+import { joinPathFragments, type Tree, visitNotIgnoredFiles } from '@nx/devkit';
+import {
+  isVitestConfigFile,
+  isVitestWorkspaceFile,
+} from './vitest-config-files';
+
+/**
+ * Packages that run vitest through a package.json script but have no local
+ * vite/vitest config relied on Vitest 3 running their own test files from the
+ * package directory. In Vitest 4 the same invocation climbs up to the root
+ * `vitest.config.*`, resolves its `test.projects` globs relative to the
+ * package directory, matches nothing, and hard-errors with "No projects were
+ * found". A minimal local config stops the climb and lets `@nx/vitest` infer
+ * the package's test target. Returns the created file paths.
+ */
+export function generateLocalVitestConfigs(tree: Tree): string[] {
+  const created: string[] = [];
+
+  const packageJsonPaths: string[] = [];
+  visitNotIgnoredFiles(tree, '', (filePath) => {
+    if (filePath === 'package.json' || filePath.endsWith('/package.json')) {
+      packageJsonPaths.push(filePath);
+    }
+  });
+
+  for (const packageJsonPath of packageJsonPaths) {
+    try {
+      processPackage(tree, packageJsonPath, created);
+    } catch {
+      // Generation is best-effort; a problematic package must not fail the
+      // migration.
+    }
+  }
+
+  return created.sort();
+}
+
+function processPackage(
+  tree: Tree,
+  packageJsonPath: string,
+  created: string[]
+): void {
+  let packageJson: any;
+  try {
+    packageJson = JSON.parse(tree.read(packageJsonPath, 'utf-8'));
+  } catch {
+    return;
+  }
+  const scripts = packageJson?.scripts;
+  if (!scripts || typeof scripts !== 'object') return;
+  if (
+    !Object.values(scripts).some(
+      (script) => typeof script === 'string' && scriptInvokesVitest(script)
+    )
+  ) {
+    return;
+  }
+
+  const dir = packageJsonPath.includes('/')
+    ? packageJsonPath.slice(0, packageJsonPath.lastIndexOf('/'))
+    : '.';
+  const siblings = tree.children(dir === '.' ? '' : dir);
+  if (siblings.some((f) => isVitestConfigFile(f))) return;
+  // A directory hosting the workspace file is the projects-mode entry
+  // point, both before and after the migration; it needs no local config.
+  if (siblings.some((f) => isVitestWorkspaceFile(f))) return;
+
+  const ext =
+    siblings.some((f) => /^tsconfig(\..+)?\.json$/.test(f)) ||
+    tree.exists('tsconfig.base.json') ||
+    tree.exists('tsconfig.json')
+      ? '.ts'
+      : '.mjs';
+  const configPath = joinPathFragments(dir, `vitest.config${ext}`);
+  tree.write(
+    configPath,
+    `import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {},
+});
+`
+  );
+  created.push(configPath);
+}
+
+/**
+ * True when some command in the script runs the `vitest` binary (directly,
+ * path-prefixed, or after a runner/env prefix like `npx`/`cross-env A=1`)
+ * without pointing it at an explicit config. `npm run vitest` style commands
+ * run another script, not the binary, and invocations passing `--config`,
+ * `-c`, or `--root` don't rely on config discovery from the cwd, so a
+ * generated local config would only get in the way of target inference.
+ */
+function scriptInvokesVitest(script: string): boolean {
+  return script.split(/&&|\|\||;|\|/).some((command) => {
+    const tokens = command.trim().split(/\s+/);
+    const vitestIndex = tokens.findIndex(
+      (token, i) =>
+        (token === 'vitest' || token.endsWith('/vitest')) &&
+        tokens[i - 1] !== 'run' &&
+        tokens[i - 1] !== 'run-script'
+    );
+    if (vitestIndex === -1) return false;
+    return !tokens
+      .slice(vitestIndex + 1)
+      .some(
+        (token) =>
+          token === '--config' ||
+          token === '-c' ||
+          token === '--root' ||
+          token.startsWith('--config=') ||
+          token.startsWith('--root=')
+      );
+  });
+}

--- a/packages/vite/src/migrations/update-23-0-0/lib/generate-local-vitest-configs.ts
+++ b/packages/vite/src/migrations/update-23-0-0/lib/generate-local-vitest-configs.ts
@@ -23,9 +23,11 @@ export function generateLocalVitestConfigs(tree: Tree): string[] {
     }
   });
 
+  const rootHasTsconfig =
+    tree.exists('tsconfig.base.json') || tree.exists('tsconfig.json');
   for (const packageJsonPath of packageJsonPaths) {
     try {
-      processPackage(tree, packageJsonPath, created);
+      processPackage(tree, packageJsonPath, rootHasTsconfig, created);
     } catch {
       // Generation is best-effort; a problematic package must not fail the
       // migration.
@@ -38,6 +40,7 @@ export function generateLocalVitestConfigs(tree: Tree): string[] {
 function processPackage(
   tree: Tree,
   packageJsonPath: string,
+  rootHasTsconfig: boolean,
   created: string[]
 ): void {
   let packageJson: any;
@@ -66,9 +69,7 @@ function processPackage(
   if (siblings.some((f) => isVitestWorkspaceFile(f))) return;
 
   const ext =
-    siblings.some((f) => /^tsconfig(\..+)?\.json$/.test(f)) ||
-    tree.exists('tsconfig.base.json') ||
-    tree.exists('tsconfig.json')
+    rootHasTsconfig || siblings.some((f) => /^tsconfig(\..+)?\.json$/.test(f))
       ? '.ts'
       : '.mjs';
   const configPath = joinPathFragments(dir, `vitest.config${ext}`);
@@ -110,6 +111,7 @@ function scriptInvokesVitest(script: string): boolean {
           token === '-c' ||
           token === '--root' ||
           token.startsWith('--config=') ||
+          token.startsWith('-c=') ||
           token.startsWith('--root=')
       );
   });

--- a/packages/vite/src/migrations/update-23-0-0/lib/inline-vitest-workspace.ts
+++ b/packages/vite/src/migrations/update-23-0-0/lib/inline-vitest-workspace.ts
@@ -1,6 +1,7 @@
 import { joinPathFragments, type Tree, visitNotIgnoredFiles } from '@nx/devkit';
 import { ensureTypescript } from '@nx/js/internal';
 import { ast } from '@phenomnomnominal/tsquery';
+import picomatch = require('picomatch');
 import type {
   Expression,
   ObjectLiteralExpression,
@@ -124,8 +125,9 @@ function extractStaticProjectGlobs(contents: string): string[] | null {
 
   const globs: string[] = [];
   for (const element of expression.elements) {
-    if (!ts.isStringLiteral(element)) return null;
-    globs.push(element.text);
+    const unwrapped = unwrapExpression(element);
+    if (!ts.isStringLiteral(unwrapped)) return null;
+    globs.push(unwrapped.text);
   }
   return globs;
 }
@@ -169,6 +171,10 @@ function tryAddProjectsToConfig(
   if (hasSpreadOrUnsupportedProperty(configObject.properties, ['test'])) {
     return false;
   }
+
+  // Duplicate keys are valid JS; editing the first occurrence would be dead
+  // code since the last one wins at runtime.
+  if (countPropertyAssignments(configObject, 'test') > 1) return false;
 
   const testProperty = findPropertyAssignment(configObject, 'test');
   const projectsText = `projects: ${formatEntriesArray(entries)}`;
@@ -264,8 +270,6 @@ function computeDualConfigNegations(
   workspaceFilePath: string,
   globs: string[]
 ): { negations: string[]; advisories: string[] } {
-  // Lazily required to reuse the same module instance as the main migration.
-  const picomatch: typeof import('picomatch') = require('picomatch');
   const matchers = globs
     .filter((g) => !g.startsWith('!'))
     // picomatch does not normalize a leading './', vitest's glob layer does.
@@ -378,6 +382,23 @@ function findDefaultExportConfigObject(
     expression = unwrapExpression(expression.arguments[0]);
   }
   return ts.isObjectLiteralExpression(expression) ? expression : undefined;
+}
+
+function countPropertyAssignments(
+  objectLiteral: ObjectLiteralExpression,
+  name: string
+): number {
+  let count = 0;
+  for (const property of objectLiteral.properties) {
+    if (
+      ts.isPropertyAssignment(property) &&
+      (ts.isIdentifier(property.name) || ts.isStringLiteral(property.name)) &&
+      property.name.text === name
+    ) {
+      count++;
+    }
+  }
+  return count;
 }
 
 function findPropertyAssignment(

--- a/packages/vite/src/migrations/update-23-0-0/lib/inline-vitest-workspace.ts
+++ b/packages/vite/src/migrations/update-23-0-0/lib/inline-vitest-workspace.ts
@@ -1,0 +1,440 @@
+import { joinPathFragments, type Tree, visitNotIgnoredFiles } from '@nx/devkit';
+import { ensureTypescript } from '@nx/js/internal';
+import { ast } from '@phenomnomnominal/tsquery';
+import type {
+  Expression,
+  ObjectLiteralExpression,
+  ObjectLiteralElementLike,
+  PropertyAssignment,
+  SourceFile,
+} from 'typescript';
+import { applyTextEdits } from './ast-edits';
+import { isVitestWorkspaceFile } from './vitest-config-files';
+
+let ts: typeof import('typescript');
+
+// Mirrors vitest's own config lookup (CONFIG_NAMES x CONFIG_EXTENSIONS),
+// including its vitest-over-vite preference order.
+const CONFIG_EXTENSIONS = ['.ts', '.mts', '.cts', '.js', '.mjs', '.cjs'];
+
+const VITEST_CONFIG_RE = /^vitest\.config\.(js|ts|mjs|mts|cjs|cts)$/;
+const VITE_CONFIG_RE = /^vite\.config\.(js|ts|mjs|mts|cjs|cts)$/;
+
+/**
+ * Inline `vitest.workspace.*` files whose project list is a static array of
+ * string literals into the sibling root `vitest.config.*` under
+ * `test.projects` (creating the config file when none exists), then delete
+ * the workspace file. Vitest 4 removed workspace files entirely.
+ *
+ * Anything not statically tractable (dynamic arrays, inline project objects,
+ * non-object-literal configs, pre-existing `test.projects`) is left in place
+ * and reported through `unhandled` for the agent.
+ */
+export function inlineVitestWorkspaceFiles(
+  tree: Tree,
+  unhandled: string[]
+): { foundWorkspaceFiles: boolean } {
+  ts ??= ensureTypescript();
+
+  const workspaceFiles: string[] = [];
+  visitNotIgnoredFiles(tree, '', (filePath) => {
+    if (isVitestWorkspaceFile(filePath)) workspaceFiles.push(filePath);
+  });
+
+  for (const filePath of workspaceFiles) {
+    let inlined = false;
+    try {
+      inlined = tryInlineWorkspaceFile(tree, filePath, unhandled);
+    } catch {
+      // A failed inline must never fail the migration; the agent handles it.
+      inlined = false;
+    }
+    if (!inlined) {
+      unhandled.push(
+        `${filePath}: \`vitest.workspace.*\` files are removed in Vitest 4 and this one could not be inlined automatically. ` +
+          `Inline its project list into the root \`vitest.config.*\` under \`test.projects\` and delete this file.`
+      );
+    }
+  }
+
+  return { foundWorkspaceFiles: workspaceFiles.length > 0 };
+}
+
+function tryInlineWorkspaceFile(
+  tree: Tree,
+  filePath: string,
+  unhandled: string[]
+): boolean {
+  const globs = extractStaticProjectGlobs(tree.read(filePath, 'utf-8'));
+  if (!globs || globs.length === 0) return false;
+
+  const dir = posixDirname(filePath);
+  const { negations, advisories } = computeDualConfigNegations(
+    tree,
+    dir,
+    filePath,
+    globs
+  );
+  const entries = [...globs, ...negations];
+
+  const vitestConfigPath = findExistingConfig(tree, dir, 'vitest.config');
+  if (vitestConfigPath) {
+    if (!tryAddProjectsToConfig(tree, vitestConfigPath, entries)) {
+      return false;
+    }
+  } else if (findExistingConfig(tree, dir, 'vite.config')) {
+    // A sibling vite.config may carry its own test block; creating a
+    // vitest.config next to it would shadow it for test runs. Let the agent
+    // decide where the projects belong.
+    return false;
+  } else {
+    createVitestConfig(tree, dir, filePath, entries);
+  }
+
+  tree.delete(filePath);
+  unhandled.push(...advisories);
+  return true;
+}
+
+/**
+ * Extracts the project globs from a workspace file when its default export is
+ * a plain array of string literals, optionally wrapped in `defineWorkspace`.
+ * Returns `null` for any other shape.
+ */
+function extractStaticProjectGlobs(contents: string): string[] | null {
+  const sourceFile = ast(contents);
+  const exportAssignment = sourceFile.statements.find(
+    (s) => ts.isExportAssignment(s) && !s.isExportEquals
+  );
+  if (!exportAssignment || !ts.isExportAssignment(exportAssignment)) {
+    return null;
+  }
+
+  let expression = unwrapExpression(exportAssignment.expression);
+  if (
+    ts.isCallExpression(expression) &&
+    ts.isIdentifier(expression.expression) &&
+    expression.expression.text === 'defineWorkspace' &&
+    expression.arguments.length === 1
+  ) {
+    expression = unwrapExpression(expression.arguments[0]);
+  }
+
+  if (!ts.isArrayLiteralExpression(expression)) return null;
+
+  const globs: string[] = [];
+  for (const element of expression.elements) {
+    if (!ts.isStringLiteral(element)) return null;
+    globs.push(element.text);
+  }
+  return globs;
+}
+
+function unwrapExpression(expression: Expression): Expression {
+  while (
+    ts.isAsExpression(expression) ||
+    ts.isSatisfiesExpression(expression) ||
+    ts.isParenthesizedExpression(expression)
+  ) {
+    expression = expression.expression;
+  }
+  return expression;
+}
+
+function findExistingConfig(
+  tree: Tree,
+  dir: string,
+  name: 'vitest.config' | 'vite.config'
+): string | undefined {
+  for (const ext of CONFIG_EXTENSIONS) {
+    const candidate = joinPathFragments(dir, `${name}${ext}`);
+    if (tree.exists(candidate)) return candidate;
+  }
+  return undefined;
+}
+
+/**
+ * Inserts `projects: [...]` into an existing config file's `test` block (or a
+ * whole `test` block when missing). Returns false when the config shape is
+ * not statically safe to edit.
+ */
+function tryAddProjectsToConfig(
+  tree: Tree,
+  configPath: string,
+  entries: string[]
+): boolean {
+  const contents = tree.read(configPath, 'utf-8');
+  const configObject = findDefaultExportConfigObject(ast(contents));
+  if (!configObject) return false;
+  if (hasSpreadOrUnsupportedProperty(configObject.properties, ['test'])) {
+    return false;
+  }
+
+  const testProperty = findPropertyAssignment(configObject, 'test');
+  const projectsText = `projects: ${formatEntriesArray(entries)}`;
+
+  if (testProperty) {
+    const testObject = testProperty.initializer;
+    if (!ts.isObjectLiteralExpression(testObject)) return false;
+    if (
+      hasSpreadOrUnsupportedProperty(testObject.properties, [
+        'projects',
+        'workspace',
+      ])
+    ) {
+      return false;
+    }
+    if (
+      findPropertyAssignment(testObject, 'projects') ||
+      findPropertyAssignment(testObject, 'workspace')
+    ) {
+      // The config already defines its own project set; merging two project
+      // lists is a semantic decision the agent must make.
+      return false;
+    }
+    const insertPos = testObject.getStart() + 1;
+    tree.write(
+      configPath,
+      applyTextEdits(contents, [
+        { start: insertPos, end: insertPos, replacement: `${projectsText},` },
+      ])
+    );
+  } else {
+    const insertPos = configObject.getStart() + 1;
+    tree.write(
+      configPath,
+      applyTextEdits(contents, [
+        {
+          start: insertPos,
+          end: insertPos,
+          replacement: `test: {${projectsText},},`,
+        },
+      ])
+    );
+  }
+  return true;
+}
+
+function createVitestConfig(
+  tree: Tree,
+  dir: string,
+  workspaceFilePath: string,
+  entries: string[]
+): void {
+  const workspaceExt = workspaceFilePath.slice(
+    workspaceFilePath.lastIndexOf('.')
+  );
+  // The generated file uses ESM syntax, so anything that isn't unambiguously
+  // ESM-capable (.js depends on package type, .cts/.cjs are CJS) gets .mjs.
+  const ext = ['.ts', '.mts', '.mjs'].includes(workspaceExt)
+    ? workspaceExt
+    : '.mjs';
+  tree.write(
+    joinPathFragments(dir, `vitest.config${ext}`),
+    `import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    projects: ${formatEntriesArray(entries)},
+  },
+});
+`
+  );
+}
+
+function formatEntriesArray(entries: string[]): string {
+  return `[${entries
+    .map((e) => `'${e.replace(/\\/g, '\\\\').replace(/'/g, "\\'")}'`)
+    .join(', ')}]`;
+}
+
+/**
+ * Vitest errors at startup when two matched config files resolve to the same
+ * project name, which is the default outcome for directories holding both a
+ * `vite.config.*` and a `vitest.config.*` (both default to the directory's
+ * package name). For those directories, exclude the `vite.config.*` file via
+ * a negative glob, matching vitest's own vitest-over-vite preference when it
+ * resolves a directory entry. Directories whose two configs have statically
+ * distinct names are intentionally separate projects and are left alone, as
+ * is anything not statically determinable.
+ */
+function computeDualConfigNegations(
+  tree: Tree,
+  rootDir: string,
+  workspaceFilePath: string,
+  globs: string[]
+): { negations: string[]; advisories: string[] } {
+  // Lazily required to reuse the same module instance as the main migration.
+  const picomatch: typeof import('picomatch') = require('picomatch');
+  const matchers = globs
+    .filter((g) => !g.startsWith('!'))
+    // picomatch does not normalize a leading './', vitest's glob layer does.
+    .map((g) => picomatch(g.replace(/^\.\//, ''), { dot: true }));
+
+  const matchedByDir = new Map<string, { vite?: string; vitest?: string }>();
+  visitNotIgnoredFiles(tree, rootDir === '.' ? '' : rootDir, (filePath) => {
+    const relativePath = relativeToDir(filePath, rootDir);
+    if (!matchers.some((m) => m(relativePath))) return;
+    const base = posixBasename(filePath);
+    const dir = posixDirname(filePath);
+    const pair = matchedByDir.get(dir) ?? {};
+    if (VITEST_CONFIG_RE.test(base)) pair.vitest = filePath;
+    else if (VITE_CONFIG_RE.test(base)) pair.vite = filePath;
+    matchedByDir.set(dir, pair);
+  });
+
+  const negations: string[] = [];
+  const advisories: string[] = [];
+  for (const [dir, pair] of matchedByDir) {
+    if (!pair.vite || !pair.vitest) continue;
+    const viteName = determineStaticProjectName(tree, pair.vite);
+    const vitestName = determineStaticProjectName(tree, pair.vitest);
+    if (viteName === undefined || vitestName === undefined) {
+      advisories.push(
+        `${workspaceFilePath}: the inlined \`test.projects\` globs match both \`${pair.vite}\` and \`${pair.vitest}\`, and their project names could not be statically compared. ` +
+          `If vitest fails at startup with "Project name ... is not unique", exclude one of them from \`test.projects\` with a negative glob (e.g. \`'!${relativeToDir(
+            pair.vite,
+            rootDir
+          )}'\`).`
+      );
+      continue;
+    }
+    const resolvedViteName =
+      viteName === 'default' ? defaultProjectName(tree, dir) : viteName.name;
+    const resolvedVitestName =
+      vitestName === 'default'
+        ? defaultProjectName(tree, dir)
+        : vitestName.name;
+    if (resolvedViteName !== resolvedVitestName) continue;
+    negations.push(`!${relativeToDir(pair.vite, rootDir)}`);
+  }
+  return { negations: negations.sort(), advisories: advisories.sort() };
+}
+
+/**
+ * Statically determines a config file's project name. Returns:
+ *   - `{ name }` for an explicit string-literal `test.name`
+ *   - `'default'` when no `test.name` is set (vitest falls back to the
+ *     directory's package.json name or basename)
+ *   - `undefined` when not statically determinable
+ */
+function determineStaticProjectName(
+  tree: Tree,
+  configPath: string
+): { name: string } | 'default' | undefined {
+  const configObject = findDefaultExportConfigObject(
+    ast(tree.read(configPath, 'utf-8'))
+  );
+  if (!configObject) return undefined;
+  if (hasSpreadOrUnsupportedProperty(configObject.properties, ['test'])) {
+    return undefined;
+  }
+
+  const testProperty = findPropertyAssignment(configObject, 'test');
+  if (!testProperty) return 'default';
+  if (!ts.isObjectLiteralExpression(testProperty.initializer)) {
+    return undefined;
+  }
+  const testObject = testProperty.initializer;
+  if (hasSpreadOrUnsupportedProperty(testObject.properties, ['name'])) {
+    return undefined;
+  }
+
+  const nameProperty = findPropertyAssignment(testObject, 'name');
+  if (!nameProperty) return 'default';
+  if (ts.isStringLiteral(nameProperty.initializer)) {
+    return { name: nameProperty.initializer.text };
+  }
+  return undefined;
+}
+
+function defaultProjectName(tree: Tree, dir: string): string {
+  const packageJsonPath = joinPathFragments(dir, 'package.json');
+  if (tree.exists(packageJsonPath)) {
+    try {
+      const name = JSON.parse(tree.read(packageJsonPath, 'utf-8')).name;
+      if (typeof name === 'string' && name) return name;
+    } catch {}
+  }
+  return posixBasename(dir);
+}
+
+function findDefaultExportConfigObject(
+  sourceFile: SourceFile
+): ObjectLiteralExpression | undefined {
+  const exportAssignment = sourceFile.statements.find(
+    (s) => ts.isExportAssignment(s) && !s.isExportEquals
+  );
+  if (!exportAssignment || !ts.isExportAssignment(exportAssignment)) {
+    return undefined;
+  }
+  let expression = unwrapExpression(exportAssignment.expression);
+  if (
+    ts.isCallExpression(expression) &&
+    ts.isIdentifier(expression.expression) &&
+    expression.expression.text === 'defineConfig' &&
+    expression.arguments.length === 1
+  ) {
+    expression = unwrapExpression(expression.arguments[0]);
+  }
+  return ts.isObjectLiteralExpression(expression) ? expression : undefined;
+}
+
+function findPropertyAssignment(
+  objectLiteral: ObjectLiteralExpression,
+  name: string
+): PropertyAssignment | undefined {
+  for (const property of objectLiteral.properties) {
+    if (
+      ts.isPropertyAssignment(property) &&
+      (ts.isIdentifier(property.name) || ts.isStringLiteral(property.name)) &&
+      property.name.text === name
+    ) {
+      return property;
+    }
+  }
+  return undefined;
+}
+
+/**
+ * True when the object contains a spread (its contents can't be known
+ * statically) or when any of `criticalNames` appears as something other than
+ * a plain property assignment (shorthand, method, computed name), in which
+ * case edits or reads keyed on those names would be unsafe.
+ */
+function hasSpreadOrUnsupportedProperty(
+  properties: readonly ObjectLiteralElementLike[],
+  criticalNames: string[]
+): boolean {
+  for (const property of properties) {
+    if (ts.isSpreadAssignment(property)) return true;
+    if (ts.isPropertyAssignment(property)) {
+      if (ts.isComputedPropertyName(property.name)) return true;
+      continue;
+    }
+    const name =
+      property.name &&
+      (ts.isIdentifier(property.name) || ts.isStringLiteral(property.name))
+        ? property.name.text
+        : undefined;
+    if (name === undefined || criticalNames.includes(name)) return true;
+  }
+  return false;
+}
+
+function posixDirname(filePath: string): string {
+  const idx = filePath.lastIndexOf('/');
+  return idx === -1 ? '.' : filePath.slice(0, idx);
+}
+
+function posixBasename(filePath: string): string {
+  const idx = filePath.lastIndexOf('/');
+  return idx === -1 ? filePath : filePath.slice(idx + 1);
+}
+
+function relativeToDir(filePath: string, dir: string): string {
+  if (dir === '.' || dir === '') return filePath;
+  return filePath.startsWith(`${dir}/`)
+    ? filePath.slice(dir.length + 1)
+    : filePath;
+}

--- a/packages/vite/src/migrations/update-23-0-0/migrate-to-vitest-4.spec.ts
+++ b/packages/vite/src/migrations/update-23-0-0/migrate-to-vitest-4.spec.ts
@@ -322,6 +322,33 @@ export default defineConfig({});
       ).toBe(true);
     });
 
+    it('forwards an advisory when the vitest config side is not statically determinable', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'vitest.workspace.ts',
+        `export default ['**/vite.config.{mjs,js,ts,mts}', '**/vitest.config.{mjs,js,ts,mts}'];\n`
+      );
+      tree.write(
+        'packages/dual/vite.config.ts',
+        `import { defineConfig } from 'vite';\nexport default defineConfig({ test: {} });\n`
+      );
+      tree.write(
+        'packages/dual/vitest.config.ts',
+        `import { defineConfig } from 'vitest/config';\nimport { base } from './base';\nexport default defineConfig({ ...base });\n`
+      );
+
+      const result = await migrateToVitest4(tree);
+
+      expect(tree.read('vitest.config.ts', 'utf-8')).not.toContain("'!");
+      expect(
+        result?.agentContext?.some(
+          (s) =>
+            s.includes('packages/dual/vitest.config.ts') &&
+            s.includes('negative glob')
+        )
+      ).toBe(true);
+    });
+
     it('matches ./-prefixed globs when computing exclusions', async () => {
       const tree = createTreeWithEmptyWorkspace();
       tree.write(
@@ -344,14 +371,70 @@ export default defineConfig({});
       );
     });
 
-    it('creates an .mjs config for CJS-flavored workspace file extensions', async () => {
+    it('inlines a workspace file located in a non-root directory', async () => {
       const tree = createTreeWithEmptyWorkspace();
-      tree.write('vitest.workspace.cts', `export default ['apps/*'];\n`);
+      tree.write(
+        'apps/sub/vitest.workspace.ts',
+        `export default ['**/vitest.config.{mjs,js,ts,mts}'];\n`
+      );
 
       await migrateToVitest4(tree);
 
-      expect(tree.exists('vitest.workspace.cts')).toBe(false);
-      expect(tree.read('vitest.config.mjs', 'utf-8')).toContain('projects:');
+      expect(tree.exists('apps/sub/vitest.workspace.ts')).toBe(false);
+      expect(tree.read('apps/sub/vitest.config.ts', 'utf-8')).toContain(
+        "projects: ['**/vitest.config.{mjs,js,ts,mts}']"
+      );
+      expect(tree.exists('vitest.config.ts')).toBe(false);
+    });
+
+    it('inlines array elements wrapped in as-const assertions', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'vitest.workspace.ts',
+        `export default ['apps/*' as const, 'libs/*'];\n`
+      );
+
+      await migrateToVitest4(tree);
+
+      expect(tree.exists('vitest.workspace.ts')).toBe(false);
+      const config = tree.read('vitest.config.ts', 'utf-8');
+      expect(config).toContain("'apps/*'");
+      expect(config).toContain("'libs/*'");
+    });
+
+    it('creates an .mjs config for CJS-flavored workspace file extensions', async () => {
+      for (const ext of ['cts', 'cjs']) {
+        const tree = createTreeWithEmptyWorkspace();
+        tree.write(`vitest.workspace.${ext}`, `export default ['apps/*'];\n`);
+
+        await migrateToVitest4(tree);
+
+        expect(tree.exists(`vitest.workspace.${ext}`)).toBe(false);
+        expect(tree.read('vitest.config.mjs', 'utf-8')).toContain('projects:');
+      }
+    });
+
+    it('defers when the existing root config has duplicate test properties', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write('vitest.workspace.ts', `export default ['packages/*'];\n`);
+      tree.write(
+        'vitest.config.ts',
+        `import { defineConfig } from 'vitest/config';
+export default defineConfig({
+  test: { globals: true },
+  test: { environment: 'node' },
+});
+`
+      );
+      const before = tree.read('vitest.config.ts', 'utf-8');
+
+      const result = await migrateToVitest4(tree);
+
+      expect(tree.exists('vitest.workspace.ts')).toBe(true);
+      expect(tree.read('vitest.config.ts', 'utf-8')).toBe(before);
+      expect(
+        result?.agentContext?.some((s) => s.includes('vitest.workspace'))
+      ).toBe(true);
     });
   });
 
@@ -427,18 +510,59 @@ export default defineConfig({});
     it('does not treat `npm run vitest` style scripts as vitest invocations', async () => {
       const tree = createTreeWithEmptyWorkspace();
       tree.write('vitest.workspace.ts', `export default ['packages/*'];\n`);
+      for (const [pkg, script] of [
+        ['npm-delegated', 'npm run vitest'],
+        ['pnpm-delegated', 'pnpm run vitest'],
+        ['yarn-delegated', 'yarn run vitest'],
+      ]) {
+        tree.write(
+          `packages/${pkg}/package.json`,
+          JSON.stringify({
+            name: pkg,
+            scripts: { vitest: 'jest', test: script },
+          })
+        );
+      }
+
+      await migrateToVitest4(tree);
+
+      for (const pkg of ['npm-delegated', 'pnpm-delegated', 'yarn-delegated']) {
+        expect(tree.exists(`packages/${pkg}/vitest.config.ts`)).toBe(false);
+        expect(tree.exists(`packages/${pkg}/vitest.config.mjs`)).toBe(false);
+      }
+    });
+
+    it('skips packages whose directory hosts a vitest.workspace file', async () => {
+      const tree = createTreeWithEmptyWorkspace();
       tree.write(
-        'packages/delegated/package.json',
-        JSON.stringify({
-          name: 'delegated',
-          scripts: { vitest: 'jest', test: 'npm run vitest' },
-        })
+        'apps/sub/vitest.workspace.ts',
+        `import { extra } from './extra';\nexport default ['packages/*', ...extra];\n`
+      );
+      tree.write(
+        'apps/sub/package.json',
+        JSON.stringify({ name: 'sub', scripts: { test: 'vitest run' } })
       );
 
       await migrateToVitest4(tree);
 
-      expect(tree.exists('packages/delegated/vitest.config.ts')).toBe(false);
-      expect(tree.exists('packages/delegated/vitest.config.mjs')).toBe(false);
+      // The deferred workspace file marks this directory as the
+      // projects-mode entry point; no local config is generated.
+      expect(tree.exists('apps/sub/vitest.config.ts')).toBe(false);
+    });
+
+    it('generates a .ts config when only the package has a tsconfig', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.delete('tsconfig.base.json');
+      tree.write('vitest.workspace.ts', `export default ['packages/*'];\n`);
+      tree.write('packages/local-ts/tsconfig.json', '{}');
+      tree.write(
+        'packages/local-ts/package.json',
+        JSON.stringify({ name: 'local-ts', scripts: { test: 'vitest run' } })
+      );
+
+      await migrateToVitest4(tree);
+
+      expect(tree.exists('packages/local-ts/vitest.config.ts')).toBe(true);
     });
 
     it('skips packages whose vitest script points at an explicit config or root', async () => {
@@ -452,10 +576,24 @@ export default defineConfig({});
         })
       );
       tree.write(
+        'packages/short-config/package.json',
+        JSON.stringify({
+          name: 'short-config',
+          scripts: { test: 'vitest run -c=../shared/vitest.shared.ts' },
+        })
+      );
+      tree.write(
         'packages/explicit-root/package.json',
         JSON.stringify({
           name: 'explicit-root',
           scripts: { test: 'vitest run --root=.' },
+        })
+      );
+      tree.write(
+        'packages/spaced-root/package.json',
+        JSON.stringify({
+          name: 'spaced-root',
+          scripts: { test: 'vitest run --root .' },
         })
       );
 
@@ -464,9 +602,36 @@ export default defineConfig({});
       expect(tree.exists('packages/shared-config/vitest.config.ts')).toBe(
         false
       );
+      expect(tree.exists('packages/short-config/vitest.config.ts')).toBe(false);
       expect(tree.exists('packages/explicit-root/vitest.config.ts')).toBe(
         false
       );
+      expect(tree.exists('packages/spaced-root/vitest.config.ts')).toBe(false);
+    });
+
+    it('detects vitest invocations behind package manager runner prefixes', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write('tsconfig.base.json', '{}');
+      tree.write('vitest.workspace.ts', `export default ['packages/*'];\n`);
+      tree.write(
+        'packages/pnpm-runner/package.json',
+        JSON.stringify({
+          name: 'pnpm-runner',
+          scripts: { test: 'pnpm vitest run' },
+        })
+      );
+      tree.write(
+        'packages/yarn-runner/package.json',
+        JSON.stringify({
+          name: 'yarn-runner',
+          scripts: { test: 'yarn vitest' },
+        })
+      );
+
+      await migrateToVitest4(tree);
+
+      expect(tree.exists('packages/pnpm-runner/vitest.config.ts')).toBe(true);
+      expect(tree.exists('packages/yarn-runner/vitest.config.ts')).toBe(true);
     });
 
     it('generates local configs even when the workspace file inlining was deferred', async () => {

--- a/packages/vite/src/migrations/update-23-0-0/migrate-to-vitest-4.spec.ts
+++ b/packages/vite/src/migrations/update-23-0-0/migrate-to-vitest-4.spec.ts
@@ -70,15 +70,16 @@ export default defineConfig({
       expect(tree.read('vitest.config.ts', 'utf-8')).toContain('projects: ');
     });
 
-    it('logs unhandled when the external vitest.workspace file form is present', async () => {
+    it('logs unhandled when the external vitest.workspace file is not statically inlineable', async () => {
       const tree = createTreeWithEmptyWorkspace();
       tree.write(
         'vitest.workspace.ts',
-        `import { defineWorkspace } from 'vitest/config';\nexport default defineWorkspace(['apps/*']);\n`
+        `import { defineWorkspace } from 'vitest/config';\nimport { extra } from './extra';\nexport default defineWorkspace(['apps/*', ...extra]);\n`
       );
 
       const result = await migrateToVitest4(tree);
 
+      expect(tree.exists('vitest.workspace.ts')).toBe(true);
       expect(
         result?.agentContext?.some((s) => s.includes('vitest.workspace'))
       ).toBe(true);
@@ -86,6 +87,425 @@ export default defineConfig({
       expect(
         result?.agentContext?.some((s) => s.includes('defineWorkspace'))
       ).toBe(true);
+    });
+  });
+
+  describe('vitest.workspace inlining (V4-2)', () => {
+    it('inlines a static array default export into a new root vitest.config.ts and deletes the workspace file', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'vitest.workspace.ts',
+        `export default ['**/vite.config.{mjs,js,ts,mts}', '**/vitest.config.{mjs,js,ts,mts}'];\n`
+      );
+
+      const result = await migrateToVitest4(tree);
+
+      expect(tree.exists('vitest.workspace.ts')).toBe(false);
+      const config = tree.read('vitest.config.ts', 'utf-8');
+      expect(config).toContain("import { defineConfig } from 'vitest/config'");
+      expect(config).toContain("'**/vite.config.{mjs,js,ts,mts}'");
+      expect(config).toContain("'**/vitest.config.{mjs,js,ts,mts}'");
+      expect(config).toContain('projects:');
+      expect(
+        result?.agentContext?.some((s) => s.includes('vitest.workspace'))
+      ).toBeFalsy();
+    });
+
+    it('inlines the defineWorkspace call form', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'vitest.workspace.ts',
+        `import { defineWorkspace } from 'vitest/config';\nexport default defineWorkspace(['apps/*', 'libs/*']);\n`
+      );
+
+      const result = await migrateToVitest4(tree);
+
+      expect(tree.exists('vitest.workspace.ts')).toBe(false);
+      const config = tree.read('vitest.config.ts', 'utf-8');
+      expect(config).toContain("'apps/*'");
+      expect(config).toContain("'libs/*'");
+      // The deleted file's defineWorkspace import must not be flagged.
+      expect(
+        result?.agentContext?.some((s) => s.includes('defineWorkspace'))
+      ).toBeFalsy();
+    });
+
+    it('creates an .mjs config when the workspace file is plain .js', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write('vitest.workspace.js', `export default ['apps/*'];\n`);
+
+      await migrateToVitest4(tree);
+
+      expect(tree.exists('vitest.workspace.js')).toBe(false);
+      expect(tree.read('vitest.config.mjs', 'utf-8')).toContain('projects:');
+    });
+
+    it('merges the projects into an existing root vitest.config.ts test block', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write('vitest.workspace.ts', `export default ['packages/*'];\n`);
+      tree.write(
+        'vitest.config.ts',
+        `import { defineConfig } from 'vitest/config';
+export default defineConfig({
+  test: { globals: true },
+});
+`
+      );
+
+      await migrateToVitest4(tree);
+
+      expect(tree.exists('vitest.workspace.ts')).toBe(false);
+      const config = tree.read('vitest.config.ts', 'utf-8');
+      expect(config).toContain("projects: ['packages/*']");
+      expect(config).toContain('globals: true');
+    });
+
+    it('adds a test block to an existing root vitest.config.ts without one', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write('vitest.workspace.ts', `export default ['packages/*'];\n`);
+      tree.write(
+        'vitest.config.ts',
+        `import { defineConfig } from 'vitest/config';
+export default defineConfig({
+  cacheDir: './node_modules/.vitest',
+});
+`
+      );
+
+      await migrateToVitest4(tree);
+
+      expect(tree.exists('vitest.workspace.ts')).toBe(false);
+      const config = tree.read('vitest.config.ts', 'utf-8');
+      expect(config).toContain("projects: ['packages/*']");
+      expect(config).toContain('cacheDir:');
+    });
+
+    it('defers when the existing root config already defines test.projects', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write('vitest.workspace.ts', `export default ['packages/*'];\n`);
+      tree.write(
+        'vitest.config.ts',
+        `import { defineConfig } from 'vitest/config';
+export default defineConfig({
+  test: { projects: ['apps/*'] },
+});
+`
+      );
+
+      const before = tree.read('vitest.config.ts', 'utf-8');
+
+      const result = await migrateToVitest4(tree);
+
+      expect(tree.exists('vitest.workspace.ts')).toBe(true);
+      // The deferral must not leave partial edits behind.
+      expect(tree.read('vitest.config.ts', 'utf-8')).toBe(before);
+      expect(
+        result?.agentContext?.some((s) => s.includes('vitest.workspace'))
+      ).toBe(true);
+    });
+
+    it('defers when only a root vite.config.ts exists', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write('vitest.workspace.ts', `export default ['packages/*'];\n`);
+      tree.write(
+        'vite.config.ts',
+        `import { defineConfig } from 'vite';
+export default defineConfig({});
+`
+      );
+
+      const result = await migrateToVitest4(tree);
+
+      expect(tree.exists('vitest.workspace.ts')).toBe(true);
+      expect(tree.exists('vitest.config.ts')).toBe(false);
+      expect(
+        result?.agentContext?.some((s) => s.includes('vitest.workspace'))
+      ).toBe(true);
+    });
+
+    it('excludes the vite config of directories where both configs resolve to the same default project name', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'vitest.workspace.ts',
+        `export default ['**/vite.config.{mjs,js,ts,mts}', '**/vitest.config.{mjs,js,ts,mts}'];\n`
+      );
+      tree.write(
+        'packages/dual/package.json',
+        JSON.stringify({ name: '@repro/dual' })
+      );
+      tree.write(
+        'packages/dual/vite.config.ts',
+        `import { defineConfig } from 'vite';\nexport default defineConfig({ test: { environment: 'node' } });\n`
+      );
+      tree.write(
+        'packages/dual/vitest.config.ts',
+        `import { defineConfig } from 'vitest/config';\nexport default defineConfig({ test: { environment: 'node' } });\n`
+      );
+
+      await migrateToVitest4(tree);
+
+      expect(tree.read('vitest.config.ts', 'utf-8')).toContain(
+        "'!packages/dual/vite.config.ts'"
+      );
+    });
+
+    it('does not exclude configs with distinct explicit test.name values', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'vitest.workspace.ts',
+        `export default ['**/vite.config.{mjs,js,ts,mts}', '**/vitest.config.{mjs,js,ts,mts}'];\n`
+      );
+      tree.write(
+        'packages/dual/vite.config.ts',
+        `import { defineConfig } from 'vite';\nexport default defineConfig({ test: { name: 'dual-unit' } });\n`
+      );
+      tree.write(
+        'packages/dual/vitest.config.ts',
+        `import { defineConfig } from 'vitest/config';\nexport default defineConfig({ test: { name: 'dual-e2e' } });\n`
+      );
+
+      await migrateToVitest4(tree);
+
+      expect(tree.read('vitest.config.ts', 'utf-8')).not.toContain("'!");
+    });
+
+    it('excludes the vite config when its explicit test.name equals the other config default name', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'vitest.workspace.ts',
+        `export default ['**/vite.config.{mjs,js,ts,mts}', '**/vitest.config.{mjs,js,ts,mts}'];\n`
+      );
+      tree.write(
+        'packages/dual/package.json',
+        JSON.stringify({ name: '@repro/dual' })
+      );
+      tree.write(
+        'packages/dual/vite.config.ts',
+        `import { defineConfig } from 'vite';\nexport default defineConfig({ test: { name: '@repro/dual' } });\n`
+      );
+      tree.write(
+        'packages/dual/vitest.config.ts',
+        `import { defineConfig } from 'vitest/config';\nexport default defineConfig({ test: {} });\n`
+      );
+
+      await migrateToVitest4(tree);
+
+      expect(tree.read('vitest.config.ts', 'utf-8')).toContain(
+        "'!packages/dual/vite.config.ts'"
+      );
+    });
+
+    it('does not exclude configs whose project name is not statically determinable and forwards an advisory', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'vitest.workspace.ts',
+        `export default ['**/vite.config.{mjs,js,ts,mts}', '**/vitest.config.{mjs,js,ts,mts}'];\n`
+      );
+      tree.write(
+        'packages/dual/vite.config.ts',
+        `import { defineConfig } from 'vite';\nimport { base } from './base';\nexport default defineConfig({ ...base });\n`
+      );
+      tree.write(
+        'packages/dual/vitest.config.ts',
+        `import { defineConfig } from 'vitest/config';\nexport default defineConfig({ test: {} });\n`
+      );
+
+      const result = await migrateToVitest4(tree);
+
+      expect(tree.read('vitest.config.ts', 'utf-8')).not.toContain("'!");
+      expect(
+        result?.agentContext?.some(
+          (s) =>
+            s.includes('packages/dual/vite.config.ts') &&
+            s.includes('negative glob')
+        )
+      ).toBe(true);
+    });
+
+    it('matches ./-prefixed globs when computing exclusions', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'vitest.workspace.ts',
+        `export default ['./**/vite.config.ts', './**/vitest.config.ts'];\n`
+      );
+      tree.write(
+        'packages/dual/vite.config.ts',
+        `import { defineConfig } from 'vite';\nexport default defineConfig({});\n`
+      );
+      tree.write(
+        'packages/dual/vitest.config.ts',
+        `import { defineConfig } from 'vitest/config';\nexport default defineConfig({ test: {} });\n`
+      );
+
+      await migrateToVitest4(tree);
+
+      expect(tree.read('vitest.config.ts', 'utf-8')).toContain(
+        "'!packages/dual/vite.config.ts'"
+      );
+    });
+
+    it('creates an .mjs config for CJS-flavored workspace file extensions', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write('vitest.workspace.cts', `export default ['apps/*'];\n`);
+
+      await migrateToVitest4(tree);
+
+      expect(tree.exists('vitest.workspace.cts')).toBe(false);
+      expect(tree.read('vitest.config.mjs', 'utf-8')).toContain('projects:');
+    });
+  });
+
+  describe('config-less package local config generation', () => {
+    it('generates a minimal local config for packages running vitest via a package.json script', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write('tsconfig.base.json', '{}');
+      tree.write('vitest.workspace.ts', `export default ['packages/*'];\n`);
+      tree.write(
+        'packages/config-less/package.json',
+        JSON.stringify({
+          name: '@repro/config-less',
+          scripts: { test: 'vitest run' },
+        })
+      );
+
+      const result = await migrateToVitest4(tree);
+
+      const config = tree.read(
+        'packages/config-less/vitest.config.ts',
+        'utf-8'
+      );
+      expect(config).toContain("import { defineConfig } from 'vitest/config'");
+      expect(
+        result?.nextSteps?.some((s) =>
+          s.includes('packages/config-less/vitest.config.ts')
+        )
+      ).toBe(true);
+    });
+
+    it('generates an .mjs config when no tsconfig is present', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      // createTreeWithEmptyWorkspace seeds a root tsconfig.base.json; drop it
+      // to simulate a JS-only workspace.
+      tree.delete('tsconfig.base.json');
+      tree.write('vitest.workspace.ts', `export default ['packages/*'];\n`);
+      tree.write(
+        'packages/config-less/package.json',
+        JSON.stringify({
+          name: '@repro/config-less',
+          scripts: { test: 'cross-env NODE_ENV=test vitest run' },
+        })
+      );
+
+      await migrateToVitest4(tree);
+
+      expect(tree.exists('packages/config-less/vitest.config.mjs')).toBe(true);
+    });
+
+    it('skips packages that already have a config and packages without vitest scripts', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write('vitest.workspace.ts', `export default ['packages/*'];\n`);
+      tree.write(
+        'packages/with-config/package.json',
+        JSON.stringify({ name: 'with-config', scripts: { test: 'vitest run' } })
+      );
+      tree.write(
+        'packages/with-config/vitest.config.ts',
+        `import { defineConfig } from 'vitest/config';\nexport default defineConfig({ test: {} });\n`
+      );
+      tree.write(
+        'packages/no-vitest/package.json',
+        JSON.stringify({ name: 'no-vitest', scripts: { test: 'jest' } })
+      );
+
+      await migrateToVitest4(tree);
+
+      expect(tree.exists('packages/with-config/vitest.config.mjs')).toBe(false);
+      expect(tree.exists('packages/no-vitest/vitest.config.ts')).toBe(false);
+      expect(tree.exists('packages/no-vitest/vitest.config.mjs')).toBe(false);
+    });
+
+    it('does not treat `npm run vitest` style scripts as vitest invocations', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write('vitest.workspace.ts', `export default ['packages/*'];\n`);
+      tree.write(
+        'packages/delegated/package.json',
+        JSON.stringify({
+          name: 'delegated',
+          scripts: { vitest: 'jest', test: 'npm run vitest' },
+        })
+      );
+
+      await migrateToVitest4(tree);
+
+      expect(tree.exists('packages/delegated/vitest.config.ts')).toBe(false);
+      expect(tree.exists('packages/delegated/vitest.config.mjs')).toBe(false);
+    });
+
+    it('skips packages whose vitest script points at an explicit config or root', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write('vitest.workspace.ts', `export default ['packages/*'];\n`);
+      tree.write(
+        'packages/shared-config/package.json',
+        JSON.stringify({
+          name: 'shared-config',
+          scripts: { test: 'vitest run --config ../shared/vitest.shared.ts' },
+        })
+      );
+      tree.write(
+        'packages/explicit-root/package.json',
+        JSON.stringify({
+          name: 'explicit-root',
+          scripts: { test: 'vitest run --root=.' },
+        })
+      );
+
+      await migrateToVitest4(tree);
+
+      expect(tree.exists('packages/shared-config/vitest.config.ts')).toBe(
+        false
+      );
+      expect(tree.exists('packages/explicit-root/vitest.config.ts')).toBe(
+        false
+      );
+    });
+
+    it('generates local configs even when the workspace file inlining was deferred', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write('tsconfig.base.json', '{}');
+      tree.write(
+        'vitest.workspace.ts',
+        `import { extra } from './extra';\nexport default ['packages/*', ...extra];\n`
+      );
+      tree.write(
+        'packages/config-less/package.json',
+        JSON.stringify({
+          name: '@repro/config-less',
+          scripts: { test: 'vitest run' },
+        })
+      );
+
+      await migrateToVitest4(tree);
+
+      // The agent will still inline the workspace file into a root projects
+      // config; the local config must exist either way.
+      expect(tree.exists('vitest.workspace.ts')).toBe(true);
+      expect(tree.exists('packages/config-less/vitest.config.ts')).toBe(true);
+    });
+
+    it('does not generate local configs when no vitest.workspace file exists', async () => {
+      const tree = createTreeWithEmptyWorkspace();
+      tree.write(
+        'packages/config-less/package.json',
+        JSON.stringify({
+          name: '@repro/config-less',
+          scripts: { test: 'vitest run' },
+        })
+      );
+
+      await migrateToVitest4(tree);
+
+      expect(tree.exists('packages/config-less/vitest.config.ts')).toBe(false);
+      expect(tree.exists('packages/config-less/vitest.config.mjs')).toBe(false);
     });
   });
 

--- a/packages/vite/src/migrations/update-23-0-0/migrate-to-vitest-4.ts
+++ b/packages/vite/src/migrations/update-23-0-0/migrate-to-vitest-4.ts
@@ -19,9 +19,10 @@ import {
   type TextEdit,
 } from './lib/ast-edits';
 import { visitCiFiles } from './lib/ci-files';
+import { generateLocalVitestConfigs } from './lib/generate-local-vitest-configs';
+import { inlineVitestWorkspaceFiles } from './lib/inline-vitest-workspace';
 import {
   isJsOrTsFile,
-  isVitestWorkspaceFile,
   visitVitestConfigFiles,
 } from './lib/vitest-config-files';
 
@@ -48,15 +49,15 @@ export default async function migrateToVitest4(tree: Tree) {
     processVitestConfig(tree, filePath, unhandled)
   );
 
-  // Workspace files are removed entirely in v4 — their presence is always a
-  // signal that the agent needs to inline them into the root config.
-  visitNotIgnoredFiles(tree, '', (filePath) => {
-    if (!isVitestWorkspaceFile(filePath)) return;
-    unhandled.push(
-      `${filePath}: \`vitest.workspace.*\` files are removed in Vitest 4. ` +
-        `Inline its project list into the root \`vitest.config.*\` under \`test.projects\` and delete this file.`
-    );
-  });
+  // Workspace files are removed entirely in v4. Static ones are inlined into
+  // the root config here; dynamic shapes are forwarded to the agent.
+  const { foundWorkspaceFiles } = inlineVitestWorkspaceFiles(tree, unhandled);
+
+  // The new root projects config breaks `vitest` runs from package
+  // directories that have no config of their own; give those packages one.
+  const generatedConfigs = foundWorkspaceFiles
+    ? generateLocalVitestConfigs(tree)
+    : [];
 
   visitNotIgnoredFiles(tree, '', (filePath) => {
     if (!isJsOrTsFile(filePath)) return;
@@ -81,6 +82,14 @@ export default async function migrateToVitest4(tree: Tree) {
   const nextSteps = [
     `If your CI provider stores Vitest env vars in its dashboard (GitHub Actions repo/org secrets, GitLab CI/CD variables, Vercel/Netlify env vars, etc.), rename \`VITEST_MAX_THREADS\` and \`VITEST_MAX_FORKS\` to \`VITEST_MAX_WORKERS\`, and \`VITE_NODE_DEPS_MODULE_DIRECTORIES\` to \`VITEST_MODULE_DIRECTORIES\`. The pre-pass only handles in-repo files.`,
   ];
+  if (generatedConfigs.length > 0) {
+    nextSteps.push(
+      `Generated a minimal vitest config for packages that run vitest via a package.json script but had no local config (${generatedConfigs.join(
+        ', '
+      )}). Without one, Vitest 4 climbs to the root \`test.projects\` config and fails to start from those directories. Review them and add any test options the packages need. ` +
+        `Note that these packages are now also discovered as projects by root-level \`vitest\` runs when the root \`test.projects\` globs match their new config files.`
+    );
+  }
 
   const result: { nextSteps?: string[]; agentContext?: string[] } = {
     nextSteps,

--- a/packages/vite/src/migrations/update-23-0-0/migrate-to-vitest-4.ts
+++ b/packages/vite/src/migrations/update-23-0-0/migrate-to-vitest-4.ts
@@ -87,7 +87,7 @@ export default async function migrateToVitest4(tree: Tree) {
       `Generated a minimal vitest config for packages that run vitest via a package.json script but had no local config (${generatedConfigs.join(
         ', '
       )}). Without one, Vitest 4 climbs to the root \`test.projects\` config and fails to start from those directories. Review them and add any test options the packages need. ` +
-        `Note that these packages are now also discovered as projects by root-level \`vitest\` runs when the root \`test.projects\` globs match their new config files.`
+        `Note that these packages may also be discovered as projects by root-level \`vitest\` runs when the root \`test.projects\` globs match their new config files.`
     );
   }
 
@@ -188,7 +188,8 @@ function collectCoverageRemovalEdits(
 
 /**
  * `test.workspace` → `test.projects` (V4-2). The external `vitest.workspace.*`
- * file form is detected separately at the top level and always logged.
+ * file form is handled separately at the top level: static files are inlined,
+ * the rest are logged for the agent.
  */
 function collectWorkspaceRenameEdits(
   sourceFile: SourceFile,


### PR DESCRIPTION
## Current Behavior

The `migrate-to-vitest-4` migration defers `vitest.workspace.*` handling entirely to the AI step, which inlines the project globs verbatim into a root `vitest.config.*` under `test.projects`. After the upgrade, packages that run tests through a package.json `vitest` script without a local config fail with "No projects were found": Vitest 4 discovers the new root config by walking up from the package directory and resolves the `test.projects` globs relative to that directory. Workspaces migrated without the AI step get no workspace-file handling at all. Reported while testing the Nx 23 betas; reproduction: https://github.com/juristr/nx23-vitest-issue-repro.

## Expected Behavior

The migration handles workspace files deterministically and produces a working setup on its own:

- Static `vitest.workspace.*` files (the Nx-generated shape) are inlined into the root `vitest.config.*` under `test.projects` and deleted. Only dynamic shapes are forwarded to the AI step.
- Packages that run vitest via a package.json script and have no local config get a minimal `vitest.config.*` generated, so their tests keep running from the package directory and `@nx/vitest` infers their test target.
- When the inlined globs match both a `vite.config.*` and a `vitest.config.*` in the same directory resolving to the same project name, the `vite.config.*` file is excluded with a negative glob. This matches vitest's own vitest-over-vite preference and avoids the "Project name ... is not unique" startup error that the copied globs previously produced on root-level runs. Cases that can't be determined statically are forwarded to the AI step as advisories.

Anything the migration cannot do safely (dynamic workspace files, configs it can't merge into) is still deferred to the AI step with accurate context, and the instructions teach the agent the same rules for the files it inlines itself.

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/troubleshoot-migrate-to-vitest-4-issue-ba08225a)
<!-- polygraph-session-end -->
