### PR TITLE
fix(core): use standard utm params on performance-report links

### DIFF
--- a/e2e/lerna-smoke-tests/src/lerna-smoke-tests.test.ts
+++ b/e2e/lerna-smoke-tests/src/lerna-smoke-tests.test.ts
@@ -79,7 +79,7 @@ describe('Lerna Smoke Tests', () => {
                 Critical path: {DURATION} (1 task)
                 Recoverable time: {DURATION}
                 Recommendations:
-                - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm=performance-report.
+                - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache.
                 - Speed up or split the longest tasks on the critical path:
                 package-1:print-name    {DURATION}
 

--- a/e2e/release/src/independent-projects.test.ts
+++ b/e2e/release/src/independent-projects.test.ts
@@ -697,7 +697,7 @@ describe('nx release - independent projects', () => {
         Recoverable time: {DURATION}
 
         Recommendations:
-        - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm=performance-report.
+        - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache.
         - Speed up or split the longest tasks on the critical path:
         {project-name}:nx-release-publish    {DURATION}
 
@@ -755,7 +755,7 @@ describe('nx release - independent projects', () => {
         Recoverable time: {DURATION}
 
         Recommendations:
-        - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm=performance-report.
+        - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache.
         - Speed up or split the longest tasks on the critical path:
         {project-name}:nx-release-publish    {DURATION}
 
@@ -801,7 +801,7 @@ describe('nx release - independent projects', () => {
         Recoverable time: {DURATION}
 
         Recommendations:
-        - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm=performance-report.
+        - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache.
         - Speed up or split the longest tasks on the critical path:
         {project-name}:nx-release-publish    {DURATION}
 
@@ -893,7 +893,7 @@ describe('nx release - independent projects', () => {
         Recoverable time: {DURATION}
 
         Recommendations:
-        - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm=performance-report.
+        - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache.
         - Speed up or split the longest tasks on the critical path:
         {project-name}:nx-release-publish    {DURATION}
 
@@ -944,7 +944,7 @@ describe('nx release - independent projects', () => {
           Recoverable time: {DURATION}
 
           Recommendations:
-          - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm=performance-report.
+          - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache.
           - Speed up or split the longest tasks on the critical path:
           {project-name}:nx-release-publish    {DURATION}
 
@@ -1036,7 +1036,7 @@ describe('nx release - independent projects', () => {
         Recoverable time: {DURATION}
 
         Recommendations:
-        - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm=performance-report.
+        - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache.
         - Speed up or split the longest tasks on the critical path:
         {project-name}:nx-release-publish    {DURATION}
 
@@ -1087,7 +1087,7 @@ describe('nx release - independent projects', () => {
         Recoverable time: {DURATION}
 
         Recommendations:
-        - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm=performance-report.
+        - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache.
         - Speed up or split the longest tasks on the critical path:
         {project-name}:nx-release-publish    {DURATION}
 
@@ -1156,7 +1156,7 @@ describe('nx release - independent projects', () => {
         Recoverable time: {DURATION}
 
         Recommendations:
-        - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm=performance-report.
+        - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache.
         - Speed up or split the longest tasks on the critical path:
         {project-name}:nx-release-publish    {DURATION}
 

--- a/e2e/release/src/independent-projects.workspaces.test.ts
+++ b/e2e/release/src/independent-projects.workspaces.test.ts
@@ -702,7 +702,7 @@ describe('nx release - independent projects - workspaces', () => {
                   Recoverable time: {DURATION}
 
                   Recommendations:
-                  - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm=performance-report.
+                  - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache.
                   - Speed up or split the longest tasks on the critical path:
                   {project-name}:nx-release-publish    {DURATION}
 
@@ -760,7 +760,7 @@ describe('nx release - independent projects - workspaces', () => {
                   Recoverable time: {DURATION}
 
                   Recommendations:
-                  - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm=performance-report.
+                  - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache.
                   - Speed up or split the longest tasks on the critical path:
                   {project-name}:nx-release-publish    {DURATION}
 
@@ -806,7 +806,7 @@ describe('nx release - independent projects - workspaces', () => {
                   Recoverable time: {DURATION}
 
                   Recommendations:
-                  - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm=performance-report.
+                  - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache.
                   - Speed up or split the longest tasks on the critical path:
                   {project-name}:nx-release-publish    {DURATION}
 
@@ -900,7 +900,7 @@ describe('nx release - independent projects - workspaces', () => {
         Recoverable time: {DURATION}
 
         Recommendations:
-        - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm=performance-report.
+        - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache.
         - Speed up or split the longest tasks on the critical path:
         {project-name}:nx-release-publish    {DURATION}
 
@@ -951,7 +951,7 @@ describe('nx release - independent projects - workspaces', () => {
         Recoverable time: {DURATION}
 
         Recommendations:
-        - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm=performance-report.
+        - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache.
         - Speed up or split the longest tasks on the critical path:
         {project-name}:nx-release-publish    {DURATION}
 
@@ -1045,7 +1045,7 @@ describe('nx release - independent projects - workspaces', () => {
         Recoverable time: {DURATION}
 
         Recommendations:
-        - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm=performance-report.
+        - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache.
         - Speed up or split the longest tasks on the critical path:
         {project-name}:nx-release-publish    {DURATION}
 
@@ -1096,7 +1096,7 @@ describe('nx release - independent projects - workspaces', () => {
         Recoverable time: {DURATION}
 
         Recommendations:
-        - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm=performance-report.
+        - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache.
         - Speed up or split the longest tasks on the critical path:
         {project-name}:nx-release-publish    {DURATION}
 
@@ -1165,7 +1165,7 @@ describe('nx release - independent projects - workspaces', () => {
         Recoverable time: {DURATION}
 
         Recommendations:
-        - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm=performance-report.
+        - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache.
         - Speed up or split the longest tasks on the critical path:
         {project-name}:nx-release-publish    {DURATION}
 

--- a/e2e/release/src/preserve-local-dependency-protocols.test.ts
+++ b/e2e/release/src/preserve-local-dependency-protocols.test.ts
@@ -285,7 +285,7 @@ describe('nx release preserve local dependency protocols', () => {
         Critical path: {DURATION} (2 tasks)
         Recoverable time: {DURATION}
         Recommendations:
-        - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm=performance-report.
+        - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache.
         - Speed up or split the longest tasks on the critical path:
         {project-name}:nx-release-publish    {DURATION}
         {project-name}:nx-release-publish    {DURATION}
@@ -365,7 +365,7 @@ describe('nx release preserve local dependency protocols', () => {
         Critical path: {DURATION} (2 tasks)
         Recoverable time: {DURATION}
         Recommendations:
-        - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm=performance-report.
+        - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache.
         - Speed up or split the longest tasks on the critical path:
         {project-name}:nx-release-publish    {DURATION}
         {project-name}:nx-release-publish    {DURATION}

--- a/e2e/release/src/private-js-packages.test.ts
+++ b/e2e/release/src/private-js-packages.test.ts
@@ -153,7 +153,7 @@ describe('nx release - private JS packages', () => {
       Recoverable time: {DURATION}
 
       Recommendations:
-      - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm=performance-report.
+      - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache.
       - Speed up or split the longest tasks on the critical path:
       {public-project-name}:nx-release-publish    {DURATION}
 
@@ -206,7 +206,7 @@ describe('nx release - private JS packages', () => {
       Recoverable time: {DURATION}
 
       Recommendations:
-      - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm=performance-report.
+      - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache.
       - Speed up or split the longest tasks on the critical path:
       {public-project-name}:nx-release-publish    {DURATION}
 
@@ -326,7 +326,7 @@ describe('nx release - private JS packages', () => {
       Recoverable time: {DURATION}
 
       Recommendations:
-      - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm=performance-report.
+      - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache.
       - Speed up or split the longest tasks on the critical path:
       {public-project-name}:nx-release-publish    {DURATION}
 

--- a/e2e/release/src/release-publishable-libraries-ts-solution.test.ts
+++ b/e2e/release/src/release-publishable-libraries-ts-solution.test.ts
@@ -142,7 +142,7 @@ describe('release publishable libraries in workspace with ts solution setup', ()
       Critical path: {DURATION} (1 task)
       Recoverable time: {DURATION}
       Recommendations:
-      - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm=performance-report.
+      - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache.
       - Speed up or split the longest tasks on the critical path:
       @proj/{project-name}:nx-release-publish    {DURATION}
     `);
@@ -209,7 +209,7 @@ describe('release publishable libraries in workspace with ts solution setup', ()
       Critical path: {DURATION} (1 task)
       Recoverable time: {DURATION}
       Recommendations:
-      - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm=performance-report.
+      - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache.
       - Speed up or split the longest tasks on the critical path:
       @proj/{project-name}:nx-release-publish    {DURATION}
     `);
@@ -271,7 +271,7 @@ describe('release publishable libraries in workspace with ts solution setup', ()
       Critical path: {DURATION} (1 task)
       Recoverable time: {DURATION}
       Recommendations:
-      - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm=performance-report.
+      - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache.
       - Speed up or split the longest tasks on the critical path:
       @proj/{project-name}:nx-release-publish    {DURATION}
     `);
@@ -338,7 +338,7 @@ describe('release publishable libraries in workspace with ts solution setup', ()
       Critical path: {DURATION} (1 task)
       Recoverable time: {DURATION}
       Recommendations:
-      - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm=performance-report.
+      - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache.
       - Speed up or split the longest tasks on the critical path:
       @proj/{project-name}:nx-release-publish    {DURATION}
     `);

--- a/e2e/release/src/release-publishable-libraries.test.ts
+++ b/e2e/release/src/release-publishable-libraries.test.ts
@@ -150,7 +150,7 @@ describe('release publishable libraries', () => {
       Critical path: {DURATION} (1 task)
       Recoverable time: {DURATION}
       Recommendations:
-      - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm=performance-report.
+      - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache.
       - Speed up or split the longest tasks on the critical path:
       {project-name}:nx-release-publish    {DURATION}
     `);
@@ -217,7 +217,7 @@ describe('release publishable libraries', () => {
       Critical path: {DURATION} (1 task)
       Recoverable time: {DURATION}
       Recommendations:
-      - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm=performance-report.
+      - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache.
       - Speed up or split the longest tasks on the critical path:
       {project-name}:nx-release-publish    {DURATION}
     `);
@@ -282,7 +282,7 @@ describe('release publishable libraries', () => {
       Critical path: {DURATION} (1 task)
       Recoverable time: {DURATION}
       Recommendations:
-      - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm=performance-report.
+      - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache.
       - Speed up or split the longest tasks on the critical path:
       {project-name}:nx-release-publish    {DURATION}
     `);
@@ -345,7 +345,7 @@ describe('release publishable libraries', () => {
       Critical path: {DURATION} (1 task)
       Recoverable time: {DURATION}
       Recommendations:
-      - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm=performance-report.
+      - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache.
       - Speed up or split the longest tasks on the critical path:
       {project-name}:nx-release-publish    {DURATION}
     `);
@@ -412,7 +412,7 @@ describe('release publishable libraries', () => {
       Critical path: {DURATION} (1 task)
       Recoverable time: {DURATION}
       Recommendations:
-      - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm=performance-report.
+      - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache.
       - Speed up or split the longest tasks on the critical path:
       {project-name}:nx-release-publish    {DURATION}
     `);

--- a/e2e/release/src/release.test.ts
+++ b/e2e/release/src/release.test.ts
@@ -276,7 +276,7 @@ describe('nx release', () => {
       Recoverable time: {DURATION}
 
       Recommendations:
-      - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm=performance-report.
+      - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache.
       - Speed up or split the longest tasks on the critical path:
       {project-name}:nx-release-publish    {DURATION}
       {project-name}:nx-release-publish    {DURATION}
@@ -463,7 +463,7 @@ describe('nx release', () => {
       Recoverable time: {DURATION}
 
       Recommendations:
-      - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm=performance-report.
+      - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache.
       - Speed up or split the longest tasks on the critical path:
       {project-name}:nx-release-publish    {DURATION}
       {project-name}:nx-release-publish    {DURATION}
@@ -577,7 +577,7 @@ describe('nx release', () => {
       Recoverable time: {DURATION}
 
       Recommendations:
-      - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm=performance-report.
+      - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache.
       - Speed up or split the longest tasks on the critical path:
       {project-name}:nx-release-publish    {DURATION}
       {project-name}:nx-release-publish    {DURATION}
@@ -623,7 +623,7 @@ describe('nx release', () => {
       Recoverable time: {DURATION}
 
       Recommendations:
-      - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm=performance-report.
+      - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache.
       - Speed up or split the longest tasks on the critical path:
       {project-name}:nx-release-publish    {DURATION}
       {project-name}:nx-release-publish    {DURATION}
@@ -674,7 +674,7 @@ describe('nx release', () => {
       Recoverable time: {DURATION}
 
       Recommendations:
-      - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm=performance-report.
+      - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache.
       - Speed up or split the longest tasks on the critical path:
       {project-name}:nx-release-publish    {DURATION}
       {project-name}:nx-release-publish    {DURATION}

--- a/packages/nx/src/native/tui/components/countdown_popup.rs
+++ b/packages/nx/src/native/tui/components/countdown_popup.rs
@@ -668,7 +668,7 @@ mod tests {
     // render and hyperlink exactly these.
     const CACHE_PHRASE: &str =
         "Drastically reduce your run duration by sharing a cache across your team and CI";
-    const CACHE_HREF: &str = "https://nx.dev/ci/features/remote-cache?utm=performance-report";
+    const CACHE_HREF: &str = "https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache";
 
     fn summary_with(recommendations: Vec<String>) -> PerformanceSummaryPayload {
         PerformanceSummaryPayload {

--- a/packages/nx/src/tasks-runner/life-cycles/performance-life-cycle.spec.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/performance-life-cycle.spec.ts
@@ -713,7 +713,7 @@ describe('cache reporting', () => {
     // No-TTY jest env → no hyperlinks → the tagged URL prints verbatim.
     expect(report).toContain('sharing a cache across your team and CI');
     expect(report).toContain(
-      'https://nx.dev/ci/features/remote-cache?utm=performance-report'
+      'https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache'
     );
   });
 
@@ -734,7 +734,7 @@ describe('cache reporting', () => {
       // the hidden target — never a raw URL. Sequence: ESC]8;; <target> BEL <phrase>.
       const OSC8 = ']8;;';
       expect(report).toContain(
-        `${OSC8}https://nx.dev/ci/features/remote-cache?utm=performance-reportDrastically reduce your run duration by sharing a cache across your team and CI`
+        `${OSC8}https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cacheDrastically reduce your run duration by sharing a cache across your team and CI`
       );
       // The URL must never appear as plain visible text: every occurrence is
       // immediately preceded by the OSC 8 target preamble.
@@ -842,7 +842,7 @@ describe('exit summary payload (TUI countdown)', () => {
       expect(payload.links).toEqual([
         {
           text: 'Drastically reduce your run duration by sharing a cache across your team and CI',
-          href: 'https://nx.dev/ci/features/remote-cache?utm=performance-report',
+          href: 'https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache',
         },
       ]);
       expect(
@@ -947,7 +947,7 @@ describe('formatReport', () => {
     const OSC8 = ']8;;';
     const BEL = '';
     const agentsHref =
-      'https://nx.dev/ci/features/distribute-task-execution?utm=performance-report';
+      'https://nx.dev/ci/features/distribute-task-execution?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=nx-agents';
     const phrase = 'Distribute across machines with Nx Agents';
 
     const prev = process.env.FORCE_HYPERLINK;
@@ -1004,7 +1004,7 @@ describe('formatReport', () => {
         ? os.availableParallelism()
         : os.cpus().length;
     const PERF_DOCS =
-      'https://nx.dev/docs/concepts/ci-concepts/parallelization-distribution?utm=performance-report';
+      'https://nx.dev/docs/concepts/ci-concepts/parallelization-distribution?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=parallelization';
     // parallel=1, spare cores: `b` queues for the only slot → 50% recoverable by
     // --parallel, so the parallelism lever shows, and it links to the perf docs.
     const a = makeTask('a', { start: 0, end: 1000 });
@@ -1086,8 +1086,8 @@ describe('formatReport', () => {
           Recoverable time:  800ms (40% of the run)
 
           Recommendations:
-            - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm=performance-report.
-            - Distribute across machines with Nx Agents → https://nx.dev/ci/features/distribute-task-execution?utm=performance-report.
+            - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache.
+            - Distribute across machines with Nx Agents → https://nx.dev/ci/features/distribute-task-execution?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=nx-agents.
             - Speed up or split the longest tasks on the critical path:
                 np    1.2s"
       `);
@@ -1181,7 +1181,7 @@ describe('formatReportMarkdown', () => {
 
       ### Recommendations
 
-      - [Drastically reduce your run duration by sharing a cache across your team and CI](https://nx.dev/ci/features/remote-cache?utm=performance-report).
+      - [Drastically reduce your run duration by sharing a cache across your team and CI](https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache).
       - Speed up or split the longest tasks on the critical path:<br>a    3.0s"
     `);
   });
@@ -1213,7 +1213,7 @@ describe('formatReportMarkdown', () => {
     const md = formatReportMarkdown(s, '');
 
     expect(md).toContain(
-      '[Distribute across machines with Nx Agents](https://nx.dev/ci/features/distribute-task-execution?utm=performance-report)'
+      '[Distribute across machines with Nx Agents](https://nx.dev/ci/features/distribute-task-execution?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=nx-agents)'
     );
   });
 
@@ -1227,7 +1227,7 @@ describe('formatReportMarkdown', () => {
     })!;
 
     expect(formatReportMarkdown(s, '')).toContain(
-      '[Drastically reduce your run duration by sharing a cache across your team and CI](https://nx.dev/ci/features/remote-cache?utm=performance-report)'
+      '[Drastically reduce your run duration by sharing a cache across your team and CI](https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache)'
     );
   });
 });

--- a/packages/nx/src/tasks-runner/life-cycles/performance-report.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/performance-report.ts
@@ -7,11 +7,12 @@ const NX_AGENTS_URL = 'https://nx.dev/ci/features/distribute-task-execution';
 const NX_REMOTE_CACHE_URL = 'https://nx.dev/ci/features/remote-cache';
 const NX_PERFORMANCE_URL =
   'https://nx.dev/docs/concepts/ci-concepts/parallelization-distribution';
-/** utm tag attributing report clicks back to it. */
-const UTM = '?utm=performance-report';
-const NX_PERFORMANCE_LINK = `${NX_PERFORMANCE_URL}${UTM}`;
-const NX_AGENTS_LINK = `${NX_AGENTS_URL}${UTM}`;
-const NX_REMOTE_CACHE_LINK = `${NX_REMOTE_CACHE_URL}${UTM}`;
+/** utm tag attributing report clicks back to it; the content names the CTA clicked. */
+const utm = (content: string) =>
+  `?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=${content}`;
+const NX_PERFORMANCE_LINK = `${NX_PERFORMANCE_URL}${utm('parallelization')}`;
+const NX_AGENTS_LINK = `${NX_AGENTS_URL}${utm('nx-agents')}`;
+const NX_REMOTE_CACHE_LINK = `${NX_REMOTE_CACHE_URL}${utm('remote-cache')}`;
 /**
  * Whole-phrase CTA: the whole sentence is the link. The Rust TUI popup keeps no
  * copy of this string; it gets the phrase + href from the exit payload's `links`.


### PR DESCRIPTION
## Current Behavior

<!-- This is the behavior we have today -->

The docs links in the CLI performance report carry a non-standard tracking tag (`?utm=performance-report`), which analytics tools don't parse as UTM parameters, so clicks from the report aren't attributed.

## Expected Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

All performance-report links — in the terminal report, the GitHub Actions job summary, and the TUI countdown popup — use standard UTM parameters:

```
?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=<cta>
```

`utm_content` identifies which recommendation was clicked: `remote-cache`, `nx-agents`, or `parallelization`.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Internal analytics attribution change; no linked issue.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/UTM-tracking-parameters-standardization-32e04d6f)
<!-- polygraph-session-end -->