### PR TITLE
fix(core): detect Codex sandbox on Linux to disable daemon and plugin isolation

### DIFF
--- a/packages/nx/src/utils/is-sandbox.spec.ts
+++ b/packages/nx/src/utils/is-sandbox.spec.ts
@@ -5,6 +5,7 @@ describe('isSandbox', () => {
     'SANDBOX_RUNTIME',
     'GEMINI_SANDBOX',
     'CODEX_SANDBOX',
+    'CODEX_SANDBOX_NETWORK_DISABLED',
     'CURSOR_SANDBOX',
   ];
 

--- a/packages/nx/src/utils/is-sandbox.ts
+++ b/packages/nx/src/utils/is-sandbox.ts
@@ -3,6 +3,8 @@ export function isSandbox(): boolean {
     !!process.env.SANDBOX_RUNTIME ||
     !!process.env.GEMINI_SANDBOX ||
     !!process.env.CODEX_SANDBOX ||
+    // Codex only sets CODEX_SANDBOX on macOS; on Linux it sets this instead.
+    !!process.env.CODEX_SANDBOX_NETWORK_DISABLED ||
     !!process.env.CURSOR_SANDBOX
   );
 }


### PR DESCRIPTION
## Current Behavior

Inside the OpenAI Codex sandbox on **Linux**, Nx keeps the daemon and plugin isolation enabled. Both communicate with spawned child processes over Unix domain sockets, which Codex's Linux sandbox (Landlock + seccomp) blocks when network access is disabled — so commands fail.

This works on macOS because Codex sets `CODEX_SANDBOX=seatbelt`, which `isSandbox()` already detects. But that variable is macOS-only in Codex (guarded by `#[cfg(target_os = "macos")]`). On Linux, Codex never sets `CODEX_SANDBOX`; it sets `CODEX_SANDBOX_NETWORK_DISABLED=1` instead. Nx wasn't watching for that, so `isSandbox()` returned `false` and the safe in-process path was never taken.

## Expected Behavior

`isSandbox()` also checks `CODEX_SANDBOX_NETWORK_DISABLED` — the variable Codex actually sets on Linux (and, cross-platform, whenever network is disabled). Nx now detects the Codex sandbox on Linux and disables the daemon and plugin isolation, running with the in-process, no-socket path. This variable is set precisely in the network-disabled case, which is the same condition under which Codex's seccomp policy blocks `AF_UNIX` connect — so detection targets exactly the scenario that fails, without false positives on a normally-networked machine.

## Related Issue(s)

N/A

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Detect-Codex-sandbox-on-Linux-0c69b61c)
<!-- polygraph-session-end -->