### PR TITLE
chore(repo): capture segfault cores and backtraces in main linux ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -138,8 +138,13 @@ jobs:
           kept=0
           for c in "${cores[@]}"; do
             echo "===== backtrace for $c ====="
+            # `command -v node` resolves to the mise shim; symbolizing a core
+            # against the wrong executable yields garbage frames. Read the
+            # crashed process's real executable path from the core itself.
+            exe=$(file -b "$c" | sed -n "s/.*execfn: '\([^']*\)'.*/\1/p")
+            [ -x "$exe" ] || exe=$(mise which node 2>/dev/null || command -v node)
             gdb -q -batch -ex 'set pagination off' -ex bt -ex 'info threads' \
-              "$(command -v node)" "$c" 2>&1 | head -150 | tee -a /tmp/backtraces.txt
+              "$exe" "$c" 2>&1 | head -150 | tee -a /tmp/backtraces.txt
             if [ "$kept" -lt 3 ]; then
               gzip -f "$c" && kept=$((kept+1)) || true
             else

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,8 +92,18 @@ jobs:
         run:
           pnpm nx report
 
+      - name: Enable core dumps for segfault diagnostics
+        run: |
+          sudo mkdir -p /tmp/cores && sudo chmod 777 /tmp/cores
+          # Runner default pipes cores to apport, which discards them.
+          sudo sysctl -w kernel.core_pattern='/tmp/cores/core.%e.%p'
+
       - name: Run Checks/Lint/Test/Build
         run: |
+          # Intermittent SIGSEGV kills of nx clients happen in this step
+          # (e.g. runs 29067764140, 29103579727); keep cores so the
+          # "Collect segfault cores" step can capture a native backtrace.
+          ulimit -c unlimited
           pids=()
 
           pnpm nx record -- nx format:check &
@@ -115,6 +125,38 @@ jobs:
             wait "$pid"
           done
         timeout-minutes: 100
+      - name: Collect segfault cores
+        if: failure()
+        run: |
+          shopt -s nullglob
+          cores=(/tmp/cores/core.*)
+          if [ ${#cores[@]} -eq 0 ]; then
+            echo 'No core dumps found'
+            exit 0
+          fi
+          command -v gdb >/dev/null || { sudo apt-get update -q && sudo apt-get install -y -q gdb; }
+          kept=0
+          for c in "${cores[@]}"; do
+            echo "===== backtrace for $c ====="
+            gdb -q -batch -ex 'set pagination off' -ex bt -ex 'info threads' \
+              "$(command -v node)" "$c" 2>&1 | head -150 | tee -a /tmp/backtraces.txt
+            if [ "$kept" -lt 3 ]; then
+              gzip -f "$c" && kept=$((kept+1)) || true
+            else
+              rm -f "$c"
+            fi
+          done
+
+      - name: Upload segfault cores
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: segfault-cores-linux
+          path: |
+            /tmp/backtraces.txt
+            /tmp/cores/*.gz
+          if-no-files-found: ignore
+
       - name: Fix CI
         run: pnpm nx fix-ci
         if: failure()


### PR DESCRIPTION
## Current Behavior

`main-linux` jobs are intermittently killed by SIGSEGV (e.g. runs [29067764140](https://github.com/nrwl/nx/actions/runs/29067764140) and [29103579727](https://github.com/nrwl/nx/actions/runs/29103579727): the backgrounded `nx run-many -t check-imports check-lock-files check-codeowners` client dies ~3.5s after startup in the Nx Cloud heartbeat spawn window). When it happens there is **no native stack trace anywhere**: the GitHub runner's default `kernel.core_pattern` pipes core dumps to apport, which discards them, so every crash leaves only a one-line `killed with SIGSEGV`.

A dedicated reproduction effort (PR #36303, 3 rounds × 3 legs: node 26.3.0 / node 24.11.0 / node 26.3.0 + `NX_COMPILE_CACHE=false`, ~360 iterations including stress-ng CPU+memory pressure, heartbeat spawn window verified exercised every iteration) produced **zero** crashes — the trigger needs something the real job has (likely the affected wave's fork/exec churn), so it cannot be cheaply reproduced outside production.

## Expected Behavior

The next organic crash produces actionable evidence instead of a one-liner:

- `kernel.core_pattern` is repointed to `/tmp/cores` and `ulimit -c unlimited` is set inside the `Run Checks/Lint/Test/Build` step, so any segfaulting process on the runner (nx client, daemon, heartbeat child, jest worker) leaves a core.
- On job failure, a `Collect segfault cores` step prints a `gdb` backtrace (`bt` + `info threads`) for each core into the job log and keeps up to 3 gzipped cores.
- An `Upload segfault cores` step publishes `backtraces.txt` and the gzipped cores as a `segfault-cores-linux` artifact.

When the job passes or no process segfaults, the added steps are a no-op (a few seconds of overhead at job start; the collect/upload steps only run `if: failure()`).

## Related Issue(s)

Related diagnostic PR: #36303 (SIGSEGV A/B hunt — experiment sandbox, not for merge). Investigation fingerprint: three identical production crashes (Jun 27, Jul 10 ×2), all post the Jun 3 node 24.11.0 → 26.3.0 bump (#35847).

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/CI-SIGSEGV-A-B-hunt-node-26.3.0-vs-24.11.0-vs-compile-cache-off-1f3ab9a9)
<!-- polygraph-session-end -->