### PR TITLE
docs(misc): reword Node Fly.io guide linkcard to drop Nx 15.7 reference

### DIFF
--- a/astro-docs/src/content/docs/technologies/node/Guides/node-server-fly-io.mdoc
+++ b/astro-docs/src/content/docs/technologies/node/Guides/node-server-fly-io.mdoc
@@ -22,7 +22,7 @@ This example uses [Fastify](https://www.fastify.dev/) but you can equally use [E
 You can also install the `@nx/node` package into an existing Nx monorepo and generate a new Node application.
 
 {% cardgrid %}
-{% linkcard title="Build Node backends - The Easy Way!" description="Starting with Nx 15.7 we now have first-class support for building Node backend applications" href="https://youtu.be/K4f-fMuAoRY" /%}
+{% linkcard title="Build Node backends - The Easy Way!" description="Nx has first-class support for building Node backend applications" href="https://youtu.be/K4f-fMuAoRY" /%}
 {% linkcard title="Easy, Modular Node Applications!" description="In this video, we're going to explore how to modularize a Node backend application"  href="https://youtu.be/LHLW0b4fr2w" /%}
 {% /cardgrid %}
 


### PR DESCRIPTION
## Current Behavior

The Fly.io Node guide has a linkcard whose copy reads like a 2022 launch announcement: "Starting with Nx 15.7 we now have first-class support for building Node backend applications". Node backend support has been standard for many majors, so the version reference is stale.

## Expected Behavior

The linkcard description is reworded to "Nx has first-class support for building Node backend applications", dropping the Nx 15.7 reference.

## Related Issue(s)

DOC-525
