### PR TITLE
fix(core): warn when the self-hosted remote cache disables TLS verification (NXC-4593)

### DIFF
--- a/packages/nx/src/tasks-runner/cache.ts
+++ b/packages/nx/src/tasks-runner/cache.ts
@@ -340,6 +340,14 @@ export class DbCache {
         );
         return null;
       }
+      // The cache request runs in Rust (reqwest), which honors
+      // NODE_TLS_REJECT_UNAUTHORIZED but bypasses Node's TLS stack, so Node's own
+      // insecure-TLS warning never fires for it. Re-emit Node's warning here.
+      if (process.env.NODE_TLS_REJECT_UNAUTHORIZED === '0') {
+        process.emitWarning(
+          "Setting the NODE_TLS_REJECT_UNAUTHORIZED environment variable to '0' makes TLS connections and HTTPS requests insecure by disabling certificate verification."
+        );
+      }
       return new HttpRemoteCache();
     }
     return null;


### PR DESCRIPTION
## Current Behavior

The self-hosted HTTP remote cache (`NX_SELF_HOSTED_REMOTE_CACHE_SERVER`) makes its request from Rust (`reqwest`). It honors `NODE_TLS_REJECT_UNAUTHORIZED=0` by disabling TLS certificate verification — but because the request bypasses Node's TLS stack, **Node's built-in insecure-TLS warning never fires**, so the user is silently downgraded to unverified TLS with no indication.

## Expected Behavior

When `NODE_TLS_REJECT_UNAUTHORIZED=0` is set and the self-hosted HTTP remote cache is in use, Nx re-emits Node's standard warning via `process.emitWarning`:

> Setting the NODE_TLS_REJECT_UNAUTHORIZED environment variable to '0' makes TLS connections and HTTPS requests insecure by disabling certificate verification.

This goes through Node's own warning machinery (so it respects `--no-warnings`, `NODE_NO_WARNINGS`, `--trace-warnings`, and de-duplication), surfacing the insecure configuration instead of leaving it silent.

## Related Issue(s)

Follow-up TLS hardening for the self-hosted remote cache, alongside the path-traversal fix in #36116 (NXC-4593).

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/lucid-sparrow-3e44e727)
<!-- polygraph-session-end -->