### PR TITLE
chore(repo): cap gradle workers on CI agents to avoid oversubscription

### DIFF
--- a/.nx/workflows/agents.yaml
+++ b/.nx/workflows/agents.yaml
@@ -13,6 +13,8 @@ common-env-vars: &common-env-vars
   # These are need for build and link validation for next.js and astro apps
   NEXT_PUBLIC_ASTRO_URL: 'https://master--nx-docs.netlify.app'
   NX_DEV_URL: 'https://canary.nx.dev'
+  # Cap gradle workers so co-located e2e tasks don't oversubscribe the agent.
+  GRADLE_OPTS: '-Dorg.gradle.workers.max=2'
 
 common-init-steps: &common-init-steps
   - name: Checkout


### PR DESCRIPTION
## Current Behavior

Gradle e2e tasks run with `org.gradle.parallel=true` and no worker cap, so each build fans out across every core. The `e2e-ci**` assignment rule in `dynamic-changesets.yaml` co-locates several e2e tasks on a single Nx Cloud agent (3 on `linux-large`, up to 6 on `linux-extra-large`). When multiple gradle e2e tasks land on the same machine, they each grab all cores and oversubscribe the agent's CPU (and stack daemon/Kotlin/test-fork JVMs in memory).

## Expected Behavior

Cap each gradle build to 2 task workers via `GRADLE_OPTS=-Dorg.gradle.workers.max=2` in the shared agent `common-env-vars`. Co-located gradle e2e tasks no longer oversubscribe the shared agent. Only gradle invocations read `GRADLE_OPTS`, so other tasks are unaffected. Daemon behavior is left untouched (the e2e harness intentionally keeps daemons in the test body).

This is a first, low-risk step — it tames CPU fan-out but does not isolate the shared `~/.gradle` / `~/.m2` state between simultaneous gradle builds; pinning gradle e2e to `parallelism: 1` is a possible follow-up if needed.

## Related Issue(s)

N/A — internal CI tuning.
