### PR TITLE
fix(nx-cloud): use standard utm params on cloud prompt links

### DIFF
--- a/packages/create-nx-workspace/src/utils/nx/ab-testing.spec.ts
+++ b/packages/create-nx-workspace/src/utils/nx/ab-testing.spec.ts
@@ -166,7 +166,7 @@ describe('NX_CLOUD_HYPERLINK', () => {
 
     expect(link).toContain(`${BEL}${url}${OSC}`);
     expect(link).toContain(
-      `${url}?utm_source=nx-cli&utm_medium=create-nx-workspace`
+      `${url}?utm_source=nx-cli&utm_medium=cli&utm_campaign=nx-cloud-connect&utm_content=create-nx-workspace`
     );
   });
 

--- a/packages/create-nx-workspace/src/utils/nx/ab-testing.ts
+++ b/packages/create-nx-workspace/src/utils/nx/ab-testing.ts
@@ -17,14 +17,14 @@ export const NX_CLOUD_URL = 'https://nx.dev/nx-cloud';
 
 /**
  * Clickable Nx Cloud marketing link for cloud prompt footers. Every
- * create-nx-workspace prompt reports the same medium, so the link is a single
- * baked constant embedded directly in the footers. Visible text stays the clean
- * `NX_CLOUD_URL` while clicks carry UTM attribution; terminals without OSC 8
- * support just render the bare URL (CLOUD-4642).
+ * create-nx-workspace prompt reports the same content tag, so the link is a
+ * single baked constant embedded directly in the footers. Visible text stays
+ * the clean `NX_CLOUD_URL` while clicks carry UTM attribution; terminals
+ * without OSC 8 support just render the bare URL (CLOUD-4642).
  */
 export const NX_CLOUD_HYPERLINK = terminalLink(
   NX_CLOUD_URL,
-  `${NX_CLOUD_URL}?utm_source=nx-cli&utm_medium=create-nx-workspace`
+  `${NX_CLOUD_URL}?utm_source=nx-cli&utm_medium=cli&utm_campaign=nx-cloud-connect&utm_content=create-nx-workspace`
 );
 
 // Flow variant controls both tracking and banner display (CLOUD-4235)

--- a/packages/nx/src/command-line/nx-cloud/connect/connect-to-nx-cloud.ts
+++ b/packages/nx/src/command-line/nx-cloud/connect/connect-to-nx-cloud.ts
@@ -232,7 +232,7 @@ export async function connectExistingRepoToNxCloudPrompt(
   key: MessageKey = 'setupNxCloud',
   recordCompletion = true
 ): Promise<MessageOptionKey> {
-  const res = await nxCloudPrompt(key, utmMediumForCommand(command));
+  const res = await nxCloudPrompt(key, utmContentForCommand(command));
   // TODO: once legacy init-v1 (the NX_ADD_PLUGINS=false / useInferencePlugins:false path) is
   // removed, drop this recordStat and the recordCompletion flag entirely - init-v2 records its
   // own complete, and view-logs should record its own stat, so this shared helper won't record.
@@ -261,7 +261,7 @@ export async function connectExistingRepoToNxCloudPrompt(
 export async function connectToNxCloudWithPrompt(command: string) {
   const setNxCloud = await nxCloudPrompt(
     'setupNxCloud',
-    utmMediumForCommand(command)
+    utmContentForCommand(command)
   );
   let useCloud = false;
   if (setNxCloud === 'yes') {
@@ -292,7 +292,7 @@ export async function connectToNxCloudWithPrompt(command: string) {
   });
 }
 
-function utmMediumForCommand(command: string): string {
+function utmContentForCommand(command: string): string {
   switch (command) {
     case 'migrate':
       return 'nx-migrate';
@@ -305,7 +305,7 @@ function utmMediumForCommand(command: string): string {
 
 async function nxCloudPrompt(
   key: MessageKey,
-  utmMedium: string
+  utmContent: string
 ): Promise<MessageOptionKey> {
   const { message, choices, initial, footer, hint } = messages.getPrompt(key);
 
@@ -318,7 +318,7 @@ async function nxCloudPrompt(
   } as any; // meeroslav: types in enquirer are not up to date
   if (footer) {
     promptConfig.footer = () =>
-      pc.dim(`${footer} ${nxCloudHyperlink(utmMedium)}`);
+      pc.dim(`${footer} ${nxCloudHyperlink(utmContent)}`);
   }
   if (hint) {
     promptConfig.hint = () => pc.dim(hint);

--- a/packages/nx/src/utils/ab-testing.spec.ts
+++ b/packages/nx/src/utils/ab-testing.spec.ts
@@ -25,7 +25,7 @@ describe('nxCloudHyperlink', () => {
     expect(link).toContain(`${BEL}${NX_CLOUD_URL}${OSC}`);
     // Tracked URL is the link target only.
     expect(link).toContain(
-      `${NX_CLOUD_URL}?utm_source=nx-cli&utm_medium=nx-init`
+      `${NX_CLOUD_URL}?utm_source=nx-cli&utm_medium=cli&utm_campaign=nx-cloud-connect&utm_content=nx-init`
     );
   });
 

--- a/packages/nx/src/utils/ab-testing.ts
+++ b/packages/nx/src/utils/ab-testing.ts
@@ -10,12 +10,12 @@ export const NX_CLOUD_URL = 'https://nx.dev/nx-cloud';
 /**
  * Clickable Nx Cloud marketing link for cloud prompt footers. The visible text
  * stays the clean `NX_CLOUD_URL` while clicks carry UTM attribution; terminals
- * without OSC 8 support just render the bare URL (CLOUD-4642). The medium is
- * per-command because `nx init` and `nx migrate` share a footer but report
- * different mediums.
+ * without OSC 8 support just render the bare URL (CLOUD-4642). The content tag
+ * is per-command because `nx init` and `nx migrate` share a footer but report
+ * different commands.
  */
-export function nxCloudHyperlink(utmMedium: string): string {
-  const tracked = `${NX_CLOUD_URL}?utm_source=nx-cli&utm_medium=${utmMedium}`;
+export function nxCloudHyperlink(utmContent: string): string {
+  const tracked = `${NX_CLOUD_URL}?utm_source=nx-cli&utm_medium=cli&utm_campaign=nx-cloud-connect&utm_content=${utmContent}`;
   return terminalLink(NX_CLOUD_URL, tracked);
 }
 


### PR DESCRIPTION
## Current Behavior

<!-- This is the behavior we have today -->

The Nx Cloud links in the CLI's cloud-connect prompt footers carry partial UTM tags: `?utm_source=nx-cli&utm_medium=<feature>`, where the feature slot (`create-nx-workspace`, `nx-init`, `nx-migrate`, `nx-connect`) sits in `utm_medium`. The medium isn't a real channel value, and there is no campaign or content attribution.

## Expected Behavior

<!-- This is the behavior we should expect with the changes in this PR -->

All cloud-prompt links use the standard UTM parameter set:

```
?utm_source=nx-cli&utm_medium=cli&utm_campaign=nx-cloud-connect&utm_content=<command>
```

`utm_content` identifies which command showed the prompt: `create-nx-workspace`, `nx-init`, `nx-migrate`, or `nx-connect`.

> [!NOTE]
> Analytics dashboards filtering on the old `utm_medium` values (e.g. `create-nx-workspace`) will need their filters updated once this ships.

Follow-up to #36226, which applied the same scheme to the performance-report links.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Internal analytics attribution change; no linked issue.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/UTM-tracking-parameters-standardization-32e04d6f)
<!-- polygraph-session-end -->