### PR TITLE
fix(core): box JsonFileSet payload to keep HashInstruction small

### DIFF
--- a/packages/nx/src/native/tasks/hash_plan_inspector.rs
+++ b/packages/nx/src/native/tasks/hash_plan_inspector.rs
@@ -160,17 +160,13 @@ impl HashPlanInspector {
                     ..Default::default()
                 })
             }
-            HashInstruction::JsonFileSet {
-                project_name,
-                json_path,
-                ..
-            } => {
+            HashInstruction::JsonFileSet(json) => {
                 // Resolve the file paths the JsonFileSet would hash, without
                 // reading or parsing any JSON. Field/excludeField filters are
                 // irrelevant here — the reported inputs are still the files.
                 let matched = collect_json_input_files(
-                    json_path,
-                    project_name.as_deref(),
+                    &json.json_path,
+                    json.project_name.as_deref(),
                     &self.project_file_map,
                     &self.all_workspace_files,
                 )?;

--- a/packages/nx/src/native/tasks/hash_planner.rs
+++ b/packages/nx/src/native/tasks/hash_planner.rs
@@ -1,7 +1,7 @@
 use crate::native::logger::enable_logger;
 use crate::native::tasks::{
     dep_outputs::get_dep_output,
-    types::{CwdMode, HashInstruction, TaskGraph},
+    types::{CwdMode, HashInstruction, JsonFileSetInput, TaskGraph},
 };
 use crate::native::types::{Input, NxJson};
 use crate::native::{
@@ -468,12 +468,12 @@ impl HashPlanner {
                 } else {
                     None
                 };
-                Some(HashInstruction::JsonFileSet {
+                Some(HashInstruction::JsonFileSet(Box::new(JsonFileSetInput {
                     project_name: proj_name,
                     json_path: resolve_tokens(json, project_root, project_name),
                     fields: fields.map(|f| f.to_vec()),
                     exclude_fields: exclude_fields.map(|f| f.to_vec()),
-                })
+                })))
             }
             _ => None,
         });

--- a/packages/nx/src/native/tasks/task_hasher.rs
+++ b/packages/nx/src/native/tasks/task_hasher.rs
@@ -567,12 +567,7 @@ impl TaskHasher {
                 };
                 (hashed_all_externals, inputs)
             }
-            HashInstruction::JsonFileSet {
-                project_name,
-                json_path,
-                fields,
-                exclude_fields,
-            } => {
+            HashInstruction::JsonFileSet(json) => {
                 // Cache is keyed on the full instruction string so
                 // different fields/excludeFields against the same file
                 // remain distinct. `instruction.to_string()` already
@@ -586,10 +581,10 @@ impl TaskHasher {
                 } else {
                     let result = hash_json_files(
                         &self.workspace_root,
-                        json_path,
-                        project_name.as_deref(),
-                        fields.as_deref(),
-                        exclude_fields.as_deref(),
+                        &json.json_path,
+                        json.project_name.as_deref(),
+                        json.fields.as_deref(),
+                        json.exclude_fields.as_deref(),
                         &self.project_file_map,
                         &self.all_workspace_files,
                     )?;

--- a/packages/nx/src/native/tasks/types.rs
+++ b/packages/nx/src/native/tasks/types.rs
@@ -137,6 +137,17 @@ pub enum CwdMode {
     Relative,
 }
 
+/// Payload of `HashInstruction::JsonFileSet`. Boxed in the enum: inlined, its
+/// four fields would nearly double the size of every HashInstruction in every
+/// task's plan, whether or not json inputs are used.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
+pub struct JsonFileSetInput {
+    pub project_name: Option<String>,
+    pub json_path: String,
+    pub fields: Option<Vec<String>>,
+    pub exclude_fields: Option<Vec<String>>,
+}
+
 #[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone)]
 pub enum HashInstruction {
     WorkspaceFileSet(Vec<String>),
@@ -149,12 +160,7 @@ pub enum HashInstruction {
     TaskOutput(String, Vec<String>),
     External(String),
     AllExternalDependencies,
-    JsonFileSet {
-        project_name: Option<String>,
-        json_path: String,
-        fields: Option<Vec<String>>,
-        exclude_fields: Option<Vec<String>>,
-    },
+    JsonFileSet(Box<JsonFileSetInput>),
 }
 
 impl ToNapiValue for HashInstruction {
@@ -217,27 +223,38 @@ impl fmt::Display for HashInstruction {
                 HashInstruction::TsConfiguration(project_name) => {
                     format!("{project_name}:TsConfig")
                 }
-                HashInstruction::JsonFileSet {
-                    project_name,
-                    json_path,
-                    fields,
-                    exclude_fields,
-                } => {
-                    let prefix = project_name
+                HashInstruction::JsonFileSet(json) => {
+                    let prefix = json
+                        .project_name
                         .as_deref()
                         .map(|p| format!("{p}:"))
                         .unwrap_or_default();
-                    let fields_str = fields
+                    let fields_str = json
+                        .fields
                         .as_ref()
                         .map(|f| format!("[{}]", f.join(",")))
                         .unwrap_or_default();
-                    let exclude_str = exclude_fields
+                    let exclude_str = json
+                        .exclude_fields
                         .as_ref()
                         .map(|f| format!("![{}]", f.join(",")))
                         .unwrap_or_default();
-                    format!("{prefix}json:{json_path}{fields_str}{exclude_str}")
+                    format!("{prefix}json:{}{fields_str}{exclude_str}", json.json_path)
                 }
             }
         )
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn hash_instruction_stays_small() {
+        // Plans hold one HashInstruction per (task x transitive-dep input) —
+        // millions on large workspaces — and the enum sizes to its largest
+        // variant. Box large payloads instead of growing this (NXC-4604).
+        assert!(std::mem::size_of::<HashInstruction>() <= 56);
     }
 }


### PR DESCRIPTION
## Current Behavior

The `JsonFileSet` variant added in #35248 inlines four pointer-sized fields, growing `size_of::<HashInstruction>()` from 56 to 96 bytes. Rust enums size to their largest variant, so every `HashInstruction` in every task's plan pays the extra 40 bytes — millions of instructions on large workspaces (plans hold instructions for each task's project plus all transitive dependencies) — whether or not `json` inputs are configured. A memory bisect isolated this PR at +122 MiB peak RSS per process on a 500k-file workspace (cold path; plans are rebuilt every invocation, so the warm path pays too). The json feature itself is dormant without `json` inputs — the cost was purely the enum layout.

## Expected Behavior

The `JsonFileSet` payload lives behind a `Box` (`JsonFileSet(Box<JsonFileSetInput>)`), returning the enum to 56 bytes. The pointer indirection only costs workspaces that actually configure `json` inputs, where it is noise next to reading and parsing a JSON file. Instruction `Display` strings (and therefore all hashes and plan snapshots) are byte-for-byte unchanged.

A `size_of` regression test pins the enum at ≤56 bytes so a future variant can't silently rewiden it (clippy's `large_enum_variant` default threshold of 200 bytes would not catch this).

## Related Issue(s)

Fixes NXC-4604

Sibling of #36244 (NXC-4603); together they address 340 of the +431 MiB Nx 22.7.0 cold-path memory regression behind #36152.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/NXC-4603-Workspace-Fileset-Cache-Memory-Fix-69f28e06)
<!-- polygraph-session-end -->