### PR TITLE
fix(core): support npm 12 and pnpm in the package provenance check

### DIFF
--- a/packages/nx/src/utils/provenance.spec.ts
+++ b/packages/nx/src/utils/provenance.spec.ts
@@ -1,0 +1,123 @@
+import * as packageManager from './package-manager';
+import { ensurePackageHasProvenance } from './provenance';
+
+describe('ensurePackageHasProvenance', () => {
+  const attestationUrl =
+    'https://registry.npmjs.org/-/npm/v1/attestations/nx@1.0.0';
+  // shaped like a real `npm view <pkg>@<version> --json` entry
+  const packument = (version: string, withAttestations = true) => ({
+    version,
+    dist: {
+      integrity: `sha512-${version}`,
+      ...(withAttestations
+        ? { attestations: { url: `${attestationUrl}-${version}` } }
+        : {}),
+    },
+  });
+
+  let packageRegistryViewSpy: jest.SpyInstance;
+  const originalFetch = global.fetch;
+  const originalSkip = process.env.NX_SKIP_PROVENANCE_CHECK;
+
+  beforeEach(() => {
+    delete process.env.NX_SKIP_PROVENANCE_CHECK;
+    packageRegistryViewSpy = jest.spyOn(packageManager, 'packageRegistryView');
+    // fail the fetch so the check stops right after locating the attestation
+    // URL; isolates the npm-view parsing from full attestation validation.
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+    }) as unknown as typeof fetch;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    global.fetch = originalFetch;
+    if (originalSkip === undefined) {
+      delete process.env.NX_SKIP_PROVENANCE_CHECK;
+    } else {
+      process.env.NX_SKIP_PROVENANCE_CHECK = originalSkip;
+    }
+  });
+
+  it('does nothing when NX_SKIP_PROVENANCE_CHECK is set', async () => {
+    process.env.NX_SKIP_PROVENANCE_CHECK = 'true';
+
+    await expect(
+      ensurePackageHasProvenance('nx', '1.0.0')
+    ).resolves.toBeUndefined();
+    expect(packageRegistryViewSpy).not.toHaveBeenCalled();
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('locates the attestation URL when npm returns a bare object (npm <= 11)', async () => {
+    packageRegistryViewSpy.mockResolvedValue(
+      JSON.stringify(packument('1.0.0'))
+    );
+
+    // reaching the fetch (HTTP 500) proves the attestation URL was found
+    await expect(ensurePackageHasProvenance('nx', '1.0.0')).rejects.toThrow(
+      'HTTP 500'
+    );
+    expect(global.fetch).toHaveBeenCalledWith(`${attestationUrl}-1.0.0`);
+  });
+
+  it('locates the attestation URL when npm 12 / pnpm wrap a single version in an array', async () => {
+    packageRegistryViewSpy.mockResolvedValue(
+      JSON.stringify([packument('1.0.0')])
+    );
+
+    await expect(ensurePackageHasProvenance('nx', '1.0.0')).rejects.toThrow(
+      'HTTP 500'
+    );
+    expect(global.fetch).toHaveBeenCalledWith(`${attestationUrl}-1.0.0`);
+  });
+
+  it('refuses a version range that matches multiple versions', async () => {
+    // a range yields every matching version; we cannot tell which one installs
+    packageRegistryViewSpy.mockResolvedValue(
+      JSON.stringify([
+        packument('1.0.0'),
+        packument('1.1.0'),
+        packument('1.2.0'),
+      ])
+    );
+
+    await expect(ensurePackageHasProvenance('nx', '^1.0.0')).rejects.toThrow(
+      'Specify an exact version'
+    );
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('throws when a bare object has no attestation URL', async () => {
+    packageRegistryViewSpy.mockResolvedValue(
+      JSON.stringify(packument('1.0.0', false))
+    );
+
+    await expect(ensurePackageHasProvenance('nx', '1.0.0')).rejects.toThrow(
+      'No attestation URL found'
+    );
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('throws when a single-element array has no attestation URL', async () => {
+    packageRegistryViewSpy.mockResolvedValue(
+      JSON.stringify([packument('1.0.0', false)])
+    );
+
+    await expect(ensurePackageHasProvenance('nx', '1.0.0')).rejects.toThrow(
+      'No attestation URL found'
+    );
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('throws on an empty array rather than crashing', async () => {
+    packageRegistryViewSpy.mockResolvedValue(JSON.stringify([]));
+
+    await expect(ensurePackageHasProvenance('nx', '1.0.0')).rejects.toThrow(
+      'No attestation URL found'
+    );
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/packages/nx/src/utils/provenance.ts
+++ b/packages/nx/src/utils/provenance.ts
@@ -32,9 +32,23 @@ export async function ensurePackageHasProvenance(
       packageVersion,
       '--json --silent'
     );
-    const npmViewResult = JSON.parse(result);
+    const parsed = JSON.parse(result);
+    // `npm view <pkg>@<spec> --json` returns a bare object on npm <= 11 but an
+    // array on npm 12 and pnpm, even for a single resolved version. A version
+    // range matches several versions and the registry lists all of them
+    // (including deprecated ones the installer skips), so we cannot tell which
+    // one will actually be installed; refuse rather than verify the wrong
+    // artifact.
+    if (Array.isArray(parsed) && parsed.length > 1) {
+      throw new ProvenanceError(
+        packageName,
+        packageVersion,
+        'Provenance can only be verified for a single version, but this version resolved to multiple candidates. Specify an exact version.'
+      );
+    }
+    const npmViewResult = Array.isArray(parsed) ? parsed[0] : parsed;
 
-    const attURL = npmViewResult.dist?.attestations?.url;
+    const attURL = npmViewResult?.dist?.attestations?.url;
 
     if (!attURL)
       throw new ProvenanceError(


### PR DESCRIPTION
## Current Behavior

`nx migrate` (and `nx init`, AI agent setup - anything that verifies the `nx` package before installing it) aborts with `An error occurred while checking the provenance of nx@latest. ... Error: No attestation URL found` on npm 12, pnpm, and yarn workspaces, even when the package is published with valid provenance. The only workarounds were `NX_SKIP_PROVENANCE_CHECK=true` or downgrading to npm <= 11.

## Expected Behavior

The provenance check reads the attestation and `nx migrate` proceeds. `npm view <pkg>@<spec> --json` returns a bare object on npm <= 11 but an array on npm 12 and pnpm, even for a single resolved version; both shapes are now handled. A spec that resolves to multiple versions (a range) fails with a clear message asking for an exact version instead of the misleading "No attestation URL found", since the registry also lists versions the installer skips (for example deprecated ones) and the version that would install cannot be determined reliably.

## Related Issue(s)

Fixes #36338

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/gh-36338-da986a7f)
<!-- polygraph-session-end -->