### PR TITLE
fix(bundling): prevent TS6059 when an app imports a workspace lib from source

### DIFF
--- a/e2e/rspack/tests/rspack.legacy.spec.ts
+++ b/e2e/rspack/tests/rspack.legacy.spec.ts
@@ -1,3 +1,4 @@
+import { names } from '@nx/devkit';
 import {
   cleanupProject,
   newProject,
@@ -114,6 +115,50 @@ describe('rspack e2e legacy', () => {
 
     const result = runCLI(`build ${appName}`);
 
+    expect(result).toContain(
+      `Successfully ran target build for project ${appName}`
+    );
+  });
+
+  it('should build without a TS6059 rootDir error when importing a lib from source', () => {
+    // Reproduces nx#35017: on TS 6 an app with a narrow rootDir that imports a
+    // workspace lib from source failed the rspack build's type-check with TS6059.
+    const appName = uniq('app');
+    const libName = uniq('lib');
+
+    runCLI(
+      `generate @nx/react:app --directory=apps/${appName} --bundler=rspack --e2eTestRunner=none --style=css --no-interactive`,
+      { env: { NX_ADD_PLUGINS: 'false' } }
+    );
+    runCLI(
+      `generate @nx/react:lib --directory=libs/${libName} --bundler=none --unitTestRunner=none --importPath=@acme/rspack-from-source --no-interactive`,
+      { env: { NX_ADD_PLUGINS: 'false' } }
+    );
+
+    // Narrow the app's rootDir so the from-source lib falls outside it (the
+    // configuration reported in the issue).
+    updateJson(`apps/${appName}/tsconfig.app.json`, (json) => {
+      json.compilerOptions ??= {};
+      json.compilerOptions.rootDir = 'src';
+      return json;
+    });
+
+    const libCmp = names(libName).className;
+    updateFile(
+      `apps/${appName}/src/app/app.tsx`,
+      `import { ${libCmp} } from '@acme/rspack-from-source';
+
+export function App() {
+  return <${libCmp} />;
+}
+
+export default App;
+`
+    );
+
+    const result = runCLI(`build ${appName}`);
+
+    expect(result).not.toContain('TS6059');
     expect(result).toContain(
       `Successfully ran target build for project ${appName}`
     );

--- a/e2e/vite/src/vite-legacy.test.ts
+++ b/e2e/vite/src/vite-legacy.test.ts
@@ -385,6 +385,57 @@ export default App;
     });
   });
 
+  describe('type-check app importing a workspace lib from source', () => {
+    // Reproduces nx#35017: on TS 6 an app with a narrow rootDir that imports a
+    // workspace lib from source failed the vite build's type-check with TS6059.
+    let app: string;
+
+    beforeAll(() => {
+      proj = newProject({ packages: ['@nx/react', '@nx/vite'] });
+      app = uniq('app');
+      const lib = uniq('lib');
+
+      runCLI(
+        `generate @nx/react:app ${app} --bundler=vite --unitTestRunner=none --no-interactive --directory=${app}`
+      );
+      runCLI(
+        `generate @nx/react:lib ${lib} --unitTestRunner=none --bundler=none --importPath="@acme/from-source" --no-interactive --directory=${lib}`
+      );
+
+      // Narrow the app's rootDir so the from-source lib falls outside it (the
+      // configuration reported in the issue).
+      updateJson(`${app}/tsconfig.app.json`, (json) => {
+        json.compilerOptions ??= {};
+        json.compilerOptions.rootDir = 'src';
+        return json;
+      });
+
+      const libCmp = names(lib).className;
+      updateFile(
+        `${app}/src/app/app.tsx`,
+        `import { ${libCmp} } from '@acme/from-source';
+
+export function App() {
+  return <${libCmp} />;
+}
+
+export default App;
+`
+      );
+    });
+
+    afterAll(() => {
+      cleanupProject();
+    });
+
+    it('should build without a TS6059 rootDir error', () => {
+      const result = runCLI(`build ${app} --buildLibsFromSource=true`);
+
+      expect(result).not.toContain('TS6059');
+      expect(result).toContain('Successfully ran target build for project');
+    });
+  });
+
   describe('should be able to create libs that use vitest', () => {
     describe('using default project configuration', () => {
       const lib = uniq('my-default-lib');

--- a/packages/rspack/src/executors/rspack/rspack.impl.spec.ts
+++ b/packages/rspack/src/executors/rspack/rspack.impl.spec.ts
@@ -1,0 +1,40 @@
+import { ExecutorContext } from '@nx/devkit';
+import { runTypeCheck } from '@nx/js';
+import { executeTypeCheck } from './rspack.impl';
+import { RspackExecutorSchema } from './schema';
+
+jest.mock('@nx/js', () => ({
+  ...jest.requireActual('@nx/js'),
+  runTypeCheck: jest.fn().mockResolvedValue({ errors: [], warnings: [] }),
+  printDiagnostics: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../../utils/create-compiler', () => ({
+  createCompiler: jest.fn(),
+  isMultiCompiler: jest.fn(),
+}));
+
+describe('rspack executeTypeCheck', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  // TS 6 defaults rootDir to the tsconfig dir, so a workspace lib resolved from
+  // source (outside the project) fails the type-check with TS6059. The check
+  // must widen rootDir to the workspace root.
+  it('type-checks with rootDir set to the workspace root', async () => {
+    const context = {
+      root: '/root',
+      projectName: 'my-app',
+      projectGraph: {
+        nodes: { 'my-app': { data: { root: 'apps/my-app' } } },
+      },
+    } as unknown as ExecutorContext;
+
+    await executeTypeCheck(
+      { tsConfig: 'apps/my-app/tsconfig.app.json' } as RspackExecutorSchema,
+      context
+    );
+
+    expect(runTypeCheck).toHaveBeenCalledWith(
+      expect.objectContaining({ rootDir: '/root' })
+    );
+  });
+});

--- a/packages/rspack/src/executors/rspack/rspack.impl.ts
+++ b/packages/rspack/src/executors/rspack/rspack.impl.ts
@@ -144,7 +144,7 @@ function registerCleanupCallback(callback: () => void) {
   process.on('exit', wrapped);
 }
 
-async function executeTypeCheck(
+export async function executeTypeCheck(
   options: RspackExecutorSchema,
   context: ExecutorContext
 ) {
@@ -154,6 +154,10 @@ async function executeTypeCheck(
     workspaceRoot: resolve(projectConfiguration.root),
     tsConfigPath: options.tsConfig,
     mode: 'noEmit',
+    // TS 6 defaults rootDir to the tsconfig dir, so from-source workspace
+    // libs (outside the project) trip TS6059. rootDir is emit-only and this
+    // is noEmit, so widen it to the workspace root to clear the false error.
+    rootDir: context.root,
   });
 
   await printDiagnostics(result.errors, result.warnings);

--- a/packages/rspack/src/plugins/utils/apply-base-config.spec.ts
+++ b/packages/rspack/src/plugins/utils/apply-base-config.spec.ts
@@ -212,3 +212,68 @@ describe('apply-base-config libraryTarget handling', () => {
     });
   });
 });
+
+describe('apply-base-config ts-checker rootDir (TS6059 prevention)', () => {
+  const capturedPluginConfigs: any[] = [];
+
+  beforeEach(() => {
+    capturedPluginConfigs.length = 0;
+    jest.resetModules();
+    global.NX_GRAPH_CREATION = false;
+    jest.doMock('ts-checker-rspack-plugin', () => ({
+      TsCheckerRspackPlugin: class {
+        constructor(pluginConfig: any) {
+          capturedPluginConfigs.push(pluginConfig);
+        }
+        apply() {}
+      },
+    }));
+  });
+
+  afterEach(() => {
+    delete global.NX_GRAPH_CREATION;
+    jest.resetModules();
+  });
+
+  const baseOptions = {
+    root: '/test',
+    projectRoot: 'apps/test',
+    target: 'web',
+    tsConfig: 'apps/test/tsconfig.app.json',
+  } as NormalizedNxAppRspackPluginOptions;
+
+  it('widens the ts-checker rootDir to the workspace root in a classic setup', async () => {
+    jest.doMock('@nx/js/internal', () => ({
+      ...jest.requireActual('@nx/js/internal'),
+      isUsingTsSolutionSetup: () => false,
+    }));
+
+    const { applyBaseConfig } = await import('./apply-base-config');
+    applyBaseConfig({ ...baseOptions }, {});
+
+    expect(capturedPluginConfigs).toHaveLength(1);
+    expect(
+      capturedPluginConfigs[0].typescript.configOverwrite.compilerOptions
+        .rootDir
+    ).toBe('/test');
+  });
+
+  it('does not override rootDir when using the TS solution setup', async () => {
+    jest.doMock('@nx/js/internal', () => ({
+      ...jest.requireActual('@nx/js/internal'),
+      isUsingTsSolutionSetup: () => true,
+    }));
+    // The TS solution setup only type-checks during serve, so force serve mode
+    // to make the plugin be installed at all.
+    jest.doMock('../../utils/is-serve-mode', () => ({
+      isServeMode: () => true,
+    }));
+
+    const { applyBaseConfig } = await import('./apply-base-config');
+    applyBaseConfig({ ...baseOptions }, {});
+
+    expect(capturedPluginConfigs).toHaveLength(1);
+    expect(capturedPluginConfigs[0].typescript.configOverwrite).toBeUndefined();
+    expect(capturedPluginConfigs[0].typescript.build).toBe(true);
+  });
+});

--- a/packages/rspack/src/plugins/utils/apply-base-config.ts
+++ b/packages/rspack/src/plugins/utils/apply-base-config.ts
@@ -341,6 +341,13 @@ function applyNxDependentConfig(
     if (isUsingTsSolution) {
       pluginConfig.typescript.build = true;
       pluginConfig.typescript.mode = 'readonly';
+    } else {
+      // TS 6 defaults rootDir to the tsconfig dir, so from-source workspace
+      // libs (outside a narrow rootDir) trip TS6059. The checker runs read-only
+      // here, so widen rootDir to the workspace root to clear the false error.
+      pluginConfig.typescript.configOverwrite = {
+        compilerOptions: { rootDir: options.root },
+      };
     }
 
     plugins.push(new TsCheckerRspackPlugin(pluginConfig));

--- a/packages/vite/src/utils/executor-utils.spec.ts
+++ b/packages/vite/src/utils/executor-utils.spec.ts
@@ -1,0 +1,29 @@
+import { validateTypes } from './executor-utils';
+import { runTypeCheck } from '@nx/js';
+
+jest.mock('@nx/js', () => ({
+  runTypeCheck: jest.fn().mockResolvedValue({ errors: [], warnings: [] }),
+  printDiagnostics: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('@nx/js/internal', () => ({
+  calculateProjectBuildableDependencies: jest.fn(),
+  createTmpTsConfig: jest.fn(),
+}));
+
+describe('validateTypes', () => {
+  afterEach(() => jest.clearAllMocks());
+
+  // TS 6 defaults rootDir to the tsconfig dir, so a workspace lib resolved from
+  // source (outside the project) fails the type-check with TS6059. The check
+  // must widen rootDir to the workspace root.
+  it('type-checks with rootDir set to the workspace root', async () => {
+    await validateTypes({
+      workspaceRoot: '/root',
+      tsconfig: 'apps/my-app/tsconfig.app.json',
+    });
+
+    expect(runTypeCheck).toHaveBeenCalledWith(
+      expect.objectContaining({ rootDir: '/root' })
+    );
+  });
+});

--- a/packages/vite/src/utils/executor-utils.ts
+++ b/packages/vite/src/utils/executor-utils.ts
@@ -20,6 +20,10 @@ export async function validateTypes(opts: {
         ? opts.tsconfig
         : join(opts.workspaceRoot, opts.tsconfig),
       mode: 'noEmit',
+      // TS 6 defaults rootDir to the tsconfig dir, so from-source workspace
+      // libs (outside the project) trip TS6059. rootDir is emit-only and this
+      // is noEmit, so widen it to the workspace root to clear the false error.
+      rootDir: opts.workspaceRoot,
     });
 
     await printDiagnostics(result.errors, result.warnings);


### PR DESCRIPTION
## Current Behavior

On TypeScript 6, building an app with `@nx/vite` or `@nx/rspack` fails type-checking with `TS6059` ("File ... is not under 'rootDir' ...") when the app has a narrow `rootDir` (for example `"src"`) and imports a workspace library from source. TypeScript 6 changed the default `rootDir` to the tsconfig's own directory, so the library's source files fall outside the app's `rootDir` even though `rootDir` only controls emit layout, which vite and rspack handle themselves.

## Expected Behavior

The build succeeds. The `@nx/vite` and `@nx/rspack` type-checks now widen `rootDir` to the workspace root, so a workspace library imported from source no longer trips `TS6059`. This matches what `@nx/esbuild` already does.

## Related Issue(s)

Related #35017

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/gh-35017-c68ef038)
<!-- polygraph-session-end -->
