### PR TITLE
docs(misc): add redirect for moved nx-vs-turborepo page

### DIFF
--- a/astro-docs/netlify.toml
+++ b/astro-docs/netlify.toml
@@ -80,6 +80,11 @@ to = "/docs/extending-nx/create-preset"
 from = "/docs/guides/adopting-nx/adding-to-monorepos"
 to = "/docs/guides/adopting-nx/adding-to-monorepo"
 
+# Turborepo comparison moved to Comparisons section (#36275)
+[[redirects]]
+from = "/docs/guides/adopting-nx/nx-vs-turborepo"
+to = "/docs/guides/comparisons/nx-vs-turborepo"
+
 # Angular multiple workspace migration page removed (DOC-419)
 [[redirects]]
 from = "/docs/technologies/angular/migration/angular-multiple"


### PR DESCRIPTION
## Current Behavior

`/docs/guides/adopting-nx/nx-vs-turborepo` 404s after the page moved to comparisons (#36275) without a redirect.

## Expected Behavior

Old URL redirects to `/docs/guides/comparisons/nx-vs-turborepo`.

## Related Issue(s)

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/docs-fix-turbo-link-25f6491f)
<!-- polygraph-session-end -->