### PR TITLE
chore(repo): add sigsegv ab hunt diagnostic workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,8 +92,18 @@ jobs:
         run:
           pnpm nx report
 
+      - name: Enable core dumps for segfault diagnostics
+        run: |
+          sudo mkdir -p /tmp/cores && sudo chmod 777 /tmp/cores
+          # Runner default pipes cores to apport, which discards them.
+          sudo sysctl -w kernel.core_pattern='/tmp/cores/core.%e.%p'
+
       - name: Run Checks/Lint/Test/Build
         run: |
+          # Intermittent SIGSEGV kills of nx clients happen in this step
+          # (e.g. runs 29067764140, 29103579727); keep cores so the
+          # "Collect segfault cores" step can capture a native backtrace.
+          ulimit -c unlimited
           pids=()
 
           pnpm nx record -- nx format:check &
@@ -115,6 +125,38 @@ jobs:
             wait "$pid"
           done
         timeout-minutes: 100
+      - name: Collect segfault cores
+        if: failure()
+        run: |
+          shopt -s nullglob
+          cores=(/tmp/cores/core.*)
+          if [ ${#cores[@]} -eq 0 ]; then
+            echo 'No core dumps found'
+            exit 0
+          fi
+          command -v gdb >/dev/null || { sudo apt-get update -q && sudo apt-get install -y -q gdb; }
+          kept=0
+          for c in "${cores[@]}"; do
+            echo "===== backtrace for $c ====="
+            gdb -q -batch -ex 'set pagination off' -ex bt -ex 'info threads' \
+              "$(command -v node)" "$c" 2>&1 | head -150 | tee -a /tmp/backtraces.txt
+            if [ "$kept" -lt 3 ]; then
+              gzip -f "$c" && kept=$((kept+1)) || true
+            else
+              rm -f "$c"
+            fi
+          done
+
+      - name: Upload segfault cores
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: segfault-cores-linux
+          path: |
+            /tmp/backtraces.txt
+            /tmp/cores/*.gz
+          if-no-files-found: ignore
+
       - name: Fix CI
         run: pnpm nx fix-ci
         if: failure()

--- a/.github/workflows/sigsegv-ab.yml
+++ b/.github/workflows/sigsegv-ab.yml
@@ -1,0 +1,183 @@
+name: SIGSEGV AB Hunt
+
+# Diagnostic workflow for the intermittent SIGSEGV kills of nx clients in
+# main-linux (see e.g. run 29103579727). Reproduces the crash conditions
+# (concurrent cloud-recording nx clients, cold shared V8 compile cache,
+# heartbeat spawn window) in a loop, across three legs:
+#   - node 26.3.0                      (current CI default; expected to crash)
+#   - node 24.11.0                     (pre-Jun-3 pin; expected clean)
+#   - node 26.3.0 + NX_COMPILE_CACHE=false (isolates the compile cache)
+# Captures core dumps and prints gdb backtraces so the first crash yields a
+# native stack. Report-only: legs always end green; read the step summary.
+
+on:
+  push:
+    branches:
+      - ci-segv-ab
+  workflow_dispatch:
+    inputs:
+      iterations:
+        description: Loop count per leg
+        default: '60'
+
+env:
+  NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
+  NX_CLOUD_ENABLE_METRICS_COLLECTION: 'true'
+  PNPM_HOME: ~/.pnpm
+  COREPACK_DEFAULT_TO_LATEST: '0'
+
+jobs:
+  hunt:
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - leg: node26
+            node-version: 26.3.0
+            nx-compile-cache: 'true'
+          - leg: node24
+            node-version: 24.11.0
+            nx-compile-cache: 'true'
+          - leg: node26-no-compile-cache
+            node-version: 26.3.0
+            nx-compile-cache: 'false'
+    env:
+      NODE_VERSION: ${{ matrix.node-version }}
+      NX_COMPILE_CACHE: ${{ matrix.nx-compile-cache }}
+      NX_DAEMON: 'true'
+      NX_PERF_LOGGING: 'false'
+      NX_NATIVE_LOGGING: 'false'
+      NX_CI_EXECUTION_ENV: 'linux'
+      NX_CLOUD_NO_TIMEOUTS: 'true'
+      NX_CLOUD_VERBOSE_LOGGING: 'true'
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+        with:
+          fetch-depth: 0
+          filter: tree:0
+
+      - name: Fetch Master
+        run: git fetch origin master:master
+
+      - name: Set SHAs
+        uses: nrwl/nx-set-shas@310288c04d90696f9f1bc27c5e3caea6642b53d4 # v5.0.0
+        with:
+          main-branch-name: 'master'
+
+      - name: Setup dev tools with mise
+        uses: jdx/mise-action@146a28175021df8ca24f8ee1828cc2a60f980bd5 # v3
+
+      - name: Enable corepack and install pnpm
+        run: |
+          corepack enable
+          corepack prepare --activate
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        run: echo "STORE_PATH=$(pnpm store path)" >> $GITHUB_OUTPUT
+
+      - name: Cache pnpm store
+        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install project dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Crash hunt loop
+        run: |
+          set -uo pipefail
+          sudo mkdir -p /tmp/cores && sudo chmod 777 /tmp/cores
+          # Runner default pipes cores to apport, which discards them.
+          sudo sysctl -w kernel.core_pattern='/tmp/cores/core.%e.%p'
+          ulimit -c unlimited
+          command -v gdb >/dev/null || { sudo apt-get update -q && sudo apt-get install -y -q gdb; }
+
+          ITER='${{ inputs.iterations }}'
+          ITER="${ITER:-60}"
+          crashes=0
+          kept_cores=0
+
+          for i in $(seq 1 "$ITER"); do
+            # Re-open the heartbeat spawn window: without this, iteration 1's
+            # heartbeat process survives and later iterations skip the spawn
+            # path where the crash lands. Ephemeral runner, targeted pattern.
+            pkill -f 'heartbeat/background-process' 2>/dev/null || true
+            rm -rf /tmp/run-group-* 2>/dev/null || true
+            # Cold shared compile cache each iteration = the racy write window.
+            rm -rf /tmp/node-compile-cache 2>/dev/null || true
+
+            # Direct bin invocation (not `pnpm nx`): pnpm collapses a child's
+            # signal death into exit 1, which would hide 128+SIGSEGV from wait.
+            pids=(); names=()
+            node_modules/.bin/nx run-many -t check-imports check-lock-files check-codeowners --parallel=1 --no-dte > /tmp/iter-runmany.log 2>&1 &
+            pids+=($!); names+=(runmany)
+            node_modules/.bin/nx run-many -t check-lock-files --parallel=1 --no-dte > /tmp/iter-lockfiles.log 2>&1 &
+            pids+=($!); names+=(lockfiles)
+            node_modules/.bin/nx sync:check > /tmp/iter-sync.log 2>&1 &
+            pids+=($!); names+=(sync)
+
+            iter_crash=0
+            for idx in "${!pids[@]}"; do
+              ec=0; wait "${pids[$idx]}" || ec=$?
+              if [ "$ec" -ge 128 ]; then
+                iter_crash=1
+                sig=$((ec - 128))
+                echo "::warning::iter $i: ${names[$idx]} died with signal $sig (exit $ec)"
+                echo "===== iter $i ${names[$idx]} log tail ====="
+                tail -50 "/tmp/iter-${names[$idx]}.log" || true
+              fi
+            done
+            # A core from ANY process (client, daemon, heartbeat child) or
+            # segfault text in a log also counts as a crash.
+            if compgen -G '/tmp/cores/core.*' > /dev/null 2>&1; then
+              ls /tmp/cores/core.* 2>/dev/null | grep -qv '\.gz$' && iter_crash=1
+            fi
+            if grep -laiE 'SIGSEGV|Segmentation fault' /tmp/iter-*.log > /dev/null 2>&1; then
+              iter_crash=1
+              echo "::warning::iter $i: segfault text found in logs"
+              grep -aiE 'SIGSEGV|Segmentation fault' /tmp/iter-*.log | head -5 || true
+            fi
+
+            if [ "$iter_crash" = 1 ]; then
+              crashes=$((crashes+1))
+              sudo dmesg 2>/dev/null | grep -iE 'segv|segfault' | tail -5 || true
+              for core in /tmp/cores/core.*; do
+                [ -e "$core" ] || continue
+                case "$core" in *.gz) continue ;; esac
+                echo "===== backtrace for $core ====="
+                gdb -q -batch -ex 'set pagination off' -ex bt -ex 'info threads' \
+                  "$(command -v node)" "$core" 2>&1 | head -150 | tee -a /tmp/backtraces.txt
+                if [ "$kept_cores" -lt 2 ]; then
+                  gzip -f "$core" && kept_cores=$((kept_cores+1)) || true
+                else
+                  rm -f "$core"
+                fi
+              done
+            fi
+            echo "iter $i/$ITER done (crashes so far: $crashes)"
+          done
+
+          {
+            echo "## Leg ${{ matrix.leg }} (node $NODE_VERSION, NX_COMPILE_CACHE=$NX_COMPILE_CACHE)"
+            echo ""
+            echo "**$crashes / $ITER iterations had signal deaths**"
+          } >> "$GITHUB_STEP_SUMMARY"
+          echo "RESULT leg=${{ matrix.leg }}: $crashes/$ITER iterations had signal deaths"
+
+      - name: Upload crash evidence
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: crash-evidence-${{ matrix.leg }}
+          path: |
+            /tmp/backtraces.txt
+            /tmp/cores/*.gz
+          if-no-files-found: ignore

--- a/.github/workflows/sigsegv-ab.yml
+++ b/.github/workflows/sigsegv-ab.yml
@@ -104,6 +104,11 @@ jobs:
           ITER="${ITER:-60}"
           crashes=0
           kept_cores=0
+          hb_windows=0
+
+          # Production parity: the crashing step always runs inside a CIPE
+          # started at the top of the job.
+          npx nx-cloud@next start-ci-run || true
 
           for i in $(seq 1 "$ITER"); do
             # Re-open the heartbeat spawn window: without this, iteration 1's
@@ -123,6 +128,10 @@ jobs:
             pids+=($!); names+=(lockfiles)
             node_modules/.bin/nx sync:check > /tmp/iter-sync.log 2>&1 &
             pids+=($!); names+=(sync)
+            node_modules/.bin/nx record -- echo "iter-$i-a" > /tmp/iter-reca.log 2>&1 &
+            pids+=($!); names+=(reca)
+            node_modules/.bin/nx record -- echo "iter-$i-b" > /tmp/iter-recb.log 2>&1 &
+            pids+=($!); names+=(recb)
 
             iter_crash=0
             for idx in "${!pids[@]}"; do
@@ -140,10 +149,17 @@ jobs:
             if compgen -G '/tmp/cores/core.*' > /dev/null 2>&1; then
               ls /tmp/cores/core.* 2>/dev/null | grep -qv '\.gz$' && iter_crash=1
             fi
-            if grep -laiE 'SIGSEGV|Segmentation fault' /tmp/iter-*.log > /dev/null 2>&1; then
+            # Case-sensitive: the branch's own lowercase commit title
+            # ("...sigsegv ab hunt...") echoes into Nx Cloud metadata in every
+            # log, so -i produced 100% false positives on the first run.
+            if grep -laE 'SIGSEGV|Segmentation fault' /tmp/iter-*.log > /dev/null 2>&1; then
               iter_crash=1
               echo "::warning::iter $i: segfault text found in logs"
-              grep -aiE 'SIGSEGV|Segmentation fault' /tmp/iter-*.log | head -5 || true
+              grep -aE 'SIGSEGV|Segmentation fault' /tmp/iter-*.log | head -5 || true
+            fi
+            # Probe: confirm the heartbeat spawn window was actually exercised.
+            if grep -laq 'heartbeat background process' /tmp/iter-*.log 2>/dev/null; then
+              hb_windows=$((hb_windows+1))
             fi
 
             if [ "$iter_crash" = 1 ]; then
@@ -169,8 +185,10 @@ jobs:
             echo "## Leg ${{ matrix.leg }} (node $NODE_VERSION, NX_COMPILE_CACHE=$NX_COMPILE_CACHE)"
             echo ""
             echo "**$crashes / $ITER iterations had signal deaths**"
+            echo ""
+            echo "Heartbeat spawn window exercised in $hb_windows / $ITER iterations"
           } >> "$GITHUB_STEP_SUMMARY"
-          echo "RESULT leg=${{ matrix.leg }}: $crashes/$ITER iterations had signal deaths"
+          echo "RESULT leg=${{ matrix.leg }}: $crashes/$ITER iterations had signal deaths (heartbeat window in $hb_windows)"
 
       - name: Upload crash evidence
         if: always()

--- a/.github/workflows/sigsegv-ab.yml
+++ b/.github/workflows/sigsegv-ab.yml
@@ -66,15 +66,28 @@ jobs:
             exit 1
           fi
           command -v gdb >/dev/null || { sudo apt-get update -q && sudo apt-get install -y -q gdb; }
+          # `command -v node` resolves to the mise SHIM (a Rust binary), and
+          # symbolizing against the wrong executable yields garbage frames —
+          # the first canary run proved it. Read the real executable path
+          # from the core itself.
+          exe=$(file -b "${cores[0]}" | sed -n "s/.*execfn: '\([^']*\)'.*/\1/p")
+          [ -x "$exe" ] || exe=$(mise which node 2>/dev/null || command -v node)
+          echo "symbolizing against: $exe"
           gdb -q -batch -ex 'set pagination off' -ex bt -ex 'info threads' \
-            "$(command -v node)" "${cores[0]}" 2>&1 | tee /tmp/bt.txt
+            "$exe" "${cores[0]}" 2>&1 | tee /tmp/bt.txt
           frames=$(grep -c '^#' /tmp/bt.txt || true)
           echo "backtrace frames: $frames"
           if [ "$frames" -lt 3 ]; then
             echo '::error::CANARY FAILED: gdb produced fewer than 3 frames'
             exit 1
           fi
-          echo "Canary OK: core captured, $frames frames resolved" >> "$GITHUB_STEP_SUMMARY"
+          # A raise()-induced SIGSEGV with the CORRECT executable must
+          # resolve real symbols (libc raise/pthread_kill or node/v8/libuv).
+          if ! grep -qE 'raise|pthread_kill|node::|v8::|uv_' /tmp/bt.txt; then
+            echo '::error::CANARY FAILED: no recognizable symbols — wrong executable?'
+            exit 1
+          fi
+          echo "Canary OK: core captured, $frames frames, symbols resolve against $exe" >> "$GITHUB_STEP_SUMMARY"
 
   hunt:
     runs-on: ubuntu-latest
@@ -234,8 +247,10 @@ jobs:
                 [ -e "$core" ] || continue
                 case "$core" in *.gz) continue ;; esac
                 echo "===== backtrace for $core ====="
+                exe=$(file -b "$core" | sed -n "s/.*execfn: '\([^']*\)'.*/\1/p")
+                [ -x "$exe" ] || exe=$(mise which node 2>/dev/null || command -v node)
                 gdb -q -batch -ex 'set pagination off' -ex bt -ex 'info threads' \
-                  "$(command -v node)" "$core" 2>&1 | head -150 | tee -a /tmp/backtraces.txt
+                  "$exe" "$core" 2>&1 | head -150 | tee -a /tmp/backtraces.txt
                 if [ "$kept_cores" -lt 2 ]; then
                   gzip -f "$core" && kept_cores=$((kept_cores+1)) || true
                 else

--- a/.github/workflows/sigsegv-ab.yml
+++ b/.github/workflows/sigsegv-ab.yml
@@ -27,6 +27,55 @@ env:
   COREPACK_DEFAULT_TO_LATEST: '0'
 
 jobs:
+  # Proves the capture pipeline in ci.yml's "Collect segfault cores" end to
+  # end: a real node process is SIGSEGV'd on purpose under the identical
+  # core_pattern/ulimit setup, and the job FAILS unless a core appears and
+  # gdb yields usable frames. Runs on every push; the expensive hunt legs
+  # only run on manual dispatch.
+  canary:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      NODE_VERSION: 26.3.0
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Setup dev tools with mise
+        uses: jdx/mise-action@146a28175021df8ca24f8ee1828cc2a60f980bd5 # v3
+
+      - name: Enable core dumps exactly like the ci.yml catcher
+        run: |
+          sudo mkdir -p /tmp/cores && sudo chmod 777 /tmp/cores
+          sudo sysctl -w kernel.core_pattern='/tmp/cores/core.%e.%p'
+
+      - name: Crash a real node process on purpose
+        run: |
+          ulimit -c unlimited
+          ec=0
+          node -e 'process.kill(process.pid, "SIGSEGV")' || ec=$?
+          echo "node exited with $ec (expect 139)"
+          ls -la /tmp/cores/
+
+      - name: Validate a core was captured and gdb yields frames
+        run: |
+          shopt -s nullglob
+          cores=(/tmp/cores/core.*)
+          if [ ${#cores[@]} -eq 0 ]; then
+            echo '::error::CANARY FAILED: no core dump captured'
+            exit 1
+          fi
+          command -v gdb >/dev/null || { sudo apt-get update -q && sudo apt-get install -y -q gdb; }
+          gdb -q -batch -ex 'set pagination off' -ex bt -ex 'info threads' \
+            "$(command -v node)" "${cores[0]}" 2>&1 | tee /tmp/bt.txt
+          frames=$(grep -c '^#' /tmp/bt.txt || true)
+          echo "backtrace frames: $frames"
+          if [ "$frames" -lt 3 ]; then
+            echo '::error::CANARY FAILED: gdb produced fewer than 3 frames'
+            exit 1
+          fi
+          echo "Canary OK: core captured, $frames frames resolved" >> "$GITHUB_STEP_SUMMARY"
+
   hunt:
     runs-on: ubuntu-latest
     timeout-minutes: 90
@@ -111,7 +160,9 @@ jobs:
           trap 'kill $STRESS_PID 2>/dev/null || true' EXIT
 
           ITER='${{ inputs.iterations }}'
-          ITER="${ITER:-60}"
+          # Cache-busted iterations execute tasks for real (~2-3 min each
+          # instead of ~25s replays), so the push-triggered default is lower.
+          ITER="${ITER:-20}"
           crashes=0
           kept_cores=0
           hb_windows=0
@@ -128,6 +179,10 @@ jobs:
             rm -rf /tmp/run-group-* 2>/dev/null || true
             # Cold shared compile cache each iteration = the racy write window.
             rm -rf /tmp/node-compile-cache 2>/dev/null || true
+            # Bust the nx cache (nx.json sharedGlobals includes this env var)
+            # so every iteration EXECUTES tasks — real fork/exec churn, cache
+            # writes, and terminal-output uploads — instead of cache replays.
+            export NX_AB_SALT="salt-$i"
 
             # Direct bin invocation (not `pnpm nx`): pnpm collapses a child's
             # signal death into exit 1, which would hide 128+SIGSEGV from wait.

--- a/.github/workflows/sigsegv-ab.yml
+++ b/.github/workflows/sigsegv-ab.yml
@@ -100,6 +100,16 @@ jobs:
           ulimit -c unlimited
           command -v gdb >/dev/null || { sudo apt-get update -q && sudo apt-get install -y -q gdb; }
 
+          # Rounds 1-2 (idle box) produced 0 crashes in 180 exercised
+          # heartbeat windows. Production crashes happen while the full
+          # affected build/test/e2e wave loads the runner, so recreate that
+          # pressure: CPU contention + memory pressure force frequent V8 GC,
+          # which is where latent heap corruption actually manifests.
+          command -v stress-ng >/dev/null || sudo apt-get install -y -q stress-ng
+          stress-ng --cpu 2 --vm 2 --vm-bytes 40% --quiet &
+          STRESS_PID=$!
+          trap 'kill $STRESS_PID 2>/dev/null || true' EXIT
+
           ITER='${{ inputs.iterations }}'
           ITER="${ITER:-60}"
           crashes=0

--- a/nx.json
+++ b/nx.json
@@ -16,7 +16,8 @@
     "sharedGlobals": [
       "{workspaceRoot}/babel.config.json",
       "{workspaceRoot}/.nx/workflows/agents.yaml",
-      "{workspaceRoot}/.github/workflows/ci.yml"
+      "{workspaceRoot}/.github/workflows/ci.yml",
+      { "env": "NX_AB_SALT" }
     ],
     "copyReadme": [
       "{projectRoot}/README.md",


### PR DESCRIPTION
> **Diagnostic PR — not intended to merge as-is.** It exists to run the `SIGSEGV AB Hunt` workflow on CI infrastructure and capture a native stack for the intermittent segfaults.

## Current Behavior

`main-linux` CI jobs are intermittently killed by SIGSEGV. Three identical instances are fingerprinted (Jun 27 run 28275… job 83784567773; Jul 10 runs 29067764140 and 29103579727): the backgrounded `nx run-many -t check-imports check-lock-files check-codeowners --parallel=1 --no-dte` client dies ~3.5s after startup — right in the Nx Cloud heartbeat spawn window — printing a bare `undefined` and then being killed. All instances postdate the Jun 3 CI bump from node 24.11.0 to 26.3.0 (#35847); the same setup ran clean on node 24 for the prior four weeks. There is no native stack trace anywhere, so the root cause (V8 vs shared compile cache vs native binding) cannot be pinned.

## Expected Behavior

A `workflow_dispatch`/branch-push workflow (`.github/workflows/sigsegv-ab.yml`) loops the crash conditions ~60× per leg across three legs:

| Leg | Purpose |
|-----|---------|
| node 26.3.0 | control — current CI default, expected to crash |
| node 24.11.0 | previous pin — expected clean |
| node 26.3.0 + `NX_COMPILE_CACHE=false` | isolates the shared V8 compile cache |

Each iteration runs 3 concurrent nx clients with a cold shared `/tmp/node-compile-cache` and a fresh heartbeat run-group, with core dumps enabled (`kernel.core_pattern` repointed away from apport) and `gdb` backtraces printed in-log and uploaded as artifacts. Legs are report-only (always green); results land in each leg's step summary as `N / 60 iterations had signal deaths`. nx is invoked via `node_modules/.bin/nx` directly because pnpm collapses signal deaths into exit 1.

## Related Issue(s)

N/A — diagnostic for the intermittent CI SIGSEGV investigation (notes tracked internally).

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/CI-SIGSEGV-A-B-hunt-node-26.3.0-vs-24.11.0-vs-compile-cache-off-1f3ab9a9)
<!-- polygraph-session-end -->