### PR TITLE
feat(storybook): update Storybook to support Angular 22

### DIFF
--- a/packages/storybook/migrations.json
+++ b/packages/storybook/migrations.json
@@ -335,6 +335,106 @@
           "alwaysAddToPackageJson": false
         }
       }
+    },
+    "23.1.0": {
+      "version": "23.1.0-rc.3",
+      "requires": {
+        "storybook": ">=10.0.0 <10.5.0"
+      },
+      "packages": {
+        "@storybook/angular": {
+          "version": "^10.5.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/react": {
+          "version": "^10.5.0",
+          "alwaysAddToPackageJson": false
+        },
+        "storybook": {
+          "version": "^10.5.0",
+          "alwaysAddToPackageJson": true
+        },
+        "@storybook/addon-onboarding": {
+          "version": "^10.5.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/addon-themes": {
+          "version": "^10.5.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/builder-webpack5": {
+          "version": "^10.5.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/core-webpack": {
+          "version": "^10.5.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/html": {
+          "version": "^10.5.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/html-vite": {
+          "version": "^10.5.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/nextjs": {
+          "version": "^10.5.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/preact": {
+          "version": "^10.5.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/preact-vite": {
+          "version": "^10.5.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/react-vite": {
+          "version": "^10.5.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/react-webpack5": {
+          "version": "^10.5.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/server": {
+          "version": "^10.5.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/server-webpack5": {
+          "version": "^10.5.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/svelte": {
+          "version": "^10.5.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/svelte-vite": {
+          "version": "^10.5.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/sveltekit": {
+          "version": "^10.5.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/vue3": {
+          "version": "^10.5.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/vue3-vite": {
+          "version": "^10.5.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/web-components": {
+          "version": "^10.5.0",
+          "alwaysAddToPackageJson": false
+        },
+        "@storybook/web-components-vite": {
+          "version": "^10.5.0",
+          "alwaysAddToPackageJson": false
+        }
+      }
     }
   }
 }

--- a/packages/storybook/src/utils/utilities.spec.ts
+++ b/packages/storybook/src/utils/utilities.spec.ts
@@ -213,7 +213,7 @@ describe('testing utilities', () => {
           })
         );
         const version = getStorybookVersionToInstall(tree);
-        expect(version).toBe('^10.1.0');
+        expect(version).toBe('^10.5.0');
       });
 
       it('should return the v8 install constant when v8 is installed', () => {
@@ -242,7 +242,7 @@ describe('testing utilities', () => {
         );
         const version = getStorybookVersionToInstall(tree);
         // v7 is below the floor; no version map entry — fall through to latest.
-        expect(version).toBe('^10.1.0');
+        expect(version).toBe('^10.5.0');
       });
 
       it('should return the v9 install constant when v9 is installed via dependencies', () => {

--- a/packages/storybook/src/utils/versions.ts
+++ b/packages/storybook/src/utils/versions.ts
@@ -10,7 +10,7 @@ export const tsLibVersion = '^2.3.0';
 export const minSupportedStorybookVersion = '8.0.0';
 
 // Fresh-install default. Latest supported major.
-export const storybookVersion = '^10.1.0';
+export const storybookVersion = '^10.5.0';
 export const reactVersion = '^18.2.0';
 export const viteVersion = '^6.0.0';
 
@@ -28,7 +28,7 @@ type CompatVersions = 8 | 9 | 10;
 const versionMap: Record<CompatVersions, StorybookVersions> = {
   8: { storybookVersion: '^8.6.11' },
   9: { storybookVersion: '^9.0.5' },
-  10: { storybookVersion: '^10.1.0' },
+  10: { storybookVersion: '^10.5.0' },
 };
 
 export function versions(tree: Tree): StorybookVersions {


### PR DESCRIPTION
## Current Behavior

Nx pins the fresh-install default and the Storybook 10 compatibility floor for `@storybook/angular` (and the other Storybook packages) at `^10.1.0`. Versions 10.1.0 through 10.4.x declare `@angular/core` and `@angular/compiler-cli` peers of `>=18.0.0 <22.0.0`, so they exclude Angular 22. Angular 22 workspaces cannot resolve a compatible `@storybook/angular` through Nx's version handling, and `nx migrate` never bumps existing 10.0-10.4 installs to a version that admits Angular 22.

## Expected Behavior

Storybook 10.5.0 raised the `@storybook/angular` peer ceiling to `>=18.0.0 <23.0.0`, admitting Angular 22. The fresh-install default and the Storybook 10 compat entry now resolve to `^10.5.0`, and a new `packageJsonUpdates` migration upgrades existing Storybook 10.0-10.4 workspaces to `^10.5.0`. The peer floor is unchanged at `>=18.0.0`, so Angular 18-21 stay supported.

## Related Issue(s)

Fixes NXC-4537

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/nxc-4537-cf3f6f85)
<!-- polygraph-session-end -->