### PR TITLE
fix(misc): resolve CSS url() assets on Windows in postcss-cli-resources

### DIFF
--- a/packages/angular-rspack/src/lib/utils/postcss-cli-resources.ts
+++ b/packages/angular-rspack/src/lib/utils/postcss-cli-resources.ts
@@ -8,7 +8,6 @@
 
 import { interpolateName } from 'loader-utils';
 import * as path from 'node:path';
-import { pathToFileURL } from 'node:url';
 import type { Declaration, Plugin } from 'postcss';
 import { assertIsError } from './misc-helpers';
 
@@ -109,7 +108,12 @@ export default function (options?: PostcssCliResourcesOptions): Plugin {
     // Separate URL query/hash from the file path before resolving
     const [, filePath, urlSuffix] = inputUrl.match(/^([^?#]*)(.*)$/)!;
     const resolvedPath = path.resolve(context, filePath.replace(/\\/g, '/'));
-    const { pathname } = pathToFileURL(resolvedPath);
+    // Resolve a relative filesystem path, not a file:// URL pathname: on Windows the
+    // pathname is `/C:/...` (spaces as %20), which the resolver cannot find. Relative
+    // (not absolute) lets `resolve()`'s `./`-prefixed lookup succeed on the first try.
+    const resolveRequest = path
+      .relative(context, resolvedPath)
+      .replace(/\\/g, '/');
     let hash = '';
     let search = '';
     if (urlSuffix) {
@@ -117,7 +121,7 @@ export default function (options?: PostcssCliResourcesOptions): Plugin {
     }
     const resolver = (file: string, base: string) =>
       new Promise<string>((resolve, reject) => {
-        loader.resolve(base, decodeURI(file), (err, result) => {
+        loader.resolve(base, file, (err, result) => {
           if (err) {
             reject(err);
 
@@ -127,7 +131,7 @@ export default function (options?: PostcssCliResourcesOptions): Plugin {
         });
       });
 
-    const result = await resolve(pathname as string, context, resolver);
+    const result = await resolve(resolveRequest, context, resolver);
 
     return new Promise<string>((resolve, reject) => {
       loader.fs.readFile(result, (err, content) => {

--- a/packages/rspack/src/plugins/utils/plugins/postcss-cli-resources.ts
+++ b/packages/rspack/src/plugins/utils/plugins/postcss-cli-resources.ts
@@ -1,6 +1,5 @@
 import { interpolateName } from 'loader-utils';
 import * as path from 'path';
-import { pathToFileURL } from 'url';
 import type { Declaration } from 'postcss';
 import type { LoaderContext } from '@rspack/core';
 
@@ -107,7 +106,12 @@ export function PostcssCliResources(options: PostcssCliResourcesOptions) {
     // Separate URL query/hash from the file path before resolving
     const [, filePath, urlSuffix] = inputUrl.match(/^([^?#]*)(.*)$/)!;
     const resolvedPath = path.resolve(context, filePath.replace(/\\/g, '/'));
-    const { pathname } = pathToFileURL(resolvedPath);
+    // Resolve a relative filesystem path, not a file:// URL pathname: on Windows the
+    // pathname is `/C:/...` (spaces as %20), which the resolver cannot find. Relative
+    // (not absolute) lets `resolve()`'s `./`-prefixed lookup succeed on the first try.
+    const resolveRequest = path
+      .relative(context, resolvedPath)
+      .replace(/\\/g, '/');
     let hash = '';
     let search = '';
     if (urlSuffix) {
@@ -115,7 +119,7 @@ export function PostcssCliResources(options: PostcssCliResourcesOptions) {
     }
     const resolver = (file: string, base: string) =>
       new Promise<boolean | string>((resolve, reject) => {
-        loader.resolve(base, decodeURI(file), (err, result) => {
+        loader.resolve(base, file, (err, result) => {
           if (err) {
             reject(err);
             return;
@@ -123,7 +127,7 @@ export function PostcssCliResources(options: PostcssCliResourcesOptions) {
           resolve(result);
         });
       });
-    const result = await resolve(pathname as string, context, resolver);
+    const result = await resolve(resolveRequest, context, resolver);
     return new Promise<boolean | string>((resolve, reject) => {
       loader.fs.readFile(result as string, (err: Error, content: Buffer) => {
         if (err) {

--- a/packages/webpack/src/utils/webpack/plugins/postcss-cli-resources.ts
+++ b/packages/webpack/src/utils/webpack/plugins/postcss-cli-resources.ts
@@ -1,6 +1,5 @@
 import { interpolateName } from 'loader-utils';
 import * as path from 'path';
-import { pathToFileURL } from 'url';
 import type { Declaration } from 'postcss';
 import type { LoaderContext } from 'webpack';
 
@@ -107,7 +106,12 @@ export function PostcssCliResources(options: PostcssCliResourcesOptions) {
     // Separate URL query/hash from the file path before resolving
     const [, filePath, urlSuffix] = inputUrl.match(/^([^?#]*)(.*)$/)!;
     const resolvedPath = path.resolve(context, filePath.replace(/\\/g, '/'));
-    const { pathname } = pathToFileURL(resolvedPath);
+    // Resolve a relative filesystem path, not a file:// URL pathname: on Windows the
+    // pathname is `/C:/...` (spaces as %20), which the resolver cannot find. Relative
+    // (not absolute) lets `resolve()`'s `./`-prefixed lookup succeed on the first try.
+    const resolveRequest = path
+      .relative(context, resolvedPath)
+      .replace(/\\/g, '/');
     let hash = '';
     let search = '';
     if (urlSuffix) {
@@ -115,7 +119,7 @@ export function PostcssCliResources(options: PostcssCliResourcesOptions) {
     }
     const resolver = (file: string, base: string) =>
       new Promise<boolean | string>((resolve, reject) => {
-        loader.resolve(base, decodeURI(file), (err, result) => {
+        loader.resolve(base, file, (err, result) => {
           if (err) {
             reject(err);
             return;
@@ -123,7 +127,7 @@ export function PostcssCliResources(options: PostcssCliResourcesOptions) {
           resolve(result);
         });
       });
-    const result = await resolve(pathname as string, context, resolver);
+    const result = await resolve(resolveRequest, context, resolver);
     return new Promise<boolean | string>((resolve, reject) => {
       loader.fs.readFile(result as string, (err: Error, content: Buffer) => {
         if (err) {


### PR DESCRIPTION
## Current Behavior

On Windows, CSS `url(...)` references to local assets (SVGs, fonts such as `codicon.ttf`, etc.) fail to resolve during an `@nx/rspack`, `@nx/webpack`, or `@nx/angular-rspack` build, even when the file exists on disk. The build reports `RspackResolver(NotFound("/C:/.../file.svg"))`. It is most visible when the workspace path contains spaces.

## Expected Behavior

CSS `url()` assets resolve on Windows regardless of the drive letter or spaces in the path.

## Related Issue(s)

Fixes #36336

## Implementation Details

The `postcss-cli-resources` plugin resolved assets by passing `pathToFileURL(resolvedPath).pathname` to the bundler resolver. That value is a URL path (`/C:/Users/...`, with spaces percent-encoded), not a filesystem path, so the resolver could not find the file. On POSIX the URL pathname coincides with the filesystem path, which is why only Windows was affected. #34676 fixed an earlier `new URL(winPath, 'file:///')` drive-letter misparse but kept feeding the pathname into the resolver.

The fix resolves a relative filesystem path derived from `resolvedPath` instead, and drops the paired `decodeURI` that only existed to undo the pathname encoding. It is applied to the `@nx/rspack`, `@nx/webpack`, and `@nx/angular-rspack` copies of the plugin.

The plugin has no existing unit coverage and the resolver needs a real webpack/rspack loader context, so no automated test was added; the change was validated with build and lint and cross-checked against upstream `@angular-devkit/build-angular`.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/gh-36336-b7b11fff)
<!-- polygraph-session-end -->