### PR TITLE
fix(angular-rspack): speed up builds and align behavior with the esbuild application builder

### DIFF
--- a/e2e/angular/src/projects-build-and-test.test.ts
+++ b/e2e/angular/src/projects-build-and-test.test.ts
@@ -129,6 +129,30 @@ describe('Angular Projects - Build and Test', () => {
       env: { NODE_ENV: 'production' },
     });
 
+    // Build with sourcemaps enabled (the development configuration sets
+    // `sourceMap: true`) and verify the emitted sourcemap resolves back to
+    // the original TypeScript sources instead of the intermediate Ivy JS.
+    runCLI(`build ${app} --skip-nx-cache`, {
+      env: { NGRS_CONFIG: 'development' },
+    });
+    const bundleMap = JSON.parse(
+      readFile(`dist/my-dir/${app}/browser/main.js.map`)
+    );
+    const tsSources = bundleMap.sources
+      .map((source: string, index: number) => ({
+        source,
+        content: bundleMap.sourcesContent?.[index],
+      }))
+      .filter(({ source }) => source.endsWith('.ts'));
+    expect(tsSources.length).toBeGreaterThan(0);
+    // The original TypeScript contains the `@Component` decorator, while the
+    // intermediate Ivy JS has it compiled away into `ɵcmp`.
+    const componentSource = tsSources.find(({ content }) =>
+      content?.includes('@Component')
+    );
+    expect(componentSource).toBeDefined();
+    expect(componentSource.content).not.toContain('ɵcmp');
+
     if (runE2ETests()) {
       expect(() => runCLI(`e2e ${app}-e2e`)).not.toThrow();
       expect(await killPort(port)).toBeTruthy();

--- a/packages/angular-rspack-compiler/src/compilation/build-and-analyze.spec.ts
+++ b/packages/angular-rspack-compiler/src/compilation/build-and-analyze.spec.ts
@@ -1,0 +1,96 @@
+import type { JavaScriptTransformer } from '@angular/build/private';
+import { normalize } from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { AngularCompilation } from '../models';
+import type { TransformedSource } from '../utils/source-file-cache';
+import { buildAndAnalyze } from './build-and-analyze';
+
+vi.mock('../utils/assert-supported-versions', () => ({
+  assertSupportedAngularRspackCompilerVersions: vi.fn(),
+}));
+
+describe('buildAndAnalyze', () => {
+  const transformData = vi.fn();
+  const javascriptTransformer = {
+    transformData,
+  } as unknown as JavaScriptTransformer;
+  let typescriptFileCache: Map<string, string | TransformedSource>;
+
+  const compilationWithEmit = (
+    files: Array<{ filename: string; contents: string | Uint8Array }>
+  ) =>
+    ({
+      emitAffectedFiles: vi.fn().mockResolvedValue(files),
+    }) as unknown as AngularCompilation;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    typescriptFileCache = new Map();
+  });
+
+  it('should store the raw emit without transforming it eagerly', async () => {
+    const compilation = compilationWithEmit([
+      { filename: '/root/src/main.ts', contents: 'emitted js' },
+    ]);
+
+    await buildAndAnalyze(
+      compilation,
+      typescriptFileCache,
+      javascriptTransformer
+    );
+
+    expect(typescriptFileCache.get('/root/src/main.ts')).toBe('emitted js');
+    expect(transformData).not.toHaveBeenCalled();
+  });
+
+  it('should replace a stale transformed entry with the new raw emit', async () => {
+    typescriptFileCache.set('/root/src/main.ts', {
+      code: 'old transformed',
+      map: undefined,
+    });
+    const compilation = compilationWithEmit([
+      { filename: '/root/src/main.ts', contents: 'new emit' },
+    ]);
+
+    await buildAndAnalyze(
+      compilation,
+      typescriptFileCache,
+      javascriptTransformer
+    );
+
+    expect(typescriptFileCache.get('/root/src/main.ts')).toBe('new emit');
+  });
+
+  it('should decode binary emit contents to text', async () => {
+    const compilation = compilationWithEmit([
+      {
+        filename: '/root/src/messages.json',
+        contents: new TextEncoder().encode('{"a":1}'),
+      },
+    ]);
+
+    await buildAndAnalyze(
+      compilation,
+      typescriptFileCache,
+      javascriptTransformer
+    );
+
+    expect(typescriptFileCache.get('/root/src/messages.json')).toBe('{"a":1}');
+  });
+
+  it('should strip the Windows drive letter from the cache key', async () => {
+    const compilation = compilationWithEmit([
+      { filename: 'C:/root/src/main.ts', contents: 'emitted js' },
+    ]);
+
+    await buildAndAnalyze(
+      compilation,
+      typescriptFileCache,
+      javascriptTransformer
+    );
+
+    expect(typescriptFileCache.get(normalize('/root/src/main.ts'))).toBe(
+      'emitted js'
+    );
+  });
+});

--- a/packages/angular-rspack-compiler/src/compilation/build-and-analyze.ts
+++ b/packages/angular-rspack-compiler/src/compilation/build-and-analyze.ts
@@ -1,13 +1,25 @@
 import { JavaScriptTransformer } from '@angular/build/private';
-import { normalize } from 'path';
 import { AngularCompilation } from '../models';
 import { assertSupportedAngularRspackCompilerVersions } from '../utils/assert-supported-versions';
+import {
+  toTypeScriptFileCacheKey,
+  type TransformedSource,
+} from '../utils/source-file-cache';
 
-const JS_TS_FILE_PATTERN = /\.[cm]?[jt]sx?$/;
-
+/**
+ * Emits the affected files of the Angular compilation into the given file
+ * cache as raw, untransformed text. The Rspack loaders in `@nx/angular-rspack`
+ * run the JavaScript transformer on entries on demand and replace them in
+ * place, so only files the bundler actually requests pay the transformation
+ * cost, matching the on-demand transformation in `@angular/build`'s esbuild
+ * compiler plugin.
+ *
+ * @param javascriptTransformer Unused. Kept for signature compatibility; the
+ * transformer now runs in the loaders.
+ */
 export async function buildAndAnalyze(
   angularCompilation: AngularCompilation,
-  typescriptFileCache: Map<string, string | Uint8Array>,
+  typescriptFileCache: Map<string, string | TransformedSource>,
   javascriptTransformer: JavaScriptTransformer
 ) {
   assertSupportedAngularRspackCompilerVersions();
@@ -16,26 +28,12 @@ export async function buildAndAnalyze(
     filename,
     contents,
   } of await angularCompilation.emitAffectedFiles()) {
-    const normalizedFilename = normalize(filename.replace(/^[A-Z]:/, ''));
+    const text =
+      typeof contents === 'string'
+        ? contents
+        : Buffer.from(contents).toString();
 
-    // Skip JavaScript transformation for non-JS/TS files (JSON, CSS, etc.)
-    // Let Rspack handle these through its native module rules
-    if (!JS_TS_FILE_PATTERN.test(normalizedFilename)) {
-      const text =
-        typeof contents === 'string'
-          ? contents
-          : Buffer.from(contents).toString();
-      typescriptFileCache.set(normalizedFilename, text);
-      continue;
-    }
-
-    await javascriptTransformer
-      .transformData(normalizedFilename, contents, true, false)
-      .then((contents) => {
-        typescriptFileCache.set(
-          normalizedFilename,
-          Buffer.from(contents).toString()
-        );
-      });
+    // Setting the raw emit also evicts any stale transformed entry.
+    typescriptFileCache.set(toTypeScriptFileCacheKey(filename), text);
   }
 }

--- a/packages/angular-rspack-compiler/src/compilation/setup-compilation.spec.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-compilation.spec.ts
@@ -11,7 +11,8 @@ vi.mock('../utils', () => ({
       _tsconfig: string,
       existingOptions: Record<string, unknown>
     ) => ({
-      options: existingOptions,
+      // Explicit overrides still win; existingOptions never carries module.
+      options: { module: 99, ...existingOptions },
       rootNames: ['/root/src/main.ts'],
     }),
   }),
@@ -107,7 +108,7 @@ describe('setupCompilation', () => {
         _tsconfig: string,
         existingOptions: Record<string, unknown>
       ) => ({
-        options: { ...existingOptions, target: 9 },
+        options: { ...existingOptions, target: 9, module: 99 },
         rootNames: ['/root/src/main.ts'],
       }),
     } as never);
@@ -148,5 +149,165 @@ describe('setupCompilation', () => {
     expect(setupWarnings).toEqual([
       "TypeScript compiler option 'target' is set to 'ES2022'.",
     ]);
+  });
+
+  it('should force partial compilation mode to full and warn', async () => {
+    vi.mocked(loadCompilerCli).mockResolvedValueOnce({
+      readConfiguration: (
+        _tsconfig: string,
+        existingOptions: Record<string, unknown>
+      ) => ({
+        options: {
+          ...existingOptions,
+          target: 9,
+          module: 99,
+          compilationMode: 'partial',
+        },
+        rootNames: ['/root/src/main.ts'],
+      }),
+    } as never);
+
+    const { compilerOptions, setupWarnings } = await setupCompilation(
+      { source: { tsconfigPath: '/root/tsconfig.json' } },
+      options
+    );
+
+    expect(compilerOptions.compilationMode).toBe('full');
+    expect(setupWarnings).toEqual([
+      expect.stringContaining('partial compilation mode is not supported'),
+    ]);
+  });
+
+  it('should not change a full compilation mode', async () => {
+    vi.mocked(loadCompilerCli).mockResolvedValueOnce({
+      readConfiguration: (
+        _tsconfig: string,
+        existingOptions: Record<string, unknown>
+      ) => ({
+        options: {
+          ...existingOptions,
+          target: 9,
+          module: 99,
+          compilationMode: 'full',
+        },
+        rootNames: ['/root/src/main.ts'],
+      }),
+    } as never);
+
+    const { compilerOptions, setupWarnings } = await setupCompilation(
+      { source: { tsconfigPath: '/root/tsconfig.json' } },
+      options
+    );
+
+    expect(compilerOptions.compilationMode).toBe('full');
+    expect(setupWarnings).toEqual([]);
+  });
+
+  it.each([
+    [undefined, 7, true],
+    [1 /* CommonJS */, 7, true],
+    [4 /* System */, 7, true],
+    [5 /* ES2015 */, 5, false],
+    [99 /* ESNext */, 99, false],
+    [200 /* Preserve */, 200, false],
+  ])(
+    'should force unsupported module values to ES2022 (module: %s)',
+    async (module, expectedModule, warned) => {
+      vi.mocked(loadCompilerCli).mockResolvedValueOnce({
+        readConfiguration: (
+          _tsconfig: string,
+          existingOptions: Record<string, unknown>
+        ) => ({
+          options: { ...existingOptions, target: 9, module },
+          rootNames: ['/root/src/main.ts'],
+        }),
+      } as never);
+
+      const { compilerOptions, setupWarnings } = await setupCompilation(
+        { source: { tsconfigPath: '/root/tsconfig.json' } },
+        options
+      );
+
+      expect(compilerOptions.module).toBe(expectedModule);
+      if (warned) {
+        expect(setupWarnings).toContainEqual(
+          expect.stringContaining(
+            "'module' values 'CommonJS', 'UMD', 'System' and 'AMD' are not supported"
+          )
+        );
+      } else {
+        expect(setupWarnings).toEqual([]);
+      }
+    }
+  );
+
+  it.each([
+    { moduleResolution: 100 /* Bundler */ },
+    { module: 200 /* Preserve */ },
+  ])(
+    'should sync the custom conditions to the bundler with %o',
+    async (caseOpts) => {
+      vi.mocked(loadCompilerCli).mockResolvedValueOnce({
+        readConfiguration: (
+          _tsconfig: string,
+          existingOptions: Record<string, unknown>
+        ) => ({
+          options: {
+            ...existingOptions,
+            target: 9,
+            module: 99,
+            customConditions: ['from-tsconfig'],
+            ...caseOpts,
+          },
+          rootNames: ['/root/src/main.ts'],
+        }),
+      } as never);
+
+      const { compilerOptions } = await setupCompilation(
+        { source: { tsconfigPath: '/root/tsconfig.json' } },
+        { ...options, customConditions: ['es2020', 'es2015'] }
+      );
+
+      expect(compilerOptions.customConditions).toEqual(['es2020', 'es2015']);
+    }
+  );
+
+  it('should keep the tsconfig custom conditions without bundler-style resolution', async () => {
+    vi.mocked(loadCompilerCli).mockResolvedValueOnce({
+      readConfiguration: (
+        _tsconfig: string,
+        existingOptions: Record<string, unknown>
+      ) => ({
+        options: {
+          ...existingOptions,
+          target: 9,
+          module: 100 /* Node16 */,
+          moduleResolution: 3 /* Node16 */,
+          customConditions: ['from-tsconfig'],
+        },
+        rootNames: ['/root/src/main.ts'],
+      }),
+    } as never);
+
+    const { compilerOptions } = await setupCompilation(
+      { source: { tsconfigPath: '/root/tsconfig.json' } },
+      { ...options, customConditions: ['es2020'] }
+    );
+
+    expect(compilerOptions.customConditions).toEqual(['from-tsconfig']);
+  });
+
+  it('should force the preserveSymlinks option over the tsconfig value', async () => {
+    const enabled = await setupCompilation(
+      { source: { tsconfigPath: '/root/tsconfig.json' } },
+      { ...options, preserveSymlinks: true }
+    );
+    expect(enabled.compilerOptions.preserveSymlinks).toBe(true);
+
+    const disabled = await setupCompilation(
+      { source: { tsconfigPath: '/root/tsconfig.json' } },
+      options
+    );
+    expect(disabled.compilerOptions.preserveSymlinks).toBeUndefined();
   });
 });

--- a/packages/angular-rspack-compiler/src/compilation/setup-compilation.spec.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-compilation.spec.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it, vi } from 'vitest';
+import { loadCompilerCli } from '../utils';
 import {
   setupCompilation,
   type SetupCompilationOptions,
@@ -82,4 +83,70 @@ describe('setupCompilation', () => {
       expect(compilerOptions.composite).toBe(false);
     }
   );
+
+  it('should raise targets below ES2022 and warn about it', async () => {
+    // The mocked readConfiguration echoes the existing options, which carry
+    // no target, so the ES2022 forcing applies.
+    const { compilerOptions, setupWarnings } = await setupCompilation(
+      { source: { tsconfigPath: '/root/tsconfig.json' } },
+      options
+    );
+
+    expect(compilerOptions.target).toBe(9 /* ts.ScriptTarget.ES2022 */);
+    expect(compilerOptions.useDefineForClassFields).toBe(false);
+    expect(setupWarnings).toEqual([
+      expect.stringContaining(
+        "'target' and 'useDefineForClassFields' are set to 'ES2022' and 'false'"
+      ),
+    ]);
+  });
+
+  it('should not warn when the target is already ES2022', async () => {
+    vi.mocked(loadCompilerCli).mockResolvedValueOnce({
+      readConfiguration: (
+        _tsconfig: string,
+        existingOptions: Record<string, unknown>
+      ) => ({
+        options: { ...existingOptions, target: 9 },
+        rootNames: ['/root/src/main.ts'],
+      }),
+    } as never);
+
+    const { compilerOptions, setupWarnings } = await setupCompilation(
+      { source: { tsconfigPath: '/root/tsconfig.json' } },
+      options
+    );
+
+    expect(compilerOptions.target).toBe(9);
+    expect(compilerOptions.useDefineForClassFields).toBeUndefined();
+    expect(setupWarnings).toEqual([]);
+  });
+
+  it('should warn only about the target when useDefineForClassFields is explicit', async () => {
+    vi.mocked(loadCompilerCli).mockResolvedValueOnce({
+      readConfiguration: (
+        _tsconfig: string,
+        existingOptions: Record<string, unknown>
+      ) => ({
+        options: {
+          ...existingOptions,
+          module: 99,
+          target: 7 /* ES2020 */,
+          useDefineForClassFields: true,
+        },
+        rootNames: ['/root/src/main.ts'],
+      }),
+    } as never);
+
+    const { compilerOptions, setupWarnings } = await setupCompilation(
+      { source: { tsconfigPath: '/root/tsconfig.json' } },
+      options
+    );
+
+    expect(compilerOptions.target).toBe(9);
+    expect(compilerOptions.useDefineForClassFields).toBe(true);
+    expect(setupWarnings).toEqual([
+      "TypeScript compiler option 'target' is set to 'ES2022'.",
+    ]);
+  });
 });

--- a/packages/angular-rspack-compiler/src/compilation/setup-compilation.spec.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-compilation.spec.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it, vi } from 'vitest';
+import {
+  setupCompilation,
+  type SetupCompilationOptions,
+} from './setup-compilation';
+
+vi.mock('../utils', () => ({
+  loadCompilerCli: vi.fn().mockResolvedValue({
+    readConfiguration: (
+      _tsconfig: string,
+      existingOptions: Record<string, unknown>
+    ) => ({
+      options: existingOptions,
+      rootNames: ['/root/src/main.ts'],
+    }),
+  }),
+}));
+
+vi.mock('../utils/assert-supported-versions', () => ({
+  assertSupportedAngularRspackCompilerVersions: vi.fn(),
+}));
+
+vi.mock('@angular/build/private', () => ({
+  ComponentStylesheetBundler: class {},
+  findTailwindConfiguration: vi.fn().mockReturnValue(undefined),
+  generateSearchDirectories: vi.fn().mockResolvedValue([]),
+  loadPostcssConfiguration: vi.fn().mockResolvedValue(undefined),
+  getSupportedBrowsers: vi.fn().mockReturnValue([]),
+}));
+
+describe('setupCompilation', () => {
+  const options: SetupCompilationOptions = {
+    root: '/root',
+    tsConfig: '/root/tsconfig.json',
+    aot: true,
+    inlineStyleLanguage: 'css',
+    fileReplacements: [],
+  };
+
+  it('should not emit TS sourcemaps when script sourcemaps are disabled', async () => {
+    const { compilerOptions } = await setupCompilation(
+      { source: { tsconfigPath: '/root/tsconfig.json' } },
+      options
+    );
+
+    expect(compilerOptions.inlineSourceMap).toBe(false);
+    expect(compilerOptions.inlineSources).toBe(false);
+    expect(compilerOptions.sourceMap).toBeUndefined();
+  });
+
+  it('should emit inline TS sourcemaps when script sourcemaps are enabled', async () => {
+    const { compilerOptions } = await setupCompilation(
+      { source: { tsconfigPath: '/root/tsconfig.json' } },
+      { ...options, sourceMap: true }
+    );
+
+    expect(compilerOptions.inlineSourceMap).toBe(true);
+    expect(compilerOptions.inlineSources).toBe(true);
+    expect(compilerOptions.sourceMap).toBeUndefined();
+  });
+
+  it('should not emit TS sourcemaps when using TS project references', async () => {
+    const { compilerOptions } = await setupCompilation(
+      { source: { tsconfigPath: '/root/tsconfig.json' } },
+      { ...options, sourceMap: true, useTsProjectReferences: true }
+    );
+
+    expect(compilerOptions.inlineSourceMap).toBe(false);
+    expect(compilerOptions.inlineSources).toBe(false);
+    expect(compilerOptions.sourceMap).toBe(false);
+    expect(compilerOptions.isolatedModules).toBe(true);
+  });
+});

--- a/packages/angular-rspack-compiler/src/compilation/setup-compilation.spec.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-compilation.spec.ts
@@ -70,4 +70,16 @@ describe('setupCompilation', () => {
     expect(compilerOptions.sourceMap).toBe(false);
     expect(compilerOptions.isolatedModules).toBe(true);
   });
+
+  it.each([undefined, true])(
+    'should force composite compilation off (useTsProjectReferences: %s)',
+    async (useTsProjectReferences) => {
+      const { compilerOptions } = await setupCompilation(
+        { source: { tsconfigPath: '/root/tsconfig.json' } },
+        { ...options, useTsProjectReferences }
+      );
+
+      expect(compilerOptions.composite).toBe(false);
+    }
+  );
 });

--- a/packages/angular-rspack-compiler/src/compilation/setup-compilation.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-compilation.ts
@@ -35,6 +35,7 @@ export interface SetupCompilationOptions {
   hasServer?: boolean;
   includePaths?: string[];
   sass?: Sass;
+  watch?: boolean;
 }
 
 export const DEFAULT_NG_COMPILER_OPTIONS: ts.CompilerOptions = {
@@ -123,7 +124,7 @@ export async function setupCompilation(
       tailwindConfiguration,
     },
     options.inlineStyleLanguage,
-    false
+    !!options.watch
   );
 
   return {

--- a/packages/angular-rspack-compiler/src/compilation/setup-compilation.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-compilation.ts
@@ -38,6 +38,8 @@ export interface SetupCompilationOptions {
   sass?: Sass;
   watch?: boolean;
   sourceMap?: boolean;
+  preserveSymlinks?: boolean;
+  customConditions?: string[];
 }
 
 export const DEFAULT_NG_COMPILER_OPTIONS: ts.CompilerOptions = {
@@ -63,8 +65,9 @@ let COMPONENT_STYLESHEET_BUNDLER: ComponentStylesheetBundler | undefined =
  * defaults applied and creates (or reuses) the shared component stylesheet
  * bundler. TypeScript sourcemaps are emitted inline and only when
  * `options.sourceMap` is enabled. Targets below ES2022 are raised (see
- * `applyEs2022TargetDefaults`) with a warning in the returned
- * `setupWarnings`.
+ * `applyEs2022TargetDefaults`), unsupported `module` values are set to
+ * ES2022, and partial compilation mode is forced to full, each with a
+ * warning in the returned `setupWarnings`.
  */
 export async function setupCompilation(
   config: Pick<RsbuildConfig, 'mode' | 'source'>,
@@ -86,6 +89,9 @@ export async function setupCompilation(
       // Composite emit is unsupported and conflicts with the incremental
       // state handling; force it off.
       composite: false,
+      // The bundler resolves symlinks based on this option alone; the
+      // program must resolve the same way, so the tsconfig value is ignored.
+      preserveSymlinks: options.preserveSymlinks,
       ...(options.useTsProjectReferences
         ? {
             sourceMap: false,
@@ -109,6 +115,24 @@ export async function setupCompilation(
         : "TypeScript compiler options 'target' and 'useDefineForClassFields' are set to 'ES2022' and 'false' respectively."
     );
   }
+  // Partial compilation output requires the Angular linker, which the JS
+  // transformer skips for application code; it would ship unlinked and fail
+  // at runtime.
+  if (compilerOptions.compilationMode === 'partial') {
+    setupWarnings.push(
+      'Angular partial compilation mode is not supported when building applications. Full compilation mode will be used instead.'
+    );
+    compilerOptions.compilationMode = 'full';
+  }
+  if (
+    compilerOptions.module === undefined ||
+    compilerOptions.module < ts.ModuleKind.ES2015
+  ) {
+    compilerOptions.module = ts.ModuleKind.ES2022;
+    setupWarnings.push(
+      "TypeScript compiler options 'module' values 'CommonJS', 'UMD', 'System' and 'AMD' are not supported. The 'module' option will be set to 'ES2022' instead."
+    );
+  }
   if (
     compilerOptions.isolatedModules &&
     compilerOptions.emitDecoratorMetadata
@@ -117,6 +141,15 @@ export async function setupCompilation(
       "TypeScript compiler option 'isolatedModules' may prevent the 'emitDecoratorMetadata' option from emitting all metadata. " +
         "The 'emitDecoratorMetadata' option is not required by Angular and can be removed if not explicitly required by the project."
     );
+  }
+  // With bundler-style resolution the program resolves package exports with
+  // these conditions; keep them in step with the bundler's custom
+  // conditions so both resolve the same files.
+  if (
+    compilerOptions.moduleResolution === ts.ModuleResolutionKind.Bundler ||
+    compilerOptions.module === ts.ModuleKind.Preserve
+  ) {
+    compilerOptions.customConditions = options.customConditions;
   }
 
   const searchDirectories = await generateSearchDirectories([options.root]);

--- a/packages/angular-rspack-compiler/src/compilation/setup-compilation.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-compilation.ts
@@ -2,6 +2,7 @@ import { RsbuildConfig } from '@rsbuild/core';
 import * as ts from 'typescript';
 import { InlineStyleLanguage, FileReplacement, type Sass } from '../models';
 import { loadCompilerCli } from '../utils';
+import { applyEs2022TargetDefaults } from '../utils/typescript-compiler-options';
 import { assertSupportedAngularRspackCompilerVersions } from '../utils/assert-supported-versions';
 import {
   ComponentStylesheetBundler,
@@ -61,7 +62,9 @@ let COMPONENT_STYLESHEET_BUNDLER: ComponentStylesheetBundler | undefined =
  * Reads the project's TypeScript configuration with the Angular compiler
  * defaults applied and creates (or reuses) the shared component stylesheet
  * bundler. TypeScript sourcemaps are emitted inline and only when
- * `options.sourceMap` is enabled.
+ * `options.sourceMap` is enabled. Targets below ES2022 are raised (see
+ * `applyEs2022TargetDefaults`) with a warning in the returned
+ * `setupWarnings`.
  */
 export async function setupCompilation(
   config: Pick<RsbuildConfig, 'mode' | 'source'>,
@@ -74,13 +77,14 @@ export async function setupCompilation(
     config.source?.tsconfigPath ?? options.tsConfig,
     {
       ...DEFAULT_NG_COMPILER_OPTIONS,
-      // Inline sourcemaps only when script sourcemaps are requested, matching
-      // the esbuild application builder (keeps Angular's fast emit path).
+      // Sourcemaps must be inline to survive the loader chain, and emitting
+      // them forgoes Angular's fast raw-TS emit path, so only emit them when
+      // script sourcemaps are requested.
       inlineSources: !!options.sourceMap,
       inlineSourceMap: !!options.sourceMap,
       sourceMap: undefined,
       // Composite emit is unsupported and conflicts with the incremental
-      // state handling; force off like @angular/build.
+      // state handling; force it off.
       composite: false,
       ...(options.useTsProjectReferences
         ? {
@@ -94,6 +98,26 @@ export async function setupCompilation(
   );
 
   const compilerOptions = tsCompilerOptions;
+
+  const setupWarnings: string[] = [];
+  const hasExplicitUseDefineForClassFields =
+    compilerOptions.useDefineForClassFields !== undefined;
+  if (applyEs2022TargetDefaults(compilerOptions)) {
+    setupWarnings.push(
+      hasExplicitUseDefineForClassFields
+        ? "TypeScript compiler option 'target' is set to 'ES2022'."
+        : "TypeScript compiler options 'target' and 'useDefineForClassFields' are set to 'ES2022' and 'false' respectively."
+    );
+  }
+  if (
+    compilerOptions.isolatedModules &&
+    compilerOptions.emitDecoratorMetadata
+  ) {
+    setupWarnings.push(
+      "TypeScript compiler option 'isolatedModules' may prevent the 'emitDecoratorMetadata' option from emitting all metadata. " +
+        "The 'emitDecoratorMetadata' option is not required by Angular and can be removed if not explicitly required by the project."
+    );
+  }
 
   const searchDirectories = await generateSearchDirectories([options.root]);
   const postcssConfiguration =
@@ -146,6 +170,7 @@ export async function setupCompilation(
     rootNames,
     compilerOptions,
     componentStylesheetBundler: COMPONENT_STYLESHEET_BUNDLER,
+    setupWarnings,
   };
 }
 

--- a/packages/angular-rspack-compiler/src/compilation/setup-compilation.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-compilation.ts
@@ -16,6 +16,13 @@ import { createRequire } from 'node:module';
 export interface StylesheetTransformResult {
   contents: string;
   outputFiles?: Array<{ path: string; text: string }>;
+  /** Bundle metadata listing the files that went into the stylesheet. */
+  metafile?: {
+    outputs: Record<
+      string,
+      { inputs: Record<string, { bytesInOutput: number }> }
+    >;
+  };
 }
 
 export interface SetupCompilationOptions {
@@ -174,10 +181,10 @@ export function styleTransform(
         }
       }
 
-      // Return both contents and outputFiles
       return {
         contents: stylesheetResult.contents,
         outputFiles: stylesheetResult.outputFiles,
+        metafile: stylesheetResult.metafile,
       };
     } catch (e) {
       console.error(

--- a/packages/angular-rspack-compiler/src/compilation/setup-compilation.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-compilation.ts
@@ -79,6 +79,9 @@ export async function setupCompilation(
       inlineSources: !!options.sourceMap,
       inlineSourceMap: !!options.sourceMap,
       sourceMap: undefined,
+      // Composite emit is unsupported and conflicts with the incremental
+      // state handling; force off like @angular/build.
+      composite: false,
       ...(options.useTsProjectReferences
         ? {
             sourceMap: false,

--- a/packages/angular-rspack-compiler/src/compilation/setup-compilation.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-compilation.ts
@@ -36,12 +36,12 @@ export interface SetupCompilationOptions {
   includePaths?: string[];
   sass?: Sass;
   watch?: boolean;
+  sourceMap?: boolean;
 }
 
 export const DEFAULT_NG_COMPILER_OPTIONS: ts.CompilerOptions = {
   suppressOutputPathCheck: true,
   outDir: undefined,
-  sourceMap: true,
   declaration: false,
   declarationMap: false,
   allowEmptyCodegenFiles: false,
@@ -57,6 +57,12 @@ export const DEFAULT_NG_COMPILER_OPTIONS: ts.CompilerOptions = {
 let COMPONENT_STYLESHEET_BUNDLER: ComponentStylesheetBundler | undefined =
   undefined;
 
+/**
+ * Reads the project's TypeScript configuration with the Angular compiler
+ * defaults applied and creates (or reuses) the shared component stylesheet
+ * bundler. TypeScript sourcemaps are emitted inline and only when
+ * `options.sourceMap` is enabled.
+ */
 export async function setupCompilation(
   config: Pick<RsbuildConfig, 'mode' | 'source'>,
   options: SetupCompilationOptions
@@ -68,9 +74,15 @@ export async function setupCompilation(
     config.source?.tsconfigPath ?? options.tsConfig,
     {
       ...DEFAULT_NG_COMPILER_OPTIONS,
+      // Inline sourcemaps only when script sourcemaps are requested, matching
+      // the esbuild application builder (keeps Angular's fast emit path).
+      inlineSources: !!options.sourceMap,
+      inlineSourceMap: !!options.sourceMap,
+      sourceMap: undefined,
       ...(options.useTsProjectReferences
         ? {
             sourceMap: false,
+            inlineSourceMap: false,
             inlineSources: false,
             isolatedModules: true,
           }

--- a/packages/angular-rspack-compiler/src/compilation/setup-compilation.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-compilation.ts
@@ -67,7 +67,9 @@ let COMPONENT_STYLESHEET_BUNDLER: ComponentStylesheetBundler | undefined =
  * `options.sourceMap` is enabled. Targets below ES2022 are raised (see
  * `applyEs2022TargetDefaults`), unsupported `module` values are set to
  * ES2022, and partial compilation mode is forced to full, each with a
- * warning in the returned `setupWarnings`.
+ * warning in the returned `setupWarnings`. Combining `isolatedModules` with
+ * `emitDecoratorMetadata` is also warned about, without forcing either
+ * option.
  */
 export async function setupCompilation(
   config: Pick<RsbuildConfig, 'mode' | 'source'>,

--- a/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.spec.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.spec.ts
@@ -149,13 +149,14 @@ describe('setupCompilationWithAngularCompilation', () => {
     }
   );
 
-  it('should fill transpilation gate options the compilation does not marshal back', async () => {
+  it('should compute the transpilation gate from the options the compilation reports, not the local ones', async () => {
     vi.mocked(setupCompilation).mockResolvedValueOnce({
       rootNames: ['/root/src/main.ts'],
+      // Gate-relevant local values that differ from what the compilation
+      // reports; they must not leak into the gate.
       compilerOptions: {
-        isolatedModules: true,
-        experimentalDecorators: true,
-        target: 9,
+        isolatedModules: false,
+        sourceMap: true,
       },
       componentStylesheetBundler: {},
     } as never);
@@ -315,9 +316,10 @@ describe('setupCompilationWithAngularCompilation', () => {
     expect(compilerOptions.tsBuildInfoFile).toBeUndefined();
   });
 
-  // The default tsconfig (isolated modules, legacy decorators, ES2022) with
-  // sourcemaps off takes the fast path; anything the swc rule can't
-  // replicate falls back to TypeScript transpilation.
+  // The flag must mirror the emit's own gate (isolated modules and no
+  // sourcemaps emit raw Angular-transformed TypeScript); tsconfig semantics
+  // like decorators or class fields are the swc rule's concern and must not
+  // flip the classification of what the compilation emitted.
   const fastPathOptions = {
     isolatedModules: true,
     experimentalDecorators: true,
@@ -326,15 +328,17 @@ describe('setupCompilationWithAngularCompilation', () => {
   it.each([
     [fastPathOptions, false],
     [{}, true],
+    [{ isolatedModules: false }, true],
     [{ ...fastPathOptions, sourceMap: true }, true],
     [{ ...fastPathOptions, inlineSourceMap: true }, true],
-    [{ ...fastPathOptions, experimentalDecorators: false }, true],
-    [{ ...fastPathOptions, emitDecoratorMetadata: true }, true],
-    [{ ...fastPathOptions, useDefineForClassFields: false }, true],
-    [{ ...fastPathOptions, verbatimModuleSyntax: true }, true],
-    [{ ...fastPathOptions, importsNotUsedAsValues: 1 }, true],
-    [{ ...fastPathOptions, target: undefined }, true],
-    [{ ...fastPathOptions, target: 4 }, true],
+    [{ ...fastPathOptions, experimentalDecorators: false }, false],
+    [{ ...fastPathOptions, emitDecoratorMetadata: true }, false],
+    [{ ...fastPathOptions, useDefineForClassFields: false }, false],
+    [{ ...fastPathOptions, verbatimModuleSyntax: true }, false],
+    // Module federation apps set target ES2020; the emit still produces raw
+    // TypeScript, so the loaders must not hand it to the JS transformer.
+    [{ ...fastPathOptions, target: 7 }, false],
+    [{ ...fastPathOptions, target: undefined }, false],
   ])(
     'should compute useTypeScriptTranspilation from the initialized compiler options %o',
     async (initializedCompilerOptions, expected) => {

--- a/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.spec.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.spec.ts
@@ -1,7 +1,10 @@
 import { describe, expect, it, vi } from 'vitest';
 import type { AngularCompilation, SourceFileCache } from '../models';
 import { setupCompilationWithAngularCompilation } from './setup-with-angular-compilation';
-import type { SetupCompilationOptions } from './setup-compilation';
+import {
+  styleTransform,
+  type SetupCompilationOptions,
+} from './setup-compilation';
 
 vi.mock('./setup-compilation', () => ({
   setupCompilation: vi.fn().mockResolvedValue({
@@ -55,5 +58,68 @@ describe('setupCompilationWithAngularCompilation', () => {
 
     expect(sourceFileCache.referencedFiles).toEqual(['/root/src/main.ts']);
     expect(result.angularCompilation).toBe(angularCompilation);
+  });
+
+  it('should collect stylesheet metafile inputs keyed by stylesheet', async () => {
+    vi.mocked(styleTransform).mockReturnValueOnce(async () => ({
+      contents: '.a{}',
+      metafile: {
+        outputs: {
+          'out.css': {
+            inputs: {
+              'node_modules/css-pkg/styles.css': { bytesInOutput: 3 },
+            },
+          },
+        },
+      },
+    }));
+    let hostOptions:
+      | {
+          transformStylesheet: (
+            styles: string,
+            containingFile: string,
+            stylesheetFile?: string,
+            order?: number,
+            className?: string
+          ) => Promise<string>;
+        }
+      | undefined;
+    const angularCompilation = {
+      initialize: vi.fn().mockImplementation((_tsconfig, host) => {
+        hostOptions = host;
+        return Promise.resolve({ referencedFiles: [] });
+      }),
+    } as unknown as AngularCompilation;
+
+    const result = await setupCompilationWithAngularCompilation(
+      { source: { tsconfigPath: '/root/tsconfig.json' } },
+      options,
+      undefined,
+      angularCompilation
+    );
+
+    await hostOptions!.transformStylesheet(
+      '.a{}',
+      '/root/src/app/app.component.ts',
+      '/root/src/app/app.component.scss'
+    );
+    await hostOptions!.transformStylesheet(
+      '.b{}',
+      '/root/src/app/app.component.ts',
+      undefined,
+      0,
+      'AppComponent'
+    );
+
+    expect(result.collectedStylesheetMetafileInputs).toEqual([
+      {
+        source: '/root/src/app/app.component.scss',
+        inputs: { 'node_modules/css-pkg/styles.css': { bytesInOutput: 3 } },
+      },
+      {
+        source: '/root/src/app/app.component.ts?class=AppComponent&order=0',
+        inputs: { 'node_modules/css-pkg/styles.css': { bytesInOutput: 3 } },
+      },
+    ]);
   });
 });

--- a/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.spec.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.spec.ts
@@ -60,6 +60,63 @@ describe('setupCompilationWithAngularCompilation', () => {
     ).rejects.toThrow('TS version not supported');
   });
 
+  it('should close a compilation created here when initialization fails', async () => {
+    const closeMock = vi.fn();
+    createAngularCompilationMock.mockResolvedValueOnce({
+      initialize: vi.fn().mockRejectedValue(new Error('init failed')),
+      close: closeMock,
+    });
+
+    await expect(
+      setupCompilationWithAngularCompilation(
+        { source: { tsconfigPath: '/root/tsconfig.json' } },
+        options
+      )
+    ).rejects.toThrow('init failed');
+
+    expect(closeMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('should not close a caller-provided compilation when initialization fails', async () => {
+    const close = vi.fn();
+    const angularCompilation = {
+      initialize: vi.fn().mockRejectedValue(new Error('init failed')),
+      close,
+    } as unknown as AngularCompilation;
+
+    await expect(
+      setupCompilationWithAngularCompilation(
+        { source: { tsconfigPath: '/root/tsconfig.json' } },
+        options,
+        undefined,
+        angularCompilation
+      )
+    ).rejects.toThrow('init failed');
+
+    expect(close).not.toHaveBeenCalled();
+  });
+
+  it('should attach the setup warnings to initialization errors', async () => {
+    vi.mocked(setupCompilation).mockResolvedValueOnce({
+      rootNames: ['/root/src/main.ts'],
+      compilerOptions: {},
+      componentStylesheetBundler: {},
+      setupWarnings: ['target raised'],
+    } as unknown as Awaited<ReturnType<typeof setupCompilation>>);
+    const angularCompilation = {
+      initialize: vi.fn().mockRejectedValue(new Error('init failed')),
+    } as unknown as AngularCompilation;
+
+    await expect(
+      setupCompilationWithAngularCompilation(
+        { source: { tsconfigPath: '/root/tsconfig.json' } },
+        options,
+        undefined,
+        angularCompilation
+      )
+    ).rejects.toMatchObject({ setupWarnings: ['target raised'] });
+  });
+
   it('should set referenced files on the source file cache', async () => {
     const angularCompilation = {
       initialize: vi

--- a/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.spec.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.spec.ts
@@ -1,3 +1,4 @@
+import { join } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
 import type { AngularCompilation, SourceFileCache } from '../models';
 import { setupCompilationWithAngularCompilation } from './setup-with-angular-compilation';
@@ -103,6 +104,80 @@ describe('setupCompilationWithAngularCompilation', () => {
     );
 
     expect(invalidate).not.toHaveBeenCalled();
+  });
+
+  it('should persist the TS incremental state when a persistent cache path is available', async () => {
+    const compilerOptions: Record<string, unknown> = {};
+    vi.mocked(setupCompilation).mockResolvedValueOnce({
+      rootNames: ['/root/src/main.ts'],
+      compilerOptions,
+      componentStylesheetBundler: {},
+    } as unknown as Awaited<ReturnType<typeof setupCompilation>>);
+    const angularCompilation = {
+      initialize: vi.fn().mockResolvedValue({ referencedFiles: [] }),
+    } as unknown as AngularCompilation;
+    const sourceFileCache = {
+      persistentCachePath: '/root/.angular/cache/22.0.0/app',
+    } as SourceFileCache;
+
+    await setupCompilationWithAngularCompilation(
+      { source: { tsconfigPath: '/root/tsconfig.json' } },
+      options,
+      sourceFileCache,
+      angularCompilation
+    );
+
+    expect(compilerOptions.incremental).toBe(true);
+    expect(compilerOptions.tsBuildInfoFile).toBe(
+      join('/root/.angular/cache/22.0.0/app', '.tsbuildinfo')
+    );
+  });
+
+  it('should respect an explicitly disabled incremental compilation', async () => {
+    const compilerOptions: Record<string, unknown> = { incremental: false };
+    vi.mocked(setupCompilation).mockResolvedValueOnce({
+      rootNames: ['/root/src/main.ts'],
+      compilerOptions,
+      componentStylesheetBundler: {},
+    } as unknown as Awaited<ReturnType<typeof setupCompilation>>);
+    const angularCompilation = {
+      initialize: vi.fn().mockResolvedValue({ referencedFiles: [] }),
+    } as unknown as AngularCompilation;
+    const sourceFileCache = {
+      persistentCachePath: '/root/.angular/cache/22.0.0/app',
+    } as SourceFileCache;
+
+    await setupCompilationWithAngularCompilation(
+      { source: { tsconfigPath: '/root/tsconfig.json' } },
+      options,
+      sourceFileCache,
+      angularCompilation
+    );
+
+    expect(compilerOptions.incremental).toBe(false);
+    expect(compilerOptions.tsBuildInfoFile).toBeUndefined();
+  });
+
+  it('should disable incremental compilation without a persistent cache path', async () => {
+    const compilerOptions: Record<string, unknown> = {};
+    vi.mocked(setupCompilation).mockResolvedValueOnce({
+      rootNames: ['/root/src/main.ts'],
+      compilerOptions,
+      componentStylesheetBundler: {},
+    } as unknown as Awaited<ReturnType<typeof setupCompilation>>);
+    const angularCompilation = {
+      initialize: vi.fn().mockResolvedValue({ referencedFiles: [] }),
+    } as unknown as AngularCompilation;
+
+    await setupCompilationWithAngularCompilation(
+      { source: { tsconfigPath: '/root/tsconfig.json' } },
+      options,
+      undefined,
+      angularCompilation
+    );
+
+    expect(compilerOptions.incremental).toBe(false);
+    expect(compilerOptions.tsBuildInfoFile).toBeUndefined();
   });
 
   // The default tsconfig (isolated modules, legacy decorators, ES2022) with

--- a/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.spec.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.spec.ts
@@ -105,6 +105,47 @@ describe('setupCompilationWithAngularCompilation', () => {
     expect(invalidate).not.toHaveBeenCalled();
   });
 
+  // The default tsconfig (isolated modules, legacy decorators, ES2022) with
+  // sourcemaps off takes the fast path; anything the swc rule can't
+  // replicate falls back to TypeScript transpilation.
+  const fastPathOptions = {
+    isolatedModules: true,
+    experimentalDecorators: true,
+    target: 9,
+  };
+  it.each([
+    [fastPathOptions, false],
+    [{}, true],
+    [{ ...fastPathOptions, sourceMap: true }, true],
+    [{ ...fastPathOptions, inlineSourceMap: true }, true],
+    [{ ...fastPathOptions, experimentalDecorators: false }, true],
+    [{ ...fastPathOptions, emitDecoratorMetadata: true }, true],
+    [{ ...fastPathOptions, useDefineForClassFields: false }, true],
+    [{ ...fastPathOptions, verbatimModuleSyntax: true }, true],
+    [{ ...fastPathOptions, importsNotUsedAsValues: 1 }, true],
+    [{ ...fastPathOptions, target: undefined }, true],
+    [{ ...fastPathOptions, target: 4 }, true],
+  ])(
+    'should compute useTypeScriptTranspilation from the initialized compiler options %o',
+    async (initializedCompilerOptions, expected) => {
+      const angularCompilation = {
+        initialize: vi.fn().mockResolvedValue({
+          referencedFiles: [],
+          compilerOptions: initializedCompilerOptions,
+        }),
+      } as unknown as AngularCompilation;
+
+      const result = await setupCompilationWithAngularCompilation(
+        { source: { tsconfigPath: '/root/tsconfig.json' } },
+        options,
+        undefined,
+        angularCompilation
+      );
+
+      expect(result.useTypeScriptTranspilation).toBe(expected);
+    }
+  );
+
   it('should collect stylesheet metafile inputs keyed by stylesheet', async () => {
     vi.mocked(styleTransform).mockReturnValueOnce(async () => ({
       contents: '.a{}',

--- a/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.spec.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.spec.ts
@@ -1,5 +1,5 @@
 import { join } from 'node:path';
-import { describe, expect, it, vi } from 'vitest';
+import { afterEach, describe, expect, it, vi } from 'vitest';
 import {
   toTypeScriptFileCacheKey,
   type AngularCompilation,
@@ -12,6 +12,10 @@ import {
   type SetupCompilationOptions,
 } from './setup-compilation';
 
+const { createAngularCompilationMock } = vi.hoisted(() => ({
+  createAngularCompilationMock: vi.fn(),
+}));
+
 vi.mock('./setup-compilation', () => ({
   setupCompilation: vi.fn().mockResolvedValue({
     rootNames: ['/root/src/main.ts'],
@@ -21,7 +25,16 @@ vi.mock('./setup-compilation', () => ({
   styleTransform: vi.fn(() => async () => ({ contents: '' })),
 }));
 
+vi.mock('../models', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('../models')>()),
+  createAngularCompilation: createAngularCompilationMock,
+}));
+
 describe('setupCompilationWithAngularCompilation', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
   const options: SetupCompilationOptions = {
     root: '/root',
     tsConfig: '/root/tsconfig.json',
@@ -94,6 +107,79 @@ describe('setupCompilationWithAngularCompilation', () => {
         ],
       ])
     );
+  });
+
+  it('should create a worker-based Angular compilation by default', async () => {
+    const angularCompilation = {
+      initialize: vi.fn().mockResolvedValue({ referencedFiles: [] }),
+    };
+    createAngularCompilationMock.mockResolvedValueOnce(angularCompilation);
+
+    const result = await setupCompilationWithAngularCompilation(
+      { source: { tsconfigPath: '/root/tsconfig.json' } },
+      options
+    );
+
+    expect(createAngularCompilationMock).toHaveBeenCalledWith(
+      false,
+      true,
+      true
+    );
+    expect(result.angularCompilation).toBe(angularCompilation);
+  });
+
+  it.each(['0', 'false', 'FALSE'])(
+    'should use the in-process Angular compilation when NG_BUILD_PARALLEL_TS is "%s"',
+    async (value) => {
+      vi.stubEnv('NG_BUILD_PARALLEL_TS', value);
+      createAngularCompilationMock.mockResolvedValueOnce({
+        initialize: vi.fn().mockResolvedValue({ referencedFiles: [] }),
+      });
+
+      await setupCompilationWithAngularCompilation(
+        { source: { tsconfigPath: '/root/tsconfig.json' } },
+        options
+      );
+
+      expect(createAngularCompilationMock).toHaveBeenCalledWith(
+        false,
+        true,
+        false
+      );
+    }
+  );
+
+  it('should fill transpilation gate options the compilation does not marshal back', async () => {
+    vi.mocked(setupCompilation).mockResolvedValueOnce({
+      rootNames: ['/root/src/main.ts'],
+      compilerOptions: {
+        isolatedModules: true,
+        experimentalDecorators: true,
+        target: 9,
+      },
+      componentStylesheetBundler: {},
+    } as never);
+    const angularCompilation = {
+      initialize: vi.fn().mockResolvedValue({
+        referencedFiles: [],
+        // The worker-based compilation only marshals these options back.
+        compilerOptions: {
+          allowJs: false,
+          isolatedModules: true,
+          sourceMap: undefined,
+          inlineSourceMap: undefined,
+        },
+      }),
+    } as unknown as AngularCompilation;
+
+    const result = await setupCompilationWithAngularCompilation(
+      { source: { tsconfigPath: '/root/tsconfig.json' } },
+      options,
+      undefined,
+      angularCompilation
+    );
+
+    expect(result.useTypeScriptTranspilation).toBe(false);
   });
 
   it('should not build resource dependencies when the compilation does not report them', async () => {

--- a/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.spec.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.spec.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest';
 import type { AngularCompilation, SourceFileCache } from '../models';
 import { setupCompilationWithAngularCompilation } from './setup-with-angular-compilation';
 import {
+  setupCompilation,
   styleTransform,
   type SetupCompilationOptions,
 } from './setup-compilation';
@@ -58,6 +59,50 @@ describe('setupCompilationWithAngularCompilation', () => {
 
     expect(sourceFileCache.referencedFiles).toEqual(['/root/src/main.ts']);
     expect(result.angularCompilation).toBe(angularCompilation);
+  });
+
+  it('should invalidate the stylesheet bundler for modified files', async () => {
+    const invalidate = vi.fn();
+    vi.mocked(setupCompilation).mockResolvedValueOnce({
+      rootNames: ['/root/src/main.ts'],
+      compilerOptions: {},
+      componentStylesheetBundler: { invalidate },
+    } as unknown as Awaited<ReturnType<typeof setupCompilation>>);
+    const angularCompilation = {
+      initialize: vi.fn().mockResolvedValue({ referencedFiles: [] }),
+    } as unknown as AngularCompilation;
+    const modifiedFiles = new Set(['/root/src/app/app.component.css']);
+
+    await setupCompilationWithAngularCompilation(
+      { source: { tsconfigPath: '/root/tsconfig.json' } },
+      options,
+      undefined,
+      angularCompilation,
+      modifiedFiles
+    );
+
+    expect(invalidate).toHaveBeenCalledWith(modifiedFiles);
+  });
+
+  it('should not invalidate the stylesheet bundler on the initial build', async () => {
+    const invalidate = vi.fn();
+    vi.mocked(setupCompilation).mockResolvedValueOnce({
+      rootNames: ['/root/src/main.ts'],
+      compilerOptions: {},
+      componentStylesheetBundler: { invalidate },
+    } as unknown as Awaited<ReturnType<typeof setupCompilation>>);
+    const angularCompilation = {
+      initialize: vi.fn().mockResolvedValue({ referencedFiles: [] }),
+    } as unknown as AngularCompilation;
+
+    await setupCompilationWithAngularCompilation(
+      { source: { tsconfigPath: '/root/tsconfig.json' } },
+      options,
+      undefined,
+      angularCompilation
+    );
+
+    expect(invalidate).not.toHaveBeenCalled();
   });
 
   it('should collect stylesheet metafile inputs keyed by stylesheet', async () => {

--- a/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.spec.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.spec.ts
@@ -1,6 +1,10 @@
 import { join } from 'node:path';
 import { describe, expect, it, vi } from 'vitest';
-import type { AngularCompilation, SourceFileCache } from '../models';
+import {
+  toTypeScriptFileCacheKey,
+  type AngularCompilation,
+  type SourceFileCache,
+} from '../models';
 import { setupCompilationWithAngularCompilation } from './setup-with-angular-compilation';
 import {
   setupCompilation,
@@ -60,6 +64,51 @@ describe('setupCompilationWithAngularCompilation', () => {
 
     expect(sourceFileCache.referencedFiles).toEqual(['/root/src/main.ts']);
     expect(result.angularCompilation).toBe(angularCompilation);
+  });
+
+  it('should re-key the compiler-tracked resource dependencies like the emit cache', async () => {
+    const angularCompilation = {
+      initialize: vi.fn().mockResolvedValue({
+        referencedFiles: [],
+        componentResourcesDependencies: new Map([
+          [
+            'C:/root/src/app/app.component.ts',
+            ['/root/src/app/app.component.html'],
+          ],
+        ]),
+      }),
+    } as unknown as AngularCompilation;
+
+    const result = await setupCompilationWithAngularCompilation(
+      { source: { tsconfigPath: '/root/tsconfig.json' } },
+      options,
+      undefined,
+      angularCompilation
+    );
+
+    expect(result.resourceDependencies).toEqual(
+      new Map([
+        [
+          toTypeScriptFileCacheKey('C:/root/src/app/app.component.ts'),
+          ['/root/src/app/app.component.html'],
+        ],
+      ])
+    );
+  });
+
+  it('should not build resource dependencies when the compilation does not report them', async () => {
+    const angularCompilation = {
+      initialize: vi.fn().mockResolvedValue({ referencedFiles: [] }),
+    } as unknown as AngularCompilation;
+
+    const result = await setupCompilationWithAngularCompilation(
+      { source: { tsconfigPath: '/root/tsconfig.json' } },
+      options,
+      undefined,
+      angularCompilation
+    );
+
+    expect(result.resourceDependencies).toBeUndefined();
   });
 
   it('should invalidate the stylesheet bundler for modified files', async () => {

--- a/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.ts
@@ -178,8 +178,9 @@ export async function setupCompilationWithAngularCompilation(
   // Angular-transformed TypeScript, on this exact expression over the
   // program's options (JIT always transpiles). The loaders classify the
   // emitted cache entries with this flag, so it must never diverge from the
-  // emit's gate. The worker-based initialize reports only the four options
-  // the gate reads; any other option would be undefined here.
+  // emit's gate. The worker-based initialize reports only four options; the
+  // three the gate reads are among them, and any other option would be
+  // undefined here.
   const useTypeScriptTranspilation =
     !initializedCompilerOptions?.isolatedModules ||
     !!initializedCompilerOptions?.sourceMap ||

--- a/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.ts
@@ -1,4 +1,5 @@
 import type { RsbuildConfig } from '@rsbuild/core';
+import { join } from 'node:path';
 import {
   createAngularCompilation,
   AngularCompilation,
@@ -28,15 +29,30 @@ export async function setupCompilationWithAngularCompilation(
 ) {
   const { rootNames, compilerOptions, componentStylesheetBundler } =
     await setupCompilation(config, options);
+
+  // Persist the TypeScript incremental state to the cache directory when one
+  // is available, matching the esbuild application builder's gating.
+  if (
+    sourceFileCache?.persistentCachePath &&
+    compilerOptions.incremental !== false
+  ) {
+    compilerOptions.incremental = true;
+    compilerOptions.tsBuildInfoFile = join(
+      sourceFileCache.persistentCachePath,
+      '.tsbuildinfo'
+    );
+  } else {
+    compilerOptions.incremental = false;
+  }
+
   angularCompilation ??= await createAngularCompilation(
     !options.aot,
     !options.hasServer,
     false
   );
 
-  // Drop the bundler's cached results for files the watcher reported as
-  // modified so dependent stylesheets get rebuilt; skipped on the initial
-  // build when there's nothing to invalidate.
+  // Drop the bundler's cached results for changed files so dependent
+  // stylesheets get rebuilt; there's nothing to invalidate on the first build.
   if (modifiedFiles) {
     componentStylesheetBundler.invalidate(modifiedFiles);
   }

--- a/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.ts
@@ -28,11 +28,15 @@ export async function setupCompilationWithAngularCompilation(
   angularCompilation?: AngularCompilation,
   modifiedFiles?: Set<string>
 ) {
-  const { rootNames, compilerOptions, componentStylesheetBundler } =
-    await setupCompilation(config, options);
+  const {
+    rootNames,
+    compilerOptions,
+    componentStylesheetBundler,
+    setupWarnings,
+  } = await setupCompilation(config, options);
 
   // Persist the TypeScript incremental state to the cache directory when one
-  // is available, matching the esbuild application builder's gating.
+  // is available so later cold builds resume from it.
   if (
     sourceFileCache?.persistentCachePath &&
     compilerOptions.incremental !== false
@@ -91,8 +95,8 @@ export async function setupCompilationWithAngularCompilation(
     }
 
     if (result.metafile) {
-      // Inline styles share the containing file; disambiguate like
-      // `@angular/build` does so entries stay unique per stylesheet.
+      // Inline styles share the containing file; disambiguate with the
+      // class name and order so entries stay unique per stylesheet.
       let source = stylesheetFile ?? containingFile;
       if (!stylesheetFile) {
         source += `?class=${className}&order=${order}`;
@@ -144,30 +148,16 @@ export async function setupCompilationWithAngularCompilation(
     }
   }
 
-  // The worker-based compilation only marshals a subset of the initialized
-  // compiler options back; fill the gaps from the options handed to the
-  // compilation, which are what it actually used.
-  const effectiveCompilerOptions = {
-    ...compilerOptions,
-    ...initializedCompilerOptions,
-  };
-
-  // Mirrors @angular/build: with isolated modules and no sourcemaps, Angular
-  // emits transformed TypeScript and leaves transpilation to the bundler.
-  // Unlike esbuild, the swc rule transpiling that output doesn't read the
-  // project's tsconfig; it assumes the default tsconfig semantics (legacy
-  // decorators without metadata, ES2022 targets, default class-field and
-  // import-elision behavior). Other configs use TypeScript transpilation.
+  // Only the AOT emit branches between TypeScript transpilation and raw
+  // Angular-transformed TypeScript, on this exact expression over the
+  // program's options (JIT always transpiles). The loaders classify the
+  // emitted cache entries with this flag, so it must never diverge from the
+  // emit's gate. The worker-based initialize reports only the four options
+  // the gate reads; any other option would be undefined here.
   const useTypeScriptTranspilation =
-    !effectiveCompilerOptions.isolatedModules ||
-    !!effectiveCompilerOptions.sourceMap ||
-    !!effectiveCompilerOptions.inlineSourceMap ||
-    !effectiveCompilerOptions.experimentalDecorators ||
-    !!effectiveCompilerOptions.emitDecoratorMetadata ||
-    effectiveCompilerOptions.useDefineForClassFields === false ||
-    !!effectiveCompilerOptions.verbatimModuleSyntax ||
-    !!effectiveCompilerOptions.importsNotUsedAsValues ||
-    (effectiveCompilerOptions.target ?? 0) < 9; /* ts.ScriptTarget.ES2022 */
+    !initializedCompilerOptions?.isolatedModules ||
+    !!initializedCompilerOptions?.sourceMap ||
+    !!initializedCompilerOptions?.inlineSourceMap;
 
   return {
     angularCompilation,
@@ -175,5 +165,6 @@ export async function setupCompilationWithAngularCompilation(
     collectedStylesheetMetafileInputs,
     useTypeScriptTranspilation,
     resourceDependencies,
+    setupWarnings,
   };
 }

--- a/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.ts
@@ -4,6 +4,7 @@ import {
   createAngularCompilation,
   AngularCompilation,
   SourceFileCache,
+  toTypeScriptFileCacheKey,
 } from '../models';
 import {
   setupCompilation,
@@ -106,22 +107,37 @@ export async function setupCompilationWithAngularCompilation(
   // Initialization errors are intentionally not caught here: callers must
   // surface them as build errors instead of continuing with a compilation
   // that was never initialized.
-  const { compilerOptions: initializedCompilerOptions, referencedFiles } =
-    await angularCompilation.initialize(
-      config.source?.tsconfigPath ?? options.tsConfig,
-      {
-        sourceFileCache,
-        fileReplacements,
-        modifiedFiles,
-        transformStylesheet: wrappedTransformStylesheet,
-        processWebWorker(workerFile: string) {
-          return workerFile;
-        },
+  const {
+    compilerOptions: initializedCompilerOptions,
+    referencedFiles,
+    componentResourcesDependencies,
+  } = await angularCompilation.initialize(
+    config.source?.tsconfigPath ?? options.tsConfig,
+    {
+      sourceFileCache,
+      fileReplacements,
+      modifiedFiles,
+      transformStylesheet: wrappedTransformStylesheet,
+      processWebWorker(workerFile: string) {
+        return workerFile;
       },
-      () => compilerOptions
-    );
+    },
+    () => compilerOptions
+  );
   if (sourceFileCache) {
     sourceFileCache.referencedFiles = referencedFiles;
+  }
+
+  // The compiler already tracks each source file's template and stylesheet
+  // dependencies; re-key them like the emit cache so loaders can register
+  // watch dependencies without re-parsing sources. AOT only: JIT compilations
+  // do not report them and fall back to the URL resolvers.
+  let resourceDependencies: Map<string, readonly string[]> | undefined;
+  if (componentResourcesDependencies) {
+    resourceDependencies = new Map();
+    for (const [file, dependencies] of componentResourcesDependencies) {
+      resourceDependencies.set(toTypeScriptFileCacheKey(file), dependencies);
+    }
   }
 
   // Mirrors @angular/build: with isolated modules and no sourcemaps, Angular
@@ -146,5 +162,6 @@ export async function setupCompilationWithAngularCompilation(
     collectedStylesheetAssets,
     collectedStylesheetMetafileInputs,
     useTypeScriptTranspilation,
+    resourceDependencies,
   };
 }

--- a/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.ts
@@ -8,8 +8,16 @@ import {
   setupCompilation,
   styleTransform,
   SetupCompilationOptions,
-  StylesheetTransformResult,
 } from './setup-compilation';
+
+/**
+ * The files bundled into a component stylesheet, keyed by the stylesheet
+ * they were bundled from. Used to attribute package licenses.
+ */
+export interface StylesheetMetafileInputs {
+  source: string;
+  inputs: Record<string, { bytesInOutput: number }>;
+}
 
 export async function setupCompilationWithAngularCompilation(
   config: Pick<RsbuildConfig, 'source'>,
@@ -35,19 +43,36 @@ export async function setupCompilationWithAngularCompilation(
 
   // Store collected stylesheet output files
   const collectedStylesheetAssets: Array<{ path: string; text: string }> = [];
+  const collectedStylesheetMetafileInputs: StylesheetMetafileInputs[] = [];
 
   // Create a wrapper around styleTransform to collect outputFiles
   const transformFn = styleTransform(componentStylesheetBundler);
   const wrappedTransformStylesheet = async (
     styles: string,
     containingFile: string,
-    stylesheetFile?: string
+    stylesheetFile?: string,
+    order?: number,
+    className?: string
   ) => {
     const result = await transformFn(styles, containingFile, stylesheetFile);
 
     // Collect outputFiles if present
     if (result.outputFiles && result.outputFiles.length > 0) {
       collectedStylesheetAssets.push(...result.outputFiles);
+    }
+
+    if (result.metafile) {
+      // Inline styles share the containing file; disambiguate like
+      // `@angular/build` does so entries stay unique per stylesheet.
+      let source = stylesheetFile ?? containingFile;
+      if (!stylesheetFile) {
+        source += `?class=${className}&order=${order}`;
+      }
+      const inputs: StylesheetMetafileInputs['inputs'] = {};
+      for (const output of Object.values(result.metafile.outputs)) {
+        Object.assign(inputs, output.inputs);
+      }
+      collectedStylesheetMetafileInputs.push({ source, inputs });
     }
 
     // Return just the contents string as expected by Angular compilation
@@ -76,5 +101,6 @@ export async function setupCompilationWithAngularCompilation(
   return {
     angularCompilation,
     collectedStylesheetAssets,
+    collectedStylesheetMetafileInputs,
   };
 }

--- a/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.ts
@@ -90,25 +90,45 @@ export async function setupCompilationWithAngularCompilation(
   // Initialization errors are intentionally not caught here: callers must
   // surface them as build errors instead of continuing with a compilation
   // that was never initialized.
-  const { referencedFiles } = await angularCompilation.initialize(
-    config.source?.tsconfigPath ?? options.tsConfig,
-    {
-      sourceFileCache,
-      fileReplacements,
-      modifiedFiles,
-      transformStylesheet: wrappedTransformStylesheet,
-      processWebWorker(workerFile: string) {
-        return workerFile;
+  const { compilerOptions: initializedCompilerOptions, referencedFiles } =
+    await angularCompilation.initialize(
+      config.source?.tsconfigPath ?? options.tsConfig,
+      {
+        sourceFileCache,
+        fileReplacements,
+        modifiedFiles,
+        transformStylesheet: wrappedTransformStylesheet,
+        processWebWorker(workerFile: string) {
+          return workerFile;
+        },
       },
-    },
-    () => compilerOptions
-  );
+      () => compilerOptions
+    );
   if (sourceFileCache) {
     sourceFileCache.referencedFiles = referencedFiles;
   }
+
+  // Mirrors @angular/build: with isolated modules and no sourcemaps, Angular
+  // emits transformed TypeScript and leaves transpilation to the bundler.
+  // Unlike esbuild, the swc rule transpiling that output doesn't read the
+  // project's tsconfig; it assumes the default tsconfig semantics (legacy
+  // decorators without metadata, ES2022 targets, default class-field and
+  // import-elision behavior). Other configs use TypeScript transpilation.
+  const useTypeScriptTranspilation =
+    !initializedCompilerOptions?.isolatedModules ||
+    !!initializedCompilerOptions.sourceMap ||
+    !!initializedCompilerOptions.inlineSourceMap ||
+    !initializedCompilerOptions.experimentalDecorators ||
+    !!initializedCompilerOptions.emitDecoratorMetadata ||
+    initializedCompilerOptions.useDefineForClassFields === false ||
+    !!initializedCompilerOptions.verbatimModuleSyntax ||
+    !!initializedCompilerOptions.importsNotUsedAsValues ||
+    (initializedCompilerOptions.target ?? 0) < 9; /* ts.ScriptTarget.ES2022 */
+
   return {
     angularCompilation,
     collectedStylesheetAssets,
     collectedStylesheetMetafileInputs,
+    useTypeScriptTranspilation,
   };
 }

--- a/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.ts
@@ -46,10 +46,14 @@ export async function setupCompilationWithAngularCompilation(
     compilerOptions.incremental = false;
   }
 
+  // Mirrors @angular/build's NG_BUILD_PARALLEL_TS switch: anything but
+  // 0/false runs the Angular compilation in a worker thread, so type
+  // checking overlaps with the bundling work.
+  const parallelTs = process.env['NG_BUILD_PARALLEL_TS'];
   angularCompilation ??= await createAngularCompilation(
     !options.aot,
     !options.hasServer,
-    false
+    parallelTs !== '0' && parallelTs?.toLowerCase() !== 'false'
   );
 
   // Drop the bundler's cached results for changed files so dependent
@@ -140,6 +144,14 @@ export async function setupCompilationWithAngularCompilation(
     }
   }
 
+  // The worker-based compilation only marshals a subset of the initialized
+  // compiler options back; fill the gaps from the options handed to the
+  // compilation, which are what it actually used.
+  const effectiveCompilerOptions = {
+    ...compilerOptions,
+    ...initializedCompilerOptions,
+  };
+
   // Mirrors @angular/build: with isolated modules and no sourcemaps, Angular
   // emits transformed TypeScript and leaves transpilation to the bundler.
   // Unlike esbuild, the swc rule transpiling that output doesn't read the
@@ -147,15 +159,15 @@ export async function setupCompilationWithAngularCompilation(
   // decorators without metadata, ES2022 targets, default class-field and
   // import-elision behavior). Other configs use TypeScript transpilation.
   const useTypeScriptTranspilation =
-    !initializedCompilerOptions?.isolatedModules ||
-    !!initializedCompilerOptions.sourceMap ||
-    !!initializedCompilerOptions.inlineSourceMap ||
-    !initializedCompilerOptions.experimentalDecorators ||
-    !!initializedCompilerOptions.emitDecoratorMetadata ||
-    initializedCompilerOptions.useDefineForClassFields === false ||
-    !!initializedCompilerOptions.verbatimModuleSyntax ||
-    !!initializedCompilerOptions.importsNotUsedAsValues ||
-    (initializedCompilerOptions.target ?? 0) < 9; /* ts.ScriptTarget.ES2022 */
+    !effectiveCompilerOptions.isolatedModules ||
+    !!effectiveCompilerOptions.sourceMap ||
+    !!effectiveCompilerOptions.inlineSourceMap ||
+    !effectiveCompilerOptions.experimentalDecorators ||
+    !!effectiveCompilerOptions.emitDecoratorMetadata ||
+    effectiveCompilerOptions.useDefineForClassFields === false ||
+    !!effectiveCompilerOptions.verbatimModuleSyntax ||
+    !!effectiveCompilerOptions.importsNotUsedAsValues ||
+    (effectiveCompilerOptions.target ?? 0) < 9; /* ts.ScriptTarget.ES2022 */
 
   return {
     angularCompilation,

--- a/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.ts
@@ -33,6 +33,14 @@ export async function setupCompilationWithAngularCompilation(
     !options.hasServer,
     false
   );
+
+  // Drop the bundler's cached results for files the watcher reported as
+  // modified so dependent stylesheets get rebuilt; skipped on the initial
+  // build when there's nothing to invalidate.
+  if (modifiedFiles) {
+    componentStylesheetBundler.invalidate(modifiedFiles);
+  }
+
   modifiedFiles ??= new Set(rootNames);
 
   const fileReplacements: Record<string, string> =

--- a/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.ts
@@ -54,11 +54,20 @@ export async function setupCompilationWithAngularCompilation(
   // 0/false runs the Angular compilation in a worker thread, so type
   // checking overlaps with the bundling work.
   const parallelTs = process.env['NG_BUILD_PARALLEL_TS'];
-  angularCompilation ??= await createAngularCompilation(
-    !options.aot,
-    !options.hasServer,
-    parallelTs !== '0' && parallelTs?.toLowerCase() !== 'false'
-  );
+  let createdAngularCompilation = false;
+  if (!angularCompilation) {
+    try {
+      angularCompilation = await createAngularCompilation(
+        !options.aot,
+        !options.hasServer,
+        parallelTs !== '0' && parallelTs?.toLowerCase() !== 'false'
+      );
+    } catch (error) {
+      attachSetupWarnings(error, setupWarnings);
+      throw error;
+    }
+    createdAngularCompilation = true;
+  }
 
   // Drop the bundler's cached results for changed files so dependent
   // stylesheets get rebuilt; there's nothing to invalidate on the first build.
@@ -112,26 +121,43 @@ export async function setupCompilationWithAngularCompilation(
     return result.contents;
   };
 
-  // Initialization errors are intentionally not caught here: callers must
-  // surface them as build errors instead of continuing with a compilation
-  // that was never initialized.
+  // Initialization errors are rethrown for callers to surface as build
+  // errors instead of continuing with a compilation that was never
+  // initialized.
+  let initializationResult;
+  try {
+    initializationResult = await angularCompilation.initialize(
+      config.source?.tsconfigPath ?? options.tsConfig,
+      {
+        sourceFileCache,
+        fileReplacements,
+        modifiedFiles,
+        transformStylesheet: wrappedTransformStylesheet,
+        processWebWorker(workerFile: string) {
+          return workerFile;
+        },
+      },
+      () => compilerOptions
+    );
+  } catch (error) {
+    // A worker-based compilation spawns its worker thread on construction;
+    // close one created here or every failing setup would leak a worker.
+    // A caller-provided compilation stays alive for the caller to reuse.
+    if (createdAngularCompilation) {
+      try {
+        await angularCompilation.close?.();
+      } catch {
+        // The initialization error is the one worth surfacing.
+      }
+    }
+    attachSetupWarnings(error, setupWarnings);
+    throw error;
+  }
   const {
     compilerOptions: initializedCompilerOptions,
     referencedFiles,
     componentResourcesDependencies,
-  } = await angularCompilation.initialize(
-    config.source?.tsconfigPath ?? options.tsConfig,
-    {
-      sourceFileCache,
-      fileReplacements,
-      modifiedFiles,
-      transformStylesheet: wrappedTransformStylesheet,
-      processWebWorker(workerFile: string) {
-        return workerFile;
-      },
-    },
-    () => compilerOptions
-  );
+  } = initializationResult;
   if (sourceFileCache) {
     sourceFileCache.referencedFiles = referencedFiles;
   }
@@ -167,4 +193,12 @@ export async function setupCompilationWithAngularCompilation(
     resourceDependencies,
     setupWarnings,
   };
+}
+
+// Callers report initialization failures as build errors; hand them the
+// setup warnings so they are not lost with the failed build.
+function attachSetupWarnings(error: unknown, setupWarnings: string[]): void {
+  if (error && typeof error === 'object') {
+    (error as { setupWarnings?: string[] }).setupWarnings = setupWarnings;
+  }
 }

--- a/packages/angular-rspack-compiler/src/models/index.ts
+++ b/packages/angular-rspack-compiler/src/models/index.ts
@@ -8,6 +8,7 @@ export { JavaScriptTransformer, AngularCompilation, createAngularCompilation };
 export {
   SourceFileCache,
   toTypeScriptFileCacheKey,
+  type BabelFileCacheEntry,
   type TransformedSource,
 } from '../utils/source-file-cache';
 

--- a/packages/angular-rspack-compiler/src/models/index.ts
+++ b/packages/angular-rspack-compiler/src/models/index.ts
@@ -1,16 +1,15 @@
 import {
   JavaScriptTransformer,
-  SourceFileCache,
   AngularCompilation,
   createAngularCompilation,
 } from '@angular/build/private';
 
+export { JavaScriptTransformer, AngularCompilation, createAngularCompilation };
 export {
-  JavaScriptTransformer,
   SourceFileCache,
-  AngularCompilation,
-  createAngularCompilation,
-};
+  toTypeScriptFileCacheKey,
+  type TransformedSource,
+} from '../utils/source-file-cache';
 
 export * from './inline-style-language';
 export * from './file-replacement';

--- a/packages/angular-rspack-compiler/src/utils/index.ts
+++ b/packages/angular-rspack-compiler/src/utils/index.ts
@@ -2,4 +2,5 @@ export * from './regex-filters';
 export * from './component-resolvers';
 export * from './javascript-transformer-cache';
 export * from './load-compiler-cli';
+export * from './typescript-compiler-options';
 export { maxWorkers } from './utils';

--- a/packages/angular-rspack-compiler/src/utils/index.ts
+++ b/packages/angular-rspack-compiler/src/utils/index.ts
@@ -1,4 +1,5 @@
 export * from './regex-filters';
 export * from './component-resolvers';
+export * from './javascript-transformer-cache';
 export * from './load-compiler-cli';
 export { maxWorkers } from './utils';

--- a/packages/angular-rspack-compiler/src/utils/javascript-transformer-cache.spec.ts
+++ b/packages/angular-rspack-compiler/src/utils/javascript-transformer-cache.spec.ts
@@ -1,0 +1,70 @@
+import { join } from 'node:path';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createJavascriptTransformerCache } from './javascript-transformer-cache';
+
+const { requireMock } = vi.hoisted(() => {
+  const requireMock = Object.assign(vi.fn(), { resolve: vi.fn() });
+  return { requireMock };
+});
+
+vi.mock('node:module', () => ({
+  createRequire: () => requireMock,
+}));
+
+describe('createJavascriptTransformerCache', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should create a namespaced cache backed by a store in the cache directory', async () => {
+    const cache = { get: vi.fn(), put: vi.fn() };
+    const createCache = vi.fn().mockReturnValue(cache);
+    const close = vi.fn().mockResolvedValue(undefined);
+    const storeCtor = vi.fn();
+    requireMock.resolve.mockReturnValue(
+      join('/root/node_modules/@angular/build', 'package.json')
+    );
+    requireMock.mockReturnValue({
+      LmdbCacheStore: class {
+        createCache = createCache;
+        close = close;
+        constructor(cachePath: string) {
+          storeCtor(cachePath);
+        }
+      },
+    });
+
+    const result = createJavascriptTransformerCache('/root/.angular/cache');
+
+    expect(requireMock.resolve).toHaveBeenCalledWith(
+      '@angular/build/package.json'
+    );
+    expect(requireMock).toHaveBeenCalledWith(
+      join(
+        '/root/node_modules/@angular/build',
+        'src/tools/esbuild/lmdb-cache-store.js'
+      )
+    );
+    expect(storeCtor).toHaveBeenCalledWith(
+      join('/root/.angular/cache', 'angular-compiler.db')
+    );
+    expect(createCache).toHaveBeenCalledWith('jstransformer');
+    expect(result?.cache).toBe(cache);
+
+    await result?.close();
+    expect(close).toHaveBeenCalled();
+  });
+
+  it('should return undefined when the store cannot be loaded', () => {
+    requireMock.resolve.mockReturnValue(
+      join('/root/node_modules/@angular/build', 'package.json')
+    );
+    requireMock.mockImplementation(() => {
+      throw new Error('platform not supported');
+    });
+
+    expect(
+      createJavascriptTransformerCache('/root/.angular/cache')
+    ).toBeUndefined();
+  });
+});

--- a/packages/angular-rspack-compiler/src/utils/javascript-transformer-cache.ts
+++ b/packages/angular-rspack-compiler/src/utils/javascript-transformer-cache.ts
@@ -1,0 +1,47 @@
+import { createRequire } from 'node:module';
+import { dirname, join } from 'node:path';
+import type { Cache } from '@angular/build/private';
+
+export interface JavascriptTransformerCache {
+  cache: Cache<Uint8Array>;
+  close(): Promise<void>;
+}
+
+interface LmdbCacheStoreLike {
+  createCache<V>(namespace: string): Cache<V>;
+  close(): Promise<void>;
+}
+
+/**
+ * Creates the persistent store the esbuild application builder uses for
+ * `JavaScriptTransformer` results, so Angular package linking is only paid
+ * on the first build with a given cache directory.
+ *
+ * The LMDB-backed store is not part of `@angular/build`'s exported API and
+ * its exports map blocks subpath imports, so it is loaded from the resolved
+ * package location. Returns `undefined` when it cannot be loaded (older
+ * `@angular/build` versions, platforms without lmdb prebuilds), in which
+ * case the transformer runs uncached.
+ */
+export function createJavascriptTransformerCache(
+  persistentCachePath: string
+): JavascriptTransformerCache | undefined {
+  try {
+    const requireFn = createRequire(__filename);
+    const angularBuildDir = dirname(
+      requireFn.resolve('@angular/build/package.json')
+    );
+    const { LmdbCacheStore } = requireFn(
+      join(angularBuildDir, 'src/tools/esbuild/lmdb-cache-store.js')
+    ) as { LmdbCacheStore: new (cachePath: string) => LmdbCacheStoreLike };
+    const store = new LmdbCacheStore(
+      join(persistentCachePath, 'angular-compiler.db')
+    );
+    return {
+      cache: store.createCache('jstransformer'),
+      close: () => store.close(),
+    };
+  } catch {
+    return undefined;
+  }
+}

--- a/packages/angular-rspack-compiler/src/utils/regex-filters.ts
+++ b/packages/angular-rspack-compiler/src/utils/regex-filters.ts
@@ -1,4 +1,6 @@
 export const TS_ALL_EXT_REGEX = /\.[cm]?tsx?(\?|$)/;
+export const TS_EXT_REGEX = /\.[cm]?ts(\?|$)/;
+export const TSX_EXT_REGEX = /\.tsx(\?|$)/;
 export const JS_ALL_EXT_REGEX = /\.[cm]?jsx?(\?|$)/;
 export const JS_EXT_REGEX = /\.[cm]?js$/;
 

--- a/packages/angular-rspack-compiler/src/utils/source-file-cache.spec.ts
+++ b/packages/angular-rspack-compiler/src/utils/source-file-cache.spec.ts
@@ -1,0 +1,44 @@
+import { normalize } from 'node:path';
+import type ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+import { SourceFileCache, toTypeScriptFileCacheKey } from './source-file-cache';
+
+describe('SourceFileCache', () => {
+  it('should drop cached source files and track modified files on invalidate', () => {
+    const cache = new SourceFileCache();
+    cache.set(normalize('/root/src/main.ts'), {} as ts.SourceFile);
+    cache.set(normalize('/root/src/other.ts'), {} as ts.SourceFile);
+
+    cache.invalidate(['/root/src/main.ts']);
+
+    expect(cache.has(normalize('/root/src/main.ts'))).toBe(false);
+    expect(cache.has(normalize('/root/src/other.ts'))).toBe(true);
+    expect(cache.modifiedFiles).toEqual(
+      new Set([normalize('/root/src/main.ts')])
+    );
+  });
+
+  it('should not evict emitted output on invalidate', () => {
+    const cache = new SourceFileCache();
+    cache.typeScriptFileCache.set(
+      toTypeScriptFileCacheKey('/root/src/main.ts'),
+      'raw emit'
+    );
+
+    cache.invalidate(['/root/src/main.ts']);
+
+    // A fresh emit overwrites the entry; invalidating must not drop it, or
+    // files that are not re-emitted would lose their compiled output.
+    expect(
+      cache.typeScriptFileCache.get(
+        toTypeScriptFileCacheKey('/root/src/main.ts')
+      )
+    ).toBe('raw emit');
+  });
+
+  it('should strip the Windows drive letter from cache keys', () => {
+    expect(toTypeScriptFileCacheKey('C:/root/src/main.ts')).toBe(
+      normalize('/root/src/main.ts')
+    );
+  });
+});

--- a/packages/angular-rspack-compiler/src/utils/source-file-cache.spec.ts
+++ b/packages/angular-rspack-compiler/src/utils/source-file-cache.spec.ts
@@ -36,6 +36,57 @@ describe('SourceFileCache', () => {
     ).toBe('raw emit');
   });
 
+  it('should evict transformed package code on invalidate', () => {
+    const cache = new SourceFileCache();
+    cache.babelFileCache.set(
+      toTypeScriptFileCacheKey('/root/dist/lib/index.mjs'),
+      'transformed'
+    );
+
+    cache.invalidate(['/root/dist/lib/index.mjs']);
+
+    // Files outside the Angular compilation are never re-emitted, so a
+    // modification must drop the cached transform.
+    expect(
+      cache.babelFileCache.has(
+        toTypeScriptFileCacheKey('/root/dist/lib/index.mjs')
+      )
+    ).toBe(false);
+  });
+
+  it('should evict emitted output for removed files on prune', () => {
+    const cache = new SourceFileCache();
+    cache.typeScriptFileCache.set(
+      toTypeScriptFileCacheKey('/root/src/removed.ts'),
+      'raw emit'
+    );
+    cache.typeScriptFileCache.set(
+      toTypeScriptFileCacheKey('/root/src/kept.ts'),
+      'raw emit'
+    );
+    cache.babelFileCache.set(
+      toTypeScriptFileCacheKey('/root/src/removed.ts'),
+      'transformed'
+    );
+
+    cache.prune(['/root/src/removed.ts']);
+
+    expect(
+      cache.babelFileCache.has(toTypeScriptFileCacheKey('/root/src/removed.ts'))
+    ).toBe(false);
+
+    expect(
+      cache.typeScriptFileCache.has(
+        toTypeScriptFileCacheKey('/root/src/removed.ts')
+      )
+    ).toBe(false);
+    expect(
+      cache.typeScriptFileCache.has(
+        toTypeScriptFileCacheKey('/root/src/kept.ts')
+      )
+    ).toBe(true);
+  });
+
   it('should strip the Windows drive letter from cache keys', () => {
     expect(toTypeScriptFileCacheKey('C:/root/src/main.ts')).toBe(
       normalize('/root/src/main.ts')

--- a/packages/angular-rspack-compiler/src/utils/source-file-cache.spec.ts
+++ b/packages/angular-rspack-compiler/src/utils/source-file-cache.spec.ts
@@ -40,7 +40,7 @@ describe('SourceFileCache', () => {
     const cache = new SourceFileCache();
     cache.babelFileCache.set(
       toTypeScriptFileCacheKey('/root/dist/lib/index.mjs'),
-      'transformed'
+      { code: 'transformed', map: undefined, chainedMap: undefined }
     );
 
     cache.invalidate(['/root/dist/lib/index.mjs']);
@@ -64,10 +64,11 @@ describe('SourceFileCache', () => {
       toTypeScriptFileCacheKey('/root/src/kept.ts'),
       'raw emit'
     );
-    cache.babelFileCache.set(
-      toTypeScriptFileCacheKey('/root/src/removed.ts'),
-      'transformed'
-    );
+    cache.babelFileCache.set(toTypeScriptFileCacheKey('/root/src/removed.ts'), {
+      code: 'transformed',
+      map: undefined,
+      chainedMap: undefined,
+    });
 
     cache.prune(['/root/src/removed.ts']);
 

--- a/packages/angular-rspack-compiler/src/utils/source-file-cache.ts
+++ b/packages/angular-rspack-compiler/src/utils/source-file-cache.ts
@@ -22,6 +22,16 @@ export interface TransformedSource {
 }
 
 /**
+ * A {@link TransformedSource} produced under a specific loader-chained input
+ * sourcemap. The JavaScript transformer reads and merges a file's external
+ * sourcemap itself, so the entry is only valid while that map is unchanged;
+ * `chainedMap` holds the serialized map the entry was produced with.
+ */
+export interface BabelFileCacheEntry extends TransformedSource {
+  chainedMap: string | undefined;
+}
+
+/**
  * Key used by `typeScriptFileCache`: the normalized path with any Windows
  * drive letter stripped, so emitted filenames and loader resource paths match.
  */
@@ -42,10 +52,13 @@ export class SourceFileCache extends Map<string, ts.SourceFile> {
 
   /**
    * JavaScript transformer output for files outside the Angular compilation
-   * (e.g. package code), keyed by {@link toTypeScriptFileCacheKey}. These are
-   * never re-emitted, so modifying a file must evict its entry.
+   * (e.g. package code), split into code and forwarded sourcemap, keyed by
+   * {@link toTypeScriptFileCacheKey}. These are never re-emitted, so
+   * modifying a file must evict its entry; a changed chained input map
+   * invalidates an entry at the consumer instead (see
+   * {@link BabelFileCacheEntry}).
    */
-  readonly babelFileCache = new Map<string, string>();
+  readonly babelFileCache = new Map<string, BabelFileCacheEntry>();
 
   referencedFiles?: readonly string[];
 

--- a/packages/angular-rspack-compiler/src/utils/source-file-cache.ts
+++ b/packages/angular-rspack-compiler/src/utils/source-file-cache.ts
@@ -40,6 +40,13 @@ export class SourceFileCache extends Map<string, ts.SourceFile> {
    */
   readonly typeScriptFileCache = new Map<string, string | TransformedSource>();
 
+  /**
+   * JavaScript transformer output for files outside the Angular compilation
+   * (e.g. package code), keyed by {@link toTypeScriptFileCacheKey}. These are
+   * never re-emitted, so modifying a file must evict its entry.
+   */
+  readonly babelFileCache = new Map<string, string>();
+
   referencedFiles?: readonly string[];
 
   constructor(readonly persistentCachePath?: string) {
@@ -51,6 +58,8 @@ export class SourceFileCache extends Map<string, ts.SourceFile> {
       this.modifiedFiles.clear();
     }
     for (let file of files) {
+      this.babelFileCache.delete(toTypeScriptFileCacheKey(file));
+
       file = path.normalize(file);
 
       // Normalize separators to allow matching TypeScript Host paths
@@ -60,6 +69,18 @@ export class SourceFileCache extends Map<string, ts.SourceFile> {
 
       this.delete(file);
       this.modifiedFiles.add(file);
+    }
+  }
+
+  /**
+   * Drops output cached for files deleted from disk. Modified files don't
+   * need this for emitted output: their next emit overwrites the entry.
+   */
+  prune(removedFiles: Iterable<string>): void {
+    for (const file of removedFiles) {
+      const key = toTypeScriptFileCacheKey(file);
+      this.typeScriptFileCache.delete(key);
+      this.babelFileCache.delete(key);
     }
   }
 }

--- a/packages/angular-rspack-compiler/src/utils/source-file-cache.ts
+++ b/packages/angular-rspack-compiler/src/utils/source-file-cache.ts
@@ -7,30 +7,47 @@
  */
 
 import * as path from 'node:path';
-import { pathToFileURL } from 'node:url';
 import type ts from 'typescript';
 import { isUsingWindows } from './utils';
 
 const WINDOWS_SEP_REGEXP = new RegExp(`\\${path.win32.sep}`, 'g');
 
+/**
+ * Angular compilation output after the JavaScript transformer has run, with
+ * any inline sourcemap already split off the code.
+ */
+export interface TransformedSource {
+  code: string;
+  map: string | undefined;
+}
+
+/**
+ * Key used by `typeScriptFileCache`: the normalized path with any Windows
+ * drive letter stripped, so emitted filenames and loader resource paths match.
+ */
+export function toTypeScriptFileCacheKey(file: string): string {
+  return path.normalize(file.replace(/^[A-Z]:/, ''));
+}
+
 export class SourceFileCache extends Map<string, ts.SourceFile> {
   readonly modifiedFiles = new Set<string>();
-  readonly babelFileCache = new Map<string, Uint8Array>();
-  readonly typeScriptFileCache = new Map<string, string | Uint8Array>();
+
+  /**
+   * Emitted build output keyed by {@link toTypeScriptFileCacheKey}. A `string`
+   * entry is the raw, untransformed emit; the loaders replace it in place with
+   * a {@link TransformedSource} once the JavaScript transformer has run.
+   * Overwriting an entry with a fresh raw emit evicts the stale transform.
+   */
+  readonly typeScriptFileCache = new Map<string, string | TransformedSource>();
 
   referencedFiles?: readonly string[];
-
-  constructor(readonly persistentCachePath?: string) {
-    super();
-  }
 
   invalidate(files: Iterable<string>): void {
     if (files !== this.modifiedFiles) {
       this.modifiedFiles.clear();
     }
     for (let file of files) {
-      this.babelFileCache.delete(file);
-      this.typeScriptFileCache.delete(pathToFileURL(file).href);
+      file = path.normalize(file);
 
       // Normalize separators to allow matching TypeScript Host paths
       if (isUsingWindows()) {

--- a/packages/angular-rspack-compiler/src/utils/source-file-cache.ts
+++ b/packages/angular-rspack-compiler/src/utils/source-file-cache.ts
@@ -42,6 +42,10 @@ export class SourceFileCache extends Map<string, ts.SourceFile> {
 
   referencedFiles?: readonly string[];
 
+  constructor(readonly persistentCachePath?: string) {
+    super();
+  }
+
   invalidate(files: Iterable<string>): void {
     if (files !== this.modifiedFiles) {
       this.modifiedFiles.clear();

--- a/packages/angular-rspack-compiler/src/utils/typescript-compiler-options.spec.ts
+++ b/packages/angular-rspack-compiler/src/utils/typescript-compiler-options.spec.ts
@@ -1,0 +1,35 @@
+import * as ts from 'typescript';
+import { describe, expect, it } from 'vitest';
+import { applyEs2022TargetDefaults } from './typescript-compiler-options';
+
+describe('applyEs2022TargetDefaults', () => {
+  it.each([
+    [{}, ts.ScriptTarget.ES2022, false, true],
+    [{ target: ts.ScriptTarget.ES2020 }, ts.ScriptTarget.ES2022, false, true],
+    [
+      { target: ts.ScriptTarget.ES2020, useDefineForClassFields: true },
+      ts.ScriptTarget.ES2022,
+      true,
+      true,
+    ],
+    [
+      { target: ts.ScriptTarget.ES2022 },
+      ts.ScriptTarget.ES2022,
+      undefined,
+      false,
+    ],
+    [
+      { target: ts.ScriptTarget.ESNext },
+      ts.ScriptTarget.ESNext,
+      undefined,
+      false,
+    ],
+  ])(
+    'should adjust %o only when the target is below ES2022',
+    (compilerOptions: ts.CompilerOptions, target, udcf, adjusted) => {
+      expect(applyEs2022TargetDefaults(compilerOptions)).toBe(adjusted);
+      expect(compilerOptions.target).toBe(target);
+      expect(compilerOptions.useDefineForClassFields).toBe(udcf);
+    }
+  );
+});

--- a/packages/angular-rspack-compiler/src/utils/typescript-compiler-options.spec.ts
+++ b/packages/angular-rspack-compiler/src/utils/typescript-compiler-options.spec.ts
@@ -48,6 +48,7 @@ describe('applyEs2022TargetDefaults', () => {
 
 describe('resolveSwcTranspilationTransform', () => {
   let dir: string;
+  let jsxCaseId = 0;
 
   const writeTsConfig = (
     name: string,
@@ -86,6 +87,7 @@ describe('resolveSwcTranspilationTransform', () => {
       decoratorMetadata: false,
       useDefineForClassFields: true,
       verbatimModuleSyntax: false,
+      react: { runtime: 'classic', development: false },
     });
   });
 
@@ -161,6 +163,35 @@ describe('resolveSwcTranspilationTransform', () => {
     });
   });
 
+  it.each([
+    [{}, { runtime: 'classic', development: false }],
+    [{ jsx: 'react' }, { runtime: 'classic', development: false }],
+    [{ jsx: 'preserve' }, { runtime: 'classic', development: false }],
+    [{ jsx: 'react-native' }, { runtime: 'classic', development: false }],
+    [{ jsx: 'react-jsx' }, { runtime: 'automatic', development: false }],
+    [{ jsx: 'react-jsxdev' }, { runtime: 'automatic', development: true }],
+    [
+      { jsx: 'react', jsxFactory: 'h', jsxFragmentFactory: 'F' },
+      { runtime: 'classic', development: false, pragma: 'h', pragmaFrag: 'F' },
+    ],
+    [
+      { jsx: 'react-jsx', jsxImportSource: 'preact' },
+      { runtime: 'automatic', development: false, importSource: 'preact' },
+    ],
+  ])(
+    'should derive the JSX transform from %o like esbuild',
+    (jsxOptions, expected) => {
+      const path = writeTsConfig(`jsx-${jsxCaseId++}.json`, {
+        target: 'ES2022',
+        ...jsxOptions,
+      });
+
+      expect(resolveSwcTranspilationTransform(path, '2023-11').react).toEqual(
+        expected
+      );
+    }
+  );
+
   it('should resolve options through an extends chain', () => {
     realFs.mkdirSync(join(dir, 'nested'), { recursive: true });
     realFs.writeFileSync(
@@ -188,6 +219,7 @@ describe('resolveSwcTranspilationTransform', () => {
         decoratorMetadata: false,
         useDefineForClassFields: false,
         verbatimModuleSyntax: false,
+        react: { runtime: 'classic', development: false },
       });
     }
   });

--- a/packages/angular-rspack-compiler/src/utils/typescript-compiler-options.spec.ts
+++ b/packages/angular-rspack-compiler/src/utils/typescript-compiler-options.spec.ts
@@ -1,6 +1,18 @@
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import * as ts from 'typescript';
-import { describe, expect, it } from 'vitest';
-import { applyEs2022TargetDefaults } from './typescript-compiler-options';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import {
+  applyEs2022TargetDefaults,
+  resolveSwcTranspilationTransform,
+} from './typescript-compiler-options';
+
+// The tsconfig fixtures must live on the real filesystem: the package test
+// setup mocks `fs` with memfs, but `ts.sys` reads configs outside the mock.
+let realFs: typeof import('node:fs');
+beforeAll(async () => {
+  realFs = await vi.importActual<typeof import('node:fs')>('node:fs');
+});
 
 describe('applyEs2022TargetDefaults', () => {
   it.each([
@@ -32,4 +44,151 @@ describe('applyEs2022TargetDefaults', () => {
       expect(compilerOptions.useDefineForClassFields).toBe(udcf);
     }
   );
+});
+
+describe('resolveSwcTranspilationTransform', () => {
+  let dir: string;
+
+  const writeTsConfig = (
+    name: string,
+    compilerOptions: Record<string, unknown>,
+    extendsPath?: string
+  ) => {
+    const path = join(dir, name);
+    realFs.writeFileSync(
+      path,
+      JSON.stringify({
+        ...(extendsPath ? { extends: extendsPath } : {}),
+        compilerOptions,
+        files: [],
+      })
+    );
+    return path;
+  };
+
+  beforeAll(() => {
+    dir = realFs.mkdtempSync(join(tmpdir(), 'swc-transform-'));
+  });
+
+  afterAll(() => {
+    realFs.rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('should derive legacy decorator semantics for the default Angular tsconfig', () => {
+    const path = writeTsConfig('ng-default.json', {
+      experimentalDecorators: true,
+      isolatedModules: true,
+      target: 'ES2022',
+    });
+
+    expect(resolveSwcTranspilationTransform(path, '2023-11')).toEqual({
+      legacyDecorator: true,
+      decoratorMetadata: false,
+      useDefineForClassFields: true,
+      verbatimModuleSyntax: false,
+    });
+  });
+
+  it('should use assignment class field semantics when the target is below ES2022', () => {
+    const path = writeTsConfig('mf.json', {
+      experimentalDecorators: true,
+      target: 'ES2020',
+    });
+
+    expect(resolveSwcTranspilationTransform(path, '2023-11')).toMatchObject({
+      useDefineForClassFields: false,
+    });
+  });
+
+  it('should keep an explicit useDefineForClassFields', () => {
+    const belowTarget = writeTsConfig('udcf-below.json', {
+      target: 'ES2020',
+      useDefineForClassFields: true,
+    });
+    const es2022 = writeTsConfig('udcf-es2022.json', {
+      target: 'ES2022',
+      useDefineForClassFields: false,
+    });
+
+    expect(
+      resolveSwcTranspilationTransform(belowTarget, '2023-11')
+    ).toMatchObject({
+      useDefineForClassFields: true,
+    });
+    expect(resolveSwcTranspilationTransform(es2022, '2023-11')).toMatchObject({
+      useDefineForClassFields: false,
+    });
+  });
+
+  it('should select standard decorators with the given revision when experimentalDecorators is not set', () => {
+    const path = writeTsConfig('tc39.json', { target: 'ES2022' });
+
+    expect(resolveSwcTranspilationTransform(path, '2022-03')).toMatchObject({
+      legacyDecorator: false,
+      decoratorVersion: '2022-03',
+    });
+  });
+
+  it('should emit decorator metadata only with legacy decorators', () => {
+    const legacy = writeTsConfig('metadata-legacy.json', {
+      experimentalDecorators: true,
+      emitDecoratorMetadata: true,
+      target: 'ES2022',
+    });
+    const standard = writeTsConfig('metadata-standard.json', {
+      emitDecoratorMetadata: true,
+      target: 'ES2022',
+    });
+
+    expect(resolveSwcTranspilationTransform(legacy, '2023-11')).toMatchObject({
+      decoratorMetadata: true,
+    });
+    expect(resolveSwcTranspilationTransform(standard, '2023-11')).toMatchObject(
+      {
+        decoratorMetadata: false,
+      }
+    );
+  });
+
+  it('should honor verbatimModuleSyntax', () => {
+    const path = writeTsConfig('vms.json', {
+      target: 'ES2022',
+      verbatimModuleSyntax: true,
+    });
+
+    expect(resolveSwcTranspilationTransform(path, '2023-11')).toMatchObject({
+      verbatimModuleSyntax: true,
+    });
+  });
+
+  it('should resolve options through an extends chain', () => {
+    realFs.mkdirSync(join(dir, 'nested'), { recursive: true });
+    realFs.writeFileSync(
+      join(dir, 'nested', 'base.json'),
+      JSON.stringify({
+        compilerOptions: { experimentalDecorators: true, target: 'ES2020' },
+      })
+    );
+    const path = writeTsConfig('child.json', {}, './nested/base.json');
+
+    expect(resolveSwcTranspilationTransform(path, '2023-11')).toMatchObject({
+      legacyDecorator: true,
+      useDefineForClassFields: false,
+    });
+  });
+
+  it('should derive the forced defaults when the tsconfig is missing or malformed', () => {
+    const malformed = join(dir, 'malformed.json');
+    realFs.writeFileSync(malformed, '{ not json');
+
+    for (const path of [join(dir, 'missing.json'), malformed]) {
+      expect(resolveSwcTranspilationTransform(path, '2023-11')).toEqual({
+        legacyDecorator: false,
+        decoratorVersion: '2023-11',
+        decoratorMetadata: false,
+        useDefineForClassFields: false,
+        verbatimModuleSyntax: false,
+      });
+    }
+  });
 });

--- a/packages/angular-rspack-compiler/src/utils/typescript-compiler-options.ts
+++ b/packages/angular-rspack-compiler/src/utils/typescript-compiler-options.ts
@@ -1,3 +1,4 @@
+import { dirname } from 'node:path';
 import * as ts from 'typescript';
 
 /**
@@ -19,4 +20,60 @@ export function applyEs2022TargetDefaults(
     return true;
   }
   return false;
+}
+
+/**
+ * The `jsc.transform` options for the swc rule that transpiles TypeScript
+ * emitted by the Angular compilation (and raw sources), derived from the
+ * project's tsconfig so the output keeps the semantics the type program
+ * assumed.
+ */
+export interface SwcTranspilationTransform {
+  legacyDecorator: boolean;
+  /**
+   * The revision applied for standard (TC39) decorators
+   * (`legacyDecorator: false`); swc's default revision predates the
+   * semantics TypeScript implements.
+   */
+  decoratorVersion?: '2022-03' | '2023-11';
+  decoratorMetadata: boolean;
+  useDefineForClassFields: boolean;
+  verbatimModuleSyntax: boolean;
+}
+
+export function resolveSwcTranspilationTransform(
+  tsconfigPath: string,
+  standardDecoratorVersion: '2022-03' | '2023-11'
+): SwcTranspilationTransform {
+  // Read errors are reported in-band and deliberately ignored: a missing or
+  // malformed tsconfig recovers to the forced defaults here, and the build
+  // still fails through rspack's own resolution of the same tsconfig path.
+  const configFile = ts.readConfigFile(tsconfigPath, ts.sys.readFile);
+  const compilerOptions: ts.CompilerOptions = {
+    ...ts.parseJsonConfigFileContent(
+      configFile.config,
+      ts.sys,
+      dirname(tsconfigPath)
+    ).options,
+  };
+
+  applyEs2022TargetDefaults(compilerOptions);
+
+  const legacyDecorator = !!compilerOptions.experimentalDecorators;
+
+  return {
+    legacyDecorator,
+    ...(legacyDecorator ? {} : { decoratorVersion: standardDecoratorVersion }),
+    // Design-type metadata comes from the type checker; swc emits what the
+    // annotations alone provide, which is as much as a per-file transpiler
+    // can honor.
+    decoratorMetadata:
+      legacyDecorator && !!compilerOptions.emitDecoratorMetadata,
+    // With the target raised to ES2022 the forced default is false; an
+    // ES2022+ tsconfig without the option gets TypeScript's default. For a
+    // target-less tsconfig esbuild instead uses its own default of true,
+    // contradicting the program options it forces; we follow the program.
+    useDefineForClassFields: compilerOptions.useDefineForClassFields ?? true,
+    verbatimModuleSyntax: !!compilerOptions.verbatimModuleSyntax,
+  };
 }

--- a/packages/angular-rspack-compiler/src/utils/typescript-compiler-options.ts
+++ b/packages/angular-rspack-compiler/src/utils/typescript-compiler-options.ts
@@ -1,0 +1,22 @@
+import * as ts from 'typescript';
+
+/**
+ * Raises `target` to ES2022, the syntax the bundling pipeline emits
+ * regardless of the configured target, defaulting `useDefineForClassFields`
+ * to `false` in that case to keep the assignment semantics a lower target
+ * implied. Returns whether the options were adjusted so callers can surface
+ * a setup warning.
+ */
+export function applyEs2022TargetDefaults(
+  compilerOptions: ts.CompilerOptions
+): boolean {
+  if (
+    compilerOptions.target === undefined ||
+    compilerOptions.target < ts.ScriptTarget.ES2022
+  ) {
+    compilerOptions.target = ts.ScriptTarget.ES2022;
+    compilerOptions.useDefineForClassFields ??= false;
+    return true;
+  }
+  return false;
+}

--- a/packages/angular-rspack-compiler/src/utils/typescript-compiler-options.ts
+++ b/packages/angular-rspack-compiler/src/utils/typescript-compiler-options.ts
@@ -39,6 +39,18 @@ export interface SwcTranspilationTransform {
   decoratorMetadata: boolean;
   useDefineForClassFields: boolean;
   verbatimModuleSyntax: boolean;
+  /**
+   * JSX lowering for `.tsx` sources, read from the tsconfig the way esbuild
+   * does: the automatic runtime for 'react-jsx'/'react-jsxdev', the classic
+   * transform otherwise ('preserve' included; esbuild lowers it too).
+   */
+  react: {
+    runtime: 'automatic' | 'classic';
+    development: boolean;
+    pragma?: string;
+    pragmaFrag?: string;
+    importSource?: string;
+  };
 }
 
 export function resolveSwcTranspilationTransform(
@@ -75,5 +87,25 @@ export function resolveSwcTranspilationTransform(
     // contradicting the program options it forces; we follow the program.
     useDefineForClassFields: compilerOptions.useDefineForClassFields ?? true,
     verbatimModuleSyntax: !!compilerOptions.verbatimModuleSyntax,
+    react: resolveJsxTransform(compilerOptions),
+  };
+}
+
+// swc's factory defaults (React.createElement, React.Fragment, 'react')
+// match esbuild's, so the options are only set when the tsconfig sets them.
+function resolveJsxTransform(
+  compilerOptions: ts.CompilerOptions
+): SwcTranspilationTransform['react'] {
+  const { jsx, jsxFactory, jsxFragmentFactory, jsxImportSource } =
+    compilerOptions;
+  return {
+    runtime:
+      jsx === ts.JsxEmit.ReactJSX || jsx === ts.JsxEmit.ReactJSXDev
+        ? 'automatic'
+        : 'classic',
+    development: jsx === ts.JsxEmit.ReactJSXDev,
+    ...(jsxFactory ? { pragma: jsxFactory } : {}),
+    ...(jsxFragmentFactory ? { pragmaFrag: jsxFragmentFactory } : {}),
+    ...(jsxImportSource ? { importSource: jsxImportSource } : {}),
   };
 }

--- a/packages/angular-rspack/package.json
+++ b/packages/angular-rspack/package.json
@@ -65,7 +65,6 @@
     "css-loader": "^7.1.2",
     "jsonc-parser": "catalog:",
     "less-loader": "catalog:css",
-    "license-webpack-plugin": "^4.0.2",
     "loader-utils": "3.3.1",
     "open": "10.1.0",
     "ora": "catalog:",

--- a/packages/angular-rspack/src/lib/config/config-utils/browser-config.ts
+++ b/packages/angular-rspack/src/lib/config/config-utils/browser-config.ts
@@ -1,7 +1,4 @@
-import {
-  TS_ALL_EXT_REGEX,
-  type SwcTranspilationTransform,
-} from '@nx/angular-rspack-compiler';
+import type { SwcTranspilationTransform } from '@nx/angular-rspack-compiler';
 import type { Configuration } from '@rspack/core';
 import { isRspackV2 } from '../../utils/rspack-version';
 import { isServeMode } from '../../utils/rspack-serve-env';
@@ -15,6 +12,7 @@ import type { SharedLicenseInputs } from '../../plugins/extract-licenses-plugin'
 import { getDevServerConfig } from './dev-server-config-utils';
 import { getPolyfillsEntry, toRspackEntries } from './entry-points';
 import { getOptimization } from './optimization-config';
+import { getSwcTranspilationRules } from './swc-transpilation';
 import { resolve } from 'path';
 import { HmrLoader } from '../../plugins/loaders/hmr-accept-loader';
 
@@ -83,28 +81,7 @@ export async function getBrowserConfig(
     module: {
       ...defaultConfig.module,
       rules: [
-        {
-          test: TS_ALL_EXT_REGEX,
-          use: [
-            {
-              loader: 'builtin:swc-loader',
-              options: {
-                jsc: {
-                  parser: {
-                    syntax: 'typescript',
-                    // Angular's fast emit path can leave decorators in the
-                    // output; parse them regardless of which semantics the
-                    // transform applies.
-                    decorators: true,
-                  },
-                  // Transpile with the semantics the type program assumed.
-                  transform: swcTranspilationTransform,
-                  target: 'es2022',
-                },
-              },
-            },
-          ],
-        },
+        ...getSwcTranspilationRules(swcTranspilationTransform),
         ...(normalizedOptions.devServer?.hmr
           ? [
               {

--- a/packages/angular-rspack/src/lib/config/config-utils/browser-config.ts
+++ b/packages/angular-rspack/src/lib/config/config-utils/browser-config.ts
@@ -8,6 +8,7 @@ import type {
   NormalizedAngularRspackPluginOptions,
 } from '../../models';
 import { NgRspackPlugin } from '../../plugins/ng-rspack';
+import type { SharedLicenseInputs } from '../../plugins/extract-licenses-plugin';
 import { getDevServerConfig } from './dev-server-config-utils';
 import { getPolyfillsEntry, toRspackEntries } from './entry-points';
 import { getOptimization } from './optimization-config';
@@ -18,7 +19,8 @@ export async function getBrowserConfig(
   normalizedOptions: NormalizedAngularRspackPluginOptions,
   i18n: I18nOptions,
   hashFormat: HashFormat,
-  defaultConfig: Configuration
+  defaultConfig: Configuration,
+  sharedLicenseInputs?: SharedLicenseInputs
 ): Promise<Configuration> {
   const isDevServer = isServeMode();
   const isProduction = process.env['NODE_ENV'] === 'production';
@@ -109,6 +111,7 @@ export async function getBrowserConfig(
       new NgRspackPlugin(normalizedOptions, {
         i18nOptions: i18n,
         platform: 'browser',
+        sharedLicenseInputs,
       }),
     ],
   };

--- a/packages/angular-rspack/src/lib/config/config-utils/browser-config.ts
+++ b/packages/angular-rspack/src/lib/config/config-utils/browser-config.ts
@@ -88,6 +88,13 @@ export async function getBrowserConfig(
                 jsc: {
                   parser: {
                     syntax: 'typescript',
+                    // Angular's fast emit path can leave decorators in the
+                    // output; compile them with the legacy semantics the
+                    // default tsconfig (experimentalDecorators) implies.
+                    decorators: true,
+                  },
+                  transform: {
+                    legacyDecorator: true,
                   },
                   target: 'es2022',
                 },

--- a/packages/angular-rspack/src/lib/config/config-utils/browser-config.ts
+++ b/packages/angular-rspack/src/lib/config/config-utils/browser-config.ts
@@ -8,6 +8,7 @@ import type {
   NormalizedAngularRspackPluginOptions,
 } from '../../models';
 import { NgRspackPlugin } from '../../plugins/ng-rspack';
+import type { AngularRspackPlugin } from '../../plugins/angular-rspack-plugin';
 import type { SharedLicenseInputs } from '../../plugins/extract-licenses-plugin';
 import { getDevServerConfig } from './dev-server-config-utils';
 import { getPolyfillsEntry, toRspackEntries } from './entry-points';
@@ -22,7 +23,8 @@ export async function getBrowserConfig(
   hashFormat: HashFormat,
   defaultConfig: Configuration,
   swcTranspilationTransform: SwcTranspilationTransform,
-  sharedLicenseInputs?: SharedLicenseInputs
+  sharedLicenseInputs?: SharedLicenseInputs,
+  sharedAngularPlugin?: AngularRspackPlugin
 ): Promise<Configuration> {
   const isDevServer = isServeMode();
   const isProduction = process.env['NODE_ENV'] === 'production';
@@ -99,6 +101,7 @@ export async function getBrowserConfig(
         i18nOptions: i18n,
         platform: 'browser',
         sharedLicenseInputs,
+        sharedAngularPlugin,
       }),
     ],
   };

--- a/packages/angular-rspack/src/lib/config/config-utils/browser-config.ts
+++ b/packages/angular-rspack/src/lib/config/config-utils/browser-config.ts
@@ -1,4 +1,7 @@
-import { TS_ALL_EXT_REGEX } from '@nx/angular-rspack-compiler';
+import {
+  TS_ALL_EXT_REGEX,
+  type SwcTranspilationTransform,
+} from '@nx/angular-rspack-compiler';
 import type { Configuration } from '@rspack/core';
 import { isRspackV2 } from '../../utils/rspack-version';
 import { isServeMode } from '../../utils/rspack-serve-env';
@@ -20,6 +23,7 @@ export async function getBrowserConfig(
   i18n: I18nOptions,
   hashFormat: HashFormat,
   defaultConfig: Configuration,
+  swcTranspilationTransform: SwcTranspilationTransform,
   sharedLicenseInputs?: SharedLicenseInputs
 ): Promise<Configuration> {
   const isDevServer = isServeMode();
@@ -89,13 +93,12 @@ export async function getBrowserConfig(
                   parser: {
                     syntax: 'typescript',
                     // Angular's fast emit path can leave decorators in the
-                    // output; compile them with the legacy semantics the
-                    // default tsconfig (experimentalDecorators) implies.
+                    // output; parse them regardless of which semantics the
+                    // transform applies.
                     decorators: true,
                   },
-                  transform: {
-                    legacyDecorator: true,
-                  },
+                  // Transpile with the semantics the type program assumed.
+                  transform: swcTranspilationTransform,
                   target: 'es2022',
                 },
               },

--- a/packages/angular-rspack/src/lib/config/config-utils/server-config.ts
+++ b/packages/angular-rspack/src/lib/config/config-utils/server-config.ts
@@ -1,5 +1,9 @@
 import type { SwcTranspilationTransform } from '@nx/angular-rspack-compiler';
-import { type Configuration, ContextReplacementPlugin } from '@rspack/core';
+import {
+  type Configuration,
+  ContextReplacementPlugin,
+  DefinePlugin,
+} from '@rspack/core';
 import { resolve } from 'path';
 import type {
   I18nOptions,
@@ -82,6 +86,11 @@ export async function getServerConfig(
       ...(defaultConfig.plugins ?? []),
       // Fixes Critical dependency: the request of a dependency is an expression
       new ContextReplacementPlugin(/@?hapi|express[\\/]/),
+      // rspack inlines `import.meta.url` as the source file's URL, breaking
+      // the `isMainModule` listen gate; point it at the emitted bundle.
+      new DefinePlugin({
+        'import.meta.url': "require('node:url').pathToFileURL(__filename).href",
+      }),
       new NgRspackPlugin(normalizedOptions, {
         i18nOptions: i18n,
         platform: 'server',

--- a/packages/angular-rspack/src/lib/config/config-utils/server-config.ts
+++ b/packages/angular-rspack/src/lib/config/config-utils/server-config.ts
@@ -1,4 +1,7 @@
-import { TS_ALL_EXT_REGEX } from '@nx/angular-rspack-compiler';
+import {
+  TS_ALL_EXT_REGEX,
+  type SwcTranspilationTransform,
+} from '@nx/angular-rspack-compiler';
 import { type Configuration, ContextReplacementPlugin } from '@rspack/core';
 import { resolve } from 'path';
 import type {
@@ -17,6 +20,7 @@ export async function getServerConfig(
   normalizedOptions: NormalizedAngularRspackPluginOptions,
   i18n: I18nOptions,
   defaultConfig: Configuration,
+  swcTranspilationTransform: SwcTranspilationTransform,
   sharedLicenseInputs?: SharedLicenseInputs
 ): Promise<Configuration> {
   const isDevServer = isServeMode();
@@ -67,13 +71,12 @@ export async function getServerConfig(
                   parser: {
                     syntax: 'typescript',
                     // Angular's fast emit path can leave decorators in the
-                    // output; compile them with the legacy semantics the
-                    // default tsconfig (experimentalDecorators) implies.
+                    // output; parse them regardless of which semantics the
+                    // transform applies.
                     decorators: true,
                   },
-                  transform: {
-                    legacyDecorator: true,
-                  },
+                  // Transpile with the semantics the type program assumed.
+                  transform: swcTranspilationTransform,
                   target: 'es2022',
                 },
               },

--- a/packages/angular-rspack/src/lib/config/config-utils/server-config.ts
+++ b/packages/angular-rspack/src/lib/config/config-utils/server-config.ts
@@ -1,7 +1,4 @@
-import {
-  TS_ALL_EXT_REGEX,
-  type SwcTranspilationTransform,
-} from '@nx/angular-rspack-compiler';
+import type { SwcTranspilationTransform } from '@nx/angular-rspack-compiler';
 import { type Configuration, ContextReplacementPlugin } from '@rspack/core';
 import { resolve } from 'path';
 import type {
@@ -14,6 +11,7 @@ import { PrerenderPlugin } from '../../plugins/prerender-plugin';
 import { isPackageInstalled } from '../../utils/misc-helpers';
 import { getDevServerConfig } from './dev-server-config-utils';
 import { getOptimization } from './optimization-config';
+import { getSwcTranspilationRules } from './swc-transpilation';
 import { isServeMode } from '../../utils/rspack-serve-env';
 
 export async function getServerConfig(
@@ -61,28 +59,7 @@ export async function getServerConfig(
     module: {
       ...defaultConfig.module,
       rules: [
-        {
-          test: TS_ALL_EXT_REGEX,
-          use: [
-            {
-              loader: 'builtin:swc-loader',
-              options: {
-                jsc: {
-                  parser: {
-                    syntax: 'typescript',
-                    // Angular's fast emit path can leave decorators in the
-                    // output; parse them regardless of which semantics the
-                    // transform applies.
-                    decorators: true,
-                  },
-                  // Transpile with the semantics the type program assumed.
-                  transform: swcTranspilationTransform,
-                  target: 'es2022',
-                },
-              },
-            },
-          ],
-        },
+        ...getSwcTranspilationRules(swcTranspilationTransform),
         {
           // eslint-disable-next-line @nx/enforce-module-boundaries
           loader: require.resolve(

--- a/packages/angular-rspack/src/lib/config/config-utils/server-config.ts
+++ b/packages/angular-rspack/src/lib/config/config-utils/server-config.ts
@@ -6,6 +6,7 @@ import type {
   NormalizedAngularRspackPluginOptions,
 } from '../../models';
 import { NgRspackPlugin } from '../../plugins/ng-rspack';
+import type { SharedLicenseInputs } from '../../plugins/extract-licenses-plugin';
 import { PrerenderPlugin } from '../../plugins/prerender-plugin';
 import { isPackageInstalled } from '../../utils/misc-helpers';
 import { getDevServerConfig } from './dev-server-config-utils';
@@ -15,7 +16,8 @@ import { isServeMode } from '../../utils/rspack-serve-env';
 export async function getServerConfig(
   normalizedOptions: NormalizedAngularRspackPluginOptions,
   i18n: I18nOptions,
-  defaultConfig: Configuration
+  defaultConfig: Configuration,
+  sharedLicenseInputs?: SharedLicenseInputs
 ): Promise<Configuration> {
   const isDevServer = isServeMode();
   const { root } = normalizedOptions;
@@ -94,6 +96,7 @@ export async function getServerConfig(
       new NgRspackPlugin(normalizedOptions, {
         i18nOptions: i18n,
         platform: 'server',
+        sharedLicenseInputs,
       }),
       ...(normalizedOptions.prerender ||
       (normalizedOptions.appShell && !isDevServer)

--- a/packages/angular-rspack/src/lib/config/config-utils/server-config.ts
+++ b/packages/angular-rspack/src/lib/config/config-utils/server-config.ts
@@ -6,6 +6,7 @@ import type {
   NormalizedAngularRspackPluginOptions,
 } from '../../models';
 import { NgRspackPlugin } from '../../plugins/ng-rspack';
+import type { AngularRspackPlugin } from '../../plugins/angular-rspack-plugin';
 import type { SharedLicenseInputs } from '../../plugins/extract-licenses-plugin';
 import { PrerenderPlugin } from '../../plugins/prerender-plugin';
 import { isPackageInstalled } from '../../utils/misc-helpers';
@@ -19,7 +20,8 @@ export async function getServerConfig(
   i18n: I18nOptions,
   defaultConfig: Configuration,
   swcTranspilationTransform: SwcTranspilationTransform,
-  sharedLicenseInputs?: SharedLicenseInputs
+  sharedLicenseInputs?: SharedLicenseInputs,
+  sharedAngularPlugin?: AngularRspackPlugin
 ): Promise<Configuration> {
   const isDevServer = isServeMode();
   const { root } = normalizedOptions;
@@ -84,6 +86,7 @@ export async function getServerConfig(
         i18nOptions: i18n,
         platform: 'server',
         sharedLicenseInputs,
+        sharedAngularPlugin,
       }),
       ...(normalizedOptions.prerender ||
       (normalizedOptions.appShell && !isDevServer)

--- a/packages/angular-rspack/src/lib/config/config-utils/server-config.ts
+++ b/packages/angular-rspack/src/lib/config/config-utils/server-config.ts
@@ -66,6 +66,13 @@ export async function getServerConfig(
                 jsc: {
                   parser: {
                     syntax: 'typescript',
+                    // Angular's fast emit path can leave decorators in the
+                    // output; compile them with the legacy semantics the
+                    // default tsconfig (experimentalDecorators) implies.
+                    decorators: true,
+                  },
+                  transform: {
+                    legacyDecorator: true,
                   },
                   target: 'es2022',
                 },

--- a/packages/angular-rspack/src/lib/config/config-utils/swc-transpilation-semantics.spec.ts
+++ b/packages/angular-rspack/src/lib/config/config-utils/swc-transpilation-semantics.spec.ts
@@ -1,0 +1,360 @@
+import {
+  resolveSwcTranspilationTransform,
+  type SwcTranspilationTransform,
+} from '@nx/angular-rspack-compiler';
+import { rspack } from '@rspack/core';
+import {
+  mkdtempSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { createRequire } from 'node:module';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { pathToFileURL } from 'node:url';
+import * as ts from 'typescript';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+// Anchored on the package directory (the Nx vitest plugin runs tests with
+// the project root as cwd) instead of the module URL so the file typechecks
+// as CommonJS and runs as ESM.
+const packageDir = process.cwd();
+const nodeRequire = createRequire(join(packageDir, 'package.json'));
+
+/**
+ * Executes fixtures through rspack's builtin swc loader configured from a
+ * tsconfig and through TypeScript itself with the options the type program
+ * would use, asserting both produce the same runtime behavior. This pins the
+ * semantics the swc rule must preserve for the raw TypeScript the Angular
+ * compilation emits: class field assignment vs definition, legacy and
+ * standard (TC39) decorators, and decorator metadata.
+ */
+describe('swc transpilation semantics', () => {
+  let dir: string;
+  let caseId = 0;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), 'swc-semantics-'));
+  });
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function writeCase(
+    source: string,
+    tsconfigCompilerOptions: Record<string, unknown>
+  ) {
+    const caseDir = join(dir, `case-${caseId++}`);
+    mkdirSync(caseDir, { recursive: true });
+    writeFileSync(join(caseDir, 'index.ts'), source);
+    const tsconfigPath = join(caseDir, 'tsconfig.json');
+    writeFileSync(
+      tsconfigPath,
+      JSON.stringify({ compilerOptions: tsconfigCompilerOptions, files: [] })
+    );
+    return { caseDir, tsconfigPath };
+  }
+
+  async function buildWithSwcRule(
+    caseDir: string,
+    transform: SwcTranspilationTransform,
+    rspackInstance: typeof rspack = rspack
+  ) {
+    const outDir = join(caseDir, `out-${caseId++}`);
+    await new Promise<void>((res, rej) => {
+      rspackInstance(
+        {
+          mode: 'none',
+          context: caseDir,
+          entry: join(caseDir, 'index.ts'),
+          output: { path: outDir, filename: 'bundle.js' },
+          devtool: false,
+          resolve: { extensions: ['.ts'] },
+          module: {
+            rules: [
+              {
+                test: /\.ts$/,
+                use: [
+                  {
+                    // Mirrors the rule in browser-config.ts/server-config.ts.
+                    loader: 'builtin:swc-loader',
+                    options: {
+                      jsc: {
+                        parser: { syntax: 'typescript', decorators: true },
+                        transform,
+                        target: 'es2022',
+                      },
+                    },
+                  },
+                ],
+              },
+            ],
+          },
+        },
+        (err, stats) => {
+          if (err) {
+            rej(err);
+          } else if (stats?.hasErrors()) {
+            rej(new Error(stats.toString({ errors: true, all: false })));
+          } else {
+            res();
+          }
+        }
+      );
+    });
+    return readFileSync(join(outDir, 'bundle.js'), 'utf8');
+  }
+
+  function transpileWithTypeScript(
+    source: string,
+    compilerOptions: ts.CompilerOptions
+  ) {
+    return ts.transpileModule(source, {
+      compilerOptions: { module: ts.ModuleKind.CommonJS, ...compilerOptions },
+    }).outputText;
+  }
+
+  function execute(code: string): unknown[] {
+    const observations: unknown[] = [];
+    const globals = globalThis as { __record__?: (v: unknown) => void };
+    globals.__record__ = (v) => observations.push(v);
+    const reflect = Reflect as { metadata?: unknown };
+    // Minimal recording stand-in for the reflect-metadata polyfill so both
+    // outputs' metadata calls become observable behavior.
+    reflect.metadata = (key: string, value: unknown) => {
+      return (_target: unknown, propertyKey?: string | symbol) => {
+        observations.push([
+          key,
+          typeof value === 'function' ? value.name : value,
+          propertyKey,
+        ]);
+      };
+    };
+    try {
+      const moduleExports = {};
+      new Function('require', 'module', 'exports', code)(
+        nodeRequire,
+        { exports: moduleExports },
+        moduleExports
+      );
+    } finally {
+      delete globals.__record__;
+      delete reflect.metadata;
+    }
+    return observations;
+  }
+
+  const classFieldsFixture = `
+    const record = (globalThis as any).__record__;
+    class Base {
+      get x(): number {
+        return 42;
+      }
+      set x(value: number) {
+        record(['set', value]);
+      }
+    }
+    class Child extends Base {
+      x = 1;
+    }
+    const child = new Child();
+    record([
+      'value',
+      child.x,
+      Object.getOwnPropertyDescriptor(child, 'x') !== undefined,
+    ]);
+  `;
+
+  it('should match TypeScript class field semantics for targets below ES2022', async () => {
+    const { caseDir, tsconfigPath } = writeCase(classFieldsFixture, {
+      target: 'ES2020',
+      experimentalDecorators: true,
+    });
+
+    const swcObservations = execute(
+      await buildWithSwcRule(
+        caseDir,
+        resolveSwcTranspilationTransform(tsconfigPath, '2023-11')
+      )
+    );
+    // The type program raises the target to ES2022 with assignment
+    // semantics; the ground truth uses the same forced options.
+    const tsObservations = execute(
+      transpileWithTypeScript(classFieldsFixture, {
+        target: ts.ScriptTarget.ES2022,
+        useDefineForClassFields: false,
+        experimentalDecorators: true,
+      })
+    );
+
+    expect(swcObservations).toEqual(tsObservations);
+    expect(swcObservations).toEqual([
+      ['set', 1],
+      ['value', 42, false],
+    ]);
+  });
+
+  it('should match TypeScript class field semantics for ES2022 targets', async () => {
+    const { caseDir, tsconfigPath } = writeCase(classFieldsFixture, {
+      target: 'ES2022',
+      experimentalDecorators: true,
+    });
+
+    const swcObservations = execute(
+      await buildWithSwcRule(
+        caseDir,
+        resolveSwcTranspilationTransform(tsconfigPath, '2023-11')
+      )
+    );
+    const tsObservations = execute(
+      transpileWithTypeScript(classFieldsFixture, {
+        target: ts.ScriptTarget.ES2022,
+        experimentalDecorators: true,
+      })
+    );
+
+    expect(swcObservations).toEqual(tsObservations);
+    expect(swcObservations).toEqual([['value', 1, true]]);
+  });
+
+  it('should emit decorator metadata like TypeScript when enabled', async () => {
+    const fixture = `
+      const record = (globalThis as any).__record__;
+      function dec(target: any, key: string) {
+        record(['dec', key]);
+      }
+      class Service {}
+      class Consumer {
+        @dec name: string = 'n';
+        @dec service: Service = new Service();
+      }
+      new Consumer();
+    `;
+    const { caseDir, tsconfigPath } = writeCase(fixture, {
+      target: 'ES2022',
+      experimentalDecorators: true,
+      emitDecoratorMetadata: true,
+    });
+
+    const swcObservations = execute(
+      await buildWithSwcRule(
+        caseDir,
+        resolveSwcTranspilationTransform(tsconfigPath, '2023-11')
+      )
+    );
+    const tsObservations = execute(
+      transpileWithTypeScript(fixture, {
+        target: ts.ScriptTarget.ES2022,
+        experimentalDecorators: true,
+        emitDecoratorMetadata: true,
+      })
+    );
+
+    expect(swcObservations).toEqual(tsObservations);
+    expect(swcObservations).toContainEqual(['design:type', 'String', 'name']);
+    expect(swcObservations).toContainEqual([
+      'design:type',
+      'Service',
+      'service',
+    ]);
+  });
+
+  const tc39Fixture = `
+    const record = (globalThis as any).__record__;
+    function dec(value: any, context: any) {
+      record(['dec', context.kind, context.name, context.static]);
+      context.addInitializer?.(function (this: any) {
+        record(['init', context.kind, context.name]);
+      });
+      if (context.kind === 'method') {
+        return function (this: any, ...args: any[]) {
+          record(['call', context.name]);
+          return value.call(this, ...args);
+        };
+      }
+    }
+    @dec
+    class C {
+      @dec f = 1;
+      @dec m() {
+        return 2;
+      }
+      @dec accessor a = 3;
+      @dec static s = 4;
+    }
+    const c = new C();
+    record(['m', c.m()]);
+    record(['values', c.f, c.a, C.s]);
+  `;
+
+  it("should match TypeScript standard (TC39) decorator behavior with rspack v2's '2023-11' revision", async (ctx) => {
+    const { caseDir, tsconfigPath } = writeCase(tc39Fixture, {
+      target: 'ES2022',
+    });
+
+    // This package resolves rspack v1 whose bundled swc predates '2023-11';
+    // exercise the revision the config selects on v2 with the workspace's
+    // rspack v2 install.
+    let v2Module: typeof import('@rspack/core');
+    try {
+      v2Module = (await import(
+        pathToFileURL(
+          nodeRequire.resolve('@rspack/core', {
+            paths: [join(packageDir, '../..')],
+          })
+        ).href
+      )) as typeof import('@rspack/core');
+    } catch {
+      return ctx.skip('workspace rspack v2 install not resolvable');
+    }
+    if (parseInt(v2Module.rspackVersion ?? '1', 10) < 2) {
+      return ctx.skip('workspace rspack is not v2');
+    }
+    const rspackV2 = v2Module.rspack;
+
+    const swcObservations = execute(
+      await buildWithSwcRule(
+        caseDir,
+        resolveSwcTranspilationTransform(tsconfigPath, '2023-11'),
+        rspackV2
+      )
+    );
+    const tsObservations = execute(
+      transpileWithTypeScript(tc39Fixture, { target: ts.ScriptTarget.ES2022 })
+    );
+
+    expect(swcObservations).toEqual(tsObservations);
+  });
+
+  it("should keep TC39 decorator outcomes with rspack v1's '2022-03' fallback revision", async () => {
+    const { caseDir, tsconfigPath } = writeCase(tc39Fixture, {
+      target: 'ES2022',
+    });
+
+    const swcObservations = execute(
+      await buildWithSwcRule(
+        caseDir,
+        resolveSwcTranspilationTransform(tsconfigPath, '2022-03')
+      )
+    );
+    const tsObservations = execute(
+      transpileWithTypeScript(tc39Fixture, { target: ts.ScriptTarget.ES2022 })
+    );
+
+    // The '2022-03' revision applies decorators and initializers in a
+    // different order than the final spec TypeScript implements, and its
+    // swc emit drops field addInitializer callbacks entirely; the decorated
+    // members must still end up with the same values and wrappers.
+    expect(swcObservations).toContainEqual(['call', 'm']);
+    expect(swcObservations).toContainEqual(['m', 2]);
+    expect(swcObservations).toContainEqual(['values', 1, 3, 4]);
+    expect(
+      new Set(swcObservations.filter((o) => (o as unknown[])[0] === 'dec'))
+    ).toEqual(
+      new Set(tsObservations.filter((o) => (o as unknown[])[0] === 'dec'))
+    );
+  });
+});

--- a/packages/angular-rspack/src/lib/config/config-utils/swc-transpilation-semantics.spec.ts
+++ b/packages/angular-rspack/src/lib/config/config-utils/swc-transpilation-semantics.spec.ts
@@ -16,6 +16,7 @@ import { join } from 'node:path';
 import { pathToFileURL } from 'node:url';
 import * as ts from 'typescript';
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { getSwcTranspilationRules } from './swc-transpilation';
 
 // Anchored on the package directory (the Nx vitest plugin runs tests with
 // the project root as cwd) instead of the module URL so the file typechecks
@@ -29,7 +30,8 @@ const nodeRequire = createRequire(join(packageDir, 'package.json'));
  * would use, asserting both produce the same runtime behavior. This pins the
  * semantics the swc rule must preserve for the raw TypeScript the Angular
  * compilation emits: class field assignment vs definition, legacy and
- * standard (TC39) decorators, and decorator metadata.
+ * standard (TC39) decorators, decorator metadata, and JSX lowering for
+ * `.tsx` sources.
  */
 describe('swc transpilation semantics', () => {
   let dir: string;
@@ -45,23 +47,26 @@ describe('swc transpilation semantics', () => {
 
   function writeCase(
     source: string,
-    tsconfigCompilerOptions: Record<string, unknown>
+    tsconfigCompilerOptions: Record<string, unknown>,
+    ext = 'ts'
   ) {
     const caseDir = join(dir, `case-${caseId++}`);
     mkdirSync(caseDir, { recursive: true });
-    writeFileSync(join(caseDir, 'index.ts'), source);
+    const entry = join(caseDir, `index.${ext}`);
+    writeFileSync(entry, source);
     const tsconfigPath = join(caseDir, 'tsconfig.json');
     writeFileSync(
       tsconfigPath,
       JSON.stringify({ compilerOptions: tsconfigCompilerOptions, files: [] })
     );
-    return { caseDir, tsconfigPath };
+    return { caseDir, tsconfigPath, entry };
   }
 
   async function buildWithSwcRule(
     caseDir: string,
     transform: SwcTranspilationTransform,
-    rspackInstance: typeof rspack = rspack
+    rspackInstance: typeof rspack = rspack,
+    entry: string = join(caseDir, 'index.ts')
   ) {
     const outDir = join(caseDir, `out-${caseId++}`);
     await new Promise<void>((res, rej) => {
@@ -69,29 +74,14 @@ describe('swc transpilation semantics', () => {
         {
           mode: 'none',
           context: caseDir,
-          entry: join(caseDir, 'index.ts'),
+          entry,
           output: { path: outDir, filename: 'bundle.js' },
           devtool: false,
-          resolve: { extensions: ['.ts'] },
+          // '.js' resolves the bundled jsx runtime the automatic-runtime case
+          // pulls in; the explicit list overrides rspack's default extensions.
+          resolve: { extensions: ['.ts', '.tsx', '.js'] },
           module: {
-            rules: [
-              {
-                test: /\.ts$/,
-                use: [
-                  {
-                    // Mirrors the rule in browser-config.ts/server-config.ts.
-                    loader: 'builtin:swc-loader',
-                    options: {
-                      jsc: {
-                        parser: { syntax: 'typescript', decorators: true },
-                        transform,
-                        target: 'es2022',
-                      },
-                    },
-                  },
-                ],
-              },
-            ],
+            rules: getSwcTranspilationRules(transform),
           },
         },
         (err, stats) => {
@@ -113,11 +103,14 @@ describe('swc transpilation semantics', () => {
     compilerOptions: ts.CompilerOptions
   ) {
     return ts.transpileModule(source, {
+      // The `.tsx` name only changes how `<` parses; no existing fixture uses
+      // an angle-bracket cast, so it is safe to set unconditionally.
+      fileName: 'index.tsx',
       compilerOptions: { module: ts.ModuleKind.CommonJS, ...compilerOptions },
     }).outputText;
   }
 
-  function execute(code: string): unknown[] {
+  function execute(code: string, requireFn = nodeRequire): unknown[] {
     const observations: unknown[] = [];
     const globals = globalThis as { __record__?: (v: unknown) => void };
     globals.__record__ = (v) => observations.push(v);
@@ -136,7 +129,7 @@ describe('swc transpilation semantics', () => {
     try {
       const moduleExports = {};
       new Function('require', 'module', 'exports', code)(
-        nodeRequire,
+        requireFn,
         { exports: moduleExports },
         moduleExports
       );
@@ -356,5 +349,103 @@ describe('swc transpilation semantics', () => {
     ).toEqual(
       new Set(tsObservations.filter((o) => (o as unknown[])[0] === 'dec'))
     );
+  });
+
+  it('should match TypeScript classic JSX lowering for .tsx sources', async () => {
+    const jsxFixture = `
+      const record = (globalThis as any).__record__;
+      function h(tag: any, props: unknown, ...children: unknown[]) {
+        record(['h', typeof tag === 'function' ? tag.name : tag, props, children]);
+        return { tag };
+      }
+      function F() {}
+      export const el = <div id={'a'}>hi<span>x</span></div>;
+      export const frag = <>{el}</>;
+    `;
+    const { caseDir, tsconfigPath, entry } = writeCase(
+      jsxFixture,
+      {
+        target: 'ES2022',
+        jsx: 'react',
+        jsxFactory: 'h',
+        jsxFragmentFactory: 'F',
+      },
+      'tsx'
+    );
+
+    // These fixtures carry no decorators, so the revision does not affect the
+    // JSX output; '2022-03' keeps the default rspack v1 swc from rejecting the
+    // '2023-11' decorator config it does not implement.
+    const swcObservations = execute(
+      await buildWithSwcRule(
+        caseDir,
+        resolveSwcTranspilationTransform(tsconfigPath, '2022-03'),
+        rspack,
+        entry
+      )
+    );
+    const tsObservations = execute(
+      transpileWithTypeScript(jsxFixture, {
+        target: ts.ScriptTarget.ES2022,
+        jsx: ts.JsxEmit.React,
+        jsxFactory: 'h',
+        jsxFragmentFactory: 'F',
+      })
+    );
+
+    expect(swcObservations).toEqual(tsObservations);
+    expect(swcObservations.length).toBeGreaterThan(0);
+  });
+
+  it('should match TypeScript automatic-runtime JSX lowering for .tsx sources', async () => {
+    const jsxFixture = `
+      const record = (globalThis as any).__record__;
+      export const el = <div id={'a'}>hi<span>x</span></div>;
+      record(['el', (el as any).type ?? '?']);
+    `;
+    const { caseDir, tsconfigPath, entry } = writeCase(
+      jsxFixture,
+      { target: 'ES2022', jsx: 'react-jsx', jsxImportSource: 'myjsx' },
+      'tsx'
+    );
+
+    // Recording runtime resolved from the case dir: rspack bundles it into
+    // the swc output, and the TypeScript ground truth requires it at runtime.
+    const runtimeDir = join(caseDir, 'node_modules', 'myjsx');
+    mkdirSync(runtimeDir, { recursive: true });
+    writeFileSync(
+      join(runtimeDir, 'package.json'),
+      JSON.stringify({ name: 'myjsx', version: '1.0.0' })
+    );
+    writeFileSync(
+      join(runtimeDir, 'jsx-runtime.js'),
+      `const record = (...a) => globalThis.__record__(...a);
+exports.jsx = (t, p, k) => { record(['jsx', (t && t.name) || t, p, k]); return { type: t }; };
+exports.jsxs = (t, p, k) => { record(['jsxs', (t && t.name) || t, p, k]); return { type: t }; };
+exports.Fragment = Symbol.for('frag');
+`
+    );
+
+    // No decorators here either; '2022-03' avoids the default rspack v1 swc
+    // panic on the '2023-11' revision without changing the JSX output.
+    const swcObservations = execute(
+      await buildWithSwcRule(
+        caseDir,
+        resolveSwcTranspilationTransform(tsconfigPath, '2022-03'),
+        rspack,
+        entry
+      )
+    );
+    const tsObservations = execute(
+      transpileWithTypeScript(jsxFixture, {
+        target: ts.ScriptTarget.ES2022,
+        jsx: ts.JsxEmit.ReactJSX,
+        jsxImportSource: 'myjsx',
+      }),
+      createRequire(join(caseDir, 'x.js'))
+    );
+
+    expect(swcObservations).toEqual(tsObservations);
+    expect(swcObservations.length).toBeGreaterThan(0);
   });
 });

--- a/packages/angular-rspack/src/lib/config/config-utils/swc-transpilation.spec.ts
+++ b/packages/angular-rspack/src/lib/config/config-utils/swc-transpilation.spec.ts
@@ -1,0 +1,59 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { isRspackV2 } from '../../utils/rspack-version';
+import { getSwcTranspilationTransform } from './swc-transpilation';
+
+vi.mock('../../utils/rspack-version', () => ({
+  isRspackV2: vi.fn().mockReturnValue(true),
+}));
+
+describe('getSwcTranspilationTransform', () => {
+  let dir: string;
+
+  beforeAll(() => {
+    dir = mkdtempSync(join(tmpdir(), 'swc-transpilation-'));
+  });
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  const writeTsConfig = (
+    name: string,
+    compilerOptions: Record<string, unknown>
+  ) => {
+    const path = join(dir, name);
+    writeFileSync(path, JSON.stringify({ compilerOptions, files: [] }));
+    return path;
+  };
+
+  it('should not set a decorator revision for legacy decorators', () => {
+    const path = writeTsConfig('legacy.json', {
+      experimentalDecorators: true,
+      target: 'ES2022',
+    });
+
+    expect(getSwcTranspilationTransform(path).decoratorVersion).toBeUndefined();
+  });
+
+  it("should select the '2023-11' standard decorator revision on rspack v2", () => {
+    const path = writeTsConfig('standard-v2.json', { target: 'ES2022' });
+
+    expect(getSwcTranspilationTransform(path)).toMatchObject({
+      legacyDecorator: false,
+      decoratorVersion: '2023-11',
+    });
+  });
+
+  it("should fall back to the '2022-03' standard decorator revision on rspack v1", () => {
+    vi.mocked(isRspackV2).mockReturnValueOnce(false);
+    const path = writeTsConfig('standard-v1.json', { target: 'ES2022' });
+
+    expect(getSwcTranspilationTransform(path)).toMatchObject({
+      legacyDecorator: false,
+      decoratorVersion: '2022-03',
+    });
+  });
+});

--- a/packages/angular-rspack/src/lib/config/config-utils/swc-transpilation.ts
+++ b/packages/angular-rspack/src/lib/config/config-utils/swc-transpilation.ts
@@ -1,0 +1,23 @@
+import {
+  resolveSwcTranspilationTransform,
+  type SwcTranspilationTransform,
+} from '@nx/angular-rspack-compiler';
+import { isRspackV2 } from '../../utils/rspack-version';
+
+/**
+ * The `jsc.transform` options for the swc rule, derived from the project's
+ * tsconfig with the standard decorator revision the installed rspack
+ * supports.
+ */
+export function getSwcTranspilationTransform(
+  tsConfig: string
+): SwcTranspilationTransform {
+  // '2023-11' matches TypeScript's standard decorator behavior, but only
+  // the swc bundled with rspack v2 implements it (older versions panic).
+  // The closest revision rspack v1 supports applies decorators in the older
+  // spec order and drops field addInitializer callbacks.
+  return resolveSwcTranspilationTransform(
+    tsConfig,
+    isRspackV2() ? '2023-11' : '2022-03'
+  );
+}

--- a/packages/angular-rspack/src/lib/config/config-utils/swc-transpilation.ts
+++ b/packages/angular-rspack/src/lib/config/config-utils/swc-transpilation.ts
@@ -1,7 +1,10 @@
 import {
   resolveSwcTranspilationTransform,
+  TS_EXT_REGEX,
+  TSX_EXT_REGEX,
   type SwcTranspilationTransform,
 } from '@nx/angular-rspack-compiler';
+import type { RuleSetRule } from '@rspack/core';
 import { isRspackV2 } from '../../utils/rspack-version';
 
 /**
@@ -20,4 +23,39 @@ export function getSwcTranspilationTransform(
     tsConfig,
     isRspackV2() ? '2023-11' : '2022-03'
   );
+}
+
+/**
+ * The swc module rules transpiling the TypeScript the Angular compilation
+ * emits (and raw sources). Split by extension: JSX parsing must only be
+ * enabled for `.tsx` sources because it steals the `<T>` cast syntax from
+ * plain TypeScript.
+ */
+export function getSwcTranspilationRules(
+  transform: SwcTranspilationTransform
+): RuleSetRule[] {
+  const rule = (test: RegExp, tsx: boolean): RuleSetRule => ({
+    test,
+    use: [
+      {
+        loader: 'builtin:swc-loader',
+        options: {
+          jsc: {
+            parser: {
+              syntax: 'typescript',
+              tsx,
+              // Angular's fast emit path can leave decorators in the
+              // output; parse them regardless of which semantics the
+              // transform applies.
+              decorators: true,
+            },
+            // Transpile with the semantics the type program assumed.
+            transform,
+            target: 'es2022',
+          },
+        },
+      },
+    ],
+  });
+  return [rule(TS_EXT_REGEX, false), rule(TSX_EXT_REGEX, true)];
 }

--- a/packages/angular-rspack/src/lib/config/create-config.spec.ts
+++ b/packages/angular-rspack/src/lib/config/create-config.spec.ts
@@ -231,6 +231,45 @@ describe('createConfig', () => {
     }
   }, 10000);
 
+  it('should share one Angular compilation between the browser and server configs', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'create-config-ssr-'));
+    try {
+      await mkdir(join(root, 'src'), { recursive: true });
+      await writeFile(join(root, 'src', 'main.server.ts'), '');
+      await writeFile(join(root, 'src', 'server.ts'), '');
+
+      const configs = await _createConfig({
+        ...configBase,
+        root,
+        server: './src/main.server.ts',
+        ssr: { entry: './src/server.ts' },
+      });
+
+      expect(configs).toHaveLength(2);
+      const [browserPlugin, serverPlugin] = configs.map((config) =>
+        config.plugins?.find(
+          (plugin) => plugin?.constructor.name === 'NgRspackPlugin'
+        )
+      );
+      expect(browserPlugin['sharedAngularPlugin']).toBeDefined();
+      expect(browserPlugin['sharedAngularPlugin']).toBe(
+        serverPlugin['sharedAngularPlugin']
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  }, 10000);
+
+  it('should not create a shared Angular compilation for a browser-only build', async () => {
+    const configs = await _createConfig(configBase);
+
+    expect(configs).toHaveLength(1);
+    const browserPlugin = configs[0].plugins?.find(
+      (plugin) => plugin?.constructor.name === 'NgRspackPlugin'
+    );
+    expect(browserPlugin['sharedAngularPlugin']).toBeUndefined();
+  }, 10000);
+
   describe('createConfig', () => {
     const runCreateConfig = () => {
       return createConfig(

--- a/packages/angular-rspack/src/lib/config/create-config.spec.ts
+++ b/packages/angular-rspack/src/lib/config/create-config.spec.ts
@@ -49,30 +49,108 @@ describe('createConfig', () => {
     ]);
   });
 
-  it('should compile legacy decorators in the TS transpilation rule', async () => {
-    const configs = await _createConfig(configBase);
+  it('should derive the TS transpilation rule semantics from the tsconfig', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'create-config-swc-'));
+    try {
+      await writeFile(
+        join(root, 'tsconfig.json'),
+        JSON.stringify({
+          compilerOptions: {
+            experimentalDecorators: true,
+            emitDecoratorMetadata: true,
+            target: 'ES2022',
+          },
+          files: [],
+        })
+      );
+      const configs = await _createConfig({
+        ...configBase,
+        root,
+        tsConfig: join(root, 'tsconfig.json'),
+      });
 
-    const tsRule = configs[0].module?.rules?.find(
-      (rule) =>
-        typeof rule === 'object' &&
-        rule !== null &&
-        (
-          rule as { use?: Array<{ loader?: string }> }
-        ).use?.[0]?.loader?.includes('swc-loader')
-    ) as unknown as {
-      use: Array<{
-        options: {
-          jsc: {
-            parser: { decorators?: boolean };
-            transform?: { legacyDecorator?: boolean };
+      const tsRule = configs[0].module?.rules?.find(
+        (rule) =>
+          typeof rule === 'object' &&
+          rule !== null &&
+          (
+            rule as { use?: Array<{ loader?: string }> }
+          ).use?.[0]?.loader?.includes('swc-loader')
+      ) as unknown as {
+        use: Array<{
+          options: {
+            jsc: {
+              parser: { decorators?: boolean };
+              transform?: {
+                legacyDecorator?: boolean;
+                decoratorMetadata?: boolean;
+                useDefineForClassFields?: boolean;
+              };
+            };
           };
-        };
-      }>;
-    };
+        }>;
+      };
 
-    expect(tsRule).toBeDefined();
-    expect(tsRule.use[0].options.jsc.parser.decorators).toBe(true);
-    expect(tsRule.use[0].options.jsc.transform?.legacyDecorator).toBe(true);
+      expect(tsRule).toBeDefined();
+      expect(tsRule.use[0].options.jsc.parser.decorators).toBe(true);
+      expect(tsRule.use[0].options.jsc.transform).toMatchObject({
+        legacyDecorator: true,
+        decoratorMetadata: true,
+        useDefineForClassFields: true,
+      });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  it('should derive the TS transpilation rule semantics from an overridden tsconfig', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'create-config-swc-override-'));
+    try {
+      await writeFile(
+        join(root, 'tsconfig.json'),
+        JSON.stringify({
+          compilerOptions: {
+            experimentalDecorators: true,
+            target: 'ES2022',
+          },
+          files: [],
+        })
+      );
+      await writeFile(
+        join(root, 'tsconfig.custom.json'),
+        JSON.stringify({
+          compilerOptions: { target: 'ES2022' },
+          files: [],
+        })
+      );
+      const configs = await _createConfig(
+        { ...configBase, root, tsConfig: join(root, 'tsconfig.json') },
+        { resolve: { tsConfig: join(root, 'tsconfig.custom.json') } }
+      );
+
+      const tsRule = configs[0].module?.rules?.find(
+        (rule) =>
+          typeof rule === 'object' &&
+          rule !== null &&
+          (
+            rule as { use?: Array<{ loader?: string }> }
+          ).use?.[0]?.loader?.includes('swc-loader')
+      ) as unknown as {
+        use: Array<{
+          options: { jsc: { transform?: { legacyDecorator?: boolean } } };
+        }>;
+      };
+
+      expect(tsRule).toBeDefined();
+      // The override tsconfig omits experimentalDecorators, so the rule uses
+      // standard decorator semantics even though options.tsConfig enables the
+      // legacy ones.
+      expect(tsRule.use[0].options.jsc.transform).toMatchObject({
+        legacyDecorator: false,
+      });
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
   });
 
   it('should share the license inputs between the browser and server configs', async () => {

--- a/packages/angular-rspack/src/lib/config/create-config.spec.ts
+++ b/packages/angular-rspack/src/lib/config/create-config.spec.ts
@@ -153,6 +153,55 @@ describe('createConfig', () => {
     }
   });
 
+  it('should split the TS transpilation rules by extension for JSX support', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'create-config-swc-jsx-'));
+    try {
+      await writeFile(
+        join(root, 'tsconfig.json'),
+        JSON.stringify({
+          compilerOptions: { target: 'ES2022', jsx: 'react-jsx' },
+          files: [],
+        })
+      );
+      const configs = await _createConfig({
+        ...configBase,
+        root,
+        tsConfig: join(root, 'tsconfig.json'),
+      });
+
+      const swcRules = (configs[0].module?.rules ?? []).filter(
+        (rule) =>
+          typeof rule === 'object' &&
+          rule !== null &&
+          (
+            rule as { use?: Array<{ loader?: string }> }
+          ).use?.[0]?.loader?.includes('swc-loader')
+      ) as unknown as Array<{
+        use: Array<{
+          options: {
+            jsc: {
+              parser: { tsx?: boolean };
+              transform?: { react?: { runtime?: string } };
+            };
+          };
+        }>;
+      }>;
+
+      expect(swcRules).toHaveLength(2);
+      expect(swcRules[0].use[0].options.jsc.parser.tsx).toBe(false);
+      expect(swcRules[1].use[0].options.jsc.parser.tsx).toBe(true);
+      expect(swcRules[1].use[0].options.jsc.transform?.react).toMatchObject({
+        runtime: 'automatic',
+      });
+      // The tsconfig is parsed once; both rules share the same transform.
+      expect(swcRules[0].use[0].options.jsc.transform).toBe(
+        swcRules[1].use[0].options.jsc.transform
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
   it('should share the license inputs between the browser and server configs', async () => {
     const root = await mkdtemp(join(tmpdir(), 'create-config-ssr-'));
     try {

--- a/packages/angular-rspack/src/lib/config/create-config.spec.ts
+++ b/packages/angular-rspack/src/lib/config/create-config.spec.ts
@@ -1,3 +1,5 @@
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import { AngularRspackPluginOptions } from '../models';
@@ -46,6 +48,35 @@ describe('createConfig', () => {
       expect.objectContaining({ mode: 'development' }),
     ]);
   });
+
+  it('should share the license inputs between the browser and server configs', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'create-config-ssr-'));
+    try {
+      await mkdir(join(root, 'src'), { recursive: true });
+      await writeFile(join(root, 'src', 'main.server.ts'), '');
+      await writeFile(join(root, 'src', 'server.ts'), '');
+
+      const configs = await _createConfig({
+        ...configBase,
+        root,
+        server: './src/main.server.ts',
+        ssr: { entry: './src/server.ts' },
+      });
+
+      expect(configs).toHaveLength(2);
+      const [browserPlugin, serverPlugin] = configs.map((config) =>
+        config.plugins?.find(
+          (plugin) => plugin?.constructor.name === 'NgRspackPlugin'
+        )
+      );
+      expect(browserPlugin['sharedLicenseInputs']).toBeInstanceOf(Map);
+      expect(browserPlugin['sharedLicenseInputs']).toBe(
+        serverPlugin['sharedLicenseInputs']
+      );
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  }, 10000);
 
   describe('createConfig', () => {
     const runCreateConfig = () => {

--- a/packages/angular-rspack/src/lib/config/create-config.spec.ts
+++ b/packages/angular-rspack/src/lib/config/create-config.spec.ts
@@ -49,6 +49,32 @@ describe('createConfig', () => {
     ]);
   });
 
+  it('should compile legacy decorators in the TS transpilation rule', async () => {
+    const configs = await _createConfig(configBase);
+
+    const tsRule = configs[0].module?.rules?.find(
+      (rule) =>
+        typeof rule === 'object' &&
+        rule !== null &&
+        (
+          rule as { use?: Array<{ loader?: string }> }
+        ).use?.[0]?.loader?.includes('swc-loader')
+    ) as unknown as {
+      use: Array<{
+        options: {
+          jsc: {
+            parser: { decorators?: boolean };
+            transform?: { legacyDecorator?: boolean };
+          };
+        };
+      }>;
+    };
+
+    expect(tsRule).toBeDefined();
+    expect(tsRule.use[0].options.jsc.parser.decorators).toBe(true);
+    expect(tsRule.use[0].options.jsc.transform?.legacyDecorator).toBe(true);
+  });
+
   it('should share the license inputs between the browser and server configs', async () => {
     const root = await mkdtemp(join(tmpdir(), 'create-config-ssr-'));
     try {

--- a/packages/angular-rspack/src/lib/config/create-config.spec.ts
+++ b/packages/angular-rspack/src/lib/config/create-config.spec.ts
@@ -260,6 +260,35 @@ describe('createConfig', () => {
     }
   }, 10000);
 
+  it('should define a runtime import.meta.url for the server bundle', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'create-config-ssr-'));
+    try {
+      await mkdir(join(root, 'src'), { recursive: true });
+      await writeFile(join(root, 'src', 'main.server.ts'), '');
+      await writeFile(join(root, 'src', 'server.ts'), '');
+
+      const configs = await _createConfig({
+        ...configBase,
+        root,
+        server: './src/main.server.ts',
+        ssr: { entry: './src/server.ts' },
+      });
+
+      const findImportMetaUrlDefine = (config: (typeof configs)[0]) =>
+        config.plugins?.find(
+          (plugin) =>
+            plugin?.constructor.name === 'DefinePlugin' &&
+            'import.meta.url' in
+              ((plugin as unknown as { _args: Record<string, string>[] })
+                ._args[0] ?? {})
+        );
+      expect(findImportMetaUrlDefine(configs[1])).toBeDefined();
+      expect(findImportMetaUrlDefine(configs[0])).toBeUndefined();
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  }, 10000);
+
   it('should not create a shared Angular compilation for a browser-only build', async () => {
     const configs = await _createConfig(configBase);
 

--- a/packages/angular-rspack/src/lib/config/create-config.ts
+++ b/packages/angular-rspack/src/lib/config/create-config.ts
@@ -15,6 +15,7 @@ import {
 } from './config-utils/user-defined-config-helpers';
 import { assertSupportedRspackCoreVersion } from '../utils/assert-supported-rspack-version';
 import { isServeMode } from '../utils/rspack-serve-env';
+import type { SharedLicenseInputs } from '../plugins/extract-licenses-plugin';
 
 export async function createConfig(
   defaultOptions: {
@@ -67,12 +68,18 @@ export async function _createConfig(
     hashFormat
   );
 
+  // The browser and server compilers write the licenses file to the same
+  // location; sharing the collected inputs makes each emit the union.
+  const sharedLicenseInputs: SharedLicenseInputs | undefined =
+    normalizedOptions.hasServer ? new Map() : undefined;
+
   const configs: Configuration[] = [];
   if (normalizedOptions.hasServer) {
     const serverConfig: Configuration = await getServerConfig(
       normalizedOptions,
       i18n,
-      defaultConfig
+      defaultConfig,
+      sharedLicenseInputs
     );
     const mergedConfig = rspackMerge(serverConfig, rspackConfigOverrides ?? {});
     configs.push(mergedConfig);
@@ -82,7 +89,8 @@ export async function _createConfig(
     normalizedOptions,
     i18n,
     hashFormat,
-    defaultConfig
+    defaultConfig,
+    sharedLicenseInputs
   );
   const mergedConfig = rspackMerge(browserConfig, rspackConfigOverrides ?? {});
   configs.unshift(mergedConfig);

--- a/packages/angular-rspack/src/lib/config/create-config.ts
+++ b/packages/angular-rspack/src/lib/config/create-config.ts
@@ -9,6 +9,7 @@ import {
 import { getCommonConfig } from './config-utils/common-config';
 import { getServerConfig } from './config-utils/server-config';
 import { getBrowserConfig } from './config-utils/browser-config';
+import { getSwcTranspilationTransform } from './config-utils/swc-transpilation';
 import {
   handleConfigurations,
   parseConfigurationMode,
@@ -68,6 +69,15 @@ export async function _createConfig(
     hashFormat
   );
 
+  // Overrides may point module resolution at a different tsconfig; derive
+  // the swc rule semantics from the one the bundler will actually use.
+  const overrideTsConfig = rspackConfigOverrides?.resolve?.tsConfig;
+  const swcTranspilationTransform = getSwcTranspilationTransform(
+    typeof overrideTsConfig === 'string'
+      ? overrideTsConfig
+      : (overrideTsConfig?.configFile ?? normalizedOptions.tsConfig)
+  );
+
   // The browser and server compilers write the licenses file to the same
   // location; sharing the collected inputs makes each emit the union.
   const sharedLicenseInputs: SharedLicenseInputs | undefined =
@@ -79,6 +89,7 @@ export async function _createConfig(
       normalizedOptions,
       i18n,
       defaultConfig,
+      swcTranspilationTransform,
       sharedLicenseInputs
     );
     const mergedConfig = rspackMerge(serverConfig, rspackConfigOverrides ?? {});
@@ -90,6 +101,7 @@ export async function _createConfig(
     i18n,
     hashFormat,
     defaultConfig,
+    swcTranspilationTransform,
     sharedLicenseInputs
   );
   const mergedConfig = rspackMerge(browserConfig, rspackConfigOverrides ?? {});

--- a/packages/angular-rspack/src/lib/config/create-config.ts
+++ b/packages/angular-rspack/src/lib/config/create-config.ts
@@ -17,6 +17,7 @@ import {
 import { assertSupportedRspackCoreVersion } from '../utils/assert-supported-rspack-version';
 import { isServeMode } from '../utils/rspack-serve-env';
 import type { SharedLicenseInputs } from '../plugins/extract-licenses-plugin';
+import { AngularRspackPlugin } from '../plugins/angular-rspack-plugin';
 
 export async function createConfig(
   defaultOptions: {
@@ -83,6 +84,14 @@ export async function _createConfig(
   const sharedLicenseInputs: SharedLicenseInputs | undefined =
     normalizedOptions.hasServer ? new Map() : undefined;
 
+  // An SSR build's compilers also share one Angular compilation: the browser
+  // program already includes the server entry points, so the server compiler
+  // consumes the browser compilation's output instead of running a second
+  // compilation of the same program.
+  const sharedAngularPlugin = normalizedOptions.hasServer
+    ? new AngularRspackPlugin(normalizedOptions, i18n)
+    : undefined;
+
   const configs: Configuration[] = [];
   if (normalizedOptions.hasServer) {
     const serverConfig: Configuration = await getServerConfig(
@@ -90,7 +99,8 @@ export async function _createConfig(
       i18n,
       defaultConfig,
       swcTranspilationTransform,
-      sharedLicenseInputs
+      sharedLicenseInputs,
+      sharedAngularPlugin
     );
     const mergedConfig = rspackMerge(serverConfig, rspackConfigOverrides ?? {});
     configs.push(mergedConfig);
@@ -102,7 +112,8 @@ export async function _createConfig(
     hashFormat,
     defaultConfig,
     swcTranspilationTransform,
-    sharedLicenseInputs
+    sharedLicenseInputs,
+    sharedAngularPlugin
   );
   const mergedConfig = rspackMerge(browserConfig, rspackConfigOverrides ?? {});
   configs.unshift(mergedConfig);

--- a/packages/angular-rspack/src/lib/models/augmented-compilation.ts
+++ b/packages/angular-rspack/src/lib/models/augmented-compilation.ts
@@ -10,6 +10,9 @@ export const NG_RSPACK_SYMBOL_NAME = 'NG_RSPACK_BUILD';
 export type NG_RSPACK_COMPILATION_STATE = {
   javascriptTransformer: JavaScriptTransformer;
   typescriptFileCache: SourceFileCache['typeScriptFileCache'];
+  // Mirrors @angular/build: false means Angular emitted transformed
+  // TypeScript and the bundler transpiles it (fast path).
+  useTypeScriptTranspilation: boolean;
   // True when the Angular compilation failed to initialize or emit, meaning
   // the typescript file cache cannot be relied on for this build.
   angularCompilationFailed: boolean;

--- a/packages/angular-rspack/src/lib/models/augmented-compilation.ts
+++ b/packages/angular-rspack/src/lib/models/augmented-compilation.ts
@@ -20,6 +20,10 @@ export type NG_RSPACK_COMPILATION_STATE = {
   // Metafile inputs of the bundled component stylesheets, for license
   // extraction (workspace-relative paths).
   stylesheetMetafileInputs: Record<string, { bytesInOutput: number }>;
+  // Template and stylesheet dependencies per source file as tracked by the
+  // Angular compiler, keyed like the typescript file cache. Absent for JIT
+  // compilations and @angular/build versions that do not report them.
+  resourceDependencies?: ReadonlyMap<string, readonly string[]>;
   i18n?: I18nOptions;
 };
 export type NgRspackCompilation = Compilation & {

--- a/packages/angular-rspack/src/lib/models/augmented-compilation.ts
+++ b/packages/angular-rspack/src/lib/models/augmented-compilation.ts
@@ -10,6 +10,7 @@ export const NG_RSPACK_SYMBOL_NAME = 'NG_RSPACK_BUILD';
 export type NG_RSPACK_COMPILATION_STATE = {
   javascriptTransformer: JavaScriptTransformer;
   typescriptFileCache: SourceFileCache['typeScriptFileCache'];
+  babelFileCache: SourceFileCache['babelFileCache'];
   // Mirrors @angular/build: false means Angular emitted transformed
   // TypeScript and the bundler transpiles it (fast path).
   useTypeScriptTranspilation: boolean;

--- a/packages/angular-rspack/src/lib/models/augmented-compilation.ts
+++ b/packages/angular-rspack/src/lib/models/augmented-compilation.ts
@@ -13,6 +13,9 @@ export type NG_RSPACK_COMPILATION_STATE = {
   // True when the Angular compilation failed to initialize or emit, meaning
   // the typescript file cache cannot be relied on for this build.
   angularCompilationFailed: boolean;
+  // Metafile inputs of the bundled component stylesheets, for license
+  // extraction (workspace-relative paths).
+  stylesheetMetafileInputs: Record<string, { bytesInOutput: number }>;
   i18n?: I18nOptions;
 };
 export type NgRspackCompilation = Compilation & {

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.spec.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.spec.ts
@@ -10,12 +10,17 @@ const {
   disposeComponentStylesheetBundlerMock,
   transformerCloseMock,
   sourceFileCacheCtorMock,
+  sourceFileCacheInstances,
 } = vi.hoisted(() => ({
   buildAndAnalyzeMock: vi.fn(),
   setupCompilationMock: vi.fn(),
   disposeComponentStylesheetBundlerMock: vi.fn(),
   transformerCloseMock: vi.fn(),
   sourceFileCacheCtorMock: vi.fn(),
+  sourceFileCacheInstances: [] as Array<{
+    invalidate: ReturnType<typeof vi.fn>;
+    prune: ReturnType<typeof vi.fn>;
+  }>,
 }));
 
 vi.mock('@nx/angular-rspack-compiler', () => ({
@@ -27,10 +32,13 @@ vi.mock('@nx/angular-rspack-compiler', () => ({
   },
   SourceFileCache: class {
     typeScriptFileCache = new Map<string, unknown>();
+    babelFileCache = new Map<string, string>();
     referencedFiles: string[] = [];
     invalidate = vi.fn();
+    prune = vi.fn();
     constructor(persistentCachePath?: string) {
       sourceFileCacheCtorMock(persistentCachePath);
+      sourceFileCacheInstances.push(this);
     }
   },
   maxWorkers: () => 1,
@@ -361,6 +369,39 @@ describe('AngularRspackPlugin', () => {
     }
   });
 
+  it('should invalidate modified and removed files and prune removed files on rebuilds', async () => {
+    const compiler = createFakeCompiler();
+    const plugin = new AngularRspackPlugin(options);
+    plugin.apply(compiler as never);
+
+    // first watch build initializes the compilation
+    await fireAsyncTaps(compiler.hooks.watchRun, compiler);
+    await fireAsyncTaps(compiler.hooks.beforeCompile, {});
+
+    (compiler as { watching?: unknown }).watching = {
+      compiler: {
+        modifiedFiles: new Set(['/root/src/modified.ts']),
+        removedFiles: new Set(['/root/src/removed.ts']),
+      },
+    };
+    await fireAsyncTaps(compiler.hooks.beforeCompile, {});
+
+    const sourceFileCache = sourceFileCacheInstances.at(-1)!;
+    expect(sourceFileCache.invalidate).toHaveBeenCalledWith(
+      new Set(['/root/src/modified.ts', '/root/src/removed.ts'])
+    );
+    expect(sourceFileCache.prune).toHaveBeenCalledWith(
+      new Set(['/root/src/removed.ts'])
+    );
+    expect(setupCompilationMock).toHaveBeenLastCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      new Set(['/root/src/modified.ts', '/root/src/removed.ts'])
+    );
+  });
+
   it('should expose the TypeScript transpilation mode and stylesheet metafile inputs to the loaders', async () => {
     setupCompilationMock.mockResolvedValue({
       angularCompilation: { diagnoseFiles: vi.fn().mockResolvedValue({}) },
@@ -416,6 +457,7 @@ describe('AngularRspackPlugin', () => {
     (compiler as { watching?: unknown }).watching = {
       compiler: {
         modifiedFiles: new Set(['/root/src/app/app.component.ts']),
+        removedFiles: new Set<string>(),
       },
     };
     await fireAsyncTaps(compiler.hooks.beforeCompile, {});

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.spec.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.spec.ts
@@ -1,4 +1,5 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import type { NormalizedAngularRspackPluginOptions } from '../models';
 import { NG_RSPACK_SYMBOL_NAME, type NgRspackCompilation } from '../models';
 import { AngularRspackPlugin } from './angular-rspack-plugin';
@@ -8,11 +9,13 @@ const {
   setupCompilationMock,
   disposeComponentStylesheetBundlerMock,
   transformerCloseMock,
+  sourceFileCacheCtorMock,
 } = vi.hoisted(() => ({
   buildAndAnalyzeMock: vi.fn(),
   setupCompilationMock: vi.fn(),
   disposeComponentStylesheetBundlerMock: vi.fn(),
   transformerCloseMock: vi.fn(),
+  sourceFileCacheCtorMock: vi.fn(),
 }));
 
 vi.mock('@nx/angular-rspack-compiler', () => ({
@@ -23,9 +26,12 @@ vi.mock('@nx/angular-rspack-compiler', () => ({
     close = transformerCloseMock;
   },
   SourceFileCache: class {
-    typeScriptFileCache = new Map<string, string | Uint8Array>();
+    typeScriptFileCache = new Map<string, unknown>();
     referencedFiles: string[] = [];
     invalidate = vi.fn();
+    constructor(persistentCachePath?: string) {
+      sourceFileCacheCtorMock(persistentCachePath);
+    }
   },
   maxWorkers: () => 1,
   setupCompilationWithAngularCompilation: setupCompilationMock,
@@ -131,6 +137,9 @@ describe('AngularRspackPlugin', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    // The persistent cache is disabled when a CI environment is detected;
+    // clear the variable so tests behave the same locally and in CI.
+    vi.stubEnv('CI', '');
     transformerCloseMock.mockResolvedValue(undefined);
     disposeComponentStylesheetBundlerMock.mockResolvedValue(undefined);
     buildAndAnalyzeMock.mockResolvedValue(undefined);
@@ -140,6 +149,10 @@ describe('AngularRspackPlugin', () => {
       collectedStylesheetMetafileInputs: [],
       useTypeScriptTranspilation: true,
     });
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
   });
 
   function applyPlugin() {
@@ -293,6 +306,59 @@ describe('AngularRspackPlugin', () => {
 
     expect(transformerCloseMock).toHaveBeenCalled();
     expect(disposeComponentStylesheetBundlerMock).toHaveBeenCalled();
+  });
+
+  it('should use a persistent cache path scoped to the project', () => {
+    new AngularRspackPlugin({ ...options, projectName: 'app' });
+
+    expect(sourceFileCacheCtorMock).toHaveBeenCalledWith(
+      expect.stringContaining(join('.angular', 'cache'))
+    );
+    expect(sourceFileCacheCtorMock).toHaveBeenCalledWith(
+      expect.stringContaining(join('app', 'angular-rspack'))
+    );
+  });
+
+  it('should not use a persistent cache path without a project name', () => {
+    new AngularRspackPlugin(options);
+
+    expect(sourceFileCacheCtorMock).toHaveBeenCalledWith(undefined);
+  });
+
+  it.each(['1', 'true', 'TRUE'])(
+    'should not use a persistent cache path when CI is "%s"',
+    (ci) => {
+      vi.stubEnv('CI', ci);
+
+      new AngularRspackPlugin({ ...options, projectName: 'app' });
+
+      expect(sourceFileCacheCtorMock).toHaveBeenCalledWith(undefined);
+    }
+  );
+
+  it.each(['0', 'false'])(
+    'should keep the persistent cache path when CI is "%s"',
+    (ci) => {
+      vi.stubEnv('CI', ci);
+
+      new AngularRspackPlugin({ ...options, projectName: 'app' });
+
+      expect(sourceFileCacheCtorMock).toHaveBeenCalledWith(
+        expect.stringContaining(join('.angular', 'cache'))
+      );
+    }
+  );
+
+  it('should not use a persistent cache path in a web container', () => {
+    const versions = process.versions as { webcontainer?: string };
+    versions.webcontainer = '1.0.0';
+    try {
+      new AngularRspackPlugin({ ...options, projectName: 'app' });
+
+      expect(sourceFileCacheCtorMock).toHaveBeenCalledWith(undefined);
+    } finally {
+      delete versions.webcontainer;
+    }
   });
 
   it('should expose the TypeScript transpilation mode and stylesheet metafile inputs to the loaders', async () => {

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.spec.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.spec.ts
@@ -307,6 +307,43 @@ describe('AngularRspackPlugin', () => {
     expect(state.angularCompilationFailed).toBe(false);
   });
 
+  it('should keep reporting setup warnings while initialization fails and clear them after success', async () => {
+    const setupError = Object.assign(new Error('transient failure'), {
+      setupWarnings: ['target raised'],
+    });
+    setupCompilationMock.mockResolvedValue({
+      angularCompilation: { diagnoseFiles: vi.fn().mockResolvedValue({}) },
+      collectedStylesheetAssets: [],
+      collectedStylesheetMetafileInputs: [],
+      useTypeScriptTranspilation: true,
+      setupWarnings: ['target raised'],
+    });
+    setupCompilationMock.mockRejectedValueOnce(setupError);
+    const compiler = applyPlugin();
+
+    // initial build fails to initialize; the setup warnings ride along on
+    // the failure and land on this build alongside the error
+    await runBuildStart(compiler);
+    const failedCompilation = createFakeCompilation(compiler);
+    fireSyncTaps(compiler.hooks.thisCompilation, failedCompilation);
+    expect(failedCompilation.warnings).toHaveLength(1);
+    expect(failedCompilation.warnings[0].message).toContain('target raised');
+
+    // the successful rebuild reports the warnings again (isInitialSetup is
+    // still true since no compilation was ever assigned)
+    await fireAsyncTaps(compiler.hooks.watchRun, compiler);
+    await fireAsyncTaps(compiler.hooks.beforeCompile, {});
+    const recoveredCompilation = createFakeCompilation(compiler);
+    fireSyncTaps(compiler.hooks.thisCompilation, recoveredCompilation);
+    expect(recoveredCompilation.warnings).toHaveLength(1);
+    expect(recoveredCompilation.warnings[0].message).toContain('target raised');
+
+    // and clears them so later rebuilds stay quiet
+    const laterCompilation = createFakeCompilation(compiler);
+    fireSyncTaps(compiler.hooks.thisCompilation, laterCompilation);
+    expect(laterCompilation.warnings).toHaveLength(0);
+  });
+
   it('should not throw from afterDone when the run failed before producing stats', async () => {
     const compiler = applyPlugin();
 

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.spec.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.spec.ts
@@ -137,6 +137,7 @@ describe('AngularRspackPlugin', () => {
     setupCompilationMock.mockResolvedValue({
       angularCompilation: { diagnoseFiles: vi.fn().mockResolvedValue({}) },
       collectedStylesheetAssets: [],
+      collectedStylesheetMetafileInputs: [],
     });
   });
 
@@ -281,5 +282,71 @@ describe('AngularRspackPlugin', () => {
 
     expect(transformerCloseMock).toHaveBeenCalled();
     expect(disposeComponentStylesheetBundlerMock).toHaveBeenCalled();
+  });
+
+  it('should expose the stylesheet metafile inputs to other plugins', async () => {
+    setupCompilationMock.mockResolvedValue({
+      angularCompilation: { diagnoseFiles: vi.fn().mockResolvedValue({}) },
+      collectedStylesheetAssets: [],
+      collectedStylesheetMetafileInputs: [
+        {
+          source: '/root/src/app/app.component.scss',
+          inputs: { 'node_modules/css-pkg/styles.css': { bytesInOutput: 5 } },
+        },
+      ],
+    });
+    const compiler = applyPlugin();
+
+    await runBuildStart(compiler);
+
+    const compilation = createFakeCompilation(compiler);
+    fireSyncTaps(compiler.hooks.compilation, compilation);
+    const state = (compilation as unknown as NgRspackCompilation)[
+      NG_RSPACK_SYMBOL_NAME
+    ]();
+    expect(state.stylesheetMetafileInputs).toEqual({
+      'node_modules/css-pkg/styles.css': { bytesInOutput: 5 },
+    });
+  });
+
+  it('should drop stylesheet metafile inputs for modified files, including inline-style entries', async () => {
+    setupCompilationMock.mockResolvedValueOnce({
+      angularCompilation: { diagnoseFiles: vi.fn().mockResolvedValue({}) },
+      collectedStylesheetAssets: [],
+      collectedStylesheetMetafileInputs: [
+        {
+          source: '/root/src/app/app.component.ts?class=AppComponent&order=0',
+          inputs: { 'node_modules/css-pkg/styles.css': { bytesInOutput: 5 } },
+        },
+        {
+          source: '/root/src/app/other.component.scss',
+          inputs: { 'node_modules/other-pkg/styles.css': { bytesInOutput: 5 } },
+        },
+      ],
+    });
+    const compiler = createFakeCompiler();
+    const plugin = new AngularRspackPlugin(options);
+    plugin.apply(compiler as never);
+
+    // first watch build collects the stylesheet inputs
+    await fireAsyncTaps(compiler.hooks.watchRun, compiler);
+    await fireAsyncTaps(compiler.hooks.beforeCompile, {});
+
+    // rebuild with the inline-styled component modified
+    (compiler as { watching?: unknown }).watching = {
+      compiler: {
+        modifiedFiles: new Set(['/root/src/app/app.component.ts']),
+      },
+    };
+    await fireAsyncTaps(compiler.hooks.beforeCompile, {});
+
+    const compilation = createFakeCompilation(compiler);
+    fireSyncTaps(compiler.hooks.compilation, compilation);
+    const state = (compilation as unknown as NgRspackCompilation)[
+      NG_RSPACK_SYMBOL_NAME
+    ]();
+    expect(state.stylesheetMetafileInputs).toEqual({
+      'node_modules/other-pkg/styles.css': { bytesInOutput: 5 },
+    });
   });
 });

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.spec.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.spec.ts
@@ -324,6 +324,45 @@ describe('AngularRspackPlugin', () => {
     expect(disposeComponentStylesheetBundlerMock).toHaveBeenCalled();
   });
 
+  it('should close the Angular compilation on shutdown', async () => {
+    const close = vi.fn();
+    setupCompilationMock.mockResolvedValue({
+      angularCompilation: {
+        diagnoseFiles: vi.fn().mockResolvedValue({}),
+        close,
+      },
+      collectedStylesheetAssets: [],
+    });
+    const compiler = applyPlugin();
+    await runBuildStart(compiler);
+
+    await fireAsyncTaps(compiler.hooks.shutdown);
+
+    expect(close).toHaveBeenCalled();
+  });
+
+  it('should start diagnostics with the build and reuse the result on emit', async () => {
+    const diagnoseFiles = vi
+      .fn()
+      .mockResolvedValue({ errors: [{ text: 'type error' }] });
+    setupCompilationMock.mockResolvedValue({
+      angularCompilation: { diagnoseFiles },
+      collectedStylesheetAssets: [],
+    });
+    const compiler = applyPlugin();
+
+    await runBuildStart(compiler);
+    expect(diagnoseFiles).toHaveBeenCalledTimes(1);
+
+    const compilation = createFakeCompilation(compiler);
+    await fireAsyncTaps(compiler.hooks.emit, compilation);
+
+    expect(diagnoseFiles).toHaveBeenCalledTimes(1);
+    expect(
+      compilation.errors.some((error) => error.message.includes('type error'))
+    ).toBe(true);
+  });
+
   it('should use a persistent cache path scoped to the project', () => {
     new AngularRspackPlugin({ ...options, projectName: 'app' });
 
@@ -418,6 +457,15 @@ describe('AngularRspackPlugin', () => {
   });
 
   it('should invalidate modified and removed files and prune removed files on rebuilds', async () => {
+    const angularCompilation = {
+      diagnoseFiles: vi.fn().mockResolvedValue({}),
+      update: vi.fn(),
+    };
+    setupCompilationMock.mockResolvedValue({
+      angularCompilation,
+      collectedStylesheetAssets: [],
+      collectedStylesheetMetafileInputs: [],
+    });
     const compiler = createFakeCompiler();
     const plugin = new AngularRspackPlugin(options);
     plugin.apply(compiler as never);
@@ -434,6 +482,10 @@ describe('AngularRspackPlugin', () => {
     };
     await fireAsyncTaps(compiler.hooks.beforeCompile, {});
 
+    // A worker-based compilation tracks modified files itself.
+    expect(angularCompilation.update).toHaveBeenCalledWith(
+      new Set(['/root/src/modified.ts', '/root/src/removed.ts'])
+    );
     const sourceFileCache = sourceFileCacheInstances.at(-1)!;
     expect(sourceFileCache.invalidate).toHaveBeenCalledWith(
       new Set(['/root/src/modified.ts', '/root/src/removed.ts'])

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.spec.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.spec.ts
@@ -403,6 +403,9 @@ describe('AngularRspackPlugin', () => {
   });
 
   it('should expose the TypeScript transpilation mode and stylesheet metafile inputs to the loaders', async () => {
+    const resourceDependencies = new Map([
+      ['/root/src/app/app.component.ts', ['/root/src/app/app.component.html']],
+    ]);
     setupCompilationMock.mockResolvedValue({
       angularCompilation: { diagnoseFiles: vi.fn().mockResolvedValue({}) },
       collectedStylesheetAssets: [],
@@ -413,6 +416,7 @@ describe('AngularRspackPlugin', () => {
         },
       ],
       useTypeScriptTranspilation: false,
+      resourceDependencies,
     });
     const compiler = applyPlugin();
 
@@ -427,6 +431,7 @@ describe('AngularRspackPlugin', () => {
     expect(state.stylesheetMetafileInputs).toEqual({
       'node_modules/css-pkg/styles.css': { bytesInOutput: 5 },
     });
+    expect(state.resourceDependencies).toBe(resourceDependencies);
   });
 
   it('should drop stylesheet metafile inputs for modified files, including inline-style entries', async () => {

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.spec.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.spec.ts
@@ -8,14 +8,18 @@ const {
   buildAndAnalyzeMock,
   setupCompilationMock,
   disposeComponentStylesheetBundlerMock,
+  transformerCtorMock,
   transformerCloseMock,
+  createJavascriptTransformerCacheMock,
   sourceFileCacheCtorMock,
   sourceFileCacheInstances,
 } = vi.hoisted(() => ({
   buildAndAnalyzeMock: vi.fn(),
   setupCompilationMock: vi.fn(),
   disposeComponentStylesheetBundlerMock: vi.fn(),
+  transformerCtorMock: vi.fn(),
   transformerCloseMock: vi.fn(),
+  createJavascriptTransformerCacheMock: vi.fn(),
   sourceFileCacheCtorMock: vi.fn(),
   sourceFileCacheInstances: [] as Array<{
     invalidate: ReturnType<typeof vi.fn>;
@@ -25,10 +29,14 @@ const {
 
 vi.mock('@nx/angular-rspack-compiler', () => ({
   buildAndAnalyze: buildAndAnalyzeMock,
+  createJavascriptTransformerCache: createJavascriptTransformerCacheMock,
   DiagnosticModes: { All: 7 },
   disposeComponentStylesheetBundler: disposeComponentStylesheetBundlerMock,
   JavaScriptTransformer: class {
     close = transformerCloseMock;
+    constructor(...args: unknown[]) {
+      transformerCtorMock(...args);
+    }
   },
   SourceFileCache: class {
     typeScriptFileCache = new Map<string, unknown>();
@@ -331,6 +339,39 @@ describe('AngularRspackPlugin', () => {
     new AngularRspackPlugin(options);
 
     expect(sourceFileCacheCtorMock).toHaveBeenCalledWith(undefined);
+  });
+
+  it('should give the transformer a persistent cache when a cache path is available', async () => {
+    const cache = { get: vi.fn(), put: vi.fn() };
+    const close = vi.fn();
+    createJavascriptTransformerCacheMock.mockReturnValueOnce({ cache, close });
+
+    const plugin = new AngularRspackPlugin({ ...options, projectName: 'app' });
+
+    expect(createJavascriptTransformerCacheMock).toHaveBeenCalledWith(
+      expect.stringContaining(join('app', 'angular-rspack'))
+    );
+    expect(transformerCtorMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      cache
+    );
+
+    const compiler = createFakeCompiler();
+    plugin.apply(compiler as never);
+    await fireAsyncTaps(compiler.hooks.shutdown);
+    expect(close).toHaveBeenCalled();
+  });
+
+  it('should not create a transformer cache when the persistent cache is disabled', () => {
+    new AngularRspackPlugin(options);
+
+    expect(createJavascriptTransformerCacheMock).not.toHaveBeenCalled();
+    expect(transformerCtorMock).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      undefined
+    );
   });
 
   it.each(['1', 'true', 'TRUE'])(

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.spec.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.spec.ts
@@ -30,7 +30,7 @@ const {
 vi.mock('@nx/angular-rspack-compiler', () => ({
   buildAndAnalyze: buildAndAnalyzeMock,
   createJavascriptTransformerCache: createJavascriptTransformerCacheMock,
-  DiagnosticModes: { All: 7 },
+  DiagnosticModes: { All: 7, Semantic: 4 },
   disposeComponentStylesheetBundler: disposeComponentStylesheetBundlerMock,
   JavaScriptTransformer: class {
     close = transformerCloseMock;
@@ -342,6 +342,30 @@ describe('AngularRspackPlugin', () => {
     const laterCompilation = createFakeCompilation(compiler);
     fireSyncTaps(compiler.hooks.thisCompilation, laterCompilation);
     expect(laterCompilation.warnings).toHaveLength(0);
+  });
+
+  it('should run only option and syntactic diagnostics when type checking is skipped', async () => {
+    const diagnoseFiles = vi.fn().mockResolvedValue({});
+    setupCompilationMock.mockResolvedValue({
+      angularCompilation: { diagnoseFiles },
+      collectedStylesheetAssets: [],
+    });
+    const compiler = createFakeCompiler();
+    const plugin = new AngularRspackPlugin({
+      ...options,
+      skipTypeChecking: true,
+    } as never);
+    plugin.apply(compiler as never);
+
+    await runBuildStart(compiler);
+
+    // DiagnosticModes.All & ~DiagnosticModes.Semantic === 7 & ~4 === 3
+    expect(diagnoseFiles).toHaveBeenCalledWith(3);
+
+    // the diagnostics result is still consumed on emit without erroring
+    const compilation = createFakeCompilation(compiler);
+    await fireAsyncTaps(compiler.hooks.emit, compilation);
+    expect(compilation.errors).toHaveLength(0);
   });
 
   it('should not throw from afterDone when the run failed before producing stats', async () => {

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.spec.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.spec.ts
@@ -402,6 +402,27 @@ describe('AngularRspackPlugin', () => {
     expect(close).toHaveBeenCalled();
   });
 
+  it('should still close the Angular compilation and the stylesheet bundler when an earlier shutdown close fails', async () => {
+    transformerCloseMock.mockRejectedValue(
+      new Error('worker pool destroy failed')
+    );
+    const close = vi.fn();
+    setupCompilationMock.mockResolvedValue({
+      angularCompilation: {
+        diagnoseFiles: vi.fn().mockResolvedValue({}),
+        close,
+      },
+      collectedStylesheetAssets: [],
+    });
+    const compiler = applyPlugin();
+    await runBuildStart(compiler);
+
+    await fireAsyncTaps(compiler.hooks.shutdown);
+
+    expect(close).toHaveBeenCalled();
+    expect(disposeComponentStylesheetBundlerMock).toHaveBeenCalled();
+  });
+
   it('should start diagnostics with the build and reuse the result on emit', async () => {
     const diagnoseFiles = vi
       .fn()

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.spec.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.spec.ts
@@ -335,10 +335,15 @@ describe('AngularRspackPlugin', () => {
     );
   });
 
-  it('should not use a persistent cache path without a project name', () => {
+  it('should scope the persistent cache path by the project root without a project name', () => {
     new AngularRspackPlugin(options);
 
-    expect(sourceFileCacheCtorMock).toHaveBeenCalledWith(undefined);
+    expect(sourceFileCacheCtorMock).toHaveBeenCalledWith(
+      expect.stringContaining(join('.angular', 'cache'))
+    );
+    expect(sourceFileCacheCtorMock).toHaveBeenCalledWith(
+      expect.stringContaining(join('root', 'angular-rspack'))
+    );
   });
 
   it('should give the transformer a persistent cache when a cache path is available', async () => {
@@ -364,6 +369,8 @@ describe('AngularRspackPlugin', () => {
   });
 
   it('should not create a transformer cache when the persistent cache is disabled', () => {
+    vi.stubEnv('CI', '1');
+
     new AngularRspackPlugin(options);
 
     expect(createJavascriptTransformerCacheMock).not.toHaveBeenCalled();

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.spec.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.spec.ts
@@ -595,6 +595,128 @@ describe('AngularRspackPlugin', () => {
     expect(state.resourceDependencies).toBe(resourceDependencies);
   });
 
+  describe('applyToDependentCompiler', () => {
+    function applyToBothCompilers() {
+      const ownerCompiler = createFakeCompiler();
+      const dependentCompiler = createFakeCompiler();
+      const plugin = new AngularRspackPlugin(options);
+      plugin.apply(ownerCompiler as never);
+      plugin.applyToDependentCompiler(dependentCompiler as never);
+      return { ownerCompiler, dependentCompiler };
+    }
+
+    async function fireAfterSeal(
+      compilation: ReturnType<typeof createFakeCompilation>
+    ) {
+      return await new Promise<Error | undefined>((resolve) => {
+        compilation.hooks.afterSeal.taps[0].fn((error?: Error) =>
+          resolve(error)
+        );
+      });
+    }
+
+    it('should expose the owning compilation state without compiling again', async () => {
+      const { ownerCompiler, dependentCompiler } = applyToBothCompilers();
+
+      await runBuildStart(ownerCompiler);
+
+      // the dependent compiler registers no compilation-driving hooks
+      await fireAsyncTaps(dependentCompiler.hooks.beforeRun, dependentCompiler);
+      await fireAsyncTaps(dependentCompiler.hooks.beforeCompile, {});
+      expect(setupCompilationMock).toHaveBeenCalledTimes(1);
+      expect(buildAndAnalyzeMock).toHaveBeenCalledTimes(1);
+
+      // its loaders read straight from the owning compiler's caches
+      const ownerCompilation = createFakeCompilation(ownerCompiler);
+      fireSyncTaps(ownerCompiler.hooks.compilation, ownerCompilation);
+      const dependentCompilation = createFakeCompilation(dependentCompiler);
+      fireSyncTaps(dependentCompiler.hooks.compilation, dependentCompilation);
+      const ownerState = (ownerCompilation as unknown as NgRspackCompilation)[
+        NG_RSPACK_SYMBOL_NAME
+      ]();
+      const dependentState = (
+        dependentCompilation as unknown as NgRspackCompilation
+      )[NG_RSPACK_SYMBOL_NAME]();
+      expect(dependentState.typescriptFileCache).toBe(
+        ownerState.typescriptFileCache
+      );
+      expect(dependentState.javascriptTransformer).toBe(
+        ownerState.javascriptTransformer
+      );
+    });
+
+    it('should surface an Angular compilation failure on the dependent compilation', async () => {
+      setupCompilationMock.mockRejectedValue(new Error('NgtscProgram failed'));
+      const { ownerCompiler, dependentCompiler } = applyToBothCompilers();
+
+      await runBuildStart(ownerCompiler);
+
+      const compilation = createFakeCompilation(dependentCompiler);
+      fireSyncTaps(dependentCompiler.hooks.thisCompilation, compilation);
+      expect(compilation.errors).toHaveLength(1);
+      expect(compilation.errors[0].message).toContain(
+        'Angular compilation initialization failed.'
+      );
+
+      fireSyncTaps(dependentCompiler.hooks.compilation, compilation);
+      const state = (compilation as unknown as NgRspackCompilation)[
+        NG_RSPACK_SYMBOL_NAME
+      ]();
+      expect(state.angularCompilationFailed).toBe(true);
+    });
+
+    it('should fail the seal of an errored one-shot dependent build', async () => {
+      const { dependentCompiler } = applyToBothCompilers();
+
+      const compilation = createFakeCompilation(dependentCompiler);
+      compilation.errors.push(new Error('loader failed'));
+      (compilation as unknown as { getStats: () => unknown }).getStats =
+        () => ({
+          toJson: () => ({ errors: [{ message: 'loader failed' }] }),
+        });
+      fireSyncTaps(dependentCompiler.hooks.thisCompilation, compilation);
+
+      const sealError = await fireAfterSeal(compilation);
+      expect(sealError).toBeInstanceOf(Error);
+      expect(sealError?.message).toContain('loader failed');
+    });
+
+    it('should not fail the seal of an errored watch rebuild', async () => {
+      const { dependentCompiler } = applyToBothCompilers();
+      fireSyncTaps(dependentCompiler.hooks.watchRun, dependentCompiler);
+
+      const compilation = createFakeCompilation(dependentCompiler);
+      compilation.errors.push(new Error('loader failed'));
+      fireSyncTaps(dependentCompiler.hooks.thisCompilation, compilation);
+
+      const sealError = await fireAfterSeal(compilation);
+      expect(sealError).toBeUndefined();
+    });
+
+    it('should not throw from afterDone when the run failed before producing stats', () => {
+      const { dependentCompiler } = applyToBothCompilers();
+
+      expect(() =>
+        fireSyncTaps(dependentCompiler.hooks.afterDone, undefined)
+      ).not.toThrow();
+    });
+
+    it('should keep watch-modified files tracked as dependencies of the dependent compiler', () => {
+      const { dependentCompiler } = applyToBothCompilers();
+
+      (dependentCompiler as { watching?: unknown }).watching = {
+        compiler: { modifiedFiles: new Set(['/root/src/app/app.ts']) },
+      };
+      fireSyncTaps(dependentCompiler.hooks.watchRun, dependentCompiler);
+
+      const compilation = createFakeCompilation(dependentCompiler);
+      fireSyncTaps(dependentCompiler.hooks.compilation, compilation);
+      expect(compilation.fileDependencies.add).toHaveBeenCalledWith(
+        '/root/src/app/app.ts'
+      );
+    });
+  });
+
   it('should drop stylesheet metafile inputs for modified files, including inline-style entries', async () => {
     setupCompilationMock.mockResolvedValueOnce({
       angularCompilation: { diagnoseFiles: vi.fn().mockResolvedValue({}) },

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.spec.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.spec.ts
@@ -138,6 +138,7 @@ describe('AngularRspackPlugin', () => {
       angularCompilation: { diagnoseFiles: vi.fn().mockResolvedValue({}) },
       collectedStylesheetAssets: [],
       collectedStylesheetMetafileInputs: [],
+      useTypeScriptTranspilation: true,
     });
   });
 
@@ -294,7 +295,7 @@ describe('AngularRspackPlugin', () => {
     expect(disposeComponentStylesheetBundlerMock).toHaveBeenCalled();
   });
 
-  it('should expose the stylesheet metafile inputs to other plugins', async () => {
+  it('should expose the TypeScript transpilation mode and stylesheet metafile inputs to the loaders', async () => {
     setupCompilationMock.mockResolvedValue({
       angularCompilation: { diagnoseFiles: vi.fn().mockResolvedValue({}) },
       collectedStylesheetAssets: [],
@@ -304,6 +305,7 @@ describe('AngularRspackPlugin', () => {
           inputs: { 'node_modules/css-pkg/styles.css': { bytesInOutput: 5 } },
         },
       ],
+      useTypeScriptTranspilation: false,
     });
     const compiler = applyPlugin();
 
@@ -314,6 +316,7 @@ describe('AngularRspackPlugin', () => {
     const state = (compilation as unknown as NgRspackCompilation)[
       NG_RSPACK_SYMBOL_NAME
     ]();
+    expect(state.useTypeScriptTranspilation).toBe(false);
     expect(state.stylesheetMetafileInputs).toEqual({
       'node_modules/css-pkg/styles.css': { bytesInOutput: 5 },
     });
@@ -333,6 +336,7 @@ describe('AngularRspackPlugin', () => {
           inputs: { 'node_modules/other-pkg/styles.css': { bytesInOutput: 5 } },
         },
       ],
+      useTypeScriptTranspilation: true,
     });
     const compiler = createFakeCompiler();
     const plugin = new AngularRspackPlugin(options);

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.spec.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.spec.ts
@@ -232,12 +232,22 @@ describe('AngularRspackPlugin', () => {
     // emit must resolve (the callback fires) rather than leak the rejection
     await fireAsyncTaps(compiler.hooks.emit, compilation);
 
-    expect(transformerCloseMock).toHaveBeenCalled();
     expect(
       compilation.errors.some((error) =>
         error.message.includes('Angular diagnostics failed.')
       )
     ).toBe(true);
+  });
+
+  it('should not close the JS transformer worker pool on emit', async () => {
+    const compiler = applyPlugin();
+
+    await runBuildStart(compiler);
+
+    const compilation = createFakeCompilation(compiler);
+    await fireAsyncTaps(compiler.hooks.emit, compilation);
+
+    expect(transformerCloseMock).not.toHaveBeenCalled();
   });
 
   it('should clear the error and recover on a rebuild that initializes successfully', async () => {

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
@@ -149,7 +149,7 @@ export class AngularRspackPlugin implements RspackPluginInstance {
     compiler.hooks.beforeRun.tapAsync(
       PLUGIN_NAME,
       async (compiler, callback) => {
-        await this.setupCompilation(root, compiler.options.resolve.tsConfig);
+        await this.setupCompilation(root, compiler.options.resolve);
 
         compiler.hooks.beforeCompile.tapAsync(
           PLUGIN_NAME,
@@ -210,7 +210,7 @@ export class AngularRspackPlugin implements RspackPluginInstance {
               }
               await this.setupCompilation(
                 root,
-                compiler.options.resolve.tsConfig,
+                compiler.options.resolve,
                 changedFiles.size > 0 ? changedFiles : undefined,
                 true
               );
@@ -579,12 +579,13 @@ export class AngularRspackPlugin implements RspackPluginInstance {
 
   private async setupCompilation(
     root: string,
-    tsConfig: RspackOptionsNormalized['resolve']['tsConfig'],
+    resolve: RspackOptionsNormalized['resolve'],
     modifiedFiles?: Set<string>,
     watch = false
   ) {
     this.#initializationError = undefined;
     this.#emitError = undefined;
+    const tsConfig = resolve.tsConfig;
     const tsconfigPath = tsConfig
       ? typeof tsConfig === 'string'
         ? tsConfig
@@ -610,6 +611,10 @@ export class AngularRspackPlugin implements RspackPluginInstance {
           sass: this.#_options.stylePreprocessorOptions?.sass,
           watch,
           sourceMap: this.#_options.sourceMap.scripts,
+          preserveSymlinks: this.#_options.preserveSymlinks,
+          // '...' splices rspack's default conditions back in; the rest are
+          // the bundler's custom conditions the program must match.
+          customConditions: resolve.conditionNames?.filter((c) => c !== '...'),
         },
         this.#sourceFileCache,
         this.#angularCompilation,

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
@@ -55,6 +55,7 @@ export class AngularRspackPlugin implements RspackPluginInstance {
   >();
   #stylesheetMetafileInputs: StylesheetMetafileInputs['inputs'] = {};
   #collectedStylesheetMetafileInputs: StylesheetMetafileInputs[] = [];
+  #useTypeScriptTranspilation = true;
   #initializationError: string | undefined;
   #emitError: string | undefined;
 
@@ -442,6 +443,7 @@ export class AngularRspackPlugin implements RspackPluginInstance {
         javascriptTransformer: this
           .#javascriptTransformer as unknown as JavaScriptTransformer,
         typescriptFileCache: this.#sourceFileCache.typeScriptFileCache,
+        useTypeScriptTranspilation: this.#useTypeScriptTranspilation,
         angularCompilationFailed:
           this.#initializationError !== undefined ||
           this.#emitError !== undefined,
@@ -526,6 +528,7 @@ export class AngularRspackPlugin implements RspackPluginInstance {
           includePaths: this.#_options.stylePreprocessorOptions?.includePaths,
           sass: this.#_options.stylePreprocessorOptions?.sass,
           watch,
+          sourceMap: this.#_options.sourceMap.scripts,
         },
         this.#sourceFileCache,
         this.#angularCompilation,
@@ -535,6 +538,8 @@ export class AngularRspackPlugin implements RspackPluginInstance {
       this.#collectedStylesheetAssets = result.collectedStylesheetAssets;
       this.#collectedStylesheetMetafileInputs =
         result.collectedStylesheetMetafileInputs ?? [];
+      this.#useTypeScriptTranspilation =
+        result.useTypeScriptTranspilation ?? true;
     } catch (error) {
       this.#initializationError = `Angular compilation initialization failed.\n${formatError(
         error

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
@@ -155,14 +155,21 @@ export class AngularRspackPlugin implements RspackPluginInstance {
           compiler.hooks.beforeCompile.tapAsync(
             PLUGIN_NAME,
             async (params, callback) => {
-              const watchingModifiedFiles = compiler.watching?.compiler
-                ?.modifiedFiles
-                ? new Set(compiler.watching.compiler.modifiedFiles)
-                : new Set<string>();
+              const watchingCompiler = compiler.watching?.compiler;
+              const watchingModifiedFiles = new Set(
+                watchingCompiler?.modifiedFiles
+              );
+              const removedFiles = new Set(watchingCompiler?.removedFiles);
+              // Removed files invalidate the compilation like modified ones.
+              const changedFiles = new Set([
+                ...watchingModifiedFiles,
+                ...removedFiles,
+              ]);
 
               if (this.#angularCompilation) {
-                this.#sourceFileCache.invalidate(watchingModifiedFiles);
-                for (const file of watchingModifiedFiles) {
+                this.#sourceFileCache.invalidate(changedFiles);
+                this.#sourceFileCache.prune(removedFiles);
+                for (const file of changedFiles) {
                   // Inline styles are keyed `<file>?class=...`; drop those
                   // along with the file's own entry.
                   for (const key of this.#stylesheetMetafileInputsBySource.keys()) {
@@ -175,9 +182,7 @@ export class AngularRspackPlugin implements RspackPluginInstance {
               await this.setupCompilation(
                 root,
                 compiler.options.resolve.tsConfig,
-                watchingModifiedFiles.size > 0
-                  ? watchingModifiedFiles
-                  : undefined,
+                changedFiles.size > 0 ? changedFiles : undefined,
                 true
               );
 
@@ -438,11 +443,9 @@ export class AngularRspackPlugin implements RspackPluginInstance {
       }
     );
 
-    // Failed builds skip the done hook (afterSeal fails the seal), so release
-    // the esbuild service here too. The JavaScriptTransformer is closed only
-    // on shutdown (like @angular/build's onDispose): a per-build close would
-    // tear down its worker pool on every watch rebuild. Runs on close for
-    // both one-shot and watch; both teardowns are idempotent.
+    // Failed builds skip the done hook, so release the esbuild service here
+    // too. The transformer closes only on shutdown: a per-build close would
+    // tear down its worker pool on every watch rebuild. Both are idempotent.
     compiler.hooks.shutdown.tapAsync(
       `${PLUGIN_NAME}_cleanup`,
       async (callback) => {
@@ -475,6 +478,7 @@ export class AngularRspackPlugin implements RspackPluginInstance {
         javascriptTransformer: this
           .#javascriptTransformer as unknown as JavaScriptTransformer,
         typescriptFileCache: this.#sourceFileCache.typeScriptFileCache,
+        babelFileCache: this.#sourceFileCache.babelFileCache,
         useTypeScriptTranspilation: this.#useTypeScriptTranspilation,
         angularCompilationFailed:
           this.#initializationError !== undefined ||

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
@@ -351,9 +351,9 @@ export class AngularRspackPlugin implements RspackPluginInstance {
       // failure diagnostics still run since they usually carry the root
       // cause.
       try {
-        if (!this.#_options.skipTypeChecking && !this.#initializationError) {
+        if (!this.#initializationError) {
           const { errors, warnings } = await (this.#diagnosticsPromise ??
-            this.#angularCompilation.diagnoseFiles(DiagnosticModes.All));
+            this.#angularCompilation.diagnoseFiles(this.#diagnosticModes()));
           for (const error of errors ?? []) {
             compilation.errors.push({
               name: PLUGIN_NAME,
@@ -641,6 +641,14 @@ export class AngularRspackPlugin implements RspackPluginInstance {
     }
   }
 
+  // Skipping type checking skips only the semantic pass; option and
+  // syntactic diagnostics still surface configuration and parse errors.
+  #diagnosticModes(): DiagnosticModes {
+    return this.#_options.skipTypeChecking
+      ? ((DiagnosticModes.All & ~DiagnosticModes.Semantic) as DiagnosticModes)
+      : DiagnosticModes.All;
+  }
+
   private async buildAndAnalyze() {
     this.#diagnosticsPromise = undefined;
     if (this.#initializationError) {
@@ -659,19 +667,17 @@ export class AngularRspackPlugin implements RspackPluginInstance {
     }
     this.#mergeStylesheetMetafileInputs();
 
-    // Start type checking now so it overlaps with bundling; with the
+    // Start diagnostics now so they overlap with bundling; with the
     // worker-based compilation it runs off the main thread and the emit hook
     // only waits for what is left. Diagnostics still run after an emit
     // failure since they usually carry the root cause.
-    if (!this.#_options.skipTypeChecking) {
-      const diagnosticsPromise = this.#angularCompilation.diagnoseFiles(
-        DiagnosticModes.All
-      );
-      // Failed builds skip the emit hook that reports the result; don't
-      // leave the rejection unhandled.
-      diagnosticsPromise.catch(() => {});
-      this.#diagnosticsPromise = diagnosticsPromise;
-    }
+    const diagnosticsPromise = this.#angularCompilation.diagnoseFiles(
+      this.#diagnosticModes()
+    );
+    // Failed builds skip the emit hook that reports the result; don't
+    // leave the rejection unhandled.
+    diagnosticsPromise.catch(() => {});
+    this.#diagnosticsPromise = diagnosticsPromise;
   }
 
   // Fold this build's stylesheet bundling results into the persistent

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
@@ -6,6 +6,7 @@ import {
 } from '@angular/build/private';
 import {
   buildAndAnalyze,
+  createJavascriptTransformerCache,
   DiagnosticModes,
   disposeComponentStylesheetBundler,
   JavaScriptTransformer,
@@ -13,6 +14,7 @@ import {
   maxWorkers,
   setupCompilationWithAngularCompilation,
   AngularCompilation,
+  type JavascriptTransformerCache,
   type StylesheetMetafileInputs,
 } from '@nx/angular-rspack-compiler';
 import { workspaceRoot } from '@nx/devkit';
@@ -87,6 +89,7 @@ export class AngularRspackPlugin implements RspackPluginInstance {
   #collectedStylesheetMetafileInputs: StylesheetMetafileInputs[] = [];
   #useTypeScriptTranspilation = true;
   #resourceDependencies?: ReadonlyMap<string, readonly string[]>;
+  #javascriptTransformerCache?: JavascriptTransformerCache;
   #initializationError: string | undefined;
   #emitError: string | undefined;
 
@@ -96,9 +99,12 @@ export class AngularRspackPlugin implements RspackPluginInstance {
   ) {
     this.#_options = options;
     this.#i18n = i18nOptions;
-    this.#sourceFileCache = new SourceFileCache(
-      getPersistentCachePath(options)
-    );
+    const persistentCachePath = getPersistentCachePath(options);
+    this.#sourceFileCache = new SourceFileCache(persistentCachePath);
+    if (persistentCachePath) {
+      this.#javascriptTransformerCache =
+        createJavascriptTransformerCache(persistentCachePath);
+    }
     this.#javascriptTransformer = new JavaScriptTransformer(
       {
         /**
@@ -113,7 +119,8 @@ export class AngularRspackPlugin implements RspackPluginInstance {
         advancedOptimizations: this.#_options.advancedOptimizations,
         jit: !this.#_options.aot,
       },
-      maxWorkers()
+      maxWorkers(),
+      this.#javascriptTransformerCache?.cache
     ) as unknown as ResolvedJavascriptTransformer;
   }
 
@@ -452,6 +459,7 @@ export class AngularRspackPlugin implements RspackPluginInstance {
       async (callback) => {
         try {
           await this.#javascriptTransformer.close();
+          await this.#javascriptTransformerCache?.close();
           await disposeComponentStylesheetBundler();
         } catch {
           // Best-effort cleanup that must never fail the compiler teardown.

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
@@ -303,11 +303,6 @@ export class AngularRspackPlugin implements RspackPluginInstance {
         );
       }
 
-      try {
-        await this.#javascriptTransformer.close();
-      } catch {
-        // Best-effort cleanup that must never hang the build.
-      }
       callback();
     });
 
@@ -411,8 +406,10 @@ export class AngularRspackPlugin implements RspackPluginInstance {
     );
 
     // Failed builds skip the done hook (afterSeal fails the seal), so release
-    // the esbuild service and worker pool here too. Runs on close for both
-    // one-shot and watch; both teardowns are idempotent.
+    // the esbuild service here too. The JavaScriptTransformer is closed only
+    // on shutdown (like @angular/build's onDispose): a per-build close would
+    // tear down its worker pool on every watch rebuild. Runs on close for
+    // both one-shot and watch; both teardowns are idempotent.
     compiler.hooks.shutdown.tapAsync(
       `${PLUGIN_NAME}_cleanup`,
       async (callback) => {

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
@@ -105,6 +105,7 @@ export class AngularRspackPlugin implements RspackPluginInstance {
   #useTypeScriptTranspilation = true;
   #resourceDependencies?: ReadonlyMap<string, readonly string[]>;
   #javascriptTransformerCache?: JavascriptTransformerCache;
+  #diagnosticsPromise?: ReturnType<AngularCompilation['diagnoseFiles']>;
   #initializationError: string | undefined;
   #emitError: string | undefined;
 
@@ -190,6 +191,9 @@ export class AngularRspackPlugin implements RspackPluginInstance {
               ]);
 
               if (this.#angularCompilation) {
+                // The worker-based compilation tracks modified files itself;
+                // the in-process one takes them from the host options.
+                await this.#angularCompilation.update?.(changedFiles);
                 this.#sourceFileCache.invalidate(changedFiles);
                 this.#sourceFileCache.prune(removedFiles);
                 for (const file of changedFiles) {
@@ -336,8 +340,8 @@ export class AngularRspackPlugin implements RspackPluginInstance {
       // cause, matching @angular/build's application builder.
       try {
         if (!this.#_options.skipTypeChecking && !this.#initializationError) {
-          const { errors, warnings } =
-            await this.#angularCompilation.diagnoseFiles(DiagnosticModes.All);
+          const { errors, warnings } = await (this.#diagnosticsPromise ??
+            this.#angularCompilation.diagnoseFiles(DiagnosticModes.All));
           for (const error of errors ?? []) {
             compilation.errors.push({
               name: PLUGIN_NAME,
@@ -475,6 +479,9 @@ export class AngularRspackPlugin implements RspackPluginInstance {
         try {
           await this.#javascriptTransformer.close();
           await this.#javascriptTransformerCache?.close();
+          // Terminates the worker of a worker-based compilation, which would
+          // otherwise keep the process alive.
+          await this.#angularCompilation?.close?.();
           await disposeComponentStylesheetBundler();
         } catch {
           // Best-effort cleanup that must never fail the compiler teardown.
@@ -610,6 +617,7 @@ export class AngularRspackPlugin implements RspackPluginInstance {
   }
 
   private async buildAndAnalyze() {
+    this.#diagnosticsPromise = undefined;
     if (this.#initializationError) {
       return;
     }
@@ -625,6 +633,20 @@ export class AngularRspackPlugin implements RspackPluginInstance {
       )}`;
     }
     this.#mergeStylesheetMetafileInputs();
+
+    // Start type checking now so it overlaps with bundling; with the
+    // worker-based compilation it runs off the main thread and the emit hook
+    // only waits for what is left. Diagnostics still run after an emit
+    // failure since they usually carry the root cause.
+    if (!this.#_options.skipTypeChecking) {
+      const diagnosticsPromise = this.#angularCompilation.diagnoseFiles(
+        DiagnosticModes.All
+      );
+      // Failed builds skip the emit hook that reports the result; don't
+      // leave the rejection unhandled.
+      diagnosticsPromise.catch(() => {});
+      this.#diagnosticsPromise = diagnosticsPromise;
+    }
   }
 
   // Fold this build's stylesheet bundling results into the persistent

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
@@ -86,6 +86,7 @@ export class AngularRspackPlugin implements RspackPluginInstance {
   #stylesheetMetafileInputs: StylesheetMetafileInputs['inputs'] = {};
   #collectedStylesheetMetafileInputs: StylesheetMetafileInputs[] = [];
   #useTypeScriptTranspilation = true;
+  #resourceDependencies?: ReadonlyMap<string, readonly string[]>;
   #initializationError: string | undefined;
   #emitError: string | undefined;
 
@@ -484,6 +485,7 @@ export class AngularRspackPlugin implements RspackPluginInstance {
           this.#initializationError !== undefined ||
           this.#emitError !== undefined,
         stylesheetMetafileInputs: this.#stylesheetMetafileInputs,
+        resourceDependencies: this.#resourceDependencies,
         i18n: this.#i18n,
       });
     });
@@ -576,6 +578,7 @@ export class AngularRspackPlugin implements RspackPluginInstance {
         result.collectedStylesheetMetafileInputs ?? [];
       this.#useTypeScriptTranspilation =
         result.useTypeScriptTranspilation ?? true;
+      this.#resourceDependencies = result.resourceDependencies;
     } catch (error) {
       this.#initializationError = `Angular compilation initialization failed.\n${formatError(
         error

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
@@ -144,7 +144,8 @@ export class AngularRspackPlugin implements RspackPluginInstance {
                 compiler.options.resolve.tsConfig,
                 watchingModifiedFiles.size > 0
                   ? watchingModifiedFiles
-                  : undefined
+                  : undefined,
+                true
               );
 
               await this.buildAndAnalyze();
@@ -500,7 +501,8 @@ export class AngularRspackPlugin implements RspackPluginInstance {
   private async setupCompilation(
     root: string,
     tsConfig: RspackOptionsNormalized['resolve']['tsConfig'],
-    modifiedFiles?: Set<string>
+    modifiedFiles?: Set<string>,
+    watch = false
   ) {
     this.#initializationError = undefined;
     this.#emitError = undefined;
@@ -526,6 +528,7 @@ export class AngularRspackPlugin implements RspackPluginInstance {
           hasServer: this.#_options.hasServer,
           includePaths: this.#_options.stylePreprocessorOptions?.includePaths,
           sass: this.#_options.stylePreprocessorOptions?.sass,
+          watch,
         },
         this.#sourceFileCache,
         this.#angularCompilation,

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
@@ -239,12 +239,15 @@ export class AngularRspackPlugin implements RspackPluginInstance {
         addError(compilation, angularCompilationError);
       }
 
-      // Setup warnings describe the one-time compilation setup; report them
-      // on the build that produced them and keep rebuilds quiet.
+      // Setup warnings describe the one-time compilation setup; repeat them
+      // while initialization keeps failing so they also land with the first
+      // successful build, then keep rebuilds quiet.
       for (const setupWarning of this.#setupWarnings) {
         addWarning(compilation, setupWarning);
       }
-      this.#setupWarnings = [];
+      if (!this.#initializationError) {
+        this.#setupWarnings = [];
+      }
 
       // Handle errors thrown by loaders that prevent sealing (but ignore for watch mode)
       compilation.hooks.afterSeal.tapAsync(PLUGIN_NAME, (callback) => {
@@ -623,6 +626,10 @@ export class AngularRspackPlugin implements RspackPluginInstance {
         this.#setupWarnings = result.setupWarnings ?? [];
       }
     } catch (error) {
+      if (isInitialSetup) {
+        this.#setupWarnings =
+          (error as { setupWarnings?: string[] } | null)?.setupWarnings ?? [];
+      }
       this.#initializationError = `Angular compilation initialization failed.\n${formatError(
         error
       )}`;

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
@@ -55,8 +55,9 @@ type ResolvedJavascriptTransformer = Parameters<typeof buildAndAnalyze>[2];
 function getPersistentCachePath(
   options: NormalizedAngularRspackPluginOptions
 ): string | undefined {
-  // Same default gating as @angular/build's cache options: disk caching is
-  // skipped in CI and in web containers.
+  // Skip disk caching in CI, where fresh checkouts never reuse it, and in
+  // web containers, where it brings no benefit, costs browser memory, and
+  // the lmdb-backed transformer cache is unsupported.
   const ci = process.env['CI'];
   if (ci === '1' || ci?.toLowerCase() === 'true') {
     return undefined;
@@ -108,6 +109,7 @@ export class AngularRspackPlugin implements RspackPluginInstance {
   #diagnosticsPromise?: ReturnType<AngularCompilation['diagnoseFiles']>;
   #initializationError: string | undefined;
   #emitError: string | undefined;
+  #setupWarnings: string[] = [];
 
   constructor(
     options: NormalizedAngularRspackPluginOptions,
@@ -228,14 +230,21 @@ export class AngularRspackPlugin implements RspackPluginInstance {
     );
 
     compiler.hooks.thisCompilation.tap(PLUGIN_NAME, (compilation) => {
-      // Surface a failed Angular compilation as a build error (like
-      // @angular/build) instead of an exception that stalls the hooks chain.
-      // Watch builds recover on the next rebuild's re-init.
+      // Surface a failed Angular compilation as a build error instead of an
+      // exception that stalls the hooks chain. Watch builds recover on the
+      // next rebuild's re-init.
       const angularCompilationError =
         this.#initializationError ?? this.#emitError;
       if (angularCompilationError) {
         addError(compilation, angularCompilationError);
       }
+
+      // Setup warnings describe the one-time compilation setup; report them
+      // on the build that produced them and keep rebuilds quiet.
+      for (const setupWarning of this.#setupWarnings) {
+        addWarning(compilation, setupWarning);
+      }
+      this.#setupWarnings = [];
 
       // Handle errors thrown by loaders that prevent sealing (but ignore for watch mode)
       compilation.hooks.afterSeal.tapAsync(PLUGIN_NAME, (callback) => {
@@ -337,7 +346,7 @@ export class AngularRspackPlugin implements RspackPluginInstance {
       // there is no (or only stale) compilation state to diagnose and the
       // failure is already reported as a compilation error. After an emit
       // failure diagnostics still run since they usually carry the root
-      // cause, matching @angular/build's application builder.
+      // cause.
       try {
         if (!this.#_options.skipTypeChecking && !this.#initializationError) {
           const { errors, warnings } = await (this.#diagnosticsPromise ??
@@ -578,6 +587,7 @@ export class AngularRspackPlugin implements RspackPluginInstance {
         ? tsConfig
         : tsConfig.configFile
       : this.#_options.tsConfig;
+    const isInitialSetup = this.#angularCompilation === undefined;
     try {
       const result = await setupCompilationWithAngularCompilation(
         {
@@ -609,6 +619,9 @@ export class AngularRspackPlugin implements RspackPluginInstance {
       this.#useTypeScriptTranspilation =
         result.useTypeScriptTranspilation ?? true;
       this.#resourceDependencies = result.resourceDependencies;
+      if (isInitialSetup) {
+        this.#setupWarnings = result.setupWarnings ?? [];
+      }
     } catch (error) {
       this.#initializationError = `Angular compilation initialization failed.\n${formatError(
         error

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
@@ -13,6 +13,7 @@ import {
   maxWorkers,
   setupCompilationWithAngularCompilation,
   AngularCompilation,
+  type StylesheetMetafileInputs,
 } from '@nx/angular-rspack-compiler';
 import { workspaceRoot } from '@nx/devkit';
 import {
@@ -46,6 +47,14 @@ export class AngularRspackPlugin implements RspackPluginInstance {
   // This will be defined in the apply method correctly
   #angularCompilation: AngularCompilation;
   #collectedStylesheetAssets: Array<{ path: string; text: string }> = [];
+  // Latest bundled inputs per stylesheet, persisted across rebuilds since
+  // only re-bundled stylesheets produce new results.
+  #stylesheetMetafileInputsBySource = new Map<
+    string,
+    StylesheetMetafileInputs['inputs']
+  >();
+  #stylesheetMetafileInputs: StylesheetMetafileInputs['inputs'] = {};
+  #collectedStylesheetMetafileInputs: StylesheetMetafileInputs[] = [];
   #initializationError: string | undefined;
   #emitError: string | undefined;
 
@@ -120,6 +129,15 @@ export class AngularRspackPlugin implements RspackPluginInstance {
 
               if (this.#angularCompilation) {
                 this.#sourceFileCache.invalidate(watchingModifiedFiles);
+                for (const file of watchingModifiedFiles) {
+                  // Inline styles are keyed `<file>?class=...`; drop those
+                  // along with the file's own entry.
+                  for (const key of this.#stylesheetMetafileInputsBySource.keys()) {
+                    if (key === file || key.startsWith(`${file}?`)) {
+                      this.#stylesheetMetafileInputsBySource.delete(key);
+                    }
+                  }
+                }
               }
               await this.setupCompilation(
                 root,
@@ -429,6 +447,7 @@ export class AngularRspackPlugin implements RspackPluginInstance {
         angularCompilationFailed:
           this.#initializationError !== undefined ||
           this.#emitError !== undefined,
+        stylesheetMetafileInputs: this.#stylesheetMetafileInputs,
         i18n: this.#i18n,
       });
     });
@@ -514,6 +533,8 @@ export class AngularRspackPlugin implements RspackPluginInstance {
       );
       this.#angularCompilation = result.angularCompilation;
       this.#collectedStylesheetAssets = result.collectedStylesheetAssets;
+      this.#collectedStylesheetMetafileInputs =
+        result.collectedStylesheetMetafileInputs ?? [];
     } catch (error) {
       this.#initializationError = `Angular compilation initialization failed.\n${formatError(
         error
@@ -536,6 +557,20 @@ export class AngularRspackPlugin implements RspackPluginInstance {
         error
       )}`;
     }
+    this.#mergeStylesheetMetafileInputs();
+  }
+
+  // Fold this build's stylesheet bundling results into the persistent
+  // per-stylesheet map and refresh the flattened view exposed to plugins.
+  #mergeStylesheetMetafileInputs() {
+    for (const { source, inputs } of this.#collectedStylesheetMetafileInputs) {
+      this.#stylesheetMetafileInputsBySource.set(source, inputs);
+    }
+    const flattened: StylesheetMetafileInputs['inputs'] = {};
+    for (const inputs of this.#stylesheetMetafileInputsBySource.values()) {
+      Object.assign(flattened, inputs);
+    }
+    this.#stylesheetMetafileInputs = flattened;
   }
 }
 

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
@@ -26,7 +26,14 @@ import {
   sources,
 } from '@rspack/core';
 import { createRequire } from 'node:module';
-import { dirname, join, normalize, resolve } from 'node:path';
+import {
+  basename,
+  dirname,
+  join,
+  normalize,
+  relative,
+  resolve,
+} from 'node:path';
 import {
   type I18nOptions,
   NG_RSPACK_SYMBOL_NAME,
@@ -48,9 +55,6 @@ type ResolvedJavascriptTransformer = Parameters<typeof buildAndAnalyze>[2];
 function getPersistentCachePath(
   options: NormalizedAngularRspackPluginOptions
 ): string | undefined {
-  if (!options.projectName) {
-    return undefined;
-  }
   // Same default gating as @angular/build's cache options: disk caching is
   // skipped in CI and in web containers.
   const ci = process.env['CI'];
@@ -60,13 +64,24 @@ function getPersistentCachePath(
   if (process.versions.webcontainer) {
     return undefined;
   }
+  // In Nx workspaces the project name scopes the cache. Outside them (plain
+  // programmatic `createConfig` usage) there is no project graph to name the
+  // project, so scope by the project root instead of skipping the cache.
+  let projectScope = options.projectName;
+  if (!projectScope) {
+    const relativeRoot = relative(workspaceRoot, options.root);
+    projectScope =
+      relativeRoot && !relativeRoot.startsWith('..')
+        ? relativeRoot.replace(/[\\/]/g, '-')
+        : basename(options.root);
+  }
   const { version } = createRequire(__filename)('@angular/build/package.json');
   return join(
     workspaceRoot,
     '.angular',
     'cache',
     version,
-    options.projectName,
+    projectScope,
     'angular-rspack'
   );
 }

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
@@ -23,6 +23,7 @@ import {
   type RspackPluginInstance,
   sources,
 } from '@rspack/core';
+import { createRequire } from 'node:module';
 import { dirname, join, normalize, resolve } from 'node:path';
 import {
   type I18nOptions,
@@ -38,6 +39,35 @@ import { getStatsOptions } from '../config/config-utils/get-stats-options';
 
 const PLUGIN_NAME = 'AngularRspackPlugin';
 type ResolvedJavascriptTransformer = Parameters<typeof buildAndAnalyze>[2];
+
+// A project-scoped directory under the Angular CLI cache directory, with an
+// `angular-rspack` leaf so the state never collides with @angular/build's own
+// cache for the same project.
+function getPersistentCachePath(
+  options: NormalizedAngularRspackPluginOptions
+): string | undefined {
+  if (!options.projectName) {
+    return undefined;
+  }
+  // Same default gating as @angular/build's cache options: disk caching is
+  // skipped in CI and in web containers.
+  const ci = process.env['CI'];
+  if (ci === '1' || ci?.toLowerCase() === 'true') {
+    return undefined;
+  }
+  if (process.versions.webcontainer) {
+    return undefined;
+  }
+  const { version } = createRequire(__filename)('@angular/build/package.json');
+  return join(
+    workspaceRoot,
+    '.angular',
+    'cache',
+    version,
+    options.projectName,
+    'angular-rspack'
+  );
+}
 
 export class AngularRspackPlugin implements RspackPluginInstance {
   #_options: NormalizedAngularRspackPluginOptions;
@@ -65,7 +95,9 @@ export class AngularRspackPlugin implements RspackPluginInstance {
   ) {
     this.#_options = options;
     this.#i18n = i18nOptions;
-    this.#sourceFileCache = new SourceFileCache();
+    this.#sourceFileCache = new SourceFileCache(
+      getPersistentCachePath(options)
+    );
     this.#javascriptTransformer = new JavaScriptTransformer(
       {
         /**

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
@@ -249,20 +249,6 @@ export class AngularRspackPlugin implements RspackPluginInstance {
         this.#setupWarnings = [];
       }
 
-      // Handle errors thrown by loaders that prevent sealing (but ignore for watch mode)
-      compilation.hooks.afterSeal.tapAsync(PLUGIN_NAME, (callback) => {
-        if (!watchRunInitialized && compilation.errors.length > 0) {
-          const stats = compilation.getStats();
-          const compilationError = statsErrorsToString(
-            stats.toJson(),
-            getStatsOptions(this.#_options.verbose)
-          );
-          callback(new Error(compilationError));
-        } else {
-          callback();
-        }
-      });
-
       compilation.hooks.processAssets.tap(
         {
           name: PLUGIN_NAME,
@@ -437,28 +423,7 @@ export class AngularRspackPlugin implements RspackPluginInstance {
       }
     });
 
-    compiler.hooks.afterDone.tap(PLUGIN_NAME, (stats) => {
-      // Despite the typings, stats is undefined when the run fails before
-      // producing stats (e.g. the afterSeal hook above fails the seal for a
-      // build with errors). Rspack reports that failure itself.
-      if (!stats) {
-        return;
-      }
-
-      // Get stats options - merge defaults with user's config if provided
-      const configStats = compiler.options.stats;
-      const defaultStatsOptions = getStatsOptions(this.#_options.verbose);
-      const statsOptions =
-        typeof configStats === 'object' && configStats !== null
-          ? { ...defaultStatsOptions, ...configStats }
-          : defaultStatsOptions;
-
-      rspackStatsLogger(stats, statsOptions);
-      // Don't forcibly exit the process with errors when in watch mode
-      if (!watchRunInitialized && stats.hasErrors()) {
-        process.exit(1);
-      }
-    });
+    this.#applyBuildResultReporting(compiler, () => watchRunInitialized);
 
     // Dispose the shared component stylesheet bundler after a one-shot build so
     // its esbuild service (a child process and sockets, with @angular/build >=
@@ -502,35 +467,9 @@ export class AngularRspackPlugin implements RspackPluginInstance {
       }
     );
 
-    compiler.hooks.normalModuleFactory.tap(
-      PLUGIN_NAME,
-      (normalModuleFactory) => {
-        normalModuleFactory.hooks.beforeResolve.tap(PLUGIN_NAME, (data) => {
-          if (data.request.startsWith('angular:jit:')) {
-            const path = data.request.split(';')[1];
-            data.request = `${normalize(
-              resolve(dirname(data.contextInfo.issuer), path)
-            )}?raw`;
-          }
-        });
-      }
-    );
+    this.#applyJitResourceResolution(compiler);
 
-    compiler.hooks.compilation.tap(PLUGIN_NAME, (compilation) => {
-      (compilation as NgRspackCompilation)[NG_RSPACK_SYMBOL_NAME] = () => ({
-        javascriptTransformer: this
-          .#javascriptTransformer as unknown as JavaScriptTransformer,
-        typescriptFileCache: this.#sourceFileCache.typeScriptFileCache,
-        babelFileCache: this.#sourceFileCache.babelFileCache,
-        useTypeScriptTranspilation: this.#useTypeScriptTranspilation,
-        angularCompilationFailed:
-          this.#initializationError !== undefined ||
-          this.#emitError !== undefined,
-        stylesheetMetafileInputs: this.#stylesheetMetafileInputs,
-        resourceDependencies: this.#resourceDependencies,
-        i18n: this.#i18n,
-      });
-    });
+    this.#exposeLoaderState(compiler);
 
     if (this.#_options.serviceWorker) {
       compiler.hooks.done.tapAsync(
@@ -575,6 +514,125 @@ export class AngularRspackPlugin implements RspackPluginInstance {
         }
       );
     }
+  }
+
+  /**
+   * Wires a compiler to consume this plugin instance's compilation state
+   * without running an Angular compilation of its own. The server compiler
+   * of an SSR build runs after the browser compiler
+   * (`dependencies: ['browser']`), whose program already includes the server
+   * entry points, so its loaders read the emitted files straight from this
+   * instance's caches.
+   */
+  applyToDependentCompiler(compiler: Compiler) {
+    let watchRunInitialized = false;
+    let currentWatchingModifiedFiles = new Set<string>();
+    // Keeps modified files watched across rebuilds (same invariant as the
+    // matching tap in apply()).
+    compiler.hooks.compilation.tap(PLUGIN_NAME + '_fileDeps', (compilation) => {
+      currentWatchingModifiedFiles.forEach((file) => {
+        compilation.fileDependencies.add(file);
+      });
+    });
+    compiler.hooks.watchRun.tap(PLUGIN_NAME, (watchRunCompiler) => {
+      watchRunInitialized = true;
+      currentWatchingModifiedFiles = new Set(
+        watchRunCompiler.watching?.compiler?.modifiedFiles
+      );
+    });
+
+    // Surface a failed Angular compilation on this compiler too; its loaders
+    // emit empty modules in that case.
+    compiler.hooks.thisCompilation.tap(PLUGIN_NAME, (compilation) => {
+      const angularCompilationError =
+        this.#initializationError ?? this.#emitError;
+      if (angularCompilationError) {
+        addError(compilation, angularCompilationError);
+      }
+    });
+
+    this.#applyBuildResultReporting(compiler, () => watchRunInitialized);
+
+    this.#applyJitResourceResolution(compiler);
+
+    this.#exposeLoaderState(compiler);
+  }
+
+  // Fails the seal of an errored one-shot build and logs the compiler's
+  // stats; watch builds stay alive and recover on the next rebuild.
+  #applyBuildResultReporting(compiler: Compiler, isWatchRun: () => boolean) {
+    compiler.hooks.thisCompilation.tap(PLUGIN_NAME, (compilation) => {
+      // Handle errors thrown by loaders that prevent sealing (but ignore for watch mode)
+      compilation.hooks.afterSeal.tapAsync(PLUGIN_NAME, (callback) => {
+        if (!isWatchRun() && compilation.errors.length > 0) {
+          const stats = compilation.getStats();
+          const compilationError = statsErrorsToString(
+            stats.toJson(),
+            getStatsOptions(this.#_options.verbose)
+          );
+          callback(new Error(compilationError));
+        } else {
+          callback();
+        }
+      });
+    });
+
+    compiler.hooks.afterDone.tap(PLUGIN_NAME, (stats) => {
+      // Despite the typings, stats is undefined when the run fails before
+      // producing stats (e.g. the afterSeal hook above fails the seal for a
+      // build with errors). Rspack reports that failure itself.
+      if (!stats) {
+        return;
+      }
+
+      // Get stats options - merge defaults with user's config if provided
+      const configStats = compiler.options.stats;
+      const defaultStatsOptions = getStatsOptions(this.#_options.verbose);
+      const statsOptions =
+        typeof configStats === 'object' && configStats !== null
+          ? { ...defaultStatsOptions, ...configStats }
+          : defaultStatsOptions;
+
+      rspackStatsLogger(stats, statsOptions);
+      // Don't forcibly exit the process with errors when in watch mode
+      if (!isWatchRun() && stats.hasErrors()) {
+        process.exit(1);
+      }
+    });
+  }
+
+  #applyJitResourceResolution(compiler: Compiler) {
+    compiler.hooks.normalModuleFactory.tap(
+      PLUGIN_NAME,
+      (normalModuleFactory) => {
+        normalModuleFactory.hooks.beforeResolve.tap(PLUGIN_NAME, (data) => {
+          if (data.request.startsWith('angular:jit:')) {
+            const path = data.request.split(';')[1];
+            data.request = `${normalize(
+              resolve(dirname(data.contextInfo.issuer), path)
+            )}?raw`;
+          }
+        });
+      }
+    );
+  }
+
+  #exposeLoaderState(compiler: Compiler) {
+    compiler.hooks.compilation.tap(PLUGIN_NAME, (compilation) => {
+      (compilation as NgRspackCompilation)[NG_RSPACK_SYMBOL_NAME] = () => ({
+        javascriptTransformer: this
+          .#javascriptTransformer as unknown as JavaScriptTransformer,
+        typescriptFileCache: this.#sourceFileCache.typeScriptFileCache,
+        babelFileCache: this.#sourceFileCache.babelFileCache,
+        useTypeScriptTranspilation: this.#useTypeScriptTranspilation,
+        angularCompilationFailed:
+          this.#initializationError !== undefined ||
+          this.#emitError !== undefined,
+        stylesheetMetafileInputs: this.#stylesheetMetafileInputs,
+        resourceDependencies: this.#resourceDependencies,
+        i18n: this.#i18n,
+      });
+    });
   }
 
   private async setupCompilation(

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
@@ -448,21 +448,29 @@ export class AngularRspackPlugin implements RspackPluginInstance {
     );
 
     // Failed builds skip the done hook, so release the esbuild service here
-    // too. The transformer closes only on shutdown: a per-build close would
-    // tear down its worker pool on every watch rebuild. Both are idempotent.
+    // too; disposing the bundler again after a one-shot build is a no-op.
+    // The transformer closes only on shutdown: a per-build close would tear
+    // down its worker pool on every watch rebuild.
     compiler.hooks.shutdown.tapAsync(
       `${PLUGIN_NAME}_cleanup`,
       async (callback) => {
-        try {
-          await this.#javascriptTransformer.close();
-          await this.#javascriptTransformerCache?.close();
-          // Terminates the worker of a worker-based compilation, which would
-          // otherwise keep the process alive.
-          await this.#angularCompilation?.close?.();
-          await disposeComponentStylesheetBundler();
-        } catch {
-          // Best-effort cleanup that must never fail the compiler teardown.
-        }
+        // Isolated per close so a failing one cannot skip the rest and leak
+        // their resources (an unterminated compilation worker keeps the
+        // process alive). Kept sequential: the transformer writes results
+        // through the cache store, so its worker pool closes first.
+        const closeSafely = async (close: () => unknown) => {
+          try {
+            await close();
+          } catch {
+            // Best-effort cleanup that must never fail the compiler teardown.
+          }
+        };
+        await closeSafely(() => this.#javascriptTransformer.close());
+        await closeSafely(() => this.#javascriptTransformerCache?.close());
+        // Terminates the worker of a worker-based compilation, which would
+        // otherwise keep the process alive.
+        await closeSafely(() => this.#angularCompilation?.close?.());
+        await closeSafely(() => disposeComponentStylesheetBundler());
         callback();
       }
     );

--- a/packages/angular-rspack/src/lib/plugins/extract-licenses-plugin.spec.ts
+++ b/packages/angular-rspack/src/lib/plugins/extract-licenses-plugin.spec.ts
@@ -1,0 +1,321 @@
+import { mkdtemp, mkdir, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { NG_RSPACK_SYMBOL_NAME } from '../models';
+import {
+  ExtractLicensesPlugin,
+  extractLicenses,
+} from './extract-licenses-plugin';
+
+describe('extractLicenses', () => {
+  let root: string;
+
+  const addPackage = async (
+    name: string,
+    version: string,
+    license: string,
+    licenseFile?: { name: string; content: string }
+  ) => {
+    const packageDir = join(root, 'node_modules', name);
+    await mkdir(packageDir, { recursive: true });
+    await writeFile(
+      join(packageDir, 'package.json'),
+      JSON.stringify({ name, version, license })
+    );
+    if (licenseFile) {
+      await writeFile(join(packageDir, licenseFile.name), licenseFile.content);
+    }
+  };
+
+  const metafileFor = (...inputPaths: string[]) => ({
+    outputs: {
+      0: {
+        inputs: Object.fromEntries(
+          inputPaths.map((p) => [p, { bytesInOutput: 1 }])
+        ),
+      },
+    },
+  });
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'extract-licenses-'));
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  it('should extract the license of a package with a LICENSE file', async () => {
+    await addPackage('foo', '1.0.0', 'MIT', {
+      name: 'LICENSE',
+      content: 'FOO LICENSE TEXT',
+    });
+
+    const content = await extractLicenses(
+      metafileFor(join('node_modules', 'foo', 'index.js')),
+      root
+    );
+
+    expect(content).toContain('Package: foo');
+    expect(content).toContain('License: "MIT"');
+    expect(content).toContain('FOO LICENSE TEXT');
+  });
+
+  it('should extract the license of a scoped package', async () => {
+    await addPackage('@scope/bar', '2.0.0', 'Apache-2.0', {
+      name: 'LICENSE.md',
+      content: 'BAR LICENSE TEXT',
+    });
+
+    const content = await extractLicenses(
+      metafileFor(join('node_modules', '@scope', 'bar', 'main.js')),
+      root
+    );
+
+    expect(content).toContain('Package: @scope/bar');
+    expect(content).toContain('License: "Apache-2.0"');
+    expect(content).toContain('BAR LICENSE TEXT');
+  });
+
+  it('should skip paths that are not part of a package', async () => {
+    const content = await extractLicenses(
+      metafileFor(join('src', 'main.ts')),
+      root
+    );
+
+    expect(content).not.toContain('Package:');
+  });
+
+  it('should skip packages without a package.json', async () => {
+    const content = await extractLicenses(
+      metafileFor(join('node_modules', 'missing', 'index.js')),
+      root
+    );
+
+    expect(content).not.toContain('Package:');
+  });
+
+  it('should list a package only once for multiple input files', async () => {
+    await addPackage('foo', '1.0.0', 'MIT', {
+      name: 'LICENSE',
+      content: 'FOO LICENSE TEXT',
+    });
+
+    const content = await extractLicenses(
+      metafileFor(
+        join('node_modules', 'foo', 'index.js'),
+        join('node_modules', 'foo', 'other.js')
+      ),
+      root
+    );
+
+    expect(content.match(/Package: foo/g)).toHaveLength(1);
+  });
+
+  it('should emit an entry without license text when no license file exists', async () => {
+    await addPackage('foo', '1.0.0', 'MIT');
+
+    const content = await extractLicenses(
+      metafileFor(join('node_modules', 'foo', 'index.js')),
+      root
+    );
+
+    expect(content).toContain('Package: foo');
+    expect(content).toContain('License: "MIT"');
+  });
+});
+
+describe('ExtractLicensesPlugin', () => {
+  let root: string;
+
+  beforeEach(async () => {
+    root = await mkdtemp(join(tmpdir(), 'extract-licenses-plugin-'));
+  });
+
+  afterEach(async () => {
+    await rm(root, { recursive: true, force: true });
+  });
+
+  const setupFakeCompiler = () => {
+    let processAssetsFn: (() => Promise<void>) | undefined;
+    const emitAsset = vi.fn();
+    const chunks: unknown[] = [];
+    const chunkModules = new Map<unknown, unknown[]>();
+    const compilation = {
+      chunks,
+      chunkGraph: {
+        getChunkModulesIterable: (chunk: unknown) =>
+          chunkModules.get(chunk) ?? [],
+      },
+      hooks: {
+        processAssets: {
+          tapPromise: (_opts: unknown, fn: () => Promise<void>) => {
+            processAssetsFn = fn;
+          },
+        },
+      },
+      emitAsset,
+    };
+    const compiler = {
+      hooks: {
+        thisCompilation: {
+          tap: (_name: string, fn: (compilation: unknown) => void) =>
+            fn(compilation),
+        },
+      },
+      rspack: {
+        Compilation: { PROCESS_ASSETS_STAGE_REPORT: 5000 },
+        sources: {
+          RawSource: class {
+            constructor(public source: string) {}
+          },
+        },
+      },
+    };
+    return {
+      compiler,
+      compilation,
+      chunks,
+      chunkModules,
+      emitAsset,
+      runProcessAssets: () => {
+        if (!processAssetsFn) {
+          throw new Error('processAssets was not tapped');
+        }
+        return processAssetsFn();
+      },
+    };
+  };
+
+  const addPackage = async (name: string, version: string, license: string) => {
+    const packageDir = join(root, 'node_modules', name);
+    await mkdir(packageDir, { recursive: true });
+    await writeFile(
+      join(packageDir, 'package.json'),
+      JSON.stringify({ name, version, license })
+    );
+    await writeFile(join(packageDir, 'LICENSE'), `${name} LICENSE TEXT`);
+  };
+
+  it('should emit a licenses asset for the packages in the chunk graph', async () => {
+    await addPackage('foo', '1.0.0', 'MIT');
+    const { compiler, chunks, chunkModules, emitAsset, runProcessAssets } =
+      setupFakeCompiler();
+    const chunk = {};
+    chunks.push(chunk);
+    chunkModules.set(chunk, [
+      {
+        nameForCondition: () => join(root, 'node_modules', 'foo', 'index.js'),
+      },
+      { nameForCondition: () => join(root, 'src', 'main.ts') },
+      { nameForCondition: () => undefined },
+    ]);
+
+    new ExtractLicensesPlugin({
+      outputFilename: '../3rdpartylicenses.txt',
+      rootDirectory: root,
+    }).apply(compiler as never);
+    await runProcessAssets();
+
+    expect(emitAsset).toHaveBeenCalledTimes(1);
+    const [assetName, source] = emitAsset.mock.calls[0];
+    expect(assetName).toBe('../3rdpartylicenses.txt');
+    expect(source.source).toContain('Package: foo');
+    expect(source.source).toContain('foo LICENSE TEXT');
+  });
+
+  it('should include packages from concatenated module inner modules', async () => {
+    await addPackage('bar', '1.0.0', 'MIT');
+    const { compiler, chunks, chunkModules, emitAsset, runProcessAssets } =
+      setupFakeCompiler();
+    const chunk = {};
+    chunks.push(chunk);
+    chunkModules.set(chunk, [
+      {
+        nameForCondition: () => join(root, 'src', 'main.ts'),
+        modules: [
+          {
+            nameForCondition: () =>
+              join(root, 'node_modules', 'bar', 'index.js'),
+          },
+        ],
+      },
+    ]);
+
+    new ExtractLicensesPlugin({
+      outputFilename: '../3rdpartylicenses.txt',
+      rootDirectory: root,
+    }).apply(compiler as never);
+    await runProcessAssets();
+
+    const [, source] = emitAsset.mock.calls[0];
+    expect(source.source).toContain('Package: bar');
+  });
+
+  it('should include packages bundled into component stylesheets', async () => {
+    await addPackage('css-pkg', '1.0.0', 'MIT');
+    const { compiler, compilation, emitAsset, runProcessAssets } =
+      setupFakeCompiler();
+    (compilation as Record<string, unknown>)[NG_RSPACK_SYMBOL_NAME] = () => ({
+      stylesheetMetafileInputs: {
+        [join('node_modules', 'css-pkg', 'styles.css')]: { bytesInOutput: 10 },
+      },
+    });
+
+    new ExtractLicensesPlugin({
+      outputFilename: '../3rdpartylicenses.txt',
+      rootDirectory: root,
+    }).apply(compiler as never);
+    await runProcessAssets();
+
+    const [, source] = emitAsset.mock.calls[0];
+    expect(source.source).toContain('Package: css-pkg');
+  });
+
+  it('should emit the union of the inputs shared across compilers', async () => {
+    await addPackage('browser-pkg', '1.0.0', 'MIT');
+    await addPackage('server-pkg', '1.0.0', 'MIT');
+    const sharedInputs = new Map();
+
+    const browser = setupFakeCompiler();
+    const browserChunk = {};
+    browser.chunks.push(browserChunk);
+    browser.chunkModules.set(browserChunk, [
+      {
+        nameForCondition: () =>
+          join(root, 'node_modules', 'browser-pkg', 'index.js'),
+      },
+    ]);
+    new ExtractLicensesPlugin({
+      outputFilename: '../3rdpartylicenses.txt',
+      rootDirectory: root,
+      sharedInputs,
+    }).apply(browser.compiler as never);
+    await browser.runProcessAssets();
+
+    const server = setupFakeCompiler();
+    const serverChunk = {};
+    server.chunks.push(serverChunk);
+    server.chunkModules.set(serverChunk, [
+      {
+        nameForCondition: () =>
+          join(root, 'node_modules', 'server-pkg', 'index.js'),
+      },
+    ]);
+    new ExtractLicensesPlugin({
+      outputFilename: '../3rdpartylicenses.txt',
+      rootDirectory: root,
+      sharedInputs,
+    }).apply(server.compiler as never);
+    await server.runProcessAssets();
+
+    // The browser compiler ran first with only its own inputs; the server
+    // compiler runs after it and emits the union of both.
+    const [, browserSource] = browser.emitAsset.mock.calls[0];
+    expect(browserSource.source).toContain('Package: browser-pkg');
+    const [, serverSource] = server.emitAsset.mock.calls[0];
+    expect(serverSource.source).toContain('Package: browser-pkg');
+    expect(serverSource.source).toContain('Package: server-pkg');
+  });
+});

--- a/packages/angular-rspack/src/lib/plugins/extract-licenses-plugin.ts
+++ b/packages/angular-rspack/src/lib/plugins/extract-licenses-plugin.ts
@@ -1,0 +1,302 @@
+/**
+ * @license
+ * Copyright Google LLC All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.dev/license
+ */
+
+import type { Compiler, Module, RspackPluginInstance } from '@rspack/core';
+import { readFile } from 'node:fs/promises';
+import path from 'node:path';
+import { NG_RSPACK_SYMBOL_NAME, type NgRspackCompilation } from '../models';
+
+/**
+ * The subset of the esbuild `Metafile` structure consumed by `extractLicenses`.
+ * Built here from the rspack chunk graph instead of an esbuild bundling step.
+ */
+interface LicenseMetafile {
+  outputs: Record<
+    string | number,
+    { inputs: Record<string, { bytesInOutput: number }> }
+  >;
+}
+
+/**
+ * The path segment used to signify that a file is part of a package.
+ */
+const NODE_MODULE_SEGMENT = 'node_modules';
+
+/**
+ * String constant for the NPM recommended custom license wording.
+ *
+ * See: https://docs.npmjs.com/cli/v9/configuring-npm/package-json#license
+ *
+ * Example:
+ * ```
+ * {
+ *   "license" : "SEE LICENSE IN <filename>"
+ * }
+ * ```
+ */
+const CUSTOM_LICENSE_TEXT = 'SEE LICENSE IN ';
+
+/**
+ * A list of commonly named license files found within packages.
+ */
+const LICENSE_FILES = ['LICENSE', 'LICENSE.txt', 'LICENSE.md'];
+
+/**
+ * Header text that will be added to the top of the output license extraction file.
+ */
+const EXTRACTION_FILE_HEADER = '';
+
+/**
+ * The package entry separator to use within the output license extraction file.
+ */
+const EXTRACTION_FILE_SEPARATOR = '-'.repeat(80) + '\n';
+
+/**
+ * Extracts license information for each node module package included in the output
+ * files of the built code. This includes JavaScript and CSS output files. The esbuild
+ * metafile generated during the bundling steps is used as the source of information
+ * regarding what input files where included and where they are located. A path segment
+ * of `node_modules` is used to indicate that a file belongs to a package and its license
+ * should be include in the output licenses file.
+ *
+ * The package name and license field are extracted from the `package.json` file for the
+ * package. If a license file (e.g., `LICENSE`) is present in the root of the package, it
+ * will also be included in the output licenses file.
+ *
+ * Vendored from `@angular/build` (`src/tools/esbuild/license-extractor.ts`, identical
+ * across the supported Angular majors) since it is not exposed in the package's public
+ * or private API. Only the esbuild `Metafile` type import is replaced with the local
+ * `LicenseMetafile` interface.
+ *
+ * @param metafile An esbuild metafile object.
+ * @param rootDirectory The root directory of the workspace.
+ * @returns A string containing the content of the output licenses file.
+ */
+export async function extractLicenses(
+  metafile: LicenseMetafile,
+  rootDirectory: string
+) {
+  let extractedLicenseContent = `${EXTRACTION_FILE_HEADER}\n${EXTRACTION_FILE_SEPARATOR}`;
+
+  const seenPaths = new Set<string>();
+  const seenPackages = new Set<string>();
+
+  for (const entry of Object.values(metafile.outputs)) {
+    for (const [inputPath, { bytesInOutput }] of Object.entries(entry.inputs)) {
+      // Skip if not included in output
+      if (bytesInOutput <= 0) {
+        continue;
+      }
+
+      // Skip already processed paths
+      if (seenPaths.has(inputPath)) {
+        continue;
+      }
+      seenPaths.add(inputPath);
+
+      // Skip non-package paths
+      if (!inputPath.includes(NODE_MODULE_SEGMENT)) {
+        continue;
+      }
+
+      // Extract the package name from the path
+      let baseDirectory = path.join(rootDirectory, inputPath);
+      let nameOrScope, nameOrFile;
+      let found = false;
+      while (baseDirectory !== path.dirname(baseDirectory)) {
+        const segment = path.basename(baseDirectory);
+        if (segment === NODE_MODULE_SEGMENT) {
+          found = true;
+          break;
+        }
+
+        nameOrFile = nameOrScope;
+        nameOrScope = segment;
+        baseDirectory = path.dirname(baseDirectory);
+      }
+
+      // Skip non-package path edge cases that are not caught in the includes check above
+      if (!found || !nameOrScope) {
+        continue;
+      }
+
+      const packageName = nameOrScope.startsWith('@')
+        ? `${nameOrScope}/${nameOrFile}`
+        : nameOrScope;
+      const packageDirectory = path.join(baseDirectory, packageName);
+
+      // Load the package's metadata to find the package's name, version, and license type
+      const packageJsonPath = path.join(packageDirectory, 'package.json');
+      let packageJson;
+      try {
+        packageJson = JSON.parse(await readFile(packageJsonPath, 'utf-8')) as {
+          name: string;
+          version: string;
+          // The object form is deprecated and should only be present in old packages
+          license?: string | { type: string };
+        };
+      } catch {
+        // Invalid package
+        continue;
+      }
+
+      // Skip already processed packages
+      const packageId = `${packageName}@${packageJson.version}`;
+      if (seenPackages.has(packageId)) {
+        continue;
+      }
+      seenPackages.add(packageId);
+
+      // Attempt to find license text inside package
+      let licenseText = '';
+      if (
+        typeof packageJson.license === 'string' &&
+        packageJson.license.toLowerCase().startsWith(CUSTOM_LICENSE_TEXT)
+      ) {
+        // Attempt to load the package's custom license
+        let customLicensePath;
+        const customLicenseFile = path.normalize(
+          packageJson.license.slice(CUSTOM_LICENSE_TEXT.length + 1).trim()
+        );
+        if (
+          customLicenseFile.startsWith('..') ||
+          path.isAbsolute(customLicenseFile)
+        ) {
+          // Path is attempting to access files outside of the package
+          // TODO: Issue warning?
+        } else {
+          customLicensePath = path.join(packageDirectory, customLicenseFile);
+          try {
+            licenseText = await readFile(customLicensePath, 'utf-8');
+            break;
+          } catch {}
+        }
+      } else {
+        // Search for a license file within the root of the package
+        for (const potentialLicense of LICENSE_FILES) {
+          const packageLicensePath = path.join(
+            packageDirectory,
+            potentialLicense
+          );
+          try {
+            licenseText = await readFile(packageLicensePath, 'utf-8');
+            break;
+          } catch {}
+        }
+      }
+
+      // Generate the package's license entry in the output content
+      extractedLicenseContent += `Package: ${packageJson.name}\n`;
+      extractedLicenseContent += `License: ${JSON.stringify(
+        packageJson.license,
+        null,
+        2
+      )}\n`;
+      extractedLicenseContent += `\n${licenseText}\n`;
+      extractedLicenseContent += EXTRACTION_FILE_SEPARATOR;
+    }
+  }
+
+  return extractedLicenseContent;
+}
+
+const PLUGIN_NAME = 'angular-extract-licenses-plugin';
+
+/**
+ * License extraction inputs collected so far, keyed by the plugin instance
+ * (one per compiler) that produced them. Sharing one map across the browser
+ * and server compilers makes each emit the union of both, since they write
+ * the licenses file to the same output location.
+ */
+export type SharedLicenseInputs = Map<
+  object,
+  Record<string, { bytesInOutput: number }>
+>;
+
+export interface ExtractLicensesPluginOptions {
+  /**
+   * Asset name for the licenses file, relative to the compilation output path.
+   */
+  outputFilename: string;
+  /**
+   * The root directory of the workspace.
+   */
+  rootDirectory: string;
+  /**
+   * Inputs shared with the other compilers of the build, when it has several.
+   */
+  sharedInputs?: SharedLicenseInputs;
+}
+
+/**
+ * Emits a licenses file for the node module packages included in the output,
+ * mirroring the `@angular/build` application builder's `extractLicenses`
+ * behavior and output. Feeds the chunk graph's module paths to the vendored
+ * extractor in place of an esbuild metafile.
+ */
+export class ExtractLicensesPlugin implements RspackPluginInstance {
+  private readonly sharedInputs: SharedLicenseInputs;
+
+  constructor(private options: ExtractLicensesPluginOptions) {
+    this.sharedInputs = options.sharedInputs ?? new Map();
+  }
+
+  apply(compiler: Compiler) {
+    compiler.hooks.thisCompilation.tap(PLUGIN_NAME, (compilation) => {
+      compilation.hooks.processAssets.tapPromise(
+        {
+          name: PLUGIN_NAME,
+          stage: compiler.rspack.Compilation.PROCESS_ASSETS_STAGE_REPORT,
+        },
+        async () => {
+          const { outputFilename, rootDirectory } = this.options;
+          const inputs: Record<string, { bytesInOutput: number }> = {};
+          for (const chunk of compilation.chunks) {
+            for (const module of compilation.chunkGraph.getChunkModulesIterable(
+              chunk
+            )) {
+              // Concatenated modules (production) wrap the actual source
+              // modules, whose paths carry the package information.
+              const innerModules = (module as Module & { modules?: Module[] })
+                .modules;
+              for (const m of innerModules ?? [module]) {
+                const resourcePath = m.nameForCondition?.();
+                if (!resourcePath) {
+                  continue;
+                }
+                inputs[path.relative(rootDirectory, resourcePath)] = {
+                  bytesInOutput: 1,
+                };
+              }
+            }
+          }
+
+          // Packages bundled into component stylesheets never appear in the
+          // chunk graph; their inputs are tracked by the Angular plugin.
+          const stylesheetInputs = (
+            compilation as Partial<NgRspackCompilation>
+          )[NG_RSPACK_SYMBOL_NAME]?.().stylesheetMetafileInputs;
+          Object.assign(inputs, stylesheetInputs);
+
+          this.sharedInputs.set(this, inputs);
+          const outputs: LicenseMetafile['outputs'] = {};
+          let outputIndex = 0;
+          for (const compilerInputs of this.sharedInputs.values()) {
+            outputs[outputIndex++] = { inputs: compilerInputs };
+          }
+
+          const licenses = await extractLicenses({ outputs }, rootDirectory);
+          compilation.emitAsset(
+            outputFilename,
+            new compiler.rspack.sources.RawSource(licenses)
+          );
+        }
+      );
+    });
+  }
+}

--- a/packages/angular-rspack/src/lib/plugins/i18n-inline-plugin.ts
+++ b/packages/angular-rspack/src/lib/plugins/i18n-inline-plugin.ts
@@ -139,7 +139,7 @@ export class I18nInlinePlugin implements RspackPluginInstance {
   // - First segment matches a locale subPath: the asset is already inside a
   //   per-locale dir (re-entrancy guard).
   // - Path contains a `..` segment: the asset is globally scoped and emits
-  //   outside the per-locale dir (e.g. `LicenseWebpackPlugin`'s
+  //   outside the per-locale dir (e.g. `ExtractLicensesPlugin`'s
   //   `../3rdpartylicenses.txt`, which lands at `outputPath.base`). This
   //   mirrors how Angular's application builder excludes
   //   `BuildOutputFileType.Root` files from i18n inlining; without the

--- a/packages/angular-rspack/src/lib/plugins/loaders/angular-partial-transform.loader.spec.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/angular-partial-transform.loader.spec.ts
@@ -7,6 +7,7 @@ import { default as angularPartialTransformLoader } from './angular-partial-tran
 describe('angular-partial-transform.loader', () => {
   const callback = vi.fn();
   const typescriptFileCache = new Map<string, string | TransformedSource>();
+  const babelFileCache = new Map<string, string>();
   const transformFile = vi.fn();
   const transformData = vi.fn();
   const makeCompilation = (angularCompilationFailed = false) =>
@@ -14,6 +15,7 @@ describe('angular-partial-transform.loader', () => {
       [NG_RSPACK_SYMBOL_NAME]: () => ({
         javascriptTransformer: { transformFile, transformData },
         typescriptFileCache,
+        babelFileCache,
         angularCompilationFailed,
       }),
     }) as unknown as NgRspackCompilation;
@@ -25,6 +27,7 @@ describe('angular-partial-transform.loader', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     typescriptFileCache.clear();
+    babelFileCache.clear();
   });
 
   it('should return content when NG_RSPACK_SYMBOL_NAME is undefined', () => {
@@ -62,13 +65,28 @@ describe('angular-partial-transform.loader', () => {
     await vi.waitFor(() =>
       expect(callback).toHaveBeenCalledWith(null, 'transformed')
     );
-    expect(typescriptFileCache.get('/path/to/file.js')).toEqual({
-      code: 'transformed',
-      map: undefined,
-    });
+    expect(babelFileCache.get('/path/to/file.js')).toBe('transformed');
+    expect(typescriptFileCache.has('/path/to/file.js')).toBe(false);
   });
 
-  it('should serve a previously transformed entry without re-transforming', () => {
+  it('should serve a previously transformed file without re-transforming', () => {
+    babelFileCache.set('/path/to/file.js', 'transformed');
+
+    angularPartialTransformLoader.call(
+      {
+        ...thisValue,
+        _compilation: makeCompilation(),
+        resourcePath: '/path/to/file.js',
+      },
+      '@angular content'
+    );
+
+    expect(callback).toHaveBeenCalledWith(null, 'transformed');
+    expect(transformFile).not.toHaveBeenCalled();
+    expect(transformData).not.toHaveBeenCalled();
+  });
+
+  it('should serve a transformed emit entry without re-transforming', () => {
     typescriptFileCache.set('/path/to/file.js', {
       code: 'transformed',
       map: undefined,

--- a/packages/angular-rspack/src/lib/plugins/loaders/angular-partial-transform.loader.spec.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/angular-partial-transform.loader.spec.ts
@@ -1,13 +1,22 @@
-import type { LoaderContext } from '@rspack/core';
-import type { TransformedSource } from '@nx/angular-rspack-compiler';
+import type { LoaderContext, RawSourceMap } from '@rspack/core';
+import type {
+  BabelFileCacheEntry,
+  TransformedSource,
+} from '@nx/angular-rspack-compiler';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { NG_RSPACK_SYMBOL_NAME, type NgRspackCompilation } from '../../models';
 import { default as angularPartialTransformLoader } from './angular-partial-transform.loader';
 
+const { readFileMock } = vi.hoisted(() => ({ readFileMock: vi.fn() }));
+vi.mock('node:fs/promises', async (importOriginal) => ({
+  ...(await importOriginal<typeof import('node:fs/promises')>()),
+  readFile: readFileMock,
+}));
+
 describe('angular-partial-transform.loader', () => {
   const callback = vi.fn();
   const typescriptFileCache = new Map<string, string | TransformedSource>();
-  const babelFileCache = new Map<string, string>();
+  const babelFileCache = new Map<string, BabelFileCacheEntry>();
   const transformFile = vi.fn();
   const transformData = vi.fn();
   const makeCompilation = (angularCompilationFailed = false) =>
@@ -23,6 +32,20 @@ describe('angular-partial-transform.loader', () => {
     async: vi.fn(() => callback),
     _compilation: {},
   } as unknown as LoaderContext<unknown>;
+  const chainMap = {
+    version: 3,
+    sources: ['/path/to/file-original.ts'],
+    sourcesContent: ['original source'],
+    names: [],
+    mappings: 'AAAA',
+  } as RawSourceMap;
+  // Built via concatenation so tools scanning this file for sourcemap
+  // comments do not mistake the literal for a real one.
+  const inlineComment = (map: object) =>
+    `//# sourceMapping` +
+    `URL=data:application/json;charset=utf-8;base64,${Buffer.from(
+      JSON.stringify(map)
+    ).toString('base64')}`;
 
   beforeEach(() => {
     vi.clearAllMocks();
@@ -33,7 +56,13 @@ describe('angular-partial-transform.loader', () => {
   it('should return content when NG_RSPACK_SYMBOL_NAME is undefined', () => {
     angularPartialTransformLoader.call(thisValue, '@angular content');
 
-    expect(callback).toHaveBeenCalledWith(null, '@angular content');
+    expect(callback).toHaveBeenCalledWith(null, '@angular content', undefined);
+  });
+
+  it('should forward the chained sourcemap when NG_RSPACK_SYMBOL_NAME is undefined', () => {
+    angularPartialTransformLoader.call(thisValue, '@angular content', chainMap);
+
+    expect(callback).toHaveBeenCalledWith(null, '@angular content', chainMap);
   });
 
   it('should pass content through when the angular compilation failed', () => {
@@ -43,10 +72,11 @@ describe('angular-partial-transform.loader', () => {
         _compilation: makeCompilation(true),
         resourcePath: '/path/to/file.js',
       },
-      '@angular content'
+      '@angular content',
+      chainMap
     );
 
-    expect(callback).toHaveBeenCalledWith(null, '@angular content');
+    expect(callback).toHaveBeenCalledWith(null, '@angular content', chainMap);
     expect(transformFile).not.toHaveBeenCalled();
   });
 
@@ -63,14 +93,21 @@ describe('angular-partial-transform.loader', () => {
     );
 
     await vi.waitFor(() =>
-      expect(callback).toHaveBeenCalledWith(null, 'transformed')
+      expect(callback).toHaveBeenCalledWith(null, 'transformed', undefined)
     );
-    expect(babelFileCache.get('/path/to/file.js')).toBe('transformed');
+    expect(babelFileCache.get('/path/to/file.js')).toEqual({
+      code: 'transformed',
+      map: undefined,
+      chainedMap: undefined,
+    });
     expect(typescriptFileCache.has('/path/to/file.js')).toBe(false);
   });
 
-  it('should serve a previously transformed file without re-transforming', () => {
-    babelFileCache.set('/path/to/file.js', 'transformed');
+  it('should extract the inline sourcemap from the transformed file', async () => {
+    const map = { version: 3, sources: ['file.js'], mappings: 'AAAA' };
+    transformFile.mockResolvedValue(
+      Buffer.from(`transformed\n${inlineComment(map)}\n`)
+    );
 
     angularPartialTransformLoader.call(
       {
@@ -81,9 +118,224 @@ describe('angular-partial-transform.loader', () => {
       '@angular content'
     );
 
-    expect(callback).toHaveBeenCalledWith(null, 'transformed');
+    await vi.waitFor(() =>
+      expect(callback).toHaveBeenCalledWith(
+        null,
+        'transformed',
+        JSON.stringify(map)
+      )
+    );
+    expect(babelFileCache.get('/path/to/file.js')).toEqual({
+      code: 'transformed',
+      map: JSON.stringify(map),
+      chainedMap: undefined,
+    });
+  });
+
+  it('should chain the loader sourcemap when the transformer passed through an external map reference', async () => {
+    // A file needing no transformation is passed through with its original
+    // comment; source-map-loader has already read the referenced map file.
+    transformFile.mockResolvedValue(
+      Buffer.from('untouched\n//# sourceMapping' + 'URL=file.js.map\n')
+    );
+
+    angularPartialTransformLoader.call(
+      {
+        ...thisValue,
+        _compilation: makeCompilation(),
+        resourcePath: '/path/to/file.js',
+      },
+      '@angular content',
+      chainMap
+    );
+
+    await vi.waitFor(() =>
+      expect(callback).toHaveBeenCalledWith(
+        null,
+        'untouched',
+        JSON.stringify(chainMap)
+      )
+    );
+    expect(babelFileCache.get('/path/to/file.js')).toEqual({
+      code: 'untouched',
+      map: JSON.stringify(chainMap),
+      chainedMap: JSON.stringify(chainMap),
+    });
+  });
+
+  it('should chain the loader sourcemap when the transformer passed through a block-form external map reference', async () => {
+    transformFile.mockResolvedValue(
+      Buffer.from('untouched\n/*# sourceMapping' + 'URL=file.js.map */\n')
+    );
+
+    angularPartialTransformLoader.call(
+      {
+        ...thisValue,
+        _compilation: makeCompilation(),
+        resourcePath: '/path/to/file.js',
+      },
+      '@angular content',
+      chainMap
+    );
+
+    await vi.waitFor(() =>
+      expect(callback).toHaveBeenCalledWith(
+        null,
+        'untouched',
+        JSON.stringify(chainMap)
+      )
+    );
+  });
+
+  it('should not forward the loader sourcemap when the transformed file carries no sourcemap comment', async () => {
+    // The transformer strips all sourcemap comments when sourcemaps are off
+    // for the file; the chained map describes pre-transform content, so
+    // forwarding it would attach a mismatched map.
+    transformFile.mockResolvedValue(Buffer.from('transformed'));
+
+    angularPartialTransformLoader.call(
+      {
+        ...thisValue,
+        _compilation: makeCompilation(),
+        resourcePath: '/path/to/file.js',
+      },
+      '@angular content',
+      chainMap
+    );
+
+    await vi.waitFor(() =>
+      expect(callback).toHaveBeenCalledWith(null, 'transformed', undefined)
+    );
+    expect(babelFileCache.get('/path/to/file.js')).toEqual({
+      code: 'transformed',
+      map: undefined,
+      chainedMap: JSON.stringify(chainMap),
+    });
+  });
+
+  it('should serve a previously transformed file without re-transforming', () => {
+    babelFileCache.set('/path/to/file.js', {
+      code: 'transformed',
+      map: '{"mappings":"AAAA"}',
+      chainedMap: undefined,
+    });
+
+    angularPartialTransformLoader.call(
+      {
+        ...thisValue,
+        _compilation: makeCompilation(),
+        resourcePath: '/path/to/file.js',
+      },
+      '@angular content'
+    );
+
+    expect(callback).toHaveBeenCalledWith(
+      null,
+      'transformed',
+      '{"mappings":"AAAA"}'
+    );
     expect(transformFile).not.toHaveBeenCalled();
     expect(transformData).not.toHaveBeenCalled();
+  });
+
+  it('should serve a cached transform when the chained sourcemap is unchanged', () => {
+    babelFileCache.set('/path/to/file.js', {
+      code: 'transformed',
+      map: JSON.stringify(chainMap),
+      chainedMap: JSON.stringify(chainMap),
+    });
+
+    angularPartialTransformLoader.call(
+      {
+        ...thisValue,
+        _compilation: makeCompilation(),
+        resourcePath: '/path/to/file.js',
+      },
+      '@angular content',
+      chainMap
+    );
+
+    expect(callback).toHaveBeenCalledWith(
+      null,
+      'transformed',
+      JSON.stringify(chainMap)
+    );
+    expect(transformFile).not.toHaveBeenCalled();
+  });
+
+  it('should bypass the transformer caches and re-transform when the chained sourcemap changed', async () => {
+    // The transformer merges a file's external map file into its output and
+    // its persistent cache is keyed on the file bytes alone, so a
+    // watch-mode change to that map (its own loader dependency) must
+    // re-transform the current file data directly.
+    const staleChainMap = {
+      ...chainMap,
+      sourcesContent: ['stale original source'],
+    } as RawSourceMap;
+    babelFileCache.set('/path/to/file.js', {
+      code: 'untouched',
+      map: JSON.stringify(staleChainMap),
+      chainedMap: JSON.stringify(staleChainMap),
+    });
+    readFileMock.mockResolvedValue('raw file data');
+    transformData.mockResolvedValue(
+      Buffer.from('untouched\n//# sourceMapping' + 'URL=file.js.map\n')
+    );
+
+    angularPartialTransformLoader.call(
+      {
+        ...thisValue,
+        _compilation: makeCompilation(),
+        resourcePath: '/path/to/file.js',
+      },
+      '@angular content',
+      chainMap
+    );
+
+    await vi.waitFor(() =>
+      expect(callback).toHaveBeenCalledWith(
+        null,
+        'untouched',
+        JSON.stringify(chainMap)
+      )
+    );
+    expect(readFileMock).toHaveBeenCalledWith('/path/to/file.js', 'utf8');
+    expect(transformData).toHaveBeenCalledWith(
+      '/path/to/file.js',
+      'raw file data',
+      false,
+      false
+    );
+    expect(transformFile).not.toHaveBeenCalled();
+    expect(babelFileCache.get('/path/to/file.js')).toEqual({
+      code: 'untouched',
+      map: JSON.stringify(chainMap),
+      chainedMap: JSON.stringify(chainMap),
+    });
+  });
+
+  it('should fail the module when reading the file for a bypassed transform rejects', async () => {
+    const error = new Error('read failed');
+    babelFileCache.set('/path/to/file.js', {
+      code: 'untouched',
+      map: undefined,
+      chainedMap: undefined,
+    });
+    readFileMock.mockRejectedValue(error);
+
+    angularPartialTransformLoader.call(
+      {
+        ...thisValue,
+        _compilation: makeCompilation(),
+        resourcePath: '/path/to/file.js',
+      },
+      '@angular content',
+      chainMap
+    );
+
+    await vi.waitFor(() => expect(callback).toHaveBeenCalledWith(error));
+    expect(transformData).not.toHaveBeenCalled();
+    expect(transformFile).not.toHaveBeenCalled();
   });
 
   it('should serve a transformed emit entry without re-transforming', () => {
@@ -146,7 +398,7 @@ describe('angular-partial-transform.loader', () => {
       '@angular content'
     );
 
-    expect(callback).toHaveBeenCalledWith(null, '@angular content');
+    expect(callback).toHaveBeenCalledWith(null, '@angular content', undefined);
     expect(transformFile).not.toHaveBeenCalled();
     expect(transformData).not.toHaveBeenCalled();
   });
@@ -187,8 +439,38 @@ describe('angular-partial-transform.loader', () => {
       'plain js content'
     );
 
-    expect(callback).toHaveBeenCalledWith(null, 'plain js content');
+    expect(callback).toHaveBeenCalledWith(null, 'plain js content', undefined);
     expect(transformFile).not.toHaveBeenCalled();
+  });
+
+  it('should forward the chained sourcemap for files it passes through', () => {
+    angularPartialTransformLoader.call(
+      {
+        ...thisValue,
+        _compilation: makeCompilation(),
+        resourcePath: '/path/to/plain.js',
+      },
+      'plain js content',
+      chainMap
+    );
+
+    expect(callback).toHaveBeenCalledWith(null, 'plain js content', chainMap);
+  });
+
+  it('should drop a chained sourcemap that rspack would reject', () => {
+    // A package can ship a parseable sourcemap with wrongly typed fields;
+    // rspack fails the module build when one is forwarded.
+    angularPartialTransformLoader.call(
+      {
+        ...thisValue,
+        _compilation: makeCompilation(),
+        resourcePath: '/path/to/plain.js',
+      },
+      'plain js content',
+      { version: 3, sources: [42], mappings: 'AAAA' } as unknown as RawSourceMap
+    );
+
+    expect(callback).toHaveBeenCalledWith(null, 'plain js content', undefined);
   });
 
   it('should fail the module when the transform rejects', async () => {

--- a/packages/angular-rspack/src/lib/plugins/loaders/angular-partial-transform.loader.spec.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/angular-partial-transform.loader.spec.ts
@@ -1,16 +1,18 @@
 import type { LoaderContext } from '@rspack/core';
+import type { TransformedSource } from '@nx/angular-rspack-compiler';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { NG_RSPACK_SYMBOL_NAME, type NgRspackCompilation } from '../../models';
 import { default as angularPartialTransformLoader } from './angular-partial-transform.loader';
 
 describe('angular-partial-transform.loader', () => {
   const callback = vi.fn();
-  const typescriptFileCache = new Map<string, string | Uint8Array>();
+  const typescriptFileCache = new Map<string, string | TransformedSource>();
   const transformFile = vi.fn();
+  const transformData = vi.fn();
   const makeCompilation = (angularCompilationFailed = false) =>
     ({
       [NG_RSPACK_SYMBOL_NAME]: () => ({
-        javascriptTransformer: { transformFile },
+        javascriptTransformer: { transformFile, transformData },
         typescriptFileCache,
         angularCompilationFailed,
       }),
@@ -60,7 +62,115 @@ describe('angular-partial-transform.loader', () => {
     await vi.waitFor(() =>
       expect(callback).toHaveBeenCalledWith(null, 'transformed')
     );
-    expect(typescriptFileCache.get('/path/to/file.js')).toBe('transformed');
+    expect(typescriptFileCache.get('/path/to/file.js')).toEqual({
+      code: 'transformed',
+      map: undefined,
+    });
+  });
+
+  it('should serve a previously transformed entry without re-transforming', () => {
+    typescriptFileCache.set('/path/to/file.js', {
+      code: 'transformed',
+      map: undefined,
+    });
+
+    angularPartialTransformLoader.call(
+      {
+        ...thisValue,
+        _compilation: makeCompilation(),
+        resourcePath: '/path/to/file.js',
+      },
+      '@angular content'
+    );
+
+    expect(callback).toHaveBeenCalledWith(null, 'transformed', undefined);
+    expect(transformFile).not.toHaveBeenCalled();
+    expect(transformData).not.toHaveBeenCalled();
+  });
+
+  it('should transform a raw emit from the cache even without @angular content', async () => {
+    typescriptFileCache.set('/path/to/util.js', 'raw emitted js');
+    transformData.mockResolvedValue(Buffer.from('transformed emit'));
+
+    angularPartialTransformLoader.call(
+      {
+        ...thisValue,
+        _compilation: makeCompilation(),
+        resourcePath: '/path/to/util.js',
+      },
+      'plain js content'
+    );
+
+    await vi.waitFor(() =>
+      expect(callback).toHaveBeenCalledWith(null, 'transformed emit')
+    );
+    expect(transformData).toHaveBeenCalledWith(
+      '/path/to/util.js',
+      'raw emitted js',
+      true,
+      false
+    );
+    expect(transformFile).not.toHaveBeenCalled();
+    expect(typescriptFileCache.get('/path/to/util.js')).toEqual({
+      code: 'transformed emit',
+      map: undefined,
+    });
+  });
+
+  it('should pass through the module federation runtime data URI', () => {
+    angularPartialTransformLoader.call(
+      {
+        ...thisValue,
+        _compilation: makeCompilation(),
+        resourcePath:
+          'data:text/javascript;charset=utf-8,__module_federation_bundler_runtime__',
+      },
+      '@angular content'
+    );
+
+    expect(callback).toHaveBeenCalledWith(null, '@angular content');
+    expect(transformFile).not.toHaveBeenCalled();
+    expect(transformData).not.toHaveBeenCalled();
+  });
+
+  it('should not overwrite a newer emit stored while transforming', async () => {
+    typescriptFileCache.set('/path/to/racy.js', 'raw emit');
+    let resolveTransform: (value: Uint8Array) => void;
+    transformData.mockReturnValue(
+      new Promise((resolve) => {
+        resolveTransform = resolve;
+      })
+    );
+
+    angularPartialTransformLoader.call(
+      {
+        ...thisValue,
+        _compilation: makeCompilation(),
+        resourcePath: '/path/to/racy.js',
+      },
+      'plain js content'
+    );
+    // A rebuild emits fresh content while the transform is in flight.
+    typescriptFileCache.set('/path/to/racy.js', 'newer raw emit');
+    resolveTransform!(Buffer.from('stale transformed'));
+    await vi.waitFor(() => expect(callback).toHaveBeenCalled());
+
+    expect(callback).toHaveBeenCalledWith(null, 'stale transformed');
+    expect(typescriptFileCache.get('/path/to/racy.js')).toBe('newer raw emit');
+  });
+
+  it('should pass through files without @angular content and no cache entry', () => {
+    angularPartialTransformLoader.call(
+      {
+        ...thisValue,
+        _compilation: makeCompilation(),
+        resourcePath: '/path/to/plain.js',
+      },
+      'plain js content'
+    );
+
+    expect(callback).toHaveBeenCalledWith(null, 'plain js content');
+    expect(transformFile).not.toHaveBeenCalled();
   });
 
   it('should fail the module when the transform rejects', async () => {

--- a/packages/angular-rspack/src/lib/plugins/loaders/angular-partial-transform.loader.spec.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/angular-partial-transform.loader.spec.ts
@@ -102,7 +102,7 @@ describe('angular-partial-transform.loader', () => {
     );
 
     await vi.waitFor(() =>
-      expect(callback).toHaveBeenCalledWith(null, 'transformed emit')
+      expect(callback).toHaveBeenCalledWith(null, 'transformed emit', undefined)
     );
     expect(transformData).toHaveBeenCalledWith(
       '/path/to/util.js',
@@ -155,7 +155,7 @@ describe('angular-partial-transform.loader', () => {
     resolveTransform!(Buffer.from('stale transformed'));
     await vi.waitFor(() => expect(callback).toHaveBeenCalled());
 
-    expect(callback).toHaveBeenCalledWith(null, 'stale transformed');
+    expect(callback).toHaveBeenCalledWith(null, 'stale transformed', undefined);
     expect(typescriptFileCache.get('/path/to/racy.js')).toBe('newer raw emit');
   });
 

--- a/packages/angular-rspack/src/lib/plugins/loaders/angular-partial-transform.loader.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/angular-partial-transform.loader.ts
@@ -14,6 +14,7 @@ export default function loader(this: LoaderContext<unknown>, content: string) {
     const {
       javascriptTransformer,
       typescriptFileCache,
+      babelFileCache,
       angularCompilationFailed,
     } = (this._compilation as NgRspackCompilation)[NG_RSPACK_SYMBOL_NAME]();
 
@@ -70,13 +71,16 @@ export default function loader(this: LoaderContext<unknown>, content: string) {
       return;
     }
 
+    const cachedTransform = babelFileCache.get(normalizedRequest);
+    if (cachedTransform !== undefined) {
+      callback(null, cachedTransform);
+      return;
+    }
+
     javascriptTransformer.transformFile(request, false, false).then(
       (contents) => {
         const transformedCode = Buffer.from(contents).toString('utf8');
-        typescriptFileCache.set(normalizedRequest, {
-          code: transformedCode,
-          map: undefined,
-        });
+        babelFileCache.set(normalizedRequest, transformedCode);
         callback(null, transformedCode);
       },
       (error) => {

--- a/packages/angular-rspack/src/lib/plugins/loaders/angular-partial-transform.loader.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/angular-partial-transform.loader.ts
@@ -1,6 +1,7 @@
 import { LoaderContext } from '@rspack/core';
 import { toTypeScriptFileCacheKey } from '@nx/angular-rspack-compiler';
 import { NG_RSPACK_SYMBOL_NAME, NgRspackCompilation } from '../../models';
+import { extractInlineSourceMap } from './inline-source-map';
 
 export default function loader(this: LoaderContext<unknown>, content: string) {
   const callback = this.async();
@@ -47,15 +48,13 @@ export default function loader(this: LoaderContext<unknown>, content: string) {
         .then(
           (transformed: Uint8Array) => {
             const text = Buffer.from(transformed).toString('utf8');
+            const [code, map] = extractInlineSourceMap(text);
             // A newer emit may have replaced the entry while transforming;
             // only store the result for the emit it was produced from.
             if (typescriptFileCache.get(normalizedRequest) === cached) {
-              typescriptFileCache.set(normalizedRequest, {
-                code: text,
-                map: undefined,
-              });
+              typescriptFileCache.set(normalizedRequest, { code, map });
             }
-            callback(null, text);
+            callback(null, code, map);
           },
           (error) => {
             // Fail the module instead of leaving the loader callback pending,

--- a/packages/angular-rspack/src/lib/plugins/loaders/angular-partial-transform.loader.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/angular-partial-transform.loader.ts
@@ -1,4 +1,5 @@
 import { LoaderContext } from '@rspack/core';
+import { toTypeScriptFileCacheKey } from '@nx/angular-rspack-compiler';
 import { NG_RSPACK_SYMBOL_NAME, NgRspackCompilation } from '../../models';
 
 export default function loader(this: LoaderContext<unknown>, content: string) {
@@ -30,25 +31,53 @@ export default function loader(this: LoaderContext<unknown>, content: string) {
       callback(null, content);
       return;
     }
-    if (!content.includes('@angular')) {
-      callback(null, content);
+
+    const normalizedRequest = toTypeScriptFileCacheKey(request);
+    const cached = typescriptFileCache.get(normalizedRequest);
+    if (cached !== undefined) {
+      if (typeof cached !== 'string') {
+        callback(null, cached.code, cached.map);
+        return;
+      }
+
+      // A string entry is raw JavaScript emitted by the Angular compilation
+      // (allowJs); it always needs the JavaScript transformations applied.
+      javascriptTransformer
+        .transformData(normalizedRequest, cached, true, false)
+        .then(
+          (transformed: Uint8Array) => {
+            const text = Buffer.from(transformed).toString('utf8');
+            // A newer emit may have replaced the entry while transforming;
+            // only store the result for the emit it was produced from.
+            if (typescriptFileCache.get(normalizedRequest) === cached) {
+              typescriptFileCache.set(normalizedRequest, {
+                code: text,
+                map: undefined,
+              });
+            }
+            callback(null, text);
+          },
+          (error) => {
+            // Fail the module instead of leaving the loader callback pending,
+            // which would hang the build.
+            callback(error instanceof Error ? error : new Error(String(error)));
+          }
+        );
       return;
     }
 
-    const existingTransform = typescriptFileCache.get(request);
-    if (existingTransform) {
-      const existingContents =
-        typeof existingTransform === 'string'
-          ? existingTransform
-          : Buffer.from(existingTransform).toString('utf8');
-      callback(null, existingContents);
+    if (!content.includes('@angular')) {
+      callback(null, content);
       return;
     }
 
     javascriptTransformer.transformFile(request, false, false).then(
       (contents) => {
         const transformedCode = Buffer.from(contents).toString('utf8');
-        typescriptFileCache.set(request, transformedCode);
+        typescriptFileCache.set(normalizedRequest, {
+          code: transformedCode,
+          map: undefined,
+        });
         callback(null, transformedCode);
       },
       (error) => {

--- a/packages/angular-rspack/src/lib/plugins/loaders/angular-partial-transform.loader.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/angular-partial-transform.loader.ts
@@ -1,15 +1,23 @@
-import { LoaderContext } from '@rspack/core';
+import { readFile } from 'node:fs/promises';
+import { LoaderContext, RawSourceMap } from '@rspack/core';
 import { toTypeScriptFileCacheKey } from '@nx/angular-rspack-compiler';
 import { NG_RSPACK_SYMBOL_NAME, NgRspackCompilation } from '../../models';
-import { extractInlineSourceMap } from './inline-source-map';
+import {
+  extractInlineSourceMap,
+  isForwardableSourceMap,
+} from './inline-source-map';
 
-export default function loader(this: LoaderContext<unknown>, content: string) {
+export default function loader(
+  this: LoaderContext<unknown>,
+  content: string,
+  inputMap?: string | RawSourceMap
+) {
   const callback = this.async();
   if (
     (this._compilation as NgRspackCompilation)[NG_RSPACK_SYMBOL_NAME] ===
     undefined
   ) {
-    callback(null, content);
+    callback(null, content, inputMap);
   } else {
     const {
       javascriptTransformer,
@@ -18,10 +26,17 @@ export default function loader(this: LoaderContext<unknown>, content: string) {
       angularCompilationFailed,
     } = (this._compilation as NgRspackCompilation)[NG_RSPACK_SYMBOL_NAME]();
 
+    // The sourcemap chained by earlier loaders: source-map-loader runs first
+    // and consumes the file's own sourceMappingURL comment (inline or an
+    // external .map file) subject to the vendor sourcemap policy. Rspack
+    // fails the module build on maps it cannot deserialize, so drop anything
+    // unusable instead of forwarding it.
+    const chainMap = isForwardableSourceMap(inputMap) ? inputMap : undefined;
+
     if (angularCompilationFailed) {
       // The build is already failing with the Angular compilation error,
       // so skip transforming and pass the original content through.
-      callback(null, content);
+      callback(null, content, chainMap);
       return;
     }
 
@@ -30,7 +45,7 @@ export default function loader(this: LoaderContext<unknown>, content: string) {
       request.startsWith('data:text/javascript') &&
       request.includes('__module_federation_bundler_runtime__')
     ) {
-      callback(null, content);
+      callback(null, content, chainMap);
       return;
     }
 
@@ -49,7 +64,7 @@ export default function loader(this: LoaderContext<unknown>, content: string) {
         .then(
           (transformed: Uint8Array) => {
             const text = Buffer.from(transformed).toString('utf8');
-            const [code, map] = extractInlineSourceMap(text);
+            const { code, map } = extractInlineSourceMap(text);
             // A newer emit may have replaced the entry while transforming;
             // only store the result for the emit it was produced from.
             if (typescriptFileCache.get(normalizedRequest) === cached) {
@@ -67,21 +82,61 @@ export default function loader(this: LoaderContext<unknown>, content: string) {
     }
 
     if (!content.includes('@angular')) {
-      callback(null, content);
+      callback(null, content, chainMap);
       return;
     }
 
+    // The chained map takes part in cache validity: the transformer reads
+    // the file's external map file itself and merges it into its output, so
+    // a cached transform is stale once that map changes, even though the
+    // file itself did not.
+    const serializedChainMap = chainMap ? JSON.stringify(chainMap) : undefined;
     const cachedTransform = babelFileCache.get(normalizedRequest);
-    if (cachedTransform !== undefined) {
-      callback(null, cachedTransform);
+    if (
+      cachedTransform !== undefined &&
+      cachedTransform.chainedMap === serializedChainMap
+    ) {
+      callback(null, cachedTransform.code, cachedTransform.map);
       return;
     }
 
-    javascriptTransformer.transformFile(request, false, false).then(
+    // A mismatched entry means the chained map changed since the entry was
+    // produced. The transformer's persistent cache is keyed on the file
+    // bytes only, so `transformFile` would return the same stale output;
+    // hand it the current file data instead, which always runs the worker
+    // and re-reads the changed map file. A cold process has no entry to
+    // compare against, so a stale persistent entry can still be served
+    // there, matching the esbuild application builder's behavior.
+    const transformed =
+      cachedTransform !== undefined
+        ? readFile(request, 'utf8').then((data) =>
+            javascriptTransformer.transformData(request, data, false, false)
+          )
+        : javascriptTransformer.transformFile(request, false, false);
+
+    transformed.then(
       (contents) => {
-        const transformedCode = Buffer.from(contents).toString('utf8');
-        babelFileCache.set(normalizedRequest, transformedCode);
-        callback(null, transformedCode);
+        const text = Buffer.from(contents).toString('utf8');
+        const {
+          code,
+          map: extractedMap,
+          strippedComment,
+        } = extractInlineSourceMap(text);
+        // The transformer's output carries a trailing sourcemap comment only
+        // when sourcemaps apply to this file: its own inline map for
+        // transformed output, the file's original comment when passed
+        // through untouched. A stripped comment without a usable inline map
+        // references an external map file, which source-map-loader has
+        // already read, so chain its map. No comment at all means sourcemaps
+        // are off for this file and nothing must be forwarded.
+        const map =
+          extractedMap ?? (strippedComment ? serializedChainMap : undefined);
+        babelFileCache.set(normalizedRequest, {
+          code,
+          map,
+          chainedMap: serializedChainMap,
+        });
+        callback(null, code, map);
       },
       (error) => {
         // Fail the module instead of leaving the loader callback pending,

--- a/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.spec.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.spec.ts
@@ -83,6 +83,90 @@ describe('angular-transform.loader', () => {
     );
   });
 
+  it('should register compiler-tracked resource dependencies without invoking the resolvers', () => {
+    const styleUrlsResolver = { resolve: vi.fn() };
+    const templateUrlsResolver = { resolve: vi.fn() };
+
+    angularTransformLoader.call(
+      {
+        ...thisValue,
+        _compilation: {
+          [NG_RSPACK_SYMBOL_NAME]: () => ({
+            typescriptFileCache,
+            javascriptTransformer,
+            useTypeScriptTranspilation: true,
+            resourceDependencies: new Map([
+              [
+                '/home/projects/analog/src/app/app.component.ts',
+                [
+                  '/home/projects/analog/src/app/app.component.html',
+                  '/home/projects/analog/src/app/app.component.css',
+                ],
+              ],
+            ]),
+          }),
+        } as unknown as NgRspackCompilation,
+        resourcePath: '/home/projects/analog/src/app/app.component.ts',
+        addDependency,
+      },
+      '@Component()',
+      { templateUrlsResolver, styleUrlsResolver } as any
+    );
+
+    expect(addDependency).toHaveBeenCalledTimes(2);
+    expect(addDependency).toHaveBeenNthCalledWith(
+      1,
+      '/home/projects/analog/src/app/app.component.html'
+    );
+    expect(addDependency).toHaveBeenNthCalledWith(
+      2,
+      '/home/projects/analog/src/app/app.component.css'
+    );
+    expect(templateUrlsResolver.resolve).not.toHaveBeenCalled();
+    expect(styleUrlsResolver.resolve).not.toHaveBeenCalled();
+  });
+
+  it('should fall back to the URL resolvers for files the compiler did not track', () => {
+    angularTransformLoader.call(
+      {
+        ...thisValue,
+        _compilation: {
+          [NG_RSPACK_SYMBOL_NAME]: () => ({
+            typescriptFileCache,
+            javascriptTransformer,
+            useTypeScriptTranspilation: true,
+            resourceDependencies: new Map([
+              ['/some/other/file.ts', ['/some/other/file.html']],
+            ]),
+          }),
+        } as unknown as NgRspackCompilation,
+        resourcePath: '/home/projects/analog/src/app/app.component.ts',
+        addDependency,
+      },
+      '@Component()',
+      {
+        templateUrlsResolver: new TemplateUrlsResolverMock(
+          () =>
+            './app.component.html|/home/projects/analog/src/app/app.component.html'
+        ),
+        styleUrlsResolver: new StyleUrlsResolverMock(
+          () =>
+            './app.component.css|/home/projects/analog/src/app/app.component.css'
+        ),
+      } as any
+    );
+
+    expect(addDependency).toHaveBeenCalledTimes(2);
+    expect(addDependency).toHaveBeenNthCalledWith(
+      1,
+      '/home/projects/analog/src/app/app.component.html'
+    );
+    expect(addDependency).toHaveBeenNthCalledWith(
+      2,
+      '/home/projects/analog/src/app/app.component.css'
+    );
+  });
+
   it('should emit an empty module when the angular compilation failed', () => {
     angularTransformLoader.call(
       {

--- a/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.spec.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.spec.ts
@@ -1,7 +1,8 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { default as angularTransformLoader } from './angular-transform.loader';
-import { NG_RSPACK_SYMBOL_NAME, type NgRspackCompilation } from '../../models';
 import type { LoaderContext } from '@rspack/core';
+import type { TransformedSource } from '@nx/angular-rspack-compiler';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NG_RSPACK_SYMBOL_NAME, type NgRspackCompilation } from '../../models';
+import { default as angularTransformLoader } from './angular-transform.loader';
 
 class StyleUrlsResolverMock {
   constructor(private cb: (content: string) => string) {}
@@ -22,10 +23,14 @@ class TemplateUrlsResolverMock {
 describe('angular-transform.loader', () => {
   const callback = vi.fn();
   const addDependency = vi.fn();
-  const typescriptFileCache = new Map<string, string | Buffer>();
+  const typescriptFileCache = new Map<string, string | TransformedSource>();
+  const javascriptTransformer = {
+    transformData: vi.fn(),
+  };
   const _compilation = {
     [NG_RSPACK_SYMBOL_NAME]: () => ({
       typescriptFileCache,
+      javascriptTransformer,
     }),
   } as unknown as NgRspackCompilation;
   const thisValue = {
@@ -35,6 +40,7 @@ describe('angular-transform.loader', () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    typescriptFileCache.clear();
   });
 
   it('should return content when NG_RSPACK_SYMBOL_NAME is undefined', () => {
@@ -105,11 +111,11 @@ describe('angular-transform.loader', () => {
     expect(callback).toHaveBeenCalledWith(null, 'content');
   });
 
-  it('should return content when typescriptFileCache does contain string', () => {
-    typescriptFileCache.set(
-      '/home/projects/analog/src/app/app.component.ts',
-      'cached content'
-    );
+  it('should serve a transformed entry without re-transforming', () => {
+    typescriptFileCache.set('/home/projects/analog/src/app/app.component.ts', {
+      code: 'transformed content',
+      map: undefined,
+    });
 
     angularTransformLoader.call(
       {
@@ -120,24 +126,85 @@ describe('angular-transform.loader', () => {
       '@Component()'
     );
 
-    expect(callback).toHaveBeenCalledWith(null, 'cached content');
+    expect(callback).toHaveBeenCalledWith(
+      null,
+      'transformed content',
+      undefined
+    );
+    expect(javascriptTransformer.transformData).not.toHaveBeenCalled();
   });
 
-  it('should return content when typescriptFileCache does contain Buffer', () => {
-    typescriptFileCache.set(
-      '/home/projects/analog/src/app/app.component.ts',
-      Buffer.from('cached content')
+  it('should transform the raw emit on demand and cache the result', async () => {
+    typescriptFileCache.set('/path/to/lazy.ts', 'raw emit');
+    javascriptTransformer.transformData.mockResolvedValue(
+      Buffer.from('transformed content')
     );
 
     angularTransformLoader.call(
       {
         ...thisValue,
         _compilation,
-        resourcePath: '/home/projects/analog/src/app/app.component.ts',
+        resourcePath: '/path/to/lazy.ts',
       },
-      '@Component()'
+      'content'
+    );
+    await vi.waitFor(() => expect(callback).toHaveBeenCalled());
+
+    expect(javascriptTransformer.transformData).toHaveBeenCalledWith(
+      '/path/to/lazy.ts',
+      'raw emit',
+      true,
+      false
+    );
+    expect(callback).toHaveBeenCalledWith(null, 'transformed content');
+    expect(typescriptFileCache.get('/path/to/lazy.ts')).toEqual({
+      code: 'transformed content',
+      map: undefined,
+    });
+  });
+
+  it('should not overwrite a newer emit stored while transforming', async () => {
+    typescriptFileCache.set('/path/to/racy.ts', 'raw emit');
+    let resolveTransform: (value: Uint8Array) => void;
+    javascriptTransformer.transformData.mockReturnValue(
+      new Promise((resolve) => {
+        resolveTransform = resolve;
+      })
     );
 
-    expect(callback).toHaveBeenCalledWith(null, Buffer.from('cached content'));
+    angularTransformLoader.call(
+      {
+        ...thisValue,
+        _compilation,
+        resourcePath: '/path/to/racy.ts',
+      },
+      'content'
+    );
+    // A rebuild emits fresh content while the transform is in flight.
+    typescriptFileCache.set('/path/to/racy.ts', 'newer raw emit');
+    resolveTransform!(Buffer.from('stale transformed'));
+    await vi.waitFor(() => expect(callback).toHaveBeenCalled());
+
+    expect(callback).toHaveBeenCalledWith(null, 'stale transformed');
+    expect(typescriptFileCache.get('/path/to/racy.ts')).toBe('newer raw emit');
+  });
+
+  it('should forward transformation errors to the loader callback', async () => {
+    typescriptFileCache.set('/path/to/broken.ts', 'raw emit');
+    const error = new Error('transform failed');
+    javascriptTransformer.transformData.mockRejectedValue(error);
+
+    angularTransformLoader.call(
+      {
+        ...thisValue,
+        _compilation,
+        resourcePath: '/path/to/broken.ts',
+      },
+      'content'
+    );
+    await vi.waitFor(() => expect(callback).toHaveBeenCalled());
+
+    expect(callback).toHaveBeenCalledWith(error);
+    expect(typescriptFileCache.get('/path/to/broken.ts')).toBe('raw emit');
   });
 });

--- a/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.spec.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.spec.ts
@@ -27,12 +27,15 @@ describe('angular-transform.loader', () => {
   const javascriptTransformer = {
     transformData: vi.fn(),
   };
-  const _compilation = {
-    [NG_RSPACK_SYMBOL_NAME]: () => ({
-      typescriptFileCache,
-      javascriptTransformer,
-    }),
-  } as unknown as NgRspackCompilation;
+  const makeCompilation = (useTypeScriptTranspilation = true) =>
+    ({
+      [NG_RSPACK_SYMBOL_NAME]: () => ({
+        typescriptFileCache,
+        javascriptTransformer,
+        useTypeScriptTranspilation,
+      }),
+    }) as unknown as NgRspackCompilation;
+  const _compilation = makeCompilation();
   const thisValue = {
     async: vi.fn(() => callback),
     _compilation: {},
@@ -111,10 +114,10 @@ describe('angular-transform.loader', () => {
     expect(callback).toHaveBeenCalledWith(null, 'content');
   });
 
-  it('should serve a transformed entry without re-transforming', () => {
+  it('should serve a transformed entry with its sourcemap', () => {
     typescriptFileCache.set('/home/projects/analog/src/app/app.component.ts', {
       code: 'transformed content',
-      map: undefined,
+      map: '{"version":3}',
     });
 
     angularTransformLoader.call(
@@ -129,15 +132,23 @@ describe('angular-transform.loader', () => {
     expect(callback).toHaveBeenCalledWith(
       null,
       'transformed content',
-      undefined
+      '{"version":3}'
     );
     expect(javascriptTransformer.transformData).not.toHaveBeenCalled();
   });
 
-  it('should transform the raw emit on demand and cache the result', async () => {
+  it('should transform the raw emit on demand and cache the result with its sourcemap extracted', async () => {
+    const map = JSON.stringify({
+      version: 3,
+      sources: ['/path/to/lazy.ts'],
+      mappings: '',
+    });
+    const inlineMap = Buffer.from(map).toString('base64');
     typescriptFileCache.set('/path/to/lazy.ts', 'raw emit');
     javascriptTransformer.transformData.mockResolvedValue(
-      Buffer.from('transformed content')
+      Buffer.from(
+        `const code = 1;\n//# sourceMappingURL=data:application/json;base64,${inlineMap}`
+      )
     );
 
     angularTransformLoader.call(
@@ -156,11 +167,31 @@ describe('angular-transform.loader', () => {
       true,
       false
     );
-    expect(callback).toHaveBeenCalledWith(null, 'transformed content');
+    expect(callback).toHaveBeenCalledWith(null, 'const code = 1;', map);
     expect(typescriptFileCache.get('/path/to/lazy.ts')).toEqual({
-      code: 'transformed content',
-      map: undefined,
+      code: 'const code = 1;',
+      map,
     });
+  });
+
+  it('should pass the raw emit through untouched when TypeScript transpilation is off', () => {
+    typescriptFileCache.set('/path/to/fast.ts', 'angular-transformed ts');
+
+    angularTransformLoader.call(
+      {
+        ...thisValue,
+        _compilation: makeCompilation(false),
+        resourcePath: '/path/to/fast.ts',
+      },
+      'content'
+    );
+
+    expect(callback).toHaveBeenCalledWith(null, 'angular-transformed ts');
+    expect(javascriptTransformer.transformData).not.toHaveBeenCalled();
+    // The raw entry stays so later loader calls serve it again.
+    expect(typescriptFileCache.get('/path/to/fast.ts')).toBe(
+      'angular-transformed ts'
+    );
   });
 
   it('should not overwrite a newer emit stored while transforming', async () => {
@@ -185,7 +216,7 @@ describe('angular-transform.loader', () => {
     resolveTransform!(Buffer.from('stale transformed'));
     await vi.waitFor(() => expect(callback).toHaveBeenCalled());
 
-    expect(callback).toHaveBeenCalledWith(null, 'stale transformed');
+    expect(callback).toHaveBeenCalledWith(null, 'stale transformed', undefined);
     expect(typescriptFileCache.get('/path/to/racy.ts')).toBe('newer raw emit');
   });
 

--- a/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.ts
@@ -89,7 +89,7 @@ export default function loader(
         .transformData(normalizedRequest, cached, true, false)
         .then((transformed: Uint8Array) => {
           const text = Buffer.from(transformed).toString();
-          const [code, map] = extractInlineSourceMap(text);
+          const { code, map } = extractInlineSourceMap(text);
           // A newer emit may have replaced the entry while transforming;
           // only store the result for the emit it was produced from.
           if (typescriptFileCache.get(normalizedRequest) === cached) {

--- a/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.ts
@@ -34,6 +34,7 @@ export default function loader(
       javascriptTransformer,
       useTypeScriptTranspilation,
       angularCompilationFailed,
+      resourceDependencies,
     } = (this._compilation as NgRspackCompilation)[NG_RSPACK_SYMBOL_NAME]();
 
     if (angularCompilationFailed) {
@@ -46,17 +47,27 @@ export default function loader(
 
     const normalizedRequest = toTypeScriptFileCacheKey(this.resourcePath);
 
-    const templateUrls = templateUrlsResolver.resolve(
-      content,
-      normalizedRequest
-    );
-    const styleUrls = styleUrlsResolver.resolve(content, normalizedRequest);
-    for (const urlSet of [...templateUrls, ...styleUrls]) {
-      // `urlSet` is a string where a relative path is joined with an
-      // absolute path using the `|` symbol.
-      // For example: `./app.component.html|/home/projects/analog/src/app/app.component.html`.
-      const [, absoluteFileUrl] = urlSet.split('|');
-      this.addDependency(absoluteFileUrl);
+    const resourceDeps = resourceDependencies?.get(normalizedRequest);
+    if (resourceDeps !== undefined) {
+      // The compiler tracked this file's template and stylesheet
+      // dependencies; registering them keeps the module rebuilding when a
+      // resource changes, at no parsing cost.
+      for (const dependency of resourceDeps) {
+        this.addDependency(dependency);
+      }
+    } else {
+      const templateUrls = templateUrlsResolver.resolve(
+        content,
+        normalizedRequest
+      );
+      const styleUrls = styleUrlsResolver.resolve(content, normalizedRequest);
+      for (const urlSet of [...templateUrls, ...styleUrls]) {
+        // `urlSet` is a string where a relative path is joined with an
+        // absolute path using the `|` symbol.
+        // For example: `./app.component.html|/home/projects/analog/src/app/app.component.html`.
+        const [, absoluteFileUrl] = urlSet.split('|');
+        this.addDependency(absoluteFileUrl);
+      }
     }
 
     const cached = typescriptFileCache.get(normalizedRequest);

--- a/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.ts
@@ -1,9 +1,9 @@
 import type { LoaderContext } from '@rspack/core';
-import { normalize } from 'path';
 import { NG_RSPACK_SYMBOL_NAME, NgRspackCompilation } from '../../models';
 import {
   StyleUrlsResolver,
   TemplateUrlsResolver,
+  toTypeScriptFileCacheKey,
 } from '@nx/angular-rspack-compiler';
 
 const _styleUrlsResolver = new StyleUrlsResolver();
@@ -28,9 +28,11 @@ export default function loader(
   ) {
     callback(null, content);
   } else {
-    const { typescriptFileCache, angularCompilationFailed } = (
-      this._compilation as NgRspackCompilation
-    )[NG_RSPACK_SYMBOL_NAME]();
+    const {
+      typescriptFileCache,
+      javascriptTransformer,
+      angularCompilationFailed,
+    } = (this._compilation as NgRspackCompilation)[NG_RSPACK_SYMBOL_NAME]();
 
     if (angularCompilationFailed) {
       // The Angular compilation failure is already reported as a compilation
@@ -40,8 +42,7 @@ export default function loader(
       return;
     }
 
-    const request = this.resourcePath.replace(/^[A-Z]:/, '');
-    const normalizedRequest = normalize(request);
+    const normalizedRequest = toTypeScriptFileCacheKey(this.resourcePath);
 
     const templateUrls = templateUrlsResolver.resolve(
       content,
@@ -56,13 +57,36 @@ export default function loader(
       this.addDependency(absoluteFileUrl);
     }
 
-    const contents = typescriptFileCache.get(normalizedRequest);
-    if (contents === undefined) {
-      callback(null, content);
-    } else if (typeof contents === 'string') {
-      callback(null, contents);
-    } else {
-      callback(null, Buffer.from(contents));
+    const cached = typescriptFileCache.get(normalizedRequest);
+    if (cached !== undefined) {
+      if (typeof cached !== 'string') {
+        callback(null, cached.code, cached.map);
+        return;
+      }
+
+      // A string entry is a raw emit from the Angular compilation: run the
+      // JavaScript transformations on demand and replace the entry with the
+      // result, matching the on-demand transformation in `@angular/build`'s
+      // esbuild compiler plugin `onLoad` hook. Subsequent loader calls hit
+      // the fast path above until a fresh emit replaces the entry again.
+      javascriptTransformer
+        .transformData(normalizedRequest, cached, true, false)
+        .then((transformed: Uint8Array) => {
+          const text = Buffer.from(transformed).toString();
+          // A newer emit may have replaced the entry while transforming;
+          // only store the result for the emit it was produced from.
+          if (typescriptFileCache.get(normalizedRequest) === cached) {
+            typescriptFileCache.set(normalizedRequest, {
+              code: text,
+              map: undefined,
+            });
+          }
+          callback(null, text);
+        })
+        .catch((err: Error) => callback(err));
+      return;
     }
+
+    callback(null, content);
   }
 }

--- a/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.ts
@@ -5,6 +5,7 @@ import {
   TemplateUrlsResolver,
   toTypeScriptFileCacheKey,
 } from '@nx/angular-rspack-compiler';
+import { extractInlineSourceMap } from './inline-source-map';
 
 const _styleUrlsResolver = new StyleUrlsResolver();
 const _templateUrlsResolver = new TemplateUrlsResolver();
@@ -31,6 +32,7 @@ export default function loader(
     const {
       typescriptFileCache,
       javascriptTransformer,
+      useTypeScriptTranspilation,
       angularCompilationFailed,
     } = (this._compilation as NgRspackCompilation)[NG_RSPACK_SYMBOL_NAME]();
 
@@ -64,24 +66,25 @@ export default function loader(
         return;
       }
 
-      // A string entry is a raw emit from the Angular compilation: run the
-      // JavaScript transformations on demand and replace the entry with the
-      // result, matching the on-demand transformation in `@angular/build`'s
-      // esbuild compiler plugin `onLoad` hook. Subsequent loader calls hit
-      // the fast path above until a fresh emit replaces the entry again.
+      // A string entry is a raw emit from the Angular compilation. Without
+      // TypeScript transpilation it is Angular-transformed TypeScript that
+      // the bundler transpiles as-is, matching `@angular/build`.
+      if (!useTypeScriptTranspilation) {
+        callback(null, cached);
+        return;
+      }
+
       javascriptTransformer
         .transformData(normalizedRequest, cached, true, false)
         .then((transformed: Uint8Array) => {
           const text = Buffer.from(transformed).toString();
+          const [code, map] = extractInlineSourceMap(text);
           // A newer emit may have replaced the entry while transforming;
           // only store the result for the emit it was produced from.
           if (typescriptFileCache.get(normalizedRequest) === cached) {
-            typescriptFileCache.set(normalizedRequest, {
-              code: text,
-              map: undefined,
-            });
+            typescriptFileCache.set(normalizedRequest, { code, map });
           }
-          callback(null, text);
+          callback(null, code, map);
         })
         .catch((err: Error) => callback(err));
       return;

--- a/packages/angular-rspack/src/lib/plugins/loaders/inline-source-map.spec.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/inline-source-map.spec.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { extractInlineSourceMap } from './inline-source-map';
+
+describe('extractInlineSourceMap', () => {
+  // Assembled at runtime so tools scanning this file for sourcemap comments
+  // do not mistake the literal for a real one.
+  const inlineComment = (map: string) =>
+    '//# sourceMapping' +
+    `URL=data:application/json;base64,${Buffer.from(map).toString('base64')}`;
+
+  it('should split a valid inline sourcemap off the code', () => {
+    const map = JSON.stringify({ version: 3, sources: ['foo.ts'] });
+    const code = `const foo = 1;\n${inlineComment(map)}`;
+
+    expect(extractInlineSourceMap(code)).toEqual(['const foo = 1;', map]);
+  });
+
+  it('should return the code unchanged when there is no inline sourcemap', () => {
+    const code = 'const foo = 1;';
+
+    expect(extractInlineSourceMap(code)).toEqual([code, undefined]);
+  });
+
+  it('should strip the comment and return no map when the sourcemap is malformed', () => {
+    const code = `const foo = 1;\n${inlineComment('{not json')}`;
+
+    expect(extractInlineSourceMap(code)).toEqual(['const foo = 1;', undefined]);
+  });
+});

--- a/packages/angular-rspack/src/lib/plugins/loaders/inline-source-map.spec.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/inline-source-map.spec.ts
@@ -1,29 +1,237 @@
 import { describe, expect, it } from 'vitest';
-import { extractInlineSourceMap } from './inline-source-map';
+import {
+  extractInlineSourceMap,
+  isForwardableSourceMap,
+} from './inline-source-map';
 
 describe('extractInlineSourceMap', () => {
   // Assembled at runtime so tools scanning this file for sourcemap comments
   // do not mistake the literal for a real one.
-  const inlineComment = (map: string) =>
+  const inlineComment = (map: string, charset = '') =>
     '//# sourceMapping' +
-    `URL=data:application/json;base64,${Buffer.from(map).toString('base64')}`;
+    `URL=data:application/json;${charset}base64,${Buffer.from(map).toString(
+      'base64'
+    )}`;
 
   it('should split a valid inline sourcemap off the code', () => {
-    const map = JSON.stringify({ version: 3, sources: ['foo.ts'] });
+    const map = JSON.stringify({
+      version: 3,
+      sources: ['foo.ts'],
+      mappings: 'AAAA',
+    });
     const code = `const foo = 1;\n${inlineComment(map)}`;
 
-    expect(extractInlineSourceMap(code)).toEqual(['const foo = 1;', map]);
+    expect(extractInlineSourceMap(code)).toEqual({
+      code: 'const foo = 1;',
+      map,
+      strippedComment: true,
+    });
+  });
+
+  it('should split an inline sourcemap with a charset segment', () => {
+    const map = JSON.stringify({ mappings: 'AAAA' });
+    const code = `const foo = 1;\n${inlineComment(map, 'charset=utf-8;')}`;
+
+    expect(extractInlineSourceMap(code)).toEqual({
+      code: 'const foo = 1;',
+      map,
+      strippedComment: true,
+    });
+  });
+
+  it('should not leave a stray carriage return when the code uses CRLF', () => {
+    const map = JSON.stringify({ mappings: 'AAAA' });
+    const code = `const foo = 1;\r\n${inlineComment(map)}\r\n`;
+
+    expect(extractInlineSourceMap(code)).toEqual({
+      code: 'const foo = 1;',
+      map,
+      strippedComment: true,
+    });
   });
 
   it('should return the code unchanged when there is no inline sourcemap', () => {
     const code = 'const foo = 1;';
 
-    expect(extractInlineSourceMap(code)).toEqual([code, undefined]);
+    expect(extractInlineSourceMap(code)).toEqual({
+      code,
+      map: undefined,
+      strippedComment: false,
+    });
   });
 
   it('should strip the comment and return no map when the sourcemap is malformed', () => {
     const code = `const foo = 1;\n${inlineComment('{not json')}`;
 
-    expect(extractInlineSourceMap(code)).toEqual(['const foo = 1;', undefined]);
+    expect(extractInlineSourceMap(code)).toEqual({
+      code: 'const foo = 1;',
+      map: undefined,
+      strippedComment: true,
+    });
+  });
+
+  it('should strip the comment and return no map when the map would be rejected by rspack', () => {
+    const code = `const foo = 1;\n${inlineComment(
+      JSON.stringify({ version: 3, sources: [42], mappings: 'AAAA' })
+    )}`;
+
+    expect(extractInlineSourceMap(code)).toEqual({
+      code: 'const foo = 1;',
+      map: undefined,
+      strippedComment: true,
+    });
+  });
+
+  it('should strip a comment referencing an external map file and return no map', () => {
+    const code = `const foo = 1;\n//# sourceMapping` + `URL=foo.js.map\n`;
+
+    expect(extractInlineSourceMap(code)).toEqual({
+      code: 'const foo = 1;',
+      map: undefined,
+      strippedComment: true,
+    });
+  });
+
+  it('should split an inline sourcemap in a block comment off the code', () => {
+    const map = JSON.stringify({ mappings: 'AAAA' });
+    const code =
+      `const foo = 1;\n/*# sourceMapping` +
+      `URL=data:application/json;base64,${Buffer.from(map).toString(
+        'base64'
+      )} */\n`;
+
+    expect(extractInlineSourceMap(code)).toEqual({
+      code: 'const foo = 1;',
+      map,
+      strippedComment: true,
+    });
+  });
+
+  it('should strip a block comment referencing an external map file', () => {
+    const code = `const foo = 1;\n/*# sourceMapping` + `URL=foo.js.map */\n`;
+
+    expect(extractInlineSourceMap(code)).toEqual({
+      code: 'const foo = 1;',
+      map: undefined,
+      strippedComment: true,
+    });
+  });
+
+  it('should split an inline sourcemap in a legacy //@ comment off the code', () => {
+    const map = JSON.stringify({ mappings: 'AAAA' });
+    const code =
+      `const foo = 1;\n//@ sourceMapping` +
+      `URL=data:application/json;base64,${Buffer.from(map).toString(
+        'base64'
+      )}\n`;
+
+    expect(extractInlineSourceMap(code)).toEqual({
+      code: 'const foo = 1;',
+      map,
+      strippedComment: true,
+    });
+  });
+
+  it('should strip a legacy /*@ block comment referencing an external map file', () => {
+    const code = `const foo = 1;\n/*@ sourceMapping` + `URL=foo.js.map */\n`;
+
+    expect(extractInlineSourceMap(code)).toEqual({
+      code: 'const foo = 1;',
+      map: undefined,
+      strippedComment: true,
+    });
+  });
+
+  it('should accept a tab between the marker and the URL', () => {
+    const code = `const foo = 1;\n//#\tsourceMapping` + `URL=foo.js.map\n`;
+
+    expect(extractInlineSourceMap(code)).toEqual({
+      code: 'const foo = 1;',
+      map: undefined,
+      strippedComment: true,
+    });
+  });
+
+  it('should not strip a block comment spanning multiple lines', () => {
+    const code = `const foo = 1;\n/*# sourceMapping` + `URL=foo.js.map\n*/\n`;
+
+    expect(extractInlineSourceMap(code)).toEqual({
+      code,
+      map: undefined,
+      strippedComment: false,
+    });
+  });
+
+  it('should only strip a trailing comment', () => {
+    const map = JSON.stringify({ mappings: 'AAAA' });
+    const code = `const foo = 1;\n${inlineComment(map)}\nconst bar = 2;\n`;
+
+    expect(extractInlineSourceMap(code)).toEqual({
+      code,
+      map: undefined,
+      strippedComment: false,
+    });
+  });
+});
+
+// The accept/reject rules mirror rspack's deserializer, which fails the
+// module build on anything it rejects. Verified against rspack 1.6 and 2.0:
+// only `mappings` is required, other fields are optional and null-tolerant
+// but type-checked when present.
+describe('isForwardableSourceMap', () => {
+  const base = { version: 3, sources: ['a.ts'], names: [], mappings: 'AAAA' };
+
+  it.each([
+    ['a minimal map with only mappings', { mappings: 'AAAA' }],
+    ['a map without version', { sources: ['a.ts'], mappings: 'AAAA' }],
+    ['a map with a string version', { ...base, version: '3' }],
+    ['a map with empty mappings', { ...base, mappings: '' }],
+    ['a map with null sources', { ...base, sources: null }],
+    ['a map with a null sources element', { ...base, sources: [null] }],
+    ['a map with a null names element', { ...base, names: [null] }],
+    [
+      'a map with a null sourcesContent element',
+      { ...base, sourcesContent: [null] },
+    ],
+    [
+      'a map with null optional fields',
+      { ...base, file: null, sourceRoot: null, debugId: null },
+    ],
+    ['a map with an ignoreList', { ...base, ignoreList: [0, 4294967295] }],
+    ['a map with unknown fields', { ...base, somethingElse: 42 }],
+  ])('should accept %s', (_, value) => {
+    expect(isForwardableSourceMap(value)).toBe(true);
+  });
+
+  it.each([
+    ['null', null],
+    ['an array', []],
+    ['a string', '{"mappings":"AAAA"}'],
+    ['a map without mappings', { version: 3, sources: ['a.ts'] }],
+    ['a map with non-string mappings', { ...base, mappings: 42 }],
+    ['a map with a non-string sources element', { ...base, sources: [42] }],
+    ['a map with a non-string names element', { ...base, names: [1] }],
+    [
+      'a map with a non-string sourcesContent element',
+      { ...base, sourcesContent: [42] },
+    ],
+    ['a map with a non-string file', { ...base, file: 42 }],
+    ['a map with a non-string sourceRoot', { ...base, sourceRoot: 1 }],
+    ['a map with a non-string debugId', { ...base, debugId: 1 }],
+    [
+      'a map with a non-numeric ignoreList element',
+      { ...base, ignoreList: ['a'] },
+    ],
+    ['a map with a negative ignoreList element', { ...base, ignoreList: [-1] }],
+    [
+      'a map with a fractional ignoreList element',
+      { ...base, ignoreList: [1.5] },
+    ],
+    [
+      'a map with an ignoreList element above the u32 range',
+      { ...base, ignoreList: [4294967296] },
+    ],
+  ])('should reject %s', (_, value) => {
+    expect(isForwardableSourceMap(value)).toBe(false);
   });
 });

--- a/packages/angular-rspack/src/lib/plugins/loaders/inline-source-map.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/inline-source-map.ts
@@ -17,7 +17,8 @@ export function extractInlineSourceMap(
   try {
     JSON.parse(map);
   } catch {
-    return [code, undefined];
+    // A malformed map is unusable; still strip its comment from the code.
+    return [code.slice(0, match.index), undefined];
   }
   return [code.slice(0, match.index), map];
 }

--- a/packages/angular-rspack/src/lib/plugins/loaders/inline-source-map.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/inline-source-map.ts
@@ -1,0 +1,23 @@
+const INLINE_SOURCE_MAP_REGEX =
+  /\n?\/\/# sourceMappingURL=data:application\/json[^,]*;base64,([A-Za-z0-9+/=]+)\s*$/;
+
+/**
+ * Splits an inline sourcemap comment off the given code so it can be passed
+ * to the loader callback and chained into the final sourcemaps, mirroring how
+ * the esbuild pipeline consumes the Angular compilation's inline sourcemaps.
+ */
+export function extractInlineSourceMap(
+  code: string
+): [code: string, map: string | undefined] {
+  const match = code.match(INLINE_SOURCE_MAP_REGEX);
+  if (match?.index === undefined) {
+    return [code, undefined];
+  }
+  const map = Buffer.from(match[1], 'base64').toString();
+  try {
+    JSON.parse(map);
+  } catch {
+    return [code, undefined];
+  }
+  return [code.slice(0, match.index), map];
+}

--- a/packages/angular-rspack/src/lib/plugins/loaders/inline-source-map.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/inline-source-map.ts
@@ -1,24 +1,102 @@
-const INLINE_SOURCE_MAP_REGEX =
-  /\n?\/\/# sourceMappingURL=data:application\/json[^,]*;base64,([A-Za-z0-9+/=]+)\s*$/;
+import type { RawSourceMap } from '@rspack/core';
+
+// A `sourceMappingURL` value: an inline base64 data URI (captured) or any
+// other reference, e.g. an external `.js.map` file.
+const SOURCE_MAP_URL_SOURCE =
+  'sourceMappingURL=(?:data:application\\/json[^,]*;base64,([A-Za-z0-9+/=]+)|[^\\r\\n]*?)';
+
+// Matches a trailing sourcemap comment in the forms source-map-loader
+// consumes: `//#`, the legacy `//@`, and their single-line block variants
+// `/*# ... */` and `/*@ ... */`. The leading `\r?\n` consumes the newline
+// preceding the comment so no stray `\r` is left on the stripped code. The
+// inline base64 payload lands in group 1 (line comment) or group 2 (block
+// comment).
+const TRAILING_SOURCE_MAP_COMMENT_REGEX = new RegExp(
+  `(?:\\r?\\n)?(?:\\/\\/[#@][ \\t]+${SOURCE_MAP_URL_SOURCE}|\\/\\*[#@][ \\t]+${SOURCE_MAP_URL_SOURCE}[ \\t]*\\*\\/)\\s*$`
+);
+
+export interface ExtractedSourceMap {
+  code: string;
+  /** The decoded sourcemap as a JSON string, when inline and usable. */
+  map: string | undefined;
+  /**
+   * Whether a trailing sourceMappingURL comment was stripped from the code,
+   * even when it yielded no usable map (an external file reference or a
+   * payload rspack would reject).
+   */
+  strippedComment: boolean;
+}
 
 /**
- * Splits an inline sourcemap comment off the given code so it can be passed
- * to the loader callback and chained into the final sourcemaps, mirroring how
- * the esbuild pipeline consumes the Angular compilation's inline sourcemaps.
+ * Splits a trailing sourcemap comment off the given code so the map can be
+ * passed to the loader callback and chained into the final sourcemaps,
+ * mirroring how the esbuild pipeline consumes the inline sourcemaps of the
+ * Angular compilation and the JavaScript transformer. Comments that carry no
+ * usable inline map are still stripped: esbuild never emits input
+ * sourceMappingURL comments into the bundle.
  */
-export function extractInlineSourceMap(
-  code: string
-): [code: string, map: string | undefined] {
-  const match = code.match(INLINE_SOURCE_MAP_REGEX);
+export function extractInlineSourceMap(code: string): ExtractedSourceMap {
+  const match = code.match(TRAILING_SOURCE_MAP_COMMENT_REGEX);
   if (match?.index === undefined) {
-    return [code, undefined];
+    return { code, map: undefined, strippedComment: false };
   }
-  const map = Buffer.from(match[1], 'base64').toString();
+  const stripped = code.slice(0, match.index);
+  const inlinePayload = match[1] ?? match[2];
+  if (inlinePayload === undefined) {
+    // A reference to an external map file; there is nothing to decode.
+    return { code: stripped, map: undefined, strippedComment: true };
+  }
+  const map = Buffer.from(inlinePayload, 'base64').toString('utf8');
   try {
-    JSON.parse(map);
+    if (!isForwardableSourceMap(JSON.parse(map))) {
+      return { code: stripped, map: undefined, strippedComment: true };
+    }
   } catch {
     // A malformed map is unusable; still strip its comment from the code.
-    return [code.slice(0, match.index), undefined];
+    return { code: stripped, map: undefined, strippedComment: true };
   }
-  return [code.slice(0, match.index), map];
+  return { code: stripped, map, strippedComment: true };
+}
+
+/**
+ * Whether rspack's sourcemap deserializer accepts this value as a
+ * loader-provided map. Rspack fails the module build on any map it cannot
+ * deserialize, even when sourcemaps are disabled, so externally authored maps
+ * (a package's own sourcemap) must pass this check before being handed to
+ * the loader callback. Mirrors rspack's deserialization rules: `mappings`
+ * must be a string; every other field is optional and may be null, but a
+ * present value must have the expected type, including array elements
+ * (`sources`, `names` and `sourcesContent` entries may be null; `ignoreList`
+ * entries are deserialized as unsigned 32-bit integers).
+ */
+export function isForwardableSourceMap(value: unknown): value is RawSourceMap {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false;
+  }
+  const map = value as Record<string, unknown>;
+  const isNullableString = (v: unknown) => v === null || typeof v === 'string';
+  const isOptional = (v: unknown, check: (v: unknown) => boolean) =>
+    v === undefined || v === null || check(v);
+  const isArrayOf = (v: unknown, check: (v: unknown) => boolean) =>
+    Array.isArray(v) && v.every(check);
+
+  return (
+    typeof map.mappings === 'string' &&
+    isOptional(map.sources, (v) => isArrayOf(v, isNullableString)) &&
+    isOptional(map.names, (v) => isArrayOf(v, isNullableString)) &&
+    isOptional(map.sourcesContent, (v) => isArrayOf(v, isNullableString)) &&
+    isOptional(map.file, (v) => typeof v === 'string') &&
+    isOptional(map.sourceRoot, (v) => typeof v === 'string') &&
+    isOptional(map.debugId, (v) => typeof v === 'string') &&
+    isOptional(map.ignoreList, (v) =>
+      isArrayOf(
+        v,
+        (el) =>
+          typeof el === 'number' &&
+          Number.isInteger(el) &&
+          el >= 0 &&
+          el <= 0xffffffff
+      )
+    )
+  );
 }

--- a/packages/angular-rspack/src/lib/plugins/ng-rspack.ts
+++ b/packages/angular-rspack/src/lib/plugins/ng-rspack.ts
@@ -5,7 +5,7 @@ import {
   DefinePlugin,
   RspackPluginInstance,
 } from '@rspack/core';
-import { posix, relative, resolve } from 'node:path';
+import { posix, relative, resolve, sep } from 'node:path';
 import { getEntryPoints } from '../config/config-utils/entry-points';
 import type {
   I18nOptions,
@@ -88,6 +88,31 @@ export class NgRspackPlugin implements RspackPluginInstance {
                 new compiler.rspack.sources.RawSource('{"type": "commonjs"}\n')
               );
             }
+          }
+        );
+      });
+    } else {
+      // Deployment tooling reads this at the output root of every build; the
+      // PrerenderPlugin overwrites it with the rendered routes after emit.
+      compiler.hooks.thisCompilation.tap('NgRspackPlugin', (compilation) => {
+        compilation.hooks.processAssets.tap(
+          {
+            name: 'NgRspackPlugin',
+            stage: compiler.rspack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONS,
+          },
+          () => {
+            compilation.emitAsset(
+              posix.join(
+                ...relative(
+                  this.pluginOptions.outputPath.browser,
+                  this.pluginOptions.outputPath.base
+                ).split(sep),
+                'prerendered-routes.json'
+              ),
+              new compiler.rspack.sources.RawSource(
+                JSON.stringify({ routes: {} }, null, 2)
+              )
+            );
           }
         );
       });

--- a/packages/angular-rspack/src/lib/plugins/ng-rspack.ts
+++ b/packages/angular-rspack/src/lib/plugins/ng-rspack.ts
@@ -29,6 +29,7 @@ export class NgRspackPlugin implements RspackPluginInstance {
   readonly isPlatformServer: boolean;
   readonly i18n: I18nOptions;
   private readonly sharedLicenseInputs: SharedLicenseInputs | undefined;
+  private readonly sharedAngularPlugin: AngularRspackPlugin | undefined;
 
   constructor(
     pluginOptions: NormalizedAngularRspackPluginOptions,
@@ -41,12 +42,21 @@ export class NgRspackPlugin implements RspackPluginInstance {
        * overwriting each other's licenses file.
        */
       sharedLicenseInputs?: SharedLicenseInputs;
+      /**
+       * Angular compilation shared across the compilers of an SSR build: the
+       * browser compiler owns it (its program includes the server entry
+       * points) and the server compiler consumes its output instead of
+       * running a second compilation. When absent, each compiler runs its
+       * own compilation.
+       */
+      sharedAngularPlugin?: AngularRspackPlugin;
     }
   ) {
     this.pluginOptions = pluginOptions;
     this.i18n = extraOptions.i18nOptions;
     this.isPlatformServer = extraOptions.platform === 'server';
     this.sharedLicenseInputs = extraOptions.sharedLicenseInputs;
+    this.sharedAngularPlugin = extraOptions.sharedAngularPlugin;
   }
 
   apply(compiler: Compiler) {
@@ -131,7 +141,15 @@ export class NgRspackPlugin implements RspackPluginInstance {
       new I18nInlinePlugin(this.pluginOptions, this.i18n).apply(compiler);
     }
     new RxjsEsmResolutionPlugin().apply(compiler);
-    new AngularRspackPlugin(this.pluginOptions, this.i18n).apply(compiler);
+    if (this.sharedAngularPlugin) {
+      if (this.isPlatformServer) {
+        this.sharedAngularPlugin.applyToDependentCompiler(compiler);
+      } else {
+        this.sharedAngularPlugin.apply(compiler);
+      }
+    } else {
+      new AngularRspackPlugin(this.pluginOptions, this.i18n).apply(compiler);
+    }
     if (!this.isPlatformServer && this.pluginOptions.index) {
       new IndexHtmlPlugin({
         indexPath: this.pluginOptions.index.input,

--- a/packages/angular-rspack/src/lib/plugins/ng-rspack.ts
+++ b/packages/angular-rspack/src/lib/plugins/ng-rspack.ts
@@ -72,6 +72,26 @@ export class NgRspackPlugin implements RspackPluginInstance {
         new AngularSsrDevServer(this.pluginOptions).apply(compiler);
       }
     }
+    if (this.isPlatformServer) {
+      // The server bundle is CommonJS; the marker keeps Node loading it as
+      // such under a `"type": "module"` workspace package.json.
+      compiler.hooks.thisCompilation.tap('NgRspackPlugin', (compilation) => {
+        compilation.hooks.processAssets.tap(
+          {
+            name: 'NgRspackPlugin',
+            stage: compiler.rspack.Compilation.PROCESS_ASSETS_STAGE_ADDITIONS,
+          },
+          () => {
+            if (!compilation.getAsset('package.json')) {
+              compilation.emitAsset(
+                'package.json',
+                new compiler.rspack.sources.RawSource('{"type": "commonjs"}\n')
+              );
+            }
+          }
+        );
+      });
+    }
     if (!isDevServer && this.pluginOptions.progress) {
       new ProgressPlugin(this.isPlatformServer ? 'server' : 'browser').apply(
         compiler

--- a/packages/angular-rspack/src/lib/plugins/ng-rspack.ts
+++ b/packages/angular-rspack/src/lib/plugins/ng-rspack.ts
@@ -15,6 +15,10 @@ import { loadEsmModule } from '../utils/misc-helpers';
 import { isServeMode } from '../utils/rspack-serve-env';
 import { AngularRspackPlugin } from './angular-rspack-plugin';
 import { AngularSsrDevServer } from './angular-ssr-dev-server';
+import {
+  ExtractLicensesPlugin,
+  type SharedLicenseInputs,
+} from './extract-licenses-plugin';
 import { I18nInlinePlugin } from './i18n-inline-plugin';
 import { IndexHtmlPlugin } from './index-html-plugin';
 import { ProgressPlugin } from './progress-plugin';
@@ -24,17 +28,25 @@ export class NgRspackPlugin implements RspackPluginInstance {
   readonly pluginOptions: NormalizedAngularRspackPluginOptions;
   readonly isPlatformServer: boolean;
   readonly i18n: I18nOptions;
+  private readonly sharedLicenseInputs: SharedLicenseInputs | undefined;
 
   constructor(
     pluginOptions: NormalizedAngularRspackPluginOptions,
     extraOptions: {
       platform: 'browser' | 'server';
       i18nOptions: I18nOptions;
+      /**
+       * License extraction inputs shared across the compilers of an SSR
+       * build, so the browser and server compilers emit the union instead of
+       * overwriting each other's licenses file.
+       */
+      sharedLicenseInputs?: SharedLicenseInputs;
     }
   ) {
     this.pluginOptions = pluginOptions;
     this.i18n = extraOptions.i18nOptions;
     this.isPlatformServer = extraOptions.platform === 'server';
+    this.sharedLicenseInputs = extraOptions.sharedLicenseInputs;
   }
 
   apply(compiler: Compiler) {
@@ -103,13 +115,7 @@ export class NgRspackPlugin implements RspackPluginInstance {
       }).apply(compiler);
     }
     if (this.pluginOptions.extractLicenses) {
-      const { LicenseWebpackPlugin } = require('license-webpack-plugin');
-      new LicenseWebpackPlugin({
-        stats: {
-          warnings: false,
-          errors: false,
-        },
-        perChunkOutput: false,
+      new ExtractLicensesPlugin({
         outputFilename: posix.join(
           relative(
             this.pluginOptions.outputPath.browser,
@@ -117,8 +123,9 @@ export class NgRspackPlugin implements RspackPluginInstance {
           ),
           '3rdpartylicenses.txt'
         ),
-        skipChildCompilers: true,
-      }).apply(compiler as any);
+        rootDirectory: root,
+        sharedInputs: this.sharedLicenseInputs,
+      }).apply(compiler);
     }
     if (this.i18n.shouldInline) {
       new I18nInlinePlugin(this.pluginOptions, this.i18n).apply(compiler);

--- a/packages/angular-rspack/src/lib/plugins/prerender-plugin.ts
+++ b/packages/angular-rspack/src/lib/plugins/prerender-plugin.ts
@@ -2,7 +2,7 @@ import { Compilation, type Compiler, RspackPluginInstance } from '@rspack/core';
 import { augmentAppWithServiceWorker } from '@angular/build/private';
 import { workspaceRoot } from '@nx/devkit';
 import { existsSync } from 'fs';
-import { readFile } from 'fs/promises';
+import { readFile, writeFile } from 'fs/promises';
 import { join } from 'path';
 import assert from 'assert';
 import {
@@ -40,15 +40,49 @@ export class PrerenderPlugin implements RspackPluginInstance {
     compiler.hooks.afterEmit.tapAsync(
       'Angular Rspack',
       async (compilation, callback) => {
+        const prerenderedRoutes = new Set<string>();
         if (this.#_options.appShell) {
           await this.#prerenderAppShell(compilation);
+          prerenderedRoutes.add('/');
         }
         if (this.#_options.prerender) {
-          await this.#prerenderSSGUniversal(compilation);
+          for (const route of await this.#prerenderSSGUniversal(compilation)) {
+            // RoutesSet stores routes without the leading slash; the manifest
+            // keys carry it, matching the esbuild application builder.
+            prerenderedRoutes.add(`/${route}`);
+          }
         }
+        await this.#writePrerenderedRoutesManifest(
+          compilation,
+          prerenderedRoutes
+        );
         callback();
       }
     );
+  }
+
+  /**
+   * Overwrites the empty `prerendered-routes.json` emitted at the output root
+   * by the browser compiler with the routes that were prerendered.
+   */
+  async #writePrerenderedRoutesManifest(
+    compilation: Compilation,
+    prerenderedRoutes: Set<string>
+  ): Promise<void> {
+    // fromEntries keeps a route literally named "__proto__" an own key.
+    const routes = Object.fromEntries(
+      [...prerenderedRoutes].sort().map((route) => [route, {}])
+    );
+
+    try {
+      await writeFile(
+        join(this.#_options.outputPath.base, 'prerendered-routes.json'),
+        JSON.stringify({ routes }, null, 2)
+      );
+    } catch (error) {
+      assertIsError(error);
+      addError(compilation, error.message);
+    }
   }
 
   async #prerenderAppShell(compilation: Compilation) {
@@ -135,7 +169,7 @@ export class PrerenderPlugin implements RspackPluginInstance {
     }
   }
 
-  async #prerenderSSGUniversal(compilation: Compilation) {
+  async #prerenderSSGUniversal(compilation: Compilation): Promise<string[]> {
     // Users can specify a different base html file e.g. "src/home.html"
     const indexFile = getIndexOutputFile(
       this.#_options.index as IndexExpandedDefinition
@@ -230,6 +264,8 @@ export class PrerenderPlugin implements RspackPluginInstance {
     } finally {
       void worker.destroy();
     }
+
+    return routes ?? [];
   }
 
   async #getRoutes(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2266,9 +2266,6 @@ importers:
       less-loader:
         specifier: catalog:css
         version: 12.3.1(@rspack/core@1.6.8(@swc/helpers@0.5.23))(less@4.5.1)(webpack@5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@7.0.3(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.105.2)))
-      license-webpack-plugin:
-        specifier: ^4.0.2
-        version: 4.0.2(webpack@5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@7.0.3(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.105.2)))
       loader-utils:
         specifier: 3.3.1
         version: 3.3.1
@@ -47714,12 +47711,6 @@ snapshots:
       treeify: 1.1.0
     transitivePeerDependencies:
       - supports-color
-
-  license-webpack-plugin@4.0.2(webpack@5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@7.0.3(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.105.2))):
-    dependencies:
-      webpack-sources: 3.3.3
-    optionalDependencies:
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.27.3)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@7.0.3(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.105.2))
 
   license-webpack-plugin@4.0.2(webpack@5.105.2):
     dependencies:


### PR DESCRIPTION
## Current Behavior

Watch-mode rebuilds with `@nx/angular-rspack` are slow and get slower as the app grows. Every rebuild re-runs license extraction over all modules, rebuilds every component stylesheet, spawns a fresh JavaScript transform worker pool, eagerly re-transforms every file emitted by the Angular compilation, and re-checks the TypeScript program from scratch. The initial build also trails the `@angular/build` esbuild builder: component resource URLs are resolved by re-parsing every module, type checking runs serially on the main thread after the bundle is sealed, and the Angular linker output is never cached.

The build also diverges from the application builder's behavior in several cases. Production builds of module federation apps crash when Angular's fast emit path hands raw TypeScript to the JavaScript transformer. The swc rule always transpiles with hardcoded legacy decorator semantics regardless of the project tsconfig, and `.tsx` sources fail with syntax errors. Unsupported tsconfig options the application builder rewrites (partial compilation mode, `module` values below ES2015) are used as-is and produce broken output. Disabling type checking also swallows tsconfig option and syntax errors, and a failed compilation setup leaks its worker thread and drops the setup warnings. Bundle sourcemaps are not chained through dependency maps either: vendor packages and prebuilt workspace libraries resolve to their transformed JavaScript instead of their original sources, and references to external `.map` files are ignored.

SSR builds have additional problems. The browser and server compilers each run a full Angular compilation of the same program, so every build pays the compilation cost twice and reports every diagnostic twice. The CommonJS server bundle crashes on startup in a workspace whose package.json sets `"type": "module"`, `import.meta.url` in the server bundle is inlined as the source file's URL so `isMainModule` guards never match and the server does not start listening, and no `prerendered-routes.json` manifest is emitted for deployment tooling to read.

## Expected Behavior

Rebuilds only redo work for what changed, matching the performance behavior of the `@angular/build` application builder while producing the same outputs:

- license extraction no longer runs on every rebuild; browser and server builds share their collected inputs so the SSR `3rdpartylicenses.txt` stays a union of both
- component stylesheets rebuild incrementally in watch mode
- the JavaScript transform worker pool stays alive across rebuilds
- files emitted by the Angular compilation are transformed on demand and cached until their source changes; the per-file TypeScript transpilation step is skipped when the tsconfig lets the bundler's swc loader handle it
- TypeScript incremental state persists across builds in the Angular cache directory
- stale cached transforms are dropped for changed and deleted files
- component template and style URLs are registered from the compiler's tracked resource dependencies instead of re-parsing every module
- the Angular linker output is reused across builds from a disk cache
- the persistent caches stay active outside Nx workspaces (plain programmatic usage), scoped by project root
- the Angular compilation runs in a worker thread and type checking overlaps with bundling instead of running serially after it
- an SSR build runs one Angular compilation shared between the browser and server compilers, with diagnostics reported once per build; component stylesheet media assets are emitted only to the browser output like the application builder

Behavior matches the application builder where it diverged:

- production builds of module federation apps work: the loaders classify the Angular compilation's output with the exact gate its emit uses
- the swc rule derives its transpilation semantics (class fields, decorator flavor and metadata, `verbatimModuleSyntax`) from the project tsconfig instead of hardcoding legacy decorators
- `.tsx` sources build, with JSX lowering read from the tsconfig the way esbuild reads it
- tsconfig options the application builder rewrites are forced the same way, each with its setup warning: targets below ES2022 are raised, partial compilation mode falls back to full, `module` values below ES2015 are set to ES2022, and `customConditions` and `preserveSymlinks` are kept in sync with the bundler
- with `skipTypeChecking` only the semantic pass is skipped; tsconfig option errors and syntax errors still surface
- a failed compilation setup no longer leaks its worker thread, and its setup warnings are reported with the failing build instead of being dropped
- bundle sourcemaps resolve vendor packages and prebuilt workspace libraries to their original sources, including through external `.map` file references; maps rspack cannot deserialize are dropped instead of failing the module build
- the server output includes a `{"type": "commonjs"}` package.json marker so it runs under a `"type": "module"` workspace
- `import.meta.url` in the server bundle resolves to the emitted bundle at runtime, so `isMainModule`-gated servers start correctly
- `prerendered-routes.json` is emitted at the output root of every build and filled with the prerendered routes

Benchmarked on a workspace with 8000 components (cold start, watch mode, dev config, medians of 3 runs; the `@angular/build` esbuild builder on the same app as reference):

|                      | Before | After | Speedup | `@angular/build` |
| -------------------- | ------ | ----- | ------- | ---------------- |
| Initial build        | ~33s   | ~18s  | 1.8x    | ~20s             |
| First rebuild        | ~19s   | ~8.3s | 2.3x    | ~9.7s            |
| Steady-state rebuild | ~9.4s  | ~1.2s | 7.8x    | ~2.1s            |

The initial build now matches the esbuild builder and rebuilds are faster. With SSR enabled on the same workspace, builds come in at ~27.5s/~13.9s/~3.5s vs the esbuild builder's ~28s/~16s/~4.6s.

## Related Issue(s)

Fixes #34936

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/gh-34936-4f8ace2a)
<!-- polygraph-session-end -->

