### PR TITLE
feat(angular): support jest-preset-angular 16.2.0 for Angular v22

### DIFF
--- a/packages/angular/src/utils/versions.ts
+++ b/packages/angular/src/utils/versions.ts
@@ -27,7 +27,7 @@ export const autoprefixerVersion = '^10.4.0';
 export const tsNodeVersion = '10.9.1';
 export const lessVersion = '^4.3.0';
 
-export const jestPresetAngularVersion = '~16.0.0';
+export const jestPresetAngularVersion = '~16.2.0';
 export const typesNodeVersion = '^22.0.0';
 export const jasmineMarblesVersion = '^0.9.2';
 

--- a/packages/jest/migrations.json
+++ b/packages/jest/migrations.json
@@ -241,6 +241,21 @@
           "alwaysAddToPackageJson": false
         }
       }
+    },
+    "23.1.0-jest-preset-angular": {
+      "version": "23.1.0-beta.0",
+      "requires": {
+        "@angular/compiler-cli": ">=22.0.0 <23.0.0",
+        "@angular/core": ">=22.0.0 <23.0.0",
+        "@angular/platform-browser": ">=22.0.0 <23.0.0",
+        "jest": "^30.0.0"
+      },
+      "packages": {
+        "jest-preset-angular": {
+          "version": "~16.2.0",
+          "alwaysAddToPackageJson": false
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Current Behavior

`@nx/angular` generates `jest-preset-angular@~16.0.0` for jest-based unit tests. That version peers `@angular/core <22`, so Angular v22 projects end up with an incompatible preset, and there is no migration to move existing projects forward.

## Expected Behavior

New Angular v22 projects get `jest-preset-angular@~16.2.0` (peer widened to `>=19.0.0 <23.0.0`), and existing projects are bumped to it on `nx migrate` to v22. The migration lives in `@nx/jest` (processed after `@nx/angular`) to avoid the Angular/Jest requirement deadlock, is gated on `@angular/core` 22, and only applies where `jest-preset-angular` is installed. Angular 21 and 20 keep their pinned versions.

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/angular-v22-76d725d8)
<!-- polygraph-session-end -->