### PR TITLE
feat(core): re-add isCacheableTask helper

### DIFF
--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -650,6 +650,10 @@ export function shouldStreamOutput(
   return false;
 }
 
+export function isCacheableTask(task: Task): boolean {
+  return task.cache;
+}
+
 function longRunningTask(task: Task) {
   const t = task.target.target;
   return (


### PR DESCRIPTION
## Current Behavior

`isCacheableTask` was removed during the cleanup that made `task.cache` always an explicit boolean. Internal call sites now read `task.cache` directly, so the named helper no longer exists.

## Expected Behavior

Re-adds a minimal `isCacheableTask(task)` helper to `packages/nx/src/tasks-runner/utils.ts` that returns `task.cache`. This restores a named, reusable predicate for task cacheability. It does not reintroduce the old `cacheableOperations` / `cacheableTargets` fallback or the `options` parameter, since `task.cache` is now always set.

## Related Issue(s)

N/A

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Re-add-isCacheableTask-helper-2d550389)
<!-- polygraph-session-end -->