### PR TITLE
feat(release): add option to force changelog generation for programmatic usage

### DIFF
--- a/packages/nx/src/command-line/release/changelog.spec.ts
+++ b/packages/nx/src/command-line/release/changelog.spec.ts
@@ -1,0 +1,214 @@
+import type { ProjectFileMap, ProjectGraph } from '../../config/project-graph';
+import { TempFs } from '../../internal-testing-utils/temp-fs';
+import { output } from '../../utils/output';
+import { createAPI } from './changelog';
+import type { ReleaseGroupWithName } from './config/filter-release-groups';
+import type { ReleaseGraph } from './utils/release-graph';
+
+jest.mock('../../project-graph/project-graph', () => ({
+  createProjectGraphAsync: jest.fn(),
+}));
+
+jest.mock('../../project-graph/file-map-utils', () => ({
+  createProjectFileMapUsingProjectGraph: jest.fn(),
+  createFileMapUsingProjectGraph: jest.fn(() =>
+    Promise.resolve({
+      fileMap: { projectFileMap: {}, nonProjectFiles: [] },
+    })
+  ),
+}));
+
+jest.mock('./utils/git', () => ({
+  ...jest.requireActual('./utils/git'),
+  getCommitHash: jest.fn(() => Promise.resolve('abc123')),
+  getGitDiff: jest.fn(() => Promise.resolve([])),
+  parseCommits: jest.fn(() => []),
+  gitAdd: jest.fn(),
+  gitPush: jest.fn(),
+  gitTag: jest.fn(),
+}));
+
+jest.mock('./config/version-plans', () => ({
+  ...jest.requireActual('./config/version-plans'),
+  readRawVersionPlans: jest.fn(() => Promise.resolve([])),
+  setResolvedVersionPlansOnGroups: jest.fn(),
+}));
+
+jest.mock('./changelog/version-plan-filtering', () => ({
+  ...jest.requireActual('./changelog/version-plan-filtering'),
+  resolveWorkspaceChangelogFromSHA: jest.fn(() => Promise.resolve('fromsha')),
+}));
+
+const MOCK_CHANGELOG_CONTENTS = '## 1.0.0\n\nMocked changelog contents';
+
+jest.mock('./utils/resolve-changelog-renderer', () => ({
+  resolveChangelogRenderer: jest.fn(
+    () =>
+      class FakeChangelogRenderer {
+        async render() {
+          return MOCK_CHANGELOG_CONTENTS;
+        }
+      }
+  ),
+}));
+
+jest.mock('./utils/remote-release-clients/remote-release-client', () => ({
+  ...jest.requireActual('./utils/remote-release-clients/remote-release-client'),
+  createRemoteReleaseClient: jest.fn(() =>
+    Promise.resolve({
+      remoteReleaseProviderName: 'GitHub',
+      createPostGitTask: jest.fn(),
+    })
+  ),
+}));
+
+const {
+  createProjectGraphAsync,
+} = require('../../project-graph/project-graph');
+const {
+  createProjectFileMapUsingProjectGraph,
+} = require('../../project-graph/file-map-utils');
+
+describe('releaseChangelog', () => {
+  let tempFs: TempFs;
+  let projectGraph: ProjectGraph;
+  let projectFileMap: ProjectFileMap;
+  let releaseGraph: ReleaseGraph;
+
+  beforeEach(async () => {
+    jest.clearAllMocks();
+
+    tempFs = new TempFs('nx-release-changelog-test');
+    await tempFs.createFiles({
+      'package.json': JSON.stringify({
+        name: 'root',
+        version: '0.0.0',
+        private: true,
+      }),
+      'packages/pkg-a/package.json': JSON.stringify({
+        name: 'pkg-a',
+        version: '0.0.0',
+      }),
+    });
+
+    projectGraph = {
+      nodes: {
+        'pkg-a': {
+          name: 'pkg-a',
+          type: 'lib',
+          data: {
+            root: 'packages/pkg-a',
+            targets: {
+              'nx-release-publish': {},
+            },
+          } as any,
+        },
+      },
+      dependencies: {},
+    };
+    projectFileMap = {
+      'pkg-a': [
+        {
+          file: 'packages/pkg-a/package.json',
+          hash: 'abc',
+        },
+      ],
+    };
+
+    createProjectGraphAsync.mockResolvedValue(projectGraph);
+    createProjectFileMapUsingProjectGraph.mockResolvedValue(projectFileMap);
+
+    const releaseGroup = {
+      name: '__default__',
+      projectsRelationship: 'fixed',
+      projects: ['pkg-a'],
+      changelog: false,
+      versionPlans: false,
+      resolvedVersionPlans: false,
+      releaseTag: {
+        pattern: 'v{version}',
+        checkAllBranchesWhen: undefined,
+        requireSemver: true,
+        strictPreid: false,
+      },
+    } as unknown as ReleaseGroupWithName;
+
+    releaseGraph = {
+      releaseGroups: [releaseGroup],
+      releaseGroupToFilteredProjects: new Map([
+        [releaseGroup, new Set(['pkg-a'])],
+      ]),
+      resolveRepositoryTags: jest.fn(),
+      filterLog: null,
+    } as unknown as ReleaseGraph;
+
+    jest.spyOn(output, 'warn').mockImplementation(() => {});
+    jest.spyOn(output, 'log').mockImplementation(() => {});
+    jest.spyOn(output, 'logSingleLine').mockImplementation(() => {});
+    jest.spyOn(output, 'note').mockImplementation(() => {});
+    jest.spyOn(output, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    tempFs.cleanup();
+    jest.restoreAllMocks();
+  });
+
+  function runReleaseChangelog(
+    extraArgs: Record<string, unknown> = {}
+  ): ReturnType<ReturnType<typeof createAPI>> {
+    // Mirrors programmatic usage of `new ReleaseClient(config, true).releaseChangelog(...)`
+    const releaseChangelog = createAPI(
+      {
+        changelog: {
+          // `file: false` and `createRelease` unset (which resolves to false) means
+          // the changelog config is considered "effectively disabled"
+          workspaceChangelog: {
+            file: false,
+          },
+        },
+      },
+      true
+    );
+    return releaseChangelog({
+      version: '1.0.0',
+      gitCommit: false,
+      gitTag: false,
+      gitPush: false,
+      stageChanges: false,
+      releaseGraph,
+      ...extraArgs,
+    } as Parameters<ReturnType<typeof createAPI>>[0]);
+  }
+
+  describe('when changelogs are effectively disabled (file: false and createRelease resolving to false)', () => {
+    it('should skip changelog generation and return an empty result by default', async () => {
+      const result = await runReleaseChangelog();
+
+      expect(result).toEqual({});
+      expect(output.warn).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: `Changelogs are disabled. No changelog entries will be generated`,
+        })
+      );
+    });
+
+    it('should generate changelogs when forceChangelogGeneration is set, making contents available in memory', async () => {
+      const result = await runReleaseChangelog({
+        forceChangelogGeneration: true,
+      });
+
+      expect(output.warn).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: `Changelogs are disabled. No changelog entries will be generated`,
+        })
+      );
+      expect(result.workspaceChangelog).toBeDefined();
+      expect(result.workspaceChangelog!.contents).toEqual(
+        MOCK_CHANGELOG_CONTENTS
+      );
+      // file: false means nothing should have been written to disk
+      await expect(tempFs.readFile('CHANGELOG.md')).rejects.toThrow();
+    });
+  });
+});

--- a/packages/nx/src/command-line/release/changelog.ts
+++ b/packages/nx/src/command-line/release/changelog.ts
@@ -206,7 +206,12 @@ export function createAPI(
       output.note(releaseGraph.filterLog);
     }
 
+    // Programmatic API consumers can force changelog generation to run even when the resolved
+    // configuration is considered effectively disabled (e.g. when they have disabled changelog
+    // file writing and remote release creation because they consume the returned changelog
+    // contents in memory instead)
     const changelogGenerationEnabled =
+      args.forceChangelogGeneration ||
       isChangelogEffectivelyEnabled(
         nxReleaseConfig.changelog.workspaceChangelog
       ) ||

--- a/packages/nx/src/command-line/release/command-object.ts
+++ b/packages/nx/src/command-line/release/command-object.ts
@@ -71,6 +71,18 @@ export type ChangelogOptions = NxReleaseArgs &
     createRelease?: false | 'github' | 'gitlab';
     resolveVersionPlans?: 'all' | 'using-from-and-to';
     replaceExistingContents?: boolean;
+    /**
+     * Force changelog generation to run even when the resolved changelog configuration is
+     * considered effectively disabled (i.e. changelog file writing is disabled via `file: false`
+     * and remote release creation resolves to being disabled).
+     *
+     * This is intended for programmatic API consumers of `releaseChangelog` who intentionally
+     * disable file writing and remote release creation because they want to consume the generated
+     * changelog contents in memory from the returned result instead.
+     *
+     * NOTE: This option is only available via the programmatic API, it is not exposed as a CLI flag.
+     */
+    forceChangelogGeneration?: boolean;
     // This will only be set if using the `nx release` top level command, or orchestrating via the programmatic API
     releaseGraph?: ReleaseGraph;
   };


### PR DESCRIPTION
## Current Behavior

Since #35405, `releaseChangelog` early-returns `{}` with the warning `Changelogs are disabled. No changelog entries will be generated` whenever the resolved changelog config is not "effectively enabled" (`file !== false || createRelease !== false`).

This broke a legitimate programmatic pattern: callers using `new ReleaseClient(config, true).releaseChangelog(...)` with `workspaceChangelog: { file: false, ... }` who consume the returned `workspaceChangelog.contents` in memory instead of writing a file or creating a remote release. Real-world consumer: the Nx Cloud changelog automation in nrwl/ocean, which captures the contents in memory and pushes them to the nrwl/nx-cloud-changelog repo. It silently generated nothing from Nx 23.0.0-rc.0 onward (workaround: nrwl/ocean#12223).

## Expected Behavior

Programmatic API consumers can explicitly opt out of the skip:

```ts
await new ReleaseClient(config, true).releaseChangelog({
  version: '1.0.0',
  forceChangelogGeneration: true,
  // ...
});
```

`forceChangelogGeneration` bypasses only the early-return gate. Everything else is unchanged: `file: false` still prevents disk writes, no remote release is created, and git operations are unaffected. The perf optimization from #35405 remains the default.

The option is programmatic-API-only (documented in TSDoc on `ChangelogOptions`), not a CLI flag: the in-memory consumption pattern only exists via the API, and a CLI user forcing generation with all outputs disabled would produce no observable output.

## Changes

- `packages/nx/src/command-line/release/command-object.ts`: add `forceChangelogGeneration?: boolean` to `ChangelogOptions` with TSDoc.
- `packages/nx/src/command-line/release/changelog.ts`: check `args.forceChangelogGeneration` before the `isChangelogEffectivelyEnabled` gate.
- `packages/nx/src/command-line/release/changelog.spec.ts`: tests for the default skip behavior and the forced path (including asserting no file is written with `file: false`).

## Verification

- New spec: 2/2 passing.
- Full release area: 24 suites, 464 passing (1 skipped).
- Typecheck and ESLint clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/Nx-Cloud-changelog-generation-fix-Nx-23-ReleaseClient-gate-a02735de)
<!-- polygraph-session-end -->