### PR TITLE
fix(ai): adapt generated skill commands to the workspace package manager

### DIFF
--- a/packages/nx/src/ai/constants.ts
+++ b/packages/nx/src/ai/constants.ts
@@ -56,11 +56,16 @@ export const rulesRegex = new RegExp(
 export interface AgentRulesWrappedOptions {
   writeNxCloudRules: boolean;
   useH1?: boolean;
+  workspaceRoot?: string;
 }
 
 export const getAgentRulesWrapped = (options: AgentRulesWrappedOptions) => {
-  const { writeNxCloudRules, useH1 = true } = options;
-  const agentRulesString = getAgentRules({ nxCloud: writeNxCloudRules, useH1 });
+  const { writeNxCloudRules, useH1 = true, workspaceRoot } = options;
+  const agentRulesString = getAgentRules({
+    nxCloud: writeNxCloudRules,
+    useH1,
+    workspaceRoot,
+  });
   return `${nxRulesMarkerCommentStart}\n${nxRulesMarkerCommentDescription}\n\n${agentRulesString}\n\n${nxRulesMarkerCommentEnd}`;
 };
 

--- a/packages/nx/src/ai/set-up-ai-agents/adapt-skill-files-to-package-manager.spec.ts
+++ b/packages/nx/src/ai/set-up-ai-agents/adapt-skill-files-to-package-manager.spec.ts
@@ -1,0 +1,56 @@
+import { createTreeWithEmptyWorkspace } from '../../generators/testing-utils/create-tree-with-empty-workspace';
+import { adaptSkillFilesToPackageManager } from './adapt-skill-files-to-package-manager';
+import * as packageManager from '../../utils/package-manager';
+
+describe('adaptSkillFilesToPackageManager', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should rewrite pnpm nx commands in skills for yarn workspaces', () => {
+    jest.spyOn(packageManager, 'detectPackageManager').mockReturnValue('yarn');
+    jest.spyOn(packageManager, 'getPackageManagerCommand').mockReturnValue({
+      install: 'yarn',
+      ciInstall: 'yarn install --immutable',
+      updateLockFile: 'yarn install',
+      add: 'yarn add',
+      addDev: 'yarn add -D',
+      rm: 'yarn remove',
+      exec: 'yarn',
+      dlx: 'yarn dlx',
+      run: (script: string) => `yarn ${script}`,
+      list: 'yarn info --name-only',
+      why: 'yarn why',
+      getRegistryUrl: 'yarn config get registry',
+      publish: () => 'yarn publish',
+    });
+
+    const tree = createTreeWithEmptyWorkspace();
+    tree.write(
+      '.cursor/skills/nx-plugins/SKILL.md',
+      '# Plugins\n\n- List plugins: `pnpm nx list`\n- Install: `pnpm nx add @nx/react`\n'
+    );
+
+    adaptSkillFilesToPackageManager(tree, '.');
+
+    const content = tree.read('.cursor/skills/nx-plugins/SKILL.md', 'utf-8');
+    expect(content).toContain('`yarn nx list`');
+    expect(content).toContain('`yarn nx add @nx/react`');
+    expect(content).not.toContain('pnpm nx');
+  });
+
+  it('should leave skill files unchanged for pnpm workspaces', () => {
+    jest.spyOn(packageManager, 'detectPackageManager').mockReturnValue('pnpm');
+
+    const tree = createTreeWithEmptyWorkspace();
+    const original =
+      '# Plugins\n\n- List plugins: `pnpm nx list`\n';
+    tree.write('.claude/skills/nx-plugins/SKILL.md', original);
+
+    adaptSkillFilesToPackageManager(tree, '.');
+
+    expect(tree.read('.claude/skills/nx-plugins/SKILL.md', 'utf-8')).toBe(
+      original
+    );
+  });
+});

--- a/packages/nx/src/ai/set-up-ai-agents/adapt-skill-files-to-package-manager.ts
+++ b/packages/nx/src/ai/set-up-ai-agents/adapt-skill-files-to-package-manager.ts
@@ -1,0 +1,120 @@
+import { join } from 'path';
+import { Tree } from '../../generators/tree';
+import {
+  detectPackageManager,
+  getPackageManagerCommand,
+  PackageManager,
+} from '../../utils/package-manager';
+
+const SKILL_ROOT_DIRS = [
+  '.agents/skills',
+  '.cursor/skills',
+  '.github/skills',
+  '.opencode/skills',
+  '.gemini/skills',
+  '.claude/skills',
+];
+
+/**
+ * Skill templates in nx-ai-agents-config are authored with pnpm examples.
+ * Rewrite them to match the workspace package manager when copied or refreshed.
+ */
+export function adaptSkillFilesToPackageManager(
+  tree: Tree,
+  directory: string
+): void {
+  const workspaceDir = join(tree.root, directory);
+  const packageManager = detectPackageManager(workspaceDir);
+  if (packageManager === 'pnpm') {
+    return;
+  }
+
+  const commands = getPackageManagerCommand(packageManager, workspaceDir);
+  const nxPrefix = getNxCommandPrefix(packageManager);
+
+  for (const skillRoot of SKILL_ROOT_DIRS) {
+    const basePath = join(directory, skillRoot);
+    if (!tree.exists(basePath)) {
+      continue;
+    }
+    for (const filePath of listFilesRecursive(tree, basePath)) {
+      if (!filePath.endsWith('.md')) {
+        continue;
+      }
+      const content = tree.read(filePath, 'utf-8');
+      if (!content?.includes('pnpm')) {
+        continue;
+      }
+      tree.write(
+        filePath,
+        adaptSkillContent(content, packageManager, commands, nxPrefix)
+      );
+    }
+  }
+}
+
+function listFilesRecursive(tree: Tree, dir: string): string[] {
+  const files: string[] = [];
+  for (const child of tree.children(dir)) {
+    const childPath = join(dir, child);
+    if (tree.isFile(childPath)) {
+      files.push(childPath);
+    } else {
+      files.push(...listFilesRecursive(tree, childPath));
+    }
+  }
+  return files;
+}
+
+function getNxCommandPrefix(packageManager: PackageManager): string {
+  switch (packageManager) {
+    case 'yarn':
+      return 'yarn';
+    case 'npm':
+      return 'npm exec';
+    case 'bun':
+      return 'bunx';
+    default:
+      return 'pnpm';
+  }
+}
+
+function adaptSkillContent(
+  content: string,
+  packageManager: PackageManager,
+  commands: ReturnType<typeof getPackageManagerCommand>,
+  nxPrefix: string
+): string {
+  const replacements: [string, string][] = [
+    ['pnpm add -Dw', commands.addDev],
+    ['pnpm add -wD', commands.addDev],
+    ['pnpm add -w', commands.add],
+    ['pnpm add -D', commands.addDev],
+    ['pnpm add', commands.add],
+    ['pnpm install', commands.install],
+    ['pnpm exec', commands.exec],
+    ['pnpm dlx', commands.dlx],
+    ['pnpx', commands.dlx],
+    ['pnpm nx', `${nxPrefix} nx`],
+  ];
+
+  let adapted = content;
+  for (const [from, to] of replacements) {
+    adapted = adapted.split(from).join(to);
+  }
+
+  if (packageManager === 'yarn') {
+    adapted = adapted
+      .split('pnpm-workspace.yaml')
+      .join('package.json `workspaces`');
+    adapted = adapted.split('pnpm.overrides').join('resolutions');
+  } else if (packageManager === 'npm') {
+    adapted = adapted
+      .split('pnpm-workspace.yaml')
+      .join('package.json `workspaces`');
+  } else if (packageManager === 'bun') {
+    adapted = adapted.split('pnpm-workspace.yaml').join('package.json workspaces');
+  }
+
+  return adapted;
+}

--- a/packages/nx/src/ai/set-up-ai-agents/get-agent-rules.ts
+++ b/packages/nx/src/ai/set-up-ai-agents/get-agent-rules.ts
@@ -1,16 +1,36 @@
+import {
+  detectPackageManager,
+} from '../../utils/package-manager';
+
 export interface AgentRulesOptions {
   nxCloud: boolean;
   useH1?: boolean;
+  workspaceRoot?: string;
+}
+
+function getNxCommandExample(workspaceRoot?: string): string {
+  const packageManager = detectPackageManager(workspaceRoot ?? '');
+  switch (packageManager) {
+    case 'yarn':
+      return 'yarn nx build';
+    case 'npm':
+      return 'npm exec nx test';
+    case 'bun':
+      return 'bunx nx build';
+    default:
+      return 'pnpm nx build';
+  }
 }
 
 export function getAgentRules(options: AgentRulesOptions) {
   const { nxCloud, useH1 = true } = options;
   const header = useH1 ? '#' : '##';
+  const nxCommandExample = getNxCommandExample(options.workspaceRoot);
   return `${header} General Guidelines for working with Nx
 
 - For navigating/exploring the workspace, invoke the \`nx-workspace\` skill first - it has patterns for querying projects, targets, and dependencies
 - When running tasks (for example build, lint, test, e2e, etc.), always prefer running the task through \`nx\` (i.e. \`nx run\`, \`nx run-many\`, \`nx affected\`) instead of using the underlying tooling directly
-- Prefix nx commands with the workspace's package manager (e.g., \`pnpm nx build\`, \`npm exec nx test\`) - avoids using globally installed CLI
+- Prefix nx commands with the workspace's package manager (e.g., \`${nxCommandExample}\`) - avoids using globally installed CLI
 - You have access to the Nx MCP server and its tools, use them to help the user
 - For Nx plugin best practices, check \`node_modules/@nx/<plugin>/PLUGIN.md\`. Not all plugins have this file - proceed without it if unavailable.
 - NEVER guess CLI flags - always check nx_docs or \`--help\` first when unsure

--- a/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.ts
+++ b/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.ts
@@ -43,6 +43,7 @@ import {
   SetupAiAgentsGeneratorSchema,
 } from './schema';
 import { handleImport } from '../../utils/handle-import';
+import { adaptSkillFilesToPackageManager } from './adapt-skill-files-to-package-manager';
 
 export type ModificationResults = {
   messages: CLINoteMessageConfig[];
@@ -354,6 +355,8 @@ export async function setupAiAgentsGeneratorImpl(
 
   await formatChangedFilesWithPrettierIfAvailable(tree);
 
+  adaptSkillFilesToPackageManager(tree, options.directory);
+
   // we use the check variable to determine if we should actually make changes or just report what would be changed
   return async (check: boolean = false) => {
     const messages: CLINoteMessageConfig[] = [];
@@ -429,6 +432,7 @@ function writeAgentRules(tree: Tree, path: string, writeNxCloudRules: boolean) {
     const expectedRules = getAgentRulesWrapped({
       writeNxCloudRules,
       useH1: true,
+      workspaceRoot: tree.root,
     });
     tree.write(path, expectedRules);
     return;
@@ -447,6 +451,7 @@ function writeAgentRules(tree: Tree, path: string, writeNxCloudRules: boolean) {
     const expectedRules = getAgentRulesWrapped({
       writeNxCloudRules,
       useH1: !hasExternalH1,
+      workspaceRoot: tree.root,
     });
     const contentOnly = (str: string) =>
       str
@@ -471,6 +476,7 @@ function writeAgentRules(tree: Tree, path: string, writeNxCloudRules: boolean) {
     const expectedRules = getAgentRulesWrapped({
       writeNxCloudRules,
       useH1: !hasExistingH1,
+      workspaceRoot: tree.root,
     });
     tree.write(path, existing + '\n\n' + expectedRules);
   }


### PR DESCRIPTION
## Current Behavior

`configure-ai-agents` copies skill templates with hardcoded `pnpm nx` command examples. In yarn/npm/bun workspaces, the generated `SKILL.md` files and `AGENTS.md` guidance still point at `pnpm`.

## Expected Behavior

Copied skills and agent rules use the workspace's detected package manager (`yarn nx`, `npm exec nx`, etc.).

## Related Issue(s)

Fixes #36312

Adds `adaptSkillFilesToPackageManager` after skill copy. Unit tests in `adapt-skill-files-to-package-manager.spec.ts` (2 passing).