### PR TITLE
fix(misc): bump ci-workflow generator to node 24 and current action majors

### DIFF
--- a/astro-docs/src/content/docs/features/CI Features/distribute-task-execution.mdoc
+++ b/astro-docs/src/content/docs/features/CI Features/distribute-task-execution.mdoc
@@ -281,7 +281,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       ...
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           filter: tree:0
@@ -289,9 +289,9 @@ jobs:
       - run: pnpm dlx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
       # Cache node_modules
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: 'pnpm'
       ...
 

--- a/astro-docs/src/content/docs/features/CI Features/split-e2e-tasks.mdoc
+++ b/astro-docs/src/content/docs/features/CI Features/split-e2e-tasks.mdoc
@@ -448,20 +448,20 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           filter: tree:0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         with:
           version: 9
 
       - run: pnpm dlx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="e2e-ci"
 
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: 'pnpm'
 
       - run: pnpm install --frozen-lockfile

--- a/astro-docs/src/content/docs/getting-started/Tutorials/gradle-tutorial.mdoc
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/gradle-tutorial.mdoc
@@ -2489,13 +2489,13 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           filter: tree:0
           fetch-depth: 0
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
       - name: Set up JDK 21 for x64
         uses: actions/setup-java@v4
         with:

--- a/astro-docs/src/content/docs/getting-started/setup-ci.mdoc
+++ b/astro-docs/src/content/docs/getting-started/setup-ci.mdoc
@@ -93,7 +93,7 @@ Use `nx affected` to run tasks only for projects impacted by the PR's changes:
 
 ```yaml {% meta="{5}" %}
 # .github/workflows/ci.yml
-- uses: actions/checkout@v4
+- uses: actions/checkout@v7
   with:
     fetch-depth: 0
 - run: npx nx affected -t lint test build

--- a/astro-docs/src/content/docs/guides/Adopting Nx/adding-to-existing-project.mdoc
+++ b/astro-docs/src/content/docs/guides/Adopting Nx/adding-to-existing-project.mdoc
@@ -357,7 +357,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           filter: tree:0
@@ -367,9 +367,9 @@ jobs:
       # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
       # Connect your workspace by running "nx connect" and uncomment this
       - run: npx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: 'npm'
       - run: npm ci
       - uses: nrwl/nx-set-shas@v5

--- a/astro-docs/src/content/docs/guides/Adopting Nx/adding-to-monorepo.mdoc
+++ b/astro-docs/src/content/docs/guides/Adopting Nx/adding-to-monorepo.mdoc
@@ -375,7 +375,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           filter: tree:0
@@ -385,9 +385,9 @@ jobs:
       # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
       # Connect your workspace by running "nx connect" and uncomment this
       - run: npx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
-      - uses: actions/setup-node@v3
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: 'npm'
       - run: npm ci
       - uses: nrwl/nx-set-shas@v5

--- a/astro-docs/src/content/docs/guides/Nx Cloud/bring-your-own-compute.mdoc
+++ b/astro-docs/src/content/docs/guides/Nx Cloud/bring-your-own-compute.mdoc
@@ -39,7 +39,7 @@ jobs:
     name: Nx Cloud - Main Job
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           # We need to fetch all branches and commits so that Nx affected has a base to compare against.
           fetch-depth: 0
@@ -51,9 +51,9 @@ jobs:
           package-json-path: '${{ github.workspace }}/package.json'
 
       - name: Use the package manager cache if available
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: 'npm'
 
       - name: Install dependencies
@@ -85,7 +85,7 @@ jobs:
         agent: [1, 2, 3]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       # Set node/npm/yarn versions using volta
       - uses: volta-cli/action@v4
@@ -93,9 +93,9 @@ jobs:
           package-json-path: '${{ github.workspace }}/package.json'
 
       - name: Use the package manager cache if available
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: 'npm'
 
       - name: Install dependencies

--- a/astro-docs/src/content/docs/guides/Nx Cloud/setup-ci.mdoc
+++ b/astro-docs/src/content/docs/guides/Nx Cloud/setup-ci.mdoc
@@ -46,7 +46,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           filter: tree:0
           fetch-depth: 0
@@ -58,9 +58,9 @@ jobs:
       # - run: npx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
       # Cache node_modules
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: 'npm'
 
       - run: npm ci

--- a/astro-docs/src/content/docs/guides/Nx Release/publish-in-ci-cd.mdoc
+++ b/astro-docs/src/content/docs/guides/Nx Release/publish-in-ci-cd.mdoc
@@ -146,15 +146,15 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           filter: tree:0
 
       - name: Install Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies
@@ -225,14 +225,14 @@ jobs:
       id-token: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Install Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           registry-url: https://registry.npmjs.org/
 
       - name: Install dependencies
@@ -383,12 +383,12 @@ jobs:
   publish:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
 
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
 
       - name: Install dependencies
         run: npm ci

--- a/astro-docs/src/content/docs/reference/Nx Cloud/assignment-rules.mdoc
+++ b/astro-docs/src/content/docs/reference/Nx Cloud/assignment-rules.mdoc
@@ -368,11 +368,11 @@ jobs:
         agent: [1, 2, 3]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: 'npm'
 
       - ... # other setup steps you may need
@@ -396,11 +396,11 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: 24
           cache: 'npm'
 
       - ... # other setup steps you may need

--- a/packages/workspace/src/generators/ci-workflow/__snapshots__/ci-workflow.spec.ts.snap
+++ b/packages/workspace/src/generators/ci-workflow/__snapshots__/ci-workflow.spec.ts.snap
@@ -67,7 +67,7 @@ jobs:
 `;
 
 exports[`CI Workflow generator connected to nxCloud optional e2e should add e2e to bitbucket pipelines config 1`] = `
-"image: node:20
+"image: node:24
 
 clone:
   depth: full
@@ -177,7 +177,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           filter: tree:0
           fetch-depth: 0
@@ -189,9 +189,9 @@ jobs:
       # - run: npx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="e2e-ci"
 
       # Cache node_modules
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: 'npm'
 
       - run: npm ci
@@ -225,7 +225,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           filter: tree:0
           fetch-depth: 0
@@ -237,9 +237,9 @@ jobs:
       # - run: npx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="e2e-ci"
 
       # Cache node_modules
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: 'npm'
 
       - run: npm ci
@@ -391,7 +391,7 @@ jobs:
 `;
 
 exports[`CI Workflow generator connected to nxCloud with bun should generate bitbucket pipelines config 1`] = `
-"image: node:20
+"image: node:24
 
 clone:
   depth: full
@@ -444,7 +444,7 @@ pipelines:
 `;
 
 exports[`CI Workflow generator connected to nxCloud with bun should generate bitbucket pipelines config when packageManager is set to \${packageManager} in package.json 1`] = `
-"image: node:20
+"image: node:24
 
 clone:
   depth: full
@@ -603,12 +603,12 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           filter: tree:0
           fetch-depth: 0
 
-      - uses: oven-sh/setup-bun@v1
+      - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
@@ -647,12 +647,12 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           filter: tree:0
           fetch-depth: 0
 
-      - uses: oven-sh/setup-bun@v1
+      - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
@@ -691,12 +691,12 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           filter: tree:0
           fetch-depth: 0
 
-      - uses: oven-sh/setup-bun@v1
+      - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
@@ -719,7 +719,7 @@ jobs:
 `;
 
 exports[`CI Workflow generator connected to nxCloud with bun should generate gitlab config 1`] = `
-"image: node:20
+"image: node:24
 variables:
   CI: 'true'
   GIT_DEPTH: 0
@@ -882,7 +882,7 @@ jobs:
 `;
 
 exports[`CI Workflow generator connected to nxCloud with npm should generate bitbucket pipelines config 1`] = `
-"image: node:20
+"image: node:24
 
 clone:
   depth: full
@@ -931,7 +931,7 @@ pipelines:
 `;
 
 exports[`CI Workflow generator connected to nxCloud with npm should generate bitbucket pipelines config when packageManager is set to \${packageManager} in package.json 1`] = `
-"image: node:20
+"image: node:24
 
 clone:
   depth: full
@@ -1078,7 +1078,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           filter: tree:0
           fetch-depth: 0
@@ -1090,9 +1090,9 @@ jobs:
       # - run: npx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
       # Cache node_modules
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: 'npm'
 
       - run: npm ci
@@ -1124,7 +1124,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           filter: tree:0
           fetch-depth: 0
@@ -1136,9 +1136,9 @@ jobs:
       # - run: npx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
       # Cache node_modules
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: 'npm'
 
       - run: npm ci
@@ -1170,7 +1170,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           filter: tree:0
           fetch-depth: 0
@@ -1182,9 +1182,9 @@ jobs:
       # - run: npx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
       # Cache node_modules
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: 'npm'
 
       - run: npm ci
@@ -1200,7 +1200,7 @@ jobs:
 `;
 
 exports[`CI Workflow generator connected to nxCloud with npm should generate gitlab config 1`] = `
-"image: node:20
+"image: node:24
 variables:
   CI: 'true'
   GIT_DEPTH: 0
@@ -1277,7 +1277,7 @@ jobs:
         env:
           AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)
 
-      - script: npm install --prefix=$HOME/.local -g pnpm@8
+      - script: npm install --prefix=$HOME/.local -g pnpm@11
         displayName: Install PNPM
 
       # This enables task distribution via Nx Cloud
@@ -1344,7 +1344,7 @@ jobs:
         env:
           AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)
 
-      - script: npm install --prefix=$HOME/.local -g pnpm@8
+      - script: npm install --prefix=$HOME/.local -g pnpm@11
         displayName: Install PNPM
 
       # This enables task distribution via Nx Cloud
@@ -1367,7 +1367,7 @@ jobs:
 `;
 
 exports[`CI Workflow generator connected to nxCloud with pnpm should generate bitbucket pipelines config 1`] = `
-"image: node:20
+"image: node:24
 
 clone:
   depth: full
@@ -1380,7 +1380,7 @@ pipelines:
           script:
             - export NX_BRANCH=$BITBUCKET_PR_ID
 
-            - npm install --prefix=$HOME/.local -g pnpm@8
+            - npm install --prefix=$HOME/.local -g pnpm@11
 
             # This enables task distribution via Nx Cloud
             # Run this command as early as possible, before dependencies are installed
@@ -1409,7 +1409,7 @@ pipelines:
             # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
             - pnpm dlx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
-            - npm install --prefix=$HOME/.local -g pnpm@8
+            - npm install --prefix=$HOME/.local -g pnpm@11
 
             - pnpm install --frozen-lockfile
 
@@ -1420,7 +1420,7 @@ pipelines:
 `;
 
 exports[`CI Workflow generator connected to nxCloud with pnpm should generate bitbucket pipelines config when packageManager is set to \${packageManager} in package.json 1`] = `
-"image: node:20
+"image: node:24
 
 clone:
   depth: full
@@ -1433,7 +1433,7 @@ pipelines:
           script:
             - export NX_BRANCH=$BITBUCKET_PR_ID
 
-            - npm install --prefix=$HOME/.local -g pnpm@8
+            - npm install --prefix=$HOME/.local -g pnpm@11
 
             # This enables task distribution via Nx Cloud
             # Run this command as early as possible, before dependencies are installed
@@ -1462,7 +1462,7 @@ pipelines:
             # Learn more at https://nx.dev/ci/reference/nx-cloud-cli#npx-nxcloud-startcirun
             - pnpm dlx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
-            - npm install --prefix=$HOME/.local -g pnpm@8
+            - npm install --prefix=$HOME/.local -g pnpm@11
 
             - pnpm install --frozen-lockfile
 
@@ -1487,7 +1487,7 @@ jobs:
 
       - run:
           name: Install PNPM
-          command: npm install --prefix=$HOME/.local -g pnpm@8
+          command: npm install --prefix=$HOME/.local -g pnpm@11
 
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
@@ -1532,7 +1532,7 @@ jobs:
 
       - run:
           name: Install PNPM
-          command: npm install --prefix=$HOME/.local -g pnpm@8
+          command: npm install --prefix=$HOME/.local -g pnpm@11
 
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
@@ -1579,15 +1579,15 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           filter: tree:0
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
-          version: 9.8.0
+          version: 11.13.0
           run_install: false
 
       # This enables task distribution via Nx Cloud
@@ -1597,9 +1597,9 @@ jobs:
       # - run: pnpm dlx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
       # Cache node_modules
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: 'pnpm'
 
       - run: pnpm install --frozen-lockfile
@@ -1631,12 +1631,12 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           filter: tree:0
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
           run_install: false
@@ -1648,9 +1648,9 @@ jobs:
       # - run: pnpm dlx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
       # Cache node_modules
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: 'pnpm'
 
       - run: pnpm install --frozen-lockfile
@@ -1682,15 +1682,15 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           filter: tree:0
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
-          version: 9.8.0
+          version: 11.13.0
           run_install: false
 
       # This enables task distribution via Nx Cloud
@@ -1700,9 +1700,9 @@ jobs:
       # - run: pnpm dlx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
       # Cache node_modules
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: 'pnpm'
 
       - run: pnpm install --frozen-lockfile
@@ -1718,7 +1718,7 @@ jobs:
 `;
 
 exports[`CI Workflow generator connected to nxCloud with pnpm should generate gitlab config 1`] = `
-"image: node:20
+"image: node:24
 variables:
   CI: 'true'
   GIT_DEPTH: 0
@@ -1730,7 +1730,7 @@ CI:
     - main
     - merge_requests
   script:
-    - npm install --prefix=$HOME/.local -g pnpm@8
+    - npm install --prefix=$HOME/.local -g pnpm@11
 
     # This enables task distribution via Nx Cloud
     # Run this command as early as possible, before dependencies are installed
@@ -1881,7 +1881,7 @@ jobs:
 `;
 
 exports[`CI Workflow generator connected to nxCloud with yarn should generate bitbucket pipelines config 1`] = `
-"image: node:20
+"image: node:24
 
 clone:
   depth: full
@@ -1930,7 +1930,7 @@ pipelines:
 `;
 
 exports[`CI Workflow generator connected to nxCloud with yarn should generate bitbucket pipelines config when packageManager is set to \${packageManager} in package.json 1`] = `
-"image: node:20
+"image: node:24
 
 clone:
   depth: full
@@ -2077,7 +2077,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           filter: tree:0
           fetch-depth: 0
@@ -2089,9 +2089,9 @@ jobs:
       # - run: npx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
       # Cache node_modules
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: 'yarn'
 
       - run: yarn install --frozen-lockfile
@@ -2123,7 +2123,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           filter: tree:0
           fetch-depth: 0
@@ -2137,9 +2137,9 @@ jobs:
       # - run: npx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
       # Cache node_modules
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: 'yarn'
 
       - run: yarn install --frozen-lockfile
@@ -2171,7 +2171,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           filter: tree:0
           fetch-depth: 0
@@ -2183,9 +2183,9 @@ jobs:
       # - run: npx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
       # Cache node_modules
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: 'yarn'
 
       - run: yarn install --frozen-lockfile
@@ -2201,7 +2201,7 @@ jobs:
 `;
 
 exports[`CI Workflow generator connected to nxCloud with yarn should generate gitlab config 1`] = `
-"image: node:20
+"image: node:24
 variables:
   CI: 'true'
   GIT_DEPTH: 0
@@ -2300,7 +2300,7 @@ jobs:
 `;
 
 exports[`CI Workflow generator not connected to nxCloud optional e2e should add e2e to bitbucket pipelines config 1`] = `
-"image: node:20
+"image: node:24
 
 clone:
   depth: full
@@ -2411,7 +2411,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           filter: tree:0
           fetch-depth: 0
@@ -2423,9 +2423,9 @@ jobs:
       # - run: npx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="e2e-ci"
 
       # Cache node_modules
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: 'npm'
 
       - run: npm ci
@@ -2459,7 +2459,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           filter: tree:0
           fetch-depth: 0
@@ -2471,9 +2471,9 @@ jobs:
       # - run: npx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="e2e-ci"
 
       # Cache node_modules
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: 'npm'
 
       - run: npm ci
@@ -2625,7 +2625,7 @@ jobs:
 `;
 
 exports[`CI Workflow generator not connected to nxCloud with bun should generate bitbucket pipelines config 1`] = `
-"image: node:20
+"image: node:24
 
 clone:
   depth: full
@@ -2679,7 +2679,7 @@ pipelines:
 `;
 
 exports[`CI Workflow generator not connected to nxCloud with bun should generate bitbucket pipelines config when packageManager is set to \${packageManager} in package.json 1`] = `
-"image: node:20
+"image: node:24
 
 clone:
   depth: full
@@ -2839,12 +2839,12 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           filter: tree:0
           fetch-depth: 0
 
-      - uses: oven-sh/setup-bun@v1
+      - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
@@ -2883,12 +2883,12 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           filter: tree:0
           fetch-depth: 0
 
-      - uses: oven-sh/setup-bun@v1
+      - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
@@ -2927,12 +2927,12 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           filter: tree:0
           fetch-depth: 0
 
-      - uses: oven-sh/setup-bun@v1
+      - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 
@@ -2955,7 +2955,7 @@ jobs:
 `;
 
 exports[`CI Workflow generator not connected to nxCloud with bun should generate gitlab config 1`] = `
-"image: node:20
+"image: node:24
 variables:
   CI: 'true'
   GIT_DEPTH: 0
@@ -3118,7 +3118,7 @@ jobs:
 `;
 
 exports[`CI Workflow generator not connected to nxCloud with npm should generate bitbucket pipelines config 1`] = `
-"image: node:20
+"image: node:24
 
 clone:
   depth: full
@@ -3168,7 +3168,7 @@ pipelines:
 `;
 
 exports[`CI Workflow generator not connected to nxCloud with npm should generate bitbucket pipelines config when packageManager is set to \${packageManager} in package.json 1`] = `
-"image: node:20
+"image: node:24
 
 clone:
   depth: full
@@ -3316,7 +3316,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           filter: tree:0
           fetch-depth: 0
@@ -3328,9 +3328,9 @@ jobs:
       # - run: npx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
       # Cache node_modules
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: 'npm'
 
       - run: npm ci
@@ -3362,7 +3362,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           filter: tree:0
           fetch-depth: 0
@@ -3374,9 +3374,9 @@ jobs:
       # - run: npx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
       # Cache node_modules
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: 'npm'
 
       - run: npm ci
@@ -3408,7 +3408,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           filter: tree:0
           fetch-depth: 0
@@ -3420,9 +3420,9 @@ jobs:
       # - run: npx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
       # Cache node_modules
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: 'npm'
 
       - run: npm ci
@@ -3438,7 +3438,7 @@ jobs:
 `;
 
 exports[`CI Workflow generator not connected to nxCloud with npm should generate gitlab config 1`] = `
-"image: node:20
+"image: node:24
 variables:
   CI: 'true'
   GIT_DEPTH: 0
@@ -3515,7 +3515,7 @@ jobs:
         env:
           AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)
 
-      - script: npm install --prefix=$HOME/.local -g pnpm@8
+      - script: npm install --prefix=$HOME/.local -g pnpm@11
         displayName: Install PNPM
 
       # This enables task distribution via Nx Cloud
@@ -3582,7 +3582,7 @@ jobs:
         env:
           AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)
 
-      - script: npm install --prefix=$HOME/.local -g pnpm@8
+      - script: npm install --prefix=$HOME/.local -g pnpm@11
         displayName: Install PNPM
 
       # This enables task distribution via Nx Cloud
@@ -3605,7 +3605,7 @@ jobs:
 `;
 
 exports[`CI Workflow generator not connected to nxCloud with pnpm should generate bitbucket pipelines config 1`] = `
-"image: node:20
+"image: node:24
 
 clone:
   depth: full
@@ -3618,7 +3618,7 @@ pipelines:
           script:
             - export NX_BRANCH=$BITBUCKET_PR_ID
 
-            - npm install --prefix=$HOME/.local -g pnpm@8
+            - npm install --prefix=$HOME/.local -g pnpm@11
 
             # This enables task distribution via Nx Cloud
             # Run this command as early as possible, before dependencies are installed
@@ -3648,7 +3648,7 @@ pipelines:
             # Connect your workspace by running "nx connect" and uncomment this
             # - pnpm dlx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
-            - npm install --prefix=$HOME/.local -g pnpm@8
+            - npm install --prefix=$HOME/.local -g pnpm@11
 
             - pnpm install --frozen-lockfile
 
@@ -3659,7 +3659,7 @@ pipelines:
 `;
 
 exports[`CI Workflow generator not connected to nxCloud with pnpm should generate bitbucket pipelines config when packageManager is set to \${packageManager} in package.json 1`] = `
-"image: node:20
+"image: node:24
 
 clone:
   depth: full
@@ -3672,7 +3672,7 @@ pipelines:
           script:
             - export NX_BRANCH=$BITBUCKET_PR_ID
 
-            - npm install --prefix=$HOME/.local -g pnpm@8
+            - npm install --prefix=$HOME/.local -g pnpm@11
 
             # This enables task distribution via Nx Cloud
             # Run this command as early as possible, before dependencies are installed
@@ -3702,7 +3702,7 @@ pipelines:
             # Connect your workspace by running "nx connect" and uncomment this
             # - pnpm dlx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
-            - npm install --prefix=$HOME/.local -g pnpm@8
+            - npm install --prefix=$HOME/.local -g pnpm@11
 
             - pnpm install --frozen-lockfile
 
@@ -3727,7 +3727,7 @@ jobs:
 
       - run:
           name: Install PNPM
-          command: npm install --prefix=$HOME/.local -g pnpm@8
+          command: npm install --prefix=$HOME/.local -g pnpm@11
 
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
@@ -3772,7 +3772,7 @@ jobs:
 
       - run:
           name: Install PNPM
-          command: npm install --prefix=$HOME/.local -g pnpm@8
+          command: npm install --prefix=$HOME/.local -g pnpm@11
 
       # This enables task distribution via Nx Cloud
       # Run this command as early as possible, before dependencies are installed
@@ -3819,15 +3819,15 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           filter: tree:0
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
-          version: 9.8.0
+          version: 11.13.0
           run_install: false
 
       # This enables task distribution via Nx Cloud
@@ -3837,9 +3837,9 @@ jobs:
       # - run: pnpm dlx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
       # Cache node_modules
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: 'pnpm'
 
       - run: pnpm install --frozen-lockfile
@@ -3871,12 +3871,12 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           filter: tree:0
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
           run_install: false
@@ -3888,9 +3888,9 @@ jobs:
       # - run: pnpm dlx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
       # Cache node_modules
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: 'pnpm'
 
       - run: pnpm install --frozen-lockfile
@@ -3922,15 +3922,15 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           filter: tree:0
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:
-          version: 9.8.0
+          version: 11.13.0
           run_install: false
 
       # This enables task distribution via Nx Cloud
@@ -3940,9 +3940,9 @@ jobs:
       # - run: pnpm dlx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
       # Cache node_modules
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: 'pnpm'
 
       - run: pnpm install --frozen-lockfile
@@ -3958,7 +3958,7 @@ jobs:
 `;
 
 exports[`CI Workflow generator not connected to nxCloud with pnpm should generate gitlab config 1`] = `
-"image: node:20
+"image: node:24
 variables:
   CI: 'true'
   GIT_DEPTH: 0
@@ -3970,7 +3970,7 @@ CI:
     - main
     - merge_requests
   script:
-    - npm install --prefix=$HOME/.local -g pnpm@8
+    - npm install --prefix=$HOME/.local -g pnpm@11
 
     # This enables task distribution via Nx Cloud
     # Run this command as early as possible, before dependencies are installed
@@ -4121,7 +4121,7 @@ jobs:
 `;
 
 exports[`CI Workflow generator not connected to nxCloud with yarn should generate bitbucket pipelines config 1`] = `
-"image: node:20
+"image: node:24
 
 clone:
   depth: full
@@ -4171,7 +4171,7 @@ pipelines:
 `;
 
 exports[`CI Workflow generator not connected to nxCloud with yarn should generate bitbucket pipelines config when packageManager is set to \${packageManager} in package.json 1`] = `
-"image: node:20
+"image: node:24
 
 clone:
   depth: full
@@ -4319,7 +4319,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           filter: tree:0
           fetch-depth: 0
@@ -4331,9 +4331,9 @@ jobs:
       # - run: npx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
       # Cache node_modules
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: 'yarn'
 
       - run: yarn install --frozen-lockfile
@@ -4365,7 +4365,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           filter: tree:0
           fetch-depth: 0
@@ -4379,9 +4379,9 @@ jobs:
       # - run: npx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
       # Cache node_modules
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: 'yarn'
 
       - run: yarn install --frozen-lockfile
@@ -4413,7 +4413,7 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           filter: tree:0
           fetch-depth: 0
@@ -4425,9 +4425,9 @@ jobs:
       # - run: npx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
       # Cache node_modules
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: 'yarn'
 
       - run: yarn install --frozen-lockfile
@@ -4443,7 +4443,7 @@ jobs:
 `;
 
 exports[`CI Workflow generator not connected to nxCloud with yarn should generate gitlab config 1`] = `
-"image: node:20
+"image: node:24
 variables:
   CI: 'true'
   GIT_DEPTH: 0

--- a/packages/workspace/src/generators/ci-workflow/ci-workflow.spec.ts
+++ b/packages/workspace/src/generators/ci-workflow/ci-workflow.spec.ts
@@ -383,7 +383,7 @@ describe('CI Workflow generator', () => {
           main:
             runs-on: ubuntu-latest
             steps:
-              - uses: actions/checkout@v4
+              - uses: actions/checkout@v7
                 with:
                   filter: tree:0
                   fetch-depth: 0
@@ -395,9 +395,9 @@ describe('CI Workflow generator', () => {
               # - run: npx nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="build"
 
               # Cache node_modules
-              - uses: actions/setup-node@v4
+              - uses: actions/setup-node@v6
                 with:
-                  node-version: 20
+                  node-version: 24
                   cache: 'npm'
 
               - run: npm ci
@@ -534,7 +534,7 @@ describe('CI Workflow generator', () => {
 
       expect(tree.read('bitbucket-pipelines.yml', 'utf-8'))
         .toMatchInlineSnapshot(`
-        "image: node:20
+        "image: node:24
 
         clone:
           depth: full
@@ -588,7 +588,7 @@ describe('CI Workflow generator', () => {
       await ciWorkflowGenerator(tree, { ci: 'gitlab', name: 'CI' });
 
       expect(tree.read('.gitlab-ci.yml', 'utf-8')).toMatchInlineSnapshot(`
-        "image: node:20
+        "image: node:24
         variables:
           CI: 'true'
           GIT_DEPTH: 0

--- a/packages/workspace/src/generators/ci-workflow/files/azure/azure-pipelines.yml__tmpl__
+++ b/packages/workspace/src/generators/ci-workflow/files/azure/azure-pipelines.yml__tmpl__
@@ -43,7 +43,7 @@ jobs:
           AZURE_DEVOPS_EXT_PAT: $(System.AccessToken)<% } %>
 
       <% if(packageManager == 'pnpm'){ %>
-      - script: npm install --prefix=$HOME/.local -g pnpm@8
+      - script: npm install --prefix=$HOME/.local -g pnpm@11
         displayName: Install PNPM
 
       <% } %>

--- a/packages/workspace/src/generators/ci-workflow/files/bitbucket-pipelines/bitbucket-pipelines.yml__tmpl__
+++ b/packages/workspace/src/generators/ci-workflow/files/bitbucket-pipelines/bitbucket-pipelines.yml__tmpl__
@@ -1,4 +1,4 @@
-image: node:20
+image: node:24
 
 clone:
   depth: full
@@ -12,7 +12,7 @@ pipelines:
             - export NX_BRANCH=$BITBUCKET_PR_ID
 
             <% if(packageManager == 'pnpm'){ %>
-            - npm install --prefix=$HOME/.local -g pnpm@8
+            - npm install --prefix=$HOME/.local -g pnpm@11
 
             <% } %>
             <% if(packageManager == 'bun'){ %>
@@ -54,7 +54,7 @@ pipelines:
             # - <%= packageManagerPreInstallPrefix %> nx start-ci-run --distribute-on="3 linux-medium-js" --stop-agents-after="<% if(hasE2E){ %>e2e-ci<% } else { %>build<% } %>"
             <% } %>
             <% if(packageManager == 'pnpm'){ %>
-            - npm install --prefix=$HOME/.local -g pnpm@8
+            - npm install --prefix=$HOME/.local -g pnpm@11
             <% } %>
             <% if(packageManager == 'bun'){ %>
             - npm install --prefix=$HOME/.local -g bun

--- a/packages/workspace/src/generators/ci-workflow/files/circleci/.circleci/config.yml__tmpl__
+++ b/packages/workspace/src/generators/ci-workflow/files/circleci/.circleci/config.yml__tmpl__
@@ -12,7 +12,7 @@ jobs:
       <% if(packageManager == 'pnpm'){ %>
       - run:
           name: Install PNPM
-          command: npm install --prefix=$HOME/.local -g pnpm@8
+          command: npm install --prefix=$HOME/.local -g pnpm@11
       <% } %>
       <% if(packageManager == 'bun'){ %>
       - run:

--- a/packages/workspace/src/generators/ci-workflow/files/github/.github/workflows/__workflowFileName__.yml__tmpl__
+++ b/packages/workspace/src/generators/ci-workflow/files/github/.github/workflows/__workflowFileName__.yml__tmpl__
@@ -14,22 +14,22 @@ jobs:
   main:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           filter: tree:0
           fetch-depth: 0
 
       <% if(packageManager === 'bun'){ %>
-      - uses: oven-sh/setup-bun@v1
+      - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
       <% } else if (packageManager === 'yarn' && packageManagerVersion) { %>
       - run: corepack enable
       <% } else if(packageManager ==='pnpm'){ %>
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v6
         name: Install pnpm
         with:<% if (!packageManagerVersion) { %>
-          version: 9.8.0<% } %>
+          version: 11.13.0<% } %>
           run_install: false
       <% } %>
       # This enables task distribution via Nx Cloud
@@ -40,9 +40,9 @@ jobs:
 
       <% if(packageManager !== 'bun'){ %>
       # Cache node_modules
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 20
+          node-version: 24
           cache: '<%= packageManager %>'
        <% } %>
       - run: <%= packageManagerInstall %><% if(hasCypress){ %>

--- a/packages/workspace/src/generators/ci-workflow/files/gitlab/.gitlab-ci.yml__tmpl__
+++ b/packages/workspace/src/generators/ci-workflow/files/gitlab/.gitlab-ci.yml__tmpl__
@@ -1,4 +1,4 @@
-image: node:20
+image: node:24
 variables:
   CI: 'true'
   GIT_DEPTH: 0
@@ -11,7 +11,7 @@ variables:
     - merge_requests
   script:
     <% if(packageManager == 'pnpm'){ %>
-    - npm install --prefix=$HOME/.local -g pnpm@8
+    - npm install --prefix=$HOME/.local -g pnpm@11
     <% } %>
     <% if(packageManager == 'bun'){ %>
     - npm install --prefix=$HOME/.local -g bun


### PR DESCRIPTION
## Current Behavior

The `@nx/workspace:ci-workflow` templates pin node 20, `actions/checkout@v4`, and `actions/setup-node@v4`, so generated CI lags the documented example.

## Expected Behavior

Generated CI uses node 24, `checkout@v7`, `setup-node@v6`, `setup-bun@v2`, `pnpm/action-setup@v6`, and pnpm 11 pins across all providers. CI doc snippets are aligned to the same majors.

## Related Issue(s)

Fixes NXC-4676

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/nxc-4676-node-20-bump-b48c0a2d)
<!-- polygraph-session-end -->