### PR TITLE
feat(core): confirm before creating migration commits on the default branch

### DIFF
--- a/packages/nx/src/command-line/migrate/migrate.spec.ts
+++ b/packages/nx/src/command-line/migrate/migrate.spec.ts
@@ -41,6 +41,7 @@ import { PackageJson } from '../../utils/package-json';
 import * as packageMgrUtils from '../../utils/package-manager';
 
 import {
+  confirmCommitsOnDefaultBranch,
   createFetcher,
   filterDowngradedUpdates,
   formatCommandFailure,
@@ -4997,6 +4998,64 @@ describe('Migration', () => {
         });
         expect(result.effective).toBe(true);
         expect(result.warning).toBeUndefined();
+      });
+    });
+
+    describe('confirmCommitsOnDefaultBranch', () => {
+      beforeEach(() => {
+        jest.clearAllMocks();
+      });
+
+      it('proceeds without prompting when the branch cannot be resolved', async () => {
+        await expect(
+          confirmCommitsOnDefaultBranch({
+            currentBranch: null,
+            defaultBranch: 'main',
+          })
+        ).resolves.toBe(true);
+        expect(mockPrompt).not.toHaveBeenCalled();
+      });
+
+      it('proceeds without prompting when the default branch is unknown', async () => {
+        await expect(
+          confirmCommitsOnDefaultBranch({
+            currentBranch: 'main',
+            defaultBranch: null,
+          })
+        ).resolves.toBe(true);
+        expect(mockPrompt).not.toHaveBeenCalled();
+      });
+
+      it('proceeds without prompting when not on the default branch', async () => {
+        await expect(
+          confirmCommitsOnDefaultBranch({
+            currentBranch: 'feature/foo',
+            defaultBranch: 'main',
+          })
+        ).resolves.toBe(true);
+        expect(mockPrompt).not.toHaveBeenCalled();
+      });
+
+      it('proceeds when the user confirms on the default branch', async () => {
+        mockPrompt.mockResolvedValue({ proceed: true });
+        await expect(
+          confirmCommitsOnDefaultBranch({
+            currentBranch: 'main',
+            defaultBranch: 'main',
+          })
+        ).resolves.toBe(true);
+        expect(mockPrompt).toHaveBeenCalledTimes(1);
+      });
+
+      it('aborts when the user declines on the default branch', async () => {
+        mockPrompt.mockResolvedValue({ proceed: false });
+        await expect(
+          confirmCommitsOnDefaultBranch({
+            currentBranch: 'main',
+            defaultBranch: 'main',
+          })
+        ).resolves.toBe(false);
+        expect(mockPrompt).toHaveBeenCalledTimes(1);
       });
     });
 

--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -43,9 +43,11 @@ import { extractFileFromTarball } from '../../utils/tar';
 import { writeFormattedJsonFile } from '../../utils/write-formatted-json-file';
 import { logger } from '../../utils/logger';
 import {
+  getGitCurrentBranch,
   getUncommittedChangesSnapshot,
   isGitRepository,
 } from '../../utils/git-utils';
+import { getBaseRef } from '../../utils/command-line-utils';
 import {
   ArrayPackageGroup,
   getDependencyVersionFromPackageJson,
@@ -2785,6 +2787,34 @@ export function resolveCreateCommits(args: {
 }
 
 /**
+ * Confirms before creating per-migration commits while the user sits on the
+ * repository's default branch, so migrations don't silently commit there (most
+ * relevant since `--agentic` enables commits by default). Only the default
+ * branch triggers a prompt; a detached HEAD, a different branch, or an
+ * unresolved default branch all proceed untouched. Callers gate this on
+ * commits being effective and prompting being possible, so non-interactive
+ * runs (CI, `--no-interactive`) never reach here.
+ */
+export async function confirmCommitsOnDefaultBranch(args: {
+  currentBranch: string | null;
+  defaultBranch: string | null;
+}): Promise<boolean> {
+  const { currentBranch, defaultBranch } = args;
+  if (!currentBranch || !defaultBranch || currentBranch !== defaultBranch) {
+    return true;
+  }
+  const { proceed } = await migratePrompt<{ proceed: boolean }>([
+    {
+      name: 'proceed',
+      type: 'confirm',
+      message: `You're on the default branch '${currentBranch}'. nx migrate will create a commit for each migration on this branch. Continue?`,
+      initial: false,
+    },
+  ]);
+  return proceed;
+}
+
+/**
  * Resolves whether the framework-owned generic-validation agent step should run
  * after generator-only migrations.
  *
@@ -3470,6 +3500,26 @@ async function runMigrations(
   }
   if (createCommitsWarning) {
     output.warn({ title: createCommitsWarning });
+  }
+
+  if (effectiveCreateCommits && canPrompt(opts.interactive)) {
+    const currentBranch = getGitCurrentBranch(root);
+    // `getBaseRef` may carry an `origin/` prefix (set by the CI-workflow
+    // generator); compare against the local branch name.
+    const defaultBranch = getBaseRef(readNxJson(root)).replace(/^origin\//, '');
+    const proceed = await confirmCommitsOnDefaultBranch({
+      currentBranch,
+      defaultBranch,
+    });
+    if (!proceed) {
+      output.log({
+        title: `Skipped running migrations to avoid committing to the default branch '${currentBranch}'.`,
+        bodyLines: [
+          'Switch to a different branch and re-run, or re-run and confirm to proceed.',
+        ],
+      });
+      return;
+    }
   }
 
   const shouldRunValidation = resolveShouldRunValidation({

--- a/packages/nx/src/utils/git-utils.spec.ts
+++ b/packages/nx/src/utils/git-utils.spec.ts
@@ -1,6 +1,7 @@
 import {
   parseVcsRemoteUrl,
   getVcsRemoteInfo,
+  getGitCurrentBranch,
   getUncommittedChangesSnapshot,
   tryCommitChanges,
 } from './git-utils';
@@ -208,6 +209,38 @@ describe('git utils tests', () => {
       });
 
       expect(getVcsRemoteInfo()).toBeNull();
+    });
+  });
+
+  describe('getGitCurrentBranch', () => {
+    afterEach(() => {
+      jest.resetAllMocks();
+    });
+
+    it('should return the current branch name', () => {
+      (execSync as jest.Mock).mockReturnValue('main\n');
+
+      expect(getGitCurrentBranch()).toBe('main');
+    });
+
+    it('should return null for a detached HEAD', () => {
+      (execSync as jest.Mock).mockReturnValue('HEAD\n');
+
+      expect(getGitCurrentBranch()).toBeNull();
+    });
+
+    it('should return null for empty output', () => {
+      (execSync as jest.Mock).mockReturnValue('\n');
+
+      expect(getGitCurrentBranch()).toBeNull();
+    });
+
+    it('should return null when execSync throws', () => {
+      (execSync as jest.Mock).mockImplementation(() => {
+        throw new Error('not a git repository');
+      });
+
+      expect(getGitCurrentBranch()).toBeNull();
     });
   });
 

--- a/packages/nx/src/utils/git-utils.ts
+++ b/packages/nx/src/utils/git-utils.ts
@@ -357,6 +357,23 @@ export function isGitRepository(directory?: string): boolean {
   }
 }
 
+// Checked-out branch name, or null when there isn't one to act on: a detached
+// HEAD reports the literal "HEAD" (treated as no branch), and any git error
+// (not a repo, no commits yet) also yields null.
+export function getGitCurrentBranch(directory?: string): string | null {
+  try {
+    const branch = execSync('git rev-parse --abbrev-ref HEAD', {
+      encoding: 'utf8',
+      cwd: directory,
+      stdio: ['ignore', 'pipe', 'ignore'],
+      windowsHide: true,
+    }).trim();
+    return branch && branch !== 'HEAD' ? branch : null;
+  } catch {
+    return null;
+  }
+}
+
 // Sync companion to `GitRepository.hasUncommittedChanges` for callers that
 // can't drop into the async class (e.g. the migrate orchestrator, which
 // branches on this before spawning subprocesses synchronously).


### PR DESCRIPTION
## Current Behavior

`nx migrate` creates a commit for each applied migration when `--create-commits` is in effect. Those commits are enabled explicitly with the flag, and now also by default under `--agentic` in interactive runs. When the user is on the repository's default branch, migrations run without warning and write the per-migration commits directly onto the default branch, which is often not what the user wants.

## Expected Behavior

When per-migration commits are in effect and the run is interactive, `nx migrate` now checks whether the current branch is the repository's default branch (resolved via `getBaseRef`, the same signal `nx affected` uses). If so, it prompts for confirmation before proceeding. Declining skips the run so the user can switch to another branch first; confirming proceeds as before. A detached HEAD or any non-default branch proceeds untouched. Non-interactive runs (CI, `--no-interactive`) never prompt and behave exactly as they do today.

## Related Issue(s)

Fixes NXC-4614

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/nxc-4614-e9e9a6a9)
<!-- polygraph-session-end -->