### PR TITLE
fix(js): scope incremental type-check .tsbuildinfo per project

### DIFF
--- a/packages/esbuild/src/executors/esbuild/esbuild.impl.ts
+++ b/packages/esbuild/src/executors/esbuild/esbuild.impl.ts
@@ -254,7 +254,10 @@ function getTypeCheckOptions(
 
   if (watch) {
     typeCheckOptions.incremental = true;
-    typeCheckOptions.cacheDir = cacheDir;
+    // Scope the incremental .tsbuildinfo per project (in its own subdir, not
+    // alongside Nx's cache files) so concurrent serves don't collide on a
+    // single file.
+    typeCheckOptions.cacheDir = join(cacheDir, 'esbuild', projectRoot);
   }
 
   if (options.isTsSolutionSetup && options.skipTypeCheck) {

--- a/packages/js/src/utils/swc/compile-swc.ts
+++ b/packages/js/src/utils/swc/compile-swc.ts
@@ -59,7 +59,10 @@ function getTypeCheckOptions(normalizedOptions: NormalizedSwcExecutorOptions) {
 
   if (watch) {
     typeCheckOptions.incremental = true;
-    typeCheckOptions.cacheDir = cacheDir;
+    // Scope the incremental .tsbuildinfo per project (in its own subdir, not
+    // alongside Nx's cache files) so concurrent watch type-checks don't collide
+    // on a single file.
+    typeCheckOptions.cacheDir = join(cacheDir, 'swc', projectRoot);
   }
 
   if (normalizedOptions.isTsSolutionSetup && normalizedOptions.skipTypeCheck) {

--- a/packages/js/src/utils/typescript/run-type-check.spec.ts
+++ b/packages/js/src/utils/typescript/run-type-check.spec.ts
@@ -1,4 +1,10 @@
-import { mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { runTypeCheck } from './run-type-check';
@@ -54,6 +60,33 @@ describe('runTypeCheck', () => {
     });
 
     expect(result.errors).toHaveLength(2);
+  });
+
+  it('should write the incremental .tsbuildinfo into the provided cache dir, creating nested paths', async () => {
+    // Callers (e.g. the esbuild executor) pass a per-project cache dir so
+    // concurrent type checks don't collide on a single .tsbuildinfo. The util
+    // must honor that path even when its parent dirs don't exist yet.
+    const cacheDir = join(
+      workspaceRoot,
+      '.nx',
+      'cache',
+      'esbuild',
+      'apps/app1'
+    );
+    writeFileSync(
+      join(projectRoot, 'valid-source.ts'),
+      `export const msg = 'Hello';`
+    );
+
+    await runTypeCheck({
+      workspaceRoot,
+      tsConfigPath,
+      mode: 'noEmit',
+      incremental: true,
+      cacheDir,
+    });
+
+    expect(existsSync(join(cacheDir, '.tsbuildinfo'))).toBe(true);
   });
 
   it('should support emitting declarations', async () => {

--- a/packages/js/src/utils/typescript/run-type-check.ts
+++ b/packages/js/src/utils/typescript/run-type-check.ts
@@ -96,6 +96,10 @@ export async function runTypeCheck(
       options: {
         ...compilerOptions,
         incremental: true,
+        // Set after the spread so it overrides any user-set tsBuildInfoFile.
+        // This is a dedicated type-check program with Nx-injected options that
+        // differ from the real build, so its build info must not share a file
+        // with the build, or it corrupts the build's incremental cache.
         tsBuildInfoFile: path.join(cacheDir, '.tsbuildinfo'),
       },
     });


### PR DESCRIPTION
## Current Behavior

Serving two applications with the esbuild executor in watch mode (and likewise two swc watch builds) made both type-check passes write their incremental build info to a single `<workspaceRoot>/.nx/cache/.tsbuildinfo`. The concurrent incremental programs overwrote each other's state, so type checking thrashed and could report stale or incorrect results.

## Expected Behavior

The incremental type-check build info is scoped per executor and project (`<cache>/<esbuild|swc>/<projectRoot>/.tsbuildinfo`), so concurrent serves and watch builds no longer collide on a single file.

## Implementation Details

`runTypeCheck` runs a dedicated type-check program whose compiler options differ from the real build, so it intentionally overrides any user-set `tsBuildInfoFile` to keep its build info out of the build's own incremental cache. The per-project scoping is applied where each executor builds the cache dir it passes in, leaving the shared util generic.

## Related Issue(s)

Fixes #36113

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/gh-36113-3e75fc00)
<!-- polygraph-session-end -->