### PR TITLE
docs(misc): note that package managers can override .env variables

### DIFF
--- a/astro-docs/src/content/docs/guides/Tips-n-Tricks/define-environment-variables.mdoc
+++ b/astro-docs/src/content/docs/guides/Tips-n-Tricks/define-environment-variables.mdoc
@@ -79,9 +79,9 @@ for workspace-specific settings (like the [Nx Cloud token](/docs/guides/nx-cloud
 {% aside type="caution" title="Package managers can set variables before Nx runs" %}
 The rule above also applies to variables you didn't set yourself. A package manager can put variables into the process before Nx reads any `.env` file, and Nx keeps those values.
 
-For example, npm's `node-options` setting (from a project, user, or global `.npmrc`) becomes a `NODE_OPTIONS` variable when you run `npm run nx ...` or `npx nx ...`. If you also set `NODE_OPTIONS` in `.env`, the `.npmrc` value wins, while running `nx` directly uses the `.env` value.
+For example, the npm `node-options` setting (from a project, user, or global `.npmrc`) becomes a `NODE_OPTIONS` variable when you run `npm run nx ...` or `npx nx ...`. If you also set `NODE_OPTIONS` in `.env`, the `.npmrc` value wins, while running `nx` directly uses the `.env` value.
 
-This is the package manager's behavior, not Nx overriding your files. If you rely on a variable from `.env`, make sure nothing else sets it, such as npm's `node-options`.
+The package manager sets the value, not Nx. If you rely on a variable from `.env`, make sure nothing else sets it first.
 {% /aside %}
 
 {% aside type="caution" title="Env files are not loaded in batch mode" %}

--- a/astro-docs/src/content/docs/guides/Tips-n-Tricks/define-environment-variables.mdoc
+++ b/astro-docs/src/content/docs/guides/Tips-n-Tricks/define-environment-variables.mdoc
@@ -76,6 +76,14 @@ We recommend nesting your **app** specific `env` files in `apps/your-app`, and c
 for workspace-specific settings (like the [Nx Cloud token](/docs/guides/nx-cloud/access-tokens)).
 {% /aside %}
 
+{% aside type="caution" title="Package managers can set variables before Nx runs" %}
+The rule above also applies to variables you didn't set yourself. A package manager can put variables into the process before Nx reads any `.env` file, and Nx keeps those values.
+
+For example, npm's `node-options` setting (from a project, user, or global `.npmrc`) becomes a `NODE_OPTIONS` variable when you run `npm run nx ...` or `npx nx ...`. If you also set `NODE_OPTIONS` in `.env`, the `.npmrc` value wins, while running `nx` directly uses the `.env` value.
+
+This is the package manager's behavior, not Nx overriding your files. If you rely on a variable from `.env`, make sure nothing else sets it, such as npm's `node-options`.
+{% /aside %}
+
 {% aside type="caution" title="Env files are not loaded in batch mode" %}
 The task-specific `.env` files described above are **not** loaded for tasks run with [batch mode](/docs/reference/glossary#batch-mode) (Gradle and Maven tasks run this way be default). Batch processes only receive the variables present in the current environment and root .env files, like `.env` and `.env.local`, so variables defined in files like `.env.[target-name]` won't be available.
 {% /aside %}


### PR DESCRIPTION
## Current Behavior

The environment variables guide explains that Nx ignores a variable that is already loaded into the process, but it doesn't mention that a package manager can be what loads it. Running Nx through `npm run` or `npx` can set variables before Nx reads `.env` files (for example, npm's `node-options` config becomes a real `NODE_OPTIONS` variable). The `.env` value is then silently ignored, while running `nx` directly uses it. Users hit this and mistake it for an Nx bug.

## Expected Behavior

The guide documents the interaction. A new caution aside in the environment variables guide explains that a package manager can set variables before Nx runs, uses npm's `node-options` -> `NODE_OPTIONS` as the concrete example, and clarifies that this is the package manager's behavior, not Nx overriding your files.

## Why documentation only

When Nx runs via `npm run` / `npx`, npm translates its `node-options` config (from any `.npmrc`: project, user, or global) into a real `NODE_OPTIONS` environment variable before Nx starts. Nx loads `.env` files with dotenv's default `override: false`, so a variable already present in the environment wins. Direct `nx` runs have no such variable, so `.env` applies.

This process-env-wins behavior is intentional and already documented (it protects system variables like `NODE_ENV`). Letting `.env` override it would regress that protection, and Nx can't reliably distinguish an npm-injected variable from a genuine shell or CI one: npm exposes only the merged value, not its origin. Documenting the interaction is the correct fix.

## Related Issue(s)

Fixes #30298

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/gh-30298-1d731484)
<!-- polygraph-session-end -->