### PR TITLE
fix(js): restore the pre-TypeScript 6 default of loading all @types

### DIFF
--- a/packages/js/migrations.json
+++ b/packages/js/migrations.json
@@ -31,7 +31,7 @@
     },
     "23-1-0-add-ignore-deprecations-for-ts6": {
       "version": "23.1.0-beta.0",
-      "description": "Adds `\"ignoreDeprecations\": \"6.0\"` to tsconfig files whose compilerOptions (or ts-node.compilerOptions) directly carry a TypeScript 6 deprecated option value (e.g. moduleResolution node/node10/classic, baseUrl, target es5, esModuleInterop false, outFile, module amd/umd/system/none, alwaysStrict false, allowSyntheticDefaultImports false, downlevelIteration set). Also pins `\"strict\": false` and `\"noUncheckedSideEffectImports\": false` in chain-root tsconfigs (no \"extends\") that lack each key, preserving pre-TS6 behavior where their defaults were less strict.",
+      "description": "Adds `\"ignoreDeprecations\": \"6.0\"` to tsconfig files whose compilerOptions (or ts-node.compilerOptions) directly carry a TypeScript 6 deprecated option value (e.g. moduleResolution node/node10/classic, baseUrl, target es5, esModuleInterop false, outFile, module amd/umd/system/none, alwaysStrict false, allowSyntheticDefaultImports false, downlevelIteration set). Also pins `\"strict\": false`, `\"noUncheckedSideEffectImports\": false`, and `\"types\": [\"*\"]` in chain-root tsconfigs (no \"extends\") that lack each key, preserving pre-TS6 behavior where these defaults were stricter or, for `types`, stopped auto-loading all @types packages.",
       "requires": {
         "typescript": ">=6.0.0"
       },

--- a/packages/js/src/migrations/update-23-1-0/add-ignore-deprecations-for-ts6.md
+++ b/packages/js/src/migrations/update-23-1-0/add-ignore-deprecations-for-ts6.md
@@ -3,7 +3,7 @@
 TypeScript 6 turns several long-deprecated compiler options into hard errors and flips a few option defaults to stricter values. So that an existing workspace keeps compiling on TypeScript 6 without being migrated to a full TypeScript 6 setup, this migration makes two edits to the `tsconfig*.json` files in the workspace:
 
 - Adds `"ignoreDeprecations": "6.0"` to any `compilerOptions` (or `ts-node.compilerOptions`) block that directly sets a TypeScript 6 deprecated option - for example `moduleResolution` set to `node`/`node10`/`classic`, `baseUrl`, `target` set to `es5`, `esModuleInterop: false`, `outFile`, `module` set to `amd`/`umd`/`system`/`none`, `alwaysStrict: false`, `allowSyntheticDefaultImports: false`, or `downlevelIteration`.
-- Pins `"strict": false` and `"noUncheckedSideEffectImports": false` on every chain-root tsconfig (one without an `extends`) that does not already set them. TypeScript 6 treats an absent `strict` as `true` (it was `false` when unset before) and defaults `noUncheckedSideEffectImports` to `true`, which turns a bare side-effect import such as `import './styles.css'` without an ambient module declaration into an error. Pinning both preserves the pre-TypeScript 6 behavior.
+- Pins `"strict": false`, `"noUncheckedSideEffectImports": false`, and `"types": ["*"]` on every chain-root tsconfig (one without an `extends`) that does not already set them. TypeScript 6 treats an absent `strict` as `true` (it was `false` when unset before), defaults `noUncheckedSideEffectImports` to `true` (which turns a bare side-effect import such as `import './styles.css'` without an ambient module declaration into an error), and no longer auto-loads every `@types` package when `types` is unset the way TypeScript 5 did. The `"*"` wildcard restores that last default. Pinning all three preserves the pre-TypeScript 6 behavior.
 
 Files that use `extends` inherit these settings from their chain root and are left untouched, and pure solution-style tsconfigs (`"files": []` with no `include`) are skipped. The migration only runs when the workspace is on TypeScript 6.
 
@@ -23,7 +23,7 @@ Files that use `extends` inherit these settings from their chain root and are le
 
 ##### After
 
-```json title="tsconfig.json" {6-8}
+```json title="tsconfig.json" {6-9}
 {
   "compilerOptions": {
     "target": "es5",
@@ -31,7 +31,8 @@ Files that use `extends` inherit these settings from their chain root and are le
     "moduleResolution": "bundler",
     "ignoreDeprecations": "6.0",
     "strict": false,
-    "noUncheckedSideEffectImports": false
+    "noUncheckedSideEffectImports": false,
+    "types": ["*"]
   }
 }
 ```

--- a/packages/js/src/migrations/update-23-1-0/add-ignore-deprecations-for-ts6.spec.ts
+++ b/packages/js/src/migrations/update-23-1-0/add-ignore-deprecations-for-ts6.spec.ts
@@ -239,7 +239,7 @@ describe('add-ignore-deprecations-for-ts6 migration', () => {
     expect(json.compilerOptions.ignoreDeprecations).toBeUndefined();
   });
 
-  it('applies all three pins on a chain root carrying a deprecated option', async () => {
+  it('applies all pins on a chain root carrying a deprecated option', async () => {
     tree.write(
       'tsconfig.json',
       JSON.stringify({ compilerOptions: { moduleResolution: 'node' } }, null, 2)
@@ -251,6 +251,7 @@ describe('add-ignore-deprecations-for-ts6 migration', () => {
     expect(json.compilerOptions.ignoreDeprecations).toBe('6.0');
     expect(json.compilerOptions.strict).toBe(false);
     expect(json.compilerOptions.noUncheckedSideEffectImports).toBe(false);
+    expect(json.compilerOptions.types).toEqual(['*']);
   });
 
   describe('strict-pin pass', () => {
@@ -464,6 +465,90 @@ describe('add-ignore-deprecations-for-ts6 migration', () => {
       const json = readJson(tree, 'tsconfig.json');
       expect(json.compilerOptions.strict).toBe(false);
       expect(json.compilerOptions.noUncheckedSideEffectImports).toBe(false);
+    });
+  });
+
+  describe('types-pin pass', () => {
+    it('adds types ["*"] to a chain root without an explicit types key', async () => {
+      tree.write(
+        'tsconfig.base.json',
+        JSON.stringify(
+          {
+            compilerOptions: { module: 'esnext', moduleResolution: 'bundler' },
+          },
+          null,
+          2
+        )
+      );
+
+      await update(tree);
+
+      const json = readJson(tree, 'tsconfig.base.json');
+      expect(json.compilerOptions.types).toEqual(['*']);
+    });
+
+    it('does not touch types on a file that has "extends"', async () => {
+      tree.write(
+        'tsconfig.app.json',
+        JSON.stringify(
+          { extends: './tsconfig.json', compilerOptions: { module: 'esnext' } },
+          null,
+          2
+        )
+      );
+
+      await update(tree);
+
+      const json = readJson(tree, 'tsconfig.app.json');
+      expect(json.compilerOptions.types).toBeUndefined();
+    });
+
+    it('does not overwrite an explicit types list', async () => {
+      tree.write(
+        'tsconfig.json',
+        JSON.stringify(
+          { compilerOptions: { types: ['node'], module: 'esnext' } },
+          null,
+          2
+        )
+      );
+
+      await update(tree);
+
+      const json = readJson(tree, 'tsconfig.json');
+      expect(json.compilerOptions.types).toEqual(['node']);
+    });
+
+    it('does not overwrite an explicit empty types array (deliberate opt-out)', async () => {
+      tree.write(
+        'tsconfig.json',
+        JSON.stringify(
+          { compilerOptions: { types: [], module: 'esnext' } },
+          null,
+          2
+        )
+      );
+
+      await update(tree);
+
+      const json = readJson(tree, 'tsconfig.json');
+      expect(json.compilerOptions.types).toEqual([]);
+    });
+
+    it('skips solution-style containers with files:[] and no include', async () => {
+      tree.write(
+        'tsconfig.json',
+        JSON.stringify(
+          { files: [], references: [{ path: './packages/a' }] },
+          null,
+          2
+        )
+      );
+
+      await update(tree);
+
+      const json = readJson(tree, 'tsconfig.json');
+      expect(json.compilerOptions).toBeUndefined();
     });
   });
 });

--- a/packages/js/src/migrations/update-23-1-0/add-ignore-deprecations-for-ts6.ts
+++ b/packages/js/src/migrations/update-23-1-0/add-ignore-deprecations-for-ts6.ts
@@ -30,14 +30,19 @@ type CompilerOptions = Record<string, unknown>;
  *    false, downlevelIteration set to any value).
  *
  * 2. default-preserving pass - for every chain root (no "extends" key), pins
- *    the TS6 compiler-option defaults that flipped to a stricter value back to
- *    their pre-TS6 value, but only when the root does not set them explicitly:
+ *    the TS6 compiler-option defaults that changed in a way that breaks existing
+ *    workspaces back to their pre-TS6 value, but only when the root does not set
+ *    them explicitly:
  *      - "strict": false - TS6 treats an absent "strict" as true; TS5 as false.
  *      - "noUncheckedSideEffectImports": false - TS6 defaults it to true, which
  *        turns a bare side-effect import of an asset lacking an ambient
  *        declaration (e.g. `import './styles.css'`) into a hard TS2882 error; it
  *        is a semantic diagnostic, not a deprecation, so `ignoreDeprecations`
  *        cannot silence it.
+ *      - "types": ["*"]. TS6 loads no @types packages when `types` is unset,
+ *        whereas TS5 loaded them all; the "*" wildcard restores that default so
+ *        a config relying on it (e.g. ts-node type-checking jest.config.ts)
+ *        keeps finding @types/node.
  *    Files with "extends" inherit from their chain root and are left untouched.
  *    Pure solution-style containers (root has `"files": []` and no "include")
  *    select no source files, so pinning there is noise and they are skipped.
@@ -68,7 +73,7 @@ export default async function (tree: Tree) {
   }
   if (defaultsPinCount > 0) {
     logger.info(
-      `Pinned pre-TS6 compiler option defaults ("strict", "noUncheckedSideEffectImports") on ${defaultsPinCount} tsconfig chain root(s) to preserve existing behavior.`
+      `Pinned pre-TS6 compiler option defaults ("strict", "noUncheckedSideEffectImports", "types") on ${defaultsPinCount} tsconfig chain root(s) to preserve existing behavior.`
     );
   }
 
@@ -180,12 +185,15 @@ function hasDeprecatedValue(compilerOptions: CompilerOptions): boolean {
   return false;
 }
 
-// TS6 compiler-option defaults that flipped to a stricter value. We pin each
-// back to its pre-TS6 value on chain roots that don't set it, so existing
-// workspaces keep building without adopting a legit TS6 setup.
-const DEFAULT_PRESERVING_PINS: ReadonlyArray<[string, boolean]> = [
+// TS6 compiler-option defaults that changed in a way that breaks existing
+// workspaces. We pin each back to its pre-TS6 value on chain roots that don't
+// set it, so existing workspaces keep building without adopting a legit TS6
+// setup.
+const DEFAULT_PRESERVING_PINS: ReadonlyArray<[string, boolean | string[]]> = [
   ['strict', false],
   ['noUncheckedSideEffectImports', false],
+  // TS6 loads no @types when `types` is unset (TS5 loaded all); "*" restores it.
+  ['types', ['*']],
 ];
 
 function pinPreTs6Defaults(tree: Tree, tsconfigPath: string): boolean {
@@ -228,7 +236,7 @@ function pinPreTs6Defaults(tree: Tree, tsconfigPath: string): boolean {
   let contents = original;
   let changed = false;
   for (const [key, value] of DEFAULT_PRESERVING_PINS) {
-    // An explicit value (true or false) means the user opted in - leave it.
+    // An explicit value means the user opted in; leave it.
     if (key in compilerOptions) {
       continue;
     }


### PR DESCRIPTION
## Current Behavior

TypeScript 6 no longer auto-includes every `@types/*` package when `compilerOptions.types` is unset, whereas TypeScript 5 did. A workspace that relied on that default loses `@types/node`, so jest's ts-node loader type-checking `jest.config.ts` fails with `TS2591: Cannot find name 'module'`.

## Expected Behavior

The existing TypeScript 6 tsconfig migration also pins `types: ["*"]` (the wildcard that re-includes every discovered `@types` package) on chain-root tsconfigs that don't already set `types`, alongside the `strict` and `noUncheckedSideEffectImports` defaults it already preserves. Leaf configs inherit it through `extends`, and an explicit `types` (including `[]`) is left untouched.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/nx-23.1.0-beta-migration-b1195096)
<!-- polygraph-session-end -->