### PR TITLE
docs(misc): document Bun catalog

### DIFF
--- a/astro-docs/src/content/docs/getting-started/Tutorials/managing-dependencies.mdoc
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/managing-dependencies.mdoc
@@ -236,7 +236,32 @@ npm does not have catalog support. Enforce a single version policy by defining a
 {% /tabitem %}
 {% tabitem label="bun" %}
 
-Bun does not currently support catalogs. Define shared dependency versions in the root `package.json` and reference them using `workspace:*` for internal packages.
+```jsonc
+// package.json
+{
+  "workspaces": {
+    "packages": [
+      "packages/*"
+    ],
+    "catalog": {
+      "react": ^19.0.0
+      "react-dom": ^19.0.0
+    }
+  }
+}
+```
+
+```jsonc
+// packages/app/package.json
+{
+  "dependencies": {
+    "react": "catalog:",
+    "react-dom": "catalog:",
+  },
+}
+```
+
+See the [Bun catalogs documentation here](https://bun.com/docs/pm/catalogs#catalogs).
 
 {% /tabitem %}
 {% /tabs %}

--- a/astro-docs/src/content/docs/getting-started/Tutorials/managing-dependencies.mdoc
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/managing-dependencies.mdoc
@@ -244,8 +244,10 @@ npm does not have catalog support. Enforce a single version policy by defining a
       "packages/*"
     ],
     "catalog": {
-      "react": ^19.0.0
-      "react-dom": ^19.0.0
+
+      "react": "^19.0.0",
+      "react-dom": "^19.0.0"
+
     }
   }
 }


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

Bun does support `catalog` since [bun-v1.2.14](https://github.com/oven-sh/bun/releases/tag/bun-v1.2.14) (https://bun.sh/blog/bun-v1.2.14#catalogs-in-bun-install). This PR fixes the outdated documentation on the subject.
