### PR TITLE
fix(react-native): include migration docs in the built package

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -485,6 +485,9 @@
         "rule": "./tools/workspace-plugin/dist/src/conformance-rules/nx-package-group"
       },
       {
+        "rule": "./tools/workspace-plugin/dist/src/conformance-rules/migration-markdown-assets"
+      },
+      {
         "rule": "./tools/workspace-plugin/dist/src/conformance-rules/no-ignored-tracked-files"
       },
       {

--- a/packages/react-native/assets.json
+++ b/packages/react-native/assets.json
@@ -2,6 +2,9 @@
   "outDir": "packages/react-native/dist",
   "assets": [
     {
+      "glob": "src/migrations/**/*.md"
+    },
+    {
       "glob": "**/files/**"
     },
     {

--- a/tools/workspace-plugin/jest.config.cts
+++ b/tools/workspace-plugin/jest.config.cts
@@ -3,6 +3,11 @@ module.exports = {
   displayName: 'workspace-plugin',
   preset: '../../jest.preset.js',
   moduleFileExtensions: ['ts', 'js', 'html'],
+  moduleNameMapper: {
+    // `nodenext` requires a `.js` specifier on relative imports; point them back
+    // at the TypeScript sources jest actually loads.
+    '^(\\.{1,2}/.*)\\.js$': '$1',
+  },
   coverageDirectory: '../../coverage/tools/workspace-plugin',
   // Override the workspace-wide resolver that redirects @nx/* imports to
   // packages/* source; this project is intended to consume the installed

--- a/tools/workspace-plugin/src/conformance-rules/migration-markdown-assets/index.spec.ts
+++ b/tools/workspace-plugin/src/conformance-rules/migration-markdown-assets/index.spec.ts
@@ -1,0 +1,142 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import { validateMigrationMarkdownAssets } from './index';
+
+describe('migration-markdown-assets', () => {
+  let rootDir: string;
+  const projectRoot = 'packages/acme';
+
+  beforeEach(() => {
+    rootDir = mkdtempSync(join(tmpdir(), 'migration-markdown-assets-'));
+  });
+
+  afterEach(() => {
+    rmSync(rootDir, { recursive: true, force: true });
+  });
+
+  function writeFile(path: string, content = '# Doc') {
+    const file = join(rootDir, path);
+    mkdirSync(dirname(file), { recursive: true });
+    writeFileSync(file, content);
+  }
+
+  function validate(migrations: Record<string, any>, assets: any[]) {
+    return validateMigrationMarkdownAssets({
+      migrations,
+      assetsJson: { outDir: `${projectRoot}/dist`, assets },
+      projectRoot,
+      sourceProject: 'acme',
+      migrationsPath: join(rootDir, projectRoot, 'migrations.json'),
+      rootDir,
+    });
+  }
+
+  const migrationWith = (key: string, value: string) => ({
+    generators: {
+      'update-1-0-0': {
+        version: '1.0.0',
+        implementation: './dist/src/migrations/update-1-0-0/migration',
+        [key]: value,
+      },
+    },
+  });
+
+  it.each(['documentation', 'prompt'])(
+    'should return no violations when an asset glob copies the %s file into dist',
+    (key) => {
+      writeFile('packages/acme/src/migrations/update-1-0-0/doc.md');
+
+      const violations = validate(
+        migrationWith(key, './dist/src/migrations/update-1-0-0/doc.md'),
+        [{ glob: 'src/migrations/**/*.md' }]
+      );
+
+      expect(violations).toEqual([]);
+    }
+  );
+
+  it.each(['documentation', 'prompt'])(
+    'should return a violation when no asset glob copies the %s file into dist',
+    (key) => {
+      writeFile('packages/acme/src/migrations/update-1-0-0/doc.md');
+
+      const violations = validate(
+        migrationWith(key, './dist/src/migrations/update-1-0-0/doc.md'),
+        [{ glob: 'src/**/schema.json' }]
+      );
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0].message).toContain(
+        './dist/src/migrations/update-1-0-0/doc.md'
+      );
+      expect(violations[0].sourceProject).toBe('acme');
+    }
+  );
+
+  it('should return a violation when the glob matches but copies the file elsewhere in dist', () => {
+    writeFile('packages/acme/src/migrations/update-1-0-0/doc.md');
+
+    const violations = validate(
+      migrationWith(
+        'documentation',
+        './dist/src/migrations/update-1-0-0/doc.md'
+      ),
+      [{ glob: 'src/migrations/**/*.md', output: '/docs' }]
+    );
+
+    expect(violations).toHaveLength(1);
+  });
+
+  it('should return no violations when a string asset copies the file into dist', () => {
+    writeFile('packages/acme/src/migrations/update-1-0-0/doc.md');
+
+    const violations = validate(
+      migrationWith(
+        'documentation',
+        './dist/src/migrations/update-1-0-0/doc.md'
+      ),
+      ['packages/acme/src/migrations/**/*.md']
+    );
+
+    expect(violations).toEqual([]);
+  });
+
+  it('should resolve globs against an input directory', () => {
+    writeFile('packages/acme/src/migrations/update-1-0-0/doc.md');
+
+    const violations = validate(
+      migrationWith('documentation', './dist/migrations/update-1-0-0/doc.md'),
+      [{ glob: 'migrations/**/*.md', input: 'packages/acme/src' }]
+    );
+
+    expect(violations).toEqual([]);
+  });
+
+  it('should ignore references that point outside dist', () => {
+    writeFile('packages/acme/migrations/update-1-0-0/doc.md');
+
+    const violations = validate(
+      migrationWith('documentation', './migrations/update-1-0-0/doc.md'),
+      [{ glob: 'src/**/schema.json' }]
+    );
+
+    expect(violations).toEqual([]);
+  });
+
+  it('should return no violations when no migration references markdown', () => {
+    const violations = validate(
+      {
+        generators: {
+          'update-1-0-0': {
+            version: '1.0.0',
+            implementation: './dist/src/migrations/update-1-0-0/migration',
+          },
+        },
+      },
+      [{ glob: 'src/**/schema.json' }]
+    );
+
+    expect(violations).toEqual([]);
+  });
+});

--- a/tools/workspace-plugin/src/conformance-rules/migration-markdown-assets/index.spec.ts
+++ b/tools/workspace-plugin/src/conformance-rules/migration-markdown-assets/index.spec.ts
@@ -113,15 +113,16 @@ describe('migration-markdown-assets', () => {
     expect(violations).toEqual([]);
   });
 
-  it('should ignore references that point outside dist', () => {
-    writeFile('packages/acme/migrations/update-1-0-0/doc.md');
+  it('should return a violation when a reference points outside dist', () => {
+    writeFile('packages/acme/src/migrations/update-1-0-0/doc.md');
 
     const violations = validate(
-      migrationWith('documentation', './migrations/update-1-0-0/doc.md'),
-      [{ glob: 'src/**/schema.json' }]
+      migrationWith('documentation', './src/migrations/update-1-0-0/doc.md'),
+      [{ glob: 'src/migrations/**/*.md' }]
     );
 
-    expect(violations).toEqual([]);
+    expect(violations).toHaveLength(1);
+    expect(violations[0].message).toContain('resolves outside');
   });
 
   it('should return no violations when no migration references markdown', () => {

--- a/tools/workspace-plugin/src/conformance-rules/migration-markdown-assets/index.spec.ts
+++ b/tools/workspace-plugin/src/conformance-rules/migration-markdown-assets/index.spec.ts
@@ -165,4 +165,104 @@ describe('migration-markdown-assets', () => {
 
     expect(violations).toEqual([]);
   });
+
+  describe('implementation paths', () => {
+    function writeTsconfig(
+      compilerOptions: { rootDir: string; outDir: string },
+      name = 'tsconfig.lib.json'
+    ) {
+      writeFile(`${projectRoot}/${name}`, JSON.stringify({ compilerOptions }));
+    }
+
+    function validateImplementation(implementation: Record<string, string>) {
+      return validate(
+        {
+          generators: {
+            'update-1-0-0': { version: '1.0.0', ...implementation },
+          },
+        },
+        [{ glob: 'src/**/schema.json' }]
+      );
+    }
+
+    it('should return no violations when the implementation maps to an existing source file', () => {
+      writeTsconfig({ rootDir: '.', outDir: 'dist' });
+      writeFile(`${projectRoot}/src/migrations/update-1-0-0/migration.ts`);
+
+      const violations = validateImplementation({
+        implementation: './dist/src/migrations/update-1-0-0/migration',
+      });
+
+      expect(violations).toEqual([]);
+    });
+
+    it('should return a violation when the implementation points outside the build output', () => {
+      writeTsconfig({ rootDir: '.', outDir: 'dist' });
+      writeFile(`${projectRoot}/src/migrations/update-1-0-0/migration.ts`);
+
+      const violations = validateImplementation({
+        implementation: './src/migrations/update-1-0-0/migration',
+      });
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0].message).toContain(
+        'resolves outside the build output'
+      );
+    });
+
+    it('should return a violation when the source file the implementation maps to is missing', () => {
+      writeTsconfig({ rootDir: '.', outDir: 'dist' });
+
+      const violations = validateImplementation({
+        implementation: './dist/src/migrations/update-1-0-0/migration',
+      });
+
+      expect(violations).toHaveLength(1);
+      expect(violations[0].message).toContain(
+        'packages/acme/src/migrations/update-1-0-0/migration.ts'
+      );
+    });
+
+    it('should check a `factory` entry the same way as an `implementation` one', () => {
+      writeTsconfig({ rootDir: '.', outDir: 'dist' });
+
+      const violations = validateImplementation({
+        factory: './dist/src/migrations/update-1-0-0/migration',
+      });
+
+      expect(violations).toHaveLength(1);
+    });
+
+    it('should ignore a `#member` suffix when resolving the source file', () => {
+      writeTsconfig({ rootDir: '.', outDir: 'dist' });
+      writeFile(`${projectRoot}/src/migrations/update-1-0-0/migration.ts`);
+
+      const violations = validateImplementation({
+        implementation: './dist/src/migrations/update-1-0-0/migration#update',
+      });
+
+      expect(violations).toEqual([]);
+    });
+
+    it('should map the implementation through a rootDir of "src"', () => {
+      writeTsconfig({ rootDir: 'src', outDir: 'dist' });
+      writeFile(`${projectRoot}/src/migrations/update-1-0-0/migration.ts`);
+
+      const violations = validateImplementation({
+        implementation: './dist/migrations/update-1-0-0/migration',
+      });
+
+      expect(violations).toEqual([]);
+    });
+
+    it('should fall back to tsconfig.json when tsconfig.lib.json is absent', () => {
+      writeTsconfig({ rootDir: '.', outDir: 'dist' }, 'tsconfig.json');
+
+      const violations = validateImplementation({
+        implementation: './dist/src/migrations/update-1-0-0/migration',
+      });
+
+      expect(violations).toHaveLength(1);
+    });
+  });
 });

--- a/tools/workspace-plugin/src/conformance-rules/migration-markdown-assets/index.spec.ts
+++ b/tools/workspace-plugin/src/conformance-rules/migration-markdown-assets/index.spec.ts
@@ -125,6 +125,31 @@ describe('migration-markdown-assets', () => {
     expect(violations[0].message).toContain('resolves outside');
   });
 
+  it('should check the generators entry when schematics declares the same name', () => {
+    writeFile('packages/acme/src/migrations/update-1-0-0/from-generators.md');
+
+    const violations = validate(
+      {
+        schematics: {
+          'update-1-0-0': {
+            version: '1.0.0',
+            documentation: './dist/src/migrations/update-1-0-0/uncopied.md',
+          },
+        },
+        generators: {
+          'update-1-0-0': {
+            version: '1.0.0',
+            documentation:
+              './dist/src/migrations/update-1-0-0/from-generators.md',
+          },
+        },
+      },
+      [{ glob: 'src/migrations/**/*.md' }]
+    );
+
+    expect(violations).toEqual([]);
+  });
+
   it('should return no violations when no migration references markdown', () => {
     const violations = validate(
       {

--- a/tools/workspace-plugin/src/conformance-rules/migration-markdown-assets/index.ts
+++ b/tools/workspace-plugin/src/conformance-rules/migration-markdown-assets/index.ts
@@ -62,40 +62,51 @@ export function validateMigrationMarkdownAssets(opts: {
 }): ConformanceViolation[] {
   const { migrations, assetsJson, projectRoot, rootDir } = opts;
   const outputDir = resolve(rootDir, assetsJson.outDir);
+  // Same precedence as nx's own migration resolution: a `generators` entry wins
+  // over a `schematics` one of the same name.
   const entries = {
-    ...(migrations.generators ?? {}),
     ...(migrations.schematics ?? {}),
+    ...(migrations.generators ?? {}),
   };
 
+  const violations: ConformanceViolation[] = [];
   const referenced: { key: string; value: string; expected: string }[] = [];
   for (const migration of Object.values<any>(entries)) {
     for (const key of REFERENCE_KEYS) {
       const value = migration[key];
       if (!value) continue;
       const expected = resolve(rootDir, projectRoot, value);
-      // A reference outside the output dir is a file checked into the package
-      // and published through package.json#files, not one the build copies.
-      if (!isInside(outputDir, expected)) continue;
+      if (!isInside(outputDir, expected)) {
+        violations.push({
+          message: `The \`${key}\` file "${value}" referenced by migrations.json resolves outside "${assetsJson.outDir}". Only that directory is published, so the reference cannot resolve in the installed package.`,
+          sourceProject: opts.sourceProject,
+          file: opts.migrationsPath,
+        });
+        continue;
+      }
       referenced.push({ key, value, expected });
     }
   }
-  if (!referenced.length) return [];
 
-  const copied = collectCopiedFiles(assetsJson, projectRoot, rootDir);
+  if (referenced.length) {
+    const copied = collectCopiedFiles(assetsJson, projectRoot, rootDir);
+    for (const { key, value, expected } of referenced) {
+      if (copied.has(expected)) continue;
+      violations.push({
+        message: `The \`${key}\` file "${value}" referenced by migrations.json is not copied into "${assetsJson.outDir}", so the published package does not contain it. Either the source file is missing or no assets.json glob copies it to that path.`,
+        sourceProject: opts.sourceProject,
+        file: opts.migrationsPath,
+      });
+    }
+  }
 
-  return referenced
-    .filter(({ expected }) => !copied.has(expected))
-    .map(({ key, value }) => ({
-      message: `The \`${key}\` file "${value}" is referenced by migrations.json but no assets.json glob copies it into "${assetsJson.outDir}", so the published package does not contain it.`,
-      sourceProject: opts.sourceProject,
-      file: opts.migrationsPath,
-    }));
+  return violations;
 }
 
 /**
- * Drives the real copy-assets pipeline with a collecting callback in place of
- * the copying one, so the resulting paths are what a build would produce
- * without touching the file system.
+ * Drives the real copy-assets pipeline over the working tree with a collecting
+ * callback in place of the copying one, so the resulting paths are the ones a
+ * build would produce, without writing any of them.
  */
 function collectCopiedFiles(
   assetsJson: AssetsJson,

--- a/tools/workspace-plugin/src/conformance-rules/migration-markdown-assets/index.ts
+++ b/tools/workspace-plugin/src/conformance-rules/migration-markdown-assets/index.ts
@@ -17,7 +17,7 @@ export default createConformanceRule({
   name: 'migration-markdown-assets',
   category: 'consistency',
   description:
-    'Ensures the markdown files a migrations.json references through `prompt` and `documentation` are copied into the built package',
+    'Ensures the files a migrations.json references resolve in the built package: the `prompt` and `documentation` markdown is copied into it, and every implementation path maps back to a source file',
   implementation: async ({ projectGraph }) => {
     const violations: ConformanceViolation[] = [];
 
@@ -71,7 +71,19 @@ export function validateMigrationMarkdownAssets(opts: {
 
   const violations: ConformanceViolation[] = [];
   const referenced: { key: string; value: string; expected: string }[] = [];
+  const buildLayout = readBuildLayout(projectRoot, rootDir);
   for (const migration of Object.values<any>(entries)) {
+    // Same precedence as nx's own resolution: `implementation` wins over `factory`.
+    const implementation = migration.implementation || migration.factory;
+    if (implementation && buildLayout) {
+      const violation = validateImplementationPath(
+        implementation,
+        buildLayout,
+        opts
+      );
+      if (violation) violations.push(violation);
+    }
+
     for (const key of REFERENCE_KEYS) {
       const value = migration[key];
       if (!value) continue;
@@ -101,6 +113,80 @@ export function validateMigrationMarkdownAssets(opts: {
   }
 
   return violations;
+}
+
+type BuildLayout = { sourceDir: string; outDir: string };
+
+/**
+ * Reads the `rootDir`/`outDir` the package builds with. Returns null when
+ * neither tsconfig declares both, so a package whose layout cannot be
+ * determined is left unchecked rather than checked against a guess.
+ */
+function readBuildLayout(
+  projectRoot: string,
+  rootDir: string
+): BuildLayout | null {
+  for (const tsconfig of ['tsconfig.lib.json', 'tsconfig.json']) {
+    const tsconfigPath = join(rootDir, projectRoot, tsconfig);
+    if (!existsSync(tsconfigPath)) continue;
+    const compilerOptions = readJsonFile(tsconfigPath).compilerOptions ?? {};
+    if (compilerOptions.rootDir && compilerOptions.outDir) {
+      return {
+        sourceDir: compilerOptions.rootDir,
+        outDir: compilerOptions.outDir,
+      };
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Implementations are tsc outputs rather than copied assets, so the assets
+ * pipeline cannot vouch for them. Map the published path back through the
+ * build's `rootDir`/`outDir` and check the source file it comes from instead.
+ */
+function validateImplementationPath(
+  implementation: string,
+  buildLayout: BuildLayout,
+  opts: {
+    projectRoot: string;
+    sourceProject: string;
+    migrationsPath: string;
+    rootDir: string;
+  }
+): ConformanceViolation | null {
+  const packageDir = join(opts.rootDir, opts.projectRoot);
+  const outputDir = resolve(packageDir, buildLayout.outDir);
+  // A `#member` suffix names an export within the file; only the path matters here.
+  const publishedPath = implementation.split('#')[0];
+  const published = resolve(packageDir, publishedPath);
+
+  if (!isInside(outputDir, published)) {
+    return {
+      message: `The implementation "${implementation}" referenced by migrations.json resolves outside the build output "${buildLayout.outDir}". Implementation paths are published paths and must point at a file the build emits.`,
+      sourceProject: opts.sourceProject,
+      file: opts.migrationsPath,
+    };
+  }
+
+  const sourceFile = `${join(
+    packageDir,
+    buildLayout.sourceDir,
+    relative(outputDir, published)
+  )}.ts`;
+  if (!existsSync(sourceFile)) {
+    return {
+      message: `The implementation "${implementation}" referenced by migrations.json maps back to "${relative(
+        opts.rootDir,
+        sourceFile
+      )}", which does not exist, so the build emits nothing at that path.`,
+      sourceProject: opts.sourceProject,
+      file: opts.migrationsPath,
+    };
+  }
+
+  return null;
 }
 
 /**

--- a/tools/workspace-plugin/src/conformance-rules/migration-markdown-assets/index.ts
+++ b/tools/workspace-plugin/src/conformance-rules/migration-markdown-assets/index.ts
@@ -1,0 +1,122 @@
+import {
+  createConformanceRule,
+  type ConformanceViolation,
+} from '@nx/conformance';
+import { readJsonFile, workspaceRoot } from '@nx/devkit';
+import { CopyAssetsHandler } from '@nx/js/src/utils/assets/copy-assets-handler';
+import { existsSync } from 'node:fs';
+import { isAbsolute, join, relative, resolve } from 'node:path';
+import {
+  toExecutorAssets,
+  type AssetsJson,
+} from '../../plugins/copy-assets-plugin.js';
+
+const REFERENCE_KEYS = ['prompt', 'documentation'] as const;
+
+export default createConformanceRule({
+  name: 'migration-markdown-assets',
+  category: 'consistency',
+  description:
+    'Ensures the markdown files a migrations.json references through `prompt` and `documentation` are copied into the built package',
+  implementation: async ({ projectGraph }) => {
+    const violations: ConformanceViolation[] = [];
+
+    for (const project of Object.values(projectGraph.nodes)) {
+      const projectRoot = project.data.root;
+      const migrationsPath = join(
+        workspaceRoot,
+        projectRoot,
+        'migrations.json'
+      );
+      const assetsPath = join(workspaceRoot, projectRoot, 'assets.json');
+      if (!existsSync(migrationsPath) || !existsSync(assetsPath)) continue;
+
+      violations.push(
+        ...validateMigrationMarkdownAssets({
+          migrations: readJsonFile(migrationsPath),
+          assetsJson: readJsonFile<AssetsJson>(assetsPath),
+          projectRoot,
+          sourceProject: project.name,
+          migrationsPath,
+          rootDir: workspaceRoot,
+        })
+      );
+    }
+
+    return {
+      severity: 'high',
+      details: {
+        violations,
+      },
+    };
+  },
+});
+
+export function validateMigrationMarkdownAssets(opts: {
+  migrations: Record<string, any>;
+  assetsJson: AssetsJson;
+  projectRoot: string;
+  sourceProject: string;
+  migrationsPath: string;
+  rootDir: string;
+}): ConformanceViolation[] {
+  const { migrations, assetsJson, projectRoot, rootDir } = opts;
+  const outputDir = resolve(rootDir, assetsJson.outDir);
+  const entries = {
+    ...(migrations.generators ?? {}),
+    ...(migrations.schematics ?? {}),
+  };
+
+  const referenced: { key: string; value: string; expected: string }[] = [];
+  for (const migration of Object.values<any>(entries)) {
+    for (const key of REFERENCE_KEYS) {
+      const value = migration[key];
+      if (!value) continue;
+      const expected = resolve(rootDir, projectRoot, value);
+      // A reference outside the output dir is a file checked into the package
+      // and published through package.json#files, not one the build copies.
+      if (!isInside(outputDir, expected)) continue;
+      referenced.push({ key, value, expected });
+    }
+  }
+  if (!referenced.length) return [];
+
+  const copied = collectCopiedFiles(assetsJson, projectRoot, rootDir);
+
+  return referenced
+    .filter(({ expected }) => !copied.has(expected))
+    .map(({ key, value }) => ({
+      message: `The \`${key}\` file "${value}" is referenced by migrations.json but no assets.json glob copies it into "${assetsJson.outDir}", so the published package does not contain it.`,
+      sourceProject: opts.sourceProject,
+      file: opts.migrationsPath,
+    }));
+}
+
+/**
+ * Drives the real copy-assets pipeline with a collecting callback in place of
+ * the copying one, so the resulting paths are what a build would produce
+ * without touching the file system.
+ */
+function collectCopiedFiles(
+  assetsJson: AssetsJson,
+  projectRoot: string,
+  rootDir: string
+): Set<string> {
+  const copied = new Set<string>();
+  new CopyAssetsHandler({
+    rootDir,
+    projectDir: join(rootDir, projectRoot),
+    outputDir: resolve(rootDir, assetsJson.outDir),
+    assets: toExecutorAssets(assetsJson, projectRoot),
+    callback: (events) => {
+      for (const event of events) copied.add(event.dest);
+    },
+  }).processAllAssetsOnceSync();
+
+  return copied;
+}
+
+function isInside(dir: string, file: string): boolean {
+  const rel = relative(dir, file);
+  return !!rel && !rel.startsWith('..') && !isAbsolute(rel);
+}

--- a/tools/workspace-plugin/src/conformance-rules/migration-markdown-assets/index.ts
+++ b/tools/workspace-plugin/src/conformance-rules/migration-markdown-assets/index.ts
@@ -78,7 +78,7 @@ export function validateMigrationMarkdownAssets(opts: {
       const expected = resolve(rootDir, projectRoot, value);
       if (!isInside(outputDir, expected)) {
         violations.push({
-          message: `The \`${key}\` file "${value}" referenced by migrations.json resolves outside "${assetsJson.outDir}". Only that directory is published, so the reference cannot resolve in the installed package.`,
+          message: `The \`${key}\` file "${value}" referenced by migrations.json resolves outside the built output "${assetsJson.outDir}". Migration references resolve relative to the installed package root and must point inside the built output.`,
           sourceProject: opts.sourceProject,
           file: opts.migrationsPath,
         });

--- a/tools/workspace-plugin/src/conformance-rules/migration-markdown-assets/schema.json
+++ b/tools/workspace-plugin/src/conformance-rules/migration-markdown-assets/schema.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "http://json-schema.org/schema",
+  "$id": "migration-markdown-assets",
+  "title": "migration-markdown-assets rule configuration",
+  "type": "object",
+  "properties": {},
+  "additionalProperties": false
+}

--- a/tools/workspace-plugin/src/plugins/copy-assets-plugin.ts
+++ b/tools/workspace-plugin/src/plugins/copy-assets-plugin.ts
@@ -6,7 +6,7 @@ import {
 } from '@nx/js/src/utils/assets/copy-assets-handler';
 import { dirname, join, relative } from 'node:path';
 
-interface AssetEntry {
+export interface AssetEntry {
   glob: string;
   input?: string;
   output?: string;
@@ -14,9 +14,63 @@ interface AssetEntry {
   includeIgnoredFiles?: boolean;
 }
 
-interface AssetsJson {
+export interface AssetsJson {
   outDir: string;
   assets: (AssetEntry | string)[];
+}
+
+export type ExecutorAsset =
+  | {
+      input: string;
+      glob: string;
+      ignore?: string[];
+      output: string;
+      includeIgnoredFiles?: boolean;
+    }
+  | string;
+
+/**
+ * Expands an assets.json into the shape the copy-assets executor consumes.
+ * Shared with the migration-markdown-assets conformance rule so both derive the
+ * copied files from the same inputs.
+ */
+export function toExecutorAssets(
+  assetsJson: AssetsJson,
+  projectRoot: string
+): ExecutorAsset[] {
+  // Separate string assets (passed through as-is) from object assets
+  const objectAssets: AssetEntry[] = [];
+  const stringAssets: string[] = [];
+  for (const asset of assetsJson.assets) {
+    if (typeof asset === 'string') {
+      stringAssets.push(asset);
+    } else {
+      objectAssets.push(asset);
+    }
+  }
+
+  return [
+    ...objectAssets.map((asset) => {
+      const input = asset.input ?? projectRoot;
+      const output = asset.output ?? '/';
+      const ignore =
+        input === projectRoot
+          ? [
+              `${relative(projectRoot, assetsJson.outDir)}/**`,
+              'assets.json',
+              ...(asset.ignore ?? []),
+            ]
+          : asset.ignore;
+      return {
+        input,
+        glob: asset.glob,
+        ...(ignore?.length ? { ignore } : {}),
+        output,
+        ...(asset.includeIgnoredFiles ? { includeIgnoredFiles: true } : {}),
+      };
+    }),
+    ...stringAssets,
+  ];
 }
 
 export const createNodes: CreateNodes = [
@@ -29,51 +83,13 @@ export const createNodes: CreateNodes = [
           join(context.workspaceRoot, configFilePath)
         );
 
-        // Separate string assets (passed through as-is) from object assets
-        const objectAssets: AssetEntry[] = [];
-        const stringAssets: string[] = [];
-        for (const asset of assetsJson.assets) {
-          if (typeof asset === 'string') {
-            stringAssets.push(asset);
-          } else {
-            objectAssets.push(asset);
-          }
-        }
-
-        // Build executor assets
-        const executorAssets: (
-          | {
-              input: string;
-              glob: string;
-              ignore?: string[];
-              output: string;
-              includeIgnoredFiles?: boolean;
-            }
-          | string
-        )[] = [
-          ...objectAssets.map((asset) => {
-            const input = asset.input ?? projectRoot;
-            const output = asset.output ?? '/';
-            const ignore =
-              input === projectRoot
-                ? [
-                    `${relative(projectRoot, assetsJson.outDir)}/**`,
-                    'assets.json',
-                    ...(asset.ignore ?? []),
-                  ]
-                : asset.ignore;
-            return {
-              input,
-              glob: asset.glob,
-              ...(ignore?.length ? { ignore } : {}),
-              output,
-              ...(asset.includeIgnoredFiles
-                ? { includeIgnoredFiles: true }
-                : {}),
-            };
-          }),
-          ...stringAssets,
-        ];
+        const executorAssets = toExecutorAssets(assetsJson, projectRoot);
+        const objectAssets = assetsJson.assets.filter(
+          (asset): asset is AssetEntry => typeof asset !== 'string'
+        );
+        const stringAssets = assetsJson.assets.filter(
+          (asset): asset is string => typeof asset === 'string'
+        );
 
         // Normalize assets to derive outputs
         const projectDir = join(context.workspaceRoot, projectRoot);


### PR DESCRIPTION
> [!NOTE]
> #36377 makes the migrations reference pages read the `documentation` key, which is what surfaces this package's missing file on the page. The two PRs are independent and can merge in any order.

## Current Behavior

`@nx/react-native` declares a `documentation` file for `update-23-0-0-migrate-create-nodes-v2-import`, but its assets config never copies `src/migrations/**/*.md` into `dist`. Since the published package ships its built output from `dist`, it points at a file it does not contain:

- `nx migrate --run-migrations --agentic` warns that the documentation file could not be resolved and drops it as agent context.
- The migrations reference page renders the entry with only its one-line description, while the identical migration in sibling plugins renders its docs.

Nothing caught this. `assertValidMigrationPaths` maps the published `./dist/...` path back to the source tree and asserts the source file exists, which it does, so the spec passes while the built package stays broken.

## Expected Behavior

The markdown is copied into the built package, so the published tarball contains the file it references and both consumers read it.

The `migration-markdown-assets` conformance rule closes the gap the spec leaves open, for every package rather than the 27 with a `migrations.spec.ts`. It checks each `prompt` and `documentation` reference against the files the assets config actually produces, catching a file that is never copied, one copied somewhere other than the declared path, and a reference resolving outside the built output. Rather than reimplementing the glob and output semantics, it drives the copy-assets pipeline with a collecting callback in place of the copying one, so the paths it compares against are the ones a build produces; it needs no `dist`. `toExecutorAssets` moves out of the copy-assets plugin so the rule and the plugin expand an `assets.json` the same way. The generated `copy-assets` targets are unchanged.

Relative imports need a `.js` specifier under `nodenext`, which jest resolves back to the TypeScript sources through the added `moduleNameMapper`.

## Related Issue(s)

Fixes NXC-4713

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/fix-migration-docs-3961141b)
<!-- polygraph-session-end -->




