### PR TITLE
fix(core): share workspace fileset hash results instead of deep-cloning per task

### DIFF
--- a/packages/nx/src/native/tasks/hashers.rs
+++ b/packages/nx/src/native/tasks/hashers.rs
@@ -8,6 +8,7 @@ mod hash_runtime;
 mod hash_task_output;
 mod hash_tsconfig;
 mod hash_workspace_files;
+mod once_cache;
 
 pub use hash_cwd::*;
 pub use hash_env::*;
@@ -22,3 +23,4 @@ pub use hash_runtime::*;
 pub use hash_task_output::*;
 pub use hash_tsconfig::*;
 pub use hash_workspace_files::*;
+pub(crate) use once_cache::OnceCache;

--- a/packages/nx/src/native/tasks/hashers/hash_project_files.rs
+++ b/packages/nx/src/native/tasks/hashers/hash_project_files.rs
@@ -2,10 +2,9 @@ use std::collections::HashMap;
 use std::sync::Arc;
 
 use anyhow::*;
-use dashmap::DashMap;
-use once_cell::sync::OnceCell;
 use tracing::{trace, trace_span};
 
+use super::once_cache::OnceCache;
 use crate::native::glob::build_glob_set;
 use crate::native::types::FileData;
 
@@ -15,7 +14,7 @@ pub struct ProjectFilesHashResult {
     pub files: Vec<String>,
 }
 
-pub(crate) type ProjectFileSetCache = DashMap<String, Arc<OnceCell<Arc<ProjectFilesHashResult>>>>;
+pub(crate) type ProjectFileSetCache = OnceCache<ProjectFilesHashResult>;
 
 fn project_file_set_cache_key(project_name: &str, file_sets: &[String]) -> String {
     let mut sorted_file_sets: Vec<&str> = file_sets.iter().map(String::as_str).collect();
@@ -62,17 +61,9 @@ pub(crate) fn hash_project_files_with_inputs_cached(
     project_file_map: &HashMap<String, Vec<FileData>>,
     cache: &ProjectFileSetCache,
 ) -> Result<Arc<ProjectFilesHashResult>> {
-    let cache_key = project_file_set_cache_key(project_name, file_sets);
-    let cache_cell = cache
-        .entry(cache_key)
-        .or_insert_with(|| Arc::new(OnceCell::new()))
-        .clone();
-
-    cache_cell
-        .get_or_try_init(|| {
-            hash_project_files_with_inputs(project_name, file_sets, project_file_map).map(Arc::new)
-        })
-        .cloned()
+    cache.get_or_try_init(project_file_set_cache_key(project_name, file_sets), || {
+        hash_project_files_with_inputs(project_name, file_sets, project_file_map)
+    })
 }
 
 /// base function that should be testable (to make sure that we're getting the proper files back)

--- a/packages/nx/src/native/tasks/hashers/hash_workspace_files.rs
+++ b/packages/nx/src/native/tasks/hashers/hash_workspace_files.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
-use dashmap::DashMap;
 use rayon::prelude::*;
 
+use super::once_cache::OnceCache;
 use crate::native::glob::build_glob_set;
 use crate::native::glob::glob_files::glob_files;
 use crate::native::hasher::hash;
@@ -16,7 +16,7 @@ pub struct WorkspaceFilesHashResult {
     pub files: Vec<String>,
 }
 
-pub(crate) type WorkspaceFileSetCache = DashMap<String, Arc<WorkspaceFilesHashResult>>;
+pub(crate) type WorkspaceFileSetCache = OnceCache<WorkspaceFilesHashResult>;
 
 fn workspace_file_set_cache_key(workspace_file_sets: &[String]) -> String {
     let mut sorted_file_sets: Vec<&str> = workspace_file_sets.iter().map(String::as_str).collect();
@@ -108,18 +108,9 @@ pub(crate) fn hash_workspace_files_with_inputs_cached(
     all_workspace_files: &[FileData],
     cache: &WorkspaceFileSetCache,
 ) -> Result<Arc<WorkspaceFilesHashResult>> {
-    let cache_key = workspace_file_set_cache_key(workspace_file_sets);
-    if let Some(entry) = cache.get(&cache_key) {
-        return Ok(Arc::clone(entry.value()));
-    }
-
-    // Misses hold the shard write lock while computing, which also blocks other
-    // keys on the same shard. Acceptable here: this map only ever holds a
-    // handful of workspace fileset combos, each computed once.
-    let entry = cache.entry(cache_key).or_try_insert_with(|| {
-        hash_workspace_files_with_inputs(workspace_file_sets, all_workspace_files).map(Arc::new)
-    })?;
-    Ok(Arc::clone(entry.value()))
+    cache.get_or_try_init(workspace_file_set_cache_key(workspace_file_sets), || {
+        hash_workspace_files_with_inputs(workspace_file_sets, all_workspace_files)
+    })
 }
 
 #[cfg(test)]

--- a/packages/nx/src/native/tasks/hashers/hash_workspace_files.rs
+++ b/packages/nx/src/native/tasks/hashers/hash_workspace_files.rs
@@ -1,7 +1,6 @@
 use std::sync::Arc;
 
 use dashmap::DashMap;
-use once_cell::sync::OnceCell;
 use rayon::prelude::*;
 
 use crate::native::glob::build_glob_set;
@@ -17,8 +16,7 @@ pub struct WorkspaceFilesHashResult {
     pub files: Vec<String>,
 }
 
-pub(crate) type WorkspaceFileSetCache =
-    DashMap<String, Arc<OnceCell<Arc<WorkspaceFilesHashResult>>>>;
+pub(crate) type WorkspaceFileSetCache = DashMap<String, Arc<WorkspaceFilesHashResult>>;
 
 fn workspace_file_set_cache_key(workspace_file_sets: &[String]) -> String {
     let mut sorted_file_sets: Vec<&str> = workspace_file_sets.iter().map(String::as_str).collect();
@@ -111,16 +109,17 @@ pub(crate) fn hash_workspace_files_with_inputs_cached(
     cache: &WorkspaceFileSetCache,
 ) -> Result<Arc<WorkspaceFilesHashResult>> {
     let cache_key = workspace_file_set_cache_key(workspace_file_sets);
-    let cache_cell = cache
-        .entry(cache_key)
-        .or_insert_with(|| Arc::new(OnceCell::new()))
-        .clone();
+    if let Some(entry) = cache.get(&cache_key) {
+        return Ok(Arc::clone(entry.value()));
+    }
 
-    cache_cell
-        .get_or_try_init(|| {
-            hash_workspace_files_with_inputs(workspace_file_sets, all_workspace_files).map(Arc::new)
-        })
-        .cloned()
+    // Misses hold the shard write lock while computing, which also blocks other
+    // keys on the same shard. Acceptable here: this map only ever holds a
+    // handful of workspace fileset combos, each computed once.
+    let entry = cache.entry(cache_key).or_try_insert_with(|| {
+        hash_workspace_files_with_inputs(workspace_file_sets, all_workspace_files).map(Arc::new)
+    })?;
+    Ok(Arc::clone(entry.value()))
 }
 
 #[cfg(test)]

--- a/packages/nx/src/native/tasks/hashers/hash_workspace_files.rs
+++ b/packages/nx/src/native/tasks/hashers/hash_workspace_files.rs
@@ -1,3 +1,7 @@
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use once_cell::sync::OnceCell;
 use rayon::prelude::*;
 
 use crate::native::glob::build_glob_set;
@@ -11,6 +15,20 @@ use tracing::{debug, debug_span, trace, warn};
 pub struct WorkspaceFilesHashResult {
     pub hash: String,
     pub files: Vec<String>,
+}
+
+pub(crate) type WorkspaceFileSetCache =
+    DashMap<String, Arc<OnceCell<Arc<WorkspaceFilesHashResult>>>>;
+
+fn workspace_file_set_cache_key(workspace_file_sets: &[String]) -> String {
+    let mut sorted_file_sets: Vec<&str> = workspace_file_sets.iter().map(String::as_str).collect();
+    sorted_file_sets.sort();
+
+    format!(
+        "{}\0{}",
+        sorted_file_sets.len(),
+        sorted_file_sets.join("\0")
+    )
 }
 
 /// Expands workspace file set patterns by stripping `{workspaceRoot}/` prefix.
@@ -85,6 +103,24 @@ pub fn hash_workspace_files_with_inputs(
             files,
         })
     })
+}
+
+pub(crate) fn hash_workspace_files_with_inputs_cached(
+    workspace_file_sets: &[String],
+    all_workspace_files: &[FileData],
+    cache: &WorkspaceFileSetCache,
+) -> Result<Arc<WorkspaceFilesHashResult>> {
+    let cache_key = workspace_file_set_cache_key(workspace_file_sets);
+    let cache_cell = cache
+        .entry(cache_key)
+        .or_insert_with(|| Arc::new(OnceCell::new()))
+        .clone();
+
+    cache_cell
+        .get_or_try_init(|| {
+            hash_workspace_files_with_inputs(workspace_file_sets, all_workspace_files).map(Arc::new)
+        })
+        .cloned()
 }
 
 #[cfg(test)]
@@ -162,5 +198,38 @@ mod test {
             .unwrap();
             assert_eq!(result.hash, "13759877301064854697");
         }
+    }
+
+    #[test]
+    fn should_cache_by_fileset_combo_regardless_of_order() {
+        let first_file_sets = &[
+            "{workspaceRoot}/**/*".to_string(),
+            "!{workspaceRoot}/**/*.spec.ts".to_string(),
+        ];
+        let second_file_sets = &[
+            "!{workspaceRoot}/**/*.spec.ts".to_string(),
+            "{workspaceRoot}/**/*".to_string(),
+        ];
+        let all_workspace_files = vec![
+            FileData {
+                file: "test1.ts".into(),
+                hash: "file_data1".into(),
+            },
+            FileData {
+                file: "test.spec.ts".into(),
+                hash: "file_data2".into(),
+            },
+        ];
+
+        let cache = WorkspaceFileSetCache::new();
+        let first =
+            hash_workspace_files_with_inputs_cached(first_file_sets, &all_workspace_files, &cache)
+                .unwrap();
+        let second =
+            hash_workspace_files_with_inputs_cached(second_file_sets, &all_workspace_files, &cache)
+                .unwrap();
+
+        assert_eq!(cache.len(), 1);
+        assert!(Arc::ptr_eq(&first, &second));
     }
 }

--- a/packages/nx/src/native/tasks/hashers/once_cache.rs
+++ b/packages/nx/src/native/tasks/hashers/once_cache.rs
@@ -1,0 +1,79 @@
+use std::sync::Arc;
+
+use dashmap::DashMap;
+use once_cell::sync::OnceCell;
+
+/// Concurrent compute-once cache for expensive-to-build, cheap-to-share values.
+///
+/// The first caller for a key runs `init` while the map itself stays unlocked
+/// (the cell is detached from the map before computing, so other keys on the
+/// same shard are never blocked). Concurrent callers for the same key wait on
+/// the cell and then share the result; hits are an Arc refcount bump, never a
+/// deep copy. A failed `init` leaves the cell empty, so the next caller
+/// retries instead of observing a cached error.
+pub(crate) struct OnceCache<T>(DashMap<String, Arc<OnceCell<Arc<T>>>>);
+
+impl<T> OnceCache<T> {
+    pub fn new() -> Self {
+        Self(DashMap::new())
+    }
+
+    pub fn get_or_try_init<E>(
+        &self,
+        key: String,
+        init: impl FnOnce() -> Result<T, E>,
+    ) -> Result<Arc<T>, E> {
+        let cell = self
+            .0
+            .entry(key)
+            .or_insert_with(|| Arc::new(OnceCell::new()))
+            .clone();
+        cell.get_or_try_init(|| init().map(Arc::new)).cloned()
+    }
+
+    #[cfg(test)]
+    pub fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn computes_once_and_shares_the_result() {
+        let cache: OnceCache<String> = OnceCache::new();
+        let mut computations = 0;
+
+        let first = cache
+            .get_or_try_init("key".into(), || {
+                computations += 1;
+                Ok::<_, ()>("value".to_string())
+            })
+            .unwrap();
+        let second = cache
+            .get_or_try_init("key".into(), || {
+                computations += 1;
+                Ok::<_, ()>("other".to_string())
+            })
+            .unwrap();
+
+        assert_eq!(computations, 1);
+        assert!(Arc::ptr_eq(&first, &second));
+        assert_eq!(cache.len(), 1);
+    }
+
+    #[test]
+    fn failed_init_is_not_cached() {
+        let cache: OnceCache<String> = OnceCache::new();
+
+        let failed = cache.get_or_try_init("key".into(), || Err("boom"));
+        assert_eq!(failed.unwrap_err(), "boom");
+
+        let recovered = cache
+            .get_or_try_init("key".into(), || Ok::<_, &str>("value".to_string()))
+            .unwrap();
+        assert_eq!(*recovered, "value");
+    }
+}

--- a/packages/nx/src/native/tasks/task_hasher.rs
+++ b/packages/nx/src/native/tasks/task_hasher.rs
@@ -16,9 +16,10 @@ use crate::native::{
 };
 use crate::native::{
     tasks::hashers::{
-        CachedTaskOutput, JsonHashResult, ProjectFileSetCache, hash_all_externals, hash_external,
-        hash_json_files, hash_project_config, hash_project_files_with_inputs_cached,
-        hash_task_output, hash_tsconfig_selectively, hash_workspace_files_with_inputs,
+        CachedTaskOutput, JsonHashResult, ProjectFileSetCache, WorkspaceFileSetCache,
+        hash_all_externals, hash_external, hash_json_files, hash_project_config,
+        hash_project_files_with_inputs_cached, hash_task_output, hash_tsconfig_selectively,
+        hash_workspace_files_with_inputs_cached,
     },
     types::FileData,
     workspace::types::ProjectFiles,
@@ -139,14 +140,6 @@ pub struct HasherOptions {
     pub selectively_hash_ts_config: bool,
 }
 
-/// Cached result for project/workspace file hashing.
-/// Stores both the hash value and the matched file paths (for input collection).
-#[derive(Clone)]
-struct CachedFileSetHash {
-    hash: String,
-    files: Vec<String>,
-}
-
 #[napi]
 pub struct TaskHasher {
     workspace_root: String,
@@ -160,7 +153,7 @@ pub struct TaskHasher {
     external_cache: Arc<DashMap<String, String>>,
     // Persisted across hash_plans() calls: they only fold the immutable FileData
     // snapshot, so they never go stale. (Live-disk/exec caches stay per-call — see below.)
-    workspace_file_set_cache: DashMap<String, CachedFileSetHash>,
+    workspace_file_set_cache: WorkspaceFileSetCache,
     project_file_set_cache: ProjectFileSetCache,
     // Fold over all externals; identical for every task, so computed once.
     all_externals_hash: OnceCell<String>,
@@ -193,7 +186,7 @@ impl TaskHasher {
             root_tsconfig_path,
             options,
             external_cache: Arc::new(DashMap::new()),
-            workspace_file_set_cache: DashMap::new(),
+            workspace_file_set_cache: WorkspaceFileSetCache::new(),
             project_file_set_cache: ProjectFileSetCache::new(),
             all_externals_hash: OnceCell::new(),
         }
@@ -386,32 +379,21 @@ impl TaskHasher {
         let empty = HashInputsBuilder::default();
         let (hash, inputs) = match instruction {
             HashInstruction::WorkspaceFileSet(workspace_file_set) => {
-                let cache_key = instruction.to_string();
-                // Check cache first; clone and drop the Ref before any insert
-                let cached_entry = if let Some(entry) = workspace_file_set_cache.get(&cache_key) {
-                    entry.clone()
-                } else {
-                    let result = hash_workspace_files_with_inputs(
-                        workspace_file_set,
-                        &self.all_workspace_files,
-                    )?;
-                    let entry = CachedFileSetHash {
-                        hash: result.hash,
-                        files: result.files,
-                    };
-                    workspace_file_set_cache.insert(cache_key, entry.clone());
-                    entry
-                };
+                let cached_entry = hash_workspace_files_with_inputs_cached(
+                    workspace_file_set,
+                    &self.all_workspace_files,
+                    workspace_file_set_cache,
+                )?;
                 trace!(parent: &span, "hash_workspace_files: {:?}", now.elapsed());
                 let inputs = if collect_inputs {
                     HashInputsBuilder {
-                        files: cached_entry.files.into_iter().collect(),
+                        files: cached_entry.files.iter().cloned().collect(),
                         ..Default::default()
                     }
                 } else {
                     empty
                 };
-                (cached_entry.hash, inputs)
+                (cached_entry.hash.clone(), inputs)
             }
             HashInstruction::Runtime(runtime) => {
                 let hashed_runtime =
@@ -621,7 +603,7 @@ struct HashInstructionArgs<'a> {
     task_output_cache: &'a DashMap<String, CachedTaskOutput>,
     runtime_cache: &'a DashMap<String, String>,
     project_file_set_cache: &'a ProjectFileSetCache,
-    workspace_file_set_cache: &'a DashMap<String, CachedFileSetHash>,
+    workspace_file_set_cache: &'a WorkspaceFileSetCache,
     json_file_set_cache: &'a DashMap<String, JsonHashResult>,
     cwd: &'a std::path::Path,
     collect_inputs: bool,


### PR DESCRIPTION
## Current Behavior

The workspace fileset cache introduced in #34971 stores plain `Vec<String>` file lists and deep-clones the entire matched list on every cache hit — once per task, concurrently across all rayon threads. Since a sharedGlobals-style workspace fileset appears in nearly every task's plan and can match a large portion of the workspace, hashing a large task graph allocates and copies the full file list thousands of times. A memory bisect attributed ~218 MiB of increased peak RSS to this (plus allocator fragmentation from the churn). Two threads can also race on the same cache key and compute the same fileset twice.

## Expected Behavior

The workspace fileset cache uses the same shape the project fileset cache already uses: `DashMap<String, Arc<OnceCell<Arc<WorkspaceFilesHashResult>>>>`.

- Cache hits are an `Arc` refcount bump instead of a deep copy of the file list — all threads share one copy.
- `OnceCell` guarantees each unique fileset combo is computed exactly once (no get-then-insert race, no duplicate transient lists).
- File paths are only cloned on the rare `collect_inputs` path, where they are actually consumed.
- The cache key sorts filesets, so order-variant combos share one entry (hash output is order-independent; test added mirroring the project-side one).

Hash values are byte-for-byte identical — this only changes how cached results are stored and shared.

## Related Issue(s)

Fixes NXC-4603

Memory regression introduced by #34971 (bisected: parent #34942, 1 commit apart).

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/NXC-4603-Workspace-Fileset-Cache-Memory-Fix-69f28e06)
<!-- polygraph-session-end -->