### PR TITLE
fix(core): defer unresolved spread tokens when merging intermediate target configurations

### DIFF
--- a/packages/nx/src/generators/utils/project-configuration.spec.ts
+++ b/packages/nx/src/generators/utils/project-configuration.spec.ts
@@ -137,6 +137,30 @@ describe('project configuration', () => {
     expect(tree.exists('test/project.json')).toBeFalsy();
   });
 
+  it('should round-trip spread tokens through read + update', () => {
+    // `'...'` only resolves during project-graph construction. Generators
+    // read the raw file, so the token must survive read → update unchanged.
+    writeJson(tree, 'libs/test/project.json', {
+      name: 'test',
+      targets: {
+        build: {
+          inputs: ['...', '{projectRoot}/extra.json'],
+        },
+      },
+    });
+
+    const config = readProjectConfiguration(tree, 'test');
+    expect(config.targets.build.inputs).toEqual([
+      '...',
+      '{projectRoot}/extra.json',
+    ]);
+
+    updateProjectConfiguration(tree, 'test', config);
+    expect(
+      readJson(tree, 'libs/test/project.json').targets.build.inputs
+    ).toEqual(['...', '{projectRoot}/extra.json']);
+  });
+
   describe('JSON schema', () => {
     it('should have JSON $schema in project configuration for standalone projects', () => {
       addProjectConfiguration(tree, 'test', projectConfiguration, true);

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
@@ -22,6 +22,7 @@ import type {
   ConfigurationSourceMaps,
   SourceInformation,
 } from './project-configuration/source-maps';
+import { readTargetsFromPackageJson } from '../../utils/package-json';
 
 describe('findMatchingConfigFiles', () => {
   const files = [
@@ -605,6 +606,68 @@ describe('project-configuration-utils', () => {
       // The target defaults override specified, so base is ['from-defaults']
       // Then project.json's ['explicit', '...'] expands to ['explicit', 'from-defaults']
       expect(buildTarget.inputs).toEqual(['explicit', 'from-defaults']);
+    });
+
+    it('should resolve spread tokens from package.json script target augmentation against target defaults', () => {
+      // https://github.com/nrwl/nx/issues/36235 — `nx.targets.build` augments
+      // the script-derived target inside the package.json reader. The `'...'`
+      // has no base there and must survive the reader's internal merge to
+      // expand against targetDefaults in the pipeline.
+      const targets = readTargetsFromPackageJson(
+        {
+          name: 'app-1',
+          version: '1.0.0',
+          private: true,
+          scripts: { build: 'echo hi' },
+          nx: {
+            targets: {
+              build: {
+                inputs: ['...', '{projectRoot}/package.json'],
+              },
+            },
+          },
+        },
+        {},
+        'app-1',
+        '/tmp/test',
+        { run: (script: string) => `pnpm run ${script}` } as any
+      );
+
+      const defaultResults = [
+        [
+          [
+            'nx/core/package-json-workspaces',
+            'app-1/package.json',
+            {
+              projects: {
+                'app-1': { name: 'app-1', root: 'app-1', targets },
+              },
+            },
+          ],
+        ],
+      ] as const;
+
+      const errors = [];
+      const result = mergeCreateNodesResults(
+        [],
+        defaultResults as any,
+        {
+          targetDefaults: {
+            build: {
+              inputs: ['{workspaceRoot}/pnpm-lock.yaml'],
+            },
+          },
+        },
+        '/tmp/test',
+        errors
+      );
+
+      const buildTarget = result.projectRootMap['app-1'].targets!['build'];
+      expect(buildTarget.inputs).toEqual([
+        '{workspaceRoot}/pnpm-lock.yaml',
+        '{projectRoot}/package.json',
+      ]);
+      expect(errors).toEqual([]);
     });
 
     it('should handle empty specified results', () => {

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -367,9 +367,7 @@ export function mergeCreateNodesResults(
       intermediateDefaultRootMap,
       project,
       defaultConfigurationSourceMaps,
-      sourceInfo,
-      false,
-      true
+      sourceInfo
     );
   };
 

--- a/packages/nx/src/project-graph/utils/project-configuration/project-nodes-manager.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/project-nodes-manager.ts
@@ -31,7 +31,9 @@ export function mergeProjectConfigurationIntoRootMap(
   // This function is used when reading project configuration
   // in generators, where we don't want to do this.
   skipTargetNormalization?: boolean,
-  deferSpreadsWithoutBase?: boolean
+  // Preserve `'...'` spreads that have no base value (default) so a later
+  // merge layer can resolve them; pass `false` only for a final merge.
+  deferSpreadsWithoutBase: boolean = true
 ): {
   nameChanged: boolean;
 } {
@@ -319,11 +321,15 @@ export class ProjectNodesManager {
   ): void {
     const previousName = this.rootMap[project.root]?.name;
 
+    // This is a final apply — dangling `'...'` spreads must resolve (expand
+    // against the empty base) so they never leak into the project graph.
     mergeProjectConfigurationIntoRootMap(
       this.rootMap,
       project,
       configurationSourceMaps,
-      sourceInformation
+      sourceInformation,
+      undefined,
+      false
     );
 
     const merged = this.rootMap[project.root];

--- a/packages/nx/src/project-graph/utils/project-configuration/target-defaults.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-defaults.spec.ts
@@ -91,6 +91,17 @@ describe('readTargetDefaultsForTarget (nested-array)', () => {
         })
       ).toEqual({ cache: false, inputs: ['jest.config.ts'] });
     });
+
+    it('preserves an unresolvable spread token when merging multiple matching entries', () => {
+      // The merged result is an intermediate that later merges onto the
+      // plugin-provided target — a `'...'` with no base among the matching
+      // entries must survive for that downstream merge.
+      expect(
+        readTargetDefaultsForTarget('test', {
+          test: [{ cache: true }, { inputs: ['...', 'extra'] }],
+        })
+      ).toEqual({ cache: true, inputs: ['...', 'extra'] });
+    });
   });
 
   it('matches a projects filter against the project node', () => {

--- a/packages/nx/src/project-graph/utils/project-configuration/target-defaults.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-defaults.ts
@@ -484,9 +484,9 @@ function mergeMatchingEntries(
   for (const entry of entries) {
     if (!entryFilterMatches(entry.filter, ctx)) continue;
     const config = stripFilter(entry);
-    // A lone matching entry is returned without merging so deferred `'...'`
-    // spread tokens survive for the downstream merge; only a second match
-    // triggers a merge, later entry winning.
+    // Later matches merge on top, earlier entry as base. Unresolvable `'...'`
+    // spreads are deferred by default so they survive for the downstream
+    // merge against the plugin-provided target.
     acc = acc === null ? config : mergeTargetConfigurations(config, acc);
   }
   return acc;

--- a/packages/nx/src/project-graph/utils/project-configuration/target-merging.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-merging.ts
@@ -372,6 +372,10 @@ function mergeConfigurations<T extends Object>(
  * @param projectConfigSourceMap The source map to be filled with metadata about where each property came from
  * @param sourceInformation The metadata about where the new target was defined
  * @param targetIdentifier The identifier for the target to merge, used for source map
+ * @param deferSpreadsWithoutBase Whether a `'...'` spread with no base value is preserved
+ * for a later merge layer to resolve (default), or expanded against the empty base and
+ * dropped. Pass `false` only for a final merge whose result is consumed directly rather
+ * than merged onto a lower-priority base.
  * @returns A merged target configuration
  */
 export function mergeTargetConfigurations(
@@ -380,7 +384,7 @@ export function mergeTargetConfigurations(
   projectConfigSourceMap?: Record<string, SourceInformation>,
   sourceInformation?: SourceInformation,
   targetIdentifier?: string,
-  deferSpreadsWithoutBase?: boolean
+  deferSpreadsWithoutBase: boolean = true
 ): TargetConfiguration {
   const {
     configurations: defaultConfigurations,

--- a/packages/nx/src/utils/package-json.spec.ts
+++ b/packages/nx/src/utils/package-json.spec.ts
@@ -358,6 +358,34 @@ describe('readTargetsFromPackageJson', () => {
     `);
   });
 
+  it('should preserve unresolved spread tokens when extending script based targets', () => {
+    // https://github.com/nrwl/nx/issues/36235 — the script-derived target has
+    // no `inputs`, so the `'...'` cannot resolve here. It must survive into
+    // the plugin result so the graph pipeline can expand it against
+    // targetDefaults / specified plugin values.
+    const result = readTargetsFromPackageJson(
+      {
+        name: 'my-other-app',
+        version: '',
+        scripts: {
+          build: 'echo 1',
+        },
+        nx: {
+          targets: {
+            build: {
+              inputs: ['...', '{projectRoot}/package.json'],
+            },
+          },
+        },
+      },
+      {},
+      workspaceRoot,
+      '/root',
+      packageManagerCommand
+    );
+    expect(result.build.inputs).toEqual(['...', '{projectRoot}/package.json']);
+  });
+
   it('should override scripts if provided an executor', () => {
     const result = readTargetsFromPackageJson(
       {


### PR DESCRIPTION
## Current Behavior

A `'...'` spread token defined in a package.json's `nx.targets` is silently dropped when the target also has a matching npm script. `readTargetsFromPackageJson` merges the `nx.targets` augmentation onto the script-derived target with spread resolution enabled; since the script target has no value for the spread key (e.g. `inputs`), the token expands against an empty base and disappears from the plugin result. By the time the project-graph pipeline merges targetDefaults — the layer the token was meant to pull in — there is no token left to resolve, so the defaults are lost entirely.

Given the reproduction from #36235 (`targetDefaults.build.inputs: ["{workspaceRoot}/pnpm-lock.yaml"]`, package.json `nx.targets.build.inputs: ["...", "{packageRoot}/package.json"]`, and a `build` script), the resolved inputs are `["{packageRoot}/package.json"]`.

The same class of bug exists in two other merges that produce intermediate configurations:

- `mergeMatchingEntries` (targetDefaults): when two or more array entries match, a dangling spread in a later entry is dropped instead of surviving for the downstream merge onto the plugin-provided target.
- Generator configuration reads (`readProjectConfiguration` → `updateProjectConfiguration`): a `'...'` authored in project.json is stripped from the file on round-trip.

## Expected Behavior

Unresolvable `'...'` spread tokens survive intermediate merges and resolve at the merge layer that actually has a base. The repro now resolves `build.inputs` to `["{workspaceRoot}/pnpm-lock.yaml", "{packageRoot}/package.json"]`.

Implementation: `deferSpreadsWithoutBase` now defaults to `true` in `mergeTargetConfigurations` and `mergeProjectConfigurationIntoRootMap` — deferring is what every intermediate-producing call site needs. The one final-apply site, `ProjectNodesManager#mergeProjectNode` (which covers specified-plugin results, targetDefaults results, and the intermediate replay), passes explicit `false` so dangling tokens always expand-or-drop there and a literal `'...'` can never leak into the project graph.

Regression tests (all verified failing before the fix):

- package.json reader preserves the token when augmenting a script target
- end-to-end `mergeCreateNodesResults` replication of #36235
- multi-entry targetDefaults preserve a dangling spread
- `'...'` round-trips through generator read + update

## Related Issue(s)

Fixes #36235

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/spread-intermediates-bd814e27)
<!-- polygraph-session-end -->