### PR TITLE
fix(core): prevent path traversal / zip-slip in self-hosted remote cache

### DIFF
--- a/packages/nx/src/native/cache/cache.rs
+++ b/packages/nx/src/native/cache/cache.rs
@@ -1,5 +1,5 @@
 use std::fs::{create_dir_all, read_to_string, write};
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::rc::Rc;
 use std::time::Instant;
 use tracing::{debug, trace};
@@ -243,6 +243,7 @@ impl NxCache {
         trace!("Successfully wrote terminal outputs ({} bytes)", total_size);
 
         // Expand the outputs
+        let outputs = normalize_outputs(&self.workspace_root, outputs);
         let expanded_outputs = _expand_outputs(&self.workspace_root, outputs)?;
         trace!("Successfully expanded {} outputs", expanded_outputs.len());
 
@@ -389,6 +390,7 @@ impl NxCache {
     ) -> anyhow::Result<i64> {
         let outputs_path = Path::new(&cached_result.outputs_path);
 
+        let outputs = normalize_outputs(&self.workspace_root, outputs);
         let expanded_outputs = _expand_outputs(outputs_path, outputs)?;
 
         trace!(
@@ -506,5 +508,87 @@ where
                 std::thread::sleep(std::time::Duration::from_millis(timeout as u64));
             }
         }
+    }
+}
+
+/// Normalize declared output paths for cache use. Absolute paths are only
+/// meaningful inside the workspace: an in-workspace absolute path is made
+/// relative to the workspace root, and one pointing outside is dropped (the
+/// cache mirrors the workspace and never reads or writes outside it). Relative
+/// paths that climb out via `..` are dropped for the same reason; the rest pass
+/// through unchanged.
+fn normalize_outputs(workspace_root: &Path, outputs: Vec<String>) -> Vec<String> {
+    outputs
+        .into_iter()
+        .filter_map(|output| {
+            let path = Path::new(&output);
+            let relative = if path.is_absolute() {
+                match path.strip_prefix(workspace_root) {
+                    Ok(rel) => rel,
+                    Err(_) => {
+                        trace!("Skipping cache output outside the workspace: {}", output);
+                        return None;
+                    }
+                }
+            } else {
+                path
+            };
+            if escapes_workspace(relative) {
+                trace!("Skipping cache output outside the workspace: {}", output);
+                return None;
+            }
+            Some(relative.to_normalized_string())
+        })
+        .collect()
+}
+
+/// Whether a relative path climbs above its base via `..`.
+fn escapes_workspace(path: &Path) -> bool {
+    let mut depth: i32 = 0;
+    for component in path.components() {
+        match component {
+            Component::ParentDir => {
+                depth -= 1;
+                if depth < 0 {
+                    return true;
+                }
+            }
+            Component::Normal(_) => depth += 1,
+            Component::CurDir => {}
+            // A relative path shouldn't contain a root/prefix; treat as escaping.
+            Component::RootDir | Component::Prefix(_) => return true,
+        }
+    }
+    false
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[cfg(unix)]
+    #[test]
+    fn normalize_outputs_relativizes_in_workspace_absolute_paths() {
+        let ws = Path::new("/ws/root");
+        let out = normalize_outputs(
+            ws,
+            vec!["dist".to_string(), "/ws/root/build/app".to_string()],
+        );
+        assert_eq!(out, vec!["dist".to_string(), "build/app".to_string()]);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn normalize_outputs_skips_paths_outside_workspace() {
+        let ws = Path::new("/ws/root");
+        let out = normalize_outputs(
+            ws,
+            vec![
+                "/etc/cron.d/evil".to_string(),
+                "../../escape".to_string(),
+                "dist".to_string(),
+            ],
+        );
+        assert_eq!(out, vec!["dist".to_string()]);
     }
 }

--- a/packages/nx/src/native/cache/cache.rs
+++ b/packages/nx/src/native/cache/cache.rs
@@ -11,7 +11,7 @@ use rusqlite::{params, types::Value};
 use sysinfo::Disks;
 
 use crate::native::cache::expand_outputs::_expand_outputs;
-use crate::native::cache::file_ops::_copy;
+use crate::native::cache::file_ops::{_copy, copy_outputs_into_workspace};
 use crate::native::db::connection::NxDbConnection;
 use crate::native::utils::Normalize;
 use napi::bindgen_prelude::External;
@@ -391,39 +391,16 @@ impl NxCache {
 
         let expanded_outputs = _expand_outputs(outputs_path, outputs)?;
 
-        trace!("Removing expanded outputs: {:?}", &expanded_outputs);
-        remove_items(
-            expanded_outputs
-                .iter()
-                .map(|p| self.workspace_root.join(p))
-                .collect::<Vec<_>>()
-                .as_slice(),
-        )?;
-
         trace!(
-            "Copying Files from Cache {:?} -> {:?}",
-            &outputs_path, &self.workspace_root
+            "Restoring {} outputs from cache {:?} -> {:?}",
+            expanded_outputs.len(),
+            &outputs_path,
+            &self.workspace_root
         );
-        let sz = _copy(outputs_path, &self.workspace_root);
-
-        match sz {
-            Err(e) => {
-                let kind = underlying_io_error_kind(&e);
-                match kind {
-                    Some(std::io::ErrorKind::NotFound) => {
-                        trace!("No artifacts to copy: {:?}", e);
-                        Ok(0)
-                    }
-                    _ => {
-                        return Err(anyhow::anyhow!("Error copying files from cache: {:?}", e));
-                    }
-                }
-            }
-            Ok(sz) => {
-                trace!("Copied {} bytes from cache", sz);
-                Ok(sz)
-            }
-        }
+        // Restore only the declared outputs, confined to the workspace, so a
+        // malicious remote-cache artifact cannot drop files beyond the declared
+        // outputs or escape the workspace through a symlink.
+        copy_outputs_into_workspace(&self.workspace_root, outputs_path, &expanded_outputs)
     }
 
     #[napi]
@@ -530,14 +507,4 @@ where
             }
         }
     }
-}
-
-// From: https://docs.rs/anyhow/latest/anyhow/struct.Error.html#example-1
-fn underlying_io_error_kind(error: &anyhow::Error) -> Option<std::io::ErrorKind> {
-    for cause in error.chain() {
-        if let Some(io_error) = cause.downcast_ref::<std::io::Error>() {
-            return Some(io_error.kind());
-        }
-    }
-    None
 }

--- a/packages/nx/src/native/cache/cache.rs
+++ b/packages/nx/src/native/cache/cache.rs
@@ -243,7 +243,7 @@ impl NxCache {
         trace!("Successfully wrote terminal outputs ({} bytes)", total_size);
 
         // Expand the outputs
-        let outputs = normalize_outputs(&self.workspace_root, outputs);
+        let outputs = normalize_outputs(&self.workspace_root, outputs)?;
         let expanded_outputs = _expand_outputs(&self.workspace_root, outputs)?;
         trace!("Successfully expanded {} outputs", expanded_outputs.len());
 
@@ -390,7 +390,7 @@ impl NxCache {
     ) -> anyhow::Result<i64> {
         let outputs_path = Path::new(&cached_result.outputs_path);
 
-        let outputs = normalize_outputs(&self.workspace_root, outputs);
+        let outputs = normalize_outputs(&self.workspace_root, outputs)?;
         let expanded_outputs = _expand_outputs(outputs_path, outputs)?;
 
         trace!(
@@ -509,29 +509,27 @@ where
 }
 
 /// Normalize declared output paths for cache use: relativize an in-workspace
-/// absolute path to the workspace root, and drop any path that resolves outside
-/// the workspace (absolute elsewhere, or relative climbing out via `..`).
-fn normalize_outputs(workspace_root: &Path, outputs: Vec<String>) -> Vec<String> {
+/// absolute path to the workspace root. Errors if any path resolves outside the
+/// workspace (absolute elsewhere, or relative climbing out via `..`).
+fn normalize_outputs(workspace_root: &Path, outputs: Vec<String>) -> anyhow::Result<Vec<String>> {
     outputs
         .into_iter()
-        .filter_map(|output| {
+        .map(|output| {
             let path = Path::new(&output);
             let relative = if path.is_absolute() {
-                match path.strip_prefix(workspace_root) {
-                    Ok(rel) => rel,
-                    Err(_) => {
-                        trace!("Skipping cache output outside the workspace: {}", output);
-                        return None;
-                    }
-                }
+                path.strip_prefix(workspace_root).map_err(|_| {
+                    anyhow::anyhow!("Cache output is outside the workspace: {}", output)
+                })?
             } else {
                 path
             };
             if escapes_workspace(relative) {
-                trace!("Skipping cache output outside the workspace: {}", output);
-                return None;
+                return Err(anyhow::anyhow!(
+                    "Cache output is outside the workspace: {}",
+                    output
+                ));
             }
-            Some(relative.to_normalized_string())
+            Ok(relative.to_normalized_string())
         })
         .collect()
 }
@@ -567,22 +565,22 @@ mod test {
         let out = normalize_outputs(
             ws,
             vec!["dist".to_string(), "/ws/root/build/app".to_string()],
-        );
+        )
+        .unwrap();
         assert_eq!(out, vec!["dist".to_string(), "build/app".to_string()]);
     }
 
     #[cfg(unix)]
     #[test]
-    fn normalize_outputs_skips_paths_outside_workspace() {
+    fn normalize_outputs_errors_on_paths_outside_workspace() {
         let ws = Path::new("/ws/root");
-        let out = normalize_outputs(
-            ws,
-            vec![
-                "/etc/cron.d/evil".to_string(),
-                "../../escape".to_string(),
-                "dist".to_string(),
-            ],
+        // Absolute path outside the workspace.
+        assert!(normalize_outputs(ws, vec!["/etc/cron.d/evil".to_string()]).is_err());
+        // Relative path climbing out via `..`.
+        assert!(normalize_outputs(ws, vec!["../../escape".to_string()]).is_err());
+        // A valid output alongside an escaping one still errors.
+        assert!(
+            normalize_outputs(ws, vec!["dist".to_string(), "../../escape".to_string()]).is_err()
         );
-        assert_eq!(out, vec!["dist".to_string()]);
     }
 }

--- a/packages/nx/src/native/cache/cache.rs
+++ b/packages/nx/src/native/cache/cache.rs
@@ -399,9 +399,6 @@ impl NxCache {
             &outputs_path,
             &self.workspace_root
         );
-        // Restore only the declared outputs, confined to the workspace, so a
-        // malicious remote-cache artifact cannot drop files beyond the declared
-        // outputs or escape the workspace through a symlink.
         copy_outputs_into_workspace(&self.workspace_root, outputs_path, &expanded_outputs)
     }
 
@@ -511,12 +508,9 @@ where
     }
 }
 
-/// Normalize declared output paths for cache use. Absolute paths are only
-/// meaningful inside the workspace: an in-workspace absolute path is made
-/// relative to the workspace root, and one pointing outside is dropped (the
-/// cache mirrors the workspace and never reads or writes outside it). Relative
-/// paths that climb out via `..` are dropped for the same reason; the rest pass
-/// through unchanged.
+/// Normalize declared output paths for cache use: relativize an in-workspace
+/// absolute path to the workspace root, and drop any path that resolves outside
+/// the workspace (absolute elsewhere, or relative climbing out via `..`).
 fn normalize_outputs(workspace_root: &Path, outputs: Vec<String>) -> Vec<String> {
     outputs
         .into_iter()

--- a/packages/nx/src/native/cache/cache.rs
+++ b/packages/nx/src/native/cache/cache.rs
@@ -583,4 +583,34 @@ mod test {
             normalize_outputs(ws, vec!["dist".to_string(), "../../escape".to_string()]).is_err()
         );
     }
+
+    #[cfg(windows)]
+    #[test]
+    fn normalize_outputs_relativizes_in_workspace_absolute_paths() {
+        let ws = Path::new(r"C:\ws\root");
+        // A drive-letter absolute path inside the workspace is relativized and
+        // its separators normalized to forward slashes.
+        let out = normalize_outputs(
+            ws,
+            vec!["dist".to_string(), r"C:\ws\root\build\app".to_string()],
+        )
+        .unwrap();
+        assert_eq!(out, vec!["dist".to_string(), "build/app".to_string()]);
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn normalize_outputs_errors_on_paths_outside_workspace() {
+        let ws = Path::new(r"C:\ws\root");
+        // Absolute path on the same drive but outside the workspace.
+        assert!(normalize_outputs(ws, vec![r"C:\Windows\System32".to_string()]).is_err());
+        // Absolute path on a different drive.
+        assert!(normalize_outputs(ws, vec![r"D:\elsewhere".to_string()]).is_err());
+        // Relative path climbing out via `..`.
+        assert!(normalize_outputs(ws, vec![r"..\..\escape".to_string()]).is_err());
+        // A valid output alongside an escaping one still errors.
+        assert!(
+            normalize_outputs(ws, vec!["dist".to_string(), r"..\..\escape".to_string()]).is_err()
+        );
+    }
 }

--- a/packages/nx/src/native/cache/file_ops.rs
+++ b/packages/nx/src/native/cache/file_ops.rs
@@ -50,14 +50,17 @@ pub fn _copy_impl(src: &Path, dest: &Path, boundary: Option<&Path>) -> anyhow::R
         }
     }
 
-    let size = if src.is_dir() {
-        trace!("Copying directory: {:?}", &src);
-        copy_dir_all(&src, &dest, boundary).map_err(anyhow::Error::new)?
-    } else if src.is_symlink() {
+    // Check symlink before dir: `is_dir()` follows symlinks, so a cache output
+    // shipped as a symlink-to-dir would otherwise be followed and its (possibly
+    // external) target contents copied into the workspace.
+    let size = if src.is_symlink() {
         trace!("Copying symlink: {:?}", &src);
         remove_existing_symlink(&dest)?;
         symlink(fs::read_link(&src)?, &dest)?;
         0
+    } else if src.is_dir() {
+        trace!("Copying directory: {:?}", &src);
+        copy_dir_all(&src, &dest, boundary).map_err(anyhow::Error::new)?
     } else {
         trace!("Copying file: {:?}", &src);
         fs::copy(&src, &dest)?
@@ -385,5 +388,38 @@ mod test {
 
         assert!(workspace.join("link").symlink_metadata().is_err());
         assert!(outside.child("keep.txt").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn restore_does_not_follow_symlinked_output_dir() {
+        use std::os::unix::fs::symlink;
+
+        // A directory outside the workspace whose contents an attacker wants
+        // exfiltrated into the build outputs.
+        let outside = TempDir::new().unwrap();
+        outside.child("secret.txt").write_str("SECRET").unwrap();
+
+        // A malicious artifact ships the declared output `dist` as a symlink to
+        // that external directory (`unpack_in` creates such symlinks).
+        let cache = TempDir::new().unwrap();
+        symlink(outside.path(), cache.join("dist")).unwrap();
+
+        let workspace = TempDir::new().unwrap();
+        let expanded = vec!["dist".to_string()];
+        copy_outputs_into_workspace(workspace.path(), cache.path(), &expanded).unwrap();
+
+        // The symlink must be recreated verbatim, not followed: the external
+        // contents must not be copied into the workspace as real files.
+        let dist = workspace.join("dist");
+        assert!(
+            dist.symlink_metadata().unwrap().file_type().is_symlink(),
+            "a symlinked cache output must be recreated as a symlink, not followed"
+        );
+        // Removing the recreated link leaves no real copy behind, and the
+        // external target is untouched.
+        remove_path(&dist).unwrap();
+        assert!(!dist.join("secret.txt").exists());
+        assert!(outside.child("secret.txt").exists());
     }
 }

--- a/packages/nx/src/native/cache/file_ops.rs
+++ b/packages/nx/src/native/cache/file_ops.rs
@@ -21,44 +21,124 @@ pub fn _copy<P>(src: P, dest: P) -> anyhow::Result<i64>
 where
     P: AsRef<Path>,
 {
+    _copy_impl(src.as_ref(), dest.as_ref(), None)
+}
+
+/// Copy `src` to `dest`.
+///
+/// When `boundary` is `Some(root)` the copy is confined to `root` (used when
+/// restoring cache outputs into the workspace): parent directories are created
+/// without following symlinks — a symlink occupying a path under `root` is
+/// replaced with a real directory — and any pre-existing entry at `dest` is
+/// removed instead of written through. This stops a malicious cache artifact
+/// from writing outside the workspace via a planted or pre-existing symlink.
+/// With `None` the original behavior is used.
+pub fn _copy_impl(src: &Path, dest: &Path, boundary: Option<&Path>) -> anyhow::Result<i64> {
     let dest: PathBuf = remove_trailing_single_dot(dest);
     let dest_parent = dest.parent().unwrap_or(&dest);
-    let src: PathBuf = src.as_ref().into();
+    let src: PathBuf = src.into();
 
     trace!("Copying {:?} -> {:?}", &src, &dest);
 
-    if !dest_parent.exists() {
-        trace!("Creating parent directory: {:?}", dest_parent);
-        fs::create_dir_all(dest_parent)?;
-        trace!("Successfully created parent directory: {:?}", dest_parent);
+    match boundary {
+        Some(root) => {
+            create_dir_all_within(root, dest_parent)?;
+            // Drop any existing entry first so a stale symlink/dir/file is never
+            // followed or merged into during a restore.
+            remove_path(&dest)?;
+        }
+        None => {
+            if !dest_parent.exists() {
+                trace!("Creating parent directory: {:?}", dest_parent);
+                fs::create_dir_all(dest_parent)?;
+            }
+        }
     }
 
     let size = if src.is_dir() {
         trace!("Copying directory: {:?}", &src);
-        let copied_size = copy_dir_all(&src, &dest).map_err(anyhow::Error::new)?;
-        trace!(
-            "Successfully copied directory: {:?} ({} bytes)",
-            &src, copied_size
-        );
-        copied_size
+        copy_dir_all(&src, &dest, boundary).map_err(anyhow::Error::new)?
     } else if src.is_symlink() {
         trace!("Copying symlink: {:?}", &src);
         remove_existing_symlink(&dest)?;
         symlink(fs::read_link(&src)?, &dest)?;
-        trace!("Successfully copied symlink: {:?}", &src);
         0
     } else {
         trace!("Copying file: {:?}", &src);
-        let copied_size = fs::copy(&src, &dest)?;
-        trace!(
-            "Successfully copied file: {:?} ({} bytes)",
-            &src, copied_size
-        );
-        copied_size
+        fs::copy(&src, &dest)?
     };
 
     debug!("Copy completed: {:?} -> {:?} ({} bytes)", &src, &dest, size);
     Ok(size as i64)
+}
+
+/// Create `dir` and any missing ancestors, but never traverse a symlink at or
+/// below `boundary`: a symlink (or file) occupying such a path is removed and
+/// replaced with a real directory. Components at or above `boundary` are trusted
+/// and left untouched, so this never disturbs e.g. a `/tmp` system symlink.
+fn create_dir_all_within(boundary: &Path, dir: &Path) -> io::Result<()> {
+    // At or above the boundary: trust the existing tree, only create if missing.
+    if dir == boundary || !dir.starts_with(boundary) {
+        return match fs::symlink_metadata(dir) {
+            Ok(_) => Ok(()),
+            Err(_) => fs::create_dir_all(dir),
+        };
+    }
+
+    if let Some(parent) = dir.parent() {
+        create_dir_all_within(boundary, parent)?;
+    }
+
+    match fs::symlink_metadata(dir) {
+        Ok(meta) if meta.file_type().is_dir() => Ok(()),
+        Ok(_) => {
+            // A symlink or file occupies the path — remove it (the link itself,
+            // never its target) and create a real directory in its place.
+            remove_path(dir)?;
+            fs::create_dir(dir)
+        }
+        Err(_) => match fs::create_dir(dir) {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == io::ErrorKind::AlreadyExists => Ok(()),
+            Err(e) => Err(e),
+        },
+    }
+}
+
+/// Remove the entry at `path` without following a final symlink (the link is
+/// unlinked, never its target); a directory is removed recursively. A missing
+/// path is a no-op.
+fn remove_path(path: &Path) -> io::Result<()> {
+    match fs::symlink_metadata(path) {
+        Ok(meta) if meta.file_type().is_dir() => fs::remove_dir_all(path),
+        Ok(_) => fs::remove_file(path),
+        Err(e) if e.kind() == io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
+/// Restore the given (already expanded) cache outputs from `outputs_path` into
+/// `workspace_root`. Only the listed outputs are copied — never the whole
+/// extracted cache directory — and every copy is confined to `workspace_root`,
+/// so a malicious cache artifact can neither place files beyond the declared
+/// outputs nor escape the workspace through a symlink.
+pub fn copy_outputs_into_workspace(
+    workspace_root: &Path,
+    outputs_path: &Path,
+    expanded_outputs: &[String],
+) -> anyhow::Result<i64> {
+    let mut size = 0;
+    for output in expanded_outputs {
+        let from = outputs_path.join(output);
+        // Only restore entries the artifact actually contains.
+        if fs::symlink_metadata(&from).is_err() {
+            trace!("No cached artifact for output {}, skipping", output);
+            continue;
+        }
+        let to = workspace_root.join(output);
+        size += _copy_impl(&from, &to, Some(workspace_root))?;
+    }
+    Ok(size)
 }
 
 fn remove_trailing_single_dot(path: impl AsRef<Path>) -> PathBuf {
@@ -102,10 +182,16 @@ fn remove_existing_symlink(path: &Path) -> io::Result<()> {
     Ok(())
 }
 
-fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<u64> {
+fn copy_dir_all(
+    src: impl AsRef<Path>,
+    dst: impl AsRef<Path>,
+    boundary: Option<&Path>,
+) -> io::Result<u64> {
     trace!("Creating directory: {:?}", dst.as_ref());
-    fs::create_dir_all(&dst)?;
-    trace!("Successfully created directory: {:?}", dst.as_ref());
+    match boundary {
+        Some(root) => create_dir_all_within(root, dst.as_ref())?,
+        None => fs::create_dir_all(&dst)?,
+    }
 
     trace!("Reading source directory: {:?}", src.as_ref());
     let mut total_size = 0;
@@ -121,28 +207,24 @@ fn copy_dir_all(src: impl AsRef<Path>, dst: impl AsRef<Path>) -> io::Result<u64>
 
         let size: u64 = if ty.is_dir() {
             trace!("Copying subdirectory: {:?}", entry.path());
-            let subdir_size = copy_dir_all(entry.path(), dest_path)?;
+            let subdir_size = copy_dir_all(entry.path(), dest_path, boundary)?;
             dirs_copied += 1;
-            trace!(
-                "Successfully copied subdirectory: {:?} ({} bytes)",
-                entry_name, subdir_size
-            );
             subdir_size
         } else if ty.is_symlink() {
             trace!("Copying symlink: {:?}", entry.path());
             remove_existing_symlink(&dest_path)?;
             symlink(fs::read_link(entry.path())?, dest_path)?;
             symlinks_copied += 1;
-            trace!("Successfully copied symlink: {:?}", entry_name);
             0
         } else {
             trace!("Copying file: {:?}", entry.path());
+            // On restore, replace a pre-existing symlink rather than following
+            // it out of the workspace.
+            if boundary.is_some() {
+                remove_existing_symlink(&dest_path)?;
+            }
             let file_size = fs::copy(entry.path(), dest_path)?;
             files_copied += 1;
-            trace!(
-                "Successfully copied file: {:?} ({} bytes)",
-                entry_name, file_size
-            );
             file_size
         };
         total_size += size;
@@ -239,5 +321,79 @@ mod test {
             temp.child("new-parent/file.txt").read_link().unwrap(),
             target.path()
         );
+    }
+
+    #[test]
+    fn restore_copies_only_declared_outputs() {
+        // A malicious artifact ships files beyond the declared outputs; the
+        // restore must copy ONLY the declared (expanded) outputs.
+        let cache = TempDir::new().unwrap();
+        let workspace = TempDir::new().unwrap();
+
+        cache.child("dist/main.js").write_str("ok").unwrap();
+        cache
+            .child(".git/hooks/pre-commit")
+            .write_str("#!/bin/sh\nevil")
+            .unwrap();
+        cache.child("package.json").write_str("{evil}").unwrap();
+
+        let expanded = vec!["dist/main.js".to_string()];
+        copy_outputs_into_workspace(workspace.path(), cache.path(), &expanded).unwrap();
+
+        assert!(workspace.child("dist/main.js").exists());
+        assert!(!workspace.child(".git/hooks/pre-commit").exists());
+        assert!(!workspace.child("package.json").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn restore_does_not_traverse_parent_symlink() {
+        use std::os::unix::fs::symlink;
+
+        // A directory outside the workspace holding a victim file.
+        let outside = TempDir::new().unwrap();
+        outside.child("keep.txt").write_str("keep").unwrap();
+
+        let cache = TempDir::new().unwrap();
+        cache.child("dist/payload.js").write_str("PWNED").unwrap();
+
+        let workspace = TempDir::new().unwrap();
+        // A planted/pre-existing symlink: <workspace>/dist -> <outside>.
+        symlink(outside.path(), workspace.join("dist")).unwrap();
+
+        let expanded = vec!["dist/payload.js".to_string()];
+        copy_outputs_into_workspace(workspace.path(), cache.path(), &expanded).unwrap();
+
+        // The write must land in the workspace, not through the symlink.
+        assert!(!outside.child("payload.js").exists());
+        // The implicit delete must not have followed the symlink either.
+        assert!(outside.child("keep.txt").exists());
+        // The symlink was replaced with a real directory holding the output.
+        assert!(workspace.child("dist/payload.js").exists());
+        assert!(
+            !workspace
+                .join("dist")
+                .symlink_metadata()
+                .unwrap()
+                .file_type()
+                .is_symlink()
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn remove_path_unlinks_symlink_without_following() {
+        use std::os::unix::fs::symlink;
+
+        let outside = TempDir::new().unwrap();
+        outside.child("keep.txt").write_str("keep").unwrap();
+
+        let workspace = TempDir::new().unwrap();
+        symlink(outside.path(), workspace.join("link")).unwrap();
+
+        remove_path(&workspace.join("link")).unwrap();
+
+        assert!(workspace.join("link").symlink_metadata().is_err());
+        assert!(outside.child("keep.txt").exists());
     }
 }

--- a/packages/nx/src/native/cache/file_ops.rs
+++ b/packages/nx/src/native/cache/file_ops.rs
@@ -1,4 +1,4 @@
-use std::path::{Path, PathBuf};
+use std::path::{Component, Path, PathBuf};
 use std::{fs, io};
 
 use fs_extra::error::ErrorKind;
@@ -54,9 +54,20 @@ pub fn _copy_impl(src: &Path, dest: &Path, boundary: Option<&Path>) -> anyhow::R
     // shipped as a symlink-to-dir would otherwise be followed and its (possibly
     // external) target contents copied into the workspace.
     let size = if src.is_symlink() {
+        let target = fs::read_link(&src)?;
+        // On restore, refuse a cache symlink whose target escapes the workspace.
+        if let Some(root) = boundary {
+            if symlink_target_escapes(root, &dest, &target) {
+                return Err(anyhow::anyhow!(
+                    "Refusing to restore cache symlink {:?} escaping the workspace: {:?}",
+                    dest,
+                    target
+                ));
+            }
+        }
         trace!("Copying symlink: {:?}", &src);
         remove_existing_symlink(&dest)?;
-        symlink(fs::read_link(&src)?, &dest)?;
+        symlink(target, &dest)?;
         0
     } else if src.is_dir() {
         trace!("Copying directory: {:?}", &src);
@@ -165,6 +176,36 @@ fn symlink<P: AsRef<Path>, Q: AsRef<Path>>(original: P, link: Q) -> io::Result<(
 /// Removes an existing symlink at `path` if one exists.
 /// Uses `symlink_metadata` which does not follow symlinks, so it correctly
 /// detects dangling symlinks that `is_file()`/`is_dir()` would miss.
+/// Whether a symlink placed at `link_path` pointing to `target` would resolve
+/// outside `boundary` once followed. Absolute targets are checked directly;
+/// relative targets are resolved against the symlink's own directory. The check
+/// is lexical (collapses `.`/`..`, no symlink resolution) — sufficient because
+/// restore realizes every parent directory within `boundary` as a real
+/// directory, so there are no intermediate symlinks left to follow.
+fn symlink_target_escapes(boundary: &Path, link_path: &Path, target: &Path) -> bool {
+    let resolved = if target.is_absolute() {
+        target.to_path_buf()
+    } else {
+        link_path.parent().unwrap_or(link_path).join(target)
+    };
+    !lexically_normalize(&resolved).starts_with(lexically_normalize(boundary))
+}
+
+/// Collapse `.` and `..` components lexically, without touching the filesystem.
+fn lexically_normalize(path: &Path) -> PathBuf {
+    let mut normalized = PathBuf::new();
+    for component in path.components() {
+        match component {
+            Component::ParentDir => {
+                normalized.pop();
+            }
+            Component::CurDir => {}
+            other => normalized.push(other.as_os_str()),
+        }
+    }
+    normalized
+}
+
 fn remove_existing_symlink(path: &Path) -> io::Result<()> {
     match fs::symlink_metadata(path) {
         Ok(meta) if meta.file_type().is_symlink() => {
@@ -205,9 +246,22 @@ fn copy_dir_all(
             dirs_copied += 1;
             subdir_size
         } else if ty.is_symlink() {
+            let target = fs::read_link(entry.path())?;
+            // On restore, refuse a cache symlink whose target escapes the workspace.
+            if let Some(root) = boundary {
+                if symlink_target_escapes(root, &dest_path, &target) {
+                    return Err(io::Error::new(
+                        io::ErrorKind::Other,
+                        format!(
+                            "Refusing to restore cache symlink {:?} escaping the workspace: {:?}",
+                            dest_path, target
+                        ),
+                    ));
+                }
+            }
             trace!("Copying symlink: {:?}", entry.path());
             remove_existing_symlink(&dest_path)?;
-            symlink(fs::read_link(entry.path())?, dest_path)?;
+            symlink(target, dest_path)?;
             symlinks_copied += 1;
             0
         } else {
@@ -392,7 +446,7 @@ mod test {
 
     #[cfg(unix)]
     #[test]
-    fn restore_does_not_follow_symlinked_output_dir() {
+    fn restore_rejects_symlinked_output_escaping_workspace() {
         use std::os::unix::fs::symlink;
 
         // A directory outside the workspace whose contents an attacker wants
@@ -407,19 +461,41 @@ mod test {
 
         let workspace = TempDir::new().unwrap();
         let expanded = vec!["dist".to_string()];
+        let result = copy_outputs_into_workspace(workspace.path(), cache.path(), &expanded);
+
+        // The escaping symlink must be rejected — not recreated, not followed.
+        assert!(
+            result.is_err(),
+            "a cache symlink escaping the workspace must be rejected"
+        );
+        assert!(
+            workspace.join("dist").symlink_metadata().is_err(),
+            "no symlink must be left in the workspace"
+        );
+        assert!(outside.child("secret.txt").exists());
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn restore_allows_symlinked_output_within_workspace() {
+        use std::os::unix::fs::symlink;
+
+        // The legit pnpm/Next.js case: an output symlink whose (relative) target
+        // stays inside the workspace must still be restored.
+        let cache = TempDir::new().unwrap();
+        cache.child("dist/real.js").write_str("ok").unwrap();
+        symlink("real.js", cache.join("dist/link.js")).unwrap();
+
+        let workspace = TempDir::new().unwrap();
+        let expanded = vec!["dist/real.js".to_string(), "dist/link.js".to_string()];
         copy_outputs_into_workspace(workspace.path(), cache.path(), &expanded).unwrap();
 
-        // The symlink must be recreated verbatim, not followed: the external
-        // contents must not be copied into the workspace as real files.
-        let dist = workspace.join("dist");
+        let link = workspace.join("dist/link.js");
         assert!(
-            dist.symlink_metadata().unwrap().file_type().is_symlink(),
-            "a symlinked cache output must be recreated as a symlink, not followed"
+            link.symlink_metadata().unwrap().file_type().is_symlink(),
+            "an in-workspace symlink output must be restored"
         );
-        // Removing the recreated link leaves no real copy behind, and the
-        // external target is untouched.
-        remove_path(&dist).unwrap();
-        assert!(!dist.join("secret.txt").exists());
-        assert!(outside.child("secret.txt").exists());
+        assert_eq!(link.read_link().unwrap(), Path::new("real.js"));
+        assert_eq!(std::fs::read_to_string(&link).unwrap(), "ok");
     }
 }

--- a/packages/nx/src/native/cache/file_ops.rs
+++ b/packages/nx/src/native/cache/file_ops.rs
@@ -26,13 +26,9 @@ where
 
 /// Copy `src` to `dest`.
 ///
-/// When `boundary` is `Some(root)` the copy is confined to `root` (used when
-/// restoring cache outputs into the workspace): parent directories are created
-/// without following symlinks — a symlink occupying a path under `root` is
-/// replaced with a real directory — and any pre-existing entry at `dest` is
-/// removed instead of written through. This stops a malicious cache artifact
-/// from writing outside the workspace via a planted or pre-existing symlink.
-/// With `None` the original behavior is used.
+/// With `boundary = Some(root)` the copy is confined to `root` (cache restore):
+/// parents are realized as real dirs (any symlink under `root` is replaced) and
+/// existing entries are removed, not written through. `None` keeps the original.
 pub fn _copy_impl(src: &Path, dest: &Path, boundary: Option<&Path>) -> anyhow::Result<i64> {
     let dest: PathBuf = remove_trailing_single_dot(dest);
     let dest_parent = dest.parent().unwrap_or(&dest);
@@ -43,8 +39,7 @@ pub fn _copy_impl(src: &Path, dest: &Path, boundary: Option<&Path>) -> anyhow::R
     match boundary {
         Some(root) => {
             create_dir_all_within(root, dest_parent)?;
-            // Drop any existing entry first so a stale symlink/dir/file is never
-            // followed or merged into during a restore.
+            // Never follow or merge into a stale entry at the destination.
             remove_path(&dest)?;
         }
         None => {
@@ -72,10 +67,9 @@ pub fn _copy_impl(src: &Path, dest: &Path, boundary: Option<&Path>) -> anyhow::R
     Ok(size as i64)
 }
 
-/// Create `dir` and any missing ancestors, but never traverse a symlink at or
-/// below `boundary`: a symlink (or file) occupying such a path is removed and
-/// replaced with a real directory. Components at or above `boundary` are trusted
-/// and left untouched, so this never disturbs e.g. a `/tmp` system symlink.
+/// Create `dir` and missing ancestors without traversing a symlink at or below
+/// `boundary`: such a symlink/file is replaced with a real directory. Paths at
+/// or above `boundary` are trusted and untouched (e.g. a `/tmp` system symlink).
 fn create_dir_all_within(boundary: &Path, dir: &Path) -> io::Result<()> {
     // At or above the boundary: trust the existing tree, only create if missing.
     if dir == boundary || !dir.starts_with(boundary) {
@@ -92,8 +86,7 @@ fn create_dir_all_within(boundary: &Path, dir: &Path) -> io::Result<()> {
     match fs::symlink_metadata(dir) {
         Ok(meta) if meta.file_type().is_dir() => Ok(()),
         Ok(_) => {
-            // A symlink or file occupies the path — remove it (the link itself,
-            // never its target) and create a real directory in its place.
+            // Replace a symlink/file occupying the path with a real directory.
             remove_path(dir)?;
             fs::create_dir(dir)
         }
@@ -106,8 +99,7 @@ fn create_dir_all_within(boundary: &Path, dir: &Path) -> io::Result<()> {
 }
 
 /// Remove the entry at `path` without following a final symlink (the link is
-/// unlinked, never its target); a directory is removed recursively. A missing
-/// path is a no-op.
+/// unlinked, not its target); directories recurse, a missing path is a no-op.
 fn remove_path(path: &Path) -> io::Result<()> {
     match fs::symlink_metadata(path) {
         Ok(meta) if meta.file_type().is_dir() => fs::remove_dir_all(path),
@@ -117,11 +109,10 @@ fn remove_path(path: &Path) -> io::Result<()> {
     }
 }
 
-/// Restore the given (already expanded) cache outputs from `outputs_path` into
-/// `workspace_root`. Only the listed outputs are copied — never the whole
-/// extracted cache directory — and every copy is confined to `workspace_root`,
-/// so a malicious cache artifact can neither place files beyond the declared
-/// outputs nor escape the workspace through a symlink.
+/// Restore the given expanded outputs from `outputs_path` into `workspace_root`.
+/// Only the listed outputs are copied (never the whole cache dir) and each copy
+/// is confined to `workspace_root`, so a malicious artifact can't write beyond
+/// the declared outputs or escape via a symlink.
 pub fn copy_outputs_into_workspace(
     workspace_root: &Path,
     outputs_path: &Path,
@@ -218,8 +209,7 @@ fn copy_dir_all(
             0
         } else {
             trace!("Copying file: {:?}", entry.path());
-            // On restore, replace a pre-existing symlink rather than following
-            // it out of the workspace.
+            // On restore, don't follow a pre-existing dest symlink.
             if boundary.is_some() {
                 remove_existing_symlink(&dest_path)?;
             }

--- a/packages/nx/src/native/cache/file_ops.rs
+++ b/packages/nx/src/native/cache/file_ops.rs
@@ -1,4 +1,4 @@
-use std::path::{Component, Path, PathBuf};
+use std::path::{Path, PathBuf};
 use std::{fs, io};
 
 use fs_extra::error::ErrorKind;
@@ -50,24 +50,15 @@ pub fn _copy_impl(src: &Path, dest: &Path, boundary: Option<&Path>) -> anyhow::R
         }
     }
 
-    // Check symlink before dir: `is_dir()` follows symlinks, so a cache output
-    // shipped as a symlink-to-dir would otherwise be followed and its (possibly
-    // external) target contents copied into the workspace.
+    // Check symlink before dir: `is_dir()` follows symlinks, so a symlinked
+    // output must be recreated as a link, not followed (which would copy its
+    // target's contents in). The link is recreated verbatim even if it points
+    // outside the workspace — it is only a pointer, and we never write *through*
+    // a symlink (create_dir_all_within realizes parents as real directories).
     let size = if src.is_symlink() {
-        let target = fs::read_link(&src)?;
-        // On restore, refuse a cache symlink whose target escapes the workspace.
-        if let Some(root) = boundary {
-            if symlink_target_escapes(root, &dest, &target) {
-                return Err(anyhow::anyhow!(
-                    "Refusing to restore cache symlink {:?} escaping the workspace: {:?}",
-                    dest,
-                    target
-                ));
-            }
-        }
         trace!("Copying symlink: {:?}", &src);
         remove_existing_symlink(&dest)?;
-        symlink(target, &dest)?;
+        symlink(fs::read_link(&src)?, &dest)?;
         0
     } else if src.is_dir() {
         trace!("Copying directory: {:?}", &src);
@@ -176,36 +167,6 @@ fn symlink<P: AsRef<Path>, Q: AsRef<Path>>(original: P, link: Q) -> io::Result<(
 /// Removes an existing symlink at `path` if one exists.
 /// Uses `symlink_metadata` which does not follow symlinks, so it correctly
 /// detects dangling symlinks that `is_file()`/`is_dir()` would miss.
-/// Whether a symlink placed at `link_path` pointing to `target` would resolve
-/// outside `boundary` once followed. Absolute targets are checked directly;
-/// relative targets are resolved against the symlink's own directory. The check
-/// is lexical (collapses `.`/`..`, no symlink resolution) — sufficient because
-/// restore realizes every parent directory within `boundary` as a real
-/// directory, so there are no intermediate symlinks left to follow.
-fn symlink_target_escapes(boundary: &Path, link_path: &Path, target: &Path) -> bool {
-    let resolved = if target.is_absolute() {
-        target.to_path_buf()
-    } else {
-        link_path.parent().unwrap_or(link_path).join(target)
-    };
-    !lexically_normalize(&resolved).starts_with(lexically_normalize(boundary))
-}
-
-/// Collapse `.` and `..` components lexically, without touching the filesystem.
-fn lexically_normalize(path: &Path) -> PathBuf {
-    let mut normalized = PathBuf::new();
-    for component in path.components() {
-        match component {
-            Component::ParentDir => {
-                normalized.pop();
-            }
-            Component::CurDir => {}
-            other => normalized.push(other.as_os_str()),
-        }
-    }
-    normalized
-}
-
 fn remove_existing_symlink(path: &Path) -> io::Result<()> {
     match fs::symlink_metadata(path) {
         Ok(meta) if meta.file_type().is_symlink() => {
@@ -246,22 +207,9 @@ fn copy_dir_all(
             dirs_copied += 1;
             subdir_size
         } else if ty.is_symlink() {
-            let target = fs::read_link(entry.path())?;
-            // On restore, refuse a cache symlink whose target escapes the workspace.
-            if let Some(root) = boundary {
-                if symlink_target_escapes(root, &dest_path, &target) {
-                    return Err(io::Error::new(
-                        io::ErrorKind::Other,
-                        format!(
-                            "Refusing to restore cache symlink {:?} escaping the workspace: {:?}",
-                            dest_path, target
-                        ),
-                    ));
-                }
-            }
             trace!("Copying symlink: {:?}", entry.path());
             remove_existing_symlink(&dest_path)?;
-            symlink(target, dest_path)?;
+            symlink(fs::read_link(entry.path())?, dest_path)?;
             symlinks_copied += 1;
             0
         } else {
@@ -446,32 +394,34 @@ mod test {
 
     #[cfg(unix)]
     #[test]
-    fn restore_rejects_symlinked_output_escaping_workspace() {
+    fn restore_recreates_escaping_symlink_without_following_it() {
         use std::os::unix::fs::symlink;
 
-        // A directory outside the workspace whose contents an attacker wants
-        // exfiltrated into the build outputs.
+        // A directory outside the workspace.
         let outside = TempDir::new().unwrap();
         outside.child("secret.txt").write_str("SECRET").unwrap();
 
-        // A malicious artifact ships the declared output `dist` as a symlink to
-        // that external directory (`unpack_in` creates such symlinks).
+        // The declared output `dist` is a symlink pointing outside the workspace.
         let cache = TempDir::new().unwrap();
         symlink(outside.path(), cache.join("dist")).unwrap();
 
         let workspace = TempDir::new().unwrap();
         let expanded = vec!["dist".to_string()];
-        let result = copy_outputs_into_workspace(workspace.path(), cache.path(), &expanded);
+        copy_outputs_into_workspace(workspace.path(), cache.path(), &expanded).unwrap();
 
-        // The escaping symlink must be rejected — not recreated, not followed.
+        // The symlink is recreated verbatim — a pointer outside the workspace is
+        // allowed; nothing was written *through* it.
+        let dist = workspace.join("dist");
         assert!(
-            result.is_err(),
-            "a cache symlink escaping the workspace must be rejected"
+            dist.symlink_metadata().unwrap().file_type().is_symlink(),
+            "the symlink should be recreated, not rejected"
         );
-        assert!(
-            workspace.join("dist").symlink_metadata().is_err(),
-            "no symlink must be left in the workspace"
-        );
+        assert_eq!(dist.read_link().unwrap(), outside.path());
+
+        // The target's contents were NOT copied into the workspace as real files
+        // (the symlink was not followed): removing the link leaves nothing behind.
+        remove_path(&dist).unwrap();
+        assert!(!dist.join("secret.txt").exists());
         assert!(outside.child("secret.txt").exists());
     }
 

--- a/packages/nx/src/native/cache/http_remote_cache.rs
+++ b/packages/nx/src/native/cache/http_remote_cache.rs
@@ -183,9 +183,24 @@ impl HttpRemoteCache {
         cache_directory: String,
         hash: String,
     ) -> anyhow::Result<CachedResult> {
-        let content = response.bytes().await.unwrap();
+        let content = response
+            .bytes()
+            .await
+            .map_err(|e| anyhow::anyhow!("Failed to read remote cache response body: {}", e))?;
         trace!("Downloaded {} bytes from remote cache", content.len());
-        let tar = flate2::read::GzDecoder::new(content.as_ref());
+        Self::extract_tarball(content.as_ref(), &cache_directory, &hash)
+    }
+
+    /// Extract a gzipped cache tarball into `<cache_directory>/<hash>`.
+    ///
+    /// Uses `tar`'s `unpack_in` so a malicious cache server can't escape
+    /// `output_dir` via `..`, absolute paths, or symlinks.
+    fn extract_tarball(
+        content: &[u8],
+        cache_directory: &str,
+        hash: &str,
+    ) -> anyhow::Result<CachedResult> {
+        let tar = flate2::read::GzDecoder::new(content);
         let mut archive = Archive::new(tar);
         let entries = archive
             .entries() // Get the entries in the archive
@@ -195,7 +210,9 @@ impl HttpRemoteCache {
         let mut terminal_output: Option<String> = None;
         let mut size: i64 = 0;
 
-        let output_dir = Path::new(&cache_directory).join(&hash);
+        let output_dir = Path::new(cache_directory).join(hash);
+        // `unpack_in` canonicalizes `output_dir`, so it must exist beforehand.
+        fs::create_dir_all(&output_dir)?;
 
         // Extract the archive to the specified cache directory
         for entry in entries {
@@ -209,6 +226,11 @@ impl HttpRemoteCache {
 
             if entry_path == "code" {
                 let code_file_bytes = entry.bytes().collect::<Result<Vec<u8>, _>>()?;
+                // Guard the indexing below: a short/empty `code` entry from a
+                // malicious server must not panic (and crash the Node process).
+                if code_file_bytes.len() < 2 {
+                    return Err(anyhow::anyhow!("Invalid exit code in cache artifact"));
+                }
                 code = Some(i16::from_be_bytes([code_file_bytes[0], code_file_bytes[1]]));
                 trace!("Retrieved exit code from cache: {}", code.unwrap());
             } else if entry_path == "terminalOutput" {
@@ -223,29 +245,248 @@ impl HttpRemoteCache {
                     terminal_output_size
                 );
             } else {
-                let path_on_disk = output_dir.join(entry_path);
-                trace!("Extracting entry to {}", path_on_disk.display());
-                fs::create_dir_all(path_on_disk.parent().expect("This will have a parent, we just joined it above so there is at least one dir."))?;
-                // Ensure the directory exists before extracting
-                match entry.unpack(&path_on_disk) {
-                    Err(e) => {
-                        return Err(anyhow::anyhow!("Failed to unpack entry: {}", e));
-                    }
-                    Ok(f) => match f {
-                        tar::Unpacked::File(f) => size += f.metadata()?.len() as i64,
-                        _ => (),
-                    },
+                trace!(
+                    "Extracting entry {} into {}",
+                    entry_path,
+                    output_dir.display()
+                );
+                let is_file = entry.header().entry_type().is_file();
+                let entry_size = entry.size();
+                // Reject entries `unpack_in` skips (`..`) or refuses (symlink escape).
+                let unpacked = entry
+                    .unpack_in(&output_dir)
+                    .map_err(|e| anyhow::anyhow!("Failed to unpack entry: {}", e))?;
+                if !unpacked {
+                    return Err(anyhow::anyhow!(
+                        "Refusing to extract cache entry with unsafe path: {}",
+                        entry_path
+                    ));
+                }
+                if is_file {
+                    size += entry_size as i64;
                 }
             }
         }
 
         trace!("Extracted tarball to {}", output_dir.display());
 
+        let code = code.ok_or_else(|| anyhow::anyhow!("Exit code not found in cache artifact"))?;
         Ok(CachedResult {
             terminal_output,
-            code: code.expect("Exit code not found in cache"),
+            code,
             outputs_path: output_dir.to_string_lossy().into_owned(),
             size: Some(size),
         })
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use assert_fs::TempDir;
+    use flate2::Compression;
+    use flate2::write::GzEncoder;
+    use tar::{Builder, EntryType, Header};
+
+    /// Forge a tar entry, writing `name` straight into the header to bypass the
+    /// `tar` Builder's `..`/absolute-path validation, like a hostile server.
+    fn raw_entry(name: &str, ty: EntryType, link: Option<&str>, data: &[u8]) -> (Header, Vec<u8>) {
+        let mut header = Header::new_ustar();
+        header.set_size(data.len() as u64);
+        header.set_entry_type(ty);
+        header.set_mode(0o644);
+        header.set_mtime(0);
+        if let Some(target) = link {
+            header.set_link_name(target).unwrap();
+        }
+        let name_bytes = name.as_bytes();
+        header.as_mut_bytes()[..name_bytes.len()].copy_from_slice(name_bytes);
+        header.set_cksum();
+        (header, data.to_vec())
+    }
+
+    fn code_entry(code: u32) -> (Header, Vec<u8>) {
+        raw_entry("code", EntryType::Regular, None, &code.to_be_bytes())
+    }
+
+    fn terminal_output_entry(output: &str) -> (Header, Vec<u8>) {
+        raw_entry(
+            "terminalOutput",
+            EntryType::Regular,
+            None,
+            output.as_bytes(),
+        )
+    }
+
+    fn build_tar_gz(entries: Vec<(Header, Vec<u8>)>) -> Vec<u8> {
+        let mut builder = Builder::new(GzEncoder::new(Vec::new(), Compression::default()));
+        for (header, data) in &entries {
+            builder.append(header, data.as_slice()).unwrap();
+        }
+        builder.into_inner().unwrap().finish().unwrap()
+    }
+
+    #[test]
+    fn extract_rejects_parent_dir_traversal() {
+        let temp = TempDir::new().unwrap();
+        let cache_dir = temp.join("cache");
+        // `../../escape.txt` from <cache>/123 resolves to <temp>/escape.txt.
+        let tar = build_tar_gz(vec![raw_entry(
+            "../../escape.txt",
+            EntryType::Regular,
+            None,
+            b"PWNED",
+        )]);
+
+        let result = HttpRemoteCache::extract_tarball(&tar, cache_dir.to_str().unwrap(), "123");
+
+        assert!(result.is_err(), "a `..` entry must be rejected");
+        assert!(
+            !temp.join("escape.txt").exists(),
+            "extraction must not write outside the cache directory"
+        );
+    }
+
+    #[test]
+    fn extract_contains_absolute_paths() {
+        let temp = TempDir::new().unwrap();
+        let cache_dir = temp.join("cache");
+        let abs_target = temp.join("outside").join("pwned.txt");
+        let tar = build_tar_gz(vec![
+            raw_entry(
+                abs_target.to_str().unwrap(),
+                EntryType::Regular,
+                None,
+                b"PWNED",
+            ),
+            code_entry(0),
+            terminal_output_entry("done"),
+        ]);
+
+        let result = HttpRemoteCache::extract_tarball(&tar, cache_dir.to_str().unwrap(), "123");
+
+        // Absolute paths are stripped to relative, so extraction is contained, not rejected.
+        assert!(
+            result.is_ok(),
+            "absolute paths should be contained, not error: {:?}",
+            result.err()
+        );
+        assert!(
+            !abs_target.exists(),
+            "an absolute entry must not escape the cache directory"
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn extract_rejects_symlink_escape() {
+        let temp = TempDir::new().unwrap();
+        let cache_dir = temp.join("cache");
+        let outside = temp.join("outside");
+        std::fs::create_dir_all(&outside).unwrap();
+
+        // `evil` -> <temp>/outside, then `evil/pwned.txt` would escape if followed.
+        let tar = build_tar_gz(vec![
+            raw_entry(
+                "evil",
+                EntryType::Symlink,
+                Some(outside.to_str().unwrap()),
+                b"",
+            ),
+            raw_entry("evil/pwned.txt", EntryType::Regular, None, b"PWNED"),
+        ]);
+
+        let result = HttpRemoteCache::extract_tarball(&tar, cache_dir.to_str().unwrap(), "123");
+
+        assert!(
+            result.is_err(),
+            "writing through a symlink must be rejected"
+        );
+        assert!(
+            !outside.join("pwned.txt").exists(),
+            "extraction must not write through a symlink out of the cache directory"
+        );
+    }
+
+    #[test]
+    fn extract_unpacks_legitimate_tarball() {
+        let temp = TempDir::new().unwrap();
+        let cache_dir = temp.join("cache");
+        let tar = build_tar_gz(vec![
+            raw_entry("dist/main.js", EntryType::Regular, None, b"console.log(1)"),
+            code_entry(0),
+            terminal_output_entry("build complete"),
+        ]);
+
+        let result = HttpRemoteCache::extract_tarball(&tar, cache_dir.to_str().unwrap(), "123")
+            .expect("legitimate tarball should extract");
+
+        assert_eq!(result.code, 0);
+        assert_eq!(result.terminal_output.as_deref(), Some("build complete"));
+        let extracted = cache_dir.join("123").join("dist").join("main.js");
+        assert!(extracted.exists(), "expected extracted output file");
+        assert_eq!(
+            std::fs::read_to_string(&extracted).unwrap(),
+            "console.log(1)"
+        );
+        assert_eq!(
+            result.size,
+            Some(("build complete".len() + "console.log(1)".len()) as i64)
+        );
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn extract_rejects_hardlink_escape() {
+        let temp = TempDir::new().unwrap();
+        let cache_dir = temp.join("cache");
+        // A file outside the cache dir the hardlink entry tries to reach.
+        let outside = temp.join("outside.txt");
+        std::fs::write(&outside, b"secret").unwrap();
+
+        // A hard link entry whose target points outside output_dir.
+        let tar = build_tar_gz(vec![raw_entry(
+            "evil",
+            EntryType::Link,
+            Some(outside.to_str().unwrap()),
+            b"",
+        )]);
+
+        let result = HttpRemoteCache::extract_tarball(&tar, cache_dir.to_str().unwrap(), "123");
+
+        assert!(
+            result.is_err(),
+            "a hardlink escaping the cache dir must be rejected"
+        );
+    }
+
+    #[test]
+    fn extract_rejects_short_code_entry() {
+        // A 1-byte `code` entry must error, not panic on out-of-bounds indexing.
+        let temp = TempDir::new().unwrap();
+        let cache_dir = temp.join("cache");
+        let tar = build_tar_gz(vec![raw_entry("code", EntryType::Regular, None, b"\0")]);
+
+        let result = HttpRemoteCache::extract_tarball(&tar, cache_dir.to_str().unwrap(), "123");
+
+        assert!(
+            result.is_err(),
+            "a short code entry must be rejected, not panic"
+        );
+    }
+
+    #[test]
+    fn extract_rejects_missing_code_entry() {
+        // A tarball without a `code` entry must error, not panic via expect.
+        let temp = TempDir::new().unwrap();
+        let cache_dir = temp.join("cache");
+        let tar = build_tar_gz(vec![terminal_output_entry("done")]);
+
+        let result = HttpRemoteCache::extract_tarball(&tar, cache_dir.to_str().unwrap(), "123");
+
+        assert!(
+            result.is_err(),
+            "a missing code entry must be rejected, not panic"
+        );
     }
 }

--- a/packages/nx/src/native/cache/http_remote_cache.rs
+++ b/packages/nx/src/native/cache/http_remote_cache.rs
@@ -226,8 +226,7 @@ impl HttpRemoteCache {
 
             if entry_path == "code" {
                 let code_file_bytes = entry.bytes().collect::<Result<Vec<u8>, _>>()?;
-                // Guard the indexing below: a short/empty `code` entry from a
-                // malicious server must not panic (and crash the Node process).
+                // A short/empty `code` entry must not panic on the indexing below.
                 if code_file_bytes.len() < 2 {
                     return Err(anyhow::anyhow!("Invalid exit code in cache artifact"));
                 }
@@ -462,7 +461,6 @@ mod test {
 
     #[test]
     fn extract_rejects_short_code_entry() {
-        // A 1-byte `code` entry must error, not panic on out-of-bounds indexing.
         let temp = TempDir::new().unwrap();
         let cache_dir = temp.join("cache");
         let tar = build_tar_gz(vec![raw_entry("code", EntryType::Regular, None, b"\0")]);
@@ -477,7 +475,6 @@ mod test {
 
     #[test]
     fn extract_rejects_missing_code_entry() {
-        // A tarball without a `code` entry must error, not panic via expect.
         let temp = TempDir::new().unwrap();
         let cache_dir = temp.join("cache");
         let tar = build_tar_gz(vec![terminal_output_entry("done")]);

--- a/packages/nx/src/native/cache/http_remote_cache.rs
+++ b/packages/nx/src/native/cache/http_remote_cache.rs
@@ -221,8 +221,9 @@ impl HttpRemoteCache {
 
             let entry_path = entry
                 .path()
-                .map(|p| p.to_string_lossy().into_owned())
-                .unwrap();
+                .map_err(|e| anyhow::anyhow!("Invalid entry path in cache artifact: {}", e))?
+                .to_string_lossy()
+                .into_owned();
 
             if entry_path == "code" {
                 let code_file_bytes = entry.bytes().collect::<Result<Vec<u8>, _>>()?;

--- a/packages/nx/src/native/cache/http_remote_cache.rs
+++ b/packages/nx/src/native/cache/http_remote_cache.rs
@@ -227,11 +227,12 @@ impl HttpRemoteCache {
 
             if entry_path == "code" {
                 let code_file_bytes = entry.bytes().collect::<Result<Vec<u8>, _>>()?;
-                // A short/empty `code` entry must not panic on the indexing below.
-                if code_file_bytes.len() < 2 {
-                    return Err(anyhow::anyhow!("Invalid exit code in cache artifact"));
-                }
-                code = Some(i16::from_be_bytes([code_file_bytes[0], code_file_bytes[1]]));
+                // The exit code is stored as a 4-byte big-endian integer (see `store`).
+                let code_bytes: [u8; 4] = code_file_bytes
+                    .as_slice()
+                    .try_into()
+                    .map_err(|_| anyhow::anyhow!("Invalid exit code in cache artifact"))?;
+                code = Some(u32::from_be_bytes(code_bytes) as i16);
                 trace!("Retrieved exit code from cache: {}", code.unwrap());
             } else if entry_path == "terminalOutput" {
                 let terminal_output_bytes = entry.bytes().collect::<Result<Vec<u8>, _>>()?;
@@ -485,6 +486,23 @@ mod test {
         assert!(
             result.is_err(),
             "a missing code entry must be rejected, not panic"
+        );
+    }
+
+    #[test]
+    fn extract_reads_full_exit_code() {
+        let temp = TempDir::new().unwrap();
+        let cache_dir = temp.join("cache");
+        // The code is stored as a 4-byte big-endian int; the reader must consume
+        // all 4 bytes rather than truncating a nonzero code to 0.
+        let tar = build_tar_gz(vec![code_entry(1)]);
+
+        let result = HttpRemoteCache::extract_tarball(&tar, cache_dir.to_str().unwrap(), "123")
+            .expect("a valid code entry should extract");
+
+        assert_eq!(
+            result.code, 1,
+            "exit code must round-trip, not truncate to 0"
         );
     }
 }


### PR DESCRIPTION
## Current Behavior

The self-hosted HTTP remote cache extracts and restores artifacts without
containment:

- Extraction joins untrusted tar entry names onto the cache directory and unpacks
  them with tar's unguarded `Entry::unpack()`, which performs no boundary check.
- Restore copies the **entire** cache directory into the workspace and recreates
  entries while following symlinks, and clears prior outputs with a delete that
  follows symlinks.

A malicious — or on-path/MITM'd — `NX_SELF_HOSTED_REMOTE_CACHE_SERVER` can craft a
tarball whose entries (`../`, absolute paths, or symlinks/hardlinks) escape the
cache directory / workspace and write to arbitrary locations the Nx process can
reach. That arbitrary file write becomes RCE by targeting files like
`~/.ssh/authorized_keys`, a git hook, or `~/.zshrc`. Several malformed-input cases
also panic the process, and a remote-cached exit code is decoded from only the
first 2 of its 4 stored bytes (so a nonzero code can restore as `0`).

## Expected Behavior

- **Extraction is contained** via tar's `unpack_in`: `..` entries are rejected,
  absolute paths are stripped to relative, and writes *through* symlinks/hardlinks
  are refused — nothing escapes `<cacheDir>/<hash>`.
- **Restore copies only the declared task outputs** (never the whole cache dir),
  each confined to the workspace root. Parent directories are realized as real
  directories, so a write never traverses a symlink; symlinks are recreated
  verbatim (the pointer is allowed — writing *through* it is not); stale
  destinations are removed without following symlinks.
- **Declared outputs that resolve outside the workspace are rejected** with a clear
  error (both when storing and restoring).
- **Malformed artifacts error instead of panicking** — unreadable response body,
  short/missing exit-code entry, and non-UTF8 entry names (the last only surfaced
  on Windows).
- **The exit code is read from all 4 stored bytes**, fixing a nonzero code being
  restored as `0`.
- Adds extensive native tests: parent-dir traversal, absolute-path containment,
  symlink/hardlink write-through rejection, restore confined to declared outputs,
  symlink-not-followed / write-through-blocked, out-of-workspace output rejection,
  malformed/short/missing exit code, and exit-code round-trip.

## Related Issue(s)

NXC-4593 — self-hosted HTTP remote cache path traversal

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/lucid-sparrow-3e44e727)
<!-- polygraph-session-end -->