### PR TITLE
fix(core): prevent nx migrate crash when include=optional filters out the target package

### DIFF
--- a/packages/nx/src/command-line/migrate/migrate.spec.ts
+++ b/packages/nx/src/command-line/migrate/migrate.spec.ts
@@ -45,6 +45,7 @@ import {
   filterDowngradedUpdates,
   formatCommandFailure,
   formatSkippedPromptsNextStep,
+  generateMigrationsJsonAndUpdatePackageJson,
   isHybridMigration,
   isNpmPeerDepsError,
   isPromptOnlyMigration,
@@ -4467,6 +4468,81 @@ describe('Migration', () => {
         ).rejects.toThrow(/Invalid prompt path/);
       }
     );
+  });
+
+  describe('generateMigrationsJsonAndUpdatePackageJson (--include=optional)', () => {
+    let root: string;
+
+    beforeEach(() => {
+      root = mkdtempSync(join(tmpdir(), 'nx-migrate-optional-'));
+      writeFileSync(join(root, 'nx.json'), JSON.stringify({}));
+    });
+
+    afterEach(() => {
+      rmSync(root, { recursive: true, force: true });
+    });
+
+    // NXC-4590: under `--include=optional` the target package (e.g. `nx`) is in
+    // its own required closure, so the Migrator drops its entry from
+    // `packageUpdates`. The orchestration must not assume that entry exists when
+    // resolving the version for the AI-migrations directory.
+    it('does not crash when the target package is filtered out of packageUpdates', async () => {
+      writeFileSync(
+        join(root, 'package.json'),
+        JSON.stringify({
+          name: 'w',
+          version: '0.0.0',
+          devDependencies: {
+            nx: '0.0.0',
+            requiredChild: '1.0.0',
+            optionalChild: '1.0.0',
+          },
+        })
+      );
+
+      // `packageGroup` puts `requiredChild` in nx's required closure; both `nx`
+      // and `requiredChild` are dropped under optional, leaving `optionalChild`.
+      const fetch = (p: string, version: string) => {
+        if (p === 'nx') {
+          return Promise.resolve({
+            version: '23.0.0',
+            packageGroup: [{ package: 'requiredChild', version: '23.0.0' }],
+            packageJsonUpdates: {
+              mixed: {
+                version: '23.0.0',
+                packages: {
+                  requiredChild: { version: '3.0.0' },
+                  optionalChild: { version: '3.0.0' },
+                },
+              },
+            },
+          });
+        }
+        return Promise.resolve({ version: '3.0.0' });
+      };
+
+      const opts = {
+        type: 'generateMigrations' as const,
+        targetPackage: 'nx',
+        targetVersion: '23.0.0',
+        from: {},
+        to: {},
+        interactive: false,
+        include: 'optional' as const,
+      };
+
+      await expect(
+        generateMigrationsJsonAndUpdatePackageJson(root, opts, fetch as any)
+      ).resolves.toBeUndefined();
+
+      const updated = JSON.parse(
+        readFileSync(join(root, 'package.json'), 'utf-8')
+      );
+      // Optional update applied; the filtered-out required packages untouched.
+      expect(updated.devDependencies.optionalChild).toBe('3.0.0');
+      expect(updated.devDependencies.requiredChild).toBe('1.0.0');
+      expect(updated.devDependencies.nx).toBe('0.0.0');
+    });
   });
 
   describe('writePromptMigrationFiles', () => {

--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -2206,7 +2206,8 @@ function readNxVersion(packageJson: PackageJson, root: string) {
   );
 }
 
-async function generateMigrationsJsonAndUpdatePackageJson(
+// Exported for testing the optional-include orchestration seam (see NXC-4590).
+export async function generateMigrationsJsonAndUpdatePackageJson(
   root: string,
   opts: GenerateMigrations,
   fetch?: MigratorOptions['fetch']
@@ -2308,11 +2309,17 @@ async function generateMigrationsJsonAndUpdatePackageJson(
       writableUpdates
     );
 
+    // Under `--include=optional` the target's own entry is filtered out of
+    // `packageUpdates` (it's a required package), so resolve the version
+    // defensively. Also reused by the completion analytics below.
+    const resolvedTargetVersion =
+      packageUpdates[walkedTargetPackage]?.version ?? opts.targetVersion;
+
     const promptMigrationFiles = writePromptMigrationFiles(
       root,
       migrations,
       promptContents ?? {},
-      packageUpdates[walkedTargetPackage].version
+      resolvedTargetVersion
     );
 
     if (migrations.length > 0) {
@@ -2329,8 +2336,6 @@ async function generateMigrationsJsonAndUpdatePackageJson(
           ? `- Processed optional dependency updates only (skipped required package updates).`
           : null;
 
-    const resolvedTargetVersion =
-      packageUpdates[walkedTargetPackage]?.version ?? opts.targetVersion;
     // The param expressions below evaluate before the report function is
     // entered; `safeReport` keeps them inside the analytics boundary so a
     // param-building throw can't surface here and convert an already


### PR DESCRIPTION
## Current Behavior

`nx migrate --include=optional` crashes with `Cannot read properties of undefined (reading 'version')`. The target package sits in its own required closure, so the Migrator drops its `packageUpdates` entry; `generateMigrationsJsonAndUpdatePackageJson` then reads `.version` off it unguarded when building the `writePromptMigrationFiles` argument.

## Expected Behavior

Resolve the target version defensively (`packageUpdates[walkedTargetPackage]?.version ?? opts.targetVersion`, the same form already used for completion analytics); optional migrate completes without crashing.

## Related Issue(s)

Fixes NXC-4590

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/migrate-error-c1c6a147)
<!-- polygraph-session-end -->