### PR TITLE
chore(repo): parallelize macos e2e suites and drop dead homebrew cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -179,15 +179,6 @@ jobs:
             echo "No React Native projects affected, skipping macOS tests"
           fi
 
-      - name: Restore Homebrew packages
-        if: steps.check-changes.outputs.has_changes == 'true'
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: |
-            /opt/homebrew
-            ~/Library/Caches/Homebrew
-          key: nrwl-nx-homebrew-packages
-
       - name: Configure Detox Environment, Install applesimutils
         if: steps.check-changes.outputs.has_changes == 'true'
         run: |
@@ -290,15 +281,6 @@ jobs:
           echo "Checking simulator logs..."
           ls -la ~/Library/Logs/CoreSimulator/ || echo "No simulator logs found"
 
-      - name: Save Homebrew Cache
-        if: steps.check-changes.outputs.has_changes == 'true'
-        uses: actions/cache@0400d5f644dc74513175e3cd8d07132dd4860809 # v4.2.4
-        with:
-          path: |
-            /opt/homebrew
-            ~/Library/Caches/Homebrew
-          key: nrwl-nx-homebrew-packages
-
       - name: Get pnpm store directory
         if: steps.check-changes.outputs.has_changes == 'true'
         id: pnpm-cache-macos
@@ -326,4 +308,4 @@ jobs:
       - name: Run E2E Tests for macOS
         if: steps.check-changes.outputs.has_changes == 'true'
         run: |
-          pnpm nx affected -t e2e-macos-local --parallel=1 --base=$NX_BASE --head=$NX_HEAD
+          pnpm nx affected -t e2e-macos-local --parallel=2 --base=$NX_BASE --head=$NX_HEAD

--- a/e2e/expo/src/expo-legacy.test.ts
+++ b/e2e/expo/src/expo-legacy.test.ts
@@ -6,6 +6,7 @@ import {
   newProject,
   promisifiedTreeKill,
   readJson,
+  reservePort,
   runCLI,
   runCLIAsync,
   runCommand,
@@ -93,7 +94,7 @@ describe('@nx/expo (legacy)', () => {
 
   it('should serve with metro', async () => {
     let process: ChildProcess;
-    const port = 8051;
+    const port = await reservePort();
 
     try {
       process = await runCommandUntil(
@@ -184,7 +185,7 @@ describe('@nx/expo (legacy)', () => {
   });
 
   it('should start', async () => {
-    const port = 8041;
+    const port = await reservePort();
     // run start command
     const startProcess = await runCommandUntil(
       `start ${appName} -- --port=${port}`,

--- a/e2e/expo/src/expo.test.ts
+++ b/e2e/expo/src/expo.test.ts
@@ -14,6 +14,7 @@ import {
   killPorts,
   createFile,
   removeFile,
+  reservePort,
 } from '@nx/e2e-utils';
 import { join } from 'path';
 
@@ -106,7 +107,7 @@ describe('@nx/expo', () => {
 
   it('should start the app', async () => {
     let process: ChildProcess;
-    const port = 8088;
+    const port = await reservePort();
 
     try {
       process = await runCommandUntil(
@@ -125,7 +126,7 @@ describe('@nx/expo', () => {
 
   it('should serve the app', async () => {
     let process: ChildProcess;
-    const port = 8071;
+    const port = await reservePort();
 
     try {
       process = await runCommandUntil(

--- a/e2e/react-native/src/react-native-legacy.test.ts
+++ b/e2e/react-native/src/react-native-legacy.test.ts
@@ -6,6 +6,7 @@ import {
   killProcessAndPorts,
   newProject,
   readJson,
+  reservePort,
   runCLI,
   runCLIAsync,
   runCommand,
@@ -140,7 +141,7 @@ describe('@nx/react-native (legacy)', () => {
 
   it('should start', async () => {
     let process: ChildProcess;
-    const port = 8081;
+    const port = await reservePort();
 
     try {
       process = await runCommandUntil(
@@ -169,7 +170,7 @@ describe('@nx/react-native (legacy)', () => {
 
   it('should serve', async () => {
     let process: ChildProcess;
-    const port = 8081;
+    const port = await reservePort();
 
     try {
       process = await runCommandUntil(

--- a/e2e/react-native/src/react-native.test.ts
+++ b/e2e/react-native/src/react-native.test.ts
@@ -8,6 +8,7 @@ import {
   killProcessAndPorts,
   fileExists,
   checkFilesExist,
+  reservePort,
   runE2ETests,
   updateFile,
   readJson,
@@ -91,7 +92,7 @@ describe('@nx/react-native', () => {
 
   it('should start the app', async () => {
     let childProcess: ChildProcess;
-    const port = 8082;
+    const port = await reservePort();
 
     try {
       childProcess = await runCommandUntil(
@@ -120,7 +121,7 @@ describe('@nx/react-native', () => {
 
   it('should serve', async () => {
     let childProcess: ChildProcess;
-    const port = 8081;
+    const port = await reservePort();
 
     try {
       childProcess = await runCommandUntil(


### PR DESCRIPTION
## Current Behavior

The `main-macos` CI job takes ~52 minutes when React Native projects are affected (example: run [29289435938](https://github.com/nrwl/nx/actions/runs/29289435938)). Two structural inefficiencies:

1. The three e2e suites run strictly serially (`--parallel=1`): e2e-react-native (13m33s) → e2e-detox (5m59s) → e2e-expo (15m28s) = ~35 min. The serial constraint exists because the suites hard-code overlapping ports (8081 in both react-native test files, which is also Metro's default).
2. The Homebrew cache (`/opt/homebrew`, static key) is net-negative in both regimes, measured across recent runs:
   - Cache miss (first run of a PR): ~4.5 min of post-job tar/upload — twice, since both a Restore and a Save step register post-saves (the second fails with "unable to reserve cache").
   - Cache hit (re-runs): ~2-2.7 min restore, while the applesimutils install step it protects takes ~20-50s **with or without the cache** (the step is dominated by xcode-select/simctl housekeeping, not brew).

## Expected Behavior

The job drops to roughly 30 minutes:

- Hard-coded ports in the react-native and expo e2e suites (8081/8082/8088/8071/8051/8041) are replaced with `reservePort()`, the existing lock-file-based utility built for parallel e2e processes, so suites can no longer collide on ports. (The cypress/playwright 4200 blocks are unchanged — they're gated behind `runE2ETests()`, which is false on macOS.)
- `e2e-macos-local` runs with `--parallel=2`: detox + react-native overlap expo, cutting ~35 min of serial e2e to ~20 min. Kept at 2 rather than 3 since GitHub macOS runners have ~3-4 cores and each suite already fans out (Metro, npm installs); if 2 proves stable, 3 is a cheap follow-up experiment.
- The Homebrew cache steps are removed; applesimutils installs fresh (~20s).

## Related Issue(s)

N/A

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Speed-up-main-macos-CI-job-parallel-e2e--drop-dead-Homebrew-cache-7918829a)
<!-- polygraph-session-end -->