### PR TITLE
fix(angular): make nx migrate to Angular 22 leave a buildable workspace

### DIFF
--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -348,6 +348,15 @@
       "description": "Add the `trustProxyHeaders` option to `AngularNodeAppEngine` and `AngularAppEngine` instantiations in SSR server files, matching the Angular v22 `trust-proxy-headers` migration.",
       "factory": "./dist/src/migrations/update-23-1-0/add-trust-proxy-headers",
       "documentation": "./dist/src/migrations/update-23-1-0/add-trust-proxy-headers.md"
+    },
+    "update-23-1-0-add-angular-build": {
+      "version": "23.1.0-beta.0",
+      "requires": {
+        "@angular/core": ">=22.0.0"
+      },
+      "description": "Add `@angular/build` to `devDependencies` when a project uses the `@nx/angular:application` or `@nx/angular:unit-test` executor, or an `@angular/build:*` executor, and it is not already installed. These executors import `@angular/build` directly at runtime, but it has only ever been available transitively via `@angular-devkit/build-angular`, which is not reliable across package managers.",
+      "factory": "./dist/src/migrations/update-23-1-0/add-angular-build",
+      "documentation": "./dist/src/migrations/update-23-1-0/add-angular-build.md"
     }
   },
   "packageJsonUpdates": {

--- a/packages/angular/migrations.json
+++ b/packages/angular/migrations.json
@@ -357,6 +357,15 @@
       "description": "Add `@angular/build` to `devDependencies` when a project uses the `@nx/angular:application` or `@nx/angular:unit-test` executor, or an `@angular/build:*` executor, and it is not already installed. These executors import `@angular/build` directly at runtime, but it has only ever been available transitively via `@angular-devkit/build-angular`, which is not reliable across package managers.",
       "factory": "./dist/src/migrations/update-23-1-0/add-angular-build",
       "documentation": "./dist/src/migrations/update-23-1-0/add-angular-build.md"
+    },
+    "update-23-1-0-remove-conflicting-extended-diagnostics": {
+      "version": "23.1.0-beta.0",
+      "requires": {
+        "@angular/core": ">=22.0.0"
+      },
+      "description": "Remove the `extendedDiagnostics` Angular compiler option from tsconfig files where `strictTemplates` resolves to `false`. Angular v22's `strict-templates-default` and `strict-safe-navigation-narrow` migrations can together produce this combination, which the Angular compiler rejects (`extendedDiagnostics` requires `strictTemplates` to be enabled).",
+      "factory": "./dist/src/migrations/update-23-1-0/remove-conflicting-extended-diagnostics",
+      "documentation": "./dist/src/migrations/update-23-1-0/remove-conflicting-extended-diagnostics.md"
     }
   },
   "packageJsonUpdates": {

--- a/packages/angular/ng-package.json
+++ b/packages/angular/ng-package.json
@@ -11,6 +11,7 @@
     "@phenomnomnominal/tsquery",
     "@typescript-eslint/",
     "enquirer",
+    "jsonc-parser",
     "magic-string",
     "picocolors",
     "picomatch",

--- a/packages/angular/package.json
+++ b/packages/angular/package.json
@@ -81,6 +81,7 @@
     "@phenomnomnominal/tsquery": "catalog:typescript",
     "@typescript-eslint/type-utils": "catalog:eslint",
     "enquirer": "catalog:",
+    "jsonc-parser": "catalog:",
     "magic-string": "~0.30.2",
     "picocolors": "catalog:",
     "picomatch": "catalog:",

--- a/packages/angular/src/migrations/update-23-1-0/add-angular-build.md
+++ b/packages/angular/src/migrations/update-23-1-0/add-angular-build.md
@@ -1,0 +1,61 @@
+#### Add `@angular/build` When Used by an Executor
+
+The `@nx/angular:application` and `@nx/angular:unit-test` executors load the Angular builders by importing `@angular/build` directly, and any `@angular/build:*` executor is provided by that package, so `@angular/build` is a required runtime dependency for workspaces using those targets. Nothing declares it as a direct dependency, though: it has only ever been available transitively as a dependency of `@angular-devkit/build-angular`. That is not reliable (for example, under Yarn Berry it can be missing from `node_modules` even when `@angular-devkit/build-angular` is installed), and when `@angular/build` cannot be resolved the build fails with "This executor requires the package @angular/build to be installed". This migration adds `@angular/build` to `devDependencies` when a project uses one of those executors and it is not already installed, at the version the application generator installs. An existing version is preserved.
+
+Executor usage is detected on any target using `@nx/angular:application`, `@nx/angular:unit-test`, or an `@angular/build:*` executor. Targets that inherit their executor from an `nx.json` `targetDefaults` entry are detected too.
+
+#### Examples
+
+##### `project.json`
+
+Before:
+
+```jsonc {5}
+// project.json
+{
+  "targets": {
+    "build": {
+      "executor": "@nx/angular:application",
+      "options": {},
+    },
+  },
+}
+```
+
+After (`package.json`):
+
+```jsonc {4}
+// package.json
+{
+  "devDependencies": {
+    "@angular/build": "~22.0.4",
+  },
+}
+```
+
+##### `nx.json` (`targetDefaults`)
+
+A project whose `build` target inherits its executor from an `nx.json` `targetDefaults` entry is also detected:
+
+```jsonc {5}
+// nx.json
+{
+  "targetDefaults": {
+    "build": {
+      "executor": "@nx/angular:application",
+      "options": {},
+    },
+  },
+}
+```
+
+```jsonc
+// apps/app1/project.json
+{
+  "targets": {
+    "build": {},
+  },
+}
+```
+
+`@angular/build` is added to `package.json` as shown above.

--- a/packages/angular/src/migrations/update-23-1-0/add-angular-build.spec.ts
+++ b/packages/angular/src/migrations/update-23-1-0/add-angular-build.spec.ts
@@ -1,0 +1,161 @@
+import {
+  addProjectConfiguration,
+  readJson,
+  readNxJson,
+  updateJson,
+  updateNxJson,
+  type Tree,
+} from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { angularDevkitVersion } from '../../utils/versions';
+import migration from './add-angular-build';
+
+const angularBuildExecutors = [
+  '@nx/angular:application',
+  '@nx/angular:unit-test',
+  '@angular/build:application',
+  '@angular/build:dev-server',
+];
+
+describe('add-angular-build migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  function getAngularBuildVersion(): string | undefined {
+    return readJson(tree, 'package.json').devDependencies?.['@angular/build'];
+  }
+
+  test.each(angularBuildExecutors)(
+    'should add @angular/build when a target uses the "%s" executor',
+    async (executor) => {
+      addProjectConfiguration(tree, 'app1', {
+        root: 'apps/app1',
+        projectType: 'application',
+        targets: { build: { executor, options: {} } },
+      });
+
+      await migration(tree);
+
+      expect(getAngularBuildVersion()).toBe(angularDevkitVersion);
+    }
+  );
+
+  it('should detect the executor in a library project (no projectType gate)', async () => {
+    addProjectConfiguration(tree, 'lib1', {
+      root: 'libs/lib1',
+      projectType: 'library',
+      targets: { test: { executor: '@nx/angular:unit-test', options: {} } },
+    });
+
+    await migration(tree);
+
+    expect(getAngularBuildVersion()).toBe(angularDevkitVersion);
+  });
+
+  it('should not add @angular/build when no target uses a relevant executor', async () => {
+    addProjectConfiguration(tree, 'app1', {
+      root: 'apps/app1',
+      projectType: 'application',
+      targets: {
+        build: {
+          executor: '@angular-devkit/build-angular:browser',
+          options: {},
+        },
+      },
+    });
+
+    await migration(tree);
+
+    expect(getAngularBuildVersion()).toBeUndefined();
+  });
+
+  it('should bail out early when @angular/build is already a devDependency', async () => {
+    updateJson(tree, 'package.json', (json) => {
+      json.devDependencies = {
+        ...json.devDependencies,
+        '@angular/build': '~21.0.0',
+      };
+      return json;
+    });
+    addProjectConfiguration(tree, 'app1', {
+      root: 'apps/app1',
+      projectType: 'application',
+      targets: { build: { executor: '@nx/angular:application', options: {} } },
+    });
+
+    await migration(tree);
+
+    expect(getAngularBuildVersion()).toBe('~21.0.0');
+  });
+
+  it('should bail out early when @angular/build is already a dependency (not duplicated into devDependencies)', async () => {
+    updateJson(tree, 'package.json', (json) => {
+      json.dependencies = {
+        ...json.dependencies,
+        '@angular/build': '~21.0.0',
+      };
+      return json;
+    });
+    addProjectConfiguration(tree, 'app1', {
+      root: 'apps/app1',
+      projectType: 'application',
+      targets: { build: { executor: '@nx/angular:application', options: {} } },
+    });
+
+    await migration(tree);
+
+    const packageJson = readJson(tree, 'package.json');
+    expect(packageJson.dependencies['@angular/build']).toBe('~21.0.0');
+    expect(getAngularBuildVersion()).toBeUndefined();
+  });
+
+  describe('nx.json targetDefaults', () => {
+    it('should detect an executor inherited from a record-shaped targetDefault keyed by target name', async () => {
+      // A project `build` target with no executor inherits it from the default.
+      addProjectConfiguration(tree, 'app1', {
+        root: 'apps/app1',
+        projectType: 'application',
+        targets: { build: {} },
+      });
+      const nxJson = readNxJson(tree);
+      nxJson.targetDefaults = {
+        build: { executor: '@nx/angular:application', options: {} },
+      };
+      updateNxJson(tree, nxJson);
+
+      await migration(tree);
+
+      expect(getAngularBuildVersion()).toBe(angularDevkitVersion);
+    });
+
+    it('should detect a record-shaped targetDefault keyed by the executor', async () => {
+      const nxJson = readNxJson(tree);
+      nxJson.targetDefaults = {
+        '@angular/build:application': { options: {} },
+      };
+      updateNxJson(tree, nxJson);
+
+      await migration(tree);
+
+      expect(getAngularBuildVersion()).toBe(angularDevkitVersion);
+    });
+
+    it('should not add @angular/build when targetDefaults do not use a relevant executor', async () => {
+      const nxJson = readNxJson(tree);
+      nxJson.targetDefaults = {
+        build: {
+          executor: '@angular-devkit/build-angular:browser',
+          options: {},
+        },
+      };
+      updateNxJson(tree, nxJson);
+
+      await migration(tree);
+
+      expect(getAngularBuildVersion()).toBeUndefined();
+    });
+  });
+});

--- a/packages/angular/src/migrations/update-23-1-0/add-angular-build.ts
+++ b/packages/angular/src/migrations/update-23-1-0/add-angular-build.ts
@@ -1,0 +1,77 @@
+import {
+  addDependenciesToPackageJson,
+  getProjects,
+  readJson,
+  readNxJson,
+  type Tree,
+} from '@nx/devkit';
+import { angularDevkitVersion } from '../../utils/versions';
+
+// The `@nx/angular:application` and `@nx/angular:unit-test` executors import
+// `@angular/build` directly to run the Angular builders, and any
+// `@angular/build:*` executor is provided by that package; it is a required
+// runtime dependency for these targets. Nothing declares it as a direct
+// dependency, though: it has only ever been pulled in transitively via
+// `@angular-devkit/build-angular`, which isn't reliable (it can be absent from
+// node_modules, e.g. under Yarn Berry), so `require.resolve('@angular/build')`
+// fails and the build breaks. Add it as a direct dependency when an executor
+// needs it, at the version the application generator installs.
+const angularBuildExecutors = [
+  '@nx/angular:application',
+  '@nx/angular:unit-test',
+];
+
+function usesAngularBuild(executors: Array<string | undefined>): boolean {
+  return executors.some(
+    (e) =>
+      e != null &&
+      (angularBuildExecutors.includes(e) || e.startsWith('@angular/build:'))
+  );
+}
+
+export default async function (tree: Tree) {
+  // Already a direct dependency -> nothing to add.
+  const { dependencies, devDependencies } = readJson(tree, 'package.json');
+  if (dependencies?.['@angular/build'] || devDependencies?.['@angular/build']) {
+    return;
+  }
+
+  let needsAngularBuild = false;
+
+  // project.json targets
+  for (const [, project] of getProjects(tree)) {
+    needsAngularBuild = Object.values(project.targets ?? {}).some((target) =>
+      usesAngularBuild([target.executor])
+    );
+    if (needsAngularBuild) {
+      break;
+    }
+  }
+
+  // nx.json targetDefaults (keyed by target name or executor): a project's empty
+  // target can inherit the executor from a default.
+  if (!needsAngularBuild) {
+    const targetDefaults = readNxJson(tree)?.targetDefaults;
+    if (targetDefaults) {
+      needsAngularBuild = Object.entries(targetDefaults).some(
+        ([targetOrExecutor, config]) =>
+          // Mirror `add-istanbul-instrumenter`: the filtered array value form is
+          // out of scope; only plain object defaults carry an inheritable executor.
+          !Array.isArray(config) &&
+          usesAngularBuild([targetOrExecutor, config.executor])
+      );
+    }
+  }
+
+  if (!needsAngularBuild) {
+    return;
+  }
+
+  return addDependenciesToPackageJson(
+    tree,
+    {},
+    { '@angular/build': angularDevkitVersion },
+    undefined,
+    true
+  );
+}

--- a/packages/angular/src/migrations/update-23-1-0/remove-conflicting-extended-diagnostics.md
+++ b/packages/angular/src/migrations/update-23-1-0/remove-conflicting-extended-diagnostics.md
@@ -1,0 +1,37 @@
+#### Remove `extendedDiagnostics` When `strictTemplates` Is Disabled
+
+Angular v22 ships two `ng update` migrations that can leave a project's `tsconfig` in a state the Angular compiler rejects. `strict-templates-default` adds `"strictTemplates": false` to projects that had not enabled strict templates, and `strict-safe-navigation-narrow` adds an `extendedDiagnostics` block to every project `tsconfig`. The compiler requires `strictTemplates` to be enabled whenever `extendedDiagnostics` is configured, so the two together fail the build with "Using extendedDiagnostics requires that strictTemplates is also enabled".
+
+Because `@nx/angular` migrations run after Angular's, this migration reconciles the result: for any `tsconfig` where `strictTemplates` resolves to `false` (following the `extends` chain), it removes the `extendedDiagnostics` block. This keeps the intended `strictTemplates: false` behavior rather than enabling strict templates, which would change behavior and surface new template errors. Projects that keep `strictTemplates` enabled are left untouched.
+
+#### Examples
+
+##### `tsconfig.app.json`
+
+Before:
+
+```jsonc {3,10}
+// tsconfig.app.json
+{
+  "angularCompilerOptions": {
+    "extendedDiagnostics": {
+      "checks": {
+        "nullishCoalescingNotNullable": "suppress",
+        "optionalChainNotNullable": "suppress",
+      },
+    },
+    "strictTemplates": false,
+  },
+}
+```
+
+After:
+
+```jsonc {3}
+// tsconfig.app.json
+{
+  "angularCompilerOptions": {
+    "strictTemplates": false,
+  },
+}
+```

--- a/packages/angular/src/migrations/update-23-1-0/remove-conflicting-extended-diagnostics.spec.ts
+++ b/packages/angular/src/migrations/update-23-1-0/remove-conflicting-extended-diagnostics.spec.ts
@@ -1,0 +1,154 @@
+import { readJson, type Tree } from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migration from './remove-conflicting-extended-diagnostics';
+
+const extendedDiagnostics = {
+  checks: {
+    nullishCoalescingNotNullable: 'suppress',
+    optionalChainNotNullable: 'suppress',
+  },
+};
+
+describe('remove-conflicting-extended-diagnostics migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  function writeTsconfig(path: string, json: unknown): void {
+    tree.write(path, JSON.stringify(json, null, 2));
+  }
+
+  it('removes extendedDiagnostics when strictTemplates is false in the same file', async () => {
+    writeTsconfig('apps/app1/tsconfig.app.json', {
+      compilerOptions: { outDir: 'out' },
+      angularCompilerOptions: { extendedDiagnostics, strictTemplates: false },
+    });
+
+    await migration(tree);
+
+    const json = readJson(tree, 'apps/app1/tsconfig.app.json');
+    expect(json.angularCompilerOptions.extendedDiagnostics).toBeUndefined();
+    expect(json.angularCompilerOptions.strictTemplates).toBe(false);
+  });
+
+  it('keeps extendedDiagnostics when strictTemplates is true', async () => {
+    writeTsconfig('apps/app1/tsconfig.app.json', {
+      compilerOptions: { outDir: 'out' },
+      angularCompilerOptions: { extendedDiagnostics, strictTemplates: true },
+    });
+
+    await migration(tree);
+
+    const json = readJson(tree, 'apps/app1/tsconfig.app.json');
+    expect(json.angularCompilerOptions.extendedDiagnostics).toEqual(
+      extendedDiagnostics
+    );
+  });
+
+  it('keeps extendedDiagnostics when strictTemplates is unset (only explicit false conflicts)', async () => {
+    writeTsconfig('apps/app1/tsconfig.app.json', {
+      compilerOptions: { outDir: 'out' },
+      angularCompilerOptions: { extendedDiagnostics },
+    });
+
+    await migration(tree);
+
+    const json = readJson(tree, 'apps/app1/tsconfig.app.json');
+    expect(json.angularCompilerOptions.extendedDiagnostics).toEqual(
+      extendedDiagnostics
+    );
+  });
+
+  it('removes extendedDiagnostics when strictTemplates is false in an extended base', async () => {
+    writeTsconfig('tsconfig.base.json', {
+      compilerOptions: { strict: false },
+      angularCompilerOptions: { strictTemplates: false },
+    });
+    writeTsconfig('apps/app1/tsconfig.app.json', {
+      extends: '../../tsconfig.base.json',
+      compilerOptions: { outDir: 'out' },
+      angularCompilerOptions: { extendedDiagnostics },
+    });
+
+    await migration(tree);
+
+    const json = readJson(tree, 'apps/app1/tsconfig.app.json');
+    expect(json.angularCompilerOptions.extendedDiagnostics).toBeUndefined();
+  });
+
+  it('keeps extendedDiagnostics when an extended base enables strictTemplates', async () => {
+    writeTsconfig('tsconfig.base.json', {
+      compilerOptions: { strict: true },
+      angularCompilerOptions: { strictTemplates: true },
+    });
+    writeTsconfig('apps/app1/tsconfig.app.json', {
+      extends: '../../tsconfig.base.json',
+      compilerOptions: { outDir: 'out' },
+      angularCompilerOptions: { extendedDiagnostics },
+    });
+
+    await migration(tree);
+
+    const json = readJson(tree, 'apps/app1/tsconfig.app.json');
+    expect(json.angularCompilerOptions.extendedDiagnostics).toEqual(
+      extendedDiagnostics
+    );
+  });
+
+  it('prefers a local strictTemplates over an inherited one', async () => {
+    // Base disables strict templates, but the app re-enables them locally, so
+    // extendedDiagnostics is valid and must be kept.
+    writeTsconfig('tsconfig.base.json', {
+      compilerOptions: {},
+      angularCompilerOptions: { strictTemplates: false },
+    });
+    writeTsconfig('apps/app1/tsconfig.app.json', {
+      extends: '../../tsconfig.base.json',
+      compilerOptions: { outDir: 'out' },
+      angularCompilerOptions: { extendedDiagnostics, strictTemplates: true },
+    });
+
+    await migration(tree);
+
+    const json = readJson(tree, 'apps/app1/tsconfig.app.json');
+    expect(json.angularCompilerOptions.extendedDiagnostics).toEqual(
+      extendedDiagnostics
+    );
+  });
+
+  it('does not touch tsconfig files without extendedDiagnostics', async () => {
+    writeTsconfig('apps/app1/tsconfig.app.json', {
+      compilerOptions: { outDir: 'out' },
+      angularCompilerOptions: { strictTemplates: false },
+    });
+
+    await migration(tree);
+
+    const json = readJson(tree, 'apps/app1/tsconfig.app.json');
+    expect(json.angularCompilerOptions).toEqual({ strictTemplates: false });
+  });
+
+  it('only removes the conflicting blocks across multiple projects', async () => {
+    writeTsconfig('apps/conflicting/tsconfig.app.json', {
+      compilerOptions: { outDir: 'out' },
+      angularCompilerOptions: { extendedDiagnostics, strictTemplates: false },
+    });
+    writeTsconfig('apps/strict/tsconfig.app.json', {
+      compilerOptions: { outDir: 'out' },
+      angularCompilerOptions: { extendedDiagnostics, strictTemplates: true },
+    });
+
+    await migration(tree);
+
+    expect(
+      readJson(tree, 'apps/conflicting/tsconfig.app.json')
+        .angularCompilerOptions.extendedDiagnostics
+    ).toBeUndefined();
+    expect(
+      readJson(tree, 'apps/strict/tsconfig.app.json').angularCompilerOptions
+        .extendedDiagnostics
+    ).toEqual(extendedDiagnostics);
+  });
+});

--- a/packages/angular/src/migrations/update-23-1-0/remove-conflicting-extended-diagnostics.ts
+++ b/packages/angular/src/migrations/update-23-1-0/remove-conflicting-extended-diagnostics.ts
@@ -1,0 +1,161 @@
+import {
+  formatFiles,
+  logger,
+  type Tree,
+  visitNotIgnoredFiles,
+} from '@nx/devkit';
+import { basename, posix } from 'node:path';
+import {
+  applyEdits,
+  findNodeAtLocation,
+  getNodeValue,
+  modify,
+  parseTree,
+} from 'jsonc-parser';
+
+const FORMATTING_OPTIONS = {
+  formattingOptions: { keepLines: true, insertSpaces: true, tabSize: 2 },
+};
+
+// Angular v22's `strict-safe-navigation-narrow` migration adds an
+// `extendedDiagnostics` block to project tsconfigs unconditionally, while its
+// `strict-templates-default` migration pins `strictTemplates: false` on
+// workspaces that had not enabled strict templates. The Angular compiler rejects
+// that combination (it errors when `extendedDiagnostics` is set and
+// `strictTemplates` is `false`), so those projects fail to build. `@nx/angular`
+// migrations run after Angular's, so we reconcile it here: drop the
+// `extendedDiagnostics` block wherever `strictTemplates` resolves to `false`,
+// preserving the intended `strictTemplates: false` behavior (enabling strict
+// templates instead would change behavior and surface new template errors).
+export default async function (tree: Tree) {
+  let removedCount = 0;
+  visitNotIgnoredFiles(tree, '.', (filePath) => {
+    const name = basename(filePath);
+    if (!name.startsWith('tsconfig') || !name.endsWith('.json')) {
+      return;
+    }
+    if (removeConflictingExtendedDiagnostics(tree, filePath)) {
+      removedCount += 1;
+    }
+  });
+
+  if (removedCount > 0) {
+    logger.info(
+      `Removed the "extendedDiagnostics" Angular compiler option from ${removedCount} tsconfig file(s) where "strictTemplates" is disabled, resolving the conflict introduced by the Angular v22 template migrations.`
+    );
+  }
+
+  await formatFiles(tree);
+}
+
+function removeConflictingExtendedDiagnostics(
+  tree: Tree,
+  tsconfigPath: string
+): boolean {
+  const original = tree.read(tsconfigPath, 'utf-8');
+  if (!original) {
+    return false;
+  }
+
+  const root = parseTree(original);
+  if (!root || root.type !== 'object') {
+    return false;
+  }
+
+  // Only touch files that locally declare `extendedDiagnostics`; the Angular
+  // migration adds it to project tsconfigs, never to a shared base.
+  const extendedDiagnosticsNode = findNodeAtLocation(root, [
+    'angularCompilerOptions',
+    'extendedDiagnostics',
+  ]);
+  if (!extendedDiagnosticsNode) {
+    return false;
+  }
+
+  // The compiler errors only when the resolved `strictTemplates` is explicitly
+  // `false` (an unset value doesn't trigger it), so mirror that exact condition.
+  if (resolveStrictTemplates(tree, tsconfigPath) !== false) {
+    return false;
+  }
+
+  const edits = modify(
+    original,
+    ['angularCompilerOptions', 'extendedDiagnostics'],
+    undefined,
+    FORMATTING_OPTIONS
+  );
+  tree.write(tsconfigPath, applyEdits(original, edits));
+
+  return true;
+}
+
+// Resolves `angularCompilerOptions.strictTemplates` for a tsconfig, following
+// the `extends` chain (a local value wins over an inherited one). TypeScript
+// doesn't merge the non-standard `angularCompilerOptions`, so the chain is
+// traversed manually, matching how the Angular compiler resolves it.
+function resolveStrictTemplates(
+  tree: Tree,
+  tsconfigPath: string,
+  seen = new Set<string>()
+): boolean | undefined {
+  if (seen.has(tsconfigPath)) {
+    return undefined;
+  }
+  seen.add(tsconfigPath);
+
+  const content = tree.read(tsconfigPath, 'utf-8');
+  if (!content) {
+    return undefined;
+  }
+  const root = parseTree(content);
+  if (!root || root.type !== 'object') {
+    return undefined;
+  }
+
+  const localNode = findNodeAtLocation(root, [
+    'angularCompilerOptions',
+    'strictTemplates',
+  ]);
+  if (localNode) {
+    const value = getNodeValue(localNode);
+    return typeof value === 'boolean' ? value : undefined;
+  }
+
+  const extendsNode = findNodeAtLocation(root, ['extends']);
+  if (!extendsNode) {
+    return undefined;
+  }
+  const extendsValue = getNodeValue(extendsNode);
+  // `extends` can be a single path or an ordered array (later entries win).
+  const parents = Array.isArray(extendsValue)
+    ? [...extendsValue].reverse()
+    : [extendsValue];
+  for (const parent of parents) {
+    const parentPath = resolveExtendsPath(tree, tsconfigPath, parent);
+    if (!parentPath) {
+      continue;
+    }
+    const resolved = resolveStrictTemplates(tree, parentPath, seen);
+    if (resolved !== undefined) {
+      return resolved;
+    }
+  }
+
+  return undefined;
+}
+
+// Resolves a relative `extends` target to a workspace path within the tree.
+// Package/`node_modules` bases (which never carry the migration's output) are
+// skipped by returning null.
+function resolveExtendsPath(
+  tree: Tree,
+  tsconfigPath: string,
+  extendsValue: unknown
+): string | null {
+  if (typeof extendsValue !== 'string' || !extendsValue.startsWith('.')) {
+    return null;
+  }
+  const base = posix.join(posix.dirname(tsconfigPath), extendsValue);
+  const candidates = base.endsWith('.json') ? [base] : [base, `${base}.json`];
+  return candidates.find((candidate) => tree.exists(candidate)) ?? null;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2370,6 +2370,9 @@ importers:
       enquirer:
         specifier: 'catalog:'
         version: 2.3.6
+      jsonc-parser:
+        specifier: 'catalog:'
+        version: 3.3.1
       magic-string:
         specifier: ~0.30.2
         version: 0.30.17


### PR DESCRIPTION
## Current Behavior

Migrating an Angular workspace to Angular 22 with `nx migrate` can leave projects that fail to build:

- Projects using the `@nx/angular:application` or `@nx/angular:unit-test` executor, or an `@angular/build:*` executor, fail with "This executor requires the package @angular/build to be installed". Those executors load `@angular/build` directly, but nothing declares it as a direct dependency; it was only ever present transitively through `@angular-devkit/build-angular`, which is not reliable across package managers (under Yarn Berry it can be absent from `node_modules` entirely).
- Angular's own `strict-templates-default` and `strict-safe-navigation-narrow` migrations can together leave a project `tsconfig` with `strictTemplates: false` and an `extendedDiagnostics` block. The Angular compiler rejects that combination with "Using extendedDiagnostics requires that strictTemplates is also enabled".

## Expected Behavior

`nx migrate` leaves a buildable workspace:

- `@angular/build` is added as a direct dependency when a project uses an executor that requires it and it is not already declared, at the version the application generator installs. An existing dependency is left untouched.
- Where `strictTemplates` resolves to `false`, the conflicting `extendedDiagnostics` block is removed (keeping `strictTemplates: false`), so the compiler accepts the configuration. Projects that keep strict templates enabled are untouched.

## Implementation Details

Two deterministic `@nx/angular` migrations under `update-23-1-0`:

- `add-angular-build`: early-bails if `@angular/build` is already declared; otherwise scans project targets and `nx.json` `targetDefaults` for the executors that require it. Mirrors the existing `add-istanbul-instrumenter` migration.
- `remove-conflicting-extended-diagnostics`: runs after Angular's schematics; scans every `tsconfig*.json` and removes `extendedDiagnostics` where `strictTemplates` resolves to `false` (following the `extends` chain), editing via `jsonc-parser` to preserve formatting. Removing the block preserves the intended `strictTemplates: false` behavior; enabling strict templates instead would change behavior and surface new template errors.

The `extendedDiagnostics`/`strictTemplates` conflict originates in Angular's v22 `ng update` schematics and reproduces without nx; an upstream report is planned. This migration reconciles the result so `nx migrate` completes cleanly.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/nx-23.1.0-beta-migration-b1195096)
<!-- polygraph-session-end -->