### PR TITLE
feat(core): enable remote cache from the tui performance report

### DIFF
--- a/packages/nx/src/command-line/nx-cloud/connect/connect-to-nx-cloud.ts
+++ b/packages/nx/src/command-line/nx-cloud/connect/connect-to-nx-cloud.ts
@@ -228,10 +228,11 @@ function sleep(ms: number) {
 }
 
 /**
- * Runs the same logic as `nx connect` headlessly for the TUI: no prompts, no
- * spinner, no browser open (the TUI displays the returned onboarding URL in a
- * popup instead). Throws on failure (e.g. offline, missing git remote) so the
- * TUI can surface the error.
+ * Runs the same logic as `nx connect` for the TUI. A flag on
+ * `runConnectToNxCloud` doesn't fit here: the TUI needs the onboarding URL as
+ * the RETURN VALUE (that flow prints it and returns a boolean), failures as
+ * THROWS so the popup can display them (that flow prints and returns false),
+ * no spinner/browser side effects, and the `nx-tui` source for analytics.
  */
 export async function connectToNxCloudFromTui(): Promise<string> {
   const baseMeta = {
@@ -249,7 +250,33 @@ export async function connectToNxCloudFromTui(): Promise<string> {
     meta: { type: 'start', ...baseMeta },
   });
   try {
-    const url = await generateConnectUrlForTui();
+    const nxJson = readNxJson();
+
+    const checkRemote = process.env.NX_SKIP_CHECK_REMOTE !== 'true';
+    const hasRemote = !!getVcsRemoteInfo();
+    if (!hasRemote && checkRemote) {
+      throw new Error(
+        'Push this repository to a VCS provider (e.g. GitHub) first, then try again.'
+      );
+    }
+
+    // The connect affordances are only offered while not connected, but guard
+    // anyway (e.g. the workspace was connected from another terminal mid-run).
+    let url: string;
+    if (isNxCloudUsed(nxJson)) {
+      const token =
+        process.env.NX_CLOUD_AUTH_TOKEN ||
+        process.env.NX_CLOUD_ACCESS_TOKEN ||
+        nxJson.nxCloudAccessToken ||
+        nxJson.nxCloudId;
+      url = await createNxCloudOnboardingURL('nx-tui', token, undefined, false);
+    } else {
+      const token = await connectWorkspaceToCloud({
+        installationSource: 'nx-tui',
+      });
+      url = await createNxCloudOnboardingURL('nx-tui', token, undefined, false);
+    }
+
     await recordStat({
       command: 'connect',
       nxVersion,
@@ -275,34 +302,6 @@ export async function connectToNxCloudFromTui(): Promise<string> {
     });
     throw error;
   }
-}
-
-async function generateConnectUrlForTui(): Promise<string> {
-  const nxJson = readNxJson();
-
-  const checkRemote = process.env.NX_SKIP_CHECK_REMOTE !== 'true';
-  const hasRemote = !!getVcsRemoteInfo();
-  if (!hasRemote && checkRemote) {
-    throw new Error(
-      'Push this repository to a VCS provider (e.g. GitHub) first, then try again.'
-    );
-  }
-
-  // The connect shortcut is only offered while not connected, but guard anyway
-  // (e.g. the workspace was connected from another terminal mid-run).
-  if (isNxCloudUsed(nxJson)) {
-    const token =
-      process.env.NX_CLOUD_AUTH_TOKEN ||
-      process.env.NX_CLOUD_ACCESS_TOKEN ||
-      nxJson.nxCloudAccessToken ||
-      nxJson.nxCloudId;
-    return createNxCloudOnboardingURL('nx-tui', token, undefined, false);
-  }
-
-  const token = await connectWorkspaceToCloud({
-    installationSource: 'nx-tui',
-  });
-  return createNxCloudOnboardingURL('nx-tui', token, undefined, false);
 }
 
 export async function connectExistingRepoToNxCloudPrompt(

--- a/packages/nx/src/command-line/nx-cloud/connect/connect-to-nx-cloud.ts
+++ b/packages/nx/src/command-line/nx-cloud/connect/connect-to-nx-cloud.ts
@@ -227,6 +227,84 @@ function sleep(ms: number) {
   return new Promise((resolve) => setTimeout(resolve, ms));
 }
 
+/**
+ * Runs the same logic as `nx connect` headlessly for the TUI: no prompts, no
+ * spinner, no browser open (the TUI displays the returned onboarding URL in a
+ * popup instead). Throws on failure (e.g. offline, missing git remote) so the
+ * TUI can surface the error.
+ */
+export async function connectToNxCloudFromTui(): Promise<string> {
+  const baseMeta = {
+    nodeVersion: process.versions.node,
+    os: process.platform,
+    packageManager: detectPackageManager(),
+    aiAgent: isAiAgent(),
+    isCI: isCI(),
+    source: 'nx-tui',
+  };
+  await recordStat({
+    command: 'connect',
+    nxVersion,
+    useCloud: true,
+    meta: { type: 'start', ...baseMeta },
+  });
+  try {
+    const url = await generateConnectUrlForTui();
+    await recordStat({
+      command: 'connect',
+      nxVersion,
+      useCloud: true,
+      meta: { type: 'complete', ...baseMeta },
+    });
+    return url;
+  } catch (error) {
+    const message =
+      (error instanceof Error && error.message) ||
+      String(error ?? 'Unknown error');
+    await recordStat({
+      command: 'connect',
+      nxVersion,
+      useCloud: false,
+      meta: {
+        type: 'error',
+        errorCode: 'UNKNOWN',
+        errorName: error instanceof Error ? error.name : typeof error,
+        errorMessage: message.slice(0, 500),
+        ...baseMeta,
+      },
+    });
+    throw error;
+  }
+}
+
+async function generateConnectUrlForTui(): Promise<string> {
+  const nxJson = readNxJson();
+
+  const checkRemote = process.env.NX_SKIP_CHECK_REMOTE !== 'true';
+  const hasRemote = !!getVcsRemoteInfo();
+  if (!hasRemote && checkRemote) {
+    throw new Error(
+      'Push this repository to a VCS provider (e.g. GitHub) first, then try again.'
+    );
+  }
+
+  // The connect shortcut is only offered while not connected, but guard anyway
+  // (e.g. the workspace was connected from another terminal mid-run).
+  if (isNxCloudUsed(nxJson)) {
+    const token =
+      process.env.NX_CLOUD_AUTH_TOKEN ||
+      process.env.NX_CLOUD_ACCESS_TOKEN ||
+      nxJson.nxCloudAccessToken ||
+      nxJson.nxCloudId;
+    return createNxCloudOnboardingURL('nx-tui', token, undefined, false);
+  }
+
+  const token = await connectWorkspaceToCloud({
+    installationSource: 'nx-tui',
+  });
+  return createNxCloudOnboardingURL('nx-tui', token, undefined, false);
+}
+
 export async function connectExistingRepoToNxCloudPrompt(
   command = 'init',
   key: MessageKey = 'setupNxCloud',

--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -28,7 +28,7 @@ export declare class ExternalObject<T> {
   }
 }
 export declare class AppLifeCycle {
-  constructor(tasks: Array<Task>, initiatingTasks: Array<string>, runMode: RunMode, pinnedTasks: Array<string>, tuiCliArgs: TuiCliArgs, tuiConfig: TuiConfig, titleText: string, workspaceRoot: string, taskGraph: TaskGraph)
+  constructor(tasks: Array<Task>, initiatingTasks: Array<string>, runMode: RunMode, pinnedTasks: Array<string>, tuiCliArgs: TuiCliArgs, tuiConfig: TuiConfig, titleText: string, workspaceRoot: string, taskGraph: TaskGraph, cloudConnectionStatus?: CloudConnectionStatus | undefined | null)
   startCommand(threadCount?: number | undefined | null): void
   scheduleTask(task: Task): void
   startTasks(tasks: Array<Task>, metadata: object): void
@@ -53,6 +53,22 @@ export declare class AppLifeCycle {
    * Cloud client can call it via the lifecycle it already receives.
    */
   setCloudLink(label: string, url: string): void
+  /**
+   * Register the callback fired when the user presses the connect-to-cloud
+   * shortcut. JS runs the `nx connect` logic and pushes the resulting URL
+   * back via `setConnectUrl` / `setConnectError`.
+   */
+  registerConnectToCloudCallback(connectCallback: (() => unknown)): void
+  /** Deliver the Nx Cloud onboarding URL to the performance-report popup. */
+  setConnectUrl(url: string): void
+  /** Surface a connect failure in the performance-report popup. */
+  setConnectError(message: string): void
+  /**
+   * Update the Nx Cloud connection status gating the enable-remote-cache
+   * affordances (e.g. after a TUI-initiated connect wrote an nxCloudId to
+   * nx.json).
+   */
+  setCloudConnectionStatus(status: CloudConnectionStatus): void
 }
 
 export declare class ChildProcess {
@@ -295,6 +311,17 @@ export declare function canInstallNxConsole(): Promise<boolean>
 export declare function canInstallNxConsoleForEditor(editor: SupportedEditor): Promise<boolean>
 
 export declare function closeDbConnection(connection: ExternalObject<NxDbConnection>): void
+
+/**
+ * Whether the workspace is connected to Nx Cloud. Computed by JS at startup
+ * and updated mid-run after a successful TUI-initiated connect. Passing no
+ * status at all (JS `undefined`) means cloud is disabled for the workspace
+ * and the TUI shows no cloud status.
+ */
+export declare const enum CloudConnectionStatus {
+  Connected = 'Connected',
+  NotConnected = 'NotConnected'
+}
 
 export declare function connectToNxDb(cacheDir: string, dbName?: string | undefined | null): ExternalObject<NxDbConnection>
 

--- a/packages/nx/src/native/native-bindings.js
+++ b/packages/nx/src/native/native-bindings.js
@@ -598,6 +598,7 @@ module.exports.BatchStatus = nativeBinding.BatchStatus
 module.exports.canInstallNxConsole = nativeBinding.canInstallNxConsole
 module.exports.canInstallNxConsoleForEditor = nativeBinding.canInstallNxConsoleForEditor
 module.exports.closeDbConnection = nativeBinding.closeDbConnection
+module.exports.CloudConnectionStatus = nativeBinding.CloudConnectionStatus
 module.exports.connectToNxDb = nativeBinding.connectToNxDb
 module.exports.copy = nativeBinding.copy
 module.exports.detectAiAgent = nativeBinding.detectAiAgent

--- a/packages/nx/src/native/tui/app.rs
+++ b/packages/nx/src/native/tui/app.rs
@@ -1094,11 +1094,17 @@ impl App {
                                 self.dispatch_action(Action::SwitchMode(TuiMode::Inline));
                                 return Ok(false);
                             }
-                            KeyCode::Char('C') if countdown_popup.should_start_connect() => {
+                            KeyCode::Char('C')
+                                if countdown_popup.has_summary()
+                                    && countdown_popup.should_start_connect() =>
+                            {
                                 // Start the enable-remote-cache connect flow the
                                 // footer hint advertises. Keep the report open
                                 // (pinned) so the URL renders inside it when the
-                                // flow completes.
+                                // flow completes. Gated on has_summary: the
+                                // no-report exit dialog shows none of the connect
+                                // affordances, so `C` there must fall through to
+                                // the any-key dismissal like every other key.
                                 countdown_popup.pin_open();
                                 self.core.state().lock().cancel_quit();
                                 self.start_cloud_connect_from_report();
@@ -4661,5 +4667,37 @@ mod tests {
 
         press_key(&mut app, KeyCode::Char('C'), KeyModifiers::SHIFT);
         assert_eq!(report_connect_state(&app), CloudConnectState::Loading);
+    }
+
+    /// The mid-run exit dialog (no summary) shows no connect affordances, so
+    /// `<shift>+c` there must behave like any other key - dismiss the dialog -
+    /// and MUST NOT silently start a connect flow (which creates a remote
+    /// workspace and writes nx.json).
+    #[test]
+    fn connect_shortcut_inert_on_no_report_exit_dialog() {
+        let mut app = create_test_app();
+        app.set_cloud_connection_status(Some(CloudConnectionStatus::NotConnected));
+        // q mid-run: countdown dialog without a summary.
+        {
+            let popup = app
+                .components
+                .iter_mut()
+                .find_map(|c| c.as_any_mut().downcast_mut::<CountdownPopup>())
+                .unwrap();
+            popup.start_countdown(3);
+        }
+        app.update_focus(Focus::CountdownPopup);
+
+        press_key(&mut app, KeyCode::Char('C'), KeyModifiers::SHIFT);
+
+        assert_eq!(
+            report_connect_state(&app),
+            CloudConnectState::NotStarted,
+            "no connect attempt starts from the exit dialog"
+        );
+        assert!(
+            !report_visible(&app),
+            "the key falls through to the any-key dismissal"
+        );
     }
 }

--- a/packages/nx/src/native/tui/app.rs
+++ b/packages/nx/src/native/tui/app.rs
@@ -29,7 +29,7 @@ use crate::native::{
 use super::action::Action;
 use super::clipboard::copy_to_clipboard;
 use super::components::Component;
-use super::components::countdown_popup::CountdownPopup;
+use super::components::countdown_popup::{CONNECT_BUTTON_HREF, CloudConnectState, CountdownPopup};
 use super::components::dependency_view::{DependencyView, DependencyViewState};
 use super::components::help_popup::HelpPopup;
 use super::components::hint_popup::HintPopup;
@@ -43,7 +43,9 @@ use super::components::task_selection_manager::{
 use super::components::tasks_list::{TaskListClick, TaskStatus, TasksList};
 use super::components::terminal_pane::{TerminalPane, TerminalPaneData, TerminalPaneState};
 use super::graph_utils::{get_task_count, is_task_continuous};
-use super::lifecycle::{BatchStatus, PerformanceSummaryPayload, RunMode, TuiMode};
+use super::lifecycle::{
+    BatchStatus, CloudConnectionStatus, PerformanceSummaryPayload, RunMode, TuiMode,
+};
 use super::pty::PtyInstance;
 use super::theme::THEME;
 use super::tui;
@@ -476,6 +478,14 @@ impl App {
         if let Some(summary) = state.lock().exit_summary() {
             countdown_popup.set_summary(summary);
             tasks_list.set_perf_report_available(true);
+        }
+        // Re-hydrate the cloud connection status and any connect-attempt
+        // result so the report popup's enable-remote-cache affordances (and a
+        // generated URL) survive mode switches.
+        {
+            let state_lock = state.lock();
+            countdown_popup.set_cloud_connection_status(state_lock.get_cloud_connection_status());
+            countdown_popup.set_connect_state(state_lock.get_cloud_connect_state());
         }
         let hint_popup = HintPopup::new();
 
@@ -1082,6 +1092,16 @@ impl App {
                                 self.core.state().lock().cancel_quit();
                                 self.update_focus(self.previous_focus);
                                 self.dispatch_action(Action::SwitchMode(TuiMode::Inline));
+                                return Ok(false);
+                            }
+                            KeyCode::Char('C') if countdown_popup.should_start_connect() => {
+                                // Start the enable-remote-cache connect flow the
+                                // footer hint advertises. Keep the report open
+                                // (pinned) so the URL renders inside it when the
+                                // flow completes.
+                                countdown_popup.pin_open();
+                                self.core.state().lock().cancel_quit();
+                                self.start_cloud_connect_from_report();
                                 return Ok(false);
                             }
                             _ => {
@@ -1840,6 +1860,76 @@ impl App {
             .set_cloud_link(Some((label.clone(), url.clone())));
         // Dispatch to TasksList component for UI rendering
         self.dispatch_action(Action::UpdateCloudLink(label, url));
+    }
+
+    pub fn set_cloud_connection_status(&mut self, status: Option<CloudConnectionStatus>) {
+        // Store in state (for mode switching persistence)
+        self.core.state().lock().set_cloud_connection_status(status);
+        // Update the report popup directly (it gates the enable-remote-cache
+        // affordances on this)
+        if let Some(countdown_popup) = self
+            .components
+            .iter_mut()
+            .find_map(|c| c.as_any_mut().downcast_mut::<CountdownPopup>())
+        {
+            countdown_popup.set_cloud_connection_status(status);
+        }
+    }
+
+    /// Deliver the Nx Cloud onboarding URL to the report popup. Also persisted
+    /// in TuiState so it survives mode switches (and reopens of the report).
+    pub fn set_connect_url(&mut self, url: String) {
+        self.core
+            .state()
+            .lock()
+            .set_cloud_connect_state(CloudConnectState::Ready(url.clone()));
+        if let Some(countdown_popup) = self
+            .components
+            .iter_mut()
+            .find_map(|c| c.as_any_mut().downcast_mut::<CountdownPopup>())
+        {
+            countdown_popup.set_connect_state(CloudConnectState::Ready(url));
+        }
+    }
+
+    /// Surface a connect failure in the report popup (see `set_connect_url`).
+    pub fn set_connect_error(&mut self, message: String) {
+        self.core
+            .state()
+            .lock()
+            .set_cloud_connect_state(CloudConnectState::Error(message.clone()));
+        if let Some(countdown_popup) = self
+            .components
+            .iter_mut()
+            .find_map(|c| c.as_any_mut().downcast_mut::<CountdownPopup>())
+        {
+            countdown_popup.set_connect_state(CloudConnectState::Error(message));
+        }
+    }
+
+    /// Kick off the connect flow from the report popup: mark it loading and
+    /// fire the JS callback, which runs the `nx connect` logic headlessly and
+    /// pushes the URL back via `set_connect_url`.
+    fn start_cloud_connect_from_report(&mut self) {
+        if let Some(countdown_popup) = self
+            .components
+            .iter_mut()
+            .find_map(|c| c.as_any_mut().downcast_mut::<CountdownPopup>())
+        {
+            countdown_popup.set_connect_state(CloudConnectState::Loading);
+        }
+        let fired = {
+            let mut state = self.core.state().lock();
+            state.set_cloud_connect_state(CloudConnectState::Loading);
+            state.call_connect_to_cloud_callback()
+        };
+        if !fired {
+            // JS never registered a connect callback; fail instead of hanging
+            // in the loading state.
+            self.set_connect_error(
+                "The connect flow is not available in this session.".to_string(),
+            );
+        }
     }
 
     /// Dispatches an action to the action tx for other components to handle however they see fit
@@ -2753,7 +2843,14 @@ impl App {
                     .or_else(|| self.region_url_at(col, row))
                 {
                     self.pin_active_modal_open();
-                    self.open_url_or_hint(&href);
+                    // The report's "Enable remote cache" button is a link with
+                    // a sentinel href: start the connect flow instead of
+                    // opening a browser.
+                    if href == CONNECT_BUTTON_HREF {
+                        self.start_cloud_connect_from_report();
+                    } else {
+                        self.open_url_or_hint(&href);
+                    }
                     return;
                 }
                 // Only a click *outside* the modal dismisses it.
@@ -3871,6 +3968,18 @@ impl TuiApp for App {
     fn set_cloud_link(&mut self, label: String, url: String) {
         App::set_cloud_link(self, label, url);
     }
+
+    fn set_cloud_connection_status(&mut self, status: Option<CloudConnectionStatus>) {
+        App::set_cloud_connection_status(self, status);
+    }
+
+    fn set_connect_url(&mut self, url: String) {
+        App::set_connect_url(self, url);
+    }
+
+    fn set_connect_error(&mut self, message: String) {
+        App::set_connect_error(self, message);
+    }
 }
 
 #[cfg(test)]
@@ -3905,6 +4014,7 @@ mod tests {
             String::from("Test"),
             task_graph,
             HashMap::new(),
+            None,
             None,
         )));
 
@@ -4452,5 +4562,104 @@ mod tests {
             switched_to_inline,
             "Enter on the report should switch to inline in one press"
         );
+    }
+
+    fn report_connect_state(app: &App) -> CloudConnectState {
+        app.components
+            .iter()
+            .find_map(|c| c.as_any().downcast_ref::<CountdownPopup>())
+            .map(|p| p.connect_state().clone())
+            .unwrap()
+    }
+
+    fn press_key(app: &mut App, code: KeyCode, modifiers: KeyModifiers) {
+        let (tx, _rx) = mpsc::unbounded_channel();
+        app.handle_event(tui::Event::Key(KeyEvent::new(code, modifiers)), &tx)
+            .unwrap();
+    }
+
+    /// `<shift>+c` on the focused report starts the connect flow: the report
+    /// stays open (pinned) in the loading state and the pending auto-exit is
+    /// cancelled.
+    #[test]
+    fn connect_shortcut_on_report_starts_loading_and_keeps_it_open() {
+        let mut app = create_test_app();
+        app.set_cloud_connection_status(Some(CloudConnectionStatus::NotConnected));
+        show_focused_report(&mut app);
+
+        press_key(&mut app, KeyCode::Char('C'), KeyModifiers::SHIFT);
+
+        assert!(
+            report_visible(&app),
+            "the report stays open to show the URL"
+        );
+        assert_eq!(report_connect_state(&app), CloudConnectState::Loading);
+        assert_eq!(
+            app.core.state().lock().get_cloud_connect_state(),
+            CloudConnectState::Loading,
+            "loading state is persisted for mode switches"
+        );
+        assert!(
+            !app.core.state().lock().should_quit(),
+            "starting the connect flow cancels the pending auto-exit"
+        );
+    }
+
+    /// When the workspace is already connected (or cloud is disabled), the
+    /// shortcut falls through to the generic any-key dismissal and starts
+    /// nothing.
+    #[test]
+    fn connect_shortcut_inert_when_connected_or_disabled() {
+        for status in [Some(CloudConnectionStatus::Connected), None] {
+            let mut app = create_test_app();
+            app.set_cloud_connection_status(status);
+            show_focused_report(&mut app);
+
+            press_key(&mut app, KeyCode::Char('C'), KeyModifiers::SHIFT);
+
+            assert_eq!(
+                report_connect_state(&app),
+                CloudConnectState::NotStarted,
+                "no connect attempt starts for status {status:?}"
+            );
+        }
+    }
+
+    /// The delivered URL lands in the report popup and is persisted in
+    /// TuiState, so an app rebuilt from the same state (mode switch)
+    /// re-hydrates it instead of losing it against the memoized JS promise.
+    #[test]
+    fn connect_url_reaches_report_and_survives_mode_switch_rebuild() {
+        let mut app = create_test_app();
+        app.set_cloud_connection_status(Some(CloudConnectionStatus::NotConnected));
+        show_focused_report(&mut app);
+        press_key(&mut app, KeyCode::Char('C'), KeyModifiers::SHIFT);
+
+        app.set_connect_url("https://cloud.nx.app/connect/abcd1234".to_string());
+        assert_eq!(
+            report_connect_state(&app),
+            CloudConnectState::Ready("https://cloud.nx.app/connect/abcd1234".to_string())
+        );
+
+        let shared_state = app.core.state().clone();
+        let rebuilt = App::with_state(shared_state, TuiMode::FullScreen).unwrap();
+        assert_eq!(
+            report_connect_state(&rebuilt),
+            CloudConnectState::Ready("https://cloud.nx.app/connect/abcd1234".to_string()),
+            "rebuilt app re-hydrates the connect result from TuiState"
+        );
+    }
+
+    /// A failed attempt allows a retry with the same shortcut.
+    #[test]
+    fn connect_error_allows_retry_from_report() {
+        let mut app = create_test_app();
+        app.set_cloud_connection_status(Some(CloudConnectionStatus::NotConnected));
+        show_focused_report(&mut app);
+        press_key(&mut app, KeyCode::Char('C'), KeyModifiers::SHIFT);
+        app.set_connect_error("network down".to_string());
+
+        press_key(&mut app, KeyCode::Char('C'), KeyModifiers::SHIFT);
+        assert_eq!(report_connect_state(&app), CloudConnectState::Loading);
     }
 }

--- a/packages/nx/src/native/tui/components/countdown_popup.rs
+++ b/packages/nx/src/native/tui/components/countdown_popup.rs
@@ -22,14 +22,11 @@ use super::Component;
 use super::link::{Link, LinkRegistry};
 use super::nx_paragraph::{NxLine, NxParagraph, NxSpan, NxText};
 
-/// Sentinel `href` for the "Enable remote cache" button. It is registered in
-/// the link registry like a real link (so its rendered rect is hit-testable),
-/// but the app intercepts it and starts the connect flow instead of opening a
-/// browser.
+/// Sentinel `href` for the clickable "Enable remote cache" footer hint. It is
+/// registered in the link registry like a real link (so its rendered rect is
+/// hit-testable), but the app intercepts it and starts the connect flow
+/// instead of opening a browser.
 pub const CONNECT_BUTTON_HREF: &str = "nx-tui://enable-remote-cache";
-
-/// Display text of the inline "Enable remote cache" button.
-const CONNECT_BUTTON_LABEL: &str = "[ Enable remote cache ]";
 
 /// State of the TUI-initiated connect attempt kicked off from the report's
 /// "Enable remote cache" affordances. Persisted in `TuiState` so it survives
@@ -482,7 +479,7 @@ impl CountdownPopup {
         let has_report = !report.is_empty();
         // Two modes: a finished run shows the Performance Report; otherwise (e.g. q
         // pressed mid-run) the original exit dialog with just the interactive hints.
-        let mut content = if has_report {
+        let content = if has_report {
             self.report_mode_content(report)
         } else {
             Self::exit_dialog_content()
@@ -491,43 +488,11 @@ impl CountdownPopup {
         // Turn the recommendation phrases into clickable links, then lay the report
         // out through NxParagraph so each link's rect is recorded.
         self.link_registry.clear();
-        let mut all_links: Vec<SummaryLink> = self
+        let all_links: Vec<SummaryLink> = self
             .summary
             .as_ref()
             .map(|s| s.links.clone())
             .unwrap_or_default();
-
-        // "Enable remote cache" button: appended inline right after the
-        // remote-cache recommendation, only while the workspace is not
-        // connected and no connect attempt has been made yet. It is a synthetic
-        // link with a sentinel href that the app intercepts to start the
-        // connect flow (linkify below turns it into a clickable rect).
-        let show_connect_button = has_report
-            && self.can_connect_to_cloud()
-            && matches!(self.connect_state, CloudConnectState::NotStarted);
-        if show_connect_button {
-            let cache_link_texts: Vec<String> = all_links
-                .iter()
-                .filter(|l| l.href.contains("remote-cache"))
-                .map(|l| l.text.clone())
-                .collect();
-            let cache_line = content.iter_mut().find(|line| {
-                let raw: String = line
-                    .spans
-                    .iter()
-                    .map(|s| s.content.as_ref())
-                    .collect::<String>();
-                cache_link_texts.iter().any(|t| raw.contains(t.as_str()))
-            });
-            if let Some(line) = cache_line {
-                line.spans.push(Span::raw(" "));
-                line.spans.push(Span::raw(CONNECT_BUTTON_LABEL));
-                all_links.push(SummaryLink {
-                    text: CONNECT_BUTTON_LABEL.to_string(),
-                    href: CONNECT_BUTTON_HREF.to_string(),
-                });
-            }
-        }
 
         let nx_content: NxText = content
             .into_iter()
@@ -586,16 +551,19 @@ impl CountdownPopup {
 
         // Keybinding actions in the bottom border — only with a report, where there's
         // a pane to reopen and possibly scroll (scroll only when the report overflows).
+        // The connect hint doubles as a clickable CTA; its width is captured so
+        // its rendered rect can be registered for mouse hit-testing below.
+        let mut connect_hint_width: Option<u16> = None;
         let bottom_hints: Option<Vec<Span>> = if has_report {
             let mut footer = vec![Span::raw("  ")];
             // Advertise the connect shortcut while it can start an attempt
             // (fresh or retry after an error).
             if self.should_start_connect() {
-                footer.push(Span::styled(
-                    "Enable remote cache: ",
-                    Style::default().fg(THEME.secondary_fg),
-                ));
-                footer.push(Span::styled("<shift>+c", Style::default().fg(THEME.info)));
+                let label = "Enable remote cache: ";
+                let key = "<shift>+c";
+                connect_hint_width = Some((label.len() + key.len()) as u16);
+                footer.push(Span::styled(label, Style::default().fg(THEME.secondary_fg)));
+                footer.push(Span::styled(key, Style::default().fg(THEME.info)));
                 footer.push(Span::raw("   "));
             }
             footer.extend([
@@ -750,6 +718,28 @@ impl CountdownPopup {
 
         f.render_widget(Clear, popup_area);
         f.render_widget(block.clone(), popup_area);
+
+        // Register the "Enable remote cache" footer hint's rendered rect under
+        // the sentinel href, so clicking it starts the connect flow like the
+        // shortcut does. The bottom title is right-aligned within the border
+        // (popup width minus the two corner columns); the hint sits after the
+        // footer's leading 2-space pad.
+        if let Some(hint_width) = connect_hint_width {
+            let titles_width = popup_width.saturating_sub(2);
+            let line_start =
+                popup_area.x + 1 + titles_width.saturating_sub(bottom_width.min(titles_width));
+            let hint_rect = Rect {
+                x: line_start + 2,
+                y: popup_area.y + popup_area.height.saturating_sub(1),
+                width: hint_width,
+                height: 1,
+            }
+            .intersection(popup_area);
+            if hint_rect.width > 0 {
+                self.link_registry
+                    .push(hint_rect, CONNECT_BUTTON_HREF.to_string());
+            }
+        }
         // NxParagraph records each rendered link's rect into the registry, which
         // the app's modal mouse handler hit-tests to open it.
         f.render_stateful_widget(popup, main_area, &mut self.link_registry);
@@ -856,7 +846,7 @@ mod tests {
     // The remote-cache CTA text/href the payload carries (built in TS); the popup must
     // render and hyperlink exactly these.
     const CACHE_PHRASE: &str =
-        "Drastically reduce your run duration by sharing a cache across your team and CI";
+        "Enable remote cache to reduce your run duration by sharing it with your team and CI";
     const CACHE_HREF: &str = "https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache";
 
     fn summary_with(recommendations: Vec<String>) -> PerformanceSummaryPayload {
@@ -1038,61 +1028,57 @@ mod tests {
     }
 
     #[test]
-    fn shows_connect_button_and_hint_only_when_not_connected() {
-        // Not connected: the button follows the cache rec, is clickable via the
-        // sentinel href, and the footer advertises the shortcut.
+    fn connect_hint_shows_and_is_clickable_only_when_not_connected() {
+        // Not connected: the footer CTA renders and its rect is clickable via
+        // the sentinel href.
         let mut popup = CountdownPopup::new();
         popup.set_summary(summary_with_cache_rec());
         popup.set_cloud_connection_status(Some(CloudConnectionStatus::NotConnected));
         let (text, hrefs) = render_with_registry(&mut popup);
-        assert!(text.contains("[ Enable remote cache ]"));
         assert!(text.contains("Enable remote cache: <shift>+c"));
         assert!(hrefs.iter().any(|h| h == CONNECT_BUTTON_HREF));
 
-        // Connected: neither the button nor the footer hint render.
+        // Connected: the footer hint does not render and nothing is clickable.
         let mut popup = CountdownPopup::new();
         popup.set_summary(summary_with_cache_rec());
         popup.set_cloud_connection_status(Some(CloudConnectionStatus::Connected));
         let (text, hrefs) = render_with_registry(&mut popup);
-        assert!(!text.contains("[ Enable remote cache ]"));
         assert!(!text.contains("<shift>+c"));
         assert!(!hrefs.iter().any(|h| h == CONNECT_BUTTON_HREF));
 
         // No status at all (cloud disabled): same as connected.
         let mut popup = CountdownPopup::new();
         popup.set_summary(summary_with_cache_rec());
-        let (text, _) = render_with_registry(&mut popup);
-        assert!(!text.contains("[ Enable remote cache ]"));
+        let (text, hrefs) = render_with_registry(&mut popup);
         assert!(!text.contains("<shift>+c"));
+        assert!(!hrefs.iter().any(|h| h == CONNECT_BUTTON_HREF));
     }
 
     #[test]
     fn footer_hint_shows_even_without_the_cache_rec() {
         // A run without the remote-cache recommendation (e.g. good hit rate but
-        // still unconnected) has no button to attach, but the footer shortcut
-        // still offers the connect flow.
+        // still unconnected) still offers the connect flow via the footer CTA.
         let mut popup = CountdownPopup::new();
         popup.set_summary(summary_with(vec!["Some other recommendation".to_string()]));
         popup.set_cloud_connection_status(Some(CloudConnectionStatus::NotConnected));
         let (text, hrefs) = render_with_registry(&mut popup);
-        assert!(!text.contains("[ Enable remote cache ]"));
         assert!(text.contains("Enable remote cache: <shift>+c"));
-        assert!(!hrefs.iter().any(|h| h == CONNECT_BUTTON_HREF));
+        assert!(hrefs.iter().any(|h| h == CONNECT_BUTTON_HREF));
     }
 
     #[test]
     fn connect_states_render_at_the_bottom() {
-        // Loading: progress text, button and hint gone (attempt in flight).
+        // Loading: progress text; the footer CTA is gone (attempt in flight).
         let mut popup = CountdownPopup::new();
         popup.set_summary(summary_with_cache_rec());
         popup.set_cloud_connection_status(Some(CloudConnectionStatus::NotConnected));
         popup.set_connect_state(CloudConnectState::Loading);
-        let (text, _) = render_with_registry(&mut popup);
+        let (text, hrefs) = render_with_registry(&mut popup);
         assert!(text.contains("Generating your Nx Cloud connect URL..."));
-        assert!(!text.contains("[ Enable remote cache ]"));
         assert!(!text.contains("<shift>+c"));
+        assert!(!hrefs.iter().any(|h| h == CONNECT_BUTTON_HREF));
 
-        // Ready: the short URL renders and is clickable; still no button.
+        // Ready: the short URL renders and is clickable.
         let url = "https://cloud.nx.app/connect/abcd1234";
         let mut popup = CountdownPopup::new();
         popup.set_summary(summary_with_cache_rec());
@@ -1101,7 +1087,6 @@ mod tests {
         let (text, hrefs) = render_with_registry(&mut popup);
         assert!(text.contains(&format!("Finish your setup: {url}")));
         assert!(hrefs.iter().any(|h| h == url));
-        assert!(!text.contains("[ Enable remote cache ]"));
 
         // The URL stays visible after the workspace flips to connected (the
         // user still needs it to finish onboarding in the browser).

--- a/packages/nx/src/native/tui/components/countdown_popup.rs
+++ b/packages/nx/src/native/tui/components/countdown_popup.rs
@@ -603,7 +603,10 @@ impl CountdownPopup {
                 ),
                 Span::styled("p", Style::default().fg(THEME.info)),
             ]);
-            if self.is_scrollable() {
+            // The scroll hint yields to the connect hint: with both, the footer
+            // exceeds the 70-col popup cap and ratatui left-truncates the row.
+            // Scrolling still works; the hint returns once an attempt starts.
+            if self.is_scrollable() && !self.should_start_connect() {
                 footer.push(Span::styled(
                     "   scroll: ",
                     Style::default().fg(THEME.secondary_fg),
@@ -1105,6 +1108,32 @@ mod tests {
         let (text, _) = render_with_registry(&mut popup);
         assert!(text.contains("Could not connect: network down"));
         assert!(text.contains("Enable remote cache: <shift>+c"));
+    }
+
+    #[test]
+    fn scroll_hint_yields_to_the_connect_hint() {
+        // A tall report overflows the popup viewport (scrollable). With the
+        // connect hint shown, both hints together exceed the 70-col cap and
+        // ratatui would left-truncate the footer - so the scroll hint yields.
+        let mut tall = summary_with_cache_rec();
+        tall.recommendations
+            .extend((0..80).map(|i| format!("Recommendation number {i}")));
+
+        let mut popup = CountdownPopup::new();
+        popup.set_summary(tall.clone());
+        popup.set_cloud_connection_status(Some(CloudConnectionStatus::NotConnected));
+        let (text, _) = render_with_registry(&mut popup);
+        assert!(text.contains("Enable remote cache: <shift>+c"));
+        assert!(
+            !text.contains("scroll:"),
+            "scroll hint yields while the connect hint renders"
+        );
+
+        // Once an attempt started (hint gone), the scroll hint returns.
+        popup.set_connect_state(CloudConnectState::Loading);
+        let (text, _) = render_with_registry(&mut popup);
+        assert!(!text.contains("<shift>+c"));
+        assert!(text.contains("scroll:"));
     }
 
     #[test]

--- a/packages/nx/src/native/tui/components/countdown_popup.rs
+++ b/packages/nx/src/native/tui/components/countdown_popup.rs
@@ -663,12 +663,12 @@ impl CountdownPopup {
             .max(1);
         let estimated_rows = nx_content.wrapped_rows(inner_width, false);
         // Rows reserved at the bottom of the inner area for the connect
-        // progress/URL line (plus a blank separator row above it).
+        // progress/URL line, plus a divider row and a blank row above it.
         let connect_rows: u16 = connect_line
             .as_ref()
             .map(|l| {
                 let text: NxText = vec![l.clone()].into();
-                text.wrapped_rows(inner_width, false).max(1) as u16 + 1
+                text.wrapped_rows(inner_width, false).max(1) as u16 + 2
             })
             .unwrap_or(0);
         let popup_height = ((estimated_rows as u16)
@@ -710,9 +710,8 @@ impl CountdownPopup {
             ..inner_area
         };
         let connect_area = Rect {
-            // Skip the blank separator row above the connect line.
-            y: inner_area.y + main_area.height + 1,
-            height: connect_rows.saturating_sub(1),
+            y: inner_area.y + main_area.height,
+            height: connect_rows,
             ..inner_area
         }
         // On a tiny terminal the clamped popup may not fit the reserved rows.
@@ -755,13 +754,19 @@ impl CountdownPopup {
         // the app's modal mouse handler hit-tests to open it.
         f.render_stateful_widget(popup, main_area, &mut self.link_registry);
 
-        // The connect progress/URL line, centered above the footer hints.
+        // The connect section: a divider separating it from the report, then
+        // the progress/URL line centered above the footer hints.
         if let Some(line) = connect_line
             && connect_area.height > 0
         {
-            let connect_paragraph = NxParagraph::new(NxText::from(vec![line]))
-                .alignment(Alignment::Center)
-                .wrap(Wrap { trim: false });
+            let divider = NxLine::from_spans(vec![NxSpan::Text(Span::styled(
+                "─".repeat(connect_area.width as usize),
+                Style::default().fg(THEME.info),
+            ))]);
+            let connect_paragraph =
+                NxParagraph::new(NxText::from(vec![divider, NxLine::default(), line]))
+                    .alignment(Alignment::Center)
+                    .wrap(Wrap { trim: false });
             f.render_stateful_widget(connect_paragraph, connect_area, &mut self.link_registry);
         }
 
@@ -1150,6 +1155,16 @@ mod tests {
         let (text, _) = render_with_registry(&mut popup);
 
         let line_text = format!("Finish your setup: {url}");
+
+        // A divider row separates the report from the connect section: an
+        // inner row (bordered by │ on both sides) made of ─ characters.
+        let has_divider = text.lines().any(|l| {
+            let chars: Vec<char> = l.chars().collect();
+            chars.iter().filter(|&&c| c == '│').count() == 2
+                && chars.iter().filter(|&&c| c == '─').count() > 20
+        });
+        assert!(has_divider, "a divider renders above the connect line");
+
         let url_row = text.lines().find(|l| l.contains(&line_text)).unwrap();
         // Compare the space padding between the border columns on either side
         // of the line (work in chars: the border glyphs are multi-byte).

--- a/packages/nx/src/native/tui/components/countdown_popup.rs
+++ b/packages/nx/src/native/tui/components/countdown_popup.rs
@@ -548,9 +548,13 @@ impl CountdownPopup {
                         Style::default().fg(THEME.secondary_fg),
                     ))]))
                 }
-                CloudConnectState::Ready(url) => Some(NxLine::from_spans(vec![NxSpan::Link(
-                    Link::new(url.clone(), url.clone()),
-                )])),
+                CloudConnectState::Ready(url) => Some(NxLine::from_spans(vec![
+                    NxSpan::Text(Span::styled(
+                        "Finish your setup: ".to_string(),
+                        Style::default().fg(THEME.primary_fg),
+                    )),
+                    NxSpan::Link(Link::new(url.clone(), url.clone())),
+                ])),
                 CloudConnectState::Error(message) => {
                     Some(NxLine::from_spans(vec![NxSpan::Text(Span::styled(
                         format!("Could not connect: {message}"),
@@ -1090,7 +1094,7 @@ mod tests {
         popup.set_cloud_connection_status(Some(CloudConnectionStatus::NotConnected));
         popup.set_connect_state(CloudConnectState::Ready(url.to_string()));
         let (text, hrefs) = render_with_registry(&mut popup);
-        assert!(text.contains(url));
+        assert!(text.contains(&format!("Finish your setup: {url}")));
         assert!(hrefs.iter().any(|h| h == url));
         assert!(!text.contains("[ Enable remote cache ]"));
 
@@ -1145,19 +1149,20 @@ mod tests {
         popup.set_connect_state(CloudConnectState::Ready(url.to_string()));
         let (text, _) = render_with_registry(&mut popup);
 
-        let url_row = text.lines().find(|l| l.contains(url)).unwrap();
+        let line_text = format!("Finish your setup: {url}");
+        let url_row = text.lines().find(|l| l.contains(&line_text)).unwrap();
         // Compare the space padding between the border columns on either side
-        // of the URL (work in chars: the border glyphs are multi-byte).
+        // of the line (work in chars: the border glyphs are multi-byte).
         let chars: Vec<char> = url_row.chars().collect();
         let left_border = chars.iter().position(|&c| c == '│').unwrap();
         let right_border = chars.iter().rposition(|&c| c == '│').unwrap();
         let inner: String = chars[left_border + 1..right_border].iter().collect();
-        let start = inner.find(url).unwrap();
+        let start = inner.find(&line_text).unwrap();
         let left_pad = start;
-        let right_pad = inner.len() - start - url.len();
+        let right_pad = inner.len() - start - line_text.len();
         assert!(
             left_pad.abs_diff(right_pad) <= 4,
-            "URL should be roughly centered (left pad {left_pad}, right pad {right_pad})"
+            "the setup line should be roughly centered (left pad {left_pad}, right pad {right_pad})"
         );
     }
 

--- a/packages/nx/src/native/tui/components/countdown_popup.rs
+++ b/packages/nx/src/native/tui/components/countdown_popup.rs
@@ -12,13 +12,40 @@ use ratatui::{
 use std::any::Any;
 use std::time::{Duration, Instant};
 
-use crate::native::tui::lifecycle::{Link as SummaryLink, PerformanceSummaryPayload};
+use crate::native::tui::lifecycle::{
+    CloudConnectionStatus, Link as SummaryLink, PerformanceSummaryPayload,
+};
 use crate::native::tui::theme::THEME;
 use crate::native::tui::utils::{format_duration, pluralize};
 
 use super::Component;
 use super::link::{Link, LinkRegistry};
 use super::nx_paragraph::{NxLine, NxParagraph, NxSpan, NxText};
+
+/// Sentinel `href` for the "Enable remote cache" button. It is registered in
+/// the link registry like a real link (so its rendered rect is hit-testable),
+/// but the app intercepts it and starts the connect flow instead of opening a
+/// browser.
+pub const CONNECT_BUTTON_HREF: &str = "nx-tui://enable-remote-cache";
+
+/// Display text of the inline "Enable remote cache" button.
+const CONNECT_BUTTON_LABEL: &str = "[ Enable remote cache ]";
+
+/// State of the TUI-initiated connect attempt kicked off from the report's
+/// "Enable remote cache" affordances. Persisted in `TuiState` so it survives
+/// mode switches (both apps re-hydrate their popup from there).
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub enum CloudConnectState {
+    /// No connect attempt has been made yet.
+    #[default]
+    NotStarted,
+    /// JS is creating the workspace / generating the onboarding URL.
+    Loading,
+    /// The onboarding URL is ready to follow.
+    Ready(String),
+    /// The connect attempt failed (e.g. offline, missing git remote).
+    Error(String),
+}
 
 /// Convert a styled line into an `NxLine`, turning any occurrence of a known
 /// link phrase into a clickable [`Link`]. Replaces the old buffer-scanning OSC 8
@@ -115,6 +142,11 @@ pub struct CountdownPopup {
     /// Clickable report links recorded during render; the app hit-tests these
     /// (via the modal mouse path) to open them.
     link_registry: LinkRegistry,
+    /// Nx Cloud connection status; `Some(NotConnected)` enables the
+    /// "Enable remote cache" button and footer hint. `None` = cloud disabled.
+    cloud_connection_status: Option<CloudConnectionStatus>,
+    /// State of the connect attempt started from this popup.
+    connect_state: CloudConnectState,
 }
 
 impl CountdownPopup {
@@ -132,12 +164,46 @@ impl CountdownPopup {
             summary: None,
             pinned: false,
             link_registry: LinkRegistry::new(),
+            cloud_connection_status: None,
+            connect_state: CloudConnectState::default(),
         }
     }
 
     /// Set the run report shown above the hint text.
     pub fn set_summary(&mut self, summary: PerformanceSummaryPayload) {
         self.summary = Some(summary);
+    }
+
+    pub fn set_cloud_connection_status(&mut self, status: Option<CloudConnectionStatus>) {
+        self.cloud_connection_status = status;
+    }
+
+    pub fn set_connect_state(&mut self, state: CloudConnectState) {
+        self.connect_state = state;
+    }
+
+    pub fn connect_state(&self) -> &CloudConnectState {
+        &self.connect_state
+    }
+
+    /// Whether the enable-remote-cache affordances apply at all: only while the
+    /// workspace is not connected to Nx Cloud.
+    pub fn can_connect_to_cloud(&self) -> bool {
+        matches!(
+            self.cloud_connection_status,
+            Some(CloudConnectionStatus::NotConnected)
+        )
+    }
+
+    /// Whether pressing the connect shortcut should start a (new) attempt: the
+    /// affordance is live and there is no attempt in flight or completed (an
+    /// `Error` allows a retry; a `Ready` URL is just displayed).
+    pub fn should_start_connect(&self) -> bool {
+        self.can_connect_to_cloud()
+            && matches!(
+                self.connect_state,
+                CloudConnectState::NotStarted | CloudConnectState::Error(_)
+            )
     }
 
     /// Build the styled report lines from the structured summary — the native
@@ -416,7 +482,7 @@ impl CountdownPopup {
         let has_report = !report.is_empty();
         // Two modes: a finished run shows the Performance Report; otherwise (e.g. q
         // pressed mid-run) the original exit dialog with just the interactive hints.
-        let content = if has_report {
+        let mut content = if has_report {
             self.report_mode_content(report)
         } else {
             Self::exit_dialog_content()
@@ -425,16 +491,76 @@ impl CountdownPopup {
         // Turn the recommendation phrases into clickable links, then lay the report
         // out through NxParagraph so each link's rect is recorded.
         self.link_registry.clear();
-        let all_links: Vec<SummaryLink> = self
+        let mut all_links: Vec<SummaryLink> = self
             .summary
             .as_ref()
             .map(|s| s.links.clone())
             .unwrap_or_default();
+
+        // "Enable remote cache" button: appended inline right after the
+        // remote-cache recommendation, only while the workspace is not
+        // connected and no connect attempt has been made yet. It is a synthetic
+        // link with a sentinel href that the app intercepts to start the
+        // connect flow (linkify below turns it into a clickable rect).
+        let show_connect_button = has_report
+            && self.can_connect_to_cloud()
+            && matches!(self.connect_state, CloudConnectState::NotStarted);
+        if show_connect_button {
+            let cache_link_texts: Vec<String> = all_links
+                .iter()
+                .filter(|l| l.href.contains("remote-cache"))
+                .map(|l| l.text.clone())
+                .collect();
+            let cache_line = content.iter_mut().find(|line| {
+                let raw: String = line
+                    .spans
+                    .iter()
+                    .map(|s| s.content.as_ref())
+                    .collect::<String>();
+                cache_link_texts.iter().any(|t| raw.contains(t.as_str()))
+            });
+            if let Some(line) = cache_line {
+                line.spans.push(Span::raw(" "));
+                line.spans.push(Span::raw(CONNECT_BUTTON_LABEL));
+                all_links.push(SummaryLink {
+                    text: CONNECT_BUTTON_LABEL.to_string(),
+                    href: CONNECT_BUTTON_HREF.to_string(),
+                });
+            }
+        }
+
         let nx_content: NxText = content
             .into_iter()
             .map(|line| linkify_line(line, &all_links))
             .collect::<Vec<NxLine>>()
             .into();
+
+        // Connect-attempt progress/result, rendered centered at the bottom of
+        // the popup above the footer hints. Kept visible even after the status
+        // flips to connected (the user still needs the URL to finish
+        // onboarding in the browser).
+        let connect_line: Option<NxLine> = if has_report {
+            match &self.connect_state {
+                CloudConnectState::NotStarted => None,
+                CloudConnectState::Loading => {
+                    Some(NxLine::from_spans(vec![NxSpan::Text(Span::styled(
+                        "Generating your Nx Cloud connect URL...".to_string(),
+                        Style::default().fg(THEME.secondary_fg),
+                    ))]))
+                }
+                CloudConnectState::Ready(url) => Some(NxLine::from_spans(vec![NxSpan::Link(
+                    Link::new(url.clone(), url.clone()),
+                )])),
+                CloudConnectState::Error(message) => {
+                    Some(NxLine::from_spans(vec![NxSpan::Text(Span::styled(
+                        format!("Could not connect: {message}"),
+                        Style::default().fg(THEME.error),
+                    ))]))
+                }
+            }
+        } else {
+            None
+        };
 
         let seconds_remaining = if let Some(start_time) = self.start_time {
             let elapsed = start_time.elapsed();
@@ -457,8 +583,18 @@ impl CountdownPopup {
         // Keybinding actions in the bottom border — only with a report, where there's
         // a pane to reopen and possibly scroll (scroll only when the report overflows).
         let bottom_hints: Option<Vec<Span>> = if has_report {
-            let mut footer = vec![
-                Span::raw("  "),
+            let mut footer = vec![Span::raw("  ")];
+            // Advertise the connect shortcut while it can start an attempt
+            // (fresh or retry after an error).
+            if self.should_start_connect() {
+                footer.push(Span::styled(
+                    "Enable remote cache: ",
+                    Style::default().fg(THEME.secondary_fg),
+                ));
+                footer.push(Span::styled("<shift>+c", Style::default().fg(THEME.info)));
+                footer.push(Span::raw("   "));
+            }
+            footer.extend([
                 Span::styled("quit: ", Style::default().fg(THEME.secondary_fg)),
                 Span::styled("q", Style::default().fg(THEME.info)),
                 Span::styled(
@@ -466,7 +602,7 @@ impl CountdownPopup {
                     Style::default().fg(THEME.secondary_fg),
                 ),
                 Span::styled("p", Style::default().fg(THEME.info)),
-            ];
+            ]);
             if self.is_scrollable() {
                 footer.push(Span::styled(
                     "   scroll: ",
@@ -491,9 +627,11 @@ impl CountdownPopup {
         };
 
         // Size the popup to its content so a short cached-run report doesn't float in a
-        // fixed-width box, while staying wide enough for the title row and the bottom
-        // keybindings; cap at 70 so long recommendations still wrap.
-        let content_width = nx_content.max_width();
+        // fixed-width box, while staying wide enough for the title row, the bottom
+        // keybindings and the connect URL; cap at 70 so long recommendations still wrap.
+        let content_width = nx_content
+            .max_width()
+            .max(connect_line.as_ref().map(|l| l.width()).unwrap_or(0));
         let title_row_width: u16 = title_spans.iter().map(|s| s.width() as u16).sum::<u16>()
             + close_hint.iter().map(|s| s.width() as u16).sum::<u16>();
         let bottom_width: u16 = bottom_hints
@@ -517,9 +655,20 @@ impl CountdownPopup {
             .width
             .max(1);
         let estimated_rows = nx_content.wrapped_rows(inner_width, false);
-        let popup_height = ((estimated_rows as u16).saturating_add(4))
-            .min(safe_area.height.saturating_sub(4))
-            .max(5);
+        // Rows reserved at the bottom of the inner area for the connect
+        // progress/URL line (plus a blank separator row above it).
+        let connect_rows: u16 = connect_line
+            .as_ref()
+            .map(|l| {
+                let text: NxText = vec![l.clone()].into();
+                text.wrapped_rows(inner_width, false).max(1) as u16 + 1
+            })
+            .unwrap_or(0);
+        let popup_height = ((estimated_rows as u16)
+            .saturating_add(connect_rows)
+            .saturating_add(4))
+        .min(safe_area.height.saturating_sub(4))
+        .max(5);
 
         let popup_x = safe_area.x + (safe_area.width.saturating_sub(popup_width)) / 2;
         let popup_y = safe_area.y + (safe_area.height.saturating_sub(popup_height)) / 2;
@@ -543,15 +692,29 @@ impl CountdownPopup {
 
         let inner_area = block.inner(popup_area);
         // Record the inner text area so the app can bound selection/link hit-tests.
-        self.content_area = Some(inner_area);
-        self.viewport_height = inner_area.height as usize;
         // The text area sits inside the border + padding, so it never includes
         // the scrollbar (drawn on the far-right border column).
         self.content_area = Some(inner_area);
 
+        // Split the bottom rows off for the connect progress/URL line; the
+        // report scrolls within what remains.
+        let main_area = Rect {
+            height: inner_area.height.saturating_sub(connect_rows),
+            ..inner_area
+        };
+        let connect_area = Rect {
+            // Skip the blank separator row above the connect line.
+            y: inner_area.y + main_area.height + 1,
+            height: connect_rows.saturating_sub(1),
+            ..inner_area
+        }
+        // On a tiny terminal the clamped popup may not fit the reserved rows.
+        .intersection(inner_area);
+        self.viewport_height = main_area.height as usize;
+
         // Content height in wrapped rows, driving the scrollbar and the scroll
         // bound in scroll_down.
-        self.content_height = nx_content.wrapped_rows(inner_area.width, false);
+        self.content_height = nx_content.wrapped_rows(main_area.width, false);
 
         let scrollable_rows = self.content_height.saturating_sub(self.viewport_height);
         let needs_scrollbar = scrollable_rows > 0;
@@ -569,17 +732,31 @@ impl CountdownPopup {
         // rows by scroll_down's max_scroll, matching Paragraph::scroll's row-based
         // offset — slicing the unwrapped `content` with a wrapped-row offset
         // panicked the process.
+        //
+        // The block (borders + titles) renders over the whole popup; the report
+        // paragraph renders into `main_area` so the reserved connect rows stay
+        // clear of scrolled content.
         let popup = NxParagraph::new(nx_content)
-            .block(block.clone())
             // trim: false preserves leading whitespace so the report's
             // indentation renders.
             .wrap(Wrap { trim: false })
             .scroll((self.scroll_offset as u16, 0));
 
         f.render_widget(Clear, popup_area);
+        f.render_widget(block.clone(), popup_area);
         // NxParagraph records each rendered link's rect into the registry, which
         // the app's modal mouse handler hit-tests to open it.
-        f.render_stateful_widget(popup, popup_area, &mut self.link_registry);
+        f.render_stateful_widget(popup, main_area, &mut self.link_registry);
+
+        // The connect progress/URL line, centered above the footer hints.
+        if let Some(line) = connect_line
+            && connect_area.height > 0
+        {
+            let connect_paragraph = NxParagraph::new(NxText::from(vec![line]))
+                .alignment(Alignment::Center)
+                .wrap(Wrap { trim: false });
+            f.render_stateful_widget(connect_paragraph, connect_area, &mut self.link_registry);
+        }
 
         if needs_scrollbar {
             // Blank out the corners so the scrollbar arrows don't collide with
@@ -809,6 +986,150 @@ mod tests {
             "popup width should follow content (short {short_w} vs wide {wide_w})"
         );
         assert!(wide_w <= 70, "popup width caps at 70: {wide_w}");
+    }
+
+    /// A summary carrying the remote-cache CTA rec + link, as TS builds it.
+    fn summary_with_cache_rec() -> PerformanceSummaryPayload {
+        let mut s = summary_with(vec![format!("{CACHE_PHRASE}.")]);
+        s.links = vec![Link {
+            text: CACHE_PHRASE.to_string(),
+            href: CACHE_HREF.to_string(),
+        }];
+        s
+    }
+
+    /// Render and return (visible text, clickable hrefs found anywhere).
+    fn render_with_registry(popup: &mut CountdownPopup) -> (String, Vec<String>) {
+        let mut terminal = Terminal::new(TestBackend::new(74, 60)).unwrap();
+        terminal
+            .draw(|f| {
+                let area = f.area();
+                popup.render(f, area);
+            })
+            .unwrap();
+        let buffer = terminal.backend().buffer().clone();
+        let mut text = String::new();
+        for y in 0..buffer.area.height {
+            for x in 0..buffer.area.width {
+                text.push_str(buffer.cell((x, y)).unwrap().symbol());
+            }
+            text.push('\n');
+        }
+        let registry = popup.link_registry().unwrap();
+        let mut hrefs: Vec<String> = (0..buffer.area.height)
+            .flat_map(|y| (0..buffer.area.width).map(move |x| (x, y)))
+            .filter_map(|(x, y)| registry.hit_test(x, y).map(str::to_string))
+            .collect();
+        hrefs.sort();
+        hrefs.dedup();
+        (text, hrefs)
+    }
+
+    #[test]
+    fn shows_connect_button_and_hint_only_when_not_connected() {
+        // Not connected: the button follows the cache rec, is clickable via the
+        // sentinel href, and the footer advertises the shortcut.
+        let mut popup = CountdownPopup::new();
+        popup.set_summary(summary_with_cache_rec());
+        popup.set_cloud_connection_status(Some(CloudConnectionStatus::NotConnected));
+        let (text, hrefs) = render_with_registry(&mut popup);
+        assert!(text.contains("[ Enable remote cache ]"));
+        assert!(text.contains("Enable remote cache: <shift>+c"));
+        assert!(hrefs.iter().any(|h| h == CONNECT_BUTTON_HREF));
+
+        // Connected: neither the button nor the footer hint render.
+        let mut popup = CountdownPopup::new();
+        popup.set_summary(summary_with_cache_rec());
+        popup.set_cloud_connection_status(Some(CloudConnectionStatus::Connected));
+        let (text, hrefs) = render_with_registry(&mut popup);
+        assert!(!text.contains("[ Enable remote cache ]"));
+        assert!(!text.contains("<shift>+c"));
+        assert!(!hrefs.iter().any(|h| h == CONNECT_BUTTON_HREF));
+
+        // No status at all (cloud disabled): same as connected.
+        let mut popup = CountdownPopup::new();
+        popup.set_summary(summary_with_cache_rec());
+        let (text, _) = render_with_registry(&mut popup);
+        assert!(!text.contains("[ Enable remote cache ]"));
+        assert!(!text.contains("<shift>+c"));
+    }
+
+    #[test]
+    fn footer_hint_shows_even_without_the_cache_rec() {
+        // A run without the remote-cache recommendation (e.g. good hit rate but
+        // still unconnected) has no button to attach, but the footer shortcut
+        // still offers the connect flow.
+        let mut popup = CountdownPopup::new();
+        popup.set_summary(summary_with(vec!["Some other recommendation".to_string()]));
+        popup.set_cloud_connection_status(Some(CloudConnectionStatus::NotConnected));
+        let (text, hrefs) = render_with_registry(&mut popup);
+        assert!(!text.contains("[ Enable remote cache ]"));
+        assert!(text.contains("Enable remote cache: <shift>+c"));
+        assert!(!hrefs.iter().any(|h| h == CONNECT_BUTTON_HREF));
+    }
+
+    #[test]
+    fn connect_states_render_at_the_bottom() {
+        // Loading: progress text, button and hint gone (attempt in flight).
+        let mut popup = CountdownPopup::new();
+        popup.set_summary(summary_with_cache_rec());
+        popup.set_cloud_connection_status(Some(CloudConnectionStatus::NotConnected));
+        popup.set_connect_state(CloudConnectState::Loading);
+        let (text, _) = render_with_registry(&mut popup);
+        assert!(text.contains("Generating your Nx Cloud connect URL..."));
+        assert!(!text.contains("[ Enable remote cache ]"));
+        assert!(!text.contains("<shift>+c"));
+
+        // Ready: the short URL renders and is clickable; still no button.
+        let url = "https://cloud.nx.app/connect/abcd1234";
+        let mut popup = CountdownPopup::new();
+        popup.set_summary(summary_with_cache_rec());
+        popup.set_cloud_connection_status(Some(CloudConnectionStatus::NotConnected));
+        popup.set_connect_state(CloudConnectState::Ready(url.to_string()));
+        let (text, hrefs) = render_with_registry(&mut popup);
+        assert!(text.contains(url));
+        assert!(hrefs.iter().any(|h| h == url));
+        assert!(!text.contains("[ Enable remote cache ]"));
+
+        // The URL stays visible after the workspace flips to connected (the
+        // user still needs it to finish onboarding in the browser).
+        popup.set_cloud_connection_status(Some(CloudConnectionStatus::Connected));
+        let (text, _) = render_with_registry(&mut popup);
+        assert!(text.contains(url));
+
+        // Error: the message renders and the retry shortcut is advertised.
+        let mut popup = CountdownPopup::new();
+        popup.set_summary(summary_with_cache_rec());
+        popup.set_cloud_connection_status(Some(CloudConnectionStatus::NotConnected));
+        popup.set_connect_state(CloudConnectState::Error("network down".to_string()));
+        let (text, _) = render_with_registry(&mut popup);
+        assert!(text.contains("Could not connect: network down"));
+        assert!(text.contains("Enable remote cache: <shift>+c"));
+    }
+
+    #[test]
+    fn connect_url_renders_centered() {
+        let url = "https://cloud.nx.app/connect/abcd1234";
+        let mut popup = CountdownPopup::new();
+        popup.set_summary(summary_with_cache_rec());
+        popup.set_cloud_connection_status(Some(CloudConnectionStatus::NotConnected));
+        popup.set_connect_state(CloudConnectState::Ready(url.to_string()));
+        let (text, _) = render_with_registry(&mut popup);
+
+        let url_row = text.lines().find(|l| l.contains(url)).unwrap();
+        // Compare the space padding between the border columns on either side
+        // of the URL (work in chars: the border glyphs are multi-byte).
+        let chars: Vec<char> = url_row.chars().collect();
+        let left_border = chars.iter().position(|&c| c == '│').unwrap();
+        let right_border = chars.iter().rposition(|&c| c == '│').unwrap();
+        let inner: String = chars[left_border + 1..right_border].iter().collect();
+        let start = inner.find(url).unwrap();
+        let left_pad = start;
+        let right_pad = inner.len() - start - url.len();
+        assert!(
+            left_pad.abs_diff(right_pad) <= 4,
+            "URL should be roughly centered (left pad {left_pad}, right pad {right_pad})"
+        );
     }
 
     #[test]

--- a/packages/nx/src/native/tui/inline_app.rs
+++ b/packages/nx/src/native/tui/inline_app.rs
@@ -115,6 +115,7 @@ impl InlineApp {
             task_graph,
             HashMap::new(), // estimated_task_timings - will be set later via set_estimated_task_timings()
             None,
+            None,
         )));
 
         Ok(Self {
@@ -1172,6 +1173,7 @@ mod tests {
             existing_graph,
             HashMap::new(),
             None,
+            None,
         )));
 
         // Create app with existing state
@@ -1617,6 +1619,7 @@ mod tests {
             task_graph,
             HashMap::new(),
             None,
+            None,
         )));
 
         let mut app = InlineApp::with_state(state.clone(), None).unwrap();
@@ -1650,6 +1653,7 @@ mod tests {
             String::from("Test"),
             task_graph,
             HashMap::new(),
+            None,
             None,
         )));
 
@@ -1804,6 +1808,7 @@ mod integration_tests {
             String::from("Shared"),
             task_graph,
             HashMap::new(),
+            None,
             None,
         )));
 

--- a/packages/nx/src/native/tui/lifecycle.rs
+++ b/packages/nx/src/native/tui/lifecycle.rs
@@ -95,6 +95,17 @@ pub enum BatchStatus {
     Failure,
 }
 
+/// Whether the workspace is connected to Nx Cloud. Computed by JS at startup
+/// and updated mid-run after a successful TUI-initiated connect. Passing no
+/// status at all (JS `undefined`) means cloud is disabled for the workspace
+/// and the TUI shows no cloud status.
+#[napi(string_enum)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CloudConnectionStatus {
+    Connected,
+    NotConnected,
+}
+
 /// A docs link rendered as an OSC 8 hyperlink. Both fields come from TS so the
 /// popup never hardcodes a URL.
 #[napi(object)]
@@ -357,6 +368,7 @@ impl AppLifeCycle {
         title_text: String,
         workspace_root: String,
         task_graph: TaskGraph,
+        cloud_connection_status: Option<CloudConnectionStatus>,
     ) -> Self {
         // Get the target names from nx_args.targets
         let rust_tui_cli_args = tui_cli_args.into();
@@ -378,6 +390,7 @@ impl AppLifeCycle {
             task_graph,
             std::collections::HashMap::new(), // estimated_task_timings - will be set later
             None,
+            cloud_connection_status,
         )));
 
         // Default to FullScreen mode for the constructor
@@ -767,6 +780,44 @@ impl AppLifeCycle {
     #[napi]
     pub fn set_cloud_link(&self, label: String, url: String) -> napi::Result<()> {
         self.with_app(|app| app.set_cloud_link(label, url));
+        Ok(())
+    }
+
+    /// Register the callback fired when the user presses the connect-to-cloud
+    /// shortcut. JS runs the `nx connect` logic and pushes the resulting URL
+    /// back via `setConnectUrl` / `setConnectError`.
+    // This method is excluded from test builds because it uses ThreadsafeFunction
+    // which requires Node.js runtime symbols.
+    #[cfg(not(test))]
+    #[napi]
+    pub fn register_connect_to_cloud_callback(
+        &self,
+        connect_callback: ThreadsafeFunction<(), Unknown<'static>, (), Status, false>,
+    ) -> napi::Result<()> {
+        self.with_app(|app| app.set_connect_to_cloud_callback(connect_callback));
+        Ok(())
+    }
+
+    /// Deliver the Nx Cloud onboarding URL to the performance-report popup.
+    #[napi]
+    pub fn set_connect_url(&self, url: String) -> napi::Result<()> {
+        self.with_app(|app| app.set_connect_url(url));
+        Ok(())
+    }
+
+    /// Surface a connect failure in the performance-report popup.
+    #[napi]
+    pub fn set_connect_error(&self, message: String) -> napi::Result<()> {
+        self.with_app(|app| app.set_connect_error(message));
+        Ok(())
+    }
+
+    /// Update the Nx Cloud connection status gating the enable-remote-cache
+    /// affordances (e.g. after a TUI-initiated connect wrote an nxCloudId to
+    /// nx.json).
+    #[napi]
+    pub fn set_cloud_connection_status(&self, status: CloudConnectionStatus) -> napi::Result<()> {
+        self.with_app(|app| app.set_cloud_connection_status(Some(status)));
         Ok(())
     }
 }

--- a/packages/nx/src/native/tui/tui_app.rs
+++ b/packages/nx/src/native/tui/tui_app.rs
@@ -12,15 +12,18 @@ use crate::native::{
 };
 
 use super::action::Action;
+use super::components::countdown_popup::CloudConnectState;
 use super::components::task_selection_manager::SelectionEntry;
 use super::components::tasks_list::TaskStatus;
-use super::lifecycle::{BatchInfo, BatchStatus, PerformanceSummaryPayload, TuiMode};
+use super::lifecycle::{
+    BatchInfo, BatchStatus, CloudConnectionStatus, PerformanceSummaryPayload, TuiMode,
+};
 use super::pty::PtyInstance;
 use super::tui;
 use super::tui_core::TuiCore;
 use super::tui_state::TuiState;
 #[cfg(not(test))]
-use super::tui_state::{DoneCallback, ForcedShutdownCallback};
+use super::tui_state::{ConnectToCloudCallback, DoneCallback, ForcedShutdownCallback};
 use super::utils::write_output_to_pty;
 use crate::native::utils::time::current_timestamp_millis;
 
@@ -399,6 +402,39 @@ pub trait TuiApp: Send {
     /// so the rendered TasksList picks the link up.
     fn set_cloud_link(&mut self, label: String, url: String) {
         self.state().lock().set_cloud_link(Some((label, url)));
+    }
+
+    /// Set the Nx Cloud connection status gating the enable-remote-cache
+    /// affordances in the report popup.
+    ///
+    /// Default implementation stores the status directly in TuiState;
+    /// mode-specific implementations also update their live popup.
+    fn set_cloud_connection_status(&mut self, status: Option<CloudConnectionStatus>) {
+        self.state().lock().set_cloud_connection_status(status);
+    }
+
+    /// Register the callback fired when the user starts the connect flow from
+    /// the report popup. Stored in TuiState so it survives mode switches.
+    #[cfg(not(test))]
+    fn set_connect_to_cloud_callback(&mut self, callback: ConnectToCloudCallback) {
+        self.state().lock().set_connect_to_cloud_callback(callback);
+    }
+
+    /// Deliver the Nx Cloud onboarding URL to the report popup.
+    ///
+    /// Default implementation persists it in TuiState so it survives mode
+    /// switches; mode-specific implementations also update their live popup.
+    fn set_connect_url(&mut self, url: String) {
+        self.state()
+            .lock()
+            .set_cloud_connect_state(CloudConnectState::Ready(url));
+    }
+
+    /// Surface a connect failure in the report popup (see `set_connect_url`).
+    fn set_connect_error(&mut self, message: String) {
+        self.state()
+            .lock()
+            .set_cloud_connect_state(CloudConnectState::Error(message));
     }
 
     /// Set the run report shown in the exit-countdown popup.

--- a/packages/nx/src/native/tui/tui_state.rs
+++ b/packages/nx/src/native/tui/tui_state.rs
@@ -13,10 +13,13 @@ use crate::native::utils::time::current_timestamp_millis;
 
 // Re-export for backward compatibility with places that use TuiState timing
 
+use super::components::countdown_popup::CloudConnectState;
 use super::components::task_selection_manager::SelectionEntry;
 use super::components::tasks_list::TaskStatus;
 use super::config::TuiConfig;
-use super::lifecycle::{BatchInfo, BatchStatus, PerformanceSummaryPayload, RunMode};
+use super::lifecycle::{
+    BatchInfo, BatchStatus, CloudConnectionStatus, PerformanceSummaryPayload, RunMode,
+};
 use super::pty::PtyInstance;
 
 // In test mode, use a stub type instead of the real NAPI ThreadsafeFunction.
@@ -26,11 +29,15 @@ use super::pty::PtyInstance;
 pub type DoneCallback = ();
 #[cfg(test)]
 pub type ForcedShutdownCallback = ();
+#[cfg(test)]
+pub type ConnectToCloudCallback = ();
 
 #[cfg(not(test))]
 pub type DoneCallback = ThreadsafeFunction<(), Unknown<'static>, (), Status, false>;
 #[cfg(not(test))]
 pub type ForcedShutdownCallback = ThreadsafeFunction<(), Unknown<'static>, (), Status, false>;
+#[cfg(not(test))]
+pub type ConnectToCloudCallback = ThreadsafeFunction<(), Unknown<'static>, (), Status, false>;
 
 /// Batch metadata stored for mode switching persistence
 #[derive(Debug, Clone)]
@@ -72,6 +79,7 @@ pub struct TuiState {
     // In test mode these are () which is zero-sized and has no Drop impl
     done_callback: Option<DoneCallback>,
     forced_shutdown_callback: Option<ForcedShutdownCallback>,
+    connect_to_cloud_callback: Option<ConnectToCloudCallback>,
 
     // === Console Messaging ===
     console_messenger: Option<NxConsoleMessageConnection>,
@@ -86,6 +94,14 @@ pub struct TuiState {
     /// Structured Nx Cloud link (display label, href URL), shown as a clickable
     /// label in place of the raw cloud message when set.
     cloud_link: Option<(String, String)>,
+    /// Nx Cloud connection status, computed by JS at startup and updated after
+    /// a TUI-initiated connect. `None` means cloud is disabled for the
+    /// workspace (NX_NO_CLOUD / neverConnectToCloud) and the connect
+    /// affordances are hidden.
+    cloud_connection_status: Option<CloudConnectionStatus>,
+    /// State of the connect attempt started from the performance-report popup
+    /// (loading/URL/error). Stored here so it survives mode switches.
+    cloud_connect_state: CloudConnectState,
 
     // === Performance Report ===
     /// Stored here (not on the per-instance popup) so it survives mode switches;
@@ -130,6 +146,7 @@ impl TuiState {
         task_graph: TaskGraph,
         estimated_task_timings: HashMap<String, i64>,
         dimensions: Option<(u16, u16)>,
+        cloud_connection_status: Option<CloudConnectionStatus>,
     ) -> Self {
         // Initialize task status map with NotStarted for all tasks
         let mut task_status_map = HashMap::new();
@@ -152,12 +169,15 @@ impl TuiState {
             title_text,
             done_callback: None,
             forced_shutdown_callback: None,
+            connect_to_cloud_callback: None,
             console_messenger: None,
             quit_at: None,
             is_forced_shutdown: false,
             user_has_interacted: false,
             cloud_message: None,
             cloud_link: None,
+            cloud_connection_status,
+            cloud_connect_state: CloudConnectState::default(),
             exit_summary: None,
             ui_pane_tasks: [None, None],
             ui_spacebar_mode: false,
@@ -366,6 +386,34 @@ impl TuiState {
         self.forced_shutdown_callback = Some(callback);
     }
 
+    /// Set the connect-to-cloud callback (fired when the user starts the
+    /// connect flow from the report popup; JS runs the `nx connect` logic and
+    /// pushes the URL back)
+    #[cfg(not(test))]
+    pub fn set_connect_to_cloud_callback(&mut self, callback: ConnectToCloudCallback) {
+        self.connect_to_cloud_callback = Some(callback);
+    }
+
+    /// Fire the connect-to-cloud callback. Returns false when JS never
+    /// registered one, so the caller can surface an error instead of hanging
+    /// in a loading state.
+    #[cfg(not(test))]
+    pub fn call_connect_to_cloud_callback(&self) -> bool {
+        if let Some(callback) = &self.connect_to_cloud_callback {
+            callback.call((), ThreadsafeFunctionCallMode::NonBlocking);
+            true
+        } else {
+            false
+        }
+    }
+
+    // In test mode pretend the callback fired so tests can exercise the
+    // loading state of the connect flow.
+    #[cfg(test)]
+    pub fn call_connect_to_cloud_callback(&self) -> bool {
+        true
+    }
+
     /// Call the done callback if it exists
     /// Can be called multiple times safely
     /// If is_forced_shutdown is true, also calls the forced_shutdown_callback first
@@ -511,6 +559,26 @@ impl TuiState {
     /// Get the structured cloud link (if any).
     pub fn get_cloud_link(&self) -> Option<&(String, String)> {
         self.cloud_link.as_ref()
+    }
+
+    /// Set the Nx Cloud connection status.
+    pub fn set_cloud_connection_status(&mut self, status: Option<CloudConnectionStatus>) {
+        self.cloud_connection_status = status;
+    }
+
+    /// Get the Nx Cloud connection status (None = cloud disabled).
+    pub fn get_cloud_connection_status(&self) -> Option<CloudConnectionStatus> {
+        self.cloud_connection_status
+    }
+
+    /// Set the connect-attempt state (loading/URL/error).
+    pub fn set_cloud_connect_state(&mut self, state: CloudConnectState) {
+        self.cloud_connect_state = state;
+    }
+
+    /// Get the connect-attempt state for mode-switch rehydration.
+    pub fn get_cloud_connect_state(&self) -> CloudConnectState {
+        self.cloud_connect_state.clone()
     }
 
     // === UI State Methods (for mode switching persistence) ===
@@ -681,6 +749,7 @@ mod tests {
             String::from("Test"),
             task_graph,
             HashMap::new(),
+            None,
             None,
         )
     }
@@ -1029,6 +1098,7 @@ mod integration_tests {
             String::from("Test"),
             task_graph,
             HashMap::new(),
+            None,
             None,
         )
     }

--- a/packages/nx/src/nx-cloud/generators/connect-to-nx-cloud/connect-to-nx-cloud.ts
+++ b/packages/nx/src/nx-cloud/generators/connect-to-nx-cloud/connect-to-nx-cloud.ts
@@ -200,7 +200,8 @@ export async function connectToNxCloud(
     !schema.generateToken &&
     isGitHubDetected &&
     (schema.installationSource === 'nx-connect' ||
-      schema.installationSource === 'nx-console')
+      schema.installationSource === 'nx-console' ||
+      schema.installationSource === 'nx-tui')
   )
     return null;
 

--- a/packages/nx/src/tasks-runner/life-cycles/performance-life-cycle.spec.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/performance-life-cycle.spec.ts
@@ -711,7 +711,7 @@ describe('cache reporting', () => {
     expect(s.remoteCacheEnabled).toBe(false);
     const report = formatReport(s);
     // No-TTY jest env → no hyperlinks → the tagged URL prints verbatim.
-    expect(report).toContain('sharing a cache across your team and CI');
+    expect(report).toContain('sharing it with your team and CI');
     expect(report).toContain(
       'https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache'
     );
@@ -734,7 +734,7 @@ describe('cache reporting', () => {
       // the hidden target — never a raw URL. Sequence: ESC]8;; <target> BEL <phrase>.
       const OSC8 = ']8;;';
       expect(report).toContain(
-        `${OSC8}https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cacheDrastically reduce your run duration by sharing a cache across your team and CI`
+        `${OSC8}https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cacheEnable remote cache to reduce your run duration by sharing it with your team and CI`
       );
       // The URL must never appear as plain visible text: every occurrence is
       // immediately preceded by the OSC 8 target preamble.
@@ -841,7 +841,7 @@ describe('exit summary payload (TUI countdown)', () => {
       // links the text it was handed without a byte-identical constant of its own.
       expect(payload.links).toEqual([
         {
-          text: 'Drastically reduce your run duration by sharing a cache across your team and CI',
+          text: 'Enable remote cache to reduce your run duration by sharing it with your team and CI',
           href: 'https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache',
         },
       ]);
@@ -992,7 +992,7 @@ describe('formatReport', () => {
 
     if (cores >= 2) {
       const parallelAt = report.indexOf('Increase parallelism');
-      const cacheAt = report.indexOf('Drastically reduce');
+      const cacheAt = report.indexOf('Enable remote cache');
       expect(parallelAt).toBeGreaterThanOrEqual(0);
       expect(cacheAt).toBeGreaterThan(parallelAt);
     }
@@ -1040,9 +1040,11 @@ describe('formatReport', () => {
     );
 
     expect(report).toContain('Recommendations:');
-    expect(report).toContain('- Drastically reduce your run duration');
+    expect(report).toContain(
+      '- Enable remote cache to reduce your run duration'
+    );
     expect(report).toMatch(/- Speed up or split/);
-    const cacheAt = report.indexOf('Drastically reduce');
+    const cacheAt = report.indexOf('Enable remote cache');
     const distributeAt = report.indexOf('Distribute across machines');
     const speedUpAt = report.indexOf('Speed up or split');
     expect(cacheAt).toBeGreaterThanOrEqual(0);
@@ -1086,7 +1088,7 @@ describe('formatReport', () => {
           Recoverable time:  800ms (40% of the run)
 
           Recommendations:
-            - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache.
+            - Enable remote cache to reduce your run duration by sharing it with your team and CI → https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache.
             - Distribute across machines with Nx Agents → https://nx.dev/ci/features/distribute-task-execution?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=nx-agents.
             - Speed up or split the longest tasks on the critical path:
                 np    1.2s"
@@ -1181,7 +1183,7 @@ describe('formatReportMarkdown', () => {
 
       ### Recommendations
 
-      - [Drastically reduce your run duration by sharing a cache across your team and CI](https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache).
+      - [Enable remote cache to reduce your run duration by sharing it with your team and CI](https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache).
       - Speed up or split the longest tasks on the critical path:<br>a    3.0s"
     `);
   });
@@ -1227,7 +1229,7 @@ describe('formatReportMarkdown', () => {
     })!;
 
     expect(formatReportMarkdown(s, '')).toContain(
-      '[Drastically reduce your run duration by sharing a cache across your team and CI](https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache)'
+      '[Enable remote cache to reduce your run duration by sharing it with your team and CI](https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache)'
     );
   });
 });

--- a/packages/nx/src/tasks-runner/life-cycles/performance-report.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/performance-report.ts
@@ -18,7 +18,7 @@ const NX_REMOTE_CACHE_LINK = `${NX_REMOTE_CACHE_URL}${utm('remote-cache')}`;
  * copy of this string; it gets the phrase + href from the exit payload's `links`.
  */
 const NX_REMOTE_CACHE_CTA =
-  'Drastically reduce your run duration by sharing a cache across your team and CI';
+  'Enable remote cache to reduce your run duration by sharing it with your team and CI';
 const NX_DISTRIBUTE_CTA = 'Distribute across machines with Nx Agents';
 
 /**

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -17,7 +17,7 @@ import {
   getTaskDetails,
   hashTasksThatDoNotDependOnOutputsOfOtherTasks,
 } from '../hasher/hash-task';
-import { hashArray, logDebug, RunMode } from '../native';
+import { CloudConnectionStatus, hashArray, logDebug, RunMode } from '../native';
 import {
   runPostTasksExecution,
   runPreTasksExecution,
@@ -238,6 +238,14 @@ async function getTerminalOutputLifeCycle(
       });
     }
 
+    // undefined = cloud is disabled for this workspace (NX_NO_CLOUD /
+    // neverConnectToCloud): the TUI shows no cloud status at all.
+    const cloudConnectionStatus = isNxCloudDisabled(nxJson)
+      ? undefined
+      : isNxCloudUsed(nxJson)
+        ? CloudConnectionStatus.Connected
+        : CloudConnectionStatus.NotConnected;
+
     const lifeCycles: LifeCycle[] = [tsLifeCycle];
     // Only run the TUI if there are tasks to run
     if (tasks.length > 0) {
@@ -250,11 +258,45 @@ async function getTerminalOutputLifeCycle(
         nxJson.tui ?? {},
         titleText,
         workspaceRoot,
-        taskGraph
+        taskGraph,
+        cloudConnectionStatus
       );
       // The native endCommand renders the perf report in the exit popup; the runner
       // sources the payload and CompositeLifeCycle forwards it here.
       lifeCycles.unshift(appLifeCycle as unknown as LifeCycle);
+
+      if (cloudConnectionStatus === CloudConnectionStatus.NotConnected) {
+        // Pressing the connect shortcut in the TUI fires this callback: run the
+        // same logic as `nx connect` headlessly and push the onboarding URL
+        // back into the TUI's connect popup. Memoized so reopening the popup
+        // can't kick off a second workspace creation; reset on failure so the
+        // user can retry.
+        let tuiConnectPromise: Promise<void> | undefined;
+        appLifeCycle.registerConnectToCloudCallback(() => {
+          tuiConnectPromise ??= (async () => {
+            try {
+              const { connectToNxCloudFromTui } = await import(
+                '../command-line/nx-cloud/connect/connect-to-nx-cloud.js'
+              );
+              const url = await connectToNxCloudFromTui();
+              appLifeCycle.setConnectUrl(url);
+              // The manual flow writes an nxCloudId to nx.json immediately; the
+              // GitHub flow completes in the browser. Only flip the footer
+              // status once nx.json actually reflects a connection.
+              if (isNxCloudUsed(readNxJson())) {
+                appLifeCycle.setCloudConnectionStatus(
+                  CloudConnectionStatus.Connected
+                );
+              }
+            } catch (e) {
+              tuiConnectPromise = undefined;
+              appLifeCycle.setConnectError(
+                e instanceof Error ? e.message : String(e)
+              );
+            }
+          })();
+        });
+      }
 
       /**
        * Patch stdout.write and stderr.write methods to pass Nx Cloud client logs to the TUI via the lifecycle


### PR DESCRIPTION
## Current Behavior

The performance report's remote-cache recommendation links to docs only. Connecting requires quitting and running `nx connect`.

## Expected Behavior

When the workspace is not connected to Nx Cloud, the report shows an inline "[ Enable remote cache ]" button after the remote-cache recommendation and an "Enable remote cache: <shift>+c" footer hint. Activating either runs the same logic as `nx connect` headlessly and prints the short onboarding URL centered at the bottom of the popup. Connected workspaces show neither affordance.

<img width="1392" height="929" alt="Screenshot 2026-07-07 at 12 55 27 PM" src="https://github.com/user-attachments/assets/a15779ad-bd31-4f79-93f9-16ea2b439df6" />

<img width="1392" height="929" alt="Screenshot 2026-07-07 at 12 55 31 PM" src="https://github.com/user-attachments/assets/c97a983f-caf6-4c02-b1ac-8d422feb774d" />


## Related Issue(s)

NXC-4606

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/nxc-4606-e6f49ee0)
<!-- polygraph-session-end -->