### PR TITLE
fix(angular): guard the trust-proxy-headers migration against unreadable files

### DIFF
--- a/packages/angular/src/migrations/update-23-1-0/add-trust-proxy-headers.ts
+++ b/packages/angular/src/migrations/update-23-1-0/add-trust-proxy-headers.ts
@@ -20,6 +20,9 @@ export default async function (tree: Tree) {
       }
 
       const content = tree.read(path, 'utf-8');
+      if (!content) {
+        return;
+      }
       // Skip already-migrated files and files not instantiating an SSR engine.
       if (
         content.includes(TODO_COMMENT) ||


### PR DESCRIPTION
## Current Behavior

The Angular 23.1 `add-trust-proxy-headers` migration reads each candidate `.ts` file and calls `.includes()` on the result without a null check. When `tree.read` returns null for an unreadable file, the migration throws and aborts mid-run, leaving a partially-applied migration.

## Expected Behavior

The migration skips a file whose contents cannot be read, matching the sibling 23.1 migrations, and completes without aborting.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/nx-23.1.0-beta-migration-b1195096)
<!-- polygraph-session-end -->