### PR TITLE
fix(misc): render agent skills against the workspace they are generated into

### DIFF
--- a/packages/nx/src/ai/constants.ts
+++ b/packages/nx/src/ai/constants.ts
@@ -1,6 +1,7 @@
 import { join } from 'path';
 import { major } from 'semver';
 import { readJsonFile } from '../utils/fileutils';
+import type { PackageManager } from '../utils/package-manager';
 import {
   getAgentRules,
   AgentRulesOptions,
@@ -56,11 +57,16 @@ export const rulesRegex = new RegExp(
 export interface AgentRulesWrappedOptions {
   writeNxCloudRules: boolean;
   useH1?: boolean;
+  packageManager?: PackageManager;
 }
 
 export const getAgentRulesWrapped = (options: AgentRulesWrappedOptions) => {
-  const { writeNxCloudRules, useH1 = true } = options;
-  const agentRulesString = getAgentRules({ nxCloud: writeNxCloudRules, useH1 });
+  const { writeNxCloudRules, useH1 = true, packageManager } = options;
+  const agentRulesString = getAgentRules({
+    nxCloud: writeNxCloudRules,
+    useH1,
+    packageManager,
+  });
   return `${nxRulesMarkerCommentStart}\n${nxRulesMarkerCommentDescription}\n\n${agentRulesString}\n\n${nxRulesMarkerCommentEnd}`;
 };
 

--- a/packages/nx/src/ai/set-up-ai-agents/get-agent-rules.spec.ts
+++ b/packages/nx/src/ai/set-up-ai-agents/get-agent-rules.spec.ts
@@ -1,0 +1,35 @@
+import { getAgentRules } from './get-agent-rules';
+
+describe('getAgentRules', () => {
+  // Claude installs its skills from the plugin marketplace rather than through
+  // generateFiles, so those files never see the workspace render. The rules block below is
+  // the only place nx can tell Claude how to invoke nx in *this* workspace — which makes
+  // it the load-bearing half of the fix for Claude specifically.
+  it.each([
+    ['npm', 'npm exec nx'],
+    ['yarn', 'yarn nx'],
+    ['pnpm', 'pnpm nx'],
+    ['bun', 'bunx nx'],
+  ] as const)('tells the agent to run nx as `%s` -> `%s`', (pm, invocation) => {
+    const rules = getAgentRules({ nxCloud: false, packageManager: pm });
+
+    expect(rules).toContain(`Run nx as \`${invocation}\``);
+    expect(rules).toContain(`This workspace uses ${pm}.`);
+    // It should state the answer, not send the agent off to find it.
+    expect(rules).not.toContain(
+      "Prefix nx commands with the workspace's package manager"
+    );
+  });
+
+  it('never leaves a non-pnpm workspace looking at a pnpm example', () => {
+    const rules = getAgentRules({ nxCloud: false, packageManager: 'yarn' });
+    expect(rules).not.toContain('pnpm');
+  });
+
+  it('falls back to describing how to find the package manager when it is unknown', () => {
+    const rules = getAgentRules({ nxCloud: false });
+    expect(rules).toContain(
+      "Prefix nx commands with the workspace's package manager"
+    );
+  });
+});

--- a/packages/nx/src/ai/set-up-ai-agents/get-agent-rules.ts
+++ b/packages/nx/src/ai/set-up-ai-agents/get-agent-rules.ts
@@ -1,16 +1,36 @@
+import type { PackageManager } from '../../utils/package-manager';
+import { getWorkspaceContext } from './workspace-context';
+
 export interface AgentRulesOptions {
   nxCloud: boolean;
   useH1?: boolean;
+  packageManager?: PackageManager;
+}
+
+/**
+ * Claude's skills are installed from the plugin marketplace rather than copied through
+ * `generateFiles`, so unlike every other agent they never pass through the workspace
+ * render. This line is the one place nx can still state the package manager to Claude
+ * directly, which is why it is worth stating rather than describing.
+ */
+function getNxInvocationRule(
+  packageManager: PackageManager | undefined
+): string {
+  const { pm } = getWorkspaceContext(packageManager, '');
+  if (!pm) {
+    return `- Prefix nx commands with the workspace's package manager (e.g., \`pnpm nx build\`, \`npm exec nx test\`) - avoids using globally installed CLI`;
+  }
+  return `- This workspace uses ${pm.name}. Run nx as \`${pm.nx}\` (e.g. \`${pm.nx} build\`) - avoids using globally installed CLI`;
 }
 
 export function getAgentRules(options: AgentRulesOptions) {
-  const { nxCloud, useH1 = true } = options;
+  const { nxCloud, useH1 = true, packageManager } = options;
   const header = useH1 ? '#' : '##';
   return `${header} General Guidelines for working with Nx
 
 - For navigating/exploring the workspace, invoke the \`nx-workspace\` skill first - it has patterns for querying projects, targets, and dependencies
 - When running tasks (for example build, lint, test, e2e, etc.), always prefer running the task through \`nx\` (i.e. \`nx run\`, \`nx run-many\`, \`nx affected\`) instead of using the underlying tooling directly
-- Prefix nx commands with the workspace's package manager (e.g., \`pnpm nx build\`, \`npm exec nx test\`) - avoids using globally installed CLI
+${getNxInvocationRule(packageManager)}
 - You have access to the Nx MCP server and its tools, use them to help the user
 - For Nx plugin best practices, check \`node_modules/@nx/<plugin>/PLUGIN.md\`. Not all plugins have this file - proceed without it if unavailable.
 - NEVER guess CLI flags - always check nx_docs or \`--help\` first when unsure

--- a/packages/nx/src/ai/set-up-ai-agents/schema.d.ts
+++ b/packages/nx/src/ai/set-up-ai-agents/schema.d.ts
@@ -1,3 +1,4 @@
+import type { PackageManager } from '../../utils/package-manager';
 import type { Agent } from '../utils';
 
 export type SetupAiAgentsGeneratorSchema = {
@@ -5,7 +6,21 @@ export type SetupAiAgentsGeneratorSchema = {
   writeNxCloudRules?: boolean;
   packageVersion?: string;
   agents?: Agent[];
+  /**
+   * Used to render the skill templates, so they can state which package manager the
+   * workspace uses instead of telling the agent to go read the lockfile.
+   *
+   * Passed in rather than detected because during `create-nx-workspace` the lockfile does
+   * not exist yet — sniffing the filesystem there falls through to whichever package
+   * manager happened to invoke the CLI, which is not necessarily the one being set up.
+   * When absent, templates render their "determine it yourself" fallback.
+   */
+  packageManager?: PackageManager;
 };
 
-export type NormalizedSetupAiAgentsGeneratorSchema =
-  Required<SetupAiAgentsGeneratorSchema>;
+// `packageManager` stays optional: it is genuinely unknown in some flows, and the skill
+// templates are written to handle that rather than to be handed a guess.
+export type NormalizedSetupAiAgentsGeneratorSchema = Required<
+  Omit<SetupAiAgentsGeneratorSchema, 'packageManager'>
+> &
+  Pick<SetupAiAgentsGeneratorSchema, 'packageManager'>;

--- a/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.spec.ts
+++ b/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.spec.ts
@@ -1157,12 +1157,17 @@ description = "Polls Nx Cloud CI pipeline."
 config_file = ".codex/agents/ci-monitor-subagent.toml"
 `;
 
+      // Captured once, at module scope. Taking this inside beforeEach re-reads
+      // fs.existsSync *after* the previous test already spied on it — and jest.spyOn
+      // hands back the same mock for an already-spied method, so `originalExistsSync`
+      // becomes the mock itself and its fallthrough recurses until the stack blows.
+      const originalExistsSync = fs.existsSync;
+
       beforeEach(() => {
         getAiConfigRepoPathSpy = jest
           .spyOn(cloneModule, 'getAiConfigRepoPath')
           .mockReturnValue('/fake/repo');
 
-        const originalExistsSync = fs.existsSync;
         existsSyncSpy = jest
           .spyOn(fs, 'existsSync')
           .mockImplementation((path: any) => {
@@ -1183,6 +1188,14 @@ config_file = ".codex/agents/ci-monitor-subagent.toml"
               path.includes('/fake/repo/generated/')
             ) {
               return false; // No other generated dirs
+            }
+            if (
+              typeof path === 'string' &&
+              path.includes('/fake/repo/templates')
+            ) {
+              // This fake config repo predates the workspace-context templates, so the
+              // generator should fall back to copying `generated/` as-is.
+              return false;
             }
             return originalExistsSync(path);
           });

--- a/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.ts
+++ b/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.ts
@@ -43,6 +43,11 @@ import {
   SetupAiAgentsGeneratorSchema,
 } from './schema';
 import { handleImport } from '../../utils/handle-import';
+import {
+  getWorkspaceContext,
+  TEMPLATES_SCHEMA_VERSION,
+} from './workspace-context';
+import type { PackageManager } from '../../utils/package-manager';
 
 export type ModificationResults = {
   messages: CLINoteMessageConfig[];
@@ -122,6 +127,7 @@ function normalizeOptions(
     writeNxCloudRules: options.writeNxCloudRules ?? false,
     packageVersion: options.packageVersion ?? 'latest',
     agents: options.agents ?? [...supportedAgents],
+    packageManager: options.packageManager,
   };
 }
 
@@ -141,12 +147,22 @@ export async function setupAiAgentsGeneratorImpl(
     hasAgent('codex') ||
     hasAgent('opencode')
   ) {
-    writeAgentRules(tree, agentsMd, options.writeNxCloudRules);
+    writeAgentRules(
+      tree,
+      agentsMd,
+      options.writeNxCloudRules,
+      options.packageManager
+    );
   }
 
   if (hasAgent('claude')) {
     const claudePath = join(options.directory, 'CLAUDE.md');
-    writeAgentRules(tree, claudePath, options.writeNxCloudRules);
+    writeAgentRules(
+      tree,
+      claudePath,
+      options.writeNxCloudRules,
+      options.packageManager
+    );
 
     // Configure Claude plugin via marketplace (plugin includes MCP server)
     const claudeSettingsPath = join(
@@ -265,7 +281,12 @@ export async function setupAiAgentsGeneratorImpl(
 
     // Only set contextFileName to AGENTS.md if GEMINI.md doesn't exist already to preserve existing setups
     if (!contextFileName && !tree.exists(geminiMd)) {
-      writeAgentRules(tree, agentsMd, options.writeNxCloudRules);
+      writeAgentRules(
+        tree,
+        agentsMd,
+        options.writeNxCloudRules,
+        options.packageManager
+      );
       updateJson(tree, geminiSettingsPath, (json) => ({
         ...json,
         contextFileName: 'AGENTS.md',
@@ -274,7 +295,8 @@ export async function setupAiAgentsGeneratorImpl(
       writeAgentRules(
         tree,
         contextFileName ?? geminiMd,
-        options.writeNxCloudRules
+        options.writeNxCloudRules,
+        options.packageManager
       );
     }
   }
@@ -283,37 +305,55 @@ export async function setupAiAgentsGeneratorImpl(
   if (aiConfigRepoPath) {
     const repoPath = aiConfigRepoPath;
 
+    // The skills come in two flavours. `templates/<version>` still carries the workspace
+    // facts as tokens, so we can tell the agent that this workspace uses yarn rather than
+    // making it go read the lockfile. `generated/` has those tokens already resolved
+    // against an empty context, and is what we fall back to when the config repo predates
+    // the schema we know how to populate.
+    const workspaceContext = getWorkspaceContext(
+      options.packageManager,
+      join(tree.root, options.directory)
+    );
+    const templatesRoot = join(repoPath, 'templates', TEMPLATES_SCHEMA_VERSION);
+    const skillsRoot = existsSync(templatesRoot) ? templatesRoot : repoPath;
+    const skillsSubdir = skillsRoot === templatesRoot ? '' : 'generated';
+
     // Shared skills directory used by codex, cursor, and gemini
     if (hasAgent('codex') || hasAgent('cursor') || hasAgent('gemini')) {
-      const sharedSkillsSrc = join(repoPath, 'generated/.agents');
+      const sharedSkillsSrc = join(skillsRoot, skillsSubdir, '.agents');
       if (existsSync(sharedSkillsSrc)) {
         generateFiles(
           tree,
           sharedSkillsSrc,
           join(options.directory, '.agents'),
-          {}
+          workspaceContext
         );
       }
     }
 
     // Agent-specific directories (commands, agents, config)
     const agentDirs: { agent: Agent; src: string; dest: string }[] = [
-      { agent: 'opencode', src: 'generated/.opencode', dest: '.opencode' },
-      { agent: 'copilot', src: 'generated/.github', dest: '.github' },
-      { agent: 'cursor', src: 'generated/.cursor', dest: '.cursor' },
+      { agent: 'opencode', src: '.opencode', dest: '.opencode' },
+      { agent: 'copilot', src: '.github', dest: '.github' },
+      { agent: 'cursor', src: '.cursor', dest: '.cursor' },
       {
         agent: 'codex',
-        src: 'generated/.codex/agents',
+        src: '.codex/agents',
         dest: '.codex/agents',
       },
-      { agent: 'gemini', src: 'generated/.gemini', dest: '.gemini' },
+      { agent: 'gemini', src: '.gemini', dest: '.gemini' },
     ];
 
     for (const { agent, src, dest } of agentDirs) {
       if (hasAgent(agent)) {
-        const srcPath = join(repoPath, src);
+        const srcPath = join(skillsRoot, skillsSubdir, src);
         if (existsSync(srcPath)) {
-          generateFiles(tree, srcPath, join(options.directory, dest), {});
+          generateFiles(
+            tree,
+            srcPath,
+            join(options.directory, dest),
+            workspaceContext
+          );
         }
       }
     }
@@ -423,12 +463,18 @@ export async function setupAiAgentsGeneratorImpl(
   };
 }
 
-function writeAgentRules(tree: Tree, path: string, writeNxCloudRules: boolean) {
+function writeAgentRules(
+  tree: Tree,
+  path: string,
+  writeNxCloudRules: boolean,
+  packageManager?: PackageManager
+) {
   if (!tree.exists(path)) {
     // File doesn't exist - create with h1 header (standalone content)
     const expectedRules = getAgentRulesWrapped({
       writeNxCloudRules,
       useH1: true,
+      packageManager,
     });
     tree.write(path, expectedRules);
     return;
@@ -447,6 +493,7 @@ function writeAgentRules(tree: Tree, path: string, writeNxCloudRules: boolean) {
     const expectedRules = getAgentRulesWrapped({
       writeNxCloudRules,
       useH1: !hasExternalH1,
+      packageManager,
     });
     const contentOnly = (str: string) =>
       str
@@ -471,6 +518,7 @@ function writeAgentRules(tree: Tree, path: string, writeNxCloudRules: boolean) {
     const expectedRules = getAgentRulesWrapped({
       writeNxCloudRules,
       useH1: !hasExistingH1,
+      packageManager,
     });
     tree.write(path, existing + '\n\n' + expectedRules);
   }

--- a/packages/nx/src/ai/set-up-ai-agents/workspace-context.spec.ts
+++ b/packages/nx/src/ai/set-up-ai-agents/workspace-context.spec.ts
@@ -1,0 +1,45 @@
+import { getWorkspaceContext } from './workspace-context';
+
+describe('getWorkspaceContext', () => {
+  it('renders no workspace facts when the package manager is unknown', () => {
+    // The templates guard every fact, so this makes them fall back to telling the agent
+    // how to determine the package manager itself — which is the correct answer when we
+    // genuinely do not know it.
+    expect(getWorkspaceContext(undefined, '/root')).toEqual({ pm: null });
+  });
+
+  it.each([
+    ['npm', 'npm exec nx'],
+    ['yarn', 'yarn nx'],
+    ['pnpm', 'pnpm nx'],
+    ['bun', 'bunx nx'],
+  ] as const)('states how to invoke nx under %s', (packageManager, nx) => {
+    expect(getWorkspaceContext(packageManager, '/root').pm.nx).toBe(nx);
+  });
+
+  it('distinguishes invoking nx from running an arbitrary local binary', () => {
+    // `exec` answers "run a local binary" and `nx` answers "run nx here". Conflating them
+    // is what produces docs that prefix nx two different ways on the same page.
+    const { pm } = getWorkspaceContext('npm', '/root');
+    expect(pm.exec).toBe('npx');
+    expect(pm.nx).toBe('npm exec nx');
+  });
+
+  it('reports workspace-protocol support', () => {
+    expect(
+      getWorkspaceContext('pnpm', '/root').pm.supportsWorkspaceProtocol
+    ).toBe(true);
+    expect(
+      getWorkspaceContext('npm', '/root').pm.supportsWorkspaceProtocol
+    ).toBe(false);
+  });
+
+  it('names where workspace globs live', () => {
+    expect(getWorkspaceContext('pnpm', '/root').pm.workspaceGlobFile).toContain(
+      'pnpm-workspace.yaml'
+    );
+    expect(getWorkspaceContext('npm', '/root').pm.workspaceGlobFile).toContain(
+      'package.json'
+    );
+  });
+});

--- a/packages/nx/src/ai/set-up-ai-agents/workspace-context.ts
+++ b/packages/nx/src/ai/set-up-ai-agents/workspace-context.ts
@@ -1,0 +1,78 @@
+import {
+  getPackageManagerCommand,
+  type PackageManager,
+} from '../../utils/package-manager';
+
+/**
+ * The schema the skill templates in `nrwl/nx-ai-agents-config` are written against.
+ *
+ * Bumping this means reading a different `templates/<version>` directory. Adding a fact is
+ * backwards-compatible — templates guard every fact, so an older nx simply renders the
+ * fallback branch. Removing or reshaping one is not, and needs a new version there first.
+ */
+export const TEMPLATES_SCHEMA_VERSION = 'v1';
+
+/** A workspace fact the skills would otherwise tell the agent to go and determine. */
+export interface PackageManagerContext {
+  name: PackageManager;
+  /** How to invoke nx here, e.g. `npm exec nx`. */
+  nx: string;
+  exec: string;
+  dlx: string;
+  add: string;
+  addDev: string;
+  install: string;
+  workspaceGlobFile: string;
+  supportsWorkspaceProtocol: boolean;
+}
+
+export interface WorkspaceContext {
+  pm: PackageManagerContext | null;
+}
+
+/**
+ * How nx is invoked under each package manager.
+ *
+ * This is deliberately not `getPackageManagerCommand().exec` — `exec` answers "run a local
+ * binary" (`npx`), which is a different question than "run nx in this workspace"
+ * (`npm exec nx`). Using one for the other is what produces docs that prefix nx two
+ * different ways on the same page.
+ */
+const NX_INVOCATION: Record<PackageManager, string> = {
+  npm: 'npm exec nx',
+  yarn: 'yarn nx',
+  pnpm: 'pnpm nx',
+  bun: 'bunx nx',
+};
+
+const WORKSPACE_GLOB_FILE: Record<PackageManager, string> = {
+  npm: 'the `workspaces` field in the root `package.json`',
+  yarn: 'the `workspaces` field in the root `package.json`',
+  pnpm: '`pnpm-workspace.yaml`',
+  bun: 'the `workspaces` field in the root `package.json`',
+};
+
+export function getWorkspaceContext(
+  packageManager: PackageManager | undefined,
+  root: string
+): WorkspaceContext {
+  if (!packageManager) {
+    return { pm: null };
+  }
+
+  const commands = getPackageManagerCommand(packageManager, root);
+
+  return {
+    pm: {
+      name: packageManager,
+      nx: NX_INVOCATION[packageManager],
+      exec: commands.exec,
+      dlx: commands.dlx,
+      add: commands.add,
+      addDev: commands.addDev,
+      install: commands.install,
+      workspaceGlobFile: WORKSPACE_GLOB_FILE[packageManager],
+      supportsWorkspaceProtocol: packageManager !== 'npm',
+    },
+  };
+}

--- a/packages/nx/src/ai/utils.ts
+++ b/packages/nx/src/ai/utils.ts
@@ -21,6 +21,7 @@ import {
   parseGeminiSettings,
 } from './constants';
 import setupAiAgentsGenerator from './set-up-ai-agents/set-up-ai-agents';
+import { detectPackageManager } from '../utils/package-manager';
 
 // when adding new agents, be sure to also update the list in
 // packages/create-nx-workspace/src/create-workspace-options.ts
@@ -264,6 +265,7 @@ async function agentWouldChangeWithGenerator(
       directory: '.',
       agents: [agent],
       writeNxCloudRules: isNxCloudUsed(readNxJson()),
+      packageManager: detectPackageManager(workspaceRoot),
     },
     true
   );
@@ -286,6 +288,7 @@ export async function configureAgents(
       directory: '.',
       agents,
       writeNxCloudRules,
+      packageManager: detectPackageManager(workspaceRoot),
     },
     !useLatest
   );

--- a/packages/nx/src/command-line/init/init-v2.ts
+++ b/packages/nx/src/command-line/init/init-v2.ts
@@ -438,6 +438,7 @@ async function runInit(
       writeNxCloudRules: options.nxCloud !== false,
       packageVersion: 'latest',
       agents: [...selectedAgents],
+      packageManager: detectPackageManager(repoRoot),
     });
 
     const changes = tree.listChanges();

--- a/packages/workspace/src/generators/new/generate-workspace-files.ts
+++ b/packages/workspace/src/generators/new/generate-workspace-files.ts
@@ -192,6 +192,8 @@ export async function generateWorkspaceFiles(
       writeNxCloudRules: options.nxCloud !== 'skip',
       packageVersion: 'latest',
       agents: [...options.aiAgents],
+      // Explicit: there is no lockfile to detect from yet at this point.
+      packageManager: options.packageManager,
     });
   }
 


### PR DESCRIPTION
## Current Behavior

`nx configure-ai-agents` copies the skill files from `nx-ai-agents-config` verbatim, so every workspace is told to run `pnpm nx add @nx/react` regardless of its package manager. The issue was reported from a yarn 4 workspace, where `.claude/skills/nx-plugins/SKILL.md` instructs the agent to use pnpm.

Several skills also spend a paragraph telling the agent to *determine* the package manager from the lockfile — something nx already knows at the moment it writes them.

## Expected Behavior

The generated skills state the facts nx knows.

`generateFiles` is already an EJS renderer, and both call sites here were handing it an empty substitution map. The config repo now publishes `templates/<version>` alongside `generated/`, carrying the workspace facts as tokens rather than resolved defaults, so this fills the map in:

```
templates/v1 present -> render it against the workspace
otherwise            -> fall back to generated/, exactly as today
```

Rendered for a yarn workspace:

```
- List plugins: `yarn nx list`
1. **Run nx as `yarn nx`** — this workspace uses yarn
```

### Claude

Claude is the exception, and it's where the bug was reported. Its skills install from the plugin marketplace rather than being copied through `generateFiles`, so they never see the workspace render.

Two things cover it:
- The upstream skills are now package-manager-agnostic (`nx list`, not `pnpm nx list`), so the marketplace copy can no longer be *wrong*.
- The agent-rules block is the one file nx still writes for Claude directly, so it now **states** the invocation rather than describing how to derive it:

  ```
  - This workspace uses yarn. Run nx as `yarn nx` (e.g. `yarn nx build`) - avoids using globally installed CLI
  ```

### Why `packageManager` is passed in, not detected

During `create-nx-workspace` there is no lockfile yet, so `detectPackageManager` falls through to `detectInvokedPackageManager()` — i.e. whichever package manager happened to invoke the CLI, which is not necessarily the one being set up. `pnpm dlx create-nx-workspace --pm=npm` would have detected pnpm. `options.packageManager` is authoritative and already available at that call site. Callers operating on an existing workspace detect it as before.

### Why the template dir is versioned

The config repo is cloned at **unpinned HEAD**, so every released nx — forever — reaches whatever is on its default branch. A template referencing a token that the *installed* nx doesn't pass throws `ReferenceError` and breaks `configure-ai-agents` for users who will never upgrade. Asking for `templates/v1` means new facts can be added (older nx renders the guarded fallback) while reshaping one requires a new version directory. If the version is absent, nx falls back to `generated/` — degraded, never broken.

## Notes

- `pm.nx` (`npm exec nx`) is kept distinct from `pm.exec` (`npx`). Conflating "invoke nx" with "run a local binary" is what produces docs that prefix nx two different ways on the same page.
- Fixes a latent recursion in `set-up-ai-agents.spec.ts`: `originalExistsSync` was captured *inside* `beforeEach`, after a previous test had already spied on `fs.existsSync`. `jest.spyOn` returns the existing mock for an already-spied method, so the capture became the mock itself and its fallthrough recursed until the stack overflowed. It never fired because nothing reached the fallthrough — until this change looked for `templates/`.
- `nx test nx` (`ai/`): 82 passed. `nx test workspace` (generators/new): 105 passed + 89 snapshots.

## Related Issue(s)

Depends on nrwl/nx-ai-agents-config#119, but does **not** block on it — without `templates/v1` present, this falls back to `generated/` and behaves exactly as today. The two are independently mergeable in either order.

Fixes #36312