### PR TITLE
fix(testing): keep ts-jest resolving exports-only libs on typescript < 6

### DIFF
--- a/packages/jest/migrations.json
+++ b/packages/jest/migrations.json
@@ -77,6 +77,15 @@
       "description": "Rename imports of `createNodesV2` from `@nx/jest/plugin` to the canonical `createNodes` export.",
       "implementation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
       "documentation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"
+    },
+    "set-ts-jest-isolated-modules": {
+      "version": "23.1.0-beta.3",
+      "requires": {
+        "ts-jest": ">=29.2.0"
+      },
+      "description": "Set `isolatedModules: true` in `tsconfig.spec.json` for ts-jest projects on TypeScript < 6. ts-jest 29.2+ forces `moduleResolution: node10` on the CommonJS path, which ignores package `exports` maps and breaks (TS2307) resolution of exports-only workspace libraries; transpiling per file avoids the type-resolution failure.",
+      "implementation": "./dist/src/migrations/update-23-1-0/set-ts-jest-isolated-modules",
+      "documentation": "./dist/src/migrations/update-23-1-0/set-ts-jest-isolated-modules.md"
     }
   },
   "packageJsonUpdates": {

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -112,6 +112,7 @@
     "jest-config": "catalog:jest",
     "jest-resolve": "catalog:jest",
     "jest-util": "catalog:jest",
+    "jsonc-parser": "catalog:",
     "minimatch": "catalog:",
     "picocolors": "catalog:",
     "resolve.exports": "2.0.3",

--- a/packages/jest/src/generators/configuration/configuration.spec.ts
+++ b/packages/jest/src/generators/configuration/configuration.spec.ts
@@ -595,6 +595,63 @@ describe('jestProject', () => {
       expect(tree.exists('packages/pkg1/.spec.swcrc')).toBeFalsy();
     });
 
+    it('should set isolatedModules in tsconfig.spec.json for ts-jest below TypeScript 6', async () => {
+      updateJson(tree, 'package.json', (json) => {
+        json.devDependencies = {
+          ...json.devDependencies,
+          typescript: '~5.9.2',
+        };
+        return json;
+      });
+
+      await configurationGenerator(tree, {
+        ...defaultOptions,
+        project: 'pkg1',
+      });
+
+      const tsConfig = readJson(tree, 'packages/pkg1/tsconfig.spec.json');
+      expect(tsConfig.compilerOptions.moduleResolution).toBe('node10');
+      expect(tsConfig.compilerOptions.isolatedModules).toBe(true);
+    });
+
+    it('should not set isolatedModules in tsconfig.spec.json on TypeScript 6 or above', async () => {
+      updateJson(tree, 'package.json', (json) => {
+        json.devDependencies = {
+          ...json.devDependencies,
+          typescript: '~6.0.3',
+        };
+        return json;
+      });
+
+      await configurationGenerator(tree, {
+        ...defaultOptions,
+        project: 'pkg1',
+      });
+
+      const tsConfig = readJson(tree, 'packages/pkg1/tsconfig.spec.json');
+      expect(tsConfig.compilerOptions.moduleResolution).toBe('bundler');
+      expect(tsConfig.compilerOptions.isolatedModules).toBeUndefined();
+    });
+
+    it('should not set isolatedModules for the swc compiler below TypeScript 6', async () => {
+      updateJson(tree, 'package.json', (json) => {
+        json.devDependencies = {
+          ...json.devDependencies,
+          typescript: '~5.9.2',
+        };
+        return json;
+      });
+
+      await configurationGenerator(tree, {
+        ...defaultOptions,
+        project: 'pkg1',
+        compiler: 'swc',
+      });
+
+      const tsConfig = readJson(tree, 'packages/pkg1/tsconfig.spec.json');
+      expect(tsConfig.compilerOptions.isolatedModules).toBeUndefined();
+    });
+
     it(`should setup a task pipeline for the test target to depend on the deps' build target`, async () => {
       await configurationGenerator(tree, {
         ...defaultOptions,

--- a/packages/jest/src/generators/configuration/files/common/tsconfig.spec.json__tmpl__
+++ b/packages/jest/src/generators/configuration/files/common/tsconfig.spec.json__tmpl__
@@ -3,7 +3,8 @@
   "compilerOptions": {
     "outDir": "<%= outDir %>",<% if (module) { %>
     "module": "<%= module %>",<% } if (module === 'commonjs') { %>
-    "moduleResolution": "<%= moduleResolution %>",<% } if (supportTsx) { %>
+    "moduleResolution": "<%= moduleResolution %>",<% } if (isolatedModules) { %>
+    "isolatedModules": true,<% } if (supportTsx) { %>
     "jsx": "react-jsx",<% } %>"types": ["jest", "node"]
   },<% if(setupFile !== 'none') { %>
   "files": ["src/test-setup.ts"],<% } %>

--- a/packages/jest/src/generators/configuration/lib/create-files.ts
+++ b/packages/jest/src/generators/configuration/lib/create-files.ts
@@ -60,6 +60,19 @@ export function createFiles(
     ? `test-output/jest/coverage`
     : `${rootOffset}coverage/${projectRoot}`;
 
+  const usesTsJestModuleSettings =
+    !options.isTsSolutionSetup || transformer === 'ts-jest';
+  const moduleResolution = usesTsJestModuleSettings
+    ? getTsConfigModuleResolution(tree)
+    : undefined;
+  // ts-jest forces `moduleResolution: node10` on the CommonJS path for
+  // TypeScript < 6, and node10 ignores package `exports`. Transpiling per file
+  // keeps exports-only workspace libraries resolvable. See NXC-4591.
+  const isolatedModules =
+    options.isTsSolutionSetup &&
+    transformer === 'ts-jest' &&
+    moduleResolution === 'node10';
+
   generateFiles(tree, join(__dirname, commonFilesFolder), projectConfig.root, {
     tmpl: '',
     ...options,
@@ -78,14 +91,9 @@ export function createFiles(
     outDir: options.isTsSolutionSetup
       ? `./out-tsc/jest`
       : `${rootOffset}dist/out-tsc`,
-    module:
-      !options.isTsSolutionSetup || transformer === 'ts-jest'
-        ? 'commonjs'
-        : undefined,
-    moduleResolution:
-      !options.isTsSolutionSetup || transformer === 'ts-jest'
-        ? getTsConfigModuleResolution(tree)
-        : undefined,
+    module: usesTsJestModuleSettings ? 'commonjs' : undefined,
+    moduleResolution,
+    isolatedModules,
   });
 
   if (options.setupFile !== 'angular') {

--- a/packages/jest/src/migrations/update-23-1-0/set-ts-jest-isolated-modules.md
+++ b/packages/jest/src/migrations/update-23-1-0/set-ts-jest-isolated-modules.md
@@ -1,0 +1,41 @@
+#### Set isolatedModules for ts-jest below TypeScript 6
+
+The jest 30 path of `@nx/jest` bumps ts-jest to 29.4.x.
+On the CommonJS jest path, ts-jest 29.2+ uses `moduleResolution: node10` when `bundler` is invalid alongside the forced `module: commonjs`, which is the case below TypeScript 6.
+`node10` does not read package `exports` maps, so a workspace library that exposes types only through `exports` fails to resolve during the ts-jest type check:
+
+```text
+error TS2307: Cannot find module '@my-org/some-lib' or its corresponding type declarations.
+```
+
+The migration sets `isolatedModules: true` in each affected `tsconfig.spec.json`, so ts-jest transpiles each file independently and skips the cross-file type resolution that was failing.
+This matches the `isolatedModules: true` that fresh ts-solution workspaces already set in `tsconfig.base.json`.
+Type checking stays on each project's dedicated typecheck target.
+
+The migration runs only below TypeScript 6, in ts-solution workspaces that do not already enable `isolatedModules`.
+TypeScript 6 and above resolves `exports` under `bundler` with `commonjs`, so those workspaces are left unchanged.
+
+#### Sample code changes
+
+##### Before
+
+```json title="tsconfig.spec.json"
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "types": ["jest", "node"]
+  }
+}
+```
+
+##### After
+
+```json title="tsconfig.spec.json" {4}
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "isolatedModules": true,
+    "types": ["jest", "node"]
+  }
+}
+```

--- a/packages/jest/src/migrations/update-23-1-0/set-ts-jest-isolated-modules.spec.ts
+++ b/packages/jest/src/migrations/update-23-1-0/set-ts-jest-isolated-modules.spec.ts
@@ -1,0 +1,215 @@
+import { addProjectConfiguration, type Tree, writeJson } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migration from './set-ts-jest-isolated-modules';
+
+const TS_JEST_CONFIG = `export default {
+  displayName: 'lib1',
+  preset: '../../jest.preset.js',
+};
+`;
+
+/** Make the tree look like a ts-solution, package-manager-workspaces setup. */
+function setupTsSolution(
+  tree: Tree,
+  { tsVersion, baseCompilerOptions = { composite: true } } = {} as {
+    tsVersion?: string;
+    baseCompilerOptions?: Record<string, unknown>;
+  }
+) {
+  writeJson(tree, 'package.json', {
+    name: '@acme/source',
+    workspaces: ['packages/*'],
+    devDependencies: { typescript: `~${tsVersion ?? '5.9.0'}` },
+  });
+  tree.write(
+    'node_modules/typescript/package.json',
+    JSON.stringify({ name: 'typescript', version: tsVersion ?? '5.9.2' })
+  );
+  writeJson(tree, 'tsconfig.base.json', {
+    compilerOptions: baseCompilerOptions,
+  });
+  writeJson(tree, 'tsconfig.json', {
+    extends: './tsconfig.base.json',
+    files: [],
+    include: [],
+    references: [],
+  });
+}
+
+function addTsJestProject(
+  tree: Tree,
+  name: string,
+  { jestConfig = TS_JEST_CONFIG, tsconfigSpec = true } = {}
+) {
+  const root = `packages/${name}`;
+  addProjectConfiguration(tree, name, { root, sourceRoot: `${root}/src` });
+  tree.write(`${root}/jest.config.ts`, jestConfig);
+  if (tsconfigSpec) {
+    tree.write(
+      `${root}/tsconfig.spec.json`,
+      `{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./out-tsc/jest",
+    "module": "commonjs",
+    "types": ["jest", "node"]
+  },
+  "include": ["src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]
+}
+`
+    );
+  }
+  return root;
+}
+
+describe('set-ts-jest-isolated-modules migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('adds isolatedModules to a ts-jest tsconfig.spec.json on TS < 6', async () => {
+    setupTsSolution(tree, { tsVersion: '5.9.2' });
+    const root = addTsJestProject(tree, 'lib1');
+
+    await migration(tree);
+
+    expect(tree.read(`${root}/tsconfig.spec.json`, 'utf-8'))
+      .toMatchInlineSnapshot(`
+      "{
+        "extends": "../../tsconfig.base.json",
+        "compilerOptions": {
+          "outDir": "./out-tsc/jest",
+          "module": "commonjs",
+          "types": ["jest", "node"],
+          "isolatedModules": true
+        },
+        "include": ["src/**/*.test.ts", "src/**/*.spec.ts", "src/**/*.d.ts"]
+      }
+      "
+    `);
+  });
+
+  it('preserves comments and existing options', async () => {
+    setupTsSolution(tree, { tsVersion: '5.9.2' });
+    addProjectConfiguration(tree, 'lib1', { root: 'packages/lib1' });
+    tree.write('packages/lib1/jest.config.ts', TS_JEST_CONFIG);
+    tree.write(
+      'packages/lib1/tsconfig.spec.json',
+      `{
+  // jest type-check config
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "commonjs" // forced by ts-jest
+  }
+}
+`
+    );
+
+    await migration(tree);
+
+    const result = tree.read('packages/lib1/tsconfig.spec.json', 'utf-8');
+    expect(result).toContain('// jest type-check config');
+    expect(result).toContain('// forced by ts-jest');
+    expect(result).toContain('"isolatedModules": true');
+  });
+
+  it('is a no-op on TypeScript >= 6', async () => {
+    setupTsSolution(tree, { tsVersion: '6.0.3' });
+    const root = addTsJestProject(tree, 'lib1');
+    const before = tree.read(`${root}/tsconfig.spec.json`, 'utf-8');
+
+    await migration(tree);
+
+    expect(tree.read(`${root}/tsconfig.spec.json`, 'utf-8')).toBe(before);
+  });
+
+  it('is a no-op when not a ts-solution (package-manager-workspaces) setup', async () => {
+    // No workspaces / tsconfig.base setup -> path-based workspace.
+    tree.write(
+      'node_modules/typescript/package.json',
+      JSON.stringify({ name: 'typescript', version: '5.9.2' })
+    );
+    const root = addTsJestProject(tree, 'lib1');
+    const before = tree.read(`${root}/tsconfig.spec.json`, 'utf-8');
+
+    await migration(tree);
+
+    expect(tree.read(`${root}/tsconfig.spec.json`, 'utf-8')).toBe(before);
+  });
+
+  it('is a no-op when the base tsconfig already enables isolatedModules', async () => {
+    setupTsSolution(tree, {
+      tsVersion: '5.9.2',
+      baseCompilerOptions: { composite: true, isolatedModules: true },
+    });
+    const root = addTsJestProject(tree, 'lib1');
+    const before = tree.read(`${root}/tsconfig.spec.json`, 'utf-8');
+
+    await migration(tree);
+
+    expect(tree.read(`${root}/tsconfig.spec.json`, 'utf-8')).toBe(before);
+  });
+
+  it('skips swc, babel, and angular jest projects', async () => {
+    setupTsSolution(tree, { tsVersion: '5.9.2' });
+    const swc = addTsJestProject(tree, 'swclib', {
+      jestConfig: `export default {
+  preset: '../../jest.preset.js',
+  transform: { '^.+\\\\.[tj]s$': ['@swc/jest'] },
+};
+`,
+    });
+    const babel = addTsJestProject(tree, 'babellib', {
+      jestConfig: `export default {
+  preset: '../../jest.preset.js',
+  transform: { '^.+\\\\.[tj]s$': 'babel-jest' },
+};
+`,
+    });
+    const ng = addTsJestProject(tree, 'nglib', {
+      jestConfig: `export default { preset: 'jest-preset-angular' };\n`,
+    });
+    const before = {
+      swc: tree.read(`${swc}/tsconfig.spec.json`, 'utf-8'),
+      babel: tree.read(`${babel}/tsconfig.spec.json`, 'utf-8'),
+      ng: tree.read(`${ng}/tsconfig.spec.json`, 'utf-8'),
+    };
+
+    await migration(tree);
+
+    expect(tree.read(`${swc}/tsconfig.spec.json`, 'utf-8')).toBe(before.swc);
+    expect(tree.read(`${babel}/tsconfig.spec.json`, 'utf-8')).toBe(
+      before.babel
+    );
+    expect(tree.read(`${ng}/tsconfig.spec.json`, 'utf-8')).toBe(before.ng);
+  });
+
+  it('skips a project whose tsconfig.spec.json already sets isolatedModules', async () => {
+    setupTsSolution(tree, { tsVersion: '5.9.2' });
+    addProjectConfiguration(tree, 'lib1', { root: 'packages/lib1' });
+    tree.write('packages/lib1/jest.config.ts', TS_JEST_CONFIG);
+    const original = `{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": { "module": "commonjs", "isolatedModules": true }
+}
+`;
+    tree.write('packages/lib1/tsconfig.spec.json', original);
+
+    await migration(tree);
+
+    expect(tree.read('packages/lib1/tsconfig.spec.json', 'utf-8')).toBe(
+      original
+    );
+  });
+
+  it('skips a ts-jest project that has no tsconfig.spec.json', async () => {
+    setupTsSolution(tree, { tsVersion: '5.9.2' });
+    addProjectConfiguration(tree, 'lib1', { root: 'packages/lib1' });
+    tree.write('packages/lib1/jest.config.ts', TS_JEST_CONFIG);
+
+    await expect(migration(tree)).resolves.not.toThrow();
+    expect(tree.exists('packages/lib1/tsconfig.spec.json')).toBe(false);
+  });
+});

--- a/packages/jest/src/migrations/update-23-1-0/set-ts-jest-isolated-modules.ts
+++ b/packages/jest/src/migrations/update-23-1-0/set-ts-jest-isolated-modules.ts
@@ -1,0 +1,121 @@
+import {
+  formatFiles,
+  getProjects,
+  joinPathFragments,
+  logger,
+  type Tree,
+} from '@nx/devkit';
+import {
+  isTypescriptVersionAtLeast,
+  isUsingTsSolutionSetup,
+} from '@nx/js/internal';
+import {
+  applyEdits,
+  findNodeAtLocation,
+  getNodeValue,
+  modify,
+  parseTree,
+} from 'jsonc-parser';
+import { findJestConfig } from '../../utils/config/config-file';
+
+const FORMATTING_OPTIONS = {
+  formattingOptions: { keepLines: true, insertSpaces: true, tabSize: 2 },
+};
+
+// A jest config mentioning any of these uses swc/babel/angular (or is the root
+// aggregator), not ts-jest, so skip it.
+const NON_TS_JEST_MARKERS = [
+  '@swc/jest',
+  'babel-jest',
+  'jest-preset-angular',
+  'getJestProjectsAsync',
+];
+
+/**
+ * NXC-4591: ts-jest 29.2+ uses `moduleResolution: node10` on the CommonJS path
+ * for TypeScript < 6, which ignores package `exports` and breaks exports-only
+ * workspace libs (TS2307). `isolatedModules: true` makes ts-jest transpile per
+ * file, skipping that resolution. TS >= 6 is unaffected.
+ */
+export default async function (tree: Tree) {
+  // TS >= 6 resolves `exports` under bundler + commonjs; not affected.
+  if (isTypescriptVersionAtLeast(tree, '6.0.0')) {
+    return;
+  }
+  // Path-based workspaces resolve via tsconfig `paths`, not `exports`; skip them.
+  if (!isUsingTsSolutionSetup(tree)) {
+    return;
+  }
+  // Fresh ts-solution workspaces already enable this in the base config.
+  if (rootEnablesIsolatedModules(tree)) {
+    return;
+  }
+
+  let count = 0;
+  for (const [, project] of getProjects(tree)) {
+    const specPath = getTsJestSpecTsconfig(tree, project.root);
+    if (specPath && setIsolatedModules(tree, specPath)) {
+      count++;
+    }
+  }
+
+  if (count > 0) {
+    logger.info(
+      `NXC-4591: set "isolatedModules": true in ${count} tsconfig.spec.json file(s) so ts-jest resolves exports-only workspace libraries on TypeScript < 6.`
+    );
+  }
+
+  await formatFiles(tree);
+}
+
+function rootEnablesIsolatedModules(tree: Tree): boolean {
+  return (
+    readCompilerOption(tree, 'tsconfig.base.json', 'isolatedModules') === true
+  );
+}
+
+// The project's tsconfig.spec.json if it runs ts-jest, else null.
+function getTsJestSpecTsconfig(tree: Tree, root: string): string | null {
+  const jestConfig = findJestConfig(tree, root);
+  if (!jestConfig) {
+    return null;
+  }
+  const source = tree.read(jestConfig, 'utf-8') ?? '';
+  if (NON_TS_JEST_MARKERS.some((marker) => source.includes(marker))) {
+    return null;
+  }
+  const specPath = joinPathFragments(root, 'tsconfig.spec.json');
+  return tree.exists(specPath) ? specPath : null;
+}
+
+function setIsolatedModules(tree: Tree, tsconfigPath: string): boolean {
+  if (readCompilerOption(tree, tsconfigPath, 'isolatedModules') === true) {
+    return false;
+  }
+  const contents = tree.read(tsconfigPath, 'utf-8');
+  if (!contents) {
+    return false;
+  }
+  const edits = modify(
+    contents,
+    ['compilerOptions', 'isolatedModules'],
+    true,
+    FORMATTING_OPTIONS
+  );
+  tree.write(tsconfigPath, applyEdits(contents, edits));
+  return true;
+}
+
+function readCompilerOption(
+  tree: Tree,
+  tsconfigPath: string,
+  option: string
+): unknown {
+  const contents = tree.read(tsconfigPath, 'utf-8');
+  if (!contents) {
+    return undefined;
+  }
+  const root = parseTree(contents);
+  const node = root && findNodeAtLocation(root, ['compilerOptions', option]);
+  return node ? getNodeValue(node) : undefined;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2978,6 +2978,9 @@ importers:
       jest-util:
         specifier: catalog:jest
         version: 30.3.0
+      jsonc-parser:
+        specifier: 'catalog:'
+        version: 3.3.1
       minimatch:
         specifier: ^10.2.5
         version: 10.2.5


### PR DESCRIPTION
## Current Behavior

The jest-30 path of `@nx/jest` bumps ts-jest to 29.4.x. On the CommonJS jest path, ts-jest 29.2+ falls back to `moduleResolution: node10` when `bundler` is invalid alongside the forced `module: commonjs` (TypeScript < 6). `node10` ignores package `exports` maps, so workspace libraries that expose types only via `exports` fail with TS2307 during the ts-jest type check.

## Expected Behavior

A new migration sets `isolatedModules: true` in `tsconfig.spec.json` for ts-jest projects on TypeScript < 6 ts-solution workspaces (that do not already enable it), so ts-jest transpiles per file and the cross-file type resolution no longer runs. TypeScript >= 6 (where `bundler` is valid with `commonjs` and resolves `exports`) is unaffected.

## Related Issue(s)

NXC-4591

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/ts-jest-broken-83851e61)
<!-- polygraph-session-end -->