### PR TITLE
fix(linter): run typescript-eslint v8 rule migrations for scoped-only workspaces

### DIFF
--- a/packages/eslint/migrations.json
+++ b/packages/eslint/migrations.json
@@ -27,17 +27,11 @@
     },
     "update-23-1-0-remove-removed-typescript-eslint-extension-rules": {
       "version": "23.1.0-beta.5",
-      "requires": {
-        "typescript-eslint": ">=8.0.0"
-      },
       "description": "Handle typescript-eslint rules removed in v8 in ESLint flat configs, since referencing a removed rule stops the config from loading. Deletes the removed formatting/extension rules (e.g. @typescript-eslint/no-extra-semi) and rewrites the safe 1:1 renames (no-throw-literal -> only-throw-error, no-useless-template-literals -> no-unnecessary-template-expression) to preserve enforcement.",
       "implementation": "./dist/src/migrations/update-23-1-0/remove-removed-typescript-eslint-extension-rules"
     },
     "update-23-1-0-migrate-ban-types-rule": {
       "version": "23.1.0-beta.5",
-      "requires": {
-        "typescript-eslint": ">=8.0.0"
-      },
       "description": "Migrate the removed @typescript-eslint/ban-types rule to its v8 successors (no-empty-object-type, no-unsafe-function-type, no-wrapper-object-types), whose options do not map 1:1 - so it is driven by an AI prompt rather than a deterministic codemod.",
       "prompt": "./dist/src/migrations/update-23-1-0/migrate-ban-types-rule.md"
     }

--- a/packages/eslint/src/migrations/update-23-1-0/migrate-ban-types-rule.md
+++ b/packages/eslint/src/migrations/update-23-1-0/migrate-ban-types-rule.md
@@ -7,6 +7,20 @@ config that still references it fails to load. It was split into three rules:
 - `@typescript-eslint/no-unsafe-function-type` - the `Function` type
 - `@typescript-eslint/no-wrapper-object-types` - wrapper types (`String`, `Number`, `Boolean`, `Object`, ...)
 
+## First, check whether there is anything to do
+
+Confirm both conditions before changing anything. If either fails, make no
+changes and stop:
+
+1. Some ESLint flat config (`eslint.config.{mjs,cjs,js,cts,ts,mts}`) references
+   `@typescript-eslint/ban-types`. Search the workspace for that string; if no
+   config uses the rule, there is nothing to migrate.
+2. The workspace is on typescript-eslint v8 or later (check `typescript-eslint`
+   or `@typescript-eslint/eslint-plugin` in `package.json`). On v7 the rule
+   still exists, so leave it untouched.
+
+## Migrate
+
 In every ESLint flat config (`eslint.config.{mjs,cjs,js,cts,ts,mts}`) that sets
 `@typescript-eslint/ban-types`, replace that single entry with the three rules
 above. The options do not map 1:1: if the old entry was just `'error'`/`'warn'`,

--- a/packages/eslint/src/migrations/update-23-1-0/remove-removed-typescript-eslint-extension-rules.spec.ts
+++ b/packages/eslint/src/migrations/update-23-1-0/remove-removed-typescript-eslint-extension-rules.spec.ts
@@ -1,13 +1,24 @@
 import 'nx/src/internal-testing-utils/mock-project-graph';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
-import { type Tree } from '@nx/devkit';
+import { type Tree, updateJson } from '@nx/devkit';
 import update from './remove-removed-typescript-eslint-extension-rules';
+
+function declareDevDependency(tree: Tree, pkg: string, version: string): void {
+  updateJson(tree, 'package.json', (json) => {
+    json.devDependencies = { ...json.devDependencies, [pkg]: version };
+    return json;
+  });
+}
 
 describe('remove-removed-typescript-eslint-extension-rules migration', () => {
   let tree: Tree;
 
   beforeEach(() => {
     tree = createTreeWithEmptyWorkspace();
+    // The migration only edits configs when typescript-eslint v8 is present, so
+    // declare it for the rule-editing tests. The version-gate tests below
+    // override this.
+    declareDevDependency(tree, 'typescript-eslint', '^8.0.0');
   });
 
   it('deletes removed formatting rules, renames safe semantic rules, and leaves ban-types for the prompt migration', async () => {
@@ -81,5 +92,55 @@ describe('remove-removed-typescript-eslint-extension-rules migration', () => {
     expect(tree.read('apps/app/eslint.config.mjs', 'utf-8')).not.toContain(
       '@typescript-eslint/semi'
     );
+  });
+
+  it('runs when only the scoped @typescript-eslint/eslint-plugin v8 is declared', async () => {
+    updateJson(tree, 'package.json', (json) => {
+      delete json.devDependencies['typescript-eslint'];
+      json.devDependencies['@typescript-eslint/eslint-plugin'] = '^8.0.0';
+      return json;
+    });
+    tree.write(
+      'eslint.config.mjs',
+      `export default [
+  { rules: { '@typescript-eslint/no-extra-semi': 'error' } },
+];
+`
+    );
+
+    await update(tree);
+
+    expect(tree.read('eslint.config.mjs', 'utf-8')).not.toContain(
+      '@typescript-eslint/no-extra-semi'
+    );
+  });
+
+  it('bails when typescript-eslint is absent', async () => {
+    updateJson(tree, 'package.json', (json) => {
+      delete json.devDependencies['typescript-eslint'];
+      return json;
+    });
+    const config = `export default [
+  { rules: { '@typescript-eslint/no-extra-semi': 'error' } },
+];
+`;
+    tree.write('eslint.config.mjs', config);
+
+    await update(tree);
+
+    expect(tree.read('eslint.config.mjs', 'utf-8')).toEqual(config);
+  });
+
+  it('bails when typescript-eslint is still on v7', async () => {
+    declareDevDependency(tree, 'typescript-eslint', '^7.16.1');
+    const config = `export default [
+  { rules: { '@typescript-eslint/no-extra-semi': 'error' } },
+];
+`;
+    tree.write('eslint.config.mjs', config);
+
+    await update(tree);
+
+    expect(tree.read('eslint.config.mjs', 'utf-8')).toEqual(config);
   });
 });

--- a/packages/eslint/src/migrations/update-23-1-0/remove-removed-typescript-eslint-extension-rules.ts
+++ b/packages/eslint/src/migrations/update-23-1-0/remove-removed-typescript-eslint-extension-rules.ts
@@ -1,4 +1,6 @@
 import { formatFiles, type Tree, visitNotIgnoredFiles } from '@nx/devkit';
+import { getDeclaredPackageVersion } from '@nx/devkit/internal';
+import { major } from 'semver';
 import * as ts from 'typescript';
 
 // Inlined rather than imported from the @nx/eslint utils so this migration stays
@@ -69,7 +71,25 @@ const RENAMED_TS_ESLINT_RULES = new Map([
   ],
 ]);
 
+// The stripped rules only disappear in typescript-eslint v8. On v7 (or with
+// typescript-eslint absent) they are still valid, so editing a config would
+// wrongly drop a live rule. Gate on the umbrella `typescript-eslint` or the
+// scoped `@typescript-eslint/eslint-plugin` (a workspace declares one or the
+// other); the migration's JSON `requires` cannot express that OR.
+function hasTypescriptEslintV8(tree: Tree): boolean {
+  return ['typescript-eslint', '@typescript-eslint/eslint-plugin'].some(
+    (pkg) => {
+      const version = getDeclaredPackageVersion(tree, pkg);
+      return version !== null && major(version) >= 8;
+    }
+  );
+}
+
 export default async function update(tree: Tree): Promise<void> {
+  if (!hasTypescriptEslintV8(tree)) {
+    return;
+  }
+
   let changed = false;
 
   visitNotIgnoredFiles(tree, '.', (path) => {


### PR DESCRIPTION
## Current Behavior

When migrating to Nx 23.1.0, the migrations that clean up `typescript-eslint` rules removed in v8 (the extension-rule codemod `remove-removed-typescript-eslint-extension-rules` and the `ban-types` prompt) only ran when the workspace declared the umbrella `typescript-eslint` package, because they were gated on it through `requires`. Workspaces that depend on the scoped `@typescript-eslint/*` packages instead never declare the umbrella, so both migrations were skipped. Their ESLint flat configs kept referencing rules that v8 removed (for example `@typescript-eslint/no-extra-semi`), which stops the flat config from loading and breaks the project graph.

## Expected Behavior

The migrations also run for workspaces that use only the scoped `@typescript-eslint/*` packages. `requires` cannot express an OR across the umbrella and scoped package names, so the gate is removed and the condition is checked inside each migration: the extension-rule codemod bails unless `typescript-eslint` or `@typescript-eslint/eslint-plugin` is on v8 or later, and the `ban-types` prompt performs the same check and exits early when no flat config references the rule.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/nx-23.1.0-beta-migration-b1195096)
<!-- polygraph-session-end -->