### PR TITLE
chore(repo): override websocket-driver to ^0.7.5 to patch GHSA-xv26-6w52-cph6

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -368,6 +368,7 @@ overrides:
   form-data: ^4.0.6
   hasown: 2.0.4
   '@xhmikosr/decompress': 10.2.1
+  websocket-driver: ^0.7.5
 
 patchedDependencies:
   '@astrojs/starlight': 228878a1bd48ba76f2630925a90b16047a4b87b4559f750d4372442909652235
@@ -27012,8 +27013,8 @@ packages:
       webpack-cli:
         optional: true
 
-  websocket-driver@0.7.4:
-    resolution: {integrity: sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==}
+  websocket-driver@0.7.5:
+    resolution: {integrity: sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==}
     engines: {node: '>=0.8.0'}
 
   websocket-extensions@0.1.4:
@@ -45028,7 +45029,7 @@ snapshots:
 
   faye-websocket@0.11.4:
     dependencies:
-      websocket-driver: 0.7.4
+      websocket-driver: 0.7.5
 
   fb-dotslash@0.5.8: {}
 
@@ -54377,7 +54378,7 @@ snapshots:
     dependencies:
       faye-websocket: 0.11.4
       uuid: 8.3.2
-      websocket-driver: 0.7.4
+      websocket-driver: 0.7.5
 
   socks-proxy-agent@8.0.5:
     dependencies:
@@ -57720,7 +57721,7 @@ snapshots:
       - postcss
       - uglify-js
 
-  websocket-driver@0.7.4:
+  websocket-driver@0.7.5:
     dependencies:
       http-parser-js: 0.5.10
       safe-buffer: 5.2.1

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -31,6 +31,7 @@ overrides:
   # pin to one version so expand-deps can flatten nx's published deps.
   hasown: '2.0.4'
   '@xhmikosr/decompress': '10.2.1'
+  websocket-driver: '^0.7.5'
 onlyBuiltDependencies:
   - '@nestjs/core'
   - 'nx'


### PR DESCRIPTION
## Current Behavior

The daily **NPM Audit** workflow (`.github/workflows/npm-audit.yml`, which runs `pnpm dlx audit-ci --critical`) is failing on a critical advisory:

- **[GHSA-xv26-6w52-cph6](https://github.com/advisories/GHSA-xv26-6w52-cph6)** (CVE-2026-54466, CVSS 9.2) - `websocket-driver` parses crafted protocol length headers into an integer large enough to lose precision in a 64-bit float, so the payload is parsed incorrectly.
- Vulnerable range: `< 0.7.5`; patched in `0.7.5`.
- The lockfile resolved `websocket-driver@0.7.4`, pulled in transitively via `webpack-dev-server > sockjs` (and `sockjs > faye-websocket`).

The patch has been out since 2026-06-04. The advisory was only reviewed into the GitHub Advisory Database on 2026-07-15, which is when the audit started reporting it, so nothing changed on our side.

## Expected Behavior

`websocket-driver` is pinned to the patched `^0.7.5` via a pnpm override, so all consumers resolve the safe version and the audit passes with `critical: 0`.

Verified locally with the exact CI command:

```
pnpm dlx audit-ci --critical --report-type summary
-> "critical": 0  ->  Passed pnpm security audit.
```

`websocket-driver@0.7.5` clears the repo's `minimumReleaseAge` gate.

## Implementation Details

Both consumers already allow the patched version (`sockjs@0.3.24` asks for `^0.7.4`, `faye-websocket@0.11.4` for `>=0.5.1`), so the lockfile was simply stale. The override is not needed to unblock the resolution, but it keeps every path on a safe version and guards against a future consumer pulling an older one, matching how #35974 and #36333 handled the same situation.

The override only affects this repo's lockfile. It is not published, and it does not change what users resolve: `webpack-dev-server` is an optional peer dependency of `@nx/webpack`, so a downstream install resolves `websocket-driver` on its own and already picks up `0.7.5`.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/fix-security-audit-b0c1e833)
<!-- polygraph-session-end -->