### PR TITLE
fix(core): re-spawn nx migrate without a shell to preserve argv exactly

### DIFF
--- a/e2e/nx/src/misc.test.ts
+++ b/e2e/nx/src/misc.test.ts
@@ -996,34 +996,32 @@ describe('migrate', () => {
   });
 
   it('should run migrations and create individual git commits using a provided custom commit prefix', () => {
-    // Windows has shell escaping issues so this test would always fail
-    if (isNotWindows()) {
-      runCLI(
-        'migrate migrate-parent-package@2.0.0 --from="migrate-parent-package@1.0.0"',
-        {
-          env: {
-            NX_MIGRATE_SKIP_INSTALL: 'true',
-            NX_MIGRATE_USE_LOCAL: 'true',
-          },
-        }
-      );
+    runCLI(
+      'migrate migrate-parent-package@2.0.0 --from="migrate-parent-package@1.0.0"',
+      {
+        env: {
+          NX_MIGRATE_SKIP_INSTALL: 'true',
+          NX_MIGRATE_USE_LOCAL: 'true',
+        },
+      }
+    );
 
-      // the prefix contains spaces and parens, which the re-spawn must quote to survive the shell
-      runCLI(
-        `migrate --run-migrations=migrations.json --create-commits --commit-prefix="chore(core): AUTOMATED - "`,
-        {
-          env: {
-            NX_MIGRATE_SKIP_INSTALL: 'true',
-            NX_MIGRATE_USE_LOCAL: 'true',
-          },
-        }
-      );
+    // the prefix contains spaces and parens, which the re-spawn must pass
+    // through as a single argument on every platform
+    runCLI(
+      `migrate --run-migrations=migrations.json --create-commits --commit-prefix="chore(core): AUTOMATED - "`,
+      {
+        env: {
+          NX_MIGRATE_SKIP_INSTALL: 'true',
+          NX_MIGRATE_USE_LOCAL: 'true',
+        },
+      }
+    );
 
-      const recentCommits = runCommand('git --no-pager log --oneline -n 10');
+    const recentCommits = runCommand('git --no-pager log --oneline -n 10');
 
-      expect(recentCommits).toContain('chore(core): AUTOMATED - run11');
-      expect(recentCommits).toContain('chore(core): AUTOMATED - run20');
-    }
+    expect(recentCommits).toContain('chore(core): AUTOMATED - run11');
+    expect(recentCommits).toContain('chore(core): AUTOMATED - run20');
   });
 
   it('should fail if a custom commit prefix is provided when --create-commits is not enabled', () => {

--- a/e2e/nx/src/misc.test.ts
+++ b/e2e/nx/src/misc.test.ts
@@ -1008,9 +1008,9 @@ describe('migrate', () => {
         }
       );
 
-      // runs migrations with createCommits enabled and custom commit-prefix (NOTE: the extra quotes are needed here to avoid shell escaping issues)
+      // the prefix contains spaces and parens, which the re-spawn must quote to survive the shell
       runCLI(
-        `migrate --run-migrations=migrations.json --create-commits --commit-prefix="'chore(core): AUTOMATED - '"`,
+        `migrate --run-migrations=migrations.json --create-commits --commit-prefix="chore(core): AUTOMATED - "`,
         {
           env: {
             NX_MIGRATE_SKIP_INSTALL: 'true',

--- a/e2e/nx/src/misc.test.ts
+++ b/e2e/nx/src/misc.test.ts
@@ -997,34 +997,32 @@ describe('migrate', () => {
   });
 
   it('should run migrations and create individual git commits using a provided custom commit prefix', () => {
-    // Windows has shell escaping issues so this test would always fail
-    if (isNotWindows()) {
-      runCLI(
-        'migrate migrate-parent-package@2.0.0 --from="migrate-parent-package@1.0.0"',
-        {
-          env: {
-            NX_MIGRATE_SKIP_INSTALL: 'true',
-            NX_MIGRATE_USE_LOCAL: 'true',
-          },
-        }
-      );
+    runCLI(
+      'migrate migrate-parent-package@2.0.0 --from="migrate-parent-package@1.0.0"',
+      {
+        env: {
+          NX_MIGRATE_SKIP_INSTALL: 'true',
+          NX_MIGRATE_USE_LOCAL: 'true',
+        },
+      }
+    );
 
-      // runs migrations with createCommits enabled and custom commit-prefix (NOTE: the extra quotes are needed here to avoid shell escaping issues)
-      runCLI(
-        `migrate --run-migrations=migrations.json --create-commits --commit-prefix="'chore(core): AUTOMATED - '"`,
-        {
-          env: {
-            NX_MIGRATE_SKIP_INSTALL: 'true',
-            NX_MIGRATE_USE_LOCAL: 'true',
-          },
-        }
-      );
+    // the prefix contains spaces and parens, which the re-spawn must pass
+    // through as a single argument on every platform
+    runCLI(
+      `migrate --run-migrations=migrations.json --create-commits --commit-prefix="chore(core): AUTOMATED - "`,
+      {
+        env: {
+          NX_MIGRATE_SKIP_INSTALL: 'true',
+          NX_MIGRATE_USE_LOCAL: 'true',
+        },
+      }
+    );
 
-      const recentCommits = runCommand('git --no-pager log --oneline -n 10');
+    const recentCommits = runCommand('git --no-pager log --oneline -n 10');
 
-      expect(recentCommits).toContain('chore(core): AUTOMATED - run11');
-      expect(recentCommits).toContain('chore(core): AUTOMATED - run20');
-    }
+    expect(recentCommits).toContain('chore(core): AUTOMATED - run11');
+    expect(recentCommits).toContain('chore(core): AUTOMATED - run20');
   });
 
   it('should run a single migration with --run-migration without recording run state', () => {

--- a/e2e/nx/src/misc.test.ts
+++ b/e2e/nx/src/misc.test.ts
@@ -1007,8 +1007,6 @@ describe('migrate', () => {
       }
     );
 
-    // the prefix contains spaces and parens, which the re-spawn must pass
-    // through as a single argument on every platform
     runCLI(
       `migrate --run-migrations=migrations.json --create-commits --commit-prefix="chore(core): AUTOMATED - "`,
       {

--- a/packages/nx/src/command-line/migrate/migrate-guard-wiring.spec.ts
+++ b/packages/nx/src/command-line/migrate/migrate-guard-wiring.spec.ts
@@ -19,10 +19,14 @@ jest.mock('../../utils/provenance', () => ({
     mockEnsurePackageHasProvenance(...args),
 }));
 
+// Both spawn helpers are mocked: the hand-off calls runNxArgvSync, and leaving
+// runNxSync live would let its fallback path spawn a real nx.
 const mockRunNxSync = jest.fn();
+const mockRunNxArgvSync = jest.fn();
 jest.mock('../../utils/child-process', () => ({
   ...jest.requireActual('../../utils/child-process'),
   runNxSync: (...args: unknown[]) => mockRunNxSync(...args),
+  runNxArgvSync: (...args: unknown[]) => mockRunNxArgvSync(...args),
 }));
 
 const mockRunInstall = jest.fn();
@@ -85,7 +89,7 @@ describe('migrate() version-skew-guard wiring (temp-installation hand-off)', () 
 
   beforeEach(() => {
     mockAssertWorkspaceNx.mockReset().mockReturnValue(undefined);
-    mockRunNxSync.mockReset();
+    mockRunNxArgvSync.mockReset();
     mockRunInstall.mockReset().mockResolvedValue(undefined);
     delete process.env.NX_MIGRATE_SKIP_INSTALL;
     jest.spyOn(output, 'log').mockImplementation(() => {});
@@ -116,9 +120,9 @@ describe('migrate() version-skew-guard wiring (temp-installation hand-off)', () 
       expect(mockAssertWorkspaceNx).toHaveBeenCalledWith(
         expect.objectContaining({ argv })
       );
-      expect(mockRunNxSync).toHaveBeenCalledTimes(1);
+      expect(mockRunNxArgvSync).toHaveBeenCalledTimes(1);
       expect(mockAssertWorkspaceNx.mock.invocationCallOrder[0]).toBeLessThan(
-        mockRunNxSync.mock.invocationCallOrder[0]
+        mockRunNxArgvSync.mock.invocationCallOrder[0]
       );
     });
 
@@ -139,7 +143,7 @@ describe('migrate() version-skew-guard wiring (temp-installation hand-off)', () 
         mockAssertWorkspaceNx.mock.invocationCallOrder[0]
       );
       expect(mockAssertWorkspaceNx.mock.invocationCallOrder[0]).toBeLessThan(
-        mockRunNxSync.mock.invocationCallOrder[0]
+        mockRunNxArgvSync.mock.invocationCallOrder[0]
       );
     });
 
@@ -180,7 +184,7 @@ describe('migrate() version-skew-guard wiring (temp-installation hand-off)', () 
       );
 
       expect(exitCode).toBe(1);
-      expect(mockRunNxSync).not.toHaveBeenCalled();
+      expect(mockRunNxArgvSync).not.toHaveBeenCalled();
     });
   });
 });
@@ -195,7 +199,7 @@ describe('runMigration() version-skew-guard wiring (temp-CLI install)', () => {
     mockResolveRunTarget.mockReset().mockResolvedValue('temp-cli');
     mockEnsurePackageHasProvenance.mockReset();
     mockResolvePackageVersion.mockReset().mockResolvedValue('23.2.0');
-    mockRunNxSync.mockReset();
+    mockRunNxArgvSync.mockReset();
     jest.spyOn(output, 'log').mockImplementation(() => {});
     jest.spyOn(output, 'warn').mockImplementation(() => {});
     jest.spyOn(output, 'error').mockImplementation(() => {});
@@ -255,10 +259,11 @@ describe('runMigration() version-skew-guard wiring (temp-CLI install)', () => {
 
     expect(exitCode).toBe(0);
     expect(mockEnsurePackageHasProvenance).not.toHaveBeenCalled();
-    expect(mockRunNxSync).toHaveBeenCalledTimes(1);
-    expect(mockRunNxSync.mock.calls[0][0]).toBe(
-      '_migrate --run-migration=@nx/js:gen'
-    );
+    expect(mockRunNxArgvSync).toHaveBeenCalledTimes(1);
+    expect(mockRunNxArgvSync.mock.calls[0][0]).toEqual([
+      '_migrate',
+      '--run-migration=@nx/js:gen',
+    ]);
   });
 
   it('neither installs the temp CLI nor runs the local nx when the router refuses', async () => {
@@ -270,6 +275,6 @@ describe('runMigration() version-skew-guard wiring (temp-CLI install)', () => {
 
     expect(exitCode).toBe(1);
     expect(mockEnsurePackageHasProvenance).not.toHaveBeenCalled();
-    expect(mockRunNxSync).not.toHaveBeenCalled();
+    expect(mockRunNxArgvSync).not.toHaveBeenCalled();
   });
 });

--- a/packages/nx/src/command-line/migrate/migrate-guard-wiring.spec.ts
+++ b/packages/nx/src/command-line/migrate/migrate-guard-wiring.spec.ts
@@ -19,8 +19,8 @@ jest.mock('../../utils/provenance', () => ({
     mockEnsurePackageHasProvenance(...args),
 }));
 
-// Both spawn helpers are mocked: the hand-off calls runNxArgvSync, and leaving
-// runNxSync live would let its fallback path spawn a real nx.
+// Both spawn helpers are mocked: the hand-off calls runNxArgvSync, and
+// connect-to-nx-cloud, which migrate.ts imports, calls runNxSync.
 const mockRunNxSync = jest.fn();
 const mockRunNxArgvSync = jest.fn();
 jest.mock('../../utils/child-process', () => ({
@@ -236,8 +236,6 @@ describe('runMigration() version-skew-guard wiring (temp-CLI install)', () => {
     restoreEnv('NODE_PATH', originalNodePath);
   });
 
-  // Stands in for the install nxCliPath() performs, so the hand-off reads a
-  // manifest this test controls.
   function stubTempCliInstall(bin?: unknown): string {
     const tmpDir = realpathSync(
       mkdtempSync(join(tmpdir(), 'guard-wiring-temp-cli-'))
@@ -313,7 +311,6 @@ describe('runMigration() version-skew-guard wiring (temp-CLI install)', () => {
   });
 
   it('spawns the entry point the temp installation declares, not a fixed layout', async () => {
-    // nx has published its entry point at dist/bin/nx.js since 23.0.0.
     const tmpDir = stubTempCliInstall({ nx: './dist/bin/nx.js' });
 
     try {
@@ -328,7 +325,6 @@ describe('runMigration() version-skew-guard wiring (temp-CLI install)', () => {
       expect(mockRunNxArgvSync.mock.calls[0][1]).toMatchObject({
         nxBin: join(tmpDir, 'node_modules', 'nx', 'dist', 'bin', 'nx.js'),
       });
-      // the argv never reaches a shell
       expect(
         mockExecSync.mock.calls.filter(([cmd]: [string]) =>
           cmd.includes('_migrate')
@@ -341,6 +337,9 @@ describe('runMigration() version-skew-guard wiring (temp-CLI install)', () => {
 
   it('falls back to the temp installation shim when its manifest names no nx bin', async () => {
     const tmpDir = stubTempCliInstall();
+    process.argv = [...process.argv, '--commit-prefix=chore(repo): '];
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'linux' });
 
     try {
       const exitCode = await runMigration();
@@ -350,6 +349,41 @@ describe('runMigration() version-skew-guard wiring (temp-CLI install)', () => {
       expect(mockExecSync).toHaveBeenCalledWith(
         `${join(
           tmpDir,
+          'node_modules',
+          '.bin',
+          'nx'
+        )} _migrate --run-migration=@nx/js:gen '--commit-prefix=chore(repo): '`,
+        expect.objectContaining({ windowsHide: true })
+      );
+    } finally {
+      Object.defineProperty(process, 'platform', { value: originalPlatform });
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('does not hand off to an nx installed above the temp directory', async () => {
+    // The temp installation declares nx itself, so a hoisted nx above it is
+    // one nobody asked for, and the system temp directory is shared.
+    const tmpDir = realpathSync(
+      mkdtempSync(join(tmpdir(), 'guard-wiring-temp-cli-'))
+    );
+    const installDir = join(tmpDir, 'install');
+    mkdirSync(join(tmpDir, 'node_modules', 'nx'), { recursive: true });
+    writeFileSync(
+      join(tmpDir, 'node_modules', 'nx', 'package.json'),
+      JSON.stringify({ name: 'nx', bin: { nx: './dist/bin/nx.js' } })
+    );
+    mkdirSync(installDir, { recursive: true });
+    mockTmpDirSync.mockReturnValue({ name: installDir });
+
+    try {
+      const exitCode = await runMigration();
+
+      expect(exitCode).toBe(0);
+      expect(mockRunNxArgvSync).not.toHaveBeenCalled();
+      expect(mockExecSync).toHaveBeenCalledWith(
+        `${join(
+          installDir,
           'node_modules',
           '.bin',
           'nx'

--- a/packages/nx/src/command-line/migrate/migrate-guard-wiring.spec.ts
+++ b/packages/nx/src/command-line/migrate/migrate-guard-wiring.spec.ts
@@ -29,6 +29,20 @@ jest.mock('../../utils/child-process', () => ({
   runNxArgvSync: (...args: unknown[]) => mockRunNxArgvSync(...args),
 }));
 
+// The temp-CLI hand-off installs nx for real; stubbing the dir it installs
+// into and the commands it runs lets a test shape that installation.
+const mockTmpDirSync = jest.fn();
+jest.mock('tmp', () => ({
+  ...jest.requireActual('tmp'),
+  dirSync: (...args: unknown[]) => mockTmpDirSync(...args),
+}));
+
+const mockExecSync = jest.fn();
+jest.mock('child_process', () => ({
+  ...jest.requireActual('child_process'),
+  execSync: (...args: unknown[]) => mockExecSync(...args),
+}));
+
 const mockRunInstall = jest.fn();
 jest.mock('./execute-migration', () => ({
   ...jest.requireActual('./execute-migration'),
@@ -194,12 +208,16 @@ describe('runMigration() version-skew-guard wiring (temp-CLI install)', () => {
   const originalUseLocal = process.env.NX_USE_LOCAL;
   const originalMigrateUseLocal = process.env.NX_MIGRATE_USE_LOCAL;
   const originalCliVersion = process.env.NX_MIGRATE_CLI_VERSION;
+  // nxCliPath() appends the temp installation to NODE_PATH.
+  const originalNodePath = process.env.NODE_PATH;
 
   beforeEach(() => {
     mockResolveRunTarget.mockReset().mockResolvedValue('temp-cli');
     mockEnsurePackageHasProvenance.mockReset();
     mockResolvePackageVersion.mockReset().mockResolvedValue('23.2.0');
     mockRunNxArgvSync.mockReset();
+    mockExecSync.mockReset();
+    mockTmpDirSync.mockReset();
     jest.spyOn(output, 'log').mockImplementation(() => {});
     jest.spyOn(output, 'warn').mockImplementation(() => {});
     jest.spyOn(output, 'error').mockImplementation(() => {});
@@ -215,7 +233,23 @@ describe('runMigration() version-skew-guard wiring (temp-CLI install)', () => {
     restoreEnv('NX_USE_LOCAL', originalUseLocal);
     restoreEnv('NX_MIGRATE_USE_LOCAL', originalMigrateUseLocal);
     restoreEnv('NX_MIGRATE_CLI_VERSION', originalCliVersion);
+    restoreEnv('NODE_PATH', originalNodePath);
   });
+
+  // Stands in for the install nxCliPath() performs, so the hand-off reads a
+  // manifest this test controls.
+  function stubTempCliInstall(bin?: unknown): string {
+    const tmpDir = realpathSync(
+      mkdtempSync(join(tmpdir(), 'guard-wiring-temp-cli-'))
+    );
+    mkdirSync(join(tmpDir, 'node_modules', 'nx'), { recursive: true });
+    writeFileSync(
+      join(tmpDir, 'node_modules', 'nx', 'package.json'),
+      JSON.stringify({ name: 'nx', version: '23.2.0', ...(bin ? { bin } : {}) })
+    );
+    mockTmpDirSync.mockReturnValue({ name: tmpDir });
+    return tmpDir;
+  }
 
   it('runs the router with the raw argv before installing the temp CLI', async () => {
     // The first step of the temp-CLI install (nxCliPath), so rejecting it
@@ -276,5 +310,54 @@ describe('runMigration() version-skew-guard wiring (temp-CLI install)', () => {
     expect(exitCode).toBe(1);
     expect(mockEnsurePackageHasProvenance).not.toHaveBeenCalled();
     expect(mockRunNxArgvSync).not.toHaveBeenCalled();
+  });
+
+  it('spawns the entry point the temp installation declares, not a fixed layout', async () => {
+    // nx has published its entry point at dist/bin/nx.js since 23.0.0.
+    const tmpDir = stubTempCliInstall({ nx: './dist/bin/nx.js' });
+
+    try {
+      const exitCode = await runMigration();
+
+      expect(exitCode).toBe(0);
+      expect(mockRunNxArgvSync).toHaveBeenCalledTimes(1);
+      expect(mockRunNxArgvSync.mock.calls[0][0]).toEqual([
+        '_migrate',
+        '--run-migration=@nx/js:gen',
+      ]);
+      expect(mockRunNxArgvSync.mock.calls[0][1]).toMatchObject({
+        nxBin: join(tmpDir, 'node_modules', 'nx', 'dist', 'bin', 'nx.js'),
+      });
+      // the argv never reaches a shell
+      expect(
+        mockExecSync.mock.calls.filter(([cmd]: [string]) =>
+          cmd.includes('_migrate')
+        )
+      ).toEqual([]);
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
+  });
+
+  it('falls back to the temp installation shim when its manifest names no nx bin', async () => {
+    const tmpDir = stubTempCliInstall();
+
+    try {
+      const exitCode = await runMigration();
+
+      expect(exitCode).toBe(0);
+      expect(mockRunNxArgvSync).not.toHaveBeenCalled();
+      expect(mockExecSync).toHaveBeenCalledWith(
+        `${join(
+          tmpDir,
+          'node_modules',
+          '.bin',
+          'nx'
+        )} _migrate --run-migration=@nx/js:gen`,
+        expect.objectContaining({ windowsHide: true })
+      );
+    } finally {
+      rmSync(tmpDir, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -89,7 +89,7 @@ import {
   getInstalledVersion,
 } from '../../utils/installed-nx-version';
 import { readNxJson } from '../../config/configuration';
-import { runNxSync } from '../../utils/child-process';
+import { runNxArgvSync } from '../../utils/child-process';
 import { daemonClient } from '../../daemon/client/client';
 import { isNxCloudUsed, isNxCloudDisabled } from '../../utils/nx-cloud-utils';
 import {
@@ -3404,7 +3404,7 @@ async function runMigrations(
     // we are running from a temp installation with nx latest, switch to running
     // from local installation
     const exitCode = runOrReturnExitCode(() =>
-      runNxSync(`migrate ${args.map(quoteShellArg).join(' ')}`, {
+      runNxArgvSync(['migrate', ...args], {
         stdio: ['inherit', 'inherit', 'inherit'],
         env: {
           ...process.env,
@@ -3759,12 +3759,10 @@ export async function migrate(
 
 export async function runMigration() {
   return handleErrors(process.env.NX_VERBOSE_LOGGING === 'true', async () => {
-    // the forwarded argv is re-joined into a shell command, so each argument
-    // must be quoted to survive it (e.g. a --commit-prefix with spaces or parens)
-    const forwardedArgs = process.argv.slice(3).map(quoteShellArg).join(' ');
+    const forwardedArgv = process.argv.slice(3);
     const runLocalMigrate = () =>
       runOrReturnExitCode(() =>
-        runNxSync(`_migrate ${forwardedArgs}`, {
+        runNxArgvSync(['_migrate', ...forwardedArgv], {
           stdio: ['inherit', 'inherit', 'inherit'],
         })
       );
@@ -3788,11 +3786,22 @@ export async function runMigration() {
       ) {
         delete process.env.npm_config_registry;
       }
+      // p is the temp install's bin shim; spawn its JS entry directly so the
+      // forwarded argv is not re-parsed by a shell
+      const tempNxEntry = join(dirname(dirname(p)), 'nx', 'bin', 'nx.js');
       return runOrReturnExitCode(() =>
-        execSync(`${p} _migrate ${forwardedArgs}`, {
-          stdio: ['inherit', 'inherit', 'inherit'],
-          windowsHide: true,
-        })
+        existsSync(tempNxEntry)
+          ? runNxArgvSync(['_migrate', ...forwardedArgv], {
+              stdio: ['inherit', 'inherit', 'inherit'],
+              nxBin: tempNxEntry,
+            })
+          : execSync(
+              `${p} _migrate ${forwardedArgv.map(quoteShellArg).join(' ')}`,
+              {
+                stdio: ['inherit', 'inherit', 'inherit'],
+                windowsHide: true,
+              }
+            )
       );
     }
 

--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -41,6 +41,7 @@ import {
 } from '../../utils/fileutils';
 import { extractFileFromTarball } from '../../utils/tar';
 import { writeFormattedJsonFile } from '../../utils/write-formatted-json-file';
+import { quoteShellArg } from '../../utils/shell-quoting';
 import { logger } from '../../utils/logger';
 import {
   getUncommittedChangesSnapshot,
@@ -3758,9 +3759,12 @@ export async function migrate(
 
 export async function runMigration() {
   return handleErrors(process.env.NX_VERBOSE_LOGGING === 'true', async () => {
+    // the forwarded argv is re-joined into a shell command, so each argument
+    // must be quoted to survive it (e.g. a --commit-prefix with spaces or parens)
+    const forwardedArgs = process.argv.slice(3).map(quoteShellArg).join(' ');
     const runLocalMigrate = () =>
       runOrReturnExitCode(() =>
-        runNxSync(`_migrate ${process.argv.slice(3).join(' ')}`, {
+        runNxSync(`_migrate ${forwardedArgs}`, {
           stdio: ['inherit', 'inherit', 'inherit'],
         })
       );
@@ -3785,7 +3789,7 @@ export async function runMigration() {
         delete process.env.npm_config_registry;
       }
       return runOrReturnExitCode(() =>
-        execSync(`${p} _migrate ${process.argv.slice(3).join(' ')}`, {
+        execSync(`${p} _migrate ${forwardedArgs}`, {
           stdio: ['inherit', 'inherit', 'inherit'],
           windowsHide: true,
         })

--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -3404,7 +3404,7 @@ async function runMigrations(
     // we are running from a temp installation with nx latest, switch to running
     // from local installation
     const exitCode = runOrReturnExitCode(() =>
-      runNxSync(`migrate ${args.join(' ')}`, {
+      runNxSync(`migrate ${args.map(quoteShellArg).join(' ')}`, {
         stdio: ['inherit', 'inherit', 'inherit'],
         env: {
           ...process.env,

--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -3449,10 +3449,12 @@ function stringifyCaught(e: unknown): string {
 // A resolver-based lookup (including `resolvePackageJsonWithoutCachePollution`,
 // which does defeat Node's package self-reference) is the wrong tool here:
 // resolvers fall back to NODE_PATH after the explicit paths, and NODE_PATH
-// names the temp installation when this runs there, while the hand-off spawn
-// locates nx through the package manager's bin lookup, which ignores
-// NODE_PATH. The PnP branch below stays bespoke either way: a resolver cannot
-// see into the zip cache without the PnP runtime.
+// names the temp installation when this runs there. The scan below reads its
+// candidate directories itself, so neither NODE_PATH nor self-reference can
+// reach it; `getNxBin` (utils/child-process.ts), which locates the nx the
+// hand-off spawns, walks the same directories for the same reason. The PnP
+// branch below stays bespoke either way: a resolver cannot see into the zip
+// cache without the PnP runtime.
 export function readLocalNxVersion(root: string): string | undefined {
   // A PnP manifest is consulted only when yarn drives the hand-off:
   // `getRunNxBaseCommand` builds the hand-off command through this same
@@ -3698,8 +3700,9 @@ export async function runMigration() {
     // that parsed the flags, so it needs no capability check. Two lookups
     // can still diverge from the running install, both properties of the
     // spawn machinery rather than of this fallback: a `.nx/installation`
-    // beside a root package.json, and a spawn that misses the workspace
-    // install and falls back to an nx on PATH (pnpm exec).
+    // beside a root package.json, and, once the spawn falls back to the
+    // package manager, a lookup that misses the workspace install and lands
+    // on an nx on PATH (pnpm exec).
     const forwardedArgv = process.argv.slice(3);
     const runLocalMigrate = () =>
       runOrReturnExitCode(() =>

--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -83,7 +83,7 @@ import {
   getInstalledVersion,
 } from '../../utils/installed-nx-version';
 import { readNxJson } from '../../config/configuration';
-import { runNxArgvSync } from '../../utils/child-process';
+import { getNxBin, runNxArgvSync } from '../../utils/child-process';
 import { daemonClient } from '../../daemon/client/client';
 import { isNxCloudUsed, isNxCloudDisabled } from '../../utils/nx-cloud-utils';
 import { formatFilesWithPrettierIfAvailable } from '../../generators/internal-utils/format-changed-files-with-prettier-if-available';
@@ -3753,11 +3753,12 @@ export async function runMigration() {
       // Intentionally not the workspace's nx: `p` is an nx CLI freshly
       // installed into a temp dir by nxCliPath() (latest, or
       // NX_MIGRATE_CLI_VERSION), so migrations run with an up-to-date migrate
-      // implementation. `p` is that install's bin shim; spawn its JS entry
-      // directly so the forwarded argv is not re-parsed by a shell.
-      const tempNxEntry = join(dirname(dirname(p)), 'nx', 'bin', 'nx.js');
+      // implementation. `p` is <tmpDir>/node_modules/.bin/nx, a shell shim;
+      // spawning the entry point that install's own manifest names instead
+      // keeps the forwarded argv out of a shell.
+      const tempNxEntry = getNxBin(dirname(dirname(dirname(p))));
       return runOrReturnExitCode(() =>
-        existsSync(tempNxEntry)
+        tempNxEntry
           ? runNxArgvSync(['_migrate', ...forwardedArgv], {
               stdio: ['inherit', 'inherit', 'inherit'],
               nxBin: tempNxEntry,

--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -33,6 +33,7 @@ import {
 } from '../../utils/fileutils';
 import { extractFileFromTarball } from '../../utils/tar';
 import { writeFormattedJsonFile } from '../../utils/write-formatted-json-file';
+import { quoteShellArg } from '../../utils/shell-quoting';
 import { logger } from '../../utils/logger';
 import {
   getGitCurrentBranch,
@@ -82,7 +83,7 @@ import {
   getInstalledVersion,
 } from '../../utils/installed-nx-version';
 import { readNxJson } from '../../config/configuration';
-import { runNxSync } from '../../utils/child-process';
+import { runNxArgvSync } from '../../utils/child-process';
 import { daemonClient } from '../../daemon/client/client';
 import { isNxCloudUsed, isNxCloudDisabled } from '../../utils/nx-cloud-utils';
 import { formatFilesWithPrettierIfAvailable } from '../../generators/internal-utils/format-changed-files-with-prettier-if-available';
@@ -3057,12 +3058,11 @@ export async function executeMigrations(
 
 // Forwards this invocation's raw argv to the workspace-local nx, used from
 // each run path's temp-installation check (`!__dirname.startsWith(workspaceRoot)`)
-// right after its gated `runInstall` pre-install. `runNxSync` resolves nx
-// through the workspace's package manager at spawn time, so the child runs
-// the bytes that pre-install put in place.
+// right after its gated `runInstall` pre-install. nx is located at spawn time,
+// so the child runs the bytes that pre-install put in place.
 function handOffToLocalNx(args: string[]): number | undefined {
   const exitCode = runOrReturnExitCode(() =>
-    runNxSync(`migrate ${args.join(' ')}`, {
+    runNxArgvSync(['migrate', ...args], {
       stdio: ['inherit', 'inherit', 'inherit'],
       env: {
         ...process.env,
@@ -3700,9 +3700,10 @@ export async function runMigration() {
     // spawn machinery rather than of this fallback: a `.nx/installation`
     // beside a root package.json, and a spawn that misses the workspace
     // install and falls back to an nx on PATH (pnpm exec).
+    const forwardedArgv = process.argv.slice(3);
     const runLocalMigrate = () =>
       runOrReturnExitCode(() =>
-        runNxSync(`_migrate ${process.argv.slice(3).join(' ')}`, {
+        runNxArgvSync(['_migrate', ...forwardedArgv], {
           stdio: ['inherit', 'inherit', 'inherit'],
         })
       );
@@ -3746,15 +3747,25 @@ export async function runMigration() {
       ) {
         delete process.env.npm_config_registry;
       }
-      // Intentionally not runNxSync: `p` is an nx CLI freshly installed into a
-      // temp dir by nxCliPath() (latest, or NX_MIGRATE_CLI_VERSION), so
-      // migrations run with an up-to-date migrate implementation instead of
-      // the workspace's current nx.
+      // Intentionally not the workspace's nx: `p` is an nx CLI freshly
+      // installed into a temp dir by nxCliPath() (latest, or
+      // NX_MIGRATE_CLI_VERSION), so migrations run with an up-to-date migrate
+      // implementation. `p` is that install's bin shim; spawn its JS entry
+      // directly so the forwarded argv is not re-parsed by a shell.
+      const tempNxEntry = join(dirname(dirname(p)), 'nx', 'bin', 'nx.js');
       return runOrReturnExitCode(() =>
-        execSync(`${p} _migrate ${process.argv.slice(3).join(' ')}`, {
-          stdio: ['inherit', 'inherit', 'inherit'],
-          windowsHide: true,
-        })
+        existsSync(tempNxEntry)
+          ? runNxArgvSync(['_migrate', ...forwardedArgv], {
+              stdio: ['inherit', 'inherit', 'inherit'],
+              nxBin: tempNxEntry,
+            })
+          : execSync(
+              `${p} _migrate ${forwardedArgv.map(quoteShellArg).join(' ')}`,
+              {
+                stdio: ['inherit', 'inherit', 'inherit'],
+                windowsHide: true,
+              }
+            )
       );
     }
 

--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -83,7 +83,7 @@ import {
   getInstalledVersion,
 } from '../../utils/installed-nx-version';
 import { readNxJson } from '../../config/configuration';
-import { getNxBin, runNxArgvSync } from '../../utils/child-process';
+import { readInstalledNxBin, runNxArgvSync } from '../../utils/child-process';
 import { daemonClient } from '../../daemon/client/client';
 import { isNxCloudUsed, isNxCloudDisabled } from '../../utils/nx-cloud-utils';
 import { formatFilesWithPrettierIfAvailable } from '../../generators/internal-utils/format-changed-files-with-prettier-if-available';
@@ -3056,10 +3056,8 @@ export async function executeMigrations(
   };
 }
 
-// Forwards this invocation's raw argv to the workspace-local nx, used from
-// each run path's temp-installation check (`!__dirname.startsWith(workspaceRoot)`)
-// right after its gated `runInstall` pre-install. nx is located at spawn time,
-// so the child runs the bytes that pre-install put in place.
+// nx is located at spawn time, after the gated pre-install, so the child runs
+// the bytes that install put in place.
 function handOffToLocalNx(args: string[]): number | undefined {
   const exitCode = runOrReturnExitCode(() =>
     runNxArgvSync(['migrate', ...args], {
@@ -3452,9 +3450,11 @@ function stringifyCaught(e: unknown): string {
 // names the temp installation when this runs there. The scan below reads its
 // candidate directories itself, so neither NODE_PATH nor self-reference can
 // reach it; `getNxBin` (utils/child-process.ts), which locates the nx the
-// hand-off spawns, walks the same directories for the same reason. The PnP
-// branch below stays bespoke either way: a resolver cannot see into the zip
-// cache without the PnP runtime.
+// hand-off spawns, avoids resolvers for the same reason, over a narrower set
+// of directories: it skips `.nx/installation`, declines a root without a
+// package.json, and stops at the nearest install rather than reading past an
+// unusable one. The PnP branch below stays bespoke either way: a resolver
+// cannot see into the zip cache without the PnP runtime.
 export function readLocalNxVersion(root: string): string | undefined {
   // A PnP manifest is consulted only when yarn drives the hand-off:
   // `getRunNxBaseCommand` builds the hand-off command through this same
@@ -3587,12 +3587,13 @@ export function readLocalNxVersion(root: string): string | undefined {
 // The workspace's own install locations first (.nx/installation, root), then
 // ancestor directories: package-manager executable lookup ascends (npx and
 // bun always, pnpm and yarn inside an outer workspace) and hoisted layouts
-// install nx above the workspace root. An unrelated ancestor install the
-// hand-off's spawn would not run can be read here; the guards then judge that
-// version rather than failing open. A hand-off issued anyway may not fail
-// visibly: yarn reports "command not found", but pnpm exec falls back to an
-// nx on PATH, so the version read here is the readable answer, not
-// necessarily the executed one.
+// install nx above the workspace root. `getNxBin` ascends too, so an ancestor
+// read here is usually the one the hand-off spawns. They diverge for a
+// `.nx/installation` workspace, which `getNxBin` declines, and where the only
+// nx found sits past the package manager's own lookup boundary and the spawn
+// has fallen back to that manager: yarn then reports "command not found"
+// while pnpm exec lands on an nx on PATH. The version read here is therefore
+// the readable answer, not necessarily the executed one.
 function scanNodeModulesForNxVersion(root: string): string | undefined {
   const searchPaths = [...getNxRequirePaths(root)];
   for (let dir = dirname(root); ; dir = dirname(dir)) {
@@ -3755,8 +3756,10 @@ export async function runMigration() {
       // NX_MIGRATE_CLI_VERSION), so migrations run with an up-to-date migrate
       // implementation. `p` is <tmpDir>/node_modules/.bin/nx, a shell shim;
       // spawning the entry point that install's own manifest names instead
-      // keeps the forwarded argv out of a shell.
-      const tempNxEntry = getNxBin(dirname(dirname(dirname(p))));
+      // keeps the forwarded argv out of a shell. That install declares nx
+      // itself, so it is read without ascending: an nx above the temp dir is
+      // one nothing asked for, and the shim below is the answer instead.
+      const tempNxEntry = readInstalledNxBin(dirname(dirname(dirname(p))));
       return runOrReturnExitCode(() =>
         tempNxEntry
           ? runNxArgvSync(['_migrate', ...forwardedArgv], {
@@ -3764,7 +3767,9 @@ export async function runMigration() {
               nxBin: tempNxEntry,
             })
           : execSync(
-              `${p} _migrate ${forwardedArgv.map(quoteShellArg).join(' ')}`,
+              `${quoteShellArg(p)} _migrate ${forwardedArgv
+                .map(quoteShellArg)
+                .join(' ')}`,
               {
                 stdio: ['inherit', 'inherit', 'inherit'],
                 windowsHide: true,

--- a/packages/nx/src/command-line/migrate/version-skew-guard.ts
+++ b/packages/nx/src/command-line/migrate/version-skew-guard.ts
@@ -14,8 +14,8 @@ import { normalizeVersion } from './version-utils';
 // plan phase instead.
 export const NEW_MIGRATE_FLAGS_FLOOR = '23.2.0';
 
-// yargs accepts both spellings and the raw argv is forwarded verbatim across
-// both migrate hops, so detection must catch each one.
+// yargs accepts both spellings and the raw argv is forwarded across both
+// migrate hops, so detection must catch each one.
 export const NEW_MIGRATE_FLAGS = ['--run-migration', '--runMigration'] as const;
 
 /**
@@ -154,10 +154,9 @@ export async function resolveNewMigrateFlagsRunTarget(options: {
  * because the invoking nx's version is not forwarded across hop A; the
  * refusal names the workspace update that resolves it.
  *
- * `readLocalNxVersion` returns undefined when no readable nx install exists
- * at or above the workspace root; that case does not block. The hand-off
- * spawns the `nx migrate` wrapper, and without an nx installation to
- * delegate to it exits visibly rather than running anything.
+ * `readLocalNxVersion` returning undefined does not block: the hand-off then
+ * resolves nx as it always does, which may fail visibly or land on another nx
+ * the package manager locates.
  */
 export function assertWorkspaceNxSupportsNewMigrateFlags(options: {
   argv: string[];

--- a/packages/nx/src/utils/child-process.spec.ts
+++ b/packages/nx/src/utils/child-process.spec.ts
@@ -1,0 +1,55 @@
+import { runNxArgvSync } from './child-process';
+
+jest.mock('child_process', () => ({
+  ...jest.requireActual('child_process'),
+  spawnSync: jest.fn(),
+}));
+
+import { spawnSync } from 'child_process';
+
+describe('runNxArgvSync', () => {
+  const spawnSyncMock = spawnSync as jest.Mock;
+
+  beforeEach(() => {
+    spawnSyncMock.mockReset();
+    spawnSyncMock.mockReturnValue({ status: 0 });
+  });
+
+  it('passes every argument through verbatim with no shell involved', () => {
+    const argv = [
+      '_migrate',
+      '--commit-prefix=chore(repo): [nx migration] ',
+      '--data=%FOO% and ^caret and $HOME',
+      '',
+    ];
+
+    runNxArgvSync(argv, { nxBin: '/tmp/nx/bin/nx.js' });
+
+    expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+    const [command, args, options] = spawnSyncMock.mock.calls[0];
+    expect(command).toBe(process.execPath);
+    expect(args).toEqual(['/tmp/nx/bin/nx.js', ...argv]);
+    expect(options.shell).toBeUndefined();
+  });
+
+  it('throws an error carrying the exit status when the command fails', () => {
+    spawnSyncMock.mockReturnValue({ status: 7 });
+
+    let caught: any;
+    try {
+      runNxArgvSync(['_migrate'], { nxBin: '/tmp/nx/bin/nx.js' });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeDefined();
+    expect(caught.status).toBe(7);
+  });
+
+  it('throws the spawn error when the process could not start', () => {
+    spawnSyncMock.mockReturnValue({ error: new Error('ENOENT'), status: null });
+
+    expect(() =>
+      runNxArgvSync(['_migrate'], { nxBin: '/tmp/nx/bin/nx.js' })
+    ).toThrow('ENOENT');
+  });
+});

--- a/packages/nx/src/utils/child-process.spec.ts
+++ b/packages/nx/src/utils/child-process.spec.ts
@@ -18,8 +18,12 @@ jest.mock('./workspace-root', () => ({
 
 import { spawnSync } from 'child_process';
 import { existsSync } from 'fs';
-import { getRunNxBaseCommand, runNxArgvSync } from './child-process';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { getNxBin, getRunNxBaseCommand, runNxArgvSync } from './child-process';
 import type { PackageManagerCommands } from './package-manager';
+
+const realFs = jest.requireActual('fs') as typeof import('fs');
 
 describe('getRunNxBaseCommand', () => {
   const pmc = { exec: 'npx' } as PackageManagerCommands;
@@ -51,6 +55,128 @@ describe('getRunNxBaseCommand', () => {
     withPlatform('linux', () => {
       expect(getRunNxBaseCommand(pmc, '/root')).toBe('./nx');
     });
+  });
+});
+
+describe('getNxBin', () => {
+  let fixture: string;
+
+  // Shaped like the published package, whose `bin` points into `dist`, so the
+  // tests would notice the lookup falling back to a guessed path.
+  function writeNxInstall(
+    dir: string,
+    bin: unknown = { nx: './dist/bin/nx.js' }
+  ) {
+    const nxDir = join(dir, 'node_modules', 'nx');
+    realFs.mkdirSync(join(nxDir, 'dist', 'bin'), { recursive: true });
+    realFs.writeFileSync(
+      join(nxDir, 'package.json'),
+      JSON.stringify({ name: 'nx', version: '1.0.0', bin })
+    );
+    realFs.writeFileSync(join(nxDir, 'dist', 'bin', 'nx.js'), '');
+    return join(nxDir, 'dist', 'bin', 'nx.js');
+  }
+
+  function workspace(name: string): string {
+    const root = join(fixture, name);
+    realFs.mkdirSync(root, { recursive: true });
+    realFs.writeFileSync(join(root, 'package.json'), '{}');
+    return root;
+  }
+
+  beforeEach(() => {
+    (existsSync as jest.Mock).mockImplementation(realFs.existsSync);
+    fixture = realFs.realpathSync(
+      realFs.mkdtempSync(join(tmpdir(), 'nx-get-nx-bin-'))
+    );
+  });
+
+  afterEach(() => {
+    realFs.rmSync(fixture, { recursive: true, force: true });
+  });
+
+  it('takes the entry point the workspace nx names in its bin field', () => {
+    const root = workspace('ws');
+    const nxBin = writeNxInstall(root);
+
+    expect(getNxBin(root)).toBe(nxBin);
+  });
+
+  it('accepts the single-entry bin form', () => {
+    const root = workspace('ws');
+    const nxBin = writeNxInstall(root, './dist/bin/nx.js');
+
+    expect(getNxBin(root)).toBe(nxBin);
+  });
+
+  it('finds nx hoisted into an ancestor node_modules', () => {
+    const nxBin = writeNxInstall(fixture);
+    const root = workspace('ws');
+
+    expect(getNxBin(root)).toBe(nxBin);
+  });
+
+  it('prefers the nearest install over a hoisted one', () => {
+    writeNxInstall(fixture);
+    const root = workspace('ws');
+    const nxBin = writeNxInstall(root);
+
+    expect(getNxBin(root)).toBe(nxBin);
+  });
+
+  it('returns null when the workspace holds no nx of its own', () => {
+    // A resolver would still answer here, from NODE_PATH or from the running
+    // package. `nx migrate` puts its temp installation on NODE_PATH before
+    // handing off, and handing off to that would re-enter the same hand-off.
+    expect(getNxBin(workspace('ws'))).toBeNull();
+  });
+
+  it('returns null when the installed nx names no nx bin', () => {
+    const root = workspace('ws');
+    writeNxInstall(root, { 'nx-cloud': './dist/bin/nx-cloud.js' });
+
+    expect(getNxBin(root)).toBeNull();
+  });
+
+  it('returns null when the installed nx has an unreadable manifest', () => {
+    const root = workspace('ws');
+    writeNxInstall(root);
+    realFs.writeFileSync(
+      join(root, 'node_modules', 'nx', 'package.json'),
+      '{ not json'
+    );
+
+    expect(getNxBin(root)).toBeNull();
+  });
+
+  it('returns null when the workspace has no root package.json', () => {
+    // A `.nx/installation` workspace: the `./nx` wrapper has to run so it can
+    // re-sync the installation, so nothing may be spawned directly.
+    const root = join(fixture, 'ws');
+    writeNxInstall(join(root, '.nx', 'installation'));
+
+    expect(getNxBin(root)).toBeNull();
+  });
+
+  it('finds nx linked into the workspace node_modules from outside it', () => {
+    // `npm link nx` and a `file:` dependency both land here. The package
+    // manager runs this nx, so it is the workspace's nx however far outside
+    // the link target sits.
+    const outside = join(fixture, 'outside');
+    realFs.mkdirSync(outside, { recursive: true });
+    writeNxInstall(outside);
+
+    const root = workspace('ws');
+    realFs.mkdirSync(join(root, 'node_modules'), { recursive: true });
+    realFs.symlinkSync(
+      join(outside, 'node_modules', 'nx'),
+      join(root, 'node_modules', 'nx'),
+      'dir'
+    );
+
+    expect(getNxBin(root)).toBe(
+      join(root, 'node_modules', 'nx', 'dist', 'bin', 'nx.js')
+    );
   });
 });
 

--- a/packages/nx/src/utils/child-process.spec.ts
+++ b/packages/nx/src/utils/child-process.spec.ts
@@ -2,6 +2,10 @@ jest.mock('fs', () => ({
   ...jest.requireActual('fs'),
   existsSync: jest.fn(),
 }));
+jest.mock('child_process', () => ({
+  ...jest.requireActual('child_process'),
+  spawnSync: jest.fn(),
+}));
 jest.mock('../native', () => ({ ChildProcess: class {} }));
 jest.mock('./package-manager', () => ({
   detectPackageManager: jest.fn(),
@@ -12,8 +16,9 @@ jest.mock('./workspace-root', () => ({
   workspaceRootInner: jest.fn(() => '/root'),
 }));
 
+import { spawnSync } from 'child_process';
 import { existsSync } from 'fs';
-import { getRunNxBaseCommand } from './child-process';
+import { getRunNxBaseCommand, runNxArgvSync } from './child-process';
 import type { PackageManagerCommands } from './package-manager';
 
 describe('getRunNxBaseCommand', () => {
@@ -46,5 +51,52 @@ describe('getRunNxBaseCommand', () => {
     withPlatform('linux', () => {
       expect(getRunNxBaseCommand(pmc, '/root')).toBe('./nx');
     });
+  });
+});
+
+describe('runNxArgvSync', () => {
+  const spawnSyncMock = spawnSync as jest.Mock;
+
+  beforeEach(() => {
+    spawnSyncMock.mockReset();
+    spawnSyncMock.mockReturnValue({ status: 0 });
+  });
+
+  it('passes every argument through verbatim with no shell involved', () => {
+    const argv = [
+      '_migrate',
+      '--commit-prefix=chore(repo): [nx migration] ',
+      '--data=%FOO% and ^caret and $HOME',
+      '',
+    ];
+
+    runNxArgvSync(argv, { nxBin: '/tmp/nx/bin/nx.js' });
+
+    expect(spawnSyncMock).toHaveBeenCalledTimes(1);
+    const [command, args, options] = spawnSyncMock.mock.calls[0];
+    expect(command).toBe(process.execPath);
+    expect(args).toEqual(['/tmp/nx/bin/nx.js', ...argv]);
+    expect(options.shell).toBeUndefined();
+  });
+
+  it('throws an error carrying the exit status when the command fails', () => {
+    spawnSyncMock.mockReturnValue({ status: 7 });
+
+    let caught: any;
+    try {
+      runNxArgvSync(['_migrate'], { nxBin: '/tmp/nx/bin/nx.js' });
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeDefined();
+    expect(caught.status).toBe(7);
+  });
+
+  it('throws the spawn error when the process could not start', () => {
+    spawnSyncMock.mockReturnValue({ error: new Error('ENOENT'), status: null });
+
+    expect(() =>
+      runNxArgvSync(['_migrate'], { nxBin: '/tmp/nx/bin/nx.js' })
+    ).toThrow('ENOENT');
   });
 });

--- a/packages/nx/src/utils/child-process.spec.ts
+++ b/packages/nx/src/utils/child-process.spec.ts
@@ -5,6 +5,7 @@ jest.mock('fs', () => ({
 jest.mock('child_process', () => ({
   ...jest.requireActual('child_process'),
   spawnSync: jest.fn(),
+  execSync: jest.fn(),
 }));
 jest.mock('../native', () => ({ ChildProcess: class {} }));
 jest.mock('./package-manager', () => ({
@@ -16,12 +17,20 @@ jest.mock('./workspace-root', () => ({
   workspaceRootInner: jest.fn(() => '/root'),
 }));
 
-import { spawnSync } from 'child_process';
+import { execSync, spawnSync } from 'child_process';
 import { existsSync } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
-import { getNxBin, getRunNxBaseCommand, runNxArgvSync } from './child-process';
-import type { PackageManagerCommands } from './package-manager';
+import {
+  getNxBin,
+  getRunNxBaseCommand,
+  readInstalledNxBin,
+  runNxArgvSync,
+} from './child-process';
+import {
+  getPackageManagerCommand,
+  type PackageManagerCommands,
+} from './package-manager';
 
 const realFs = jest.requireActual('fs') as typeof import('fs');
 
@@ -151,8 +160,10 @@ describe('getNxBin', () => {
 
   it('returns null when the workspace has no root package.json', () => {
     // A `.nx/installation` workspace: the `./nx` wrapper has to run so it can
-    // re-sync the installation, so nothing may be spawned directly.
+    // re-sync the installation, so nothing may be spawned directly, not even
+    // the hoisted nx the ascent would otherwise hand back.
     const root = join(fixture, 'ws');
+    writeNxInstall(fixture);
     writeNxInstall(join(root, '.nx', 'installation'));
 
     expect(getNxBin(root)).toBeNull();
@@ -177,6 +188,27 @@ describe('getNxBin', () => {
     expect(getNxBin(root)).toBe(
       join(root, 'node_modules', 'nx', 'dist', 'bin', 'nx.js')
     );
+  });
+
+  describe('readInstalledNxBin', () => {
+    it('takes the entry point the nx installed in that directory names', () => {
+      const root = workspace('ws');
+      const nxBin = writeNxInstall(root);
+
+      expect(readInstalledNxBin(root)).toBe(nxBin);
+    });
+
+    it('returns null rather than reaching for an ancestor nx', () => {
+      // The caller installed nx itself, so an ancestor's is one nobody asked
+      // for. `nx migrate` reads its temp installation through here, and that
+      // temp dir sits directly under the shared system temp directory.
+      writeNxInstall(fixture);
+      const root = join(fixture, 'installation');
+      realFs.mkdirSync(root, { recursive: true });
+
+      expect(readInstalledNxBin(root)).toBeNull();
+      expect(readInstalledNxBin(fixture)).not.toBeNull();
+    });
   });
 });
 
@@ -224,5 +256,27 @@ describe('runNxArgvSync', () => {
     expect(() =>
       runNxArgvSync(['_migrate'], { nxBin: '/tmp/nx/bin/nx.js' })
     ).toThrow('ENOENT');
+  });
+
+  it('hands quoted arguments to the package manager when no nx can be resolved', () => {
+    const execSyncMock = execSync as jest.Mock;
+    execSyncMock.mockReset();
+    // A root package.json with no readable nx beside it: the shape of the
+    // workspaces `getNxBin` declines, so the shell fallback runs.
+    (existsSync as jest.Mock).mockReturnValue(true);
+    (getPackageManagerCommand as jest.Mock).mockReturnValue({ exec: 'npx' });
+    const originalPlatform = process.platform;
+    Object.defineProperty(process, 'platform', { value: 'linux' });
+
+    try {
+      runNxArgvSync(['_migrate', '--commit-prefix=chore(repo): x']);
+    } finally {
+      Object.defineProperty(process, 'platform', { value: originalPlatform });
+    }
+
+    expect(spawnSyncMock).not.toHaveBeenCalled();
+    expect(execSyncMock.mock.calls[0][0]).toBe(
+      `npx nx _migrate '--commit-prefix=chore(repo): x'`
+    );
   });
 });

--- a/packages/nx/src/utils/child-process.ts
+++ b/packages/nx/src/utils/child-process.ts
@@ -1,8 +1,10 @@
 import {
   exec,
   execSync,
+  spawnSync,
   type ExecOptions,
   type ExecSyncOptions,
+  type SpawnSyncOptions,
 } from 'child_process';
 import { existsSync } from 'fs';
 import { join, relative } from 'path';
@@ -14,6 +16,8 @@ import {
 import { workspaceRoot, workspaceRootInner } from './workspace-root';
 import { ChildProcess } from '../native';
 import { messageToCode } from './exit-codes';
+import { getNxRequirePaths } from './installation-directory';
+import { quoteShellArg } from './shell-quoting';
 
 export function getRunNxBaseCommand(
   packageManagerCommand?: PackageManagerCommands,
@@ -32,6 +36,62 @@ export function getRunNxBaseCommand(
     } else {
       return './' + join(`${offsetFromRoot}`, 'nx');
     }
+  }
+}
+
+/**
+ * Resolve the local nx CLI entry point, including `.nx/installation` wrapper
+ * layouts. Returns null when nx cannot be resolved from disk (e.g. Yarn PnP).
+ */
+export function getNxBin(root: string = workspaceRoot): string | null {
+  try {
+    return require.resolve('nx/bin/nx.js', { paths: getNxRequirePaths(root) });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Run a nx command, passing the arguments through as an argv array.
+ *
+ * When the nx entry point can be resolved, the child is spawned directly with
+ * no shell in between, so every argument reaches the child exactly as
+ * provided — shell metacharacters (`(`, `%`, `^`, spaces, quotes) are data,
+ * not syntax. When nx cannot be resolved from disk (e.g. Yarn PnP), falls
+ * back to the package-manager + shell path with each argument quoted.
+ */
+export function runNxArgvSync(
+  argv: string[],
+  options?: SpawnSyncOptions & {
+    cwd?: string;
+    nxBin?: string;
+  }
+) {
+  let { nxBin, ...spawnOptions } = options ?? {};
+  spawnOptions.cwd ??= process.cwd();
+  spawnOptions.windowsHide ??= true;
+
+  nxBin ??= getNxBin(
+    workspaceRootInner(spawnOptions.cwd as string, null) ?? workspaceRoot
+  );
+  if (!nxBin) {
+    runNxSync(
+      argv.map(quoteShellArg).join(' '),
+      spawnOptions as ExecSyncOptions & { cwd?: string }
+    );
+    return;
+  }
+
+  const result = spawnSync(process.execPath, [nxBin, ...argv], spawnOptions);
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    const error = new Error(
+      `Command failed: nx ${argv.join(' ')} (exit code ${result.status})`
+    );
+    (error as any).status = result.status ?? 1;
+    throw error;
   }
 }
 

--- a/packages/nx/src/utils/child-process.ts
+++ b/packages/nx/src/utils/child-process.ts
@@ -7,7 +7,7 @@ import {
   type SpawnSyncOptions,
 } from 'child_process';
 import { existsSync } from 'fs';
-import { join, relative } from 'path';
+import { dirname, join, relative } from 'path';
 import {
   detectPackageManager,
   getPackageManagerCommand,
@@ -16,7 +16,7 @@ import {
 import { workspaceRoot, workspaceRootInner } from './workspace-root';
 import { ChildProcess } from '../native';
 import { messageToCode } from './exit-codes';
-import { getNxRequirePaths } from './installation-directory';
+import { readJsonFile } from './fileutils';
 import { quoteShellArg } from './shell-quoting';
 
 export function getRunNxBaseCommand(
@@ -26,7 +26,8 @@ export function getRunNxBaseCommand(
   if (existsSync(join(workspaceRoot, 'package.json'))) {
     if (!packageManagerCommand) {
       // `readLocalNxVersion` (command-line/migrate/migrate.ts) mirrors this
-      // selector to predict which nx the spawn will run; keep the two in sync.
+      // selector to predict which nx a spawn will run, for the workspaces
+      // `getNxBin` declines to resolve; keep the two in sync.
       const pm = detectPackageManager(workspaceRoot);
       packageManagerCommand = getPackageManagerCommand(pm, workspaceRoot);
     }
@@ -42,25 +43,69 @@ export function getRunNxBaseCommand(
 }
 
 /**
- * Resolve the local nx CLI entry point, including `.nx/installation` wrapper
- * layouts. Returns null when nx cannot be resolved from disk (e.g. Yarn PnP).
+ * Locate the nx entry point the workspace at `root` would run, so a caller can
+ * spawn it directly instead of going through a shell.
+ *
+ * Returns null whenever that answer is not certain, leaving the caller to fall
+ * back to `getRunNxBaseCommand` and let the package manager locate nx. Null is
+ * therefore always safe: it costs the argument fidelity a direct spawn buys,
+ * never the ability to run.
  */
 export function getNxBin(root: string = workspaceRoot): string | null {
-  try {
-    return require.resolve('nx/bin/nx.js', { paths: getNxRequirePaths(root) });
-  } catch {
+  // A workspace with no root package.json runs nx through the `./nx` wrapper,
+  // which reinstalls `.nx/installation` whenever it drifts from nx.json's
+  // `installation.version`. Spawning the resolved entry point would skip that
+  // sync, and a migration is precisely when the version changes.
+  if (!existsSync(join(root, 'package.json'))) {
     return null;
+  }
+
+  return findInstalledNxBin(root);
+}
+
+// Mirrors a package manager's own bin lookup: ascend to the nearest installed
+// nx (npx and bun ascend always, pnpm and yarn inside an outer workspace) and
+// take the entry point its `bin` field names, which is the file the manager
+// links into `node_modules/.bin`.
+//
+// Deliberately not a resolver. Resolvers answer from NODE_PATH once their
+// explicit paths miss, and `nxCliPath` (command-line/migrate/migrate.ts) points
+// NODE_PATH at the temp installation before spawning it; they also answer
+// through package self-reference, which hands back the running nx whatever
+// `paths` they are given. Either one lets the temp installation hand off to
+// itself, which for `--run-migrations` re-enters the same hand-off and respawns
+// without end.
+function findInstalledNxBin(root: string): string | null {
+  for (let dir = root; ; dir = dirname(dir)) {
+    const packageDir = join(dir, 'node_modules', 'nx');
+    const manifest = join(packageDir, 'package.json');
+    if (existsSync(manifest)) {
+      let bin: string | Record<string, string> | undefined;
+      try {
+        ({ bin } = readJsonFile<{ bin?: string | Record<string, string> }>(
+          manifest
+        ));
+      } catch {
+        return null;
+      }
+      // npm accepts both the single-entry shorthand and the map form.
+      const entry = typeof bin === 'string' ? bin : bin?.nx;
+      return typeof entry === 'string' ? join(packageDir, entry) : null;
+    }
+    if (dir === dirname(dir)) {
+      return null;
+    }
   }
 }
 
 /**
  * Run a nx command, passing the arguments through as an argv array.
  *
- * When the nx entry point can be resolved, the child is spawned directly with
- * no shell in between, so every argument reaches the child exactly as
- * provided — shell metacharacters (`(`, `%`, `^`, spaces, quotes) are data,
- * not syntax. When nx cannot be resolved from disk (e.g. Yarn PnP), falls
- * back to the package-manager + shell path with each argument quoted.
+ * When `getNxBin` names an entry point, the child is spawned directly with no
+ * shell in between, so every argument reaches the child exactly as provided:
+ * shell metacharacters (`(`, `%`, `^`, spaces, quotes) are data, not syntax.
+ * Otherwise falls back to the package-manager + shell path with each argument
+ * quoted.
  */
 export function runNxArgvSync(
   argv: string[],

--- a/packages/nx/src/utils/child-process.ts
+++ b/packages/nx/src/utils/child-process.ts
@@ -1,8 +1,10 @@
 import {
   exec,
   execSync,
+  spawnSync,
   type ExecOptions,
   type ExecSyncOptions,
+  type SpawnSyncOptions,
 } from 'child_process';
 import { existsSync } from 'fs';
 import { join, relative } from 'path';
@@ -14,6 +16,8 @@ import {
 import { workspaceRoot, workspaceRootInner } from './workspace-root';
 import { ChildProcess } from '../native';
 import { messageToCode } from './exit-codes';
+import { getNxRequirePaths } from './installation-directory';
+import { quoteShellArg } from './shell-quoting';
 
 export function getRunNxBaseCommand(
   packageManagerCommand?: PackageManagerCommands,
@@ -34,6 +38,62 @@ export function getRunNxBaseCommand(
     } else {
       return './' + join(`${offsetFromRoot}`, 'nx');
     }
+  }
+}
+
+/**
+ * Resolve the local nx CLI entry point, including `.nx/installation` wrapper
+ * layouts. Returns null when nx cannot be resolved from disk (e.g. Yarn PnP).
+ */
+export function getNxBin(root: string = workspaceRoot): string | null {
+  try {
+    return require.resolve('nx/bin/nx.js', { paths: getNxRequirePaths(root) });
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Run a nx command, passing the arguments through as an argv array.
+ *
+ * When the nx entry point can be resolved, the child is spawned directly with
+ * no shell in between, so every argument reaches the child exactly as
+ * provided — shell metacharacters (`(`, `%`, `^`, spaces, quotes) are data,
+ * not syntax. When nx cannot be resolved from disk (e.g. Yarn PnP), falls
+ * back to the package-manager + shell path with each argument quoted.
+ */
+export function runNxArgvSync(
+  argv: string[],
+  options?: SpawnSyncOptions & {
+    cwd?: string;
+    nxBin?: string;
+  }
+) {
+  let { nxBin, ...spawnOptions } = options ?? {};
+  spawnOptions.cwd ??= process.cwd();
+  spawnOptions.windowsHide ??= true;
+
+  nxBin ??= getNxBin(
+    workspaceRootInner(spawnOptions.cwd as string, null) ?? workspaceRoot
+  );
+  if (!nxBin) {
+    runNxSync(
+      argv.map(quoteShellArg).join(' '),
+      spawnOptions as ExecSyncOptions & { cwd?: string }
+    );
+    return;
+  }
+
+  const result = spawnSync(process.execPath, [nxBin, ...argv], spawnOptions);
+  if (result.error) {
+    throw result.error;
+  }
+  if (result.status !== 0) {
+    const error = new Error(
+      `Command failed: nx ${argv.join(' ')} (exit code ${result.status})`
+    );
+    (error as any).status = result.status ?? 1;
+    throw error;
   }
 }
 

--- a/packages/nx/src/utils/child-process.ts
+++ b/packages/nx/src/utils/child-process.ts
@@ -43,13 +43,13 @@ export function getRunNxBaseCommand(
 }
 
 /**
- * Locate the nx entry point the workspace at `root` would run, so a caller can
- * spawn it directly instead of going through a shell.
+ * Locate an nx entry point to spawn for the workspace at `root`, so a caller
+ * can run it directly instead of going through a shell. `findInstalledNxBin`
+ * decides which one.
  *
- * Returns null whenever that answer is not certain, leaving the caller to fall
- * back to `getRunNxBaseCommand` and let the package manager locate nx. Null is
- * therefore always safe: it costs the argument fidelity a direct spawn buys,
- * never the ability to run.
+ * Null means nothing may be spawned directly, leaving the caller to fall back
+ * to `getRunNxBaseCommand`. Null is therefore always safe: it costs the
+ * argument fidelity a direct spawn buys, never the ability to run.
  */
 export function getNxBin(root: string = workspaceRoot): string | null {
   // A workspace with no root package.json runs nx through the `./nx` wrapper,
@@ -63,10 +63,36 @@ export function getNxBin(root: string = workspaceRoot): string | null {
   return findInstalledNxBin(root);
 }
 
-// Mirrors a package manager's own bin lookup: ascend to the nearest installed
-// nx (npx and bun ascend always, pnpm and yarn inside an outer workspace) and
-// take the entry point its `bin` field names, which is the file the manager
-// links into `node_modules/.bin`.
+/**
+ * The entry point the nx installed directly under `dir` names, with no ascent
+ * to `dir`'s ancestors. For an installation that declares nx itself, such as
+ * the temp CLI `nx migrate` builds, an ancestor's nx is never the right answer.
+ */
+export function readInstalledNxBin(dir: string): string | null {
+  const packageDir = join(dir, 'node_modules', 'nx');
+  const manifest = join(packageDir, 'package.json');
+  if (!existsSync(manifest)) {
+    return null;
+  }
+
+  let bin: string | Record<string, string> | undefined;
+  try {
+    ({ bin } = readJsonFile<{ bin?: string | Record<string, string> }>(
+      manifest
+    ));
+  } catch {
+    return null;
+  }
+  // npm accepts both the single-entry shorthand and the map form.
+  const entry = typeof bin === 'string' ? bin : bin?.nx;
+  return typeof entry === 'string' ? join(packageDir, entry) : null;
+}
+
+// Ascend to the nearest installed nx and take the entry point its `bin` field
+// names, which is the file a package manager links into `node_modules/.bin`.
+// Deliberately npx-shaped: npx and bun ascend unconditionally while pnpm and
+// yarn stop at an outer workspace, so this can name an nx those two would
+// decline to run.
 //
 // Deliberately not a resolver. Resolvers answer from NODE_PATH once their
 // explicit paths miss, and `nxCliPath` (command-line/migrate/migrate.ts) points
@@ -77,20 +103,10 @@ export function getNxBin(root: string = workspaceRoot): string | null {
 // without end.
 function findInstalledNxBin(root: string): string | null {
   for (let dir = root; ; dir = dirname(dir)) {
-    const packageDir = join(dir, 'node_modules', 'nx');
-    const manifest = join(packageDir, 'package.json');
-    if (existsSync(manifest)) {
-      let bin: string | Record<string, string> | undefined;
-      try {
-        ({ bin } = readJsonFile<{ bin?: string | Record<string, string> }>(
-          manifest
-        ));
-      } catch {
-        return null;
-      }
-      // npm accepts both the single-entry shorthand and the map form.
-      const entry = typeof bin === 'string' ? bin : bin?.nx;
-      return typeof entry === 'string' ? join(packageDir, entry) : null;
+    // The nearest install wins, so an unusable manifest there ends the search
+    // rather than deferring to an ancestor.
+    if (existsSync(join(dir, 'node_modules', 'nx', 'package.json'))) {
+      return readInstalledNxBin(dir);
     }
     if (dir === dirname(dir)) {
       return null;
@@ -104,8 +120,9 @@ function findInstalledNxBin(root: string): string | null {
  * When `getNxBin` names an entry point, the child is spawned directly with no
  * shell in between, so every argument reaches the child exactly as provided:
  * shell metacharacters (`(`, `%`, `^`, spaces, quotes) are data, not syntax.
- * Otherwise falls back to the package-manager + shell path with each argument
- * quoted.
+ * Otherwise falls back to the package-manager + shell path, where every
+ * argument goes through `quoteShellArg` and the Windows limits it documents
+ * apply.
  */
 export function runNxArgvSync(
   argv: string[],

--- a/packages/nx/src/utils/shell-quoting.spec.ts
+++ b/packages/nx/src/utils/shell-quoting.spec.ts
@@ -1,4 +1,4 @@
-import { needsShellQuoting } from './shell-quoting';
+import { needsShellQuoting, quoteShellArg } from './shell-quoting';
 
 describe('needsShellQuoting', () => {
   it.each([
@@ -39,5 +39,62 @@ describe('needsShellQuoting', () => {
     ['empty string', ''],
   ])('returns false for %s: %j', (_, value) => {
     expect(needsShellQuoting(value)).toBe(false);
+  });
+});
+
+describe('quoteShellArg', () => {
+  const originalPlatform = process.platform;
+
+  const setPlatform = (platform: NodeJS.Platform) =>
+    Object.defineProperty(process, 'platform', { value: platform });
+
+  afterEach(() => {
+    setPlatform(originalPlatform);
+  });
+
+  it.each([
+    ['version', '23.1.0-beta.6'],
+    ['flag', '--create-commits'],
+    ['flag with plain value', '--run-migrations=migrations.json'],
+  ])('leaves %s unquoted: %j', (_, value) => {
+    setPlatform('linux');
+    expect(quoteShellArg(value)).toBe(value);
+    setPlatform('win32');
+    expect(quoteShellArg(value)).toBe(value);
+  });
+
+  describe('on POSIX', () => {
+    beforeEach(() => setPlatform('linux'));
+
+    it.each([
+      [
+        'spaces and parentheses',
+        '--commit-prefix=chore(repo): [nx migration] ',
+        `'--commit-prefix=chore(repo): [nx migration] '`,
+      ],
+      ['dollar sign', 'pre$fix', `'pre$fix'`],
+      ['backtick', 'pre`fix', `'pre\`fix'`],
+      ['embedded single quote', "it's", `'it'\\''s'`],
+      ['embedded double quote', 'say "hi"', `'say "hi"'`],
+    ])('quotes %s: %j', (_, value, expected) => {
+      expect(quoteShellArg(value)).toBe(expected);
+    });
+  });
+
+  describe('on Windows', () => {
+    beforeEach(() => setPlatform('win32'));
+
+    it.each([
+      [
+        'spaces and parentheses',
+        '--commit-prefix=chore(repo): [nx migration] ',
+        `"--commit-prefix=chore(repo): [nx migration] "`,
+      ],
+      ['embedded double quote', 'say "hi"', `"say \\"hi\\""`],
+      ['backslashes before a double quote', 'a\\"b', `"a\\\\\\"b"`],
+      ['trailing backslash', 'C:\\dir\\', `"C:\\dir\\\\"`],
+    ])('quotes %s: %j', (_, value, expected) => {
+      expect(quoteShellArg(value)).toBe(expected);
+    });
   });
 });

--- a/packages/nx/src/utils/shell-quoting.spec.ts
+++ b/packages/nx/src/utils/shell-quoting.spec.ts
@@ -1,4 +1,4 @@
-import { needsShellQuoting } from './shell-quoting';
+import { needsShellQuoting, quoteShellArg } from './shell-quoting';
 
 describe('needsShellQuoting', () => {
   it.each([
@@ -39,5 +39,64 @@ describe('needsShellQuoting', () => {
     ['empty string', ''],
   ])('returns false for %s: %j', (_, value) => {
     expect(needsShellQuoting(value)).toBe(false);
+  });
+});
+
+describe('quoteShellArg', () => {
+  const originalPlatform = process.platform;
+
+  const setPlatform = (platform: NodeJS.Platform) =>
+    Object.defineProperty(process, 'platform', { value: platform });
+
+  afterEach(() => {
+    setPlatform(originalPlatform);
+  });
+
+  it.each([
+    ['version', '23.1.0-beta.6'],
+    ['flag', '--create-commits'],
+    ['flag with plain value', '--run-migrations=migrations.json'],
+  ])('leaves %s unquoted: %j', (_, value) => {
+    setPlatform('linux');
+    expect(quoteShellArg(value)).toBe(value);
+    setPlatform('win32');
+    expect(quoteShellArg(value)).toBe(value);
+  });
+
+  describe('on POSIX', () => {
+    beforeEach(() => setPlatform('linux'));
+
+    it.each([
+      [
+        'spaces and parentheses',
+        '--commit-prefix=chore(repo): [nx migration] ',
+        `'--commit-prefix=chore(repo): [nx migration] '`,
+      ],
+      ['dollar sign', 'pre$fix', `'pre$fix'`],
+      ['backtick', 'pre`fix', `'pre\`fix'`],
+      ['embedded single quote', "it's", `'it'\\''s'`],
+      ['embedded double quote', 'say "hi"', `'say "hi"'`],
+      ['empty string', '', `''`],
+    ])('quotes %s: %j', (_, value, expected) => {
+      expect(quoteShellArg(value)).toBe(expected);
+    });
+  });
+
+  describe('on Windows', () => {
+    beforeEach(() => setPlatform('win32'));
+
+    it.each([
+      [
+        'spaces and parentheses',
+        '--commit-prefix=chore(repo): [nx migration] ',
+        `"--commit-prefix=chore(repo): [nx migration] "`,
+      ],
+      ['embedded double quote', 'say "hi"', `"say \\"hi\\""`],
+      ['backslashes before a double quote', 'a\\"b', `"a\\\\\\"b"`],
+      ['trailing backslash', 'C:\\dir\\', `"C:\\dir\\\\"`],
+      ['empty string', '', `""`],
+    ])('quotes %s: %j', (_, value, expected) => {
+      expect(quoteShellArg(value)).toBe(expected);
+    });
   });
 });

--- a/packages/nx/src/utils/shell-quoting.spec.ts
+++ b/packages/nx/src/utils/shell-quoting.spec.ts
@@ -76,6 +76,7 @@ describe('quoteShellArg', () => {
       ['backtick', 'pre`fix', `'pre\`fix'`],
       ['embedded single quote', "it's", `'it'\\''s'`],
       ['embedded double quote', 'say "hi"', `'say "hi"'`],
+      ['empty string', '', `''`],
     ])('quotes %s: %j', (_, value, expected) => {
       expect(quoteShellArg(value)).toBe(expected);
     });
@@ -93,6 +94,7 @@ describe('quoteShellArg', () => {
       ['embedded double quote', 'say "hi"', `"say \\"hi\\""`],
       ['backslashes before a double quote', 'a\\"b', `"a\\\\\\"b"`],
       ['trailing backslash', 'C:\\dir\\', `"C:\\dir\\\\"`],
+      ['empty string', '', `""`],
     ])('quotes %s: %j', (_, value, expected) => {
       expect(quoteShellArg(value)).toBe(expected);
     });

--- a/packages/nx/src/utils/shell-quoting.spec.ts
+++ b/packages/nx/src/utils/shell-quoting.spec.ts
@@ -94,9 +94,19 @@ describe('quoteShellArg', () => {
       ['embedded double quote', 'say "hi"', `"say \\"hi\\""`],
       ['backslashes before a double quote', 'a\\"b', `"a\\\\\\"b"`],
       ['trailing backslash', 'C:\\dir\\', `"C:\\dir\\\\"`],
+      ['caret, which cmd.exe would otherwise eat', 'a^b', `"a^b"`],
       ['empty string', '', `""`],
     ])('quotes %s: %j', (_, value, expected) => {
       expect(quoteShellArg(value)).toBe(expected);
     });
+
+    it('leaves a percent sign unquoted, since quoting cannot stop %VAR%', () => {
+      expect(quoteShellArg('%USERNAME%')).toBe('%USERNAME%');
+    });
+  });
+
+  it('treats a caret as ordinary text on POSIX, where it has no meaning', () => {
+    setPlatform('linux');
+    expect(quoteShellArg('a^b')).toBe('a^b');
   });
 });

--- a/packages/nx/src/utils/shell-quoting.spec.ts
+++ b/packages/nx/src/utils/shell-quoting.spec.ts
@@ -91,13 +91,21 @@ describe('quoteShellArg', () => {
         '--commit-prefix=chore(repo): [nx migration] ',
         `"--commit-prefix=chore(repo): [nx migration] "`,
       ],
-      ['embedded double quote', 'say "hi"', `"say \\"hi\\""`],
-      ['backslashes before a double quote', 'a\\"b', `"a\\\\\\"b"`],
       ['trailing backslash', 'C:\\dir\\', `"C:\\dir\\\\"`],
       ['caret, which cmd.exe would otherwise eat', 'a^b', `"a^b"`],
       ['empty string', '', `""`],
     ])('quotes %s: %j', (_, value, expected) => {
       expect(quoteShellArg(value)).toBe(expected);
+    });
+
+    it.each([
+      ['a double quote', 'say "hi"'],
+      ['backslashes before a double quote', 'a\\"b'],
+      ['a double quote ahead of a command separator', 'x"&whoami&"y'],
+    ])('refuses %s: %j', (_, value) => {
+      expect(() => quoteShellArg(value)).toThrow(
+        'would end the quoting and leave the rest of the argument to be read as commands'
+      );
     });
 
     it('leaves a percent sign unquoted, since quoting cannot stop %VAR%', () => {

--- a/packages/nx/src/utils/shell-quoting.ts
+++ b/packages/nx/src/utils/shell-quoting.ts
@@ -39,3 +39,21 @@ export function isAlreadyQuoted(str: string): boolean {
       (str[0] === '"' && str[str.length - 1] === '"'))
   );
 }
+
+/**
+ * Quote a string so it survives being interpolated into a shell command line
+ * as a single argument, preserving its content exactly.
+ *
+ * On POSIX shells the argument is wrapped in single quotes (which suppress
+ * all interpolation), escaping embedded single quotes. On Windows it is
+ * wrapped in double quotes following the MSVCRT argv parsing rules
+ * (backslashes are only special when they precede a double quote).
+ */
+export function quoteShellArg(arg: string): string {
+  if (!needsShellQuoting(arg)) {
+    return arg;
+  }
+  return process.platform === 'win32'
+    ? `"${arg.replace(/(\\*)"/g, '$1$1\\"').replace(/(\\+)$/, '$1$1')}"`
+    : `'${arg.replace(/'/g, `'\\''`)}'`;
+}

--- a/packages/nx/src/utils/shell-quoting.ts
+++ b/packages/nx/src/utils/shell-quoting.ts
@@ -42,14 +42,21 @@ export function isAlreadyQuoted(str: string): boolean {
 
 /**
  * Quote a string so it survives being interpolated into a shell command line
- * as a single argument, preserving its content exactly.
+ * as a single argument. Strings without shell metacharacters pass through
+ * unquoted.
  *
- * On POSIX shells the argument is wrapped in single quotes (which suppress
- * all interpolation), escaping embedded single quotes. On Windows it is
- * wrapped in double quotes following the MSVCRT argv parsing rules
- * (backslashes are only special when they precede a double quote).
+ * On POSIX shells quoting preserves the content exactly: the argument is
+ * wrapped in single quotes (which suppress all interpolation), escaping
+ * embedded single quotes. On Windows it is wrapped in double quotes
+ * following the MSVCRT argv parsing rules (backslashes are only special
+ * when they precede a double quote); cmd.exe-level metacharacters (`%`, `^`)
+ * are not escaped.
  */
 export function quoteShellArg(arg: string): string {
+  if (arg === '') {
+    // an unquoted empty string would vanish when joined into a command line
+    return process.platform === 'win32' ? '""' : "''";
+  }
   if (!needsShellQuoting(arg)) {
     return arg;
   }

--- a/packages/nx/src/utils/shell-quoting.ts
+++ b/packages/nx/src/utils/shell-quoting.ts
@@ -39,3 +39,28 @@ export function isAlreadyQuoted(str: string): boolean {
       (str[0] === '"' && str[str.length - 1] === '"'))
   );
 }
+
+/**
+ * Quote a string so it survives being interpolated into a shell command line
+ * as a single argument. Strings without shell metacharacters pass through
+ * unquoted.
+ *
+ * On POSIX shells quoting preserves the content exactly: the argument is
+ * wrapped in single quotes (which suppress all interpolation), escaping
+ * embedded single quotes. On Windows it is wrapped in double quotes
+ * following the MSVCRT argv parsing rules (backslashes are only special
+ * when they precede a double quote); cmd.exe-level metacharacters (`%`, `^`)
+ * are not escaped.
+ */
+export function quoteShellArg(arg: string): string {
+  if (arg === '') {
+    // an unquoted empty string would vanish when joined into a command line
+    return process.platform === 'win32' ? '""' : "''";
+  }
+  if (!needsShellQuoting(arg)) {
+    return arg;
+  }
+  return process.platform === 'win32'
+    ? `"${arg.replace(/(\\*)"/g, '$1$1\\"').replace(/(\\+)$/, '$1$1')}"`
+    : `'${arg.replace(/'/g, `'\\''`)}'`;
+}

--- a/packages/nx/src/utils/shell-quoting.ts
+++ b/packages/nx/src/utils/shell-quoting.ts
@@ -47,20 +47,24 @@ export function isAlreadyQuoted(str: string): boolean {
  *
  * On POSIX shells quoting preserves the content exactly: the argument is
  * wrapped in single quotes (which suppress all interpolation), escaping
- * embedded single quotes. On Windows it is wrapped in double quotes
- * following the MSVCRT argv parsing rules (backslashes are only special
- * when they precede a double quote); cmd.exe-level metacharacters (`%`, `^`)
- * are not escaped.
+ * embedded single quotes. On Windows it is wrapped in double quotes following
+ * the MSVCRT argv parsing rules (backslashes are only special when they precede
+ * a double quote), which also stops cmd.exe from reading a `^` as its escape
+ * character. `%` is the one character left uncovered, since cmd.exe expands
+ * %VAR% inside double quotes too.
  */
 export function quoteShellArg(arg: string): string {
+  const isWindows = process.platform === 'win32';
   if (arg === '') {
     // an unquoted empty string would vanish when joined into a command line
-    return process.platform === 'win32' ? '""' : "''";
+    return isWindows ? '""' : "''";
   }
-  if (!needsShellQuoting(arg)) {
+  // `^` is cmd.exe syntax rather than shell syntax, so it earns quoting only
+  // where cmd.exe parses the command line.
+  if (!needsShellQuoting(arg) && !(isWindows && arg.includes('^'))) {
     return arg;
   }
-  return process.platform === 'win32'
+  return isWindows
     ? `"${arg.replace(/(\\*)"/g, '$1$1\\"').replace(/(\\+)$/, '$1$1')}"`
     : `'${arg.replace(/'/g, `'\\''`)}'`;
 }

--- a/packages/nx/src/utils/shell-quoting.ts
+++ b/packages/nx/src/utils/shell-quoting.ts
@@ -42,19 +42,25 @@ export function isAlreadyQuoted(str: string): boolean {
 
 /**
  * Quote a string so it survives being interpolated into a shell command line
- * as a single argument. Strings without shell metacharacters pass through
- * unquoted.
+ * as a single argument.
  *
- * On POSIX shells quoting preserves the content exactly: the argument is
- * wrapped in single quotes (which suppress all interpolation), escaping
- * embedded single quotes. On Windows it is wrapped in double quotes following
- * the MSVCRT argv parsing rules (backslashes are only special when they precede
- * a double quote), which also stops cmd.exe from reading a `^` as its escape
- * character. `%` is the one character left uncovered, since cmd.exe expands
- * %VAR% inside double quotes too.
+ * On Windows the safety boundary is one unbroken double-quoted run: it keeps
+ * `^`, `&`, `|`, `<` and `>` literal through cmd.exe's parse and a `.cmd`
+ * shim's re-parse of `%*`, but not `%`, which cmd.exe expands inside double
+ * quotes too.
+ *
+ * @throws on Windows when the argument contains a double quote, which ends that
+ * run, since cmd.exe recognizes no backslash escape. Carrying one means
+ * caret-escaping every metacharacter instead, doubled for a `.cmd` shim, which
+ * this path does not implement.
  */
 export function quoteShellArg(arg: string): string {
   const isWindows = process.platform === 'win32';
+  if (isWindows && arg.includes('"')) {
+    throw new Error(
+      `Cannot safely pass ${arg} to cmd.exe as a single argument: a double quote inside it would end the quoting and leave the rest of the argument to be read as commands. Remove the double quote and run the command again.`
+    );
+  }
   if (arg === '') {
     // an unquoted empty string would vanish when joined into a command line
     return isWindows ? '""' : "''";
@@ -65,6 +71,8 @@ export function quoteShellArg(arg: string): string {
     return arg;
   }
   return isWindows
-    ? `"${arg.replace(/(\\*)"/g, '$1$1\\"').replace(/(\\+)$/, '$1$1')}"`
+    ? // MSVCRT reads the backslashes that precede the closing quote as escapes,
+      // so they have to be doubled to survive as themselves.
+      `"${arg.replace(/(\\+)$/, '$1$1')}"`
     : `'${arg.replace(/'/g, `'\\''`)}'`;
 }


### PR DESCRIPTION
## Current Behavior

`nx migrate --run-migrations` re-spawns itself as `nx _migrate` by joining the raw forwarded argv (`process.argv.slice(3).join(' ')`) into a shell command string, in both re-spawn paths (the temp-install CLI and the `NX_MIGRATE_USE_LOCAL` local path). Any forwarded argument containing shell metacharacters is re-split or crashes the shell:

```
nx migrate --run-migrations --create-commits --commit-prefix="chore(repo): [nx migration] "
/bin/sh: 1: Syntax error: "(" unexpected
```

The same argument list works when invoking `nx _migrate` directly, which is the only workaround today. This bit 3 of 5 repos in a coordinated migration run where a scoped commit prefix (required by commitlint) contains parentheses and spaces.

Quoting alone does not fix Windows, where every route from a package manager to nx runs through cmd.exe: `%VAR%` expands inside double quotes, and a bare `^` is eaten as the escape character. The e2e case covering `--commit-prefix` was skipped on Windows for exactly that reason.

## Expected Behavior

The re-spawn no longer builds a command string. `runNxArgvSync` locates the nx to run and spawns `process.execPath` with an argv array, so nothing parses the arguments in between and each one reaches the child byte for byte. Both re-spawn routes go through it: the workspace's own nx under `NX_MIGRATE_USE_LOCAL`, and on the default route the CLI that `nx migrate` installs into a temp dir. The e2e case covering that prefix drops its `isNotWindows` guard, though the Windows CI matrix is commented out today, so nothing exercises it on that platform yet.

`getNxBin` decides what to spawn for the workspace routes, reading rather than resolving: it ascends to the nearest `node_modules/nx` and takes the entry point its `bin` field names, which is the file a package manager links into `node_modules/.bin`. The ascent is npx-shaped, so a workspace with no nx of its own can be handed an ancestor's that pnpm or yarn would decline to run. Reading the manifest is what keeps the temp installation working too: nx moved its entry point from `bin/nx.js` to `dist/bin/nx.js` in 22.7.0, so a fixed layout can only ever match one side of that. That installation is read from its own directory alone, since it declares nx itself and an nx above the temp directory is one nothing asked for. A resolver is the wrong tool here, as the comment on `readLocalNxVersion` already noted. `require.resolve` answers from `NODE_PATH` once its explicit paths miss, and `nxCliPath` points `NODE_PATH` at the temp installation before spawning it; it also answers through Node's package self-reference, which returns the running nx whatever `paths` it is given. Either one lets the temp installation hand off to itself, which under `--run-migrations` re-enters the same hand-off and respawns without end.

`getNxBin` returns null for a Yarn PnP workspace and for a `.nx/installation` workspace, where the `./nx` wrapper has to run so it can re-sync the installation against `nx.json`'s `installation.version`. The caller then falls back to whatever `getRunNxBaseCommand` names, the package manager or that wrapper, with each argument quoted.

On that fallback path, arguments containing `^` are now quoted on Windows as well. The character is deliberately not added to `SHELL_META_CHARS`, which is shared with `serializeOverridesIntoCommandLine`, where quoting every `^1.2.3` version range would change unrelated task output.

> [!NOTE]
> On Windows the fallback path does not carry two kinds of argument. One containing a double quote is refused: the quoting rests on an unbroken double-quoted run, and an embedded quote ends it, since cmd.exe recognizes no backslash escape. Carrying one would mean caret-escaping every metacharacter instead, doubled again for a `.cmd` shim, which is not worth taking on for a path with no Windows coverage to check it against. A `%VAR%` is still expanded, since cmd.exe expands it inside double quotes too, and suppressing that needs the `%%cd:~,%` trick, which only works when the caller owns the whole `cmd.exe /e:ON /c "..."` line, and `execSync` does not. Both are confined to a Yarn PnP or `.nx/installation` workspace on Windows, since every other workspace takes the argv path.

Unit tests cover the argv spawn and its exit-code contract, `getNxBin`'s lookup and each of its null cases, the shell fallback taken when no nx resolves, the refusal of a Windows argument carrying a double quote, and the quoting on both platforms including the exact commit prefix above. A regression test pins the temp hand-off against reaching for an nx above its own directory. The POSIX quoting was also checked by round-tripping the helper's output through a real `/bin/sh`.

## Related Issue(s)

No existing issue — discovered during the multi-repo migration to 23.1.0-beta.6.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/nxc-4662-6d5e3016)
<!-- polygraph-session-end -->


