### PR TITLE
feat(core): forward mouse and resize events to tasks running in the TUI's pty

### DIFF
--- a/packages/nx/src/native/dts-header.d.ts
+++ b/packages/nx/src/native/dts-header.d.ts
@@ -17,6 +17,10 @@ interface WriterArc {
   readonly __brand: unique symbol;
 }
 
+interface MasterArc {
+  readonly __brand: unique symbol;
+}
+
 interface HashInstruction {
   readonly __brand: unique symbol;
 }

--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -17,6 +17,10 @@ interface WriterArc {
   readonly __brand: unique symbol;
 }
 
+interface MasterArc {
+  readonly __brand: unique symbol;
+}
+
 interface HashInstruction {
   readonly __brand: unique symbol;
 }
@@ -36,7 +40,7 @@ export declare class AppLifeCycle {
   endTasks(taskResults: Array<TaskResult>, metadata: object): void
   endCommand(summary?: PerformanceSummaryPayload | undefined | null): void
   __init(doneCallback: (() => unknown)): void
-  registerRunningTask(taskId: string, parserAndWriter: ExternalObject<[ParserArc, WriterArc]>): void
+  registerRunningTask(taskId: string, ptyHandles: ExternalObject<[ParserArc, WriterArc, MasterArc]>): void
   registerRunningTaskWithEmptyParser(taskId: string): void
   appendTaskOutput(taskId: string, output: string, isPtyOutput: boolean): void
   setTaskStatus(taskId: string, status: TaskStatus): void
@@ -56,7 +60,7 @@ export declare class AppLifeCycle {
 }
 
 export declare class ChildProcess {
-  getParserAndWriter(): ExternalObject<[ParserArc, WriterArc]>
+  getPtyHandles(): ExternalObject<[ParserArc, WriterArc, MasterArc]>
   getPid(): number
   kill(signal?: NodeJS.Signals | number): void
   onExit(callback: (message: string) => void): void

--- a/packages/nx/src/native/pseudo_terminal/child_process.rs
+++ b/packages/nx/src/native/pseudo_terminal/child_process.rs
@@ -1,5 +1,5 @@
 use super::process_killer::{ProcessKiller, normalize_signal};
-use crate::native::pseudo_terminal::pseudo_terminal::{MasterArc, PtyHandles};
+use crate::native::pseudo_terminal::pseudo_terminal::{MasterArc, ParserArc, WriterArc};
 use crossbeam_channel::Sender;
 use crossbeam_channel::{Receiver, bounded, select};
 use napi::Either;
@@ -51,7 +51,7 @@ impl ChildProcess {
     }
 
     #[napi]
-    pub fn get_pty_handles(&mut self) -> External<PtyHandles> {
+    pub fn get_pty_handles(&mut self) -> External<(ParserArc, WriterArc, MasterArc)> {
         External::new((
             self.parser.clone(),
             self.writer_arc.clone(),

--- a/packages/nx/src/native/pseudo_terminal/child_process.rs
+++ b/packages/nx/src/native/pseudo_terminal/child_process.rs
@@ -1,5 +1,5 @@
 use super::process_killer::{ProcessKiller, normalize_signal};
-use crate::native::pseudo_terminal::pseudo_terminal::{ParserArc, WriterArc};
+use crate::native::pseudo_terminal::pseudo_terminal::{MasterArc, PtyHandles};
 use crossbeam_channel::Sender;
 use crossbeam_channel::{Receiver, bounded, select};
 use napi::Either;
@@ -25,12 +25,14 @@ pub struct ChildProcess {
     pub(crate) wait_receiver: Receiver<String>,
     thread_handles: Vec<Sender<()>>,
     writer_arc: Arc<Mutex<Box<dyn Write + Send>>>,
+    master_arc: MasterArc,
 }
 #[napi]
 impl ChildProcess {
     pub fn new(
         parser: Arc<RwLock<Parser>>,
         writer_arc: Arc<Mutex<Box<dyn Write + Send>>>,
+        master_arc: MasterArc,
         pid: i32,
         process_killer: ProcessKiller,
         message_receiver: Receiver<String>,
@@ -39,6 +41,7 @@ impl ChildProcess {
         Self {
             parser,
             writer_arc,
+            master_arc,
             pid,
             process_killer,
             message_receiver,
@@ -48,8 +51,12 @@ impl ChildProcess {
     }
 
     #[napi]
-    pub fn get_parser_and_writer(&mut self) -> External<(ParserArc, WriterArc)> {
-        External::new((self.parser.clone(), self.writer_arc.clone()))
+    pub fn get_pty_handles(&mut self) -> External<PtyHandles> {
+        External::new((
+            self.parser.clone(),
+            self.writer_arc.clone(),
+            self.master_arc.clone(),
+        ))
     }
 
     #[napi]

--- a/packages/nx/src/native/pseudo_terminal/pseudo_terminal.rs
+++ b/packages/nx/src/native/pseudo_terminal/pseudo_terminal.rs
@@ -7,7 +7,9 @@ use crossterm::{
 };
 use napi::bindgen_prelude::*;
 use parking_lot::{Mutex, RwLock};
-use portable_pty::{CommandBuilder, NativePtySystem, PtyPair, PtySize, PtySystem};
+use portable_pty::{
+    CommandBuilder, MasterPty, NativePtySystem, PtyPair, PtySize, PtySystem, SlavePty,
+};
 use std::io::stdout;
 use std::{
     collections::HashMap,
@@ -26,7 +28,10 @@ use super::os;
 use crate::native::pseudo_terminal::{child_process::ChildProcess, process_killer::ProcessKiller};
 
 pub struct PseudoTerminal {
-    pub pty_pair: PtyPair,
+    // slave is listed before master so that it is dropped first, matching the
+    // drop order PtyPair documents and relies on.
+    pub slave: Box<dyn SlavePty + Send>,
+    pub master: MasterArc,
     pub stdout_tx: Sender<String>,
     pub stdout_rx: Receiver<String>,
     pub printing_rx: Receiver<()>,
@@ -50,6 +55,26 @@ impl Default for PseudoTerminalOptions {
 
 pub type ParserArc = Arc<RwLock<Parser>>;
 pub type WriterArc = Arc<Mutex<Box<dyn Write + Send>>>;
+/// The control end of the pty. Resizing it issues the TIOCSWINSZ ioctl, which
+/// updates the winsize the kernel reports to the child and raises SIGWINCH so
+/// the child knows to redraw at the new dimensions.
+pub type MasterArc = Arc<Mutex<Box<dyn MasterPty + Send>>>;
+
+/// The handles the TUI needs to display and drive a running pty task: the parser
+/// it renders from, the writer it forwards input to, and the master it resizes.
+pub type PtyHandles = (ParserArc, WriterArc, MasterArc);
+
+/// Resize the pty so the child process is told its window changed.
+pub fn resize_master(master: &MasterArc, rows: u16, cols: u16) {
+    if let Err(e) = master.lock().resize(PtySize {
+        rows,
+        cols,
+        pixel_width: 0,
+        pixel_height: 0,
+    }) {
+        debug!("Failed to resize pty to {}x{}: {}", rows, cols, e);
+    }
+}
 
 impl PseudoTerminal {
     pub fn new(options: PseudoTerminalOptions) -> Result<Self> {
@@ -60,14 +85,14 @@ impl PseudoTerminal {
 
         trace!("Opening Pseudo Terminal");
         let (w, h) = options.size;
-        let pty_pair = pty_system.openpty(PtySize {
+        let PtyPair { slave, master } = pty_system.openpty(PtySize {
             rows: h,
             cols: w,
             pixel_width: 0,
             pixel_height: 0,
         })?;
 
-        let writer = pty_pair.master.take_writer()?;
+        let writer = master.take_writer()?;
         let writer_arc = Arc::new(Mutex::new(writer));
         let writer_clone = writer_arc.clone();
 
@@ -84,7 +109,8 @@ impl PseudoTerminal {
             });
         }
 
-        let mut reader = pty_pair.master.try_clone_reader()?;
+        let mut reader = master.try_clone_reader()?;
+        let master_arc: MasterArc = Arc::new(Mutex::new(master));
         let (stdout_tx, stdout_rx) = unbounded();
         let (printing_tx, printing_rx) = unbounded();
         // Output -> stdout handling
@@ -211,7 +237,8 @@ impl PseudoTerminal {
             writer: writer_arc,
             running,
             parser,
-            pty_pair,
+            slave,
+            master: master_arc,
             stdout_rx,
             stdout_tx,
             printing_rx,
@@ -230,8 +257,6 @@ impl PseudoTerminal {
         command_label: Option<String>,
     ) -> napi::Result<ChildProcess> {
         let command_dir = get_directory(command_dir)?;
-
-        let pair = &self.pty_pair;
 
         let quiet = quiet.unwrap_or(false);
 
@@ -268,7 +293,7 @@ impl PseudoTerminal {
         }
 
         trace!("Running {}", command_clone);
-        let mut child = pair.slave.spawn_command(cmd)?;
+        let mut child = self.slave.spawn_command(cmd)?;
         self.running.store(true, Ordering::SeqCst);
 
         let is_tty = tty.unwrap_or_else(|| std::io::stdout().is_tty());
@@ -325,6 +350,7 @@ impl PseudoTerminal {
         Ok(ChildProcess::new(
             self.parser.clone(),
             self.writer.clone(),
+            self.master.clone(),
             pid,
             process_killer,
             self.stdout_rx.clone(),

--- a/packages/nx/src/native/tui/app.rs
+++ b/packages/nx/src/native/tui/app.rs
@@ -143,6 +143,9 @@ pub struct App {
     /// Whether the TUI is currently capturing the mouse. Toggled with F10 so the
     /// user can fall back to their terminal's native cell selection.
     mouse_capture_enabled: bool,
+    /// Whether any-motion tracking (?1003) is currently enabled on the outer
+    /// terminal, mirroring an interactive pane's app that requested it.
+    any_motion_capture_enabled: bool,
     /// An in-progress (or completed-but-still-highlighted) text selection over a
     /// rendered region (popup text area or task list), in screen coordinates.
     region_selection: Option<RegionSelection>,
@@ -571,6 +574,7 @@ impl App {
             last_click: None,
             selecting_pane: None,
             mouse_capture_enabled: true,
+            any_motion_capture_enabled: false,
             region_selection: None,
             region_snapshot: None,
             pending_list_click: None,
@@ -1542,7 +1546,9 @@ impl App {
                         self.close_popup(Focus::HintPopup);
                     }
                 } else {
+                    // The disable sequence resets ?1003 too.
                     let _ = crate::native::tui::tui::disable_mouse_capture();
+                    self.any_motion_capture_enabled = false;
                     // In-app selections can no longer be updated by the mouse.
                     self.clear_all_pane_selections();
                     self.region_selection = None;
@@ -1826,6 +1832,7 @@ impl App {
                 })
                 .ok();
                 self.mouse_regions = captured_regions;
+                self.sync_any_motion_capture();
             }
             Action::SendConsoleMessage(msg) => {
                 let state = self.core.state().lock();
@@ -2496,6 +2503,19 @@ impl App {
         }
 
         let (col, row) = (mouse.column, mouse.row);
+
+        // An interactive pane running an app that requested mouse reporting
+        // (vim, htop, lazygit, ...) gets events over its content forwarded to
+        // the app; the TUI's own scroll/select/focus handling applies
+        // everywhere else and to apps that never asked for the mouse.
+        if let Some(MouseRegionKind::Pane(pane_idx)) = self.region_at(col, row)
+            && self.terminal_pane_data[pane_idx]
+                .handle_mouse_event(mouse)
+                .unwrap_or(false)
+        {
+            return;
+        }
+
         match mouse.kind {
             MouseEventKind::ScrollUp => self.scroll_at(col, row, ScrollDirection::Up, action_tx),
             MouseEventKind::ScrollDown => {
@@ -2505,6 +2525,31 @@ impl App {
             MouseEventKind::Drag(MouseButton::Left) => self.handle_left_drag(col, row),
             MouseEventKind::Up(MouseButton::Left) => self.handle_left_release(col, row),
             _ => {}
+        }
+    }
+
+    /// The outer terminal normally runs in button-event tracking (?1002) so
+    /// bare hover motion doesn't flood the event loop. An interactive pane
+    /// whose app asked for any-motion tracking (?1003) needs those hover
+    /// events to forward, so mirror the request on the outer terminal while it
+    /// holds and drop back to the narrow set once it no longer does.
+    fn sync_any_motion_capture(&mut self) {
+        let wanted = self.mouse_capture_enabled
+            && self.terminal_pane_data.iter().any(|pane| {
+                pane.is_interactive()
+                    && pane
+                        .pty
+                        .as_ref()
+                        .and_then(|pty| pty.mouse_protocol())
+                        .is_some_and(|(mode, _)| mode == vt100_ctt::MouseProtocolMode::AnyMotion)
+            });
+        if wanted != self.any_motion_capture_enabled {
+            self.any_motion_capture_enabled = wanted;
+            let _ = if wanted {
+                crate::native::tui::tui::enable_any_motion_capture()
+            } else {
+                crate::native::tui::tui::disable_any_motion_capture()
+            };
         }
     }
 

--- a/packages/nx/src/native/tui/app.rs
+++ b/packages/nx/src/native/tui/app.rs
@@ -22,7 +22,7 @@ use tui_logger::{LevelFilter, TuiLoggerSmartWidget, TuiWidgetEvent, TuiWidgetSta
 
 use crate::native::tui::tui::Tui;
 use crate::native::{
-    pseudo_terminal::pseudo_terminal::{ParserArc, WriterArc},
+    pseudo_terminal::pseudo_terminal::PtyHandles,
     tasks::types::{Task, TaskResult},
 };
 
@@ -830,14 +830,13 @@ impl App {
     }
 
     // A pseudo-terminal running task will provide the parser and writer directly
-    pub fn register_running_interactive_task(
-        &mut self,
-        task_id: String,
-        parser_and_writer: &(ParserArc, WriterArc),
-    ) {
+    pub fn register_running_interactive_task(&mut self, task_id: String, pty_handles: &PtyHandles) {
         debug!("Registering interactive task: {}", task_id);
-        let pty =
-            PtyInstance::interactive(parser_and_writer.0.clone(), parser_and_writer.1.clone());
+        let pty = PtyInstance::interactive(
+            pty_handles.0.clone(),
+            pty_handles.1.clone(),
+            pty_handles.2.clone(),
+        );
         self.register_running_task(task_id, pty);
     }
 

--- a/packages/nx/src/native/tui/components/terminal_pane.rs
+++ b/packages/nx/src/native/tui/components/terminal_pane.rs
@@ -1,8 +1,8 @@
 use crate::native::tui::clipboard::copy_to_clipboard;
-use crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEvent};
 use ratatui::{
     buffer::Buffer,
-    layout::{Alignment, Rect},
+    layout::{Alignment, Position, Rect},
     style::{Modifier, Style, Stylize},
     text::{Line, Span},
     widgets::{
@@ -472,6 +472,32 @@ impl TerminalPaneData {
             }
         }
         Ok(None)
+    }
+
+    /// Forward a mouse event to the running application when this pane is in
+    /// interactive mode and the app has requested mouse reporting (vim, htop,
+    /// lazygit, ...). Returns true when the event was consumed by the app, in
+    /// which case the TUI's own scroll/select handling must not run.
+    pub fn handle_mouse_event(&mut self, mouse: MouseEvent) -> io::Result<bool> {
+        if !self.is_interactive {
+            return Ok(false);
+        }
+        let Some(pty) = &self.pty else {
+            return Ok(false);
+        };
+        let Some(area) = self.last_content_area else {
+            return Ok(false);
+        };
+        if !area.contains(Position::new(mouse.column, mouse.row)) {
+            return Ok(false);
+        }
+        let mut pty_mut = pty.as_ref().clone();
+        pty_mut.forward_mouse_event(
+            mouse.kind,
+            mouse.modifiers,
+            mouse.column - area.x,
+            mouse.row - area.y,
+        )
     }
 
     pub fn set_interactive(&mut self, interactive: bool) {

--- a/packages/nx/src/native/tui/inline_app.rs
+++ b/packages/nx/src/native/tui/inline_app.rs
@@ -19,7 +19,7 @@ use crate::native::tui::utils::{
     calculate_actual_duration_ms, format_duration_with_estimate, get_task_status_style,
 };
 use crate::native::{
-    pseudo_terminal::pseudo_terminal::{ParserArc, WriterArc},
+    pseudo_terminal::pseudo_terminal::PtyHandles,
     tasks::types::{Task, TaskGraph},
 };
 
@@ -628,13 +628,12 @@ impl TuiApp for InlineApp {
     ///
     /// Inline mode needs smaller PTYs to fit the compact viewport,
     /// unlike full-screen mode where interactive PTYs use their own dimensions.
-    fn register_running_interactive_task(
-        &mut self,
-        task_id: String,
-        parser_and_writer: &(ParserArc, WriterArc),
-    ) {
-        let mut pty =
-            PtyInstance::interactive(parser_and_writer.0.clone(), parser_and_writer.1.clone());
+    fn register_running_interactive_task(&mut self, task_id: String, pty_handles: &PtyHandles) {
+        let mut pty = PtyInstance::interactive(
+            pty_handles.0.clone(),
+            pty_handles.1.clone(),
+            pty_handles.2.clone(),
+        );
 
         // Resize PTY to inline dimensions (mode-specific)
         let (rows, cols) = self.calculate_pty_dimensions();

--- a/packages/nx/src/native/tui/lifecycle.rs
+++ b/packages/nx/src/native/tui/lifecycle.rs
@@ -14,7 +14,7 @@ use napi::{Status, bindgen_prelude::Unknown};
 use crate::native::ide::nx_console::messaging::NxConsoleMessageConnection;
 #[cfg(not(test))]
 use crate::native::logger::enable_logger;
-use crate::native::pseudo_terminal::pseudo_terminal::PtyHandles;
+use crate::native::pseudo_terminal::pseudo_terminal::{MasterArc, ParserArc, WriterArc};
 use crate::native::tasks::types::{Task, TaskGraph, TaskResult};
 
 #[cfg(not(test))]
@@ -682,7 +682,7 @@ impl AppLifeCycle {
     }
 
     #[napi]
-    pub fn register_running_task(&mut self, task_id: String, pty_handles: &External<PtyHandles>) {
+    pub fn register_running_task(&mut self, task_id: String, pty_handles: &External<(ParserArc, WriterArc, MasterArc)>) {
         self.with_app(|app| app.register_running_interactive_task(task_id, &**pty_handles));
     }
 

--- a/packages/nx/src/native/tui/lifecycle.rs
+++ b/packages/nx/src/native/tui/lifecycle.rs
@@ -682,7 +682,11 @@ impl AppLifeCycle {
     }
 
     #[napi]
-    pub fn register_running_task(&mut self, task_id: String, pty_handles: &External<(ParserArc, WriterArc, MasterArc)>) {
+    pub fn register_running_task(
+        &mut self,
+        task_id: String,
+        pty_handles: &External<(ParserArc, WriterArc, MasterArc)>,
+    ) {
         self.with_app(|app| app.register_running_interactive_task(task_id, &**pty_handles));
     }
 

--- a/packages/nx/src/native/tui/lifecycle.rs
+++ b/packages/nx/src/native/tui/lifecycle.rs
@@ -14,7 +14,7 @@ use napi::{Status, bindgen_prelude::Unknown};
 use crate::native::ide::nx_console::messaging::NxConsoleMessageConnection;
 #[cfg(not(test))]
 use crate::native::logger::enable_logger;
-use crate::native::pseudo_terminal::pseudo_terminal::{ParserArc, WriterArc};
+use crate::native::pseudo_terminal::pseudo_terminal::PtyHandles;
 use crate::native::tasks::types::{Task, TaskGraph, TaskResult};
 
 #[cfg(not(test))]
@@ -682,12 +682,8 @@ impl AppLifeCycle {
     }
 
     #[napi]
-    pub fn register_running_task(
-        &mut self,
-        task_id: String,
-        parser_and_writer: &External<(ParserArc, WriterArc)>,
-    ) {
-        self.with_app(|app| app.register_running_interactive_task(task_id, &**parser_and_writer));
+    pub fn register_running_task(&mut self, task_id: String, pty_handles: &External<PtyHandles>) {
+        self.with_app(|app| app.register_running_interactive_task(task_id, &**pty_handles));
     }
 
     #[napi]

--- a/packages/nx/src/native/tui/mod.rs
+++ b/packages/nx/src/native/tui/mod.rs
@@ -7,6 +7,7 @@ pub mod escape_sequences;
 pub mod graph_utils;
 pub mod inline_app;
 pub mod lifecycle;
+pub mod mouse_protocol;
 pub mod pty;
 pub mod scroll_momentum;
 pub mod status_icons;

--- a/packages/nx/src/native/tui/mouse_protocol.rs
+++ b/packages/nx/src/native/tui/mouse_protocol.rs
@@ -1,0 +1,355 @@
+//! Encodes mouse events into the xterm mouse reporting wire format so they can
+//! be forwarded to a child application running in a PTY.
+//!
+//! A TUI app running inside a task pane (vim, htop, lazygit, ...) requests
+//! mouse reporting by emitting DECSET sequences (`?9`/`?1000`/`?1002`/`?1003`
+//! plus the `?1005`/`?1006` encodings). The embedded vt100 parser tracks those
+//! requests and exposes them as [`MouseProtocolMode`] / [`MouseProtocolEncoding`];
+//! this module produces the byte sequences a real terminal would send back for
+//! the mode and encoding the app asked for.
+
+use crossterm::event::{KeyModifiers, MouseButton, MouseEventKind};
+use vt100_ctt::{MouseProtocolEncoding, MouseProtocolMode};
+
+/// Encode a mouse event for a child app, or `None` when the app's requested
+/// mode doesn't cover this kind of event (including mode `None`).
+///
+/// `col` and `row` are 0-based cells relative to the child's screen; the wire
+/// format is 1-based.
+pub fn encode_mouse_event(
+    mode: MouseProtocolMode,
+    encoding: MouseProtocolEncoding,
+    kind: MouseEventKind,
+    modifiers: KeyModifiers,
+    col: u16,
+    row: u16,
+) -> Option<Vec<u8>> {
+    let reportable = match mode {
+        MouseProtocolMode::None => false,
+        MouseProtocolMode::Press => matches!(
+            kind,
+            MouseEventKind::Down(_)
+                | MouseEventKind::ScrollUp
+                | MouseEventKind::ScrollDown
+                | MouseEventKind::ScrollLeft
+                | MouseEventKind::ScrollRight
+        ),
+        MouseProtocolMode::PressRelease => {
+            !matches!(kind, MouseEventKind::Drag(_) | MouseEventKind::Moved)
+        }
+        MouseProtocolMode::ButtonMotion => !matches!(kind, MouseEventKind::Moved),
+        MouseProtocolMode::AnyMotion => true,
+    };
+    if !reportable {
+        return None;
+    }
+
+    let (mut code, is_release) = match kind {
+        MouseEventKind::Down(button) => (button_code(button), false),
+        MouseEventKind::Up(button) => (button_code(button), true),
+        MouseEventKind::Drag(button) => (button_code(button) + 32, false),
+        MouseEventKind::Moved => (3 + 32, false),
+        MouseEventKind::ScrollUp => (64, false),
+        MouseEventKind::ScrollDown => (65, false),
+        MouseEventKind::ScrollLeft => (66, false),
+        MouseEventKind::ScrollRight => (67, false),
+    };
+
+    // X10 mode predates modifier reporting.
+    if mode != MouseProtocolMode::Press {
+        if modifiers.contains(KeyModifiers::SHIFT) {
+            code += 4;
+        }
+        if modifiers.contains(KeyModifiers::ALT) {
+            code += 8;
+        }
+        if modifiers.contains(KeyModifiers::CONTROL) {
+            code += 16;
+        }
+    }
+
+    let x = col as u32 + 1;
+    let y = row as u32 + 1;
+
+    match encoding {
+        MouseProtocolEncoding::Sgr => Some(
+            format!(
+                "\x1b[<{};{};{}{}",
+                code,
+                x,
+                y,
+                if is_release { 'm' } else { 'M' }
+            )
+            .into_bytes(),
+        ),
+        MouseProtocolEncoding::Default => {
+            // Legacy encoding can't distinguish which button was released:
+            // the low two bits become 3, modifier bits are kept.
+            let code = if is_release {
+                (code & !0b11) | 0b11
+            } else {
+                code
+            };
+            Some(vec![
+                0x1b,
+                b'[',
+                b'M',
+                32 + code as u8,
+                legacy_coord(x),
+                legacy_coord(y),
+            ])
+        }
+        MouseProtocolEncoding::Utf8 => {
+            let code = if is_release {
+                (code & !0b11) | 0b11
+            } else {
+                code
+            };
+            let mut bytes = b"\x1b[M".to_vec();
+            let mut push = |value: u32| {
+                let ch = char::from_u32(32 + value.min(2015)).unwrap_or(' ');
+                let mut buf = [0u8; 4];
+                bytes.extend_from_slice(ch.encode_utf8(&mut buf).as_bytes());
+            };
+            push(code);
+            push(x);
+            push(y);
+            Some(bytes)
+        }
+    }
+}
+
+fn button_code(button: MouseButton) -> u32 {
+    match button {
+        MouseButton::Left => 0,
+        MouseButton::Middle => 1,
+        MouseButton::Right => 2,
+    }
+}
+
+/// Legacy single-byte coordinate: 32 + value, saturating at the encoding's
+/// 223-cell limit so the byte stays valid.
+fn legacy_coord(value: u32) -> u8 {
+    (32 + value.min(223)) as u8
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn mode_none_reports_nothing() {
+        assert_eq!(
+            encode_mouse_event(
+                MouseProtocolMode::None,
+                MouseProtocolEncoding::Sgr,
+                MouseEventKind::Down(MouseButton::Left),
+                KeyModifiers::NONE,
+                0,
+                0,
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn sgr_press_and_release() {
+        let press = encode_mouse_event(
+            MouseProtocolMode::PressRelease,
+            MouseProtocolEncoding::Sgr,
+            MouseEventKind::Down(MouseButton::Left),
+            KeyModifiers::NONE,
+            4,
+            9,
+        )
+        .unwrap();
+        assert_eq!(press, b"\x1b[<0;5;10M");
+
+        let release = encode_mouse_event(
+            MouseProtocolMode::PressRelease,
+            MouseProtocolEncoding::Sgr,
+            MouseEventKind::Up(MouseButton::Left),
+            KeyModifiers::NONE,
+            4,
+            9,
+        )
+        .unwrap();
+        assert_eq!(release, b"\x1b[<0;5;10m");
+    }
+
+    #[test]
+    fn sgr_wheel_and_modifiers() {
+        let wheel_up = encode_mouse_event(
+            MouseProtocolMode::PressRelease,
+            MouseProtocolEncoding::Sgr,
+            MouseEventKind::ScrollUp,
+            KeyModifiers::NONE,
+            0,
+            0,
+        )
+        .unwrap();
+        assert_eq!(wheel_up, b"\x1b[<64;1;1M");
+
+        let ctrl_click = encode_mouse_event(
+            MouseProtocolMode::PressRelease,
+            MouseProtocolEncoding::Sgr,
+            MouseEventKind::Down(MouseButton::Right),
+            KeyModifiers::CONTROL,
+            0,
+            0,
+        )
+        .unwrap();
+        assert_eq!(ctrl_click, b"\x1b[<18;1;1M");
+    }
+
+    #[test]
+    fn legacy_encoding_press_and_release() {
+        let press = encode_mouse_event(
+            MouseProtocolMode::PressRelease,
+            MouseProtocolEncoding::Default,
+            MouseEventKind::Down(MouseButton::Left),
+            KeyModifiers::NONE,
+            0,
+            0,
+        )
+        .unwrap();
+        assert_eq!(press, b"\x1b[M\x20\x21\x21");
+
+        // Release collapses to button 3 in the legacy encoding.
+        let release = encode_mouse_event(
+            MouseProtocolMode::PressRelease,
+            MouseProtocolEncoding::Default,
+            MouseEventKind::Up(MouseButton::Left),
+            KeyModifiers::NONE,
+            0,
+            0,
+        )
+        .unwrap();
+        assert_eq!(release, b"\x1b[M\x23\x21\x21");
+    }
+
+    #[test]
+    fn legacy_encoding_clamps_large_coordinates() {
+        let press = encode_mouse_event(
+            MouseProtocolMode::PressRelease,
+            MouseProtocolEncoding::Default,
+            MouseEventKind::Down(MouseButton::Left),
+            KeyModifiers::NONE,
+            500,
+            500,
+        )
+        .unwrap();
+        assert_eq!(press[4], 255);
+        assert_eq!(press[5], 255);
+    }
+
+    #[test]
+    fn utf8_encoding_multibyte_coordinates() {
+        let press = encode_mouse_event(
+            MouseProtocolMode::PressRelease,
+            MouseProtocolEncoding::Utf8,
+            MouseEventKind::Down(MouseButton::Left),
+            KeyModifiers::NONE,
+            299,
+            0,
+        )
+        .unwrap();
+        // 32 + 300 = 332 encodes as two UTF-8 bytes.
+        let mut expected = b"\x1b[M\x20".to_vec();
+        let mut buf = [0u8; 4];
+        expected.extend_from_slice(
+            char::from_u32(332)
+                .unwrap()
+                .encode_utf8(&mut buf)
+                .as_bytes(),
+        );
+        expected.extend_from_slice("\u{21}".as_bytes());
+        assert_eq!(press, expected);
+    }
+
+    #[test]
+    fn press_mode_ignores_release_drag_motion_and_modifiers() {
+        for kind in [
+            MouseEventKind::Up(MouseButton::Left),
+            MouseEventKind::Drag(MouseButton::Left),
+            MouseEventKind::Moved,
+        ] {
+            assert_eq!(
+                encode_mouse_event(
+                    MouseProtocolMode::Press,
+                    MouseProtocolEncoding::Sgr,
+                    kind,
+                    KeyModifiers::NONE,
+                    0,
+                    0,
+                ),
+                None
+            );
+        }
+
+        // X10 never learned about modifiers.
+        let press = encode_mouse_event(
+            MouseProtocolMode::Press,
+            MouseProtocolEncoding::Sgr,
+            MouseEventKind::Down(MouseButton::Left),
+            KeyModifiers::CONTROL,
+            0,
+            0,
+        )
+        .unwrap();
+        assert_eq!(press, b"\x1b[<0;1;1M");
+    }
+
+    #[test]
+    fn motion_reporting_follows_mode() {
+        let drag = MouseEventKind::Drag(MouseButton::Left);
+        let moved = MouseEventKind::Moved;
+
+        assert!(
+            encode_mouse_event(
+                MouseProtocolMode::PressRelease,
+                MouseProtocolEncoding::Sgr,
+                drag,
+                KeyModifiers::NONE,
+                0,
+                0
+            )
+            .is_none()
+        );
+        assert_eq!(
+            encode_mouse_event(
+                MouseProtocolMode::ButtonMotion,
+                MouseProtocolEncoding::Sgr,
+                drag,
+                KeyModifiers::NONE,
+                2,
+                3
+            )
+            .unwrap(),
+            b"\x1b[<32;3;4M"
+        );
+        assert!(
+            encode_mouse_event(
+                MouseProtocolMode::ButtonMotion,
+                MouseProtocolEncoding::Sgr,
+                moved,
+                KeyModifiers::NONE,
+                0,
+                0
+            )
+            .is_none()
+        );
+        assert_eq!(
+            encode_mouse_event(
+                MouseProtocolMode::AnyMotion,
+                MouseProtocolEncoding::Sgr,
+                moved,
+                KeyModifiers::NONE,
+                2,
+                3
+            )
+            .unwrap(),
+            b"\x1b[<35;3;4M"
+        );
+    }
+}

--- a/packages/nx/src/native/tui/pty.rs
+++ b/packages/nx/src/native/tui/pty.rs
@@ -1,7 +1,8 @@
+use super::mouse_protocol::encode_mouse_event;
 use super::scroll_momentum::{ScrollDirection, ScrollMomentum};
 use super::strings::display_width;
 use super::utils::normalize_newlines;
-use crossterm::event::{KeyCode, KeyEvent};
+use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEventKind};
 use parking_lot::{Mutex, RwLock, RwLockReadGuard};
 use std::{
     io::{self, Write},
@@ -640,6 +641,45 @@ impl PtyInstance {
 
     pub fn get_dimensions(&self) -> (u16, u16) {
         *self.dimensions.read()
+    }
+
+    /// The mouse reporting mode and encoding the child app has requested via
+    /// DECSET (`?9`/`?1000`/`?1002`/`?1003` and `?1005`/`?1006`). `None` when
+    /// the parser is momentarily write-locked by the output thread.
+    pub fn mouse_protocol(
+        &self,
+    ) -> Option<(
+        vt100_ctt::MouseProtocolMode,
+        vt100_ctt::MouseProtocolEncoding,
+    )> {
+        let parser = self.parser.try_read()?;
+        let screen = parser.screen();
+        Some((
+            screen.mouse_protocol_mode(),
+            screen.mouse_protocol_encoding(),
+        ))
+    }
+
+    /// Forward a mouse event to the child app if it has requested mouse
+    /// reporting. `col`/`row` are 0-based cells relative to the child's
+    /// screen. Returns whether the event was written.
+    pub fn forward_mouse_event(
+        &mut self,
+        kind: MouseEventKind,
+        modifiers: KeyModifiers,
+        col: u16,
+        row: u16,
+    ) -> io::Result<bool> {
+        let Some((mode, encoding)) = self.mouse_protocol() else {
+            return Ok(false);
+        };
+        match encode_mouse_event(mode, encoding, kind, modifiers, col, row) {
+            Some(bytes) => {
+                self.write_input(&bytes)?;
+                Ok(true)
+            }
+            None => Ok(false),
+        }
     }
 
     pub fn handle_arrow_keys(&mut self, event: KeyEvent) {

--- a/packages/nx/src/native/tui/pty.rs
+++ b/packages/nx/src/native/tui/pty.rs
@@ -2,6 +2,7 @@ use super::mouse_protocol::encode_mouse_event;
 use super::scroll_momentum::{ScrollDirection, ScrollMomentum};
 use super::strings::display_width;
 use super::utils::normalize_newlines;
+use crate::native::pseudo_terminal::pseudo_terminal::{MasterArc, resize_master};
 use crossterm::event::{KeyCode, KeyEvent, KeyModifiers, MouseEventKind};
 use parking_lot::{Mutex, RwLock, RwLockReadGuard};
 use std::{
@@ -65,6 +66,10 @@ struct ScrollbackState {
 pub struct PtyInstance {
     parser: Arc<RwLock<Parser>>,
     writer: Option<Arc<Mutex<Box<dyn Write + Send>>>>,
+    /// Control end of the underlying pty, when the task actually runs in one.
+    /// Resizing the parser only changes how we render captured bytes; resizing
+    /// the master is what tells the child process to redraw at the new size.
+    master: Option<MasterArc>,
     dimensions: Arc<RwLock<(u16, u16)>>,
     scroll_momentum: Arc<Mutex<ScrollMomentum>>,
     /// Generation counter for async resize. Incremented on each resize request
@@ -381,12 +386,14 @@ impl PtyInstance {
     pub fn interactive(
         parser: Arc<RwLock<Parser>>,
         writer: Arc<Mutex<Box<dyn Write + Send>>>,
+        master: MasterArc,
     ) -> Self {
         // Read the dimensions from the parser
         let (rows, cols) = parser.read().screen().size();
         Self {
             parser,
             writer: Some(writer),
+            master: Some(master),
             dimensions: Arc::new(RwLock::new((rows, cols))),
             scroll_momentum: Arc::new(Mutex::new(ScrollMomentum::new())),
             resize_generation: Arc::new(AtomicU64::new(0)),
@@ -414,6 +421,7 @@ impl PtyInstance {
         Self {
             parser,
             writer: None,
+            master: None,
             dimensions: Arc::new(RwLock::new((rows, cols))),
             scroll_momentum: Arc::new(Mutex::new(ScrollMomentum::new())),
             resize_generation: Arc::new(AtomicU64::new(0)),
@@ -438,6 +446,7 @@ impl PtyInstance {
         Self {
             parser,
             writer: None,
+            master: None,
             dimensions: Arc::new(RwLock::new((rows, cols))),
             scroll_momentum: Arc::new(Mutex::new(ScrollMomentum::new())),
             resize_generation: Arc::new(AtomicU64::new(0)),
@@ -475,6 +484,16 @@ impl PtyInstance {
         }
     }
 
+    /// Resize the underlying pty, raising SIGWINCH in the child.
+    ///
+    /// Tasks that don't run in a pty (batch tasks, forked processes) have no
+    /// master and simply have nothing to notify.
+    fn notify_child_of_resize(&self, rows: u16, cols: u16) {
+        if let Some(master) = &self.master {
+            resize_master(master, rows, cols);
+        }
+    }
+
     pub fn resize(&mut self, rows: u16, cols: u16) -> io::Result<()> {
         // Ensure minimum sizes
         let rows = rows.max(3);
@@ -498,6 +517,9 @@ impl PtyInstance {
         if !should_resize {
             return Ok(());
         }
+
+        // Tell the child process its window changed so it redraws at the new size
+        self.notify_child_of_resize(rows, cols);
 
         // Update dimensions
         let mut dimensions_guard = self.dimensions.write();
@@ -560,6 +582,13 @@ impl PtyInstance {
 
         // Increment generation to cancel any in-flight resize
         let generation = self.resize_generation.fetch_add(1, Ordering::SeqCst) + 1;
+
+        // Tell the child process its window changed so it redraws at the new size.
+        // This is independent of the reparse below: the reparse re-wraps the bytes
+        // we have already captured (which is what keeps scrollback correct), while
+        // this is what makes the child itself emit correctly-sized output from here
+        // on. Full-screen children (opentui, ink, vim...) only relayout on SIGWINCH.
+        self.notify_child_of_resize(rows, cols);
 
         // Update dimensions immediately so subsequent resize calls see the new
         // target and early-return instead of spawning redundant threads
@@ -1073,6 +1102,7 @@ impl PtyInstance {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use portable_pty::PtySystem;
     use std::sync::Arc;
 
     fn create_test_pty_instance(alternate_screen: bool) -> PtyInstance {
@@ -1086,6 +1116,7 @@ mod tests {
         PtyInstance {
             parser,
             writer: None,
+            master: None,
             dimensions: Arc::new(RwLock::new((24, 80))),
             scroll_momentum: Arc::new(Mutex::new(ScrollMomentum::new())),
             resize_generation: Arc::new(AtomicU64::new(0)),
@@ -1317,5 +1348,76 @@ mod tests {
         // Jumping to the very end clamps to the bottom.
         pty.scroll_to_visual_row(10_000);
         assert_eq!(pty.get_scroll_offset(), 0);
+    }
+
+    /// Build an interactive PtyInstance backed by a real pty, returning the
+    /// instance alongside the master so tests can read back the winsize the
+    /// kernel reports — which is what the child process sees.
+    fn create_interactive_pty_instance(rows: u16, cols: u16) -> (PtyInstance, MasterArc) {
+        let pair = portable_pty::NativePtySystem::default()
+            .openpty(portable_pty::PtySize {
+                rows,
+                cols,
+                pixel_width: 0,
+                pixel_height: 0,
+            })
+            .expect("failed to open pty");
+
+        let writer = Arc::new(Mutex::new(pair.master.take_writer().unwrap()));
+        let master: MasterArc = Arc::new(Mutex::new(pair.master));
+        let parser = Arc::new(RwLock::new(Parser::new(rows, cols, 1000)));
+
+        let pty = PtyInstance::interactive(parser, writer, master.clone());
+        (pty, master)
+    }
+
+    fn master_size(master: &MasterArc) -> (u16, u16) {
+        let size = master.lock().get_size().expect("failed to read pty size");
+        (size.rows, size.cols)
+    }
+
+    #[test]
+    fn test_resize_updates_kernel_winsize() {
+        let (mut pty, master) = create_interactive_pty_instance(24, 80);
+        assert_eq!(master_size(&master), (24, 80));
+
+        pty.resize(30, 100).unwrap();
+
+        // The kernel-reported size is what the child sees via TIOCGWINSZ, and
+        // changing it is what raises SIGWINCH. Without this the child keeps
+        // rendering at its original dimensions no matter how the pane changes.
+        assert_eq!(master_size(&master), (30, 100));
+        assert_eq!(pty.get_dimensions(), (30, 100));
+    }
+
+    #[test]
+    fn test_resize_async_updates_kernel_winsize() {
+        let (pty, master) = create_interactive_pty_instance(24, 80);
+
+        // The reparse is backgrounded, but the child must be notified eagerly —
+        // so the ioctl lands before resize_async returns.
+        pty.resize_async(40, 120);
+
+        assert_eq!(master_size(&master), (40, 120));
+    }
+
+    #[test]
+    fn test_resize_to_same_dimensions_does_not_notify_child() {
+        let (mut pty, master) = create_interactive_pty_instance(24, 80);
+
+        pty.resize(24, 80).unwrap();
+
+        // No spurious SIGWINCH: a no-op resize must stay a no-op, otherwise every
+        // redraw would kick full-screen children into relayouting.
+        assert_eq!(master_size(&master), (24, 80));
+    }
+
+    #[test]
+    fn test_non_interactive_pty_resize_has_no_master_to_notify() {
+        // Tasks without a pty (batch tasks, forked processes) still resize their
+        // parser for rendering; they just have no child to signal.
+        let mut pty = PtyInstance::non_interactive_with_dimensions(24, 80);
+        pty.resize(30, 100).unwrap();
+        assert_eq!(pty.get_dimensions(), (30, 100));
     }
 }

--- a/packages/nx/src/native/tui/tui.rs
+++ b/packages/nx/src/native/tui/tui.rs
@@ -156,8 +156,18 @@ pub struct Tui {
 /// - `?1006h` — SGR extended coordinates, so columns/rows past 223 are reported
 ///   correctly and release events are distinguishable.
 const ENABLE_MOUSE_CAPTURE_SEQ: &[u8] = b"\x1b[?1000h\x1b[?1002h\x1b[?1006h";
-/// Disable sequence — the same modes reset, in reverse order.
-const DISABLE_MOUSE_CAPTURE_SEQ: &[u8] = b"\x1b[?1006l\x1b[?1002l\x1b[?1000l";
+/// Disable sequence — the same modes reset, in reverse order. Also resets
+/// `?1003`, which is enabled on demand while an interactive pane's app
+/// requests any-motion tracking (see `enable_any_motion_capture`); resetting
+/// an unset mode is a no-op, so every teardown path can clear it blindly.
+const DISABLE_MOUSE_CAPTURE_SEQ: &[u8] = b"\x1b[?1003l\x1b[?1006l\x1b[?1002l\x1b[?1000l";
+
+/// Any-motion ("all-event") tracking, enabled only while a focused interactive
+/// pane's app has itself requested `?1003` so its hover events can be
+/// forwarded. Kept out of the base capture set because it reports every mouse
+/// move, flooding the event loop when nothing needs the data.
+const ENABLE_ANY_MOTION_SEQ: &[u8] = b"\x1b[?1003h";
+const DISABLE_ANY_MOTION_SEQ: &[u8] = b"\x1b[?1003l";
 
 /// Enable mouse reporting on the terminal (stderr — the same stream the TUI
 /// renders to). Idempotent: re-enabling already-enabled modes is a no-op for
@@ -174,6 +184,18 @@ pub(crate) fn enable_mouse_capture() -> std::io::Result<()> {
 pub(crate) fn disable_mouse_capture() -> std::io::Result<()> {
     let mut stderr = std::io::stderr();
     stderr.write_all(DISABLE_MOUSE_CAPTURE_SEQ)?;
+    stderr.flush()
+}
+
+pub(crate) fn enable_any_motion_capture() -> std::io::Result<()> {
+    let mut stderr = std::io::stderr();
+    stderr.write_all(ENABLE_ANY_MOTION_SEQ)?;
+    stderr.flush()
+}
+
+pub(crate) fn disable_any_motion_capture() -> std::io::Result<()> {
+    let mut stderr = std::io::stderr();
+    stderr.write_all(DISABLE_ANY_MOTION_SEQ)?;
     stderr.flush()
 }
 

--- a/packages/nx/src/native/tui/tui_app.rs
+++ b/packages/nx/src/native/tui/tui_app.rs
@@ -7,7 +7,7 @@ use tokio::sync::mpsc::UnboundedSender;
 
 use crate::native::ide::nx_console::messaging::NxConsoleMessageConnection;
 use crate::native::{
-    pseudo_terminal::pseudo_terminal::{ParserArc, WriterArc},
+    pseudo_terminal::pseudo_terminal::PtyHandles,
     tasks::types::{Task, TaskResult},
 };
 
@@ -238,24 +238,23 @@ pub trait TuiApp: Send {
         // Default: no-op
     }
 
-    /// Register a running interactive task with its PTY parser and writer
+    /// Register a running interactive task with its PTY handles
     ///
     /// Default implementation creates a PTY, registers it, and calls the hook.
-    /// Interactive PTYs are NOT resized because they handle dimensions through
-    /// the parser/writer. Override if mode-specific resizing is needed.
+    /// The PTY inherits the dimensions it was opened with; it is resized to the
+    /// pane it is displayed in once the pane is laid out. Override if
+    /// mode-specific resizing is needed at registration time.
     ///
     /// # Arguments
     ///
     /// * `task_id` - The task identifier
-    /// * `parser_and_writer` - Reference to PTY parser and writer
-    fn register_running_interactive_task(
-        &mut self,
-        task_id: String,
-        parser_and_writer: &(ParserArc, WriterArc),
-    ) {
-        // Interactive PTYs don't need dimension calculation - they use parser/writer dimensions
-        let pty =
-            PtyInstance::interactive(parser_and_writer.0.clone(), parser_and_writer.1.clone());
+    /// * `pty_handles` - Reference to the PTY parser, writer and master
+    fn register_running_interactive_task(&mut self, task_id: String, pty_handles: &PtyHandles) {
+        let pty = PtyInstance::interactive(
+            pty_handles.0.clone(),
+            pty_handles.1.clone(),
+            pty_handles.2.clone(),
+        );
 
         let pty = Arc::new(pty);
         self.state()

--- a/packages/nx/src/tasks-runner/life-cycle.ts
+++ b/packages/nx/src/tasks-runner/life-cycle.ts
@@ -72,7 +72,7 @@ export interface LifeCycle {
 
   registerRunningTask?(
     taskId: string,
-    parserAndWriter: ExternalObject<[any, any]>
+    ptyHandles: ExternalObject<[any, any, any]>
   ): void;
 
   registerRunningTaskWithEmptyParser?(taskId: string): void;
@@ -182,11 +182,11 @@ export class CompositeLifeCycle implements LifeCycle {
 
   registerRunningTask(
     taskId: string,
-    parserAndWriter: ExternalObject<[any, any]>
+    ptyHandles: ExternalObject<[any, any, any]>
   ): void {
     for (let l of this.lifeCycles) {
       if (l.registerRunningTask) {
-        l.registerRunningTask(taskId, parserAndWriter);
+        l.registerRunningTask(taskId, ptyHandles);
       }
     }
   }

--- a/packages/nx/src/tasks-runner/pseudo-terminal.ts
+++ b/packages/nx/src/tasks-runner/pseudo-terminal.ts
@@ -235,8 +235,8 @@ export class PseudoTtyProcess implements RunningTask {
     }
   }
 
-  getParserAndWriter() {
-    return this.childProcess.getParserAndWriter();
+  getPtyHandles() {
+    return this.childProcess.getPtyHandles();
   }
 }
 

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -1180,7 +1180,7 @@ export class TaskOrchestrator {
             // This is an external of a the pseudo terminal where a task is running and can be passed to the TUI
             this.options.lifeCycle.registerRunningTask(
               task.id,
-              runningTask.getParserAndWriter()
+              runningTask.getPtyHandles()
             );
             runningTask.onOutput((output) => {
               this.options.lifeCycle.appendTaskOutput(task.id, output, true);
@@ -1239,7 +1239,7 @@ export class TaskOrchestrator {
           // This is an external of a the pseudo terminal where a task is running and can be passed to the TUI
           this.options.lifeCycle.registerRunningTask(
             task.id,
-            runningTask.getParserAndWriter()
+            runningTask.getPtyHandles()
           );
           runningTask.onOutput((output) => {
             this.options.lifeCycle.appendTaskOutput(task.id, output, true);


### PR DESCRIPTION
This PR makes the Nx TUI a more complete terminal emulator for the tasks it hosts. It carries two related fixes: **mouse events are forwarded into child apps**, and **terminal resizes are propagated to them**.

Both address the same underlying gap — the TUI renders a child's output faithfully, but was a one-way street: it never told the child about input or environment changes that a real terminal would.

## Current Behavior

### Mouse events

The TUI captured mouse events for its own use (pane focus, scrolling) but never passed them to the child app. Apps that request mouse reporting — anything that sets a DEC private mode to opt in — received nothing, so clicking and dragging inside a task's pane did nothing.

### Resize events

The TUI opens a pseudoterminal for each task **once**, sized to the host terminal at spawn time, and never touches it again. `MasterPty::resize()` — the call that issues `TIOCSWINSZ` and makes the kernel raise `SIGWINCH` — was never invoked anywhere in the codebase (`PtySize` appeared exactly once, at `openpty`).

What `handle_pty_resize` actually did was resize our **vt100 parser**: rebuild it at the new dimensions and replay the captured raw output. That re-wraps bytes we already have, but the child process is never told anything changed. So:

- The child's kernel winsize stays frozen at the host terminal's size for its entire life, and `process.stdout.columns/rows` never updates.
- No `SIGWINCH` is ever delivered, so `process.stdout.on('resize')` never fires.

Line-oriented tools (jest, vite) looked fine, because replaying their output through a re-sized parser genuinely re-wraps it. Full-screen children are a different story: they emit absolute cursor positioning computed for the size they *think* they have, and only relayout when signalled. **opentui-based apps in particular do not react to resize at all when run inside the TUI.**

## Expected Behavior

### Mouse events

A new `mouse_protocol` module parses the DEC private mode requests a child app makes and exposes the mode/encoding it asked for. `PtyInstance::forward_mouse_event` then encodes each event to match — honoring the requested **mode** (`Press` / `PressRelease` / `ButtonMotion` / `AnyMotion`, and `None` to stay silent) and **encoding** (SGR, legacy default, UTF-8) — and writes it to the child on the pty writer. Events the app didn't ask for are filtered out rather than blindly sent, and coordinates are translated from screen space into cells relative to the child's own screen.

### Resize events

The pty master is threaded from `PseudoTerminal` → `ChildProcess` → `PtyInstance`, and `PtyInstance::resize`/`resize_async` now issue `TIOCSWINSZ` alongside the existing parser reparse.

The two are complementary, not alternatives:

- The **reparse stays** — scrollback and re-wrapping of already-captured output depend on it.
- The **ioctl is purely the notification** that raises `SIGWINCH`, so the child itself redraws at the new dimensions from here on.

This applies to **every task that runs in a pty**. Tasks without one (batch tasks, forked processes) carry `master: None` and have nothing to notify. The pre-existing "skip if dimensions unchanged" guard now does double duty: it already avoided a wasted reparse, and it now also prevents spurious `SIGWINCH` storms that would kick full-screen children into relayouting on every no-op resize.

### Why the two halves don't share plumbing

Worth calling out for reviewers, since they sound like the same problem:

- **Mouse is in-band.** The app opts in via a DEC mode and the terminal answers with bytes on the pty writer. Solvable without ever touching the pty master — which is exactly what the mouse commit does.
- **Resize is out-of-band.** The kernel owns the winsize; the app subscribes to a *signal*, not to a byte stream. There is no escape sequence we could have written to the pty instead, which is why this half needs the master handle threaded through.

## Validation

We audited [opentui](https://github.com/anomalyco/opentui) directly to confirm `SIGWINCH` is genuinely the mechanism it depends on, rather than assuming it:

- It reads its size once from `process.stdout.columns/rows` (`packages/core/src/renderer.ts:676`).
- It detects changes through exactly one mechanism: `process.on("SIGWINCH", ...)` (`packages/core/src/renderer.ts:1165`).
- There is **no** DEC mode 2048 (in-band resize notification) support, no DSR probing, no polling loop, and no `COLUMNS`/`LINES` fallback — so a terminal emulator cannot notify it by writing escape sequences to the pty. The ioctl is the only path.
- On `SIGWINCH` it reallocates its native framebuffers, relayouts the renderable tree, and schedules a frame — a real repaint, so a correctly-signalled app visibly recovers.

Beyond the unit tests, the resize path was verified end-to-end against a real `node` child running inside the pty: it printed `START 80x24`, and after a `PtyInstance::resize(30, 100)` its own `process.stdout.on('resize')` handler fired with `RESIZE 100x30` — the same signal opentui subscribes to.

## Tests

Mouse encoding is covered by unit tests in `mouse_protocol.rs` across the mode/encoding matrix, including the `None` mode staying silent.

Four new tests in `pty.rs` assert against the **kernel-reported** winsize (`master.get_size()`), which is what the child reads via `TIOCGWINSZ` — not against our own dimension bookkeeping, so they fail if the ioctl regresses even while the parser still resizes correctly:

- `resize` updates the kernel winsize
- `resize_async` updates it eagerly (the ioctl lands before the backgrounded reparse)
- a no-op resize does **not** notify the child
- a pty-less task still resizes its parser, with no master to notify

## Known limitation

The pty is still *opened* at the host terminal's size (`PseudoTerminalOptions::default()`). A task only receives pane-correct dimensions once its pane is laid out and `handle_pty_resize` runs. In practice the child is signalled when it's displayed and self-heals, but a full-screen app's very first frame may be drawn at the wrong size. Sizing the pty at `openpty` time is a separate change.

## Related Issue(s)

N/A — reported directly.
