### PR TITLE
fix(testing): update eslint-plugin-cypress for ESLint 9 compatibility

### DIFF
--- a/packages/cypress/migrations.json
+++ b/packages/cypress/migrations.json
@@ -127,6 +127,18 @@
           "alwaysAddToPackageJson": false
         }
       }
+    },
+    "23.1.0-eslint-plugin-cypress": {
+      "version": "23.1.0-beta.6",
+      "requires": {
+        "eslint-plugin-cypress": ">=2.0.0 <3.5.0"
+      },
+      "packages": {
+        "eslint-plugin-cypress": {
+          "version": "^3.5.0",
+          "alwaysAddToPackageJson": false
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
## Current Behavior

`eslint-plugin-cypress` v2.x predates ESLint 9: its rules call the removed `context.getAncestors()` / `getScope()` APIs. After a workspace bumps to ESLint 9 during the Nx 23.1 migration, nothing updates the plugin, so cypress lint crashes at runtime (or the affected rules get disabled as a workaround, which silently drops their coverage).

## Expected Behavior

A new `packageJsonUpdate` bumps `eslint-plugin-cypress` to `^3.5.0` (the version `@nx/cypress` installs for new projects, which supports ESLint 9) when the installed version is below it. `alwaysAddToPackageJson` is false, so it is a no-op for workspaces without the plugin, and the version-range gate skips workspaces already on v3.5 or newer.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/nx-23.1.0-beta-migration-b1195096)
<!-- polygraph-session-end -->