### PR TITLE
docs(misc): refresh stale version references in astro-docs

### DIFF
--- a/astro-docs/src/content/docs/extending-nx/create-install-package.mdoc
+++ b/astro-docs/src/content/docs/extending-nx/create-install-package.mdoc
@@ -21,7 +21,7 @@ Customizing your initial project setup is already possible with an [Nx Preset ge
 npx create-nx-workspace --preset my-plugin
 ```
 
-This allows you to take full control over the shape of the generated Nx workspace. You might however want to have your own `create-{x}` package, whether that is for marketing purposes, branding or better discoverability. Starting with Nx 16.5 you can now have such a `create-{x}` package generated for you.
+This allows you to take full control over the shape of the generated Nx workspace. You might however want to have your own `create-{x}` package, whether that is for marketing purposes, branding or better discoverability. You can have such a `create-{x}` package generated for you.
 
 ## Generating a "Create package"
 

--- a/astro-docs/src/content/docs/extending-nx/local-executors.mdoc
+++ b/astro-docs/src/content/docs/extending-nx/local-executors.mdoc
@@ -142,7 +142,7 @@ Hello World
 
 {% aside type="caution" title="string" %}
 
-Nx uses the paths from `tsconfig.base.json` when running plugins locally, but uses the recommended tsconfig for node 16 for other compiler options. See https://github.com/tsconfig/bases/blob/main/bases/node16.json
+Nx uses the paths from `tsconfig.base.json` when running plugins locally, but uses `nodenext` for module resolution and other compiler options.
 
 {% /aside %}
 

--- a/astro-docs/src/content/docs/extending-nx/local-generators.mdoc
+++ b/astro-docs/src/content/docs/extending-nx/local-generators.mdoc
@@ -113,7 +113,7 @@ If your package.json has a different name, adjust the command accordingly.
 
 {% aside type="caution" title="TsConfig" %}
 
-Nx uses the paths from `tsconfig.base.json` when running plugins locally, but uses the recommended tsconfig for node 16 for other compiler options. See https://github.com/tsconfig/bases/blob/main/bases/node16.json
+Nx uses the paths from `tsconfig.base.json` when running plugins locally, but uses `nodenext` for module resolution and other compiler options.
 
 {% /aside %}
 

--- a/astro-docs/src/content/docs/extending-nx/project-graph-plugins.mdoc
+++ b/astro-docs/src/content/docs/extending-nx/project-graph-plugins.mdoc
@@ -369,8 +369,6 @@ export const createNodesV2: CreateNodesV2<MyPluginOptions> = [
 ];
 ```
 
-This functionality is available in Nx 17 or higher.
-
 ## Visualizing the project graph
 
 You can then visualize the project graph as described [here](/docs/features/explore-graph). However, there is a cache that Nx uses to avoid recalculating the project graph as much as possible. As you develop your project graph plugin, it might be a good idea to set the following environment variable to disable the project graph cache: `NX_CACHE_PROJECT_GRAPH=false`.

--- a/astro-docs/src/content/docs/features/CI Features/distribute-task-execution.mdoc
+++ b/astro-docs/src/content/docs/features/CI Features/distribute-task-execution.mdoc
@@ -63,7 +63,7 @@ jobs:
       # Cache node_modules
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'pnpm'
       ...
 

--- a/astro-docs/src/content/docs/features/CI Features/split-e2e-tasks.mdoc
+++ b/astro-docs/src/content/docs/features/CI Features/split-e2e-tasks.mdoc
@@ -461,7 +461,7 @@ jobs:
 
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 22
           cache: 'pnpm'
 
       - run: pnpm install --frozen-lockfile

--- a/astro-docs/src/content/docs/features/explore-graph.mdoc
+++ b/astro-docs/src/content/docs/features/explore-graph.mdoc
@@ -424,9 +424,9 @@ Try playing around with a [fully interactive graph on a sample repo](https://nrw
 
 {% /graph %}
 
-**Composite View (Nx 20+):**
+**Composite View:**
 
-{% graph height="450px" title="Composite View (Nx 20+)" %}
+{% graph height="450px" title="Composite View" %}
 
 ```json
 {

--- a/astro-docs/src/content/docs/getting-started/Tutorials/angular-monorepo-tutorial.mdoc
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/angular-monorepo-tutorial.mdoc
@@ -18,7 +18,7 @@ What you'll learn:
 
 ## Prerequisite: Tutorial setup
 
-This tutorial requires [Node.js](https://nodejs.org) (v20.19 or later) installed on your machine.
+This tutorial requires [Node.js](https://nodejs.org) (v22 or later) installed on your machine.
 
 ### Step 1: Creating a new Nx Angular workspace
 

--- a/astro-docs/src/content/docs/getting-started/Tutorials/react-monorepo-tutorial.mdoc
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/react-monorepo-tutorial.mdoc
@@ -18,7 +18,7 @@ What you'll learn:
 
 ## Prerequisite: Tutorial setup
 
-This tutorial requires [Node.js](https://nodejs.org) (v20.19 or later) installed on your machine.
+This tutorial requires [Node.js](https://nodejs.org) (v22 or later) installed on your machine.
 
 ### Step 1: Creating a new Nx React workspace
 

--- a/astro-docs/src/content/docs/getting-started/Tutorials/typescript-packages-tutorial.mdoc
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/typescript-packages-tutorial.mdoc
@@ -18,7 +18,7 @@ What you'll learn:
 
 ## Ready to start?
 
-This tutorial requires [Node.js](https://nodejs.org) (v20.19 or later) installed on your machine.
+This tutorial requires [Node.js](https://nodejs.org) (v22 or later) installed on your machine.
 
 ### Step 1: Creating a new Nx TypeScript workspace
 

--- a/astro-docs/src/content/docs/guides/Adopting Nx/adding-to-existing-project.mdoc
+++ b/astro-docs/src/content/docs/guides/Adopting Nx/adding-to-existing-project.mdoc
@@ -369,7 +369,7 @@ jobs:
       - run: npx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
       - run: npm ci
       - uses: nrwl/nx-set-shas@v5

--- a/astro-docs/src/content/docs/guides/Adopting Nx/adding-to-monorepo.mdoc
+++ b/astro-docs/src/content/docs/guides/Adopting Nx/adding-to-monorepo.mdoc
@@ -387,7 +387,7 @@ jobs:
       - run: npx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
       - uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
       - run: npm ci
       - uses: nrwl/nx-set-shas@v5

--- a/astro-docs/src/content/docs/guides/Nx Cloud/bring-your-own-compute.mdoc
+++ b/astro-docs/src/content/docs/guides/Nx Cloud/bring-your-own-compute.mdoc
@@ -53,7 +53,7 @@ jobs:
       - name: Use the package manager cache if available
         uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
 
       - name: Install dependencies
@@ -95,7 +95,7 @@ jobs:
       - name: Use the package manager cache if available
         uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
 
       - name: Install dependencies
@@ -294,7 +294,7 @@ Run agents directly on Bitbucket Pipelines with the workflow below:
 
 ```yaml
 // bitbucket-pipelines.yml
-image: node:20
+image: node:22
 
 clone:
   depth: full
@@ -351,7 +351,7 @@ Run agents directly on GitLab with the workflow below:
 
 ```yaml
 // .gitlab-ci.yml
-image: node:18
+image: node:22
 
 # Creating template for DTE agents
 .dte-agent:

--- a/astro-docs/src/content/docs/guides/Nx Cloud/setup-ci.mdoc
+++ b/astro-docs/src/content/docs/guides/Nx Cloud/setup-ci.mdoc
@@ -60,7 +60,7 @@ jobs:
       # Cache node_modules
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
 
       - run: npm ci
@@ -140,7 +140,7 @@ Below is an example of a GitLab setup, building and testing only what is affecte
 
 ```yaml
 // .gitlab-ci.yml
-image: node:20
+image: node:22
 variables:
   CI: 'true'
 
@@ -321,7 +321,7 @@ Below is an example of a Bitbucket Pipelines, building and testing only what is 
 
 ```yaml
 // bitbucket-pipelines.yml
-image: node:20
+image: node:22
 
 clone:
   depth: full

--- a/astro-docs/src/content/docs/guides/Nx Release/publish-in-ci-cd.mdoc
+++ b/astro-docs/src/content/docs/guides/Nx Release/publish-in-ci-cd.mdoc
@@ -154,7 +154,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies
@@ -232,7 +232,7 @@ jobs:
       - name: Install Node
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies
@@ -388,7 +388,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:
-          node-version: 20
+          node-version: 22
 
       - name: Install dependencies
         run: npm ci

--- a/astro-docs/src/content/docs/guides/Tasks & Caching/convert-to-inferred.mdoc
+++ b/astro-docs/src/content/docs/guides/Tasks & Caching/convert-to-inferred.mdoc
@@ -17,7 +17,7 @@ src="https://youtu.be/wADNsVItnsM"
 title="Project Crystal"
 /%}
 
-For the best experience, we recommend that you [migrate](/docs/features/automate-updating-dependencies) to the latest Nx version before continuing. At minimum, you should be on Nx version 19.6.
+For the best experience, we recommend that you [migrate](/docs/features/automate-updating-dependencies) to the latest Nx version before continuing.
 
 ```shell
 npx nx migrate latest

--- a/astro-docs/src/content/docs/guides/Tasks & Caching/run-tasks-in-parallel.mdoc
+++ b/astro-docs/src/content/docs/guides/Tasks & Caching/run-tasks-in-parallel.mdoc
@@ -18,32 +18,9 @@ npx nx build myapp --parallel=50%
 
 Note, you can also change the default in `nx.json`, like this:
 
-{% tabs %}
-{% tabitem label="Nx >= 17" %}
-
 ```json
 // nx.json
 {
   "parallel": 5
 }
 ```
-
-{% /tabitem %}
-{% tabitem label="Nx < 17" %}
-
-```json
-// nx.json
-{
-  "tasksRunnerOptions": {
-    "default": {
-      "runner": "nx/tasks-runners/default",
-      "options": {
-        "parallel": 5
-      }
-    }
-  }
-}
-```
-
-{% /tabitem %}
-{% /tabs %}

--- a/astro-docs/src/content/docs/guides/Tips-n-Tricks/advanced-update.mdoc
+++ b/astro-docs/src/content/docs/guides/Tips-n-Tricks/advanced-update.mdoc
@@ -198,7 +198,7 @@ To avoid passing the same flags on every run, set defaults in the [`migrate` sec
 Sometimes, you may want to use a different version of a package than what Nx recommends. To do that, specify the package and version:
 
 ```shell
-nx migrate --to="jest@22.0.0,cypress@3.4.0"
+nx migrate --to="jest@30.0.0,cypress@15.0.0"
 ```
 
 By default, Nx uses currently installed packages to calculate what migrations need to run. To override them, override the version:

--- a/astro-docs/src/content/docs/guides/Tips-n-Tricks/identify-dependencies-between-folders.mdoc
+++ b/astro-docs/src/content/docs/guides/Tips-n-Tricks/identify-dependencies-between-folders.mdoc
@@ -14,12 +14,6 @@ If you're not sure which code you want to split into a new library, this can be 
 
 Here is a technique to use during the exploration phase to help identify which code makes sense to separate into its own library.
 
-{% aside type="note" title="Requires Nx 15.3" %}
-
-Nx 15.3 introduced nested projects, which are necessary for Nx to be aware of `project.json` files inside of an existing project.
-
-{% /aside %}
-
 ## Set up
 
 1. Identify the folders that might make sense to separate into their own library

--- a/astro-docs/src/content/docs/reference/Nx Cloud/assignment-rules.mdoc
+++ b/astro-docs/src/content/docs/reference/Nx Cloud/assignment-rules.mdoc
@@ -372,7 +372,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
 
       - ... # other setup steps you may need
@@ -400,7 +400,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 22
           cache: 'npm'
 
       - ... # other setup steps you may need

--- a/astro-docs/src/content/docs/reference/nx-cloud-cli.mdoc
+++ b/astro-docs/src/content/docs/reference/nx-cloud-cli.mdoc
@@ -103,8 +103,6 @@ npx nx-cloud configure --personalAccessToken=SOME_ACCESS_TOKEN --nx-cloud-url=ht
 
 When logging into Nx Cloud with a [Personal Access Token](/docs/guides/nx-cloud/personal-access-tokens), your `nx.json` file needs to include the `nxCloudId` property, which acts as a unique identifier for your workspace. If you have been using the previous `nxCloudAccessToken` to connect, simply run `npx nx-cloud convert-to-nx-cloud-id` to automatically update your configuration to use `nxCloudId`.
 
-If you are connecting to Nx Cloud with a workspace that is version 19.6 or lower, this command will also install the latest version of the Nx Cloud npm package and add it into your `package.json`. Only Nx versions 19.7 and higher natively support the `nxCloudId` property in the `nx.json` file; for versions 19.6 and lower, the Nx Cloud npm package will be needed to use that property.
-
 **Usage:**
 
 ```shell

--- a/astro-docs/src/content/docs/reference/nx-console-settings.mdoc
+++ b/astro-docs/src/content/docs/reference/nx-console-settings.mdoc
@@ -222,7 +222,7 @@ Specifies generator names or wildcard patterns to show in the generator picker.
   "nxConsole.generatorAllowlist": [
     "@nx/react:*",
     "@nx/next:application",
-    "@nrwl/workspace:library"
+    "@nx/workspace:library"
   ]
 }
 ```
@@ -241,7 +241,7 @@ Navigate to **Settings/Preferences > Tools > Nx Console** and add patterns in th
 ```text
 @nx/react:*
 @nx/next:application
-@nrwl/workspace:library
+@nx/workspace:library
 ```
 
 {% /tabitem %}

--- a/astro-docs/src/content/docs/reference/nx-json.mdoc
+++ b/astro-docs/src/content/docs/reference/nx-json.mdoc
@@ -337,7 +337,7 @@ Note that the inputs and outputs are specified on both the `@nx/js:tsc` and `bui
 
 ### Cache
 
-In Nx 17 and higher, caching is configured by specifying `"cache": true` in a target's configuration. This will tell Nx that it's ok to cache the results of a given target. For instance, if you have a target that runs tests, you can specify `"cache": true` in the target default configuration for `test` and Nx will cache the results of running tests.
+Caching is configured by specifying `"cache": true` in a target's configuration. This will tell Nx that it's ok to cache the results of a given target. For instance, if you have a target that runs tests, you can specify `"cache": true` in the target default configuration for `test` and Nx will cache the results of running tests.
 
 ```json
 // nx.json

--- a/astro-docs/src/content/docs/reference/project-configuration.mdoc
+++ b/astro-docs/src/content/docs/reference/project-configuration.mdoc
@@ -209,7 +209,7 @@ A large portion of project configuration is related to defining the tasks for th
 
 ### Cache
 
-In Nx 17 and higher, caching is configured by specifying `"cache": true` in a target's configuration. This will tell Nx that it's ok to cache the results of a given target. For instance, if you have a target that runs tests, you can specify `"cache": true` in the target default configuration for `test` and Nx will cache the results of running tests.
+Caching is configured by specifying `"cache": true` in a target's configuration. This will tell Nx that it's ok to cache the results of a given target. For instance, if you have a target that runs tests, you can specify `"cache": true` in the target default configuration for `test` and Nx will cache the results of running tests.
 
 ```json
 // project.json

--- a/astro-docs/src/content/docs/technologies/angular/angular-rspack/Guides/getting-started.mdoc
+++ b/astro-docs/src/content/docs/technologies/angular/angular-rspack/Guides/getting-started.mdoc
@@ -34,7 +34,7 @@ NX   Let's create a new workspace [https://nx.dev/getting-started/intro]
 ✔ Which unit test runner would you like to use? · vitest
 ✔ Test runner to use for end to end (E2E) tests · playwright
 
-NX   Creating your v20.8.0 workspace.
+NX   Creating your v23.0.0 workspace.
 ```
 
 {% /tabitem %}
@@ -54,7 +54,7 @@ NX   Let's create a new workspace [https://nx.dev/getting-started/intro]
 ✔ Which unit test runner would you like to use? · vitest
 ✔ Test runner to use for end to end (E2E) tests · playwright
 
-NX   Creating your v20.8.0 workspace.
+NX   Creating your v23.0.0 workspace.
 ```
 
 {% /tabitem %}

--- a/astro-docs/src/content/docs/technologies/angular/angular-rspack/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/angular/angular-rspack/introduction.mdoc
@@ -13,7 +13,7 @@ The `@angular-rspack/nx` plugin supports the following package versions.
 
 | Package         | Supported Versions                                                                        |
 | --------------- | ----------------------------------------------------------------------------------------- |
-| `@rspack/core`  | >=1.3.5 <1.7.0                                                                            |
+| `@rspack/core`  | ^2.0.0 \|\| >=1.3.5 <1.7.0                                                                |
 | `@angular/core` | See [Angular version matrix](/docs/technologies/angular/guides/angular-nx-version-matrix) |
 
 [Nx generators](/docs/features/generate-code) install the latest supported versions automatically when scaffolding new projects.

--- a/astro-docs/src/content/docs/technologies/react/next/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/react/next/introduction.mdoc
@@ -19,7 +19,7 @@ The `@nx/next` plugin supports the following package versions.
 
 | Package | Supported Versions |
 | ------- | ------------------ |
-| `next`  | >=14.0.0 <17.0.0   |
+| `next`  | >=15.0.0 <17.0.0   |
 
 [Nx generators](/docs/features/generate-code) install the latest supported versions automatically when scaffolding new projects.
 

--- a/astro-docs/src/content/docs/technologies/test-tools/storybook/Guides/one-storybook-for-all.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/storybook/Guides/one-storybook-for-all.mdoc
@@ -38,7 +38,7 @@ nx g @nx/storybook:configuration storybook-host --interactionTests=true --uiFram
 This generator will only create the `libs/storybook-host/.storybook` folder. It will also [infer the tasks](/docs/concepts/inferred-tasks): `storybook`, `build-storybook`, and `test-storybook`. This is all we care about. We don't need any stories for this project since we will import the stories from other projects in our workspace. So, if you want, you can delete the contents of the `src/lib` folder.
 
 {% aside type="note" title="Using explicit tasks" %}
-If you're on an Nx version lower than 18 or have opted out of using inferred tasks, the `storybook`, `build-storybook`, and `test-storybook` targets will be explicitly defined in the `libs/storybook-host/project.json` file.
+If you have opted out of using inferred tasks, the `storybook`, `build-storybook`, and `test-storybook` targets will be explicitly defined in the `libs/storybook-host/project.json` file.
 {% /aside %}
 
 ### Import the stories in our library's main.ts

--- a/astro-docs/src/content/docs/technologies/typescript/Guides/define-secondary-entrypoints.mdoc
+++ b/astro-docs/src/content/docs/technologies/typescript/Guides/define-secondary-entrypoints.mdoc
@@ -33,7 +33,7 @@ import bar from 'my-lib/bar';
 
 Nx helps generate other properties in the `package.json` file, and you can also use Nx to maintain this property.
 
-If you're using the `@nx/js:tsc` executor, as of Nx 16.8, you can specify the `additionalEntryPoints` and `generateExportsField` options. Here's an example:
+If you're using the `@nx/js:tsc` executor, you can specify the `additionalEntryPoints` and `generateExportsField` options. Here's an example:
 
 {% tabs %}
 {% tabitem label="package.json" %}

--- a/astro-docs/src/content/docs/technologies/typescript/Guides/enable-tsc-batch-mode.mdoc
+++ b/astro-docs/src/content/docs/technologies/typescript/Guides/enable-tsc-batch-mode.mdoc
@@ -6,10 +6,6 @@ sidebar:
 filter: 'type:Guides'
 ---
 
-{% aside type="tip" title="Available since Nx 16.6.0" %}
-The `@nx/js:tsc` batch implementation was introduced in Nx **16.6.0**.
-{% /aside %}
-
 If you're using `@nx/js:tsc` to build your projects, you can opt in to its batch implementation. It uses the [TypeScript APIs for incremental builds](https://www.typescriptlang.org/docs/handbook/project-references.html#build-mode-for-typescript) to batch task execution into a single process, which is faster than the default one-process-per-task approach. The larger the task graph, the bigger the speedup.
 
 {% aside type="caution" title="Experimental feature" %}

--- a/astro-docs/src/content/docs/troubleshooting/troubleshoot-cache-misses.mdoc
+++ b/astro-docs/src/content/docs/troubleshooting/troubleshoot-cache-misses.mdoc
@@ -9,9 +9,7 @@ Problem: A task is being executed when you expect it to be replayed from the cac
 ## Check 1: Check if your task is marked as cacheable:
 
 - Check the task has a "Cacheable" label in the Project Details View. You can do so by running `nx show project <project-name> --web` or by checking it in [Nx Console](/docs/guides/nx-console/console-project-details).
-- If you're using a version lower than Nx 17.2.0, check:
-  - the target configuration in the project's `project.json` file has `"cache": true` set, or
-  - the target configuration in `nx.json#targetDefaults` has `"cache": true` set, or
+- Check the target configuration has `"cache": true` set, either in the project's `project.json` or in `nx.json#targetDefaults`.
 
 ## Check 2: Check if the output of your task is changing the inputs of your task
 


### PR DESCRIPTION
## Current Behavior

Tech overview support tables, tutorials, CI YAML, and several guides cite outdated versions and carry dead pre-Nx-18 version gates.

## Expected Behavior

- `next` overview range -> `>=15.0.0 <17.0.0`; `angular-rspack` `@rspack/core` -> `^2.0.0 || >=1.3.5 <1.7.0` (matches its peerDep)
- Tutorials require Node 22; CI YAML `node 18/20` -> `22`
- Remove dead `Nx <17` / `<=19.6` / `<17.2.0` / pre-18 tabs and conditionals
- `@nrwl/workspace` -> `@nx/workspace`; local-plugin tsconfig note -> `nodenext`
- Drop stale "since Nx 16.x" / "Nx 17+" / "Nx 15.3" / "Nx 20+" asides and example versions

Docs-only; no `peerDependencies` changed. Verified against `packages/*/package.json` peerDeps; vale passes with 0 errors. TypeScript support matrix intentionally left to #36111.

## Related Issue(s)

Docs staleness audit 2026-06-24

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/stale-docs-0d1fd73b)
<!-- polygraph-session-end -->