### PR TITLE
fix(core): stop passing git revisions through a shell in affected commands

### DIFF
--- a/packages/nx/src/command-line/migrate/migrate-ui-api.spec.ts
+++ b/packages/nx/src/command-line/migrate/migrate-ui-api.spec.ts
@@ -1,0 +1,128 @@
+jest.mock('child_process');
+jest.mock('fs');
+import { execFileSync, execSync } from 'child_process';
+import { existsSync, readFileSync } from 'fs';
+import {
+  finishMigrationProcess,
+  undoMigration,
+  type MigrationsJsonMetadata,
+} from './migrate-ui-api';
+
+const SHA = 'a1b2c3d4e5f6a1b2c3d4e5f6a1b2c3d4e5f6a1b2';
+// `git reset --hard ${ref}^` appends a caret, so a payload needs a trailing
+// `#` to comment it out.
+const PAYLOAD = 'HEAD; touch /tmp/nx-migrate-pwned #';
+
+describe('migrate-ui-api git invocations', () => {
+  const execSyncMock = execSync as jest.Mock;
+  const execFileSyncMock = execFileSync as jest.Mock;
+
+  beforeEach(() => {
+    execSyncMock.mockReturnValue('');
+    execFileSyncMock.mockReturnValue('');
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  describe('undoMigration', () => {
+    function metadataWithRef(ref: string): MigrationsJsonMetadata {
+      return {
+        completedMigrations: {
+          'some-migration': {
+            type: 'successful',
+            name: 'some-migration',
+            changedFiles: [{ path: 'a.ts', type: 'UPDATE' } as any],
+            ref,
+          },
+        },
+      };
+    }
+
+    it('should pass the ref to git as an argument rather than through a shell', () => {
+      undoMigration('/workspace', 'some-migration')(metadataWithRef(SHA));
+
+      expect(execFileSyncMock).toHaveBeenCalledWith(
+        'git',
+        ['reset', '--hard', `${SHA}^`],
+        expect.objectContaining({ cwd: '/workspace' })
+      );
+      expect(execSyncMock).not.toHaveBeenCalled();
+    });
+
+    it('should reject a ref from migrations.json that is not a commit sha', () => {
+      expect(() =>
+        undoMigration('/workspace', 'some-migration')(metadataWithRef(PAYLOAD))
+      ).toThrow(/Invalid git commit sha/);
+
+      expect(execFileSyncMock).not.toHaveBeenCalled();
+      expect(execSyncMock).not.toHaveBeenCalled();
+    });
+
+    it('should not invoke git when the migration changed no files', () => {
+      const metadata = metadataWithRef(SHA);
+      (metadata.completedMigrations['some-migration'] as any).changedFiles = [];
+
+      undoMigration('/workspace', 'some-migration')(metadata);
+
+      expect(execFileSyncMock).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('finishMigrationProcess', () => {
+    function mockMigrationsJson(initialGitRef?: { ref: string }) {
+      (existsSync as jest.Mock).mockReturnValue(false);
+      (readFileSync as jest.Mock).mockReturnValue(
+        JSON.stringify({
+          'nx-console': initialGitRef ? { initialGitRef } : {},
+        })
+      );
+    }
+
+    it('should pass the commit message over stdin rather than interpolating it', () => {
+      mockMigrationsJson();
+
+      finishMigrationProcess(
+        '/workspace',
+        false,
+        'chore: bump "foo" to $LATEST'
+      );
+
+      expect(execSyncMock).toHaveBeenCalledWith(
+        'git commit --no-verify -F -',
+        expect.objectContaining({ input: 'chore: bump "foo" to $LATEST' })
+      );
+      expect(execSyncMock).not.toHaveBeenCalledWith(
+        expect.stringContaining('bump "foo"'),
+        expect.anything()
+      );
+    });
+
+    it('should pass the squash ref to git as an argument rather than through a shell', () => {
+      mockMigrationsJson({ ref: SHA });
+
+      finishMigrationProcess('/workspace', true, 'chore: migrate');
+
+      expect(execFileSyncMock).toHaveBeenCalledWith(
+        'git',
+        ['reset', '--soft', SHA],
+        expect.objectContaining({ cwd: '/workspace' })
+      );
+    });
+
+    it('should reject an initialGitRef from migrations.json that is not a commit sha', () => {
+      mockMigrationsJson({ ref: PAYLOAD });
+
+      expect(() =>
+        finishMigrationProcess('/workspace', true, 'chore: migrate')
+      ).toThrow(/Invalid git commit sha/);
+
+      expect(execFileSyncMock).not.toHaveBeenCalled();
+      expect(execSyncMock).not.toHaveBeenCalledWith(
+        expect.stringContaining('touch /tmp/nx-migrate-pwned'),
+        expect.anything()
+      );
+    });
+  });
+});

--- a/packages/nx/src/command-line/migrate/migrate-ui-api.ts
+++ b/packages/nx/src/command-line/migrate/migrate-ui-api.ts
@@ -1,8 +1,9 @@
-import { execSync, spawn, ChildProcess } from 'child_process';
+import { execFileSync, execSync, spawn, ChildProcess } from 'child_process';
 import { existsSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import type { MigrationDetailsWithId } from '../../config/misc-interfaces';
 import type { FileChange } from '../../generators/tree';
+import { assertValidGitSha } from '../../utils/git-revision';
 import {
   getImplementationPath as getMigrationImplementationPath,
   isHybridMigration,
@@ -107,6 +108,10 @@ export function finishMigrationProcess(
     parsedMigrationsJson['nx-console'] as MigrationsJsonMetadata
   ).initialGitRef;
 
+  if (squashCommits && initialGitRef) {
+    assertValidGitSha(initialGitRef.ref);
+  }
+
   if (existsSync(migrationsJsonPath)) {
     rmSync(migrationsJsonPath);
   }
@@ -116,25 +121,26 @@ export function finishMigrationProcess(
     windowsHide: true,
   });
 
-  execSync(`git commit -m "${commitMessage}" --no-verify`, {
+  commit(workspacePath, commitMessage);
+
+  if (squashCommits && initialGitRef) {
+    execFileSync('git', ['reset', '--soft', initialGitRef.ref], {
+      cwd: workspacePath,
+      encoding: 'utf-8',
+      windowsHide: true,
+    });
+
+    commit(workspacePath, commitMessage);
+  }
+}
+
+function commit(workspacePath: string, commitMessage: string) {
+  execSync('git commit --no-verify -F -', {
     cwd: workspacePath,
     encoding: 'utf-8',
     windowsHide: true,
+    input: commitMessage,
   });
-
-  if (squashCommits && initialGitRef) {
-    execSync(`git reset --soft ${initialGitRef.ref}`, {
-      cwd: workspacePath,
-      encoding: 'utf-8',
-      windowsHide: true,
-    });
-
-    execSync(`git commit -m "${commitMessage}" --no-verify`, {
-      cwd: workspacePath,
-      encoding: 'utf-8',
-      windowsHide: true,
-    });
-  }
 }
 
 export async function runSingleMigration(
@@ -489,7 +495,8 @@ export function undoMigration(workspacePath: string, id: string) {
     // `existing.ref` is the unmodified HEAD at run time, so `ref^` would
     // reset past unrelated history. Only flip the metadata to skipped.
     if (existing.changedFiles.length > 0) {
-      execSync(`git reset --hard ${existing.ref}^`, {
+      assertValidGitSha(existing.ref);
+      execFileSync('git', ['reset', '--hard', `${existing.ref}^`], {
         cwd: workspacePath,
         encoding: 'utf-8',
         windowsHide: true,

--- a/packages/nx/src/project-graph/file-utils.spec.ts
+++ b/packages/nx/src/project-graph/file-utils.spec.ts
@@ -7,14 +7,17 @@ jest.mock('fs', () => {
       .mockImplementation((...args) => actual.existsSync(...args)),
   };
 });
+jest.mock('child_process');
 import {
   calculateFileChanges,
   DeletedFileChange,
   LockFileChange,
   WholeFileChange,
 } from './file-utils';
+import { execFileSync, execSync } from 'child_process';
 import * as fs from 'fs';
 import { JsonDiffType } from '../utils/json-diff';
+import { workspaceRoot } from '../utils/workspace-root';
 import ignore = require('ignore');
 
 describe('calculateFileChanges', () => {
@@ -125,5 +128,63 @@ describe('calculateFileChanges', () => {
       ig
     );
     expect(changes.length).toEqual(0);
+  });
+
+  describe('reading a file at a revision', () => {
+    const execSyncMock = execSync as jest.Mock;
+    const execFileSyncMock = execFileSync as jest.Mock;
+
+    beforeEach(() => {
+      jest.spyOn(fs, 'existsSync').mockReturnValue(true);
+      // `git rev-parse --show-toplevel`, used to make the path repo-relative
+      execSyncMock.mockReturnValue(Buffer.from(`${workspaceRoot}\n`));
+      execFileSyncMock.mockReturnValue(Buffer.from('{}'));
+    });
+
+    afterEach(() => {
+      jest.resetAllMocks();
+    });
+
+    function readProjJsonAtBase(base: string) {
+      const changes = calculateFileChanges(['proj/tsconfig.json'], {
+        base,
+        head: 'HEAD',
+      } as any);
+      changes[0].getChanges();
+    }
+
+    it('should pass the revision to git as an argument rather than through a shell', () => {
+      readProjJsonAtBase('main');
+
+      expect(execFileSyncMock).toHaveBeenCalledWith(
+        'git',
+        ['show', 'main:proj/tsconfig.json'],
+        expect.anything()
+      );
+    });
+
+    it('should treat a shell substitution in the revision as an opaque revision', () => {
+      readProjJsonAtBase('$(touch /tmp/nx-pwned)');
+
+      expect(execFileSyncMock).toHaveBeenCalledWith(
+        'git',
+        ['show', '$(touch /tmp/nx-pwned):proj/tsconfig.json'],
+        expect.anything()
+      );
+      expect(execSyncMock).not.toHaveBeenCalledWith(
+        expect.stringContaining('touch /tmp/nx-pwned'),
+        expect.anything()
+      );
+    });
+
+    it('should not invoke git for an option-like revision', () => {
+      readProjJsonAtBase('--upload-pack=id');
+
+      expect(execFileSyncMock).not.toHaveBeenCalled();
+      expect(execSyncMock).not.toHaveBeenCalledWith(
+        expect.stringContaining('--upload-pack=id'),
+        expect.anything()
+      );
+    });
   });
 });

--- a/packages/nx/src/project-graph/file-utils.ts
+++ b/packages/nx/src/project-graph/file-utils.ts
@@ -11,6 +11,7 @@ import { extname, join, relative, sep } from 'path';
 import type { FileData } from '../config/project-graph';
 import type { NxArgs } from '../utils/command-line-utils';
 import { readJsonFile } from '../utils/fileutils';
+import { assertValidGitRevision } from '../utils/git-revision';
 import { getIgnoreObject } from '../utils/ignore';
 import { jsonDiff } from '../utils/json-diff';
 import { workspaceRoot } from '../utils/workspace-root';
@@ -161,15 +162,22 @@ function defaultReadFileAtRevision(
   file: string,
   revision: void | string
 ): string {
+  if (revision) {
+    assertValidGitRevision(revision);
+  }
   try {
     const filePathInGitRepository = getFilePathInGitRepository(file);
     return !revision
       ? readFileSync(file, 'utf-8')
-      : execSync(`git show ${revision}:${filePathInGitRepository}`, {
-          maxBuffer: TEN_MEGABYTES,
-          stdio: ['pipe', 'pipe', 'ignore'],
-          windowsHide: true,
-        })
+      : execFileSync(
+          'git',
+          ['show', `${revision}:${filePathInGitRepository}`],
+          {
+            maxBuffer: TEN_MEGABYTES,
+            stdio: ['pipe', 'pipe', 'ignore'],
+            windowsHide: true,
+          }
+        )
           .toString()
           .trim();
   } catch {
@@ -189,6 +197,7 @@ function defaultReadBunLockFileAtRevision(
     }).trim();
   }
 
+  assertValidGitRevision(revision);
   const filePathInGitRepository = getFilePathInGitRepository(file);
   const tempDirectory = mkdtempSync(join(tmpdir(), 'nx-bun-lock-'));
   const tempLockfilePath = join(tempDirectory, 'bun.lockb');

--- a/packages/nx/src/utils/command-line-utils.spec.ts
+++ b/packages/nx/src/utils/command-line-utils.spec.ts
@@ -1,7 +1,9 @@
+import { execFileSync, execSync } from 'child_process';
 import { splitArgsIntoNxArgsAndOverrides } from './command-line-utils';
 import { withEnvironmentVariables as withEnvironment } from '../internal-testing-utils/with-environment';
 
 jest.mock('../project-graph/file-utils');
+jest.mock('child_process');
 
 describe('splitArgs', () => {
   const blockedEnvVars = [
@@ -499,6 +501,121 @@ describe('splitArgs', () => {
           )
       );
       expect(nxArgs.parallel).toEqual(3);
+    });
+  });
+
+  describe('resolving the affected base against git', () => {
+    const execFileSyncMock = execFileSync as jest.Mock;
+    const execSyncMock = execSync as jest.Mock;
+
+    function splitAffectedArgs(args: Record<string, any>, nxJson = {}) {
+      return splitArgsIntoNxArgsAndOverrides(
+        { $0: '', __overrides_unparsed__: [], ...args },
+        'affected',
+        { printWarnings: false },
+        nxJson as any
+      );
+    }
+
+    beforeEach(() => {
+      execFileSyncMock.mockReturnValue(Buffer.from('a1b2c3d\n'));
+    });
+
+    afterEach(() => {
+      jest.resetAllMocks();
+    });
+
+    it('should resolve the merge base by passing revisions as arguments rather than through a shell', () => {
+      splitAffectedArgs({ base: 'main', head: 'HEAD' });
+
+      expect(execSyncMock).not.toHaveBeenCalled();
+      expect(execFileSyncMock).toHaveBeenCalledWith(
+        'git',
+        ['merge-base', 'main', 'HEAD'],
+        expect.anything()
+      );
+    });
+
+    it('should treat a shell substitution in --base as an opaque revision instead of executing it', () => {
+      const { nxArgs } = splitAffectedArgs({ base: '$(touch /tmp/nx-pwned)' });
+
+      expect(execSyncMock).not.toHaveBeenCalled();
+      expect(execFileSyncMock).toHaveBeenCalledWith(
+        'git',
+        ['merge-base', '$(touch /tmp/nx-pwned)', 'HEAD'],
+        expect.anything()
+      );
+      expect(nxArgs.base).toEqual('a1b2c3d');
+    });
+
+    it('should treat a shell substitution in nx.json defaultBase as an opaque revision', () => {
+      splitAffectedArgs({}, { defaultBase: '$(touch /tmp/nx-pwned)' });
+
+      expect(execSyncMock).not.toHaveBeenCalled();
+      expect(execFileSyncMock).toHaveBeenCalledWith(
+        'git',
+        ['merge-base', '$(touch /tmp/nx-pwned)', 'HEAD'],
+        expect.anything()
+      );
+    });
+
+    it('should treat a shell substitution in NX_BASE as an opaque revision', () => {
+      withEnvironment({ NX_BASE: '$(touch /tmp/nx-pwned)' }, () =>
+        splitAffectedArgs({})
+      );
+
+      expect(execSyncMock).not.toHaveBeenCalled();
+      expect(execFileSyncMock).toHaveBeenCalledWith(
+        'git',
+        ['merge-base', '$(touch /tmp/nx-pwned)', 'HEAD'],
+        expect.anything()
+      );
+    });
+
+    it('should reject an option-like base before invoking git', () => {
+      expect(() => splitAffectedArgs({ base: '--upload-pack=id' })).toThrow(
+        /Invalid git revision/
+      );
+      expect(execFileSyncMock).not.toHaveBeenCalled();
+    });
+
+    it('should reject an option-like head before invoking git', () => {
+      expect(() =>
+        splitAffectedArgs({ base: 'main', head: '--upload-pack=id' })
+      ).toThrow(/Invalid git revision/);
+      expect(execFileSyncMock).not.toHaveBeenCalled();
+    });
+
+    it('should reject an option-like defaultBase from nx.json before invoking git', () => {
+      expect(() =>
+        splitAffectedArgs({}, { defaultBase: '--upload-pack=id' })
+      ).toThrow(/Invalid git revision/);
+      expect(execFileSyncMock).not.toHaveBeenCalled();
+    });
+
+    it('should fall back to the fork point without a shell when merge-base fails', () => {
+      execFileSyncMock.mockImplementationOnce(() => {
+        throw new Error('no merge base');
+      });
+
+      splitAffectedArgs({ base: 'main' });
+
+      expect(execSyncMock).not.toHaveBeenCalled();
+      expect(execFileSyncMock).toHaveBeenLastCalledWith(
+        'git',
+        ['merge-base', '--fork-point', 'main', 'HEAD'],
+        expect.anything()
+      );
+    });
+
+    it('should fall back to the given base when git cannot resolve it', () => {
+      execFileSyncMock.mockImplementation(() => {
+        throw new Error('unknown revision');
+      });
+
+      const { nxArgs } = splitAffectedArgs({ base: 'some-branch' });
+
+      expect(nxArgs.base).toEqual('some-branch');
     });
   });
 });

--- a/packages/nx/src/utils/command-line-utils.ts
+++ b/packages/nx/src/utils/command-line-utils.ts
@@ -3,8 +3,9 @@ import type { Arguments } from 'yargs';
 import { TEN_MEGABYTES } from '../project-graph/file-utils';
 import { output } from './output';
 import { NxJsonConfiguration } from '../config/nx-json';
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { ProjectGraph } from '../config/project-graph';
+import { assertValidGitRevision } from './git-revision';
 import { workspaceRoot } from './workspace-root';
 import { readParallelFromArgsAndEnv } from '../command-line/yargs-utils/shared-options';
 
@@ -277,31 +278,28 @@ export function parseFiles(options: NxArgs): { files: string[] } {
 }
 
 function getUncommittedFiles(): string[] {
-  return parseGitOutput(`git diff --name-only --no-renames --relative HEAD .`);
+  return parseGitOutput([
+    'diff',
+    '--name-only',
+    '--no-renames',
+    '--relative',
+    'HEAD',
+    '.',
+  ]);
 }
 
 function getUntrackedFiles(): string[] {
-  return parseGitOutput(`git ls-files --others --exclude-standard`);
+  return parseGitOutput(['ls-files', '--others', '--exclude-standard']);
 }
 
 function getMergeBase(base: string, head: string = 'HEAD') {
+  assertValidGitRevision(base);
+  assertValidGitRevision(head);
   try {
-    return execSync(`git merge-base "${base}" "${head}"`, {
-      maxBuffer: TEN_MEGABYTES,
-      cwd: workspaceRoot,
-      stdio: 'pipe',
-      windowsHide: true,
-    })
-      .toString()
-      .trim();
+    return runGit(['merge-base', base, head]).toString().trim();
   } catch {
     try {
-      return execSync(`git merge-base --fork-point "${base}" "${head}"`, {
-        maxBuffer: TEN_MEGABYTES,
-        cwd: workspaceRoot,
-        stdio: 'pipe',
-        windowsHide: true,
-      })
+      return runGit(['merge-base', '--fork-point', base, head])
         .toString()
         .trim();
     } catch {
@@ -311,18 +309,29 @@ function getMergeBase(base: string, head: string = 'HEAD') {
 }
 
 function getFilesUsingBaseAndHead(base: string, head: string): string[] {
-  return parseGitOutput(
-    `git diff --name-only --no-renames --relative "${base}" "${head}"`
-  );
+  assertValidGitRevision(base);
+  assertValidGitRevision(head);
+  return parseGitOutput([
+    'diff',
+    '--name-only',
+    '--no-renames',
+    '--relative',
+    base,
+    head,
+  ]);
 }
 
-function parseGitOutput(command: string): string[] {
-  return execSync(command, {
+function runGit(args: string[]): Buffer {
+  return execFileSync('git', args, {
     maxBuffer: TEN_MEGABYTES,
     cwd: workspaceRoot,
     stdio: 'pipe',
     windowsHide: true,
-  })
+  });
+}
+
+function parseGitOutput(args: string[]): string[] {
+  return runGit(args)
     .toString('utf-8')
     .split('\n')
     .map((a) => a.trim())

--- a/packages/nx/src/utils/git-revision.spec.ts
+++ b/packages/nx/src/utils/git-revision.spec.ts
@@ -1,4 +1,30 @@
-import { assertValidGitRevision } from './git-revision';
+import { assertValidGitRevision, assertValidGitSha } from './git-revision';
+
+describe('assertValidGitSha', () => {
+  it.each([
+    'e83c5163316f89bfbde7d9ab23ca2e25604af290',
+    'E83C5163316F89BFBDE7D9AB23CA2E25604AF290',
+    '4a9d2b1',
+  ])('should accept the commit sha %s', (sha) => {
+    expect(() => assertValidGitSha(sha)).not.toThrow();
+  });
+
+  it.each([
+    'HEAD; touch /tmp/pwned #',
+    'HEAD',
+    'main',
+    '$(id)',
+    'e83c516^',
+    '',
+    'abc',
+  ])('should reject %s, which is not a commit sha', (sha) => {
+    expect(() => assertValidGitSha(sha)).toThrow(/Invalid git commit sha/);
+  });
+
+  it('should name the invalid sha in the error message', () => {
+    expect(() => assertValidGitSha('HEAD; id')).toThrow('HEAD; id');
+  });
+});
 
 describe('assertValidGitRevision', () => {
   it.each([

--- a/packages/nx/src/utils/git-revision.spec.ts
+++ b/packages/nx/src/utils/git-revision.spec.ts
@@ -1,0 +1,50 @@
+import { assertValidGitRevision } from './git-revision';
+
+describe('assertValidGitRevision', () => {
+  it.each([
+    'main',
+    'master',
+    'origin/main',
+    'HEAD',
+    'HEAD~1',
+    'HEAD^',
+    'v1.2.3',
+    'release/1.x',
+    '4a9d2b1',
+    'e83c5163316f89bfbde7d9ab23ca2e25604af290',
+    'main@{u}',
+    'HEAD@{2.days.ago}',
+    '@{-1}',
+    'feature/some-branch.name_with-chars',
+  ])('should accept the valid revision %s', (revision) => {
+    expect(() => assertValidGitRevision(revision)).not.toThrow();
+  });
+
+  it.each([
+    '--upload-pack=touch /tmp/pwned',
+    '--output=/tmp/pwned',
+    '-c',
+    '--exec=id',
+  ])('should reject the option-like revision %s', (revision) => {
+    expect(() => assertValidGitRevision(revision)).toThrow(
+      /Invalid git revision/
+    );
+  });
+
+  it('should name the invalid revision in the error message', () => {
+    expect(() => assertValidGitRevision('--upload-pack=id')).toThrow(
+      '--upload-pack=id'
+    );
+  });
+
+  // Passing revisions as arguments rather than through a shell is what makes
+  // these inert, so they do not need to be rejected.
+  it.each([
+    '$(touch /tmp/pwned)',
+    'main; touch /tmp/pwned',
+    '`id`',
+    'main | id',
+  ])('should accept the shell metacharacters in %s', (revision) => {
+    expect(() => assertValidGitRevision(revision)).not.toThrow();
+  });
+});

--- a/packages/nx/src/utils/git-revision.ts
+++ b/packages/nx/src/utils/git-revision.ts
@@ -10,3 +10,18 @@ export function assertValidGitRevision(revision: string): void {
     );
   }
 }
+
+const COMMIT_SHA = /^[0-9a-f]{7,40}$/i;
+
+/**
+ * For refs Nx itself recorded from `git rev-parse` and later read back off
+ * disk, where anything other than a commit sha means the value was tampered
+ * with rather than that the user picked an unusual revision.
+ */
+export function assertValidGitSha(sha: string): void {
+  if (!COMMIT_SHA.test(sha)) {
+    throw new Error(
+      `Invalid git commit sha: "${sha}". Expected a hexadecimal commit sha.`
+    );
+  }
+}

--- a/packages/nx/src/utils/git-revision.ts
+++ b/packages/nx/src/utils/git-revision.ts
@@ -1,0 +1,12 @@
+/**
+ * Git parses any argument beginning with `-` as an option rather than a
+ * revision, so a flag-shaped revision could smuggle options such as
+ * `--upload-pack` into the git commands Nx runs.
+ */
+export function assertValidGitRevision(revision: string): void {
+  if (revision.startsWith('-')) {
+    throw new Error(
+      `Invalid git revision: "${revision}". Git revisions cannot start with "-".`
+    );
+  }
+}


### PR DESCRIPTION
## Current Behavior

Untrusted values reach git commands that are executed through a shell via `execSync`, so shell metacharacters in those values are evaluated before git ever receives an argument. There are two distinct areas, both the same bug class.

### 1. Affected base/head revisions

The affected base and head revisions are interpolated into git command strings. These come from `defaultBase` / `affected.defaultBase` in `nx.json` and from the `NX_BASE` / `NX_HEAD` environment variables, in addition to the `--base` / `--head` flags.

Double quoting is not sufficient: the shell still evaluates command substitution inside double quotes, so a revision such as `$(...)` or a backtick expression is executed. It runs even though git itself then fails, because substitution happens first.

`getMergeBase` is called while affected arguments are being parsed, so the sink is reachable from `nx affected`, `nx show projects --affected`, `nx graph --affected`, `nx format`, and `nx release plan`.

### 2. Migrate UI git refs

`finishMigrationProcess` and `undoMigration` read a git ref back out of the workspace's `migrations.json` (`nx-console.initialGitRef.ref`, `completedMigrations[].ref`) and interpolate it, unquoted, into `git reset`. Nx writes those refs from `git rev-parse HEAD`, but nothing revalidates them on read, so a workspace shipping a crafted `migrations.json` can reach the sink through the Nx Console migrate UI.

| Location | Command | Quoting |
| --- | --- | --- |
| `utils/command-line-utils.ts` | `git merge-base`, `git diff` | double-quoted |
| `project-graph/file-utils.ts` | `git show ${revision}:${path}` | unquoted |
| `migrate/migrate-ui-api.ts` | `git reset --soft/--hard ${ref}` | unquoted |

Separately, `migrate-ui-api.ts` builds `git commit -m "${commitMessage}"`. That message is the operator's own text rather than untrusted input, but it breaks or misbehaves whenever the message contains a double quote or `$`.

## Expected Behavior

Git is invoked with argument arrays via `execFileSync`, so no shell is involved and values are passed as opaque arguments. A revision containing shell metacharacters is now simply an invalid revision that git rejects.

Two validation helpers are added, matching the two different trust boundaries:

- `assertValidGitRevision` rejects revisions beginning with `-`, which git would otherwise parse as an *option* rather than a revision (for example `--upload-pack=...`). This is deliberately narrow so it cannot false-reject a legitimate revision: `HEAD~1`, `origin/main`, `v1.2.3`, `@{-1}` and `HEAD@{2.days.ago}` all continue to work.
- `assertValidGitSha` requires a hexadecimal commit sha. It is used only for refs Nx itself recorded from `git rev-parse` and later reads back off disk, where anything else indicates the value was tampered with rather than that the user chose an unusual revision. It runs before any destructive step, so a rejected ref cannot leave the workspace with `migrations.json` already deleted and a commit already made.

Where correct patterns already existed in the codebase, they are reused rather than reinvented: `defaultReadBunLockFileAtRevision` in `file-utils.ts` already used the safe `execFileSync` argv form, and `commitChanges` in `git-utils.ts` already passed commit messages over stdin via `git commit -F -`. The commit message handling in `migrate-ui-api.ts` now matches the latter.

### Testing

Both issues were reproduced end-to-end against the real code paths before fixing, and each new regression test was confirmed to fail against the unfixed code. Coverage asserts that git is invoked with argument arrays and never through a shell, that substitution-shaped values are passed through as opaque arguments, and that tampered refs are rejected before git is invoked.

## Related Issue(s)

Fixes NXC-4679
