### PR TITLE
fix(vitest): apply mode-based config consistently in the test executor

### DIFF
--- a/packages/vitest/src/executors/test/lib/utils.spec.ts
+++ b/packages/vitest/src/executors/test/lib/utils.spec.ts
@@ -1,6 +1,104 @@
-import { workspaceRoot } from '@nx/devkit';
+import { ExecutorContext, workspaceRoot } from '@nx/devkit';
 import { isAbsolute, join } from 'path';
-import { resolveReportsDirectory } from './utils';
+import { getOptions, resolveReportsDirectory } from './utils';
+import { normalizeViteConfigFilePath } from '../../../utils/options-utils';
+import {
+  loadViteDynamicImport,
+  loadVitestDynamicImport,
+} from '../../../utils/executor-utils';
+
+jest.mock('../../../utils/options-utils', () => ({
+  normalizeViteConfigFilePath: jest.fn(),
+}));
+jest.mock('../../../utils/executor-utils', () => ({
+  loadViteDynamicImport: jest.fn(),
+  loadVitestDynamicImport: jest.fn(),
+}));
+
+describe('getOptions', () => {
+  const context = {
+    root: '/root',
+    cwd: '/root',
+    projectName: 'my-lib',
+  } as unknown as ExecutorContext;
+  let loadConfigFromFile: jest.Mock;
+
+  beforeEach(() => {
+    (normalizeViteConfigFilePath as jest.Mock).mockReturnValue(
+      '/root/libs/my-lib/vitest.config.ts'
+    );
+    loadConfigFromFile = jest.fn(async () => ({
+      path: '/root/libs/my-lib/vitest.config.ts',
+      config: { test: { reporters: ['default'] } },
+    }));
+    (loadViteDynamicImport as jest.Mock).mockResolvedValue({
+      loadConfigFromFile,
+    });
+    (loadVitestDynamicImport as jest.Mock).mockResolvedValue({
+      parseCLI: jest.fn(() => ({ filter: [], options: {} })),
+    });
+  });
+
+  afterEach(() => jest.clearAllMocks());
+
+  it('should forward the configured mode so vitest reloads the config with it', async () => {
+    const result = await getOptions(
+      { configFile: 'vitest.config.ts', mode: 'ci' },
+      context,
+      'libs/my-lib'
+    );
+
+    // pre-load and the mode handed to vitest must match, otherwise mode-based
+    // config branches resolve inconsistently between the two loads.
+    expect(loadConfigFromFile).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: 'ci' }),
+      '/root/libs/my-lib/vitest.config.ts'
+    );
+    expect(result.mode).toBe('ci');
+  });
+
+  it('should default the forwarded mode to "test" when none is provided', async () => {
+    const result = await getOptions(
+      { configFile: 'vitest.config.ts' },
+      context,
+      'libs/my-lib'
+    );
+
+    expect(loadConfigFromFile).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: 'test' }),
+      '/root/libs/my-lib/vitest.config.ts'
+    );
+    expect(result.mode).toBe('test');
+  });
+
+  it('should default the mode to runMode so benchmark config branches still apply', async () => {
+    const result = await getOptions(
+      { configFile: 'vitest.config.ts', runMode: 'benchmark' },
+      context,
+      'libs/my-lib'
+    );
+
+    expect(loadConfigFromFile).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: 'benchmark' }),
+      '/root/libs/my-lib/vitest.config.ts'
+    );
+    expect(result.mode).toBe('benchmark');
+  });
+
+  it('should let an explicit mode take precedence over runMode', async () => {
+    const result = await getOptions(
+      { configFile: 'vitest.config.ts', mode: 'ci', runMode: 'benchmark' },
+      context,
+      'libs/my-lib'
+    );
+
+    expect(loadConfigFromFile).toHaveBeenCalledWith(
+      expect.objectContaining({ mode: 'ci' }),
+      '/root/libs/my-lib/vitest.config.ts'
+    );
+    expect(result.mode).toBe('ci');
+  });
+});
 
 describe('resolveReportsDirectory', () => {
   it('should resolve a workspace-root-relative path to absolute', () => {

--- a/packages/vitest/src/executors/test/lib/utils.ts
+++ b/packages/vitest/src/executors/test/lib/utils.ts
@@ -39,9 +39,15 @@ export async function getOptions(
     );
   }
 
+  // Vitest derives the Vite config mode as `options.mode || runMode`, where
+  // runMode defaults to 'test' (or 'benchmark'). Resolve it once and reuse it
+  // for both this pre-load and the value forwarded to vitest below, so the
+  // config file resolves its mode-based branches identically on both loads.
+  const mode = options.mode ?? options.runMode ?? 'test';
+
   const resolved = await loadConfigFromFile(
     {
-      mode: options?.mode ?? 'test',
+      mode,
       command: 'serve',
     },
     viteConfigPath
@@ -98,6 +104,10 @@ export async function getOptions(
     // but leaving it here in case someone did not migrate correctly
     root: resolved?.config?.root ?? root,
     config: viteConfigPath,
+    // Forward the resolved mode so vitest reloads the config file with it;
+    // otherwise it falls back to its run-mode default and drops mode-based
+    // settings the pre-load above resolved (e.g. outputFile, coverage.reporter).
+    mode,
     // Vitest's resolveConfig processes reporters in two steps:
     // 1. options.reporters (plural) sets resolved.reporters
     // 2. resolved.reporter (singular, from config) overwrites resolved.reporters


### PR DESCRIPTION
## Current Behavior

When a `@nx/vitest:test` target sets a `mode` (for example a `ci` configuration whose `vitest.config.ts` branches on `({ mode }) => ...`), only some mode-based settings were applied at runtime. `test.reporters` changed as expected, but `test.outputFile` and `test.coverage.reporter` fell back to their non-`ci` values, so JUnit output could be written to stdout instead of the configured file and coverage used the default reporters.

The executor loaded the config once with the configured mode to read the reporters, then let Vitest reload the config without forwarding that mode. Vitest then resolved every other mode-based branch with its default run mode (`test`), so only the explicitly forwarded `reporters` honored the configured mode.

## Expected Behavior

All mode-derived Vitest config (reporters, outputFile, coverage.reporter, and any other mode-based branch) is applied consistently. The executor resolves the mode once (an explicit `mode`, otherwise `runMode`, otherwise `test`) and forwards it to Vitest so both config loads resolve their mode-based branches identically. This mirrors Vitest's own default where the config mode falls back to the run mode, so `benchmark` targets keep loading their config with mode `benchmark`.

## Related Issue(s)

Fixes #35196

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/gh-35196-928adbb7)
<!-- polygraph-session-end -->