### PR TITLE
fix(gradle): derive dependent-task input extensions from the task model instead of scanning disk

### DIFF
--- a/e2e/gradle/src/gradle-cache.test.ts
+++ b/e2e/gradle/src/gradle-cache.test.ts
@@ -1,0 +1,84 @@
+import {
+  cleanupProject,
+  createFile,
+  newProject,
+  runCLI,
+  tmpProjPath,
+  uniq,
+  updateFile,
+} from '@nx/e2e-utils';
+import { readdirSync, statSync } from 'fs';
+import { join, relative } from 'path';
+
+import { createGradleProject } from './utils/create-gradle-project';
+
+describe('Gradle cache invalidation', () => {
+  const gradleProjectName = uniq('my-gradle-project');
+
+  beforeAll(() => {
+    newProject({ packages: [] });
+    createGradleProject(gradleProjectName, 'kotlin');
+    // Created before the graph is computed so it is tracked as an input.
+    createFile('list/src/main/resources/config.conf', 'setting = initial\n');
+    runCLI(`add @nx/gradle`);
+  });
+  afterAll(() => cleanupProject());
+
+  // A cache hit renders as "[local cache]", "[remote cache]", or, when the
+  // outputs on disk already match, "[existing outputs match the cache]".
+  const fromCache = (task: string) =>
+    new RegExp(`${task}.*\\[(local cache|remote cache|existing outputs match)`);
+
+  it('should rebuild on source and resource changes and hit cache otherwise', () => {
+    // Fresh workspace: first build misses, rebuild hits.
+    let output = runCLI('run list:jar', { verbose: true });
+    expect(output).not.toMatch(fromCache('list:jar'));
+    output = runCLI('run list:jar', { verbose: true });
+    expect(output).toMatch(fromCache('list:jar'));
+
+    // Source change (a new function, so the bytecode changes): compilation
+    // and jar rerun, then both cache again.
+    const sourceFile = findFirstFile(
+      join(tmpProjPath(), 'list/src/main/kotlin'),
+      '.kt'
+    );
+    updateFile(
+      relative(tmpProjPath(), sourceFile),
+      (content) => `${content}\nfun cacheInvalidationProbe(): Int = 42\n`
+    );
+    output = runCLI('run list:jar', { verbose: true });
+    expect(output).not.toMatch(fromCache('list:compileKotlin'));
+    expect(output).not.toMatch(fromCache('list:jar'));
+    output = runCLI('run list:jar', { verbose: true });
+    expect(output).toMatch(fromCache('list:jar'));
+
+    // Resource change: jar repackages while compilation stays cached, then
+    // caches again.
+    updateFile('list/src/main/resources/config.conf', 'setting = changed\n');
+    output = runCLI('run list:jar', { verbose: true });
+    expect(output).not.toMatch(fromCache('list:jar'));
+    expect(output).toMatch(fromCache('list:compileKotlin'));
+    output = runCLI('run list:jar', { verbose: true });
+    expect(output).toMatch(fromCache('list:jar'));
+
+    // Unrelated file: cache hit.
+    createFile('list/notes.md', 'not an input\n');
+    output = runCLI('run list:jar', { verbose: true });
+    expect(output).toMatch(fromCache('list:jar'));
+  });
+});
+
+function findFirstFile(dir: string, extension: string): string {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      const found = findFirstFile(full, extension);
+      if (found) {
+        return found;
+      }
+    } else if (entry.endsWith(extension)) {
+      return full;
+    }
+  }
+  return '';
+}

--- a/e2e/gradle/src/gradle-cache.test.ts
+++ b/e2e/gradle/src/gradle-cache.test.ts
@@ -31,9 +31,9 @@ describe('Gradle cache invalidation', () => {
 
   it('should rebuild on source and resource changes and hit cache otherwise', () => {
     // Fresh workspace: first build misses, rebuild hits.
-    let output = runCLI('run list:jar', { verbose: true });
+    let output = runCLI('build list', { verbose: true });
     expect(output).not.toMatch(fromCache('list:jar'));
-    output = runCLI('run list:jar', { verbose: true });
+    output = runCLI('build list', { verbose: true });
     expect(output).toMatch(fromCache('list:jar'));
 
     // Source change (a new function, so the bytecode changes): compilation
@@ -46,32 +46,32 @@ describe('Gradle cache invalidation', () => {
       relative(tmpProjPath(), sourceFile),
       (content) => `${content}\nfun cacheInvalidationProbe(): Int = 42\n`
     );
-    output = runCLI('run list:jar', { verbose: true });
+    output = runCLI('build list', { verbose: true });
     expect(output).not.toMatch(fromCache('list:compileKotlin'));
     expect(output).not.toMatch(fromCache('list:jar'));
-    output = runCLI('run list:jar', { verbose: true });
+    output = runCLI('build list', { verbose: true });
     expect(output).toMatch(fromCache('list:jar'));
 
     // Resource change: jar repackages while compilation stays cached, then
     // caches again.
     updateFile('list/src/main/resources/config.conf', 'setting = changed\n');
-    output = runCLI('run list:jar', { verbose: true });
+    output = runCLI('build list', { verbose: true });
     expect(output).not.toMatch(fromCache('list:jar'));
     expect(output).toMatch(fromCache('list:compileKotlin'));
-    output = runCLI('run list:jar', { verbose: true });
+    output = runCLI('build list', { verbose: true });
     expect(output).toMatch(fromCache('list:jar'));
 
     // NEW resource file, added after the graph was computed: still invalidates,
     // because inputs are directory globs rather than a frozen file list.
     createFile('list/src/main/resources/added-later.conf', 'setting = new\n');
-    output = runCLI('run list:jar', { verbose: true });
+    output = runCLI('build list', { verbose: true });
     expect(output).not.toMatch(fromCache('list:jar'));
-    output = runCLI('run list:jar', { verbose: true });
+    output = runCLI('build list', { verbose: true });
     expect(output).toMatch(fromCache('list:jar'));
 
     // Unrelated file: cache hit.
     createFile('list/notes.md', 'not an input\n');
-    output = runCLI('run list:jar', { verbose: true });
+    output = runCLI('build list', { verbose: true });
     expect(output).toMatch(fromCache('list:jar'));
   });
 });

--- a/e2e/gradle/src/gradle-cache.test.ts
+++ b/e2e/gradle/src/gradle-cache.test.ts
@@ -61,6 +61,14 @@ describe('Gradle cache invalidation', () => {
     output = runCLI('run list:jar', { verbose: true });
     expect(output).toMatch(fromCache('list:jar'));
 
+    // NEW resource file, added after the graph was computed: still invalidates,
+    // because inputs are directory globs rather than a frozen file list.
+    createFile('list/src/main/resources/added-later.conf', 'setting = new\n');
+    output = runCLI('run list:jar', { verbose: true });
+    expect(output).not.toMatch(fromCache('list:jar'));
+    output = runCLI('run list:jar', { verbose: true });
+    expect(output).toMatch(fromCache('list:jar'));
+
     // Unrelated file: cache hit.
     createFile('list/notes.md', 'not an input\n');
     output = runCLI('run list:jar', { verbose: true });

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/ProjectUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/ProjectUtils.kt
@@ -94,7 +94,7 @@ private fun createNodeForProjectImpl(
     externalNodes = gradleTargets.externalNodes
     logger.info(
         "${Date()} ${project.name} createNodeForProject: get nodes and external nodes for $projectRoot")
-  } catch (e: Exception) {
+  } catch (e: Throwable) {
     logger.info("${project.name}: get nodes error: ${e.message}")
     nodes = emptyMap()
     externalNodes = emptyMap()
@@ -309,7 +309,7 @@ private fun processTargetsForProjectImpl(
       }
 
       logger.info("$now ${project.name}: Processed task ${task.path}")
-    } catch (e: Exception) {
+    } catch (e: Throwable) {
       logger.error("Error processing task ${task.path}: ${e.message}", e)
     }
   }

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -177,85 +177,88 @@ fun getGradleFilesInputs(workspaceRoot: String): List<String> {
  * build: it never inspects the working tree, so it yields the same result on a clean checkout and
  * on a fully built one.
  *
+ * This is the extension-level view used by unit tests. The production input derivation uses
+ * [dependentOutputPatterns], which formats patterns per dependency and falls back to a catch-all
+ * for uncharacterizable directory outputs.
+ *
  * Test tasks consume .class + .jar (compiled code and library jars on the test classpath). Compile
  * tasks consume .class (Kotlin also emits .kotlin_module) from upstream compile tasks. Archive
  * dependents contribute their declared archive extension (jar, war, tar, and gz/bz2 for compressed
- * tars). Any dependent that declares concrete FILE outputs contributes those files' extensions.
- *
- * A Copy/Sync/ProcessResources task declares its outputs as a directory (no inner extensions), but
- * it also declares its sources via `from(...)` and is pass-through, so its declared concrete-file
- * source extensions equal its effective output extensions. Those declared source paths are read
- * without touching disk (see [declaredCopySourceExtensions]).
- *
- * Directory outputs and non-file sources (FileTrees, providers, task outputs) are intentionally NOT
- * expanded: the task model does not declare which file extensions land inside them, and scanning
- * would reintroduce a dependency on transient on-disk state. Producers whose artifacts must
- * invalidate consumers should declare file outputs (or wire `from(task)` delegation) so their
- * extensions are visible here.
+ * tars). Any dependent that declares concrete FILE outputs contributes those files' extensions. A
+ * pass-through Copy/Sync task contributes the extensions of its declared concrete-file sources
+ * (read without touching disk; see [declaredCopySourceExtensions]).
  */
 fun inferExtensionsFromInputProperties(
     task: Task,
     dependentTasks: Set<Task>,
     gitIgnoreClassifier: GitIgnoreClassifier
-): Set<String> =
-    collectDependentOutputExtensions(task, dependentTasks, gitIgnoreClassifier).extensions
-
-/**
- * Result of characterizing a task's dependency outputs: the per-extension globs to emit, plus
- * whether a catch-all is required because some dependency's outputs could not be reduced to
- * extensions.
- */
-data class DependentOutputExtensions(val extensions: Set<String>, val needsCatchAll: Boolean)
-
-/**
- * Characterize the outputs of a task's dependencies from the Gradle task model, deciding per
- * dependency whether it can be reduced to concrete extensions or needs a conservative catch-all.
- *
- * For each dependency we union [extensionsForTaskType], [declaredArchiveExtensions],
- * [declaredFileOutputExtensions] and [declaredCopySourceExtensions]. If that yields extensions we
- * contribute them; if it yields nothing but the dependency declares a DIRECTORY output whose
- * contents we cannot characterize, we flag a catch-all. A dependency that declares NO outputs is
- * left alone — a `dependentTasksOutputFiles` glob is matched within a dependency's declared
- * outputs, so there is nothing for a catch-all to match.
- *
- * The consuming task's own type and pass-through copy sources also contribute extensions (matched
- * against dependency outputs), but never trigger a catch-all — the catch-all is strictly about
- * dependency outputs.
- */
-fun collectDependentOutputExtensions(
-    task: Task,
-    dependentTasks: Set<Task>,
-    gitIgnoreClassifier: GitIgnoreClassifier
-): DependentOutputExtensions {
+): Set<String> {
   val extensions = mutableSetOf<String>()
-  var needsCatchAll = false
 
-  // Extensions implied by this task's own type (what it consumes from upstream) and, for a
-  // pass-through Copy/Sync task, its declared concrete-file sources (what it forwards downstream
-  // even when the producer that generated them declares no outputs).
+  // The consuming task's own type (what it consumes from upstream) and pass-through copy sources.
+  // NOTE: the task itself is NOT routed through dependencyOutputExtensions — that would leak its
+  // archive/file-output extensions into its own inputs (e.g. a Jar task must not gain a **/*.jar
+  // self-input).
   extensions.addAll(extensionsForTaskType(task))
   extensions.addAll(declaredCopySourceExtensions(task, gitIgnoreClassifier))
 
+  // Each dependency's declared output model (dispatched by task kind).
   dependentTasks.forEach { depTask ->
-    val depExtensions = mutableSetOf<String>()
-    depExtensions.addAll(extensionsForTaskType(depTask))
-    depExtensions.addAll(declaredArchiveExtensions(depTask))
-    depExtensions.addAll(declaredFileOutputExtensions(depTask))
-    depExtensions.addAll(declaredCopySourceExtensions(depTask, gitIgnoreClassifier))
-
-    if (depExtensions.isNotEmpty()) {
-      extensions.addAll(depExtensions)
-    } else if (declaresDirectoryOutput(depTask)) {
-      // Uncharacterizable: a directory output whose file extensions the task model does not
-      // declare (e.g. a Copy whose only source is a FileTree, or an opaque custom task with just
-      // an @OutputDirectory). Fall back to "**/*" so this dependency's outputs are still hashed.
-      // Known limitation: a MIXED Copy (concrete source + FileTree source) is characterized by its
-      // concrete part and will NOT get a catch-all, so the FileTree part is under-covered. Rare.
-      needsCatchAll = true
-    }
+    extensions.addAll(dependencyOutputExtensions(depTask, gitIgnoreClassifier))
   }
 
-  return DependentOutputExtensions(extensions.toSet(), needsCatchAll)
+  return extensions.toSet()
+}
+
+/**
+ * Output extensions a DEPENDENCY task produces, dispatched by task kind.
+ *
+ * Archive and copy are first-class branches because their extensions are READ from declared
+ * instance data (archiveExtension plus Tar compression; the from(...) sources) rather than being
+ * constant per class. Compile and test tasks are constant per class, so they delegate to
+ * [extensionsForTaskType] via the else branch — no duplication, and that constant map stays
+ * reusable for the task-itself heuristic. [declaredFileOutputExtensions] is the universal floor:
+ * any task may declare a concrete OutputFile on top of its kind.
+ *
+ * Ordered so that an archive task (which is also an AbstractCopyTask) is characterized by its
+ * archive output, not its sources. Nothing here inspects the working tree.
+ */
+private fun dependencyOutputExtensions(task: Task, gitIgnore: GitIgnoreClassifier): Set<String> {
+  val byKind =
+      when {
+        task is AbstractArchiveTask -> declaredArchiveExtensions(task)
+        task is AbstractCopyTask -> declaredCopySourceExtensions(task, gitIgnore)
+        else -> extensionsForTaskType(task) // Kotlin/Java compile, Test, else {}
+      }
+  // Universal baseline: any task may declare concrete FILE outputs beyond its kind.
+  return byKind + declaredFileOutputExtensions(task)
+}
+
+/**
+ * Derive the dependentTasksOutputFiles patterns for a single dependency task from the Gradle task
+ * model. Returns patterns already formatted as per-extension globs or the wildcard catch-all, with
+ * the non-input IC extensions (such as bin) filtered out — ready to wrap in a
+ * dependentTasksOutputFiles input. Never inspects the working tree, so the result is identical on a
+ * clean checkout and a fully built one.
+ *
+ * The extensions come from [dependencyOutputExtensions]; if none are nameable but the task declares
+ * a DIRECTORY output, a conservative wildcard catch-all is emitted so the dependency's outputs are
+ * still hashed (a Copy whose only source is a FileTree, or an opaque custom task).
+ *
+ * Known limitation: a MIXED Copy (concrete source plus FileTree source) is characterized by its
+ * concrete part and will NOT get the catch-all, so the FileTree part is under-covered. Rare.
+ */
+private fun dependentOutputPatterns(task: Task, gitIgnore: GitIgnoreClassifier): Set<String> {
+  val extensions = dependencyOutputExtensions(task, gitIgnore)
+  return when {
+    extensions.isNotEmpty() ->
+        extensions
+            .filterNot { nonInputDependentOutputExtensions.contains(it) }
+            .map { "**/*.$it" }
+            .toSet()
+    declaresDirectoryOutput(task) -> setOf("**/*")
+    else -> emptySet()
+  }
 }
 
 /**
@@ -481,26 +484,30 @@ private fun getInputsForTaskImpl(
       }
     }
 
-    // Characterize dependent-task outputs purely from the Gradle task model (task types and
-    // declared archive/file outputs), independent of whether build artifacts exist on disk.
-    val dependentOutputs =
-        collectDependentOutputExtensions(task, tasksToProcess, gitIgnoreClassifier)
+    // Patterns the TASK ITSELF (the consuming task being characterized) produces/consumes: its own
+    // type plus, for a pass-through Copy/Sync, its declared concrete-file sources. These must land
+    // in
+    // the task's OWN inputs (e.g. processResources bundling a generated dist/*.tar.gz must gain
+    // **/*.gz on itself, not only on downstream consumers). The task itself never contributes a
+    // catch-all and is deliberately NOT routed through dependencyOutputExtensions (so a Jar/Test
+    // task
+    // does not gain a self-input from its own archive/file outputs).
+    val taskOwnPatterns =
+        (extensionsForTaskType(task) + declaredCopySourceExtensions(task, gitIgnoreClassifier))
+            .filterNot { nonInputDependentOutputExtensions.contains(it) }
+            .map { "**/*.$it" }
 
-    if (dependentOutputs.needsCatchAll) {
-      // At least one dependency has an uncharacterizable directory output. A "**/*" glob is matched
-      // within each dependency's declared output dirs (and broadcasts across all of them), so it
-      // subsumes the per-extension globs; emit it alone.
-      inputs.add(mapOf("dependentTasksOutputFiles" to "**/*", "transitive" to true))
-    } else {
-      // Consolidate dependent-task outputs into per-extension globs (skip non-deterministic IC
-      // state, e.g. compiler *.bin).
-      dependentOutputs.extensions
-          .filterNot { nonInputDependentOutputExtensions.contains(it) }
-          .forEach { extension ->
-            inputs.add(
-                mapOf("dependentTasksOutputFiles" to "**/*.$extension", "transitive" to true))
-          }
-    }
+    // Characterize each DEPENDENCY's outputs into patterns from the Gradle task model (independent
+    // of
+    // on-disk build state); a "**/*" pattern (for an uncharacterizable directory output) is matched
+    // within that dependency's declared output dirs. Union with the task-itself patterns, dedupe
+    // and
+    // emit.
+    (taskOwnPatterns + tasksToProcess.flatMap { dependentOutputPatterns(it, gitIgnoreClassifier) })
+        .toSet()
+        .forEach { pattern ->
+          inputs.add(mapOf("dependentTasksOutputFiles" to pattern, "transitive" to true))
+        }
 
     if (externalDependencies.isNotEmpty()) {
       inputs.add(mapOf("externalDependencies" to externalDependencies))

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -10,6 +10,7 @@ import kotlin.io.path.Path
 import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.Task
+import org.gradle.api.file.FileSystemLocation
 import org.gradle.api.internal.TaskInternal
 import org.gradle.api.internal.file.copy.CopySpecInternal
 import org.gradle.api.internal.file.copy.DefaultCopySpec
@@ -17,6 +18,7 @@ import org.gradle.api.internal.provider.ProviderInternal
 import org.gradle.api.internal.provider.TransformBackedProvider
 import org.gradle.api.internal.tasks.DefaultTaskDependency
 import org.gradle.api.internal.tasks.DefaultTaskOutputs
+import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.AbstractCopyTask
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.bundling.AbstractArchiveTask
@@ -336,15 +338,23 @@ private fun collectCopySourceExtensions(
 }
 
 /**
- * Convert a declared `from(...)` argument into a concrete [File] when it is a path we can read
- * without touching disk. Returns null for non-path argument types (FileTree, FileCollection,
- * provider, task output, ...).
+ * Convert a declared `from(...)` argument into a concrete [File] when it resolves to a single path
+ * we can read without touching disk. Handles the idiomatic lazy forms:
+ * - [FileSystemLocation] (RegularFile / Directory), e.g. from a `layout` file
+ * - [Provider] (RegularFileProperty / DirectoryProperty / `layout.buildDirectory.file(...)` /
+ *   `provider { ... }`), unwrapped ONCE via [Provider.getOrNull] (not `get()`) and recursed
+ *
+ * Resolution stays config-time: `orNull` on a layout/property provider computes the declared path
+ * without the file existing. Returns null for argument types that would require enumerating the
+ * working tree (FileTree, FileCollection, task output) or for a provider with no value.
  */
 private fun fileFromDeclaredSource(source: Any?): File? =
     when (source) {
       is File -> source
       is java.nio.file.Path -> source.toFile()
       is CharSequence -> File(source.toString())
+      is FileSystemLocation -> source.asFile
+      is Provider<*> -> fileFromDeclaredSource(source.orNull)
       else -> null
     }
 

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -199,31 +199,23 @@ fun inferExtensionsFromInputProperties(
   extensions.addAll(declaredCopySourceExtensions(task, gitIgnoreClassifier))
 
   // Each dependency's declared output model (dispatched by task kind).
-  dependentTasks.forEach { depTask ->
-    extensions.addAll(dependencyOutputExtensions(depTask, gitIgnoreClassifier))
-  }
+  dependentTasks.forEach { depTask -> extensions.addAll(dependencyOutputExtensions(depTask)) }
 
   return extensions.toSet()
 }
 
 /**
- * Output extensions a DEPENDENCY task produces, dispatched by task kind.
- *
- * Archive and copy are first-class branches because their extensions are READ from declared
- * instance data (archiveExtension plus Tar compression; the from(...) sources) rather than being
- * constant per class. Compile and test tasks are constant per class, so they delegate to
- * [extensionsForTaskType] via the else branch — no duplication, and that constant map stays
- * reusable for the task-itself heuristic. [declaredFileOutputExtensions] is the universal floor:
- * any task may declare a concrete OutputFile on top of its kind.
- *
- * Ordered so that an archive task (which is also an AbstractCopyTask) is characterized by its
- * archive output, not its sources. Nothing here inspects the working tree.
+ * Output extensions a DEPENDENCY task produces, dispatched by task kind. A consumer hashes the
+ * dependency's OUTPUT, so read declared outputs, not sources. Archives read archiveExtension (plus
+ * Tar compression); compile/test are constant per class via [extensionsForTaskType];
+ * [declaredFileOutputExtensions] adds any declared OutputFile. A Copy names nothing here; its
+ * directory output is covered by [dependentOutputPatterns]'s catch-all (reading sources would miss
+ * committed files that enter via a directory source, e.g. a resource copied onto a jar).
  */
-private fun dependencyOutputExtensions(task: Task, gitIgnore: GitIgnoreClassifier): Set<String> {
+private fun dependencyOutputExtensions(task: Task): Set<String> {
   val byKind =
       when {
         task is AbstractArchiveTask -> declaredArchiveExtensions(task)
-        task is AbstractCopyTask -> declaredCopySourceExtensions(task, gitIgnore)
         else -> extensionsForTaskType(task) // Kotlin/Java compile, Test, else {}
       }
   // Universal baseline: any task may declare concrete FILE outputs beyond its kind.
@@ -231,21 +223,14 @@ private fun dependencyOutputExtensions(task: Task, gitIgnore: GitIgnoreClassifie
 }
 
 /**
- * Derive the dependentTasksOutputFiles patterns for a single dependency task from the Gradle task
- * model. Returns patterns already formatted as per-extension globs or the wildcard catch-all, with
- * the non-input IC extensions (such as bin) filtered out — ready to wrap in a
- * dependentTasksOutputFiles input. Never inspects the working tree, so the result is identical on a
- * clean checkout and a fully built one.
- *
- * The extensions come from [dependencyOutputExtensions]; if none are nameable but the task declares
- * a DIRECTORY output, a conservative wildcard catch-all is emitted so the dependency's outputs are
- * still hashed (a Copy whose only source is a FileTree, or an opaque custom task).
- *
- * Known limitation: a MIXED Copy (concrete source plus FileTree source) is characterized by its
- * concrete part and will NOT get the catch-all, so the FileTree part is under-covered. Rare.
+ * dependentTasksOutputFiles patterns for one dependency, from the task model only (so a clean and a
+ * built tree agree). Named extensions from [dependencyOutputExtensions] become per-extension globs
+ * (non-input IC extensions filtered out); if none are nameable but the task declares a DIRECTORY
+ * output, emit the wildcard catch-all so its outputs are still hashed. A Copy is the common
+ * catch-all case.
  */
-private fun dependentOutputPatterns(task: Task, gitIgnore: GitIgnoreClassifier): Set<String> {
-  val extensions = dependencyOutputExtensions(task, gitIgnore)
+private fun dependentOutputPatterns(task: Task): Set<String> {
+  val extensions = dependencyOutputExtensions(task)
   return when {
     extensions.isNotEmpty() ->
         extensions
@@ -268,17 +253,14 @@ private fun dependentOutputPatterns(task: Task, gitIgnore: GitIgnoreClassifier):
  *
  * BFS with a visited guard so cycles and diamonds are handled and each task is characterized once.
  */
-private fun effectiveDependencyPatterns(
-    directDeps: Set<Task>,
-    gitIgnore: GitIgnoreClassifier
-): Set<String> {
+private fun effectiveDependencyPatterns(directDeps: Set<Task>): Set<String> {
   val patterns = mutableSetOf<String>()
   val visited = mutableSetOf<Task>()
   val queue = ArrayDeque(directDeps.toList())
   while (queue.isNotEmpty()) {
     val dep = queue.removeFirst()
     if (!visited.add(dep)) continue // cycle / dedup guard
-    val depPatterns = dependentOutputPatterns(dep, gitIgnore)
+    val depPatterns = dependentOutputPatterns(dep)
     if (depPatterns.isNotEmpty()) {
       patterns.addAll(depPatterns) // real producer -> take its patterns, stop
     } else {
@@ -584,11 +566,9 @@ private fun getInputsForTaskImpl(
     // dependency's declared output dirs. Opaque lifecycle tasks (e.g. `classes`, which produces no
     // patterns) are seen through to their real producers (e.g. `processResources`). Union with the
     // task-itself patterns, dedupe and emit.
-    (taskOwnPatterns + effectiveDependencyPatterns(tasksToProcess, gitIgnoreClassifier))
-        .toSet()
-        .forEach { pattern ->
-          inputs.add(mapOf("dependentTasksOutputFiles" to pattern, "transitive" to true))
-        }
+    (taskOwnPatterns + effectiveDependencyPatterns(tasksToProcess)).toSet().forEach { pattern ->
+      inputs.add(mapOf("dependentTasksOutputFiles" to pattern, "transitive" to true))
+    }
 
     if (externalDependencies.isNotEmpty()) {
       inputs.add(mapOf("externalDependencies" to externalDependencies))

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -262,6 +262,37 @@ private fun dependentOutputPatterns(task: Task, gitIgnore: GitIgnoreClassifier):
 }
 
 /**
+ * Collect dependentTasksOutputFiles patterns for a set of direct dependencies, seeing THROUGH
+ * opaque lifecycle tasks. A dependency that yields patterns (a real producer: extension globs or a
+ * wildcard catch-all for a declared directory output) contributes them and stops. A dependency that
+ * yields NO patterns (an opaque aggregator like `classes`, with no declared outputs and no
+ * characterizable type) is treated as transparent: we recurse into ITS dependencies. This surfaces
+ * producers such as `processResources` that a consumer (`jar`) only reaches transitively via
+ * `classes`.
+ *
+ * BFS with a visited guard so cycles and diamonds are handled and each task is characterized once.
+ */
+private fun effectiveDependencyPatterns(
+    directDeps: Set<Task>,
+    gitIgnore: GitIgnoreClassifier
+): Set<String> {
+  val patterns = mutableSetOf<String>()
+  val visited = mutableSetOf<Task>()
+  val queue = ArrayDeque(directDeps.toList())
+  while (queue.isNotEmpty()) {
+    val dep = queue.removeFirst()
+    if (!visited.add(dep)) continue // cycle / dedup guard
+    val depPatterns = dependentOutputPatterns(dep, gitIgnore)
+    if (depPatterns.isNotEmpty()) {
+      patterns.addAll(depPatterns) // real producer -> take its patterns, stop
+    } else {
+      queue.addAll(getDependsOnTask(dep)) // opaque/lifecycle -> see through, recurse
+    }
+  }
+  return patterns
+}
+
+/**
  * Extensions a task's type is known to consume from (or produce for) upstream tasks, derived purely
  * from the task class. Reuses [isKotlinCompileTask] for Kotlin-compile detection.
  */
@@ -497,13 +528,12 @@ private fun getInputsForTaskImpl(
             .filterNot { nonInputDependentOutputExtensions.contains(it) }
             .map { "**/*.$it" }
 
-    // Characterize each DEPENDENCY's outputs into patterns from the Gradle task model (independent
-    // of
-    // on-disk build state); a "**/*" pattern (for an uncharacterizable directory output) is matched
-    // within that dependency's declared output dirs. Union with the task-itself patterns, dedupe
-    // and
-    // emit.
-    (taskOwnPatterns + tasksToProcess.flatMap { dependentOutputPatterns(it, gitIgnoreClassifier) })
+    // Characterize the dependency outputs from the Gradle task model (independent of on-disk build
+    // state). A "**/*" pattern (for an uncharacterizable directory output) is matched within a
+    // dependency's declared output dirs. Opaque lifecycle tasks (e.g. `classes`, which produces no
+    // patterns) are seen through to their real producers (e.g. `processResources`). Union with the
+    // task-itself patterns, dedupe and emit.
+    (taskOwnPatterns + effectiveDependencyPatterns(tasksToProcess, gitIgnoreClassifier))
         .toSet()
         .forEach { pattern ->
           inputs.add(mapOf("dependentTasksOutputFiles" to pattern, "transitive" to true))

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -479,6 +479,91 @@ private fun fileFromDeclaredSource(source: Any?): File? =
     }
 
 /**
+ * Declared `from(...)` sources of a copy task that are COMMITTED directories. These become
+ * directory globs so files added later are picked up without recomputing the graph. Gitignored
+ * (generated) dirs are excluded: their existence depends on build state, which would make the graph
+ * differ between a clean and a built tree.
+ */
+private fun declaredCopySourceDirs(
+    task: Task,
+    gitIgnoreClassifier: GitIgnoreClassifier
+): Set<File> {
+  if (task !is AbstractCopyTask) return emptySet()
+  val dirs = mutableSetOf<File>()
+  try {
+    val rootSpec = task.javaClass.getMethod("getRootSpec").invoke(task)
+    if (rootSpec != null) {
+      collectCopySourceDirs(rootSpec, task, dirs, gitIgnoreClassifier)
+    }
+  } catch (t: Throwable) {
+    task.logger.debug("Could not read copy source dirs for ${task.path}: ${t.message}")
+  }
+  return dirs
+}
+
+private fun collectCopySourceDirs(
+    spec: Any,
+    task: Task,
+    into: MutableSet<File>,
+    gitIgnoreClassifier: GitIgnoreClassifier
+) {
+  fun addCommittedDir(dir: File) {
+    val resolved = if (dir.isAbsolute) dir else File(task.project.projectDir, dir.path)
+    // Committed state, not build state: a committed source dir exists identically on a clean and
+    // a built tree, so this stat keeps the derivation deterministic.
+    if (!gitIgnoreClassifier.isIgnored(resolved) && resolved.isDirectory) {
+      into.add(resolved)
+    }
+  }
+  val sourcePaths =
+      try {
+        spec.javaClass.getMethod("getSourcePaths").invoke(spec) as? Iterable<*>
+      } catch (t: Throwable) {
+        null
+      }
+  sourcePaths?.forEach { source ->
+    try {
+      when (source) {
+        // from(sourceSets.main.resources) - the idiomatic processResources wiring.
+        is org.gradle.api.file.SourceDirectorySet -> source.srcDirs.forEach { addCommittedDir(it) }
+        else -> fileFromDeclaredSource(source)?.let { addCommittedDir(it) }
+      }
+    } catch (t: Throwable) {}
+  }
+  val children =
+      try {
+        spec.javaClass.getMethod("getChildren").invoke(spec) as? Iterable<*>
+      } catch (t: Throwable) {
+        null
+      }
+  children?.filterNotNull()?.forEach { child ->
+    collectCopySourceDirs(child, task, into, gitIgnoreClassifier)
+  }
+}
+
+/**
+ * Source roots that may feed this task: every source set's srcDirs (java, resources, and the Kotlin
+ * extension's), read from the public API. Which of them the task actually uses is decided by
+ * matching its resolved input files against them.
+ */
+private fun candidateSourceRoots(task: Task): Set<File> {
+  val roots = mutableSetOf<File>()
+  try {
+    val sourceSets =
+        task.project.extensions.findByName("sourceSets") as? org.gradle.api.tasks.SourceSetContainer
+    sourceSets?.forEach { sourceSet ->
+      roots.addAll(sourceSet.allSource.srcDirs)
+      ((sourceSet as? org.gradle.api.plugins.ExtensionAware)?.extensions?.findByName("kotlin")
+              as? org.gradle.api.file.SourceDirectorySet)
+          ?.let { roots.addAll(it.srcDirs) }
+    }
+  } catch (t: Throwable) {
+    task.logger.debug("Could not read source sets for ${task.path}: ${t.message}")
+  }
+  return roots
+}
+
+/**
  * Parse task and get inputs for this task
  *
  * @param dependsOnTasks set of tasks this task depends on
@@ -518,11 +603,15 @@ private fun getInputsForTaskImpl(
 
     val tasksToProcess = dependsOnTasks ?: getDependsOnTask(task)
 
-    // Classify this task's declared input files into direct source inputs vs external
-    // dependencies. Build-artifact extensions are intentionally NOT harvested from the working
-    // tree here; they are derived deterministically from the Gradle task model below (see
-    // inferExtensionsFromInputProperties). Keeping this independent of on-disk build state ensures
-    // two checkouts of the same commit produce the same graph.
+    // Classify this task's declared input files into directory globs, direct source inputs, and
+    // external dependencies. Files under a known source root collapse into a `root/**/*` glob so
+    // files added later invalidate the cache without recomputing the graph (a per-file listing is
+    // frozen at graph-computation time). Build-artifact extensions are intentionally NOT harvested
+    // from the working tree; they are derived from the task model below.
+    val copySourceDirs = declaredCopySourceDirs(task, gitIgnoreClassifier)
+    val sourceRoots = candidateSourceRoots(task) + copySourceDirs
+    // A declared copy source dir globs even when it contributed no file yet.
+    val usedRoots = copySourceDirs.toMutableSet()
     task.inputs.files.forEach { inputFile ->
       val relativePath = replaceRootInPath(inputFile.path, projectRoot, workspaceRoot)
 
@@ -543,11 +632,19 @@ private fun getInputsForTaskImpl(
         // from the working tree.
         gitIgnoreClassifier.isIgnored(inputFile) -> {}
 
-        // Regular source file - add as direct input
+        // File inside a source root - covered by the root's glob
         else -> {
-          inputs.add(relativePath)
+          val root = sourceRoots.firstOrNull { inputFile.path.startsWith(it.path + File.separator) }
+          if (root != null) {
+            usedRoots.add(root)
+          } else {
+            inputs.add(relativePath)
+          }
         }
       }
+    }
+    usedRoots.forEach { root ->
+      replaceRootInPath(root.path, projectRoot, workspaceRoot)?.let { inputs.add("$it/**/*") }
     }
 
     // Patterns the TASK ITSELF (the consuming task being characterized) produces/consumes: its own

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -11,10 +11,13 @@ import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.internal.TaskInternal
+import org.gradle.api.internal.file.copy.CopySpecInternal
+import org.gradle.api.internal.file.copy.DefaultCopySpec
 import org.gradle.api.internal.provider.ProviderInternal
 import org.gradle.api.internal.provider.TransformBackedProvider
 import org.gradle.api.internal.tasks.DefaultTaskDependency
 import org.gradle.api.internal.tasks.DefaultTaskOutputs
+import org.gradle.api.tasks.AbstractCopyTask
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.bundling.AbstractArchiveTask
 import org.gradle.api.tasks.bundling.Compression
@@ -177,22 +180,32 @@ fun getGradleFilesInputs(workspaceRoot: String): List<String> {
  * dependents contribute their declared archive extension (jar, war, tar, and gz/bz2 for compressed
  * tars). Any dependent that declares concrete FILE outputs contributes those files' extensions.
  *
- * Directory outputs are intentionally NOT expanded: the task model does not declare which file
- * extensions land inside a directory, and scanning it would reintroduce a dependency on transient
- * on-disk state. Producers whose artifacts must invalidate consumers should declare file outputs
- * (or wire `from(task)` delegation) so their extensions are visible here.
+ * A Copy/Sync/ProcessResources task declares its outputs as a directory (no inner extensions), but
+ * it also declares its sources via `from(...)` and is pass-through, so its declared concrete-file
+ * source extensions equal its effective output extensions. Those declared source paths are read
+ * without touching disk (see [declaredCopySourceExtensions]).
+ *
+ * Directory outputs and non-file sources (FileTrees, providers, task outputs) are intentionally NOT
+ * expanded: the task model does not declare which file extensions land inside them, and scanning
+ * would reintroduce a dependency on transient on-disk state. Producers whose artifacts must
+ * invalidate consumers should declare file outputs (or wire `from(task)` delegation) so their
+ * extensions are visible here.
  */
 fun inferExtensionsFromInputProperties(task: Task, dependentTasks: Set<Task>): Set<String> {
   val extensions = mutableSetOf<String>()
 
-  // Extensions implied by this task's own type (what it consumes from upstream).
+  // Extensions implied by this task's own type (what it consumes from upstream) and, for a
+  // pass-through Copy/Sync task, its declared concrete-file sources (what it forwards downstream
+  // even when the producer that generated them declares no outputs).
   extensions.addAll(extensionsForTaskType(task))
+  extensions.addAll(declaredCopySourceExtensions(task))
 
   // Extensions implied by each dependent task's declared model (what it produces).
   dependentTasks.forEach { depTask ->
     extensions.addAll(extensionsForTaskType(depTask))
     extensions.addAll(declaredArchiveExtensions(depTask))
     extensions.addAll(declaredFileOutputExtensions(depTask))
+    extensions.addAll(declaredCopySourceExtensions(depTask))
   }
 
   return extensions.toSet()
@@ -258,6 +271,61 @@ private fun declaredFileOutputExtensions(task: Task): Set<String> {
     task.logger.debug("Could not read declared file outputs for ${task.path}: ${e.message}")
   }
   return extensions
+}
+
+/**
+ * Extensions declared as concrete-file sources of an [AbstractCopyTask]
+ * (Copy/Sync/ProcessResources).
+ *
+ * A copy task is pass-through, so its declared source extensions equal its effective output
+ * extensions. Its outputs are a directory (no inner extensions), so we read the DECLARED source
+ * objects from the copy spec tree instead. Only concrete file paths (`File`,
+ * `String`/`CharSequence` or `java.nio.file.Path`) are considered; FileTrees, FileCollections,
+ * providers and task outputs are skipped, since turning them into extensions would require
+ * enumerating the working tree. This is existence-independent: the raw `from(...)` arguments are
+ * read, never resolved.
+ */
+private fun declaredCopySourceExtensions(task: Task): Set<String> {
+  if (task !is AbstractCopyTask) return emptySet()
+  val extensions = mutableSetOf<String>()
+  try {
+    collectCopySourceExtensions(task.rootSpec, extensions)
+  } catch (e: Exception) {
+    task.logger.debug("Could not read copy source paths for ${task.path}: ${e.message}")
+  }
+  return extensions
+}
+
+/**
+ * Recursively collect declared concrete-file source extensions from a copy spec and its children.
+ */
+private fun collectCopySourceExtensions(spec: CopySpecInternal, into: MutableSet<String>) {
+  if (spec is DefaultCopySpec) {
+    spec.sourcePaths.forEach { source ->
+      try {
+        extensionFromDeclaredPath(source)?.let { into.add(it) }
+      } catch (e: Exception) {
+        // Skip any source we cannot classify without touching disk.
+      }
+    }
+  }
+  spec.children.forEach { child -> collectCopySourceExtensions(child, into) }
+}
+
+/**
+ * Extract a file extension from a declared `from(...)` argument, but only when the argument is a
+ * concrete file path we can read without touching disk. Returns null for directories/extension-less
+ * paths and for non-path argument types (FileTree, FileCollection, provider, task output, ...).
+ */
+private fun extensionFromDeclaredPath(source: Any?): String? {
+  val file: File =
+      when (source) {
+        is File -> source
+        is java.nio.file.Path -> source.toFile()
+        is CharSequence -> File(source.toString())
+        else -> return null
+      }
+  return file.extension.ifEmpty { null }
 }
 
 /**

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -262,6 +262,8 @@ private fun effectiveDependencyPatterns(directDeps: Set<Task>): Set<String> {
     if (!visited.add(dep)) continue // cycle / dedup guard
     val depPatterns = dependentOutputPatterns(dep)
     if (depPatterns.isNotEmpty()) {
+      // A catch-all subsumes every other pattern, so stop the walk as soon as one appears.
+      if ("**/*" in depPatterns) return setOf("**/*")
       patterns.addAll(depPatterns) // real producer -> take its patterns, stop
     } else {
       queue.addAll(getDependsOnTask(dep)) // opaque/lifecycle -> see through, recurse
@@ -565,8 +567,12 @@ private fun getInputsForTaskImpl(
     // state). A "**/*" pattern (for an uncharacterizable directory output) is matched within a
     // dependency's declared output dirs. Opaque lifecycle tasks (e.g. `classes`, which produces no
     // patterns) are seen through to their real producers (e.g. `processResources`). Union with the
-    // task-itself patterns, dedupe and emit.
-    (taskOwnPatterns + effectiveDependencyPatterns(tasksToProcess)).toSet().forEach { pattern ->
+    // task-itself patterns and dedupe.
+    val dependentPatterns = (taskOwnPatterns + effectiveDependencyPatterns(tasksToProcess)).toSet()
+    // The catch-all subsumes every specific glob (it matches the same outputs), so when present
+    // emit only it.
+    val emittedPatterns = if ("**/*" in dependentPatterns) setOf("**/*") else dependentPatterns
+    emittedPatterns.forEach { pattern ->
       inputs.add(mapOf("dependentTasksOutputFiles" to pattern, "transitive" to true))
     }
 

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -306,19 +306,20 @@ private fun declaredArchiveExtensions(task: Task): Set<String> {
   return extensions
 }
 
+private const val OUTPUT_TYPE_FILE = "FILE"
+
 /**
- * Reflectively read a task's declared output file-property specs. The concrete `TaskOutputs`
- * implementation and the return type of `getFileProperties()` relocated/changed between Gradle 8
- * and 9, so we resolve by method name+params (which ignores return type) to work on both. Returns
- * an empty list on any reflection failure.
+ * Reflectively read a task's declared output file-property specs, resolving `getFileProperties()`
+ * by name+params (its return type relocated between Gradle 8 and 9). Null means the read threw; an
+ * empty list means the task declares no outputs.
  */
-private fun outputFileProperties(task: Task): List<Any> =
+private fun outputFileProperties(task: Task): List<Any>? =
     try {
       (task.outputs.javaClass.getMethod("getFileProperties").invoke(task.outputs) as? Iterable<*>)
           ?.filterNotNull()
           ?.toList() ?: emptyList()
     } catch (t: Throwable) {
-      emptyList()
+      null
     }
 
 /** Reflectively read an output-property spec's output type name ("FILE" / "DIRECTORY"). */
@@ -345,33 +346,32 @@ private fun specPropertyFiles(spec: Any): org.gradle.api.file.FileCollection? =
  * extensions and are skipped on purpose to avoid depending on transient on-disk state.
  */
 private fun declaredFileOutputExtensions(task: Task): Set<String> {
+  val specs = outputFileProperties(task) ?: return emptySet()
   val extensions = mutableSetOf<String>()
-  try {
-    outputFileProperties(task).forEach { spec ->
-      if (specOutputTypeName(spec) == "FILE") {
-        specPropertyFiles(spec)?.files?.forEach { file ->
-          val extension = file.extension
-          if (extension.isNotEmpty()) {
-            extensions.add(extension)
-          }
-        }
+  specs.forEach { spec ->
+    if (specOutputTypeName(spec) == OUTPUT_TYPE_FILE) {
+      specPropertyFiles(spec)?.files?.forEach { file ->
+        if (file.extension.isNotEmpty()) extensions.add(file.extension)
       }
     }
-  } catch (t: Throwable) {
-    task.logger.debug("Could not read declared file outputs for ${task.path}: ${t.message}")
   }
   return extensions
 }
 
 /**
- * True if the task declares at least one DIRECTORY output in the task model (read reflectively).
+ * True if the task declares a non-file output, or its output model couldn't be read (fail open:
+ * over-declare the catch-all rather than silently under-declare into a stale cache).
  */
 private fun declaresDirectoryOutput(task: Task): Boolean {
-  return try {
-    outputFileProperties(task).any { specOutputTypeName(it) == "DIRECTORY" }
-  } catch (t: Throwable) {
-    false
+  val specs = outputFileProperties(task)
+  if (specs == null) {
+    task.logger.warn(
+        "nx(gradle): could not read declared output properties for ${task.path} " +
+            "(Gradle ${task.project.gradle.gradleVersion}); over-declaring its inputs as **/* to " +
+            "avoid a stale cache.")
+    return true
   }
+  return specs.any { specOutputTypeName(it) != OUTPUT_TYPE_FILE }
 }
 
 /**

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -168,21 +168,9 @@ fun getGradleFilesInputs(workspaceRoot: String): List<String> {
 }
 
 /**
- * Derive the file extensions that a task consumes from its dependents' outputs, using ONLY the
- * Gradle task model (task types and declared outputs). This is a pure function of the configured
- * build: it never inspects the working tree, so it yields the same result on a clean checkout and
- * on a fully built one.
- *
- * This is the extension-level view used by unit tests. The production input derivation uses
- * [dependentOutputPatterns], which formats patterns per dependency and falls back to a catch-all
- * for uncharacterizable directory outputs.
- *
- * Test tasks consume .class + .jar (compiled code and library jars on the test classpath). Compile
- * tasks consume .class (Kotlin also emits .kotlin_module) from upstream compile tasks. Archive
- * dependents contribute their declared archive extension (jar, war, tar, and gz/bz2 for compressed
- * tars). Any dependent that declares concrete FILE outputs contributes those files' extensions. A
- * pass-through Copy/Sync task contributes the extensions of its declared concrete-file sources
- * (read without touching disk; see [declaredCopySourceExtensions]).
+ * Extension-level view of the input derivation, used by unit tests. Production uses
+ * [dependentOutputPatterns]. The task itself is not routed through [dependencyOutputExtensions] so
+ * it does not gain a self-input from its own outputs.
  */
 fun inferExtensionsFromInputProperties(
     task: Task,
@@ -190,44 +178,29 @@ fun inferExtensionsFromInputProperties(
     gitIgnoreClassifier: GitIgnoreClassifier
 ): Set<String> {
   val extensions = mutableSetOf<String>()
-
-  // The consuming task's own type (what it consumes from upstream) and pass-through copy sources.
-  // NOTE: the task itself is NOT routed through dependencyOutputExtensions — that would leak its
-  // archive/file-output extensions into its own inputs (e.g. a Jar task must not gain a **/*.jar
-  // self-input).
   extensions.addAll(extensionsForTaskType(task))
   extensions.addAll(declaredCopySourceExtensions(task, gitIgnoreClassifier))
-
-  // Each dependency's declared output model (dispatched by task kind).
   dependentTasks.forEach { depTask -> extensions.addAll(dependencyOutputExtensions(depTask)) }
-
   return extensions.toSet()
 }
 
 /**
- * Output extensions a DEPENDENCY task produces, dispatched by task kind. A consumer hashes the
- * dependency's OUTPUT, so read declared outputs, not sources. Archives read archiveExtension (plus
- * Tar compression); compile/test are constant per class via [extensionsForTaskType];
- * [declaredFileOutputExtensions] adds any declared OutputFile. A Copy names nothing here; its
- * directory output is covered by [dependentOutputPatterns]'s catch-all (reading sources would miss
- * committed files that enter via a directory source, e.g. a resource copied onto a jar).
+ * Output extensions a dependency task produces. A consumer hashes the dependency's OUTPUT, so this
+ * reads declared outputs, never sources. A Copy names nothing here; its directory output gets the
+ * catch-all in [dependentOutputPatterns].
  */
 private fun dependencyOutputExtensions(task: Task): Set<String> {
   val byKind =
       when {
         task is AbstractArchiveTask -> declaredArchiveExtensions(task)
-        else -> extensionsForTaskType(task) // Kotlin/Java compile, Test, else {}
+        else -> extensionsForTaskType(task)
       }
-  // Universal baseline: any task may declare concrete FILE outputs beyond its kind.
   return byKind + declaredFileOutputExtensions(task)
 }
 
 /**
- * dependentTasksOutputFiles patterns for one dependency, from the task model only (so a clean and a
- * built tree agree). Named extensions from [dependencyOutputExtensions] become per-extension globs
- * (non-input IC extensions filtered out); if none are nameable but the task declares a DIRECTORY
- * output, emit the wildcard catch-all so its outputs are still hashed. A Copy is the common
- * catch-all case.
+ * dependentTasksOutputFiles patterns for one dependency: per-extension globs when nameable,
+ * otherwise the wildcard catch-all for a declared directory output (a Copy is the common case).
  */
 private fun dependentOutputPatterns(task: Task): Set<String> {
   val extensions = dependencyOutputExtensions(task)
@@ -243,15 +216,9 @@ private fun dependentOutputPatterns(task: Task): Set<String> {
 }
 
 /**
- * Collect dependentTasksOutputFiles patterns for a set of direct dependencies, seeing THROUGH
- * opaque lifecycle tasks. A dependency that yields patterns (a real producer: extension globs or a
- * wildcard catch-all for a declared directory output) contributes them and stops. A dependency that
- * yields NO patterns (an opaque aggregator like `classes`, with no declared outputs and no
- * characterizable type) is treated as transparent: we recurse into ITS dependencies. This surfaces
- * producers such as `processResources` that a consumer (`jar`) only reaches transitively via
- * `classes`.
- *
- * BFS with a visited guard so cycles and diamonds are handled and each task is characterized once.
+ * Collect dependentTasksOutputFiles patterns for direct dependencies, seeing through opaque
+ * lifecycle tasks (e.g. `classes`) to their real producers (e.g. `processResources`). BFS with a
+ * visited guard for cycles and diamonds.
  */
 private fun effectiveDependencyPatterns(directDeps: Set<Task>): Set<String> {
   val patterns = mutableSetOf<String>()
@@ -272,10 +239,7 @@ private fun effectiveDependencyPatterns(directDeps: Set<Task>): Set<String> {
   return patterns
 }
 
-/**
- * Extensions a task's type is known to consume from (or produce for) upstream tasks, derived purely
- * from the task class. Reuses [isKotlinCompileTask] for Kotlin-compile detection.
- */
+/** Extensions a task's type is known to consume or produce, derived purely from the task class. */
 private fun extensionsForTaskType(task: Task): Set<String> =
     when {
       task is GradleTest -> setOf("class", "jar")
@@ -285,10 +249,8 @@ private fun extensionsForTaskType(task: Task): Set<String> =
     }
 
 /**
- * Declared archive extension(s) for an [AbstractArchiveTask] (Jar/Zip/Tar/War/shadowJar), read from
- * the task model without requiring the archive to exist. Compressed tars additionally contribute
- * the compression suffix (gz/bz2), since the produced file ends in that extension even though
- * `archiveExtension` remains "tar".
+ * Declared archive extension(s) for an [AbstractArchiveTask]. Compressed tars also contribute the
+ * compression suffix (gz/bz2): the produced file ends in it while `archiveExtension` stays "tar".
  */
 private fun declaredArchiveExtensions(task: Task): Set<String> {
   if (task !is AbstractArchiveTask) return emptySet()
@@ -341,12 +303,7 @@ private fun specPropertyFiles(spec: Any): org.gradle.api.file.FileCollection? =
       null
     }
 
-/**
- * Extensions of a task's declared FILE outputs, read from the task model via reflection (see
- * [outputFileProperties]). Only FILE-type outputs are considered: the model declares their concrete
- * paths (available even before the files exist), whereas DIRECTORY outputs declare no inner
- * extensions and are skipped on purpose to avoid depending on transient on-disk state.
- */
+/** Extensions of a task's declared FILE outputs, read from the declared paths (not disk). */
 private fun declaredFileOutputExtensions(task: Task): Set<String> {
   val specs = outputFileProperties(task) ?: return emptySet()
   val extensions = mutableSetOf<String>()
@@ -377,21 +334,9 @@ private fun declaresDirectoryOutput(task: Task): Boolean {
 }
 
 /**
- * Extensions declared as concrete-file sources of an [AbstractCopyTask]
- * (Copy/Sync/ProcessResources).
- *
- * A copy task is pass-through, so its declared source extensions equal its effective output
- * extensions. Its outputs are a directory (no inner extensions), so we read the DECLARED source
- * objects from the copy spec tree instead. Only concrete file paths (`File`,
- * `String`/`CharSequence` or `java.nio.file.Path`) are considered; FileTrees, FileCollections,
- * providers and task outputs are skipped, since turning them into extensions would require
- * enumerating the working tree. This is existence-independent: the raw `from(...)` arguments are
- * read, never resolved.
- *
- * Only sources that are NOT checked in (i.e. gitignored/generated build outputs) contribute an
- * extension. `dependentTasksOutputFiles` globs are matched against dependency OUTPUTS, so a
- * checked-in source is already captured as a direct source input by the `task.inputs.files` branch
- * and emitting a glob for it would be redundant and imprecise.
+ * Extensions of a copy task's declared concrete-file `from(...)` sources, read from the raw
+ * arguments without resolving them. Only gitignored (generated) sources contribute: checked-in
+ * sources are already direct inputs.
  */
 private fun declaredCopySourceExtensions(
     task: Task,
@@ -400,9 +345,7 @@ private fun declaredCopySourceExtensions(
   if (task !is AbstractCopyTask) return emptySet()
   val extensions = mutableSetOf<String>()
   try {
-    // AbstractCopyTask.getRootSpec() returns a CopySpecInternal (internal type); resolve it
-    // reflectively (by name+params) so we do not compile-bind to it — it relocated/changed between
-    // Gradle 8 and 9.
+    // getRootSpec() returns an internal type that moved between Gradle 8 and 9; resolve by name.
     val rootSpec = task.javaClass.getMethod("getRootSpec").invoke(task)
     if (rootSpec != null) {
       collectCopySourceExtensions(rootSpec, extensions, gitIgnoreClassifier)
@@ -413,12 +356,6 @@ private fun declaredCopySourceExtensions(
   return extensions
 }
 
-/**
- * Recursively collect declared concrete-file source extensions from a copy spec and its children,
- * limited to non-checked-in (gitignored/generated) sources. The spec is passed as [Any] and its
- * `getSourcePaths()` / `getChildren()` are read reflectively, so we never compile-bind to the
- * internal CopySpecInternal/DefaultCopySpec types (which changed between Gradle 8 and 9).
- */
 private fun collectCopySourceExtensions(
     spec: Any,
     into: MutableSet<String>,
@@ -435,15 +372,10 @@ private fun collectCopySourceExtensions(
   sourcePaths?.forEach { source ->
     try {
       val file = fileFromDeclaredSource(source) ?: return@forEach
-      // Only generated (gitignored) sources need a dependentTasksOutputFiles glob; checked-in
-      // sources are already emitted as direct inputs. isIgnored is a pattern match and does not
-      // require the file to exist.
       if (gitIgnoreClassifier.isIgnored(file)) {
         file.extension.takeIf { it.isNotEmpty() }?.let { into.add(it) }
       }
-    } catch (t: Throwable) {
-      // Skip any source we cannot classify without touching disk.
-    }
+    } catch (t: Throwable) {}
   }
 
   val children =
@@ -458,15 +390,9 @@ private fun collectCopySourceExtensions(
 }
 
 /**
- * Convert a declared `from(...)` argument into a concrete [File] when it resolves to a single path
- * we can read without touching disk. Handles the idiomatic lazy forms:
- * - [FileSystemLocation] (RegularFile / Directory), e.g. from a `layout` file
- * - [Provider] (RegularFileProperty / DirectoryProperty / `layout.buildDirectory.file(...)` /
- *   `provider { ... }`), unwrapped ONCE via [Provider.getOrNull] (not `get()`) and recursed
- *
- * Resolution stays config-time: `orNull` on a layout/property provider computes the declared path
- * without the file existing. Returns null for argument types that would require enumerating the
- * working tree (FileTree, FileCollection, task output) or for a provider with no value.
+ * Convert a declared `from(...)` argument into a concrete [File] without touching disk, unwrapping
+ * lazy forms ([FileSystemLocation], [Provider]). Null for types that would require enumerating the
+ * working tree (FileTree, FileCollection, task output).
  */
 private fun fileFromDeclaredSource(source: Any?): File? =
     when (source) {
@@ -479,10 +405,9 @@ private fun fileFromDeclaredSource(source: Any?): File? =
     }
 
 /**
- * Declared `from(...)` sources of a copy task that are COMMITTED directories. These become
- * directory globs so files added later are picked up without recomputing the graph. Gitignored
- * (generated) dirs are excluded: their existence depends on build state, which would make the graph
- * differ between a clean and a built tree.
+ * Declared `from(...)` sources of a copy task that are committed directories; these become globs so
+ * files added later are picked up without recomputing the graph. Gitignored dirs are excluded:
+ * their existence depends on build state.
  */
 private fun declaredCopySourceDirs(
     task: Task,
@@ -509,8 +434,8 @@ private fun collectCopySourceDirs(
 ) {
   fun addCommittedDir(dir: File) {
     val resolved = if (dir.isAbsolute) dir else File(task.project.projectDir, dir.path)
-    // Committed state, not build state: a committed source dir exists identically on a clean and
-    // a built tree, so this stat keeps the derivation deterministic.
+    // A committed dir exists identically on a clean and a built tree, so this stat is
+    // deterministic.
     if (!gitIgnoreClassifier.isIgnored(resolved) && resolved.isDirectory) {
       into.add(resolved)
     }
@@ -524,7 +449,6 @@ private fun collectCopySourceDirs(
   sourcePaths?.forEach { source ->
     try {
       when (source) {
-        // from(sourceSets.main.resources) - the idiomatic processResources wiring.
         is org.gradle.api.file.SourceDirectorySet -> source.srcDirs.forEach { addCommittedDir(it) }
         else -> fileFromDeclaredSource(source)?.let { addCommittedDir(it) }
       }
@@ -541,11 +465,7 @@ private fun collectCopySourceDirs(
   }
 }
 
-/**
- * Source roots that may feed this task: every source set's srcDirs (java, resources, and the Kotlin
- * extension's), read from the public API. Which of them the task actually uses is decided by
- * matching its resolved input files against them.
- */
+/** Source roots that may feed this task: every source set's srcDirs, from the public API. */
 private fun candidateSourceRoots(task: Task): Set<File> {
   val roots = mutableSetOf<File>()
   try {
@@ -603,11 +523,9 @@ private fun getInputsForTaskImpl(
 
     val tasksToProcess = dependsOnTasks ?: getDependsOnTask(task)
 
-    // Classify this task's declared input files into directory globs, direct source inputs, and
-    // external dependencies. Files under a known source root collapse into a `root/**/*` glob so
-    // files added later invalidate the cache without recomputing the graph (a per-file listing is
-    // frozen at graph-computation time). Build-artifact extensions are intentionally NOT harvested
-    // from the working tree; they are derived from the task model below.
+    // Files under a known source root collapse into a `root/**/*` glob so files added later
+    // invalidate the cache without recomputing the graph (a per-file listing is frozen at
+    // graph-computation time).
     val copySourceDirs = declaredCopySourceDirs(task, gitIgnoreClassifier)
     val sourceRoots = candidateSourceRoots(task) + copySourceDirs
     // A declared copy source dir globs even when it contributed no file yet.
@@ -627,9 +545,7 @@ private fun getInputsForTaskImpl(
           }
         }
 
-        // File matches gitignore pattern - it is a build artifact, not a source input. Skip it so
-        // it is not added as a direct input; its extension is recovered from the task model, not
-        // from the working tree.
+        // Gitignored - a build artifact, recovered from the task model, not the working tree
         gitIgnoreClassifier.isIgnored(inputFile) -> {}
 
         // File inside a source root - covered by the root's glob
@@ -647,27 +563,16 @@ private fun getInputsForTaskImpl(
       replaceRootInPath(root.path, projectRoot, workspaceRoot)?.let { inputs.add("$it/**/*") }
     }
 
-    // Patterns the TASK ITSELF (the consuming task being characterized) produces/consumes: its own
-    // type plus, for a pass-through Copy/Sync, its declared concrete-file sources. These must land
-    // in
-    // the task's OWN inputs (e.g. processResources bundling a generated dist/*.tar.gz must gain
-    // **/*.gz on itself, not only on downstream consumers). The task itself never contributes a
-    // catch-all and is deliberately NOT routed through dependencyOutputExtensions (so a Jar/Test
-    // task
-    // does not gain a self-input from its own archive/file outputs).
+    // The task's own patterns: its type plus, for a Copy/Sync, its declared generated sources
+    // (e.g. processResources bundling a generated dist/*.tar.gz gains **/*.gz on itself). Not
+    // routed through dependencyOutputExtensions so a task gains no self-input from its own outputs.
     val taskOwnPatterns =
         (extensionsForTaskType(task) + declaredCopySourceExtensions(task, gitIgnoreClassifier))
             .filterNot { nonInputDependentOutputExtensions.contains(it) }
             .map { "**/*.$it" }
 
-    // Characterize the dependency outputs from the Gradle task model (independent of on-disk build
-    // state). A "**/*" pattern (for an uncharacterizable directory output) is matched within a
-    // dependency's declared output dirs. Opaque lifecycle tasks (e.g. `classes`, which produces no
-    // patterns) are seen through to their real producers (e.g. `processResources`). Union with the
-    // task-itself patterns and dedupe.
     val dependentPatterns = (taskOwnPatterns + effectiveDependencyPatterns(tasksToProcess)).toSet()
-    // The catch-all subsumes every specific glob (it matches the same outputs), so when present
-    // emit only it.
+    // The catch-all subsumes every specific glob, so when present emit only it.
     val emittedPatterns = if ("**/*" in dependentPatterns) setOf("**/*") else dependentPatterns
     emittedPatterns.forEach { pattern ->
       inputs.add(mapOf("dependentTasksOutputFiles" to pattern, "transitive" to true))

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -14,12 +14,14 @@ import org.gradle.api.internal.TaskInternal
 import org.gradle.api.internal.provider.ProviderInternal
 import org.gradle.api.internal.provider.TransformBackedProvider
 import org.gradle.api.internal.tasks.DefaultTaskDependency
-import org.gradle.api.tasks.Copy
-import org.gradle.api.tasks.Sync
+import org.gradle.api.internal.tasks.DefaultTaskOutputs
 import org.gradle.api.tasks.TaskProvider
 import org.gradle.api.tasks.bundling.AbstractArchiveTask
+import org.gradle.api.tasks.bundling.Compression
+import org.gradle.api.tasks.bundling.Tar
 import org.gradle.api.tasks.compile.AbstractCompile
 import org.gradle.api.tasks.testing.Test as GradleTest
+import org.gradle.internal.file.TreeType
 
 private val kotlinCompileToolClass: Class<*>? by lazy {
   try {
@@ -31,27 +33,6 @@ private val kotlinCompileToolClass: Class<*>? by lazy {
 
 private fun isKotlinCompileTask(task: Task): Boolean =
     kotlinCompileToolClass?.isInstance(task) == true
-
-// AGP task classes aren't on our classpath; resolve by name (like isKotlinCompileTask).
-// Maintained allow-list of AGP producers whose outputs feed downstream tasks.
-// FQCNs (esp. internal.tasks.*) can move between AGP majors; verify per version.
-private val agpCopyLikeClasses: List<Class<*>> by lazy {
-  listOf(
-          "com.android.build.gradle.tasks.MergeResources",
-          "com.android.build.gradle.tasks.MergeSourceSetFolders",
-          "com.android.build.gradle.tasks.ProcessApplicationManifest",
-          "com.android.build.gradle.internal.tasks.MergeJavaResourceTask",
-      )
-      .mapNotNull { name ->
-        try {
-          Class.forName(name)
-        } catch (e: Throwable) {
-          null
-        }
-      }
-}
-
-private fun isAgpCopyLikeTask(task: Task): Boolean = agpCopyLikeClasses.any { it.isInstance(task) }
 
 /**
  * Process a task and convert it into target Going to populate:
@@ -186,49 +167,97 @@ fun getGradleFilesInputs(workspaceRoot: String): List<String> {
 }
 
 /**
- * Infer file extensions consumed by a task from its dependents' outputs using task type checks.
+ * Derive the file extensions that a task consumes from its dependents' outputs, using ONLY the
+ * Gradle task model (task types and declared outputs). This is a pure function of the configured
+ * build: it never inspects the working tree, so it yields the same result on a clean checkout and
+ * on a fully built one.
  *
  * Test tasks consume .class + .jar (compiled code and library jars on the test classpath). Compile
- * tasks consume .class from upstream compile tasks (e.g. compileTestKotlin → compileKotlin).
- * Archive dependents declare their own extension (jar, war, etc).
+ * tasks consume .class (Kotlin also emits .kotlin_module) from upstream compile tasks. Archive
+ * dependents contribute their declared archive extension (jar, war, tar, and gz/bz2 for compressed
+ * tars). Any dependent that declares concrete FILE outputs contributes those files' extensions.
  *
- * Works at configuration time without requiring files to exist on disk.
+ * Directory outputs are intentionally NOT expanded: the task model does not declare which file
+ * extensions land inside a directory, and scanning it would reintroduce a dependency on transient
+ * on-disk state. Producers whose artifacts must invalidate consumers should declare file outputs
+ * (or wire `from(task)` delegation) so their extensions are visible here.
  */
 fun inferExtensionsFromInputProperties(task: Task, dependentTasks: Set<Task>): Set<String> {
   val extensions = mutableSetOf<String>()
 
-  when {
-    task is GradleTest -> {
-      extensions.add("class")
-      extensions.add("jar")
-    }
-    task is AbstractCompile || isKotlinCompileTask(task) -> extensions.add("class")
-  }
+  // Extensions implied by this task's own type (what it consumes from upstream).
+  extensions.addAll(extensionsForTaskType(task))
 
+  // Extensions implied by each dependent task's declared model (what it produces).
   dependentTasks.forEach { depTask ->
-    if (depTask is AbstractArchiveTask) {
-      try {
-        depTask.archiveExtension.get().takeIf { it.isNotEmpty() }?.let { extensions.add(it) }
-      } catch (e: Exception) {
-        task.logger.debug("Could not read archiveExtension for ${depTask.path}: ${e.message}")
-      }
-    }
-    if (depTask is AbstractCompile || isKotlinCompileTask(depTask)) {
-      extensions.add("class")
-    }
-    if (depTask is Copy || depTask is Sync || isAgpCopyLikeTask(depTask)) {
-      try {
-        depTask.inputs.files.forEach { f ->
-          if (f.isFile && f.extension.isNotEmpty()) extensions.add(f.extension)
-        }
-      } catch (e: Exception) {
-        task.logger.debug(
-            "Could not read copy/merge source inputs for ${depTask.path}: ${e.message}")
-      }
-    }
+    extensions.addAll(extensionsForTaskType(depTask))
+    extensions.addAll(declaredArchiveExtensions(depTask))
+    extensions.addAll(declaredFileOutputExtensions(depTask))
   }
 
   return extensions.toSet()
+}
+
+/**
+ * Extensions a task's type is known to consume from (or produce for) upstream tasks, derived purely
+ * from the task class. Reuses [isKotlinCompileTask] for Kotlin-compile detection.
+ */
+private fun extensionsForTaskType(task: Task): Set<String> =
+    when {
+      task is GradleTest -> setOf("class", "jar")
+      isKotlinCompileTask(task) -> setOf("class", "kotlin_module")
+      task is AbstractCompile -> setOf("class")
+      else -> emptySet()
+    }
+
+/**
+ * Declared archive extension(s) for an [AbstractArchiveTask] (Jar/Zip/Tar/War/shadowJar), read from
+ * the task model without requiring the archive to exist. Compressed tars additionally contribute
+ * the compression suffix (gz/bz2), since the produced file ends in that extension even though
+ * `archiveExtension` remains "tar".
+ */
+private fun declaredArchiveExtensions(task: Task): Set<String> {
+  if (task !is AbstractArchiveTask) return emptySet()
+  val extensions = mutableSetOf<String>()
+  try {
+    task.archiveExtension.orNull?.takeIf { it.isNotEmpty() }?.let { extensions.add(it) }
+  } catch (e: Exception) {
+    task.logger.debug("Could not read archiveExtension for ${task.path}: ${e.message}")
+  }
+  if (task is Tar) {
+    when (task.compression) {
+      Compression.GZIP -> extensions.add("gz")
+      Compression.BZIP2 -> extensions.add("bz2")
+      else -> {}
+    }
+  }
+  return extensions
+}
+
+/**
+ * Extensions of a task's declared FILE outputs, read from the task model. Only FILE-type outputs
+ * are considered: the model declares their concrete paths (available even before the files exist),
+ * whereas DIRECTORY outputs declare no inner extensions and are skipped on purpose to avoid
+ * depending on transient on-disk state.
+ */
+private fun declaredFileOutputExtensions(task: Task): Set<String> {
+  val extensions = mutableSetOf<String>()
+  try {
+    val outputs = task.outputs as? DefaultTaskOutputs ?: return emptySet()
+    outputs.fileProperties.forEach { spec ->
+      if (spec.outputType == TreeType.FILE) {
+        spec.propertyFiles.forEach { file ->
+          val extension = file.extension
+          if (extension.isNotEmpty()) {
+            extensions.add(extension)
+          }
+        }
+      }
+    }
+  } catch (e: Exception) {
+    task.logger.debug("Could not read declared file outputs for ${task.path}: ${e.message}")
+  }
+  return extensions
 }
 
 /**
@@ -266,24 +295,16 @@ private fun getInputsForTaskImpl(
   return try {
     val inputs = mutableListOf<Any>()
     val externalDependencies = mutableListOf<String>()
-    val dependentTaskOutputExtensions = mutableSetOf<String>()
 
     inputs.addAll(getGradleFilesInputs(workspaceRoot))
 
-    // Collect outputs from dependent tasks - group by extension for glob patterns
     val tasksToProcess = dependsOnTasks ?: getDependsOnTask(task)
-    tasksToProcess.forEach { dependentTask ->
-      dependentTask.outputs.files.files.forEach { outputFile ->
-        if (isFileInWorkspace(outputFile, workspaceRoot)) {
-          val extension = outputFile.extension
-          if (extension.isNotEmpty()) {
-            dependentTaskOutputExtensions.add(extension)
-          }
-        }
-      }
-    }
 
-    // Process each tasks's input files from the tooling API
+    // Classify this task's declared input files into direct source inputs vs external
+    // dependencies. Build-artifact extensions are intentionally NOT harvested from the working
+    // tree here; they are derived deterministically from the Gradle task model below (see
+    // inferExtensionsFromInputProperties). Keeping this independent of on-disk build state ensures
+    // two checkouts of the same commit produce the same graph.
     task.inputs.files.forEach { inputFile ->
       val relativePath = replaceRootInPath(inputFile.path, projectRoot, workspaceRoot)
 
@@ -299,14 +320,10 @@ private fun getInputsForTaskImpl(
           }
         }
 
-        // File matches gitignore pattern - treat as dependentTasksOutputFiles (build artifact)
-        // Group by extension for glob patterns
-        gitIgnoreClassifier.isIgnored(inputFile) -> {
-          val extension = inputFile.extension
-          if (extension.isNotEmpty()) {
-            dependentTaskOutputExtensions.add(extension)
-          }
-        }
+        // File matches gitignore pattern - it is a build artifact, not a source input. Skip it so
+        // it is not added as a direct input; its extension is recovered from the task model, not
+        // from the working tree.
+        gitIgnoreClassifier.isIgnored(inputFile) -> {}
 
         // Regular source file - add as direct input
         else -> {
@@ -315,9 +332,9 @@ private fun getInputsForTaskImpl(
       }
     }
 
-    // Supplement with extensions inferred from Gradle metadata (handles clean builds where
-    // output directories exist but are empty, so file-based extension discovery misses them)
-    dependentTaskOutputExtensions.addAll(inferExtensionsFromInputProperties(task, tasksToProcess))
+    // Derive dependent-task output extensions purely from the Gradle task model (task types and
+    // declared archive/file outputs), independent of whether build artifacts exist on disk.
+    val dependentTaskOutputExtensions = inferExtensionsFromInputProperties(task, tasksToProcess)
 
     // Consolidate dependent-task outputs into per-extension globs (skip non-deterministic IC state)
     dependentTaskOutputExtensions
@@ -336,11 +353,6 @@ private fun getInputsForTaskImpl(
     task.logger.debug("Stack trace:", e)
     null
   }
-}
-
-/** Checks if a file is within the workspace. */
-private fun isFileInWorkspace(file: File, workspaceRoot: String): Boolean {
-  return file.path.startsWith(workspaceRoot + File.separator)
 }
 
 /**

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -12,12 +12,9 @@ import org.gradle.api.Project
 import org.gradle.api.Task
 import org.gradle.api.file.FileSystemLocation
 import org.gradle.api.internal.TaskInternal
-import org.gradle.api.internal.file.copy.CopySpecInternal
-import org.gradle.api.internal.file.copy.DefaultCopySpec
 import org.gradle.api.internal.provider.ProviderInternal
 import org.gradle.api.internal.provider.TransformBackedProvider
 import org.gradle.api.internal.tasks.DefaultTaskDependency
-import org.gradle.api.internal.tasks.DefaultTaskOutputs
 import org.gradle.api.provider.Provider
 import org.gradle.api.tasks.AbstractCopyTask
 import org.gradle.api.tasks.TaskProvider
@@ -26,7 +23,6 @@ import org.gradle.api.tasks.bundling.Compression
 import org.gradle.api.tasks.bundling.Tar
 import org.gradle.api.tasks.compile.AbstractCompile
 import org.gradle.api.tasks.testing.Test as GradleTest
-import org.gradle.internal.file.TreeType
 
 private val kotlinCompileToolClass: Class<*>? by lazy {
   try {
@@ -329,18 +325,49 @@ private fun declaredArchiveExtensions(task: Task): Set<String> {
 }
 
 /**
- * Extensions of a task's declared FILE outputs, read from the task model. Only FILE-type outputs
- * are considered: the model declares their concrete paths (available even before the files exist),
- * whereas DIRECTORY outputs declare no inner extensions and are skipped on purpose to avoid
- * depending on transient on-disk state.
+ * Reflectively read a task's declared output file-property specs. The concrete `TaskOutputs`
+ * implementation and the return type of `getFileProperties()` relocated/changed between Gradle 8
+ * and 9, so we resolve by method name+params (which ignores return type) to work on both. Returns
+ * an empty list on any reflection failure.
+ */
+private fun outputFileProperties(task: Task): List<Any> =
+    try {
+      (task.outputs.javaClass.getMethod("getFileProperties").invoke(task.outputs) as? Iterable<*>)
+          ?.filterNotNull()
+          ?.toList() ?: emptyList()
+    } catch (t: Throwable) {
+      emptyList()
+    }
+
+/** Reflectively read an output-property spec's output type name ("FILE" / "DIRECTORY"). */
+private fun specOutputTypeName(spec: Any): String? =
+    try {
+      spec.javaClass.getMethod("getOutputType").invoke(spec)?.toString()
+    } catch (t: Throwable) {
+      null
+    }
+
+/** Reflectively read an output-property spec's declared files. */
+private fun specPropertyFiles(spec: Any): org.gradle.api.file.FileCollection? =
+    try {
+      spec.javaClass.getMethod("getPropertyFiles").invoke(spec)
+          as? org.gradle.api.file.FileCollection
+    } catch (t: Throwable) {
+      null
+    }
+
+/**
+ * Extensions of a task's declared FILE outputs, read from the task model via reflection (see
+ * [outputFileProperties]). Only FILE-type outputs are considered: the model declares their concrete
+ * paths (available even before the files exist), whereas DIRECTORY outputs declare no inner
+ * extensions and are skipped on purpose to avoid depending on transient on-disk state.
  */
 private fun declaredFileOutputExtensions(task: Task): Set<String> {
   val extensions = mutableSetOf<String>()
   try {
-    val outputs = task.outputs as? DefaultTaskOutputs ?: return emptySet()
-    outputs.fileProperties.forEach { spec ->
-      if (spec.outputType == TreeType.FILE) {
-        spec.propertyFiles.forEach { file ->
+    outputFileProperties(task).forEach { spec ->
+      if (specOutputTypeName(spec) == "FILE") {
+        specPropertyFiles(spec)?.files?.forEach { file ->
           val extension = file.extension
           if (extension.isNotEmpty()) {
             extensions.add(extension)
@@ -348,18 +375,19 @@ private fun declaredFileOutputExtensions(task: Task): Set<String> {
         }
       }
     }
-  } catch (e: Exception) {
-    task.logger.debug("Could not read declared file outputs for ${task.path}: ${e.message}")
+  } catch (t: Throwable) {
+    task.logger.debug("Could not read declared file outputs for ${task.path}: ${t.message}")
   }
   return extensions
 }
 
-/** True if the task declares at least one DIRECTORY output in the task model. */
+/**
+ * True if the task declares at least one DIRECTORY output in the task model (read reflectively).
+ */
 private fun declaresDirectoryOutput(task: Task): Boolean {
   return try {
-    val outputs = task.outputs as? DefaultTaskOutputs ?: return false
-    outputs.fileProperties.any { it.outputType == TreeType.DIRECTORY }
-  } catch (e: Exception) {
+    outputFileProperties(task).any { specOutputTypeName(it) == "DIRECTORY" }
+  } catch (t: Throwable) {
     false
   }
 }
@@ -388,38 +416,61 @@ private fun declaredCopySourceExtensions(
   if (task !is AbstractCopyTask) return emptySet()
   val extensions = mutableSetOf<String>()
   try {
-    collectCopySourceExtensions(task.rootSpec, extensions, gitIgnoreClassifier)
-  } catch (e: Exception) {
-    task.logger.debug("Could not read copy source paths for ${task.path}: ${e.message}")
+    // AbstractCopyTask.getRootSpec() returns a CopySpecInternal (internal type); resolve it
+    // reflectively (by name+params) so we do not compile-bind to it — it relocated/changed between
+    // Gradle 8 and 9.
+    val rootSpec = task.javaClass.getMethod("getRootSpec").invoke(task)
+    if (rootSpec != null) {
+      collectCopySourceExtensions(rootSpec, extensions, gitIgnoreClassifier)
+    }
+  } catch (t: Throwable) {
+    task.logger.debug("Could not read copy source paths for ${task.path}: ${t.message}")
   }
   return extensions
 }
 
 /**
  * Recursively collect declared concrete-file source extensions from a copy spec and its children,
- * limited to non-checked-in (gitignored/generated) sources.
+ * limited to non-checked-in (gitignored/generated) sources. The spec is passed as [Any] and its
+ * `getSourcePaths()` / `getChildren()` are read reflectively, so we never compile-bind to the
+ * internal CopySpecInternal/DefaultCopySpec types (which changed between Gradle 8 and 9).
  */
 private fun collectCopySourceExtensions(
-    spec: CopySpecInternal,
+    spec: Any,
     into: MutableSet<String>,
     gitIgnoreClassifier: GitIgnoreClassifier
 ) {
-  if (spec is DefaultCopySpec) {
-    spec.sourcePaths.forEach { source ->
+  // DefaultCopySpec.getSourcePaths() holds the raw from(...) arguments. Absent (null) on specs that
+  // do not expose it -> nothing to read at this level.
+  val sourcePaths =
       try {
-        val file = fileFromDeclaredSource(source) ?: return@forEach
-        // Only generated (gitignored) sources need a dependentTasksOutputFiles glob; checked-in
-        // sources are already emitted as direct inputs. isIgnored is a pattern match and does not
-        // require the file to exist.
-        if (gitIgnoreClassifier.isIgnored(file)) {
-          file.extension.takeIf { it.isNotEmpty() }?.let { into.add(it) }
-        }
-      } catch (e: Exception) {
-        // Skip any source we cannot classify without touching disk.
+        spec.javaClass.getMethod("getSourcePaths").invoke(spec) as? Iterable<*>
+      } catch (t: Throwable) {
+        null
       }
+  sourcePaths?.forEach { source ->
+    try {
+      val file = fileFromDeclaredSource(source) ?: return@forEach
+      // Only generated (gitignored) sources need a dependentTasksOutputFiles glob; checked-in
+      // sources are already emitted as direct inputs. isIgnored is a pattern match and does not
+      // require the file to exist.
+      if (gitIgnoreClassifier.isIgnored(file)) {
+        file.extension.takeIf { it.isNotEmpty() }?.let { into.add(it) }
+      }
+    } catch (t: Throwable) {
+      // Skip any source we cannot classify without touching disk.
     }
   }
-  spec.children.forEach { child -> collectCopySourceExtensions(child, into, gitIgnoreClassifier) }
+
+  val children =
+      try {
+        spec.javaClass.getMethod("getChildren").invoke(spec) as? Iterable<*>
+      } catch (t: Throwable) {
+        null
+      }
+  children?.filterNotNull()?.forEach { child ->
+    collectCopySourceExtensions(child, into, gitIgnoreClassifier)
+  }
 }
 
 /**
@@ -544,7 +595,7 @@ private fun getInputsForTaskImpl(
     }
 
     inputs.ifEmpty { null }
-  } catch (e: Exception) {
+  } catch (e: Throwable) {
     task.logger.info("Error getting inputs for ${task.path}: ${e.message}")
     task.logger.debug("Stack trace:", e)
     null

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -197,8 +197,38 @@ fun inferExtensionsFromInputProperties(
     task: Task,
     dependentTasks: Set<Task>,
     gitIgnoreClassifier: GitIgnoreClassifier
-): Set<String> {
+): Set<String> =
+    collectDependentOutputExtensions(task, dependentTasks, gitIgnoreClassifier).extensions
+
+/**
+ * Result of characterizing a task's dependency outputs: the per-extension globs to emit, plus
+ * whether a catch-all is required because some dependency's outputs could not be reduced to
+ * extensions.
+ */
+data class DependentOutputExtensions(val extensions: Set<String>, val needsCatchAll: Boolean)
+
+/**
+ * Characterize the outputs of a task's dependencies from the Gradle task model, deciding per
+ * dependency whether it can be reduced to concrete extensions or needs a conservative catch-all.
+ *
+ * For each dependency we union [extensionsForTaskType], [declaredArchiveExtensions],
+ * [declaredFileOutputExtensions] and [declaredCopySourceExtensions]. If that yields extensions we
+ * contribute them; if it yields nothing but the dependency declares a DIRECTORY output whose
+ * contents we cannot characterize, we flag a catch-all. A dependency that declares NO outputs is
+ * left alone — a `dependentTasksOutputFiles` glob is matched within a dependency's declared
+ * outputs, so there is nothing for a catch-all to match.
+ *
+ * The consuming task's own type and pass-through copy sources also contribute extensions (matched
+ * against dependency outputs), but never trigger a catch-all — the catch-all is strictly about
+ * dependency outputs.
+ */
+fun collectDependentOutputExtensions(
+    task: Task,
+    dependentTasks: Set<Task>,
+    gitIgnoreClassifier: GitIgnoreClassifier
+): DependentOutputExtensions {
   val extensions = mutableSetOf<String>()
+  var needsCatchAll = false
 
   // Extensions implied by this task's own type (what it consumes from upstream) and, for a
   // pass-through Copy/Sync task, its declared concrete-file sources (what it forwards downstream
@@ -206,15 +236,26 @@ fun inferExtensionsFromInputProperties(
   extensions.addAll(extensionsForTaskType(task))
   extensions.addAll(declaredCopySourceExtensions(task, gitIgnoreClassifier))
 
-  // Extensions implied by each dependent task's declared model (what it produces).
   dependentTasks.forEach { depTask ->
-    extensions.addAll(extensionsForTaskType(depTask))
-    extensions.addAll(declaredArchiveExtensions(depTask))
-    extensions.addAll(declaredFileOutputExtensions(depTask))
-    extensions.addAll(declaredCopySourceExtensions(depTask, gitIgnoreClassifier))
+    val depExtensions = mutableSetOf<String>()
+    depExtensions.addAll(extensionsForTaskType(depTask))
+    depExtensions.addAll(declaredArchiveExtensions(depTask))
+    depExtensions.addAll(declaredFileOutputExtensions(depTask))
+    depExtensions.addAll(declaredCopySourceExtensions(depTask, gitIgnoreClassifier))
+
+    if (depExtensions.isNotEmpty()) {
+      extensions.addAll(depExtensions)
+    } else if (declaresDirectoryOutput(depTask)) {
+      // Uncharacterizable: a directory output whose file extensions the task model does not
+      // declare (e.g. a Copy whose only source is a FileTree, or an opaque custom task with just
+      // an @OutputDirectory). Fall back to "**/*" so this dependency's outputs are still hashed.
+      // Known limitation: a MIXED Copy (concrete source + FileTree source) is characterized by its
+      // concrete part and will NOT get a catch-all, so the FileTree part is under-covered. Rare.
+      needsCatchAll = true
+    }
   }
 
-  return extensions.toSet()
+  return DependentOutputExtensions(extensions.toSet(), needsCatchAll)
 }
 
 /**
@@ -277,6 +318,16 @@ private fun declaredFileOutputExtensions(task: Task): Set<String> {
     task.logger.debug("Could not read declared file outputs for ${task.path}: ${e.message}")
   }
   return extensions
+}
+
+/** True if the task declares at least one DIRECTORY output in the task model. */
+private fun declaresDirectoryOutput(task: Task): Boolean {
+  return try {
+    val outputs = task.outputs as? DefaultTaskOutputs ?: return false
+    outputs.fileProperties.any { it.outputType == TreeType.DIRECTORY }
+  } catch (e: Exception) {
+    false
+  }
 }
 
 /**
@@ -430,17 +481,26 @@ private fun getInputsForTaskImpl(
       }
     }
 
-    // Derive dependent-task output extensions purely from the Gradle task model (task types and
+    // Characterize dependent-task outputs purely from the Gradle task model (task types and
     // declared archive/file outputs), independent of whether build artifacts exist on disk.
-    val dependentTaskOutputExtensions =
-        inferExtensionsFromInputProperties(task, tasksToProcess, gitIgnoreClassifier)
+    val dependentOutputs =
+        collectDependentOutputExtensions(task, tasksToProcess, gitIgnoreClassifier)
 
-    // Consolidate dependent-task outputs into per-extension globs (skip non-deterministic IC state)
-    dependentTaskOutputExtensions
-        .filterNot { nonInputDependentOutputExtensions.contains(it) }
-        .forEach { extension ->
-          inputs.add(mapOf("dependentTasksOutputFiles" to "**/*.$extension", "transitive" to true))
-        }
+    if (dependentOutputs.needsCatchAll) {
+      // At least one dependency has an uncharacterizable directory output. A "**/*" glob is matched
+      // within each dependency's declared output dirs (and broadcasts across all of them), so it
+      // subsumes the per-extension globs; emit it alone.
+      inputs.add(mapOf("dependentTasksOutputFiles" to "**/*", "transitive" to true))
+    } else {
+      // Consolidate dependent-task outputs into per-extension globs (skip non-deterministic IC
+      // state, e.g. compiler *.bin).
+      dependentOutputs.extensions
+          .filterNot { nonInputDependentOutputExtensions.contains(it) }
+          .forEach { extension ->
+            inputs.add(
+                mapOf("dependentTasksOutputFiles" to "**/*.$extension", "transitive" to true))
+          }
+    }
 
     if (externalDependencies.isNotEmpty()) {
       inputs.add(mapOf("externalDependencies" to externalDependencies))

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -191,21 +191,25 @@ fun getGradleFilesInputs(workspaceRoot: String): List<String> {
  * invalidate consumers should declare file outputs (or wire `from(task)` delegation) so their
  * extensions are visible here.
  */
-fun inferExtensionsFromInputProperties(task: Task, dependentTasks: Set<Task>): Set<String> {
+fun inferExtensionsFromInputProperties(
+    task: Task,
+    dependentTasks: Set<Task>,
+    gitIgnoreClassifier: GitIgnoreClassifier
+): Set<String> {
   val extensions = mutableSetOf<String>()
 
   // Extensions implied by this task's own type (what it consumes from upstream) and, for a
   // pass-through Copy/Sync task, its declared concrete-file sources (what it forwards downstream
   // even when the producer that generated them declares no outputs).
   extensions.addAll(extensionsForTaskType(task))
-  extensions.addAll(declaredCopySourceExtensions(task))
+  extensions.addAll(declaredCopySourceExtensions(task, gitIgnoreClassifier))
 
   // Extensions implied by each dependent task's declared model (what it produces).
   dependentTasks.forEach { depTask ->
     extensions.addAll(extensionsForTaskType(depTask))
     extensions.addAll(declaredArchiveExtensions(depTask))
     extensions.addAll(declaredFileOutputExtensions(depTask))
-    extensions.addAll(declaredCopySourceExtensions(depTask))
+    extensions.addAll(declaredCopySourceExtensions(depTask, gitIgnoreClassifier))
   }
 
   return extensions.toSet()
@@ -284,12 +288,20 @@ private fun declaredFileOutputExtensions(task: Task): Set<String> {
  * providers and task outputs are skipped, since turning them into extensions would require
  * enumerating the working tree. This is existence-independent: the raw `from(...)` arguments are
  * read, never resolved.
+ *
+ * Only sources that are NOT checked in (i.e. gitignored/generated build outputs) contribute an
+ * extension. `dependentTasksOutputFiles` globs are matched against dependency OUTPUTS, so a
+ * checked-in source is already captured as a direct source input by the `task.inputs.files` branch
+ * and emitting a glob for it would be redundant and imprecise.
  */
-private fun declaredCopySourceExtensions(task: Task): Set<String> {
+private fun declaredCopySourceExtensions(
+    task: Task,
+    gitIgnoreClassifier: GitIgnoreClassifier
+): Set<String> {
   if (task !is AbstractCopyTask) return emptySet()
   val extensions = mutableSetOf<String>()
   try {
-    collectCopySourceExtensions(task.rootSpec, extensions)
+    collectCopySourceExtensions(task.rootSpec, extensions, gitIgnoreClassifier)
   } catch (e: Exception) {
     task.logger.debug("Could not read copy source paths for ${task.path}: ${e.message}")
   }
@@ -297,36 +309,44 @@ private fun declaredCopySourceExtensions(task: Task): Set<String> {
 }
 
 /**
- * Recursively collect declared concrete-file source extensions from a copy spec and its children.
+ * Recursively collect declared concrete-file source extensions from a copy spec and its children,
+ * limited to non-checked-in (gitignored/generated) sources.
  */
-private fun collectCopySourceExtensions(spec: CopySpecInternal, into: MutableSet<String>) {
+private fun collectCopySourceExtensions(
+    spec: CopySpecInternal,
+    into: MutableSet<String>,
+    gitIgnoreClassifier: GitIgnoreClassifier
+) {
   if (spec is DefaultCopySpec) {
     spec.sourcePaths.forEach { source ->
       try {
-        extensionFromDeclaredPath(source)?.let { into.add(it) }
+        val file = fileFromDeclaredSource(source) ?: return@forEach
+        // Only generated (gitignored) sources need a dependentTasksOutputFiles glob; checked-in
+        // sources are already emitted as direct inputs. isIgnored is a pattern match and does not
+        // require the file to exist.
+        if (gitIgnoreClassifier.isIgnored(file)) {
+          file.extension.takeIf { it.isNotEmpty() }?.let { into.add(it) }
+        }
       } catch (e: Exception) {
         // Skip any source we cannot classify without touching disk.
       }
     }
   }
-  spec.children.forEach { child -> collectCopySourceExtensions(child, into) }
+  spec.children.forEach { child -> collectCopySourceExtensions(child, into, gitIgnoreClassifier) }
 }
 
 /**
- * Extract a file extension from a declared `from(...)` argument, but only when the argument is a
- * concrete file path we can read without touching disk. Returns null for directories/extension-less
- * paths and for non-path argument types (FileTree, FileCollection, provider, task output, ...).
+ * Convert a declared `from(...)` argument into a concrete [File] when it is a path we can read
+ * without touching disk. Returns null for non-path argument types (FileTree, FileCollection,
+ * provider, task output, ...).
  */
-private fun extensionFromDeclaredPath(source: Any?): String? {
-  val file: File =
-      when (source) {
-        is File -> source
-        is java.nio.file.Path -> source.toFile()
-        is CharSequence -> File(source.toString())
-        else -> return null
-      }
-  return file.extension.ifEmpty { null }
-}
+private fun fileFromDeclaredSource(source: Any?): File? =
+    when (source) {
+      is File -> source
+      is java.nio.file.Path -> source.toFile()
+      is CharSequence -> File(source.toString())
+      else -> null
+    }
 
 /**
  * Parse task and get inputs for this task
@@ -402,7 +422,8 @@ private fun getInputsForTaskImpl(
 
     // Derive dependent-task output extensions purely from the Gradle task model (task types and
     // declared archive/file outputs), independent of whether build artifacts exist on disk.
-    val dependentTaskOutputExtensions = inferExtensionsFromInputProperties(task, tasksToProcess)
+    val dependentTaskOutputExtensions =
+        inferExtensionsFromInputProperties(task, tasksToProcess, gitIgnoreClassifier)
 
     // Consolidate dependent-task outputs into per-extension globs (skip non-deterministic IC state)
     dependentTaskOutputExtensions

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
@@ -221,62 +221,69 @@ class ProcessTaskUtilsTest {
     }
 
     @Test
-    fun `test getInputsForTask discovers Copy task source extensions in clean build`() {
-      // Create source files with specific extensions in a source directory
-      val sourceDir = java.io.File("$workspaceRoot/src/resources").apply { mkdirs() }
-      java.io.File(sourceDir, "config.conf").writeText("test config")
-      java.io.File(sourceDir, "data.json").writeText("{}")
+    fun `test getInputsForTask dependent output extensions are deterministic across trees`() {
+      // A dependent whose extension IS derivable from the task model (declared archive extension).
+      val jarProducer =
+          project.tasks.register("jarProducer", org.gradle.api.tasks.bundling.Jar::class.java).get()
+      jarProducer.archiveExtension.set("jar")
 
-      // Create a Copy task that copies from source to destination (but don't populate destination)
-      val copyTask =
-          project.tasks.register("processResources", org.gradle.api.tasks.Copy::class.java).get()
-      copyTask.from(sourceDir)
-      copyTask.into(java.io.File("$workspaceRoot/build/resources"))
-      // Note: we do NOT create/populate the destination directory to simulate a clean build
+      // A Copy dependent whose SOURCE extensions must NOT leak into the derivation: their presence
+      // on disk depends on transient build state.
+      val sourceDir = java.io.File("$workspaceRoot/src/bundled")
+      val copyDep =
+          project.tasks.register("copyBundled", org.gradle.api.tasks.Copy::class.java).get()
+      copyDep.from(sourceDir)
+      copyDep.into(java.io.File("$workspaceRoot/build/bundled"))
 
-      // Create a consumer task that depends on the Copy task
-      val consumerTask = project.tasks.register("classes").get()
-      consumerTask.dependsOn(copyTask)
+      val consumer = project.tasks.register("consumerDeterministic").get()
+      consumer.dependsOn(jarProducer, copyDep)
 
       val gitIgnoreClassifier = GitIgnoreClassifier(java.io.File(workspaceRoot))
-      val result =
+
+      fun outputFileGlobs(): Set<String> =
           getInputsForTask(
-              null, consumerTask, projectRoot, workspaceRoot, mutableMapOf(), gitIgnoreClassifier)
+                  null, consumer, projectRoot, workspaceRoot, mutableMapOf(), gitIgnoreClassifier)
+              ?.filterIsInstance<Map<*, *>>()
+              ?.mapNotNull { it["dependentTasksOutputFiles"] as? String }
+              ?.toSet() ?: emptySet()
 
-      assertNotNull(result, "Result should not be null")
+      // Clean tree: no source or artifact files on disk.
+      val clean = outputFileGlobs()
 
-      // Should contain globs for both .conf and .json extensions inferred from Copy task inputs
-      assertTrue(
-          result!!.any {
-            it is Map<*, *> &&
-                it["dependentTasksOutputFiles"] == "**/*.conf" &&
-                it["transitive"] == true
-          },
-          "Expected **/*.conf glob in result: $result")
-      assertTrue(
-          result.any {
-            it is Map<*, *> &&
-                it["dependentTasksOutputFiles"] == "**/*.json" &&
-                it["transitive"] == true
-          },
-          "Expected **/*.json glob in result: $result")
+      // Built tree: create Copy sources and the jar output on disk (transient build state).
+      sourceDir.mkdirs()
+      java.io.File(sourceDir, "bundle.tar.gz").writeText("x")
+      java.io.File(sourceDir, "data.json").writeText("{}")
+      java.io.File("$workspaceRoot/build/libs").mkdirs()
+      java.io.File("$workspaceRoot/build/libs/app.jar").writeText("x")
+      val built = outputFileGlobs()
+
+      // The derivation must be a pure function of the task model, not of on-disk build state.
+      assertEquals(
+          clean,
+          built,
+          "dependentTasksOutputFiles must not change between a clean and a built tree")
+
+      // The model-derivable extension is present; the Copy SOURCE extensions never leak in.
+      assertTrue(clean.contains("**/*.jar"), "Expected jar from archiveExtension, got $clean")
+      assertFalse(clean.contains("**/*.gz"), "Copy source .gz must not leak, got $clean")
+      assertFalse(clean.contains("**/*.json"), "Copy source .json must not leak, got $clean")
     }
 
     @Test
-    fun `test getInputsForTask discovers Sync task source extensions in clean build`() {
-      // Create source files with specific extensions in a source directory
+    fun `test getInputsForTask does not derive extensions from Copy or Sync source files`() {
+      // Regression guard: Copy/Sync SOURCE file extensions must not drive dependentTasksOutputFiles
+      // globs. Their presence on disk depends on transient build state, and a Sync/Copy task
+      // declares only a destination DIRECTORY output (no per-extension info) in the task model.
       val sourceDir = java.io.File("$workspaceRoot/src/sync-input").apply { mkdirs() }
       java.io.File(sourceDir, "config.conf").writeText("test config")
       java.io.File(sourceDir, "data.json").writeText("{}")
 
-      // Create a Sync task that syncs from source to destination (but don't populate destination)
       val syncTask =
           project.tasks.register("syncResources", org.gradle.api.tasks.Sync::class.java).get()
       syncTask.from(sourceDir)
       syncTask.into(java.io.File("$workspaceRoot/build/sync-output"))
-      // Note: we do NOT create/populate the destination directory to simulate a clean build
 
-      // Create a consumer task that depends on the Sync task
       val consumerTask = project.tasks.register("consumerSync").get()
       consumerTask.dependsOn(syncTask)
 
@@ -285,23 +292,14 @@ class ProcessTaskUtilsTest {
           getInputsForTask(
               null, consumerTask, projectRoot, workspaceRoot, mutableMapOf(), gitIgnoreClassifier)
 
-      assertNotNull(result, "Result should not be null")
+      val globs =
+          result
+              ?.filterIsInstance<Map<*, *>>()
+              ?.mapNotNull { it["dependentTasksOutputFiles"] as? String }
+              ?.toSet() ?: emptySet()
 
-      // Should contain globs for both .conf and .json extensions inferred from Sync task inputs
-      assertTrue(
-          result!!.any {
-            it is Map<*, *> &&
-                it["dependentTasksOutputFiles"] == "**/*.conf" &&
-                it["transitive"] == true
-          },
-          "Expected **/*.conf glob in result for Sync: $result")
-      assertTrue(
-          result.any {
-            it is Map<*, *> &&
-                it["dependentTasksOutputFiles"] == "**/*.json" &&
-                it["transitive"] == true
-          },
-          "Expected **/*.json glob in result for Sync: $result")
+      assertFalse(globs.contains("**/*.conf"), "Sync source .conf must not leak, got $globs")
+      assertFalse(globs.contains("**/*.json"), "Sync source .json must not leak, got $globs")
     }
 
     @Test
@@ -342,10 +340,9 @@ class ProcessTaskUtilsTest {
     }
 
     @Test
-    fun `test AGP task detection gracefully handles missing classes in classpath`() {
-      // When AGP classes are not on the classpath, isAgpCopyLikeTask returns false.
-      // This test verifies the detection doesn't crash and gracefully degrades.
-      // Create a plain task (not Copy, Sync, or AGP) as a dependency.
+    fun `test getInputsForTask with a plain dependent yields no output-file globs`() {
+      // A dependent task with no recognized type and no declared outputs contributes no
+      // dependentTasksOutputFiles globs, and the derivation must not crash.
       val plainTask = project.tasks.register("plainTask").get()
 
       // Create a consumer task that depends on it
@@ -354,13 +351,17 @@ class ProcessTaskUtilsTest {
 
       val gitIgnoreClassifier = GitIgnoreClassifier(java.io.File(workspaceRoot))
 
-      // This should not crash even though AGP is not on the classpath
       val result =
           getInputsForTask(
               null, consumerTask, projectRoot, workspaceRoot, mutableMapOf(), gitIgnoreClassifier)
 
-      // Verify it completes without error (graceful degradation)
-      // Result can be null if there are no inputs - thats fine
+      // No recognized type or declared outputs -> no output-file globs (result may be null if the
+      // task has no inputs at all).
+      val globs =
+          result?.filterIsInstance<Map<*, *>>()?.count {
+            it.containsKey("dependentTasksOutputFiles")
+          } ?: 0
+      assertEquals(0, globs, "Plain dependent should yield no dependentTasksOutputFiles: $result")
     }
 
     @Test
@@ -588,10 +589,9 @@ class ProcessTaskUtilsTest {
 
       // Add inputs with mixed types
       val sourceFile = java.io.File("$workspaceRoot/src/main.kt") // Not ignored - should be input
-      val buildFile = java.io.File("$workspaceRoot/build/classes/Main.class") // Ignored - should be
-      // dependentTasksOutputFiles
-      val logFile =
-          java.io.File("$workspaceRoot/app.log") // Ignored - should be dependentTasksOutputFiles
+      val buildFile =
+          java.io.File("$workspaceRoot/build/classes/Main.class") // Ignored - build artifact
+      val logFile = java.io.File("$workspaceRoot/app.log") // Ignored - build artifact
       val configFile =
           java.io.File("$workspaceRoot/config/app.properties") // Not ignored - should be input
 
@@ -610,21 +610,22 @@ class ProcessTaskUtilsTest {
       // Config file should be regular input
       assertTrue(result.any { it == Path("{projectRoot}", "config", "app.properties").toString() })
 
-      // Build file (class extension) should be consolidated into dependentTasksOutputFiles glob
-      assertTrue(
-          result.any {
-            it is Map<*, *> &&
-                it["dependentTasksOutputFiles"] == "**/*.class" &&
-                it["transitive"] == true
-          })
+      // Gitignored build artifacts must NOT be added as direct source inputs.
+      assertFalse(
+          result.any { it == Path("{projectRoot}", "build", "classes", "Main.class").toString() },
+          "Gitignored build artifact should not be a direct input: $result")
+      assertFalse(
+          result.any { it == Path("{projectRoot}", "app.log").toString() },
+          "Gitignored log file should not be a direct input: $result")
 
-      // Log file should be consolidated into dependentTasksOutputFiles glob
-      assertTrue(
-          result.any {
-            it is Map<*, *> &&
-                it["dependentTasksOutputFiles"] == "**/*.log" &&
-                it["transitive"] == true
-          })
+      // Extensions are NOT harvested from gitignored inputs on disk; they are derived from the task
+      // model (dependent task outputs). This task has no dependents, so no output-file globs exist.
+      assertFalse(
+          result.any { it is Map<*, *> && it["dependentTasksOutputFiles"] == "**/*.class" },
+          "Extensions must not be harvested from gitignored inputs on disk: $result")
+      assertFalse(
+          result.any { it is Map<*, *> && it["dependentTasksOutputFiles"] == "**/*.log" },
+          "Extensions must not be harvested from gitignored inputs on disk: $result")
     }
 
     @Test
@@ -661,20 +662,21 @@ class ProcessTaskUtilsTest {
 
       assertTrue(result!!.any { it == Path("{projectRoot}", "src", "Main.java").toString() })
 
-      // Both ignored files should be consolidated into glob patterns by extension
-      assertTrue(
-          result.any {
-            it is Map<*, *> &&
-                it["dependentTasksOutputFiles"] == "**/*.class" &&
-                it["transitive"] == true
-          })
+      // Gitignored build artifacts must NOT be added as direct source inputs.
+      assertFalse(
+          result.any { it == Path("{projectRoot}", "dist", "production", "Main.class").toString() },
+          "Gitignored build artifact should not be a direct input: $result")
+      assertFalse(
+          result.any { it == Path("{projectRoot}", "dist", "app.jar").toString() },
+          "Gitignored build artifact should not be a direct input: $result")
 
-      assertTrue(
-          result.any {
-            it is Map<*, *> &&
-                it["dependentTasksOutputFiles"] == "**/*.jar" &&
-                it["transitive"] == true
-          })
+      // Extensions are NOT harvested from gitignored inputs on disk (this task has no dependents).
+      assertFalse(
+          result.any { it is Map<*, *> && it["dependentTasksOutputFiles"] == "**/*.class" },
+          "Extensions must not be harvested from gitignored inputs on disk: $result")
+      assertFalse(
+          result.any { it is Map<*, *> && it["dependentTasksOutputFiles"] == "**/*.jar" },
+          "Extensions must not be harvested from gitignored inputs on disk: $result")
     }
   }
 

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
@@ -305,6 +305,36 @@ class ProcessTaskUtilsTest {
     }
 
     @Test
+    fun `test getInputsForTask over-declares catch-all when a dependency output read fails`() {
+      // A TaskOutputs implementing only the public interface makes the reflective
+      // getFileProperties() read throw; the dependency must over-declare "**/*".
+      val realDep = project.tasks.register("failingDep").get()
+      val fakeDep =
+          object : org.gradle.api.Task by realDep {
+            override fun getOutputs(): org.gradle.api.tasks.TaskOutputs =
+                object : org.gradle.api.tasks.TaskOutputs by realDep.outputs {}
+          }
+      val consumer = project.tasks.register("consumerFailingDep").get()
+      val gitIgnoreClassifier = GitIgnoreClassifier(java.io.File(workspaceRoot))
+
+      val globs =
+          getInputsForTask(
+                  setOf(fakeDep),
+                  consumer,
+                  projectRoot,
+                  workspaceRoot,
+                  mutableMapOf(),
+                  gitIgnoreClassifier)
+              ?.filterIsInstance<Map<*, *>>()
+              ?.mapNotNull { it["dependentTasksOutputFiles"] as? String }
+              ?.toSet() ?: emptySet()
+
+      assertTrue(
+          globs.contains("**/*"),
+          "A dependency whose output model can't be read must over-declare **/*, got $globs")
+    }
+
+    @Test
     fun `test getInputsForTask falls back to catch-all for a fileTree-only Copy dependency`() {
       // A Copy whose only source is a FileTree yields no characterizable extensions, but its
       // destination @OutputDirectory triggers the catch-all. FileTree contents are never

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
@@ -271,15 +271,19 @@ class ProcessTaskUtilsTest {
     }
 
     @Test
-    fun `test getInputsForTask derives Copy concrete-file sources but not FileTree sources`() {
+    fun `test getInputsForTask derives generated Copy sources but not checked-in or FileTree ones`() {
       // A Copy/Sync task is pass-through: its declared concrete-file sources (from(File ...)) equal
-      // its effective outputs and ARE derived, deterministically, even when the files do not exist
-      // on disk. FileTree / directory sources must NOT be enumerated.
+      // its effective outputs. Only GENERATED (gitignored) sources need a dependentTasksOutputFiles
+      // glob; checked-in sources are already captured as direct inputs, and FileTree/directory
+      // sources must never be enumerated. Extensions are derived without the files existing on
+      // disk.
       val syncTask =
           project.tasks.register("syncResources", org.gradle.api.tasks.Sync::class.java).get()
-      // Concrete declared file sources (intentionally NOT created on disk yet).
+      // Generated (the fixture gitignores "dist") concrete file sources, intentionally NOT created.
       syncTask.from(java.io.File("$workspaceRoot/dist/bundle.tar.gz"))
       syncTask.from(java.io.File("$workspaceRoot/dist/runner.json"))
+      // Checked-in concrete file source (NOT gitignored) - must not yield a glob.
+      syncTask.from(java.io.File("$workspaceRoot/src/main/resources/config.conf"))
       // A FileTree source whose contents must never be enumerated.
       val leakDir = java.io.File("$workspaceRoot/dist/leak").apply { mkdirs() }
       java.io.File(leakDir, "secret.leak").writeText("x")
@@ -303,16 +307,19 @@ class ProcessTaskUtilsTest {
               ?.mapNotNull { it["dependentTasksOutputFiles"] as? String }
               ?.toSet() ?: emptySet()
 
-      // Clean tree (bundle/runner files absent): concrete-file source extensions still derived.
+      // Clean tree (generated files absent): generated concrete-file source extensions still
+      // derived.
       val clean = outputFileGlobs()
-      // Built tree: create the concrete source files on disk.
+      // Built tree: create the generated source files on disk.
       java.io.File("$workspaceRoot/dist/bundle.tar.gz").writeText("x")
       java.io.File("$workspaceRoot/dist/runner.json").writeText("{}")
       val built = outputFileGlobs()
 
       assertEquals(clean, built, "Copy source derivation must not depend on on-disk state")
-      assertTrue(clean.contains("**/*.gz"), "Expected gz from from(File .tar.gz), got $clean")
-      assertTrue(clean.contains("**/*.json"), "Expected json from from(File .json), got $clean")
+      assertTrue(clean.contains("**/*.gz"), "Expected gz from generated from(File), got $clean")
+      assertTrue(clean.contains("**/*.json"), "Expected json from generated from(File), got $clean")
+      assertFalse(
+          clean.contains("**/*.conf"), "Checked-in Copy source must not produce a glob, got $clean")
       assertFalse(
           clean.contains("**/*.leak"),
           "FileTree source contents must not be enumerated, got $clean")
@@ -766,7 +773,9 @@ class ProcessTaskUtilsTest {
       val compileTestKotlin = kotlinProject.tasks.getByName("compileTestKotlin")
       val dependsOnTasks = getDependsOnTask(compileTestKotlin)
 
-      val extensions = inferExtensionsFromInputProperties(compileTestKotlin, dependsOnTasks)
+      val extensions =
+          inferExtensionsFromInputProperties(
+              compileTestKotlin, dependsOnTasks, GitIgnoreClassifier(kotlinProject.rootDir))
 
       assertTrue(extensions.contains("class"), "Expected 'class' extension, got $extensions")
       assertTrue(
@@ -781,7 +790,9 @@ class ProcessTaskUtilsTest {
 
       val compileKotlin = kotlinProject.tasks.getByName("compileKotlin")
 
-      val extensions = inferExtensionsFromInputProperties(compileKotlin, emptySet())
+      val extensions =
+          inferExtensionsFromInputProperties(
+              compileKotlin, emptySet(), GitIgnoreClassifier(kotlinProject.rootDir))
 
       assertTrue(
           extensions.contains("class"),
@@ -799,7 +810,9 @@ class ProcessTaskUtilsTest {
       val compileKotlin = kotlinProject.tasks.getByName("compileKotlin")
       val plain = kotlinProject.tasks.register("plain").get()
 
-      val extensions = inferExtensionsFromInputProperties(plain, setOf(compileKotlin))
+      val extensions =
+          inferExtensionsFromInputProperties(
+              plain, setOf(compileKotlin), GitIgnoreClassifier(kotlinProject.rootDir))
 
       assertTrue(
           extensions.contains("class"),
@@ -813,7 +826,9 @@ class ProcessTaskUtilsTest {
 
       val compileJava = project.tasks.getByName("compileJava")
 
-      val extensions = inferExtensionsFromInputProperties(compileJava, emptySet())
+      val extensions =
+          inferExtensionsFromInputProperties(
+              compileJava, emptySet(), GitIgnoreClassifier(project.rootDir))
 
       assertTrue(extensions.contains("class"), "Expected 'class' extension, got $extensions")
       assertFalse(
@@ -829,7 +844,10 @@ class ProcessTaskUtilsTest {
       val dependentTasks = setOf(jarTask)
 
       val extensions =
-          inferExtensionsFromInputProperties(kotlinProject.tasks.getByName("build"), dependentTasks)
+          inferExtensionsFromInputProperties(
+              kotlinProject.tasks.getByName("build"),
+              dependentTasks,
+              GitIgnoreClassifier(kotlinProject.rootDir))
 
       assertTrue(
           extensions.contains("jar"),
@@ -842,7 +860,9 @@ class ProcessTaskUtilsTest {
       kotlinProject.plugins.apply("org.jetbrains.kotlin.jvm")
 
       val testTask = kotlinProject.tasks.getByName("test")
-      val extensions = inferExtensionsFromInputProperties(testTask, emptySet())
+      val extensions =
+          inferExtensionsFromInputProperties(
+              testTask, emptySet(), GitIgnoreClassifier(kotlinProject.rootDir))
 
       assertTrue(
           extensions.contains("class"), "Expected 'class' extension for Test task, got $extensions")
@@ -855,7 +875,8 @@ class ProcessTaskUtilsTest {
       val project = ProjectBuilder.builder().build()
       val task = project.tasks.register("plainTask").get()
 
-      val extensions = inferExtensionsFromInputProperties(task, emptySet())
+      val extensions =
+          inferExtensionsFromInputProperties(task, emptySet(), GitIgnoreClassifier(project.rootDir))
 
       assertTrue(extensions.isEmpty(), "Expected empty extensions for plain task, got $extensions")
     }

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
@@ -505,6 +505,43 @@ class ProcessTaskUtilsTest {
     }
 
     @Test
+    fun `test getInputsForTask jar sees processResources sources through the classes lifecycle task`() {
+      // Ocean nx-api scenario: the Java plugin wires jar -> classes -> {compileJava,
+      // processResources}.
+      // processResources is a Copy that bundles generated dist/ archives. jar reaches it only
+      // transitively through the opaque `classes` lifecycle task, so the dependency traversal must
+      // see through `classes` to surface processResources' **/*.gz and **/*.json patterns on jar.
+      project.plugins.apply("java")
+
+      val processResources =
+          project.tasks.getByName("processResources") as org.gradle.api.tasks.Copy
+      processResources.from(
+          java.io.File("$workspaceRoot/dist/libs/polygraph/cli/bundle/polygraph-bundle.tar.gz"))
+      processResources.from(
+          java.io.File("$workspaceRoot/dist/libs/polygraph/cli/bundle/polygraph-runner.json"))
+      // The generated bundles are intentionally NOT created on disk (clean tree).
+
+      val jar = project.tasks.getByName("jar")
+      val gitIgnoreClassifier = GitIgnoreClassifier(java.io.File(workspaceRoot))
+
+      val result =
+          getInputsForTask(
+              null, jar, projectRoot, workspaceRoot, mutableMapOf(), gitIgnoreClassifier)
+
+      println("=== getInputsForTask(jar) inputs (verbatim) ===")
+      result?.forEach { println("  $it") }
+      println("=== end jar inputs ===")
+
+      assertNotNull(result, "jar inputs should not be null")
+      val hasPattern = { p: String ->
+        result!!.any { it is Map<*, *> && it["dependentTasksOutputFiles"] == p }
+      }
+      assertTrue(hasPattern("**/*.gz"), "jar must see processResources' **/*.gz, got $result")
+      assertTrue(hasPattern("**/*.json"), "jar must see processResources' **/*.json, got $result")
+      assertTrue(hasPattern("**/*.class"), "jar must see compileJava's **/*.class, got $result")
+    }
+
+    @Test
     fun `test getInputsForTask uses archiveExtension for Jar, not source extensions`() {
       // Create a Jar task with source files
       val sourceDir = java.io.File("$workspaceRoot/src/main/java").apply { mkdirs() }

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
@@ -221,18 +221,17 @@ class ProcessTaskUtilsTest {
     }
 
     @Test
-    fun `test getInputsForTask dependent output extensions are deterministic across trees`() {
+    fun `test getInputsForTask characterizable dependencies yield specific globs deterministically`() {
       // A dependent whose extension IS derivable from the task model (declared archive extension).
       val jarProducer =
           project.tasks.register("jarProducer", org.gradle.api.tasks.bundling.Jar::class.java).get()
       jarProducer.archiveExtension.set("jar")
 
-      // A Copy dependent with a DIRECTORY source: its contents must NOT be enumerated (only
-      // declared concrete-file sources are read), so nothing on disk under it can leak in.
-      val sourceDir = java.io.File("$workspaceRoot/src/bundled")
+      // A Copy dependent with a CONCRETE gitignored source: characterizable (yields gz), so it
+      // contributes a specific glob and never a catch-all.
       val copyDep =
           project.tasks.register("copyBundled", org.gradle.api.tasks.Copy::class.java).get()
-      copyDep.from(sourceDir)
+      copyDep.from(java.io.File("$workspaceRoot/dist/bundle.tar.gz"))
       copyDep.into(java.io.File("$workspaceRoot/build/bundled"))
 
       val consumer = project.tasks.register("consumerDeterministic").get()
@@ -247,13 +246,12 @@ class ProcessTaskUtilsTest {
               ?.mapNotNull { it["dependentTasksOutputFiles"] as? String }
               ?.toSet() ?: emptySet()
 
-      // Clean tree: no source or artifact files on disk.
+      // Clean tree: no artifact files on disk.
       val clean = outputFileGlobs()
 
-      // Built tree: create Copy sources and the jar output on disk (transient build state).
-      sourceDir.mkdirs()
-      java.io.File(sourceDir, "bundle.tar.gz").writeText("x")
-      java.io.File(sourceDir, "data.json").writeText("{}")
+      // Built tree: create the generated source and jar output on disk (transient build state).
+      java.io.File("$workspaceRoot/dist").mkdirs()
+      java.io.File("$workspaceRoot/dist/bundle.tar.gz").writeText("x")
       java.io.File("$workspaceRoot/build/libs").mkdirs()
       java.io.File("$workspaceRoot/build/libs/app.jar").writeText("x")
       val built = outputFileGlobs()
@@ -264,10 +262,102 @@ class ProcessTaskUtilsTest {
           built,
           "dependentTasksOutputFiles must not change between a clean and a built tree")
 
-      // The model-derivable extension is present; the Copy SOURCE extensions never leak in.
+      // Characterizable dependencies yield specific globs, never the catch-all.
       assertTrue(clean.contains("**/*.jar"), "Expected jar from archiveExtension, got $clean")
-      assertFalse(clean.contains("**/*.gz"), "Copy source .gz must not leak, got $clean")
-      assertFalse(clean.contains("**/*.json"), "Copy source .json must not leak, got $clean")
+      assertTrue(clean.contains("**/*.gz"), "Expected gz from concrete Copy source, got $clean")
+      assertFalse(
+          clean.contains("**/*"), "Characterizable deps must not trigger the catch-all, got $clean")
+    }
+
+    @Test
+    fun `test getInputsForTask falls back to catch-all for uncharacterizable directory output`() {
+      // An opaque dependency that declares only an @OutputDirectory (no type/archive/file-output we
+      // can reduce to extensions) triggers a conservative "**/*" so its directory is still hashed.
+      val opaqueDep = project.tasks.register("opaqueDep").get()
+      opaqueDep.outputs.dir(java.io.File("$workspaceRoot/build/opaque"))
+
+      val consumer = project.tasks.register("consumerOpaque").get()
+      consumer.dependsOn(opaqueDep)
+
+      val gitIgnoreClassifier = GitIgnoreClassifier(java.io.File(workspaceRoot))
+
+      fun outputFileGlobs(): Set<String> =
+          getInputsForTask(
+                  null, consumer, projectRoot, workspaceRoot, mutableMapOf(), gitIgnoreClassifier)
+              ?.filterIsInstance<Map<*, *>>()
+              ?.mapNotNull { it["dependentTasksOutputFiles"] as? String }
+              ?.toSet() ?: emptySet()
+
+      val clean = outputFileGlobs()
+      java.io.File("$workspaceRoot/build/opaque").mkdirs()
+      java.io.File("$workspaceRoot/build/opaque/thing.dat").writeText("x")
+      val built = outputFileGlobs()
+
+      assertEquals(clean, built, "catch-all must be deterministic across clean and built trees")
+      assertTrue(
+          clean.contains("**/*"), "Expected catch-all for an opaque directory output, got $clean")
+    }
+
+    @Test
+    fun `test getInputsForTask falls back to catch-all for a fileTree-only Copy dependency`() {
+      // A Copy whose only source is a FileTree yields no characterizable extensions, but its
+      // destination @OutputDirectory triggers the catch-all. FileTree contents are never
+      // enumerated.
+      val treeDir = java.io.File("$workspaceRoot/dist/tree").apply { mkdirs() }
+      java.io.File(treeDir, "a.dat").writeText("x")
+      val copyDep = project.tasks.register("copyTree", org.gradle.api.tasks.Copy::class.java).get()
+      copyDep.from(project.fileTree(treeDir))
+      copyDep.into(java.io.File("$workspaceRoot/build/tree-out"))
+
+      val consumer = project.tasks.register("consumerTree").get()
+      consumer.dependsOn(copyDep)
+
+      val gitIgnoreClassifier = GitIgnoreClassifier(java.io.File(workspaceRoot))
+
+      fun outputFileGlobs(): Set<String> =
+          getInputsForTask(
+                  null, consumer, projectRoot, workspaceRoot, mutableMapOf(), gitIgnoreClassifier)
+              ?.filterIsInstance<Map<*, *>>()
+              ?.mapNotNull { it["dependentTasksOutputFiles"] as? String }
+              ?.toSet() ?: emptySet()
+
+      val clean = outputFileGlobs()
+      java.io.File(treeDir, "b.json").writeText("{}")
+      val built = outputFileGlobs()
+
+      assertEquals(clean, built, "catch-all must be deterministic across clean and built trees")
+      assertTrue(
+          clean.contains("**/*"),
+          "fileTree-only Copy dependency should yield the catch-all, got $clean")
+      assertFalse(
+          clean.contains("**/*.dat"), "FileTree contents must not be enumerated, got $clean")
+      assertFalse(
+          clean.contains("**/*.json"), "FileTree contents must not be enumerated, got $clean")
+    }
+
+    @Test
+    fun `test getInputsForTask does not use catch-all for a typed compile dependency`() {
+      project.plugins.apply("java")
+      val compileJava = project.tasks.getByName("compileJava")
+
+      val consumer = project.tasks.register("consumerCompile").get()
+      consumer.dependsOn(compileJava)
+
+      val gitIgnoreClassifier = GitIgnoreClassifier(java.io.File(workspaceRoot))
+      val result =
+          getInputsForTask(
+              null, consumer, projectRoot, workspaceRoot, mutableMapOf(), gitIgnoreClassifier)
+      val globs =
+          result
+              ?.filterIsInstance<Map<*, *>>()
+              ?.mapNotNull { it["dependentTasksOutputFiles"] as? String }
+              ?.toSet() ?: emptySet()
+
+      // Typed compile task (directory output, but typed) yields a specific class glob, not "**/*".
+      assertTrue(globs.contains("**/*.class"), "Expected class from JavaCompile, got $globs")
+      assertFalse(
+          globs.contains("**/*"),
+          "Typed compile dependency must not trigger the catch-all, got $globs")
     }
 
     @Test

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
@@ -471,6 +471,40 @@ class ProcessTaskUtilsTest {
     }
 
     @Test
+    fun `test getInputsForTask Copy task itself derives its own from() source extensions`() {
+      // A Copy/Sync task characterized as the CONSUMING task (not as a dependency) must contribute
+      // its own declared concrete-file source extensions to its OWN inputs - the nx-api
+      // processResources case, where a task bundles a generated dist/*.tar.gz via from(File). The
+      // generated (gitignored) source is intentionally NOT created on disk.
+      val syncTask =
+          project.tasks.register("syncResources", org.gradle.api.tasks.Sync::class.java).get()
+      syncTask.from(java.io.File("$workspaceRoot/dist/bundle.tar.gz"))
+      syncTask.into(java.io.File("$workspaceRoot/build/sync-output"))
+
+      val gitIgnoreClassifier = GitIgnoreClassifier(java.io.File(workspaceRoot))
+
+      fun outputFileGlobs(): Set<String> =
+          getInputsForTask(
+                  null, syncTask, projectRoot, workspaceRoot, mutableMapOf(), gitIgnoreClassifier)
+              ?.filterIsInstance<Map<*, *>>()
+              ?.mapNotNull { it["dependentTasksOutputFiles"] as? String }
+              ?.toSet() ?: emptySet()
+
+      // Clean tree: the bundle does not exist on disk.
+      val clean = outputFileGlobs()
+      // Built tree: create the generated source.
+      java.io.File("$workspaceRoot/dist").mkdirs()
+      java.io.File("$workspaceRoot/dist/bundle.tar.gz").writeText("x")
+      val built = outputFileGlobs()
+
+      assertEquals(
+          clean, built, "The task's own source derivation must not depend on on-disk state")
+      assertTrue(
+          clean.contains("**/*.gz"),
+          "Expected gz from the Copy task's own from(File) source, got $clean")
+    }
+
+    @Test
     fun `test getInputsForTask uses archiveExtension for Jar, not source extensions`() {
       // Create a Jar task with source files
       val sourceDir = java.io.File("$workspaceRoot/src/main/java").apply { mkdirs() }

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
@@ -222,8 +222,7 @@ class ProcessTaskUtilsTest {
 
     @Test
     fun `test getInputsForTask collapses to the catch-all when a dependency declares a directory output`() {
-      // Archive dep -> precise "**/*.jar"; Copy dep -> "**/*" catch-all. When both are present the
-      // catch-all subsumes the archive glob, so the set collapses to "**/*".
+      // Archive dep -> "**/*.jar"; Copy dep -> "**/*"; the catch-all subsumes, so it collapses.
       val jarProducer =
           project.tasks.register("jarProducer", org.gradle.api.tasks.bundling.Jar::class.java).get()
       jarProducer.archiveExtension.set("jar")
@@ -261,8 +260,6 @@ class ProcessTaskUtilsTest {
           built,
           "dependentTasksOutputFiles must not change between a clean and a built tree")
 
-      // The catch-all is the only emitted pattern; the archive's precise glob and the copy's source
-      // extension are both subsumed.
       assertEquals(
           setOf("**/*"),
           clean,
@@ -271,9 +268,6 @@ class ProcessTaskUtilsTest {
 
     @Test
     fun `test getInputsForTask archive dependency yields its precise extension without the catch-all`() {
-      // An archive dependency alone (no directory-output dependency) is characterized by its
-      // declared
-      // archive extension: a precise glob, never the catch-all.
       val jarProducer =
           project.tasks.register("jarProducer", org.gradle.api.tasks.bundling.Jar::class.java).get()
       jarProducer.archiveExtension.set("jar")
@@ -299,8 +293,6 @@ class ProcessTaskUtilsTest {
 
     @Test
     fun `test getInputsForTask falls back to catch-all for uncharacterizable directory output`() {
-      // An opaque dependency that declares only an @OutputDirectory (no type/archive/file-output we
-      // can reduce to extensions) triggers a conservative "**/*" so its directory is still hashed.
       val opaqueDep = project.tasks.register("opaqueDep").get()
       opaqueDep.outputs.dir(java.io.File("$workspaceRoot/build/opaque"))
 
@@ -358,9 +350,6 @@ class ProcessTaskUtilsTest {
 
     @Test
     fun `test getInputsForTask falls back to catch-all for a fileTree-only Copy dependency`() {
-      // A Copy whose only source is a FileTree yields no characterizable extensions, but its
-      // destination @OutputDirectory triggers the catch-all. FileTree contents are never
-      // enumerated.
       val treeDir = java.io.File("$workspaceRoot/dist/tree").apply { mkdirs() }
       java.io.File(treeDir, "a.dat").writeText("x")
       val copyDep = project.tasks.register("copyTree", org.gradle.api.tasks.Copy::class.java).get()
@@ -469,8 +458,6 @@ class ProcessTaskUtilsTest {
 
     @Test
     fun `test getInputsForTask does not emit directory globs for gitignored copy source dirs`() {
-      // A generated (gitignored) source dir exists only on a built tree; globbing it would make
-      // the graph differ between clean and built checkouts.
       val generatedDir = java.io.File("$workspaceRoot/dist/generated").apply { mkdirs() }
       java.io.File(generatedDir, "bundle.tar.gz").writeText("x")
       val copyTask =
@@ -539,14 +526,8 @@ class ProcessTaskUtilsTest {
 
     @Test
     fun `test getInputsForTask Copy task itself derives generated sources but not checked-in or FileTree`() {
-      // A Copy/Sync task, characterized as the CONSUMING task ITSELF, contributes the extensions of
-      // its declared concrete-file sources to its OWN inputs (taskOwnPatterns). Only GENERATED
-      // (gitignored) sources need a dependentTasksOutputFiles glob; checked-in sources are already
-      // captured as direct inputs, and FileTree/directory sources must never be enumerated.
-      // Extensions are derived without the files existing on disk. (As a DEPENDENCY the same Copy
-      // is
-      // characterized by its output directory via the "**/*" catch-all - see the deterministic and
-      // see-through tests.)
+      // Only generated (gitignored) sources glob; checked-in sources are direct inputs and
+      // FileTree contents are never enumerated.
       val syncTask =
           project.tasks.register("syncResources", org.gradle.api.tasks.Sync::class.java).get()
       // Generated (the fixture gitignores "dist") concrete file sources, intentionally NOT created.
@@ -569,8 +550,6 @@ class ProcessTaskUtilsTest {
               ?.mapNotNull { it["dependentTasksOutputFiles"] as? String }
               ?.toSet() ?: emptySet()
 
-      // Clean tree (generated files absent): generated concrete-file source extensions still
-      // derived.
       val clean = outputFileGlobs()
       // Built tree: create the generated source files on disk.
       java.io.File("$workspaceRoot/dist/bundle.tar.gz").writeText("x")
@@ -589,11 +568,7 @@ class ProcessTaskUtilsTest {
 
     @Test
     fun `test getInputsForTask Copy task itself unwraps provider and FileSystemLocation sources`() {
-      // Lazy provider / FileSystemLocation sources of the Copy task ITSELF must be unwrapped so
-      // their
-      // extensions are derived without the file existing on disk. Gitignore "build" and "dist" so
-      // the
-      // generated paths count as not-checked-in.
+      // Provider / FileSystemLocation sources unwrap without the file existing on disk.
       java.io.File(workspaceRoot, ".gitignore").writeText("dist\nbuild")
 
       val syncTask =
@@ -636,10 +611,6 @@ class ProcessTaskUtilsTest {
 
     @Test
     fun `test getInputsForTask Copy task itself derives its own from() source extensions`() {
-      // A Copy/Sync task characterized as the CONSUMING task (not as a dependency) must contribute
-      // its own declared concrete-file source extensions to its OWN inputs - the nx-api
-      // processResources case, where a task bundles a generated dist/*.tar.gz via from(File). The
-      // generated (gitignored) source is intentionally NOT created on disk.
       val syncTask =
           project.tasks.register("syncResources", org.gradle.api.tasks.Sync::class.java).get()
       syncTask.from(java.io.File("$workspaceRoot/dist/bundle.tar.gz"))

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
@@ -221,14 +221,17 @@ class ProcessTaskUtilsTest {
     }
 
     @Test
-    fun `test getInputsForTask characterizable dependencies yield specific globs deterministically`() {
-      // A dependent whose extension IS derivable from the task model (declared archive extension).
+    fun `test getInputsForTask characterizes deps by declared output deterministically`() {
+      // An archive dependent has a FILE output, so its extension is derivable (a precise glob).
       val jarProducer =
           project.tasks.register("jarProducer", org.gradle.api.tasks.bundling.Jar::class.java).get()
       jarProducer.archiveExtension.set("jar")
 
-      // A Copy dependent with a CONCRETE gitignored source: characterizable (yields gz), so it
-      // contributes a specific glob and never a catch-all.
+      // A Copy dependent has a DIRECTORY output. A consumer reads that whole output directory,
+      // whose
+      // contents the model cannot enumerate, so the dependency is characterized by the "**/*"
+      // catch-all rather than by its sources. Characterizing by sources would miss committed files
+      // that enter through a directory source (the nx-api application.conf case).
       val copyDep =
           project.tasks.register("copyBundled", org.gradle.api.tasks.Copy::class.java).get()
       copyDep.from(java.io.File("$workspaceRoot/dist/bundle.tar.gz"))
@@ -262,11 +265,14 @@ class ProcessTaskUtilsTest {
           built,
           "dependentTasksOutputFiles must not change between a clean and a built tree")
 
-      // Characterizable dependencies yield specific globs, never the catch-all.
+      // Archive (file output) -> precise extension. Copy (directory output) -> catch-all.
       assertTrue(clean.contains("**/*.jar"), "Expected jar from archiveExtension, got $clean")
-      assertTrue(clean.contains("**/*.gz"), "Expected gz from concrete Copy source, got $clean")
+      assertTrue(
+          clean.contains("**/*"),
+          "Expected the catch-all for a Copy dependency's directory output, got $clean")
       assertFalse(
-          clean.contains("**/*"), "Characterizable deps must not trigger the catch-all, got $clean")
+          clean.contains("**/*.gz"),
+          "A Copy dependency is characterized by its output, not its sources, got $clean")
     }
 
     @Test
@@ -361,12 +367,15 @@ class ProcessTaskUtilsTest {
     }
 
     @Test
-    fun `test getInputsForTask derives generated Copy sources but not checked-in or FileTree ones`() {
-      // A Copy/Sync task is pass-through: its declared concrete-file sources (from(File ...)) equal
-      // its effective outputs. Only GENERATED (gitignored) sources need a dependentTasksOutputFiles
-      // glob; checked-in sources are already captured as direct inputs, and FileTree/directory
-      // sources must never be enumerated. Extensions are derived without the files existing on
-      // disk.
+    fun `test getInputsForTask Copy task itself derives generated sources but not checked-in or FileTree`() {
+      // A Copy/Sync task, characterized as the CONSUMING task ITSELF, contributes the extensions of
+      // its declared concrete-file sources to its OWN inputs (taskOwnPatterns). Only GENERATED
+      // (gitignored) sources need a dependentTasksOutputFiles glob; checked-in sources are already
+      // captured as direct inputs, and FileTree/directory sources must never be enumerated.
+      // Extensions are derived without the files existing on disk. (As a DEPENDENCY the same Copy
+      // is
+      // characterized by its output directory via the "**/*" catch-all - see the deterministic and
+      // see-through tests.)
       val syncTask =
           project.tasks.register("syncResources", org.gradle.api.tasks.Sync::class.java).get()
       // Generated (the fixture gitignores "dist") concrete file sources, intentionally NOT created.
@@ -380,19 +389,11 @@ class ProcessTaskUtilsTest {
       syncTask.from(project.fileTree(leakDir))
       syncTask.into(java.io.File("$workspaceRoot/build/sync-output"))
 
-      val consumerTask = project.tasks.register("consumerSync").get()
-      consumerTask.dependsOn(syncTask)
-
       val gitIgnoreClassifier = GitIgnoreClassifier(java.io.File(workspaceRoot))
 
       fun outputFileGlobs(): Set<String> =
           getInputsForTask(
-                  null,
-                  consumerTask,
-                  projectRoot,
-                  workspaceRoot,
-                  mutableMapOf(),
-                  gitIgnoreClassifier)
+                  null, syncTask, projectRoot, workspaceRoot, mutableMapOf(), gitIgnoreClassifier)
               ?.filterIsInstance<Map<*, *>>()
               ?.mapNotNull { it["dependentTasksOutputFiles"] as? String }
               ?.toSet() ?: emptySet()
@@ -416,12 +417,12 @@ class ProcessTaskUtilsTest {
     }
 
     @Test
-    fun `test getInputsForTask unwraps provider and FileSystemLocation Copy sources on clean tree`() {
-      // Lazy provider / FileSystemLocation sources must be unwrapped so their extensions are
-      // derived
-      // without the file existing on disk. Gitignore "build" and "dist" so the generated paths
-      // count
-      // as not-checked-in.
+    fun `test getInputsForTask Copy task itself unwraps provider and FileSystemLocation sources`() {
+      // Lazy provider / FileSystemLocation sources of the Copy task ITSELF must be unwrapped so
+      // their
+      // extensions are derived without the file existing on disk. Gitignore "build" and "dist" so
+      // the
+      // generated paths count as not-checked-in.
       java.io.File(workspaceRoot, ".gitignore").writeText("dist\nbuild")
 
       val syncTask =
@@ -435,19 +436,11 @@ class ProcessTaskUtilsTest {
       syncTask.from(project.provider { java.io.File("$workspaceRoot/src/main/resources/app.conf") })
       syncTask.into(java.io.File("$workspaceRoot/build/sync-output"))
 
-      val consumerTask = project.tasks.register("consumerSync").get()
-      consumerTask.dependsOn(syncTask)
-
       val gitIgnoreClassifier = GitIgnoreClassifier(java.io.File(workspaceRoot))
 
       fun outputFileGlobs(): Set<String> =
           getInputsForTask(
-                  null,
-                  consumerTask,
-                  projectRoot,
-                  workspaceRoot,
-                  mutableMapOf(),
-                  gitIgnoreClassifier)
+                  null, syncTask, projectRoot, workspaceRoot, mutableMapOf(), gitIgnoreClassifier)
               ?.filterIsInstance<Map<*, *>>()
               ?.mapNotNull { it["dependentTasksOutputFiles"] as? String }
               ?.toSet() ?: emptySet()
@@ -505,12 +498,19 @@ class ProcessTaskUtilsTest {
     }
 
     @Test
-    fun `test getInputsForTask jar sees processResources sources through the classes lifecycle task`() {
+    fun `test getInputsForTask jar sees processResources output through the classes lifecycle task`() {
       // Ocean nx-api scenario: the Java plugin wires jar -> classes -> {compileJava,
-      // processResources}.
-      // processResources is a Copy that bundles generated dist/ archives. jar reaches it only
-      // transitively through the opaque `classes` lifecycle task, so the dependency traversal must
-      // see through `classes` to surface processResources' **/*.gz and **/*.json patterns on jar.
+      // processResources}. processResources is a Copy that bundles generated dist/ archives AND
+      // copies committed resources from src/main/resources. jar reaches it only transitively
+      // through
+      // the opaque `classes` lifecycle task, so the traversal must see through `classes`.
+      //
+      // Regression: jar must watch processResources' OUTPUT directory via "**/*", which covers
+      // every
+      // file the copy emits - the generated bundles AND the committed application.conf. Deriving
+      // from
+      // the copy's sources gave jar only {**/*.gz, **/*.json} and silently missed the committed
+      // resource, so editing application.conf would not invalidate the cached jar.
       project.plugins.apply("java")
 
       val processResources =
@@ -519,6 +519,12 @@ class ProcessTaskUtilsTest {
           java.io.File("$workspaceRoot/dist/libs/polygraph/cli/bundle/polygraph-bundle.tar.gz"))
       processResources.from(
           java.io.File("$workspaceRoot/dist/libs/polygraph/cli/bundle/polygraph-runner.json"))
+      // A committed resource copied through a directory source (checked in, so it never surfaces as
+      // a
+      // derived source extension - only the "**/*" catch-all covers it).
+      val resourcesDir = java.io.File("$workspaceRoot/src/main/resources").apply { mkdirs() }
+      java.io.File(resourcesDir, "application.conf").writeText("key = value")
+      processResources.from(resourcesDir)
       // The generated bundles are intentionally NOT created on disk (clean tree).
 
       val jar = project.tasks.getByName("jar")
@@ -536,8 +542,12 @@ class ProcessTaskUtilsTest {
       val hasPattern = { p: String ->
         result!!.any { it is Map<*, *> && it["dependentTasksOutputFiles"] == p }
       }
-      assertTrue(hasPattern("**/*.gz"), "jar must see processResources' **/*.gz, got $result")
-      assertTrue(hasPattern("**/*.json"), "jar must see processResources' **/*.json, got $result")
+      // The catch-all covers processResources' whole output directory: the generated bundles AND
+      // the
+      // committed application.conf. This is the fix for the missed-committed-resource regression.
+      assertTrue(
+          hasPattern("**/*"),
+          "jar must watch processResources' output directory via the catch-all, got $result")
       assertTrue(hasPattern("**/*.class"), "jar must see compileJava's **/*.class, got $result")
     }
 

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
@@ -326,6 +326,61 @@ class ProcessTaskUtilsTest {
     }
 
     @Test
+    fun `test getInputsForTask unwraps provider and FileSystemLocation Copy sources on clean tree`() {
+      // Lazy provider / FileSystemLocation sources must be unwrapped so their extensions are
+      // derived
+      // without the file existing on disk. Gitignore "build" and "dist" so the generated paths
+      // count
+      // as not-checked-in.
+      java.io.File(workspaceRoot, ".gitignore").writeText("dist\nbuild")
+
+      val syncTask =
+          project.tasks.register("syncResources", org.gradle.api.tasks.Sync::class.java).get()
+      // Provider<RegularFile>: layout.buildDirectory.file(...) -> build/... (gitignored), NOT
+      // created.
+      syncTask.from(project.layout.buildDirectory.file("generated/foo.json"))
+      // Bare FileSystemLocation (RegularFile) under dist/ (gitignored).
+      syncTask.from(project.layout.projectDirectory.file("dist/bar.xml"))
+      // Checked-in provider source (NOT gitignored) - the gate must still skip it.
+      syncTask.from(project.provider { java.io.File("$workspaceRoot/src/main/resources/app.conf") })
+      syncTask.into(java.io.File("$workspaceRoot/build/sync-output"))
+
+      val consumerTask = project.tasks.register("consumerSync").get()
+      consumerTask.dependsOn(syncTask)
+
+      val gitIgnoreClassifier = GitIgnoreClassifier(java.io.File(workspaceRoot))
+
+      fun outputFileGlobs(): Set<String> =
+          getInputsForTask(
+                  null,
+                  consumerTask,
+                  projectRoot,
+                  workspaceRoot,
+                  mutableMapOf(),
+                  gitIgnoreClassifier)
+              ?.filterIsInstance<Map<*, *>>()
+              ?.mapNotNull { it["dependentTasksOutputFiles"] as? String }
+              ?.toSet() ?: emptySet()
+
+      // Clean tree: none of the provider targets exist on disk yet.
+      val clean = outputFileGlobs()
+      // Built tree: materialize the generated provider target.
+      java.io.File("$workspaceRoot/build/generated").mkdirs()
+      java.io.File("$workspaceRoot/build/generated/foo.json").writeText("{}")
+      val built = outputFileGlobs()
+
+      assertEquals(clean, built, "Provider source derivation must not depend on on-disk state")
+      assertTrue(
+          clean.contains("**/*.json"),
+          "Expected json from from(layout.buildDirectory.file(...)) on a clean tree, got $clean")
+      assertTrue(
+          clean.contains("**/*.xml"), "Expected xml from a FileSystemLocation source, got $clean")
+      assertFalse(
+          clean.contains("**/*.conf"),
+          "Checked-in provider source must not produce a glob, got $clean")
+    }
+
+    @Test
     fun `test getInputsForTask uses archiveExtension for Jar, not source extensions`() {
       // Create a Jar task with source files
       val sourceDir = java.io.File("$workspaceRoot/src/main/java").apply { mkdirs() }

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
@@ -221,17 +221,13 @@ class ProcessTaskUtilsTest {
     }
 
     @Test
-    fun `test getInputsForTask characterizes deps by declared output deterministically`() {
-      // An archive dependent has a FILE output, so its extension is derivable (a precise glob).
+    fun `test getInputsForTask collapses to the catch-all when a dependency declares a directory output`() {
+      // Archive dep -> precise "**/*.jar"; Copy dep -> "**/*" catch-all. When both are present the
+      // catch-all subsumes the archive glob, so the set collapses to "**/*".
       val jarProducer =
           project.tasks.register("jarProducer", org.gradle.api.tasks.bundling.Jar::class.java).get()
       jarProducer.archiveExtension.set("jar")
 
-      // A Copy dependent has a DIRECTORY output. A consumer reads that whole output directory,
-      // whose
-      // contents the model cannot enumerate, so the dependency is characterized by the "**/*"
-      // catch-all rather than by its sources. Characterizing by sources would miss committed files
-      // that enter through a directory source (the nx-api application.conf case).
       val copyDep =
           project.tasks.register("copyBundled", org.gradle.api.tasks.Copy::class.java).get()
       copyDep.from(java.io.File("$workspaceRoot/dist/bundle.tar.gz"))
@@ -265,14 +261,40 @@ class ProcessTaskUtilsTest {
           built,
           "dependentTasksOutputFiles must not change between a clean and a built tree")
 
-      // Archive (file output) -> precise extension. Copy (directory output) -> catch-all.
-      assertTrue(clean.contains("**/*.jar"), "Expected jar from archiveExtension, got $clean")
+      // The catch-all is the only emitted pattern; the archive's precise glob and the copy's source
+      // extension are both subsumed.
+      assertEquals(
+          setOf("**/*"),
+          clean,
+          "The catch-all must subsume the specific globs (jar, gz), got $clean")
+    }
+
+    @Test
+    fun `test getInputsForTask archive dependency yields its precise extension without the catch-all`() {
+      // An archive dependency alone (no directory-output dependency) is characterized by its
+      // declared
+      // archive extension: a precise glob, never the catch-all.
+      val jarProducer =
+          project.tasks.register("jarProducer", org.gradle.api.tasks.bundling.Jar::class.java).get()
+      jarProducer.archiveExtension.set("jar")
+
+      val consumer = project.tasks.register("consumerArchiveOnly").get()
+      consumer.dependsOn(jarProducer)
+
+      val gitIgnoreClassifier = GitIgnoreClassifier(java.io.File(workspaceRoot))
+      val globs =
+          getInputsForTask(
+                  null, consumer, projectRoot, workspaceRoot, mutableMapOf(), gitIgnoreClassifier)
+              ?.filterIsInstance<Map<*, *>>()
+              ?.mapNotNull { it["dependentTasksOutputFiles"] as? String }
+              ?.toSet() ?: emptySet()
+
       assertTrue(
-          clean.contains("**/*"),
-          "Expected the catch-all for a Copy dependency's directory output, got $clean")
+          globs.contains("**/*.jar"),
+          "Expected the precise jar glob from archiveExtension, got $globs")
       assertFalse(
-          clean.contains("**/*.gz"),
-          "A Copy dependency is characterized by its output, not its sources, got $clean")
+          globs.contains("**/*"),
+          "An archive-only dependency must not trigger the catch-all, got $globs")
     }
 
     @Test
@@ -529,18 +551,12 @@ class ProcessTaskUtilsTest {
 
     @Test
     fun `test getInputsForTask jar sees processResources output through the classes lifecycle task`() {
-      // Ocean nx-api scenario: the Java plugin wires jar -> classes -> {compileJava,
-      // processResources}. processResources is a Copy that bundles generated dist/ archives AND
-      // copies committed resources from src/main/resources. jar reaches it only transitively
-      // through
-      // the opaque `classes` lifecycle task, so the traversal must see through `classes`.
-      //
-      // Regression: jar must watch processResources' OUTPUT directory via "**/*", which covers
-      // every
-      // file the copy emits - the generated bundles AND the committed application.conf. Deriving
-      // from
-      // the copy's sources gave jar only {**/*.gz, **/*.json} and silently missed the committed
-      // resource, so editing application.conf would not invalidate the cached jar.
+      // Ocean nx-api: jar -> classes -> {compileJava, processResources}, where processResources is
+      // a
+      // Copy bundling generated dist/ archives AND copying committed src/main/resources.
+      // Regression:
+      // jar must watch processResources' OUTPUT via "**/*" (covering committed application.conf);
+      // deriving from the copy's sources gave only {gz, json} and silently staled the jar.
       project.plugins.apply("java")
 
       val processResources =
@@ -549,9 +565,8 @@ class ProcessTaskUtilsTest {
           java.io.File("$workspaceRoot/dist/libs/polygraph/cli/bundle/polygraph-bundle.tar.gz"))
       processResources.from(
           java.io.File("$workspaceRoot/dist/libs/polygraph/cli/bundle/polygraph-runner.json"))
-      // A committed resource copied through a directory source (checked in, so it never surfaces as
-      // a
-      // derived source extension - only the "**/*" catch-all covers it).
+      // A committed resource copied through a directory source (only the "**/*" catch-all covers
+      // it).
       val resourcesDir = java.io.File("$workspaceRoot/src/main/resources").apply { mkdirs() }
       java.io.File(resourcesDir, "application.conf").writeText("key = value")
       processResources.from(resourcesDir)
@@ -578,7 +593,9 @@ class ProcessTaskUtilsTest {
       assertTrue(
           hasPattern("**/*"),
           "jar must watch processResources' output directory via the catch-all, got $result")
-      assertTrue(hasPattern("**/*.class"), "jar must see compileJava's **/*.class, got $result")
+      assertFalse(
+          hasPattern("**/*.class"),
+          "the catch-all subsumes compileJava's **/*.class on jar, got $result")
     }
 
     @Test

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
@@ -419,6 +419,125 @@ class ProcessTaskUtilsTest {
     }
 
     @Test
+    fun `test getInputsForTask emits a directory glob for a committed Copy source dir`() {
+      // A glob keeps files added AFTER graph computation covered; a per-file listing would not.
+      val resourcesDir = java.io.File("$workspaceRoot/src/main/resources").apply { mkdirs() }
+      java.io.File(resourcesDir, "application.conf").writeText("key = value")
+      val copyTask =
+          project.tasks.register("copyResources", org.gradle.api.tasks.Copy::class.java).get()
+      copyTask.from(resourcesDir)
+      copyTask.into(java.io.File("$workspaceRoot/build/out"))
+
+      val gitIgnoreClassifier = GitIgnoreClassifier(java.io.File(workspaceRoot))
+      val result =
+          getInputsForTask(
+              null, copyTask, projectRoot, workspaceRoot, mutableMapOf(), gitIgnoreClassifier)!!
+
+      val dirGlob = Path("{projectRoot}", "src", "main", "resources").toString() + "/**/*"
+      assertTrue(result.contains(dirGlob), "Expected directory glob $dirGlob, got $result")
+      assertFalse(
+          result.contains(
+              Path("{projectRoot}", "src", "main", "resources", "application.conf").toString()),
+          "Files under a globbed source dir must not be enumerated, got $result")
+    }
+
+    @Test
+    fun `test getInputsForTask emits a directory glob for the processResources source dir`() {
+      // The idiomatic wiring: processResources copies from the main SourceDirectorySet.
+      project.plugins.apply("java")
+      val resourcesDir = java.io.File("$workspaceRoot/src/main/resources").apply { mkdirs() }
+      java.io.File(resourcesDir, "application.conf").writeText("key = value")
+
+      val processResources = project.tasks.getByName("processResources")
+      val gitIgnoreClassifier = GitIgnoreClassifier(java.io.File(workspaceRoot))
+      val result =
+          getInputsForTask(
+              null,
+              processResources,
+              projectRoot,
+              workspaceRoot,
+              mutableMapOf(),
+              gitIgnoreClassifier)!!
+
+      val dirGlob = Path("{projectRoot}", "src", "main", "resources").toString() + "/**/*"
+      assertTrue(result.contains(dirGlob), "Expected directory glob $dirGlob, got $result")
+      assertFalse(
+          result.contains(
+              Path("{projectRoot}", "src", "main", "resources", "application.conf").toString()),
+          "Resource files under a globbed source dir must not be enumerated, got $result")
+    }
+
+    @Test
+    fun `test getInputsForTask does not emit directory globs for gitignored copy source dirs`() {
+      // A generated (gitignored) source dir exists only on a built tree; globbing it would make
+      // the graph differ between clean and built checkouts.
+      val generatedDir = java.io.File("$workspaceRoot/dist/generated").apply { mkdirs() }
+      java.io.File(generatedDir, "bundle.tar.gz").writeText("x")
+      val copyTask =
+          project.tasks.register("copyGenerated", org.gradle.api.tasks.Copy::class.java).get()
+      copyTask.from(generatedDir)
+      copyTask.into(java.io.File("$workspaceRoot/build/out"))
+
+      val gitIgnoreClassifier = GitIgnoreClassifier(java.io.File(workspaceRoot))
+      val result =
+          getInputsForTask(
+              null, copyTask, projectRoot, workspaceRoot, mutableMapOf(), gitIgnoreClassifier)
+              ?: emptyList()
+
+      assertFalse(
+          result.filterIsInstance<String>().any { it.contains("generated") },
+          "Gitignored copy source dirs must not become globs or direct inputs, got $result")
+    }
+
+    @Test
+    fun `test getInputsForTask collapses source-set files into a source root glob`() {
+      project.plugins.apply("java")
+      val srcDir = java.io.File("$workspaceRoot/src/main/java").apply { mkdirs() }
+      java.io.File(srcDir, "Foo.java").writeText("class Foo {}")
+      java.io.File(srcDir, "Bar.java").writeText("class Bar {}")
+
+      val compileJava = project.tasks.getByName("compileJava")
+      val gitIgnoreClassifier = GitIgnoreClassifier(java.io.File(workspaceRoot))
+      val result =
+          getInputsForTask(
+              null, compileJava, projectRoot, workspaceRoot, mutableMapOf(), gitIgnoreClassifier)!!
+
+      val rootGlob = Path("{projectRoot}", "src", "main", "java").toString() + "/**/*"
+      assertTrue(result.contains(rootGlob), "Expected source root glob $rootGlob, got $result")
+      assertFalse(
+          result.contains(Path("{projectRoot}", "src", "main", "java", "Foo.java").toString()),
+          "Source files under a globbed root must not be enumerated, got $result")
+    }
+
+    @Test
+    fun `test getInputsForTask keeps main and test source root globs disjoint`() {
+      project.plugins.apply("java")
+      val mainDir = java.io.File("$workspaceRoot/src/main/java").apply { mkdirs() }
+      java.io.File(mainDir, "Foo.java").writeText("class Foo {}")
+      val testDir = java.io.File("$workspaceRoot/src/test/java").apply { mkdirs() }
+      java.io.File(testDir, "FooTest.java").writeText("class FooTest {}")
+
+      val gitIgnoreClassifier = GitIgnoreClassifier(java.io.File(workspaceRoot))
+      fun globsOf(taskName: String): List<String> =
+          getInputsForTask(
+                  null,
+                  project.tasks.getByName(taskName),
+                  projectRoot,
+                  workspaceRoot,
+                  mutableMapOf(),
+                  gitIgnoreClassifier)
+              ?.filterIsInstance<String>()
+              ?.filter { it.endsWith("/**/*") } ?: emptyList()
+
+      val mainGlob = Path("{projectRoot}", "src", "main", "java").toString() + "/**/*"
+      val testGlob = Path("{projectRoot}", "src", "test", "java").toString() + "/**/*"
+      assertTrue(globsOf("compileJava").contains(mainGlob))
+      assertFalse(globsOf("compileJava").contains(testGlob))
+      assertTrue(globsOf("compileTestJava").contains(testGlob))
+      assertFalse(globsOf("compileTestJava").contains(mainGlob))
+    }
+
+    @Test
     fun `test getInputsForTask Copy task itself derives generated sources but not checked-in or FileTree`() {
       // A Copy/Sync task, characterized as the CONSUMING task ITSELF, contributes the extensions of
       // its declared concrete-file sources to its OWN inputs (taskOwnPatterns). Only GENERATED

--- a/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
+++ b/packages/gradle/project-graph/src/test/kotlin/dev/nx/gradle/utils/ProcessTaskUtilsTest.kt
@@ -227,8 +227,8 @@ class ProcessTaskUtilsTest {
           project.tasks.register("jarProducer", org.gradle.api.tasks.bundling.Jar::class.java).get()
       jarProducer.archiveExtension.set("jar")
 
-      // A Copy dependent whose SOURCE extensions must NOT leak into the derivation: their presence
-      // on disk depends on transient build state.
+      // A Copy dependent with a DIRECTORY source: its contents must NOT be enumerated (only
+      // declared concrete-file sources are read), so nothing on disk under it can leak in.
       val sourceDir = java.io.File("$workspaceRoot/src/bundled")
       val copyDep =
           project.tasks.register("copyBundled", org.gradle.api.tasks.Copy::class.java).get()
@@ -271,35 +271,51 @@ class ProcessTaskUtilsTest {
     }
 
     @Test
-    fun `test getInputsForTask does not derive extensions from Copy or Sync source files`() {
-      // Regression guard: Copy/Sync SOURCE file extensions must not drive dependentTasksOutputFiles
-      // globs. Their presence on disk depends on transient build state, and a Sync/Copy task
-      // declares only a destination DIRECTORY output (no per-extension info) in the task model.
-      val sourceDir = java.io.File("$workspaceRoot/src/sync-input").apply { mkdirs() }
-      java.io.File(sourceDir, "config.conf").writeText("test config")
-      java.io.File(sourceDir, "data.json").writeText("{}")
-
+    fun `test getInputsForTask derives Copy concrete-file sources but not FileTree sources`() {
+      // A Copy/Sync task is pass-through: its declared concrete-file sources (from(File ...)) equal
+      // its effective outputs and ARE derived, deterministically, even when the files do not exist
+      // on disk. FileTree / directory sources must NOT be enumerated.
       val syncTask =
           project.tasks.register("syncResources", org.gradle.api.tasks.Sync::class.java).get()
-      syncTask.from(sourceDir)
+      // Concrete declared file sources (intentionally NOT created on disk yet).
+      syncTask.from(java.io.File("$workspaceRoot/dist/bundle.tar.gz"))
+      syncTask.from(java.io.File("$workspaceRoot/dist/runner.json"))
+      // A FileTree source whose contents must never be enumerated.
+      val leakDir = java.io.File("$workspaceRoot/dist/leak").apply { mkdirs() }
+      java.io.File(leakDir, "secret.leak").writeText("x")
+      syncTask.from(project.fileTree(leakDir))
       syncTask.into(java.io.File("$workspaceRoot/build/sync-output"))
 
       val consumerTask = project.tasks.register("consumerSync").get()
       consumerTask.dependsOn(syncTask)
 
       val gitIgnoreClassifier = GitIgnoreClassifier(java.io.File(workspaceRoot))
-      val result =
-          getInputsForTask(
-              null, consumerTask, projectRoot, workspaceRoot, mutableMapOf(), gitIgnoreClassifier)
 
-      val globs =
-          result
+      fun outputFileGlobs(): Set<String> =
+          getInputsForTask(
+                  null,
+                  consumerTask,
+                  projectRoot,
+                  workspaceRoot,
+                  mutableMapOf(),
+                  gitIgnoreClassifier)
               ?.filterIsInstance<Map<*, *>>()
               ?.mapNotNull { it["dependentTasksOutputFiles"] as? String }
               ?.toSet() ?: emptySet()
 
-      assertFalse(globs.contains("**/*.conf"), "Sync source .conf must not leak, got $globs")
-      assertFalse(globs.contains("**/*.json"), "Sync source .json must not leak, got $globs")
+      // Clean tree (bundle/runner files absent): concrete-file source extensions still derived.
+      val clean = outputFileGlobs()
+      // Built tree: create the concrete source files on disk.
+      java.io.File("$workspaceRoot/dist/bundle.tar.gz").writeText("x")
+      java.io.File("$workspaceRoot/dist/runner.json").writeText("{}")
+      val built = outputFileGlobs()
+
+      assertEquals(clean, built, "Copy source derivation must not depend on on-disk state")
+      assertTrue(clean.contains("**/*.gz"), "Expected gz from from(File .tar.gz), got $clean")
+      assertTrue(clean.contains("**/*.json"), "Expected json from from(File .json), got $clean")
+      assertFalse(
+          clean.contains("**/*.leak"),
+          "FileTree source contents must not be enumerated, got $clean")
     }
 
     @Test


### PR DESCRIPTION
## Current Behavior

The `@nx/gradle` project-graph plugin derives each task's `dependentTasksOutputFiles` extension globs by scanning the working tree:
- resolved dependent `outputs.files.files` (a `FileCollection` only contains files that exist),
- gitignore-classified `task.inputs.files` (extension harvest),
- Copy/Sync source scan gated by `f.isFile` (existence check).

These sources only observe files that exist on disk, so two checkouts of the same commit can produce different task graphs depending on transient build state. A clean checkout misses `.class`, `.jar`, `.kotlin_module`, `.gz`, `.json` and other build artifacts that exist in a built tree, which under-invalidates consuming tasks.

## Root Cause

The extension derivation is not a pure function of the committed code — it depends on the transient presence of build outputs on disk. The task-graph hash must be independent of build state, so this is a soundness bug (observed as two ocean worktrees producing different `:nx-api:gradle:jar` inputs at the same commit).

## Change

Derive the extension set purely from the Gradle task **model** — task types and declared outputs — never from the working tree:

- **`extensionsForTaskType(task)`** — task class → extensions: Test → `{class, jar}`, Kotlin compile → `{class, kotlin_module}`, `AbstractCompile`/Java → `{class}`.
- **`declaredArchiveExtensions(task)`** — `AbstractArchiveTask.archiveExtension` + `Tar` compression suffix (`gz`/`bz2`).
- **`declaredFileOutputExtensions(task)`** — declared **FILE** outputs only (DIRECTORY outputs declare no inner extensions; their on-disk contents are transient).

Removed:
- on-disk scans (`outputs.files.files.forEach`, gitignore-harvested extensions),
- the `f.isFile` existence gate in the Copy/Sync source scan,
- dead helpers `isFileInWorkspace`, `isAgpCopyLikeTask` (only fed the removed disk scan).

The gitignore check is **kept** solely to stop build artifacts being added as direct source inputs; it no longer harvests extensions. No sorting is introduced (out of scope).

## Determinism guarantee

Added regression test `test getInputsForTask dependent output extensions are deterministic across trees`: builds a dependent task with a declared archive (Jar) + a Copy task, evaluates `dependentTasksOutputFiles` on a **clean** tree, then populates the tree with transient build outputs, and asserts the globs are **identical**. It also asserts Copy source extensions (`tar.gz`, `json`) do **not** leak.

Full suite: **84 tests pass** (19 suites, 0 failures). `./gradlew :gradle-project-graph:check` is green (compile + test + ktfmt + validatePlugins).

## Risk & fallback

**Under-invalidation for undeclared producers:** if a producer task does not declare its output (e.g. an `Exec` task with no `outputs.file(...)`), the plugin can't derive its extension from the model, so a consumer may not invalidate when that artifact changes.

- **Recommended:** declare FILE outputs on such tasks and use `from(task)` delegation in consumers (Copy/`processResources`) instead of literal `from(File)` paths.
- **Conservative fallback (out of scope here, possible follow-up):** a directory catch-all glob for dependents whose only declared output is a directory.

_Note on Gradle 8.14.3: `TaskOutputsInternal` does not expose `fileProperties` in this version; the impl class `DefaultTaskOutputs` is used instead._

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Ocean-and-Nx-06083f9d)
<!-- polygraph-session-end -->