### PR TITLE
fix(js): prevent doubled output paths in buildable library path mappings

### DIFF
--- a/packages/js/src/utils/buildable-libs-utils.spec.ts
+++ b/packages/js/src/utils/buildable-libs-utils.spec.ts
@@ -46,6 +46,33 @@ describe('updatePaths', () => {
     });
   });
 
+  it('should not double the output when the root is a substring of the output and the mapping points to the output', () => {
+    // Repro for #36079: project root `base` is a substring of the output
+    // `dist/libs/base`, and the mapping already points into the output.
+    const paths: Record<string, string[]> = {
+      '@proj/base/features/clipboard': [
+        'dist/libs/base/src/lib/features/clipboard.d.ts',
+      ],
+    };
+
+    updatePaths(
+      [
+        {
+          name: '@proj/base',
+          node: { name: 'base', type: 'lib', data: { root: 'base' } } as any,
+          outputs: ['dist/libs/base'],
+        },
+      ],
+      paths
+    );
+
+    expect(paths['@proj/base/features/clipboard']).toEqual([
+      './dist/libs/base/features/clipboard',
+      './dist/libs/base/src/lib/features/clipboard.d',
+      './dist/libs/base/src/lib/features/clipboard.d.ts',
+    ]);
+  });
+
   it('should handle outputs with glob patterns', () => {
     const paths: Record<string, string[]> = {
       '@proj/lib1': ['libs/lib1/src/index.ts'],

--- a/packages/js/src/utils/buildable-libs-utils.ts
+++ b/packages/js/src/utils/buildable-libs-utils.ts
@@ -517,7 +517,16 @@ export function updatePaths(
             mappedPaths = mappedPaths.concat(
               paths[path].flatMap((p) =>
                 dep.outputs.flatMap((output) => {
-                  const basePath = p.replace(root, output);
+                  // Re-map the root prefix to the output. Match root only as a
+                  // leading segment (after an optional `./`) so a root that
+                  // also appears later in the value (e.g. output `dist/libs/base`
+                  // for root `base`) isn't doubled.
+                  const dotPrefix = p.startsWith('./') ? './' : '';
+                  const value = dotPrefix ? p.slice(2) : p;
+                  const basePath =
+                    value === root || value.startsWith(`${root}/`)
+                      ? `${dotPrefix}${output}${value.slice(root.length)}`
+                      : p;
                   return [
                     // extension-less path to support compiled output
                     basePath.replace(


### PR DESCRIPTION
## Current Behavior

On Nx 23, building a buildable library with `@nx/angular:package` (and other buildable-library executors) fails with `TS2307` for subpath imports such as `@org/base/features/clipboard`. With `NX_VERBOSE_LOGGING_PATH_MAPPINGS=true`, the generated tsconfig path mappings contain doubled paths like `dist/libs/dist/libs/base/src/lib/features/clipboard.d.ts`.

## Expected Behavior

`nx build` succeeds and the generated path mappings point to valid paths without the `dist/libs/dist/libs/...` duplication.

## Related Issue(s)

Fixes #36079

## Implementation Details

`updatePaths` in `packages/js/src/utils/buildable-libs-utils.ts` remapped each dependency path mapping with `p.replace(root, output)`, a first-occurrence substring replace. When the project root (e.g. `base`) is a substring of the output directory (`dist/libs/base`) and the tsconfig mapping already points into the output (`dist/libs/base/src/lib/features/clipboard.d.ts`), the replace rewrote the `base` inside `dist/libs/base`, producing the doubled `dist/libs/dist/libs/base/...` path.

The root is now matched only as a leading path segment (after an optional `./`); values that do not start with the root are left untouched. For mappings that point to source under the project root the output is unchanged, so normal workspaces are unaffected.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/gh-36079-514731c3)
<!-- polygraph-session-end -->