### PR TITLE
fix(vite): prevent watch false leaking into dev server config

### DIFF
--- a/packages/vite/src/executors/dev-server/dev-server.impl.ts
+++ b/packages/vite/src/executors/dev-server/dev-server.impl.ts
@@ -181,10 +181,19 @@ async function getServerExtraArgs(
   }
 
   if (configuration) {
+    const normalizeWatchOption = <T>(
+      watch: T | false | undefined
+    ): T | undefined => {
+      return watch === false ? undefined : watch;
+    };
+
     serverOptions = {
       ...serverOptions,
-      watch: buildOptionsFromBuildTarget?.watch ?? serverOptions?.watch,
+      watch:
+        normalizeWatchOption(buildOptionsFromBuildTarget?.watch) ??
+        normalizeWatchOption(serverOptions?.watch),
     };
+
     otherOptions = {
       ...otherOptions,
       ...(otherOptionsFromBuildTarget ?? {}),


### PR DESCRIPTION
Closes #36078

<!-- Please make sure you have read the submission guidelines before posting an PR -->

<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->

<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior

When the Vite dev-server executor references a build target with a named configuration, the build target options can include `watch: false`.

That value is currently merged into the Vite dev-server config as `server.watch: false`.

`watch: false` is valid for the Nx build executor, but it is not a valid/useful value for Vite dev-server `server.watch`. This can cause downstream Vite plugins to fail when they expect `server.watch` to be unset or an object.

For example, plugins may safely initialise missing watch config with:

```ts
config.server ??= {};
config.server.watch ??= {};
```

However, if `config.server.watch` is `false`, the nullish assignment does not replace it. The plugin can then fail when trying to read or assign properties such as `config.server.watch.ignored`.

## Expected Behavior

The Vite dev-server executor should not forward `watch: false` into Vite’s `server.watch` config.

This patch normalises `false` to `undefined` when resolving the watch option from the referenced build target and dev-server options.

This keeps the existing precedence behaviour while preventing the invalid boolean value from leaking into the Vite server config. Valid watch option objects continue to be passed through unchanged.

## Related Issue(s)

Fixes #36078 

