### PR TITLE
fix(core): respect explicit --nxCloud=skip for AI agents in create-nx-workspace

### DIFF
--- a/packages/create-nx-workspace/bin/create-nx-workspace.ts
+++ b/packages/create-nx-workspace/bin/create-nx-workspace.ts
@@ -608,10 +608,6 @@ async function normalizeArgsMiddleware(
         );
       }
 
-      // Always enable Nx Cloud for AI agents - ignore --nxCloud=skip since the AI
-      // may pass it without asking the user. Nx Cloud is required for the full experience.
-      argv.nxCloud = 'yes';
-
       // Skip GitHub push prompts in AI mode - we'll provide instructions in the success output
       argv.skipGitHubPush = true;
     } else {


### PR DESCRIPTION

## Current Behavior
AI agent mode forces nxCloud to 'yes', ignoring an explicit --nxCloud=skip/never.

## Expected Behavior
Honor an explicitly-passed --nxCloud value; only default to 'yes' when none is passed.


---

Polygraph session: https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/cwn-skip-normalization-a4081532
