### PR TITLE
feat(vitest): support Angular v22 in the Analog test setup

### DIFF
--- a/packages/vitest/migrations.json
+++ b/packages/vitest/migrations.json
@@ -109,6 +109,19 @@
           "alwaysAddToPackageJson": false
         }
       }
+    },
+    "23.1.0-analog": {
+      "version": "23.1.0-beta.0",
+      "packages": {
+        "@analogjs/vite-plugin-angular": {
+          "version": "~2.6.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@analogjs/vitest-angular": {
+          "version": "~2.6.0",
+          "alwaysAddToPackageJson": false
+        }
+      }
     }
   }
 }

--- a/packages/vitest/src/utils/versions.ts
+++ b/packages/vitest/src/utils/versions.ts
@@ -22,7 +22,7 @@ export const ajvVersion = '^8.0.0';
 export const happyDomVersion = '~9.20.3';
 export const edgeRuntimeVmVersion = '~3.0.2';
 export const jitiVersion = '2.4.2';
-export const analogVitestAngular = '~2.1.2';
+export const analogVitestAngular = '~2.6.0';
 
 type VitestVersions = {
   vitestVersion: string;


### PR DESCRIPTION
## Current Behavior

`@nx/vitest` pins the Analog packages (`@analogjs/vitest-angular` and `@analogjs/vite-plugin-angular`) at `~2.1.2` through the shared `analogVitestAngular` constant. Analog `2.1.x` peer ranges exclude Angular v22 (`@angular-devkit/architect` `>=0.1500.0 <0.2200.0`, and `@analogjs/vite-plugin-angular` lists `@angular/build` only up to `^21.0.0`), so the Angular + Vitest setup is not compatible with Angular v22.

## Expected Behavior

`analogVitestAngular` is bumped to `~2.6.0`. Analog `2.6.0` widens its peers to include Angular v22 (`@angular/build ^18 || ^19 || ^20 || ^21 || ^22`, architect `<0.2300.0`) while keeping support for Angular 18-21, so new Angular Vitest projects work on v22 without dropping the older majors. A new `23.1.0-analog` `packageJsonUpdate` bumps both Analog packages to `~2.6.0` for existing workspaces on `nx migrate`, following the existing `22.2.0-analog` / `22.3.2-analog` precedent (ungated, since `2.6.0` is compatible across the whole supported Angular range).

Addresses NXC-4536.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/angular-v22-3d830e58)
<!-- polygraph-session-end -->