### PR TITLE
fix(core): harden supply-chain surface flagged by socket

### DIFF
--- a/graph/client/webpack.config.js
+++ b/graph/client/webpack.config.js
@@ -4,6 +4,24 @@ const { NxAppWebpackPlugin } = require('@nx/webpack/app-plugin');
 // nx-ignore-next-line
 const { NxReactWebpackPlugin } = require('@nx/react/webpack-plugin');
 
+// Webpack's global runtime module falls back to `new Function("return this")()`
+// to resolve the global object. Supply-chain scanners flag that as `eval` usage.
+// The graph app only ever runs in browsers/webviews where `globalThis` exists,
+// so rewrite the runtime module to assign it directly - same value, no `Function`.
+class RemoveEvalGlobalPlugin {
+  apply(compiler) {
+    const { RuntimeGlobals, Template } = compiler.webpack;
+    compiler.hooks.thisCompilation.tap('RemoveEvalGlobal', (compilation) => {
+      compilation.hooks.runtimeModule.tap('RemoveEvalGlobal', (module) => {
+        if (module.name === 'global') {
+          module.generate = () =>
+            Template.asString([`${RuntimeGlobals.global} = globalThis;`]);
+        }
+      });
+    });
+  }
+}
+
 module.exports = {
   output: {
     path: join(__dirname, 'dist'),
@@ -23,6 +41,7 @@ module.exports = {
     },
   },
   plugins: [
+    new RemoveEvalGlobalPlugin(),
     new NxAppWebpackPlugin({
       index: './src/index.html',
       compiler: 'babel',

--- a/packages/nx/src/command-line/migrate/migrate-ui-api.ts
+++ b/packages/nx/src/command-line/migrate/migrate-ui-api.ts
@@ -1,4 +1,4 @@
-import { execSync, spawn, ChildProcess } from 'child_process';
+import { execSync, execFileSync, spawn, ChildProcess } from 'child_process';
 import { existsSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import type { MigrationDetailsWithId } from '../../config/misc-interfaces';
@@ -116,20 +116,22 @@ export function finishMigrationProcess(
     windowsHide: true,
   });
 
-  execSync(`git commit -m "${commitMessage}" --no-verify`, {
+  // Pass args as an array (no shell) so commit messages and refs read from
+  // migrations.json can't break out into shell command injection.
+  execFileSync('git', ['commit', '-m', commitMessage, '--no-verify'], {
     cwd: workspacePath,
     encoding: 'utf-8',
     windowsHide: true,
   });
 
   if (squashCommits && initialGitRef) {
-    execSync(`git reset --soft ${initialGitRef.ref}`, {
+    execFileSync('git', ['reset', '--soft', initialGitRef.ref], {
       cwd: workspacePath,
       encoding: 'utf-8',
       windowsHide: true,
     });
 
-    execSync(`git commit -m "${commitMessage}" --no-verify`, {
+    execFileSync('git', ['commit', '-m', commitMessage, '--no-verify'], {
       cwd: workspacePath,
       encoding: 'utf-8',
       windowsHide: true,
@@ -489,7 +491,7 @@ export function undoMigration(workspacePath: string, id: string) {
     // `existing.ref` is the unmodified HEAD at run time, so `ref^` would
     // reset past unrelated history. Only flip the metadata to skipped.
     if (existing.changedFiles.length > 0) {
-      execSync(`git reset --hard ${existing.ref}^`, {
+      execFileSync('git', ['reset', '--hard', `${existing.ref}^`], {
         cwd: workspacePath,
         encoding: 'utf-8',
         windowsHide: true,

--- a/packages/nx/src/daemon/server/server.ts
+++ b/packages/nx/src/daemon/server/server.ts
@@ -254,6 +254,23 @@ async function handleMessage(socket: Socket, data: string) {
       new Error(`Unsupported payload sent to daemon server: ${unparsedPayload}`)
     );
   }
+
+  // Validate the deserialized payload shape before dispatching on `payload.type`.
+  // The daemon deserializes client-controlled data (JSON or v8), so reject
+  // anything that isn't a well-formed message object instead of acting on it.
+  if (
+    payload == null ||
+    typeof payload !== 'object' ||
+    typeof payload.type !== 'string'
+  ) {
+    await respondWithErrorAndExit(
+      socket,
+      `Invalid payload from the client`,
+      new Error(`Malformed message sent to daemon server`)
+    );
+    return;
+  }
+
   serverLogger.log(`Received ${mode} message of type ${payload.type}`);
 
   if (isDaemonMessage(payload) && payload.env) {


### PR DESCRIPTION
## Current Behavior

Socket flags several supply-chain alerts on `nx`. Three are real and fixable:

- Graph webpack bundle emits `new Function("return this")()` (webpack's global runtime module), flagged as `eval` usage.
- `migrate-ui-api` runs `git` via shell strings interpolating the commit message and refs read from `migrations.json` - a shell command injection vector.
- The daemon dispatches on `payload.type` immediately after `v8`/JSON deserializing client bytes, with no shape validation.

## Expected Behavior

- Graph runtime assigns `__webpack_require__.g = globalThis` directly - no `Function`/`eval`. Same value; the graph app only runs where `globalThis` exists. Verified the real release build has zero `new Function` in the graph dist.
- Git calls use `execFileSync` argument arrays (no shell), so refs and messages cannot break out.
- The daemon rejects non-object / missing-`type` payloads before dispatch.

All changes are behaviorally inert for legitimate inputs. The remaining Socket alerts (shell/network/fs/install-scripts) are inherent to Nx and out of scope here.

## Related Issue(s)

NXC-4674

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/nxc-4674-sockdev-f7a09d1e)
<!-- polygraph-session-end -->