### PR TITLE
docs(webpack): remove stale svgr option from NxReactWebpackPlugin

### DIFF
--- a/astro-docs/src/content/docs/technologies/build-tools/webpack/Guides/webpack-plugins.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/webpack/Guides/webpack-plugins.mdoc
@@ -355,29 +355,16 @@ module.exports = {
 
 ### NxReactWebpackPlugin
 
-#### Options
-
-##### svgr
-
-Type: `boolean`
-
-Enables or disables [React SVGR](https://react-svgr.com/). Default is `true`.
-
-**Deprecated:** Add SVGR support in your Webpack configuration without relying on Nx. This option will be removed in Nx 22. See https://react-svgr.com/docs/webpack/
+This plugin adds React support, such as Fast Refresh, to your Webpack configuration.
 
 #### Example
 
 ```js
 const { NxReactWebpackPlugin } = require('@nx/react/webpack-plugin');
-const { join } = require('path');
 
 module.exports = {
   // ...
-  plugins: [
-    new NxReactWebpackPlugin({
-      svgr: false,
-    }),
-  ],
+  plugins: [new NxReactWebpackPlugin()],
 };
 ```
 


### PR DESCRIPTION
## Current Behavior

The Webpack plugins guide documents an `svgr` option for `NxReactWebpackPlugin`, including an `svgr: false` example and a deprecation note saying it "will be removed in Nx 22". The option no longer exists in source — it was already removed in Nx 22, and `applyReactConfig` only adds React Fast Refresh.

## Expected Behavior

The stale option docs and `svgr: false` example are removed. The section now shows a minimal usage example. Users needing the old behavior can refer to the Nx 22 docs archive at 22.nx.dev/docs.

## Related Issue(s)

Fixes DOC-523
