### PR TITLE
fix(core): respect empty externalDependencies with ^ dependency inputs

### DIFF
--- a/packages/nx/src/native/tasks/hash_planner.rs
+++ b/packages/nx/src/native/tasks/hash_planner.rs
@@ -28,6 +28,40 @@ pub struct HashPlanner {
     external_deps_mapped: OnceLock<HashMap<String, Vec<String>>>,
 }
 
+/// Resolution of a target's own `externalDependencies` inputs. The variant
+/// decides both the external hash instructions added at the task's own level
+/// and whether `^`-dependency inputs may contribute external nodes (#36239).
+enum TargetExternalInput {
+    /// Executor deps can't be determined (target missing, or a local-plugin
+    /// executor we can't introspect). Contributes no external instructions.
+    Unknown,
+    /// A specific set of external nodes: an @nx executor's deps, or an explicit
+    /// non-empty `externalDependencies` list.
+    Specific(Vec<HashInstruction>),
+    /// No `externalDependencies` input declared, so hash every external dep.
+    All,
+    /// An empty `externalDependencies` input: the task opted out of external
+    /// deps, so `^`-dependency traversal must skip external nodes (#36239).
+    OptedOut,
+}
+
+impl TargetExternalInput {
+    /// External hash instructions contributed at the task's own level.
+    fn into_instructions(self) -> Vec<HashInstruction> {
+        match self {
+            TargetExternalInput::Specific(instructions) => instructions,
+            TargetExternalInput::All => vec![HashInstruction::AllExternalDependencies],
+            TargetExternalInput::Unknown | TargetExternalInput::OptedOut => vec![],
+        }
+    }
+
+    /// Whether the task opted out of external deps via an empty
+    /// `externalDependencies` input.
+    fn opted_out(&self) -> bool {
+        matches!(self, TargetExternalInput::OptedOut)
+    }
+}
+
 #[napi]
 impl HashPlanner {
     #[napi(constructor)]
@@ -71,12 +105,13 @@ impl HashPlanner {
                     .ok_or_else(|| anyhow::anyhow!("Task with id '{id}' not found"))?;
                 let inputs = get_inputs(task, &self.project_graph, &self.nx_json)?;
 
-                let target = self.target_input(
+                let target_external = self.target_input(
                     &task.target.project,
                     &task.target.target,
                     &inputs.self_inputs,
                     external_deps_mapped,
                 )?;
+                let external_deps_opted_out = target_external.opted_out();
 
                 let self_inputs = self.self_and_deps_inputs(
                     &task.target.project,
@@ -84,11 +119,12 @@ impl HashPlanner {
                     &inputs,
                     &task_graph,
                     external_deps_mapped,
+                    external_deps_opted_out,
                     &mut Box::new(hashbrown::HashSet::from([task.target.project.as_str()])),
                 )?;
 
-                let mut inputs: Vec<HashInstruction> = target
-                    .unwrap_or(vec![])
+                let mut inputs: Vec<HashInstruction> = target_external
+                    .into_instructions()
                     .into_iter()
                     .chain(vec![
                         HashInstruction::Environment("NX_CLOUD_ENCRYPTION_KEY".into()),
@@ -151,16 +187,20 @@ impl HashPlanner {
         Ok(External::new(plans))
     }
 
+    /// Resolves the target's own `externalDependencies` inputs. The returned
+    /// `TargetExternalInput` tells the caller both what external hash
+    /// instructions to add at the task's own level and whether `^`-dependency
+    /// inputs may pull in external nodes (#36239).
     fn target_input<'a>(
         &'a self,
         project_name: &str,
         target_name: &str,
         self_inputs: &[Input],
         external_deps_map: &'a HashMap<String, Vec<String>>,
-    ) -> anyhow::Result<Option<Vec<HashInstruction>>> {
+    ) -> anyhow::Result<TargetExternalInput> {
         let project = &self.project_graph.nodes[project_name];
         let Some(target) = project.targets.get(target_name) else {
-            return Ok(None);
+            return Ok(TargetExternalInput::Unknown);
         };
 
         // we can only vouch for @nx packages's executor dependencies
@@ -182,7 +222,7 @@ impl HashPlanner {
             else {
                 // this usually happens because the executor was a local plugin.
                 // todo)) @Cammisuli: we need to gather the project's inputs and its dep inputs similar to how we do it in `self_and_deps_inputs`
-                return Ok(None);
+                return Ok(TargetExternalInput::Unknown);
             };
             let mut external_deps: Vec<&'a String> = vec![];
             trace!(
@@ -195,7 +235,7 @@ impl HashPlanner {
             );
             external_deps.push(existing_package);
             external_deps.extend(&external_deps_map[existing_package]);
-            Ok(Some(
+            Ok(TargetExternalInput::Specific(
                 external_deps
                     .iter()
                     .map(|s| HashInstruction::External(s.to_string()))
@@ -245,16 +285,19 @@ impl HashPlanner {
                 }
             }
             if !external_deps.is_empty() {
-                Ok(Some(
+                Ok(TargetExternalInput::Specific(
                     external_deps
                         .iter()
                         .map(|s| HashInstruction::External(s.to_string()))
                         .collect(),
                 ))
             } else if !has_external_deps {
-                Ok(Some(vec![HashInstruction::AllExternalDependencies]))
+                Ok(TargetExternalInput::All)
             } else {
-                Ok(None)
+                // An `externalDependencies` input was declared but resolved to no
+                // packages (e.g. `{ externalDependencies: [] }`). The task opted
+                // out of external deps entirely.
+                Ok(TargetExternalInput::OptedOut)
             }
         }
     }
@@ -266,6 +309,7 @@ impl HashPlanner {
         inputs: &SplitInputs,
         task_graph: &TaskGraph,
         external_deps_mapped: &'a HashMap<String, Vec<String>>,
+        external_deps_opted_out: bool,
         visited: &mut Box<hashbrown::HashSet<&'a str>>,
     ) -> anyhow::Result<Vec<HashInstruction>> {
         let project_deps = &self.project_graph.dependencies[project_name];
@@ -276,6 +320,7 @@ impl HashPlanner {
             task_graph,
             project_deps,
             external_deps_mapped,
+            external_deps_opted_out,
             visited,
         )?;
 
@@ -319,6 +364,7 @@ impl HashPlanner {
         task_graph: &TaskGraph,
         project_deps: &'a [String],
         external_deps_mapped: &'a HashMap<String, Vec<String>>,
+        external_deps_opted_out: bool,
         visited: &mut Box<hashbrown::HashSet<&'a str>>,
     ) -> anyhow::Result<Vec<HashInstruction>> {
         if inputs.len() == 1 {
@@ -328,6 +374,7 @@ impl HashPlanner {
                 task_graph,
                 project_deps,
                 external_deps_mapped,
+                external_deps_opted_out,
                 visited,
             );
         }
@@ -345,6 +392,7 @@ impl HashPlanner {
                 task_graph,
                 project_deps,
                 external_deps_mapped,
+                external_deps_opted_out,
                 &mut visited_for_input,
             )?);
         }
@@ -359,6 +407,7 @@ impl HashPlanner {
         task_graph: &TaskGraph,
         project_deps: &'a [String],
         external_deps_mapped: &'a HashMap<String, Vec<String>>,
+        external_deps_opted_out: bool,
         visited: &mut Box<hashbrown::HashSet<&'a str>>,
     ) -> anyhow::Result<Vec<HashInstruction>> {
         let mut deps_inputs: Vec<HashInstruction> = Vec::with_capacity(project_deps.len());
@@ -378,16 +427,24 @@ impl HashPlanner {
                 else {
                     continue;
                 };
+                // Propagate the opt-out flag: an opted-out task must skip
+                // external nodes at every depth of the `^`-dependency chain,
+                // not only its direct deps (#36239).
                 deps_inputs.extend(self.self_and_deps_inputs(
                     dep,
                     task,
                     &dep_inputs,
                     task_graph,
                     external_deps_mapped,
+                    external_deps_opted_out,
                     visited,
                 )?);
-            } else {
-                // todo(jcammisuli): add a check to skip this when the new task hasher is ready, and when `AllExternalDependencies` is used
+            } else if !external_deps_opted_out {
+                // A `^`-dependency input pulls in the external nodes of the
+                // traversed projects. Skip them when the task opted out of
+                // external dependencies via an empty `externalDependencies`
+                // input, otherwise they defeat that opt-out (#36239).
+                // todo(jcammisuli): also skip this when `AllExternalDependencies` is used, once the new task hasher is ready
                 if let Some(external_deps) = external_deps_mapped.get(dep) {
                     deps_inputs.push(HashInstruction::External(dep.to_string()));
                     deps_inputs.extend(

--- a/packages/nx/src/native/tests/planner.spec.ts
+++ b/packages/nx/src/native/tests/planner.spec.ts
@@ -766,6 +766,126 @@ describe('task planner', () => {
     expect(plans['proj:build']).not.toContain('AllExternalDependencies');
   });
 
+  it('should respect empty externalDependencies when dependency inputs are present', async () => {
+    let projectFileMap = {
+      proj: [{ file: '/file.ts', hash: 'file.hash' }],
+    };
+    let builder = new ProjectGraphBuilder(undefined, projectFileMap);
+    builder.addNode({
+      name: 'proj',
+      type: 'lib',
+      data: {
+        root: 'libs/proj',
+        targets: {
+          build: {
+            executor: 'nx:run-commands',
+            inputs: [{ externalDependencies: [] }, 'production', '^production'],
+          },
+        },
+      },
+    });
+    builder.addExternalNode({
+      name: 'npm:react',
+      type: 'npm',
+      data: {
+        version: '17.0.0',
+        packageName: 'react',
+      },
+    });
+    builder.addStaticDependency('proj', 'npm:react', '/file.ts');
+    let projectGraph = builder.getUpdatedProjectGraph();
+    let taskGraph = createTaskGraph(
+      projectGraph,
+      {},
+      ['proj'],
+      ['build'],
+      undefined,
+      {}
+    );
+    let nxJson = {
+      namedInputs: {
+        production: ['{projectRoot}/**/*'],
+      },
+    } as any;
+    const planner = new HashPlanner(
+      nxJson,
+      transferProjectGraph(transformProjectGraphForRust(projectGraph))
+    );
+
+    const plans = planner.getPlans(['proj:build'], taskGraph);
+    // `externalDependencies: []` opts the task out of hashing npm packages;
+    // the `^production` dependency input must not re-introduce them.
+    expect(plans['proj:build']).not.toContain('AllExternalDependencies');
+    expect(plans['proj:build']).not.toContain('npm:react');
+    // the opt-out must not strip legitimate file inputs.
+    expect(plans['proj:build']).toContain('proj:libs/proj/**/*');
+  });
+
+  it('should respect empty externalDependencies for transitive dependency inputs', async () => {
+    let projectFileMap = {
+      proj: [{ file: '/proj.ts', hash: 'proj.hash' }],
+      libA: [{ file: '/libA.ts', hash: 'libA.hash' }],
+    };
+    let builder = new ProjectGraphBuilder(undefined, projectFileMap);
+    builder.addNode({
+      name: 'proj',
+      type: 'lib',
+      data: {
+        root: 'libs/proj',
+        targets: {
+          build: {
+            executor: 'nx:run-commands',
+            inputs: [{ externalDependencies: [] }, 'production', '^production'],
+          },
+        },
+      },
+    });
+    builder.addNode({
+      name: 'libA',
+      type: 'lib',
+      data: {
+        root: 'libs/libA',
+        targets: { build: { executor: 'nx:run-commands' } },
+      },
+    });
+    builder.addExternalNode({
+      name: 'npm:lodash',
+      type: 'npm',
+      data: {
+        version: '4.17.21',
+        packageName: 'lodash',
+      },
+    });
+    builder.addStaticDependency('proj', 'libA', '/proj.ts');
+    builder.addStaticDependency('libA', 'npm:lodash', '/libA.ts');
+    let projectGraph = builder.getUpdatedProjectGraph();
+    let taskGraph = createTaskGraph(
+      projectGraph,
+      {},
+      ['proj'],
+      ['build'],
+      undefined,
+      {}
+    );
+    let nxJson = {
+      namedInputs: {
+        production: ['{projectRoot}/**/*'],
+      },
+    } as any;
+    const planner = new HashPlanner(
+      nxJson,
+      transferProjectGraph(transformProjectGraphForRust(projectGraph))
+    );
+
+    const plans = planner.getPlans(['proj:build'], taskGraph);
+    // `^production` recurses through libA to its own deps, so the opt-out must
+    // skip libA's npm nodes too, not just proj's direct ones (#36239).
+    expect(plans['proj:build']).not.toContain('AllExternalDependencies');
+    expect(plans['proj:build']).not.toContain('npm:lodash');
+    // the traversal still reached libA and kept its file inputs.
+    expect(plans['proj:build']).toContain('libA:libs/libA/**/*');
+  });
+
   it('should include npm projects', async () => {
     let projectFileMap = {
       app: [{ file: '/filea.ts', hash: 'a.hash' }],


### PR DESCRIPTION
## Current Behavior

A task input of `{ externalDependencies: [] }` opts a task out of hashing npm packages, and on its own it works: only the declared file inputs feed the cache key. But adding a `^`-prefixed dependency input (`^production`, `^{projectRoot}/**/*`) alongside it made the hasher pull in every npm dependency again, so the opt-out was effectively ignored and the task hash changed whenever any npm package updated. `nx show target inputs <project>:<target>` reports all npm dependencies in this case.

## Expected Behavior

`{ externalDependencies: [] }` is respected regardless of the other inputs. A `^`-dependency input still contributes the file inputs of dependency projects, but no npm packages once the task has opted out.

## Related Issue(s)

Fixes #36239

## Implementation Details

The opt-out was honored only at the task's own level (`target_input`). The `^`-dependency traversal in the native hash planner (`gather_dependency_input`) added an `External` instruction for every npm node it reached, at every depth of the dependency chain, without consulting the opt-out. The opt-out state is now threaded through the dependency-gathering recursion, and external nodes are skipped when the task opted out.

`target_input` now returns a `TargetExternalInput` enum instead of an `(Option, bool)` tuple, so the opted-out state cannot be dropped by a caller that reads only the instructions. Planner tests cover the direct case and the transitive case (`^` into a workspace dependency that has its own npm dependency). Existing snapshots are unchanged, so default-input and explicit non-empty `externalDependencies` hashing behavior is preserved.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/gh-36239-4ca3076b)
<!-- polygraph-session-end -->