### PR TITLE
fix(linter): update terminal cli regex for local-dist build

### DIFF
--- a/packages/eslint-plugin/src/utils/runtime-lint-utils.spec.ts
+++ b/packages/eslint-plugin/src/utils/runtime-lint-utils.spec.ts
@@ -402,7 +402,7 @@ describe('is terminal run', () => {
     // Mac: $run npx nx lint my-nx-project
     mockProcessArgv([
       '/Users/user/.nvm/versions/node/v16.13.0/bin/node',
-      '/Users/user/my-repo/node_modules/nx/bin/run-executor.js',
+      '/Users/user/my-repo/node_modules/nx/dist/bin/run-executor.js',
       '{"targetDescription":{"project":"my-nx-project","target":"lint"}',
     ]);
     expect(isTerminalRun()).toBe(true);
@@ -412,7 +412,7 @@ describe('is terminal run', () => {
     // Windows: $run npx nx lint my-nx-project
     mockProcessArgv([
       'C:\\Program Files\\nodejs\\node.exe',
-      'C:\\dev\\my-repo\\node_modules\\nx\\bin\\run-executor.js',
+      'C:\\dev\\my-repo\\node_modules\\nx\\dist\\bin\\run-executor.js',
       '{"targetDescription":{"project":"my-nx-project","target":"lint"}',
     ]);
     expect(isTerminalRun()).toBe(true);

--- a/packages/eslint-plugin/src/utils/runtime-lint-utils.ts
+++ b/packages/eslint-plugin/src/utils/runtime-lint-utils.ts
@@ -449,7 +449,7 @@ export function hasBuildExecutor(
 
 const ESLINT_REGEX = /node_modules.*[\/\\]eslint(?:\.js)?$/;
 const JEST_REGEX = /node_modules\/.bin\/jest$/; // when we run unit tests in jest
-const NRWL_CLI_REGEX = /nx[\/\\]bin[\/\\]run-executor\.js$/;
+const NRWL_CLI_REGEX = /nx[\/\\]dist[\/\\]bin[\/\\]run-executor\.js$/;
 
 export function isTerminalRun(): boolean {
   return (


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->
Since NX 22.7.0 the NX package is published with a dist folder. This change causes the eslint-plugin to read the ProjectGraph for every file as the regex if it runs in the terminal never matched. This change updates the regex to include the dist folder

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->
Only the first file reads the ProjectGraph all the other files can read it from cache (globalThis). The regex for isTerminalRun should not impact this behavior

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #36199
