### PR TITLE
fix(repo): correct config path in update-repos scripts and use next migrate CLI

### DIFF
--- a/tools/update-repos/src/setup-repos.ts
+++ b/tools/update-repos/src/setup-repos.ts
@@ -20,16 +20,8 @@ interface Config {
 
 const SCRIPT_DIR = __dirname;
 const REPOS_DIR = path.join(os.tmpdir(), 'updating-nx', 'repos');
-const CONFIG_FILE = path.join(
-  SCRIPT_DIR,
-  '..',
-  '..',
-  '..',
-  'tools',
-  'update-repos',
-  'config',
-  'repos.json'
-);
+// Compiled to tools/update-repos/dist/src, so the package root is two levels up.
+const CONFIG_FILE = path.join(SCRIPT_DIR, '..', '..', 'config', 'repos.json');
 
 function log(message: string) {
   const timestamp = new Date().toISOString().replace('T', ' ').substring(0, 19);

--- a/tools/update-repos/src/update-repo.ts
+++ b/tools/update-repos/src/update-repo.ts
@@ -29,16 +29,8 @@ type PackageManager = 'npm' | 'yarn' | 'pnpm' | 'bun';
 
 const SCRIPT_DIR = __dirname;
 const REPOS_DIR = path.join(os.tmpdir(), 'updating-nx', 'repos');
-const CONFIG_FILE = path.join(
-  SCRIPT_DIR,
-  '..',
-  '..',
-  '..',
-  'tools',
-  'update-repos',
-  'config',
-  'repos.json'
-);
+// Compiled to tools/update-repos/dist/src, so the package root is two levels up.
+const CONFIG_FILE = path.join(SCRIPT_DIR, '..', '..', 'config', 'repos.json');
 
 function log(message: string) {
   const timestamp = new Date().toISOString().replace('T', ' ').substring(0, 19);
@@ -55,7 +47,8 @@ function getErrorMessage(error: unknown): string {
 async function execWithOutput(
   command: string,
   cwd: string,
-  description?: string
+  description?: string,
+  env?: NodeJS.ProcessEnv
 ): Promise<void> {
   if (description) {
     log(`🔄 ${description}`);
@@ -69,6 +62,7 @@ async function execWithOutput(
     const child = spawn('bash', ['-c', finalCommand], {
       cwd,
       stdio: ['inherit', 'pipe', 'pipe'],
+      env: env ? { ...process.env, ...env } : undefined,
     });
 
     child.stdout.on('data', (data) => {
@@ -147,14 +141,14 @@ function getMigrateCommand(packageManager: PackageManager): string {
 function getRunMigrationsCommand(packageManager: PackageManager): string {
   switch (packageManager) {
     case 'pnpm':
-      return 'pnpm exec nx migrate --run-migrations --create-commits';
+      return 'pnpm exec nx migrate --run-migrations --create-commits --agentic';
     case 'yarn':
-      return 'yarn nx migrate --run-migrations --create-commits';
+      return 'yarn nx migrate --run-migrations --create-commits --agentic';
     case 'bun':
-      return 'bun nx migrate --run-migrations --create-commits';
+      return 'bun nx migrate --run-migrations --create-commits --agentic';
     case 'npm':
     default:
-      return 'npx nx migrate --run-migrations --create-commits';
+      return 'npx nx migrate --run-migrations --create-commits --agentic';
   }
 }
 
@@ -421,12 +415,13 @@ async function updateRepository(repoName: string): Promise<PullRequestInfo> {
     const fromVersion = await getNxVersion(repoDir, packageManager);
     log(`📦 Current Nx version: ${fromVersion}`);
 
-    // Run nx migrate
+    // Run nx migrate with the next version of the migrate CLI itself
     const migrateCmd = getMigrateCommand(packageManager);
     await execWithOutput(
       migrateCmd,
       repoDir,
-      'Running Nx migration to next version'
+      'Running Nx migration to next version',
+      { NX_MIGRATE_CLI_VERSION: 'next' }
     );
 
     // Install updated dependencies to get the new Nx version
@@ -462,7 +457,8 @@ async function updateRepository(repoName: string): Promise<PullRequestInfo> {
       await execWithOutput(
         runMigrationsCmd,
         repoDir,
-        'Applying Nx migrations (auto-commits enabled)'
+        'Applying Nx migrations (auto-commits enabled)',
+        { NX_MIGRATE_CLI_VERSION: 'next' }
       );
 
       // Clean up migrations.json after successful migration


### PR DESCRIPTION
## Current Behavior

- The `update-all-repos` script fails to find its config file. Since the build moved off the workspace-root `dist/` (#35915), `CONFIG_FILE` in `update-repo.ts` and `setup-repos.ts` resolves to `tools/tools/update-repos/config/repos.json`, which does not exist.
- `nx migrate` runs with the default (`latest`) migrate CLI version.
- Migrations run without the `--agentic` flag.

## Expected Behavior

- `CONFIG_FILE` resolves relative to the package root (two levels up from the compiled `dist/src` output), so the scripts find `tools/update-repos/config/repos.json` again.
- Both migrate invocations run with `NX_MIGRATE_CLI_VERSION=next`, so the next version of the migrate CLI drives the flow. The env var is passed through the spawn environment because commands are wrapped in `mise exec --`, which would treat a `VAR=x` prefix as a program name.
- `--agentic` is passed to `nx migrate --run-migrations`.

## Related Issue(s)

N/A — tooling fix found while running the update-all-repos script.

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/Fix-update-all-repos-tooling-script-199f7e9b)
<!-- polygraph-session-end -->