### PR TITLE
fix(react): reserve ports in rspack e2e test to avoid default port collisions

### DIFF
--- a/e2e/react/src/react-rspack.test.ts
+++ b/e2e/react/src/react-rspack.test.ts
@@ -4,6 +4,7 @@ import {
   killPorts,
   newProject,
   readFile,
+  reservePort,
   runCLI,
   runE2ETests,
   uniq,
@@ -31,7 +32,7 @@ describe('Build React applications and libraries with Rspack', () => {
 
   it('should generate app with custom port', async () => {
     const appName = uniq('app');
-    const customPort = 8081;
+    const customPort = await reservePort();
 
     runCLI(
       `generate @nx/react:app ${appName} --bundler=rspack --port=${customPort} --unit-test-runner=vitest --no-interactive --skipFormat --linter=eslint --e2eTestRunner=playwright`
@@ -52,9 +53,10 @@ describe('Build React applications and libraries with Rspack', () => {
   it('should be able to use Rspack to build and test apps', async () => {
     const appName = uniq('app');
     const libName = uniq('lib');
+    const port = await reservePort();
 
     runCLI(
-      `generate @nx/react:app ${appName} --bundler=rspack --unit-test-runner=vitest --no-interactive --skipFormat --linter=eslint`
+      `generate @nx/react:app ${appName} --bundler=rspack --port=${port} --unit-test-runner=vitest --no-interactive --skipFormat --linter=eslint`
     );
     runCLI(
       `generate @nx/react:lib ${libName} --bundler=none --no-interactive --unit-test-runner=vitest --skipFormat --linter=eslint`


### PR DESCRIPTION
## Current Behavior

The `e2e/react/src/react-rspack.test.ts` test "should be able to use Rspack to build and test apps" generates the app without a `--port`, so the dev/preview server falls back to the framework default of `4200`. When e2e tests run in parallel on the same agent, multiple tests end up fighting over port `4200`. One preview server gets killed (exit code `137` / SIGKILL) and Playwright fails with `NS_ERROR_CONNECTION_REFUSED` / `Connection refused`.

The first test ("should generate app with custom port") hardcoded `8081`, which carries the same parallel-collision risk.

## Expected Behavior

Both tests reserve a unique port via `reservePort()` (the established pattern used across the e2e suite, e.g. `e2e/react/src/react-rsbuild.test.ts`) and pin it on the generate command, so parallel tests never collide on a shared default port.

- Test 1 now reserves a port instead of hardcoding `8081` — the custom-port assertion still holds since it checks `port: ${customPort}`.
- Test 2 now reserves a port and passes `--port=${port}` so the preview server and Playwright use a collision-free port.

## Related Issue(s)

N/A — CI flake fix.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/nrwl-nx---fix-rspack-test-PR-205fdf70)
<!-- polygraph-session-end -->