### PR TITLE
fix(nx-dev): remove empty SaaS and Mobile template filters

### DIFF
--- a/astro-docs/src/data/templates.ts
+++ b/astro-docs/src/data/templates.ts
@@ -19,9 +19,7 @@ export type TemplateCategory =
   | 'Module Federation'
   | 'Documentation'
   | 'Packages'
-  | 'Media'
-  | 'Mobile'
-  | 'SaaS';
+  | 'Media';
 
 export interface TemplateStep {
   label: string;
@@ -678,8 +676,6 @@ export const categories: TemplateCategory[] = [
   'Fullstack',
   'Backend',
   'Module Federation',
-  'SaaS',
-  'Mobile',
   'Documentation',
   'Packages',
   'Media',


### PR DESCRIPTION
## Current Behavior

The templates gallery renders SaaS and Mobile filter buttons, but no template uses those categories, so both filters show an empty list.

## Expected Behavior

Only categories that have templates appear as filters. Removes the unused SaaS and Mobile categories.

## Related Issue(s)

N/A