### PR TITLE
feat(angular): add istanbul-lib-instrument for Angular v22 Karma coverage

### DIFF
--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -330,6 +330,15 @@
       "description": "Rename the `ssr.experimentalPlatform` option to `ssr.platform` in `@angular/build:application`, `@angular-devkit/build-angular:application`, and `@nx/angular:application` targets, matching the Angular v22 rename.",
       "factory": "./dist/src/migrations/update-23-1-0/rename-ssr-experimental-platform",
       "documentation": "./dist/src/migrations/update-23-1-0/rename-ssr-experimental-platform.md"
+    },
+    "update-23-1-0-add-istanbul-instrumenter": {
+      "version": "23.1.0-beta.0",
+      "requires": {
+        "@angular/core": ">=22.0.0"
+      },
+      "description": "Add `istanbul-lib-instrument` to `devDependencies` when a project runs unit tests with Karma (the `@angular-devkit/build-angular:karma` / `@angular/build:karma` builders, or `@angular/build:unit-test` / `@nx/angular:unit-test` with `runner: karma`), matching the Angular v22 `add-istanbul-instrumenter` migration.",
+      "factory": "./dist/src/migrations/update-23-1-0/add-istanbul-instrumenter",
+      "documentation": "./dist/src/migrations/update-23-1-0/add-istanbul-instrumenter.md"
     }
   },
   "packageJsonUpdates": {

--- a/packages/angular/src/migrations/update-23-1-0/add-istanbul-instrumenter.md
+++ b/packages/angular/src/migrations/update-23-1-0/add-istanbul-instrumenter.md
@@ -1,0 +1,65 @@
+#### Add `istanbul-lib-instrument` for Karma Coverage
+
+Angular v22 makes `istanbul-lib-instrument` an optional peer dependency of `@angular/build`, used to instrument code for Karma coverage. Since optional peers are not installed automatically, this migration adds `istanbul-lib-instrument` to `devDependencies` when the workspace has a project that runs unit tests with Karma, so Karma coverage keeps working. An existing version is preserved.
+
+Karma usage is detected on any target using the `@angular-devkit/build-angular:karma` or `@angular/build:karma` builders, or the `@angular/build:unit-test` / `@nx/angular:unit-test` executors with the `runner` option set to `karma`. Targets that inherit their executor or `runner` from an `nx.json` `targetDefaults` entry are detected too.
+
+#### Examples
+
+##### `project.json`
+
+Before:
+
+```jsonc {5}
+// project.json
+{
+  "targets": {
+    "test": {
+      "executor": "@nx/angular:unit-test",
+      "options": {
+        "runner": "karma",
+      },
+    },
+  },
+}
+```
+
+After (`package.json`):
+
+```jsonc {4}
+// package.json
+{
+  "devDependencies": {
+    "istanbul-lib-instrument": "^6.0.3",
+  },
+}
+```
+
+##### `nx.json` (`targetDefaults`)
+
+A project whose `test` target inherits its executor and `runner` from an `nx.json` `targetDefaults` entry is also detected:
+
+```jsonc {7}
+// nx.json
+{
+  "targetDefaults": {
+    "test": {
+      "executor": "@nx/angular:unit-test",
+      "options": {
+        "runner": "karma",
+      },
+    },
+  },
+}
+```
+
+```jsonc
+// apps/app1/project.json
+{
+  "targets": {
+    "test": {},
+  },
+}
+```
+
+`istanbul-lib-instrument` is added to `package.json` as shown above.

--- a/packages/angular/src/migrations/update-23-1-0/add-istanbul-instrumenter.spec.ts
+++ b/packages/angular/src/migrations/update-23-1-0/add-istanbul-instrumenter.spec.ts
@@ -1,0 +1,204 @@
+import {
+  addProjectConfiguration,
+  readJson,
+  readNxJson,
+  updateJson,
+  updateNxJson,
+  type Tree,
+} from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migration from './add-istanbul-instrumenter';
+
+const istanbulLibInstrumentVersion = '^6.0.3';
+const karmaBuilders = [
+  '@angular-devkit/build-angular:karma',
+  '@angular/build:karma',
+];
+const unitTestBuilders = ['@angular/build:unit-test', '@nx/angular:unit-test'];
+
+describe('add-istanbul-instrumenter migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  function getInstrumenterVersion(): string | undefined {
+    return readJson(tree, 'package.json').devDependencies?.[
+      'istanbul-lib-instrument'
+    ];
+  }
+
+  test.each(karmaBuilders)(
+    'should add istanbul-lib-instrument when a target uses the "%s" Karma builder',
+    async (executor) => {
+      addProjectConfiguration(tree, 'app1', {
+        root: 'apps/app1',
+        projectType: 'application',
+        targets: { test: { executor, options: {} } },
+      });
+
+      await migration(tree);
+
+      expect(getInstrumenterVersion()).toBe(istanbulLibInstrumentVersion);
+    }
+  );
+
+  test.each(unitTestBuilders)(
+    'should add istanbul-lib-instrument when "%s" uses runner: karma',
+    async (executor) => {
+      addProjectConfiguration(tree, 'app1', {
+        root: 'apps/app1',
+        projectType: 'application',
+        targets: { test: { executor, options: { runner: 'karma' } } },
+      });
+
+      await migration(tree);
+
+      expect(getInstrumenterVersion()).toBe(istanbulLibInstrumentVersion);
+    }
+  );
+
+  it('should detect runner: karma set only in a configuration', async () => {
+    addProjectConfiguration(tree, 'app1', {
+      root: 'apps/app1',
+      projectType: 'application',
+      targets: {
+        test: {
+          executor: '@nx/angular:unit-test',
+          options: { runner: 'vitest' },
+          configurations: { ci: { runner: 'karma' } },
+        },
+      },
+    });
+
+    await migration(tree);
+
+    expect(getInstrumenterVersion()).toBe(istanbulLibInstrumentVersion);
+  });
+
+  it('should detect Karma in a library project (no projectType gate)', async () => {
+    addProjectConfiguration(tree, 'lib1', {
+      root: 'libs/lib1',
+      projectType: 'library',
+      targets: { test: { executor: '@angular/build:karma', options: {} } },
+    });
+
+    await migration(tree);
+
+    expect(getInstrumenterVersion()).toBe(istanbulLibInstrumentVersion);
+  });
+
+  it('should not add istanbul-lib-instrument when no target uses Karma', async () => {
+    addProjectConfiguration(tree, 'app1', {
+      root: 'apps/app1',
+      projectType: 'application',
+      targets: {
+        test: {
+          executor: '@angular/build:unit-test',
+          options: { runner: 'vitest' },
+        },
+      },
+    });
+
+    await migration(tree);
+
+    expect(getInstrumenterVersion()).toBeUndefined();
+  });
+
+  it('should not overwrite an existing istanbul-lib-instrument version', async () => {
+    updateJson(tree, 'package.json', (json) => {
+      json.devDependencies = {
+        ...json.devDependencies,
+        'istanbul-lib-instrument': '^5.0.0',
+      };
+      return json;
+    });
+    addProjectConfiguration(tree, 'app1', {
+      root: 'apps/app1',
+      projectType: 'application',
+      targets: { test: { executor: '@angular/build:karma', options: {} } },
+    });
+
+    await migration(tree);
+
+    expect(getInstrumenterVersion()).toBe('^5.0.0');
+  });
+
+  describe('nx.json targetDefaults', () => {
+    it('should detect a Karma executor inherited from a record-shaped targetDefault keyed by target name', async () => {
+      // A project `test` target with no executor inherits it from the default.
+      addProjectConfiguration(tree, 'app1', {
+        root: 'apps/app1',
+        projectType: 'application',
+        targets: { test: {} },
+      });
+      const nxJson = readNxJson(tree);
+      nxJson.targetDefaults = {
+        test: { executor: '@angular/build:karma', options: {} },
+      };
+      updateNxJson(tree, nxJson);
+
+      await migration(tree);
+
+      expect(getInstrumenterVersion()).toBe(istanbulLibInstrumentVersion);
+    });
+
+    it('should detect a record-shaped targetDefault keyed by a Karma builder executor', async () => {
+      const nxJson = readNxJson(tree);
+      nxJson.targetDefaults = {
+        '@angular-devkit/build-angular:karma': { options: {} },
+      };
+      updateNxJson(tree, nxJson);
+
+      await migration(tree);
+
+      expect(getInstrumenterVersion()).toBe(istanbulLibInstrumentVersion);
+    });
+
+    it('should detect runner: karma on a unit-test targetDefault keyed by target name', async () => {
+      const nxJson = readNxJson(tree);
+      nxJson.targetDefaults = {
+        test: {
+          executor: '@nx/angular:unit-test',
+          options: { runner: 'karma' },
+        },
+      };
+      updateNxJson(tree, nxJson);
+
+      await migration(tree);
+
+      expect(getInstrumenterVersion()).toBe(istanbulLibInstrumentVersion);
+    });
+
+    it('should detect runner: karma on an array-shaped targetDefault', async () => {
+      const nxJson = readNxJson(tree);
+      nxJson.targetDefaults = [
+        {
+          executor: '@angular/build:unit-test',
+          options: { runner: 'karma' },
+        },
+      ];
+      updateNxJson(tree, nxJson);
+
+      await migration(tree);
+
+      expect(getInstrumenterVersion()).toBe(istanbulLibInstrumentVersion);
+    });
+
+    it('should not add istanbul-lib-instrument when targetDefaults do not use Karma', async () => {
+      const nxJson = readNxJson(tree);
+      nxJson.targetDefaults = {
+        test: {
+          executor: '@nx/angular:unit-test',
+          options: { runner: 'vitest' },
+        },
+      };
+      updateNxJson(tree, nxJson);
+
+      await migration(tree);
+
+      expect(getInstrumenterVersion()).toBeUndefined();
+    });
+  });
+});

--- a/packages/angular/src/migrations/update-23-1-0/add-istanbul-instrumenter.ts
+++ b/packages/angular/src/migrations/update-23-1-0/add-istanbul-instrumenter.ts
@@ -1,0 +1,91 @@
+import {
+  addDependenciesToPackageJson,
+  getProjects,
+  readNxJson,
+  type TargetConfiguration,
+  type Tree,
+} from '@nx/devkit';
+import { allTargetOptions } from '../../utils/targets';
+
+// In v22 `istanbul-lib-instrument` is an optional peer dependency of
+// `@angular/build` used to instrument code for Karma coverage. Optional peers
+// are not installed automatically, so it must be added when Karma is in use.
+// Inlined here (not in `versions.ts`) because no generator installs it; only
+// this migration does. Mirrors Angular's `add-istanbul-instrumenter`.
+const istanbulLibInstrumentVersion = '^6.0.3';
+
+const karmaBuilders = [
+  '@angular-devkit/build-angular:karma',
+  '@angular/build:karma',
+];
+const unitTestBuilders = ['@angular/build:unit-test', '@nx/angular:unit-test'];
+
+type UnitTestOptions = { runner?: string };
+
+// A target uses Karma when its builder is a Karma builder, or it's a unit-test
+// builder with `runner: karma` (in options or any configuration). `executors`
+// holds the candidate executor ids: a target's own executor, or those a project
+// `test` target inherits from an nx.json targetDefault (keyed by target name or
+// by executor).
+function usesKarma(
+  executors: Array<string | undefined>,
+  target: Pick<TargetConfiguration, 'options' | 'configurations'>
+): boolean {
+  if (executors.some((e) => karmaBuilders.includes(e))) {
+    return true;
+  }
+
+  if (executors.some((e) => unitTestBuilders.includes(e))) {
+    for (const [, options] of allTargetOptions(
+      target as TargetConfiguration<UnitTestOptions>
+    )) {
+      if (options?.runner === 'karma') {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+export default async function (tree: Tree) {
+  let needsInstrumenter = false;
+
+  // project.json targets
+  for (const [, project] of getProjects(tree)) {
+    needsInstrumenter = Object.values(project.targets ?? {}).some((target) =>
+      usesKarma([target.executor], target)
+    );
+    if (needsInstrumenter) {
+      break;
+    }
+  }
+
+  // nx.json targetDefaults (array and legacy record shapes): a project's empty
+  // `test` target can inherit a Karma executor/runner from a default.
+  if (!needsInstrumenter) {
+    const targetDefaults = readNxJson(tree)?.targetDefaults;
+    if (Array.isArray(targetDefaults)) {
+      needsInstrumenter = targetDefaults.some((entry) =>
+        usesKarma([entry.executor, entry.target], entry)
+      );
+    } else if (targetDefaults) {
+      needsInstrumenter = Object.entries(targetDefaults).some(
+        ([targetOrExecutor, config]) =>
+          usesKarma([targetOrExecutor, config.executor], config)
+      );
+    }
+  }
+
+  if (!needsInstrumenter) {
+    return;
+  }
+
+  return addDependenciesToPackageJson(
+    tree,
+    {},
+    { 'istanbul-lib-instrument': istanbulLibInstrumentVersion },
+    undefined,
+    true
+  );
+}


### PR DESCRIPTION
## Current Behavior

In Angular v22, `istanbul-lib-instrument` is an optional peer dependency of `@angular/build` used to instrument code for Karma coverage. Optional peers are not installed automatically, so projects that run unit tests with Karma can lose coverage instrumentation after migrating.

## Expected Behavior

A migration adds `istanbul-lib-instrument` to `devDependencies` when a project runs unit tests with Karma (a Karma builder, or `@angular/build:unit-test` / `@nx/angular:unit-test` with `runner: karma`), including targets that inherit their executor or `runner` from an `nx.json` `targetDefaults` entry. Existing versions are preserved.

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/angular-v22-76d725d8)
<!-- polygraph-session-end -->