### PR TITLE
chore(repo): harden nx-docs-style-check to apply the style guide per rule

### DIFF
--- a/.claude/skills/nx-docs-style-check/SKILL.md
+++ b/.claude/skills/nx-docs-style-check/SKILL.md
@@ -58,9 +58,21 @@ Run `nx run astro-docs:vale` to check the modified files.
   For ambiguous cases, suggest the fix and ask.
 - **suggestions** — mention them to the user but do not auto-fix.
 
-### Step 2: Fix issues Vale doesn't catch
+### Step 2: Apply the guide by hand (Vale covers only a subset)
 
-Read `astro-docs/STYLE_GUIDE.md` and check for that things that Vale may have missed.
+Vale enforces only the mechanical rules, and even the ones it implements are partial. A
+clean Vale run is **not** evidence the guide passed. Reading the guide is also not enough;
+you have to test your changed text against each rule.
+
+For the diff you just made:
+
+1. Run the guide's own "Pre-publish pass order" end to end, in order, on your changed text.
+   Where a pass is a procedure (a grep, a count, a rewrite), perform it on your text rather
+   than just confirming the pass exists.
+2. Then go through the rest of `STYLE_GUIDE.md` rule by rule, checking your changed lines
+   against every rule the pass order did not already cover. A rule counts as checked only
+   after you've read your actual sentences through it, not after you've read the rule.
+3. Fix every violation. If a rule genuinely doesn't apply to this change, move on.
 
 ### Handling false positives
 


### PR DESCRIPTION
## Current Behavior

The `nx-docs-style-check` skill's Phase 2 Step 2 told the agent to read `STYLE_GUIDE.md` and check for what Vale missed. Reading satisfied the step without ever testing the changed text against the rules. Vale only tokenizes a subset of the guide (for example product-name possessives beyond "Nx's", and closers outside its fixed phrase list), so a clean Vale run plus a full read still let guide violations ship.

## Expected Behavior

Step 2 now forces the agent to run the guide's own Pre-publish pass order end to end on the changed text, then check the remaining rules line by line. It stays generic and names no specific rule, so it does not teach a narrow checklist.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/docs-agent-instructions-hardening-49080ffa)
<!-- polygraph-session-end -->