### PR TITLE
docs(nx-dev): add Nx Cloud workspace tour CTA to setup-ci page

### DIFF
--- a/astro-docs/src/content/docs/getting-started/setup-ci.mdoc
+++ b/astro-docs/src/content/docs/getting-started/setup-ci.mdoc
@@ -37,6 +37,8 @@ Page: {pageUrl}
 
 Connect your workspace to Nx Cloud and run your CI tasks through `nx`. That turns on remote caching, affected, distribution, and self-healing CI.
 
+{% call_to_action variant="default" title="Tour an Nx Cloud workspace" url="https://cloud.nx.app/demo/intro?utm_source=nx-dev&utm_medium=ci-tutorial&utm_campaign=workspace-tour" description="See distributed task execution, caching, and run analytics on a live workspace before you wire up your own CI." /%}
+
 ## Make sure you have Nx
 
 If you don't have Nx in your repo yet, add it first.


### PR DESCRIPTION
## What

Adds a call-to-action at the top of the **Set up CI** getting-started docs page prompting readers to take a guided tour of a live Nx Cloud workspace.

## Why

Gives readers a way to see distributed task execution, caching, and run analytics on a real workspace before wiring up their own CI.

## Details

- File: `astro-docs/src/content/docs/getting-started/setup-ci.mdoc`
- Reuses the existing `{% call_to_action %}` Markdoc component (same one used on `nx-cloud.mdoc`, `conformance.mdoc`).
- Placed after the intro sentence, before the first `## Make sure you have Nx` heading.
- Links to `https://cloud.nx.app/demo/intro` with UTM params (`utm_source=nx-dev`, `utm_medium=ci-tutorial`, `utm_campaign=workspace-tour`).
- One file, +2 lines.

Copy:
> **Tour an Nx Cloud workspace** — See distributed task execution, caching, and run analytics on a live workspace before you wire up your own CI.

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/demo-CTAs-c0c4dc8b)
<!-- polygraph-session-end -->