### PR TITLE
fix(core): resolve name refs copied into pattern-matched target arrays

### DIFF
--- a/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
@@ -172,8 +172,8 @@ describe('project-configuration-utils', () => {
     });
 
     // Mirror of the dependsOn P2 regression for the inputs path:
-    // processInputs and processDependsOn share writeReplacement /
-    // createRef plumbing, but the top-level walk is separate. Locks in
+    // processInputs and processDependsOn share the createRef plumbing,
+    // but the substitution sweep walks each array separately. Locks in
     // that default-plugin inputs references get sentinel treatment too.
     it('should resolve inputs refs owned by default plugins when the referenced project is renamed during the default apply', () => {
       const specifiedResults: CreateNodesResultEntry[][] = [

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
@@ -608,6 +608,113 @@ describe('project-configuration-utils', () => {
       expect(buildTarget.inputs).toEqual(['explicit', 'from-defaults']);
     });
 
+    it('should resolve name refs in every pattern-matched target when a project.json pattern target spreads targetDefaults', () => {
+      // Regression: the spread copies the targetDefaults dependsOn entries
+      // (already sentinelized as name refs) by reference into a fresh array
+      // for every target matching the pattern. Write-back through each
+      // sentinel's original array left raw sentinel objects in the copies,
+      // which later crashed task graph creation ("pattern is not iterable").
+      const specifiedResults = [
+        [
+          [
+            'fake-atomizer-plugin',
+            'e2e/maven/jest.config.ts',
+            {
+              projects: {
+                'e2e/maven': {
+                  name: 'e2e-maven',
+                  targets: {
+                    'e2e-ci--src/a.test.ts': { command: 'echo a' },
+                    'e2e-ci--src/b.test.ts': { command: 'echo b' },
+                  },
+                },
+              },
+            },
+          ],
+        ],
+      ] as const;
+
+      const defaultResults = [
+        [
+          [
+            'nx/core/project-json',
+            'project.json',
+            {
+              projects: {
+                '.': {
+                  name: '@nx/nx-source',
+                  root: '.',
+                  targets: {
+                    'populate-storage': { command: 'echo populate' },
+                    'local-registry': { command: 'echo registry' },
+                  },
+                },
+              },
+            },
+          ],
+          [
+            'nx/core/project-json',
+            'e2e/maven/project.json',
+            {
+              projects: {
+                'e2e/maven': {
+                  name: 'e2e-maven',
+                  root: 'e2e/maven',
+                  targets: {
+                    'e2e-ci--**/**': {
+                      dependsOn: ['...', 'maven-plugin:install'],
+                    },
+                  },
+                },
+              },
+            },
+          ],
+          [
+            'nx/core/project-json',
+            'libs/maven-plugin/project.json',
+            {
+              projects: {
+                'libs/maven-plugin': {
+                  name: 'maven-plugin',
+                  root: 'libs/maven-plugin',
+                  targets: {
+                    install: { command: 'echo install' },
+                  },
+                },
+              },
+            },
+          ],
+        ],
+      ] as const;
+
+      const errors = [];
+      const result = mergeCreateNodesResults(
+        specifiedResults as any,
+        defaultResults as any,
+        {
+          targetDefaults: {
+            'e2e-ci--**/**': {
+              dependsOn: [
+                '@nx/nx-source:populate-storage',
+                '@nx/nx-source:local-registry',
+              ],
+            },
+          },
+        },
+        '/tmp/test',
+        errors
+      );
+
+      const targets = result.projectRootMap['e2e/maven'].targets!;
+      const expected = [
+        '@nx/nx-source:populate-storage',
+        '@nx/nx-source:local-registry',
+        'maven-plugin:install',
+      ];
+      expect(targets['e2e-ci--src/a.test.ts'].dependsOn).toEqual(expected);
+      expect(targets['e2e-ci--src/b.test.ts'].dependsOn).toEqual(expected);
+    });
+
     it('should resolve spread tokens from package.json script target augmentation against target defaults', () => {
       // https://github.com/nrwl/nx/issues/36235 — `nx.targets.build` augments
       // the script-derived target inside the package.json reader. The `'...'`

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -432,12 +432,10 @@ export function mergeCreateNodesResults(
     }
   }
 
-  // The intermediate apply may have rebuilt dependsOn / inputs arrays
-  // via spread merges, leaving sentinels inserted against the
-  // intermediate rootMap pointing at now-orphaned arrays. Re-walking
-  // the final merged targets rebinds each encountered sentinel's
-  // `parent` to the current array (see
-  // ProjectNameInNodePropsManager#processInputs / processDependsOn).
+  // The intermediate apply may have rebuilt dependsOn / inputs arrays via
+  // spread merges, introducing name-ref strings that weren't visible in any
+  // single plugin result. Re-walking the final merged targets sentinelizes
+  // them so the final substitution sweep resolves them too.
   nodesManager.registerNameRefs(intermediateDefaultRootMap);
 
   // Overlay default-plugin attribution onto the main source maps using

--- a/packages/nx/src/project-graph/utils/project-configuration/name-substitution-manager.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/name-substitution-manager.spec.ts
@@ -2187,5 +2187,51 @@ describe('ProjectNameInNodePropsManager', () => {
       expect(typeof mergedDependsOn[0]).toBe('string');
       expect(typeof mergedDependsOn[1]).toBe('string');
     });
+
+    // Regression: applying a pattern target (e.g. `e2e-ci--**/**`) copies
+    // its dependsOn entries by reference into a fresh array on every
+    // matching target, and those arrays are never re-registered. Write-back
+    // through the sentinel's original array left the copies holding raw
+    // sentinel objects, which later crashed task graph creation
+    // ("pattern is not iterable").
+    it('should resolve sentinels copied into arrays that are never re-registered', () => {
+      const manager = createManager();
+
+      const projectA = createProject('project-a', 'libs/a', {
+        targets: {
+          'e2e-ci--**/**': {
+            dependsOn: ['project-b:build'],
+          },
+        },
+      });
+      const projectB = createProject('project-b', 'libs/b');
+      const baseResult = createPluginResult([projectA, projectB]);
+      identifyProjects(manager, baseResult);
+      manager.registerNameRefs(baseResult);
+
+      // Simulate pattern-target application: the matching atomized target
+      // gets a fresh dependsOn array holding the same sentinel reference.
+      // Nothing re-registers this array.
+      const templateDependsOn = projectA.targets['e2e-ci--**/**']
+        .dependsOn as unknown[];
+      const atomizedDependsOn: unknown[] = [templateDependsOn[0]];
+      projectA.targets['e2e-ci--src/a.test.ts'] = {
+        dependsOn: atomizedDependsOn,
+      };
+
+      const rootMap = createRootMap([
+        {
+          name: 'project-a',
+          root: 'libs/a',
+          targets: projectA.targets,
+        },
+        { name: 'project-b', root: 'libs/b' },
+      ]);
+
+      manager.applySubstitutions(rootMap);
+
+      expect(atomizedDependsOn[0]).toBe('project-b:build');
+      expect(templateDependsOn[0]).toBe('project-b:build');
+    });
   });
 });

--- a/packages/nx/src/project-graph/utils/project-configuration/name-substitution-manager.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/name-substitution-manager.ts
@@ -16,15 +16,12 @@ type ProjectsEntry = string | NameRef;
  * reference. `RootRef` carries the referenced project's root (resolved
  * via nameMap lookup); `UsageRef` carries the raw written name (for
  * forward refs, promoted to `RootRef` in place when the name is
- * identified). `parent` + `key` let the final pass write the resolved
- * name back; `targetPart` preserves the `:target` suffix from
+ * identified). `targetPart` preserves the `:target` suffix from
  * `dependsOn` strings.
  */
 export abstract class NameRef {
   constructor(
     public value: string,
-    public parent: unknown,
-    public key: string | undefined,
     public targetPart: string | undefined
   ) {}
 }
@@ -49,15 +46,15 @@ export function isUsageRef(value: unknown): value is UsageRef {
  * then resolves them after all merging is done.
  *
  * Tracking by array position breaks once `'...'` spreads shuffle indices,
- * so each ref becomes a sentinel object. Arrays spread-merge by pushing
- * element references, so sentinel identity survives any downstream
- * merges — the final pass walks a flat registry and writes the resolved
- * name back through each sentinel's `parent` back-reference. Orphaned
- * sentinels (from arrays dropped by a full-replace) write harmlessly.
+ * so each ref becomes a sentinel object. Merges copy sentinels by
+ * reference — one sentinel can end up in many arrays (e.g. a pattern
+ * target's dependsOn applied to every matching target) — so the final
+ * pass sweeps the merged rootMap and resolves every sentinel where it
+ * actually sits. Sentinels in arrays dropped by a full-replace are never
+ * visited and vanish with their array.
  */
 export class ProjectNameInNodePropsManager {
   private getNameMap: () => Record<string, ProjectConfiguration>;
-  private allRefs = new Set<RootRef | UsageRef>();
   private pendingByName = new Map<string, Set<RootRef | UsageRef>>();
 
   constructor(getNameMap?: () => Record<string, ProjectConfiguration>) {
@@ -100,24 +97,16 @@ export class ProjectNameInNodePropsManager {
   private processInputs(inputs: InputEntry[]): void {
     for (let i = 0; i < inputs.length; i++) {
       const entry = inputs[i];
-      // Existing sentinel: spread merges may have copied it out of its
-      // original array, so rebind parent to this one.
-      if (isNameRef(entry)) {
-        entry.parent = inputs;
-        continue;
-      }
+      if (isNameRef(entry)) continue;
       if (!entry || typeof entry !== 'object') continue;
       if (!('projects' in entry)) continue;
       const element = entry as { projects: unknown };
       const projects = element.projects;
 
-      if (isNameRef(projects)) {
-        // Object-parent sentinel — element identity is stable across spread.
-        continue;
-      }
+      if (isNameRef(projects)) continue;
       if (typeof projects === 'string') {
         if (projects === 'self' || projects === 'dependencies') continue;
-        element.projects = this.createRef(projects, element, 'projects');
+        element.projects = this.createRef(projects);
       } else if (Array.isArray(projects)) {
         this.processProjectsArray(projects);
       }
@@ -131,12 +120,7 @@ export class ProjectNameInNodePropsManager {
   ): void {
     for (let i = 0; i < dependsOn.length; i++) {
       const dep = dependsOn[i];
-      // Existing sentinel: rebind parent to this array in case a spread
-      // merge copied it out of its original.
-      if (isNameRef(dep)) {
-        dep.parent = dependsOn;
-        continue;
-      }
+      if (isNameRef(dep)) continue;
 
       if (typeof dep === 'string') {
         // `^target` and same-project targets aren't cross-project refs.
@@ -150,12 +134,7 @@ export class ProjectNameInNodePropsManager {
         );
         if (rest.length === 0) continue;
         const targetPart = rest.join(':');
-        dependsOn[i] = this.createRef(
-          maybeProject,
-          dependsOn,
-          undefined,
-          targetPart
-        );
+        dependsOn[i] = this.createRef(maybeProject, targetPart);
         continue;
       }
 
@@ -174,7 +153,7 @@ export class ProjectNameInNodePropsManager {
         ) {
           continue;
         }
-        element.projects = this.createRef(projects, element, 'projects');
+        element.projects = this.createRef(projects);
       } else if (Array.isArray(projects)) {
         this.processProjectsArray(projects);
       }
@@ -184,30 +163,23 @@ export class ProjectNameInNodePropsManager {
   private processProjectsArray(projects: ProjectsEntry[]): void {
     for (let j = 0; j < projects.length; j++) {
       const name = projects[j];
-      if (isNameRef(name)) {
-        name.parent = projects;
-        continue;
-      }
+      if (isNameRef(name)) continue;
       if (typeof name !== 'string') continue;
       if (isGlobPattern(name)) continue;
-      projects[j] = this.createRef(name, projects, undefined);
+      projects[j] = this.createRef(name);
     }
   }
 
   // Builds a sentinel and registers it.
   private createRef(
     referencedName: string,
-    parent: unknown,
-    key: string | undefined,
     targetPart?: string
   ): RootRef | UsageRef {
     const referencedRoot = this.getNameMap()[referencedName]?.root;
     const ref: RootRef | UsageRef =
       referencedRoot !== undefined
-        ? new RootRef(referencedRoot, parent, key, targetPart)
-        : new UsageRef(referencedName, parent, key, targetPart);
-
-    this.allRefs.add(ref);
+        ? new RootRef(referencedRoot, targetPart)
+        : new UsageRef(referencedName, targetPart);
 
     if (ref instanceof UsageRef) {
       let set = this.pendingByName.get(referencedName);
@@ -236,28 +208,73 @@ export class ProjectNameInNodePropsManager {
     }
   }
 
-  // Writes each sentinel's current resolved name back into its owning slot.
-  // Called once after all plugin results have been merged.
+  // Resolves every sentinel in the merged rootMap in place. Sweeping the
+  // final config (rather than writing through back-references held by the
+  // sentinels) covers sentinels that merges copied into arrays other than
+  // the one they were created in, e.g. a pattern target's dependsOn applied
+  // to every matching target. Called once after all plugin results have
+  // been merged.
   applySubstitutions(rootMap: Record<string, ProjectConfiguration>): void {
     const nameByRoot: Record<string, string | undefined> = {};
     for (const root in rootMap) {
       nameByRoot[root] = rootMap[root]?.name;
     }
 
-    for (const ref of this.allRefs) {
-      const finalName = this.resolveFinalName(ref, nameByRoot);
-      if (finalName === undefined) continue;
-
-      const replacement =
-        ref.targetPart !== undefined
-          ? `${finalName}:${ref.targetPart}`
-          : finalName;
-
-      this.writeReplacement(ref, replacement);
+    for (const root in rootMap) {
+      const targets = rootMap[root]?.targets;
+      if (!targets) continue;
+      for (const targetName in targets) {
+        const targetConfig = targets[targetName];
+        if (!targetConfig || typeof targetConfig !== 'object') continue;
+        if (Array.isArray(targetConfig.inputs)) {
+          this.substituteInArray(targetConfig.inputs, nameByRoot);
+        }
+        if (Array.isArray(targetConfig.dependsOn)) {
+          this.substituteInArray(targetConfig.dependsOn, nameByRoot);
+        }
+      }
     }
 
-    this.allRefs.clear();
     this.pendingByName.clear();
+  }
+
+  private substituteInArray(
+    entries: Array<InputEntry | DependsOnEntry>,
+    nameByRoot: Record<string, string | undefined>
+  ): void {
+    for (let i = 0; i < entries.length; i++) {
+      const entry = entries[i];
+      if (isNameRef(entry)) {
+        const finalName = this.resolveFinalName(entry, nameByRoot);
+        if (finalName !== undefined) {
+          entries[i] =
+            entry.targetPart !== undefined
+              ? `${finalName}:${entry.targetPart}`
+              : finalName;
+        }
+        continue;
+      }
+      if (!entry || typeof entry !== 'object' || !('projects' in entry)) {
+        continue;
+      }
+      const element = entry as { projects: unknown };
+      if (isNameRef(element.projects)) {
+        const finalName = this.resolveFinalName(element.projects, nameByRoot);
+        if (finalName !== undefined) {
+          element.projects = finalName;
+        }
+      } else if (Array.isArray(element.projects)) {
+        const projects = element.projects as ProjectsEntry[];
+        for (let j = 0; j < projects.length; j++) {
+          const name = projects[j];
+          if (!isNameRef(name)) continue;
+          const finalName = this.resolveFinalName(name, nameByRoot);
+          if (finalName !== undefined) {
+            projects[j] = finalName;
+          }
+        }
+      }
+    }
   }
 
   private resolveFinalName(
@@ -269,20 +286,5 @@ export class ProjectNameInNodePropsManager {
     }
     // Unpromoted forward ref — best effort, fall back to the written name.
     return this.getNameMap()[ref.value]?.name ?? ref.value;
-  }
-
-  private writeReplacement(ref: NameRef, replacement: string): void {
-    const parent = ref.parent;
-    if (Array.isArray(parent)) {
-      // One sentinel may appear at multiple indices (e.g. `[..., ...]`
-      // pushed the same reference twice via spread), so replace all.
-      for (let i = 0; i < parent.length; i++) {
-        if (parent[i] === ref) parent[i] = replacement;
-      }
-      return;
-    }
-    if (parent && typeof parent === 'object' && ref.key !== undefined) {
-      (parent as Record<string, unknown>)[ref.key] = replacement;
-    }
   }
 }

--- a/packages/nx/src/project-graph/utils/project-configuration/project-nodes-manager.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/project-nodes-manager.ts
@@ -361,7 +361,7 @@ export class ProjectNodesManager {
    *
    * Pass a different `mergedRootMap` for the default-plugin intermediate
    * pass, then call again with `this.rootMap` after it's applied so
-   * sentinel parents rebind onto the final arrays.
+   * name refs introduced by that merge are sentinelized as well.
    */
   registerNameRefs(
     pluginResultProjects?: Record<


### PR DESCRIPTION
## Current Behavior

Name-ref sentinels (used to keep `dependsOn`/`inputs` project references correct across renames) are written back through a pointer to the array they were created in. Merges copy sentinels **by reference** into fresh arrays — most visibly when a project.json pattern target (e.g. `e2e-ci--**/**`) with a `"..."` spread is applied to every matching atomized target. The copies never get resolved, leaving raw internal objects (`RootRef { value, parent, targetPart }`) in the final project configuration, and task graph creation crashes with:

```
NX   pattern is not iterable
```

## Expected Behavior

Every name ref resolves to its project name wherever it ends up. `applySubstitutions` now sweeps the merged rootMap and resolves each sentinel in place, covering arrays a sentinel was copied into. Since write-back no longer depends on back-references, the `parent`/`key` fields, the `allRefs` registry, and the parent-rebinding branches are removed.

The new integration test reproduces the exact corruption on the previous implementation (raw `RootRef` objects in the atomized targets' `dependsOn`) and passes with the sweep.

## Related Issue(s)

Found while using `"..."` in the `dependsOn` of atomized e2e pattern targets in this repo (see `e2e/gradle/project.json` / `e2e/maven/project.json`); that cleanup was reverted from #36302 and can be re-applied once this fix ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qjm3xvLS2vLRsaxt4vv56d

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/PR-for-pnpm-11-ERR_PNPM_IGNORED_BUILDS-fix-f71af2eb)
<!-- polygraph-session-end -->