### PR TITLE
chore(repo): sandbox the reproduce-verifier's repro + PR build

### DIFF
--- a/.claude/agents/reproduce-verifier.md
+++ b/.claude/agents/reproduce-verifier.md
@@ -124,64 +124,16 @@ Level 2 publishes nx packages from the worktree at HEAD into a local verdaccio i
 
 #### Prerequisites
 
-1. Node 20+ and pnpm 10.28.2+ in PATH.
-2. Worktree has been built or can be built (`pnpm install` may need to run first).
-3. Port 4873 is free (or a different port is specified via `VERDACCIO_PORT`).
-4. Disk space for `dist/local-registry/storage` (~500MB-1GB).
+1. The `nx-review-sandbox` image exists: `docker image inspect nx-review-sandbox:latest`. If not, run `setup-review-sandbox` — it carries the repo's full toolchain (node/java/dotnet/maven/rust via mise). **java + dotnet are required** because nx dogfoods the `@nx/dotnet` + `@nx/gradle` graph plugins; the build fails without them.
+2. Docker + the isolation runtime (gVisor on Linux / the Docker VM on macOS) + container networking are healthy — see the `reproduce-issue` skill's Preflight.
 
-If any prerequisite is missing, report and skip Level 2 — do NOT attempt partial setup.
+If a prerequisite is missing, report and skip Level 2 — **never build or run on the host.**
 
-#### Step 1: Install dependencies in the worktree (if needed)
+#### Steps 1–3: build the PR — INSIDE the sandbox (no host build)
 
-```bash
-cd "$WORKTREE_PATH"
-test -d node_modules || pnpm install --frozen-lockfile
-```
+**Nothing builds on the host.** The build is done by the `reproduce-issue` skill's **PR-build mode** (`nx-build:<HEAD_SHA>`): the skill's sandbox container clones `nrwl/nx`, checks out that SHA, runs `mise install` + `pnpm install`, then builds + publishes nx to a verdaccio on **`localhost` inside the same container** — and reproduces against it. One container, localhost, no host verdaccio, no `WORKTREE_PATH` build.
 
-If `pnpm install` fails, stop and report. Do not try to continue.
-
-#### Step 2: Start the local registry
-
-Start verdaccio in the background. It must outlive the publish step but be killable on cleanup.
-
-```bash
-cd "$WORKTREE_PATH"
-PORT=${VERDACCIO_PORT:-4873}
-pnpm nx local-registry @nx/nx-source --port=$PORT >/tmp/verdaccio-<PR_NUMBER>.log 2>&1 &
-VERDACCIO_PID=$!
-echo "$VERDACCIO_PID" > /tmp/verdaccio-<PR_NUMBER>.pid
-```
-
-Wait up to 60s for the registry to accept connections:
-
-```bash
-for i in $(seq 1 60); do
-  if curl -sf http://localhost:$PORT/-/ping >/dev/null 2>&1; then break; fi
-  sleep 1
-done
-curl -sf http://localhost:$PORT/-/ping >/dev/null || { echo "verdaccio failed to start"; exit 1; }
-```
-
-If startup fails, kill the pid (if set), report, and exit.
-
-#### Step 3: Publish nx to the local registry
-
-```bash
-cd "$WORKTREE_PATH"
-NX_LOCAL_REGISTRY_PORT=$PORT \
-NX_VERBOSE_LOGGING=true \
-PUBLISHED_VERSION=${TARGET_PUBLISHED_VERSION:-major} \
-pnpm nx populate-local-registry-storage @nx/nx-source 2>&1 | tee /tmp/publish-<PR_NUMBER>.log
-```
-
-This runs `pnpm nx-release --local ${PUBLISHED_VERSION}` internally — it builds all packages, versions them, and publishes to verdaccio. Takes 5-10 minutes. If it fails, capture the error and skip to cleanup.
-
-After success, determine the exact published version:
-
-```bash
-PUBLISHED_NX_VERSION=$(node -p "require('$WORKTREE_PATH/dist/packages/nx/package.json').version")
-echo "Published version: $PUBLISHED_NX_VERSION"
-```
+So the old host Steps 1–3 are gone — the whole build → publish → reproduce happens in **Step 4's single skill call**. (`WORKTREE_PATH` is still used read-only by Levels 0–1; Level 2 never builds it.)
 
 #### Step 4: Run the external repro IN THE SANDBOX (via the `reproduce-issue` skill)
 
@@ -192,8 +144,7 @@ Skill(skill="reproduce-issue", args="""
 repro: repo:<REPO_URL>            # EXTERNAL_REPO
   # -- or, for GENERATED_WORKSPACE:
   # repro: create:"--preset=<PRESET_FROM_ISSUE> <OTHER_FLAGS_FROM_ISSUE> --no-interactive --skipGit"
-nx-version: <PUBLISHED_NX_VERSION>
-nx-registry: <URL of the local registry serving the PR build — see "Registry" below>
+nx-build: <HEAD_SHA>             # PR-build mode: the skill builds THIS commit in-sandbox and reproduces against it
 command: <REPRO_COMMAND, verbatim from the issue>
 node-image: node:<major from the issue's Nx Report; default 22>
 expect: <the reported symptom, one line>

--- a/.claude/agents/reproduce-verifier.md
+++ b/.claude/agents/reproduce-verifier.md
@@ -118,7 +118,7 @@ Only attempt Level 1 for `LOCAL_TEST` or `LOCAL_NX_TARGET` scenarios. For other 
 
 Only attempt Level 2 when `RUN_LEVEL_2: true` is passed by the caller. Default is off — Level 2 takes ~10-15 minutes per invocation.
 
-Level 2 publishes nx packages from the worktree at HEAD into a local verdaccio instance, then runs the external repro against that build. This is **HEAD-only** — we do not re-publish at master for the baseline. The verdict becomes `PR_REPRO_PASSES` or `PR_REPRO_FAILS`, describing what happened _at the PR_ without trying to confirm the bug existed on master. That limitation is a deliberate trade for wall-clock time. If the caller needs a master baseline, they can run Level 2 twice manually.
+Level 2 publishes nx packages from the worktree at HEAD into a local verdaccio instance, then runs the external repro against that build **inside an isolated sandbox** — the clone/install/run is delegated to the **`reproduce-issue`** skill (Step 4), so untrusted repro code never executes on the host. This is **HEAD-only** — we do not re-publish at master for the baseline. The verdict becomes `PR_REPRO_PASSES` or `PR_REPRO_FAILS`, describing what happened _at the PR_ without trying to confirm the bug existed on master. That limitation is a deliberate trade for wall-clock time. If the caller needs a master baseline, they can run Level 2 twice manually.
 
 **Critical:** you MUST always clean up, even on failure. Use the exit-trap pattern described in step 9 below.
 
@@ -183,109 +183,27 @@ PUBLISHED_NX_VERSION=$(node -p "require('$WORKTREE_PATH/dist/packages/nx/package
 echo "Published version: $PUBLISHED_NX_VERSION"
 ```
 
-#### Step 4: Prepare the scratch repro workspace
+#### Step 4: Run the external repro IN THE SANDBOX (via the `reproduce-issue` skill)
 
-Use `/tmp/pr-<PR_NUMBER>-repro/` as the scratch dir — deliberately outside the nx repo, so the generated/cloned workspace's own nx root can't be mistaken for (or nested inside) the repo you're reviewing. Always wipe it at the start of this step:
+**Do NOT clone, install, or run the untrusted repro on the host.** Its `install` scripts and repro command are arbitrary third-party code — delegate the whole thing to the **`reproduce-issue`** skill, which clones/creates → rewrites the nx deps → installs → runs the repro → classifies, **all inside an isolated container** (gVisor on Linux, the Docker VM on macOS), then destroys it. There is no host scratch dir.
 
-```bash
-REPRO_DIR=/tmp/pr-<PR_NUMBER>-repro
-rm -rf "$REPRO_DIR"
-mkdir -p "$REPRO_DIR"
+```
+Skill(skill="reproduce-issue", args="""
+repro: repo:<REPO_URL>            # EXTERNAL_REPO
+  # -- or, for GENERATED_WORKSPACE:
+  # repro: create:"--preset=<PRESET_FROM_ISSUE> <OTHER_FLAGS_FROM_ISSUE> --no-interactive --skipGit"
+nx-version: <PUBLISHED_NX_VERSION>
+nx-registry: <URL of the local registry serving the PR build — see "Registry" below>
+command: <REPRO_COMMAND, verbatim from the issue>
+node-image: node:<major from the issue's Nx Report; default 22>
+expect: <the reported symptom, one line>
+setup: <files the issue says to create first, else omit>
+""")
 ```
 
-**For `EXTERNAL_REPO`:**
+The skill returns a block whose `verdict:` is one of `PR_REPRO_PASSES | PR_REPRO_FAILS | PR_REPRO_FAILS_DIFFERENT | PR_REPRO_INCONCLUSIVE | SETUP_FAILED`, plus the exit code and an output tail. **Use that verdict directly** in your report — do not re-run anything on the host. If it returns `SETUP_FAILED`, note which step (clone / create / install) broke; do not fall back to the host.
 
-1. Clone the repro repo:
-
-   ```bash
-   git clone --depth=1 <REPO_URL> "$REPRO_DIR"
-   ```
-
-2. Rewrite all `nx` / `@nx/*` / `@nrwl/*` dependency versions in `$REPRO_DIR/package.json` to the exact `$PUBLISHED_NX_VERSION`:
-
-   ```bash
-   node -e '
-     const fs = require("fs");
-     const p = JSON.parse(fs.readFileSync(process.argv[1], "utf8"));
-     const v = process.argv[2];
-     for (const section of ["dependencies", "devDependencies"]) {
-       const deps = p[section] || {};
-       for (const name of Object.keys(deps)) {
-         if (name === "nx" || name.startsWith("@nx/") || name.startsWith("@nrwl/")) {
-           deps[name] = v;
-         }
-       }
-     }
-     fs.writeFileSync(process.argv[1], JSON.stringify(p, null, 2) + "\n");
-   ' "$REPRO_DIR/package.json" "$PUBLISHED_NX_VERSION"
-   ```
-
-3. If the repo has a lockfile, delete it (it's now stale after the rewrite):
-
-   ```bash
-   rm -f "$REPRO_DIR/package-lock.json" "$REPRO_DIR/pnpm-lock.yaml" "$REPRO_DIR/yarn.lock"
-   ```
-
-4. Detect the package manager (prefer the same one used by the repo; fall back to npm):
-
-   ```bash
-   if test -f "$REPRO_DIR/pnpm-workspace.yaml"; then PM=pnpm;
-   elif grep -q '"packageManager"' "$REPRO_DIR/package.json" 2>/dev/null; then
-     PM=$(node -p "require('$REPRO_DIR/package.json').packageManager?.split('@')[0] || 'npm'")
-   else PM=npm; fi
-   ```
-
-5. Install with the registry env var pointing at verdaccio:
-
-   ```bash
-   cd "$REPRO_DIR"
-   npm_config_registry=http://localhost:$PORT \
-   BUN_CONFIG_REGISTRY=http://localhost:$PORT \
-   YARN_REGISTRY=http://localhost:$PORT \
-   $PM install 2>&1 | tee /tmp/install-<PR_NUMBER>.log
-   ```
-
-   If install fails, capture why. Common causes: lockfile not deleted, version mismatch the rewrite didn't catch (peer deps of sibling packages), missing `@nx/*` plugins in our publish set. Record and stop.
-
-**For `GENERATED_WORKSPACE`:**
-
-Instead of cloning, run `create-nx-workspace` pointed at the local registry:
-
-```bash
-cd /tmp
-npm_config_registry=http://localhost:$PORT \
-BUN_CONFIG_REGISTRY=http://localhost:$PORT \
-YARN_REGISTRY=http://localhost:$PORT \
-npx --yes create-nx-workspace@$PUBLISHED_NX_VERSION \
-  --name=pr-<PR_NUMBER>-repro \
-  --preset=<PRESET_FROM_ISSUE> \
-  --no-interactive \
-  --skipGit \
-  <OTHER_FLAGS_FROM_ISSUE> 2>&1 | tee /tmp/create-workspace-<PR_NUMBER>.log
-```
-
-Pull `<PRESET_FROM_ISSUE>` and `<OTHER_FLAGS_FROM_ISSUE>` from the reported repro steps. If the issue doesn't specify a preset, use `apps` as a safe default and flag it in the report.
-
-#### Step 5: Run the reported repro command
-
-Extract the exact command from the issue body. If it references specific files to create first, create them in the scratch dir. Run with a timeout:
-
-```bash
-cd "$REPRO_DIR"
-timeout 300 <REPRO_COMMAND> 2>&1 | tee /tmp/repro-<PR_NUMBER>.log
-REPRO_EXIT=$?
-```
-
-Note: `timeout` may not be available on macOS by default — use `gtimeout` (from `brew install coreutils`) or emulate with a background kill. If neither is available, run without a timeout but watch carefully.
-
-#### Step 6: Classify the outcome
-
-Compare the output (`/tmp/repro-<PR_NUMBER>.log` + `REPRO_EXIT`) to the reported behavior:
-
-- `PR_REPRO_PASSES` — the command succeeded, matching the PR's claimed fix. Verdict.
-- `PR_REPRO_FAILS_WITH_REPORTED_ERROR` — the command failed with the same error the issue describes. The PR did NOT fix the bug. Verdict `PR_REPRO_FAILS`.
-- `PR_REPRO_FAILS_DIFFERENT` — the command failed but with a different error. Flag for human review — may be env-specific or a related-but-different bug.
-- `PR_REPRO_INCONCLUSIVE` — output doesn't clearly match either direction. Capture the tail of the log and stop.
+**Registry — where the PR's nx comes from.** Target architecture: the PR is **built inside the sandbox** and served from a verdaccio on `localhost` in that same sandbox, so `nx-registry:http://localhost:<PORT>` — no host reachability, no listen-address change. That build (Steps 1–3) is being migrated off the host into the sandbox and needs the `nx-review-sandbox` image (`setup-review-sandbox`). Until the migration lands, Steps 1–3 still publish to a host verdaccio; status + the container-to-container handoff are tracked in `tmp/notes/review-in-container-plan.md`.
 
 #### Step 7: Always clean up (cleanup trap)
 
@@ -303,15 +221,15 @@ fi
 # 2. Belt-and-suspenders: free the port even if pid is gone
 npx -y kill-port $PORT 2>/dev/null || true
 
-# 3. Remove scratch workspace
-rm -rf /tmp/pr-<PR_NUMBER>-repro
+# 3. No host scratch dir to remove — the repro lived and died inside the sandbox
+#    (the reproduce-issue skill's container self-destroys via --rm). If a sandbox
+#    container ever lingers, clear it with /sandbox-prune.
 
-# 4. Remove the ephemeral logs only AFTER capturing their tails in your report
-#    Keep them on failure so the user can inspect them:
+# 4. Remove the ephemeral HOST logs only AFTER capturing their tails in your report.
+#    Only verdaccio + publish run on the host now; the repro's own output comes
+#    back inside the skill's returned block:
 #    - /tmp/verdaccio-<PR_NUMBER>.log
 #    - /tmp/publish-<PR_NUMBER>.log
-#    - /tmp/install-<PR_NUMBER>.log  (or create-workspace)
-#    - /tmp/repro-<PR_NUMBER>.log
 ```
 
 Do NOT `rm -rf dist/local-registry/storage` in the nx worktree — that storage is shared state used by E2E tests. Leave it.

--- a/.claude/skills/reproduce-issue/SKILL.md
+++ b/.claude/skills/reproduce-issue/SKILL.md
@@ -1,0 +1,151 @@
+---
+name: reproduce-issue
+description: The single skill for reproducing an nx issue. Given a GitHub issue number (human entry) OR explicit repro parameters (agent entry), it runs the reproduction ENTIRELY inside an isolated Docker sandbox — gVisor on Linux, the Docker VM on macOS — so the untrusted repro's install scripts and commands never execute on the host, then reports whether it reproduces. Called by humans via "/reproduce-issue #N", "reproduce this bug", "does this reproduce", and by the reproduce-verifier agent (Level 2). Nothing lands on the host.
+allowed-tools: Read, Grep, Glob, Bash(uname *), Bash(gh issue view *), Bash(gh issue list *), Bash(docker run *), Bash(docker cp *), Bash(docker rm *), Bash(docker info *), Bash(docker pull *)
+---
+
+# Reproduce an issue (sandboxed)
+
+Reproduce an nx bug **entirely inside an isolated container** and report the outcome. The untrusted repro — its `install` (arbitrary postinstall scripts) and its repro command — runs only in the sandbox, never on the host. `--rm` destroys everything on exit; nothing touches the host filesystem.
+
+This is the one reproduction engine in the repo. It has two front doors:
+
+## Entry A — a GitHub issue (human: `/reproduce-issue <N>`)
+
+1. Fetch the issue:
+   ```bash
+   gh issue view <N> --repo nrwl/nx --json number,title,body,comments,labels
+   ```
+2. Extract from the body: the **repro repo URL** (or `create-nx-workspace` steps), the **exact command(s)** that show the bug, the **reported vs expected** behavior, and the **Nx Report** (nx version + Node version).
+3. Fill the parameters below and run the sandbox (default `nx-version` = whatever the issue reports / the repo pins; default registry = public npm).
+
+## Entry B — explicit parameters (agent: reproduce-verifier Level 2)
+
+The caller passes these directly:
+
+- **`repro`** — `repo:<git-url>` (clone a public repo) OR `create:"<create-nx-workspace args>"`.
+- **`nx-version:<version>`** — rewrite the repro's `nx` / `@nx/*` / `@nrwl/*` deps to this exact version.
+- **`nx-registry:<url>`** (optional) — registry to install nx from. Default public npm. **Point at a host verdaccio to test an unreleased PR build** (see below).
+- **`command:"<repro-cmd>"`** — the command whose output/exit code decides the verdict.
+- **`node-image:<img>`** (optional) — base image matching the issue's Node (default `node:22`; public images are multi-arch → native on Apple Silicon).
+- **`expect:<reported symptom>`** (optional), **`setup:"<files/steps>"`** (optional) — files to create in the workspace first.
+
+## Platform (where the sandbox boundary comes from)
+
+Run `uname -s` once:
+
+- **Linux** → add `--runtime=runsc` to `docker run` (gVisor is the sandbox).
+- **macOS (`Darwin`)** → **omit `--runtime=runsc`** (the Docker VM is the sandbox). Verify `docker info` works; if not, tell the user to `colima start` (or start Docker Desktop / OrbStack).
+
+The command below shows the Linux form — on macOS drop `--runtime=runsc`, keep the rest.
+
+## Preflight — check the environment, fail with a FIX (not a mystery)
+
+Before running anything, verify prerequisites in order and **stop at the first miss, printing the one-line fix**. Most misses point at the `setup-review-sandbox` skill, which installs/builds everything.
+
+1. **Docker is up:**
+
+   ```bash
+   docker info >/dev/null 2>&1 && echo up || echo MISSING
+   ```
+
+   Miss → Linux: `sudo systemctl start docker`. macOS: `colima start` (or open Docker Desktop). Or run `setup-review-sandbox`.
+
+2. **Container networking works** (the check that would have caught the `veth` breakage):
+
+   ```bash
+   docker run --rm --network none alpine true   # A: is the sandbox itself OK?
+   docker run --rm alpine true                  # B: is networking OK?
+   ```
+
+   If **A passes but B fails** with `veth ... operation not supported` → networking is broken (usually a kernel update left `veth` unloadable). Fix: `sudo modprobe veth`; if that errors with a BTF/version mismatch, **reboot** (the running kernel no longer matches its modules).
+
+3. **Isolation runtime (platform-specific):**
+   - **Linux** — gVisor registered as a Docker runtime?
+     ```bash
+     docker info --format '{{range $k,$v := .Runtimes}}{{$k}} {{end}}' | grep -q runsc && echo ok || echo MISSING
+     ```
+     Miss → run `setup-review-sandbox` (installs + registers `runsc`).
+   - **macOS** — the Docker VM (Colima / Docker Desktop) _is_ the sandbox; step 1 already covered it. No `runsc`.
+
+4. **(PR-build mode ONLY) the toolchain image exists:**
+   ```bash
+   docker image inspect nx-review-sandbox:latest >/dev/null 2>&1 && echo ok || echo MISSING
+   ```
+   Miss → run `setup-review-sandbox` (builds it from `tools/review-sandbox/Dockerfile`). **Skip this check** when reproducing against a _published_ nx version — that path needs only steps 1–3 and a public `node` image.
+
+If all needed checks pass, proceed.
+
+## Safety rails (do NOT break these)
+
+- The untrusted repro runs **only** in the container. **Never `-v` a host path in.** nx comes from a registry (or `docker cp`-ed tarballs), never a mount.
+- Always pass: `--cap-drop ALL`, `--security-opt no-new-privileges`, `--memory 4g --cpus 4 --pids-limit 2048`, `--rm`; plus `--runtime=runsc` on Linux.
+- Network is ON (clone + install need it). gVisor still protects the host kernel; on macOS the VM protects the host.
+- One `docker` command per Bash call. (Chaining inside the container's `bash -c '...'` is one host command, which is fine.)
+
+## Run
+
+Detect platform, then a single host command does clone/create → dep-rewrite → install → repro, all inside the sandbox:
+
+```bash
+# RUNTIME="--runtime=runsc"   on Linux
+# RUNTIME=""                   on macOS
+docker run --rm $RUNTIME \
+  --cap-drop ALL --security-opt no-new-privileges \
+  --memory 4g --cpus 4 --pids-limit 2048 \
+  node:22 bash -c '
+    set -e
+    git clone --depth 1 <GIT_URL> /repro          # repo: form
+    # -- or -- npx --yes create-nx-workspace <ARGS> --directory /repro   # create: form
+    cd /repro
+
+    node -e '"'"'
+      const fs=require("fs"),p=JSON.parse(fs.readFileSync("package.json","utf8")),v=process.argv[1];
+      for (const s of ["dependencies","devDependencies"]) for (const n of Object.keys(p[s]||{}))
+        if (n==="nx"||n.startsWith("@nx/")||n.startsWith("@nrwl/")) p[s][n]=v;
+      fs.writeFileSync("package.json", JSON.stringify(p,null,2)+"\n");
+    '"'"' <NX_VERSION>
+
+    rm -f package-lock.json pnpm-lock.yaml yarn.lock
+    PM=npm; test -f pnpm-workspace.yaml && PM=pnpm
+    npm i -g pnpm@11 >/dev/null 2>&1 || true
+    npm_config_registry=<NX_REGISTRY> $PM install
+
+    ( timeout 300 <REPRO_COMMAND> ); echo "REPRO_EXIT=$?"
+    echo "kernel: $(uname -r)"
+  '
+```
+
+Substitute `<GIT_URL>`/`<ARGS>`, `<NX_VERSION>`, `<NX_REGISTRY>` (default `https://registry.npmjs.org`), and `<REPRO_COMMAND>`.
+
+## Classify + report
+
+Compare output and `REPRO_EXIT` against the reported symptom, and return this block (verdicts match the reproduce-verifier's Level 2 vocabulary):
+
+```
+repro:        <repo-url | create-nx-workspace ...>
+nx-version:   <version>   (registry: <url>)
+command:      <verbatim>
+exit code:    <N>
+verdict:      <PR_REPRO_PASSES | PR_REPRO_FAILS | PR_REPRO_FAILS_DIFFERENT | PR_REPRO_INCONCLUSIVE | SETUP_FAILED>
+output (tail ~20 lines):
+  <...>
+```
+
+- succeeded (matches the claimed fix) → `PR_REPRO_PASSES`
+- failed with the reported error → `PR_REPRO_FAILS`
+- failed with a _different_ error → `PR_REPRO_FAILS_DIFFERENT` (flag for human)
+- unclear → `PR_REPRO_INCONCLUSIVE`
+- clone/create/install broke before the repro ran → `SETUP_FAILED` (say which step + tail)
+
+(For a human `/reproduce-issue` run against a released version, "reproduced" vs "did not reproduce" is the plain-language answer; the verdict vocab above is for the agent.)
+
+## Testing an unreleased PR build
+
+To test a PR's _unreleased_ nx, the PR branch is **built inside the sandbox** (not on the host), and the built nx is served to the repro **from inside the same sandbox**: a verdaccio on `localhost` in the container (pass `nx-registry:http://localhost:<PORT>`), or tarballs on a docker volume shared between the build and repro containers. Either way it's container-local — **no host verdaccio, no `host.docker.internal`, no listen-address change.**
+
+Prerequisite: the in-sandbox nx build needs the review-sandbox image to carry **dotnet + a JDK** (nx dogfoods `@nx/dotnet` + `@nx/gradle` in its project graph). Tracked in `tmp/notes/review-in-container-plan.md`.
+
+## Cleanup
+
+`--rm` destroys the container and everything in it on exit. Nothing persists on the host. Stray sandbox containers/images: `/sandbox-prune`.

--- a/.claude/skills/reproduce-issue/SKILL.md
+++ b/.claude/skills/reproduce-issue/SKILL.md
@@ -24,8 +24,9 @@ This is the one reproduction engine in the repo. It has two front doors:
 The caller passes these directly:
 
 - **`repro`** — `repo:<git-url>` (clone a public repo) OR `create:"<create-nx-workspace args>"`.
-- **`nx-version:<version>`** — rewrite the repro's `nx` / `@nx/*` / `@nrwl/*` deps to this exact version.
-- **`nx-registry:<url>`** (optional) — registry to install nx from. Default public npm. **Point at a host verdaccio to test an unreleased PR build** (see below).
+- **`nx-version:<version>`** — install this **published** nx and rewrite the repro's `nx` / `@nx/*` / `@nrwl/*` deps to it. For reproducing against a released version.
+- **`nx-build:<git-ref>`** (PR-verification mode) — instead of a published version, **build nx from this `nrwl/nx` commit inside the sandbox** and reproduce against it. Uses the `nx-review-sandbox` image; the skill derives the version and serves it from a `localhost` verdaccio in the same container. Mutually exclusive with `nx-version`.
+- **`nx-registry:<url>`** (optional, `nx-version` mode only) — registry to install from. Default public npm.
 - **`command:"<repro-cmd>"`** — the command whose output/exit code decides the verdict.
 - **`node-image:<img>`** (optional) — base image matching the issue's Node (default `node:22`; public images are multi-arch → native on Apple Silicon).
 - **`expect:<reported symptom>`** (optional), **`setup:"<files/steps>"`** (optional) — files to create in the workspace first.
@@ -140,11 +141,44 @@ output (tail ~20 lines):
 
 (For a human `/reproduce-issue` run against a released version, "reproduced" vs "did not reproduce" is the plain-language answer; the verdict vocab above is for the agent.)
 
-## Testing an unreleased PR build
+## PR-build mode — build nx from source in the sandbox (`nx-build`)
 
-To test a PR's _unreleased_ nx, the PR branch is **built inside the sandbox** (not on the host), and the built nx is served to the repro **from inside the same sandbox**: a verdaccio on `localhost` in the container (pass `nx-registry:http://localhost:<PORT>`), or tarballs on a docker volume shared between the build and repro containers. Either way it's container-local — **no host verdaccio, no `host.docker.internal`, no listen-address change.**
+When `nx-build:<git-ref>` is given, do everything in **one `nx-review-sandbox` container** (it carries the mise toolchain incl. **java + dotnet**, required by nx's `@nx/dotnet`/`@nx/gradle` graph plugins). One container, `localhost` throughout — no host build, no host verdaccio, no `host.docker.internal`, no listen-address change:
 
-Prerequisite: the in-sandbox nx build needs the review-sandbox image to carry **dotnet + a JDK** (nx dogfoods `@nx/dotnet` + `@nx/gradle` in its project graph). Tracked in `tmp/notes/review-in-container-plan.md`.
+```bash
+# RUNTIME="--runtime=runsc"  on Linux, ""  on macOS
+docker run --rm $RUNTIME \
+  --cap-drop ALL --security-opt no-new-privileges \
+  --memory 20g --cpus 6 --pids-limit 8192 --tmpfs /work:rw,exec,size=16g \
+  -e CI=true -e NX_DAEMON=false \
+  nx-review-sandbox:latest bash -c '
+    set -e
+    # 1. build nx from the PR commit
+    cd /work
+    git clone --filter=blob:none https://github.com/nrwl/nx nx && cd nx
+    git checkout <GIT_REF>
+    mise install && pnpm install --frozen-lockfile
+    PORT=4873
+    pnpm nx local-registry @nx/nx-source --port=$PORT >/tmp/verdaccio.log 2>&1 &
+    for i in $(seq 1 60); do curl -sf http://localhost:$PORT/-/ping >/dev/null 2>&1 && break; sleep 1; done
+    NX_LOCAL_REGISTRY_PORT=$PORT pnpm nx populate-local-registry-storage @nx/nx-source
+    NXV=$(node -p "require(\"/work/nx/dist/packages/nx/package.json\").version")
+
+    # 2. reproduce against that build — same container, localhost registry
+    cd /work
+    git clone --depth 1 <GIT_URL> repro     # or: npx --yes create-nx-workspace <ARGS> --directory repro
+    cd repro
+    # rewrite nx/@nx/@nrwl deps to "$NXV" (same node one-liner as the Run section)
+    rm -f package-lock.json pnpm-lock.yaml yarn.lock
+    npm_config_registry=http://localhost:$PORT pnpm install
+    ( timeout 300 <REPRO_COMMAND> ); echo "REPRO_EXIT=$?"
+    echo "kernel: $(uname -r)"
+  '
+```
+
+Because verdaccio and the repro live in the **same** container, the registry is plain `localhost` — the reachability/listen-address problems a host verdaccio would create simply don't exist. Classify the result exactly as in "Classify + report".
+
+Prerequisite: the `nx-review-sandbox` image (`setup-review-sandbox`). The nx build is heavy (~several min + several GB) — RAM-backed via the tmpfs above so it stays off the host disk.
 
 ## Cleanup
 

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -358,12 +358,12 @@ git -C "$NX_REPO_PATH" worktree add --detach "$WORKTREE_BASE/pr-<NUMBER>-verify"
 
 (Detached on purpose: the `pr-<NUMBER>` branch is already checked out by the review worktree, and the verifier only ever checks out SHAs.)
 
-Decide whether to opt in to Level 2 (expensive verdaccio-based external-repo reproduction, ~10-15 min per PR). Default is **off** — Level 2 only runs when:
+Decide whether to opt in to Level 2 (expensive **sandboxed** reproduction — the agent builds the PR and runs the external repro inside a container, ~10-15 min per PR). Default is **off** — Level 2 only runs when:
 
 - The caller of this skill explicitly requested deep verification (e.g. invoked with the `--verify-external-repros` flag, or a manual `/review-pr <N> --verify-repros` pattern), OR
 - `$NX_REVIEW_LEVEL_2=1` is set in the environment.
 
-Level 2 is for deep-dive passes where you want end-user-level proof — each run takes ~10-15 minutes and ~0.5-1 GB of disk, so opt in deliberately.
+Level 2 is for deep-dive passes where you want end-user-level proof — each run **builds nx inside the sandbox** (needs the `nx-review-sandbox` image; run `setup-review-sandbox` if missing), takes ~10-15 minutes and several GB, so opt in deliberately. Nothing in Level 2 builds or runs on the host.
 
 ```
 Agent(

--- a/.claude/skills/setup-review-sandbox/SKILL.md
+++ b/.claude/skills/setup-review-sandbox/SKILL.md
@@ -1,0 +1,95 @@
+---
+name: setup-review-sandbox
+description: One-time setup of the sandbox prerequisites used by the reproduce-issue skill and the reproduce-verifier agent — Docker, the isolation runtime (gVisor on Linux / Colima on macOS), healthy container networking, and the nx-review-sandbox toolchain image (built from the repo's mise.toml). Idempotent; re-run any time to verify or repair. Use when the user says "set up the review sandbox", "install the sandbox prereqs", "build the sandbox image", or a reproduce-issue preflight reports something MISSING.
+allowed-tools: Read, Grep, Glob, Bash(uname *), Bash(docker info *), Bash(docker run *), Bash(docker build *), Bash(docker image inspect *), Bash(docker images *), Bash(command -v *), Bash(lsmod *)
+---
+
+# Set up the review sandbox (one-time)
+
+Installs and verifies everything the `reproduce-issue` skill / `reproduce-verifier` agent need to run untrusted PR code in isolation. Idempotent — each step checks first and only acts if needed. Steps needing `sudo` are handed to the user to run in their terminal (this skill cannot `sudo` non-interactively).
+
+Run `uname -s` first — the path differs on Linux vs macOS.
+
+## 1. Docker
+
+```bash
+docker info >/dev/null 2>&1 && echo "docker OK" || echo "docker MISSING"
+```
+
+- **MISSING, Linux:** install Docker Engine, then `sudo systemctl enable --now docker` and add yourself to the `docker` group (`sudo usermod -aG docker $USER`, then re-login).
+- **MISSING, macOS:** `brew install colima docker` then `colima start` (or install Docker Desktop).
+
+## 2. Isolation runtime
+
+### Linux — gVisor (`runsc`)
+
+```bash
+docker info --format '{{range $k,$v := .Runtimes}}{{$k}} {{end}}' | grep -q runsc && echo "runsc OK" || echo "runsc MISSING"
+```
+
+If MISSING, have the user run this in their terminal (needs `sudo`; their shell is fish — exit codes are `$status`):
+
+```bash
+sudo apt-get update && sudo apt-get install -y apt-transport-https ca-certificates curl gnupg
+curl -fsSL https://gvisor.dev/archive.key | sudo gpg --dearmor -o /usr/share/keyrings/gvisor-archive-keyring.gpg
+echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/gvisor-archive-keyring.gpg] https://storage.googleapis.com/gvisor/releases release main" | sudo tee /etc/apt/sources.list.d/gvisor.list
+sudo apt-get update && sudo apt-get install -y runsc
+sudo runsc install          # registers runsc as a Docker runtime
+sudo systemctl restart docker
+```
+
+Then re-check the runtime line above.
+
+### macOS — the Docker VM is the sandbox
+
+No `runsc`. Just confirm the VM is up:
+
+```bash
+docker info >/dev/null 2>&1 && echo "docker VM OK" || echo "start it: colima start"
+```
+
+## 3. Container networking (catches the `veth` class of breakage)
+
+```bash
+docker run --rm --network none alpine true && echo "sandbox OK"
+docker run --rm alpine true && echo "networking OK" || echo "networking BROKEN"
+```
+
+If the first passes but the second fails with `veth ... operation not supported`:
+
+```bash
+sudo modprobe veth
+```
+
+If `modprobe` errors with a BTF / version mismatch (`failed to validate module [veth] BTF`), the running kernel no longer matches its on-disk modules (a kernel update landed while it was booted) — **reboot**, after which it auto-loads. Persist it: `echo veth | sudo tee /etc/modules-load.d/veth.conf`.
+
+## 4. The toolchain image (`nx-review-sandbox`)
+
+Needed only to **build an unreleased PR's nx** in the sandbox (reproduce-verifier Level 2). Reproducing against a published nx version does NOT need it.
+
+```bash
+docker image inspect nx-review-sandbox:latest >/dev/null 2>&1 && echo "image OK" || echo "image MISSING"
+```
+
+If MISSING, build it from the repo root (so `mise.toml` is in the build context). This installs the repo's exact toolchain — node/java/dotnet/maven/rust/bun via mise — and takes a while + several GB:
+
+```bash
+docker build -t nx-review-sandbox:latest -f tools/review-sandbox/Dockerfile .
+```
+
+Requires steps 1 + 3 to pass first (build needs working networking). If disk is tight, `/sandbox-prune` first.
+
+## 5. Verify (smoke test)
+
+Confirm the sandbox actually isolates and carries the tools:
+
+```bash
+# RUNTIME="--runtime=runsc"  on Linux, ""  on macOS
+docker run --rm $RUNTIME nx-review-sandbox:latest bash -lc '
+  echo "kernel: $(uname -r)"       # Linux+gVisor: 4.19.0-gvisor ; macOS: the VM kernel
+  mise ls 2>/dev/null | head
+  node --version; java -version 2>&1 | head -1; dotnet --version
+'
+```
+
+Green when: the kernel is NOT your host kernel, and node/java/dotnet report versions. Report a concise ✅/❌ per step and what (if anything) the user still needs to run.

--- a/tools/review-sandbox/Dockerfile
+++ b/tools/review-sandbox/Dockerfile
@@ -1,0 +1,40 @@
+# Review sandbox base image.
+#
+# Builds nx (JS + its napi-rs Rust native module) and runs reproductions inside a
+# gVisor/VM sandbox, so PR-authored code never builds or runs on the host during
+# a code review. Used by the reproduce-verifier agent + the reproduce-issue skill.
+#
+# The toolchain is driven by the repo's own mise.toml — the single source of truth —
+# so node / java / dotnet / maven / rust / bun / pnpm(corepack) stay in lockstep with
+# what the repo actually uses. java + dotnet are required because nx dogfoods the
+# @nx/dotnet and @nx/gradle plugins in its own project graph.
+#
+# Build from the repo root so mise.toml is in the build context:
+#   docker build -t nx-review-sandbox:latest -f tools/review-sandbox/Dockerfile .
+FROM debian:bookworm-slim
+
+# System libraries mise-managed tools do NOT provide:
+#  - the nx napi-rs Rust native build needs a C/C++ toolchain (build-essential, clang,
+#    libclang, pkg-config, libssl, python3);
+#  - .NET needs libicu / krb5 / zlib at runtime;
+#  - mise needs curl/git/unzip/xz/ca-certificates to fetch + extract toolchains.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      build-essential clang libclang-dev pkg-config libssl-dev python3 \
+      git curl ca-certificates unzip xz-utils \
+      libicu72 libgssapi-krb5-2 zlib1g \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install mise — the version manager the nx repo uses.
+RUN curl -fsSL https://mise.run | sh
+ENV PATH="/root/.local/bin:/root/.local/share/mise/shims:${PATH}" \
+    MISE_YES=1
+
+WORKDIR /work
+
+# Bake the repo's pinned toolchain into the image (fast common case). At run time,
+# `mise install` inside the PR checkout picks up any tool-version bumps the PR made.
+COPY mise.toml /work/mise.toml
+RUN mise trust /work/mise.toml \
+    && mise install \
+    && mise reshim \
+    && mise ls


### PR DESCRIPTION
## Current Behavior

The `reproduce-verifier` agent (used by `/review-pr`) grounds a review by reproducing the linked-issue bug. Today it does that **on the host**: Level 2 clones the untrusted external repro repo and runs its `install` / repro commands directly on the reviewer's machine, and builds the PR's nx via `pnpm install` + `nx-release --local` in the worktree. So a malicious PR — or a malicious repro repo linked from an issue — can execute arbitrary code on the reviewer's machine during a review.

## Expected Behavior

All untrusted execution moves into an isolated sandbox (gVisor on Linux, the Docker VM on macOS). **Nothing builds or runs on the host.**

- Add a `reproduce-issue` skill — the single sandboxed reproduction engine, callable by humans (`/reproduce-issue <N>`) and by the `reproduce-verifier` agent, with a self-diagnosing preflight (Docker / isolation runtime / container networking / image).
- Add a `setup-review-sandbox` skill — one-time, idempotent prereq install + build of a mise-driven toolchain image (node / java / dotnet / maven / rust / bun straight from the repo's `mise.toml`).
- Add `tools/review-sandbox/Dockerfile` — that image.
- Rewire `reproduce-verifier` Level 2 to delegate to the skill's PR-build mode: one `nx-review-sandbox` container clones `nrwl/nx`, checks out the PR commit, builds + publishes nx to a `localhost` verdaccio, and reproduces against it — all in-container.
- `/review-pr` needs no code change (it delegates to the agent); its Level 2 description is updated to match.

## Related Issue(s)

N/A — internal review-pipeline tooling.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Sandbox-the-reproduce-verifiers-repro--PR-build-d3b54387)
<!-- polygraph-session-end -->