### PR TITLE
fix(gradle): track copy/sync and AGP merge task outputs in dependent task inputs

### DIFF
--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -14,6 +14,8 @@ import org.gradle.api.internal.TaskInternal
 import org.gradle.api.internal.provider.ProviderInternal
 import org.gradle.api.internal.provider.TransformBackedProvider
 import org.gradle.api.internal.tasks.DefaultTaskDependency
+import org.gradle.api.tasks.Copy
+import org.gradle.api.tasks.Sync
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.bundling.AbstractArchiveTask
 import org.gradle.api.tasks.compile.AbstractCompile
@@ -29,6 +31,27 @@ private val kotlinCompileToolClass: Class<*>? by lazy {
 
 private fun isKotlinCompileTask(task: Task): Boolean =
     kotlinCompileToolClass?.isInstance(task) == true
+
+// AGP task classes aren't on our classpath; resolve by name (like isKotlinCompileTask).
+// Maintained allow-list of AGP producers whose outputs feed downstream tasks.
+// FQCNs (esp. internal.tasks.*) can move between AGP majors; verify per version.
+private val agpCopyLikeClasses: List<Class<*>> by lazy {
+  listOf(
+          "com.android.build.gradle.tasks.MergeResources",
+          "com.android.build.gradle.tasks.MergeSourceSetFolders",
+          "com.android.build.gradle.tasks.ProcessApplicationManifest",
+          "com.android.build.gradle.internal.tasks.MergeJavaResourceTask",
+      )
+      .mapNotNull { name ->
+        try {
+          Class.forName(name)
+        } catch (e: Throwable) {
+          null
+        }
+      }
+}
+
+private fun isAgpCopyLikeTask(task: Task): Boolean = agpCopyLikeClasses.any { it.isInstance(task) }
 
 /**
  * Process a task and convert it into target Going to populate:
@@ -192,6 +215,16 @@ fun inferExtensionsFromInputProperties(task: Task, dependentTasks: Set<Task>): S
     }
     if (depTask is AbstractCompile || isKotlinCompileTask(depTask)) {
       extensions.add("class")
+    }
+    if (depTask is Copy || depTask is Sync || isAgpCopyLikeTask(depTask)) {
+      try {
+        depTask.inputs.files.forEach { f ->
+          if (f.isFile && f.extension.isNotEmpty()) extensions.add(f.extension)
+        }
+      } catch (e: Exception) {
+        task.logger.debug(
+            "Could not read copy/merge source inputs for ${depTask.path}: ${e.message}")
+      }
     }
   }
 

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
@@ -221,6 +221,149 @@ class ProcessTaskUtilsTest {
     }
 
     @Test
+    fun `test getInputsForTask discovers Copy task source extensions in clean build`() {
+      // Create source files with specific extensions in a source directory
+      val sourceDir = java.io.File("$workspaceRoot/src/resources").apply { mkdirs() }
+      java.io.File(sourceDir, "config.conf").writeText("test config")
+      java.io.File(sourceDir, "data.json").writeText("{}")
+
+      // Create a Copy task that copies from source to destination (but don't populate destination)
+      val copyTask =
+          project.tasks.register("processResources", org.gradle.api.tasks.Copy::class.java).get()
+      copyTask.from(sourceDir)
+      copyTask.into(java.io.File("$workspaceRoot/build/resources"))
+      // Note: we do NOT create/populate the destination directory to simulate a clean build
+
+      // Create a consumer task that depends on the Copy task
+      val consumerTask = project.tasks.register("classes").get()
+      consumerTask.dependsOn(copyTask)
+
+      val gitIgnoreClassifier = GitIgnoreClassifier(java.io.File(workspaceRoot))
+      val result =
+          getInputsForTask(
+              null, consumerTask, projectRoot, workspaceRoot, mutableMapOf(), gitIgnoreClassifier)
+
+      assertNotNull(result, "Result should not be null")
+
+      // Should contain globs for both .conf and .json extensions inferred from Copy task inputs
+      assertTrue(
+          result!!.any {
+            it is Map<*, *> &&
+                it["dependentTasksOutputFiles"] == "**/*.conf" &&
+                it["transitive"] == true
+          },
+          "Expected **/*.conf glob in result: $result")
+      assertTrue(
+          result.any {
+            it is Map<*, *> &&
+                it["dependentTasksOutputFiles"] == "**/*.json" &&
+                it["transitive"] == true
+          },
+          "Expected **/*.json glob in result: $result")
+    }
+
+    @Test
+    fun `test getInputsForTask discovers Sync task source extensions in clean build`() {
+      // Create source files with specific extensions in a source directory
+      val sourceDir = java.io.File("$workspaceRoot/src/sync-input").apply { mkdirs() }
+      java.io.File(sourceDir, "config.conf").writeText("test config")
+      java.io.File(sourceDir, "data.json").writeText("{}")
+
+      // Create a Sync task that syncs from source to destination (but don't populate destination)
+      val syncTask =
+          project.tasks.register("syncResources", org.gradle.api.tasks.Sync::class.java).get()
+      syncTask.from(sourceDir)
+      syncTask.into(java.io.File("$workspaceRoot/build/sync-output"))
+      // Note: we do NOT create/populate the destination directory to simulate a clean build
+
+      // Create a consumer task that depends on the Sync task
+      val consumerTask = project.tasks.register("consumerSync").get()
+      consumerTask.dependsOn(syncTask)
+
+      val gitIgnoreClassifier = GitIgnoreClassifier(java.io.File(workspaceRoot))
+      val result =
+          getInputsForTask(
+              null, consumerTask, projectRoot, workspaceRoot, mutableMapOf(), gitIgnoreClassifier)
+
+      assertNotNull(result, "Result should not be null")
+
+      // Should contain globs for both .conf and .json extensions inferred from Sync task inputs
+      assertTrue(
+          result!!.any {
+            it is Map<*, *> &&
+                it["dependentTasksOutputFiles"] == "**/*.conf" &&
+                it["transitive"] == true
+          },
+          "Expected **/*.conf glob in result for Sync: $result")
+      assertTrue(
+          result.any {
+            it is Map<*, *> &&
+                it["dependentTasksOutputFiles"] == "**/*.json" &&
+                it["transitive"] == true
+          },
+          "Expected **/*.json glob in result for Sync: $result")
+    }
+
+    @Test
+    fun `test getInputsForTask uses archiveExtension for Jar, not source extensions`() {
+      // Create a Jar task with source files
+      val sourceDir = java.io.File("$workspaceRoot/src/main/java").apply { mkdirs() }
+      java.io.File(sourceDir, "Main.java").writeText("public class Main {}")
+
+      val jarTask =
+          project.tasks.register("packageJar", org.gradle.api.tasks.bundling.Jar::class.java).get()
+      jarTask.from(sourceDir)
+      // Set explicit archive extension
+      jarTask.archiveExtension.set("jar")
+      // Do NOT create the archive output file to simulate clean build
+
+      // Create a consumer task that depends on the Jar task
+      val consumerTask = project.tasks.register("consumerJar").get()
+      consumerTask.dependsOn(jarTask)
+
+      val gitIgnoreClassifier = GitIgnoreClassifier(java.io.File(workspaceRoot))
+      val result =
+          getInputsForTask(
+              null, consumerTask, projectRoot, workspaceRoot, mutableMapOf(), gitIgnoreClassifier)
+
+      assertNotNull(result, "Result should not be null")
+
+      // Should contain **/*.jar (from archiveExtension), NOT **/*.java (from source)
+      assertTrue(
+          result!!.any {
+            it is Map<*, *> &&
+                it["dependentTasksOutputFiles"] == "**/*.jar" &&
+                it["transitive"] == true
+          },
+          "Expected **/*.jar glob from archiveExtension in result: $result")
+      assertTrue(
+          result.none { it is Map<*, *> && it["dependentTasksOutputFiles"] == "**/*.java" },
+          "Should NOT have **/*.java glob for Jar task (uses archiveExtension instead): $result")
+    }
+
+    @Test
+    fun `test AGP task detection gracefully handles missing classes in classpath`() {
+      // When AGP classes are not on the classpath, isAgpCopyLikeTask returns false.
+      // This test verifies the detection doesn't crash and gracefully degrades.
+      // Create a plain task (not Copy, Sync, or AGP) as a dependency.
+      val plainTask = project.tasks.register("plainTask").get()
+
+      // Create a consumer task that depends on it
+      val consumerTask = project.tasks.register("consumer").get()
+      consumerTask.dependsOn(plainTask)
+
+      val gitIgnoreClassifier = GitIgnoreClassifier(java.io.File(workspaceRoot))
+
+      // This should not crash even though AGP is not on the classpath
+      val result =
+          getInputsForTask(
+              null, consumerTask, projectRoot, workspaceRoot, mutableMapOf(), gitIgnoreClassifier)
+
+      // Verify it completes without error (graceful degradation)
+      // Result can be null if there are no inputs - thats fine
+    }
+
+    @Test
     fun `test getInputsForTask ignores bin incremental-compilation outputs`() {
       val dependentTask = project.tasks.register("dependentCompile").get()
 


### PR DESCRIPTION
## Problem

A consuming Gradle task that `dependsOn` a `Copy`/`Sync` task did not pick up that task's outputs in its Nx `inputs`. Example: `processResources` (a `Copy`) feeds `classes`, but `classes` only declared `{ "dependentTasksOutputFiles": "**/*.class" }`, so changing a resource did not invalidate the `classes` cache even though `processResources` is a declared `dependsOn`.

## Root cause

`inferExtensionsFromInputProperties` in `TaskUtils.kt` predicts dependent-task output extensions from task *type*, and only handled compile (`AbstractCompile` / Kotlin compile), archive (`AbstractArchiveTask`), and test tasks. `Copy` / `Sync` tasks (including `ProcessResources`) were not handled. On a clean build their output directories are empty, so the file-based output discovery also finds nothing, and no extension is inferred for them.

## Fix

Predict extensions from a `Copy` / `Sync` task's *source* (`inputs.files`). The source files exist at graph-construction time, unlike the (not-yet-produced) outputs. The `dependentTasksOutputFiles` glob is still matched later, at hash time, once the dependency has run and its outputs exist, so predicting the extension set from the source is sufficient and clean-build-safe.

Also matches AGP merge/copy tasks (`MergeResources`, `MergeSourceSetFolders`, `ProcessApplicationManifest`, `MergeJavaResourceTask`) through a reflection-based allow-list, since AGP is not on the plugin's classpath. Missing classes resolve to `null` and are skipped, so non-Android projects are unaffected.

## Tests

`ProcessTaskUtilsTest`:
- `Copy` dependency, clean build (`.conf` / `.json` source, no materialized outputs) → consumer gets `**/*.conf` + `**/*.json`.
- `Sync` dependency, same scenario → same result.
- `Jar` dependency still contributes only its `archiveExtension`, not source extensions.
- Graceful degradation when AGP classes are absent from the classpath.

`./gradlew :gradle-project-graph:test --tests "ProcessTaskUtilsTest"` passes (39 tests, 0 failures); `ktfmtCheck` is clean.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/lively-ferret-e9ee99bb)
<!-- polygraph-session-end -->