### PR TITLE
fix(graph): prevent project details web view top from being clipped

### DIFF
--- a/graph/project-details/src/lib/project-details-page.tsx
+++ b/graph/project-details/src/lib/project-details-page.tsx
@@ -60,7 +60,7 @@ export function ProjectDetailsPage() {
 
   return (
     <ExpandedTargetsProvider>
-      <div className="flex h-fit w-full flex-col justify-center text-slate-700 dark:text-slate-400">
+      <div className="flex h-fit w-full flex-col text-slate-700 dark:text-slate-400">
         <ScrollRestoration />
         {environment !== 'nx-console' ? (
           <ProjectDetailsHeader />


### PR DESCRIPTION
## Current Behavior

In the standalone project details web view (`nx show project <name> --web`), the top of the page is clipped and unreachable when a project's content is taller than the viewport. The Nx logo header, the project title, Root/Type, and the Targets heading get pushed above the scroll origin, so the page appears to start partway down (e.g. at "NPM Scripts") with no way to scroll up to the missing content.

Cause: the page container used `justify-center` on a flex column. The `#app` flex parent stretches that container to the viewport height, so taller projects overflow, and `justify-center` splits the overflow symmetrically, shoving the top of the content above the scrollable area.

<img width="1395" height="497" alt="image" src="https://github.com/user-attachments/assets/f846c751-c9c5-48ef-92a0-e3ad174d84ee" />

## Expected Behavior

Content flows from the top and the entire page is scrollable, so the header, title, and Targets heading are always visible/reachable regardless of project height. Fixed by removing `justify-center` from the page container.

<img width="1335" height="605" alt="image" src="https://github.com/user-attachments/assets/abc97334-8a82-4047-9d80-02e750383352" />

## Validation on smaller target

It renders correctly on a project that does not overflow the viewport:

<img width="1326" height="576" alt="image" src="https://github.com/user-attachments/assets/815c1f03-d462-43a3-b905-6bb4e051be27" />

