### PR TITLE
fix(release): stop breaking change changelog entry from swallowing trailing PR body

### DIFF
--- a/packages/nx/release/changelog-renderer/index.spec.ts
+++ b/packages/nx/release/changelog-renderer/index.spec.ts
@@ -1011,6 +1011,127 @@ A	packages/nx/src/migrations/update-22-0-0/consolidate-release-tag-config.ts
           - James Henry"
         `);
       });
+
+      it('should stop the breaking change explanation at trailing PR body sections and metadata', async () => {
+        const breakingChangeFollowedByPrBody: ChangelogChange = {
+          shortHash: '192f66811',
+          authors: [{ name: 'Test User', email: 'test@example.com' }],
+          body: `## Current behavior
+
+Angular v22 is not supported.
+
+## Expected behavior
+
+Angular v22 should be supported.
+
+BREAKING CHANGE: Angular v19 is no longer supported.
+
+## Related issues
+
+Fixes #35910
+
+<!-- polygraph-session-start -->
+---
+[View session information ↗](https://app.trypolygraph.com/orgs/example/sessions/angular-v22)
+<!-- polygraph-session-end -->
+
+---------
+
+Co-authored-by: nx-cloud[bot] <71083854+nx-cloud[bot]@users.noreply.github.com>"
+
+M	packages/angular/src/utils/versions.ts
+"`,
+          description: 'support angular v22',
+          type: 'feat',
+          scope: 'angular',
+          githubReferences: [
+            { type: 'pull-request', value: '#35851' },
+            { value: '192f66811', type: 'hash' },
+          ],
+          isBreaking: true,
+          revertedHashes: [],
+          affectedProjects: ['angular'],
+        };
+
+        const markdown = await new DefaultChangelogRenderer({
+          changes: [breakingChangeFollowedByPrBody],
+          remoteReleaseClient,
+          changelogEntryVersion: 'v1.1.0',
+          project: null,
+          isVersionPlans: false,
+          entryWhenNoChanges: false,
+          changelogRenderOptions: { authors: true, commitReferences: true },
+          conventionalCommitsConfig: DEFAULT_CONVENTIONAL_COMMITS_CONFIG,
+        }).render();
+
+        expect(markdown).toMatchInlineSnapshot(`
+          "## v1.1.0
+
+          ### 🚀 Features
+
+          - ⚠️  **angular:** support angular v22 ([#35851](https://example.com/example/example/pull/35851))
+
+          ### ⚠️  Breaking Changes
+
+          - **angular:** support angular v22  ([#35851](https://example.com/example/example/pull/35851))
+            Angular v19 is no longer supported.
+
+          ### ❤️ Thank You
+
+          - Test User"
+        `);
+      });
+
+      it('should strip HTML comments from the explanation without truncating the text around them', async () => {
+        const breakingChangeWithInlineComment: ChangelogChange = {
+          shortHash: 'def456',
+          authors: [{ name: 'Test User', email: 'test@example.com' }],
+          body:
+            'BREAKING CHANGE: The old API has been removed.\n' +
+            '<!-- internal review note, please ignore -->\n' +
+            'Migrate to the new API instead.\n' +
+            '"\n\nM\tpackages/nx/file.ts\n"',
+          description: 'remove the old API',
+          type: 'feat',
+          scope: 'core',
+          githubReferences: [
+            { type: 'pull-request', value: '#54321' },
+            { value: 'def456', type: 'hash' },
+          ],
+          isBreaking: true,
+          revertedHashes: [],
+          affectedProjects: ['nx'],
+        };
+
+        const markdown = await new DefaultChangelogRenderer({
+          changes: [breakingChangeWithInlineComment],
+          remoteReleaseClient,
+          changelogEntryVersion: 'v1.1.0',
+          project: null,
+          isVersionPlans: false,
+          entryWhenNoChanges: false,
+          changelogRenderOptions: { authors: true, commitReferences: true },
+          conventionalCommitsConfig: DEFAULT_CONVENTIONAL_COMMITS_CONFIG,
+        }).render();
+
+        expect(markdown).toMatchInlineSnapshot(`
+          "## v1.1.0
+
+          ### 🚀 Features
+
+          - ⚠️  **core:** remove the old API ([#54321](https://example.com/example/example/pull/54321))
+
+          ### ⚠️  Breaking Changes
+
+          - **core:** remove the old API  ([#54321](https://example.com/example/example/pull/54321))
+            The old API has been removed.
+            Migrate to the new API instead.
+
+          ### ❤️ Thank You
+
+          - Test User"
+        `);
+      });
     });
 
     describe('dependency bumps', () => {

--- a/packages/nx/release/changelog-renderer/index.ts
+++ b/packages/nx/release/changelog-renderer/index.ts
@@ -8,6 +8,9 @@ import type { RemoteReleaseClient } from '../../src/command-line/release/utils/r
  */
 export type { ChangelogChange };
 
+// Stripped from breaking change explanations (e.g. bot/session markers).
+const HtmlCommentRegex = /<!--[\s\S]*?-->/g;
+
 /**
  * The ChangelogRenderOptions are specific to each ChangelogRenderer implementation, and are taken
  * from the user's nx.json configuration and passed as is into the ChangelogRenderer function.
@@ -502,21 +505,36 @@ export default class DefaultChangelogRenderer {
 
     const startOfBreakingChange = startIndex + breakingChangeIdentifier.length;
 
-    // Extract all text after BREAKING CHANGE: until we hit a Co-authored-by section or git metadata
-    let endOfBreakingChange = message.length;
-
-    const coAuthoredBySection = message.indexOf('---------\n\nCo-authored-by:');
-    if (coAuthoredBySection !== -1) {
-      endOfBreakingChange = coAuthoredBySection;
-    } else {
-      // Look for the git metadata delimiter (a line with just ")
-      const gitMetadataMarker = message.indexOf('"\n', startOfBreakingChange);
-      if (gitMetadataMarker !== -1) {
-        endOfBreakingChange = gitMetadataMarker;
+    // A squash-merged PR body can trail the note with template sections,
+    // trailers, and git metadata. Strip comments (they can appear anywhere),
+    // then keep lines until the first boundary.
+    const lines = message
+      .slice(startOfBreakingChange)
+      .replace(HtmlCommentRegex, '')
+      .split('\n');
+    // The rest of the "BREAKING CHANGE:" line is always kept; scan from the next.
+    const explanationLines: string[] = [lines[0]];
+    for (let i = 1; i < lines.length; i++) {
+      if (this.isBreakingChangeBoundary(lines[i])) {
+        break;
       }
+      explanationLines.push(lines[i]);
     }
 
-    return message.substring(startOfBreakingChange, endOfBreakingChange).trim();
+    return explanationLines.join('\n').trim();
+  }
+
+  private isBreakingChangeBoundary(line: string): boolean {
+    const trimmed = line.trim();
+    return (
+      // Markdown heading (e.g. "## Related issues")
+      /^#{1,6}\s/.test(trimmed) ||
+      // Horizontal rule / separator
+      /^-{3,}$/.test(trimmed) ||
+      /^Co-authored-by:/i.test(trimmed) ||
+      // Git metadata delimiter following the body
+      trimmed === '"'
+    );
   }
 
   protected formatName(name = ''): string {


### PR DESCRIPTION
## Current Behavior

When a commit contains a `BREAKING CHANGE:` footer followed by additional PR-body content (common with squash-merged PR descriptions), the changelog's "⚠️ Breaking Changes" section captured **everything** after `BREAKING CHANGE:` until it reached the `Co-authored-by:` / git-metadata block at the very bottom of the commit. As a result, the breaking-change entry swallowed unrelated content such as the `## Related issues` section, the `Fixes #NNNNN` reference, and `<!-- ... -->` HTML comment markers (e.g. polygraph session blocks).

For example, commit [`192f6681`](https://github.com/nrwl/nx/commit/192f66811d67ebd551504b314c2e9ed9614c16e1) (`feat(angular): support angular v22`) rendered its breaking change as the note **plus** the Related Issues heading, the `Fixes #35910` reference, and the entire polygraph session comment block.

## Expected Behavior

The breaking-change entry contains only the breaking-change note itself. For the example above it now renders just:

> Angular v19 is no longer supported.

`extractBreakingChangeExplanation` now:

- **strips HTML comments** (`<!-- ... -->`, including multi-line) wherever they appear, so a comment in the middle of a note no longer truncates the text around it; and
- **scans line-by-line** from the `BREAKING CHANGE:` line and stops at the first structural boundary: a Markdown heading (e.g. `## Related issues`), a horizontal rule / separator (`---`), a `Co-authored-by:` trailer, or the git-metadata `"` delimiter.

Multi-line and multi-paragraph breaking changes remain fully supported (preserving the behavior from #33070). Two regression tests were added — one reproducing the `192f6681` commit body, and one proving HTML comments are stripped rather than used to truncate — and all 18 changelog-renderer tests pass.

## Related Issue(s)

No tracked issue — reported via internal review of the changelog output for commit `192f6681`.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Nx-changelog-renderer-breaking-changes-parsing-fix-c3d89b8c)
<!-- polygraph-session-end -->