### PR TITLE
docs(misc): document Nx Cloud CIPE settings snapshotting in CI

### DIFF
--- a/astro-docs/src/content/docs/reference/Nx Cloud/assignment-rules.mdoc
+++ b/astro-docs/src/content/docs/reference/Nx Cloud/assignment-rules.mdoc
@@ -8,8 +8,8 @@ Assignment rules allow you to control which tasks can run on which agents. Save 
 
 Assignment rules are defined in `yaml` files within your workspace's `.nx/workflows` directory. You can use assignment rules with [Nx Agents](/docs/features/ci-features/distribute-task-execution).
 
-{% aside type="caution" title="Assignment rules apply only if start-ci-run runs first" %}
-Assignment rules are locked in when the CI Pipeline Execution is created. If any `nx` command contacts Nx Cloud before `npx nx-cloud start-ci-run`, your rules are ignored for that run. See [`start-ci-run`](/docs/reference/nx-cloud-cli#nx-cloud-start-ci-run) for details.
+{% aside type="caution" title="Run start-ci-run first" %}
+Assignment rules only apply if `npx nx-cloud start-ci-run` runs before any other `nx` command. See [`start-ci-run`](/docs/reference/nx-cloud-cli#nx-cloud-start-ci-run).
 {% /aside %}
 
 ## How to define an assignment rule

--- a/astro-docs/src/content/docs/reference/Nx Cloud/assignment-rules.mdoc
+++ b/astro-docs/src/content/docs/reference/Nx Cloud/assignment-rules.mdoc
@@ -8,6 +8,10 @@ Assignment rules allow you to control which tasks can run on which agents. Save 
 
 Assignment rules are defined in `yaml` files within your workspace's `.nx/workflows` directory. You can use assignment rules with [Nx Agents](/docs/features/ci-features/distribute-task-execution).
 
+{% aside type="caution" title="Assignment rules apply only if start-ci-run runs first" %}
+Assignment rules are locked in when the CI Pipeline Execution is created. If any `nx` command contacts Nx Cloud before `npx nx-cloud start-ci-run`, your rules are ignored for that run. See [`start-ci-run`](/docs/reference/nx-cloud-cli#nx-cloud-start-ci-run) for details.
+{% /aside %}
+
 ## How to define an assignment rule
 
 Each assignment rule has one of the following properties that it matches against tasks: `projects`, `targets`, and/or `configurations`. You can provide a list of globs to match against the tasks in your workspace. It also has a list of possible [agent types](/docs/reference/nx-cloud/launch-templates) that tasks with the matching properties can run on. Rules are defined in yaml like the following:

--- a/astro-docs/src/content/docs/reference/nx-cloud-cli.mdoc
+++ b/astro-docs/src/content/docs/reference/nx-cloud-cli.mdoc
@@ -354,6 +354,14 @@ At the beginning of your main job, invoke `npx nx-cloud start-ci-run`. This tell
 
 This command is the same as running `nx start-ci-run`.
 
+{% aside type="caution" title="Run start-ci-run before any other Nx command" %}
+The first `nx` command that contacts Nx Cloud creates the CI Pipeline Execution (CIPE) and locks in its settings for the whole run. Those settings include the access token's scope, the distribution configuration, your [assignment rules](/docs/reference/nx-cloud/assignment-rules), and the stop-agents conditions.
+
+If another `nx` command reaches Nx Cloud before `start-ci-run`, the CIPE is created with default settings and your `start-ci-run` flags are ignored for that run. The result is assignment rules or stop conditions that appear to have no effect.
+
+Run `npx nx-cloud start-ci-run` (or the orchestrator job that runs it) before any other `nx` command, including across separate or downstream pipelines that share the same CIPE.
+{% /aside %}
+
 **Usage:**
 
 ```shell

--- a/astro-docs/src/content/docs/reference/nx-cloud-cli.mdoc
+++ b/astro-docs/src/content/docs/reference/nx-cloud-cli.mdoc
@@ -355,11 +355,9 @@ At the beginning of your main job, invoke `npx nx-cloud start-ci-run`. This tell
 This command is the same as running `nx start-ci-run`.
 
 {% aside type="caution" title="Run start-ci-run before any other Nx command" %}
-The first `nx` command that contacts Nx Cloud creates the CI Pipeline Execution (CIPE) and locks in its settings for the whole run. Those settings include the access token's scope, the distribution configuration, your [assignment rules](/docs/reference/nx-cloud/assignment-rules), and the stop-agents conditions.
+Run `npx nx-cloud start-ci-run` (or the orchestrator job that runs it) before any other `nx` command, including across separate or downstream pipelines that share the same CI Pipeline Execution (CIPE).
 
-If another `nx` command reaches Nx Cloud before `start-ci-run`, the CIPE is created with default settings and your `start-ci-run` flags are ignored for that run. The result is assignment rules or stop conditions that appear to have no effect.
-
-Run `npx nx-cloud start-ci-run` (or the orchestrator job that runs it) before any other `nx` command, including across separate or downstream pipelines that share the same CIPE.
+The first `nx` command that contacts Nx Cloud creates the CIPE and locks in its settings for the whole run, including the access token's scope, the distribution configuration, your [assignment rules](/docs/reference/nx-cloud/assignment-rules), and the stop-agents conditions. If another `nx` command reaches Nx Cloud first, the CIPE is created with default settings and your `start-ci-run` flags are ignored for that run. The result is assignment rules or stop conditions that appear to have no effect.
 {% /aside %}
 
 **Usage:**


### PR DESCRIPTION
## Current Behavior

The docs don't explain that the first `nx` command to reach Nx Cloud during a CI run creates the CI Pipeline Execution (CIPE) and locks in its settings (access token scope, distribution config, assignment rules, stop conditions). When another `nx` command contacts Nx Cloud before `npx nx-cloud start-ci-run` — for example because the orchestrator runs in a separate or downstream pipeline — the CIPE is created with defaults and the intended `start-ci-run` flags silently have no effect. A customer hit this with assignment rules not applying in GitLab.

## Expected Behavior

Adds a caution aside to the [`start-ci-run`](https://github.com/nrwl/nx/blob/HEAD/astro-docs/src/content/docs/reference/nx-cloud-cli.mdoc) reference explaining the snapshotting behavior and that `start-ci-run` must run before any other `nx` command, including across downstream pipelines that share the same CIPE. Adds a short cross-linked note on the [assignment rules](https://github.com/nrwl/nx/blob/HEAD/astro-docs/src/content/docs/reference/Nx%20Cloud/assignment-rules.mdoc) page, where someone debugging "rules not applying" is likely to land.

## Related Issue(s)

Docs-only change tracked in DOC-527.
