### PR TITLE
fix(repo): de-flake inferred-project e2e tests by waiting for graph registration

### DIFF
--- a/e2e/plugin/src/nx-plugin-ts-solution.test.ts
+++ b/e2e/plugin/src/nx-plugin-ts-solution.test.ts
@@ -6,10 +6,10 @@ import {
   readJson,
   renameFile,
   runCLI,
-  runCommand,
   uniq,
   updateFile,
   updateJson,
+  waitForInferredProject,
 } from '@nx/e2e-utils';
 import {
   ASYNC_GENERATOR_EXECUTOR_CONTENTS,
@@ -128,6 +128,10 @@ describe('Nx Plugin (TS solution)', () => {
       })
     );
     createFile(`packages/${inferredProject}/my-project-file`);
+
+    // Wait for the daemon to register the newly created inferred project
+    // before asserting, to avoid a watcher-latency race.
+    await waitForInferredProject(inferredProject);
 
     // Attempt to use inferred project w/ Nx
     expect(runCLI(`build ${inferredProject}`)).toContain(
@@ -310,6 +314,8 @@ describe('Nx Plugin (TS solution)', () => {
     );
     createFile(`packages/${inferredProject}/my-project-file`);
 
+    await waitForInferredProject(inferredProject);
+
     expect(runCLI(`build ${inferredProject}`)).toContain(
       'custom registered target'
     );
@@ -427,6 +433,8 @@ export const dockerCreateNodes = (files: string[], options: PluginOptions) => {
       );
       createFile(`packages/${inferredProject}/my-project-file`);
 
+      await waitForInferredProject(inferredProject);
+
       expect(runCLI(`build ${inferredProject}`)).toContain(
         'custom registered target'
       );
@@ -504,6 +512,8 @@ exports.createNodesV2 = [
       JSON.stringify({ name: inferredProject, version: '0.0.1' })
     );
     createFile(`packages/${inferredProject}/my-project-file`);
+
+    await waitForInferredProject(inferredProject);
 
     // With no source condition, Nx resolves to the dist artifact — loading
     // should succeed (not hard-fail with a "custom condition" error).

--- a/e2e/plugin/src/nx-plugin.test.ts
+++ b/e2e/plugin/src/nx-plugin.test.ts
@@ -15,6 +15,7 @@ import {
   uniq,
   updateFile,
   updateJson,
+  waitForInferredProject,
 } from '@nx/e2e-utils';
 import type { PackageJson } from 'nx/src/utils/package-json';
 
@@ -320,6 +321,10 @@ describe('Nx Plugin', () => {
       // Create project that should be inferred by Nx
       const inferredProject = uniq('inferred');
       createFile(`${inferredProject}/my-project-file`);
+
+      // Wait for the daemon to register the newly created inferred project
+      // before asserting, to avoid a watcher-latency race.
+      await waitForInferredProject(inferredProject);
 
       // Attempt to use inferred project w/ Nx
       expect(runCLI(`build ${inferredProject}`)).toContain(

--- a/e2e/utils/command-utils.ts
+++ b/e2e/utils/command-utils.ts
@@ -507,6 +507,40 @@ export function runCLI(
 }
 runCLI.lastExitCode = 0 as number;
 
+/**
+ * Polls `nx show project <name>` until the project is registered.
+ *
+ * Under the forced daemon (`NX_DAEMON=true`), the daemon only recomputes the
+ * project graph once its file watcher reports a change. A test that writes an
+ * inferred project's files and immediately queries the graph can outrun the
+ * OS's delivery of those filesystem events to the watcher, so the daemon serves
+ * a cached graph that predates the project (`Cannot find project '<name>'`).
+ * Gate assertions on this helper so the test waits for the project to actually
+ * be inferred instead of assuming instant visibility.
+ */
+export async function waitForInferredProject(
+  projectName: string,
+  opts: RunCmdOpts & { timeout?: number; interval?: number } = {}
+): Promise<void> {
+  const { timeout = 15_000, interval = 500, ...runOpts } = opts;
+  const start = performance.now();
+  let lastOutput = '';
+  do {
+    lastOutput = runCLI(`show project ${projectName} --json`, {
+      ...runOpts,
+      silenceError: true,
+    });
+    if (runCLI.lastExitCode === 0) {
+      return;
+    }
+    await new Promise((resolve) => setTimeout(resolve, interval));
+  } while (performance.now() - start < timeout);
+
+  throw new Error(
+    `Timed out after ${timeout}ms waiting for project "${projectName}" to be inferred by Nx.\nLast output:\n${lastOutput}`
+  );
+}
+
 export function runLernaCLI(
   command: string,
   opts: RunCmdOpts = {


### PR DESCRIPTION
## Current Behavior

The inferred-project e2e tests in `@nx/plugin` fail intermittently with `Cannot find project 'inferred<random_id>'`. The task `e2e-plugin:e2e-ci--src/nx-plugin-ts-solution.test.ts` has a documented flakiness rate of ~39%.

The cause is a **watcher-latency race in the e2e harness**, not a product bug:

- e2e forces the daemon on (`NX_DAEMON=true`, `e2e/utils/command-utils.ts`).
- The daemon only recomputes the project graph when its native file watcher reports a change — it never rescans disk per request (`needsRecompute` in `project-graph-incremental-recomputation.ts`).
- The tests write an inferred project's files with `createFile` (a synchronous write) and *immediately* run `nx build <project>`. That can outrun the OS's delivery of those filesystem events to the watcher.
- The daemon's existing mitigations (`flushPendingWorkspaceChanges`, the `setImmediate` yield) only drain events the OS has **already handed** to the native watcher, so they cannot cover the write → OS-notify window.

The daemon then serves a cached graph that predates the project, and the build fails to resolve it. Variance in CI-agent load is what makes it intermittent rather than consistently broken.

## Expected Behavior

The tests wait for the inferred project to actually be registered before asserting on it, instead of assuming instant visibility.

This PR adds `waitForInferredProject(name)` to `e2e-utils`. It polls `nx show project <name> --json` — which `process.exit(1)`s when the project isn't in the graph — until it exits 0, bounded at 15s. Because the gate queries the *same* daemon graph path the subsequent `build` uses, once it returns the build cannot fail with `Cannot find project`.

It's applied to every write-then-immediately-query inferred site: 4 in `nx-plugin-ts-solution.test.ts`, 1 in `nx-plugin.test.ts`.

Notes on the approach:

- The residual window **cannot** be closed inside the daemon — it can't know about a file the OS hasn't told it about yet — and a full-disk rescan per request would gut the daemon's performance model. So the fix belongs at the test/harness layer.
- Chosen over `{ daemon: false }`, which would fix the race but drop daemon+inference coverage that these tests are deliberately exercising.
- Chosen over blindly retrying `build`, which would mask a genuine build failure. Gating on `show project` keeps the intent explicit: if the project registers but the build is really broken, the build assertion still fails loudly.
- The wait is condition-based rather than a fixed sleep, so it self-adjusts to however long the OS takes to deliver the watch event on a given machine.

Also drops a now-unused `runCommand` import from the ts-solution test.

## Related Issue(s)

No filed issue — this addresses the known flaky task `e2e-plugin:e2e-ci--src/nx-plugin-ts-solution.test.ts` (~39% flake rate), which has been surfacing as unrelated-PR CI noise.

## Verification

- `nx typecheck` passes for `e2e-utils` and `e2e-plugin`.
- Confirmed the `nx show project` exit-code contract in source (`packages/nx/src/command-line/show/project.ts`), which the gate relies on.
- Real verification is CI under agent load, since the test passes ~61% of the time locally regardless. Worth re-running the `e2e-plugin` tasks a few times to build confidence the flake is gone rather than merely not-triggered.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/flaky-inferrence-e2e-2192d869)
<!-- polygraph-session-end -->