### PR TITLE
fix(core): pin nx to the running version in temp package installs

### DIFF
--- a/packages/nx/src/utils/package-json.spec.ts
+++ b/packages/nx/src/utils/package-json.spec.ts
@@ -19,6 +19,7 @@ import {
 } from './package-json';
 import * as pacakgeManager from './package-manager';
 import { getPackageManagerCommand } from './package-manager';
+import { nxVersion } from './versions';
 import { workspaceRoot } from './workspace-root';
 
 describe('buildTargetFromScript', () => {
@@ -100,6 +101,40 @@ describe('installPackageToTmp', () => {
     expect(execSyncSpy).toHaveBeenCalledTimes(1);
     expect(execSyncSpy.mock.calls[0][0]).toBe(
       'pnpm add -Dw nx@latest --ignore-scripts'
+    );
+
+    cleanup();
+  });
+
+  // Regression test for https://github.com/nrwl/nx/issues/36144
+  // Installing a package without pinning `nx` lets the package manager float
+  // `nx` to a newer major (via `@nx/devkit`'s +/- 1 major peer range), so the
+  // package loaded from the temp dir runs against a mismatched nx.
+  it('should pin `nx` to the running version when installing another package', () => {
+    const tempDir = mkdtempSync(join(tmpdir(), 'nx-install-test-'));
+    const cleanup = jest.fn(() =>
+      rmSync(tempDir, { recursive: true, force: true })
+    );
+    jest.spyOn(pacakgeManager, 'createTempNpmDirectory').mockReturnValue({
+      dir: tempDir,
+      cleanup,
+    });
+    jest
+      .spyOn(pacakgeManager, 'getPackageManagerVersion')
+      .mockReturnValue('10.0.0');
+    jest.spyOn(pacakgeManager, 'getPackageManagerCommand').mockReturnValue({
+      addDev: 'npm install -D',
+      ignoreScriptsFlag: '--ignore-scripts',
+    } as any);
+    const execSyncSpy = jest
+      .spyOn(childProcess, 'execSync')
+      .mockReturnValue('' as any);
+
+    installPackageToTmp('@nx/webpack', '22.7.6', 'npm');
+
+    expect(execSyncSpy).toHaveBeenCalledTimes(1);
+    expect(execSyncSpy.mock.calls[0][0]).toBe(
+      `npm install -D @nx/webpack@22.7.6 nx@${nxVersion} --ignore-scripts`
     );
 
     cleanup();

--- a/packages/nx/src/utils/package-json.ts
+++ b/packages/nx/src/utils/package-json.ts
@@ -27,6 +27,7 @@ import {
   PackageManager,
   PackageManagerCommands,
 } from './package-manager';
+import { nxVersion } from './versions';
 import { workspaceRoot } from './workspace-root';
 
 export interface NxProjectPackageJsonConfiguration
@@ -416,7 +417,14 @@ function preparePackageInstallation(
   // it into the temp dir, so the `-w` here resolves to the temp dir.
   const pmCommands = getPackageManagerCommand(packageManager);
   const preInstallCommand = pmCommands.preInstall;
-  const installCommand = `${pmCommands.addDev} ${pkg}@${requiredVersion} ${
+  // When installing anything other than `nx` itself, pin `nx` in the temp
+  // install to the version this process is running. `@nx/devkit`'s peer
+  // range spans +/- 1 major, so an unpinned temp install can float `nx` to
+  // a newer major next to the requested package, and code loaded from the
+  // temp dir (e.g. a plugin pulled in via `ensurePackage`) would then run
+  // against a different nx than the workspace (see #36144).
+  const nxPin = pkg === 'nx' ? '' : ` nx@${nxVersion}`;
+  const installCommand = `${pmCommands.addDev} ${pkg}@${requiredVersion}${nxPin} ${
     pmCommands.ignoreScriptsFlag ?? ''
   }`;
 


### PR DESCRIPTION
## Current Behavior

`installPackageToTmp` (which backs `@nx/devkit`'s `ensurePackage`, among others) installs the requested package into a bare temp directory without pinning `nx`. `@nx/devkit` declares its `nx` peer dependency with a range spanning +/- 1 major (`>= 22 <= 24` on the 23.x line), so the package manager is free to satisfy that peer with a newer `nx` major than the one the workspace runs. The plugin code loaded from the temp directory then resolves that mismatched `nx`.

This is the root cause behind #36144: during `create-nx-workspace@22.7.6 --preset=nest`, `ensurePackage('@nx/webpack', '22.7.6')` installed `@nx/webpack@22.7.6` into a temp dir where `nx` floated to `23.x`, and `addPlugin` -> `retrieveProjectConfigurations` crashed on the changed argument shape.

The same class of breakage is live at the 23 -> 24 boundary today. Verified against a local Verdaccio registry with a fake `nx@24.0.0` published: `create-nx-workspace@23.0.1 --preset=nest`'s ensurePackage temp install pulled `nx@24.0.0` next to `@nx/webpack@23.0.1`. Any incompatible internal API change in a real nx 24 would reproduce the #36144 crash for every published 23.x CLI.

## Expected Behavior

Temp installs performed by `installPackageToTmp` pin `nx` to the version of the running process, so the temp directory always contains a matching `nx` and code loaded from it runs against the same nx the workspace uses. Installs of `nx` itself (the daemon pulling `nx@latest`, `nx init`, AI-agents setup) are unchanged.

Verified end-to-end against a local Verdaccio registry with a fake `nx@24.0.0` published (tagged `latest`):

| create-nx-workspace | ensurePackage temp dir | Result |
| --- | --- | --- |
| 23.0.1 (shipped, no fix) | `nx@24.0.0` next to `@nx/webpack@23.0.1` | mismatch (future crash) |
| 23.9.10 (this fix) | `nx@23.9.10` next to `@nx/webpack@23.9.10` | pinned, versions match |

A unit test locks the install command shape (fails with the exact unpinned command if the fix is reverted); the existing exact-command tests for installing `nx` itself keep passing, proving those flows are untouched.

## Related Issue(s)

Addresses the root cause behind #36144 going forward. The crash for already-published 22.x CLIs is covered by the backward-compat shim in #36189, which remains necessary (and should be backported to 23.0.x) because the shipped 22.x CLIs can only be reached through the `nx` package they transitively float to.

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/kind-wren-3766add2)
<!-- polygraph-session-end -->