### PR TITLE
feat(nx-dev): show product hunt launch banner in docs

### DIFF
--- a/astro-docs/src/components/layout/ConfBanner.astro
+++ b/astro-docs/src/components/layout/ConfBanner.astro
@@ -45,9 +45,11 @@ const active = isConfBannerActive();
     z-index: calc(var(--sl-z-index-navbar) + 1);
     height: var(--conf-banner-h, 2.5rem);
     display: flex;
+    flex-wrap: wrap;
     align-items: center;
+    align-content: center;
     justify-content: center;
-    gap: 0.625rem;
+    gap: 0.25rem 0.625rem;
     padding-inline: 1rem;
     /* Theme-aware: light strip in light mode, dark strip in dark mode. */
     background-color: var(--sl-color-bg-nav);

--- a/astro-docs/src/components/layout/ConfBanner.astro
+++ b/astro-docs/src/components/layout/ConfBanner.astro
@@ -15,12 +15,11 @@ const active = isConfBannerActive();
     >
       <span class="conf-banner__text">
         <span class="conf-banner__brand">
-          AI <span class="conf-banner__heart">&#9829;</span> Monorepos
+          🚀 We&rsquo;re live on Product Hunt
         </span>
-        <span class="conf-banner__desc">Free online conference &middot; June 23</span>
       </span>
       <span class="conf-banner__cta">
-        Join us!
+        Vote or leave a comment today!
         <svg
           class="conf-banner__arrow"
           viewBox="0 0 20 20"
@@ -72,15 +71,6 @@ const active = isConfBannerActive();
     white-space: nowrap;
   }
 
-  .conf-banner__heart {
-    color: #f43f5e;
-  }
-
-  .conf-banner__desc {
-    color: var(--sl-color-gray-3);
-    white-space: nowrap;
-  }
-
   .conf-banner__cta {
     display: inline-flex;
     align-items: center;
@@ -100,12 +90,5 @@ const active = isConfBannerActive();
   .conf-banner__arrow {
     width: 1rem;
     height: 1rem;
-  }
-
-  /* Tight viewports: drop the descriptor so the bar stays one line at 2.5rem. */
-  @media (max-width: 30rem) {
-    .conf-banner__desc {
-      display: none;
-    }
   }
 </style>

--- a/astro-docs/src/components/layout/PageFrame.astro
+++ b/astro-docs/src/components/layout/PageFrame.astro
@@ -90,9 +90,17 @@ const bannerId = bannerConfig ? `${bannerConfig.title}-${bannerConfig.activeUnti
       min-height: 100vh;
     }
 
-    /* Height of the conference promo strip; reused to offset everything below it. */
+    /* Height of the promo strip; reused to offset everything below it. */
     .page.has-conf-banner {
       --conf-banner-h: 2.5rem;
+    }
+
+    /* Narrow viewports: the banner copy wraps to two lines, so grow the strip
+       (and every offset derived from it) to keep the content from clipping. */
+    @media (max-width: 36rem) {
+      .page.has-conf-banner {
+        --conf-banner-h: 3.75rem;
+      }
     }
 
     .header {

--- a/astro-docs/src/components/layout/conf-banner.ts
+++ b/astro-docs/src/components/layout/conf-banner.ts
@@ -1,9 +1,9 @@
-// Time-boxed promo bar for the "AI <3 Monorepos" online conference.
+// Time-boxed promo bar for the Polygraph Product Hunt launch.
 // Build-time gated: the next rebuild after `activeUntil` drops the banner.
 export const confBanner = {
-  url: 'https://monorepo.tools/conf?utm_campaign=2026%20Conferences&utm_source=nx-docs&utm_medium=banner',
-  // End of June 23 2026, ET (UTC-4).
-  activeUntil: '2026-06-24T04:00:00Z',
+  url: 'https://www.producthunt.com/products/polygraph',
+  // End of June 25 2026, ET (UTC-4).
+  activeUntil: '2026-06-26T04:00:00Z',
 };
 
 export function isConfBannerActive(now: Date = new Date()): boolean {


### PR DESCRIPTION
## Current Behavior

The docs top banner was used for the "AI <3 Monorepos" conference (DOC-521) and auto-expired after June 24. There's currently no banner promoting the Polygraph Product Hunt launch.

## Expected Behavior

Repurposes the existing time-boxed promo bar for the Polygraph Product Hunt launch:

- Links the banner to https://www.producthunt.com/products/polygraph
- Copy: **🚀 We're live on Product Hunt** · _Vote or leave a comment today!_
- `activeUntil` set to `2026-06-26T04:00:00Z` (midnight ET, June 25) — the banner is build-time gated and auto-hides on the first rebuild after that
- Removed the now-unused conference `__heart`/`__desc` styles

No new wiring needed — the banner renders site-wide through `PageFrame.astro` while active.

## Related Issue(s)

N/A — launch-day promo.

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/docs-conf-banner-e2599b5b)
<!-- polygraph-session-end -->


<img width="1282" height="227" alt="image" src="https://github.com/user-attachments/assets/c82da986-2050-48a8-b74d-62e0ac810975" />

<img width="548" height="223" alt="image" src="https://github.com/user-attachments/assets/a3e916ec-fa05-4777-85db-94929326294c" />
