### PR TITLE
fix(nx-cloud): normalize nx-init source before persisting workspace

### DIFF
--- a/packages/nx/src/nx-cloud/generators/connect-to-nx-cloud/connect-to-nx-cloud.spec.ts
+++ b/packages/nx/src/nx-cloud/generators/connect-to-nx-cloud/connect-to-nx-cloud.spec.ts
@@ -1,0 +1,24 @@
+import { normalizeWorkspaceInstallationSource } from './connect-to-nx-cloud';
+
+describe('normalizeWorkspaceInstallationSource', () => {
+  it('should leave a plain nx-init source unchanged', () => {
+    expect(normalizeWorkspaceInstallationSource('nx-init')).toBe('nx-init');
+  });
+
+  it.each([
+    'nx-init-angular',
+    'nx-init-monorepo',
+    'nx-init-nest',
+    'nx-init-npm-repo',
+    'nx-init-turborepo',
+  ])('should collapse the %s flavor to nx-init', (source) => {
+    expect(normalizeWorkspaceInstallationSource(source)).toBe('nx-init');
+  });
+
+  it.each(['nx-connect', 'nx-console', 'user', 'vcs-repository', 'unknown'])(
+    'should leave the non-init source %s verbatim',
+    (source) => {
+      expect(normalizeWorkspaceInstallationSource(source)).toBe(source);
+    }
+  );
+});

--- a/packages/nx/src/nx-cloud/generators/connect-to-nx-cloud/connect-to-nx-cloud.ts
+++ b/packages/nx/src/nx-cloud/generators/connect-to-nx-cloud/connect-to-nx-cloud.ts
@@ -166,6 +166,20 @@ function addNxCloudIdToNxJson(
   }
 }
 
+/**
+ * Collapse `nx-init` flavors (e.g. `nx-init-angular`, `nx-init-npm-repo`) to
+ * `nx-init` before persisting the workspace's installationSource, so acquisition
+ * dashboards that filter on the exact `nx-init` source still count flavored
+ * inits. Every other source (e.g. `nx-connect`, `nx-console`) is left verbatim.
+ */
+export function normalizeWorkspaceInstallationSource(
+  installationSource: string
+): string {
+  return installationSource.startsWith('nx-init')
+    ? 'nx-init'
+    : installationSource;
+}
+
 export async function connectToNxCloud(
   tree: Tree,
   schema: ConnectToNxCloudOptions,
@@ -204,17 +218,21 @@ export async function connectToNxCloud(
   )
     return null;
 
+  const workspaceInstallationSource = normalizeWorkspaceInstallationSource(
+    schema.installationSource
+  );
+
   try {
     responseFromCreateNxCloudWorkspaceV2 = await createNxCloudWorkspaceV2(
       getRootPackageName(tree, schema.directory),
-      schema.installationSource,
+      workspaceInstallationSource,
       getNxInitDate()
     );
   } catch (e) {
     if (e.response?.status === 404) {
       responseFromCreateNxCloudWorkspaceV1 = await createNxCloudWorkspaceV1(
         getRootPackageName(tree, schema.directory),
-        schema.installationSource,
+        workspaceInstallationSource,
         getNxInitDate()
       );
     } else {


### PR DESCRIPTION
## Current Behavior

When a user says "yes" to Nx Cloud during `nx init`, the CLI creates the workspace doc inline and persists the raw `installationSource`. The flavored init sources (`nx-init-angular`, `nx-init-npm-repo`, `nx-init-monorepo`, ...) are stored verbatim, so acquisition dashboards that filter on the exact `nx-init` source miss them (mostly Angular inits).

The onboarding URL path already normalizes these via `getSource()`, but the workspace-create path does not - the two drifted.

## Expected Behavior

`nx-init*` flavors collapse to `nx-init` before the create POST, so the persisted workspace `installationSource` is countable by the exact `nx-init` dashboard filter. All other sources (`nx-connect`, `nx-console`, etc.) are left verbatim - only the `nx-init` family is collapsed.

Forward-only: existing workspace docs are unchanged.

## Related Issue(s)

N/A

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/info-init-discrepancies-0622c9be)
<!-- polygraph-session-end -->