### PR TITLE
fix(angular): correct declaration maps and exports of buildable libraries

### DIFF
--- a/e2e/angular/src/projects-buildable-libs.test.ts
+++ b/e2e/angular/src/projects-buildable-libs.test.ts
@@ -1,5 +1,6 @@
 import { names } from '@nx/devkit';
 import {
+  checkFilesDoNotExist,
   readFile,
   readJson,
   runCLI,
@@ -192,6 +193,16 @@ describe('Angular Projects - Buildable Libraries', () => {
         `${names(buildableLib).fileName}-module.ts`
       ),
     ]);
+
+    // the flat module file is built in memory by ngc and has no source on disk,
+    // so it must not ship a declaration map
+    const { typings } = readJson<{ typings: string }>(
+      `dist/${buildableLib}/package.json`
+    );
+    expect(readFile(`dist/${buildableLib}/${typings}`)).not.toContain(
+      'sourceMappingURL'
+    );
+    checkFilesDoNotExist(`dist/${buildableLib}/${typings}.map`);
 
     // to proof it has been built from source the "main.js" should actually contain
     // the path to dist

--- a/e2e/angular/src/projects-buildable-libs.test.ts
+++ b/e2e/angular/src/projects-buildable-libs.test.ts
@@ -1,6 +1,14 @@
 import { names } from '@nx/devkit';
-import { readFile, runCLI, uniq, updateFile, updateJson } from '@nx/e2e-utils';
-import { join } from 'path';
+import {
+  readFile,
+  readJson,
+  runCLI,
+  tmpProjPath,
+  uniq,
+  updateFile,
+  updateJson,
+} from '@nx/e2e-utils';
+import { dirname, join, relative } from 'path';
 import {
   setupProjectsTest,
   resetProjectsTest,
@@ -162,6 +170,28 @@ describe('Angular Projects - Buildable Libraries', () => {
       `Building entry point '@${proj}/${buildableLib}'`
     );
     expect(libOutput).toContain(`nx run ${app1}:build:development`);
+
+    // the development configuration keeps declarationMap enabled, so the lib
+    // emits declaration maps that must still resolve to its sources
+    const declarationMap = `dist/${buildableLib}/lib/${
+      names(buildableLib).fileName
+    }-module.d.ts.map`;
+    const { sources } = readJson<{ sources: string[] }>(declarationMap);
+    expect(
+      sources.map((source) =>
+        relative(
+          tmpProjPath(),
+          join(tmpProjPath(dirname(declarationMap)), source)
+        )
+      )
+    ).toEqual([
+      join(
+        buildableLib,
+        'src',
+        'lib',
+        `${names(buildableLib).fileName}-module.ts`
+      ),
+    ]);
 
     // to proof it has been built from source the "main.js" should actually contain
     // the path to dist

--- a/e2e/angular/src/projects-buildable-libs.test.ts
+++ b/e2e/angular/src/projects-buildable-libs.test.ts
@@ -1,6 +1,7 @@
 import { names } from '@nx/devkit';
 import {
   checkFilesDoNotExist,
+  checkFilesExist,
   readFile,
   readJson,
   runCLI,
@@ -36,12 +37,16 @@ describe('Angular Projects - Buildable Libraries', () => {
     // ARRANGE
     const buildableLib = uniq('buildlib1');
     const buildableChildLib = uniq('buildlib2');
+    const entryPoint = uniq('entrypoint');
 
     runCLI(
       `generate @nx/angular:library ${buildableLib} --buildable=true --no-standalone --no-interactive`
     );
     runCLI(
       `generate @nx/angular:library ${buildableChildLib} --buildable=true --no-standalone --no-interactive`
+    );
+    runCLI(
+      `generate @nx/angular:secondary-entry-point --name=${entryPoint} --library=${buildableLib} --no-interactive`
     );
 
     // update the app module to include a ref to the buildable lib
@@ -194,15 +199,26 @@ describe('Angular Projects - Buildable Libraries', () => {
       ),
     ]);
 
+    const { typings, exports: packageExports } = readJson<{
+      typings: string;
+      exports: Record<string, Record<string, string>>;
+    }>(`dist/${buildableLib}/package.json`);
+
     // the flat module file is built in memory by ngc and has no source on disk,
     // so it must not ship a declaration map
-    const { typings } = readJson<{ typings: string }>(
-      `dist/${buildableLib}/package.json`
-    );
     expect(readFile(`dist/${buildableLib}/${typings}`)).not.toContain(
       'sourceMappingURL'
     );
     checkFilesDoNotExist(`dist/${buildableLib}/${typings}.map`);
+
+    // the package manifest is written while the primary entry point is in
+    // progress, so the secondary entry point is mapped before it is built
+    expect(packageExports[`./${entryPoint}`]).toBeDefined();
+    checkFilesExist(
+      ...Object.values(packageExports).flatMap((conditions) =>
+        Object.values(conditions).map((file) => `dist/${buildableLib}/${file}`)
+      )
+    );
 
     // to proof it has been built from source the "main.js" should actually contain
     // the path to dist

--- a/e2e/angular/src/projects-buildable-libs.test.ts
+++ b/e2e/angular/src/projects-buildable-libs.test.ts
@@ -1,6 +1,7 @@
 import { names } from '@nx/devkit';
 import {
   checkFilesDoNotExist,
+  checkFilesExist,
   readFile,
   readJson,
   runCLI,
@@ -36,12 +37,16 @@ describe('Angular Projects - Buildable Libraries', () => {
     // ARRANGE
     const buildableLib = uniq('buildlib1');
     const buildableChildLib = uniq('buildlib2');
+    const entryPoint = uniq('entrypoint');
 
     runCLI(
       `generate @nx/angular:library ${buildableLib} --buildable=true --no-standalone --no-interactive`
     );
     runCLI(
       `generate @nx/angular:library ${buildableChildLib} --buildable=true --no-standalone --no-interactive`
+    );
+    runCLI(
+      `generate @nx/angular:secondary-entry-point --name=${entryPoint} --library=${buildableLib} --no-interactive`
     );
 
     // update the app module to include a ref to the buildable lib
@@ -200,15 +205,26 @@ describe('Angular Projects - Buildable Libraries', () => {
       ),
     ]);
 
+    const { typings, exports: packageExports } = readJson<{
+      typings: string;
+      exports: Record<string, Record<string, string>>;
+    }>(`dist/${buildableLib}/package.json`);
+
     // the flat module file is built in memory by ngc and has no source on disk,
     // so it must not ship a declaration map
-    const { typings } = readJson<{ typings: string }>(
-      `dist/${buildableLib}/package.json`
-    );
     expect(readFile(`dist/${buildableLib}/${typings}`)).not.toContain(
       'sourceMappingURL'
     );
     checkFilesDoNotExist(`dist/${buildableLib}/${typings}.map`);
+
+    // the package manifest is written while the primary entry point is in
+    // progress, so the secondary entry point is mapped before it is built
+    expect(packageExports[`./${entryPoint}`]).toBeDefined();
+    checkFilesExist(
+      ...Object.values(packageExports).flatMap((conditions) =>
+        Object.values(conditions).map((file) => `dist/${buildableLib}/${file}`)
+      )
+    );
 
     // to proof it has been built from source the "main.js" should actually contain
     // the path to dist

--- a/e2e/angular/src/projects-buildable-libs.test.ts
+++ b/e2e/angular/src/projects-buildable-libs.test.ts
@@ -1,5 +1,6 @@
 import { names } from '@nx/devkit';
 import {
+  checkFilesDoNotExist,
   readFile,
   readJson,
   runCLI,
@@ -198,6 +199,16 @@ describe('Angular Projects - Buildable Libraries', () => {
         `${names(buildableLib).fileName}-module.ts`
       ),
     ]);
+
+    // the flat module file is built in memory by ngc and has no source on disk,
+    // so it must not ship a declaration map
+    const { typings } = readJson<{ typings: string }>(
+      `dist/${buildableLib}/package.json`
+    );
+    expect(readFile(`dist/${buildableLib}/${typings}`)).not.toContain(
+      'sourceMappingURL'
+    );
+    checkFilesDoNotExist(`dist/${buildableLib}/${typings}.map`);
 
     // to proof it has been built from source the "main.js" should actually contain
     // the path to dist

--- a/e2e/angular/src/projects-buildable-libs.test.ts
+++ b/e2e/angular/src/projects-buildable-libs.test.ts
@@ -1,6 +1,14 @@
 import { names } from '@nx/devkit';
-import { readFile, runCLI, uniq, updateFile, updateJson } from '@nx/e2e-utils';
-import { join } from 'path';
+import {
+  readFile,
+  readJson,
+  runCLI,
+  tmpProjPath,
+  uniq,
+  updateFile,
+  updateJson,
+} from '@nx/e2e-utils';
+import { dirname, join, relative } from 'path';
 import {
   setupProjectsTest,
   resetProjectsTest,
@@ -168,6 +176,28 @@ describe('Angular Projects - Buildable Libraries', () => {
       `Building entry point '@${proj}/${buildableLib}'`
     );
     expect(libOutput).toContain(`nx run ${app1}:build:development`);
+
+    // the development configuration keeps declarationMap enabled, so the lib
+    // emits declaration maps that must still resolve to its sources
+    const declarationMap = `dist/${buildableLib}/lib/${
+      names(buildableLib).fileName
+    }-module.d.ts.map`;
+    const { sources } = readJson<{ sources: string[] }>(declarationMap);
+    expect(
+      sources.map((source) =>
+        relative(
+          tmpProjPath(),
+          join(tmpProjPath(dirname(declarationMap)), source)
+        )
+      )
+    ).toEqual([
+      join(
+        buildableLib,
+        'src',
+        'lib',
+        `${names(buildableLib).fileName}-module.ts`
+      ),
+    ]);
 
     // to proof it has been built from source the "main.js" should actually contain
     // the path to dist

--- a/e2e/angular/src/projects-buildable-libs.test.ts
+++ b/e2e/angular/src/projects-buildable-libs.test.ts
@@ -183,8 +183,7 @@ describe('Angular Projects - Buildable Libraries', () => {
     );
     expect(libOutput).toContain(`nx run ${app1}:build:development`);
 
-    // the development configuration keeps declarationMap enabled, so the lib
-    // emits declaration maps that must still resolve to its sources
+    // the development configuration keeps declarationMap enabled
     const declarationMap = `dist/${buildableLib}/lib/${
       names(buildableLib).fileName
     }-module.d.ts.map`;

--- a/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ng-package/entry-point/write-bundles.transform.spec.ts
+++ b/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ng-package/entry-point/write-bundles.transform.spec.ts
@@ -1,0 +1,109 @@
+import { dirname, join, relative, resolve } from 'node:path';
+import { remapDeclarationMapSources } from './write-bundles.transform';
+
+describe('remapDeclarationMapSources', () => {
+  const dest = resolve('/tmp/dist/my-lib');
+  // ngc emits declaration maps under tmp-typings; the transform moves them up
+  // one directory by dropping the tmp-typings segment.
+  const originalPath = join(dest, 'tmp-typings', 'lib', 'foo.d.ts.map');
+  const newPath = join(dest, 'lib', 'foo.d.ts.map');
+
+  function makeMap(sources: string[], sourceRoot = ''): string {
+    return JSON.stringify({
+      version: 3,
+      file: 'foo.d.ts',
+      sourceRoot,
+      sources,
+      names: [],
+      mappings: 'AAAA',
+    });
+  }
+
+  it('rebases sources so they still point at the original source after the move up a directory', () => {
+    // source path as ngc emits it, relative to the tmp-typings location
+    const emitted = relative(
+      dirname(originalPath),
+      resolve('/tmp/src/lib/foo.ts')
+    );
+
+    const result = remapDeclarationMapSources(
+      originalPath,
+      newPath,
+      makeMap([emitted])
+    );
+
+    const { sources } = JSON.parse(result);
+    // one fewer '../' now that the map lives one directory higher
+    expect(sources).toEqual(['../../../src/lib/foo.ts']);
+    // the rebased path resolves to the same absolute source file
+    expect(resolve(dirname(newPath), sources[0])).toEqual(
+      resolve('/tmp/src/lib/foo.ts')
+    );
+  });
+
+  it('preserves the JSON structure and only rewrites sources', () => {
+    const result = JSON.parse(
+      remapDeclarationMapSources(
+        originalPath,
+        newPath,
+        makeMap(['../../../../src/lib/foo.ts'])
+      )
+    );
+
+    expect(result).toMatchObject({
+      version: 3,
+      file: 'foo.d.ts',
+      names: [],
+      mappings: 'AAAA',
+    });
+  });
+
+  it('returns the content untouched when a sourceRoot is set', () => {
+    // sources resolve against the sourceRoot rather than the map's location,
+    // so moving the map does not invalidate them
+    const content = makeMap(['lib/foo.ts'], 'https://cdn.example/src/');
+    expect(remapDeclarationMapSources(originalPath, newPath, content)).toBe(
+      content
+    );
+  });
+
+  it('returns the content untouched when the map does not change directory', () => {
+    const content = makeMap(['../../src/lib/foo.ts']);
+    expect(remapDeclarationMapSources(newPath, newPath, content)).toBe(content);
+  });
+
+  it('returns the content untouched when it is not a valid source map', () => {
+    expect(remapDeclarationMapSources(originalPath, newPath, 'not json')).toBe(
+      'not json'
+    );
+  });
+
+  it.each([
+    ['null JSON', 'null'],
+    ['a JSON primitive', '123'],
+    ['a map without sources', '{"version":3}'],
+    ['a map whose sources is not an array', '{"version":3,"sources":"foo.ts"}'],
+  ])('returns the content untouched for %s', (_name, content) => {
+    expect(remapDeclarationMapSources(originalPath, newPath, content)).toBe(
+      content
+    );
+  });
+
+  it('leaves non-string source entries untouched while rebasing string ones', () => {
+    const result = JSON.parse(
+      remapDeclarationMapSources(
+        originalPath,
+        newPath,
+        JSON.stringify({
+          version: 3,
+          sources: [null, '../../../../src/lib/foo.ts'],
+        })
+      )
+    );
+
+    expect(result.sources[0]).toBeNull();
+    expect(resolve(dirname(newPath), result.sources[1])).toEqual(
+      resolve('/tmp/src/lib/foo.ts')
+    );
+  });
+});

--- a/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ng-package/entry-point/write-bundles.transform.spec.ts
+++ b/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ng-package/entry-point/write-bundles.transform.spec.ts
@@ -1,5 +1,44 @@
 import { dirname, join, relative, resolve } from 'node:path';
-import { remapDeclarationMapSources } from './write-bundles.transform';
+import {
+  remapDeclarationMapSources,
+  removeSourceMappingUrl,
+} from './write-bundles.transform';
+
+describe('removeSourceMappingUrl', () => {
+  // the flat module file as ngc emits it, without a trailing newline
+  const flatModule = [
+    '/**',
+    ' * Generated bundle index. Do not edit.',
+    ' */',
+    `export * from './public-api';`,
+    '',
+  ].join('\n');
+
+  it('removes a trailing source map reference', () => {
+    expect(
+      removeSourceMappingUrl(
+        `${flatModule}//# sourceMappingURL=my-lib.d.ts.map`
+      )
+    ).toBe(flatModule);
+  });
+
+  it('removes a trailing source map reference followed by a newline', () => {
+    expect(
+      removeSourceMappingUrl(
+        `${flatModule}//# sourceMappingURL=my-lib.d.ts.map\n`
+      )
+    ).toBe(flatModule);
+  });
+
+  it('returns the content untouched when there is no source map reference', () => {
+    expect(removeSourceMappingUrl(flatModule)).toBe(flatModule);
+  });
+
+  it('only removes the reference when it is the last thing in the file', () => {
+    const content = `//# sourceMappingURL=my-lib.d.ts.map\n${flatModule}`;
+    expect(removeSourceMappingUrl(content)).toBe(content);
+  });
+});
 
 describe('remapDeclarationMapSources', () => {
   const dest = resolve('/tmp/dist/my-lib');

--- a/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ng-package/entry-point/write-bundles.transform.spec.ts
+++ b/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ng-package/entry-point/write-bundles.transform.spec.ts
@@ -5,7 +5,7 @@ import {
 } from './write-bundles.transform';
 
 describe('removeSourceMappingUrl', () => {
-  // the flat module file as ngc emits it, without a trailing newline
+  // the flat module file as ngc emits it
   const flatModule = [
     '/**',
     ' * Generated bundle index. Do not edit.',
@@ -98,8 +98,7 @@ describe('remapDeclarationMapSources', () => {
   });
 
   it('returns the content untouched when a sourceRoot is set', () => {
-    // sources resolve against the sourceRoot rather than the map's location,
-    // so moving the map does not invalidate them
+    // the root is prepended to each source, so they are not map-relative paths
     const content = makeMap(['lib/foo.ts'], 'https://cdn.example/src/');
     expect(remapDeclarationMapSources(originalPath, newPath, content)).toBe(
       content

--- a/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ng-package/entry-point/write-bundles.transform.spec.ts
+++ b/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ng-package/entry-point/write-bundles.transform.spec.ts
@@ -1,5 +1,7 @@
 import { dirname, join, relative, resolve } from 'node:path';
+import type { NgEntryPointType } from './entry-point';
 import {
+  normalizeEsm2022Path,
   remapDeclarationMapSources,
   removeSourceMappingUrl,
 } from './write-bundles.transform';
@@ -143,5 +145,68 @@ describe('remapDeclarationMapSources', () => {
     expect(resolve(dirname(newPath), result.sources[1])).toEqual(
       resolve('/tmp/src/lib/foo.ts')
     );
+  });
+});
+
+describe('normalizeEsm2022Path', () => {
+  function entryPointWithDest(destinationPath: string): NgEntryPointType {
+    return { primaryDestinationPath: destinationPath } as NgEntryPointType;
+  }
+
+  it('writes the ESM2022 outputs under esm2022', () => {
+    const dest = resolve('/tmp/dist/my-lib');
+
+    expect(
+      normalizeEsm2022Path(
+        join(dest, 'tmp-esm2022', 'lib', 'foo.js'),
+        entryPointWithDest(dest)
+      )
+    ).toBe(join(dest, 'esm2022', 'lib', 'foo.js'));
+  });
+
+  it('writes the declarations at the destination path', () => {
+    const dest = resolve('/tmp/dist/my-lib');
+
+    expect(
+      normalizeEsm2022Path(
+        join(dest, 'tmp-typings', 'lib', 'foo.d.ts'),
+        entryPointWithDest(dest)
+      )
+    ).toBe(join(dest, 'lib', 'foo.d.ts'));
+  });
+
+  it('rewrites the tmp-esm2022 segment under a destination path carrying the same name', () => {
+    const dest = resolve('/tmp/dist/tmp-esm2022-lib/my-lib');
+
+    expect(
+      normalizeEsm2022Path(
+        join(dest, 'tmp-esm2022', 'lib', 'foo.js'),
+        entryPointWithDest(dest)
+      )
+    ).toBe(join(dest, 'esm2022', 'lib', 'foo.js'));
+  });
+
+  it('rewrites the tmp-typings segment under a destination path carrying the same name', () => {
+    const dest = resolve('/tmp/dist/tmp-typings-lib/my-lib');
+
+    expect(
+      normalizeEsm2022Path(
+        join(dest, 'tmp-typings', 'lib', 'foo.d.ts'),
+        entryPointWithDest(dest)
+      )
+    ).toBe(join(dest, 'lib', 'foo.d.ts'));
+  });
+
+  it('leaves a sibling directory sharing the segment name untouched', () => {
+    const dest = resolve('/tmp/dist/my-lib');
+    const path = join(dest, 'tmp-typings-extra', 'lib', 'foo.d.ts');
+
+    expect(normalizeEsm2022Path(path, entryPointWithDest(dest))).toBe(path);
+  });
+
+  it('leaves the path untouched when there is no destination path', () => {
+    const path = join(resolve('/tmp/dist/my-lib'), 'tmp-typings', 'foo.d.ts');
+
+    expect(normalizeEsm2022Path(path, {} as NgEntryPointType)).toBe(path);
   });
 });

--- a/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ng-package/entry-point/write-bundles.transform.spec.ts
+++ b/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ng-package/entry-point/write-bundles.transform.spec.ts
@@ -44,8 +44,7 @@ describe('removeSourceMappingUrl', () => {
 
 describe('remapDeclarationMapSources', () => {
   const dest = resolve('/tmp/dist/my-lib');
-  // ngc emits declaration maps under tmp-typings; the transform moves them up
-  // one directory by dropping the tmp-typings segment.
+  // ngc emits declaration maps under tmp-typings; normalization removes that segment.
   const originalPath = join(dest, 'tmp-typings', 'lib', 'foo.d.ts.map');
   const newPath = join(dest, 'lib', 'foo.d.ts.map');
 
@@ -61,7 +60,6 @@ describe('remapDeclarationMapSources', () => {
   }
 
   it('rebases sources so they still point at the original source after the move up a directory', () => {
-    // source path as ngc emits it, relative to the tmp-typings location
     const emitted = relative(
       dirname(originalPath),
       resolve('/tmp/src/lib/foo.ts')
@@ -76,7 +74,6 @@ describe('remapDeclarationMapSources', () => {
     const { sources } = JSON.parse(result);
     // one fewer '../' now that the map lives one directory higher
     expect(sources).toEqual(['../../../src/lib/foo.ts']);
-    // the rebased path resolves to the same absolute source file
     expect(resolve(dirname(newPath), sources[0])).toEqual(
       resolve('/tmp/src/lib/foo.ts')
     );

--- a/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ng-package/entry-point/write-bundles.transform.ts
+++ b/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ng-package/entry-point/write-bundles.transform.ts
@@ -85,7 +85,8 @@ export const writeBundlesTransform = (_options: NgPackagrOptions) => {
       await mkdir(entryPoint.destinationPath, { recursive: true });
     }
 
-    // Update package node only when processing the primary entry point
+    // Adjust the remaining entry points and the package node once the primary
+    // one is reached
     if (!entryPoint.isSecondaryEntryPoint) {
       // the package manifest maps every entry point and is written while the
       // primary one is in progress, so the rest need their destination files
@@ -139,7 +140,8 @@ export function remapDeclarationMapSources(
     return content;
   }
   // ng-packagr forces `sourceRoot: ''`, so sources are relative to the map file.
-  // A map with a sourceRoot resolves its sources against that instead, so leave it be.
+  // A non-empty root is prepended to each source, so the entries are not plain
+  // map-relative paths and rebasing them on their own would be wrong.
   if (map.sourceRoot) {
     return content;
   }

--- a/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ng-package/entry-point/write-bundles.transform.ts
+++ b/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ng-package/entry-point/write-bundles.transform.ts
@@ -44,16 +44,32 @@ export const writeBundlesTransform = (_options: NgPackagrOptions) => {
     entryPointNode.data.entryPoint = entryPoint;
     entryPointNode.data.destinationFiles = entryPoint.destinationFiles;
 
+    // ngc builds the flat module file in memory and never writes it to disk, so
+    // the declaration map emitted for it points at a source that doesn't exist.
+    const flatModuleDeclarations = normalize(
+      entryPointNode.data.destinationFiles.declarations
+    );
+    const flatModuleDeclarationsMap = `${flatModuleDeclarations}.map`;
+
     for (const [
       path,
       outputCache,
     ] of entryPointNode.cache.outputCache.entries()) {
+      const originalPath = normalize(path);
+      if (originalPath === flatModuleDeclarationsMap) {
+        continue;
+      }
+
       const normalizedPath = normalizeEsm2022Path(path, entryPoint);
-      // Declaration maps under tmp-typings land one directory up, so their
-      // source paths need rebasing; maps that don't move are left untouched.
-      const content = normalizedPath.endsWith('.d.ts.map')
-        ? remapDeclarationMapSources(path, normalizedPath, outputCache.content)
-        : outputCache.content;
+      let content = outputCache.content;
+      if (originalPath === flatModuleDeclarations) {
+        // its declaration map is dropped above, so don't leave a reference behind
+        content = removeSourceMappingUrl(content);
+      } else if (normalizedPath.endsWith('.d.ts.map')) {
+        // Declaration maps under tmp-typings land one directory up, so their
+        // source paths need rebasing; maps that don't move are left untouched.
+        content = remapDeclarationMapSources(path, normalizedPath, content);
+      }
 
       // Only write if content has changed
       if (await shouldWriteFile(normalizedPath, content)) {
@@ -83,6 +99,10 @@ export const writeBundlesTransform = (_options: NgPackagrOptions) => {
     }
   });
 };
+
+export function removeSourceMappingUrl(content: string): string {
+  return content.replace(/\/\/# sourceMappingURL=[^\r\n]*\s*$/, '');
+}
 
 export function remapDeclarationMapSources(
   originalPath: string,

--- a/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ng-package/entry-point/write-bundles.transform.ts
+++ b/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ng-package/entry-point/write-bundles.transform.ts
@@ -15,8 +15,9 @@ import {
 } from 'ng-packagr/src/lib/ng-package/nodes';
 import type { NgPackagrOptions } from 'ng-packagr/src/lib/ng-package/options.di';
 import { NgPackage } from 'ng-packagr/src/lib/ng-package/package';
+import { ensureUnixPath } from 'ng-packagr/src/lib/utils/path';
 import { mkdir, writeFile, readFile } from 'node:fs/promises';
-import { dirname, join, normalize } from 'node:path';
+import { dirname, join, normalize, relative, resolve } from 'node:path';
 import { createNgEntryPoint, type NgEntryPointType } from './entry-point';
 
 async function shouldWriteFile(
@@ -48,11 +49,16 @@ export const writeBundlesTransform = (_options: NgPackagrOptions) => {
       outputCache,
     ] of entryPointNode.cache.outputCache.entries()) {
       const normalizedPath = normalizeEsm2022Path(path, entryPoint);
+      // Declaration maps under tmp-typings land one directory up, so their
+      // source paths need rebasing; maps that don't move are left untouched.
+      const content = normalizedPath.endsWith('.d.ts.map')
+        ? remapDeclarationMapSources(path, normalizedPath, outputCache.content)
+        : outputCache.content;
 
       // Only write if content has changed
-      if (await shouldWriteFile(normalizedPath, outputCache.content)) {
+      if (await shouldWriteFile(normalizedPath, content)) {
         await mkdir(dirname(normalizedPath), { recursive: true });
-        await writeFile(normalizedPath, outputCache.content);
+        await writeFile(normalizedPath, content);
       }
     }
     if (
@@ -77,6 +83,41 @@ export const writeBundlesTransform = (_options: NgPackagrOptions) => {
     }
   });
 };
+
+export function remapDeclarationMapSources(
+  originalPath: string,
+  newPath: string,
+  content: string
+): string {
+  const originalDir = dirname(normalize(originalPath));
+  const newDir = dirname(normalize(newPath));
+  if (originalDir === newDir) {
+    return content;
+  }
+
+  let map: { sources?: unknown; sourceRoot?: unknown };
+  try {
+    map = JSON.parse(content);
+  } catch {
+    return content;
+  }
+  if (!map || typeof map !== 'object' || !Array.isArray(map.sources)) {
+    return content;
+  }
+  // ng-packagr forces `sourceRoot: ''`, so sources are relative to the map file.
+  // A map with a sourceRoot resolves its sources against that instead, so leave it be.
+  if (map.sourceRoot) {
+    return content;
+  }
+
+  map.sources = map.sources.map((source) =>
+    typeof source === 'string'
+      ? ensureUnixPath(relative(newDir, resolve(originalDir, source)))
+      : source
+  );
+
+  return JSON.stringify(map);
+}
 
 function normalizeEsm2022Path(
   path: string,

--- a/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ng-package/entry-point/write-bundles.transform.ts
+++ b/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ng-package/entry-point/write-bundles.transform.ts
@@ -10,6 +10,7 @@
 import { transformFromPromise } from 'ng-packagr/src/lib/graph/transform';
 import type { NgEntryPoint } from 'ng-packagr/src/lib/ng-package/entry-point/entry-point';
 import {
+  byEntryPoint,
   isEntryPointInProgress,
   isPackage,
 } from 'ng-packagr/src/lib/ng-package/nodes';
@@ -86,6 +87,19 @@ export const writeBundlesTransform = (_options: NgPackagrOptions) => {
 
     // Update package node only when processing the primary entry point
     if (!entryPoint.isSecondaryEntryPoint) {
+      // the package manifest maps every entry point and is written while the
+      // primary one is in progress, so the rest need their destination files
+      // adjusted by now even though they may not have been processed yet
+      for (const node of graph.filter(byEntryPoint())) {
+        if (node === entryPointNode) {
+          continue;
+        }
+
+        const nodeEntryPoint = toCustomNgEntryPoint(node.data.entryPoint);
+        node.data.entryPoint = nodeEntryPoint;
+        node.data.destinationFiles = nodeEntryPoint.destinationFiles;
+      }
+
       const packageNode = graph.find(isPackage);
       if (packageNode) {
         packageNode.data = new NgPackage(

--- a/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ng-package/entry-point/write-bundles.transform.ts
+++ b/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ng-package/entry-point/write-bundles.transform.ts
@@ -18,7 +18,7 @@ import type { NgPackagrOptions } from 'ng-packagr/src/lib/ng-package/options.di'
 import { NgPackage } from 'ng-packagr/src/lib/ng-package/package';
 import { ensureUnixPath } from 'ng-packagr/src/lib/utils/path';
 import { mkdir, writeFile, readFile } from 'node:fs/promises';
-import { dirname, join, normalize, relative, resolve } from 'node:path';
+import { dirname, join, normalize, relative, resolve, sep } from 'node:path';
 import { createNgEntryPoint, type NgEntryPointType } from './entry-point';
 
 async function shouldWriteFile(
@@ -155,7 +155,7 @@ export function remapDeclarationMapSources(
   return JSON.stringify(map);
 }
 
-function normalizeEsm2022Path(
+export function normalizeEsm2022Path(
   path: string,
   entryPoint: NgEntryPointType
 ): string {
@@ -164,20 +164,25 @@ function normalizeEsm2022Path(
     return normalizedPath;
   }
 
-  if (
-    normalizedPath.startsWith(
-      join(entryPoint.primaryDestinationPath, 'tmp-esm2022')
-    )
-  ) {
-    return normalizedPath.replace('tmp-esm2022', 'esm2022');
+  // the segments are located from the destination path, since replacing the
+  // first occurrence in the full path would rewrite the destination path itself
+  const tmpEsm2022Dir =
+    join(entryPoint.primaryDestinationPath, 'tmp-esm2022') + sep;
+  if (normalizedPath.startsWith(tmpEsm2022Dir)) {
+    return join(
+      entryPoint.primaryDestinationPath,
+      'esm2022',
+      normalizedPath.slice(tmpEsm2022Dir.length)
+    );
   }
 
-  if (
-    normalizedPath.startsWith(
-      join(entryPoint.primaryDestinationPath, 'tmp-typings')
-    )
-  ) {
-    return normalizedPath.replace('tmp-typings', '');
+  const tmpTypingsDir =
+    join(entryPoint.primaryDestinationPath, 'tmp-typings') + sep;
+  if (normalizedPath.startsWith(tmpTypingsDir)) {
+    return join(
+      entryPoint.primaryDestinationPath,
+      normalizedPath.slice(tmpTypingsDir.length)
+    );
   }
 
   return normalizedPath;

--- a/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ng-package/entry-point/write-bundles.transform.ts
+++ b/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ng-package/entry-point/write-bundles.transform.ts
@@ -67,8 +67,8 @@ export const writeBundlesTransform = (_options: NgPackagrOptions) => {
         // its declaration map is dropped above, so don't leave a reference behind
         content = removeSourceMappingUrl(content);
       } else if (normalizedPath.endsWith('.d.ts.map')) {
-        // Declaration maps under tmp-typings land one directory up, so their
-        // source paths need rebasing; maps that don't move are left untouched.
+        // declaration maps under tmp-typings land one directory up, so their
+        // source paths need rebasing
         content = remapDeclarationMapSources(path, normalizedPath, content);
       }
 
@@ -85,12 +85,9 @@ export const writeBundlesTransform = (_options: NgPackagrOptions) => {
       await mkdir(entryPoint.destinationPath, { recursive: true });
     }
 
-    // Adjust the remaining entry points and the package node once the primary
-    // one is reached
     if (!entryPoint.isSecondaryEntryPoint) {
-      // the package manifest maps every entry point and is written while the
-      // primary one is in progress, so the rest need their destination files
-      // adjusted by now even though they may not have been processed yet
+      // the primary manifest reads every entry point, so adjust any that have
+      // not been processed yet
       for (const node of graph.filter(byEntryPoint())) {
         if (node === entryPointNode) {
           continue;
@@ -140,8 +137,7 @@ export function remapDeclarationMapSources(
     return content;
   }
   // ng-packagr forces `sourceRoot: ''`, so sources are relative to the map file.
-  // A non-empty root is prepended to each source, so the entries are not plain
-  // map-relative paths and rebasing them on their own would be wrong.
+  // A non-empty root is prepended to each source, so rebasing them alone is wrong.
   if (map.sourceRoot) {
     return content;
   }
@@ -164,8 +160,7 @@ export function normalizeEsm2022Path(
     return normalizedPath;
   }
 
-  // the segments are located from the destination path, since replacing the
-  // first occurrence in the full path would rewrite the destination path itself
+  // rewrite only below the destination path, which may itself contain the segment
   const tmpEsm2022Dir =
     join(entryPoint.primaryDestinationPath, 'tmp-esm2022') + sep;
   if (normalizedPath.startsWith(tmpEsm2022Dir)) {


### PR DESCRIPTION
## Current Behavior

`@nx/angular:ng-packagr-lite` builds buildable Angular libraries. On the `development` configuration, the generated `tsconfig.lib.json` keeps `declarationMap: true`, and four things go wrong:

- The emitted `.d.ts.map` files point one directory too far up, so an editor cannot jump from a consumer back to the library source. Declaration maps carry no copy of the source, so nothing recovers the broken path.
- The flat module file ships a declaration map of its own, and refers to it from the `.d.ts`. That map points at a file the build never writes.
- The generated `package.json` maps secondary entry points to files the executor never emits. Importing `@org/lib/entry-point` from an installed package fails with "Cannot find module".
- The build writes files outside the output path when that path itself contains `tmp-typings` or `tmp-esm2022` in one of its folder names.

## Expected Behavior

- Declaration maps point at the library's real source files, so go-to-source works from a consumer.
- The flat module file that the Angular compiler generates ships no declaration map.
- Secondary entry points map to files the executor writes, so importing them from an installed package works.
- Every file the build writes lands inside the configured output path.

## Related Issue(s)

Fixes #36357

## Implementation Notes

- The Angular compiler writes declarations under `<dest>/tmp-typings`, with map sources relative to that folder. The transform moves them one folder up, and rebases each `sources` entry against the new location.
- Maps that stay in place, that are not valid JSON, or that declare a `sourceRoot` pass through untouched. The sibling `tmp-esm2022` rename keeps the same depth, so `.js.map` files were never affected.
- The flat module file exists only in memory, so its map has no source to point at. Dropping the map and its `//# sourceMappingURL=` line leaves the `.d.ts` identical to a build with `declarationMap` off.
- The package manifest is written while the primary entry point is in progress. Every entry point is adjusted then, so the manifest does not depend on build order.
- The folder rewrite matched the first `tmp-typings` or `tmp-esm2022` anywhere in the path. The guard and the rewrite are anchored at the destination path instead.
- The executor supports ng-packagr 20, 21 and 22. Builds on 20.3.2, 21.2.5 and 22.0.1 reproduce every defect and resolve it. The paths and internals this transform reads are unchanged from 20.0.0 to 22.1.1.
- With tsserver, go-to-definition on an exported symbol lands on the `.ts` source.

> [!NOTE]
> Go-to-definition on the import specifier itself still lands on the generated flat module `.d.ts`. That file has no source to map back to. A full ng-packagr build lands on the entry file. Symbols imported from the library resolve to source either way.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/gh-36357-ccdce4ca)
<!-- polygraph-session-end -->
