### PR TITLE
fix(maven): de-flake maven e2e by dropping -X debug forks and widening timeout

### DIFF
--- a/e2e/maven/src/maven.test.ts
+++ b/e2e/maven/src/maven.test.ts
@@ -47,14 +47,10 @@ describe('Maven', () => {
   });
 
   it('should build Maven project with dependencies without batch mode', () => {
-    // Build app which depends on lib, which depends on utils.
-    // Without --batch, Nx fans `app:install` out into one task per Maven
-    // lifecycle phase per project (~87 tasks total), each spawning its own
-    // mvn JVM. On loaded CI hosts this routinely runs 220-290s, so the
-    // default 5-minute runCLI timeout is too tight; bump it to 10 minutes.
+    // Avoid `verbose: true`: it sets NX_VERBOSE_LOGGING, which makes every
+    // --no-batch fork run `mvn -X`.
     let buildOutput = runCLI('run app:install --no-batch', {
-      verbose: true,
-      timeout: 10 * 60 * 1000,
+      timeout: 15 * 60 * 1000,
     });
 
     // Should build dependencies first
@@ -124,11 +120,8 @@ describe('Maven', () => {
     expect(output).toContain('- mvn-package:');
     expect(output).toContain('- mvn-install-ci:');
 
-    // Verify prefixed target works. Same lifecycle-fan-out concern as the
-    // app:install case above — give it a 10-minute timeout so CI load
-    // doesn't push us past the default 5 minutes.
     const buildOutput = runCLI('run app:mvn-compile --no-batch', {
-      timeout: 10 * 60 * 1000,
+      timeout: 15 * 60 * 1000,
     });
     expect(buildOutput).toContain('BUILD SUCCESS');
   });


### PR DESCRIPTION
## Current Behavior

The `e2e/maven/src/maven.test.ts` cases "should build Maven project with dependencies without batch mode" and "should support targetNamePrefix option" intermittently time out (e.g. `Command timed out after 600s: run app:install --no-batch`).

`nx run <project>:install --no-batch` fans the build out into one task per Maven lifecycle phase per module (~87 tasks), each spawning a fresh `mvn` JVM that re-scans the whole reactor. That serial fan-out alone runs ~450-550s even with a warm `~/.m2`. The `install` run additionally passed `verbose: true`, which sets `NX_VERBOSE_LOGGING=true` and makes every one of the ~87 forks run `mvn -X` (full debug) — a large amount of extra per-fork log I/O that pushed it over the previous 10-minute budget.

## Expected Behavior

- The `install` run no longer passes `verbose: true`, so the ~87 forks don't each run `mvn -X`. The assertions (`BUILD SUCCESS` + jar existence) don't need verbose output.
- Both `--no-batch` runs get a 15-minute timeout, comfortably above the inherent serial fan-out floor, so CI load no longer tips them over.

## Related Issue(s)

N/A — CI flake fix.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/nrwl-nx---fix-rspack-test-PR-205fdf70)
<!-- polygraph-session-end -->