### PR TITLE
fix(core): make nx migrate honor preapproved packages and emit a valid temp workspace

### DIFF
--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -414,7 +414,8 @@ export class Migrator {
             )))
         ) {
           const updateEntries = Object.entries(packageUpdate.packages);
-          // Validate up front so invalid metadata still fails fast.
+          // Validate all up front so invalid metadata fails fast, before any
+          // resolution does I/O.
           for (const [name, update] of updateEntries) {
             this.validatePackageUpdateVersion(
               packageToCheck.package,
@@ -422,22 +423,20 @@ export class Migrator {
               update
             );
           }
-          // Each version resolves independently, so resolve them concurrently
-          // instead of awaiting one registry/install round-trip at a time.
-          const resolvedVersions = await Promise.all(
-            updateEntries.map(([name, update]) =>
-              this.resolveVersionForCascade(name, update.version)
-            )
-          );
-          // Assign in the original order so packageUpdates ordering is stable.
-          updateEntries.forEach(([name, update], index) => {
+          // Resolve serially: resolution can prompt (pnpm strict cooldown) and
+          // append to minimumReleaseAgeExclude, so a serial loop avoids
+          // overlapping prompts and keeps packageUpdates ordering stable.
+          for (const [name, update] of updateEntries) {
             const resolvedUpdate = {
               ...update,
-              version: resolvedVersions[index],
+              version: await this.resolveVersionForCascade(
+                name,
+                update.version
+              ),
             };
             filteredUpdates[name] = resolvedUpdate;
             this.packageUpdates[name] = resolvedUpdate;
-          });
+          }
         }
       }
 
@@ -453,12 +452,12 @@ export class Migrator {
     packageName: string,
     version: string
   ): Promise<string> {
-    // If the version is already an exact semver, no need to resolve
+    // Already a fully-qualified semver (incl. prereleases) - nothing to resolve.
     if (valid(version)) {
       return version;
     }
-    // Otherwise, resolve through the min-release-age policy to honor
-    // preapproved packages configured in the package manager
+    // Otherwise resolve the spec (range/tag) through the min-release-age policy,
+    // which also honors any configured minimumReleaseAgeExclude entries.
     return resolvePackageVersionRespectingMinReleaseAge(packageName, version);
   }
 

--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -413,15 +413,20 @@ export class Migrator {
               packageToCheck.package
             )))
         ) {
-          Object.entries(packageUpdate.packages).forEach(([name, update]) => {
+          for (const [name, update] of Object.entries(packageUpdate.packages)) {
             this.validatePackageUpdateVersion(
               packageToCheck.package,
               name,
               update
             );
-            filteredUpdates[name] = update;
-            this.packageUpdates[name] = update;
-          });
+            const resolvedVersion = await this.resolveVersionForCascade(
+              name,
+              update.version
+            );
+            const resolvedUpdate = { ...update, version: resolvedVersion };
+            filteredUpdates[name] = resolvedUpdate;
+            this.packageUpdates[name] = resolvedUpdate;
+          }
         }
       }
 
@@ -431,6 +436,19 @@ export class Migrator {
         )
       );
     }
+  }
+
+  private async resolveVersionForCascade(
+    packageName: string,
+    version: string
+  ): Promise<string> {
+    // If the version is already an exact semver, no need to resolve
+    if (valid(version)) {
+      return version;
+    }
+    // Otherwise, resolve through the min-release-age policy to honor
+    // preapproved packages configured in the package manager
+    return resolvePackageVersionRespectingMinReleaseAge(packageName, version);
   }
 
   private async populatePackageJsonUpdatesAndGetPackagesToCheck(

--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -413,20 +413,31 @@ export class Migrator {
               packageToCheck.package
             )))
         ) {
-          for (const [name, update] of Object.entries(packageUpdate.packages)) {
+          const updateEntries = Object.entries(packageUpdate.packages);
+          // Validate up front so invalid metadata still fails fast.
+          for (const [name, update] of updateEntries) {
             this.validatePackageUpdateVersion(
               packageToCheck.package,
               name,
               update
             );
-            const resolvedVersion = await this.resolveVersionForCascade(
-              name,
-              update.version
-            );
-            const resolvedUpdate = { ...update, version: resolvedVersion };
+          }
+          // Each version resolves independently, so resolve them concurrently
+          // instead of awaiting one registry/install round-trip at a time.
+          const resolvedVersions = await Promise.all(
+            updateEntries.map(([name, update]) =>
+              this.resolveVersionForCascade(name, update.version)
+            )
+          );
+          // Assign in the original order so packageUpdates ordering is stable.
+          updateEntries.forEach(([name, update], index) => {
+            const resolvedUpdate = {
+              ...update,
+              version: resolvedVersions[index],
+            };
             filteredUpdates[name] = resolvedUpdate;
             this.packageUpdates[name] = resolvedUpdate;
-          }
+          });
         }
       }
 

--- a/packages/nx/src/command-line/migrate/resolve-package-version.spec.ts
+++ b/packages/nx/src/command-line/migrate/resolve-package-version.spec.ts
@@ -571,7 +571,9 @@ describe('preapproved packages with min-release-age', () => {
     });
 
     // A non-preapproved package hitting a violation should still be gated
-    const blocked = [{ version: '2.0.0-rc.0', publishedAt: new Date().toISOString() }];
+    const blocked = [
+      { version: '2.0.0-rc.0', publishedAt: new Date().toISOString() },
+    ];
     mockResolve.mockRejectedValue(
       new MinReleaseAgeViolationError({
         packageManager: 'yarn',
@@ -584,7 +586,10 @@ describe('preapproved packages with min-release-age', () => {
     );
 
     await expect(
-      resolvePackageVersionRespectingMinReleaseAge('some-other-pkg', '2.0.0-rc.0')
+      resolvePackageVersionRespectingMinReleaseAge(
+        'some-other-pkg',
+        '2.0.0-rc.0'
+      )
     ).rejects.toThrow(MinReleaseAgeViolationError);
   });
 });

--- a/packages/nx/src/command-line/migrate/resolve-package-version.spec.ts
+++ b/packages/nx/src/command-line/migrate/resolve-package-version.spec.ts
@@ -509,3 +509,82 @@ describe('resolvePackageVersionRespectingMinReleaseAge', () => {
     ).rejects.toThrow('registry exploded');
   });
 });
+
+describe('preapproved packages with min-release-age', () => {
+  it('preapproved packages (exact name and glob) bypass the min-release-age gate during resolution', async () => {
+    resetResolvePackageVersionState();
+    // Simulate yarn policy with npmMinimalAgeGate and npmPreapprovedPackages
+    mockReadPolicy.mockResolvedValue({
+      outcome: 'active',
+      policy: {
+        packageManager: 'yarn',
+        packageManagerVersion: '4.15.0',
+        cutoffMs: Date.now() - 24 * 60 * 60 * 1000, // 24 hours ago
+        windowMs: 24 * 60 * 60 * 1000,
+        sourceDescription: 'yarn npmMinimalAgeGate (1440 min)',
+        // isExcluded checks both exact name ('nx') and glob ('@nx/*')
+        isExcluded: (name: string, version: string) => {
+          return name === 'nx' || name.startsWith('@nx/');
+        },
+        behavior: { packageManager: 'yarn', missingVersionTime: 'pass' },
+      },
+    });
+
+    // Mock the resolution to return an immature version when it would be blocked,
+    // but isApproved() in the actual implementation checks isExcluded first
+    // so preapproved packages should resolve successfully even to fresh versions
+    mockResolve.mockResolvedValue({
+      version: '23.1.0-beta.0', // Fresh prerelease < 24h old
+      unconstrained: '23.1.0-beta.0',
+    });
+
+    // Both exact name and glob-matched packages should resolve to the immature version
+    const nxVersion = await resolvePackageVersionRespectingMinReleaseAge(
+      'nx',
+      '23.1.0-beta.0'
+    );
+    expect(nxVersion).toBe('23.1.0-beta.0');
+
+    const nxParserVersion = await resolvePackageVersionRespectingMinReleaseAge(
+      '@nx/parser',
+      '23.1.0-beta.0'
+    );
+    expect(nxParserVersion).toBe('23.1.0-beta.0');
+  });
+
+  it('non-preapproved packages are still gated by the min-release-age policy', async () => {
+    resetResolvePackageVersionState();
+    mockReadPolicy.mockResolvedValue({
+      outcome: 'active',
+      policy: {
+        packageManager: 'yarn',
+        packageManagerVersion: '4.15.0',
+        cutoffMs: Date.now() - 24 * 60 * 60 * 1000,
+        windowMs: 24 * 60 * 60 * 1000,
+        sourceDescription: 'yarn npmMinimalAgeGate (1440 min)',
+        // Only 'nx' and '@nx/*' are preapproved; other packages are not
+        isExcluded: (name: string, version: string) => {
+          return name === 'nx' || name.startsWith('@nx/');
+        },
+        behavior: { packageManager: 'yarn', missingVersionTime: 'pass' },
+      },
+    });
+
+    // A non-preapproved package hitting a violation should still be gated
+    const blocked = [{ version: '2.0.0-rc.0', publishedAt: new Date().toISOString() }];
+    mockResolve.mockRejectedValue(
+      new MinReleaseAgeViolationError({
+        packageManager: 'yarn',
+        packageName: 'some-other-pkg',
+        spec: '2.0.0-rc.0',
+        pmShapedDetail: 'All versions satisfying "2.0.0-rc.0" are quarantined',
+        blocked,
+        remediation: [],
+      })
+    );
+
+    await expect(
+      resolvePackageVersionRespectingMinReleaseAge('some-other-pkg', '2.0.0-rc.0')
+    ).rejects.toThrow(MinReleaseAgeViolationError);
+  });
+});

--- a/packages/nx/src/utils/min-release-age/behavior/pnpm.spec.ts
+++ b/packages/nx/src/utils/min-release-age/behavior/pnpm.spec.ts
@@ -1,3 +1,4 @@
+import { join } from 'path';
 import { MinReleaseAgeViolationError } from '../errors';
 import type { RegistryMetadata } from '../packument';
 import type { MinReleaseAgePolicy, PmMinReleaseAgeBehavior } from '../policy';
@@ -559,6 +560,19 @@ describe('pnpm min-release-age behavior', () => {
         .mockImplementation(() => require('@zkochan/js-yaml').dump(doc ?? {}));
     }
 
+    // Only the project .npmrc exists, with the given contents.
+    function mockProjectNpmrc(contents: string) {
+      jest.resetModules();
+      const fs = require('fs');
+      const npmrcPath = join('/root', '.npmrc');
+      jest
+        .spyOn(fs, 'existsSync')
+        .mockImplementation((p: any) => p === npmrcPath);
+      jest
+        .spyOn(fs, 'readFileSync')
+        .mockImplementation((p: any) => (p === npmrcPath ? contents : ''));
+    }
+
     // Workspace yaml present but unparseable (unterminated flow collection).
     function mockCorruptWorkspaceYaml() {
       jest.resetModules();
@@ -871,6 +885,32 @@ describe('pnpm min-release-age behavior', () => {
       if (result.outcome === 'active') {
         expect(result.policy.windowMs).toBe(1440 * MINUTE);
         expect(result.policy.isExcluded('pkg-a', '1.0.0')).toBe(true);
+      }
+    });
+
+    it('v10 npm_config_ env exclude comma-splits and trims (matches @pnpm/npm-conf)', async () => {
+      mockYaml({ minimumReleaseAge: 1440 });
+      process.env.npm_config_minimum_release_age_exclude = 'nx, @nx/*';
+      const result = await readPnpmPolicy('/root', '10.20.0');
+      expect(result.outcome).toBe('active');
+      if (result.outcome === 'active') {
+        expect(result.policy.isExcluded('nx', '1.0.0')).toBe(true);
+        expect(result.policy.isExcluded('@nx/devkit', '1.0.0')).toBe(true);
+        expect(result.policy.isExcluded('other', '1.0.0')).toBe(false);
+      }
+    });
+
+    it('v10 .npmrc exclude comma-splits (matches @pnpm/npm-conf)', async () => {
+      mockProjectNpmrc(
+        'minimum-release-age=1440\nminimum-release-age-exclude=nx,@nx/*\n'
+      );
+      const result = await readPnpmPolicy('/root', '10.20.0');
+      expect(result.outcome).toBe('active');
+      if (result.outcome === 'active') {
+        expect(result.policy.windowMs).toBe(1440 * MINUTE);
+        expect(result.policy.isExcluded('nx', '1.0.0')).toBe(true);
+        expect(result.policy.isExcluded('@nx/devkit', '1.0.0')).toBe(true);
+        expect(result.policy.isExcluded('other', '1.0.0')).toBe(false);
       }
     });
 

--- a/packages/nx/src/utils/min-release-age/behavior/pnpm.spec.ts
+++ b/packages/nx/src/utils/min-release-age/behavior/pnpm.spec.ts
@@ -1,4 +1,3 @@
-import { join } from 'path';
 import { MinReleaseAgeViolationError } from '../errors';
 import type { RegistryMetadata } from '../packument';
 import type { MinReleaseAgePolicy, PmMinReleaseAgeBehavior } from '../policy';
@@ -530,61 +529,30 @@ describe('pnpm min-release-age behavior', () => {
   });
 
   describe('readPnpmPolicy', () => {
-    let originalEnv: NodeJS.ProcessEnv;
-
-    beforeEach(() => {
-      originalEnv = process.env;
-      process.env = { ...originalEnv };
-      for (const key of Object.keys(process.env)) {
-        if (/^pnpm_config_|^PNPM_CONFIG_|^npm_config_/i.test(key)) {
-          delete process.env[key];
-        }
-      }
-    });
-
     afterEach(() => {
-      process.env = originalEnv;
       jest.restoreAllMocks();
     });
 
-    function mockYaml(doc: Record<string, unknown> | null) {
-      jest.resetModules();
-      const fs = require('fs');
-      jest.spyOn(fs, 'existsSync').mockImplementation((p: any) => {
-        return typeof p === 'string' && p.endsWith('pnpm-workspace.yaml')
-          ? doc !== null
-          : false;
-      });
+    // readPnpmPolicy reads pnpm's resolved config via `pnpm config list --json`,
+    // so mock that single spawn rather than any config surface. Keys use pnpm's
+    // kebab-case form; an exclude array mirrors a yaml surface, a comma-joined
+    // string mirrors .npmrc / env. pnpm itself decides which surface won.
+    function mockPnpmConfig(config: Record<string, unknown> | 'throw') {
       jest
-        .spyOn(fs, 'readFileSync')
-        .mockImplementation(() => require('@zkochan/js-yaml').dump(doc ?? {}));
+        .spyOn(require('child_process'), 'execSync')
+        .mockImplementation(() => {
+          if (config === 'throw') {
+            throw new Error('pnpm config list failed');
+          }
+          return JSON.stringify(config);
+        });
     }
 
-    // Only the project .npmrc exists, with the given contents.
-    function mockProjectNpmrc(contents: string) {
-      jest.resetModules();
-      const fs = require('fs');
-      const npmrcPath = join('/root', '.npmrc');
-      jest
-        .spyOn(fs, 'existsSync')
-        .mockImplementation((p: any) => p === npmrcPath);
-      jest
-        .spyOn(fs, 'readFileSync')
-        .mockImplementation((p: any) => (p === npmrcPath ? contents : ''));
-    }
-
-    // Workspace yaml present but unparseable (unterminated flow collection).
-    function mockCorruptWorkspaceYaml() {
-      jest.resetModules();
-      const fs = require('fs');
-      jest
-        .spyOn(fs, 'existsSync')
-        .mockImplementation(
-          (p: any) => typeof p === 'string' && p.endsWith('pnpm-workspace.yaml')
-        );
-      jest
-        .spyOn(fs, 'readFileSync')
-        .mockReturnValue('minimumReleaseAge: [1, 2');
+    function pnpmBehavior(behavior: PmMinReleaseAgeBehavior) {
+      return behavior as Extract<
+        PmMinReleaseAgeBehavior,
+        { packageManager: 'pnpm' }
+      >;
     }
 
     it('versions below 10.16.0 -> inactive', async () => {
@@ -597,244 +565,129 @@ describe('pnpm min-release-age behavior', () => {
       expect(result.outcome).toBe('ambiguous');
     });
 
-    it('v10 no surfaces set -> inactive', async () => {
-      mockYaml(null);
+    it('unable to read pnpm config -> ambiguous (defer to install)', async () => {
+      mockPnpmConfig('throw');
+      const result = await readPnpmPolicy('/root', '10.16.0');
+      expect(result.outcome).toBe('ambiguous');
+    });
+
+    it('v10 no cooldown configured -> inactive', async () => {
+      mockPnpmConfig({});
       const result = await readPnpmPolicy('/root', '10.16.0');
       expect(result.outcome).toBe('inactive');
     });
 
-    it('v10 workspace yaml window -> active strict', async () => {
-      mockYaml({ minimumReleaseAge: 1440 });
+    it('v10 window -> active strict', async () => {
+      mockPnpmConfig({ 'minimum-release-age': 1440 });
       const result = await readPnpmPolicy('/root', '10.16.0');
       expect(result.outcome).toBe('active');
       if (result.outcome === 'active') {
         expect(result.policy.windowMs).toBe(1440 * MINUTE);
-        const behavior = result.policy.behavior as Extract<
-          PmMinReleaseAgeBehavior,
-          { packageManager: 'pnpm' }
-        >;
+        const behavior = pnpmBehavior(result.policy.behavior);
         expect(behavior.strict).toBe(true);
         expect(behavior.looseFallback).toBe(false);
         expect(behavior.missingTimeMap).toBe('error');
       }
     });
 
-    it('v10 zero window -> inactive (window-zero)', async () => {
-      mockYaml({ minimumReleaseAge: 0 });
+    it('zero window -> inactive', async () => {
+      mockPnpmConfig({ 'minimum-release-age': 0 });
       const result = await readPnpmPolicy('/root', '10.16.0');
       expect(result.outcome).toBe('inactive');
     });
 
-    it('v10 negative window -> inactive (window-negative)', async () => {
-      mockYaml({ minimumReleaseAge: -10 });
+    it('negative window -> inactive', async () => {
+      mockPnpmConfig({ 'minimum-release-age': -10 });
       const result = await readPnpmPolicy('/root', '10.16.0');
       expect(result.outcome).toBe('inactive');
     });
 
-    it('v10 invalid window -> ambiguous (window-invalid)', async () => {
-      mockYaml({ minimumReleaseAge: 'abc' });
-      const result = await readPnpmPolicy('/root', '10.16.0');
-      expect(result.outcome).toBe('ambiguous');
-    });
-
-    it('v10 unparseable workspace yaml -> ambiguous (defer to install)', async () => {
-      mockCorruptWorkspaceYaml();
-      const result = await readPnpmPolicy('/root', '10.16.0');
-      expect(result.outcome).toBe('ambiguous');
-    });
-
-    it('v11 unparseable workspace yaml -> ambiguous (defer to install)', async () => {
-      mockCorruptWorkspaceYaml();
-      const result = await readPnpmPolicy('/root', '11.0.0');
-      expect(result.outcome).toBe('ambiguous');
-    });
-
-    it('v11 no explicit surface -> active loose default 1440', async () => {
-      mockYaml(null);
+    it('v11 no explicit window -> active loose default 1440', async () => {
+      mockPnpmConfig({});
       const result = await readPnpmPolicy('/root', '11.0.0');
       expect(result.outcome).toBe('active');
       if (result.outcome === 'active') {
         expect(result.policy.windowMs).toBe(1440 * MINUTE);
-        expect(result.policy.sourceDescription).toContain('default');
-        const behavior = result.policy.behavior as Extract<
-          PmMinReleaseAgeBehavior,
-          { packageManager: 'pnpm' }
-        >;
+        const behavior = pnpmBehavior(result.policy.behavior);
         expect(behavior.strict).toBe(false);
         expect(behavior.looseFallback).toBe(true);
       }
     });
 
-    // The built-in 1440 default is injected programmatically (not in pnpm's
-    // explicitlySetKeys), so the >=11.0.4 strict auto-on rule must NOT fire on
-    // it - the default stays loose, the normal pnpm 11 state.
+    // The built-in 1440 default is not reported by pnpm's config (only an
+    // explicitly-set window is), so the >=11.0.4 strict auto-on rule must NOT
+    // fire on it - the default stays loose, the normal pnpm 11 state.
     it.each(['11.0.4', '11.1.3', '11.5.2'])(
       'v%s built-in default window stays loose (no strict auto-on)',
       async (version) => {
-        mockYaml(null);
+        mockPnpmConfig({});
         const result = await readPnpmPolicy('/root', version);
         expect(result.outcome).toBe('active');
         if (result.outcome === 'active') {
           expect(result.policy.windowMs).toBe(1440 * MINUTE);
-          expect(result.policy.sourceDescription).toContain('default');
-          const behavior = result.policy.behavior as Extract<
-            PmMinReleaseAgeBehavior,
-            { packageManager: 'pnpm' }
-          >;
+          const behavior = pnpmBehavior(result.policy.behavior);
           expect(behavior.strict).toBe(false);
           expect(behavior.looseFallback).toBe(true);
         }
       }
     );
 
-    it('v11 >=11.0.4 explicit yaml window auto-enables strict', async () => {
-      mockYaml({ minimumReleaseAge: 2880 });
+    it('v11 >=11.0.4 explicit window auto-enables strict', async () => {
+      mockPnpmConfig({ 'minimum-release-age': 2880 });
       const result = await readPnpmPolicy('/root', '11.0.4');
       expect(result.outcome).toBe('active');
       if (result.outcome === 'active') {
-        const behavior = result.policy.behavior as Extract<
-          PmMinReleaseAgeBehavior,
-          { packageManager: 'pnpm' }
-        >;
+        const behavior = pnpmBehavior(result.policy.behavior);
         expect(behavior.strict).toBe(true);
         expect(behavior.looseFallback).toBe(false);
       }
     });
 
     it('v11 >=11.0.4 explicit strict:false stays loose', async () => {
-      mockYaml({ minimumReleaseAge: 2880, minimumReleaseAgeStrict: false });
+      mockPnpmConfig({
+        'minimum-release-age': 2880,
+        'minimum-release-age-strict': false,
+      });
       const result = await readPnpmPolicy('/root', '11.0.4');
       expect(result.outcome).toBe('active');
       if (result.outcome === 'active') {
-        const behavior = result.policy.behavior as Extract<
-          PmMinReleaseAgeBehavior,
-          { packageManager: 'pnpm' }
-        >;
-        expect(behavior.strict).toBe(false);
+        expect(pnpmBehavior(result.policy.behavior).strict).toBe(false);
       }
     });
 
     it('v11.0.0 explicit window does NOT auto-enable strict', async () => {
-      mockYaml({ minimumReleaseAge: 2880 });
+      mockPnpmConfig({ 'minimum-release-age': 2880 });
       const result = await readPnpmPolicy('/root', '11.0.0');
       expect(result.outcome).toBe('active');
       if (result.outcome === 'active') {
-        const behavior = result.policy.behavior as Extract<
-          PmMinReleaseAgeBehavior,
-          { packageManager: 'pnpm' }
-        >;
-        expect(behavior.strict).toBe(false);
+        expect(pnpmBehavior(result.policy.behavior).strict).toBe(false);
       }
     });
 
     it('v11.1.3+ writesExcludes true', async () => {
-      mockYaml({ minimumReleaseAge: 1440 });
+      mockPnpmConfig({ 'minimum-release-age': 1440 });
       const result = await readPnpmPolicy('/root', '11.1.3');
       expect(result.outcome).toBe('active');
       if (result.outcome === 'active') {
-        const behavior = result.policy.behavior as Extract<
-          PmMinReleaseAgeBehavior,
-          { packageManager: 'pnpm' }
-        >;
-        expect(behavior.writesExcludes).toBe(true);
+        expect(pnpmBehavior(result.policy.behavior).writesExcludes).toBe(true);
       }
     });
 
     it('v11.1.2 writesExcludes false', async () => {
-      mockYaml({ minimumReleaseAge: 1440 });
+      mockPnpmConfig({ 'minimum-release-age': 1440 });
       const result = await readPnpmPolicy('/root', '11.1.2');
       expect(result.outcome).toBe('active');
       if (result.outcome === 'active') {
-        const behavior = result.policy.behavior as Extract<
-          PmMinReleaseAgeBehavior,
-          { packageManager: 'pnpm' }
-        >;
-        expect(behavior.writesExcludes).toBe(false);
+        expect(pnpmBehavior(result.policy.behavior).writesExcludes).toBe(false);
       }
     });
 
-    it('v11 lowercase env window beats yaml', async () => {
-      mockYaml({ minimumReleaseAge: 2880 });
-      process.env.pnpm_config_minimum_release_age = '60';
-      const result = await readPnpmPolicy('/root', '11.0.4');
-      expect(result.outcome).toBe('active');
-      if (result.outcome === 'active') {
-        expect(result.policy.windowMs).toBe(60 * MINUTE);
-        expect(result.policy.sourceDescription).toContain('env');
-      }
-    });
-
-    it('v11.0.4 ignores uppercase env (only lowercase honored <11.1.0)', async () => {
-      mockYaml(null);
-      process.env.PNPM_CONFIG_MINIMUM_RELEASE_AGE = '60';
-      const result = await readPnpmPolicy('/root', '11.0.4');
-      // No explicit lowercase surface -> falls to default loose 1440.
-      expect(result.outcome).toBe('active');
-      if (result.outcome === 'active') {
-        expect(result.policy.windowMs).toBe(1440 * MINUTE);
-      }
-    });
-
-    it('v11.1.0 honors uppercase env', async () => {
-      mockYaml(null);
-      process.env.PNPM_CONFIG_MINIMUM_RELEASE_AGE = '60';
-      const result = await readPnpmPolicy('/root', '11.1.0');
-      expect(result.outcome).toBe('active');
-      if (result.outcome === 'active') {
-        expect(result.policy.windowMs).toBe(60 * MINUTE);
-      }
-    });
-
-    // v10 layers config via @pnpm/npm-conf -> reads npm_config_*; pnpm_config_*
-    // is a v11-only surface and dead on v10.
-    it('v10 reads npm_config_minimum_release_age env', async () => {
-      mockYaml(null);
-      process.env.npm_config_minimum_release_age = '120';
-      const result = await readPnpmPolicy('/root', '10.16.0');
-      expect(result.outcome).toBe('active');
-      if (result.outcome === 'active') {
-        expect(result.policy.windowMs).toBe(120 * MINUTE);
-        expect(result.policy.sourceDescription).toContain('env');
-      }
-    });
-
-    it('v10 ignores pnpm_config_minimum_release_age env', async () => {
-      mockYaml(null);
-      process.env.pnpm_config_minimum_release_age = '120';
-      const result = await readPnpmPolicy('/root', '10.16.0');
-      // No npm_config_* / yaml / .npmrc surface -> nothing active on v10.
-      expect(result.outcome).toBe('inactive');
-    });
-
-    // v11 reads pnpm_config_*; npm_config_* is dead on v11.
-    it('v11 ignores npm_config_minimum_release_age env', async () => {
-      mockYaml(null);
-      process.env.npm_config_minimum_release_age = '120';
-      const result = await readPnpmPolicy('/root', '11.0.4');
-      // npm_config_* not read on v11 -> falls to the built-in 1440 default.
-      expect(result.outcome).toBe('active');
-      if (result.outcome === 'active') {
-        expect(result.policy.windowMs).toBe(1440 * MINUTE);
-        expect(result.policy.sourceDescription).toContain('default');
-      }
-    });
-
-    it('v11 reads pnpm_config_minimum_release_age env', async () => {
-      mockYaml(null);
-      process.env.pnpm_config_minimum_release_age = '120';
-      const result = await readPnpmPolicy('/root', '11.0.4');
-      expect(result.outcome).toBe('active');
-      if (result.outcome === 'active') {
-        expect(result.policy.windowMs).toBe(120 * MINUTE);
-        expect(result.policy.sourceDescription).toContain('env');
-      }
-    });
-
-    // pnpm v11's [String, Array] env schema: JSON array first, else the raw
-    // string as ONE entry - never comma-split.
-    it('v11 env exclude accepts a JSON array', async () => {
-      mockYaml(null);
-      process.env.pnpm_config_minimum_release_age_exclude = '["pkg-a","pkg-b"]';
+    // pnpm reports the resolved exclude as a JSON array (set in a yaml surface).
+    it('honors an exclude array from pnpm config', async () => {
+      mockPnpmConfig({
+        'minimum-release-age': 1440,
+        'minimum-release-age-exclude': ['pkg-a', 'pkg-b'],
+      });
       const result = await readPnpmPolicy('/root', '11.5.2');
       expect(result.outcome).toBe('active');
       if (result.outcome === 'active') {
@@ -844,134 +697,53 @@ describe('pnpm min-release-age behavior', () => {
       }
     });
 
-    // pnpm merges surfaces per key: window, excludes, and strict can each come
-    // from a different surface.
-    it('v11 env window combines with yaml excludes and yaml strict', async () => {
-      mockYaml({
-        minimumReleaseAgeExclude: ['pkg-a'],
-        minimumReleaseAgeStrict: false,
+    // pnpm reports the resolved exclude as a comma-joined string (set via
+    // .npmrc / env). This is the ocean case: `minimum-release-age-exclude=nx,@nx/*`.
+    it('honors a comma-joined exclude string from pnpm config', async () => {
+      mockPnpmConfig({
+        'minimum-release-age': 10080,
+        'minimum-release-age-exclude': 'nx,@nx/*',
       });
-      process.env.pnpm_config_minimum_release_age = '60';
-      const result = await readPnpmPolicy('/root', '11.0.4');
+      const result = await readPnpmPolicy('/root', '10.26.1');
       expect(result.outcome).toBe('active');
       if (result.outcome === 'active') {
-        expect(result.policy.windowMs).toBe(60 * MINUTE);
-        expect(result.policy.isExcluded('pkg-a', '1.0.0')).toBe(true);
-        const behavior = result.policy.behavior as Extract<
-          PmMinReleaseAgeBehavior,
-          { packageManager: 'pnpm' }
-        >;
-        // Explicit yaml strict: false beats the >=11.0.4 auto-on rule.
-        expect(behavior.strict).toBe(false);
-      }
-    });
-
-    it('v11 env exclude overrides yaml exclude (per-key replace, not merge)', async () => {
-      mockYaml({ minimumReleaseAgeExclude: ['pkg-a'] });
-      process.env.pnpm_config_minimum_release_age_exclude = '["pkg-b"]';
-      const result = await readPnpmPolicy('/root', '11.5.2');
-      expect(result.outcome).toBe('active');
-      if (result.outcome === 'active') {
-        expect(result.policy.isExcluded('pkg-b', '1.0.0')).toBe(true);
-        expect(result.policy.isExcluded('pkg-a', '1.0.0')).toBe(false);
-      }
-    });
-
-    it('v10 honors minimumReleaseAgeExclude from pnpm-workspace.yaml', async () => {
-      mockYaml({
-        minimumReleaseAge: 1440,
-        minimumReleaseAgeExclude: ['nx', '@nx/*'],
-      });
-      const result = await readPnpmPolicy('/root', '10.20.0');
-      expect(result.outcome).toBe('active');
-      if (result.outcome === 'active') {
-        expect(result.policy.windowMs).toBe(1440 * MINUTE);
         expect(result.policy.isExcluded('nx', '1.0.0')).toBe(true);
         expect(result.policy.isExcluded('@nx/devkit', '1.0.0')).toBe(true);
         expect(result.policy.isExcluded('other', '1.0.0')).toBe(false);
       }
     });
 
-    // pnpm v10 reads the cooldown WINDOW from npm_config_*, but NOT the exclude
-    // list - minimumReleaseAgeExclude is wired up only from pnpm-workspace.yaml.
-    // Verified against pnpm 10.x: an .npmrc/npm_config_* exclude does not bypass
-    // the gate. Mirror that so nx never resolves a version pnpm would still gate.
-    it('v10 ignores minimumReleaseAgeExclude from npm_config_ env', async () => {
-      mockYaml({ minimumReleaseAge: 1440 });
-      process.env.npm_config_minimum_release_age_exclude = 'nx';
-      const result = await readPnpmPolicy('/root', '10.20.0');
-      expect(result.outcome).toBe('active');
-      if (result.outcome === 'active') {
-        expect(result.policy.windowMs).toBe(1440 * MINUTE);
-        expect(result.policy.isExcluded('nx', '1.0.0')).toBe(false);
-      }
-    });
-
-    it('v10 reads the .npmrc window but ignores its exclude list', async () => {
-      mockProjectNpmrc(
-        'minimum-release-age=1440\nminimum-release-age-exclude=nx,@nx/*\n'
-      );
-      const result = await readPnpmPolicy('/root', '10.20.0');
-      expect(result.outcome).toBe('active');
-      if (result.outcome === 'active') {
-        // window from .npmrc is honored...
-        expect(result.policy.windowMs).toBe(1440 * MINUTE);
-        // ...but the exclude is not (pnpm v10 only honors it from the yaml).
-        expect(result.policy.isExcluded('nx', '1.0.0')).toBe(false);
-        expect(result.policy.isExcluded('@nx/devkit', '1.0.0')).toBe(false);
-      }
-    });
-
-    it('v11 env exclude treats a non-JSON value as a single entry', async () => {
-      mockYaml(null);
-      process.env.pnpm_config_minimum_release_age_exclude = 'pkg-a,pkg-b';
-      const result = await readPnpmPolicy('/root', '11.5.2');
-      expect(result.outcome).toBe('active');
-      if (result.outcome === 'active') {
-        // Not comma-split: neither bare name matches the literal entry.
-        expect(result.policy.isExcluded('pkg-a', '2.0.0')).toBe(false);
-        expect(result.policy.isExcluded('pkg-b', '1.0.0')).toBe(false);
-      }
-    });
-
-    // pnpm passes a JSON array with a non-string element verbatim, then errors at
-    // install (ERR_PNPM_INVALID_MINIMUM_RELEASE_AGE_EXCLUDE); nx defers rather
-    // than mimic the crash.
-    it('v11 env exclude JSON array with a non-string element -> ambiguous', async () => {
-      mockYaml(null);
-      process.env.pnpm_config_minimum_release_age_exclude = '["pkg-a", 123]';
+    // An entry pnpm's version-policy grammar rejects (a range in a version
+    // union) is a version-dependent landmine; nx defers rather than crash.
+    it('invalid exclude entry -> ambiguous (defer to install)', async () => {
+      mockPnpmConfig({
+        'minimum-release-age': 1440,
+        'minimum-release-age-exclude': ['pkg-a@^1.0.0'],
+      });
       const result = await readPnpmPolicy('/root', '11.5.2');
       expect(result.outcome).toBe('ambiguous');
     });
 
-    // pnpm's Boolean env schema yields true/false only for the literals; a
-    // malformed value drops the key, so the >=11.0.4 explicit-window strict
-    // auto-on still fires (the env doesn't force strict off).
-    it('v11 malformed strict env value falls through (auto-on still applies)', async () => {
-      mockYaml({ minimumReleaseAge: 2880 });
-      process.env.pnpm_config_minimum_release_age_strict = '1';
-      const result = await readPnpmPolicy('/root', '11.0.4');
+    it('v11 ignoreMissingTime defaults to skip; explicit false errors', async () => {
+      mockPnpmConfig({ 'minimum-release-age': 1440 });
+      let result = await readPnpmPolicy('/root', '11.5.2');
       expect(result.outcome).toBe('active');
       if (result.outcome === 'active') {
-        const behavior = result.policy.behavior as Extract<
-          PmMinReleaseAgeBehavior,
-          { packageManager: 'pnpm' }
-        >;
-        expect(behavior.strict).toBe(true);
+        expect(pnpmBehavior(result.policy.behavior).missingTimeMap).toBe(
+          'skip'
+        );
       }
-    });
 
-    it('v11 explicit strict:false env beats the >=11.0.4 auto-on rule', async () => {
-      mockYaml({ minimumReleaseAge: 2880 });
-      process.env.pnpm_config_minimum_release_age_strict = 'false';
-      const result = await readPnpmPolicy('/root', '11.0.4');
+      mockPnpmConfig({
+        'minimum-release-age': 1440,
+        'minimum-release-age-ignore-missing-time': false,
+      });
+      result = await readPnpmPolicy('/root', '11.5.2');
       expect(result.outcome).toBe('active');
       if (result.outcome === 'active') {
-        const behavior = result.policy.behavior as Extract<
-          PmMinReleaseAgeBehavior,
-          { packageManager: 'pnpm' }
-        >;
-        expect(behavior.strict).toBe(false);
+        expect(pnpmBehavior(result.policy.behavior).missingTimeMap).toBe(
+          'error'
+        );
       }
     });
   });
@@ -1023,37 +795,18 @@ describe('pnpm min-release-age behavior', () => {
   });
 
   describe('exclude grammar (via readPnpmPolicy.isExcluded)', () => {
-    let originalEnv: NodeJS.ProcessEnv;
-
-    beforeEach(() => {
-      originalEnv = process.env;
-      process.env = { ...originalEnv };
-      for (const key of Object.keys(process.env)) {
-        if (/^pnpm_config_|^PNPM_CONFIG_|^npm_config_/i.test(key)) {
-          delete process.env[key];
-        }
-      }
-    });
-
     afterEach(() => {
-      process.env = originalEnv;
       jest.restoreAllMocks();
     });
 
-    function mockYaml(doc: Record<string, unknown>) {
-      const fs = require('fs');
-      jest
-        .spyOn(fs, 'existsSync')
-        .mockImplementation(
-          (p: any) => typeof p === 'string' && p.endsWith('pnpm-workspace.yaml')
-        );
-      jest
-        .spyOn(fs, 'readFileSync')
-        .mockImplementation(() => require('@zkochan/js-yaml').dump(doc));
-    }
-
     async function excludeFor(version: string, doc: Record<string, unknown>) {
-      mockYaml(doc);
+      // pnpm reports a yaml-set exclude as a JSON array via `config list --json`.
+      jest.spyOn(require('child_process'), 'execSync').mockReturnValue(
+        JSON.stringify({
+          'minimum-release-age': doc.minimumReleaseAge,
+          'minimum-release-age-exclude': doc.minimumReleaseAgeExclude,
+        })
+      );
       const result = await readPnpmPolicy('/root', version);
       if (result.outcome !== 'active') {
         return result.outcome;

--- a/packages/nx/src/utils/min-release-age/behavior/pnpm.spec.ts
+++ b/packages/nx/src/utils/min-release-age/behavior/pnpm.spec.ts
@@ -877,40 +877,48 @@ describe('pnpm min-release-age behavior', () => {
       }
     });
 
-    it('v10 yaml window combines with npm_config_ env excludes', async () => {
-      mockYaml({ minimumReleaseAge: 1440 });
-      process.env.npm_config_minimum_release_age_exclude = 'pkg-a';
+    it('v10 honors minimumReleaseAgeExclude from pnpm-workspace.yaml', async () => {
+      mockYaml({
+        minimumReleaseAge: 1440,
+        minimumReleaseAgeExclude: ['nx', '@nx/*'],
+      });
       const result = await readPnpmPolicy('/root', '10.20.0');
       expect(result.outcome).toBe('active');
       if (result.outcome === 'active') {
         expect(result.policy.windowMs).toBe(1440 * MINUTE);
-        expect(result.policy.isExcluded('pkg-a', '1.0.0')).toBe(true);
-      }
-    });
-
-    it('v10 npm_config_ env exclude comma-splits and trims (matches @pnpm/npm-conf)', async () => {
-      mockYaml({ minimumReleaseAge: 1440 });
-      process.env.npm_config_minimum_release_age_exclude = 'nx, @nx/*';
-      const result = await readPnpmPolicy('/root', '10.20.0');
-      expect(result.outcome).toBe('active');
-      if (result.outcome === 'active') {
         expect(result.policy.isExcluded('nx', '1.0.0')).toBe(true);
         expect(result.policy.isExcluded('@nx/devkit', '1.0.0')).toBe(true);
         expect(result.policy.isExcluded('other', '1.0.0')).toBe(false);
       }
     });
 
-    it('v10 .npmrc exclude comma-splits (matches @pnpm/npm-conf)', async () => {
+    // pnpm v10 reads the cooldown WINDOW from npm_config_*, but NOT the exclude
+    // list - minimumReleaseAgeExclude is wired up only from pnpm-workspace.yaml.
+    // Verified against pnpm 10.x: an .npmrc/npm_config_* exclude does not bypass
+    // the gate. Mirror that so nx never resolves a version pnpm would still gate.
+    it('v10 ignores minimumReleaseAgeExclude from npm_config_ env', async () => {
+      mockYaml({ minimumReleaseAge: 1440 });
+      process.env.npm_config_minimum_release_age_exclude = 'nx';
+      const result = await readPnpmPolicy('/root', '10.20.0');
+      expect(result.outcome).toBe('active');
+      if (result.outcome === 'active') {
+        expect(result.policy.windowMs).toBe(1440 * MINUTE);
+        expect(result.policy.isExcluded('nx', '1.0.0')).toBe(false);
+      }
+    });
+
+    it('v10 reads the .npmrc window but ignores its exclude list', async () => {
       mockProjectNpmrc(
         'minimum-release-age=1440\nminimum-release-age-exclude=nx,@nx/*\n'
       );
       const result = await readPnpmPolicy('/root', '10.20.0');
       expect(result.outcome).toBe('active');
       if (result.outcome === 'active') {
+        // window from .npmrc is honored...
         expect(result.policy.windowMs).toBe(1440 * MINUTE);
-        expect(result.policy.isExcluded('nx', '1.0.0')).toBe(true);
-        expect(result.policy.isExcluded('@nx/devkit', '1.0.0')).toBe(true);
-        expect(result.policy.isExcluded('other', '1.0.0')).toBe(false);
+        // ...but the exclude is not (pnpm v10 only honors it from the yaml).
+        expect(result.policy.isExcluded('nx', '1.0.0')).toBe(false);
+        expect(result.policy.isExcluded('@nx/devkit', '1.0.0')).toBe(false);
       }
     });
 

--- a/packages/nx/src/utils/min-release-age/behavior/pnpm.ts
+++ b/packages/nx/src/utils/min-release-age/behavior/pnpm.ts
@@ -1,6 +1,4 @@
-import { existsSync, readFileSync } from 'fs';
-import { homedir } from 'os';
-import { basename, join } from 'path';
+import { execSync } from 'child_process';
 import {
   gte,
   maxSatisfying,
@@ -11,7 +9,6 @@ import {
 } from 'semver';
 import { MS_PER_DAY, MS_PER_MINUTE } from '../constants';
 import { MinReleaseAgeViolationError } from '../errors';
-import { readNpmrcEntries } from '../npmrc';
 import type { RegistryMetadata } from '../packument';
 import {
   blockedVersionsFrom,
@@ -42,8 +39,6 @@ interface PnpmBehaviorRow {
   strictAutoOnWhenExplicit: boolean;
   excludeGrammar: 'v1-exact-names' | 'v2-globs-unions';
   writesExcludes: boolean;
-  // v11.1.0+ also reads uppercase PNPM_CONFIG_* env vars.
-  uppercaseEnv: boolean;
 }
 
 // Ordered newest-bound-first so the first matching row applies.
@@ -55,7 +50,6 @@ const PNPM_BEHAVIOR_ROWS: PnpmBehaviorRow[] = [
     strictAutoOnWhenExplicit: true,
     excludeGrammar: 'v2-globs-unions',
     writesExcludes: true,
-    uppercaseEnv: true,
   },
   {
     minVersion: '11.1.0',
@@ -64,7 +58,6 @@ const PNPM_BEHAVIOR_ROWS: PnpmBehaviorRow[] = [
     strictAutoOnWhenExplicit: true,
     excludeGrammar: 'v2-globs-unions',
     writesExcludes: false,
-    uppercaseEnv: true,
   },
   {
     minVersion: '11.0.4',
@@ -73,7 +66,6 @@ const PNPM_BEHAVIOR_ROWS: PnpmBehaviorRow[] = [
     strictAutoOnWhenExplicit: true,
     excludeGrammar: 'v2-globs-unions',
     writesExcludes: false,
-    uppercaseEnv: false,
   },
   {
     minVersion: '11.0.0',
@@ -82,7 +74,6 @@ const PNPM_BEHAVIOR_ROWS: PnpmBehaviorRow[] = [
     strictAutoOnWhenExplicit: false,
     excludeGrammar: 'v2-globs-unions',
     writesExcludes: false,
-    uppercaseEnv: false,
   },
   {
     minVersion: '10.19.0',
@@ -91,7 +82,6 @@ const PNPM_BEHAVIOR_ROWS: PnpmBehaviorRow[] = [
     strictAutoOnWhenExplicit: false,
     excludeGrammar: 'v2-globs-unions',
     writesExcludes: false,
-    uppercaseEnv: false,
   },
   {
     minVersion: '10.16.0',
@@ -100,7 +90,6 @@ const PNPM_BEHAVIOR_ROWS: PnpmBehaviorRow[] = [
     strictAutoOnWhenExplicit: false,
     excludeGrammar: 'v1-exact-names',
     writesExcludes: false,
-    uppercaseEnv: false,
   },
 ];
 
@@ -108,50 +97,89 @@ function findBehaviorRow(pmVersion: string): PnpmBehaviorRow | undefined {
   return PNPM_BEHAVIOR_ROWS.find((row) => gte(pmVersion, row.minVersion));
 }
 
-// A single resolved cooldown window plus its excludes, tagged with where the
-// window came from for messaging.
-interface WindowResolution {
-  kind: 'ok';
-  windowMinutes: number;
+// pnpm's effective minimum-release-age configuration, as pnpm itself resolves it.
+interface PnpmCooldownConfig {
+  // undefined when no surface set the window, so the caller can apply pnpm's
+  // version-specific default.
+  windowMinutes: number | undefined;
   excludes: string[];
-  sourceDescription: string;
-  // True when the window came from a real surface (env/yaml/global/.npmrc);
-  // false only for the invisible built-in 1440 default. Drives the >=11.0.4
-  // strict auto-on rule, which fires only on an explicitly set window.
-  windowExplicit: boolean;
+  strictExplicit: boolean | undefined;
+  ignoreMissingTimeExplicit: boolean | undefined;
 }
 
-// Sentinel for an unparseable surface value. A discriminant (rather than a bare
-// `{ invalid }` shape) is required because nx builds with strictNullChecks off,
-// where `in`/equality narrowing does not subtract object union members.
-interface InvalidWindow {
-  kind: 'invalid';
-  reason: string;
+// Asks pnpm for its own resolved config rather than re-deriving how pnpm layers
+// .npmrc / env / pnpm-workspace.yaml / global config across versions. Returns
+// null if pnpm cannot be run or its output is not parseable JSON, so the caller
+// defers to a real install.
+function readPnpmConfigList(root: string): Record<string, unknown> | null {
+  let raw: string;
+  try {
+    raw = execSync('pnpm config list --json', {
+      cwd: root,
+      encoding: 'utf-8',
+      windowsHide: true,
+      stdio: ['ignore', 'pipe', 'ignore'],
+    });
+  } catch {
+    return null;
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    return parsed && typeof parsed === 'object'
+      ? (parsed as Record<string, unknown>)
+      : null;
+  } catch {
+    return null;
+  }
 }
 
-// Builds a resolved cooldown window, tagging it with the surface label used in
-// messaging. windowExplicit is false only for the invisible built-in default.
-function okWindow(
-  windowMinutes: number,
-  excludes: string[],
-  source: string,
-  windowExplicit = true
-): WindowResolution {
+// Extracts the cooldown keys from pnpm's reported config. pnpm reports the
+// kebab-case keys; the exclude list comes back as a JSON array (set in a yaml
+// surface) or a comma-joined string (set via .npmrc / env).
+function parseCooldownConfig(
+  config: Record<string, unknown>
+): PnpmCooldownConfig {
   return {
-    kind: 'ok',
-    windowMinutes,
-    excludes,
-    sourceDescription: `pnpm minimumReleaseAge (${windowMinutes} min, ${source})`,
-    windowExplicit,
+    windowMinutes: toNumber(config['minimum-release-age']) ?? undefined,
+    excludes: parseExcludeValue(config['minimum-release-age-exclude']),
+    strictExplicit: toBoolean(config['minimum-release-age-strict']),
+    ignoreMissingTimeExplicit: toBoolean(
+      config['minimum-release-age-ignore-missing-time']
+    ),
   };
 }
 
+function parseExcludeValue(value: unknown): string[] {
+  const entries = Array.isArray(value)
+    ? value.map((entry) => String(entry))
+    : typeof value === 'string'
+      ? value.split(',')
+      : [];
+  return entries
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
+}
+
+function toBoolean(value: unknown): boolean | undefined {
+  if (typeof value === 'boolean') {
+    return value;
+  }
+  if (value === 'true') {
+    return true;
+  }
+  if (value === 'false') {
+    return false;
+  }
+  return undefined;
+}
+
 /**
- * Reads pnpm's effective cooldown configuration once. The surface set and
- * precedence depend on the pnpm major: v10 layers npm-conf surfaces
- * (workspace yaml > npm_config env > project .npmrc > user .npmrc); v11
- * layers pnpm-native surfaces (pnpm_config / PNPM_CONFIG env >
- * pnpm-workspace.yaml > global config.yaml > built-in 1440-minute default).
+ * Reads pnpm's effective cooldown configuration once by asking pnpm itself
+ * (`pnpm config list --json`) instead of re-implementing how it layers config
+ * surfaces (a moving target across pnpm versions). The window and excludes come
+ * straight from pnpm; the strict default, exclude grammar, and loose-fallback
+ * semantics stay version-keyed because pnpm does not report those resolved
+ * values.
  */
 export async function readPnpmPolicy(
   root: string,
@@ -171,35 +199,37 @@ export async function readPnpmPolicy(
     return { outcome: 'inactive' };
   }
 
-  let resolution: WindowResolution | InvalidWindow | null;
-  let strictExplicit: boolean | undefined;
-  let ignoreMissingTimeExplicit: boolean | undefined;
-  if (row.major === 11) {
-    const read = readV11Surfaces(root, row);
-    resolution = read.window;
-    strictExplicit = read.strictExplicit;
-    ignoreMissingTimeExplicit = read.ignoreMissingTime;
-  } else {
-    resolution = readV10Surfaces(root);
-    // v10 strict is hardcoded; no surface toggles it.
-    strictExplicit = undefined;
-  }
-
-  if (!resolution) {
-    return { outcome: 'inactive' };
-  }
-  if (resolution.kind !== 'ok') {
-    return { outcome: 'ambiguous', reason: resolution.reason };
-  }
-
-  const { windowMinutes, excludes, sourceDescription, windowExplicit } =
-    resolution;
-  if (!Number.isFinite(windowMinutes)) {
+  const config = readPnpmConfigList(root);
+  if (config === null) {
+    // Could not read pnpm's resolved config; defer to a real install rather than
+    // guess the policy.
     return {
       outcome: 'ambiguous',
-      reason: `Invalid pnpm minimumReleaseAge value: ${String(windowMinutes)}.`,
+      reason: 'Unable to read the pnpm minimum-release-age configuration.',
     };
   }
+  const {
+    windowMinutes: explicitWindow,
+    excludes,
+    strictExplicit,
+    ignoreMissingTimeExplicit,
+  } = parseCooldownConfig(config);
+
+  // An explicitly configured window (from whatever surface pnpm honors) wins;
+  // otherwise v11 falls back to its built-in 1440-minute (1 day) default, while
+  // v10 has no default (no cooldown).
+  let windowMinutes: number;
+  let windowExplicit: boolean;
+  if (explicitWindow !== undefined) {
+    windowMinutes = explicitWindow;
+    windowExplicit = true;
+  } else if (row.major === 11) {
+    windowMinutes = 1440;
+    windowExplicit = false;
+  } else {
+    return { outcome: 'inactive' };
+  }
+
   // 0 disables; negatives push the cutoff into the future -> everything passes.
   if (windowMinutes <= 0) {
     return { outcome: 'inactive' };
@@ -207,6 +237,7 @@ export async function readPnpmPolicy(
 
   const windowMs = windowMinutes * MS_PER_MINUTE;
   const cutoffMs = Date.now() - windowMs;
+  const sourceDescription = `pnpm minimumReleaseAge (${windowMinutes} min)`;
 
   const strict = resolveStrict(row, strictExplicit, windowExplicit);
   // v10 always errors on missing time; v11 defaults to skip unless a surface
@@ -263,344 +294,6 @@ function resolveStrict(
   return row.strictAutoOnWhenExplicit && windowExplicit;
 }
 
-// --- v11 surfaces -----------------------------------------------------------
-
-function readV11Surfaces(
-  root: string,
-  row: PnpmBehaviorRow
-): {
-  window: WindowResolution | InvalidWindow | null;
-  strictExplicit: boolean | undefined;
-  ignoreMissingTime: boolean | undefined;
-} {
-  const env = process.env;
-  const keySet = envKeySetForMajor(row);
-
-  const wsRead = readYamlWindow(join(root, 'pnpm-workspace.yaml'));
-  if (wsRead && wsRead.kind === 'invalid') {
-    return {
-      window: wsRead,
-      strictExplicit: undefined,
-      ignoreMissingTime: undefined,
-    };
-  }
-  const globalRead = readYamlWindow(join(getConfigDir(env), 'config.yaml'));
-  if (globalRead && globalRead.kind === 'invalid') {
-    return {
-      window: globalRead,
-      strictExplicit: undefined,
-      ignoreMissingTime: undefined,
-    };
-  }
-  const wsYaml = wsRead && wsRead.kind === 'ok' ? wsRead : null;
-  const globalYaml = globalRead && globalRead.kind === 'ok' ? globalRead : null;
-
-  // pnpm v11 resolves each cooldown key independently across surfaces:
-  // env > pnpm-workspace.yaml > global config.yaml > built-in default.
-  const strictExplicit =
-    readEnvBoolean(env, keySet, 'minimum_release_age_strict') ??
-    wsYaml?.strict ??
-    globalYaml?.strict;
-  const ignoreMissingTime =
-    readEnvBoolean(env, keySet, 'minimum_release_age_ignore_missing_time') ??
-    wsYaml?.ignoreMissingTime ??
-    globalYaml?.ignoreMissingTime;
-  const envExcludes = readEnvArray(env, keySet, 'minimum_release_age_exclude');
-  if (envExcludes === 'invalid') {
-    return {
-      window: {
-        kind: 'invalid',
-        reason: 'Invalid pnpm minimumReleaseAgeExclude entry.',
-      },
-      strictExplicit: undefined,
-      ignoreMissingTime: undefined,
-    };
-  }
-  const excludes =
-    envExcludes ?? wsYaml?.excludes ?? globalYaml?.excludes ?? [];
-
-  const envWindow = readEnvNumber(env, keySet, 'minimum_release_age');
-  // pnpm drops a NaN env value rather than erroring; treat 'invalid' as unset
-  // and fall through to lower surfaces.
-  if (envWindow !== undefined && envWindow !== 'invalid') {
-    return {
-      window: okWindow(envWindow, excludes, 'env'),
-      strictExplicit,
-      ignoreMissingTime,
-    };
-  }
-  if (wsYaml && wsYaml.windowMinutes !== undefined) {
-    return {
-      window: okWindow(wsYaml.windowMinutes, excludes, 'pnpm-workspace.yaml'),
-      strictExplicit,
-      ignoreMissingTime,
-    };
-  }
-  if (globalYaml && globalYaml.windowMinutes !== undefined) {
-    return {
-      window: okWindow(
-        globalYaml.windowMinutes,
-        excludes,
-        'global config.yaml'
-      ),
-      strictExplicit,
-      ignoreMissingTime,
-    };
-  }
-
-  // Built-in 1440-minute (1 day) default, injected programmatically and
-  // invisible to `pnpm config get`. Loose unless some surface set strict.
-  return {
-    window: okWindow(1440, excludes, 'default', false),
-    strictExplicit,
-    ignoreMissingTime,
-  };
-}
-
-// --- v10 surfaces -----------------------------------------------------------
-
-function readV10Surfaces(
-  root: string
-): WindowResolution | InvalidWindow | null {
-  // v10 layers the cooldown WINDOW via @pnpm/npm-conf, per key:
-  // workspace yaml > npm_config_* env > project .npmrc > user .npmrc.
-  const wsRead = readYamlWindow(join(root, 'pnpm-workspace.yaml'));
-  if (wsRead && wsRead.kind === 'invalid') {
-    return wsRead;
-  }
-  const wsYaml = wsRead && wsRead.kind === 'ok' ? wsRead : null;
-
-  const env = process.env;
-  const keySet: EnvKeySet = { prefix: 'npm_config_', uppercase: false };
-  const rawEnvWindow = readEnvNumber(env, keySet, 'minimum_release_age');
-  // npm-conf drops values that fail the Number type; treat as unset.
-  const envWindow = rawEnvWindow === 'invalid' ? undefined : rawEnvWindow;
-
-  const projectNpmrc = readNpmrcSurface(join(root, '.npmrc'));
-  const userNpmrc = readNpmrcSurface(join(homedir(), '.npmrc'));
-
-  // The EXCLUDE list is honored only from pnpm-workspace.yaml on v10. Verified
-  // empirically against pnpm 10.x (and the @pnpm/npm-conf source): a real
-  // `pnpm install` ignores minimumReleaseAgeExclude set in .npmrc or
-  // npm_config_* - only the cooldown window is read from those surfaces. So nx
-  // must NOT honor an exclude pnpm itself drops, or it would resolve a fresh
-  // version the user's pnpm would still gate.
-  const excludes = wsYaml?.excludes ?? [];
-
-  if (wsYaml && wsYaml.windowMinutes !== undefined) {
-    return okWindow(wsYaml.windowMinutes, excludes, 'pnpm-workspace.yaml');
-  }
-  if (envWindow !== undefined) {
-    return okWindow(envWindow, excludes, 'env');
-  }
-  for (const npmrc of [projectNpmrc, userNpmrc]) {
-    if (npmrc && npmrc.windowMinutes !== undefined) {
-      return okWindow(npmrc.windowMinutes, excludes, '.npmrc');
-    }
-  }
-
-  return null;
-}
-
-// --- surface parsers --------------------------------------------------------
-
-interface YamlWindow {
-  kind: 'ok';
-  windowMinutes?: number;
-  // undefined when the key is absent, so per-key precedence can fall through
-  // to a lower surface.
-  excludes?: string[];
-  strict?: boolean;
-  ignoreMissingTime?: boolean;
-}
-
-function readYamlRaw(path: string): Record<string, unknown> | 'invalid' | null {
-  if (!existsSync(path)) {
-    return null;
-  }
-  try {
-    const { load } = require('@zkochan/js-yaml');
-    return (load(readFileSync(path, 'utf-8')) as Record<string, unknown>) ?? {};
-  } catch {
-    // The file exists but is unparseable. An absent file falls through to lower
-    // surfaces; a corrupt one can't be reasoned about, so signal it and let the
-    // caller defer to a real install (matching npm/yarn/bun on a read failure).
-    return 'invalid';
-  }
-}
-
-function readYamlWindow(path: string): YamlWindow | InvalidWindow | null {
-  const doc = readYamlRaw(path);
-  if (doc === 'invalid') {
-    return { kind: 'invalid', reason: `Unable to parse ${basename(path)}.` };
-  }
-  if (!doc) {
-    return null;
-  }
-  // Each key is read independently; pnpm merges surfaces per key.
-  const excludes = readArrayKey(doc, 'minimumReleaseAgeExclude');
-  const strict = readBooleanKey(doc, 'minimumReleaseAgeStrict');
-  const ignoreMissingTime = readBooleanKey(
-    doc,
-    'minimumReleaseAgeIgnoreMissingTime'
-  );
-  const raw = doc['minimumReleaseAge'];
-  if (raw === undefined || raw === null) {
-    return { kind: 'ok', excludes, strict, ignoreMissingTime };
-  }
-  const num = toNumber(raw);
-  if (num === null) {
-    return {
-      kind: 'invalid',
-      reason: `Invalid pnpm minimumReleaseAge value: ${String(raw)}.`,
-    };
-  }
-  return {
-    kind: 'ok',
-    windowMinutes: num,
-    excludes,
-    strict,
-    ignoreMissingTime,
-  };
-}
-
-function readNpmrcSurface(path: string): { windowMinutes?: number } | null {
-  const entries = readNpmrcEntries(path);
-  if (entries === null) {
-    return null;
-  }
-  // v10 reads the kebab-case window via npm-conf; camelCase in .npmrc is never
-  // honored. Only the window is read here: pnpm does NOT honor
-  // minimumReleaseAgeExclude from .npmrc or npm_config_* - the exclude list is
-  // only wired up from pnpm-workspace.yaml (see readV10Surfaces).
-  let windowMinutes: number | undefined;
-  for (const { key, value: rawValue } of entries) {
-    if (key === 'minimum-release-age') {
-      const num = toNumber(stripQuotes(rawValue));
-      if (num !== null) {
-        windowMinutes = num;
-      }
-    }
-  }
-  return { windowMinutes };
-}
-
-// pnpm mirrors getConfigDir: XDG_CONFIG_HOME, else per-platform default.
-function getConfigDir(env: NodeJS.ProcessEnv): string {
-  if (env.XDG_CONFIG_HOME) {
-    return join(env.XDG_CONFIG_HOME, 'pnpm');
-  }
-  if (process.platform === 'darwin') {
-    return join(homedir(), 'Library/Preferences/pnpm');
-  }
-  if (process.platform !== 'win32') {
-    return join(homedir(), '.config/pnpm');
-  }
-  if (env.LOCALAPPDATA) {
-    return join(env.LOCALAPPDATA, 'pnpm/config');
-  }
-  return join(homedir(), '.config/pnpm');
-}
-
-// --- env helpers ------------------------------------------------------------
-
-// Which env surface a pnpm major honors. v10 layers config via @pnpm/npm-conf,
-// which reads `npm_config_*`; `pnpm_config_*` is dead there. v11 reads
-// `pnpm_config_*` (and uppercase `PNPM_CONFIG_*` only >=11.1.0); `npm_config_*`
-// is dead there.
-interface EnvKeySet {
-  prefix: 'pnpm_config_' | 'npm_config_';
-  uppercase: boolean;
-}
-
-function envKeySetForMajor(row: PnpmBehaviorRow): EnvKeySet {
-  return row.major === 11
-    ? { prefix: 'pnpm_config_', uppercase: row.uppercaseEnv }
-    : { prefix: 'npm_config_', uppercase: false };
-}
-
-function envKeys(keySet: EnvKeySet, suffix: string): string[] {
-  const keys = [`${keySet.prefix}${suffix}`];
-  if (keySet.uppercase) {
-    keys.push(`${keySet.prefix.toUpperCase()}${suffix.toUpperCase()}`);
-  }
-  return keys;
-}
-
-function readEnvRaw(
-  env: NodeJS.ProcessEnv,
-  keySet: EnvKeySet,
-  suffix: string
-): string | undefined {
-  for (const key of envKeys(keySet, suffix)) {
-    if (env[key] !== undefined) {
-      return env[key];
-    }
-  }
-  return undefined;
-}
-
-function readEnvNumber(
-  env: NodeJS.ProcessEnv,
-  keySet: EnvKeySet,
-  suffix: string
-): number | 'invalid' | undefined {
-  const raw = readEnvRaw(env, keySet, suffix);
-  if (raw === undefined) {
-    return undefined;
-  }
-  const num = toNumber(raw);
-  // pnpm parses env values via Number(); NaN drops the key.
-  return num === null ? 'invalid' : num;
-}
-
-function readEnvBoolean(
-  env: NodeJS.ProcessEnv,
-  keySet: EnvKeySet,
-  suffix: string
-): boolean | undefined {
-  const raw = readEnvRaw(env, keySet, suffix);
-  // pnpm's Boolean env schema (config/reader/src/env.ts) yields only true/false
-  // for the literals; anything else drops the key, so the value falls through to
-  // lower surfaces / defaults instead of coercing to false.
-  if (raw === 'true') {
-    return true;
-  }
-  if (raw === 'false') {
-    return false;
-  }
-  return undefined;
-}
-
-function readEnvArray(
-  env: NodeJS.ProcessEnv,
-  keySet: EnvKeySet,
-  suffix: string
-): string[] | 'invalid' | undefined {
-  const raw = readEnvRaw(env, keySet, suffix);
-  if (raw === undefined) {
-    return undefined;
-  }
-  // Only v11's pnpm_config_* env feeds the exclude list (pnpm does not honor a
-  // v10 npm_config_* exclude). pnpm v11's [String, Array] env schema tries a
-  // JSON array first, then falls back to the raw value as a single entry - never
-  // comma-split.
-  try {
-    const parsed = JSON.parse(raw);
-    if (Array.isArray(parsed)) {
-      // pnpm passes the array verbatim, then errors at install
-      // (ERR_PNPM_INVALID_MINIMUM_RELEASE_AGE_EXCLUDE) on any non-string
-      // element; signal invalid so the caller defers to a real install.
-      return parsed.every((e) => typeof e === 'string')
-        ? (parsed as string[])
-        : 'invalid';
-    }
-  } catch {}
-  return [raw];
-}
-
-// --- value helpers ----------------------------------------------------------
-
 function toNumber(value: unknown): number | null {
   if (typeof value === 'number') {
     return Number.isFinite(value) ? value : null;
@@ -614,47 +307,6 @@ function toNumber(value: unknown): number | null {
     return Number.isFinite(num) ? num : null;
   }
   return null;
-}
-
-function stripQuotes(value: string): string {
-  if (
-    (value.startsWith('"') && value.endsWith('"')) ||
-    (value.startsWith("'") && value.endsWith("'"))
-  ) {
-    return value.slice(1, -1);
-  }
-  return value;
-}
-
-function readArrayKey(
-  doc: Record<string, unknown>,
-  key: string
-): string[] | undefined {
-  const value = doc[key];
-  if (Array.isArray(value)) {
-    return value.map((v) => String(v));
-  }
-  if (typeof value === 'string') {
-    return [value];
-  }
-  return undefined;
-}
-
-function readBooleanKey(
-  doc: Record<string, unknown>,
-  key: string
-): boolean | undefined {
-  const value = doc[key];
-  if (typeof value === 'boolean') {
-    return value;
-  }
-  if (value === 'true') {
-    return true;
-  }
-  if (value === 'false') {
-    return false;
-  }
-  return undefined;
 }
 
 // --- excludes ---------------------------------------------------------------

--- a/packages/nx/src/utils/min-release-age/behavior/pnpm.ts
+++ b/packages/nx/src/utils/min-release-age/behavior/pnpm.ts
@@ -485,8 +485,9 @@ function readNpmrcSurface(
         windowMinutes = num;
       }
     } else if (key === 'minimum-release-age-exclude') {
-      // npm-conf accumulates repeated ini keys into an array.
-      (excludes ??= []).push(value);
+      // npm-conf accumulates repeated ini keys AND comma-splits each value, so
+      // `a,b` on one line and two separate `=` lines are equivalent.
+      (excludes ??= []).push(...splitNpmConfList(value));
     }
   }
   return { windowMinutes, excludes };
@@ -589,7 +590,7 @@ function readEnvArray(
     return undefined;
   }
   // pnpm v11's [String, Array] env schema tries a JSON array first, then falls
-  // back to the raw value as a single entry. v10 (nopt) never JSON-parses.
+  // back to the raw value as a single entry - never comma-split.
   if (keySet.prefix === 'pnpm_config_') {
     try {
       const parsed = JSON.parse(raw);
@@ -602,8 +603,11 @@ function readEnvArray(
           : 'invalid';
       }
     } catch {}
+    return [raw];
   }
-  return [raw];
+  // v10 reads npm_config_* via @pnpm/npm-conf, which comma-splits array-typed
+  // values (the same parsing it applies to .npmrc).
+  return splitNpmConfList(raw);
 }
 
 // --- value helpers ----------------------------------------------------------
@@ -621,6 +625,16 @@ function toNumber(value: unknown): number | null {
     return Number.isFinite(num) ? num : null;
   }
   return null;
+}
+
+// @pnpm/npm-conf (pnpm v10's .npmrc / npm_config_* reader) treats array-typed
+// settings as comma-separated lists, trimming each entry. Mirror that so a value
+// like `nx,@nx/*` becomes two patterns instead of one invalid entry.
+function splitNpmConfList(value: string): string[] {
+  return value
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter((entry) => entry.length > 0);
 }
 
 function stripQuotes(value: string): string {

--- a/packages/nx/src/utils/min-release-age/behavior/pnpm.ts
+++ b/packages/nx/src/utils/min-release-age/behavior/pnpm.ts
@@ -362,7 +362,7 @@ function readV11Surfaces(
 function readV10Surfaces(
   root: string
 ): WindowResolution | InvalidWindow | null {
-  // v10 layers config via @pnpm/npm-conf, per key:
+  // v10 layers the cooldown WINDOW via @pnpm/npm-conf, per key:
   // workspace yaml > npm_config_* env > project .npmrc > user .npmrc.
   const wsRead = readYamlWindow(join(root, 'pnpm-workspace.yaml'));
   if (wsRead && wsRead.kind === 'invalid') {
@@ -379,15 +379,13 @@ function readV10Surfaces(
   const projectNpmrc = readNpmrcSurface(join(root, '.npmrc'));
   const userNpmrc = readNpmrcSurface(join(homedir(), '.npmrc'));
 
-  // v10 reads npm_config_*, which never JSON-parses, so readEnvArray can only
-  // yield a single-entry array or undefined here - never 'invalid'.
-  const envExcludes = readEnvArray(env, keySet, 'minimum_release_age_exclude');
-  const excludes =
-    wsYaml?.excludes ??
-    (envExcludes === 'invalid' ? undefined : envExcludes) ??
-    projectNpmrc?.excludes ??
-    userNpmrc?.excludes ??
-    [];
+  // The EXCLUDE list is honored only from pnpm-workspace.yaml on v10. Verified
+  // empirically against pnpm 10.x (and the @pnpm/npm-conf source): a real
+  // `pnpm install` ignores minimumReleaseAgeExclude set in .npmrc or
+  // npm_config_* - only the cooldown window is read from those surfaces. So nx
+  // must NOT honor an exclude pnpm itself drops, or it would resolve a fresh
+  // version the user's pnpm would still gate.
+  const excludes = wsYaml?.excludes ?? [];
 
   if (wsYaml && wsYaml.windowMinutes !== undefined) {
     return okWindow(wsYaml.windowMinutes, excludes, 'pnpm-workspace.yaml');
@@ -466,31 +464,25 @@ function readYamlWindow(path: string): YamlWindow | InvalidWindow | null {
   };
 }
 
-function readNpmrcSurface(
-  path: string
-): { windowMinutes?: number; excludes?: string[] } | null {
+function readNpmrcSurface(path: string): { windowMinutes?: number } | null {
   const entries = readNpmrcEntries(path);
   if (entries === null) {
     return null;
   }
-  // v10 reads the kebab-case keys via npm-conf; camelCase in .npmrc is never
-  // honored. Only the two cooldown keys are relevant here.
+  // v10 reads the kebab-case window via npm-conf; camelCase in .npmrc is never
+  // honored. Only the window is read here: pnpm does NOT honor
+  // minimumReleaseAgeExclude from .npmrc or npm_config_* - the exclude list is
+  // only wired up from pnpm-workspace.yaml (see readV10Surfaces).
   let windowMinutes: number | undefined;
-  let excludes: string[] | undefined;
   for (const { key, value: rawValue } of entries) {
-    const value = stripQuotes(rawValue);
     if (key === 'minimum-release-age') {
-      const num = toNumber(value);
+      const num = toNumber(stripQuotes(rawValue));
       if (num !== null) {
         windowMinutes = num;
       }
-    } else if (key === 'minimum-release-age-exclude') {
-      // npm-conf accumulates repeated ini keys AND comma-splits each value, so
-      // `a,b` on one line and two separate `=` lines are equivalent.
-      (excludes ??= []).push(...splitNpmConfList(value));
     }
   }
-  return { windowMinutes, excludes };
+  return { windowMinutes };
 }
 
 // pnpm mirrors getConfigDir: XDG_CONFIG_HOME, else per-platform default.
@@ -589,25 +581,22 @@ function readEnvArray(
   if (raw === undefined) {
     return undefined;
   }
-  // pnpm v11's [String, Array] env schema tries a JSON array first, then falls
-  // back to the raw value as a single entry - never comma-split.
-  if (keySet.prefix === 'pnpm_config_') {
-    try {
-      const parsed = JSON.parse(raw);
-      if (Array.isArray(parsed)) {
-        // pnpm passes the array verbatim, then errors at install
-        // (ERR_PNPM_INVALID_MINIMUM_RELEASE_AGE_EXCLUDE) on any non-string
-        // element; signal invalid so the caller defers to a real install.
-        return parsed.every((e) => typeof e === 'string')
-          ? (parsed as string[])
-          : 'invalid';
-      }
-    } catch {}
-    return [raw];
-  }
-  // v10 reads npm_config_* via @pnpm/npm-conf, which comma-splits array-typed
-  // values (the same parsing it applies to .npmrc).
-  return splitNpmConfList(raw);
+  // Only v11's pnpm_config_* env feeds the exclude list (pnpm does not honor a
+  // v10 npm_config_* exclude). pnpm v11's [String, Array] env schema tries a
+  // JSON array first, then falls back to the raw value as a single entry - never
+  // comma-split.
+  try {
+    const parsed = JSON.parse(raw);
+    if (Array.isArray(parsed)) {
+      // pnpm passes the array verbatim, then errors at install
+      // (ERR_PNPM_INVALID_MINIMUM_RELEASE_AGE_EXCLUDE) on any non-string
+      // element; signal invalid so the caller defers to a real install.
+      return parsed.every((e) => typeof e === 'string')
+        ? (parsed as string[])
+        : 'invalid';
+    }
+  } catch {}
+  return [raw];
 }
 
 // --- value helpers ----------------------------------------------------------
@@ -625,16 +614,6 @@ function toNumber(value: unknown): number | null {
     return Number.isFinite(num) ? num : null;
   }
   return null;
-}
-
-// @pnpm/npm-conf (pnpm v10's .npmrc / npm_config_* reader) treats array-typed
-// settings as comma-separated lists, trimming each entry. Mirror that so a value
-// like `nx,@nx/*` becomes two patterns instead of one invalid entry.
-function splitNpmConfList(value: string): string[] {
-  return value
-    .split(',')
-    .map((entry) => entry.trim())
-    .filter((entry) => entry.length > 0);
 }
 
 function stripQuotes(value: string): string {

--- a/packages/nx/src/utils/package-manager.spec.ts
+++ b/packages/nx/src/utils/package-manager.spec.ts
@@ -458,8 +458,14 @@ describe('package-manager', () => {
       expect(result).toContain('minimumReleaseAge: 1440');
     });
 
-    it('should not throw on an empty file', () => {
-      expect(() => modifyPnpmWorkspaceYamlToFitNewDirectory('')).not.toThrow();
+    it('should add a packages field to an empty or comments-only manifest', () => {
+      // An empty/comments-only source has null doc contents; older pnpm still
+      // rejects a packages-less manifest, so `packages: ['.']` must be added.
+      for (const src of ['', '   \n', '# only a comment\n']) {
+        expect(
+          parse(modifyPnpmWorkspaceYamlToFitNewDirectory(src)).packages
+        ).toEqual(['.']);
+      }
     });
   });
 

--- a/packages/nx/src/utils/package-manager.spec.ts
+++ b/packages/nx/src/utils/package-manager.spec.ts
@@ -12,6 +12,7 @@ import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import * as childProcess from 'child_process';
 import { tmpdir } from 'os';
+import { parse } from 'yaml';
 
 import * as configModule from '../config/configuration';
 import * as projectGraphFileUtils from '../project-graph/file-utils';
@@ -414,16 +415,32 @@ describe('package-manager', () => {
   });
 
   describe('modifyPnpmWorkspaceYamlToFitNewDirectory', () => {
-    it('should drop workspace packages but keep settings', () => {
+    it('should replace member globs with a temp-root self-reference but keep settings', () => {
       const result = modifyPnpmWorkspaceYamlToFitNewDirectory(
         [
           'packages:',
           "  - 'packages/*'",
+          "  - '!libs/owners'",
           'minimumReleaseAge: 1440',
           'registry: https://example.com/',
         ].join('\n')
       );
-      expect(result).not.toContain('packages');
+      // The original member globs don't resolve in the temp dir, so drop them...
+      expect(result).not.toContain('packages/*');
+      expect(result).not.toContain('!libs/owners');
+      // ...but keep `packages` non-empty so pnpm <10.5 accepts the manifest.
+      expect(parse(result).packages).toEqual(['.']);
+      expect(result).toContain('minimumReleaseAge: 1440');
+      expect(result).toContain('registry: https://example.com/');
+    });
+
+    it('should add a packages field when the source manifest has none', () => {
+      // pnpm <10.5 (and corepack's default pnpm) reject a workspace manifest
+      // whose `packages` field is missing or empty.
+      const result = modifyPnpmWorkspaceYamlToFitNewDirectory(
+        ['minimumReleaseAge: 1440', 'registry: https://example.com/'].join('\n')
+      );
+      expect(parse(result).packages).toEqual(['.']);
       expect(result).toContain('minimumReleaseAge: 1440');
       expect(result).toContain('registry: https://example.com/');
     });

--- a/packages/nx/src/utils/package-manager.ts
+++ b/packages/nx/src/utils/package-manager.ts
@@ -405,10 +405,10 @@ export function modifyYarnRcToFitNewDirectory(contents: string): string {
  * registry, auth and release-age settings still apply, and so `pnpm add -w`
  * recognizes the directory as a workspace root. `patchedDependencies` (relative
  * patch paths) only resolves in the real workspace, so it is dropped. The
- * `packages` member globs don't resolve in the temp dir either, but pnpm <10.5
- * (and corepack's bundled default pnpm) reject a workspace manifest whose
- * `packages` field is missing or empty, so they are replaced with a
- * self-reference rather than deleted.
+ * `packages` field is always set to a self-reference (`['.']`) - the temp dir is
+ * a single-package workspace - whether or not the source had one, since pnpm
+ * <10.5 (and corepack's bundled default pnpm) reject a workspace manifest whose
+ * `packages` field is missing or empty.
  *
  * Exported for testing - not meant to be used outside of this file.
  *
@@ -419,12 +419,11 @@ export function modifyPnpmWorkspaceYamlToFitNewDirectory(
   contents: string
 ): string {
   const doc = parseDocument(contents);
-  if (doc.contents) {
-    // The temp dir is a single-package workspace; '.' keeps `packages` non-empty
-    // for older pnpm while matching only the temp root.
-    doc.set('packages', ['.']);
-    doc.delete('patchedDependencies');
-  }
+  // Set unconditionally so an empty/comments-only source (null doc.contents)
+  // still gets a packages field; doc.set creates the root map.
+  doc.set('packages', ['.']);
+  // Relative patch paths don't resolve in the temp dir.
+  doc.delete('patchedDependencies');
   return doc.toString();
 }
 

--- a/packages/nx/src/utils/package-manager.ts
+++ b/packages/nx/src/utils/package-manager.ts
@@ -403,9 +403,12 @@ export function modifyYarnRcToFitNewDirectory(contents: string): string {
 /**
  * We copy pnpm-workspace.yaml to the temporary directory so the workspace's
  * registry, auth and release-age settings still apply, and so `pnpm add -w`
- * recognizes the directory as a workspace root. `packages` (member globs) and
- * `patchedDependencies` (relative patch paths) only resolve in the real
- * workspace, so they are dropped.
+ * recognizes the directory as a workspace root. `patchedDependencies` (relative
+ * patch paths) only resolves in the real workspace, so it is dropped. The
+ * `packages` member globs don't resolve in the temp dir either, but pnpm <10.5
+ * (and corepack's bundled default pnpm) reject a workspace manifest whose
+ * `packages` field is missing or empty, so they are replaced with a
+ * self-reference rather than deleted.
  *
  * Exported for testing - not meant to be used outside of this file.
  *
@@ -417,7 +420,9 @@ export function modifyPnpmWorkspaceYamlToFitNewDirectory(
 ): string {
   const doc = parseDocument(contents);
   if (doc.contents) {
-    doc.delete('packages');
+    // The temp dir is a single-package workspace; '.' keeps `packages` non-empty
+    // for older pnpm while matching only the temp root.
+    doc.set('packages', ['.']);
     doc.delete('patchedDependencies');
   }
   return doc.toString();


### PR DESCRIPTION
## Current Behavior

`nx migrate` resolves package versions and fetches migration metadata by installing into a throwaway temp directory. Two problems surface in pnpm workspaces:

1. **Preapproved packages were downgraded.** The per-package migration cascade extracted versions straight from the migration descriptors without running them through min-release-age policy resolution. Packages explicitly preapproved to bypass the cooldown gate (e.g. `npmPreapprovedPackages` in `.yarnrc.yml`, or pnpm's `minimumReleaseAgeExclude`) were still downgraded to older "stable" versions.

2. **The temp workspace manifest was invalid for older pnpm.** When copying `pnpm-workspace.yaml` into the temp dir, nx deleted the `packages` field entirely. pnpm `< 10.5` — including the bundled default pnpm that corepack falls back to inside the temp dir (which carries no `packageManager` pin) — rejects a workspace manifest whose `packages` field is missing or empty:

   ```
    ERROR  packages field missing or empty
   ...
    NX   Failed to fetch migrations for nx@latest
   ```

   This breaks `nx migrate` even when the user's real `pnpm-workspace.yaml` is perfectly valid.

## Expected Behavior

1. The migration cascade resolves each version through the min-release-age policy via the new `resolveVersionForCascade()`, so preapproved packages keep the version their package-manager config allows instead of being downgraded.

2. The temp `pnpm-workspace.yaml` keeps a non-empty `packages` field that every supported pnpm accepts. The member globs (which only resolve in the real workspace) are replaced with a self-reference (`packages: ['.']`) — the temp dir genuinely is a single-package workspace — rather than dropped. `patchedDependencies` (relative patch paths) is still dropped.

Both changes ship with regression tests.

## Related Issue(s)

No public issue — surfaced via an internal report of `nx migrate` failing in a downstream pnpm monorepo (nx 23.0.0-rc.4, pnpm 10.x via corepack).
