### PR TITLE
docs(misc): add sandbox badge to nx READMEs

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@
     <a href=""><img src="https://img.shields.io/npm/l/nx.svg?style=for-the-badge" alt="License"></a>
     <a href="https://go.nx.dev/community"><img src="https://img.shields.io/discord/1143497901675401286?label=discord&style=for-the-badge" alt="Discord"></a>
     <a href="https://x.com/nxdevtools"><img src="https://img.shields.io/badge/@nxdevtools-555?style=for-the-badge&logo=x" alt="X (Twitter)"></a>
+    <a href="https://nx.dev/docs/features/ci-features/sandboxing"><img src="https://staging.nx.app/workspaces/62d013ea0852fe0a2df74438/sandbox-badge.svg?style=for-the-badge" alt="Nx Sandboxing"></a>
   </p>
 
  <br />

--- a/scripts/readme-fragments/links.md
+++ b/scripts/readme-fragments/links.md
@@ -1,11 +1,10 @@
 <div style="text-align: center;">
 
-[![CircleCI](https://circleci.com/gh/nrwl/nx.svg?style=svg)](https://circleci.com/gh/nrwl/nx)
 [![License](https://img.shields.io/npm/l/@nx/workspace.svg?style=flat-square)]()
 [![NPM Version](https://badge.fury.io/js/nx.svg)](https://www.npmjs.com/package/nx)
 [![Semantic Release](https://img.shields.io/badge/%20%20%F0%9F%93%A6%F0%9F%9A%80-semantic--release-e10079.svg?style=flat-square)]()
 [![Commitizen friendly](https://img.shields.io/badge/commitizen-friendly-brightgreen.svg)](http://commitizen.github.io/cz-cli/)
-[![Join the chat at https://gitter.im/nrwl-nx/community](https://badges.gitter.im/nrwl-nx/community.svg)](https://gitter.im/nrwl-nx/community?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Join us on the Official Nx Discord Server](https://img.shields.io/discord/1143497901675401286?label=discord)](https://go.nx.dev/community)
+[![Nx Sandboxing](https://staging.nx.app/workspaces/62d013ea0852fe0a2df74438/sandbox-badge.svg)](https://nx.dev/docs/features/ci-features/sandboxing)
 
 </div>


### PR DESCRIPTION
## Current Behavior

Root and npm package READMEs show CircleCI and gitter badges, with no sandbox badge.

## Expected Behavior

Root README shows a for-the-badge style sandbox badge; generated npm package READMEs show the default-style sandbox badge (via the shared `scripts/readme-fragments/links.md` fragment). The CircleCI and gitter badges are removed from the npm fragment. Both badges link to the nx.dev sandboxing docs.

## Related Issue(s)

NXC-4568

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/nx-cli-readme-badge-aaf40283)
<!-- polygraph-session-end -->