### PR TITLE
fix(core): skip daemon project-graph recompute on no-op file rewrites

### DIFF
--- a/e2e/nx/src/watch.test.ts
+++ b/e2e/nx/src/watch.test.ts
@@ -18,11 +18,16 @@ import { tmpdir } from 'os';
 let cacheDirectory = mkdtempSync(join(tmpdir(), 'daemon'));
 console.log('cache directory', cacheDirectory);
 
-async function writeFileForWatcher(path: string, content: string) {
+let writeSeq = 0;
+function uniqueFileContent() {
+  return `content-${Date.now()}-${++writeSeq}`;
+}
+
+async function writeFileForWatcher(path: string, content?: string) {
   const e2ePath = join(tmpProjPath(), path);
 
   console.log(`writing to: ${e2ePath}`);
-  writeFileSync(e2ePath, content);
+  writeFileSync(e2ePath, content ?? uniqueFileContent());
   await wait(10);
 }
 
@@ -67,22 +72,22 @@ describe('Nx Watch', () => {
     const getOutput = await runWatch(
       `--projects=${proj1} -- echo \\$NX_PROJECT_NAME`
     );
-    await writeFileForWatcher(`libs/${proj1}/newfile.txt`, 'content');
-    await writeFileForWatcher(`libs/${proj2}/newfile.txt`, 'content');
-    await writeFileForWatcher(`libs/${proj1}/newfile2.txt`, 'content');
-    await writeFileForWatcher(`libs/${proj3}/newfile2.txt`, 'content');
-    await writeFileForWatcher(`newfile2.txt`, 'content');
+    await writeFileForWatcher(`libs/${proj1}/newfile.txt`);
+    await writeFileForWatcher(`libs/${proj2}/newfile.txt`);
+    await writeFileForWatcher(`libs/${proj1}/newfile2.txt`);
+    await writeFileForWatcher(`libs/${proj3}/newfile2.txt`);
+    await writeFileForWatcher(`newfile2.txt`);
 
     expect(await getOutput()).toEqual([proj1]);
   }, 50000);
 
   it('should watch for all projects and output the project name', async () => {
     const getOutput = await runWatch(`--all -- echo \\$NX_PROJECT_NAME`);
-    await writeFileForWatcher(`libs/${proj1}/newfile.txt`, 'content');
-    await writeFileForWatcher(`libs/${proj2}/newfile.txt`, 'content');
-    await writeFileForWatcher(`libs/${proj1}/newfile2.txt`, 'content');
-    await writeFileForWatcher(`libs/${proj3}/newfile2.txt`, 'content');
-    await writeFileForWatcher(`newfile2.txt`, 'content');
+    await writeFileForWatcher(`libs/${proj1}/newfile.txt`);
+    await writeFileForWatcher(`libs/${proj2}/newfile.txt`);
+    await writeFileForWatcher(`libs/${proj1}/newfile2.txt`);
+    await writeFileForWatcher(`libs/${proj3}/newfile2.txt`);
+    await writeFileForWatcher(`newfile2.txt`);
 
     let content = await getOutput();
     let results = content.sort();
@@ -92,10 +97,10 @@ describe('Nx Watch', () => {
 
   it('should watch for all project changes and output the file name changes', async () => {
     const getOutput = await runWatch(`--all -- echo \\$NX_FILE_CHANGES`);
-    await writeFileForWatcher(`libs/${proj1}/newfile.txt`, 'content');
-    await writeFileForWatcher(`libs/${proj2}/newfile.txt`, 'content');
-    await writeFileForWatcher(`libs/${proj1}/newfile2.txt`, 'content');
-    await writeFileForWatcher(`newfile2.txt`, 'content');
+    await writeFileForWatcher(`libs/${proj1}/newfile.txt`);
+    await writeFileForWatcher(`libs/${proj2}/newfile.txt`);
+    await writeFileForWatcher(`libs/${proj1}/newfile2.txt`);
+    await writeFileForWatcher(`newfile2.txt`);
 
     let output = (await getOutput())[0];
     let results = output.split(' ').sort();
@@ -111,10 +116,10 @@ describe('Nx Watch', () => {
     const getOutput = await runWatch(
       `--all --includeGlobalWorkspaceFiles -- echo \\$NX_FILE_CHANGES`
     );
-    await writeFileForWatcher(`libs/${proj1}/newfile.txt`, 'content');
-    await writeFileForWatcher(`libs/${proj2}/newfile.txt`, 'content');
-    await writeFileForWatcher(`libs/${proj1}/newfile2.txt`, 'content');
-    await writeFileForWatcher(`newfile2.txt`, 'content');
+    await writeFileForWatcher(`libs/${proj1}/newfile.txt`);
+    await writeFileForWatcher(`libs/${proj2}/newfile.txt`);
+    await writeFileForWatcher(`libs/${proj1}/newfile2.txt`);
+    await writeFileForWatcher(`newfile2.txt`);
 
     let output = (await getOutput())[0];
     let results = output.split(' ').sort();
@@ -131,11 +136,11 @@ describe('Nx Watch', () => {
     const getOutput = await runWatch(
       `--projects=${proj1},${proj3} -- echo \\$NX_PROJECT_NAME`
     );
-    await writeFileForWatcher(`libs/${proj1}/newfile.txt`, 'content');
-    await writeFileForWatcher(`libs/${proj2}/newfile.txt`, 'content');
-    await writeFileForWatcher(`libs/${proj1}/newfile2.txt`, 'content');
-    await writeFileForWatcher(`libs/${proj3}/newfile2.txt`, 'content');
-    await writeFileForWatcher(`newfile2.txt`, 'content');
+    await writeFileForWatcher(`libs/${proj1}/newfile.txt`);
+    await writeFileForWatcher(`libs/${proj2}/newfile.txt`);
+    await writeFileForWatcher(`libs/${proj1}/newfile2.txt`);
+    await writeFileForWatcher(`libs/${proj3}/newfile2.txt`);
+    await writeFileForWatcher(`newfile2.txt`);
 
     let output = await getOutput();
     let results = output.sort();
@@ -152,11 +157,11 @@ describe('Nx Watch', () => {
     const getOutput = await runWatch(
       `--projects=${proj3} --includeDependencies -- echo \\$NX_PROJECT_NAME`
     );
-    await writeFileForWatcher(`libs/${proj1}/newfile.txt`, 'content');
-    await writeFileForWatcher(`libs/${proj2}/newfile.txt`, 'content');
-    await writeFileForWatcher(`libs/${proj1}/newfile2.txt`, 'content');
-    await writeFileForWatcher(`libs/${proj3}/newfile2.txt`, 'content');
-    await writeFileForWatcher(`newfile2.txt`, 'content');
+    await writeFileForWatcher(`libs/${proj1}/newfile.txt`);
+    await writeFileForWatcher(`libs/${proj2}/newfile.txt`);
+    await writeFileForWatcher(`libs/${proj1}/newfile2.txt`);
+    await writeFileForWatcher(`libs/${proj3}/newfile2.txt`);
+    await writeFileForWatcher(`newfile2.txt`);
 
     let output = await getOutput();
     let results = output.sort();
@@ -190,7 +195,7 @@ describe('Nx Watch', () => {
     );
 
     // Write file before daemon restart
-    await writeFileForWatcher(`libs/${proj1}/before-restart.txt`, 'content');
+    await writeFileForWatcher(`libs/${proj1}/before-restart.txt`);
     await wait(1000);
 
     // Kill the daemon
@@ -205,7 +210,7 @@ describe('Nx Watch', () => {
     await wait(3000);
 
     // Write file after daemon restart - watch should reconnect and receive this
-    await writeFileForWatcher(`libs/${proj1}/after-restart.txt`, 'content');
+    await writeFileForWatcher(`libs/${proj1}/after-restart.txt`);
 
     const output = await getOutput();
     expect(output).toContain(proj1);

--- a/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
+++ b/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
@@ -76,7 +76,10 @@ export let currentSourceMaps: ConfigurationSourceMaps | undefined;
 
 // Maps file path to a version counter that increments on each modification.
 // This lets us detect mid-flight re-modifications when clearing processed files.
-const collectedUpdatedFiles = new Map<string, number>();
+const collectedUpdatedFiles = new Map<
+  string,
+  { version: number; hash: string }
+>();
 const collectedDeletedFiles = new Map<string, number>();
 
 const projectGraphRecomputationListeners = new Set<
@@ -276,9 +279,37 @@ export function scheduleProjectGraphRecomputation(
   deletedFiles: string[]
 ) {
   ++fileChangeCounter;
-  for (let f of [...createdFiles, ...updatedFiles]) {
+
+  // Hash the changed files up front and drop no-op rewrites before they can
+  // trigger an expensive recompute. Restoring a cached task output, a
+  // `git checkout` back to the same content, or a formatter that changes
+  // nothing all rewrite a file (new inode) the watcher reports as changed
+  // even though the bytes are identical. updateFilesInContext updates the
+  // workspace context and returns only the files whose content actually
+  // changed. Hashing here — once per watcher batch — rather than inside the
+  // recompute keeps it off the stale-retry path, which would otherwise see
+  // "no change" after the first pass already updated the context hashes.
+  performance.mark('hash-watched-changes-start');
+  const changedFileHashes =
+    createdFiles.length > 0 ||
+    updatedFiles.length > 0 ||
+    deletedFiles.length > 0
+      ? (updateFilesInContext(
+          workspaceRoot,
+          [...createdFiles, ...updatedFiles],
+          deletedFiles
+        ) ?? {})
+      : {};
+  performance.mark('hash-watched-changes-end');
+  performance.measure(
+    'hash changed files from watcher',
+    'hash-watched-changes-start',
+    'hash-watched-changes-end'
+  );
+
+  for (const [f, hash] of Object.entries(changedFileHashes)) {
     collectedDeletedFiles.delete(f);
-    collectedUpdatedFiles.set(f, fileChangeCounter);
+    collectedUpdatedFiles.set(f, { version: fileChangeCounter, hash });
   }
 
   for (let f of deletedFiles) {
@@ -288,11 +319,7 @@ export function scheduleProjectGraphRecomputation(
 
   // The native watcher already coalesces a burst of events into one batch,
   // so socket + listener notifications dispatch immediately.
-  if (
-    createdFiles.length > 0 ||
-    updatedFiles.length > 0 ||
-    deletedFiles.length > 0
-  ) {
+  if (Object.keys(changedFileHashes).length > 0 || deletedFiles.length > 0) {
     notifyFileChangeListeners({ createdFiles, updatedFiles, deletedFiles });
     notifyFileWatcherSockets(createdFiles, updatedFiles, deletedFiles);
     // Bump generation synchronously so any in-flight compute fails its
@@ -424,22 +451,18 @@ async function processFilesAndCreateAndSerializeProjectGraph(
   };
 
   try {
-    performance.mark('hash-watched-changes-start');
     const updatedFilesSnapshot = new Map(collectedUpdatedFiles);
     const deletedFilesSnapshot = new Map(collectedDeletedFiles);
     const updatedFiles = [...updatedFilesSnapshot.keys()];
     const deletedFiles = [...deletedFilesSnapshot.keys()];
-    let updatedFileHashes = updateFilesInContext(
-      workspaceRoot,
-      updatedFiles,
-      deletedFiles
-    );
-    performance.mark('hash-watched-changes-end');
-    performance.measure(
-      'hash changed files from watcher',
-      'hash-watched-changes-start',
-      'hash-watched-changes-end'
-    );
+    // Hashes were already computed (and the workspace context updated) in
+    // scheduleProjectGraphRecomputation, which also dropped no-op rewrites.
+    // Reuse them so the context isn't re-hashed on every (possibly stale)
+    // recompute attempt.
+    const updatedFileHashes: Record<string, string> = {};
+    for (const [f, { hash }] of updatedFilesSnapshot) {
+      updatedFileHashes[f] = hash;
+    }
     serverLogger.requestLog(
       `Updated workspace context based on watched changes, recomputing project graph...`
     );
@@ -494,8 +517,8 @@ async function processFilesAndCreateAndSerializeProjectGraph(
     // from the daemon's view (project graph misses recently added files).
     // Match version-stamps so a file modified mid-flight (higher version)
     // stays in the queue for reprocessing.
-    for (const [f, version] of updatedFilesSnapshot) {
-      if (collectedUpdatedFiles.get(f) === version) {
+    for (const [f, { version }] of updatedFilesSnapshot) {
+      if (collectedUpdatedFiles.get(f)?.version === version) {
         collectedUpdatedFiles.delete(f);
       }
     }

--- a/packages/nx/src/native/workspace/context.rs
+++ b/packages/nx/src/native/workspace/context.rs
@@ -170,7 +170,7 @@ impl FilesWorker {
             };
         }
 
-        let updated_files_hashes: HashMap<String, String> = updated_files
+        let new_hashes: HashMap<String, String> = updated_files
             .par_iter()
             .filter_map(|path| {
                 let full_path = workspace_root_path.join(path);
@@ -182,16 +182,29 @@ impl FilesWorker {
             })
             .collect();
 
-        for (file, hash) in &updated_files_hashes {
-            map.entry(file.into())
-                .and_modify(|e| e.clone_from(hash))
-                .or_insert(hash.clone());
+        // Report only files whose content actually changed (new files, or
+        // files whose hash differs from what we already had). Restoring a
+        // cached task output rewrites a file with identical bytes (new inode,
+        // same content) and the watcher reports it as a change — but treating
+        // that as a real change makes the daemon recompute the project graph
+        // for nothing.
+        let mut changed_files_hashes: HashMap<String, String> = HashMap::new();
+        for (file, new_hash) in new_hashes {
+            match map.get(Path::new(&file)) {
+                Some(existing) if *existing == new_hash => {
+                    // Unchanged content — leave the map as-is, do not report.
+                }
+                _ => {
+                    map.insert(PathBuf::from(&file), new_hash.clone());
+                    changed_files_hashes.insert(file, new_hash);
+                }
+            }
         }
 
         *files = map.into_iter().collect();
         files.par_sort();
 
-        updated_files_hashes
+        changed_files_hashes
     }
 }
 
@@ -478,5 +491,50 @@ mod tests {
                 "multi_glob group {i} must be sorted regardless of file creation order"
             );
         }
+    }
+
+    /// Restoring a cached task output rewrites a file with identical bytes
+    /// (new inode, same content). The watcher reports it as a change, but
+    /// `incremental_update` must report only files whose content actually
+    /// changed — otherwise the daemon recomputes the whole project graph for
+    /// a no-op rewrite.
+    #[test]
+    fn incremental_update_reports_only_real_content_changes() {
+        let temp = TempDir::new().unwrap();
+        temp.child("a.txt").write_str("hello").unwrap();
+        temp.child("b.txt").write_str("world").unwrap();
+
+        let cache = TempDir::new().unwrap();
+        let ctx = WorkspaceContext::new(
+            temp.path().to_string_lossy().to_string(),
+            cache.path().to_string_lossy().to_string(),
+        );
+        // Force the initial file gather + hash to complete before updating.
+        ctx.all_file_data();
+
+        // Rewrite a.txt with identical content — a no-op rewrite.
+        temp.child("a.txt").write_str("hello").unwrap();
+        let no_op = ctx.incremental_update(vec!["a.txt".into()], vec![]);
+        assert!(
+            no_op.is_empty(),
+            "rewriting a file with identical content must report no change; got {no_op:?}"
+        );
+
+        // Genuinely change b.txt — must be reported.
+        temp.child("b.txt").write_str("changed").unwrap();
+        let changed = ctx.incremental_update(vec!["b.txt".into()], vec![]);
+        assert_eq!(
+            changed.keys().collect::<Vec<_>>(),
+            vec![&"b.txt".to_string()],
+            "a real content change must be reported; got {changed:?}"
+        );
+
+        // A brand-new file must be reported as a change.
+        temp.child("c.txt").write_str("new").unwrap();
+        let created = ctx.incremental_update(vec!["c.txt".into()], vec![]);
+        assert!(
+            created.contains_key("c.txt"),
+            "a newly-created file must be reported; got {created:?}"
+        );
     }
 }


### PR DESCRIPTION
## Current Behavior

The first task run against a freshly started Nx daemon is ~3-5s slower than subsequent runs. Repro:

```
nx reset --only-daemon && nx show projects   # warm the daemon + project graph
nx build js                                  # first build — slow
nx build js                                  # second build — fast
```

The overhead is a full project-graph recompute. On the first build, Nx restores cached task outputs — including the `nx` package's generated native bindings, which live in the watched `packages/nx/src/native/` source tree — with byte-identical content but new inodes. The file watcher legitimately reports these as changes, and the daemon recomputes the entire project graph, cold-reloading every plugin worker (~3s of the overhead), even though no file content actually changed. Subsequent runs skip the cache restore ("existing outputs match the cache, left as is"), so no events fire and there is no recompute.

Daemon-side evidence: the slow `HASH_TASKS` batch reports `Handling time: 3004ms` while the native `hash_plans` inside it completes in ~7ms — the time is spent blocked on the recompute, not on hashing.

## Expected Behavior

A file rewritten with identical content does not trigger a project-graph recompute. The daemon recomputes only when something actually changes — a file's content hash changes, a new path appears, or a file is deleted — so the first task run against a fresh daemon no longer pays for a needless cold recompute.

Implementation:

- **native** (`WorkspaceContext::update_files`): returns only the files whose content actually changed (a new path, or a hash differing from the existing entry) instead of every updated path. The old hash was already available in the file map and was previously discarded.
- **daemon** (`scheduleProjectGraphRecomputation`): hashes watched changes once per watcher batch and gates `kickOffRecompute` on real changes; the hashes are threaded through `collectedUpdatedFiles` so the recompute body no longer re-hashes (keeping the content check off the stale-retry path, which would otherwise see "no change" after the first pass already updated the context).

This also avoids needless recomputes from `git checkout` back to identical content, formatters that change nothing, and `touch`.

Verification: new Rust unit test (`incremental_update_reports_only_real_content_changes`), existing native watch suite still green, and a direct check that `incrementalUpdate` returns `{}` for identical bytes and `[changed]` for a real change.

**Behavior note:** a side effect is that `nx watch` no longer fires on pure no-op rewrites (content identical).

## Related Issue(s)

N/A

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Fix-daemon-performance-bug---nrwl-nx-5364e560)
<!-- polygraph-session-end -->