### PR TITLE
feat(nx-dev): add docs top banner for ai monorepos conference

### DIFF
--- a/astro-docs/src/components/layout/ConfBanner.astro
+++ b/astro-docs/src/components/layout/ConfBanner.astro
@@ -1,0 +1,111 @@
+---
+import { confBanner, isConfBannerActive } from './conf-banner';
+
+const active = isConfBannerActive();
+---
+
+{
+  active && (
+    <a
+      class="conf-banner"
+      href={confBanner.url}
+      target="_blank"
+      rel="noopener noreferrer"
+      id="conf-banner-link"
+    >
+      <span class="conf-banner__text">
+        <span class="conf-banner__brand">
+          AI <span class="conf-banner__heart">&#9829;</span> Monorepos
+        </span>
+        <span class="conf-banner__desc">Free online conference &middot; June 23</span>
+      </span>
+      <span class="conf-banner__cta">
+        Join us!
+        <svg
+          class="conf-banner__arrow"
+          viewBox="0 0 20 20"
+          fill="currentColor"
+          aria-hidden="true"
+        >
+          <path
+            fill-rule="evenodd"
+            d="M5 10a.75.75 0 0 1 .75-.75h6.638L9.96 7.046a.75.75 0 0 1 1.08-1.04l3.75 3.75a.75.75 0 0 1 0 1.04l-3.75 3.75a.75.75 0 1 1-1.08-1.04l2.428-2.206H5.75A.75.75 0 0 1 5 10Z"
+            clip-rule="evenodd"
+          />
+        </svg>
+      </span>
+    </a>
+  )
+}
+
+<style>
+  .conf-banner {
+    position: fixed;
+    inset-block-start: 0;
+    inset-inline: 0;
+    z-index: calc(var(--sl-z-index-navbar) + 1);
+    height: var(--conf-banner-h, 2.5rem);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    gap: 0.625rem;
+    padding-inline: 1rem;
+    /* Theme-aware: light strip in light mode, dark strip in dark mode. */
+    background-color: var(--sl-color-bg-nav);
+    color: var(--sl-color-gray-2);
+    font-size: 0.875rem;
+    line-height: 1.2;
+    text-decoration: none;
+    border-bottom: 1px solid var(--sl-color-hairline-shade);
+  }
+
+  .conf-banner__text {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-weight: 500;
+  }
+
+  .conf-banner__brand {
+    font-weight: 700;
+    color: var(--sl-color-gray-1);
+    white-space: nowrap;
+  }
+
+  .conf-banner__heart {
+    color: #f43f5e;
+  }
+
+  .conf-banner__desc {
+    color: var(--sl-color-gray-3);
+    white-space: nowrap;
+  }
+
+  .conf-banner__cta {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.125rem;
+    font-weight: 600;
+    color: var(--sl-color-text-accent);
+    text-decoration: underline;
+    text-underline-offset: 2px;
+    white-space: nowrap;
+    transition: color 0.15s ease;
+  }
+
+  .conf-banner:hover .conf-banner__cta {
+    color: var(--sl-color-accent-high);
+  }
+
+  .conf-banner__arrow {
+    width: 1rem;
+    height: 1rem;
+  }
+
+  /* Tight viewports: drop the descriptor so the bar stays one line at 2.5rem. */
+  @media (max-width: 30rem) {
+    .conf-banner__desc {
+      display: none;
+    }
+  }
+</style>

--- a/astro-docs/src/components/layout/PageFrame.astro
+++ b/astro-docs/src/components/layout/PageFrame.astro
@@ -5,9 +5,12 @@ import { Footer } from '@nx/nx-dev-ui-common/src/lib/footer';
 import { GitHubStarWidget } from '@nx/nx-dev-ui-common/src/lib/github-star-widget';
 import { WebinarNotifier } from '@nx/nx-dev-ui-common/src/lib/webinar-notifier';
 import { getCollection } from 'astro:content';
+import ConfBanner from './ConfBanner.astro';
+import { isConfBannerActive } from './conf-banner';
 
 const { hasSidebar } = Astro.locals.starlightRoute;
 const githubStarsCount = Astro.locals.githubStarsCount ?? 0;
+const showConfBanner = isConfBannerActive();
 
 // Get banner from collection
 const bannerCollection = await getCollection('banner');
@@ -23,7 +26,8 @@ const showBanner = isBannerActive(bannerConfig);
 const bannerId = bannerConfig ? `${bannerConfig.title}-${bannerConfig.activeUntil || 'no-expiry'}` : '';
 ---
 
-<div class="page sl-flex">
+<div class:list={['page', 'sl-flex', { 'has-conf-banner': showConfBanner }]}>
+  <ConfBanner />
   <header class="header"><slot name="header" /></header>
   {
     hasSidebar && (
@@ -85,6 +89,11 @@ const bannerId = bannerConfig ? `${bannerConfig.title}-${bannerConfig.activeUnti
       min-height: 100vh;
     }
 
+    /* Height of the conference promo strip; reused to offset everything below it. */
+    .page.has-conf-banner {
+      --conf-banner-h: 2.5rem;
+    }
+
     .header {
       z-index: var(--sl-z-index-navbar);
       position: fixed;
@@ -96,6 +105,11 @@ const bannerId = bannerConfig ? `${bannerConfig.title}-${bannerConfig.activeUnti
       padding: var(--sl-nav-pad-y) var(--sl-nav-pad-x);
       padding-inline-end: var(--sl-nav-pad-x);
       background-color: var(--sl-color-bg-nav);
+    }
+
+    /* Push the fixed header below the banner. */
+    .page.has-conf-banner .header {
+      inset-block-start: var(--conf-banner-h);
     }
 
     :global([data-has-sidebar]) .header {
@@ -113,6 +127,10 @@ const bannerId = bannerConfig ? `${bannerConfig.title}-${bannerConfig.activeUnti
       width: 100%;
       background-color: var(--sl-color-bg-sidebar);
       overflow-y: auto;
+    }
+
+    .page.has-conf-banner .sidebar-pane {
+      inset-block-start: calc(var(--sl-nav-height) + var(--conf-banner-h));
     }
 
     :global([aria-expanded='true']) ~ .sidebar-pane {
@@ -143,6 +161,18 @@ const bannerId = bannerConfig ? `${bannerConfig.title}-${bannerConfig.activeUnti
     .main-frame {
       padding-top: calc(var(--sl-nav-height) + var(--sl-mobile-toc-height));
       padding-inline-start: var(--sl-content-inline-start);
+    }
+
+    .page.has-conf-banner .main-frame {
+      padding-top: calc(
+        var(--sl-nav-height) + var(--sl-mobile-toc-height) +
+          var(--conf-banner-h)
+      );
+    }
+
+    /* Starlight's mobile on-this-page bar is fixed at the nav height; shift it too. */
+    .page.has-conf-banner :global(mobile-starlight-toc > nav) {
+      top: calc(var(--sl-nav-height) + var(--conf-banner-h));
     }
 
     @media (min-width: 50rem) {

--- a/astro-docs/src/components/layout/conf-banner.ts
+++ b/astro-docs/src/components/layout/conf-banner.ts
@@ -1,0 +1,11 @@
+// Time-boxed promo bar for the "AI <3 Monorepos" online conference.
+// Build-time gated: the next rebuild after `activeUntil` drops the banner.
+export const confBanner = {
+  url: 'https://monorepo.tools/conf?utm_campaign=2026%20Conferences&utm_source=nx-docs&utm_medium=banner',
+  // End of June 23 2026, ET (UTC-4).
+  activeUntil: '2026-06-24T04:00:00Z',
+};
+
+export function isConfBannerActive(now: Date = new Date()): boolean {
+  return now < new Date(confBanner.activeUntil);
+}


### PR DESCRIPTION
## Current Behavior

No top promo bar on the Astro docs site.

## Expected Behavior

- Full-width top strip promoting the AI ♥ Monorepos conference (June 23).
- Theme-aware (light strip in light mode, dark strip in dark mode).
- Offsets header, sidebar, main content, and mobile TOC by the banner height.
- Build-time gated via `activeUntil`; drops on the next rebuild after the conference.

Preview: https://deploy-preview-35956--nx-docs.netlify.app/docs/getting-started/intro

<img width="1392" height="1032" alt="Screenshot 2026-06-11 at 8 48 33 AM" src="https://github.com/user-attachments/assets/64511293-b3ff-4706-976c-f10227ae56be" />
<img width="1392" height="1032" alt="Screenshot 2026-06-11 at 8 48 30 AM" src="https://github.com/user-attachments/assets/28d5ee65-9f0b-4814-aad5-704cd9128006" />

## Related Issue(s)

DOC-521

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/docs-conf-banner-e2599b5b)
<!-- polygraph-session-end -->