### PR TITLE
fix(core): prevent intermittent lockfile graph errors from stale or corrupted caches

### DIFF
--- a/e2e/nx/src/misc.test.ts
+++ b/e2e/nx/src/misc.test.ts
@@ -758,6 +758,34 @@ describe('Nx Commands', () => {
     }, 300000);
   });
 
+  // NXC-2793 / #30416: corrupted or stale lockfile caches in
+  // .nx/workspace-data must never fail project graph computation with
+  // "Source project does not exist: npm:<pkg>" - nx reprocesses instead.
+  describe('lockfile cache resilience', () => {
+    it('should compute the project graph when lockfile caches are corrupted or stale', () => {
+      runCLI('show projects'); // warm the caches
+      // Truncated file, as left behind by a killed process
+      updateFile(
+        '.nx/workspace-data/parsed-lock-file.nodes.json',
+        '{"lockFileHash":"stale","nod'
+      );
+      // Valid shape but referencing packages that are not in the graph
+      updateFile(
+        '.nx/workspace-data/parsed-lock-file.dependencies.json',
+        JSON.stringify({
+          lockFileHash: 'stale',
+          dependencies: [
+            { source: 'npm:ghost', target: 'npm:missing', type: 'static' },
+          ],
+        })
+      );
+      // Restart the daemon so the next command reads the poisoned caches
+      runCLI('reset --only-daemon');
+
+      expect(() => runCLI('show projects')).not.toThrow();
+    });
+  });
+
   it('should show help if no command provided', () => {
     const output = runCLI('', { silenceError: true });
     expect(output).toContain('Smart Monorepos · Fast Builds');

--- a/packages/nx/src/daemon/server/project-graph-incremental-recomputation.spec.ts
+++ b/packages/nx/src/daemon/server/project-graph-incremental-recomputation.spec.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { TempFs } from '../../internal-testing-utils/temp-fs';
@@ -218,6 +218,107 @@ describe('getCachedSerializedProjectGraphPromise — watcher race coverage', () 
       } finally {
         process.removeListener('unhandledRejection', onUnhandled);
       }
+    });
+  });
+
+  // Regression test for intermittent "Source project does not exist:
+  // npm:<pkg>" errors (NXC-2793 / #30416): knownExternalNodes was only
+  // refreshed when the project-config hash changed, so a lockfile-only
+  // change (install without config edits) kept feeding stale external
+  // nodes into graph construction until the daemon process died.
+  //
+  // A mock plugin mirrors the js lockfile plugin's shape: createNodes
+  // derives external nodes from the current lockfile bytes, and
+  // createDependencies emits an edge between them when present.
+  it('refreshes external nodes when only the lockfile changes', async () => {
+    fs.createFilesSync({
+      'nx.json': JSON.stringify({}),
+      'package.json': JSON.stringify({ name: 'root' }),
+      'package-lock.json': 'without-autoprefixer',
+    });
+
+    await jest.isolateModulesAsync(async () => {
+      const { setWorkspaceRoot } = require('../../utils/workspace-root');
+      setWorkspaceRoot(fs.tempDir);
+
+      const externalNodesFromLockfile = () => {
+        const contents = readFileSync(
+          join(fs.tempDir, 'package-lock.json'),
+          'utf-8'
+        );
+        if (!contents.includes('with-autoprefixer')) return {};
+        return {
+          'npm:autoprefixer': {
+            type: 'npm' as const,
+            name: 'npm:autoprefixer' as const,
+            data: { version: '10.4.0', packageName: 'autoprefixer' },
+          },
+          'npm:picocolors': {
+            type: 'npm' as const,
+            name: 'npm:picocolors' as const,
+            data: { version: '1.0.0', packageName: 'picocolors' },
+          },
+        };
+      };
+
+      const fakeLockfilePlugin = {
+        name: 'fake-lockfile-plugin',
+        createNodes: [
+          'package-lock.json',
+          async (files: string[]) => [
+            [
+              'fake-lockfile-plugin',
+              files[0],
+              { externalNodes: externalNodesFromLockfile() },
+            ],
+          ],
+        ],
+        createDependencies: async () =>
+          Object.keys(externalNodesFromLockfile()).length
+            ? [
+                {
+                  source: 'npm:autoprefixer',
+                  target: 'npm:picocolors',
+                  type: 'static',
+                },
+              ]
+            : [],
+      };
+
+      jest.doMock('../../project-graph/plugins/get-plugins', () => ({
+        __esModule: true,
+        getPlugins: jest.fn(async () => [fakeLockfilePlugin]),
+        getPluginsSeparated: jest.fn(async () => ({
+          specifiedPlugins: [],
+          defaultPlugins: [fakeLockfilePlugin],
+        })),
+      }));
+
+      const {
+        scheduleProjectGraphRecomputation,
+        getCachedSerializedProjectGraphPromise,
+      } = require('./project-graph-incremental-recomputation');
+
+      const first = await getCachedSerializedProjectGraphPromise();
+      expect(first.error).toBeFalsy();
+      expect(
+        first.projectGraph?.externalNodes?.['npm:autoprefixer']
+      ).toBeUndefined();
+
+      // Lockfile-only change: package.json and project configs untouched,
+      // so the config hash stays the same. Route the change directly
+      // (what the watcher callback does) to keep the test deterministic.
+      writeFileSync(join(fs.tempDir, 'package-lock.json'), 'with-autoprefixer');
+      scheduleProjectGraphRecomputation([], ['package-lock.json'], []);
+
+      // Without the fix: knownExternalNodes stays stale (empty), the
+      // dependency edge fails validation, and this errors with
+      // "Source project does not exist: npm:autoprefixer".
+      const second = await getCachedSerializedProjectGraphPromise();
+      expect(second.error).toBeFalsy();
+      expect(
+        second.projectGraph?.externalNodes?.['npm:autoprefixer']
+      ).toBeDefined();
     });
   });
 });

--- a/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
+++ b/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
@@ -383,7 +383,11 @@ async function processCollectedUpdatedAndDeletedFiles(
       return { fileMap: fresh, configHash, knownExternalNodes: externalNodes };
     }
 
-    // Config unchanged → patch the existing file map in place.
+    // Config unchanged → patch the existing file map in place. External
+    // nodes still refresh from this cycle's createNodes results: a
+    // lockfile-only change (install without config changes) alters them
+    // without touching the config hash, and keeping the stale set makes
+    // createDependencies throw "Source project does not exist: npm:<pkg>".
     if (fileMapWithFiles) {
       return {
         fileMap: updateFileMap(
@@ -393,12 +397,13 @@ async function processCollectedUpdatedAndDeletedFiles(
           deletedFiles
         ),
         configHash,
+        knownExternalNodes: externalNodes,
       };
     }
 
     // No prior map (first compute on this daemon).
     const fresh = await retrieveWorkspaceFiles(workspaceRoot, projectRootMap);
-    return { fileMap: fresh, configHash };
+    return { fileMap: fresh, configHash, knownExternalNodes: externalNodes };
   } catch (e) {
     // this is expected
     // for instance, project.json can be incorrect or a file we are trying to has
@@ -679,6 +684,8 @@ async function resetInternalState() {
   currentProjectFileMapCache = undefined;
   currentProjectGraph = undefined;
   currentSourceMaps = undefined;
+  knownExternalNodes = {};
+  storedWorkspaceConfigHash = undefined;
   collectedUpdatedFiles.clear();
   collectedDeletedFiles.clear();
   cacheHasBeenPersisted = false;

--- a/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
+++ b/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
@@ -383,7 +383,7 @@ async function processCollectedUpdatedAndDeletedFiles(
       return { fileMap: fresh, configHash, knownExternalNodes: externalNodes };
     }
 
-    // Config unchanged → patch the existing file map in place. External
+    // Config unchanged -> patch the existing file map in place. External
     // nodes still refresh from this cycle's createNodes results: a
     // lockfile-only change (install without config changes) alters them
     // without touching the config hash, and keeping the stale set makes

--- a/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
+++ b/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
@@ -363,7 +363,7 @@ function computeWorkspaceConfigHash(
 type FileMapUpdate = {
   fileMap: NonNullable<typeof fileMapWithFiles>;
   configHash: string;
-  knownExternalNodes?: Record<string, ProjectGraphExternalNode>;
+  knownExternalNodes: Record<string, ProjectGraphExternalNode>;
 };
 
 async function processCollectedUpdatedAndDeletedFiles(
@@ -511,9 +511,7 @@ async function processFilesAndCreateAndSerializeProjectGraph(
     // can't clobber a newer compute's write.
     fileMapWithFiles = fileMapUpdate.fileMap;
     storedWorkspaceConfigHash = fileMapUpdate.configHash;
-    if (fileMapUpdate.knownExternalNodes) {
-      knownExternalNodes = fileMapUpdate.knownExternalNodes;
-    }
+    knownExternalNodes = fileMapUpdate.knownExternalNodes;
 
     // Drain only after committing — a stale compute that returns at the
     // staleness check above must leave its snapshot in `collected*` so the

--- a/packages/nx/src/plugins/js/index.spec.ts
+++ b/packages/nx/src/plugins/js/index.spec.ts
@@ -218,16 +218,11 @@ describe('js plugin lockfile cache resilience', () => {
       // Lockfile rewritten mid-flight (e.g. npm install still running)
       fs.createFileSync('package-lock.json', LOCKFILE);
 
+      // Must not throw, and must not emit edges referencing nodes the graph
+      // does not have. The graph has no external nodes here (they came from
+      // the empty lockfile), so every lockfile edge must be dropped.
       const deps = await h.runCreateDependencies(externalNodes);
-      // Must not throw, and must not emit edges referencing nodes the
-      // graph does not have
-      for (const dep of deps) {
-        expect(externalNodes[dep.source] ?? dep.source).toBeTruthy();
-        expect(
-          externalNodes[dep.source] !== undefined ||
-            !dep.source.startsWith('npm:')
-        ).toBe(true);
-      }
+      expect(deps).toEqual([]);
     });
   });
 });

--- a/packages/nx/src/plugins/js/index.spec.ts
+++ b/packages/nx/src/plugins/js/index.spec.ts
@@ -1,0 +1,221 @@
+import { readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { TempFs } from '../../internal-testing-utils/temp-fs';
+
+// Regression tests for intermittent "Source project does not exist: npm:<pkg>"
+// graph failures caused by stale/corrupted lockfile caches in
+// .nx/workspace-data (see #27213, #30416). The plugin must never fail graph
+// construction because of bad cache state - it reprocesses or degrades
+// gracefully instead.
+
+const LOCKFILE = JSON.stringify({
+  name: 'repro',
+  version: '1.0.0',
+  lockfileVersion: 3,
+  requires: true,
+  packages: {
+    '': {
+      name: 'repro',
+      version: '1.0.0',
+      dependencies: { autoprefixer: '^10.0.0' },
+    },
+    'node_modules/autoprefixer': {
+      version: '10.4.0',
+      resolved:
+        'https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.0.tgz',
+      integrity: 'sha512-autoprefixer',
+      dependencies: { picocolors: '^1.0.0' },
+    },
+    'node_modules/picocolors': {
+      version: '1.0.0',
+      resolved: 'https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz',
+      integrity: 'sha512-picocolors',
+    },
+  },
+});
+
+const LOCKFILE_WITHOUT_AUTOPREFIXER = JSON.stringify({
+  name: 'repro',
+  version: '1.0.0',
+  lockfileVersion: 3,
+  requires: true,
+  packages: {
+    '': { name: 'repro', version: '1.0.0' },
+  },
+});
+
+describe('js plugin lockfile cache resilience', () => {
+  let fs: TempFs;
+
+  beforeEach(() => {
+    fs = new TempFs('js-lockfile-cache');
+    fs.createFilesSync({
+      'nx.json': JSON.stringify({}),
+      'package.json': JSON.stringify({ name: 'repro', version: '1.0.0' }),
+      'package-lock.json': LOCKFILE,
+    });
+  });
+
+  afterEach(() => {
+    fs.cleanup();
+  });
+
+  async function runPlugin(fn: (harness: any) => Promise<void>) {
+    await jest.isolateModulesAsync(async () => {
+      const { setWorkspaceRoot } = require('../../utils/workspace-root');
+      setWorkspaceRoot(fs.tempDir);
+      const plugin = require('./index');
+      const { hashArray } = require('../../hasher/file-hasher');
+      const { nxVersion } = require('../../utils/versions');
+      const { workspaceDataDirectory } = require('../../utils/cache-directory');
+
+      const createNodesContext = {
+        workspaceRoot: fs.tempDir,
+        nxJsonConfiguration: {},
+        configFiles: [],
+      };
+
+      const runCreateNodes = async () => {
+        const results = await plugin.createNodes[1](
+          ['package-lock.json'],
+          undefined,
+          createNodesContext
+        );
+        return results[0][1].externalNodes;
+      };
+
+      const runCreateDependencies = async (externalNodes: any) =>
+        plugin.createDependencies(undefined, {
+          externalNodes,
+          projects: {},
+          nxJsonConfiguration: {},
+          workspaceRoot: fs.tempDir,
+          fileMap: { projectFileMap: {}, nonProjectFiles: [] },
+          filesToProcess: { projectFileMap: {}, nonProjectFiles: [] },
+        });
+
+      const lockFileHash = (contents: string) =>
+        hashArray([nxVersion, contents]);
+
+      await fn({
+        runCreateNodes,
+        runCreateDependencies,
+        lockFileHash,
+        nodesCachePath: join(
+          workspaceDataDirectory,
+          'parsed-lock-file.nodes.json'
+        ),
+        depsCachePath: join(
+          workspaceDataDirectory,
+          'parsed-lock-file.dependencies.json'
+        ),
+      });
+    });
+  }
+
+  it('computes dependencies and reuses caches on a second run', async () => {
+    await runPlugin(async (h) => {
+      const externalNodes = await h.runCreateNodes();
+      expect(externalNodes['npm:autoprefixer']).toBeDefined();
+      const deps = await h.runCreateDependencies(externalNodes);
+      expect(deps).toContainEqual(
+        expect.objectContaining({
+          source: 'npm:autoprefixer',
+          target: 'npm:picocolors',
+        })
+      );
+    });
+    // Second run in a fresh module registry - both phases served from cache
+    await runPlugin(async (h) => {
+      const externalNodes = await h.runCreateNodes();
+      expect(externalNodes['npm:autoprefixer']).toBeDefined();
+      const deps = await h.runCreateDependencies(externalNodes);
+      expect(deps).toContainEqual(
+        expect.objectContaining({
+          source: 'npm:autoprefixer',
+          target: 'npm:picocolors',
+        })
+      );
+    });
+  });
+
+  it('self-heals when the cached dependencies reference nodes that do not exist', async () => {
+    await runPlugin(async (h) => {
+      const externalNodes = await h.runCreateNodes();
+      // Poison the deps cache: valid shape, hash claiming the current
+      // lockfile, but edges referencing a package that is not in the graph.
+      // This is the persistent on-disk state left behind by interrupted or
+      // racing processes before caches became atomic and self-describing.
+      writeFileSync(
+        h.depsCachePath,
+        JSON.stringify({
+          lockFileHash: h.lockFileHash(
+            readFileSync(join(fs.tempDir, 'package-lock.json'), 'utf-8')
+          ),
+          dependencies: [
+            { source: 'npm:ghost', target: 'npm:picocolors', type: 'static' },
+          ],
+        })
+      );
+
+      const deps = await h.runCreateDependencies(externalNodes);
+      expect(deps).not.toContainEqual(
+        expect.objectContaining({ source: 'npm:ghost' })
+      );
+      expect(deps).toContainEqual(
+        expect.objectContaining({
+          source: 'npm:autoprefixer',
+          target: 'npm:picocolors',
+        })
+      );
+      // Cache was rewritten with the reparsed result
+      const rewritten = JSON.parse(readFileSync(h.depsCachePath, 'utf-8'));
+      expect(rewritten.dependencies).not.toContainEqual(
+        expect.objectContaining({ source: 'npm:ghost' })
+      );
+    });
+  });
+
+  it('reprocesses when cache files are truncated or corrupted', async () => {
+    await runPlugin(async (h) => {
+      const externalNodes = await h.runCreateNodes();
+      await h.runCreateDependencies(externalNodes);
+      // Simulate torn writes from a killed process
+      writeFileSync(h.nodesCachePath, '{"lockFileHash":"abc","nod');
+      writeFileSync(h.depsCachePath, '');
+    });
+    await runPlugin(async (h) => {
+      const externalNodes = await h.runCreateNodes();
+      expect(externalNodes['npm:autoprefixer']).toBeDefined();
+      const deps = await h.runCreateDependencies(externalNodes);
+      expect(deps).toContainEqual(
+        expect.objectContaining({
+          source: 'npm:autoprefixer',
+          target: 'npm:picocolors',
+        })
+      );
+    });
+  });
+
+  it('does not fail the graph when the lockfile changes between createNodes and createDependencies', async () => {
+    await runPlugin(async (h) => {
+      fs.createFileSync('package-lock.json', LOCKFILE_WITHOUT_AUTOPREFIXER);
+      const externalNodes = await h.runCreateNodes();
+      expect(externalNodes['npm:autoprefixer']).toBeUndefined();
+
+      // Lockfile rewritten mid-flight (e.g. npm install still running)
+      fs.createFileSync('package-lock.json', LOCKFILE);
+
+      const deps = await h.runCreateDependencies(externalNodes);
+      // Must not throw, and must not emit edges referencing nodes the
+      // graph does not have
+      for (const dep of deps) {
+        expect(externalNodes[dep.source] ?? dep.source).toBeTruthy();
+        expect(
+          externalNodes[dep.source] !== undefined ||
+            !dep.source.startsWith('npm:')
+        ).toBe(true);
+      }
+    });
+  });
+});

--- a/packages/nx/src/plugins/js/index.spec.ts
+++ b/packages/nx/src/plugins/js/index.spec.ts
@@ -188,6 +188,36 @@ describe('js plugin lockfile cache resilience', () => {
     });
   });
 
+  it('does not persist a reduced edge set when the ctx is transiently incomplete', async () => {
+    await runPlugin(async (h) => {
+      await h.runCreateNodes();
+      // A daemon cycle can hand createDependencies an incomplete external
+      // node set (e.g. after a transient plugin error). Returned edges are
+      // filtered, but the cache written under the real hash must keep the
+      // full lockfile-derived set.
+      const deps = await h.runCreateDependencies({});
+      expect(deps).toEqual([]);
+      const cache = JSON.parse(readFileSync(h.depsCachePath, 'utf-8'));
+      expect(cache.dependencies).toContainEqual(
+        expect.objectContaining({
+          source: 'npm:autoprefixer',
+          target: 'npm:picocolors',
+        })
+      );
+    });
+    // Next healthy cycle serves the full set from that cache
+    await runPlugin(async (h) => {
+      const externalNodes = await h.runCreateNodes();
+      const deps = await h.runCreateDependencies(externalNodes);
+      expect(deps).toContainEqual(
+        expect.objectContaining({
+          source: 'npm:autoprefixer',
+          target: 'npm:picocolors',
+        })
+      );
+    });
+  });
+
   it('reprocesses when cache files are truncated or corrupted', async () => {
     await runPlugin(async (h) => {
       const externalNodes = await h.runCreateNodes();

--- a/packages/nx/src/plugins/js/index.spec.ts
+++ b/packages/nx/src/plugins/js/index.spec.ts
@@ -1,5 +1,5 @@
-import { readFileSync, writeFileSync } from 'node:fs';
-import { join } from 'node:path';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
 import { TempFs } from '../../internal-testing-utils/temp-fs';
 
 // Regression tests for intermittent "Source project does not exist: npm:<pkg>"
@@ -109,12 +109,23 @@ describe('js plugin lockfile cache resilience', () => {
           workspaceDataDirectory,
           'parsed-lock-file.dependencies.json'
         ),
+        legacyHashPaths: [
+          join(workspaceDataDirectory, 'lockfile-nodes.hash'),
+          join(workspaceDataDirectory, 'lockfile-dependencies.hash'),
+        ],
       });
     });
   }
 
   it('computes dependencies and reuses caches on a second run', async () => {
     await runPlugin(async (h) => {
+      // Legacy hash files from an older Nx version - must be removed so a
+      // version switch back cannot pair them with the new cache format
+      for (const p of h.legacyHashPaths) {
+        mkdirSync(dirname(p), { recursive: true });
+        writeFileSync(p, 'some-hash');
+      }
+
       const externalNodes = await h.runCreateNodes();
       expect(externalNodes['npm:autoprefixer']).toBeDefined();
       const deps = await h.runCreateDependencies(externalNodes);
@@ -124,6 +135,7 @@ describe('js plugin lockfile cache resilience', () => {
           target: 'npm:picocolors',
         })
       );
+      for (const p of h.legacyHashPaths) expect(existsSync(p)).toBe(false);
     });
     // Second run in a fresh module registry - both phases served from cache
     await runPlugin(async (h) => {

--- a/packages/nx/src/plugins/js/index.ts
+++ b/packages/nx/src/plugins/js/index.ts
@@ -17,7 +17,10 @@ import { RawProjectGraphDependency } from '../../project-graph/project-graph-bui
 import { workspaceDataDirectory } from '../../utils/cache-directory';
 import { combineGlobPatterns } from '../../utils/globs';
 import { logger } from '../../utils/logger';
-import { detectPackageManager } from '../../utils/package-manager';
+import {
+  detectPackageManager,
+  PackageManager,
+} from '../../utils/package-manager';
 import { safeWriteFileCache } from '../../utils/plugin-cache-utils';
 import { nxVersion } from '../../utils/versions';
 import { workspaceRoot } from '../../utils/workspace-root';
@@ -37,6 +40,10 @@ export const name = 'nx/js/dependencies-and-lockfile';
 // Separate in-memory caches
 let cachedExternalNodes: ProjectGraph['externalNodes'] | undefined;
 let cachedKeyMap: Map<string, any> | undefined;
+// Hash of the lockfile the in-memory nodes/keyMap were derived from. The
+// dependencies cache is only trusted when it matches this hash, so nodes and
+// dependencies always come from the same lockfile state.
+let cachedNodesLockFileHash: string | undefined;
 
 export const createNodes: CreateNodes = [
   combineGlobPatterns(LOCKFILES),
@@ -65,13 +72,14 @@ function internalCreateNodes(lockFile: string, _, context: CreateNodesContext) {
       : readBunLockFile(lockFilePath);
   const lockFileHash = getLockFileHash(lockFileContents);
 
-  if (!lockFileNeedsReprocessing(lockFileHash, externalNodesHashFile)) {
-    const { nodes, keyMap } = readCachedExternalNodes();
-    cachedExternalNodes = nodes;
-    cachedKeyMap = keyMap;
+  const cached = readCachedExternalNodes(lockFileHash);
+  if (cached) {
+    cachedExternalNodes = cached.nodes;
+    cachedKeyMap = cached.keyMap;
+    cachedNodesLockFileHash = lockFileHash;
 
     return {
-      externalNodes: nodes,
+      externalNodes: cached.nodes,
     };
   }
 
@@ -83,6 +91,7 @@ function internalCreateNodes(lockFile: string, _, context: CreateNodesContext) {
   );
   cachedExternalNodes = externalNodes;
   cachedKeyMap = keyMap;
+  cachedNodesLockFileHash = lockFileHash;
 
   writeExternalNodesCache(lockFileHash, externalNodes, keyMap);
 
@@ -106,26 +115,7 @@ export const createDependencies: CreateDependencies = (
     lockFileExists(packageManager) &&
     cachedExternalNodes
   ) {
-    const lockFilePath = join(workspaceRoot, getLockFileName(packageManager));
-    const lockFileContents =
-      packageManager !== 'bun'
-        ? readFileSync(lockFilePath, 'utf-8')
-        : readBunLockFile(lockFilePath);
-    const lockFileHash = getLockFileHash(lockFileContents);
-
-    if (!lockFileNeedsReprocessing(lockFileHash, dependenciesHashFile)) {
-      lockfileDependencies = readCachedDependencies();
-    } else {
-      lockfileDependencies = getLockFileDependencies(
-        packageManager,
-        lockFileContents,
-        lockFileHash,
-        ctx,
-        cachedKeyMap
-      );
-
-      writeDependenciesCache(lockFileHash, lockfileDependencies);
-    }
+    lockfileDependencies = getLockfileDependenciesSafely(packageManager, ctx);
   }
 
   performance.mark('build typescript dependencies - start');
@@ -141,6 +131,83 @@ export const createDependencies: CreateDependencies = (
   );
   return lockfileDependencies.concat(explicitProjectDependencies);
 };
+
+/**
+ * Computes the workspace's external dependency edges from the lockfile,
+ * reusing the on-disk cache when it is consistent with the external nodes
+ * currently in memory. Never throws: any inconsistency falls back to
+ * reparsing, and a failed parse degrades to "no lockfile dependencies for
+ * this run" instead of failing the whole project graph.
+ */
+function getLockfileDependenciesSafely(
+  packageManager: PackageManager,
+  ctx: CreateDependenciesContext
+): RawProjectGraphDependency[] {
+  const lockFilePath = join(workspaceRoot, getLockFileName(packageManager));
+  try {
+    const lockFileContents =
+      packageManager !== 'bun'
+        ? readFileSync(lockFilePath, 'utf-8')
+        : readBunLockFile(lockFilePath);
+    const lockFileHash = getLockFileHash(lockFileContents);
+
+    if (lockFileHash === cachedNodesLockFileHash) {
+      const cachedDependencies = readCachedDependencies(lockFileHash);
+      // A cached entry referencing nodes that no longer exist is poisoned
+      // (e.g. written by an interrupted process) - reparse instead of
+      // failing graph construction with "Source project does not exist".
+      if (cachedDependencies && dependenciesAreValid(cachedDependencies, ctx)) {
+        return cachedDependencies;
+      }
+
+      const lockfileDependencies = getLockFileDependencies(
+        packageManager,
+        lockFileContents,
+        lockFileHash,
+        ctx,
+        cachedKeyMap
+      );
+      writeDependenciesCache(lockFileHash, lockfileDependencies);
+      return lockfileDependencies;
+    }
+
+    // The lockfile changed between createNodes and createDependencies (e.g.
+    // mid-install). ctx.externalNodes reflect the old state, so drop edges
+    // that no longer line up and skip the cache write - the next run sees a
+    // settled lockfile and reprocesses both phases consistently.
+    const lockfileDependencies = getLockFileDependencies(
+      packageManager,
+      lockFileContents,
+      lockFileHash,
+      ctx,
+      cachedKeyMap
+    );
+    return lockfileDependencies.filter((d) => dependencyIsValid(d, ctx));
+  } catch (e) {
+    logger.warn(
+      `Could not resolve dependencies from ${lockFilePath}. External dependency information may be incomplete until the next run. ${
+        e instanceof Error ? e.message : e
+      }`
+    );
+    return [];
+  }
+}
+
+function dependencyIsValid(
+  dep: RawProjectGraphDependency,
+  ctx: CreateDependenciesContext
+): boolean {
+  const exists = (name: string) =>
+    !!ctx.externalNodes[name] || !!ctx.projects[name];
+  return exists(dep.source) && exists(dep.target);
+}
+
+function dependenciesAreValid(
+  deps: RawProjectGraphDependency[],
+  ctx: CreateDependenciesContext
+): boolean {
+  return deps.every((d) => dependencyIsValid(d, ctx));
+}
 
 function getLockFileHash(lockFileContents: string) {
   return hashArray([nxVersion, lockFileContents]);
@@ -189,45 +256,45 @@ function deserializeKeyMap(
   return keyMap;
 }
 
-function lockFileNeedsReprocessing(lockHash: string, hashFilePath: string) {
-  try {
-    return readFileSync(hashFilePath).toString() !== lockHash;
-  } catch {
-    return true;
-  }
-}
-
-// External nodes cache functions
+// External nodes cache functions.
+// The lockfile hash is embedded in the cache file (single atomic write) so a
+// cache entry can never claim to be valid for a lockfile state it was not
+// computed from - the failure mode behind intermittent
+// "Source project does not exist: npm:<pkg>" errors.
 function writeExternalNodesCache(
   hash: string,
   nodes: ProjectGraph['externalNodes'],
   keyMap: Map<string, any>
 ) {
   const serializedKeyMap = serializeKeyMap(keyMap);
-  const cacheData = { nodes, keyMap: serializedKeyMap };
+  const cacheData = { lockFileHash: hash, nodes, keyMap: serializedKeyMap };
   const content = safeStringify(cacheData);
   if (content === undefined) {
     logger.warn(
       `Failed to serialize external nodes cache. Skipping cache write.`
     );
     tryRemoveFile(externalNodesCache);
-    tryRemoveFile(externalNodesHashFile);
     return;
   }
   safeWriteFileCache(externalNodesCache, content);
-  if (existsSync(externalNodesCache)) {
-    safeWriteFileCache(externalNodesHashFile, hash);
-  }
 }
 
-function readCachedExternalNodes(): {
+function readCachedExternalNodes(expectedHash: string): {
   nodes: ProjectGraph['externalNodes'];
   keyMap: Map<string, any>;
-} {
-  const { nodes, keyMap } = JSON.parse(
-    readFileSync(externalNodesCache, 'utf-8')
-  );
-  return { nodes, keyMap: deserializeKeyMap(keyMap, nodes) };
+} | null {
+  try {
+    const { lockFileHash, nodes, keyMap } = JSON.parse(
+      readFileSync(externalNodesCache, 'utf-8')
+    );
+    if (lockFileHash !== expectedHash || !nodes || !keyMap) {
+      return null;
+    }
+    return { nodes, keyMap: deserializeKeyMap(keyMap, nodes) };
+  } catch {
+    // Missing, torn, or corrupted cache - reprocess from the lockfile
+    return null;
+  }
 }
 
 // Dependencies cache functions
@@ -235,18 +302,31 @@ function writeDependenciesCache(
   hash: string,
   dependencies: RawProjectGraphDependency[]
 ) {
-  const content = safeStringify(dependencies);
+  const content = safeStringify({ lockFileHash: hash, dependencies });
   if (content === undefined) {
     logger.warn(
       `Failed to serialize dependencies cache. Skipping cache write.`
     );
     tryRemoveFile(dependenciesCache);
-    tryRemoveFile(dependenciesHashFile);
     return;
   }
   safeWriteFileCache(dependenciesCache, content);
-  if (existsSync(dependenciesCache)) {
-    safeWriteFileCache(dependenciesHashFile, hash);
+}
+
+function readCachedDependencies(
+  expectedHash: string
+): RawProjectGraphDependency[] | null {
+  try {
+    const { lockFileHash, dependencies } = JSON.parse(
+      readFileSync(dependenciesCache, 'utf-8')
+    );
+    if (lockFileHash !== expectedHash || !Array.isArray(dependencies)) {
+      return null;
+    }
+    return dependencies;
+  } catch {
+    // Missing, torn, or corrupted cache - reprocess from the lockfile
+    return null;
   }
 }
 
@@ -268,19 +348,7 @@ function tryRemoveFile(path: string): void {
   }
 }
 
-function readCachedDependencies(): RawProjectGraphDependency[] {
-  return JSON.parse(readFileSync(dependenciesCache).toString());
-}
-
 // Cache file paths
-const externalNodesHashFile = join(
-  workspaceDataDirectory,
-  'lockfile-nodes.hash'
-);
-const dependenciesHashFile = join(
-  workspaceDataDirectory,
-  'lockfile-dependencies.hash'
-);
 const externalNodesCache = join(
   workspaceDataDirectory,
   'parsed-lock-file.nodes.json'

--- a/packages/nx/src/plugins/js/index.ts
+++ b/packages/nx/src/plugins/js/index.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, rmSync } from 'fs';
+import { readFileSync } from 'fs';
 import { join } from 'path';
 import { performance } from 'perf_hooks';
 import {
@@ -21,7 +21,10 @@ import {
   detectPackageManager,
   PackageManager,
 } from '../../utils/package-manager';
-import { safeWriteFileCache } from '../../utils/plugin-cache-utils';
+import {
+  safeWriteFileCache,
+  tryRemoveFile,
+} from '../../utils/plugin-cache-utils';
 import { nxVersion } from '../../utils/versions';
 import { workspaceRoot } from '../../utils/workspace-root';
 import { readBunLockFile } from './lock-file/bun-parser';
@@ -37,13 +40,17 @@ import { jsPluginConfig } from './utils/config';
 
 export const name = 'nx/js/dependencies-and-lockfile';
 
-// Separate in-memory caches
-let cachedExternalNodes: ProjectGraph['externalNodes'] | undefined;
-let cachedKeyMap: Map<string, any> | undefined;
-// Hash of the lockfile the in-memory nodes/keyMap were derived from. The
-// dependencies cache is only trusted when it matches this hash, so nodes and
-// dependencies always come from the same lockfile state.
-let cachedNodesLockFileHash: string | undefined;
+interface LockfileParseState {
+  lockFileHash: string;
+  nodes: ProjectGraph['externalNodes'];
+  keyMap: Map<string, any>;
+}
+
+// In-memory parse state shared between createNodes and createDependencies.
+// One object so nodes, keyMap, and the lockfile hash they were derived from
+// can never drift apart - the dependencies cache is only trusted when it
+// matches this hash.
+let inMemoryLockfileState: LockfileParseState | undefined;
 
 export const createNodes: CreateNodes = [
   combineGlobPatterns(LOCKFILES),
@@ -66,17 +73,12 @@ function internalCreateNodes(lockFile: string, _, context: CreateNodesContext) {
   }
 
   const lockFilePath = join(workspaceRoot, lockFile);
-  const lockFileContents =
-    packageManager !== 'bun'
-      ? readFileSync(lockFilePath, 'utf-8')
-      : readBunLockFile(lockFilePath);
+  const lockFileContents = readLockFileContents(packageManager, lockFilePath);
   const lockFileHash = getLockFileHash(lockFileContents);
 
   const cached = readCachedExternalNodes(lockFileHash);
   if (cached) {
-    cachedExternalNodes = cached.nodes;
-    cachedKeyMap = cached.keyMap;
-    cachedNodesLockFileHash = lockFileHash;
+    inMemoryLockfileState = { lockFileHash, ...cached };
 
     return {
       externalNodes: cached.nodes,
@@ -89,9 +91,7 @@ function internalCreateNodes(lockFile: string, _, context: CreateNodesContext) {
     lockFileHash,
     context
   );
-  cachedExternalNodes = externalNodes;
-  cachedKeyMap = keyMap;
-  cachedNodesLockFileHash = lockFileHash;
+  inMemoryLockfileState = { lockFileHash, nodes: externalNodes, keyMap };
 
   writeExternalNodesCache(lockFileHash, externalNodes, keyMap);
 
@@ -113,9 +113,13 @@ export const createDependencies: CreateDependencies = (
   if (
     pluginConfig.analyzeLockfile &&
     lockFileExists(packageManager) &&
-    cachedExternalNodes
+    inMemoryLockfileState
   ) {
-    lockfileDependencies = getLockfileDependenciesSafely(packageManager, ctx);
+    lockfileDependencies = getLockfileDependenciesSafely(
+      packageManager,
+      inMemoryLockfileState,
+      ctx
+    );
   }
 
   performance.mark('build typescript dependencies - start');
@@ -135,54 +139,47 @@ export const createDependencies: CreateDependencies = (
 /**
  * Computes the workspace's external dependency edges from the lockfile,
  * reusing the on-disk cache when it is consistent with the external nodes
- * currently in memory. Never throws: any inconsistency falls back to
- * reparsing, and a failed parse degrades to "no lockfile dependencies for
- * this run" instead of failing the whole project graph.
+ * currently in memory. Never throws and never emits an edge referencing a
+ * node the graph does not have: bad cache state falls back to reparsing, and
+ * a failed parse degrades to "no lockfile dependencies for this run" instead
+ * of failing the whole project graph.
  */
 function getLockfileDependenciesSafely(
   packageManager: PackageManager,
+  state: LockfileParseState,
   ctx: CreateDependenciesContext
 ): RawProjectGraphDependency[] {
   const lockFilePath = join(workspaceRoot, getLockFileName(packageManager));
   try {
-    const lockFileContents =
-      packageManager !== 'bun'
-        ? readFileSync(lockFilePath, 'utf-8')
-        : readBunLockFile(lockFilePath);
+    const lockFileContents = readLockFileContents(packageManager, lockFilePath);
     const lockFileHash = getLockFileHash(lockFileContents);
+    // Inconsistent means the lockfile changed between createNodes and
+    // createDependencies (e.g. mid-install): ctx.externalNodes reflect the
+    // old state, so skip the caches - the next run sees a settled lockfile
+    // and reprocesses both phases consistently.
+    const consistent = lockFileHash === state.lockFileHash;
 
-    if (lockFileHash === cachedNodesLockFileHash) {
+    if (consistent) {
       const cachedDependencies = readCachedDependencies(lockFileHash);
       // A cached entry referencing nodes that no longer exist is poisoned
       // (e.g. written by an interrupted process) - reparse instead of
       // failing graph construction with "Source project does not exist".
-      if (cachedDependencies && dependenciesAreValid(cachedDependencies, ctx)) {
+      if (cachedDependencies?.every((d) => dependencyIsValid(d, ctx))) {
         return cachedDependencies;
       }
-
-      const lockfileDependencies = getLockFileDependencies(
-        packageManager,
-        lockFileContents,
-        lockFileHash,
-        ctx,
-        cachedKeyMap
-      );
-      writeDependenciesCache(lockFileHash, lockfileDependencies);
-      return lockfileDependencies;
     }
 
-    // The lockfile changed between createNodes and createDependencies (e.g.
-    // mid-install). ctx.externalNodes reflect the old state, so drop edges
-    // that no longer line up and skip the cache write - the next run sees a
-    // settled lockfile and reprocesses both phases consistently.
     const lockfileDependencies = getLockFileDependencies(
       packageManager,
       lockFileContents,
       lockFileHash,
       ctx,
-      cachedKeyMap
-    );
-    return lockfileDependencies.filter((d) => dependencyIsValid(d, ctx));
+      state.keyMap
+    ).filter((d) => dependencyIsValid(d, ctx));
+    if (consistent) {
+      writeDependenciesCache(lockFileHash, lockfileDependencies);
+    }
+    return lockfileDependencies;
   } catch (e) {
     logger.warn(
       `Could not resolve dependencies from ${lockFilePath}. External dependency information may be incomplete until the next run. ${
@@ -202,11 +199,13 @@ function dependencyIsValid(
   return exists(dep.source) && exists(dep.target);
 }
 
-function dependenciesAreValid(
-  deps: RawProjectGraphDependency[],
-  ctx: CreateDependenciesContext
-): boolean {
-  return deps.every((d) => dependencyIsValid(d, ctx));
+function readLockFileContents(
+  packageManager: PackageManager,
+  lockFilePath: string
+): string {
+  return packageManager !== 'bun'
+    ? readFileSync(lockFilePath, 'utf-8')
+    : readBunLockFile(lockFilePath);
 }
 
 function getLockFileHash(lockFileContents: string) {
@@ -256,84 +255,80 @@ function deserializeKeyMap(
   return keyMap;
 }
 
-// External nodes cache functions.
-// The lockfile hash is embedded in the cache file (single atomic write) so a
-// cache entry can never claim to be valid for a lockfile state it was not
-// computed from - the failure mode behind intermittent
-// "Source project does not exist: npm:<pkg>" errors.
+// On-disk caches. The lockfile hash is embedded in each cache file and
+// written in a single atomic write, so a cache entry can never claim to be
+// valid for a lockfile state it was not computed from - the failure mode
+// behind intermittent "Source project does not exist: npm:<pkg>" errors.
+function writeHashedCache(
+  cachePath: string,
+  legacyHashPath: string,
+  hash: string,
+  payload: Record<string, unknown>
+): void {
+  const content = safeStringify({ lockFileHash: hash, ...payload });
+  if (content === undefined) {
+    logger.warn(`Failed to serialize ${cachePath}. Skipping cache write.`);
+    tryRemoveFile(cachePath);
+    return;
+  }
+  safeWriteFileCache(cachePath, content);
+  // Older Nx versions trust the legacy hash file and would misread the
+  // embedded-hash cache format after a version switch
+  tryRemoveFile(legacyHashPath);
+}
+
+function readHashedCache(
+  cachePath: string,
+  expectedHash: string
+): Record<string, any> | null {
+  try {
+    const data = JSON.parse(readFileSync(cachePath, 'utf-8'));
+    return data?.lockFileHash === expectedHash ? data : null;
+  } catch {
+    // Missing, torn, or corrupted cache - reprocess from the lockfile
+    return null;
+  }
+}
+
 function writeExternalNodesCache(
   hash: string,
   nodes: ProjectGraph['externalNodes'],
   keyMap: Map<string, any>
 ) {
-  const serializedKeyMap = serializeKeyMap(keyMap);
-  const cacheData = { lockFileHash: hash, nodes, keyMap: serializedKeyMap };
-  const content = safeStringify(cacheData);
-  if (content === undefined) {
-    logger.warn(
-      `Failed to serialize external nodes cache. Skipping cache write.`
-    );
-    tryRemoveFile(externalNodesCache);
-    return;
-  }
-  safeWriteFileCache(externalNodesCache, content);
-  // Older Nx versions trust this hash file and would misread the new
-  // embedded-hash cache format after a version switch
-  tryRemoveFile(legacyExternalNodesHashFile);
+  writeHashedCache(externalNodesCache, legacyExternalNodesHashFile, hash, {
+    nodes,
+    keyMap: serializeKeyMap(keyMap),
+  });
 }
 
 function readCachedExternalNodes(expectedHash: string): {
   nodes: ProjectGraph['externalNodes'];
   keyMap: Map<string, any>;
 } | null {
-  try {
-    const { lockFileHash, nodes, keyMap } = JSON.parse(
-      readFileSync(externalNodesCache, 'utf-8')
-    );
-    if (lockFileHash !== expectedHash || !nodes || !keyMap) {
-      return null;
-    }
-    return { nodes, keyMap: deserializeKeyMap(keyMap, nodes) };
-  } catch {
-    // Missing, torn, or corrupted cache - reprocess from the lockfile
+  const data = readHashedCache(externalNodesCache, expectedHash);
+  if (!data?.nodes || !data.keyMap) {
     return null;
   }
+  return {
+    nodes: data.nodes,
+    keyMap: deserializeKeyMap(data.keyMap, data.nodes),
+  };
 }
 
-// Dependencies cache functions
 function writeDependenciesCache(
   hash: string,
   dependencies: RawProjectGraphDependency[]
 ) {
-  const content = safeStringify({ lockFileHash: hash, dependencies });
-  if (content === undefined) {
-    logger.warn(
-      `Failed to serialize dependencies cache. Skipping cache write.`
-    );
-    tryRemoveFile(dependenciesCache);
-    return;
-  }
-  safeWriteFileCache(dependenciesCache, content);
-  // Older Nx versions trust this hash file and would misread the new
-  // embedded-hash cache format after a version switch
-  tryRemoveFile(legacyDependenciesHashFile);
+  writeHashedCache(dependenciesCache, legacyDependenciesHashFile, hash, {
+    dependencies,
+  });
 }
 
 function readCachedDependencies(
   expectedHash: string
 ): RawProjectGraphDependency[] | null {
-  try {
-    const { lockFileHash, dependencies } = JSON.parse(
-      readFileSync(dependenciesCache, 'utf-8')
-    );
-    if (lockFileHash !== expectedHash || !Array.isArray(dependencies)) {
-      return null;
-    }
-    return dependencies;
-  } catch {
-    // Missing, torn, or corrupted cache - reprocess from the lockfile
-    return null;
-  }
+  const data = readHashedCache(dependenciesCache, expectedHash);
+  return Array.isArray(data?.dependencies) ? data.dependencies : null;
 }
 
 function safeStringify(data: unknown): string | undefined {
@@ -341,16 +336,6 @@ function safeStringify(data: unknown): string | undefined {
     return JSON.stringify(data, null, 2);
   } catch {
     return undefined;
-  }
-}
-
-function tryRemoveFile(path: string): void {
-  try {
-    if (existsSync(path)) {
-      rmSync(path);
-    }
-  } catch {
-    // Best effort
   }
 }
 

--- a/packages/nx/src/plugins/js/index.ts
+++ b/packages/nx/src/plugins/js/index.ts
@@ -277,6 +277,9 @@ function writeExternalNodesCache(
     return;
   }
   safeWriteFileCache(externalNodesCache, content);
+  // Older Nx versions trust this hash file and would misread the new
+  // embedded-hash cache format after a version switch
+  tryRemoveFile(legacyExternalNodesHashFile);
 }
 
 function readCachedExternalNodes(expectedHash: string): {
@@ -311,6 +314,9 @@ function writeDependenciesCache(
     return;
   }
   safeWriteFileCache(dependenciesCache, content);
+  // Older Nx versions trust this hash file and would misread the new
+  // embedded-hash cache format after a version switch
+  tryRemoveFile(legacyDependenciesHashFile);
 }
 
 function readCachedDependencies(
@@ -349,6 +355,16 @@ function tryRemoveFile(path: string): void {
 }
 
 // Cache file paths
+// Hash-file paths from the pre-embedded-hash cache format; removed on write
+// so older Nx versions never pair them with the new cache files
+const legacyExternalNodesHashFile = join(
+  workspaceDataDirectory,
+  'lockfile-nodes.hash'
+);
+const legacyDependenciesHashFile = join(
+  workspaceDataDirectory,
+  'lockfile-dependencies.hash'
+);
 const externalNodesCache = join(
   workspaceDataDirectory,
   'parsed-lock-file.nodes.json'

--- a/packages/nx/src/plugins/js/index.ts
+++ b/packages/nx/src/plugins/js/index.ts
@@ -153,33 +153,38 @@ function getLockfileDependenciesSafely(
   try {
     const lockFileContents = readLockFileContents(packageManager, lockFilePath);
     const lockFileHash = getLockFileHash(lockFileContents);
-    // Inconsistent means the lockfile changed between createNodes and
-    // createDependencies (e.g. mid-install): ctx.externalNodes reflect the
-    // old state, so skip the caches - the next run sees a settled lockfile
-    // and reprocesses both phases consistently.
-    const consistent = lockFileHash === state.lockFileHash;
-
-    if (consistent) {
-      const cachedDependencies = readCachedDependencies(lockFileHash);
-      // A cached entry referencing nodes that no longer exist is poisoned
-      // (e.g. written by an interrupted process) - reparse instead of
-      // failing graph construction with "Source project does not exist".
-      if (cachedDependencies?.every((d) => dependencyIsValid(d, ctx))) {
-        return cachedDependencies;
-      }
+    // The lockfile changed between createNodes and createDependencies (e.g.
+    // mid-install). Parsing it with the older keyMap would mix lockfile
+    // generations, so skip lockfile edges for this run - the next run sees
+    // a settled lockfile and reprocesses both phases consistently.
+    if (lockFileHash !== state.lockFileHash) {
+      return [];
     }
 
+    const cachedDependencies = readCachedDependencies(lockFileHash);
+    // A cached entry referencing nodes that no longer exist is poisoned
+    // (e.g. written by an interrupted process) - reparse instead of
+    // failing graph construction with "Source project does not exist".
+    if (cachedDependencies?.every((d) => dependencyIsValid(d, ctx))) {
+      return cachedDependencies;
+    }
+
+    // Parse against the node set derived from this same lockfile, not the
+    // caller's ctx: a transiently incomplete ctx (e.g. a daemon cycle that
+    // committed partial external nodes after a plugin error) would make the
+    // parsers throw or silently drop edges, persisting a reduced edge set
+    // under the real hash. The cache must describe the lockfile - which is
+    // what the embedded hash vouches for - so only the returned value is
+    // filtered to what the graph can actually hold.
     const lockfileDependencies = getLockFileDependencies(
       packageManager,
       lockFileContents,
       lockFileHash,
-      ctx,
+      { ...ctx, externalNodes: state.nodes },
       state.keyMap
-    ).filter((d) => dependencyIsValid(d, ctx));
-    if (consistent) {
-      writeDependenciesCache(lockFileHash, lockfileDependencies);
-    }
-    return lockfileDependencies;
+    );
+    writeDependenciesCache(lockFileHash, lockfileDependencies);
+    return lockfileDependencies.filter((d) => dependencyIsValid(d, ctx));
   } catch (e) {
     logger.warn(
       `Could not resolve dependencies from ${lockFilePath}. External dependency information may be incomplete until the next run. ${

--- a/packages/nx/src/utils/plugin-cache-utils.ts
+++ b/packages/nx/src/utils/plugin-cache-utils.ts
@@ -218,31 +218,33 @@ function loadFromDisk<T>(cachePath: string): {
  *
  * Writes to a temp file in the same directory and renames it into place so
  * concurrent readers (daemon workers, parallel nx processes) never observe
- * a partially-written file.
- *
- * Strategy:
- * 1. Attempt mkdirSync + writeFileSync to temp file + renameSync
- * 2. On failure: remove temp and existing cache file, log warning, return without throwing
+ * a partially-written file. Rename can fail transiently (e.g. EPERM on
+ * Windows when a reader holds the destination open), so it retries with a
+ * fresh temp file - mirroring nx-deps-cache - and only removes the existing
+ * cache file after all attempts fail, so one transient error does not
+ * discard a previously-good cache.
  */
 export function safeWriteFileCache(cachePath: string, content: string): void {
-  const tmpPath = `${cachePath}.${process.pid}.tmp`;
-  try {
-    mkdirSync(dirname(cachePath), { recursive: true });
-    writeFileSync(tmpPath, content);
-    renameSync(tmpPath, cachePath);
-  } catch (e) {
-    logger.warn(
-      `Failed to write cache at ${cachePath}: ${
-        e instanceof Error ? e.message : 'unknown error'
-      }. Removing existing cache file.`
-    );
-    tryRemoveFile(tmpPath);
-    tryRemoveFile(cachePath);
+  for (let attempt = 1; attempt <= 5; attempt++) {
+    const unique = (Math.random().toString(16) + '0000000').slice(2, 10);
+    const tmpPath = `${cachePath}~${unique}`;
+    try {
+      mkdirSync(dirname(cachePath), { recursive: true });
+      writeFileSync(tmpPath, content);
+      renameSync(tmpPath, cachePath);
+      return;
+    } catch {
+      tryRemoveFile(tmpPath);
+    }
   }
+  logger.warn(
+    `Failed to write cache at ${cachePath} after 5 attempts. Removing existing cache file.`
+  );
+  tryRemoveFile(cachePath);
 }
 
 /**
- * Best-effort file removal — missing files and fs errors are ignored.
+ * Best-effort file removal - missing files and fs errors are ignored.
  */
 export function tryRemoveFile(path: string): void {
   try {

--- a/packages/nx/src/utils/plugin-cache-utils.ts
+++ b/packages/nx/src/utils/plugin-cache-utils.ts
@@ -1,4 +1,10 @@
-import { existsSync, mkdirSync, unlinkSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync,
+} from 'node:fs';
 import { dirname } from 'node:path';
 import { readJsonFile } from './fileutils';
 import { logger } from './logger';
@@ -143,11 +149,15 @@ export class PluginCache<T> {
       content = JSON.stringify({ entries: {}, accessOrder: [] });
     }
 
-    // Attempt to write the serialized content to disk
+    // Attempt to write the serialized content to disk (atomically, so
+    // concurrent readers never observe a partially-written file)
+    const tmpPath = `${this.cachePath}.${process.pid}.tmp`;
     try {
-      writeFileSync(this.cachePath, content);
+      writeFileSync(tmpPath, content);
+      renameSync(tmpPath, this.cachePath);
     } catch {
       // Filesystem error — wipe cache so a corrupted file doesn't persist
+      tryRemoveFile(tmpPath);
       tryRemoveFile(this.cachePath);
     }
   }
@@ -218,20 +228,27 @@ function loadFromDisk<T>(cachePath: string): {
 /**
  * Safely writes already-stringified content to a cache file on disk.
  *
+ * Writes to a temp file in the same directory and renames it into place so
+ * concurrent readers (daemon workers, parallel nx processes) never observe
+ * a partially-written file.
+ *
  * Strategy:
- * 1. Attempt mkdirSync + writeFileSync
- * 2. On failure: remove existing cache file, log warning, return without throwing
+ * 1. Attempt mkdirSync + writeFileSync to temp file + renameSync
+ * 2. On failure: remove temp and existing cache file, log warning, return without throwing
  */
 export function safeWriteFileCache(cachePath: string, content: string): void {
+  const tmpPath = `${cachePath}.${process.pid}.tmp`;
   try {
     mkdirSync(dirname(cachePath), { recursive: true });
-    writeFileSync(cachePath, content);
+    writeFileSync(tmpPath, content);
+    renameSync(tmpPath, cachePath);
   } catch (e) {
     logger.warn(
       `Failed to write cache at ${cachePath}: ${
         e instanceof Error ? e.message : 'unknown error'
       }. Removing existing cache file.`
     );
+    tryRemoveFile(tmpPath);
     tryRemoveFile(cachePath);
   }
 }

--- a/packages/nx/src/utils/plugin-cache-utils.ts
+++ b/packages/nx/src/utils/plugin-cache-utils.ts
@@ -119,8 +119,6 @@ export class PluginCache<T> {
    *    write an empty cache so the file is valid
    */
   writeToDisk(): void {
-    mkdirSync(dirname(this.cachePath), { recursive: true });
-
     let content: string | undefined;
 
     try {
@@ -149,17 +147,7 @@ export class PluginCache<T> {
       content = JSON.stringify({ entries: {}, accessOrder: [] });
     }
 
-    // Attempt to write the serialized content to disk (atomically, so
-    // concurrent readers never observe a partially-written file)
-    const tmpPath = `${this.cachePath}.${process.pid}.tmp`;
-    try {
-      writeFileSync(tmpPath, content);
-      renameSync(tmpPath, this.cachePath);
-    } catch {
-      // Filesystem error — wipe cache so a corrupted file doesn't persist
-      tryRemoveFile(tmpPath);
-      tryRemoveFile(this.cachePath);
-    }
+    safeWriteFileCache(this.cachePath, content);
   }
 
   /**
@@ -253,9 +241,10 @@ export function safeWriteFileCache(cachePath: string, content: string): void {
   }
 }
 
-// --- Internal helpers ---
-
-function tryRemoveFile(path: string): void {
+/**
+ * Best-effort file removal — missing files and fs errors are ignored.
+ */
+export function tryRemoveFile(path: string): void {
   try {
     unlinkSync(path);
   } catch {


### PR DESCRIPTION
## Current Behavior

Lockfile parse results are cached in `.nx/workspace-data` as four independent files (nodes + hash, dependencies + hash) with non-atomic writes and no consistency check between them. Concurrent nx processes or a kill between writes can pair dependency data from one lockfile state with a hash claiming another; the poisoned cache then matches the current lockfile forever, and every command fails with `Source project does not exist: npm:<pkg>` until `nx reset`. The daemon also freezes external nodes across lockfile-only changes, failing in-flight recomputes.

## Expected Behavior

Lockfile caches are atomic (hash embedded in the file, tmp+rename writes), only reused when consistent with the external nodes in memory, and self-heal by reparsing when they reference missing nodes. The daemon refreshes external nodes on every cycle. Bad cache state never fails project graph computation.

[nxc-2793-lockfile-fix.pdf](https://github.com/user-attachments/files/29748203/nxc-2793-lockfile-fix.pdf)


## Related Issue(s)

NXC-2793

Fixes #30416

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/nxc-2793-bc2a19f2)
<!-- polygraph-session-end -->