### PR TITLE
fix(devkit): restore prettier v2 support in formatFiles

### DIFF
--- a/packages/devkit/src/generators/format-files.ts
+++ b/packages/devkit/src/generators/format-files.ts
@@ -6,6 +6,20 @@ import {
 import * as path from 'path';
 import type * as Prettier from 'prettier';
 
+// Prettier v3 (ESM) exposes its API as named exports; v2 (CJS) exposes it under
+// `.default` when loaded via `import()`. Return whichever carries the API, or
+// null if prettier isn't installed.
+async function importPrettier(): Promise<typeof Prettier | null> {
+  try {
+    const imported = await import('prettier');
+    return (
+      (imported as any).resolveConfig ? imported : (imported as any).default
+    ) as typeof Prettier;
+  } catch {
+    return null;
+  }
+}
+
 /**
  * Formats all the created or updated files using Prettier
  * @param tree - the file system tree
@@ -39,9 +53,9 @@ export async function formatFiles(
     return;
   }
 
-  let prettier: typeof Prettier;
+  let prettier: typeof Prettier | null;
   try {
-    prettier = await import('prettier');
+    prettier = await importPrettier();
     /**
      * Even after we discovered prettier in node_modules, we need to be sure that the user is intentionally using prettier
      * before proceeding to format with it.

--- a/packages/js/src/utils/prettier.ts
+++ b/packages/js/src/utils/prettier.ts
@@ -15,11 +15,23 @@ export interface ExistingPrettierConfig {
   config: Options;
 }
 
-export async function resolveUserExistingPrettierConfig(): Promise<ExistingPrettierConfig | null> {
-  let prettier: typeof import('prettier');
+// Prettier v3 (ESM) exposes its API as named exports; v2 (CJS) exposes it under
+// `.default` when loaded via `import()`. Return whichever carries the API, or
+// null if prettier isn't installed.
+async function importPrettier(): Promise<typeof import('prettier') | null> {
   try {
-    prettier = await import('prettier');
+    const imported = await import('prettier');
+    return (
+      (imported as any).resolveConfig ? imported : (imported as any).default
+    ) as typeof import('prettier');
   } catch {
+    return null;
+  }
+}
+
+export async function resolveUserExistingPrettierConfig(): Promise<ExistingPrettierConfig | null> {
+  const prettier = await importPrettier();
+  if (!prettier) {
     return null;
   }
 
@@ -101,18 +113,14 @@ export function generatePrettierSetup(
 export async function resolvePrettierConfigPath(
   tree: Tree
 ): Promise<string | null> {
-  let prettier: typeof import('prettier');
-  try {
-    prettier = await import('prettier');
-  } catch {
+  const prettier = await importPrettier();
+  if (!prettier) {
     return null;
   }
 
-  if (prettier) {
-    const filePath = await prettier.resolveConfigFile();
-    if (filePath) {
-      return filePath;
-    }
+  const configFilePath = await prettier.resolveConfigFile();
+  if (configFilePath) {
+    return configFilePath;
   }
 
   if (!tree) {


### PR DESCRIPTION
## Current Behavior

In workspaces still on Prettier v2, generators and migrations stopped formatting the files they create or update. The output is left unformatted (a "Could not format ..." warning is logged and swallowed). This started after upgrading to Nx 23.x. Running `nx format` / `nx format:write` directly is unaffected, and Prettier v3 workspaces are unaffected. Nx still supports Prettier v2, so this is a regression.

## Expected Behavior

Generators and migrations format their output again on Prettier v2, matching the behavior before Nx 23.x. Prettier v3 continues to work.

## Implementation Details

The regression came from the move to `nodenext` module resolution. `formatFiles` (and the `@nx/js` prettier config helpers) load prettier via `await import('prettier')`. Under `module: commonjs` that was downleveled to `__importStar(require('prettier'))`, which copies a CJS module's own enumerable exports onto the namespace, so `prettier.resolveConfig` was defined. Under `nodenext` the native `import()` is preserved, and Node's CJS interop for Prettier v2 exposes only some named exports (not `resolveConfig`); the rest are reachable only under `.default`. So `prettier.resolveConfig` was `undefined` and the per-file format call threw "prettier.resolveConfig is not a function".

The fix selects the object that actually carries prettier's API (the namespace for v3, `.default` for v2) before using it, in `formatFiles` and the `@nx/js` helpers `resolveUserExistingPrettierConfig` and `resolvePrettierConfigPath`.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/nx-23.1.0-beta-migration-b1195096)
<!-- polygraph-session-end -->
