### PR TITLE
fix(repo): trust wix/brew tap so macOS detox CI can install applesimutils

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,9 +199,12 @@ jobs:
           if ! brew list applesimutils &>/dev/null; then
             echo "Installing applesimutils..."
             HOMEBREW_NO_AUTO_UPDATE=1 brew tap wix/brew >/dev/null
+            # Homebrew now refuses to load formulae from third-party taps unless trusted
+            brew trust wix/brew
             HOMEBREW_NO_AUTO_UPDATE=1 brew install applesimutils >/dev/null || {
               echo "Failed to install applesimutils, retrying with update..."
               brew update
+              brew trust wix/brew
               HOMEBREW_NO_AUTO_UPDATE=1 brew install applesimutils
             }
           else

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -224,9 +224,12 @@ jobs:
           if ! brew list applesimutils &>/dev/null; then
             echo 'Installing applesimutils...'
             HOMEBREW_NO_AUTO_UPDATE=1 brew tap wix/brew >/dev/null
+            # Homebrew now refuses to load formulae from third-party taps unless trusted
+            brew trust wix/brew
             HOMEBREW_NO_AUTO_UPDATE=1 brew install applesimutils >/dev/null || {
               echo 'Failed to install applesimutils, retrying with update...'
               brew update
+              brew trust wix/brew
               HOMEBREW_NO_AUTO_UPDATE=1 brew install applesimutils
             }
           else


### PR DESCRIPTION
## Current Behavior

The macOS CI jobs (`main-macos` in `ci.yml` and the macOS matrix in `e2e-matrix.yml`) fail during the "Configure Detox Environment, Install applesimutils" step. The `macos-latest` hosted-runner image rolled forward to build `20260623.0190.x`, which ships a newer Homebrew that refuses to load formulae from untrusted third-party taps:

```
Error: Refusing to load formula wix/brew/applesimutils from untrusted tap wix/brew.
Run `brew trust --formula wix/brew/applesimutils` or `brew trust wix/brew` to trust it.
```

Since the step taps `wix/brew` and installs `applesimutils`, the install hard-fails and the job exits 1. Nothing in the repo changed — this is floating-tag (`macos-latest`) image drift picking up the new Homebrew trust gate.

## Expected Behavior

The tap is explicitly trusted immediately after tapping, so `brew install applesimutils` loads and installs successfully and the macOS detox jobs run as before.

- Adds `brew trust wix/brew` after `brew tap wix/brew` in both `.github/workflows/ci.yml` and `.github/workflows/e2e-matrix.yml`, on both the initial-install and the update-retry paths.
- Touches `e2e/detox/src/detox.test.ts` with a one-line comment so `scripts/check-react-native-changes.js` detects an RN-path change and re-triggers the macOS jobs to validate this fix.

## Related Issue(s)

N/A — CI infrastructure fix.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/macOS-CI-Homebrew-tap-loading-failure-applesimutils-3e78e6ab)
<!-- polygraph-session-end -->