### PR TITLE
docs(misc): refresh angular docs pages and fix broken angular urls

### DIFF
--- a/astro-docs/netlify.toml
+++ b/astro-docs/netlify.toml
@@ -152,6 +152,11 @@ to = "/docs/knowledge-base/installation-and-updates"
 from = "/docs/technologies/build-tools/vite/configure-vite"
 to = "/docs/technologies/build-tools/vite/guides/configure-vite"
 
+# DOC-544: Pre-2022 docs URL structure still receives heavy traffic (65k+ requests/30d) and 404s.
+[[redirects]]
+from = "/angular/plugins/*"
+to = "/docs/technologies/angular/introduction"
+
 # DOC-522: Polygraph is a standalone product, no longer part of Nx Cloud.
 # Reroute the Polygraph-specific docs pages to the standalone landing page.
 # force = true so these win over the catch-all rewrite below.

--- a/astro-docs/src/content/docs/technologies/angular/Guides/dynamic-module-federation-with-angular.mdoc
+++ b/astro-docs/src/content/docs/technologies/angular/Guides/dynamic-module-federation-with-angular.mdoc
@@ -14,6 +14,10 @@ The difficulty in achieving this with a Micro Frontend Architecture using Static
 
 Walk through how the concept of "Build once, deploy everywhere" can be easily achieved in a Micro Frontend Architecture that uses Dynamic Module Federation.
 
+{% aside type="tip" title="Faster builds with Rspack" %}
+The examples below use webpack. The `@nx/angular:host` and `@nx/angular:remote` generators also accept `--bundler=rspack` to use [Angular Rspack](/docs/technologies/angular/angular-rspack/introduction) for faster, webpack-compatible builds.
+{% /aside %}
+
 ## Aim
 
 The aim of this guide is three-fold. We want to be able to:

--- a/astro-docs/src/content/docs/technologies/angular/Guides/nx-and-angular.mdoc
+++ b/astro-docs/src/content/docs/technologies/angular/Guides/nx-and-angular.mdoc
@@ -20,6 +20,7 @@ Nx...
 - helps define clear architectural guidelines and promotes best practices to organize and scale your codebase.
 - helps integrate modern tooling by actively working with devtool authors to make sure they work well with Nx and your framework of choice.
 - is adaptable: start small with a single-project setup and grow it to a monorepo when needed.
+- speeds up CI with [Nx Cloud](/docs/getting-started/nx-cloud): remote caching, distributed task execution, and self-healing CI.
 - has an active community of contributors and plugin authors.
 - has been proven in large enterprise-level projects.
 
@@ -51,6 +52,7 @@ Here's a quick side-by-side overview comparing the features between the Angular 
 | [Local Caching](/docs/features/cache-task-results)                                                         | ❌\*\*          | ✅            |
 | [Remote Caching](/docs/features/ci-features/remote-cache)                                                  | ❌              | ✅            |
 | [Distributed Task Execution on CI](/docs/features/ci-features/distribute-task-execution)                   | ❌              | ✅            |
+| [Self-Healing CI](/docs/features/ci-features/self-healing-ci)                                              | ❌              | ✅            |
 | Custom Hashers                                                                                             | ❌              | ✅            |
 | [Extensible Plugin System](/docs/extending-nx/intro)                                                       | ❌              | ✅            |
 
@@ -75,41 +77,40 @@ Nx is not just exclusively for monorepos, but can create
 
 ### Generate a new project
 
-You can create a new Nx single-project workspace using the following command:
+You can create a new Nx workspace using the following command:
 
 ```shell
-npx create-nx-workspace myngapp --preset=angular-standalone
+npx create-nx-workspace@latest myngapp --template=nrwl/angular-template
 ```
 
-{% aside type="note" title="Want a monorepo instead?" %}
-You can use the `--preset=angular-monorepo` to start with a monorepo structure. Note, however, that you can start simple and migrate to a monorepo later.
-{% /aside %}
-
-The single-project workspace setup follows a similar structure to what the Angular CLI generates.
+Each project keeps a familiar Angular structure. For example, an application generated with `nx g @nx/angular:app apps/myngapp` looks like this:
 
 ```plaintext
 └─ myngapp
-   ├─ public
-   │  └─ favicon.ico
-   ├─ src
-   │  ├─ app
-   │  │  ├─ app.config.ts
-   │  │  ├─ app.css
-   │  │  ├─ app.html
-   │  │  ├─ app.routes.ts
-   │  │  ├─ app.spec.ts
-   │  │  ├─ app.ts
-   │  │  └─ nx-welcome.ts
-   │  ├─ index.html
-   │  ├─ main.ts
-   │  ├─ styles.css
-   │  └─ test-setup.ts
+   ├─ apps
+   │  └─ myngapp
+   │     ├─ public
+   │     │  └─ favicon.ico
+   │     ├─ src
+   │     │  ├─ app
+   │     │  │  ├─ app.config.ts
+   │     │  │  ├─ app.css
+   │     │  │  ├─ app.html
+   │     │  │  ├─ app.routes.ts
+   │     │  │  ├─ app.spec.ts
+   │     │  │  ├─ app.ts
+   │     │  │  └─ nx-welcome.ts
+   │     │  ├─ index.html
+   │     │  ├─ main.ts
+   │     │  ├─ styles.css
+   │     │  └─ test-setup.ts
+   │     ├─ project.json
+   │     ├─ tsconfig.app.json
+   │     ├─ tsconfig.json
+   │     └─ tsconfig.spec.json
    ├─ nx.json
    ├─ package.json
-   ├─ project.json
-   ├─ tsconfig.app.json
-   ├─ tsconfig.json
-   └─ tsconfig.spec.json
+   └─ tsconfig.base.json
 ```
 
 ### project.json vs angular.json
@@ -134,7 +135,7 @@ Nx comes with slightly different terminology than the Angular CLI for some featu
   ...
   "targets": {
     "build": {
-      "executor": "@angular-devkit/build-angular:browser",
+      "executor": "@angular/build:application",
       ...
     },
     ...
@@ -211,46 +212,6 @@ The [`nx add` command](/docs/reference/nx-commands#nx-add) is similar to the `ng
 nx add [package]
 ```
 
-The command was introduced in **Nx 17.3.0**. If you're using an older version, you can instead run:
-
-{% tabs %}
-{% tabitem label="npm" %}
-
-```shell
-npm add [package]
-nx g [package]:ng-add
-```
-
-{% /tabitem %}
-
-{% tabitem label="yarn" %}
-
-```shell
-yarn add [package]
-nx g [package]:ng-add
-```
-
-{% /tabitem %}
-
-{% tabitem label="pnpm" %}
-
-```shell
-pnpm add [package]
-nx g [package]:ng-add
-```
-
-{% /tabitem %}
-
-{% tabitem label="bun" %}
-
-```shell
-bun add [package]
-nx g [package]:ng-add
-```
-
-{% /tabitem %}
-{% /tabs %}
-
 Replace `[package]` with the package name you're trying to add.
 
 ### Speed
@@ -262,10 +223,11 @@ Features like
 - only running tasks on [affected projects](/docs/features/ci-features/affected)
 - running [tasks in parallel](/docs/features/run-tasks#run-tasks-for-multiple-projects)
 - applying [computation caching](/docs/features/cache-task-results)
-- offering [remote caching abilities](/docs/features/ci-features/remote-cache) on CI
+- offering [remote caching abilities](/docs/features/ci-features/remote-cache) on CI through Nx Cloud
 - offering [task distribution across machines (Nx Agents)](/docs/features/ci-features/distribute-task-execution)
+- fixing broken CI runs automatically with [self-healing CI](/docs/features/ci-features/self-healing-ci)
 
-And, Nx already uses fast, modern tooling like [ESBuild](/docs/technologies/build-tools/esbuild/introduction), [Vite](/docs/technologies/build-tools/vite/introduction), Vitest and [Rspack](/docs/technologies/build-tools/rspack/introduction) for non-Angular stacks. So once Angular is ready to use these tools, Nx will also be ready.
+Nx also invests in fast build tooling for Angular beyond the Angular CLI. If you rely on webpack-specific features such as Module Federation, [Angular Rspack](/docs/technologies/angular/angular-rspack/introduction) provides a fast, webpack-compatible build pipeline for Angular.
 
 ### Editor integration
 

--- a/astro-docs/src/content/docs/technologies/angular/Migration/angular.mdoc
+++ b/astro-docs/src/content/docs/technologies/angular/Migration/angular.mdoc
@@ -22,9 +22,7 @@ This will enable you to use the Nx CLI in your existing Angular CLI workspace wh
 
 - The `nx`, `@nx/workspace` and `prettier` packages will be installed.
 - An `nx.json` file will be created in the root of your workspace.
-- For an Angular 14+ repo, the `angular.json` file is split into separate `project.json` files for each project.
-
-**Note:** The changes will be slightly different for Angular 13 and lower.
+- The `angular.json` file is split into separate `project.json` files for each project.
 
 ## Migrating to an Nx Monorepo
 

--- a/astro-docs/src/content/docs/technologies/angular/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/angular/introduction.mdoc
@@ -13,6 +13,25 @@ filter: 'type:References'
 The `@nx/angular` plugin adds [generators](#local-development), Angular CLI builder integration (executors) and migrations so you can run Angular tasks through Nx. With Nx, each project has its own configuration instead of a single `angular.json` file, making it more scalable for Angular monorepos.
 You can use Angular with Nx without the plugin and still get [task caching](/docs/features/cache-task-results), [task orchestration](/docs/features/run-tasks), and the [project graph](/docs/features/explore-graph).
 
+## Why Nx instead of the Angular CLI?
+
+Nx does everything the Angular CLI does, and adds monorepo support, enforced module boundaries, task caching, and CI acceleration through [Nx Cloud](/docs/getting-started/nx-cloud).
+
+| Feature                                                                | Angular CLI | Nx            |
+| ---------------------------------------------------------------------- | ----------- | ------------- |
+| Generate apps, components, services                                    | ✅          | ✅            |
+| Build, serve, and test projects                                        | ✅          | ✅            |
+| Automated updates with migrations                                      | ✅          | ✅ (Enhanced) |
+| First-class monorepo support                                           | ❌          | ✅            |
+| [Enforced module boundaries](/docs/features/enforce-module-boundaries) | ❌          | ✅            |
+| Interactive project graph                                              | ❌          | ✅            |
+| Build and test only what is affected                                   | ❌          | ✅            |
+| Local and remote caching                                               | ❌          | ✅            |
+| Distributed task execution on CI                                       | ❌          | ✅            |
+| Self-healing CI                                                        | ❌          | ✅            |
+
+For a detailed comparison and migration notes, see [Nx and the Angular CLI](/docs/technologies/angular/guides/nx-and-angular).
+
 ## Requirements
 
 The `@nx/angular` plugin supports the following package versions.
@@ -46,14 +65,36 @@ nx show project <your-app-name>
 
 Look for `build`, `serve`, `test`, `lint`, or `e2e` targets generated from `angular.json`.
 
-### Create a new workspace
+### Create an Angular monorepo
+
+Create a new workspace with an Angular application already set up:
 
 ```shell
-npx create-nx-workspace my-org --template=nrwl/angular-template
+npx create-nx-workspace@latest my-org --template=nrwl/angular-template
 ```
 
-{% aside type="tip" title="Angular Tutorial" %}
-For a guided walkthrough, follow the [Learn Nx Tutorial](/docs/getting-started/tutorials/crafting-your-workspace).
+This scaffolds an Nx monorepo with an Angular app and Nx preconfigured for caching, task running, and CI. You grow the monorepo by generating more [applications](#generate-an-angular-application) and [libraries](#generate-an-angular-library), organized by application and by domain:
+
+{% filetree %}
+
+- my-org/
+  - apps/
+    - store/
+    - store-e2e/
+  - libs/
+    - products/
+      - feature-product-list/
+      - data-access/
+    - shared/
+      - ui/
+  - nx.json
+  - package.json
+  - tsconfig.base.json
+
+{% /filetree %}
+
+{% aside type="tip" title="Learn Nx" %}
+For a guided, step-by-step walkthrough of building a monorepo with Nx, follow the [Learn Nx tutorial](/docs/getting-started/tutorials/crafting-your-workspace).
 {% /aside %}
 
 ## Local development
@@ -100,7 +141,7 @@ If you need libraries that build or publish, generate them with build output ena
 See [Set up incremental builds for Angular libraries](/docs/technologies/angular/guides/setup-incremental-builds-angular) for details.
 
 ```shell
-nx g @nx/angular:lib libs/my-lib
+nx g @nx/angular:lib libs/my-lib --publishable --importPath=@my-org/my-lib
 ```
 
 ### Set up Module Federation
@@ -123,15 +164,32 @@ nx g @nx/angular:remote apps/login --host=shell
 
 Pass `--dynamic` for [dynamic federation](/docs/technologies/angular/guides/dynamic-module-federation-with-angular) (remotes resolved at runtime) or `--ssr` for [server-side rendering with Module Federation](/docs/technologies/angular/guides/module-federation-with-ssr).
 
+## Structure your Angular monorepo
+
+Split each application into small, focused libraries grouped by domain (for example `products`, `checkout`, `shared/ui`). Tag those libraries and [enforce module boundaries](/docs/features/enforce-module-boundaries) to control which libraries can depend on each other. This keeps a growing monorepo maintainable and makes `nx affected` precise.
+
+To decide how to split projects, see [folder structure](/docs/concepts/decisions/folder-structure) and [project size](/docs/concepts/decisions/project-size). For a worked example of organizing Angular apps into feature, UI, data-access, and utility libraries, see [Architecting Angular Applications](/blog/architecting-angular-applications).
+
 ## Set up CI for your Angular monorepo
 
-In CI, Nx runs [`nx affected`](/docs/features/ci-features/affected) to rebuild and retest only the projects a change touches, and [caches](/docs/features/cache-task-results) results to skip repeated work.
+In CI, Nx runs [`nx affected`](/docs/features/ci-features/affected) to rebuild and retest only the projects a change touches. Connecting your workspace to Nx Cloud adds:
+
+- [Remote caching](/docs/features/ci-features/remote-cache) to share build and test results across your team and CI machines
+- [Nx Agents](/docs/features/ci-features/distribute-task-execution) to distribute your Angular builds, tests, and lint tasks across machines
+- [Self-healing CI](/docs/features/ci-features/self-healing-ci) to propose fixes for failed tasks directly in your editor or PR
+
+Connect your workspace:
+
+```shell
+npx nx connect
+```
 
 For a complete pipeline, see [Set up CI](/docs/getting-started/setup-ci).
 
 ## What's next
 
 {% cardgrid %}
+{% linkcard title="Set up CI with Nx Cloud" description="Remote caching, Nx Agents, and self-healing CI." href="/docs/getting-started/setup-ci" /%}
 {% linkcard title="Learn Nx Tutorial" description="Build a monorepo step-by-step with Nx." href="/docs/getting-started/tutorials/crafting-your-workspace" /%}
 {% linkcard title="Migrate from Angular CLI" description="Move an existing Angular CLI project into Nx." href="/docs/technologies/angular/migration/angular" /%}
 {% linkcard title="Dynamic Module Federation" description="Load Angular remotes at runtime with dynamic federation." href="/docs/technologies/angular/guides/dynamic-module-federation-with-angular" /%}

--- a/astro-docs/src/plugins/plugin.loader.ts
+++ b/astro-docs/src/plugins/plugin.loader.ts
@@ -183,9 +183,15 @@ export async function generateAllPluginDocs(
 
     try {
       // Process generators
+      const introPath = `/docs/${getPluginSlug(pluginName, 'introduction')}`;
+
       const generators = parseGenerators(pluginPath);
       if (generators && generators.size > 0) {
-        const markdown = getGeneratorsMarkdown(pluginName, generators);
+        const markdown = getGeneratorsMarkdown(
+          pluginName,
+          generators,
+          introPath
+        );
         const slug = getPluginSlug(pluginName, 'generators');
         if (slug) {
           store.set({
@@ -215,7 +221,7 @@ export async function generateAllPluginDocs(
       // Process executors
       const executors = parseExecutors(pluginPath);
       if (executors && executors.size > 0) {
-        const markdown = getExecutorsMarkdown(pluginName, executors);
+        const markdown = getExecutorsMarkdown(pluginName, executors, introPath);
         const slug = getPluginSlug(pluginName, 'executors');
         if (slug) {
           store.set({
@@ -247,7 +253,11 @@ export async function generateAllPluginDocs(
       // if there are not migrations then getMigrationsMarkdown will render a custom message
       // to check previous Nx version docs
       if (migrations) {
-        const markdown = getMigrationsMarkdown(pluginName, migrations);
+        const markdown = getMigrationsMarkdown(
+          pluginName,
+          migrations,
+          introPath
+        );
         const slug = getPluginSlug(pluginName, 'migrations');
         if (slug) {
           store.set({

--- a/astro-docs/src/plugins/utils/core-nx-plugin-generation.ts
+++ b/astro-docs/src/plugins/utils/core-nx-plugin-generation.ts
@@ -74,7 +74,11 @@ export async function loadNxSpecialPackage(
   // Process generators
   const generators = parseGenerators(pluginPath);
   if (generators && generators.size > 0) {
-    const markdown = getGeneratorsMarkdown(packageName, generators);
+    const markdown = getGeneratorsMarkdown(
+      packageName,
+      generators,
+      `/docs/reference/${packageName}`
+    );
     entries.push({
       id: `${packageName}-generators`,
       body: markdown,
@@ -98,7 +102,11 @@ export async function loadNxSpecialPackage(
   // Process executors
   const executors = parseExecutors(pluginPath);
   if (executors && executors.size > 0) {
-    const markdown = getExecutorsMarkdown(packageName, executors);
+    const markdown = getExecutorsMarkdown(
+      packageName,
+      executors,
+      `/docs/reference/${packageName}`
+    );
     entries.push({
       id: `${packageName}-executors`,
       body: markdown,
@@ -122,7 +130,11 @@ export async function loadNxSpecialPackage(
   // Process migrations
   const migrations = parseMigrations(pluginPath);
   if (migrations && migrations.size > 0) {
-    const markdown = getMigrationsMarkdown(packageName, migrations);
+    const markdown = getMigrationsMarkdown(
+      packageName,
+      migrations,
+      `/docs/reference/${packageName}`
+    );
     entries.push({
       id: `${packageName}-migrations`,
       body: markdown,

--- a/astro-docs/src/plugins/utils/generate-plugin-markdown.ts
+++ b/astro-docs/src/plugins/utils/generate-plugin-markdown.ts
@@ -72,11 +72,15 @@ export function generatePackageUpdateItem(name: string, item: any): string {
 
 export function getMigrationsMarkdown(
   pluginName: string,
-  items: Map<string, PluginMigrationItem>
+  items: Map<string, PluginMigrationItem>,
+  introPath?: string
 ): string {
   const packageName = `@nx/${pluginName}`;
 
   let markdown = ``;
+  if (introPath) {
+    markdown += `For an overview of the plugin and setup instructions, see the [${packageName} introduction](${introPath}).\n\n`;
+  }
   if (items.size === 0) {
     markdown += `No migrations found for \`${packageName}\`.
 Nx only retains migrations for the last 2 major versions of Nx.
@@ -162,7 +166,8 @@ Below is a complete reference for all available migrations.
 
 export function getGeneratorsMarkdown(
   pluginName: string,
-  items: Map<string, PluginItem>
+  items: Map<string, PluginItem>,
+  introPath?: string
 ): string {
   const packageName = `@nx/${pluginName}`;
 
@@ -170,6 +175,10 @@ export function getGeneratorsMarkdown(
 The ${packageName} plugin provides various generators to help you create and configure ${pluginName} projects within your Nx workspace.
 Below is a complete reference for all available generators and their options.
 `;
+
+  if (introPath) {
+    markdown += `\nFor an overview of the plugin and setup instructions, see the [${packageName} introduction](${introPath}).\n`;
+  }
 
   // Sort items alphabetically
   const sortedItems = Array.from(items.entries()).sort(([a], [b]) =>
@@ -293,7 +302,8 @@ nx generate ${packageName}:<generator> --help
 
 export function getExecutorsMarkdown(
   pluginName: string,
-  items: Map<string, any>
+  items: Map<string, any>,
+  introPath?: string
 ): string {
   const packageName = `@nx/${pluginName}`;
 
@@ -301,6 +311,10 @@ export function getExecutorsMarkdown(
   The ${packageName} plugin provides various executors to help you create and configure ${pluginName} projects within your Nx workspace.
 Below is a complete reference for all available executors and their options.
 `;
+
+  if (introPath) {
+    markdown += `\nFor an overview of the plugin and setup instructions, see the [${packageName} introduction](${introPath}).\n`;
+  }
 
   // Sort items alphabetically
   const sortedItems = Array.from(items.entries()).sort(([a], [b]) =>

--- a/packages/nx/bin/init-local.ts
+++ b/packages/nx/bin/init-local.ts
@@ -184,7 +184,7 @@ function handleAngularCLIFallbacks(workspace: WorkspaceTypeAndRoot) {
       `- change versions of packages to match organizational requirements`
     );
     console.log(
-      `And, in general, it is lot more reliable for non-trivial workspaces. Read more at: https://nx.dev/getting-started/nx-and-angular#ng-update-and-nx-migrate`
+      `And, in general, it is lot more reliable for non-trivial workspaces. Read more at: https://nx.dev/docs/technologies/angular/guides/nx-and-angular#ng-update-vs-nx-migrate`
     );
     console.log(
       `Run "nx migrate latest" to update to the latest version of Nx.`


### PR DESCRIPTION
## Current Behavior

The `/angular/plugins/*` URLs (top Angular traffic, 65k+ requests/30d) 404 with no redirect. The Angular intro doesn't surface Nx Clo
ud or cover creating and structuring an Angular monorepo, which is the dominant Angular search intent. The generated generators/execu
tors/migrations reference pages don't link back to their plugin intro, and a few guides plus a CLI message point at outdated content.

## Expected Behavior

Mainly an update to the [Angular intro page](https://deploy-preview-36276--nx-docs.netlify.app/docs/technologies/angular/introduction) to surface more useful information for users coming from search engines, etc.

`/angular/plugins/*` redirects to the Angular intro. The intro leads with an Angular CLI comparison, a "Create an Angular monorepo" s
ection with a folder-structure example, a "Structure your Angular monorepo" section, and Nx Cloud-forward CI. API reference pages lin
k back to their plugin intro, the nx-and-angular / migration / dynamic module federation guides are updated for current tooling, and
the CLI prints a live docs URL on `ng update`.


## Related Issue(s)

DOC-544
