### PR TITLE
fix(core): make unit tests pass locally regardless of invoking package manager

### DIFF
--- a/packages/nx/src/generators/utils/nx-json.ts
+++ b/packages/nx/src/generators/utils/nx-json.ts
@@ -46,15 +46,18 @@ export function updateNxJson(tree: Tree, nxJson: NxJsonConfiguration): void {
 
 function readNxJsonExtends(tree: Tree, extendsPath: string) {
   try {
-    return readJson(
-      tree,
-      relative(
-        tree.root,
-        require.resolve(extendsPath, {
-          paths: [tree.root],
-        })
-      )
-    );
+    let resolvedExtendsPath: string;
+    try {
+      resolvedExtendsPath = require.resolve(extendsPath, {
+        paths: [tree.root],
+      });
+    } catch {
+      // Tree roots without a node_modules folder (e.g. the in-memory trees
+      // used in tests) can't anchor module resolution; fall back to
+      // resolving from the running nx package.
+      resolvedExtendsPath = require.resolve(extendsPath);
+    }
+    return readJson(tree, relative(tree.root, resolvedExtendsPath));
   } catch (e) {
     throw new Error(`Unable to resolve nx.json extends. Error: ${e.message}`);
   }

--- a/scripts/unit-test-setup.js
+++ b/scripts/unit-test-setup.js
@@ -40,6 +40,17 @@ module.exports = () => {
    */
   process.env.NX_DAEMON = 'false';
 
+  /**
+   * Package manager detection falls back to npm_config_user_agent when no
+   * lockfile exists (the common case for in-memory test trees), so test
+   * results would depend on whether jest was invoked through npm, pnpm, or
+   * yarn. CI agents run under an npm user agent; remove the variable so
+   * local runs behave the same. Tests that exercise a specific package
+   * manager set this variable (or write a lockfile/pnpm-workspace.yaml)
+   * themselves.
+   */
+  delete process.env.npm_config_user_agent;
+
   const emptyProjectGraph = { nodes: {}, dependencies: {} };
   const emptyProjectGraphAndMaps = {
     projectGraph: emptyProjectGraph,


### PR DESCRIPTION
## Current Behavior

Two classes of unit tests fail when run locally but pass on CI:

1. Running tests via `pnpm nx test <project>` injects `npm_config_user_agent=pnpm/...` into the jest processes. `detectPackageManager` falls back to that variable when the test tree has no lockfile (the common case for in-memory trees), so package-manager-dependent generator tests behave differently than their snapshots expect. CI agents start via `npx nx-cloud`, so the same tests see an npm user agent and pass.

2. `readNxJsonExtends` resolves `nx.json` `extends` with `require.resolve(extendsPath, { paths: [tree.root] })`. For in-memory test trees the root is `/virtual`, which has no `node_modules`, and jest 30 throws after exhausting the given paths instead of falling back. Any test that reads an nx.json with `extends` (e.g. `@nx/eslint:lint-project` preset tests) fails with a cold jest cache.

## Expected Behavior

- `scripts/unit-test-setup.js` removes `npm_config_user_agent` so package manager detection in tests is deterministic and matches CI. Tests that exercise a specific package manager already force it explicitly (lockfile/pnpm-workspace.yaml in the tree, or setting the variable themselves).
- `readNxJsonExtends` falls back to resolving from the running nx package when workspace-rooted resolution fails.

`pnpm nx test eslint` passes fully locally with these changes (20/20 suites).

## Related Issue(s)
