### PR TITLE
docs(misc): remove stale "prior to Nx 18" framing from Node proxy guide

### DIFF
--- a/astro-docs/src/content/docs/technologies/node/Guides/application-proxies.mdoc
+++ b/astro-docs/src/content/docs/technologies/node/Guides/application-proxies.mdoc
@@ -90,15 +90,14 @@ export default defineConfig({
 });
 ```
 
-## Automatically configure frontend executors
+## Automatically configure frontend proxies
 
 {% aside type="caution" title="Not recommended for new projects" %}
-We recommend configuring proxies using support from existing tooling. Webpack and Vite both come with proxy support out of the box, as do most modern tools. Using `--frontendProject` is meant for Nx prior to version 18.
+We recommend configuring proxies using support from existing tooling. Webpack and Vite both come with proxy support out of the box, as do most modern tools.
 {% /aside %}
 
-Prior to Nx version 18, projects use [executors](/docs/concepts/executors-and-configurations) to run tasks. If your frontend project is
-using executors, then the Node, Nest and Express app generators have an option to configure proxy API requests. This
-can be done by passing the `--frontendProject` with the project name you wish to enable proxy support for.
+The Node, Nest and Express app generators have an option to configure proxy API requests. This can be done by passing
+the `--frontendProject` with the project name you wish to enable proxy support for.
 
 ```shell
 nx g @nx/node:app apps/<node-app> --frontendProject my-react-app


### PR DESCRIPTION
## Current Behavior

The "Automatically configure frontend executors" section of the Node application proxies guide framed `--frontendProject` as something "meant for Nx prior to version 18" and claimed projects use executors only "prior to Nx version 18". Nx 18 shipped in early 2024, so this framing is stale.

## Expected Behavior

The stale version references are removed. Note that `--frontendProject` is **not** actually removed from the `@nx/node`, `@nx/nest`, and `@nx/express` generators — it's still an active, documented option (and `@nx/node` still ships the proxy-generation logic). So rather than deleting the section as the issue originally suggested, this rewrites it to drop the inaccurate version framing while keeping the still-valid feature documented. The section heading is also updated to "Automatically configure frontend proxies" since it no longer pertains specifically to executors.

## Related Issue(s)

Fixes DOC-531
