### PR TITLE
fix(core): re-hash batch tasks with deps outputs after execution

### DIFF
--- a/packages/nx/src/tasks-runner/task-orchestrator.spec.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.spec.ts
@@ -1,0 +1,173 @@
+import { ProjectGraph } from '../config/project-graph';
+import { Task, TaskGraph } from '../config/task-graph';
+import { TaskOrchestrator } from './task-orchestrator';
+
+jest.mock('./task-env', () => ({
+  ...jest.requireActual('./task-env'),
+  getTaskSpecificEnv: jest.fn(() => process.env),
+}));
+
+jest.mock('./utils', () => ({
+  ...jest.requireActual('./utils'),
+  getCustomHasher: jest.fn(() => null),
+}));
+
+describe('TaskOrchestrator', () => {
+  describe('batch re-hash of depsOutputs tasks', () => {
+    function createTask(id: string): Task {
+      const [project, target] = id.split(':');
+      return {
+        id,
+        target: { project, target },
+        overrides: {},
+        outputs: [`{workspaceRoot}/dist/${project}`],
+        projectRoot: project,
+        cache: true,
+        parallelism: true,
+      } as Task;
+    }
+
+    function createProjectGraph(): ProjectGraph {
+      const node = (name: string, inputs?: unknown[]) => ({
+        name,
+        type: 'lib' as const,
+        data: {
+          root: name,
+          targets: {
+            build: {
+              executor: 'my-plugin:build',
+              ...(inputs ? { inputs } : {}),
+            },
+          },
+        },
+      });
+      return {
+        nodes: {
+          dep: node('dep'),
+          consumer: node('consumer', [
+            { dependentTasksOutputFiles: '**/*.jar', transitive: true },
+          ]),
+        },
+        dependencies: {
+          dep: [],
+          consumer: [{ source: 'consumer', target: 'dep', type: 'static' }],
+        },
+        externalNodes: {},
+      } as unknown as ProjectGraph;
+    }
+
+    function createOrchestrator(taskGraph: TaskGraph) {
+      let hasherCallCount = 0;
+      const hasher = {
+        hashTasks: jest.fn(async (tasks: Task[]) => {
+          hasherCallCount++;
+          return tasks.map((t) => ({
+            value: `${t.id}|call-${hasherCallCount}`,
+            details: {
+              command: 'cmd',
+              nodes: {},
+              implicitDeps: {},
+              runtime: {},
+            },
+          }));
+        }),
+      };
+
+      // Bypass the constructor — its field initializers open db connections
+      // and fork processes that this test doesn't need.
+      const orchestrator: any = Object.create(TaskOrchestrator.prototype);
+      orchestrator.hasher = hasher;
+      orchestrator.projectGraph = createProjectGraph();
+      orchestrator.taskGraph = taskGraph;
+      orchestrator.fullTaskGraph = taskGraph;
+      orchestrator.nxJson = {};
+      orchestrator.taskDetails = null;
+      orchestrator.taskInvocationTracker = null;
+      orchestrator.completedTasks = new Map();
+      orchestrator.options = { lifeCycle: { scheduleTask: jest.fn() } };
+      orchestrator.forkedProcessTaskRunner = {
+        cleanUpBatchProcesses: jest.fn(),
+      };
+      orchestrator.applyCachedResults = jest.fn().mockResolvedValue([]);
+      orchestrator.preRunSteps = jest.fn();
+      const hashesAtCacheTime: Record<string, string> = {};
+      orchestrator.postRunSteps = jest.fn(async (results: any[]) => {
+        for (const r of results) {
+          hashesAtCacheTime[r.task.id] = r.task.hash;
+          orchestrator.completedTasks.set(r.task.id, r.status);
+        }
+      });
+      orchestrator.runBatch = jest.fn(async (batch: any) =>
+        Object.values(batch.taskGraph.tasks).map((task) => ({
+          task,
+          status: 'success',
+          code: 0,
+        }))
+      );
+
+      return { orchestrator, hasher, hashesAtCacheTime };
+    }
+
+    it('should re-hash tasks with depsOutputs inputs after their deps execute in the same batch', async () => {
+      const dep = createTask('dep:build');
+      const consumer = createTask('consumer:build');
+      const taskGraph: TaskGraph = {
+        roots: ['dep:build'],
+        tasks: { 'dep:build': dep, 'consumer:build': consumer },
+        dependencies: { 'dep:build': [], 'consumer:build': ['dep:build'] },
+        continuousDependencies: { 'dep:build': [], 'consumer:build': [] },
+      };
+      const { orchestrator, hasher, hashesAtCacheTime } =
+        createOrchestrator(taskGraph);
+
+      await orchestrator.applyFromCacheOrRunBatch(
+        true,
+        { id: 'batch-1', executorName: 'my-plugin:batch', taskGraph },
+        0
+      );
+
+      // Preliminary hashes: dep (call 1), consumer (call 2). The consumer's
+      // preliminary hash predates the dep's outputs being written, so a third
+      // call must re-hash the consumer after the batch ran.
+      expect(hasher.hashTasks).toHaveBeenCalledTimes(3);
+      expect(hasher.hashTasks.mock.calls[2][0].map((t: Task) => t.id)).toEqual([
+        'consumer:build',
+      ]);
+      expect(consumer.hash).toBe('consumer:build|call-3');
+      expect(dep.hash).toBe('dep:build|call-1');
+
+      // The re-hashed value is what gets cached, not the preliminary one
+      expect(hashesAtCacheTime['consumer:build']).toBe('consumer:build|call-3');
+      expect(hashesAtCacheTime['dep:build']).toBe('dep:build|call-1');
+    });
+
+    it('should not re-hash tasks whose deps were all cache hits', async () => {
+      const dep = createTask('dep:build');
+      const consumer = createTask('consumer:build');
+      const taskGraph: TaskGraph = {
+        roots: ['dep:build'],
+        tasks: { 'dep:build': dep, 'consumer:build': consumer },
+        dependencies: { 'dep:build': [], 'consumer:build': ['dep:build'] },
+        continuousDependencies: { 'dep:build': [], 'consumer:build': [] },
+      };
+      const { orchestrator, hasher } = createOrchestrator(taskGraph);
+      // dep resolves from cache, so its outputs are already settled on disk
+      // when the consumer's hash is computed
+      orchestrator.applyCachedResults = jest.fn(async (tasks: Task[]) =>
+        tasks
+          .filter((t) => t.id === 'dep:build')
+          .map((task) => ({ task, status: 'local-cache', code: 0 }))
+      );
+
+      await orchestrator.applyFromCacheOrRunBatch(
+        true,
+        { id: 'batch-1', executorName: 'my-plugin:batch', taskGraph },
+        0
+      );
+
+      // dep (call 1) and consumer (call 2) — no post-execution re-hash needed
+      expect(hasher.hashTasks).toHaveBeenCalledTimes(2);
+      expect(consumer.hash).toBe('consumer:build|call-2');
+    });
+  });
+});

--- a/packages/nx/src/tasks-runner/task-orchestrator.spec.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.spec.ts
@@ -2,6 +2,9 @@ import { ProjectGraph } from '../config/project-graph';
 import { Task, TaskGraph } from '../config/task-graph';
 import { TaskOrchestrator } from './task-orchestrator';
 
+performance.mark = jest.fn((name: string) => ({ name }) as PerformanceMark);
+performance.measure = jest.fn();
+
 jest.mock('./task-env', () => ({
   ...jest.requireActual('./task-env'),
   getTaskSpecificEnv: jest.fn(() => process.env),

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -744,6 +744,12 @@ export class TaskOrchestrator {
         )
         .map((r) => r.task);
       if (tasksToRehash.length > 0) {
+        // hashTasks skips tasks that already have a hash — clear the
+        // preliminary hashes so these tasks actually get re-hashed
+        for (const task of tasksToRehash) {
+          task.hash = undefined;
+          task.hashDetails = undefined;
+        }
         await this.hashBatchTasks(tasksToRehash);
       }
     }


### PR DESCRIPTION
## Current Behavior

Since #34798, the post-batch re-hash of tasks with `dependentTasksOutputFiles` inputs is a silent no-op. `applyFromCacheOrRunBatch` collects `needsRehashAfterExecution` tasks and calls `hashBatchTasks(tasksToRehash)` after the batch executes, but the bulk `hashTasks` it delegates to filters out every task that already has a hash — and all re-hash candidates carry the preliminary hash assigned before the batch ran.

As a result, batch tasks are cached under hashes computed from the **pre-execution** state of their dependencies' outputs. The next invocation hashes the settled disk state, computes a different hash, and misses the cache — even when nothing changed. On gradle workspaces (`@nx/gradle` batches by default and its inferred targets hash `**/*.jar` / `**/*.class` across transitive dep outputs) this guarantees that any CI step re-running the same targets after a step that executed gradle work misses the whole chain. The stale keys can also produce false hits: a later invocation whose preliminary hash matches a previously stored stale key restores an artifact that does not correspond to the current inputs.

Reproduced on a large gradle workspace (nx 23.0.0-rc.0):

- two back-to-back identical `nx run-many -t package` invocations: run 2 re-executed 61/117 tasks, gradle reporting `UP-TO-DATE` on every one of them (nothing changed except the hash keys)
- locally: a deterministic 8-task miss wave on every second run, where each stale task's recorded hash matches the pre-execution disk state and the recomputed settled hash differs

## Expected Behavior

A second identical invocation is 100% cache hits. With this fix applied (via pnpm patch) to the same workspace, the same two-invocation CI job goes from failing (61 re-executed) to 117/117 cache hits.

## The Fix

Clear the preliminary `hash`/`hashDetails` on the tasks queued for re-hashing so the bulk hasher actually re-hashes them against the freshly written dependency outputs. Kept localized to the orchestrator call site rather than changing the `!task.hash` filter in `hashTasks`, since the filter prevents redundant re-hashing at every level of the batch walk.

Adds a regression spec: a consumer with `dependentTasksOutputFiles` whose in-batch dependency executes must get a fresh post-execution hash (fails without the fix), and tasks whose deps were all cache hits are not pointlessly re-hashed.

## Known residual (not addressed here)

Tasks that **cache-hit** during the batch walk are recorded under their lookup-time hash. If a preliminary hash false-hits on a previously stored stale key (e.g. entries written by versions affected by this bug), the restored artifact is recorded under a key the next invocation will not recompute. This leg is timing-dependent and much rarer than the executed-task leg fixed here; flagging it for follow-up.

## Related Issue(s)

Regression introduced by #34798.

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/affected-package-is-not-cached-a5603ad8)
<!-- polygraph-session-end -->