### PR TITLE
docs(core): rewrite targetDefaults reference and guide for array shape and voice

### DIFF
--- a/astro-docs/STYLE_GUIDE.md
+++ b/astro-docs/STYLE_GUIDE.md
@@ -331,11 +331,12 @@ Use triple backticks with a language identifier:
 ````markdown
 ```json
 {
-  "targetDefaults": {
-    "build": {
+  "targetDefaults": [
+    {
+      "target": "build",
       "cache": true
     }
-  }
+  ]
 }
 ```
 ````
@@ -347,11 +348,12 @@ Use triple backticks with a language identifier:
 ```json
 {
   // ... other config
-  "targetDefaults": {
-    "build": {
+  "targetDefaults": [
+    {
+      "target": "build",
       "cache": true
     }
-  }
+  ]
 }
 ```
 

--- a/astro-docs/src/content/docs/concepts/how-caching-works.mdoc
+++ b/astro-docs/src/content/docs/concepts/how-caching-works.mdoc
@@ -108,8 +108,9 @@ If the `outputs` property for a given target isn't defined in the project's `pac
 ```jsonc title="nx.json"
 {
   ...
-  "targetDefaults": {
-    "build": {
+  "targetDefaults": [
+    {
+      "target": "build",
       "dependsOn": [
         "^build"
       ],
@@ -119,7 +120,7 @@ If the `outputs` property for a given target isn't defined in the project's `pac
         "{projectRoot}/public/build"
       ]
     }
-  }
+  ]
 }
 ```
 
@@ -138,15 +139,17 @@ By default the cache considers all project files (e.g. `{projectRoot}/**/*`). Th
 
 ```json title="nx.json"
 {
-  "targetDefaults": {
-    "build": {
+  "targetDefaults": [
+    {
+      "target": "build",
       "inputs": ["{projectRoot}/**/*", "!{projectRoot}/**/*.md"]
       ...
     },
-    "test": {
+    {
+      "target": "test",
       "inputs": [...]
     }
-  }
+  ]
 }
 ```
 

--- a/astro-docs/src/content/docs/concepts/inferred-tasks.mdoc
+++ b/astro-docs/src/content/docs/concepts/inferred-tasks.mdoc
@@ -324,7 +324,7 @@ nx show project my-project --web
 ## Overriding inferred task configuration
 
 You can override the task configuration inferred by plugins in several ways.
-If you want to overwrite the task configuration for multiple projects, [use the `targetDefaults` object](/docs/reference/nx-json#target-defaults) in the `nx.json` file.
+If you want to overwrite the task configuration for multiple projects, [add an entry to the `targetDefaults` array](/docs/reference/nx-json#target-defaults) in the `nx.json` file.
 If you only want to override the task configuration for a specific project, [update that project's configuration](/docs/reference/project-configuration) in `package.json` or `project.json`.
 This configuration is more specific so it will override both the inferred configuration and the `targetDefaults`.
 

--- a/astro-docs/src/content/docs/concepts/task-pipeline-configuration.mdoc
+++ b/astro-docs/src/content/docs/concepts/task-pipeline-configuration.mdoc
@@ -70,14 +70,16 @@ Define task dependencies in the form of "rules", which are then followed when ru
 ```jsonc title="nx.json"
 {
   ...
-  "targetDefaults": {
-    "build": {
+  "targetDefaults": [
+    {
+      "target": "build",
       "dependsOn": ["^build", "prebuild"]
     },
-    "test": {
+    {
+      "target": "test",
       "dependsOn": ["build"]
     }
-  }
+  ]
 }
 ```
 

--- a/astro-docs/src/content/docs/concepts/types-of-configuration.mdoc
+++ b/astro-docs/src/content/docs/concepts/types-of-configuration.mdoc
@@ -34,7 +34,7 @@ In a repository with many different projects and many different tools, there wil
 If you need to track down the value of a specific configuration property (say `runInBand` for `jest` on the `/apps/my-app` project) you need to look in the following locations. The configuration settings are merged with priority being given to the file higher up in the list.
 
 1. In `/apps/my-app/project.json`, the `options` listed under the `test` target that uses the `@nx/jest:jest` executor.
-2. In `/nx.json`, the `targetDefaults` listed for the `test` target.
+2. In `/nx.json`, the `targetDefaults` entries matching the `test` target.
 3. One of the `test` target options references `/apps/my-app/jest.config.ts`
 4. Which extends `/jest.config.ts`
 

--- a/astro-docs/src/content/docs/features/cache-task-results.mdoc
+++ b/astro-docs/src/content/docs/features/cache-task-results.mdoc
@@ -20,19 +20,21 @@ Nx **restores both the terminal output and the files** created from running the 
 {% tabs syncKey="nx-version" %}
 {% tabitem label="Nx >= 17" %}
 
-To enable caching for `build` and `test`, edit the `targetDefaults` property in `nx.json` to include the `build` and `test` tasks:
+To enable caching for `build` and `test`, edit the `targetDefaults` property in `nx.json` to include entries for the `build` and `test` tasks:
 
 ```json
 // nx.json
 {
-  "targetDefaults": {
-    "build": {
+  "targetDefaults": [
+    {
+      "target": "build",
       "cache": true
     },
-    "test": {
+    {
+      "target": "test",
       "cache": true
     }
-  }
+  ]
 }
 ```
 
@@ -87,7 +89,7 @@ You can define these inputs and outputs at the project level (`project.json`) or
 
 Take the following example: we want to exclude all `*.md` files from the cache so that whenever we change the README.md (or any other markdown file), it does _not_ invalidate the build cache. We also know that the build output will be stored in a folder named after the project name in the `dist` folder at the root of the workspace.
 
-To achieve this, we can add `inputs` and `outputs` definitions globally for all projects or at a per-project level:
+To achieve this, you can add `inputs` and `outputs` definitions globally for all projects or at a per-project level:
 
 {% tabs %}
 {% tabitem label="Globally" %}
@@ -95,12 +97,13 @@ To achieve this, we can add `inputs` and `outputs` definitions globally for all 
 ```json
 // nx.json
 {
-  "targetDefaults": {
-    "build": {
+  "targetDefaults": [
+    {
+      "target": "build",
       "inputs": ["{projectRoot}/**/*", "!{projectRoot}/**/*.md"],
       "outputs": ["{workspaceRoot}/dist/{projectName}"]
     }
-  }
+  ]
 }
 ```
 

--- a/astro-docs/src/content/docs/features/run-tasks.mdoc
+++ b/astro-docs/src/content/docs/features/run-tasks.mdoc
@@ -209,21 +209,22 @@ Nx can automatically detect the dependencies between projects (see [project grap
 
 {% /graph %}
 
-However, you need to specify for which targets this ordering is important. In the following example we are telling Nx that before running the `build` target it needs to run the `build` target on all the projects the current project depends on:
+However, you need to specify for which targets this ordering is important. The following example tells Nx that before running the `build` target it needs to run the `build` target on all the projects the current project depends on:
 
 ```json
 // nx.json
 {
   ...
-  "targetDefaults": {
-    "build": {
+  "targetDefaults": [
+    {
+      "target": "build",
       "dependsOn": ["^build"]
     }
-  }
+  ]
 }
 ```
 
-This means that if we run `nx build myreactapp`, Nx will first execute `build` on `shared-ui` and `feat-products` before running `build` on `myreactapp`.
+This means that if you run `nx build myreactapp`, Nx will first execute `build` on `shared-ui` and `feat-products` before running `build` on `myreactapp`.
 
 You can define these task dependencies globally for your workspace in `nx.json` or individually in each project's `project.json` file.
 

--- a/astro-docs/src/content/docs/getting-started/Tutorials/caching.mdoc
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/caching.mdoc
@@ -43,11 +43,11 @@ Caching is opt-in per task. The recommended approach is to set `cache: true` in 
 ```jsonc
 // nx.json
 {
-  "targetDefaults": {
-    "build": { "cache": true },
-    "test": { "cache": true },
-    "lint": { "cache": true },
-  },
+  "targetDefaults": [
+    { "target": "build", "cache": true },
+    { "target": "test", "cache": true },
+    { "target": "lint", "cache": true },
+  ],
 }
 ```
 
@@ -145,13 +145,14 @@ Local cache is stored in `.nx/cache` by default. Run `nx reset` to clear all loc
 ```jsonc
 // nx.json
 {
-  "targetDefaults": {
-    "build": {
+  "targetDefaults": [
+    {
+      "target": "build",
       "cache": true,
       "inputs": ["{projectRoot}/src/**/*", "{projectRoot}/tsconfig.json"],
       "outputs": ["{projectRoot}/dist"],
     },
-  },
+  ],
 }
 ```
 
@@ -209,12 +210,13 @@ Nx provides sensible defaults out of the box. For example, test specification fi
       "!{projectRoot}/**/*.test.ts",
     ],
   },
-  "targetDefaults": {
-    "build": {
+  "targetDefaults": [
+    {
+      "target": "build",
       "inputs": ["production", "^production"],
       "cache": true,
     },
-  },
+  ],
 }
 ```
 

--- a/astro-docs/src/content/docs/getting-started/Tutorials/configuring-tasks.mdoc
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/configuring-tasks.mdoc
@@ -101,11 +101,12 @@ The `dependsOn` property defines this ordering:
 ```jsonc
 // nx.json
 {
-  "targetDefaults": {
-    "build": {
+  "targetDefaults": [
+    {
+      "target": "build",
       "dependsOn": ["^build"],
     },
-  },
+  ],
 }
 ```
 
@@ -218,11 +219,12 @@ When many projects share the same task configuration, defining it in every `proj
 ```jsonc
 // nx.json
 {
-  "targetDefaults": {
-    "build": {
+  "targetDefaults": [
+    {
+      "target": "build",
       "dependsOn": ["^build"],
     },
-  },
+  ],
 }
 ```
 

--- a/astro-docs/src/content/docs/getting-started/Tutorials/reducing-configuration-boilerplate.mdoc
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/reducing-configuration-boilerplate.mdoc
@@ -112,15 +112,17 @@ Move shared configuration to `nx.json` so projects inherit defaults:
 ```jsonc
 // nx.json
 {
-  "targetDefaults": {
-    "build": {
+  "targetDefaults": [
+    {
+      "target": "build",
       "cache": true,
       "dependsOn": ["^build"],
     },
-    "test": {
+    {
+      "target": "test",
       "cache": true,
     },
-  },
+  ],
 }
 ```
 

--- a/astro-docs/src/content/docs/getting-started/Tutorials/running-tasks.mdoc
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/running-tasks.mdoc
@@ -115,11 +115,12 @@ Nx runs tasks in parallel by default, respecting the [task dependencies](/docs/g
 ```jsonc
 // nx.json
 {
-  "targetDefaults": {
-    "build": {
+  "targetDefaults": [
+    {
+      "target": "build",
       "dependsOn": ["^build"],
     },
-  },
+  ],
 }
 ```
 

--- a/astro-docs/src/content/docs/guides/Adopting Nx/from-turborepo.mdoc
+++ b/astro-docs/src/content/docs/guides/Adopting Nx/from-turborepo.mdoc
@@ -43,7 +43,7 @@ It's important to remember that Nx is a superset of Turborepo, it can do everyth
 
 ### Example: Basic configuration comparison
 
-To help with understanding the new `nx.json` file, let's compare it to the `turbo.json` file:
+To help with understanding the new `nx.json` file, compare it to the `turbo.json` file:
 
 ```json
 {
@@ -79,25 +79,29 @@ After running `nx init`, you'll automatically have an equivalent `nx.json`:
 ```json
 {
   "$schema": "./node_modules/nx/schemas/nx-schema.json",
-  "targetDefaults": {
-    "build": {
+  "targetDefaults": [
+    {
+      "target": "build",
       "dependsOn": ["^build"],
       "inputs": ["{projectRoot}/**/*", "{projectRoot}/.env*"],
       "outputs": ["{projectRoot}/.next/**", "!{projectRoot}/.next/cache/**"],
       "cache": true
     },
-    "lint": {
+    {
+      "target": "lint",
       "dependsOn": ["^lint"],
       "cache": true
     },
-    "check-types": {
+    {
+      "target": "check-types",
       "dependsOn": ["^check-types"],
       "cache": true
     },
-    "dev": {
+    {
+      "target": "dev",
       "continuous": true
     }
-  }
+  ]
 }
 ```
 

--- a/astro-docs/src/content/docs/guides/Adopting Nx/nx-vs-turborepo.mdoc
+++ b/astro-docs/src/content/docs/guides/Adopting Nx/nx-vs-turborepo.mdoc
@@ -93,8 +93,9 @@ Here's the same workspace configured with both tools:
       "!{projectRoot}/jest.config.[jt]s"
     ]
   },
-  "targetDefaults": {
-    "build": {
+  "targetDefaults": [
+    {
+      "target": "build",
       "dependsOn": ["^build"],
       "inputs": ["production", "^production"],
       "outputs": ["{projectRoot}/dist"],
@@ -103,30 +104,38 @@ Here's the same workspace configured with both tools:
         "prod": {}
       }
     },
-    "check-types": {
+    {
+      "target": "check-types",
       "dependsOn": ["^check-types"],
       "inputs": ["production", "^production"],
       "cache": true
     },
-    "test": {
+    {
+      "target": "test",
       "inputs": ["default", "^production"],
       "outputs": ["{projectRoot}/coverage"],
       "cache": true
     },
-    "lint": {
+    {
+      "target": "lint",
       "inputs": ["default", "{workspaceRoot}/eslint.config.mjs"],
       "cache": true
     },
-    "dev": {
+    {
+      "target": "dev",
       "continuous": true
     },
-    "@org/shop-e2e:test:e2e": {
+    {
+      "target": "test:e2e",
+      "projects": ["@org/shop-e2e"],
       "dependsOn": ["@org/shop:build"]
     },
-    "@org/admin-e2e:test:e2e": {
+    {
+      "target": "test:e2e",
+      "projects": ["@org/admin-e2e"],
       "dependsOn": ["@org/admin:build"]
     }
-  }
+  ]
 }
 ```
 

--- a/astro-docs/src/content/docs/guides/Nx Release/updating-version-references.mdoc
+++ b/astro-docs/src/content/docs/guides/Nx Release/updating-version-references.mdoc
@@ -93,24 +93,25 @@ If, for example, we want to build our projects to a centralized `dist/` director
       // path structures for both the source and dist directories, where {projectRoot} and {projectName} are available placeholders that will be interpolated by Nx
       "manifestRootsToUpdate": [
         "{projectRoot}",
-        // We use the object form of the manifestRootsToUpdate to specify that we want to update the dist package.json files and not preserve the local dependency references (if not using pnpm or bun)
+        // The object form of manifestRootsToUpdate updates the dist package.json files without preserving the local dependency references (if not using pnpm or bun)
         {
           "path": "dist/packages/{projectName}",
-          "preserveLocalDependencyProtocols": false, // (NOT NEEDED WHEN USING pnpm or bun) because we need to ensure our dist package.json files are valid for publishing and the local dependency references such as "workspace:" and "file:" are removed
+          "preserveLocalDependencyProtocols": false, // (NOT NEEDED WHEN USING pnpm or bun) ensures the dist package.json files are valid for publishing and the local dependency references such as "workspace:" and "file:" are removed
         },
       ],
     },
   },
-  "targetDefaults": {
+  "targetDefaults": [
     // Ensure that publishing works from the dist directory
-    // The nx-release-publish target is added implicitly behind the scenes by Nx Release, and we can therefore configure it in targetDefaults
-    "nx-release-publish": {
+    // The nx-release-publish target is added implicitly behind the scenes by Nx Release, so it can be configured in targetDefaults
+    {
+      "target": "nx-release-publish",
       "options": {
         // the packageRoot property is specific the TS/JS nx-release-publish implementation, other ecosystem plugins may have different options
         "packageRoot": "dist/packages/{projectName}", // path structure for your dist directory, where {projectRoot} and {projectName} are available placeholders that will be interpolated by Nx
       },
     },
-  },
+  ],
 }
 ```
 
@@ -145,23 +146,24 @@ If the package manager we are using is not using pnpm or bun (See Scenario 4 bel
     // Ensure that versioning works only in the dist directory
     "version": {
       "manifestRootsToUpdate": ["dist/packages/{projectName}"], // path structure for your dist directory, where {projectRoot} and {projectName} are available placeholders that will be interpolated by Nx
-      "currentVersionResolver": "git-tag", // or "registry", because we are no longer referencing our source package.json as the source of truth for the current version
-      "preserveLocalDependencyProtocols": false, // (NOT NEEDED WHEN USING pnpm or bun) because we need to ensure our dist package.json files are valid for publishing and the local dependency references are removed
+      "currentVersionResolver": "git-tag", // or "registry", because the source package.json is no longer the source of truth for the current version
+      "preserveLocalDependencyProtocols": false, // (NOT NEEDED WHEN USING pnpm or bun) ensures the dist package.json files are valid for publishing and the local dependency references are removed
     },
   },
-  "targetDefaults": {
+  "targetDefaults": [
     // Ensure that publishing works from the dist directory
-    // The nx-release-publish target is added implicitly behind the scenes by Nx Release, and we can therefore configure it in targetDefaults
-    "nx-release-publish": {
+    // The nx-release-publish target is added implicitly behind the scenes by Nx Release, so it can be configured in targetDefaults
+    {
+      "target": "nx-release-publish",
       "options": {
         "packageRoot": "dist/packages/{projectName}", // path structure for your dist directory, where {projectRoot} and {projectName} are available placeholders that will be interpolated by Nx
       },
     },
-  },
+  ],
 }
 ```
 
-After applying a patch version, our dist package.json will therefore ultimately look like this:
+After applying a patch version, the dist package.json will therefore look like this:
 
 ```jsonc
 // dist/packages/my-project/package.json

--- a/astro-docs/src/content/docs/guides/Tasks & Caching/configure-inputs.mdoc
+++ b/astro-docs/src/content/docs/guides/Tasks & Caching/configure-inputs.mdoc
@@ -339,14 +339,15 @@ As you configure `inputs`, keep the project details screen open and it will refr
 
 [Target Defaults](/docs/reference/nx-json#target-defaults) defined in `nx.json` apply to a set of targets. Defining `inputs` here one time will apply to a set of similar targets.
 
-```jsonc {% meta="{5}" %}
+```jsonc {% meta="{6}" %}
 // nx.json
 {
-  "targetDefaults": {
-    "build": {
+  "targetDefaults": [
+    {
+      "target": "build",
       "inputs": ["production", "^production"],
     },
-  },
+  ],
 }
 ```
 
@@ -454,14 +455,15 @@ Instead of defining a named input and referencing it with `^`, you can directly 
 ```jsonc
 // nx.json
 {
-  "targetDefaults": {
-    "build": {
+  "targetDefaults": [
+    {
+      "target": "build",
       "inputs": [
         "production",
         "^{projectRoot}/src/**/*.ts", // Only consider .ts source files from dependencies
       ],
     },
-  },
+  ],
 }
 ```
 

--- a/astro-docs/src/content/docs/guides/Tasks & Caching/configure-outputs.mdoc
+++ b/astro-docs/src/content/docs/guides/Tasks & Caching/configure-outputs.mdoc
@@ -75,14 +75,15 @@ As you configure `outputs`, keep the project details screen open and it will ref
 
 [Target Defaults](/docs/reference/nx-json#target-defaults) defined in `nx.json` apply to a set of targets. Defining `outputs` here one time will apply to a set of similar targets.
 
-```jsonc {% meta="{5}" %}
+```jsonc {% meta="{6}" %}
 // nx.json
 {
-  "targetDefaults": {
-    "build": {
+  "targetDefaults": [
+    {
+      "target": "build",
       "outputs": ["{projectRoot}/dist"],
     },
-  },
+  ],
 }
 ```
 

--- a/astro-docs/src/content/docs/guides/Tasks & Caching/defining-task-pipeline.mdoc
+++ b/astro-docs/src/content/docs/guides/Tasks & Caching/defining-task-pipeline.mdoc
@@ -18,11 +18,12 @@ You can define dependencies among tasks by using the `dependsOn` property:
 // nx.json
 {
   ...
-  "targetDefaults": {
-    "build": {
+  "targetDefaults": [
+    {
+      "target": "build",
       "dependsOn": ["^build"]
     }
-  }
+  ]
 }
 ```
 
@@ -34,11 +35,12 @@ Task dependencies can be [defined globally](/docs/reference/nx-json#target-defau
 // nx.json
 {
   ...
-  "targetDefaults": {
-    "build": {
+  "targetDefaults": [
+    {
+      "target": "build",
       "dependsOn": ["^build"]
     }
-  }
+  ]
 }
 ```
 

--- a/astro-docs/src/content/docs/guides/Tasks & Caching/pass-args-to-commands.mdoc
+++ b/astro-docs/src/content/docs/guides/Tasks & Caching/pass-args-to-commands.mdoc
@@ -227,14 +227,15 @@ To provide the same args for all projects in the workspace, you need to update t
 ```json
 // nx.json
 {
-  "targetDefaults": {
-    "build": {
+  "targetDefaults": [
+    {
+      "target": "build",
       "options": {
         "assetsInlineLimit": 2048,
         "assetsDir": "static/assets"
       }
     }
-  }
+  ]
 }
 ```
 
@@ -245,13 +246,14 @@ To provide the same args for all projects in the workspace, you need to update t
 ```json
 // nx.json
 {
-  "targetDefaults": {
-    "build": {
+  "targetDefaults": [
+    {
+      "target": "build",
       "options": {
         "args": ["--assetsInlineLimit=2048", "--assetsDir=static/assets"]
       }
     }
-  }
+  ]
 }
 ```
 

--- a/astro-docs/src/content/docs/guides/Tasks & Caching/reduce-repetitive-configuration.mdoc
+++ b/astro-docs/src/content/docs/guides/Tasks & Caching/reduce-repetitive-configuration.mdoc
@@ -6,7 +6,7 @@ filter: 'type:Guides'
 
 Nx can help you dramatically reduce the lines of configuration code that you need to maintain.
 
-Lets say you have three libraries in your repository - `lib1`, `lib2` and `lib3`. The folder structure looks like this:
+Say you have three libraries in your repository - `lib1`, `lib2` and `lib3`. The folder structure looks like this:
 
 {% filetree %}
 
@@ -178,13 +178,14 @@ If you scan through these three files, they look very similar. The only differen
 
 ## Reduce configuration with targetDefaults
 
-Let's use [the `targetDefaults` property](/docs/reference/nx-json#target-defaults) in `nx.json` to reduce some of this duplicate configuration code.
+Use [the `targetDefaults` property](/docs/reference/nx-json#target-defaults) in `nx.json` to reduce some of this duplicate configuration code.
 
 ```json
 // nx.json
 {
-  "targetDefaults": {
-    "build": {
+  "targetDefaults": [
+    {
+      "target": "build",
       "executor": "@nx/js:tsc",
       "outputs": ["{options.outputPath}"],
       "options": {
@@ -194,14 +195,16 @@ Let's use [the `targetDefaults` property](/docs/reference/nx-json#target-default
         "assets": ["{projectRoot}/*.md"]
       }
     },
-    "lint": {
+    {
+      "target": "lint",
       "executor": "@nx/eslint:lint",
       "outputs": ["{options.outputFile}"],
       "options": {
         "lintFilePatterns": ["{projectRoot}/**/*.ts"]
       }
     },
-    "test": {
+    {
+      "target": "test",
       "executor": "@nx/jest:jest",
       "outputs": ["{workspaceRoot}/coverage/{projectRoot}"],
       "options": {
@@ -215,7 +218,7 @@ Let's use [the `targetDefaults` property](/docs/reference/nx-json#target-default
         }
       }
     }
-  }
+  ]
 }
 ```
 
@@ -290,12 +293,12 @@ Now the `project.json` files can be reduced to this:
 {% /tabs %}
 
 {% aside type="caution" title="Target defaults" %}
-This recipe assumes every target with the same name uses the same executor. If you have targets with the same name using different executors and you're providing target defaults for executor options, don't place the executor options under a default target using the target name as the key. Instead, separate target default configurations can be added using the executors as the keys, each with their specific configuration.
+This recipe assumes every target with the same name uses the same executor. If targets with the same name use different executors, don't set executor-specific options on an entry that matches on `target` alone. Instead, add a separate entry for each executor that matches on `executor`, each with its own configuration. Entries can also be scoped with the `projects` and `plugin` filters described in the [nx.json reference](/docs/reference/nx-json#target-defaults).
 {% /aside %}
 
 ## Ramifications
 
-This change adds 33 lines of code to `nx.json` and removes 84 lines of code from the `project.json` files. That's a net reduction of 51 lines of code. And you'll get more benefits from this strategy the more projects you have in your repo.
+This change adds 36 lines of code to `nx.json` and removes 84 lines of code from the `project.json` files. That's a net reduction of 48 lines of code. And you'll get more benefits from this strategy the more projects you have in your repo.
 
 Reducing lines of code is nice, but just like using the DRY principle in code, there are other benefits:
 

--- a/astro-docs/src/content/docs/reference/nx-json.mdoc
+++ b/astro-docs/src/content/docs/reference/nx-json.mdoc
@@ -207,14 +207,7 @@ Tells Nx which base branch to use when calculating affected projects.
 
 ## Target defaults
 
-Target defaults provide ways to set common options for a particular target in your workspace. When building your project's configuration, we merge it with up to 1 default from this map. For a given target, we look at its name and its executor. We then check target defaults looking for a configuration whose key matches any of the following:
-
-- `` `${executor}` ``
-- `` `${targetName}` `` (if the configuration specifies the executor, this needs to match the target's executor as well)
-
-Additionally, if there is not a match for either of the above, we look for other keys that may match the target name via a glob pattern. For example, a key in the target defaults that looks like `e2e-ci--**/**` would match all of the targets created by a task atomizer plugin.
-
-Target defaults matching the executor takes precedence over those matching the target name. If we find a target default for a given target, we use it as the base for that target's configuration.
+Target defaults provide ways to set common options for a particular target in your workspace. When Nx builds a project's configuration, it merges each target with at most one matching entry from `targetDefaults` and uses that entry as the base for the target's configuration. To find the matching entry, Nx compares the target's name and executor against each entry and selects the most specific match.
 
 `targetDefaults` is an array of entries. Each entry must specify at least one of `target` (name or glob), `executor`, `projects`, or `plugin`. Optional `projects` and `plugin` filters let you scope a default to a subset of projects or targets inferred by a particular plugin.
 
@@ -226,7 +219,7 @@ Target defaults matching the executor takes precedence over those matching the t
 | `plugin`   | `string`                                                                     | Optional. Restricts the default to targets originated by a specific plugin (e.g. `@nx/vite`). Useful when two plugins expose a target with the same name (e.g. `@nx/vite:test` and `@nx/jest:test` both as `test`). |
 | other      | any field from [Target Configuration](/docs/reference/project-configuration) | The defaults applied when the filter matches.                                                                                                                                                                       |
 
-When multiple entries match a given `(target, project)` tuple, the **most specific** entry wins (`target + projects + plugin` > `target + projects` > `target + plugin` > `target` alone). Within the same specificity tier, an exact `target` match beats a glob match, and later entries in the array beat earlier ones.
+When multiple entries match a given `(target, project)` tuple, the **most specific** entry wins (`target + projects + plugin` > `target + projects` > `target + plugin` > `target` alone). Within the same specificity tier, an entry matching both `target` and `executor` beats an executor-only match, which beats an exact `target` match, which in turn beats a glob match. Later entries in the array beat earlier ones.
 
 ```json
 // nx.json — polyglot example
@@ -944,7 +937,7 @@ You can configure [Docker release](/docs/guides/nx-release/release-docker-images
 }
 ```
 
-This allows you to have other releases such as [NPM](/docs/guides/nx-release/release-npm-packages) or [Rust crates](/docs/guides/nx-release/publish-rust-crates) in the same workspace.
+You can combine this with other releases such as [NPM](/docs/guides/nx-release/release-npm-packages) or [Rust crates](/docs/guides/nx-release/publish-rust-crates) in the same workspace.
 
 ## Sync
 

--- a/astro-docs/src/content/docs/technologies/angular/Guides/setup-incremental-builds-angular.mdoc
+++ b/astro-docs/src/content/docs/technologies/angular/Guides/setup-incremental-builds-angular.mdoc
@@ -209,11 +209,12 @@ required executors you can add it to the `targetDefaults` section of the `nx.jso
 ```json
 // nx.json
 {
-  "targetDefaults": {
-    "@nx/angular:application": {
+  "targetDefaults": [
+    {
+      "executor": "@nx/angular:application",
       "dependsOn": ["^build"]
     }
-  }
+  ]
 }
 ```
 
@@ -223,11 +224,12 @@ required executors you can add it to the `targetDefaults` section of the `nx.jso
 ```json
 // nx.json
 {
-  "targetDefaults": {
-    "@nx/angular:browser-esbuild": {
+  "targetDefaults": [
+    {
+      "executor": "@nx/angular:browser-esbuild",
       "dependsOn": ["^build"]
     }
-  }
+  ]
 }
 ```
 
@@ -237,11 +239,12 @@ required executors you can add it to the `targetDefaults` section of the `nx.jso
 ```json
 // nx.json
 {
-  "targetDefaults": {
-    "@nx/angular:webpack-browser": {
+  "targetDefaults": [
+    {
+      "executor": "@nx/angular:webpack-browser",
       "dependsOn": ["^build"]
     }
-  }
+  ]
 }
 ```
 
@@ -331,14 +334,16 @@ And the `targetDefaults` configured in the `nx.json` as:
 
 ```json
 {
-  "targetDefaults": {
-    "build": {
+  "targetDefaults": [
+    {
+      "target": "build",
       "dependsOn": ["build-base"]
     },
-    "build-base": {
+    {
+      "target": "build-base",
       "dependsOn": ["^build-base"]
     }
-  }
+  ]
 }
 ```
 

--- a/astro-docs/src/content/docs/technologies/module-federation/vite-module-federation.mdoc
+++ b/astro-docs/src/content/docs/technologies/module-federation/vite-module-federation.mdoc
@@ -104,11 +104,15 @@ Nx is not the federation mechanism here. It runs the tasks. The `nx.json` `targe
 
 ```json
 {
-  "targetDefaults": {
-    "dev": { "continuous": true, "dependsOn": ["^build"] },
-    "build": { "dependsOn": ["^build"], "outputs": ["{projectRoot}/dist"] },
-    "preview": { "continuous": true, "dependsOn": ["build"] }
-  }
+  "targetDefaults": [
+    { "target": "dev", "continuous": true, "dependsOn": ["^build"] },
+    {
+      "target": "build",
+      "dependsOn": ["^build"],
+      "outputs": ["{projectRoot}/dist"]
+    },
+    { "target": "preview", "continuous": true, "dependsOn": ["build"] }
+  ]
 }
 ```
 

--- a/benchmarks/nx.json
+++ b/benchmarks/nx.json
@@ -1,7 +1,8 @@
 {
   "$schema": "../node_modules/nx/schemas/nx-schema.json",
-  "targetDefaults": {
-    "build": {
+  "targetDefaults": [
+    {
+      "target": "build",
       "command": "mkdir -p {projectRoot}/dist && cp lorem.md {projectRoot}/dist/output.md",
       "dependsOn": ["^build"],
       "cache": true,
@@ -12,18 +13,20 @@
       ],
       "outputs": ["{projectRoot}/dist"]
     },
-    "cat": {
+    {
+      "target": "cat",
       "command": "cat lorem.md",
       "cache": true,
       "inputs": ["{projectRoot}/**/*", "{workspaceRoot}/lorem.md"]
     },
-    "copy": {
+    {
+      "target": "copy",
       "command": "mkdir -p {projectRoot}/copy-out && cp lorem.md {projectRoot}/copy-out/output.md",
       "cache": true,
       "inputs": ["{projectRoot}/**/*", "{workspaceRoot}/lorem.md"],
       "outputs": ["{projectRoot}/copy-out"]
     }
-  },
+  ],
   "analytics": false,
   "parallel": 5
 }

--- a/packages/angular/src/generators/ng-add/utilities/workspace.ts
+++ b/packages/angular/src/generators/ng-add/utilities/workspace.ts
@@ -71,35 +71,49 @@ export function createNxJson(
           : []),
       ].filter(Boolean),
     },
-    targetDefaults: {
-      build: {
+    targetDefaults: [
+      {
+        target: 'build',
         dependsOn: ['^build'],
         inputs: ['production', '^production'],
         cache: true,
       },
-      test: targets.test
-        ? {
-            inputs: ['default', '^production', '{workspaceRoot}/karma.conf.js'],
-            cache: true,
-          }
-        : undefined,
-      lint: targets.lint
-        ? {
-            inputs: [
-              'default',
-              '{workspaceRoot}/.eslintrc.json',
-              '{workspaceRoot}/eslint.config.cjs',
-            ],
-            cache: true,
-          }
-        : undefined,
-      e2e: targets.e2e
-        ? {
-            inputs: ['default', '^production'],
-            cache: true,
-          }
-        : undefined,
-    },
+      ...(targets.test
+        ? [
+            {
+              target: 'test',
+              inputs: [
+                'default',
+                '^production',
+                '{workspaceRoot}/karma.conf.js',
+              ],
+              cache: true,
+            },
+          ]
+        : []),
+      ...(targets.lint
+        ? [
+            {
+              target: 'lint',
+              inputs: [
+                'default',
+                '{workspaceRoot}/.eslintrc.json',
+                '{workspaceRoot}/eslint.config.cjs',
+              ],
+              cache: true,
+            },
+          ]
+        : []),
+      ...(targets.e2e
+        ? [
+            {
+              target: 'e2e',
+              inputs: ['default', '^production'],
+              cache: true,
+            },
+          ]
+        : []),
+    ],
     defaultProject,
   });
 }

--- a/packages/angular/src/migrations/update-19-6-1/ensure-depends-on-for-mf.spec.ts
+++ b/packages/angular/src/migrations/update-19-6-1/ensure-depends-on-for-mf.spec.ts
@@ -25,7 +25,7 @@ describe('ensure-depends-on-for-mf', () => {
     it('adds dependsOn ^build and the dev-remotes env input when the entry already exists', async () => {
       const tree = createTreeWithEmptyWorkspace();
       const nxJson = readNxJson(tree) as LegacyNxJson;
-      nxJson.targetDefaults ??= {};
+      nxJson.targetDefaults = {};
       nxJson.targetDefaults[WEBPACK_EXECUTOR] = {
         inputs: ['production', '^production'],
       };
@@ -61,7 +61,7 @@ describe('ensure-depends-on-for-mf', () => {
     it('appends ^build to dependsOn while preserving other existing deps', async () => {
       const tree = createTreeWithEmptyWorkspace();
       const nxJson = readNxJson(tree) as LegacyNxJson;
-      nxJson.targetDefaults ??= {};
+      nxJson.targetDefaults = {};
       nxJson.targetDefaults[WEBPACK_EXECUTOR] = {
         inputs: ['production', '^production'],
         dependsOn: ['some-task'],
@@ -83,7 +83,7 @@ describe('ensure-depends-on-for-mf', () => {
     it('leaves an already-correct entry alone (modulo shape upgrade)', async () => {
       const tree = createTreeWithEmptyWorkspace();
       const nxJson = readNxJson(tree) as LegacyNxJson;
-      nxJson.targetDefaults ??= {};
+      nxJson.targetDefaults = {};
       nxJson.targetDefaults[WEBPACK_EXECUTOR] = {
         inputs: ['production', '^production', NX_MF_DEV_REMOTES],
         dependsOn: ['^build'],

--- a/packages/angular/src/migrations/update-20-2-0/remove-tailwind-config-from-ng-packagr-executors.spec.ts
+++ b/packages/angular/src/migrations/update-20-2-0/remove-tailwind-config-from-ng-packagr-executors.spec.ts
@@ -138,7 +138,7 @@ describe('remove-tailwind-config-from-ng-packagr-executors migration', () => {
     'should delete "tailwindConfig" option in nx.json target defaults for a target with the "%s" executor',
     async (executor) => {
       updateJson<LegacyNxJson>(tree, 'nx.json', (json) => {
-        json.targetDefaults ??= {};
+        json.targetDefaults = {};
         json.targetDefaults.build = {
           executor,
           options: {
@@ -178,7 +178,7 @@ describe('remove-tailwind-config-from-ng-packagr-executors migration', () => {
     'should delete empty target defaults for a target with the "%s" executor',
     async (executor) => {
       updateJson<LegacyNxJson>(tree, 'nx.json', (json) => {
-        json.targetDefaults ??= {};
+        json.targetDefaults = {};
         json.targetDefaults.build = {
           executor,
           options: {
@@ -199,7 +199,7 @@ describe('remove-tailwind-config-from-ng-packagr-executors migration', () => {
       await migration(tree);
 
       const nxJson = readJson<LegacyNxJson>(tree, 'nx.json');
-      expect(nxJson.targetDefaults.build).toBeUndefined();
+      expect(nxJson.targetDefaults?.build).toBeUndefined();
     }
   );
 
@@ -207,7 +207,7 @@ describe('remove-tailwind-config-from-ng-packagr-executors migration', () => {
     'should delete "tailwindConfig" option in nx.json target defaults for the "%s" executor',
     async (executor) => {
       updateJson<LegacyNxJson>(tree, 'nx.json', (json) => {
-        json.targetDefaults ??= {};
+        json.targetDefaults = {};
         json.targetDefaults[executor] = {
           options: {
             project: '{projectRoot}/ng-package.json',
@@ -247,7 +247,7 @@ describe('remove-tailwind-config-from-ng-packagr-executors migration', () => {
     'should delete empty target defaults for a target with the "%s" executor',
     async (executor) => {
       updateJson<LegacyNxJson>(tree, 'nx.json', (json) => {
-        json.targetDefaults ??= {};
+        json.targetDefaults = {};
         json.targetDefaults[executor] = {
           options: {
             tailwindConfig: '{projectRoot}/tailwind.config.js',
@@ -267,8 +267,7 @@ describe('remove-tailwind-config-from-ng-packagr-executors migration', () => {
       await migration(tree);
 
       const nxJson = readJson<LegacyNxJson>(tree, 'nx.json');
-      console.log(nxJson.targetDefaults);
-      expect(nxJson.targetDefaults[executor]).toBeUndefined();
+      expect(nxJson.targetDefaults?.[executor]).toBeUndefined();
     }
   );
 

--- a/packages/cypress/src/generators/convert-to-inferred/convert-to-inferred.spec.ts
+++ b/packages/cypress/src/generators/convert-to-inferred/convert-to-inferred.spec.ts
@@ -15,6 +15,7 @@ import {
   type Tree,
   updateNxJson,
   writeJson,
+  type TargetDefaultEntry,
 } from '@nx/devkit';
 import { TempFs } from '@nx/devkit/internal-testing-utils';
 import { join } from 'node:path';
@@ -246,10 +247,11 @@ describe('Cypress - Convert Executors To Plugin', () => {
       updateProjectConfiguration(tree, project.name, project);
       createTestProject(tree, { appRoot: 'second', appName: 'second' });
       const nxJson = readNxJson(tree);
-      nxJson.targetDefaults ??= {};
-      nxJson.targetDefaults['@nx/cypress:cypress'] = {
+      nxJson.targetDefaults ??= [];
+      (nxJson.targetDefaults as TargetDefaultEntry[]).push({
+        executor: '@nx/cypress:cypress',
         inputs: ['default', '^default'],
-      };
+      });
       updateNxJson(tree, nxJson);
 
       await convertToInferred(tree, {
@@ -266,10 +268,11 @@ describe('Cypress - Convert Executors To Plugin', () => {
       const project = createTestProject(tree);
       createTestProject(tree, { appRoot: 'second', appName: 'second' });
       const nxJson = readNxJson(tree);
-      nxJson.targetDefaults ??= {};
-      nxJson.targetDefaults['@nx/cypress:cypress'] = {
+      nxJson.targetDefaults ??= [];
+      (nxJson.targetDefaults as TargetDefaultEntry[]).push({
+        executor: '@nx/cypress:cypress',
         inputs: ['default', '^default', '{workspaceRoot}/some-file.ts'],
-      };
+      });
       updateNxJson(tree, nxJson);
 
       await convertToInferred(tree, {
@@ -291,15 +294,16 @@ describe('Cypress - Convert Executors To Plugin', () => {
       const project = createTestProject(tree);
       createTestProject(tree, { appRoot: 'second', appName: 'second' });
       const nxJson = readNxJson(tree);
-      nxJson.targetDefaults ??= {};
-      nxJson.targetDefaults['@nx/cypress:cypress'] = {
+      nxJson.targetDefaults ??= [];
+      (nxJson.targetDefaults as TargetDefaultEntry[]).push({
+        executor: '@nx/cypress:cypress',
         inputs: [
           'default',
           '^default',
           '{workspaceRoot}/some-file.ts',
           { externalDependencies: ['some-external-dep'] },
         ],
-      };
+      });
       updateNxJson(tree, nxJson);
 
       await convertToInferred(tree, {
@@ -321,15 +325,16 @@ describe('Cypress - Convert Executors To Plugin', () => {
       const project = createTestProject(tree);
       createTestProject(tree, { appRoot: 'second', appName: 'second' });
       const nxJson = readNxJson(tree);
-      nxJson.targetDefaults ??= {};
-      nxJson.targetDefaults['@nx/cypress:cypress'] = {
+      nxJson.targetDefaults ??= [];
+      (nxJson.targetDefaults as TargetDefaultEntry[]).push({
+        executor: '@nx/cypress:cypress',
         inputs: [
           'default',
           '^default',
           '{workspaceRoot}/some-file.ts',
           { externalDependencies: ['cypress', 'some-external-dep'] },
         ],
-      };
+      });
       updateNxJson(tree, nxJson);
 
       await convertToInferred(tree, {
@@ -580,12 +585,13 @@ describe('Cypress - Convert Executors To Plugin', () => {
     it('should add Cypress options found in targetDefaults for the executor to the project.json', async () => {
       // ARRANGE
       const nxJson = readNxJson(tree);
-      nxJson.targetDefaults ??= {};
-      nxJson.targetDefaults['@nx/cypress:cypress'] = {
+      nxJson.targetDefaults ??= [];
+      (nxJson.targetDefaults as TargetDefaultEntry[]).push({
+        executor: '@nx/cypress:cypress',
         options: {
           exit: false,
         },
-      };
+      });
       updateNxJson(tree, nxJson);
       const project = createTestProject(tree);
 

--- a/packages/cypress/src/generators/init/init.spec.ts
+++ b/packages/cypress/src/generators/init/init.spec.ts
@@ -119,14 +119,16 @@ describe('init', () => {
             "plugin": "@nx/cypress/plugin",
           },
         ],
-        "targetDefaults": {
-          "build": {
+        "targetDefaults": [
+          {
             "cache": true,
+            "target": "build",
           },
-          "lint": {
+          {
             "cache": true,
+            "target": "lint",
           },
-        },
+        ],
       }
     `);
   });

--- a/packages/cypress/src/migrations/update-21-0-0/remove-tsconfig-and-copy-files-options-from-cypress-executor.spec.ts
+++ b/packages/cypress/src/migrations/update-21-0-0/remove-tsconfig-and-copy-files-options-from-cypress-executor.spec.ts
@@ -163,7 +163,7 @@ describe('remove-tsconfig-and-copy-files-options-from-cypress-executor', () => {
 
   it('should remove tsConfig and copyFiles options in nx.json target defaults for a target with the cypress executor', async () => {
     updateJson<LegacyNxJson>(tree, 'nx.json', (json) => {
-      json.targetDefaults ??= {};
+      json.targetDefaults = {};
       json.targetDefaults.e2e = {
         executor: '@nx/cypress:cypress',
         options: {
@@ -205,7 +205,7 @@ describe('remove-tsconfig-and-copy-files-options-from-cypress-executor', () => {
 
   it('should remove tsConfig and copyFiles options in nx.json target defaults for the cypress executor', async () => {
     updateJson<LegacyNxJson>(tree, 'nx.json', (json) => {
-      json.targetDefaults ??= {};
+      json.targetDefaults = {};
       json.targetDefaults['@nx/cypress:cypress'] = {
         options: {
           cypressConfig: '{projectRoot}/cypress.config.ts',

--- a/packages/detox/assets.json
+++ b/packages/detox/assets.json
@@ -10,6 +10,9 @@
     {
       "glob": "src/**/schema.d.ts"
     },
+    {
+      "glob": "src/migrations/**/*.md"
+    },
     "LICENSE"
   ]
 }

--- a/packages/devkit/src/generators/e2e-web-server-info-utils.spec.ts
+++ b/packages/devkit/src/generators/e2e-web-server-info-utils.spec.ts
@@ -14,7 +14,12 @@ jest.mock(
 );
 
 import { createTreeWithEmptyWorkspace } from 'nx/src/devkit-testing-exports';
-import { type Tree, readNxJson, updateNxJson } from 'nx/src/devkit-exports';
+import {
+  type TargetDefaultEntry,
+  type Tree,
+  readNxJson,
+  updateNxJson,
+} from 'nx/src/devkit-exports';
 import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
 import { getE2EWebServerInfo } from './e2e-web-server-info-utils';
 
@@ -167,12 +172,13 @@ describe('getE2EWebServerInfo', () => {
         previewTargetName: 'vite:preview',
       },
     });
-    nxJson.targetDefaults ??= {};
-    nxJson.targetDefaults['vite:serve'] = {
+    nxJson.targetDefaults ??= [];
+    (nxJson.targetDefaults as TargetDefaultEntry[]).push({
+      target: 'vite:serve',
       options: {
         port: 4400,
       },
-    };
+    });
     updateNxJson(tree, nxJson);
 
     // ACT

--- a/packages/docker/assets.json
+++ b/packages/docker/assets.json
@@ -5,6 +5,7 @@
     { "glob": "**/files/**/.gitkeep" },
     { "glob": "src/**/schema.json" },
     { "glob": "src/**/schema.d.ts" },
+    { "glob": "src/migrations/**/*.md" },
     "LICENSE"
   ]
 }

--- a/packages/eslint/src/generators/convert-to-inferred/convert-to-inferred.spec.ts
+++ b/packages/eslint/src/generators/convert-to-inferred/convert-to-inferred.spec.ts
@@ -10,6 +10,7 @@ import {
   type ProjectConfiguration,
   type ProjectGraph,
   type Tree,
+  type TargetDefaultEntry,
 } from '@nx/devkit';
 import { TempFs } from '@nx/devkit/internal-testing-utils';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
@@ -546,10 +547,11 @@ describe('Eslint - Convert Executors To Plugin', () => {
       updateProjectConfiguration(tree, project.name, project);
       createTestProject(tree, { appRoot: 'second', appName: 'second' });
       const nxJson = readNxJson(tree);
-      nxJson.targetDefaults ??= {};
-      nxJson.targetDefaults['@nx/eslint:lint'] = {
+      nxJson.targetDefaults ??= [];
+      (nxJson.targetDefaults as TargetDefaultEntry[]).push({
+        executor: '@nx/eslint:lint',
         inputs: ['default', '^default', '{projectRoot}/.eslintrc.json'],
-      };
+      });
       updateNxJson(tree, nxJson);
 
       await convertToInferred(tree, {
@@ -566,15 +568,16 @@ describe('Eslint - Convert Executors To Plugin', () => {
       const project = createTestProject(tree);
       createTestProject(tree, { appRoot: 'second', appName: 'second' });
       const nxJson = readNxJson(tree);
-      nxJson.targetDefaults ??= {};
-      nxJson.targetDefaults['@nx/eslint:lint'] = {
+      nxJson.targetDefaults ??= [];
+      (nxJson.targetDefaults as TargetDefaultEntry[]).push({
+        executor: '@nx/eslint:lint',
         inputs: [
           'default',
           '{projectRoot}/.eslintrc.json',
           '{projectRoot}/.eslintignore',
           '{projectRoot}/eslint.config.cjs',
         ],
-      };
+      });
       updateNxJson(tree, nxJson);
 
       await convertToInferred(tree, {
@@ -597,8 +600,9 @@ describe('Eslint - Convert Executors To Plugin', () => {
       const project = createTestProject(tree);
       createTestProject(tree, { appRoot: 'second', appName: 'second' });
       const nxJson = readNxJson(tree);
-      nxJson.targetDefaults ??= {};
-      nxJson.targetDefaults['@nx/eslint:lint'] = {
+      nxJson.targetDefaults ??= [];
+      (nxJson.targetDefaults as TargetDefaultEntry[]).push({
+        executor: '@nx/eslint:lint',
         inputs: [
           'default',
           '{projectRoot}/.eslintrc.json',
@@ -606,7 +610,7 @@ describe('Eslint - Convert Executors To Plugin', () => {
           '{projectRoot}/eslint.config.cjs',
           { externalDependencies: ['eslint-plugin-react'] },
         ],
-      };
+      });
       updateNxJson(tree, nxJson);
 
       await convertToInferred(tree, {
@@ -629,8 +633,9 @@ describe('Eslint - Convert Executors To Plugin', () => {
       const project = createTestProject(tree);
       createTestProject(tree, { appRoot: 'second', appName: 'second' });
       const nxJson = readNxJson(tree);
-      nxJson.targetDefaults ??= {};
-      nxJson.targetDefaults['@nx/eslint:lint'] = {
+      nxJson.targetDefaults ??= [];
+      (nxJson.targetDefaults as TargetDefaultEntry[]).push({
+        executor: '@nx/eslint:lint',
         inputs: [
           'default',
           '{projectRoot}/.eslintrc.json',
@@ -638,7 +643,7 @@ describe('Eslint - Convert Executors To Plugin', () => {
           '{projectRoot}/eslint.config.cjs',
           { externalDependencies: ['eslint', 'eslint-plugin-react'] },
         ],
-      };
+      });
       updateNxJson(tree, nxJson);
 
       await convertToInferred(tree, {
@@ -972,12 +977,13 @@ describe('Eslint - Convert Executors To Plugin', () => {
     it('should add Eslint options found in targetDefaults for the executor to the project.json', async () => {
       // ARRANGE
       const nxJson = readNxJson(tree);
-      nxJson.targetDefaults ??= {};
-      nxJson.targetDefaults['@nx/eslint:lint'] = {
+      nxJson.targetDefaults ??= [];
+      (nxJson.targetDefaults as TargetDefaultEntry[]).push({
+        executor: '@nx/eslint:lint',
         options: {
           maxWarnings: 10,
         },
-      };
+      });
       updateNxJson(tree, nxJson);
       const project = createTestProject(tree);
 

--- a/packages/jest/src/generators/convert-to-inferred/convert-to-inferred.spec.ts
+++ b/packages/jest/src/generators/convert-to-inferred/convert-to-inferred.spec.ts
@@ -10,6 +10,7 @@ import {
   type ProjectConfiguration,
   type ProjectGraph,
   type Tree,
+  type TargetDefaultEntry,
 } from '@nx/devkit';
 import { TempFs } from '@nx/devkit/internal-testing-utils';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
@@ -350,10 +351,11 @@ describe('Jest - Convert Executors To Plugin', () => {
       });
       const project2TestTarget = project2.targets.test;
       const nxJson = readNxJson(tree);
-      nxJson.targetDefaults ??= {};
-      nxJson.targetDefaults['@nx/jest:jest'] = {
+      nxJson.targetDefaults ??= [];
+      (nxJson.targetDefaults as TargetDefaultEntry[]).push({
+        executor: '@nx/jest:jest',
         options: { passWithNoTests: true },
-      };
+      });
       updateNxJson(tree, nxJson);
 
       await convertToInferred(tree, {

--- a/packages/jest/src/migrations/update-23-0-0/migrate-jest-executor-setup-file.md
+++ b/packages/jest/src/migrations/update-23-0-0/migrate-jest-executor-setup-file.md
@@ -106,17 +106,18 @@ Remove the option from a target default using the `@nx/jest:jest` executor:
 
 ##### Before
 
-```json title="nx.json" {7}
+```json title="nx.json" {8}
 {
-  "targetDefaults": {
-    "test": {
+  "targetDefaults": [
+    {
+      "target": "test",
       "executor": "@nx/jest:jest",
       "options": {
         "jestConfig": "{projectRoot}/jest.config.ts",
         "setupFile": "{projectRoot}/src/test-setup.ts"
       }
     }
-  }
+  ]
 }
 ```
 
@@ -124,33 +125,35 @@ Remove the option from a target default using the `@nx/jest:jest` executor:
 
 ```json title="nx.json"
 {
-  "targetDefaults": {
-    "test": {
+  "targetDefaults": [
+    {
+      "target": "test",
       "executor": "@nx/jest:jest",
       "options": {
         "jestConfig": "{projectRoot}/jest.config.ts"
       }
     }
-  }
+  ]
 }
 ```
 
 Per-project paths don't make sense as workspace defaults, so the option is removed without rewriting individual project Jest configs. A warning is logged so the setup file path can be added to each project's Jest config manually if needed.
 
-Remove the option from a target default using the `@nx/jest:jest` executor as the key:
+Remove the option from a target default entry matching on the `@nx/jest:jest` executor:
 
 ##### Before
 
-```json title="nx.json" {6}
+```json title="nx.json" {7}
 {
-  "targetDefaults": {
-    "@nx/jest:jest": {
+  "targetDefaults": [
+    {
+      "executor": "@nx/jest:jest",
       "options": {
         "jestConfig": "{projectRoot}/jest.config.ts",
         "setupFile": "{projectRoot}/src/test-setup.ts"
       }
     }
-  }
+  ]
 }
 ```
 
@@ -158,12 +161,13 @@ Remove the option from a target default using the `@nx/jest:jest` executor as th
 
 ```json title="nx.json"
 {
-  "targetDefaults": {
-    "@nx/jest:jest": {
+  "targetDefaults": [
+    {
+      "executor": "@nx/jest:jest",
       "options": {
         "jestConfig": "{projectRoot}/jest.config.ts"
       }
     }
-  }
+  ]
 }
 ```

--- a/packages/js/src/migrations/update-22-0-0/remove-external-options-from-js-executors.spec.ts
+++ b/packages/js/src/migrations/update-22-0-0/remove-external-options-from-js-executors.spec.ts
@@ -4,6 +4,7 @@ import {
   readProjectConfiguration,
   updateJson,
   type NxJsonConfiguration,
+  type TargetDefaultEntry,
   type TargetDefaultsRecord,
   type Tree,
 } from '@nx/devkit';
@@ -14,7 +15,8 @@ import migration, {
 } from './remove-external-options-from-js-executors';
 
 // This migration ran before targetDefaults supported the array shape, so
-// the test fixtures all use the legacy record shape.
+// most fixtures use the legacy record shape; workspaces migrating late may
+// already be on the array shape, which is covered as well.
 type LegacyNxJson = Omit<NxJsonConfiguration, 'targetDefaults'> & {
   targetDefaults?: TargetDefaultsRecord;
 };
@@ -169,7 +171,7 @@ describe('remove-external-options-from-js-executors migration', () => {
     'should delete "external" and "externalBuildTargets" options in nx.json target defaults for a target with the "%s" executor',
     async (executor) => {
       updateJson<LegacyNxJson>(tree, 'nx.json', (json) => {
-        json.targetDefaults ??= {};
+        json.targetDefaults = {};
         json.targetDefaults.build = {
           executor,
           options: {
@@ -223,7 +225,7 @@ describe('remove-external-options-from-js-executors migration', () => {
     'should remove empty options but keep empty configurations for a target with the "%s" executor',
     async (executor) => {
       updateJson<LegacyNxJson>(tree, 'nx.json', (json) => {
-        json.targetDefaults ??= {};
+        json.targetDefaults = {};
         json.targetDefaults.build = {
           executor,
           options: {
@@ -261,7 +263,7 @@ describe('remove-external-options-from-js-executors migration', () => {
     'should delete "external" and "externalBuildTargets" options in nx.json target defaults for the "%s" executor',
     async (executor) => {
       updateJson<LegacyNxJson>(tree, 'nx.json', (json) => {
-        json.targetDefaults ??= {};
+        json.targetDefaults = {};
         json.targetDefaults[executor] = {
           options: {
             main: '{projectRoot}/src/index.ts',
@@ -313,21 +315,28 @@ describe('remove-external-options-from-js-executors migration', () => {
   it.each(executors)(
     'should only delete target defaults for the "%s" executor when nothing remains after migration',
     async (executor) => {
-      updateJson<LegacyNxJson>(tree, 'nx.json', (json) => {
-        json.targetDefaults ??= {};
-        json.targetDefaults[executor] = {
-          options: {
-            external: ['react'],
-            externalBuildTargets: ['build'],
+      updateJson<NxJsonConfiguration>(tree, 'nx.json', (json) => {
+        json.targetDefaults = [
+          { target: 'build', cache: true },
+          {
+            executor,
+            options: {
+              external: ['react'],
+              externalBuildTargets: ['build'],
+            },
           },
-        };
+        ];
         return json;
       });
 
       await migration(tree);
 
-      const nxJson = readJson<LegacyNxJson>(tree, 'nx.json');
-      expect(nxJson.targetDefaults[executor]).toBeUndefined();
+      const nxJson = readJson<NxJsonConfiguration>(tree, 'nx.json');
+      expect(
+        (nxJson.targetDefaults as TargetDefaultEntry[]).some(
+          (td) => td.executor === executor
+        )
+      ).toBe(false);
     }
   );
 });

--- a/packages/maven/assets.json
+++ b/packages/maven/assets.json
@@ -3,6 +3,7 @@
   "assets": [
     { "glob": "**/files/**", "input": "packages/maven/src" },
     { "glob": "**/schema.json", "input": "packages/maven/src" },
+    { "glob": "migrations/**/*.md", "input": "packages/maven/src" },
     { "glob": "@(generators|executors).json" },
     {
       "glob": "**/*.jar",

--- a/packages/maven/eslint.config.mjs
+++ b/packages/maven/eslint.config.mjs
@@ -10,7 +10,7 @@ export default [
         'error',
         {
           buildTargets: ['build-base'],
-          ignoredDependencies: ['nx'],
+          ignoredDependencies: ['nx', 'typescript'],
         },
       ],
     },

--- a/packages/maven/migrations.json
+++ b/packages/maven/migrations.json
@@ -60,6 +60,12 @@
       "version": "22.7.0-beta.11",
       "description": "Update Maven plugin version from 0.0.16 to 0.0.17 in pom.xml files",
       "factory": "./dist/migrations/0-0-17/update-pom-xml-version"
+    },
+    "update-23-0-0-migrate-create-nodes-v2-import": {
+      "version": "23.0.0-beta.26",
+      "description": "Rename imports of `createNodesV2` from `@nx/maven` to the canonical `createNodes` export.",
+      "implementation": "./dist/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
+      "documentation": "./dist/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"
     }
   }
 }

--- a/packages/maven/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md
+++ b/packages/maven/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md
@@ -1,0 +1,25 @@
+#### Rename `createNodesV2` imports to `createNodes`
+
+`@nx/maven` renamed its primary inferred-plugin export from `createNodesV2` to `createNodes`. The `createNodesV2` name is preserved as a deprecated alias for now, but new code should use `createNodes`.
+
+This migration scans every `.ts`, `.tsx`, `.cts`, and `.mts` file in your workspace and rewrites named imports and re-exports of `createNodesV2` from `@nx/maven` to `createNodes`.
+
+#### Sample Code Changes
+
+##### Before
+
+```ts
+import { createNodesV2 } from '@nx/maven';
+```
+
+##### After
+
+```ts
+import { createNodes } from '@nx/maven';
+```
+
+Aliases are preserved (`createNodesV2 as cn` becomes `createNodes as cn`), and if a file already imports both names (`{ createNodes, createNodesV2 }`) the redundant binding is dropped.
+
+#### What is not rewritten
+
+Only static `import`/`export` named bindings from `@nx/maven` are rewritten. Namespace imports, dynamic `import(...)`, `require(...)` destructuring, and property access such as `plugin.createNodesV2` are left untouched — they keep working through the `createNodesV2` runtime alias. Update those by hand if you want to drop the deprecated name everywhere.

--- a/packages/maven/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.spec.ts
+++ b/packages/maven/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.spec.ts
@@ -1,0 +1,244 @@
+import { type Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migration, {
+  rewriteCreateNodesV2Imports,
+} from './migrate-create-nodes-v2-to-create-nodes';
+
+const SPECIFIERS = new Set(['@nx/maven']);
+const rewrite = (source: string) =>
+  rewriteCreateNodesV2Imports(source, SPECIFIERS);
+
+describe('migrate-create-nodes-v2-to-create-nodes migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  describe('rewriteCreateNodesV2Imports', () => {
+    it('renames a lone createNodesV2 named import', () => {
+      const input = `import { createNodesV2 } from '@nx/maven';\n`;
+      expect(rewrite(input)).toBe(`import { createNodes } from '@nx/maven';\n`);
+    });
+
+    it('preserves other named imports while renaming createNodesV2', () => {
+      const input = `import { createNodesV2, SomeOtherExport } from '@nx/maven';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes, SomeOtherExport } from '@nx/maven';\n`
+      );
+    });
+
+    it('rewrites the original name in `as` aliases', () => {
+      const input = `import { createNodesV2 as cn } from '@nx/maven';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes as cn } from '@nx/maven';\n`
+      );
+    });
+
+    it('collapses a redundant `createNodesV2 as createNodes` alias', () => {
+      const input = `import { createNodesV2 as createNodes } from '@nx/maven';\n`;
+      expect(rewrite(input)).toBe(`import { createNodes } from '@nx/maven';\n`);
+    });
+
+    it('dedupes when both createNodes and createNodesV2 are imported', () => {
+      const input = `import { createNodes, createNodesV2 } from '@nx/maven';\n`;
+      expect(rewrite(input)).toBe(`import { createNodes } from '@nx/maven';\n`);
+    });
+
+    it('dedupes when createNodesV2 precedes createNodes', () => {
+      const input = `import { createNodesV2, createNodes } from '@nx/maven';\n`;
+      expect(rewrite(input)).toBe(`import { createNodes } from '@nx/maven';\n`);
+    });
+
+    it('handles multi-line named imports', () => {
+      const input = `import {\n  createNodes,\n  createNodesV2,\n  SomeOtherExport,\n} from '@nx/maven';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes, SomeOtherExport } from '@nx/maven';\n`
+      );
+    });
+
+    it('preserves a default import alongside the renamed binding', () => {
+      const input = `import def, { createNodesV2 } from '@nx/maven';\n`;
+      expect(rewrite(input)).toBe(
+        `import def, { createNodes } from '@nx/maven';\n`
+      );
+    });
+
+    it('handles `import type` declarations', () => {
+      const input = `import type { createNodesV2 } from '@nx/maven';\n`;
+      expect(rewrite(input)).toBe(
+        `import type { createNodes } from '@nx/maven';\n`
+      );
+    });
+
+    it('preserves inline `type` modifiers', () => {
+      const input = `import { type createNodesV2 } from '@nx/maven';\n`;
+      expect(rewrite(input)).toBe(
+        `import { type createNodes } from '@nx/maven';\n`
+      );
+    });
+
+    it('rewrites named re-exports', () => {
+      const input = `export { createNodesV2 } from '@nx/maven';\n`;
+      expect(rewrite(input)).toBe(`export { createNodes } from '@nx/maven';\n`);
+    });
+
+    it('rewrites aliased named re-exports', () => {
+      const input = `export { createNodesV2 as cn } from '@nx/maven';\n`;
+      expect(rewrite(input)).toBe(
+        `export { createNodes as cn } from '@nx/maven';\n`
+      );
+    });
+
+    it('does not touch createNodesV2 from a different specifier', () => {
+      const input = `import { createNodesV2 } from '@nx/other-plugin/plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not touch createNodesV2 from a relative specifier', () => {
+      const input = `import { createNodesV2 } from './plugin';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not touch unrelated imports from the target specifier', () => {
+      const input = `import { createNodes } from '@nx/maven';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not rewrite `export * from` declarations', () => {
+      const input = `export * from '@nx/maven';\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('leaves createNodesV2 in strings and comments alone', () => {
+      const input =
+        `// import { createNodesV2 } from '@nx/maven';\n` +
+        `const s = "createNodesV2";\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('does not rewrite require() destructuring (still valid via alias)', () => {
+      const input = `const { createNodesV2 } = require('@nx/maven');\n`;
+      expect(rewrite(input)).toBe(input);
+    });
+
+    it('renames value usages of a lone createNodesV2 import', () => {
+      const input =
+        `import { createNodesV2 } from '@nx/maven';\n` +
+        `export const plugin = createNodesV2;\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/maven';\n` +
+          `export const plugin = createNodes;\n`
+      );
+    });
+
+    it('renames a value usage passed as a call argument', () => {
+      const input =
+        `import { createNodesV2 } from '@nx/maven';\n` +
+        `addPlugin(graph, '@nx/maven', createNodesV2, {});\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/maven';\n` +
+          `addPlugin(graph, '@nx/maven', createNodes, {});\n`
+      );
+    });
+
+    it('renames value usages when deduped against an existing createNodes', () => {
+      const input =
+        `import { createNodes, createNodesV2 } from '@nx/maven';\n` +
+        `use(createNodesV2);\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/maven';\n` + `use(createNodes);\n`
+      );
+    });
+
+    it('expands a shorthand property usage to preserve the key', () => {
+      const input =
+        `import { createNodesV2 } from '@nx/maven';\n` +
+        `export const plugins = { createNodesV2 };\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/maven';\n` +
+          `export const plugins = { createNodesV2: createNodes };\n`
+      );
+    });
+
+    it('leaves property accesses and strings while renaming the binding', () => {
+      const input =
+        `import { createNodesV2 } from '@nx/maven';\n` +
+        `const v = createNodesV2;\n` +
+        `const w = config.createNodesV2;\n` +
+        `const s = 'createNodesV2';\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes } from '@nx/maven';\n` +
+          `const v = createNodes;\n` +
+          `const w = config.createNodesV2;\n` +
+          `const s = 'createNodesV2';\n`
+      );
+    });
+
+    it('does not rename usages for an aliased import (local name preserved)', () => {
+      const input =
+        `import { createNodesV2 as cn } from '@nx/maven';\n` +
+        `export const plugin = cn;\n`;
+      expect(rewrite(input)).toBe(
+        `import { createNodes as cn } from '@nx/maven';\n` +
+          `export const plugin = cn;\n`
+      );
+    });
+  });
+
+  describe('migration runner', () => {
+    it('rewrites imports across .ts/.tsx/.cts/.mts files', async () => {
+      tree.write(
+        'libs/foo/src/a.ts',
+        `import { createNodesV2 } from '@nx/maven';\n`
+      );
+      tree.write(
+        'libs/foo/src/b.tsx',
+        `import { createNodesV2 as cn } from '@nx/maven';\n`
+      );
+      tree.write(
+        'libs/foo/src/c.cts',
+        `export { createNodesV2 } from '@nx/maven';\n`
+      );
+      tree.write(
+        'libs/foo/src/d.mts',
+        `import { createNodesV2, SomeOtherExport } from '@nx/maven';\n`
+      );
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/a.ts', 'utf-8')).toContain(
+        `import { createNodes } from '@nx/maven';`
+      );
+      expect(tree.read('libs/foo/src/b.tsx', 'utf-8')).toContain(
+        `import { createNodes as cn } from '@nx/maven';`
+      );
+      expect(tree.read('libs/foo/src/c.cts', 'utf-8')).toContain(
+        `export { createNodes } from '@nx/maven';`
+      );
+      expect(tree.read('libs/foo/src/d.mts', 'utf-8')).toContain(
+        `import { createNodes, SomeOtherExport } from '@nx/maven';`
+      );
+    });
+
+    it('does not touch files without the deprecated name', async () => {
+      const content = `import { createNodes } from '@nx/maven';\n`;
+      tree.write('libs/foo/src/index.ts', content);
+
+      await migration(tree);
+
+      expect(tree.read('libs/foo/src/index.ts', 'utf-8')).toBe(content);
+    });
+
+    it('does not rewrite non-TS files', async () => {
+      const md = `Example: \`import { createNodesV2 } from '@nx/maven';\`\n`;
+      tree.write('docs/example.md', md);
+
+      await migration(tree);
+
+      expect(tree.read('docs/example.md', 'utf-8')).toContain(
+        `import { createNodesV2 } from '@nx/maven';`
+      );
+    });
+  });
+});

--- a/packages/maven/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.ts
+++ b/packages/maven/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.ts
@@ -1,0 +1,317 @@
+import {
+  applyChangesToString,
+  ChangeType,
+  ensurePackage,
+  formatFiles,
+  logger,
+  type StringChange,
+  type Tree,
+  visitNotIgnoredFiles,
+} from '@nx/devkit';
+import type {
+  ExportDeclaration,
+  ExportSpecifier,
+  Identifier,
+  ImportDeclaration,
+  ImportSpecifier,
+  NamedExports,
+  NamedImports,
+  Node,
+  SourceFile,
+} from 'typescript';
+
+const TS_EXTENSIONS = ['.ts', '.tsx', '.cts', '.mts'] as const;
+const DEPRECATED_NAME = 'createNodesV2';
+const CANONICAL_NAME = 'createNodes';
+
+// Module specifiers from which `@nx/maven` publicly exposes `createNodesV2`.
+// A named import or re-export of `createNodesV2` from one of these is rewritten
+// to the canonical `createNodes` export.
+const TARGET_SPECIFIERS: ReadonlySet<string> = new Set(['@nx/maven']);
+
+let ts: typeof import('typescript') | undefined;
+
+export default async function migrateCreateNodesV2ToCreateNodes(
+  tree: Tree
+): Promise<void> {
+  let touchedCount = 0;
+
+  visitNotIgnoredFiles(tree, '.', (filePath) => {
+    if (!TS_EXTENSIONS.some((ext) => filePath.endsWith(ext))) {
+      return;
+    }
+    const original = tree.read(filePath, 'utf-8');
+    if (!original || !original.includes(DEPRECATED_NAME)) {
+      return;
+    }
+    const updated = rewriteCreateNodesV2Imports(original, TARGET_SPECIFIERS);
+    if (updated !== original) {
+      tree.write(filePath, updated);
+      touchedCount += 1;
+    }
+  });
+
+  if (touchedCount > 0) {
+    logger.info(
+      `Renamed \`${DEPRECATED_NAME}\` imports to \`${CANONICAL_NAME}\` in ${touchedCount} file(s).`
+    );
+  }
+
+  await formatFiles(tree);
+}
+
+/**
+ * Rewrites named imports and re-exports of `createNodesV2` to `createNodes`
+ * when they come from one of the given module specifiers. Only the named
+ * bindings are touched — the module specifier, the `import`/`export` keyword,
+ * any `type` modifier, and any default import are left untouched.
+ */
+export function rewriteCreateNodesV2Imports(
+  source: string,
+  specifiers: ReadonlySet<string>
+): string {
+  ts ??= ensurePackage<typeof import('typescript')>('typescript', '*');
+  const sourceFile = ts.createSourceFile(
+    'tmp.ts',
+    source,
+    ts.ScriptTarget.Latest,
+    /* setParentNodes */ true,
+    ts.ScriptKind.TSX
+  );
+
+  const changes: StringChange[] = [];
+  let renameLocalUsages = false;
+  for (const stmt of sourceFile.statements) {
+    if (ts.isImportDeclaration(stmt)) {
+      renameLocalUsages =
+        collectImportRewrite(sourceFile, stmt, specifiers, changes) ||
+        renameLocalUsages;
+    } else if (ts.isExportDeclaration(stmt)) {
+      collectExportRewrite(sourceFile, stmt, specifiers, changes);
+    }
+  }
+
+  // Renaming a local `createNodesV2` import binding to `createNodes` (a lone
+  // `{ createNodesV2 }`, or one deduped against an existing `createNodes`)
+  // changes the name in scope, so value references to `createNodesV2` in the
+  // file body must be renamed too — otherwise they dangle. Aliased imports and
+  // re-exports keep their local name, so they never trigger this.
+  if (renameLocalUsages) {
+    collectValueUsageRewrites(sourceFile, changes);
+  }
+
+  return changes.length > 0 ? applyChangesToString(source, changes) : source;
+}
+
+function isTargetSpecifier(
+  node: ImportDeclaration['moduleSpecifier'],
+  specifiers: ReadonlySet<string>
+): boolean {
+  return ts!.isStringLiteral(node) && specifiers.has(node.text);
+}
+
+function collectImportRewrite(
+  sourceFile: SourceFile,
+  stmt: ImportDeclaration,
+  specifiers: ReadonlySet<string>,
+  changes: StringChange[]
+): boolean {
+  if (!isTargetSpecifier(stmt.moduleSpecifier, specifiers)) {
+    return false;
+  }
+  const namedBindings = stmt.importClause?.namedBindings;
+  // Only `import { ... }` carries renameable named bindings. `import x`,
+  // `import * as ns`, and side-effect imports reference the module wholesale
+  // and keep working through the `createNodesV2` runtime alias, so we leave
+  // them be. A mixed `import def, { createNodesV2 }` still has its named
+  // bindings rewritten below — the default binding is untouched.
+  if (!namedBindings || !ts!.isNamedImports(namedBindings)) {
+    return false;
+  }
+  // The local `createNodesV2` binding only disappears when it is imported
+  // without an alias — a lone `{ createNodesV2 }` or one deduped against an
+  // existing `createNodes`. `{ createNodesV2 as x }` keeps the local `x`, so
+  // its in-file usages are unaffected and must not be rewritten.
+  const localBindingRenamed = (
+    namedBindings.elements as readonly ImportSpecifier[]
+  ).some(
+    (el) =>
+      el.name.text === DEPRECATED_NAME &&
+      (el.propertyName ?? el.name).text === DEPRECATED_NAME
+  );
+  rewriteNamedBindings(sourceFile, namedBindings, changes);
+  return localBindingRenamed;
+}
+
+function collectExportRewrite(
+  sourceFile: SourceFile,
+  stmt: ExportDeclaration,
+  specifiers: ReadonlySet<string>,
+  changes: StringChange[]
+): void {
+  if (
+    !stmt.moduleSpecifier ||
+    !isTargetSpecifier(stmt.moduleSpecifier, specifiers)
+  ) {
+    return;
+  }
+  // `export { ... } from '...'` can be rewritten; `export * from '...'` has no
+  // named bindings to rename.
+  if (!stmt.exportClause || !ts!.isNamedExports(stmt.exportClause)) {
+    return;
+  }
+  rewriteNamedBindings(sourceFile, stmt.exportClause, changes);
+}
+
+/**
+ * Re-renders the `{ ... }` of a named import/export, renaming any
+ * `createNodesV2` specifier to `createNodes`. If renaming would collide with a
+ * `createNodes` that is already present (e.g. `{ createNodes, createNodesV2 }`),
+ * the duplicate is dropped. Returns without recording a change when the binding
+ * list contains no `createNodesV2`.
+ */
+function rewriteNamedBindings(
+  sourceFile: SourceFile,
+  namedBindings: NamedImports | NamedExports,
+  changes: StringChange[]
+): void {
+  const elements = namedBindings.elements as readonly (
+    | ImportSpecifier
+    | ExportSpecifier
+  )[];
+  const hasDeprecated = elements.some(
+    (el) => (el.propertyName ?? el.name).text === DEPRECATED_NAME
+  );
+  if (!hasDeprecated) {
+    return;
+  }
+
+  const seen = new Set<string>();
+  const rendered: string[] = [];
+  for (const el of elements) {
+    const text = renderSpecifier(el);
+    if (!seen.has(text)) {
+      seen.add(text);
+      rendered.push(text);
+    }
+  }
+
+  const start = namedBindings.getStart(sourceFile);
+  changes.push(
+    {
+      type: ChangeType.Delete,
+      start,
+      length: namedBindings.getEnd() - start,
+    },
+    {
+      type: ChangeType.Insert,
+      index: start,
+      text: `{ ${rendered.join(', ')} }`,
+    }
+  );
+}
+
+function renderSpecifier(el: ImportSpecifier | ExportSpecifier): string {
+  const typePrefix = el.isTypeOnly ? 'type ' : '';
+  const rename = (name: string) =>
+    name === DEPRECATED_NAME ? CANONICAL_NAME : name;
+
+  // `{ name }` — no alias, so the local binding follows the rename.
+  if (!el.propertyName) {
+    return `${typePrefix}${rename(el.name.text)}`;
+  }
+
+  // `{ propertyName as name }` — only the imported (left) side is renamed; the
+  // local alias is preserved. A now-redundant alias such as
+  // `createNodesV2 as createNodes` collapses to `createNodes`.
+  const canonicalImported = rename(el.propertyName.text);
+  const localName = el.name.text;
+  return canonicalImported === localName
+    ? `${typePrefix}${localName}`
+    : `${typePrefix}${canonicalImported} as ${localName}`;
+}
+
+/**
+ * Renames value references of `createNodesV2` to `createNodes` in the file
+ * body. Only called once a local `createNodesV2` import binding has actually
+ * been renamed, so these references would otherwise dangle. Occurrences that
+ * are not references to that binding are skipped: the import/export
+ * declarations themselves, property accesses (`x.createNodesV2`), qualified
+ * type names, object-literal keys, and declaration names that shadow the
+ * import. A shorthand property (`{ createNodesV2 }`) is expanded to
+ * `{ createNodesV2: createNodes }` so the property key is preserved. Strings
+ * and comments are never `Identifier` nodes, so they are left alone.
+ */
+function collectValueUsageRewrites(
+  sourceFile: SourceFile,
+  changes: StringChange[]
+): void {
+  const visit = (node: Node): void => {
+    if (
+      ts!.isIdentifier(node) &&
+      node.text === DEPRECATED_NAME &&
+      isRenamableValueUsage(node)
+    ) {
+      const start = node.getStart(sourceFile);
+      changes.push(
+        {
+          type: ChangeType.Delete,
+          start,
+          length: node.getEnd() - start,
+        },
+        {
+          type: ChangeType.Insert,
+          index: start,
+          text: ts!.isShorthandPropertyAssignment(node.parent)
+            ? `${DEPRECATED_NAME}: ${CANONICAL_NAME}`
+            : CANONICAL_NAME,
+        }
+      );
+    }
+    node.forEachChild(visit);
+  };
+  sourceFile.forEachChild(visit);
+}
+
+/**
+ * Whether a `createNodesV2` identifier is a value reference to the renamed
+ * import binding, as opposed to a position that must be left untouched.
+ */
+function isRenamableValueUsage(node: Identifier): boolean {
+  const parent = node.parent;
+  if (!parent) {
+    return false;
+  }
+  // Import/export bindings — already handled by the declaration rewrite.
+  if (
+    ts!.isImportSpecifier(parent) ||
+    ts!.isExportSpecifier(parent) ||
+    ts!.isImportClause(parent) ||
+    ts!.isNamespaceImport(parent)
+  ) {
+    return false;
+  }
+  // `x.createNodesV2` / `X.createNodesV2` — a member name, not the binding.
+  if (ts!.isPropertyAccessExpression(parent) && parent.name === node) {
+    return false;
+  }
+  if (ts!.isQualifiedName(parent) && parent.right === node) {
+    return false;
+  }
+  // `{ createNodesV2: ... }` — an object-literal key, not the binding.
+  if (ts!.isPropertyAssignment(parent) && parent.name === node) {
+    return false;
+  }
+  // A declaration whose name shadows the import (variable, param, etc.).
+  if (
+    (ts!.isVariableDeclaration(parent) ||
+      ts!.isParameter(parent) ||
+      ts!.isBindingElement(parent) ||
+      ts!.isFunctionDeclaration(parent) ||
+      ts!.isClassDeclaration(parent)) &&
+    parent.name === node
+  ) {
+    return false;
+  }
+  return true;
+}

--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -791,7 +791,9 @@ export interface NxJsonConfiguration<T = '*' | string[]> {
    */
   namedInputs?: { [inputName: string]: (string | InputDefinition)[] };
   /**
-   * Dependencies between different target names across all projects
+   * Default configuration applied to targets across all projects. Entries
+   * match targets by target name and/or executor, optionally narrowed by
+   * the `projects` and `plugin` filters.
    */
   targetDefaults?: TargetDefaults;
   /**

--- a/packages/nx/src/generators/testing-utils/create-tree-with-empty-workspace.ts
+++ b/packages/nx/src/generators/testing-utils/create-tree-with-empty-workspace.ts
@@ -43,14 +43,16 @@ function addCommonFiles(tree: Tree, addAppsAndLibsFolders: boolean): Tree {
       affected: {
         defaultBase: 'main',
       },
-      targetDefaults: {
-        build: {
+      targetDefaults: [
+        {
+          target: 'build',
           cache: true,
         },
-        lint: {
+        {
+          target: 'lint',
           cache: true,
         },
-      },
+      ],
     })
   );
   tree.write(

--- a/packages/nx/src/hasher/native-task-hasher-impl.spec.ts
+++ b/packages/nx/src/hasher/native-task-hasher-impl.spec.ts
@@ -46,13 +46,14 @@ describe('native task hasher', () => {
       production: ['default'],
       sharedGlobals: [],
     },
-    targetDefaults: {
-      build: {
+    targetDefaults: [
+      {
+        target: 'build',
         cache: true,
         dependsOn: ['^build'],
         inputs: ['production', '^production'],
       },
-    },
+    ],
   };
 
   beforeEach(async () => {
@@ -193,7 +194,7 @@ describe('native task hasher', () => {
             "unrelated:ProjectConfiguration": "11133337791644294114",
             "unrelated:TsConfig": "2264969541778889434",
             "unrelated:libs/unrelated/**/*": "4127219831408253695",
-            "workspace:[{workspaceRoot}/nx.json,{workspaceRoot}/.gitignore,{workspaceRoot}/.nxignore]": "6993407921919898285",
+            "workspace:[{workspaceRoot}/nx.json,{workspaceRoot}/.gitignore,{workspaceRoot}/.nxignore]": "6859150227600641022",
           },
           "inputs": {
             "depOutputs": [],
@@ -220,7 +221,7 @@ describe('native task hasher', () => {
               "echo runtime123",
             ],
           },
-          "value": "15987635381237972716",
+          "value": "5031601627279345290",
         },
       ]
     `);
@@ -284,7 +285,7 @@ describe('native task hasher', () => {
           "parent:ProjectConfiguration": "8031122597231773116",
           "parent:TsConfig": "2264969541778889434",
           "parent:libs/parent/**/*": "17059468255294227635",
-          "workspace:[{workspaceRoot}/nx.json,{workspaceRoot}/.gitignore,{workspaceRoot}/.nxignore]": "6993407921919898285",
+          "workspace:[{workspaceRoot}/nx.json,{workspaceRoot}/.gitignore,{workspaceRoot}/.nxignore]": "6859150227600641022",
         },
         "inputs": {
           "depOutputs": [],
@@ -308,7 +309,7 @@ describe('native task hasher', () => {
           ],
           "runtime": [],
         },
-        "value": "10262178246623018030",
+        "value": "14228125929120094206",
       }
     `);
   });
@@ -959,7 +960,7 @@ describe('native task hasher', () => {
           "parent:ProjectConfiguration": "3608670998275221195",
           "parent:TsConfig": "8661678577354855152",
           "parent:libs/parent/**/*": "17059468255294227635",
-          "workspace:[{workspaceRoot}/nx.json,{workspaceRoot}/.gitignore,{workspaceRoot}/.nxignore]": "6993407921919898285",
+          "workspace:[{workspaceRoot}/nx.json,{workspaceRoot}/.gitignore,{workspaceRoot}/.nxignore]": "6859150227600641022",
         },
         "inputs": {
           "depOutputs": [],
@@ -979,7 +980,7 @@ describe('native task hasher', () => {
           ],
           "runtime": [],
         },
-        "value": "16657264716563422624",
+        "value": "4925424742213548611",
       }
     `);
   });
@@ -1056,7 +1057,7 @@ describe('native task hasher', () => {
           "parent:ProjectConfiguration": "3608670998275221195",
           "parent:TsConfig": "2264969541778889434",
           "parent:libs/parent/**/*": "17059468255294227635",
-          "workspace:[{workspaceRoot}/nx.json,{workspaceRoot}/.gitignore,{workspaceRoot}/.nxignore]": "6993407921919898285",
+          "workspace:[{workspaceRoot}/nx.json,{workspaceRoot}/.gitignore,{workspaceRoot}/.nxignore]": "6859150227600641022",
         },
         "inputs": {
           "depOutputs": [],
@@ -1080,7 +1081,7 @@ describe('native task hasher', () => {
           ],
           "runtime": [],
         },
-        "value": "1325637283470296766",
+        "value": "290026322141806557",
       }
     `);
 
@@ -1101,7 +1102,7 @@ describe('native task hasher', () => {
           "parent:ProjectConfiguration": "3608670998275221195",
           "parent:TsConfig": "2264969541778889434",
           "parent:libs/parent/**/*": "17059468255294227635",
-          "workspace:[{workspaceRoot}/nx.json,{workspaceRoot}/.gitignore,{workspaceRoot}/.nxignore]": "6993407921919898285",
+          "workspace:[{workspaceRoot}/nx.json,{workspaceRoot}/.gitignore,{workspaceRoot}/.nxignore]": "6859150227600641022",
         },
         "inputs": {
           "depOutputs": [],
@@ -1125,7 +1126,7 @@ describe('native task hasher', () => {
           ],
           "runtime": [],
         },
-        "value": "1325637283470296766",
+        "value": "290026322141806557",
       }
     `);
   });

--- a/packages/nx/src/migrations/update-18-0-0/disable-crystal-for-existing-workspaces.spec.ts
+++ b/packages/nx/src/migrations/update-18-0-0/disable-crystal-for-existing-workspaces.spec.ts
@@ -10,14 +10,16 @@ describe('disable crystal for existing workspaces', () => {
         "affected": {
           "defaultBase": "main"
         },
-        "targetDefaults": {
-          "build": {
+        "targetDefaults": [
+          {
+            "target": "build",
             "cache": true
           },
-          "lint": {
+          {
+            "target": "lint",
             "cache": true
           }
-        },
+        ],
         "useInferencePlugins": false
       }
       "

--- a/packages/nx/src/migrations/update-20-0-1/use-legacy-cache.spec.ts
+++ b/packages/nx/src/migrations/update-20-0-1/use-legacy-cache.spec.ts
@@ -19,14 +19,16 @@ describe('use legacy cache', () => {
         "affected": {
           "defaultBase": "main",
         },
-        "targetDefaults": {
-          "build": {
+        "targetDefaults": [
+          {
             "cache": true,
+            "target": "build",
           },
-          "lint": {
+          {
             "cache": true,
+            "target": "lint",
           },
-        },
+        ],
         "useLegacyCache": true,
       }
     `);
@@ -45,14 +47,16 @@ describe('use legacy cache', () => {
         "affected": {
           "defaultBase": "main",
         },
-        "targetDefaults": {
-          "build": {
+        "targetDefaults": [
+          {
             "cache": true,
+            "target": "build",
           },
-          "lint": {
+          {
             "cache": true,
+            "target": "lint",
           },
-        },
+        ],
       }
     `);
   });

--- a/packages/playwright/assets.json
+++ b/packages/playwright/assets.json
@@ -4,6 +4,7 @@
     { "glob": "**/files/**" },
     { "glob": "src/**/schema.json" },
     { "glob": "src/**/schema.d.ts" },
+    { "glob": "src/migrations/**/*.md" },
     { "glob": "PLUGIN.md" },
     "LICENSE"
   ]

--- a/packages/playwright/src/generators/convert-to-inferred/convert-to-inferred.spec.ts
+++ b/packages/playwright/src/generators/convert-to-inferred/convert-to-inferred.spec.ts
@@ -15,6 +15,7 @@ import {
   type Tree,
   updateNxJson,
   writeJson,
+  type TargetDefaultEntry,
 } from '@nx/devkit';
 import { TempFs } from '@nx/devkit/internal-testing-utils';
 import { join } from 'node:path';
@@ -384,10 +385,11 @@ describe('Playwright - Convert Executors To Plugin', () => {
       updateProjectConfiguration(tree, project.name, project);
       createTestProject(tree, { appRoot: 'second', appName: 'second' });
       const nxJson = readNxJson(tree);
-      nxJson.targetDefaults ??= {};
-      nxJson.targetDefaults['@nx/playwright:playwright'] = {
+      nxJson.targetDefaults ??= [];
+      (nxJson.targetDefaults as TargetDefaultEntry[]).push({
+        executor: '@nx/playwright:playwright',
         inputs: ['default', '^default'],
-      };
+      });
       updateNxJson(tree, nxJson);
 
       await convertToInferred(tree, {
@@ -406,10 +408,11 @@ describe('Playwright - Convert Executors To Plugin', () => {
       updateProjectConfiguration(tree, project.name, project);
       createTestProject(tree, { appRoot: 'second', appName: 'second' });
       const nxJson = readNxJson(tree);
-      nxJson.targetDefaults ??= {};
-      nxJson.targetDefaults['@nx/playwright:playwright'] = {
+      nxJson.targetDefaults ??= [];
+      (nxJson.targetDefaults as TargetDefaultEntry[]).push({
+        executor: '@nx/playwright:playwright',
         inputs: ['default', '^default', '{workspaceRoot}/some-file.ts'],
-      };
+      });
       updateNxJson(tree, nxJson);
 
       await convertToInferred(tree, {
@@ -611,12 +614,13 @@ describe('Playwright - Convert Executors To Plugin', () => {
     it('should add Playwright options found in targetDefaults for the executor to the project.json', async () => {
       // ARRANGE
       const nxJson = readNxJson(tree);
-      nxJson.targetDefaults ??= {};
-      nxJson.targetDefaults['@nx/playwright:playwright'] = {
+      nxJson.targetDefaults ??= [];
+      (nxJson.targetDefaults as TargetDefaultEntry[]).push({
+        executor: '@nx/playwright:playwright',
         options: {
           globalTimeout: 100000,
         },
-      };
+      });
       updateNxJson(tree, nxJson);
       const project = createTestProject(tree);
 

--- a/packages/remix/src/generators/convert-to-inferred/convert-to-inferred.spec.ts
+++ b/packages/remix/src/generators/convert-to-inferred/convert-to-inferred.spec.ts
@@ -10,6 +10,7 @@ import {
   type ExpandedPluginConfiguration,
   updateNxJson,
   detectPackageManager,
+  type TargetDefaultEntry,
 } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { TempFs } from '@nx/devkit/internal-testing-utils';
@@ -297,12 +298,13 @@ describe('Remix - Convert To Inferred', () => {
       const project2Targets = project2.targets;
 
       const nxJson = readNxJson(tree);
-      nxJson.targetDefaults ??= {};
-      nxJson.targetDefaults['@nx/remix:build'] = {
+      nxJson.targetDefaults ??= [];
+      (nxJson.targetDefaults as TargetDefaultEntry[]).push({
+        executor: '@nx/remix:build',
         options: {
           sourcemap: true,
         },
-      };
+      });
       updateNxJson(tree, nxJson);
 
       // ACT

--- a/packages/remix/src/generators/init/init.spec.ts
+++ b/packages/remix/src/generators/init/init.spec.ts
@@ -48,14 +48,16 @@ describe('Remix Init Generator', () => {
             "plugin": "@nx/remix/plugin",
           },
         ],
-        "targetDefaults": {
-          "build": {
+        "targetDefaults": [
+          {
             "cache": true,
+            "target": "build",
           },
-          "lint": {
+          {
             "cache": true,
+            "target": "lint",
           },
-        },
+        ],
       }
     `);
   });

--- a/packages/rollup/src/migrations/update-23-0-0/remove-use-legacy-typescript-plugin.md
+++ b/packages/rollup/src/migrations/update-23-0-0/remove-use-legacy-typescript-plugin.md
@@ -43,17 +43,18 @@ Remove `useLegacyTypescriptPlugin` from the `@nx/rollup:rollup` executor target 
 
 ##### Before
 
-```json title="nx.json" {7}
+```json title="nx.json" {8}
 {
-  "targetDefaults": {
-    "@nx/rollup:rollup": {
+  "targetDefaults": [
+    {
+      "executor": "@nx/rollup:rollup",
       "options": {
         "outputPath": "dist/{projectRoot}",
         "tsConfig": "{projectRoot}/tsconfig.lib.json",
         "useLegacyTypescriptPlugin": true
       }
     }
-  }
+  ]
 }
 ```
 
@@ -61,14 +62,15 @@ Remove `useLegacyTypescriptPlugin` from the `@nx/rollup:rollup` executor target 
 
 ```json title="nx.json"
 {
-  "targetDefaults": {
-    "@nx/rollup:rollup": {
+  "targetDefaults": [
+    {
+      "executor": "@nx/rollup:rollup",
       "options": {
         "outputPath": "dist/{projectRoot}",
         "tsConfig": "{projectRoot}/tsconfig.lib.json"
       }
     }
-  }
+  ]
 }
 ```
 

--- a/packages/rsbuild/assets.json
+++ b/packages/rsbuild/assets.json
@@ -5,6 +5,7 @@
     { "glob": "**/files/**/.gitkeep" },
     { "glob": "src/**/schema.json" },
     { "glob": "src/**/schema.d.ts" },
+    { "glob": "src/migrations/**/*.md" },
     "LICENSE"
   ]
 }

--- a/packages/storybook/src/generators/convert-to-inferred/convert-to-inferred.spec.ts
+++ b/packages/storybook/src/generators/convert-to-inferred/convert-to-inferred.spec.ts
@@ -9,6 +9,7 @@ import {
   readNxJson,
   type ExpandedPluginConfiguration,
   updateNxJson,
+  type TargetDefaultEntry,
 } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { TempFs } from '@nx/devkit/internal-testing-utils';
@@ -360,12 +361,13 @@ describe('Storybook - Convert To Inferred', () => {
       const project2Targets = project2.targets;
 
       const nxJson = readNxJson(tree);
-      nxJson.targetDefaults ??= {};
-      nxJson.targetDefaults['@nx/storybook:build'] = {
+      nxJson.targetDefaults ??= [];
+      (nxJson.targetDefaults as TargetDefaultEntry[]).push({
+        executor: '@nx/storybook:build',
         options: {
           webpackStatsJson: true,
         },
-      };
+      });
       updateNxJson(tree, nxJson);
 
       // ACT

--- a/packages/vite/src/generators/convert-to-inferred/convert-to-inferred.spec.ts
+++ b/packages/vite/src/generators/convert-to-inferred/convert-to-inferred.spec.ts
@@ -15,6 +15,7 @@ import {
   type Tree,
   updateNxJson,
   writeJson,
+  type TargetDefaultEntry,
 } from '@nx/devkit';
 import { TempFs } from '@nx/devkit/internal-testing-utils';
 import { join } from 'node:path';
@@ -657,12 +658,13 @@ describe('Vite - Convert Executors To Plugin', () => {
     it('should add Vite options found in targetDefaults for the executor to the project.json', async () => {
       // ARRANGE
       const nxJson = readNxJson(tree);
-      nxJson.targetDefaults ??= {};
-      nxJson.targetDefaults['@nx/vite:build'] = {
+      nxJson.targetDefaults ??= [];
+      (nxJson.targetDefaults as TargetDefaultEntry[]).push({
+        executor: '@nx/vite:build',
         options: {
           mode: 'production',
         },
-      };
+      });
       updateNxJson(tree, nxJson);
       const project = createTestProject(tree);
 

--- a/packages/vite/src/generators/init/init.spec.ts
+++ b/packages/vite/src/generators/init/init.spec.ts
@@ -169,14 +169,16 @@ describe('@nx/vite:init', () => {
               "plugin": "@nx/vite/plugin",
             },
           ],
-          "targetDefaults": {
-            "build": {
+          "targetDefaults": [
+            {
               "cache": true,
+              "target": "build",
             },
-            "lint": {
+            {
               "cache": true,
+              "target": "lint",
             },
-          },
+          ],
         }
       `);
     });

--- a/packages/vitest/src/generators/convert-to-inferred/convert-to-inferred.spec.ts
+++ b/packages/vitest/src/generators/convert-to-inferred/convert-to-inferred.spec.ts
@@ -15,6 +15,7 @@ import {
   type Tree,
   updateNxJson,
   writeJson,
+  type TargetDefaultEntry,
 } from '@nx/devkit';
 import { TempFs } from '@nx/devkit/internal-testing-utils';
 import { join } from 'node:path';
@@ -324,10 +325,11 @@ describe('@nx/vitest:convert-to-inferred', () => {
 
     it('inherits options declared in targetDefaults for the executor', async () => {
       const nxJson = readNxJson(tree);
-      nxJson.targetDefaults ??= {};
-      nxJson.targetDefaults['@nx/vitest:test'] = {
+      nxJson.targetDefaults ??= [];
+      (nxJson.targetDefaults as TargetDefaultEntry[]).push({
+        executor: '@nx/vitest:test',
         options: { watch: false },
-      };
+      });
       updateNxJson(tree, nxJson);
       const project = createTestProject(tree);
 

--- a/packages/workspace/presets/core.json
+++ b/packages/workspace/presets/core.json
@@ -1,9 +1,10 @@
 {
-  "targetDefaults": {
-    "build": {
+  "targetDefaults": [
+    {
+      "target": "build",
       "dependsOn": ["^build"]
     }
-  },
+  ],
   "workspaceLayout": {
     "appsDir": "packages",
     "libsDir": "packages"

--- a/packages/workspace/presets/npm.json
+++ b/packages/workspace/presets/npm.json
@@ -1,7 +1,8 @@
 {
-  "targetDefaults": {
-    "build": {
+  "targetDefaults": [
+    {
+      "target": "build",
       "dependsOn": ["^build"]
     }
-  }
+  ]
 }


### PR DESCRIPTION

- Replace the stale legacy map/key matching prose in the nx.json
  reference's Target defaults section, which contradicted the
  array-shape docs below it, and rewrite it from the tool's
  perspective instead of first person
- Document the full within-tier specificity order (target+executor >
  executor > exact target > glob) in the precedence paragraph
- Convert the Reduce Repetitive Configuration guide's example to the
  array shape, update the same-name/different-executor caution for
  entry-based matching, and recount the Ramifications line totals
- Also fixes up some missing config for migrations after earlier PRs