### PR TITLE
fix(core): use --config.frozen-lockfile=false for pnpm add during migrate

### DIFF
--- a/packages/nx/src/utils/package-json.spec.ts
+++ b/packages/nx/src/utils/package-json.spec.ts
@@ -88,7 +88,7 @@ describe('installPackageToTmp', () => {
       .spyOn(pacakgeManager, 'getPackageManagerVersion')
       .mockReturnValue('9.0.0');
     jest.spyOn(pacakgeManager, 'getPackageManagerCommand').mockReturnValue({
-      addDev: 'pnpm add -Dw --no-frozen-lockfile',
+      addDev: 'pnpm add -Dw --config.frozen-lockfile=false',
       ignoreScriptsFlag: '--ignore-scripts',
     } as any);
     const execSyncSpy = jest
@@ -99,7 +99,7 @@ describe('installPackageToTmp', () => {
 
     expect(execSyncSpy).toHaveBeenCalledTimes(1);
     expect(execSyncSpy.mock.calls[0][0]).toBe(
-      'pnpm add -Dw --no-frozen-lockfile nx@latest --config.auto-install-peers=false --ignore-scripts'
+      'pnpm add -Dw --config.frozen-lockfile=false nx@latest --config.auto-install-peers=false --ignore-scripts'
     );
 
     cleanup();
@@ -145,12 +145,12 @@ describe('installPackageToTmp', () => {
     // pnpm: peers are omitted by disabling auto-install
     execSyncSpy.mockClear();
     jest.spyOn(pacakgeManager, 'getPackageManagerCommand').mockReturnValue({
-      addDev: 'pnpm add -Dw --no-frozen-lockfile',
+      addDev: 'pnpm add -Dw --config.frozen-lockfile=false',
       ignoreScriptsFlag: '--ignore-scripts',
     } as any);
     installPackageToTmp('@nx/cypress', '1.0.0', 'pnpm');
     expect(execSyncSpy.mock.calls[0][0]).toBe(
-      'pnpm add -Dw --no-frozen-lockfile @nx/cypress@1.0.0 --config.auto-install-peers=false --ignore-scripts'
+      'pnpm add -Dw --config.frozen-lockfile=false @nx/cypress@1.0.0 --config.auto-install-peers=false --ignore-scripts'
     );
 
     // yarn: Berry does not auto-install peers, so no flag is added

--- a/packages/nx/src/utils/package-json.spec.ts
+++ b/packages/nx/src/utils/package-json.spec.ts
@@ -88,7 +88,7 @@ describe('installPackageToTmp', () => {
       .spyOn(pacakgeManager, 'getPackageManagerVersion')
       .mockReturnValue('9.0.0');
     jest.spyOn(pacakgeManager, 'getPackageManagerCommand').mockReturnValue({
-      addDev: 'pnpm add -Dw',
+      addDev: 'pnpm add -Dw --no-frozen-lockfile',
       ignoreScriptsFlag: '--ignore-scripts',
     } as any);
     const execSyncSpy = jest
@@ -99,7 +99,7 @@ describe('installPackageToTmp', () => {
 
     expect(execSyncSpy).toHaveBeenCalledTimes(1);
     expect(execSyncSpy.mock.calls[0][0]).toBe(
-      'pnpm add -Dw nx@latest --config.auto-install-peers=false --ignore-scripts'
+      'pnpm add -Dw --no-frozen-lockfile nx@latest --config.auto-install-peers=false --ignore-scripts'
     );
 
     cleanup();
@@ -145,12 +145,12 @@ describe('installPackageToTmp', () => {
     // pnpm: peers are omitted by disabling auto-install
     execSyncSpy.mockClear();
     jest.spyOn(pacakgeManager, 'getPackageManagerCommand').mockReturnValue({
-      addDev: 'pnpm add -Dw',
+      addDev: 'pnpm add -Dw --no-frozen-lockfile',
       ignoreScriptsFlag: '--ignore-scripts',
     } as any);
     installPackageToTmp('@nx/cypress', '1.0.0', 'pnpm');
     expect(execSyncSpy.mock.calls[0][0]).toBe(
-      'pnpm add -Dw @nx/cypress@1.0.0 --config.auto-install-peers=false --ignore-scripts'
+      'pnpm add -Dw --no-frozen-lockfile @nx/cypress@1.0.0 --config.auto-install-peers=false --ignore-scripts'
     );
 
     // yarn: Berry does not auto-install peers, so no flag is added

--- a/packages/nx/src/utils/package-manager.spec.ts
+++ b/packages/nx/src/utils/package-manager.spec.ts
@@ -789,7 +789,7 @@ describe('package-manager', () => {
       );
     });
 
-    it('should return pnpm add commands with --no-frozen-lockfile in a workspace', () => {
+    it('should return pnpm add commands with --config.frozen-lockfile=false in a workspace', () => {
       jest.spyOn(childProcess, 'execSync').mockImplementation((p) => {
         if (p === 'pnpm --version') {
           return '9.15.7';
@@ -800,11 +800,15 @@ describe('package-manager', () => {
         path.endsWith('pnpm-workspace.yaml')
       );
       const commands = getPackageManagerCommand('pnpm');
-      expect(commands.add).toEqual('pnpm add -w --no-frozen-lockfile');
-      expect(commands.addDev).toEqual('pnpm add -Dw --no-frozen-lockfile');
+      expect(commands.add).toEqual(
+        'pnpm add -w --config.frozen-lockfile=false'
+      );
+      expect(commands.addDev).toEqual(
+        'pnpm add -Dw --config.frozen-lockfile=false'
+      );
     });
 
-    it('should return pnpm add commands with --no-frozen-lockfile outside a workspace', () => {
+    it('should return pnpm add commands with --config.frozen-lockfile=false outside a workspace', () => {
       jest.spyOn(childProcess, 'execSync').mockImplementation((p) => {
         if (p === 'pnpm --version') {
           return '9.15.7';
@@ -813,8 +817,10 @@ describe('package-manager', () => {
       });
       (existsSync as jest.Mock).mockReturnValue(false);
       const commands = getPackageManagerCommand('pnpm');
-      expect(commands.add).toEqual('pnpm add --no-frozen-lockfile');
-      expect(commands.addDev).toEqual('pnpm add -D --no-frozen-lockfile');
+      expect(commands.add).toEqual('pnpm add --config.frozen-lockfile=false');
+      expect(commands.addDev).toEqual(
+        'pnpm add -D --config.frozen-lockfile=false'
+      );
     });
   });
 

--- a/packages/nx/src/utils/package-manager.spec.ts
+++ b/packages/nx/src/utils/package-manager.spec.ts
@@ -788,6 +788,34 @@ describe('package-manager', () => {
         'bun publish --cwd="dist/packages/my-pkg" --json --registry="https://registry.npmjs.org/" --tag=latest'
       );
     });
+
+    it('should return pnpm add commands with --no-frozen-lockfile in a workspace', () => {
+      jest.spyOn(childProcess, 'execSync').mockImplementation((p) => {
+        if (p === 'pnpm --version') {
+          return '9.15.7';
+        }
+        throw new Error(`Unexpected command: ${p}`);
+      });
+      (existsSync as jest.Mock).mockImplementation((path: string) =>
+        path.endsWith('pnpm-workspace.yaml')
+      );
+      const commands = getPackageManagerCommand('pnpm');
+      expect(commands.add).toEqual('pnpm add -w --no-frozen-lockfile');
+      expect(commands.addDev).toEqual('pnpm add -Dw --no-frozen-lockfile');
+    });
+
+    it('should return pnpm add commands with --no-frozen-lockfile outside a workspace', () => {
+      jest.spyOn(childProcess, 'execSync').mockImplementation((p) => {
+        if (p === 'pnpm --version') {
+          return '9.15.7';
+        }
+        throw new Error(`Unexpected command: ${p}`);
+      });
+      (existsSync as jest.Mock).mockReturnValue(false);
+      const commands = getPackageManagerCommand('pnpm');
+      expect(commands.add).toEqual('pnpm add --no-frozen-lockfile');
+      expect(commands.addDev).toEqual('pnpm add -D --no-frozen-lockfile');
+    });
   });
 
   describe('packageRegistryView', () => {

--- a/packages/nx/src/utils/package-manager.ts
+++ b/packages/nx/src/utils/package-manager.ts
@@ -207,8 +207,12 @@ export function getPackageManagerCommand(
         install: 'pnpm install --no-frozen-lockfile', // explicitly disable in case of CI
         ciInstall: 'pnpm install --frozen-lockfile',
         updateLockFile: 'pnpm install --lockfile-only',
-        add: isPnpmWorkspace ? 'pnpm add -w' : 'pnpm add',
-        addDev: isPnpmWorkspace ? 'pnpm add -Dw' : 'pnpm add -D',
+        add: isPnpmWorkspace
+          ? 'pnpm add -w --no-frozen-lockfile'
+          : 'pnpm add --no-frozen-lockfile',
+        addDev: isPnpmWorkspace
+          ? 'pnpm add -Dw --no-frozen-lockfile'
+          : 'pnpm add -D --no-frozen-lockfile',
         rm: 'pnpm rm',
         exec: modernPnpm ? 'pnpm exec' : 'pnpx',
         dlx: modernPnpm ? 'pnpm dlx' : 'pnpx',

--- a/packages/nx/src/utils/package-manager.ts
+++ b/packages/nx/src/utils/package-manager.ts
@@ -208,11 +208,11 @@ export function getPackageManagerCommand(
         ciInstall: 'pnpm install --frozen-lockfile',
         updateLockFile: 'pnpm install --lockfile-only',
         add: isPnpmWorkspace
-          ? 'pnpm add -w --no-frozen-lockfile'
-          : 'pnpm add --no-frozen-lockfile',
+          ? 'pnpm add -w --config.frozen-lockfile=false'
+          : 'pnpm add --config.frozen-lockfile=false',
         addDev: isPnpmWorkspace
-          ? 'pnpm add -Dw --no-frozen-lockfile'
-          : 'pnpm add -D --no-frozen-lockfile',
+          ? 'pnpm add -Dw --config.frozen-lockfile=false'
+          : 'pnpm add -D --config.frozen-lockfile=false',
         rm: 'pnpm rm',
         exec: modernPnpm ? 'pnpm exec' : 'pnpx',
         dlx: modernPnpm ? 'pnpm dlx' : 'pnpx',


### PR DESCRIPTION
## Current Behavior

When running `nx migrate` in a pnpm workspace with `frozenLockfile: true` in `pnpm-workspace.yaml`, migration metadata fetching can fail during the install fallback with:

```
Failed to fetch migrations for @angular/cli@22.0.6
Command failed: pnpm add -w @angular/cli@22.0.6
[ERR_PNPM_LOCKFILE_CONFIG_MISMATCH] Cannot proceed with the frozen installation.
```

Nx already passes `--no-frozen-lockfile` for pnpm `install` commands (including post-migration workspace installs), but **not** for `pnpm add` commands used when fetching migrations in temporary directories. Because `createTempNpmDirectory()` copies `pnpm-workspace.yaml` into the temp dir, `frozenLockfile: true` is inherited and blocks `pnpm add`.

## Expected Behavior

Nx-initiated `pnpm add` / `pnpm add -D` commands should include `--no-frozen-lockfile`, matching the existing pnpm `install` behavior. This allows `nx migrate` to fetch package migrations in workspaces that enforce frozen lockfiles for developer consistency.

## Related Issue(s)

No existing upstream issue was found for this specific migrate + `frozenLockfile` failure.

## Changes

- Add `--no-frozen-lockfile` to pnpm `add` and `addDev` command templates in `getPackageManagerCommand()`
- Add regression tests for workspace and non-workspace pnpm add commands
- Update temp install test expectations in `package-json.spec.ts`

## Test plan

- [x] `jest packages/nx/src/utils/package-manager.spec.ts packages/nx/src/utils/package-json.spec.ts --config packages/nx/jest.config.cts --testNamePattern="getPackageManagerCommand|installPackageToTmp"` (10 tests passed)
