### PR TITLE
fix(core): degrade cooldown-blocked dist-tags within their own channel

### DIFF
--- a/packages/nx/src/command-line/migrate/resolve-package-version.spec.ts
+++ b/packages/nx/src/command-line/migrate/resolve-package-version.spec.ts
@@ -64,7 +64,6 @@ function pnpmPolicy(
         packageManager: 'pnpm',
         strict: overrides.strict ?? false,
         looseFallback: true,
-        latestTagDegrade: 'any-major',
         writesExcludes: overrides.writesExcludes ?? true,
         missingTimeMap: 'skip',
       },

--- a/packages/nx/src/utils/min-release-age/behavior/bun.spec.ts
+++ b/packages/nx/src/utils/min-release-age/behavior/bun.spec.ts
@@ -65,6 +65,23 @@ const pkgEdge = metadataFromAges(
   { latest: '1.0.1' }
 );
 
+// Multiple prerelease channels sharing a release line, for the channel-aware
+// tag degrade.
+const pkgChannels = metadataFromAges(
+  'pkg-ch',
+  {
+    '22.7.0': 200,
+    '22.7.5': 6,
+    '22.7.0-rc.2': 220,
+    '23.0.0-beta.1': 100,
+    '23.0.0-pr.5': 90,
+    '23.0.0-rc.0': 2,
+    '23.1.0-rc.1': 80,
+    '23.1.0-rc.4': 4,
+  },
+  { latest: '22.7.5', next: '23.0.0-rc.0', pre: '23.1.0-rc.4' }
+);
+
 function policyWithWindow(windowHours: number): MinReleaseAgePolicy {
   const windowMs = windowHours * HOUR;
   return {
@@ -172,25 +189,38 @@ describe('bun min-release-age behavior', () => {
       );
     });
 
-    it('latest tag degrades via the stability walk (2.0.0 -> 1.1.1)', () => {
-      // bun applies the same stability walk to ALL tags (no npm-style <=target).
+    it('latest tag (too-new stable) degrades to the newest compliant stable (2.0.0 -> 1.2.0)', () => {
       expect(pickBunVersion('latest', pkgA, policy)).toEqual({
-        version: '1.1.1',
+        version: '1.2.0',
         unconstrained: '2.0.0',
       });
     });
 
-    it('non-latest tag (hot -> 2.0.0) degrades to 1.1.1', () => {
+    it('non-latest tag (hot -> 2.0.0) degrades to 1.2.0', () => {
       expect(pickBunVersion('hot', pkgA, policy)).toEqual({
-        version: '1.1.1',
+        version: '1.2.0',
         unconstrained: '2.0.0',
       });
     });
 
-    it('prerelease tag stays in its channel (canary -> canary.1, never beta)', () => {
+    it('prerelease tag keeps a compliant same-line same-channel version (canary.3 -> canary.1)', () => {
       expect(pickBunVersion('canary', pkgA, policy)).toEqual({
         version: '3.0.0-canary.1',
         unconstrained: '3.0.0-canary.3',
+      });
+    });
+
+    it('too-new rc tag never crosses into a pr/beta channel -> latest stable', () => {
+      expect(pickBunVersion('next', pkgChannels, policy)).toEqual({
+        version: '22.7.0',
+        unconstrained: '23.0.0-rc.0',
+      });
+    });
+
+    it('too-new rc tag keeps a compliant same-line rc (pre -> 23.1.0-rc.1)', () => {
+      expect(pickBunVersion('pre', pkgChannels, policy)).toEqual({
+        version: '23.1.0-rc.1',
+        unconstrained: '23.1.0-rc.4',
       });
     });
 

--- a/packages/nx/src/utils/min-release-age/behavior/bun.spec.ts
+++ b/packages/nx/src/utils/min-release-age/behavior/bun.spec.ts
@@ -210,9 +210,9 @@ describe('bun min-release-age behavior', () => {
       });
     });
 
-    it('too-new rc tag never crosses into a pr/beta channel -> latest stable', () => {
+    it('too-new rc tag falls to its same-line beta, never into pr', () => {
       expect(pickBunVersion('next', pkgChannels, policy)).toEqual({
-        version: '22.7.0',
+        version: '23.0.0-beta.1',
         unconstrained: '23.0.0-rc.0',
       });
     });

--- a/packages/nx/src/utils/min-release-age/behavior/bun.ts
+++ b/packages/nx/src/utils/min-release-age/behavior/bun.ts
@@ -163,8 +163,8 @@ function readBunInstall(path: string): BunInstallConfig | 'error' {
  *   version >= min(window, 7d), inclusive); unstable -> keep walking but remember
  *   it; stop past `now - (window + 7d)`; no stable -> newest age-passing fallback.
  *   No in-range version at all -> err.not_found (a plain, non-cooldown error).
- * - dist-tag too new -> degrade to the newest compliant version in the tag's
- *   own channel, falling back to stable (`degradeTagToCompliant`); none ->
+ * - dist-tag too new -> degrade via the shared channel-aware rule (see
+ *   `degradeTagToCompliant` for the ordering); none compliant ->
  *   TooRecentVersion.
  * Missing/unparseable publish times are treated as timestamp 0 (always pass);
  * future timestamps are blocked.

--- a/packages/nx/src/utils/min-release-age/behavior/bun.ts
+++ b/packages/nx/src/utils/min-release-age/behavior/bun.ts
@@ -5,7 +5,12 @@ import { parse as parseToml } from 'smol-toml';
 import { MS_PER_DAY, MS_PER_SECOND } from '../constants';
 import { MinReleaseAgeViolationError } from '../errors';
 import type { RegistryMetadata } from '../packument';
-import { blockedVersionsFrom, classifySpec, type PickOutcome } from '../pick';
+import {
+  blockedVersionsFrom,
+  classifySpec,
+  degradeTagToCompliant,
+  type PickOutcome,
+} from '../pick';
 import type {
   MinReleaseAgePolicy,
   MinReleaseAgePolicyReadResult,
@@ -148,8 +153,9 @@ function readBunInstall(path: string): BunInstallConfig | 'error' {
 }
 
 /**
- * Mirrors bun's resolver (find_best_version_with_filter /
- * find_by_dist_tag_with_filter, byte-identical 1.3.0 -> 1.3.14):
+ * bun resolution. Exact pins and ranges mirror bun's resolver
+ * (find_best_version_with_filter, byte-identical 1.3.0 -> 1.3.14); dist-tag
+ * degrade uses the shared cross-PM rule:
  * - exact pin too new -> hard error (TooRecentVersion), no fallback.
  * - range -> the `latest` dist-tag is checked first: in-range and age-passing ->
  *   return it immediately. Otherwise walk newest to oldest skipping age-blocked;
@@ -157,9 +163,9 @@ function readBunInstall(path: string): BunInstallConfig | 'error' {
  *   version >= min(window, 7d), inclusive); unstable -> keep walking but remember
  *   it; stop past `now - (window + 7d)`; no stable -> newest age-passing fallback.
  *   No in-range version at all -> err.not_found (a plain, non-cooldown error).
- * - dist-tag (ALL tags) -> target passes -> return; else the same stability
- *   walk over versions <= the tag target, constrained to the tag's prerelease
- *   channel (canary never falls back to beta).
+ * - dist-tag too new -> degrade to the newest compliant version in the tag's
+ *   own channel, falling back to stable (`degradeTagToCompliant`); none ->
+ *   TooRecentVersion.
  * Missing/unparseable publish times are treated as timestamp 0 (always pass);
  * future timestamps are blocked.
  */
@@ -185,14 +191,11 @@ export function pickBunVersion(
     if (passesGate(metadata, policy, target)) {
       return { version: target, unconstrained: target };
     }
-    const picked = walkStability(
-      metadata,
-      policy,
-      candidatesForTag(metadata, target),
-      target
+    const degraded = degradeTagToCompliant(target, metadata, (v) =>
+      passesGate(metadata, policy, v)
     );
-    if (picked) {
-      return { version: picked, unconstrained: target };
+    if (degraded) {
+      return { version: degraded, unconstrained: target };
     }
     throw tooRecent(metadata, policy, spec);
   }
@@ -276,39 +279,6 @@ function walkStability(
 
   // No stable candidate: fall back to the newest age-passing version, if any.
   return best;
-}
-
-/**
- * The candidate set for a too-recent dist-tag: versions at or below the tag
- * target, sorted newest-first, constrained to the same prerelease channel as
- * the target (a stable target excludes all prereleases).
- */
-function candidatesForTag(
-  metadata: RegistryMetadata,
-  target: string
-): string[] {
-  const targetChannel = prereleaseChannel(target);
-  return metadata.versions
-    .filter((v) => {
-      if (rcompare(v, target) < 0) {
-        // newer than the target
-        return false;
-      }
-      return prereleaseChannel(v) === targetChannel;
-    })
-    .sort(rcompare);
-}
-
-// The base prerelease channel ("canary" from "3.0.0-canary.1"), or null for a
-// stable version.
-function prereleaseChannel(version: string): string | null {
-  const dash = version.indexOf('-');
-  if (dash === -1) {
-    return null;
-  }
-  const pre = version.slice(dash + 1);
-  const dot = pre.indexOf('.');
-  return dot === -1 ? pre : pre.slice(0, dot);
 }
 
 // A version passes when its publish time is at or before the cutoff

--- a/packages/nx/src/utils/min-release-age/behavior/npm.spec.ts
+++ b/packages/nx/src/utils/min-release-age/behavior/npm.spec.ts
@@ -241,12 +241,12 @@ describe('npm min-release-age behavior', () => {
       });
     });
 
-    it('too-new rc tag never crosses into a pr/beta channel -> latest stable', () => {
-      // next -> 23.0.0-rc.0 is too new. The internal 23.0.0-pr.5 and 23.0.0-beta.1
-      // are different channels (excluded), and the only same-channel candidate is
-      // the cross-line 22.7.0-rc.2, which loses to the stable 22.7.0.
+    it('too-new rc tag falls to its same-line beta, never into pr', () => {
+      // next -> 23.0.0-rc.0 is too new and has no older same-line rc; beta is a
+      // lower rung of the same line so 23.0.0-beta.1 wins, while the internal
+      // 23.0.0-pr.5 (newer-published) is off the ladder and stays walled off.
       expect(pickNpmVersion('next', pkgChannels, policy)).toEqual({
-        version: '22.7.0',
+        version: '23.0.0-beta.1',
         unconstrained: '23.0.0-rc.0',
       });
     });

--- a/packages/nx/src/utils/min-release-age/behavior/npm.spec.ts
+++ b/packages/nx/src/utils/min-release-age/behavior/npm.spec.ts
@@ -16,31 +16,11 @@ import type { RegistryMetadata } from '../packument';
 import type { MinReleaseAgePolicy } from '../policy';
 import { pickNpmVersion, readNpmPolicy } from './npm';
 
-// Mirrors readNpmrcEntries parsing so the mocked surface map (path -> contents)
-// drives detectSurfaces; an absent path reads as a missing file (null).
-function parseNpmrcEntries(
-  raw: string | undefined
-): { key: string; value: string }[] | null {
-  if (raw === undefined) {
-    return null;
-  }
-  const entries: { key: string; value: string }[] = [];
-  for (const line of raw.split(/\r?\n/)) {
-    const trimmed = line.trim();
-    if (!trimmed || trimmed.startsWith('#') || trimmed.startsWith(';')) {
-      continue;
-    }
-    const eq = trimmed.indexOf('=');
-    if (eq === -1) {
-      continue;
-    }
-    entries.push({
-      key: trimmed.slice(0, eq).trim(),
-      value: trimmed.slice(eq + 1).trim(),
-    });
-  }
-  return entries;
-}
+// The real parser drives the mocked surface map (path -> contents) so
+// detectSurfaces sees genuine parsing; an absent path reads as a missing
+// file (null).
+const { parseNpmrcContent } =
+  jest.requireActual<typeof import('../npmrc')>('../npmrc');
 
 const HOUR = 3_600_000;
 const NOW = Date.parse('2026-06-05T00:00:00.000Z');
@@ -280,6 +260,20 @@ describe('npm min-release-age behavior', () => {
       });
     });
 
+    it('tag with no compliant candidate at all -> ENOVERSIONS violation', () => {
+      // latest -> 1.0.1 is too new and the degrade pool (1.0.0, also too new)
+      // has nothing compliant, so the tag path's ENOVERSIONS fires.
+      try {
+        pickNpmVersion('latest', pkgB, policy);
+        throw new Error('expected throw');
+      } catch (e) {
+        expect(e).toBeInstanceOf(MinReleaseAgeViolationError);
+        expect((e as MinReleaseAgeViolationError).pmShapedDetail).toBe(
+          'No versions available for pkg-b'
+        );
+      }
+    });
+
     it('tag pointing at an already-mature version returns it', () => {
       expect(pickNpmVersion('stable-old', pkgA, policy)).toEqual({
         version: '1.0.1',
@@ -385,7 +379,7 @@ describe('npm min-release-age behavior', () => {
     beforeEach(() => {
       npmrcFiles = {};
       readNpmrcEntriesMock.mockImplementation((p: string) =>
-        parseNpmrcEntries(npmrcFiles[p])
+        npmrcFiles[p] === undefined ? null : parseNpmrcContent(npmrcFiles[p])
       );
     });
 

--- a/packages/nx/src/utils/min-release-age/behavior/npm.spec.ts
+++ b/packages/nx/src/utils/min-release-age/behavior/npm.spec.ts
@@ -1,12 +1,46 @@
 jest.mock('child_process');
+// detectSurfaces reads os.homedir() and the .npmrc files through named imports
+// bound at module load, so a per-test jest.spyOn never intercepts them. Mock at
+// module scope (as yarn.spec.ts does for os) so the host's real ~/.npmrc cannot
+// leak into the config-surface attribution tests.
+jest.mock('os', () => ({
+  ...jest.requireActual('os'),
+  homedir: jest.fn(() => '/home/user'),
+}));
+jest.mock('../npmrc', () => ({ readNpmrcEntries: jest.fn(() => null) }));
 
 import * as childProcess from 'child_process';
-import * as fs from 'fs';
-import * as os from 'os';
 import { MinReleaseAgeViolationError } from '../errors';
+import { readNpmrcEntries } from '../npmrc';
 import type { RegistryMetadata } from '../packument';
 import type { MinReleaseAgePolicy } from '../policy';
 import { pickNpmVersion, readNpmPolicy } from './npm';
+
+// Mirrors readNpmrcEntries parsing so the mocked surface map (path -> contents)
+// drives detectSurfaces; an absent path reads as a missing file (null).
+function parseNpmrcEntries(
+  raw: string | undefined
+): { key: string; value: string }[] | null {
+  if (raw === undefined) {
+    return null;
+  }
+  const entries: { key: string; value: string }[] = [];
+  for (const line of raw.split(/\r?\n/)) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#') || trimmed.startsWith(';')) {
+      continue;
+    }
+    const eq = trimmed.indexOf('=');
+    if (eq === -1) {
+      continue;
+    }
+    entries.push({
+      key: trimmed.slice(0, eq).trim(),
+      value: trimmed.slice(eq + 1).trim(),
+    });
+  }
+  return entries;
+}
 
 const HOUR = 3_600_000;
 const NOW = Date.parse('2026-06-05T00:00:00.000Z');
@@ -65,6 +99,24 @@ const pkgEdge = metadataFromAges(
   'pkg-edge',
   { '1.0.0': 24.2, '1.0.1': 23.8 },
   { latest: '1.0.1' }
+);
+
+// Multiple prerelease channels sharing a release line, for the channel-aware
+// tag degrade: an `rc` next-target with an internal `pr` build and a `beta` of
+// the same line, plus an older cross-line `rc` and a same-line older `rc`.
+const pkgChannels = metadataFromAges(
+  'pkg-ch',
+  {
+    '22.7.0': 200,
+    '22.7.5': 6,
+    '22.7.0-rc.2': 220,
+    '23.0.0-beta.1': 100,
+    '23.0.0-pr.5': 90,
+    '23.0.0-rc.0': 2,
+    '23.1.0-rc.1': 80,
+    '23.1.0-rc.4': 4,
+  },
+  { latest: '22.7.5', next: '23.0.0-rc.0', pre: '23.1.0-rc.4' }
 );
 
 // 24h window policy anchored to the fixture clock.
@@ -209,6 +261,25 @@ describe('npm min-release-age behavior', () => {
       });
     });
 
+    it('too-new rc tag never crosses into a pr/beta channel -> latest stable', () => {
+      // next -> 23.0.0-rc.0 is too new. The internal 23.0.0-pr.5 and 23.0.0-beta.1
+      // are different channels (excluded), and the only same-channel candidate is
+      // the cross-line 22.7.0-rc.2, which loses to the stable 22.7.0.
+      expect(pickNpmVersion('next', pkgChannels, policy)).toEqual({
+        version: '22.7.0',
+        unconstrained: '23.0.0-rc.0',
+      });
+    });
+
+    it('too-new rc tag keeps a compliant same-line rc', () => {
+      // pre -> 23.1.0-rc.4 is too new, but 23.1.0-rc.1 (same channel, same line)
+      // is compliant and outranks every stable below 23.x.
+      expect(pickNpmVersion('pre', pkgChannels, policy)).toEqual({
+        version: '23.1.0-rc.1',
+        unconstrained: '23.1.0-rc.4',
+      });
+    });
+
     it('tag pointing at an already-mature version returns it', () => {
       expect(pickNpmVersion('stable-old', pkgA, policy)).toEqual({
         version: '1.0.1',
@@ -306,29 +377,20 @@ describe('npm min-release-age behavior', () => {
 
   describe('readNpmPolicy', () => {
     const execSyncMock = childProcess.execSync as jest.Mock;
+    const readNpmrcEntriesMock = readNpmrcEntries as jest.Mock;
 
     // path -> .npmrc contents; absent paths read as missing files.
     let npmrcFiles: Record<string, string>;
 
     beforeEach(() => {
       npmrcFiles = {};
-      jest.spyOn(os, 'homedir').mockReturnValue('/home/user');
-      jest
-        .spyOn(fs, 'existsSync')
-        .mockImplementation(
-          (p: any) => typeof p === 'string' && p in npmrcFiles
-        );
-      jest.spyOn(fs, 'readFileSync').mockImplementation((p: any) => {
-        if (typeof p === 'string' && p in npmrcFiles) {
-          return npmrcFiles[p];
-        }
-        throw new Error(`ENOENT: ${p}`);
-      });
+      readNpmrcEntriesMock.mockImplementation((p: string) =>
+        parseNpmrcEntries(npmrcFiles[p])
+      );
     });
 
     afterEach(() => {
       jest.clearAllMocks();
-      jest.restoreAllMocks();
     });
 
     function mockConfig(config: Record<string, unknown>) {

--- a/packages/nx/src/utils/min-release-age/behavior/npm.ts
+++ b/packages/nx/src/utils/min-release-age/behavior/npm.ts
@@ -293,8 +293,8 @@ function createNpmPolicy(opts: {
  * npm-pick-manifest@11.0.3; dist-tag degrade uses the shared cross-PM rule:
  * - exact pin too new -> ETARGET (no fallback).
  * - unknown dist-tag -> ETARGET (no version to resolve against).
- * - dist-tag too new -> degrade to the newest compliant version in the tag's
- *   own channel, falling back to stable (`degradeTagToCompliant`); none -> ENOVERSIONS.
+ * - dist-tag too new -> degrade via the shared channel-aware rule (see
+ *   `degradeTagToCompliant` for the ordering); none compliant -> ENOVERSIONS.
  * - range -> filter every version by maturity FIRST; empty -> ENOVERSIONS;
  *   else newest in-range survivor; survivors but none in range -> ETARGET.
  */

--- a/packages/nx/src/utils/min-release-age/behavior/npm.ts
+++ b/packages/nx/src/utils/min-release-age/behavior/npm.ts
@@ -9,6 +9,7 @@ import type { RegistryMetadata } from '../packument';
 import {
   blockedVersionsFrom,
   classifySpec,
+  degradeTagToCompliant,
   isVersionMature,
   newestInRange,
   type PickOutcome,
@@ -288,11 +289,12 @@ function createNpmPolicy(opts: {
 }
 
 /**
- * Mirrors npm-pick-manifest@11.0.3 under an active `before` filter:
+ * npm resolution under an active `before` filter. Exact pins and ranges mirror
+ * npm-pick-manifest@11.0.3; dist-tag degrade uses the shared cross-PM rule:
  * - exact pin too new -> ETARGET (no fallback).
  * - unknown dist-tag -> ETARGET (no version to resolve against).
- * - dist-tag too new -> recurse with `<=tagTarget` (newest passing version at
- *   or below the tag target, prereleases of the same line included).
+ * - dist-tag too new -> degrade to the newest compliant version in the tag's
+ *   own channel, falling back to stable (`degradeTagToCompliant`); none -> ENOVERSIONS.
  * - range -> filter every version by maturity FIRST; empty -> ENOVERSIONS;
  *   else newest in-range survivor; survivors but none in range -> ETARGET.
  */
@@ -327,8 +329,13 @@ export function pickNpmVersion(
     if (isVersionMature(metadata.name, tagTarget, metadata, policy)) {
       return { version: tagTarget, unconstrained };
     }
-    // npm recurses with `<=tagTarget`, which flows through the range path.
-    return pickRange(metadata, policy, `<=${tagTarget}`, spec, unconstrained);
+    const degraded = degradeTagToCompliant(tagTarget, metadata, (v) =>
+      isVersionMature(metadata.name, v, metadata, policy)
+    );
+    if (degraded) {
+      return { version: degraded, unconstrained };
+    }
+    throw enoVersions(metadata, policy, spec);
   }
 
   return pickRange(metadata, policy, spec, spec, newestInRange(metadata, spec));

--- a/packages/nx/src/utils/min-release-age/behavior/pnpm.spec.ts
+++ b/packages/nx/src/utils/min-release-age/behavior/pnpm.spec.ts
@@ -233,13 +233,13 @@ describe('pnpm min-release-age behavior', () => {
       });
     });
 
-    it('too-new rc tag never crosses into a pr/beta channel -> latest stable', () => {
-      // next -> 23.0.0-rc.0 too new; 23.0.0-pr.5 / 23.0.0-beta.1 are other
-      // channels (excluded), the only same-channel candidate 22.7.0-rc.2 loses
-      // to the stable 22.7.0.
+    it('too-new rc tag falls to its same-line beta, never into pr', () => {
+      // next -> 23.0.0-rc.0 too new with no older same-line rc; the same-line
+      // 23.0.0-beta.1 (lower ladder rung) wins, while the newer-published
+      // internal 23.0.0-pr.5 is off the ladder and stays walled off.
       expect(pickPnpmVersion('next', pkgChannels, v11StrictPolicy(24))).toEqual(
         {
-          version: '22.7.0',
+          version: '23.0.0-beta.1',
           unconstrained: '23.0.0-rc.0',
         }
       );

--- a/packages/nx/src/utils/min-release-age/behavior/pnpm.spec.ts
+++ b/packages/nx/src/utils/min-release-age/behavior/pnpm.spec.ts
@@ -434,6 +434,21 @@ describe('pnpm min-release-age behavior', () => {
         immature: true,
       });
     });
+
+    it('tag pointing at a non-semver target -> violation, never an immature install', () => {
+      // An immature return here would make the consumer write pkg@<garbage>
+      // into minimumReleaseAgeExclude, which pnpm rejects on every later
+      // install (ERR_PNPM_INVALID_VERSION_UNION).
+      const meta: RegistryMetadata = {
+        name: 'pkg-garbage',
+        versions: ['1.0.0'],
+        time: { '1.0.0': new Date(NOW - 9600 * HOUR).toISOString() },
+        distTags: { latest: 'not-a-version' },
+      };
+      expect(() => pickPnpmVersion('latest', meta, v11LoosePolicy(24))).toThrow(
+        MinReleaseAgeViolationError
+      );
+    });
   });
 
   describe('excludes bypass', () => {

--- a/packages/nx/src/utils/min-release-age/behavior/pnpm.spec.ts
+++ b/packages/nx/src/utils/min-release-age/behavior/pnpm.spec.ts
@@ -66,10 +66,30 @@ const pkgEdge = metadataFromAges(
 
 // A latest tag whose target is a too-new new-major; degrade has no same-major
 // mature candidate but a lower major does.
-const pkgNewMajor = metadataFromAges(
-  'pkg-newmajor',
-  { '1.2.0': 25, '1.2.1': 12, '2.0.0': 6 },
-  { latest: '2.0.0' }
+// Multiple prerelease channels sharing a release line, for the channel-aware
+// tag degrade: an `rc` next-target with an internal `pr` build and a `beta` of
+// the same line, plus an older cross-line `rc` and a same-line older `rc`.
+const pkgChannels = metadataFromAges(
+  'pkg-ch',
+  {
+    '22.7.0': 200,
+    '22.7.5': 6,
+    '22.7.0-rc.2': 220,
+    '23.0.0-beta.1': 100,
+    '23.0.0-pr.5': 90,
+    '23.0.0-rc.0': 2,
+    '23.1.0-rc.1': 80,
+    '23.1.0-rc.4': 4,
+  },
+  { latest: '22.7.5', next: '23.0.0-rc.0', pre: '23.1.0-rc.4' }
+);
+
+// Every version younger than the 24h window: a too-new tag has no compliant
+// degrade candidate, exercising the strict-violation / loose-immature paths.
+const pkgAllTooNew = metadataFromAges(
+  'pkg-allnew',
+  { '1.2.0': 12, '2.0.0': 6 },
+  { latest: '1.2.0', hot: '2.0.0' }
 );
 
 function basePolicy(
@@ -90,7 +110,6 @@ function basePolicy(
       packageManager: 'pnpm',
       strict: true,
       looseFallback: false,
-      latestTagDegrade: 'any-major',
       writesExcludes: false,
       missingTimeMap: 'error',
       ...behaviorOverrides,
@@ -109,7 +128,6 @@ function v10Policy(
     {
       strict: true,
       looseFallback: false,
-      latestTagDegrade: 'same-major',
       writesExcludes: false,
       missingTimeMap: 'error',
     },
@@ -127,7 +145,6 @@ function v11StrictPolicy(
     {
       strict: true,
       looseFallback: false,
-      latestTagDegrade: 'any-major',
       writesExcludes: true,
       missingTimeMap: 'skip',
     },
@@ -146,7 +163,6 @@ function v11SingleFormStrictPolicy(
     {
       strict: true,
       looseFallback: false,
-      latestTagDegrade: 'any-major',
       writesExcludes: false,
       missingTimeMap: 'skip',
     },
@@ -164,7 +180,6 @@ function v11LoosePolicy(
     {
       strict: false,
       looseFallback: true,
-      latestTagDegrade: 'any-major',
       writesExcludes: false,
       missingTimeMap: 'skip',
     },
@@ -188,18 +203,11 @@ describe('pnpm min-release-age behavior', () => {
       });
     });
 
-    it('latest tag degrades to newest mature any-major (tag-latest 10.20+ -> 1.2.0)', () => {
-      // pivot: pnpm 10.16-10.19 (same-major) FAIL; 10.20+ (any-major) -> 1.2.0.
+    it('latest tag (too-new stable) degrades to the newest compliant stable (2.0.0 -> 1.2.0)', () => {
       expect(pickPnpmVersion('latest', pkgA, v11StrictPolicy(24))).toEqual({
         version: '1.2.0',
         unconstrained: '2.0.0',
       });
-    });
-
-    it('latest tag same-major (10.16-10.19) with no same-major mature -> violation (tag-latest)', () => {
-      expect(() => pickPnpmVersion('latest', pkgA, v10Policy(24))).toThrow(
-        MinReleaseAgeViolationError
-      );
     });
 
     it('tag pointing at an already-mature version returns it (tag-stableold)', () => {
@@ -209,7 +217,7 @@ describe('pnpm min-release-age behavior', () => {
       });
     });
 
-    it('prerelease tag degrades within its line (tag-prerelease canary.3 -> canary.1)', () => {
+    it('prerelease tag keeps a compliant same-line same-channel version (canary.3 -> canary.1)', () => {
       expect(pickPnpmVersion('canary', pkgA, v10Policy(24))).toEqual({
         version: '3.0.0-canary.1',
         unconstrained: '3.0.0-canary.3',
@@ -222,6 +230,25 @@ describe('pnpm min-release-age behavior', () => {
       ).toEqual({
         version: '3.0.0-canary.1',
         unconstrained: '3.0.0-canary.3',
+      });
+    });
+
+    it('too-new rc tag never crosses into a pr/beta channel -> latest stable', () => {
+      // next -> 23.0.0-rc.0 too new; 23.0.0-pr.5 / 23.0.0-beta.1 are other
+      // channels (excluded), the only same-channel candidate 22.7.0-rc.2 loses
+      // to the stable 22.7.0.
+      expect(pickPnpmVersion('next', pkgChannels, v11StrictPolicy(24))).toEqual(
+        {
+          version: '22.7.0',
+          unconstrained: '23.0.0-rc.0',
+        }
+      );
+    });
+
+    it('too-new rc tag keeps a compliant same-line rc (pre -> 23.1.0-rc.1)', () => {
+      expect(pickPnpmVersion('pre', pkgChannels, v11StrictPolicy(24))).toEqual({
+        version: '23.1.0-rc.1',
+        unconstrained: '23.1.0-rc.4',
       });
     });
   });
@@ -331,19 +358,16 @@ describe('pnpm min-release-age behavior', () => {
     // 11.0.0..11.1.2 cannot derive an immatureVersion from a tag name, so a
     // too-new non-latest tag falls back to NO_MATCHING (pivot: 11.0.4..11.1.0
     // tag-nonlatest -> ERR_PNPM_NO_MATCHING_VERSION).
-    it('v11.0.0..11.1.2 too-new non-latest tag -> NO_MATCHING fallback shape', () => {
-      const meta = metadataFromAges(
-        'pkg-hot',
-        { '1.2.0': 25, '2.0.0': 6 },
-        { latest: '1.2.0', hot: '2.0.0' }
-      );
+    it('v11.0.0..11.1.2 too-new tag with no compliant degrade -> NO_MATCHING fallback shape', () => {
       try {
-        pickPnpmVersion('hot', meta, v11SingleFormStrictPolicy(24));
+        pickPnpmVersion('hot', pkgAllTooNew, v11SingleFormStrictPolicy(24));
         throw new Error('expected throw');
       } catch (e) {
         expect(e).toBeInstanceOf(MinReleaseAgeViolationError);
         const detail = (e as MinReleaseAgeViolationError).pmShapedDetail;
-        expect(detail).toContain('No matching version found for pkg-hot@hot');
+        expect(detail).toContain(
+          'No matching version found for pkg-allnew@hot'
+        );
         expect(detail).not.toContain('does not meet the minimumReleaseAge');
       }
     });
@@ -403,131 +427,12 @@ describe('pnpm min-release-age behavior', () => {
       });
     });
 
-    it('non-latest tag too-new keeps original target immature (tag-nonlatest 11.0.0 -> 2.0.0)', () => {
-      expect(pickPnpmVersion('hot', pkgA, v11LoosePolicy(24))).toEqual({
+    it('too-new tag with no compliant degrade keeps original target immature (hot -> 2.0.0)', () => {
+      expect(pickPnpmVersion('hot', pkgAllTooNew, v11LoosePolicy(24))).toEqual({
         version: '2.0.0',
         unconstrained: '2.0.0',
         immature: true,
       });
-    });
-  });
-
-  describe('latest tag degrade: same-major vs any-major', () => {
-    it('v10 (<10.20) same-major: too-new new-major latest with no same-major mature -> violation', () => {
-      // latest -> 2.0.0 (too new); same-major candidates are only 2.x (all too
-      // new) -> no degrade -> hard fail.
-      expect(() =>
-        pickPnpmVersion('latest', pkgNewMajor, v10Policy(24))
-      ).toThrow(MinReleaseAgeViolationError);
-    });
-
-    it('any-major (>=10.20) degrades latest across majors (-> 1.2.0)', () => {
-      expect(
-        pickPnpmVersion('latest', pkgNewMajor, v11StrictPolicy(24))
-      ).toEqual({
-        version: '1.2.0',
-        unconstrained: '2.0.0',
-      });
-    });
-
-    it('non-latest tag never degrades across majors even on any-major rows', () => {
-      // hot -> 2.0.0 too new; non-latest stays same-major -> no 2.x mature ->
-      // strict violation.
-      const meta = metadataFromAges(
-        'pkg-hot',
-        { '1.2.0': 25, '2.0.0': 6 },
-        { latest: '1.2.0', hot: '2.0.0' }
-      );
-      expect(() => pickPnpmVersion('hot', meta, v11StrictPolicy(24))).toThrow(
-        MinReleaseAgeViolationError
-      );
-    });
-  });
-
-  // pnpm 10.16 matched the degrade same-major by string prefix with NO
-  // prerelease filter; 10.17 switched to a numeric-major comparison plus a
-  // prerelease-flag filter (npm-resolver -> registry/pkg-metadata-filter). A
-  // same-major mature prerelease therefore wins the degrade on 10.16 but is
-  // excluded on 10.17+.
-  describe('same-major degrade prerelease filter (10.16 vs 10.17+)', () => {
-    // latest -> 1.5.0 (stable, too new). Same major has a mature stable 1.2.0
-    // and a mature prerelease 1.9.0-beta.1.
-    const meta = metadataFromAges(
-      'pkg-prefix',
-      { '1.2.0': 100, '1.5.0': 6, '1.9.0-beta.1': 100 },
-      { latest: '1.5.0' }
-    );
-
-    it('10.16 includes a same-major prerelease and picks the highest (-> 1.9.0-beta.1)', () => {
-      expect(pickPnpmVersion('latest', meta, v10Policy(24))).toEqual({
-        version: '1.9.0-beta.1',
-        unconstrained: '1.5.0',
-      });
-    });
-
-    it('10.17 filters the prerelease out and degrades to the stable 1.2.0', () => {
-      expect(
-        pickPnpmVersion(
-          'latest',
-          meta,
-          v10Policy(24, { packageManagerVersion: '10.17.0' })
-        )
-      ).toEqual({
-        version: '1.2.0',
-        unconstrained: '1.5.0',
-      });
-    });
-  });
-
-  describe('deprecation tie-break (10.18+) prefers non-deprecated', () => {
-    it('any-major skips a deprecated higher candidate when a non-deprecated lower one is mature', () => {
-      const meta: RegistryMetadata & {
-        deprecations?: Record<string, string | true>;
-      } = {
-        ...metadataFromAges(
-          'pkg-dep',
-          { '1.1.0': 100, '1.2.0': 80, '2.0.0': 6 },
-          { latest: '2.0.0' }
-        ),
-        deprecations: { '1.2.0': 'do not use' },
-      };
-      expect(pickPnpmVersion('latest', meta, v11StrictPolicy(24))).toEqual({
-        version: '1.1.0',
-        unconstrained: '2.0.0',
-      });
-    });
-
-    // pnpm applies the tie-break to same-major degrades too (since 10.18), not
-    // only the any-major latest path.
-    const sameMajorMeta: RegistryMetadata & {
-      deprecations?: Record<string, string | true>;
-    } = {
-      ...metadataFromAges(
-        'pkg-dep-same',
-        { '1.1.0': 100, '1.2.0': 80, '1.5.0': 6 },
-        { latest: '1.5.0' }
-      ),
-      deprecations: { '1.2.0': 'do not use' },
-    };
-
-    it('10.18 same-major skips the deprecated higher candidate (-> 1.1.0)', () => {
-      expect(
-        pickPnpmVersion(
-          'latest',
-          sameMajorMeta,
-          v10Policy(24, { packageManagerVersion: '10.18.0' })
-        )
-      ).toEqual({ version: '1.1.0', unconstrained: '1.5.0' });
-    });
-
-    it('10.17 has no tie-break and keeps the deprecated higher candidate (-> 1.2.0)', () => {
-      expect(
-        pickPnpmVersion(
-          'latest',
-          sameMajorMeta,
-          v10Policy(24, { packageManagerVersion: '10.17.0' })
-        )
-      ).toEqual({ version: '1.2.0', unconstrained: '1.5.0' });
     });
   });
 

--- a/packages/nx/src/utils/min-release-age/behavior/pnpm.ts
+++ b/packages/nx/src/utils/min-release-age/behavior/pnpm.ts
@@ -858,7 +858,11 @@ function pickTag(
   if (degraded) {
     return { version: degraded, unconstrained };
   }
-  if (behavior.looseFallback) {
+  // The loose fallback requires a real version: a non-semver tag target must
+  // not be installed immature, or the consumer would write `pkg@<garbage>`
+  // into minimumReleaseAgeExclude and break every later install
+  // (ERR_PNPM_INVALID_VERSION_UNION).
+  if (behavior.looseFallback && valid(tagTarget)) {
     // No compliant candidate; loose keeps the original (immature) target.
     return { version: tagTarget, unconstrained, immature: true };
   }

--- a/packages/nx/src/utils/min-release-age/behavior/pnpm.ts
+++ b/packages/nx/src/utils/min-release-age/behavior/pnpm.ts
@@ -5,7 +5,6 @@ import {
   gte,
   maxSatisfying,
   minSatisfying,
-  prerelease,
   rcompare,
   satisfies,
   valid,
@@ -17,6 +16,7 @@ import type { RegistryMetadata } from '../packument';
 import {
   blockedVersionsFrom,
   classifySpec,
+  degradeTagToCompliant,
   newestInRange,
   splitPackageDescriptor,
   type PickOutcome,
@@ -30,7 +30,7 @@ import type {
 
 // First-match-by-version-range row describing how a pnpm version treats the
 // cooldown gate. Resolution semantics differ enough across the 10.16/10.19/
-// 10.20/11.0.0/11.0.4/11.1.0/11.1.3 boundaries that they are encoded as data.
+// 11.0.0/11.0.4/11.1.0/11.1.3 boundaries that they are encoded as data.
 interface PnpmBehaviorRow {
   // Inclusive lower bound; the first row whose bound is <= the version wins
   // when iterating newest-bound-first.
@@ -40,7 +40,6 @@ interface PnpmBehaviorRow {
   strictMode: 'always' | 'default-loose';
   // >=11.0.4: window explicitly set on any surface auto-enables strict.
   strictAutoOnWhenExplicit: boolean;
-  latestTagDegrade: 'same-major' | 'any-major';
   excludeGrammar: 'v1-exact-names' | 'v2-globs-unions';
   writesExcludes: boolean;
   // v11.1.0+ also reads uppercase PNPM_CONFIG_* env vars.
@@ -54,7 +53,6 @@ const PNPM_BEHAVIOR_ROWS: PnpmBehaviorRow[] = [
     major: 11,
     strictMode: 'default-loose',
     strictAutoOnWhenExplicit: true,
-    latestTagDegrade: 'any-major',
     excludeGrammar: 'v2-globs-unions',
     writesExcludes: true,
     uppercaseEnv: true,
@@ -64,7 +62,6 @@ const PNPM_BEHAVIOR_ROWS: PnpmBehaviorRow[] = [
     major: 11,
     strictMode: 'default-loose',
     strictAutoOnWhenExplicit: true,
-    latestTagDegrade: 'any-major',
     excludeGrammar: 'v2-globs-unions',
     writesExcludes: false,
     uppercaseEnv: true,
@@ -74,7 +71,6 @@ const PNPM_BEHAVIOR_ROWS: PnpmBehaviorRow[] = [
     major: 11,
     strictMode: 'default-loose',
     strictAutoOnWhenExplicit: true,
-    latestTagDegrade: 'any-major',
     excludeGrammar: 'v2-globs-unions',
     writesExcludes: false,
     uppercaseEnv: false,
@@ -84,17 +80,6 @@ const PNPM_BEHAVIOR_ROWS: PnpmBehaviorRow[] = [
     major: 11,
     strictMode: 'default-loose',
     strictAutoOnWhenExplicit: false,
-    latestTagDegrade: 'any-major',
-    excludeGrammar: 'v2-globs-unions',
-    writesExcludes: false,
-    uppercaseEnv: false,
-  },
-  {
-    minVersion: '10.20.0',
-    major: 10,
-    strictMode: 'always',
-    strictAutoOnWhenExplicit: false,
-    latestTagDegrade: 'any-major',
     excludeGrammar: 'v2-globs-unions',
     writesExcludes: false,
     uppercaseEnv: false,
@@ -104,7 +89,6 @@ const PNPM_BEHAVIOR_ROWS: PnpmBehaviorRow[] = [
     major: 10,
     strictMode: 'always',
     strictAutoOnWhenExplicit: false,
-    latestTagDegrade: 'same-major',
     excludeGrammar: 'v2-globs-unions',
     writesExcludes: false,
     uppercaseEnv: false,
@@ -114,7 +98,6 @@ const PNPM_BEHAVIOR_ROWS: PnpmBehaviorRow[] = [
     major: 10,
     strictMode: 'always',
     strictAutoOnWhenExplicit: false,
-    latestTagDegrade: 'same-major',
     excludeGrammar: 'v1-exact-names',
     writesExcludes: false,
     uppercaseEnv: false,
@@ -235,7 +218,6 @@ export async function readPnpmPolicy(
     strict,
     // Loose fallback only exists on v11 when strict is off.
     looseFallback: row.major === 11 && !strict,
-    latestTagDegrade: row.latestTagDegrade,
     writesExcludes: row.writesExcludes,
     missingTimeMap:
       row.major === 10 ? 'error' : ignoreMissingTime ? 'skip' : 'error',
@@ -793,15 +775,14 @@ function escapeRegExp(value: string): string {
 // --- pick -------------------------------------------------------------------
 
 /**
- * Mirrors pnpm's resolver under an active cooldown:
+ * pnpm resolution under an active cooldown. Exact pins and ranges mirror pnpm's
+ * resolver; dist-tag degrade uses the shared cross-PM rule:
  * - exact pin too new -> strict/v10 violation; v11 loose installs it (immature).
  * - range -> newest mature; none -> v10/strict violation, v11 loose lowest
  *   (least-immature) version unfiltered (immature).
- * - latest tag -> degrade to newest mature (same-major <10.20, any-major after),
- *   none -> violation (loose installs the original target immature when even
- *   the unfiltered tag exists).
- * - non-latest tags (all versions) -> same-major mature required, else
- *   violation/loose-immature.
+ * - dist-tag too new -> degrade to the newest compliant version in the tag's
+ *   own channel, falling back to stable (`degradeTagToCompliant`); none ->
+ *   violation (v11 loose installs the original target immature).
  */
 export function pickPnpmVersion(
   spec: string,
@@ -871,16 +852,14 @@ function pickTag(
     return { version: tagTarget, unconstrained };
   }
 
-  // latest degrades any-major (>=10.20) or same-major; non-latest is always
-  // same-major. Prerelease flag must match the original tag target.
-  const anyMajor =
-    spec === 'latest' && behavior.latestTagDegrade === 'any-major';
-  const degraded = degradeTag(metadata, policy, behavior, tagTarget, anyMajor);
+  const degraded = degradeTagToCompliant(tagTarget, metadata, (v) =>
+    mature(metadata, policy, v, behavior)
+  );
   if (degraded) {
     return { version: degraded, unconstrained };
   }
   if (behavior.looseFallback) {
-    // No mature tag candidate; loose keeps the original (immature) target.
+    // No compliant candidate; loose keeps the original (immature) target.
     return { version: tagTarget, unconstrained, immature: true };
   }
   throw violation(metadata, policy, spec, 'tag', [tagTarget]);
@@ -919,67 +898,6 @@ function pickRange(
   throw violation(metadata, policy, spec, 'range', blocked);
 }
 
-// Mirrors pnpm's filterPkgMetadataByPublishDate dist-tag repopulation: highest
-// mature candidate with (unless any-major) the same major as the original
-// target. pnpm 10.16 matched the major by string prefix with no prerelease
-// filter and no deprecation tie-break; 10.17 switched to numeric-major matching
-// and added the prerelease-flag filter; 10.18 added the deprecation tie-break.
-// All three apply to same-major degrades; any-major for `latest` arrived in
-// 10.20 (npm-resolver -> registry/pkg-metadata-filter).
-function degradeTag(
-  metadata: RegistryMetadata,
-  policy: MinReleaseAgePolicy,
-  behavior: PnpmBehavior,
-  target: string,
-  anyMajor: boolean
-): string | undefined {
-  const pmVersion = policy.packageManagerVersion;
-  const filtersNumericAndPrerelease = gte(pmVersion, '10.17.0');
-  const prefersNonDeprecated = gte(pmVersion, '10.18.0');
-  const targetMajor = majorOf(target);
-  const targetIsPre = prerelease(target) !== null;
-  const targetMajorPrefix = `${targetMajor}.`;
-  const candidates = matureVersions(metadata, policy, behavior).filter((v) => {
-    if (
-      filtersNumericAndPrerelease &&
-      (prerelease(v) !== null) !== targetIsPre
-    ) {
-      return false;
-    }
-    if (anyMajor) {
-      return true;
-    }
-    return filtersNumericAndPrerelease
-      ? majorOf(v) === targetMajor
-      : v.startsWith(targetMajorPrefix);
-  });
-  if (candidates.length === 0) {
-    return undefined;
-  }
-  return pickPreferringNonDeprecated(
-    candidates,
-    metadata,
-    prefersNonDeprecated
-  );
-}
-
-function pickPreferringNonDeprecated(
-  candidates: string[],
-  metadata: RegistryMetadata,
-  preferNonDeprecated: boolean
-): string {
-  const sorted = [...candidates].sort(rcompare);
-  // Deprecations are fetched lazily by the migrate layer when needed; the
-  // synchronous pick prefers highest and lets the deprecation map (if attached
-  // to metadata) break ties. 10.16-10.17 never had the tie-break.
-  const deprecated = preferNonDeprecated ? metadata.deprecations : undefined;
-  if (!deprecated) {
-    return sorted[0];
-  }
-  const nonDeprecated = sorted.filter((v) => !deprecated[v]);
-  return nonDeprecated[0] ?? sorted[0];
-}
-
 function matureVersions(
   metadata: RegistryMetadata,
   policy: MinReleaseAgePolicy,
@@ -1009,10 +927,6 @@ function mature(
     return false;
   }
   return Date.parse(time) <= policy.cutoffMs;
-}
-
-function majorOf(version: string): number {
-  return Number(version.split('.')[0].replace(/[^0-9].*$/, '')) || 0;
 }
 
 // --- errors -----------------------------------------------------------------

--- a/packages/nx/src/utils/min-release-age/behavior/pnpm.ts
+++ b/packages/nx/src/utils/min-release-age/behavior/pnpm.ts
@@ -780,9 +780,9 @@ function escapeRegExp(value: string): string {
  * - exact pin too new -> strict/v10 violation; v11 loose installs it (immature).
  * - range -> newest mature; none -> v10/strict violation, v11 loose lowest
  *   (least-immature) version unfiltered (immature).
- * - dist-tag too new -> degrade to the newest compliant version in the tag's
- *   own channel, falling back to stable (`degradeTagToCompliant`); none ->
- *   violation (v11 loose installs the original target immature).
+ * - dist-tag too new -> degrade via the shared channel-aware rule (see
+ *   `degradeTagToCompliant` for the ordering); none compliant -> violation
+ *   (v11 loose installs the original target immature).
  */
 export function pickPnpmVersion(
   spec: string,

--- a/packages/nx/src/utils/min-release-age/behavior/yarn.spec.ts
+++ b/packages/nx/src/utils/min-release-age/behavior/yarn.spec.ts
@@ -172,9 +172,9 @@ describe('yarn min-release-age behavior', () => {
       });
     });
 
-    it('too-new rc tag never crosses into a pr/beta channel -> latest stable', () => {
+    it('too-new rc tag falls to its same-line beta, never into pr', () => {
       expect(pickYarnVersion('next', pkgChannels, p)).toEqual({
-        version: '22.7.0',
+        version: '23.0.0-beta.1',
         unconstrained: '23.0.0-rc.0',
       });
     });

--- a/packages/nx/src/utils/min-release-age/behavior/yarn.spec.ts
+++ b/packages/nx/src/utils/min-release-age/behavior/yarn.spec.ts
@@ -75,6 +75,23 @@ const pkgEdge = metadataFromAges(
   { latest: '1.0.1' }
 );
 
+// Multiple prerelease channels sharing a release line, for the channel-aware
+// tag degrade.
+const pkgChannels = metadataFromAges(
+  'pkg-ch',
+  {
+    '22.7.0': 200,
+    '22.7.5': 6,
+    '22.7.0-rc.2': 220,
+    '23.0.0-beta.1': 100,
+    '23.0.0-pr.5': 90,
+    '23.0.0-rc.0': 2,
+    '23.1.0-rc.1': 80,
+    '23.1.0-rc.4': 4,
+  },
+  { latest: '22.7.5', next: '23.0.0-rc.0', pre: '23.1.0-rc.4' }
+);
+
 function policy(
   windowHours: number,
   opts: {
@@ -141,32 +158,32 @@ describe('yarn min-release-age behavior', () => {
       });
     });
 
-    it('non-latest tag too new -> violation references derived ^range (tag-nonlatest)', () => {
-      expect(() => pickYarnVersion('hot', pkgA, p)).toThrow(
-        MinReleaseAgeViolationError
-      );
-      try {
-        pickYarnVersion('hot', pkgA, p);
-      } catch (e) {
-        // yarn add re-resolves the tag through the gated semver resolver using a
-        // `^<target>` range (default modifier), so the message names ^2.0.0.
-        expect((e as MinReleaseAgeViolationError).pmShapedDetail).toBe(
-          'All versions satisfying "^2.0.0" are quarantined'
-        );
-      }
+    it('non-latest tag (hot) degrades to the newest approved stable (2.0.0 -> 1.2.0)', () => {
+      expect(pickYarnVersion('hot', pkgA, p)).toEqual({
+        version: '1.2.0',
+        unconstrained: '2.0.0',
+      });
     });
 
-    it('prerelease tag too new -> violation references derived ^range (tag-prerelease)', () => {
-      expect(() => pickYarnVersion('canary', pkgA, p)).toThrow(
-        MinReleaseAgeViolationError
-      );
-      try {
-        pickYarnVersion('canary', pkgA, p);
-      } catch (e) {
-        expect((e as MinReleaseAgeViolationError).pmShapedDetail).toBe(
-          'All versions satisfying "^3.0.0-canary.3" are quarantined'
-        );
-      }
+    it('prerelease tag keeps a compliant same-line same-channel version (canary.3 -> canary.1)', () => {
+      expect(pickYarnVersion('canary', pkgA, p)).toEqual({
+        version: '3.0.0-canary.1',
+        unconstrained: '3.0.0-canary.3',
+      });
+    });
+
+    it('too-new rc tag never crosses into a pr/beta channel -> latest stable', () => {
+      expect(pickYarnVersion('next', pkgChannels, p)).toEqual({
+        version: '22.7.0',
+        unconstrained: '23.0.0-rc.0',
+      });
+    });
+
+    it('too-new rc tag keeps a compliant same-line rc (pre -> 23.1.0-rc.1)', () => {
+      expect(pickYarnVersion('pre', pkgChannels, p)).toEqual({
+        version: '23.1.0-rc.1',
+        unconstrained: '23.1.0-rc.4',
+      });
     });
 
     it('prerelease range degrades within its line (range-prerelease)', () => {
@@ -215,8 +232,8 @@ describe('yarn min-release-age behavior', () => {
       }
     });
 
-    it('latest walk-down with no lower version -> dedicated tag message', () => {
-      // Every version too new -> latest cannot fall back.
+    it('tag with no compliant degrade -> YN0016 quarantined', () => {
+      // Every version too new -> the tag cannot degrade.
       const allFresh = metadataFromAges(
         'pkg-fresh',
         { '1.0.0': 2, '1.1.0': 1 },
@@ -227,46 +244,24 @@ describe('yarn min-release-age behavior', () => {
         throw new Error('expected throw');
       } catch (e) {
         expect((e as MinReleaseAgeViolationError).pmShapedDetail).toBe(
-          'The version for tag "latest" is quarantined, and no lower version is available'
+          'All versions satisfying "latest" are quarantined'
         );
       }
     });
   });
 
-  describe('walk-down prerelease tolerance flips at 4.11', () => {
-    // latest is a too-new stable; the only approved lower version is a
-    // prerelease, all lower stables are too new.
-    const meta = metadataFromAges(
-      'pkg-pre',
-      { '2.0.0': 1, '1.5.0': 2, '1.0.0-beta.1': 9600 },
-      { latest: '2.0.0' }
-    );
-
-    it('pre-4.11 tolerates a lower prerelease in the fallback', () => {
-      expect(
-        pickYarnVersion('latest', meta, policy(24, { pmVersion: '4.10.1' }))
-      ).toEqual({ version: '1.0.0-beta.1', unconstrained: '2.0.0' });
-    });
-
-    it('4.11+ excludes prereleases when latest is stable -> violation', () => {
-      expect(() =>
-        pickYarnVersion('latest', meta, policy(24, { pmVersion: '4.11.0' }))
-      ).toThrow(MinReleaseAgeViolationError);
-    });
-
-    it('4.11+ tolerates a lower prerelease when latest is itself a prerelease', () => {
-      const preLatest = metadataFromAges(
-        'pkg-prelatest',
-        { '3.0.0-canary.3': 2, '3.0.0-canary.1': 9600 },
-        { latest: '3.0.0-canary.3' }
+  describe('stable tag excludes prereleases', () => {
+    it('a too-new stable tag never degrades to a lower prerelease -> violation', () => {
+      // latest -> 2.0.0 (stable, too new). The only compliant lower version is a
+      // prerelease, so a stable target degrades to nothing and quarantines.
+      const meta = metadataFromAges(
+        'pkg-pre',
+        { '2.0.0': 1, '1.5.0': 2, '1.0.0-beta.1': 9600 },
+        { latest: '2.0.0' }
       );
-      expect(
-        pickYarnVersion(
-          'latest',
-          preLatest,
-          policy(24, { pmVersion: '4.11.0' })
-        )
-      ).toEqual({ version: '3.0.0-canary.1', unconstrained: '3.0.0-canary.3' });
+      expect(() => pickYarnVersion('latest', meta, policy(24))).toThrow(
+        MinReleaseAgeViolationError
+      );
     });
   });
 

--- a/packages/nx/src/utils/min-release-age/behavior/yarn.ts
+++ b/packages/nx/src/utils/min-release-age/behavior/yarn.ts
@@ -3,13 +3,14 @@ import { existsSync, readFileSync } from 'fs';
 import { homedir } from 'os';
 import { dirname, join } from 'path';
 import { minimatch } from 'minimatch';
-import { lt, prerelease, rcompare, rsort, satisfies, validRange } from 'semver';
+import { lt, rcompare, satisfies, validRange } from 'semver';
 import { MS_PER_MINUTE } from '../constants';
 import { MinReleaseAgeViolationError } from '../errors';
 import type { RegistryMetadata } from '../packument';
 import {
   blockedVersionsFrom,
   classifySpec,
+  degradeTagToCompliant,
   newestInRange,
   splitPackageDescriptor,
   type PickOutcome,
@@ -263,14 +264,12 @@ function splitDescriptor(entry: string): {
 }
 
 /**
- * Mirrors yarn berry's NpmSemverResolver/NpmTagResolver gate:
+ * yarn resolution under an active cooldown. Exact pins and ranges mirror yarn
+ * berry's NpmSemverResolver gate; dist-tag degrade uses the shared cross-PM rule:
  * - exact/range: newest approved match; none approved -> violation (YN0016
  *   wording >=4.13, YN0082 wording <4.13).
- * - `latest` tag too new: highest approved version `semver.lt(latest)`, with
- *   prereleases tolerated only when latest itself is a prerelease (>=4.11; pre
- *   4.11 prereleases may be picked); none -> violation.
- * - non-latest tags too new: yarn re-resolves through the gated semver resolver
- *   and fails -> violation.
+ * - dist-tag too new -> degrade to the newest compliant version in the tag's
+ *   own channel, falling back to stable (`degradeTagToCompliant`); none -> violation.
  */
 export function pickYarnVersion(
   spec: string,
@@ -306,51 +305,13 @@ function pickTag(
   if (isApproved(metadata, policy, target)) {
     return { version: target, unconstrained };
   }
-
-  // Only `latest` walks down in the tag resolver; every other tag is re-resolved
-  // by `yarn add` through the gated semver resolver using a range derived from
-  // the resolved target (default `^` modifier via defaultSemverRangePrefix), so
-  // the failure references e.g. `^2.0.0`, not the bare tag name.
-  if (spec !== 'latest') {
-    throw quarantined(metadata, policy, `^${target}`, [target]);
+  const degraded = degradeTagToCompliant(target, metadata, (v) =>
+    isApproved(metadata, policy, v)
+  );
+  if (degraded) {
+    return { version: degraded, unconstrained };
   }
-
-  const fallback = walkDownFromLatest(target, metadata, policy);
-  if (fallback) {
-    return { version: fallback, unconstrained };
-  }
-  throw new MinReleaseAgeViolationError({
-    packageManager: 'yarn',
-    packageName: metadata.name,
-    spec,
-    pmShapedDetail: `The version for tag "${spec}" is quarantined, and no lower version is available`,
-    blocked: blockedVersionsFrom(metadata, [target]),
-    remediation: [remediationHint(metadata, policy)],
-  });
-}
-
-function walkDownFromLatest(
-  latest: string,
-  metadata: RegistryMetadata,
-  policy: MinReleaseAgePolicy
-): string | null {
-  // 4.11+ tolerates prereleases in the fallback only when latest is itself a
-  // prerelease; earlier versions may pick any lower approved version.
-  const pre4_11 = lt(policy.packageManagerVersion, '4.11.0');
-  const tolerate = pre4_11 || prerelease(latest) !== null;
-  const sorted = rsort([...metadata.versions]);
-  for (const candidate of sorted) {
-    if (!lt(candidate, latest)) {
-      continue;
-    }
-    if (!tolerate && prerelease(candidate) !== null) {
-      continue;
-    }
-    if (isApproved(metadata, policy, candidate)) {
-      return candidate;
-    }
-  }
-  return null;
+  throw quarantined(metadata, policy, spec, [target]);
 }
 
 function pickRange(

--- a/packages/nx/src/utils/min-release-age/behavior/yarn.ts
+++ b/packages/nx/src/utils/min-release-age/behavior/yarn.ts
@@ -268,8 +268,8 @@ function splitDescriptor(entry: string): {
  * berry's NpmSemverResolver gate; dist-tag degrade uses the shared cross-PM rule:
  * - exact/range: newest approved match; none approved -> violation (YN0016
  *   wording >=4.13, YN0082 wording <4.13).
- * - dist-tag too new -> degrade to the newest compliant version in the tag's
- *   own channel, falling back to stable (`degradeTagToCompliant`); none -> violation.
+ * - dist-tag too new -> degrade via the shared channel-aware rule (see
+ *   `degradeTagToCompliant` for the ordering); none compliant -> violation.
  */
 export function pickYarnVersion(
   spec: string,

--- a/packages/nx/src/utils/min-release-age/npmrc.ts
+++ b/packages/nx/src/utils/min-release-age/npmrc.ts
@@ -23,6 +23,11 @@ export function readNpmrcEntries(path: string): NpmrcEntry[] | null {
   } catch {
     return null;
   }
+  return parseNpmrcContent(raw);
+}
+
+/** The parsing half of {@link readNpmrcEntries}, usable without a filesystem. */
+export function parseNpmrcContent(raw: string): NpmrcEntry[] {
   const entries: NpmrcEntry[] = [];
   for (const line of raw.split(/\r?\n/)) {
     const trimmed = line.trim();

--- a/packages/nx/src/utils/min-release-age/packument.spec.ts
+++ b/packages/nx/src/utils/min-release-age/packument.spec.ts
@@ -3,7 +3,7 @@ jest.mock('../package-manager', () => ({
 }));
 
 import { packageRegistryView } from '../package-manager';
-import { fetchDeprecations, fetchRegistryMetadata } from './packument';
+import { fetchRegistryMetadata } from './packument';
 
 const viewMock = packageRegistryView as jest.Mock;
 
@@ -71,60 +71,5 @@ describe('fetchRegistryMetadata', () => {
     );
     await fetchRegistryMetadata('pkg-a');
     expect(viewMock).toHaveBeenCalledWith('pkg-a', '', '--json');
-  });
-});
-
-describe('fetchDeprecations', () => {
-  afterEach(() => jest.clearAllMocks());
-
-  it('queries the per-version map via npm with a ranged version+deprecated projection', async () => {
-    viewMock.mockResolvedValue('[]');
-    await fetchDeprecations('pkg-a');
-    expect(viewMock).toHaveBeenCalledWith(
-      'pkg-a',
-      '>=0.0.0',
-      'version deprecated --json',
-      { forceNpm: true }
-    );
-  });
-
-  it('returns an empty map when the lookup throws (e.g. npm unavailable)', async () => {
-    viewMock.mockRejectedValue(new Error('npm not found'));
-    await expect(fetchDeprecations('pkg-a')).resolves.toEqual({});
-  });
-
-  it('maps an array of mixed version/deprecated entries', async () => {
-    viewMock.mockResolvedValue(
-      JSON.stringify([
-        { version: '1.0.0', deprecated: 'do not use' },
-        { version: '1.1.0' },
-        { version: '1.2.0', deprecated: 'gone' },
-      ])
-    );
-    await expect(fetchDeprecations('pkg-a')).resolves.toEqual({
-      '1.0.0': 'do not use',
-      '1.2.0': 'gone',
-    });
-  });
-
-  it('returns an empty map when no version is deprecated (array of strings)', async () => {
-    viewMock.mockResolvedValue(JSON.stringify(['1.0.0', '1.1.0']));
-    await expect(fetchDeprecations('pkg-a')).resolves.toEqual({});
-  });
-
-  it('maps a single-object response', async () => {
-    viewMock.mockResolvedValue(
-      JSON.stringify({ version: '1.0.0', deprecated: 'do not use' })
-    );
-    await expect(fetchDeprecations('pkg-a')).resolves.toEqual({
-      '1.0.0': 'do not use',
-    });
-  });
-
-  it('returns an empty object for a scalar/empty response', async () => {
-    viewMock.mockResolvedValue('');
-    await expect(fetchDeprecations('pkg-a')).resolves.toEqual({});
-    viewMock.mockResolvedValue(JSON.stringify('1.0.0'));
-    await expect(fetchDeprecations('pkg-a')).resolves.toEqual({});
   });
 });

--- a/packages/nx/src/utils/min-release-age/packument.ts
+++ b/packages/nx/src/utils/min-release-age/packument.ts
@@ -6,9 +6,6 @@ export interface RegistryMetadata {
   // null when the registry serves no time map (third-party registries)
   time: Record<string, string> | null;
   distTags: Record<string, string>;
-  // populated lazily (via fetchDeprecations) only for the pnpm >=10.20
-  // any-major latest-tag degrade, which prefers a non-deprecated candidate
-  deprecations?: Record<string, string | true>;
 }
 
 // `npm view <pkg> --json` collapses single-element fields to scalars.
@@ -50,72 +47,4 @@ export async function fetchRegistryMetadata(
     time,
     distTags: parsed['dist-tags'] ?? {},
   };
-}
-
-/**
- * Fetches the deprecation map for a package, keyed by version. Lazy: only the
- * pnpm >=10.20 latest-tag any-major degrade path needs it.
- *
- * `npm view <pkg> deprecated` with no version range only reports the latest
- * manifest's scalar value, so it is paired with `version` over an all-matching
- * range. The result shape varies: an array of `{ version, deprecated? }` (mixed
- * deprecations), an array of bare version strings (none deprecated), a single
- * object (one match), or a scalar - all normalized to the per-version map.
- *
- * Forced through npm: `pnpm view <pkg>@<range>` collapses to the single highest
- * match, so it cannot produce a per-version map. A failed lookup (e.g. npm
- * unavailable) degrades to an empty map - the same as no deprecations.
- */
-export async function fetchDeprecations(
-  pkg: string
-): Promise<Record<string, string | true>> {
-  let raw: string;
-  try {
-    raw = await packageRegistryView(
-      pkg,
-      '>=0.0.0',
-      'version deprecated --json',
-      {
-        forceNpm: true,
-      }
-    );
-  } catch {
-    return {};
-  }
-  if (!raw) {
-    return {};
-  }
-  let parsed: unknown;
-  try {
-    parsed = JSON.parse(raw);
-  } catch {
-    return {};
-  }
-
-  const deprecations: Record<string, string | true> = {};
-  const add = (entry: unknown): void => {
-    if (
-      !entry ||
-      typeof entry !== 'object' ||
-      !('version' in entry) ||
-      !('deprecated' in entry)
-    ) {
-      return;
-    }
-    const { version, deprecated } = entry as {
-      version: unknown;
-      deprecated: unknown;
-    };
-    if (typeof version === 'string' && deprecated) {
-      deprecations[version] =
-        typeof deprecated === 'string' ? deprecated : true;
-    }
-  };
-
-  if (Array.isArray(parsed)) {
-    parsed.forEach(add);
-  } else {
-    add(parsed);
-  }
-  return deprecations;
 }

--- a/packages/nx/src/utils/min-release-age/pick.spec.ts
+++ b/packages/nx/src/utils/min-release-age/pick.spec.ts
@@ -1,5 +1,5 @@
 import type { RegistryMetadata } from './packument';
-import { classifySpec, isVersionMature } from './pick';
+import { classifySpec, degradeTagToCompliant, isVersionMature } from './pick';
 import type { MinReleaseAgePolicy } from './policy';
 
 describe('classifySpec', () => {
@@ -58,5 +58,98 @@ describe('isVersionMature', () => {
         name === 'pkg-a' && version === '1.1.0',
     } as unknown as MinReleaseAgePolicy;
     expect(isVersionMature('pkg-a', '1.1.0', metadata, excluding)).toBe(true);
+  });
+});
+
+describe('degradeTagToCompliant', () => {
+  const metadata: RegistryMetadata = {
+    name: 'pkg-a',
+    versions: [
+      '22.7.0',
+      '22.7.5',
+      '22.7.0-rc.2',
+      '23.0.0-beta.1',
+      '23.0.0-pr.5',
+      '23.0.0-rc.0',
+      '23.1.0-rc.1',
+      '23.1.0-rc.4',
+    ],
+    time: null,
+    distTags: {},
+  };
+  // Everything except the two newest-line release candidates and 22.7.5.
+  const compliant = (version: string): boolean =>
+    !['22.7.5', '23.0.0-rc.0', '23.1.0-rc.4'].includes(version);
+
+  it('degrades a stable target to the newest compliant stable', () => {
+    expect(degradeTagToCompliant('22.7.5', metadata, compliant)).toBe('22.7.0');
+  });
+
+  it('excludes prereleases entirely for a stable target', () => {
+    // Only a lower prerelease is compliant -> nothing in the stable-only pool.
+    const onlyPre = (v: string) => v === '23.0.0-pr.5';
+    expect(degradeTagToCompliant('22.7.5', metadata, onlyPre)).toBeNull();
+  });
+
+  it('keeps a prerelease target in its own channel and never crosses to pr/beta', () => {
+    // next -> 23.0.0-rc.0: the pr/beta of the same line are out, the only
+    // same-channel candidate (22.7.0-rc.2) loses to the stable 22.7.0.
+    expect(degradeTagToCompliant('23.0.0-rc.0', metadata, compliant)).toBe(
+      '22.7.0'
+    );
+  });
+
+  it('prefers a compliant same-line same-channel prerelease over stable', () => {
+    expect(degradeTagToCompliant('23.1.0-rc.4', metadata, compliant)).toBe(
+      '23.1.0-rc.1'
+    );
+  });
+
+  it('returns null when nothing in the pool is compliant', () => {
+    expect(degradeTagToCompliant('22.7.5', metadata, () => false)).toBeNull();
+  });
+
+  it('orders the pool by publish date, newest released first', () => {
+    // 1.9.5 is a backport published after 1.10.0, so it wins despite the lower
+    // version - the pool is ordered by release date, not semver.
+    const dated: RegistryMetadata = {
+      name: 'pkg-b',
+      versions: ['1.9.0', '1.10.0', '1.9.5', '2.0.0'],
+      time: {
+        '1.9.0': '2026-01-01T00:00:00.000Z',
+        '1.10.0': '2026-06-01T00:00:00.000Z',
+        '1.9.5': '2026-06-10T00:00:00.000Z',
+        '2.0.0': '2026-06-11T00:00:00.000Z',
+      },
+      distTags: {},
+    };
+    // The too-new target is the only non-compliant version.
+    const compliantByDate = (v: string): boolean => v !== '2.0.0';
+    expect(degradeTagToCompliant('2.0.0', dated, compliantByDate)).toBe(
+      '1.9.5'
+    );
+  });
+
+  it('exhausts same-line prereleases before the common pool, even when a stable shipped between them', () => {
+    // 22.9.5 was published after 23.0.0-rc.1 but before the too-new
+    // 23.0.0-rc.2. rc.1 must still win: every same-line rc.* is tried before
+    // any stable enters consideration, so the newer-published stable can't jump
+    // ahead.
+    const meta: RegistryMetadata = {
+      name: 'pkg-c',
+      versions: ['22.9.0', '22.9.5', '23.0.0-rc.1', '23.0.0-rc.2'],
+      time: {
+        '22.9.0': '2026-05-20T00:00:00.000Z',
+        '23.0.0-rc.1': '2026-06-01T00:00:00.000Z',
+        '22.9.5': '2026-06-05T00:00:00.000Z',
+        '23.0.0-rc.2': '2026-06-10T00:00:00.000Z',
+      },
+      distTags: {},
+    };
+    // Only the too-new target rc.2 is non-compliant.
+    const compliant = (v: string): boolean => v !== '23.0.0-rc.2';
+    expect(degradeTagToCompliant('23.0.0-rc.2', meta, compliant)).toBe(
+      '23.0.0-rc.1'
+    );
   });
 });

--- a/packages/nx/src/utils/min-release-age/pick.spec.ts
+++ b/packages/nx/src/utils/min-release-age/pick.spec.ts
@@ -92,11 +92,71 @@ describe('degradeTagToCompliant', () => {
     expect(degradeTagToCompliant('22.7.5', metadata, onlyPre)).toBeNull();
   });
 
-  it('keeps a prerelease target in its own channel and never crosses to pr/beta', () => {
-    // next -> 23.0.0-rc.0: the pr/beta of the same line are out, the only
-    // same-channel candidate (22.7.0-rc.2) loses to the stable 22.7.0.
+  it('falls from a blocked rc to a same-line beta, never into pr', () => {
+    // 23.0.0-rc.0 has no older same-line rc sibling; beta sits on a lower
+    // ladder rung of the same line, so 23.0.0-beta.1 wins. The internal
+    // 23.0.0-pr.5 is off the ladder and stays walled off.
     expect(degradeTagToCompliant('23.0.0-rc.0', metadata, compliant)).toBe(
+      '23.0.0-beta.1'
+    );
+  });
+
+  it('drops to the common pool when no same-line ladder candidate is compliant', () => {
+    // With the same-line beta also blocked, the only same-channel candidate
+    // (the cross-line 22.7.0-rc.2) loses to the stable 22.7.0.
+    const withoutBeta = (v: string) => compliant(v) && v !== '23.0.0-beta.1';
+    expect(degradeTagToCompliant('23.0.0-rc.0', metadata, withoutBeta)).toBe(
       '22.7.0'
+    );
+  });
+
+  it('returns null when only an off-ladder channel is compliant', () => {
+    // pr has no place on the ladder, so it never enters the pool even as the
+    // sole compliant version below the target.
+    const onlyPr = (v: string) => v === '23.0.0-pr.5';
+    expect(degradeTagToCompliant('23.0.0-rc.0', metadata, onlyPr)).toBeNull();
+  });
+
+  it('never climbs the ladder: a beta target ignores a lower rc', () => {
+    // 22.0.0-rc.1 is below the target by semver but on a HIGHER rung; the
+    // ladder only permits descent, so nothing qualifies.
+    const meta: RegistryMetadata = {
+      name: 'pkg-climb',
+      versions: ['22.0.0-rc.1', '23.0.0-beta.0', '23.0.0-beta.1'],
+      time: null,
+      distTags: {},
+    };
+    const onlyRc = (v: string) => v === '22.0.0-rc.1';
+    expect(degradeTagToCompliant('23.0.0-beta.1', meta, onlyRc)).toBeNull();
+  });
+
+  it('treats next as off-ladder (rolling snapshot in some ecosystems)', () => {
+    const meta: RegistryMetadata = {
+      name: 'pkg-next',
+      versions: ['23.0.0-next.3', '23.0.0-rc.0'],
+      time: null,
+      distTags: {},
+    };
+    const onlyNext = (v: string) => v === '23.0.0-next.3';
+    expect(degradeTagToCompliant('23.0.0-rc.0', meta, onlyNext)).toBeNull();
+  });
+
+  it('prefers a same-line lower-rung beta over a newer-published cross-line stable', () => {
+    // The stable backport was published after the beta, so publish-date order
+    // alone would pick it; the same-line tier must outrank publish recency.
+    const meta: RegistryMetadata = {
+      name: 'pkg-tier',
+      versions: ['22.7.0', '23.0.0-beta.1', '23.0.0-rc.0'],
+      time: {
+        '23.0.0-beta.1': '2026-06-01T00:00:00.000Z',
+        '22.7.0': '2026-06-08T00:00:00.000Z',
+        '23.0.0-rc.0': '2026-06-10T00:00:00.000Z',
+      },
+      distTags: {},
+    };
+    const compliantByDate = (v: string) => v !== '23.0.0-rc.0';
+    expect(degradeTagToCompliant('23.0.0-rc.0', meta, compliantByDate)).toBe(
+      '23.0.0-beta.1'
     );
   });
 

--- a/packages/nx/src/utils/min-release-age/pick.spec.ts
+++ b/packages/nx/src/utils/min-release-age/pick.spec.ts
@@ -86,8 +86,9 @@ describe('degradeTagToCompliant', () => {
   });
 
   it('excludes prereleases entirely for a stable target', () => {
-    // Only a lower prerelease is compliant -> nothing in the stable-only pool.
-    const onlyPre = (v: string) => v === '23.0.0-pr.5';
+    // Only a prerelease BELOW the stable target is compliant: it survives the
+    // newer-than-target cut, so only the channel rule keeps it out of the pool.
+    const onlyPre = (v: string) => v === '22.7.0-rc.2';
     expect(degradeTagToCompliant('22.7.5', metadata, onlyPre)).toBeNull();
   });
 
@@ -107,6 +108,24 @@ describe('degradeTagToCompliant', () => {
 
   it('returns null when nothing in the pool is compliant', () => {
     expect(degradeTagToCompliant('22.7.5', metadata, () => false)).toBeNull();
+  });
+
+  it('returns null for a non-semver target instead of throwing', () => {
+    expect(
+      degradeTagToCompliant('not-a-version', metadata, () => true)
+    ).toBeNull();
+  });
+
+  it('skips non-semver junk in the versions list instead of throwing', () => {
+    const junk: RegistryMetadata = {
+      name: 'pkg-junk',
+      versions: ['created', '1.0.0', '1.1.0'],
+      time: null,
+      distTags: {},
+    };
+    expect(degradeTagToCompliant('1.1.0', junk, (v) => v === '1.0.0')).toBe(
+      '1.0.0'
+    );
   });
 
   it('orders the pool by publish date, newest released first', () => {

--- a/packages/nx/src/utils/min-release-age/pick.ts
+++ b/packages/nx/src/utils/min-release-age/pick.ts
@@ -1,4 +1,12 @@
-import { rcompare, satisfies, valid, validRange } from 'semver';
+import {
+  compare,
+  parse,
+  prerelease,
+  rcompare,
+  satisfies,
+  valid,
+  validRange,
+} from 'semver';
 import { pickBunVersion } from './behavior/bun';
 import { pickNpmVersion } from './behavior/npm';
 import { pickPnpmVersion } from './behavior/pnpm';
@@ -86,6 +94,91 @@ export function newestInRange(
       .filter((v) => satisfies(v, range, { includePrerelease: false }))
       .sort(rcompare)[0] ?? range
   );
+}
+
+/**
+ * The prerelease channel of a version: the first dotted identifier of its
+ * prerelease tag (e.g. `rc` for `23.0.0-rc.0`, `pr` for `23.0.0-pr.123`), or
+ * null for a stable release. Channels keep parallel prerelease lines apart so a
+ * cooldown degrade never crosses from `rc` into an internal `pr` build.
+ */
+function prereleaseChannel(version: string): string | null {
+  const pre = prerelease(version);
+  return pre && pre.length > 0 ? String(pre[0]) : null;
+}
+
+// The stable `major.minor.patch` of a version, ignoring any prerelease tag
+// (e.g. `23.0.0` for both `23.0.0-rc.0` and `23.0.0`).
+function releaseLine(version: string): string {
+  const parsed = parse(version);
+  return parsed ? `${parsed.major}.${parsed.minor}.${parsed.patch}` : version;
+}
+
+// Publish time in epoch ms; a version with no registry time sorts last.
+function publishedAtMs(metadata: RegistryMetadata, version: string): number {
+  const time = metadata.time?.[version];
+  const parsed = time ? Date.parse(time) : NaN;
+  return Number.isNaN(parsed) ? -Infinity : parsed;
+}
+
+/**
+ * Degrades a too-new dist-tag target to a cooldown-compliant version "of the
+ * same kind", shared by every package manager.
+ *
+ * The candidate pool is every version at or below the resolved target that is
+ * either stable or shares the target's prerelease channel. It is ordered so
+ * that same-channel prereleases of the target's exact release line come first,
+ * then everything else; within each group the most recently published version
+ * comes first (semver breaks ties and orders versions with no publish time).
+ * The first compliant version in that order wins.
+ *
+ * So a stable target degrades to the newest compliant stable, and a prerelease
+ * target keeps a compliant prerelease of the release it points at when one
+ * exists, otherwise drops to the newest compliant version below it - never
+ * crossing into a different prerelease channel (e.g. an internal `pr` build).
+ * Returns null when nothing in the pool is compliant; callers turn that into
+ * their package manager's violation.
+ *
+ * `isCompliant` is the caller's per-PM maturity test (package managers differ
+ * on missing publish times and excludes).
+ */
+export function degradeTagToCompliant(
+  target: string,
+  metadata: RegistryMetadata,
+  isCompliant: (version: string) => boolean
+): string | null {
+  const targetChannel = prereleaseChannel(target);
+  const targetLine = releaseLine(target);
+
+  const pool = metadata.versions.filter((version) => {
+    if (compare(version, target) > 0) {
+      return false; // newer than the target
+    }
+    const channel = prereleaseChannel(version);
+    // A prerelease in any other channel (and every prerelease when the target
+    // is stable) is out; stables and same-channel prereleases stay.
+    return channel === null || channel === targetChannel;
+  });
+
+  // Same-channel prereleases of the target's exact release line rank ahead of
+  // the rest; within each group, newest published first.
+  const sameLine = (version: string): boolean =>
+    prereleaseChannel(version) === targetChannel &&
+    releaseLine(version) === targetLine;
+  pool.sort((a, b) => {
+    const sameLineDelta = Number(sameLine(b)) - Number(sameLine(a));
+    if (sameLineDelta !== 0) {
+      return sameLineDelta;
+    }
+    const publishedA = publishedAtMs(metadata, a);
+    const publishedB = publishedAtMs(metadata, b);
+    if (publishedA !== publishedB) {
+      return publishedB - publishedA;
+    }
+    return compare(b, a);
+  });
+
+  return pool.find((version) => isCompliant(version)) ?? null;
 }
 
 /**

--- a/packages/nx/src/utils/min-release-age/pick.ts
+++ b/packages/nx/src/utils/min-release-age/pick.ts
@@ -147,12 +147,18 @@ export function degradeTagToCompliant(
   metadata: RegistryMetadata,
   isCompliant: (version: string) => boolean
 ): string | null {
+  // semver.compare throws on a non-semver string; a tag pointing at one has no
+  // channel or ordering to reason about, so report no candidate and let the
+  // caller raise its violation.
+  if (!valid(target)) {
+    return null;
+  }
   const targetChannel = prereleaseChannel(target);
   const targetLine = releaseLine(target);
 
   const pool = metadata.versions.filter((version) => {
-    if (compare(version, target) > 0) {
-      return false; // newer than the target
+    if (!valid(version) || compare(version, target) > 0) {
+      return false; // unparseable or newer than the target
     }
     const channel = prereleaseChannel(version);
     // A prerelease in any other channel (and every prerelease when the target

--- a/packages/nx/src/utils/min-release-age/pick.ts
+++ b/packages/nx/src/utils/min-release-age/pick.ts
@@ -121,23 +121,48 @@ function publishedAtMs(metadata: RegistryMetadata, version: string): number {
   return Number.isNaN(parsed) ? -Infinity : parsed;
 }
 
+// Prerelease channels with a conventional maturity order, least mature first.
+// A blocked target may descend to a lower rung of its own release line
+// (rc.0 -> beta.x); channels off the ladder (pr, canary, ...) have no implied
+// ordering and stay walled off. `next` is deliberately omitted: it is pre-rc
+// in some ecosystems (Angular) but a rolling dev snapshot in others - exactly
+// the kind of build a degrade must never land on.
+const ORDERED_CHANNELS = ['alpha', 'beta', 'rc'];
+
+// Whether a prerelease channel may serve as a degrade candidate for a target
+// on `targetChannel`: the target's own channel always; a strictly lower rung
+// when both sit on the ladder. A stable target (null channel) admits none.
+function channelAdmits(targetChannel: string | null, channel: string): boolean {
+  if (channel === targetChannel) {
+    return true;
+  }
+  if (targetChannel === null) {
+    return false;
+  }
+  const rank = ORDERED_CHANNELS.indexOf(channel);
+  const targetRank = ORDERED_CHANNELS.indexOf(targetChannel);
+  return rank !== -1 && targetRank !== -1 && rank < targetRank;
+}
+
 /**
  * Degrades a too-new dist-tag target to a cooldown-compliant version "of the
  * same kind", shared by every package manager.
  *
  * The candidate pool is every version at or below the resolved target that is
- * either stable or shares the target's prerelease channel. It is ordered so
- * that same-channel prereleases of the target's exact release line come first,
+ * stable, in the target's prerelease channel, or on a lower rung of the
+ * channel ladder (alpha < beta < rc). It is ordered so that prereleases of
+ * the target's exact release line come first - own channel, then lower rungs -
  * then everything else; within each group the most recently published version
  * comes first (semver breaks ties and orders versions with no publish time).
  * The first compliant version in that order wins.
  *
  * So a stable target degrades to the newest compliant stable, and a prerelease
  * target keeps a compliant prerelease of the release it points at when one
- * exists, otherwise drops to the newest compliant version below it - never
- * crossing into a different prerelease channel (e.g. an internal `pr` build).
- * Returns null when nothing in the pool is compliant; callers turn that into
- * their package manager's violation.
+ * exists (an rc may fall to a same-line beta), otherwise drops to the newest
+ * compliant version below it - never crossing into a channel with no place on
+ * the ladder (e.g. an internal `pr` build) and never climbing up it. Returns
+ * null when nothing in the pool is compliant; callers turn that into their
+ * package manager's violation.
  *
  * `isCompliant` is the caller's per-PM maturity test (package managers differ
  * on missing publish times and excludes).
@@ -161,20 +186,28 @@ export function degradeTagToCompliant(
       return false; // unparseable or newer than the target
     }
     const channel = prereleaseChannel(version);
-    // A prerelease in any other channel (and every prerelease when the target
-    // is stable) is out; stables and same-channel prereleases stay.
-    return channel === null || channel === targetChannel;
+    // Stables always stay; a prerelease stays only in the target's channel or
+    // on a lower ladder rung (every prerelease is out for a stable target).
+    return channel === null || channelAdmits(targetChannel, channel);
   });
 
-  // Same-channel prereleases of the target's exact release line rank ahead of
-  // the rest; within each group, newest published first.
-  const sameLine = (version: string): boolean =>
-    prereleaseChannel(version) === targetChannel &&
-    releaseLine(version) === targetLine;
+  // Prereleases of the target's exact release line rank ahead of the rest -
+  // own channel before lower rungs - then everything else; within each tier,
+  // newest published first.
+  const tier = (version: string): number => {
+    if (releaseLine(version) !== targetLine) {
+      return 2;
+    }
+    const channel = prereleaseChannel(version);
+    if (channel === targetChannel) {
+      return 0;
+    }
+    return channel === null ? 2 : 1;
+  };
   pool.sort((a, b) => {
-    const sameLineDelta = Number(sameLine(b)) - Number(sameLine(a));
-    if (sameLineDelta !== 0) {
-      return sameLineDelta;
+    const tierDelta = tier(a) - tier(b);
+    if (tierDelta !== 0) {
+      return tierDelta;
     }
     const publishedA = publishedAtMs(metadata, a);
     const publishedB = publishedAtMs(metadata, b);

--- a/packages/nx/src/utils/min-release-age/policy.ts
+++ b/packages/nx/src/utils/min-release-age/policy.ts
@@ -37,7 +37,6 @@ export type PmMinReleaseAgeBehavior =
       strict: boolean;
       // v11 loose fallback: no mature match -> lowest (least-immature) version
       looseFallback: boolean;
-      latestTagDegrade: 'same-major' | 'any-major';
       // >=11.1.3: pnpm itself writes excludes / prompts; nx mirrors that
       writesExcludes: boolean;
       missingTimeMap: 'error' | 'skip';

--- a/packages/nx/src/utils/min-release-age/resolve.spec.ts
+++ b/packages/nx/src/utils/min-release-age/resolve.spec.ts
@@ -1,32 +1,21 @@
 jest.mock('./packument', () => ({
   fetchRegistryMetadata: jest.fn(),
-  fetchDeprecations: jest.fn(),
 }));
-jest.mock('./pick', () => {
-  const { valid, validRange } = require('semver');
-  return {
-    pickMinReleaseAgeCompliantVersion: jest.fn(),
-    // real classification so the deprecation-prefetch gate evaluates correctly
-    classifySpec: (spec: string) =>
-      valid(spec) ? 'exact' : validRange(spec) ? 'range' : 'tag',
-  };
-});
+jest.mock('./pick', () => ({
+  pickMinReleaseAgeCompliantVersion: jest.fn(),
+}));
 
-import { fetchDeprecations, fetchRegistryMetadata } from './packument';
+import { fetchRegistryMetadata } from './packument';
 import { pickMinReleaseAgeCompliantVersion } from './pick';
 import type { MinReleaseAgePolicy } from './policy';
 import { resolveCompliantVersion } from './resolve';
 
 const mockFetchMetadata = fetchRegistryMetadata as jest.Mock;
-const mockFetchDeprecations = fetchDeprecations as jest.Mock;
 const mockPick = pickMinReleaseAgeCompliantVersion as jest.Mock;
 
-function pnpmPolicy(
-  latestTagDegrade: 'same-major' | 'any-major',
-  packageManagerVersion = '11.5.2'
-): MinReleaseAgePolicy {
+function pnpmPolicy(): MinReleaseAgePolicy {
   return {
-    packageManagerVersion,
+    packageManagerVersion: '11.5.2',
     cutoffMs: 0,
     windowMs: 0,
     sourceDescription: 'pnpm',
@@ -35,21 +24,9 @@ function pnpmPolicy(
       packageManager: 'pnpm',
       strict: false,
       looseFallback: true,
-      latestTagDegrade,
       writesExcludes: true,
       missingTimeMap: 'skip',
     },
-  };
-}
-
-function npmPolicy(): MinReleaseAgePolicy {
-  return {
-    packageManagerVersion: '11.16.0',
-    cutoffMs: 0,
-    windowMs: 0,
-    sourceDescription: 'npm',
-    isExcluded: () => false,
-    behavior: { packageManager: 'npm' },
   };
 }
 
@@ -66,50 +43,19 @@ describe('resolveCompliantVersion', () => {
   });
 
   it('fetches the packument and returns the pick', async () => {
-    const outcome = await resolveCompliantVersion(
-      'pkg-a',
-      '^1.0.0',
-      pnpmPolicy('any-major')
-    );
+    const metadata = {
+      name: 'pkg-a',
+      versions: ['1.2.0'],
+      time: {},
+      distTags: { latest: '1.2.0' },
+    };
+    mockFetchMetadata.mockResolvedValue(metadata);
+    const policy = pnpmPolicy();
+
+    const outcome = await resolveCompliantVersion('pkg-a', 'latest', policy);
+
     expect(mockFetchMetadata).toHaveBeenCalledWith('pkg-a');
+    expect(mockPick).toHaveBeenCalledWith('latest', metadata, policy);
     expect(outcome).toEqual({ version: '1.2.0', unconstrained: '1.2.0' });
-  });
-
-  it('prefetches and attaches deprecations for a pnpm >=10.18 tag spec', async () => {
-    mockFetchDeprecations.mockResolvedValue({ '2.0.0': 'old' });
-
-    await resolveCompliantVersion('pkg-a', 'latest', pnpmPolicy('any-major'));
-
-    expect(mockFetchDeprecations).toHaveBeenCalledWith('pkg-a');
-    // The map is attached to the metadata the pick consumes.
-    expect(mockPick.mock.calls[0][1].deprecations).toEqual({ '2.0.0': 'old' });
-  });
-
-  it('prefetches deprecations for a same-major tag degrade (pnpm applies the tie-break to same-major since 10.18)', async () => {
-    await resolveCompliantVersion(
-      'pkg-a',
-      'latest',
-      pnpmPolicy('same-major', '10.18.0')
-    );
-    expect(mockFetchDeprecations).toHaveBeenCalledWith('pkg-a');
-  });
-
-  it('does not prefetch deprecations for pnpm <10.18 (no tie-break yet)', async () => {
-    await resolveCompliantVersion(
-      'pkg-a',
-      'latest',
-      pnpmPolicy('same-major', '10.17.0')
-    );
-    expect(mockFetchDeprecations).not.toHaveBeenCalled();
-  });
-
-  it('does not prefetch deprecations for a non-tag spec', async () => {
-    await resolveCompliantVersion('pkg-a', '^1.0.0', pnpmPolicy('any-major'));
-    expect(mockFetchDeprecations).not.toHaveBeenCalled();
-  });
-
-  it('does not prefetch deprecations for a non-pnpm policy', async () => {
-    await resolveCompliantVersion('pkg-a', 'latest', npmPolicy());
-    expect(mockFetchDeprecations).not.toHaveBeenCalled();
   });
 });

--- a/packages/nx/src/utils/min-release-age/resolve.ts
+++ b/packages/nx/src/utils/min-release-age/resolve.ts
@@ -1,17 +1,10 @@
-import { gte } from 'semver';
-import { fetchDeprecations, fetchRegistryMetadata } from './packument';
-import {
-  classifySpec,
-  pickMinReleaseAgeCompliantVersion,
-  type PickOutcome,
-} from './pick';
+import { fetchRegistryMetadata } from './packument';
+import { pickMinReleaseAgeCompliantVersion, type PickOutcome } from './pick';
 import type { MinReleaseAgePolicy } from './policy';
 
 /**
  * Resolves an already catalog-dereferenced spec to a cooldown-compliant version
- * under the given policy: fetches the packument, lazily fetches the deprecation
- * map for pnpm >=10.18 dist-tag resolution (the versions where pnpm prefers a
- * non-deprecated candidate when degrading a tag), then picks. Throws
+ * under the given policy: fetches the packument, then picks. Throws
  * MinReleaseAgeViolationError when the PM at this version would refuse to resolve.
  */
 export async function resolveCompliantVersion(
@@ -20,12 +13,5 @@ export async function resolveCompliantVersion(
   policy: MinReleaseAgePolicy
 ): Promise<PickOutcome> {
   const metadata = await fetchRegistryMetadata(packageName);
-  if (
-    policy.behavior.packageManager === 'pnpm' &&
-    gte(policy.packageManagerVersion, '10.18.0') &&
-    classifySpec(spec) === 'tag'
-  ) {
-    metadata.deprecations = await fetchDeprecations(packageName);
-  }
   return pickMinReleaseAgeCompliantVersion(spec, metadata, policy);
 }


### PR DESCRIPTION
## Current Behavior

When a package manager's minimum-release-age (cooldown) policy is active, `nx migrate` resolves dist-tags through per-package-manager emulation, and degrading a too-new tag produced inconsistent, often nonsensical results. `nx migrate next` could resolve to an internal `pr.*` preview build or a years-old release candidate; the npm path diverged from what npm itself installs; and yarn errored outright. Each of npm, pnpm, yarn, and bun carried its own tag-degrade implementation.

## Expected Behavior

Dist-tag degrade is unified into a single rule across all four package managers. When the resolved tag target is within the cooldown window, the candidate pool is every version at or below it that is stable, in the target's own prerelease channel, or on a lower rung of an explicit channel ladder (`alpha < beta < rc`). That pool is ordered, and the first compliant version wins:

- Prereleases of the target's exact `major.minor.patch` come first — own channel, then lower ladder rungs.
- Then everything else, ordered by most recently published.

So `latest` (or any stable tag) lands on the newest compliant stable. A prerelease tag keeps a compliant prerelease of the release it points at: every same-line release candidate is exhausted first, and a blocked `rc.0` with no older rc sibling falls to a same-line `beta.x` rather than skipping back to the previous stable. A newer-published cross-line backport can't outrank the same-line beta, and the degrade never climbs the ladder upward. Channels with no place on the ladder (such as the internal `pr` builds, or `canary`) stay walled off entirely. `next` is deliberately left off the ladder: it is pre-rc in some ecosystems (Angular) but a rolling dev snapshot in others — exactly the class of build a degrade must never land on. The channel is derived generically from a version's prerelease identifier, so it works for any package's naming convention.

## Implementation Details

A shared `degradeTagToCompliant` helper replaces npm's `<=tagTarget` recursion, pnpm's same-major degrade (and its deprecation tie-break machinery), yarn's latest-only walk-down, and bun's channel walk. It builds the pool, orders it (same-line own-channel, then same-line lower-rung, then by publish date), and returns the first version that passes the caller's maturity test; each package manager supplies only that test and its own violation shape. The helper guards against non-semver dist-tag targets and registry version entries (`semver.compare` previously threw, and the migrate consumer swallows unknown errors into a real-install fallback).

The cleanup also drops the now-dead `latestTagDegrade` behavior axis and the redundant pnpm 10.20 behavior row, along with the tests that pinned the old version-specific behavior. The npm policy-reader specs are isolated from the host's real `~/.npmrc` and reuse the real `.npmrc` parser (`parseNpmrcContent`) instead of a hand-copied mirror, and npm's tag-path ENOVERSIONS branch is now covered.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/fix-nx-migrate-min-release-99acf946)
<!-- polygraph-session-end -->