### PR TITLE
docs(misc): update broken doc links in deprecation warnings

### DIFF
--- a/packages/angular/tailwind.ts
+++ b/packages/angular/tailwind.ts
@@ -4,7 +4,7 @@ let hasWarned = false;
 
 /**
  * @deprecated `@nx/angular/tailwind` will be removed in Nx 24. Migrate to Tailwind CSS v4 which no longer needs glob patterns.
- * See: https://nx.dev/docs/technologies/angular/guides/using-tailwind-css-with-angular
+ * See: https://nx.dev/docs/technologies/angular/guides/using-tailwind-css-with-angular-projects
  */
 export function createGlobPatternsForDependencies(
   dirPath: string,
@@ -15,7 +15,7 @@ export function createGlobPatternsForDependencies(
     console.warn(
       `\nWARNING: "@nx/angular/tailwind" is deprecated and will be removed in Nx 24.\n` +
         `Migrate to Tailwind CSS v4 which no longer needs glob patterns for content detection.\n` +
-        `See: https://nx.dev/docs/technologies/angular/guides/using-tailwind-css-with-angular\n`
+        `See: https://nx.dev/docs/technologies/angular/guides/using-tailwind-css-with-angular-projects\n`
     );
   }
   try {

--- a/packages/nx/bin/nx.ts
+++ b/packages/nx/bin/nx.ts
@@ -328,7 +328,7 @@ function warnIfUsingOutdatedGlobalInstall(
       : [];
 
     bodyLines.push(
-      'For more information, see https://nx.dev/more-concepts/global-nx'
+      'For more information, see https://nx.dev/docs/getting-started/installation#global-installation'
     );
     output.warn({
       title: `It's time to update Nx 🎉`,


### PR DESCRIPTION
## What

Two broken documentation links in runtime warning messages, fixed in one PR.

### 1. `packages/angular/tailwind.ts` (fixes #36108)

The deprecation warning for `@nx/angular/tailwind` pointed to:
```
https://nx.dev/docs/technologies/angular/guides/using-tailwind-css-with-angular
```
which returns a 404. The correct URL is:
```
https://nx.dev/docs/technologies/angular/guides/using-tailwind-css-with-angular-projects
```
(the page was renamed to include the `-projects` suffix)

### 2. `packages/nx/bin/nx.ts` (fixes #36072)

The global version mismatch warning pointed to:
```
https://nx.dev/more-concepts/global-nx
```
which returns a 404. The docs were moved to:
```
https://nx.dev/docs/getting-started/installation#global-installation
```

## Checklist
- [x] Verified both replacement URLs return 200