### PR TITLE
fix(js): preserve esModuleInterop default when migrating to TypeScript 6

### DIFF
--- a/packages/js/migrations.json
+++ b/packages/js/migrations.json
@@ -31,7 +31,7 @@
     },
     "23-1-0-add-ignore-deprecations-for-ts6": {
       "version": "23.1.0-beta.0",
-      "description": "Adds `\"ignoreDeprecations\": \"6.0\"` to tsconfig files whose compilerOptions (or ts-node.compilerOptions) directly carry a TypeScript 6 deprecated option value (e.g. moduleResolution node/node10/classic, baseUrl, target es5, esModuleInterop false, outFile, module amd/umd/system/none, alwaysStrict false, allowSyntheticDefaultImports false, downlevelIteration set). Also pins `\"strict\": false`, `\"noUncheckedSideEffectImports\": false`, and `\"types\": [\"*\"]` in chain-root tsconfigs (no \"extends\") that lack each key, preserving pre-TS6 behavior where these defaults were stricter or, for `types`, stopped auto-loading all @types packages.",
+      "description": "Adds `\"ignoreDeprecations\": \"6.0\"` to tsconfig files whose compilerOptions (or ts-node.compilerOptions) directly carry a TypeScript 6 deprecated option value (e.g. moduleResolution node/node10/classic, baseUrl, target es5, esModuleInterop false, outFile, module amd/umd/system/none, alwaysStrict false, allowSyntheticDefaultImports false, downlevelIteration set). Also pins `\"strict\": false`, `\"noUncheckedSideEffectImports\": false`, `\"types\": [\"*\"]`, and `\"esModuleInterop\": false` in chain-root tsconfigs (no \"extends\") that lack each key, preserving pre-TS6 behavior where these defaults changed; `esModuleInterop` false is itself deprecated (removed in TS7) so it also receives `ignoreDeprecations`, deferring the interop change to the TS7 migration.",
       "requires": {
         "typescript": ">=6.0.0"
       },

--- a/packages/js/src/migrations/update-23-1-0/add-ignore-deprecations-for-ts6.md
+++ b/packages/js/src/migrations/update-23-1-0/add-ignore-deprecations-for-ts6.md
@@ -3,7 +3,7 @@
 TypeScript 6 turns several long-deprecated compiler options into hard errors and flips a few option defaults to stricter values. So that an existing workspace keeps compiling on TypeScript 6 without being migrated to a full TypeScript 6 setup, this migration makes two edits to the `tsconfig*.json` files in the workspace:
 
 - Adds `"ignoreDeprecations": "6.0"` to any `compilerOptions` (or `ts-node.compilerOptions`) block that directly sets a TypeScript 6 deprecated option - for example `moduleResolution` set to `node`/`node10`/`classic`, `baseUrl`, `target` set to `es5`, `esModuleInterop: false`, `outFile`, `module` set to `amd`/`umd`/`system`/`none`, `alwaysStrict: false`, `allowSyntheticDefaultImports: false`, or `downlevelIteration`.
-- Pins `"strict": false`, `"noUncheckedSideEffectImports": false`, and `"types": ["*"]` on every chain-root tsconfig (one without an `extends`) that does not already set them. TypeScript 6 treats an absent `strict` as `true` (it was `false` when unset before), defaults `noUncheckedSideEffectImports` to `true` (which turns a bare side-effect import such as `import './styles.css'` without an ambient module declaration into an error), and no longer auto-loads every `@types` package when `types` is unset the way TypeScript 5 did. The `"*"` wildcard restores that last default. Pinning all three preserves the pre-TypeScript 6 behavior.
+- Pins `"strict": false`, `"noUncheckedSideEffectImports": false`, `"types": ["*"]`, and `"esModuleInterop": false` on every chain-root tsconfig (one without an `extends`) that does not already set them. TypeScript 6 treats an absent `strict` as `true` (it was `false` when unset before), defaults `noUncheckedSideEffectImports` to `true` (which turns a bare side-effect import such as `import './styles.css'` without an ambient module declaration into an error), no longer auto-loads every `@types` package when `types` is unset the way TypeScript 5 did (the `"*"` wildcard restores that last default), and flips `esModuleInterop` from `false` to `true` (so an `import * as x from '<cjs>'` binds a non-callable namespace object and a call or `new` on that import fails at runtime). Pinning all four preserves the pre-TypeScript 6 behavior. Because `esModuleInterop: false` is itself a TypeScript 6 deprecated value, this pin runs before the `ignoreDeprecations` edit above, so the added `false` is silenced in the same run.
 
 Files that use `extends` inherit these settings from their chain root and are left untouched, and pure solution-style tsconfigs (`"files": []` with no `include`) are skipped. The migration only runs when the workspace is on TypeScript 6.
 
@@ -23,16 +23,17 @@ Files that use `extends` inherit these settings from their chain root and are le
 
 ##### After
 
-```json title="tsconfig.json" {6-9}
+```json title="tsconfig.json" {6-10}
 {
   "compilerOptions": {
     "target": "es5",
     "module": "esnext",
     "moduleResolution": "bundler",
-    "ignoreDeprecations": "6.0",
     "strict": false,
     "noUncheckedSideEffectImports": false,
-    "types": ["*"]
+    "types": ["*"],
+    "esModuleInterop": false,
+    "ignoreDeprecations": "6.0"
   }
 }
 ```

--- a/packages/js/src/migrations/update-23-1-0/add-ignore-deprecations-for-ts6.spec.ts
+++ b/packages/js/src/migrations/update-23-1-0/add-ignore-deprecations-for-ts6.spec.ts
@@ -44,10 +44,16 @@ describe('add-ignore-deprecations-for-ts6 migration', () => {
   );
 
   it('skips files with no deprecated options', async () => {
+    // An "extends" file is not a chain root, so the default-preserving pass
+    // leaves it alone (it would otherwise pin the deprecated
+    // "esModuleInterop": false), isolating the deprecation-detection logic.
     tree.write(
-      'tsconfig.json',
+      'tsconfig.app.json',
       JSON.stringify(
-        { compilerOptions: { module: 'esnext', moduleResolution: 'bundler' } },
+        {
+          extends: './tsconfig.json',
+          compilerOptions: { module: 'esnext', moduleResolution: 'bundler' },
+        },
         null,
         2
       )
@@ -55,7 +61,7 @@ describe('add-ignore-deprecations-for-ts6 migration', () => {
 
     await update(tree);
 
-    const json = readJson(tree, 'tsconfig.json');
+    const json = readJson(tree, 'tsconfig.app.json');
     expect(json.compilerOptions.ignoreDeprecations).toBeUndefined();
   });
 
@@ -127,10 +133,13 @@ describe('add-ignore-deprecations-for-ts6 migration', () => {
   });
 
   it('adds ignoreDeprecations to a ts-node.compilerOptions block', async () => {
+    // "extends" keeps the default-preserving pass off the top-level block, so
+    // only the ts-node block's own deprecated value drives ignoreDeprecations.
     tree.write(
-      'tsconfig.json',
+      'tsconfig.app.json',
       JSON.stringify(
         {
+          extends: './tsconfig.json',
           compilerOptions: { module: 'esnext', moduleResolution: 'bundler' },
           'ts-node': { compilerOptions: { moduleResolution: 'node10' } },
         },
@@ -141,7 +150,7 @@ describe('add-ignore-deprecations-for-ts6 migration', () => {
 
     await update(tree);
 
-    const json = readJson(tree, 'tsconfig.json');
+    const json = readJson(tree, 'tsconfig.app.json');
     expect(json.compilerOptions.ignoreDeprecations).toBeUndefined();
     expect(json['ts-node'].compilerOptions.ignoreDeprecations).toBe('6.0');
   });
@@ -212,22 +221,15 @@ describe('add-ignore-deprecations-for-ts6 migration', () => {
   });
 
   it('does not add ignoreDeprecations for alwaysStrict true', async () => {
+    // "extends" file so the default-preserving pass doesn't pin the deprecated
+    // "esModuleInterop": false; only alwaysStrict (true, not deprecated) is here.
     tree.write(
-      'tsconfig.json',
-      JSON.stringify({ compilerOptions: { alwaysStrict: true } }, null, 2)
-    );
-
-    await update(tree);
-
-    const json = readJson(tree, 'tsconfig.json');
-    expect(json.compilerOptions.ignoreDeprecations).toBeUndefined();
-  });
-
-  it('does not add ignoreDeprecations when downlevelIteration is absent', async () => {
-    tree.write(
-      'tsconfig.json',
+      'tsconfig.app.json',
       JSON.stringify(
-        { compilerOptions: { module: 'esnext', moduleResolution: 'bundler' } },
+        {
+          extends: './tsconfig.json',
+          compilerOptions: { alwaysStrict: true },
+        },
         null,
         2
       )
@@ -235,7 +237,28 @@ describe('add-ignore-deprecations-for-ts6 migration', () => {
 
     await update(tree);
 
-    const json = readJson(tree, 'tsconfig.json');
+    const json = readJson(tree, 'tsconfig.app.json');
+    expect(json.compilerOptions.ignoreDeprecations).toBeUndefined();
+  });
+
+  it('does not add ignoreDeprecations when downlevelIteration is absent', async () => {
+    // "extends" file so the default-preserving pass doesn't add its own
+    // deprecated "esModuleInterop": false and confound the assertion.
+    tree.write(
+      'tsconfig.app.json',
+      JSON.stringify(
+        {
+          extends: './tsconfig.json',
+          compilerOptions: { module: 'esnext', moduleResolution: 'bundler' },
+        },
+        null,
+        2
+      )
+    );
+
+    await update(tree);
+
+    const json = readJson(tree, 'tsconfig.app.json');
     expect(json.compilerOptions.ignoreDeprecations).toBeUndefined();
   });
 
@@ -252,6 +275,7 @@ describe('add-ignore-deprecations-for-ts6 migration', () => {
     expect(json.compilerOptions.strict).toBe(false);
     expect(json.compilerOptions.noUncheckedSideEffectImports).toBe(false);
     expect(json.compilerOptions.types).toEqual(['*']);
+    expect(json.compilerOptions.esModuleInterop).toBe(false);
   });
 
   describe('strict-pin pass', () => {
@@ -549,6 +573,64 @@ describe('add-ignore-deprecations-for-ts6 migration', () => {
 
       const json = readJson(tree, 'tsconfig.json');
       expect(json.compilerOptions).toBeUndefined();
+    });
+  });
+
+  describe('esModuleInterop-pin pass', () => {
+    it('pins esModuleInterop false and silences it on a bare chain root', async () => {
+      tree.write(
+        'tsconfig.base.json',
+        JSON.stringify(
+          {
+            compilerOptions: { module: 'esnext', moduleResolution: 'bundler' },
+          },
+          null,
+          2
+        )
+      );
+
+      await update(tree);
+
+      const json = readJson(tree, 'tsconfig.base.json');
+      // TS6's default is true; false preserves the pre-TS6 `import * as <cjs>`
+      // call behavior, and the deprecation pass silences the now-deprecated
+      // false value in the same run.
+      expect(json.compilerOptions.esModuleInterop).toBe(false);
+      expect(json.compilerOptions.ignoreDeprecations).toBe('6.0');
+    });
+
+    it('does not overwrite an explicit esModuleInterop true', async () => {
+      tree.write(
+        'tsconfig.json',
+        JSON.stringify(
+          { compilerOptions: { esModuleInterop: true, module: 'esnext' } },
+          null,
+          2
+        )
+      );
+
+      await update(tree);
+
+      const json = readJson(tree, 'tsconfig.json');
+      expect(json.compilerOptions.esModuleInterop).toBe(true);
+      // true is not deprecated, so nothing forces ignoreDeprecations here.
+      expect(json.compilerOptions.ignoreDeprecations).toBeUndefined();
+    });
+
+    it('does not touch esModuleInterop on a file that has "extends"', async () => {
+      tree.write(
+        'tsconfig.app.json',
+        JSON.stringify(
+          { extends: './tsconfig.json', compilerOptions: { module: 'esnext' } },
+          null,
+          2
+        )
+      );
+
+      await update(tree);
+
+      const json = readJson(tree, 'tsconfig.app.json');
+      expect(json.compilerOptions.esModuleInterop).toBeUndefined();
     });
   });
 });

--- a/packages/js/src/migrations/update-23-1-0/add-ignore-deprecations-for-ts6.ts
+++ b/packages/js/src/migrations/update-23-1-0/add-ignore-deprecations-for-ts6.ts
@@ -20,16 +20,12 @@ const FORMATTING_OPTIONS = {
 type CompilerOptions = Record<string, unknown>;
 
 /**
- * Two independent passes over every tsconfig*.json in the workspace:
+ * Two passes over every tsconfig*.json in the workspace. The default-preserving
+ * pass runs first, then the ignoreDeprecations pass, so a default it pins to a
+ * now-deprecated value ("esModuleInterop": false) is picked up and silenced by
+ * the deprecation pass in the same run.
  *
- * 1. ignoreDeprecations pass - adds `ignoreDeprecations: "6.0"` to any
- *    compilerOptions (or ts-node.compilerOptions) block that directly carries a
- *    TS6 hard-deprecated option value (moduleResolution node/node10/classic,
- *    baseUrl, target es5, esModuleInterop false, outFile, module
- *    amd/umd/system/none, alwaysStrict false, allowSyntheticDefaultImports
- *    false, downlevelIteration set to any value).
- *
- * 2. default-preserving pass - for every chain root (no "extends" key), pins
+ * 1. default-preserving pass - for every chain root (no "extends" key), pins
  *    the TS6 compiler-option defaults that changed in a way that breaks existing
  *    workspaces back to their pre-TS6 value, but only when the root does not set
  *    them explicitly:
@@ -43,9 +39,24 @@ type CompilerOptions = Record<string, unknown>;
  *        whereas TS5 loaded them all; the "*" wildcard restores that default so
  *        a config relying on it (e.g. ts-node type-checking jest.config.ts)
  *        keeps finding @types/node.
+ *      - "esModuleInterop": false - TS6 flips its default from false to true, so
+ *        `import * as x from '<cjs>'` that used to bind x to the callable module
+ *        now binds a non-callable namespace object, breaking any call/`new` on
+ *        such an import at runtime. Pinning false restores the pre-TS6 behavior.
+ *        Unlike the others, false is itself deprecated in TS6 (removed in TS7),
+ *        which is why this pass must precede the ignoreDeprecations pass; it
+ *        defers the interop change to the eventual TS7 migration.
  *    Files with "extends" inherit from their chain root and are left untouched.
  *    Pure solution-style containers (root has `"files": []` and no "include")
  *    select no source files, so pinning there is noise and they are skipped.
+ *
+ * 2. ignoreDeprecations pass - adds `ignoreDeprecations: "6.0"` to any
+ *    compilerOptions (or ts-node.compilerOptions) block that directly carries a
+ *    TS6 hard-deprecated option value (moduleResolution node/node10/classic,
+ *    baseUrl, target es5, esModuleInterop false, outFile, module
+ *    amd/umd/system/none, alwaysStrict false, allowSyntheticDefaultImports
+ *    false, downlevelIteration set to any value), including an "esModuleInterop":
+ *    false the default-preserving pass just added.
  *
  * Only runs on TS6 workspaces (gated by `requires` in migrations.json), because
  * `ignoreDeprecations: "6.0"` is itself a hard error (TS5103) on TS 5.x.
@@ -58,11 +69,13 @@ export default async function (tree: Tree) {
     if (!name.startsWith('tsconfig') || !name.endsWith('.json')) {
       return;
     }
-    if (addIgnoreDeprecations(tree, filePath)) {
-      deprecationCount += 1;
-    }
+    // Pin defaults first: a pinned "esModuleInterop": false is a deprecated
+    // value the deprecation pass then silences.
     if (pinPreTs6Defaults(tree, filePath)) {
       defaultsPinCount += 1;
+    }
+    if (addIgnoreDeprecations(tree, filePath)) {
+      deprecationCount += 1;
     }
   });
 
@@ -73,7 +86,7 @@ export default async function (tree: Tree) {
   }
   if (defaultsPinCount > 0) {
     logger.info(
-      `Pinned pre-TS6 compiler option defaults ("strict", "noUncheckedSideEffectImports", "types") on ${defaultsPinCount} tsconfig chain root(s) to preserve existing behavior.`
+      `Pinned pre-TS6 compiler option defaults ("strict", "noUncheckedSideEffectImports", "types", "esModuleInterop") on ${defaultsPinCount} tsconfig chain root(s) to preserve existing behavior.`
     );
   }
 
@@ -194,6 +207,11 @@ const DEFAULT_PRESERVING_PINS: ReadonlyArray<[string, boolean | string[]]> = [
   ['noUncheckedSideEffectImports', false],
   // TS6 loads no @types when `types` is unset (TS5 loaded all); "*" restores it.
   ['types', ['*']],
+  // TS6 flips esModuleInterop's default false->true, changing `import * as
+  // <cjs>` call semantics at runtime; false preserves pre-TS6 behavior. It is
+  // itself deprecated (removed in TS7), so the deprecation pass (run after this
+  // one) silences it. See the file-level doc for the ordering rationale.
+  ['esModuleInterop', false],
 ];
 
 function pinPreTs6Defaults(tree: Tree, tsconfigPath: string): boolean {


### PR DESCRIPTION
## Current Behavior

TypeScript 6 changes the default of `esModuleInterop` from `false` to `true`. The `add-ignore-deprecations-for-ts6` migration preserves several other compiler-option defaults that TS6 changed (`strict`, `noUncheckedSideEffectImports`, `types`), but not `esModuleInterop`. A workspace whose chain-root tsconfig relied on the old default and imports a CommonJS module with `import * as x from '<cjs>'` ends up with a non-callable namespace object after migrating, so calling or `new`-ing that import fails at runtime.

## Expected Behavior

The migration now pins `esModuleInterop: false` on chain-root tsconfigs (no `extends`) that do not already set it, keeping the pre-TS6 behavior. Chain roots that set `esModuleInterop` explicitly are left as-is. Since `esModuleInterop: false` is itself deprecated in TS6 and removed in TS7, the pinned value also receives `ignoreDeprecations: "6.0"` (the default-preserving pass runs before the deprecation pass), deferring the interop change to the future TS7 migration.
