### PR TITLE
docs(misc): link Docker page to dedicated compute cluster

### DIFF
--- a/astro-docs/sidebar.mts
+++ b/astro-docs/sidebar.mts
@@ -522,6 +522,10 @@ const technologiesGroups: SidebarItems = [
             label: 'Rsbuild',
             link: 'technologies/build-tools/rsbuild/introduction',
           },
+          {
+            label: 'Docker',
+            link: 'technologies/build-tools/docker/introduction',
+          },
         ],
       },
       {

--- a/astro-docs/src/content/docs/technologies/build-tools/docker/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/docker/introduction.mdoc
@@ -22,10 +22,6 @@ nx add @nx/docker
 
 This will install the correct version of `@nx/docker` to match the version of Nx you are using.
 
-{% aside title="Minimum Nx Version" type="caution" %}
-The `@nx/docker` plugin only became available in Nx 21.4.0-beta.9. Your Nx Workspace will need to be on this version or higher to use it.
-{% /aside %}
-
 ### How @nx/docker infers tasks
 
 The `@nx/docker` plugin will create a task for any project that has a Dockerfile present. It will infer the following tasks:
@@ -182,15 +178,19 @@ This configuration:
 - Enables Docker BuildKit for improved build performance
 - Injects build arguments and environment variables from the CI/CD pipeline
 
+## Set up CI
+
+In CI, Nx runs [`nx affected`](/docs/features/ci-features/affected) to rebuild and retest only the projects a change touches, and [caches](/docs/features/cache-task-results) results to skip repeated work.
+
+For a complete pipeline, see [Set up CI](/docs/getting-started/setup-ci).
+
+{% aside type="note" title="Building Docker images on Nx Agents" %}
+To build Docker images on Nx Agents, your organization needs the [dedicated compute cluster](/docs/features/ci-features/dedicated-compute-cluster) add-on. It reserves an isolated Nx Cloud environment that runs Docker-in-Docker, which agents need to build and push container images.
+{% /aside %}
+
 ## Using Nx release to publish Docker images
 
 The `@nx/docker` plugin provides a `nx-release-publish` target for publishing docker images to a registry.
 [Nx Release](/docs/features/manage-releases) was also updated to support versioning docker images, generating changelogs, and publishing docker images to a registry through a single command.
 
 You can learn more about how to manage releases for Docker Images in the [Release Docker Images](/docs/guides/nx-release/release-docker-images) guide.
-
-## Set up CI
-
-In CI, Nx runs [`nx affected`](/docs/features/ci-features/affected) to rebuild and retest only the projects a change touches, and [caches](/docs/features/cache-task-results) results to skip repeated work.
-
-For a complete pipeline, see [Set up CI](/docs/getting-started/setup-ci).


### PR DESCRIPTION
## Current Behavior

The Docker introduction page has no pointer to the dedicated compute cluster add-on, which Docker users need to build images on Nx Agents. The page is also missing from the Build tools sidebar group.

## Expected Behavior

- Info note in the Set up CI section links to the dedicated compute cluster add-on.
- Set up CI section moved above the Nx release publish section.
- Removed the minimum Nx version caution.
- Docker added to the Build tools sidebar group.

## Related Issue(s)

DOC-543

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/docs-docker-9f342ee2)
<!-- polygraph-session-end -->