### PR TITLE
fix(misc): suppress outdated disclaimer for unsupported AI agents with AGENTS.md

### DIFF
--- a/packages/nx/src/ai/configure-ai-agents-disclaimer.spec.ts
+++ b/packages/nx/src/ai/configure-ai-agents-disclaimer.spec.ts
@@ -1,0 +1,63 @@
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { shouldPrintConfigureAiAgentsDisclaimer } from './configure-ai-agents-disclaimer';
+import { agentsMdPath, getAgentRulesWrapped } from './constants';
+
+jest.mock('./detect-ai-agent', () => ({
+  detectAiAgent: jest.fn(() => null),
+}));
+
+import { detectAiAgent } from './detect-ai-agent';
+
+describe('shouldPrintConfigureAiAgentsDisclaimer', () => {
+  const outdated = [{ name: 'claude' as const, displayName: 'Claude Code' }];
+  const mockedDetectAiAgent = detectAiAgent as jest.MockedFunction<
+    typeof detectAiAgent
+  >;
+
+  beforeEach(() => {
+    mockedDetectAiAgent.mockReturnValue(null);
+  });
+
+  it('should not print when nothing is outdated', () => {
+    expect(shouldPrintConfigureAiAgentsDisclaimer([], '/tmp')).toBe(false);
+  });
+
+  it('should not print for unsupported agents when AGENTS.md has Nx rules', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'nx-disclaimer-'));
+    try {
+      writeFileSync(
+        agentsMdPath(dir),
+        getAgentRulesWrapped({ writeNxCloudRules: false, useH1: true })
+      );
+      expect(shouldPrintConfigureAiAgentsDisclaimer(outdated, dir)).toBe(false);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('should print for unsupported agents when AGENTS.md is missing', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'nx-disclaimer-'));
+    try {
+      expect(existsSync(agentsMdPath(dir))).toBe(false);
+      expect(shouldPrintConfigureAiAgentsDisclaimer(outdated, dir)).toBe(true);
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
+  });
+
+  it('should print when the detected supported agent is outdated', () => {
+    mockedDetectAiAgent.mockReturnValue('claude');
+
+    expect(shouldPrintConfigureAiAgentsDisclaimer(outdated, '/tmp')).toBe(true);
+  });
+
+  it('should not print when a different supported agent is outdated', () => {
+    mockedDetectAiAgent.mockReturnValue('cursor');
+
+    expect(shouldPrintConfigureAiAgentsDisclaimer(outdated, '/tmp')).toBe(
+      false
+    );
+  });
+});

--- a/packages/nx/src/ai/configure-ai-agents-disclaimer.ts
+++ b/packages/nx/src/ai/configure-ai-agents-disclaimer.ts
@@ -1,0 +1,35 @@
+import { existsSync, readFileSync } from 'fs';
+import { AgentStatusInfo } from '../daemon/message-types/configure-ai-agents';
+import { detectAiAgent } from './detect-ai-agent';
+import { agentsMdPath, rulesRegex } from './constants';
+
+/**
+ * Whether to show the "configure-ai-agents is outdated" banner after a task run.
+ */
+export function shouldPrintConfigureAiAgentsDisclaimer(
+  outdatedAgents: AgentStatusInfo[],
+  workspaceRoot: string
+): boolean {
+  if (outdatedAgents.length === 0) {
+    return false;
+  }
+
+  const detectedAgent = detectAiAgent();
+  if (detectedAgent) {
+    return outdatedAgents.some((agent) => agent.name === detectedAgent);
+  }
+
+  // Unsupported agents (e.g. qwen) cannot be configured via `nx configure-ai-agents`.
+  // If the repo already has Nx rules in AGENTS.md, skip the misleading warning.
+  const agentsMd = agentsMdPath(workspaceRoot);
+  if (!existsSync(agentsMd)) {
+    return true;
+  }
+
+  try {
+    const content = readFileSync(agentsMd, 'utf-8');
+    return !rulesRegex.test(content);
+  } catch {
+    return true;
+  }
+}

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -34,6 +34,7 @@ import {
   getNxKeyInformation,
 } from '../utils/nx-key';
 import { output } from '../utils/output';
+import { shouldPrintConfigureAiAgentsDisclaimer } from '../ai/configure-ai-agents-disclaimer';
 import {
   collectEnabledTaskSyncGeneratorsFromTaskGraph,
   flushSyncGeneratorChanges,
@@ -623,13 +624,16 @@ async function printConfigureAiAgentsDisclaimer(): Promise<void> {
       return;
     }
     const { outdatedAgents } = await daemonClient.getConfigureAiAgentsStatus();
-    if (outdatedAgents.length > 0) {
-      output.logRawLine(
-        output.dim(
-          'Your AI agent configuration is outdated. Run "nx configure-ai-agents" to update.'
-        )
-      );
+    if (
+      !shouldPrintConfigureAiAgentsDisclaimer(outdatedAgents, workspaceRoot)
+    ) {
+      return;
     }
+    output.logRawLine(
+      output.dim(
+        'Your AI agent configuration is outdated. Run "nx configure-ai-agents" to update.'
+      )
+    );
   } catch {
     // Silently ignore errors
   }


### PR DESCRIPTION
## Current Behavior

After a task run, Nx shows an "outdated configure-ai-agents" warning whenever any supported agent config is stale — even if the active agent isn't one `configure-ai-agents` can update (e.g. qwen) and `AGENTS.md` already has Nx rules.

## Expected Behavior

Only show the outdated banner for the detected supported agent. For unsupported agents, skip it when `AGENTS.md` already contains the Nx rules block.

## Related Issue(s)

Fixes #36264

Extracted `shouldPrintConfigureAiAgentsDisclaimer` from `run-command.ts`. Unit tests in `configure-ai-agents-disclaimer.spec.ts` (5 passing).