### PR TITLE
fix(core): allow {projectRoot} after the start of an output when project is at the workspace root

### DIFF
--- a/packages/nx/src/tasks-runner/utils.spec.ts
+++ b/packages/nx/src/tasks-runner/utils.spec.ts
@@ -154,7 +154,7 @@ describe('utils', () => {
       ).toEqual(['dist']);
     });
 
-    it('should throw when {projectRoot} is used not at the beginning and the value is .', () => {
+    it('should interpolate {projectRoot} = . used not at the beginning by normalizing the path', () => {
       const data = {
         name: 'myapp',
         type: 'app',
@@ -162,19 +162,42 @@ describe('utils', () => {
           root: '.',
           targets: {
             build: {
-              outputs: ['test/{projectRoot}'],
+              outputs: ['{workspaceRoot}/test/{projectRoot}'],
             },
           },
           files: [],
         },
       };
-      expect(() =>
+      expect(
         getOutputsForTargetAndConfiguration(
           task.target,
           task.overrides,
           data as any
         )
-      ).toThrow();
+      ).toEqual(['test']);
+    });
+
+    it('should interpolate {projectRoot} = . used in the middle by normalizing the path', () => {
+      const data = {
+        name: 'myapp',
+        type: 'app',
+        data: {
+          root: '.',
+          targets: {
+            build: {
+              outputs: ['{workspaceRoot}/dist/{projectRoot}/sub'],
+            },
+          },
+          files: [],
+        },
+      };
+      expect(
+        getOutputsForTargetAndConfiguration(
+          task.target,
+          task.overrides,
+          data as any
+        )
+      ).toEqual(['dist/sub']);
     });
 
     it('should support interpolation based on options', () => {

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -425,12 +425,6 @@ export function interpolate(template: string, data: any): string {
     );
   }
 
-  if (data.projectRoot == '.' && template.includes('{projectRoot}', 1)) {
-    throw new Error(
-      `Output '${template}' is invalid. When {projectRoot} is '.', it can only be used at the beginning of the expression.`
-    );
-  }
-
   const parts = template.split('/').map((s) => _interpolate(s, data));
 
   return join(...parts).replace('{workspaceRoot}/', '');


### PR DESCRIPTION
## Current Behavior

  When a project sits at the workspace root (`projectRoot` is `.`), any output that uses `{projectRoot}`
  after the start of the expression — e.g. the `targetDefaults` output
  `{workspaceRoot}/test/{projectRoot}` — fails task graph creation with:

  ```
  NX   Output '{workspaceRoot}/test/{projectRoot}' is invalid. When {projectRoot} is '.', it can only be
  used at the beginning of the expression.
  ```

  This commonly bites when a plugin (e.g. `@nx/vitest` via a root `vitest.config.ts`) infers a target
  for the root project and a name-based target default supplies the outputs. Because the error throws
  during task graph creation, it fails any run that includes the root project, and the user can't fix it
  from `targetDefaults` alone since the default is shared by all projects.

  ## Expected Behavior

  `{projectRoot}` is interpolated for root projects regardless of its position, and the resulting path
  is normalized:

  - `{workspaceRoot}/test/{projectRoot}` → `test`
  - `{workspaceRoot}/dist/{projectRoot}/sub` → `dist/sub`

  ### Why removing the guard is safe

  The throw was added in 40b39b2e64 (Dec 2022, alongside the introduction of root/standalone projects)
  for two reasons, and neither holds anymore:

  1. **Path normalization.** At the time, `interpolate()` was a naive string replace, so
  `coverage/{projectRoot}` for a root project would have produced the unnormalized path `coverage/.`.
  #26244 rewrote the function to split segments and `join()` them, which resolves `.` cleanly — the
  beginning-position case (`{projectRoot}/dist` → `dist`) already works this way today.

  2. **Output overlap.** For a root project, `{workspaceRoot}/coverage/{projectRoot}` collapses to
  `coverage`, a parent of every other project's `coverage/<root>` output (which is why that commit also
  migrated the jest defaults to `{projectName}`). But the guard only blocks one spelling of this: a root
  project with `{projectRoot}/coverage` or a literal `{workspaceRoot}/coverage` output produces the
  identical overlap and is allowed today. Nx has no overlap detection for outputs in general —
  overlapping outputs are already permitted everywhere else, while this hard error leaves users of
  shared target defaults with no escape hatch.

  Verified against a minimal reproduction (root project with a `test` target + `"outputs":
  ["{workspaceRoot}/test/{projectRoot}"]` in `targetDefaults`): fails on nx 22.7.5, succeeds with this
  change; non-root projects are unaffected.

  ## Related Issue(s)

  Fixes #35839