### PR TITLE
fix(misc): remove duplicate nx init cloud-prompt telemetry event

### DIFF
--- a/packages/nx/src/command-line/init/init-v2.ts
+++ b/packages/nx/src/command-line/init/init-v2.ts
@@ -457,7 +457,7 @@ async function runInit(
     nxCloudChoice = 'skip';
   } else {
     nxCloudChoice = options.interactive
-      ? await connectExistingRepoToNxCloudPrompt()
+      ? await connectExistingRepoToNxCloudPrompt('init', 'setupNxCloud', false)
       : 'skip';
   }
   if (nxCloudChoice === 'yes') {

--- a/packages/nx/src/command-line/nx-cloud/connect/connect-to-nx-cloud.ts
+++ b/packages/nx/src/command-line/nx-cloud/connect/connect-to-nx-cloud.ts
@@ -232,21 +232,6 @@ export async function connectExistingRepoToNxCloudPrompt(
   key: MessageKey = 'setupNxCloud'
 ): Promise<MessageOptionKey> {
   const res = await nxCloudPrompt(key, utmMediumForCommand(command));
-  await recordStat({
-    command,
-    nxVersion,
-    useCloud: res === 'yes',
-    meta: {
-      type: 'complete',
-      setupCloudPrompt: messages.codeOfSelectedPromptMessage(key) || '',
-      nxCloudArg: res,
-      nodeVersion: process.versions.node,
-      os: process.platform,
-      packageManager: detectPackageManager(),
-      aiAgent: isAiAgent(),
-      isCI: isCI(),
-    },
-  });
   return res;
 }
 

--- a/packages/nx/src/command-line/nx-cloud/connect/connect-to-nx-cloud.ts
+++ b/packages/nx/src/command-line/nx-cloud/connect/connect-to-nx-cloud.ts
@@ -233,6 +233,9 @@ export async function connectExistingRepoToNxCloudPrompt(
   recordCompletion = true
 ): Promise<MessageOptionKey> {
   const res = await nxCloudPrompt(key, utmMediumForCommand(command));
+  // TODO: once legacy init-v1 (the NX_ADD_PLUGINS=false / useInferencePlugins:false path) is
+  // removed, drop this recordStat and the recordCompletion flag entirely - init-v2 records its
+  // own complete, and view-logs should record its own stat, so this shared helper won't record.
   // init-v2 records its own init "complete" stat, so it opts out here to avoid double-counting.
   // Other callers (e.g. view-logs, legacy init-v1) rely on this as their only completion event.
   if (recordCompletion) {

--- a/packages/nx/src/command-line/nx-cloud/connect/connect-to-nx-cloud.ts
+++ b/packages/nx/src/command-line/nx-cloud/connect/connect-to-nx-cloud.ts
@@ -229,9 +229,29 @@ function sleep(ms: number) {
 
 export async function connectExistingRepoToNxCloudPrompt(
   command = 'init',
-  key: MessageKey = 'setupNxCloud'
+  key: MessageKey = 'setupNxCloud',
+  recordCompletion = true
 ): Promise<MessageOptionKey> {
   const res = await nxCloudPrompt(key, utmMediumForCommand(command));
+  // init-v2 records its own init "complete" stat, so it opts out here to avoid double-counting.
+  // Other callers (e.g. view-logs, legacy init-v1) rely on this as their only completion event.
+  if (recordCompletion) {
+    await recordStat({
+      command,
+      nxVersion,
+      useCloud: res === 'yes',
+      meta: {
+        type: 'complete',
+        setupCloudPrompt: messages.codeOfSelectedPromptMessage(key) || '',
+        nxCloudArg: res,
+        nodeVersion: process.versions.node,
+        os: process.platform,
+        packageManager: detectPackageManager(),
+        aiAgent: isAiAgent(),
+        isCI: isCI(),
+      },
+    });
+  }
   return res;
 }
 


### PR DESCRIPTION
## Current Behavior

Interactive `nx init` with cloud emits two `command:"init"` `type:"complete"` telemetry events per run: one from the shared `connectExistingRepoToNxCloudPrompt` helper (carries `setupCloudPrompt`) and one from `init-v2` (carries `pluginsInstalled`). This double-counts inits in telemetry.

The helper is shared: `view-logs` and legacy `init-v1` (the `NX_ADD_PLUGINS=false` / `useInferencePlugins:false` path) rely on it as their only completion event, so simply deleting it would drop their telemetry.

## Expected Behavior

The helper's `recordStat` is gated behind a new `recordCompletion` flag (default `true`). `init-v2` passes `false` since it records its own complete, so init is counted once. `view-logs` and `init-v1` keep the default and retain their only completion event.


A TODO notes that once `init-v1` is removed, the helper's `recordStat` and the flag can be dropped entirely.

## Related Issue(s)
N/A (telemetry-accuracy fix)

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/info-init-discrepancies-091e90ab)
<!-- polygraph-session-end -->