### PR TITLE
fix(react): stop pinning eslint-plugin-react in generated projects

### DIFF
--- a/packages/react/src/utils/versions.ts
+++ b/packages/react/src/utils/versions.ts
@@ -39,7 +39,7 @@ export const reactReduxVersion = '^9.2.0';
 
 export const eslintPluginImportVersion = '2.31.0';
 export const eslintPluginJsxA11yVersion = '6.10.1';
-export const eslintPluginReactVersion = '7.35.0';
+export const eslintPluginReactVersion = '^7.35.0';
 export const eslintPluginReactHooksVersion = '5.0.0';
 
 export const tsLibVersion = '^2.3.0';


### PR DESCRIPTION
## Current Behavior

New React projects pin `eslint-plugin-react` to an exact `7.35.0`, so they cannot pick up compatible `7.x` updates. It also diverges from the `^7.35.0` range the 23.1 migration applies to existing workspaces, leaving generated and migrated projects on different specs.

## Expected Behavior

Generating a React project installs `eslint-plugin-react` at `^7.35.0`, the same range the migration uses, so new and migrated workspaces land on the same spec.

> [!NOTE]
> Follow-up to #36161 (merged), which added the migration to `^7.35.0` but left the generated version pinned at `7.35.0`.
