### PR TITLE
fix(core): resolve source-loaded plugin transitive workspace imports

### DIFF
--- a/e2e/plugin/src/nx-plugin-ts-solution.test.ts
+++ b/e2e/plugin/src/nx-plugin-ts-solution.test.ts
@@ -2,6 +2,8 @@ import {
   checkFilesExist,
   cleanupProject,
   createFile,
+  getPackageManagerCommand,
+  getSelectedPackageManager,
   newProject,
   readJson,
   renameFile,
@@ -511,6 +513,125 @@ exports.createNodesV2 = [
       'dist registered target'
     );
   });
+
+  it('should resolve a source-loaded local plugin transitive workspace import from source', async () => {
+    const plugin = uniq('plugin');
+    const lib = uniq('lib');
+    const marker = 'resolved-workspace-dep-from-source';
+    const pm = getSelectedPackageManager();
+
+    runCLI(`generate @nx/plugin:plugin packages/${plugin}`);
+
+    const sourceCondition =
+      readJson('tsconfig.base.json').compilerOptions.customConditions[0];
+    expect(sourceCondition).not.toBe('development');
+
+    // A sibling workspace package exposing its TS source via the workspace
+    // custom condition and its built output via `default`. Its `dist` is never
+    // built, so the plugin can only import it if source resolution wins.
+    createFile(
+      `packages/${lib}/package.json`,
+      JSON.stringify({
+        name: `@${workspaceName}/${lib}`,
+        version: '0.0.1',
+        main: './dist/index.js',
+        exports: {
+          './package.json': './package.json',
+          '.': {
+            [sourceCondition]: './src/index.ts',
+            default: './dist/index.js',
+          },
+        },
+      })
+    );
+    createFile(
+      `packages/${lib}/src/index.ts`,
+      `export const workspaceDepMarker = '${marker}';\n`
+    );
+
+    // The plugin's registered (source) entry statically imports the sibling
+    // package, so loading the plugin forces the transitive resolution of
+    // `@${workspaceName}/${lib}`.
+    updateFile(
+      `packages/${plugin}/src/plugins/deps/plugin.ts`,
+      `import { basename, dirname } from 'path';
+import type { CreateNodesV2 } from '@nx/devkit';
+import { workspaceDepMarker } from '@${workspaceName}/${lib}';
+
+type PluginOptions = { inferredTags: string[] };
+
+export const createNodesV2: CreateNodesV2<PluginOptions> = [
+  '**/my-project-file',
+  (files, options) =>
+    files.map((f) => {
+      const root = dirname(f);
+      const name = basename(root);
+      return [
+        f,
+        {
+          projects: {
+            [root]: {
+              root,
+              name,
+              targets: {
+                build: {
+                  executor: 'nx:run-commands',
+                  options: { command: \`echo '\${workspaceDepMarker}'\` },
+                },
+              },
+              tags: options.inferredTags,
+            },
+          },
+        },
+      ];
+    }),
+];
+`
+    );
+
+    updateJson(`packages/${plugin}/package.json`, (pkg) => {
+      pkg.dependencies ??= {};
+      pkg.dependencies[`@${workspaceName}/${lib}`] =
+        pm === 'pnpm' ? 'workspace:*' : '*';
+      pkg.exports = {
+        ...pkg.exports,
+        './deps': {
+          [sourceCondition]: './src/plugins/deps/plugin.ts',
+          default: './dist/plugins/deps/plugin.js',
+        },
+      };
+      return pkg;
+    });
+
+    updateJson(`nx.json`, (nxJson) => {
+      nxJson.plugins ??= [];
+      nxJson.plugins.push({
+        plugin: `@${workspaceName}/${plugin}/deps`,
+        options: { inferredTags: ['deps-tag'] },
+      });
+      return nxJson;
+    });
+
+    // Link the new package so the bare specifier resolves via node_modules.
+    runCommand(getPackageManagerCommand({ packageManager: pm }).install);
+
+    const inferredProject = uniq('deps-inferred');
+    createFile(
+      `packages/${inferredProject}/package.json`,
+      JSON.stringify({ name: inferredProject, version: '0.0.1' })
+    );
+    createFile(`packages/${inferredProject}/my-project-file`);
+
+    // The plugin loads from source during graph construction; its import of the
+    // sibling package must resolve to source (dist was never built). If it fell
+    // through to dist, plugin load would fail and the inferred target wouldn't
+    // exist.
+    const configuration = JSON.parse(
+      runCLI(`show project ${inferredProject} --json`)
+    );
+    expect(configuration.tags).toContain('deps-tag');
+    expect(runCLI(`build ${inferredProject}`)).toContain(marker);
+  }, 120000);
 
   it('should respect and support generating plugins with a name different than the import path', async () => {
     const plugin = uniq('plugin');

--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -24,6 +24,7 @@ import {
   PostTasksExecutionContext,
   PreTasksExecutionContext,
 } from '../../project-graph/plugins/public-api';
+import { getPluginResolveConditionNodeArgs } from '../../plugins/js/utils/typescript';
 import { preventRecursionInGraphConstruction } from '../../project-graph/project-graph';
 import { ConfigurationSourceMaps } from '../../project-graph/utils/project-configuration/source-maps';
 import { parseMessage } from '../../utils/consume-messages-from-socket';
@@ -1342,7 +1343,12 @@ export class DaemonClient {
 
     const backgroundProcess = spawn(
       process.execPath,
-      [join(__dirname, `../server/start.js`)],
+      [
+        // Spawn with the same resolve conditions Nx uses for plugin entries so a
+        // source-loaded plugin's transitive workspace imports resolve to source.
+        ...getPluginResolveConditionNodeArgs(),
+        join(__dirname, `../server/start.js`),
+      ],
       {
         cwd: workspaceRoot,
         stdio: ['ignore', out.fd, err.fd],

--- a/packages/nx/src/plugins/js/utils/register.ts
+++ b/packages/nx/src/plugins/js/utils/register.ts
@@ -416,6 +416,97 @@ const isInvokedByTsx: boolean = (() => {
   );
 })();
 
+let resolveConditionsInjected = false;
+
+/**
+ * Make Node's module resolver honor the given export conditions for the rest of
+ * the process, via `module.registerHooks()`. Used when a local plugin is loaded
+ * from source in-process (no child process to pass `--conditions` to at spawn):
+ * the hook appends the conditions to every resolution so the plugin's transitive
+ * workspace imports resolve to source the same way the plugin entry did.
+ *
+ * No-op when:
+ *   - `conditions` is empty (nothing to inject);
+ *   - every target condition is already active at startup (a spawned plugin
+ *     worker or daemon was launched with the full `--conditions` set, so Node's
+ *     resolver already honors them and the per-resolve hook would be redundant);
+ *   - `module.registerHooks` is unavailable (Node < 22.15 / < 23.5). Those
+ *     runtimes keep the `NODE_OPTIONS=--conditions` escape hatch.
+ *
+ * Idempotent and best-effort.
+ */
+export function ensureResolveConditionsInjected(conditions: string[]): void {
+  if (resolveConditionsInjected) return;
+  resolveConditionsInjected = true;
+
+  if (!conditions.length) return;
+
+  // Skip only when Node already honors every target condition (e.g. a worker or
+  // daemon spawned with the full `--conditions` set); a partial overlap still
+  // needs the hook to add the missing ones.
+  const activeConditions = getConditionsActiveAtStartup();
+  if (conditions.every((condition) => activeConditions.has(condition))) return;
+
+  const module = require('node:module') as typeof import('node:module');
+  const registerHooks = (
+    module as typeof module & {
+      registerHooks?: (opts: {
+        resolve?: (
+          specifier: string,
+          context: { conditions?: string[] },
+          nextResolve: (specifier: string, context?: unknown) => unknown
+        ) => unknown;
+      }) => unknown;
+    }
+  ).registerHooks;
+  if (typeof registerHooks !== 'function') return;
+
+  try {
+    registerHooks.call(module, {
+      resolve(specifier, context, nextResolve) {
+        const merged = context.conditions
+          ? [...context.conditions, ...conditions]
+          : conditions;
+        return nextResolve(specifier, { ...context, conditions: merged });
+      },
+    });
+  } catch {
+    // Best-effort: leave Node's native resolution in place rather than failing.
+  }
+}
+
+/**
+ * Export conditions this process was started with, parsed from `--conditions`
+ * (or its `-C` alias) in `process.execArgv` and `NODE_OPTIONS`. Node's resolver
+ * already honors these, so the injected hook only needs to cover target
+ * conditions not present here.
+ */
+function getConditionsActiveAtStartup(): Set<string> {
+  const active = new Set<string>();
+  const collect = (tokens: string[]) => {
+    for (let i = 0; i < tokens.length; i++) {
+      const token = tokens[i];
+      if (token === '--conditions' || token === '-C') {
+        const value = tokens[i + 1];
+        if (value) {
+          active.add(value);
+          i++;
+        }
+      } else if (token.startsWith('--conditions=')) {
+        active.add(token.slice('--conditions='.length));
+      } else if (token.startsWith('-C=')) {
+        active.add(token.slice('-C='.length));
+      }
+    }
+  };
+
+  collect(process.execArgv ?? []);
+  const nodeOptions = process.env.NODE_OPTIONS;
+  if (nodeOptions) collect(nodeOptions.split(/\s+/).filter(Boolean));
+
+  return active;
+}
+
 /**
  * Whether the current Node.js runtime exposes native TypeScript type
  * stripping. This is the authoritative gate - it correctly handles every

--- a/packages/nx/src/plugins/js/utils/typescript.ts
+++ b/packages/nx/src/plugins/js/utils/typescript.ts
@@ -158,6 +158,23 @@ export function getRootTsConfigResolveExportsConditions(
     : [...conditions, 'development'];
 }
 
+/**
+ * Node `--conditions <name>` CLI args for spawning a plugin worker or the daemon
+ * with the plugin-resolution conditions active at startup. Mirrors the set Nx
+ * uses to resolve the plugin entry (`getRootTsConfigResolveExportsConditions`)
+ * so the entry and the plugin's transitive workspace imports resolve the same
+ * way; Node's own resolver otherwise ignores TypeScript `customConditions` and a
+ * source-loaded plugin's imports land on their unbuilt `dist`.
+ */
+export function getPluginResolveConditionNodeArgs(
+  root: string = workspaceRoot
+): string[] {
+  return getRootTsConfigResolveExportsConditions(root).flatMap((c) => [
+    '--conditions',
+    c,
+  ]);
+}
+
 export function findNodes(
   node: Node,
   kind: SyntaxKind | SyntaxKind[],

--- a/packages/nx/src/project-graph/plugins/isolation/isolated-plugin.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/isolated-plugin.ts
@@ -11,6 +11,7 @@ import {
   consumeMessagesFromSocket,
   parseMessage,
 } from '../../../utils/consume-messages-from-socket';
+import { getPluginResolveConditionNodeArgs } from '../../../plugins/js/utils/typescript';
 import { getNxRequirePaths } from '../../../utils/installation-directory';
 import { logger } from '../../../utils/logger';
 import { ProgressTopics } from '../../../utils/progress-topics';
@@ -559,6 +560,9 @@ async function startPluginWorker(name: string) {
   const worker = spawn(
     process.execPath,
     [
+      // Spawn the worker with the same resolve conditions Nx uses for plugin
+      // entries so the plugin's transitive workspace imports resolve to source.
+      ...getPluginResolveConditionNodeArgs(),
       ...(isWorkerTypescript ? ['--require', 'ts-node/register'] : []),
       workerPath,
       ipcPath,

--- a/packages/nx/src/project-graph/plugins/transpiler.ts
+++ b/packages/nx/src/project-graph/plugins/transpiler.ts
@@ -4,11 +4,15 @@ import type * as ts from 'typescript';
 import {
   ensureCjsResolverPatched,
   ensureNodeNextEsmResolverRegistered,
+  ensureResolveConditionsInjected,
   isNativeStripPreferred,
   registerTranspiler,
   registerTsConfigPaths,
 } from '../../plugins/js/utils/register';
-import { readTsConfigWithoutFiles } from '../../plugins/js/utils/typescript';
+import {
+  getRootTsConfigResolveExportsConditions,
+  readTsConfigWithoutFiles,
+} from '../../plugins/js/utils/typescript';
 import { workspaceRoot } from '../../utils/workspace-root';
 
 export let unregisterPluginTSTranspiler: (() => void) | null = null;
@@ -28,6 +32,13 @@ export function registerPluginTSTranspiler() {
   if (unregisterPluginTSTranspiler !== null) {
     return;
   }
+
+  // Align Node's runtime resolution with the source-first plugin entry so the
+  // plugin's transitive workspace imports don't fall through to unbuilt `dist`.
+  // A no-op inside a plugin worker/daemon already spawned with `--conditions`.
+  ensureResolveConditionsInjected(
+    getRootTsConfigResolveExportsConditions(workspaceRoot)
+  );
 
   if (isNativeStripPreferred()) {
     // Native strip handles `.ts` syntax but doesn't rewrite NodeNext-style


### PR DESCRIPTION
## Current Behavior

A local plugin registered in `nx.json` and loaded from its TypeScript source resolves its own entry through Nx's resolver, which honors the workspace tsconfig `customConditions`. Its transitive `import` of a sibling workspace library, though, goes through Node's resolver, which ignores those conditions and falls through to the library's unbuilt `dist`. Plugin loading then fails with `Cannot find module .../node_modules/@scope/lib/dist/index.js`, and the only workaround is to start Nx with `NODE_OPTIONS=--conditions=<condition>`.

## Expected Behavior

A source-loaded local plugin's transitive workspace imports resolve to source the same way the plugin entry does, with no extra `NODE_OPTIONS` and without building the library first.

## Implementation Details

Nx passes the plugin-entry resolve conditions (tsconfig `customConditions` plus the back-compat `development`) to Node so a transitive import resolves the same way the entry did:

- `--conditions` on the plugin worker spawn (`isolated-plugin.ts`) and the daemon spawn (`client.ts`), a startup flag both Node's ESM and CJS resolvers honor. This covers the default topology (isolated plugins and/or daemon on).
- An in-process `module.registerHooks` resolve hook (`register.ts`, wired from `registerPluginTSTranspiler`) for the case where the plugin loads in the client process itself (isolation and daemon both off) and there is no child process to pass the flag to. This path needs Node 22.15+/23.5+; older runtimes keep the documented `NODE_OPTIONS=--conditions` escape hatch.

An e2e test in `nx-plugin-ts-solution` registers a source plugin that imports an unbuilt sibling package and asserts the plugin loads and its inferred target resolves.

## Related Issue(s)

Fixes NXC-4672

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/nx-plugin-local-deps-4595129b)
<!-- polygraph-session-end -->
