### PR TITLE
fix(core): run the nx.bat wrapper for dot-nx setup on windows

### DIFF
--- a/packages/nx/src/command-line/init/implementation/dot-nx/add-nx-scripts.spec.ts
+++ b/packages/nx/src/command-line/init/implementation/dot-nx/add-nx-scripts.spec.ts
@@ -1,4 +1,18 @@
-import { sanitizeWrapperScript } from './add-nx-scripts';
+import {
+  getDotNxWrapperVersionCommand,
+  sanitizeWrapperScript,
+} from './add-nx-scripts';
+
+describe('getDotNxWrapperVersionCommand', () => {
+  it('should invoke the nx.bat wrapper on Windows', () => {
+    expect(getDotNxWrapperVersionCommand('win32')).toBe('.\\nx.bat --version');
+  });
+
+  it('should invoke the ./nx wrapper on non-Windows platforms', () => {
+    expect(getDotNxWrapperVersionCommand('linux')).toBe('./nx --version');
+    expect(getDotNxWrapperVersionCommand('darwin')).toBe('./nx --version');
+  });
+});
 
 describe('sanitizeWrapperScript', () => {
   it('should remove any comments starting with //#', () => {

--- a/packages/nx/src/command-line/init/implementation/dot-nx/add-nx-scripts.ts
+++ b/packages/nx/src/command-line/init/implementation/dot-nx/add-nx-scripts.ts
@@ -51,6 +51,13 @@ const SHELL_SCRIPT_CONTENTS = [
   `node ${path.posix.join('$path_to_root', nxWrapperPath(path.posix))} "$@"`,
 ].join('\n');
 
+// cmd.exe can't run the bash './nx' wrapper; use the generated nx.bat on Windows.
+export function getDotNxWrapperVersionCommand(
+  platform: NodeJS.Platform = process.platform
+): string {
+  return platform === 'win32' ? '.\\nx.bat --version' : './nx --version';
+}
+
 export function generateDotNxSetup(version?: string) {
   const host = new FsTree(process.cwd(), false, '.nx setup');
   writeMinimalNxJson(host, version);
@@ -67,7 +74,7 @@ export function generateDotNxSetup(version?: string) {
   // This is needed when using a global nx with dot-nx, otherwise running any nx command using global command will fail due to missing modules.
   // Pipe stderr so failures surface in telemetry instead of bare "Command failed: ./nx --version".
   try {
-    execSync('./nx --version', {
+    execSync(getDotNxWrapperVersionCommand(), {
       stdio: ['ignore', 'ignore', 'pipe'],
       encoding: 'utf8',
       windowsHide: true,


### PR DESCRIPTION
## Current Behavior

nx init's global-nx (dot-nx) setup verifies the wrapper with `execSync('./nx --version')`. On Windows cmd.exe cannot run `./nx` ("'.' is not recognized"), so dot-nx setup fails.

## Expected Behavior

On Windows the verification runs the generated `nx.bat` wrapper instead, selected by platform.

## Related Issue(s)

NXC-4571