### PR TITLE
fix(webpack): disable extractComments on the swc terser minimizer

### DIFF
--- a/packages/webpack/src/plugins/nx-webpack-plugin/lib/apply-base-config.spec.ts
+++ b/packages/webpack/src/plugins/nx-webpack-plugin/lib/apply-base-config.spec.ts
@@ -2,6 +2,12 @@ import { applyBaseConfig } from './apply-base-config';
 import { NormalizedNxAppWebpackPluginOptions } from '../nx-app-webpack-plugin-options';
 import { Configuration } from 'webpack';
 
+// swc-loader is an optional peer dependency that isn't installed in this
+// workspace; stub the loader factory so tests don't depend on resolving it.
+jest.mock('./compiler-loaders', () => ({
+  createLoaderFromCompiler: () => ({ test: /\.([jt])sx?$/ }),
+}));
+
 describe('apply-base-config libraryTarget handling', () => {
   let options: NormalizedNxAppWebpackPluginOptions;
   let config: Partial<Configuration>;
@@ -121,5 +127,48 @@ describe('apply-base-config libraryTarget handling', () => {
     expect(config.output.libraryTarget).toBeUndefined();
     expect((config.output.library as any).type).toBe('module');
     expect((config.output.library as any).name).toBe('MyLib');
+  });
+});
+
+describe('apply-base-config minimizer', () => {
+  let options: NormalizedNxAppWebpackPluginOptions;
+  let config: Partial<Configuration>;
+
+  beforeEach(() => {
+    options = {
+      root: '/test',
+      projectRoot: 'apps/test',
+      sourceRoot: 'apps/test/src',
+      target: 'web',
+      optimization: true,
+    } as NormalizedNxAppWebpackPluginOptions;
+
+    config = {};
+    global.NX_GRAPH_CREATION = false;
+  });
+
+  afterEach(() => {
+    delete global.NX_GRAPH_CREATION;
+  });
+
+  // terser-webpack-plugin 5.6+ forwards `extractComments` into swc's minify
+  // options, which rejects it as an unknown field. Both compiler branches must
+  // disable it. See https://github.com/nrwl/nx/issues/36233.
+  it('should set extractComments: false on the swc minimizer', () => {
+    options.compiler = 'swc';
+
+    applyBaseConfig(options, config);
+
+    const terserPlugin = config.optimization.minimizer[0] as any;
+    expect(terserPlugin.options.extractComments).toBe(false);
+  });
+
+  it('should set extractComments: false on the babel minimizer', () => {
+    options.compiler = 'babel';
+
+    applyBaseConfig(options, config);
+
+    const terserPlugin = config.optimization.minimizer[0] as any;
+    expect(terserPlugin.options.extractComments).toBe(false);
   });
 });

--- a/packages/webpack/src/plugins/nx-webpack-plugin/lib/apply-base-config.ts
+++ b/packages/webpack/src/plugins/nx-webpack-plugin/lib/apply-base-config.ts
@@ -199,6 +199,10 @@ function applyNxIndependentConfig(
           })
         : new TerserPlugin({
             minify: TerserPlugin.swcMinify,
+            // terser-webpack-plugin 5.6+ forwards `extractComments` into swc's
+            // minify options, which rejects it as an unknown field. Disable it
+            // like the babel branch does above.
+            extractComments: false,
             // `terserOptions` options will be passed to `swc`
             terserOptions: {
               module: true,


### PR DESCRIPTION
## Current Behavior

Production builds using `@nx/webpack:webpack` with `compiler: 'swc'` and optimization enabled crash during minification once `terser-webpack-plugin` resolves to 5.6.x:

```
ERROR in main.js
main.js from Terser plugin
unknown field `extractComments`, expected one of `parse`, `compress`, `mangle`, `format`, `output`, `ecma`, ...
```

The babel compiler path sets `extractComments: false` on its `TerserPlugin`, but the swc path did not.

## Expected Behavior

`compiler: 'swc'` production builds minify successfully, consistent with the babel path.

## Related Issue(s)

Fixes #36233

## Implementation Details

`terser-webpack-plugin` 5.6 changed its swc minifier to forward the plugin-level `extractComments` option (default `true`) into `@swc/core`'s `minify()` options. `@swc/core` rejects `extractComments` as an unknown field, so any swc production build using Nx's default minimizer throws. Only `extractComments: false` avoids the forward, since the plugin skips it only when the value is exactly `false`.

The fix sets `extractComments: false` on the swc `TerserPlugin`, mirroring the babel branch. Verified against a real webpack build: on 5.6.1 the crash disappears, and the emitted bundle is byte-identical to the output on the previously pinned 5.3.x (which ignored the option), so there is no behavior change beyond removing the crash.

The trigger is the `terser-webpack-plugin` 5.6 bump, not a specific webpack version; the crash reproduces on webpack 5.105.x as well.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/gh-36233-863e6541)
<!-- polygraph-session-end -->