### PR TITLE
fix(core): close daemon log descriptors after spawn to avoid Node 26 crash

### DIFF
--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -1,9 +1,10 @@
 import { ChildProcess, spawn } from 'child_process';
-import { FileHandle, open } from 'fs/promises';
 import { connect } from 'net';
 import {
+  closeSync,
   existsSync,
   mkdirSync,
+  openSync,
   readFileSync,
   statSync,
   writeFileSync,
@@ -173,8 +174,6 @@ export class DaemonClient {
   private _daemonStatus: DaemonStatus = DaemonStatus.DISCONNECTED;
   private _waitForDaemonReady: Promise<void> | null = null;
   private _daemonReady: () => void | null = null;
-  private _out: FileHandle = null;
-  private _err: FileHandle = null;
 
   // Shared file watcher connection state
   private fileWatcherMessenger: DaemonSocketMessenger | undefined;
@@ -269,11 +268,6 @@ export class DaemonClient {
     this.currentResolve = null;
     this.currentReject = null;
     this._enabled = undefined;
-
-    this._out?.close();
-    this._err?.close();
-    this._out = null;
-    this._err = null;
 
     // Clean up file watcher and project graph listener connections
     this.fileWatcherMessenger?.close();
@@ -1327,16 +1321,12 @@ export class DaemonClient {
       writeFileSync(DAEMON_OUTPUT_LOG_FILE, '');
     }
 
-    // Open the log handles into locals first. If the previous daemon's
-    // socket close handler fires reset() while we're awaiting these opens,
-    // it would null out this._out/this._err and the spawn below would hit
-    // `Cannot read properties of null (reading 'fd')`.
-    const [out, err] = await Promise.all([
-      open(DAEMON_OUTPUT_LOG_FILE, 'a'),
-      open(DAEMON_OUTPUT_LOG_FILE, 'a'),
-    ]);
-    this._out = out;
-    this._err = err;
+    // Redirect the detached daemon's stdout/stderr into the log file. The
+    // child dup's these descriptors at spawn, so we close ours right after
+    // instead of holding them for the life of this process (Node >=26 turns a
+    // file descriptor closed during garbage collection into a fatal error).
+    const outFd = openSync(DAEMON_OUTPUT_LOG_FILE, 'a');
+    const errFd = openSync(DAEMON_OUTPUT_LOG_FILE, 'a');
 
     clientLogger.log(`[Client] Starting new daemon server in background`);
 
@@ -1345,13 +1335,16 @@ export class DaemonClient {
       [join(__dirname, `../server/start.js`)],
       {
         cwd: workspaceRoot,
-        stdio: ['ignore', out.fd, err.fd],
+        stdio: ['ignore', outFd, errFd],
         detached: true,
         windowsHide: true,
         shell: false,
         env: getDaemonEnv(),
       }
     );
+    // The child now owns dup'd copies of the descriptors, so release ours.
+    closeSync(outFd);
+    closeSync(errFd);
     // if this process is the process that spawned the daemon,
     // the daemon env is already up to date
     this.envReflectionSent = true;


### PR DESCRIPTION
## Current Behavior

Nx commands that start the daemon open two file descriptors on the daemon log and keep them open for the whole process, letting garbage collection close them. On Node 26 a file descriptor closed during garbage collection is a fatal `ERR_INVALID_STATE` error, so when GC collects those descriptors before the process exits, the command crashes with a non-zero exit code after its work has already completed. On Node 20-24 the same pattern only prints a deprecation warning.

This surfaces as flaky failures on Node 26, e.g. the release lock-file e2e (`should not update pnpm-lock.yaml when package manager is pnpm (>= 9)`), where the crash makes `execSync` throw even though the release ran correctly.

## Expected Behavior

The daemon's stdout/stderr are redirected into the log through descriptors that the parent closes immediately after spawning the detached daemon. The child keeps its own dup'd descriptors, so daemon logging is unchanged, while the parent no longer holds a descriptor that GC can close. Commands that start the daemon now exit cleanly on Node 26.

## Implementation Details

`startInBackground` opened the log with `fs/promises` `open` (a `FileHandle`) and stored the handles on the client, closing them only in `reset()`, which runs on daemon socket-close. A command that starts the daemon and leaves it running never hit that path, so the handles were left for GC to close. The handles are now opened with `openSync` and closed with `closeSync` right after `spawn`; a raw descriptor has no GC finalizer, so the failure cannot recur. This also removes the `reset()` cleanup and the earlier reset-race workaround, since nothing is retained on the client.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/troubleshoot-flaky-tasks-e92822a8)
<!-- polygraph-session-end -->