### PR TITLE
fix(core): speed up bun lockfile parsing

### DIFF
--- a/packages/nx/src/plugins/js/lock-file/bun-parser.ts
+++ b/packages/nx/src/plugins/js/lock-file/bun-parser.ts
@@ -155,6 +155,10 @@ const specParseCache = new Map<
   string,
   { name: string; version: string; protocol: string }
 >();
+// Memoizes (packageName, versionSpec) -> resolved version for the current
+// lockfile. The same name/range pairs repeat across many dependency lists, so
+// the semver resolution is done once per distinct pair instead of per edge.
+const resolvedVersionCache = new Map<string, string | null>();
 
 // Structured error types for better error handling
 export class BunLockfileParseError extends Error {
@@ -221,6 +225,7 @@ export function clearCache(): void {
   keyMap.clear();
   packageVersions.clear();
   specParseCache.clear();
+  resolvedVersionCache.clear();
 }
 
 // ===== UTILITY FUNCTIONS =====
@@ -1181,48 +1186,44 @@ function createHoistedNodes(
  * O(1) lookup using pre-computed index
  */
 function isNestedPackageKey(packageKey: string, index: PackageIndex): boolean {
-  // If the key doesn't contain '/', it's a direct package entry
-  if (!packageKey.includes('/')) {
+  // If the key doesn't contain '/', it's a direct package entry.
+  // Work off slash indices instead of split('/')+slice+join to avoid an
+  // array allocation per key (this runs for every package entry, twice).
+  const lastSlash = packageKey.lastIndexOf('/');
+  if (lastSlash === -1) {
     return false;
   }
 
-  // Check if this looks like a workspace-specific or nested entry
-  const parts = packageKey.split('/');
+  // prefix = everything before the last '/'
+  const prefix = packageKey.substring(0, lastSlash);
 
-  // For multi-part keys, check if the prefix is a workspace path or package name
-  if (parts.length >= 2) {
-    const prefix = parts.slice(0, -1).join('/');
-
-    // O(1) check against known workspace paths
-    if (index.workspacePaths.has(prefix)) {
-      return true;
-    }
-
-    // O(1) check against workspace package names (scoped packages)
-    if (index.workspaceNames.has(prefix)) {
-      return true;
-    }
-
-    // Check for scoped workspace packages (e.g., "@quz/pkg1/lodash")
-    // The prefix must contain '/' to be a scoped package (e.g., "@scope/pkg")
-    // A prefix like just "@scope" without '/' is not a scoped package
-    if (prefix.startsWith('@') && prefix.includes('/')) {
-      return true;
-    }
-
-    // If the key looks like a simple scoped package (e.g., "@custom/lodash")
-    // where parts.length === 2 and first part starts with '@', it's likely
-    // a scoped package alias, not a nested dependency
-    if (parts.length === 2 && parts[0].startsWith('@')) {
-      return false;
-    }
-
-    // This could be dependency nesting (e.g., "is-even/is-odd")
-    // These should be filtered out as they're not direct packages
+  // O(1) check against known workspace paths
+  if (index.workspacePaths.has(prefix)) {
     return true;
   }
 
-  return false;
+  // O(1) check against workspace package names (scoped packages)
+  if (index.workspaceNames.has(prefix)) {
+    return true;
+  }
+
+  // Check for scoped workspace packages (e.g., "@quz/pkg1/lodash")
+  // The prefix must contain '/' to be a scoped package (e.g., "@scope/pkg")
+  // A prefix like just "@scope" without '/' is not a scoped package
+  if (prefix.startsWith('@') && prefix.includes('/')) {
+    return true;
+  }
+
+  // If the key looks like a simple scoped package (e.g., "@custom/lodash")
+  // with a single '/' where the first segment starts with '@', it's likely
+  // a scoped package alias, not a nested dependency
+  if (packageKey.indexOf('/') === lastSlash && packageKey.startsWith('@')) {
+    return false;
+  }
+
+  // This could be dependency nesting (e.g., "is-even/is-odd")
+  // These should be filtered out as they're not direct packages
+  return true;
 }
 
 /**
@@ -1305,6 +1306,30 @@ function getHoistedVersion(
  * O(1) lookup using pre-computed index instead of O(n) scan through all packages
  */
 function findResolvedVersion(
+  packageName: string,
+  versionSpec: string,
+  index: PackageIndex,
+  manifests?: BunLockFile['manifests']
+): string | null {
+  // Resolution depends only on (packageName, versionSpec) for a given lockfile
+  // (index and manifests are constant per parse), so memoize across edges.
+  const cacheKey = `${packageName}\n${versionSpec}`;
+  const cached = resolvedVersionCache.get(cacheKey);
+  if (cached !== undefined) {
+    return cached;
+  }
+
+  const resolved = computeResolvedVersion(
+    packageName,
+    versionSpec,
+    index,
+    manifests
+  );
+  resolvedVersionCache.set(cacheKey, resolved);
+  return resolved;
+}
+
+function computeResolvedVersion(
   packageName: string,
   versionSpec: string,
   index: PackageIndex,
@@ -1417,19 +1442,27 @@ function findBestVersionMatch(
     return semverVersions[0].version;
   }
 
-  // Return the highest satisfying version (similar to npm behavior)
-  // Sort versions in descending order and return the first one
-  const sortedVersions = satisfyingVersions.sort((a, b) => {
+  // Return the highest satisfying version (similar to npm behavior).
+  // Single-pass max instead of a full sort: only the top element is used, and
+  // the numeric-collation comparator is expensive, so O(n) comparisons beat
+  // O(n log n). Keeps the first element on ties, matching the previous stable
+  // descending sort followed by [0].
+  let best = satisfyingVersions[0];
+  for (let i = 1; i < satisfyingVersions.length; i++) {
+    const candidate = satisfyingVersions[i];
+    let cmp: number;
     try {
-      return b.version.localeCompare(a.version, undefined, {
+      cmp = candidate.version.localeCompare(best.version, undefined, {
         numeric: true,
         sensitivity: 'base',
       });
     } catch {
-      // Fallback to string comparison
-      return b.version.localeCompare(a.version);
+      cmp = candidate.version.localeCompare(best.version);
     }
-  });
+    if (cmp > 0) {
+      best = candidate;
+    }
+  }
 
-  return sortedVersions[0].version;
+  return best.version;
 }


### PR DESCRIPTION
## Current Behavior

Creating the project graph for a bun workspace parses `bun.lock` to build the external nodes and their dependency edges. On a large lockfile (~7,200 packages) the dependency phase takes close to a second. For every dependency edge the resolver re-runs semver `satisfies` across all candidate versions of a package and selects the highest with a full sort that compares versions via `String.localeCompare` with numeric collation, an expensive Intl comparator. The same `(package, range)` pairs are resolved over and over, and the nested-key check allocates a fresh array per package key via `split`/`join`.

## Expected Behavior

Version resolution is memoized per `(package, versionSpec)`, so each distinct pair is resolved once instead of per edge. The version selection replaces the full sort with a single-pass max using the same comparator, so the chosen version is unchanged. The nested-key prefix is computed with slash-index math instead of `split`/`join`.

Output is identical: same nodes and dependencies, verified byte-for-byte and against the existing parser tests. The memoization adds a small bounded per-lockfile resolution cache (~0.5MB) that is cleared when the lockfile changes.

## Performance

Measured on a real-world `bun.lock` (1.9 MB, ~7,200 packages, ~8,200 dependency edges), median of 31 runs with forced GC:

| Phase | Before | After | Speedup |
| :-- | --: | --: | :-: |
| createNodes | 43 ms | 41 ms | ~1x |
| createDependencies | 889 ms | 55 ms | **16x faster** |
| **Total** (nodes + deps) | **930 ms** | **97 ms** | **9.6x faster** |

The dependency phase is where the time went, and it drops from ~889 ms to ~55 ms.

## Related Issue(s)

NXC-3352

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/nxc-3352-caacfea8)
<!-- polygraph-session-end -->
