### PR TITLE
fix(core): clean up temp directories and remove the tmp dependency

### DIFF
--- a/packages/create-nx-workspace/package.json
+++ b/packages/create-nx-workspace/package.json
@@ -43,7 +43,6 @@
     "flat": "^5.0.2",
     "open": "^8.4.0",
     "ora": "catalog:",
-    "tmp": "catalog:",
     "tslib": "catalog:typescript",
     "yargs": "catalog:"
   },

--- a/packages/create-nx-workspace/src/create-sandbox.ts
+++ b/packages/create-nx-workspace/src/create-sandbox.ts
@@ -1,5 +1,5 @@
-import { writeFileSync } from 'fs';
-import { dirSync } from 'tmp';
+import { mkdtempSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
 import ora from 'ora';
 import { join } from 'path';
 
@@ -24,7 +24,7 @@ export async function createSandbox(packageManager: PackageManager) {
 
   const { install, preInstall } = getPackageManagerCommand(packageManager);
 
-  const tmpDir = dirSync().name;
+  const tmpDir = mkdtempSync(join(tmpdir(), 'nx-'));
   try {
     writeFileSync(
       join(tmpDir, 'package.json'),

--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -77,7 +77,6 @@
     "semver": "catalog:",
     "string-width": "^4.2.3",
     "tar-stream": "~2.2.0",
-    "tmp": "catalog:",
     "tsconfig-paths": "catalog:typescript",
     "tslib": "catalog:typescript",
     "which": "catalog:",

--- a/packages/nx/src/command-line/import/import.ts
+++ b/packages/nx/src/command-line/import/import.ts
@@ -3,7 +3,7 @@ import { existsSync, promises as fsp } from 'node:fs';
 import * as pc from 'picocolors';
 import { cloneFromUpstream, GitRepository } from '../../utils/git-utils';
 import { stat, mkdir, rm } from 'node:fs/promises';
-import { tmpdir } from 'tmp';
+import { tmpdir } from 'node:os';
 import { prompt } from 'enquirer';
 import { output } from '../../utils/output';
 const createSpinner = require('ora');
@@ -132,7 +132,7 @@ export async function importHandler(options: ImportOptions) {
     });
   }
 
-  const tempImportDirectory = join(tmpdir, 'nx-import');
+  const tempImportDirectory = join(tmpdir(), 'nx-import');
 
   if (!sourceRepository) {
     sourceRepository = (

--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -3980,9 +3980,7 @@ export async function nxCliPath(nxWorkspaceRoot?: string) {
     const packageManager = detectPackageManager();
     const pmc = getPackageManagerCommand(packageManager);
 
-    // The dir holds the installed nx CLI used for the rest of the migration, so
-    // it must outlive this function; the exit hook removes it on process exit.
-    const { dir: tmpDir } = createTempDir('nx-migrate-');
+    const tmpDir = createTempDir('nx-migrate-');
     writeJsonFile(join(tmpDir, 'package.json'), {
       dependencies: {
         nx: version,

--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -41,6 +41,7 @@ import {
 } from '../../utils/fileutils';
 import { extractFileFromTarball } from '../../utils/tar';
 import { writeFormattedJsonFile } from '../../utils/write-formatted-json-file';
+import { createTempDir } from '../../utils/temp-dir';
 import { logger } from '../../utils/logger';
 import {
   getUncommittedChangesSnapshot,
@@ -3979,8 +3980,9 @@ export async function nxCliPath(nxWorkspaceRoot?: string) {
     const packageManager = detectPackageManager();
     const pmc = getPackageManagerCommand(packageManager);
 
-    const { dirSync } = require('tmp');
-    const tmpDir = dirSync().name;
+    // The dir holds the installed nx CLI used for the rest of the migration, so
+    // it must outlive this function; the exit hook removes it on process exit.
+    const { dir: tmpDir } = createTempDir('nx-migrate-');
     writeJsonFile(join(tmpDir, 'package.json'), {
       dependencies: {
         nx: version,

--- a/packages/nx/src/command-line/release/changelog.ts
+++ b/packages/nx/src/command-line/release/changelog.ts
@@ -2,7 +2,7 @@ import * as pc from 'picocolors';
 import { prompt } from 'enquirer';
 import { readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { prerelease } from 'semver';
-import { dirSync } from 'tmp';
+import { createTempDir } from '../../utils/temp-dir';
 import type { DependencyBump } from '../../../release/changelog-renderer';
 import { NxReleaseConfiguration, readNxJson } from '../../config/nx-json';
 import { ProjectGraphProjectNode } from '../../config/project-graph';
@@ -1019,15 +1019,19 @@ async function generateChangelogForWorkspace({
    * in a similar style to git interactive rebases/merges.
    */
   if (interactive) {
-    const tmpDir = dirSync().name;
-    const changelogPath = joinPathFragments(
-      tmpDir,
-      // Include the tree path in the name so that it is easier to identify which changelog file is being edited
-      `PREVIEW__${interpolatedTreePath.replace(/\//g, '_')}`
-    );
-    writeFileSync(changelogPath, contents);
-    await launchEditor(changelogPath);
-    contents = readFileSync(changelogPath, 'utf-8');
+    const { dir: tmpDir, cleanup } = createTempDir('nx-changelog-');
+    try {
+      const changelogPath = joinPathFragments(
+        tmpDir,
+        // Include the tree path in the name so that it is easier to identify which changelog file is being edited
+        `PREVIEW__${interpolatedTreePath.replace(/\//g, '_')}`
+      );
+      writeFileSync(changelogPath, contents);
+      await launchEditor(changelogPath);
+      contents = readFileSync(changelogPath, 'utf-8');
+    } finally {
+      cleanup();
+    }
   }
 
   if (interpolatedTreePath) {
@@ -1187,15 +1191,19 @@ async function generateChangelogForProjects({
      * in a similar style to git interactive rebases/merges.
      */
     if (interactive) {
-      const tmpDir = dirSync().name;
-      const changelogPath = joinPathFragments(
-        tmpDir,
-        // Include the tree path in the name so that it is easier to identify which changelog file is being edited
-        `PREVIEW__${interpolatedTreePath.replace(/\//g, '_')}`
-      );
-      writeFileSync(changelogPath, contents);
-      await launchEditor(changelogPath);
-      contents = readFileSync(changelogPath, 'utf-8');
+      const { dir: tmpDir, cleanup } = createTempDir('nx-changelog-');
+      try {
+        const changelogPath = joinPathFragments(
+          tmpDir,
+          // Include the tree path in the name so that it is easier to identify which changelog file is being edited
+          `PREVIEW__${interpolatedTreePath.replace(/\//g, '_')}`
+        );
+        writeFileSync(changelogPath, contents);
+        await launchEditor(changelogPath);
+        contents = readFileSync(changelogPath, 'utf-8');
+      } finally {
+        cleanup();
+      }
     }
 
     if (interpolatedTreePath) {

--- a/packages/nx/src/command-line/release/changelog.ts
+++ b/packages/nx/src/command-line/release/changelog.ts
@@ -1019,19 +1019,15 @@ async function generateChangelogForWorkspace({
    * in a similar style to git interactive rebases/merges.
    */
   if (interactive) {
-    const { dir: tmpDir, cleanup } = createTempDir('nx-changelog-');
-    try {
-      const changelogPath = joinPathFragments(
-        tmpDir,
-        // Include the tree path in the name so that it is easier to identify which changelog file is being edited
-        `PREVIEW__${interpolatedTreePath.replace(/\//g, '_')}`
-      );
-      writeFileSync(changelogPath, contents);
-      await launchEditor(changelogPath);
-      contents = readFileSync(changelogPath, 'utf-8');
-    } finally {
-      cleanup();
-    }
+    const tmpDir = createTempDir('nx-changelog-');
+    const changelogPath = joinPathFragments(
+      tmpDir,
+      // Include the tree path in the name so that it is easier to identify which changelog file is being edited
+      `PREVIEW__${interpolatedTreePath.replace(/\//g, '_')}`
+    );
+    writeFileSync(changelogPath, contents);
+    await launchEditor(changelogPath);
+    contents = readFileSync(changelogPath, 'utf-8');
   }
 
   if (interpolatedTreePath) {
@@ -1191,19 +1187,15 @@ async function generateChangelogForProjects({
      * in a similar style to git interactive rebases/merges.
      */
     if (interactive) {
-      const { dir: tmpDir, cleanup } = createTempDir('nx-changelog-');
-      try {
-        const changelogPath = joinPathFragments(
-          tmpDir,
-          // Include the tree path in the name so that it is easier to identify which changelog file is being edited
-          `PREVIEW__${interpolatedTreePath.replace(/\//g, '_')}`
-        );
-        writeFileSync(changelogPath, contents);
-        await launchEditor(changelogPath);
-        contents = readFileSync(changelogPath, 'utf-8');
-      } finally {
-        cleanup();
-      }
+      const tmpDir = createTempDir('nx-changelog-');
+      const changelogPath = joinPathFragments(
+        tmpDir,
+        // Include the tree path in the name so that it is easier to identify which changelog file is being edited
+        `PREVIEW__${interpolatedTreePath.replace(/\//g, '_')}`
+      );
+      writeFileSync(changelogPath, contents);
+      await launchEditor(changelogPath);
+      contents = readFileSync(changelogPath, 'utf-8');
     }
 
     if (interpolatedTreePath) {

--- a/packages/nx/src/command-line/release/plan.ts
+++ b/packages/nx/src/command-line/release/plan.ts
@@ -351,18 +351,14 @@ async function _promptForMessage(versionPlanName: string): Promise<string> {
     let message = reply.message.trim();
 
     if (!message.length) {
-      const { dir: tmpDir, cleanup } = createTempDir('nx-version-plan-');
-      try {
-        const messageFilePath = join(
-          tmpDir,
-          `DRAFT_MESSAGE__${versionPlanName}.md`
-        );
-        writeFileSync(messageFilePath, '');
-        await launchEditor(messageFilePath);
-        message = readFileSync(messageFilePath, 'utf-8');
-      } finally {
-        cleanup();
-      }
+      const tmpDir = createTempDir('nx-version-plan-');
+      const messageFilePath = join(
+        tmpDir,
+        `DRAFT_MESSAGE__${versionPlanName}.md`
+      );
+      writeFileSync(messageFilePath, '');
+      await launchEditor(messageFilePath);
+      message = readFileSync(messageFilePath, 'utf-8');
     }
 
     message = message.trim();

--- a/packages/nx/src/command-line/release/plan.ts
+++ b/packages/nx/src/command-line/release/plan.ts
@@ -3,7 +3,7 @@ import { readFileSync, writeFileSync } from 'node:fs';
 import { mkdir, writeFile } from 'node:fs/promises';
 import { join } from 'node:path';
 import { RELEASE_TYPES } from 'semver';
-import { dirSync } from 'tmp';
+import { createTempDir } from '../../utils/temp-dir';
 import { NxReleaseConfiguration, readNxJson } from '../../config/nx-json';
 import { createProjectFileMapUsingProjectGraph } from '../../project-graph/file-map-utils';
 import { createProjectGraphAsync } from '../../project-graph/project-graph';
@@ -351,14 +351,18 @@ async function _promptForMessage(versionPlanName: string): Promise<string> {
     let message = reply.message.trim();
 
     if (!message.length) {
-      const tmpDir = dirSync().name;
-      const messageFilePath = join(
-        tmpDir,
-        `DRAFT_MESSAGE__${versionPlanName}.md`
-      );
-      writeFileSync(messageFilePath, '');
-      await launchEditor(messageFilePath);
-      message = readFileSync(messageFilePath, 'utf-8');
+      const { dir: tmpDir, cleanup } = createTempDir('nx-version-plan-');
+      try {
+        const messageFilePath = join(
+          tmpDir,
+          `DRAFT_MESSAGE__${versionPlanName}.md`
+        );
+        writeFileSync(messageFilePath, '');
+        await launchEditor(messageFilePath);
+        message = readFileSync(messageFilePath, 'utf-8');
+      } finally {
+        cleanup();
+      }
     }
 
     message = message.trim();

--- a/packages/nx/src/daemon/tmp-dir.ts
+++ b/packages/nx/src/daemon/tmp-dir.ts
@@ -7,7 +7,7 @@ import { mkdirSync, rmSync, statSync, writeFileSync } from 'node:fs';
 import { join } from 'path';
 import { workspaceDataDirectory } from '../utils/cache-directory';
 import { createHash } from 'crypto';
-import { tmpdir } from 'tmp';
+import { tmpdir } from 'node:os';
 import { workspaceRoot } from '../utils/workspace-root';
 
 export const DAEMON_DIR_FOR_CURRENT_WORKSPACE = join(
@@ -51,7 +51,7 @@ function socketDirName() {
   hasher.update(workspaceRoot.toLowerCase());
   hasher.update(String(process.pid));
   const unique = hasher.digest('hex').substring(0, 20);
-  return join(tmpdir, unique);
+  return join(tmpdir(), unique);
 }
 
 /**
@@ -63,7 +63,7 @@ export function getSocketDir(alreadyUnique = false) {
     const dir =
       process.env.NX_SOCKET_DIR ??
       process.env.NX_DAEMON_SOCKET_DIR ??
-      (alreadyUnique ? tmpdir : socketDirName());
+      (alreadyUnique ? tmpdir() : socketDirName());
     mkdirSync(dir, { recursive: true });
 
     return dir;

--- a/packages/nx/src/executors/run-commands/run-commands.impl.spec.ts
+++ b/packages/nx/src/executors/run-commands/run-commands.impl.spec.ts
@@ -1,8 +1,18 @@
-import { readFileSync, writeFileSync } from 'fs';
+import { mkdtempSync, readFileSync, writeFileSync } from 'fs';
 import { env } from 'npm-run-path';
-import { relative } from 'path';
-import { dirSync, fileSync } from 'tmp';
+import { tmpdir } from 'os';
+import { join, relative } from 'path';
 import runCommands, { interpolateArgsIntoCommand } from './run-commands.impl';
+
+// Local stand-ins for the `tmp` package's dirSync/fileSync (return `{ name }`).
+function dirSync(opts?: { dir?: string }) {
+  return { name: mkdtempSync(join(opts?.dir ?? tmpdir(), 'nx-')) };
+}
+function fileSync() {
+  const name = join(mkdtempSync(join(tmpdir(), 'nx-')), 'file');
+  writeFileSync(name, '');
+  return { name };
+}
 
 function normalize(p: string) {
   return p.startsWith('/private') ? p.substring(8) : p;

--- a/packages/nx/src/generators/tree.spec.ts
+++ b/packages/nx/src/generators/tree.spec.ts
@@ -1,12 +1,13 @@
 import {
   lstatSync,
   mkdirSync,
+  mkdtempSync,
   Mode,
   readFileSync,
   rmSync,
   writeFileSync,
 } from 'node:fs';
-import { dirSync, file } from 'tmp';
+import { tmpdir } from 'node:os';
 import * as path from 'path';
 import {
   FileChange,
@@ -27,7 +28,7 @@ describe('tree', () => {
       console.error = jest.fn();
       console.log = jest.fn();
 
-      dir = dirSync().name;
+      dir = mkdtempSync(path.join(tmpdir(), 'nx-'));
       mkdirSync(path.join(dir, 'parent/child'), { recursive: true });
       writeFileSync(path.join(dir, 'root-file.txt'), 'root content');
       writeFileSync(

--- a/packages/nx/src/utils/package-json.ts
+++ b/packages/nx/src/utils/package-json.ts
@@ -391,8 +391,10 @@ function preparePackageInstallation(
   requiredVersion: string,
   packageManager: PackageManager
 ) {
-  const { dir: tempDir, cleanup } =
-    createTempNpmDirectory?.() ?? createTempDir();
+  const { dir: tempDir, cleanup } = createTempNpmDirectory?.() ?? {
+    dir: createTempDir(),
+    cleanup: () => {},
+  };
 
   console.log(`Fetching ${pkg}...`);
   const isVerbose = process.env.NX_VERBOSE_LOGGING === 'true';

--- a/packages/nx/src/utils/package-json.ts
+++ b/packages/nx/src/utils/package-json.ts
@@ -4,7 +4,7 @@ import { existsSync, writeFileSync } from 'fs';
 import { dirname, join, resolve } from 'path';
 
 const execAsync = promisify(exec);
-import { dirSync } from 'tmp';
+import { createTempDir } from './temp-dir';
 import { NxJsonConfiguration } from '../config/nx-json';
 import {
   ProjectConfiguration,
@@ -391,10 +391,8 @@ function preparePackageInstallation(
   requiredVersion: string,
   packageManager: PackageManager
 ) {
-  const { dir: tempDir, cleanup } = createTempNpmDirectory?.() ?? {
-    dir: dirSync().name,
-    cleanup: () => {},
-  };
+  const { dir: tempDir, cleanup } =
+    createTempNpmDirectory?.() ?? createTempDir();
 
   console.log(`Fetching ${pkg}...`);
   const isVerbose = process.env.NX_VERBOSE_LOGGING === 'true';

--- a/packages/nx/src/utils/package-manager.ts
+++ b/packages/nx/src/utils/package-manager.ts
@@ -1,5 +1,6 @@
 import { exec, execFile, execSync } from 'child_process';
 import { copyFileSync, existsSync, readFileSync, writeFileSync } from 'fs';
+import { rm } from 'node:fs/promises';
 import { dirname, join, relative } from 'path';
 import { gte, lt, parse, satisfies } from 'semver';
 import { createTempDir } from './temp-dir';
@@ -485,9 +486,7 @@ export function copyPackageManagerConfigurationFiles(
  *                   where no existing configuration files are available to copy.
  */
 export function createTempNpmDirectory(skipCopy = false) {
-  // `cleanup` removes the dir now; it is also registered for removal on process
-  // exit in case the caller never gets a chance to call it.
-  const { dir, cleanup } = createTempDir();
+  const dir = createTempDir();
 
   // A package.json is needed for pnpm pack and for .npmrc to resolve
   writeJsonFile(`${dir}/package.json`, {});
@@ -498,6 +497,14 @@ export function createTempNpmDirectory(skipCopy = false) {
       dir
     );
   }
+
+  const cleanup = async () => {
+    try {
+      await rm(dir, { recursive: true, force: true });
+    } catch {
+      // It's okay if this fails, the OS will clean it up eventually
+    }
+  };
 
   return { dir, cleanup };
 }

--- a/packages/nx/src/utils/package-manager.ts
+++ b/packages/nx/src/utils/package-manager.ts
@@ -1,9 +1,8 @@
 import { exec, execFile, execSync } from 'child_process';
 import { copyFileSync, existsSync, readFileSync, writeFileSync } from 'fs';
-import { rm } from 'node:fs/promises';
 import { dirname, join, relative } from 'path';
 import { gte, lt, parse, satisfies } from 'semver';
-import { dirSync } from 'tmp';
+import { createTempDir } from './temp-dir';
 import { promisify } from 'util';
 import {
   Pair,
@@ -486,7 +485,9 @@ export function copyPackageManagerConfigurationFiles(
  *                   where no existing configuration files are available to copy.
  */
 export function createTempNpmDirectory(skipCopy = false) {
-  const dir = dirSync().name;
+  // `cleanup` removes the dir now; it is also registered for removal on process
+  // exit in case the caller never gets a chance to call it.
+  const { dir, cleanup } = createTempDir();
 
   // A package.json is needed for pnpm pack and for .npmrc to resolve
   writeJsonFile(`${dir}/package.json`, {});
@@ -497,14 +498,6 @@ export function createTempNpmDirectory(skipCopy = false) {
       dir
     );
   }
-
-  const cleanup = async () => {
-    try {
-      await rm(dir, { recursive: true, force: true });
-    } catch {
-      // It's okay if this fails, the OS will clean it up eventually
-    }
-  };
 
   return { dir, cleanup };
 }

--- a/packages/nx/src/utils/temp-dir.spec.ts
+++ b/packages/nx/src/utils/temp-dir.spec.ts
@@ -1,0 +1,45 @@
+import { existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { basename, dirname } from 'node:path';
+import { createTempDir } from './temp-dir';
+
+describe('createTempDir', () => {
+  it('creates a unique directory under the OS temp dir', () => {
+    const { dir, cleanup } = createTempDir();
+    try {
+      expect(existsSync(dir)).toBe(true);
+      expect(dirname(dir)).toBe(tmpdir());
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('applies the provided prefix to the directory name', () => {
+    const { dir, cleanup } = createTempDir('nx-test-');
+    try {
+      expect(basename(dir).startsWith('nx-test-')).toBe(true);
+    } finally {
+      cleanup();
+    }
+  });
+
+  it('returns distinct directories on repeated calls', () => {
+    const a = createTempDir();
+    const b = createTempDir();
+    try {
+      expect(a.dir).not.toBe(b.dir);
+    } finally {
+      a.cleanup();
+      b.cleanup();
+    }
+  });
+
+  it('removes the directory on cleanup and is idempotent', () => {
+    const { dir, cleanup } = createTempDir();
+    expect(existsSync(dir)).toBe(true);
+    cleanup();
+    expect(existsSync(dir)).toBe(false);
+    // A second call must not throw even though the directory is gone.
+    expect(() => cleanup()).not.toThrow();
+  });
+});

--- a/packages/nx/src/utils/temp-dir.spec.ts
+++ b/packages/nx/src/utils/temp-dir.spec.ts
@@ -1,25 +1,25 @@
-import { existsSync } from 'node:fs';
+import { existsSync, rmSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { basename, dirname } from 'node:path';
 import { createTempDir } from './temp-dir';
 
 describe('createTempDir', () => {
   it('creates a unique directory under the OS temp dir', () => {
-    const { dir, cleanup } = createTempDir();
+    const dir = createTempDir();
     try {
       expect(existsSync(dir)).toBe(true);
       expect(dirname(dir)).toBe(tmpdir());
     } finally {
-      cleanup();
+      rmSync(dir, { recursive: true, force: true });
     }
   });
 
   it('applies the provided prefix to the directory name', () => {
-    const { dir, cleanup } = createTempDir('nx-test-');
+    const dir = createTempDir('nx-test-');
     try {
       expect(basename(dir).startsWith('nx-test-')).toBe(true);
     } finally {
-      cleanup();
+      rmSync(dir, { recursive: true, force: true });
     }
   });
 
@@ -27,19 +27,10 @@ describe('createTempDir', () => {
     const a = createTempDir();
     const b = createTempDir();
     try {
-      expect(a.dir).not.toBe(b.dir);
+      expect(a).not.toBe(b);
     } finally {
-      a.cleanup();
-      b.cleanup();
+      rmSync(a, { recursive: true, force: true });
+      rmSync(b, { recursive: true, force: true });
     }
-  });
-
-  it('removes the directory on cleanup and is idempotent', () => {
-    const { dir, cleanup } = createTempDir();
-    expect(existsSync(dir)).toBe(true);
-    cleanup();
-    expect(existsSync(dir)).toBe(false);
-    // A second call must not throw even though the directory is gone.
-    expect(() => cleanup()).not.toThrow();
   });
 });

--- a/packages/nx/src/utils/temp-dir.ts
+++ b/packages/nx/src/utils/temp-dir.ts
@@ -1,58 +1,12 @@
-import { mkdtempSync, rmSync } from 'node:fs';
+import { mkdtempSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 
 /**
- * Directories we created and still want removed when the process exits. A dir
- * is removed from this set as soon as its `cleanup()` runs, so the exit handler
- * only ever touches dirs the caller forgot (or chose not) to clean up.
+ * Creates a unique directory under the OS temp dir and returns its path. This
+ * is a thin replacement for the `tmp` package's `dirSync().name`; cleanup is
+ * the caller's responsibility (matching the previous behavior).
  */
-const tracked = new Set<string>();
-let exitHookRegistered = false;
-
-function registerExitHook(): void {
-  if (exitHookRegistered) {
-    return;
-  }
-  exitHookRegistered = true;
-  // 'exit' handlers must be synchronous - async work is ignored. This fires on
-  // normal exit and `process.exit()`, but not on signals/crashes; in those
-  // cases the OS reclaims the temp dir on its next sweep.
-  process.once('exit', () => {
-    for (const dir of tracked) {
-      try {
-        rmSync(dir, { recursive: true, force: true });
-      } catch {}
-    }
-  });
-}
-
-export interface TempDir {
-  /** Absolute path to the newly created temporary directory. */
-  dir: string;
-  /** Remove the directory now. Idempotent and safe to call more than once. */
-  cleanup: () => void;
-}
-
-/**
- * Creates a unique directory under the OS temp dir and registers it for removal
- * when the process exits. Prefer calling `cleanup()` as soon as the directory
- * is no longer needed; the exit hook is only a safety net for dirs that must
- * outlive the calling function (and is best-effort - see `registerExitHook`).
- */
-export function createTempDir(prefix = 'nx-'): TempDir {
-  registerExitHook();
-  const dir = mkdtempSync(join(tmpdir(), prefix));
-  tracked.add(dir);
-
-  const cleanup = () => {
-    if (!tracked.delete(dir)) {
-      return;
-    }
-    try {
-      rmSync(dir, { recursive: true, force: true });
-    } catch {}
-  };
-
-  return { dir, cleanup };
+export function createTempDir(prefix = 'nx-'): string {
+  return mkdtempSync(join(tmpdir(), prefix));
 }

--- a/packages/nx/src/utils/temp-dir.ts
+++ b/packages/nx/src/utils/temp-dir.ts
@@ -1,0 +1,58 @@
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+/**
+ * Directories we created and still want removed when the process exits. A dir
+ * is removed from this set as soon as its `cleanup()` runs, so the exit handler
+ * only ever touches dirs the caller forgot (or chose not) to clean up.
+ */
+const tracked = new Set<string>();
+let exitHookRegistered = false;
+
+function registerExitHook(): void {
+  if (exitHookRegistered) {
+    return;
+  }
+  exitHookRegistered = true;
+  // 'exit' handlers must be synchronous - async work is ignored. This fires on
+  // normal exit and `process.exit()`, but not on signals/crashes; in those
+  // cases the OS reclaims the temp dir on its next sweep.
+  process.once('exit', () => {
+    for (const dir of tracked) {
+      try {
+        rmSync(dir, { recursive: true, force: true });
+      } catch {}
+    }
+  });
+}
+
+export interface TempDir {
+  /** Absolute path to the newly created temporary directory. */
+  dir: string;
+  /** Remove the directory now. Idempotent and safe to call more than once. */
+  cleanup: () => void;
+}
+
+/**
+ * Creates a unique directory under the OS temp dir and registers it for removal
+ * when the process exits. Prefer calling `cleanup()` as soon as the directory
+ * is no longer needed; the exit hook is only a safety net for dirs that must
+ * outlive the calling function (and is best-effort - see `registerExitHook`).
+ */
+export function createTempDir(prefix = 'nx-'): TempDir {
+  registerExitHook();
+  const dir = mkdtempSync(join(tmpdir(), prefix));
+  tracked.add(dir);
+
+  const cleanup = () => {
+    if (!tracked.delete(dir)) {
+      return;
+    }
+    try {
+      rmSync(dir, { recursive: true, force: true });
+    } catch {}
+  };
+
+  return { dir, cleanup };
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2583,9 +2583,6 @@ importers:
       ora:
         specifier: 'catalog:'
         version: 5.4.1
-      tmp:
-        specifier: 'catalog:'
-        version: 0.2.6
       tslib:
         specifier: catalog:typescript
         version: 2.8.1
@@ -3432,9 +3429,6 @@ importers:
       tar-stream:
         specifier: ~2.2.0
         version: 2.2.0
-      tmp:
-        specifier: 'catalog:'
-        version: 0.2.6
       tsconfig-paths:
         specifier: catalog:typescript
         version: 4.2.0
@@ -24276,6 +24270,7 @@ packages:
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
     engines: {node: ^18 || >=20}
+    deprecated: unmaintained
     hasBin: true
     peerDependencies:
       typescript: ^5.0.0


### PR DESCRIPTION
## Current Behavior

Nx uses the [`tmp`](https://www.npmjs.com/package/tmp) npm package to create temporary directories. Because `tmp.setGracefulCleanup()` is never called and the directories it creates are non-empty, `tmp`'s exit-time cleanup never actually runs. As a result, several one-off temporary directories — created during `nx migrate`, `nx release plan`, and interactive changelog editing — are left behind in the OS temp directory until the OS reclaims them. The `package.json` fallback in `preparePackageInstallation` also used a no-op `cleanup`.

## Expected Behavior

The `tmp` package is replaced with a small `createTempDir` helper (`packages/nx/src/utils/temp-dir.ts`) built on `os.tmpdir()` + `mkdtempSync`. It returns an explicit `cleanup()` and registers a single `process.once('exit')` safety net, so temporary directories are removed as soon as they are no longer needed (or, for directories that must outlive their caller, on process exit).

- Sites that only read the OS temp path (`daemon/tmp-dir.ts`, `import.ts`) now call `os.tmpdir()` directly.
- Leaking temp directories in `migrate`, `release plan`, and `changelog` are now cleaned up.
- The `tmp` dependency is dropped from both `nx` and `create-nx-workspace`. (Test files were migrated off `tmp` so `@nx/dependency-checks` stays green.)

No public API changes. `tsc`, `nx lint`, and the affected unit tests pass.

## Related Issue(s)

N/A
