### PR TITLE
fix(gradle): sort task inputs for deterministic project graph hash

### DIFF
--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -253,36 +253,38 @@ private fun getInputsForTaskImpl(
     // Process each tasks's input files from the tooling API. Sort by path so the
     // emitted input list is stable across machines (FileCollection iteration order
     // is filesystem/JVM dependent and would otherwise drift the task hash).
-    task.inputs.files.sortedBy { it.path }.forEach { inputFile ->
-      val relativePath = replaceRootInPath(inputFile.path, projectRoot, workspaceRoot)
+    task.inputs.files
+        .sortedBy { it.path }
+        .forEach { inputFile ->
+          val relativePath = replaceRootInPath(inputFile.path, projectRoot, workspaceRoot)
 
-      when {
-        // File is outside workspace - treat as external dependency
-        relativePath == null -> {
-          try {
-            val externalDep =
-                getExternalDepFromInputFile(inputFile.path, externalNodes, task.logger)
-            externalDep?.let { externalDependencies.add(it) }
-          } catch (e: Exception) {
-            task.logger.info("Error resolving external dependency for ${inputFile.path}: $e")
+          when {
+            // File is outside workspace - treat as external dependency
+            relativePath == null -> {
+              try {
+                val externalDep =
+                    getExternalDepFromInputFile(inputFile.path, externalNodes, task.logger)
+                externalDep?.let { externalDependencies.add(it) }
+              } catch (e: Exception) {
+                task.logger.info("Error resolving external dependency for ${inputFile.path}: $e")
+              }
+            }
+
+            // File matches gitignore pattern - treat as dependentTasksOutputFiles (build artifact)
+            // Group by extension for glob patterns
+            gitIgnoreClassifier.isIgnored(inputFile) -> {
+              val extension = inputFile.extension
+              if (extension.isNotEmpty()) {
+                dependentTaskOutputExtensions.add(extension)
+              }
+            }
+
+            // Regular source file - add as direct input
+            else -> {
+              inputs.add(relativePath)
+            }
           }
         }
-
-        // File matches gitignore pattern - treat as dependentTasksOutputFiles (build artifact)
-        // Group by extension for glob patterns
-        gitIgnoreClassifier.isIgnored(inputFile) -> {
-          val extension = inputFile.extension
-          if (extension.isNotEmpty()) {
-            dependentTaskOutputExtensions.add(extension)
-          }
-        }
-
-        // Regular source file - add as direct input
-        else -> {
-          inputs.add(relativePath)
-        }
-      }
-    }
 
     // Supplement with extensions inferred from Gradle metadata (handles clean builds where
     // output directories exist but are empty, so file-based extension discovery misses them)

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -250,8 +250,10 @@ private fun getInputsForTaskImpl(
       }
     }
 
-    // Process each tasks's input files from the tooling API
-    task.inputs.files.forEach { inputFile ->
+    // Process each tasks's input files from the tooling API. Sort by path so the
+    // emitted input list is stable across machines (FileCollection iteration order
+    // is filesystem/JVM dependent and would otherwise drift the task hash).
+    task.inputs.files.sortedBy { it.path }.forEach { inputFile ->
       val relativePath = replaceRootInPath(inputFile.path, projectRoot, workspaceRoot)
 
       when {
@@ -289,12 +291,13 @@ private fun getInputsForTaskImpl(
     // Consolidate dependent-task outputs into per-extension globs (skip non-deterministic IC state)
     dependentTaskOutputExtensions
         .filterNot { nonInputDependentOutputExtensions.contains(it) }
+        .sorted()
         .forEach { extension ->
           inputs.add(mapOf("dependentTasksOutputFiles" to "**/*.$extension", "transitive" to true))
         }
 
     if (externalDependencies.isNotEmpty()) {
-      inputs.add(mapOf("externalDependencies" to externalDependencies))
+      inputs.add(mapOf("externalDependencies" to externalDependencies.sorted()))
     }
 
     inputs.ifEmpty { null }


### PR DESCRIPTION
## Current Behavior

`@nx/gradle` tasks miss the Nx Cloud cache across machines. #35972 made the project-graph configuration hash deterministic by sorting `providerDependencies` (the `ProjectConfiguration` node), but each task's input file list is still emitted in `task.inputs.files` iteration order — raw Gradle `FileCollection` (filesystem/JVM) order, which differs per machine. Nx keys the task's file-set hash node on that comma-joined list, so the same task hashes differently on different DTE agents and never replays from cache.

## Evidence

On a workspace running plugin 0.1.22, two runs of an identical `:nx-api:gradle:compileKotlin` at the same commit — one an Nx Cloud cache hit, the next a miss — differ in exactly one hash node: the source-file-list fileset (same files, different order). `ProjectConfiguration` is identical, confirming #35972 works; the unsorted input list is the only remaining drift.

## Fix

Sort the emitted inputs in `getInputsForTaskImpl`: the source file list (`task.inputs.files.sortedBy { it.path }`), the dependent-output extension globs, and `externalDependencies`. Completes the determinism work started in #35972.

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/affected-package-is-not-cached-a5603ad8)
<!-- polygraph-session-end -->