### PR TITLE
docs(misc): update TypeScript version references in compile-multiple-formats guide

### DIFF
--- a/astro-docs/src/content/docs/technologies/typescript/Guides/compile-multiple-formats.mdoc
+++ b/astro-docs/src/content/docs/technologies/typescript/Guides/compile-multiple-formats.mdoc
@@ -91,10 +91,10 @@ After compiling our package using `nx build my-awesome-lib` we'll get the follow
 
 ## Configure package exports
 
-To ensure your package works correctly with TypeScript's module resolution, you need to configure the `exports` field in your source `package.json` with proper `types` entries. This is critical for TypeScript 4.7+ which requires explicit type declarations for each export condition.
+To ensure your package works correctly with TypeScript's module resolution, you need to configure the `exports` field in your source `package.json` with proper `types` entries. This is critical because TypeScript requires explicit type declarations for each export condition.
 
 {% callout type="warning" title="Types Must Be Specified for Each Condition" %}
-When using conditional exports with both ESM and CJS formats, you must include `types` entries for each condition. Without this, TypeScript may fail to resolve types correctly, causing compilation errors for consumers of your package. See the [TypeScript 4.7 release notes](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-4-7.html#packagejson-exports-imports-and-self-referencing) for more details.
+When using conditional exports with both ESM and CJS formats, you must include `types` entries for each condition. Without this, TypeScript may fail to resolve types correctly, causing compilation errors for consumers of your package.
 {% /callout %}
 
 Update your source `package.json` to include the exports configuration:


### PR DESCRIPTION
## Current Behavior

The compile-multiple-formats guide cites `TypeScript 4.7+` as the threshold for `exports` field type resolution and links the TS 4.7 release notes. TS 4.7 shipped in 2022; the current TypeScript is 5.x and this behavior is universally supported now, so the version qualifier and link are stale.

## Expected Behavior

The version qualifier is dropped (the requirement is stated unconditionally) and the stale TS 4.7 release-notes link is removed.

## Related Issue(s)

Resolves DOC-533.
