### PR TITLE
cleanup(testing): drop sub-default timeout overrides on release e2e setup hooks

### DIFF
--- a/e2e/release/src/circular-dependencies.test.ts
+++ b/e2e/release/src/circular-dependencies.test.ts
@@ -91,7 +91,7 @@ xdescribe('nx release circular dependencies', () => {
 
     // This is the verdaccio instance that the e2e tests themselves are working from
     e2eRegistryUrl = execSync('npm config get registry').toString().trim();
-  }, 60000);
+  });
 
   afterAll(() => {
     // Restore original verbose logging value

--- a/e2e/release/src/conventional-commits-config.test.ts
+++ b/e2e/release/src/conventional-commits-config.test.ts
@@ -94,7 +94,7 @@ describe('nx release conventional commits config', () => {
     await runCommandAsync(`git tag -a ${pkg4}@0.0.1 -m "${pkg4}@0.0.1"`);
     await runCommandAsync(`git tag -a ${pkg5}@0.0.1 -m "${pkg5}@0.0.1"`);
     await runCommandAsync(`git tag -a ${pkg6}@0.0.1 -m "${pkg6}@0.0.1"`);
-  }, 60000);
+  });
   afterEach(() => cleanupProject());
 
   it('should respect custom conventional commits configuration', async () => {

--- a/e2e/release/src/conventional-commits-config.workspaces.test.ts
+++ b/e2e/release/src/conventional-commits-config.workspaces.test.ts
@@ -101,7 +101,7 @@ describe('nx release conventional commits config', () => {
     await runCommandAsync(`git tag -a ${pkg4}@0.0.1 -m "${pkg4}@0.0.1"`);
     await runCommandAsync(`git tag -a ${pkg5}@0.0.1 -m "${pkg5}@0.0.1"`);
     await runCommandAsync(`git tag -a ${pkg6}@0.0.1 -m "${pkg6}@0.0.1"`);
-  }, 60000);
+  });
   afterEach(() => cleanupProject());
 
   it('should respect custom conventional commits configuration', async () => {

--- a/e2e/release/src/custom-registries.test.ts
+++ b/e2e/release/src/custom-registries.test.ts
@@ -37,7 +37,7 @@ describe('nx release - custom npm registries', () => {
     e2eRegistryHost = e2eRegistryUrl
       .replace(/^https?:\/\//, '//')
       .replace(/\/$/, '');
-  }, 60000);
+  });
 
   afterAll(() => {
     cleanupProject();

--- a/e2e/release/src/first-release.test.ts
+++ b/e2e/release/src/first-release.test.ts
@@ -75,7 +75,7 @@ describe('nx release first run', () => {
 
     await runCommandAsync(`git add .`);
     await runCommandAsync(`git commit -m "chore: initial commit"`);
-  }, 60000);
+  });
   afterAll(() => cleanupProject());
 
   describe('without --first-release', () => {

--- a/e2e/release/src/release-tag-pattern.test.ts
+++ b/e2e/release/src/release-tag-pattern.test.ts
@@ -53,7 +53,7 @@ describe('nx release releaseTag.pattern', () => {
 
     await runCommandAsync(`git add .`);
     await runCommandAsync(`git commit -m "chore: initial commit"`);
-  }, 60000);
+  });
 
   afterEach(() => cleanupProject());
 

--- a/e2e/release/src/source-tag-selection.test.ts
+++ b/e2e/release/src/source-tag-selection.test.ts
@@ -53,7 +53,7 @@ describe('nx release source tag selection', () => {
 
     await runCommandAsync(`git add .`);
     await runCommandAsync(`git commit -m "chore: initial commit"`);
-  }, 60000);
+  });
 
   afterEach(() => cleanupProject());
 

--- a/e2e/release/src/version-plans-check.test.ts
+++ b/e2e/release/src/version-plans-check.test.ts
@@ -78,7 +78,7 @@ describe('nx release version plans check command', () => {
     await runCommandAsync(`git tag -a ${pkg3}@0.0.0 -m "${pkg3}@0.0.0"`);
     await runCommandAsync(`git tag -a ${pkg4}@0.0.0 -m "${pkg4}@0.0.0"`);
     await runCommandAsync(`git tag -a ${pkg5}@0.0.0 -m "${pkg5}@0.0.0"`);
-  }, 60000);
+  });
 
   afterEach(() => cleanupProject());
 

--- a/e2e/release/src/version-plans-only-touched.test.ts
+++ b/e2e/release/src/version-plans-only-touched.test.ts
@@ -75,7 +75,7 @@ describe('nx release version plans only touched', () => {
     await runCommandAsync(`git tag -a ${pkg3}@0.0.0 -m "${pkg3}@0.0.0"`);
     await runCommandAsync(`git tag -a ${pkg4}@0.0.0 -m "${pkg4}@0.0.0"`);
     await runCommandAsync(`git tag -a ${pkg5}@0.0.0 -m "${pkg5}@0.0.0"`);
-  }, 60000);
+  });
 
   afterEach(() => cleanupProject());
 

--- a/e2e/release/src/version-plans.test.ts
+++ b/e2e/release/src/version-plans.test.ts
@@ -86,7 +86,7 @@ describe('nx release version plans', () => {
     await runCommandAsync(`git tag -a ${pkg3}@0.0.0 -m "${pkg3}@0.0.0"`);
     await runCommandAsync(`git tag -a ${pkg4}@0.0.0 -m "${pkg4}@0.0.0"`);
     await runCommandAsync(`git tag -a ${pkg5}@0.0.0 -m "${pkg5}@0.0.0"`);
-  }, 60000);
+  });
 
   afterEach(() => cleanupProject());
 


### PR DESCRIPTION
## Current Behavior

The `e2e/release` jest project sets a `120000` ms `testTimeout` (`e2e/release/jest.config.cts`), which Jest applies to any setup hook without an explicit timeout. Ten release suites instead hardcoded a `60000` ms timeout on their `newProject`-based `beforeEach`/`beforeAll` setup, half the suite default. Under CI load that setup (`newProject` plus `@nx/workspace:npm-package` generators plus git tagging) can run past 60s, so the hook times out and the suite fails intermittently. These surface as recurring high-risk flaky tasks on the Nx Cloud dashboard (version-plans, version-plans-check, version-plans-only-touched, conventional-commits-config, among others), and a CI run on this branch reproduced it in the `first-release` `beforeAll`, where `newProject` alone took 58s.

## Expected Behavior

The setup hooks drop the explicit per-hook timeout and inherit the suite's `120000` ms default, giving the heavy setup enough headroom and removing the artificial sub-default cap. The `60000` values were copy-paste boilerplate carried in by each suite's introducing PR, not a deliberate limit, and this matches the common e2e idiom where setup hooks omit a per-hook timeout and rely on the file default.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/troubleshoot-flaky-tasks-9deac4de)
<!-- polygraph-session-end -->
