### PR TITLE
fix(core): allow analytics requests through Claude Code sandbox network filter

### DIFF
--- a/packages/nx/src/ai/constants.ts
+++ b/packages/nx/src/ai/constants.ts
@@ -64,6 +64,12 @@ export const getAgentRulesWrapped = (options: AgentRulesWrappedOptions) => {
   return `${nxRulesMarkerCommentStart}\n${nxRulesMarkerCommentDescription}\n\n${agentRulesString}\n\n${nxRulesMarkerCommentEnd}`;
 };
 
+/**
+ * Hostname Nx analytics events are sent to (GA4 Measurement Protocol).
+ * Must stay in sync with GA_ENDPOINT in packages/nx/src/native/telemetry/constants.rs.
+ */
+export const analyticsDomain = 'www.google-analytics.com';
+
 export const nxMcpTomlHeader = `[mcp_servers."nx-mcp"]`;
 
 /**

--- a/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.spec.ts
+++ b/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.spec.ts
@@ -404,6 +404,52 @@ describe('setup-ai-agents generator', () => {
         expect(config.enabledPlugins['nx@nx-claude-plugins']).toBe(true);
       });
 
+      it('should allow analytics requests through the sandbox network filter', async () => {
+        const options: SetupAiAgentsGeneratorSchema = {
+          directory: '.',
+          agents: ['claude'],
+        };
+
+        await setupAiAgentsGenerator(tree, options);
+
+        const config = JSON.parse(
+          tree.read('.claude/settings.json')?.toString() ?? '{}'
+        );
+        expect(config.sandbox.network.allowedDomains).toEqual([
+          'www.google-analytics.com',
+        ]);
+      });
+
+      it('should preserve existing sandbox allowed domains and not duplicate the analytics domain', async () => {
+        const options: SetupAiAgentsGeneratorSchema = {
+          directory: '.',
+          agents: ['claude'],
+        };
+
+        tree.write(
+          '.claude/settings.json',
+          JSON.stringify({
+            sandbox: {
+              autoAllowBashIfSandboxed: true,
+              network: {
+                allowedDomains: ['example.com', 'www.google-analytics.com'],
+              },
+            },
+          })
+        );
+
+        await setupAiAgentsGenerator(tree, options);
+
+        const config = JSON.parse(
+          tree.read('.claude/settings.json')?.toString() ?? '{}'
+        );
+        expect(config.sandbox.autoAllowBashIfSandboxed).toBe(true);
+        expect(config.sandbox.network.allowedDomains).toEqual([
+          'example.com',
+          'www.google-analytics.com',
+        ]);
+      });
+
       it('should preserve existing ref in nx-claude-plugins source', async () => {
         const options: SetupAiAgentsGeneratorSchema = {
           directory: '.',

--- a/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.ts
+++ b/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.ts
@@ -24,6 +24,7 @@ import { workspaceRoot } from '../../utils/workspace-root';
 import { getInstalledNxVersion } from '../../utils/installed-nx-version';
 import {
   agentsMdPath,
+  analyticsDomain,
   claudeMcpJsonPath,
   geminiMdPath,
   getAgentRulesWrapped,
@@ -171,6 +172,21 @@ export async function setupAiAgentsGeneratorImpl(
       enabledPlugins: {
         ...json.enabledPlugins,
         'nx@nx-claude-plugins': true,
+      },
+      // Allow Nx analytics requests through Claude Code's sandbox network filter
+      sandbox: {
+        ...json.sandbox,
+        network: {
+          ...json.sandbox?.network,
+          allowedDomains: json.sandbox?.network?.allowedDomains?.includes(
+            analyticsDomain
+          )
+            ? json.sandbox.network.allowedDomains
+            : [
+                ...(json.sandbox?.network?.allowedDomains ?? []),
+                analyticsDomain,
+              ],
+        },
       },
     }));
 


### PR DESCRIPTION
## Current Behavior

When AI agents run Nx inside a network-restricted sandbox (e.g. Claude Code's sandboxed Bash), analytics requests to `https://www.google-analytics.com/g/collect` are blocked because the hostname is not on the sandbox's allowlist. Depending on the agent's configuration, this either silently drops the events or surfaces a confusing permission prompt asking why running tests wants to reach `google-analytics.com`.

## Expected Behavior

`nx configure-ai-agents` (via `setupAiAgentsGenerator`) now adds `www.google-analytics.com` to `sandbox.network.allowedDomains` in `.claude/settings.json`, alongside the existing marketplace/plugin configuration it already manages. Analytics requests during sandboxed CLI runs go through without prompting.

- Existing user-defined allowed domains are preserved; the entry is appended idempotently (no duplicates on re-run).
- The domain lives in a shared constant (`packages/nx/src/ai/constants.ts`) noted to stay in sync with `GA_ENDPOINT` in `packages/nx/src/native/telemetry/constants.rs`.
- Existing workspaces pick this up through the regular `nx configure-ai-agents --check` drift detection.

## Related Issue(s)

Internal: [NXC-4091](https://linear.app/nxdev/issue/NXC-4091/allow-analytics-requests-during-sandboxed-cli-runs)
