### PR TITLE
fix(core): include continuous and default-config dependencies in show target

### DIFF
--- a/packages/nx/src/command-line/show/show-target/info.spec.ts
+++ b/packages/nx/src/command-line/show/show-target/info.spec.ts
@@ -838,4 +838,49 @@ describe('show target info', () => {
     expect(allLogged).not.toContain('(from');
     expect(allLogged).not.toContain('(by');
   });
+
+  it('includes continuous and default-configuration deps in show target', async () => {
+    setGraph(
+      new GraphBuilder()
+        .addProjectConfiguration(
+          {
+            root: 'apps/my-app-e2e',
+            name: 'my-app-e2e',
+            targets: {
+              e2e: {
+                executor: 'nx:run-commands',
+                options: { command: 'playwright test' },
+                configurations: { ci: {} },
+                defaultConfiguration: 'ci',
+                dependsOn: [{ projects: ['my-app'], target: 'serve' }],
+              },
+            },
+          },
+          'app'
+        )
+        .addProjectConfiguration(
+          {
+            root: 'apps/my-app',
+            name: 'my-app',
+            targets: {
+              serve: {
+                executor: '@nx/web:dev-server',
+                continuous: true,
+                dependsOn: ['build'],
+              },
+              build: { executor: '@nx/web:build' },
+            },
+          },
+          'app'
+        )
+        .build()
+    );
+
+    await showTargetInfoHandler({ target: 'my-app-e2e:e2e', json: true });
+
+    const parsed = JSON.parse((console.log as jest.Mock).mock.calls[0][0]);
+    expect(parsed.dependsOn).toEqual(['my-app:serve']);
+    expect(parsed.transitiveTasks).toEqual(['my-app:build']);
+    expect(parsed.transitiveTasks).not.toContain('my-app-e2e:e2e:ci');
+  });
 });

--- a/packages/nx/src/command-line/show/show-target/info.ts
+++ b/packages/nx/src/command-line/show/show-target/info.ts
@@ -199,8 +199,21 @@ function resolveTaskGraphDependencies(
       {}
     );
 
-    const rootId = createTaskId(projectName, targetName, configuration);
-    const directDeps = taskGraph.dependencies[rootId] ?? [];
+    // `createTaskGraph` resolves the target's `defaultConfiguration`, so the real
+    // root task id may carry a `:config` suffix that `createTaskId` with the raw
+    // configuration would omit. Find the root task by (project, target) instead.
+    const rootTask = Object.values(taskGraph.tasks).find(
+      (task) =>
+        task.target.project === projectName && task.target.target === targetName
+    );
+    const rootId =
+      rootTask?.id ?? createTaskId(projectName, targetName, configuration);
+    // Continuous dependencies (e.g. dev servers) live in a separate map but are
+    // direct dependencies just like the entries in `dependencies`.
+    const directDeps = [
+      ...(taskGraph.dependencies[rootId] ?? []),
+      ...(taskGraph.continuousDependencies[rootId] ?? []),
+    ];
     const directDepSet = new Set<string>(directDeps);
 
     const depSourceIndices = directDeps.map((depTaskId) => {


### PR DESCRIPTION
## Current Behavior

`nx show target <project>:<target>` reports no `Depends On` entries in two cases:

- the target declares a `defaultConfiguration`
- a `dependsOn` entry resolves to a `continuous` task, such as a dev server

In both cases the dependency is not dropped from the output entirely, it is misfiled: it shows up in the transitive task summary instead. With a `defaultConfiguration`, the target's own root task also leaks into its transitive task list.

This is visible on a Playwright e2e target whose `dependsOn` points at a continuous serve task: `nx show project` lists the dependency, while `nx show target` shows nothing under `Depends On`.

Both regressed in #35367, when `show target` moved from static config resolution to task-graph resolution.

## Expected Behavior

`nx show target` lists continuous and default-configuration dependencies under `Depends On`, matching what `nx show project` reports, and the transitive task summary contains only genuinely transitive tasks.

## Implementation Details

Two separate causes, both in `resolveTaskGraphDependencies`:

- The root task id was rebuilt with `createTaskId(project, target, configuration)` from the raw `configuration` argument. `createTaskGraph` resolves the target's `defaultConfiguration`, so the real root task id carries a `:<config>` suffix that the reconstructed id lacked. The lookup missed, leaving `dependsOn` empty and letting the root task fall through into its own `transitiveTasks`. The root task is now resolved from the task graph by `(project, target)` instead of being reconstructed.
- A `dependsOn` edge that resolves to a continuous task is stored in `taskGraph.continuousDependencies`, not `taskGraph.dependencies`, and the command only read the latter. The direct dependencies are now the union of both maps.

The two compound: with the wrong root id, `continuousDependencies[rootId]` is also undefined, so reading the continuous map only takes effect once the root id is correct.

Added a regression test covering both: a target with a `defaultConfiguration` depending on a `continuous` target in another project. It fails on the current code (`dependsOn` comes back undefined) and passes with the fix.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/nxc-4682-4d969173)
<!-- polygraph-session-end -->