### PR TITLE
fix(vite): skip serve targets for library projects without a server config

### DIFF
--- a/packages/vite/src/plugins/plugin.spec.ts
+++ b/packages/vite/src/plugins/plugin.spec.ts
@@ -7,6 +7,7 @@ import { isUsingTsSolutionSetup } from '@nx/js/internal';
 jest.mock('../utils/executor-utils', () => ({
   loadViteDynamicImport: jest.fn().mockResolvedValue({
     resolveConfig: jest.fn().mockResolvedValue({}),
+    loadConfigFromFile: jest.fn().mockResolvedValue({ config: {} }),
   }),
 }));
 
@@ -21,6 +22,10 @@ describe('@nx/vite/plugin', () => {
 
   beforeEach(() => {
     (isUsingTsSolutionSetup as jest.Mock).mockReturnValue(false);
+    (loadViteDynamicImport as jest.Mock).mockResolvedValue({
+      resolveConfig: jest.fn().mockResolvedValue({}),
+      loadConfigFromFile: jest.fn().mockResolvedValue({ config: {} }),
+    });
   });
 
   describe('root project', () => {
@@ -114,6 +119,7 @@ describe('@nx/vite/plugin', () => {
             },
           },
         }),
+        loadConfigFromFile: jest.fn().mockResolvedValue({ config: {} }),
       });
 
       const nodes = await createNodesFunction(
@@ -401,6 +407,20 @@ describe('@nx/vite/plugin', () => {
               name: 'my-lib',
             },
           },
+          server: {
+            port: 5173,
+            host: 'localhost',
+          },
+        }),
+        loadConfigFromFile: jest.fn().mockResolvedValue({
+          config: {
+            build: {
+              lib: {
+                entry: 'index.ts',
+                name: 'my-lib',
+              },
+            },
+          },
         }),
       }),
         (context = {
@@ -433,19 +453,21 @@ describe('@nx/vite/plugin', () => {
     });
     it('should not exclude serve and preview targets when vite.config.ts is in library mode when user has defined a server config', async () => {
       const tempFs = new TempFs('test-exclude');
+      const userConfig = {
+        build: {
+          lib: {
+            entry: 'index.ts',
+            name: 'my-lib',
+          },
+        },
+        server: {
+          port: 3000,
+          host: 'localhost',
+        },
+      };
       ((loadViteDynamicImport as jest.Mock).mockResolvedValue({
-        resolveConfig: jest.fn().mockResolvedValue({
-          build: {
-            lib: {
-              entry: 'index.ts',
-              name: 'my-lib',
-            },
-          },
-          server: {
-            port: 3000,
-            host: 'localhost',
-          },
-        }),
+        resolveConfig: jest.fn().mockResolvedValue(userConfig),
+        loadConfigFromFile: jest.fn().mockResolvedValue({ config: userConfig }),
       }),
         (context = {
           nxJsonConfiguration: {

--- a/packages/vite/src/plugins/plugin.ts
+++ b/packages/vite/src/plugins/plugin.ts
@@ -216,7 +216,18 @@ async function buildViteTargets(
   } catch {
     // Plugin not installed or not needed, ignore
   }
-  const { resolveConfig } = await loadViteDynamicImport();
+  const { resolveConfig, loadConfigFromFile } = await loadViteDynamicImport();
+  const configEnv = {
+    command: 'build' as const,
+    mode: 'development' as const,
+    isSsrBuild: false,
+    isPreview: false,
+  };
+  const userConfigResult = await loadConfigFromFile(
+    configEnv,
+    absoluteConfigFilePath,
+    projectRoot
+  );
   const viteBuildConfig = await resolveConfig(
     {
       configFile: absoluteConfigFilePath,
@@ -231,7 +242,8 @@ async function buildViteTargets(
   const { buildOutputs, isBuildable, hasServeConfig } = getOutputs(
     viteBuildConfig,
     projectRoot,
-    context.workspaceRoot
+    context.workspaceRoot,
+    Boolean(userConfigResult?.config?.server)
   );
 
   const namedInputs = getNamedInputs(projectRoot, context);
@@ -483,7 +495,8 @@ function serveStaticTarget(
 function getOutputs(
   viteBuildConfig: ResolvedConfig | undefined,
   projectRoot: string,
-  workspaceRoot: string
+  workspaceRoot: string,
+  hasUserServeConfig = false
 ): {
   buildOutputs: string[];
   isBuildable: boolean;
@@ -493,7 +506,7 @@ function getOutputs(
   // "nodenext". Vite 8's rolldown types are ESM-only (.d.mts) and not
   // resolvable under moduleResolution: "node", which breaks rolldownOptions
   // on ResolvedConfig.
-  const { build, server } = viteBuildConfig as any;
+  const { build } = viteBuildConfig as any;
 
   const buildOutputPath = normalizeOutputPath(
     build?.outDir,
@@ -510,7 +523,9 @@ function getOutputs(
       existsSync(join(workspaceRoot, projectRoot, 'index.html'))
   );
 
-  const hasServeConfig = Boolean(server?.host || server?.port);
+  // Vite always resolves default server.port/host even when the user did not
+  // configure a dev server. Only treat an explicit server block as serveable.
+  const hasServeConfig = hasUserServeConfig;
 
   return {
     buildOutputs: [buildOutputPath],


### PR DESCRIPTION
## Current Behavior

The Vite plugin infers `serve`, `preview`, and `serve-static` for library-only projects. Library mode is detected via `build.lib`, but serve targets are still added because Vite's resolved config always includes default `server.port`/`host` even when the user didn't define a `server` block.

## Expected Behavior

Library projects without an explicit `server` config in `vite.config.*` should not get serve-related targets. Projects that intentionally define `server` in library mode should still get them.

## Related Issue(s)

Fixes #35957

Same regression as #29506. Uses `loadConfigFromFile` to detect a user-defined `server` block instead of relying on Vite's resolved defaults. `plugin.spec.ts` updated (13 passing).