### PR TITLE
fix(js): correct inferred tsbuildinfo output path when rootDir is set

### DIFF
--- a/packages/js/src/plugins/typescript/plugin.spec.ts
+++ b/packages/js/src/plugins/typescript/plugin.spec.ts
@@ -1111,7 +1111,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
                   },
                   "outputs": [
                     "{projectRoot}/out-tsc/my-lib/**/*.{js,cjs,mjs,jsx,d.ts,d.cts,d.mts}{,.map}",
-                    "{projectRoot}/out-tsc/my-lib/tsconfig.lib.tsbuildinfo",
+                    "{projectRoot}/out-tsc/tsconfig.lib.tsbuildinfo",
                   ],
                   "syncGenerators": [
                     "@nx/js:typescript-sync",
@@ -2954,7 +2954,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
                     },
                     "outputs": [
                       "{projectRoot}/out-tsc/my-lib/**/*.{js,cjs,mjs,jsx,d.ts,d.cts,d.mts}{,.map}",
-                      "{projectRoot}/out-tsc/my-lib/tsconfig.lib.tsbuildinfo",
+                      "{projectRoot}/out-tsc/tsconfig.lib.tsbuildinfo",
                     ],
                     "syncGenerators": [
                       "@nx/js:typescript-sync",
@@ -2998,7 +2998,7 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
                     "outputs": [
                       "{projectRoot}/tsconfig.tsbuildinfo",
                       "{projectRoot}/out-tsc/my-lib/**/*.{d.ts,d.cts,d.mts}",
-                      "{projectRoot}/out-tsc/my-lib/tsconfig.lib.tsbuildinfo",
+                      "{projectRoot}/out-tsc/tsconfig.lib.tsbuildinfo",
                     ],
                     "syncGenerators": [
                       "@nx/js:typescript-sync",
@@ -3008,6 +3008,37 @@ describe(`Plugin: ${PLUGIN_NAME}`, () => {
               },
             },
           }
+        `);
+      });
+
+      it('should resolve the tsbuildinfo file relative to rootDir, even outside outDir', async () => {
+        // tsc resolves the config path (sans extension) relative to rootDir
+        // against outDir. With rootDir 'src' the config sits one level above
+        // it, so the tsbuildinfo lands at the project root, not inside outDir.
+        configFiles = await applyFilesToTempFsAndContext(tempFs, context, {
+          'libs/my-lib/tsconfig.json': JSON.stringify({
+            files: [],
+            references: [{ path: './tsconfig.lib.json' }],
+          }),
+          'libs/my-lib/tsconfig.lib.json': JSON.stringify({
+            compilerOptions: { outDir: 'dist', rootDir: 'src' },
+            files: ['src/main.ts'],
+          }),
+          'libs/my-lib/package.json': `{}`,
+        });
+
+        const result = await invokeCreateNodesOnMatchingFiles(
+          configFiles,
+          context,
+          { build: { configName: 'tsconfig.lib.json' } }
+        );
+
+        expect(result.projects['libs/my-lib'].targets.build.outputs)
+          .toMatchInlineSnapshot(`
+          [
+            "{projectRoot}/dist/**/*.{js,cjs,mjs,jsx,d.ts,d.cts,d.mts}{,.map}",
+            "{projectRoot}/tsconfig.lib.tsbuildinfo",
+          ]
         `);
       });
 

--- a/packages/js/src/plugins/typescript/plugin.ts
+++ b/packages/js/src/plugins/typescript/plugin.ts
@@ -966,14 +966,14 @@ function getOutputs(
   // reflected in the outputs. So, we just include everything that could be
   // produced by the tsc command.
   [
-    { configBaseNameNoExt: config.basenameNoExt, tsConfig: rootTsConfig },
+    { configPath: config.absolutePath, tsConfig: rootTsConfig },
     ...Object.entries(internalProjectReferences).map(
       ([internalConfigPath, internalConfig]) => ({
-        configBaseNameNoExt: basename(internalConfigPath, '.json'),
+        configPath: internalConfigPath,
         tsConfig: internalConfig,
       })
     ),
-  ].forEach(({ configBaseNameNoExt, tsConfig }) => {
+  ].forEach(({ configPath, tsConfig }) => {
     if (tsConfig.options.outFile) {
       const outFileName = basename(tsConfig.options.outFile, '.js');
       const outFileDir = dirname(tsConfig.options.outFile);
@@ -1072,7 +1072,7 @@ function getOutputs(
     outputs.add(
       getTsBuildInfoOutputPath(
         tsConfig,
-        configBaseNameNoExt,
+        configPath,
         workspaceRoot,
         config.project
       )
@@ -1088,7 +1088,7 @@ function getOutputs(
  */
 function getTsBuildInfoOutputPath(
   tsConfig: ParsedTsconfigData,
-  configBaseNameNoExt: string,
+  configPath: string,
   workspaceRoot: string,
   project: ProjectContext
 ): string {
@@ -1110,20 +1110,34 @@ function getTsBuildInfoOutputPath(
     );
   }
 
+  const configPathNoExt = join(
+    dirname(configPath),
+    basename(configPath, '.json')
+  );
+
   if (tsConfig.options.outDir) {
-    return pathToInputOrOutput(
-      joinPathFragments(
-        tsConfig.options.outDir,
-        `${configBaseNameNoExt}.tsbuildinfo`
-      ),
-      workspaceRoot,
-      project
-    );
+    // When rootDir is set, tsc resolves the config path (sans extension)
+    // relative to rootDir against outDir, which can place the file outside
+    // outDir (e.g. rootDir 'src' with the config one level up emits to the
+    // parent of outDir). Without rootDir it just drops the file in outDir.
+    // Mirror tsc's getTsBuildInfoEmitOutputFilePath so the declared output
+    // matches what's emitted.
+    const buildInfoPath = tsConfig.options.rootDir
+      ? `${resolve(
+          tsConfig.options.outDir,
+          relative(tsConfig.options.rootDir, configPathNoExt)
+        )}.tsbuildinfo`
+      : joinPathFragments(
+          tsConfig.options.outDir,
+          `${basename(configPathNoExt)}.tsbuildinfo`
+        );
+
+    return pathToInputOrOutput(buildInfoPath, workspaceRoot, project);
   }
 
   return joinPathFragments(
     '{projectRoot}',
-    `${configBaseNameNoExt}.tsbuildinfo`
+    `${basename(configPathNoExt)}.tsbuildinfo`
   );
 }
 


### PR DESCRIPTION
## Current Behavior

The `@nx/js` TypeScript plugin infers `.tsbuildinfo` outputs for `tsc --build` tasks (build / typecheck). When a tsconfig sets `outDir`, the plugin always declared the buildinfo at `outDir/<configBaseName>.tsbuildinfo`. But when `rootDir` is also set (and `tsBuildInfoFile` is not), `tsc` resolves the path differently: it takes the config path relative to `rootDir` and resolves that against `outDir`, which can place the file outside `outDir`. For the standard generated library shape (`rootDir: "src"`), the buildinfo lands one level above a nested `outDir`; with a sibling `outDir` it lands at the project root. The declared output never matched the emitted file, causing cache misses and task-sandboxing violations.

## Expected Behavior

The inferred `.tsbuildinfo` output matches where `tsc` actually writes the file across all `outDir` + `rootDir` combinations, so the build cache captures and restores it and task sandboxing reports no violation.

## Implementation Details

`getTsBuildInfoOutputPath` now mirrors tsc's `getTsBuildInfoEmitOutputFilePath`: when `rootDir` is set it resolves the config path (sans extension) relative to `rootDir` against `outDir`. The `outFile`, `tsBuildInfoFile`, no-`outDir`, and `outDir`-without-`rootDir` cases are unchanged. Two existing snapshots that encoded the wrong path were corrected, and a regression test was added for the case where the buildinfo escapes `outDir` to the project root.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/nxc-4551-904de5a8)
<!-- polygraph-session-end -->