### PR TITLE
chore(gradle): bump gradle project graph plugin version to 0.1.22

### DIFF
--- a/packages/gradle/migrations.json
+++ b/packages/gradle/migrations.json
@@ -159,6 +159,13 @@
       "description": "Rename imports of `createNodesV2` from `@nx/gradle` and `@nx/gradle/plugin-v1` to the canonical `createNodes` export.",
       "implementation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
       "documentation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"
+    },
+    "change-plugin-version-0-1-22": {
+      "version": "23.0.0-rc.2",
+      "cli": "nx",
+      "description": "Change dev.nx.gradle.project-graph to version 0.1.22 in build file",
+      "factory": "./dist/src/migrations/23-0-0/change-plugin-version-0-1-22",
+      "documentation": "./dist/src/migrations/23-0-0/change-plugin-version-0-1-22.md"
     }
   },
   "packageJsonUpdates": {}

--- a/packages/gradle/project-graph/build.gradle.kts
+++ b/packages/gradle/project-graph/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 
 group = "dev.nx.gradle"
 
-version = "0.1.21"
+version = "0.1.22"
 
 repositories { mavenCentral() }
 

--- a/packages/gradle/project-graph/project.json
+++ b/packages/gradle/project-graph/project.json
@@ -5,6 +5,12 @@
     "gradle:publishToMavenLocal": {
       "cache": false
     },
+    "gradle:publishPluginMavenPublicationToMavenLocal": {
+      "cache": false
+    },
+    "gradle:publishNxProjectGraphPluginPluginMarkerMavenPublicationToMavenLocal": {
+      "cache": false
+    },
     "publish-staging": {
       "command": "./gradlew :gradle-project-graph:publish",
       "cache": true,

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -579,6 +579,8 @@ fun isContinuous(task: Task): Boolean {
 private val nonCacheableTasks = setOf("bootRun", "run")
 
 fun isCacheable(task: Task): Boolean {
+  // *ToMavenLocal tasks write to ~/.m2 (outside the workspace) — a cache hit skips the real publish
+  if (task.name.endsWith("ToMavenLocal")) return false
   return !nonCacheableTasks.contains(task.name)
 }
 

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
@@ -118,6 +118,15 @@ class ProcessTaskUtilsTest {
     assertNotNull(result["options"])
   }
 
+  @Test
+  fun `publishToMavenLocal tasks are not cacheable`() {
+    val project = ProjectBuilder.builder().build()
+    assertFalse(
+        isCacheable(project.tasks.register("publishPluginMavenPublicationToMavenLocal").get()))
+    assertFalse(isCacheable(project.tasks.register("publishToMavenLocal").get()))
+    assertTrue(isCacheable(project.tasks.register("compileJava").get()))
+  }
+
   @Nested
   inner class GetInputsForTaskTests {
     lateinit var project: Project

--- a/packages/gradle/src/migrations/23-0-0/change-plugin-version-0-1-22.md
+++ b/packages/gradle/src/migrations/23-0-0/change-plugin-version-0-1-22.md
@@ -1,0 +1,21 @@
+#### Change dev.nx.gradle.project-graph to version 0.1.22
+
+Change dev.nx.gradle.project-graph to version 0.1.22 in build file
+
+#### Sample Code Changes
+
+##### Before
+
+```text title="build.gradle"
+plugins {
+id "dev.nx.gradle.project-graph" version "0.1.21"
+}
+```
+
+##### After
+
+```text title="build.gradle"
+plugins {
+id "dev.nx.gradle.project-graph" version "0.1.22"
+}
+```

--- a/packages/gradle/src/migrations/23-0-0/change-plugin-version-0-1-22.ts
+++ b/packages/gradle/src/migrations/23-0-0/change-plugin-version-0-1-22.ts
@@ -1,0 +1,24 @@
+import { Tree, readNxJson } from '@nx/devkit';
+import { hasGradlePlugin } from '../../utils/has-gradle-plugin';
+import { addNxProjectGraphPlugin } from '../../generators/init/gradle-project-graph-plugin-utils';
+import { updateNxPluginVersionInCatalogsAst } from '../../utils/version-catalog-ast-utils';
+
+/* Change the plugin version to 0.1.22
+ */
+export default async function update(tree: Tree) {
+  const nxJson = readNxJson(tree);
+  if (!nxJson) {
+    return;
+  }
+  if (!hasGradlePlugin(tree)) {
+    return;
+  }
+
+  const gradlePluginVersionToUpdate = '0.1.22';
+
+  // Update version in version catalogs using AST-based approach to preserve formatting
+  await updateNxPluginVersionInCatalogsAst(tree, gradlePluginVersionToUpdate);
+
+  // Then update in build.gradle(.kts) files
+  await addNxProjectGraphPlugin(tree, gradlePluginVersionToUpdate);
+}

--- a/packages/gradle/src/utils/versions.ts
+++ b/packages/gradle/src/utils/versions.ts
@@ -2,4 +2,4 @@ import { join } from 'path';
 export const nxVersion = require(join('@nx/gradle', 'package.json')).version;
 
 export const gradleProjectGraphPluginName = 'dev.nx.gradle.project-graph';
-export const gradleProjectGraphVersion = '0.1.21';
+export const gradleProjectGraphVersion = '0.1.22';


### PR DESCRIPTION
## Current Behavior

Workspaces reference the `dev.nx.gradle.project-graph` Gradle plugin at version `0.1.21`.

## Expected Behavior

Bump the plugin to `0.1.22`. This release carries the deterministic project-configuration-hash fix from #35972 (sorting `options.includeDependsOnTasks` so the `ProjectConfiguration` hash no longer drifts between JVM runs).

The bump updates the version constant, the plugin's `build.gradle.kts`, and adds a migration (`change-plugin-version-0-1-22`, gated at `23.0.0-rc.2`) that updates existing workspaces' version catalogs and `build.gradle(.kts)` files on `nx migrate`.

> Note: the published `0.1.22` plugin artifact must include #35972 before this is released.

## Related Issue(s)

Follow-up to #35972 (the source fix).
