### PR TITLE
docs(nx-cloud): document Commit Statuses write permission

### DIFF
--- a/astro-docs/src/content/docs/guides/Nx Cloud/Source Control Integration/github-app-permissions.mdoc
+++ b/astro-docs/src/content/docs/guides/Nx Cloud/Source Control Integration/github-app-permissions.mdoc
@@ -16,7 +16,7 @@ Repository permissions:
 
 - `Checks: Read & Write`
 - `Contents: Read & Write`
-- `Commit Statuses: Read`
+- `Commit Statuses: Read & Write`
 - `Issues: Read & Write`
 - `Metadata: Read`
 - `Pull requests: Read & Write`
@@ -45,11 +45,14 @@ Organization permissions:
 
 **When it's used:** During initial setup and configuration, and regularly if Self-Healing CI is enabled.
 
-### Commit statuses (read)
+### Commit statuses (read & write)
 
-**Used for:** Reading commit status information to coordinate with other CI tools and provide accurate pipeline context.
+**Used for:**
 
-**When it's used:** During CI pipeline executions to gather context about your commits.
+- **Read:** Reading the existing statuses on a pull request's head commit so Nx Cloud only re-posts the ones that have changed.
+- **Write:** Posting each task's result (passed, failed, or in progress) as a commit status on the pull request, so the outcome of every `nx affected` or `run-many` command shows on the PR. Posted only when the workspace's "Show run status checks in pull requests" setting is enabled.
+
+**When it's used:** During CI pipeline executions on pull request branches.
 
 ### Issues (read & write)
 


### PR DESCRIPTION
The GitHub App posts CI task results as commit statuses on pull requests (POST /repos/{owner}/{repo}/statuses/{sha}), which requires the Commit Statuses: Write permission, but the reference listed Read only. Update the required-permissions list and the section to cover the write use and when it happens.

<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #
