### PR TITLE
fix(module-federation): bound static remote proxy port check to avoid nx serve hang

### DIFF
--- a/packages/module-federation/src/utils/port-utils.spec.ts
+++ b/packages/module-federation/src/utils/port-utils.spec.ts
@@ -1,0 +1,48 @@
+import * as net from 'net';
+import { isPortInUse } from './port-utils';
+
+describe('isPortInUse', () => {
+  function listenOnFreePort(): Promise<{ port: number; server: net.Server }> {
+    return new Promise((resolve) => {
+      const server = net.createServer();
+      server.listen(0, '127.0.0.1', () => {
+        resolve({ port: (server.address() as net.AddressInfo).port, server });
+      });
+    });
+  }
+
+  function closeServer(server: net.Server): Promise<void> {
+    return new Promise((resolve) => server.close(() => resolve()));
+  }
+
+  it('returns true when a server is listening on the port', async () => {
+    const { port, server } = await listenOnFreePort();
+    try {
+      await expect(isPortInUse(port, '127.0.0.1')).resolves.toBe(true);
+    } finally {
+      await closeServer(server);
+    }
+  });
+
+  it('returns false when nothing is listening on the port', async () => {
+    // Reserve a port, then release it so we have a port we know is free.
+    const { port, server } = await listenOnFreePort();
+    await closeServer(server);
+
+    await expect(isPortInUse(port, '127.0.0.1')).resolves.toBe(false);
+  });
+
+  it('returns false quickly when the host is unreachable instead of blocking', async () => {
+    // 192.0.2.1 (RFC 5737 TEST-NET-1) is a reserved address that blackholes
+    // packets. This mirrors the bug in #33909: on some Linux setups connecting
+    // to an unreachable loopback (IPv6 `::1`) yields a slow ETIMEDOUT, and
+    // without a bounded timeout the check would hang for minutes. The timeout
+    // must cap it and report the port as free.
+    const start = Date.now();
+    const result = await isPortInUse(80, '192.0.2.1', 200);
+    const elapsed = Date.now() - start;
+
+    expect(result).toBe(false);
+    expect(elapsed).toBeLessThan(5000);
+  });
+});

--- a/packages/module-federation/src/utils/port-utils.spec.ts
+++ b/packages/module-federation/src/utils/port-utils.spec.ts
@@ -1,26 +1,24 @@
-import * as net from 'net';
+import { AddressInfo, createServer, Server } from 'net';
 import { isPortInUse } from './port-utils';
 
 describe('isPortInUse', () => {
-  function listen(port: number, host = '127.0.0.1'): Promise<net.Server> {
+  function listen(port: number, host = '127.0.0.1'): Promise<Server> {
     return new Promise((resolve, reject) => {
-      const server = net.createServer();
+      const server = createServer();
       server.once('error', reject);
       server.listen(port, host, () => resolve(server));
     });
   }
 
-  function closeServer(server: net.Server): Promise<void> {
+  function closeServer(server: Server): Promise<void> {
     return new Promise((resolve) => server.close(() => resolve()));
   }
 
-  // Find a port that is currently free by binding to an ephemeral port and
-  // immediately releasing it.
   function getFreePort(): Promise<number> {
     return new Promise((resolve) => {
-      const server = net.createServer();
+      const server = createServer();
       server.listen(0, '127.0.0.1', () => {
-        const { port } = server.address() as net.AddressInfo;
+        const { port } = server.address() as AddressInfo;
         server.close(() => resolve(port));
       });
     });
@@ -47,8 +45,7 @@ describe('isPortInUse', () => {
 
     expect(await isPortInUse(port, '127.0.0.1')).toBe(false);
 
-    // If the check had leaked its probe listener, binding here would throw
-    // EADDRINUSE -- which is exactly the crash the check exists to prevent.
+    // Would throw EADDRINUSE if the check leaked its probe listener.
     const server = await listen(port);
     await closeServer(server);
   });

--- a/packages/module-federation/src/utils/port-utils.spec.ts
+++ b/packages/module-federation/src/utils/port-utils.spec.ts
@@ -2,12 +2,11 @@ import * as net from 'net';
 import { isPortInUse } from './port-utils';
 
 describe('isPortInUse', () => {
-  function listenOnFreePort(): Promise<{ port: number; server: net.Server }> {
-    return new Promise((resolve) => {
+  function listen(port: number, host = '127.0.0.1'): Promise<net.Server> {
+    return new Promise((resolve, reject) => {
       const server = net.createServer();
-      server.listen(0, '127.0.0.1', () => {
-        resolve({ port: (server.address() as net.AddressInfo).port, server });
-      });
+      server.once('error', reject);
+      server.listen(port, host, () => resolve(server));
     });
   }
 
@@ -15,8 +14,21 @@ describe('isPortInUse', () => {
     return new Promise((resolve) => server.close(() => resolve()));
   }
 
-  it('returns true when a server is listening on the port', async () => {
-    const { port, server } = await listenOnFreePort();
+  // Find a port that is currently free by binding to an ephemeral port and
+  // immediately releasing it.
+  function getFreePort(): Promise<number> {
+    return new Promise((resolve) => {
+      const server = net.createServer();
+      server.listen(0, '127.0.0.1', () => {
+        const { port } = server.address() as net.AddressInfo;
+        server.close(() => resolve(port));
+      });
+    });
+  }
+
+  it('returns true when the port is already taken', async () => {
+    const port = await getFreePort();
+    const server = await listen(port);
     try {
       await expect(isPortInUse(port, '127.0.0.1')).resolves.toBe(true);
     } finally {
@@ -24,25 +36,20 @@ describe('isPortInUse', () => {
     }
   });
 
-  it('returns false when nothing is listening on the port', async () => {
-    // Reserve a port, then release it so we have a port we know is free.
-    const { port, server } = await listenOnFreePort();
-    await closeServer(server);
+  it('returns false when the port is free', async () => {
+    const port = await getFreePort();
 
     await expect(isPortInUse(port, '127.0.0.1')).resolves.toBe(false);
   });
 
-  it('returns false quickly when the host is unreachable instead of blocking', async () => {
-    // 192.0.2.1 (RFC 5737 TEST-NET-1) is a reserved address that blackholes
-    // packets. This mirrors the bug in #33909: on some Linux setups connecting
-    // to an unreachable loopback (IPv6 `::1`) yields a slow ETIMEDOUT, and
-    // without a bounded timeout the check would hang for minutes. The timeout
-    // must cap it and report the port as free.
-    const start = Date.now();
-    const result = await isPortInUse(80, '192.0.2.1', 200);
-    const elapsed = Date.now() - start;
+  it('releases the port it probed so the caller can bind it afterwards', async () => {
+    const port = await getFreePort();
 
-    expect(result).toBe(false);
-    expect(elapsed).toBeLessThan(5000);
+    expect(await isPortInUse(port, '127.0.0.1')).toBe(false);
+
+    // If the check had leaked its probe listener, binding here would throw
+    // EADDRINUSE -- which is exactly the crash the check exists to prevent.
+    const server = await listen(port);
+    await closeServer(server);
   });
 });

--- a/packages/module-federation/src/utils/port-utils.ts
+++ b/packages/module-federation/src/utils/port-utils.ts
@@ -1,36 +1,37 @@
 import * as net from 'net';
 
 /**
- * Check if a port is already in use by attempting to connect to it.
+ * Check if a port is already in use by attempting to bind to it.
  *
- * Resolves `true` only when a TCP connection can be established (i.e. something
- * is already listening on the port). A bounded connection timeout ensures the
- * check fails fast and reports the port as free when the address is unreachable
- * rather than blocking on the OS-level TCP connect timeout (which can be minutes
- * on some Linux setups). This matters because callers pass `host: 'localhost'`,
- * which can resolve to the IPv6 loopback `::1`; when nothing accepts the
- * connection there the SYN may be dropped, yielding a slow `ETIMEDOUT` instead
- * of an immediate `ECONNREFUSED`. Without this bound `nx serve` for a module
- * federation host stalls for minutes while probing each remote's proxy port.
+ * Binding is a local operation, so this resolves immediately: if the port is
+ * already taken the OS rejects the bind with `EADDRINUSE` and we return `true`;
+ * otherwise the bind succeeds, we release the port, and return `false`.
+ *
+ * Unlike a connection-based check this performs no network round-trip, so it
+ * cannot stall on the OS-level TCP connect timeout when `localhost` resolves to
+ * an unreachable address (e.g. the IPv6 loopback `::1`, where a dropped SYN
+ * yields a slow `ETIMEDOUT`). That stall was the cause of the multi-minute
+ * `nx serve` hang for module federation hosts. It also tests the exact
+ * operation the caller is about to perform — binding the proxy to the port —
+ * so it is a precise predictor of whether starting the proxy would `EADDRINUSE`.
  */
 export function isPortInUse(
   port: number,
-  host: string = 'localhost',
-  timeout: number = 1000
+  host: string = 'localhost'
 ): Promise<boolean> {
   return new Promise((resolve) => {
-    const socket = new net.Socket();
-    const finish = (inUse: boolean) => {
-      socket.removeAllListeners();
-      socket.destroy();
-      resolve(inUse);
-    };
-    socket.setTimeout(timeout);
-    socket.once('connect', () => finish(true));
-    // Unreachable/slow host or nothing listening -> the port is not serving, so
-    // treat it as free and let the caller start its own proxy.
-    socket.once('timeout', () => finish(false));
-    socket.once('error', () => finish(false));
-    socket.connect({ port, host });
+    const server = net.createServer();
+    server.once('error', (err: NodeJS.ErrnoException) => {
+      // The port is already taken. Any other error means we could not bind for
+      // an unrelated reason; treat the port as free so the caller still attempts
+      // to start its proxy and surfaces the real error there.
+      resolve(err.code === 'EADDRINUSE');
+    });
+    server.once('listening', () => {
+      // We bound successfully, so nothing else holds the port. Release it so the
+      // caller can start its proxy on the same port.
+      server.close(() => resolve(false));
+    });
+    server.listen(port, host);
   });
 }

--- a/packages/module-federation/src/utils/port-utils.ts
+++ b/packages/module-federation/src/utils/port-utils.ts
@@ -1,35 +1,21 @@
-import * as net from 'net';
+import { createServer } from 'net';
 
 /**
- * Check if a port is already in use by attempting to bind to it.
- *
- * Binding is a local operation, so this resolves immediately: if the port is
- * already taken the OS rejects the bind with `EADDRINUSE` and we return `true`;
- * otherwise the bind succeeds, we release the port, and return `false`.
- *
- * Unlike a connection-based check this performs no network round-trip, so it
- * cannot stall on the OS-level TCP connect timeout when `localhost` resolves to
- * an unreachable address (e.g. the IPv6 loopback `::1`, where a dropped SYN
- * yields a slow `ETIMEDOUT`). That stall was the cause of the multi-minute
- * `nx serve` hang for module federation hosts. It also tests the exact
- * operation the caller is about to perform — binding the proxy to the port —
- * so it is a precise predictor of whether starting the proxy would `EADDRINUSE`.
+ * Check if a port is in use by attempting to bind to it. Binding is local and
+ * resolves immediately, so unlike a connection-based check it never stalls on
+ * the OS TCP connect timeout when `localhost` resolves to an unreachable address
+ * (e.g. IPv6 `::1`) -- the cause of the `nx serve` hang in #33909.
  */
 export function isPortInUse(
   port: number,
   host: string = 'localhost'
 ): Promise<boolean> {
   return new Promise((resolve) => {
-    const server = net.createServer();
+    const server = createServer();
     server.once('error', (err: NodeJS.ErrnoException) => {
-      // The port is already taken. Any other error means we could not bind for
-      // an unrelated reason; treat the port as free so the caller still attempts
-      // to start its proxy and surfaces the real error there.
       resolve(err.code === 'EADDRINUSE');
     });
     server.once('listening', () => {
-      // We bound successfully, so nothing else holds the port. Release it so the
-      // caller can start its proxy on the same port.
       server.close(() => resolve(false));
     });
     server.listen(port, host);

--- a/packages/module-federation/src/utils/port-utils.ts
+++ b/packages/module-federation/src/utils/port-utils.ts
@@ -1,17 +1,36 @@
-import { waitForPortOpen } from '@nx/web/internal';
+import * as net from 'net';
 
 /**
  * Check if a port is already in use by attempting to connect to it.
- * Uses waitForPortOpen with retries: 0 for an immediate check.
+ *
+ * Resolves `true` only when a TCP connection can be established (i.e. something
+ * is already listening on the port). A bounded connection timeout ensures the
+ * check fails fast and reports the port as free when the address is unreachable
+ * rather than blocking on the OS-level TCP connect timeout (which can be minutes
+ * on some Linux setups). This matters because callers pass `host: 'localhost'`,
+ * which can resolve to the IPv6 loopback `::1`; when nothing accepts the
+ * connection there the SYN may be dropped, yielding a slow `ETIMEDOUT` instead
+ * of an immediate `ECONNREFUSED`. Without this bound `nx serve` for a module
+ * federation host stalls for minutes while probing each remote's proxy port.
  */
-export async function isPortInUse(
+export function isPortInUse(
   port: number,
-  host: string = 'localhost'
+  host: string = 'localhost',
+  timeout: number = 1000
 ): Promise<boolean> {
-  try {
-    await waitForPortOpen(port, { retries: 0, host });
-    return true; // Port is open/in use
-  } catch {
-    return false; // Port is not in use
-  }
+  return new Promise((resolve) => {
+    const socket = new net.Socket();
+    const finish = (inUse: boolean) => {
+      socket.removeAllListeners();
+      socket.destroy();
+      resolve(inUse);
+    };
+    socket.setTimeout(timeout);
+    socket.once('connect', () => finish(true));
+    // Unreachable/slow host or nothing listening -> the port is not serving, so
+    // treat it as free and let the caller start its own proxy.
+    socket.once('timeout', () => finish(false));
+    socket.once('error', () => finish(false));
+    socket.connect({ port, host });
+  });
 }


### PR DESCRIPTION
## Current Behavior

`nx serve` for a module federation host can hang for several minutes on `Starting static remotes proxies...`. On affected setups the verbose logs show:

```
NX  Starting static remotes proxies...
Connecting on localhost:4201
Error connecting on localhost:4201: ETIMEDOUT
Connecting on localhost:4202
Error connecting on localhost:4202: ETIMEDOUT
NX  Static remotes proxies started successfully
```

This is a regression introduced in #33871 (released in v22.2.4). That PR added an `isPortInUse()` check before starting each static remote proxy, to avoid `EADDRINUSE` when two MF dev servers share a remote. The check performed an **unbounded** TCP connect via `waitForPortOpen(port, { retries: 0, host })`.

Callers pass `host: 'localhost'`. On Linux, `localhost` can resolve to the IPv6 loopback `::1`; when nothing is listening there and the SYN is dropped, the connect fails with a slow `ETIMEDOUT` rather than an immediate `ECONNREFUSED`. Because the attempt had no socket-level timeout, it blocked for the OS-level TCP connect timeout (~2 minutes on Linux's default `tcp_syn_retries`) — once per remote — adding minutes to startup. (`retries: 0` only disables *re-attempts*; it does not bound how long a single attempt takes to fail.) Before #33871 (v22.2.3) the same serve completed in ~23s.

## Expected Behavior

`isPortInUse()` now checks the port by **attempting to bind it** rather than connecting to it:

- If the port is already taken, the bind fails with `EADDRINUSE` → reported as in use (proxy is skipped).
- Otherwise the bind succeeds, the port is released, and it is reported as free (proxy is started).

Binding is a local operation with no network round-trip, so it resolves in ~1ms and **cannot** stall on a TCP connect timeout — the hang is structurally impossible, not merely bounded. It also tests the exact operation the caller is about to perform (binding the proxy to the port), so it precisely predicts whether starting the proxy would `EADDRINUSE`, preserving the intent of #33871.

A unit test (`port-utils.spec.ts`) covers the port-taken (`EADDRINUSE`) and port-free cases, and asserts the probe releases the port so the caller can bind it afterwards.

### Follow-up (separate PR)

`waitForPortOpen` itself has the same latent issue for its *waiting* callers (`@nx/next`, `@nx/remix`, `@nx/angular`, `@nx/react`, `@nx/rspack`, and MF's `get-static-remotes`): an unbounded per-attempt connect defeats its retry loop on `ETIMEDOUT`-prone hosts. `ETIMEDOUT` is already in its retryable allowlist, so adding a per-attempt socket timeout (treated as a retryable error) would make the retry budget behave as intended. Left out of this PR to keep the high-priority fix tightly scoped.

## Related Issue(s)

Fixes #33909
