### PR TITLE
fix(bundling): restore preprocessor extensions in postcss normalizeOp…

### DIFF
--- a/packages/rollup/src/plugins/postcss/options.spec.ts
+++ b/packages/rollup/src/plugins/postcss/options.spec.ts
@@ -10,7 +10,16 @@ describe('normalizeOptions', () => {
     expect(result.modules).toBe(false);
     expect(result.plugins).toEqual([]);
     expect(result.use).toEqual({});
-    expect(result.extensions).toEqual(['.css', '.sss', '.pcss']);
+    expect(result.extensions).toEqual([
+      '.css',
+      '.sss',
+      '.pcss',
+      '.scss',
+      '.sass',
+      '.less',
+      '.styl',
+      '.stylus',
+    ]);
     expect(result.sourceMap).toBe(false);
   });
 

--- a/packages/rollup/src/plugins/postcss/options.ts
+++ b/packages/rollup/src/plugins/postcss/options.ts
@@ -108,7 +108,7 @@ export interface PostCSSPluginOptions {
 
   /**
    * File extensions to process
-   * @default ['.css', '.sss', '.pcss']
+   * @default ['.css', '.sss', '.pcss', '.scss', '.sass', '.less', '.styl', '.stylus']
    */
   extensions?: string[];
 }
@@ -131,6 +131,21 @@ export interface NormalizedPostCSSOptions extends PostCSSPluginOptions {
 }
 
 /**
+ * Default file extensions processed by the postcss plugin.
+ * Includes plain CSS formats and all supported preprocessor extensions.
+ */
+export const defaultExtensions = [
+  '.css',
+  '.sss',
+  '.pcss',
+  '.scss',
+  '.sass',
+  '.less',
+  '.styl',
+  '.stylus',
+];
+
+/**
  * Normalize plugin options with defaults
  */
 export function normalizeOptions(
@@ -144,7 +159,7 @@ export function normalizeOptions(
     modules: options.modules ?? false,
     plugins: options.plugins ?? [],
     use: options.use ?? {},
-    extensions: options.extensions ?? ['.css', '.sss', '.pcss'],
+    extensions: options.extensions ?? defaultExtensions,
     sourceMap: options.sourceMap ?? false,
   };
 }

--- a/packages/rollup/src/plugins/postcss/postcss-plugin.ts
+++ b/packages/rollup/src/plugins/postcss/postcss-plugin.ts
@@ -131,19 +131,8 @@ function getRecursiveImportOrder(
 export function postcss(pluginOptions: PostCSSPluginOptions = {}): Plugin {
   const options: NormalizedPostCSSOptions = normalizeOptions(pluginOptions);
 
-  // Create file filter
-  const defaultExtensions = [
-    '.css',
-    '.sss',
-    '.pcss', // CSS formats
-    '.scss',
-    '.sass', // Sass
-    '.less', // Less
-    '.styl',
-    '.stylus', // Stylus
-  ];
-
-  const extensions = options.extensions ?? defaultExtensions;
+  // Create file filter — extensions always set by normalizeOptions
+  const extensions = options.extensions;
 
   const filter = createFilter(
     options.include ?? extensions.map((ext) => `**/*${ext}`),


### PR DESCRIPTION

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Building a publishable library with rollup fails for SCSS, Sass, Less, and Stylus files since 22.4.0. The files are silently skipped because the postcss plugin filter only matches [.css](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/6928394f91/resources/app/out/vs/code/electron-browser/workbench/workbench.html), .sss, and .pcss.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Preprocessor files (.scss, .sass, .less, .styl, .stylus) are processed correctly, as they were before 22.4.0 when the external [rollup-plugin-postcss](vscode-file://vscode-app/c:/Program%20Files/Microsoft%20VS%20Code/6928394f91/resources/app/out/vs/code/electron-browser/workbench/workbench.html) package was used.
## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #35854