### PR TITLE
feat(misc): add next 14 to 15 and react 18 to 19 upgrade paths

### DIFF
--- a/packages/next/migrations.json
+++ b/packages/next/migrations.json
@@ -20,6 +20,15 @@
       "description": "Rename imports of `createNodesV2` from `@nx/next/plugin` to the canonical `createNodes` export.",
       "implementation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
       "documentation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"
+    },
+    "update-23-1-0-create-ai-instructions-for-next-15": {
+      "version": "23.1.0-beta.0",
+      "requires": {
+        "next": ">=15.0.0 <16.0.0"
+      },
+      "description": "Create AI instructions to help migrate workspaces from Next.js 14 to 15.",
+      "prompt": "./dist/src/migrations/update-23-1-0/ai-instructions-for-next-15.md",
+      "documentation": "./dist/src/migrations/update-23-1-0/upgrade-to-next-15.md"
     }
   },
   "packageJsonUpdates": {
@@ -52,6 +61,22 @@
         },
         "eslint-config-next": {
           "version": "^16.1.6",
+          "alwaysAddToPackageJson": false
+        }
+      }
+    },
+    "23.1.0": {
+      "version": "23.1.0-beta.0",
+      "requires": {
+        "next": ">=14.0.0 <15.0.0"
+      },
+      "packages": {
+        "next": {
+          "version": "~15.5.18",
+          "alwaysAddToPackageJson": false
+        },
+        "eslint-config-next": {
+          "version": "^15.5.18",
           "alwaysAddToPackageJson": false
         }
       }

--- a/packages/next/src/migrations/update-23-1-0/ai-instructions-for-next-15.md
+++ b/packages/next/src/migrations/update-23-1-0/ai-instructions-for-next-15.md
@@ -1,0 +1,57 @@
+# Next.js 14 -> 15 Migration Instructions for LLM
+
+Migrate the Nx workspace's Next.js projects from 14 to 15. Run the codemod first, fix the rest by hand, build after each project.
+
+## Step 1: Codemod
+
+```bash
+npx @next/codemod@canary upgrade 15
+```
+
+Pin to `15` (not `latest` - that now resolves to 16). The `@canary` tag is what Next ships the upgrade codemod on. Handles most async-API rewrites. Review the diff.
+
+## Step 2: React 19 (App Router only)
+
+Next 15 App Router requires React 19. Page Router can stay on React 18. For App Router projects, also run the React 18 -> 19 migration.
+
+## Step 3: Async request APIs (main breaking change)
+
+`cookies`, `headers`, `draftMode`, `params`, `searchParams` are now async. Codemod covers most; fix leftovers.
+
+```tsx
+// before
+const { slug } = params;
+// after
+const { slug } = await props.params;
+```
+
+Make the component / handler `async` and `await` the value.
+
+App Router only - Pages Router `getServerSideProps` / `getStaticProps` / `getStaticPaths` `context.params` is NOT async; leave it unchanged.
+
+## Step 4: Caching defaults changed
+
+No longer cached by default: `fetch`, GET route handlers, client navigations. Re-add caching where you relied on it.
+
+- `fetch(url, { cache: 'force-cache' })`
+- Route handler: `export const dynamic = 'force-static'`
+
+## Step 5: Misc
+
+- `@next/font` removed -> import from `next/font`.
+- Route `runtime: 'experimental-edge'` -> `runtime: 'edge'`.
+- `next.config` renames: `experimental.bundlePagesExternals` -> top-level `bundlePagesRouterDependencies`; `experimental.serverComponentsExternalPackages` -> top-level `serverExternalPackages`.
+- `NextRequest.geo` / `request.ip` removed (e.g. in middleware) -> read from headers (`x-forwarded-for`, platform geo headers).
+
+## Validate
+
+```bash
+nx run PROJECT:build
+nx affected -t build,lint,test
+```
+
+## Notes for LLM
+
+- Codemod first, then manual.
+- One project at a time, build after each.
+- Skip Step 2 for Page Router projects.

--- a/packages/next/src/migrations/update-23-1-0/upgrade-to-next-15.md
+++ b/packages/next/src/migrations/update-23-1-0/upgrade-to-next-15.md
@@ -1,0 +1,33 @@
+#### Upgrade Next.js 14 to 15
+
+Bumps Next.js from 14 to 15 (and `eslint-config-next` to match). The main breaking change is that the request APIs (`params`, `searchParams`, `cookies`, `headers`, `draftMode`) are now asynchronous. App Router projects also require React 19; Page Router projects can stay on React 18. Read more in the [Next.js 15 upgrade guide](https://nextjs.org/docs/app/guides/upgrading/version-15).
+
+The paired AI instructions migration walks an agent through the full set of changes. The common ones are shown below.
+
+#### Examples
+
+##### Before
+
+```tsx title="app/blog/[slug]/page.tsx"
+export default function Page({ params, searchParams }) {
+  const { slug } = params;
+  const query = searchParams.q;
+  return <h1>{slug}</h1>;
+}
+```
+
+##### After
+
+```tsx title="app/blog/[slug]/page.tsx"
+export default async function Page(props) {
+  const { slug } = await props.params;
+  const { q: query } = await props.searchParams;
+  return <h1>{slug}</h1>;
+}
+```
+
+`cookies`, `headers`, and `draftMode` are awaited the same way (`const store = await cookies();`).
+
+#### Page Router
+
+Pages Router data functions are not affected: `getServerSideProps` / `getStaticProps` / `getStaticPaths` `context.params` stays synchronous - leave it unchanged.

--- a/packages/react/migrations.json
+++ b/packages/react/migrations.json
@@ -30,6 +30,15 @@
       "version": "23.0.0-beta.25",
       "description": "Rewrites `@nx/react/src/*` subpath imports now that the `./src/*` subpath is no longer exposed by `@nx/react`'s exports map. Named imports/exports of public symbols are routed to `@nx/react` and the rest to the new `@nx/react/internal` entry; `require`, dynamic `import` and `jest.mock` calls reference the whole module and are routed to `@nx/react/internal`.",
       "implementation": "./dist/src/migrations/update-23-0-0/rewrite-internal-subpath-imports"
+    },
+    "update-23-1-0-create-ai-instructions-for-react-19": {
+      "version": "23.1.0-beta.0",
+      "requires": {
+        "react": ">=19.0.0"
+      },
+      "description": "Create AI instructions to help migrate workspaces from React 18 to 19.",
+      "prompt": "./dist/src/migrations/update-23-1-0/ai-instructions-for-react-19.md",
+      "documentation": "./dist/src/migrations/update-23-1-0/upgrade-to-react-19.md"
     }
   },
   "packageJsonUpdates": {
@@ -199,6 +208,38 @@
         },
         "@react-router/remix-routes-option-adapter": {
           "version": "7.14.2",
+          "alwaysAddToPackageJson": false
+        }
+      }
+    },
+    "23.1.0": {
+      "version": "23.1.0-beta.0",
+      "requires": {
+        "react": ">=18.0.0 <19.0.0"
+      },
+      "packages": {
+        "react": {
+          "version": "^19.0.0",
+          "alwaysAddToPackageJson": false
+        },
+        "react-dom": {
+          "version": "^19.0.0",
+          "alwaysAddToPackageJson": false
+        },
+        "react-is": {
+          "version": "^19.0.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@types/react": {
+          "version": "^19.0.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@types/react-dom": {
+          "version": "^19.0.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@types/react-is": {
+          "version": "^19.0.0",
           "alwaysAddToPackageJson": false
         }
       }

--- a/packages/react/src/migrations/update-23-1-0/ai-instructions-for-react-19.md
+++ b/packages/react/src/migrations/update-23-1-0/ai-instructions-for-react-19.md
@@ -1,0 +1,44 @@
+# React 18 -> 19 Migration Instructions for LLM
+
+Migrate the Nx workspace's React projects from 18 to 19. Run the codemods first, fix the rest by hand, build after each project.
+
+## Step 1: Codemods
+
+```bash
+npx codemod@latest react/19/migration-recipe
+npx types-react-codemod@latest preset-19 ./PROJECT_PATH
+```
+
+First handles API changes, second handles `@types/react` 19 types. Review the diffs.
+
+## Step 2: Removed APIs (fix by hand if codemod misses)
+
+- `ReactDOM.render` / `hydrate` -> `createRoot` / `hydrateRoot` from `react-dom/client`. Note `hydrateRoot(container, element)` swaps the arg order vs `hydrate`.
+- `ReactDOM.unmountComponentAtNode` -> keep the root from `createRoot` / `hydrateRoot` and call `root.unmount()`.
+- `ReactDOM.findDOMNode` -> use refs.
+- `propTypes` -> removed for ALL components (class and function); drop it, use TS types.
+- `defaultProps` -> removed for FUNCTION components (use default params); still works on classes.
+- Legacy string refs -> callback refs or `useRef`.
+- Legacy Context: consumer `contextTypes` and provider `childContextTypes` / `getChildContext` -> `createContext`.
+- `react-test-renderer` is deprecated -> migrate tests to `@testing-library/react`.
+
+## Step 3: ref as prop
+
+`forwardRef` is no longer needed; `ref` is a normal prop. Existing `forwardRef` calls still work (deprecated).
+
+## Step 4: Types
+
+`@types/react@19`: `useRef` needs an initial arg, implicit `children` removed (declare it on props), `JSX` global moved. The types codemod handles most.
+
+## Validate
+
+```bash
+nx run PROJECT:build
+nx affected -t build,lint,test
+```
+
+## Notes for LLM
+
+- Codemods first (API + types), then manual.
+- One project at a time, build after each.
+- Confirm third-party libs support React 19 before bumping.

--- a/packages/react/src/migrations/update-23-1-0/upgrade-to-react-19.md
+++ b/packages/react/src/migrations/update-23-1-0/upgrade-to-react-19.md
@@ -1,0 +1,38 @@
+#### Upgrade React 18 to 19
+
+Bumps `react`, `react-dom`, and the React type packages from 18 to 19. React 19 removes several long-deprecated APIs; the change every project hits is the root API (`ReactDOM.render` -> `createRoot`). Read more in the [React 19 upgrade guide](https://react.dev/blog/2024/04/25/react-19-upgrade-guide).
+
+The paired AI instructions migration walks an agent through the full set of changes. The common ones are shown below.
+
+#### Examples
+
+##### Before
+
+```tsx title="src/main.tsx"
+import ReactDOM from 'react-dom';
+
+ReactDOM.render(<App />, document.getElementById('root'));
+```
+
+##### After
+
+```tsx title="src/main.tsx"
+import { createRoot } from 'react-dom/client';
+
+createRoot(document.getElementById('root')!).render(<App />);
+```
+
+`defaultProps` on a function component becomes a default parameter:
+
+##### Before
+
+```tsx
+function Badge({ color }) {}
+Badge.defaultProps = { color: 'gray' };
+```
+
+##### After
+
+```tsx
+function Badge({ color = 'gray' }) {}
+```


### PR DESCRIPTION
## Current Behavior

No `nx migrate` path from Next.js 14->15 or React 18->19.

## Expected Behavior

packageJsonUpdates bump Next.js 14->15 (+eslint-config-next) and React 18->19 (+@types/*), each opt-in via x-prompt. Prompt migrations supply AI instructions for the breaking-change code edits. Targets 23.1.

## Related Issue(s)

NXC-4548

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/nextjs-14-removal-eslint-8-drop-prep-ded9154d)
<!-- polygraph-session-end -->