### PR TITLE
docs(misc): remove stale svgr option from deprecated withReact docs

### DIFF
--- a/astro-docs/src/content/docs/technologies/build-tools/webpack/Guides/webpack-plugins.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/webpack/Guides/webpack-plugins.mdoc
@@ -542,18 +542,12 @@ module.exports = composePlugins(
 
 ### withReact
 
-The `withReact` plugin adds support for React JSX, [SVGR](https://react-svgr.com/),
+The `withReact` plugin adds support for React JSX
 and [Fast Refresh](https://github.com/pmmmwh/react-refresh-webpack-plugin)
 
 #### Options
 
-The options are the same as [`withWeb`](#withweb) plus the following.
-
-##### svgr
-
-Type: `undefined|false`
-
-SVGR allows SVG files to be imported as React components. Set this to `false` to disable this behavior.
+The options are the same as [`withWeb`](#withweb).
 
 #### Example
 
@@ -565,7 +559,6 @@ module.exports = composePlugins(
   withNx(), // always pass withNx() first
   withReact({
     styles: ['my-app/src/styles.css'],
-    svgr: false,
     postcssConfig: 'my-app/postcss',
   }),
   (config) => {


### PR DESCRIPTION
## Current Behavior

The `withReact` section of the webpack plugins guide documents an `svgr` option (`Type: undefined|false`) and shows a `svgr: false` example. That option no longer exists: `WithReactOptions extends WithWebOptions` (no `svgr`), and `applyReactConfig` only adds hot reload — there is no SVGR handling. The intro also claims `withReact` "adds support for ... SVGR".

This mirrors DOC-523 (the same stale svgr docs on `NxReactWebpackPlugin`).

## Expected Behavior

The svgr option subsection and the `svgr: false` example line are removed, and the intro no longer claims SVGR support, so the docs match the actual `withReact` API. The section is kept (it already carries a deprecation notice — `withReact` is slated for removal in Nx v24) for users still on the v22–23 compose-helper path.

## Related Issue(s)

DOC-524