### PR TITLE
cleanup(core): stop migrate tests from hitting the registry in local TTY runs

### DIFF
--- a/packages/nx/src/command-line/migrate/migrate.spec.ts
+++ b/packages/nx/src/command-line/migrate/migrate.spec.ts
@@ -2075,7 +2075,15 @@ describe('Migration', () => {
   });
 
   describe('parseMigrationsOptions', () => {
+    // Pin non-TTY so the canPrompt-gated eligibility fetch stays off as it does
+    // on CI, instead of hitting the registry in a local TTY run.
+    let originalStdinIsTTY: boolean | undefined;
     beforeEach(() => {
+      originalStdinIsTTY = process.stdin.isTTY;
+      Object.defineProperty(process.stdin, 'isTTY', {
+        value: false,
+        configurable: true,
+      });
       mockGetInstalledNxVersion.mockReturnValue('22.0.0');
       // `getInstalledVersion(pkg)` mirrors the installed nx version for the
       // canonical packages so optional bound checks read the same value.
@@ -2102,6 +2110,10 @@ describe('Migration', () => {
       mockGetInstalledPackageGroup.mockReset();
       mockGetInstalledLegacyNrwlWorkspaceVersion.mockReset();
       jest.restoreAllMocks();
+      Object.defineProperty(process.stdin, 'isTTY', {
+        value: originalStdinIsTTY,
+        configurable: true,
+      });
     });
 
     it('should work for generating migrations', async () => {


### PR DESCRIPTION
## Current Behavior

The migrate `parseMigrationsOptions` tests read the ambient `process.stdin.isTTY`. Run locally in a TTY, `canPrompt()` returns true, so the `--include` eligibility check fetches `supportsOptionalMigrations` from the npm registry for nonexistent package versions and 4 tests fail. They pass on CI only because `isCI()` forces `canPrompt()` false.

## Expected Behavior

The `parseMigrationsOptions` block pins a non-TTY stdin (as the sibling `resolveInclude` and `resolve-package-version` specs do), so the eligibility gate stays off and the suite is deterministic regardless of the host terminal. No production behavior changes.

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/fix-local-test-failures-fc5f3aee)
<!-- polygraph-session-end -->