### PR TITLE
fix(core): accept legacy plugin array in retrieveProjectConfigurations

### DIFF
--- a/packages/nx/src/project-graph/utils/retrieve-workspace-files.spec.ts
+++ b/packages/nx/src/project-graph/utils/retrieve-workspace-files.spec.ts
@@ -102,6 +102,34 @@ describe('retrieve-workspace-files', () => {
       expect(result.projects['project3']).toBeDefined();
     });
 
+    // Regression test for https://github.com/nrwl/nx/issues/36144
+    // `@nx/devkit` <= 22 (whose peer range permits nx 23) calls
+    // `retrieveProjectConfigurations` with a plain `LoadedNxPlugin[]` as the
+    // first argument, which the nx 23 signature change to `SeparatedPlugins`
+    // broke, crashing `create-nx-workspace@22 --preset=nest` with
+    // "Cannot read properties of undefined (reading 'filter')".
+    it('should accept a plain plugin array (legacy @nx/devkit <= 22 shape)', async () => {
+      await fs.createFile(
+        'project1/project.json',
+        JSON.stringify({
+          name: 'project1',
+          root: 'project1',
+        })
+      );
+
+      const mockPlugin = createTestPlugin('test-plugin', '**/project.json');
+
+      const result = await retrieveProjectConfigurations(
+        // legacy array shape passed by @nx/devkit <= 22
+        [mockPlugin] as any,
+        fs.tempDir,
+        {}
+      );
+
+      expect(result.projects).toBeDefined();
+      expect(result.projects['project1']).toBeDefined();
+    });
+
     it('multiple plugins should not affect other plugins', async () => {
       await fs.createFile(
         'project1/project.json',

--- a/packages/nx/src/project-graph/utils/retrieve-workspace-files.ts
+++ b/packages/nx/src/project-graph/utils/retrieve-workspace-files.ts
@@ -66,10 +66,21 @@ export async function retrieveWorkspaceFiles(
  * between specified and default plugin processing phases.
  */
 export async function retrieveProjectConfigurations(
-  separatedPlugins: SeparatedPlugins,
+  pluginsOrSeparatedPlugins: SeparatedPlugins | LoadedNxPlugin[],
   workspaceRoot: string,
   nxJson: NxJsonConfiguration
 ): Promise<ConfigurationResult> {
+  // Backwards compatibility: `@nx/devkit` <= 22 (whose peer range permits nx 23)
+  // calls this with a plain `LoadedNxPlugin[]` as the first argument. Nx 23
+  // changed the signature to accept `SeparatedPlugins`. Normalize the legacy
+  // array shape so those older devkit callers (e.g. `addPlugin` invoked during
+  // `create-nx-workspace --preset=...`) don't crash on `.filter` of undefined.
+  const separatedPlugins: SeparatedPlugins = Array.isArray(
+    pluginsOrSeparatedPlugins
+  )
+    ? { specifiedPlugins: pluginsOrSeparatedPlugins, defaultPlugins: [] }
+    : pluginsOrSeparatedPlugins;
+
   const specifiedWithCreateNodes = separatedPlugins.specifiedPlugins.filter(
     (p) => !!p.createNodes
   );


### PR DESCRIPTION
## Current Behavior

Creating a workspace with `create-nx-workspace@22.x --preset=nest` (and any preset that ends up calling `@nx/webpack`'s init generator) crashes during generation with:

```
NX   Cannot read properties of undefined (reading 'filter')
```

`@nx/devkit@22.x` declares `peerDependencies.nx: ">= 21 <= 23"`, so during the preset install `nx` resolves transiently to `23.x`. devkit 22.x's `add-plugin.ts` calls the `nx/src/devkit-internals` export `retrieveProjectConfigurations([plugin], root, nxJson)` with a plain `LoadedNxPlugin[]` as the first argument (the nx 22 signature). nx 23 changed that argument to `SeparatedPlugins` and immediately does `separatedPlugins.specifiedPlugins.filter(...)`, so the array-shaped argument makes `.specifiedPlugins` `undefined` and generation crashes.

Observed stack (nx 23 leaked into the temp dir; devkit/webpack/node/nest all 22.7.6):

```
at retrieveProjectConfigurations (nx@23/retrieve-workspace-files.js)
at _addPluginInternal (@nx/devkit@22.7.6/add-plugin.js)
at webpackInitGeneratorInternal (@nx/webpack@22.7.6/init.js)
at @nx/node -> @nx/nest -> @nx/workspace:preset
```

## Expected Behavior

`retrieveProjectConfigurations` continues to accept the legacy plain `LoadedNxPlugin[]` first argument used by `@nx/devkit` <= 22 (which the peer range allows against nx 23), so `create-nx-workspace@22 --preset=nest` completes successfully.

The fix widens the first parameter to `SeparatedPlugins | LoadedNxPlugin[]` and normalizes the legacy array into `{ specifiedPlugins: arr, defaultPlugins: [] }` at the top of the function. This mirrors exactly what nx 23's own `add-plugin.ts` passes for the single-plugin case. A regression test drives the legacy array shape and fails without the fix.

## Related Issue(s)

Fixes #36144

## Scope note (post-review)

This shim is the defensive backstop, not the full fix. The root cause is that `installPackageToTmp` (backing devkit's `ensurePackage`) installs plugins into a temp directory without pinning `nx`, so devkit's +/- 1 major peer range lets the package manager float `nx` to a newer major there. #36191 fixes that at the source and prevents the same breakage at the 23 -> 24 boundary (verified live: with an `nx@24.0.0` on the registry, shipped `create-nx-workspace@23.0.1` pulls `nx@24.0.0` into the ensurePackage temp dir).

This PR should still land **and be backported to the 23.0.x patch line**: it is the only fix that reaches the already-published 22.x CLIs, because the `nx` they transitively float to is the one piece we can still patch.

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/kind-wren-3766add2)
<!-- polygraph-session-end -->
