### PR TITLE
fix(core): replace per-input visited clones with undo-log scoping in hash planner

### DIFF
--- a/packages/nx/src/native/tasks/hash_planner.rs
+++ b/packages/nx/src/native/tasks/hash_planner.rs
@@ -44,8 +44,9 @@ impl<'a> VisitedTracker<'a> {
         }
     }
 
-    /// Marks the project visited. Returns false if it was already visited.
-    fn visit(&mut self, project: &'a str) -> bool {
+    /// Same contract as `HashSet::insert`: returns whether the project was
+    /// newly inserted. New insertions are logged so `rollback_to` can undo them.
+    fn insert(&mut self, project: &'a str) -> bool {
         let inserted = self.set.insert(project);
         if inserted {
             self.log.push(project);
@@ -403,7 +404,7 @@ impl HashPlanner {
         let mut deps_inputs: Vec<HashInstruction> = Vec::with_capacity(project_deps.len());
 
         for dep in project_deps {
-            if !visited.visit(dep.as_str()) {
+            if !visited.insert(dep.as_str()) {
                 continue;
             }
 
@@ -619,26 +620,26 @@ mod tests {
     use super::VisitedTracker;
 
     #[test]
-    fn visit_reports_first_visit_only() {
+    fn insert_reports_first_insertion_only() {
         let mut visited = VisitedTracker::seeded_with("seed");
-        assert!(!visited.visit("seed"));
-        assert!(visited.visit("a"));
-        assert!(!visited.visit("a"));
+        assert!(!visited.insert("seed"));
+        assert!(visited.insert("a"));
+        assert!(!visited.insert("a"));
     }
 
     #[test]
     fn rollback_unvisits_only_the_scope() {
         let mut visited = VisitedTracker::seeded_with("seed");
-        assert!(visited.visit("outer"));
+        assert!(visited.insert("outer"));
 
         let scope = visited.scope_start();
-        assert!(visited.visit("inner1"));
-        assert!(visited.visit("inner2"));
+        assert!(visited.insert("inner1"));
+        assert!(visited.insert("inner2"));
         visited.rollback_to(scope);
 
         // Scoped visits are undone; earlier ones are not.
-        assert!(visited.visit("inner1"));
-        assert!(!visited.visit("outer"));
-        assert!(!visited.visit("seed"));
+        assert!(visited.insert("inner1"));
+        assert!(!visited.insert("outer"));
+        assert!(!visited.insert("seed"));
     }
 }

--- a/packages/nx/src/native/tasks/hash_planner.rs
+++ b/packages/nx/src/native/tasks/hash_planner.rs
@@ -28,6 +28,43 @@ pub struct HashPlanner {
     external_deps_mapped: OnceLock<HashMap<String, Vec<String>>>,
 }
 
+/// Cycle-detection set with an undo log. Each dependency input needs its own
+/// visitation scope (see `gather_dependency_inputs`); rolling insertions back
+/// keeps that scoping without cloning the whole set per input.
+struct VisitedTracker<'a> {
+    set: hashbrown::HashSet<&'a str>,
+    log: Vec<&'a str>,
+}
+
+impl<'a> VisitedTracker<'a> {
+    fn seeded_with(project: &'a str) -> Self {
+        Self {
+            set: hashbrown::HashSet::from([project]),
+            log: Vec::new(),
+        }
+    }
+
+    /// Marks the project visited. Returns false if it was already visited.
+    fn visit(&mut self, project: &'a str) -> bool {
+        let inserted = self.set.insert(project);
+        if inserted {
+            self.log.push(project);
+        }
+        inserted
+    }
+
+    fn scope_start(&self) -> usize {
+        self.log.len()
+    }
+
+    /// Un-visits everything recorded since `scope_start`.
+    fn rollback_to(&mut self, scope_start: usize) {
+        for project in self.log.drain(scope_start..) {
+            self.set.remove(project);
+        }
+    }
+}
+
 #[napi]
 impl HashPlanner {
     #[napi(constructor)]
@@ -84,7 +121,7 @@ impl HashPlanner {
                     &inputs,
                     &task_graph,
                     external_deps_mapped,
-                    &mut Box::new(hashbrown::HashSet::from([task.target.project.as_str()])),
+                    &mut VisitedTracker::seeded_with(task.target.project.as_str()),
                 )?;
 
                 let mut inputs: Vec<HashInstruction> = target
@@ -266,7 +303,7 @@ impl HashPlanner {
         inputs: &SplitInputs,
         task_graph: &TaskGraph,
         external_deps_mapped: &'a HashMap<String, Vec<String>>,
-        visited: &mut Box<hashbrown::HashSet<&'a str>>,
+        visited: &mut VisitedTracker<'a>,
     ) -> anyhow::Result<Vec<HashInstruction>> {
         let project_deps = &self.project_graph.dependencies[project_name];
         let self_inputs = self.gather_self_inputs(project_name, &inputs.self_inputs);
@@ -319,7 +356,7 @@ impl HashPlanner {
         task_graph: &TaskGraph,
         project_deps: &'a [String],
         external_deps_mapped: &'a HashMap<String, Vec<String>>,
-        visited: &mut Box<hashbrown::HashSet<&'a str>>,
+        visited: &mut VisitedTracker<'a>,
     ) -> anyhow::Result<Vec<HashInstruction>> {
         if inputs.len() == 1 {
             return self.gather_dependency_input(
@@ -337,16 +374,18 @@ impl HashPlanner {
 
         for input in inputs {
             // Dependency inputs are independent. Scope cycle detection to each
-            // input so sibling inputs all apply to the same dependency.
-            let mut visited_for_input = Box::new((**visited).clone());
+            // input so sibling inputs all apply to the same dependency, rolling
+            // this input's visits back instead of cloning the set.
+            let scope = visited.scope_start();
             deps_inputs.extend(self.gather_dependency_input(
                 task,
                 input,
                 task_graph,
                 project_deps,
                 external_deps_mapped,
-                &mut visited_for_input,
+                visited,
             )?);
+            visited.rollback_to(scope);
         }
 
         Ok(deps_inputs)
@@ -359,15 +398,14 @@ impl HashPlanner {
         task_graph: &TaskGraph,
         project_deps: &'a [String],
         external_deps_mapped: &'a HashMap<String, Vec<String>>,
-        visited: &mut Box<hashbrown::HashSet<&'a str>>,
+        visited: &mut VisitedTracker<'a>,
     ) -> anyhow::Result<Vec<HashInstruction>> {
         let mut deps_inputs: Vec<HashInstruction> = Vec::with_capacity(project_deps.len());
 
         for dep in project_deps {
-            if visited.contains(dep.as_str()) {
+            if !visited.visit(dep.as_str()) {
                 continue;
             }
-            visited.insert(dep.as_str());
 
             if self.project_graph.nodes.contains_key(dep) {
                 let Some(dep_inputs) = get_inputs_for_dependency(
@@ -573,5 +611,34 @@ fn find_external_dependency_node_name<'a>(
             }
         }
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::VisitedTracker;
+
+    #[test]
+    fn visit_reports_first_visit_only() {
+        let mut visited = VisitedTracker::seeded_with("seed");
+        assert!(!visited.visit("seed"));
+        assert!(visited.visit("a"));
+        assert!(!visited.visit("a"));
+    }
+
+    #[test]
+    fn rollback_unvisits_only_the_scope() {
+        let mut visited = VisitedTracker::seeded_with("seed");
+        assert!(visited.visit("outer"));
+
+        let scope = visited.scope_start();
+        assert!(visited.visit("inner1"));
+        assert!(visited.visit("inner2"));
+        visited.rollback_to(scope);
+
+        // Scoped visits are undone; earlier ones are not.
+        assert!(visited.visit("inner1"));
+        assert!(!visited.visit("outer"));
+        assert!(!visited.visit("seed"));
     }
 }

--- a/packages/nx/src/native/tasks/hash_planner.rs
+++ b/packages/nx/src/native/tasks/hash_planner.rs
@@ -37,9 +37,11 @@ struct VisitedTracker<'a> {
 }
 
 impl<'a> VisitedTracker<'a> {
-    fn seeded_with(project: &'a str) -> Self {
+    /// The root project starts out visited, so a task never traverses
+    /// itself as its own dependency.
+    fn new(root_project: &'a str) -> Self {
         Self {
-            set: hashbrown::HashSet::from([project]),
+            set: hashbrown::HashSet::from([root_project]),
             log: Vec::new(),
         }
     }
@@ -122,7 +124,7 @@ impl HashPlanner {
                     &inputs,
                     &task_graph,
                     external_deps_mapped,
-                    &mut VisitedTracker::seeded_with(task.target.project.as_str()),
+                    &mut VisitedTracker::new(task.target.project.as_str()),
                 )?;
 
                 let mut inputs: Vec<HashInstruction> = target
@@ -621,7 +623,7 @@ mod tests {
 
     #[test]
     fn insert_reports_first_insertion_only() {
-        let mut visited = VisitedTracker::seeded_with("seed");
+        let mut visited = VisitedTracker::new("seed");
         assert!(!visited.insert("seed"));
         assert!(visited.insert("a"));
         assert!(!visited.insert("a"));
@@ -629,7 +631,7 @@ mod tests {
 
     #[test]
     fn rollback_unvisits_only_the_scope() {
-        let mut visited = VisitedTracker::seeded_with("seed");
+        let mut visited = VisitedTracker::new("seed");
         assert!(visited.insert("outer"));
 
         let scope = visited.scope_start();


### PR DESCRIPTION
## Current Behavior

The sibling-inputs correctness fix in #35071 scopes cycle detection per dependency input by cloning the entire `visited` set at every node of the recursive plan traversal (`hash_planner.rs`: `Box::new((**visited).clone())` per input). The set grows toward transitive-closure size, so on large workspaces this is an O(set) allocation and rehash per input per traversal node, across all rayon planning threads. A memory bisect isolated this at +91 MiB peak RSS per process on a 500k-file workspace (cold path; planning runs every invocation, so warm too).

## Expected Behavior

Same per-input scoping, zero clones: a `VisitedTracker` records each input's insertions in an undo log and rolls exactly those back when the input finishes. Every `visited` check during an input's traversal sees precisely what it saw before (entry state plus that input's own visits), the single-input fast path still persists visits, and the multi-input loop still leaves the caller's set untouched — so emitted instructions, and therefore hashes, are byte-for-byte identical. `visit()` also collapses the previous contains-then-insert double lookup into one, and the needless `Box` around the set is gone.

The sibling-input regression tests added by #35071 (`planner.spec.ts`, `native-task-hasher-impl.spec.ts`) pass unchanged, plus new unit tests for the tracker's scope/rollback behavior.

## Related Issue(s)

Fixes NXC-4605

Third of three cold-path regressions behind #36152: #34971 +218 MiB (#36244), #35248 +122 MiB (#36247), #35071 +91 MiB (this PR).

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/NXC-4603-Workspace-Fileset-Cache-Memory-Fix-69f28e06)
<!-- polygraph-session-end -->