### PR TITLE
docs(nx-dev): clarify projects vs files wildcard for CODEOWNERS catch-all

### DIFF
--- a/astro-docs/src/content/docs/reference/Owners/overview.mdoc
+++ b/astro-docs/src/content/docs/reference/Owners/overview.mdoc
@@ -339,3 +339,49 @@ If you are using GitLab, you can specify CODEOWNERS [sections](https://docs.gitl
 
 {% /tabitem %}
 {% /tabs %}
+
+## Set a default owner
+
+To give the whole repository a fallback owner, use a file wildcard (`files: ["*"]`), not a project wildcard (`projects: ["*"]`). The two behave differently:
+
+- `projects: ["*"]` matches every project and expands to one CODEOWNERS entry per project root. It's verbose, and it only covers files that live inside a project. Files outside every project root — a top-level `package.json`, workspace config, or other loose files at the repository root — get no owner, so this isn't a true repo-wide catch-all.
+- `files: ["*"]` emits a single `* @owner` rule that matches every file in the repository. This is the repo-wide default owner. List it first and let the more specific patterns below it win, because CODEOWNERS applies the last matching rule for a given file.
+
+{% aside type="note" title="Order matters" %}
+CODEOWNERS resolves a file to the **last** pattern that matches it. Put the `files: ["*"]` catch-all at the top of your `patterns` array so the specific rules that follow override it.
+{% /aside %}
+
+```jsonc
+// nx.json
+{
+  "owners": {
+    "format": "github",
+    "outputPath": "CODEOWNERS",
+    "patterns": [
+      {
+        "description": "Default owner for everything",
+        "files": ["*"],
+        "owners": ["@platform-team"],
+      },
+      {
+        "description": "The Finance team owns these projects",
+        "projects": ["finance-*"],
+        "owners": ["@finance-team"],
+      },
+    ],
+  },
+}
+```
+
+Nx generates the following CODEOWNERS file:
+
+```yaml {% title=".github/CODEOWNERS" %}
+# Default owner for everything
+* @platform-team
+
+# The Finance team owns these projects
+/packages/finance-ui @finance-team
+/packages/finance-data @finance-team
+```
+
+Every file falls back to `@platform-team`, and the later, more specific rule reassigns the finance projects to `@finance-team`.

--- a/astro-docs/src/content/docs/reference/Owners/overview.mdoc
+++ b/astro-docs/src/content/docs/reference/Owners/overview.mdoc
@@ -344,7 +344,7 @@ If you are using GitLab, you can specify CODEOWNERS [sections](https://docs.gitl
 
 To give the whole repository a fallback owner, use a file wildcard (`files: ["*"]`), not a project wildcard (`projects: ["*"]`). The two behave differently:
 
-- `projects: ["*"]` matches every project and expands to one CODEOWNERS entry per project root. It's verbose, and it only covers files that live inside a project. Files outside every project root — a top-level `package.json`, workspace config, or other loose files at the repository root — get no owner, so this isn't a true repo-wide catch-all.
+- `projects: ["*"]` matches every project and expands to one CODEOWNERS entry per project root. This pattern only covers files that live inside a project. Files outside every project root such as a top-level configuration files do not get an owner.
 - `files: ["*"]` matches all files in the repository and emits a single entry in CODEOWNERS, `* @owner`. You can use this pattern as a repo-wide default owner. List it first and let the more specific patterns below it override since CODEOWNERS applies the last matching rule for a given file.
 
 {% aside type="note" title="Order matters" %}
@@ -364,7 +364,7 @@ CODEOWNERS resolves a file to the **last** pattern that matches it. Put the `fil
         "owners": ["@platform-team"],
       },
       {
-        "description": "The Finance team owns these projects",
+        "description": "The Finance team owns these projects",- `projects: ["*"]` matches every project and expands to one CODEOWNERS entry per project root. This pattern only covers files that live inside a project. Files outside every project root such as a a top-level configuration files do not get an owner.
         "projects": ["finance-*"],
         "owners": ["@finance-team"],
       },

--- a/astro-docs/src/content/docs/reference/Owners/overview.mdoc
+++ b/astro-docs/src/content/docs/reference/Owners/overview.mdoc
@@ -345,7 +345,7 @@ If you are using GitLab, you can specify CODEOWNERS [sections](https://docs.gitl
 To give the whole repository a fallback owner, use a file wildcard (`files: ["*"]`), not a project wildcard (`projects: ["*"]`). The two behave differently:
 
 - `projects: ["*"]` matches every project and expands to one CODEOWNERS entry per project root. It's verbose, and it only covers files that live inside a project. Files outside every project root — a top-level `package.json`, workspace config, or other loose files at the repository root — get no owner, so this isn't a true repo-wide catch-all.
-- `files: ["*"]` emits a single `* @owner` rule that matches every file in the repository. This is the repo-wide default owner. List it first and let the more specific patterns below it win, because CODEOWNERS applies the last matching rule for a given file.
+- `files: ["*"]` matches all files in the repository and emits a single entry in CODEOWNERS, `* @owner`. You can use this pattern as a repo-wide default owner. List it first and let the more specific patterns below it override since CODEOWNERS applies the last matching rule for a given file.
 
 {% aside type="note" title="Order matters" %}
 CODEOWNERS resolves a file to the **last** pattern that matches it. Put the `files: ["*"]` catch-all at the top of your `patterns` array so the specific rules that follow override it.


### PR DESCRIPTION
## What

Adds a "Set a default owner" section to the `@nx/owners` reference (`astro-docs/src/content/docs/reference/Owners/overview.mdoc`) clarifying the difference between a project wildcard and a files wildcard when generating CODEOWNERS:

- `projects: ["*"]` matches every project and expands to **one CODEOWNERS entry per project root**. It is verbose and does not cover files outside any project root, so it is **not** a true repo-wide catch-all.
- `files: ["*"]` emits a single `* @owner` rule, which **is** the repo-wide default owner. Placed first, more specific patterns below override it (CODEOWNERS applies the last matching rule).

Includes a JSON config example and the generated `.github/CODEOWNERS` output, matching the doc's existing style.

## Why

Reported by Skyscanner: a `projects: ["*"]` "Default" pattern produced a verbose CODEOWNERS with a per-project entry for every project instead of a single catch-all. That is a configuration matter (`files: ["*"]` is the intended catch-all), so this documents the distinction.

Companion PR fixes a related owner-duplication bug in the generator: nrwl/ocean#12236 (same Polygraph session).

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/skyscanner-owners-issue-bf7d5d27)
<!-- polygraph-session-end -->