### PR TITLE
docs(nx-cloud): clarify agent environment forwarding

### DIFF
--- a/astro-docs/src/content/docs/features/CI Features/distribute-task-execution.mdoc
+++ b/astro-docs/src/content/docs/features/CI Features/distribute-task-execution.mdoc
@@ -91,6 +91,7 @@ Favor correctness over cleverness. Keep coordinator-only responsibilities in the
    - Secrets that must not be forwarded.
    - Set `NX_CLOUD_CONTINUOUS_ASSIGNMENT: true` in the global environment for the main orchestration job unless the existing pipeline has a documented reason not to.
    - Do not recommend `--with-env-vars=auto` unless the workflow already uses it or the user explicitly accepts broad forwarding.
+   - Do not pass system or CI platform identifier environment variables via `--with-env-vars`. In particular, exclude `CI`, `CIRCLECI`, `TRAVIS`, `GITHUB_ACTIONS`, `BITBUCKET_BUILD_NUMBER`, `BUILD_BUILDID`, `AGENT_NAME`, `GITLAB_CI`, and `NX_CLOUD_VERSION`; forwarding these can make an Nx Agent identify itself as the CI coordinator or as the wrong CI platform.
    - Never print full env in agent setup.
 
 6. Map reusable CI steps:


### PR DESCRIPTION
## Summary

- warn the Nx Agents migration prompt not to forward system or CI platform identifiers through `--with-env-vars`
- list the environment variables used by VCS/CI detection so the pattern is explicit
- keep the wording aligned with the Nx Cloud migration modal in nrwl/ocean#12369

## Validation

- `npx prettier --check 'astro-docs/src/content/docs/features/CI Features/distribute-task-execution.mdoc'`
- `git diff --check`
- focused Vale validation (0 errors; pre-existing warnings only)

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/proud-tapir-18e9391f)
<!-- polygraph-session-end -->