### PR TITLE
fix(misc): declare continuous on inferred executor targets

### DIFF
--- a/packages/docker/src/plugins/plugin.spec.ts
+++ b/packages/docker/src/plugins/plugin.spec.ts
@@ -147,6 +147,7 @@ describe('@nx/docker', () => {
                     },
                   },
                   nx-release-publish: {
+                    continuous: false,
                     executor: @nx/docker:release-publish,
                   },
                 },
@@ -258,6 +259,7 @@ describe('@nx/docker', () => {
                     },
                   },
                   nx-release-publish: {
+                    continuous: false,
                     executor: @nx/docker:release-publish,
                   },
                 },
@@ -335,6 +337,7 @@ describe('@nx/docker', () => {
                     },
                   },
                   nx-release-publish: {
+                    continuous: false,
                     executor: @nx/docker:release-publish,
                   },
                   run-docker: {
@@ -469,6 +472,7 @@ describe('@nx/docker', () => {
                     },
                   },
                   nx-release-publish: {
+                    continuous: false,
                     executor: @nx/docker:release-publish,
                   },
                 },
@@ -630,6 +634,7 @@ describe('@nx/docker', () => {
                     },
                   },
                   nx-release-publish: {
+                    continuous: false,
                     executor: @nx/docker:release-publish,
                   },
                 },

--- a/packages/docker/src/plugins/plugin.ts
+++ b/packages/docker/src/plugins/plugin.ts
@@ -357,6 +357,7 @@ async function createDockerTargets(
 
   targets['nx-release-publish'] = {
     executor: '@nx/docker:release-publish',
+    continuous: false,
   };
 
   return { targets, metadata };

--- a/packages/expo/plugins/plugin.ts
+++ b/packages/expo/plugins/plugin.ts
@@ -167,12 +167,15 @@ function buildExpoTargets(
     },
     [options.installTargetName]: {
       executor: '@nx/expo:install',
+      continuous: false,
     },
     [options.prebuildTargetName]: {
       executor: `@nx/expo:prebuild`,
+      continuous: false,
     },
     [options.buildTargetName]: {
       executor: `@nx/expo:build`,
+      continuous: false,
     },
     [options.submitTargetName]: {
       command: `eas submit`,

--- a/packages/playwright/src/plugins/plugin.spec.ts
+++ b/packages/playwright/src/plugins/plugin.spec.ts
@@ -139,6 +139,7 @@ describe('@nx/playwright/plugin', () => {
                   },
                   "e2e-ci--merge-reports": {
                     "cache": true,
+                    "continuous": false,
                     "executor": "@nx/playwright:merge-reports",
                     "inputs": [
                       "default",
@@ -284,6 +285,7 @@ describe('@nx/playwright/plugin', () => {
                   },
                   "e2e-ci--merge-reports": {
                     "cache": true,
+                    "continuous": false,
                     "executor": "@nx/playwright:merge-reports",
                     "inputs": [
                       "default",
@@ -683,6 +685,7 @@ describe('@nx/playwright/plugin', () => {
     expect(targets['e2e-ci--merge-reports']).toMatchInlineSnapshot(`
       {
         "cache": true,
+        "continuous": false,
         "executor": "@nx/playwright:merge-reports",
         "inputs": [
           "default",

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -372,6 +372,7 @@ async function buildPlaywrightTargets(
     }
     targets[options.mergeReportsTargetName] = {
       executor: '@nx/playwright:merge-reports',
+      continuous: false,
       cache: true,
       inputs: ciBaseTargetConfig.inputs,
       outputs: Array.from(mergeReportsTargetOutputs),

--- a/packages/react-native/plugins/plugin.ts
+++ b/packages/react-native/plugins/plugin.ts
@@ -182,6 +182,7 @@ function buildReactNativeTargets(
     },
     [options.syncDepsTargetName]: {
       executor: '@nx/react-native:sync-deps',
+      continuous: false,
     },
     [options.upgradeTargetName]: {
       command: `react-native upgrade`,


### PR DESCRIPTION
## Current Behavior

Inferred (`createNodes`) targets that set an `executor` but omit `continuous` force project-graph normalization (`normalizeTarget`) to read the executor's `schema.json` — resolved from `dist` via `executors.json` — solely to infer the `continuous` flag. In this workspace that surfaces as Nx Cloud sandbox violations (e.g. `playwright:test` reading `packages/playwright/dist/src/executors/merge-reports/schema.json`).

## Expected Behavior

The affected `createNodes` targets declare `continuous` explicitly, so normalization short-circuits the `!('continuous' in target)` guard and never reads the executor schema:

- `@nx/playwright` — `merge-reports`
- `@nx/docker` — `release-publish`
- `@nx/expo` — `install`, `prebuild`, `build`
- `@nx/react-native` — `sync-deps`

The `@nx/web:file-server` targets in storybook/vite/webpack/rspack/nuxt already declare `continuous: true`, which is why they were never affected.

## Related Issue(s)

N/A — Nx Cloud sandbox violation cleanup.
