### PR TITLE
fix(rsbuild): bump @rsbuild/plugin-sass with @rsbuild/core for the v2 migration

### DIFF
--- a/packages/rsbuild/migrations.json
+++ b/packages/rsbuild/migrations.json
@@ -48,6 +48,10 @@
         "@rsbuild/plugin-react": {
           "version": "^2.0.0",
           "alwaysAddToPackageJson": false
+        },
+        "@rsbuild/plugin-sass": {
+          "version": "^1.5.2",
+          "alwaysAddToPackageJson": false
         }
       }
     }


### PR DESCRIPTION
## Current Behavior

The 23.1 migration to `@rsbuild/core` v2 bumps `@rsbuild/core` and `@rsbuild/plugin-react` but leaves `@rsbuild/plugin-sass` on its v1 line. `@rsbuild/plugin-sass` below 1.5.2 throws `TypeError: Cannot convert undefined or null to object` against `@rsbuild/core` v2, breaking scss builds and dev servers.

## Expected Behavior

The `23.0.0-rsbuild-v2` packageJsonUpdate also bumps `@rsbuild/plugin-sass` to `^1.5.2` (only when already present), so the whole rsbuild stack moves to v2-compatible versions together.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/nx-23.1.0-beta-migration-b1195096)
<!-- polygraph-session-end -->