### PR TITLE
docs(js): add TS 6 to plugin version matrix

### DIFF
--- a/astro-docs/src/content/docs/technologies/typescript/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/typescript/introduction.mdoc
@@ -19,7 +19,7 @@ Nx supports the latest version of TypeScript. TypeScript itself only officially 
 
 | Nx Version     | TypeScript Version |
 | -------------- | ------------------ |
-| 23.x (current) | >= 5.4.2 < 5.10.0  |
+| 23.x (current) | >= 5.8.0 < 6.1.0   |
 | 22.x           | >= 5.4.2 < 5.10.0  |
 | 21.x           | >= 5.4.2 < 5.10.0  |
 | 20.x           | ~5.4.2             |


### PR DESCRIPTION
PR #35851 bumped the TS version to v6. this change adds it to the docs for the js plugin page that was missing

https://nx.dev/docs/technologies/typescript/introduction#requirements
