### PR TITLE
fix(js): add migration to keep node types on ts-node configs under typescript 6

### DIFF
--- a/packages/js/migrations.json
+++ b/packages/js/migrations.json
@@ -37,6 +37,14 @@
       },
       "factory": "./dist/src/migrations/update-23-1-0/add-ignore-deprecations-for-ts6",
       "documentation": "./dist/src/migrations/update-23-1-0/add-ignore-deprecations-for-ts6.md"
+    },
+    "23-1-0-add-node-types-to-ts-node-config": {
+      "version": "23.1.0-beta.5",
+      "description": "Adds `\"types\": [\"node\"]` to `ts-node.compilerOptions` blocks using node/node10/classic resolution and lacking a `types` field, so ts-node keeps resolving node globals (e.g. `module` in jest.config.ts) on TypeScript 6, where those resolutions no longer auto-load @types/node.",
+      "requires": {
+        "typescript": ">=6.0.0"
+      },
+      "factory": "./dist/src/migrations/update-23-1-0/add-node-types-to-ts-node-config"
     }
   },
   "packageJsonUpdates": {

--- a/packages/js/src/migrations/update-23-1-0/add-node-types-to-ts-node-config.spec.ts
+++ b/packages/js/src/migrations/update-23-1-0/add-node-types-to-ts-node-config.spec.ts
@@ -1,0 +1,68 @@
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { readJson, type Tree, writeJson } from '@nx/devkit';
+import update from './add-node-types-to-ts-node-config';
+
+describe('add-node-types-to-ts-node-config migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('adds types: ["node"] to a ts-node block using node10 without types', async () => {
+    writeJson(tree, 'tsconfig.json', {
+      compilerOptions: { module: 'NodeNext', moduleResolution: 'NodeNext' },
+      'ts-node': {
+        compilerOptions: { module: 'commonjs', moduleResolution: 'node10' },
+      },
+    });
+
+    await update(tree);
+
+    const json = readJson(tree, 'tsconfig.json');
+    expect(json['ts-node'].compilerOptions.types).toEqual(['node']);
+    // the main compilerOptions must stay untouched
+    expect(json.compilerOptions.types).toBeUndefined();
+  });
+
+  it('leaves a ts-node block that already declares types', async () => {
+    writeJson(tree, 'tsconfig.json', {
+      'ts-node': {
+        compilerOptions: {
+          moduleResolution: 'node10',
+          types: ['node', 'jest'],
+        },
+      },
+    });
+
+    await update(tree);
+
+    expect(
+      readJson(tree, 'tsconfig.json')['ts-node'].compilerOptions.types
+    ).toEqual(['node', 'jest']);
+  });
+
+  it('ignores ts-node blocks not using a node-style resolution', async () => {
+    writeJson(tree, 'tsconfig.json', {
+      'ts-node': { compilerOptions: { moduleResolution: 'bundler' } },
+    });
+
+    await update(tree);
+
+    expect(
+      readJson(tree, 'tsconfig.json')['ts-node'].compilerOptions.types
+    ).toBeUndefined();
+  });
+
+  it('does not touch tsconfigs without a ts-node block', async () => {
+    writeJson(tree, 'tsconfig.json', {
+      compilerOptions: { moduleResolution: 'node10' },
+    });
+
+    await update(tree);
+
+    expect(
+      readJson(tree, 'tsconfig.json').compilerOptions.types
+    ).toBeUndefined();
+  });
+});

--- a/packages/js/src/migrations/update-23-1-0/add-node-types-to-ts-node-config.ts
+++ b/packages/js/src/migrations/update-23-1-0/add-node-types-to-ts-node-config.ts
@@ -1,0 +1,93 @@
+import {
+  formatFiles,
+  logger,
+  type Tree,
+  visitNotIgnoredFiles,
+} from '@nx/devkit';
+import { basename } from 'node:path';
+import {
+  applyEdits,
+  findNodeAtLocation,
+  getNodeValue,
+  modify,
+  parseTree,
+} from 'jsonc-parser';
+
+const FORMATTING_OPTIONS = {
+  formattingOptions: { keepLines: true, insertSpaces: true, tabSize: 2 },
+};
+
+type CompilerOptions = Record<string, unknown>;
+
+/**
+ * `add-ignore-deprecations-for-ts6` keeps `ts-node.compilerOptions` on
+ * `moduleResolution: node10`, but under TS6 `node`/`node10`/`classic` no longer
+ * auto-load `@types/node` the way TS 5.x did. ts-node compiles `jest.config.ts`
+ * (which uses `module.exports`) with that block, so the `module` global
+ * disappears - `jest.config.ts(2,1): TS2591: Cannot find name 'module'`.
+ *
+ * Add an explicit `"types": ["node"]` so node globals stay resolvable. Scoped to
+ * the `ts-node` block only: the main `compilerOptions` drives the whole
+ * project's type-checking, so pinning its `types` there would wrongly narrow it.
+ * Gated to TS6 by `requires` in migrations.json.
+ */
+export default async function (tree: Tree) {
+  let count = 0;
+  visitNotIgnoredFiles(tree, '.', (filePath) => {
+    const name = basename(filePath);
+    if (!name.startsWith('tsconfig') || !name.endsWith('.json')) {
+      return;
+    }
+    if (addNodeTypesToTsNodeBlock(tree, filePath)) {
+      count += 1;
+    }
+  });
+
+  if (count > 0) {
+    logger.info(
+      `Added "types": ["node"] to the ts-node compilerOptions of ${count} tsconfig file(s) so jest configs keep resolving node globals on TypeScript 6.`
+    );
+  }
+
+  await formatFiles(tree);
+}
+
+function addNodeTypesToTsNodeBlock(tree: Tree, tsconfigPath: string): boolean {
+  const original = tree.read(tsconfigPath, 'utf-8');
+  if (!original) {
+    return false;
+  }
+
+  const root = parseTree(original);
+  const blockNode =
+    root && findNodeAtLocation(root, ['ts-node', 'compilerOptions']);
+  if (!blockNode || blockNode.type !== 'object') {
+    return false;
+  }
+
+  const compilerOptions = getNodeValue(blockNode) as CompilerOptions;
+  // Only node-style resolutions lose @types/node auto-discovery on TS6.
+  const moduleResolution = String(
+    compilerOptions.moduleResolution ?? ''
+  ).toLowerCase();
+  if (
+    moduleResolution !== 'node' &&
+    moduleResolution !== 'node10' &&
+    moduleResolution !== 'classic'
+  ) {
+    return false;
+  }
+  // An explicit `types` (even `[]`) is the user's choice - leave it.
+  if (compilerOptions.types !== undefined) {
+    return false;
+  }
+
+  const edits = modify(
+    original,
+    ['ts-node', 'compilerOptions', 'types'],
+    ['node'],
+    FORMATTING_OPTIONS
+  );
+  tree.write(tsconfigPath, applyEdits(original, edits));
+  return true;
+}


### PR DESCRIPTION
## Current Behavior

The `add-ignore-deprecations-for-ts6` migration keeps `ts-node.compilerOptions` on `moduleResolution: node10`, but under TypeScript 6 the `node`/`node10`/`classic` resolutions no longer auto-load `@types/node` the way 5.x did. ts-node compiles `jest.config.ts` (which uses `module.exports`) with that block, so the `module` global disappears:

```
jest.config.ts(2,1): error TS2591: Cannot find name 'module'.
```

(Surfaced by nx-console's `nxls-e2e` after migrating to 23.1.)

## Expected Behavior

Adds `23-1-0-add-node-types-to-ts-node-config` - a deterministic generator that adds `"types": ["node"]` to `ts-node.compilerOptions` blocks using a node-style resolution and lacking a `types` field. Only reads `tsconfig*.json` (no source walk), gated `typescript >=6.0.0`, and scoped to the `ts-node` block (pinning `types` on the main `compilerOptions` would wrongly narrow the whole project).

## Related Issue(s)

Fixes NXC-4596

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/nx-23.1.0-beta.0-Migration-24e91166)
<!-- polygraph-session-end -->