### PR TITLE
fix(nx-dev): keep mobile sidebar toggle clear of the conference banner

### DIFF
--- a/astro-docs/src/components/layout/PageFrame.astro
+++ b/astro-docs/src/components/layout/PageFrame.astro
@@ -176,6 +176,15 @@ const bannerId = bannerConfig ? `${bannerConfig.title}-${bannerConfig.activeUnti
       top: calc(var(--sl-nav-height) + var(--conf-banner-h));
     }
 
+    /* The fixed mobile menu (hamburger) toggle is positioned from the viewport
+       top, so it hides under the conf banner unless we clear it too. */
+    .page.has-conf-banner :global(starlight-menu-button button) {
+      top: calc(
+        (var(--sl-nav-height) - var(--sl-menu-button-size)) / 2 +
+          var(--conf-banner-h)
+      );
+    }
+
     @media (min-width: 50rem) {
       :global([data-has-sidebar]) .header {
         padding-inline-end: var(--sl-nav-pad-x);


### PR DESCRIPTION
## Current Behavior

On mobile, the conference banner offsets the header, sidebar pane, and mobile "On this page" bar down by its height, but the fixed `starlight-menu-button` (hamburger) toggle is not offset. It stays anchored near the viewport top, underneath the banner strip - rendered but unclickable. With no working toggle, the entire mobile sidebar (including the Reference section) is unreachable.

## Expected Behavior

The mobile menu toggle is offset down by `--conf-banner-h` when the banner is active, so the hamburger sits in the header and opens the full tabbed sidebar (Getting Started / Technologies / Knowledge Base / Reference). The rule is scoped to `.page.has-conf-banner`, so it is a no-op once the banner expires.

Verified on live nx.dev at mobile width: toggle moves into the header, becomes the topmost clickable element, and opens the full sidebar.

## Screenshots

<img width="965" height="1521" alt="Screenshot 2026-06-18 at 2 51 44 PM" src="https://github.com/user-attachments/assets/7ad75414-f2ca-4706-baaf-6c21019b672f" />

<img width="965" height="1521" alt="Screenshot 2026-06-18 at 2 51 45 PM" src="https://github.com/user-attachments/assets/5e78d0bb-d406-4e54-91b3-56ee15a2a04f" />

<img width="965" height="1521" alt="Screenshot 2026-06-18 at 2 51 36 PM" src="https://github.com/user-attachments/assets/e878dbbd-f9a0-4dcd-b23e-a8b72d97c80c" />

<img width="965" height="1521" alt="Screenshot 2026-06-18 at 2 51 38 PM" src="https://github.com/user-attachments/assets/5c7555d0-2f44-41e3-9540-276e0f23ac36" />


## Related Issue(s)

Fixes DOC-536

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/docs-sidebar-mobile-5d199be9)
<!-- polygraph-session-end -->