### PR TITLE
docs(nx-cloud): link Settings > Add-ons to cloud shortcut

### DIFF
--- a/astro-docs/src/content/docs/features/CI Features/dedicated-compute-cluster.mdoc
+++ b/astro-docs/src/content/docs/features/CI Features/dedicated-compute-cluster.mdoc
@@ -26,7 +26,7 @@ add-ons that require isolation in order to run with elevated capabilities.
 
 {% aside type="note" title="Nx Cloud add-on" %}
 The **dedicated compute cluster** is an Nx Cloud add-on. Manage it under
-**Settings > Add-ons** for your organization. Nx Enterprise customers on
+[**Settings > Add-ons**](https://cloud.nx.app/go/organization/add-ons) for your organization. Nx Enterprise customers on
 [single-tenant](/docs/enterprise/single-tenant/overview) deployments already run in a dedicated
 environment and get these capabilities through their deployment.
 {% /aside %}
@@ -64,7 +64,7 @@ custom agent images and DinD workloads.
 
 A dedicated compute cluster is provisioned through your organization settings:
 
-1. Open **Settings > Add-ons** for your organization.
+1. Open [**Settings > Add-ons**](https://cloud.nx.app/go/organization/add-ons) for your organization.
 2. On the **Dedicated compute cluster** card, click **Request add-on** and confirm.
 3. You will be notified via email when the cluster is ready to use.
 

--- a/astro-docs/src/content/docs/features/CI Features/docker-layer-caching.mdoc
+++ b/astro-docs/src/content/docs/features/CI Features/docker-layer-caching.mdoc
@@ -19,12 +19,12 @@ build pulls it from a registry cache instead of rebuilding it, cutting image bui
 {% aside type="note" title="Requires a dedicated compute cluster" %}
 Docker layer caching is an Nx Cloud add-on that runs on a
 [dedicated compute cluster](/docs/features/ci-features/dedicated-compute-cluster). Request the
-cluster, then enable this add-on under **Settings > Add-ons**.
+cluster, then enable this add-on under [**Settings > Add-ons**](https://cloud.nx.app/go/organization/add-ons).
 {% /aside %}
 
 You can enable Docker layer caching through your organization settings:
 
-1. Open **Settings > Add-ons** for your organization.
+1. Open [**Settings > Add-ons**](https://cloud.nx.app/go/organization/add-ons) for your organization.
 2. Under **Dedicated compute cluster** card, find **Docker layer caching** and click **Request add-on** and confirm.
 
 When the add-on is enabled, Nx Cloud runs a registry cache inside your dedicated cluster and injects

--- a/astro-docs/src/content/docs/features/CI Features/docker-read-through-cache.mdoc
+++ b/astro-docs/src/content/docs/features/CI Features/docker-read-through-cache.mdoc
@@ -30,12 +30,12 @@ It also protects your organization from Docker registry outages.
 {% aside type="note" title="Requires a dedicated compute cluster" %}
 The Docker read-through cache is an Nx Cloud add-on that runs on a
 [dedicated compute cluster](/docs/features/ci-features/dedicated-compute-cluster). Request the
-cluster, then enable this add-on under **Settings > Add-ons**.
+cluster, then enable this add-on under [**Settings > Add-ons**](https://cloud.nx.app/go/organization/add-ons).
 {% /aside %}
 
 You can enable Docker read-through cache through your organization settings:
 
-1. Open **Settings > Add-ons** for your organization.
+1. Open [**Settings > Add-ons**](https://cloud.nx.app/go/organization/add-ons) for your organization.
 2. Under **Dedicated compute cluster** card, find **Docker read-through cache** and click **Request add-on** and confirm.
 
 Once enabled, it works automatically. You don't change your Dockerfiles, `docker pull` commands, or

--- a/astro-docs/src/content/docs/features/CI Features/npm-read-through-cache.mdoc
+++ b/astro-docs/src/content/docs/features/CI Features/npm-read-through-cache.mdoc
@@ -24,12 +24,12 @@ It also protects your organization from npm registry outages.
 {% aside type="note" title="Requires a dedicated compute cluster" %}
 The npm read-through cache is an Nx Cloud add-on that runs on a
 [dedicated compute cluster](/docs/features/ci-features/dedicated-compute-cluster). Request the
-cluster, then enable this add-on under **Settings > Add-ons**.
+cluster, then enable this add-on under [**Settings > Add-ons**](https://cloud.nx.app/go/organization/add-ons).
 {% /aside %}
 
 You can enable npm read-through cache through your organization settings:
 
-1. Open **Settings > Add-ons** for your organization.
+1. Open [**Settings > Add-ons**](https://cloud.nx.app/go/organization/add-ons) for your organization.
 2. Under **Dedicated compute cluster** card, find **npm read-through cache** and click **Request add-on** and confirm.
 
 When the add-on is enabled, Nx Cloud runs a caching proxy in your dedicated cluster that sits in

--- a/astro-docs/src/content/docs/features/CI Features/resource-usage.mdoc
+++ b/astro-docs/src/content/docs/features/CI Features/resource-usage.mdoc
@@ -25,7 +25,7 @@ out-of-memory (OOM) errors, and pick the right agent size for your workload, all
 which task caused a spike.
 
 {% aside type="note" title="Nx Cloud add-on" %}
-Resource usage is a standalone Nx Cloud add-on. Enable it under **Settings > Add-ons** for your
+Resource usage is a standalone Nx Cloud add-on. Enable it under [**Settings > Add-ons**](https://cloud.nx.app/go/organization/add-ons) for your
 organization.
 {% /aside %}
 
@@ -35,7 +35,7 @@ Resource usage requires Nx 22.1 or later.
 
 ## Enabling resource usage
 
-Enable the add-on under **Settings > Add-ons**, or from the **Enable resource profiling** prompt on
+Enable the add-on under [**Settings > Add-ons**](https://cloud.nx.app/go/organization/add-ons), or from the **Enable resource profiling** prompt on
 the **Analysis** tab of any CI pipeline execution.
 
 Once the add-on is active:

--- a/astro-docs/src/content/docs/features/CI Features/sandboxing.mdoc
+++ b/astro-docs/src/content/docs/features/CI Features/sandboxing.mdoc
@@ -21,7 +21,7 @@ restore.
 {% aside type="note" title="Nx Cloud add-on" %}
 Sandboxing is an Nx Cloud add-on that runs on a
 [dedicated compute cluster](/docs/features/ci-features/dedicated-compute-cluster). Request the
-cluster, then enable sandboxing under **Settings > Add-ons**.
+cluster, then enable sandboxing under [**Settings > Add-ons**](https://cloud.nx.app/go/organization/add-ons).
 {% /aside %}
 
 {% aside type="caution" title="Nx 22.6+ Required" %}
@@ -244,7 +244,7 @@ Sandboxing requires a
 [Nx Agents](/docs/features/ci-features/distribute-task-execution).
 It is not supported when you [bring your own compute](/docs/guides/nx-cloud/bring-your-own-compute).
 
-1. Request a dedicated compute cluster under **Settings > Add-ons**, if you don't already have one.
+1. Request a dedicated compute cluster under [**Settings > Add-ons**](https://cloud.nx.app/go/organization/add-ons), if you don't already have one.
 2. Enable **Sandboxing** on the same page. If the cluster is still being provisioned, sandboxing is
    queued and activates automatically once the cluster is ready.
 

--- a/astro-docs/src/content/docs/reference/Nx Cloud/launch-templates.mdoc
+++ b/astro-docs/src/content/docs/reference/Nx Cloud/launch-templates.mdoc
@@ -74,7 +74,7 @@ A launch template's `image` defines the available base software for the agent ma
 Docker-in-Docker (DinD) runs on a
 [dedicated compute cluster](/docs/features/ci-features/dedicated-compute-cluster). Every agent in
 the cluster can run DinD, so your tasks can build and push container images or run Testcontainers.
-Request the add-on under **Settings > Add-ons**.
+Request the add-on under [**Settings > Add-ons**](https://cloud.nx.app/go/organization/add-ons).
 
 Nx Enterprise [single-tenant](/docs/enterprise/single-tenant/overview) customers get DinD through
 their dedicated deployment.


### PR DESCRIPTION
## Current Behavior
Add-on docs say "Settings > Add-ons" as plain text.

## Expected Behavior
Each mention links to https://cloud.nx.app/go/organization/add-ons.

## Related Issue(s)
Fixes NXC-4600
