### PR TITLE
fix(core): add trailing space after performance report popup title

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "packageManager": "pnpm@11.2.2",
   "scripts": {
-    "build": "nx run-many --target build --parallel 8 --exclude nx-dev,tools-documentation-create-embeddings,nx-dev-util-ai",
+    "build": "nx run-many --target build --parallel 8 --exclude nx-dev,tools-documentation-create-embeddings,nx-dev-util-ai,astro-docs",
     "commit": "czg",
     "check-commit": "node ./scripts/commit-lint.js",
     "check-format": "nx format:check --all",

--- a/packages/nx/src/native/tui/components/countdown_popup.rs
+++ b/packages/nx/src/native/tui/components/countdown_popup.rs
@@ -389,8 +389,9 @@ impl CountdownPopup {
                 format!("{time_remaining}"),
                 Style::default().fg(THEME.info),
             ));
-            spans.push(Span::styled("...  ", Style::default().fg(THEME.primary_fg)));
+            spans.push(Span::styled("...", Style::default().fg(THEME.primary_fg)));
         }
+        spans.push(Span::raw("  "));
         spans
     }
 


### PR DESCRIPTION
## Current Behavior

In the terminal UI, the performance report popup title reads ` NX  Performance Report` with no trailing space before the border once the report is pinned (i.e. when the "— exiting in N..." countdown is not shown). The trailing padding only existed inside the countdown suffix span, so it disappeared along with the countdown.

## Expected Behavior

The popup title always ends with the same trailing padding, whether or not the exit countdown is shown. The trailing spaces are now appended as a shared span after the conditional countdown block in `build_title_spans`.

Also excludes `astro-docs` from the root `package.json` `build` script, alongside the other docs-related projects.

## Related Issue(s)

N/A

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/merry-mongoose-f743b608)
<!-- polygraph-session-end -->