### PR TITLE
feat(linter): add migration to drop typescript-eslint v8-removed rules from flat configs

### DIFF
--- a/packages/eslint/migrations.json
+++ b/packages/eslint/migrations.json
@@ -24,6 +24,22 @@
       "description": "Convert remaining ESLint configs to flat config for ESLint v9 and keep the workspace lint-passing, disabling rules whose preset defaults changed.",
       "implementation": "./dist/src/migrations/update-23-1-0/convert-to-flat-config",
       "prompt": "./dist/src/migrations/update-23-1-0/convert-to-flat-config.md"
+    },
+    "update-23-1-0-remove-removed-typescript-eslint-extension-rules": {
+      "version": "23.1.0-beta.5",
+      "requires": {
+        "typescript-eslint": ">=8.0.0"
+      },
+      "description": "Handle typescript-eslint rules removed in v8 in ESLint flat configs, since referencing a removed rule stops the config from loading. Deletes the removed formatting/extension rules (e.g. @typescript-eslint/no-extra-semi) and rewrites the safe 1:1 renames (no-throw-literal -> only-throw-error, no-useless-template-literals -> no-unnecessary-template-expression) to preserve enforcement.",
+      "implementation": "./dist/src/migrations/update-23-1-0/remove-removed-typescript-eslint-extension-rules"
+    },
+    "update-23-1-0-migrate-ban-types-rule": {
+      "version": "23.1.0-beta.5",
+      "requires": {
+        "typescript-eslint": ">=8.0.0"
+      },
+      "description": "Migrate the removed @typescript-eslint/ban-types rule to its v8 successors (no-empty-object-type, no-unsafe-function-type, no-wrapper-object-types), whose options do not map 1:1 - so it is driven by an AI prompt rather than a deterministic codemod.",
+      "prompt": "./dist/src/migrations/update-23-1-0/migrate-ban-types-rule.md"
     }
   },
   "packageJsonUpdates": {

--- a/packages/eslint/src/migrations/update-23-1-0/migrate-ban-types-rule.md
+++ b/packages/eslint/src/migrations/update-23-1-0/migrate-ban-types-rule.md
@@ -1,0 +1,15 @@
+# Migrate the removed `@typescript-eslint/ban-types` rule
+
+typescript-eslint v8 removed `@typescript-eslint/ban-types`, so an ESLint flat
+config that still references it fails to load. It was split into three rules:
+
+- `@typescript-eslint/no-empty-object-type` - the `{}` type
+- `@typescript-eslint/no-unsafe-function-type` - the `Function` type
+- `@typescript-eslint/no-wrapper-object-types` - wrapper types (`String`, `Number`, `Boolean`, `Object`, ...)
+
+In every ESLint flat config (`eslint.config.{mjs,cjs,js,cts,ts,mts}`) that sets
+`@typescript-eslint/ban-types`, replace that single entry with the three rules
+above. The options do not map 1:1: if the old entry was just `'error'`/`'warn'`,
+set all three to that level; if it customized `types`/`extendDefaults`, translate
+the intent to whichever successor rule covers each banned type and drop anything
+with no equivalent. Then run `nx run-many -t lint` and confirm the configs load.

--- a/packages/eslint/src/migrations/update-23-1-0/remove-removed-typescript-eslint-extension-rules.spec.ts
+++ b/packages/eslint/src/migrations/update-23-1-0/remove-removed-typescript-eslint-extension-rules.spec.ts
@@ -1,0 +1,85 @@
+import 'nx/src/internal-testing-utils/mock-project-graph';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { type Tree } from '@nx/devkit';
+import update from './remove-removed-typescript-eslint-extension-rules';
+
+describe('remove-removed-typescript-eslint-extension-rules migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('deletes removed formatting rules, renames safe semantic rules, and leaves ban-types for the prompt migration', async () => {
+    tree.write(
+      'eslint.config.mjs',
+      `export default [
+  {
+    files: ['**/*.ts'],
+    rules: {
+      '@typescript-eslint/no-unused-vars': 'warn',
+      '@typescript-eslint/no-extra-semi': 'error',
+      'no-extra-semi': 'off',
+      '@typescript-eslint/quotes': ['error', 'single'],
+      '@typescript-eslint/ban-types': 'error',
+      '@typescript-eslint/no-throw-literal': 'warn',
+      '@typescript-eslint/no-useless-template-literals': 'error',
+    },
+  },
+];
+`
+    );
+
+    await update(tree);
+
+    const result = tree.read('eslint.config.mjs', 'utf-8');
+    // removed formatting rules are deleted
+    expect(result).not.toContain('@typescript-eslint/no-extra-semi');
+    expect(result).not.toContain('@typescript-eslint/quotes');
+    // safe 1:1 renames are rewritten to their successors, preserving the value
+    expect(result).not.toContain('@typescript-eslint/no-throw-literal');
+    expect(result).toContain("'@typescript-eslint/only-throw-error': 'warn'");
+    expect(result).not.toContain(
+      '@typescript-eslint/no-useless-template-literals'
+    );
+    expect(result).toContain(
+      "'@typescript-eslint/no-unnecessary-template-expression': 'error'"
+    );
+    // ban-types is left untouched - the companion prompt migration handles it
+    expect(result).toContain("'@typescript-eslint/ban-types': 'error'");
+    // unrelated typescript-eslint rules and the base rule are preserved
+    expect(result).toContain('@typescript-eslint/no-unused-vars');
+    expect(result).toContain('no-extra-semi');
+  });
+
+  it('leaves a config without affected rules untouched', async () => {
+    tree.write(
+      'eslint.config.mjs',
+      `export default [
+  { rules: { '@typescript-eslint/no-explicit-any': 'off' } },
+];
+`
+    );
+    const before = tree.read('eslint.config.mjs', 'utf-8');
+
+    await update(tree);
+
+    expect(tree.read('eslint.config.mjs', 'utf-8')).toEqual(before);
+  });
+
+  it('handles per-project flat configs', async () => {
+    tree.write(
+      'apps/app/eslint.config.mjs',
+      `export default [
+  { rules: { '@typescript-eslint/semi': 'error' } },
+];
+`
+    );
+
+    await update(tree);
+
+    expect(tree.read('apps/app/eslint.config.mjs', 'utf-8')).not.toContain(
+      '@typescript-eslint/semi'
+    );
+  });
+});

--- a/packages/eslint/src/migrations/update-23-1-0/remove-removed-typescript-eslint-extension-rules.ts
+++ b/packages/eslint/src/migrations/update-23-1-0/remove-removed-typescript-eslint-extension-rules.ts
@@ -1,0 +1,142 @@
+import { formatFiles, type Tree, visitNotIgnoredFiles } from '@nx/devkit';
+import * as ts from 'typescript';
+
+// Inlined rather than imported from the @nx/eslint utils so this migration stays
+// self-contained - a migration should not depend on a shared list that can change
+// in a later version.
+const ESLINT_FLAT_CONFIG_FILENAMES = [
+  'eslint.config.cjs',
+  'eslint.config.js',
+  'eslint.config.mjs',
+  'eslint.config.cts',
+  'eslint.config.ts',
+  'eslint.config.mts',
+];
+
+// Formatting/extension rules typescript-eslint removed in v8 (moved to
+// @stylistic). A flat config that still references one fails to load: "Could not
+// find <rule> in plugin @typescript-eslint".
+//
+// These are DELETED, not rewritten to the base ESLint rule (e.g.
+// `@typescript-eslint/no-extra-semi` -> `no-extra-semi`), on purpose: the base
+// equivalents are themselves deprecated and frozen in ESLint 9 (slated for
+// removal), so resurrecting one just defers the same break to the next ESLint
+// major. And Prettier - which nx workspaces run - already enforces this
+// formatting, so the rules were redundant. The long-term home is @stylistic,
+// which we will not auto-add as a dependency.
+const REMOVED_TS_ESLINT_RULES = new Set(
+  [
+    'block-spacing',
+    'brace-style',
+    'comma-dangle',
+    'comma-spacing',
+    'func-call-spacing',
+    'indent',
+    'key-spacing',
+    'keyword-spacing',
+    'lines-around-comment',
+    'lines-between-class-members',
+    'member-delimiter-style',
+    'no-extra-parens',
+    'no-extra-semi',
+    'object-curly-spacing',
+    'padding-line-between-statements',
+    'quotes',
+    'semi',
+    'space-before-blocks',
+    'space-before-function-paren',
+    'space-infix-ops',
+    'type-annotation-spacing',
+  ].map((rule) => `@typescript-eslint/${rule}`)
+);
+
+// Semantic rules typescript-eslint renamed 1:1 in v8. Unlike the formatting
+// rules these enforce real behavior, so we rewrite the key to the successor to
+// preserve enforcement rather than drop it.
+//
+// `ban-types` is intentionally NOT here: it split into three rules
+// (no-empty-object-type, no-unsafe-function-type, no-wrapper-object-types) whose
+// options do not map cleanly, so it is handled by the companion prompt-based
+// migration instead.
+const RENAMED_TS_ESLINT_RULES = new Map([
+  [
+    '@typescript-eslint/no-throw-literal',
+    '@typescript-eslint/only-throw-error',
+  ],
+  [
+    '@typescript-eslint/no-useless-template-literals',
+    '@typescript-eslint/no-unnecessary-template-expression',
+  ],
+]);
+
+export default async function update(tree: Tree): Promise<void> {
+  let changed = false;
+
+  visitNotIgnoredFiles(tree, '.', (path) => {
+    const fileName = path.split('/').pop();
+    if (!ESLINT_FLAT_CONFIG_FILENAMES.includes(fileName)) {
+      return;
+    }
+    const content = tree.read(path, 'utf-8');
+    if (!content?.includes('@typescript-eslint/')) {
+      return;
+    }
+
+    const source = ts.createSourceFile(
+      path,
+      content,
+      ts.ScriptTarget.Latest,
+      true,
+      ts.ScriptKind.JS
+    );
+
+    // {start, end, newText} edits, applied high offset -> low so earlier offsets
+    // stay valid. Covers both deletes (newText '') and key rewrites uniformly.
+    const edits: { start: number; end: number; newText: string }[] = [];
+    const visit = (node: ts.Node): void => {
+      if (
+        ts.isPropertyAssignment(node) &&
+        (ts.isStringLiteral(node.name) ||
+          ts.isNoSubstitutionTemplateLiteral(node.name))
+      ) {
+        const ruleName = node.name.text;
+        if (REMOVED_TS_ESLINT_RULES.has(ruleName)) {
+          // Remove the whole rule entry, including its leading whitespace and the
+          // trailing comma, so the surrounding rules object stays valid.
+          let end = node.end;
+          const trailingComma = content.slice(end).match(/^\s*,/);
+          if (trailingComma) {
+            end += trailingComma[0].length;
+          }
+          edits.push({ start: node.getFullStart(), end, newText: '' });
+        } else if (RENAMED_TS_ESLINT_RULES.has(ruleName)) {
+          // Rewrite only the key, preserving the existing quote style and value.
+          const keyStart = node.name.getStart(source);
+          const quote = content[keyStart];
+          edits.push({
+            start: keyStart,
+            end: node.name.getEnd(),
+            newText: `${quote}${RENAMED_TS_ESLINT_RULES.get(ruleName)}${quote}`,
+          });
+        }
+      }
+      ts.forEachChild(node, visit);
+    };
+    visit(source);
+
+    if (edits.length) {
+      edits.sort((a, b) => b.start - a.start);
+      let updated = content;
+      for (const edit of edits) {
+        updated =
+          updated.slice(0, edit.start) + edit.newText + updated.slice(edit.end);
+      }
+      tree.write(path, updated);
+      changed = true;
+    }
+  });
+
+  if (changed) {
+    await formatFiles(tree);
+  }
+}


### PR DESCRIPTION
## Current Behavior

The `@nx/eslint:convert-to-flat-config` migration copies eslintrc rules verbatim into flat config, but the 23.1 typescript-eslint v8 bump removed the formatting/extension rules (moved to `@stylistic`). A flat config that still references one - e.g. `@typescript-eslint/no-extra-semi` - fails to load:

```
Key "@typescript-eslint/no-extra-semi": Could not find "no-extra-semi" in plugin "@typescript-eslint".
```

which breaks the project graph (surfaced by nx-console's beta.4 migration).

## Expected Behavior

Adds `update-23-1-0-remove-removed-typescript-eslint-extension-rules` - an AST codemod that deletes the v8-removed typescript-eslint extension rules from every flat config (`eslint.config.{mjs,cjs,js}`). Gated on `typescript-eslint >=8.0.0` (the rules are removed in v8 and stay removed, so no upper bound).

## Related Issue(s)

Fixes NXC-4595

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/nx-23.1.0-beta.0-Migration-24e91166)
<!-- polygraph-session-end -->