### PR TITLE
chore(core): nx plugin submission [@seriouslag/nx-openapi-ts-plugin]

### DIFF
--- a/astro-docs/src/content/approved-community-plugins.json
+++ b/astro-docs/src/content/approved-community-plugins.json
@@ -563,5 +563,10 @@
     "name": "@anarchitects/nx-typeorm",
     "description": "Nx plugin for TypeORM integration in Nx backend applications and libraries.",
     "url": "https://github.com/anarchitects/anarchitecture-plugins/tree/main/packages/typeorm"
+  },
+  {
+    "name": "@seriouslag/nx-openapi-ts-plugin",
+    "description": "Nx plugin for @hey-api/openapi-ts — generators and executors for OpenAPI TypeScript client codegen",
+    "url": "https://github.com/seriouslag/openapi-ts-nx-plugin"
   }
 ]


### PR DESCRIPTION
## Plugin submission: `@seriouslag/nx-openapi-ts-plugin`

Nx plugin for [`@hey-api/openapi-ts`](https://github.com/hey-api/openapi-ts) — provides generators and executors for OpenAPI TypeScript client code generation, plus inferred targets via a project graph plugin.

- **npm:** https://www.npmjs.com/package/@seriouslag/nx-openapi-ts-plugin
- **Repository:** https://github.com/seriouslag/openapi-ts-nx-plugin

### Listing criteria

- ✅ Automated e2e tests run in CI on every push ([ci.yml](https://github.com/seriouslag/openapi-ts-nx-plugin/blob/main/.github/workflows/ci.yml)) — the e2e suite runs real codegen against the built plugin output
- ✅ `@nx/devkit` is a direct dependency (`^23.0.0`)
- ✅ `nx` is not a direct or peer dependency
- ✅ `repository.url` is set in `package.json`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
