### PR TITLE
fix(js): parse pnpm/npm publish JSON containing braces in file paths

### DIFF
--- a/packages/js/src/executors/release-publish/extract-npm-publish-json-data.spec.ts
+++ b/packages/js/src/executors/release-publish/extract-npm-publish-json-data.spec.ts
@@ -461,5 +461,352 @@ prepublishOnly from package-a
               }"
       `);
     });
+
+    it('should extract the relevant JSON data when a files[].path contains curly braces', () => {
+      // pnpm/npm publish emit the literal file path, so a template dir such as
+      // "templates/{{name}}" puts braces inside a string value. A brace-counting
+      // regex mismatches the top-level object here; the scanner must not (#36236).
+      const commandOutput = `{
+  "id": "repro-curly-braces@0.0.1",
+  "name": "repro-curly-braces",
+  "version": "0.0.1",
+  "size": 300,
+  "unpackedSize": 200,
+  "shasum": "cf4a6657f230ddf5375102bafc8f5184002a620a",
+  "integrity": "sha512-Qra/YIkAxVavs3tumB/svugHLY5CISujdeUcMd2FfvtVkjEEsVAEYbqZTq0ixnkvjVrLr27mAvH94GjjMKWzIg==",
+  "filename": "repro-curly-braces-0.0.1.tgz",
+  "files": [
+    {
+      "path": "package.json",
+      "size": 200,
+      "mode": 420
+    },
+    {
+      "path": "templates/{{name}}/file.txt",
+      "size": 6,
+      "mode": 420
+    }
+  ],
+  "entryCount": 2,
+  "bundled": []
+}`;
+      const res = extractNpmPublishJsonData(commandOutput);
+
+      expect(res.beforeJsonData).toMatchInlineSnapshot(`""`);
+      expect(res.jsonData).toMatchInlineSnapshot(`
+        {
+          "bundled": [],
+          "entryCount": 2,
+          "filename": "repro-curly-braces-0.0.1.tgz",
+          "files": [
+            {
+              "mode": 420,
+              "path": "package.json",
+              "size": 200,
+            },
+            {
+              "mode": 420,
+              "path": "templates/{{name}}/file.txt",
+              "size": 6,
+            },
+          ],
+          "id": "repro-curly-braces@0.0.1",
+          "integrity": "sha512-Qra/YIkAxVavs3tumB/svugHLY5CISujdeUcMd2FfvtVkjEEsVAEYbqZTq0ixnkvjVrLr27mAvH94GjjMKWzIg==",
+          "name": "repro-curly-braces",
+          "shasum": "cf4a6657f230ddf5375102bafc8f5184002a620a",
+          "size": 300,
+          "unpackedSize": 200,
+          "version": "0.0.1",
+        }
+      `);
+      expect(res.afterJsonData).toMatchInlineSnapshot(`""`);
+    });
+
+    it('should still extract the summary when surrounding output has unbalanced braces', () => {
+      // A lifecycle script can print arbitrary text: balanced brace pairs that are
+      // not JSON (the {{name}} in the echoed line) alongside a genuinely unmatched
+      // trailing '}'. Neither must swallow or corrupt the real summary object,
+      // whose files[].path also carries braces.
+      const commandOutput = `> repro@0.0.1 prepublishOnly
+> echo "generating {{name}} scaffold"
+
+generating {{name}} scaffold
+{
+  "id": "repro@0.0.1",
+  "name": "repro",
+  "version": "0.0.1",
+  "size": 300,
+  "unpackedSize": 200,
+  "shasum": "cf4a6657f230ddf5375102bafc8f5184002a620a",
+  "integrity": "sha512-Qra/YIkAxVavs3tumB/svugHLY5CISujdeUcMd2FfvtVkjEEsVAEYbqZTq0ixnkvjVrLr27mAvH94GjjMKWzIg==",
+  "filename": "repro-0.0.1.tgz",
+  "files": [
+    {
+      "path": "templates/{{name}}/file.txt",
+      "size": 6,
+      "mode": 420
+    }
+  ],
+  "entryCount": 1,
+  "bundled": []
+}
+done }`;
+      const res = extractNpmPublishJsonData(commandOutput);
+
+      expect(res.beforeJsonData).toMatchInlineSnapshot(`
+        "> repro@0.0.1 prepublishOnly
+        > echo "generating {{name}} scaffold"
+
+        generating {{name}} scaffold
+        "
+      `);
+      expect(res.jsonData).toMatchInlineSnapshot(`
+        {
+          "bundled": [],
+          "entryCount": 1,
+          "filename": "repro-0.0.1.tgz",
+          "files": [
+            {
+              "mode": 420,
+              "path": "templates/{{name}}/file.txt",
+              "size": 6,
+            },
+          ],
+          "id": "repro@0.0.1",
+          "integrity": "sha512-Qra/YIkAxVavs3tumB/svugHLY5CISujdeUcMd2FfvtVkjEEsVAEYbqZTq0ixnkvjVrLr27mAvH94GjjMKWzIg==",
+          "name": "repro",
+          "shasum": "cf4a6657f230ddf5375102bafc8f5184002a620a",
+          "size": 300,
+          "unpackedSize": 200,
+          "version": "0.0.1",
+        }
+      `);
+      expect(res.afterJsonData).toMatchInlineSnapshot(`
+        "
+        done }"
+      `);
+    });
+
+    it('should still extract the summary when preceding output has an unpaired quote', () => {
+      // Lifecycle output before the JSON can carry a lone '"' (an inch mark here).
+      // Quote tracking must not leak from that plain text onto the summary and
+      // hide its braces.
+      const commandOutput = `> repro@0.0.1 prepublishOnly
+> echo scaffold
+
+generated a 12" template
+{
+  "id": "repro@0.0.1",
+  "name": "repro",
+  "version": "0.0.1",
+  "size": 300,
+  "unpackedSize": 200,
+  "shasum": "cf4a6657f230ddf5375102bafc8f5184002a620a",
+  "integrity": "sha512-Qra/YIkAxVavs3tumB/svugHLY5CISujdeUcMd2FfvtVkjEEsVAEYbqZTq0ixnkvjVrLr27mAvH94GjjMKWzIg==",
+  "filename": "repro-0.0.1.tgz",
+  "files": [
+    {
+      "path": "package.json",
+      "size": 200,
+      "mode": 420
+    }
+  ],
+  "entryCount": 1,
+  "bundled": []
+}`;
+      const res = extractNpmPublishJsonData(commandOutput);
+
+      expect(res.beforeJsonData).toMatchInlineSnapshot(`
+        "> repro@0.0.1 prepublishOnly
+        > echo scaffold
+
+        generated a 12" template
+        "
+      `);
+      expect(res.jsonData).toMatchInlineSnapshot(`
+        {
+          "bundled": [],
+          "entryCount": 1,
+          "filename": "repro-0.0.1.tgz",
+          "files": [
+            {
+              "mode": 420,
+              "path": "package.json",
+              "size": 200,
+            },
+          ],
+          "id": "repro@0.0.1",
+          "integrity": "sha512-Qra/YIkAxVavs3tumB/svugHLY5CISujdeUcMd2FfvtVkjEEsVAEYbqZTq0ixnkvjVrLr27mAvH94GjjMKWzIg==",
+          "name": "repro",
+          "shasum": "cf4a6657f230ddf5375102bafc8f5184002a620a",
+          "size": 300,
+          "unpackedSize": 200,
+          "version": "0.0.1",
+        }
+      `);
+      expect(res.afterJsonData).toMatchInlineSnapshot(`""`);
+    });
+
+    it('should extract the summary when a files[].path uses backslash-escaped separators', () => {
+      // A Windows-style path escapes its separators as \\ and can include braces;
+      // the escape handling must not mis-terminate the surrounding string value.
+      const commandOutput = `{
+  "id": "repro@0.0.1",
+  "name": "repro",
+  "version": "0.0.1",
+  "size": 300,
+  "unpackedSize": 200,
+  "shasum": "cf4a6657f230ddf5375102bafc8f5184002a620a",
+  "integrity": "sha512-Qra/YIkAxVavs3tumB/svugHLY5CISujdeUcMd2FfvtVkjEEsVAEYbqZTq0ixnkvjVrLr27mAvH94GjjMKWzIg==",
+  "filename": "repro-0.0.1.tgz",
+  "files": [
+    {
+      "path": "templates\\\\{{name}}\\\\file.txt",
+      "size": 6,
+      "mode": 420
+    }
+  ],
+  "entryCount": 1,
+  "bundled": []
+}`;
+      const res = extractNpmPublishJsonData(commandOutput);
+
+      expect(res.beforeJsonData).toMatchInlineSnapshot(`""`);
+      expect(res.jsonData).toMatchInlineSnapshot(`
+        {
+          "bundled": [],
+          "entryCount": 1,
+          "filename": "repro-0.0.1.tgz",
+          "files": [
+            {
+              "mode": 420,
+              "path": "templates\\{{name}}\\file.txt",
+              "size": 6,
+            },
+          ],
+          "id": "repro@0.0.1",
+          "integrity": "sha512-Qra/YIkAxVavs3tumB/svugHLY5CISujdeUcMd2FfvtVkjEEsVAEYbqZTq0ixnkvjVrLr27mAvH94GjjMKWzIg==",
+          "name": "repro",
+          "shasum": "cf4a6657f230ddf5375102bafc8f5184002a620a",
+          "size": 300,
+          "unpackedSize": 200,
+          "version": "0.0.1",
+        }
+      `);
+      expect(res.afterJsonData).toMatchInlineSnapshot(`""`);
+    });
+
+    it('should still extract the summary when lifecycle output contains comment-like text or globs', () => {
+      // Lifecycle scripts print arbitrary text, including paths and globs such as
+      // "dist/*.js" or a "// build" line. These are not JSON comments and must not
+      // hide the summary that follows.
+      const commandOutput = `> repro@0.0.1 prepublishOnly
+> node ./scripts/build.js
+
+emitting dist/*.js and dist/**/*.d.ts
+// build complete
+{
+  "id": "repro@0.0.1",
+  "name": "repro",
+  "version": "0.0.1",
+  "size": 300,
+  "unpackedSize": 200,
+  "shasum": "cf4a6657f230ddf5375102bafc8f5184002a620a",
+  "integrity": "sha512-Qra/YIkAxVavs3tumB/svugHLY5CISujdeUcMd2FfvtVkjEEsVAEYbqZTq0ixnkvjVrLr27mAvH94GjjMKWzIg==",
+  "filename": "repro-0.0.1.tgz",
+  "files": [
+    {
+      "path": "package.json",
+      "size": 200,
+      "mode": 420
+    }
+  ],
+  "entryCount": 1,
+  "bundled": []
+}`;
+      const res = extractNpmPublishJsonData(commandOutput);
+
+      expect(res.beforeJsonData).toMatchInlineSnapshot(`
+        "> repro@0.0.1 prepublishOnly
+        > node ./scripts/build.js
+
+        emitting dist/*.js and dist/**/*.d.ts
+        // build complete
+        "
+      `);
+      expect(res.jsonData).toMatchInlineSnapshot(`
+        {
+          "bundled": [],
+          "entryCount": 1,
+          "filename": "repro-0.0.1.tgz",
+          "files": [
+            {
+              "mode": 420,
+              "path": "package.json",
+              "size": 200,
+            },
+          ],
+          "id": "repro@0.0.1",
+          "integrity": "sha512-Qra/YIkAxVavs3tumB/svugHLY5CISujdeUcMd2FfvtVkjEEsVAEYbqZTq0ixnkvjVrLr27mAvH94GjjMKWzIg==",
+          "name": "repro",
+          "shasum": "cf4a6657f230ddf5375102bafc8f5184002a620a",
+          "size": 300,
+          "unpackedSize": 200,
+          "version": "0.0.1",
+        }
+      `);
+      expect(res.afterJsonData).toMatchInlineSnapshot(`""`);
+    });
+
+    it('should unwrap the nested summary when a files[].path contains curly braces', () => {
+      // Combines the npm >= 11.16 / pnpm nesting under the package name with a
+      // brace-carrying file path, exercising the unwrap and scanner together.
+      const commandOutput = `{
+  "@scope/repro": {
+    "id": "@scope/repro@0.0.1",
+    "name": "@scope/repro",
+    "version": "0.0.1",
+    "size": 300,
+    "unpackedSize": 200,
+    "shasum": "cf4a6657f230ddf5375102bafc8f5184002a620a",
+    "integrity": "sha512-Qra/YIkAxVavs3tumB/svugHLY5CISujdeUcMd2FfvtVkjEEsVAEYbqZTq0ixnkvjVrLr27mAvH94GjjMKWzIg==",
+    "filename": "scope-repro-0.0.1.tgz",
+    "files": [
+      {
+        "path": "templates/{{name}}/file.txt",
+        "size": 6,
+        "mode": 420
+      }
+    ],
+    "entryCount": 1,
+    "bundled": []
+  }
+}`;
+      const res = extractNpmPublishJsonData(commandOutput);
+
+      expect(res.beforeJsonData).toMatchInlineSnapshot(`""`);
+      expect(res.jsonData).toMatchInlineSnapshot(`
+        {
+          "bundled": [],
+          "entryCount": 1,
+          "filename": "scope-repro-0.0.1.tgz",
+          "files": [
+            {
+              "mode": 420,
+              "path": "templates/{{name}}/file.txt",
+              "size": 6,
+            },
+          ],
+          "id": "@scope/repro@0.0.1",
+          "integrity": "sha512-Qra/YIkAxVavs3tumB/svugHLY5CISujdeUcMd2FfvtVkjEEsVAEYbqZTq0ixnkvjVrLr27mAvH94GjjMKWzIg==",
+          "name": "@scope/repro",
+          "shasum": "cf4a6657f230ddf5375102bafc8f5184002a620a",
+          "size": 300,
+          "unpackedSize": 200,
+          "version": "0.0.1",
+        }
+      `);
+      expect(res.afterJsonData).toMatchInlineSnapshot(`""`);
+    });
   });
 });

--- a/packages/js/src/executors/release-publish/extract-npm-publish-json-data.ts
+++ b/packages/js/src/executors/release-publish/extract-npm-publish-json-data.ts
@@ -6,19 +6,63 @@ const expectedNpmPublishJsonKeys = [
   'filename',
 ];
 
-// Regular expression to match JSON-like objects, including up to two levels of
-// nested objects.
-// /{(?:[^{}]|{(?:[^{}]|{[^{}]*})*})*}/g
-// Two levels of nesting are required to support both shapes of npm/pnpm publish
-// output:
-//   - Older npm (<= 11.13) prints the publish summary as a flat object whose only
-//     nesting is its own "files" array (one level deep).
-//   - Newer npm (>= 11.16, bundled with Node 26) nests that same summary under the
-//     package name, e.g. { "@scope/pkg": { ...id/name/files... } }, adding a
-//     second level. pnpm publish nests the same way when run from the workspace
-//     root. Matching two levels lets us capture the wrapper object in the nested
-//     case so its braces are not left behind in beforeJsonData/afterJsonData.
-const jsonRegex = /{(?:[^{}]|{(?:[^{}]|{[^{}]*})*})*}/g;
+// Pair each '{' with its matching '}' in the publish output. The output is npm's
+// pretty-printed JSON summary interleaved with arbitrary lifecycle-script text,
+// so we recognize only genuine JSON structure and treat everything else as
+// opaque, without interpreting it as JSON (unlike a JSONC parser):
+//   - Braces and quotes inside a JSON string value are ignored, so a files[].path
+//     like "templates/{{name}}/file.txt" doesn't throw off the pairing (#36236).
+//   - '//' and '/*' are not comments; lifecycle output legitimately prints globs
+//     and paths such as dist/*.js, and npm/pnpm emit plain JSON.
+//   - A raw newline ends a string. A valid JSON string never contains one (it is
+//     escaped as \n), so this can't truncate a real value, but it stops a stray
+//     unpaired '"' in log text from swallowing the summary on a later line.
+//   - A quote only opens a string inside an object, so a lone '"' in the preamble
+//     or between objects stays inert.
+// Stray unmatched braces are left unpaired.
+function matchBracePositions(str: string): Map<number, number> {
+  const matches = new Map<number, number>();
+  const openBraceStack: number[] = [];
+  let inString = false;
+  for (let i = 0; i < str.length; i++) {
+    const char = str[i];
+    if (inString) {
+      if (char === '\\') {
+        i++; // skip the escaped character
+      } else if (char === '"' || char === '\n' || char === '\r') {
+        inString = false;
+      }
+      continue;
+    }
+    if (char === '"') {
+      if (openBraceStack.length > 0) {
+        inString = true;
+      }
+    } else if (char === '{') {
+      openBraceStack.push(i);
+    } else if (char === '}') {
+      const openIndex = openBraceStack.pop();
+      if (openIndex !== undefined) {
+        matches.set(openIndex, i);
+      }
+    }
+  }
+  return matches;
+}
+
+// Yield every balanced {...} object in the output, left to right by start
+// position, so an outer wrapper is seen before the objects nested inside it.
+function* iterateBalancedJsonObjects(
+  str: string
+): Generator<{ text: string; index: number }> {
+  const closeByOpen = matchBracePositions(str);
+  for (let i = 0; i < str.length; i++) {
+    const closeIndex = closeByOpen.get(i);
+    if (closeIndex !== undefined) {
+      yield { text: str.slice(i, closeIndex + 1), index: i };
+    }
+  }
+}
 
 function isNpmPublishSummary(value: unknown): value is Record<string, unknown> {
   return (
@@ -35,51 +79,47 @@ export function extractNpmPublishJsonData(str: string): {
   jsonData: Record<string, unknown> | null;
   afterJsonData: string;
 } {
-  const jsonMatches = str.match(jsonRegex);
-  if (jsonMatches) {
-    for (const match of jsonMatches) {
-      // Cheap upfront check to see if the stringified JSON data has the expected keys as substrings
-      if (!expectedNpmPublishJsonKeys.every((key) => str.includes(key))) {
-        continue;
-      }
-      // Full JSON parsing to identify the JSON object
-      let parsedJson: unknown;
-      try {
-        parsedJson = JSON.parse(match);
-      } catch {
-        // Ignore parsing errors for unrelated JSON blocks
-        continue;
-      }
+  for (const { text: match, index } of iterateBalancedJsonObjects(str)) {
+    // Cheap check to skip candidates that can't be the summary before parsing
+    if (!expectedNpmPublishJsonKeys.every((key) => match.includes(key))) {
+      continue;
+    }
+    // Full JSON parsing to identify the JSON object
+    let parsedJson: unknown;
+    try {
+      parsedJson = JSON.parse(match);
+    } catch {
+      // Ignore parsing errors for unrelated JSON blocks
+      continue;
+    }
 
-      // npm <= 11.13 emits the summary as a flat object, while npm >= 11.16 (and
-      // pnpm publish run from the workspace root) nest it one level deep under the
-      // package name. Support both by unwrapping a single level when the matched
-      // object isn't itself the summary.
-      let publishData: Record<string, unknown> | null = null;
-      if (isNpmPublishSummary(parsedJson)) {
-        publishData = parsedJson;
-      } else if (typeof parsedJson === 'object' && parsedJson !== null) {
-        for (const value of Object.values(
-          parsedJson as Record<string, unknown>
-        )) {
-          if (isNpmPublishSummary(value)) {
-            publishData = value;
-            break;
-          }
+    // npm <= 11.13 emits the summary as a flat object, while npm >= 11.16 (and
+    // pnpm publish run from the workspace root) nest it one level deep under the
+    // package name. Support both by unwrapping a single level when the matched
+    // object isn't itself the summary.
+    let publishData: Record<string, unknown> | null = null;
+    if (isNpmPublishSummary(parsedJson)) {
+      publishData = parsedJson;
+    } else if (typeof parsedJson === 'object' && parsedJson !== null) {
+      for (const value of Object.values(
+        parsedJson as Record<string, unknown>
+      )) {
+        if (isNpmPublishSummary(value)) {
+          publishData = value;
+          break;
         }
       }
-
-      if (!publishData) {
-        continue;
-      }
-
-      const jsonStartIndex = str.indexOf(match);
-      return {
-        beforeJsonData: str.slice(0, jsonStartIndex),
-        jsonData: publishData,
-        afterJsonData: str.slice(jsonStartIndex + match.length),
-      };
     }
+
+    if (!publishData) {
+      continue;
+    }
+
+    return {
+      beforeJsonData: str.slice(0, index),
+      jsonData: publishData,
+      afterJsonData: str.slice(index + match.length),
+    };
   }
 
   // No applicable jsonData detected, the whole contents is the beforeJsonData


### PR DESCRIPTION
## Current Behavior

`nx release publish` can mark a publish as failed even after `pnpm publish` (or `npm publish`) has already succeeded and pushed the package to the registry. When a published file path contains curly braces, for example a template directory like `templates/{{name}}/file.txt`, the executor fails with:

> The pnpm publish output data could not be extracted. Please report this issue on https://github.com/nrwl/nx

The publish summary was located in stdout with a fixed-depth brace-counting regex. That regex is not JSON-aware: it treats `{` / `}` inside a JSON string value (such as a `files[].path`) as structural braces, so the top-level summary object no longer matches and extraction returns `null`. The package is published, but the command reports failure.

## Expected Behavior

When the package manager exits successfully and emits a valid JSON publish summary, `nx release publish` parses it and reports success, regardless of whether any `files[].path` contains curly braces.

## Related Issue(s)

Fixes #36236

## Implementation Details

`extractNpmPublishJsonData` no longer uses a regex. It pairs every `{` with its matching `}` in one string-aware pass, ignoring braces and quotes that appear inside JSON string literals, then scans the balanced objects left to right and unwraps the summary (flat, or nested one level under the package name for newer npm and for pnpm run from the workspace root).

This removes the fixed-depth limitation: string values may contain any number of braces and the object may nest arbitrarily deep. The summary is interleaved with arbitrary lifecycle-script output, so the scanner treats that surrounding text as opaque: it does not interpret `//` or `/*` as comments (a script may legitimately print a glob such as `dist/*.js`), and it ends a string at a raw newline (which valid JSON never contains) so a stray quote in log text cannot hide the summary. Stray unbalanced braces in that output are also left unpaired.

Added tests cover a `files[].path` with curly braces, a Windows-style backslash-escaped path, a summary nested under the package name with a brace-carrying path, unbalanced braces and a stray unpaired quote in surrounding lifecycle output, and comment-like text or globs before the summary.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/gh-36236-bce72e6b)
<!-- polygraph-session-end -->
