### PR TITLE
fix(angular): resolve esbuild option paths relative to the workspace root

### DIFF
--- a/e2e/angular/src/projects-esbuild.test.ts
+++ b/e2e/angular/src/projects-esbuild.test.ts
@@ -120,4 +120,39 @@ describe('Angular Projects - Esbuild', () => {
       `<title>${esbuildApp} (transformed)</title>`
     );
   });
+
+  it('should support a TypeScript "index.html" transformer located in a library referenced with {workspaceRoot}', async () => {
+    const { esbuildApp, lib1 } = setup;
+
+    // A .ts transformer is loaded via require(), unlike .mjs which Node
+    // resolves against cwd. Placing it in a library and referencing it with
+    // {workspaceRoot} exercises the workspace-relative path resolution.
+    updateFile(
+      `${lib1}/src/index.transformer.ts`,
+      `const indexHtmlTransformer = (indexContent: string): string => {
+        return indexContent.replace(
+          '<title>${esbuildApp}</title>',
+          '<title>${esbuildApp} (transformed from lib)</title>'
+        );
+      };
+
+      export default indexHtmlTransformer;`
+    );
+
+    updateJson(join(esbuildApp, 'project.json'), (config) => {
+      config.targets.build.executor = '@nx/angular:application';
+      config.targets.build.options = {
+        ...config.targets.build.options,
+        indexHtmlTransformer: `{workspaceRoot}/${lib1}/src/index.transformer.ts`,
+      };
+      return config;
+    });
+
+    runCLI(`build ${esbuildApp}`);
+
+    const indexHtmlContent = readFile(`dist/${esbuildApp}/browser/index.html`);
+    expect(indexHtmlContent).toContain(
+      `<title>${esbuildApp} (transformed from lib)</title>`
+    );
+  });
 });

--- a/packages/angular/src/executors/utilities/esbuild-extensions.ts
+++ b/packages/angular/src/executors/utilities/esbuild-extensions.ts
@@ -1,4 +1,7 @@
 import type { buildApplication } from '@angular/build';
+import { workspaceRoot } from '@nx/devkit';
+import { existsSync } from 'node:fs';
+import { isAbsolute, join } from 'node:path';
 import { loadModule } from './module-loader';
 
 // This is a workaround to make sure we use the same esbuild version as the
@@ -10,6 +13,18 @@ export type PluginSpec = {
   path: string;
   options: any;
 };
+
+// Nx strips {workspaceRoot}/ and expands {projectRoot} in option paths to a
+// path relative to the workspace root, but require() would resolve that against
+// this file's directory. Anchor it to the workspace root, while leaving bare
+// package specifiers (e.g. an esbuild plugin shipped as a package) untouched.
+function resolveModulePath(path: string): string {
+  if (isAbsolute(path)) {
+    return path;
+  }
+  const candidate = join(workspaceRoot, path);
+  return existsSync(candidate) ? candidate : path;
+}
 
 export async function loadPlugins(
   plugins: string[] | PluginSpec[] | undefined,
@@ -31,7 +46,7 @@ async function loadPlugin(
   const pluginPath =
     typeof pluginSpec === 'string' ? pluginSpec : pluginSpec.path;
 
-  let plugin = await loadModule(pluginPath, tsConfig);
+  let plugin = await loadModule(resolveModulePath(pluginPath), tsConfig);
 
   if (typeof plugin === 'function') {
     plugin =
@@ -49,7 +64,9 @@ export async function loadMiddleware(
     return [];
   }
   return Promise.all(
-    middlewareFns.map((fnPath) => loadModule(fnPath, tsConfig))
+    middlewareFns.map((fnPath) =>
+      loadModule(resolveModulePath(fnPath), tsConfig)
+    )
   );
 }
 
@@ -57,5 +74,5 @@ export async function loadIndexHtmlTransformer(
   indexHtmlTransformerPath: string,
   tsConfig: string
 ): Promise<any> {
-  return loadModule(indexHtmlTransformerPath, tsConfig);
+  return loadModule(resolveModulePath(indexHtmlTransformerPath), tsConfig);
 }


### PR DESCRIPTION
## Current Behavior

The `@nx/angular` esbuild-based executors (`application`, `browser-esbuild`, `unit-test`) and the dev-server builder load the `indexHtmlTransformer`, `plugins`, and `esbuildMiddleware` option files with `require()`. Nx first resolves the `{workspaceRoot}` and `{projectRoot}` tokens in those options to a path relative to the workspace root, so a transformer kept in a library resolved to something like `libs/common/src/index-html-nonce-transform.ts`. `require()` resolves a bare relative path against the loader's own directory under `node_modules`, not the workspace root, so the build failed with `Cannot find module 'libs/common/src/index-html-nonce-transform.ts'`.

## Expected Behavior

These option files load correctly when referenced with `{workspaceRoot}` or `{projectRoot}` (or any workspace-relative path), including when they live in a library. A plugin published as a package keeps resolving through `node_modules` unchanged.

## Related Issue(s)

Fixes #35936

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/gh-35936-4126c3f7)
<!-- polygraph-session-end -->