### PR TITLE
docs(misc): retitle technology pages for SEO and rework the Module Federation overview

### DIFF
--- a/astro-docs/src/content/docs/concepts/Decisions/overview.mdoc
+++ b/astro-docs/src/content/docs/concepts/Decisions/overview.mdoc
@@ -1,10 +1,10 @@
 ---
-title: Monorepo or Polyrepo
-description: Evaluate the organizational considerations for choosing between monorepo and polyrepo approaches, including team agreements on code management and workflows.
+title: 'Monorepo vs Polyrepo: How to Choose'
+description: Monorepo vs polyrepo comes down to how your teams agree to manage code, dependencies, ownership, and CI, not just technical limits.
 filter: 'type:Concepts'
 ---
 
-Monorepos have a lot of benefits, but there are also some costs involved. We feel strongly that the [technical challenges](/docs/concepts/decisions/why-monorepos) involved in maintaining large monorepos are fully addressed through the efficient use of Nx and Nx Cloud. Rather, the limiting factors in how large your monorepo grows are interpersonal.
+A monorepo keeps many projects in one repository, while a polyrepo splits them across separate ones. Both work well with Nx, so choosing between them is mostly an organizational decision rather than a technical one. Nx and Nx Cloud address the [technical challenges](/docs/concepts/decisions/why-monorepos) of maintaining a large monorepo, so the limiting factors in how large your monorepo grows are interpersonal.
 
 In order for teams to work together in a monorepo, they need to agree on how that repository is going to be managed. These questions can be answered in many different ways, but if the developers in the repository can't agree on the answers, then they'll need to work in separate repositories.
 

--- a/astro-docs/src/content/docs/guides/Adopting Nx/nx-vs-turborepo.mdoc
+++ b/astro-docs/src/content/docs/guides/Adopting Nx/nx-vs-turborepo.mdoc
@@ -1,6 +1,6 @@
 ---
 title: Nx vs Turborepo
-description: A data-driven comparison of Nx and Turborepo covering setup complexity, CI performance, and advanced capabilities.
+description: Nx vs Turborepo on the same workspace, with distributed CI in 9m 20s vs 19m 18s, task sandboxing, polyglot builds, generators, and release management.
 filter: 'type:Guides'
 sidebar:
   label: Nx vs Turborepo

--- a/astro-docs/src/content/docs/guides/Tips-n-Tricks/bun-workspaces.mdoc
+++ b/astro-docs/src/content/docs/guides/Tips-n-Tricks/bun-workspaces.mdoc
@@ -4,7 +4,7 @@ description: Set up a Bun workspace and add Nx in one command to get cached task
 filter: 'type:Guides'
 ---
 
-A Bun workspace lets you manage multiple packages in a single repository. Adding Nx to a Bun workspace gives you cached tasks, affected-only builds, and faster CI, while Bun keeps managing installs. This recipe sets up a Bun workspace and then adds Nx.
+A Bun workspace lets you manage multiple packages in a single repository. Adding Nx to a Bun workspace gives you cached tasks, affected-only builds, and faster CI, while Bun keeps managing installs. Set up a Bun workspace first, then add Nx.
 
 ## Set up a Bun workspace
 
@@ -51,7 +51,7 @@ Run `bun install` once at the root to install every package's dependencies and l
 
 ## Add Nx in one command
 
-Nx layers task running and caching on top of your existing Bun workspace. Bun still installs and resolves packages; Nx makes your tasks cacheable and your CI affected-aware. Add it with one command, which works on any npm, Yarn, pnpm, or Bun workspace:
+Nx layers task running and caching on top of your existing Bun workspace. Bun still installs and resolves packages. Nx makes your tasks cacheable and your CI affected-aware. Add it with one command, which works on any npm, Yarn, pnpm, or Bun workspace:
 
 ```shell
 npx nx@latest init
@@ -76,7 +76,7 @@ nx build web           # a single project
 nx affected -t build   # only projects touched by your changes
 ```
 
-The first run executes your scripts. A second run with no changes is [restored from the cache](/docs/features/cache-task-results) instantly, and [`nx affected`](/docs/features/ci-features/affected) skips the projects your change does not touch.
+The first run executes your scripts. A second run with no changes is [restored from the cache](/docs/features/cache-task-results), and [`nx affected`](/docs/features/ci-features/affected) skips the projects your change does not touch.
 
 ## How task caching works
 
@@ -96,4 +96,6 @@ The first run executes your scripts. A second run with no changes is [restored f
 
 `cache: true` makes a target cacheable: Nx hashes each project's inputs (source files, dependencies, and config) and restores its outputs from the cache when nothing has changed. `dependsOn: ["^build"]` builds a project's dependencies first. Nothing is cached unless you opt in, so you stay in control.
 
-In CI, turn on [remote caching](/docs/features/ci-features/remote-cache) and [task distribution](/docs/features/ci-features/distribute-task-execution) to share the cache across machines and parallelize tasks. For a deeper walkthrough, see [Adding Nx to an NPM/Yarn/PNPM Workspace](/docs/guides/adopting-nx/adding-to-monorepo).
+In CI, turn on [remote caching](/docs/features/ci-features/remote-cache) and [task distribution](/docs/features/ci-features/distribute-task-execution) to share the cache across machines and parallelize tasks.
+
+For a deeper walkthrough, see [Adding Nx to an NPM/Yarn/PNPM Workspace](/docs/guides/adopting-nx/adding-to-monorepo).

--- a/astro-docs/src/content/docs/guides/Tips-n-Tricks/npm-workspaces.mdoc
+++ b/astro-docs/src/content/docs/guides/Tips-n-Tricks/npm-workspaces.mdoc
@@ -4,7 +4,7 @@ description: Set up an npm workspace and add Nx in one command to get cached tas
 filter: 'type:Guides'
 ---
 
-An npm workspace lets you manage multiple packages in a single repository. Adding Nx to an npm workspace gives you cached tasks, affected-only builds, and faster CI, while npm keeps managing installs. This recipe sets up an npm workspace and then adds Nx.
+An npm workspace lets you manage multiple packages in a single repository. Adding Nx to an npm workspace gives you cached tasks, affected-only builds, and faster CI, while npm keeps managing installs. Set up an npm workspace first, then add Nx.
 
 ## Set up an npm workspace
 
@@ -51,7 +51,7 @@ Run `npm install` once at the root to install every package's dependencies and l
 
 ## Add Nx in one command
 
-Nx layers task running and caching on top of your existing npm workspace. npm still installs and resolves packages; Nx makes your tasks cacheable and your CI affected-aware. Add it with one command, which works on any npm, Yarn, pnpm, or Bun workspace:
+Nx layers task running and caching on top of your existing npm workspace. npm still installs and resolves packages. Nx makes your tasks cacheable and your CI affected-aware. Add it with one command, which works on any npm, Yarn, pnpm, or Bun workspace:
 
 ```shell
 npx nx@latest init
@@ -76,7 +76,7 @@ nx build web           # a single project
 nx affected -t build   # only projects touched by your changes
 ```
 
-The first run executes your scripts. A second run with no changes is [restored from the cache](/docs/features/cache-task-results) instantly, and [`nx affected`](/docs/features/ci-features/affected) skips the projects your change does not touch.
+The first run executes your scripts. A second run with no changes is [restored from the cache](/docs/features/cache-task-results), and [`nx affected`](/docs/features/ci-features/affected) skips the projects your change does not touch.
 
 ## How task caching works
 
@@ -96,4 +96,6 @@ The first run executes your scripts. A second run with no changes is [restored f
 
 `cache: true` makes a target cacheable: Nx hashes each project's inputs (source files, dependencies, and config) and restores its outputs from the cache when nothing has changed. `dependsOn: ["^build"]` builds a project's dependencies first. Nothing is cached unless you opt in, so you stay in control.
 
-In CI, turn on [remote caching](/docs/features/ci-features/remote-cache) and [task distribution](/docs/features/ci-features/distribute-task-execution) to share the cache across machines and parallelize tasks. For a deeper walkthrough, see [Adding Nx to an NPM/Yarn/PNPM Workspace](/docs/guides/adopting-nx/adding-to-monorepo).
+In CI, turn on [remote caching](/docs/features/ci-features/remote-cache) and [task distribution](/docs/features/ci-features/distribute-task-execution) to share the cache across machines and parallelize tasks.
+
+For a deeper walkthrough, see [Adding Nx to an NPM/Yarn/PNPM Workspace](/docs/guides/adopting-nx/adding-to-monorepo).

--- a/astro-docs/src/content/docs/guides/Tips-n-Tricks/pnpm-workspaces.mdoc
+++ b/astro-docs/src/content/docs/guides/Tips-n-Tricks/pnpm-workspaces.mdoc
@@ -4,7 +4,7 @@ description: Set up a pnpm workspace and add Nx in one command to get cached tas
 filter: 'type:Guides'
 ---
 
-A pnpm workspace lets you manage multiple packages in a single repository. Adding Nx to a pnpm workspace gives you cached tasks, affected-only builds, and faster CI, while pnpm keeps managing installs. This recipe sets up a pnpm workspace and then adds Nx.
+A pnpm workspace lets you manage multiple packages in a single repository. Adding Nx to a pnpm workspace gives you cached tasks, affected-only builds, and faster CI, while pnpm keeps managing installs. Set up a pnpm workspace first, then add Nx.
 
 ## Set up a pnpm workspace
 
@@ -50,7 +50,7 @@ Run `pnpm install` once at the root to install every package's dependencies and 
 
 ## Add Nx in one command
 
-Nx layers task running and caching on top of your existing pnpm workspace. pnpm still installs and resolves packages; Nx makes your tasks cacheable and your CI affected-aware. Add it with one command, which works on any npm, Yarn, pnpm, or Bun workspace:
+Nx layers task running and caching on top of your existing pnpm workspace. pnpm still installs and resolves packages. Nx makes your tasks cacheable and your CI affected-aware. Add it with one command, which works on any npm, Yarn, pnpm, or Bun workspace:
 
 ```shell
 npx nx@latest init
@@ -75,7 +75,7 @@ nx build web           # a single project
 nx affected -t build   # only projects touched by your changes
 ```
 
-The first run executes your scripts. A second run with no changes is [restored from the cache](/docs/features/cache-task-results) instantly, and [`nx affected`](/docs/features/ci-features/affected) skips the projects your change does not touch.
+The first run executes your scripts. A second run with no changes is [restored from the cache](/docs/features/cache-task-results), and [`nx affected`](/docs/features/ci-features/affected) skips the projects your change does not touch.
 
 ## How task caching works
 
@@ -95,4 +95,6 @@ The first run executes your scripts. A second run with no changes is [restored f
 
 `cache: true` makes a target cacheable: Nx hashes each project's inputs (source files, dependencies, and config) and restores its outputs from the cache when nothing has changed. `dependsOn: ["^build"]` builds a project's dependencies first. Nothing is cached unless you opt in, so you stay in control.
 
-In CI, turn on [remote caching](/docs/features/ci-features/remote-cache) and [task distribution](/docs/features/ci-features/distribute-task-execution) to share the cache across machines and parallelize tasks. For a deeper walkthrough, see [Adding Nx to an NPM/Yarn/PNPM Workspace](/docs/guides/adopting-nx/adding-to-monorepo) or the [From pnpm Workspaces to Distributed CI](/courses/pnpm-nx-next/lessons-00-overview) course.
+In CI, turn on [remote caching](/docs/features/ci-features/remote-cache) and [task distribution](/docs/features/ci-features/distribute-task-execution) to share the cache across machines and parallelize tasks.
+
+For a deeper walkthrough, see [Adding Nx to an NPM/Yarn/PNPM Workspace](/docs/guides/adopting-nx/adding-to-monorepo) or the [From pnpm Workspaces to Distributed CI](/courses/pnpm-nx-next/lessons-00-overview) course.

--- a/astro-docs/src/content/docs/guides/Tips-n-Tricks/yarn-workspaces.mdoc
+++ b/astro-docs/src/content/docs/guides/Tips-n-Tricks/yarn-workspaces.mdoc
@@ -4,7 +4,7 @@ description: Set up a Yarn workspace and add Nx in one command to get cached tas
 filter: 'type:Guides'
 ---
 
-A Yarn workspace lets you manage multiple packages in a single repository. Adding Nx to a Yarn workspace gives you cached tasks, affected-only builds, and faster CI, while Yarn keeps managing installs. This recipe sets up a Yarn workspace and then adds Nx.
+A Yarn workspace lets you manage multiple packages in a single repository. Adding Nx to a Yarn workspace gives you cached tasks, affected-only builds, and faster CI, while Yarn keeps managing installs. Set up a Yarn workspace first, then add Nx.
 
 {% aside type="note" title="Looking for Yarn PnP?" %}
 This recipe covers Yarn's workspaces feature. If you use Yarn's Plug'n'Play install mode, see [Using Yarn PnP with Nx](/docs/guides/tips-n-tricks/yarn-pnp).
@@ -55,7 +55,7 @@ Run `yarn install` once at the root to install every package's dependencies and 
 
 ## Add Nx in one command
 
-Nx layers task running and caching on top of your existing Yarn workspace. Yarn still installs and resolves packages; Nx makes your tasks cacheable and your CI affected-aware. Add it with one command, which works on any npm, Yarn, pnpm, or Bun workspace:
+Nx layers task running and caching on top of your existing Yarn workspace. Yarn still installs and resolves packages. Nx makes your tasks cacheable and your CI affected-aware. Add it with one command, which works on any npm, Yarn, pnpm, or Bun workspace:
 
 ```shell
 npx nx@latest init
@@ -80,7 +80,7 @@ nx build web           # a single project
 nx affected -t build   # only projects touched by your changes
 ```
 
-The first run executes your scripts. A second run with no changes is [restored from the cache](/docs/features/cache-task-results) instantly, and [`nx affected`](/docs/features/ci-features/affected) skips the projects your change does not touch.
+The first run executes your scripts. A second run with no changes is [restored from the cache](/docs/features/cache-task-results), and [`nx affected`](/docs/features/ci-features/affected) skips the projects your change does not touch.
 
 ## How task caching works
 
@@ -100,4 +100,6 @@ The first run executes your scripts. A second run with no changes is [restored f
 
 `cache: true` makes a target cacheable: Nx hashes each project's inputs (source files, dependencies, and config) and restores its outputs from the cache when nothing has changed. `dependsOn: ["^build"]` builds a project's dependencies first. Nothing is cached unless you opt in, so you stay in control.
 
-In CI, turn on [remote caching](/docs/features/ci-features/remote-cache) and [task distribution](/docs/features/ci-features/distribute-task-execution) to share the cache across machines and parallelize tasks. For a deeper walkthrough, see [Adding Nx to an NPM/Yarn/PNPM Workspace](/docs/guides/adopting-nx/adding-to-monorepo).
+In CI, turn on [remote caching](/docs/features/ci-features/remote-cache) and [task distribution](/docs/features/ci-features/distribute-task-execution) to share the cache across machines and parallelize tasks.
+
+For a deeper walkthrough, see [Adding Nx to an NPM/Yarn/PNPM Workspace](/docs/guides/adopting-nx/adding-to-monorepo).

--- a/astro-docs/src/content/docs/reference/angular/index.mdoc
+++ b/astro-docs/src/content/docs/reference/angular/index.mdoc
@@ -6,4 +6,6 @@ sidebar:
 pagefind: false
 ---
 
+For setup and guides, see [Nx with Angular](/docs/technologies/angular/introduction). The pages below are the API reference.
+
 {% sidebar_group_cards group="Reference/Angular" /%}

--- a/astro-docs/src/content/docs/reference/cypress/index.mdoc
+++ b/astro-docs/src/content/docs/reference/cypress/index.mdoc
@@ -6,4 +6,6 @@ sidebar:
 pagefind: false
 ---
 
+For setup and guides, see [Nx with Cypress](/docs/technologies/test-tools/cypress/introduction). The pages below are the API reference.
+
 {% sidebar_group_cards group="Reference/Cypress" /%}

--- a/astro-docs/src/content/docs/reference/detox/index.mdoc
+++ b/astro-docs/src/content/docs/reference/detox/index.mdoc
@@ -6,4 +6,6 @@ sidebar:
 pagefind: false
 ---
 
+For setup and guides, see [Nx with Detox](/docs/technologies/test-tools/detox/introduction). The pages below are the API reference.
+
 {% sidebar_group_cards group="Reference/Detox" /%}

--- a/astro-docs/src/content/docs/reference/dotnet/index.mdoc
+++ b/astro-docs/src/content/docs/reference/dotnet/index.mdoc
@@ -6,4 +6,6 @@ sidebar:
 pagefind: false
 ---
 
+For setup and guides, see [Nx with .NET](/docs/technologies/dotnet/introduction). The pages below are the API reference.
+
 {% sidebar_group_cards group="Reference/.NET" /%}

--- a/astro-docs/src/content/docs/reference/esbuild/index.mdoc
+++ b/astro-docs/src/content/docs/reference/esbuild/index.mdoc
@@ -6,4 +6,6 @@ sidebar:
 pagefind: false
 ---
 
+For setup and guides, see [Nx with esbuild](/docs/technologies/build-tools/esbuild/introduction). The pages below are the API reference.
+
 {% sidebar_group_cards group="Reference/ESBuild" /%}

--- a/astro-docs/src/content/docs/reference/eslint/index.mdoc
+++ b/astro-docs/src/content/docs/reference/eslint/index.mdoc
@@ -6,4 +6,6 @@ sidebar:
 pagefind: false
 ---
 
+For setup and guides, see [Nx with ESLint](/docs/technologies/eslint/introduction). The pages below are the API reference.
+
 {% sidebar_group_cards group="Reference/ESLint" /%}

--- a/astro-docs/src/content/docs/reference/java/index.mdoc
+++ b/astro-docs/src/content/docs/reference/java/index.mdoc
@@ -6,4 +6,6 @@ sidebar:
 pagefind: false
 ---
 
+For setup and guides, see [Nx with Java](/docs/technologies/java/introduction). The pages below are the API reference.
+
 {% sidebar_group_cards group="Reference/Java" /%}

--- a/astro-docs/src/content/docs/reference/jest/index.mdoc
+++ b/astro-docs/src/content/docs/reference/jest/index.mdoc
@@ -6,4 +6,6 @@ sidebar:
 pagefind: false
 ---
 
+For setup and guides, see [Nx with Jest](/docs/technologies/test-tools/jest/introduction). The pages below are the API reference.
+
 {% sidebar_group_cards group="Reference/Jest" /%}

--- a/astro-docs/src/content/docs/reference/module-federation/index.mdoc
+++ b/astro-docs/src/content/docs/reference/module-federation/index.mdoc
@@ -6,4 +6,6 @@ sidebar:
 pagefind: false
 ---
 
+For setup and guides, see [Nx with Module Federation](/docs/technologies/module-federation/introduction). The pages below are the API reference.
+
 {% sidebar_group_cards group="Reference/Module Federation" /%}

--- a/astro-docs/src/content/docs/reference/node/index.mdoc
+++ b/astro-docs/src/content/docs/reference/node/index.mdoc
@@ -6,4 +6,6 @@ sidebar:
 pagefind: false
 ---
 
+For setup and guides, see [Nx with Node.js](/docs/technologies/node/introduction). The pages below are the API reference.
+
 {% sidebar_group_cards group="Reference/Node" /%}

--- a/astro-docs/src/content/docs/reference/playwright/index.mdoc
+++ b/astro-docs/src/content/docs/reference/playwright/index.mdoc
@@ -6,4 +6,6 @@ sidebar:
 pagefind: false
 ---
 
+For setup and guides, see [Nx with Playwright](/docs/technologies/test-tools/playwright/introduction). The pages below are the API reference.
+
 {% sidebar_group_cards group="Reference/Playwright" /%}

--- a/astro-docs/src/content/docs/reference/react/index.mdoc
+++ b/astro-docs/src/content/docs/reference/react/index.mdoc
@@ -6,4 +6,6 @@ sidebar:
 pagefind: false
 ---
 
+For setup and guides, see [Nx with React](/docs/technologies/react/introduction). The pages below are the API reference.
+
 {% sidebar_group_cards group="Reference/React" /%}

--- a/astro-docs/src/content/docs/reference/rollup/index.mdoc
+++ b/astro-docs/src/content/docs/reference/rollup/index.mdoc
@@ -6,4 +6,6 @@ sidebar:
 pagefind: false
 ---
 
+For setup and guides, see [Nx with Rollup](/docs/technologies/build-tools/rollup/introduction). The pages below are the API reference.
+
 {% sidebar_group_cards group="Reference/Rollup" /%}

--- a/astro-docs/src/content/docs/reference/rsbuild/index.mdoc
+++ b/astro-docs/src/content/docs/reference/rsbuild/index.mdoc
@@ -6,4 +6,6 @@ sidebar:
 pagefind: false
 ---
 
+For setup and guides, see [Nx with Rsbuild](/docs/technologies/build-tools/rsbuild/introduction). The pages below are the API reference.
+
 {% sidebar_group_cards group="Reference/Rsbuild" /%}

--- a/astro-docs/src/content/docs/reference/rspack/index.mdoc
+++ b/astro-docs/src/content/docs/reference/rspack/index.mdoc
@@ -6,4 +6,6 @@ sidebar:
 pagefind: false
 ---
 
+For setup and guides, see [Nx with Rspack](/docs/technologies/build-tools/rspack/introduction). The pages below are the API reference.
+
 {% sidebar_group_cards group="Reference/Rspack" /%}

--- a/astro-docs/src/content/docs/reference/storybook/index.mdoc
+++ b/astro-docs/src/content/docs/reference/storybook/index.mdoc
@@ -6,4 +6,6 @@ sidebar:
 pagefind: false
 ---
 
+For setup and guides, see [Nx with Storybook](/docs/technologies/test-tools/storybook/introduction). The pages below are the API reference.
+
 {% sidebar_group_cards group="Reference/Storybook" /%}

--- a/astro-docs/src/content/docs/reference/typescript/index.mdoc
+++ b/astro-docs/src/content/docs/reference/typescript/index.mdoc
@@ -6,4 +6,6 @@ sidebar:
 pagefind: false
 ---
 
+For setup and guides, see [Nx with TypeScript](/docs/technologies/typescript/introduction). The pages below are the API reference.
+
 {% sidebar_group_cards group="Reference/TypeScript" /%}

--- a/astro-docs/src/content/docs/reference/vite/index.mdoc
+++ b/astro-docs/src/content/docs/reference/vite/index.mdoc
@@ -6,4 +6,6 @@ sidebar:
 pagefind: false
 ---
 
+For setup and guides, see [Nx with Vite](/docs/technologies/build-tools/vite/introduction). The pages below are the API reference.
+
 {% sidebar_group_cards group="Reference/Vite" /%}

--- a/astro-docs/src/content/docs/reference/vitest/index.mdoc
+++ b/astro-docs/src/content/docs/reference/vitest/index.mdoc
@@ -6,4 +6,6 @@ sidebar:
 pagefind: false
 ---
 
+For setup and guides, see [Nx with Vitest](/docs/technologies/test-tools/vitest/introduction). The pages below are the API reference.
+
 {% sidebar_group_cards group="Reference/Vitest" /%}

--- a/astro-docs/src/content/docs/reference/vue/index.mdoc
+++ b/astro-docs/src/content/docs/reference/vue/index.mdoc
@@ -6,4 +6,6 @@ sidebar:
 pagefind: false
 ---
 
+For setup and guides, see [Nx with Vue](/docs/technologies/vue/introduction). The pages below are the API reference.
+
 {% sidebar_group_cards group="Reference/Vue" /%}

--- a/astro-docs/src/content/docs/reference/webpack/index.mdoc
+++ b/astro-docs/src/content/docs/reference/webpack/index.mdoc
@@ -6,4 +6,6 @@ sidebar:
 pagefind: false
 ---
 
+For setup and guides, see [Nx with Webpack](/docs/technologies/build-tools/webpack/introduction). The pages below are the API reference.
+
 {% sidebar_group_cards group="Reference/Webpack" /%}

--- a/astro-docs/src/content/docs/technologies/angular/angular-rsbuild/index.mdoc
+++ b/astro-docs/src/content/docs/technologies/angular/angular-rsbuild/index.mdoc
@@ -6,4 +6,6 @@ description: Using Rsbuild with Angular
 pagefind: false
 ---
 
+Get started with [Nx with Angular Rsbuild](/docs/technologies/angular/angular-rsbuild/introduction), or browse the topics below.
+
 {% index_page_cards path="technologies/angular/angular-rsbuild" /%}

--- a/astro-docs/src/content/docs/technologies/angular/angular-rsbuild/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/angular/angular-rsbuild/introduction.mdoc
@@ -1,6 +1,6 @@
 ---
-title: 'Angular Rsbuild Plugin for Nx'
-description: 'Use Rsbuild as the build tool for Angular applications in your Nx workspace with the @nx/angular-rsbuild plugin.'
+title: Nx with Angular Rsbuild
+description: Use Angular Rsbuild with Nx to build and cache Angular projects across your monorepo, with affected-only builds and distributed CI.
 sidebar:
   label: 'Introduction'
 weight: 2
@@ -390,3 +390,9 @@ Enables usage of TypeScript project references.
 
 `boolean` `default: true`
 When true, creates a separate bundle for vendor (third-party) code.
+
+## Set up CI
+
+In CI, Nx runs [`nx affected`](/docs/features/ci-features/affected) to rebuild and retest only the projects a change touches, and [caches](/docs/features/cache-task-results) results to skip repeated work.
+
+For a complete pipeline, see [Set up CI](/docs/getting-started/setup-ci).

--- a/astro-docs/src/content/docs/technologies/angular/angular-rspack/index.mdoc
+++ b/astro-docs/src/content/docs/technologies/angular/angular-rspack/index.mdoc
@@ -6,4 +6,6 @@ description: Using Rspack with Angular
 pagefind: false
 ---
 
+Get started with [Nx with Angular Rspack](/docs/technologies/angular/angular-rspack/introduction), or browse the topics below.
+
 {% index_page_cards path="technologies/angular/angular-rspack" /%}

--- a/astro-docs/src/content/docs/technologies/angular/angular-rspack/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/angular/angular-rspack/introduction.mdoc
@@ -1,6 +1,6 @@
 ---
-title: 'Angular Rspack Plugin for Nx'
-description: 'Learn how Rspack can help you speed up your Angular applications.'
+title: Nx with Angular Rspack
+description: Use Angular Rspack with Nx to build and cache Angular projects across your monorepo, with affected-only builds and distributed CI.
 sidebar:
   label: 'Introduction'
 weight: 2
@@ -76,3 +76,9 @@ Below is a table of benchmarks for different bundlers, tested on an application 
 | Rspack        | 30.589       | 19.269   | 19.940  |
 
 You can find the benchmarks and run them yourself: [https://github.com/nrwl/ng-bundler-benchmark](https://github.com/nrwl/ng-bundler-benchmark)
+
+## Set up CI
+
+In CI, Nx runs [`nx affected`](/docs/features/ci-features/affected) to rebuild and retest only the projects a change touches, and [caches](/docs/features/cache-task-results) results to skip repeated work.
+
+For a complete pipeline, see [Set up CI](/docs/getting-started/setup-ci).

--- a/astro-docs/src/content/docs/technologies/angular/index.mdoc
+++ b/astro-docs/src/content/docs/technologies/angular/index.mdoc
@@ -6,4 +6,6 @@ description: Build scalable Angular applications with Nx powerful tooling and ge
 pagefind: false
 ---
 
+Get started with [Nx with Angular](/docs/technologies/angular/introduction), or browse the topics below.
+
 {% index_page_cards path="technologies/angular" /%}

--- a/astro-docs/src/content/docs/technologies/angular/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/angular/introduction.mdoc
@@ -1,6 +1,6 @@
 ---
-title: Angular Plugin for Nx
-description: Use @nx/angular to create, run, and maintain Angular applications and libraries in an Nx workspace.
+title: Nx with Angular
+description: Nx scales your Angular monorepo with caching, distributed task execution, and affected-only builds.
 keywords: [angular]
 sidebar:
   label: Introduction
@@ -9,8 +9,8 @@ weight: 2
 filter: 'type:References'
 ---
 
-[Angular](https://angular.dev) is a framework for building web applications. Nx has first party support for Angular projects. If you're familiar with the Angular CLI, `ng`, then Nx CLI will feel very familiar.
-The `@nx/angular` plugin adds [generators](#local-development), Angular CLI builder integration (executors) and migrations so you can run Angular tasks through Nx. With Nx, each project has its own configuration instead of a single `angular.json` file, making it more scalable for monorepos.
+[Angular](https://angular.dev) is a framework for building web applications, and Nx is the platform for scaling your Angular monorepo. Nx has first party support for Angular projects, so if you're familiar with the Angular CLI, `ng`, then the Nx CLI will feel very familiar.
+The `@nx/angular` plugin adds [generators](#local-development), Angular CLI builder integration (executors) and migrations so you can run Angular tasks through Nx. With Nx, each project has its own configuration instead of a single `angular.json` file, making it more scalable for Angular monorepos.
 You can use Angular with Nx without the plugin and still get [task caching](/docs/features/cache-task-results), [task orchestration](/docs/features/run-tasks), and the [project graph](/docs/features/explore-graph).
 
 ## Requirements
@@ -123,23 +123,11 @@ nx g @nx/angular:remote apps/login --host=shell
 
 Pass `--dynamic` for [dynamic federation](/docs/technologies/angular/guides/dynamic-module-federation-with-angular) (remotes resolved at runtime) or `--ssr` for [server-side rendering with Module Federation](/docs/technologies/angular/guides/module-federation-with-ssr).
 
-## CI considerations
+## Set up CI for your Angular monorepo
 
-Run only what changed using the project graph:
+In CI, Nx runs [`nx affected`](/docs/features/ci-features/affected) to rebuild and retest only the projects a change touches, and [caches](/docs/features/cache-task-results) results to skip repeated work.
 
-```shell
-nx affected -t build test lint e2e
-```
-
-Enable remote caching for faster CI runs:
-
-```shell
-nx connect
-```
-
-If you use Angular CLI configurations, define a `ci` configuration in `angular.json` and run tasks with `--configuration=ci` for CI-specific settings.
-
-See [Set Up CI](/docs/guides/nx-cloud/setup-ci) for a sample CI setup.
+For a complete pipeline, see [Set up CI](/docs/getting-started/setup-ci).
 
 ## What's next
 

--- a/astro-docs/src/content/docs/technologies/build-tools/docker/index.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/docker/index.mdoc
@@ -6,4 +6,6 @@ description: Containerize your projects with Docker and Nx
 pagefind: false
 ---
 
+Get started with [Nx with Docker](/docs/technologies/build-tools/docker/introduction), or browse the topics below.
+
 {% index_page_cards path="technologies/build-tools/docker" /%}

--- a/astro-docs/src/content/docs/technologies/build-tools/docker/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/docker/introduction.mdoc
@@ -1,6 +1,6 @@
 ---
-title: Docker Plugin for Nx
-description: The Nx Plugin for Docker contains executors and utilities for building and publishing docker images within an Nx workspace.
+title: Nx with Docker
+description: Use Docker with Nx to build, cache, and deploy containerized projects from your monorepo.
 keywords: [docker]
 sidebar:
   label: Introduction
@@ -188,3 +188,9 @@ The `@nx/docker` plugin provides a `nx-release-publish` target for publishing do
 [Nx Release](/docs/features/manage-releases) was also updated to support versioning docker images, generating changelogs, and publishing docker images to a registry through a single command.
 
 You can learn more about how to manage releases for Docker Images in the [Release Docker Images](/docs/guides/nx-release/release-docker-images) guide.
+
+## Set up CI
+
+In CI, Nx runs [`nx affected`](/docs/features/ci-features/affected) to rebuild and retest only the projects a change touches, and [caches](/docs/features/cache-task-results) results to skip repeated work.
+
+For a complete pipeline, see [Set up CI](/docs/getting-started/setup-ci).

--- a/astro-docs/src/content/docs/technologies/build-tools/esbuild/index.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/esbuild/index.mdoc
@@ -6,4 +6,6 @@ description: Fast JavaScript bundler
 pagefind: false
 ---
 
+Get started with [Nx with esbuild](/docs/technologies/build-tools/esbuild/introduction), or browse the topics below.
+
 {% index_page_cards path="technologies/build-tools/esbuild" /%}

--- a/astro-docs/src/content/docs/technologies/build-tools/esbuild/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/esbuild/introduction.mdoc
@@ -1,13 +1,13 @@
 ---
-title: esbuild Plugin for Nx
-description: The Nx Plugin for esbuild contains executors and generators that support building applications using esbuild, including setup and configuration for your Nx workspace.
+title: Nx with esbuild
+description: Use esbuild with Nx to build and cache projects across your monorepo, with affected-only builds and distributed CI.
 sidebar:
   label: Introduction
 weight: 2
 filter: 'type:References'
 ---
 
-The Nx Plugin for [esbuild](https://esbuild.github.io/api/), an extremely fast JavaScript bundler.
+The Nx Plugin for [esbuild](https://esbuild.github.io/api/), an extremely fast JavaScript bundler. Use it to build and cache projects in an esbuild monorepo, with type-checking and asset handling layered on top.
 
 ## Requirements
 
@@ -148,3 +148,9 @@ Extra API options for esbuild can be passed in the `esbuildOptions` object for y
 ## More documentation
 
 - [Using JS](/docs/technologies/typescript/introduction)
+
+## Set up CI for your esbuild monorepo
+
+In CI, Nx runs [`nx affected`](/docs/features/ci-features/affected) to rebuild and retest only the projects a change touches, and [caches](/docs/features/cache-task-results) results to skip repeated work.
+
+For a complete pipeline, see [Set up CI](/docs/getting-started/setup-ci).

--- a/astro-docs/src/content/docs/technologies/build-tools/rollup/index.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/rollup/index.mdoc
@@ -6,4 +6,6 @@ description: Module bundler for JavaScript
 pagefind: false
 ---
 
+Get started with [Nx with Rollup](/docs/technologies/build-tools/rollup/introduction), or browse the topics below.
+
 {% index_page_cards path="technologies/build-tools/rollup" /%}

--- a/astro-docs/src/content/docs/technologies/build-tools/rollup/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/rollup/introduction.mdoc
@@ -1,13 +1,13 @@
 ---
-title: Rollup Plugin for Nx
-description: The Nx Plugin for Rollup contains executors and generators that support building applications using Rollup.
+title: Nx with Rollup
+description: Use Rollup with Nx to build and cache projects across your monorepo, with affected-only builds and distributed CI.
 sidebar:
   label: Introduction
 weight: 2
 filter: 'type:References'
 ---
 
-The Nx Plugin for Rollup contains executors and generators that support building applications using Rollup.
+The Nx Plugin for Rollup contains executors and generators that support building applications with Rollup across a Rollup monorepo.
 
 ## Requirements
 
@@ -46,3 +46,9 @@ nx g @nx/js:lib mylib --bundler=rollup
 ```
 
 This will create a new library configured to use Rollup for building.
+
+## Set up CI for your Rollup monorepo
+
+In CI, Nx runs [`nx affected`](/docs/features/ci-features/affected) to rebuild and retest only the projects a change touches, and [caches](/docs/features/cache-task-results) results to skip repeated work.
+
+For a complete pipeline, see [Set up CI](/docs/getting-started/setup-ci).

--- a/astro-docs/src/content/docs/technologies/build-tools/rsbuild/index.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/rsbuild/index.mdoc
@@ -6,4 +6,6 @@ description: Rspack-based build tool
 pagefind: false
 ---
 
+Get started with [Nx with Rsbuild](/docs/technologies/build-tools/rsbuild/introduction), or browse the topics below.
+
 {% index_page_cards path="technologies/build-tools/rsbuild" /%}

--- a/astro-docs/src/content/docs/technologies/build-tools/rsbuild/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/rsbuild/introduction.mdoc
@@ -1,13 +1,13 @@
 ---
-title: Rsbuild Plugin for Nx
-description: The Nx Plugin for Rsbuild contains executors and generators that support building applications using Rsbuild.
+title: Nx with Rsbuild
+description: Use Rsbuild with Nx to build and cache projects across your monorepo, with affected-only builds and distributed CI.
 sidebar:
   label: Introduction
 weight: 2
 filter: 'type:References'
 ---
 
-The Nx Plugin for Rsbuild contains executors and generators that support building applications using Rsbuild.
+The Nx Plugin for Rsbuild contains executors and generators that support building applications using Rsbuild. In an Rsbuild monorepo, it wires each project into Nx so you can build, serve, and cache them from a single workspace.
 
 ## Requirements
 
@@ -46,3 +46,9 @@ nx g @nx/react:app myapp --bundler=rsbuild
 ```
 
 This will create a new application configured to use Rsbuild for building.
+
+## Set up CI for your Rsbuild monorepo
+
+In CI, Nx runs [`nx affected`](/docs/features/ci-features/affected) to rebuild and retest only the projects a change touches, and [caches](/docs/features/cache-task-results) results to skip repeated work.
+
+For a complete pipeline, see [Set up CI](/docs/getting-started/setup-ci).

--- a/astro-docs/src/content/docs/technologies/build-tools/rspack/index.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/rspack/index.mdoc
@@ -6,4 +6,6 @@ description: Fast Rust-based bundler
 pagefind: false
 ---
 
+Get started with [Nx with Rspack](/docs/technologies/build-tools/rspack/introduction), or browse the topics below.
+
 {% index_page_cards path="technologies/build-tools/rspack" /%}

--- a/astro-docs/src/content/docs/technologies/build-tools/rspack/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/rspack/introduction.mdoc
@@ -1,13 +1,13 @@
 ---
-title: Rspack Plugin for Nx
-description: The Nx Plugin for Rspack contains executors, generators, and utilities for managing Rspack projects in an Nx Workspace.
+title: Nx with Rspack
+description: Use Rspack with Nx to build and cache projects across your monorepo, with affected-only builds and distributed CI.
 sidebar:
   label: Introduction
 weight: 2
 filter: 'type:References'
 ---
 
-The Nx Plugin for Rspack contains executors, generators, and utilities for managing Rspack projects in an Nx Workspace.
+The Nx Plugin for Rspack contains executors, generators, and utilities for managing Rspack projects in an Nx Workspace. It helps you run, cache, and scale builds across an Rspack monorepo, with executors and generators that wire each project into the workspace.
 
 ## Requirements
 
@@ -90,3 +90,9 @@ nx g @nx/react:app my-app --bundler=rspack
 You can use the `@nx/rspack:configuration` generator to change your React to use Rspack. This generator will modify your project's configuration to use Rspack, and it will also install all the necessary dependencies, including the `@nx/rspack` plugin.
 
 You can read more about this generator on the [`@nx/rspack:configuration`](/docs/technologies/build-tools/rspack/generators#configuration) generator page.
+
+## Set up CI for your Rspack monorepo
+
+In CI, Nx runs [`nx affected`](/docs/features/ci-features/affected) to rebuild and retest only the projects a change touches, and [caches](/docs/features/cache-task-results) results to skip repeated work.
+
+For a complete pipeline, see [Set up CI](/docs/getting-started/setup-ci).

--- a/astro-docs/src/content/docs/technologies/build-tools/vite/index.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/vite/index.mdoc
@@ -6,4 +6,6 @@ description: Fast frontend build tool
 pagefind: false
 ---
 
+Get started with [Nx with Vite](/docs/technologies/build-tools/vite/introduction), or browse the topics below.
+
 {% index_page_cards path="technologies/build-tools/vite" /%}

--- a/astro-docs/src/content/docs/technologies/build-tools/vite/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/vite/introduction.mdoc
@@ -1,13 +1,13 @@
 ---
-title: Vite Plugin for Nx
-description: Use Vite with Nx for inferred dev/build tasks, generators, and CI-friendly workflows.
+title: Nx with Vite
+description: Use Vite with Nx to build and cache projects across your monorepo, with affected-only builds and distributed CI.
 sidebar:
   label: Introduction
 weight: 2
 filter: 'type:References'
 ---
 
-[Vite](https://vite.dev/) is a fast build tool and dev server for modern web apps.
+[Vite](https://vite.dev/) is a fast build tool and dev server for modern web apps. In a Vite monorepo, Nx runs and caches Vite tasks across every project so you only rebuild what changed.
 
 The `@nx/vite` plugin adds [inferred targets](#configuration) and [project configuration generators](#setup).
 
@@ -179,13 +179,11 @@ To see what tasks Nx inferred for a project, open the [project details view](/do
 nx show project my-app --web
 ```
 
-## CI and scale
+## Set up CI for your Vite monorepo
 
-Use Nx to keep CI fast in large monorepos:
+In CI, Nx runs [`nx affected`](/docs/features/ci-features/affected) to rebuild and retest only the projects a change touches, and [caches](/docs/features/cache-task-results) results to skip repeated work.
 
-- Run only affected Vite projects: `nx affected -t build,typecheck`.
-- Enable remote caching with [Nx Cloud](/docs/guides/nx-cloud/setup-ci) using `nx connect`.
-- Follow the [CI setup guide](/docs/guides/nx-cloud/setup-ci) for a full pipeline.
+For a complete pipeline, see [Set up CI](/docs/getting-started/setup-ci).
 
 ## What's next
 

--- a/astro-docs/src/content/docs/technologies/build-tools/webpack/index.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/webpack/index.mdoc
@@ -6,4 +6,6 @@ description: Powerful module bundler
 pagefind: false
 ---
 
+Get started with [Nx with Webpack](/docs/technologies/build-tools/webpack/introduction), or browse the topics below.
+
 {% index_page_cards path="technologies/build-tools/webpack" /%}

--- a/astro-docs/src/content/docs/technologies/build-tools/webpack/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/webpack/introduction.mdoc
@@ -1,13 +1,13 @@
 ---
-title: Webpack Plugin for Nx
-description: The Nx Plugin for Webpack contains executors and generators that support building applications using Webpack.
+title: Nx with Webpack
+description: Use Webpack with Nx to build and cache projects across your monorepo, with affected-only builds and distributed CI.
 sidebar:
   label: Introduction
 weight: 2
 filter: 'type:References'
 ---
 
-The Nx plugin for [webpack](https://webpack.js.org/).
+The Nx plugin for [webpack](https://webpack.js.org/) brings smart task running and caching to a Webpack monorepo.
 
 [Webpack](https://webpack.js.org/) is a static module bundler for modern JavaScript applications. The `@nx/webpack` plugin provides executors that allow you to build and serve your projects using webpack, plus an executor for SSR.
 
@@ -112,3 +112,9 @@ To generate a Web application using Webpack, run the following:
 ```bash {% frame="none" %}
 nx g @nx/web:app apps/my-app --bundler=webpack
 ```
+
+## Set up CI for your Webpack monorepo
+
+In CI, Nx runs [`nx affected`](/docs/features/ci-features/affected) to rebuild and retest only the projects a change touches, and [caches](/docs/features/cache-task-results) results to skip repeated work.
+
+For a complete pipeline, see [Set up CI](/docs/getting-started/setup-ci).

--- a/astro-docs/src/content/docs/technologies/dotnet/index.mdoc
+++ b/astro-docs/src/content/docs/technologies/dotnet/index.mdoc
@@ -6,4 +6,6 @@ description: Build scalable .NET applications
 pagefind: false
 ---
 
+Get started with [Nx with .NET](/docs/technologies/dotnet/introduction), or browse the topics below.
+
 {% index_page_cards path="technologies/dotnet" /%}

--- a/astro-docs/src/content/docs/technologies/dotnet/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/dotnet/introduction.mdoc
@@ -1,13 +1,13 @@
 ---
-title: .NET Plugin for Nx
-description: This plugin allows .NET projects to be run through Nx.
+title: Nx with .NET
+description: Nx scales your .NET monorepo with caching, distributed task execution, and affected-only builds.
 sidebar:
   label: 'Introduction'
 weight: 2
 filter: 'type:References'
 ---
 
-[.NET](https://dotnet.microsoft.com/) is a free, cross-platform, open-source developer platform for building many different types of applications. With .NET, you can use multiple languages, editors, and libraries to build for web, mobile, desktop, games, IoT, and more.
+Nx brings smart task execution and caching to your .NET monorepo. [.NET](https://dotnet.microsoft.com/) is a free, cross-platform, open-source developer platform for building many different types of applications. With .NET, you can use multiple languages, editors, and libraries to build for web, mobile, desktop, games, IoT, and more.
 
 The Nx plugin for .NET registers .NET projects in your Nx workspace. It allows MSBuild tasks to be run through Nx. Nx effortlessly makes your [CI faster](/docs/guides/nx-cloud/setup-ci).
 
@@ -225,3 +225,9 @@ nx build my-app --configuration release
 # Build with Debug configuration (usually the default)
 nx build my-app --configuration debug
 ```
+
+## Set up CI for your .NET monorepo
+
+In CI, Nx runs [`nx affected`](/docs/features/ci-features/affected) to rebuild and retest only the projects a change touches, and [caches](/docs/features/cache-task-results) results to skip repeated work.
+
+For a complete pipeline, see [Set up CI](/docs/getting-started/setup-ci).

--- a/astro-docs/src/content/docs/technologies/eslint/index.mdoc
+++ b/astro-docs/src/content/docs/technologies/eslint/index.mdoc
@@ -6,4 +6,6 @@ description: Guides and API references for ESLint in Nx
 pagefind: false
 ---
 
+Get started with [Nx with ESLint](/docs/technologies/eslint/introduction), or browse the topics below.
+
 {% index_page_cards path="technologies/eslint" /%}

--- a/astro-docs/src/content/docs/technologies/eslint/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/eslint/introduction.mdoc
@@ -1,6 +1,6 @@
 ---
-title: ESLint Plugin for Nx
-description: Learn how to set up and use the @nx/eslint plugin to integrate ESLint with Nx, enabling caching and providing code generators for ESLint configuration.
+title: Nx with ESLint
+description: Use ESLint with Nx to lint projects across your monorepo, with caching, affected-only runs, and module boundary rules.
 sidebar:
   label: Introduction
 weight: 2
@@ -95,3 +95,9 @@ nx lint my-project
 ## ESLint plugin
 
 Read about our dedicated ESLint plugin - [eslint-plugin-nx](/docs/technologies/eslint/eslint-plugin).
+
+## Set up CI
+
+In CI, Nx runs [`nx affected`](/docs/features/ci-features/affected) to rebuild and retest only the projects a change touches, and [caches](/docs/features/cache-task-results) results to skip repeated work.
+
+For a complete pipeline, see [Set up CI](/docs/getting-started/setup-ci).

--- a/astro-docs/src/content/docs/technologies/java/gradle/index.mdoc
+++ b/astro-docs/src/content/docs/technologies/java/gradle/index.mdoc
@@ -6,4 +6,6 @@ description: Using Gradle with Nx
 pagefind: false
 ---
 
+Get started with [Nx with Gradle](/docs/technologies/java/gradle/introduction), or browse the topics below.
+
 {% index_page_cards path="technologies/java/gradle" /%}

--- a/astro-docs/src/content/docs/technologies/java/gradle/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/java/gradle/introduction.mdoc
@@ -1,13 +1,13 @@
 ---
-title: Gradle Plugin for Nx
-description: Run Gradle tasks through Nx with caching, graph insights, and CI optimization.
+title: Nx with Gradle
+description: Use Gradle with Nx to cache and run tasks across your Java monorepo, with affected-only builds and distributed CI.
 sidebar:
   label: 'Introduction'
 weight: 2
 filter: 'type:References'
 ---
 
-[Gradle](https://gradle.org/) is a build automation tool for JVM-based projects.
+[Gradle](https://gradle.org/) is a build automation tool for JVM-based projects, and the `@nx/gradle` plugin brings Nx task running, caching, and graph analysis to a Gradle monorepo.
 
 The `@nx/gradle` plugin registers Gradle projects in the Nx graph so you can [set up Gradle in Nx](#setup), [run local tasks](#local-development), [configure task inference](#configuration), and [scale in CI](#ci-considerations).
 
@@ -175,31 +175,11 @@ Use `include`/`exclude` glob patterns to scope the plugin to specific projects:
 
 Individual Gradle projects can also configure Nx-specific settings using the `nx { }` DSL in `build.gradle` or `build.gradle.kts`.
 
-## CI considerations
+## Set up CI for your Gradle monorepo
 
-Only run what changed in CI:
+In CI, Nx runs [`nx affected`](/docs/features/ci-features/affected) to rebuild and retest only the projects a change touches, and [caches](/docs/features/cache-task-results) results to skip repeated work.
 
-```shell
-nx affected -t build test
-```
-
-Enable remote caching with Nx Cloud:
-
-```shell
-nx connect
-```
-
-See [Set Up CI](/docs/guides/nx-cloud/setup-ci) for provider-specific workflows. If you set `ciTestTargetName`, Nx will create CI variants that use atomized test targets.
-
-### Batch mode
-
-Batch mode runs multiple Gradle tasks in a single invocation. Enable it by setting `NX_BATCH_MODE=true`:
-
-```shell
-NX_BATCH_MODE=true nx run-many -t build test
-```
-
-If your Gradle builds require specific CI flags (for example `--no-daemon` or custom JVM args), add them to `gradle.properties` so Nx runs consistent settings locally and in CI.
+For a complete pipeline, see [Set up CI](/docs/getting-started/setup-ci).
 
 ## What's next
 

--- a/astro-docs/src/content/docs/technologies/java/index.mdoc
+++ b/astro-docs/src/content/docs/technologies/java/index.mdoc
@@ -6,4 +6,6 @@ description: Build scalable Java applications
 pagefind: false
 ---
 
+Get started with [Nx with Java](/docs/technologies/java/introduction), or browse the topics below.
+
 {% index_page_cards path="technologies/java" /%}

--- a/astro-docs/src/content/docs/technologies/java/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/java/introduction.mdoc
@@ -1,13 +1,13 @@
 ---
-title: Java with Nx
-description: Build scalable Java applications with Nx
+title: Nx with Java
+description: Nx scales your Java monorepo with caching, distributed task execution, and affected-only builds.
 sidebar:
   label: 'Introduction'
 weight: 2
 filter: 'type:References'
 ---
 
-Nx provides powerful tooling for Java projects, supporting both Gradle and Maven build systems. Whether you're working with Spring Boot, Micronaut, Quarkus, or any other Java framework, Nx helps you build faster and more efficiently.
+Nx brings caching, affected-only builds, and a project graph to your Java monorepo, working with both Gradle and Maven build systems. Whether you're working with Spring Boot, Micronaut, Quarkus, or any other Java framework, Nx helps you build faster and more efficiently.
 
 ## Requirements
 
@@ -94,3 +94,9 @@ Nx enhances your Java development workflow with:
 - **[Affected Commands](/docs/features/ci-features/affected)** - Only build and test what changed
 - **[Interactive Graph](/docs/features/explore-graph)** - Visualize your project dependencies
 - **[CI Optimization](/docs/guides/nx-cloud/setup-ci)** - Make your CI pipeline dramatically faster
+
+## Set up CI for your Java monorepo
+
+In CI, Nx runs [`nx affected`](/docs/features/ci-features/affected) to rebuild and retest only the projects a change touches, and [caches](/docs/features/cache-task-results) results to skip repeated work.
+
+For a complete pipeline, see [Set up CI](/docs/getting-started/setup-ci).

--- a/astro-docs/src/content/docs/technologies/java/maven/index.mdoc
+++ b/astro-docs/src/content/docs/technologies/java/maven/index.mdoc
@@ -6,4 +6,6 @@ description: Using Maven with Nx
 pagefind: false
 ---
 
+Get started with [Nx with Maven](/docs/technologies/java/maven/introduction), or browse the topics below.
+
 {% index_page_cards path="technologies/java/maven" /%}

--- a/astro-docs/src/content/docs/technologies/java/maven/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/java/maven/introduction.mdoc
@@ -1,6 +1,6 @@
 ---
-title: Maven Plugin for Nx
-description: This plugin allows Maven tasks to be run through Nx.
+title: Nx with Maven
+description: Use Maven with Nx to cache and run tasks across your Java monorepo, with affected-only builds and distributed CI.
 sidebar:
   label: 'Introduction'
 weight: 2
@@ -11,9 +11,9 @@ filter: 'type:References'
 The `@nx/maven` plugin is currently experimental. Features and APIs may change.
 {% /aside %}
 
-[Apache Maven](https://maven.apache.org/) is a build tool for Java projects that uses a project object model (POM) to manage builds.
+[Apache Maven](https://maven.apache.org/) is a build tool for Java projects that uses a project object model (POM) to manage builds. Nx adds incremental builds, task caching, and the project graph on top of a Maven monorepo, so a multi-module workspace stays fast as it grows.
 
-The `@nx/maven` plugin registers Maven modules as Nx projects so you can [set up Maven with Nx](#setup), [run daily Maven tasks](#local-development), [configure task inference](#configuration), and [run in CI](#ci-considerations).
+The `@nx/maven` plugin registers Maven modules as Nx projects so you can [set up Maven with Nx](#setup), [run daily Maven tasks](#local-development), [configure task inference](#configuration), and [run in CI](#set-up-ci-for-your-maven-monorepo).
 
 You can use Maven with Nx without the plugin and still get [task caching](/docs/features/cache-task-results), [task orchestration](/docs/features/run-tasks), and the [project graph](/docs/features/explore-graph).
 
@@ -176,31 +176,11 @@ Use `include`/`exclude` glob patterns to scope the plugin to specific projects:
 
 There is no per-project disable for `@nx/maven`. To stop inference entirely, remove `@nx/maven` from the `plugins` array in `nx.json`.
 
-## CI considerations
+## Set up CI for your Maven monorepo
 
-Build and test only what changed using the project graph:
+In CI, Nx runs [`nx affected`](/docs/features/ci-features/affected) to rebuild and retest only the projects a change touches, and [caches](/docs/features/cache-task-results) results to skip repeated work.
 
-```shell
-nx affected -t test package
-```
-
-Connect Nx Cloud to share cache results and speed up Maven builds in CI:
-
-```shell
-nx connect
-```
-
-### Batch mode
-
-Batch mode runs multiple Maven tasks in a single invocation. Enable it by setting `NX_BATCH_MODE=true`:
-
-```shell
-NX_BATCH_MODE=true nx run-many -t build test
-```
-
-See [Set Up CI](/docs/guides/nx-cloud/setup-ci) for a complete configuration guide.
-
-If you use Maven profiles or parallel builds in CI, define them in `.mvn/maven.config` (for example `-Pci` or `-T1C`) so Nx runs the same settings consistently.
+For a complete pipeline, see [Set up CI](/docs/getting-started/setup-ci).
 
 ## What's next
 

--- a/astro-docs/src/content/docs/technologies/module-federation/index.mdoc
+++ b/astro-docs/src/content/docs/technologies/module-federation/index.mdoc
@@ -6,4 +6,6 @@ description: Advanced guides to utilize Module Federation with Nx for micro fron
 pagefind: false
 ---
 
+Get started with [Nx with Module Federation](/docs/technologies/module-federation/introduction), or browse the topics below.
+
 {% index_page_cards path="technologies/module-federation" /%}

--- a/astro-docs/src/content/docs/technologies/module-federation/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/module-federation/introduction.mdoc
@@ -1,184 +1,71 @@
 ---
-title: Module Federation Plugin for Nx
-description: Details about the NxModuleFederationPlugin
+title: Nx with Module Federation
+description: Build micro frontends with Module Federation and Nx, sharing code across your monorepo with caching and affected-only builds.
 sidebar:
   label: Introduction
 weight: 2
 filter: 'type:References'
 ---
 
-The `NxModuleFederationPlugin` is a [Rspack](https://rspack.dev) plugin that handles module federation in Nx Workspaces. It aims to provide the same Developer Experience (DX) that you would normally get from using the Nx `withModuleFederation` function.
+Module Federation is an architectural pattern for splitting a frontend into separately built and deployed applications that compose at runtime. A host application loads remote modules exposed by other applications, and they share common dependencies so each library loads once. It's a common way to build micro frontends. For the full model, see the official [Module Federation documentation](https://module-federation.io/guide/start/index.html).
 
-## Requirements
+The fastest way to try Module Federation with Nx is the React Module Federation template. It sets up a host (`apps/shell`) and two remotes (`apps/shop`, `apps/cart`) federated over Vite with the official [Module Federation](https://module-federation.io) plugins:
 
-The `@nx/module-federation` plugin supports the following package versions.
-
-| Package                       | Supported Versions |
-| ----------------------------- | ------------------ |
-| `webpack`                     | ^5.0.0             |
-| `@rspack/core`                | ^1.6.0             |
-| `@module-federation/enhanced` | ^2.0.0             |
-| `@module-federation/node`     | ^2.0.0             |
-
-[Nx generators](/docs/features/generate-code) install the latest supported versions automatically when scaffolding new projects.
-
-## Usage
-
-To use the plugin, you need to add it to your `rspack.config.ts` file. You can do this by adding the following to your config.
-
-### Client side rendering
-
-```ts
-// rspack.config.ts
-import {
-  NxModuleFederationPlugin,
-  NxModuleFederationDevServerPlugin,
-} from '@nx/module-federation/rspack';
-import config from './module-federation.config';
-
-export default {
-  ...otherRspackConfigOptions,
-  plugins: [
-    new NxModuleFederationPlugin({
-      config,
-    }),
-    new NxModuleFederationDevServerPlugin({
-      config,
-    }),
-  ],
-};
+```shell
+npx create-nx-workspace@latest my-workspace --template nrwl/react-mfe-template
 ```
 
-### Server side rendering
+See the [template details](/docs/templates/react-mfe) for what's inside.
 
-```ts
-// rspack.config.ts
-import {
-  NxModuleFederationPlugin,
-  NxModuleFederationSSRDevServerPlugin,
-} from '@nx/module-federation/rspack';
-import config from './module-federation.config';
+## Why Nx works well with Module Federation
 
-export default {
-  ...otherRspackConfigOptions,
-  plugins: [
-    new NxModuleFederationPlugin({
-      config,
-      isServer: true,
-    }),
-    new NxModuleFederationSSRDevServerPlugin({
-      config,
-    }),
-  ],
-};
-```
+Module Federation turns one app into many independently built and served pieces. Nx knows how those pieces relate through the [project graph](/docs/features/explore-graph), so it serves, caches, and scales them as one system. You bring your own Module Federation setup, and Nx orchestrates it. Because Nx reads the topology from the graph, serving, affected rebuilds, and caching stay correct as you add remotes.
 
-## How it works
+### Serve a remote and its host together
 
-The NxModuleFederationPlugin wraps and configures the Module Federation plugin from `@module-federation/enhanced` to provide a streamlined experience in Nx workspaces. Here's what the plugin does:
+Each app has a `dev` task. The host's `dev` task is [continuous](/docs/getting-started/tutorials/running-tasks#running-continuous-tasks), so it keeps running, and each remote's `dev` task depends on it:
 
-1. **Base Configuration**: It sets up essential Rspack configurations:
-   - Disables runtime chunking (`runtimeChunk: false`)
-   - Sets a unique name for the output
-   - Configures specific settings for server-side rendering when needed
-
-2. **Module Federation Setup**: The plugin automatically:
-   - Configures the remote entry filename (`remoteEntry.js`)
-   - Sets up exposed modules based on your configuration
-   - Manages remote module connections
-   - Handles shared dependencies and libraries
-
-3. **Runtime Plugins**: It supports additional runtime plugins, including special handling for Node.js environments when running in server mode.
-
-4. **Shared Libraries**: The plugin includes a dedicated system for managing shared libraries across federated modules, helping to avoid duplicate code and ensure consistent versions.
-
-You can learn more about how Nx handles Module Federation in the [Module Federation and Nx Guide](/docs/technologies/module-federation/concepts/module-federation-and-nx#nx-support-for-module-federation).
-
-## API reference
-
-### NxModuleFederationPlugin
-
-```ts
-export class NxModuleFederationPlugin {
-  constructor(
-    private _options: {
-      config: ModuleFederationConfig;
-      isServer?: boolean;
+```jsonc
+// apps/shop/package.json
+{
+  "nx": {
+    "targets": {
+      "dev": {
+        "executor": "nx:run-commands",
+        "continuous": true,
+        "dependsOn": ["shell:dev"],
+        "options": { "command": "vite", "cwd": "apps/shop" },
+      },
     },
-    private configOverride?: NxModuleFederationConfigOverride
-  ) {}
+  },
 }
 ```
 
-### ModuleFederationConfig
+Because the remote's `dev` task depends on the host's continuous `dev` task, `nx dev shop` serves the `shop` remote and starts the `shell` host alongside it. You develop a remote in isolation while the shell stays running around it. Without Nx, you start the host and each remote in separate terminals and keep them wired together by hand. To bring up several remotes at once, run `nx run-many -t dev -p shop cart`, and the shared `shell:dev` task starts only once.
 
-```ts
-export interface ModuleFederationConfig {
-  /**
-   * The name of the module federation application.
-   */
-  name: string;
-  /**
-   * The remotes that the module federation application uses.
-   */
-  remotes?: Remotes;
-  /**
-   * The library type and name the ModuleFederationPlugin uses to expose and load the federated modules.
-   */
-  library?: ModuleFederationLibrary;
-  /**
-   * The federated modules to expose for consumption by host/consumer applications.
-   */
-  exposes?: Record<string, string>;
-  /**
-   * A function that allows you to configure shared libraries.
-   * This function is called for each shared library that is used by the module federation application.
-   * The function is passed the library name and the shared library configuration.
-   * If the function returns `undefined` the default shared library configuration is used.
-   * If the function returns `false` the shared library is not shared.
-   * If the function returns a shared library configuration object, that configuration is used.
-   */
-  shared?: SharedFunction;
-  /**
-   * Additional shared libraries that are shared by the module federation application.
-   * This is useful when you want to share a library that is not found as part of the direct dependencies of the application found in the Nx Graph.
-   */
-  additionalShared?: AdditionalSharedConfig;
-  /**
-   * `nxRuntimeLibraryControlPlugin` is a runtime module federation plugin to ensure
-   * that shared libraries are resolved from a remote with live reload capabilities.
-   * If you run into any issues with loading shared libraries, try disabling this option.
-   */
-  disableNxRuntimeLibraryControlPlugin?: boolean;
-}
+### Rebuild only the remotes a shared change touches
 
-export type Remotes = Array<string | [remoteName: string, remoteUrl: string]>;
-export type ModuleFederationLibrary = { type: string; name: string };
-export type SharedFunction = (
-  libraryName: string,
-  sharedConfig: SharedLibraryConfig
-) => undefined | false | SharedLibraryConfig;
-export interface SharedLibraryConfig {
-  singleton?: boolean;
-  strictVersion?: boolean;
-  requiredVersion?: false | string;
-  eager?: boolean;
-}
-export type AdditionalSharedConfig = Array<
-  | string
-  | [libraryName: string, sharedConfig: SharedLibraryConfig]
-  | { libraryName: string; sharedConfig: SharedLibraryConfig }
->;
+When you change a shared library, Module Federation forces every app that consumes it to redeploy. Because each host and remote is its own project, [`nx affected`](/docs/features/ci-features/affected) computes that exact set from the graph and rebuilds and retests only those apps, while Nx [caches](/docs/features/cache-task-results) the rest. Each app has its own test and e2e targets, so affected verification runs only for the apps a change touches.
+
+With [remote caching](/docs/features/ci-features/remote-cache) on [Nx Cloud](/docs/getting-started/nx-cloud), a remote already built by a teammate or in CI is restored instead of rebuilt.
+
+### Scale builds and tests across machines
+
+A workspace with many remotes has a lot to build. With Nx Cloud, [Nx Agents](/docs/features/ci-features/distribute-task-execution) distribute those builds and tests across machines, so adding remotes stops adding CI time. Nx reports worst-case CI tracking the single largest remote instead of the sum of all of them.
+
+### Keep shared dependencies in sync
+
+Module Federation breaks when two apps load incompatible copies of a shared library, such as two versions of React. The official plugins share libraries as singletons so each one loads once, and Nx workspaces can enforce a single version of each shared dependency, so the host and every remote resolve to the same copy.
+
+## Add Module Federation to an existing workspace
+
+In a React workspace, generate a host with the consumer generator and a remote with the provider generator. They wire up the official Module Federation plugins for you:
+
+```shell
+nx g @nx/react:consumer apps/shell
+nx g @nx/react:provider apps/shop --consumer=shell
 ```
 
-### NxModuleFederationConfigOverride
+The `--consumer` option makes the new remote's `dev` task depend on the host.
 
-```ts
-/**
- * Used to override the options passed to the ModuleFederationPlugin.
- */
-export type NxModuleFederationConfigOverride = Omit<
-  moduleFederationPlugin.ModuleFederationPluginOptions,
-  'exposes' | 'remotes' | 'name' | 'shared' | 'filename'
->;
-```
+With another framework, add the official Module Federation plugin to each app's bundler config, then give each app the same `continuous` and `dependsOn` tasks. Nx orchestrates the host and remotes the same way, whatever the framework. For the architecture and task-graph details, see [Module Federation and Nx](/docs/technologies/module-federation/concepts/module-federation-and-nx).

--- a/astro-docs/src/content/docs/technologies/node/express/index.mdoc
+++ b/astro-docs/src/content/docs/technologies/node/express/index.mdoc
@@ -6,4 +6,6 @@ description: Express framework support
 pagefind: false
 ---
 
+Get started with [Nx with Express](/docs/technologies/node/express/introduction), or browse the topics below.
+
 {% index_page_cards path="technologies/node/express" /%}

--- a/astro-docs/src/content/docs/technologies/node/express/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/node/express/introduction.mdoc
@@ -1,6 +1,6 @@
 ---
-title: Express Plugin for Nx
-description: Learn how to use the @nx/express plugin to create and manage Express applications in your Nx workspace, including setup and common guides.
+title: Nx with Express
+description: Nx scales your Express monorepo with caching, distributed task execution, and affected-only builds.
 sidebar:
   label: Introduction
 weight: 2
@@ -8,7 +8,8 @@ filter: 'type:References'
 ---
 
 [Express](https://expressjs.com/) is a mature, minimal, and an open source web framework for making web applications and
-apis.
+apis. Nx scales your Express monorepo, so you can grow your APIs and shared libraries
+without losing fast, reliable builds.
 
 ## Requirements
 
@@ -22,10 +23,10 @@ The `@nx/express` plugin supports the following package versions.
 
 ## Create a new workspace
 
-To create a new workspace with a pre-created Express app, run the following command:
+Start from the [Express template](/docs/templates/express-api) to scaffold a ready-to-run Express API:
 
 ```shell
- npx create-nx-workspace --preset=express
+npx create-nx-workspace@latest my-workspace --template nrwl/express-api-template
 ```
 
 ## Setting up @nx/express
@@ -48,3 +49,9 @@ This will install the correct version of `@nx/express`.
 
 - [Set Up Application Proxies](/docs/technologies/node/guides/application-proxies)
 - [Wait For Tasks To Finish](/docs/technologies/node/guides/wait-for-tasks)
+
+## Set up CI for your Express monorepo
+
+In CI, Nx runs [`nx affected`](/docs/features/ci-features/affected) to rebuild and retest only the projects a change touches, and [caches](/docs/features/cache-task-results) results to skip repeated work.
+
+For a complete pipeline, see [Set up CI](/docs/getting-started/setup-ci).

--- a/astro-docs/src/content/docs/technologies/node/index.mdoc
+++ b/astro-docs/src/content/docs/technologies/node/index.mdoc
@@ -6,4 +6,6 @@ description: Build scalable Node.js applications with Express, NestJS, and serve
 pagefind: false
 ---
 
+Get started with [Nx with Node.js](/docs/technologies/node/introduction), or browse the topics below.
+
 {% index_page_cards path="technologies/node" /%}

--- a/astro-docs/src/content/docs/technologies/node/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/node/introduction.mdoc
@@ -1,13 +1,13 @@
 ---
-title: Node.js Plugin for Nx
-description: Learn how to use the @nx/node plugin to create and manage Node.js applications and libraries in your Nx workspace, including setup, building, and testing.
+title: Nx with Node.js
+description: Nx scales your Node.js monorepo with caching, distributed task execution, and affected-only builds.
 sidebar:
   label: Introduction
 weight: 2
 filter: 'type:References'
 ---
 
-The Node Plugin contains generators and executors to manage Node applications within an Nx workspace. It provides:
+The Node Plugin contains generators and executors to manage Node applications within an Nx workspace, making it the foundation for running a Node.js monorepo. It provides:
 
 ## Requirements
 
@@ -149,3 +149,9 @@ For additional information on Node.js debugging, see the [Node.js debugging gett
 
 - [Using Cypress](/docs/technologies/test-tools/cypress/introduction)
 - [Using Jest](/docs/technologies/test-tools/jest/introduction)
+
+## Set up CI for your Node.js monorepo
+
+In CI, Nx runs [`nx affected`](/docs/features/ci-features/affected) to rebuild and retest only the projects a change touches, and [caches](/docs/features/cache-task-results) results to skip repeated work.
+
+For a complete pipeline, see [Set up CI](/docs/getting-started/setup-ci).

--- a/astro-docs/src/content/docs/technologies/node/nest/index.mdoc
+++ b/astro-docs/src/content/docs/technologies/node/nest/index.mdoc
@@ -6,4 +6,6 @@ description: NestJS framework support
 pagefind: false
 ---
 
+Get started with [Nx with Nest.js](/docs/technologies/node/nest/introduction), or browse the topics below.
+
 {% index_page_cards path="technologies/node/nest" /%}

--- a/astro-docs/src/content/docs/technologies/node/nest/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/node/nest/introduction.mdoc
@@ -1,6 +1,6 @@
 ---
-title: Nest.js Plugin for Nx
-description: Learn how to use the @nx/nest plugin to create and manage Nest.js applications and libraries in your Nx workspace, including setup and generators.
+title: Nx with Nest.js
+description: Nx scales your Nest.js monorepo with caching, distributed task execution, and affected-only builds.
 keywords: [nest, nestjs]
 sidebar:
   label: Introduction
@@ -8,7 +8,7 @@ weight: 2
 filter: 'type:References'
 ---
 
-Nest.js is a framework designed for building scalable server-side applications. In many ways, Nest is familiar to Angular developers:
+Nest.js is a framework designed for building scalable server-side applications, and Nx gives you the tooling to run a Nest.js monorepo with caching, affected-only builds, and code generators. In many ways, Nest is familiar to Angular developers:
 
 - It has excellent TypeScript support.
 - Its dependency injection system is similar to the one in Angular.
@@ -40,16 +40,10 @@ The plugin detects the installed `@nestjs/core` major and routes the rest of the
 
 ### Generating a new workspace
 
-To create a new workspace with Nest, run the following command:
+Start from the [NestJS template](/docs/templates/nestjs) to scaffold a ready-to-run NestJS API:
 
 ```shell
-npx create-nx-workspace my-workspace --preset=nest
-```
-
-Yarn users can use the following command instead:
-
-```shell
-yarn create nx-workspace my-workspace --preset=nest
+npx create-nx-workspace@latest my-workspace --template nrwl/nestjs-template
 ```
 
 ### Installation
@@ -252,3 +246,9 @@ Bundling dependencies is typically not recommended for Node applications.
 ## More documentation
 
 - [Using Jest](/docs/technologies/test-tools/jest/introduction)
+
+## Set up CI for your Nest.js monorepo
+
+In CI, Nx runs [`nx affected`](/docs/features/ci-features/affected) to rebuild and retest only the projects a change touches, and [caches](/docs/features/cache-task-results) results to skip repeated work.
+
+For a complete pipeline, see [Set up CI](/docs/getting-started/setup-ci).

--- a/astro-docs/src/content/docs/technologies/react/expo/index.mdoc
+++ b/astro-docs/src/content/docs/technologies/react/expo/index.mdoc
@@ -6,4 +6,6 @@ description: Expo React Native framework
 pagefind: false
 ---
 
+Get started with [Nx with Expo](/docs/technologies/react/expo/introduction), or browse the topics below.
+
 {% index_page_cards path="technologies/react/expo" /%}

--- a/astro-docs/src/content/docs/technologies/react/expo/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/react/expo/introduction.mdoc
@@ -1,13 +1,13 @@
 ---
-title: Expo Plugin for Nx
-description: Learn how to use the @nx/expo plugin to manage Expo applications and libraries within an Nx workspace, including setup, configuration, and task inference.
+title: Nx with Expo
+description: Nx scales your Expo monorepo with caching, distributed task execution, and affected-only builds.
 sidebar:
   label: 'Introduction'
 weight: 2
 filter: 'type:References'
 ---
 
-Expo is an open-source framework for apps that run natively on Android, iOS, and the web. Expo brings together the best of mobile and the web and enables many important features for building and scaling an app.
+Expo is an open-source framework for apps that run natively on Android, iOS, and the web. In an Expo monorepo, Nx lets you share code across native and web targets while keeping builds and tests fast. Expo brings together the best of mobile and the web and enables many important features for building and scaling an app.
 
 Expo is a set of tools built on top of React Native. The Nx Plugin for Expo contains generators for managing Expo applications and libraries within an Nx workspace.
 
@@ -362,3 +362,9 @@ Below table is a map between expo commands and Nx commands:
 
 - [Using Detox](/docs/technologies/test-tools/detox/introduction)
 - [Using Jest](/docs/technologies/test-tools/jest/introduction)
+
+## Set up CI for your Expo monorepo
+
+In CI, Nx runs [`nx affected`](/docs/features/ci-features/affected) to rebuild and retest only the projects a change touches, and [caches](/docs/features/cache-task-results) results to skip repeated work.
+
+For a complete pipeline, see [Set up CI](/docs/getting-started/setup-ci).

--- a/astro-docs/src/content/docs/technologies/react/index.mdoc
+++ b/astro-docs/src/content/docs/technologies/react/index.mdoc
@@ -6,4 +6,6 @@ description: Create modern React applications with Nx comprehensive React suppor
 pagefind: false
 ---
 
+Get started with [Nx with React](/docs/technologies/react/introduction), or browse the topics below.
+
 {% index_page_cards path="technologies/react" /%}

--- a/astro-docs/src/content/docs/technologies/react/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/react/introduction.mdoc
@@ -1,6 +1,6 @@
 ---
-title: React Plugin for Nx
-description: Create and manage React applications and libraries in your Nx workspace with generators for apps, libraries, and support for Module Federation.
+title: Nx with React
+description: Nx scales your React monorepo with caching, distributed task execution, and affected-only builds.
 keywords: [react]
 sidebar:
   label: 'Introduction'
@@ -9,7 +9,7 @@ weight: 2
 filter: 'type:References'
 ---
 
-The React plugin for Nx, `@nx/react`, provides generators for [applications and libraries](#generate-react-applications-and-libraries), executors for [Module Federation](/docs/technologies/react/guides/module-federation-with-ssr), and [library build support](/docs/concepts/buildable-and-publishable-libraries). It integrates with popular bundlers and test runners so you can configure each project to match your team's toolchain.
+The React plugin for Nx, `@nx/react`, helps you build and scale a React monorepo. It provides generators for [applications and libraries](#generate-react-applications-and-libraries), executors for [Module Federation](/docs/technologies/react/guides/module-federation-with-ssr), and [library build support](/docs/concepts/buildable-and-publishable-libraries). It integrates with popular bundlers and test runners so you can configure each project to match your team's toolchain.
 
 You don't need the plugin to use React with Nx. Any project already benefits from [caching](/docs/features/cache-task-results), [task orchestration](/docs/features/run-tasks), and the [project graph](/docs/features/explore-graph). The plugin simplifies scaffolding and code generation.
 
@@ -130,25 +130,11 @@ Or open the [project details view in Nx Console](/docs/guides/nx-console/console
 
 For full generator and executor option lists, see the [generators reference](/docs/technologies/react/generators) and [executors reference](/docs/technologies/react/executors).
 
-## CI considerations
+## Set up CI for your React monorepo
 
-See [Set Up CI](/docs/guides/nx-cloud/setup-ci) for a complete CI configuration guide.
+In CI, Nx runs [`nx affected`](/docs/features/ci-features/affected) to rebuild and retest only the projects a change touches, and [caches](/docs/features/cache-task-results) results to skip repeated work.
 
-### Build and test only what changed
-
-```shell
-nx affected -t build test lint
-```
-
-This uses the [project graph](/docs/features/explore-graph) to determine which projects are [affected](/docs/features/ci-features/affected) by your changes and only runs tasks for those.
-
-### Remote caching
-
-Share build and test cache results across your team and CI with [remote caching](/docs/features/ci-features/remote-cache):
-
-```shell
-nx connect
-```
+For a complete pipeline, see [Set up CI](/docs/getting-started/setup-ci).
 
 ## What's next
 

--- a/astro-docs/src/content/docs/technologies/react/next/index.mdoc
+++ b/astro-docs/src/content/docs/technologies/react/next/index.mdoc
@@ -6,4 +6,6 @@ description: Next.js framework support
 pagefind: false
 ---
 
+Get started with [Nx with Next.js](/docs/technologies/react/next/introduction), or browse the topics below.
+
 {% index_page_cards path="technologies/react/next" /%}

--- a/astro-docs/src/content/docs/technologies/react/next/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/react/next/introduction.mdoc
@@ -1,6 +1,6 @@
 ---
-title: Next.js Plugin for Nx
-description: Create and manage Next.js applications in your Nx workspace with inferred build, dev, and start tasks, generators for apps and libraries, and optimized CI configuration.
+title: Nx with Next.js
+description: Nx scales your Next.js monorepo with caching, distributed task execution, and affected-only builds.
 keywords: [nextjs, next, react]
 sidebar:
   label: 'Introduction'
@@ -9,7 +9,7 @@ weight: 2
 filter: 'type:References'
 ---
 
-The Next.js plugin for Nx, `@nx/next`, automatically [infers `build`, `dev`, and `start` tasks](#how-nxnext-infers-tasks) from your Next.js configuration and provides [generators for creating applications and libraries](#develop-nextjs-applications).
+Nx helps you organize a Next.js monorepo where apps and shared libraries live side by side. The Next.js plugin for Nx, `@nx/next`, automatically [infers `build`, `dev`, and `start` tasks](#how-nxnext-infers-tasks) from your Next.js configuration and provides [generators for creating applications and libraries](#develop-nextjs-applications).
 
 You don't need the plugin to use Next.js with Nx. Any project already benefits from [caching](/docs/features/cache-task-results), [task orchestration](/docs/features/run-tasks), and the [project graph](/docs/features/explore-graph). The plugin adds automatic task inference, code generators, and simplified configuration.
 
@@ -62,8 +62,10 @@ Verify the plugin is setup:
 
 ### Create a new workspace
 
+Start from the [Next.js template](/docs/templates/nextjs) to scaffold a Next.js app with a shared UI library:
+
 ```shell
-npx create-nx-workspace@latest --preset=next
+npx create-nx-workspace@latest my-workspace --template nrwl/nextjs-template
 ```
 
 ### Generate a new application
@@ -205,29 +207,11 @@ nx show project my-app
 
 Or open the [project details view in Nx Console](/docs/guides/nx-console/console-project-details#_top).
 
-## CI considerations
+## Set up CI for your Next.js monorepo
 
-See [Set Up CI](/docs/guides/nx-cloud/setup-ci) for a complete CI configuration guide.
+In CI, Nx runs [`nx affected`](/docs/features/ci-features/affected) to rebuild and retest only the projects a change touches, and [caches](/docs/features/cache-task-results) results to skip repeated work.
 
-### Build and test only what changed
-
-```shell
-nx affected -t build test lint
-```
-
-This uses the [project graph](/docs/features/explore-graph) to determine which projects are affected by your changes and only runs tasks for those. Read more about [the benefits of `nx affected`](/docs/features/ci-features/affected).
-
-### Remote caching
-
-Share build cache results across your team and CI with [remote caching](/docs/features/ci-features/remote-cache):
-
-```shell
-nx connect
-```
-
-### Static HTML export for E2E testing
-
-Next.js applications support [static HTML export](https://nextjs.org/docs/app/building-your-application/deploying/static-exports) by setting `output: 'export'` in `next.config.js`. The `serve-static` target serves these static files for E2E testing in CI, without requiring a Next.js server.
+For a complete pipeline, see [Set up CI](/docs/getting-started/setup-ci).
 
 ## What's next
 

--- a/astro-docs/src/content/docs/technologies/react/react-native/index.mdoc
+++ b/astro-docs/src/content/docs/technologies/react/react-native/index.mdoc
@@ -6,4 +6,6 @@ description: Mobile app development with React Native
 pagefind: false
 ---
 
+Get started with [Nx with React Native](/docs/technologies/react/react-native/introduction), or browse the topics below.
+
 {% index_page_cards path="technologies/react/react-native" /%}

--- a/astro-docs/src/content/docs/technologies/react/react-native/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/react/react-native/introduction.mdoc
@@ -1,13 +1,13 @@
 ---
-title: React Native Plugin for Nx
-description: The Nx Plugin for React Native contains generators for managing React Native applications and libraries within an Nx workspace, including setup and configuration.
+title: Nx with React Native
+description: Nx scales your React Native monorepo with caching, distributed task execution, and affected-only builds.
 sidebar:
   label: 'Introduction'
 weight: 2
 filter: 'type:References'
 ---
 
-React Native brings the React declarative UI framework to iOS and Android. With React Native, you use native UI controls and have full access to the native platform.
+In a React Native monorepo, Nx lets you share libraries across apps and run only the tasks a change affects. React Native brings the React declarative UI framework to iOS and Android. With React Native, you use native UI controls and have full access to the native platform.
 
 The Nx Plugin for React Native contains generators for managing React Native applications and libraries within an Nx workspace. It provides:
 
@@ -197,3 +197,9 @@ The build artifacts will be located under `<your app folder>/android/app/build`.
 
 - [Using Detox](/docs/technologies/test-tools/detox/introduction)
 - [Using Jest](/docs/technologies/test-tools/jest/introduction)
+
+## Set up CI for your React Native monorepo
+
+In CI, Nx runs [`nx affected`](/docs/features/ci-features/affected) to rebuild and retest only the projects a change touches, and [caches](/docs/features/cache-task-results) results to skip repeated work.
+
+For a complete pipeline, see [Set up CI](/docs/getting-started/setup-ci).

--- a/astro-docs/src/content/docs/technologies/react/remix/index.mdoc
+++ b/astro-docs/src/content/docs/technologies/react/remix/index.mdoc
@@ -6,4 +6,6 @@ description: Remix framework support
 pagefind: false
 ---
 
+Get started with [Nx with Remix](/docs/technologies/react/remix/introduction), or browse the topics below.
+
 {% index_page_cards path="technologies/react/remix" /%}

--- a/astro-docs/src/content/docs/technologies/react/remix/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/react/remix/introduction.mdoc
@@ -1,6 +1,6 @@
 ---
-title: Remix Plugin for Nx
-description: Create and manage Remix applications in your Nx workspace with inferred build, dev, start, and typecheck tasks, plus generators for apps, libraries, routes, loaders, and actions.
+title: Nx with Remix
+description: Nx scales your Remix monorepo with caching, distributed task execution, and affected-only builds.
 keywords: [remix, react]
 sidebar:
   label: 'Introduction'
@@ -9,7 +9,7 @@ weight: 2
 filter: 'type:References'
 ---
 
-The Remix plugin for Nx, `@nx/remix`, automatically [infers `build`, `dev`, `start`, and `typecheck` tasks](#how-nxremix-infers-tasks) from your Remix configuration and provides [generators for applications, libraries, routes, loaders, actions, and meta functions](#develop-remix-applications).
+The Remix plugin for Nx, `@nx/remix`, helps you build and scale a Remix monorepo. It automatically [infers `build`, `dev`, `start`, and `typecheck` tasks](#how-nxremix-infers-tasks) from your Remix configuration and provides [generators for applications, libraries, routes, loaders, actions, and meta functions](#develop-remix-applications).
 
 You don't need the plugin to use Remix with Nx. Any project already benefits from [caching](/docs/features/cache-task-results), [task orchestration](/docs/features/run-tasks), and the [project graph](/docs/features/explore-graph). The plugin adds automatic task inference, route scaffolding, and simplified configuration.
 
@@ -228,26 +228,11 @@ nx show project my-app
 
 Or open the [project details view in Nx Console](/docs/guides/nx-console/console-project-details#_top).
 
-## CI considerations
+## Set up CI for your Remix monorepo
 
-See [Set Up CI](/docs/guides/nx-cloud/setup-ci) for a complete CI configuration guide.
+In CI, Nx runs [`nx affected`](/docs/features/ci-features/affected) to rebuild and retest only the projects a change touches, and [caches](/docs/features/cache-task-results) results to skip repeated work.
 
-### Build and test only what changed
-
-```shell
-nx affected -t build test typecheck lint
-```
-
-This uses the [project graph](/docs/features/explore-graph) to determine which projects are affected by your changes and only runs tasks for those.
-Read more about [the benefits of `nx affected`](/docs/features/ci-features/affected).
-
-### Remote caching
-
-Share build and typecheck cache results across your team and CI with [remote caching](/docs/features/ci-features/remote-cache):
-
-```shell
-nx connect
-```
+For a complete pipeline, see [Set up CI](/docs/getting-started/setup-ci).
 
 ## What's next
 

--- a/astro-docs/src/content/docs/technologies/test-tools/cypress/index.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/cypress/index.mdoc
@@ -6,4 +6,6 @@ description: E2E testing with Cypress
 pagefind: false
 ---
 
+Get started with [Nx with Cypress](/docs/technologies/test-tools/cypress/introduction), or browse the topics below.
+
 {% index_page_cards path="technologies/test-tools/cypress" /%}

--- a/astro-docs/src/content/docs/technologies/test-tools/cypress/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/cypress/introduction.mdoc
@@ -1,6 +1,6 @@
 ---
-title: Cypress Plugin for Nx
-description: The Nx Plugin for Cypress contains executors and generators that support e2e testing with Cypress, including setup and configuration for your Nx workspace.
+title: Nx with Cypress
+description: Run Cypress through Nx for caching, affected test runs, and faster CI across your monorepo.
 sidebar:
   label: Introduction
 weight: 2
@@ -338,3 +338,9 @@ nx e2e frontend-e2e --env.API_URL="https://api.my-nx-website.com" --env.API_KEY=
 {% aside type="caution" title="Command-line args vs configuration options" %}
 Providing a flag will override any option with the same name set in the project or workspace configuration.
 {% /aside %}
+
+## Set up CI
+
+In CI, Nx runs [`nx affected`](/docs/features/ci-features/affected) to rebuild and retest only the projects a change touches, and [caches](/docs/features/cache-task-results) results to skip repeated work.
+
+For a complete pipeline, see [Set up CI](/docs/getting-started/setup-ci).

--- a/astro-docs/src/content/docs/technologies/test-tools/detox/index.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/detox/index.mdoc
@@ -6,4 +6,6 @@ description: React Native testing with Detox
 pagefind: false
 ---
 
+Get started with [Nx with Detox](/docs/technologies/test-tools/detox/introduction), or browse the topics below.
+
 {% index_page_cards path="technologies/test-tools/detox" /%}

--- a/astro-docs/src/content/docs/technologies/test-tools/detox/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/detox/introduction.mdoc
@@ -1,6 +1,6 @@
 ---
-title: Detox Plugin for Nx
-description: Learn how to set up and use Detox for end-to-end testing of mobile applications in your Nx workspace, including environment setup and configuration options.
+title: Nx with Detox
+description: Run Detox through Nx for caching, affected test runs, and faster CI across your monorepo.
 sidebar:
   label: Introduction
 weight: 2
@@ -132,3 +132,9 @@ In addition, to override the device name specified in a configuration, you could
 nx test-ios frontend-e2e --device-name "iPhone 11"
 nx test-android frontend-e2e --device-name "Pixel_4a_API_30"
 ```
+
+## Set up CI
+
+In CI, Nx runs [`nx affected`](/docs/features/ci-features/affected) to rebuild and retest only the projects a change touches, and [caches](/docs/features/cache-task-results) results to skip repeated work.
+
+For a complete pipeline, see [Set up CI](/docs/getting-started/setup-ci).

--- a/astro-docs/src/content/docs/technologies/test-tools/jest/index.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/jest/index.mdoc
@@ -6,4 +6,6 @@ description: Unit testing with Jest
 pagefind: false
 ---
 
+Get started with [Nx with Jest](/docs/technologies/test-tools/jest/introduction), or browse the topics below.
+
 {% index_page_cards path="technologies/test-tools/jest" /%}

--- a/astro-docs/src/content/docs/technologies/test-tools/jest/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/jest/introduction.mdoc
@@ -1,6 +1,6 @@
 ---
-title: Jest Plugin for Nx
-description: The Nx Plugin for Jest contains executors and generators that support testing projects using Jest, including setup and configuration for your Nx workspace.
+title: Nx with Jest
+description: Run Jest through Nx for caching, affected test runs, and faster CI across your monorepo.
 sidebar:
   label: Introduction
 weight: 2
@@ -213,48 +213,11 @@ Open the project details view in Nx Console or run:
 nx show project my-app
 ```
 
-## CI considerations
+## Set up CI
 
-See [Set Up CI](/docs/guides/nx-cloud/setup-ci) for a complete CI configuration guide.
+In CI, Nx runs [`nx affected`](/docs/features/ci-features/affected) to rebuild and retest only the projects a change touches, and [caches](/docs/features/cache-task-results) results to skip repeated work.
 
-### Build and test only what changed
-
-```shell
-nx affected -t build test typecheck lint
-```
-
-This uses the [project graph](/docs/features/explore-graph) to determine which projects are affected by your changes and only runs tasks for those.
-Read more about [the benefits of `nx affected`](/docs/features/ci-features/affected).
-
-### Remote caching
-
-Share build and typecheck cache results across your team and CI with [remote caching](/docs/features/ci-features/remote-cache):
-
-```shell
-nx connect
-```
-
-### Task splitting for slow tests
-
-For slow test suites (e.g. E2E or integration tests), set `ciTargetName` to split tests by file for distributed CI runs. Each test file becomes its own cacheable CI task with better caching and retries. See [split e2e tasks](/docs/features/ci-features/split-e2e-tasks) for details.
-
-### Feature-based testing
-
-Organize tests by feature to get better cache hits and more targeted CI runs. See the [feature-based testing guide](/docs/guides/tips-n-tricks/feature-based-testing) for strategies on structuring tests in a monorepo.
-
-### Performance with parallelization
-
-Typically, in CI it's recommended to use `nx affected -t test --parallel=[# CPUs] --runInBand` for the best performance.
-
-This is because each Jest process creates workers based on system resources, and running multiple projects via Nx with Jest workers will create too many processes overall, causing the system to run slower than desired. Using the `--runInBand` flag tells Jest to run in a single process. You can then use Nx parallelism to run multiple Jest projects at once.
-
-### Batch mode
-
-For large monorepos with many Jest projects, Batch mode can improve performance by batching compilation across projects into a single process.
-
-```shell
-NX_BATCH_MODE=true nx run-many -t test
-```
+For a complete pipeline, see [Set up CI](/docs/getting-started/setup-ci).
 
 ## What's next
 

--- a/astro-docs/src/content/docs/technologies/test-tools/playwright/index.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/playwright/index.mdoc
@@ -6,4 +6,6 @@ description: E2E testing with Playwright
 pagefind: false
 ---
 
+Get started with [Nx with Playwright](/docs/technologies/test-tools/playwright/introduction), or browse the topics below.
+
 {% index_page_cards path="technologies/test-tools/playwright" /%}

--- a/astro-docs/src/content/docs/technologies/test-tools/playwright/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/playwright/introduction.mdoc
@@ -1,6 +1,6 @@
 ---
-title: Playwright Plugin for Nx
-description: The Nx Plugin for Playwright contains executors and generators that support e2e testing with Playwright, including setup and configuration for your Nx workspace.
+title: Nx with Playwright
+description: Run Playwright through Nx for caching, affected test runs, and faster CI across your monorepo.
 sidebar:
   label: Introduction
 weight: 2
@@ -296,3 +296,9 @@ export default defineConfig({
 ```
 
 See the [Playwright configuration docs](https://playwright.dev/docs/test-configuration) for more options for Playwright.
+
+## Set up CI
+
+In CI, Nx runs [`nx affected`](/docs/features/ci-features/affected) to rebuild and retest only the projects a change touches, and [caches](/docs/features/cache-task-results) results to skip repeated work.
+
+For a complete pipeline, see [Set up CI](/docs/getting-started/setup-ci).

--- a/astro-docs/src/content/docs/technologies/test-tools/storybook/index.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/storybook/index.mdoc
@@ -6,4 +6,6 @@ description: Component development with Storybook
 pagefind: false
 ---
 
+Get started with [Nx with Storybook](/docs/technologies/test-tools/storybook/introduction), or browse the topics below.
+
 {% index_page_cards path="technologies/test-tools/storybook" /%}

--- a/astro-docs/src/content/docs/technologies/test-tools/storybook/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/storybook/introduction.mdoc
@@ -1,6 +1,6 @@
 ---
-title: Storybook Plugin for Nx
-description: This is an overview page for the Storybook plugin in Nx. It explains what Storybook is and how to set it up in your Nx workspace.
+title: Nx with Storybook
+description: Use Storybook with Nx for caching, affected builds, and faster CI across your monorepo.
 sidebar:
   label: Introduction
 weight: 2
@@ -247,3 +247,9 @@ Here's more information on common migration scenarios for Storybook with Nx. For
 
 - [Upgrading Storybook guide](/docs/technologies/test-tools/storybook/guides/upgrading-storybook)
 - [Storybook 10 migration generator](/docs/technologies/test-tools/storybook/generators#migrate-10)
+
+## Set up CI
+
+In CI, Nx runs [`nx affected`](/docs/features/ci-features/affected) to rebuild and retest only the projects a change touches, and [caches](/docs/features/cache-task-results) results to skip repeated work.
+
+For a complete pipeline, see [Set up CI](/docs/getting-started/setup-ci).

--- a/astro-docs/src/content/docs/technologies/test-tools/vitest/index.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/vitest/index.mdoc
@@ -6,4 +6,6 @@ description: Component development with Vitest
 pagefind: false
 ---
 
+Get started with [Nx with Vitest](/docs/technologies/test-tools/vitest/introduction), or browse the topics below.
+
 {% index_page_cards path="technologies/test-tools/vitest" /%}

--- a/astro-docs/src/content/docs/technologies/test-tools/vitest/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/vitest/introduction.mdoc
@@ -1,6 +1,6 @@
 ---
-title: Vitest Plugin for Nx
-description: The Nx Plugin for Vitest contains executors and generators that support testing projects using Vitest, including setup and configuration for your Nx workspace.
+title: Nx with Vitest
+description: Run Vitest through Nx for caching, affected test runs, and faster CI across your monorepo.
 sidebar:
   label: Introduction
 weight: 2
@@ -214,36 +214,11 @@ If you use Vitest for unit and e2e tests, configure the plugin twice with differ
 }
 ```
 
-## CI considerations
+## Set up CI
 
-See [Set Up CI](/docs/guides/nx-cloud/setup-ci) for a complete CI configuration guide.
+In CI, Nx runs [`nx affected`](/docs/features/ci-features/affected) to rebuild and retest only the projects a change touches, and [caches](/docs/features/cache-task-results) results to skip repeated work.
 
-### Build and test only what changed
-
-```shell
-nx affected -t test
-```
-
-This uses the [project graph](/docs/features/explore-graph) to determine which projects are affected by your changes and only runs tasks for those.
-Read more about [the benefits of `nx affected`](/docs/features/ci-features/affected).
-
-### Remote caching
-
-Share test and e2e cache results across your team and CI with [remote caching](/docs/features/ci-features/remote-cache):
-
-```shell
-nx connect
-```
-
-### Task splitting for slow tests
-
-For slow test suites (e.g. E2E or integration tests), set `ciTargetName` to split tests by file for distributed CI runs. Each test file becomes its own cacheable CI task with better caching and retries. See [split e2e tasks](/docs/features/ci-features/split-e2e-tasks) for details.
-
-If you use `testMode: "watch"` locally, use `testMode: "run"` for CI to keep runs deterministic.
-
-### Feature-based testing
-
-Organize tests by feature to get better cache hits and more targeted CI runs. See the [feature-based testing guide](/docs/guides/tips-n-tricks/feature-based-testing) for strategies on structuring tests in a monorepo.
+For a complete pipeline, see [Set up CI](/docs/getting-started/setup-ci).
 
 ## What's next
 

--- a/astro-docs/src/content/docs/technologies/typescript/index.mdoc
+++ b/astro-docs/src/content/docs/technologies/typescript/index.mdoc
@@ -6,4 +6,6 @@ description: Advanced TypeScript support with project references, incremental bu
 pagefind: false
 ---
 
+Get started with [Nx with TypeScript](/docs/technologies/typescript/introduction), or browse the topics below.
+
 {% index_page_cards path="technologies/typescript" /%}

--- a/astro-docs/src/content/docs/technologies/typescript/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/typescript/introduction.mdoc
@@ -1,6 +1,6 @@
 ---
-title: TypeScript Plugin for Nx
-description: Manage TypeScript and JavaScript libraries in your Nx workspace with automatic typechecking, builds via TSC or SWC, and support for project references and package manager workspaces.
+title: Nx with TypeScript
+description: Nx scales your TypeScript monorepo with caching, distributed task execution, and affected-only builds.
 keywords: [typescript, javascript, js, ts]
 sidebar:
   label: Introduction
@@ -9,7 +9,7 @@ weight: 2
 filter: 'type:References'
 ---
 
-The TypeScript plugin for Nx, `@nx/js`, provides [generators for creating TypeScript and JavaScript projects](#generate-and-manage-typescript-libraries), and the `@nx/js/typescript` plugin automatically infers [`typecheck` and `build` tasks](#how-the-typescript-plugin-infers-tasks) for your projects using package manager workspaces and TypeScript project references. Maintaining TypeScript project references in a monorepo can be cumbersome, the `@nx/js` plugin comes with a [sync generator](/docs/concepts/sync-generators) to automatically upkeep these references.
+The TypeScript plugin for Nx, `@nx/js`, helps you run and maintain a TypeScript monorepo. It provides [generators for creating TypeScript and JavaScript projects](#generate-and-manage-typescript-libraries), and the `@nx/js/typescript` plugin automatically infers [`typecheck` and `build` tasks](#how-the-typescript-plugin-infers-tasks) for your projects using package manager workspaces and TypeScript project references. Maintaining TypeScript project references in a monorepo can be cumbersome, the `@nx/js` plugin comes with a [sync generator](/docs/concepts/sync-generators) to automatically upkeep these references.
 
 You don't need the plugin to use TypeScript with Nx, any project already benefits from [caching](/docs/features/cache-task-results), [task orchestration](/docs/features/run-tasks), and the [project graph](/docs/features/explore-graph). The plugin can help simplify setups and maintenance of TypeScript projects at scale.
 
@@ -311,30 +311,11 @@ nx show project <my-project>
 
 Or open the [project details view in Nx Console](/docs/guides/nx-console/console-project-details#_top).
 
-## CI considerations for TypeScript projects
+## Set up CI for your TypeScript monorepo
 
-See [Set Up CI](/docs/guides/nx-cloud/setup-ci) for a complete CI configuration guide.
+In CI, Nx runs [`nx affected`](/docs/features/ci-features/affected) to rebuild and retest only the projects a change touches, and [caches](/docs/features/cache-task-results) results to skip repeated work.
 
-### Build and test only what changed
-
-```shell
-nx affected -t build test typecheck lint
-```
-
-This uses the [project graph](/docs/features/explore-graph) to determine which projects are affected by your changes and only runs tasks for those.
-Read more about [the benefits of `nx affected`](/docs/features/ci-features/affected).
-
-### Remote caching
-
-Share build and typecheck cache results across your team and CI with [remote caching](/docs/features/ci-features/remote-cache):
-
-```shell
-nx connect
-```
-
-### Batch mode
-
-For large monorepos with many TypeScript projects, [TSC batch mode](/docs/technologies/typescript/guides/enable-tsc-batch-mode) can improve build performance by batching compilation across projects.
+For a complete pipeline, see [Set up CI](/docs/getting-started/setup-ci).
 
 ## What's next
 

--- a/astro-docs/src/content/docs/technologies/vue/index.mdoc
+++ b/astro-docs/src/content/docs/technologies/vue/index.mdoc
@@ -6,4 +6,6 @@ description: Build Vue applications with Nx Vue plugin supporting Vue 3 and Nuxt
 pagefind: false
 ---
 
+Get started with [Nx with Vue](/docs/technologies/vue/introduction), or browse the topics below.
+
 {% index_page_cards path="technologies/vue" /%}

--- a/astro-docs/src/content/docs/technologies/vue/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/vue/introduction.mdoc
@@ -1,13 +1,13 @@
 ---
-title: Vue Plugin for Nx
-description: The Nx Plugin for Vue contains generators for managing Vue applications and libraries within an Nx workspace, including setup and configuration.
+title: Nx with Vue
+description: Nx scales your Vue monorepo with caching, distributed task execution, and affected-only builds.
 sidebar:
   label: 'Introduction'
 weight: 2
 filter: 'type:References'
 ---
 
-The Nx plugin for [Vue](https://vuejs.org/).
+The `@nx/vue` plugin adds first-class [Vue](https://vuejs.org/) support to an Nx workspace, so you can scaffold, build, and test apps and libraries in a Vue monorepo.
 
 ## Requirements
 
@@ -54,3 +54,9 @@ To generate a Vue library, run the following:
 ```shell
 nx g @nx/vue:lib libs/my-lib
 ```
+
+## Set up CI for your Vue monorepo
+
+In CI, Nx runs [`nx affected`](/docs/features/ci-features/affected) to rebuild and retest only the projects a change touches, and [caches](/docs/features/cache-task-results) results to skip repeated work.
+
+For a complete pipeline, see [Set up CI](/docs/getting-started/setup-ci).

--- a/astro-docs/src/content/docs/technologies/vue/nuxt/index.mdoc
+++ b/astro-docs/src/content/docs/technologies/vue/nuxt/index.mdoc
@@ -6,4 +6,6 @@ description: Nuxt framework support
 pagefind: false
 ---
 
+Get started with [Nx with Nuxt](/docs/technologies/vue/nuxt/introduction), or browse the topics below.
+
 {% index_page_cards path="technologies/vue/nuxt" /%}

--- a/astro-docs/src/content/docs/technologies/vue/nuxt/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/vue/nuxt/introduction.mdoc
@@ -1,13 +1,13 @@
 ---
-title: Nuxt Plugin for Nx
-description: The Nx Plugin for Nuxt contains generators for managing Nuxt applications within an Nx workspace, including setup and configuration.
+title: Nx with Nuxt
+description: Nx scales your Nuxt monorepo with caching, distributed task execution, and affected-only builds.
 sidebar:
   label: Introduction
 weight: 2
 filter: 'type:References'
 ---
 
-The Nx plugin for [Nuxt](https://nuxt.com/).
+The `@nx/nuxt` plugin lets you build and scale a Nuxt monorepo with [Nuxt](https://nuxt.com/), adding generators, task inference, and caching to your projects.
 
 ## Requirements
 
@@ -117,3 +117,9 @@ This command performs several actions:
 1. It will build the Nuxt application and generate the static HTML files.
 2. It will serve the static HTML files using a simple HTTP server.
 3. It will run the Cypress tests against the served static HTML files.
+
+## Set up CI for your Nuxt monorepo
+
+In CI, Nx runs [`nx affected`](/docs/features/ci-features/affected) to rebuild and retest only the projects a change touches, and [caches](/docs/features/cache-task-results) results to skip repeated work.
+
+For a complete pipeline, see [Set up CI](/docs/getting-started/setup-ci).


### PR DESCRIPTION
## Current Behavior

Technology landing pages were titled "<Tech> Plugin for Nx" with no monorepo signal, and the Module Federation overview led with deprecated APIs.

## Expected Behavior

- Every technology introduction page is titled "Nx for <Tech>" with a monorepo-forward description; `technologies/<tech>` and `reference/<tech>` listing pages link to their overview.
- Angular overview becomes the "angular monorepo" landing; monorepo-vs-polyrepo and nx-vs-turborepo metas sharpened for search.
  - https://deploy-preview-36105--nx-docs.netlify.app/docs/technologies/angular/introduction
- Module Federation overview rewritten: leads with the React Module Federation template, makes the grounded Nx case (continuous tasks, affected, Nx Agents, shared-dependency versions), and uses the current `consumer`/`provider` generators.
  - https://deploy-preview-36105--nx-docs.netlify.app/docs/technologies/module-federation/introduction
- Next.js intro uses the Next.js template.
  - https://deploy-preview-36105--nx-docs.netlify.app/docs/technologies/react/next/introduction
  
Follow-up to #36088 (merged).

## Related Issue(s)

DOC-537

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/seo-research-80058b7a)
<!-- polygraph-session-end -->