### PR TITLE
fix(core): support modern pnpm hoisted dependency keys

### DIFF
--- a/packages/nx/src/plugins/js/lock-file/pnpm-parser.spec.ts
+++ b/packages/nx/src/plugins/js/lock-file/pnpm-parser.spec.ts
@@ -2928,6 +2928,48 @@ snapshots: {}`;
     });
   });
 
+  describe('modern hoisted dependency keys', () => {
+    beforeEach(() => {
+      vol.fromJSON(
+        {
+          'node_modules/.modules.yaml': `hoistedDependencies:
+  '@scope/package@2.0.0(peer@1.0.0)':
+    '@scope/package': private`,
+        },
+        '/root'
+      );
+    });
+
+    it('should parse scoped package@version keys from .modules.yaml', () => {
+      const lockFile = `lockfileVersion: '9.0'
+
+importers:
+
+  .: {}
+
+packages:
+
+  '@scope/package@1.0.0': {}
+
+  '@scope/package@2.0.0(peer@1.0.0)': {}
+
+snapshots:
+
+  '@scope/package@1.0.0': {}
+
+  '@scope/package@2.0.0(peer@1.0.0)': {}`;
+
+      const { nodes } = getPnpmLockfileNodes(
+        lockFile,
+        '__modern_hoisted_dependency_keys__'
+      );
+
+      expect(nodes['npm:@scope/package']).toMatchObject({
+        data: { packageName: '@scope/package', version: '2.0.0' },
+      });
+    });
+  });
+
   describe('missing .modules.yaml', () => {
     beforeEach(() => {
       vol.fromJSON(

--- a/packages/nx/src/plugins/js/lock-file/pnpm-parser.spec.ts
+++ b/packages/nx/src/plugins/js/lock-file/pnpm-parser.spec.ts
@@ -2534,13 +2534,13 @@ snapshots:
             "name": "npm:another-string-width",
             "type": "npm",
           },
-          "npm:ansi-regex@5.0.1": {
+          "npm:ansi-regex": {
             "data": {
               "hash": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
               "packageName": "ansi-regex",
               "version": "5.0.1",
             },
-            "name": "npm:ansi-regex@5.0.1",
+            "name": "npm:ansi-regex",
             "type": "npm",
           },
           "npm:ansi-regex@6.2.2": {
@@ -2561,13 +2561,13 @@ snapshots:
             "name": "npm:eastasianwidth",
             "type": "npm",
           },
-          "npm:emoji-regex@8.0.0": {
+          "npm:emoji-regex": {
             "data": {
               "hash": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
               "packageName": "emoji-regex",
               "version": "8.0.0",
             },
-            "name": "npm:emoji-regex@8.0.0",
+            "name": "npm:emoji-regex",
             "type": "npm",
           },
           "npm:emoji-regex@9.2.2": {
@@ -2615,13 +2615,13 @@ snapshots:
             "name": "npm:string-width@4.2.3",
             "type": "npm",
           },
-          "npm:strip-ansi@6.0.1": {
+          "npm:strip-ansi": {
             "data": {
               "hash": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
               "packageName": "strip-ansi",
               "version": "6.0.1",
             },
-            "name": "npm:strip-ansi@6.0.1",
+            "name": "npm:strip-ansi",
             "type": "npm",
           },
           "npm:strip-ansi@7.1.2": {

--- a/packages/nx/src/plugins/js/lock-file/pnpm-parser.ts
+++ b/packages/nx/src/plugins/js/lock-file/pnpm-parser.ts
@@ -467,20 +467,16 @@ function getNodes(
 
   const hoistedDeps = loadPnpmHoistedDepsDefinition();
 
-  // Pre-build packageName -> key index for O(1) lookup instead of O(n) find() per package
-  const hoistedKeysByPackage = new Map<string, string>();
-  for (const key of Object.keys(hoistedDeps)) {
-    if (key.startsWith('/')) {
-      // Extract package name from key format: /{packageName}/{version}... or /@scope/name/{version}...
-      const withoutSlash = key.slice(1);
-      const slashIndex = withoutSlash.startsWith('@')
-        ? withoutSlash.indexOf('/', withoutSlash.indexOf('/') + 1)
-        : withoutSlash.indexOf('/');
-      if (slashIndex > 0) {
-        const pkgName = withoutSlash.slice(0, slashIndex);
-        if (!hoistedKeysByPackage.has(pkgName)) {
-          hoistedKeysByPackage.set(pkgName, key);
-        }
+  // Pre-build packageName -> version index for O(1) lookup instead of O(n) find() per package
+  const hoistedVersionsByPackage = new Map<string, string>();
+  for (const rawKey of Object.keys(hoistedDeps)) {
+    const isV5Key = rawKey.startsWith('/');
+    const key = isV5Key ? rawKey.slice(1) : rawKey;
+    const packageName = extractNameFromKey(key, isV5Key);
+    if (!hoistedVersionsByPackage.has(packageName)) {
+      const version = parseBaseVersion(getVersion(key, packageName), isV5Key);
+      if (version) {
+        hoistedVersionsByPackage.set(packageName, version);
       }
     }
   }
@@ -494,8 +490,7 @@ function getNodes(
     } else {
       const hoistedVersion = getHoistedVersion(
         packageName,
-        isV5,
-        hoistedKeysByPackage
+        hoistedVersionsByPackage
       );
       hoistedNode = versionMap.get(hoistedVersion);
     }
@@ -512,17 +507,14 @@ function getNodes(
 
 function getHoistedVersion(
   packageName: string,
-  isV5: boolean,
-  hoistedKeysByPackage: Map<string, string>
+  hoistedVersionsByPackage: Map<string, string>
 ): string {
   let version = getHoistedPackageVersion(packageName);
 
   if (!version) {
     // Use pre-built index for O(1) lookup
-    const key = hoistedKeysByPackage.get(packageName);
-    if (key) {
-      version = parseBaseVersion(getVersion(key.slice(1), packageName), isV5);
-    } else {
+    version = hoistedVersionsByPackage.get(packageName);
+    if (!version) {
       // pnpm might not hoist every package
       // similarly those packages will not be available to be used via import
       return;


### PR DESCRIPTION
## Current Behavior

Nx only indexes legacy slash-prefixed keys from pnpm's `node_modules/.modules.yaml` when determining the hoisted version of packages that have multiple versions in the lockfile. Modern pnpm releases write `package@version` keys, so the parser can leave every version qualified instead of assigning the hoisted version the `npm:<package>` graph node name.

## Expected Behavior

Nx recognizes both legacy `/package/version` keys and modern `package@version` keys, including scoped packages and peer-dependency suffixes, while retaining the O(1) package lookup introduced by the current parser.

## Testing

- `nx run nx:test --excludeTaskDependencies --skipRemoteCache --args='src/plugins/js/lock-file/pnpm-parser.spec.ts --runInBand'` (41 tests, 10 snapshots)
- `nx run nx:lint --excludeTaskDependencies --skipRemoteCache`
- `nx run nx:build-base --excludeTaskDependencies --skipRemoteCache --skipSync`

The full native dependency chain requires Cargo, Gradle, and .NET; those toolchains are not installed locally and remain covered by CI.

## Related Issue(s)

N/A — the regression is reproduced directly in the added parser test.
