### PR TITLE
feat(angular): add trustProxyHeaders to SSR engines for Angular v22

### DIFF
--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -339,6 +339,15 @@
       "description": "Add `istanbul-lib-instrument` to `devDependencies` when a project runs unit tests with Karma (the `@angular-devkit/build-angular:karma` / `@angular/build:karma` builders, or `@angular/build:unit-test` / `@nx/angular:unit-test` with `runner: karma`), matching the Angular v22 `add-istanbul-instrumenter` migration.",
       "factory": "./dist/src/migrations/update-23-1-0/add-istanbul-instrumenter",
       "documentation": "./dist/src/migrations/update-23-1-0/add-istanbul-instrumenter.md"
+    },
+    "update-23-1-0-add-trust-proxy-headers": {
+      "version": "23.1.0-beta.0",
+      "requires": {
+        "@angular/core": ">=22.0.0"
+      },
+      "description": "Add the `trustProxyHeaders` option to `AngularNodeAppEngine` and `AngularAppEngine` instantiations in SSR server files, matching the Angular v22 `trust-proxy-headers` migration.",
+      "factory": "./dist/src/migrations/update-23-1-0/add-trust-proxy-headers",
+      "documentation": "./dist/src/migrations/update-23-1-0/add-trust-proxy-headers.md"
     }
   },
   "packageJsonUpdates": {

--- a/packages/angular/src/migrations/update-23-1-0/add-trust-proxy-headers.md
+++ b/packages/angular/src/migrations/update-23-1-0/add-trust-proxy-headers.md
@@ -1,0 +1,48 @@
+#### Add `trustProxyHeaders` to SSR Engines
+
+Angular v22 adds a `trustProxyHeaders` option to `AngularNodeAppEngine` and `AngularAppEngine` that controls whether the `X-Forwarded-*` headers are trusted when resolving the incoming request URL. This migration adds the option to existing engine instantiations in SSR server files so the behavior is explicit, along with a TODO comment flagging it as security-sensitive. Instantiations that already set `trustProxyHeaders` are left unchanged.
+
+The migration scans the source files of projects that depend on `@angular/ssr` for `new AngularNodeAppEngine(...)` and `new AngularAppEngine(...)` expressions.
+
+#### Examples
+
+##### `server.ts`
+
+Before:
+
+```ts
+import { AngularNodeAppEngine } from '@angular/ssr/node';
+
+const angularApp = new AngularNodeAppEngine();
+```
+
+After:
+
+```ts
+import { AngularNodeAppEngine } from '@angular/ssr/node';
+
+const angularApp = new AngularNodeAppEngine({
+  // TODO: This is a security-sensitive option. Remove if not needed. For more information, see https://angular.dev/best-practices/security#configuring-trusted-proxy-headers
+  trustProxyHeaders: ['x-forwarded-host', 'x-forwarded-proto'],
+});
+```
+
+An existing options object is preserved, with `trustProxyHeaders` added alongside the current options:
+
+Before:
+
+```ts
+const angularApp = new AngularAppEngine({
+  allowedHosts: ['example.com'],
+});
+```
+
+After:
+
+```ts
+const angularApp = new AngularAppEngine({
+  // TODO: This is a security-sensitive option. Remove if not needed. For more information, see https://angular.dev/best-practices/security#configuring-trusted-proxy-headers
+  trustProxyHeaders: ['x-forwarded-host', 'x-forwarded-proto'],
+  allowedHosts: ['example.com'],
+});
+```

--- a/packages/angular/src/migrations/update-23-1-0/add-trust-proxy-headers.spec.ts
+++ b/packages/angular/src/migrations/update-23-1-0/add-trust-proxy-headers.spec.ts
@@ -1,0 +1,153 @@
+import {
+  addProjectConfiguration,
+  type ProjectConfiguration,
+  type ProjectGraph,
+  type Tree,
+} from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migration from './add-trust-proxy-headers';
+
+let projectGraph: ProjectGraph;
+jest.mock('@nx/devkit', () => ({
+  ...jest.requireActual('@nx/devkit'),
+  createProjectGraphAsync: () => Promise.resolve(projectGraph),
+  formatFiles: jest.fn(),
+}));
+
+const TODO_COMMENT =
+  '// TODO: This is a security-sensitive option. Remove if not needed. ' +
+  'For more information, see https://angular.dev/best-practices/security#configuring-trusted-proxy-headers';
+const TRUST_PROXY_HEADERS = `trustProxyHeaders: ['x-forwarded-host', 'x-forwarded-proto'],`;
+
+describe('add-trust-proxy-headers migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+    projectGraph = { nodes: {}, dependencies: {} };
+  });
+
+  it('should add trustProxyHeaders to a "AngularNodeAppEngine" with no arguments', async () => {
+    addProject('app1', { name: 'app1', root: 'apps/app1' }, [
+      'npm:@angular/ssr',
+    ]);
+    tree.write(
+      'apps/app1/server.ts',
+      `import { AngularNodeAppEngine } from '@angular/ssr/node';\nconst angularApp = new AngularNodeAppEngine();\n`
+    );
+
+    await migration(tree);
+
+    const content = tree.read('apps/app1/server.ts', 'utf-8');
+    expect(content).toMatchInlineSnapshot(`
+      "import { AngularNodeAppEngine } from '@angular/ssr/node';
+      const angularApp = new AngularNodeAppEngine({
+        // TODO: This is a security-sensitive option. Remove if not needed. For more information, see https://angular.dev/best-practices/security#configuring-trusted-proxy-headers
+        trustProxyHeaders: ['x-forwarded-host', 'x-forwarded-proto'],
+      });
+      "
+    `);
+  });
+
+  it('should add trustProxyHeaders to a "AngularNodeAppEngine" with existing options', async () => {
+    addProject('app1', { name: 'app1', root: 'apps/app1' }, [
+      'npm:@angular/ssr',
+    ]);
+    tree.write(
+      'apps/app1/server.ts',
+      `import { AngularNodeAppEngine } from '@angular/ssr/node';\n` +
+        `const angularApp = new AngularNodeAppEngine({\n  allowedHosts: ['localhost'],\n});\n`
+    );
+
+    await migration(tree);
+
+    const content = tree.read('apps/app1/server.ts', 'utf-8');
+    expect(content).toMatchInlineSnapshot(`
+      "import { AngularNodeAppEngine } from '@angular/ssr/node';
+      const angularApp = new AngularNodeAppEngine({
+        // TODO: This is a security-sensitive option. Remove if not needed. For more information, see https://angular.dev/best-practices/security#configuring-trusted-proxy-headers
+        trustProxyHeaders: ['x-forwarded-host', 'x-forwarded-proto'],
+        allowedHosts: ['localhost'],
+      });
+      "
+    `);
+  });
+
+  it('should add trustProxyHeaders to a "AngularAppEngine"', async () => {
+    addProject('app1', { name: 'app1', root: 'apps/app1' }, [
+      'npm:@angular/ssr',
+    ]);
+    tree.write(
+      'apps/app1/server.ts',
+      `import { AngularAppEngine } from '@angular/ssr';\nconst angularApp = new AngularAppEngine();\n`
+    );
+
+    await migration(tree);
+
+    const content = tree.read('apps/app1/server.ts', 'utf-8');
+    expect(content).toMatchInlineSnapshot(`
+      "import { AngularAppEngine } from '@angular/ssr';
+      const angularApp = new AngularAppEngine({
+        // TODO: This is a security-sensitive option. Remove if not needed. For more information, see https://angular.dev/best-practices/security#configuring-trusted-proxy-headers
+        trustProxyHeaders: ['x-forwarded-host', 'x-forwarded-proto'],
+      });
+      "
+    `);
+  });
+
+  it('should not modify an engine that already sets trustProxyHeaders', async () => {
+    addProject('app1', { name: 'app1', root: 'apps/app1' }, [
+      'npm:@angular/ssr',
+    ]);
+    const input =
+      `import { AngularAppEngine } from '@angular/ssr';\n` +
+      `const angularApp = new AngularAppEngine({\n  trustProxyHeaders: true,\n});\n`;
+    tree.write('apps/app1/server.ts', input);
+
+    await migration(tree);
+
+    expect(tree.read('apps/app1/server.ts', 'utf-8')).toBe(input);
+  });
+
+  it('should be idempotent when the TODO comment is already present', async () => {
+    addProject('app1', { name: 'app1', root: 'apps/app1' }, [
+      'npm:@angular/ssr',
+    ]);
+    const input =
+      `import { AngularNodeAppEngine } from '@angular/ssr/node';\n` +
+      `const angularApp = new AngularNodeAppEngine({\n  ${TODO_COMMENT}\n  ${TRUST_PROXY_HEADERS}\n});\n`;
+    tree.write('apps/app1/server.ts', input);
+
+    await migration(tree);
+
+    expect(tree.read('apps/app1/server.ts', 'utf-8')).toBe(input);
+  });
+
+  it('should not modify projects that do not depend on "@angular/ssr"', async () => {
+    addProject('app1', { name: 'app1', root: 'apps/app1' }, []);
+    const input = `const angularApp = new AngularNodeAppEngine();\n`;
+    tree.write('apps/app1/server.ts', input);
+
+    await migration(tree);
+
+    expect(tree.read('apps/app1/server.ts', 'utf-8')).toBe(input);
+  });
+
+  function addProject(
+    projectName: string,
+    config: ProjectConfiguration,
+    dependencies: string[]
+  ): void {
+    projectGraph.nodes[projectName] = {
+      data: config,
+      name: projectName,
+      type: 'app',
+    };
+    projectGraph.dependencies[projectName] = dependencies.map((d) => ({
+      source: projectName,
+      target: d,
+      type: 'static',
+    }));
+    addProjectConfiguration(tree, projectName, config);
+  }
+});

--- a/packages/angular/src/migrations/update-23-1-0/add-trust-proxy-headers.ts
+++ b/packages/angular/src/migrations/update-23-1-0/add-trust-proxy-headers.ts
@@ -1,0 +1,84 @@
+import { formatFiles, visitNotIgnoredFiles, type Tree } from '@nx/devkit';
+import * as ts from 'typescript';
+import { FileChangeRecorder } from '../../utils/file-change-recorder';
+import { getProjectsFilteredByDependencies } from '../utils/projects';
+
+const TODO_COMMENT =
+  '// TODO: This is a security-sensitive option. Remove if not needed. ' +
+  'For more information, see https://angular.dev/best-practices/security#configuring-trusted-proxy-headers';
+const TRUST_PROXY_HEADERS = `trustProxyHeaders: ['x-forwarded-host', 'x-forwarded-proto'],`;
+
+export default async function (tree: Tree) {
+  const projects = await getProjectsFilteredByDependencies([
+    'npm:@angular/ssr',
+  ]);
+
+  for (const graphNode of projects) {
+    visitNotIgnoredFiles(tree, graphNode.data.root, (path) => {
+      if (!path.endsWith('.ts') || path.endsWith('.d.ts')) {
+        return;
+      }
+
+      const content = tree.read(path, 'utf-8');
+      // Skip already-migrated files and files not instantiating an SSR engine.
+      if (
+        content.includes(TODO_COMMENT) ||
+        (!content.includes('AngularNodeAppEngine') &&
+          !content.includes('AngularAppEngine'))
+      ) {
+        return;
+      }
+
+      const sourceFile = ts.createSourceFile(
+        path,
+        content,
+        ts.ScriptTarget.Latest,
+        true
+      );
+      let recorder: FileChangeRecorder | undefined;
+
+      const visit = (node: ts.Node): void => {
+        if (
+          ts.isNewExpression(node) &&
+          ts.isIdentifier(node.expression) &&
+          (node.expression.text === 'AngularNodeAppEngine' ||
+            node.expression.text === 'AngularAppEngine')
+        ) {
+          if (!node.arguments || node.arguments.length === 0) {
+            // No options object: insert one before the closing parenthesis.
+            recorder ??= new FileChangeRecorder(tree, path);
+            recorder.insertRight(
+              node.end - 1,
+              `{\n  ${TODO_COMMENT}\n  ${TRUST_PROXY_HEADERS}\n}`
+            );
+          } else if (ts.isObjectLiteralExpression(node.arguments[0])) {
+            const optionsArg = node.arguments[0];
+            const hasTrustProxyHeaders = optionsArg.properties.some(
+              (prop) =>
+                ts.isPropertyAssignment(prop) &&
+                (ts.isIdentifier(prop.name) || ts.isStringLiteral(prop.name)) &&
+                prop.name.text === 'trustProxyHeaders'
+            );
+            if (!hasTrustProxyHeaders) {
+              // Insert right after the opening brace of the options object.
+              recorder ??= new FileChangeRecorder(tree, path);
+              recorder.insertRight(
+                optionsArg.getStart() + 1,
+                `\n  ${TODO_COMMENT}\n  ${TRUST_PROXY_HEADERS}`
+              );
+            }
+          }
+        }
+        ts.forEachChild(node, visit);
+      };
+
+      visit(sourceFile);
+
+      if (recorder) {
+        recorder.applyChanges();
+      }
+    });
+  }
+
+  await formatFiles(tree);
+}


### PR DESCRIPTION
## Current Behavior

Angular CLI v22 ships a `trust-proxy-headers` migration that adds the new `trustProxyHeaders` option to existing `AngularNodeAppEngine` and `AngularAppEngine` instantiations in SSR server files. Nx does not run Angular's `ng update` migrations, so Nx workspaces upgrading to Angular v22 do not get this change and their SSR engines keep the previous behavior for `X-Forwarded-*` headers.

## Expected Behavior

Nx provides an equivalent migration (`update-23-1-0-add-trust-proxy-headers`). For projects that depend on `@angular/ssr`, it scans the source files for `new AngularNodeAppEngine(...)` / `new AngularAppEngine(...)` and inserts `trustProxyHeaders: ['x-forwarded-host', 'x-forwarded-proto']`, along with a TODO comment flagging it as a security-sensitive option. Instantiations that already set `trustProxyHeaders` are left unchanged, and the migration is idempotent.

## Implementation Details

The AST logic mirrors Angular CLI's `trust-proxy-headers` schematic (same insertion positions and guards). File discovery is adapted to Nx: instead of reading the Angular CLI `build` target's `server` option, it uses `getProjectsFilteredByDependencies(['npm:@angular/ssr'])` + `visitNotIgnoredFiles`, matching the existing Nx SSR source-editing migration `replace-provide-server-routing`.

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/angular-v22-76d725d8)
<!-- polygraph-session-end -->