### PR TITLE
fix(web): run executor/plugin/generator commands with the workspace package manager

### DIFF
--- a/packages/nuxt/src/generators/application/application.ts
+++ b/packages/nuxt/src/generators/application/application.ts
@@ -2,6 +2,7 @@ import { logShowProjectCommand } from '@nx/devkit/internal';
 import {
   addDependenciesToPackageJson,
   addProjectConfiguration,
+  detectPackageManager,
   formatFiles,
   generateFiles,
   GeneratorCallback,
@@ -30,6 +31,7 @@ import { vueTestUtilsVersion, vitePluginVueVersion } from '@nx/vue';
 import { ensureDependencies } from './lib/ensure-dependencies';
 import { assertSupportedNuxtVersion } from '../../utils/assert-supported-nuxt-version';
 import { execSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import {
   getNxCloudAppOnBoardingUrl,
@@ -245,14 +247,27 @@ export async function applicationGeneratorInternal(tree: Tree, schema: Schema) {
   if (!options.skipFormat) await formatFiles(tree);
 
   tasks.push(() => {
+    const packageManager = detectPackageManager(workspaceRoot);
+    const pmc = getPackageManagerCommand(packageManager, workspaceRoot);
+    const appRoot = join(workspaceRoot, options.appProjectRoot);
+    // npm, yarn, and bun resolve binaries from `node_modules/.bin` searching
+    // upward from the cwd, so running in the app dir picks an app-level `nuxi`
+    // first and falls back to the workspace-root install. pnpm's `pnpm exec`
+    // doesn't search upward: in an integrated workspace the app dir only sees
+    // its own `node_modules/.bin` and can't reach the root-installed `nuxi`. So
+    // for pnpm only run in the app dir when it has its own `nuxi` (package-based
+    // setups, where the app copy should win); otherwise run at the workspace
+    // root, where the generator installs it.
+    const runInAppDir =
+      packageManager !== 'pnpm' ||
+      existsSync(join(appRoot, 'node_modules', '.bin', 'nuxi')) ||
+      existsSync(join(appRoot, 'node_modules', '.bin', 'nuxi.cmd'));
     try {
-      // Resolve `nuxi` from the workspace root (where it's installed), not the app
-      // subdir: PM execs like `pnpm exec` don't walk up the tree the way `npx` does.
       execSync(
-        `${getPackageManagerCommand().exec} nuxi prepare "${
-          options.appProjectRoot
-        }"`,
-        { cwd: workspaceRoot, windowsHide: true }
+        `${pmc.exec} nuxi prepare${
+          runInAppDir ? '' : ` "${options.appProjectRoot}"`
+        }`,
+        { cwd: runInAppDir ? appRoot : workspaceRoot, windowsHide: true }
       );
     } catch (e) {
       console.error(

--- a/packages/nuxt/src/generators/application/application.ts
+++ b/packages/nuxt/src/generators/application/application.ts
@@ -5,11 +5,13 @@ import {
   formatFiles,
   generateFiles,
   GeneratorCallback,
+  getPackageManagerCommand,
   joinPathFragments,
   offsetFromRoot,
   runTasksInSerial,
   toJS,
   Tree,
+  workspaceRoot,
   writeJson,
 } from '@nx/devkit';
 import { Schema } from './schema';
@@ -244,11 +246,14 @@ export async function applicationGeneratorInternal(tree: Tree, schema: Schema) {
 
   tasks.push(() => {
     try {
-      execSync(`npx -y nuxi prepare`, {
-        cwd: options.appProjectRoot,
-
-        windowsHide: true,
-      });
+      // Resolve `nuxi` from the workspace root (where it's installed), not the app
+      // subdir: PM execs like `pnpm exec` don't walk up the tree the way `npx` does.
+      execSync(
+        `${getPackageManagerCommand().exec} nuxi prepare "${
+          options.appProjectRoot
+        }"`,
+        { cwd: workspaceRoot, windowsHide: true }
+      );
     } catch (e) {
       console.error(
         `Failed to run \`nuxi prepare\` in "${options.appProjectRoot}". Please run the command manually.`

--- a/packages/vite/plugins/nx-tsconfig-paths.plugin.ts
+++ b/packages/vite/plugins/nx-tsconfig-paths.plugin.ts
@@ -1,5 +1,6 @@
 import {
   createProjectGraphAsync,
+  getPackageManagerCommand,
   joinPathFragments,
   workspaceRoot,
 } from '@nx/devkit';
@@ -158,7 +159,9 @@ export function nxViteTsPaths(options: nxViteTsPathsOptions = {}) {
               .filter((dep) => dep.node.type === 'lib')
               .map((dep) => dep.node.name)
               .join(',');
-            const buildCommand = `npx nx run-many --target=${depsBuildTarget} --projects=${buildableLibraryDependencies}`;
+            const buildCommand = `${
+              getPackageManagerCommand().exec
+            } nx run-many --target=${depsBuildTarget} --projects=${buildableLibraryDependencies}`;
             config.plugins.push(
               nxViteBuildCoordinationPlugin({ buildCommand })
             );

--- a/packages/web/src/executors/file-server/file-server.impl.ts
+++ b/packages/web/src/executors/file-server/file-server.impl.ts
@@ -3,22 +3,19 @@ import { execFileSync, fork } from 'child_process';
 import * as pc from 'picocolors';
 import {
   ExecutorContext,
+  getPackageManagerCommand,
   output,
   parseTargetString,
   readTargetOptions,
 } from '@nx/devkit';
 import { copyFileSync, unlinkSync } from 'fs';
 import { Schema } from './schema';
-import { platform } from 'os';
 import { join, resolve } from 'path';
 import { readModulePackageJson } from 'nx/src/utils/package-json';
 import { daemonClient } from 'nx/src/daemon/client/client';
 import { interpolate } from 'nx/src/tasks-runner/utils';
 import { stripGlobToBaseDir } from '@nx/js/internal';
 import detectPort from 'detect-port';
-
-// platform specific command name
-const pmCmd = platform() === 'win32' ? `npx.cmd` : 'npx';
 
 function getHttpServerArgs(options: Schema) {
   const {
@@ -170,6 +167,9 @@ export default async function* fileServerExecutor(
   let disposeWatch: () => void;
 
   if (options.buildTarget) {
+    // Run the build target through the workspace package manager so workspaces
+    // that pin a non-npm manager (e.g. devEngines.packageManager) don't fail.
+    const pmc = getPackageManagerCommand();
     const run = () => {
       if (!running) {
         running = true;
@@ -181,7 +181,7 @@ export default async function* fileServerExecutor(
         process.env.NX_SERVE_STATIC_BUILD_RUNNING = 'true';
         try {
           const args = getBuildTargetCommand(options, context);
-          execFileSync(pmCmd, args, {
+          execFileSync(pmc.exec, args, {
             stdio: [0, 1, 2],
             shell: true,
             windowsHide: true,


### PR DESCRIPTION
## Current Behavior

Several Nx code paths run `nx` (or a package binary) through a hardcoded `npx` instead of the workspace's package manager. In a workspace that pins a non-npm package manager - for example via `devEngines.packageManager` with `onFail: "error"` - npm refuses to run and the command aborts with `EBADDEVENGINES`:

- `@nx/web:file-server` (serve-static) runs the build target via `npx nx run ...` (this is the reported issue).
- The `@nx/vite` nx-tsconfig-paths plugin coordinates dependency builds during `vite serve` via `npx nx run-many ...`.
- The `@nx/nuxt` application generator runs `npx -y nuxi prepare`.

## Expected Behavior

Each of these runs through the workspace's configured package manager (`getPackageManagerCommand().exec`), so they work in pnpm, yarn, and bun workspaces, including ones that pin a non-npm manager via `packageManager` / `devEngines`. npm workspaces are unaffected, and `shell: true` is retained for the file-server spawn so Windows resolution is unchanged.

## Related Issue(s)

Fixes #35950

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/gh-35815-7d87f077)
<!-- polygraph-session-end -->