### PR TITLE
docs(angular): genericize Nx version in angular-rspack getting-started terminal output

### DIFF
--- a/astro-docs/src/content/docs/technologies/angular/angular-rspack/Guides/getting-started.mdoc
+++ b/astro-docs/src/content/docs/technologies/angular/angular-rspack/Guides/getting-started.mdoc
@@ -34,7 +34,7 @@ NX   Let's create a new workspace [https://nx.dev/getting-started/intro]
 ✔ Which unit test runner would you like to use? · vitest
 ✔ Test runner to use for end to end (E2E) tests · playwright
 
-NX   Creating your v20.8.0 workspace.
+NX   Creating your workspace.
 ```
 
 {% /tabitem %}
@@ -54,7 +54,7 @@ NX   Let's create a new workspace [https://nx.dev/getting-started/intro]
 ✔ Which unit test runner would you like to use? · vitest
 ✔ Test runner to use for end to end (E2E) tests · playwright
 
-NX   Creating your v20.8.0 workspace.
+NX   Creating your workspace.
 ```
 
 {% /tabitem %}


### PR DESCRIPTION
## Current Behavior

The angular-rspack getting-started guide shows sample terminal output `NX   Creating your v20.8.0 workspace.` in both the standard and SSR tabs, pinning an outdated Nx version (two majors behind current).

## Expected Behavior

The version string is removed so the sample output reads `NX   Creating your workspace.`, which won't go stale on each release.

## Related Issue(s)

Resolves the staleness audit finding for `astro-docs/src/content/docs/technologies/angular/angular-rspack/Guides/getting-started.mdoc`.