### PR TITLE
fix(core): do not write minimumReleaseAgeExclude during nx migrate

### DIFF
--- a/packages/nx/src/command-line/migrate/resolve-package-version.spec.ts
+++ b/packages/nx/src/command-line/migrate/resolve-package-version.spec.ts
@@ -268,10 +268,10 @@ describe('resolvePackageVersionRespectingMinReleaseAge', () => {
     log.mockRestore();
   });
 
-  it('pnpm loose immature pick writes an exclude + heads-up when the PM writes excludes', async () => {
-    jest
-      .spyOn(require('../../utils/output').output, 'log')
-      .mockImplementation(() => {});
+  it('pnpm loose immature pick returns the version without writing an exclude (the real install writes it)', async () => {
+    // migrate does not replace the install, so the subsequent `pnpm install`
+    // (>=11.1.3) auto-writes the minimumReleaseAgeExclude entry itself. nx
+    // writing it here would be redundant and risks diverging from pnpm's pick.
     mockReadPolicy.mockResolvedValue(pnpmPolicy({ writesExcludes: true }));
     mockResolve.mockResolvedValue({
       version: '1.0.1',
@@ -279,51 +279,12 @@ describe('resolvePackageVersionRespectingMinReleaseAge', () => {
       immature: true,
     });
 
-    const result = await resolvePackageVersionRespectingMinReleaseAge(
-      'pkg-b',
-      '^1.0.0'
-    );
-    expect(result).toBe('1.0.1');
-    expect(mockWriteExcludes).toHaveBeenCalledWith(expect.any(String), [
-      'pkg-b@1.0.1',
-    ]);
-  });
-
-  it('pnpm loose immature pick on a version that does not write excludes installs silently', async () => {
-    mockReadPolicy.mockResolvedValue(pnpmPolicy({ writesExcludes: false }));
-    mockResolve.mockResolvedValue({
-      version: '1.0.1',
-      unconstrained: '1.0.1',
-      immature: true,
-    });
     const result = await resolvePackageVersionRespectingMinReleaseAge(
       'pkg-b',
       '^1.0.0'
     );
     expect(result).toBe('1.0.1');
     expect(mockWriteExcludes).not.toHaveBeenCalled();
-  });
-
-  it('does not repeat the heads-up when the exclude was already present', async () => {
-    const log = jest
-      .spyOn(require('../../utils/output').output, 'log')
-      .mockImplementation(() => {});
-    mockReadPolicy.mockResolvedValue(pnpmPolicy({ writesExcludes: true }));
-    mockResolve.mockResolvedValue({
-      version: '1.0.1',
-      unconstrained: '1.0.1',
-      immature: true,
-    });
-    // Writer reports nothing newly added (entry already present).
-    mockWriteExcludes.mockReturnValue([]);
-
-    await resolvePackageVersionRespectingMinReleaseAge('pkg-b', '^1.0.0');
-
-    const addedLogs = log.mock.calls.filter((c) =>
-      c[0].title.includes('Added pkg-b')
-    );
-    expect(addedLogs).toHaveLength(0);
-    log.mockRestore();
   });
 
   it('rethrows a violation when the policy is not pnpm strict + writesExcludes', async () => {

--- a/packages/nx/src/command-line/migrate/resolve-package-version.ts
+++ b/packages/nx/src/command-line/migrate/resolve-package-version.ts
@@ -189,10 +189,9 @@ async function resolveWithPolicy(
       );
     }
 
-    if (outcome.immature && applySideEffects) {
-      handleImmaturePick(packageName, outcome.version, policy);
-    }
-
+    // An immature loose pick is returned as-is. nx does not write the
+    // minimumReleaseAgeExclude entry here: migrate does not replace the install,
+    // so the real `pnpm install` (>=11.1.3) auto-writes it itself.
     return outcome.version;
   } catch (e) {
     // A side-effect-free probe never installs/prompts/writes, so any failure -
@@ -227,37 +226,6 @@ function reportChangedOutcome(
   reportedChangedOutcomes.add(key);
   output.log({
     title: `Resolved ${packageName}@${picked} instead of ${unconstrained}: ${policy.sourceDescription}.`,
-  });
-}
-
-// pnpm v11 loose installs an immature version; >=11.1.3 also records it as an
-// exclude in pnpm-workspace.yaml. Mirror that so a later real install agrees.
-function handleImmaturePick(
-  packageName: string,
-  version: string,
-  policy: MinReleaseAgePolicy
-): void {
-  if (
-    policy.behavior.packageManager !== 'pnpm' ||
-    !policy.behavior.writesExcludes
-  ) {
-    return;
-  }
-
-  const added = appendMinimumReleaseAgeExcludes(workspaceRoot, [
-    `${packageName}@${version}`,
-  ]);
-  // Already present (e.g. a prior pick or a pre-existing entry): nothing written,
-  // so do not claim we added it.
-  if (added.length === 0) {
-    return;
-  }
-
-  output.log({
-    title: `Added ${packageName}@${version} to minimumReleaseAgeExclude in pnpm-workspace.yaml.`,
-    bodyLines: [
-      `It is within the ${policy.sourceDescription} window; this mirrors what pnpm would write at install time.`,
-    ],
   });
 }
 


### PR DESCRIPTION
## Current Behavior

When resolving package versions during `nx migrate`, Nx reads the package manager's minimum-release-age (cooldown) policy so its registry-based resolution matches what the package manager would install.

On **pnpm `>=11.1.3`** in **loose mode** — which includes pnpm's built-in 1-day default that is active even with no user configuration — an immature pick caused Nx to eagerly write the resolved `name@version` into `minimumReleaseAgeExclude` in `pnpm-workspace.yaml` during the resolution step (and log that it had done so). This surprised users whose `pnpm-workspace.yaml` was modified by `nx migrate` even though they had never configured a cooldown.

## Expected Behavior

`nx migrate` no longer writes `minimumReleaseAgeExclude` entries to `pnpm-workspace.yaml` during version resolution.

`nx migrate` resolves versions but does **not** replace the install — the real `pnpm install` still runs afterward. On pnpm `>=11.1.3` in loose mode, pnpm itself auto-writes the exclude at install time, so Nx's eager write was redundant and risked diverging from pnpm's actual pick (Nx resolves off the registry; pnpm may resolve a different version at install time).

Resolution now returns the immature version without touching `pnpm-workspace.yaml`, letting the package manager own that write at the correct layer. The strict-mode approval prompt (`handleViolation`) is unchanged: when a user has explicitly enabled a cooldown that blocks the install, Nx still prompts before writing the exclude.

## Related Issue(s)

<!-- Reported internally; add "Fixes #<issue>" here if there is a tracking issue. -->
