### PR TITLE
fix(misc): fix dead links for vite deprecation messages

### DIFF
--- a/packages/vite/src/utils/deprecation.ts
+++ b/packages/vite/src/utils/deprecation.ts
@@ -41,10 +41,10 @@ export function warnViteExecutorGenerating(): void {
 // resolution end-to-end. Asset copying is covered by Vite's native
 // `publicDir` option or the `vite-plugin-static-copy` package.
 export const NX_VITE_TS_PATHS_DEPRECATION_MESSAGE =
-  'The `nxViteTsPaths` plugin from `@nx/vite/plugins/nx-tsconfig-paths.plugin` is deprecated and will be removed in Nx v24. Replace it with `tsconfigPaths()` from the `vite-tsconfig-paths` package. See https://nx.dev/docs/technologies/build-tools/vite/configure-vite for details.';
+  'The `nxViteTsPaths` plugin from `@nx/vite/plugins/nx-tsconfig-paths.plugin` is deprecated and will be removed in Nx v24. Replace it with `tsconfigPaths()` from the `vite-tsconfig-paths` package. See https://nx.dev/docs/technologies/build-tools/vite/guides/configure-vite#typescript-paths for details.';
 
 export const NX_COPY_ASSETS_PLUGIN_DEPRECATION_MESSAGE =
-  "The `nxCopyAssetsPlugin` plugin from `@nx/vite/plugins/nx-copy-assets.plugin` is deprecated and will be removed in Nx v24. Use Vite's native `publicDir` option or the `vite-plugin-static-copy` package instead. See https://nx.dev/docs/technologies/build-tools/vite/configure-vite for details.";
+  "The `nxCopyAssetsPlugin` plugin from `@nx/vite/plugins/nx-copy-assets.plugin` is deprecated and will be removed in Nx v24. Use Vite's native `publicDir` option or the `vite-plugin-static-copy` package instead. See https://nx.dev/docs/technologies/build-tools/vite/guides/configure-vite#copying-assets for details.";
 
 let nxViteTsPathsWarned = false;
 let nxCopyAssetsPluginWarned = false;


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

Affected version: Version 23.0.1

## Current Behavior
Currently when running vitest tests the deprecation links shown in the warning messages end up in a 404 not found

For example:
`The nxCopyAssetsPlugin plugin from @nx/vite/plugins/nx-copy-assets.plugin is deprecated and will be removed in Nx v24. Use Vite's native publicDir option or the vite-plugin-static-copy package instead. See https://nx.dev/docs/technologies/build-tools/vite/configure-vite for details.`

## Expected Behavior
Those links should be pointing to the correct page in the documentation. Small fix, The path element "guide" was missing. 

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->
