### PR TITLE
fix(release): widen release e2e timeouts to absorb pre-version dlx install

### DIFF
--- a/e2e/release/src/release-publishable-libraries.test.ts
+++ b/e2e/release/src/release-publishable-libraries.test.ts
@@ -96,7 +96,9 @@ describe('release publishable libraries', () => {
       `generate @nx/js:lib packages/${jsLib} --publishable --importPath=@proj/${jsLib} --no-interactive`
     );
 
-    const releaseOutput = runCLI(`release --specifier 0.0.2 --yes`);
+    const releaseOutput = runCLI(`release --specifier 0.0.2 --yes`, {
+      timeout: 10 * 60 * 1000,
+    });
     expect(releaseOutput).toMatchInlineSnapshot(`
       NX   Executing pre-version command
       NX   Running release version for project: {project-name}
@@ -151,7 +153,9 @@ describe('release publishable libraries', () => {
       `generate @nx/react:lib packages/${reactLib} --publishable --importPath=@proj/${reactLib} --no-interactive`
     );
 
-    const releaseOutput = runCLI(`release --specifier 0.0.3 --yes`);
+    const releaseOutput = runCLI(`release --specifier 0.0.3 --yes`, {
+      timeout: 10 * 60 * 1000,
+    });
     expect(releaseOutput).toMatchInlineSnapshot(`
       NX   Executing pre-version command
       NX   Running release version for project: {project-name}
@@ -208,7 +212,9 @@ describe('release publishable libraries', () => {
       `generate @nx/angular:lib packages/${angularLib} --publishable --importPath=@proj/${angularLib} --no-interactive`
     );
 
-    const releaseOutput = runCLI(`release --specifier 0.0.4 --yes`);
+    const releaseOutput = runCLI(`release --specifier 0.0.4 --yes`, {
+      timeout: 10 * 60 * 1000,
+    });
     expect(releaseOutput).toMatchInlineSnapshot(`
       NX   Executing pre-version command
       NX   Running release version for project: {project-name}
@@ -264,7 +270,9 @@ describe('release publishable libraries', () => {
     );
     runCLI('sync');
 
-    const releaseOutput = runCLI(`release --specifier 0.0.5 --yes`);
+    const releaseOutput = runCLI(`release --specifier 0.0.5 --yes`, {
+      timeout: 10 * 60 * 1000,
+    });
     expect(releaseOutput).toMatchInlineSnapshot(`
       NX   Executing pre-version command
       NX   Running release version for project: {project-name}
@@ -316,7 +324,9 @@ describe('release publishable libraries', () => {
       `generate @nx/react-native:lib packages/${reactNativeLib} --publishable --importPath=@proj/${reactNativeLib} --no-interactive`
     );
 
-    const releaseOutput = runCLI(`release --specifier 0.0.6 --yes`);
+    const releaseOutput = runCLI(`release --specifier 0.0.6 --yes`, {
+      timeout: 10 * 60 * 1000,
+    });
     expect(releaseOutput).toMatchInlineSnapshot(`
       NX   Executing pre-version command
       NX   Running release version for project: {project-name}


### PR DESCRIPTION
## Current Behavior

`e2e/release/src/release-publishable-libraries.test.ts` intermittently fails with `Command timed out after 300s: release --specifier 0.0.3 --yes`, with output frozen at `NX  Executing pre-version command`.

`nx release` runs a pre-version command (`<pm> dlx nx run-many -t build`) that re-resolves and installs `nx` from the local verdaccio registry on every invocation before building. Under CI/registry load this can exceed the default 5-minute `runCLI` timeout. Because the tests share a single git-tag chain (each test bumps to the next version and tags it), a timeout also **cascades**: the failed test never creates its `vX` tag, so the next test resolves the wrong "current version" and its inline snapshot fails too (e.g. the angular test failing only because the react test timed out).

## Expected Behavior

Every `release` invocation gets a generous 10-minute timeout, so the pre-version `dlx` install has room to complete under load. This removes the timeout and, with it, the downstream snapshot cascade.

## Related Issue(s)

N/A — CI flake fix.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/nrwl-nx---fix-rspack-test-PR-205fdf70)
<!-- polygraph-session-end -->