### PR TITLE
feat(nx-cloud): add utm tracking to clickable cloud prompt links

### DIFF
--- a/packages/create-nx-workspace/src/utils/nx/ab-testing.spec.ts
+++ b/packages/create-nx-workspace/src/utils/nx/ab-testing.spec.ts
@@ -2,6 +2,8 @@ import {
   isEnterpriseCloudUrl,
   getBannerVariant,
   getFlowVariant,
+  NX_CLOUD_HYPERLINK,
+  NX_CLOUD_URL,
   PromptMessages,
 } from './ab-testing';
 
@@ -140,4 +142,65 @@ describe('ab-testing', () => {
       );
     });
   });
+});
+
+describe('NX_CLOUD_HYPERLINK', () => {
+  const BEL = '\u0007';
+  const OSC = '\u001B]';
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.resetModules();
+    process.env = { ...originalEnv };
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('embeds UTM attribution in the link target while keeping the visible text clean', () => {
+    process.env.FORCE_HYPERLINK = '1';
+    const { NX_CLOUD_HYPERLINK: link, NX_CLOUD_URL: url } = jest.requireActual(
+      './ab-testing'
+    ) as typeof import('./ab-testing');
+
+    expect(link).toContain(`${BEL}${url}${OSC}`);
+    expect(link).toContain(
+      `${url}?utm_source=nx-cli&utm_medium=create-nx-workspace`
+    );
+  });
+
+  it('falls back to the bare URL when hyperlinks are unsupported', () => {
+    process.env.FORCE_HYPERLINK = '0';
+    const { NX_CLOUD_HYPERLINK: link, NX_CLOUD_URL: url } = jest.requireActual(
+      './ab-testing'
+    ) as typeof import('./ab-testing');
+
+    expect(link).toBe(url);
+  });
+});
+
+describe('cloud prompt footers', () => {
+  let originalDocs: string | undefined;
+
+  beforeAll(() => {
+    originalDocs = process.env.NX_GENERATE_DOCS_PROCESS;
+    process.env.NX_GENERATE_DOCS_PROCESS = 'true';
+  });
+
+  afterAll(() => {
+    if (originalDocs === undefined) delete process.env.NX_GENERATE_DOCS_PROCESS;
+    else process.env.NX_GENERATE_DOCS_PROCESS = originalDocs;
+  });
+
+  // Drift guard: every cloud prompt footer must embed the baked hyperlink so a
+  // future footer edit that drops it fails loudly instead of silently losing
+  // attribution.
+  it.each(['setupCI', 'setupNxCloud', 'setupNxCloudV2'] as const)(
+    'embeds the Nx Cloud hyperlink in %s',
+    (key) => {
+      const { footer } = new PromptMessages().getPrompt(key);
+      expect(footer).toContain(NX_CLOUD_HYPERLINK);
+    }
+  );
 });

--- a/packages/create-nx-workspace/src/utils/nx/ab-testing.ts
+++ b/packages/create-nx-workspace/src/utils/nx/ab-testing.ts
@@ -10,7 +10,22 @@ import { join } from 'node:path';
 import { tmpdir } from 'node:os';
 import chalk from 'chalk';
 import { isCI } from '../ci/is-ci';
+import { terminalLink } from '../terminal-link';
 import type { BannerVariant, CompletionMessageKey } from './messages';
+
+export const NX_CLOUD_URL = 'https://nx.dev/nx-cloud';
+
+/**
+ * Clickable Nx Cloud marketing link for cloud prompt footers. Every
+ * create-nx-workspace prompt reports the same medium, so the link is a single
+ * baked constant embedded directly in the footers. Visible text stays the clean
+ * `NX_CLOUD_URL` while clicks carry UTM attribution; terminals without OSC 8
+ * support just render the bare URL (CLOUD-4642).
+ */
+export const NX_CLOUD_HYPERLINK = terminalLink(
+  NX_CLOUD_URL,
+  `${NX_CLOUD_URL}?utm_source=nx-cli&utm_medium=create-nx-workspace`
+);
 
 // Flow variant controls both tracking and banner display (CLOUD-4235)
 // Variants: 0 = control, 1 = updated prompt, 2 = no prompt (auto-connect)
@@ -179,8 +194,7 @@ const messageOptions: Record<string, MessageData[]> = {
         { value: 'circleci', name: 'Circle CI' },
         { value: 'skip', name: '\nDo it later' },
       ],
-      footer:
-        '\nSelf-healing CI, remote caching, and task distribution are provided by Nx Cloud: https://nx.dev/nx-cloud',
+      footer: `\nSelf-healing CI, remote caching, and task distribution are provided by Nx Cloud: ${NX_CLOUD_HYPERLINK}`,
       fallback: { value: 'skip', key: 'setupNxCloud' },
       completionMessage: 'ci-setup',
     },
@@ -198,8 +212,7 @@ const messageOptions: Record<string, MessageData[]> = {
         { value: 'yes', name: 'Yes' },
         { value: 'skip', name: 'Skip' },
       ],
-      footer:
-        '\nAutomatically fix broken PRs, 70% faster CI: https://nx.dev/nx-cloud',
+      footer: `\nAutomatically fix broken PRs, 70% faster CI: ${NX_CLOUD_HYPERLINK}`,
       fallback: undefined,
       completionMessage: 'platform-setup',
     },
@@ -217,8 +230,7 @@ const messageOptions: Record<string, MessageData[]> = {
         { value: 'skip', name: 'Skip for now' },
         { value: 'never', name: chalk.dim("No, don't ask again") },
       ],
-      footer:
-        '\nFree for small teams. Remote caching and task distribution. 2-minute setup: https://nx.dev/nx-cloud',
+      footer: `\nFree for small teams. Remote caching and task distribution. 2-minute setup: ${NX_CLOUD_HYPERLINK}`,
       fallback: undefined,
       completionMessage: 'platform-setup',
     },

--- a/packages/create-nx-workspace/src/utils/terminal-link.spec.ts
+++ b/packages/create-nx-workspace/src/utils/terminal-link.spec.ts
@@ -1,0 +1,50 @@
+import { parseVersion, terminalLink } from './terminal-link';
+
+describe('terminalLink', () => {
+  const OSC = '\u001B]';
+  const BEL = '\u0007';
+  let originalForce: string | undefined;
+
+  beforeEach(() => {
+    originalForce = process.env.FORCE_HYPERLINK;
+  });
+
+  afterEach(() => {
+    if (originalForce === undefined) {
+      delete process.env.FORCE_HYPERLINK;
+    } else {
+      process.env.FORCE_HYPERLINK = originalForce;
+    }
+  });
+
+  it('wraps text in an OSC 8 sequence when hyperlinks are supported', () => {
+    process.env.FORCE_HYPERLINK = '1';
+    const result = terminalLink('label', 'https://example.com');
+    expect(result).toBe(
+      `${OSC}8;;https://example.com${BEL}label${OSC}8;;${BEL}`
+    );
+  });
+
+  it('returns plain text when hyperlinks are not supported', () => {
+    process.env.FORCE_HYPERLINK = '0';
+    expect(terminalLink('label', 'https://example.com')).toBe('label');
+  });
+});
+
+describe('parseVersion', () => {
+  it.each([
+    // VTE packed integers: "5402" -> 0.54.2
+    ['5402', { major: 0, minor: 54, patch: 2 }],
+    ['5000', { major: 0, minor: 50, patch: 0 }],
+    ['501', { major: 0, minor: 5, patch: 1 }],
+    // Dot-separated versions
+    ['3.5.0', { major: 3, minor: 5, patch: 0 }],
+    ['1.72', { major: 1, minor: 72, patch: 0 }],
+    ['20200620', { major: 20200620, minor: 0, patch: 0 }],
+    // Missing / malformed input defaults to zeros
+    ['', { major: 0, minor: 0, patch: 0 }],
+    [undefined, { major: 0, minor: 0, patch: 0 }],
+  ])('parses %p', (input, expected) => {
+    expect(parseVersion(input as string | undefined)).toEqual(expected);
+  });
+});

--- a/packages/create-nx-workspace/src/utils/terminal-link.ts
+++ b/packages/create-nx-workspace/src/utils/terminal-link.ts
@@ -1,0 +1,103 @@
+// Keep in sync with packages/nx/src/utils/terminal-link.ts.
+// create-nx-workspace cannot depend on nx, so this generic OSC 8 helper is
+// intentionally duplicated (same reasoning as output.ts / package-manager.ts).
+
+const OSC = '\u001B]';
+const BEL = '\u0007';
+const SEP = ';';
+
+/**
+ * Wrap `text` in an OSC 8 hyperlink that points at `url`. Supported terminals
+ * render `text` as a clickable link to `url`; everywhere else `text` prints
+ * unchanged. This lets us keep tracking querystrings out of the visible output
+ * while still attaching them to the link target (CLOUD-4642).
+ */
+export function terminalLink(text: string, url: string): string {
+  if (!supportsHyperlinks()) {
+    return text;
+  }
+  return [OSC, '8', SEP, SEP, url, BEL, text, OSC, '8', SEP, SEP, BEL].join('');
+}
+
+/**
+ * Best-effort detection of OSC 8 hyperlink support, adapted from the
+ * `supports-hyperlinks` package. Defaults to false when in doubt so we never
+ * print raw escape sequences to a terminal that can't render them.
+ */
+function supportsHyperlinks(): boolean {
+  const env = process.env;
+
+  if (env.FORCE_HYPERLINK !== undefined) {
+    return !(
+      env.FORCE_HYPERLINK.length > 0 && parseInt(env.FORCE_HYPERLINK, 10) === 0
+    );
+  }
+
+  if (!process.stdout || !process.stdout.isTTY) {
+    return false;
+  }
+
+  if (process.platform === 'win32') {
+    // Only Windows Terminal advertises OSC 8 support reliably.
+    return Boolean(env.WT_SESSION);
+  }
+
+  if (env.CI || env.TEAMCITY_VERSION) {
+    return false;
+  }
+  if (env.TERM === 'dumb') {
+    return false;
+  }
+
+  if (env.TERM_PROGRAM) {
+    const version = parseVersion(env.TERM_PROGRAM_VERSION);
+    switch (env.TERM_PROGRAM) {
+      case 'iTerm.app':
+        return version.major === 3 ? version.minor >= 1 : version.major > 3;
+      case 'WezTerm':
+        return version.major >= 20200620;
+      case 'vscode':
+        return (
+          version.major > 1 || (version.major === 1 && version.minor >= 72)
+        );
+      case 'ghostty':
+        return true;
+    }
+  }
+
+  if (env.VTE_VERSION) {
+    if (env.VTE_VERSION === '0.50.0') {
+      return false;
+    }
+    const version = parseVersion(env.VTE_VERSION);
+    return version.major > 0 || version.minor >= 50;
+  }
+
+  if (env.TERM === 'xterm-kitty') {
+    return true;
+  }
+  if (env.TERMINAL_EMULATOR === 'JetBrains-JediTerm') {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Exported for testing. VTE reports versions as a packed integer, e.g. "5402"
+ * means 0.54.2; everything else is dot-separated.
+ */
+export function parseVersion(versionString = ''): {
+  major: number;
+  minor: number;
+  patch: number;
+} {
+  if (/^\d{3,4}$/.test(versionString)) {
+    const m = /(\d{1,2})(\d{2})/.exec(versionString) ?? [];
+    return { major: 0, minor: parseInt(m[1], 10), patch: parseInt(m[2], 10) };
+  }
+  const [major = 0, minor = 0, patch = 0] = (versionString ?? '')
+    .split('.')
+    .map((n) => parseInt(n, 10) || 0);
+  return { major, minor, patch };
+}

--- a/packages/nx/src/command-line/nx-cloud/connect/connect-to-nx-cloud.ts
+++ b/packages/nx/src/command-line/nx-cloud/connect/connect-to-nx-cloud.ts
@@ -18,6 +18,7 @@ import {
   MessageOptionKey,
   recordStat,
   messages,
+  nxCloudHyperlink,
 } from '../../../utils/ab-testing';
 import { nxVersion } from '../../../utils/versions';
 import { isCI } from '../../../utils/is-ci';
@@ -230,7 +231,7 @@ export async function connectExistingRepoToNxCloudPrompt(
   command = 'init',
   key: MessageKey = 'setupNxCloud'
 ): Promise<MessageOptionKey> {
-  const res = await nxCloudPrompt(key);
+  const res = await nxCloudPrompt(key, utmMediumForCommand(command));
   await recordStat({
     command,
     nxVersion,
@@ -250,7 +251,10 @@ export async function connectExistingRepoToNxCloudPrompt(
 }
 
 export async function connectToNxCloudWithPrompt(command: string) {
-  const setNxCloud = await nxCloudPrompt('setupNxCloud');
+  const setNxCloud = await nxCloudPrompt(
+    'setupNxCloud',
+    utmMediumForCommand(command)
+  );
   let useCloud = false;
   if (setNxCloud === 'yes') {
     useCloud = await connectToNxCloudCommand({ generateToken: false }, command);
@@ -280,7 +284,21 @@ export async function connectToNxCloudWithPrompt(command: string) {
   });
 }
 
-async function nxCloudPrompt(key: MessageKey): Promise<MessageOptionKey> {
+function utmMediumForCommand(command: string): string {
+  switch (command) {
+    case 'migrate':
+      return 'nx-migrate';
+    case 'view-logs':
+      return 'nx-connect';
+    default:
+      return 'nx-init';
+  }
+}
+
+async function nxCloudPrompt(
+  key: MessageKey,
+  utmMedium: string
+): Promise<MessageOptionKey> {
   const { message, choices, initial, footer, hint } = messages.getPrompt(key);
 
   const promptConfig = {
@@ -291,7 +309,8 @@ async function nxCloudPrompt(key: MessageKey): Promise<MessageOptionKey> {
     initial,
   } as any; // meeroslav: types in enquirer are not up to date
   if (footer) {
-    promptConfig.footer = () => pc.dim(footer);
+    promptConfig.footer = () =>
+      pc.dim(`${footer} ${nxCloudHyperlink(utmMedium)}`);
   }
   if (hint) {
     promptConfig.hint = () => pc.dim(hint);

--- a/packages/nx/src/utils/ab-testing.spec.ts
+++ b/packages/nx/src/utils/ab-testing.spec.ts
@@ -1,0 +1,36 @@
+import { NX_CLOUD_URL, nxCloudHyperlink } from './ab-testing';
+
+describe('nxCloudHyperlink', () => {
+  const BEL = '\u0007';
+  const OSC = '\u001B]';
+  let originalForce: string | undefined;
+
+  beforeEach(() => {
+    originalForce = process.env.FORCE_HYPERLINK;
+  });
+
+  afterEach(() => {
+    if (originalForce === undefined) {
+      delete process.env.FORCE_HYPERLINK;
+    } else {
+      process.env.FORCE_HYPERLINK = originalForce;
+    }
+  });
+
+  it('embeds UTM attribution in the link target while keeping the visible text clean', () => {
+    process.env.FORCE_HYPERLINK = '1';
+    const link = nxCloudHyperlink('nx-init');
+
+    // Visible text is the bare URL (no querystring leaks into the label).
+    expect(link).toContain(`${BEL}${NX_CLOUD_URL}${OSC}`);
+    // Tracked URL is the link target only.
+    expect(link).toContain(
+      `${NX_CLOUD_URL}?utm_source=nx-cli&utm_medium=nx-init`
+    );
+  });
+
+  it('falls back to the bare URL when hyperlinks are unsupported', () => {
+    process.env.FORCE_HYPERLINK = '0';
+    expect(nxCloudHyperlink('nx-migrate')).toBe(NX_CLOUD_URL);
+  });
+});

--- a/packages/nx/src/utils/ab-testing.ts
+++ b/packages/nx/src/utils/ab-testing.ts
@@ -2,7 +2,22 @@ import { execSync } from 'node:child_process';
 import { isCI } from './is-ci';
 import { getPackageManagerCommand } from './package-manager';
 import { getCloudUrl } from '../nx-cloud/utilities/get-cloud-options';
+import { terminalLink } from './terminal-link';
 import * as pc from 'picocolors';
+
+export const NX_CLOUD_URL = 'https://nx.dev/nx-cloud';
+
+/**
+ * Clickable Nx Cloud marketing link for cloud prompt footers. The visible text
+ * stays the clean `NX_CLOUD_URL` while clicks carry UTM attribution; terminals
+ * without OSC 8 support just render the bare URL (CLOUD-4642). The medium is
+ * per-command because `nx init` and `nx migrate` share a footer but report
+ * different mediums.
+ */
+export function nxCloudHyperlink(utmMedium: string): string {
+  const tracked = `${NX_CLOUD_URL}?utm_source=nx-cli&utm_medium=${utmMedium}`;
+  return terminalLink(NX_CLOUD_URL, tracked);
+}
 
 /**
  * Meta payload types for recordStat telemetry (matches CNW format).
@@ -52,7 +67,7 @@ const messageOptions: Record<string, MessageData[]> = {
         { value: 'never', name: pc.dim("No, don't ask again") },
       ],
       footer:
-        '\nFree for small teams. Remote caching and task distribution. 2-minute setup: https://nx.dev/nx-cloud',
+        '\nFree for small teams. Remote caching and task distribution. 2-minute setup:',
     },
     {
       code: 'cloud-self-healing-remote-cache',
@@ -63,7 +78,7 @@ const messageOptions: Record<string, MessageData[]> = {
         { value: 'skip', name: 'Skip for now' },
         { value: 'never', name: pc.dim("No, don't ask again") },
       ],
-      footer: '\nLearn about it at https://nx.dev/nx-cloud',
+      footer: '\nLearn about it at',
       hint: `\n(it's free and can be disabled any time)`,
     },
   ],
@@ -80,7 +95,7 @@ const messageOptions: Record<string, MessageData[]> = {
         },
         { value: 'skip', name: 'No' },
       ],
-      footer: '\nRead more about Nx Cloud at https://nx.dev/nx-cloud',
+      footer: '\nRead more about Nx Cloud at',
       hint: `\n(it's free and can be disabled any time)`,
     },
   ],

--- a/packages/nx/src/utils/terminal-link.spec.ts
+++ b/packages/nx/src/utils/terminal-link.spec.ts
@@ -1,0 +1,50 @@
+import { parseVersion, terminalLink } from './terminal-link';
+
+describe('terminalLink', () => {
+  const OSC = '\u001B]';
+  const BEL = '\u0007';
+  let originalForce: string | undefined;
+
+  beforeEach(() => {
+    originalForce = process.env.FORCE_HYPERLINK;
+  });
+
+  afterEach(() => {
+    if (originalForce === undefined) {
+      delete process.env.FORCE_HYPERLINK;
+    } else {
+      process.env.FORCE_HYPERLINK = originalForce;
+    }
+  });
+
+  it('wraps text in an OSC 8 sequence when hyperlinks are supported', () => {
+    process.env.FORCE_HYPERLINK = '1';
+    const result = terminalLink('label', 'https://example.com');
+    expect(result).toBe(
+      `${OSC}8;;https://example.com${BEL}label${OSC}8;;${BEL}`
+    );
+  });
+
+  it('returns plain text when hyperlinks are not supported', () => {
+    process.env.FORCE_HYPERLINK = '0';
+    expect(terminalLink('label', 'https://example.com')).toBe('label');
+  });
+});
+
+describe('parseVersion', () => {
+  it.each([
+    // VTE packed integers: "5402" -> 0.54.2
+    ['5402', { major: 0, minor: 54, patch: 2 }],
+    ['5000', { major: 0, minor: 50, patch: 0 }],
+    ['501', { major: 0, minor: 5, patch: 1 }],
+    // Dot-separated versions
+    ['3.5.0', { major: 3, minor: 5, patch: 0 }],
+    ['1.72', { major: 1, minor: 72, patch: 0 }],
+    ['20200620', { major: 20200620, minor: 0, patch: 0 }],
+    // Missing / malformed input defaults to zeros
+    ['', { major: 0, minor: 0, patch: 0 }],
+    [undefined, { major: 0, minor: 0, patch: 0 }],
+  ])('parses %p', (input, expected) => {
+    expect(parseVersion(input as string | undefined)).toEqual(expected);
+  });
+});

--- a/packages/nx/src/utils/terminal-link.ts
+++ b/packages/nx/src/utils/terminal-link.ts
@@ -1,0 +1,103 @@
+// Keep in sync with packages/create-nx-workspace/src/utils/terminal-link.ts.
+// create-nx-workspace cannot depend on nx, so this generic OSC 8 helper is
+// intentionally duplicated (same reasoning as output.ts / package-manager.ts).
+
+const OSC = '\u001B]';
+const BEL = '\u0007';
+const SEP = ';';
+
+/**
+ * Wrap `text` in an OSC 8 hyperlink that points at `url`. Supported terminals
+ * render `text` as a clickable link to `url`; everywhere else `text` prints
+ * unchanged. This lets us keep tracking querystrings out of the visible output
+ * while still attaching them to the link target (CLOUD-4642).
+ */
+export function terminalLink(text: string, url: string): string {
+  if (!supportsHyperlinks()) {
+    return text;
+  }
+  return [OSC, '8', SEP, SEP, url, BEL, text, OSC, '8', SEP, SEP, BEL].join('');
+}
+
+/**
+ * Best-effort detection of OSC 8 hyperlink support, adapted from the
+ * `supports-hyperlinks` package. Defaults to false when in doubt so we never
+ * print raw escape sequences to a terminal that can't render them.
+ */
+function supportsHyperlinks(): boolean {
+  const env = process.env;
+
+  if (env.FORCE_HYPERLINK !== undefined) {
+    return !(
+      env.FORCE_HYPERLINK.length > 0 && parseInt(env.FORCE_HYPERLINK, 10) === 0
+    );
+  }
+
+  if (!process.stdout || !process.stdout.isTTY) {
+    return false;
+  }
+
+  if (process.platform === 'win32') {
+    // Only Windows Terminal advertises OSC 8 support reliably.
+    return Boolean(env.WT_SESSION);
+  }
+
+  if (env.CI || env.TEAMCITY_VERSION) {
+    return false;
+  }
+  if (env.TERM === 'dumb') {
+    return false;
+  }
+
+  if (env.TERM_PROGRAM) {
+    const version = parseVersion(env.TERM_PROGRAM_VERSION);
+    switch (env.TERM_PROGRAM) {
+      case 'iTerm.app':
+        return version.major === 3 ? version.minor >= 1 : version.major > 3;
+      case 'WezTerm':
+        return version.major >= 20200620;
+      case 'vscode':
+        return (
+          version.major > 1 || (version.major === 1 && version.minor >= 72)
+        );
+      case 'ghostty':
+        return true;
+    }
+  }
+
+  if (env.VTE_VERSION) {
+    if (env.VTE_VERSION === '0.50.0') {
+      return false;
+    }
+    const version = parseVersion(env.VTE_VERSION);
+    return version.major > 0 || version.minor >= 50;
+  }
+
+  if (env.TERM === 'xterm-kitty') {
+    return true;
+  }
+  if (env.TERMINAL_EMULATOR === 'JetBrains-JediTerm') {
+    return true;
+  }
+
+  return false;
+}
+
+/**
+ * Exported for testing. VTE reports versions as a packed integer, e.g. "5402"
+ * means 0.54.2; everything else is dot-separated.
+ */
+export function parseVersion(versionString = ''): {
+  major: number;
+  minor: number;
+  patch: number;
+} {
+  if (/^\d{3,4}$/.test(versionString)) {
+    const m = /(\d{1,2})(\d{2})/.exec(versionString) ?? [];
+    return { major: 0, minor: parseInt(m[1], 10), patch: parseInt(m[2], 10) };
+  }
+  const [major = 0, minor = 0, patch = 0] = (versionString ?? '')
+    .split('.')
+    .map((n) => parseInt(n, 10) || 0);
+  return { major, minor, patch };
+}


### PR DESCRIPTION
## Current Behavior

Cloud setup prompts show a plain `https://nx.dev/nx-cloud` link with no attribution.

## Expected Behavior

The footer link is rendered as an OSC 8 hyperlink. The visible text stays clean (`https://nx.dev/nx-cloud`) while the click target carries `utm_source=nx-cli` plus a per-command `utm_medium` (`create-nx-workspace`, `nx-init`, `nx-migrate`, `nx-connect`). Terminals without OSC 8 support fall back to the plain link.

## Related Issue(s)

CLOUD-4642

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/cli-utm-99e98561)
<!-- polygraph-session-end -->