### PR TITLE
fix(js): prevent Windows TS6059 rootDir errors in tsc builds

### DIFF
--- a/packages/js/src/executors/tsc/tsc.impl.spec.ts
+++ b/packages/js/src/executors/tsc/tsc.impl.spec.ts
@@ -80,6 +80,18 @@ describe('tscExecutor', () => {
         rootDir: '/root/libs/ui/src',
       });
     });
+
+    it('should keep the Windows drive letter in rootDir and tsConfig', () => {
+      const result = createTypeScriptCompilationOptions(
+        normalizeOptions(testOptions, 'C:\\root', 'libs/ui/src', 'libs/ui'),
+        context
+      );
+
+      expect(result).toMatchObject({
+        rootDir: 'C:/root/libs/ui',
+        tsConfig: 'C:/root/libs/ui/tsconfig.json',
+      });
+    });
   });
 });
 

--- a/packages/js/src/executors/tsc/tsc.impl.ts
+++ b/packages/js/src/executors/tsc/tsc.impl.ts
@@ -71,8 +71,12 @@ export function createTypeScriptCompilationOptions(
     outputPath: joinPathFragments(normalizedOptions.outputPath),
     projectName: context.projectName,
     projectRoot: normalizedOptions.projectRoot,
-    rootDir: joinPathFragments(normalizedOptions.rootDir),
-    tsConfig: joinPathFragments(normalizedOptions.tsConfig),
+    // Keep the Windows drive letter on rootDir/tsConfig (only forward-slash them).
+    // joinPathFragments strips it via normalizePath, leaving them drive-less while
+    // the generated path mappings stay absolute drive-full, so alias-resolved files
+    // fail TypeScript's rootDir containment check (TS6059) on Windows.
+    rootDir: normalizedOptions.rootDir.replace(/\\/g, '/'),
+    tsConfig: normalizedOptions.tsConfig.replace(/\\/g, '/'),
     watch: normalizedOptions.watch,
     deleteOutputPath: normalizedOptions.clean,
     getCustomTransformers: getCustomTrasformersFactory(


### PR DESCRIPTION
## Current Behavior

Since 22.7.0-beta.13, building a library on Windows with `@nx/js:tsc` fails with TS6059 when a source file is reached through a workspace path alias. The alias-resolved file keeps its drive letter (`C:/...`) while `rootDir` does not (`/...`), so TypeScript treats the file as outside `rootDir`. macOS and Linux are unaffected.

## Expected Behavior

`@nx/js:tsc` builds on Windows succeed when source files are reached through workspace path aliases.

## Implementation Details

`createTypeScriptCompilationOptions` normalized `rootDir` and the tsConfig path with `joinPathFragments`, which strips the Windows drive letter, while the generated tmp tsconfig path mappings are absolute and keep the drive. Alias-resolved files therefore landed outside the drive-less `rootDir`. Both values now forward-slash without dropping the drive, so they line up with the drive-full mappings and TypeScript's `rootDir` containment check passes. macOS and Linux output is unchanged.

## Related Issue(s)

Fixes #35696

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/gh-35696-0e57c35b)
<!-- polygraph-session-end -->