### PR TITLE
fix(core): stop ratatui cursor queries from racing the TUI event stream

### DIFF
--- a/packages/nx/src/native/tui/inline_app.rs
+++ b/packages/nx/src/native/tui/inline_app.rs
@@ -784,7 +784,7 @@ impl InlineApp {
 
                     // Call insert_before on the dereferenced Terminal
                     // This only works with inline viewport
-                    if let Ok(()) = tui.insert_before(height, |buf| {
+                    match tui.insert_before(height, |buf| {
                         // Convert batched scrollback lines to owned ratatui Lines
                         let lines: Vec<Line<'static>> =
                             batch.iter().map(|line| Line::from(line.clone())).collect();
@@ -797,18 +797,21 @@ impl InlineApp {
                         use ratatui::widgets::Widget;
                         paragraph.render(buf.area, buf);
                     }) {
-                        // Track total lines inserted for cleanup on exit
-                        self.total_inserted_lines += height as u32;
+                        Ok(()) => {
+                            // Track total lines inserted for cleanup on exit
+                            self.total_inserted_lines += height as u32;
 
-                        tracing::trace!(
-                            "render_scrollback_above_tui: Rendered {} lines (total scrollback: {})",
-                            lines_to_render,
-                            current_scrollback_lines
-                        );
-                    } else {
-                        tracing::error!(
-                            "insert_before failed - method may not exist on this terminal type"
-                        );
+                            tracing::trace!(
+                                "render_scrollback_above_tui: Rendered {} lines (total scrollback: {})",
+                                lines_to_render,
+                                current_scrollback_lines
+                            );
+                        }
+                        Err(e) => {
+                            tracing::error!(
+                                "Failed to insert scrollback above the inline viewport: {e}"
+                            );
+                        }
                     }
                 }
             }

--- a/packages/nx/src/native/tui/tui.rs
+++ b/packages/nx/src/native/tui/tui.rs
@@ -23,7 +23,96 @@ use tokio_util::sync::CancellationToken;
 use tracing::{debug, trace};
 
 pub type Frame<'a> = ratatui::Frame<'a>;
-pub type Backend = CrosstermBackend<std::io::Stderr>;
+pub type Backend = CursorCachingBackend<std::io::Stderr>;
+
+/// Crossterm backend wrapper whose `get_cursor_position` answers from a cache
+/// instead of querying the terminal.
+///
+/// A real cursor query writes `ESC[6n` and reads the reply from terminal
+/// input, which races the crossterm `EventStream` that owns terminal input
+/// while the TUI runs and intermittently times out (the same conflict
+/// `draw_without_autoresize` exists to avoid). ratatui calls
+/// `get_cursor_position` internally — since ratatui-core 0.1.2,
+/// `Terminal::clear` snapshots the cursor, and `insert_before` calls `clear`
+/// on every scrollback insert (NXC-4597) — so the only way to guarantee the
+/// render path never reads terminal input is to answer cursor queries without
+/// touching the terminal.
+///
+/// The cache holds the last position set through the backend (initially the
+/// origin). That is sufficient because both viewports keep the cursor hidden
+/// and position it absolutely, and the inline viewport is full-height, so
+/// ratatui's inline viewport math yields row 0 regardless of what a real
+/// query would have returned.
+pub struct CursorCachingBackend<W: Write> {
+    inner: CrosstermBackend<W>,
+    cursor_position: ratatui::layout::Position,
+}
+
+impl<W: Write> CursorCachingBackend<W> {
+    pub fn new(writer: W) -> Self {
+        Self {
+            inner: CrosstermBackend::new(writer),
+            cursor_position: ratatui::layout::Position::ORIGIN,
+        }
+    }
+}
+
+impl<W: Write> ratatui::backend::Backend for CursorCachingBackend<W> {
+    type Error = std::io::Error;
+
+    fn draw<'a, I>(&mut self, content: I) -> std::io::Result<()>
+    where
+        I: Iterator<Item = (u16, u16, &'a ratatui::buffer::Cell)>,
+    {
+        self.inner.draw(content)
+    }
+
+    fn hide_cursor(&mut self) -> std::io::Result<()> {
+        self.inner.hide_cursor()
+    }
+
+    fn show_cursor(&mut self) -> std::io::Result<()> {
+        self.inner.show_cursor()
+    }
+
+    fn get_cursor_position(&mut self) -> std::io::Result<ratatui::layout::Position> {
+        Ok(self.cursor_position)
+    }
+
+    fn set_cursor_position<P: Into<ratatui::layout::Position>>(
+        &mut self,
+        position: P,
+    ) -> std::io::Result<()> {
+        let position = position.into();
+        self.inner.set_cursor_position(position)?;
+        self.cursor_position = position;
+        Ok(())
+    }
+
+    fn clear(&mut self) -> std::io::Result<()> {
+        self.inner.clear()
+    }
+
+    fn clear_region(&mut self, clear_type: ratatui::backend::ClearType) -> std::io::Result<()> {
+        self.inner.clear_region(clear_type)
+    }
+
+    fn append_lines(&mut self, n: u16) -> std::io::Result<()> {
+        self.inner.append_lines(n)
+    }
+
+    fn size(&self) -> std::io::Result<ratatui::layout::Size> {
+        self.inner.size()
+    }
+
+    fn window_size(&mut self) -> std::io::Result<ratatui::backend::WindowSize> {
+        self.inner.window_size()
+    }
+
+    fn flush(&mut self) -> std::io::Result<()> {
+        ratatui::backend::Backend::flush(&mut self.inner)
+    }
+}
 
 #[derive(Clone, Debug)]
 pub enum Event {
@@ -114,7 +203,8 @@ impl Tui {
         let frame_rate = 60.0;
 
         // Create fullscreen terminal with its own backend
-        let fullscreen_terminal = ratatui::Terminal::new(CrosstermBackend::new(std::io::stderr()))?;
+        let fullscreen_terminal =
+            ratatui::Terminal::new(CursorCachingBackend::new(std::io::stderr()))?;
 
         // Only create inline terminal if stdin is a TTY.
         // Inline mode requires cursor position queries (via Viewport::Inline) which use
@@ -131,7 +221,7 @@ impl Tui {
             debug!("Terminal size: {:?}", size);
             let inline_height = size.map(|(_cols, rows)| rows).unwrap_or(24);
             ratatui::Terminal::with_options(
-                CrosstermBackend::new(std::io::stderr()),
+                CursorCachingBackend::new(std::io::stderr()),
                 ratatui::TerminalOptions {
                     viewport: ratatui::Viewport::Inline(inline_height),
                 },
@@ -638,7 +728,7 @@ impl Tui {
         // The cursor position query happens here, which is safe because we
         // stopped the EventStream above.
         self.inline_terminal = Some(ratatui::Terminal::with_options(
-            CrosstermBackend::new(std::io::stderr()),
+            CursorCachingBackend::new(std::io::stderr()),
             ratatui::TerminalOptions {
                 viewport: ratatui::Viewport::Inline(rows),
             },
@@ -718,5 +808,26 @@ impl Drop for Tui {
         // is typically called during cleanup when the delay is less noticeable.
         // The main event loop should use exit_async() for proper cleanup.
         self.exit_sync().unwrap();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::CursorCachingBackend;
+    use ratatui::backend::Backend;
+    use ratatui::layout::Position;
+
+    #[test]
+    fn cursor_position_is_answered_from_cache_not_the_terminal() {
+        let mut backend = CursorCachingBackend::new(Vec::new());
+        assert_eq!(backend.get_cursor_position().unwrap(), Position::ORIGIN);
+
+        backend
+            .set_cursor_position(Position { x: 3, y: 7 })
+            .unwrap();
+        assert_eq!(
+            backend.get_cursor_position().unwrap(),
+            Position { x: 3, y: 7 }
+        );
     }
 }


### PR DESCRIPTION
## Current Behavior

Since the ratatui 0.30 bump, running tasks in the inline TUI intermittently logs `ERROR insert_before failed - method may not exist on this terminal type`, typically noticed when swapping to inline mode.

Root cause: ratatui-core **0.1.2** (a semver-compatible patch that arrived via a later `Cargo.lock` refresh, not the 0.30 bump commit itself) added a cursor-position snapshot to `Terminal::clear()`:

```rust
pub fn clear(&mut self) -> Result<(), B::Error> {
    let original_cursor = self.backend.get_cursor_position()?; // new in 0.1.2
    self.clear_viewport()?;
    self.backend.set_cursor_position(original_cursor)?;
    ...
```

`insert_before` (the inline scrollback path) calls `clear()` on every insert, so every scrollback flush now writes `ESC[6n` and reads the reply from terminal input — while crossterm's `EventStream` owns terminal input. When the query loses that race it times out (~2s) and `insert_before` returns `Err`. This is the same query/event-stream conflict the TUI already works around with `draw_without_autoresize` and by stopping the event stream around mode switches; ratatui-core 0.1.2 re-introduced it from inside the render path where we can't stop the stream.

(Enabling ratatui's `scrolling-regions` feature was considered and rejected: with our full-height inline viewport it pushes lines to scrollback via `CSI S` in a 1-row DECSTBM region, which xterm.js/VSCode drops instead of saving to scrollback.)

## Expected Behavior

No cursor-position query can ever run on the TUI render path. The crossterm backend is wrapped in `CursorCachingBackend`, whose `get_cursor_position` answers from the last position set through the backend instead of touching the terminal. This is sound because the TUI keeps the cursor hidden and positions it absolutely, and the inline viewport is full-height, so ratatui's inline viewport math yields the same result regardless of the reported position. This also structurally covers other ratatui internals that query the cursor (e.g. fullscreen `autoresize` → `resize` → `clear()` on terminal resize).

The error log for a failed scrollback insert now includes the actual `io::Error` instead of the speculative "method may not exist on this terminal type" message.

Validation: `cargo test -p nx --lib` passes (477 tests, includes a new unit test for the cached-cursor behavior); `cargo check`/`clippy` introduce no new warnings.

## Related Issue(s)

Fixes NXC-4597