### PR TITLE
fix(gradle): make project graph configuration hash deterministic

### DIFF
--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -124,7 +124,8 @@ private fun processTaskImpl(
     put("taskName", "${projectBuildPath}:${task.name}")
     val providerDependencies = findProviderBasedDependencies(task)
     if (providerDependencies.isNotEmpty()) {
-      put("includeDependsOnTasks", providerDependencies.toList())
+      // sorted(): set iteration order is JVM-run-dependent; keep options hash-stable.
+      put("includeDependsOnTasks", providerDependencies.sorted())
     }
     if (continuous) {
       put("continuous", true)

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
@@ -679,6 +679,34 @@ class ProcessTaskUtilsTest {
       assertTrue { result.contains(":compileJava") }
       assertTrue { result.contains(":checkKotlinGradlePluginConfigurationErrors") }
     }
+
+    @Test
+    fun `processTask emits includeDependsOnTasks in sorted order`() {
+      val kotlinProject = ProjectBuilder.builder().withName("kotlinProject").build()
+      kotlinProject.plugins.apply("org.jetbrains.kotlin.jvm")
+
+      val compileTestKotlin = kotlinProject.tasks.getByName("compileTestKotlin")
+      val result =
+          processTask(
+              compileTestKotlin,
+              projectBuildPath = ":kotlinProject",
+              projectRoot = kotlinProject.projectDir.path,
+              workspaceRoot = kotlinProject.rootDir.path,
+              externalNodes = mutableMapOf(),
+              dependencies = mutableSetOf(),
+              targetNameOverrides = emptyMap(),
+              gitIgnoreClassifier = GitIgnoreClassifier(kotlinProject.rootDir),
+              project = kotlinProject)
+
+      @Suppress("UNCHECKED_CAST") val options = result["options"] as Map<String, Any?>
+      @Suppress("UNCHECKED_CAST")
+      val includeDependsOnTasks = options["includeDependsOnTasks"] as List<String>
+
+      assertEquals(
+          includeDependsOnTasks.sorted(),
+          includeDependsOnTasks,
+          "includeDependsOnTasks must be sorted so options (and the ProjectConfiguration hash) stay stable across JVM runs")
+    }
   }
 
   @Nested


### PR DESCRIPTION
## Current Behavior

The `@nx/gradle` project-graph plugin produces a non-deterministic project configuration. For each target it emits `options.includeDependsOnTasks` in the iteration order of a set that is populated by walking Gradle's internal dependency containers (`findProviderBasedDependencies` → lifecycle/input-property providers). That iteration order follows JVM identity hashcodes, so it changes on every fresh JVM.

Nx hashes a target's `options` verbatim (JSON string, unsorted) into the project's `ProjectConfiguration` hash component. As a result, the `ProjectConfiguration` hash drifts between otherwise-identical runs, and tasks miss the cache on rerun even though nothing changed.

Reproduced by running the report task in 5 fresh JVMs: the `gradle-project-graph` project produced 5 distinct hashed configurations, differing only in `options.includeDependsOnTasks` ordering.

## Expected Behavior

The project configuration is deterministic: identical inputs produce the same `ProjectConfiguration` hash across runs, so task caching works on reruns. Sorting `includeDependsOnTasks` collapses all 5 runs to a single stable value.

A regression test (`processTask emits includeDependsOnTasks in sorted order`) guards against reintroducing the unsorted ordering.

## Related Issue(s)

Caught via Nx Cloud task comparison (project configuration hash drift on rerun); no separate GitHub issue.
