### PR TITLE
fix(core): set NX_CLI_SET in batch worker processes

### DIFF
--- a/packages/nx/src/tasks-runner/batch/run-batch.ts
+++ b/packages/nx/src/tasks-runner/batch/run-batch.ts
@@ -19,6 +19,10 @@ import {
 import { ProjectConfiguration } from '../../config/workspace-json-project-json';
 import { ProjectGraph } from '../../config/project-graph';
 
+// Batch workers are inside an Nx run just like task workers (see
+// bin/run-executor.ts) — mark it so nested tooling can detect Nx.
+process.env.NX_CLI_SET = 'true';
+
 function getBatchExecutor(
   executorName: string,
   projects: Record<string, ProjectConfiguration>


### PR DESCRIPTION
## Current Behavior

`bin/run-executor.ts` marks per-task worker processes with `NX_CLI_SET=true` so nested tooling can detect it is running inside an Nx invocation. Batch worker processes (`tasks-runner/batch/run-batch.ts`) do not set it. When the orchestrator is embedded rather than started via the nx CLI (e.g. Nx Cloud agents calling `runDiscreteTasks()` programmatically), processes spawned by batch executors — such as `gradlew` and anything it shells out to — see no `NX_CLI_SET`, so they cannot tell they are inside an Nx run.

## Expected Behavior

Batch workers self-identify exactly like task workers: `run-batch.ts` sets `NX_CLI_SET=true` at module scope, mirroring `bin/run-executor.ts`. Every process descending from a batch worker can detect Nx regardless of how the orchestrator was started.

## Related Issue(s)

Surfaced while making gradle builds detect nx-driven execution (companion to #36210).