### PR TITLE
fix(core): override shell-quote to ^1.8.4 to patch GHSA-w7jw-789q-3m8p

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -363,6 +363,7 @@ overrides:
   underscore: ^1.13.8
   brace-expansion: 5.0.6
   minimatch: ^10.2.5
+  shell-quote: ^1.8.4
 
 patchedDependencies:
   '@astrojs/starlight': 228878a1bd48ba76f2630925a90b16047a4b87b4559f750d4372442909652235
@@ -23223,8 +23224,8 @@ packages:
   shell-exec@1.0.2:
     resolution: {integrity: sha512-jyVd+kU2X+mWKMmGhx4fpWbPsjvD53k9ivqetutVW/BQ+WIZoDoP4d8vUMGezV6saZsiNoW2f9GIhg9Dondohg==}
 
-  shell-quote@1.8.3:
-    resolution: {integrity: sha512-ObmnIF4hXNg1BqhnHmgbDETF8dLPCggZWBjkQfhZpbszZnYur5DUljTcCHii5LC3J5E0yeO/1LIMyH+UvHQgyw==}
+  shell-quote@1.8.4:
+    resolution: {integrity: sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==}
     engines: {node: '>= 0.4'}
 
   shiki@0.14.7:
@@ -40957,7 +40958,7 @@ snapshots:
       sanitize-filename: 1.6.3
       semver: 7.7.4
       serialize-error: 8.1.0
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       signal-exit: 3.0.7
       stream-json: 1.9.1
       strip-ansi: 6.0.1
@@ -45216,7 +45217,7 @@ snapshots:
   launch-editor@2.13.1:
     dependencies:
       picocolors: 1.1.1
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
 
   layout-base@1.0.2: {}
 
@@ -49978,7 +49979,7 @@ snapshots:
 
   react-devtools-core@6.1.5:
     dependencies:
-      shell-quote: 1.8.3
+      shell-quote: 1.8.4
       ws: 7.5.10
     transitivePeerDependencies:
       - bufferutil
@@ -51416,7 +51417,7 @@ snapshots:
 
   shell-exec@1.0.2: {}
 
-  shell-quote@1.8.3: {}
+  shell-quote@1.8.4: {}
 
   shiki@0.14.7:
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -24,6 +24,7 @@ overrides:
   underscore: '^1.13.8'
   brace-expansion: '5.0.6'
   minimatch: '^10.2.5'
+  shell-quote: '^1.8.4'
 onlyBuiltDependencies:
   - '@nestjs/core'
   - 'nx'


### PR DESCRIPTION
## Current Behavior

The daily **NPM Audit** workflow (`.github/workflows/npm-audit.yml`, which runs `pnpm dlx audit-ci --critical`) is failing on a critical advisory:

- **[GHSA-w7jw-789q-3m8p](https://github.com/advisories/GHSA-w7jw-789q-3m8p)** — `shell-quote`'s `quote()` does not escape newlines in object `.op` values.
- Vulnerable range: `>= 1.1.0, <= 1.8.3`; patched in `1.8.4`.
- The lockfile resolved `shell-quote@1.8.3`, pulled in transitively (primarily via `webpack-dev-server > launch-editor > shell-quote`, also `react-devtools-core`).

Failing run: https://github.com/nrwl/nx/actions/runs/27386736287

## Expected Behavior

`shell-quote` is pinned to the patched `^1.8.4` via a pnpm override, so all consumers resolve the safe version and the audit passes with `critical: 0`.

Verified locally with the exact CI command:

```
pnpm dlx audit-ci --critical --report-type summary
→ "critical": 0  →  Passed pnpm security audit.
```

`shell-quote@1.8.4` (published 2026-05-22) clears the repo's `minimumReleaseAge` gate.

## Related Issue(s)

Fixes the failing scheduled NPM Audit workflow.
