### PR TITLE
fix(core): include root package.json dependencies for '.'-rooted projects

### DIFF
--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/explicit-package-json-dependencies.spec.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/explicit-package-json-dependencies.spec.ts
@@ -380,4 +380,103 @@ describe('explicit package json dependencies', () => {
       ])
     );
   });
+
+  it('should add dependencies from the root package.json of a project rooted at "."', async () => {
+    const rootTempFs = new TempFs('explicit-package-json-root');
+    const rootProjectsConfigurations = {
+      projects: {
+        'root-package': { root: '.', name: 'root-package' },
+        'child-package': {
+          root: 'packages/child-package',
+          name: 'child-package',
+        },
+      },
+    };
+
+    await rootTempFs.createFiles({
+      './nx.json': JSON.stringify({}),
+      './tsconfig.base.json': JSON.stringify({}),
+      './package.json': JSON.stringify({
+        name: 'root-package',
+        dependencies: { 'child-package': 'file:packages/child-package' },
+      }),
+      './packages/child-package/package.json': JSON.stringify({
+        name: 'child-package',
+        version: '1.0.0',
+      }),
+    });
+
+    const rootProjects = {
+      'root-package': {
+        name: 'root-package',
+        type: 'lib',
+        data: {
+          root: '.',
+          metadata: {
+            js: {
+              packageName: 'root-package',
+              packageExports: undefined,
+              isInPackageManagerWorkspaces: true,
+            },
+          },
+        },
+      },
+      'child-package': {
+        name: 'child-package',
+        type: 'lib',
+        data: {
+          root: 'packages/child-package',
+          metadata: {
+            js: {
+              packageName: 'child-package',
+              packageExports: undefined,
+              isInPackageManagerWorkspaces: true,
+            },
+          },
+        },
+      },
+    };
+
+    const rootFileMap = createFileMap(
+      rootProjectsConfigurations as any,
+      await getAllFileDataInContext(rootTempFs.tempDir)
+    ).fileMap;
+
+    const builder = new ProjectGraphBuilder(
+      undefined,
+      rootFileMap.projectFileMap
+    );
+    Object.values(rootProjects).forEach((p) => {
+      builder.addNode(p as any);
+    });
+
+    const rootCtx = {
+      fileMap: rootFileMap,
+      externalNodes: builder.getUpdatedProjectGraph().externalNodes,
+      projects: rootProjectsConfigurations.projects,
+      nxJsonConfiguration: {},
+      filesToProcess: rootFileMap,
+      workspaceRoot: rootTempFs.tempDir,
+    } as any;
+
+    const targetProjectLocator = new TargetProjectLocator(
+      rootProjects as any,
+      rootCtx.externalNodes,
+      new Map()
+    );
+
+    const res = buildExplicitPackageJsonDependencies(
+      rootCtx,
+      targetProjectLocator
+    );
+
+    expect(res).toContainEqual({
+      source: 'root-package',
+      target: 'child-package',
+      sourceFile: 'package.json',
+      type: 'static',
+    });
+
+    rootTempFs.cleanup();
+  });
 });

--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/explicit-package-json-dependencies.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/explicit-package-json-dependencies.ts
@@ -36,7 +36,9 @@ function isPackageJsonAtProjectRoot(
   if (!fileName.endsWith('package.json')) {
     return false;
   }
-  const filePath = fileName.slice(0, -13);
+  // A root-level package.json has no directory prefix, so its project root is '.';
+  // every other manifest sits at '<root>/package.json'.
+  const filePath = fileName === 'package.json' ? '.' : fileName.slice(0, -13);
   return !!roots[filePath];
 }
 


### PR DESCRIPTION
## Current Behavior

Since Nx 22.3.0, Nx does not create project-graph dependencies from the root `package.json` when that package is represented as a project rooted at `"."` (for example a Lerna workspace that lists `"."` as a package). Both the root and child projects are discovered, but the root project's dependencies are missing from `graph.dependencies`, so consumers of the graph treat dependent projects as independent and may run them concurrently instead of topologically.

## Expected Behavior

The root project's `package.json` dependencies are included in the project graph, so a root project that depends on a workspace project shows that dependency.

## Implementation Details

`isPackageJsonAtProjectRoot` derives a file's project root by stripping the trailing `/package.json` from its path and matching it against the known project roots. A root-level manifest is just `package.json` with no directory prefix, so the derived path was `''` and never matched the `.` project root, causing its dependencies to be skipped. The root manifest is now matched explicitly.

The regression was introduced in 22.3.0 by #33791, which replaced a full project-path match with the stripped-suffix lookup. Releases before 22.3.0 are unaffected, so an upgrade that skips the 22.3.x line (for example 22.0.x straight to 23.x) surfaces it as a 23.x change.

## Related Issue(s)

Fixes #36290

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/gh-36290-2b279c59)
<!-- polygraph-session-end -->
