### PR TITLE
chore(gradle): bump gradle project graph plugin version to 0.1.23

### DIFF
--- a/packages/gradle/migrations.json
+++ b/packages/gradle/migrations.json
@@ -166,6 +166,13 @@
       "description": "Change dev.nx.gradle.project-graph to version 0.1.22 in build file",
       "factory": "./dist/src/migrations/23-0-0/change-plugin-version-0-1-22",
       "documentation": "./dist/src/migrations/23-0-0/change-plugin-version-0-1-22.md"
+    },
+    "change-plugin-version-0-1-23": {
+      "version": "23.0.0-rc.5",
+      "cli": "nx",
+      "description": "Change dev.nx.gradle.project-graph to version 0.1.23 in build file",
+      "factory": "./dist/src/migrations/23-0-0/change-plugin-version-0-1-23",
+      "documentation": "./dist/src/migrations/23-0-0/change-plugin-version-0-1-23.md"
     }
   },
   "packageJsonUpdates": {}

--- a/packages/gradle/project-graph/build.gradle.kts
+++ b/packages/gradle/project-graph/build.gradle.kts
@@ -10,7 +10,7 @@ plugins {
 
 group = "dev.nx.gradle"
 
-version = "0.1.22"
+version = "0.1.23"
 
 repositories { mavenCentral() }
 

--- a/packages/gradle/src/migrations/23-0-0/change-plugin-version-0-1-23.md
+++ b/packages/gradle/src/migrations/23-0-0/change-plugin-version-0-1-23.md
@@ -1,0 +1,21 @@
+#### Change dev.nx.gradle.project-graph to version 0.1.23
+
+Change dev.nx.gradle.project-graph to version 0.1.23 in build file
+
+#### Sample Code Changes
+
+##### Before
+
+```text title="build.gradle"
+plugins {
+id "dev.nx.gradle.project-graph" version "0.1.22"
+}
+```
+
+##### After
+
+```text title="build.gradle"
+plugins {
+id "dev.nx.gradle.project-graph" version "0.1.23"
+}
+```

--- a/packages/gradle/src/migrations/23-0-0/change-plugin-version-0-1-23.ts
+++ b/packages/gradle/src/migrations/23-0-0/change-plugin-version-0-1-23.ts
@@ -1,0 +1,24 @@
+import { Tree, readNxJson } from '@nx/devkit';
+import { hasGradlePlugin } from '../../utils/has-gradle-plugin';
+import { addNxProjectGraphPlugin } from '../../generators/init/gradle-project-graph-plugin-utils';
+import { updateNxPluginVersionInCatalogsAst } from '../../utils/version-catalog-ast-utils';
+
+/* Change the plugin version to 0.1.23
+ */
+export default async function update(tree: Tree) {
+  const nxJson = readNxJson(tree);
+  if (!nxJson) {
+    return;
+  }
+  if (!hasGradlePlugin(tree)) {
+    return;
+  }
+
+  const gradlePluginVersionToUpdate = '0.1.23';
+
+  // Update version in version catalogs using AST-based approach to preserve formatting
+  await updateNxPluginVersionInCatalogsAst(tree, gradlePluginVersionToUpdate);
+
+  // Then update in build.gradle(.kts) files
+  await addNxProjectGraphPlugin(tree, gradlePluginVersionToUpdate);
+}

--- a/packages/gradle/src/utils/versions.ts
+++ b/packages/gradle/src/utils/versions.ts
@@ -2,4 +2,4 @@ import { join } from 'path';
 export const nxVersion = require(join('@nx/gradle', 'package.json')).version;
 
 export const gradleProjectGraphPluginName = 'dev.nx.gradle.project-graph';
-export const gradleProjectGraphVersion = '0.1.22';
+export const gradleProjectGraphVersion = '0.1.23';


### PR DESCRIPTION
## What

Bumps `dev.nx.gradle.project-graph` from `0.1.22` to `0.1.23` and adds the standard migration so existing workspaces pick up the new plugin.

This ships the fix from #36099 (track `Copy` / `Sync` and AGP merge task outputs in dependent task inputs), which lives in the Gradle companion plugin and only takes effect once the plugin version is published and consumed.

## Changes

- `packages/gradle/src/utils/versions.ts` — `gradleProjectGraphVersion` → `0.1.23`
- `packages/gradle/project-graph/build.gradle.kts` — `version` → `0.1.23`
- `packages/gradle/src/migrations/23-0-0/change-plugin-version-0-1-23.ts` / `.md` — migration that updates the plugin version in build files and version catalogs
- `packages/gradle/migrations.json` — migration entry, triggered at nx `23.0.0-rc.5`

Follows the recurring `nx-gradle-plugin-version-bump` pattern (same 5-file footprint as the previous bump to `0.1.22`).

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/lively-ferret-e9ee99bb)
<!-- polygraph-session-end -->