### PR TITLE
fix(core): exclude direct-dependency overrides from generated package.json

### DIFF
--- a/packages/nx/src/plugins/js/package-json/create-package-json.spec.ts
+++ b/packages/nx/src/plugins/js/package-json/create-package-json.spec.ts
@@ -1021,6 +1021,96 @@ describe('createPackageJson', () => {
       });
     });
 
+    it('should drop npm overrides that target a direct dependency', () => {
+      spies.push(
+        jest
+          .spyOn(fs, 'existsSync')
+          .mockImplementation(
+            (path) =>
+              path === 'libs/lib1/package.json' || path === 'package.json'
+          )
+      );
+      spies.push(
+        jest
+          .spyOn(fileutilsModule, 'readJsonFile')
+          .mockImplementation((path) => {
+            if (path === 'package.json') {
+              return {
+                ...rootPackageJson(),
+                overrides: {
+                  // `typescript` is a direct dependency of the generated
+                  // package.json - npm would reject this with EOVERRIDE.
+                  typescript: '5.0.0',
+                  // transitive-only override - must be carried through.
+                  foo: '1.0.0',
+                },
+              };
+            }
+            if (path === 'libs/lib1/package.json') {
+              return projectPackageJson();
+            }
+          })
+      );
+
+      expect(
+        createPackageJson('lib1', graph, {
+          root: '',
+        })
+      ).toEqual({
+        dependencies: {
+          random: '1.0.0',
+          typescript: '^4.8.4',
+        },
+        name: 'other-name',
+        version: '1.2.3',
+        overrides: {
+          foo: '1.0.0',
+        },
+      });
+    });
+
+    it('should omit npm overrides when every entry targets a direct dependency', () => {
+      spies.push(
+        jest
+          .spyOn(fs, 'existsSync')
+          .mockImplementation(
+            (path) =>
+              path === 'libs/lib1/package.json' || path === 'package.json'
+          )
+      );
+      spies.push(
+        jest
+          .spyOn(fileutilsModule, 'readJsonFile')
+          .mockImplementation((path) => {
+            if (path === 'package.json') {
+              return {
+                ...rootPackageJson(),
+                overrides: {
+                  typescript: '5.0.0',
+                  random: '2.0.0',
+                },
+              };
+            }
+            if (path === 'libs/lib1/package.json') {
+              return projectPackageJson();
+            }
+          })
+      );
+
+      const result = createPackageJson('lib1', graph, {
+        root: '',
+      });
+      expect(result).toEqual({
+        dependencies: {
+          random: '1.0.0',
+          typescript: '^4.8.4',
+        },
+        name: 'other-name',
+        version: '1.2.3',
+      });
+      expect(result).not.toHaveProperty('overrides');
+    });
+
     it('should add resolutions (yarn)', () => {
       spies.push(
         jest

--- a/packages/nx/src/plugins/js/package-json/create-package-json.ts
+++ b/packages/nx/src/plugins/js/package-json/create-package-json.ts
@@ -225,10 +225,32 @@ export function createPackageJson(
 
   // npm
   if (rootPackageJson.overrides && !options.skipOverrides) {
-    packageJson.overrides = {
+    // npm throws EOVERRIDE when an override key is also a direct dependency
+    // (unless specs match). The pruned dist pins exact versions and already
+    // resolved everything via the lockfile, so drop those redundant overrides.
+    const mergedOverrides = {
       ...rootPackageJson.overrides,
       ...packageJson.overrides,
     };
+    const overrides: typeof mergedOverrides = {};
+    let hasOverrides = false;
+    for (const name in mergedOverrides) {
+      if (
+        packageJson.dependencies?.[name] ||
+        packageJson.devDependencies?.[name] ||
+        packageJson.peerDependencies?.[name] ||
+        packageJson.optionalDependencies?.[name]
+      ) {
+        continue;
+      }
+      overrides[name] = mergedOverrides[name];
+      hasOverrides = true;
+    }
+    if (hasOverrides) {
+      packageJson.overrides = overrides;
+    } else {
+      delete packageJson.overrides;
+    }
   }
 
   // pnpm


### PR DESCRIPTION
## Current Behavior

`NxAppWebpackPlugin` with `generatePackageJson: true` copies the root `package.json` `overrides` block verbatim into the generated `dist/<app>/package.json` and the pruned `package-lock.json`. When a root override targets a package that is also a direct dependency of the app, the dist pins that dependency to an exact version while the override carries the root range, so npm rejects the artifacts with `EOVERRIDE` on `npm install` (and a misleading `EUSAGE` on `npm ci`).

## Expected Behavior

`createPackageJson` now drops any npm override whose key is also a direct dependency (across `dependencies`, `devDependencies`, `peerDependencies`, and `optionalDependencies`) of the generated package.json. Those overrides are redundant in the dist: the pruned lockfile has already resolved every version. Transitive-only overrides are still carried through, and the pruned npm lockfile inherits the filtered set, so both artifacts install cleanly.

The fix lives in `createPackageJson`, so every `generatePackageJson` consumer benefits (webpack, rspack, vite, next, remix, and the tsc executor). pnpm `overrides` and yarn `resolutions` are left untouched, since neither enforces this direct-dependency conflict.

## Related Issue(s)

Fixes #35675

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/gh-35675-6c6851b5)
<!-- polygraph-session-end -->