### PR TITLE
docs(misc): align compat matrices with v23 ranges

### DIFF
--- a/astro-docs/sidebar.mts
+++ b/astro-docs/sidebar.mts
@@ -465,12 +465,29 @@ const technologiesGroups: SidebarItems = [
           { label: 'Expo', link: 'technologies/react/expo/introduction' },
           { label: 'Vue', link: 'technologies/vue/introduction' },
           { label: 'Nuxt', link: 'technologies/vue/nuxt/introduction' },
+          {
+            label: 'Module Federation',
+            link: 'technologies/module-federation/introduction',
+          },
+          { label: 'ESLint', link: 'technologies/eslint/introduction' },
+        ],
+      },
+      {
+        label: 'Node',
+        collapsed: false,
+        items: [
           { label: 'Node.js', link: 'technologies/node/introduction' },
           {
             label: 'Express',
             link: 'technologies/node/express/introduction',
           },
           { label: 'Nest', link: 'technologies/node/nest/introduction' },
+        ],
+      },
+      {
+        label: 'Java (JVM)',
+        collapsed: false,
+        items: [
           { label: 'Java', link: 'technologies/java/introduction' },
           {
             label: 'Gradle',
@@ -480,13 +497,12 @@ const technologiesGroups: SidebarItems = [
             label: 'Maven',
             link: 'technologies/java/maven/introduction',
           },
-          { label: '.NET', link: 'technologies/dotnet/introduction' },
-          {
-            label: 'Module Federation',
-            link: 'technologies/module-federation/introduction',
-          },
-          { label: 'ESLint', link: 'technologies/eslint/introduction' },
         ],
+      },
+      {
+        label: '.NET',
+        collapsed: false,
+        items: [{ label: '.NET', link: 'technologies/dotnet/introduction' }],
       },
       {
         label: 'Build tools',

--- a/astro-docs/src/content/docs/extending-nx/createnodes-compatibility.mdoc
+++ b/astro-docs/src/content/docs/extending-nx/createnodes-compatibility.mdoc
@@ -10,12 +10,13 @@ This is a reference for knowing how Nx versions and the `createNodes`/`createNod
 
 The following table shows which export Nx will call based on the Nx version:
 
-| Nx Version    | Calls `createNodes` | Calls `createNodesV2` | Nx Call Preference           |
-| ------------- | ------------------- | --------------------- | ---------------------------- |
-| 17.x - 19.1.x | Yes                 | No                    | Only v1 supported            |
-| 19.2.x - 20.x | Yes (fallback)      | Yes (preferred)       | Prefers v2, falls back to v1 |
-| 21.x          | No                  | Yes                   | Only v2 supported            |
-| 22.x+         | Yes (v2 signature)  | Yes                   | Both use v2 signature        |
+| Nx Version    | Calls `createNodes` | Calls `createNodesV2` | Nx Call Preference                                           |
+| ------------- | ------------------- | --------------------- | ------------------------------------------------------------ |
+| 17.x - 19.1.x | Yes                 | No                    | Only v1 supported                                            |
+| 19.2.x - 20.x | Yes (fallback)      | Yes (preferred)       | Prefers v2, falls back to v1                                 |
+| 21.x          | No                  | Yes                   | Only v2 supported                                            |
+| 22.x          | Yes (v2 signature)  | Yes                   | Both use v2 signature                                        |
+| 23.x+         | Yes (v2 signature)  | Yes (fallback)        | Prefers `createNodes`; `createNodesV2` is a deprecated alias |
 
 ## Which Nx versions does my plugin support?
 

--- a/astro-docs/src/content/docs/how-nx-works/index.mdoc
+++ b/astro-docs/src/content/docs/how-nx-works/index.mdoc
@@ -6,4 +6,4 @@ sidebar:
 pagefind: false
 ---
 
-{% sidebar_group_cards group="How Nx Works" /%}
+{% sidebar_group_cards group="How Nx works" /%}

--- a/astro-docs/src/content/docs/technologies-tools/build-tools/index.mdoc
+++ b/astro-docs/src/content/docs/technologies-tools/build-tools/index.mdoc
@@ -6,4 +6,4 @@ sidebar:
 pagefind: false
 ---
 
-{% sidebar_group_cards group="Technologies & Tools/Build Tools" /%}
+{% sidebar_group_cards group="Technologies & tools/Build tools" /%}

--- a/astro-docs/src/content/docs/technologies-tools/dotnet/index.mdoc
+++ b/astro-docs/src/content/docs/technologies-tools/dotnet/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: .NET
+description: Nx support for .NET projects
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Technologies & tools/.NET" /%}

--- a/astro-docs/src/content/docs/technologies-tools/frameworks-libraries/index.mdoc
+++ b/astro-docs/src/content/docs/technologies-tools/frameworks-libraries/index.mdoc
@@ -6,4 +6,4 @@ sidebar:
 pagefind: false
 ---
 
-{% sidebar_group_cards group="Technologies & Tools/Frameworks & Libraries" /%}
+{% sidebar_group_cards group="Technologies & tools/Frameworks & libraries" /%}

--- a/astro-docs/src/content/docs/technologies-tools/index.mdoc
+++ b/astro-docs/src/content/docs/technologies-tools/index.mdoc
@@ -6,4 +6,4 @@ sidebar:
 pagefind: false
 ---
 
-{% sidebar_group_cards group="Technologies & Tools" /%}
+{% sidebar_group_cards group="Technologies & tools" /%}

--- a/astro-docs/src/content/docs/technologies-tools/java-jvm/index.mdoc
+++ b/astro-docs/src/content/docs/technologies-tools/java-jvm/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Java (JVM)
+description: Nx support for Java projects using Gradle and Maven
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Technologies & tools/Java (JVM)" /%}

--- a/astro-docs/src/content/docs/technologies-tools/node/index.mdoc
+++ b/astro-docs/src/content/docs/technologies-tools/node/index.mdoc
@@ -1,0 +1,9 @@
+---
+title: Node
+description: Nx support for Node.js backend frameworks like Express and Nest
+sidebar:
+  hidden: true
+pagefind: false
+---
+
+{% sidebar_group_cards group="Technologies & tools/Node" /%}

--- a/astro-docs/src/content/docs/technologies-tools/test-tools/index.mdoc
+++ b/astro-docs/src/content/docs/technologies-tools/test-tools/index.mdoc
@@ -6,4 +6,4 @@ sidebar:
 pagefind: false
 ---
 
-{% sidebar_group_cards group="Technologies & Tools/Test Tools" /%}
+{% sidebar_group_cards group="Technologies & tools/Test tools" /%}

--- a/astro-docs/src/content/docs/technologies/eslint/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/eslint/introduction.mdoc
@@ -13,9 +13,9 @@ The ESLint plugin integrates [ESLint](https://eslint.org/) with Nx. Run ESLint t
 
 The `@nx/eslint` plugin supports the following package versions.
 
-| Package  | Supported Versions |
-| -------- | ------------------ |
-| `eslint` | ^8.0.0 \|\| ^9.0.0 |
+| Package  | Supported Versions              |
+| -------- | ------------------------------- |
+| `eslint` | ^8.0.0 \|\| ^9.0.0 \|\| ^10.0.0 |
 
 [Nx generators](/docs/features/generate-code) install the latest supported versions automatically when scaffolding new projects.
 

--- a/astro-docs/src/content/docs/technologies/node/express/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/node/express/introduction.mdoc
@@ -16,7 +16,7 @@ The `@nx/express` plugin supports the following package versions.
 
 | Package   | Supported Versions |
 | --------- | ------------------ |
-| `express` | ^4.0.0, ^5.0.0     |
+| `express` | ^4.0.0 \|\| ^5.0.0 |
 
 [Nx generators](/docs/features/generate-code) install the latest supported versions automatically when scaffolding new projects.
 

--- a/astro-docs/src/content/docs/technologies/node/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/node/introduction.mdoc
@@ -25,7 +25,8 @@ Node 26 is on the Current release track and enters LTS in October 2026. Nx tests
 
 | Nx Version     | Node Version                   |
 | -------------- | ------------------------------ |
-| 22.x (current) | 26.x, 24.x, ^22.12.0, ^20.19.0 |
+| 23.x (current) | 26.x, 24.x, ^22.12.0           |
+| 22.x           | 26.x, 24.x, ^22.12.0, ^20.19.0 |
 | 21.x           | 24.x, ^22.12.0, ^20.19.0       |
 | 20.x           | 22.x, 20.x, 18.x               |
 

--- a/astro-docs/src/content/docs/technologies/node/nest/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/node/nest/introduction.mdoc
@@ -21,15 +21,16 @@ Many conventions and best practices used in Angular applications can be also be 
 
 The `@nx/nest` plugin supports the following NestJS package versions.
 
-| Package        | Supported Versions |
-| -------------- | ------------------ |
-| `@nestjs/core` | ^10.0.0, ^11.0.0   |
+| Package        | Supported Versions   |
+| -------------- | -------------------- |
+| `@nestjs/core` | ^10.0.0 \|\| ^11.0.0 |
 
 The plugin detects the installed `@nestjs/core` major and routes the rest of the `@nestjs/*` family (plus `rxjs` and `reflect-metadata`) to versions that pair with it. Fresh installs default to NestJS v11.
 
 | Nx Version     | Default NestJS Version |
 | -------------- | ---------------------- |
-| 22.x (current) | ^11.0.0                |
+| 23.x (current) | ^11.0.0                |
+| 22.x           | ^11.0.0                |
 | 21.x           | ^11.0.0                |
 | 20.x           | ^10.0.0                |
 

--- a/astro-docs/src/content/docs/technologies/react/remix/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/react/remix/introduction.mdoc
@@ -23,7 +23,7 @@ The `@nx/remix` plugin supports the following package versions.
 
 | Package          | Supported Versions |
 | ---------------- | ------------------ |
-| `@remix-run/dev` | ^2.17.3            |
+| `@remix-run/dev` | ^2.0.0             |
 
 [Nx generators](/docs/features/generate-code) install the latest supported versions automatically when scaffolding new projects.
 

--- a/astro-docs/src/content/docs/technologies/test-tools/detox/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/detox/introduction.mdoc
@@ -21,7 +21,7 @@ The `@nx/detox` plugin supports the following package versions.
 
 | Package | Supported Versions |
 | ------- | ------------------ |
-| `detox` | ^20.9.0            |
+| `detox` | ^20.0.0            |
 
 [Nx generators](/docs/features/generate-code) install the latest supported versions automatically when scaffolding new projects.
 

--- a/astro-docs/src/content/docs/technologies/test-tools/storybook/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/storybook/introduction.mdoc
@@ -21,11 +21,6 @@ The `@nx/storybook` plugin supports the following package versions.
 
 [Nx generators](/docs/features/generate-code) install the latest supported versions automatically when scaffolding new projects.
 
-<!-- The peerDependencies in @nx/storybook's package.json declares >=7.0.0 so that
-     users who still have Storybook 7 installed get a friendlier error from Nx
-     rather than a cryptic package-manager resolution failure. Storybook 7 is
-     no longer actively supported. -->
-
 ## Setting up Storybook
 
 ### Installation

--- a/astro-docs/src/content/docs/technologies/test-tools/vitest/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/vitest/introduction.mdoc
@@ -15,11 +15,11 @@ You can use Vitest with Nx without the plugin and still get [task caching](/docs
 
 ## Requirements
 
-The `@nx/vite` plugin supports the following package versions.
+The `@nx/vitest` plugin supports the following package versions.
 
-| Package  | Supported Versions                         |
-| -------- | ------------------------------------------ |
-| `vitest` | ^1.0.0 \|\| ^2.0.0 \|\| ^3.0.0 \|\| ^4.0.0 |
+| Package  | Supported Versions |
+| -------- | ------------------ |
+| `vitest` | ^3.0.0 \|\| ^4.0.0 |
 
 [Nx generators](/docs/features/generate-code) install the latest supported versions automatically when scaffolding new projects.
 

--- a/astro-docs/src/content/docs/technologies/typescript/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/typescript/introduction.mdoc
@@ -19,7 +19,8 @@ Nx supports the latest version of TypeScript. TypeScript itself only officially 
 
 | Nx Version     | TypeScript Version |
 | -------------- | ------------------ |
-| 22.x (current) | >= 5.4.2 < 5.10.0  |
+| 23.x (current) | >= 5.4.2 < 5.10.0  |
+| 22.x           | >= 5.4.2 < 5.10.0  |
 | 21.x           | >= 5.4.2 < 5.10.0  |
 | 20.x           | ~5.4.2             |
 

--- a/astro-docs/src/content/docs/technologies/vue/nuxt/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/vue/nuxt/introduction.mdoc
@@ -13,9 +13,9 @@ The Nx plugin for [Nuxt](https://nuxt.com/).
 
 The `@nx/nuxt` plugin supports the following package versions.
 
-| Package | Supported Versions  |
-| ------- | ------------------- |
-| `nuxt`  | ^3.10.0 \|\| ^4.0.0 |
+| Package | Supported Versions |
+| ------- | ------------------ |
+| `nuxt`  | ^3.0.0 \|\| ^4.0.0 |
 
 [Nx generators](/docs/features/generate-code) install the latest supported versions automatically when scaffolding new projects.
 


### PR DESCRIPTION
## Current Behavior

Technology docs version tables drift from v23 peer dep ranges (eslint missing ^10, vitest page cites @nx/vite with ^1-^4, detox/nuxt/remix floors stale). Nx version matrices stop at 22.x.

## Expected Behavior

Supported-version tables match packages/*/package.json peer deps. 23.x rows added to TypeScript, Node (Node 20 dropped), NestJS and createNodes matrices.

## Related Issue(s)

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/docs-update-misc-updates-v23-837b8d30)
<!-- polygraph-session-end -->