### PR TITLE
fix(core): keep daemon alive when a request handler errors

### DIFF
--- a/packages/nx/src/daemon/server/server.ts
+++ b/packages/nx/src/daemon/server/server.ts
@@ -156,6 +156,7 @@ import {
   handleServerProcessTerminationWithRestart,
   resetInactivityTimeout,
   respondToClient,
+  respondWithError,
   respondWithErrorAndExit,
   SERVER_INACTIVITY_TIMEOUT_MS,
   storeOutputWatcherInstance,
@@ -248,11 +249,12 @@ async function handleMessage(socket: Socket, data: string) {
       mode = 'v8';
     }
   } catch (e) {
-    await respondWithErrorAndExit(
+    await respondWithError(
       socket,
       `Invalid payload from the client`,
       new Error(`Unsupported payload sent to daemon server: ${unparsedPayload}`)
     );
+    return;
   }
   serverLogger.log(`Received ${mode} message of type ${payload.type}`);
 
@@ -471,7 +473,7 @@ async function handleMessage(socket: Socket, data: string) {
       mode
     );
   } else {
-    await respondWithErrorAndExit(
+    await respondWithError(
       socket,
       `Invalid payload from the client`,
       new Error(`Unsupported payload sent to daemon server: ${unparsedPayload}`)
@@ -494,7 +496,11 @@ export async function handleResult(
   }
   const doneHandlingMark = new Date();
   if (hr.error) {
-    await respondWithErrorAndExit(socket, hr.description, hr.error);
+    // A handler failing is local to that one request — return the error to the
+    // requesting client, but keep the daemon (and every other connected client)
+    // alive. The daemon only self-terminates when its own state is broken
+    // (e.g. a file-watcher error), not on a per-request failure.
+    await respondWithError(socket, hr.description, hr.error);
   } else {
     serverLogger.log(
       `Serializing response for ${type} message in ${mode} mode`

--- a/packages/nx/src/daemon/server/shutdown-utils.ts
+++ b/packages/nx/src/daemon/server/shutdown-utils.ts
@@ -185,15 +185,20 @@ export function respondToClient(
   });
 }
 
-export async function respondWithErrorAndExit(
+/**
+ * Send an error back to the requesting client without tearing down the daemon.
+ * Use this for handlers whose failures are local to the request (e.g. a
+ * task-history DB read) and don't corrupt the daemon's in-memory state.
+ */
+export async function respondWithError(
   socket: Socket,
   description: string,
   error: Error
 ) {
-  const isProjectGraphError = error instanceof DaemonProjectGraphError;
-  const normalizedError = isProjectGraphError
-    ? ProjectGraphError.fromDaemonProjectGraphError(error)
-    : error;
+  const normalizedError =
+    error instanceof DaemonProjectGraphError
+      ? ProjectGraphError.fromDaemonProjectGraphError(error)
+      : error;
 
   // print some extra stuff in the error message
   serverLogger.requestLog(
@@ -205,9 +210,17 @@ export async function respondWithErrorAndExit(
 
   // Respond with the original error
   await respondToClient(socket, serializeResult(error, null, null), null);
+}
+
+export async function respondWithErrorAndExit(
+  socket: Socket,
+  description: string,
+  error: Error
+) {
+  await respondWithError(socket, description, error);
 
   // Project Graph errors are okay. Restarting the daemon won't help with this.
-  if (!isProjectGraphError) {
+  if (!(error instanceof DaemonProjectGraphError)) {
     process.exit(1);
   }
 }


### PR DESCRIPTION
## Current Behavior

When a daemon message handler throws, `handleResult` routes the error through `respondWithErrorAndExit`, which calls `process.exit(1)` for any non-project-graph error. That terminates the daemon and ECONNRESETs every other connected client, so a single transient error (e.g. a task-history DB read, an unparseable payload, or an unknown message type) fails all in-flight requests across the workspace — including every worker in a distributed task execution.

## Expected Behavior

A per-request handler failure returns the error to the requesting client only; the daemon and all other connected clients stay alive. `respondWithError` is split out of `respondWithErrorAndExit` and used for per-request failures (handler errors, unparseable payloads, unknown message types). The daemon still self-restarts on a genuine health failure (a workspace file-watcher error), where continuing to serve a stale graph would be worse.

## Related Issue(s)

Surfaced via staging DTE agent logs (no GitHub issue).

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/nx-cloud-dte-debug-aee8e394)
<!-- polygraph-session-end -->