### PR TITLE
fix(angular-rspack): map bundled sourcemaps back to TypeScript sources

### DIFF
--- a/e2e/angular/src/projects-build-and-test.test.ts
+++ b/e2e/angular/src/projects-build-and-test.test.ts
@@ -129,6 +129,30 @@ describe('Angular Projects - Build and Test', () => {
       env: { NODE_ENV: 'production' },
     });
 
+    // build with sourcemaps enabled (the development configuration sets
+    // `sourceMap: true`) and verify the emitted sourcemap resolves back to
+    // the original TypeScript sources instead of the intermediate Ivy JS
+    runCLI(`build ${app} --skip-nx-cache`, {
+      env: { NGRS_CONFIG: 'development' },
+    });
+    const bundleMap = JSON.parse(
+      readFile(`dist/my-dir/${app}/browser/main.js.map`)
+    );
+    const tsSources = bundleMap.sources
+      .map((source: string, index: number) => ({
+        source,
+        content: bundleMap.sourcesContent?.[index],
+      }))
+      .filter(({ source }) => source.endsWith('.ts'));
+    expect(tsSources.length).toBeGreaterThan(0);
+    // the original TypeScript contains the `@Component` decorator, while the
+    // intermediate Ivy JS has it compiled away into `ɵcmp`
+    const componentSource = tsSources.find(({ content }) =>
+      content?.includes('@Component')
+    );
+    expect(componentSource).toBeDefined();
+    expect(componentSource.content).not.toContain('ɵcmp');
+
     if (runE2ETests()) {
       expect(() => runCLI(`e2e ${app}-e2e`)).not.toThrow();
       expect(await killPort(port)).toBeTruthy();

--- a/packages/angular-rspack-compiler/src/compilation/setup-compilation.spec.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-compilation.spec.ts
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { CompilerOptions } from 'typescript';
+import { setupCompilation } from './setup-compilation';
+
+const readConfiguration = vi.fn();
+
+vi.mock('../utils', () => ({
+  loadCompilerCli: vi.fn(async () => ({ readConfiguration })),
+}));
+
+vi.mock('../utils/assert-supported-versions', () => ({
+  assertSupportedAngularRspackCompilerVersions: vi.fn(),
+}));
+
+vi.mock('../utils/targets-from-browsers', () => ({
+  transformSupportedBrowsersToTargets: vi.fn(() => []),
+}));
+
+vi.mock('@angular/build/private', () => ({
+  ComponentStylesheetBundler: class {
+    dispose = vi.fn();
+  },
+  findTailwindConfiguration: vi.fn(() => undefined),
+  generateSearchDirectories: vi.fn(async () => []),
+  loadPostcssConfiguration: vi.fn(async () => undefined),
+  getSupportedBrowsers: vi.fn(() => []),
+}));
+
+describe('setupCompilation sourcemap options', () => {
+  const baseOptions = {
+    root: '/root',
+    tsConfig: '/root/tsconfig.json',
+    aot: true,
+    inlineStyleLanguage: 'css' as const,
+    fileReplacements: [],
+  };
+
+  // Capture the compiler options that `setupCompilation` merges and passes to
+  // the Angular compiler-cli's `readConfiguration`.
+  const getMergedOptions = (): CompilerOptions =>
+    readConfiguration.mock.calls.at(-1)?.[1];
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    readConfiguration.mockReturnValue({ options: {}, rootNames: [] });
+  });
+
+  it('emits an inline sourcemap with sources when sourcemaps are enabled', async () => {
+    await setupCompilation({ mode: 'development' }, { ...baseOptions });
+
+    const merged = getMergedOptions();
+    // An external `.js.map` is not readable by the downstream
+    // JavaScriptTransformer/linker, so the intermediate map must be inline.
+    expect(merged.sourceMap).toBe(false);
+    expect(merged.inlineSourceMap).toBe(true);
+    expect(merged.inlineSources).toBe(true);
+  });
+
+  it('respects an explicit sourceMap: false', async () => {
+    await setupCompilation(
+      { mode: 'development' },
+      { ...baseOptions, sourceMap: false }
+    );
+
+    const merged = getMergedOptions();
+    expect(merged.inlineSourceMap).toBe(false);
+    expect(merged.inlineSources).toBe(false);
+  });
+
+  it('disables sourcemaps entirely for the project-references path', async () => {
+    await setupCompilation(
+      { mode: 'development' },
+      { ...baseOptions, useTsProjectReferences: true }
+    );
+
+    const merged = getMergedOptions();
+    expect(merged.sourceMap).toBe(false);
+    expect(merged.inlineSourceMap).toBe(false);
+    expect(merged.inlineSources).toBe(false);
+    expect(merged.isolatedModules).toBe(true);
+  });
+});

--- a/packages/angular-rspack-compiler/src/compilation/setup-compilation.spec.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-compilation.spec.ts
@@ -56,14 +56,19 @@ describe('setupCompilation sourcemap options', () => {
     expect(merged.inlineSources).toBe(true);
   });
 
-  it('respects an explicit sourceMap: false', async () => {
+  it('keeps the inline sourcemap but omits sources when sourceMap is false', async () => {
     await setupCompilation(
       { mode: 'development' },
       { ...baseOptions, sourceMap: false }
     );
 
     const merged = getMergedOptions();
-    expect(merged.inlineSourceMap).toBe(false);
+    // `inlineSourceMap` must stay on even with sourcemaps disabled: without
+    // any sourcemap option, `AotCompilation.emitAffectedFiles` skips
+    // TypeScript transpilation for `isolatedModules` projects and emits raw
+    // TypeScript, which the babel-based JavaScriptTransformer cannot parse.
+    expect(merged.sourceMap).toBe(false);
+    expect(merged.inlineSourceMap).toBe(true);
     expect(merged.inlineSources).toBe(false);
   });
 

--- a/packages/angular-rspack-compiler/src/compilation/setup-compilation.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-compilation.ts
@@ -29,9 +29,11 @@ export interface SetupCompilationOptions {
   includePaths?: string[];
   sass?: Sass;
   /**
-   * Whether to emit script sourcemaps. When enabled, the Angular compilation
-   * emits an *inline* sourcemap (see `DEFAULT_NG_COMPILER_OPTIONS`) so the
-   * downstream `JavaScriptTransformer` can chain it back to the original
+   * Whether to emit script sourcemaps. The Angular compilation always emits
+   * an *inline* sourcemap (required to keep TypeScript transpilation enabled
+   * — see the compiler options below); this option controls whether the
+   * original sources are embedded in it so the downstream
+   * `JavaScriptTransformer` can chain the mapping back to the original
    * TypeScript. Defaults to `true` to preserve the previous behavior.
    */
   sourceMap?: boolean;
@@ -73,8 +75,17 @@ export async function setupCompilation(
       // input sourcemaps, so an external `.js.map` would be dropped and the
       // chained sourcemap would point at the intermediate Ivy JavaScript
       // instead of the original TypeScript.
+      //
+      // `inlineSourceMap` must stay enabled even when sourcemaps are turned
+      // off: `AotCompilation.emitAffectedFiles` skips TypeScript transpilation
+      // entirely for `isolatedModules` projects when no sourcemap option is
+      // set, emitting raw TypeScript for esbuild to transpile — but this
+      // babel-based pipeline cannot parse TypeScript. The loaders strip the
+      // inline sourcemap comment from the emitted code, and Rspack discards
+      // the extracted map when `devtool` is disabled, so only `inlineSources`
+      // is gated on the user's sourcemap setting.
       sourceMap: false,
-      inlineSourceMap: sourceMap,
+      inlineSourceMap: true,
       inlineSources: sourceMap,
       ...(options.useTsProjectReferences
         ? {

--- a/packages/angular-rspack-compiler/src/compilation/setup-compilation.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-compilation.ts
@@ -28,12 +28,18 @@ export interface SetupCompilationOptions {
   hasServer?: boolean;
   includePaths?: string[];
   sass?: Sass;
+  /**
+   * Whether to emit script sourcemaps. When enabled, the Angular compilation
+   * emits an *inline* sourcemap (see `DEFAULT_NG_COMPILER_OPTIONS`) so the
+   * downstream `JavaScriptTransformer` can chain it back to the original
+   * TypeScript. Defaults to `true` to preserve the previous behavior.
+   */
+  sourceMap?: boolean;
 }
 
 export const DEFAULT_NG_COMPILER_OPTIONS: ts.CompilerOptions = {
   suppressOutputPathCheck: true,
   outDir: undefined,
-  sourceMap: true,
   declaration: false,
   declarationMap: false,
   allowEmptyCodegenFiles: false,
@@ -55,14 +61,25 @@ export async function setupCompilation(
 ) {
   assertSupportedAngularRspackCompilerVersions();
 
+  const sourceMap = options.sourceMap ?? true;
   const { readConfiguration } = await loadCompilerCli();
   const { options: tsCompilerOptions, rootNames } = readConfiguration(
     config.source?.tsconfigPath ?? options.tsConfig,
     {
       ...DEFAULT_NG_COMPILER_OPTIONS,
+      // Align with `@angular/build`'s esbuild pipeline: emit an *inline*
+      // sourcemap that also embeds the original sources. The downstream
+      // `JavaScriptTransformer` (babel + the Angular linker) only reads inline
+      // input sourcemaps, so an external `.js.map` would be dropped and the
+      // chained sourcemap would point at the intermediate Ivy JavaScript
+      // instead of the original TypeScript.
+      sourceMap: false,
+      inlineSourceMap: sourceMap,
+      inlineSources: sourceMap,
       ...(options.useTsProjectReferences
         ? {
             sourceMap: false,
+            inlineSourceMap: false,
             inlineSources: false,
             isolatedModules: true,
           }

--- a/packages/angular-rspack/src/lib/config/config-utils/common-config.ts
+++ b/packages/angular-rspack/src/lib/config/config-utils/common-config.ts
@@ -52,6 +52,13 @@ export async function getCommonConfig(
       normalizedOptions.optimization.styles.minify
         ? 'production'
         : 'development',
+    // `devtool` must stay coupled to `sourceMap.scripts`: with script
+    // sourcemaps disabled the Angular compilation still emits inline maps
+    // (required to keep TypeScript transpilation enabled, see
+    // `setupCompilation`) but without `inlineSources`, and babel may pass a
+    // stale pre-linker map comment through — the loaders can then extract a
+    // map that must be discarded, which only happens while `devtool` is off
+    // in exactly this configuration.
     devtool: normalizedOptions.sourceMap.scripts ? 'source-map' : false,
     infrastructureLogging: {
       appendOnly: false,

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
@@ -29,6 +29,7 @@ import {
   type NgRspackCompilation,
   type NormalizedAngularRspackPluginOptions,
 } from '../models';
+import { clearExtractionCache } from './loaders/inline-source-map';
 import { getLocaleBaseHref } from '../utils/get-locale-base-href';
 import { addError, addWarning } from '../utils/rspack-diagnostics';
 import { assertNever } from '../utils/misc-helpers';
@@ -400,6 +401,9 @@ export class AngularRspackPlugin implements RspackPluginInstance {
         try {
           await this.#javascriptTransformer.close();
           await disposeComponentStylesheetBundler();
+          // Drop memoized sourcemap extractions (they intentionally persist
+          // across watch rebuilds, so they are only released on shutdown).
+          clearExtractionCache();
         } catch {
           // Best-effort cleanup that must never fail the compiler teardown.
         }

--- a/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
+++ b/packages/angular-rspack/src/lib/plugins/angular-rspack-plugin.ts
@@ -507,6 +507,7 @@ export class AngularRspackPlugin implements RspackPluginInstance {
           hasServer: this.#_options.hasServer,
           includePaths: this.#_options.stylePreprocessorOptions?.includePaths,
           sass: this.#_options.stylePreprocessorOptions?.sass,
+          sourceMap: this.#_options.sourceMap.scripts,
         },
         this.#sourceFileCache,
         this.#angularCompilation,

--- a/packages/angular-rspack/src/lib/plugins/loaders/angular-partial-transform.loader.spec.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/angular-partial-transform.loader.spec.ts
@@ -58,9 +58,43 @@ describe('angular-partial-transform.loader', () => {
     );
 
     await vi.waitFor(() =>
-      expect(callback).toHaveBeenCalledWith(null, 'transformed')
+      expect(callback).toHaveBeenCalledWith(null, 'transformed', undefined)
     );
     expect(typescriptFileCache.get('/path/to/file.js')).toBe('transformed');
+  });
+
+  it('should extract an inline sourcemap from the transformed output', async () => {
+    const map = {
+      version: 3,
+      sources: ['file.js'],
+      sourcesContent: ['@angular content'],
+      mappings: 'AAAA',
+      names: [],
+    };
+    const inlineMap = Buffer.from(JSON.stringify(map)).toString('base64');
+    // Built via concatenation so the test transform doesn't treat the literal
+    // token in this source file as a real sourcemap reference.
+    const comment =
+      `//# source` +
+      `MappingURL=data:application/json;charset=utf-8;base64,${inlineMap}`;
+    const transformed = `transformed\n${comment}\n`;
+    transformFile.mockResolvedValue(Buffer.from(transformed));
+
+    angularPartialTransformLoader.call(
+      {
+        ...thisValue,
+        _compilation: makeCompilation(),
+        resourcePath: '/path/to/file.js',
+      },
+      '@angular content'
+    );
+
+    await vi.waitFor(() =>
+      expect(callback).toHaveBeenCalledWith(null, 'transformed', map)
+    );
+    // The full transformed output (including the inline map) stays cached so
+    // subsequent reads re-extract the same map.
+    expect(typescriptFileCache.get('/path/to/file.js')).toBe(transformed);
   });
 
   it('should fail the module when the transform rejects', async () => {

--- a/packages/angular-rspack/src/lib/plugins/loaders/angular-partial-transform.loader.spec.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/angular-partial-transform.loader.spec.ts
@@ -90,10 +90,15 @@ describe('angular-partial-transform.loader', () => {
     );
 
     await vi.waitFor(() =>
-      expect(callback).toHaveBeenCalledWith(null, 'transformed', map)
+      // The map is passed to Rspack as the decoded JSON string.
+      expect(callback).toHaveBeenCalledWith(
+        null,
+        'transformed',
+        JSON.stringify(map)
+      )
     );
     // The full transformed output (including the inline map) stays cached so
-    // subsequent reads re-extract the same map.
+    // subsequent reads resolve the same extraction.
     expect(typescriptFileCache.get('/path/to/file.js')).toBe(transformed);
   });
 

--- a/packages/angular-rspack/src/lib/plugins/loaders/angular-partial-transform.loader.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/angular-partial-transform.loader.ts
@@ -1,6 +1,6 @@
 import { LoaderContext } from '@rspack/core';
 import { NG_RSPACK_SYMBOL_NAME, NgRspackCompilation } from '../../models';
-import { extractInlineSourceMap } from './inline-source-map';
+import { extractInlineSourceMapCached } from './inline-source-map';
 
 export default function loader(this: LoaderContext<unknown>, content: string) {
   const callback = this.async();
@@ -38,12 +38,11 @@ export default function loader(this: LoaderContext<unknown>, content: string) {
 
     const existingTransform = typescriptFileCache.get(request);
     if (existingTransform) {
-      const existingContents =
-        typeof existingTransform === 'string'
-          ? existingTransform
-          : Buffer.from(existingTransform).toString('utf8');
-      const { code, map } = extractInlineSourceMap(existingContents);
-      callback(null, code, map as unknown as Parameters<typeof callback>[2]);
+      const { code, map } = extractInlineSourceMapCached(
+        request,
+        existingTransform
+      );
+      callback(null, code, map);
       return;
     }
 
@@ -54,8 +53,11 @@ export default function loader(this: LoaderContext<unknown>, content: string) {
         // Hand the inline sourcemap emitted by the transformer to Rspack so
         // the mapping back to the original source is preserved; Rspack does
         // not consume inline sourcemaps from loader output on its own.
-        const { code, map } = extractInlineSourceMap(transformedCode);
-        callback(null, code, map as unknown as Parameters<typeof callback>[2]);
+        const { code, map } = extractInlineSourceMapCached(
+          request,
+          transformedCode
+        );
+        callback(null, code, map);
       },
       (error) => {
         // Fail the module instead of leaving the loader callback pending,

--- a/packages/angular-rspack/src/lib/plugins/loaders/angular-partial-transform.loader.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/angular-partial-transform.loader.ts
@@ -1,5 +1,6 @@
 import { LoaderContext } from '@rspack/core';
 import { NG_RSPACK_SYMBOL_NAME, NgRspackCompilation } from '../../models';
+import { extractInlineSourceMap } from './inline-source-map';
 
 export default function loader(this: LoaderContext<unknown>, content: string) {
   const callback = this.async();
@@ -41,7 +42,8 @@ export default function loader(this: LoaderContext<unknown>, content: string) {
         typeof existingTransform === 'string'
           ? existingTransform
           : Buffer.from(existingTransform).toString('utf8');
-      callback(null, existingContents);
+      const { code, map } = extractInlineSourceMap(existingContents);
+      callback(null, code, map as unknown as Parameters<typeof callback>[2]);
       return;
     }
 
@@ -49,7 +51,11 @@ export default function loader(this: LoaderContext<unknown>, content: string) {
       (contents) => {
         const transformedCode = Buffer.from(contents).toString('utf8');
         typescriptFileCache.set(request, transformedCode);
-        callback(null, transformedCode);
+        // Hand the inline sourcemap emitted by the transformer to Rspack so
+        // the mapping back to the original source is preserved; Rspack does
+        // not consume inline sourcemaps from loader output on its own.
+        const { code, map } = extractInlineSourceMap(transformedCode);
+        callback(null, code, map as unknown as Parameters<typeof callback>[2]);
       },
       (error) => {
         // Fail the module instead of leaving the loader callback pending,

--- a/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.spec.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.spec.ts
@@ -169,10 +169,11 @@ describe('angular-transform.loader', () => {
       '@Component()'
     );
 
+    // The map is passed to Rspack as the decoded JSON string.
     expect(callback).toHaveBeenCalledWith(
       null,
       'export class AppComponent {}',
-      map
+      JSON.stringify(map)
     );
   });
 });

--- a/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.spec.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.spec.ts
@@ -120,7 +120,7 @@ describe('angular-transform.loader', () => {
       '@Component()'
     );
 
-    expect(callback).toHaveBeenCalledWith(null, 'cached content');
+    expect(callback).toHaveBeenCalledWith(null, 'cached content', undefined);
   });
 
   it('should return content when typescriptFileCache does contain Buffer', () => {
@@ -138,6 +138,41 @@ describe('angular-transform.loader', () => {
       '@Component()'
     );
 
-    expect(callback).toHaveBeenCalledWith(null, Buffer.from('cached content'));
+    expect(callback).toHaveBeenCalledWith(null, 'cached content', undefined);
+  });
+
+  it('should extract an inline sourcemap and pass it to the callback', () => {
+    const map = {
+      version: 3,
+      sources: ['app.component.ts'],
+      sourcesContent: ['@Component()'],
+      mappings: 'AAAA',
+      names: [],
+    };
+    const inlineMap = Buffer.from(JSON.stringify(map)).toString('base64');
+    // Built via concatenation so the test transform doesn't treat the literal
+    // token in this source file as a real sourcemap reference.
+    const comment =
+      `//# source` +
+      `MappingURL=data:application/json;charset=utf-8;base64,${inlineMap}`;
+    typescriptFileCache.set(
+      '/home/projects/analog/src/app/app.component.ts',
+      `export class AppComponent {}\n${comment}\n`
+    );
+
+    angularTransformLoader.call(
+      {
+        ...thisValue,
+        _compilation,
+        resourcePath: '/home/projects/analog/src/app/app.component.ts',
+      },
+      '@Component()'
+    );
+
+    expect(callback).toHaveBeenCalledWith(
+      null,
+      'export class AppComponent {}',
+      map
+    );
   });
 });

--- a/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.ts
@@ -5,7 +5,7 @@ import {
   StyleUrlsResolver,
   TemplateUrlsResolver,
 } from '@nx/angular-rspack-compiler';
-import { extractInlineSourceMap } from './inline-source-map';
+import { extractInlineSourceMapCached } from './inline-source-map';
 
 const _styleUrlsResolver = new StyleUrlsResolver();
 const _templateUrlsResolver = new TemplateUrlsResolver();
@@ -65,16 +65,11 @@ export default function loader(
       // chained through the Angular linker). Rspack does not consume inline
       // sourcemaps from loader output, so extract it and pass it to the
       // callback to preserve the mapping back to the original TypeScript.
-      const code =
-        typeof contents === 'string'
-          ? contents
-          : Buffer.from(contents).toString('utf-8');
-      const { code: transformedCode, map } = extractInlineSourceMap(code);
-      callback(
-        null,
-        transformedCode,
-        map as unknown as Parameters<typeof callback>[2]
+      const { code, map } = extractInlineSourceMapCached(
+        normalizedRequest,
+        contents
       );
+      callback(null, code, map);
     }
   }
 }

--- a/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.ts
@@ -5,6 +5,7 @@ import {
   StyleUrlsResolver,
   TemplateUrlsResolver,
 } from '@nx/angular-rspack-compiler';
+import { extractInlineSourceMap } from './inline-source-map';
 
 const _styleUrlsResolver = new StyleUrlsResolver();
 const _templateUrlsResolver = new TemplateUrlsResolver();
@@ -59,10 +60,21 @@ export default function loader(
     const contents = typescriptFileCache.get(normalizedRequest);
     if (contents === undefined) {
       callback(null, content);
-    } else if (typeof contents === 'string') {
-      callback(null, contents);
     } else {
-      callback(null, Buffer.from(contents));
+      // The cached contents carry an inline sourcemap (emitted by ngc and
+      // chained through the Angular linker). Rspack does not consume inline
+      // sourcemaps from loader output, so extract it and pass it to the
+      // callback to preserve the mapping back to the original TypeScript.
+      const code =
+        typeof contents === 'string'
+          ? contents
+          : Buffer.from(contents).toString('utf-8');
+      const { code: transformedCode, map } = extractInlineSourceMap(code);
+      callback(
+        null,
+        transformedCode,
+        map as unknown as Parameters<typeof callback>[2]
+      );
     }
   }
 }

--- a/packages/angular-rspack/src/lib/plugins/loaders/inline-source-map.spec.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/inline-source-map.spec.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest';
+import { extractInlineSourceMap } from './inline-source-map';
+
+describe('extractInlineSourceMap', () => {
+  const map = {
+    version: 3,
+    sources: ['app.component.ts'],
+    sourcesContent: ['export class AppComponent {}'],
+    mappings: 'AAAA',
+    names: [],
+  };
+  const encode = (value: unknown) =>
+    Buffer.from(JSON.stringify(value)).toString('base64');
+  // Built via concatenation so bundlers/test transforms don't treat the
+  // literal token in this source file as a real sourcemap reference.
+  const inlineComment = (data: string, charset = true) =>
+    `//# source` +
+    `MappingURL=data:application/json;${
+      charset ? 'charset=utf-8;' : ''
+    }base64,${data}`;
+
+  it('returns the code untouched when there is no inline sourcemap', () => {
+    expect(extractInlineSourceMap('const a = 1;')).toEqual({
+      code: 'const a = 1;',
+      map: undefined,
+    });
+  });
+
+  it('extracts a base64 inline sourcemap and strips the comment', () => {
+    const code = `const a = 1;\n${inlineComment(encode(map))}\n`;
+
+    expect(extractInlineSourceMap(code)).toEqual({
+      code: 'const a = 1;',
+      map,
+    });
+  });
+
+  it('handles the comment without a charset segment', () => {
+    const code = `const a = 1;\n${inlineComment(encode(map), false)}`;
+
+    expect(extractInlineSourceMap(code)).toEqual({
+      code: 'const a = 1;',
+      map,
+    });
+  });
+
+  it('passes the code through when the embedded map is malformed', () => {
+    // Valid base64 that decodes to text which is not valid JSON.
+    const notJson = Buffer.from('not json').toString('base64');
+    const code = `const a = 1;\n${inlineComment(notJson, false)}`;
+
+    expect(extractInlineSourceMap(code)).toEqual({
+      code,
+      map: undefined,
+    });
+  });
+});

--- a/packages/angular-rspack/src/lib/plugins/loaders/inline-source-map.spec.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/inline-source-map.spec.ts
@@ -73,12 +73,24 @@ describe('extractInlineSourceMap', () => {
   });
 
   // Any JSON value that is not a raw v3 sourcemap would fail the module
-  // build when forwarded to Rspack's loader callback.
+  // build when forwarded to Rspack's loader callback — including well-shaped
+  // maps with wrongly typed nested fields, which rspack's deserializer
+  // rejects with `bad json: ExpectedString`.
   it.each([
     ['an empty object', {}],
     ['null', null],
     ['an array', []],
     ['a map missing v3 fields', { version: 3 }],
+    ['a map with a non-string sources element', { ...map, sources: [42] }],
+    ['a map with a non-string names element', { ...map, names: [1] }],
+    [
+      'a map with a non-string sourcesContent element',
+      { ...map, sourcesContent: [42] },
+    ],
+    ['a map with a non-string file', { ...map, file: 42 }],
+    ['a map with a non-string sourceRoot', { ...map, sourceRoot: 1 }],
+    ['a map with a non-string debugId', { ...map, debugId: 1 }],
+    ['a map with a non-numeric ignoreList', { ...map, ignoreList: ['a'] }],
   ])('passes the code through when the payload is %s', (_, payload) => {
     const code = `const a = 1;\n${inlineComment(encode(payload))}`;
 
@@ -86,6 +98,20 @@ describe('extractInlineSourceMap', () => {
       code,
       map: undefined,
     });
+  });
+
+  // Optional fields may be null (rspack treats a JSON null like an absent
+  // optional field) and sourcesContent entries may be null per the spec.
+  it.each([
+    ['null optional fields', { ...map, file: null, sourceRoot: null }],
+    ['a null sourcesContent entry', { ...map, sourcesContent: [null] }],
+    ['a numeric ignoreList', { ...map, ignoreList: [0] }],
+  ])('accepts a map with %s', (_, payload) => {
+    const code = `const a = 1;\n${inlineComment(encode(payload))}`;
+
+    const result = extractInlineSourceMap(code);
+    expect(result.code).toBe('const a = 1;');
+    expect(JSON.parse(result.map!)).toEqual(payload);
   });
 });
 

--- a/packages/angular-rspack/src/lib/plugins/loaders/inline-source-map.spec.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/inline-source-map.spec.ts
@@ -71,6 +71,22 @@ describe('extractInlineSourceMap', () => {
       map: undefined,
     });
   });
+
+  // Any JSON value that is not a raw v3 sourcemap would fail the module
+  // build when forwarded to Rspack's loader callback.
+  it.each([
+    ['an empty object', {}],
+    ['null', null],
+    ['an array', []],
+    ['a map missing v3 fields', { version: 3 }],
+  ])('passes the code through when the payload is %s', (_, payload) => {
+    const code = `const a = 1;\n${inlineComment(encode(payload))}`;
+
+    expect(extractInlineSourceMap(code)).toEqual({
+      code,
+      map: undefined,
+    });
+  });
 });
 
 describe('extractInlineSourceMapCached', () => {

--- a/packages/angular-rspack/src/lib/plugins/loaders/inline-source-map.spec.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/inline-source-map.spec.ts
@@ -1,24 +1,27 @@
 import { describe, expect, it } from 'vitest';
-import { extractInlineSourceMap } from './inline-source-map';
+import {
+  extractInlineSourceMap,
+  extractInlineSourceMapCached,
+} from './inline-source-map';
+
+const map = {
+  version: 3,
+  sources: ['app.component.ts'],
+  sourcesContent: ['export class AppComponent {}'],
+  mappings: 'AAAA',
+  names: [],
+};
+const encode = (value: unknown) =>
+  Buffer.from(JSON.stringify(value)).toString('base64');
+// Built via concatenation so bundlers/test transforms don't treat the
+// literal token in this source file as a real sourcemap reference.
+const inlineComment = (data: string, charset = true) =>
+  `//# source` +
+  `MappingURL=data:application/json;${
+    charset ? 'charset=utf-8;' : ''
+  }base64,${data}`;
 
 describe('extractInlineSourceMap', () => {
-  const map = {
-    version: 3,
-    sources: ['app.component.ts'],
-    sourcesContent: ['export class AppComponent {}'],
-    mappings: 'AAAA',
-    names: [],
-  };
-  const encode = (value: unknown) =>
-    Buffer.from(JSON.stringify(value)).toString('base64');
-  // Built via concatenation so bundlers/test transforms don't treat the
-  // literal token in this source file as a real sourcemap reference.
-  const inlineComment = (data: string, charset = true) =>
-    `//# source` +
-    `MappingURL=data:application/json;${
-      charset ? 'charset=utf-8;' : ''
-    }base64,${data}`;
-
   it('returns the code untouched when there is no inline sourcemap', () => {
     expect(extractInlineSourceMap('const a = 1;')).toEqual({
       code: 'const a = 1;',
@@ -26,40 +29,36 @@ describe('extractInlineSourceMap', () => {
     });
   });
 
-  it('extracts a base64 inline sourcemap and strips the comment', () => {
+  it('extracts a base64 inline sourcemap as a JSON string and strips the comment', () => {
     const code = `const a = 1;\n${inlineComment(encode(map))}\n`;
 
-    expect(extractInlineSourceMap(code)).toEqual({
-      code: 'const a = 1;',
-      map,
-    });
+    const result = extractInlineSourceMap(code);
+    expect(result.code).toBe('const a = 1;');
+    expect(JSON.parse(result.map!)).toEqual(map);
   });
 
   it('handles the comment without a charset segment', () => {
     const code = `const a = 1;\n${inlineComment(encode(map), false)}`;
 
-    expect(extractInlineSourceMap(code)).toEqual({
-      code: 'const a = 1;',
-      map,
-    });
+    const result = extractInlineSourceMap(code);
+    expect(result.code).toBe('const a = 1;');
+    expect(JSON.parse(result.map!)).toEqual(map);
   });
 
   it('strips a CRLF that precedes the comment', () => {
     const code = `const a = 1;\r\n${inlineComment(encode(map))}`;
 
-    expect(extractInlineSourceMap(code)).toEqual({
-      code: 'const a = 1;',
-      map,
-    });
+    const result = extractInlineSourceMap(code);
+    expect(result.code).toBe('const a = 1;');
+    expect(JSON.parse(result.map!)).toEqual(map);
   });
 
   it('tolerates extra trailing newlines after the comment', () => {
     const code = `const a = 1;\n${inlineComment(encode(map))}\n\n`;
 
-    expect(extractInlineSourceMap(code)).toEqual({
-      code: 'const a = 1;',
-      map,
-    });
+    const result = extractInlineSourceMap(code);
+    expect(result.code).toBe('const a = 1;');
+    expect(JSON.parse(result.map!)).toEqual(map);
   });
 
   it('passes the code through when the embedded map is malformed', () => {
@@ -71,5 +70,48 @@ describe('extractInlineSourceMap', () => {
       code,
       map: undefined,
     });
+  });
+});
+
+describe('extractInlineSourceMapCached', () => {
+  it('reuses the extraction result for the same cached contents instance', () => {
+    const code = `const a = 1;\n${inlineComment(encode(map))}`;
+
+    const first = extractInlineSourceMapCached('/memo/app.ts', code);
+    const second = extractInlineSourceMapCached('/memo/app.ts', code);
+
+    expect(second).toBe(first);
+    expect(first.code).toBe('const a = 1;');
+    expect(JSON.parse(first.map!)).toEqual(map);
+  });
+
+  it('re-extracts when the cached contents are replaced', () => {
+    const key = '/memo/replaced.ts';
+    const first = extractInlineSourceMapCached(
+      key,
+      `const a = 1;\n${inlineComment(encode(map))}`
+    );
+
+    const updatedMap = { ...map, sources: ['app.ts'] };
+    const second = extractInlineSourceMapCached(
+      key,
+      `const b = 2;\n${inlineComment(encode(updatedMap))}`
+    );
+
+    expect(second).not.toBe(first);
+    expect(second.code).toBe('const b = 2;');
+    expect(JSON.parse(second.map!)).toEqual(updatedMap);
+  });
+
+  it('decodes Uint8Array contents', () => {
+    const code = `const a = 1;\n${inlineComment(encode(map))}`;
+
+    const result = extractInlineSourceMapCached(
+      '/memo/buffer.ts',
+      new Uint8Array(Buffer.from(code))
+    );
+
+    expect(result.code).toBe('const a = 1;');
+    expect(JSON.parse(result.map!)).toEqual(map);
   });
 });

--- a/packages/angular-rspack/src/lib/plugins/loaders/inline-source-map.spec.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/inline-source-map.spec.ts
@@ -44,6 +44,24 @@ describe('extractInlineSourceMap', () => {
     });
   });
 
+  it('strips a CRLF that precedes the comment', () => {
+    const code = `const a = 1;\r\n${inlineComment(encode(map))}`;
+
+    expect(extractInlineSourceMap(code)).toEqual({
+      code: 'const a = 1;',
+      map,
+    });
+  });
+
+  it('tolerates extra trailing newlines after the comment', () => {
+    const code = `const a = 1;\n${inlineComment(encode(map))}\n\n`;
+
+    expect(extractInlineSourceMap(code)).toEqual({
+      code: 'const a = 1;',
+      map,
+    });
+  });
+
   it('passes the code through when the embedded map is malformed', () => {
     // Valid base64 that decodes to text which is not valid JSON.
     const notJson = Buffer.from('not json').toString('base64');

--- a/packages/angular-rspack/src/lib/plugins/loaders/inline-source-map.spec.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/inline-source-map.spec.ts
@@ -91,6 +91,13 @@ describe('extractInlineSourceMap', () => {
     ['a map with a non-string sourceRoot', { ...map, sourceRoot: 1 }],
     ['a map with a non-string debugId', { ...map, debugId: 1 }],
     ['a map with a non-numeric ignoreList', { ...map, ignoreList: ['a'] }],
+    // ignoreList entries are u32 on the rspack side (`ExpectedUnsigned`).
+    ['a map with a negative ignoreList entry', { ...map, ignoreList: [-1] }],
+    ['a map with a fractional ignoreList entry', { ...map, ignoreList: [1.5] }],
+    [
+      'a map with an ignoreList entry above u32 range',
+      { ...map, ignoreList: [4294967296] },
+    ],
   ])('passes the code through when the payload is %s', (_, payload) => {
     const code = `const a = 1;\n${inlineComment(encode(payload))}`;
 

--- a/packages/angular-rspack/src/lib/plugins/loaders/inline-source-map.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/inline-source-map.ts
@@ -60,6 +60,17 @@ const extractionCache = new Map<
 >();
 
 /**
+ * Release all memoized extraction results. Called on compiler shutdown so a
+ * long-lived process does not retain code/map strings for files deleted or
+ * renamed during a watch session. (During the session the memo intentionally
+ * mirrors the lifetime of the typescript file cache it shadows, which keeps
+ * such entries too.)
+ */
+export function clearExtractionCache(): void {
+  extractionCache.clear();
+}
+
+/**
  * Memoized variant of {@link extractInlineSourceMap} for contents read from
  * the typescript file cache, keyed by the cache key (the file's request path).
  */

--- a/packages/angular-rspack/src/lib/plugins/loaders/inline-source-map.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/inline-source-map.ts
@@ -3,8 +3,11 @@
  * and by Angular's `JavaScriptTransformer` (babel with `sourceMaps: 'inline'`),
  * e.g. `//# sourceMappingURL=data:application/json;charset=utf-8;base64,<data>`.
  */
+// The optional leading `\r?\n` consumes the newline (including CRLF) that
+// precedes the comment so no stray `\r` is left on the returned code, and the
+// trailing `\s*` tolerates any amount of trailing whitespace/newlines.
 const INLINE_SOURCE_MAP_REGEX =
-  /\n?\/\/# sourceMappingURL=data:application\/json;(?:charset=[^;,]+;)?base64,([a-zA-Z0-9+/=]+)[ \t]*\r?\n?$/;
+  /(?:\r?\n)?\/\/# sourceMappingURL=data:application\/json;(?:charset=[^;,]+;)?base64,([a-zA-Z0-9+/=]+)\s*$/;
 
 export interface ExtractedSourceMap {
   code: string;

--- a/packages/angular-rspack/src/lib/plugins/loaders/inline-source-map.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/inline-source-map.ts
@@ -49,25 +49,48 @@ export function extractInlineSourceMap(code: string): ExtractedSourceMap {
 
 /**
  * Validate that a decoded payload is a raw v3 sourcemap. Rspack fails the
- * module build when the loader callback receives any other JSON value
- * (`{}`, `null`, arrays, ...), so only payloads carrying the required v3
- * fields are forwarded. This matters particularly for the partial-transform
- * loader, which preserves input from arbitrary Angular-related JavaScript.
+ * module build when the loader callback receives anything its deserializer
+ * rejects — not just non-objects (`{}`, `null`, arrays, ...) but also
+ * well-shaped maps with wrongly typed fields (e.g. `sources: [42]` fails
+ * with `bad json: ExpectedString`) — so every field rspack reads is
+ * type-checked, including array elements. This matters particularly for the
+ * partial-transform loader, which preserves input from arbitrary
+ * Angular-related JavaScript. Optional fields may be `null`: rspack's
+ * deserializer treats a JSON `null` like an absent optional field.
  */
 function isRawSourceMap(json: string): boolean {
+  let parsed: unknown;
   try {
-    const parsed: unknown = JSON.parse(json);
-    return (
-      typeof parsed === 'object' &&
-      parsed !== null &&
-      !Array.isArray(parsed) &&
-      (parsed as { version?: unknown }).version === 3 &&
-      typeof (parsed as { mappings?: unknown }).mappings === 'string' &&
-      Array.isArray((parsed as { sources?: unknown }).sources)
-    );
+    parsed = JSON.parse(json);
   } catch {
     return false;
   }
+  if (typeof parsed !== 'object' || parsed === null || Array.isArray(parsed)) {
+    return false;
+  }
+
+  const map = parsed as Record<string, unknown>;
+  const isString = (value: unknown) => typeof value === 'string';
+  const isOptional = (value: unknown, check: (el: unknown) => boolean) =>
+    value === undefined || value === null || check(value);
+  const isArrayOf = (value: unknown, check: (el: unknown) => boolean) =>
+    Array.isArray(value) && value.every(check);
+
+  return (
+    map.version === 3 &&
+    typeof map.mappings === 'string' &&
+    isArrayOf(map.sources, isString) &&
+    isOptional(map.names, (v) => isArrayOf(v, isString)) &&
+    isOptional(map.sourcesContent, (v) =>
+      isArrayOf(v, (el) => el === null || isString(el))
+    ) &&
+    isOptional(map.file, isString) &&
+    isOptional(map.sourceRoot, isString) &&
+    isOptional(map.debugId, isString) &&
+    isOptional(map.ignoreList, (v) =>
+      isArrayOf(v, (el) => typeof el === 'number')
+    )
+  );
 }
 
 // In watch mode the loaders re-read unchanged entries from the shared

--- a/packages/angular-rspack/src/lib/plugins/loaders/inline-source-map.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/inline-source-map.ts
@@ -88,7 +88,16 @@ function isRawSourceMap(json: string): boolean {
     isOptional(map.sourceRoot, isString) &&
     isOptional(map.debugId, isString) &&
     isOptional(map.ignoreList, (v) =>
-      isArrayOf(v, (el) => typeof el === 'number')
+      // Source indices deserialized as u32 on the rspack side: negative,
+      // fractional, or > 0xffff_ffff values fail with `ExpectedUnsigned`.
+      isArrayOf(
+        v,
+        (el) =>
+          typeof el === 'number' &&
+          Number.isInteger(el) &&
+          el >= 0 &&
+          el <= 0xffff_ffff
+      )
     )
   );
 }

--- a/packages/angular-rspack/src/lib/plugins/loaders/inline-source-map.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/inline-source-map.ts
@@ -12,9 +12,10 @@ const INLINE_SOURCE_MAP_REGEX =
 export interface ExtractedSourceMap {
   code: string;
   /**
-   * The decoded sourcemap as a JSON string, validated to parse. Rspack's
-   * loader callback accepts string maps directly, so keeping it serialized
-   * avoids a JSON.parse/typing round-trip in the loaders.
+   * The decoded sourcemap as a JSON string, validated to be a raw v3
+   * sourcemap. Rspack's loader callback accepts string maps directly, so
+   * keeping it serialized avoids exposing a typed map object (and the casts
+   * that would require) at the loader boundary; Rspack parses it itself.
    */
   map: string | undefined;
 }
@@ -37,23 +38,46 @@ export function extractInlineSourceMap(code: string): ExtractedSourceMap {
   }
 
   const map = Buffer.from(match[1], 'base64').toString('utf-8');
-  try {
-    JSON.parse(map);
-  } catch {
-    // If the embedded map cannot be parsed, pass the code through untouched
-    // rather than failing the build over a malformed sourcemap.
+  if (!isRawSourceMap(map)) {
+    // If the embedded payload is not a sourcemap, pass the code through
+    // untouched rather than failing the build over it.
     return { code, map: undefined };
   }
 
   return { code: code.slice(0, match.index), map };
 }
 
+/**
+ * Validate that a decoded payload is a raw v3 sourcemap. Rspack fails the
+ * module build when the loader callback receives any other JSON value
+ * (`{}`, `null`, arrays, ...), so only payloads carrying the required v3
+ * fields are forwarded. This matters particularly for the partial-transform
+ * loader, which preserves input from arbitrary Angular-related JavaScript.
+ */
+function isRawSourceMap(json: string): boolean {
+  try {
+    const parsed: unknown = JSON.parse(json);
+    return (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      !Array.isArray(parsed) &&
+      (parsed as { version?: unknown }).version === 3 &&
+      typeof (parsed as { mappings?: unknown }).mappings === 'string' &&
+      Array.isArray((parsed as { sources?: unknown }).sources)
+    );
+  } catch {
+    return false;
+  }
+}
+
 // In watch mode the loaders re-read unchanged entries from the shared
 // typescript file cache on every rebuild, so memoize the extraction per cache
 // key to run the regex + base64 decode + JSON validation once per emitted
-// content instead of once per read. A re-emit stores a new string/buffer
-// instance in the file cache, so the identity check on the cached value
-// invalidates stale memo entries.
+// content instead of once per read. The `===` guard on the cached value keeps
+// the memo in sync with the file cache: reads of the same instance
+// short-circuit on reference equality, while a re-emit with changed contents
+// fails the comparison (strings compare by value, `Uint8Array` by reference)
+// and recomputes.
 const extractionCache = new Map<
   string,
   { source: string | Uint8Array; result: ExtractedSourceMap }

--- a/packages/angular-rspack/src/lib/plugins/loaders/inline-source-map.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/inline-source-map.ts
@@ -11,7 +11,12 @@ const INLINE_SOURCE_MAP_REGEX =
 
 export interface ExtractedSourceMap {
   code: string;
-  map: Record<string, unknown> | undefined;
+  /**
+   * The decoded sourcemap as a JSON string, validated to parse. Rspack's
+   * loader callback accepts string maps directly, so keeping it serialized
+   * avoids a JSON.parse/typing round-trip in the loaders.
+   */
+  map: string | undefined;
 }
 
 /**
@@ -20,8 +25,8 @@ export interface ExtractedSourceMap {
  *
  * Rspack, unlike esbuild, does not automatically consume inline
  * `//# sourceMappingURL=data:...` comments emitted by a loader. Passing the
- * parsed map as the loader's third callback argument lets Rspack chain it, so
- * the bundled sourcemaps point back to the original TypeScript instead of the
+ * map as the loader's third callback argument lets Rspack chain it, so the
+ * bundled sourcemaps point back to the original TypeScript instead of the
  * intermediate Ivy JavaScript. The comment is stripped from the returned code
  * to avoid the map being duplicated in the module source.
  */
@@ -31,15 +36,47 @@ export function extractInlineSourceMap(code: string): ExtractedSourceMap {
     return { code, map: undefined };
   }
 
+  const map = Buffer.from(match[1], 'base64').toString('utf-8');
   try {
-    const map = JSON.parse(
-      Buffer.from(match[1], 'base64').toString('utf-8')
-    ) as Record<string, unknown>;
-
-    return { code: code.slice(0, match.index), map };
+    JSON.parse(map);
   } catch {
     // If the embedded map cannot be parsed, pass the code through untouched
     // rather than failing the build over a malformed sourcemap.
     return { code, map: undefined };
   }
+
+  return { code: code.slice(0, match.index), map };
+}
+
+// In watch mode the loaders re-read unchanged entries from the shared
+// typescript file cache on every rebuild, so memoize the extraction per cache
+// key to run the regex + base64 decode + JSON validation once per emitted
+// content instead of once per read. A re-emit stores a new string/buffer
+// instance in the file cache, so the identity check on the cached value
+// invalidates stale memo entries.
+const extractionCache = new Map<
+  string,
+  { source: string | Uint8Array; result: ExtractedSourceMap }
+>();
+
+/**
+ * Memoized variant of {@link extractInlineSourceMap} for contents read from
+ * the typescript file cache, keyed by the cache key (the file's request path).
+ */
+export function extractInlineSourceMapCached(
+  key: string,
+  contents: string | Uint8Array
+): ExtractedSourceMap {
+  const cached = extractionCache.get(key);
+  if (cached && cached.source === contents) {
+    return cached.result;
+  }
+
+  const code =
+    typeof contents === 'string'
+      ? contents
+      : Buffer.from(contents).toString('utf-8');
+  const result = extractInlineSourceMap(code);
+  extractionCache.set(key, { source: contents, result });
+  return result;
 }

--- a/packages/angular-rspack/src/lib/plugins/loaders/inline-source-map.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/inline-source-map.ts
@@ -1,0 +1,42 @@
+/**
+ * A trailing inline sourcemap comment as produced by `tsc`'s `inlineSourceMap`
+ * and by Angular's `JavaScriptTransformer` (babel with `sourceMaps: 'inline'`),
+ * e.g. `//# sourceMappingURL=data:application/json;charset=utf-8;base64,<data>`.
+ */
+const INLINE_SOURCE_MAP_REGEX =
+  /\n?\/\/# sourceMappingURL=data:application\/json;(?:charset=[^;,]+;)?base64,([a-zA-Z0-9+/=]+)[ \t]*\r?\n?$/;
+
+export interface ExtractedSourceMap {
+  code: string;
+  map: Record<string, unknown> | undefined;
+}
+
+/**
+ * Extract a trailing inline sourcemap from transformed code so it can be handed
+ * to Rspack's loader callback as a proper source map.
+ *
+ * Rspack, unlike esbuild, does not automatically consume inline
+ * `//# sourceMappingURL=data:...` comments emitted by a loader. Passing the
+ * parsed map as the loader's third callback argument lets Rspack chain it, so
+ * the bundled sourcemaps point back to the original TypeScript instead of the
+ * intermediate Ivy JavaScript. The comment is stripped from the returned code
+ * to avoid the map being duplicated in the module source.
+ */
+export function extractInlineSourceMap(code: string): ExtractedSourceMap {
+  const match = code.match(INLINE_SOURCE_MAP_REGEX);
+  if (!match || match.index === undefined) {
+    return { code, map: undefined };
+  }
+
+  try {
+    const map = JSON.parse(
+      Buffer.from(match[1], 'base64').toString('utf-8')
+    ) as Record<string, unknown>;
+
+    return { code: code.slice(0, match.index), map };
+  } catch {
+    // If the embedded map cannot be parsed, pass the code through untouched
+    // rather than failing the build over a malformed sourcemap.
+    return { code, map: undefined };
+  }
+}


### PR DESCRIPTION
## Current Behavior

When building an Angular application with Rspack (`@nx/angular-rspack`), the generated sourcemaps point at the intermediate **Ivy JavaScript** instead of the original TypeScript. Setting a breakpoint in (or viewing the mapped source of) a `.ts` file shows generated Ivy code rather than the authored TypeScript.

The root cause is two broken links in the sourcemap chain (`ngc` → `JavaScriptTransformer`/linker → Rspack loader → bundle), both of which Angular's own esbuild pipeline handles differently:

1. The Angular compilation emitted an **external** `.js.map` (`sourceMap: true`). The downstream `JavaScriptTransformer` (babel + the Angular linker) only reads *inline* input sourcemaps, so the external map was dropped and the chained map stopped at the Ivy JS.
2. The Angular loaders returned transformed content but never handed the sourcemap to Rspack's loader callback. Unlike esbuild, Rspack does not auto-consume inline `//# sourceMappingURL=data:...` comments embedded in loader output, so `SourceMapDevToolPlugin` mapped the bundle output straight to the Ivy JS text.

## Expected Behavior

Bundled sourcemaps map back to the original TypeScript sources, matching how `@angular/build`'s esbuild pipeline preserves the mapping.

- Emit an intermediate **inline** sourcemap from the Angular compilation instead of an external `.js.map`, so the `JavaScriptTransformer`/linker can read it and chain it back to the TypeScript.
- Extract that inline sourcemap in the Angular loaders and pass it to Rspack's loader callback so Rspack chains it into the final bundle sourcemaps.

### Changes

- `angular-rspack-compiler`: emit inline sourcemaps from the Angular compilation, threaded through a new `sourceMap` compilation option.
  - **`inlineSourceMap` stays enabled even when sourcemaps are disabled** (only `inlineSources` is gated on the user's setting): with all sourcemap compiler options off, `AotCompilation.emitAffectedFiles` skips TypeScript transpilation for `isolatedModules` projects and emits raw TypeScript (expecting esbuild to strip types downstream), which this babel-based pipeline cannot parse — production builds of generated apps failed with a syntax error on type annotations. Keeping the inline map on matches the cost profile of the previous unconditional `sourceMap: true`. (Caught by the e2e test below.)
- `angular-rspack`: new `inline-source-map.ts` helper that extracts and strips a trailing base64 inline sourcemap comment; both `angular-transform.loader` and `angular-partial-transform.loader` forward the extracted map to Rspack.
  - Extraction is **memoized per cache key** (`===` guard on the cached value: same-instance reads short-circuit on reference equality; strings compare by value, `Uint8Array` by reference) so watch-mode rebuilds don't re-run the regex + base64 decode + JSON validation on every read of unchanged entries. The map is handed to Rspack as the decoded **JSON string** (accepted natively by the loader callback), avoiding typed-object casts at the loader boundary — Rspack parses the string itself.
  - The embedded payload is **validated as a raw v3 sourcemap, including nested field types**, before being forwarded: Rspack's deserializer fails the module build not just on non-map JSON values (`{}`, `null`, arrays) but also on wrongly typed fields (e.g. `sources: [42]`, invalid `names`/`sourcesContent`/`file`/`sourceRoot`/`debugId`/`ignoreList` → `bad json: ExpectedString`), which the partial-transform loader could otherwise pick up from arbitrary Angular-related JavaScript. Every field rspack reads is type-checked (array elements included; optional fields may be `null`, matching the deserializer); anything else passes the code through untouched with no map.

### Testing

- Unit tests for the extractor (incl. CRLF handling, trailing newlines, malformed and non-sourcemap payloads such as `{}`/`null`/arrays, wrongly typed nested fields per rejected field, null-optional acceptance, memoization), both loaders' sourcemap forwarding, and the compiler-option plumbing in `setup-compilation`.
- Extended the `should successfully work with rspack for build` e2e test: after the production build, it rebuilds with the development configuration (`sourceMap: true`), parses the emitted `main.js.map`, and asserts a `.ts` source is present whose `sourcesContent` contains the original `@Component` TypeScript and no Ivy markers (`ɵcmp`). Verified locally via the local-registry e2e flow (production + development builds green).

## Related Issue(s)

N/A — no linked issue; addresses the Rspack/Angular sourcemap regression described above.

