### PR TITLE
fix(rspack): use contenthash for chunkFilename to prevent stale chunks

### DIFF
--- a/packages/rspack/src/plugins/utils/hash-format.spec.ts
+++ b/packages/rspack/src/plugins/utils/hash-format.spec.ts
@@ -1,0 +1,19 @@
+import { getOutputHashFormat } from './hash-format';
+
+describe('getOutputHashFormat', () => {
+  it.each(['all', 'bundles'])(
+    "should hash chunks with [contenthash] (not [chunkhash]) for outputHashing '%s'",
+    (option) => {
+      const format = getOutputHashFormat(option);
+
+      // chunk filenames must match the entry `filename` hash: [contenthash]
+      // reflects module ids, [chunkhash] does not, leaving chunks stale (nx#36014).
+      expect(format.chunk).toBe('.[contenthash:16]');
+      expect(format.chunk).toBe(format.script);
+    }
+  );
+
+  it("should not hash chunks for outputHashing 'none'", () => {
+    expect(getOutputHashFormat('none').chunk).toBe('');
+  });
+});

--- a/packages/rspack/src/plugins/utils/hash-format.ts
+++ b/packages/rspack/src/plugins/utils/hash-format.ts
@@ -23,13 +23,15 @@ export function getOutputHashFormat(
     none: { chunk: '', extract: '', file: '', script: '' },
     media: { chunk: '', extract: '', file: `.[hash:${length}]`, script: '' },
     bundles: {
-      chunk: `.[chunkhash:${length}]`,
+      // [contenthash] is rspack's recommended hash for caching, matching the entry
+      // `filename`; [chunkhash] omits module ids and can serve stale chunks (nx#36014).
+      chunk: `.[contenthash:${length}]`,
       extract: `.[contenthash:${length}]`,
       file: '',
       script: `.[contenthash:${length}]`,
     },
     all: {
-      chunk: `.[chunkhash:${length}]`,
+      chunk: `.[contenthash:${length}]`,
       extract: `.[contenthash:${length}]`,
       file: `.[contenthash:${length}]`,
       script: `.[contenthash:${length}]`,


### PR DESCRIPTION
## Current Behavior

`NxAppRspackPlugin` maps `outputHashing: 'all'` (the default) to two different hash placeholders: `output.filename` uses `[contenthash]`, but `output.chunkFilename` uses `[chunkhash]`. rspack's `[chunkhash]` hashes a chunk's module bodies but not each contained module's assigned id. With the production default `optimization.moduleIds: 'deterministic'`, a module's id can be renumbered by an unrelated change to the module graph, which changes a chunk's emitted bytes without changing its `[chunkhash]` filename. Long-term-cached clients then keep the old chunk against a freshly built entry that references the new id and crash with `Uncaught TypeError: Cannot read properties of null (reading 'call')`. `optimization.realContentHash` does not mitigate this, since it only re-hashes `[contenthash]`.

## Expected Behavior

`output.chunkFilename` uses `[contenthash]`, matching `output.filename`, so a chunk's filename always changes when its emitted content does. This is rspack's recommended hash for long-term caching and matches the defaults of Angular CLI, create-react-app, and Vue CLI.

## Implementation Details

`getOutputHashFormat` in `packages/rspack/src/plugins/utils/hash-format.ts` now uses `[contenthash]` for `chunk` in both the `bundles` and `all` options. Confirmed against rspack source: `[contenthash]` folds the module id into the hash (web-infra-dev/rspack#2292, released in v0.1.2, below the `@rspack/core ^1 || ^2` support floor) while `[chunkhash]` does not.

`@nx/webpack` carries the same `[chunkhash]` default but was deliberately left unchanged: webpack's `[chunkhash]` already folds module ids into the chunk hash (via `getModuleHash`), so it does not exhibit this stale-chunk problem.

## Related Issue(s)

Fixes #36014

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/gh-36014-54fdd58d)
<!-- polygraph-session-end -->