### PR TITLE
feat(testing): add migration to verify typecheck after the 23.1 migration

### DIFF
--- a/packages/jest/migrations.json
+++ b/packages/jest/migrations.json
@@ -79,12 +79,13 @@
       "documentation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"
     },
     "set-ts-jest-isolated-modules": {
-      "version": "23.1.0-beta.3",
+      "version": "23.1.0-beta.4",
       "requires": {
         "ts-jest": ">=29.2.0"
       },
-      "description": "Set `isolatedModules: true` in `tsconfig.spec.json` for ts-jest projects on TypeScript < 6. ts-jest 29.2+ forces `moduleResolution: node10` on the CommonJS path, which ignores package `exports` maps and breaks (TS2307) resolution of exports-only workspace libraries; transpiling per file avoids the type-resolution failure.",
+      "description": "Set `isolatedModules: true` in `tsconfig.spec.json` for ts-jest projects on TypeScript < 6 (ts-jest 29.2+ forces `moduleResolution: node10` on the CommonJS path, which ignores package `exports` maps and breaks resolution of exports-only workspace libraries), then verify the workspace still typechecks and remedy any failures the change surfaced.",
       "implementation": "./dist/src/migrations/update-23-1-0/set-ts-jest-isolated-modules",
+      "prompt": "./dist/src/migrations/update-23-1-0/verify-typecheck.md",
       "documentation": "./dist/src/migrations/update-23-1-0/set-ts-jest-isolated-modules.md"
     }
   },

--- a/packages/jest/src/migrations/update-23-1-0/set-ts-jest-isolated-modules.md
+++ b/packages/jest/src/migrations/update-23-1-0/set-ts-jest-isolated-modules.md
@@ -39,3 +39,13 @@ TypeScript 6 and above resolves `exports` under `bundler` with `commonjs`, so th
   }
 }
 ```
+
+#### Verifying the workspace
+
+After the migration runs, verify the workspace still typechecks and fix anything `isolatedModules` surfaced:
+
+```bash
+nx run-many -t typecheck
+```
+
+`isolatedModules` can fail typecheck (TS1205 - re-exporting a type needs `export type`; TS2748 - const enum access) or break a project's tests at runtime even when typecheck passes. The cause is a package that re-exports a value through both `module.exports` and an ESM `export` (for example napi bindings exposing a `const enum`); per-file transpilation cannot preserve it, and consumers of that const enum break too. To fix a broken project, remove `isolatedModules` from its `tsconfig.spec.json`; if that brings back the `TS2307: Cannot find module` error this migration was added to prevent, that project needs `isolatedModules`, so fix the source instead.

--- a/packages/jest/src/migrations/update-23-1-0/verify-typecheck.md
+++ b/packages/jest/src/migrations/update-23-1-0/verify-typecheck.md
@@ -1,0 +1,14 @@
+# Verify typecheck after the Nx 23.1 migration
+
+This migration enables `isolatedModules` on ts-jest spec configs. Run
+`nx run-many -t typecheck` and fix any project it broke.
+
+`isolatedModules` can fail typecheck (TS1205 - a re-exported type needs `export type`;
+TS2748 - const enum access) or break a project's tests at runtime. To fix a broken
+project, remove `isolatedModules` from its `tsconfig.spec.json` and re-run. If a
+`TS2307: Cannot find module` error then appears for a workspace library, that project
+needs `isolatedModules` - keep it and fix the source instead (avoid mixing
+`module.exports` with an ESM `export`, and avoid cross-file `const enum`).
+
+Re-run until the projects this migration touched typecheck. See the migration
+documentation for details.


### PR DESCRIPTION
## Current Behavior

The `set-ts-jest-isolated-modules` migration (23.1) sets `isolatedModules: true` on ts-jest spec configs. This is correct for almost all projects, but can surface typecheck failures - TypeScript 5.9 deprecated tsconfig options, and isolatedModules incompatibilities - with no guidance for resolving them.

## Expected Behavior

Adds a follow-up prompt migration `update-23-1-0-verify-typecheck` (prompt-only, gated on `ts-jest >=29.2.0`) that asks the agent to run `nx run-many -t typecheck` and points it at the common failures and their remedies. A companion documentation page covers the details, including the runtime test break that typecheck cannot catch (napi/const-enum packages).

Scoped to typecheck only - build and e2e are intentionally out of scope (too slow to gate a migration on).

## Related Issue(s)

NXC-4591

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/nx-23.1.0-beta.0-Migration-24e91166)
<!-- polygraph-session-end -->