### PR TITLE
fix(core): size TUI bottom bar reservations to the actual help text

### DIFF
--- a/packages/nx/src/native/tui/components/help_text.rs
+++ b/packages/nx/src/native/tui/components/help_text.rs
@@ -30,8 +30,65 @@ impl HelpText {
         }
     }
 
-    pub fn set_collapsed_mode(&mut self, collapsed: bool) {
-        self.collapsed_mode = collapsed;
+    /// Width in terminal columns of the rendered help line. Derived from the
+    /// same spans that render, so layout reservations can't drift from the
+    /// actual content.
+    pub fn width(&self) -> u16 {
+        self.line().width() as u16
+    }
+
+    fn line(&self) -> Line<'static> {
+        let base_style = if self.is_dimmed {
+            Style::default().add_modifier(Modifier::DIM)
+        } else {
+            Style::default()
+        };
+        let key_style = base_style.fg(THEME.info);
+        let label_style = base_style.fg(THEME.secondary_fg);
+
+        if self.collapsed_mode {
+            // Show minimal hint
+            return Line::from(vec![
+                Span::styled("quit: ", label_style),
+                Span::styled("q", key_style),
+                Span::styled("  ", label_style),
+                Span::styled("help: ", label_style),
+                Span::styled("?", key_style),
+            ]);
+        }
+
+        // Show full shortcuts
+        let mut shortcuts = vec![
+            Span::styled("quit: ", label_style),
+            Span::styled("q", key_style),
+            Span::styled("  ", label_style),
+            Span::styled("help: ", label_style),
+            Span::styled("?", key_style),
+            Span::styled("  ", label_style),
+            Span::styled("navigate: ", label_style),
+            Span::styled("↑ ↓", key_style),
+            Span::styled("  ", label_style),
+            Span::styled("filter: ", label_style),
+            Span::styled("/", key_style),
+            Span::styled("  ", label_style),
+            Span::styled("pin output: ", label_style),
+            Span::styled("", label_style),
+            Span::styled("1", key_style),
+            Span::styled(" or ", label_style),
+            Span::styled("2", key_style),
+            Span::styled("  ", label_style),
+            Span::styled("show output: ", label_style),
+            Span::styled("<enter>", key_style),
+        ];
+
+        // Only advertise the performance report once it exists (run finished).
+        if self.show_perf_report {
+            shortcuts.push(Span::styled("  ", label_style));
+            shortcuts.push(Span::styled("perf report: ", label_style));
+            shortcuts.push(Span::styled("p", key_style));
+        }
+
+        Line::from(shortcuts)
     }
 
     pub fn render(&self, f: &mut Frame<'_>, area: Rect) {
@@ -52,67 +109,14 @@ impl HelpText {
             height: area.height.min(f.area().height.saturating_sub(area.y)),
         };
 
-        let base_style = if self.is_dimmed {
-            Style::default().add_modifier(Modifier::DIM)
+        let alignment = if self.collapsed_mode && self.align_left {
+            Alignment::Left
         } else {
-            Style::default()
+            Alignment::Right
         };
-        let key_style = base_style.fg(THEME.info);
-        let label_style = base_style.fg(THEME.secondary_fg);
-
-        if self.collapsed_mode {
-            // Show minimal hint
-            let hint = vec![
-                Span::styled("quit: ", label_style),
-                Span::styled("q", key_style),
-                Span::styled("  ", label_style),
-                Span::styled("help: ", label_style),
-                Span::styled("?", key_style),
-            ];
-            f.render_widget(
-                NxParagraph::new(Line::from(hint)).alignment(if self.align_left {
-                    Alignment::Left
-                } else {
-                    Alignment::Right
-                }),
-                safe_area,
-            );
-        } else {
-            // Show full shortcuts
-            let mut shortcuts = vec![
-                Span::styled("quit: ", label_style),
-                Span::styled("q", key_style),
-                Span::styled("  ", label_style),
-                Span::styled("help: ", label_style),
-                Span::styled("?", key_style),
-                Span::styled("  ", label_style),
-                Span::styled("navigate: ", label_style),
-                Span::styled("↑ ↓", key_style),
-                Span::styled("  ", label_style),
-                Span::styled("filter: ", label_style),
-                Span::styled("/", key_style),
-                Span::styled("  ", label_style),
-                Span::styled("pin output: ", label_style),
-                Span::styled("", label_style),
-                Span::styled("1", key_style),
-                Span::styled(" or ", label_style),
-                Span::styled("2", key_style),
-                Span::styled("  ", label_style),
-                Span::styled("show output: ", label_style),
-                Span::styled("<enter>", key_style),
-            ];
-
-            // Only advertise the performance report once it exists (run finished).
-            if self.show_perf_report {
-                shortcuts.push(Span::styled("  ", label_style));
-                shortcuts.push(Span::styled("perf report: ", label_style));
-                shortcuts.push(Span::styled("p", key_style));
-            }
-
-            f.render_widget(
-                NxParagraph::new(Line::from(shortcuts)).alignment(Alignment::Right),
-                safe_area,
-            );
-        }
+        f.render_widget(
+            NxParagraph::new(self.line()).alignment(alignment),
+            safe_area,
+        );
     }
 }

--- a/packages/nx/src/native/tui/components/snapshots/nx__native__tui__components__tasks_list__tests__cache_column_spacing_with_long_truncated_task_name.snap
+++ b/packages/nx/src/native/tui/components/snapshots/nx__native__tui__components__tasks_list__tests__cache_column_spacing_with_long_truncated_task_name.snap
@@ -16,4 +16,4 @@ expression: terminal.backend()
 "                                                                                          "
 "                                                                                          "
 "                                                                                          "
-"                                                                          quit: q  help: ?"
+"      quit: q  help: ?  navigate: ↑ ↓  filter: /  pin output: 1 or 2  show output: <enter>"

--- a/packages/nx/src/native/tui/components/tasks_list.rs
+++ b/packages/nx/src/native/tui/components/tasks_list.rs
@@ -46,11 +46,8 @@ const DURATION_NOT_YET_KNOWN: &str = "...";
 const DEFAULT_MAX_PARALLEL: usize = 0;
 
 // Constants for layout calculation
-const COLLAPSED_HELP_WIDTH: u16 = 19; // "quit: q help: ?"
-const FULL_HELP_WIDTH: u16 = 86; // Full help text width
 const MIN_CLOUD_URL_WIDTH: u16 = 15; // Minimum space to show at least part of the URL
 const MIN_BOTTOM_SPACING: u16 = 4; // Minimum space between Cloud and Help
-const SCROLLBAR_WIDTH: u16 = 3; // Width for scrollbar area (1 scrollbar + 2 padding)
 // Rows consumed by the table header area: top_margin(1) + header content(1) + spacing row(1)
 const TABLE_HEADER_OVERHEAD_ROWS: u16 = 3;
 // Rows before the scrollbar track starts: top_margin(1) + header content(1)
@@ -2804,6 +2801,13 @@ impl Component for TasksList {
         // either counts as "has cloud content" for laying out the bottom bar.
         let has_cloud_message = self.cloud_message.is_some() || self.cloud_link.is_some();
 
+        // Measure the help text as it will actually render (the post-run help
+        // includes the perf report hint) so reservations match reality.
+        let collapsed_help_width =
+            HelpText::new(true, false, false, self.perf_report_available).width();
+        let full_help_width =
+            HelpText::new(false, false, false, self.perf_report_available).width();
+
         // --- 2. Determine Bottom Layout Mode ---
         enum BottomLayoutMode {
             SingleLine { help_collapsed: bool }, // Cloud + Help
@@ -2821,17 +2825,15 @@ impl Component for TasksList {
             } else if let Some(message) = &self.cloud_message {
                 if message.contains("https://") {
                     let url_start_pos = message.find("https://").unwrap_or(message.len());
-                    let prefix = &message[0..url_start_pos];
                     let url = &message[url_start_pos..];
-                    let full_message_width = (prefix.len() + url.len()) as u16;
-                    let url_width = url.len() as u16;
+                    let full_message_width = Span::raw(message.as_str()).width() as u16;
+                    let url_width = Span::raw(url).width() as u16;
 
                     // Check if we'll need to fall back to URL-only rendering
                     // We need to account for the help text that will be on the same line
                     let available_for_cloud = area
                         .width
-                        .saturating_sub(SCROLLBAR_WIDTH)
-                        .saturating_sub(COLLAPSED_HELP_WIDTH)
+                        .saturating_sub(collapsed_help_width)
                         .saturating_sub(MIN_BOTTOM_SPACING);
 
                     if full_message_width <= available_for_cloud {
@@ -2841,16 +2843,15 @@ impl Component for TasksList {
                         url_width
                     }
                 } else {
-                    message.len() as u16
+                    Span::raw(message.as_str()).width() as u16
                 }
             } else {
                 0
             };
 
-            let required_width_full_help =
-                SCROLLBAR_WIDTH + cloud_text_width + FULL_HELP_WIDTH + MIN_BOTTOM_SPACING;
+            let required_width_full_help = cloud_text_width + full_help_width + MIN_BOTTOM_SPACING;
             let required_width_collapsed_help =
-                SCROLLBAR_WIDTH + cloud_text_width + COLLAPSED_HELP_WIDTH + MIN_BOTTOM_SPACING;
+                cloud_text_width + collapsed_help_width + MIN_BOTTOM_SPACING;
 
             if required_width_full_help <= area.width {
                 layout_mode = BottomLayoutMode::SingleLine {
@@ -2867,9 +2868,8 @@ impl Component for TasksList {
             }
         } else {
             // No Cloud message is present
-            let required_width_full_help = SCROLLBAR_WIDTH + FULL_HELP_WIDTH + MIN_BOTTOM_SPACING;
-            let required_width_collapsed_help =
-                SCROLLBAR_WIDTH + COLLAPSED_HELP_WIDTH + MIN_BOTTOM_SPACING;
+            let required_width_full_help = full_help_width + MIN_BOTTOM_SPACING;
+            let required_width_collapsed_help = collapsed_help_width + MIN_BOTTOM_SPACING;
 
             if required_width_full_help <= area.width {
                 layout_mode = BottomLayoutMode::NoCloud {
@@ -2902,9 +2902,9 @@ impl Component for TasksList {
 
         let needs_filter_separator = matches!(layout_mode, BottomLayoutMode::TwoLine {..} | BottomLayoutMode::NoCloud {..} if has_cloud_message || !final_help_collapsed);
         let final_help_width = if final_help_collapsed {
-            COLLAPSED_HELP_WIDTH
+            collapsed_help_width
         } else {
-            FULL_HELP_WIDTH
+            full_help_width
         };
 
         if filter_is_active {
@@ -4203,6 +4203,86 @@ mod tests {
 
         render_to_test_backend(&mut terminal, &mut tasks_list);
         insta::assert_snapshot!(terminal.backend());
+    }
+
+    /// Render the full buffer to a row-major string for content assertions.
+    fn buffer_to_string(terminal: &Terminal<TestBackend>) -> String {
+        let buffer = terminal.backend().buffer().clone();
+        (0..buffer.area.height)
+            .map(|y| {
+                (0..buffer.area.width)
+                    .map(|x| buffer[(x, y)].symbol().to_string())
+                    .collect::<String>()
+            })
+            .collect::<Vec<_>>()
+            .join("\n")
+    }
+
+    fn create_completed_tasks_list_with_cloud_message(message: &str) -> TasksList {
+        let (mut tasks_list, test_tasks) = create_test_tasks_list();
+        for task in &test_tasks {
+            tasks_list
+                .update(Action::UpdateTaskStatus(
+                    task.id.clone(),
+                    TaskStatus::Success,
+                ))
+                .unwrap();
+        }
+        tasks_list
+            .update(Action::UpdateCloudMessage(message.to_string()))
+            .ok();
+        tasks_list
+    }
+
+    #[test]
+    fn cloud_message_keeps_prefix_when_it_fits_with_collapsed_help() {
+        // 59-col message + 16-col collapsed help + 4-col gap = exactly 79 columns.
+        let message = "View logs and run details at https://nx.app/runs/KnGk4A47qk";
+        let mut tasks_list = create_completed_tasks_list_with_cloud_message(message);
+        let mut terminal = create_test_terminal(79, 15);
+
+        render_to_test_backend(&mut terminal, &mut tasks_list);
+
+        assert!(
+            buffer_to_string(&terminal).contains(message),
+            "the full message fits next to the collapsed help, so the prefix must not be dropped"
+        );
+    }
+
+    #[test]
+    fn full_help_expands_when_it_fits_next_to_cloud_message() {
+        // 59-col message + 84-col full help + 4-col gap = exactly 147 columns.
+        let message = "View logs and run details at https://nx.app/runs/KnGk4A47qk";
+        let mut tasks_list = create_completed_tasks_list_with_cloud_message(message);
+        let mut terminal = create_test_terminal(147, 15);
+
+        render_to_test_backend(&mut terminal, &mut tasks_list);
+
+        let rendered = buffer_to_string(&terminal);
+        assert!(
+            rendered.contains(message),
+            "the full message fits, so it must render"
+        );
+        assert!(
+            rendered.contains("navigate:"),
+            "the full help fits next to the message, so it must not collapse"
+        );
+    }
+
+    #[test]
+    fn perf_report_hint_is_not_clipped_next_to_cloud_message() {
+        // 59-col message + 100-col post-run full help + 4-col gap = exactly 163 columns.
+        let message = "View logs and run details at https://nx.app/runs/KnGk4A47qk";
+        let mut tasks_list = create_completed_tasks_list_with_cloud_message(message);
+        tasks_list.set_perf_report_available(true);
+        let mut terminal = create_test_terminal(163, 15);
+
+        render_to_test_backend(&mut terminal, &mut tasks_list);
+
+        assert!(
+            buffer_to_string(&terminal).contains("perf report: p"),
+            "the post-run help includes the perf report hint and fits, so it must not be clipped"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## Current Behavior

The TUI task list's bottom bar decides its layout from hardcoded width constants (`COLLAPSED_HELP_WIDTH = 19`, `FULL_HELP_WIDTH = 86`) plus a phantom `SCROLLBAR_WIDTH = 3` that the bottom row never actually renders. These constants have drifted from the real help content: the collapsed help is 16 columns, and the post-run help (which now includes `perf report: p`) is 100 columns.

Next to an Nx Cloud message this over/under-reservation causes:

- The cloud message drops its prefix (URL-only fallback) while blank columns visibly remain (e.g. at 81 cols, `View logs and run details at …` is cut to just the URL with ~6 spare columns).
- The full help collapses several columns before it stops fitting (147–151 cols).
- The `perf report: p` hint is clipped off the right edge entirely whenever a cloud message is shown after a run finishes, because the real 100-col help is drawn into an 86-col reservation.

## Expected Behavior

Layout reservations match what actually renders. `HelpText` exposes `width()` derived from the same spans it renders (including the perf-report variant), the bottom-bar math consumes it instead of the stale constants, the phantom scrollbar reservation is removed, and cloud message widths are measured as display columns rather than byte lengths. The full message, full help, and perf-report hint each appear exactly when they fit.

Three regression tests pin the boundary widths (79 / 147 / 163 cols); one snapshot updated where the full help now correctly expands at 90 cols.

## Related Issue(s)

Polygraph session: cloud-link-tui-reserves-too-much-space

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/cloud-link-tui-reserves-too-much-space-43247752)
<!-- polygraph-session-end -->