### PR TITLE
fix(angular): bump prescribed angular version to 22.0.4

### DIFF
--- a/packages/angular/src/utils/versions.ts
+++ b/packages/angular/src/utils/versions.ts
@@ -2,8 +2,8 @@ import { join } from 'path';
 
 export const nxVersion = require(join('@nx/angular', 'package.json')).version;
 
-export const angularVersion = '~22.0.0';
-export const angularDevkitVersion = '~22.0.0';
+export const angularVersion = '~22.0.4';
+export const angularDevkitVersion = '~22.0.4';
 export const ngPackagrVersion = '~22.0.0';
 export const ngrxVersion = '^21.0.0';
 export const rxjsVersion = '~7.8.0';


### PR DESCRIPTION
## Current Behavior

nx prescribes Angular `~22.0.0` for new workspaces, which allows landing on 22.0.0-22.0.3 where Angular's `change-detection-eager` ng-update codemod crashes on nested projects (`Path "app/app.component.ts" does not exist`).

## Expected Behavior

Bump `angularVersion` and `angularDevkitVersion` to `~22.0.4` - the patched release that fixes the codemod. `ngPackagrVersion` stays `~22.0.0` (no 22.0.4 is published).

## Related Issue(s)

NXC-4574

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/nx-23.1.0-beta.0-Migration-24e91166)
<!-- polygraph-session-end -->