### PR TITLE
chore(repo): add dotnet restore postinstall

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "check-codeowners": "tsx ./scripts/check-codeowners.ts",
     "nx-release": "nx nx-release @nx/nx-source --parallel 8",
     "prepublishOnly": "node ./scripts/update-package-group.js",
+    "postinstall": "dotnet restore || echo 'needs dotnet restore'",
     "local-registry": "nx local-registry @nx/nx-source",
     "submit-plugin": "node ./scripts/submit-plugin.js",
     "prepare": "is-ci || husky",


### PR DESCRIPTION
Adds a postinstall script to this repo's package.json so `dotnet restore` should run automatically