### PR TITLE
fix(core): reduce task hashing memory usage on large workspaces

### DIFF
--- a/packages/nx/src/hasher/native-task-hasher-impl.spec.ts
+++ b/packages/nx/src/hasher/native-task-hasher-impl.spec.ts
@@ -226,6 +226,93 @@ describe('native task hasher', () => {
     `);
   });
 
+  it('should hash a shared runtime input against each task env', async () => {
+    const workspaceFiles = await retrieveWorkspaceFiles(tempFs.tempDir, {
+      'libs/parent': 'parent',
+      'libs/child': 'child',
+    });
+    const builder = new ProjectGraphBuilder(
+      undefined,
+      workspaceFiles.fileMap.projectFileMap
+    );
+    const runtimeCommand = 'node -e "console.log(process.env.SELECTED_ENV)"';
+    for (const name of ['parent', 'child']) {
+      builder.addNode({
+        name,
+        type: 'lib',
+        data: {
+          root: `libs/${name}`,
+          targets: {
+            build: {
+              executor: 'nx:run-commands',
+              inputs: ['default', { runtime: runtimeCommand }],
+            },
+          },
+        },
+      });
+    }
+    const projectGraph = builder.getUpdatedProjectGraph();
+    const taskGraph = createTaskGraph(
+      projectGraph,
+      {},
+      ['parent', 'child'],
+      ['build'],
+      undefined,
+      {}
+    );
+    const hasher = new NativeTaskHasherImpl(
+      tempFs.tempDir,
+      nxJson,
+      projectGraph,
+      workspaceFiles.rustReferences,
+      { selectivelyHashTsConfig: false }
+    );
+    const tasks = [
+      taskGraph.tasks['parent:build'],
+      taskGraph.tasks['child:build'],
+    ];
+    const perTaskEnvs = {
+      'parent:build': { SELECTED_ENV: 'parent-env' },
+      'child:build': { SELECTED_ENV: 'child-env' },
+    };
+    const runtimeKey = `runtime:${runtimeCommand}`;
+
+    // Hashing each task alone cannot share values across tasks, so these
+    // are the reference hashes for each env.
+    const soloParent = await hasher.hashTask(
+      tasks[0],
+      taskGraph,
+      perTaskEnvs['parent:build']
+    );
+    const soloChild = await hasher.hashTask(
+      tasks[1],
+      taskGraph,
+      perTaskEnvs['child:build']
+    );
+    expect(soloParent.details[runtimeKey]).toBeDefined();
+    expect(soloParent.details[runtimeKey]).not.toEqual(
+      soloChild.details[runtimeKey]
+    );
+
+    // Hashing both tasks in one invocation must produce the same
+    // per-task runtime hashes, with and without input collection.
+    for (const collectInputs of [true, false]) {
+      const [parentHash, childHash] = await hasher.hashTasks(
+        tasks,
+        taskGraph,
+        perTaskEnvs,
+        undefined,
+        collectInputs
+      );
+      expect(parentHash.details[runtimeKey]).toEqual(
+        soloParent.details[runtimeKey]
+      );
+      expect(childHash.details[runtimeKey]).toEqual(
+        soloChild.details[runtimeKey]
+      );
+    }
+  });
+
   it('should hash tasks where the project has dependencies', async () => {
     const workspaceFiles = await retrieveWorkspaceFiles(tempFs.tempDir, {
       'libs/parent': 'parent',

--- a/packages/nx/src/hasher/native-task-hasher-impl.spec.ts
+++ b/packages/nx/src/hasher/native-task-hasher-impl.spec.ts
@@ -313,6 +313,64 @@ describe('native task hasher', () => {
     }
   });
 
+  it('should collect the same inputs when hashing again on the same hasher', async () => {
+    const workspaceFiles = await retrieveWorkspaceFiles(tempFs.tempDir, {
+      'libs/parent': 'parent',
+    });
+    const builder = new ProjectGraphBuilder(
+      undefined,
+      workspaceFiles.fileMap.projectFileMap
+    );
+    builder.addNode({
+      name: 'parent',
+      type: 'lib',
+      data: {
+        root: 'libs/parent',
+        targets: {
+          build: { executor: 'nx:run-commands', inputs: ['default'] },
+        },
+      },
+    });
+    const projectGraph = builder.getUpdatedProjectGraph();
+    const taskGraph = createTaskGraph(
+      projectGraph,
+      {},
+      ['parent'],
+      ['build'],
+      undefined,
+      {}
+    );
+    const hasher = new NativeTaskHasherImpl(
+      tempFs.tempDir,
+      nxJson,
+      projectGraph,
+      workspaceFiles.rustReferences,
+      { selectivelyHashTsConfig: false }
+    );
+    const tasks = [taskGraph.tasks['parent:build']];
+    const perTaskEnvs = { 'parent:build': {} };
+
+    // The matched-file indices caches persist on the hasher across calls;
+    // the second call expands paths from them instead of re-globbing.
+    const first = await hasher.hashTasks(
+      tasks,
+      taskGraph,
+      perTaskEnvs,
+      undefined,
+      true
+    );
+    const second = await hasher.hashTasks(
+      tasks,
+      taskGraph,
+      perTaskEnvs,
+      undefined,
+      true
+    );
+
+    expect(first[0].inputs.files).not.toHaveLength(0);
+    expect(sortHashInputs(second)).toEqual(sortHashInputs(first));
+  });
+
   it('should hash tasks where the project has dependencies', async () => {
     const workspaceFiles = await retrieveWorkspaceFiles(tempFs.tempDir, {
       'libs/parent': 'parent',

--- a/packages/nx/src/native/tasks/hash_plan_inspector.rs
+++ b/packages/nx/src/native/tasks/hash_plan_inspector.rs
@@ -1,6 +1,6 @@
 use crate::native::tasks::hashers::{
-    ProjectFileSetCache, collect_json_input_files, hash_project_files_with_inputs_cached,
-    hash_workspace_files_with_inputs, resolve_task_output_files,
+    ProjectFilePathsCache, collect_json_input_files, collect_project_file_paths_cached,
+    collect_workspace_file_paths, resolve_task_output_files,
 };
 use crate::native::tasks::task_hasher::{HashInputs, HashInputsBuilder};
 use crate::native::tasks::types::{HashInstruction, HashPlans};
@@ -43,7 +43,7 @@ impl HashPlanInspector {
         #[napi(ts_arg_type = "ExternalObject<Record<string, Array<HashInstruction>>>")]
         hash_plans: &External<HashPlans>,
     ) -> anyhow::Result<HashMap<String, Vec<String>>> {
-        let project_file_set_cache = ProjectFileSetCache::new();
+        let project_file_paths_cache = ProjectFilePathsCache::new();
         let pool = &hash_plans.pool;
         let results: Vec<(&String, Vec<String>)> = hash_plans
             .plans
@@ -57,8 +57,8 @@ impl HashPlanInspector {
                     // File-set instructions: resolve to actual file paths
                     HashInstruction::WorkspaceFileSet(_)
                     | HashInstruction::ProjectFileSet(_, _) => {
-                        let builder =
-                            self.resolve_instruction_inputs(instruction, &project_file_set_cache)?;
+                        let builder = self
+                            .resolve_instruction_inputs(instruction, &project_file_paths_cache)?;
                         builder
                             .files
                             .into_iter()
@@ -92,7 +92,7 @@ impl HashPlanInspector {
         #[napi(ts_arg_type = "ExternalObject<Record<string, Array<HashInstruction>>>")]
         hash_plans: &External<HashPlans>,
     ) -> anyhow::Result<HashMap<String, HashInputs>> {
-        let project_file_set_cache = ProjectFileSetCache::new();
+        let project_file_paths_cache = ProjectFilePathsCache::new();
         let pool = &hash_plans.pool;
         let results: Vec<(&String, HashInputsBuilder)> = hash_plans
             .plans
@@ -101,8 +101,10 @@ impl HashPlanInspector {
             .par_bridge()
             .map(|(task_id, id)| {
                 let instruction_ref = pool.get(id);
-                let builder = self
-                    .resolve_instruction_inputs(instruction_ref.value(), &project_file_set_cache)?;
+                let builder = self.resolve_instruction_inputs(
+                    instruction_ref.value(),
+                    &project_file_paths_cache,
+                )?;
                 Ok::<_, anyhow::Error>((task_id, builder))
             })
             .collect::<anyhow::Result<_>>()?;
@@ -126,28 +128,26 @@ impl HashPlanInspector {
     fn resolve_instruction_inputs(
         &self,
         instruction: &HashInstruction,
-        project_file_set_cache: &ProjectFileSetCache,
+        project_file_paths_cache: &ProjectFilePathsCache,
     ) -> anyhow::Result<HashInputsBuilder> {
         match instruction {
             HashInstruction::WorkspaceFileSet(workspace_file_set) => {
-                let result = hash_workspace_files_with_inputs(
-                    workspace_file_set,
-                    &self.all_workspace_files,
-                )?;
+                let files =
+                    collect_workspace_file_paths(workspace_file_set, &self.all_workspace_files)?;
                 Ok(HashInputsBuilder {
-                    files: result.files.into_iter().collect(),
+                    files: files.into_iter().collect(),
                     ..Default::default()
                 })
             }
             HashInstruction::ProjectFileSet(project_name, file_sets) => {
-                let result = hash_project_files_with_inputs_cached(
+                let files = collect_project_file_paths_cached(
                     project_name,
                     file_sets,
                     &self.project_file_map,
-                    project_file_set_cache,
+                    project_file_paths_cache,
                 )?;
                 Ok(HashInputsBuilder {
-                    files: result.files.iter().cloned().collect(),
+                    files: files.iter().cloned().collect(),
                     ..Default::default()
                 })
             }

--- a/packages/nx/src/native/tasks/hash_plan_inspector.rs
+++ b/packages/nx/src/native/tasks/hash_plan_inspector.rs
@@ -1,5 +1,5 @@
 use crate::native::tasks::hashers::{
-    ProjectFilePathsCache, collect_json_input_files, collect_project_file_paths_cached,
+    ProjectFileIndicesCache, collect_json_input_files, collect_project_file_paths_cached,
     collect_workspace_file_paths, resolve_task_output_files,
 };
 use crate::native::tasks::task_hasher::{HashInputs, HashInputsBuilder};
@@ -43,7 +43,7 @@ impl HashPlanInspector {
         #[napi(ts_arg_type = "ExternalObject<Record<string, Array<HashInstruction>>>")]
         hash_plans: &External<HashPlans>,
     ) -> anyhow::Result<HashMap<String, Vec<String>>> {
-        let project_file_paths_cache = ProjectFilePathsCache::new();
+        let project_file_indices_cache = ProjectFileIndicesCache::new();
         let pool = &hash_plans.pool;
         let results: Vec<(&String, Vec<String>)> = hash_plans
             .plans
@@ -58,7 +58,7 @@ impl HashPlanInspector {
                     HashInstruction::WorkspaceFileSet(_)
                     | HashInstruction::ProjectFileSet(_, _) => {
                         let builder = self
-                            .resolve_instruction_inputs(instruction, &project_file_paths_cache)?;
+                            .resolve_instruction_inputs(instruction, &project_file_indices_cache)?;
                         builder
                             .files
                             .into_iter()
@@ -92,7 +92,7 @@ impl HashPlanInspector {
         #[napi(ts_arg_type = "ExternalObject<Record<string, Array<HashInstruction>>>")]
         hash_plans: &External<HashPlans>,
     ) -> anyhow::Result<HashMap<String, HashInputs>> {
-        let project_file_paths_cache = ProjectFilePathsCache::new();
+        let project_file_indices_cache = ProjectFileIndicesCache::new();
         let pool = &hash_plans.pool;
         let results: Vec<(&String, HashInputsBuilder)> = hash_plans
             .plans
@@ -103,7 +103,7 @@ impl HashPlanInspector {
                 let instruction_ref = pool.get(id);
                 let builder = self.resolve_instruction_inputs(
                     instruction_ref.value(),
-                    &project_file_paths_cache,
+                    &project_file_indices_cache,
                 )?;
                 Ok::<_, anyhow::Error>((task_id, builder))
             })
@@ -128,7 +128,7 @@ impl HashPlanInspector {
     fn resolve_instruction_inputs(
         &self,
         instruction: &HashInstruction,
-        project_file_paths_cache: &ProjectFilePathsCache,
+        project_file_indices_cache: &ProjectFileIndicesCache,
     ) -> anyhow::Result<HashInputsBuilder> {
         match instruction {
             HashInstruction::WorkspaceFileSet(workspace_file_set) => {
@@ -144,10 +144,10 @@ impl HashPlanInspector {
                     project_name,
                     file_sets,
                     &self.project_file_map,
-                    project_file_paths_cache,
+                    project_file_indices_cache,
                 )?;
                 Ok(HashInputsBuilder {
-                    files: files.iter().cloned().collect(),
+                    files: files.into_iter().collect(),
                     ..Default::default()
                 })
             }

--- a/packages/nx/src/native/tasks/hashers.rs
+++ b/packages/nx/src/native/tasks/hashers.rs
@@ -15,9 +15,12 @@ pub use hash_env::*;
 pub use hash_external::*;
 pub use hash_json::*;
 pub use hash_project_config::*;
-pub(crate) use hash_project_files::{ProjectFileSetCache, hash_project_files_with_inputs_cached};
+pub(crate) use hash_project_files::{
+    ProjectFilePathsCache, ProjectFileSetCache, collect_project_file_paths_cached,
+    hash_project_files_cached,
+};
 pub use hash_project_files::{
-    ProjectFilesHashResult, collect_project_files, hash_project_files_with_inputs,
+    collect_project_file_paths, collect_project_files, hash_project_files,
 };
 pub use hash_runtime::*;
 pub use hash_task_output::*;

--- a/packages/nx/src/native/tasks/hashers.rs
+++ b/packages/nx/src/native/tasks/hashers.rs
@@ -16,11 +16,12 @@ pub use hash_external::*;
 pub use hash_json::*;
 pub use hash_project_config::*;
 pub(crate) use hash_project_files::{
-    ProjectFilePathsCache, ProjectFileSetCache, collect_project_file_paths_cached,
-    hash_project_files_cached,
+    ProjectFileIndicesCache, ProjectFileSetCache, collect_project_file_indices_cached,
+    collect_project_file_paths_cached, hash_project_files_cached,
 };
 pub use hash_project_files::{
-    collect_project_file_paths, collect_project_files, hash_project_files,
+    collect_project_file_indices, collect_project_file_paths, collect_project_files,
+    hash_project_files,
 };
 pub use hash_runtime::*;
 pub use hash_task_output::*;

--- a/packages/nx/src/native/tasks/hashers.rs
+++ b/packages/nx/src/native/tasks/hashers.rs
@@ -16,12 +16,11 @@ pub use hash_external::*;
 pub use hash_json::*;
 pub use hash_project_config::*;
 pub(crate) use hash_project_files::{
-    ProjectFileIndicesCache, ProjectFileSetCache, collect_project_file_indices_cached,
-    collect_project_file_paths_cached, hash_project_files_cached,
+    ProjectFileIndicesCache, ProjectFileSetCache, collect_project_file_paths_cached,
+    hash_project_files_cached,
 };
 pub use hash_project_files::{
-    collect_project_file_indices, collect_project_file_paths, collect_project_files,
-    hash_project_files,
+    collect_project_file_paths, collect_project_files, hash_project_files,
 };
 pub use hash_runtime::*;
 pub use hash_task_output::*;

--- a/packages/nx/src/native/tasks/hashers/hash_project_files.rs
+++ b/packages/nx/src/native/tasks/hashers/hash_project_files.rs
@@ -12,10 +12,12 @@ use crate::native::types::FileData;
 /// retaining it for the TaskHasher lifetime stays O(projects), not O(files).
 pub(crate) type ProjectFileSetCache = OnceCache<String>;
 
-/// Compute-once cache for the matched file paths of a project fileset.
-/// Only populated when task inputs are collected; callers keep it
-/// per-invocation so the expanded paths are freed once that call returns.
-pub(crate) type ProjectFilePathsCache = OnceCache<Vec<String>>;
+/// Compute-once cache for the matched file *indices* of a project fileset,
+/// into that project's `project_file_map` vec. Persistable: 4 bytes/file and
+/// references the immutable FileData snapshot, so it never goes stale — the
+/// same guarantee `ProjectFileSetCache` relies on. Paths are expanded from it
+/// per call and freed once handed to the input subscriber.
+pub(crate) type ProjectFileIndicesCache = OnceCache<Vec<u32>>;
 
 fn project_file_set_cache_key(project_name: &str, file_sets: &[String]) -> String {
     let mut sorted_file_sets: Vec<&str> = file_sets.iter().map(String::as_str).collect();
@@ -76,15 +78,56 @@ pub fn collect_project_file_paths(
     )
 }
 
+/// The matched file indices of a project fileset, into `project_file_map[project_name]`,
+/// in the same project-file-map order `collect_project_file_paths` yields.
+pub fn collect_project_file_indices(
+    project_name: &str,
+    file_sets: &[String],
+    project_file_map: &HashMap<String, Vec<FileData>>,
+) -> Result<Vec<u32>> {
+    let glob_set = build_glob_set(file_sets)?;
+    project_file_map.get(project_name).map_or_else(
+        || Err(anyhow!("project {} not found", project_name)),
+        |files| {
+            Ok(files
+                .iter()
+                .enumerate()
+                .filter(|(_, file)| glob_set.is_match(&file.file))
+                .map(|(i, _)| i as u32)
+                .collect())
+        },
+    )
+}
+
+pub(crate) fn collect_project_file_indices_cached(
+    project_name: &str,
+    file_sets: &[String],
+    project_file_map: &HashMap<String, Vec<FileData>>,
+    cache: &ProjectFileIndicesCache,
+) -> Result<Arc<Vec<u32>>> {
+    cache.get_or_try_init(project_file_set_cache_key(project_name, file_sets), || {
+        collect_project_file_indices(project_name, file_sets, project_file_map)
+    })
+}
+
+/// Expands the cached matched-file indices into owned paths. Only the compact
+/// indices persist in `cache`; the returned paths are transient and freed by
+/// the caller once handed to the input subscriber.
 pub(crate) fn collect_project_file_paths_cached(
     project_name: &str,
     file_sets: &[String],
     project_file_map: &HashMap<String, Vec<FileData>>,
-    cache: &ProjectFilePathsCache,
-) -> Result<Arc<Vec<String>>> {
-    cache.get_or_try_init(project_file_set_cache_key(project_name, file_sets), || {
-        collect_project_file_paths(project_name, file_sets, project_file_map)
-    })
+    cache: &ProjectFileIndicesCache,
+) -> Result<Vec<String>> {
+    let indices =
+        collect_project_file_indices_cached(project_name, file_sets, project_file_map, cache)?;
+    let files = project_file_map
+        .get(project_name)
+        .ok_or_else(|| anyhow!("project {} not found", project_name))?;
+    Ok(indices
+        .iter()
+        .map(|&i| files[i as usize].file.clone())
+        .collect())
 }
 
 /// base function that should be testable (to make sure that we're getting the proper files back)
@@ -297,6 +340,42 @@ mod tests {
     }
 
     #[test]
+    fn indices_expand_to_the_same_paths_as_direct_collection() {
+        let proj_name = "test_project";
+        let file_sets = &["!test/root/**/*.spec.ts".to_string()];
+        let mut file_map = HashMap::new();
+        file_map.insert(
+            String::from(proj_name),
+            vec![
+                FileData {
+                    file: "test/root/test1.ts".into(),
+                    hash: "file_data1".into(),
+                },
+                FileData {
+                    file: "test/root/test.spec.ts".into(),
+                    hash: "file_data2".into(),
+                },
+                FileData {
+                    file: "test/root/test3.ts".into(),
+                    hash: "file_data3".into(),
+                },
+            ],
+        );
+
+        let indices = collect_project_file_indices(proj_name, file_sets, &file_map).unwrap();
+        // Positions of the non-spec files within the project vec.
+        assert_eq!(indices, vec![0, 2]);
+
+        let files = &file_map[proj_name];
+        let expanded: Vec<String> = indices
+            .iter()
+            .map(|&i| files[i as usize].file.clone())
+            .collect();
+        let direct = collect_project_file_paths(proj_name, file_sets, &file_map).unwrap();
+        assert_eq!(expanded, direct);
+    }
+
+    #[test]
     fn should_cache_by_project_and_fileset_combo_regardless_of_order() {
         let proj_name = "test_project";
         let first_file_sets = &[
@@ -331,15 +410,40 @@ mod tests {
         assert_eq!(cache.len(), 1);
         assert!(Arc::ptr_eq(&first, &second));
 
-        let paths_cache = ProjectFilePathsCache::new();
-        let first =
-            collect_project_file_paths_cached(proj_name, first_file_sets, &file_map, &paths_cache)
-                .unwrap();
-        let second =
-            collect_project_file_paths_cached(proj_name, second_file_sets, &file_map, &paths_cache)
-                .unwrap();
+        let indices_cache = ProjectFileIndicesCache::new();
+        let first = collect_project_file_indices_cached(
+            proj_name,
+            first_file_sets,
+            &file_map,
+            &indices_cache,
+        )
+        .unwrap();
+        let second = collect_project_file_indices_cached(
+            proj_name,
+            second_file_sets,
+            &file_map,
+            &indices_cache,
+        )
+        .unwrap();
 
-        assert_eq!(paths_cache.len(), 1);
+        assert_eq!(indices_cache.len(), 1);
         assert!(Arc::ptr_eq(&first, &second));
+
+        // Paths expand identically regardless of which fileset ordering asks for them.
+        let paths_first = collect_project_file_paths_cached(
+            proj_name,
+            first_file_sets,
+            &file_map,
+            &indices_cache,
+        )
+        .unwrap();
+        let paths_second = collect_project_file_paths_cached(
+            proj_name,
+            second_file_sets,
+            &file_map,
+            &indices_cache,
+        )
+        .unwrap();
+        assert_eq!(paths_first, paths_second);
     }
 }

--- a/packages/nx/src/native/tasks/hashers/hash_project_files.rs
+++ b/packages/nx/src/native/tasks/hashers/hash_project_files.rs
@@ -14,8 +14,8 @@ pub(crate) type ProjectFileSetCache = OnceCache<String>;
 
 /// Compute-once cache for the matched file *indices* of a project fileset,
 /// into that project's `project_file_map` vec. Persistable: 4 bytes/file and
-/// references the immutable FileData snapshot, so it never goes stale — the
-/// same guarantee `ProjectFileSetCache` relies on. Paths are expanded from it
+/// references the immutable FileData snapshot, so it never goes stale (the
+/// same guarantee `ProjectFileSetCache` relies on). Paths are expanded from it
 /// per call and freed once handed to the input subscriber.
 pub(crate) type ProjectFileIndicesCache = OnceCache<Vec<u32>>;
 
@@ -80,7 +80,7 @@ pub fn collect_project_file_paths(
 
 /// The matched file indices of a project fileset, into `project_file_map[project_name]`,
 /// in the same project-file-map order `collect_project_file_paths` yields.
-pub fn collect_project_file_indices(
+fn collect_project_file_indices(
     project_name: &str,
     file_sets: &[String],
     project_file_map: &HashMap<String, Vec<FileData>>,
@@ -99,7 +99,7 @@ pub fn collect_project_file_indices(
     )
 }
 
-pub(crate) fn collect_project_file_indices_cached(
+fn collect_project_file_indices_cached(
     project_name: &str,
     file_sets: &[String],
     project_file_map: &HashMap<String, Vec<FileData>>,

--- a/packages/nx/src/native/tasks/hashers/hash_project_files.rs
+++ b/packages/nx/src/native/tasks/hashers/hash_project_files.rs
@@ -8,13 +8,14 @@ use super::once_cache::OnceCache;
 use crate::native::glob::build_glob_set;
 use crate::native::types::FileData;
 
-/// Result of hashing project files, including the matched file paths
-pub struct ProjectFilesHashResult {
-    pub hash: String,
-    pub files: Vec<String>,
-}
+/// Compute-once cache for project fileset hashes. Holds only the hash, so
+/// retaining it for the TaskHasher lifetime stays O(projects), not O(files).
+pub(crate) type ProjectFileSetCache = OnceCache<String>;
 
-pub(crate) type ProjectFileSetCache = OnceCache<ProjectFilesHashResult>;
+/// Compute-once cache for the matched file paths of a project fileset.
+/// Only populated when task inputs are collected; callers keep it
+/// per-invocation so the expanded paths are freed once that call returns.
+pub(crate) type ProjectFilePathsCache = OnceCache<Vec<String>>;
 
 fn project_file_set_cache_key(project_name: &str, file_sets: &[String]) -> String {
     let mut sorted_file_sets: Vec<&str> = file_sets.iter().map(String::as_str).collect();
@@ -27,42 +28,62 @@ fn project_file_set_cache_key(project_name: &str, file_sets: &[String]) -> Strin
     )
 }
 
-/// Hashes project files and returns both the hash and the list of matched file paths.
-/// This allows callers to reuse the file list without re-globbing.
+/// Hashes project files without materializing the matched file list.
 /// Token resolution ({projectRoot}, {projectName}) is handled upstream by the HashPlanner,
 /// so file_sets are expected to contain already-resolved paths.
-pub fn hash_project_files_with_inputs(
+pub fn hash_project_files(
     project_name: &str,
     file_sets: &[String],
     project_file_map: &HashMap<String, Vec<FileData>>,
-) -> Result<ProjectFilesHashResult> {
+) -> Result<String> {
     let _span = trace_span!("hash_project_files", project_name).entered();
     let collected_files = collect_project_files(project_name, file_sets, project_file_map)?;
     trace!("collected_files: {:?}", collected_files.len());
 
     let mut hasher = xxhash_rust::xxh3::Xxh3::new();
-    let mut files = Vec::with_capacity(collected_files.len());
 
     for file in collected_files {
         hasher.update(file.hash.as_bytes());
         hasher.update(file.file.as_bytes());
-        files.push(file.file.clone());
     }
 
-    Ok(ProjectFilesHashResult {
-        hash: hasher.digest().to_string(),
-        files,
-    })
+    Ok(hasher.digest().to_string())
 }
 
-pub(crate) fn hash_project_files_with_inputs_cached(
+pub(crate) fn hash_project_files_cached(
     project_name: &str,
     file_sets: &[String],
     project_file_map: &HashMap<String, Vec<FileData>>,
     cache: &ProjectFileSetCache,
-) -> Result<Arc<ProjectFilesHashResult>> {
+) -> Result<Arc<String>> {
     cache.get_or_try_init(project_file_set_cache_key(project_name, file_sets), || {
-        hash_project_files_with_inputs(project_name, file_sets, project_file_map)
+        hash_project_files(project_name, file_sets, project_file_map)
+    })
+}
+
+/// The matched file paths of a project fileset, in project-file-map order
+/// (the same order hashing folds them).
+pub fn collect_project_file_paths(
+    project_name: &str,
+    file_sets: &[String],
+    project_file_map: &HashMap<String, Vec<FileData>>,
+) -> Result<Vec<String>> {
+    Ok(
+        collect_project_files(project_name, file_sets, project_file_map)?
+            .into_iter()
+            .map(|file| file.file.clone())
+            .collect(),
+    )
+}
+
+pub(crate) fn collect_project_file_paths_cached(
+    project_name: &str,
+    file_sets: &[String],
+    project_file_map: &HashMap<String, Vec<FileData>>,
+    cache: &ProjectFilePathsCache,
+) -> Result<Arc<Vec<String>>> {
+    cache.get_or_try_init(project_file_set_cache_key(project_name, file_sets), || {
+        collect_project_file_paths(project_name, file_sets, project_file_map)
     })
 }
 
@@ -182,9 +203,9 @@ mod tests {
                 file_data4.clone(),
             ],
         );
-        let result = hash_project_files_with_inputs(proj_name, file_sets, &file_map).unwrap();
+        let result = hash_project_files(proj_name, file_sets, &file_map).unwrap();
         assert_eq!(
-            result.hash,
+            result,
             hash(
                 &[
                     file_data1.hash.as_bytes(),
@@ -233,9 +254,9 @@ mod tests {
                 file_data4.clone(),
             ],
         );
-        let result = hash_project_files_with_inputs(proj_name, file_sets, &file_map).unwrap();
+        let result = hash_project_files(proj_name, file_sets, &file_map).unwrap();
         assert_eq!(
-            result.hash,
+            result,
             hash(
                 &[
                     file_data1.hash.as_bytes(),
@@ -246,6 +267,33 @@ mod tests {
                 .concat()
             )
         );
+    }
+
+    #[test]
+    fn should_collect_file_paths_in_file_map_order() {
+        let proj_name = "test_project";
+        let file_sets = &["!test/root/**/*.spec.ts".to_string()];
+        let mut file_map = HashMap::new();
+        file_map.insert(
+            String::from(proj_name),
+            vec![
+                FileData {
+                    file: "test/root/test1.ts".into(),
+                    hash: "file_data1".into(),
+                },
+                FileData {
+                    file: "test/root/test.spec.ts".into(),
+                    hash: "file_data2".into(),
+                },
+                FileData {
+                    file: "test/root/test3.ts".into(),
+                    hash: "file_data3".into(),
+                },
+            ],
+        );
+
+        let paths = collect_project_file_paths(proj_name, file_sets, &file_map).unwrap();
+        assert_eq!(paths, vec!["test/root/test1.ts", "test/root/test3.ts"]);
     }
 
     #[test]
@@ -276,13 +324,22 @@ mod tests {
 
         let cache = ProjectFileSetCache::new();
         let first =
-            hash_project_files_with_inputs_cached(proj_name, first_file_sets, &file_map, &cache)
-                .unwrap();
+            hash_project_files_cached(proj_name, first_file_sets, &file_map, &cache).unwrap();
         let second =
-            hash_project_files_with_inputs_cached(proj_name, second_file_sets, &file_map, &cache)
-                .unwrap();
+            hash_project_files_cached(proj_name, second_file_sets, &file_map, &cache).unwrap();
 
         assert_eq!(cache.len(), 1);
+        assert!(Arc::ptr_eq(&first, &second));
+
+        let paths_cache = ProjectFilePathsCache::new();
+        let first =
+            collect_project_file_paths_cached(proj_name, first_file_sets, &file_map, &paths_cache)
+                .unwrap();
+        let second =
+            collect_project_file_paths_cached(proj_name, second_file_sets, &file_map, &paths_cache)
+                .unwrap();
+
+        assert_eq!(paths_cache.len(), 1);
         assert!(Arc::ptr_eq(&first, &second));
     }
 }

--- a/packages/nx/src/native/tasks/hashers/hash_workspace_files.rs
+++ b/packages/nx/src/native/tasks/hashers/hash_workspace_files.rs
@@ -14,10 +14,12 @@ use tracing::{debug, debug_span, trace, warn};
 /// retaining it for the TaskHasher lifetime stays O(filesets), not O(files).
 pub(crate) type WorkspaceFileSetCache = OnceCache<String>;
 
-/// Compute-once cache for the matched file paths of a workspace fileset.
-/// Only populated when task inputs are collected; callers keep it
-/// per-invocation so the expanded paths are freed once that call returns.
-pub(crate) type WorkspaceFilePathsCache = OnceCache<Vec<String>>;
+/// Compute-once cache for the matched file *indices* of a workspace fileset,
+/// into `all_workspace_files`. Persistable: 4 bytes/file and references the
+/// immutable FileData snapshot, so it never goes stale — the same guarantee
+/// `WorkspaceFileSetCache` relies on. Paths are expanded from it per call and
+/// freed once handed to the input subscriber.
+pub(crate) type WorkspaceFileIndicesCache = OnceCache<Vec<u32>>;
 
 fn workspace_file_set_cache_key(workspace_file_sets: &[String]) -> String {
     let mut sorted_file_sets: Vec<&str> = workspace_file_sets.iter().map(String::as_str).collect();
@@ -127,14 +129,52 @@ pub fn collect_workspace_file_paths(
         .collect())
 }
 
+/// The matched file indices of a workspace fileset, into `all_workspace_files`,
+/// in the same workspace-file order `collect_workspace_file_paths` yields.
+pub fn collect_workspace_file_indices(
+    workspace_file_sets: &[String],
+    all_workspace_files: &[FileData],
+) -> Result<Vec<u32>> {
+    let globs = globs_from_workspace_globs(workspace_file_sets);
+
+    if globs.is_empty() {
+        return Ok(vec![]);
+    }
+
+    let glob = build_glob_set(&globs)?;
+
+    Ok(all_workspace_files
+        .iter()
+        .enumerate()
+        .filter(|(_, file)| glob.is_match(&file.file))
+        .map(|(i, _)| i as u32)
+        .collect())
+}
+
+pub(crate) fn collect_workspace_file_indices_cached(
+    workspace_file_sets: &[String],
+    all_workspace_files: &[FileData],
+    cache: &WorkspaceFileIndicesCache,
+) -> Result<Arc<Vec<u32>>> {
+    cache.get_or_try_init(workspace_file_set_cache_key(workspace_file_sets), || {
+        collect_workspace_file_indices(workspace_file_sets, all_workspace_files)
+    })
+}
+
+/// Expands the cached matched-file indices into owned paths. Only the compact
+/// indices persist in `cache`; the returned paths are transient and freed by
+/// the caller once handed to the input subscriber.
 pub(crate) fn collect_workspace_file_paths_cached(
     workspace_file_sets: &[String],
     all_workspace_files: &[FileData],
-    cache: &WorkspaceFilePathsCache,
-) -> Result<Arc<Vec<String>>> {
-    cache.get_or_try_init(workspace_file_set_cache_key(workspace_file_sets), || {
-        collect_workspace_file_paths(workspace_file_sets, all_workspace_files)
-    })
+    cache: &WorkspaceFileIndicesCache,
+) -> Result<Vec<String>> {
+    let indices =
+        collect_workspace_file_indices_cached(workspace_file_sets, all_workspace_files, cache)?;
+    Ok(indices
+        .iter()
+        .map(|&i| all_workspace_files[i as usize].file.clone())
+        .collect())
 }
 
 #[cfg(test)]
@@ -244,6 +284,42 @@ mod test {
     }
 
     #[test]
+    fn indices_expand_to_the_same_paths_as_direct_collection() {
+        let all_workspace_files = vec![
+            FileData {
+                file: ".gitignore".into(),
+                hash: "123".into(),
+            },
+            FileData {
+                file: "package.json".into(),
+                hash: "789".into(),
+            },
+            FileData {
+                file: "packages/project/project.json".into(),
+                hash: "abc".into(),
+            },
+        ];
+        let file_sets = &["{workspaceRoot}/**/*.json".to_string()];
+
+        let indices = collect_workspace_file_indices(file_sets, &all_workspace_files).unwrap();
+        // Positions of the two .json files within all_workspace_files.
+        assert_eq!(indices, vec![1, 2]);
+
+        let expanded: Vec<String> = indices
+            .iter()
+            .map(|&i| all_workspace_files[i as usize].file.clone())
+            .collect();
+        let direct = collect_workspace_file_paths(file_sets, &all_workspace_files).unwrap();
+        assert_eq!(expanded, direct);
+
+        // Empty globs collect no indices, matching collect_workspace_file_paths.
+        let empty =
+            collect_workspace_file_indices(&["packages/{package}".to_string()], &all_workspace_files)
+                .unwrap();
+        assert!(empty.is_empty());
+    }
+
+    #[test]
     fn should_cache_by_fileset_combo_regardless_of_order() {
         let first_file_sets = &[
             "{workspaceRoot}/**/*".to_string(),
@@ -273,21 +349,36 @@ mod test {
         assert_eq!(cache.len(), 1);
         assert!(Arc::ptr_eq(&first, &second));
 
-        let paths_cache = WorkspaceFilePathsCache::new();
-        let first = collect_workspace_file_paths_cached(
+        let indices_cache = WorkspaceFileIndicesCache::new();
+        let first = collect_workspace_file_indices_cached(
             first_file_sets,
             &all_workspace_files,
-            &paths_cache,
+            &indices_cache,
         )
         .unwrap();
-        let second = collect_workspace_file_paths_cached(
+        let second = collect_workspace_file_indices_cached(
             second_file_sets,
             &all_workspace_files,
-            &paths_cache,
+            &indices_cache,
         )
         .unwrap();
 
-        assert_eq!(paths_cache.len(), 1);
+        assert_eq!(indices_cache.len(), 1);
         assert!(Arc::ptr_eq(&first, &second));
+
+        // Paths expand identically regardless of which fileset ordering asks for them.
+        let paths_first = collect_workspace_file_paths_cached(
+            first_file_sets,
+            &all_workspace_files,
+            &indices_cache,
+        )
+        .unwrap();
+        let paths_second = collect_workspace_file_paths_cached(
+            second_file_sets,
+            &all_workspace_files,
+            &indices_cache,
+        )
+        .unwrap();
+        assert_eq!(paths_first, paths_second);
     }
 }

--- a/packages/nx/src/native/tasks/hashers/hash_workspace_files.rs
+++ b/packages/nx/src/native/tasks/hashers/hash_workspace_files.rs
@@ -16,8 +16,8 @@ pub(crate) type WorkspaceFileSetCache = OnceCache<String>;
 
 /// Compute-once cache for the matched file *indices* of a workspace fileset,
 /// into `all_workspace_files`. Persistable: 4 bytes/file and references the
-/// immutable FileData snapshot, so it never goes stale — the same guarantee
-/// `WorkspaceFileSetCache` relies on. Paths are expanded from it per call and
+/// immutable FileData snapshot, so it never goes stale (the same guarantee
+/// `WorkspaceFileSetCache` relies on). Paths are expanded from it per call and
 /// freed once handed to the input subscriber.
 pub(crate) type WorkspaceFileIndicesCache = OnceCache<Vec<u32>>;
 
@@ -131,7 +131,7 @@ pub fn collect_workspace_file_paths(
 
 /// The matched file indices of a workspace fileset, into `all_workspace_files`,
 /// in the same workspace-file order `collect_workspace_file_paths` yields.
-pub fn collect_workspace_file_indices(
+fn collect_workspace_file_indices(
     workspace_file_sets: &[String],
     all_workspace_files: &[FileData],
 ) -> Result<Vec<u32>> {
@@ -151,7 +151,7 @@ pub fn collect_workspace_file_indices(
         .collect())
 }
 
-pub(crate) fn collect_workspace_file_indices_cached(
+fn collect_workspace_file_indices_cached(
     workspace_file_sets: &[String],
     all_workspace_files: &[FileData],
     cache: &WorkspaceFileIndicesCache,
@@ -313,9 +313,11 @@ mod test {
         assert_eq!(expanded, direct);
 
         // Empty globs collect no indices, matching collect_workspace_file_paths.
-        let empty =
-            collect_workspace_file_indices(&["packages/{package}".to_string()], &all_workspace_files)
-                .unwrap();
+        let empty = collect_workspace_file_indices(
+            &["packages/{package}".to_string()],
+            &all_workspace_files,
+        )
+        .unwrap();
         assert!(empty.is_empty());
     }
 

--- a/packages/nx/src/native/tasks/hashers/hash_workspace_files.rs
+++ b/packages/nx/src/native/tasks/hashers/hash_workspace_files.rs
@@ -10,13 +10,14 @@ use crate::native::types::FileData;
 use anyhow::*;
 use tracing::{debug, debug_span, trace, warn};
 
-/// Result of hashing workspace files, including the matched file paths
-pub struct WorkspaceFilesHashResult {
-    pub hash: String,
-    pub files: Vec<String>,
-}
+/// Compute-once cache for workspace fileset hashes. Holds only the hash, so
+/// retaining it for the TaskHasher lifetime stays O(filesets), not O(files).
+pub(crate) type WorkspaceFileSetCache = OnceCache<String>;
 
-pub(crate) type WorkspaceFileSetCache = OnceCache<WorkspaceFilesHashResult>;
+/// Compute-once cache for the matched file paths of a workspace fileset.
+/// Only populated when task inputs are collected; callers keep it
+/// per-invocation so the expanded paths are freed once that call returns.
+pub(crate) type WorkspaceFilePathsCache = OnceCache<Vec<String>>;
 
 fn workspace_file_set_cache_key(workspace_file_sets: &[String]) -> String {
     let mut sorted_file_sets: Vec<&str> = workspace_file_sets.iter().map(String::as_str).collect();
@@ -64,26 +65,22 @@ pub fn get_workspace_files<'a, 'b>(
     glob_files(all_workspace_files, globs, None)
 }
 
-/// Hash workspace files and return both the hash and the list of matched file paths.
-pub fn hash_workspace_files_with_inputs(
+/// Hashes workspace files without materializing the matched file list.
+pub fn hash_workspace_files(
     workspace_file_sets: &[String],
     all_workspace_files: &[FileData],
-) -> Result<WorkspaceFilesHashResult> {
+) -> Result<String> {
     let globs = globs_from_workspace_globs(workspace_file_sets);
 
     if globs.is_empty() {
-        return Ok(WorkspaceFilesHashResult {
-            hash: hash(b""),
-            files: vec![],
-        });
+        return Ok(hash(b""));
     }
 
     let glob = build_glob_set(&globs)?;
 
     let mut hasher = xxhash_rust::xxh3::Xxh3::new();
-    let mut files = Vec::new();
 
-    debug_span!("Hashing workspace fileset with inputs").in_scope(|| {
+    debug_span!("Hashing workspace fileset").in_scope(|| {
         for file in all_workspace_files
             .iter()
             .filter(|file| glob.is_match(&file.file))
@@ -91,25 +88,52 @@ pub fn hash_workspace_files_with_inputs(
             debug!("Adding {:?} ({:?}) to hash", file.hash, file.file);
             hasher.update(file.file.as_bytes());
             hasher.update(file.hash.as_bytes());
-            files.push(file.file.clone());
         }
         let hashed_value = hasher.digest().to_string();
         debug!("Hash Value: {:?}", hashed_value);
 
-        Ok(WorkspaceFilesHashResult {
-            hash: hashed_value,
-            files,
-        })
+        Ok(hashed_value)
     })
 }
 
-pub(crate) fn hash_workspace_files_with_inputs_cached(
+pub(crate) fn hash_workspace_files_cached(
     workspace_file_sets: &[String],
     all_workspace_files: &[FileData],
     cache: &WorkspaceFileSetCache,
-) -> Result<Arc<WorkspaceFilesHashResult>> {
+) -> Result<Arc<String>> {
     cache.get_or_try_init(workspace_file_set_cache_key(workspace_file_sets), || {
-        hash_workspace_files_with_inputs(workspace_file_sets, all_workspace_files)
+        hash_workspace_files(workspace_file_sets, all_workspace_files)
+    })
+}
+
+/// The matched file paths of a workspace fileset, in workspace-file order
+/// (the same order hashing folds them).
+pub fn collect_workspace_file_paths(
+    workspace_file_sets: &[String],
+    all_workspace_files: &[FileData],
+) -> Result<Vec<String>> {
+    let globs = globs_from_workspace_globs(workspace_file_sets);
+
+    if globs.is_empty() {
+        return Ok(vec![]);
+    }
+
+    let glob = build_glob_set(&globs)?;
+
+    Ok(all_workspace_files
+        .iter()
+        .filter(|file| glob.is_match(&file.file))
+        .map(|file| file.file.clone())
+        .collect())
+}
+
+pub(crate) fn collect_workspace_file_paths_cached(
+    workspace_file_sets: &[String],
+    all_workspace_files: &[FileData],
+    cache: &WorkspaceFilePathsCache,
+) -> Result<Arc<Vec<String>>> {
+    cache.get_or_try_init(workspace_file_set_cache_key(workspace_file_sets), || {
+        collect_workspace_file_paths(workspace_file_sets, all_workspace_files)
     })
 }
 
@@ -121,9 +145,8 @@ mod test {
 
     #[test]
     fn invalid_workspace_input_is_just_empty_hash() {
-        let result =
-            hash_workspace_files_with_inputs(&["packages/{package}".to_string()], &[]).unwrap();
-        assert_eq!(result.hash, hash(b""));
+        let result = hash_workspace_files(&["packages/{package}".to_string()], &[]).unwrap();
+        assert_eq!(result, hash(b""));
     }
 
     #[test]
@@ -144,7 +167,7 @@ mod test {
             file: "packages/project/project.json".into(),
             hash: "abc".into(),
         };
-        let result = hash_workspace_files_with_inputs(
+        let result = hash_workspace_files(
             &["{workspaceRoot}/.gitignore".to_string()],
             &[
                 gitignore_file.clone(),
@@ -154,7 +177,7 @@ mod test {
             ],
         )
         .unwrap();
-        assert_eq!(result.hash, "15841935230129999746");
+        assert_eq!(result, "15841935230129999746");
     }
 
     #[test]
@@ -176,7 +199,7 @@ mod test {
             hash: "abc".into(),
         };
         for _ in 0..1000 {
-            let result = hash_workspace_files_with_inputs(
+            let result = hash_workspace_files(
                 &["{workspaceRoot}/**/*".to_string()],
                 &[
                     gitignore_file.clone(),
@@ -186,8 +209,38 @@ mod test {
                 ],
             )
             .unwrap();
-            assert_eq!(result.hash, "13759877301064854697");
+            assert_eq!(result, "13759877301064854697");
         }
+    }
+
+    #[test]
+    fn should_collect_file_paths_in_workspace_file_order() {
+        let all_workspace_files = vec![
+            FileData {
+                file: ".gitignore".into(),
+                hash: "123".into(),
+            },
+            FileData {
+                file: "package.json".into(),
+                hash: "789".into(),
+            },
+            FileData {
+                file: "packages/project/project.json".into(),
+                hash: "abc".into(),
+            },
+        ];
+
+        let paths = collect_workspace_file_paths(
+            &["{workspaceRoot}/**/*.json".to_string()],
+            &all_workspace_files,
+        )
+        .unwrap();
+        assert_eq!(paths, vec!["package.json", "packages/project/project.json"]);
+
+        let paths =
+            collect_workspace_file_paths(&["packages/{package}".to_string()], &all_workspace_files)
+                .unwrap();
+        assert!(paths.is_empty());
     }
 
     #[test]
@@ -213,13 +266,28 @@ mod test {
 
         let cache = WorkspaceFileSetCache::new();
         let first =
-            hash_workspace_files_with_inputs_cached(first_file_sets, &all_workspace_files, &cache)
-                .unwrap();
+            hash_workspace_files_cached(first_file_sets, &all_workspace_files, &cache).unwrap();
         let second =
-            hash_workspace_files_with_inputs_cached(second_file_sets, &all_workspace_files, &cache)
-                .unwrap();
+            hash_workspace_files_cached(second_file_sets, &all_workspace_files, &cache).unwrap();
 
         assert_eq!(cache.len(), 1);
+        assert!(Arc::ptr_eq(&first, &second));
+
+        let paths_cache = WorkspaceFilePathsCache::new();
+        let first = collect_workspace_file_paths_cached(
+            first_file_sets,
+            &all_workspace_files,
+            &paths_cache,
+        )
+        .unwrap();
+        let second = collect_workspace_file_paths_cached(
+            second_file_sets,
+            &all_workspace_files,
+            &paths_cache,
+        )
+        .unwrap();
+
+        assert_eq!(paths_cache.len(), 1);
         assert!(Arc::ptr_eq(&first, &second));
     }
 }

--- a/packages/nx/src/native/tasks/task_hasher.rs
+++ b/packages/nx/src/native/tasks/task_hasher.rs
@@ -8,7 +8,7 @@ use crate::native::{
     hasher::hash,
     project_graph::{types::ProjectGraph, utils::create_project_root_mappings},
     tasks::types::{HashInstruction, HashPlans},
-    types::NapiDashMap,
+    types::{NapiDashMap, SharedStr},
 };
 use crate::native::{
     project_graph::utils::ProjectRootMappings,
@@ -131,7 +131,11 @@ impl From<HashInputsBuilder> for HashInputs {
 #[derive(Debug)]
 pub struct HashDetails {
     pub value: String,
-    pub details: HashMap<String, String>,
+    // Keys and values are shared Arcs: the same instruction key and hash
+    // value appear in the details of every task that depends on the input,
+    // so per-map owned strings would duplicate them once per task.
+    #[napi(ts_type = "Record<string, string>")]
+    pub details: HashMap<SharedStr, SharedStr>,
     /// Structured inputs used for hashing (file patterns, env vars, etc.)
     pub inputs: HashInputs,
 }
@@ -139,6 +143,38 @@ pub struct HashDetails {
 #[napi(object)]
 pub struct HasherOptions {
     pub selectively_hash_ts_config: bool,
+}
+
+/// Return type of `hash_plans`. Converts like the wrapped map, but shares one
+/// JS string per unique details value for the duration of the conversion.
+/// napi sets map keys as object property names, so they do not flow through
+/// `SharedStr::to_napi_value`; without this cache, each repeated hash value
+/// would materialize as a separate JS string while converting the result.
+pub struct TaskHashes(pub NapiDashMap<String, HashDetails>);
+
+impl ToNapiValue for TaskHashes {
+    unsafe fn to_napi_value(env: sys::napi_env, val: Self) -> napi::Result<sys::napi_value> {
+        let _guard = SharedStr::install_handle_cache();
+        unsafe { NapiDashMap::to_napi_value(env, val.0) }
+    }
+}
+
+/// Returns the shared Arc for `value`, allocating it on first sight. An
+/// input's hash is identical for every task that depends on it, so the same
+/// value string comes back once per downstream task; interning keeps one
+/// allocation per unique value.
+fn intern_value(interner: &DashMap<String, Arc<str>>, value: String) -> Arc<str> {
+    if let Some(existing) = interner.get(&value) {
+        return existing.clone();
+    }
+    match interner.entry(value) {
+        dashmap::mapref::entry::Entry::Occupied(existing) => existing.get().clone(),
+        dashmap::mapref::entry::Entry::Vacant(vacant) => {
+            let shared: Arc<str> = Arc::from(vacant.key().as_str());
+            vacant.insert(shared.clone());
+            shared
+        }
+    }
 }
 
 #[napi]
@@ -209,7 +245,7 @@ impl TaskHasher {
         per_task_envs: HashMap<String, HashMap<String, String>>,
         cwd: String,
         collect_task_inputs: Option<bool>,
-    ) -> anyhow::Result<NapiDashMap<String, HashDetails>> {
+    ) -> anyhow::Result<TaskHashes> {
         for task_id in hash_plans.plans.keys() {
             if !per_task_envs.contains_key(task_id) {
                 anyhow::bail!("hash_plans: missing env entry for task {}", task_id);
@@ -228,7 +264,7 @@ impl TaskHasher {
         cwd: String,
         collect_task_inputs: Option<bool>,
         resolve_env: F,
-    ) -> anyhow::Result<NapiDashMap<String, HashDetails>>
+    ) -> anyhow::Result<TaskHashes>
     where
         F: Fn(&str) -> &'a HashMap<String, String> + Sync,
     {
@@ -241,6 +277,8 @@ impl TaskHasher {
         // expanded fileset file lists are freed once this call returns.
         let project_file_paths_cache = ProjectFilePathsCache::new();
         let workspace_file_paths_cache = WorkspaceFilePathsCache::new();
+        // Deduplicates hash values across tasks; see intern_value.
+        let value_interner: DashMap<String, Arc<str>> = DashMap::new();
         let should_collect_inputs = collect_task_inputs.unwrap_or(false);
 
         let function_start = std::time::Instant::now();
@@ -284,7 +322,7 @@ impl TaskHasher {
             .par_bridge()
             .try_for_each(|(task_id, id)| {
                 let instruction_ref = pool.get(id);
-                let (instruction_key, hash_value, inputs) = self.hash_instruction(
+                let (hash_value, inputs) = self.hash_instruction(
                     task_id,
                     instruction_ref.value(),
                     HashInstructionArgs {
@@ -313,7 +351,10 @@ impl TaskHasher {
                         details: HashMap::new(),
                         inputs: HashInputs::default(),
                     });
-                entry.details.insert(instruction_key, hash_value);
+                entry.details.insert(
+                    pool.key(id).into(),
+                    intern_value(&value_interner, hash_value).into(),
+                );
 
                 // Accumulate inputs using HashSet for O(1) deduplication (only when collecting)
                 if let Some(ref accum) = inputs_accum {
@@ -360,7 +401,7 @@ impl TaskHasher {
             assemble_duration
         );
 
-        Ok(hashes)
+        Ok(TaskHashes(hashes))
     }
 
     fn hash_instruction(
@@ -383,7 +424,7 @@ impl TaskHasher {
             cwd,
             collect_inputs,
         }: HashInstructionArgs,
-    ) -> anyhow::Result<(String, String, HashInputsBuilder)> {
+    ) -> anyhow::Result<(String, HashInputsBuilder)> {
         let now = std::time::Instant::now();
         let span = trace_span!("hashing", task_id).entered();
         let empty = HashInputsBuilder::default();
@@ -606,7 +647,7 @@ impl TaskHasher {
                 (cached_entry.hash, inputs)
             }
         };
-        Ok((instruction.to_string(), hash, inputs))
+        Ok((hash, inputs))
     }
 }
 
@@ -625,4 +666,23 @@ struct HashInstructionArgs<'a> {
     json_file_set_cache: &'a DashMap<String, JsonHashResult>,
     cwd: &'a std::path::Path,
     collect_inputs: bool,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn intern_value_shares_one_allocation_per_unique_value() {
+        let interner: DashMap<String, Arc<str>> = DashMap::new();
+
+        let first = intern_value(&interner, "12345".to_string());
+        let second = intern_value(&interner, "12345".to_string());
+        let other = intern_value(&interner, "67890".to_string());
+
+        assert_eq!(&*first, "12345");
+        assert!(Arc::ptr_eq(&first, &second));
+        assert!(!Arc::ptr_eq(&first, &other));
+        assert_eq!(interner.len(), 2);
+    }
 }

--- a/packages/nx/src/native/tasks/task_hasher.rs
+++ b/packages/nx/src/native/tasks/task_hasher.rs
@@ -16,8 +16,8 @@ use crate::native::{
 };
 use crate::native::{
     tasks::hashers::{
-        CachedTaskOutput, JsonHashResult, ProjectFilePathsCache, ProjectFileSetCache,
-        WorkspaceFilePathsCache, WorkspaceFileSetCache, collect_project_file_paths_cached,
+        CachedTaskOutput, JsonHashResult, ProjectFileIndicesCache, ProjectFileSetCache,
+        WorkspaceFileIndicesCache, WorkspaceFileSetCache, collect_project_file_paths_cached,
         collect_workspace_file_paths_cached, hash_all_externals, hash_external, hash_json_files,
         hash_project_config, hash_project_files_cached, hash_task_output,
         hash_tsconfig_selectively, hash_workspace_files_cached,
@@ -190,11 +190,15 @@ pub struct TaskHasher {
     options: Option<HasherOptions>,
     external_cache: Arc<DashMap<String, String>>,
     // Persisted across hash_plans() calls: they only fold the immutable FileData
-    // snapshot, so they never go stale. Hash-only: matched file lists are only
-    // expanded per-invocation when inputs are collected. (Live-disk/exec caches
-    // stay per-call, see below.)
+    // snapshot, so they never go stale. The set caches are hash-only; the indices
+    // caches hold the matched files' positions in that snapshot (4 bytes each, not
+    // the path strings) and are only populated when inputs are collected. Paths are
+    // expanded from the indices per call. (Live-disk/exec caches stay per-call, see
+    // below.)
     workspace_file_set_cache: WorkspaceFileSetCache,
     project_file_set_cache: ProjectFileSetCache,
+    workspace_file_indices_cache: WorkspaceFileIndicesCache,
+    project_file_indices_cache: ProjectFileIndicesCache,
     // Fold over all externals; identical for every task, so computed once.
     all_externals_hash: OnceCell<String>,
 }
@@ -228,6 +232,8 @@ impl TaskHasher {
             external_cache: Arc::new(DashMap::new()),
             workspace_file_set_cache: WorkspaceFileSetCache::new(),
             project_file_set_cache: ProjectFileSetCache::new(),
+            workspace_file_indices_cache: WorkspaceFileIndicesCache::new(),
+            project_file_indices_cache: ProjectFileIndicesCache::new(),
             all_externals_hash: OnceCell::new(),
         }
     }
@@ -274,10 +280,6 @@ impl TaskHasher {
         let task_output_cache = DashMap::new();
         let runtime_cache: DashMap<String, String> = DashMap::new();
         let json_file_set_cache: DashMap<String, JsonHashResult> = DashMap::new();
-        // Per-invocation and only populated when collecting inputs, so the
-        // expanded fileset file lists are freed once this call returns.
-        let project_file_paths_cache = ProjectFilePathsCache::new();
-        let workspace_file_paths_cache = WorkspaceFilePathsCache::new();
         // Deduplicates env-dependent hash values (Environment, Runtime)
         // across tasks; see intern_value. Other instruction types share
         // values through per-id slots instead.
@@ -377,8 +379,6 @@ impl TaskHasher {
                                 runtime_cache: &runtime_cache,
                                 project_file_set_cache: &self.project_file_set_cache,
                                 workspace_file_set_cache: &self.workspace_file_set_cache,
-                                project_file_paths_cache: &project_file_paths_cache,
-                                workspace_file_paths_cache: &workspace_file_paths_cache,
                                 json_file_set_cache: &json_file_set_cache,
                                 cwd: cwd_path,
                                 collect_inputs: should_collect_inputs,
@@ -466,8 +466,6 @@ impl TaskHasher {
             runtime_cache,
             project_file_set_cache,
             workspace_file_set_cache,
-            project_file_paths_cache,
-            workspace_file_paths_cache,
             json_file_set_cache,
             cwd,
             collect_inputs,
@@ -488,10 +486,10 @@ impl TaskHasher {
                     let files = collect_workspace_file_paths_cached(
                         workspace_file_set,
                         &self.all_workspace_files,
-                        workspace_file_paths_cache,
+                        &self.workspace_file_indices_cache,
                     )?;
                     HashInputsBuilder {
-                        files: files.iter().cloned().collect(),
+                        files: files.into_iter().collect(),
                         ..Default::default()
                     }
                 } else {
@@ -539,10 +537,10 @@ impl TaskHasher {
                         project_name,
                         file_sets,
                         &self.project_file_map,
-                        project_file_paths_cache,
+                        &self.project_file_indices_cache,
                     )?;
                     HashInputsBuilder {
-                        files: files.iter().cloned().collect(),
+                        files: files.into_iter().collect(),
                         ..Default::default()
                     }
                 } else {
@@ -709,8 +707,6 @@ struct HashInstructionArgs<'a> {
     runtime_cache: &'a DashMap<String, String>,
     project_file_set_cache: &'a ProjectFileSetCache,
     workspace_file_set_cache: &'a WorkspaceFileSetCache,
-    project_file_paths_cache: &'a ProjectFilePathsCache,
-    workspace_file_paths_cache: &'a WorkspaceFilePathsCache,
     json_file_set_cache: &'a DashMap<String, JsonHashResult>,
     cwd: &'a std::path::Path,
     collect_inputs: bool,

--- a/packages/nx/src/native/tasks/task_hasher.rs
+++ b/packages/nx/src/native/tasks/task_hasher.rs
@@ -159,9 +159,10 @@ impl ToNapiValue for TaskHashes {
     }
 }
 
-/// Returns the shared Arc for `value`, allocating it on first sight. An
-/// input's hash is identical for every task that depends on it, so the same
-/// value string comes back once per downstream task; interning keeps one
+/// Returns the shared Arc for `value`, allocating it on first sight. Only
+/// Environment and Runtime values flow through here: they depend on the
+/// task's env, so they cannot live in the shared per-id slots, but tasks
+/// whose envs agree still produce identical strings; interning keeps one
 /// allocation per unique value.
 fn intern_value(interner: &DashMap<String, Arc<str>>, value: String) -> Arc<str> {
     if let Some(existing) = interner.get(&value) {
@@ -277,7 +278,9 @@ impl TaskHasher {
         // expanded fileset file lists are freed once this call returns.
         let project_file_paths_cache = ProjectFilePathsCache::new();
         let workspace_file_paths_cache = WorkspaceFilePathsCache::new();
-        // Deduplicates hash values across tasks; see intern_value.
+        // Deduplicates env-dependent hash values (Environment, Runtime)
+        // across tasks; see intern_value. Other instruction types share
+        // values through per-id slots instead.
         let value_interner: DashMap<String, Arc<str>> = DashMap::new();
         let should_collect_inputs = collect_task_inputs.unwrap_or(false);
 
@@ -315,6 +318,19 @@ impl TaskHasher {
         let cwd_path = std::path::Path::new(&cwd);
 
         let pool = &hash_plans.pool;
+        // Id-indexed snapshots so the hot loop reads a plain Vec instead of
+        // taking a DashMap shard lock per (task, instruction) entry. Every
+        // instruction except Environment and Runtime (whose values depend on
+        // the task's env) hashes to the same value for every task within an
+        // invocation, so its value lives in a per-id slot: a filled OnceCell
+        // is an atomic load, and it lets the loop skip hash_instruction
+        // entirely when inputs are not collected.
+        let instruction_keys: Vec<SharedStr> = (0..pool.len() as u32)
+            .map(|id| SharedStr::from(pool.key(id)))
+            .collect();
+        let value_slots: Vec<OnceCell<SharedStr>> = std::iter::repeat_with(OnceCell::new)
+            .take(pool.len())
+            .collect();
         hash_plans
             .plans
             .iter()
@@ -322,26 +338,64 @@ impl TaskHasher {
             .par_bridge()
             .try_for_each(|(task_id, id)| {
                 let instruction_ref = pool.get(id);
-                let (hash_value, inputs) = self.hash_instruction(
-                    task_id,
-                    instruction_ref.value(),
-                    HashInstructionArgs {
-                        js_env: resolve_env(task_id),
-                        ts_config_hash: &ts_config_hash,
-                        project_root_mappings: &project_root_mappings,
-                        sorted_externals: &sorted_externals,
-                        selectively_hash_tsconfig,
-                        task_output_cache: &task_output_cache,
-                        runtime_cache: &runtime_cache,
-                        project_file_set_cache: &self.project_file_set_cache,
-                        workspace_file_set_cache: &self.workspace_file_set_cache,
-                        project_file_paths_cache: &project_file_paths_cache,
-                        workspace_file_paths_cache: &workspace_file_paths_cache,
-                        json_file_set_cache: &json_file_set_cache,
-                        cwd: cwd_path,
-                        collect_inputs: should_collect_inputs,
-                    },
-                )?;
+                // Env-dependent values cannot be shared across tasks. The
+                // match is exhaustive so a new instruction type must be
+                // classified here before it can ride the shared slots.
+                let slot = match instruction_ref.value() {
+                    HashInstruction::Environment(_) | HashInstruction::Runtime(_) => None,
+                    HashInstruction::WorkspaceFileSet(_)
+                    | HashInstruction::Cwd(_)
+                    | HashInstruction::ProjectFileSet(_, _)
+                    | HashInstruction::ProjectConfiguration(_)
+                    | HashInstruction::TsConfiguration(_)
+                    | HashInstruction::TaskOutput(_, _)
+                    | HashInstruction::External(_)
+                    | HashInstruction::AllExternalDependencies
+                    | HashInstruction::JsonFileSet(_) => Some(&value_slots[id as usize]),
+                };
+
+                let cached = if should_collect_inputs {
+                    // Inputs are per task, so every entry must run
+                    // hash_instruction to produce them.
+                    None
+                } else {
+                    slot.and_then(|s| s.get()).cloned()
+                };
+                let value = match cached {
+                    Some(value) => value,
+                    None => {
+                        let (hash_value, inputs) = self.hash_instruction(
+                            task_id,
+                            instruction_ref.value(),
+                            HashInstructionArgs {
+                                js_env: resolve_env(task_id),
+                                ts_config_hash: &ts_config_hash,
+                                project_root_mappings: &project_root_mappings,
+                                sorted_externals: &sorted_externals,
+                                selectively_hash_tsconfig,
+                                task_output_cache: &task_output_cache,
+                                runtime_cache: &runtime_cache,
+                                project_file_set_cache: &self.project_file_set_cache,
+                                workspace_file_set_cache: &self.workspace_file_set_cache,
+                                project_file_paths_cache: &project_file_paths_cache,
+                                workspace_file_paths_cache: &workspace_file_paths_cache,
+                                json_file_set_cache: &json_file_set_cache,
+                                cwd: cwd_path,
+                                collect_inputs: should_collect_inputs,
+                            },
+                        )?;
+
+                        // Accumulate inputs using HashSet for O(1) deduplication (only when collecting)
+                        if let Some(ref accum) = inputs_accum {
+                            accum.entry(task_id.to_string()).or_default().extend(inputs);
+                        }
+
+                        match slot {
+                            Some(slot) => slot.get_or_init(|| SharedStr::from(hash_value)).clone(),
+                            None => intern_value(&value_interner, hash_value).into(),
+                        }
+                    }
+                };
 
                 // Accumulate hash details
                 let mut entry = hashes
@@ -351,15 +405,9 @@ impl TaskHasher {
                         details: HashMap::new(),
                         inputs: HashInputs::default(),
                     });
-                entry.details.insert(
-                    pool.key(id).into(),
-                    intern_value(&value_interner, hash_value).into(),
-                );
-
-                // Accumulate inputs using HashSet for O(1) deduplication (only when collecting)
-                if let Some(ref accum) = inputs_accum {
-                    accum.entry(task_id.to_string()).or_default().extend(inputs);
-                }
+                entry
+                    .details
+                    .insert(instruction_keys[id as usize].clone(), value);
 
                 Ok::<(), anyhow::Error>(())
             })?;

--- a/packages/nx/src/native/tasks/task_hasher.rs
+++ b/packages/nx/src/native/tasks/task_hasher.rs
@@ -16,10 +16,11 @@ use crate::native::{
 };
 use crate::native::{
     tasks::hashers::{
-        CachedTaskOutput, JsonHashResult, ProjectFileSetCache, WorkspaceFileSetCache,
-        hash_all_externals, hash_external, hash_json_files, hash_project_config,
-        hash_project_files_with_inputs_cached, hash_task_output, hash_tsconfig_selectively,
-        hash_workspace_files_with_inputs_cached,
+        CachedTaskOutput, JsonHashResult, ProjectFilePathsCache, ProjectFileSetCache,
+        WorkspaceFilePathsCache, WorkspaceFileSetCache, collect_project_file_paths_cached,
+        collect_workspace_file_paths_cached, hash_all_externals, hash_external, hash_json_files,
+        hash_project_config, hash_project_files_cached, hash_task_output,
+        hash_tsconfig_selectively, hash_workspace_files_cached,
     },
     types::FileData,
     workspace::types::ProjectFiles,
@@ -152,7 +153,9 @@ pub struct TaskHasher {
     options: Option<HasherOptions>,
     external_cache: Arc<DashMap<String, String>>,
     // Persisted across hash_plans() calls: they only fold the immutable FileData
-    // snapshot, so they never go stale. (Live-disk/exec caches stay per-call — see below.)
+    // snapshot, so they never go stale. Hash-only: matched file lists are only
+    // expanded per-invocation when inputs are collected. (Live-disk/exec caches
+    // stay per-call, see below.)
     workspace_file_set_cache: WorkspaceFileSetCache,
     project_file_set_cache: ProjectFileSetCache,
     // Fold over all externals; identical for every task, so computed once.
@@ -234,6 +237,10 @@ impl TaskHasher {
         let task_output_cache = DashMap::new();
         let runtime_cache: DashMap<String, String> = DashMap::new();
         let json_file_set_cache: DashMap<String, JsonHashResult> = DashMap::new();
+        // Per-invocation and only populated when collecting inputs, so the
+        // expanded fileset file lists are freed once this call returns.
+        let project_file_paths_cache = ProjectFilePathsCache::new();
+        let workspace_file_paths_cache = WorkspaceFilePathsCache::new();
         let should_collect_inputs = collect_task_inputs.unwrap_or(false);
 
         let function_start = std::time::Instant::now();
@@ -290,6 +297,8 @@ impl TaskHasher {
                         runtime_cache: &runtime_cache,
                         project_file_set_cache: &self.project_file_set_cache,
                         workspace_file_set_cache: &self.workspace_file_set_cache,
+                        project_file_paths_cache: &project_file_paths_cache,
+                        workspace_file_paths_cache: &workspace_file_paths_cache,
                         json_file_set_cache: &json_file_set_cache,
                         cwd: cwd_path,
                         collect_inputs: should_collect_inputs,
@@ -368,6 +377,8 @@ impl TaskHasher {
             runtime_cache,
             project_file_set_cache,
             workspace_file_set_cache,
+            project_file_paths_cache,
+            workspace_file_paths_cache,
             json_file_set_cache,
             cwd,
             collect_inputs,
@@ -378,21 +389,26 @@ impl TaskHasher {
         let empty = HashInputsBuilder::default();
         let (hash, inputs) = match instruction {
             HashInstruction::WorkspaceFileSet(workspace_file_set) => {
-                let cached_entry = hash_workspace_files_with_inputs_cached(
+                let hashed = hash_workspace_files_cached(
                     workspace_file_set,
                     &self.all_workspace_files,
                     workspace_file_set_cache,
                 )?;
                 trace!(parent: &span, "hash_workspace_files: {:?}", now.elapsed());
                 let inputs = if collect_inputs {
+                    let files = collect_workspace_file_paths_cached(
+                        workspace_file_set,
+                        &self.all_workspace_files,
+                        workspace_file_paths_cache,
+                    )?;
                     HashInputsBuilder {
-                        files: cached_entry.files.iter().cloned().collect(),
+                        files: files.iter().cloned().collect(),
                         ..Default::default()
                     }
                 } else {
                     empty
                 };
-                (cached_entry.hash.clone(), inputs)
+                ((*hashed).clone(), inputs)
             }
             HashInstruction::Runtime(runtime) => {
                 let hashed_runtime =
@@ -422,7 +438,7 @@ impl TaskHasher {
                 (hashed_cwd, empty)
             }
             HashInstruction::ProjectFileSet(project_name, file_sets) => {
-                let cached_entry = hash_project_files_with_inputs_cached(
+                let hashed = hash_project_files_cached(
                     project_name,
                     file_sets,
                     &self.project_file_map,
@@ -430,14 +446,20 @@ impl TaskHasher {
                 )?;
                 trace!(parent: &span, "hash_project_files: {:?}", now.elapsed());
                 let inputs = if collect_inputs {
+                    let files = collect_project_file_paths_cached(
+                        project_name,
+                        file_sets,
+                        &self.project_file_map,
+                        project_file_paths_cache,
+                    )?;
                     HashInputsBuilder {
-                        files: cached_entry.files.iter().cloned().collect(),
+                        files: files.iter().cloned().collect(),
                         ..Default::default()
                     }
                 } else {
                     empty
                 };
-                (cached_entry.hash.clone(), inputs)
+                ((*hashed).clone(), inputs)
             }
             HashInstruction::ProjectConfiguration(project_name) => {
                 let hashed_project_config =
@@ -598,6 +620,8 @@ struct HashInstructionArgs<'a> {
     runtime_cache: &'a DashMap<String, String>,
     project_file_set_cache: &'a ProjectFileSetCache,
     workspace_file_set_cache: &'a WorkspaceFileSetCache,
+    project_file_paths_cache: &'a ProjectFilePathsCache,
+    workspace_file_paths_cache: &'a WorkspaceFilePathsCache,
     json_file_set_cache: &'a DashMap<String, JsonHashResult>,
     cwd: &'a std::path::Path,
     collect_inputs: bool,

--- a/packages/nx/src/native/tasks/types.rs
+++ b/packages/nx/src/native/tasks/types.rs
@@ -173,6 +173,9 @@ pub enum HashInstruction {
 pub struct InstructionPool {
     ids: DashMap<HashInstruction, u32>,
     items: DashMap<u32, HashInstruction>,
+    // Display strings, rendered once per unique instruction at intern time so
+    // hashing can hand out shared keys instead of re-rendering per task.
+    keys: DashMap<u32, Arc<str>>,
     next_id: AtomicU32,
 }
 
@@ -193,6 +196,7 @@ impl InstructionPool {
             dashmap::mapref::entry::Entry::Vacant(vacant) => {
                 let id = self.next_id.fetch_add(1, Ordering::Relaxed);
                 self.items.insert(id, vacant.key().clone());
+                self.keys.insert(id, Arc::from(vacant.key().to_string()));
                 vacant.insert(id);
                 id
             }
@@ -203,6 +207,15 @@ impl InstructionPool {
         self.items
             .get(&id)
             .expect("instruction ids are only handed out by intern()")
+    }
+
+    /// The instruction's Display string, shared across all tasks that
+    /// reference the instruction.
+    pub fn key(&self, id: u32) -> Arc<str> {
+        self.keys
+            .get(&id)
+            .expect("instruction ids are only handed out by intern()")
+            .clone()
     }
 
     pub fn len(&self) -> usize {
@@ -303,6 +316,18 @@ impl fmt::Display for HashInstruction {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn pool_key_matches_display_and_is_shared() {
+        let pool = InstructionPool::new();
+        let instruction = HashInstruction::ProjectConfiguration("proj".to_string());
+        let id = pool.intern(instruction.clone());
+
+        let key = pool.key(id);
+        assert_eq!(&*key, instruction.to_string());
+        // Every call hands out the same allocation, not a fresh string.
+        assert!(Arc::ptr_eq(&key, &pool.key(id)));
+    }
 
     #[test]
     fn hash_instruction_stays_small() {

--- a/packages/nx/src/native/types.rs
+++ b/packages/nx/src/native/types.rs
@@ -2,8 +2,10 @@ mod file_data;
 mod inputs;
 mod napi_dashmap;
 mod nx_json;
+mod shared_str;
 
 pub use file_data::FileData;
 pub use inputs::*;
 pub use napi_dashmap::NapiDashMap;
 pub use nx_json::*;
+pub use shared_str::SharedStr;

--- a/packages/nx/src/native/types/shared_str.rs
+++ b/packages/nx/src/native/types/shared_str.rs
@@ -1,0 +1,124 @@
+use std::cell::RefCell;
+use std::collections::HashMap;
+use std::fmt;
+use std::ops::Deref;
+use std::sync::Arc;
+
+use napi::bindgen_prelude::{FromNapiValue, ToNapiValue, TypeName, ValidateNapiValue, ValueType};
+use napi::sys;
+
+thread_local! {
+    // Maps Arc address -> the JS string already created for it in the current
+    // conversion. The Arc is kept alive in the entry so its address cannot be
+    // freed and reused for a different string while the cache holds it.
+    static HANDLE_CACHE: RefCell<Option<HashMap<usize, (Arc<str>, sys::napi_value)>>> =
+        const { RefCell::new(None) };
+}
+
+/// Clears the handle cache when the installing conversion finishes.
+pub struct SharedStrHandleCacheGuard {
+    // !Send: napi handles are only valid on the JS thread that created them.
+    _not_send: std::marker::PhantomData<*const ()>,
+}
+
+impl Drop for SharedStrHandleCacheGuard {
+    fn drop(&mut self) {
+        HANDLE_CACHE.with(|cache| *cache.borrow_mut() = None);
+    }
+}
+
+/// A reference-counted immutable string that crosses the napi boundary as a
+/// plain JS string. Use it for map keys/values that repeat across many
+/// entries (e.g. per-task hash details on large graphs): clones share one
+/// allocation instead of duplicating the bytes per entry.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub struct SharedStr(Arc<str>);
+
+impl SharedStr {
+    /// Until the returned guard drops, `to_napi_value` calls on this thread
+    /// create one JS string per unique Arc and reuse its handle for every
+    /// clone. napi handles are only valid within the native call that created
+    /// them, so install this around a single synchronous conversion and let
+    /// the guard drop before returning to JS. Not reentrant: a nested install
+    /// replaces the current cache.
+    pub fn install_handle_cache() -> SharedStrHandleCacheGuard {
+        HANDLE_CACHE.with(|cache| *cache.borrow_mut() = Some(HashMap::new()));
+        SharedStrHandleCacheGuard {
+            _not_send: std::marker::PhantomData,
+        }
+    }
+}
+
+impl From<String> for SharedStr {
+    fn from(value: String) -> Self {
+        Self(Arc::from(value))
+    }
+}
+
+impl From<Arc<str>> for SharedStr {
+    fn from(value: Arc<str>) -> Self {
+        Self(value)
+    }
+}
+
+impl AsRef<str> for SharedStr {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl Deref for SharedStr {
+    type Target = str;
+
+    fn deref(&self) -> &str {
+        &self.0
+    }
+}
+
+impl fmt::Display for SharedStr {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl TypeName for SharedStr {
+    fn type_name() -> &'static str {
+        "string"
+    }
+
+    fn value_type() -> ValueType {
+        ValueType::String
+    }
+}
+
+impl ValidateNapiValue for SharedStr {}
+
+impl FromNapiValue for SharedStr {
+    unsafe fn from_napi_value(env: sys::napi_env, val: sys::napi_value) -> napi::Result<Self> {
+        Ok(Self(Arc::from(unsafe {
+            String::from_napi_value(env, val)
+        }?)))
+    }
+}
+
+impl ToNapiValue for SharedStr {
+    unsafe fn to_napi_value(env: sys::napi_env, val: Self) -> napi::Result<sys::napi_value> {
+        let address = Arc::as_ptr(&val.0) as *const () as usize;
+        let cached = HANDLE_CACHE.with(|cache| {
+            cache
+                .borrow()
+                .as_ref()
+                .and_then(|entries| entries.get(&address).map(|(_, handle)| *handle))
+        });
+        if let Some(handle) = cached {
+            return Ok(handle);
+        }
+        let handle = unsafe { <&str as ToNapiValue>::to_napi_value(env, &val.0) }?;
+        HANDLE_CACHE.with(|cache| {
+            if let Some(entries) = cache.borrow_mut().as_mut() {
+                entries.insert(address, (val.0.clone(), handle));
+            }
+        });
+        Ok(handle)
+    }
+}


### PR DESCRIPTION
## Current Behavior

For every (task, instruction) pair, hashing allocates an owned instruction-key string and hash-value string and keeps both in that task's hash details map. Identical keys and values recur in the details of every task that depends on the same input, so a large graph holds hundreds of thousands of duplicated strings natively, and converting the result to JS creates a separate JS string per map entry while the native maps are still alive. The task hasher's persistent fileset caches also store the full list of matched file paths alongside each fileset hash even though the lists are only consumed when task inputs are collected, and the lists are built on every cache miss when nothing will read them.

## Expected Behavior

Instruction keys are rendered once in the instruction pool and shared across all task maps, each env-independent instruction's hash value is computed once per hashing invocation and shared across every task that depends on it, details maps hold shared references, and the napi conversion reuses one JS string per unique detail value. The persistent fileset caches store only the hashes. When inputs are collected, each fileset's match persists as positions into the immutable file snapshot (4 bytes per matched file), so repeated collection reuses the match without re-globbing; paths are expanded per call and freed once hashing returns, and the hash plan inspector lists matched files without hashing. Task hash values, per-instruction details, and collected inputs are byte-identical, verified by comparing full 1000-task hash dumps between builds.

### Measurements

Peak RSS of the full Nx process tree during a cold, 100% cache-miss `nx run-many` on a synthetic workspace with 1000 projects and 500k files (node 20, daemon disabled, medians, all builds measured back-to-back on the same machine). 22.7.0-beta.0 is the last version before the memory growth reported in #36152 and is included as the baseline.

| Build | Peak RSS per process |
| --- | --- |
| 22.7.0-beta.0 | 1.270 GiB |
| master | 1.473 GiB |
| this PR | **1.291 GiB (-186 MiB vs master)** |

Peak memory drops back into the 22.7.0-beta.0 baseline's own run-to-run spread. Hashing wall time improves as well: timing `hashPlans` directly over all 1000 tasks (warm medians) gives 3150 ms on master vs 2263 ms on this PR (-28%), since shared instructions are now hashed once per invocation instead of once per dependent task; with input collection enabled the timings are on par. Separately, the fileset cache change cuts the memory the task hasher keeps alive after hashing completes (settled RSS after GC, same workspace) from ~108 MB to below the ~20 MB the measurement can resolve. With input collection enabled, the persisted match indices add no measurable retention (consistent with 4 bytes per matched file), while master retains ~42 MB more in matched-path lists on a 100-task sample.

Absolute numbers depend on the workspace shape (file count, project count, dependency density), so other workspaces will see different amounts, but the reductions reproduce consistently (run-to-run variance of 1-3%, non-overlapping distributions between master and this PR).

## Related Issue(s)

Related to #36152

## Implementation Details

- `SharedStr`, an `Arc<str>` newtype that converts to a plain JS string, keeps the details maps pointer-shared natively.
- Instruction Display strings are rendered once at intern time in the instruction pool; `hash_plans` snapshots them into an id-indexed vector so the hot loop reads a plain array instead of a concurrent map.
- Every instruction except `Environment` and `Runtime` (whose values depend on the task's env) hashes to the same value for every task within an invocation, so values are computed once into per-id slots and shared; when inputs are not collected, a filled slot skips `hash_instruction` entirely. Env-dependent values are interned per invocation.
- The `TaskHashes` return wrapper installs a per-conversion, thread-local cache mapping each unique Arc to the JS string already created for it (the Arc is pinned in the cache so an address cannot be freed and reused mid-conversion). Map keys become object property names and do not go through this cache.
- The persistent fileset caches are hash-only. Matched-file indices into the immutable file snapshot persist alongside them, populated only when inputs are collected; the indices share the snapshot's staleness guarantee, and paths are expanded from them per call.
<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/gh-36152-655cd716)
<!-- polygraph-session-end -->
