### PR TITLE
fix(core): report tasks running in another Nx process in the inline TUI

### DIFF
--- a/packages/nx/src/native/tui/app.rs
+++ b/packages/nx/src/native/tui/app.rs
@@ -984,7 +984,7 @@ impl App {
                 if matches!(key.code, KeyCode::F(11))
                     && !matches!(self.focus(), Focus::CountdownPopup)
                 {
-                    self.dispatch_action(Action::SwitchMode(TuiMode::Inline));
+                    self.request_inline_mode();
                     return Ok(false);
                 }
 
@@ -1116,7 +1116,7 @@ impl App {
                                 countdown_popup.cancel_countdown();
                                 self.core.state().lock().cancel_quit();
                                 self.close_popup(Focus::CountdownPopup);
-                                self.dispatch_action(Action::SwitchMode(TuiMode::Inline));
+                                self.request_inline_mode();
                                 return Ok(false);
                             }
                             _ => {
@@ -1287,8 +1287,7 @@ impl App {
                                     // If focused on a specific terminal pane, and not interactive, enter should
                                     // swap to inline tui mode focusing that task
                                     KeyCode::Enter => {
-                                        // dispatch action to switch to inline mode with focused task
-                                        self.dispatch_action(Action::SwitchMode(TuiMode::Inline));
+                                        self.request_inline_mode();
                                     }
                                     _ => {
                                         // Forward other keys for interactivity, scrolling (j/k) etc
@@ -1882,6 +1881,34 @@ impl App {
     /// Dispatches an action to the action tx for other components to handle however they see fit
     fn dispatch_action(&self, action: Action) {
         self.core.dispatch_action(action);
+    }
+
+    /// Switch to inline mode showing the focused (or selected) item.
+    ///
+    /// Inline mode renders that one item's pty, so a task that another Nx
+    /// process is running has nothing to show there. Stay in full-screen, where
+    /// the pane at least explains what's happening, and say why.
+    fn request_inline_mode(&mut self) {
+        let item_id = self
+            .get_focused_pane_item()
+            .or_else(|| self.get_selected_item())
+            .map(|item| item.id().to_string());
+
+        if let Some(item_id) = item_id {
+            if self
+                .core
+                .state()
+                .lock()
+                .is_running_in_another_process(&item_id)
+            {
+                self.dispatch_action(Action::ShowHint(
+                    "This task is running in another Nx process".to_string(),
+                ));
+                return;
+            }
+        }
+
+        self.dispatch_action(Action::SwitchMode(TuiMode::Inline));
     }
 
     fn recalculate_layout_areas(&mut self) {
@@ -2492,7 +2519,7 @@ impl App {
                     return;
                 }
                 if is_double {
-                    self.dispatch_action(Action::SwitchMode(TuiMode::Inline));
+                    self.request_inline_mode();
                     return;
                 }
                 // Begin a text selection drag at the clicked cell (NXC-3946).
@@ -4439,6 +4466,63 @@ mod tests {
         let switched = std::iter::from_fn(|| rx.try_recv().ok())
             .any(|a| matches!(a, Action::SwitchMode(TuiMode::Inline)));
         assert!(switched, "two clicks on the same cell are a double-click");
+    }
+
+    /// Inline mode has nothing to render for a task another Nx process is
+    /// running (there is no pty here), so entering it is blocked with a hint.
+    #[test]
+    fn test_inline_mode_blocked_for_task_running_in_another_process() {
+        let mut app = create_test_app();
+        app.spacebar_mode = false;
+        app.pane_tasks[0] = Some(SelectionEntry::Task("app1:build".to_string()));
+        app.set_base_focus(Focus::MultipleOutput(0));
+        app.core
+            .state()
+            .lock()
+            .update_task_status("app1:build", TaskStatus::Shared);
+
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        app.register_action_handler(tx).unwrap();
+
+        app.request_inline_mode();
+
+        let actions: Vec<Action> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
+        assert!(
+            !actions
+                .iter()
+                .any(|a| matches!(a, Action::SwitchMode(TuiMode::Inline))),
+            "a task running in another Nx process must not open the inline view"
+        );
+        assert!(
+            actions.iter().any(|a| matches!(a, Action::ShowHint(_))),
+            "the user should be told why the inline view didn't open"
+        );
+    }
+
+    /// The guard is specific to tasks running elsewhere - a normal in-progress
+    /// task still drops into inline.
+    #[test]
+    fn test_inline_mode_allowed_for_local_task() {
+        let mut app = create_test_app();
+        app.spacebar_mode = false;
+        app.pane_tasks[0] = Some(SelectionEntry::Task("app1:build".to_string()));
+        app.set_base_focus(Focus::MultipleOutput(0));
+        app.core
+            .state()
+            .lock()
+            .update_task_status("app1:build", TaskStatus::InProgress);
+
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        app.register_action_handler(tx).unwrap();
+
+        app.request_inline_mode();
+
+        let switched = std::iter::from_fn(|| rx.try_recv().ok())
+            .any(|a| matches!(a, Action::SwitchMode(TuiMode::Inline)));
+        assert!(
+            switched,
+            "a locally running task should open the inline view"
+        );
     }
 
     #[test]

--- a/packages/nx/src/native/tui/inline_app.rs
+++ b/packages/nx/src/native/tui/inline_app.rs
@@ -1040,6 +1040,11 @@ impl InlineApp {
             .map(|s| s.id().to_string())
             .or_else(|| self.get_current_running_item());
 
+        // A task the user is watching can start out (or become) one that another
+        // Nx process is running - it will never get a pty here, so say so rather
+        // than sitting on "Waiting for tasks to start...".
+        let mut fallback_message = " Waiting for tasks to start... ";
+
         if let Some(ref current_task) = current_task {
             let state = self.core.state().lock();
             if let Some(pty) = state.get_pty_instance(current_task) {
@@ -1048,15 +1053,22 @@ impl InlineApp {
                 self.render_inline_task_output(f, area, &pty);
                 return;
             }
+            if state.is_running_in_another_process(current_task) {
+                fallback_message = " Running in another Nx process... ";
+            } else if matches!(
+                state.get_task_status(current_task),
+                Some(TaskStatus::InProgress)
+            ) {
+                fallback_message = " Waiting for task results... ";
+            }
         }
 
-        // Fallback: show a message indicating no task is running
         use crate::native::tui::theme::THEME;
         use ratatui::layout::Alignment;
         use ratatui::style::Style;
         use ratatui::widgets::{Block, Borders};
 
-        let message = NxParagraph::new(" Waiting for tasks to start... ")
+        let message = NxParagraph::new(fallback_message)
             .style(Style::default().fg(THEME.secondary_fg))
             .alignment(Alignment::Center)
             .block(Block::default().borders(Borders::NONE));
@@ -1822,5 +1834,43 @@ mod integration_tests {
             state2.get_task_status("shared:build"),
             Some(TaskStatus::Success)
         );
+    }
+
+    fn render_main_content(app: &mut InlineApp) -> String {
+        use ratatui::{Terminal, backend::TestBackend};
+
+        let mut terminal = Terminal::new(TestBackend::new(60, 3)).unwrap();
+        terminal
+            .draw(|f| {
+                let area = f.area();
+                app.render_inline_main_content(f, area);
+            })
+            .unwrap();
+
+        terminal
+            .backend()
+            .buffer()
+            .content
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect()
+    }
+
+    /// A task being watched inline can transition straight from pending to
+    /// running in another Nx process. It never gets a pty here, so the view has
+    /// to say that instead of waiting for output that will never arrive.
+    #[test]
+    fn test_inline_reports_task_running_in_another_process() {
+        let mut app = create_test_inline_app();
+        app.selected_item = Some(SelectionEntry::Task("app1:build".to_string()));
+
+        app.update_task_status("app1:build", TaskStatus::NotStarted);
+        assert!(render_main_content(&mut app).contains("Waiting for tasks to start"));
+
+        app.update_task_status("app1:build", TaskStatus::Shared);
+        assert!(render_main_content(&mut app).contains("Running in another Nx process"));
+
+        app.update_task_status("app1:build", TaskStatus::Stopped);
+        assert!(render_main_content(&mut app).contains("Running in another Nx process"));
     }
 }

--- a/packages/nx/src/native/tui/tui_state.rs
+++ b/packages/nx/src/native/tui/tui_state.rs
@@ -195,6 +195,17 @@ impl TuiState {
         &self.task_status_map
     }
 
+    /// Whether the task is being run by a different Nx process.
+    ///
+    /// Such a task has no pty here, so there is no output to stream and nothing
+    /// to interact with - all this process can do is wait for its results.
+    pub fn is_running_in_another_process(&self, task_id: &str) -> bool {
+        matches!(
+            self.get_task_status(task_id),
+            Some(TaskStatus::Shared | TaskStatus::Stopped)
+        ) && self.get_pty_instance(task_id).is_none()
+    }
+
     /// Get the task ID of the first currently running task (if any)
     ///
     /// This is useful for inline mode which shows output for the current running task.


### PR DESCRIPTION
## Current Behavior

When a task is being run by a *different* Nx process, no pty is registered for it in this process — there is no output to stream and nothing to interact with.

The full-screen terminal pane handles this: it renders **"Running in another Nx process..."**. The inline TUI does not. It falls back to **"Waiting for tasks to start..."** for *any* missing pty, so:

- Entering inline mode on such a task drops you into a view that can never render output, with a message implying output is on its way.
- If you are already in the inline view when a task transitions from pending (dependency view) into running-elsewhere, the inline view silently stays on "Waiting for tasks to start..." forever.

## Expected Behavior

- **Entering inline mode is blocked** for a task that another Nx process is running. All four entry points (F11, <kbd>Enter</kbd> on a focused pane, double-click on a pane, and <kbd>Enter</kbd>/F11 from the run report) now show a hint — *"This task is running in another Nx process"* — and stay in full-screen, where the pane explains what is happening.
- **The inline view reports the real state** when it is already open: a task running elsewhere renders "Running in another Nx process...", and an in-progress task with no pty renders "Waiting for task results...", matching the full-screen pane's wording.

### Implementation notes

- `TuiState::is_running_in_another_process(task_id)` — new shared predicate (status is `Shared`/`Stopped` **and** no local pty). This is the exact condition `terminal_pane.rs` already used inline; lifting it means both TUIs agree on one definition instead of the inline app guessing from a missing pty.
- `App::request_inline_mode()` — a single funnel for every path into inline mode, so the guard applies uniformly (and any future entry point inherits it).
- `InlineApp::render_inline_main_content` — the no-pty fallback now asks *why* the pty is missing instead of always assuming the task has not started yet.

### Tests

Three new Rust tests: the blocked switch, the still-allowed switch for a normal local in-progress task, and the inline render across the `NotStarted → Shared → Stopped` transition (rendered via `TestBackend` and asserted on the output). All 277 TUI tests pass; `cargo fmt --check` is clean.

## Related Issue(s)

N/A — reported directly.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Fix-inline-TUI-Waiting-for-tasks-state-for-multi-process-scenarios-7a1fd4ea)
<!-- polygraph-session-end -->