### PR TITLE
fix(core): exclude NX_CLOUD_ env vars from daemon env reflection

### DIFF
--- a/packages/nx/src/daemon/client/daemon-environment.ts
+++ b/packages/nx/src/daemon/client/daemon-environment.ts
@@ -100,6 +100,13 @@ const DAEMON_ENV_PREFIX_EXCLUSIONS = [
   'npm_',
   'pnpm_',
 
+  // Nx Cloud runner/agent vars (per-worker values like NX_CLOUD_WORKER_ID
+  // and NX_CLOUD_EXECUTION_ID diverge between distributed-execution workers
+  // and cannot affect the project graph; without this every worker that
+  // talks to the daemon would force a graph recompute). The cloud auth/access
+  // tokens are allow-listed below — they are stable and signal cloud usage.
+  'NX_CLOUD_',
+
   // Editors / IDEs
   'VSCODE_',
   'JETBRAINS_',
@@ -116,7 +123,22 @@ const DAEMON_ENV_PREFIX_EXCLUSIONS = [
   'HYPERFINE_', // hyperfine sets HYPERFINE_RANDOMIZED_ENVIRONMENT_OFFSET for each iteration
 ];
 
+/**
+ * Vars that match an excluded prefix but should still reach the daemon. The
+ * Nx Cloud auth/access tokens are excluded by the `NX_CLOUD_` prefix, but
+ * unlike the per-worker cloud vars they are stable across clients (so they
+ * don't churn the daemon env) and signal that the workspace uses Nx Cloud
+ * (e.g. for analytics). Keep them.
+ */
+const DAEMON_ENV_PREFIX_EXCLUSION_OVERRIDES = new Set([
+  'NX_CLOUD_ACCESS_TOKEN',
+  'NX_CLOUD_AUTH_TOKEN',
+]);
+
 function isExcludedEnvVar(key: string): boolean {
+  if (DAEMON_ENV_PREFIX_EXCLUSION_OVERRIDES.has(key)) {
+    return false;
+  }
   return (
     DAEMON_ENV_VARS_EXCLUSIONS.has(key) ||
     DAEMON_ENV_PREFIX_EXCLUSIONS.some((prefix) => key.startsWith(prefix))
@@ -140,8 +162,8 @@ export function getDaemonEnv() {
  * client's project-graph computation. Deletion skips excluded vars and
  * required settings, which the daemon owns and clients should not control.
  */
-export function applyDaemonEnvFromClient(newEnv: NodeJS.ProcessEnv): boolean {
-  let changed = false;
+export function applyDaemonEnvFromClient(newEnv: NodeJS.ProcessEnv): string[] {
+  const changedKeys: string[] = [];
   const allKeys = new Set([
     ...Object.keys(process.env),
     ...Object.keys(newEnv),
@@ -150,15 +172,15 @@ export function applyDaemonEnvFromClient(newEnv: NodeJS.ProcessEnv): boolean {
     if (key in newEnv) {
       if (process.env[key] !== newEnv[key]) {
         process.env[key] = newEnv[key];
-        changed = true;
+        changedKeys.push(key);
       }
     } else if (
       !isExcludedEnvVar(key) &&
       !Object.hasOwn(DAEMON_ENV_REQUIRED_SETTINGS, key)
     ) {
       delete process.env[key];
-      changed = true;
+      changedKeys.push(key);
     }
   }
-  return changed;
+  return changedKeys;
 }

--- a/packages/nx/src/daemon/server/server.ts
+++ b/packages/nx/src/daemon/server/server.ts
@@ -257,9 +257,13 @@ async function handleMessage(socket: Socket, data: string) {
   serverLogger.log(`Received ${mode} message of type ${payload.type}`);
 
   if (isDaemonMessage(payload) && payload.env) {
-    const envChanged = applyDaemonEnvFromClient(payload.env);
-    if (envChanged) {
-      serverLogger.log('Graph recompute necessary due to env variable refresh');
+    const changedEnvKeys = applyDaemonEnvFromClient(payload.env);
+    if (changedEnvKeys.length > 0) {
+      serverLogger.log(
+        `Graph recompute necessary due to env variable refresh. Changed keys: ${changedEnvKeys.join(
+          ', '
+        )}`
+      );
       forwardEnvToPluginWorkers(payload.env);
       invalidateGraphCache();
     }


### PR DESCRIPTION
## Current Behavior

Nx Cloud distributed-execution workers each open their own connection to the Nx daemon and send their full (filtered) process environment with messages like `GET_ESTIMATED_TASK_TIMINGS`. Per-worker Nx Cloud vars (`NX_CLOUD_WORKER_ID`, `NX_CLOUD_WORKER_INDEX`, `NX_CLOUD_EXECUTION_ID`, `NX_CLOUD_ORCHESTRATOR_SOCKET`) are not excluded from the env the daemon reflects, so they differ from the env the daemon was started with — and differ between workers. Every worker that talks to the daemon rewrites the daemon env and invalidates the project-graph cache, forcing a full graph recompute on each worker message (`Graph recompute necessary due to env variable refresh`). The daemon also does not log which keys changed, so the churn is hard to diagnose.

## Expected Behavior

`NX_CLOUD_`-prefixed vars are excluded from the env reflected by the daemon (they cannot affect the project graph), so connecting workers no longer trigger graph recomputes. The daemon also logs the changed env keys when a refresh does occur, to make future env-driven recompute churn diagnosable.

## Related Issue(s)

Surfaced via staging DTE agent logs (no GitHub issue).

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/nx-cloud-dte-debug-aee8e394)
<!-- polygraph-session-end -->