### PR TITLE
fix(linter): harden the ESLint v9 flat-config migration

### DIFF
--- a/packages/eslint/src/migrations/update-23-1-0/convert-to-flat-config.md
+++ b/packages/eslint/src/migrations/update-23-1-0/convert-to-flat-config.md
@@ -179,7 +179,9 @@ The set of rules the user explicitly configured before the migration is in `<adv
    nx run-many -t lint
    ```
 
-2. For each rule that now reports errors:
+2. Tell a rule violation apart from a plugin crash. If a project fails with a thrown error instead of rule findings - a `TypeError` such as `context.getAncestors is not a function`, a `Could not find "<rule>" in plugin "<name>"` / `couldn't find the config "<name>" to extend from`, or a plugin that fails to load - the plugin predates ESLint v9; this is not a changed preset default. Do NOT disable the rule (that silently drops its coverage); update the plugin instead (section 6), then re-run lint and continue.
+
+3. For each rule that now reports errors (findings, not a thrown error):
    - If the rule ID is NOT in the user's explicit list, it came from a changed preset default. Disable it in the relevant flat config with a short comment explaining why.
    - If the rule ID IS in the user's explicit list, the user chose it. Leave it as-is and report it in your handoff summary.
 
@@ -200,6 +202,7 @@ export default [
 **Action items**:
 
 - [ ] Run lint and collect every newly reported rule.
+- [ ] Treat a plugin crash (a thrown error, not rule findings) as a version incompatibility: update the plugin (section 6), never disable its rules to silence it.
 - [ ] Disable preset-originated rules that the user did not configure.
 - [ ] Never disable or weaken a rule the user explicitly configured.
 - [ ] Never edit source files to satisfy a newly enabled rule.
@@ -240,6 +243,7 @@ npm install --save-dev eslint-formatter-junit
 
 - **Removed CLI flags and executor options**: `--rulesdir`, `--ext`, and `--resolve-plugins-relative-to` were removed. The matching `@nx/eslint:lint` options (`rulesdir`, `resolvePluginsRelativeTo`, `ignorePath`) are not supported for flat config. Move file targeting into the config via the `files` and `ignores` keys.
 - **No eslintrc auto-merge**: flat config does not merge `.eslintrc.*` files found up the tree. Every setting must live in `eslint.config.*`.
+- **Third-party plugins that predate ESLint v9**: an installed ESLint plugin that was not updated for v9 breaks at lint time - its rules call the removed `context` APIs below, or it only ships an eslintrc config that no longer loads. This surfaces as a thrown error (see section 4), not a new rule violation. List the installed plugins from `package.json` (`dependencies`/`devDependencies` matching `eslint-plugin-*` or `@<scope>/eslint-plugin-*`), and for each confirm its version supports ESLint v9 (its changelog, or that `peerDependencies.eslint` allows `>=9`). Update any that do not, and prefer the plugin's flat entry point where it ships one (for example `eslint-plugin-cypress/flat`). Update the plugin rather than disabling its rules.
 - **Local rule API moved to `SourceCode`** (only relevant if the workspace authors its own rules):
   - `context.getScope()` to `sourceCode.getScope(node)`
   - `context.getAncestors()` to `sourceCode.getAncestors(node)`
@@ -252,6 +256,7 @@ npm install --save-dev eslint-formatter-junit
 **Action items**:
 
 - [ ] Remove unsupported CLI flags and executor options; move targeting into `files` / `ignores`.
+- [ ] Update any installed third-party ESLint plugin that does not yet support ESLint v9, preferring its flat entry point; do not disable its rules to work around a load error.
 - [ ] Update local rules to the `SourceCode` API and add `meta.schema` where required.
 
 ---

--- a/packages/eslint/src/migrations/update-23-1-0/remove-removed-typescript-eslint-extension-rules.spec.ts
+++ b/packages/eslint/src/migrations/update-23-1-0/remove-removed-typescript-eslint-extension-rules.spec.ts
@@ -143,4 +143,20 @@ describe('remove-removed-typescript-eslint-extension-rules migration', () => {
 
     expect(tree.read('eslint.config.mjs', 'utf-8')).toEqual(config);
   });
+
+  it('cleans the shared eslint.base.config.* files too', async () => {
+    tree.write(
+      'eslint.base.config.mjs',
+      `export default [
+  { rules: { '@typescript-eslint/indent': ['error', 2] } },
+];
+`
+    );
+
+    await update(tree);
+
+    expect(tree.read('eslint.base.config.mjs', 'utf-8')).not.toContain(
+      '@typescript-eslint/indent'
+    );
+  });
 });

--- a/packages/eslint/src/migrations/update-23-1-0/remove-removed-typescript-eslint-extension-rules.ts
+++ b/packages/eslint/src/migrations/update-23-1-0/remove-removed-typescript-eslint-extension-rules.ts
@@ -5,7 +5,8 @@ import * as ts from 'typescript';
 
 // Inlined rather than imported from the @nx/eslint utils so this migration stays
 // self-contained - a migration should not depend on a shared list that can change
-// in a later version.
+// in a later version. Includes the shared `eslint.base.config.*` files: they are
+// flat configs too and can carry the removed rules a project config inherits.
 const ESLINT_FLAT_CONFIG_FILENAMES = [
   'eslint.config.cjs',
   'eslint.config.js',
@@ -13,6 +14,14 @@ const ESLINT_FLAT_CONFIG_FILENAMES = [
   'eslint.config.cts',
   'eslint.config.ts',
   'eslint.config.mts',
+  'eslint.base.js',
+  'eslint.base.ts',
+  'eslint.base.config.cjs',
+  'eslint.base.config.js',
+  'eslint.base.config.mjs',
+  'eslint.base.config.cts',
+  'eslint.base.config.ts',
+  'eslint.base.config.mts',
 ];
 
 // Formatting/extension rules typescript-eslint removed in v8 (moved to


### PR DESCRIPTION
## Current Behavior

Two gaps in the Nx 23.1 ESLint v9 migration:

- The deterministic `remove-removed-typescript-eslint-extension-rules` migration only scanned per-project `eslint.config.*` files, so a shared `eslint.base.config.*` carrying a rule typescript-eslint removed in v8 was skipped and kept failing to load.
- The `convert-to-flat-config` agentic prompt told the agent to disable any rule that reports errors. An installed ESLint plugin too old for ESLint 9 crashes at lint time (removed `context` APIs, or an eslintrc-only config), so the agent disabled those rules instead of updating the plugin, silently dropping coverage.

## Expected Behavior

- The rule-removal migration also processes the shared `eslint.base.config.*` files.
- The `convert-to-flat-config` prompt distinguishes a plugin crash from a rule violation and instructs the agent to check each installed plugin's ESLint v9 support and update the incompatible ones (preferring a flat entry point) rather than disabling their rules.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/nx-23.1.0-beta-migration-b1195096)
<!-- polygraph-session-end -->