### PR TITLE
docs(misc): remove dead legacy version tabs from Nx Cloud auth docs

### DIFF
--- a/astro-docs/src/content/docs/guides/Nx Cloud/access-tokens.mdoc
+++ b/astro-docs/src/content/docs/guides/Nx Cloud/access-tokens.mdoc
@@ -267,33 +267,11 @@ pipeline {
 
 We **do not recommend** that you commit an access token to your repository but older versions of Nx do support this and if you open your `nx.json`, you may see something like this:
 
-{% tabs %}
-{% tabitem label="Nx >= 17" %}
-
 ```json
 {
   "nxCloudAccessToken": "SOMETOKEN"
 }
 ```
-
-{% /tabitem %}
-{% tabitem label="Nx < 17" %}
-
-```json
-{
-  "tasksRunnerOptions": {
-    "default": {
-      "runner": "nx-cloud",
-      "options": {
-        "accessToken": "SOMETOKEN"
-      }
-    }
-  }
-}
-```
-
-{% /tabitem %}
-{% /tabs %}
 
 {% aside type="caution" title="Nx Cloud authentication is changing" %}
 From Nx 19.7 new workspaces are connected to Nx Cloud with a property called `nxCloudId` instead, and we recommend developers use [`nx login`](/docs/reference/nx-cloud-cli#npx-nxcloud-login) to provision their own local [personal access tokens](/docs/guides/nx-cloud/personal-access-tokens) for user based authentication.

--- a/astro-docs/src/content/docs/guides/Nx Cloud/personal-access-tokens.mdoc
+++ b/astro-docs/src/content/docs/guides/Nx Cloud/personal-access-tokens.mdoc
@@ -14,44 +14,12 @@ From Nx 19.7 repositories are connected to Nx Cloud via a property in `nx.json` 
 Ensure that you have the `nxCloudId` property in your `nx.json` file to connect to Nx Cloud with a Personal Access Token. If you have been using `nxCloudAccessToken`, you can convert it to `nxCloudId` by running [`npx nx-cloud convert-to-nx-cloud-id`](/docs/reference/nx-cloud-cli#npx-nxcloud-converttonxcloudid).
 {% /aside %}
 
-{% tabs %}
-{% tabitem label="Nx >= 19.7" %}
-
 ```json
 // nx.json
 {
   "nxCloudId": "SOMEID"
 }
 ```
-
-{% /tabitem %}
-{% tabitem label="Nx <= 19.6" %}
-
-```json
-// nx.json
-"tasksRunnerOptions": {
-    "default": {
-      "runner": "nx-cloud",
-      "options": {
-        "nxCloudId": "SOMEID"
-      }
-    }
-  }
-```
-
-To utilize personal access tokens and Nx Cloud ID with Nx <= 19.6, the nx-cloud npm package is also required to be installed in your workspaces `package.json`.
-
-```json
-// package.json
-{
-  "devDependencies": {
-    "nx-cloud": "latest"
-  }
-}
-```
-
-{% /tabitem %}
-{% /tabs %}
 
 ## Personal access tokens (PATs)
 


### PR DESCRIPTION
## Current Behavior

Both Nx Cloud authentication docs pages use a two-tab layout contrasting the current `nxCloudId`/`nxCloudAccessToken` approach with a legacy approach that uses `tasksRunnerOptions` and a separate `nx-cloud` install. Since the minimum supported Nx version is 22+, the legacy tabs are dead and only add noise.

- `access-tokens.mdoc`: "Nx >= 17" vs "Nx < 17" tabs
- `personal-access-tokens.mdoc`: "Nx >= 19.7" vs "Nx <= 19.6" tabs

## Expected Behavior

The legacy tab is removed on both pages, leaving just the single current approach (no tab wrapper).

## Related Issue(s)

Documentation cleanup from a staleness audit; no GitHub issue.