### PR TITLE
fix(linter): reconcile angular-eslint v22 breaking changes in flat config

### DIFF
--- a/packages/eslint/src/generators/convert-to-flat-config/angular-eslint.spec.ts
+++ b/packages/eslint/src/generators/convert-to-flat-config/angular-eslint.spec.ts
@@ -31,9 +31,8 @@ describe('migrateAngularEslintV22FlatConfig', () => {
 `;
     tree.write('apps/app/eslint.config.mjs', original);
 
-    const changed = await migrateAngularEslintV22FlatConfig(tree);
+    await migrateAngularEslintV22FlatConfig(tree);
 
-    expect(changed).toBe(false);
     expect(tree.read('apps/app/eslint.config.mjs', 'utf-8')).toBe(original);
   });
 
@@ -61,10 +60,9 @@ export default [
 `
     );
 
-    const changed = await migrateAngularEslintV22FlatConfig(tree);
+    await migrateAngularEslintV22FlatConfig(tree);
 
     const content = tree.read('apps/app/eslint.config.mjs', 'utf-8');
-    expect(changed).toBe(true);
     expect(content).not.toContain('compat.extends');
     expect(content).not.toContain('FlatCompat');
     expect(content).toMatch(/import angular from ['"]angular-eslint['"]/);
@@ -99,10 +97,9 @@ export default [
 `
     );
 
-    const changed = await migrateAngularEslintV22FlatConfig(tree);
+    await migrateAngularEslintV22FlatConfig(tree);
 
     const content = tree.read('apps/app/eslint.config.mjs', 'utf-8');
-    expect(changed).toBe(true);
     expect(content).not.toContain('process-inline-templates');
     expect(content).not.toContain('compat.extends');
     expect(content).not.toContain('FlatCompat');
@@ -135,10 +132,9 @@ export default [
 `
     );
 
-    const changed = await migrateAngularEslintV22FlatConfig(tree);
+    await migrateAngularEslintV22FlatConfig(tree);
 
     const content = tree.read('apps/app/eslint.config.mjs', 'utf-8');
-    expect(changed).toBe(true);
     expect(content).not.toContain('no-conflicting-lifecycle');
     expect(content).toContain('@angular-eslint/directive-selector');
     expect(content).toContain('@angular-eslint/use-lifecycle-interface');
@@ -295,9 +291,8 @@ export default [
 `;
     tree.write('apps/app/eslint.config.mjs', original);
 
-    const changed = await migrateAngularEslintV22FlatConfig(tree);
+    await migrateAngularEslintV22FlatConfig(tree);
 
-    expect(changed).toBe(false);
     expect(tree.read('apps/app/eslint.config.mjs', 'utf-8')).toBe(original);
   });
 
@@ -389,10 +384,9 @@ export default [
 `
     );
 
-    const changed = await migrateAngularEslintV22FlatConfig(tree);
+    await migrateAngularEslintV22FlatConfig(tree);
 
     const content = tree.read('apps/app/eslint.config.mjs', 'utf-8');
-    expect(changed).toBe(true);
     expect(content).not.toContain('process-inline-templates');
     expect(content).not.toContain('no-conflicting-lifecycle');
     expect(content).not.toContain('compat.config');
@@ -427,10 +421,9 @@ export default [
 `
     );
 
-    const changed = await migrateAngularEslintV22FlatConfig(tree);
+    await migrateAngularEslintV22FlatConfig(tree);
 
     const content = tree.read('apps/app/eslint.config.mjs', 'utf-8');
-    expect(changed).toBe(true);
     expect(content).not.toContain('compat.config');
     expect(content).not.toContain('FlatCompat');
     expect(content).toMatch(/import angular from ['"]angular-eslint['"]/);
@@ -462,10 +455,9 @@ export default [
 `
     );
 
-    const changed = await migrateAngularEslintV22FlatConfig(tree);
+    await migrateAngularEslintV22FlatConfig(tree);
 
     const content = tree.read('apps/app/eslint.config.mjs', 'utf-8');
-    expect(changed).toBe(true);
     expect(content).not.toContain('compat.config');
     // The collapse strips the arrow's own spreads by the actual parameter name,
     // so none is left dangling (a `...cfg` with no binding would throw on load).
@@ -496,11 +488,10 @@ export default [
 `;
     tree.write('apps/app/eslint.config.mjs', original);
 
-    const changed = await migrateAngularEslintV22FlatConfig(tree);
+    await migrateAngularEslintV22FlatConfig(tree);
 
     // The block carries env alongside extends, so it is left byte-for-byte intact
     // rather than partially rewritten into a broken config.
-    expect(changed).toBe(false);
     expect(tree.read('apps/app/eslint.config.mjs', 'utf-8')).toBe(original);
   });
 
@@ -593,9 +584,8 @@ export default [
 `
     );
 
-    const changed = await migrateAngularEslintV22FlatConfig(tree);
+    await migrateAngularEslintV22FlatConfig(tree);
 
-    expect(changed).toBe(true);
     expect(tree.read('apps/app/eslint.config.mjs', 'utf-8')).not.toContain(
       'no-conflicting-lifecycle'
     );

--- a/packages/eslint/src/generators/convert-to-flat-config/angular-eslint.spec.ts
+++ b/packages/eslint/src/generators/convert-to-flat-config/angular-eslint.spec.ts
@@ -1,0 +1,603 @@
+import 'nx/src/internal-testing-utils/mock-project-graph';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import { readJson, updateJson, type Tree } from '@nx/devkit';
+import { migrateAngularEslintV22FlatConfig } from './angular-eslint';
+
+describe('migrateAngularEslintV22FlatConfig', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  function setAngularEslintVersion(version: string): void {
+    updateJson(tree, 'package.json', (json) => {
+      json.devDependencies = {
+        ...json.devDependencies,
+        '@angular-eslint/eslint-plugin': version,
+      };
+      return json;
+    });
+  }
+
+  it('is a no-op below angular-eslint v22 (the refs are still valid)', async () => {
+    setAngularEslintVersion('^21.0.0');
+    const original = `export default [
+  {
+    files: ['**/*.ts'],
+    rules: { '@angular-eslint/no-conflicting-lifecycle': 'error' },
+  },
+];
+`;
+    tree.write('apps/app/eslint.config.mjs', original);
+
+    const changed = await migrateAngularEslintV22FlatConfig(tree);
+
+    expect(changed).toBe(false);
+    expect(tree.read('apps/app/eslint.config.mjs', 'utf-8')).toBe(original);
+  });
+
+  it('remaps the removed eslintrc configs to their flat-native counterparts', async () => {
+    setAngularEslintVersion('^22.0.0');
+    tree.write(
+      'apps/app/eslint.config.mjs',
+      `import { FlatCompat } from '@eslint/eslintrc';
+import js from '@eslint/js';
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+});
+
+export default [
+  ...compat.extends(
+    'plugin:@angular-eslint/recommended',
+    'plugin:@angular-eslint/all',
+    'plugin:@angular-eslint/template/recommended',
+    'plugin:@angular-eslint/template/accessibility',
+    'plugin:@angular-eslint/template/all'
+  ),
+];
+`
+    );
+
+    const changed = await migrateAngularEslintV22FlatConfig(tree);
+
+    const content = tree.read('apps/app/eslint.config.mjs', 'utf-8');
+    expect(changed).toBe(true);
+    expect(content).not.toContain('compat.extends');
+    expect(content).not.toContain('FlatCompat');
+    expect(content).toMatch(/import angular from ['"]angular-eslint['"]/);
+    expect(content).toContain('...angular.configs.tsRecommended');
+    expect(content).toContain('...angular.configs.tsAll');
+    expect(content).toContain('...angular.configs.templateRecommended');
+    expect(content).toContain('...angular.configs.templateAccessibility');
+    expect(content).toContain('...angular.configs.templateAll');
+  });
+
+  it('turns the process-inline-templates shim into a processor block and drops the orphaned FlatCompat', async () => {
+    setAngularEslintVersion('^22.0.0');
+    tree.write(
+      'apps/app/eslint.config.mjs',
+      `import nx from '@nx/eslint-plugin';
+import { FlatCompat } from '@eslint/eslintrc';
+import js from '@eslint/js';
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+});
+
+export default [
+  ...nx.configs['flat/angular'],
+  ...compat.extends('plugin:@angular-eslint/template/process-inline-templates'),
+  {
+    files: ['**/*.ts'],
+    rules: {},
+  },
+];
+`
+    );
+
+    const changed = await migrateAngularEslintV22FlatConfig(tree);
+
+    const content = tree.read('apps/app/eslint.config.mjs', 'utf-8');
+    expect(changed).toBe(true);
+    expect(content).not.toContain('process-inline-templates');
+    expect(content).not.toContain('compat.extends');
+    expect(content).not.toContain('FlatCompat');
+    expect(content).not.toContain('@eslint/eslintrc');
+    // The @eslint/js import only fed FlatCompat's recommendedConfig; it goes too.
+    expect(content).not.toContain('@eslint/js');
+    expect(content).toMatch(/import angular from ['"]angular-eslint['"]/);
+    expect(content).toContain('processor: angular.processInlineTemplates');
+    expect(content).toContain("files: ['**/*.ts']");
+    expect(content).toContain("nx.configs['flat/angular']");
+  });
+
+  it('removes the no-conflicting-lifecycle rule and leaves other rules', async () => {
+    setAngularEslintVersion('^22.0.0');
+    tree.write(
+      'apps/app/eslint.config.mjs',
+      `import nx from '@nx/eslint-plugin';
+
+export default [
+  ...nx.configs['flat/angular'],
+  {
+    files: ['**/*.ts'],
+    rules: {
+      '@angular-eslint/directive-selector': ['error', { type: 'attribute' }],
+      '@angular-eslint/no-conflicting-lifecycle': 'error',
+      '@angular-eslint/use-lifecycle-interface': 'error',
+    },
+  },
+];
+`
+    );
+
+    const changed = await migrateAngularEslintV22FlatConfig(tree);
+
+    const content = tree.read('apps/app/eslint.config.mjs', 'utf-8');
+    expect(changed).toBe(true);
+    expect(content).not.toContain('no-conflicting-lifecycle');
+    expect(content).toContain('@angular-eslint/directive-selector');
+    expect(content).toContain('@angular-eslint/use-lifecycle-interface');
+  });
+
+  it('keeps unrelated configs in a residual compat.extends and preserves FlatCompat', async () => {
+    setAngularEslintVersion('^22.0.0');
+    tree.write(
+      'apps/app/eslint.config.mjs',
+      `import { FlatCompat } from '@eslint/eslintrc';
+import js from '@eslint/js';
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+});
+
+export default [
+  ...compat.extends(
+    'plugin:@angular-eslint/recommended',
+    'plugin:custom/config'
+  ),
+];
+`
+    );
+
+    await migrateAngularEslintV22FlatConfig(tree);
+
+    const content = tree.read('apps/app/eslint.config.mjs', 'utf-8');
+    expect(content).toContain('...angular.configs.tsRecommended');
+    expect(content).toContain("...compat.extends('plugin:custom/config')");
+    expect(content).toContain('new FlatCompat');
+    expect(content).toContain('@eslint/eslintrc');
+  });
+
+  it('preserves argument order so rule precedence is unchanged', async () => {
+    setAngularEslintVersion('^22.0.0');
+    tree.write(
+      'apps/app/eslint.config.mjs',
+      `import { FlatCompat } from '@eslint/eslintrc';
+
+const compat = new FlatCompat({ baseDirectory: __dirname });
+
+export default [
+  ...compat.extends(
+    'plugin:custom/base',
+    'plugin:@angular-eslint/recommended'
+  ),
+];
+`
+    );
+
+    await migrateAngularEslintV22FlatConfig(tree);
+
+    const content = tree.read('apps/app/eslint.config.mjs', 'utf-8');
+    // custom/base was listed first, so its residual compat.extends must stay
+    // before the remapped angular config (flat config is last-wins).
+    expect(
+      content.indexOf("...compat.extends('plugin:custom/base')")
+    ).toBeLessThan(content.indexOf('...angular.configs.tsRecommended'));
+  });
+
+  it('keeps the @eslint/js import when it is still referenced', async () => {
+    setAngularEslintVersion('^22.0.0');
+    tree.write(
+      'apps/app/eslint.config.mjs',
+      `import { FlatCompat } from '@eslint/eslintrc';
+import js from '@eslint/js';
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+});
+
+export default [
+  js.configs.recommended,
+  ...compat.extends('plugin:@angular-eslint/recommended'),
+];
+`
+    );
+
+    await migrateAngularEslintV22FlatConfig(tree);
+
+    const content = tree.read('apps/app/eslint.config.mjs', 'utf-8');
+    expect(content).not.toContain('new FlatCompat');
+    // js is still used by the top-level js.configs.recommended, so its import stays.
+    expect(content).toContain('@eslint/js');
+    expect(content).toContain('js.configs.recommended');
+  });
+
+  it('does not delete a trailing comment on the preceding rule', async () => {
+    setAngularEslintVersion('^22.0.0');
+    tree.write(
+      'apps/app/eslint.config.mjs',
+      `export default [
+  {
+    files: ['**/*.ts'],
+    rules: {
+      '@angular-eslint/directive-selector': 'error', // keep this note
+      '@angular-eslint/no-conflicting-lifecycle': 'error',
+    },
+  },
+];
+`
+    );
+
+    await migrateAngularEslintV22FlatConfig(tree);
+
+    const content = tree.read('apps/app/eslint.config.mjs', 'utf-8');
+    expect(content).not.toContain('no-conflicting-lifecycle');
+    expect(content).toContain('keep this note');
+    expect(content).toContain('@angular-eslint/directive-selector');
+  });
+
+  it('removes a rule with a comment before its comma without leaving a dangling comma', async () => {
+    setAngularEslintVersion('^22.0.0');
+    tree.write(
+      'apps/app/eslint.config.mjs',
+      `export default [
+  {
+    files: ['**/*.ts'],
+    rules: {
+      '@angular-eslint/no-conflicting-lifecycle': 'error' /* drop me */,
+      '@angular-eslint/use-lifecycle-interface': 'error',
+    },
+  },
+];
+`
+    );
+
+    await migrateAngularEslintV22FlatConfig(tree);
+
+    const content = tree.read('apps/app/eslint.config.mjs', 'utf-8');
+    expect(content).not.toContain('no-conflicting-lifecycle');
+    expect(content).toContain('@angular-eslint/use-lifecycle-interface');
+    // No leading/double comma left where the rule (and its comment) was removed.
+    expect(content).not.toMatch(/{\s*,/);
+    expect(content).not.toMatch(/,\s*,/);
+  });
+
+  it('leaves configs without the removed refs untouched', async () => {
+    setAngularEslintVersion('^22.0.0');
+    const original = `import nx from '@nx/eslint-plugin';
+
+export default [
+  ...nx.configs['flat/angular'],
+  {
+    files: ['**/*.ts'],
+    rules: {
+      '@angular-eslint/directive-selector': ['error', { type: 'attribute' }],
+    },
+  },
+];
+`;
+    tree.write('apps/app/eslint.config.mjs', original);
+
+    const changed = await migrateAngularEslintV22FlatConfig(tree);
+
+    expect(changed).toBe(false);
+    expect(tree.read('apps/app/eslint.config.mjs', 'utf-8')).toBe(original);
+  });
+
+  it('adds the angular-eslint dependency when it introduces angular references', async () => {
+    setAngularEslintVersion('^22.0.0');
+    tree.write(
+      'apps/app/eslint.config.mjs',
+      `import { FlatCompat } from '@eslint/eslintrc';
+import js from '@eslint/js';
+
+const compat = new FlatCompat({ baseDirectory: __dirname });
+
+export default [
+  ...compat.extends('plugin:@angular-eslint/recommended'),
+];
+`
+    );
+
+    await migrateAngularEslintV22FlatConfig(tree);
+
+    const { devDependencies } = readJson(tree, 'package.json');
+    expect(devDependencies['angular-eslint']).toBe('^22.0.0');
+  });
+
+  it('reconciles both base and per-project flat configs', async () => {
+    setAngularEslintVersion('^22.0.0');
+    tree.write(
+      'eslint.base.config.mjs',
+      `export default [
+  {
+    files: ['**/*.ts'],
+    rules: { '@angular-eslint/no-conflicting-lifecycle': 'error' },
+  },
+];
+`
+    );
+    tree.write(
+      'apps/app/eslint.config.mjs',
+      `export default [
+  {
+    files: ['**/*.ts'],
+    rules: { '@angular-eslint/no-conflicting-lifecycle': ['error'] },
+  },
+];
+`
+    );
+
+    await migrateAngularEslintV22FlatConfig(tree);
+
+    expect(tree.read('eslint.base.config.mjs', 'utf-8')).not.toContain(
+      'no-conflicting-lifecycle'
+    );
+    expect(tree.read('apps/app/eslint.config.mjs', 'utf-8')).not.toContain(
+      'no-conflicting-lifecycle'
+    );
+  });
+
+  it('collapses the per-override compat.config().map() shape and drops the redundant processor', async () => {
+    setAngularEslintVersion('^22.0.0');
+    tree.write(
+      'apps/app/eslint.config.mjs',
+      `import { FlatCompat } from '@eslint/eslintrc';
+import js from '@eslint/js';
+import nx from '@nx/eslint-plugin';
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+});
+
+export default [
+  ...nx.configs['flat/base'],
+  ...nx.configs['flat/angular'],
+  ...compat
+    .config({
+      extends: ['plugin:@angular-eslint/template/process-inline-templates'],
+    })
+    .map((config) => ({
+      ...config,
+      files: ['**/*.ts'],
+      rules: {
+        ...config.rules,
+        '@angular-eslint/directive-selector': ['error', { type: 'attribute' }],
+        '@angular-eslint/no-conflicting-lifecycle': 'error',
+      },
+    })),
+  ...nx.configs['flat/angular-template'],
+];
+`
+    );
+
+    const changed = await migrateAngularEslintV22FlatConfig(tree);
+
+    const content = tree.read('apps/app/eslint.config.mjs', 'utf-8');
+    expect(changed).toBe(true);
+    expect(content).not.toContain('process-inline-templates');
+    expect(content).not.toContain('no-conflicting-lifecycle');
+    expect(content).not.toContain('compat.config');
+    expect(content).not.toContain('FlatCompat');
+    // The override's own files/rules survive the collapse.
+    expect(content).toContain("files: ['**/*.ts']");
+    expect(content).toContain('@angular-eslint/directive-selector');
+    // flat/angular already applies the processor, so the shim is dropped, not
+    // re-emitted, and no angular-eslint import is needed.
+    expect(content).toContain("nx.configs['flat/angular']");
+    expect(content).not.toContain('processor: angular.processInlineTemplates');
+    expect(content).not.toContain("from 'angular-eslint'");
+  });
+
+  it('remaps a direct angular-eslint config inside the per-override shape and scopes it to the files', async () => {
+    setAngularEslintVersion('^22.0.0');
+    tree.write(
+      'apps/app/eslint.config.mjs',
+      `import { FlatCompat } from '@eslint/eslintrc';
+
+const compat = new FlatCompat({ baseDirectory: __dirname });
+
+export default [
+  ...compat
+    .config({ extends: ['plugin:@angular-eslint/recommended'] })
+    .map((config) => ({
+      ...config,
+      files: ['**/*.ts'],
+      rules: { ...config.rules, 'no-console': 'error' },
+    })),
+];
+`
+    );
+
+    const changed = await migrateAngularEslintV22FlatConfig(tree);
+
+    const content = tree.read('apps/app/eslint.config.mjs', 'utf-8');
+    expect(changed).toBe(true);
+    expect(content).not.toContain('compat.config');
+    expect(content).not.toContain('FlatCompat');
+    expect(content).toMatch(/import angular from ['"]angular-eslint['"]/);
+    // The shared config is scoped to the override's files, as the .map did.
+    expect(content).toContain(
+      "...angular.configs.tsRecommended.map((c) => ({ ...c, files: ['**/*.ts'] }))"
+    );
+    // The override's own rules survive in the collapsed block.
+    expect(content).toContain("'no-console': 'error'");
+  });
+
+  it('collapses the per-override shape when the map parameter is not named config', async () => {
+    setAngularEslintVersion('^22.0.0');
+    tree.write(
+      'apps/app/eslint.config.mjs',
+      `import { FlatCompat } from '@eslint/eslintrc';
+
+const compat = new FlatCompat({ baseDirectory: __dirname });
+
+export default [
+  ...compat
+    .config({ extends: ['plugin:@angular-eslint/recommended'] })
+    .map((cfg) => ({
+      ...cfg,
+      files: ['**/*.ts'],
+      rules: { ...cfg.rules, 'no-console': 'error' },
+    })),
+];
+`
+    );
+
+    const changed = await migrateAngularEslintV22FlatConfig(tree);
+
+    const content = tree.read('apps/app/eslint.config.mjs', 'utf-8');
+    expect(changed).toBe(true);
+    expect(content).not.toContain('compat.config');
+    // The collapse strips the arrow's own spreads by the actual parameter name,
+    // so none is left dangling (a `...cfg` with no binding would throw on load).
+    expect(content).not.toContain('...cfg');
+    expect(content).toContain(
+      "...angular.configs.tsRecommended.map((c) => ({ ...c, files: ['**/*.ts'] }))"
+    );
+    expect(content).toContain("'no-console': 'error'");
+  });
+
+  it('leaves a compat.config block that carries more than extends untouched', async () => {
+    setAngularEslintVersion('^22.0.0');
+    const original = `import { FlatCompat } from '@eslint/eslintrc';
+
+const compat = new FlatCompat({ baseDirectory: __dirname });
+
+export default [
+  ...compat
+    .config({
+      env: { browser: true },
+      extends: ['plugin:@angular-eslint/recommended'],
+    })
+    .map((config) => ({
+      ...config,
+      files: ['**/*.ts'],
+    })),
+];
+`;
+    tree.write('apps/app/eslint.config.mjs', original);
+
+    const changed = await migrateAngularEslintV22FlatConfig(tree);
+
+    // The block carries env alongside extends, so it is left byte-for-byte intact
+    // rather than partially rewritten into a broken config.
+    expect(changed).toBe(false);
+    expect(tree.read('apps/app/eslint.config.mjs', 'utf-8')).toBe(original);
+  });
+
+  it('handles the per-override shape in a CJS config and removes the FlatCompat require', async () => {
+    setAngularEslintVersion('^22.0.0');
+    tree.write(
+      'apps/app/eslint.config.cjs',
+      `const { FlatCompat } = require('@eslint/eslintrc');
+const js = require('@eslint/js');
+const nx = require('@nx/eslint-plugin');
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+});
+
+module.exports = [
+  ...nx.configs['flat/angular'],
+  ...compat
+    .config({
+      extends: ['plugin:@angular-eslint/template/process-inline-templates'],
+    })
+    .map((config) => ({
+      ...config,
+      files: ['**/*.ts'],
+      rules: { ...config.rules, '@angular-eslint/directive-selector': 'error' },
+    })),
+];
+`
+    );
+
+    await migrateAngularEslintV22FlatConfig(tree);
+
+    const content = tree.read('apps/app/eslint.config.cjs', 'utf-8');
+    expect(content).not.toContain('process-inline-templates');
+    expect(content).not.toContain('compat.config');
+    expect(content).not.toContain('FlatCompat');
+    expect(content).not.toContain('@eslint/eslintrc');
+    expect(content).toContain('@angular-eslint/directive-selector');
+  });
+
+  it('preserves interleaved config order across multiple residual groups', async () => {
+    setAngularEslintVersion('^22.0.0');
+    tree.write(
+      'apps/app/eslint.config.mjs',
+      `import { FlatCompat } from '@eslint/eslintrc';
+
+const compat = new FlatCompat({ baseDirectory: __dirname });
+
+export default [
+  ...compat.extends(
+    'plugin:custom/a',
+    'plugin:@angular-eslint/recommended',
+    'plugin:custom/b',
+    'plugin:@angular-eslint/all'
+  ),
+];
+`
+    );
+
+    await migrateAngularEslintV22FlatConfig(tree);
+
+    const content = tree.read('apps/app/eslint.config.mjs', 'utf-8');
+    const aIndex = content.indexOf("...compat.extends('plugin:custom/a')");
+    const recIndex = content.indexOf('...angular.configs.tsRecommended');
+    const bIndex = content.indexOf("...compat.extends('plugin:custom/b')");
+    const allIndex = content.indexOf('...angular.configs.tsAll');
+    expect(aIndex).toBeGreaterThanOrEqual(0);
+    expect(recIndex).toBeGreaterThan(aIndex);
+    expect(bIndex).toBeGreaterThan(recIndex);
+    expect(allIndex).toBeGreaterThan(bIndex);
+  });
+
+  it('gates on the umbrella angular-eslint dependency when the scoped plugin is absent', async () => {
+    updateJson(tree, 'package.json', (json) => {
+      json.devDependencies = {
+        ...json.devDependencies,
+        'angular-eslint': '^22.0.0',
+      };
+      return json;
+    });
+    tree.write(
+      'apps/app/eslint.config.mjs',
+      `export default [
+  {
+    files: ['**/*.ts'],
+    rules: { '@angular-eslint/no-conflicting-lifecycle': 'error' },
+  },
+];
+`
+    );
+
+    const changed = await migrateAngularEslintV22FlatConfig(tree);
+
+    expect(changed).toBe(true);
+    expect(tree.read('apps/app/eslint.config.mjs', 'utf-8')).not.toContain(
+      'no-conflicting-lifecycle'
+    );
+  });
+});

--- a/packages/eslint/src/generators/convert-to-flat-config/angular-eslint.ts
+++ b/packages/eslint/src/generators/convert-to-flat-config/angular-eslint.ts
@@ -60,16 +60,15 @@ const FLAT_CONFIG_FILENAMES = new Set([
  *
  * Gated on angular-eslint v22+: the shims resolve on v18-v21, so rewriting them
  * there would be churn, and only the v22 flat exports are known here. Does not
- * format; the caller owns formatting. Returns whether any file changed.
+ * format; the caller owns formatting.
  */
 export async function migrateAngularEslintV22FlatConfig(
   tree: Tree
-): Promise<boolean> {
+): Promise<void> {
   if (!isAngularEslintV22OrLater(tree)) {
-    return false;
+    return;
   }
 
-  let changed = false;
   let needsAngularDependency = false;
 
   visitNotIgnoredFiles(tree, '.', (path) => {
@@ -85,7 +84,6 @@ export async function migrateAngularEslintV22FlatConfig(
     const { updated, introducedAngularRef } = rewriteContent(content);
     if (updated !== content) {
       tree.write(path, updated);
-      changed = true;
       needsAngularDependency ||= introducedAngularRef;
     }
   });
@@ -99,8 +97,6 @@ export async function migrateAngularEslintV22FlatConfig(
       true
     );
   }
-
-  return changed;
 }
 
 // The umbrella `angular-eslint` and the scoped `@angular-eslint/*` packages

--- a/packages/eslint/src/generators/convert-to-flat-config/angular-eslint.ts
+++ b/packages/eslint/src/generators/convert-to-flat-config/angular-eslint.ts
@@ -1,0 +1,575 @@
+import {
+  addDependenciesToPackageJson,
+  applyChangesToString,
+  ChangeType,
+  getDependencyVersionFromPackageJson,
+  StringChange,
+  visitNotIgnoredFiles,
+  type Tree,
+} from '@nx/devkit';
+import { coerce } from 'semver';
+import * as ts from 'typescript';
+import {
+  BASE_ESLINT_CONFIG_FILENAMES,
+  ESLINT_FLAT_CONFIG_FILENAMES,
+} from '../../utils/config-file';
+import {
+  addImportToFlatConfig,
+  removeImportFromFlatConfig,
+} from '../utils/flat-config/ast-utils';
+
+// angular-eslint v22 dropped the legacy eslintrc config format, so every
+// `plugin:@angular-eslint/*` shared config stops resolving. The converter emits
+// them as `compat.extends(...)` shims (it maps only `plugin:@nx/*` natively), so
+// those shims fail to load. Each removed eslintrc config has a flat-native
+// counterpart on the umbrella `angular-eslint` package; remap the shims to it.
+const ANGULAR_ESLINT_CONFIG_MAP: Record<string, string> = {
+  'plugin:@angular-eslint/recommended': 'tsRecommended',
+  'plugin:@angular-eslint/all': 'tsAll',
+  'plugin:@angular-eslint/template/recommended': 'templateRecommended',
+  'plugin:@angular-eslint/template/accessibility': 'templateAccessibility',
+  'plugin:@angular-eslint/template/all': 'templateAll',
+};
+
+// Not a shared config but a processor: v22 exposes it as `processInlineTemplates`,
+// applied via a `{ files, processor }` block rather than an extends spread.
+const PROCESS_INLINE_TEMPLATES =
+  'plugin:@angular-eslint/template/process-inline-templates';
+
+// angular-eslint v22 removed this rule; a config that still lists it throws on
+// load: "Could not find no-conflicting-lifecycle in plugin @angular-eslint".
+const REMOVED_RULE = '@angular-eslint/no-conflicting-lifecycle';
+
+const FLAT_CONFIG_FILENAMES = new Set([
+  ...ESLINT_FLAT_CONFIG_FILENAMES,
+  ...BASE_ESLINT_CONFIG_FILENAMES,
+]);
+
+/**
+ * Reconciles converted flat configs with angular-eslint v22's breaking changes so
+ * they load again. The converter carries the removed `plugin:@angular-eslint/*`
+ * configs as FlatCompat shims in two shapes: a bare `...compat.extends(...)` for
+ * top-level extends, and a `...compat.config({ extends }).map(...)` for per-override
+ * extends. This handles both: shared configs become their flat-native
+ * `angular.configs.*` counterparts, and `process-inline-templates` becomes a
+ * `processor` block. The per-override shape drops that block when `flat/angular`
+ * already applies the processor; the top-level shape keeps it. It also drops the
+ * removed `no-conflicting-lifecycle` rule, injects the `angular-eslint` import
+ * (and dependency) when it introduces `angular.*` references, and removes the
+ * FlatCompat scaffolding left unused afterwards.
+ *
+ * Gated on angular-eslint v22+: the shims resolve on v18-v21, so rewriting them
+ * there would be churn, and only the v22 flat exports are known here. Does not
+ * format; the caller owns formatting. Returns whether any file changed.
+ */
+export async function migrateAngularEslintV22FlatConfig(
+  tree: Tree
+): Promise<boolean> {
+  if (!isAngularEslintV22OrLater(tree)) {
+    return false;
+  }
+
+  let changed = false;
+  let needsAngularDependency = false;
+
+  visitNotIgnoredFiles(tree, '.', (path) => {
+    const fileName = path.split('/').pop();
+    if (!fileName || !FLAT_CONFIG_FILENAMES.has(fileName)) {
+      return;
+    }
+    const content = tree.read(path, 'utf-8');
+    if (!content || !referencesRemovedAngularEslint(content)) {
+      return;
+    }
+
+    const { updated, introducedAngularRef } = rewriteContent(content);
+    if (updated !== content) {
+      tree.write(path, updated);
+      changed = true;
+      needsAngularDependency ||= introducedAngularRef;
+    }
+  });
+
+  if (needsAngularDependency) {
+    addDependenciesToPackageJson(
+      tree,
+      {},
+      { 'angular-eslint': resolveAngularEslintVersion(tree) },
+      'package.json',
+      true
+    );
+  }
+
+  return changed;
+}
+
+// The umbrella `angular-eslint` and the scoped `@angular-eslint/*` packages
+// release in lockstep, so any one reflects the declared version. `nx migrate`
+// writes the version bump before migrations run, and the standalone generator
+// reads the currently installed version; either way package.json is the source.
+function readAngularEslintVersion(tree: Tree): string | undefined {
+  return (
+    getDependencyVersionFromPackageJson(
+      tree,
+      '@angular-eslint/eslint-plugin'
+    ) ??
+    getDependencyVersionFromPackageJson(tree, 'angular-eslint') ??
+    getDependencyVersionFromPackageJson(tree, '@angular-eslint/template-parser')
+  );
+}
+
+// Pin the umbrella to the major already installed, falling back to the latest
+// major nx generates when none is present. @nx/eslint can't read the canonical
+// pin from @nx/angular without inverting the package dependency (@nx/angular
+// depends on @nx/eslint), so the fallback is hardcoded; keep it in sync with
+// `angularEslintVersion` in packages/angular/src/utils/versions.ts.
+export function resolveAngularEslintVersion(tree: Tree): string {
+  const version = readAngularEslintVersion(tree);
+  const major = version ? coerce(version)?.major : undefined;
+
+  return major != null ? `^${major}.0.0` : '^22.0.0';
+}
+
+function isAngularEslintV22OrLater(tree: Tree): boolean {
+  const version = readAngularEslintVersion(tree);
+  const major = version ? coerce(version)?.major : undefined;
+
+  return major != null && major >= 22;
+}
+
+// Cheap pre-filter so untouched configs are neither parsed nor rewritten.
+function referencesRemovedAngularEslint(content: string): boolean {
+  return (
+    content.includes(REMOVED_RULE) ||
+    content.includes(PROCESS_INLINE_TEMPLATES) ||
+    Object.keys(ANGULAR_ESLINT_CONFIG_MAP).some((config) =>
+      content.includes(config)
+    )
+  );
+}
+
+function rewriteContent(content: string): {
+  updated: string;
+  introducedAngularRef: boolean;
+} {
+  // `flat/angular` (from `plugin:@nx/angular`) already applies the inline-template
+  // processor, so a process-inline-templates shim alongside it is redundant.
+  const flatAngularPresent = /flat\/angular['"]/.test(content);
+
+  // Rewrite the compat shims first, then drop the removed rule on the result: a
+  // rule can live inside a shim's `.map` body that pass 1 collapses, so doing
+  // both in one pass would collect overlapping edits.
+  const { updated: rewritten, introducedAngularRef } = rewriteAngularShims(
+    content,
+    flatAngularPresent
+  );
+  const updated = removeRule(rewritten, REMOVED_RULE);
+
+  if (updated === content) {
+    return { updated: content, introducedAngularRef: false };
+  }
+
+  let cleaned = removeOrphanedFlatCompat(updated);
+  if (introducedAngularRef) {
+    cleaned = addImportToFlatConfig(cleaned, 'angular', 'angular-eslint');
+  }
+
+  return { updated: cleaned, introducedAngularRef };
+}
+
+// Rewrites both shapes the converter emits for angular-eslint extends: the bare
+// `...compat.extends(...)` spread (top-level extends) and the
+// `...compat.config({ extends: [...] }).map(...)` spread (per-override extends).
+function rewriteAngularShims(
+  content: string,
+  flatAngularPresent: boolean
+): { updated: string; introducedAngularRef: boolean } {
+  const source = ts.createSourceFile(
+    '',
+    content,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.JS
+  );
+
+  const changes: StringChange[] = [];
+  let introducedAngularRef = false;
+
+  const replaceSpread = (node: ts.SpreadElement, replacement: string) => {
+    const start = node.getStart(source);
+    changes.push({ type: ChangeType.Delete, start, length: node.end - start });
+    changes.push({ type: ChangeType.Insert, index: start, text: replacement });
+  };
+
+  const visit = (node: ts.Node): void => {
+    if (ts.isSpreadElement(node) && ts.isCallExpression(node.expression)) {
+      // Shape 1: `...compat.extends('plugin:@angular-eslint/...', ...)`
+      if (node.expression.expression.getText(source) === 'compat.extends') {
+        const replacement = buildExtendsReplacement(node.expression.arguments);
+        if (replacement !== null) {
+          replaceSpread(node, replacement);
+          introducedAngularRef = true;
+        }
+      } else {
+        // Shape 2: `...compat.config({ extends: [...] }).map(config => (...))`
+        const replacement = buildConfigOverrideReplacement(
+          node,
+          source,
+          flatAngularPresent
+        );
+        if (replacement !== null) {
+          replaceSpread(node, replacement.text);
+          introducedAngularRef ||= replacement.introducedAngularRef;
+        }
+      }
+    }
+
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+
+  return {
+    updated: changes.length ? applyChangesToString(content, changes) : content,
+    introducedAngularRef,
+  };
+}
+
+// Removes every `<rule>: ...` property assignment (with its trailing comma and
+// any trailing comment) so the config loads once the rule no longer exists.
+function removeRule(content: string, rule: string): string {
+  const source = ts.createSourceFile(
+    '',
+    content,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.JS
+  );
+
+  const changes: StringChange[] = [];
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isPropertyAssignment(node) &&
+      (ts.isStringLiteral(node.name) ||
+        ts.isNoSubstitutionTemplateLiteral(node.name)) &&
+      node.name.text === rule
+    ) {
+      // `getStart` (not `getFullStart`) so leading trivia is left intact; that
+      // trivia includes any trailing comment on the previous property.
+      const start = node.getStart(source);
+      changes.push({
+        type: ChangeType.Delete,
+        start,
+        length: consumeTrailingComma(content, node.end) - start,
+      });
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+
+  return changes.length ? applyChangesToString(content, changes) : content;
+}
+
+type ClassifiedExtend =
+  | { kind: 'remapped'; config: string }
+  | { kind: 'processor' }
+  | { kind: 'other'; value: string };
+
+// Sorts one `extends` entry into the flat-native config it maps to, the inline-
+// template processor, or an unrelated config left in a residual compat shim.
+// Shared by both shim builders so the classification lives in one place.
+function classifyExtend(value: string): ClassifiedExtend {
+  const remapped = ANGULAR_ESLINT_CONFIG_MAP[value];
+  if (remapped) {
+    return { kind: 'remapped', config: remapped };
+  }
+  if (value === PROCESS_INLINE_TEMPLATES) {
+    return { kind: 'processor' };
+  }
+  return { kind: 'other', value };
+}
+
+// Rewrites the per-override shim shape
+// `...compat.config({ extends: [E] }).map(config => ({ ...config, files, rules }))`.
+// Shared configs in `extends` become `angular.configs.*` scoped to the override's
+// files; process-inline-templates becomes a processor block (dropped when
+// `flat/angular` already applies it). When `extends` empties, the
+// `compat.config(...).map(...)` wrapper collapses to the plain `{ files, rules }`
+// block it was scoping. Returns null when the block has no removed angular-eslint
+// config, or has a shape beyond a plain `{ extends }` object (left untouched
+// rather than risk corrupting it).
+function buildConfigOverrideReplacement(
+  node: ts.SpreadElement,
+  source: ts.SourceFile,
+  flatAngularPresent: boolean
+): { text: string; introducedAngularRef: boolean } | null {
+  const mapCall = node.expression;
+  // Structural match (not `getText`) so it survives prettier wrapping the
+  // `compat.config(...).map(...)` chain across lines in an already-formatted config.
+  if (
+    !ts.isCallExpression(mapCall) ||
+    mapCall.arguments.length !== 1 ||
+    !ts.isArrowFunction(mapCall.arguments[0]) ||
+    !ts.isPropertyAccessExpression(mapCall.expression) ||
+    mapCall.expression.name.text !== 'map' ||
+    !ts.isCallExpression(mapCall.expression.expression)
+  ) {
+    return null;
+  }
+  const configCall = mapCall.expression.expression;
+  if (
+    !ts.isPropertyAccessExpression(configCall.expression) ||
+    !ts.isIdentifier(configCall.expression.expression) ||
+    configCall.expression.expression.text !== 'compat' ||
+    configCall.expression.name.text !== 'config'
+  ) {
+    return null;
+  }
+
+  // Only handle a plain `{ extends: [...string literals] }` object; a block that
+  // also carries plugins/env/etc. is left alone rather than partially rewritten.
+  const configArg = configCall.arguments[0];
+  if (!configArg || !ts.isObjectLiteralExpression(configArg)) {
+    return null;
+  }
+  const extendsProp = configArg.properties.find(
+    (prop): prop is ts.PropertyAssignment =>
+      ts.isPropertyAssignment(prop) &&
+      ts.isIdentifier(prop.name) &&
+      prop.name.text === 'extends'
+  );
+  if (
+    !extendsProp ||
+    configArg.properties.length !== 1 ||
+    !ts.isArrayLiteralExpression(extendsProp.initializer) ||
+    !extendsProp.initializer.elements.every((el) => ts.isStringLiteral(el))
+  ) {
+    return null;
+  }
+
+  const remappedConfigs: string[] = [];
+  const otherConfigs: string[] = [];
+  let hasProcessor = false;
+  for (const element of extendsProp.initializer.elements) {
+    const classified = classifyExtend((element as ts.StringLiteral).text);
+    if (classified.kind === 'remapped') {
+      remappedConfigs.push(classified.config);
+    } else if (classified.kind === 'processor') {
+      hasProcessor = true;
+    } else {
+      otherConfigs.push(classified.value);
+    }
+  }
+  if (!remappedConfigs.length && !hasProcessor) {
+    return null;
+  }
+
+  const arrow = mapCall.arguments[0] as ts.ArrowFunction;
+  // The collapse branch strips the arrow's `...param` spreads by name, so the
+  // param must be a plain identifier; bail otherwise rather than mangle the body.
+  const mapParam = arrow.parameters[0]?.name;
+  if (!mapParam || !ts.isIdentifier(mapParam)) {
+    return null;
+  }
+  const paramName = mapParam.text;
+  const body = arrow.body;
+  if (
+    !ts.isParenthesizedExpression(body) ||
+    !ts.isObjectLiteralExpression(body.expression)
+  ) {
+    return null;
+  }
+  const filesProp = body.expression.properties.find(
+    (prop): prop is ts.PropertyAssignment =>
+      ts.isPropertyAssignment(prop) &&
+      ts.isIdentifier(prop.name) &&
+      prop.name.text === 'files'
+  );
+  if (!filesProp) {
+    return null;
+  }
+  const filesText = filesProp.initializer.getText(source);
+
+  const elements: string[] = [];
+  let introducedAngularRef = false;
+  for (const config of remappedConfigs) {
+    // Scope the shared config to the override's files, as the `.map` did.
+    elements.push(
+      `...angular.configs.${config}.map((c) => ({ ...c, files: ${filesText} }))`
+    );
+    introducedAngularRef = true;
+  }
+  if (hasProcessor && !flatAngularPresent) {
+    elements.push(
+      `{ files: ${filesText}, processor: angular.processInlineTemplates }`
+    );
+    introducedAngularRef = true;
+  }
+
+  if (otherConfigs.length) {
+    // Unrelated configs stay in a compat.config, keeping the override's
+    // files/rules through the original callback.
+    elements.push(
+      `...compat.config({ extends: [${otherConfigs
+        .map((config) => `'${config}'`)
+        .join(', ')}] }).map(${arrow.getText(source)})`
+    );
+  } else {
+    // Nothing left to extend: the `.map` only scoped the extended configs, so
+    // collapse it to the plain object it was building, dropping the arrow's now-
+    // orphaned `...param` / `...param.rules` spreads once the wrapper that bound
+    // the param is gone. The negative lookahead keeps `...param` from matching a
+    // longer identifier that merely starts with it.
+    const orphanedSpreads = new RegExp(
+      `\\.\\.\\.${escapeRegExp(paramName)}(?![\\w$])(?:\\.rules)?\\s*,?\\s*`,
+      'g'
+    );
+    elements.push(body.expression.getText(source).replace(orphanedSpreads, ''));
+  }
+
+  return { text: elements.join(',\n'), introducedAngularRef };
+}
+
+// Rewrites a `compat.extends(...)` shim's arguments in place: each removed
+// angular-eslint config becomes an `angular.configs.*` spread, process-inline-
+// templates becomes a processor block, and any unrelated configs stay in a
+// residual `compat.extends`. Argument order is preserved (flat config is
+// last-wins, so reordering would change rule precedence). Returns the joined
+// replacement array elements, or null when no argument is a config nx removed
+// (leave the shim untouched).
+function buildExtendsReplacement(
+  args: ts.NodeArray<ts.Expression>
+): string | null {
+  // The converter only ever emits string-literal arguments; bail on anything
+  // else rather than risk dropping an argument shape we don't understand.
+  if (!args.every((arg) => ts.isStringLiteral(arg))) {
+    return null;
+  }
+
+  const elements: string[] = [];
+  let pendingOtherConfigs: string[] = [];
+  let replacedAny = false;
+
+  // Emit the run of unrelated configs seen so far as one `compat.extends(...)`
+  // at their original position, so they keep their precedence relative to the
+  // remapped configs around them.
+  const flushOtherConfigs = () => {
+    if (pendingOtherConfigs.length) {
+      elements.push(
+        `...compat.extends(${pendingOtherConfigs
+          .map((config) => `'${config}'`)
+          .join(', ')})`
+      );
+      pendingOtherConfigs = [];
+    }
+  };
+
+  for (const arg of args) {
+    const classified = classifyExtend((arg as ts.StringLiteral).text);
+    if (classified.kind === 'remapped') {
+      flushOtherConfigs();
+      elements.push(`...angular.configs.${classified.config}`);
+      replacedAny = true;
+    } else if (classified.kind === 'processor') {
+      flushOtherConfigs();
+      elements.push(
+        `{ files: ['**/*.ts'], processor: angular.processInlineTemplates }`
+      );
+      replacedAny = true;
+    } else {
+      pendingOtherConfigs.push(classified.value);
+    }
+  }
+  flushOtherConfigs();
+
+  return replacedAny ? elements.join(',\n') : null;
+}
+
+// Extends past whitespace, comments, the trailing comma after `end`, and a
+// same-line comment after that comma so the enclosing object/array stays valid
+// after a deletion. Comments before the comma are skipped too: a comment between
+// the value and its comma would otherwise leave a dangling leading comma (a
+// syntax error); a comment after the comma belonged to the removed entry.
+function consumeTrailingComma(content: string, end: number): number {
+  const trailing = content
+    .slice(end)
+    .match(/^(?:\s|\/\/[^\n]*\n?|\/\*[\s\S]*?\*\/)*,[ \t]*(?:\/\/[^\n]*)?/);
+  return trailing ? end + trailing[0].length : end;
+}
+
+// After the shims are rewritten, the `const compat = new FlatCompat(...)`
+// declaration, its `@eslint/eslintrc` import, and the `@eslint/js` import that
+// fed its `recommendedConfig` may be left unused. Drop each once nothing else
+// references it, so the config carries no dead FlatCompat scaffolding.
+function removeOrphanedFlatCompat(content: string): string {
+  if (!content.includes('new FlatCompat')) {
+    return content;
+  }
+
+  const source = ts.createSourceFile(
+    '',
+    content,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.JS
+  );
+
+  const compatDeclaration = source.statements.find(
+    (node): node is ts.VariableStatement =>
+      ts.isVariableStatement(node) &&
+      node.declarationList.declarations.some(
+        (decl) => ts.isIdentifier(decl.name) && decl.name.text === 'compat'
+      )
+  );
+
+  // The declaration binding is itself one `compat` identifier; anything beyond
+  // it means the config still uses `compat`, so leave the scaffolding in place.
+  if (!compatDeclaration || countIdentifier(content, 'compat') > 1) {
+    return content;
+  }
+
+  let updated =
+    content.slice(0, compatDeclaration.getFullStart()) +
+    content.slice(compatDeclaration.end);
+  updated = removeImportFromFlatConfig(
+    updated,
+    'FlatCompat',
+    '@eslint/eslintrc'
+  );
+
+  // FlatCompat's `recommendedConfig: js.configs.recommended` is usually the only
+  // use of `@eslint/js`; once the declaration is gone and nothing else
+  // references `js`, drop that import too.
+  if (countIdentifier(updated, 'js') <= 1) {
+    updated = removeImportFromFlatConfig(updated, 'js', '@eslint/js');
+  }
+
+  return updated;
+}
+
+// Counts identifiers with the given name (declarations, bindings, and
+// references alike) so callers can tell an orphaned binding from a live one.
+function countIdentifier(content: string, name: string): number {
+  const source = ts.createSourceFile(
+    '',
+    content,
+    ts.ScriptTarget.Latest,
+    true,
+    ts.ScriptKind.JS
+  );
+  let count = 0;
+  const visit = (node: ts.Node): void => {
+    if (ts.isIdentifier(node) && node.text === name) {
+      count++;
+    }
+    ts.forEachChild(node, visit);
+  };
+  visit(source);
+
+  return count;
+}
+
+// Escapes regex metacharacters so a dynamic identifier (an arrow parameter name)
+// can be matched literally. Identifiers can legitimately contain `$`.
+function escapeRegExp(value: string): string {
+  return value.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+}

--- a/packages/eslint/src/generators/convert-to-flat-config/generator.spec.ts
+++ b/packages/eslint/src/generators/convert-to-flat-config/generator.spec.ts
@@ -322,6 +322,124 @@ describe('convert-to-flat-config generator', () => {
       ).toEqual('^22.0.0');
     });
 
+    it('remaps angular-eslint v22 removed configs the converter carried over as FlatCompat shims', async () => {
+      await lintProjectGenerator(tree, {
+        skipFormat: false,
+        linter: 'eslint',
+        project: 'test-lib',
+        setParserOptionsProject: false,
+        eslintConfigFormat: 'cjs',
+      });
+      updateJson(tree, 'package.json', (json) => {
+        json.devDependencies = {
+          ...(json.devDependencies ?? {}),
+          '@angular-eslint/eslint-plugin': '^22.0.0',
+        };
+        return json;
+      });
+      updateJson(tree, '.eslintrc.json', (json) => {
+        json.extends = ['plugin:@angular-eslint/recommended'];
+        return json;
+      });
+
+      await convertToFlatConfigGenerator(tree, options);
+
+      const content = tree.read('eslint.config.cjs', 'utf-8');
+      expect(content).toContain('angular.configs.tsRecommended');
+      expect(content).toContain("require('angular-eslint')");
+      expect(content).not.toContain(
+        "compat.extends('plugin:@angular-eslint/recommended')"
+      );
+      expect(
+        readJson(tree, 'package.json').devDependencies['angular-eslint']
+      ).toEqual('^22.0.0');
+    });
+
+    it('leaves the converter output untouched below angular-eslint v22', async () => {
+      await lintProjectGenerator(tree, {
+        skipFormat: false,
+        linter: 'eslint',
+        project: 'test-lib',
+        setParserOptionsProject: false,
+        eslintConfigFormat: 'cjs',
+      });
+      updateJson(tree, 'package.json', (json) => {
+        json.devDependencies = {
+          ...(json.devDependencies ?? {}),
+          '@angular-eslint/eslint-plugin': '^21.0.0',
+        };
+        return json;
+      });
+      updateJson(tree, '.eslintrc.json', (json) => {
+        json.extends = ['plugin:@angular-eslint/recommended'];
+        return json;
+      });
+
+      await convertToFlatConfigGenerator(tree, options);
+
+      const content = tree.read('eslint.config.cjs', 'utf-8');
+      expect(content).toContain(
+        "compat.extends('plugin:@angular-eslint/recommended')"
+      );
+      expect(content).not.toContain('angular.configs.tsRecommended');
+    });
+
+    it('reconciles the process-inline-templates shim the converter emits for a standard Angular override', async () => {
+      await lintProjectGenerator(tree, {
+        skipFormat: false,
+        linter: 'eslint',
+        project: 'test-lib',
+        setParserOptionsProject: false,
+        eslintConfigFormat: 'cjs',
+      });
+      updateJson(tree, 'package.json', (json) => {
+        json.devDependencies = {
+          ...(json.devDependencies ?? {}),
+          '@angular-eslint/eslint-plugin': '^22.0.0',
+        };
+        return json;
+      });
+      // The standard nx Angular `*.ts` override: the converter lifts
+      // plugin:@nx/angular to flat/angular and wraps process-inline-templates in
+      // a `compat.config({extends}).map(...)` shim, which fails to load on v22.
+      updateJson(tree, '.eslintrc.json', (json) => {
+        json.overrides = [
+          {
+            files: ['*.ts'],
+            extends: [
+              'plugin:@nx/angular',
+              'plugin:@angular-eslint/template/process-inline-templates',
+            ],
+            rules: {
+              '@angular-eslint/directive-selector': [
+                'error',
+                { type: 'attribute' },
+              ],
+              '@angular-eslint/no-conflicting-lifecycle': 'error',
+            },
+          },
+        ];
+        return json;
+      });
+
+      await convertToFlatConfigGenerator(tree, options);
+
+      const content = tree.read('eslint.config.cjs', 'utf-8');
+      // The shim and the removed rule are gone; the override's own rule survives.
+      expect(content).not.toContain('process-inline-templates');
+      expect(content).not.toContain('no-conflicting-lifecycle');
+      expect(content).not.toContain('compat.config');
+      expect(content).not.toContain('FlatCompat');
+      expect(content).toContain('flat/angular');
+      expect(content).toContain('@angular-eslint/directive-selector');
+      // flat/angular already applies the processor, so no processor block is
+      // re-emitted and no angular-eslint import is introduced.
+      expect(content).not.toContain(
+        'processor: angular.processInlineTemplates'
+      );
+      expect(content).not.toContain("from 'angular-eslint'");
+    });
+
     it('should add global eslintignores', async () => {
       await lintProjectGenerator(tree, {
         skipFormat: false,

--- a/packages/eslint/src/generators/convert-to-flat-config/generator.ts
+++ b/packages/eslint/src/generators/convert-to-flat-config/generator.ts
@@ -32,11 +32,14 @@ import {
   ESLINT_FLAT_CONFIG_FILENAMES,
 } from '../../utils/config-file';
 import { ESLint } from 'eslint';
-import { coerce } from 'semver';
 import {
   convertEslintJsonToFlatConfig,
   renameLegacyEslintrcFile,
 } from './converters/json-converter';
+import {
+  migrateAngularEslintV22FlatConfig,
+  resolveAngularEslintVersion,
+} from './angular-eslint';
 
 export async function convertToFlatConfigGenerator(
   tree: Tree,
@@ -97,7 +100,11 @@ export async function convertToFlatConfigGenerator(
   // replace references in nx.json and project.json files
   updateNxJsonConfig(tree, options.eslintConfigFormat);
   updateProjectConfigsInputs(tree, options.eslintConfigFormat);
-  // install missing packages
+
+  // The converter carries angular-eslint's removed eslintrc configs over as
+  // FlatCompat shims; on v22 those no longer resolve, so reconcile them to the
+  // flat-native config before formatting (no-op below v22).
+  await migrateAngularEslintV22FlatConfig(tree);
 
   if (!options.skipFormat) {
     await formatFiles(tree);
@@ -500,25 +507,4 @@ function processConvertedConfig(
     'package.json',
     keepExistingVersions
   );
-}
-
-// The umbrella `angular-eslint` and the scoped `@angular-eslint/*` packages
-// release in lockstep, so pin the umbrella to the major already installed,
-// falling back to the latest major nx generates when none is present. @nx/eslint
-// can't read the canonical pin from @nx/angular without inverting the package
-// dependency (@nx/angular depends on @nx/eslint), so the fallback is hardcoded;
-// keep it in sync with `angularEslintVersion` in packages/angular/src/utils/versions.ts.
-function resolveAngularEslintVersion(tree: Tree): string {
-  const installed =
-    getDependencyVersionFromPackageJson(
-      tree,
-      '@angular-eslint/eslint-plugin'
-    ) ??
-    getDependencyVersionFromPackageJson(
-      tree,
-      '@angular-eslint/template-parser'
-    );
-  const installedMajor = installed ? coerce(installed)?.major : undefined;
-
-  return installedMajor != null ? `^${installedMajor}.0.0` : '^22.0.0';
 }

--- a/packages/eslint/src/generators/utils/flat-config/ast-utils.ts
+++ b/packages/eslint/src/generators/utils/flat-config/ast-utils.ts
@@ -827,19 +827,27 @@ function removeImportFromFlatConfigCJS(
 ): string {
   const changes: StringChange[] = [];
   ts.forEachChild(source, (node) => {
-    // we can only combine object binding patterns
     if (
-      ts.isVariableStatement(node) &&
-      ts.isVariableDeclaration(node.declarationList.declarations[0]) &&
-      ts.isIdentifier(node.declarationList.declarations[0].name) &&
-      node.declarationList.declarations[0].name.getText() === variable &&
-      ts.isCallExpression(node.declarationList.declarations[0].initializer) &&
-      node.declarationList.declarations[0].initializer.expression.getText() ===
-        'require' &&
-      ts.isStringLiteral(
-        node.declarationList.declarations[0].initializer.arguments[0]
-      ) &&
-      node.declarationList.declarations[0].initializer.arguments[0].text === imp
+      !ts.isVariableStatement(node) ||
+      !ts.isVariableDeclaration(node.declarationList.declarations[0])
+    ) {
+      return;
+    }
+    const declaration = node.declarationList.declarations[0];
+    // Match both `const x = require(imp)` and a sole-binding
+    // `const { x } = require(imp)`, so an object-binding import is removed too.
+    const name = declaration.name;
+    const bindsVariable =
+      (ts.isIdentifier(name) && name.getText() === variable) ||
+      (ts.isObjectBindingPattern(name) &&
+        name.elements.length === 1 &&
+        name.elements[0].name.getText() === variable);
+    if (
+      bindsVariable &&
+      ts.isCallExpression(declaration.initializer) &&
+      declaration.initializer.expression.getText() === 'require' &&
+      ts.isStringLiteral(declaration.initializer.arguments[0]) &&
+      declaration.initializer.arguments[0].text === imp
     ) {
       changes.push({
         type: ChangeType.Delete,

--- a/packages/eslint/src/migrations/update-23-1-0/convert-to-flat-config.spec.ts
+++ b/packages/eslint/src/migrations/update-23-1-0/convert-to-flat-config.spec.ts
@@ -4,6 +4,7 @@ import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import {
   addProjectConfiguration,
   type NxJsonConfiguration,
+  readJson,
   type Tree,
   updateJson,
 } from '@nx/devkit';
@@ -160,6 +161,161 @@ describe('convert-to-flat-config migration', () => {
     expect(
       result!.agentContext.some((entry) => entry.includes('FlatCompat'))
     ).toBe(false);
+  });
+
+  it('reconciles angular-eslint v22 removed refs in an already-flat config', async () => {
+    updateJson(tree, 'package.json', (json) => {
+      json.devDependencies = {
+        ...json.devDependencies,
+        '@angular-eslint/eslint-plugin': '^22.0.0',
+      };
+      return json;
+    });
+    tree.write(
+      'eslint.config.mjs',
+      `import nx from '@nx/eslint-plugin';
+import { FlatCompat } from '@eslint/eslintrc';
+import js from '@eslint/js';
+
+const compat = new FlatCompat({
+  baseDirectory: __dirname,
+  recommendedConfig: js.configs.recommended,
+});
+
+export default [
+  ...nx.configs['flat/angular'],
+  ...compat.extends('plugin:@angular-eslint/template/process-inline-templates'),
+  {
+    files: ['**/*.ts'],
+    rules: { '@angular-eslint/no-conflicting-lifecycle': 'error' },
+  },
+];
+`
+    );
+
+    await update(tree);
+
+    const content = tree.read('eslint.config.mjs', 'utf-8');
+    expect(content).not.toContain('no-conflicting-lifecycle');
+    expect(content).not.toContain('process-inline-templates');
+    expect(content).not.toContain('FlatCompat');
+    expect(content).toContain("import angular from 'angular-eslint'");
+    expect(content).toContain('processor: angular.processInlineTemplates');
+  });
+
+  it('reconciles angular-eslint v22 exactly once when converting an eslintrc root', async () => {
+    updateJson(tree, 'package.json', (json) => {
+      json.devDependencies = {
+        ...json.devDependencies,
+        '@angular-eslint/eslint-plugin': '^22.0.0',
+      };
+      return json;
+    });
+    tree.write(
+      '.eslintrc.json',
+      JSON.stringify({
+        root: true,
+        extends: ['plugin:@angular-eslint/recommended'],
+      })
+    );
+
+    await update(tree);
+
+    // The generator converts the root and reconciles the shim during conversion,
+    // so the migration's explicit second pass is a no-op: the import is injected
+    // once and the dependency added once, not duplicated.
+    const content = tree.read('eslint.config.mjs', 'utf-8');
+    expect(content).toContain('...angular.configs.tsRecommended');
+    expect(content).not.toContain('FlatCompat');
+    expect(
+      content.match(/import angular from ['"]angular-eslint['"]/g)
+    ).toHaveLength(1);
+    const { devDependencies } = readJson(tree, 'package.json');
+    expect(devDependencies['angular-eslint']).toMatch(/^\^22\./);
+  });
+
+  it('leaves angular-eslint refs intact before v22 (rule is still valid)', async () => {
+    updateJson(tree, 'package.json', (json) => {
+      json.devDependencies = {
+        ...json.devDependencies,
+        '@angular-eslint/eslint-plugin': '^21.0.0',
+      };
+      return json;
+    });
+    tree.write(
+      'eslint.config.mjs',
+      `export default [
+  {
+    files: ['**/*.ts'],
+    rules: { '@angular-eslint/no-conflicting-lifecycle': 'error' },
+  },
+];
+`
+    );
+
+    await update(tree);
+
+    expect(tree.read('eslint.config.mjs', 'utf-8')).toContain(
+      'no-conflicting-lifecycle'
+    );
+  });
+
+  it('reconciles project flat configs even when the root config is JavaScript-based', async () => {
+    updateJson(tree, 'package.json', (json) => {
+      json.devDependencies = {
+        ...json.devDependencies,
+        '@angular-eslint/eslint-plugin': '^22.0.0',
+      };
+      return json;
+    });
+    // A JavaScript-based root config makes rootState 'js', so the generator does
+    // not run; a project already on flat config must still be reconciled.
+    tree.write('.eslintrc.js', 'module.exports = { root: true };');
+    tree.write(
+      'apps/app/eslint.config.mjs',
+      `export default [
+  {
+    files: ['**/*.ts'],
+    rules: { '@angular-eslint/no-conflicting-lifecycle': 'error' },
+  },
+];
+`
+    );
+
+    await update(tree);
+
+    expect(tree.read('apps/app/eslint.config.mjs', 'utf-8')).not.toContain(
+      'no-conflicting-lifecycle'
+    );
+  });
+
+  it('reconciles project flat configs even when there is no root config', async () => {
+    updateJson(tree, 'package.json', (json) => {
+      json.devDependencies = {
+        ...json.devDependencies,
+        '@angular-eslint/eslint-plugin': '^22.0.0',
+      };
+      return json;
+    });
+    // No root ESLint config of any shape makes rootState 'none'; a project
+    // already on flat config must still be reconciled, not skipped by the
+    // no-root-config early return.
+    tree.write(
+      'apps/app/eslint.config.mjs',
+      `export default [
+  {
+    files: ['**/*.ts'],
+    rules: { '@angular-eslint/no-conflicting-lifecycle': 'error' },
+  },
+];
+`
+    );
+
+    await update(tree);
+
+    expect(tree.read('apps/app/eslint.config.mjs', 'utf-8')).not.toContain(
+      'no-conflicting-lifecycle'
+    );
   });
 
   it.each(['.eslintrc.js', '.eslintrc.cjs'])(

--- a/packages/eslint/src/migrations/update-23-1-0/convert-to-flat-config.ts
+++ b/packages/eslint/src/migrations/update-23-1-0/convert-to-flat-config.ts
@@ -75,18 +75,17 @@ export default async function update(tree: Tree): Promise<{
     // conversion, so the converted flat configs load without agent repair.
     await convertToFlatConfigGenerator(tree, {
       keepExistingVersions: true,
-      skipFormat: false,
+      skipFormat: true,
     });
   }
 
-  // Reconcile angular-eslint v22's removed eslintrc configs in any flat config
-  // present. Runs for every root state: project-level flat configs can exist
-  // even when the root is JavaScript-based (so the generator never ran), already
-  // flat, or absent entirely. No-op for the converted root above (idempotent).
-  // Gated on v22.
-  if (await migrateAngularEslintV22FlatConfig(tree)) {
-    await formatFiles(tree);
-  }
+  // Reconcile angular-eslint v22's removed eslintrc configs in any flat config.
+  // Runs for every root state: project-level flat configs can exist even when the
+  // root is JavaScript-based (so the generator never ran), already flat, or
+  // absent. No-op for the converted root above (idempotent).
+  await migrateAngularEslintV22FlatConfig(tree);
+
+  await formatFiles(tree);
 
   if (rootState === 'none') {
     // Nothing to migrate beyond the angular-eslint reconciliation above.

--- a/packages/eslint/src/migrations/update-23-1-0/convert-to-flat-config.ts
+++ b/packages/eslint/src/migrations/update-23-1-0/convert-to-flat-config.ts
@@ -1,9 +1,16 @@
-import { getProjects, readJson, readNxJson, type Tree } from '@nx/devkit';
+import {
+  formatFiles,
+  getProjects,
+  readJson,
+  readNxJson,
+  type Tree,
+} from '@nx/devkit';
 import {
   BASE_ESLINT_CONFIG_FILENAMES,
   ESLINT_FLAT_CONFIG_FILENAMES,
 } from '../../utils/config-file';
 import { convertToFlatConfigGenerator } from '../../generators/convert-to-flat-config/generator';
+import { migrateAngularEslintV22FlatConfig } from '../../generators/convert-to-flat-config/angular-eslint';
 
 // Output formatters ESLint removed in v9. Built-in names only; community
 // formatter packages (referenced by their package name) keep working.
@@ -62,16 +69,28 @@ export default async function update(tree: Tree): Promise<{
   const unsupportedOptionTargets = findUnsupportedFlatConfigOptionTargets(tree);
 
   const rootState = detectRootConfigState(tree);
-  if (rootState === 'none') {
-    // No ESLint configuration to migrate.
-    return;
-  }
 
   if (rootState === 'convertible') {
+    // The generator reconciles angular-eslint v22's removed configs as part of
+    // conversion, so the converted flat configs load without agent repair.
     await convertToFlatConfigGenerator(tree, {
       keepExistingVersions: true,
       skipFormat: false,
     });
+  }
+
+  // Reconcile angular-eslint v22's removed eslintrc configs in any flat config
+  // present. Runs for every root state: project-level flat configs can exist
+  // even when the root is JavaScript-based (so the generator never ran), already
+  // flat, or absent entirely. No-op for the converted root above (idempotent).
+  // Gated on v22.
+  if (await migrateAngularEslintV22FlatConfig(tree)) {
+    await formatFiles(tree);
+  }
+
+  if (rootState === 'none') {
+    // Nothing to migrate beyond the angular-eslint reconciliation above.
+    return;
   }
 
   const agentContext: string[] = [


### PR DESCRIPTION
## Current Behavior

`angular-eslint` v22 dropped the legacy eslintrc config format and removed the `no-conflicting-lifecycle` rule. When nx converts an eslintrc Angular workspace to flat config (via the `@nx/eslint:convert-to-flat-config` generator or the 23.1 migration), it carries the removed `plugin:@angular-eslint/*` shared configs over as `FlatCompat` shims and may keep the removed rule. After the v22 bump those configs no longer resolve, so ESLint fails to load the flat config (`Could not find "no-conflicting-lifecycle" in plugin "@angular-eslint"`, and unresolvable `extends`). Project configs that an older nx already converted to flat config hit the same failure.

## Expected Behavior

The converted (or already-flat) config loads cleanly on `angular-eslint` v22. Both shim shapes the converter emits are reconciled to their flat-native equivalents:

- Top-level `...compat.extends(...)` and per-override `...compat.config({ extends }).map(...)` shared configs become `angular.configs.*`, scoped to the same files.
- `process-inline-templates` becomes a `processor` block, dropped when `flat/angular` already applies it.
- The removed `no-conflicting-lifecycle` rule is dropped.
- The `angular-eslint` import and devDependency are injected, and the now-unused `FlatCompat` scaffolding is stripped.

The reconciliation runs in both the `convert-to-flat-config` generator and the `update-23-1-0` migration, so fresh conversions and already-flat project configs are both covered. It is gated on `angular-eslint` v22+ (the shims still resolve on v18-v21).

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/nx-23.1.0-beta-migration-b1195096)
<!-- polygraph-session-end -->