### PR TITLE
docs(misc): add v23 to docs version switcher

### DIFF
--- a/astro-docs/src/components/layout/Header.astro
+++ b/astro-docs/src/components/layout/Header.astro
@@ -19,7 +19,8 @@ const nxDevUrl = import.meta.env.SITE || 'https://nx.dev';
 
 // Version options
 const versions = [
-  { version: 'v22', href: '/docs/getting-started/intro', current: true },
+  { version: 'v23', href: '/docs/getting-started/intro', current: true },
+  { version: 'v22', href: 'https://22.nx.dev/docs' },
   { version: 'v21', href: 'https://21.nx.dev/docs' },
   { version: 'v20', href: 'https://20.nx.dev/docs' },
   { version: 'v19', href: 'https://19.nx.dev/docs' },


### PR DESCRIPTION
## Current Behavior

Version dropdown shows v22 as current with no v22 archive link.

## Expected Behavior

v23 is current; v22 points to https://22.nx.dev/docs alongside v21/v20/v19.

## Related Issue(s)

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/docs-update-misc-updates-v23-837b8d30)
<!-- polygraph-session-end -->