### PR TITLE
docs(nx-plugin): add guide on writing performant createNodes v2 plugins

### DIFF
--- a/astro-docs/sidebar.mts
+++ b/astro-docs/sidebar.mts
@@ -808,6 +808,10 @@ const knowledgeBaseGroups: SidebarItems = [
             link: 'extending-nx/createnodes-compatibility',
           },
           {
+            label: 'Performant project graph plugins',
+            link: 'extending-nx/performant-project-graph-plugins',
+          },
+          {
             label: 'Organization-specific plugin',
             link: 'extending-nx/organization-specific-plugin',
           },

--- a/astro-docs/src/content/docs/extending-nx/performant-project-graph-plugins.mdoc
+++ b/astro-docs/src/content/docs/extending-nx/performant-project-graph-plugins.mdoc
@@ -1,0 +1,230 @@
+---
+title: Write a Performant Project Graph Plugin
+description: Practical patterns and caveats for writing fast createNodes plugins, including disk caching, work hoisting, and parallel config loading.
+filter: 'type:Guides'
+---
+
+Your plugin's `createNodes` function runs every time Nx computes the project graph, which happens before _any_ task is restored from cache. If it does expensive work for every matching file, that cost is paid on every command (`nx build`, `nx graph`, even editor integrations), and it is paid by every developer and every CI machine. A plugin that recomputes everything from scratch is a common cause of slow graph creation, and the cost is magnified on Windows, where filesystem and process-spawn operations are significantly more expensive than on Linux or macOS.
+
+The patterns below are the ones the first-party Nx plugins use to keep graph creation fast. They assume you're already familiar with the [project graph plugin API](/docs/extending-nx/project-graph-plugins) and have written a basic [tooling plugin](/docs/extending-nx/tooling-plugin).
+
+{% aside type="note" title="Internal helpers" %}
+Some helpers shown below (`PluginCache`, `calculateHashesForCreateNodes`) are exported from `@nx/devkit/internal`, and `workspaceDataDirectory` comes from `nx/src/utils/cache-directory`. These are lower-stability surfaces than the main `@nx/devkit` entry point, so they can change between major versions. They are the same helpers first-party plugins rely on, but if you need to support a wide range of Nx versions you can implement the equivalent behavior yourself (a content hash plus a JSON file on disk).
+{% /aside %}
+
+## Set up shared state once per batch
+
+`createNodes` hands you _all_ matching files in a single call, which lets you set up shared state once and amortize expensive work across every project. Every other pattern here depends on processing the batch together rather than file by file.
+
+Wrap your per-file logic with `createNodesFromFiles`, which fans the files out and processes them in parallel while keeping the returned results in a deterministic order:
+
+```ts
+// src/index.ts
+import {
+  CreateNodes,
+  CreateNodesContext,
+  createNodesFromFiles,
+} from '@nx/devkit';
+
+const configGlob = '**/my-tool.config.{js,ts}';
+
+export const createNodes: CreateNodes<MyPluginOptions> = [
+  configGlob,
+  async (configFiles, options, context) => {
+    // Set up shared state here, once for the whole batch (see below).
+    return await createNodesFromFiles(
+      (configFile, options, context, idx) =>
+        createNodesInternal(configFile, options, context, idx),
+      configFiles,
+      options,
+      context
+    );
+  },
+];
+```
+
+{% aside type="note" title="Export name by Nx version" %}
+Use `createNodes` for Nx 22 and later, where it carries this batched signature. For Nx 21 and earlier, the equivalent export is named `createNodesV2`. To support both, export `createNodes` and add `export const createNodesV2 = createNodes`. See the [CreateNodes API Compatibility](/docs/extending-nx/createnodes-compatibility) guide.
+{% /aside %}
+
+## Cache results to disk
+
+Most of a plugin's cost is recomputing target configuration that hasn't changed. Cache the result of processing each config file on disk, keyed by a hash of everything that can affect the output. On the next run, unchanged projects are read straight from the cache instead of being reprocessed.
+
+The hash must include every input that affects the result: the project's files, the plugin options, and any external files the config references (for example, a lockfile or a shared base config). `calculateHashesForCreateNodes` batches the workspace-context hashing for all project roots into a single call, much faster than hashing each root individually.
+
+```ts
+import { createNodesFromFiles } from '@nx/devkit';
+import {
+  PluginCache,
+  calculateHashesForCreateNodes,
+} from '@nx/devkit/internal';
+import { hashObject } from 'nx/src/devkit-internals';
+import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
+import { dirname, join } from 'node:path';
+
+export const createNodes: CreateNodes<MyPluginOptions> = [
+  configGlob,
+  async (configFiles, options, context) => {
+    // One cache file per unique set of options so different plugin
+    // configurations don't collide.
+    const optionsHash = hashObject(options);
+    const cachePath = join(
+      workspaceDataDirectory,
+      `my-plugin-${optionsHash}.hash`
+    );
+    const targetsCache = new PluginCache<MyTargets>(cachePath);
+
+    const projectRoots = configFiles.map((f) => dirname(f));
+    const hashes = await calculateHashesForCreateNodes(
+      projectRoots,
+      options,
+      context
+    );
+
+    try {
+      return await createNodesFromFiles(
+        async (configFile, options, context, idx) => {
+          const hash = hashes[idx];
+
+          if (!targetsCache.has(hash)) {
+            // Only the expensive work runs on a cache miss.
+            targetsCache.set(
+              hash,
+              await buildTargets(configFile, options, context)
+            );
+          }
+
+          return {
+            projects: {
+              [projectRoots[idx]]: { targets: targetsCache.get(hash) },
+            },
+          };
+        },
+        configFiles,
+        options,
+        context
+      );
+    } finally {
+      // Always persist, even if one file throws, so the work already
+      // done isn't lost.
+      targetsCache.writeToDisk();
+    }
+  },
+];
+```
+
+A few things to get right:
+
+- **Write the cache in a `finally` block** so a failure processing one file doesn't discard the entries computed for the others.
+- **Include referenced files in the hash.** If your config `extends` a base file or your targets depend on a lockfile, pass those paths through the `additionalGlobs` argument of `calculateHashesForCreateNodes` so a change to them invalidates the cache:
+
+  ```ts
+  const hashes = await calculateHashesForCreateNodes(
+    projectRoots,
+    options,
+    context,
+    projectRoots.map(() => [lockFileName, ...referencedConfigFiles])
+  );
+  ```
+
+- **Respect `NX_CACHE_PROJECT_GRAPH=false`.** `PluginCache` already does this: it returns an empty cache when the variable is set, which is what makes the [development overrides](#develop-and-debug-your-plugin) below work.
+
+## Hoist shared work out of the per-file loop
+
+Even with a disk cache, the first run (and any run after a change) processes files. Anything that's identical across files should be computed once per batch, not once per file. Set up in-memory caches in the `createNodes` body and pass them into your per-file function:
+
+```ts
+async (configFiles, options, context) => {
+  // Detected once for the whole workspace, not per project.
+  const packageManager = detectPackageManager(context.workspaceRoot);
+
+  // Shared across files: many projects extend the same base tsconfig or
+  // use the same preset, so read and resolve each one only once.
+  const tsconfigCache = new Map<string, RawTsconfig>();
+  const presetCache: Record<string, unknown> = {};
+
+  return await createNodesFromFiles(
+    (configFile, options, context, idx) =>
+      buildTargets(configFile, options, context, {
+        packageManager,
+        tsconfigCache,
+        presetCache,
+      }),
+    configFiles,
+    options,
+    context
+  );
+};
+```
+
+Common things worth hoisting: package-manager detection, lockfile name resolution, shared base configs, and tool presets. The `@nx/jest` plugin, for example, caches resolved presets and the tsconfig `extends` chain this way because most projects in a workspace share them.
+
+## Load configuration files in parallel
+
+When you must read or evaluate config files, do it concurrently with `Promise.all` rather than in a sequential loop. Reading config off disk is I/O-bound, and transpiling and evaluating TypeScript configs is CPU-bound. Both parallelize well:
+
+```ts
+const loadedConfigs = await Promise.all(
+  configFiles.map((configFile) =>
+    loadConfigFile(join(context.workspaceRoot, configFile))
+  )
+);
+```
+
+This matters most on Windows, where each `readFileSync`/`readdirSync` call carries more overhead, so collapsing serial I/O into parallel batches has an outsized effect.
+
+## Keep your file glob narrow
+
+The first element of the `createNodes` tuple is a glob Nx matches against the whole workspace. A broad pattern like `**/*.json` forces Nx to consider far more files and calls your function with files you'll only discard. Match the most specific filename you can:
+
+```ts
+// Prefer this
+const configGlob = '**/vite.config.{js,ts,mjs,mts,cjs,cts}';
+
+// Over a catch-all you have to filter down yourself
+const configGlob = '**/*.config.*';
+```
+
+If you can only decide whether a file is relevant after looking at its siblings (for example, requiring a `package.json` or `project.json` next to it), do that check early and `return {}` before doing any expensive work. A precise glob is still cheaper than a broad glob plus a filter.
+
+## Keep output deterministic
+
+Nx hashes the graph node your plugin produces to decide whether cached task results can be reused. If your function returns different output across runs or machines, because of array ordering, absolute paths, or environment values, Nx computes a different hash and treats unchanged code as a cache miss, defeating both your plugin cache and task caching downstream.
+
+Sort arrays (`targets`, `inputs`, `outputs`, `dependsOn`) explicitly before returning, and avoid leaking `process.env` values, absolute paths, timestamps, or random IDs into target configuration. Prefer workspace-relative tokens like `{workspaceRoot}` and `{projectRoot}`. See [Inferred Tasks](/docs/concepts/inferred-tasks) for the full set of determinism rules.
+
+## Avoid per-file process spawning and heavy top-level imports
+
+Two patterns quietly dominate graph-creation time:
+
+- **Spawning a child process per file.** If your plugin shells out to a tool to read configuration, the process-startup cost is paid for every project and is especially expensive on Windows. Batch the work into a single invocation where possible, or read the configuration directly instead of shelling out.
+- **Heavy imports at module load.** Everything imported at the top of your plugin entry point is loaded every time Nx loads the plugin, even on a full cache hit. Keep top-level imports light and `await import(...)` heavy or rarely-used dependencies inside the code path that actually needs them.
+
+## Develop and debug your plugin
+
+While iterating, disable the caching layers that would otherwise hide your changes:
+
+```shell
+# The daemon caches your plugin code, so changes won't take effect until it restarts.
+NX_DAEMON=false nx graph
+
+# Bypass the project graph cache so your createNodes logic always re-runs.
+NX_CACHE_PROJECT_GRAPH=false nx graph
+```
+
+To find where graph-creation time is actually going, turn on performance logging. Nx prints the duration of each internal step, including project-graph construction:
+
+```shell
+NX_PERF_LOGGING=true NX_DAEMON=false nx graph
+```
+
+If a user reports slow graph creation, ask them for this output along with `nx report`. The per-step timings make it clear whether the cost is in your plugin (`createNodes`) versus elsewhere, and `nx report` confirms the Nx and plugin versions in play.
+
+## Related documentation
+
+- [Extending the Project Graph](/docs/extending-nx/project-graph-plugins) - The full project graph plugin API
+- [Integrate a New Tool with a Tooling Plugin](/docs/extending-nx/tooling-plugin) - End-to-end tutorial for building a plugin
+- [CreateNodes API Compatibility](/docs/extending-nx/createnodes-compatibility) - Supporting multiple Nx versions
+- [Inferred Tasks](/docs/concepts/inferred-tasks) - How Nx builds the graph from plugins
+- [CreateNodesV2 API Reference](/docs/reference/devkit/CreateNodesV2) - Detailed API documentation

--- a/astro-docs/src/content/docs/extending-nx/project-graph-plugins.mdoc
+++ b/astro-docs/src/content/docs/extending-nx/project-graph-plugins.mdoc
@@ -17,6 +17,10 @@ Project graph plugins are able to add new nodes or dependencies to the project g
 When developing project graph plugins, disable the [Nx Daemon](/docs/concepts/nx-daemon) by setting `NX_DAEMON=false`. The daemon caches your plugin code, so changes to your plugin won't be reflected until the daemon restarts.
 {% /aside %}
 
+{% aside type="note" title="Writing a fast plugin" %}
+`createNodesV2` runs on every graph computation, so its cost is paid on every command. Once your plugin works, see [Write a Performant Project Graph Plugin](/docs/extending-nx/performant-project-graph-plugins) for caching and other patterns that keep graph creation fast.
+{% /aside %}
+
 ## Adding plugins to workspace
 
 You can register a plugin by adding it to the plugins array in `nx.json`:

--- a/astro-docs/src/content/docs/extending-nx/tooling-plugin.mdoc
+++ b/astro-docs/src/content/docs/extending-nx/tooling-plugin.mdoc
@@ -448,6 +448,7 @@ it('should infer tasks', () => {
 
 Now that you have a working plugin, here are a few other topics you may want to investigate:
 
+- [Write a performant project graph plugin](/docs/extending-nx/performant-project-graph-plugins) with caching so graph creation stays fast
 - [Publish your Nx plugin](/docs/extending-nx/publish-plugin) to npm and the Nx plugin registry
 - [Write migration generators](/docs/extending-nx/migration-generators) to automatically account for breaking changes
 - [Create a preset](/docs/extending-nx/create-preset) to scaffold out an entire new repository


### PR DESCRIPTION
## Current Behavior

The plugin authoring docs explain the `createNodesV2` API and how to build a tooling plugin, but there's no guidance on writing a *performant* one. `createNodesV2` runs on every graph computation (before any task cache is consulted), so an inefficient plugin slows down every command for every developer and CI machine — most painfully on Windows, where one team reported ~8 minute graph creation.

## Expected Behavior

Adds a new guide, **Write a Performant Project Graph Plugin**, under `extending-nx`, collecting the patterns Nx's own first-party plugins use:

- Prefer the batched `createNodesV2` API over per-file v1
- Cache results to disk with a content hash (`PluginCache` + `calculateHashesForCreateNodes`), writing in a `finally` block
- Hoist shared work (package-manager detection, presets, base configs) out of the per-file loop
- Load config files in parallel with `Promise.all`
- Keep file globs narrow and output deterministic
- Avoid per-file process spawning and heavy top-level imports
- Develop/debug with `NX_DAEMON`/`NX_CACHE_PROJECT_GRAPH` overrides and diagnose slow graphs with `NX_PERF_LOGGING` + `nx report`

Also adds cross-links from the project graph plugin and tooling plugin pages, plus a sidebar entry.

Preview: https://deploy-preview-35981--nx-docs.netlify.app/docs/extending-nx/performant-project-graph-plugins

## Related Issue(s)

Resolves Linear DOC-516 (auto-linked via the branch name).
