### PR TITLE
fix(webpack): bundle non-buildable library subpaths with fallback-array exports

### DIFF
--- a/packages/rspack/src/plugins/utils/get-non-buildable-libs.spec.ts
+++ b/packages/rspack/src/plugins/utils/get-non-buildable-libs.spec.ts
@@ -151,4 +151,42 @@ describe('createAllowlistFromExports', () => {
     } as any);
     expect(result).toEqual(['@test/lib', '@test/lib/valid']);
   });
+
+  it('should handle wildcard exports with fallback array targets', () => {
+    const result = createAllowlistFromExports('@test/lib', {
+      './*': ['./src/*.ts', './src/*/index.ts'],
+    });
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBe('@test/lib');
+    expect(result[1]).toBeInstanceOf(RegExp);
+
+    const regex = result[1] as RegExp;
+    expect(regex.test('@test/lib/utils')).toBe(true);
+    expect(regex.test('@test/lib/filters/all-exceptions.filter')).toBe(true);
+    expect(regex.test('@test/lib')).toBe(false);
+  });
+
+  it('should handle exact subpath exports with fallback array targets', () => {
+    const result = createAllowlistFromExports('@test/lib', {
+      './utils': ['./src/utils.ts', './src/utils/index.ts'],
+    });
+    expect(result).toEqual(['@test/lib', '@test/lib/utils']);
+  });
+
+  it('should handle fallback arrays nested in conditional exports', () => {
+    const result = createAllowlistFromExports('@test/lib', {
+      './utils': {
+        development: ['./src/utils.ts', './src/utils/index.ts'],
+      },
+    });
+    expect(result).toEqual(['@test/lib', '@test/lib/utils']);
+  });
+
+  it('should skip export paths with empty fallback arrays', () => {
+    const result = createAllowlistFromExports('@test/lib', {
+      './utils': [],
+      './valid': './src/valid.ts',
+    });
+    expect(result).toEqual(['@test/lib', '@test/lib/valid']);
+  });
 });

--- a/packages/rspack/src/plugins/utils/get-non-buildable-libs.ts
+++ b/packages/rspack/src/plugins/utils/get-non-buildable-libs.ts
@@ -16,12 +16,26 @@ function resolveConditionalExport(target: any): string | null {
     return target;
   }
 
+  // Fallback arrays: take the first non-empty target. Node resolves them in
+  // order on disk; for the allowlist any valid target marks the subpath.
+  if (Array.isArray(target)) {
+    for (const candidate of target) {
+      const resolved = resolveConditionalExport(candidate);
+      if (resolved) {
+        return resolved;
+      }
+    }
+
+    return null;
+  }
+
   if (typeof target === 'object' && target !== null) {
     // Priority order for conditions
     const conditions = ['development', 'import', 'require', 'default'];
     for (const condition of conditions) {
-      if (target[condition] && typeof target[condition] === 'string') {
-        return target[condition];
+      const resolved = resolveConditionalExport(target[condition]);
+      if (resolved) {
+        return resolved;
       }
     }
   }

--- a/packages/webpack/src/plugins/nx-webpack-plugin/lib/utils.spec.ts
+++ b/packages/webpack/src/plugins/nx-webpack-plugin/lib/utils.spec.ts
@@ -151,4 +151,42 @@ describe('createAllowlistFromExports', () => {
     } as any);
     expect(result).toEqual(['@test/lib', '@test/lib/valid']);
   });
+
+  it('should handle wildcard exports with fallback array targets', () => {
+    const result = createAllowlistFromExports('@test/lib', {
+      './*': ['./src/*.ts', './src/*/index.ts'],
+    });
+    expect(result).toHaveLength(2);
+    expect(result[0]).toBe('@test/lib');
+    expect(result[1]).toBeInstanceOf(RegExp);
+
+    const regex = result[1] as RegExp;
+    expect(regex.test('@test/lib/utils')).toBe(true);
+    expect(regex.test('@test/lib/filters/all-exceptions.filter')).toBe(true);
+    expect(regex.test('@test/lib')).toBe(false);
+  });
+
+  it('should handle exact subpath exports with fallback array targets', () => {
+    const result = createAllowlistFromExports('@test/lib', {
+      './utils': ['./src/utils.ts', './src/utils/index.ts'],
+    });
+    expect(result).toEqual(['@test/lib', '@test/lib/utils']);
+  });
+
+  it('should handle fallback arrays nested in conditional exports', () => {
+    const result = createAllowlistFromExports('@test/lib', {
+      './utils': {
+        development: ['./src/utils.ts', './src/utils/index.ts'],
+      },
+    });
+    expect(result).toEqual(['@test/lib', '@test/lib/utils']);
+  });
+
+  it('should skip export paths with empty fallback arrays', () => {
+    const result = createAllowlistFromExports('@test/lib', {
+      './utils': [],
+      './valid': './src/valid.ts',
+    });
+    expect(result).toEqual(['@test/lib', '@test/lib/valid']);
+  });
 });

--- a/packages/webpack/src/plugins/nx-webpack-plugin/lib/utils.ts
+++ b/packages/webpack/src/plugins/nx-webpack-plugin/lib/utils.ts
@@ -15,12 +15,26 @@ function resolveConditionalExport(target: any): string | null {
     return target;
   }
 
+  // Fallback arrays: take the first non-empty target. Node resolves them in
+  // order on disk; for the allowlist any valid target marks the subpath.
+  if (Array.isArray(target)) {
+    for (const candidate of target) {
+      const resolved = resolveConditionalExport(candidate);
+      if (resolved) {
+        return resolved;
+      }
+    }
+
+    return null;
+  }
+
   if (typeof target === 'object' && target !== null) {
     // Priority order for conditions
     const conditions = ['development', 'import', 'require', 'default'];
     for (const condition of conditions) {
-      if (target[condition] && typeof target[condition] === 'string') {
-        return target[condition];
+      const resolved = resolveConditionalExport(target[condition]);
+      if (resolved) {
+        return resolved;
       }
     }
   }


### PR DESCRIPTION
## Current Behavior

In a TypeScript solution workspace, `@nx/webpack` and `@nx/rspack` leave subpath imports from a non-buildable workspace library external when the library's `package.json` uses a Node fallback-array export target, for example:

```json
{
  "exports": {
    "./*": ["./src/*.ts", "./src/*/index.ts"]
  }
}
```

The import stays a raw `require('@acme/nest-utils/filters/all-exceptions.filter')` in the bundle, so Node resolves it to raw TypeScript at runtime and crashes on non-erasable syntax (for example a NestJS constructor parameter property: `SyntaxError: TypeScript parameter property is not supported in strip-only mode`). Changing the export target from an array to a string works around it.

## Expected Behavior

Fallback arrays are valid Node.js export targets, so Nx produces the same externals allowlist entry for `"./*": "./src/*.ts"` and `"./*": ["./src/*.ts", "./src/*/index.ts"]`. Non-buildable workspace-library subpaths are bundled from source in both cases.

## Related Issue(s)

Fixes #36309

## Implementation Details

`resolveConditionalExport` (mirrored in the `@nx/webpack` and `@nx/rspack` non-buildable-lib helpers) returned `null` for array targets: arrays are `typeof === 'object'` but carry none of the checked condition keys, so `createAllowlistFromExports` skipped the export path and never added the wildcard allowlist entry. It now resolves fallback arrays recursively, returning the first non-empty target, and applies the same recursion to array-valued condition targets such as `{ "import": ["./a.ts"] }`. Unit tests cover wildcard, exact-subpath, condition-nested, and empty-array cases in both packages.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/gh-36309-b8774c4a)
<!-- polygraph-session-end -->