### PR TITLE
fix(react): validate typecheck in the React 19 migration

### DIFF
--- a/packages/react/src/migrations/update-23-1-0/ai-instructions-for-react-19.md
+++ b/packages/react/src/migrations/update-23-1-0/ai-instructions-for-react-19.md
@@ -1,6 +1,6 @@
 # React 18 -> 19 Migration Instructions for LLM
 
-Migrate the Nx workspace's React projects from 18 to 19. Run the codemods first, fix the rest by hand, build after each project.
+Migrate the Nx workspace's React projects from 18 to 19. Run the codemods first, fix the rest by hand, typecheck and build after each project.
 
 ## Step 1: Codemods
 
@@ -35,17 +35,55 @@ npx types-react-codemod@latest refobject-defaults ./PROJECT_PATH       # RefObje
 
 ## Step 4: Types
 
-`@types/react@19`: `useRef` needs an initial arg, implicit `children` removed (declare it on props), `JSX` global moved. The types codemod handles most.
+`@types/react@19` moves the `JSX` namespace out of global scope into the `react` module (`React.JSX`); `useRef` needs an initial arg; implicit `children` is removed (declare it on props). The `scoped-jsx` codemod (part of `preset-19`) rewrites JSX type _usages_: it points `JSX.Element`, `JSX.IntrinsicElements`, and the like at the `react`-scoped namespace.
+
+It does NOT rewrite global `JSX` _augmentations_. A custom element or web component typed with a global augmentation:
+
+```ts
+declare global {
+  namespace JSX {
+    interface IntrinsicElements {
+      'my-element': ...;
+    }
+  }
+}
+```
+
+no longer merges into the JSX that React resolves under the automatic runtime (`jsx: "react-jsx"`), so the element becomes a `TS2339` unknown-property error in every consuming `.tsx`. Re-target the augmentation at the `react` module:
+
+```ts
+import type {} from 'react';
+
+declare module 'react' {
+  namespace JSX {
+    interface IntrinsicElements {
+      'my-element': ...;
+    }
+  }
+}
+```
+
+The `import type {} from 'react'` is required when the file (or its tsconfig `types`) does not otherwise pull in `react`; without `react` in the program the augmentation fails with `TS2664: Invalid module name in augmentation`. Keep any `eslint-disable` comment already on the `namespace` line.
 
 ## Validate
 
+Run build and typecheck across the affected projects, then lint and test:
+
 ```bash
 nx run PROJECT:build
-nx affected -t build,lint,test
+nx affected -t build,typecheck,lint,test
 ```
+
+Most React 19 breakages are type-level (the `JSX` namespace move, implicit `children`, ref types) and surface only at `typecheck`, not at `build` or `test`. A type change in a shared library often errors only in its consumers, so re-run until every project that depends on what you changed is green, not just the project you edited.
 
 ## Notes for LLM
 
 - Codemods first (API + types), then manual.
-- One project at a time, build after each.
+- One project at a time; typecheck and build after each.
+- A custom element or JSX augmentation may live in a non-React library that React code pulls in through a bare side-effect import (`import '@scope/ui';`). Fix it there; `typecheck` on the consumers points you to it.
 - Confirm third-party libs support React 19 before bumping.
+
+## References
+
+- React 19 upgrade guide (the TypeScript section covers the `JSX`, `useRef`, and `ref` changes): https://react.dev/blog/2024/04/25/react-19-upgrade-guide
+- `types-react-codemod` (what each codemod does, including `scoped-jsx`): https://github.com/eps1lon/types-react-codemod


### PR DESCRIPTION
## Current Behavior

The `@nx/react` React 18 -> 19 migration ships AI instructions that drive the upgrade. Those instructions validated `build`, `lint`, and `test`, but not `typecheck`. React 19 moves the `JSX` namespace out of global scope into the `react` module, so a custom element or web component typed with a global `declare global { namespace JSX { interface IntrinsicElements } }` augmentation no longer merges under the automatic JSX runtime. Consuming `.tsx` files then fail `typecheck` with `TS2339`, while `build` and `test` still pass, so the migration reports success and leaves the workspace with a broken `typecheck`. Step 4 also described the `JSX` change as something "the types codemod handles most", when `types-react-codemod`'s `scoped-jsx` rewrites JSX type usages, not global augmentations.

## Expected Behavior

The migration validates `typecheck` alongside `build`, `lint`, and `test`, so type-level regressions surface during the migration instead of after it, and it notes that a shared library's type change shows up only in its consumers. Step 4 documents the real gap and gives the verified rewrite for global `JSX` augmentations (`declare global` -> `declare module 'react'`, plus `import type {} from 'react'` to avoid `TS2664` when `react` is not already in the file's program). It links the React 19 upgrade guide and the codemod docs instead of duplicating them.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/nx-23.1.0-beta-migration-b1195096)
<!-- polygraph-session-end -->