### PR TITLE
fix(core): do not fail local plugin lookup when workspace has no root tsconfig

### DIFF
--- a/packages/nx/src/project-graph/plugins/resolve-plugin.spec.ts
+++ b/packages/nx/src/project-graph/plugins/resolve-plugin.spec.ts
@@ -31,7 +31,7 @@ jest.mock('../../utils/workspace-root', () => ({
   workspaceRoot: '/workspace',
 }));
 
-// Return minimal tsconfig so readTsConfigPaths doesn't throw when it finds the file.
+// Return a minimal tsconfig for tests that exercise the tsconfig-present path.
 jest.mock('../../utils/fileutils', () => ({
   readJsonFile: jest.fn(() => ({ compilerOptions: { paths: {} } })),
 }));
@@ -105,7 +105,7 @@ function onlyFilesExist(...files: string[]) {
 
 describe('resolveSubpathFromExports (via getPluginPathAndName)', () => {
   beforeEach(() => {
-    // Default: tsconfig exists (so readTsConfigPaths doesn't throw), nothing else.
+    // Default: tsconfig exists (tests exercise the tsconfig-present path), nothing else.
     existsSyncMock.mockImplementation((p: unknown) => {
       const s = String(p);
       return s.endsWith('tsconfig.base.json') || s.endsWith('tsconfig.json');

--- a/packages/nx/src/project-graph/plugins/resolve-plugin.spec.ts
+++ b/packages/nx/src/project-graph/plugins/resolve-plugin.spec.ts
@@ -44,13 +44,17 @@ jest.mock('../../project-graph/utils/retrieve-workspace-files', () => ({
   retrieveProjectConfigurationsWithoutPluginInference: jest.fn(() =>
     Promise.resolve({})
   ),
+  clearProjectsWithoutPluginInferenceCache: jest.fn(),
 }));
 
 jest.mock('../../project-graph/utils/find-project-for-path', () => ({
   findProjectForPath: jest.fn(() => null),
 }));
 
-import { getPluginPathAndName } from './resolve-plugin';
+import {
+  getPluginPathAndName,
+  resetResolvePluginCache,
+} from './resolve-plugin';
 import type { ProjectConfiguration } from '../../config/workspace-json-project-json';
 
 // ---------------------------------------------------------------------------
@@ -187,6 +191,33 @@ describe('resolveSubpathFromExports (via getPluginPathAndName)', () => {
         root
       )
     ).toThrow(/Unable to resolve local plugin/);
+  });
+
+  it('resolves a local plugin when the workspace has no root tsconfig', () => {
+    // Workspaces wired purely through package-manager workspaces +
+    // package.json exports have no tsconfig.base.json/tsconfig.json at the
+    // root. Local plugin lookup must fall through to the package-metadata
+    // matching instead of throwing and failing every local plugin load.
+    resetResolvePluginCache();
+    const distFile = `${projectPath}/dist/plugin/index.js`;
+    // No tsconfig exists anywhere — only the built plugin file.
+    onlyFilesExist(distFile);
+
+    const projects = setupProject(
+      {
+        './plugin': { default: './dist/plugin/index.js' },
+      },
+      ['@scope/my-plugin/plugin']
+    );
+
+    const { pluginPath } = getPluginPathAndName(
+      '@scope/my-plugin/plugin',
+      [`${root}/node_modules`],
+      projects,
+      root
+    );
+
+    expect(pluginPath).toBe(distFile);
   });
 
   it('throws an informative error when the subpath has no exports entry', () => {

--- a/packages/nx/src/project-graph/plugins/resolve-plugin.ts
+++ b/packages/nx/src/project-graph/plugins/resolve-plugin.ts
@@ -377,7 +377,13 @@ function readTsConfigPaths(root: string = workspaceRoot) {
       .map((x) => path.join(root, x))
       .filter((x) => existsSync(x))[0];
     if (!tsconfigPath) {
-      throw new Error('unable to find tsconfig.base.json or tsconfig.json');
+      // Workspaces that wire up packages purely through package-manager
+      // workspaces + package.json exports have no root tsconfig — they simply
+      // have no tsconfig path mappings. Local plugin lookup must fall through
+      // to the package-metadata matching below instead of failing the whole
+      // plugin load.
+      tsconfigPaths = {};
+      return tsconfigPaths;
     }
     const { compilerOptions } = readJsonFile(tsconfigPath);
     tsconfigPaths = compilerOptions?.paths;

--- a/packages/nx/src/project-graph/plugins/resolve-plugin.ts
+++ b/packages/nx/src/project-graph/plugins/resolve-plugin.ts
@@ -380,8 +380,8 @@ function readTsConfigPaths(root: string = workspaceRoot) {
       // Workspaces that wire up packages purely through package-manager
       // workspaces + package.json exports have no root tsconfig — they simply
       // have no tsconfig path mappings. Local plugin lookup must fall through
-      // to the package-metadata matching below instead of failing the whole
-      // plugin load.
+      // to the package-metadata matching in `findNxProjectForImportPath`
+      // instead of failing the whole plugin load.
       tsconfigPaths = {};
       return tsconfigPaths;
     }


### PR DESCRIPTION
## Current Behavior

In a workspace that has **no root `tsconfig.base.json` / `tsconfig.json`** — packages wired purely through package-manager workspaces and `package.json` `exports` — every workspace-local plugin listed in `nx.json` fails to load:

```
 NX   Failed to load 6 Nx plugin(s):

  - @scope/my-plugin: unable to find tsconfig.base.json or tsconfig.json
  ...
```

**This affects the latest stable release, not just the 23 RCs.** The source-first local plugin resolution was backported to the 22.x line in **`22.7.3`**. Verified against the published dists of every version in between:

| nx version | symlinked local plugin, no root tsconfig |
|---|---|
| 22.7.1 | ✅ works |
| 22.7.2 | ✅ works |
| 22.7.3 | ❌ broken (backport of #35631 / #35751 lands) |
| 22.7.4 | ❌ broken |
| 22.7.5 (`latest`) | ❌ broken |
| 23.0.0-rc.0 (`next`) | ❌ broken |
| 22.7.5 + this fix | ✅ works |

Since the source-first local plugin resolution (#35631, #35751), `resolveNxPlugin` runs `lookupLocalPlugin` for any plugin whose `require.resolve` lands inside the workspace (true for every symlinked workspace package). `findNxProjectForImportPath` then calls `readTsConfigPaths`, which **throws** when no root tsconfig exists — aborting the whole plugin load before the function ever reaches its tsconfig-independent fallbacks (package-metadata matching, then Node resolution of the built artifact).

### Minimal reproduction (5 files, released `nx@22.7.5`)

```jsonc
// package.json
{ "name": "repro", "private": true, "devDependencies": { "nx": "22.7.5" } }
```

```yaml
# pnpm-workspace.yaml
packages:
  - 'packages/*'
```

```jsonc
// nx.json
{ "plugins": ["@repro/my-plugin"] }
```

```jsonc
// packages/my-plugin/package.json
{ "name": "@repro/my-plugin", "exports": { ".": { "default": "./dist/index.js" } } }
```

```js
// packages/my-plugin/dist/index.js
module.exports.createNodesV2 = ['**/never-matches.xyz', async () => []];
```

`pnpm install && pnpm exec nx show projects` →

```
 NX   Failed to load 1 Nx plugin(s):

  - @repro/my-plugin: unable to find tsconfig.base.json or tsconfig.json
```

With this PR's change applied to `dist/src/project-graph/plugins/resolve-plugin.js` in the same install: exit 0, projects list as expected.

## Expected Behavior

A missing root tsconfig just means the workspace has no tsconfig path mappings. `readTsConfigPaths` returns an empty mapping, `findNxProjectForImportPath` falls through to `getWorkspacePackagesMetadata` matching, and plugin resolution proceeds exactly as before the change (source via `exports` conditions when present, built dist otherwise).

This matches the function's own tolerance for a tsconfig *without* `compilerOptions.paths` (`return tsconfigPaths ?? {}`).

Given the 22.x backport, a backport of this fix to the 22.x line would also be appreciated.

## Related Issue(s)

Fixes #35970

Standalone repro (5 files, released `nx@22.7.5`): https://github.com/agcty/nx-repro-local-plugin-no-root-tsconfig

Regression introduced with the source-first local plugin resolution (#35631 / #35751), present in `23.0.0-rc.0` and backported into the stable line in `22.7.3` (22.7.2 and below unaffected). Originally encountered upgrading a bun-workspaces monorepo (six local inference plugins, per-package tsconfigs, no root tsconfig) from 22.7.1 to 23.0.0-rc.0 — all `nx` commands fail at plugin load. Additionally verified end-to-end: in the affected workspace, with this change applied, all 57 projects and all six local plugins load and tasks run; the new unit test fails with exactly the pre-fix error when the source change is reverted.
