### PR TITLE
fix(release): skip GitHub URL resolution when remote releases disabled

### DIFF
--- a/packages/nx/src/command-line/release/utils/remote-release-clients/remote-release-client.ts
+++ b/packages/nx/src/command-line/release/utils/remote-release-clients/remote-release-client.ts
@@ -248,9 +248,7 @@ export async function createRemoteReleaseClient(
     // GitHub and GitHub Enterprise Server
     case typeof createReleaseConfig === 'object' &&
       (createReleaseConfig.provider === 'github-enterprise-server' ||
-        createReleaseConfig.provider === 'github'):
-    // If remote releases are disabled, assume GitHub repo data resolution (but don't attempt to resolve a token) to match existing behavior
-    case createReleaseConfig === false: {
+        createReleaseConfig.provider === 'github'): {
       const { GithubRemoteReleaseClient } = await handleImport(
         './github.js',
         __dirname
@@ -259,15 +257,23 @@ export async function createRemoteReleaseClient(
         createReleaseConfig,
         remoteName
       );
-      const token =
-        createReleaseConfig && repoData
-          ? await GithubRemoteReleaseClient.resolveTokenData(repoData.hostname)
-          : null;
+      const token = repoData
+        ? await GithubRemoteReleaseClient.resolveTokenData(repoData.hostname)
+        : null;
       return new GithubRemoteReleaseClient(
         repoData,
         createReleaseConfig,
         token
       );
+    }
+    // If remote releases are disabled, repoData is not needed — skip resolveRepoData to avoid
+    // failing on non-GitHub remote URLs (e.g. self-hosted GitLab)
+    case createReleaseConfig === false: {
+      const { GithubRemoteReleaseClient } = await handleImport(
+        './github.js',
+        __dirname
+      );
+      return new GithubRemoteReleaseClient(null, false, null);
     }
     // GitLab
     case typeof createReleaseConfig === 'object' &&


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
```
Error: Could not extract "user/repo" data from the resolved remote URL: <my-remote-repo-url>
```

Even if `createRelease` is `false`


## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Disabling `createReleaseConfig` doesn't show errors.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes https://github.com/nrwl/nx/issues/35439
