### PR TITLE
docs(misc): add golden-path and structural style rules to docs guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,6 +23,8 @@ When working on Nx documentation, all documentation content lives in the `astro-
 
 **MANDATORY**: After editing any file in `astro-docs/src/content/`, run the `nx-docs-style-check` skill. No exceptions.
 
+**MANDATORY**: All documentation content must follow `astro-docs/STYLE_GUIDE.md`. vale only enforces its mechanical rules, so check the structural and voice rules yourself.
+
 ### Quick Reference
 
 - Documentation content: `astro-docs/src/content/docs/`

--- a/astro-docs/STYLE_GUIDE.md
+++ b/astro-docs/STYLE_GUIDE.md
@@ -43,6 +43,22 @@ Distinguish platform features from ecosystem tools to prevent "Features" from be
 - Yes: **Platform Features**.
 - No (only React users): **Technologies**.
 
+### 6. The golden path (the "one way" rule)
+
+Feature pages teach the default workflow. Limit flags and variants to the ones a reader needs
+to make a decision.
+
+**The test:** Would a first-time user need this sentence to succeed or to choose? If not, it
+belongs in the corresponding Knowledge Base guide.
+
+- Show one command form. If `nx migrate` works without arguments, don't also show `nx migrate latest`.
+- When a flag presents a real choice, explain it briefly on the feature page (for example, why
+  pick `--include=required` over `all`) and link the Knowledge Base guide for constraints and
+  edge cases.
+- Remove deprecated options entirely when a replacement exists - no deprecation asides. The same
+  applies to workflows a new flag has superseded.
+- When two sections converge on the same flag or topic after a rewrite, merge them into one.
+
 ### Sidebar structure
 
 The sidebar has four top-level sections that follow the user journey:


### PR DESCRIPTION
- STYLE_GUIDE: new IA principle 6 "The golden path" (one command form, permutations in KB guides, remove deprecated options outright, merge converged sections).
- CLAUDE.md: instruct `STYLE_GUIDE.md` to be used when authoring docs.

