### PR TITLE
fix(core): prevent non-npm devEngines pin from breaking npm registry lookups

### DIFF
--- a/packages/nx/src/utils/package-manager.spec.ts
+++ b/packages/nx/src/utils/package-manager.spec.ts
@@ -26,6 +26,8 @@ import {
   modifyPnpmWorkspaceYamlToFitNewDirectory,
   modifyYarnRcToFitNewDirectory,
   modifyYarnRcYmlToFitNewDirectory,
+  packageRegistryPack,
+  packageRegistryView,
   parseVersionFromPackageManagerField,
   PackageManager,
 } from './package-manager';
@@ -762,6 +764,80 @@ describe('package-manager', () => {
       expect(commands.publish(...publishCmdParam)).toEqual(
         'bun publish --cwd="dist/packages/my-pkg" --json --registry="https://registry.npmjs.org/" --tag=latest'
       );
+    });
+  });
+
+  describe('packageRegistryView', () => {
+    let execMock: jest.SpyInstance;
+
+    beforeEach(() => {
+      execMock = jest.spyOn(childProcess, 'exec').mockImplementation(((
+        _cmd: string,
+        options: any,
+        callback: any
+      ) => {
+        const cb = typeof options === 'function' ? options : callback;
+        cb(null, { stdout: '' });
+        return undefined;
+      }) as any);
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+      jest.clearAllMocks();
+    });
+
+    it('should force npm to bypass devEngines enforcement when substituting npm in a yarn workspace', async () => {
+      jest
+        .spyOn(configModule, 'readNxJson')
+        .mockReturnValue({ cli: { packageManager: 'yarn' } });
+
+      await packageRegistryView('nx', 'latest', '--json');
+
+      const [cmd, options] = execMock.mock.calls[0];
+      expect(cmd).toContain('npm view');
+      expect(options.env.npm_config_force).toBe('true');
+    });
+
+    it('should not force when querying through pnpm', async () => {
+      jest
+        .spyOn(configModule, 'readNxJson')
+        .mockReturnValue({ cli: { packageManager: 'pnpm' } });
+
+      await packageRegistryView('nx', 'latest', '--json');
+
+      const [cmd, options] = execMock.mock.calls[0];
+      expect(cmd).toContain('pnpm view');
+      expect(options.env?.npm_config_force).toBeUndefined();
+    });
+  });
+
+  describe('packageRegistryPack', () => {
+    let execMock: jest.SpyInstance;
+
+    beforeEach(() => {
+      execMock = jest.spyOn(childProcess, 'exec').mockImplementation(((
+        _cmd: string,
+        options: any,
+        callback: any
+      ) => {
+        const cb = typeof options === 'function' ? options : callback;
+        cb(null, { stdout: 'nx-1.0.0.tgz' });
+        return undefined;
+      }) as any);
+    });
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+      jest.clearAllMocks();
+    });
+
+    it('should force npm to bypass devEngines enforcement', async () => {
+      await packageRegistryPack('/tmp/pack', 'nx', '1.0.0');
+
+      const [cmd, options] = execMock.mock.calls[0];
+      expect(cmd).toContain('npm pack');
+      expect(options.env.npm_config_force).toBe('true');
     });
   });
 });

--- a/packages/nx/src/utils/package-manager.ts
+++ b/packages/nx/src/utils/package-manager.ts
@@ -628,8 +628,15 @@ export async function packageRegistryView(
   // Quote the spec so range operators (e.g. `>=0.0.0`) are not parsed as shell
   // redirections.
   const spec = version ? `${pkg}@${version}` : pkg;
+  // npm enforces `devEngines.packageManager` on every command, even a read-only
+  // `view`; in a yarn/bun workspace we run npm, so a non-npm pin with
+  // `onFail: error` aborts the lookup. force downgrades that to a warning.
+  // Scoped to npm so a `pnpm view` spawn is left untouched.
   const { stdout } = await execAsync(`${pm} view "${spec}" ${args}`, {
     windowsHide: true,
+    ...(pm === 'npm'
+      ? { env: { ...process.env, npm_config_force: 'true' } }
+      : {}),
   });
   return stdout.toString().trim();
 }
@@ -651,6 +658,9 @@ export async function packageRegistryPack(
   const { stdout } = await execAsync(`${pm} pack ${pkg}@${version}`, {
     cwd,
     windowsHide: true,
+    // npm enforces `devEngines.packageManager` even on `pack`; force keeps the
+    // download working in workspaces that pin a non-npm manager (onFail: error).
+    env: { ...process.env, npm_config_force: 'true' },
   });
 
   const tarballPath = stdout.trim();


### PR DESCRIPTION
## Current Behavior

`nx migrate` fails with a `ProvenanceError` in workspaces that pin a non-npm package manager through `devEngines.packageManager` with `onFail: "error"`:

```
ProvenanceError: An error occurred while checking the provenance of nx@latest...
 Error: Command failed: npm view nx@latest --json --silent
```

Provenance verification and version resolution shell out to `npm view` and `npm pack`. npm is used here on purpose: `yarn info` and `bun pm view` return unreliable shapes for the per-version field queries these checks need. npm 11 runs its `devEngines.packageManager` check on every command, even a read-only `view`, so it aborts with `EBADDEVENGINES` before the lookup runs.

## Expected Behavior

The registry lookups behind `nx migrate` succeed regardless of a non-npm `devEngines.packageManager` pin, so the migration runs normally.

## Implementation Details

`packageRegistryView` and `packageRegistryPack` now pass `npm_config_force=true` to the spawned npm, which downgrades the `devEngines` mismatch from an error to a warning so the read proceeds. A registry query is not governed by the workspace's package-manager pin, so this is safe. The override is scoped to npm spawns; a `pnpm view` in a pnpm workspace is left untouched.

## Related Issue(s)

Fixes #35815

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/gh-35815-7d87f077)
<!-- polygraph-session-end -->