### PR TITLE
fix: angular-rspack loader error stats

### DIFF
--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
@@ -154,9 +154,15 @@ export class AngularRspackPlugin implements RspackPluginInstance {
       compilation.hooks.afterSeal.tapAsync(PLUGIN_NAME, (callback) => {
         if (!watchRunInitialized && compilation.errors.length > 0) {
           const stats = compilation.getStats();
+          const statsOptions = {
+            children: true,
+            errors: true,
+            errorDetails: true,
+            errorStack: true,
+          };
           const compilationError = statsErrorsToString(
-            stats.toJson(),
-            getStatsOptions(this.#_options.verbose)
+            stats.toJson(statsOptions),
+            statsOptions
           );
           callback(new Error(compilationError));
         } else {


### PR DESCRIPTION
## Summary

Fixes the Angular Rspack plugin error formatting path for loader errors that prevent sealing. Rspack now defaults many stats fields off, so calling `stats.toJson()` without explicit stats options can omit the error data that `statsErrorsToString` expects.

This change uses a minimal local stats options object based on the fields read by `statsErrorsToString`: top-level and child errors, plus the formatting flags for colors, error details, and error stacks.

## Validation

- `corepack pnpm exec prettier --check packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts`
- `NODE_OPTIONS='--conditions=@nx/nx-source' corepack pnpm exec vitest --config vitest.config.mts run` from `packages/angular-rspack`
