### PR TITLE
fix(release): only extract body issue references linked via closing keywords

### DIFF
--- a/packages/nx/src/command-line/release/utils/git.spec.ts
+++ b/packages/nx/src/command-line/release/utils/git.spec.ts
@@ -126,6 +126,68 @@ Closes #1`,
       `);
     });
 
+    it('should match issue references linked via closing keywords in the commit body', () => {
+      const references = extractReferencesFromCommit({
+        message: 'fix: all the things (#20607)',
+        body: `Some description of the change.
+
+Fixes #789
+Resolves: #790`,
+        shortHash: 'abc123',
+        author: { name: 'Test Author', email: 'test@example.com' },
+      });
+      expect(references).toMatchInlineSnapshot(`
+        [
+          {
+            "type": "pull-request",
+            "value": "#20607",
+          },
+          {
+            "type": "issue",
+            "value": "#789",
+          },
+          {
+            "type": "issue",
+            "value": "#790",
+          },
+          {
+            "type": "hash",
+            "value": "abc123",
+          },
+        ]
+      `);
+    });
+
+    it('should not match issue numbers mentioned in the commit body without a closing keyword', () => {
+      const references = extractReferencesFromCommit({
+        message: 'fix: all the things (#20607)',
+        body: `This works around web-infra-dev/rspack#2292 and the tsx bug
+tracked in [#781](https://github.com/privatenumber/tsx/issues/781).
+
+Similar to the approach taken in #34111.
+
+Fixes #36014`,
+        shortHash: 'abc123',
+        author: { name: 'Test Author', email: 'test@example.com' },
+      });
+      expect(references).toMatchInlineSnapshot(`
+        [
+          {
+            "type": "pull-request",
+            "value": "#20607",
+          },
+          {
+            "type": "issue",
+            "value": "#36014",
+          },
+          {
+            "type": "hash",
+            "value": "abc123",
+          },
+        ]
+      `);
+    });
+
     it('should match GitLab style merge request references', () => {
       const references = extractReferencesFromCommit({
         message: "Merge branch 'mr-to-fix-issue' into 'main'",

--- a/packages/nx/src/command-line/release/utils/git.ts
+++ b/packages/nx/src/command-line/release/utils/git.ts
@@ -606,8 +606,10 @@ export function extractReferencesFromCommit(commit: RawGitCommit): Reference[] {
     }
   }
 
-  // Extract issue references from commit body
-  for (const m of commit.body.matchAll(IssueRE)) {
+  // Extract issue references from commit body, only when linked via a closing
+  // keyword so that other repos' issue numbers mentioned in prose are not
+  // picked up (e.g. "web-infra-dev/rspack#2292")
+  for (const m of commit.body.matchAll(IssueClosingKeywordRE)) {
     if (!references.some((i) => i.value === m[1])) {
       references.push({ type: 'issue', value: m[1] });
     }
@@ -641,6 +643,9 @@ const PullRequestRE = /\([ a-z]*(#\d+)\s*\)/gm;
 // GitLab style merge request references
 const GitLabMergeRequestRE = /See merge request (?:[a-z0-9/-]+)?(![\d]+)/gim;
 const IssueRE = /(#\d+)/gm;
+// GitHub style issue closing keywords, e.g. "Fixes #1234"
+const IssueClosingKeywordRE =
+  /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?):?\s+(#\d+)/gim;
 const ChangedFileRegex = /(A|M|D|R\d*|C\d*)\t([^\t\n]*)\t?(.*)?/gm;
 const RevertHashRE = /This reverts commit (?<hash>[\da-f]{40})./gm;
 


### PR DESCRIPTION
## Current Behavior

`nx release changelog` extracts issue references from the commit body with a bare `/(#\d+)/gm` regex, so **every** `#number` in a squashed PR description becomes an issue link in the changelog — including other repos' issue numbers.

For example, the [23.1.0 release notes](https://github.com/nrwl/nx/releases/tag/23.1.0) contain:

> **rspack:** support @rspack/core@2 and @rsbuild/core@2 (multi-version compliance) (#35682, #35764, #13420, #781)

where `#13420` is actually `web-infra-dev/rspack#13420` and `#781` is `privatenumber/tsx#781` — upstream issues discussed in the PR description, rendered as (bogus) `nrwl/nx` issue links. The same release also picked up `nrwl/nx-console#3175`, `facebook/react#418`, and `web-infra-dev/rspack#2292`, plus noisy same-repo PR mentions that were merely referenced in prose.

## Expected Behavior

Issue references are only extracted from the commit body when linked via a GitHub closing keyword (`Fixes #123`, `Closes #123`, `Resolves: #123`, ...) — the same rule GitHub itself uses to auto-link and close issues. Cross-repo forms (`owner/repo#123`), markdown links to other repos, and casual same-repo mentions no longer produce changelog references.

Subject-line extraction (the PR number in `(#123)` and inline issue refs) is unchanged. Both regular commits and version plans go through the same `extractReferencesFromCommit` function, so this fixes both paths.

## Related Issue(s)

N/A

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Fix-nx-release-changelog-scraping-other-repos-issue-numbers-7967dd62)
<!-- polygraph-session-end -->