### PR TITLE
fix(misc): bump axios to 1.16.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -347,7 +347,7 @@
     "@types/license-checker": "^25.0.3",
     "@yarnpkg/lockfile": "^1.1.0",
     "@yarnpkg/parsers": "3.0.2",
-    "axios": "1.16.0",
+    "axios": "1.16.1",
     "classnames": "^2.5.1",
     "cliui": "^8.0.1",
     "clsx": "^2.0.0",

--- a/packages/create-nx-workspace/package.json
+++ b/packages/create-nx-workspace/package.json
@@ -37,7 +37,7 @@
   },
   "homepage": "https://nx.dev",
   "dependencies": {
-    "axios": "1.16.0",
+    "axios": "1.16.1",
     "chalk": "catalog:",
     "enquirer": "catalog:",
     "flat": "^5.0.2",

--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -54,7 +54,7 @@
     "@napi-rs/wasm-runtime": "0.2.4",
     "@yarnpkg/lockfile": "^1.1.0",
     "@zkochan/js-yaml": "catalog:",
-    "axios": "1.16.0",
+    "axios": "1.16.1",
     "picocolors": "catalog:",
     "cli-cursor": "3.1.0",
     "cli-spinners": "2.6.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -412,8 +412,8 @@ importers:
         specifier: 3.0.2
         version: 3.0.2
       axios:
-        specifier: 1.16.0
-        version: 1.16.0
+        specifier: 1.16.1
+        version: 1.16.1
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
@@ -2575,8 +2575,8 @@ importers:
   packages/create-nx-workspace:
     dependencies:
       axios:
-        specifier: 1.16.0
-        version: 1.16.0
+        specifier: 1.16.1
+        version: 1.16.1
       chalk:
         specifier: 'catalog:'
         version: 4.1.2
@@ -3379,8 +3379,8 @@ importers:
         specifier: 'catalog:'
         version: 0.0.7
       axios:
-        specifier: 1.16.0
-        version: 1.16.0
+        specifier: 1.16.1
+        version: 1.16.1
       cli-cursor:
         specifier: 3.1.0
         version: 3.1.0
@@ -15200,6 +15200,9 @@ packages:
 
   axios@1.16.0:
     resolution: {integrity: sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==}
+
+  axios@1.16.1:
+    resolution: {integrity: sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==}
 
   axobject-query@4.1.0:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
@@ -40571,6 +40574,16 @@ snapshots:
       proxy-from-env: 2.1.0
     transitivePeerDependencies:
       - debug
+
+  axios@1.16.1:
+    dependencies:
+      follow-redirects: 1.16.0(debug@4.4.3)
+      form-data: 4.0.6
+      https-proxy-agent: 5.0.1
+      proxy-from-env: 2.1.0
+    transitivePeerDependencies:
+      - debug
+      - supports-color
 
   axobject-query@4.1.0: {}
 


### PR DESCRIPTION
Claude Code web sessions require axios >= 1.16.1, and we're on 1.16.0. Because an egress proxy is used in web sessions, the existing axios will always fail when connecting to Nx Cloud.

Here is the full `README.md` of the proxy available in web sessions (I asked Claude to dump the full content to me):

```markdown
# Claude Code agent proxy

Outbound HTTPS from this session goes through a local proxy at http://127.0.0.1:36257
(set via HTTPS_PROXY) which tunnels to a policy-enforcing egress proxy. TLS is
re-terminated there, so every tool must trust the CA bundle at
/root/.ccr/ca-bundle.crt. The standard CA environment variables, the system trust
store (where possible), a JVM truststore, the Bazel system bazelrc, the
browser NSS store, and gsutil's boto config are already set up.

## Quick diagnosis

1. Run: curl -sS http://127.0.0.1:36257/__agentproxy/status
   It reports proxy state, which trust and git accommodations are active
   (javaTrustStorePath, toolTrustFailureCodes, gitSshRewrite,
   gitConfigConflicts), and the most recent proxy-side failures.
2. Find the failure class below and apply the matching fix; gitConfigConflicts
   codes map to the git section, toolTrustFailureCodes to the JVM section.
3. Never disable TLS verification, never unset HTTPS_PROXY, and do not retry
   organization policy denials (403/407) — report them instead.
```

With axios 1.16.0 the proxy fails with 405 Method Not Allowed, with 1.16.1 this was patched.