### PR TITLE
docs(misc): remove deprecated Nx < 17 tab from cache-task-results

### DIFF
--- a/astro-docs/src/content/docs/features/cache-task-results.mdoc
+++ b/astro-docs/src/content/docs/features/cache-task-results.mdoc
@@ -17,9 +17,6 @@ Nx **restores both the terminal output and the files** created from running the 
 
 ## Define cacheable tasks
 
-{% tabs syncKey="nx-version" %}
-{% tabitem label="Nx >= 17" %}
-
 To enable caching for `build` and `test`, edit the `targetDefaults` property in `nx.json` to include the `build` and `test` tasks:
 
 ```json
@@ -35,28 +32,6 @@ To enable caching for `build` and `test`, edit the `targetDefaults` property in 
   }
 }
 ```
-
-{% /tabitem %}
-{% tabitem label="Nx < 17" %}
-
-To enable caching for `build` and `test`, edit the `cacheableOperations` property in `nx.json` to include the `build` and `test` tasks:
-
-```json
-// nx.json
-{
-  "tasksRunnerOptions": {
-    "default": {
-      "runner": "nx/tasks-runners/default",
-      "options": {
-        "cacheableOperations": ["build", "test"]
-      }
-    }
-  }
-}
-```
-
-{% /tabitem %}
-{% /tabs %}
 
 {% aside type="note" title="Cacheable operations need to be side effect free" %}
 This means that given the same input they should always result in


### PR DESCRIPTION
## Current Behavior

The Cache Task Results page shows a `{% tabs syncKey="nx-version" %}` block with two approaches. The "Nx < 17" tab documents the deprecated `tasksRunnerOptions.default.options.cacheableOperations` config. `cacheableOperations` was deprecated in Nx 17 and `tasksRunnerOptions` fully deprecated in Nx 20, and the minimum supported Nx is 22+, so this tab is dead content.

## Expected Behavior

The tabs block is collapsed to the single, current `targetDefaults.build.cache: true` approach.
