### PR TITLE
docs(misc): drop stale version-intro framing from concept docs

### DIFF
--- a/astro-docs/src/content/docs/concepts/nx-daemon.mdoc
+++ b/astro-docs/src/content/docs/concepts/nx-daemon.mdoc
@@ -6,7 +6,7 @@ sidebar:
 filter: 'type:Concepts'
 ---
 
-In version 13 we introduced the opt-in Nx Daemon which Nx can leverage to dramatically speed up project graph computation, particularly for large workspaces.
+The Nx Daemon dramatically speeds up project graph computation, particularly for large workspaces.
 
 ## Why is it needed?
 

--- a/astro-docs/src/content/docs/concepts/sync-generators.mdoc
+++ b/astro-docs/src/content/docs/concepts/sync-generators.mdoc
@@ -6,7 +6,7 @@ sidebar:
 filter: 'type:Concepts'
 ---
 
-In Nx 19.8, you can use sync generators to ensure that your repository is maintained in a correct state. One specific application is to use the project graph to update files. These can be global configuration files or scripts, or at the task level to ensure that files are in sync before a task is run.
+Sync generators ensure that your repository is maintained in a correct state. One specific application is to use the project graph to update files. These can be global configuration files or scripts, or at the task level to ensure that files are in sync before a task is run.
 
 Sync Generator Examples:
 

--- a/astro-docs/src/content/docs/guides/Adopting Nx/preserving-git-histories.mdoc
+++ b/astro-docs/src/content/docs/guides/Adopting Nx/preserving-git-histories.mdoc
@@ -8,7 +8,7 @@ sidebar:
 
 {% aside type="note" title="Automatically import with 'nx import'" %}
 
-In Nx 19.8 we introduced `nx import` which helps you import projects into your Nx workspace, including preserving the Git history. [Read more in the according doc](/docs/guides/adopting-nx/import-project).
+`nx import` helps you import projects into your Nx workspace, including preserving the Git history. [Read more in the according doc](/docs/guides/adopting-nx/import-project).
 
 {% /aside %}
 

--- a/astro-docs/src/content/docs/reference/project-configuration.mdoc
+++ b/astro-docs/src/content/docs/reference/project-configuration.mdoc
@@ -585,7 +585,7 @@ And the E2E project's `e2e` task has a dependency on the `serve` task, which ens
 
 ### Sync generators
 
-In the same way that `dependsOn` tells Nx to run another task before running this task, the `syncGenerator` property tells Nx to run a generator to ensure that your files are in the correct state before this task is run. [Sync generators](/docs/concepts/sync-generators) are especially useful for keeping configuration files up to date with the project graph. Sync generators are available in Nx 19.8+.
+In the same way that `dependsOn` tells Nx to run another task before running this task, the `syncGenerator` property tells Nx to run a generator to ensure that your files are in the correct state before this task is run. [Sync generators](/docs/concepts/sync-generators) are especially useful for keeping configuration files up to date with the project graph.
 
 ```json
 {


### PR DESCRIPTION
## Current Behavior

Several stable concept/reference pages open with "Introduced in Nx X" launch notes that no longer add value. One of them is also factually stale: the Nx Daemon is described as "opt-in", but it's now default-on.

## Expected Behavior

The version-intro framing is dropped on each page, leaving plain present-tense descriptions:

- `concepts/nx-daemon.mdoc` — removed "In version 13 we introduced the opt-in Nx Daemon" (also fixes the opt-in/default-on inaccuracy)
- `concepts/sync-generators.mdoc` — removed "In Nx 19.8, you can use sync generators"
- `reference/project-configuration.mdoc` — removed "Sync generators are available in Nx 19.8+."
- `guides/Adopting Nx/preserving-git-histories.mdoc` — removed "In Nx 19.8 we introduced `nx import`"

## Related Issue(s)

Source: dot-ai-config staleness audit 2026-06-17.
