### PR TITLE
fix(gradle): do not cache publishToMavenLocal tasks

### DIFF
--- a/packages/gradle/project-graph/project.json
+++ b/packages/gradle/project-graph/project.json
@@ -5,6 +5,12 @@
     "gradle:publishToMavenLocal": {
       "cache": false
     },
+    "gradle:publishPluginMavenPublicationToMavenLocal": {
+      "cache": false
+    },
+    "gradle:publishNxProjectGraphPluginPluginMarkerMavenPublicationToMavenLocal": {
+      "cache": false
+    },
     "publish-staging": {
       "command": "./gradlew :gradle-project-graph:publish",
       "cache": true,

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -578,6 +578,8 @@ fun isContinuous(task: Task): Boolean {
 private val nonCacheableTasks = setOf("bootRun", "run")
 
 fun isCacheable(task: Task): Boolean {
+  // *ToMavenLocal tasks write to ~/.m2 (outside the workspace) — a cache hit skips the real publish
+  if (task.name.endsWith("ToMavenLocal")) return false
   return !nonCacheableTasks.contains(task.name)
 }
 

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
@@ -118,6 +118,15 @@ class ProcessTaskUtilsTest {
     assertNotNull(result["options"])
   }
 
+  @Test
+  fun `publishToMavenLocal tasks are not cacheable`() {
+    val project = ProjectBuilder.builder().build()
+    assertFalse(
+        isCacheable(project.tasks.register("publishPluginMavenPublicationToMavenLocal").get()))
+    assertFalse(isCacheable(project.tasks.register("publishToMavenLocal").get()))
+    assertTrue(isCacheable(project.tasks.register("compileJava").get()))
+  }
+
   @Nested
   inner class GetInputsForTaskTests {
     lateinit var project: Project


### PR DESCRIPTION
## Current Behavior

Gradle tasks that publish to the local Maven repo are treated as cacheable by `@nx/gradle`. But they write to `~/.m2` — outside the workspace and not a tracked Nx output — so a cache hit restores the build artifacts without performing the real `~/.m2` write.

Two facts make this break in distributed CI:

- `@nx/gradle` runs each gradle task as its own Nx task and invokes it with `--exclude-task` for every dependency, so the aggregator `publishToMavenLocal` is a no-op (all its work is in the excluded sub-tasks).
- The sub-tasks that actually publish — `publishPluginMavenPublicationToMavenLocal` and `publishNxProjectGraphPluginPluginMarkerMavenPublicationToMavenLocal` — are cacheable. The first agent to run them publishes to *its* `~/.m2` and caches the result; every other agent gets a cache hit and never touches its own `~/.m2`.

So when an e2e depends on a locally published (unreleased) plugin version, the e2e agent's `~/.m2` doesn't have it and resolution fails:

```
Plugin [id: 'dev.nx.gradle.project-graph', version: '0.1.22'] was not found
  Searched: MavenLocal(file:/home/.m2/repository), Gradle Central Plugin Repository, MavenRepo
```

## Expected Behavior

`*ToMavenLocal` tasks are never cacheable, so they always execute on the agent that depends on them and actually populate that agent's `~/.m2`.

This PR has two parts:

1. **Plugin (durable):** `isCacheable` returns `false` for any task whose name ends with `ToMavenLocal` (covers `publishToMavenLocal`, `publish*PublicationToMavenLocal`, `publishAllPublicationsToMavenLocal`). Unit test added.
2. **Workspace stopgap:** `packages/gradle/project-graph/project.json` overrides the two publication tasks to `cache: false`, so this repo's own gradle e2e is fixed now — before the plugin change is published and consumed. Verified `nx show project :gradle-project-graph` now reports `cache: false` for both.

## Related Issue(s)

Found while investigating gradle e2e failures on a plugin version bump; no separate GitHub issue.
