### PR TITLE
fix(angular-rspack): surface compilation failures as build errors and release resources on teardown

### DIFF
--- a/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.spec.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { AngularCompilation, SourceFileCache } from '../models';
+import { setupCompilationWithAngularCompilation } from './setup-with-angular-compilation';
+import type { SetupCompilationOptions } from './setup-compilation';
+
+vi.mock('./setup-compilation', () => ({
+  setupCompilation: vi.fn().mockResolvedValue({
+    rootNames: ['/root/src/main.ts'],
+    compilerOptions: {},
+    componentStylesheetBundler: {},
+  }),
+  styleTransform: vi.fn(() => async () => ({ contents: '' })),
+}));
+
+describe('setupCompilationWithAngularCompilation', () => {
+  const options: SetupCompilationOptions = {
+    root: '/root',
+    tsConfig: '/root/tsconfig.json',
+    aot: true,
+    inlineStyleLanguage: 'css',
+    fileReplacements: [],
+  };
+
+  it('should propagate initialization errors', async () => {
+    const angularCompilation = {
+      initialize: vi
+        .fn()
+        .mockRejectedValue(new Error('TS version not supported')),
+    } as unknown as AngularCompilation;
+
+    await expect(
+      setupCompilationWithAngularCompilation(
+        { source: { tsconfigPath: '/root/tsconfig.json' } },
+        options,
+        undefined,
+        angularCompilation
+      )
+    ).rejects.toThrow('TS version not supported');
+  });
+
+  it('should set referenced files on the source file cache', async () => {
+    const angularCompilation = {
+      initialize: vi
+        .fn()
+        .mockResolvedValue({ referencedFiles: ['/root/src/main.ts'] }),
+    } as unknown as AngularCompilation;
+    const sourceFileCache = {} as SourceFileCache;
+
+    const result = await setupCompilationWithAngularCompilation(
+      { source: { tsconfigPath: '/root/tsconfig.json' } },
+      options,
+      sourceFileCache,
+      angularCompilation
+    );
+
+    expect(sourceFileCache.referencedFiles).toEqual(['/root/src/main.ts']);
+    expect(result.angularCompilation).toBe(angularCompilation);
+  });
+});

--- a/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.ts
@@ -54,25 +54,24 @@ export async function setupCompilationWithAngularCompilation(
     return result.contents;
   };
 
-  try {
-    const { referencedFiles } = await angularCompilation.initialize(
-      config.source?.tsconfigPath ?? options.tsConfig,
-      {
-        sourceFileCache,
-        fileReplacements,
-        modifiedFiles,
-        transformStylesheet: wrappedTransformStylesheet,
-        processWebWorker(workerFile: string) {
-          return workerFile;
-        },
+  // Initialization errors are intentionally not caught here: callers must
+  // surface them as build errors instead of continuing with a compilation
+  // that was never initialized.
+  const { referencedFiles } = await angularCompilation.initialize(
+    config.source?.tsconfigPath ?? options.tsConfig,
+    {
+      sourceFileCache,
+      fileReplacements,
+      modifiedFiles,
+      transformStylesheet: wrappedTransformStylesheet,
+      processWebWorker(workerFile: string) {
+        return workerFile;
       },
-      () => compilerOptions
-    );
-    if (sourceFileCache) {
-      sourceFileCache.referencedFiles = referencedFiles;
-    }
-  } catch (e) {
-    console.error('Failed to initialize Angular Compilation', e);
+    },
+    () => compilerOptions
+  );
+  if (sourceFileCache) {
+    sourceFileCache.referencedFiles = referencedFiles;
   }
   return {
     angularCompilation,

--- a/packages/angular-rspack/src/lib/models/augmented-compilation.ts
+++ b/packages/angular-rspack/src/lib/models/augmented-compilation.ts
@@ -10,6 +10,9 @@ export const NG_RSPACK_SYMBOL_NAME = 'NG_RSPACK_BUILD';
 export type NG_RSPACK_COMPILATION_STATE = {
   javascriptTransformer: JavaScriptTransformer;
   typescriptFileCache: SourceFileCache['typeScriptFileCache'];
+  // True when the Angular compilation failed to initialize or emit, meaning
+  // the typescript file cache cannot be relied on for this build.
+  angularCompilationFailed: boolean;
   i18n?: I18nOptions;
 };
 export type NgRspackCompilation = Compilation & {

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.spec.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.spec.ts
@@ -1,0 +1,285 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { NormalizedAngularRspackPluginOptions } from '../models';
+import { NG_RSPACK_SYMBOL_NAME, type NgRspackCompilation } from '../models';
+import { AngularRspackPlugin } from './angular-rspack-plugin';
+
+const {
+  buildAndAnalyzeMock,
+  setupCompilationMock,
+  disposeComponentStylesheetBundlerMock,
+  transformerCloseMock,
+} = vi.hoisted(() => ({
+  buildAndAnalyzeMock: vi.fn(),
+  setupCompilationMock: vi.fn(),
+  disposeComponentStylesheetBundlerMock: vi.fn(),
+  transformerCloseMock: vi.fn(),
+}));
+
+vi.mock('@nx/angular-rspack-compiler', () => ({
+  buildAndAnalyze: buildAndAnalyzeMock,
+  DiagnosticModes: { All: 7 },
+  disposeComponentStylesheetBundler: disposeComponentStylesheetBundlerMock,
+  JavaScriptTransformer: class {
+    close = transformerCloseMock;
+  },
+  SourceFileCache: class {
+    typeScriptFileCache = new Map<string, string | Uint8Array>();
+    referencedFiles: string[] = [];
+    invalidate = vi.fn();
+  },
+  maxWorkers: () => 1,
+  setupCompilationWithAngularCompilation: setupCompilationMock,
+  AngularCompilation: class {},
+}));
+
+type Tap = { name: string; fn: (...args: unknown[]) => unknown };
+function createHook() {
+  const taps: Tap[] = [];
+  return {
+    taps,
+    tap: (name: string, fn: Tap['fn']) => taps.push({ name, fn }),
+    tapAsync: (name: string, fn: Tap['fn']) => taps.push({ name, fn }),
+  };
+}
+
+class FakeWebpackError extends Error {}
+
+function createFakeCompiler() {
+  const compiler = {
+    hooks: {
+      beforeRun: createHook(),
+      watchRun: createHook(),
+      beforeCompile: createHook(),
+      compilation: createHook(),
+      thisCompilation: createHook(),
+      emit: createHook(),
+      afterEmit: createHook(),
+      done: createHook(),
+      afterDone: createHook(),
+      shutdown: createHook(),
+      normalModuleFactory: createHook(),
+    },
+    options: {
+      resolve: { tsConfig: '/root/tsconfig.json' },
+      stats: undefined,
+      target: 'web',
+    },
+    rspack: {
+      Compilation: { PROCESS_ASSETS_STAGE_ADDITIONS: 100 },
+      WebpackError: FakeWebpackError,
+      sources: {},
+    },
+    watching: undefined,
+  };
+  return compiler;
+}
+
+function createFakeCompilation(
+  compiler: ReturnType<typeof createFakeCompiler>
+) {
+  return {
+    errors: [] as Error[],
+    warnings: [] as Error[],
+    hooks: { afterSeal: createHook(), processAssets: createHook() },
+    fileDependencies: { add: vi.fn() },
+    compiler,
+  };
+}
+
+async function fireAsyncTaps(
+  hook: ReturnType<typeof createHook>,
+  ...args: unknown[]
+) {
+  for (const tap of [...hook.taps]) {
+    await new Promise<void>((resolve, reject) => {
+      try {
+        const result = tap.fn(...args, resolve);
+        // rspack ignores promises returned from tapAsync functions, so a
+        // rejection means the tap leaked an error instead of handling it -
+        // fail the test in that case.
+        if (result instanceof Promise) {
+          result.catch(reject);
+        }
+      } catch (e) {
+        reject(e);
+      }
+    });
+  }
+}
+
+function fireSyncTaps(hook: ReturnType<typeof createHook>, ...args: unknown[]) {
+  for (const tap of [...hook.taps]) {
+    tap.fn(...args);
+  }
+}
+
+describe('AngularRspackPlugin', () => {
+  const options = {
+    root: '/root',
+    aot: true,
+    tsConfig: '/root/tsconfig.json',
+    inlineStyleLanguage: 'css',
+    fileReplacements: [],
+    hasServer: false,
+    skipTypeChecking: false,
+    sourceMap: { scripts: true, styles: true, hidden: false, vendor: false },
+    advancedOptimizations: false,
+    budgets: [],
+    verbose: false,
+    outputPath: { browser: '/root/dist/browser' },
+  } as unknown as NormalizedAngularRspackPluginOptions;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    transformerCloseMock.mockResolvedValue(undefined);
+    disposeComponentStylesheetBundlerMock.mockResolvedValue(undefined);
+    buildAndAnalyzeMock.mockResolvedValue(undefined);
+    setupCompilationMock.mockResolvedValue({
+      angularCompilation: { diagnoseFiles: vi.fn().mockResolvedValue({}) },
+      collectedStylesheetAssets: [],
+    });
+  });
+
+  function applyPlugin() {
+    const compiler = createFakeCompiler();
+    const plugin = new AngularRspackPlugin(options);
+    plugin.apply(compiler as never);
+    return compiler;
+  }
+
+  async function runBuildStart(
+    compiler: ReturnType<typeof createFakeCompiler>
+  ) {
+    // beforeRun registers the beforeCompile tap that runs build and analyze
+    await fireAsyncTaps(compiler.hooks.beforeRun, compiler);
+    await fireAsyncTaps(compiler.hooks.beforeCompile, {});
+  }
+
+  it('should report an initialization failure as a compilation error and skip further compilation steps', async () => {
+    setupCompilationMock.mockRejectedValue(new Error('NgtscProgram failed'));
+    const compiler = applyPlugin();
+
+    await runBuildStart(compiler);
+
+    expect(buildAndAnalyzeMock).not.toHaveBeenCalled();
+
+    const compilation = createFakeCompilation(compiler);
+    fireSyncTaps(compiler.hooks.thisCompilation, compilation);
+    expect(compilation.errors).toHaveLength(1);
+    expect(compilation.errors[0].message).toContain(
+      'Angular compilation initialization failed.'
+    );
+    expect(compilation.errors[0].message).toContain('NgtscProgram failed');
+
+    // the loaders are signaled to short-circuit
+    fireSyncTaps(compiler.hooks.compilation, compilation);
+    const state = (compilation as unknown as NgRspackCompilation)[
+      NG_RSPACK_SYMBOL_NAME
+    ]();
+    expect(state.angularCompilationFailed).toBe(true);
+
+    // emit skips diagnostics (no angular compilation to diagnose) and does not throw
+    await fireAsyncTaps(compiler.hooks.emit, compilation);
+    expect(compilation.errors).toHaveLength(1);
+  });
+
+  it('should report an emit failure as a compilation error and still run diagnostics', async () => {
+    const diagnoseFiles = vi.fn().mockResolvedValue({});
+    setupCompilationMock.mockResolvedValue({
+      angularCompilation: { diagnoseFiles },
+      collectedStylesheetAssets: [],
+    });
+    buildAndAnalyzeMock.mockRejectedValue(new Error('worker crashed'));
+    const compiler = applyPlugin();
+
+    await runBuildStart(compiler);
+
+    const compilation = createFakeCompilation(compiler);
+    fireSyncTaps(compiler.hooks.thisCompilation, compilation);
+    expect(compilation.errors).toHaveLength(1);
+    expect(compilation.errors[0].message).toContain(
+      'Angular compilation emit failed.'
+    );
+    expect(compilation.errors[0].message).toContain('worker crashed');
+
+    // the loaders are signaled to short-circuit
+    fireSyncTaps(compiler.hooks.compilation, compilation);
+    const state = (compilation as unknown as NgRspackCompilation)[
+      NG_RSPACK_SYMBOL_NAME
+    ]();
+    expect(state.angularCompilationFailed).toBe(true);
+
+    // unlike an initialization failure, diagnostics still run - they
+    // usually carry the root cause of the emit failure
+    await fireAsyncTaps(compiler.hooks.emit, compilation);
+    expect(diagnoseFiles).toHaveBeenCalled();
+  });
+
+  it('should surface a diagnostics failure as a build error instead of hanging the build', async () => {
+    const diagnoseFiles = vi
+      .fn()
+      .mockRejectedValue(new Error('diagnostics crashed'));
+    setupCompilationMock.mockResolvedValue({
+      angularCompilation: { diagnoseFiles },
+      collectedStylesheetAssets: [],
+    });
+    const compiler = applyPlugin();
+
+    await runBuildStart(compiler);
+
+    const compilation = createFakeCompilation(compiler);
+    // emit must resolve (the callback fires) rather than leak the rejection
+    await fireAsyncTaps(compiler.hooks.emit, compilation);
+
+    expect(transformerCloseMock).toHaveBeenCalled();
+    expect(
+      compilation.errors.some((error) =>
+        error.message.includes('Angular diagnostics failed.')
+      )
+    ).toBe(true);
+  });
+
+  it('should clear the error and recover on a rebuild that initializes successfully', async () => {
+    setupCompilationMock.mockRejectedValueOnce(new Error('transient failure'));
+    const compiler = applyPlugin();
+
+    // first watch build fails to initialize
+    await fireAsyncTaps(compiler.hooks.watchRun, compiler);
+    await fireAsyncTaps(compiler.hooks.beforeCompile, {});
+    const failedCompilation = createFakeCompilation(compiler);
+    fireSyncTaps(compiler.hooks.thisCompilation, failedCompilation);
+    expect(failedCompilation.errors).toHaveLength(1);
+    expect(buildAndAnalyzeMock).not.toHaveBeenCalled();
+
+    // next rebuild initializes successfully and recovers
+    await fireAsyncTaps(compiler.hooks.watchRun, compiler);
+    await fireAsyncTaps(compiler.hooks.beforeCompile, {});
+    const compilation = createFakeCompilation(compiler);
+    fireSyncTaps(compiler.hooks.thisCompilation, compilation);
+    expect(compilation.errors).toHaveLength(0);
+    expect(buildAndAnalyzeMock).toHaveBeenCalledTimes(1);
+
+    fireSyncTaps(compiler.hooks.compilation, compilation);
+    const state = (compilation as unknown as NgRspackCompilation)[
+      NG_RSPACK_SYMBOL_NAME
+    ]();
+    expect(state.angularCompilationFailed).toBe(false);
+  });
+
+  it('should not throw from afterDone when the run failed before producing stats', async () => {
+    const compiler = applyPlugin();
+
+    expect(() =>
+      fireSyncTaps(compiler.hooks.afterDone, undefined)
+    ).not.toThrow();
+  });
+
+  it('should release the worker pool and the stylesheet bundler on shutdown', async () => {
+    const compiler = applyPlugin();
+
+    await fireAsyncTaps(compiler.hooks.shutdown);
+
+    expect(transformerCloseMock).toHaveBeenCalled();
+    expect(disposeComponentStylesheetBundlerMock).toHaveBeenCalled();
+  });
+});

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
@@ -46,6 +46,8 @@ export class AngularRspackPlugin implements RspackPluginInstance {
   // This will be defined in the apply method correctly
   #angularCompilation: AngularCompilation;
   #collectedStylesheetAssets: Array<{ path: string; text: string }> = [];
+  #initializationError: string | undefined;
+  #emitError: string | undefined;
 
   constructor(
     options: NormalizedAngularRspackPluginOptions,
@@ -84,11 +86,7 @@ export class AngularRspackPlugin implements RspackPluginInstance {
         compiler.hooks.beforeCompile.tapAsync(
           PLUGIN_NAME,
           async (params, callback) => {
-            await buildAndAnalyze(
-              this.#angularCompilation,
-              this.#sourceFileCache.typeScriptFileCache,
-              this.#javascriptTransformer
-            );
+            await this.buildAndAnalyze();
             callback();
           }
         );
@@ -131,11 +129,7 @@ export class AngularRspackPlugin implements RspackPluginInstance {
                   : undefined
               );
 
-              await buildAndAnalyze(
-                this.#angularCompilation,
-                this.#sourceFileCache.typeScriptFileCache,
-                this.#javascriptTransformer
-              );
+              await this.buildAndAnalyze();
 
               // Update shared state for compilation hook
               currentWatchingModifiedFiles = watchingModifiedFiles;
@@ -150,6 +144,15 @@ export class AngularRspackPlugin implements RspackPluginInstance {
     );
 
     compiler.hooks.thisCompilation.tap(PLUGIN_NAME, (compilation) => {
+      // Surface a failed Angular compilation as a build error (like
+      // @angular/build) instead of an exception that stalls the hooks chain.
+      // Watch builds recover on the next rebuild's re-init.
+      const angularCompilationError =
+        this.#initializationError ?? this.#emitError;
+      if (angularCompilationError) {
+        addError(compilation, angularCompilationError);
+      }
+
       // Handle errors thrown by loaders that prevent sealing (but ignore for watch mode)
       compilation.hooks.afterSeal.tapAsync(PLUGIN_NAME, (callback) => {
         if (!watchRunInitialized && compilation.errors.length > 0) {
@@ -246,28 +249,46 @@ export class AngularRspackPlugin implements RspackPluginInstance {
     });
 
     compiler.hooks.emit.tapAsync(PLUGIN_NAME, async (compilation, callback) => {
-      if (!this.#_options.skipTypeChecking) {
-        const { errors, warnings } =
-          await this.#angularCompilation.diagnoseFiles(DiagnosticModes.All);
-        for (const error of errors ?? []) {
-          compilation.errors.push({
-            name: PLUGIN_NAME,
-            message: error.text || '',
-            file: error.location?.file,
-            stack: error.text,
-          });
+      // Skip diagnostics when the Angular compilation failed to initialize:
+      // there is no (or only stale) compilation state to diagnose and the
+      // failure is already reported as a compilation error. After an emit
+      // failure diagnostics still run since they usually carry the root
+      // cause, matching @angular/build's application builder.
+      try {
+        if (!this.#_options.skipTypeChecking && !this.#initializationError) {
+          const { errors, warnings } =
+            await this.#angularCompilation.diagnoseFiles(DiagnosticModes.All);
+          for (const error of errors ?? []) {
+            compilation.errors.push({
+              name: PLUGIN_NAME,
+              message: error.text || '',
+              file: error.location?.file,
+              stack: error.text,
+            });
+          }
+          for (const warning of warnings ?? []) {
+            compilation.warnings.push({
+              name: PLUGIN_NAME,
+              message: warning.text || '',
+              file: warning.location?.file,
+              stack: warning.text,
+            });
+          }
         }
-        for (const warning of warnings ?? []) {
-          compilation.warnings.push({
-            name: PLUGIN_NAME,
-            message: warning.text || '',
-            file: warning.location?.file,
-            stack: warning.text,
-          });
-        }
+      } catch (error) {
+        // A diagnostics failure must not leave the loader callback pending
+        // and hang the build. Surface it as a build error instead.
+        addError(
+          compilation,
+          `Angular diagnostics failed.\n${formatError(error)}`
+        );
       }
 
-      await this.#javascriptTransformer.close();
+      try {
+        await this.#javascriptTransformer.close();
+      } catch {
+        // Best-effort cleanup that must never hang the build.
+      }
       callback();
     });
 
@@ -326,6 +347,13 @@ export class AngularRspackPlugin implements RspackPluginInstance {
     });
 
     compiler.hooks.afterDone.tap(PLUGIN_NAME, (stats) => {
+      // Despite the typings, stats is undefined when the run fails before
+      // producing stats (e.g. the afterSeal hook above fails the seal for a
+      // build with errors). Rspack reports that failure itself.
+      if (!stats) {
+        return;
+      }
+
       // Get stats options - merge defaults with user's config if provided
       const configStats = compiler.options.stats;
       const defaultStatsOptions = getStatsOptions(this.#_options.verbose);
@@ -363,6 +391,22 @@ export class AngularRspackPlugin implements RspackPluginInstance {
       }
     );
 
+    // Failed builds skip the done hook (afterSeal fails the seal), so release
+    // the esbuild service and worker pool here too. Runs on close for both
+    // one-shot and watch; both teardowns are idempotent.
+    compiler.hooks.shutdown.tapAsync(
+      `${PLUGIN_NAME}_cleanup`,
+      async (callback) => {
+        try {
+          await this.#javascriptTransformer.close();
+          await disposeComponentStylesheetBundler();
+        } catch {
+          // Best-effort cleanup that must never fail the compiler teardown.
+        }
+        callback();
+      }
+    );
+
     compiler.hooks.normalModuleFactory.tap(
       PLUGIN_NAME,
       (normalModuleFactory) => {
@@ -382,6 +426,9 @@ export class AngularRspackPlugin implements RspackPluginInstance {
         javascriptTransformer: this
           .#javascriptTransformer as unknown as JavaScriptTransformer,
         typescriptFileCache: this.#sourceFileCache.typeScriptFileCache,
+        angularCompilationFailed:
+          this.#initializationError !== undefined ||
+          this.#emitError !== undefined,
         i18n: this.#i18n,
       });
     });
@@ -436,33 +483,64 @@ export class AngularRspackPlugin implements RspackPluginInstance {
     tsConfig: RspackOptionsNormalized['resolve']['tsConfig'],
     modifiedFiles?: Set<string>
   ) {
+    this.#initializationError = undefined;
+    this.#emitError = undefined;
     const tsconfigPath = tsConfig
       ? typeof tsConfig === 'string'
         ? tsConfig
         : tsConfig.configFile
       : this.#_options.tsConfig;
-    const result = await setupCompilationWithAngularCompilation(
-      {
-        source: {
-          tsconfigPath: tsconfigPath,
+    try {
+      const result = await setupCompilationWithAngularCompilation(
+        {
+          source: {
+            tsconfigPath: tsconfigPath,
+          },
         },
-      },
-      {
-        root,
-        aot: this.#_options.aot,
-        tsConfig: tsconfigPath,
-        inlineStyleLanguage: this.#_options.inlineStyleLanguage,
-        fileReplacements: this.#_options.fileReplacements,
-        useTsProjectReferences: this.#_options.useTsProjectReferences,
-        hasServer: this.#_options.hasServer,
-        includePaths: this.#_options.stylePreprocessorOptions?.includePaths,
-        sass: this.#_options.stylePreprocessorOptions?.sass,
-      },
-      this.#sourceFileCache,
-      this.#angularCompilation,
-      modifiedFiles
-    );
-    this.#angularCompilation = result.angularCompilation;
-    this.#collectedStylesheetAssets = result.collectedStylesheetAssets;
+        {
+          root,
+          aot: this.#_options.aot,
+          tsConfig: tsconfigPath,
+          inlineStyleLanguage: this.#_options.inlineStyleLanguage,
+          fileReplacements: this.#_options.fileReplacements,
+          useTsProjectReferences: this.#_options.useTsProjectReferences,
+          hasServer: this.#_options.hasServer,
+          includePaths: this.#_options.stylePreprocessorOptions?.includePaths,
+          sass: this.#_options.stylePreprocessorOptions?.sass,
+        },
+        this.#sourceFileCache,
+        this.#angularCompilation,
+        modifiedFiles
+      );
+      this.#angularCompilation = result.angularCompilation;
+      this.#collectedStylesheetAssets = result.collectedStylesheetAssets;
+    } catch (error) {
+      this.#initializationError = `Angular compilation initialization failed.\n${formatError(
+        error
+      )}`;
+    }
   }
+
+  private async buildAndAnalyze() {
+    if (this.#initializationError) {
+      return;
+    }
+    try {
+      await buildAndAnalyze(
+        this.#angularCompilation,
+        this.#sourceFileCache.typeScriptFileCache,
+        this.#javascriptTransformer
+      );
+    } catch (error) {
+      this.#emitError = `Angular compilation emit failed.\n${formatError(
+        error
+      )}`;
+    }
+  }
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error
+    ? (error.stack ?? error.message)
+    : String(error);
 }

--- a/packages/angular-rspack/src/lib/plugins/loaders/angular-partial-transform.loader.spec.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/angular-partial-transform.loader.spec.ts
@@ -1,0 +1,81 @@
+import type { LoaderContext } from '@rspack/core';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NG_RSPACK_SYMBOL_NAME, type NgRspackCompilation } from '../../models';
+import { default as angularPartialTransformLoader } from './angular-partial-transform.loader';
+
+describe('angular-partial-transform.loader', () => {
+  const callback = vi.fn();
+  const typescriptFileCache = new Map<string, string | Uint8Array>();
+  const transformFile = vi.fn();
+  const makeCompilation = (angularCompilationFailed = false) =>
+    ({
+      [NG_RSPACK_SYMBOL_NAME]: () => ({
+        javascriptTransformer: { transformFile },
+        typescriptFileCache,
+        angularCompilationFailed,
+      }),
+    }) as unknown as NgRspackCompilation;
+  const thisValue = {
+    async: vi.fn(() => callback),
+    _compilation: {},
+  } as unknown as LoaderContext<unknown>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    typescriptFileCache.clear();
+  });
+
+  it('should return content when NG_RSPACK_SYMBOL_NAME is undefined', () => {
+    angularPartialTransformLoader.call(thisValue, '@angular content');
+
+    expect(callback).toHaveBeenCalledWith(null, '@angular content');
+  });
+
+  it('should pass content through when the angular compilation failed', () => {
+    angularPartialTransformLoader.call(
+      {
+        ...thisValue,
+        _compilation: makeCompilation(true),
+        resourcePath: '/path/to/file.js',
+      },
+      '@angular content'
+    );
+
+    expect(callback).toHaveBeenCalledWith(null, '@angular content');
+    expect(transformFile).not.toHaveBeenCalled();
+  });
+
+  it('should transform the file and cache the result', async () => {
+    transformFile.mockResolvedValue(Buffer.from('transformed'));
+
+    angularPartialTransformLoader.call(
+      {
+        ...thisValue,
+        _compilation: makeCompilation(),
+        resourcePath: '/path/to/file.js',
+      },
+      '@angular content'
+    );
+
+    await vi.waitFor(() =>
+      expect(callback).toHaveBeenCalledWith(null, 'transformed')
+    );
+    expect(typescriptFileCache.get('/path/to/file.js')).toBe('transformed');
+  });
+
+  it('should fail the module when the transform rejects', async () => {
+    const error = new Error('worker crashed');
+    transformFile.mockRejectedValue(error);
+
+    angularPartialTransformLoader.call(
+      {
+        ...thisValue,
+        _compilation: makeCompilation(),
+        resourcePath: '/path/to/file.js',
+      },
+      '@angular content'
+    );
+
+    await vi.waitFor(() => expect(callback).toHaveBeenCalledWith(error));
+  });
+});

--- a/packages/angular-rspack/src/lib/plugins/loaders/angular-partial-transform.loader.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/angular-partial-transform.loader.ts
@@ -9,9 +9,18 @@ export default function loader(this: LoaderContext<unknown>, content: string) {
   ) {
     callback(null, content);
   } else {
-    const { javascriptTransformer, typescriptFileCache } = (
-      this._compilation as NgRspackCompilation
-    )[NG_RSPACK_SYMBOL_NAME]();
+    const {
+      javascriptTransformer,
+      typescriptFileCache,
+      angularCompilationFailed,
+    } = (this._compilation as NgRspackCompilation)[NG_RSPACK_SYMBOL_NAME]();
+
+    if (angularCompilationFailed) {
+      // The build is already failing with the Angular compilation error,
+      // so skip transforming and pass the original content through.
+      callback(null, content);
+      return;
+    }
 
     const request = this.resourcePath;
     if (
@@ -36,12 +45,17 @@ export default function loader(this: LoaderContext<unknown>, content: string) {
       return;
     }
 
-    javascriptTransformer
-      .transformFile(request, false, false)
-      .then((contents) => {
+    javascriptTransformer.transformFile(request, false, false).then(
+      (contents) => {
         const transformedCode = Buffer.from(contents).toString('utf8');
         typescriptFileCache.set(request, transformedCode);
         callback(null, transformedCode);
-      });
+      },
+      (error) => {
+        // Fail the module instead of leaving the loader callback pending,
+        // which would hang the build.
+        callback(error instanceof Error ? error : new Error(String(error)));
+      }
+    );
   }
 }

--- a/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.spec.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.spec.ts
@@ -74,6 +74,24 @@ describe('angular-transform.loader', () => {
     );
   });
 
+  it('should emit an empty module when the angular compilation failed', () => {
+    angularTransformLoader.call(
+      {
+        ...thisValue,
+        _compilation: {
+          [NG_RSPACK_SYMBOL_NAME]: () => ({
+            typescriptFileCache,
+            angularCompilationFailed: true,
+          }),
+        } as unknown as NgRspackCompilation,
+        resourcePath: '/path/to/file.ts',
+      },
+      'content'
+    );
+
+    expect(callback).toHaveBeenCalledWith(null, '');
+  });
+
   it('should return content when typescriptFileCache does not contain normalizedRequest', () => {
     angularTransformLoader.call(
       {

--- a/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.ts
@@ -28,9 +28,17 @@ export default function loader(
   ) {
     callback(null, content);
   } else {
-    const { typescriptFileCache } = (this._compilation as NgRspackCompilation)[
-      NG_RSPACK_SYMBOL_NAME
-    ]();
+    const { typescriptFileCache, angularCompilationFailed } = (
+      this._compilation as NgRspackCompilation
+    )[NG_RSPACK_SYMBOL_NAME]();
+
+    if (angularCompilationFailed) {
+      // The Angular compilation failure is already reported as a compilation
+      // error. Emit empty modules instead of raw TS sources that would only
+      // bury it under parser errors.
+      callback(null, '');
+      return;
+    }
 
     const request = this.resourcePath.replace(/^[A-Z]:/, '');
     const normalizedRequest = normalize(request);


### PR DESCRIPTION
## Current Behavior

When an Angular compilation fails to initialize, the error was swallowed by a try/catch that only logged to the console. The build then continued with a compilation that was never initialized and failed later in confusing ways: a cascade of raw TypeScript parser errors that buried the real cause, or a hung process that never exited. Failed builds also leaked the esbuild stylesheet service and the JavaScript transformer worker pool, so `rspack build` could hang on exit.

## Expected Behavior

Angular compilation initialization and emit failures are reported as rspack build errors, mirroring @angular/build's application builder: an initialization failure is reported and skips diagnostics, while an emit failure is reported but still runs diagnostics since they usually carry the root cause. In watch mode the error clears and the build recovers on the next successful rebuild. The build loaders short-circuit when the compilation failed so the real error is not buried under parser errors, and the esbuild service and worker pool are released on shutdown so `rspack build` exits cleanly.

## Implementation Details

- `setupCompilationWithAngularCompilation` rethrows initialization errors instead of logging and continuing.
- `AngularRspackPlugin` tracks initialization and emit failures separately and reports them as compilation errors in `thisCompilation`; the `emit` hook gates diagnostics on the initialization failure only, so emit failures still surface diagnostics.
- The transform loaders read an `angularCompilationFailed` flag from the shared compilation state and emit empty or pass-through modules when set. The partial-transform loader fails its module on a transform rejection, and the `emit` hook is guarded so a diagnostics throw can no longer leave the build hanging.
- A `shutdown` hook releases the JavaScript transformer worker pool and disposes the component stylesheet bundler, covering failed builds that skip the `done` hook.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/fix-angular-rspack-esbuild-leak-dcae7b74)
<!-- polygraph-session-end -->