### PR TITLE
fix(vite): widen vite ts-solution e2e build timeouts for cold multi-lib build

### DIFF
--- a/e2e/vite/src/vite-ts-solution.test.ts
+++ b/e2e/vite/src/vite-ts-solution.test.ts
@@ -106,13 +106,15 @@ ${content}`
     runCLI(`sync`);
 
     // check build
-    expect(runCLI(`build ${reactApp}`)).toContain(
+    expect(runCLI(`build ${reactApp}`, { timeout: 10 * 60 * 1000 })).toContain(
       `Successfully ran target build for project @proj/${reactApp}`
     );
 
     // check typecheck
-    expect(runCLI(`typecheck ${reactApp}`)).toContain(
+    expect(
+      runCLI(`typecheck ${reactApp}`, { timeout: 10 * 60 * 1000 })
+    ).toContain(
       `Successfully ran target typecheck for project @proj/${reactApp}`
     );
-  }, 300_000);
+  }, 1_200_000);
 });


### PR DESCRIPTION
## Current Behavior

`e2e/vite/src/vite-ts-solution.test.ts` ("should generate app and consume libraries with different bundlers") intermittently fails with `Command timed out after 300s: build react-app...`.

The single `build <app>` cold-builds the app's six dependency libraries first (esbuild / rollup / swc / tsc / vite / none) and then the app, serially, in a freshly created TS-solution workspace. Each individual build is sub-second, but the serial total (plus first-run tsc project-reference build, bundler cold starts, and graph computation) can exceed the default 5-minute `runCLI` timeout under CI load. The command hit that 300s `runCLI` cap (separate from the test's own jest timeout).

## Expected Behavior

The `build` and `typecheck` invocations get a 10-minute `runCLI` timeout, and the test's jest timeout is raised to 20 minutes to cover the seven generators + install + sync + build + typecheck end-to-end. CI load no longer tips the cold multi-library build over its budget.

## Related Issue(s)

N/A — CI flake fix.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/nrwl-nx---fix-rspack-test-PR-205fdf70)
<!-- polygraph-session-end -->