### PR TITLE
fix(core): read and replay cached failures when NX_CACHE_FAILURES is enabled

### DIFF
--- a/e2e/nx/src/cache.test.ts
+++ b/e2e/nx/src/cache.test.ts
@@ -156,6 +156,48 @@ describe('cache', () => {
     updateFile('nx.json', (c) => originalNxJson);
   }, 120000);
 
+  it('should replay cached failures when NX_CACHE_FAILURES is enabled', async () => {
+    const mylib = uniq('mylib');
+    runCLI(`generate @nx/js:library ${mylib} --directory=libs/${mylib}`);
+
+    // A cacheable target that always fails. Each real execution appends to
+    // runs.log at the workspace root — a path outside the task's inputs, so
+    // it never affects the hash and is never restored from the cache. Its
+    // length therefore tells us whether the command actually re-ran.
+    updateJson(join('libs', mylib, 'project.json'), (c) => {
+      c.targets['always-fails'] = {
+        cache: true,
+        executor: 'nx:run-commands',
+        inputs: ['{projectRoot}/**/*'],
+        options: {
+          command: `node -e "require('fs').appendFileSync('runs.log', 'x'); process.exit(1)"`,
+        },
+      };
+      return c;
+    });
+
+    const env = { NX_CACHE_FAILURES: 'true' };
+
+    // First run executes the command, fails, and caches the failure.
+    const firstRun = runCLI(`run ${mylib}:always-fails`, {
+      silenceError: true,
+      env,
+    });
+    expect(runCLI.lastExitCode).toBe(1);
+    expect(firstRun).toContain('Running target always-fails');
+    expect(readFile('runs.log')).toBe('x');
+
+    // Second run must replay the cached failure: it still fails (non-zero
+    // exit) but does NOT re-execute the command, so runs.log is unchanged.
+    const secondRun = runCLI(`run ${mylib}:always-fails`, {
+      silenceError: true,
+      env,
+    });
+    expect(runCLI.lastExitCode).toBe(1);
+    expect(secondRun).toContain('always-fails');
+    expect(readFile('runs.log')).toBe('x');
+  }, 120000);
+
   it('should support using globs as outputs', async () => {
     const mylib = uniq('mylib');
     runCLI(`generate @nx/js:library ${mylib} --directory=libs/${mylib}`);

--- a/packages/nx/src/tasks-runner/task-orchestrator.spec.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.spec.ts
@@ -173,4 +173,97 @@ describe('TaskOrchestrator', () => {
       expect(consumer.hash).toBe('consumer:build|call-2');
     });
   });
+
+  describe('cached failures (NX_CACHE_FAILURES)', () => {
+    const originalCacheFailures = process.env.NX_CACHE_FAILURES;
+
+    afterEach(() => {
+      if (originalCacheFailures === undefined) {
+        delete process.env.NX_CACHE_FAILURES;
+      } else {
+        process.env.NX_CACHE_FAILURES = originalCacheFailures;
+      }
+    });
+
+    function createTask(id: string): Task {
+      const [project, target] = id.split(':');
+      return {
+        id,
+        target: { project, target },
+        overrides: {},
+        outputs: [],
+        projectRoot: project,
+        cache: true,
+        parallelism: true,
+        hash: `${id}-hash`,
+      } as Task;
+    }
+
+    function createOrchestrator(batchResults: Map<string, any>) {
+      const orchestrator: any = Object.create(TaskOrchestrator.prototype);
+      orchestrator.cache = {
+        getBatch: jest.fn(async () => batchResults),
+        copyFilesFromCache: jest.fn(),
+      };
+      orchestrator.shouldCopyOutputsFromCacheBatch = jest.fn(
+        async () => new Map()
+      );
+      orchestrator.options = {
+        lifeCycle: { printTaskTerminalOutput: jest.fn() },
+      };
+      return orchestrator;
+    }
+
+    it('should not read failed results from cache by default', async () => {
+      const passing = createTask('app:test');
+      const failing = createTask('app:lint');
+      const orchestrator = createOrchestrator(
+        new Map([
+          [passing.hash, { code: 0, terminalOutput: 'ok', remote: false }],
+          [failing.hash, { code: 1, terminalOutput: 'boom', remote: false }],
+        ])
+      );
+      delete process.env.NX_CACHE_FAILURES;
+
+      const hits = await orchestrator.fetchCacheHits([passing, failing]);
+
+      expect(hits.map((h: any) => h.task.id)).toEqual(['app:test']);
+    });
+
+    it('should read failed results from cache when NX_CACHE_FAILURES is enabled', async () => {
+      const passing = createTask('app:test');
+      const failing = createTask('app:lint');
+      const orchestrator = createOrchestrator(
+        new Map([
+          [passing.hash, { code: 0, terminalOutput: 'ok', remote: false }],
+          [failing.hash, { code: 1, terminalOutput: 'boom', remote: false }],
+        ])
+      );
+      process.env.NX_CACHE_FAILURES = 'true';
+
+      const hits = await orchestrator.fetchCacheHits([passing, failing]);
+
+      expect(hits.map((h: any) => h.task.id)).toEqual(['app:test', 'app:lint']);
+    });
+
+    it('should report a cached failure as a failure, not a cache hit', async () => {
+      const failing = createTask('app:lint');
+      const orchestrator = createOrchestrator(new Map());
+
+      const results = await orchestrator.finalizeCacheHits([
+        {
+          task: failing,
+          cachedResult: { code: 1, terminalOutput: 'boom', remote: false },
+        },
+      ]);
+
+      expect(results).toHaveLength(1);
+      expect(results[0].status).toBe('failure');
+      expect(results[0].code).toBe(1);
+      // The cached failure output is still surfaced to the user.
+      expect(
+        orchestrator.options.lifeCycle.printTaskTerminalOutput
+      ).toHaveBeenCalledWith(failing, 'failure', 'boom');
+    });
+  });
 });

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -479,9 +479,14 @@ export class TaskOrchestrator {
   private async fetchCacheHits(tasks: Task[]): Promise<CacheHit[]> {
     const batchResults = await this.cache.getBatch(tasks);
     const cacheHits: CacheHit[] = [];
+    const cacheFailures = process.env.NX_CACHE_FAILURES === 'true';
     for (const task of tasks) {
       const cachedResult = batchResults.get(task.hash);
-      if (cachedResult && cachedResult.code === 0) {
+      // Successful results are always replayed from cache. Failed results
+      // (non-zero code) are only replayed when NX_CACHE_FAILURES is enabled,
+      // mirroring shouldCacheTaskResult on the write side — otherwise cached
+      // failures would be written but never read back.
+      if (cachedResult && (cachedResult.code === 0 || cacheFailures)) {
         cacheHits.push({ task, cachedResult });
       }
     }
@@ -529,11 +534,19 @@ export class TaskOrchestrator {
     const results: TaskResult[] = [];
     for (const { task, cachedResult } of cacheHits) {
       const shouldCopy = shouldCopyMap.get(task.hash) ?? false;
-      const status: TaskStatus = cachedResult.remote
-        ? 'remote-cache'
-        : shouldCopy
-          ? 'local-cache'
-          : 'local-cache-kept-existing';
+      // A cached failure (only replayed when NX_CACHE_FAILURES is enabled) is
+      // reported as a plain failure so exit codes, run summaries, and the TUI
+      // treat it as a failed run rather than a successful cache hit. Reporting
+      // it as 'failure' also ensures its terminal output is always printed,
+      // which the cache statuses suppress for non-initiating projects.
+      const status: TaskStatus =
+        cachedResult.code !== 0
+          ? 'failure'
+          : cachedResult.remote
+            ? 'remote-cache'
+            : shouldCopy
+              ? 'local-cache'
+              : 'local-cache-kept-existing';
 
       this.options.lifeCycle.printTaskTerminalOutput(
         task,
@@ -651,7 +664,10 @@ export class TaskOrchestrator {
             cachedTasks.map((task) => this.options.lifeCycle.scheduleTask(task))
           );
           await this.preRunSteps(cachedTasks, { groupId });
-          await this.postRunSteps(cacheResults, doNotSkipCache, { groupId });
+          await this.postRunSteps(cacheResults, doNotSkipCache, {
+            groupId,
+            fromCache: true,
+          });
         }
 
         for (const task of eligible) {
@@ -948,7 +964,10 @@ export class TaskOrchestrator {
     const hitTasks = cacheHits.map((h) => h.task);
     await this.preRunSteps(hitTasks, { groupId });
     const results = await this.finalizeCacheHits(cacheHits);
-    await this.postRunSteps(results, doNotSkipCache, { groupId });
+    await this.postRunSteps(results, doNotSkipCache, {
+      groupId,
+      fromCache: true,
+    });
     return results;
   }
 
@@ -1407,7 +1426,7 @@ export class TaskOrchestrator {
       terminalOutput?: string;
     }[],
     doNotSkipCache: boolean,
-    { groupId }: { groupId: number }
+    { groupId, fromCache = false }: { groupId: number; fromCache?: boolean }
   ) {
     const now = Date.now();
     const tasksToRecord: { outputs: string[]; hash: string }[] = [];
@@ -1428,7 +1447,11 @@ export class TaskOrchestrator {
       await this.recordOutputsHashBatch(tasksToRecord);
     }
 
-    if (doNotSkipCache && !this.stopRequested) {
+    // Skip caching for results that were just replayed from the cache.
+    // Successful cache hits are already filtered out below by status, but a
+    // replayed failure (reported as 'failure' so it counts as a failed run)
+    // would otherwise be re-written to the cache on every replay.
+    if (doNotSkipCache && !this.stopRequested && !fromCache) {
       // cache the results
       performance.mark('cache-results-start');
       await Promise.all(

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -664,10 +664,8 @@ export class TaskOrchestrator {
             cachedTasks.map((task) => this.options.lifeCycle.scheduleTask(task))
           );
           await this.preRunSteps(cachedTasks, { groupId });
-          await this.postRunSteps(cacheResults, doNotSkipCache, {
-            groupId,
-            fromCache: true,
-          });
+          // Replayed from the cache — don't write the results back.
+          await this.postRunSteps(cacheResults, false, groupId);
         }
 
         for (const task of eligible) {
@@ -771,7 +769,7 @@ export class TaskOrchestrator {
     }
 
     if (batchResults.length > 0) {
-      await this.postRunSteps(batchResults, doNotSkipCache, { groupId });
+      await this.postRunSteps(batchResults, doNotSkipCache, groupId);
     }
 
     // Update batch status based on all task results
@@ -964,10 +962,8 @@ export class TaskOrchestrator {
     const hitTasks = cacheHits.map((h) => h.task);
     await this.preRunSteps(hitTasks, { groupId });
     const results = await this.finalizeCacheHits(cacheHits);
-    await this.postRunSteps(results, doNotSkipCache, {
-      groupId,
-      fromCache: true,
-    });
+    // Replayed from the cache — don't write the results back.
+    await this.postRunSteps(results, false, groupId);
     return results;
   }
 
@@ -1022,7 +1018,7 @@ export class TaskOrchestrator {
     await this.postRunSteps(
       [{ task, status: 'failure', terminalOutput }],
       doNotSkipCache,
-      { groupId }
+      groupId
     );
   }
 
@@ -1103,7 +1099,7 @@ export class TaskOrchestrator {
     };
 
     try {
-      await this.postRunSteps([result], doNotSkipCache, { groupId });
+      await this.postRunSteps([result], doNotSkipCache, groupId);
     } finally {
       this.discreteTaskExitHandled.delete(task.id);
       resolveDiscreteExit!();
@@ -1425,8 +1421,8 @@ export class TaskOrchestrator {
       status: TaskStatus;
       terminalOutput?: string;
     }[],
-    doNotSkipCache: boolean,
-    { groupId, fromCache = false }: { groupId: number; fromCache?: boolean }
+    shouldCache: boolean,
+    groupId: number
   ) {
     const now = Date.now();
     const tasksToRecord: { outputs: string[]; hash: string }[] = [];
@@ -1447,11 +1443,10 @@ export class TaskOrchestrator {
       await this.recordOutputsHashBatch(tasksToRecord);
     }
 
-    // Skip caching for results that were just replayed from the cache.
-    // Successful cache hits are already filtered out below by status, but a
-    // replayed failure (reported as 'failure' so it counts as a failed run)
-    // would otherwise be re-written to the cache on every replay.
-    if (doNotSkipCache && !this.stopRequested && !fromCache) {
+    // Caller decides whether these results should be written to the cache.
+    // Cache replays pass false so a replayed failure (reported as 'failure' so
+    // it counts as a failed run) isn't re-written to the cache on every replay.
+    if (shouldCache && !this.stopRequested) {
       // cache the results
       performance.mark('cache-results-start');
       await Promise.all(

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -479,14 +479,13 @@ export class TaskOrchestrator {
   private async fetchCacheHits(tasks: Task[]): Promise<CacheHit[]> {
     const batchResults = await this.cache.getBatch(tasks);
     const cacheHits: CacheHit[] = [];
-    const cacheFailures = process.env.NX_CACHE_FAILURES === 'true';
     for (const task of tasks) {
       const cachedResult = batchResults.get(task.hash);
-      // Successful results are always replayed from cache. Failed results
-      // (non-zero code) are only replayed when NX_CACHE_FAILURES is enabled,
-      // mirroring shouldCacheTaskResult on the write side — otherwise cached
-      // failures would be written but never read back.
-      if (cachedResult && (cachedResult.code === 0 || cacheFailures)) {
+      // Replay a cached result only under the same condition it was cached
+      // under (shouldCacheTaskResult): successes always, failures only when
+      // NX_CACHE_FAILURES is enabled. Otherwise cached failures would be
+      // written but never read back.
+      if (cachedResult && this.shouldCacheTaskResult(task, cachedResult.code)) {
         cacheHits.push({ task, cachedResult });
       }
     }


### PR DESCRIPTION
## Current Behavior

When `NX_CACHE_FAILURES=true` is set, Nx writes failed task results to the cache but never reads them back. The write side (`shouldCacheTaskResult`) already honors the flag and stores failures, but the read side (`fetchCacheHits` in `task-orchestrator.ts`) filtered cache entries to `cachedResult.code === 0`. As a result, a cached failure was treated as a cache miss and the task was re-executed on every run, making the flag effectively a no-op.

This affected both the single-task path (`resolveCachedTasks`) and the batch path (`applyBatchCachedResults`), since both funnel through `fetchCacheHits`.

## Expected Behavior

With `NX_CACHE_FAILURES=true`, a failing cacheable task is replayed from the cache on subsequent runs instead of re-executing:

- The cached failure is read back (the task does **not** re-run).
- The cached terminal output is replayed.
- The run still exits non-zero, and run summaries, the TUI, and dependent-task skipping all correctly treat it as a failed run.

To get this right, a replayed cached failure is reported with `status: 'failure'` rather than a cache status — the exit-code logic and every summary/TUI lifecycle treat the cache statuses (`local-cache`, `remote-cache`, `local-cache-kept-existing`) as success, so a cached failure had to surface as a failure to be counted correctly. Replayed cache hits also no longer get redundantly re-written to the cache (new `fromCache` guard in `postRunSteps`).

### Verification

A minimal workspace with a failing cacheable target (appending to a file outside its inputs on each real execution):

- Before: second run re-executes the command (marker file grows).
- After: second run replays the cached failure (marker file unchanged) and still exits with code `1`.

Covered by a new unit test in `task-orchestrator.spec.ts` and an e2e test in `e2e/nx/src/cache.test.ts`.

## Related Issue(s)

Fixes #35901
