### PR TITLE
fix(vitest): honor watch config and keep --ui open in the test executor

### DIFF
--- a/packages/vitest/src/executors/test/lib/utils.spec.ts
+++ b/packages/vitest/src/executors/test/lib/utils.spec.ts
@@ -6,6 +6,7 @@ import {
   loadViteDynamicImport,
   loadVitestDynamicImport,
 } from '../../../utils/executor-utils';
+import { isCI } from 'nx/src/devkit-internals';
 
 jest.mock('../../../utils/options-utils', () => ({
   normalizeViteConfigFilePath: jest.fn(),
@@ -14,6 +15,7 @@ jest.mock('../../../utils/executor-utils', () => ({
   loadViteDynamicImport: jest.fn(),
   loadVitestDynamicImport: jest.fn(),
 }));
+jest.mock('nx/src/devkit-internals', () => ({ isCI: jest.fn() }));
 
 describe('getOptions', () => {
   const context = {
@@ -37,6 +39,7 @@ describe('getOptions', () => {
     (loadVitestDynamicImport as jest.Mock).mockResolvedValue({
       parseCLI: jest.fn(() => ({ filter: [], options: {} })),
     });
+    (isCI as jest.Mock).mockReturnValue(false);
   });
 
   afterEach(() => jest.clearAllMocks());
@@ -97,6 +100,113 @@ describe('getOptions', () => {
       '/root/libs/my-lib/vitest.config.ts'
     );
     expect(result.mode).toBe('ci');
+  });
+
+  describe('watch resolution', () => {
+    const mockParsedWatch = (watch: boolean | undefined) => {
+      (loadVitestDynamicImport as jest.Mock).mockResolvedValue({
+        parseCLI: jest.fn(() => ({
+          filter: [],
+          options: watch === undefined ? {} : { watch },
+        })),
+      });
+    };
+    const mockConfigWatch = (watch: boolean | undefined) => {
+      loadConfigFromFile.mockResolvedValue({
+        path: '/root/libs/my-lib/vitest.config.ts',
+        config: {
+          test: {
+            reporters: ['default'],
+            ...(watch === undefined ? {} : { watch }),
+          },
+        },
+      });
+    };
+    const mockParsedUi = () => {
+      (loadVitestDynamicImport as jest.Mock).mockResolvedValue({
+        parseCLI: jest.fn(() => ({ filter: [], options: { ui: true } })),
+      });
+    };
+    const withEnv = async (
+      ci: boolean,
+      tty: boolean,
+      fn: () => Promise<void>
+    ) => {
+      (isCI as jest.Mock).mockReturnValue(ci);
+      const prevTty = process.stdin.isTTY;
+      Object.defineProperty(process.stdin, 'isTTY', {
+        value: tty,
+        configurable: true,
+      });
+      try {
+        await fn();
+      } finally {
+        Object.defineProperty(process.stdin, 'isTTY', {
+          value: prevTty,
+          configurable: true,
+        });
+      }
+    };
+    const callGetOptions = () =>
+      getOptions({ configFile: 'vitest.config.ts' }, context, 'libs/my-lib');
+
+    it('should default watch to false when neither CLI nor config set it', async () => {
+      const result = await callGetOptions();
+      expect(result.watch).toBe(false);
+    });
+
+    it('should honor config test.watch when no CLI --watch is passed', async () => {
+      mockConfigWatch(true);
+      const result = await callGetOptions();
+      expect(result.watch).toBe(true);
+    });
+
+    it('should let an explicit CLI --watch override the config', async () => {
+      mockParsedWatch(true);
+      mockConfigWatch(false);
+      const result = await callGetOptions();
+      expect(result.watch).toBe(true);
+    });
+
+    it('should let an explicit CLI --no-watch override config test.watch: true', async () => {
+      mockParsedWatch(false);
+      mockConfigWatch(true);
+      const result = await callGetOptions();
+      expect(result.watch).toBe(false);
+    });
+
+    it('should watch on --ui in an interactive terminal (not CI)', async () => {
+      mockParsedUi();
+      await withEnv(false, true, async () => {
+        const result = await callGetOptions();
+        expect(result.watch).toBe(true);
+      });
+    });
+
+    it('should not watch on --ui in CI', async () => {
+      mockParsedUi();
+      await withEnv(true, true, async () => {
+        const result = await callGetOptions();
+        expect(result.watch).toBe(false);
+      });
+    });
+
+    it('should not watch on --ui when not attached to a TTY', async () => {
+      mockParsedUi();
+      await withEnv(false, false, async () => {
+        const result = await callGetOptions();
+        expect(result.watch).toBe(false);
+      });
+    });
+
+    it('should let config test.watch: false override --ui', async () => {
+      mockParsedUi();
+      mockConfigWatch(false);
+      await withEnv(false, true, async () => {
+        const result = await callGetOptions();
+        expect(result.watch).toBe(false);
+      });
+    });
   });
 });
 

--- a/packages/vitest/src/executors/test/lib/utils.ts
+++ b/packages/vitest/src/executors/test/lib/utils.ts
@@ -12,6 +12,7 @@ import {
   loadViteDynamicImport,
   loadVitestDynamicImport,
 } from '../../../utils/executor-utils';
+import { isCI } from 'nx/src/devkit-internals';
 
 export async function getOptions(
   options: VitestExecutorOptions,
@@ -94,10 +95,20 @@ export async function getOptions(
     ...passThroughOptions
   } = normalizedExtraArgs as Record<string, any>;
 
+  // Vitest keeps the UI/browser server alive only in watch mode and has no
+  // --ui -> watch link, so a run-once `nx test --ui` tears the UI down right
+  // after the run. When --ui is requested from an interactive, non-CI terminal,
+  // default watch on so the UI stays open; bare runs and CI stay run-once so
+  // `nx run-many`/`affected` don't hang. An explicit CLI --watch/--no-watch or a
+  // config `test.watch` still takes precedence.
+  const uiRequested = passThroughOptions.ui === true;
+  const watchForUi = uiRequested && !!process.stdin.isTTY && !isCI();
+
   return {
-    // Explicitly set watch mode to false if not provided otherwise vitest
-    // will enable watch mode by default for non CI environments
-    watch: watch ?? false,
+    watch:
+      watch ??
+      (resolved?.config?.['test'] as Record<string, any>)?.watch ??
+      watchForUi,
     // Pass through any additional Vitest options
     ...passThroughOptions,
     // This should not be needed as it's going to be set in vite.config.ts


### PR DESCRIPTION
## Current Behavior

The `@nx/vitest:test` executor always forced `watch: false` when `--watch` was not passed on the command line. This overrode the `test.watch` setting in the Vitest config, so `nx test --ui` ran the tests once and immediately tore down the Vitest UI and browser server. Setting `test.watch: true` in the config had no effect either.

## Expected Behavior

The executor no longer overrides the watch setting. Watch resolves from an explicit CLI `--watch`/`--no-watch`, then the config's `test.watch`, and finally defaults on for `--ui` when running in an interactive, non-CI terminal, matching how vitest decides its own interactive watch default. `nx test --ui` now keeps the UI and browser open in a terminal, and `test.watch: true` is respected. Bare runs, CI, and configs that keep `test.watch: false` stay run-once so `nx run-many` and `affected` do not hang.

## Related Issue(s)

Fixes #30263

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/gh-30263-8097bc46)
<!-- polygraph-session-end -->