### PR TITLE
fix(core): support pnpm 11 patched dependency hashes

### DIFF
--- a/packages/nx/src/plugins/js/lock-file/pnpm-parser.spec.ts
+++ b/packages/nx/src/plugins/js/lock-file/pnpm-parser.spec.ts
@@ -2111,6 +2111,45 @@ snapshots:
       });
     });
 
+    it('should include pnpm 11 scalar patch hash in external node hash', () => {
+      const lockFile = `lockfileVersion: '9.0'
+
+patchedDependencies:
+  vitest@3.2.4: pnpm-11-patch-hash
+
+importers:
+
+  .:
+    dependencies:
+      vitest:
+        specifier: 3.2.4
+        version: 3.2.4
+
+packages:
+
+  vitest@3.2.4:
+    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
+
+snapshots:
+
+  vitest@3.2.4: {}`;
+
+      const { nodes: externalNodes } = getPnpmLockfileNodes(
+        lockFile,
+        'test-lockfile-hash-pnpm-11'
+      );
+
+      expect(externalNodes['npm:vitest']).toMatchObject({
+        type: 'npm',
+        name: 'npm:vitest',
+        data: {
+          version: '3.2.4',
+          packageName: 'vitest',
+          hash: 'sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==|pnpm-11-patch-hash',
+        },
+      });
+    });
+
     it('should detect patch hash changes', () => {
       const lockFileWithPatch = `lockfileVersion: '9.0'
 

--- a/packages/nx/src/plugins/js/lock-file/pnpm-parser.ts
+++ b/packages/nx/src/plugins/js/lock-file/pnpm-parser.ts
@@ -250,7 +250,13 @@ function getNodes(
   if (data.patchedDependencies) {
     for (const specifier of Object.keys(data.patchedDependencies)) {
       const patchInfo = data.patchedDependencies[specifier];
-      if (patchInfo && typeof patchInfo === 'object' && 'hash' in patchInfo) {
+      const patchHash =
+        typeof patchInfo === 'string'
+          ? patchInfo
+          : patchInfo && typeof patchInfo === 'object' && 'hash' in patchInfo
+            ? patchInfo.hash
+            : undefined;
+      if (patchHash) {
         const packageName = extractNameFromKey(specifier, false);
         const versionSpecifier = getVersion(specifier, packageName) || null;
         if (!patchEntriesByPackage.has(packageName)) {
@@ -258,7 +264,7 @@ function getNodes(
         }
         patchEntriesByPackage.get(packageName).push({
           versionSpecifier,
-          hash: patchInfo.hash,
+          hash: patchHash,
         });
       }
     }


### PR DESCRIPTION
## Current Behavior

Nx includes pnpm patch hashes in external dependency hashes only when `patchedDependencies` uses the older object form with `hash` and `path`. pnpm 11 serializes these values as scalar hash strings, so Nx silently falls back to the registry integrity and can restore stale cached tasks after a patch changes.

## Expected Behavior

Nx accepts both the older object form and pnpm 11's scalar form, preserving existing selector matching while combining either patch hash with the package integrity. The regression test covers pnpm 11 while the existing object-form tests continue to verify backwards compatibility.

## Related Issue(s)

Follow-up to https://github.com/nrwl/nx/pull/33551 after pnpm changed the lockfile representation in https://github.com/pnpm/pnpm/pull/10911.

## Testing

- `pnpm exec jest --config packages/nx/jest.config.cts packages/nx/src/plugins/js/lock-file/pnpm-parser.spec.ts --runInBand` (40 tests)
- `pnpm exec tsc -p packages/nx/tsconfig.lib.json --noEmit`
- `pnpm exec eslint --no-ignore packages/nx/src/plugins/js/lock-file/pnpm-parser.ts packages/nx/src/plugins/js/lock-file/pnpm-parser.spec.ts`

The full `pnpm nx prepush` command cannot construct the project graph locally because the repository's .NET SDK is unavailable. The same failure reproduces on clean `upstream/master` before task execution.

🤖 Prepared with Amp.