### PR TITLE
fix(nx-dev): run next-sitemap directly instead of via pnpm

### DIFF
--- a/nx-dev/nx-dev/project.json
+++ b/nx-dev/nx-dev/project.json
@@ -28,7 +28,7 @@
         { "env": "NEXT_PUBLIC_NO_INDEX" }
       ],
       "outputs": ["{workspaceRoot}/nx-dev/nx-dev/public/sitemap*.xml"],
-      "command": "pnpm next-sitemap --config ./next-sitemap.config.js && node ./scripts/patch-sitemap-index.mjs",
+      "command": "next-sitemap --config ./next-sitemap.config.js && node ./scripts/patch-sitemap-index.mjs",
       "options": {
         "cwd": "nx-dev/nx-dev"
       }


### PR DESCRIPTION
## Current Behavior

The `nx-dev:sitemap` target runs its command through `pnpm`:

```
pnpm next-sitemap --config ./next-sitemap.config.js && node ./scripts/patch-sitemap-index.mjs
```

Because the binary is launched via `pnpm`, pnpm performs its install-sync check on every run, reading `pnpm-lock.yaml` and the patches declared in `pnpm-workspace.yaml` (`patches/@astrojs__starlight.patch`) before `next-sitemap` even starts. Those files are outside the task's declared inputs, so Nx Cloud sandboxing flags the task with unexpected reads, which undermines cache reliability.

## Expected Behavior

The target invokes `next-sitemap` directly. Nx `run-commands` already prepends `node_modules/.bin` to `PATH`, and `next-sitemap` is installed at the workspace root, so the binary resolves without the `pnpm` launcher. The task now reads only its declared inputs — no more unexpected reads of `pnpm-lock.yaml` or the Starlight patch.

Verified locally with `nx sitemap nx-dev --skip-nx-cache`: both `next-sitemap` and the `patch-sitemap-index.mjs` step run successfully.

## Related Issue(s)

N/A — internal CI/caching correctness fix (Nx Cloud sandbox violations).

<details>
<summary>Pre-create review (run before PR open)</summary>

### Critical
none

### Important
none

### Suggestions
- `packages/nx/project.json` still uses the `pnpm <bin>` pattern for a different target (`napi artifacts`). Out of scope here; the same fix applies if it ever hits the sandbox flag.

_Reviewer confirmed: `next-sitemap` resolves reliably via `run-commands` PATH handling (ancestor `node_modules/.bin` dirs are appended; verified against the executor's spec), and dropping `pnpm` changes no env/node/script-resolution behavior. silent-failure-hunter / pr-test-analyzer / comment-analyzer skipped as N/A — one-line build-config change with no logic, error handling, testable units, or new comments._

</details>
