### PR TITLE
fix(linter): install angular-eslint when converting Angular configs to flat config

### DIFF
--- a/packages/eslint/src/generators/convert-to-flat-config/generator.spec.ts
+++ b/packages/eslint/src/generators/convert-to-flat-config/generator.spec.ts
@@ -270,6 +270,58 @@ describe('convert-to-flat-config generator', () => {
       ).toEqual(eslintrcVersion);
     });
 
+    it('adds the umbrella angular-eslint package when converting a config that uses the @nx/angular preset', async () => {
+      await lintProjectGenerator(tree, {
+        skipFormat: false,
+        linter: 'eslint',
+        project: 'test-lib',
+        setParserOptionsProject: false,
+        eslintConfigFormat: 'cjs',
+      });
+      // An Angular eslintrc workspace has the scoped packages installed; the
+      // umbrella is what the flat/angular preset needs and what is missing.
+      updateJson(tree, 'package.json', (json) => {
+        json.devDependencies = {
+          ...(json.devDependencies ?? {}),
+          '@angular-eslint/eslint-plugin': '^21.5.0',
+        };
+        return json;
+      });
+      updateJson(tree, '.eslintrc.json', (json) => {
+        json.extends = ['plugin:@nx/angular'];
+        return json;
+      });
+
+      await convertToFlatConfigGenerator(tree, options);
+
+      expect(tree.read('eslint.config.cjs', 'utf-8')).toContain('flat/angular');
+      // Pinned to the installed @angular-eslint major.
+      expect(
+        readJson(tree, 'package.json').devDependencies['angular-eslint']
+      ).toEqual('^21.0.0');
+    });
+
+    it('falls back to the latest angular-eslint major when no @angular-eslint packages are installed', async () => {
+      await lintProjectGenerator(tree, {
+        skipFormat: false,
+        linter: 'eslint',
+        project: 'test-lib',
+        setParserOptionsProject: false,
+        eslintConfigFormat: 'cjs',
+      });
+      updateJson(tree, '.eslintrc.json', (json) => {
+        json.extends = ['plugin:@nx/angular'];
+        return json;
+      });
+
+      await convertToFlatConfigGenerator(tree, options);
+
+      expect(tree.read('eslint.config.cjs', 'utf-8')).toContain('flat/angular');
+      expect(
+        readJson(tree, 'package.json').devDependencies['angular-eslint']
+      ).toEqual('^22.0.0');
+    });
+
     it('should add global eslintignores', async () => {
       await lintProjectGenerator(tree, {
         skipFormat: false,

--- a/packages/eslint/src/generators/convert-to-flat-config/generator.ts
+++ b/packages/eslint/src/generators/convert-to-flat-config/generator.ts
@@ -32,6 +32,7 @@ import {
   ESLINT_FLAT_CONFIG_FILENAMES,
 } from '../../utils/config-file';
 import { ESLint } from 'eslint';
+import { coerce } from 'semver';
 import {
   convertEslintJsonToFlatConfig,
   renameLegacyEslintrcFile,
@@ -482,6 +483,12 @@ function processConvertedConfig(
     devDependencies['@eslint/js'] = eslintVersion;
   }
 
+  // The flat/angular presets import the umbrella `angular-eslint` package; add
+  // it when the converted config references them so the result resolves.
+  if (content.includes('flat/angular')) {
+    devDependencies['angular-eslint'] = resolveAngularEslintVersion(tree);
+  }
+
   // Direct invocation is an opt-in upgrade, so by default existing pins are
   // overwritten to land the workspace on the latest flat-config-ready stack.
   // Migrations pass `keepExistingVersions` so the version bump stays owned by
@@ -493,4 +500,25 @@ function processConvertedConfig(
     'package.json',
     keepExistingVersions
   );
+}
+
+// The umbrella `angular-eslint` and the scoped `@angular-eslint/*` packages
+// release in lockstep, so pin the umbrella to the major already installed,
+// falling back to the latest major nx generates when none is present. @nx/eslint
+// can't read the canonical pin from @nx/angular without inverting the package
+// dependency (@nx/angular depends on @nx/eslint), so the fallback is hardcoded;
+// keep it in sync with `angularEslintVersion` in packages/angular/src/utils/versions.ts.
+function resolveAngularEslintVersion(tree: Tree): string {
+  const installed =
+    getDependencyVersionFromPackageJson(
+      tree,
+      '@angular-eslint/eslint-plugin'
+    ) ??
+    getDependencyVersionFromPackageJson(
+      tree,
+      '@angular-eslint/template-parser'
+    );
+  const installedMajor = installed ? coerce(installed)?.major : undefined;
+
+  return installedMajor != null ? `^${installedMajor}.0.0` : '^22.0.0';
 }


### PR DESCRIPTION
## Current Behavior

The `@nx/eslint:convert-to-flat-config` generator converts ESLint configs that extend the `@nx/angular` preset into flat config that spreads `nx.configs['flat/angular']`. That preset imports the umbrella `angular-eslint` package at runtime, but the generator never adds it to the workspace. A workspace converted from a working eslintrc Angular setup (for example by the 23.1 `convert-to-flat-config` migration) then fails to lint with `Cannot find module 'angular-eslint'`.

## Expected Behavior

When the converted config references the `flat/angular` preset, the generator adds `angular-eslint` to devDependencies, pinned to the `@angular-eslint` major already installed in the workspace (falling back to the latest major nx generates). The converted workspace lints cleanly.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/nx-23.1.0-beta-migration-b1195096)
<!-- polygraph-session-end -->