### PR TITLE
fix(core): intern hash instructions in a pool and plan with id lists

### DIFF
--- a/packages/nx/src/native/tasks/hash_plan_inspector.rs
+++ b/packages/nx/src/native/tasks/hash_plan_inspector.rs
@@ -3,7 +3,7 @@ use crate::native::tasks::hashers::{
     hash_workspace_files_with_inputs, resolve_task_output_files,
 };
 use crate::native::tasks::task_hasher::{HashInputs, HashInputsBuilder};
-use crate::native::tasks::types::HashInstruction;
+use crate::native::tasks::types::{HashInstruction, HashPlans};
 use crate::native::types::FileData;
 use hashbrown::HashSet;
 use napi::bindgen_prelude::External;
@@ -40,18 +40,19 @@ impl HashPlanInspector {
     #[napi(ts_return_type = "Record<string, string[]>")]
     pub fn inspect(
         &self,
-        hash_plans: &External<HashMap<String, Vec<HashInstruction>>>,
+        #[napi(ts_arg_type = "ExternalObject<Record<string, Array<HashInstruction>>>")]
+        hash_plans: &External<HashPlans>,
     ) -> anyhow::Result<HashMap<String, Vec<String>>> {
         let project_file_set_cache = ProjectFileSetCache::new();
+        let pool = &hash_plans.pool;
         let results: Vec<(&String, Vec<String>)> = hash_plans
+            .plans
             .iter()
-            .flat_map(|(task_id, instructions)| {
-                instructions
-                    .iter()
-                    .map(move |instruction| (task_id, instruction))
-            })
+            .flat_map(|(task_id, ids)| ids.iter().map(move |id| (task_id, *id)))
             .par_bridge()
-            .map(|(task_id, instruction)| {
+            .map(|(task_id, id)| {
+                let instruction_ref = pool.get(id);
+                let instruction = instruction_ref.value();
                 let strings = match instruction {
                     // File-set instructions: resolve to actual file paths
                     HashInstruction::WorkspaceFileSet(_)
@@ -88,20 +89,20 @@ impl HashPlanInspector {
     #[napi(ts_return_type = "Record<string, HashInputs>")]
     pub fn inspect_inputs(
         &self,
-        hash_plans: &External<HashMap<String, Vec<HashInstruction>>>,
+        #[napi(ts_arg_type = "ExternalObject<Record<string, Array<HashInstruction>>>")]
+        hash_plans: &External<HashPlans>,
     ) -> anyhow::Result<HashMap<String, HashInputs>> {
         let project_file_set_cache = ProjectFileSetCache::new();
+        let pool = &hash_plans.pool;
         let results: Vec<(&String, HashInputsBuilder)> = hash_plans
+            .plans
             .iter()
-            .flat_map(|(task_id, instructions)| {
-                instructions
-                    .iter()
-                    .map(move |instruction| (task_id, instruction))
-            })
+            .flat_map(|(task_id, ids)| ids.iter().map(move |id| (task_id, *id)))
             .par_bridge()
-            .map(|(task_id, instruction)| {
-                let builder =
-                    self.resolve_instruction_inputs(instruction, &project_file_set_cache)?;
+            .map(|(task_id, id)| {
+                let instruction_ref = pool.get(id);
+                let builder = self
+                    .resolve_instruction_inputs(instruction_ref.value(), &project_file_set_cache)?;
                 Ok::<_, anyhow::Error>((task_id, builder))
             })
             .collect::<anyhow::Result<_>>()?;

--- a/packages/nx/src/native/tasks/hash_planner.rs
+++ b/packages/nx/src/native/tasks/hash_planner.rs
@@ -1,7 +1,7 @@
 use crate::native::logger::enable_logger;
 use crate::native::tasks::{
     dep_outputs::get_dep_output,
-    types::{CwdMode, HashInstruction, JsonFileSetInput, TaskGraph},
+    types::{CwdMode, HashInstruction, HashPlans, InstructionPool, JsonFileSetInput, TaskGraph},
 };
 use crate::native::types::{Input, NxJson};
 use crate::native::{
@@ -13,6 +13,7 @@ use rayon::prelude::*;
 use std::collections::HashMap;
 use tracing::trace;
 
+use crate::native::tasks::hashers::OnceCache;
 use crate::native::tasks::inputs::{
     expand_single_project_inputs, get_inputs, get_inputs_for_dependency, get_named_inputs,
 };
@@ -26,6 +27,24 @@ pub struct HashPlanner {
     project_graph: Arc<ProjectGraph>,
     /// Each external node mapped to its transitive project-node deps, memoized per instance.
     external_deps_mapped: OnceLock<HashMap<String, Vec<String>>>,
+    /// Memoized instruction ids contributed by (dependency project, propagated
+    /// input), including its whole transitive closure. Shared across all tasks
+    /// in all get_plans calls: values derive only from the immutable project
+    /// graph and nx_json. Only consulted on acyclic graphs — see
+    /// `dependency_memo_enabled`.
+    subtree_memo: OnceCache<SubtreeResult>,
+    is_acyclic: OnceLock<bool>,
+    /// Interner backing every plan this planner produces.
+    instruction_pool: Arc<InstructionPool>,
+}
+
+/// Instruction ids contributed by one (project, propagated input) dependency subtree.
+struct SubtreeResult {
+    ids: Vec<u32>,
+    /// True when the subtree cannot be spliced from the memo: it contains
+    /// deps-outputs inputs (whose resolution depends on the root task) or an
+    /// unexpected propagation shape. Callers must use the per-task traversal.
+    needs_legacy: bool,
 }
 
 /// Cycle-detection set with an undo log. Each dependency input needs its own
@@ -82,6 +101,9 @@ impl HashPlanner {
             nx_json,
             project_graph: Arc::clone(project_graph),
             external_deps_mapped: OnceLock::new(),
+            subtree_memo: OnceCache::new(),
+            is_acyclic: OnceLock::new(),
+            instruction_pool: Arc::new(InstructionPool::new()),
         }
     }
 
@@ -89,7 +111,7 @@ impl HashPlanner {
         &self,
         task_ids: Vec<&str>,
         task_graph: TaskGraph,
-    ) -> anyhow::Result<HashMap<String, Vec<HashInstruction>>> {
+    ) -> anyhow::Result<HashPlans> {
         let function_start = std::time::Instant::now();
 
         trace!("Starting get_plans_internal for {} tasks", task_ids.len());
@@ -101,8 +123,9 @@ impl HashPlanner {
 
         trace!("External deps setup completed in {:?}", setup_duration);
 
+        let pool = &self.instruction_pool;
         let parallel_start = std::time::Instant::now();
-        let result: anyhow::Result<HashMap<String, Vec<HashInstruction>>> = task_ids
+        let result: anyhow::Result<HashMap<String, Vec<u32>>> = task_ids
             .par_iter()
             .map(|id| {
                 let task = &task_graph
@@ -118,16 +141,11 @@ impl HashPlanner {
                     external_deps_mapped,
                 )?;
 
-                let self_inputs = self.self_and_deps_inputs(
-                    &task.target.project,
-                    task,
-                    &inputs,
-                    &task_graph,
-                    external_deps_mapped,
-                    &mut VisitedTracker::new(task.target.project.as_str()),
-                )?;
-
-                let mut inputs: Vec<HashInstruction> = target
+                // Task-scoped instructions are built as values and interned;
+                // the O(tasks x closure) dependency portion inside
+                // self_and_deps_inputs is spliced from the subtree memo as ids
+                // without materialization.
+                let mut ids: Vec<u32> = target
                     .unwrap_or(vec![])
                     .into_iter()
                     .chain(vec![
@@ -138,13 +156,22 @@ impl HashPlanner {
                             "{workspaceRoot}/.nxignore".to_string(),
                         ]),
                     ])
-                    .chain(self_inputs)
+                    .map(|instruction| pool.intern(instruction))
                     .collect();
 
-                inputs.par_sort();
-                inputs.dedup();
+                ids.extend(self.self_and_deps_inputs(
+                    &task.target.project,
+                    task,
+                    &inputs,
+                    &task_graph,
+                    external_deps_mapped,
+                    &mut VisitedTracker::new(task.target.project.as_str()),
+                )?);
 
-                Ok((id.to_string(), inputs))
+                ids.sort_unstable();
+                ids.dedup();
+
+                Ok((id.to_string(), ids))
             })
             .collect();
 
@@ -153,11 +180,12 @@ impl HashPlanner {
 
         if result.is_ok() {
             tracing::debug!(
-                "get_plans_internal COMPLETED in {:?} - processed {} tasks (setup: {:?}, parallel_planning: {:?})",
+                "get_plans_internal COMPLETED in {:?} - processed {} tasks (setup: {:?}, parallel_planning: {:?}, pool: {} unique instructions)",
                 total_duration,
                 task_ids.len(),
                 setup_duration,
-                parallel_duration
+                parallel_duration,
+                self.instruction_pool.len()
             );
         } else {
             tracing::debug!(
@@ -167,7 +195,32 @@ impl HashPlanner {
             );
         }
 
-        result
+        result.map(|plans| HashPlans {
+            pool: Arc::clone(&self.instruction_pool),
+            plans,
+        })
+    }
+
+    /// Materialized, Ord-sorted plans for the string-returning JS API; the
+    /// hashing path uses `get_plans_reference` and never materializes.
+    pub fn get_plans_materialized(
+        &self,
+        task_ids: Vec<&str>,
+        task_graph: TaskGraph,
+    ) -> anyhow::Result<HashMap<String, Vec<HashInstruction>>> {
+        let hash_plans = self.get_plans_internal(task_ids, task_graph)?;
+        Ok(hash_plans
+            .plans
+            .into_iter()
+            .map(|(task_id, ids)| {
+                let mut instructions: Vec<HashInstruction> = ids
+                    .into_iter()
+                    .map(|id| hash_plans.pool.get(id).value().clone())
+                    .collect();
+                instructions.par_sort();
+                (task_id, instructions)
+            })
+            .collect())
     }
 
     #[napi(ts_return_type = "Record<string, string[]>")]
@@ -177,15 +230,15 @@ impl HashPlanner {
         task_graph: TaskGraph,
     ) -> anyhow::Result<HashMap<String, Vec<HashInstruction>>> {
         let task_ids: Vec<&str> = task_ids.iter().map(|s| s.as_str()).collect();
-        self.get_plans_internal(task_ids, task_graph)
+        self.get_plans_materialized(task_ids, task_graph)
     }
 
-    #[napi]
+    #[napi(ts_return_type = "ExternalObject<Record<string, Array<HashInstruction>>>")]
     pub fn get_plans_reference(
         &self,
         task_ids: Vec<String>,
         task_graph: TaskGraph,
-    ) -> anyhow::Result<External<HashMap<String, Vec<HashInstruction>>>> {
+    ) -> anyhow::Result<External<HashPlans>> {
         let task_ids: Vec<&str> = task_ids.iter().map(|s| s.as_str()).collect();
         let plans = self.get_plans_internal(task_ids, task_graph)?;
         Ok(External::new(plans))
@@ -307,28 +360,28 @@ impl HashPlanner {
         task_graph: &TaskGraph,
         external_deps_mapped: &'a HashMap<String, Vec<String>>,
         visited: &mut VisitedTracker<'a>,
-    ) -> anyhow::Result<Vec<HashInstruction>> {
+    ) -> anyhow::Result<Vec<u32>> {
+        let pool = &self.instruction_pool;
         let project_deps = &self.project_graph.dependencies[project_name];
-        let self_inputs = self.gather_self_inputs(project_name, &inputs.self_inputs);
-        let deps_inputs = self.gather_dependency_inputs(
+
+        let mut ids: Vec<u32> = self
+            .gather_self_inputs(project_name, &inputs.self_inputs)
+            .into_iter()
+            .chain(self.gather_dependency_outputs(task, task_graph, &inputs.deps_outputs)?)
+            .chain(self.gather_project_inputs(&inputs.project_inputs)?)
+            .map(|instruction| pool.intern(instruction))
+            .collect();
+
+        ids.extend(self.gather_dependency_inputs(
             task,
             &inputs.deps_inputs,
             task_graph,
             project_deps,
             external_deps_mapped,
             visited,
-        )?;
+        )?);
 
-        let deps_outputs =
-            self.gather_dependency_outputs(task, task_graph, &inputs.deps_outputs)?;
-        let projects = self.gather_project_inputs(&inputs.project_inputs)?;
-
-        Ok(self_inputs
-            .into_iter()
-            .chain(deps_inputs)
-            .chain(deps_outputs)
-            .chain(projects)
-            .collect())
+        Ok(ids)
     }
 
     fn compute_external_deps(&self) -> HashMap<String, Vec<String>> {
@@ -351,6 +404,120 @@ impl HashPlanner {
             .collect()
     }
 
+    /// The subtree memo composes child results without per-path cycle checks,
+    /// so it is only sound on acyclic graphs (also avoids OnceCell deadlock on
+    /// a dependency cycle). Cyclic graphs use the visited-scoped traversal.
+    fn dependency_memo_enabled(&self) -> bool {
+        *self
+            .is_acyclic
+            .get_or_init(|| self.project_graph_is_acyclic())
+    }
+
+    fn project_graph_is_acyclic(&self) -> bool {
+        const WHITE: u8 = 0;
+        const GRAY: u8 = 1;
+        const BLACK: u8 = 2;
+        let deps = &self.project_graph.dependencies;
+        let mut color: hashbrown::HashMap<&str, u8> = hashbrown::HashMap::new();
+
+        for start in deps.keys() {
+            if color.get(start.as_str()).copied().unwrap_or(WHITE) != WHITE {
+                continue;
+            }
+            let mut stack: Vec<(&str, usize)> = vec![(start.as_str(), 0)];
+            color.insert(start.as_str(), GRAY);
+            while let Some((node, edge_idx)) = stack.last_mut() {
+                let children = deps.get(*node).map(|c| c.as_slice()).unwrap_or(&[]);
+                if let Some(child) = children.get(*edge_idx) {
+                    *edge_idx += 1;
+                    if !self.project_graph.nodes.contains_key(child) {
+                        continue;
+                    }
+                    match color.get(child.as_str()).copied().unwrap_or(WHITE) {
+                        GRAY => return false,
+                        WHITE => {
+                            color.insert(child.as_str(), GRAY);
+                            stack.push((child.as_str(), 0));
+                        }
+                        _ => {}
+                    }
+                } else {
+                    color.insert(node, BLACK);
+                    stack.pop();
+                }
+            }
+        }
+        true
+    }
+
+    fn memoized_dep_subtree(
+        &self,
+        dep: &str,
+        input: &Input,
+        external_deps_mapped: &HashMap<String, Vec<String>>,
+    ) -> anyhow::Result<Arc<SubtreeResult>> {
+        let cache_key = match input {
+            Input::Inputs { input, .. } => format!("{dep}\0i\0{input}"),
+            Input::FileSet { fileset, .. } => format!("{dep}\0f\0{fileset}"),
+            // Other input kinds never reach dependencies (get_inputs_for_dependency
+            // returns None for them), so they share one empty entry per project.
+            _ => format!("{dep}\0none"),
+        };
+        self.subtree_memo.get_or_try_init(cache_key, || {
+            self.compute_dep_subtree(dep, input, external_deps_mapped)
+        })
+    }
+
+    fn compute_dep_subtree(
+        &self,
+        dep: &str,
+        input: &Input,
+        external_deps_mapped: &HashMap<String, Vec<String>>,
+    ) -> anyhow::Result<SubtreeResult> {
+        let Some(dep_inputs) =
+            get_inputs_for_dependency(&self.project_graph.nodes[dep], &self.nx_json, input)?
+        else {
+            return Ok(SubtreeResult {
+                ids: vec![],
+                needs_legacy: false,
+            });
+        };
+
+        // Deps-outputs resolution depends on the root task; a propagation shape
+        // other than the canonical single input is unexpected — both fall back.
+        let mut needs_legacy =
+            !dep_inputs.deps_outputs.is_empty() || dep_inputs.deps_inputs.len() != 1;
+        let pool = &self.instruction_pool;
+        let mut ids: Vec<u32> = self
+            .gather_self_inputs(dep, &dep_inputs.self_inputs)
+            .into_iter()
+            .map(|instruction| pool.intern(instruction))
+            .collect();
+
+        if let Some(child_input) = dep_inputs.deps_inputs.first() {
+            for child in &self.project_graph.dependencies[dep] {
+                if self.project_graph.nodes.contains_key(child) {
+                    let sub =
+                        self.memoized_dep_subtree(child, child_input, external_deps_mapped)?;
+                    needs_legacy |= sub.needs_legacy;
+                    ids.extend_from_slice(&sub.ids);
+                } else if let Some(external_deps) = external_deps_mapped.get(child) {
+                    ids.push(pool.intern(HashInstruction::External(child.to_string())));
+                    ids.extend(
+                        external_deps
+                            .iter()
+                            .map(|s| pool.intern(HashInstruction::External(s.to_string()))),
+                    );
+                }
+            }
+        }
+
+        ids.sort_unstable();
+        ids.dedup();
+
+        Ok(SubtreeResult { ids, needs_legacy })
+    }
+
     // todo(jcammisuli): parallelize this more. This function takes the longest time to run
     fn gather_dependency_inputs<'a>(
         &'a self,
@@ -360,7 +527,7 @@ impl HashPlanner {
         project_deps: &'a [String],
         external_deps_mapped: &'a HashMap<String, Vec<String>>,
         visited: &mut VisitedTracker<'a>,
-    ) -> anyhow::Result<Vec<HashInstruction>> {
+    ) -> anyhow::Result<Vec<u32>> {
         if inputs.len() == 1 {
             return self.gather_dependency_input(
                 task,
@@ -372,8 +539,7 @@ impl HashPlanner {
             );
         }
 
-        let mut deps_inputs: Vec<HashInstruction> =
-            Vec::with_capacity(inputs.len() * project_deps.len());
+        let mut deps_inputs: Vec<u32> = Vec::with_capacity(inputs.len() * project_deps.len());
 
         for input in inputs {
             // Dependency inputs are independent. Scope cycle detection to each
@@ -402,8 +568,10 @@ impl HashPlanner {
         project_deps: &'a [String],
         external_deps_mapped: &'a HashMap<String, Vec<String>>,
         visited: &mut VisitedTracker<'a>,
-    ) -> anyhow::Result<Vec<HashInstruction>> {
-        let mut deps_inputs: Vec<HashInstruction> = Vec::with_capacity(project_deps.len());
+    ) -> anyhow::Result<Vec<u32>> {
+        let pool = &self.instruction_pool;
+        let memo_enabled = self.dependency_memo_enabled();
+        let mut deps_inputs: Vec<u32> = Vec::with_capacity(project_deps.len());
 
         for dep in project_deps {
             if !visited.insert(dep.as_str()) {
@@ -411,6 +579,16 @@ impl HashPlanner {
             }
 
             if self.project_graph.nodes.contains_key(dep) {
+                if memo_enabled {
+                    let sub = self.memoized_dep_subtree(dep, input, external_deps_mapped)?;
+                    if !sub.needs_legacy {
+                        // Spliced subtrees skip per-node visited marking, so
+                        // sibling deps with shared closures emit duplicates;
+                        // the plan-level sort + dedup collapses them.
+                        deps_inputs.extend_from_slice(&sub.ids);
+                        continue;
+                    }
+                }
                 let Some(dep_inputs) = get_inputs_for_dependency(
                     &self.project_graph.nodes[dep],
                     &self.nx_json,
@@ -430,11 +608,11 @@ impl HashPlanner {
             } else {
                 // todo(jcammisuli): add a check to skip this when the new task hasher is ready, and when `AllExternalDependencies` is used
                 if let Some(external_deps) = external_deps_mapped.get(dep) {
-                    deps_inputs.push(HashInstruction::External(dep.to_string()));
+                    deps_inputs.push(pool.intern(HashInstruction::External(dep.to_string())));
                     deps_inputs.extend(
                         external_deps
                             .iter()
-                            .map(|s| HashInstruction::External(s.to_string())),
+                            .map(|s| pool.intern(HashInstruction::External(s.to_string()))),
                     );
                 }
             }

--- a/packages/nx/src/native/tasks/task_hasher.rs
+++ b/packages/nx/src/native/tasks/task_hasher.rs
@@ -7,7 +7,7 @@ use hashbrown::HashSet;
 use crate::native::{
     hasher::hash,
     project_graph::{types::ProjectGraph, utils::create_project_root_mappings},
-    tasks::types::HashInstruction,
+    tasks::types::{HashInstruction, HashPlans},
     types::NapiDashMap,
 };
 use crate::native::{
@@ -201,12 +201,13 @@ impl TaskHasher {
     #[napi(ts_return_type = "Record<string, HashDetails>")]
     pub fn hash_plans(
         &self,
-        hash_plans: &External<HashMap<String, Vec<HashInstruction>>>,
+        #[napi(ts_arg_type = "ExternalObject<Record<string, Array<HashInstruction>>>")]
+        hash_plans: &External<HashPlans>,
         per_task_envs: HashMap<String, HashMap<String, String>>,
         cwd: String,
         collect_task_inputs: Option<bool>,
     ) -> anyhow::Result<NapiDashMap<String, HashDetails>> {
-        for task_id in hash_plans.keys() {
+        for task_id in hash_plans.plans.keys() {
             if !per_task_envs.contains_key(task_id) {
                 anyhow::bail!("hash_plans: missing env entry for task {}", task_id);
             }
@@ -220,7 +221,7 @@ impl TaskHasher {
 
     fn hash_plans_impl<'a, F>(
         &self,
-        hash_plans: &External<HashMap<String, Vec<HashInstruction>>>,
+        hash_plans: &External<HashPlans>,
         cwd: String,
         collect_task_inputs: Option<bool>,
         resolve_env: F,
@@ -237,8 +238,7 @@ impl TaskHasher {
 
         let function_start = std::time::Instant::now();
 
-        trace!("hashing plans {:?}", &**hash_plans);
-        trace!("Starting hash_plans with {} plans", hash_plans.len());
+        trace!("Starting hash_plans with {} plans", hash_plans.plans.len());
         trace!("all workspace files: {}", self.all_workspace_files.len());
         trace!("project_file_map: {}", self.project_file_map.len());
 
@@ -269,18 +269,17 @@ impl TaskHasher {
         };
         let cwd_path = std::path::Path::new(&cwd);
 
+        let pool = &hash_plans.pool;
         hash_plans
+            .plans
             .iter()
-            .flat_map(|(task_id, instructions)| {
-                instructions
-                    .iter()
-                    .map(move |instruction| (task_id, instruction))
-            })
+            .flat_map(|(task_id, ids)| ids.iter().map(move |id| (task_id, *id)))
             .par_bridge()
-            .try_for_each(|(task_id, instruction)| {
+            .try_for_each(|(task_id, id)| {
+                let instruction_ref = pool.get(id);
                 let (instruction_key, hash_value, inputs) = self.hash_instruction(
                     task_id,
-                    instruction,
+                    instruction_ref.value(),
                     HashInstructionArgs {
                         js_env: resolve_env(task_id),
                         ts_config_hash: &ts_config_hash,
@@ -346,7 +345,7 @@ impl TaskHasher {
         debug!(
             "hash_plans COMPLETED in {:?} - processed {} plans (setup: {:?}, hashing: {:?}, assembly: {:?})",
             total_duration,
-            hash_plans.len(),
+            hash_plans.plans.len(),
             setup_duration,
             hash_duration,
             assemble_duration

--- a/packages/nx/src/native/tasks/types.rs
+++ b/packages/nx/src/native/tasks/types.rs
@@ -1,6 +1,9 @@
 use std::fmt::Formatter;
+use std::sync::Arc;
+use std::sync::atomic::{AtomicU32, Ordering};
 use std::{collections::HashMap, fmt, ptr};
 
+use dashmap::DashMap;
 use napi::{
     bindgen_prelude::{ToNapiValue, check_status},
     sys,
@@ -161,6 +164,57 @@ pub enum HashInstruction {
     External(String),
     AllExternalDependencies,
     JsonFileSet(Box<JsonFileSetInput>),
+}
+
+/// Append-only interner for hash instructions. Plans store `u32` ids into the
+/// pool, so each unique instruction is materialized once per planner instance
+/// instead of once per task that references it.
+#[derive(Default)]
+pub struct InstructionPool {
+    ids: DashMap<HashInstruction, u32>,
+    items: DashMap<u32, HashInstruction>,
+    next_id: AtomicU32,
+}
+
+impl InstructionPool {
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Returns the id for the instruction, allocating one on first sight.
+    /// Value-equal instructions always intern to the same id, so sorting a
+    /// plan's ids and deduping is equivalent to value-level dedup.
+    pub fn intern(&self, instruction: HashInstruction) -> u32 {
+        if let Some(id) = self.ids.get(&instruction) {
+            return *id;
+        }
+        match self.ids.entry(instruction) {
+            dashmap::mapref::entry::Entry::Occupied(existing) => *existing.get(),
+            dashmap::mapref::entry::Entry::Vacant(vacant) => {
+                let id = self.next_id.fetch_add(1, Ordering::Relaxed);
+                self.items.insert(id, vacant.key().clone());
+                vacant.insert(id);
+                id
+            }
+        }
+    }
+
+    pub fn get(&self, id: u32) -> dashmap::mapref::one::Ref<'_, u32, HashInstruction> {
+        self.items
+            .get(&id)
+            .expect("instruction ids are only handed out by intern()")
+    }
+
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+}
+
+/// Hash plans as pool-interned instruction ids, plus the pool that resolves
+/// them. This is what crosses from the HashPlanner to the TaskHasher.
+pub struct HashPlans {
+    pub pool: Arc<InstructionPool>,
+    pub plans: HashMap<String, Vec<u32>>,
 }
 
 impl ToNapiValue for HashInstruction {


### PR DESCRIPTION
## Current Behavior

Hash plans are `HashMap<task, Vec<HashInstruction>>` — every task owns deep copies of every instruction in its dependency closure. The distinct-instruction population is only a few thousand values (a couple per project × input), but plans store them O(tasks × closure) times: ~1.1M copies × ~200 bytes on a 1,110-task benchmark with deep closures. This is the structure that #35071's sibling-inputs correctness fix legitimately inflated (the real mechanism behind NXC-4605's +91 MiB), and it exists in every parallel DTE agent process (#36152).

## Expected Behavior

Plans store `u32` ids into an `InstructionPool` interner and travel with it as `HashPlans` through the planner→hasher `External`:

- The interner's entry()-serialized id allocation guarantees value-equal ⇒ id-equal, so integer sort+dedup ≡ value-level dedup.
- Dependency subtrees are memoized per (project, propagated input) as id lists and spliced into plans as integer memcpy — zero materialization on the O(tasks × closure) path. Deps-outputs subtrees and cyclic graphs use the existing per-task traversal, interned at the boundary.
- `task_hasher` / `hash_plan_inspector` resolve ids in place; the string-returning `getPlans` API materializes and Ord-sorts, keeping observable behavior identical.

**Measured** (densified bench: 1,110 tasks, avg closure ~555, 3 runs): planning 373 ms → 144 ms (~2.6×), peak process RSS 947 MB → 658 MB (−31%), `hash_plans` unchanged. Task hashes byte-for-byte identical — 72 TS hasher+planner tests and all Rust tests pass. Negative control: the same memo returning materialized instructions measured 2.8× slower; the representation change is the entire win.

> [!NOTE]
> **Stacked on #36248** (uses its `VisitedTracker`); retarget to `master` once that merges. Draft pending: full e2e sweep, a committed `bench:plan` variant (the stock benchmarks workspace has no dependency inputs and cannot exercise this path), scoped clone of the pool `Ref` in the Runtime hash arm, and a proper opaque d.ts type name.

## Related Issue(s)

Fixes NXC-4607

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/NXC-4603-Workspace-Fileset-Cache-Memory-Fix-69f28e06)
<!-- polygraph-session-end -->