### PR TITLE
fix(gradle): exclude incremental-compilation .bin files from task inputs

### DIFF
--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -285,10 +285,12 @@ private fun getInputsForTaskImpl(
     // output directories exist but are empty, so file-based extension discovery misses them)
     dependentTaskOutputExtensions.addAll(inferExtensionsFromInputProperties(task, tasksToProcess))
 
-    // Add consolidated dependentTasksOutputFiles entries using glob patterns by extension
-    dependentTaskOutputExtensions.forEach { extension ->
-      inputs.add(mapOf("dependentTasksOutputFiles" to "**/*.$extension", "transitive" to true))
-    }
+    // Consolidate dependent-task outputs into per-extension globs (skip non-deterministic IC state)
+    dependentTaskOutputExtensions
+        .filterNot { nonInputDependentOutputExtensions.contains(it) }
+        .forEach { extension ->
+          inputs.add(mapOf("dependentTasksOutputFiles" to "**/*.$extension", "transitive" to true))
+        }
 
     if (externalDependencies.isNotEmpty()) {
       inputs.add(mapOf("externalDependencies" to externalDependencies))
@@ -580,6 +582,9 @@ private val nonCacheableTasks = setOf("bootRun", "run")
 fun isCacheable(task: Task): Boolean {
   return !nonCacheableTasks.contains(task.name)
 }
+
+// Compiler incremental-compilation state (*.bin) — non-deterministic and not consumed downstream.
+private val nonInputDependentOutputExtensions = setOf("bin")
 
 fun findProviderBasedDependencies(task: Task): Set<String> {
   val taskInternal = task as? TaskInternal ?: return emptySet()

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
@@ -212,6 +212,33 @@ class ProcessTaskUtilsTest {
     }
 
     @Test
+    fun `test getInputsForTask ignores bin incremental-compilation outputs`() {
+      val dependentTask = project.tasks.register("dependentCompile").get()
+
+      val classFile = java.io.File("$workspaceRoot/build/classes/kotlin/main/Main.class")
+      val incrementalBin =
+          java.io.File("$workspaceRoot/build/tmp/compileJava/previous-compilation-data.bin")
+      dependentTask.outputs.file(classFile)
+      dependentTask.outputs.file(incrementalBin)
+
+      val mainTask = project.tasks.register("consumerTask").get()
+      mainTask.dependsOn(dependentTask)
+
+      val gitIgnoreClassifier = GitIgnoreClassifier(java.io.File(workspaceRoot))
+      val result =
+          getInputsForTask(
+              null, mainTask, projectRoot, workspaceRoot, mutableMapOf(), gitIgnoreClassifier)
+
+      assertNotNull(result)
+
+      assertTrue(
+          result!!.any { it is Map<*, *> && it["dependentTasksOutputFiles"] == "**/*.class" })
+      assertTrue(
+          result.none { it is Map<*, *> && it["dependentTasksOutputFiles"] == "**/*.bin" },
+          "Expected no **/*.bin dependentTasksOutputFiles input, got $result")
+    }
+
+    @Test
     fun `test getInputsForTask with pre-computed dependsOnTasks`() {
       // Create dependent task with output
       val dependentTask = project.tasks.register("dependentTask").get()


### PR DESCRIPTION
## Current Behavior

The `@nx/gradle` project-graph plugin infers a `dependentTasksOutputFiles: "**/*.bin"` input for any task that depends on a Java/Kotlin compile task. That happens because the compile tasks declare their incremental-compilation state as task outputs, and the plugin consolidates dependent-output file extensions into globs:

- `compileJava` / `compileTestJava` → `build/tmp/<task>/previous-compilation-data.bin`
- `compileKotlin` / `compileTestKotlin` → `build/kotlin/<task>/cacheable` and `…/classpath-snapshot` (`*.bin`)

These `.bin` files are the compilers' incremental bookkeeping — rewritten on **every** compile and embedding **machine-specific absolute paths**. No downstream task consumes them. As a result, every consuming task (`test`, `jar`, `classes`, `testClasses`, `javadoc`, `validatePlugins`, …) gets a hash input that changes on every build and never matches across machines/agents, so those tasks miss the cache constantly.

## Expected Behavior

The `.bin` incremental-compilation state is excluded from the inferred `dependentTasksOutputFiles` inputs. Consuming tasks still hash the real `.class`/`.jar` outputs, so cache correctness is preserved while the spurious churn is removed. A unit test asserts a dependent task's `.bin` output never produces a `**/*.bin` input (while `.class` still does).

Note: this changes the Gradle plugin source, so it takes effect once shipped via a `dev.nx.gradle.project-graph` version bump.

## Related Issue(s)

Found during a Gradle project-graph hash-drift investigation; no separate GitHub issue.
