### PR TITLE
fix(bundling): support TypeScript esbuildConfig files in the esbuild executor

### DIFF
--- a/e2e/esbuild/src/esbuild-basic-external-config.test.ts
+++ b/e2e/esbuild/src/esbuild-basic-external-config.test.ts
@@ -27,4 +27,34 @@ describe('EsBuild Plugin - Basic - External Config', () => {
     const output = runCLI(`build ${myPkg}`);
     expect(output).toContain('custom config loaded');
   }, 120_000);
+
+  it('should support external TypeScript esbuild.config.ts file', async () => {
+    const myPkg = uniq('my-pkg');
+    runCLI(
+      `generate @nx/js:lib ${myPkg} --directory=libs/${myPkg} --bundler=esbuild`
+    );
+    // The config imports a sibling TS module by extensionless path and uses
+    // TS-only syntax. Raw require() can't resolve the extensionless '.ts'
+    // import (and can't parse the TS syntax on Node without native type
+    // stripping), so this only builds through the transpiled loadConfigFile path.
+    updateFile(
+      `libs/${myPkg}/noop.plugin.ts`,
+      `import type { Plugin } from 'esbuild';\n\nexport const noopPlugin: Plugin = {\n  name: 'noop',\n  setup() {\n    console.log('noop plugin setup ran');\n  },\n};\n`
+    );
+    updateFile(
+      `libs/${myPkg}/esbuild.config.ts`,
+      `import type { BuildOptions } from 'esbuild';\nimport { noopPlugin } from './noop.plugin';\n\nconsole.log('custom ts config loaded');\n\nexport default {\n  plugins: [noopPlugin],\n} satisfies BuildOptions;\n`
+    );
+    updateJson(join('libs', myPkg, 'project.json'), (json) => {
+      delete json.targets.build.options.esbuildOptions;
+      json.targets.build.options.esbuildConfig = `libs/${myPkg}/esbuild.config.ts`;
+      return json;
+    });
+
+    const output = runCLI(`build ${myPkg}`);
+    expect(output).toContain('custom ts config loaded');
+    // Proves the imported TS plugin reached esbuild and its setup() ran,
+    // not just that the config module evaluated.
+    expect(output).toContain('noop plugin setup ran');
+  }, 120_000);
 });

--- a/packages/esbuild/src/executors/esbuild/esbuild.impl.ts
+++ b/packages/esbuild/src/executors/esbuild/esbuild.impl.ts
@@ -51,7 +51,7 @@ export async function* esbuildExecutor(
 ) {
   process.env.NODE_ENV ??= context.configurationName ?? 'production';
 
-  const options = normalizeOptions(_options, context);
+  const options = await normalizeOptions(_options, context);
   if (options.deleteOutputPath)
     rmSync(options.outputPath, { recursive: true, force: true });
 

--- a/packages/esbuild/src/executors/esbuild/lib/normalize.spec.ts
+++ b/packages/esbuild/src/executors/esbuild/lib/normalize.spec.ts
@@ -50,9 +50,9 @@ describe('normalizeOptions', () => {
     },
   };
 
-  it('should handle single entry point options', () => {
+  it('should handle single entry point options', async () => {
     expect(
-      normalizeOptions(
+      await normalizeOptions(
         {
           main: 'apps/myapp/src/index.ts',
           outputPath: 'dist/apps/myapp',
@@ -81,9 +81,9 @@ describe('normalizeOptions', () => {
     });
   });
 
-  it('should handle multiple entry point options', () => {
+  it('should handle multiple entry point options', async () => {
     expect(
-      normalizeOptions(
+      await normalizeOptions(
         {
           main: 'apps/myapp/src/index.ts',
           outputPath: 'dist/apps/myapp',
@@ -114,9 +114,9 @@ describe('normalizeOptions', () => {
     });
   });
 
-  it('should support custom output file name', () => {
+  it('should support custom output file name', async () => {
     expect(
-      normalizeOptions(
+      await normalizeOptions(
         {
           main: 'apps/myapp/src/index.ts',
           outputPath: 'dist/apps/myapp',
@@ -146,8 +146,8 @@ describe('normalizeOptions', () => {
     });
   });
 
-  it('should validate against multiple entry points + outputFileName', () => {
-    expect(() =>
+  it('should validate against multiple entry points + outputFileName', async () => {
+    await expect(
       normalizeOptions(
         {
           main: 'apps/myapp/src/index.ts',
@@ -161,12 +161,12 @@ describe('normalizeOptions', () => {
         },
         context
       )
-    ).toThrow(/Cannot use/);
+    ).rejects.toThrow(/Cannot use/);
   });
 
-  it('should add package.json to assets array if generatePackageJson is false', () => {
+  it('should add package.json to assets array if generatePackageJson is false', async () => {
     expect(
-      normalizeOptions(
+      await normalizeOptions(
         {
           main: 'apps/myapp/src/index.ts',
           outputPath: 'dist/apps/myapp',
@@ -195,7 +195,7 @@ describe('normalizeOptions', () => {
     });
   });
 
-  it("should use the tsconfig declaration option if the declaration option isn't defined", () => {
+  it("should use the tsconfig declaration option if the declaration option isn't defined", async () => {
     (
       readTsConfig as jest.MockedFunction<typeof readTsConfig>
     ).mockImplementationOnce(() => ({
@@ -207,7 +207,7 @@ describe('normalizeOptions', () => {
     }));
 
     expect(
-      normalizeOptions(
+      await normalizeOptions(
         {
           main: 'apps/myapp/src/index.ts',
           outputPath: 'dist/apps/myapp',
@@ -220,9 +220,9 @@ describe('normalizeOptions', () => {
     ).toEqual(expect.objectContaining({ declaration: true }));
   });
 
-  it('should override thirdParty if bundle:false', () => {
+  it('should override thirdParty if bundle:false', async () => {
     expect(
-      normalizeOptions(
+      await normalizeOptions(
         {
           main: 'apps/myapp/src/index.ts',
           outputPath: 'dist/apps/myapp',
@@ -237,9 +237,9 @@ describe('normalizeOptions', () => {
     ).toEqual(expect.objectContaining({ thirdParty: false }));
   });
 
-  it('should override skipTypeCheck if declaration:true', () => {
+  it('should override skipTypeCheck if declaration:true', async () => {
     expect(
-      normalizeOptions(
+      await normalizeOptions(
         {
           main: 'apps/myapp/src/index.ts',
           outputPath: 'dist/apps/myapp',

--- a/packages/esbuild/src/executors/esbuild/lib/normalize.ts
+++ b/packages/esbuild/src/executors/esbuild/lib/normalize.ts
@@ -1,4 +1,5 @@
 import { joinPathFragments, logger, type ExecutorContext } from '@nx/devkit';
+import { loadConfigFile } from '@nx/devkit/internal';
 import { readTsConfig } from '@nx/js';
 import { isUsingTsSolutionSetup } from '@nx/js/internal';
 import * as esbuild from 'esbuild';
@@ -10,10 +11,10 @@ import type {
   NormalizedEsBuildExecutorOptions,
 } from '../schema';
 
-export function normalizeOptions(
+export async function normalizeOptions(
   options: EsBuildExecutorOptions,
   context: ExecutorContext
-): NormalizedEsBuildExecutorOptions {
+): Promise<NormalizedEsBuildExecutorOptions> {
   const isTsSolutionSetup = isUsingTsSolutionSetup();
   if (isTsSolutionSetup && options.generatePackageJson) {
     throw new Error(
@@ -88,7 +89,10 @@ export function normalizeOptions(
       throw new Error(
         `Path of esbuildConfig does not exist: ${userDefinedConfig}`
       );
-    userDefinedBuildOptions = require(userDefinedConfig);
+    // Use loadConfigFile so TypeScript configs (import type, satisfies, TS
+    // plugin imports) are transpiled instead of require()'d raw.
+    userDefinedBuildOptions =
+      await loadConfigFile<esbuild.BuildOptions>(userDefinedConfig);
   } else if (options.esbuildOptions) {
     userDefinedBuildOptions = options.esbuildOptions;
   }


### PR DESCRIPTION
## Current Behavior

When `@nx/esbuild:esbuild` is configured with a TypeScript `esbuildConfig` (e.g. `esbuild.config.ts`), the executor loads it with a raw `require()`, which does not transpile TypeScript. A config that uses TS-only syntax such as `import type` or `satisfies`, or that imports a TypeScript plugin, fails with a `SyntaxError` before the build can start. The only workaround is a `.cjs` bridge file or registering a runtime TypeScript loader.

## Expected Behavior

The esbuild executor loads TypeScript `esbuildConfig` files directly, including configs that use `import type` / `satisfies` and that import TypeScript plugins, matching the config-loading behavior of the other bundler executors.

## Implementation Details

The config is now loaded through `loadConfigFile` (`@nx/devkit/internal`), the same helper the rollup executor already uses for user configs. It detects TypeScript by extension, transpiles via swc, and registers tsconfig-paths so relative TS plugin imports resolve. `normalizeOptions` becomes `async` to await the load. Added an e2e that builds a project with a `.ts` config using `import type`, `satisfies`, and a sibling TS plugin whose `setup()` runs.

## Related Issue(s)

Fixes #36349

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/gh-36349-91f23d8e)
<!-- polygraph-session-end -->