### PR TITLE
fix(core): unbreak pnpm 11 installs by acknowledging build-script deps from generators

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ env:
   PNPM_HOME: ~/.pnpm
   # Pin corepack to the pnpm version from packageManager. Without this, corepack
   # falls back to "latest" in directories that have no packageManager field
-  # (e.g. e2e temp dirs), pulling pnpm 11 and breaking install.
+  # (e.g. e2e temp dirs) instead of the repo's pinned pnpm.
   COREPACK_DEFAULT_TO_LATEST: '0'
 
 jobs:

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -343,6 +343,8 @@ jobs:
           npm_config_registry: http://localhost:4872
           # pnpm 11 reads pnpm_config_* env vars instead of npm_config_*
           pnpm_config_registry: http://localhost:4872
+          # pnpm 11's minimumReleaseAge policy rejects packages published < 24h ago
+          pnpm_config_minimum_release_age: '0'
           YARN_REGISTRY: http://localhost:4872
           CI: true
 
@@ -370,6 +372,8 @@ jobs:
           npm_config_registry: http://localhost:4872
           # pnpm 11 reads pnpm_config_* env vars instead of npm_config_*
           pnpm_config_registry: http://localhost:4872
+          # pnpm 11's minimumReleaseAge policy rejects packages published < 24h ago
+          pnpm_config_minimum_release_age: '0'
           YARN_REGISTRY: http://localhost:4872
           DEVELOPER_DIR: '/Applications/Xcode.app/Contents/Developer'
           CI: true

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -349,6 +349,9 @@ jobs:
           # undecided; keep pnpm 10's warn-and-skip and skip implicit dep checks
           pnpm_config_strict_dep_builds: 'false'
           pnpm_config_verify_deps_before_run: 'false'
+          # pnpm 11 ignores .npmrc prefer-frozen-lockfile; keep installs
+          # non-frozen so tests can edit package.json and re-install
+          pnpm_config_frozen_lockfile: 'false'
           YARN_REGISTRY: http://localhost:4872
           CI: true
 
@@ -382,6 +385,9 @@ jobs:
           # undecided; keep pnpm 10's warn-and-skip and skip implicit dep checks
           pnpm_config_strict_dep_builds: 'false'
           pnpm_config_verify_deps_before_run: 'false'
+          # pnpm 11 ignores .npmrc prefer-frozen-lockfile; keep installs
+          # non-frozen so tests can edit package.json and re-install
+          pnpm_config_frozen_lockfile: 'false'
           YARN_REGISTRY: http://localhost:4872
           DEVELOPER_DIR: '/Applications/Xcode.app/Contents/Developer'
           CI: true

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -345,6 +345,10 @@ jobs:
           pnpm_config_registry: http://localhost:4872
           # pnpm 11's minimumReleaseAge policy rejects packages published < 24h ago
           pnpm_config_minimum_release_age: '0'
+          # e2e installs plugins directly, leaving their transitive build scripts
+          # undecided; keep pnpm 10's warn-and-skip and skip implicit dep checks
+          pnpm_config_strict_dep_builds: 'false'
+          pnpm_config_verify_deps_before_run: 'false'
           YARN_REGISTRY: http://localhost:4872
           CI: true
 
@@ -374,6 +378,10 @@ jobs:
           pnpm_config_registry: http://localhost:4872
           # pnpm 11's minimumReleaseAge policy rejects packages published < 24h ago
           pnpm_config_minimum_release_age: '0'
+          # e2e installs plugins directly, leaving their transitive build scripts
+          # undecided; keep pnpm 10's warn-and-skip and skip implicit dep checks
+          pnpm_config_strict_dep_builds: 'false'
+          pnpm_config_verify_deps_before_run: 'false'
           YARN_REGISTRY: http://localhost:4872
           DEVELOPER_DIR: '/Applications/Xcode.app/Contents/Developer'
           CI: true

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -15,7 +15,7 @@ env:
   CYPRESS_CACHE_FOLDER: ${{ github.workspace }}/.cypress
   # Pin corepack to the pnpm version from packageManager. Without this, corepack
   # falls back to "latest" in directories that have no packageManager field
-  # (e.g. e2e temp dirs), pulling pnpm 11 and breaking install.
+  # (e.g. e2e temp dirs) instead of the repo's pinned pnpm.
   COREPACK_DEFAULT_TO_LATEST: '0'
 
 permissions: {}

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -341,17 +341,6 @@ jobs:
           NODE_OPTIONS: --max_old_space_size=8192
           SELECTED_PM: ${{ matrix.package_manager }}
           npm_config_registry: http://localhost:4872
-          # pnpm 11 reads pnpm_config_* env vars instead of npm_config_*
-          pnpm_config_registry: http://localhost:4872
-          # pnpm 11's minimumReleaseAge policy rejects packages published < 24h ago
-          pnpm_config_minimum_release_age: '0'
-          # e2e installs plugins directly, leaving their transitive build scripts
-          # undecided; keep pnpm 10's warn-and-skip and skip implicit dep checks
-          pnpm_config_strict_dep_builds: 'false'
-          pnpm_config_verify_deps_before_run: 'false'
-          # pnpm 11 ignores .npmrc prefer-frozen-lockfile; keep installs
-          # non-frozen so tests can edit package.json and re-install
-          pnpm_config_frozen_lockfile: 'false'
           YARN_REGISTRY: http://localhost:4872
           CI: true
 
@@ -377,17 +366,6 @@ jobs:
           NODE_OPTIONS: --max_old_space_size=8192
           SELECTED_PM: 'npm'
           npm_config_registry: http://localhost:4872
-          # pnpm 11 reads pnpm_config_* env vars instead of npm_config_*
-          pnpm_config_registry: http://localhost:4872
-          # pnpm 11's minimumReleaseAge policy rejects packages published < 24h ago
-          pnpm_config_minimum_release_age: '0'
-          # e2e installs plugins directly, leaving their transitive build scripts
-          # undecided; keep pnpm 10's warn-and-skip and skip implicit dep checks
-          pnpm_config_strict_dep_builds: 'false'
-          pnpm_config_verify_deps_before_run: 'false'
-          # pnpm 11 ignores .npmrc prefer-frozen-lockfile; keep installs
-          # non-frozen so tests can edit package.json and re-install
-          pnpm_config_frozen_lockfile: 'false'
           YARN_REGISTRY: http://localhost:4872
           DEVELOPER_DIR: '/Applications/Xcode.app/Contents/Developer'
           CI: true

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -341,6 +341,8 @@ jobs:
           NODE_OPTIONS: --max_old_space_size=8192
           SELECTED_PM: ${{ matrix.package_manager }}
           npm_config_registry: http://localhost:4872
+          # pnpm 11 reads pnpm_config_* env vars instead of npm_config_*
+          pnpm_config_registry: http://localhost:4872
           YARN_REGISTRY: http://localhost:4872
           CI: true
 
@@ -366,6 +368,8 @@ jobs:
           NODE_OPTIONS: --max_old_space_size=8192
           SELECTED_PM: 'npm'
           npm_config_registry: http://localhost:4872
+          # pnpm 11 reads pnpm_config_* env vars instead of npm_config_*
+          pnpm_config_registry: http://localhost:4872
           YARN_REGISTRY: http://localhost:4872
           DEVELOPER_DIR: '/Applications/Xcode.app/Contents/Developer'
           CI: true

--- a/.github/workflows/nightly/process-matrix.ts
+++ b/.github/workflows/nightly/process-matrix.ts
@@ -78,7 +78,8 @@ const matrixData: MatrixData = {
       package_managers: ['npm', 'pnpm', 'yarn'],
       // TODO: re-add '26.0.0' once playwright ships the yauzl fix for node 26 extract hang.
       // See https://github.com/microsoft/playwright/issues/40724
-      node_versions: ['22.13.0', '24.0.0'],
+      // Floors track @angular/cli engines (^22.22.3 || ^24.15.0): ng new refuses older.
+      node_versions: ['22.22.3', '24.15.0'],
       excluded: ['e2e-detox', 'e2e-react-native', 'e2e-expo']
     },
     // Docker is not supported on ARM-based macOS runners (no nested virtualization)
@@ -86,7 +87,7 @@ const matrixData: MatrixData = {
     // We may want to look into adding intel only for this docker case, at least until vm-in-vm works on latest macos
     // TODO: re-add '26.0.0' once playwright ships the yauzl fix for node 26 extract hang.
     // See https://github.com/microsoft/playwright/issues/40724
-    { os: 'macos-latest', os_name: 'MacOS', os_timeout: 90, package_managers: ['npm'], node_versions: ['24.0.0'], excluded: ['e2e-docker'] }
+    { os: 'macos-latest', os_name: 'MacOS', os_timeout: 90, package_managers: ['npm'], node_versions: ['24.15.0'], excluded: ['e2e-docker'] }
     // TODO (Jack): Fix Windows support as gradle fails when running nx build https://staging.nx.app/runs/LgD4vxGn8w?utm_source=pull-request&utm_medium=comment
     // { os: 'windows-latest', os_name: 'WinOS', os_timeout: 180, package_managers: ['npm'], node_versions: ['24.0.0'], excluded: ['e2e-detox', 'e2e-react-native', 'e2e-expo'] }
   ]

--- a/.nx/workflows/agents.yaml
+++ b/.nx/workflows/agents.yaml
@@ -7,8 +7,9 @@ common-env-vars: &common-env-vars
   NX_NATIVE_LOGGING: 'nx::native::db'
   # Pin corepack to the pnpm version from packageManager. Without this, corepack
   # falls back to "latest" in directories that have no packageManager field
-  # (e.g. e2e temp dirs created by create-nx-workspace), pulling pnpm 11 and
-  # breaking install. Same treatment as .github/workflows/{ci,e2e-matrix}.yml.
+  # (e.g. e2e temp dirs created by create-nx-workspace) instead of the repo's
+  # pinned pnpm. Same treatment as .github/workflows/{ci,e2e-matrix}.yml, which
+  # pair it with `corepack prepare --activate` (see the init step below).
   COREPACK_DEFAULT_TO_LATEST: '0'
   # These are need for build and link validation for next.js and astro apps
   NEXT_PUBLIC_ASTRO_URL: 'https://master--nx-docs.netlify.app'
@@ -31,11 +32,20 @@ common-init-steps: &common-init-steps
   - name: Setup toolchains
     uses: 'nrwl/nx-cloud-workflows/v6/workflow-steps/install-mise/main.yaml'
 
+  # Make the repo's pinned pnpm corepack's default so e2e temp dirs (no
+  # packageManager field) resolve it too, instead of corepack's bundled
+  # last-known-good version.
+  - name: Activate repo pnpm via corepack
+    script: |
+      corepack enable
+      corepack prepare --activate
+
   - name: Verify toolchain versions
     script: |
       echo "mise:   $(mise --version)"
       echo "node:   $(node --version)"
       echo "pnpm:   $(pnpm --version)"
+      echo "pnpm outside repo: $(cd $(mktemp -d) && pnpm --version)"
       echo "bun:    $(bun --version)"
       echo "rust:   $(rustc --version) - $(cargo --version)"
       echo "dotnet: $(dotnet --version)"

--- a/e2e/angular/src/module-federation-setup.ts
+++ b/e2e/angular/src/module-federation-setup.ts
@@ -25,8 +25,10 @@ export function setupModuleFederationTest(): ModuleFederationTestSetup {
 }
 
 export function cleanupModuleFederationTest(
-  setup: ModuleFederationTestSetup
+  setup: ModuleFederationTestSetup | undefined
 ): void {
   cleanupProject();
-  process.env.NX_E2E_VERBOSE_LOGGING = setup.oldVerboseLoggingValue;
+  // setup is undefined when setupModuleFederationTest itself failed; don't
+  // let cleanup throw and shadow the real error.
+  process.env.NX_E2E_VERBOSE_LOGGING = setup?.oldVerboseLoggingValue;
 }

--- a/e2e/gradle/project.json
+++ b/e2e/gradle/project.json
@@ -18,7 +18,11 @@
         "{workspaceRoot}/gradle/wrapper/gradle-wrapper.properties",
         "{workspaceRoot}/gradle.properties"
       ],
-      "dependsOn": ["...", ":gradle-project-graph:gradle:publishToMavenLocal"]
+      "dependsOn": [
+        "@nx/nx-source:populate-local-registry-storage",
+        "@nx/nx-source:local-registry-e2e",
+        ":gradle-project-graph:gradle:publishToMavenLocal"
+      ]
     },
     "e2e-ci--**/**": {
       "inputs": [
@@ -28,7 +32,11 @@
         "{workspaceRoot}/gradle/wrapper/gradle-wrapper.properties",
         "{workspaceRoot}/gradle.properties"
       ],
-      "dependsOn": ["...", ":gradle-project-graph:gradle:publishToMavenLocal"]
+      "dependsOn": [
+        "@nx/nx-source:populate-local-registry-storage",
+        "@nx/nx-source:local-registry-e2e",
+        ":gradle-project-graph:gradle:publishToMavenLocal"
+      ]
     }
   }
 }

--- a/e2e/gradle/project.json
+++ b/e2e/gradle/project.json
@@ -18,11 +18,7 @@
         "{workspaceRoot}/gradle/wrapper/gradle-wrapper.properties",
         "{workspaceRoot}/gradle.properties"
       ],
-      "dependsOn": [
-        "@nx/nx-source:populate-local-registry-storage",
-        "@nx/nx-source:local-registry-e2e",
-        ":gradle-project-graph:gradle:publishToMavenLocal"
-      ]
+      "dependsOn": ["...", ":gradle-project-graph:gradle:publishToMavenLocal"]
     },
     "e2e-ci--**/**": {
       "inputs": [
@@ -32,11 +28,7 @@
         "{workspaceRoot}/gradle/wrapper/gradle-wrapper.properties",
         "{workspaceRoot}/gradle.properties"
       ],
-      "dependsOn": [
-        "@nx/nx-source:populate-local-registry-storage",
-        "@nx/nx-source:local-registry-e2e",
-        ":gradle-project-graph:gradle:publishToMavenLocal"
-      ]
+      "dependsOn": ["...", ":gradle-project-graph:gradle:publishToMavenLocal"]
     }
   }
 }

--- a/e2e/gradle/project.json
+++ b/e2e/gradle/project.json
@@ -20,7 +20,7 @@
       ],
       "dependsOn": [
         "@nx/nx-source:populate-local-registry-storage",
-        "@nx/nx-source:local-registry",
+        "@nx/nx-source:local-registry-e2e",
         ":gradle-project-graph:gradle:publishToMavenLocal"
       ]
     },
@@ -34,7 +34,7 @@
       ],
       "dependsOn": [
         "@nx/nx-source:populate-local-registry-storage",
-        "@nx/nx-source:local-registry",
+        "@nx/nx-source:local-registry-e2e",
         ":gradle-project-graph:gradle:publishToMavenLocal"
       ]
     }

--- a/e2e/jest/src/jest.test.ts
+++ b/e2e/jest/src/jest.test.ts
@@ -2,8 +2,10 @@ import { stripIndents } from '@angular-devkit/core/src/utils/literals';
 import {
   cleanupProject,
   expectJestTestsToPass,
+  getSelectedPackageManager,
   getStrippedEnvironmentVariables,
   newProject,
+  readFile,
   runCLI,
   runCLIAsync,
   uniq,
@@ -24,6 +26,21 @@ describe('Jest', () => {
   it('should be able test projects using jest', async () => {
     await expectJestTestsToPass('@nx/js:lib --unitTestRunner=jest');
   }, 500000);
+
+  it('should record an allowBuilds decision for unrs-resolver on pnpm', () => {
+    if (getSelectedPackageManager() !== 'pnpm') {
+      return;
+    }
+
+    const name = uniq('lib');
+    runCLI(
+      `generate @nx/js:lib ${name} --unitTestRunner=jest --no-interactive`
+    );
+
+    // pnpm 11 refuses to install deps whose build scripts are neither allowed
+    // nor denied, so the jest init generator must have recorded a decision
+    expect(readFile('pnpm-workspace.yaml')).toContain('unrs-resolver: false');
+  }, 300_000);
 
   it('should be resilient against NODE_ENV values', async () => {
     const name = uniq('lib');

--- a/e2e/lerna-smoke-tests/src/lerna-smoke-tests.test.ts
+++ b/e2e/lerna-smoke-tests/src/lerna-smoke-tests.test.ts
@@ -67,11 +67,11 @@ describe('Lerna Smoke Tests', () => {
       result = result
         .replace(/.*\/node_modules\/.*\n/, '') // yarn adds "$ /node_modules/.bin/lerna run print-name" to the output
         .replace(/.*package-1@0.*\n/, '') // yarn output doesn't contain "> package-1@0.0.0 print-name"
-        .replace('$ echo test-package-1', '> echo test-package-1');
+        // npm and yarn echo the script command; pnpm 11 does not
+        .replace(/[$>] echo test-package-1\n/, '');
       expect(result).toMatchInlineSnapshot(`
 
                 > package-1:print-name
-                > echo test-package-1
                 test-package-1
                 Lerna (powered by Nx)   Successfully ran target print-name for project package-1
                 Run duration: {DURATION}

--- a/e2e/maven/project.json
+++ b/e2e/maven/project.json
@@ -9,14 +9,14 @@
     "e2e-local": {
       "dependsOn": [
         "@nx/nx-source:populate-local-registry-storage",
-        "@nx/nx-source:local-registry",
+        "@nx/nx-source:local-registry-e2e",
         "nx-maven-plugin:install"
       ]
     },
     "e2e-ci--**/**": {
       "dependsOn": [
         "@nx/nx-source:populate-local-registry-storage",
-        "@nx/nx-source:local-registry",
+        "@nx/nx-source:local-registry-e2e",
         "nx-maven-plugin:install"
       ]
     }

--- a/e2e/maven/project.json
+++ b/e2e/maven/project.json
@@ -7,10 +7,18 @@
   "// targets": "to see all targets run: nx show project e2e-maven --web",
   "targets": {
     "e2e-local": {
-      "dependsOn": ["...", "nx-maven-plugin:install"]
+      "dependsOn": [
+        "@nx/nx-source:populate-local-registry-storage",
+        "@nx/nx-source:local-registry-e2e",
+        "nx-maven-plugin:install"
+      ]
     },
     "e2e-ci--**/**": {
-      "dependsOn": ["...", "nx-maven-plugin:install"]
+      "dependsOn": [
+        "@nx/nx-source:populate-local-registry-storage",
+        "@nx/nx-source:local-registry-e2e",
+        "nx-maven-plugin:install"
+      ]
     }
   }
 }

--- a/e2e/maven/project.json
+++ b/e2e/maven/project.json
@@ -7,18 +7,10 @@
   "// targets": "to see all targets run: nx show project e2e-maven --web",
   "targets": {
     "e2e-local": {
-      "dependsOn": [
-        "@nx/nx-source:populate-local-registry-storage",
-        "@nx/nx-source:local-registry-e2e",
-        "nx-maven-plugin:install"
-      ]
+      "dependsOn": ["...", "nx-maven-plugin:install"]
     },
     "e2e-ci--**/**": {
-      "dependsOn": [
-        "@nx/nx-source:populate-local-registry-storage",
-        "@nx/nx-source:local-registry-e2e",
-        "nx-maven-plugin:install"
-      ]
+      "dependsOn": ["...", "nx-maven-plugin:install"]
     }
   }
 }

--- a/e2e/release/src/custom-registries.test.ts
+++ b/e2e/release/src/custom-registries.test.ts
@@ -233,7 +233,11 @@ describe('nx release - custom npm registries', () => {
     runCLI(`generate setup-verdaccio`);
 
     const process = await runCommandUntil(
-      `local-registry @proj/source --port=${verdaccioPort}`,
+      // location=none: this secondary registry must not touch the user-level npm
+      // config; every consumer passes --registry explicitly, and if this process
+      // is killed before its teardown runs, a mutated registry would leak to
+      // every later suite on the same machine (pnpm 11 resolves from ~/.npmrc).
+      `local-registry @proj/source --port=${verdaccioPort} --location none`,
       (output) => output.includes(`warn --- http address`)
     );
 

--- a/e2e/release/src/custom-registries.test.ts
+++ b/e2e/release/src/custom-registries.test.ts
@@ -233,10 +233,8 @@ describe('nx release - custom npm registries', () => {
     runCLI(`generate setup-verdaccio`);
 
     const process = await runCommandUntil(
-      // location=none: this secondary registry must not touch the user-level npm
-      // config; every consumer passes --registry explicitly, and if this process
-      // is killed before its teardown runs, a mutated registry would leak to
-      // every later suite on the same machine (pnpm 11 resolves from ~/.npmrc).
+      // location=none so a killed process can't leak registry config into
+      // ~/.npmrc; every consumer passes --registry explicitly instead
       `local-registry @proj/source --port=${verdaccioPort} --location none`,
       (output) => output.includes(`warn --- http address`)
     );

--- a/e2e/release/src/release-publishable-libraries-ts-solution.test.ts
+++ b/e2e/release/src/release-publishable-libraries-ts-solution.test.ts
@@ -180,10 +180,10 @@ describe('release publishable libraries in workspace with ts solution setup', ()
       📦  @proj/{project-name}@0.0.3
       === Tarball Contents ===
       XXB README.md
+      XXX.XXX kb dist/README.md
       XXB dist/index.d.ts
       XXB dist/index.esm.css
       XXB dist/index.esm.js
-      XXX.XXX kb dist/README.md
       XXB dist/src/index.d.ts
       XXB dist/src/index.d.ts.map
       XXB dist/src/lib/{project-name}.d.ts
@@ -301,10 +301,10 @@ describe('release publishable libraries in workspace with ts solution setup', ()
       📦  @proj/{project-name}@0.0.6
       === Tarball Contents ===
       XXB README.md
+      XXX.XXX kb dist/README.md
       XXB dist/index.cjs.js
       XXB dist/index.d.ts
       XXB dist/index.esm.js
-      XXX.XXX kb dist/README.md
       XXB dist/src/index.d.ts
       XXB dist/src/index.d.ts.map
       XXB dist/src/lib/{project-name}.d.ts

--- a/e2e/release/src/release.test.ts
+++ b/e2e/release/src/release.test.ts
@@ -17,6 +17,7 @@ import {
   runCommandUntil,
   tmpProjPath,
   uniq,
+  updateFile,
   updateJson,
 } from '@nx/e2e-utils';
 import { execSync } from 'node:child_process';
@@ -320,6 +321,15 @@ describe('nx release', () => {
       // every later suite on the same machine (pnpm 11 resolves from ~/.npmrc).
       `local-registry @proj/source --port=${verdaccioPort} --location none`,
       (output) => output.includes(`warn --- http address`)
+    );
+
+    // npm publish reads credentials from config files only (npx strips
+    // protected env keys like _authToken), so record a token for the custom
+    // registry in the workspace .npmrc.
+    updateFile(
+      '.npmrc',
+      (contents) =>
+        `${contents}\n//localhost:${verdaccioPort}/:_authToken=secretVerdaccioToken`
     );
 
     const versionOutput2 = runCLI(

--- a/e2e/release/src/release.test.ts
+++ b/e2e/release/src/release.test.ts
@@ -315,17 +315,14 @@ describe('nx release', () => {
     const verdaccioPort = 7190;
     const customRegistryUrl = `http://localhost:${verdaccioPort}`;
     const process = await runCommandUntil(
-      // location=none: this secondary registry must not touch the user-level npm
-      // config; every consumer passes --registry explicitly, and if this process
-      // is killed before its teardown runs, a mutated registry would leak to
-      // every later suite on the same machine (pnpm 11 resolves from ~/.npmrc).
+      // location=none so a killed process can't leak registry config into
+      // ~/.npmrc; every consumer passes --registry explicitly instead
       `local-registry @proj/source --port=${verdaccioPort} --location none`,
       (output) => output.includes(`warn --- http address`)
     );
 
-    // npm publish reads credentials from config files only (npx strips
-    // protected env keys like _authToken), so record a token for the custom
-    // registry in the workspace .npmrc.
+    // local-registry would normally record the auth token, but location=none
+    // excludes that; npm publish needs it in a config file
     updateFile(
       '.npmrc',
       (contents) =>

--- a/e2e/release/src/release.test.ts
+++ b/e2e/release/src/release.test.ts
@@ -314,7 +314,11 @@ describe('nx release', () => {
     const verdaccioPort = 7190;
     const customRegistryUrl = `http://localhost:${verdaccioPort}`;
     const process = await runCommandUntil(
-      `local-registry @proj/source --port=${verdaccioPort}`,
+      // location=none: this secondary registry must not touch the user-level npm
+      // config; every consumer passes --registry explicitly, and if this process
+      // is killed before its teardown runs, a mutated registry would leak to
+      // every later suite on the same machine (pnpm 11 resolves from ~/.npmrc).
+      `local-registry @proj/source --port=${verdaccioPort} --location none`,
       (output) => output.includes(`warn --- http address`)
     );
 

--- a/e2e/utils/create-project-utils.ts
+++ b/e2e/utils/create-project-utils.ts
@@ -626,13 +626,15 @@ export function newLernaWorkspace({
         '@nx/devkit': nxVersion,
       };
       if (packageManager === 'pnpm') {
-        json.pnpm = {
-          ...json.pnpm,
-          overrides: {
-            ...json.pnpm?.overrides,
-            ...overrides,
-          },
-        };
+        // pnpm 11 no longer reads the "pnpm" field in package.json; overrides
+        // live in pnpm-workspace.yaml.
+        updateFile(
+          'pnpm-workspace.yaml',
+          dump({
+            packages: ['packages/*'],
+            overrides,
+          })
+        );
       } else if (packageManager === 'yarn') {
         json.resolutions = {
           ...json.resolutions,

--- a/e2e/utils/create-project-utils.ts
+++ b/e2e/utils/create-project-utils.ts
@@ -9,7 +9,6 @@ import {
   updateJson,
 } from './file-utils';
 import {
-  detectPackageManager,
   e2eCwd,
   getLatestLernaVersion,
   getPublishedVersion,
@@ -177,17 +176,12 @@ export function newProject({
       // pnpm creates sym links to the pnpm store,
       // we need to run the install again after copying the temp folder
       try {
-        execSync(
-          `${getPackageManagerCommand().install}${pnpmLaxBuildsFlag(
-            projectDirectory
-          )}`,
-          {
-            cwd: projectDirectory,
-            stdio: 'pipe',
-            env: { CI: 'true', ...process.env },
-            encoding: 'utf-8',
-          }
-        );
+        execSync(getPackageManagerCommand().install, {
+          cwd: projectDirectory,
+          stdio: 'pipe',
+          env: { CI: 'true', ...process.env },
+          encoding: 'utf-8',
+        });
       } catch (e) {
         console.log('newProject() - reinstall pnpm dependencies failed');
         console.error('Full error:', e);
@@ -467,17 +461,6 @@ export function runCreatePlugin(
   }
 }
 
-/**
- * e2e tests install packages without running a generator first, so pnpm 11's
- * strict build gate would fail those installs; warn and skip like pnpm 10.
- * Generator-driven installs within tests remain strict.
- */
-function pnpmLaxBuildsFlag(cwd: string): string {
-  return detectPackageManager(cwd) === 'pnpm'
-    ? ' --config.strictDepBuilds=false'
-    : '';
-}
-
 export function packageInstall(
   pkg: string,
   projName?: string,
@@ -493,7 +476,7 @@ export function packageInstall(
 
   const command = `${
     mode === 'dev' ? pm.addDev : pm.addProd
-  } ${pkgsWithVersions}${pnpmLaxBuildsFlag(cwd)}`;
+  } ${pkgsWithVersions}`;
 
   try {
     const install = execSync(command, {
@@ -668,7 +651,7 @@ export function newLernaWorkspace({
           : packageManager === 'yarn'
             ? ' -W'
             : ''
-      }${pnpmLaxBuildsFlag(tmpProjPath())}`,
+      }`,
       {
         cwd: tmpProjPath(),
         stdio: isVerbose() ? 'inherit' : 'pipe',
@@ -692,7 +675,7 @@ export function newLernaWorkspace({
       });
     }
 
-    execSync(`${pm.install}${pnpmLaxBuildsFlag(tmpProjPath())}`, {
+    execSync(pm.install, {
       cwd: tmpProjPath(),
       stdio: isVerbose() ? 'inherit' : 'pipe',
       env: { CI: 'true', ...process.env },

--- a/e2e/utils/create-project-utils.ts
+++ b/e2e/utils/create-project-utils.ts
@@ -9,6 +9,7 @@ import {
   updateJson,
 } from './file-utils';
 import {
+  detectPackageManager,
   e2eCwd,
   getLatestLernaVersion,
   getPublishedVersion,
@@ -130,16 +131,6 @@ export function newProject({
         updateFile('.npmrc', 'prefer-frozen-lockfile=false');
       }
 
-      // e2e tests pnpm-add plugins with build-script deps without running a
-      // generator first, so pnpm 11's strict build gate would fail those
-      // installs; fall back to pnpm 10's warn-and-skip behavior.
-      if (packageManager === 'pnpm') {
-        updateFile(
-          'pnpm-workspace.yaml',
-          (content) => `${content.trimEnd()}\nstrictDepBuilds: false\n`
-        );
-      }
-
       let packagesToInstall: Array<NxPackage> = [];
       if (!packages) {
         console.warn(
@@ -186,12 +177,17 @@ export function newProject({
       // pnpm creates sym links to the pnpm store,
       // we need to run the install again after copying the temp folder
       try {
-        execSync(getPackageManagerCommand().install, {
-          cwd: projectDirectory,
-          stdio: 'pipe',
-          env: { CI: 'true', ...process.env },
-          encoding: 'utf-8',
-        });
+        execSync(
+          `${getPackageManagerCommand().install}${pnpmLaxBuildsFlag(
+            projectDirectory
+          )}`,
+          {
+            cwd: projectDirectory,
+            stdio: 'pipe',
+            env: { CI: 'true', ...process.env },
+            encoding: 'utf-8',
+          }
+        );
       } catch (e) {
         console.log('newProject() - reinstall pnpm dependencies failed');
         console.error('Full error:', e);
@@ -471,6 +467,17 @@ export function runCreatePlugin(
   }
 }
 
+/**
+ * e2e tests install packages without running a generator first, so pnpm 11's
+ * strict build gate would fail those installs; warn and skip like pnpm 10.
+ * Generator-driven installs within tests remain strict.
+ */
+function pnpmLaxBuildsFlag(cwd: string): string {
+  return detectPackageManager(cwd) === 'pnpm'
+    ? ' --config.strictDepBuilds=false'
+    : '';
+}
+
 export function packageInstall(
   pkg: string,
   projName?: string,
@@ -486,7 +493,7 @@ export function packageInstall(
 
   const command = `${
     mode === 'dev' ? pm.addDev : pm.addProd
-  } ${pkgsWithVersions}`;
+  } ${pkgsWithVersions}${pnpmLaxBuildsFlag(cwd)}`;
 
   try {
     const install = execSync(command, {
@@ -603,9 +610,6 @@ export function newLernaWorkspace({
         'pnpm-workspace.yaml',
         dump({
           packages: ['packages/*'],
-          // installing nx without acknowledging its build scripts would fail
-          // under pnpm 11's strict build gate; warn and skip like pnpm 10
-          strictDepBuilds: false,
         })
       );
       updateFile(
@@ -664,7 +668,7 @@ export function newLernaWorkspace({
           : packageManager === 'yarn'
             ? ' -W'
             : ''
-      }`,
+      }${pnpmLaxBuildsFlag(tmpProjPath())}`,
       {
         cwd: tmpProjPath(),
         stdio: isVerbose() ? 'inherit' : 'pipe',
@@ -688,7 +692,7 @@ export function newLernaWorkspace({
       });
     }
 
-    execSync(pm.install, {
+    execSync(`${pm.install}${pnpmLaxBuildsFlag(tmpProjPath())}`, {
       cwd: tmpProjPath(),
       stdio: isVerbose() ? 'inherit' : 'pipe',
       env: { CI: 'true', ...process.env },

--- a/e2e/utils/create-project-utils.ts
+++ b/e2e/utils/create-project-utils.ts
@@ -130,6 +130,16 @@ export function newProject({
         updateFile('.npmrc', 'prefer-frozen-lockfile=false');
       }
 
+      // e2e tests pnpm-add plugins with build-script deps without running a
+      // generator first, so pnpm 11's strict build gate would fail those
+      // installs; fall back to pnpm 10's warn-and-skip behavior.
+      if (packageManager === 'pnpm') {
+        updateFile(
+          'pnpm-workspace.yaml',
+          (content) => `${content.trimEnd()}\nstrictDepBuilds: false\n`
+        );
+      }
+
       let packagesToInstall: Array<NxPackage> = [];
       if (!packages) {
         console.warn(
@@ -593,6 +603,9 @@ export function newLernaWorkspace({
         'pnpm-workspace.yaml',
         dump({
           packages: ['packages/*'],
+          // installing nx without acknowledging its build scripts would fail
+          // under pnpm 11's strict build gate; warn and skip like pnpm 10
+          strictDepBuilds: false,
         })
       );
       updateFile(

--- a/e2e/utils/create-project-utils.ts
+++ b/e2e/utils/create-project-utils.ts
@@ -124,11 +124,20 @@ export function newProject({
         createNxWorkspaceEnd.name
       );
 
+      // npm strips protected config keys like _authToken from the env it
+      // passes to child processes (npx nx ...), so npm publish needs the
+      // token in a config file; the workspace .npmrc keeps it scoped to the
+      // test project instead of mutating user-level config.
+      const registryPort = process.env.NX_LOCAL_REGISTRY_PORT ?? '4873';
+      const npmrcLines = [
+        `//localhost:${registryPort}/:_authToken=secretVerdaccioToken`,
+      ];
       // Workaround: pnpm defaults to frozen-lockfile in CI, but e2e tests
       // dynamically add packages after workspace creation
       if (isCI && packageManager === 'pnpm') {
-        updateFile('.npmrc', 'prefer-frozen-lockfile=false');
+        npmrcLines.unshift('prefer-frozen-lockfile=false');
       }
+      updateFile('.npmrc', npmrcLines.join('\n'));
 
       let packagesToInstall: Array<NxPackage> = [];
       if (!packages) {

--- a/e2e/utils/global-setup.ts
+++ b/e2e/utils/global-setup.ts
@@ -74,6 +74,11 @@ export default async function (globalConfig: Config.ConfigGlobals) {
     // implicit install-before-run entirely.
     process.env.pnpm_config_strict_dep_builds = 'false';
     process.env.pnpm_config_verify_deps_before_run = 'false';
+    // pnpm 11 no longer reads pnpm settings from .npmrc, so the workspace
+    // prefer-frozen-lockfile=false workaround stopped applying; without this,
+    // tests that edit a package.json and re-run `pnpm install` fail in CI
+    // where frozen-lockfile defaults to true.
+    process.env.pnpm_config_frozen_lockfile = 'false';
 
     // bun
     process.env.BUN_CONFIG_REGISTRY = registry;

--- a/e2e/utils/global-setup.ts
+++ b/e2e/utils/global-setup.ts
@@ -67,6 +67,13 @@ export default async function (globalConfig: Config.ConfigGlobals) {
     // pnpm 11's minimumReleaseAge policy rejects packages published < 24h
     // ago; everything e2e installs was just published to the local registry.
     process.env.pnpm_config_minimum_release_age = '0';
+    // e2e installs plugin packages directly (no generator records allowBuilds
+    // decisions for their transitive deps), and pnpm 11 re-checks the whole
+    // workspace strictly on every implicit deps check (`pnpm exec nx ...`),
+    // so restore pnpm 10's warn-and-skip for the whole harness and skip the
+    // implicit install-before-run entirely.
+    process.env.pnpm_config_strict_dep_builds = 'false';
+    process.env.pnpm_config_verify_deps_before_run = 'false';
 
     // bun
     process.env.BUN_CONFIG_REGISTRY = registry;

--- a/e2e/utils/global-setup.ts
+++ b/e2e/utils/global-setup.ts
@@ -64,6 +64,9 @@ export default async function (globalConfig: Config.ConfigGlobals) {
     process.env.pnpm_config_registry = registry;
     process.env[`pnpm_config_//${listenAddress}:${port}/:_authToken`] =
       authToken;
+    // pnpm 11's minimumReleaseAge policy rejects packages published < 24h
+    // ago; everything e2e installs was just published to the local registry.
+    process.env.pnpm_config_minimum_release_age = '0';
 
     // bun
     process.env.BUN_CONFIG_REGISTRY = registry;

--- a/e2e/utils/global-setup.ts
+++ b/e2e/utils/global-setup.ts
@@ -59,6 +59,11 @@ export default async function (globalConfig: Config.ConfigGlobals) {
     // Use environment variable instead of npm config command to avoid polluting other tests
     process.env[`npm_config_//${listenAddress}:${port}/:_authToken`] =
       authToken;
+    // pnpm 11 reads pnpm_config_* env vars instead of npm_config_*, and they
+    // take precedence over any registry a stray process wrote to ~/.npmrc.
+    process.env.pnpm_config_registry = registry;
+    process.env[`pnpm_config_//${listenAddress}:${port}/:_authToken`] =
+      authToken;
 
     // bun
     process.env.BUN_CONFIG_REGISTRY = registry;
@@ -83,6 +88,7 @@ export default async function (globalConfig: Config.ConfigGlobals) {
     global.e2eTeardown = () => {
       // Clean up environment variable instead of npm config command
       delete process.env[`npm_config_//${listenAddress}:${port}/:_authToken`];
+      delete process.env[`pnpm_config_//${listenAddress}:${port}/:_authToken`];
     };
 
     /**

--- a/nx.json
+++ b/nx.json
@@ -175,7 +175,7 @@
       "inputs": ["e2eInputs", "^production"],
       "dependsOn": [
         "@nx/nx-source:populate-local-registry-storage",
-        "@nx/nx-source:local-registry"
+        "@nx/nx-source:local-registry-e2e"
       ]
     },
     "e2e-ci": {
@@ -186,7 +186,7 @@
       "inputs": ["e2eInputs", "^production"],
       "dependsOn": [
         "@nx/nx-source:populate-local-registry-storage",
-        "@nx/nx-source:local-registry"
+        "@nx/nx-source:local-registry-e2e"
       ]
     },
     "e2e-macos-ci": {
@@ -196,7 +196,7 @@
       "inputs": ["e2eInputs", "^production"],
       "dependsOn": [
         "@nx/nx-source:populate-local-registry-storage",
-        "@nx/nx-source:local-registry"
+        "@nx/nx-source:local-registry-e2e"
       ],
       "options": {
         "args": ["--forceExit"]
@@ -206,7 +206,7 @@
       "inputs": ["e2eInputs", "^production"],
       "dependsOn": [
         "@nx/nx-source:populate-local-registry-storage",
-        "@nx/nx-source:local-registry"
+        "@nx/nx-source:local-registry-e2e"
       ]
     },
     "e2e-base": {

--- a/packages/cypress/src/generators/init/init.ts
+++ b/packages/cypress/src/generators/init/init.ts
@@ -72,9 +72,11 @@ function updateDependencies(tree: Tree, options: Schema) {
   };
   if (!getInstalledCypressVersion(tree)) {
     devDependencies.cypress = cypressVersion;
-    // cypress's postinstall downloads its binary; without it cypress cannot run.
+    // Nx never enables build scripts on the user's behalf. cypress's
+    // postinstall downloads its binary, so cypress prompts the user to run
+    // `pnpm approve-builds cypress` (or `cypress install`) on first use.
     acknowledgeBuildScripts(tree, detectPackageManager(tree.root), {
-      cypress: true,
+      cypress: false,
     });
   }
 

--- a/packages/cypress/src/generators/init/init.ts
+++ b/packages/cypress/src/generators/init/init.ts
@@ -1,11 +1,12 @@
 import {
-  acknowledgePnpmBuildScripts,
+  acknowledgeBuildScripts,
   addPlugin as _addPlugin,
   upsertTargetDefault,
 } from '@nx/devkit/internal';
 import {
   addDependenciesToPackageJson,
   createProjectGraphAsync,
+  detectPackageManager,
   formatFiles,
   GeneratorCallback,
   ProjectGraph,
@@ -72,7 +73,9 @@ function updateDependencies(tree: Tree, options: Schema) {
   if (!getInstalledCypressVersion(tree)) {
     devDependencies.cypress = cypressVersion;
     // cypress's postinstall downloads its binary; without it cypress cannot run.
-    acknowledgePnpmBuildScripts(tree, { cypress: true });
+    acknowledgeBuildScripts(tree, detectPackageManager(tree.root), {
+      cypress: true,
+    });
   }
 
   tasks.push(

--- a/packages/cypress/src/generators/init/init.ts
+++ b/packages/cypress/src/generators/init/init.ts
@@ -73,8 +73,9 @@ function updateDependencies(tree: Tree, options: Schema) {
   if (!getInstalledCypressVersion(tree)) {
     devDependencies.cypress = cypressVersion;
     // Nx never enables build scripts on the user's behalf. cypress's
-    // postinstall downloads its binary, so cypress prompts the user to run
-    // `pnpm approve-builds cypress` (or `cypress install`) on first use.
+    // postinstall downloads its binary; on first use cypress tells the user
+    // to run `cypress install` (works regardless of allowBuilds), or they can
+    // flip this entry to true and `pnpm rebuild cypress`.
     acknowledgeBuildScripts(tree, detectPackageManager(tree.root), {
       cypress: false,
     });

--- a/packages/cypress/src/generators/init/init.ts
+++ b/packages/cypress/src/generators/init/init.ts
@@ -1,4 +1,5 @@
 import {
+  acknowledgePnpmBuildScripts,
   addPlugin as _addPlugin,
   upsertTargetDefault,
 } from '@nx/devkit/internal';
@@ -70,6 +71,8 @@ function updateDependencies(tree: Tree, options: Schema) {
   };
   if (!getInstalledCypressVersion(tree)) {
     devDependencies.cypress = cypressVersion;
+    // cypress's postinstall downloads its binary; without it cypress cannot run.
+    acknowledgePnpmBuildScripts(tree, { cypress: true });
   }
 
   tasks.push(

--- a/packages/cypress/src/generators/init/init.ts
+++ b/packages/cypress/src/generators/init/init.ts
@@ -72,12 +72,11 @@ function updateDependencies(tree: Tree, options: Schema) {
   };
   if (!getInstalledCypressVersion(tree)) {
     devDependencies.cypress = cypressVersion;
-    // Nx never enables build scripts on the user's behalf. cypress's
-    // postinstall downloads its binary; on first use cypress tells the user
-    // to run `cypress install` (works regardless of allowBuilds), or they can
-    // flip this entry to true and `pnpm rebuild cypress`.
+    // The user explicitly asked for cypress, and its postinstall downloads
+    // the binary it needs to run at all, so enable it — npm and yarn run it
+    // unconditionally. Transitive deps stay denied.
     acknowledgeBuildScripts(tree, detectPackageManager(tree.root), {
-      cypress: false,
+      cypress: true,
     });
   }
 

--- a/packages/detox/src/generators/init/init.ts
+++ b/packages/detox/src/generators/init/init.ts
@@ -73,8 +73,9 @@ export async function detoxInitGeneratorInternal(host: Tree, schema: Schema) {
 
 export function updateDependencies(host: Tree, schema: Schema) {
   // Nx never enables build scripts on the user's behalf. detox's postinstall
-  // builds its framework cache; the user can run `pnpm approve-builds detox`
-  // (or `detox build-framework-cache`) to enable it.
+  // builds its framework cache; the user can run `detox build-framework-cache`
+  // (works regardless of allowBuilds), or flip this entry to true and
+  // `pnpm rebuild detox`.
   acknowledgeBuildScripts(host, detectPackageManager(host.root), {
     detox: false,
   });

--- a/packages/detox/src/generators/init/init.ts
+++ b/packages/detox/src/generators/init/init.ts
@@ -1,4 +1,4 @@
-import { addPlugin } from '@nx/devkit/internal';
+import { acknowledgePnpmBuildScripts, addPlugin } from '@nx/devkit/internal';
 import {
   addDependenciesToPackageJson,
   createProjectGraphAsync,
@@ -71,6 +71,8 @@ export async function detoxInitGeneratorInternal(host: Tree, schema: Schema) {
 }
 
 export function updateDependencies(host: Tree, schema: Schema) {
+  // detox's postinstall builds its framework cache; without it detox cannot run.
+  acknowledgePnpmBuildScripts(host, { detox: true });
   return addDependenciesToPackageJson(
     host,
     {},

--- a/packages/detox/src/generators/init/init.ts
+++ b/packages/detox/src/generators/init/init.ts
@@ -72,12 +72,11 @@ export async function detoxInitGeneratorInternal(host: Tree, schema: Schema) {
 }
 
 export function updateDependencies(host: Tree, schema: Schema) {
-  // Nx never enables build scripts on the user's behalf. detox's postinstall
-  // builds its framework cache; the user can run `detox build-framework-cache`
-  // (works regardless of allowBuilds), or flip this entry to true and
-  // `pnpm rebuild detox`.
+  // The user explicitly asked for detox, and its postinstall builds the
+  // framework cache it needs to run at all, so enable it — npm and yarn run
+  // it unconditionally. Transitive deps stay denied.
   acknowledgeBuildScripts(host, detectPackageManager(host.root), {
-    detox: false,
+    detox: true,
   });
   return addDependenciesToPackageJson(
     host,

--- a/packages/detox/src/generators/init/init.ts
+++ b/packages/detox/src/generators/init/init.ts
@@ -1,7 +1,8 @@
-import { acknowledgePnpmBuildScripts, addPlugin } from '@nx/devkit/internal';
+import { acknowledgeBuildScripts, addPlugin } from '@nx/devkit/internal';
 import {
   addDependenciesToPackageJson,
   createProjectGraphAsync,
+  detectPackageManager,
   formatFiles,
   GeneratorCallback,
   readNxJson,
@@ -72,7 +73,9 @@ export async function detoxInitGeneratorInternal(host: Tree, schema: Schema) {
 
 export function updateDependencies(host: Tree, schema: Schema) {
   // detox's postinstall builds its framework cache; without it detox cannot run.
-  acknowledgePnpmBuildScripts(host, { detox: true });
+  acknowledgeBuildScripts(host, detectPackageManager(host.root), {
+    detox: true,
+  });
   return addDependenciesToPackageJson(
     host,
     {},

--- a/packages/detox/src/generators/init/init.ts
+++ b/packages/detox/src/generators/init/init.ts
@@ -72,9 +72,11 @@ export async function detoxInitGeneratorInternal(host: Tree, schema: Schema) {
 }
 
 export function updateDependencies(host: Tree, schema: Schema) {
-  // detox's postinstall builds its framework cache; without it detox cannot run.
+  // Nx never enables build scripts on the user's behalf. detox's postinstall
+  // builds its framework cache; the user can run `pnpm approve-builds detox`
+  // (or `detox build-framework-cache`) to enable it.
   acknowledgeBuildScripts(host, detectPackageManager(host.root), {
-    detox: true,
+    detox: false,
   });
   return addDependenciesToPackageJson(
     host,

--- a/packages/devkit/internal.ts
+++ b/packages/devkit/internal.ts
@@ -10,6 +10,7 @@ export {
   SchemaResolutionError,
   resolvePrompt,
   PromptResolutionError,
+  acknowledgePnpmBuildScripts,
 } from 'nx/src/devkit-internals';
 
 // Generators

--- a/packages/devkit/internal.ts
+++ b/packages/devkit/internal.ts
@@ -10,7 +10,7 @@ export {
   SchemaResolutionError,
   resolvePrompt,
   PromptResolutionError,
-  acknowledgePnpmBuildScripts,
+  acknowledgeBuildScripts,
 } from 'nx/src/devkit-internals';
 
 // Generators

--- a/packages/esbuild/src/generators/init/init.ts
+++ b/packages/esbuild/src/generators/init/init.ts
@@ -1,11 +1,12 @@
 import {
   addDependenciesToPackageJson,
+  detectPackageManager,
   formatFiles,
   GeneratorCallback,
   getDependencyVersionFromPackageJson,
   Tree,
 } from '@nx/devkit';
-import { acknowledgePnpmBuildScripts } from '@nx/devkit/internal';
+import { acknowledgeBuildScripts } from '@nx/devkit/internal';
 import { esbuildVersion } from '@nx/js/internal';
 import { assertSupportedEsbuildVersion } from '../../utils/assert-supported-esbuild-version';
 import { nxVersion } from '../../utils/versions';
@@ -18,7 +19,9 @@ export async function esbuildInitGenerator(tree: Tree, schema: Schema) {
   if (!schema.skipPackageJson) {
     // esbuild's install script only validates the prebuilt binary shipped via
     // optional dependencies, so skip it.
-    acknowledgePnpmBuildScripts(tree, { esbuild: false });
+    acknowledgeBuildScripts(tree, detectPackageManager(tree.root), {
+      esbuild: false,
+    });
     installTask = addDependenciesToPackageJson(
       tree,
       {},

--- a/packages/esbuild/src/generators/init/init.ts
+++ b/packages/esbuild/src/generators/init/init.ts
@@ -5,6 +5,7 @@ import {
   getDependencyVersionFromPackageJson,
   Tree,
 } from '@nx/devkit';
+import { acknowledgePnpmBuildScripts } from '@nx/devkit/internal';
 import { esbuildVersion } from '@nx/js/internal';
 import { assertSupportedEsbuildVersion } from '../../utils/assert-supported-esbuild-version';
 import { nxVersion } from '../../utils/versions';
@@ -15,6 +16,9 @@ export async function esbuildInitGenerator(tree: Tree, schema: Schema) {
 
   let installTask: GeneratorCallback = () => {};
   if (!schema.skipPackageJson) {
+    // esbuild's install script only validates the prebuilt binary shipped via
+    // optional dependencies, so skip it.
+    acknowledgePnpmBuildScripts(tree, { esbuild: false });
     installTask = addDependenciesToPackageJson(
       tree,
       {},

--- a/packages/jest/src/generators/init/init.ts
+++ b/packages/jest/src/generators/init/init.ts
@@ -1,4 +1,5 @@
 import {
+  acknowledgePnpmBuildScripts,
   addPlugin,
   findTargetDefault,
   upsertTargetDefault,
@@ -97,6 +98,10 @@ function createJestDefaultPatch(
 
 function updateDependencies(tree: Tree, options: JestInitSchema) {
   const { jestVersion, nxVersion } = versions(tree);
+
+  // jest 30 pulls in unrs-resolver; its build scripts only compile a fallback
+  // for platforms without prebuilt binaries, so skip them.
+  acknowledgePnpmBuildScripts(tree, { 'unrs-resolver': false });
 
   return addDependenciesToPackageJson(
     tree,

--- a/packages/jest/src/generators/init/init.ts
+++ b/packages/jest/src/generators/init/init.ts
@@ -100,8 +100,9 @@ function createJestDefaultPatch(
 function updateDependencies(tree: Tree, options: JestInitSchema) {
   const { jestVersion, nxVersion } = versions(tree);
 
-  // jest 30 pulls in unrs-resolver; its build scripts only compile a fallback
-  // for platforms without prebuilt binaries, so skip them.
+  // jest 30 pulls in unrs-resolver; its postinstall only fetches a fallback
+  // binding for platforms not covered by its prebuilt optional dependencies,
+  // so skip it.
   acknowledgeBuildScripts(tree, detectPackageManager(tree.root), {
     'unrs-resolver': false,
   });

--- a/packages/jest/src/generators/init/init.ts
+++ b/packages/jest/src/generators/init/init.ts
@@ -1,5 +1,5 @@
 import {
-  acknowledgePnpmBuildScripts,
+  acknowledgeBuildScripts,
   addPlugin,
   findTargetDefault,
   upsertTargetDefault,
@@ -7,6 +7,7 @@ import {
 import {
   addDependenciesToPackageJson,
   createProjectGraphAsync,
+  detectPackageManager,
   formatFiles,
   readNxJson,
   removeDependenciesFromPackageJson,
@@ -101,7 +102,9 @@ function updateDependencies(tree: Tree, options: JestInitSchema) {
 
   // jest 30 pulls in unrs-resolver; its build scripts only compile a fallback
   // for platforms without prebuilt binaries, so skip them.
-  acknowledgePnpmBuildScripts(tree, { 'unrs-resolver': false });
+  acknowledgeBuildScripts(tree, detectPackageManager(tree.root), {
+    'unrs-resolver': false,
+  });
 
   return addDependenciesToPackageJson(
     tree,

--- a/packages/js/src/executors/release-publish/log-tar.ts
+++ b/packages/js/src/executors/release-publish/log-tar.ts
@@ -16,7 +16,8 @@ export const logTar = (tarball, opts = {}) => {
     const columnData = columnify(
       tarball.files
         .map((f) => {
-          const bytes = formatBytes(f.size, false);
+          const bytes =
+            typeof f.size === 'number' ? formatBytes(f.size, false) : '';
           return /^node_modules\//.test(f.path)
             ? null
             : { path: f.path, size: `${bytes}` };

--- a/packages/js/src/executors/release-publish/log-tar.ts
+++ b/packages/js/src/executors/release-publish/log-tar.ts
@@ -14,7 +14,10 @@ export const logTar = (tarball, opts = {}) => {
   if (tarball.files.length) {
     console.log('');
     const columnData = columnify(
-      tarball.files
+      // Sort for a stable listing: pnpm 11 orders files differently than
+      // npm and pnpm 10.
+      [...tarball.files]
+        .sort((a, b) => (a.path < b.path ? -1 : a.path > b.path ? 1 : 0))
         .map((f) => {
           const bytes =
             typeof f.size === 'number' ? formatBytes(f.size, false) : '';

--- a/packages/js/src/executors/release-publish/release-publish.impl.ts
+++ b/packages/js/src/executors/release-publish/release-publish.impl.ts
@@ -5,6 +5,7 @@ import {
   readJsonFile,
 } from '@nx/devkit';
 import { execSync } from 'child_process';
+import { statSync } from 'fs';
 import { env as appendLocalEnv } from 'npm-run-path';
 import { join } from 'path';
 import { isLocallyLinkedPackageVersion } from '../../utils/is-locally-linked-package-version';
@@ -481,6 +482,23 @@ function runPublish(ctx: RunPublishContext): { success: boolean } {
       return {
         success: false,
       };
+    }
+
+    // pnpm 11 dropped the per-file size field from its publish --json output,
+    // so recover the sizes from disk for the tarball contents log.
+    if (Array.isArray(jsonData.files)) {
+      for (const file of jsonData.files as Array<{
+        path?: string;
+        size?: number;
+      }>) {
+        if (typeof file.size !== 'number' && typeof file.path === 'string') {
+          try {
+            file.size = statSync(join(packageRoot, file.path)).size;
+          } catch {
+            // leave the size unknown, logTar omits it
+          }
+        }
+      }
     }
 
     if (isDryRun) {

--- a/packages/js/src/plugins/jest/start-local-registry.ts
+++ b/packages/js/src/plugins/jest/start-local-registry.ts
@@ -62,6 +62,12 @@ export function startLocalRegistry({
           }
         );
 
+        // pnpm 11 reads pnpm_config_* env vars instead of npm_config_*, and
+        // they take precedence over any registry configured in ~/.npmrc
+        process.env.pnpm_config_registry = registry;
+        process.env[`pnpm_config_//${listenAddress}:${port}/:_authToken`] =
+          authToken;
+
         // bun
         process.env.BUN_CONFIG_REGISTRY = registry;
         process.env.BUN_CONFIG_TOKEN = authToken;
@@ -71,7 +77,9 @@ export function startLocalRegistry({
         process.env.YARN_NPM_REGISTRY_SERVER = registry;
         process.env.YARN_UNSAFE_HTTP_WHITELIST = listenAddress;
 
-        console.log('Set npm, bun, and yarn config registry to ' + registry);
+        console.log(
+          'Set npm, pnpm, bun, and yarn config registry to ' + registry
+        );
 
         resolve(() => {
           childProcess.kill();

--- a/packages/js/src/utils/swc/add-swc-dependencies.ts
+++ b/packages/js/src/utils/swc/add-swc-dependencies.ts
@@ -1,10 +1,15 @@
 import { addDependenciesToPackageJson, Tree } from '@nx/devkit';
+import { acknowledgePnpmBuildScripts } from '@nx/devkit/internal';
 import {
   swcCliVersion,
   swcCoreVersion,
   swcHelpersVersion,
   swcNodeVersion,
 } from '../versions';
+
+// @swc/core's postinstall only compiles a fallback for platforms without
+// prebuilt binaries, so skip it.
+const swcAllowBuilds = { '@swc/core': false };
 
 export function getSwcDependencies(): {
   dependencies: Record<string, string>;
@@ -24,6 +29,7 @@ export function getSwcDependencies(): {
 export function addSwcDependencies(tree: Tree) {
   const { dependencies, devDependencies } = getSwcDependencies();
 
+  acknowledgePnpmBuildScripts(tree, swcAllowBuilds);
   return addDependenciesToPackageJson(
     tree,
     dependencies,
@@ -34,6 +40,7 @@ export function addSwcDependencies(tree: Tree) {
 }
 
 export function addSwcRegisterDependencies(tree: Tree) {
+  acknowledgePnpmBuildScripts(tree, swcAllowBuilds);
   return addDependenciesToPackageJson(
     tree,
     {},

--- a/packages/js/src/utils/swc/add-swc-dependencies.ts
+++ b/packages/js/src/utils/swc/add-swc-dependencies.ts
@@ -11,8 +11,8 @@ import {
   swcNodeVersion,
 } from '../versions';
 
-// @swc/core's postinstall only compiles a fallback for platforms without
-// prebuilt binaries, so skip it.
+// @swc/core's postinstall only installs a wasm fallback for platforms not
+// covered by its prebuilt optional dependencies, so skip it.
 const swcAllowBuilds = { '@swc/core': false };
 
 export function getSwcDependencies(): {

--- a/packages/js/src/utils/swc/add-swc-dependencies.ts
+++ b/packages/js/src/utils/swc/add-swc-dependencies.ts
@@ -1,5 +1,9 @@
-import { addDependenciesToPackageJson, Tree } from '@nx/devkit';
-import { acknowledgePnpmBuildScripts } from '@nx/devkit/internal';
+import {
+  addDependenciesToPackageJson,
+  detectPackageManager,
+  Tree,
+} from '@nx/devkit';
+import { acknowledgeBuildScripts } from '@nx/devkit/internal';
 import {
   swcCliVersion,
   swcCoreVersion,
@@ -29,7 +33,11 @@ export function getSwcDependencies(): {
 export function addSwcDependencies(tree: Tree) {
   const { dependencies, devDependencies } = getSwcDependencies();
 
-  acknowledgePnpmBuildScripts(tree, swcAllowBuilds);
+  acknowledgeBuildScripts(
+    tree,
+    detectPackageManager(tree.root),
+    swcAllowBuilds
+  );
   return addDependenciesToPackageJson(
     tree,
     dependencies,
@@ -40,7 +48,11 @@ export function addSwcDependencies(tree: Tree) {
 }
 
 export function addSwcRegisterDependencies(tree: Tree) {
-  acknowledgePnpmBuildScripts(tree, swcAllowBuilds);
+  acknowledgeBuildScripts(
+    tree,
+    detectPackageManager(tree.root),
+    swcAllowBuilds
+  );
   return addDependenciesToPackageJson(
     tree,
     {},

--- a/packages/nest/src/utils/ensure-dependencies.ts
+++ b/packages/nest/src/utils/ensure-dependencies.ts
@@ -1,6 +1,10 @@
 import type { GeneratorCallback, Tree } from '@nx/devkit';
-import { addDependenciesToPackageJson, joinPathFragments } from '@nx/devkit';
-import { acknowledgePnpmBuildScripts } from '@nx/devkit/internal';
+import {
+  addDependenciesToPackageJson,
+  detectPackageManager,
+  joinPathFragments,
+} from '@nx/devkit';
+import { acknowledgeBuildScripts } from '@nx/devkit/internal';
 import { tsLibVersion, versions } from './versions';
 
 export function ensureDependencies(
@@ -13,7 +17,9 @@ export function ensureDependencies(
 
   const pkgVersions = versions(tree);
   // @nestjs/core's postinstall only prints a funding message, so skip it.
-  acknowledgePnpmBuildScripts(tree, { '@nestjs/core': false });
+  acknowledgeBuildScripts(tree, detectPackageManager(tree.root), {
+    '@nestjs/core': false,
+  });
   return addDependenciesToPackageJson(
     tree,
     {

--- a/packages/nest/src/utils/ensure-dependencies.ts
+++ b/packages/nest/src/utils/ensure-dependencies.ts
@@ -1,5 +1,6 @@
 import type { GeneratorCallback, Tree } from '@nx/devkit';
 import { addDependenciesToPackageJson, joinPathFragments } from '@nx/devkit';
+import { acknowledgePnpmBuildScripts } from '@nx/devkit/internal';
 import { tsLibVersion, versions } from './versions';
 
 export function ensureDependencies(
@@ -11,6 +12,8 @@ export function ensureDependencies(
     : 'package.json';
 
   const pkgVersions = versions(tree);
+  // @nestjs/core's postinstall only prints a funding message, so skip it.
+  acknowledgePnpmBuildScripts(tree, { '@nestjs/core': false });
   return addDependenciesToPackageJson(
     tree,
     {

--- a/packages/nest/src/utils/ensure-dependencies.ts
+++ b/packages/nest/src/utils/ensure-dependencies.ts
@@ -16,7 +16,9 @@ export function ensureDependencies(
     : 'package.json';
 
   const pkgVersions = versions(tree);
-  // @nestjs/core's postinstall only prints a funding message, so skip it.
+  // @nestjs/core releases up to 11.1.24 had an opencollective funding-message
+  // postinstall (removed in 11.1.25); deny it so locked installs of those
+  // versions don't trip pnpm 11's build gate.
   acknowledgeBuildScripts(tree, detectPackageManager(tree.root), {
     '@nestjs/core': false,
   });

--- a/packages/nx/src/command-line/add/add.ts
+++ b/packages/nx/src/command-line/add/add.ts
@@ -54,10 +54,18 @@ async function installPackage(
     const pmc = getPackageManagerCommand(pm);
 
     // if we explicitly specify latest in yarn berry, it won't resolve the version
-    const command =
+    let command =
       pm === 'yarn' && gte(pmv, '2.0.0') && version === 'latest'
         ? `${pmc.addDev} ${pkgName}`
         : `${pmc.addDev} ${pkgName}@${version}`;
+
+    // pnpm 11+ fails the install when the plugin's own dependency tree
+    // carries unacknowledged build scripts, and the plugin's generators can
+    // only record allowBuilds decisions after this install. Warn and skip
+    // for this one install, like pnpm 10 did.
+    if (pm === 'pnpm' && gte(pmv, '11.0.0')) {
+      command += ' --config.strictDepBuilds=false';
+    }
     await new Promise<void>((resolve) =>
       exec(
         command,

--- a/packages/nx/src/command-line/import/import.ts
+++ b/packages/nx/src/command-line/import/import.ts
@@ -683,7 +683,11 @@ async function runInstallDestinationRepo(
     output.log({
       title: 'Installing dependencies for imported code',
     });
-    runInstall(workspaceRoot, getPackageManagerCommand(packageManager));
+    runInstall(
+      workspaceRoot,
+      packageManager,
+      getPackageManagerCommand(packageManager)
+    );
     await destinationGitClient.amendCommit();
   } catch (e) {
     installed = false;

--- a/packages/nx/src/command-line/init/configure-plugins.ts
+++ b/packages/nx/src/command-line/init/configure-plugins.ts
@@ -1,6 +1,7 @@
 import { bold } from 'picocolors';
 
 import {
+  detectPackageManager,
   getPackageManagerCommand,
   PackageManagerCommands,
 } from '../../utils/package-manager';
@@ -32,8 +33,9 @@ export function installPluginPackages(
     return;
   }
   if (existsSync(join(repoRoot, 'package.json'))) {
-    addDepsToPackageJson(repoRoot, plugins);
-    runInstall(repoRoot, pmc);
+    const packageManager = detectPackageManager(repoRoot);
+    addDepsToPackageJson(repoRoot, plugins, packageManager);
+    runInstall(repoRoot, packageManager, pmc);
   } else {
     const nxJson = readNxJson(repoRoot);
     nxJson.installation.plugins ??= {};

--- a/packages/nx/src/command-line/init/configure-plugins.ts
+++ b/packages/nx/src/command-line/init/configure-plugins.ts
@@ -34,7 +34,7 @@ export function installPluginPackages(
   }
   if (existsSync(join(repoRoot, 'package.json'))) {
     const packageManager = detectPackageManager(repoRoot);
-    addDepsToPackageJson(repoRoot, plugins, packageManager);
+    addDepsToPackageJson(repoRoot, packageManager, plugins);
     runInstall(repoRoot, packageManager, pmc);
   } else {
     const nxJson = readNxJson(repoRoot);

--- a/packages/nx/src/command-line/init/implementation/add-nx-to-monorepo.ts
+++ b/packages/nx/src/command-line/init/implementation/add-nx-to-monorepo.ts
@@ -115,7 +115,7 @@ export async function addNxToMonorepo(
 
   updateGitIgnore(repoRoot);
   const packageManager = detectPackageManager(repoRoot);
-  addDepsToPackageJson(repoRoot, undefined, packageManager);
+  addDepsToPackageJson(repoRoot, packageManager);
 
   output.log({ title: '📦 Installing dependencies' });
   runInstall(repoRoot, packageManager);

--- a/packages/nx/src/command-line/init/implementation/add-nx-to-monorepo.ts
+++ b/packages/nx/src/command-line/init/implementation/add-nx-to-monorepo.ts
@@ -5,6 +5,7 @@ import { join, relative } from 'path';
 import { InitArgs } from '../init-v1';
 import { readJsonFile } from '../../../utils/fileutils';
 import { output } from '../../../utils/output';
+import { detectPackageManager } from '../../../utils/package-manager';
 import {
   addDepsToPackageJson,
   createNxJsonFile,
@@ -113,10 +114,11 @@ export async function addNxToMonorepo(
   );
 
   updateGitIgnore(repoRoot);
-  addDepsToPackageJson(repoRoot);
+  const packageManager = detectPackageManager(repoRoot);
+  addDepsToPackageJson(repoRoot, undefined, packageManager);
 
   output.log({ title: '📦 Installing dependencies' });
-  runInstall(repoRoot);
+  runInstall(repoRoot, packageManager);
 
   if (nxCloudChoice === 'yes') {
     output.log({ title: '🛠️ Setting up Nx Cloud' });

--- a/packages/nx/src/command-line/init/implementation/add-nx-to-nest.ts
+++ b/packages/nx/src/command-line/init/implementation/add-nx-to-nest.ts
@@ -11,7 +11,10 @@ import {
 } from '../../../utils/fileutils';
 import { output } from '../../../utils/output';
 import { PackageJson } from '../../../utils/package-json';
-import { getPackageManagerCommand } from '../../../utils/package-manager';
+import {
+  detectPackageManager,
+  getPackageManagerCommand,
+} from '../../../utils/package-manager';
 import {
   addDepsToPackageJson,
   createNxJsonFile,
@@ -128,10 +131,11 @@ export async function addNxToNest(options: Options, packageJson: PackageJson) {
     scriptOutputs
   );
 
-  const pmc = getPackageManagerCommand();
+  const packageManager = detectPackageManager(repoRoot);
+  const pmc = getPackageManagerCommand(packageManager);
 
   updateGitIgnore(repoRoot);
-  addDepsToPackageJson(repoRoot);
+  addDepsToPackageJson(repoRoot, undefined, packageManager);
   addNestPluginToPackageJson(repoRoot);
   markRootPackageJsonAsNxProjectLegacy(repoRoot, cacheableOperations, pmc);
 
@@ -145,7 +149,7 @@ export async function addNxToNest(options: Options, packageJson: PackageJson) {
 
   output.log({ title: '📦 Installing dependencies' });
 
-  runInstall(repoRoot);
+  runInstall(repoRoot, packageManager, pmc);
 
   if (nxCloudChoice === 'yes') {
     output.log({ title: '🛠️ Setting up Nx Cloud' });

--- a/packages/nx/src/command-line/init/implementation/add-nx-to-nest.ts
+++ b/packages/nx/src/command-line/init/implementation/add-nx-to-nest.ts
@@ -135,7 +135,7 @@ export async function addNxToNest(options: Options, packageJson: PackageJson) {
   const pmc = getPackageManagerCommand(packageManager);
 
   updateGitIgnore(repoRoot);
-  addDepsToPackageJson(repoRoot, undefined, packageManager);
+  addDepsToPackageJson(repoRoot, packageManager);
   addNestPluginToPackageJson(repoRoot);
   markRootPackageJsonAsNxProjectLegacy(repoRoot, cacheableOperations, pmc);
 

--- a/packages/nx/src/command-line/init/implementation/add-nx-to-npm-repo.ts
+++ b/packages/nx/src/command-line/init/implementation/add-nx-to-npm-repo.ts
@@ -3,7 +3,10 @@ import { join } from 'path';
 import { InitArgs } from '../init-v1';
 import { readJsonFile } from '../../../utils/fileutils';
 import { output } from '../../../utils/output';
-import { getPackageManagerCommand } from '../../../utils/package-manager';
+import {
+  detectPackageManager,
+  getPackageManagerCommand,
+} from '../../../utils/package-manager';
 import {
   addDepsToPackageJson,
   createNxJsonFile,
@@ -89,10 +92,11 @@ export async function addNxToNpmRepo(options: Options, guided: boolean = true) {
 
   createNxJsonFile(repoRoot, [], cacheableOperations, scriptOutputs);
 
-  const pmc = getPackageManagerCommand();
+  const packageManager = detectPackageManager(repoRoot);
+  const pmc = getPackageManagerCommand(packageManager);
 
   updateGitIgnore(repoRoot);
-  addDepsToPackageJson(repoRoot);
+  addDepsToPackageJson(repoRoot, undefined, packageManager);
   if (options.legacy) {
     markRootPackageJsonAsNxProjectLegacy(repoRoot, cacheableOperations, pmc);
   } else {
@@ -101,7 +105,7 @@ export async function addNxToNpmRepo(options: Options, guided: boolean = true) {
 
   output.log({ title: '📦 Installing dependencies' });
 
-  runInstall(repoRoot, pmc);
+  runInstall(repoRoot, packageManager, pmc);
 
   if (nxCloudChoice === 'yes') {
     output.log({ title: '🛠️ Setting up Nx Cloud' });

--- a/packages/nx/src/command-line/init/implementation/add-nx-to-npm-repo.ts
+++ b/packages/nx/src/command-line/init/implementation/add-nx-to-npm-repo.ts
@@ -96,7 +96,7 @@ export async function addNxToNpmRepo(options: Options, guided: boolean = true) {
   const pmc = getPackageManagerCommand(packageManager);
 
   updateGitIgnore(repoRoot);
-  addDepsToPackageJson(repoRoot, undefined, packageManager);
+  addDepsToPackageJson(repoRoot, packageManager);
   if (options.legacy) {
     markRootPackageJsonAsNxProjectLegacy(repoRoot, cacheableOperations, pmc);
   } else {

--- a/packages/nx/src/command-line/init/implementation/add-nx-to-turborepo.ts
+++ b/packages/nx/src/command-line/init/implementation/add-nx-to-turborepo.ts
@@ -61,7 +61,7 @@ export async function addNxToTurborepo(_options: Options) {
   const pmc = getPackageManagerCommand(packageManager);
 
   updateGitIgnore(repoRoot);
-  addDepsToPackageJson(repoRoot, undefined, packageManager);
+  addDepsToPackageJson(repoRoot, packageManager);
 
   output.log({ title: '📦 Installing dependencies' });
 

--- a/packages/nx/src/command-line/init/implementation/add-nx-to-turborepo.ts
+++ b/packages/nx/src/command-line/init/implementation/add-nx-to-turborepo.ts
@@ -3,7 +3,10 @@ import { join } from 'node:path';
 import { readJsonFile, writeJsonFile } from '../../../utils/fileutils';
 import { handleImport } from '../../../utils/handle-import';
 import { output } from '../../../utils/output';
-import { getPackageManagerCommand } from '../../../utils/package-manager';
+import {
+  detectPackageManager,
+  getPackageManagerCommand,
+} from '../../../utils/package-manager';
 import { InitArgs } from '../init-v1';
 import {
   addDepsToPackageJson,
@@ -54,12 +57,13 @@ export async function addNxToTurborepo(_options: Options) {
     writeJsonFile(nxJsonPath, nxJson);
   }
 
-  const pmc = getPackageManagerCommand();
+  const packageManager = detectPackageManager(repoRoot);
+  const pmc = getPackageManagerCommand(packageManager);
 
   updateGitIgnore(repoRoot);
-  addDepsToPackageJson(repoRoot);
+  addDepsToPackageJson(repoRoot, undefined, packageManager);
 
   output.log({ title: '📦 Installing dependencies' });
 
-  runInstall(repoRoot, pmc);
+  runInstall(repoRoot, packageManager, pmc);
 }

--- a/packages/nx/src/command-line/init/implementation/angular/index.ts
+++ b/packages/nx/src/command-line/init/implementation/angular/index.ts
@@ -120,7 +120,7 @@ async function collectCacheableOperations(options: Options): Promise<string[]> {
 
 function installDependencies(): void {
   const packageManager = detectPackageManager(repoRoot);
-  addDepsToPackageJson(repoRoot, undefined, packageManager);
+  addDepsToPackageJson(repoRoot, packageManager);
   addPluginDependencies();
   runInstall(repoRoot, packageManager);
 }

--- a/packages/nx/src/command-line/init/implementation/angular/index.ts
+++ b/packages/nx/src/command-line/init/implementation/angular/index.ts
@@ -4,6 +4,7 @@ import { readJsonFile, writeJsonFile } from '../../../../utils/fileutils';
 import { nxVersion } from '../../../../utils/versions';
 import { sortObjectByKeys } from '../../../../utils/object-sort';
 import { output } from '../../../../utils/output';
+import { detectPackageManager } from '../../../../utils/package-manager';
 import {
   getDependencyVersionFromPackageJson,
   type PackageJson,
@@ -118,9 +119,10 @@ async function collectCacheableOperations(options: Options): Promise<string[]> {
 }
 
 function installDependencies(): void {
-  addDepsToPackageJson(repoRoot);
+  const packageManager = detectPackageManager(repoRoot);
+  addDepsToPackageJson(repoRoot, undefined, packageManager);
   addPluginDependencies();
-  runInstall(repoRoot);
+  runInstall(repoRoot, packageManager);
 }
 
 function addPluginDependencies(): void {

--- a/packages/nx/src/command-line/init/implementation/check-compatible-with-plugins.spec.ts
+++ b/packages/nx/src/command-line/init/implementation/check-compatible-with-plugins.spec.ts
@@ -52,8 +52,8 @@ describe('checkCompatibleWithPlugins', () => {
   it('should return incompatible plugin with excluded files if error is AggregateCreateNodesError', async () => {
     const error = new AggregateCreateNodesError(
       [
-        ['file1', undefined],
-        ['file2', undefined],
+        ['file1', new Error('failed to process file1')],
+        ['file2', new Error('failed to process file2')],
       ],
       []
     );
@@ -64,8 +64,8 @@ describe('checkCompatibleWithPlugins', () => {
     const result = await checkCompatibleWithPlugins();
     expect(result).toEqual({
       0: [
-        { file: 'file1', error: undefined },
-        { file: 'file2', error: undefined },
+        { file: 'file1', error: new Error('failed to process file1') },
+        { file: 'file2', error: new Error('failed to process file2') },
       ],
     });
   });
@@ -93,16 +93,16 @@ describe('checkCompatibleWithPlugins', () => {
     });
     const aggregateError0 = new AggregateCreateNodesError(
       [
-        ['file1', undefined],
-        ['file2', undefined],
+        ['file1', new Error('failed to process file1')],
+        ['file2', new Error('failed to process file2')],
       ],
       []
     );
     aggregateError0.pluginIndex = 0;
     const aggregateError2 = new AggregateCreateNodesError(
       [
-        ['file3', undefined],
-        ['file4', undefined],
+        ['file3', new Error('failed to process file3')],
+        ['file4', new Error('failed to process file4')],
       ],
       []
     );
@@ -127,11 +127,14 @@ describe('checkCompatibleWithPlugins', () => {
     );
     const result = await checkCompatibleWithPlugins();
     expect(result).toEqual({
-      0: [{ file: 'file1' }, { file: 'file2' }],
+      0: [
+        { file: 'file1', error: new Error('failed to process file1') },
+        { file: 'file2', error: new Error('failed to process file2') },
+      ],
       2: [
         { file: 'file2', error: mergeNodesError },
-        { file: 'file3' },
-        { file: 'file4' },
+        { file: 'file3', error: new Error('failed to process file3') },
+        { file: 'file4', error: new Error('failed to process file4') },
       ],
     });
   });

--- a/packages/nx/src/command-line/init/implementation/utils.ts
+++ b/packages/nx/src/command-line/init/implementation/utils.ts
@@ -20,7 +20,7 @@ import {
   getPackageManagerVersion,
   PackageManagerCommands,
 } from '../../../utils/package-manager';
-import { acknowledgePnpmBuildScripts } from '../../../utils/pnpm-allow-builds';
+import { acknowledgeBuildScripts } from '../../../utils/acknowledge-build-scripts';
 import { joinPathFragments } from '../../../utils/path';
 import { nxVersion } from '../../../utils/versions';
 import { existsSync, readFileSync, writeFileSync } from 'fs';
@@ -268,7 +268,9 @@ export function addDepsToPackageJson(
   writeJsonFile(path, json);
   // nx has a postinstall script, which pnpm 11+ refuses to install
   // unacknowledged.
-  acknowledgePnpmBuildScripts(repoRoot, { nx: true });
+  acknowledgeBuildScripts(repoRoot, detectPackageManager(repoRoot), {
+    nx: true,
+  });
 }
 
 export function updateGitIgnore(root: string) {

--- a/packages/nx/src/command-line/init/implementation/utils.ts
+++ b/packages/nx/src/command-line/init/implementation/utils.ts
@@ -18,6 +18,7 @@ import {
   detectPackageManager,
   getPackageManagerCommand,
   getPackageManagerVersion,
+  PackageManager,
   PackageManagerCommands,
 } from '../../../utils/package-manager';
 import { acknowledgeBuildScripts } from '../../../utils/acknowledge-build-scripts';
@@ -254,7 +255,8 @@ export function createNxJsonFromTurboJson(
 
 export function addDepsToPackageJson(
   repoRoot: string,
-  additionalPackages?: string[]
+  additionalPackages?: string[],
+  packageManager: PackageManager = detectPackageManager(repoRoot)
 ) {
   const path = joinPathFragments(repoRoot, `package.json`);
   const json = readJsonFile(path);
@@ -268,9 +270,7 @@ export function addDepsToPackageJson(
   writeJsonFile(path, json);
   // nx has a postinstall script, which pnpm 11+ refuses to install
   // unacknowledged.
-  acknowledgeBuildScripts(repoRoot, detectPackageManager(repoRoot), {
-    nx: true,
-  });
+  acknowledgeBuildScripts(repoRoot, packageManager, { nx: true });
 }
 
 export function updateGitIgnore(root: string) {
@@ -307,13 +307,14 @@ export function updateGitIgnore(root: string) {
 
 export function runInstall(
   repoRoot: string,
-  pmc: PackageManagerCommands = getPackageManagerCommand()
+  packageManager: PackageManager = detectPackageManager(repoRoot),
+  pmc: PackageManagerCommands = getPackageManagerCommand(packageManager)
 ) {
   let command = pmc.install;
   // Plugins added during init can pull build-script deps whose allowBuilds
   // entries are only recorded by their init generators after this install;
   // warn and skip for this one install, like pnpm 10 did.
-  if (detectPackageManager(repoRoot) === 'pnpm') {
+  if (packageManager === 'pnpm') {
     try {
       if (gte(getPackageManagerVersion('pnpm', repoRoot), '11.0.0')) {
         command += ' --config.strictDepBuilds=false';

--- a/packages/nx/src/command-line/init/implementation/utils.ts
+++ b/packages/nx/src/command-line/init/implementation/utils.ts
@@ -1,5 +1,6 @@
 import { execSync } from 'child_process';
 import { join } from 'path';
+import { gte } from 'semver';
 
 import {
   NxJsonConfiguration,
@@ -14,9 +15,12 @@ import {
 import { output } from '../../../utils/output';
 import { PackageJson } from '../../../utils/package-json';
 import {
+  detectPackageManager,
   getPackageManagerCommand,
+  getPackageManagerVersion,
   PackageManagerCommands,
 } from '../../../utils/package-manager';
+import { acknowledgePnpmBuildScripts } from '../../../utils/pnpm-allow-builds';
 import { joinPathFragments } from '../../../utils/path';
 import { nxVersion } from '../../../utils/versions';
 import { existsSync, readFileSync, writeFileSync } from 'fs';
@@ -262,6 +266,9 @@ export function addDepsToPackageJson(
     }
   }
   writeJsonFile(path, json);
+  // nx has a postinstall script, which pnpm 11+ refuses to install
+  // unacknowledged.
+  acknowledgePnpmBuildScripts(repoRoot, { nx: true });
 }
 
 export function updateGitIgnore(root: string) {
@@ -300,8 +307,21 @@ export function runInstall(
   repoRoot: string,
   pmc: PackageManagerCommands = getPackageManagerCommand()
 ) {
+  let command = pmc.install;
+  // Plugins added during init can pull build-script deps whose allowBuilds
+  // entries are only recorded by their init generators after this install;
+  // warn and skip for this one install, like pnpm 10 did.
+  if (detectPackageManager(repoRoot) === 'pnpm') {
+    try {
+      if (gte(getPackageManagerVersion('pnpm', repoRoot), '11.0.0')) {
+        command += ' --config.strictDepBuilds=false';
+      }
+    } catch {
+      // The version cannot be probed; run the install unmodified.
+    }
+  }
   try {
-    execSync(pmc.install, {
+    execSync(command, {
       stdio: ['ignore', 'ignore', 'pipe'],
       encoding: 'utf8',
       cwd: repoRoot,

--- a/packages/nx/src/command-line/init/implementation/utils.ts
+++ b/packages/nx/src/command-line/init/implementation/utils.ts
@@ -255,8 +255,8 @@ export function createNxJsonFromTurboJson(
 
 export function addDepsToPackageJson(
   repoRoot: string,
-  additionalPackages?: string[],
-  packageManager: PackageManager = detectPackageManager(repoRoot)
+  packageManager: PackageManager,
+  additionalPackages?: string[]
 ) {
   const path = joinPathFragments(repoRoot, `package.json`);
   const json = readJsonFile(path);

--- a/packages/nx/src/devkit-internals.ts
+++ b/packages/nx/src/devkit-internals.ts
@@ -69,3 +69,4 @@ export {
   getCatalogManager,
   getCatalogDependenciesFromPackageJson,
 } from './utils/catalog';
+export { acknowledgePnpmBuildScripts } from './utils/pnpm-allow-builds';

--- a/packages/nx/src/devkit-internals.ts
+++ b/packages/nx/src/devkit-internals.ts
@@ -69,4 +69,4 @@ export {
   getCatalogManager,
   getCatalogDependenciesFromPackageJson,
 } from './utils/catalog';
-export { acknowledgePnpmBuildScripts } from './utils/pnpm-allow-builds';
+export { acknowledgeBuildScripts } from './utils/acknowledge-build-scripts';

--- a/packages/nx/src/project-graph/error-types.spec.ts
+++ b/packages/nx/src/project-graph/error-types.spec.ts
@@ -170,14 +170,13 @@ describe('formatAggregateCreateNodesError', () => {
 
   it('should format errors deserialized from a plugin worker without a stack', () => {
     const error = new AggregateCreateNodesError(
-      [
-        [
-          'libs/mylib/project.json',
-          { message: 'worker failure' } as unknown as Error,
-        ],
-      ],
+      [['libs/mylib/project.json', new Error('placeholder')]],
       []
     );
+    // Worker errors are rehydrated as plain objects that never pass through
+    // the constructor's coercion, so inject the tuple after construction to
+    // exercise the formatter's stack fallback for real.
+    error.errors[0][1] = { message: 'worker failure' } as unknown as Error;
 
     formatAggregateCreateNodesError(error, '@nx/jest');
 

--- a/packages/nx/src/project-graph/error-types.spec.ts
+++ b/packages/nx/src/project-graph/error-types.spec.ts
@@ -147,4 +147,48 @@ describe('formatAggregateCreateNodesError', () => {
                at foo (file.js:1:1)"
     `);
   });
+
+  it('should format non-Error values thrown by plugins', () => {
+    const error = new AggregateCreateNodesError(
+      [
+        ['libs/a/project.json', 'plain string failure' as unknown as Error],
+        ['libs/b/project.json', { code: 'ELOAD' } as unknown as Error],
+      ],
+      []
+    );
+
+    formatAggregateCreateNodesError(error, '@nx/jest');
+
+    expect(error.message).toMatchInlineSnapshot(`
+      "2 errors occurred while processing files for the @nx/jest plugin.
+        - libs/a/project.json:
+            plain string failure
+        - libs/b/project.json:
+            {"code":"ELOAD"}"
+    `);
+  });
+
+  it('should format errors deserialized from a plugin worker without a stack', () => {
+    const error = new AggregateCreateNodesError(
+      [
+        [
+          'libs/mylib/project.json',
+          { message: 'worker failure' } as unknown as Error,
+        ],
+      ],
+      []
+    );
+
+    formatAggregateCreateNodesError(error, '@nx/jest');
+
+    expect(error.message).toMatchInlineSnapshot(`
+      "An error occurred while processing files for the @nx/jest plugin.
+        - libs/mylib/project.json:
+            worker failure"
+    `);
+    expect(error.stack).toMatchInlineSnapshot(`
+      " - libs/mylib/project.json:
+           worker failure"
+    `);
+  });
 });

--- a/packages/nx/src/project-graph/error-types.ts
+++ b/packages/nx/src/project-graph/error-types.ts
@@ -310,7 +310,44 @@ export class AggregateCreateNodesError extends Error {
         'AggregateCreateNodesError must be constructed with an array of tuples where the first element is a filename or undefined and the second element is the underlying error.'
       );
     }
+    // Plugins pass through whatever value they caught, which is not
+    // guaranteed to be an Error. Coerce so formatting can rely on
+    // message and stack being present.
+    for (const errorTuple of errors) {
+      errorTuple[1] = coerceToError(errorTuple[1]);
+    }
   }
+}
+
+function coerceToError(value: unknown): Error {
+  if (value instanceof Error) {
+    return value;
+  }
+  let message: string;
+  let stack: string | undefined;
+  if (typeof value === 'object' && value !== null) {
+    const candidate = value as { message?: unknown; stack?: unknown };
+    if (typeof candidate.message === 'string') {
+      message = candidate.message;
+      if (typeof candidate.stack === 'string') {
+        stack = candidate.stack;
+      }
+    } else {
+      try {
+        message = JSON.stringify(value);
+      } catch {
+        // Circular structures cannot be stringified.
+        message = String(value);
+      }
+    }
+  } else {
+    message = String(value);
+  }
+  const error = new Error(message);
+  // A synthesized stack would point at this coercion site rather than
+  // the original failure, so prefer the original stack or just the message.
+  error.stack = stack ?? message;
+  return error;
 }
 
 export function formatAggregateCreateNodesError(
@@ -344,7 +381,8 @@ export function formatAggregateCreateNodesError(
     }
     for (const e of errors) {
       const messageLines = e.message.split('\n');
-      const stackLines = e.stack.split('\n');
+      // Errors deserialized from a plugin worker may arrive without a stack.
+      const stackLines = (e.stack ?? e.message).split('\n');
       if (file) {
         errorBodyLines.push(...messageLines.map((line) => `      ${line}`));
         errorStackLines.push(...stackLines.map((line) => `     ${line}`));

--- a/packages/nx/src/utils/acknowledge-build-scripts.spec.ts
+++ b/packages/nx/src/utils/acknowledge-build-scripts.spec.ts
@@ -68,6 +68,22 @@ describe('acknowledgeBuildScripts', () => {
     `);
   });
 
+  it('should replace the placeholder stubs pnpm writes during non-strict installs', () => {
+    tree.write(
+      'pnpm-workspace.yaml',
+      'allowBuilds:\n  unrs-resolver: set this to true or false\n  cypress: set this to true or false\n'
+    );
+
+    acknowledgeBuildScripts(tree, 'pnpm', { 'unrs-resolver': false });
+
+    expect(tree.read('pnpm-workspace.yaml', 'utf-8')).toMatchInlineSnapshot(`
+      "allowBuilds:
+        unrs-resolver: false
+        cypress: set this to true or false
+      "
+    `);
+  });
+
   it('should be a no-op for package managers other than pnpm', () => {
     const original = 'packages:\n  - "packages/*"\n';
     tree.write('pnpm-workspace.yaml', original);

--- a/packages/nx/src/utils/acknowledge-build-scripts.spec.ts
+++ b/packages/nx/src/utils/acknowledge-build-scripts.spec.ts
@@ -3,9 +3,9 @@ import { tmpdir } from 'os';
 import { join } from 'path';
 import { createTree } from '../generators/testing-utils/create-tree';
 import type { Tree } from '../generators/tree';
-import { acknowledgePnpmBuildScripts } from './pnpm-allow-builds';
+import { acknowledgeBuildScripts } from './acknowledge-build-scripts';
 
-describe('acknowledgePnpmBuildScripts', () => {
+describe('acknowledgeBuildScripts', () => {
   let tree: Tree;
 
   beforeEach(() => {
@@ -22,7 +22,7 @@ describe('acknowledgePnpmBuildScripts', () => {
       'autoInstallPeers: true\nallowBuilds:\n  nx: true\n'
     );
 
-    acknowledgePnpmBuildScripts(tree, { 'unrs-resolver': false });
+    acknowledgeBuildScripts(tree, 'pnpm', { 'unrs-resolver': false });
 
     expect(tree.read('pnpm-workspace.yaml', 'utf-8')).toMatchInlineSnapshot(`
       "autoInstallPeers: true
@@ -36,7 +36,7 @@ describe('acknowledgePnpmBuildScripts', () => {
   it('should create the allowBuilds map when missing', () => {
     tree.write('pnpm-workspace.yaml', 'packages:\n  - "packages/*"\n');
 
-    acknowledgePnpmBuildScripts(tree, { cypress: true });
+    acknowledgeBuildScripts(tree, 'pnpm', { cypress: true });
 
     expect(tree.read('pnpm-workspace.yaml', 'utf-8')).toMatchInlineSnapshot(`
       "packages:
@@ -53,7 +53,7 @@ describe('acknowledgePnpmBuildScripts', () => {
       '# team notes\nallowBuilds:\n  # user explicitly allowed this\n  unrs-resolver: true\n'
     );
 
-    acknowledgePnpmBuildScripts(tree, {
+    acknowledgeBuildScripts(tree, 'pnpm', {
       'unrs-resolver': false,
       esbuild: false,
     });
@@ -68,8 +68,19 @@ describe('acknowledgePnpmBuildScripts', () => {
     `);
   });
 
-  it('should be a no-op for non-pnpm workspaces', () => {
-    acknowledgePnpmBuildScripts(tree, { cypress: true });
+  it('should be a no-op for package managers other than pnpm', () => {
+    const original = 'packages:\n  - "packages/*"\n';
+    tree.write('pnpm-workspace.yaml', original);
+
+    acknowledgeBuildScripts(tree, 'npm', { cypress: true });
+    acknowledgeBuildScripts(tree, 'yarn', { cypress: true });
+    acknowledgeBuildScripts(tree, 'bun', { cypress: true });
+
+    expect(tree.read('pnpm-workspace.yaml', 'utf-8')).toBe(original);
+  });
+
+  it('should be a no-op when there is no pnpm-workspace.yaml', () => {
+    acknowledgeBuildScripts(tree, 'pnpm', { cypress: true });
 
     expect(tree.exists('pnpm-workspace.yaml')).toBe(false);
   });
@@ -82,7 +93,7 @@ describe('acknowledgePnpmBuildScripts', () => {
     const original = 'onlyBuiltDependencies:\n  - nx\n';
     tree.write('pnpm-workspace.yaml', original);
 
-    acknowledgePnpmBuildScripts(tree, { 'unrs-resolver': false });
+    acknowledgeBuildScripts(tree, 'pnpm', { 'unrs-resolver': false });
 
     expect(tree.read('pnpm-workspace.yaml', 'utf-8')).toBe(original);
   });
@@ -91,7 +102,7 @@ describe('acknowledgePnpmBuildScripts', () => {
     const original = '- just\n- a\n- list\n';
     tree.write('pnpm-workspace.yaml', original);
 
-    acknowledgePnpmBuildScripts(tree, { 'unrs-resolver': false });
+    acknowledgeBuildScripts(tree, 'pnpm', { 'unrs-resolver': false });
 
     expect(tree.read('pnpm-workspace.yaml', 'utf-8')).toBe(original);
   });
@@ -105,7 +116,7 @@ describe('acknowledgePnpmBuildScripts', () => {
       );
       writeFileSync(join(root, 'pnpm-workspace.yaml'), 'packages:\n  - "*"\n');
 
-      acknowledgePnpmBuildScripts(root, { nx: true });
+      acknowledgeBuildScripts(root, 'pnpm', { nx: true });
 
       expect(readFileSync(join(root, 'pnpm-workspace.yaml'), 'utf-8'))
         .toMatchInlineSnapshot(`

--- a/packages/nx/src/utils/acknowledge-build-scripts.spec.ts
+++ b/packages/nx/src/utils/acknowledge-build-scripts.spec.ts
@@ -79,10 +79,14 @@ describe('acknowledgeBuildScripts', () => {
     expect(tree.read('pnpm-workspace.yaml', 'utf-8')).toBe(original);
   });
 
-  it('should be a no-op when there is no pnpm-workspace.yaml', () => {
+  it('should create pnpm-workspace.yaml when it does not exist', () => {
     acknowledgeBuildScripts(tree, 'pnpm', { cypress: true });
 
-    expect(tree.exists('pnpm-workspace.yaml')).toBe(false);
+    expect(tree.read('pnpm-workspace.yaml', 'utf-8')).toMatchInlineSnapshot(`
+      "allowBuilds:
+        cypress: true
+      "
+    `);
   });
 
   it('should be a no-op for pnpm < 11', () => {

--- a/packages/nx/src/utils/acknowledge-build-scripts.spec.ts
+++ b/packages/nx/src/utils/acknowledge-build-scripts.spec.ts
@@ -4,6 +4,12 @@ import { join } from 'path';
 import { createTree } from '../generators/testing-utils/create-tree';
 import type { Tree } from '../generators/tree';
 import { acknowledgeBuildScripts } from './acknowledge-build-scripts';
+import { getPackageManagerVersion } from './package-manager';
+
+jest.mock('./package-manager', () => ({
+  ...jest.requireActual('./package-manager'),
+  getPackageManagerVersion: jest.fn(),
+}));
 
 describe('acknowledgeBuildScripts', () => {
   let tree: Tree;
@@ -116,6 +122,36 @@ describe('acknowledgeBuildScripts', () => {
     acknowledgeBuildScripts(tree, 'pnpm', { 'unrs-resolver': false });
 
     expect(tree.read('pnpm-workspace.yaml', 'utf-8')).toBe(original);
+  });
+
+  it('should probe the pnpm version when the packageManager pin is not exact', () => {
+    tree.write(
+      'package.json',
+      JSON.stringify({ name: 'proj', packageManager: 'pnpm@^11.0.0' })
+    );
+    jest.mocked(getPackageManagerVersion).mockReturnValueOnce('11.2.2');
+
+    acknowledgeBuildScripts(tree, 'pnpm', { 'unrs-resolver': false });
+
+    expect(tree.read('pnpm-workspace.yaml', 'utf-8')).toMatchInlineSnapshot(`
+      "allowBuilds:
+        unrs-resolver: false
+      "
+    `);
+  });
+
+  it('should be a no-op when the pnpm version cannot be determined', () => {
+    tree.write(
+      'package.json',
+      JSON.stringify({ name: 'proj', packageManager: 'pnpm@latest' })
+    );
+    jest.mocked(getPackageManagerVersion).mockImplementationOnce(() => {
+      throw new Error('Cannot determine the version of pnpm.');
+    });
+
+    acknowledgeBuildScripts(tree, 'pnpm', { 'unrs-resolver': false });
+
+    expect(tree.exists('pnpm-workspace.yaml')).toBe(false);
   });
 
   it('should leave a malformed pnpm-workspace.yaml untouched', () => {

--- a/packages/nx/src/utils/acknowledge-build-scripts.spec.ts
+++ b/packages/nx/src/utils/acknowledge-build-scripts.spec.ts
@@ -127,6 +127,17 @@ describe('acknowledgeBuildScripts', () => {
     expect(tree.read('pnpm-workspace.yaml', 'utf-8')).toBe(original);
   });
 
+  it('should leave a pnpm-workspace.yaml with parse errors untouched', () => {
+    // Map-shaped but syntactically invalid (unclosed quote): the parsed root
+    // is still a YAMLMap, but stringifying a document with errors throws.
+    const original = 'packages:\n  - "apps/*\n';
+    tree.write('pnpm-workspace.yaml', original);
+
+    acknowledgeBuildScripts(tree, 'pnpm', { 'unrs-resolver': false });
+
+    expect(tree.read('pnpm-workspace.yaml', 'utf-8')).toBe(original);
+  });
+
   it('should accept a filesystem root instead of a tree', () => {
     const root = mkdtempSync(join(tmpdir(), 'nx-allow-builds-'));
     try {

--- a/packages/nx/src/utils/acknowledge-build-scripts.ts
+++ b/packages/nx/src/utils/acknowledge-build-scripts.ts
@@ -51,9 +51,13 @@ function acknowledgePnpmBuildScripts(
   const parsed = parseDocument(
     host.exists(PNPM_WORKSPACE_FILE) ? host.read(PNPM_WORKSPACE_FILE) : ''
   );
-  // A present root that isn't a mapping is malformed for pnpm; leave it alone
-  // rather than replacing the user's content with just the allowBuilds key.
-  if (parsed.contents != null && !(parsed.contents instanceof YAMLMap)) {
+  // A file that doesn't parse cleanly or whose root isn't a mapping is
+  // malformed for pnpm; leave it alone rather than crashing or replacing the
+  // user's content. pnpm's own error on the file is the actionable signal.
+  if (
+    parsed.errors.length > 0 ||
+    (parsed.contents != null && !(parsed.contents instanceof YAMLMap))
+  ) {
     return;
   }
   const doc = parsed.contents instanceof YAMLMap ? parsed : new Document({});

--- a/packages/nx/src/utils/acknowledge-build-scripts.ts
+++ b/packages/nx/src/utils/acknowledge-build-scripts.ts
@@ -31,7 +31,8 @@ export function acknowledgeBuildScripts(
 }
 
 /**
- * Records `allowBuilds` decisions in pnpm-workspace.yaml.
+ * Records `allowBuilds` decisions in pnpm-workspace.yaml, creating the file
+ * when missing (mirroring `pnpm approve-builds` in single-package repos).
  *
  * Comment-preserving. Existing entries are never overwritten, so user
  * decisions always win. No-op for pnpm < 11, which warns instead of erroring
@@ -42,22 +43,20 @@ function acknowledgePnpmBuildScripts(
   entries: Record<string, boolean>
 ): void {
   const host = createHost(treeOrRoot);
-  if (!host.exists(PNPM_WORKSPACE_FILE)) {
-    return;
-  }
   const pnpmVersion = getPnpmVersion(host);
   if (!pnpmVersion || !gte(pnpmVersion, '11.0.0')) {
     return;
   }
 
-  const parsed = parseDocument(host.read(PNPM_WORKSPACE_FILE));
+  const parsed = parseDocument(
+    host.exists(PNPM_WORKSPACE_FILE) ? host.read(PNPM_WORKSPACE_FILE) : ''
+  );
   // A present root that isn't a mapping is malformed for pnpm; leave it alone
   // rather than replacing the user's content with just the allowBuilds key.
   if (parsed.contents != null && !(parsed.contents instanceof YAMLMap)) {
     return;
   }
-  const doc =
-    parsed.contents instanceof YAMLMap ? parsed : new Document(new YAMLMap());
+  const doc = parsed.contents instanceof YAMLMap ? parsed : new Document({});
 
   let changed = false;
   for (const [pkg, allowed] of Object.entries(entries)) {

--- a/packages/nx/src/utils/acknowledge-build-scripts.ts
+++ b/packages/nx/src/utils/acknowledge-build-scripts.ts
@@ -4,7 +4,10 @@ import { Document, parseDocument, YAMLMap } from 'yaml';
 import { gte } from 'semver';
 import type { Tree } from '../generators/tree';
 import type { PackageManager } from './package-manager';
-import { getPackageManagerVersion } from './package-manager';
+import {
+  getPackageManagerVersion,
+  parseVersionFromPackageManagerField,
+} from './package-manager';
 import { readJsonFile } from './fileutils';
 
 const PNPM_WORKSPACE_FILE = 'pnpm-workspace.yaml';
@@ -109,11 +112,12 @@ function getPnpmVersion(host: Host): string | null {
   // in-flight package.json only exists in the tree, not on disk.
   if (host.exists('package.json')) {
     const { packageManager } = host.readJson('package.json');
-    if (
-      typeof packageManager === 'string' &&
-      packageManager.startsWith('pnpm@')
-    ) {
-      return packageManager.slice('pnpm@'.length);
+    const version = parseVersionFromPackageManagerField(
+      'pnpm',
+      typeof packageManager === 'string' ? packageManager : undefined
+    );
+    if (version) {
+      return version;
     }
   }
   try {

--- a/packages/nx/src/utils/acknowledge-build-scripts.ts
+++ b/packages/nx/src/utils/acknowledge-build-scripts.ts
@@ -3,23 +3,41 @@ import { join } from 'path';
 import { Document, parseDocument, YAMLMap } from 'yaml';
 import { gte } from 'semver';
 import type { Tree } from '../generators/tree';
+import type { PackageManager } from './package-manager';
 import { getPackageManagerVersion } from './package-manager';
 import { readJsonFile } from './fileutils';
 
 const PNPM_WORKSPACE_FILE = 'pnpm-workspace.yaml';
 
 /**
- * Records `allowBuilds` decisions in pnpm-workspace.yaml for build-script
- * dependencies that are about to be installed. pnpm 11+ refuses to install a
- * dependency whose build scripts are neither allowed nor denied, so the
- * generator or command that introduces such a dependency records the
- * decision up front.
+ * Records build-script decisions for dependencies that are about to be
+ * installed, in whatever form the given package manager understands.
+ *
+ * Only pnpm needs this today: pnpm 11+ refuses to install a dependency whose
+ * build scripts are neither allowed nor denied, so the generator or command
+ * that introduces such a dependency records the decision up front. Other
+ * package managers run build scripts unconditionally, so this is a no-op for
+ * them.
+ */
+export function acknowledgeBuildScripts(
+  treeOrRoot: Tree | string,
+  packageManager: PackageManager,
+  entries: Record<string, boolean>
+): void {
+  if (packageManager !== 'pnpm') {
+    return;
+  }
+  acknowledgePnpmBuildScripts(treeOrRoot, entries);
+}
+
+/**
+ * Records `allowBuilds` decisions in pnpm-workspace.yaml.
  *
  * Comment-preserving. Existing entries are never overwritten, so user
- * decisions always win. No-op for non-pnpm workspaces and pnpm < 11 (which
- * warns instead of erroring and does not read `allowBuilds`).
+ * decisions always win. No-op for pnpm < 11, which warns instead of erroring
+ * and does not read `allowBuilds`.
  */
-export function acknowledgePnpmBuildScripts(
+function acknowledgePnpmBuildScripts(
   treeOrRoot: Tree | string,
   entries: Record<string, boolean>
 ): void {

--- a/packages/nx/src/utils/acknowledge-build-scripts.ts
+++ b/packages/nx/src/utils/acknowledge-build-scripts.ts
@@ -60,7 +60,10 @@ function acknowledgePnpmBuildScripts(
 
   let changed = false;
   for (const [pkg, allowed] of Object.entries(entries)) {
-    if (!doc.hasIn(['allowBuilds', pkg])) {
+    // Only a real boolean is a user decision. pnpm's non-strict installs stub
+    // undecided packages with a placeholder string ("set this to true or
+    // false"), which would fail the next strict install if left in place.
+    if (typeof doc.getIn(['allowBuilds', pkg]) !== 'boolean') {
       doc.setIn(['allowBuilds', pkg], allowed);
       changed = true;
     }

--- a/packages/nx/src/utils/pnpm-allow-builds.spec.ts
+++ b/packages/nx/src/utils/pnpm-allow-builds.spec.ts
@@ -1,3 +1,6 @@
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { createTree } from '../generators/testing-utils/create-tree';
 import type { Tree } from '../generators/tree';
 import { acknowledgePnpmBuildScripts } from './pnpm-allow-builds';
@@ -91,5 +94,29 @@ describe('acknowledgePnpmBuildScripts', () => {
     acknowledgePnpmBuildScripts(tree, { 'unrs-resolver': false });
 
     expect(tree.read('pnpm-workspace.yaml', 'utf-8')).toBe(original);
+  });
+
+  it('should accept a filesystem root instead of a tree', () => {
+    const root = mkdtempSync(join(tmpdir(), 'nx-allow-builds-'));
+    try {
+      writeFileSync(
+        join(root, 'package.json'),
+        JSON.stringify({ name: 'proj', packageManager: 'pnpm@11.2.2' })
+      );
+      writeFileSync(join(root, 'pnpm-workspace.yaml'), 'packages:\n  - "*"\n');
+
+      acknowledgePnpmBuildScripts(root, { nx: true });
+
+      expect(readFileSync(join(root, 'pnpm-workspace.yaml'), 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "packages:
+          - "*"
+        allowBuilds:
+          nx: true
+        "
+      `);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
   });
 });

--- a/packages/nx/src/utils/pnpm-allow-builds.spec.ts
+++ b/packages/nx/src/utils/pnpm-allow-builds.spec.ts
@@ -1,0 +1,95 @@
+import { createTree } from '../generators/testing-utils/create-tree';
+import type { Tree } from '../generators/tree';
+import { acknowledgePnpmBuildScripts } from './pnpm-allow-builds';
+
+describe('acknowledgePnpmBuildScripts', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTree();
+    tree.write(
+      'package.json',
+      JSON.stringify({ name: 'proj', packageManager: 'pnpm@11.2.2' })
+    );
+  });
+
+  it('should add entries to an existing allowBuilds map', () => {
+    tree.write(
+      'pnpm-workspace.yaml',
+      'autoInstallPeers: true\nallowBuilds:\n  nx: true\n'
+    );
+
+    acknowledgePnpmBuildScripts(tree, { 'unrs-resolver': false });
+
+    expect(tree.read('pnpm-workspace.yaml', 'utf-8')).toMatchInlineSnapshot(`
+      "autoInstallPeers: true
+      allowBuilds:
+        nx: true
+        unrs-resolver: false
+      "
+    `);
+  });
+
+  it('should create the allowBuilds map when missing', () => {
+    tree.write('pnpm-workspace.yaml', 'packages:\n  - "packages/*"\n');
+
+    acknowledgePnpmBuildScripts(tree, { cypress: true });
+
+    expect(tree.read('pnpm-workspace.yaml', 'utf-8')).toMatchInlineSnapshot(`
+      "packages:
+        - "packages/*"
+      allowBuilds:
+        cypress: true
+      "
+    `);
+  });
+
+  it('should preserve comments and never overwrite existing entries', () => {
+    tree.write(
+      'pnpm-workspace.yaml',
+      '# team notes\nallowBuilds:\n  # user explicitly allowed this\n  unrs-resolver: true\n'
+    );
+
+    acknowledgePnpmBuildScripts(tree, {
+      'unrs-resolver': false,
+      esbuild: false,
+    });
+
+    expect(tree.read('pnpm-workspace.yaml', 'utf-8')).toMatchInlineSnapshot(`
+      "# team notes
+      allowBuilds:
+        # user explicitly allowed this
+        unrs-resolver: true
+        esbuild: false
+      "
+    `);
+  });
+
+  it('should be a no-op for non-pnpm workspaces', () => {
+    acknowledgePnpmBuildScripts(tree, { cypress: true });
+
+    expect(tree.exists('pnpm-workspace.yaml')).toBe(false);
+  });
+
+  it('should be a no-op for pnpm < 11', () => {
+    tree.write(
+      'package.json',
+      JSON.stringify({ name: 'proj', packageManager: 'pnpm@10.28.2' })
+    );
+    const original = 'onlyBuiltDependencies:\n  - nx\n';
+    tree.write('pnpm-workspace.yaml', original);
+
+    acknowledgePnpmBuildScripts(tree, { 'unrs-resolver': false });
+
+    expect(tree.read('pnpm-workspace.yaml', 'utf-8')).toBe(original);
+  });
+
+  it('should leave a malformed pnpm-workspace.yaml untouched', () => {
+    const original = '- just\n- a\n- list\n';
+    tree.write('pnpm-workspace.yaml', original);
+
+    acknowledgePnpmBuildScripts(tree, { 'unrs-resolver': false });
+
+    expect(tree.read('pnpm-workspace.yaml', 'utf-8')).toBe(original);
+  });
+});

--- a/packages/nx/src/utils/pnpm-allow-builds.ts
+++ b/packages/nx/src/utils/pnpm-allow-builds.ts
@@ -1,0 +1,71 @@
+import { Document, parseDocument, YAMLMap } from 'yaml';
+import { gte } from 'semver';
+import type { Tree } from '../generators/tree';
+import { readJson } from '../generators/utils/json';
+import { getPackageManagerVersion } from './package-manager';
+
+const PNPM_WORKSPACE_FILE = 'pnpm-workspace.yaml';
+
+/**
+ * Records `allowBuilds` decisions in pnpm-workspace.yaml for build-script
+ * dependencies a generator is about to add. pnpm 11+ refuses to install a
+ * dependency whose build scripts are neither allowed nor denied, so the
+ * generator that introduces such a dependency records the decision up front.
+ *
+ * Comment-preserving. Existing entries are never overwritten, so user
+ * decisions always win. No-op for non-pnpm workspaces and pnpm < 11 (which
+ * warns instead of erroring and does not read `allowBuilds`).
+ */
+export function acknowledgePnpmBuildScripts(
+  tree: Tree,
+  entries: Record<string, boolean>
+): void {
+  if (!tree.exists(PNPM_WORKSPACE_FILE)) {
+    return;
+  }
+  const pnpmVersion = getPnpmVersion(tree);
+  if (!pnpmVersion || !gte(pnpmVersion, '11.0.0')) {
+    return;
+  }
+
+  const parsed = parseDocument(tree.read(PNPM_WORKSPACE_FILE, 'utf-8'));
+  // A present root that isn't a mapping is malformed for pnpm; leave it alone
+  // rather than replacing the user's content with just the allowBuilds key.
+  if (parsed.contents != null && !(parsed.contents instanceof YAMLMap)) {
+    return;
+  }
+  const doc =
+    parsed.contents instanceof YAMLMap ? parsed : new Document(new YAMLMap());
+
+  let changed = false;
+  for (const [pkg, allowed] of Object.entries(entries)) {
+    if (!doc.hasIn(['allowBuilds', pkg])) {
+      doc.setIn(['allowBuilds', pkg], allowed);
+      changed = true;
+    }
+  }
+  if (changed) {
+    tree.write(PNPM_WORKSPACE_FILE, doc.toString());
+  }
+}
+
+function getPnpmVersion(tree: Tree): string | null {
+  // The tree's packageManager field wins: during workspace creation the
+  // in-flight package.json only exists in the tree, not on disk.
+  if (tree.exists('package.json')) {
+    const { packageManager } = readJson(tree, 'package.json');
+    if (
+      typeof packageManager === 'string' &&
+      packageManager.startsWith('pnpm@')
+    ) {
+      return packageManager.slice('pnpm@'.length);
+    }
+  }
+  try {
+    return getPackageManagerVersion('pnpm', tree.root);
+  } catch {
+    // The version cannot be probed (e.g. pnpm is not on PATH). Leave the
+    // workspace file untouched; pnpm's own install error remains actionable.
+    return null;
+  }
+}

--- a/packages/nx/src/utils/pnpm-allow-builds.ts
+++ b/packages/nx/src/utils/pnpm-allow-builds.ts
@@ -1,34 +1,38 @@
+import { existsSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
 import { Document, parseDocument, YAMLMap } from 'yaml';
 import { gte } from 'semver';
 import type { Tree } from '../generators/tree';
-import { readJson } from '../generators/utils/json';
 import { getPackageManagerVersion } from './package-manager';
+import { readJsonFile } from './fileutils';
 
 const PNPM_WORKSPACE_FILE = 'pnpm-workspace.yaml';
 
 /**
  * Records `allowBuilds` decisions in pnpm-workspace.yaml for build-script
- * dependencies a generator is about to add. pnpm 11+ refuses to install a
+ * dependencies that are about to be installed. pnpm 11+ refuses to install a
  * dependency whose build scripts are neither allowed nor denied, so the
- * generator that introduces such a dependency records the decision up front.
+ * generator or command that introduces such a dependency records the
+ * decision up front.
  *
  * Comment-preserving. Existing entries are never overwritten, so user
  * decisions always win. No-op for non-pnpm workspaces and pnpm < 11 (which
  * warns instead of erroring and does not read `allowBuilds`).
  */
 export function acknowledgePnpmBuildScripts(
-  tree: Tree,
+  treeOrRoot: Tree | string,
   entries: Record<string, boolean>
 ): void {
-  if (!tree.exists(PNPM_WORKSPACE_FILE)) {
+  const host = createHost(treeOrRoot);
+  if (!host.exists(PNPM_WORKSPACE_FILE)) {
     return;
   }
-  const pnpmVersion = getPnpmVersion(tree);
+  const pnpmVersion = getPnpmVersion(host);
   if (!pnpmVersion || !gte(pnpmVersion, '11.0.0')) {
     return;
   }
 
-  const parsed = parseDocument(tree.read(PNPM_WORKSPACE_FILE, 'utf-8'));
+  const parsed = parseDocument(host.read(PNPM_WORKSPACE_FILE));
   // A present root that isn't a mapping is malformed for pnpm; leave it alone
   // rather than replacing the user's content with just the allowBuilds key.
   if (parsed.contents != null && !(parsed.contents instanceof YAMLMap)) {
@@ -45,15 +49,42 @@ export function acknowledgePnpmBuildScripts(
     }
   }
   if (changed) {
-    tree.write(PNPM_WORKSPACE_FILE, doc.toString());
+    host.write(PNPM_WORKSPACE_FILE, doc.toString());
   }
 }
 
-function getPnpmVersion(tree: Tree): string | null {
-  // The tree's packageManager field wins: during workspace creation the
+interface Host {
+  root: string;
+  exists(path: string): boolean;
+  read(path: string): string;
+  write(path: string, content: string): void;
+  readJson(path: string): any;
+}
+
+function createHost(treeOrRoot: Tree | string): Host {
+  if (typeof treeOrRoot === 'string') {
+    return {
+      root: treeOrRoot,
+      exists: (p) => existsSync(join(treeOrRoot, p)),
+      read: (p) => readFileSync(join(treeOrRoot, p), 'utf-8'),
+      write: (p, c) => writeFileSync(join(treeOrRoot, p), c),
+      readJson: (p) => readJsonFile(join(treeOrRoot, p)),
+    };
+  }
+  return {
+    root: treeOrRoot.root,
+    exists: (p) => treeOrRoot.exists(p),
+    read: (p) => treeOrRoot.read(p, 'utf-8'),
+    write: (p, c) => treeOrRoot.write(p, c),
+    readJson: (p) => JSON.parse(treeOrRoot.read(p, 'utf-8')),
+  };
+}
+
+function getPnpmVersion(host: Host): string | null {
+  // The host's packageManager field wins: during workspace creation the
   // in-flight package.json only exists in the tree, not on disk.
-  if (tree.exists('package.json')) {
-    const { packageManager } = readJson(tree, 'package.json');
+  if (host.exists('package.json')) {
+    const { packageManager } = host.readJson('package.json');
     if (
       typeof packageManager === 'string' &&
       packageManager.startsWith('pnpm@')
@@ -62,7 +93,7 @@ function getPnpmVersion(tree: Tree): string | null {
     }
   }
   try {
-    return getPackageManagerVersion('pnpm', tree.root);
+    return getPackageManagerVersion('pnpm', host.root);
   } catch {
     // The version cannot be probed (e.g. pnpm is not on PATH). Leave the
     // workspace file untouched; pnpm's own install error remains actionable.

--- a/packages/vite/src/generators/init/lib/utils.ts
+++ b/packages/vite/src/generators/init/lib/utils.ts
@@ -6,6 +6,7 @@ import {
   Tree,
   updateJson,
 } from '@nx/devkit';
+import { acknowledgePnpmBuildScripts } from '@nx/devkit/internal';
 import { esbuildVersion } from '@nx/js/internal';
 import { intersects } from 'semver';
 import {
@@ -79,6 +80,9 @@ export async function checkDependenciesInstalled(
             ? viteV5Version
             : viteVersion;
 
+  // vite pulls in esbuild, whose install script only validates the prebuilt
+  // binary shipped via optional dependencies, so skip it.
+  acknowledgePnpmBuildScripts(host, { esbuild: false });
   return addDependenciesToPackageJson(
     host,
     {},

--- a/packages/vite/src/generators/init/lib/utils.ts
+++ b/packages/vite/src/generators/init/lib/utils.ts
@@ -1,12 +1,13 @@
 import {
   addDependenciesToPackageJson,
+  detectPackageManager,
   getDependencyVersionFromPackageJson,
   installPackagesTask,
   output,
   Tree,
   updateJson,
 } from '@nx/devkit';
-import { acknowledgePnpmBuildScripts } from '@nx/devkit/internal';
+import { acknowledgeBuildScripts } from '@nx/devkit/internal';
 import { esbuildVersion } from '@nx/js/internal';
 import { intersects } from 'semver';
 import {
@@ -82,7 +83,9 @@ export async function checkDependenciesInstalled(
 
   // vite pulls in esbuild, whose install script only validates the prebuilt
   // binary shipped via optional dependencies, so skip it.
-  acknowledgePnpmBuildScripts(host, { esbuild: false });
+  acknowledgeBuildScripts(host, detectPackageManager(host.root), {
+    esbuild: false,
+  });
   return addDependenciesToPackageJson(
     host,
     {},

--- a/project.json
+++ b/project.json
@@ -11,6 +11,16 @@
         "clear": false
       }
     },
+    "local-registry-e2e": {
+      "executor": "@nx/js:verdaccio",
+      "options": {
+        "port": 4873,
+        "config": ".verdaccio/config.yml",
+        "storage": "dist/local-registry/storage",
+        "clear": false,
+        "location": "none"
+      }
+    },
     "populate-local-registry-storage": {
       "cache": true,
       "inputs": [
@@ -26,7 +36,7 @@
         "native"
       ],
       "dependsOn": [
-        "local-registry",
+        "local-registry-e2e",
         {
           "target": "build",
           "projects": ["tag:npm:public"]

--- a/scripts/local-registry/populate-storage.js
+++ b/scripts/local-registry/populate-storage.js
@@ -21,6 +21,13 @@ async function populateLocalRegistryStorage() {
   }
 
   process.env.npm_config_registry = registry;
+  // npm publish requires credentials client-side even though the local
+  // verdaccio allows anonymous publishing
+  process.env[`npm_config_//${listenAddress}:${port}/:_authToken`] = authToken;
+
+  // pnpm 11 reads pnpm_config_* env vars instead of npm_config_*
+  process.env.pnpm_config_registry = registry;
+  process.env[`pnpm_config_//${listenAddress}:${port}/:_authToken`] = authToken;
 
   // bun
   process.env.BUN_CONFIG_REGISTRY = registry;
@@ -46,10 +53,17 @@ exports.populateLocalRegistryStorage = populateLocalRegistryStorage;
 
 function runLocalRelease(publishVersion, isVerbose) {
   return new Promise((res, rej) => {
-    const publishProcess = exec(`pnpm nx-release --local ${publishVersion}`, {
-      env: process.env,
-      maxBuffer: LARGE_BUFFER,
-    });
+    // pnpm exec, NOT the `pnpm nx-release` run-script: `pnpm run` overwrites
+    // the inherited npm_config_registry with pnpm's own file-resolved
+    // registry, which breaks nx-release's localhost safety check now that
+    // nothing writes the local registry to ~/.npmrc.
+    const publishProcess = exec(
+      `pnpm exec nx nx-release @nx/nx-source --parallel 8 --local ${publishVersion}`,
+      {
+        env: process.env,
+        maxBuffer: LARGE_BUFFER,
+      }
+    );
     let logs = Buffer.from('');
     if (isVerbose) {
       publishProcess?.stdout?.pipe(process.stdout);

--- a/scripts/local-registry/populate-storage.js
+++ b/scripts/local-registry/populate-storage.js
@@ -28,6 +28,8 @@ async function populateLocalRegistryStorage() {
   // pnpm 11 reads pnpm_config_* env vars instead of npm_config_*
   process.env.pnpm_config_registry = registry;
   process.env[`pnpm_config_//${listenAddress}:${port}/:_authToken`] = authToken;
+  // pnpm 11's minimumReleaseAge policy rejects packages published < 24h ago
+  process.env.pnpm_config_minimum_release_age = '0';
 
   // bun
   process.env.BUN_CONFIG_REGISTRY = registry;

--- a/scripts/nx-release.ts
+++ b/scripts/nx-release.ts
@@ -471,8 +471,11 @@ function parseArgs() {
 }
 
 function getRegistry() {
+  // nx release publish delegates to `pnpm publish` in this repo, so pnpm's
+  // config resolution decides where packages would go. Note pnpm 11 reads
+  // pnpm_config_* env vars and ~/.npmrc, but ignores npm_config_* env vars.
   return new URL(
-    execSync('npm config get registry', {
+    execSync('pnpm config get registry', {
       windowsHide: false,
     })
       .toString()


### PR DESCRIPTION
## Current Behavior

pnpm 11 fails installs with `ERR_PNPM_IGNORED_BUILDS` when a dependency's build scripts are neither allowed nor denied. Workspaces generated by `create-nx-workspace` only allow `nx`, so any flow that pulls in a build-script dependency hard-fails: jest 30 pulls in `unrs-resolver` (via `jest-resolve`), vite pulls in `esbuild`, swc setups pull in `@swc/core`, etc. This breaks preset installs for real pnpm 11 users and is the dominant cause of the nightly E2E matrix failures (~70 of 139 jobs die in `newProject()`): https://github.com/nrwl/nx/actions/runs/28642151329

Three more nightly root causes ride along:

- When a plugin throws a non-Error value, `formatAggregateCreateNodesError` crashes with `Cannot read properties of undefined (reading 'split')`, masking the real error (js-strip-types failures).
- `@angular/cli@22.0.5` raised its Node floor to `^22.22.3 || ^24.15.0`, so `ng new` refuses to run on the matrix's pinned Node 22.13.0 / 24.0.0 (e2e-nx-init, e2e-angular).
- e2e tests `pnpm add` plugins directly (no generator runs first), so they hit the strict build gate regardless of generator fixes.

## Expected Behavior

- Generators that introduce build-script dependencies record the `allowBuilds` decision in `pnpm-workspace.yaml` before their install task runs, via a new comment-preserving `acknowledgePnpmBuildScripts` helper (exposed through `@nx/devkit/internal`): jest acknowledges `unrs-resolver`, vite/esbuild acknowledge `esbuild`, swc setups acknowledge `@swc/core`, nest acknowledges `@nestjs/core` (all `false` = skipped, matching pnpm 10 behavior since they ship prebuilt binaries or only print funding messages); cypress and detox set `true` because their install scripts are required to function. Entries the user already set are never overwritten; the helper no-ops for non-pnpm workspaces and pnpm < 11. Generated workspaces no longer preseed entries for dependencies they may never have.
- Non-Error `createNodes` failures are coerced to Errors in the `AggregateCreateNodesError` constructor so the real failure always surfaces.
- The e2e matrix pins Node 22.22.3 / 24.15.0, satisfying the Angular CLI floor.
- e2e-created pnpm/lerna workspaces are seeded with `strictDepBuilds: false` (pnpm 10's warn-and-skip behavior) since tests install plugins without running generators first.

Known gap (documented in the commit): `nx add <plugin>` installs the plugin package before its init generator runs, so a plugin whose own dependency tree carries a build-script package (e.g. `@nx/jest` → `jest-resolve` → `unrs-resolver`) still surfaces pnpm's `approve-builds` error in that flow.

## Related Issue(s)

Nightly E2E matrix failure: https://github.com/nrwl/nx/actions/runs/28642151329

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/PR-for-pnpm-11-ERR_PNPM_IGNORED_BUILDS-fix-f71af2eb)
<!-- polygraph-session-end -->