### PR TITLE
fix(core): support `${configDir}` in tsconfig path alias resolution

### DIFF
--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.spec.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.spec.ts
@@ -78,6 +78,7 @@ describe('TargetProjectLocator', () => {
             '@proj/feature-*': ['libs/features/*'],
             '@proj/*/utils': ['libs/scope/*/utils'],
             '@proj/*-util': ['libs/utils/*'],
+            '@configdir/*': ['${configDir}/src/*'],
           },
         },
       };
@@ -425,6 +426,29 @@ describe('TargetProjectLocator', () => {
       );
 
       expect(proj2deep).toEqual('proj2');
+    });
+
+    it('should resolve `${configDir}` path aliases relative to the importing project (as tsc does)', () => {
+      // importer in a nested project resolves to that project, not the root project
+      const fromNested = targetProjectLocator.findProjectFromImport(
+        '@configdir/foo',
+        'libs/proj/src/index.ts'
+      );
+      expect(fromNested).toEqual('proj');
+
+      // importer in a deeply nested project resolves to the nested project
+      const fromChild = targetProjectLocator.findProjectFromImport(
+        '@configdir/foo',
+        'libs/parent-path/child-path/src/index.ts'
+      );
+      expect(fromChild).toEqual('child-project');
+
+      // importer in the root project resolves to the root project
+      const fromRoot = targetProjectLocator.findProjectFromImport(
+        '@configdir/foo',
+        'index.ts'
+      );
+      expect(fromRoot).toEqual('rootProj');
     });
 
     it('should be able to resolve nested files using tsConfig paths that have similar names', () => {

--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.ts
@@ -54,6 +54,13 @@ export function isBuiltinModuleImport(importExpr: string): boolean {
   return isBuiltin(packageName) || experimentalNodeModules.has(packageName);
 }
 
+// TypeScript matches the `${configDir}` template case-insensitively and only as a
+// prefix (commandLineParser.ts `startsWithConfigDirTemplate`).
+const configDirTemplate = '${configDir}';
+function startsWithConfigDirTemplate(value: string): boolean {
+  return value.toLowerCase().startsWith(configDirTemplate.toLowerCase());
+}
+
 export class TargetProjectLocator {
   private projectRootMappings = createProjectRootMappings(this.nodes);
   private npmProjects: Record<string, ProjectGraphExternalNode | null>;
@@ -129,7 +136,10 @@ export class TargetProjectLocator {
               importExpr.length - path.suffix.length
             );
       for (let p of paths) {
-        const path = matchedStar ? p.replace('*', matchedStar) : p;
+        let path = matchedStar ? p.replace('*', matchedStar) : p;
+        if (startsWithConfigDirTemplate(path)) {
+          path = this.substituteConfigDirTemplate(path, filePath);
+        }
         const maybeResolvedProject = this.findProjectOfResolvedModule(path);
         if (maybeResolvedProject) {
           return maybeResolvedProject;
@@ -505,6 +515,30 @@ export class TargetProjectLocator {
       normalizedResolvedModule
     );
     return importedProject ? importedProject.name : void 0;
+  }
+
+  /**
+   * Expand a `${configDir}` path mapping the same way TypeScript does. The
+   * template resolves to the directory of the tsconfig used for compilation,
+   * which for the importing file is its own project, so a configDir alias always
+   * points back into the source project (matching what `tsc` resolves).
+   */
+  private substituteConfigDirTemplate(value: string, filePath: string): string {
+    const sourceFilePath = isAbsolute(filePath)
+      ? relative(workspaceRoot, filePath)
+      : filePath;
+    const sourceProjectName = findProjectForPath(
+      sourceFilePath,
+      this.projectRootMappings
+    );
+    const sourceProjectRoot = this.nodes[sourceProjectName]?.data.root ?? '.';
+
+    // tsc replaces the template with './' and normalizes against the config dir;
+    // here the config dir is the source project root (workspace-relative).
+    return posix.join(
+      sourceProjectRoot,
+      value.replace(configDirTemplate, './')
+    );
   }
 
   private getAbsolutePath(path: string) {


### PR DESCRIPTION
## Current Behavior

TypeScript's `${configDir}` template (TS 5.5+) lets a tsconfig `paths` alias point at the project currently being compiled, e.g.:

```json
"paths": { "@/*": ["${configDir}/src/app/*"] }
```

Nx's project-graph resolver read these mappings verbatim and never substituted the template. The literal `${configDir}/...` path matched no project, so resolution fell back to whatever project sits at the workspace root. With `@nx/enforce-module-boundaries` this surfaced as false `Imports of apps are forbidden` errors when an app imported its own files through a configDir alias. Switching the same import to a relative path made the error disappear.

## Expected Behavior

A `${configDir}` path alias resolves to the importing file's own project, matching how `tsc` resolves it, so importing a project's own sources through the alias no longer triggers module-boundary violations.

## Related Issue(s)

Fixes #35804

## Implementation Details

`TargetProjectLocator` (used by both the project graph and `enforce-module-boundaries`) now expands `${configDir}` in matched `paths` values before resolving, mirroring TypeScript's `commandLineParser` behavior: the template is matched case-insensitively and only as a prefix, then resolved against the importing file's project root (the directory of the tsconfig used for compilation). Only values that start with `${configDir}` change; all other aliases are untouched. Added a regression test in `target-project-locator.spec.ts` covering nested, deeply nested, and root-project importers.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/gh-35804-acb06b50)
<!-- polygraph-session-end -->