### PR TITLE
fix(core): report tasks running in another Nx process in the inline TUI

### DIFF
--- a/packages/nx/src/native/tui/app.rs
+++ b/packages/nx/src/native/tui/app.rs
@@ -991,7 +991,7 @@ impl App {
                 if matches!(key.code, KeyCode::F(11))
                     && !matches!(self.focus(), Focus::CountdownPopup)
                 {
-                    self.dispatch_action(Action::SwitchMode(TuiMode::Inline));
+                    self.request_inline_mode();
                     return Ok(false);
                 }
 
@@ -1123,7 +1123,7 @@ impl App {
                                 countdown_popup.cancel_countdown();
                                 self.core.state().lock().cancel_quit();
                                 self.close_popup(Focus::CountdownPopup);
-                                self.dispatch_action(Action::SwitchMode(TuiMode::Inline));
+                                self.request_inline_mode();
                                 return Ok(false);
                             }
                             _ => {
@@ -1303,8 +1303,7 @@ impl App {
                                     // If focused on a specific terminal pane, and not interactive, enter should
                                     // swap to inline tui mode focusing that task
                                     KeyCode::Enter => {
-                                        // dispatch action to switch to inline mode with focused task
-                                        self.dispatch_action(Action::SwitchMode(TuiMode::Inline));
+                                        self.request_inline_mode();
                                     }
                                     _ => {
                                         // Forward other keys for interactivity, scrolling (j/k) etc
@@ -1979,6 +1978,33 @@ impl App {
         props
     }
 
+    /// Switch to inline mode showing the focused (or selected) item.
+    ///
+    /// Inline mode renders that one item's pty, so a task that another Nx
+    /// process is running has nothing to show there. Stay in full-screen, where
+    /// the pane at least explains what's happening, and say why.
+    fn request_inline_mode(&mut self) {
+        let item_id = self
+            .get_focused_pane_item()
+            .or_else(|| self.get_selected_item())
+            .map(|item| item.id().to_string());
+
+        if let Some(item_id) = item_id
+            && self
+                .core
+                .state()
+                .lock()
+                .is_running_in_another_process(&item_id)
+        {
+            self.dispatch_action(Action::ShowHint(
+                "This task is running in another Nx process".to_string(),
+            ));
+            return;
+        }
+
+        self.dispatch_action(Action::SwitchMode(TuiMode::Inline));
+    }
+
     fn recalculate_layout_areas(&mut self) {
         if let Some(frame_area) = self.frame_area {
             // Only a free-text cloud message can need a second bar row; a
@@ -2598,7 +2624,7 @@ impl App {
                     return;
                 }
                 if is_double {
-                    self.dispatch_action(Action::SwitchMode(TuiMode::Inline));
+                    self.request_inline_mode();
                     return;
                 }
                 // Begin a text selection drag at the clicked cell (NXC-3946).
@@ -4603,6 +4629,63 @@ mod tests {
         let switched = std::iter::from_fn(|| rx.try_recv().ok())
             .any(|a| matches!(a, Action::SwitchMode(TuiMode::Inline)));
         assert!(switched, "two clicks on the same cell are a double-click");
+    }
+
+    /// Inline mode has nothing to render for a task another Nx process is
+    /// running (there is no pty here), so entering it is blocked with a hint.
+    #[test]
+    fn test_inline_mode_blocked_for_task_running_in_another_process() {
+        let mut app = create_test_app();
+        app.spacebar_mode = false;
+        app.pane_tasks[0] = Some(SelectionEntry::Task("app1:build".to_string()));
+        app.set_base_focus(Focus::MultipleOutput(0));
+        app.core
+            .state()
+            .lock()
+            .update_task_status("app1:build", TaskStatus::Shared);
+
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        app.register_action_handler(tx).unwrap();
+
+        app.request_inline_mode();
+
+        let actions: Vec<Action> = std::iter::from_fn(|| rx.try_recv().ok()).collect();
+        assert!(
+            !actions
+                .iter()
+                .any(|a| matches!(a, Action::SwitchMode(TuiMode::Inline))),
+            "a task running in another Nx process must not open the inline view"
+        );
+        assert!(
+            actions.iter().any(|a| matches!(a, Action::ShowHint(_))),
+            "the user should be told why the inline view didn't open"
+        );
+    }
+
+    /// The guard is specific to tasks running elsewhere - a normal in-progress
+    /// task still drops into inline.
+    #[test]
+    fn test_inline_mode_allowed_for_local_task() {
+        let mut app = create_test_app();
+        app.spacebar_mode = false;
+        app.pane_tasks[0] = Some(SelectionEntry::Task("app1:build".to_string()));
+        app.set_base_focus(Focus::MultipleOutput(0));
+        app.core
+            .state()
+            .lock()
+            .update_task_status("app1:build", TaskStatus::InProgress);
+
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        app.register_action_handler(tx).unwrap();
+
+        app.request_inline_mode();
+
+        let switched = std::iter::from_fn(|| rx.try_recv().ok())
+            .any(|a| matches!(a, Action::SwitchMode(TuiMode::Inline)));
+        assert!(
+            switched,
+            "a locally running task should open the inline view"
+        );
     }
 
     #[test]

--- a/packages/nx/src/native/tui/inline_app.rs
+++ b/packages/nx/src/native/tui/inline_app.rs
@@ -1040,6 +1040,11 @@ impl InlineApp {
             .map(|s| s.id().to_string())
             .or_else(|| self.get_current_running_item());
 
+        // A task the user is watching can start out (or become) one that another
+        // Nx process is running - it will never get a pty here, so say so rather
+        // than sitting on "Waiting for tasks to start...".
+        let mut fallback_message = " Waiting for tasks to start... ";
+
         if let Some(ref current_task) = current_task {
             let state = self.core.state().lock();
             if let Some(pty) = state.get_pty_instance(current_task) {
@@ -1048,15 +1053,22 @@ impl InlineApp {
                 self.render_inline_task_output(f, area, &pty);
                 return;
             }
+            if state.is_running_in_another_process(current_task) {
+                fallback_message = " Running in another Nx process... ";
+            } else if matches!(
+                state.get_task_status(current_task),
+                Some(TaskStatus::InProgress)
+            ) {
+                fallback_message = " Waiting for task results... ";
+            }
         }
 
-        // Fallback: show a message indicating no task is running
         use crate::native::tui::theme::THEME;
         use ratatui::layout::Alignment;
         use ratatui::style::Style;
         use ratatui::widgets::{Block, Borders};
 
-        let message = NxParagraph::new(" Waiting for tasks to start... ")
+        let message = NxParagraph::new(fallback_message)
             .style(Style::default().fg(THEME.secondary_fg))
             .alignment(Alignment::Center)
             .block(Block::default().borders(Borders::NONE));
@@ -1822,5 +1834,43 @@ mod integration_tests {
             state2.get_task_status("shared:build"),
             Some(TaskStatus::Success)
         );
+    }
+
+    fn render_main_content(app: &mut InlineApp) -> String {
+        use ratatui::{Terminal, backend::TestBackend};
+
+        let mut terminal = Terminal::new(TestBackend::new(60, 3)).unwrap();
+        terminal
+            .draw(|f| {
+                let area = f.area();
+                app.render_inline_main_content(f, area);
+            })
+            .unwrap();
+
+        terminal
+            .backend()
+            .buffer()
+            .content
+            .iter()
+            .map(|cell| cell.symbol())
+            .collect()
+    }
+
+    /// A task being watched inline can transition straight from pending to
+    /// running in another Nx process. It never gets a pty here, so the view has
+    /// to say that instead of waiting for output that will never arrive.
+    #[test]
+    fn test_inline_reports_task_running_in_another_process() {
+        let mut app = create_test_inline_app();
+        app.selected_item = Some(SelectionEntry::Task("app1:build".to_string()));
+
+        app.update_task_status("app1:build", TaskStatus::NotStarted);
+        assert!(render_main_content(&mut app).contains("Waiting for tasks to start"));
+
+        app.update_task_status("app1:build", TaskStatus::Shared);
+        assert!(render_main_content(&mut app).contains("Running in another Nx process"));
+
+        app.update_task_status("app1:build", TaskStatus::Stopped);
+        assert!(render_main_content(&mut app).contains("Running in another Nx process"));
     }
 }

--- a/packages/nx/src/native/tui/tui_state.rs
+++ b/packages/nx/src/native/tui/tui_state.rs
@@ -201,6 +201,18 @@ impl TuiState {
         &self.task_status_map
     }
 
+    /// Whether the task is `Shared` or `Stopped` with no local pty.
+    ///
+    /// Either way this process has no pty to stream or interact with, so all it
+    /// can do is wait for the task's results. The pty check is what separates a
+    /// task stopped elsewhere from one stopped locally, which does have a pty.
+    pub fn is_running_in_another_process(&self, task_id: &str) -> bool {
+        matches!(
+            self.get_task_status(task_id),
+            Some(TaskStatus::Shared | TaskStatus::Stopped)
+        ) && self.get_pty_instance(task_id).is_none()
+    }
+
     /// Get the task ID of the first currently running task (if any)
     ///
     /// This is useful for inline mode which shows output for the current running task.


### PR DESCRIPTION
## Current Behavior

When a task is being run by a *different* Nx process, this process never gets a pty for it — there is no output to stream and nothing to interact with.

The full-screen terminal pane already handles this: it renders `Running in another Nx process...` for a task whose status is `Shared`/`Stopped` with no pty.

The inline TUI does not. It falls back to `Waiting for tasks to start...` for *any* missing pty, without asking why the pty is missing, so:

- A task running in another Nx process shows `Waiting for tasks to start...` indefinitely — output that will never arrive.
- The user can still enter inline mode for such a task (F11, Enter on a focused pane, double-click a pane, Enter/F11 from the run report), landing in a view that can never render anything.
- A task already displayed inline that transitions from pending (dependency view) to running-elsewhere keeps showing the same misleading message.

## Expected Behavior

The two views agree, and inline mode is never a dead end:

- **Entering inline mode is blocked** for a task another Nx process is running. A hint (`This task is running in another Nx process`) is shown instead of switching, so the user stays in full-screen where the pane explains what is happening. All four entry points route through a single `App::request_inline_mode`.
- **The inline no-pty fallback is status-aware.** A task that is (or becomes) running-elsewhere renders `Running in another Nx process...`, covering the case where the user was *already* in the inline TUI when the task transitioned. An in-progress task with no pty renders `Waiting for task results...`, matching the full-screen pane's wording.
- A new `TuiState::is_running_in_another_process` (status is `Shared`/`Stopped` **and** no local pty) gives the inline app a single named definition of "running elsewhere" that matches what the full-screen pane checks. The pane still reads its own `TerminalPaneState` copies rather than calling the helper (it works off flattened props, not `TuiState`), so the two agree today but are not yet structurally coupled — unifying the pane on the helper is a reasonable follow-up.

Note: the guard applies to a task selected in the task list as well as one pinned to a focused pane — inline always renders exactly one item, and that item would have nothing to show.

Known limitation (inherited, follow-up): because `Shared` and `Stopped` are lumped together, a *shared* continuous task that has finished (goes `Stopped`, never had a local pty) keeps rendering `Running in another Nx process...`. The full-screen pane already behaves this way, so this change inherits rather than introduces it.

### Tests

- `test_inline_mode_blocked_for_task_running_in_another_process` — a shared task shows a hint and does not switch.
- `test_inline_mode_allowed_for_local_task` — a locally running task still drops into inline.
- `test_inline_reports_task_running_in_another_process` — renders the inline view across the `NotStarted → Shared → Stopped` transition.

All 320 TUI tests pass; `cargo fmt --check` and `cargo clippy` are clean. End-to-end validation against a real second Nx process holding a shared task has not been done — behavior is covered by unit tests.

## Related Issue(s)

Relates to [NXC-4597](https://linear.app/nxdev/issue/NXC-4597/error-insert-before-failed-when-swapping-to-inline-mode)

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Fix-inline-TUI-Waiting-for-tasks-state-for-multi-process-scenarios-7a1fd4ea)
<!-- polygraph-session-end -->
