### PR TITLE
fix(react): skip react 19 update for workspaces using remix v2

### DIFF
--- a/packages/react/migrations.json
+++ b/packages/react/migrations.json
@@ -214,6 +214,9 @@
     },
     "23.1.0": {
       "version": "23.1.0-beta.0",
+      "incompatibleWith": {
+        "@remix-run/react": "*"
+      },
       "requires": {
         "react": ">=18.0.0 <19.0.0"
       },

--- a/packages/react/src/migrations/update-23-1-0/ai-instructions-for-react-19.md
+++ b/packages/react/src/migrations/update-23-1-0/ai-instructions-for-react-19.md
@@ -11,6 +11,13 @@ npx types-react-codemod@latest preset-19 ./PROJECT_PATH
 
 First handles API changes, second handles `@types/react` 19 types. Review the diffs.
 
+`preset-19` is interactive (prompts per codemod). For a non-interactive run, the two that clear the most common type errors are:
+
+```bash
+npx types-react-codemod@latest useRef-required-initial ./PROJECT_PATH  # useRef() -> useRef(initialValue); 19 dropped the zero-arg overload
+npx types-react-codemod@latest refobject-defaults ./PROJECT_PATH       # RefObject<T> -> RefObject<T | null>; covers both ref sites and helper param signatures
+```
+
 ## Step 2: Removed APIs (fix by hand if codemod misses)
 
 - `ReactDOM.render` / `hydrate` -> `createRoot` / `hydrateRoot` from `react-dom/client`. Note `hydrateRoot(container, element)` swaps the arg order vs `hydrate`.


### PR DESCRIPTION
## Current Behavior

`nx migrate` to 23.1.0 bumps `react` to `^19` for every React-18 workspace. Remix v2 (`@remix-run/react`) peers `react@^18` and does not support React 19, so Remix apps end up with a split React tree (a forced 18 copy beside the new 19) and hydration crashes (React #418).

## Expected Behavior

The React 19 `packageJsonUpdate` is skipped when `@remix-run/react` is present, via `incompatibleWith` - matching the existing `@nx/js` and `@nx/vite` Remix guards. The React 19 AI-instructions migration also points at the `useRef-required-initial` and `refobject-defaults` codemods that clear the most common `@types/react` 19 type errors.

## Related Issue(s)

NXC-4573

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/migration-failed-ocean-ec23eb4f)
<!-- polygraph-session-end -->