### PR TITLE
cleanup(testing): add explicit timeout to cache eviction e2e tests

### DIFF
--- a/e2e/nx/src/cache-no-daemon.test.ts
+++ b/e2e/nx/src/cache-no-daemon.test.ts
@@ -597,7 +597,7 @@ console.log('Build complete');
     expect(cacheEntries).toBeGreaterThan(1);
     expect(cacheEntries).toBeLessThan(10);
     expect(cacheEntriesSize).toBeLessThanOrEqual(500 * 1024);
-  });
+  }, 120000);
 
   it('should honor NX_MAX_CACHE_SIZE env var', async () => {
     runCLI('reset');
@@ -646,7 +646,7 @@ console.log('Build complete');
     expect(cacheEntries).toBeGreaterThan(1);
     expect(cacheEntries).toBeLessThan(10);
     expect(cacheEntriesSize).toBeLessThanOrEqual(500 * 1024);
-  });
+  }, 120000);
 
   describe('http remote cache', () => {
     let cacheServer: any;

--- a/e2e/nx/src/cache.test.ts
+++ b/e2e/nx/src/cache.test.ts
@@ -588,7 +588,7 @@ console.log('Build complete');
     expect(cacheEntries).toBeGreaterThan(1);
     expect(cacheEntries).toBeLessThan(10);
     expect(cacheEntriesSize).toBeLessThanOrEqual(500 * 1024);
-  });
+  }, 120000);
 
   it('should honor NX_MAX_CACHE_SIZE env var', async () => {
     runCLI('reset');
@@ -637,7 +637,7 @@ console.log('Build complete');
     expect(cacheEntries).toBeGreaterThan(1);
     expect(cacheEntries).toBeLessThan(10);
     expect(cacheEntriesSize).toBeLessThanOrEqual(500 * 1024);
-  });
+  }, 120000);
 
   describe('http remote cache', () => {
     let cacheServer: any;


### PR DESCRIPTION
## Current Behavior

The cache-eviction e2e tests `should evict cache if larger than max cache size` and `should honor NX_MAX_CACHE_SIZE env var` (in both `e2e/nx/src/cache.test.ts` and `e2e/nx/src/cache-no-daemon.test.ts`) declare no explicit jest timeout, so they inherit the workspace default of 35000ms. Their setup runs a reset plus ten cache writes that regularly takes longer than 35s on CI; the trailing awaited size check then lets the overdue timer fire, so the tests intermittently fail with "Exceeded timeout of 35000 ms" even though the eviction result is correct and deterministic. These are among the highest flake-rate e2e tasks on the Nx Cloud flaky-task dashboard.

## Expected Behavior

The four tests declare an explicit 120000ms timeout, matching the slower sibling tests already in the same files, so the deterministic eviction work completes within budget and the tests stop flaking.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/troubleshoot-flaky-tasks-9deac4de)
<!-- polygraph-session-end -->