### PR TITLE
fix(webpack): prevent TS6059 when a tsc build bundles a workspace lib

### DIFF
--- a/e2e/webpack/src/webpack.test.ts
+++ b/e2e/webpack/src/webpack.test.ts
@@ -381,6 +381,59 @@ describe('Webpack Plugin', () => {
     );
   });
 
+  it('should build a tsc app that imports a workspace lib from source', () => {
+    // Regression for #35017: ts-loader 9.5.7+ forwards the tsconfig rootDir to
+    // transpileModule, so lib sources bundled from source (outside the app
+    // rootDir) failed with TS6059.
+    const appName = uniq('app');
+    const myPkg = uniq('my-pkg');
+
+    runCLI(
+      `generate @nx/web:application ${appName} --directory=apps/${appName} --bundler=webpack`
+    );
+
+    runCLI(
+      `generate @nx/js:lib ${myPkg} --directory=libs/${myPkg} --importPath=@${appName}/${myPkg}`
+    );
+
+    updateFile(`libs/${myPkg}/src/index.ts`, `export const foo = 'bar';\n`);
+
+    updateFile(
+      `apps/${appName}/src/main.ts`,
+      `import { foo } from '@${appName}/${myPkg}';\nconsole.log(foo);\n`
+    );
+
+    updateFile(
+      `apps/${appName}/webpack.config.js`,
+      `
+      const path  = require('path');
+      const { NxAppWebpackPlugin } = require('@nx/webpack/app-plugin');
+
+      module.exports = {
+        target: 'node',
+        output: {
+          path: path.join(__dirname, '../../dist/${appName}')
+        },
+        plugins: [
+          new NxAppWebpackPlugin({
+            compiler: 'tsc',
+            main: 'apps/${appName}/src/main.ts',
+            tsConfig: 'apps/${appName}/tsconfig.app.json',
+            outputHashing: 'none',
+            optimization: false,
+          })
+        ]
+      };`
+    );
+
+    const result = runCLI(`build ${appName}`);
+
+    expect(result).not.toContain('TS6059');
+    expect(result).toContain(
+      `Successfully ran target build for project ${appName}`
+    );
+  });
+
   it('should be able to support webpack config with nx enhanced and babel', () => {
     const appName = uniq('app');
 

--- a/package.json
+++ b/package.json
@@ -300,7 +300,7 @@
     "tree-kill": "catalog:",
     "ts-checker-rspack-plugin": "catalog:rspack",
     "ts-jest": "catalog:jest",
-    "ts-loader": "^9.3.1",
+    "ts-loader": "^9.5.7",
     "ts-node": "catalog:typescript",
     "tsconfig-paths": "catalog:typescript",
     "tsconfig-paths-webpack-plugin": "4.2.0",

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -113,7 +113,7 @@
     "source-map-loader": "^5.0.0",
     "style-loader": "^3.3.0",
     "terser-webpack-plugin": "^5.3.3",
-    "ts-loader": "^9.3.1",
+    "ts-loader": "^9.5.7",
     "tsconfig-paths-webpack-plugin": "4.2.0",
     "tslib": "catalog:typescript",
     "webpack-node-externals": "^3.0.0",

--- a/packages/webpack/src/plugins/nx-webpack-plugin/lib/compiler-loaders.spec.ts
+++ b/packages/webpack/src/plugins/nx-webpack-plugin/lib/compiler-loaders.spec.ts
@@ -5,8 +5,6 @@ describe('createLoaderFromCompiler tsc', () => {
   function tscOptions(): NormalizedNxAppWebpackPluginOptions {
     return {
       root: '/test',
-      projectRoot: 'apps/test',
-      sourceRoot: 'apps/test/src',
       tsConfig: 'apps/test/tsconfig.app.json',
       compiler: 'tsc',
       transformers: [],

--- a/packages/webpack/src/plugins/nx-webpack-plugin/lib/compiler-loaders.spec.ts
+++ b/packages/webpack/src/plugins/nx-webpack-plugin/lib/compiler-loaders.spec.ts
@@ -1,0 +1,24 @@
+import { createLoaderFromCompiler } from './compiler-loaders';
+import { NormalizedNxAppWebpackPluginOptions } from '../nx-app-webpack-plugin-options';
+
+describe('createLoaderFromCompiler tsc', () => {
+  function tscOptions(): NormalizedNxAppWebpackPluginOptions {
+    return {
+      root: '/test',
+      projectRoot: 'apps/test',
+      sourceRoot: 'apps/test/src',
+      tsConfig: 'apps/test/tsconfig.app.json',
+      compiler: 'tsc',
+      transformers: [],
+    } as unknown as NormalizedNxAppWebpackPluginOptions;
+  }
+
+  // ts-loader 9.5.7+ forwards the tsconfig rootDir to transpileModule, so
+  // workspace lib sources resolved outside the app rootDir fail with TS6059.
+  // The loader must widen rootDir to the workspace root to keep those builds green.
+  it('should widen ts-loader rootDir to the workspace root', () => {
+    const rule = createLoaderFromCompiler(tscOptions());
+
+    expect(rule.options.compilerOptions).toEqual({ rootDir: '/test' });
+  });
+});

--- a/packages/webpack/src/plugins/nx-webpack-plugin/lib/compiler-loaders.ts
+++ b/packages/webpack/src/plugins/nx-webpack-plugin/lib/compiler-loaders.ts
@@ -44,10 +44,11 @@ export function createLoaderFromCompiler(
           transpileOnly: !hasPlugin,
           // https://github.com/TypeStrong/ts-loader/pull/685
           experimentalWatchApi: true,
-          // ts-loader 9.5.7+ passes the tsconfig rootDir to transpileModule, so
-          // workspace lib sources resolved outside the app rootDir fail with
-          // TS6059. rootDir is emit-only here (webpack owns output), so widen it
-          // to the workspace root.
+          // ts-loader 9.5.7+ forwards the tsconfig rootDir to transpileModule, so
+          // workspace lib sources bundled from source (outside the app rootDir)
+          // fail with TS6059. rootDir only governs emit layout, which webpack owns
+          // here (the default transpile path emits JS, not declarations), so widen
+          // it to the workspace root to clear the error without altering output.
           compilerOptions: { rootDir: options.root },
           getCustomTransformers: (program) => ({
             before: compilerPluginHooks.beforeHooks.map((hook) =>

--- a/packages/webpack/src/plugins/nx-webpack-plugin/lib/compiler-loaders.ts
+++ b/packages/webpack/src/plugins/nx-webpack-plugin/lib/compiler-loaders.ts
@@ -44,6 +44,11 @@ export function createLoaderFromCompiler(
           transpileOnly: !hasPlugin,
           // https://github.com/TypeStrong/ts-loader/pull/685
           experimentalWatchApi: true,
+          // ts-loader 9.5.7+ passes the tsconfig rootDir to transpileModule, so
+          // workspace lib sources resolved outside the app rootDir fail with
+          // TS6059. rootDir is emit-only here (webpack owns output), so widen it
+          // to the workspace root.
+          compilerOptions: { rootDir: options.root },
           getCustomTransformers: (program) => ({
             before: compilerPluginHooks.beforeHooks.map((hook) =>
               hook(program)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1301,8 +1301,8 @@ importers:
         specifier: catalog:jest
         version: 29.4.11(@babel/core@7.29.0)(@jest/transform@30.3.0)(@jest/types@30.0.1)(babel-jest@30.3.0(@babel/core@7.29.0))(esbuild@0.25.0)(jest-util@30.3.0)(jest@30.3.0(@types/node@24.12.2)(babel-plugin-macros@3.1.0)(esbuild-register@3.6.0(esbuild@0.25.0))(ts-node@10.9.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@24.12.2)(typescript@6.0.3)))(typescript@6.0.3)
       ts-loader:
-        specifier: ^9.3.1
-        version: 9.5.2(typescript@6.0.3)(webpack@5.105.2)
+        specifier: ^9.5.7
+        version: 9.6.2(loader-utils@2.0.3)(typescript@6.0.3)(webpack@5.105.2)
       ts-node:
         specifier: catalog:typescript
         version: 10.9.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@24.12.2)(typescript@6.0.3)
@@ -4246,8 +4246,8 @@ importers:
         specifier: ^5.3.3
         version: 5.3.14(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(webpack@5.105.2)
       ts-loader:
-        specifier: ^9.3.1
-        version: 9.5.2(typescript@6.0.3)(webpack@5.105.2)
+        specifier: ^9.5.7
+        version: 9.6.2(loader-utils@2.0.3)(typescript@6.0.3)(webpack@5.105.2)
       tsconfig-paths-webpack-plugin:
         specifier: 4.2.0
         version: 4.2.0
@@ -25023,6 +25023,17 @@ packages:
     peerDependencies:
       typescript: '*'
       webpack: ^5.0.0
+
+  ts-loader@9.6.2:
+    resolution: {integrity: sha512-R4iuczmtgxvtuI556s+hTZ6/7Ee03VCAk/l/M8LY1OAsUgB7YydsCxkgq9D9pKRaD7GJqUi2u8fp9zZP/ufjKA==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      loader-utils: '*'
+      typescript: '*'
+      webpack: ^4.0.0 || ^5.0.0
+    peerDependenciesMeta:
+      loader-utils:
+        optional: true
 
   ts-morph@28.0.0:
     resolution: {integrity: sha512-Wp3tnZ2bzwxyTZMtgWVzXDfm7lB1Drz+y9DmmYH/L702PQhPyVrp3pkou3yIz4qjS14GY9kcpmLiOOMvl8oG1g==}
@@ -54484,6 +54495,16 @@ snapshots:
       source-map: 0.7.6
       typescript: 6.0.3
       webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@7.0.3)
+
+  ts-loader@9.6.2(loader-utils@2.0.3)(typescript@6.0.3)(webpack@5.105.2):
+    dependencies:
+      chalk: 4.1.2
+      picomatch: 4.0.4
+      source-map: 0.7.6
+      typescript: 6.0.3
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@7.0.3)
+    optionalDependencies:
+      loader-utils: 2.0.3
 
   ts-morph@28.0.0:
     dependencies:


### PR DESCRIPTION
## Current Behavior

Building an app with the `@nx/webpack` `tsc` compiler fails when the app imports a workspace library whose sources are bundled from source (the default `buildLibsFromSource`). The build errors with:

```
TS6059: File 'libs/lib-1/src/index.ts' is not under 'rootDir' 'apps/app-1/src'. 'rootDir' is expected to contain all source files.
```

ts-loader 9.5.7 stopped forcing `rootDir` to `undefined` (which had masked this) to avoid a TS5011 error on TypeScript 6. Because the floating `^9.3.1` range now resolves to 9.5.7+, ts-loader forwards the app tsconfig `rootDir` into `transpileModule`, and lib sources resolved outside the app `rootDir` fail the check.

## Expected Behavior

A `tsc` webpack build that imports a workspace library from source compiles without `TS6059`.

## Related Issue(s)

Fixes #35017

## Implementation Details

`rootDir` only affects output layout, which webpack owns in a bundled build, so it is safe to widen it for the loader. `createLoaderFromCompiler` now sets the ts-loader `compilerOptions.rootDir` to the workspace root, keeping it defined (avoiding TS5011) while covering the lib sources. ts-loader is raised to `^9.5.7` so the lockfile tracks the version users already resolve. Includes a unit test for the loader option and an e2e case that builds a `tsc` app importing a workspace lib from source.


<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/gh-35017-c68ef038)
<!-- polygraph-session-end -->
