### PR TITLE
fix(vite): update deprecation docs link

### DIFF
--- a/packages/vite/src/utils/deprecation.ts
+++ b/packages/vite/src/utils/deprecation.ts
@@ -41,10 +41,10 @@ export function warnViteExecutorGenerating(): void {
 // resolution end-to-end. Asset copying is covered by Vite's native
 // `publicDir` option or the `vite-plugin-static-copy` package.
 export const NX_VITE_TS_PATHS_DEPRECATION_MESSAGE =
-  'The `nxViteTsPaths` plugin from `@nx/vite/plugins/nx-tsconfig-paths.plugin` is deprecated and will be removed in Nx v24. Replace it with `tsconfigPaths()` from the `vite-tsconfig-paths` package. See https://nx.dev/docs/technologies/build-tools/vite/configure-vite for details.';
+  'The `nxViteTsPaths` plugin from `@nx/vite/plugins/nx-tsconfig-paths.plugin` is deprecated and will be removed in Nx v24. Replace it with `tsconfigPaths()` from the `vite-tsconfig-paths` package. See https://nx.dev/docs/technologies/build-tools/vite/guides/configure-vite for details.';
 
 export const NX_COPY_ASSETS_PLUGIN_DEPRECATION_MESSAGE =
-  "The `nxCopyAssetsPlugin` plugin from `@nx/vite/plugins/nx-copy-assets.plugin` is deprecated and will be removed in Nx v24. Use Vite's native `publicDir` option or the `vite-plugin-static-copy` package instead. See https://nx.dev/docs/technologies/build-tools/vite/configure-vite for details.";
+  "The `nxCopyAssetsPlugin` plugin from `@nx/vite/plugins/nx-copy-assets.plugin` is deprecated and will be removed in Nx v24. Use Vite's native `publicDir` option or the `vite-plugin-static-copy` package instead. See https://nx.dev/docs/technologies/build-tools/vite/guides/configure-vite for details.";
 
 let nxViteTsPathsWarned = false;
 let nxCopyAssetsPluginWarned = false;


### PR DESCRIPTION
## Description

Updates the Vite plugin deprecation warnings to point at the existing Configure Vite documentation page.

The previous URL omitted the `guides` segment and returned a 404. The docs page currently resolves at:

https://nx.dev/docs/technologies/build-tools/vite/guides/configure-vite

## Related Issues

Fixes #36053

## Validation

- Verified the corrected documentation URL resolves
- Ran `git diff --check`

## AI Assistance

This PR was authored with assistance from AI.