### PR TITLE
chore(repo): measure DTE agent memory on 23.1.0-beta.6

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -1,5 +1,6 @@
 {
   "$schema": "packages/nx/schemas/nx-schema.json",
+  "bust": "mem-bench-23.1.0-beta.6",
   "namedInputs": {
     "default": ["{projectRoot}/**/*", "sharedGlobals"],
     "production": [


### PR DESCRIPTION
CI-only benchmark run to capture per-agent memory metrics. nx.json is cache-busted to force full task execution. Do not merge.