### PR TITLE
fix(core): stop re-querying confirmed cache misses in task orchestrator

### DIFF
--- a/packages/nx/src/tasks-runner/task-orchestrator.spec.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.spec.ts
@@ -205,6 +205,7 @@ describe('TaskOrchestrator', () => {
         getBatch: jest.fn(async () => batchResults),
         copyFilesFromCache: jest.fn(),
       };
+      orchestrator.cacheMissedHashes = new Set();
       orchestrator.shouldCopyOutputsFromCacheBatch = jest.fn(
         async () => new Map()
       );
@@ -264,6 +265,129 @@ describe('TaskOrchestrator', () => {
       expect(
         orchestrator.options.lifeCycle.printTaskTerminalOutput
       ).toHaveBeenCalledWith(failing, 'failure', 'boom');
+    });
+  });
+
+  describe('cache miss memoization', () => {
+    const originalCacheFailures = process.env.NX_CACHE_FAILURES;
+
+    afterEach(() => {
+      if (originalCacheFailures === undefined) {
+        delete process.env.NX_CACHE_FAILURES;
+      } else {
+        process.env.NX_CACHE_FAILURES = originalCacheFailures;
+      }
+    });
+
+    function createTask(id: string): Task {
+      const [project, target] = id.split(':');
+      return {
+        id,
+        target: { project, target },
+        overrides: {},
+        outputs: [],
+        projectRoot: project,
+        cache: true,
+        parallelism: true,
+        hash: `${id}-hash`,
+      } as Task;
+    }
+
+    function createOrchestrator(batchResults: Map<string, any>) {
+      const orchestrator: any = Object.create(TaskOrchestrator.prototype);
+      orchestrator.cache = {
+        getBatch: jest.fn(async () => batchResults),
+      };
+      orchestrator.cacheMissedHashes = new Set();
+      return orchestrator;
+    }
+
+    it('should not re-query hashes already confirmed as misses', async () => {
+      const task = createTask('app:build');
+      const orchestrator = createOrchestrator(new Map());
+
+      expect(await orchestrator.fetchCacheHits([task])).toEqual([]);
+      expect(await orchestrator.fetchCacheHits([task])).toEqual([]);
+
+      expect(orchestrator.cache.getBatch).toHaveBeenCalledTimes(1);
+    });
+
+    it('should only query hashes not yet confirmed as misses', async () => {
+      const hit = createTask('app:test');
+      const miss = createTask('app:build');
+      const orchestrator = createOrchestrator(
+        new Map([[hit.hash, { code: 0, terminalOutput: 'ok', remote: false }]])
+      );
+
+      const firstHits = await orchestrator.fetchCacheHits([hit, miss]);
+      expect(firstHits.map((h: any) => h.task.id)).toEqual(['app:test']);
+
+      const secondHits = await orchestrator.fetchCacheHits([hit, miss]);
+      expect(secondHits.map((h: any) => h.task.id)).toEqual(['app:test']);
+      expect(orchestrator.cache.getBatch).toHaveBeenLastCalledWith([hit]);
+    });
+
+    it('should memoize cached failures as misses when they are not replayable', async () => {
+      const failing = createTask('app:lint');
+      const orchestrator = createOrchestrator(
+        new Map([
+          [failing.hash, { code: 1, terminalOutput: 'boom', remote: false }],
+        ])
+      );
+      delete process.env.NX_CACHE_FAILURES;
+
+      await orchestrator.fetchCacheHits([failing]);
+      await orchestrator.fetchCacheHits([failing]);
+
+      expect(orchestrator.cache.getBatch).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not memoize replayable cached failures when NX_CACHE_FAILURES is enabled', async () => {
+      const failing = createTask('app:lint');
+      const orchestrator = createOrchestrator(
+        new Map([
+          [failing.hash, { code: 1, terminalOutput: 'boom', remote: false }],
+        ])
+      );
+      process.env.NX_CACHE_FAILURES = 'true';
+
+      const hits = await orchestrator.fetchCacheHits([failing]);
+
+      expect(hits.map((h: any) => h.task.id)).toEqual(['app:lint']);
+      expect(orchestrator.cacheMissedHashes.has(failing.hash)).toBe(false);
+    });
+
+    it('should re-query a task after it is re-hashed to a new hash', async () => {
+      const task = createTask('app:build');
+      const orchestrator = createOrchestrator(new Map());
+
+      await orchestrator.fetchCacheHits([task]);
+      task.hash = 'app:build-rehash';
+      await orchestrator.fetchCacheHits([task]);
+
+      expect(orchestrator.cache.getBatch).toHaveBeenCalledTimes(2);
+      expect(orchestrator.cache.getBatch).toHaveBeenLastCalledWith([task]);
+    });
+
+    it('should skip bulk resolution entirely when every scheduled task is a known miss', async () => {
+      const task = createTask('app:build');
+      const orchestrator = createOrchestrator(new Map());
+      orchestrator.taskGraph = { tasks: { 'app:build': task } };
+      orchestrator.tasksSchedule = {
+        getAllScheduledTasks: () => ({ scheduledTasks: ['app:build'] }),
+      };
+      orchestrator.processedTasks = new Map();
+      orchestrator.groups = [];
+      orchestrator.options = {
+        parallel: 3,
+        lifeCycle: { scheduleTask: jest.fn() },
+      };
+
+      expect(await orchestrator.resolveCachedTasksBulk()).toBe(false);
+      expect(orchestrator.cache.getBatch).toHaveBeenCalledTimes(1);
+
+      expect(await orchestrator.resolveCachedTasksBulk()).toBe(false);
+      expect(orchestrator.cache.getBatch).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -134,6 +134,13 @@ export class TaskOrchestrator {
 
   private processedTasks = new Map<string, Promise<NodeJS.ProcessEnv>>();
 
+  // Hashes confirmed absent from the cache this run. A confirmed miss can
+  // only become a hit when the task itself runs — and then it leaves the
+  // schedule — so a missed hash never needs re-querying. Without this, a
+  // miss waiting for a worker slot is re-queried (including the remote
+  // retrieval) on every coordinator cycle.
+  private cacheMissedHashes = new Set<string>();
+
   private completedTasks = new Map<string, TaskStatus>();
   private waitingForTasks: Function[] = [];
   private pendingDiscreteWorkers = new Set<Promise<TaskResult | void>>();
@@ -477,9 +484,14 @@ export class TaskOrchestrator {
    * inside DbCache.getBatch.
    */
   private async fetchCacheHits(tasks: Task[]): Promise<CacheHit[]> {
-    const batchResults = await this.cache.getBatch(tasks);
+    const tasksToQuery = tasks.filter(
+      (t) => t.hash && !this.cacheMissedHashes.has(t.hash)
+    );
+    if (tasksToQuery.length === 0) return [];
+
+    const batchResults = await this.cache.getBatch(tasksToQuery);
     const cacheHits: CacheHit[] = [];
-    for (const task of tasks) {
+    for (const task of tasksToQuery) {
       const cachedResult = batchResults.get(task.hash);
       // Replay a cached result only under the same condition it was cached
       // under (shouldCacheTaskResult): successes always, failures only when
@@ -487,6 +499,8 @@ export class TaskOrchestrator {
       // written but never read back.
       if (cachedResult && this.shouldCacheTaskResult(task, cachedResult.code)) {
         cacheHits.push({ task, cachedResult });
+      } else {
+        this.cacheMissedHashes.add(task.hash);
       }
     }
     return cacheHits;
@@ -574,7 +588,9 @@ export class TaskOrchestrator {
    * The coordinator relies on this running unconditionally (when cache
    * is enabled): tasks dispatched in step 5 via runTaskDirectly skip
    * their own cache lookup on the assumption that this has already
-   * confirmed them as misses. Don't add length-based bails.
+   * confirmed them as misses. Excluding cacheMissedHashes preserves that
+   * invariant — every dispatched hash was queried exactly once — but
+   * don't add other length-based bails.
    */
   private async resolveCachedTasksBulk(): Promise<boolean> {
     const { scheduledTasks } = this.tasksSchedule.getAllScheduledTasks();
@@ -582,7 +598,12 @@ export class TaskOrchestrator {
     const candidates: Task[] = [];
     for (const id of scheduledTasks) {
       const task = this.taskGraph.tasks[id];
-      if (task.hash && !task.continuous && task.cache) {
+      if (
+        task.hash &&
+        !this.cacheMissedHashes.has(task.hash) &&
+        !task.continuous &&
+        task.cache
+      ) {
         candidates.push(task);
       }
     }


### PR DESCRIPTION
## Current Behavior

Since the warm-cache perf overhaul in #35172, `executeCoordinatorLoop` runs `resolveCachedTasksBulk()` at the top of every coordinator cycle, rebuilding its candidate list from `scheduledTasks` with no memoization of confirmed misses. Tasks only leave `scheduledTasks` when dispatched (parallelism-bounded) or completed, so a confirmed cache miss waiting for a worker slot is re-queried on every cycle — one local SQL lookup plus, for remote-cache users, one remote HTTP `retrieve()` per miss per cycle inside `DbCache.getBatch` (remote hits are persisted locally, but misses leave no tombstone).

For `N` cache-miss tasks at parallelism `P` this yields ~O(N²/P) cache lookups: ~88k lookups reported for ~1,500 tasks at `--parallel=12` (#35632). The incomplete-batch recursion in `applyFromCacheOrRunBatch` re-queries remaining batch tasks the same way. The pathology is invisible on warm-cache runs (all hits resolve in one cycle), and worst exactly where remote-cache cost matters most: cold runs.

## Expected Behavior

A miss confirmed once stays confirmed for the lifetime of the run — a confirmed miss can only become a hit when the task itself runs, at which point it leaves the schedule. Cache lookups are O(N): each unique hash is queried exactly once.

- `TaskOrchestrator` tracks confirmed-miss hashes in a per-run `cacheMissedHashes` set.
- `fetchCacheHits` filters its query list against the set and records new misses. The miss condition reuses `shouldCacheTaskResult`, so replayable cached failures (`NX_CACHE_FAILURES=true`, #35997) still count as hits.
- `resolveCachedTasksBulk` excludes known-missed candidates, so all-miss cycles early-exit without `closeGroup`/`openGroup` and lifecycle churn. The step-5 dispatch invariant (workers skip their own cache lookup because bulk resolution confirmed the miss) is preserved — every dispatched hash was still queried exactly once.
- Keying by hash keeps batch depsOutputs re-hashing correct: the re-hash produces a new hash, which is queried fresh.

Trade-off worth noting: a cache entry populated externally mid-run (e.g. a concurrent CI run of the same commit) is no longer picked up after the hash was confirmed missing — duplicated work at worst, never incorrectness.

Six new specs cover the memoization (re-query suppression, per-hash keying/re-hash behavior, `NX_CACHE_FAILURES` interplay, bulk-resolution early exit); four of them fail against the previous implementation.

## Related Issue(s)

Fixes #35632

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Investigate-issue-35632---task-orchestrator-cache-re-queries-e6c824cd)
<!-- polygraph-session-end -->