### PR TITLE
fix(js): prevent Windows TS6059 rootDir errors in buildable library builds

### DIFF
--- a/packages/js/src/utils/buildable-libs-utils.spec.ts
+++ b/packages/js/src/utils/buildable-libs-utils.spec.ts
@@ -8,7 +8,7 @@ import {
   DependentBuildableProjectNode,
   updatePaths,
 } from './buildable-libs-utils';
-import { join } from 'path';
+import { dirname, isAbsolute, join, resolve } from 'path';
 
 describe('updatePaths', () => {
   const deps: DependentBuildableProjectNode[] = [
@@ -863,5 +863,59 @@ describe('createTmpTsConfig', () => {
     expect(JSON.parse(tmpTsConfig).extends).toBe(
       '../../../../packages/foo/tsconfig.json'
     );
+  });
+
+  it('should rewrite path mappings relative to the generated tsconfig instead of absolute', () => {
+    const fs = new TempFs('buildable-libs-utils#createTmpTsConfig');
+    // Cover both a relative path value and an already-absolute one (the latter
+    // exercises the isAbsolute branch in readTsConfigWithRemappedPaths).
+    const absoluteValue = join(fs.tempDir, 'external/src/index.ts');
+    fs.createFileSync(
+      'tsconfig.base.json',
+      JSON.stringify({
+        compilerOptions: {
+          paths: {
+            '@proj/foo': ['./packages/foo/src/index.ts'],
+            '@proj/foo/sub': ['./packages/foo/sub/src/index.ts'],
+            '@proj/abs': [absoluteValue],
+          },
+        },
+      })
+    );
+    fs.createFileSync(
+      'packages/foo/tsconfig.json',
+      JSON.stringify({ extends: '../../tsconfig.base.json' })
+    );
+
+    const tmpTsConfigPath = createTmpTsConfig(
+      'packages/foo/tsconfig.json',
+      fs.tempDir,
+      'packages/foo',
+      []
+    );
+
+    const { paths } = JSON.parse(
+      readFileSync(tmpTsConfigPath, 'utf8')
+    ).compilerOptions;
+    const tmpDir = dirname(tmpTsConfigPath);
+
+    // Path values must be relative (drive-agnostic), never absolute. Absolute
+    // values keep the Windows drive letter while Nx strips it from rootDir,
+    // putting resolved files outside rootDir (TS6059).
+    for (const values of Object.values<string[]>(paths)) {
+      for (const value of values) {
+        expect(isAbsolute(value)).toBe(false);
+        expect(value.startsWith('.')).toBe(true);
+      }
+    }
+    // ...and must still resolve to the real targets from the tmp location,
+    // for both relative and absolute inputs.
+    expect(resolve(tmpDir, paths['@proj/foo'][0])).toBe(
+      join(fs.tempDir, 'packages/foo/src/index.ts')
+    );
+    expect(resolve(tmpDir, paths['@proj/foo/sub'][0])).toBe(
+      join(fs.tempDir, 'packages/foo/sub/src/index.ts')
+    );
+    expect(resolve(tmpDir, paths['@proj/abs'][0])).toBe(absoluteValue);
   });
 });

--- a/packages/js/src/utils/buildable-libs-utils.ts
+++ b/packages/js/src/utils/buildable-libs-utils.ts
@@ -214,16 +214,25 @@ function readTsConfigWithRemappedPaths(
     normalizedTsConfig
   );
   const paths = computeCompilerOptionsPaths(normalizedTsConfig, dependencies);
-  // Resolve paths to absolute so they work regardless of the tmp tsconfig
-  // location and without needing baseUrl (deprecated in TS 6, removed in TS 7).
+  // Rewrite every path relative to the generated tsconfig's directory so it
+  // resolves without baseUrl (deprecated in TS 6, removed in TS 7) regardless
+  // of where the tmp tsconfig lives. Absolute paths break tsc builds on
+  // Windows: Nx normalizes rootDir via joinPathFragments, which strips the
+  // drive letter, so an absolute drive-full mapping resolves files outside
+  // rootDir (TS6059). Relative values are drive-agnostic and TS resolves them
+  // in the consuming compilation's own path spelling.
   const pathsBase = resolvePathsBaseUrl(normalizedTsConfig);
   for (const key of Object.keys(paths)) {
     paths[key] = paths[key].map((p) => {
-      if (isAbsolute(p)) {
-        return p;
+      const absolute = isAbsolute(p) ? p : resolve(pathsBase, p);
+      const rel = relative(normalizedGeneratedTsConfigDir, absolute);
+      // A path on a different Windows drive can't be expressed relatively;
+      // relative() returns an absolute path in that case, so keep it as-is.
+      if (isAbsolute(rel)) {
+        return rel.replace(/\\/g, '/');
       }
-      const stripped = p.startsWith('./') ? p.slice(2) : p;
-      return resolve(pathsBase, stripped).replace(/\\/g, '/');
+      const normalized = rel.replace(/\\/g, '/');
+      return normalized.startsWith('.') ? normalized : `./${normalized}`;
     });
   }
   generatedTsConfig.compilerOptions.paths = paths;


### PR DESCRIPTION
## Current Behavior

Since 22.7.0-beta.13, building a buildable library on Windows fails with `error TS6059: File '...' is not under 'rootDir' '...'` whenever a source file is reached through a workspace path alias (for example, a barrel file that re-exports a sibling entry point). The offending file is reported with its drive letter (`C:/...`) while `rootDir` is reported without one (`/...`), so TypeScript treats the file as outside `rootDir`. The same projects build fine on macOS and Linux. This affects `@nx/js:tsc` and the Angular/ng-packagr executors, which share the same generated-tsconfig setup.

## Expected Behavior

Buildable libraries build on Windows without TS6059 errors, whether their sources are imported via relative paths or workspace path aliases.

## Implementation Details

On Windows the tsc compilation runs in a drive-less path space: Nx normalizes `rootDir` and the tsconfig path through `joinPathFragments`, which strips the drive letter. Since 22.7.0-beta.13 the generated temporary tsconfig wrote its `paths` as absolute values, which keep the drive letter. TypeScript uses absolute path-mapping values verbatim, so a file resolved through an alias entered the program drive-full and fell outside the drive-less `rootDir`.

`readTsConfigWithRemappedPaths` now writes each path mapping relative to the generated tsconfig's directory. Relative values carry no drive letter, and TypeScript resolves them against the config in the consuming compilation's own path spelling, so they match `rootDir`. This preserves the original goal of not requiring `baseUrl`. A guard keeps a value absolute only when it cannot be expressed relatively (a path on a different Windows drive).

> [!NOTE]
> The bug is Windows-only. The fix was reproduced and verified with a `path.win32` simulation of the full resolution chain and a symlink-based `tsc` reproduction, alongside a new unit test; a Windows CI run is the final confirmation.

## Related Issue(s)

Fixes #35696

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/gh-35696-0e57c35b)
<!-- polygraph-session-end -->