### PR TITLE
feat(angular): support Angular v22 component and unit-test schema changes

### DIFF
--- a/packages/angular/src/executors/unit-test/schema.json
+++ b/packages/angular/src/executors/unit-test/schema.json
@@ -42,6 +42,14 @@
       "type": "boolean",
       "description": "Forces all configured browsers to run in headless mode. When using the Vitest runner, this option is ignored if no browsers are configured. The Karma runner does not support this option. _Note: this is only supported in Angular versions >= 21.2.0_."
     },
+    "isolate": {
+      "type": "boolean",
+      "description": "Enables isolation for test execution. When true, Vitest runs tests in separate threads or processes. This option is only available for the Vitest runner. Defaults to false to align with the Karma/Jasmine experience. _Note: this is only supported in Angular versions >= 22.0.0_."
+    },
+    "quiet": {
+      "type": "boolean",
+      "description": "Suppresses the verbose build summary and stats table on each rebuild. Defaults to `true` locally and `false` in CI environments. _Note: this is only supported in Angular versions >= 22.0.0_."
+    },
     "include": {
       "type": "array",
       "items": {

--- a/packages/angular/src/executors/unit-test/unit-test.impl.ts
+++ b/packages/angular/src/executors/unit-test/unit-test.impl.ts
@@ -80,6 +80,20 @@ function validateOptions(options: UnitTestExecutorOptions): void {
       );
     }
   }
+
+  if (lt(angularVersion, '22.0.0')) {
+    if (options.isolate !== undefined) {
+      throw new Error(
+        `The "isolate" option requires Angular version 22.0.0 or greater. You are currently using version ${angularVersion}.`
+      );
+    }
+
+    if (options.quiet !== undefined) {
+      throw new Error(
+        `The "quiet" option requires Angular version 22.0.0 or greater. You are currently using version ${angularVersion}.`
+      );
+    }
+  }
 }
 
 /**

--- a/packages/angular/src/generators/component/component.spec.ts
+++ b/packages/angular/src/generators/component/component.spec.ts
@@ -2,6 +2,7 @@ import {
   addProjectConfiguration,
   readProjectConfiguration,
   type Tree,
+  updateJson,
   updateProjectConfiguration,
   writeJson,
 } from '@nx/devkit';
@@ -1102,6 +1103,140 @@ export class LibModule {}
         'utf-8'
       );
       expect(indexSource).toBe('');
+    });
+  });
+
+  describe('changeDetection', () => {
+    function setup(): Tree {
+      const tree = createTreeWithEmptyWorkspace();
+      addProjectConfiguration(tree, 'lib1', {
+        projectType: 'library',
+        sourceRoot: 'libs/lib1/src',
+        root: 'libs/lib1',
+      });
+      tree.write('libs/lib1/src/index.ts', '');
+
+      return tree;
+    }
+
+    it('should default to OnPush without emitting a strategy', async () => {
+      const tree = setup();
+
+      await componentGenerator(tree, {
+        path: 'libs/lib1/src/lib/example/example',
+        skipFormat: true,
+      });
+
+      const content = tree.read(
+        'libs/lib1/src/lib/example/example.ts',
+        'utf-8'
+      );
+      expect(content).not.toContain('changeDetection');
+      expect(content).not.toContain('ChangeDetectionStrategy');
+    });
+
+    it('should emit the Eager strategy when requested', async () => {
+      const tree = setup();
+
+      await componentGenerator(tree, {
+        path: 'libs/lib1/src/lib/example/example',
+        changeDetection: 'Eager',
+        skipFormat: true,
+      });
+
+      const content = tree.read(
+        'libs/lib1/src/lib/example/example.ts',
+        'utf-8'
+      );
+      expect(content).toContain(
+        'changeDetection: ChangeDetectionStrategy.Eager'
+      );
+    });
+
+    it('should not emit a strategy when OnPush is explicitly passed', async () => {
+      const tree = setup();
+
+      await componentGenerator(tree, {
+        path: 'libs/lib1/src/lib/example/example',
+        changeDetection: 'OnPush',
+        skipFormat: true,
+      });
+
+      const content = tree.read(
+        'libs/lib1/src/lib/example/example.ts',
+        'utf-8'
+      );
+      expect(content).not.toContain('changeDetection');
+      expect(content).not.toContain('ChangeDetectionStrategy');
+    });
+  });
+
+  describe('angular compat support', () => {
+    function setup(angularCoreVersion: string): Tree {
+      const tree = createTreeWithEmptyWorkspace();
+      updateJson(tree, 'package.json', (json) => ({
+        ...json,
+        dependencies: {
+          ...json.dependencies,
+          '@angular/core': angularCoreVersion,
+        },
+      }));
+      addProjectConfiguration(tree, 'lib1', {
+        projectType: 'library',
+        sourceRoot: 'libs/lib1/src',
+        root: 'libs/lib1',
+      });
+      tree.write('libs/lib1/src/index.ts', '');
+
+      return tree;
+    }
+
+    it('should default changeDetection to Default without emitting a strategy on Angular < 22', async () => {
+      const tree = setup('~21.0.0');
+
+      await componentGenerator(tree, {
+        path: 'libs/lib1/src/lib/example/example',
+        skipFormat: true,
+      });
+
+      const content = tree.read(
+        'libs/lib1/src/lib/example/example.ts',
+        'utf-8'
+      );
+      expect(content).not.toContain('changeDetection');
+      expect(content).not.toContain('ChangeDetectionStrategy');
+    });
+
+    it('should emit the OnPush changeDetection strategy on Angular < 22', async () => {
+      const tree = setup('~21.0.0');
+
+      await componentGenerator(tree, {
+        path: 'libs/lib1/src/lib/example/example',
+        changeDetection: 'OnPush',
+        skipFormat: true,
+      });
+
+      const content = tree.read(
+        'libs/lib1/src/lib/example/example.ts',
+        'utf-8'
+      );
+      expect(content).toContain(
+        'changeDetection: ChangeDetectionStrategy.OnPush'
+      );
+    });
+
+    it('should throw when the Eager changeDetection strategy is used on Angular < 22', async () => {
+      const tree = setup('~21.0.0');
+
+      await expect(
+        componentGenerator(tree, {
+          path: 'libs/lib1/src/lib/example/example',
+          changeDetection: 'Eager',
+          skipFormat: true,
+        })
+      ).rejects.toThrow(
+        'The "Eager" change detection strategy is only supported for Angular versions >= 22.0.0.'
+      );
     });
   });
 });

--- a/packages/angular/src/generators/component/component.ts
+++ b/packages/angular/src/generators/component/component.ts
@@ -14,11 +14,13 @@ import {
   findModuleFromOptions,
   normalizeOptions,
   setGeneratorDefaults,
+  validateOptions,
 } from './lib';
 import type { Schema } from './schema';
 
 export async function componentGenerator(tree: Tree, rawOptions: Schema) {
   assertSupportedAngularVersion(tree);
+  validateOptions(tree, rawOptions);
   const options = await normalizeOptions(tree, rawOptions);
 
   const { major: angularMajorVersion } = getInstalledAngularVersionInfo(tree);

--- a/packages/angular/src/generators/component/files/__fileName__.ts__tpl__
+++ b/packages/angular/src/generators/component/files/__fileName__.ts__tpl__
@@ -1,4 +1,5 @@
-import { <% if(changeDetection !== 'Default') { %>ChangeDetectionStrategy, <% }%>Component<% if(!!viewEncapsulation) { %>, ViewEncapsulation<% }%> } from '@angular/core';
+<%_ const changeDetectionDefault = angularMajorVersion >= 22 ? 'OnPush' : 'Default'; _%>
+import { <% if(changeDetection !== changeDetectionDefault) { %>ChangeDetectionStrategy, <% }%>Component<% if(!!viewEncapsulation) { %>, ViewEncapsulation<% }%> } from '@angular/core';
 
 @Component({<% if(!skipSelector) {%>
   selector: '<%= selector %>',<%}%><% if (!standalone) { %>
@@ -12,7 +13,7 @@ import { <% if(changeDetection !== 'Default') { %>ChangeDetectionStrategy, <% }%
     }
   <% } %>`<% } else if (style !== 'none') { %>,
   styleUrl: './<%= fileName %>.<%= style %>'<% } %><% if(!!viewEncapsulation) { %>,
-  encapsulation: ViewEncapsulation.<%= viewEncapsulation %><% } if (changeDetection !== 'Default') { %>,
+  encapsulation: ViewEncapsulation.<%= viewEncapsulation %><% } if (changeDetection !== changeDetectionDefault) { %>,
   changeDetection: ChangeDetectionStrategy.<%= changeDetection %><% } %>
 })
 export <% if (exportDefault) {%>default <%}%>class <%= symbolName %> {}

--- a/packages/angular/src/generators/component/lib/index.ts
+++ b/packages/angular/src/generators/component/lib/index.ts
@@ -2,3 +2,4 @@ export * from './component';
 export * from './module';
 export * from './normalize-options';
 export * from './set-generator-defaults';
+export * from './validate-options';

--- a/packages/angular/src/generators/component/lib/normalize-options.ts
+++ b/packages/angular/src/generators/component/lib/normalize-options.ts
@@ -4,12 +4,15 @@ import { determineArtifactNameAndDirectoryOptions } from '@nx/devkit/internal';
 import type { AngularProjectConfiguration } from '../../../utils/types';
 import { buildSelector, validateHtmlSelector } from '../../utils/selector';
 import { validateClassName } from '../../utils/validations';
+import { getInstalledAngularVersionInfo } from '../../utils/version-utils';
 import type { NormalizedSchema, Schema } from '../schema';
 
 export async function normalizeOptions(
   tree: Tree,
   options: Schema
 ): Promise<NormalizedSchema> {
+  const { major: angularMajorVersion } = getInstalledAngularVersionInfo(tree);
+
   const {
     artifactName: name,
     directory,
@@ -47,7 +50,9 @@ export async function normalizeOptions(
     ...options,
     name,
     projectName,
-    changeDetection: options.changeDetection ?? 'Default',
+    changeDetection:
+      options.changeDetection ??
+      (angularMajorVersion >= 22 ? 'OnPush' : 'Default'),
     style: options.style ?? 'css',
     standalone: options.standalone ?? true,
     directory,

--- a/packages/angular/src/generators/component/lib/validate-options.ts
+++ b/packages/angular/src/generators/component/lib/validate-options.ts
@@ -1,0 +1,14 @@
+import type { Tree } from '@nx/devkit';
+import { getInstalledAngularVersionInfo } from '../../utils/version-utils';
+import type { Schema } from '../schema';
+
+export function validateOptions(tree: Tree, options: Schema): void {
+  const { major: angularMajorVersion, version: angularVersion } =
+    getInstalledAngularVersionInfo(tree);
+
+  if (options.changeDetection === 'Eager' && angularMajorVersion < 22) {
+    throw new Error(
+      `The "Eager" change detection strategy is only supported for Angular versions >= 22.0.0. You are using Angular ${angularVersion}.`
+    );
+  }
+}

--- a/packages/angular/src/generators/component/schema.d.ts
+++ b/packages/angular/src/generators/component/schema.d.ts
@@ -6,7 +6,7 @@ export interface Schema {
   inlineTemplate?: boolean;
   standalone?: boolean;
   viewEncapsulation?: 'Emulated' | 'None' | 'ShadowDom';
-  changeDetection?: 'Default' | 'OnPush';
+  changeDetection?: 'Default' | 'Eager' | 'OnPush';
   style?: 'css' | 'scss' | 'sass' | 'less' | 'none';
   skipTests?: boolean;
   type?: string;

--- a/packages/angular/src/generators/component/schema.json
+++ b/packages/angular/src/generators/component/schema.json
@@ -56,10 +56,9 @@
       "alias": "v"
     },
     "changeDetection": {
-      "description": "The change detection strategy to use in the new component.",
-      "enum": ["Default", "OnPush"],
+      "description": "The change detection strategy to use in the new component. It defaults to `OnPush` for Angular versions >= 22.0.0 and `Default` for lower versions. _Note: the `Eager` value is only supported in Angular versions >= 22.0.0_.",
+      "enum": ["Default", "Eager", "OnPush"],
       "type": "string",
-      "default": "Default",
       "alias": "c"
     },
     "module": {

--- a/packages/angular/src/generators/library/__snapshots__/library.spec.ts.snap
+++ b/packages/angular/src/generators/library/__snapshots__/library.spec.ts.snap
@@ -137,15 +137,14 @@ describe('MyLib', () => {
 exports[`lib --standalone should generate a library with a standalone component as entry point and set up view encapsulation and change detection 1`] = `"export * from './lib/my-lib/my-lib';"`;
 
 exports[`lib --standalone should generate a library with a standalone component as entry point and set up view encapsulation and change detection 2`] = `
-"import { ChangeDetectionStrategy, Component, ViewEncapsulation } from '@angular/core';
+"import { Component, ViewEncapsulation } from '@angular/core';
 
 @Component({
   selector: 'lib-my-lib',
   imports: [],
   template: \`<p>MyLib works!</p>\`,
   styles: \`\`,
-  encapsulation: ViewEncapsulation.ShadowDom,
-  changeDetection: ChangeDetectionStrategy.OnPush
+  encapsulation: ViewEncapsulation.ShadowDom
 })
 export class MyLib {}
 "

--- a/packages/angular/src/generators/library/lib/normalized-schema.ts
+++ b/packages/angular/src/generators/library/lib/normalized-schema.ts
@@ -45,7 +45,7 @@ export interface NormalizedSchema {
     inlineStyle?: boolean;
     inlineTemplate?: boolean;
     viewEncapsulation?: 'Emulated' | 'None' | 'ShadowDom';
-    changeDetection?: 'Default' | 'OnPush';
+    changeDetection?: 'Default' | 'Eager' | 'OnPush';
     style?: 'css' | 'scss' | 'sass' | 'less' | 'none';
     skipTests?: boolean;
     selector?: string;

--- a/packages/angular/src/generators/library/library.spec.ts
+++ b/packages/angular/src/generators/library/library.spec.ts
@@ -1876,6 +1876,28 @@ describe('lib', () => {
         tree.read('my-lib/src/lib/my-lib/my-lib.ts', 'utf-8')
       ).toMatchSnapshot();
     });
+
+    it('should not opt out of the default change detection strategy when not specified on Angular >= 22', async () => {
+      await runLibraryGeneratorWithOpts({
+        standalone: true,
+        inlineStyle: true,
+        inlineTemplate: true,
+      });
+
+      expect(tree.read('my-lib/src/lib/my-lib/my-lib.ts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "import { Component } from '@angular/core';
+
+        @Component({
+          selector: 'lib-my-lib',
+          imports: [],
+          template: \`<p>MyLib works!</p>\`,
+          styles: \`\`
+        })
+        export class MyLib {}
+        "
+      `);
+    });
   });
 
   describe('angular compat support', () => {

--- a/packages/angular/src/generators/library/schema.d.ts
+++ b/packages/angular/src/generators/library/schema.d.ts
@@ -30,7 +30,7 @@ export interface Schema {
   inlineStyle?: boolean;
   inlineTemplate?: boolean;
   viewEncapsulation?: 'Emulated' | 'None' | 'ShadowDom';
-  changeDetection?: 'Default' | 'OnPush';
+  changeDetection?: 'Default' | 'Eager' | 'OnPush';
   style?: 'css' | 'scss' | 'sass' | 'less' | 'none';
   skipTests?: boolean;
   selector?: string;

--- a/packages/angular/src/generators/library/schema.json
+++ b/packages/angular/src/generators/library/schema.json
@@ -147,10 +147,9 @@
       "alias": "v"
     },
     "changeDetection": {
-      "description": "The change detection strategy to use in the new component. Disclaimer: This option is only valid when `--standalone` is set to `true`.",
-      "enum": ["Default", "OnPush"],
+      "description": "The change detection strategy to use in the new component. It defaults to `OnPush` for Angular versions >= 22.0.0 and `Default` for lower versions. _Note: the `Eager` value is only supported in Angular versions >= 22.0.0_. Disclaimer: This option is only valid when `--standalone` is set to `true`.",
+      "enum": ["Default", "Eager", "OnPush"],
       "type": "string",
-      "default": "Default",
       "alias": "c"
     },
     "style": {

--- a/packages/angular/src/generators/scam/schema.d.ts
+++ b/packages/angular/src/generators/scam/schema.d.ts
@@ -5,7 +5,7 @@ export interface Schema {
   inlineStyle?: boolean;
   inlineTemplate?: boolean;
   viewEncapsulation?: 'Emulated' | 'None' | 'ShadowDom';
-  changeDetection?: 'Default' | 'OnPush';
+  changeDetection?: 'Default' | 'Eager' | 'OnPush';
   style?: 'css' | 'scss' | 'sass' | 'less' | 'none';
   skipTests?: boolean;
   inlineScam?: boolean;

--- a/packages/angular/src/generators/scam/schema.json
+++ b/packages/angular/src/generators/scam/schema.json
@@ -59,10 +59,9 @@
       "alias": "v"
     },
     "changeDetection": {
-      "description": "The change detection strategy to use in the new component.",
-      "enum": ["Default", "OnPush"],
+      "description": "The change detection strategy to use in the new component. It defaults to `OnPush` for Angular versions >= 22.0.0 and `Default` for lower versions. _Note: the `Eager` value is only supported in Angular versions >= 22.0.0_.",
+      "enum": ["Default", "Eager", "OnPush"],
       "type": "string",
-      "default": "Default",
       "alias": "c"
     },
     "style": {


### PR DESCRIPTION
## Current Behavior

The `@nx/angular:component` generator's `changeDetection` option exposes only `Default`/`OnPush` and always defaults to `Default`, regardless of the installed Angular version. The `@nx/angular:unit-test` executor does not expose the `isolate` and `quiet` options added to the Angular v22 unit-test builder.

## Expected Behavior

On Angular >= 22, the component generator defaults `changeDetection` to `OnPush` and accepts the renamed `Eager` value (matching Angular v22's schematic). Angular 20/21 keep the `Default` value and default, and `Eager` is rejected there. The `@nx/angular:unit-test` executor accepts `isolate` and `quiet`, forwarding them to the v22 builder, and rejects them on Angular < 22.

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/angular-v22-76d725d8)
<!-- polygraph-session-end -->