### PR TITLE
chore(testing): make node/express app generator specs package-manager-agnostic

### DIFF
--- a/packages/express/src/generators/application/application.spec.ts
+++ b/packages/express/src/generators/application/application.spec.ts
@@ -1,3 +1,17 @@
+// Pin the detected package manager so inferred lock-file outputs (e.g.
+// prune-lockfile) and package-manager commands are deterministic regardless of
+// which package manager runs the tests.
+jest.mock('@nx/devkit', () => {
+  const actual = jest.requireActual('@nx/devkit');
+  return {
+    ...actual,
+    detectPackageManager: jest.fn(() => 'npm'),
+    getPackageManagerCommand: jest.fn((pm = 'npm') =>
+      actual.getPackageManagerCommand(pm)
+    ),
+  };
+});
+
 import {
   readJson,
   readProjectConfiguration,

--- a/packages/nest/src/generators/application/application.spec.ts
+++ b/packages/nest/src/generators/application/application.spec.ts
@@ -1,3 +1,17 @@
+// Pin the detected package manager so inferred lock-file outputs (e.g.
+// prune-lockfile) and package-manager commands are deterministic regardless of
+// which package manager runs the tests.
+jest.mock('@nx/devkit', () => {
+  const actual = jest.requireActual('@nx/devkit');
+  return {
+    ...actual,
+    detectPackageManager: jest.fn(() => 'npm'),
+    getPackageManagerCommand: jest.fn((pm = 'npm') =>
+      actual.getPackageManagerCommand(pm)
+    ),
+  };
+});
+
 import {
   getProjects,
   readJson,

--- a/packages/node/src/generators/application/application.spec.ts
+++ b/packages/node/src/generators/application/application.spec.ts
@@ -1,11 +1,20 @@
-import 'nx/src/internal-testing-utils/mock-project-graph';
-// const mockFormatFiles = jest.fn();
-// jest.mock('@nx/devkit', () => {
-//   return {
-//     ...jest.requireActual('@nx/devkit'),
-//     formatFiles: (...args) => mockFormatFiles(...args),
-// }
-// })
+// Mock `@nx/devkit` so that (1) the project graph is empty during generation and
+// (2) the detected package manager is pinned. Pinning keeps inferred lock-file
+// outputs (e.g. prune-lockfile) deterministic regardless of which package
+// manager runs the tests. Individual tests can override `detectPackageManager`.
+jest.mock('@nx/devkit', () => {
+  const actual = jest.requireActual('@nx/devkit');
+  return {
+    ...actual,
+    createProjectGraphAsync: jest
+      .fn()
+      .mockResolvedValue({ nodes: {}, dependencies: {} }),
+    detectPackageManager: jest.fn(() => 'npm'),
+    getPackageManagerCommand: jest.fn((pm = 'npm') =>
+      actual.getPackageManagerCommand(pm)
+    ),
+  };
+});
 
 import {
   getProjects,


### PR DESCRIPTION
## Current Behavior

The `@nx/node` and `@nx/express` application generator specs snapshot values that are derived from the **host** package manager, so running them under a different package manager than CI (e.g. pnpm locally vs. npm in CI) produces spurious snapshot churn:

- The **lock file name** in `prune-lockfile` outputs (`package-lock.json` vs. `pnpm-lock.yaml`) — from `getPruneTargets`, which calls `detectPackageManager()`.
- The **`runtimeExecutable`** in the generated VS Code debug config — from `getPackageManagerCommand()`.

`detectPackageManager()` checks the cwd's lock files before the invoked-package-manager fallback, and the nx repo root has a `pnpm-lock.yaml`, so these specs detect pnpm locally regardless of `npm_config_user_agent`. A contributor who runs the tests under pnpm and regenerates snapshots ends up committing pnpm-specific values that then fail on npm CI.

## Expected Behavior

The specs are deterministic regardless of which package manager runs them. Both specs mock `@nx/devkit` to pin `detectPackageManager` to `'npm'` and delegate `getPackageManagerCommand` to the real npm command (mirroring the existing mock in the `@nx/react` application spec). Because the committed snapshots are already the npm result, this introduces **no** snapshot changes — only immunity to the host package manager.

`detectPackageManager()`'s production behavior is unchanged (in a real workspace the cwd is the workspace root); this is purely test determinism, so there is no source change.

## Related Issue(s)

N/A — proactive test hardening. Surfaced while reviewing #35551, whose generator snapshot churn was caused by this host-package-manager sensitivity.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Make-node-express-app-generator-specs-package-manager-agnostic-a382908b)
<!-- polygraph-session-end -->