### PR TITLE
fix(testing): disable justInTimeCompile for webpack Cypress component testing

### DIFF
--- a/packages/angular/src/generators/cypress-component-configuration/cypress-component-configuration.spec.ts
+++ b/packages/angular/src/generators/cypress-component-configuration/cypress-component-configuration.spec.ts
@@ -452,6 +452,50 @@ describe('Cypress Component Testing Configuration', () => {
     ).toMatchSnapshot('component.ts');
   });
 
+  it('should disable justInTimeCompile on Cypress 14+', async () => {
+    mockedInstalledCypressVersion.mockReturnValue(14);
+    await generateTestLibrary(tree, { directory: 'my-lib', skipFormat: true });
+    await setup(tree, {
+      project: 'my-lib',
+      name: 'something',
+      standalone: false,
+    });
+    projectGraph = {
+      nodes: {
+        something: {
+          name: 'something',
+          type: 'app',
+          data: { ...readProjectConfiguration(tree, 'something') } as any,
+        },
+        'my-lib': {
+          name: 'my-lib',
+          type: 'lib',
+          data: { ...readProjectConfiguration(tree, 'my-lib') } as any,
+        },
+      },
+      dependencies: {
+        'my-lib': [
+          {
+            type: DependencyType.static,
+            source: 'my-lib',
+            target: 'something',
+          },
+        ],
+      },
+    };
+
+    await cypressComponentConfiguration(tree, {
+      project: 'my-lib',
+      buildTarget: 'something:build',
+      generateTests: false,
+      skipFormat: true,
+    });
+
+    const config = tree.read('my-lib/cypress.config.ts', 'utf-8');
+    expect(config).toContain('...nxComponentTestingPreset(__filename)');
+    expect(config).toContain('justInTimeCompile: false');
+  });
+
   it('should work with simple components', async () => {
     updateJson(tree, 'package.json', (json) => {
       json.dependencies = {

--- a/packages/angular/src/generators/cypress-component-configuration/cypress-component-configuration.ts
+++ b/packages/angular/src/generators/cypress-component-configuration/cypress-component-configuration.ts
@@ -234,9 +234,11 @@ async function configureCypressCT(
     ctConfigOptions.buildTarget = found.target;
   }
 
-  const { addDefaultCTConfig, getProjectCypressConfigPath } = <
-    typeof import('@nx/cypress/internal')
-  >require('@nx/cypress/internal');
+  const {
+    addDefaultCTConfig,
+    getProjectCypressConfigPath,
+    getInstalledCypressMajorVersion,
+  } = <typeof import('@nx/cypress/internal')>require('@nx/cypress/internal');
   const cypressConfigPath = getProjectCypressConfigPath(
     tree,
     projectConfig.root
@@ -244,7 +246,8 @@ async function configureCypressCT(
   const updatedCyConfig = await addDefaultCTConfig(
     tree.read(cypressConfigPath, 'utf-8'),
     ctConfigOptions,
-    '@nx/angular/plugins/component-testing'
+    '@nx/angular/plugins/component-testing',
+    getInstalledCypressMajorVersion(tree)
   );
   tree.write(cypressConfigPath, updatedCyConfig);
 }

--- a/packages/cypress/migrations.json
+++ b/packages/cypress/migrations.json
@@ -59,7 +59,8 @@
         "cypress": ">=14.0.0"
       },
       "description": "Set `justInTimeCompile: false` in webpack component testing Cypress configs on Cypress 14+, where it defaults to true and can intermittently run 0 tests in CI.",
-      "implementation": "./dist/src/migrations/update-23-1-0/disable-webpack-ct-just-in-time-compile"
+      "implementation": "./dist/src/migrations/update-23-1-0/disable-webpack-ct-just-in-time-compile",
+      "documentation": "./dist/src/migrations/update-23-1-0/disable-webpack-ct-just-in-time-compile.md"
     }
   },
   "packageJsonUpdates": {

--- a/packages/cypress/migrations.json
+++ b/packages/cypress/migrations.json
@@ -52,6 +52,14 @@
       "description": "Rename imports of `createNodesV2` from `@nx/cypress/plugin` to the canonical `createNodes` export.",
       "implementation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes",
       "documentation": "./dist/src/migrations/update-23-0-0/migrate-create-nodes-v2-to-create-nodes.md"
+    },
+    "disable-webpack-ct-just-in-time-compile": {
+      "version": "23.1.0-beta.6",
+      "requires": {
+        "cypress": ">=14.0.0"
+      },
+      "description": "Set `justInTimeCompile: false` in webpack component testing Cypress configs on Cypress 14+, where it defaults to true and can intermittently run 0 tests in CI.",
+      "implementation": "./dist/src/migrations/update-23-1-0/disable-webpack-ct-just-in-time-compile"
     }
   },
   "packageJsonUpdates": {

--- a/packages/cypress/src/migrations/update-23-1-0/disable-webpack-ct-just-in-time-compile.md
+++ b/packages/cypress/src/migrations/update-23-1-0/disable-webpack-ct-just-in-time-compile.md
@@ -1,0 +1,38 @@
+#### Disable `justInTimeCompile` for webpack component testing
+
+Cypress 14+ defaults `justInTimeCompile` to `true` for the webpack dev server, compiling each spec on demand. In run mode the runner can load a component test before its spec finishes compiling, so the spec executes 0 tests while the run still exits green - a false pass that hides broken component tests in CI.
+
+This migration sets an explicit `justInTimeCompile: false` in the Cypress configs of webpack component testing projects, keeping the choice visible and reversible. Remove the line to opt back into just-in-time compilation.
+
+#### Sample Code Changes
+
+##### Before
+
+```ts title="apps/my-app/cypress.config.ts"
+import { defineConfig } from 'cypress';
+import { nxComponentTestingPreset } from '@nx/react/plugins/component-testing';
+
+export default defineConfig({
+  component: nxComponentTestingPreset(__filename),
+});
+```
+
+##### After
+
+```ts title="apps/my-app/cypress.config.ts"
+import { defineConfig } from 'cypress';
+import { nxComponentTestingPreset } from '@nx/react/plugins/component-testing';
+
+export default defineConfig({
+  component: {
+    ...nxComponentTestingPreset(__filename),
+    // Cypress 14+ defaults justInTimeCompile to true (webpack only), which can
+    // intermittently run 0 tests in CI. Remove this line to opt back in.
+    justInTimeCompile: false,
+  },
+});
+```
+
+#### What is not changed
+
+`justInTimeCompile` only applies to the webpack dev server, so vite-based component testing is left untouched. This migration skips vite configs (including `@nx/remix`, which uses the vite dev server), configs that already set `justInTimeCompile`, and e2e-only configs.

--- a/packages/cypress/src/migrations/update-23-1-0/disable-webpack-ct-just-in-time-compile.spec.ts
+++ b/packages/cypress/src/migrations/update-23-1-0/disable-webpack-ct-just-in-time-compile.spec.ts
@@ -1,0 +1,228 @@
+import {
+  addProjectConfiguration,
+  type ProjectConfiguration,
+  type Tree,
+} from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import migration from './disable-webpack-ct-just-in-time-compile';
+
+function addCypressProject(tree: Tree, name: string, config: string): string {
+  const root = `apps/${name}`;
+  const cypressConfigPath = `${root}/cypress.config.ts`;
+  const project: ProjectConfiguration = {
+    root,
+    projectType: 'application',
+    targets: {
+      'component-test': {
+        executor: '@nx/cypress:cypress',
+        options: { cypressConfig: cypressConfigPath, testingType: 'component' },
+      },
+    },
+  };
+  addProjectConfiguration(tree, name, project);
+  tree.write(cypressConfigPath, config);
+  return cypressConfigPath;
+}
+
+describe('disable-webpack-ct-just-in-time-compile', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('should set justInTimeCompile:false for a webpack preset config', async () => {
+    const configPath = addCypressProject(
+      tree,
+      'app',
+      `import { defineConfig } from 'cypress';
+import { nxComponentTestingPreset } from '@nx/react/plugins/component-testing';
+
+export default defineConfig({
+  component: nxComponentTestingPreset(__filename),
+});
+`
+    );
+
+    await migration(tree);
+
+    const updated = tree.read(configPath, 'utf-8');
+    expect(updated).toContain('...nxComponentTestingPreset(__filename)');
+    expect(updated).toContain('justInTimeCompile: false');
+  });
+
+  it('should set justInTimeCompile:false for an angular preset config', async () => {
+    const configPath = addCypressProject(
+      tree,
+      'ng-app',
+      `import { defineConfig } from 'cypress';
+import { nxComponentTestingPreset } from '@nx/angular/plugins/component-testing';
+
+export default defineConfig({
+  component: nxComponentTestingPreset(__filename),
+});
+`
+    );
+
+    await migration(tree);
+
+    expect(tree.read(configPath, 'utf-8')).toContain(
+      'justInTimeCompile: false'
+    );
+  });
+
+  it('should set justInTimeCompile:false for an inline webpack devServer config', async () => {
+    const configPath = addCypressProject(
+      tree,
+      'inline',
+      `import { defineConfig } from 'cypress';
+
+export default defineConfig({
+  component: {
+    devServer: {
+      framework: 'react',
+      bundler: 'webpack',
+    },
+  },
+});
+`
+    );
+
+    await migration(tree);
+
+    const updated = tree.read(configPath, 'utf-8');
+    expect(updated).toContain('justInTimeCompile: false');
+    expect(updated).toContain("framework: 'react'");
+  });
+
+  it('should not touch a vite bundler config', async () => {
+    const configPath = addCypressProject(
+      tree,
+      'vite-app',
+      `import { defineConfig } from 'cypress';
+import { nxComponentTestingPreset } from '@nx/react/plugins/component-testing';
+
+export default defineConfig({
+  component: nxComponentTestingPreset(__filename, { bundler: 'vite' }),
+});
+`
+    );
+
+    await migration(tree);
+
+    expect(tree.read(configPath, 'utf-8')).not.toContain('justInTimeCompile');
+  });
+
+  it('should not touch a remix (vite) preset config', async () => {
+    const configPath = addCypressProject(
+      tree,
+      'remix-app',
+      `import { defineConfig } from 'cypress';
+import { nxComponentTestingPreset } from '@nx/remix/plugins/component-testing';
+
+export default defineConfig({
+  component: nxComponentTestingPreset(__filename),
+});
+`
+    );
+
+    await migration(tree);
+
+    expect(tree.read(configPath, 'utf-8')).not.toContain('justInTimeCompile');
+  });
+
+  it('should not touch a config that already sets justInTimeCompile', async () => {
+    const original = `import { defineConfig } from 'cypress';
+import { nxComponentTestingPreset } from '@nx/react/plugins/component-testing';
+
+export default defineConfig({
+  component: {
+    ...nxComponentTestingPreset(__filename),
+    justInTimeCompile: true,
+  },
+});
+`;
+    const configPath = addCypressProject(tree, 'opted-in', original);
+
+    await migration(tree);
+
+    expect(tree.read(configPath, 'utf-8')).toBe(original);
+    expect(tree.read(configPath, 'utf-8')).not.toContain(
+      'justInTimeCompile: false'
+    );
+  });
+
+  it('should not touch an e2e-only config', async () => {
+    const original = `import { defineConfig } from 'cypress';
+import { nxE2EPreset } from '@nx/cypress/plugins/cypress-preset';
+
+export default defineConfig({
+  e2e: nxE2EPreset(__filename),
+});
+`;
+    const configPath = addCypressProject(tree, 'e2e-app', original);
+
+    await migration(tree);
+
+    expect(tree.read(configPath, 'utf-8')).toBe(original);
+  });
+
+  it('should preserve comments when migrating an inline config', async () => {
+    const configPath = addCypressProject(
+      tree,
+      'commented',
+      `import { defineConfig } from 'cypress';
+
+export default defineConfig({
+  component: {
+    // keep the viewport small for component tests
+    viewportWidth: 500,
+    devServer: {
+      framework: 'react',
+      bundler: 'webpack',
+    },
+  },
+});
+`
+    );
+
+    await migration(tree);
+
+    const updated = tree.read(configPath, 'utf-8');
+    expect(updated).toContain('justInTimeCompile: false');
+    expect(updated).toContain('// keep the viewport small for component tests');
+    expect(updated).toContain('viewportWidth: 500');
+  });
+
+  it('should not touch a component that does not use the preset (stale import)', async () => {
+    const original = `import { defineConfig } from 'cypress';
+import { nxComponentTestingPreset } from '@nx/react/plugins/component-testing';
+
+export default defineConfig({
+  component: {
+    specPattern: 'src/**/*.cy.tsx',
+  },
+});
+`;
+    const configPath = addCypressProject(tree, 'stale-custom', original);
+
+    await migration(tree);
+
+    expect(tree.read(configPath, 'utf-8')).toBe(original);
+  });
+
+  it('should not corrupt an empty component object with a stale preset import', async () => {
+    const original = `import { defineConfig } from 'cypress';
+import { nxComponentTestingPreset } from '@nx/react/plugins/component-testing';
+
+export default defineConfig({
+  component: {},
+});
+`;
+    const configPath = addCypressProject(tree, 'stale-empty', original);
+
+    await migration(tree);
+
+    expect(tree.read(configPath, 'utf-8')).toBe(original);
+  });
+});

--- a/packages/cypress/src/migrations/update-23-1-0/disable-webpack-ct-just-in-time-compile.spec.ts
+++ b/packages/cypress/src/migrations/update-23-1-0/disable-webpack-ct-just-in-time-compile.spec.ts
@@ -24,6 +24,15 @@ function addCypressProject(tree: Tree, name: string, config: string): string {
   return cypressConfigPath;
 }
 
+function expectValidTypeScript(content: string): void {
+  const ts = require('typescript');
+  const { diagnostics } = ts.transpileModule(content, {
+    reportDiagnostics: true,
+    compilerOptions: {},
+  });
+  expect(diagnostics ?? []).toEqual([]);
+}
+
 describe('disable-webpack-ct-just-in-time-compile', () => {
   let tree: Tree;
 
@@ -224,5 +233,71 @@ export default defineConfig({
     await migration(tree);
 
     expect(tree.read(configPath, 'utf-8')).toBe(original);
+  });
+
+  it('should keep valid syntax when the last property has no trailing comma before a comment', async () => {
+    const configPath = addCypressProject(
+      tree,
+      'trailing-comment',
+      `import { defineConfig } from 'cypress';
+
+export default defineConfig({
+  component: {
+    devServer: {
+      framework: 'react',
+      bundler: 'webpack'
+    }
+    // keep the webpack devServer settings above
+  },
+});
+`
+    );
+
+    await migration(tree);
+
+    const updated = tree.read(configPath, 'utf-8');
+    expect(updated).toContain('justInTimeCompile: false');
+    expect(updated).toContain('// keep the webpack devServer settings above');
+    expectValidTypeScript(updated);
+  });
+
+  it('should migrate a webpack preset config even when a stale remix preset path appears elsewhere', async () => {
+    const configPath = addCypressProject(
+      tree,
+      'stale-remix',
+      `import { defineConfig } from 'cypress';
+import { nxComponentTestingPreset } from '@nx/react/plugins/component-testing';
+// migrated from '@nx/remix/plugins/component-testing'
+
+export default defineConfig({
+  component: nxComponentTestingPreset(__filename),
+});
+`
+    );
+
+    await migration(tree);
+
+    const updated = tree.read(configPath, 'utf-8');
+    expect(updated).toContain('...nxComponentTestingPreset(__filename)');
+    expect(updated).toContain('justInTimeCompile: false');
+  });
+
+  it('should set justInTimeCompile:false for a CommonJS require-based preset config', async () => {
+    const configPath = addCypressProject(
+      tree,
+      'cjs-app',
+      `const { nxComponentTestingPreset } = require('@nx/react/plugins/component-testing');
+const { defineConfig } = require('cypress');
+module.exports = defineConfig({
+  component: nxComponentTestingPreset(__filename),
+});
+`
+    );
+
+    await migration(tree);
+
+    const updated = tree.read(configPath, 'utf-8');
+    expect(updated).toContain('...nxComponentTestingPreset(__filename)');
+    expect(updated).toContain('justInTimeCompile: false');
   });
 });

--- a/packages/cypress/src/migrations/update-23-1-0/disable-webpack-ct-just-in-time-compile.ts
+++ b/packages/cypress/src/migrations/update-23-1-0/disable-webpack-ct-just-in-time-compile.ts
@@ -2,22 +2,15 @@ import { formatFiles, type Tree } from '@nx/devkit';
 import { ensureTypescript } from '@nx/js/internal';
 import { query } from '@phenomnomnominal/tsquery';
 import type { CallExpression, PropertyAssignment } from 'typescript';
-import { resolveCypressConfigObject } from '../../utils/config';
+import {
+  JIT_COMPILE_DISABLE_COMMENT,
+  resolveCypressConfigObject,
+} from '../../utils/config';
 import {
   cypressProjectConfigs,
   getObjectProperty,
 } from '../../utils/migrations';
 
-const JIT_COMMENT = [
-  '// Cypress 14+ defaults justInTimeCompile to true (webpack only), which can',
-  '// intermittently run 0 tests in CI. Remove this line to opt back in.',
-];
-
-const NX_WEBPACK_CT_PRESETS = [
-  '@nx/angular/plugins/component-testing',
-  '@nx/react/plugins/component-testing',
-  '@nx/next/plugins/component-testing',
-];
 // @nx/remix component testing uses the vite dev server, so justInTimeCompile
 // (webpack only) does not apply even though the preset takes no bundler option.
 const NX_VITE_CT_PRESET = '@nx/remix/plugins/component-testing';
@@ -40,7 +33,7 @@ export default async function disableWebpackCtJustInTimeCompile(tree: Tree) {
     const component = getObjectProperty(config, 'component');
     if (
       !component ||
-      !isWebpackComponentTesting(contents, component) ||
+      !isWebpackComponentTesting(component) ||
       setsJustInTimeCompile(component)
     ) {
       continue;
@@ -55,10 +48,7 @@ export default async function disableWebpackCtJustInTimeCompile(tree: Tree) {
   }
 }
 
-function isWebpackComponentTesting(
-  contents: string,
-  component: PropertyAssignment
-): boolean {
+function isWebpackComponentTesting(component: PropertyAssignment): boolean {
   ts ??= ensureTypescript();
 
   // A vite bundler (inline devServer or preset options) opts out.
@@ -75,8 +65,9 @@ function isWebpackComponentTesting(
   // Preset-based config: trust it only when `component` actually calls
   // nxComponentTestingPreset, so a stale/unused preset import doesn't count.
   if (usesNxComponentTestingPreset(component)) {
-    // @nx/remix is the only vite-based Nx CT preset.
-    return getNxCtPreset(contents) !== NX_VITE_CT_PRESET;
+    // @nx/remix is the only vite-based Nx CT preset; resolve the import bound
+    // to the call so an unrelated remix reference elsewhere can't misclassify.
+    return getComponentTestingPresetImport(component) !== NX_VITE_CT_PRESET;
   }
 
   // Hand-written config: migrate only when it has an inline devServer framework.
@@ -118,13 +109,58 @@ function getComponentProperty(
   );
 }
 
-function getNxCtPreset(contents: string): string | null {
-  if (contents.includes(NX_VITE_CT_PRESET)) {
-    return NX_VITE_CT_PRESET;
+// Resolves the module specifier that binds the `nxComponentTestingPreset`
+// identifier used inside `component`, covering both ESM `import` and CJS
+// `require` cypress configs. Returns null when no such binding is found.
+function getComponentTestingPresetImport(
+  component: PropertyAssignment
+): string | null {
+  ts ??= ensureTypescript();
+
+  for (const statement of component.getSourceFile().statements) {
+    if (ts.isImportDeclaration(statement) && statement.importClause) {
+      const namedBindings = statement.importClause.namedBindings;
+      if (
+        namedBindings &&
+        ts.isNamedImports(namedBindings) &&
+        ts.isStringLiteral(statement.moduleSpecifier) &&
+        namedBindings.elements.some(
+          (element) => element.name.text === 'nxComponentTestingPreset'
+        )
+      ) {
+        return statement.moduleSpecifier.text;
+      }
+    }
+
+    if (ts.isVariableStatement(statement)) {
+      for (const declaration of statement.declarationList.declarations) {
+        const initializer = declaration.initializer;
+        if (
+          !initializer ||
+          !ts.isCallExpression(initializer) ||
+          !ts.isIdentifier(initializer.expression) ||
+          initializer.expression.text !== 'require' ||
+          !ts.isObjectBindingPattern(declaration.name)
+        ) {
+          continue;
+        }
+        const moduleSpecifier = initializer.arguments[0];
+        if (
+          moduleSpecifier &&
+          ts.isStringLiteral(moduleSpecifier) &&
+          declaration.name.elements.some(
+            (element) =>
+              ts.isIdentifier(element.name) &&
+              element.name.text === 'nxComponentTestingPreset'
+          )
+        ) {
+          return moduleSpecifier.text;
+        }
+      }
+    }
   }
-  return (
-    NX_WEBPACK_CT_PRESETS.find((preset) => contents.includes(preset)) ?? null
-  );
+
+  return null;
 }
 
 function setsJustInTimeCompile(component: PropertyAssignment): boolean {
@@ -138,29 +174,35 @@ function addJustInTimeCompile(
   ts ??= ensureTypescript();
 
   const indent = '    ';
-  const comment = JIT_COMMENT.map((line) => `${indent}${line}`).join('\n');
+  const comment = JIT_COMPILE_DISABLE_COMMENT.map(
+    (line) => `${indent}${line}`
+  ).join('\n');
   const newProperty = `${comment}\n${indent}justInTimeCompile: false,`;
   const initializer = component.initializer;
 
-  let componentValue: string;
+  // Object literal: insert the property after the last existing one, leaving
+  // the surrounding source (comments, formatting) untouched. `component` is
+  // gated to be non-empty before we reach here.
   if (ts.isObjectLiteralExpression(initializer)) {
-    if (initializer.properties.length === 0) {
-      componentValue = `{\n${newProperty}\n  }`;
-    } else {
-      // Preserve the existing object text (including comments) and insert the
-      // new property before the closing brace.
-      const objectText = contents.slice(
-        initializer.getStart(),
-        initializer.getEnd()
-      );
-      const beforeClose = objectText.replace(/\s*}$/, '');
-      const separator = /,\s*$/.test(beforeClose) ? '' : ',';
-      componentValue = `${beforeClose}${separator}\n${newProperty}\n  }`;
+    const properties = initializer.properties;
+    const lastProperty = properties[properties.length - 1];
+    let insertAt = lastProperty.getEnd();
+    if (properties.hasTrailingComma) {
+      // Insert after the existing trailing comma, not before it.
+      const commaIndex = contents.indexOf(',', insertAt);
+      if (commaIndex !== -1) {
+        insertAt = commaIndex + 1;
+      }
     }
-  } else {
-    componentValue = `{\n${indent}...${initializer.getText()},\n${newProperty}\n  }`;
+    const separator = properties.hasTrailingComma ? '' : ',';
+    return `${contents.slice(
+      0,
+      insertAt
+    )}${separator}\n${newProperty}${contents.slice(insertAt)}`;
   }
 
+  // Preset call (or any other expression): wrap it in an object and spread.
+  const componentValue = `{\n${indent}...${initializer.getText()},\n${newProperty}\n  }`;
   return `${contents.slice(
     0,
     component.getStart()

--- a/packages/cypress/src/migrations/update-23-1-0/disable-webpack-ct-just-in-time-compile.ts
+++ b/packages/cypress/src/migrations/update-23-1-0/disable-webpack-ct-just-in-time-compile.ts
@@ -1,0 +1,168 @@
+import { formatFiles, type Tree } from '@nx/devkit';
+import { ensureTypescript } from '@nx/js/internal';
+import { query } from '@phenomnomnominal/tsquery';
+import type { CallExpression, PropertyAssignment } from 'typescript';
+import { resolveCypressConfigObject } from '../../utils/config';
+import {
+  cypressProjectConfigs,
+  getObjectProperty,
+} from '../../utils/migrations';
+
+const JIT_COMMENT = [
+  '// Cypress 14+ defaults justInTimeCompile to true (webpack only), which can',
+  '// intermittently run 0 tests in CI. Remove this line to opt back in.',
+];
+
+const NX_WEBPACK_CT_PRESETS = [
+  '@nx/angular/plugins/component-testing',
+  '@nx/react/plugins/component-testing',
+  '@nx/next/plugins/component-testing',
+];
+// @nx/remix component testing uses the vite dev server, so justInTimeCompile
+// (webpack only) does not apply even though the preset takes no bundler option.
+const NX_VITE_CT_PRESET = '@nx/remix/plugins/component-testing';
+
+let ts: typeof import('typescript');
+
+export default async function disableWebpackCtJustInTimeCompile(tree: Tree) {
+  let wereProjectsMigrated = false;
+  for await (const { cypressConfigPath } of cypressProjectConfigs(tree)) {
+    if (!tree.exists(cypressConfigPath)) {
+      continue;
+    }
+
+    const contents = tree.read(cypressConfigPath, 'utf-8');
+    const config = resolveCypressConfigObject(contents);
+    if (!config) {
+      continue;
+    }
+
+    const component = getObjectProperty(config, 'component');
+    if (
+      !component ||
+      !isWebpackComponentTesting(contents, component) ||
+      setsJustInTimeCompile(component)
+    ) {
+      continue;
+    }
+
+    tree.write(cypressConfigPath, addJustInTimeCompile(contents, component));
+    wereProjectsMigrated = true;
+  }
+
+  if (wereProjectsMigrated) {
+    await formatFiles(tree);
+  }
+}
+
+function isWebpackComponentTesting(
+  contents: string,
+  component: PropertyAssignment
+): boolean {
+  ts ??= ensureTypescript();
+
+  // A vite bundler (inline devServer or preset options) opts out.
+  if (
+    getComponentProperty(component, 'bundler').some(
+      (property) =>
+        ts.isStringLiteral(property.initializer) &&
+        property.initializer.text === 'vite'
+    )
+  ) {
+    return false;
+  }
+
+  // Preset-based config: trust it only when `component` actually calls
+  // nxComponentTestingPreset, so a stale/unused preset import doesn't count.
+  if (usesNxComponentTestingPreset(component)) {
+    // @nx/remix is the only vite-based Nx CT preset.
+    return getNxCtPreset(contents) !== NX_VITE_CT_PRESET;
+  }
+
+  // Hand-written config: migrate only when it has an inline devServer framework.
+  return hasInlineDevServerFramework(component);
+}
+
+function usesNxComponentTestingPreset(component: PropertyAssignment): boolean {
+  ts ??= ensureTypescript();
+
+  return query<CallExpression>(component, 'CallExpression').some(
+    (call) =>
+      ts.isIdentifier(call.expression) &&
+      call.expression.text === 'nxComponentTestingPreset'
+  );
+}
+
+function hasInlineDevServerFramework(component: PropertyAssignment): boolean {
+  ts ??= ensureTypescript();
+
+  if (!ts.isObjectLiteralExpression(component.initializer)) {
+    return false;
+  }
+  const devServer = getObjectProperty(component.initializer, 'devServer');
+  if (!devServer || !ts.isObjectLiteralExpression(devServer.initializer)) {
+    return false;
+  }
+
+  return !!getObjectProperty(devServer.initializer, 'framework');
+}
+
+function getComponentProperty(
+  component: PropertyAssignment,
+  name: string
+): PropertyAssignment[] {
+  ts ??= ensureTypescript();
+
+  return query<PropertyAssignment>(component, 'PropertyAssignment').filter(
+    (property) => ts.isIdentifier(property.name) && property.name.text === name
+  );
+}
+
+function getNxCtPreset(contents: string): string | null {
+  if (contents.includes(NX_VITE_CT_PRESET)) {
+    return NX_VITE_CT_PRESET;
+  }
+  return (
+    NX_WEBPACK_CT_PRESETS.find((preset) => contents.includes(preset)) ?? null
+  );
+}
+
+function setsJustInTimeCompile(component: PropertyAssignment): boolean {
+  return getComponentProperty(component, 'justInTimeCompile').length > 0;
+}
+
+function addJustInTimeCompile(
+  contents: string,
+  component: PropertyAssignment
+): string {
+  ts ??= ensureTypescript();
+
+  const indent = '    ';
+  const comment = JIT_COMMENT.map((line) => `${indent}${line}`).join('\n');
+  const newProperty = `${comment}\n${indent}justInTimeCompile: false,`;
+  const initializer = component.initializer;
+
+  let componentValue: string;
+  if (ts.isObjectLiteralExpression(initializer)) {
+    if (initializer.properties.length === 0) {
+      componentValue = `{\n${newProperty}\n  }`;
+    } else {
+      // Preserve the existing object text (including comments) and insert the
+      // new property before the closing brace.
+      const objectText = contents.slice(
+        initializer.getStart(),
+        initializer.getEnd()
+      );
+      const beforeClose = objectText.replace(/\s*}$/, '');
+      const separator = /,\s*$/.test(beforeClose) ? '' : ',';
+      componentValue = `${beforeClose}${separator}\n${newProperty}\n  }`;
+    }
+  } else {
+    componentValue = `{\n${indent}...${initializer.getText()},\n${newProperty}\n  }`;
+  }
+
+  return `${contents.slice(
+    0,
+    component.getStart()
+  )}component: ${componentValue}${contents.slice(component.getEnd())}`;
+}

--- a/packages/cypress/src/utils/config.spec.ts
+++ b/packages/cypress/src/utils/config.spec.ts
@@ -26,6 +26,46 @@ export default defineConfig({
     `);
   });
 
+  it('should disable justInTimeCompile for webpack on Cypress 14+', async () => {
+    const actual = await addDefaultCTConfig(
+      `import { defineConfig } from 'cypress';
+
+export default defineConfig({});
+`,
+      { bundler: 'webpack' },
+      '@nx/react/plugins/component-testing',
+      15
+    );
+    expect(actual).toContain('...nxComponentTestingPreset(import.meta.url)');
+    expect(actual).toContain('justInTimeCompile: false');
+  });
+
+  it('should not disable justInTimeCompile for the vite bundler', async () => {
+    const actual = await addDefaultCTConfig(
+      `import { defineConfig } from 'cypress';
+
+export default defineConfig({});
+`,
+      { bundler: 'vite' },
+      '@nx/react/plugins/component-testing',
+      15
+    );
+    expect(actual).not.toContain('justInTimeCompile');
+  });
+
+  it('should not disable justInTimeCompile on Cypress < 14', async () => {
+    const actual = await addDefaultCTConfig(
+      `import { defineConfig } from 'cypress';
+
+export default defineConfig({});
+`,
+      { bundler: 'webpack' },
+      '@nx/react/plugins/component-testing',
+      13
+    );
+    expect(actual).not.toContain('justInTimeCompile');
+  });
+
   it('should add e2e config to existing CT config', async () => {
     const actual = await addDefaultE2EConfig(
       `import { defineConfig } from 'cypress';

--- a/packages/cypress/src/utils/config.ts
+++ b/packages/cypress/src/utils/config.ts
@@ -106,11 +106,17 @@ ${updatedConfigContents}`;
  * doing so unconditionally produces mixed-syntax files in CJS workspaces
  * (an ESM `import` followed by a CJS `module.exports`), so prefer passing
  * `presetImportPath`.
+ *
+ * Pass `cypressMajorVersion` to opt webpack setups out of `justInTimeCompile`
+ * on Cypress 14+, where it defaults to `true` and can intermittently run 0
+ * tests in CI. The opt-out is emitted as an explicit `justInTimeCompile: false`
+ * so it is visible and reversible.
  **/
 export async function addDefaultCTConfig(
   cyConfigContents: string,
   options: NxComponentTestingOptions = {},
-  presetImportPath?: string
+  presetImportPath?: string,
+  cypressMajorVersion?: number | null
 ) {
   if (!cyConfigContents) {
     throw new Error('The passed in cypress config file is empty!');
@@ -131,6 +137,12 @@ export async function addDefaultCTConfig(
     // See addDefaultE2EConfig for the rationale on __filename vs
     // import.meta.url.
     const pathToConfig = isCommonJS ? '__filename' : 'import.meta.url';
+    // justInTimeCompile only applies to the webpack dev server and only exists
+    // on Cypress 14+, where it defaults to true.
+    const disableJustInTimeCompile =
+      options.bundler !== 'vite' &&
+      cypressMajorVersion != null &&
+      cypressMajorVersion >= 14;
     let configValue = `nxComponentTestingPreset(${pathToConfig})`;
     if (options) {
       if (options.bundler !== 'vite') {
@@ -145,6 +157,15 @@ export async function addDefaultCTConfig(
       }
     }
 
+    const componentValue = disableJustInTimeCompile
+      ? `{
+    ...${configValue},
+    // Cypress 14+ defaults justInTimeCompile to true (webpack only), which can
+    // intermittently run 0 tests in CI. Remove this line to opt back in.
+    justInTimeCompile: false,
+  }`
+      : configValue;
+
     updatedConfigContents = tsquery.replace(
       cyConfigContents,
       `${TS_QUERY_EXPORT_CONFIG_PREFIX} ObjectLiteralExpression:first-child`,
@@ -152,11 +173,11 @@ export async function addDefaultCTConfig(
         if (node.properties.length > 0) {
           return `{
   ${node.properties.map((p) => p.getText()).join(',\n')},
-  component: ${configValue}
+  component: ${componentValue}
 }`;
         }
         return `{
-  component: ${configValue}
+  component: ${componentValue}
 }`;
       }
     );

--- a/packages/cypress/src/utils/config.ts
+++ b/packages/cypress/src/utils/config.ts
@@ -24,6 +24,13 @@ const TS_QUERY_COMMON_JS_EXPORT_SELECTOR =
   'BinaryExpression:has(Identifier[name="module"]):has(Identifier[name="exports"])';
 const TS_QUERY_EXPORT_CONFIG_PREFIX = `:matches(ExportAssignment, ${TS_QUERY_COMMON_JS_EXPORT_SELECTOR}) `;
 
+// Shared so the CT generator (addDefaultCTConfig) and the
+// disable-webpack-ct-just-in-time-compile migration emit the identical note.
+export const JIT_COMPILE_DISABLE_COMMENT = [
+  '// Cypress 14+ defaults justInTimeCompile to true (webpack only), which can',
+  '// intermittently run 0 tests in CI. Remove this line to opt back in.',
+];
+
 export async function addDefaultE2EConfig(
   cyConfigContents: string,
   options: NxCypressE2EPresetOptions,
@@ -157,11 +164,13 @@ export async function addDefaultCTConfig(
       }
     }
 
+    const jitComment = JIT_COMPILE_DISABLE_COMMENT.map(
+      (line) => `    ${line}`
+    ).join('\n');
     const componentValue = disableJustInTimeCompile
       ? `{
     ...${configValue},
-    // Cypress 14+ defaults justInTimeCompile to true (webpack only), which can
-    // intermittently run 0 tests in CI. Remove this line to opt back in.
+${jitComment}
     justInTimeCompile: false,
   }`
       : configValue;

--- a/packages/next/src/generators/cypress-component-configuration/cypress-component-configuration.spec.ts
+++ b/packages/next/src/generators/cypress-component-configuration/cypress-component-configuration.spec.ts
@@ -48,7 +48,12 @@ describe('cypress-component-configuration generator', () => {
       } = require('@nx/next/plugins/component-testing');
       const { defineConfig } = require('cypress');
       module.exports = defineConfig({
-        component: nxComponentTestingPreset(__filename),
+        component: {
+          ...nxComponentTestingPreset(__filename),
+          // Cypress 14+ defaults justInTimeCompile to true (webpack only), which can
+          // intermittently run 0 tests in CI. Remove this line to opt back in.
+          justInTimeCompile: false,
+        },
       });
       "
     `);
@@ -171,7 +176,12 @@ describe('cypress-component-configuration generator', () => {
       } = require('@nx/next/plugins/component-testing');
       const { defineConfig } = require('cypress');
       module.exports = defineConfig({
-        component: nxComponentTestingPreset(__filename),
+        component: {
+          ...nxComponentTestingPreset(__filename),
+          // Cypress 14+ defaults justInTimeCompile to true (webpack only), which can
+          // intermittently run 0 tests in CI. Remove this line to opt back in.
+          justInTimeCompile: false,
+        },
       });
       "
     `);

--- a/packages/next/src/generators/cypress-component-configuration/cypress-component-configuration.ts
+++ b/packages/next/src/generators/cypress-component-configuration/cypress-component-configuration.ts
@@ -121,7 +121,8 @@ async function addFiles(
   const updatedCyConfig = await addDefaultCTConfig(
     tree.read(cyFile, 'utf-8'),
     undefined,
-    '@nx/next/plugins/component-testing'
+    '@nx/next/plugins/component-testing',
+    installedCypressMajorVersion
   );
   tree.write(cyFile, updatedCyConfig);
 

--- a/packages/react/src/generators/cypress-component-configuration/__snapshots__/cypress-component-configuration.spec.ts.snap
+++ b/packages/react/src/generators/cypress-component-configuration/__snapshots__/cypress-component-configuration.spec.ts.snap
@@ -28,7 +28,12 @@ exports[`React:CypressComponentTestConfiguration should generate cypress compone
 } = require('@nx/react/plugins/component-testing');
 const { defineConfig } = require('cypress');
 module.exports = defineConfig({
-  component: nxComponentTestingPreset(__filename),
+  component: {
+    ...nxComponentTestingPreset(__filename),
+    // Cypress 14+ defaults justInTimeCompile to true (webpack only), which can
+    // intermittently run 0 tests in CI. Remove this line to opt back in.
+    justInTimeCompile: false,
+  },
 });
 "
 `;

--- a/packages/react/src/utils/ct-utils.ts
+++ b/packages/react/src/utils/ct-utils.ts
@@ -60,6 +60,7 @@ export async function configureCypressCT(
   const {
     addDefaultCTConfig,
     getProjectCypressConfigPath,
+    getInstalledCypressMajorVersion,
   }: typeof import('@nx/cypress/internal') = require('@nx/cypress/internal');
 
   const ctConfigOptions: NxComponentTestingOptions = {
@@ -86,7 +87,8 @@ export async function configureCypressCT(
   const updatedCyConfig = await addDefaultCTConfig(
     tree.read(cypressConfigFilePath, 'utf-8'),
     ctConfigOptions,
-    '@nx/react/plugins/component-testing'
+    '@nx/react/plugins/component-testing',
+    getInstalledCypressMajorVersion(tree)
   );
   tree.write(cypressConfigFilePath, updatedCyConfig);
 


### PR DESCRIPTION
## Current Behavior

Cypress 14+ defaults `justInTimeCompile` to `true` for the webpack dev server, compiling each spec on demand. In run mode the runner can load a component test before its spec finishes compiling, so the spec executes 0 tests while the run still exits green. That false pass hides broken component tests in CI.

## Expected Behavior

The `@nx/angular`, `@nx/react`, and `@nx/next` component testing generators now emit an explicit `justInTimeCompile: false` in the generated Cypress config for webpack setups on Cypress 14+, keeping the choice visible and reversible. A migration backfills the same line into existing webpack component testing configs. vite and `@nx/remix` are unaffected, since `justInTimeCompile` is webpack-only.

## Implementation Details

- `addDefaultCTConfig` takes an optional installed Cypress major version and emits the opt-out only for webpack on Cypress 14+. The `@nx/angular`, `@nx/react`, and `@nx/next` generators pass `getInstalledCypressMajorVersion(tree)`.
- The `disable-webpack-ct-just-in-time-compile` migration (gated to `cypress >= 14`) inserts the property after the last existing one via the AST, so surrounding comments and formatting stay intact, and resolves the actual `nxComponentTestingPreset` import (ESM or CJS) to distinguish webpack from vite. It skips vite, `@nx/remix`, already-set, and e2e-only configs.

## Related Issue(s)

Fixes NXC-4599

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/cypress-ct-async-spec-loading-65941303)
<!-- polygraph-session-end -->