### PR TITLE
fix(core): format AI-edited files after agentic migrations

### DIFF
--- a/packages/nx/src/command-line/migrate/agentic/prompts/system-prompt.spec.ts
+++ b/packages/nx/src/command-line/migrate/agentic/prompts/system-prompt.spec.ts
@@ -144,4 +144,28 @@ describe('buildSystemPrompt', () => {
       expect(prompt).not.toContain(AUTHOR_MARKER);
     });
   });
+
+  describe('formatting the agent’s changes (author mode)', () => {
+    it('directs the agent to format the files it changed before handoff, via nx format:write', () => {
+      const prompt = buildSystemPrompt(ctx);
+      expect(prompt).toMatch(
+        /format the files you created or modified .* run `nx format:write`/
+      );
+    });
+
+    it('carves nx format:write out of the mutating-nx-command prohibition', () => {
+      const prompt = buildSystemPrompt(ctx);
+      expect(prompt).toMatch(
+        /mutate workspace state .*, except `nx format:write` to format the files you changed/
+      );
+    });
+
+    it('no longer blanket-forbids reformatting, only reformatting untouched files', () => {
+      const prompt = buildSystemPrompt(ctx);
+      expect(prompt).not.toContain(
+        'Do not refactor, reformat, or update dependencies'
+      );
+      expect(prompt).toMatch(/do not reformat files you did not change/);
+    });
+  });
 });

--- a/packages/nx/src/command-line/migrate/agentic/prompts/system-prompt.ts
+++ b/packages/nx/src/command-line/migrate/agentic/prompts/system-prompt.ts
@@ -113,9 +113,10 @@ function buildScopeRules(mode: AgenticPromptMode): string {
   return [
     `<scope_rules>`,
     `- Apply only the changes the migration prompt asks for.`,
-    `- Do not refactor, reformat, or update dependencies beyond what the migration prompt directs.`,
+    `- Do not refactor or update dependencies beyond what the migration prompt directs, and do not reformat files you did not change.`,
+    `- After applying your changes and before writing the handoff, format the files you created or modified so they match the workspace's style. If the workspace uses Prettier, run \`nx format:write\`, which formats your uncommitted changes; if it has no formatter configured, skip this.`,
     `- Do not modify files outside the workspace root.`,
-    `- Do not run other \`nx\` commands that mutate workspace state (\`nx migrate\`, \`nx reset\`, \`nx run-many\`, generators, etc.). Read-only inspection (\`nx show\`, \`nx graph --file\`, reading files) is fine.`,
+    `- Do not run other \`nx\` commands that mutate workspace state (\`nx migrate\`, \`nx reset\`, \`nx run-many\`, generators, etc.), except \`nx format:write\` to format the files you changed. Read-only inspection (\`nx show\`, \`nx graph --file\`, reading files) is fine.`,
     `- If the migration instructions are unclear, internally inconsistent, or conflict with the current workspace state, ask the user for direction (see the handoff contract). Do not guess.`,
     `</scope_rules>`,
   ].join('\n');


### PR DESCRIPTION
## Current Behavior

Agentic (AI-assisted) migrations run in two halves: a deterministic generator, then an AI agent that finishes the work. The generator formats its own output, but the AI agent edits files directly and its changes were never formatted.

The agent was actually _blocked_ from formatting by its own scope rules: the system prompt told it "Do not refactor, reformat, or update dependencies beyond what the migration prompt directs," and forbade running nx commands that mutate workspace state (which includes `nx format:write`).

As a result, after an agentic migration the workspace is left with unformatted files, and a subsequent `nx format:check` / prepush flags them. This affects every agentic migration that edits files (for example the ESLint v9 flat-config migration), not just one prompt.

## Expected Behavior

The agent formats the files it created or modified before writing its handoff, so the workspace is left consistently formatted.

The fix is in the author-mode scope rules of the agentic migration system prompt:

- Added a rule directing the agent to format its changed files before handoff — `nx format:write` when the workspace uses Prettier, otherwise skip. (`nx format:write` formats the agent's uncommitted changes, which is exactly the migration's edits at that point.)
- Reworded the blanket "do not reformat" rule to "do not reformat files you did not change," so it no longer contradicts the new instruction.
- Carved `nx format:write` out of the "do not run mutating nx commands" prohibition.

This is applied once at the `nx migrate` level, so it covers all agentic migrations.

## Related Issue(s)

No linked issue — found while running the 23.1 ESLint flat-config migration on a real workspace.
