### PR TITLE
fix(vite): detect @vitejs/plugin-vue2 (vite:vue2) for vue-tsc typecheck

### DIFF
--- a/packages/vite/src/plugins/plugin.ts
+++ b/packages/vite/src/plugins/plugin.ts
@@ -288,7 +288,7 @@ async function buildViteTargets(
 
     // Check if the project uses Vue plugin
     const hasVuePlugin = viteBuildConfig.plugins?.some(
-      (p) => p.name === 'vite:vue'
+      (p) => p.name === 'vite:vue' || p.name === 'vite:vue2'
     );
     // Explicit `compiler` option wins over inference so users can override
     // when their setup isn't detected (e.g. custom/non-standard Vue plugin).


### PR DESCRIPTION
## Current Behavior

The inferred typecheck target only treats a project as a Vue project when the Vite config registers a plugin named `vite:vue`. Projects using `@vitejs/plugin-vue2` register the plugin as `vite:vue2`, which was not matched, so Vue 2.7 projects fell back to plain `tsc`. `tsc` cannot type check `.vue` files, so the typecheck target was effectively broken for those projects.

## Expected Behavior

The Vue plugin detection also matches `vite:vue2`, so projects using `@vitejs/plugin-vue2` are correctly inferred as Vue projects and use `vue-tsc` for typechecking.

## Related Issue(s)

Fixes #36094 
