### PR TITLE
fix(core): deregister pseudo-terminal exit handlers when tasks finish

### DIFF
--- a/packages/nx/src/tasks-runner/pseudo-terminal.ts
+++ b/packages/nx/src/tasks-runner/pseudo-terminal.ts
@@ -12,10 +12,11 @@ import { PseudoIPCServer } from './pseudo-ipc';
 import { RunningTask } from './running-tasks/running-task';
 import { codeToSignal, messageToCode } from '../utils/exit-codes';
 
-// Register single event listeners for all pseudo-terminal instances
-const pseudoTerminalShutdownCallbacks: Array<(s: number) => void> = [];
+// Kill any children still alive when Nx exits. Terminals remove themselves once
+// their children exit (see releaseChild), so finished runs skip a per-terminal scan.
+const activePseudoTerminals = new Set<PseudoTerminal>();
 process.on('exit', (code) => {
-  pseudoTerminalShutdownCallbacks.forEach((cb) => cb(code));
+  activePseudoTerminals.forEach((t) => t.shutdown(code));
 });
 
 export function createPseudoTerminal(skipSupportCheck: boolean = false) {
@@ -23,9 +24,7 @@ export function createPseudoTerminal(skipSupportCheck: boolean = false) {
     throw new Error('Pseudo terminal is not supported on this platform.');
   }
   const pseudoTerminal = new PseudoTerminal(new RustPseudoTerminal());
-  pseudoTerminalShutdownCallbacks.push(
-    pseudoTerminal.shutdown.bind(pseudoTerminal)
-  );
+  activePseudoTerminals.add(pseudoTerminal);
   return pseudoTerminal;
 }
 
@@ -70,6 +69,18 @@ export class PseudoTerminal {
     }
   }
 
+  // Once all children have exited, drop the process-exit handler and close IPC.
+  private releaseChild(cp: PseudoTtyProcess) {
+    this.childProcesses.delete(cp);
+    if (this.childProcesses.size === 0) {
+      activePseudoTerminals.delete(this);
+      if (this.initialized) {
+        this.pseudoIPC.close();
+        this.initialized = false;
+      }
+    }
+  }
+
   runCommand(
     command: string,
     {
@@ -98,6 +109,7 @@ export class PseudoTerminal {
       )
     );
     this.childProcesses.add(cp);
+    cp.onExit(() => this.releaseChild(cp));
     return cp;
   }
 
@@ -137,6 +149,7 @@ export class PseudoTerminal {
       this.pseudoIPC
     );
     this.childProcesses.add(cp);
+    cp.onExit(() => this.releaseChild(cp));
 
     await this.pseudoIPC.waitForChildReady(id);
 


### PR DESCRIPTION
## Current Behavior

Every task that runs in a pseudo-terminal (the default for `run-commands` and forked task executors when the TUI is active) registers a `process.on('exit')` shutdown callback in a module-level list that is **never removed**. After the command finishes, that exit handler runs one full process-tree scan (`killProcessTree`, which snapshots the entire system process table) **per registered terminal**.

On large runs this is `O(tasks)` synchronous full-process-table scans — all for child processes that have already exited and been reaped — so it does no real work, just scanning. The result is a long "hang" *after* the command has visibly finished and the TUI has auto-exited.

Measured on the `benchmarks/` workspace (1110 projects): `run-many -t cat --tui --tui-auto-exit` reached `process.exit` quickly, then the exit handler spent **minutes** running ~1110 `killProcessTree` scans (≈100–270ms each) before the shell returned.

## Expected Behavior

A pseudo terminal now **deregisters its shutdown callback (and closes its IPC server) once its child processes exit**. A finished run therefore does no process-tree scanning at exit, so the process exits immediately.

The exit-handler safety net is preserved where it matters: a terminal whose child is still alive keeps its callback (deregistration only happens from the child's `onExit`, which fires after the OS has reaped the process), so children that are genuinely still running at an abnormal exit are still killed. For already-exited children the previous scan was a no-op anyway (the reaped PID yields an empty tree), and skipping it also avoids the latent risk of signaling a recycled PID.

Verified: exit-handler region drops from ~minutes to ~1ms for 100/300 terminals; `nx build`, lint, Rust tests (408), and the `pseudo-terminal`, `pseudo-ipc`, `task-orchestrator`, `running-tasks`, and `forked-process` jest suites all pass.

## Related Issue(s)

N/A — found via the benchmarks workspace.
