### PR TITLE
fix(core): merge default plugins through the source-map-aware merge path

### DIFF
--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -71,8 +71,10 @@ export type TargetDefaultEntry = {
 export type TargetDefaultFilter = {
   /**
    * Restrict the default to targets originated by a specific plugin
-   * (e.g. `@nx/vite`). Matches against the plugin that wrote the target's
-   * `executor` or `command`.
+   * (e.g. `@nx/vite`). Matches against the plugin from nx.json's `plugins`
+   * that wrote the target's `executor` or `command`. Targets whose
+   * executor/command comes from `project.json` or `package.json` have no
+   * source plugin and never match.
    */
   plugin?: string;
   /**

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
@@ -256,19 +256,21 @@ describe('project-configuration-utils', () => {
       ]);
     });
 
-    // Regression: default-plugin batches merge into an intermediate
-    // rootmap, not the manager's main rootmap, so filtering substitutor
-    // registration to roots the manager already knows about used to drop
-    // every default-plugin project's own dependsOn/inputs. Any
-    // cross-project reference those arrays introduced therefore never
-    // received a sentinel and stayed stale through applySubstitutions.
+    // Regression: name-reference sentinels must be registered for
+    // default-plugin batches just like specified ones. Sentinel
+    // registration is scoped to roots the manager's rootMap already
+    // knows about, and default-plugin batches used to merge somewhere
+    // else first — so every default-plugin project's own dependsOn/inputs
+    // was dropped, and any cross-project reference those arrays
+    // introduced never received a sentinel and stayed stale through
+    // applySubstitutions.
     //
     // This test drives that gap by having a default plugin rename a
     // specified-plugin project (libs/b 'b-old' → 'b-new') while a
     // separate default-plugin project.json owns a dependsOn referencing
     // the *old* name. Without sentinel registration on the default
     // batch, the final dependsOn would still say 'b-old:build'.
-    it('should resolve dependsOn refs owned by default plugins when the referenced project is renamed during the default apply', () => {
+    it('should resolve dependsOn refs owned by default plugins when another default plugin renames the referenced project', () => {
       const specifiedResults: CreateNodesResultEntry[][] = [
         [
           [
@@ -338,7 +340,7 @@ describe('project-configuration-utils', () => {
     // processInputs and processDependsOn share the createRef plumbing,
     // but the substitution sweep walks each array separately. Locks in
     // that default-plugin inputs references get sentinel treatment too.
-    it('should resolve inputs refs owned by default plugins when the referenced project is renamed during the default apply', () => {
+    it('should resolve inputs refs owned by default plugins when another default plugin renames the referenced project', () => {
       const specifiedResults: CreateNodesResultEntry[][] = [
         [
           [

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
@@ -187,6 +187,75 @@ describe('project-configuration-utils', () => {
       expect(sm['targets.processResources.executor']).toEqual(GRADLE);
     });
 
+    // Regression: when targetDefaults are present, the default layer is
+    // staged into a throwaway rootMap before its real merge. The rootMap
+    // merge adopts and grows metadata arrays in place on the objects it is
+    // handed, so staging must not hand it the plugin results themselves —
+    // otherwise the first plugin's result object accumulates the second
+    // plugin's metadata during staging, and the real merge then reads the
+    // corrupted results and duplicates every entry.
+    it('should not mutate default-plugin results when staging them for target-default synthesis', () => {
+      const packageJsonResults: CreateNodesResultEntry[] = [
+        [
+          'nx/core/package-json',
+          'libs/a/package.json',
+          {
+            projects: {
+              'libs/a': {
+                name: 'a',
+                root: 'libs/a',
+                metadata: { targetGroups: { Custom: ['echo'] } },
+                targets: {
+                  echo: {
+                    executor: 'nx:run-script',
+                    options: { script: 'echo' },
+                    metadata: { technologies: ['npm'] },
+                  },
+                },
+              },
+            },
+          },
+        ],
+      ];
+      const projectJsonResults: CreateNodesResultEntry[] = [
+        [
+          'nx/core/project-json',
+          'libs/a/project.json',
+          {
+            projects: {
+              'libs/a': {
+                name: 'a',
+                root: 'libs/a',
+                metadata: { targetGroups: { Custom: ['lint'] } },
+                targets: {
+                  echo: { metadata: { technologies: ['custom'] } },
+                },
+              },
+            },
+          },
+        ],
+      ];
+
+      const errors: MergeError[] = [];
+      const result = mergeCreateNodesResults(
+        [],
+        [packageJsonResults, projectJsonResults],
+        { targetDefaults: { build: { cache: true } } },
+        '/tmp/test',
+        errors
+      );
+
+      expect(errors).toEqual([]);
+      const project = result.projectRootMap['libs/a'];
+      expect(project.metadata!.targetGroups).toEqual({
+        Custom: ['echo', 'lint'],
+      });
+      expect(project.targets!.echo.metadata!.technologies).toEqual([
+        'npm',
+        'custom',
+      ]);
+    });
+
     // Regression: default-plugin batches merge into an intermediate
     // rootmap, not the manager's main rootmap, so filtering substitutor
     // registration to roots the manager already knows about used to drop

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
@@ -93,6 +93,100 @@ describe('project-configuration-utils', () => {
       `);
     });
 
+    // Regression: a specified plugin (e.g. @nx/gradle) infers a target with a
+    // dependsOn, and project.json (a default plugin) overrides that dependsOn
+    // outright. The default value wins, so its attribution must win too — the
+    // stale specified-plugin source used to survive at the overlapping array
+    // positions when default-plugin attribution was reconciled after the fact
+    // instead of written by the merge itself. The target node + executor stay
+    // attributed to the plugin that created the target, since project.json
+    // changed no identity prop — it only layered the dependsOn onto it.
+    it('should attribute a project.json-overridden dependsOn to project.json, not the specified plugin that inferred the target', () => {
+      const specifiedResults: CreateNodesResultEntry[][] = [
+        [
+          [
+            '@nx/gradle',
+            'apps/nx-api/build.gradle.kts',
+            {
+              projects: {
+                'apps/nx-api': {
+                  name: 'nx-api',
+                  root: 'apps/nx-api',
+                  targets: {
+                    processResources: {
+                      executor: '@nx/gradle:gradle',
+                      dependsOn: ['nx-api:classes'],
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        ],
+      ];
+
+      const defaultResults: CreateNodesResultEntry[][] = [
+        [
+          [
+            'nx/core/project-json',
+            'apps/nx-api/project.json',
+            {
+              projects: {
+                'apps/nx-api': {
+                  name: 'nx-api',
+                  root: 'apps/nx-api',
+                  targets: {
+                    processResources: {
+                      dependsOn: [
+                        'nx-packages-client-bundle:bundle',
+                        'polygraph-bundle:bundle',
+                      ],
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        ],
+      ];
+
+      const errors: MergeError[] = [];
+      const result = mergeCreateNodesResults(
+        specifiedResults,
+        defaultResults,
+        {},
+        '/tmp/test',
+        errors
+      );
+
+      const target =
+        result.projectRootMap['apps/nx-api'].targets!.processResources;
+      // Sanity: project.json's dependsOn replaced the inferred one.
+      expect(target.dependsOn).toEqual([
+        'nx-packages-client-bundle:bundle',
+        'polygraph-bundle:bundle',
+      ]);
+
+      const PROJECT_JSON: SourceInformation = [
+        'apps/nx-api/project.json',
+        'nx/core/project-json',
+      ];
+      const GRADLE: SourceInformation = [
+        'apps/nx-api/build.gradle.kts',
+        '@nx/gradle',
+      ];
+      const sm = result.configurationSourceMaps['apps/nx-api'];
+      // dependsOn — every position, plus the field-level entry — is now
+      // project.json, not the gradle plugin.
+      expect(sm['targets.processResources.dependsOn']).toEqual(PROJECT_JSON);
+      expect(sm['targets.processResources.dependsOn.0']).toEqual(PROJECT_JSON);
+      expect(sm['targets.processResources.dependsOn.1']).toEqual(PROJECT_JSON);
+      // The target node and executor still belong to the plugin that created
+      // the target.
+      expect(sm['targets.processResources']).toEqual(GRADLE);
+      expect(sm['targets.processResources.executor']).toEqual(GRADLE);
+    });
+
     // Regression: default-plugin batches merge into an intermediate
     // rootmap, not the manager's main rootmap, so filtering substitutor
     // registration to roots the manager already knows about used to drop
@@ -244,14 +338,12 @@ describe('project-configuration-utils', () => {
       ]);
     });
 
-    // Forward reference from one default-plugin batch to another:
-    // intermediate merges don't touch the manager's nameMap, so a
-    // default-plugin reference to a project that won't be created
-    // until a later default batch starts life as a usage (forward)
-    // ref. The intermediate apply loop later fires
-    // identifyProjectWithRoot for the new project; that promotion has
-    // to reach the earlier batch's pending sentinel or the final
-    // configuration will still hold a leftover NameRef object.
+    // Forward reference from one default-plugin batch to another: a
+    // default-plugin reference to a project that won't be created until a
+    // later default batch starts life as a usage (forward) ref. Merging the
+    // later batch fires identifyProjectWithRoot for the new project; that
+    // promotion has to reach the earlier batch's pending sentinel or the
+    // final configuration will still hold a leftover NameRef object.
     it('should promote forward refs introduced by one default plugin to a project created by another default plugin', () => {
       const defaultResults: CreateNodesResultEntry[][] = [
         [
@@ -311,17 +403,15 @@ describe('project-configuration-utils', () => {
       expect(typeof (aTargets.test.dependsOn as unknown[])[0]).toBe('string');
     });
 
-    // Rebinding-after-spread regression: when a specified plugin seeds
-    // a dependsOn array and a default plugin contributes a spread
-    // (`['...', ...]`), the intermediate apply runs merge logic on the
-    // owner and rebuilds the array. Sentinels inserted against the
-    // specified-plugin merge now live in an array that's been
-    // discarded — the follow-up
-    //   nodesManager.registerNameRefs(intermediateDefaultRootMap)
-    // call after the intermediate apply rebinds them to the merged
-    // array. Without it, the later rename would leave an unresolved
-    // sentinel in the first slot (the one originating from specified).
-    it('should rebind sentinels inserted by specified plugins when the intermediate apply spread-merges their array', () => {
+    // Rebinding-after-spread regression: when a specified plugin seeds a
+    // dependsOn array and a default plugin contributes a spread
+    // (`['...', ...]`), the default merge rebuilds the array. Sentinels
+    // inserted during the specified-plugin merge now live in an array that's
+    // been discarded — the default batch's own name-ref registration walks
+    // the merged config and rebinds each sentinel's parent to the new array.
+    // Without it, the later rename would leave an unresolved sentinel in the
+    // first slot (the one originating from specified).
+    it('should rebind sentinels inserted by specified plugins when a default plugin spread-merges their array', () => {
       const specifiedResults: CreateNodesResultEntry[][] = [
         [
           [
@@ -1432,14 +1522,10 @@ describe('project-configuration-utils', () => {
       expect(errors).toEqual([]);
     });
 
-    // Regression guard for the `defaultConfigurationSourceMaps` overlay
-    // in project-configuration-utils.ts: when a default plugin target
-    // lists keys before `...`, those keys yield to the specified-plugin
-    // base during the final apply, but the intermediate merge already
-    // wrote their attribution into `defaultConfigurationSourceMaps`.
-    // The overlay uses "only fill missing" semantics so that stale
-    // default-plugin entries can't clobber the correct specified-plugin
-    // attribution already recorded in `configurationSourceMaps`.
+    // When a default plugin target lists keys before `...`, those keys yield
+    // to the specified-plugin base during the merge. The spread-aware merge
+    // must leave the base's attribution untouched for them — only keys the
+    // default layer actually wins get reattributed.
     it('should attribute target-level keys that yield to base via `...` to the base source, not the default plugin', () => {
       const specifiedResults: CreateNodesResultEntry[][] = [
         [
@@ -1500,10 +1586,6 @@ describe('project-configuration-utils', () => {
       // Sanity: `cache` before `...` means base (specified) wins.
       expect(build.cache).toEqual(false);
 
-      // But the overlay misattributes `cache` to the default plugin
-      // because the intermediate merge wrote it into
-      // defaultConfigurationSourceMaps before the final apply
-      // decided base won.
       const sm = result.configurationSourceMaps['libs/a'];
       expect(sm['targets.build.cache']).toEqual([
         'libs/a/tool.config.ts',

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -263,14 +263,13 @@ type MergeFn = (
  * Runs a single plugin batch through two passes:
  *
  * 1. Every project node in every plugin result is handed to `mergeFn`,
- *    which decides where it lands (the manager's rootMap, an
- *    intermediate rootMap, etc.). Any failure is collected into
- *    `errors`; processing keeps going. External nodes are accumulated
- *    onto the shared `externalNodes` record.
+ *    which merges it into the manager's rootMap. Any failure is
+ *    collected into `errors`; processing keeps going. External nodes
+ *    are accumulated onto the shared `externalNodes` record.
  * 2. After every project in the batch has been merged, name-reference
- *    sentinels for the batch are registered against `nameRefRootMap` —
- *    the rootMap the batch was merged into — so sentinels point at the
- *    target objects that actually received the merges.
+ *    sentinels for the batch are registered against the manager's
+ *    rootMap, so sentinels point at the target objects that actually
+ *    received the merges.
  *
  * The two passes can't be collapsed: a sentinel registered too early
  * would point at the pre-merge object, and a later project in the same
@@ -282,17 +281,11 @@ function mergeCreateNodesResultsFromSinglePlugin(
   pluginResults: CreateNodesResultEntry[],
   mergeFn: MergeFn,
   nodesManager: ProjectNodesManager,
-  nameRefRootMap: Record<string, ProjectConfiguration>,
   externalNodes: Record<string, ProjectGraphExternalNode>,
   errors: MergeError[]
 ): void {
   mergeSinglePluginResults(pluginResults, mergeFn, externalNodes, errors);
-  registerNameRefsFromSinglePlugin(
-    pluginResults,
-    nodesManager,
-    nameRefRootMap,
-    errors
-  );
+  registerNameRefsFromSinglePlugin(pluginResults, nodesManager, errors);
 }
 
 function mergeSinglePluginResults(
@@ -327,7 +320,6 @@ function mergeSinglePluginResults(
 function registerNameRefsFromSinglePlugin(
   pluginResults: CreateNodesResultEntry[],
   nodesManager: ProjectNodesManager,
-  nameRefRootMap: Record<string, ProjectConfiguration>,
   errors: MergeError[]
 ): void {
   for (const result of pluginResults) {
@@ -335,7 +327,7 @@ function registerNameRefsFromSinglePlugin(
     const { projects: projectNodes } = nodes;
 
     try {
-      nodesManager.registerNameRefs(projectNodes, nameRefRootMap);
+      nodesManager.registerNameRefs(projectNodes);
     } catch (error) {
       errors.push(
         new MergeNodesError({ file, pluginName, error, pluginIndex })
@@ -385,7 +377,6 @@ export function mergeCreateNodesResults(
       pluginResults,
       mergeToManager,
       nodesManager,
-      nodesManager.getRootMap(),
       externalNodes,
       errors
     );
@@ -449,7 +440,6 @@ export function mergeCreateNodesResults(
         targetDefaultsResults,
         mergeToManager,
         nodesManager,
-        nodesManager.getRootMap(),
         externalNodes,
         errors
       );
@@ -469,7 +459,6 @@ export function mergeCreateNodesResults(
       pluginResults,
       mergeToManager,
       nodesManager,
-      nodesManager.getRootMap(),
       externalNodes,
       errors
     );

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -412,11 +412,16 @@ export function mergeCreateNodesResults(
     // Stage the default layer for synthesis. Merge errors are discarded and
     // external nodes land in a scratch object — the same results merge into
     // the manager below, where both surface once with proper plugin context.
-    // The discard is safe because every merge throw depends only on the
-    // plugin's own config, never on the merge base (which differs between
-    // the two passes).
-    // Name references are NOT registered here: sentinels registered against
-    // the throwaway rootMap would mutate the plugin results and be orphaned.
+    // The discard is safe because every merge throw is base-independent in
+    // both its condition and its reachability: each throw's condition reads
+    // only the plugin's own config, and the spread-ambiguity throws fire even
+    // when a key is dropped by a base-owns-key shortcut, because those
+    // shortcuts eagerly validate the dropped value (`assertNoIntegerLikeSpreadKey`).
+    // So a given config raises the same error in this pass and the real merge
+    // below despite their bases differing.
+    // Name references are NOT registered here: `applySubstitutions` sweeps only
+    // the manager's `rootMap`, so sentinels registered against this throwaway
+    // rootMap would never be visited and would never resolve.
     const stagingErrors: MergeError[] = [];
     const stagingExternalNodes: Record<string, ProjectGraphExternalNode> = {};
     for (const pluginResults of defaultResults) {

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -421,6 +421,9 @@ export function mergeCreateNodesResults(
     // Stage the default layer for synthesis. Merge errors are discarded and
     // external nodes land in a scratch object — the same results merge into
     // the manager below, where both surface once with proper plugin context.
+    // The discard is safe because every merge throw depends only on the
+    // plugin's own config, never on the merge base (which differs between
+    // the two passes).
     // Name references are NOT registered here: sentinels registered against
     // the throwaway rootMap would mutate the plugin results and be orphaned.
     const stagingErrors: MergeError[] = [];

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -39,6 +39,7 @@ import type {
 import { createTargetDefaultsResults } from './project-configuration/target-defaults';
 
 export { mergeTargetConfigurations } from './project-configuration/target-merging';
+import { deepClone } from './project-configuration/target-merging';
 export { readTargetDefaultsForTarget } from './project-configuration/target-defaults';
 
 export type ConfigurationResult = {
@@ -402,10 +403,14 @@ export function mergeCreateNodesResults(
     // `filter.plugin`); the real default merge writes the manager's.
     const intermediateDefaultRootMap: Record<string, ProjectConfiguration> = {};
 
+    // The rootMap merge adopts input arrays/objects by reference and grows
+    // them in place (e.g. `mergeMetadata`), so staging works on deep clones —
+    // handing it the plugin results themselves would corrupt them before the
+    // real merge below reads them.
     const mergeToIntermediate: MergeFn = (project, sourceInfo) => {
       mergeProjectConfigurationIntoRootMap(
         intermediateDefaultRootMap,
-        project,
+        deepClone(project),
         undefined,
         sourceInfo,
         false,

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -35,10 +35,6 @@ import type {
   ConfigurationSourceMaps,
   SourceInformation,
 } from './project-configuration/source-maps';
-import {
-  targetSourceMapKey,
-  TARGET_DEFAULTS_PLUGIN_NAME,
-} from './project-configuration/source-maps';
 
 import { createTargetDefaultsResults } from './project-configuration/target-defaults';
 
@@ -289,6 +285,21 @@ function mergeCreateNodesResultsFromSinglePlugin(
   externalNodes: Record<string, ProjectGraphExternalNode>,
   errors: MergeError[]
 ): void {
+  mergeSinglePluginResults(pluginResults, mergeFn, externalNodes, errors);
+  registerNameRefsFromSinglePlugin(
+    pluginResults,
+    nodesManager,
+    nameRefRootMap,
+    errors
+  );
+}
+
+function mergeSinglePluginResults(
+  pluginResults: CreateNodesResultEntry[],
+  mergeFn: MergeFn,
+  externalNodes: Record<string, ProjectGraphExternalNode>,
+  errors: MergeError[]
+): void {
   for (const result of pluginResults) {
     const [pluginName, file, nodes, pluginIndex] = result;
     const { projects: projectNodes, externalNodes: pluginExternalNodes } =
@@ -310,7 +321,14 @@ function mergeCreateNodesResultsFromSinglePlugin(
 
     Object.assign(externalNodes, pluginExternalNodes);
   }
+}
 
+function registerNameRefsFromSinglePlugin(
+  pluginResults: CreateNodesResultEntry[],
+  nodesManager: ProjectNodesManager,
+  nameRefRootMap: Record<string, ProjectConfiguration>,
+  errors: MergeError[]
+): void {
   for (const result of pluginResults) {
     const [pluginName, file, nodes, pluginIndex] = result;
     const { projects: projectNodes } = nodes;
@@ -328,19 +346,22 @@ function mergeCreateNodesResultsFromSinglePlugin(
 /**
  * Merges create nodes results into a single rootMap.
  *
- * Specified plugin results are merged once into the manager. Default
- * plugin results are first staged into an intermediate rootMap (with
- * `'...'` spreads deferred) so that synthesis can read each layer's
- * contribution without re-running the merge. The synthetic result from
- * `createTargetDefaultsResults` is then merged into the manager, and
- * the staged intermediate is replayed on top — that replay is where
- * deferred spreads expand against the final (specified + synth) base.
+ * Every layer merges into the manager through the same source-map-aware
+ * merge, in precedence order:
  *
- * Synthesis itself doesn't materialize a second rootMap. Per
- * (root, target) it does an on-the-fly merge of the two layered
- * contributions to learn the eventual executor/command, then matches
- * defaults against that merged shape. This keeps specified-plugin
- * merge work to a single pass.
+ *   specified plugins → synthetic target defaults → default plugins
+ *
+ * so field-level provenance is decided by the merge itself for all three
+ * layers — whichever layer a field's final value came from owns its
+ * attribution, and `'...'` spreads in default-plugin configs resolve against
+ * the accumulated specified + target-defaults base.
+ *
+ * Target-default synthesis needs the *merged* shape of the default layer
+ * (to predict each target's eventual executor/command) before that layer
+ * merges into the manager. To get it, default results are first staged into
+ * a throwaway intermediate rootMap with unresolvable `'...'` spreads
+ * deferred. The staging output feeds only `createTargetDefaultsResults`; the
+ * default plugins then merge into the manager from their original results.
  */
 export function mergeCreateNodesResults(
   specifiedResults: CreateNodesResultEntry[][],
@@ -354,22 +375,9 @@ export function mergeCreateNodesResults(
   const nodesManager = new ProjectNodesManager();
   const externalNodes: Record<string, ProjectGraphExternalNode> = {};
   const configurationSourceMaps: ConfigurationSourceMaps = {};
-  const intermediateDefaultRootMap: Record<string, ProjectConfiguration> = {};
-  // Kept separate so the intermediate merge doesn't clobber
-  // specified/TD attribution on fields the defaults don't touch.
-  const defaultConfigurationSourceMaps: ConfigurationSourceMaps = {};
 
   const mergeToManager: MergeFn = (project, sourceInfo) =>
     nodesManager.mergeProjectNode(project, configurationSourceMaps, sourceInfo);
-
-  const mergeToIntermediate: MergeFn = (project, sourceInfo) => {
-    mergeProjectConfigurationIntoRootMap(
-      intermediateDefaultRootMap,
-      project,
-      defaultConfigurationSourceMaps,
-      sourceInfo
-    );
-  };
 
   for (const pluginResults of specifiedResults) {
     mergeCreateNodesResultsFromSinglePlugin(
@@ -382,107 +390,81 @@ export function mergeCreateNodesResults(
     );
   }
 
+  // Without target defaults there is nothing to synthesize, and the staging
+  // pass exists only to feed synthesis — skip straight to the default-plugin
+  // merge.
+  if (Object.keys(nxJsonConfiguration.targetDefaults ?? {}).length > 0) {
+    // Throwaway staging area: the default layer's merged shape (unresolvable
+    // `'...'` spreads deferred), read only by target-default synthesis. The
+    // default plugins merge into the manager from their original results, not
+    // from this map. No source maps are kept for it — synthesis attributes
+    // targets without them (a default plugin can never be named by a
+    // `filter.plugin`); the real default merge writes the manager's.
+    const intermediateDefaultRootMap: Record<string, ProjectConfiguration> = {};
+
+    const mergeToIntermediate: MergeFn = (project, sourceInfo) => {
+      mergeProjectConfigurationIntoRootMap(
+        intermediateDefaultRootMap,
+        project,
+        undefined,
+        sourceInfo,
+        false,
+        true
+      );
+    };
+
+    // Stage the default layer for synthesis. Merge errors are discarded and
+    // external nodes land in a scratch object — the same results merge into
+    // the manager below, where both surface once with proper plugin context.
+    // Name references are NOT registered here: sentinels registered against
+    // the throwaway rootMap would mutate the plugin results and be orphaned.
+    const stagingErrors: MergeError[] = [];
+    const stagingExternalNodes: Record<string, ProjectGraphExternalNode> = {};
+    for (const pluginResults of defaultResults) {
+      mergeSinglePluginResults(
+        pluginResults,
+        mergeToIntermediate,
+        stagingExternalNodes,
+        stagingErrors
+      );
+    }
+
+    const targetDefaultsResults = createTargetDefaultsResults(
+      nodesManager.getRootMap(),
+      intermediateDefaultRootMap,
+      nxJsonConfiguration,
+      configurationSourceMaps
+    );
+
+    if (targetDefaultsResults.length > 0) {
+      mergeCreateNodesResultsFromSinglePlugin(
+        targetDefaultsResults,
+        mergeToManager,
+        nodesManager,
+        nodesManager.getRootMap(),
+        externalNodes,
+        errors
+      );
+    }
+  }
+
+  // Merge the default plugins into the manager on top of the specified + TD
+  // base, from their original results. This is the same source-map-aware path
+  // the other layers take, so every field a default plugin wins — including
+  // fields it overrides on a specified/TD target — is attributed to it by the
+  // merge itself, `'...'` spreads resolve against the real base (keys a spread
+  // lets the base win keep their base attribution), and identity provenance
+  // follows the node-ownership rules in `recordTargetIdentitySourceMapInfo` /
+  // `getMergeValueResult`.
   for (const pluginResults of defaultResults) {
     mergeCreateNodesResultsFromSinglePlugin(
       pluginResults,
-      mergeToIntermediate,
-      nodesManager,
-      intermediateDefaultRootMap,
-      externalNodes,
-      errors
-    );
-  }
-
-  const targetDefaultsResults = createTargetDefaultsResults(
-    nodesManager.getRootMap(),
-    intermediateDefaultRootMap,
-    nxJsonConfiguration,
-    configurationSourceMaps,
-    defaultConfigurationSourceMaps
-  );
-
-  if (targetDefaultsResults.length > 0) {
-    mergeCreateNodesResultsFromSinglePlugin(
-      targetDefaultsResults,
       mergeToManager,
       nodesManager,
       nodesManager.getRootMap(),
       externalNodes,
       errors
     );
-  }
-
-  // Apply the intermediate default rootMap as a single layer. Preserved
-  // spread sentinels resolve here against the real specified + TD base.
-  // Source maps are intentionally not written — TD attribution for
-  // fields that yield to the base (e.g. keys before `...`) stays intact.
-  for (const root in intermediateDefaultRootMap) {
-    const project = intermediateDefaultRootMap[root];
-    try {
-      nodesManager.mergeProjectNode(project, undefined, undefined);
-    } catch (error) {
-      errors.push(
-        new MergeNodesError({
-          file: 'nx.json',
-          pluginName: 'nx/default-plugins',
-          error,
-          pluginIndex: undefined,
-        })
-      );
-    }
-  }
-
-  // The intermediate apply may have rebuilt dependsOn / inputs arrays via
-  // spread merges, introducing name-ref strings that weren't visible in any
-  // single plugin result. Re-walking the final merged targets sentinelizes
-  // them so the final substitution sweep resolves them too.
-  nodesManager.registerNameRefs(intermediateDefaultRootMap);
-
-  // Overlay default-plugin attribution onto the main source maps using
-  // "only fill missing" semantics. Any key already present in
-  // configurationSourceMaps was written by a specified plugin or by
-  // target defaults, and that attribution is strictly more correct:
-  //  - For fields the default plugin never shadowed, the existing entry
-  //    already matches what the default plugin would overlay.
-  //  - For fields where a default plugin placed `...` after other keys,
-  //    those keys yielded to the base during the single-layer apply
-  //    above. The stale default-plugin entry in
-  //    `defaultConfigurationSourceMaps` must NOT clobber the base
-  //    attribution that the specified plugin / TD already recorded.
-  const mainRootMap = nodesManager.getRootMap();
-  for (const root in defaultConfigurationSourceMaps) {
-    const existing = (configurationSourceMaps[root] ??= {});
-    const incoming = defaultConfigurationSourceMaps[root];
-
-    // A default plugin's targets are synthesized into the main rootmap by
-    // target defaults *before* the default layer is applied, so target
-    // defaults wrote the main source map's entry for the target node and its
-    // identity fields first — even though it never authored them (it only
-    // stamps them as a merge guard and cannot bring a target into existence).
-    // The identity fields are the executor/command plus, for run-commands, the
-    // `options.command`/`options.commands` the synthetic copies from the winner
-    // to stay compatible (#36067). For those keys, the real default plugin's
-    // attribution must override the target-defaults stamp.
-    const identityKeys = new Set<string>();
-    for (const targetName in mainRootMap[root]?.targets ?? {}) {
-      const base = targetSourceMapKey(targetName);
-      identityKeys.add(base);
-      identityKeys.add(`${base}.executor`);
-      identityKeys.add(`${base}.command`);
-      identityKeys.add(`${base}.options.command`);
-      identityKeys.add(`${base}.options.commands`);
-    }
-
-    for (const key in incoming) {
-      if (existing[key] === undefined) {
-        existing[key] = incoming[key];
-      } else if (
-        identityKeys.has(key) &&
-        existing[key][1] === TARGET_DEFAULTS_PLUGIN_NAME
-      ) {
-        existing[key] = incoming[key];
-      }
-    }
   }
 
   const projectRootMap = nodesManager.getRootMap();

--- a/packages/nx/src/project-graph/utils/project-configuration/name-substitution-manager.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/name-substitution-manager.spec.ts
@@ -2234,4 +2234,37 @@ describe('ProjectNameInNodePropsManager', () => {
       expect(templateDependsOn[0]).toBe('project-b:build');
     });
   });
+
+  describe('refs registered after a rename (name history)', () => {
+    // Refs register after a whole batch merges, so a reference to `b-old`
+    // can be registered when the same batch already renamed the project to
+    // `b-new`. The name history maps the stale name back to its root so the
+    // ref binds and resolves to the current name.
+    it('should bind a ref to a stale name via the name history and resolve it to the current name', () => {
+      const manager = createManager();
+
+      const projectB = createProject('b-old', 'libs/b', {
+        targets: { build: {} },
+      });
+      identifyProjects(manager, createPluginResult([projectB]));
+
+      // The rename lands before project A's refs are registered.
+      renameProject(manager, 'libs/b', 'b-new');
+
+      const projectA = createProject('project-a', 'libs/a', {
+        targets: { test: { dependsOn: ['b-old:build'] } },
+      });
+      identifyProjects(manager, createPluginResult([projectA]));
+      manager.registerNameRefs(createPluginResult([projectA]));
+
+      const rootMap = createRootMap([
+        { name: 'project-a', root: 'libs/a', targets: projectA.targets },
+        { name: 'b-new', root: 'libs/b', targets: projectB.targets },
+      ]);
+
+      manager.applySubstitutions(rootMap);
+
+      expect(projectA.targets.test.dependsOn).toEqual(['b-new:build']);
+    });
+  });
 });

--- a/packages/nx/src/project-graph/utils/project-configuration/name-substitution-manager.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/name-substitution-manager.ts
@@ -56,6 +56,9 @@ export function isUsageRef(value: unknown): value is UsageRef {
 export class ProjectNameInNodePropsManager {
   private getNameMap: () => Record<string, ProjectConfiguration>;
   private pendingByName = new Map<string, Set<RootRef | UsageRef>>();
+  // name → root for every name a project has ever been identified by, so refs
+  // to a since-renamed name still bind to the right root (see createRef).
+  private nameHistory = new Map<string, string>();
 
   constructor(getNameMap?: () => Record<string, ProjectConfiguration>) {
     this.getNameMap = getNameMap ?? (() => ({}));
@@ -170,12 +173,18 @@ export class ProjectNameInNodePropsManager {
     }
   }
 
-  // Builds a sentinel and registers it.
+  // Builds a sentinel and registers it. When `referencedName` isn't in the
+  // current name map, fall back to the rename history: a batch may reference a
+  // project by a name that a project earlier in the same batch already renamed
+  // (refs register after the whole batch merges), and the old name still
+  // identifies the same root.
   private createRef(
     referencedName: string,
     targetPart?: string
   ): RootRef | UsageRef {
-    const referencedRoot = this.getNameMap()[referencedName]?.root;
+    const referencedRoot =
+      this.getNameMap()[referencedName]?.root ??
+      this.nameHistory.get(referencedName);
     const ref: RootRef | UsageRef =
       referencedRoot !== undefined
         ? new RootRef(referencedRoot, targetPart)
@@ -197,6 +206,12 @@ export class ProjectNameInNodePropsManager {
   // RootRef by prototype swap. Sentinel identity across spread copies means
   // one promotion updates every array the sentinel reached.
   identifyProjectWithRoot(root: string, name: string): void {
+    // Every name a root has ever gone by, including pre-rename names. A later
+    // ref to a stale name resolves to the root it identified at the time.
+    // (If two roots use the same name over a graph construction, the later
+    // one wins — matching how the live name map would have resolved it.)
+    this.nameHistory.set(name, root);
+
     const pending = this.pendingByName.get(name);
     if (!pending) return;
     this.pendingByName.delete(name);
@@ -236,6 +251,7 @@ export class ProjectNameInNodePropsManager {
     }
 
     this.pendingByName.clear();
+    this.nameHistory.clear();
   }
 
   private substituteInArray(

--- a/packages/nx/src/project-graph/utils/project-configuration/project-nodes-manager.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/project-nodes-manager.spec.ts
@@ -849,7 +849,10 @@ describe('mergeProjectConfigurationIntoRootMap', () => {
       assertCorrectKeysInSourceMap(
         sourceMap,
         'libs/lib-a',
-        ['targets.build', 'dummy2'],
+        // Ownership of the target node follows its identity: dummy2 only
+        // layered fields onto the target (no executor/command change), so
+        // the node stays with dummy, which created it.
+        ['targets.build', 'dummy'],
         ['targets.build.executor', 'dummy'],
         ['targets.build.inputs', 'dummy2'],
         ['targets.build.outputs', 'dummy2'],

--- a/packages/nx/src/project-graph/utils/project-configuration/project-nodes-manager.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/project-nodes-manager.ts
@@ -176,10 +176,10 @@ export function mergeProjectConfigurationIntoRootMap(
       const target = project.targets?.[targetName];
 
       if (sourceMap) {
-        // A target default stamping fields onto an existing target must not
-        // steal provenance for the target's existence; real plugins still win
-        // last. Field-level attribution is handled inside
-        // `mergeTargetConfigurations`.
+        // Claims the node key for a newly-created target (or reclaims it from
+        // a weak target-defaults stamp). Whether an *existing* target changes
+        // owners is decided inside `mergeTargetConfigurations`, which knows
+        // whether this merge changed the target's identity.
         recordTargetIdentitySourceMapInfo(
           sourceMap,
           targetSourceMapKey(targetName),

--- a/packages/nx/src/project-graph/utils/project-configuration/project-nodes-manager.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/project-nodes-manager.ts
@@ -355,26 +355,22 @@ export class ProjectNodesManager {
 
   /**
    * Inserts project-name sentinels into `inputs` and `dependsOn` on the
-   * merged objects from `mergedRootMap` (defaulting to this manager's
-   * rootMap). Walking the merged entries matters because a spread-produced
-   * array is a fresh instance.
-   *
-   * Pass a different `mergedRootMap` for the default-plugin intermediate
-   * pass, then call again with `this.rootMap` after it's applied so
-   * name refs introduced by that merge are sentinelized as well.
+   * merged objects in this manager's rootMap. Walking the merged entries —
+   * not the plugin results — matters because a spread-produced array is a
+   * fresh instance, and because sentinels written into plugin-result arrays
+   * would corrupt them for any later merge that re-reads the results.
    */
   registerNameRefs(
     pluginResultProjects?: Record<
       string,
       Omit<ProjectConfiguration, 'root'> & Partial<ProjectConfiguration>
-    >,
-    mergedRootMap: Record<string, ProjectConfiguration> = this.rootMap
+    >
   ): void {
     if (!pluginResultProjects) return;
     const scoped: Record<string, ProjectConfiguration> = {};
     for (const root in pluginResultProjects) {
-      if (mergedRootMap[root]) {
-        scoped[root] = mergedRootMap[root];
+      if (this.rootMap[root]) {
+        scoped[root] = this.rootMap[root];
       }
     }
     this.nameSubstitutionManager.registerNameRefs(scoped);

--- a/packages/nx/src/project-graph/utils/project-configuration/source-maps.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/source-maps.ts
@@ -14,20 +14,33 @@ export type SourceInformation = [file: string | null, plugin: string];
 export const TARGET_DEFAULTS_PLUGIN_NAME = 'nx/target-defaults';
 
 /**
- * Write the source for a target's "identity" key (the target node itself, or
- * its executor/command). Real plugins win last; a target-defaults stamp only
- * claims the key when no real plugin already recorded it — target defaults
- * never bring a target into existence, they only layer fields onto one.
+ * Write the source for the target node key (`targets.<name>`). Ownership of a
+ * target follows its identity, not the last writer:
+ *
+ *  - An unowned key goes to whoever writes it first (the creator).
+ *  - A target-defaults stamp is weak — it never authors a target's existence,
+ *    so any real plugin reclaims the key from it, and it can never take the
+ *    key from a real plugin.
+ *  - Between real plugins, the key only changes hands when the merge changed
+ *    the target's identity (executor/command) — a plugin that merely layers
+ *    fields (dependsOn, options, …) onto an existing target does not become
+ *    its owner.
  */
 export function recordTargetIdentitySourceMapInfo(
   sourceMap: Record<string, SourceInformation>,
   key: string,
-  sourceInfo: SourceInformation
+  sourceInfo: SourceInformation,
+  identityChanged = false
 ): void {
-  if (
-    sourceInfo[1] !== TARGET_DEFAULTS_PLUGIN_NAME ||
-    sourceMap[key] === undefined
-  ) {
+  const existing = sourceMap[key];
+  if (existing === undefined) {
+    sourceMap[key] = sourceInfo;
+    return;
+  }
+  if (sourceInfo[1] === TARGET_DEFAULTS_PLUGIN_NAME) {
+    return;
+  }
+  if (existing[1] === TARGET_DEFAULTS_PLUGIN_NAME || identityChanged) {
     sourceMap[key] = sourceInfo;
   }
 }

--- a/packages/nx/src/project-graph/utils/project-configuration/target-defaults.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-defaults.spec.ts
@@ -239,13 +239,13 @@ describe('createTargetDefaultsResults (plugin filter)', () => {
   // than injecting `sourcePlugin` directly, so it would catch a regression in
   // the source-map key the matcher reads the source plugin from.
   it('applies a plugin-filtered default when the target is attributed to that plugin', () => {
-    const defaultRootMap = {
+    const specifiedRootMap = {
       'apps/app': {
         root: 'apps/app',
         targets: { build: { executor: '@nx/vite:build', options: {} } },
       },
     };
-    const defaultSourceMaps = {
+    const specifiedSourceMaps = {
       'apps/app': {
         'targets.build.executor': ['vite.config.ts', '@nx/vite/plugin'] as [
           string,
@@ -263,11 +263,10 @@ describe('createTargetDefaultsResults (plugin filter)', () => {
     };
 
     const results = createTargetDefaultsResults(
+      specifiedRootMap,
       {},
-      defaultRootMap,
       nxJson as any,
-      undefined,
-      defaultSourceMaps
+      specifiedSourceMaps
     );
 
     const synthetic = results[0]?.[2]?.projects?.['apps/app']?.targets?.build;
@@ -275,13 +274,13 @@ describe('createTargetDefaultsResults (plugin filter)', () => {
   });
 
   it('does not apply a plugin-filtered default when the plugin does not match', () => {
-    const defaultRootMap = {
+    const specifiedRootMap = {
       'apps/app': {
         root: 'apps/app',
         targets: { build: { executor: '@nx/vite:build', options: {} } },
       },
     };
-    const defaultSourceMaps = {
+    const specifiedSourceMaps = {
       'apps/app': {
         'targets.build.executor': ['vite.config.ts', '@nx/vite/plugin'] as [
           string,
@@ -298,11 +297,80 @@ describe('createTargetDefaultsResults (plugin filter)', () => {
     };
 
     const results = createTargetDefaultsResults(
+      specifiedRootMap,
+      {},
+      nxJson as any,
+      specifiedSourceMaps
+    );
+
+    expect(results).toEqual([]);
+  });
+
+  it('does not match a plugin filter for a target the default layer created', () => {
+    // project.json authored the target. Default plugins are not specified in
+    // nx.json, so no `filter.plugin` can name one — the target has no
+    // matchable source plugin.
+    const defaultRootMap = {
+      'apps/app': {
+        root: 'apps/app',
+        targets: { build: { executor: '@nx/vite:build', options: {} } },
+      },
+    };
+    const nxJson = {
+      targetDefaults: {
+        build: [
+          { filter: { plugin: '@nx/vite/plugin' }, options: { foo: 'bar' } },
+        ],
+      },
+    };
+
+    const results = createTargetDefaultsResults(
       {},
       defaultRootMap,
       nxJson as any,
-      undefined,
-      defaultSourceMaps
+      undefined
+    );
+
+    expect(results).toEqual([]);
+  });
+
+  it('stops matching a plugin filter when the default layer overrides the executor', () => {
+    // The vite plugin inferred the target, but project.json replaces its
+    // executor — the identity now belongs to the default layer, so the vite
+    // filter no longer applies.
+    const specifiedRootMap = {
+      'apps/app': {
+        root: 'apps/app',
+        targets: { build: { executor: '@nx/vite:build', options: {} } },
+      },
+    };
+    const specifiedSourceMaps = {
+      'apps/app': {
+        'targets.build.executor': ['vite.config.ts', '@nx/vite/plugin'] as [
+          string,
+          string,
+        ],
+      },
+    };
+    const defaultRootMap = {
+      'apps/app': {
+        root: 'apps/app',
+        targets: { build: { executor: '@nx/js:tsc' } },
+      },
+    };
+    const nxJson = {
+      targetDefaults: {
+        build: [
+          { filter: { plugin: '@nx/vite/plugin' }, options: { foo: 'bar' } },
+        ],
+      },
+    };
+
+    const results = createTargetDefaultsResults(
+      specifiedRootMap,
+      defaultRootMap,
+      nxJson as any,
+      specifiedSourceMaps
     );
 
     expect(results).toEqual([]);
@@ -353,13 +421,13 @@ describe('createTargetDefaultsResults (source attribution)', () => {
   });
 
   it('emits one result per matching array element with an indexed file', () => {
-    const defaultRootMap = {
+    const specifiedRootMap = {
       'apps/app': {
         root: 'apps/app',
         targets: { build: { executor: '@nx/vite:build', options: {} } },
       },
     };
-    const defaultSourceMaps = {
+    const specifiedSourceMaps = {
       'apps/app': {
         'targets.build.executor': ['vite.config.ts', '@nx/vite/plugin'] as [
           string,
@@ -377,11 +445,10 @@ describe('createTargetDefaultsResults (source attribution)', () => {
     };
 
     const results = createTargetDefaultsResults(
+      specifiedRootMap,
       {},
-      defaultRootMap,
       nxJson as any,
-      undefined,
-      defaultSourceMaps
+      specifiedSourceMaps
     );
 
     // Both the catch-all (index 0) and the matching plugin-filtered entry

--- a/packages/nx/src/project-graph/utils/project-configuration/target-defaults.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-defaults.ts
@@ -20,7 +20,6 @@ import {
 import { isGlobPattern } from '../../../utils/globs';
 import type { CreateNodesResult } from '../../plugins/public-api';
 import {
-  SourceInformation,
   ConfigurationSourceMaps,
   targetSourceMapKey,
   TARGET_DEFAULTS_PLUGIN_NAME,
@@ -54,8 +53,7 @@ export function createTargetDefaultsResults(
   specifiedPluginRootMap: Record<string, ProjectConfiguration>,
   defaultPluginRootMap: Record<string, ProjectConfiguration>,
   nxJsonConfiguration: NxJsonConfiguration,
-  specifiedSourceMaps?: ConfigurationSourceMaps,
-  defaultSourceMaps?: ConfigurationSourceMaps
+  specifiedSourceMaps?: ConfigurationSourceMaps
 ): CreateNodesResultEntry[] {
   const targetDefaultsConfig = nxJsonConfiguration.targetDefaults;
   if (!targetDefaultsConfig) {
@@ -126,8 +124,8 @@ export function createTargetDefaultsResults(
         ? resolveSourcePlugin(
             root,
             targetName,
-            specifiedSourceMaps,
-            defaultSourceMaps
+            defaultTargets[targetName],
+            specifiedSourceMaps
           )
         : undefined;
 
@@ -563,41 +561,38 @@ function normalizeTargetDefaultValue(
 function resolveSourcePlugin(
   root: string,
   targetName: string,
-  specifiedSourceMaps: ConfigurationSourceMaps | undefined,
-  defaultSourceMaps: ConfigurationSourceMaps | undefined
+  defaultTarget: TargetConfiguration | undefined,
+  specifiedSourceMaps: ConfigurationSourceMaps | undefined
 ): string | undefined {
-  // Default-plugin attribution overrides specified-plugin attribution in the
-  // merge, so check it first. The executor/command keys carry the plugin that
-  // *created* the target, which is what `filter.plugin` ("targets originated by
-  // X") means. The top-level `targets.<name>` node key is deliberately NOT used
-  // as a fallback: it tracks the last writer, so a later plugin augmenting the
-  // target would mis-attribute it. The trade-off is that a target with neither
-  // an executor nor a command (a rare, non-runnable shape) resolves to no
-  // source plugin and won't match a `filter.plugin` default — accepted, since
-  // every runnable target carries one of these keys.
-  const executorKey = `${targetSourceMapKey(targetName)}.executor`;
-  const commandKey = `${targetSourceMapKey(targetName)}.command`;
-  const candidates: (string | undefined)[] = [
-    pluginFromSourceMap(defaultSourceMaps, root, executorKey),
-    pluginFromSourceMap(defaultSourceMaps, root, commandKey),
-    pluginFromSourceMap(specifiedSourceMaps, root, executorKey),
-    pluginFromSourceMap(specifiedSourceMaps, root, commandKey),
-  ];
+  // `filter.plugin` ("targets originated by X") can only name a plugin from
+  // nx.json's `plugins` — the specified set. When the default layer authors
+  // the target's identity (its merged config carries an executor or command,
+  // which the merge lets win), the originator is a default plugin and the
+  // target has no matchable source plugin; no source maps are needed to see
+  // that. Otherwise the specified layer's executor/command attribution names
+  // the originator. The top-level `targets.<name>` node key is deliberately
+  // NOT used as a fallback: it tracks ownership, so a later plugin augmenting
+  // the target would mis-attribute it. The trade-off is that a target with
+  // neither an executor nor a command (a rare, non-runnable shape) resolves to
+  // no source plugin and won't match a `filter.plugin` default — accepted,
+  // since every runnable target carries one of these keys.
+  if (
+    defaultTarget &&
+    (defaultTarget.executor !== undefined ||
+      defaultTarget.command !== undefined)
+  ) {
+    return undefined;
+  }
 
-  for (const candidate of candidates) {
-    if (candidate && candidate !== TARGET_DEFAULTS_PLUGIN_NAME)
-      return candidate;
+  const sourceMap = specifiedSourceMaps?.[root];
+  for (const identityKey of ['executor', 'command']) {
+    const plugin =
+      sourceMap?.[`${targetSourceMapKey(targetName)}.${identityKey}`]?.[1];
+    if (plugin && plugin !== TARGET_DEFAULTS_PLUGIN_NAME) {
+      return plugin;
+    }
   }
   return undefined;
-}
-
-function pluginFromSourceMap(
-  maps: ConfigurationSourceMaps | undefined,
-  root: string,
-  key: string
-): string | undefined {
-  const entry = maps?.[root]?.[key] as SourceInformation | undefined;
-  return entry?.[1];
 }
 
 // Builds a name → MatcherProjectNode view for `findMatchingProjects` to

--- a/packages/nx/src/project-graph/utils/project-configuration/target-merging.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-merging.spec.ts
@@ -711,11 +711,12 @@ describe('spread syntax in mergeTargetConfigurations', () => {
       ]);
     });
 
-    it('lets a real plugin claim the target node key last (target defaults aside)', () => {
+    it('keeps the target node key with its creator when a second plugin only layers fields', () => {
       const sourceMap: Record<string, SourceInformation> = {
         'targets.build': ['a.config.ts', 'plugin-a'],
       };
-      // A second real plugin augments the same target — real plugins win last.
+      // plugin-b re-states the same executor and adds `cache` — no identity
+      // change, so plugin-a still owns the target.
       mergeTargetConfigurations(
         { executor: 'nx:run-commands', cache: true },
         { executor: 'nx:run-commands' },
@@ -724,7 +725,30 @@ describe('spread syntax in mergeTargetConfigurations', () => {
         'targets.build'
       );
 
+      expect(sourceMap['targets.build']).toEqual(['a.config.ts', 'plugin-a']);
+    });
+
+    it('transfers the target node key when a plugin changes the target identity', () => {
+      const sourceMap: Record<string, SourceInformation> = {
+        'targets.build': ['a.config.ts', 'plugin-a'],
+        'targets.build.cache': ['a.config.ts', 'plugin-a'],
+      };
+      // plugin-b sets an executor on a target that had none — an identity
+      // change, so ownership of the node moves with it.
+      mergeTargetConfigurations(
+        { executor: '@acme/b:build' },
+        { cache: true },
+        sourceMap,
+        ['b.config.ts', 'plugin-b'],
+        'targets.build'
+      );
+
       expect(sourceMap['targets.build']).toEqual(['b.config.ts', 'plugin-b']);
+      // Fields it didn't touch keep their origin.
+      expect(sourceMap['targets.build.cache']).toEqual([
+        'a.config.ts',
+        'plugin-a',
+      ]);
     });
   });
 

--- a/packages/nx/src/project-graph/utils/project-configuration/target-merging.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-merging.spec.ts
@@ -821,6 +821,73 @@ describe('spread syntax in mergeTargetConfigurations', () => {
     ).toThrow(/integer-like key/i);
   });
 
+  // A nested `'...'` spread object with an integer-like key is ambiguous
+  // regardless of which side of the merge owns the key it lives under. When a
+  // pre-`'...'` key is owned by the base, the merge lets the base win and drops
+  // the incoming value without merging it — but the ambiguity is a property of
+  // the authored value, so it must still throw. Otherwise the error would fire
+  // in the target-defaults staging merge (default-only base) but vanish in the
+  // real merge (full base), silently dropping the invalid object.
+  describe('nested integer-like spread under a pre-"..." key', () => {
+    const nestedInvalid = {
+      '...': true,
+      '123': 'ambiguous',
+    };
+
+    it('throws when the base does NOT own the enclosing key', () => {
+      expect(() =>
+        mergeTargetConfigurations(
+          {
+            executor: 'nx:run-commands',
+            metadataThing: nestedInvalid,
+            '...': true,
+          } as any,
+          {
+            executor: 'nx:run-commands',
+            inputs: ['production'],
+          }
+        )
+      ).toThrow(/integer-like key/i);
+    });
+
+    it('throws even when the base OWNS the enclosing key (base-independent)', () => {
+      expect(() =>
+        mergeTargetConfigurations(
+          {
+            executor: 'nx:run-commands',
+            metadataThing: nestedInvalid,
+            '...': true,
+          } as any,
+          {
+            executor: 'nx:run-commands',
+            metadataThing: { existing: 'base-value' },
+            inputs: ['production'],
+          }
+        )
+      ).toThrow(/integer-like key/i);
+    });
+
+    it('throws for a named configuration the base OWNS (base-independent)', () => {
+      expect(() =>
+        mergeTargetConfigurations(
+          {
+            executor: 'nx:run-commands',
+            configurations: {
+              prod: nestedInvalid,
+              '...': true,
+            },
+          } as any,
+          {
+            executor: 'nx:run-commands',
+            configurations: {
+              prod: { existing: 'base-value' },
+            },
+          }
+        )
+      ).toThrow(/integer-like key/i);
+    });
+  });
+
   it('should replace array without spread token', () => {
     const result = mergeTargetConfigurations(
       {

--- a/packages/nx/src/project-graph/utils/project-configuration/target-merging.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-merging.spec.ts
@@ -750,6 +750,56 @@ describe('spread syntax in mergeTargetConfigurations', () => {
         'plugin-a',
       ]);
     });
+
+    it('transfers the target node key when a plugin supplies the command a run-commands target was missing', () => {
+      const sourceMap: Record<string, SourceInformation> = {
+        'targets.build': ['a.config.ts', 'plugin-a'],
+      };
+      // plugin-a created `build` as a bare nx:run-commands target with no
+      // command; plugin-b supplies `options.command` — the runnable identity
+      // for run-commands (see isCompatibleTarget) — so ownership moves, just
+      // like setting an executor on a target that had none.
+      mergeTargetConfigurations(
+        { options: { command: 'vite build' } },
+        { executor: 'nx:run-commands' },
+        sourceMap,
+        ['b.config.ts', 'plugin-b'],
+        'targets.build'
+      );
+
+      expect(sourceMap['targets.build']).toEqual(['b.config.ts', 'plugin-b']);
+    });
+
+    it('transfers the target node key when a plugin supplies the script a run-script target was missing', () => {
+      const sourceMap: Record<string, SourceInformation> = {
+        'targets.test': ['a.config.ts', 'plugin-a'],
+      };
+      mergeTargetConfigurations(
+        { options: { script: 'test' } },
+        { executor: 'nx:run-script' },
+        sourceMap,
+        ['b.config.ts', 'plugin-b'],
+        'targets.test'
+      );
+
+      expect(sourceMap['targets.test']).toEqual(['b.config.ts', 'plugin-b']);
+    });
+
+    it('keeps the target node key with its creator when a second plugin re-states the same command', () => {
+      const sourceMap: Record<string, SourceInformation> = {
+        'targets.build': ['a.config.ts', 'plugin-a'],
+      };
+      // Same runnable identity, just layered fields — no transfer.
+      mergeTargetConfigurations(
+        { options: { command: 'vite build' }, cache: true },
+        { executor: 'nx:run-commands', options: { command: 'vite build' } },
+        sourceMap,
+        ['b.config.ts', 'plugin-b'],
+        'targets.build'
+      );
+
+      expect(sourceMap['targets.build']).toEqual(['a.config.ts', 'plugin-a']);
+    });
   });
 
   it('should replace array without spread token', () => {

--- a/packages/nx/src/project-graph/utils/project-configuration/target-merging.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-merging.spec.ts
@@ -802,6 +802,25 @@ describe('spread syntax in mergeTargetConfigurations', () => {
     });
   });
 
+  // The integer-key/spread ambiguity is a property of the authored config
+  // (key hoisting loses the position), not of the merge base — so it must
+  // throw whether or not the base target is compatible. This also keeps the
+  // error identical between the target-defaults staging merge (default-only
+  // base) and the real merge (full base), so discarding staging errors can't
+  // lose it.
+  it('should throw for an integer-like key alongside a spread even when the base target is incompatible', () => {
+    expect(() =>
+      mergeTargetConfigurations(
+        {
+          executor: '@acme/b:build',
+          '123': 'ambiguous',
+          '...': true,
+        } as any,
+        { executor: '@acme/a:build' }
+      )
+    ).toThrow(/integer-like key/i);
+  });
+
   it('should replace array without spread token', () => {
     const result = mergeTargetConfigurations(
       {

--- a/packages/nx/src/project-graph/utils/project-configuration/target-merging.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-merging.ts
@@ -12,6 +12,7 @@ import {
 
 import type { SourceInformation } from './source-maps';
 import {
+  assertNoIntegerLikeSpreadKey,
   getMergeValueResult,
   INTEGER_LIKE_KEY_PATTERN,
   IntegerLikeSpreadKeyError,
@@ -277,6 +278,14 @@ function mergeConfigurations<T extends Object>(
       // Before '...': base wins for shared names. Keep base's source-map
       // entries when it owns the config.
       if (baseHasConfig) {
+        // Base wins, so the incoming config is dropped without reaching
+        // `mergeConfigurationValue`. Validate its nested spread here so an
+        // integer-like-key ambiguity throws regardless of which side owns
+        // the config name (mirrors the base-independent target-level check).
+        assertNoIntegerLikeSpreadKey(
+          newConfigurations?.[configName],
+          configIdentifier ? `Object at "${configIdentifier}"` : 'Object'
+        );
         mergedConfigurations[configName] = baseConfigurations[configName];
       } else {
         mergedConfigurations[configName] = mergeConfigurationValue(
@@ -454,6 +463,16 @@ export function mergeTargetConfigurations(
 
     if (hasSpread && keysBeforeSpread.has(key)) {
       // Before '...': base wins; fall through to target only if base lacks it.
+      // When base wins, the incoming `target[key]` is dropped without ever
+      // reaching `getMergeValueResult`, so validate its nested spread here —
+      // the integer-like-key ambiguity is a property of the authored value,
+      // not of which side owns the key, and must throw either way.
+      assertNoIntegerLikeSpreadKey(
+        target[key],
+        projectConfigSourceMap
+          ? `Object at "${targetIdentifier}.${key}"`
+          : 'Object'
+      );
       result[key] =
         key in mergeBase
           ? mergeBase[key]

--- a/packages/nx/src/project-graph/utils/project-configuration/target-merging.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-merging.ts
@@ -534,16 +534,23 @@ export function mergeTargetConfigurations(
     }
   }
 
-  // Update source map once after loop. Real plugins win last, but a target
-  // default — which only stamps fields onto an existing target and never
-  // authors its existence — must not steal the node key from the plugin that
-  // introduced the target. An incompatible replace clears these keys above, so
-  // a replacing real plugin still re-owns the node.
+  // Update the node key once after the loop. Ownership follows identity: this
+  // merge claims `targets.<name>` only when it changed the target's identity
+  // (a new/different executor or command, or an incompatible replace — whose
+  // key purge above empties the slot anyway). A plugin that only layers fields
+  // onto an existing target leaves the node with its creator; weak
+  // target-defaults stamps are always reclaimable.
   if (projectConfigSourceMap) {
+    const identityChanged =
+      !isCompatible ||
+      (target.executor !== undefined &&
+        target.executor !== baseTarget?.executor) ||
+      (target.command !== undefined && target.command !== baseTarget?.command);
     recordTargetIdentitySourceMapInfo(
       projectConfigSourceMap,
       targetIdentifier,
-      sourceInformation
+      sourceInformation,
+      identityChanged
     );
   }
 

--- a/packages/nx/src/project-graph/utils/project-configuration/target-merging.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-merging.ts
@@ -420,9 +420,12 @@ export function mergeTargetConfigurations(
     : new Set<string>();
 
   // Integer-like keys get hoisted to targetKeys[0], making their position
-  // relative to '...' unrecoverable.
+  // relative to '...' unrecoverable. This is a property of the authored
+  // config, not of the base, so it throws regardless of compatibility —
+  // which also keeps the error identical between the target-defaults staging
+  // merge and the real merge, whose bases differ.
   if (
-    hasSpread &&
+    spreadPosInTarget >= 0 &&
     targetKeys[0] &&
     INTEGER_LIKE_KEY_PATTERN.test(targetKeys[0])
   ) {

--- a/packages/nx/src/project-graph/utils/project-configuration/target-merging.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-merging.ts
@@ -545,7 +545,9 @@ export function mergeTargetConfigurations(
       !isCompatible ||
       (target.executor !== undefined &&
         target.executor !== baseTarget?.executor) ||
-      (target.command !== undefined && target.command !== baseTarget?.command);
+      (target.command !== undefined &&
+        target.command !== baseTarget?.command) ||
+      suppliesNewOptionsIdentity(baseTarget, target);
     recordTargetIdentitySourceMapInfo(
       projectConfigSourceMap,
       targetIdentifier,
@@ -640,6 +642,32 @@ export function isCompatibleTarget(
   }
 
   return true;
+}
+
+/**
+ * Run-commands and run-script targets carry their runnable identity in
+ * `options` (see {@link isCompatibleTarget}). A layer that supplies that
+ * identity where the base had none changed what the target runs — the same
+ * identity change as setting an executor on a target that had none.
+ */
+function suppliesNewOptionsIdentity(
+  baseTarget: TargetConfiguration | undefined,
+  target: TargetConfiguration
+): boolean {
+  const executor = target.executor ?? baseTarget?.executor;
+  if (executor === 'nx:run-commands') {
+    const baseCommand =
+      baseTarget?.options?.command ??
+      baseTarget?.options?.commands?.join(' && ');
+    const targetCommand =
+      target.options?.command ?? target.options?.commands?.join(' && ');
+    return !!targetCommand && targetCommand !== baseCommand;
+  }
+  if (executor === 'nx:run-script') {
+    const targetScript = target.options?.script;
+    return !!targetScript && targetScript !== baseTarget?.options?.script;
+  }
+  return false;
 }
 
 export function resolveNxTokensInOptions<T extends Object | Array<unknown>>(

--- a/packages/nx/src/project-graph/utils/project-configuration/utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/utils.ts
@@ -1,6 +1,7 @@
 import {
   readArrayItemSourceInfo,
   readObjectPropertySourceInfo,
+  TARGET_DEFAULTS_PLUGIN_NAME,
   type SourceInformation,
 } from './source-maps';
 
@@ -85,10 +86,31 @@ export function getMergeValueResult<T>(
   // plugin already set, purely as a merge guard — must not steal provenance
   // from the layer that introduced the value. A genuinely new value (no base,
   // or a different one) still attributes to the new layer.
-  if (!isUnchangedPrimitive(newValue, baseValue)) {
+  //
+  // The exception cuts the other way too: when the *existing* attribution is a
+  // target-defaults stamp (TD merges before the plugin whose value it
+  // predicted, so its stamp lands first), a real plugin re-stating that value
+  // is the genuine author and reclaims the key.
+  if (
+    !isUnchangedPrimitive(newValue, baseValue) ||
+    isReclaimableTargetDefaultsStamp(sourceMapContext)
+  ) {
     writeTopLevelSourceMap(sourceMapContext);
   }
   return newValue;
+}
+
+// Whether the key's current attribution is a weak target-defaults stamp that
+// the (non-target-defaults) writer should reclaim despite the value being
+// unchanged.
+function isReclaimableTargetDefaultsStamp(
+  ctx: SourceMapContext | undefined
+): boolean {
+  return (
+    !!ctx &&
+    ctx.sourceMap[ctx.key]?.[1] === TARGET_DEFAULTS_PLUGIN_NAME &&
+    ctx.sourceInformation[1] !== TARGET_DEFAULTS_PLUGIN_NAME
+  );
 }
 
 // Whether `newValue` leaves a defined primitive base untouched. Objects fall

--- a/packages/nx/src/project-graph/utils/project-configuration/utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/utils.ts
@@ -40,6 +40,33 @@ export class IntegerLikeSpreadKeyError extends Error {
   }
 }
 
+/**
+ * Throws `IntegerLikeSpreadKeyError` when `value` is a `'...'` spread object
+ * whose enumeration hoists an integer-like key ahead of the spread, making its
+ * authored position ambiguous.
+ *
+ * The ambiguity is a property of the authored value alone, not of any merge
+ * base. `mergeObjectWithSpread` runs this the moment it merges such a value —
+ * but a merge layer that lets the base win a key drops the incoming value
+ * without merging it, so the check must also be run eagerly at those
+ * base-owns-key shortcuts. Otherwise the error would surface or vanish
+ * depending on which side owns the key (e.g. it fires in the target-defaults
+ * staging merge but not the real merge), which is exactly the divergence that
+ * makes discarding staging errors unsafe.
+ */
+export function assertNoIntegerLikeSpreadKey(
+  value: unknown,
+  errorContext: string
+): void {
+  if (!isObject(value) || value[NX_SPREAD_TOKEN] !== true) {
+    return;
+  }
+  const keys = Object.keys(value);
+  if (keys[0] && INTEGER_LIKE_KEY_PATTERN.test(keys[0])) {
+    throw new IntegerLikeSpreadKeyError(keys[0], errorContext);
+  }
+}
+
 type SourceMapContext = {
   sourceMap: Record<string, SourceInformation>;
   key: string;
@@ -208,13 +235,11 @@ function mergeObjectWithSpread(
     ? `Object at "${sourceMapContext.key}"`
     : 'Object';
 
-  const newKeys = Object.keys(newValue);
+  // Integer-like keys are hoisted to the front of enumeration, so one
+  // alongside `'...'` makes its authored position ambiguous.
+  assertNoIntegerLikeSpreadKey(newValue, errorContext);
 
-  // Integer-like keys are hoisted to the front of enumeration, so if one
-  // exists alongside `'...'` it must be newKeys[0].
-  if (newKeys[0] && INTEGER_LIKE_KEY_PATTERN.test(newKeys[0])) {
-    throw new IntegerLikeSpreadKeyError(newKeys[0], errorContext);
-  }
+  const newKeys = Object.keys(newValue);
 
   // Base per-key sources captured lazily — only for shared keys the new
   // object overwrites before `'...'`, since writing their new source


### PR DESCRIPTION
## Current Behavior

Fields that a default plugin (`project.json`, `package.json`) overrides on a target inferred by a specified plugin keep the inferring plugin's source-map attribution. Default-plugin results are applied to the merged rootMap without source maps, and their attribution is grafted on afterwards with only-fill-missing semantics — so any key the specified plugin already wrote keeps its stale entry even when the default plugin replaced the value.

Real-world repro (nrwl/ocean): `nx show target :nx-api:gradle:processResources --verbose` shows the `dependsOn` entries authored in `apps/nx-api/project.json` as `(from apps/nx-api/build.gradle.kts by @nx/gradle)`.

## Expected Behavior

Every field is attributed to the layer that actually authored its final value. Default plugins now merge into the manager through the same source-map-aware merge as specified plugins and synthetic target defaults, so the merge itself decides provenance for all three layers and the overlay (plus its heuristics) is deleted.

Supporting semantics, each with its own commit:

- **Target node ownership follows identity**: the `targets.<name>` source-map key stays with the plugin that created the target; it only changes hands when a merge changes the target's identity (new/different executor or command, or an incompatible replace). Target-defaults stamps are weak — always reclaimable, never able to steal.
- **Name history**: name-reference sentinels registered after a project in the same batch renamed their referent still bind to the right root.
- **Leaner staging**: the intermediate default-layer merge now exists only to feed target-defaults synthesis — it is skipped entirely when nx.json has no `targetDefaults`, writes no source maps, and collects errors/external nodes into scratch objects. `filter.plugin` attribution is derived without staging source maps: a default plugin can never be named by the filter, so a default-layer-authored identity simply resolves to no matchable source plugin.

Verified with 316/316 tests across the merge-related suites (including a regression test mirroring the ocean repro) and validated against the live repro in nrwl/ocean: the `dependsOn` entries now show `(from apps/nx-api/project.json by nx/core/project-json)` while the target identity stays with `@nx/gradle`.

## Related Issue(s)

Reported via Polygraph session verification of the nested-array `targetDefaults` work (#36049) in nrwl/ocean; no standalone GitHub issue. The attribution bug predates #36049 (introduced with the default-layer overlay in #34285).

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/reapply-target-defaults-d52a940d)
<!-- polygraph-session-end -->

Fixes NXC-4608