### PR TITLE
fix(core): apply target defaults when project.json overrides an inferred run-commands target with different commands

### DIFF
--- a/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
@@ -888,6 +888,105 @@ describe('project-configuration-utils', () => {
       expect(errors).toEqual([]);
     });
 
+    it('should apply target defaults when project.json overrides an inferred run-commands target with different commands (#36067)', () => {
+      // Repro for #36067: an inferred plugin (@nx/vite) contributes a
+      // `build` target as an `nx:run-commands` invocation, and project.json
+      // overrides it with its own `nx:run-commands` `commands`. The two are
+      // command-incompatible, so project.json replaces the inferred target —
+      // but the target-name-keyed default's `dependsOn`/`cache`/`inputs`/
+      // `outputs` must still ride onto the winning project.json target. Before
+      // the fix, the synthetic defaults stayed pinned to the inferred command
+      // identity and were dropped when project.json replaced the base.
+      const specifiedResults = [
+        [
+          [
+            '@nx/vite',
+            'packages/graphql-schema/vite.config.ts',
+            {
+              projects: {
+                'packages/graphql-schema': {
+                  name: 'graphql-schema',
+                  root: 'packages/graphql-schema',
+                  targets: {
+                    build: {
+                      executor: 'nx:run-commands',
+                      options: { command: 'vite build' },
+                      cache: true,
+                      inputs: ['inferred-input'],
+                      outputs: ['{projectRoot}/dist-inferred'],
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        ],
+      ] as const;
+
+      const defaultResults = [
+        [
+          [
+            'nx/core/project-json',
+            'packages/graphql-schema/project.json',
+            {
+              projects: {
+                'packages/graphql-schema': {
+                  name: 'graphql-schema',
+                  root: 'packages/graphql-schema',
+                  targets: {
+                    build: {
+                      executor: 'nx:run-commands',
+                      options: {
+                        cwd: 'packages/graphql-schema',
+                        commands: [
+                          'vite build > /dev/null',
+                          'tsgo -p tsconfig.lib.json',
+                        ],
+                        parallel: false,
+                      },
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        ],
+      ] as const;
+
+      const errors = [];
+      const result = mergeCreateNodesResults(
+        specifiedResults as any,
+        defaultResults as any,
+        {
+          targetDefaults: {
+            build: {
+              dependsOn: ['generate', '^build'],
+              cache: true,
+              inputs: ['production', '^production'],
+              outputs: ['{projectRoot}/dist'],
+            },
+          },
+        },
+        '/tmp/test',
+        errors
+      );
+
+      const buildTarget =
+        result.projectRootMap['packages/graphql-schema'].targets!['build'];
+      // project.json's command wins the incompatible replace...
+      expect(buildTarget.options).toEqual(
+        expect.objectContaining({
+          commands: ['vite build > /dev/null', 'tsgo -p tsconfig.lib.json'],
+        })
+      );
+      // ...and the target defaults still apply to the winning target.
+      expect(buildTarget.dependsOn).toEqual(['generate', '^build']);
+      expect(buildTarget.cache).toEqual(true);
+      expect(buildTarget.inputs).toEqual(['production', '^production']);
+      expect(buildTarget.outputs).toEqual(['{projectRoot}/dist']);
+      expect(errors).toEqual([]);
+    });
+
     it('should merge multiple specified plugins contributing to the same project', () => {
       const specifiedResults = [
         [

--- a/packages/nx/src/project-graph/utils/project-configuration/target-defaults.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-defaults.ts
@@ -160,15 +160,34 @@ function buildSyntheticTargetForRoot(
     targetDefaultsConfig
   );
   if (targetDefaults && isCompatibleTarget(resolvedDefault, targetDefaults)) {
-    // Stamp executor/command so the default layer merges cleanly on top.
-    return {
-      ...targetDefaults,
-      executor: resolvedDefault.executor,
-      command: resolvedDefault.command,
-    };
+    // Stamp the default's identity so the default layer merges cleanly on top.
+    const synthetic: TargetConfiguration = { ...targetDefaults };
+    stampTargetIdentity(synthetic, resolvedDefault);
+    return synthetic;
   }
 
   return undefined;
+}
+
+// Copies `source`'s identity (executor, command, and — for run-commands — its
+// options.command/commands) onto `target` so the two compare compatible and
+// the synthetic isn't dropped when the default replaces the specified target
+// downstream (#36067). run-commands compatibility keys off
+// options.command/commands, not the top-level command, so both are carried.
+function stampTargetIdentity(
+  target: TargetConfiguration,
+  source: TargetConfiguration
+): void {
+  target.executor = source.executor;
+  target.command = source.command;
+  if (source.executor !== 'nx:run-commands') return;
+  const { command, commands } = source.options ?? {};
+  if (command === undefined && commands === undefined) return;
+  target.options = {
+    ...target.options,
+    ...(command !== undefined ? { command } : {}),
+    ...(commands !== undefined ? { commands } : {}),
+  };
 }
 
 function readAndPrepareTargetDefaults(


### PR DESCRIPTION
## Current Behavior

After upgrading to Nx 23, `targetDefaults` defined in `nx.json` are silently dropped for a target whenever a `project.json` target overrides an **inferred** `nx:run-commands` target with its own `commands`.

For example, with `@nx/vite/plugin` inferring a `build` target and:

```jsonc
// nx.json
"targetDefaults": {
  "build": {
    "dependsOn": ["generate", "^build"],
    "cache": true,
    "inputs": ["production", "^production"],
    "outputs": ["{projectRoot}/dist"]
  }
}
// packages/graphql-schema/project.json
"build": {
  "executor": "nx:run-commands",
  "options": { "cwd": "packages/graphql-schema", "commands": ["vite build", "tsgo"] }
}
```

none of `dependsOn`/`cache`/`inputs`/`outputs` are inherited. Removing `commands` makes them reappear.

### Root cause

Target defaults are synthesized as a plugin layer between the inferred plugins and `project.json`. When `project.json` overrides an inferred `nx:run-commands` target with **different** `commands`, the two are command-incompatible, so `project.json` wholesale-replaces the inferred target during the merge. The synthetic defaults were layered onto the inferred (losing) target and kept its command identity, so they were discarded along with the inferred target when `project.json` replaced the base.

`isCompatibleTarget` derives a run-commands target's command identity from `options.command`/`options.commands`, but synthesis only propagated the top-level `command` shorthand — which is `undefined` for the `options.commands` form — so the synthetic stayed pinned to the inferred command and never matched the winning `project.json` target.

## Expected Behavior

Target defaults apply to the target that wins the plugin merge (here, `project.json`), matching pre-Nx 23 behavior. The fix stamps the winning (default-plugin) run-commands command identity onto the synthetic defaults so it stays compatible with the target that replaces the specified one, and its contributions survive the downstream merge.

A regression test mirroring the issue is added to `project-configuration-utils.spec.ts`. The existing incompatible-replace tests (e.g. `@monodon/rust:test` vs `nx:run-commands`) continue to pass.

> Note for maintainers: the `reapply-target-defaults-nested-array` branch carries the same gap in its redesigned `effectiveTargetForLookup`/pre-stamp (it only propagates the top-level `command`). The behavioral regression test added here will surface it after that branch is rebased onto this PR, so the equivalent fix can be applied there.

## Related Issue(s)

Fixes #36067
