### PR TITLE
feat(core): nx tips

### DIFF
--- a/packages/nx/src/command-line/nx-commands.ts
+++ b/packages/nx/src/command-line/nx-commands.ts
@@ -58,6 +58,7 @@ import { yargsSyncCheckCommand, yargsSyncCommand } from './sync/command-object';
 import { yargsWatchCommand } from './watch/command-object';
 import { yargsCompletionCommand } from './completion/command-object';
 import { isCompletionRequest } from './completion/trigger';
+import { yargsTipsCommand } from './tips/command-object';
 
 // Ensure that the output takes up the available width of the terminal.
 yargs.wrap(yargs.terminalWidth());
@@ -123,6 +124,7 @@ export const commandsObject = yargs
   .command(yargsDownloadCloudClientCommand)
   .command(yargsMcpCommand)
   .command(yargsCompletionCommand)
+  .command(yargsTipsCommand)
   .command(resolveConformanceCommandObject())
   .command(resolveConformanceCheckCommandObject())
   .scriptName('nx')

--- a/packages/nx/src/command-line/tips/command-object.ts
+++ b/packages/nx/src/command-line/tips/command-object.ts
@@ -1,0 +1,41 @@
+import { CommandModule } from 'yargs';
+import { handleErrors } from '../../utils/handle-errors';
+import { handleImport } from '../../utils/handle-import';
+import type { TipsSubcommand } from './tips';
+
+const runTipsSubcommand =
+  (sub: TipsSubcommand): CommandModule['handler'] =>
+  async (args) => {
+    const exitCode = await handleErrors(
+      (args.verbose as boolean) ?? false,
+      async () =>
+        (await handleImport('./tips.js', __dirname)).handleTipsCommand(sub)
+    );
+    process.exit(exitCode);
+  };
+
+export const yargsTipsCommand: CommandModule = {
+  command: 'tips',
+  describe: 'Manage Nx tip-of-the-run notifications.',
+  builder: (yargs) =>
+    yargs
+      .usage('$0 tips <subcommand>')
+      .command({
+        command: 'enable',
+        describe: 'Enable post-run tip notifications.',
+        handler: runTipsSubcommand('enable'),
+      })
+      .command({
+        command: 'disable',
+        describe: 'Disable post-run tip notifications.',
+        handler: runTipsSubcommand('disable'),
+      })
+      .command({
+        command: 'show',
+        describe: 'Preview a tip now.',
+        handler: runTipsSubcommand('show'),
+      })
+      .demandCommand(1, 'Specify a subcommand: enable | disable | show'),
+  // Parent command has no handler - subcommand is always required
+  handler: () => {},
+};

--- a/packages/nx/src/command-line/tips/tips.ts
+++ b/packages/nx/src/command-line/tips/tips.ts
@@ -1,0 +1,57 @@
+import * as pc from 'picocolors';
+import { output } from '../../utils/output';
+import {
+  buildTipContext,
+  disableTips,
+  enableTips,
+  formatTip,
+  selectTip,
+} from '../../utils/tips/tips';
+
+export type TipsSubcommand = 'enable' | 'disable' | 'show';
+
+export async function handleTipsCommand(
+  subcommand: TipsSubcommand
+): Promise<number> {
+  switch (subcommand) {
+    case 'enable': {
+      enableTips();
+      output.success({
+        title: 'Nx tips enabled',
+        bodyLines: [
+          'A tip will appear in the run summary footer after successful runs.',
+          pc.dim('Disable at any time with: nx tips disable'),
+        ],
+      });
+      return 0;
+    }
+
+    case 'disable': {
+      disableTips();
+      output.success({
+        title: 'Nx tips disabled',
+        bodyLines: [
+          'No tips will appear in run summaries.',
+          pc.dim('Re-enable at any time with: nx tips enable'),
+        ],
+      });
+      return 0;
+    }
+
+    case 'show': {
+      const ctx = buildTipContext();
+      const tip = selectTip(ctx);
+      if (!tip) {
+        output.warn({ title: 'No tips available for current context.' });
+        return 0;
+      }
+      process.stdout.write(formatTip(tip, ctx));
+      return 0;
+    }
+
+    default: {
+      output.error({ title: `Unknown subcommand: ${subcommand}` });
+      return 1;
+    }
+  }
+}

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -27,6 +27,7 @@ import { createProjectGraphAsync } from '../project-graph/project-graph';
 import { NxArgs } from '../utils/command-line-utils';
 import { handleErrors } from '../utils/handle-errors';
 import { isCI } from '../utils/is-ci';
+import { maybePrintTip } from '../utils/tips/tips';
 import { isNxCloudDisabled, isNxCloudUsed } from '../utils/nx-cloud-utils';
 import { logger } from '../utils/logger';
 import {
@@ -564,6 +565,20 @@ export async function runCommandForTasks(
 
     if (printSummary) {
       printSummary();
+    }
+
+    // Post-run epilogue: one tip after the summary, unless a task failed
+    // (cancelled/continuous runs still show one). Tailored to what just ran.
+    // 'skipped' is treated like a failure here - a task is skipped when an
+    // upstream task failed, so the run did not cleanly succeed.
+    const anyTaskFailedOrSkipped = Object.values(taskResults).some(
+      (r) => r.status === 'failure' || r.status === 'skipped'
+    );
+    if (!anyTaskFailedOrSkipped) {
+      maybePrintTip({
+        runTargets: nxArgs.targets,
+        sampleProject: initiatingProject ?? projectNames[0],
+      });
     }
 
     await printConfigureAiAgentsDisclaimer();

--- a/packages/nx/src/utils/tips/catalog.ts
+++ b/packages/nx/src/utils/tips/catalog.ts
@@ -1,0 +1,86 @@
+import { NX_CLOUD_URL } from '../ab-testing';
+
+/**
+ * Nx Tips catalog - source of truth for the post-run footer tip.
+ *
+ * Each tip is a short muted message + a command (the CTA) the user can run.
+ * Commands are plain strings with {token} placeholders the client fills from
+ * the finished run: {target=<default>} -> first run target (or the default),
+ * {project} -> a real project from the run. Keeping commands as data (no
+ * functions) matches the planned cloud-served tip shape. CLI tips only, plus a
+ * single Cloud CTA (remote cache) shown when not connected.
+ */
+
+export interface TipContext {
+  isCloudConnected: boolean;
+  /** User explicitly opted out of Nx Cloud (NX_NO_CLOUD / neverConnectToCloud) */
+  isCloudOptedOut: boolean;
+  isCI: boolean;
+  isInteractive: boolean;
+  /** Targets in the run that just finished, e.g. ['build']. Fills {target}. */
+  runTargets?: string[];
+  /** A real project from the run. Fills {project}. */
+  sampleProject?: string;
+}
+
+export interface NxTip {
+  /** Kebab-case stable identifier for the tip */
+  id: string;
+  /** Short muted message, < ~70 chars */
+  text: string;
+  /** Command CTA - plain string with optional {target=<default>} / {project} placeholders */
+  command: string;
+  /** Optional docs URL - rendered as a UTM-tracked OSC 8 link (medium=tips) */
+  link?: string;
+  /** Optional relevance gate - tip is skipped when it returns false */
+  appliesWhen?: (ctx: TipContext) => boolean;
+}
+
+export const NX_TIPS: NxTip[] = [
+  // --- CLI tips (every command verified against the nx command registry) ---
+  {
+    id: 'affected',
+    text: 'Rerun only the projects affected by your changes',
+    command: 'nx affected -t {target=test}',
+  },
+  {
+    id: 'run-many',
+    text: 'Run a target across every project at once',
+    command: 'nx run-many -t {target=build}',
+  },
+  {
+    id: 'graph',
+    text: 'Explore your workspace in an interactive project graph',
+    command: 'nx graph',
+  },
+  {
+    id: 'show-project',
+    text: "See a project's targets, tags and dependencies",
+    command: 'nx show project {project}',
+  },
+  {
+    id: 'migrate',
+    text: 'Keep your Nx version up to date',
+    command: 'nx migrate',
+  },
+  {
+    id: 'watch',
+    text: 'Re-run a command whenever your files change',
+    command: 'nx watch --all -- nx run-many -t build',
+  },
+  {
+    id: 'list-plugins',
+    text: 'List installed plugins and their generators',
+    command: 'nx list',
+  },
+
+  // --- Single Cloud CTA (only when not connected) ---
+  {
+    id: 'remote-cache',
+    text: 'Share your task cache across your team and CI',
+    command: 'npx nx connect',
+    link: NX_CLOUD_URL,
+    // Not connected AND hasn't opted out - don't nag users who disabled Cloud.
+    appliesWhen: (ctx) => !ctx.isCloudConnected && !ctx.isCloudOptedOut,
+  },
+];

--- a/packages/nx/src/utils/tips/tips.spec.ts
+++ b/packages/nx/src/utils/tips/tips.spec.ts
@@ -1,0 +1,142 @@
+import { NX_TIPS } from './catalog';
+import {
+  TipsState,
+  applyTipContext,
+  formatTip,
+  selectTip,
+  shouldShowTip,
+} from './tips';
+
+const CONNECTED_CTX = {
+  isCloudConnected: true,
+  isCloudOptedOut: false,
+  isCI: false,
+  isInteractive: true,
+};
+const DISCONNECTED_CTX = { ...CONNECTED_CTX, isCloudConnected: false };
+
+const ENABLED_STATE: TipsState = { disabled: false };
+
+describe('shouldShowTip', () => {
+  it('true when enabled + interactive + not CI', () => {
+    expect(shouldShowTip(CONNECTED_CTX, ENABLED_STATE)).toBe(true);
+  });
+
+  it('false when disabled', () => {
+    expect(shouldShowTip(CONNECTED_CTX, { disabled: true })).toBe(false);
+  });
+
+  it('false in CI', () => {
+    expect(shouldShowTip({ ...CONNECTED_CTX, isCI: true }, ENABLED_STATE)).toBe(
+      false
+    );
+  });
+
+  it('false when non-interactive (no TTY)', () => {
+    expect(
+      shouldShowTip({ ...CONNECTED_CTX, isInteractive: false }, ENABLED_STATE)
+    ).toBe(false);
+  });
+});
+
+describe('selectTip', () => {
+  it('returns a tip', () => {
+    expect(selectTip(CONNECTED_CTX)).toBeDefined();
+  });
+
+  it('never returns connect-only tips when already connected', () => {
+    const connectOnlyIds = NX_TIPS.filter(
+      (t) => t.appliesWhen && !t.appliesWhen(CONNECTED_CTX)
+    ).map((t) => t.id);
+
+    for (let i = 0; i < 50; i++) {
+      expect(connectOnlyIds).not.toContain(selectTip(CONNECTED_CTX)?.id);
+    }
+  });
+
+  it('can return the cloud tip when disconnected', () => {
+    const ids = new Set<string>();
+    for (let i = 0; i < 100; i++) ids.add(selectTip(DISCONNECTED_CTX)!.id);
+    expect(ids.has('remote-cache')).toBe(true);
+  });
+
+  it('never returns the cloud tip when the user opted out', () => {
+    const optedOut = { ...DISCONNECTED_CTX, isCloudOptedOut: true };
+    for (let i = 0; i < 50; i++) {
+      expect(selectTip(optedOut)?.id).not.toBe('remote-cache');
+    }
+  });
+
+  it('never returns a {project} tip without a sampleProject', () => {
+    for (let i = 0; i < 50; i++) {
+      const tip = selectTip(DISCONNECTED_CTX)!;
+      expect(tip.command).not.toContain('{project}');
+    }
+  });
+
+  it('can return a {project} tip once a sampleProject is known', () => {
+    const ctx = { ...CONNECTED_CTX, sampleProject: '@org/api' };
+    const ids = new Set<string>();
+    for (let i = 0; i < 100; i++) ids.add(selectTip(ctx)!.id);
+    expect(ids.has('show-project')).toBe(true);
+  });
+});
+
+describe('applyTipContext', () => {
+  it('fills {target} with the run target', () => {
+    expect(
+      applyTipContext('nx affected -t {target=test}', {
+        ...DISCONNECTED_CTX,
+        runTargets: ['lint'],
+      })
+    ).toBe('nx affected -t lint');
+  });
+
+  it('falls back to the token default when no target ran', () => {
+    expect(
+      applyTipContext('nx affected -t {target=test}', DISCONNECTED_CTX)
+    ).toBe('nx affected -t test');
+    expect(
+      applyTipContext('nx run-many -t {target=build}', DISCONNECTED_CTX)
+    ).toBe('nx run-many -t build');
+  });
+
+  it('fills {project} with a real project from the run', () => {
+    expect(
+      applyTipContext('nx show project {project}', {
+        ...CONNECTED_CTX,
+        sampleProject: '@org/api',
+      })
+    ).toBe('nx show project @org/api');
+  });
+
+  it('leaves commands without placeholders untouched', () => {
+    expect(applyTipContext('npx nx connect', CONNECTED_CTX)).toBe(
+      'npx nx connect'
+    );
+  });
+});
+
+describe('formatTip', () => {
+  it('mutes the message and highlights the command CTA', () => {
+    const tip = NX_TIPS.find((t) => t.id === 'affected')!;
+    const rendered = formatTip(tip, CONNECTED_CTX);
+    expect(rendered).toContain(tip.text);
+    expect(rendered).toContain('nx affected');
+  });
+
+  it('renders the cloud tip docs link with utm attribution (OSC 8)', () => {
+    const prev = process.env.FORCE_HYPERLINK;
+    process.env.FORCE_HYPERLINK = '1'; // force terminalLink to emit the tracked href
+    try {
+      const tip = NX_TIPS.find((t) => t.id === 'remote-cache')!;
+      const rendered = formatTip(tip, DISCONNECTED_CTX);
+      expect(rendered).toContain('npx nx connect');
+      expect(rendered).toContain(
+        'https://nx.dev/nx-cloud?utm_source=nx-cli&utm_medium=tips'
+      );
+    } finally {
+      process.env.FORCE_HYPERLINK = prev;
+    }
+  });
+});

--- a/packages/nx/src/utils/tips/tips.ts
+++ b/packages/nx/src/utils/tips/tips.ts
@@ -1,0 +1,177 @@
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { homedir } from 'node:os';
+import { join } from 'node:path';
+import * as pc from 'picocolors';
+import { readNxJson } from '../../config/nx-json';
+import { isCI } from '../is-ci';
+import { isNxCloudDisabled, isNxCloudUsed } from '../nx-cloud-utils';
+import { terminalLink } from '../terminal-link';
+import { NX_TIPS, NxTip, TipContext } from './catalog';
+
+// ── State ──────────────────────────────────────────────────────────────────
+
+export interface TipsState {
+  disabled: boolean;
+}
+
+const TIPS_FILE_NAME = 'tips.json';
+const EMPTY_STATE: TipsState = { disabled: false };
+
+/**
+ * User-level Nx config dir, matching the Rust get_user_config_dir
+ * (native/config/dir.rs) that backs NxConsolePreferences - so tips state sits
+ * alongside the other user prefs (ide.json), NOT in the workspace cache. This
+ * makes `nx tips disable` survive `nx reset` and stay machine-local (never
+ * committed). Windows: %USERPROFILE%\.nx. Unix: $XDG_CONFIG_HOME/nx or
+ * ~/.config/nx. Keep in sync with native/config/dir.rs.
+ */
+function nxUserConfigDir(): string {
+  if (process.platform === 'win32') {
+    return join(homedir(), '.nx');
+  }
+  const base = process.env.XDG_CONFIG_HOME || join(homedir(), '.config');
+  return join(base, 'nx');
+}
+
+function tipsFilePath(): string {
+  return join(nxUserConfigDir(), TIPS_FILE_NAME);
+}
+
+export function readTipsState(): TipsState {
+  try {
+    return {
+      ...EMPTY_STATE,
+      ...JSON.parse(readFileSync(tipsFilePath(), 'utf-8')),
+    };
+  } catch {
+    return { ...EMPTY_STATE };
+  }
+}
+
+/**
+ * Persist tip state. Throws on failure - the only callers are the explicit
+ * `nx tips enable|disable` commands, where a silent failure would wrongly
+ * report success. The per-run path never writes (and is try/caught anyway).
+ */
+function writeTipsState(state: TipsState): void {
+  const dir = nxUserConfigDir();
+  if (!existsSync(dir)) {
+    mkdirSync(dir, { recursive: true });
+  }
+  writeFileSync(tipsFilePath(), JSON.stringify(state, null, 2), 'utf-8');
+}
+
+// ── Context ──────────────────────────────────────────────────────────────────
+
+/** Run facts used to fill command placeholders. */
+export type TipRunInfo = Pick<TipContext, 'runTargets' | 'sampleProject'>;
+
+export function buildTipContext(opts?: TipRunInfo): TipContext {
+  let isCloudConnected = false;
+  let isCloudOptedOut = false;
+  try {
+    const nxJson = readNxJson();
+    isCloudConnected = isNxCloudUsed(nxJson);
+    isCloudOptedOut = isNxCloudDisabled(nxJson);
+  } catch {
+    // Workspace may not have nx.json - treat as disconnected, not opted out
+  }
+  return {
+    isCloudConnected,
+    isCloudOptedOut,
+    isCI: !!isCI(),
+    isInteractive: !!(process.stdin.isTTY && process.stdout.isTTY),
+    runTargets: opts?.runTargets,
+    sampleProject: opts?.sampleProject,
+  };
+}
+
+// ── Selection ──────────────────────────────────────────────────────────────
+
+/**
+ * True when a tip should print: enabled, interactive TTY, not CI.
+ * Prints on every successful run - there is no cooldown.
+ */
+export function shouldShowTip(ctx: TipContext, state: TipsState): boolean {
+  return !state.disabled && !ctx.isCI && ctx.isInteractive;
+}
+
+/**
+ * Pick a random tip eligible for ctx. Skips tips whose command needs a
+ * {project} we don't have (e.g. `nx tips show` or a zero-project run) so we
+ * never print an unrunnable `nx show project <project>`.
+ */
+export function selectTip(ctx: TipContext): NxTip | undefined {
+  const eligible = NX_TIPS.filter(
+    (t) =>
+      (!t.appliesWhen || t.appliesWhen(ctx)) &&
+      (ctx.sampleProject || !t.command.includes('{project}'))
+  );
+  return eligible.length
+    ? eligible[Math.floor(Math.random() * eligible.length)]
+    : undefined;
+}
+
+// ── Enable / disable ─────────────────────────────────────────────────────────
+
+export function enableTips(): void {
+  writeTipsState({ ...readTipsState(), disabled: false });
+}
+
+export function disableTips(): void {
+  writeTipsState({ ...readTipsState(), disabled: true });
+}
+
+// ── Formatting ───────────────────────────────────────────────────────────────
+
+/**
+ * Fill a command template's placeholders from the run context:
+ *   {target=<default>} -> first run target, else <default>
+ *   {project}          -> a real project from the run, else <project>
+ */
+export function applyTipContext(command: string, ctx?: TipContext): string {
+  return command
+    .replace(
+      /\{target(?:=([^}]*))?\}/g,
+      (_, def) => ctx?.runTargets?.[0] ?? def ?? ''
+    )
+    .replace(/\{project\}/g, ctx?.sampleProject ?? '<project>');
+}
+
+/** Append UTM attribution matching the CNW/init cloud links (see nxCloudHyperlink). */
+function withTipsUtm(url: string): string {
+  const sep = url.includes('?') ? '&' : '?';
+  return `${url}${sep}utm_source=nx-cli&utm_medium=tips`;
+}
+
+/**
+ * One muted line where only the command (the CTA) is highlighted. A tip may
+ * carry a docs `link`, rendered as a UTM-tracked OSC 8 hyperlink (clean URL
+ * visible, tracking on the click; bare URL on terminals without OSC 8).
+ * Example: Tip: Share your task cache across your team and CI · npx nx connect · https://nx.dev/nx-cloud
+ */
+export function formatTip(tip: NxTip, ctx?: TipContext): string {
+  const message = pc.dim(`Tip: ${tip.text}`);
+  const command = pc.cyan(applyTipContext(tip.command, ctx));
+  const link = tip.link
+    ? ` ${pc.dim('·')} ${pc.dim(terminalLink(tip.link, withTipsUtm(tip.link)))}`
+    : '';
+  // Leading: summary already leaves a blank line above, so none here.
+  // Trailing: blank line so the tip stays distinct from any following epilogue
+  // (e.g. the "AI agent configuration is outdated" notice).
+  return `${message} ${pc.dim('·')} ${command}${link}\n\n`;
+}
+
+// ── High-level hook (called from run-command after the summary) ────────────────
+
+export function maybePrintTip(opts?: TipRunInfo): void {
+  try {
+    const ctx = buildTipContext(opts);
+    if (!shouldShowTip(ctx, readTipsState())) return;
+    const tip = selectTip(ctx);
+    if (!tip) return;
+    process.stdout.write(formatTip(tip, ctx));
+  } catch {
+    // Silent - tips are best-effort
+  }
+}


### PR DESCRIPTION
## Current Behavior

No contextual tips after a run.

## Expected Behavior

PoC: prints one runnable tip in the post-run summary footer (interactive, non-CI) - e.g. `Tip: Rerun only the projects affected by your changes · nx affected -t test`. Tips are pure-data command templates filled from the run; 7 CLI tips + 1 Cloud tip (remote cache) with a UTM-tracked link. Adds `nx tips enable|disable|show` (disabled flag stored in the user Nx config dir, survives `nx reset`).


## Screenshots

After running commands:

<img width="889" height="475" alt="image" src="https://github.com/user-attachments/assets/b138b27a-a243-4e6f-84b7-3256e626999b" />

Manual `nx tips show`:

<img width="1002" height="873" alt="image" src="https://github.com/user-attachments/assets/46e9ea66-4fd1-41ca-92fb-f6c1f14d05c1" />

Disable tips (`nx tips disable`), then running tasks no longer shows tips:

<img width="1088" height="705" alt="image" src="https://github.com/user-attachments/assets/5b03fb94-2f94-45d1-b396-39e33624ca01" />


## Related Issue(s)

None

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/cli-tips-3e65f796)
<!-- polygraph-session-end -->