### PR TITLE
fix(core): evaluate migration requires across journey

### DIFF
--- a/astro-docs/src/content/docs/extending-nx/migration-generators.mdoc
+++ b/astro-docs/src/content/docs/extending-nx/migration-generators.mdoc
@@ -96,3 +96,29 @@ If you just need to change dependency versions, you can add some configuration o
   }
 }
 ```
+
+## Gate migrations and package updates by dependency version
+
+Migration entries and `packageJsonUpdates` entries can use `requires` to apply only when another package version is relevant to the workspace.
+
+```json
+// migrations.json
+{
+  "generators": {
+    "migrate-storybook-v9": {
+      "version": "21.2.0",
+      "description": "Updates Storybook v9 configuration",
+      "implementation": "./src/migrations/migrate-storybook-v9/migrate-storybook-v9",
+      "requires": {
+        "storybook": ">=9.0.0 <10.0.0"
+      }
+    }
+  }
+}
+```
+
+If the required package is also being updated by the same `nx migrate` collection, Nx checks whether the `requires` range intersects the version journey from the installed version (or `--from` override) to the planned version. If there is no planned update for the required package, Nx checks the installed version only.
+
+This means bounded ranges like `>=9.0.0 <10.0.0` are safe for multi-major migrations. For example, a workspace moving `storybook` from `8.x` to `10.1.x` still stages migrations that require `storybook` `>=9.0.0 <10.0.0`, because the update journey crosses the `9.x` range.
+
+Nx does not treat `requires` as a boundary-crossing check. If a workspace starts inside a required range and migrates past it, the migration still matches because the journey intersects the range.

--- a/packages/nx/src/command-line/migrate/migrate.spec.ts
+++ b/packages/nx/src/command-line/migrate/migrate.spec.ts
@@ -1380,6 +1380,74 @@ describe('Migration', () => {
         });
       });
 
+      it('should collect updates when capped requirements intersect a planned dependency journey', async () => {
+        const migrator = new Migrator({
+          packageJson: createPackageJson({
+            dependencies: {
+              mypackage: '1.0.0',
+              dep: '1.0.0',
+              child: '1.0.0',
+            },
+          }),
+          getInstalledPackageVersion: (p) => {
+            if (p === 'mypackage' || p === 'dep' || p === 'child') {
+              return '1.0.0';
+            }
+            return null;
+          },
+          fetch: (p): Promise<ResolvedMigrationConfiguration> => {
+            if (p === 'mypackage') {
+              return Promise.resolve({
+                version: '3.0.0',
+                packageJsonUpdates: {
+                  depV2: {
+                    version: '2.0.0',
+                    packages: {
+                      dep: { version: '2.0.0' },
+                    },
+                  },
+                  depV3: {
+                    version: '3.0.0',
+                    packages: {
+                      dep: { version: '3.0.0' },
+                    },
+                    requires: { dep: '>=2.0.0 <3.0.0' },
+                  },
+                  childForDepV2: {
+                    version: '3.0.0',
+                    packages: {
+                      child: { version: '2.0.0' },
+                    },
+                    requires: { dep: '>=2.0.0 <3.0.0' },
+                  },
+                },
+              });
+            }
+            if (p === 'dep') {
+              return Promise.resolve({ version: '3.0.0' });
+            }
+            if (p === 'child') {
+              return Promise.resolve({ version: '2.0.0' });
+            }
+            return Promise.resolve(null);
+          },
+          from: {},
+          to: {},
+        });
+
+        const result = await migrator.migrate('mypackage', '3.0.0');
+
+        expect(result).toStrictEqual({
+          migrations: [],
+          packageUpdates: {
+            mypackage: { version: '3.0.0', addToPackageJson: false },
+            dep: { version: '3.0.0', addToPackageJson: false },
+            child: { version: '2.0.0', addToPackageJson: false },
+          },
+          minVersionWithSkippedUpdates: undefined,
+        });
+      });
+
       it('should meet requirements with versions set by dependent package updates in package groups', async () => {
         const migrator = new Migrator({
           packageJson: createPackageJson({
@@ -1565,6 +1633,207 @@ describe('Migration', () => {
   });
 
   describe('migrations', () => {
+    it.each([
+      {
+        description: 'capped rung on a chained journey',
+        installedDepVersion: '1.0.0',
+        plannedDepVersion: '3.0.0',
+        requiresRange: '>=2.0.0 <3.0.0',
+        expectedMigrationNames: ['gated'],
+      },
+      {
+        description: 'endpoint in range',
+        installedDepVersion: '2.0.0',
+        plannedDepVersion: '2.5.0',
+        requiresRange: '>=2.0.0 <3.0.0',
+        expectedMigrationNames: ['gated'],
+      },
+      {
+        description: 'journey entirely below the range',
+        installedDepVersion: '1.0.0',
+        plannedDepVersion: '1.5.0',
+        requiresRange: '>=2.0.0 <3.0.0',
+        expectedMigrationNames: [],
+      },
+      {
+        description: 'journey entirely above the range',
+        installedDepVersion: '3.0.0',
+        plannedDepVersion: '4.0.0',
+        requiresRange: '>=2.0.0 <3.0.0',
+        expectedMigrationNames: [],
+      },
+      {
+        description: 'pure floor crossed by planned update',
+        installedDepVersion: '1.0.0',
+        plannedDepVersion: '3.0.0',
+        requiresRange: '>=2.0.0',
+        expectedMigrationNames: ['gated'],
+      },
+      {
+        description: 'pure floor above planned update',
+        installedDepVersion: '3.0.0',
+        plannedDepVersion: '4.0.0',
+        requiresRange: '>=5.0.0',
+        expectedMigrationNames: [],
+      },
+      {
+        description: 'no planned update with matching installed version',
+        installedDepVersion: '2.0.0',
+        plannedDepVersion: null,
+        requiresRange: '>=2.0.0 <3.0.0',
+        expectedMigrationNames: ['gated'],
+      },
+      {
+        description: 'no planned update with non-matching installed version',
+        installedDepVersion: '1.0.0',
+        plannedDepVersion: null,
+        requiresRange: '>=2.0.0 <3.0.0',
+        expectedMigrationNames: [],
+      },
+      {
+        description: '--from override used as journey origin',
+        installedDepVersion: '3.0.0',
+        plannedDepVersion: '4.0.0',
+        requiresRange: '>=2.0.0 <3.0.0',
+        fromOverrides: { dep: '1.0.0' },
+        expectedMigrationNames: ['gated'],
+      },
+    ])(
+      'should evaluate migration requirements against the dependency journey: $description',
+      async ({
+        installedDepVersion,
+        plannedDepVersion,
+        requiresRange,
+        fromOverrides = {},
+        expectedMigrationNames,
+      }) => {
+        const installedVersions: Record<string, string> = {
+          parent: '1.0.0',
+          dep: installedDepVersion,
+        };
+        const migrator = new Migrator({
+          packageJson: createPackageJson({
+            dependencies: {
+              parent: '1.0.0',
+              dep: installedDepVersion,
+            },
+          }),
+          getInstalledPackageVersion: (p, overrides) =>
+            overrides?.[p] ?? installedVersions[p] ?? null,
+          fetch: (p): Promise<ResolvedMigrationConfiguration> => {
+            if (p === 'parent') {
+              return Promise.resolve({
+                version: '3.0.0',
+                ...(plannedDepVersion
+                  ? {
+                      packageJsonUpdates: {
+                        depUpdate: {
+                          version: '3.0.0',
+                          packages: {
+                            dep: { version: plannedDepVersion },
+                          },
+                        },
+                      },
+                    }
+                  : {}),
+                generators: {
+                  gated: {
+                    version: '3.0.0',
+                    description: 'gated desc',
+                    requires: { dep: requiresRange },
+                  },
+                },
+              });
+            }
+            if (p === 'dep') {
+              return Promise.resolve({
+                version: plannedDepVersion ?? installedDepVersion,
+              });
+            }
+            return Promise.resolve(null);
+          },
+          from: fromOverrides,
+          to: {},
+        });
+
+        const result = await migrator.migrate('parent', '3.0.0');
+
+        expect(result.migrations.map((migration) => migration.name)).toEqual(
+          expectedMigrationNames
+        );
+      }
+    );
+
+    it('should stage a capped migration when a Storybook-style chain crosses the required major', async () => {
+      const installedVersions: Record<string, string> = {
+        '@nx/storybook': '20.0.0',
+        storybook: '8.0.0',
+      };
+      const migrator = new Migrator({
+        packageJson: createPackageJson({
+          dependencies: {
+            '@nx/storybook': '20.0.0',
+            storybook: '8.0.0',
+          },
+        }),
+        getInstalledPackageVersion: (p, overrides) =>
+          overrides?.[p] ?? installedVersions[p] ?? null,
+        fetch: (p): Promise<ResolvedMigrationConfiguration> => {
+          if (p === '@nx/storybook') {
+            return Promise.resolve({
+              version: '22.2.0',
+              packageJsonUpdates: {
+                storybookV9: {
+                  version: '21.1.0',
+                  packages: {
+                    storybook: { version: '^9.0.0' },
+                  },
+                  requires: { storybook: '<9.0.0' },
+                },
+                storybookV10: {
+                  version: '22.1.0',
+                  packages: {
+                    storybook: { version: '^10.0.0' },
+                  },
+                  requires: { storybook: '>=9.0.0 <10.0.0' },
+                },
+                storybookV10_1: {
+                  version: '22.2.0',
+                  packages: {
+                    storybook: { version: '^10.1.0' },
+                  },
+                  requires: { storybook: '>=10.0.0 <10.1.0' },
+                },
+              },
+              generators: {
+                'update-21-2-0-migrate-storybook-v9': {
+                  version: '21.2.0',
+                  description: 'Migrate Storybook v9 configuration',
+                  requires: { storybook: '>=9.0.0 <10.0.0' },
+                },
+              },
+            });
+          }
+          if (p === 'storybook') {
+            return Promise.resolve({ version: '10.1.0' });
+          }
+          return Promise.resolve(null);
+        },
+        from: {},
+        to: {},
+      });
+
+      const result = await migrator.migrate('@nx/storybook', '22.2.0');
+
+      expect(result.migrations).toContainEqual({
+        version: '21.2.0',
+        name: 'update-21-2-0-migrate-storybook-v9',
+        package: '@nx/storybook',
+        description: 'Migrate Storybook v9 configuration',
+        requires: { storybook: '>=9.0.0 <10.0.0' },
+      });
+    });
+
     it('should create a list of migrations to run', async () => {
       const migrator = new Migrator({
         packageJson: createPackageJson({
@@ -2017,6 +2286,57 @@ describe('Migration', () => {
           pkg1: { version: '2.0.0', addToPackageJson: false },
         },
       });
+    });
+
+    it('should not treat capped requirements as skipped when --exclude-applied-migrations already crossed the range', async () => {
+      const installedVersions: Record<string, string> = {
+        parent: '2.0.0',
+        pkg1: '3.0.0',
+      };
+      const migrator = new Migrator({
+        packageJson: createPackageJson({
+          dependencies: {
+            parent: '2.0.0',
+            pkg1: '3.0.0',
+          },
+        }),
+        getInstalledPackageVersion: (p, overrides) =>
+          overrides?.[p] ?? installedVersions[p] ?? null,
+        fetch: (p): Promise<ResolvedMigrationConfiguration> => {
+          if (p === 'parent') {
+            return Promise.resolve({
+              version: '3.0.0',
+              packageGroup: [{ package: 'pkg1', version: '*' }],
+              generators: {
+                previousCappedMigration: {
+                  version: '1.0.0',
+                  description: 'previous capped migration desc',
+                  requires: {
+                    pkg1: '>=1.0.0 <2.0.0',
+                  },
+                },
+                newMigration: {
+                  version: '3.0.0',
+                  description: 'new migration desc',
+                },
+              },
+            });
+          }
+          if (p === 'pkg1') {
+            return Promise.resolve({ version: '3.0.0' });
+          }
+          return Promise.resolve(null);
+        },
+        from: { parent: '0.1.0' },
+        to: {},
+        excludeAppliedMigrations: true,
+      });
+
+      const result = await migrator.migrate('parent', '3.0.0');
+
+      expect(result.migrations.map((migration) => migration.name)).toEqual([
+        'newMigration',
+      ]);
     });
   });
 

--- a/packages/nx/src/command-line/migrate/migrate.spec.ts
+++ b/packages/nx/src/command-line/migrate/migrate.spec.ts
@@ -1448,6 +1448,66 @@ describe('Migration', () => {
         });
       });
 
+      it('should skip updates with invalid requirements against a planned dependency journey', async () => {
+        const migrator = new Migrator({
+          packageJson: createPackageJson({
+            dependencies: {
+              mypackage: '1.0.0',
+              dep: '1.0.0',
+              child: '1.0.0',
+            },
+          }),
+          getInstalledPackageVersion: (p) => {
+            if (p === 'mypackage' || p === 'dep' || p === 'child') {
+              return '1.0.0';
+            }
+            return null;
+          },
+          fetch: (p): Promise<ResolvedMigrationConfiguration> => {
+            if (p === 'mypackage') {
+              return Promise.resolve({
+                version: '3.0.0',
+                packageJsonUpdates: {
+                  depV3: {
+                    version: '3.0.0',
+                    packages: {
+                      dep: { version: '3.0.0' },
+                    },
+                  },
+                  invalidRequirement: {
+                    version: '3.0.0',
+                    packages: {
+                      child: { version: '2.0.0' },
+                    },
+                    requires: { dep: 'not a range' },
+                  },
+                },
+              });
+            }
+            if (p === 'dep') {
+              return Promise.resolve({ version: '3.0.0' });
+            }
+            if (p === 'child') {
+              throw new Error('should not be processed');
+            }
+            return Promise.resolve(null);
+          },
+          from: {},
+          to: {},
+        });
+
+        await expect(
+          migrator.migrate('mypackage', '3.0.0')
+        ).resolves.toStrictEqual({
+          migrations: [],
+          packageUpdates: {
+            mypackage: { version: '3.0.0', addToPackageJson: false },
+            dep: { version: '3.0.0', addToPackageJson: false },
+          },
+          minVersionWithSkippedUpdates: undefined,
+        });
+      });
+
       it('should meet requirements with versions set by dependent package updates in package groups', async () => {
         const migrator = new Migrator({
           packageJson: createPackageJson({
@@ -1697,6 +1757,13 @@ describe('Migration', () => {
         requiresRange: '>=2.0.0 <3.0.0',
         fromOverrides: { dep: '1.0.0' },
         expectedMigrationNames: ['gated'],
+      },
+      {
+        description: 'invalid range with a planned update',
+        installedDepVersion: '1.0.0',
+        plannedDepVersion: '3.0.0',
+        requiresRange: 'not a range',
+        expectedMigrationNames: [],
       },
     ])(
       'should evaluate migration requirements against the dependency journey: $description',
@@ -2313,6 +2380,13 @@ describe('Migration', () => {
                   description: 'previous capped migration desc',
                   requires: {
                     pkg1: '>=1.0.0 <2.0.0',
+                  },
+                },
+                previousInvalidMigration: {
+                  version: '1.0.0',
+                  description: 'previous invalid migration desc',
+                  requires: {
+                    pkg1: 'not a range',
                   },
                 },
                 newMigration: {

--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -17,6 +17,7 @@ import {
   rsort,
   satisfies,
   valid,
+  validRange,
 } from 'semver';
 import { URL } from 'node:url';
 import { promisify } from 'util';
@@ -774,6 +775,10 @@ export class Migrator {
     toVersion: string | null,
     versionRange: string
   ): boolean {
+    if (!validRange(versionRange, { includePrerelease: true })) {
+      return false;
+    }
+
     const cleanedToVersion = toVersion && cleanSemverVersion(toVersion);
     if (!cleanedToVersion) {
       return false;

--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -10,6 +10,7 @@ import {
   coerce,
   gt,
   gte,
+  intersects,
   lt,
   lte,
   major,
@@ -217,6 +218,13 @@ function runOrReturnExitCode(run: () => void): number {
 
 function cleanSemver(version: string) {
   return clean(version) ?? coerce(version);
+}
+
+function cleanSemverVersion(version: string): string | null {
+  const cleanedVersion = cleanSemver(version);
+  return typeof cleanedVersion === 'string'
+    ? cleanedVersion
+    : (cleanedVersion?.version ?? null);
 }
 
 function normalizeSlashes(packageName: string): string {
@@ -741,22 +749,57 @@ export class Migrator {
       return true;
     }
 
-    return Object.entries(requirements).every(([pkgName, versionRange]) => {
-      if (this.packageUpdates[pkgName]) {
-        return satisfies(
-          cleanSemver(this.packageUpdates[pkgName].version),
-          versionRange,
-          { includePrerelease: true }
-        );
-      }
+    return Object.entries(requirements).every(([pkgName, versionRange]) =>
+      this.isRequirementMet(pkgName, versionRange)
+    );
+  }
 
-      return (
-        this.getPkgVersion(pkgName) &&
-        satisfies(this.getPkgVersion(pkgName), versionRange, {
-          includePrerelease: true,
-        })
+  private isRequirementMet(pkgName: string, versionRange: string): boolean {
+    if (this.packageUpdates[pkgName]) {
+      return this.doesVersionRangeIntersectJourney(
+        this.getPkgVersion(pkgName),
+        this.packageUpdates[pkgName].version,
+        versionRange
       );
-    });
+    }
+
+    return this.doesVersionRangeMatchVersion(
+      this.getPkgVersion(pkgName),
+      versionRange
+    );
+  }
+
+  private doesVersionRangeIntersectJourney(
+    fromVersion: string | null,
+    toVersion: string | null,
+    versionRange: string
+  ): boolean {
+    const cleanedToVersion = toVersion && cleanSemverVersion(toVersion);
+    if (!cleanedToVersion) {
+      return false;
+    }
+
+    const cleanedFromVersion = fromVersion && cleanSemverVersion(fromVersion);
+    if (!cleanedFromVersion || gt(cleanedFromVersion, cleanedToVersion)) {
+      return this.doesVersionRangeMatchVersion(cleanedToVersion, versionRange);
+    }
+
+    return intersects(
+      versionRange,
+      `>=${cleanedFromVersion} <=${cleanedToVersion}`,
+      { includePrerelease: true }
+    );
+  }
+
+  private doesVersionRangeMatchVersion(
+    version: string | null,
+    versionRange: string
+  ): boolean {
+    const cleanedVersion = version && cleanSemverVersion(version);
+    return (
+      !!cleanedVersion &&
+      satisfies(cleanedVersion, versionRange, { includePrerelease: true })
+    );
   }
 
   private areIncompatiblePackagesPresent(
@@ -818,19 +861,23 @@ export class Migrator {
   private wasMigrationSkipped(
     requirements: PackageJsonUpdates[string]['requires']
   ): boolean {
-    // no requiremets, so it ran before
+    // no requirements, so it ran before
     if (!requirements || !Object.keys(requirements).length) {
       return false;
     }
 
     // at least a requirement was not met, it was skipped
-    return Object.entries(requirements).some(
-      ([pkgName, versionRange]) =>
-        !this.getInstalledPackageVersion(pkgName) ||
-        !satisfies(this.getInstalledPackageVersion(pkgName), versionRange, {
-          includePrerelease: true,
-        })
-    );
+    return Object.entries(requirements).some(([pkgName, versionRange]) => {
+      const installedVersion = this.getInstalledPackageVersion(pkgName);
+      return (
+        !installedVersion ||
+        !this.doesVersionRangeIntersectJourney(
+          this.getPkgVersion(pkgName),
+          installedVersion,
+          versionRange
+        )
+      );
+    });
   }
 
   private async runPackageJsonUpdatesConfirmationPrompt(

--- a/packages/nx/src/config/misc-interfaces.ts
+++ b/packages/nx/src/config/misc-interfaces.ts
@@ -66,14 +66,6 @@ export type PackageJsonUpdates = {
       [packageName: string]: PackageJsonUpdateForPackage;
     };
     'x-prompt'?: string;
-    /**
-     * Additional package version requirements for applying this package update.
-     * When a required package is also updated in the same `nx migrate`
-     * collection, Nx checks whether this range intersects the journey from the
-     * installed version (or `--from` override) to the planned version. When no
-     * update is planned for the required package, Nx checks the installed
-     * version as a point-in-time requirement.
-     */
     requires?: Record<string, string>;
     incompatibleWith?: Record<string, string>;
   };
@@ -115,14 +107,6 @@ export interface MigrationsJsonEntry {
   implementation?: string;
   factory?: string;
   prompt?: string;
-  /**
-   * Additional package version requirements for staging this migration. When a
-   * required package is also updated in the same `nx migrate` collection, Nx
-   * checks whether this range intersects the journey from the installed version
-   * (or `--from` override) to the planned version. When no update is planned
-   * for the required package, Nx checks the installed version as a point-in-time
-   * requirement.
-   */
   requires?: Record<string, string>;
   /**
    * Path to a markdown doc describing the migration, relative to the

--- a/packages/nx/src/config/misc-interfaces.ts
+++ b/packages/nx/src/config/misc-interfaces.ts
@@ -66,6 +66,14 @@ export type PackageJsonUpdates = {
       [packageName: string]: PackageJsonUpdateForPackage;
     };
     'x-prompt'?: string;
+    /**
+     * Additional package version requirements for applying this package update.
+     * When a required package is also updated in the same `nx migrate`
+     * collection, Nx checks whether this range intersects the journey from the
+     * installed version (or `--from` override) to the planned version. When no
+     * update is planned for the required package, Nx checks the installed
+     * version as a point-in-time requirement.
+     */
     requires?: Record<string, string>;
     incompatibleWith?: Record<string, string>;
   };
@@ -107,6 +115,14 @@ export interface MigrationsJsonEntry {
   implementation?: string;
   factory?: string;
   prompt?: string;
+  /**
+   * Additional package version requirements for staging this migration. When a
+   * required package is also updated in the same `nx migrate` collection, Nx
+   * checks whether this range intersects the journey from the installed version
+   * (or `--from` override) to the planned version. When no update is planned
+   * for the required package, Nx checks the installed version as a point-in-time
+   * requirement.
+   */
   requires?: Record<string, string>;
   /**
    * Path to a markdown doc describing the migration, relative to the


### PR DESCRIPTION
## Current Behavior

During migration collection, `requires` gates for dependencies with planned updates are evaluated against the final planned endpoint only. Bounded ranges such as `>=9.0.0 <10.0.0` can drop migrations that are needed when a single `nx migrate` run crosses that intermediate range.

## Expected Behavior

`requires` gates now intersect the required range with the dependency journey from the installed version, or `--from` override, to the planned version. Dependencies without a planned update keep the existing installed version point check. `--exclude-applied-migrations` uses the same journey-aware reasoning for bounded ranges, and plugin-author docs describe the semantics, including the non-boundary-crossing caveat.

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/nxc-4549-33e9fa7f)
<!-- polygraph-session-end -->
