### PR TITLE
fix(core): avoid retaining matched file lists in fileset hash caches

### DIFF
--- a/packages/nx/src/native/tasks/hash_plan_inspector.rs
+++ b/packages/nx/src/native/tasks/hash_plan_inspector.rs
@@ -1,6 +1,6 @@
 use crate::native::tasks::hashers::{
-    ProjectFileSetCache, collect_json_input_files, hash_project_files_with_inputs_cached,
-    hash_workspace_files_with_inputs, resolve_task_output_files,
+    ProjectFilePathsCache, collect_json_input_files, collect_project_file_paths_cached,
+    collect_workspace_file_paths, resolve_task_output_files,
 };
 use crate::native::tasks::task_hasher::{HashInputs, HashInputsBuilder};
 use crate::native::tasks::types::{HashInstruction, HashPlans};
@@ -43,7 +43,7 @@ impl HashPlanInspector {
         #[napi(ts_arg_type = "ExternalObject<Record<string, Array<HashInstruction>>>")]
         hash_plans: &External<HashPlans>,
     ) -> anyhow::Result<HashMap<String, Vec<String>>> {
-        let project_file_set_cache = ProjectFileSetCache::new();
+        let project_file_paths_cache = ProjectFilePathsCache::new();
         let pool = &hash_plans.pool;
         let results: Vec<(&String, Vec<String>)> = hash_plans
             .plans
@@ -57,8 +57,8 @@ impl HashPlanInspector {
                     // File-set instructions: resolve to actual file paths
                     HashInstruction::WorkspaceFileSet(_)
                     | HashInstruction::ProjectFileSet(_, _) => {
-                        let builder =
-                            self.resolve_instruction_inputs(instruction, &project_file_set_cache)?;
+                        let builder = self
+                            .resolve_instruction_inputs(instruction, &project_file_paths_cache)?;
                         builder
                             .files
                             .into_iter()
@@ -92,7 +92,7 @@ impl HashPlanInspector {
         #[napi(ts_arg_type = "ExternalObject<Record<string, Array<HashInstruction>>>")]
         hash_plans: &External<HashPlans>,
     ) -> anyhow::Result<HashMap<String, HashInputs>> {
-        let project_file_set_cache = ProjectFileSetCache::new();
+        let project_file_paths_cache = ProjectFilePathsCache::new();
         let pool = &hash_plans.pool;
         let results: Vec<(&String, HashInputsBuilder)> = hash_plans
             .plans
@@ -101,8 +101,10 @@ impl HashPlanInspector {
             .par_bridge()
             .map(|(task_id, id)| {
                 let instruction_ref = pool.get(id);
-                let builder = self
-                    .resolve_instruction_inputs(instruction_ref.value(), &project_file_set_cache)?;
+                let builder = self.resolve_instruction_inputs(
+                    instruction_ref.value(),
+                    &project_file_paths_cache,
+                )?;
                 Ok::<_, anyhow::Error>((task_id, builder))
             })
             .collect::<anyhow::Result<_>>()?;
@@ -126,28 +128,26 @@ impl HashPlanInspector {
     fn resolve_instruction_inputs(
         &self,
         instruction: &HashInstruction,
-        project_file_set_cache: &ProjectFileSetCache,
+        project_file_paths_cache: &ProjectFilePathsCache,
     ) -> anyhow::Result<HashInputsBuilder> {
         match instruction {
             HashInstruction::WorkspaceFileSet(workspace_file_set) => {
-                let result = hash_workspace_files_with_inputs(
-                    workspace_file_set,
-                    &self.all_workspace_files,
-                )?;
+                let files =
+                    collect_workspace_file_paths(workspace_file_set, &self.all_workspace_files)?;
                 Ok(HashInputsBuilder {
-                    files: result.files.into_iter().collect(),
+                    files: files.into_iter().collect(),
                     ..Default::default()
                 })
             }
             HashInstruction::ProjectFileSet(project_name, file_sets) => {
-                let result = hash_project_files_with_inputs_cached(
+                let files = collect_project_file_paths_cached(
                     project_name,
                     file_sets,
                     &self.project_file_map,
-                    project_file_set_cache,
+                    project_file_paths_cache,
                 )?;
                 Ok(HashInputsBuilder {
-                    files: result.files.iter().cloned().collect(),
+                    files: files.iter().cloned().collect(),
                     ..Default::default()
                 })
             }

--- a/packages/nx/src/native/tasks/hashers.rs
+++ b/packages/nx/src/native/tasks/hashers.rs
@@ -15,9 +15,12 @@ pub use hash_env::*;
 pub use hash_external::*;
 pub use hash_json::*;
 pub use hash_project_config::*;
-pub(crate) use hash_project_files::{ProjectFileSetCache, hash_project_files_with_inputs_cached};
+pub(crate) use hash_project_files::{
+    ProjectFilePathsCache, ProjectFileSetCache, collect_project_file_paths_cached,
+    hash_project_files_cached,
+};
 pub use hash_project_files::{
-    ProjectFilesHashResult, collect_project_files, hash_project_files_with_inputs,
+    collect_project_file_paths, collect_project_files, hash_project_files,
 };
 pub use hash_runtime::*;
 pub use hash_task_output::*;

--- a/packages/nx/src/native/tasks/hashers/hash_project_files.rs
+++ b/packages/nx/src/native/tasks/hashers/hash_project_files.rs
@@ -8,13 +8,14 @@ use super::once_cache::OnceCache;
 use crate::native::glob::build_glob_set;
 use crate::native::types::FileData;
 
-/// Result of hashing project files, including the matched file paths
-pub struct ProjectFilesHashResult {
-    pub hash: String,
-    pub files: Vec<String>,
-}
+/// Compute-once cache for project fileset hashes. Holds only the hash, so
+/// retaining it for the TaskHasher lifetime stays O(projects), not O(files).
+pub(crate) type ProjectFileSetCache = OnceCache<String>;
 
-pub(crate) type ProjectFileSetCache = OnceCache<ProjectFilesHashResult>;
+/// Compute-once cache for the matched file paths of a project fileset.
+/// Only populated when task inputs are collected; callers keep it
+/// per-invocation so the expanded paths are freed once that call returns.
+pub(crate) type ProjectFilePathsCache = OnceCache<Vec<String>>;
 
 fn project_file_set_cache_key(project_name: &str, file_sets: &[String]) -> String {
     let mut sorted_file_sets: Vec<&str> = file_sets.iter().map(String::as_str).collect();
@@ -27,42 +28,62 @@ fn project_file_set_cache_key(project_name: &str, file_sets: &[String]) -> Strin
     )
 }
 
-/// Hashes project files and returns both the hash and the list of matched file paths.
-/// This allows callers to reuse the file list without re-globbing.
+/// Hashes project files without materializing the matched file list.
 /// Token resolution ({projectRoot}, {projectName}) is handled upstream by the HashPlanner,
 /// so file_sets are expected to contain already-resolved paths.
-pub fn hash_project_files_with_inputs(
+pub fn hash_project_files(
     project_name: &str,
     file_sets: &[String],
     project_file_map: &HashMap<String, Vec<FileData>>,
-) -> Result<ProjectFilesHashResult> {
+) -> Result<String> {
     let _span = trace_span!("hash_project_files", project_name).entered();
     let collected_files = collect_project_files(project_name, file_sets, project_file_map)?;
     trace!("collected_files: {:?}", collected_files.len());
 
     let mut hasher = xxhash_rust::xxh3::Xxh3::new();
-    let mut files = Vec::with_capacity(collected_files.len());
 
     for file in collected_files {
         hasher.update(file.hash.as_bytes());
         hasher.update(file.file.as_bytes());
-        files.push(file.file.clone());
     }
 
-    Ok(ProjectFilesHashResult {
-        hash: hasher.digest().to_string(),
-        files,
-    })
+    Ok(hasher.digest().to_string())
 }
 
-pub(crate) fn hash_project_files_with_inputs_cached(
+pub(crate) fn hash_project_files_cached(
     project_name: &str,
     file_sets: &[String],
     project_file_map: &HashMap<String, Vec<FileData>>,
     cache: &ProjectFileSetCache,
-) -> Result<Arc<ProjectFilesHashResult>> {
+) -> Result<Arc<String>> {
     cache.get_or_try_init(project_file_set_cache_key(project_name, file_sets), || {
-        hash_project_files_with_inputs(project_name, file_sets, project_file_map)
+        hash_project_files(project_name, file_sets, project_file_map)
+    })
+}
+
+/// The matched file paths of a project fileset, in project-file-map order
+/// (the same order hashing folds them).
+pub fn collect_project_file_paths(
+    project_name: &str,
+    file_sets: &[String],
+    project_file_map: &HashMap<String, Vec<FileData>>,
+) -> Result<Vec<String>> {
+    Ok(
+        collect_project_files(project_name, file_sets, project_file_map)?
+            .into_iter()
+            .map(|file| file.file.clone())
+            .collect(),
+    )
+}
+
+pub(crate) fn collect_project_file_paths_cached(
+    project_name: &str,
+    file_sets: &[String],
+    project_file_map: &HashMap<String, Vec<FileData>>,
+    cache: &ProjectFilePathsCache,
+) -> Result<Arc<Vec<String>>> {
+    cache.get_or_try_init(project_file_set_cache_key(project_name, file_sets), || {
+        collect_project_file_paths(project_name, file_sets, project_file_map)
     })
 }
 
@@ -182,9 +203,9 @@ mod tests {
                 file_data4.clone(),
             ],
         );
-        let result = hash_project_files_with_inputs(proj_name, file_sets, &file_map).unwrap();
+        let result = hash_project_files(proj_name, file_sets, &file_map).unwrap();
         assert_eq!(
-            result.hash,
+            result,
             hash(
                 &[
                     file_data1.hash.as_bytes(),
@@ -233,9 +254,9 @@ mod tests {
                 file_data4.clone(),
             ],
         );
-        let result = hash_project_files_with_inputs(proj_name, file_sets, &file_map).unwrap();
+        let result = hash_project_files(proj_name, file_sets, &file_map).unwrap();
         assert_eq!(
-            result.hash,
+            result,
             hash(
                 &[
                     file_data1.hash.as_bytes(),
@@ -246,6 +267,33 @@ mod tests {
                 .concat()
             )
         );
+    }
+
+    #[test]
+    fn should_collect_file_paths_in_file_map_order() {
+        let proj_name = "test_project";
+        let file_sets = &["!test/root/**/*.spec.ts".to_string()];
+        let mut file_map = HashMap::new();
+        file_map.insert(
+            String::from(proj_name),
+            vec![
+                FileData {
+                    file: "test/root/test1.ts".into(),
+                    hash: "file_data1".into(),
+                },
+                FileData {
+                    file: "test/root/test.spec.ts".into(),
+                    hash: "file_data2".into(),
+                },
+                FileData {
+                    file: "test/root/test3.ts".into(),
+                    hash: "file_data3".into(),
+                },
+            ],
+        );
+
+        let paths = collect_project_file_paths(proj_name, file_sets, &file_map).unwrap();
+        assert_eq!(paths, vec!["test/root/test1.ts", "test/root/test3.ts"]);
     }
 
     #[test]
@@ -276,13 +324,22 @@ mod tests {
 
         let cache = ProjectFileSetCache::new();
         let first =
-            hash_project_files_with_inputs_cached(proj_name, first_file_sets, &file_map, &cache)
-                .unwrap();
+            hash_project_files_cached(proj_name, first_file_sets, &file_map, &cache).unwrap();
         let second =
-            hash_project_files_with_inputs_cached(proj_name, second_file_sets, &file_map, &cache)
-                .unwrap();
+            hash_project_files_cached(proj_name, second_file_sets, &file_map, &cache).unwrap();
 
         assert_eq!(cache.len(), 1);
+        assert!(Arc::ptr_eq(&first, &second));
+
+        let paths_cache = ProjectFilePathsCache::new();
+        let first =
+            collect_project_file_paths_cached(proj_name, first_file_sets, &file_map, &paths_cache)
+                .unwrap();
+        let second =
+            collect_project_file_paths_cached(proj_name, second_file_sets, &file_map, &paths_cache)
+                .unwrap();
+
+        assert_eq!(paths_cache.len(), 1);
         assert!(Arc::ptr_eq(&first, &second));
     }
 }

--- a/packages/nx/src/native/tasks/hashers/hash_workspace_files.rs
+++ b/packages/nx/src/native/tasks/hashers/hash_workspace_files.rs
@@ -10,13 +10,14 @@ use crate::native::types::FileData;
 use anyhow::*;
 use tracing::{debug, debug_span, trace, warn};
 
-/// Result of hashing workspace files, including the matched file paths
-pub struct WorkspaceFilesHashResult {
-    pub hash: String,
-    pub files: Vec<String>,
-}
+/// Compute-once cache for workspace fileset hashes. Holds only the hash, so
+/// retaining it for the TaskHasher lifetime stays O(filesets), not O(files).
+pub(crate) type WorkspaceFileSetCache = OnceCache<String>;
 
-pub(crate) type WorkspaceFileSetCache = OnceCache<WorkspaceFilesHashResult>;
+/// Compute-once cache for the matched file paths of a workspace fileset.
+/// Only populated when task inputs are collected; callers keep it
+/// per-invocation so the expanded paths are freed once that call returns.
+pub(crate) type WorkspaceFilePathsCache = OnceCache<Vec<String>>;
 
 fn workspace_file_set_cache_key(workspace_file_sets: &[String]) -> String {
     let mut sorted_file_sets: Vec<&str> = workspace_file_sets.iter().map(String::as_str).collect();
@@ -64,26 +65,22 @@ pub fn get_workspace_files<'a, 'b>(
     glob_files(all_workspace_files, globs, None)
 }
 
-/// Hash workspace files and return both the hash and the list of matched file paths.
-pub fn hash_workspace_files_with_inputs(
+/// Hashes workspace files without materializing the matched file list.
+pub fn hash_workspace_files(
     workspace_file_sets: &[String],
     all_workspace_files: &[FileData],
-) -> Result<WorkspaceFilesHashResult> {
+) -> Result<String> {
     let globs = globs_from_workspace_globs(workspace_file_sets);
 
     if globs.is_empty() {
-        return Ok(WorkspaceFilesHashResult {
-            hash: hash(b""),
-            files: vec![],
-        });
+        return Ok(hash(b""));
     }
 
     let glob = build_glob_set(&globs)?;
 
     let mut hasher = xxhash_rust::xxh3::Xxh3::new();
-    let mut files = Vec::new();
 
-    debug_span!("Hashing workspace fileset with inputs").in_scope(|| {
+    debug_span!("Hashing workspace fileset").in_scope(|| {
         for file in all_workspace_files
             .iter()
             .filter(|file| glob.is_match(&file.file))
@@ -91,25 +88,52 @@ pub fn hash_workspace_files_with_inputs(
             debug!("Adding {:?} ({:?}) to hash", file.hash, file.file);
             hasher.update(file.file.as_bytes());
             hasher.update(file.hash.as_bytes());
-            files.push(file.file.clone());
         }
         let hashed_value = hasher.digest().to_string();
         debug!("Hash Value: {:?}", hashed_value);
 
-        Ok(WorkspaceFilesHashResult {
-            hash: hashed_value,
-            files,
-        })
+        Ok(hashed_value)
     })
 }
 
-pub(crate) fn hash_workspace_files_with_inputs_cached(
+pub(crate) fn hash_workspace_files_cached(
     workspace_file_sets: &[String],
     all_workspace_files: &[FileData],
     cache: &WorkspaceFileSetCache,
-) -> Result<Arc<WorkspaceFilesHashResult>> {
+) -> Result<Arc<String>> {
     cache.get_or_try_init(workspace_file_set_cache_key(workspace_file_sets), || {
-        hash_workspace_files_with_inputs(workspace_file_sets, all_workspace_files)
+        hash_workspace_files(workspace_file_sets, all_workspace_files)
+    })
+}
+
+/// The matched file paths of a workspace fileset, in workspace-file order
+/// (the same order hashing folds them).
+pub fn collect_workspace_file_paths(
+    workspace_file_sets: &[String],
+    all_workspace_files: &[FileData],
+) -> Result<Vec<String>> {
+    let globs = globs_from_workspace_globs(workspace_file_sets);
+
+    if globs.is_empty() {
+        return Ok(vec![]);
+    }
+
+    let glob = build_glob_set(&globs)?;
+
+    Ok(all_workspace_files
+        .iter()
+        .filter(|file| glob.is_match(&file.file))
+        .map(|file| file.file.clone())
+        .collect())
+}
+
+pub(crate) fn collect_workspace_file_paths_cached(
+    workspace_file_sets: &[String],
+    all_workspace_files: &[FileData],
+    cache: &WorkspaceFilePathsCache,
+) -> Result<Arc<Vec<String>>> {
+    cache.get_or_try_init(workspace_file_set_cache_key(workspace_file_sets), || {
+        collect_workspace_file_paths(workspace_file_sets, all_workspace_files)
     })
 }
 
@@ -121,9 +145,8 @@ mod test {
 
     #[test]
     fn invalid_workspace_input_is_just_empty_hash() {
-        let result =
-            hash_workspace_files_with_inputs(&["packages/{package}".to_string()], &[]).unwrap();
-        assert_eq!(result.hash, hash(b""));
+        let result = hash_workspace_files(&["packages/{package}".to_string()], &[]).unwrap();
+        assert_eq!(result, hash(b""));
     }
 
     #[test]
@@ -144,7 +167,7 @@ mod test {
             file: "packages/project/project.json".into(),
             hash: "abc".into(),
         };
-        let result = hash_workspace_files_with_inputs(
+        let result = hash_workspace_files(
             &["{workspaceRoot}/.gitignore".to_string()],
             &[
                 gitignore_file.clone(),
@@ -154,7 +177,7 @@ mod test {
             ],
         )
         .unwrap();
-        assert_eq!(result.hash, "15841935230129999746");
+        assert_eq!(result, "15841935230129999746");
     }
 
     #[test]
@@ -176,7 +199,7 @@ mod test {
             hash: "abc".into(),
         };
         for _ in 0..1000 {
-            let result = hash_workspace_files_with_inputs(
+            let result = hash_workspace_files(
                 &["{workspaceRoot}/**/*".to_string()],
                 &[
                     gitignore_file.clone(),
@@ -186,8 +209,38 @@ mod test {
                 ],
             )
             .unwrap();
-            assert_eq!(result.hash, "13759877301064854697");
+            assert_eq!(result, "13759877301064854697");
         }
+    }
+
+    #[test]
+    fn should_collect_file_paths_in_workspace_file_order() {
+        let all_workspace_files = vec![
+            FileData {
+                file: ".gitignore".into(),
+                hash: "123".into(),
+            },
+            FileData {
+                file: "package.json".into(),
+                hash: "789".into(),
+            },
+            FileData {
+                file: "packages/project/project.json".into(),
+                hash: "abc".into(),
+            },
+        ];
+
+        let paths = collect_workspace_file_paths(
+            &["{workspaceRoot}/**/*.json".to_string()],
+            &all_workspace_files,
+        )
+        .unwrap();
+        assert_eq!(paths, vec!["package.json", "packages/project/project.json"]);
+
+        let paths =
+            collect_workspace_file_paths(&["packages/{package}".to_string()], &all_workspace_files)
+                .unwrap();
+        assert!(paths.is_empty());
     }
 
     #[test]
@@ -213,13 +266,28 @@ mod test {
 
         let cache = WorkspaceFileSetCache::new();
         let first =
-            hash_workspace_files_with_inputs_cached(first_file_sets, &all_workspace_files, &cache)
-                .unwrap();
+            hash_workspace_files_cached(first_file_sets, &all_workspace_files, &cache).unwrap();
         let second =
-            hash_workspace_files_with_inputs_cached(second_file_sets, &all_workspace_files, &cache)
-                .unwrap();
+            hash_workspace_files_cached(second_file_sets, &all_workspace_files, &cache).unwrap();
 
         assert_eq!(cache.len(), 1);
+        assert!(Arc::ptr_eq(&first, &second));
+
+        let paths_cache = WorkspaceFilePathsCache::new();
+        let first = collect_workspace_file_paths_cached(
+            first_file_sets,
+            &all_workspace_files,
+            &paths_cache,
+        )
+        .unwrap();
+        let second = collect_workspace_file_paths_cached(
+            second_file_sets,
+            &all_workspace_files,
+            &paths_cache,
+        )
+        .unwrap();
+
+        assert_eq!(paths_cache.len(), 1);
         assert!(Arc::ptr_eq(&first, &second));
     }
 }

--- a/packages/nx/src/native/tasks/task_hasher.rs
+++ b/packages/nx/src/native/tasks/task_hasher.rs
@@ -16,10 +16,11 @@ use crate::native::{
 };
 use crate::native::{
     tasks::hashers::{
-        CachedTaskOutput, JsonHashResult, ProjectFileSetCache, WorkspaceFileSetCache,
-        hash_all_externals, hash_external, hash_json_files, hash_project_config,
-        hash_project_files_with_inputs_cached, hash_task_output, hash_tsconfig_selectively,
-        hash_workspace_files_with_inputs_cached,
+        CachedTaskOutput, JsonHashResult, ProjectFilePathsCache, ProjectFileSetCache,
+        WorkspaceFilePathsCache, WorkspaceFileSetCache, collect_project_file_paths_cached,
+        collect_workspace_file_paths_cached, hash_all_externals, hash_external, hash_json_files,
+        hash_project_config, hash_project_files_cached, hash_task_output,
+        hash_tsconfig_selectively, hash_workspace_files_cached,
     },
     types::FileData,
     workspace::types::ProjectFiles,
@@ -152,7 +153,9 @@ pub struct TaskHasher {
     options: Option<HasherOptions>,
     external_cache: Arc<DashMap<String, String>>,
     // Persisted across hash_plans() calls: they only fold the immutable FileData
-    // snapshot, so they never go stale. (Live-disk/exec caches stay per-call — see below.)
+    // snapshot, so they never go stale. Hash-only: matched file lists are only
+    // expanded per-invocation when inputs are collected. (Live-disk/exec caches
+    // stay per-call, see below.)
     workspace_file_set_cache: WorkspaceFileSetCache,
     project_file_set_cache: ProjectFileSetCache,
     // Fold over all externals; identical for every task, so computed once.
@@ -234,6 +237,10 @@ impl TaskHasher {
         let task_output_cache = DashMap::new();
         let runtime_cache: DashMap<String, String> = DashMap::new();
         let json_file_set_cache: DashMap<String, JsonHashResult> = DashMap::new();
+        // Per-invocation and only populated when collecting inputs, so the
+        // expanded fileset file lists are freed once this call returns.
+        let project_file_paths_cache = ProjectFilePathsCache::new();
+        let workspace_file_paths_cache = WorkspaceFilePathsCache::new();
         let should_collect_inputs = collect_task_inputs.unwrap_or(false);
 
         let function_start = std::time::Instant::now();
@@ -290,6 +297,8 @@ impl TaskHasher {
                         runtime_cache: &runtime_cache,
                         project_file_set_cache: &self.project_file_set_cache,
                         workspace_file_set_cache: &self.workspace_file_set_cache,
+                        project_file_paths_cache: &project_file_paths_cache,
+                        workspace_file_paths_cache: &workspace_file_paths_cache,
                         json_file_set_cache: &json_file_set_cache,
                         cwd: cwd_path,
                         collect_inputs: should_collect_inputs,
@@ -368,6 +377,8 @@ impl TaskHasher {
             runtime_cache,
             project_file_set_cache,
             workspace_file_set_cache,
+            project_file_paths_cache,
+            workspace_file_paths_cache,
             json_file_set_cache,
             cwd,
             collect_inputs,
@@ -378,21 +389,26 @@ impl TaskHasher {
         let empty = HashInputsBuilder::default();
         let (hash, inputs) = match instruction {
             HashInstruction::WorkspaceFileSet(workspace_file_set) => {
-                let cached_entry = hash_workspace_files_with_inputs_cached(
+                let hashed = hash_workspace_files_cached(
                     workspace_file_set,
                     &self.all_workspace_files,
                     workspace_file_set_cache,
                 )?;
                 trace!(parent: &span, "hash_workspace_files: {:?}", now.elapsed());
                 let inputs = if collect_inputs {
+                    let files = collect_workspace_file_paths_cached(
+                        workspace_file_set,
+                        &self.all_workspace_files,
+                        workspace_file_paths_cache,
+                    )?;
                     HashInputsBuilder {
-                        files: cached_entry.files.iter().cloned().collect(),
+                        files: files.iter().cloned().collect(),
                         ..Default::default()
                     }
                 } else {
                     empty
                 };
-                (cached_entry.hash.clone(), inputs)
+                ((*hashed).clone(), inputs)
             }
             HashInstruction::Runtime(runtime) => {
                 let hashed_runtime =
@@ -422,7 +438,7 @@ impl TaskHasher {
                 (hashed_cwd, empty)
             }
             HashInstruction::ProjectFileSet(project_name, file_sets) => {
-                let cached_entry = hash_project_files_with_inputs_cached(
+                let hashed = hash_project_files_cached(
                     project_name,
                     file_sets,
                     &self.project_file_map,
@@ -430,14 +446,20 @@ impl TaskHasher {
                 )?;
                 trace!(parent: &span, "hash_project_files: {:?}", now.elapsed());
                 let inputs = if collect_inputs {
+                    let files = collect_project_file_paths_cached(
+                        project_name,
+                        file_sets,
+                        &self.project_file_map,
+                        project_file_paths_cache,
+                    )?;
                     HashInputsBuilder {
-                        files: cached_entry.files.iter().cloned().collect(),
+                        files: files.iter().cloned().collect(),
                         ..Default::default()
                     }
                 } else {
                     empty
                 };
-                (cached_entry.hash.clone(), inputs)
+                ((*hashed).clone(), inputs)
             }
             HashInstruction::ProjectConfiguration(project_name) => {
                 let hashed_project_config =
@@ -598,6 +620,8 @@ struct HashInstructionArgs<'a> {
     runtime_cache: &'a DashMap<String, String>,
     project_file_set_cache: &'a ProjectFileSetCache,
     workspace_file_set_cache: &'a WorkspaceFileSetCache,
+    project_file_paths_cache: &'a ProjectFilePathsCache,
+    workspace_file_paths_cache: &'a WorkspaceFilePathsCache,
     json_file_set_cache: &'a DashMap<String, JsonHashResult>,
     cwd: &'a std::path::Path,
     collect_inputs: bool,


### PR DESCRIPTION
## Current Behavior

The task hasher's persistent fileset caches store the full list of matched file paths alongside each fileset hash. The path lists stay in memory for the lifetime of the hasher even though they are only consumed when task inputs are collected (e.g. for graph tooling), so cache retention grows linearly with the number of matched files in the workspace. The lists are also built on every cache miss when nothing will read them, and the hash plan inspector computes fileset hashes as a side effect of listing matched files.

## Expected Behavior

The persistent caches store only the fileset hashes. Matched file lists are expanded only when inputs are actually collected, in per-invocation caches that are freed once hashing returns, so the default hashing path never allocates them. The inspector lists matched files without hashing. Task hashes, hash details, and collected inputs are unchanged, verified by comparing full per-task hash dumps between builds.

> [!NOTE]
> A follow-up PR (#36267) builds on this to deduplicate the hash detail strings themselves, reducing peak hashing memory on large workspaces.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/gh-36152-655cd716)
<!-- polygraph-session-end -->
