### PR TITLE
docs(nx): clarify forwardAllArgs default for interpolated commands

### DIFF
--- a/packages/nx/docs/run-commands-examples.md
+++ b/packages/nx/docs/run-commands-examples.md
@@ -90,6 +90,39 @@ or simply with:
 nx run frontend:create-script --name=example
 ```
 
+Keep in mind that any command in the list that does not include interpolation will still have all passed arguments forwarded to it by default. For example, given:
+
+```json
+"create-script": {
+    "executor": "nx:run-commands",
+    "options": {
+        "commands": [
+          "echo {args.name}",
+          "echo done"
+        ],
+        "parallel": false
+    }
+}
+```
+
+running `nx run frontend:create-script --name=example` also appends `--name=example` to the second command, executing `echo done --name=example`. Set `forwardAllArgs` to `false` on the commands that should not receive the arguments:
+
+```json
+"create-script": {
+    "executor": "nx:run-commands",
+    "options": {
+        "commands": [
+          "echo {args.name}",
+          {
+            "command": "echo done",
+            "forwardAllArgs": false
+          }
+        ],
+        "parallel": false
+    }
+}
+```
+
 ##### Arguments forwarding
 
 When interpolation is not present in the command, all arguments are forwarded to the command by default.


### PR DESCRIPTION
## Description

Addresses the documentation feedback in #34756.

In the **Interpolating Args** example for the `nx:run-commands` executor, it isn't obvious that commands which don't contain `{args.*}` interpolation still receive **all** forwarded arguments by default. This trips people up when a multi-command list contains a mix of interpolated and non-interpolated commands.

This PR adds a short note to the *Interpolating Args* tab that:

- explains the default forwarding behavior for non-interpolated commands in a `commands` list, with a concrete `echo done --name=example` example, and
- shows how to opt out per-command via `forwardAllArgs: false`.

## Current Behavior

The docs only document `forwardAllArgs` in the *Arguments forwarding* tab, so users following the interpolation example don't realize their other commands receive the forwarded args.

## Expected Behavior

The interpolation example calls out the default and shows how to disable it.

Closes #34756