### PR TITLE
fix(react): bump eslint-plugin-react below 7.35 for ESLint 9 compatibility

### DIFF
--- a/packages/react/migrations.json
+++ b/packages/react/migrations.json
@@ -246,6 +246,18 @@
           "alwaysAddToPackageJson": false
         }
       }
+    },
+    "23.1.0-eslint-plugin-react": {
+      "version": "23.1.0-beta.5",
+      "requires": {
+        "eslint-plugin-react": "<7.35.0"
+      },
+      "packages": {
+        "eslint-plugin-react": {
+          "version": "^7.35.0",
+          "alwaysAddToPackageJson": false
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Current Behavior

`eslint-plugin-react` below 7.35.0 calls `context.getScope` and `context.getAncestors`, which ESLint 9 removed. Once the 23.1 migration moves a workspace to ESLint 9, rules such as `react/no-direct-mutation-state` throw `context.getScope is not a function`. The migration bumps ESLint to 9 but leaves an older `eslint-plugin-react` untouched.

## Expected Behavior

A new packageJsonUpdates entry bumps workspaces still on a pre-7.35 `eslint-plugin-react` to `^7.35.0`, the first release with a `SourceCode`-based compatibility shim for ESLint 9, so React workspaces keep linting after the upgrade. The generated version is already 7.35.0, so no change to the generated pin is needed.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/nx-23.1.0-beta-migration-b1195096)
<!-- polygraph-session-end -->