### PR TITLE
fix(core): use default import for chalk

### DIFF
--- a/packages/workspace/src/utils/output.ts
+++ b/packages/workspace/src/utils/output.ts
@@ -1,4 +1,4 @@
-import * as chalk from 'chalk';
+import chalk from 'chalk';
 
 export interface CLIErrorMessageConfig {
   title: string;


### PR DESCRIPTION
chalk 4.x is a CJS module that exports the chalk instance via `module.exports`. Using `import * as chalk` caused tslib to wrap it with `__importStar`, which works but differs from how the module is meant to be consumed. Switching to a default import uses `__importDefault` instead, matching the actual shape of the export and eliminating the need for downstream patches.