### PR TITLE
fix(dotnet): pass configuration parameter for dotnet test and clean

### DIFF
--- a/packages/dotnet/analyzer/Utilities/TargetBuilder.Clean.cs
+++ b/packages/dotnet/analyzer/Utilities/TargetBuilder.Clean.cs
@@ -16,6 +16,17 @@ public static partial class TargetBuilder
             {
                 Cwd = "{projectRoot}"
             },
+            Configurations = new Dictionary<string, TargetConfiguration>
+            {
+                ["debug"] = new TargetConfiguration
+                {
+                    Args = [ "--configuration", "Debug"]
+                },
+                ["release"] = new TargetConfiguration
+                {
+                    Args = [ "--configuration", "Release"]
+                }
+            },
             Cache = false,
             Metadata = new TargetMetadata
             {

--- a/packages/dotnet/analyzer/Utilities/TargetBuilder.Test.cs
+++ b/packages/dotnet/analyzer/Utilities/TargetBuilder.Test.cs
@@ -35,6 +35,17 @@ public static partial class TargetBuilder
                 Cwd = "{projectRoot}",
                 Args = [.. defaultFlags]
             },
+            Configurations = new Dictionary<string, TargetConfiguration>
+            {
+                ["debug"] = new TargetConfiguration
+                {
+                    Args = [.. defaultFlags, "--configuration", "Debug"]
+                },
+                ["release"] = new TargetConfiguration
+                {
+                    Args = [.. defaultFlags, "--configuration", "Release"]
+                }
+            },
             DependsOn = [options.BuildTargetName],
             Cache = true,
             Inputs =


### PR DESCRIPTION
Passing the configuration parameter for `dotnet test` allows `nx test App.Tests -c release` without having already run `nx build App.Tests -c debug`.

Without the `--configuration Release` parameter the tests will try to run with the default configuration, which is Debug. But the "build" dependency is built as Release, so the tests will fail to run.

It's common to run .NET tests with Release configuration in CI.

`dotnet clean` is also configuration dependent. Currently it will only clean the Debug output.

## Current Behavior

Clean will remove Debug configuration output:
```
pnpx nx clean MsbuildAnalyzer.Tests
```

Run tests with Release configuration:
```
pnpx nx test MsbuildAnalyzer.Tests -c release --skip-nx-cache
```

Tests fails to run:
```
> nx run MsbuildAnalyzer:build:dotnet:release

> dotnet build --no-restore --no-dependencies --configuration Release

  MsbuildAnalyzer succeeded (0.2s) → bin/Release/MsbuildAnalyzer.dll

Build succeeded in 0.4s

> nx run MsbuildAnalyzer.Tests:build:dotnet:release

> dotnet build --no-restore --no-dependencies --configuration Release

  MsbuildAnalyzer.Tests succeeded (1.4s) → bin/Release/net8.0/MsbuildAnalyzer.Tests.dll

Build succeeded in 1.7s

> nx run MsbuildAnalyzer.Tests:test-native

> dotnet test --no-build --no-restore

The argument /workspaces/nx/packages/dotnet/analyzer.Tests/bin/Debug/net8.0/MsbuildAnalyzer.Tests.dll is invalid. Please use the /help option to check the list of valid arguments.
  MsbuildAnalyzer.Tests test failed with 1 error(s) (0.1s)
    /root/.local/share/mise/dotnet-root/sdk/9.0.315/Microsoft.TestPlatform.targets(48,5): error MSB6006: "dotnet" exited with code 1.

Build failed with 1 error(s) in 0.2s
```

## Expected Behavior
```
pnpx nx clean MsbuildAnalyzer.Tests -c debug 
pnpx nx clean MsbuildAnalyzer.Tests -c release
pnpx nx test MsbuildAnalyzer.Tests -c release --skip-nx-cache
```

```
> nx run MsbuildAnalyzer:build:dotnet:release

> dotnet build --no-restore --no-dependencies --configuration Release

  MsbuildAnalyzer succeeded (1.5s) → bin/Release/MsbuildAnalyzer.dll

Build succeeded in 1.7s

> nx run MsbuildAnalyzer.Tests:build:dotnet:release

> dotnet build --no-restore --no-dependencies --configuration Release

  MsbuildAnalyzer.Tests succeeded (1.5s) → bin/Release/net8.0/MsbuildAnalyzer.Tests.dll

Build succeeded in 1.7s

> nx run MsbuildAnalyzer.Tests:test-native:release

> dotnet test --no-build --no-restore --configuration Release

[xUnit.net 00:00:00.00] xUnit.net VSTest Adapter v2.8.2+699d445a1a (64-bit .NET 9.0.17)
[xUnit.net 00:00:00.03]   Discovering: MsbuildAnalyzer.Tests
[xUnit.net 00:00:00.05]   Discovered:  MsbuildAnalyzer.Tests
[xUnit.net 00:00:00.05]   Starting:    MsbuildAnalyzer.Tests
[xUnit.net 00:00:00.11]   Finished:    MsbuildAnalyzer.Tests
  MsbuildAnalyzer.Tests test succeeded (0.5s)

Test summary: total: 29, failed: 0, succeeded: 29, skipped: 0, duration: 0.4s
Build succeeded in 0.6s

> nx run MsbuildAnalyzer.Tests:test


————————————
 NX   Successfully ran target test for project MsbuildAnalyzer.Tests and 3 tasks it depends on (5s)
```

## Related Issue(s)
No