### PR TITLE
fix(core): skip projects-filtered targetDefaults when resolved without a project

### DIFF
--- a/packages/nx/src/project-graph/utils/project-configuration/target-defaults.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-defaults.spec.ts
@@ -126,6 +126,38 @@ describe('readTargetDefaultsForTarget (nested-array)', () => {
     expect(notMatched).toEqual({ cache: true });
   });
 
+  it('skips a projects filter without throwing when resolved with no project context', () => {
+    // Reproduces the crash hit by generators that read target defaults without
+    // a project (e.g. `@nx/vite`'s `getViteE2EWebServerInfo` reading a default
+    // port), which the `@nx/react-native`/`@nx/expo` app generators reach via
+    // `addE2e`. A `projects`-filtered entry cannot be evaluated with no project,
+    // so it is skipped rather than dereferencing an undefined project node.
+    const targetDefaults = {
+      test: [
+        { cache: true },
+        {
+          filter: { projects: ['tag:test-runner:vite'] },
+          inputs: ['vite.config.ts'],
+        },
+      ],
+    };
+    expect(() =>
+      readTargetDefaultsForTarget('test', targetDefaults)
+    ).not.toThrow();
+    expect(readTargetDefaultsForTarget('test', targetDefaults)).toEqual({
+      cache: true,
+    });
+  });
+
+  it('returns null (does not throw) for a target whose only entry is projects-filtered, with no project context', () => {
+    // The exact `getViteE2EWebServerInfo` shape: `readTargetDefaultsForTarget('dev', ...)`
+    // with no opts against a key that only has a projects-filtered entry.
+    const targetDefaults = {
+      dev: [{ filter: { projects: ['app'] }, options: { port: 5000 } }],
+    };
+    expect(readTargetDefaultsForTarget('dev', targetDefaults)).toBeNull();
+  });
+
   it('matches a filter.executor against the resolved executor', () => {
     const targetDefaults = {
       test: [

--- a/packages/nx/src/project-graph/utils/project-configuration/target-defaults.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-defaults.spec.ts
@@ -127,11 +127,8 @@ describe('readTargetDefaultsForTarget (nested-array)', () => {
   });
 
   it('skips a projects filter without throwing when resolved with no project context', () => {
-    // Reproduces the crash hit by generators that read target defaults without
-    // a project (e.g. `@nx/vite`'s `getViteE2EWebServerInfo` reading a default
-    // port), which the `@nx/react-native`/`@nx/expo` app generators reach via
-    // `addE2e`. A `projects`-filtered entry cannot be evaluated with no project,
-    // so it is skipped rather than dereferencing an undefined project node.
+    // Regression: generators read target defaults with no project context, e.g.
+    // getViteE2EWebServerInfo (reached by the RN/Expo app generators via addE2e).
     const targetDefaults = {
       test: [
         { cache: true },
@@ -150,8 +147,6 @@ describe('readTargetDefaultsForTarget (nested-array)', () => {
   });
 
   it('returns null (does not throw) for a target whose only entry is projects-filtered, with no project context', () => {
-    // The exact `getViteE2EWebServerInfo` shape: `readTargetDefaultsForTarget('dev', ...)`
-    // with no opts against a key that only has a projects-filtered entry.
     const targetDefaults = {
       dev: [{ filter: { projects: ['app'] }, options: { port: 5000 } }],
     };

--- a/packages/nx/src/project-graph/utils/project-configuration/target-defaults.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-defaults.ts
@@ -504,12 +504,8 @@ function entryFilterMatches(
   if (!filter) return true;
 
   if (filter.projects) {
-    // A `projects` filter can only be evaluated against a concrete project.
-    // When resolving target defaults with no project context (e.g. reading a
-    // default port via `readTargetDefaultsForTarget(target, targetDefaults)`
-    // with no `opts`), there is no project to test, so the filter cannot match
-    // — and passing the absent node to `findMatchingProjects` would dereference
-    // `undefined`. Treat it as a non-match instead of throwing.
+    // No project context: a `projects` filter can't match, and passing the
+    // absent node to `findMatchingProjects` would dereference undefined.
     if (!ctx.projectName || !ctx.projectNode) {
       return false;
     }

--- a/packages/nx/src/project-graph/utils/project-configuration/target-defaults.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-defaults.ts
@@ -504,6 +504,15 @@ function entryFilterMatches(
   if (!filter) return true;
 
   if (filter.projects) {
+    // A `projects` filter can only be evaluated against a concrete project.
+    // When resolving target defaults with no project context (e.g. reading a
+    // default port via `readTargetDefaultsForTarget(target, targetDefaults)`
+    // with no `opts`), there is no project to test, so the filter cannot match
+    // — and passing the absent node to `findMatchingProjects` would dereference
+    // `undefined`. Treat it as a non-match instead of throwing.
+    if (!ctx.projectName || !ctx.projectNode) {
+      return false;
+    }
     const matched = findMatchingProjects([...filter.projects], {
       [ctx.projectName]: ctx.projectNode,
     });


### PR DESCRIPTION
## Current Behavior

`readTargetDefaultsForTarget(target, targetDefaults)` crashes when a `targetDefaults` entry uses the new nested-array shape with a `projects` filter and the function is called **without a project context** (no `projectName`/`projectNode` in `opts`).

`entryFilterMatches` passes the absent project node to `findMatchingProjects` as `{ [undefined]: undefined }`, which then dereferences the missing node:

```
TypeError: Cannot read properties of undefined (reading 'data')
    at addMatchingProjectsByDirectory (find-matching-projects.js)
    at findMatchingProjects
    at entryFilterMatches
    at mergeMatchingEntries → resolveTargetDefault → readTargetDefaultsForTarget
```

(depending on the matcher branch, the same undefined node can also surface as `Cannot convert undefined or null to object`.)

This is reachable from real generators: `@nx/vite`'s `getViteE2EWebServerInfo` reads a default port via `readTargetDefaultsForTarget('dev' | 'serve', nxJson.targetDefaults)` with no project context, and the **`@nx/react-native` and `@nx/expo` application generators** hit it through `addE2e`. On a workspace that has any projects-filtered target default, `nx generate @nx/react-native:app` / `@nx/expo:app` crashes. This surfaced as failing `e2e-expo` / `e2e-react-native` macOS CI tasks and reproduces deterministically with a minimal workspace.

The filtered-array `targetDefaults` shape was introduced in #36049.

## Expected Behavior

A `projects` filter cannot be evaluated without a concrete project to test against, so when `readTargetDefaultsForTarget` is called with no project context the filtered entry is treated as a **non-match** (skipped) instead of throwing. Callers that just want an unfiltered/default value (like a default port) fall back cleanly.

The fix guards the `filter.projects` branch in `entryFilterMatches`: if there is no `projectName`/`projectNode`, return `false` before calling `findMatchingProjects`.

Added two regression tests in `target-defaults.spec.ts` (the exact `getViteE2EWebServerInfo` shapes). Verified they **fail on the unpatched source** with `Cannot read properties of undefined (reading 'data')` and **pass with the fix** (25/25 green).

## Related Issue(s)

Fixes the `@nx/react-native` / `@nx/expo` app-generator crash observed on the nx 23.1.0-rc.0 migration. Same root change (#36049, the `TargetDefaultValue` nested-array shape) as the nx-console typecheck fix in the linked Polygraph session.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Migrate-nrwl-repos-to-nx-23.1.0-rc.0-b8c94700)
<!-- polygraph-session-end -->