### PR TITLE
docs(core): add a TUI development and testing guide

### DIFF
--- a/astro-docs/src/plugins/plugin.loader.ts
+++ b/astro-docs/src/plugins/plugin.loader.ts
@@ -28,7 +28,14 @@ import {
   pluginToTechnology,
 } from './utils/plugin-mappings';
 
-const PLUGIN_PATHS = readdirSync(join(workspaceRoot, 'packages'));
+// Only directories are packages. Stray files at the packages/ root (e.g.
+// a CLAUDE.md dev-doc) must not be treated as plugins — doing so generates
+// a bogus `technologies/undefined/<file>/...` route that fails link validation.
+const PLUGIN_PATHS = readdirSync(join(workspaceRoot, 'packages'), {
+  withFileTypes: true,
+})
+  .filter((entry) => entry.isDirectory())
+  .map((entry) => entry.name);
 
 type DocEntry = CollectionEntry<'plugin-docs'>;
 

--- a/packages/CLAUDE.md
+++ b/packages/CLAUDE.md
@@ -1,0 +1,15 @@
+# Developing Packages Locally
+
+## Running your locally built package
+
+By default the workspace's tooling resolves the _published_ packages
+installed in `node_modules` — local source changes and rebuilds are
+invisible to it. To dogfood a locally built package:
+
+1. Build it once: `nx build <package>` (e.g. `nx build nx`).
+2. Link it one time: `pnpm link ./packages/<package>`.
+3. From then on, rebuilding with `nx build <package>` is reflected in the
+   workspace — no re-linking needed.
+
+Without the link, no amount of rebuilding shows up in the CLI or tooling
+you invoke.

--- a/packages/devkit/CLAUDE.md
+++ b/packages/devkit/CLAUDE.md
@@ -17,11 +17,47 @@
   └── @nx/devkit/internal      → nx/src/devkit-internals (subset)
 ```
 
+## Importing from `nx`
+
+**Every import from the `nx` package must come from `nx/src/devkit-exports`
+or `nx/src/devkit-internals` — no other `nx` deep imports.** This is
+enforced by the `@typescript-eslint/no-restricted-imports` rule in
+`packages/devkit/eslint.config.mjs`. The two entry points exist so the
+surface devkit depends on is explicit and version-checkable; a deep import
+into arbitrary `nx` internals silently breaks the compatibility contract
+below, because nothing tracks whether that internal exists across the
+supported `nx` versions.
+
+## Rules for the other packages in this repo
+
+Every other first-party package (`@nx/js`, `@nx/react`, ...) must get its
+core types and utilities **from `@nx/devkit` or `@nx/devkit/internal` —
+never by importing `nx` directly**. Devkit is the compatibility boundary:
+it is the one place that knows which `nx` entry points are safe across the
+supported version range, and a direct `nx` import bypasses that entirely.
+
 ## Version Compatibility Contract
 
 **This is the most important thing to understand when modifying devkit or its nx entry points.**
 
 `@nx/devkit` supports `nx` at the current major version **+/- 1 major version**. The `peerDependencies` in `package.json` encode this — e.g. `"nx": ">= 21 <= 23"` means `@nx/devkit@22` works with `nx@21`, `nx@22`, and `nx@23`.
+
+**These rules govern the _main public exports_ of `@nx/devkit` (the root
+entry point).** The `@nx/devkit/internal` entry point is exempt: it exists
+only for the first-party packages in this repo, and those are all released
+in lockstep at the same version — an `@nx/react@23` always runs with
+`@nx/devkit@23` — so the internal API carries no cross-version
+compatibility burden and can change freely between majors.
+
+**The contract cuts both ways.** `@nx/devkit@23` must work with `nx@22`,
+`nx@23`, and keep working up through `nx@24` — and, equally, changes to
+`nx` itself must not break the _previous_ devkit major: while developing
+`nx@23`, verify it remains compatible with the published `@nx/devkit@22`
+(plugins in the wild pair a newer `nx` with an older devkit all the time).
+In practice: treat everything reachable from `devkit-exports` and
+`devkit-internals` as an API that published devkit versions within the
+supported window already depend on — removing or reshaping it is a break
+even when nothing inside this repo still uses it.
 
 ### What This Means for Changes
 

--- a/packages/nx/src/native/tui/CLAUDE.md
+++ b/packages/nx/src/native/tui/CLAUDE.md
@@ -1,0 +1,180 @@
+# TUI Development & Testing Guide
+
+Hard-won knowledge for working on the terminal UI. The TUI is unusual code:
+it renders 60 times a second, shares a parser between threads, and its bugs
+are often invisible in unit tests but obvious on a real terminal. This guide
+covers how to build, test, and debug it without rediscovering the traps.
+
+## Building and running
+
+- **One-time setup:** link the local `nx` package so your builds are what
+  the CLI runs — see `packages/CLAUDE.md` (initial `nx build nx`, then
+  `pnpm link ./packages/nx`).
+- **`nx build nx` is required for the running `nx` to reflect native
+  changes.** `nx build-native nx` alone compiles the Rust but the CLI
+  won't pick it up.
+- **The native-file cache is size-keyed.** A rebuilt `.node` with the same
+  byte size as the previous build loads the _stale_ artifact. When verifying
+  Rust changes at runtime, always run with:
+
+  ```bash
+  NX_SKIP_NATIVE_FILE_CACHE=true NX_DAEMON=false nx <command>
+  ```
+
+- `NX_TUI=true` forces the TUI on; `--tui-auto-exit false` keeps it open
+  after the run finishes so you can inspect/search the completed output.
+
+## Driving the real TUI (the tmux recipe)
+
+Unit tests can't catch everything — several real bugs (highlight drift on
+live streaming output, resize repaint stalls) only reproduced against a live
+PTY. The reliable way to test interactively without a human:
+
+```bash
+# Run a task in a dedicated tmux pane
+tmux send-keys -t <pane> 'NX_TUI=true nx run <task> --tui-auto-exit false' Enter
+
+# Drive keys (e.g. open a search and navigate)
+tmux send-keys -t <pane> '/'; tmux send-keys -t <pane> 'error'
+tmux send-keys -t <pane> Enter; tmux send-keys -t <pane> 'n'
+
+# Inspect: plain text
+tmux capture-pane -t <pane> -p
+# Inspect: WITH ANSI escapes (styles!) — this is how you verify highlights
+tmux capture-pane -t <pane> -e -p
+```
+
+In the `-e` capture, parse SGR sequences to locate styling: search matches
+are reverse-video (`\e[7m`), the current match is the warning background
+(`\e[48;5;3m`) with black foreground. Asserting "the highlight run spells
+the query" against the parsed capture is the ground truth for alignment.
+
+For temporary instrumentation, gate debug writes behind an env var and log
+to a file (`std::fs::OpenOptions` append to `/tmp/...`), rebuild, drive via
+tmux, read the file. Remove the instrumentation before committing.
+
+## The Rust test suite
+
+```bash
+cargo test -p nx native::tui          # the whole TUI suite
+cargo insta test -p nx --accept -- status_bar   # accept snapshot updates
+```
+
+- Snapshots live in `components/snapshots/` (insta). Review `.snap.new`
+  content before accepting; delete orphaned snapshots when renaming tests.
+- **Render-path tests beat math tests.** Render through the real
+  `StatefulWidget` into a `ratatui::buffer::Buffer` and assert on cells —
+  this exercises borders, padding, ANSI, wrapping, and scroll offsets that
+  pure-function tests skip.
+- **Marker-row snapshots** make style assertions reviewable: alongside each
+  text row, emit a row of `#`/`*` markers for styled cells. Drift shows up
+  as a visibly shifted marker in the snapshot diff.
+- **Beware masking.** Repetitive content hides positional bugs: with every
+  line starting `[INFO]`, a highlight shifted one row down lands on the next
+  line's `INFO` and "spells the query" anyway. Use unique markers per line
+  when asserting positions.
+- **Mutation-check regression tests.** Before trusting a new regression
+  test, revert the fix and confirm the test fails. Several plausible tests
+  written during development passed against the buggy code.
+
+## Coordinate systems — the one big trap
+
+There are two ways to count visual rows, and they are NOT interchangeable:
+
+1. **The grid basis** — `get_total_content_rows()` =
+   `scrollback.len() + rows.len()` on the vt100 grid. This is what the
+   renderer (tui-term `PseudoTerminal`) actually draws, and the basis for
+   scroll offsets and overlay positioning.
+2. **Re-wrapped logical lines** — `all_contents()` joins wrapped grid rows
+   into logical lines, then code re-wraps them with `wrap_ansi`.
+
+These diverge on real output. `Row::write_contents` in the vt100 fork trims
+trailing blank cells, and `\r`/clear-to-EOL progress output (Maven, npm,
+cargo) leaves wrapped rows with trailing blanks — so the reconstructed
+logical line is shorter than the grid's real layout and re-wrapping
+undercounts rows. The error accumulates over hundreds of lines and shifts
+anything positioned in the wrong basis (this was the search-highlight-drift
+bug, invisible until ~1000 lines of narrow cursor-heavy output).
+
+**Rule: anything that maps onto rendered cells must be computed in the grid
+basis.** To get grid-exact positions for the full content, re-parse
+`all_contents_formatted()` into a fresh `Parser::new(total_rows, cols, 0)` —
+zero scrollback makes every grid row directly addressable, and the layout
+matches the render by construction (~1–2 ms at the scrollback cap; fine when
+gated behind a change check).
+
+Related capacity limits, both relevant to tests:
+
+- `SCROLLBACK_SIZE` (1000) evicts whole **visual rows**, so a wrapped
+  logical line can be chopped mid-wrap at the top of the scrollback.
+- `MAX_RAW_OUTPUT_BYTES` (5 MB) compaction replays the formatted screen into
+  a fresh parser — `raw_output` **shrinks**, so nothing may assume its
+  length is monotonic (it only ever *changes* per write).
+
+## Locking discipline (the render thread must never wait)
+
+The parser is `Arc<RwLock<Parser>>` (parking_lot: non-reentrant,
+writer-preferring), shared with the PTY reader thread that writes incoming
+output.
+
+- **Read everything you need BEFORE taking the screen guard.** Taking a
+  second `read()` while holding `get_screen()`'s guard deadlocks the render
+  thread the moment the writer queues a `write()` (this froze the whole TUI
+  once).
+- **Per-frame checks must use `try_read` with a cached fallback.** A
+  blocking `read()` on the render thread serializes repainting behind the
+  output writer and the async-resize swap — measured as visible resize lag.
+  Failing toward "use last frame's value" is always safe; failing toward
+  "wait" never is.
+- `resize_async` updates the cached `dimensions` immediately but swaps the
+  reparsed parser in later on a background thread — the cache and
+  `screen().size()` disagree during that window. Code that positions against
+  rendered content must read the width from the screen it is rendering, not
+  the cache (`set_cached_dimensions_for_test` exists to force this
+  divergence in tests).
+
+## Performance debugging
+
+Measure before optimizing — two real examples where the intuitive suspect
+was innocent:
+
+- The grid re-parse was suspected of causing resize lag; instrumentation
+  showed ~0.5–1.8 ms per content change (~3/sec while streaming). The actual
+  stall was a per-frame blocking `read()`.
+- Frame-time probes (log draws over a threshold) during tmux-driven resizes
+  showed 12–21 ms full-redraw spikes occur **with or without** the feature
+  under suspicion — i.e. pre-existing, not a regression.
+
+Recipe: env-gated timing writes to a `/tmp` log, `nx build nx`, drive the
+scenario via tmux, compare with the feature disabled. Delete the probes
+afterwards (`rg 'NX_.*_DEBUG|/tmp/nx_' packages/nx/src` should be empty).
+
+## The vt100 fork
+
+Terminal parsing uses `vt100-ctt` (a pinned-rev git fork). Facts confirmed
+against its source that TUI code relies on:
+
+- `all_contents()` joins wrapped rows (no `\n` between them) and trims
+  trailing blank cells per row.
+- `get_total_content_rows()` is literally `scrollback.len() + rows.len()`.
+- `all_contents_formatted()` reproduces the exact visual layout when re-fed
+  to a parser at the same width — this is what makes the tall re-parse
+  grid-exact.
+- Only *visible* rows are addressable (`rows()`, `row_wrapped()`);
+  scrollback rows have no public per-row access — exposing an `all_rows()`
+  iterator upstream is the known cleaner alternative to the re-parse.
+
+## Component conventions
+
+- Widgets render per-frame from props derived from the canonical `TuiState`
+  — components must not keep mirror copies of run state (drift class the
+  status bar work eliminated). Persistent widget state (e.g. a click-target
+  `LinkRegistry`) belongs in `StatefulWidget::State`, owned by the `App`.
+- UI that appears in more than one place gets ONE implementation: the task
+  filter and pane search share `search_filter.rs` (input row, confirmed
+  display, and the key bindings via `interpret_session_key`) so they cannot
+  drift apart. Follow that pattern for any future shared idiom.
+- Emoji in the status bar: prefer text-presentation glyphs; if forcing emoji
+  presentation with VS16, ratatui counts the sequence two cells wide, so
+  layout math stays consistent — but terminal-side rendering still varies,
+  so keep adjacent spacing tolerant of a one-cell difference.

--- a/packages/nx/src/native/tui/CLAUDE.md
+++ b/packages/nx/src/native/tui/CLAUDE.md
@@ -109,7 +109,7 @@ Related capacity limits, both relevant to tests:
   logical line can be chopped mid-wrap at the top of the scrollback.
 - `MAX_RAW_OUTPUT_BYTES` (5 MB) compaction replays the formatted screen into
   a fresh parser — `raw_output` **shrinks**, so nothing may assume its
-  length is monotonic (it only ever *changes* per write).
+  length is monotonic (it only ever _changes_ per write).
 
 ## Locking discipline (the render thread must never wait)
 
@@ -160,7 +160,7 @@ against its source that TUI code relies on:
 - `all_contents_formatted()` reproduces the exact visual layout when re-fed
   to a parser at the same width — this is what makes the tall re-parse
   grid-exact.
-- Only *visible* rows are addressable (`rows()`, `row_wrapped()`);
+- Only _visible_ rows are addressable (`rows()`, `row_wrapped()`);
   scrollback rows have no public per-row access — exposing an `all_rows()`
   iterator upstream is the known cleaner alternative to the re-parse.
 

--- a/tools/workspace-plugin/src/plugins/copy-assets-plugin.ts
+++ b/tools/workspace-plugin/src/plugins/copy-assets-plugin.ts
@@ -54,14 +54,18 @@ export const createNodes: CreateNodes = [
           ...objectAssets.map((asset) => {
             const input = asset.input ?? projectRoot;
             const output = asset.output ?? '/';
+            // CLAUDE.md files are repo-internal development docs — never
+            // ship them in published packages, no matter how broad a
+            // package's asset globs are (some copy `**/*.md`).
             const ignore =
               input === projectRoot
                 ? [
                     `${relative(projectRoot, assetsJson.outDir)}/**`,
                     'assets.json',
+                    '**/CLAUDE.md',
                     ...(asset.ignore ?? []),
                   ]
-                : asset.ignore;
+                : ['**/CLAUDE.md', ...(asset.ignore ?? [])];
             return {
               input,
               glob: asset.glob,


### PR DESCRIPTION
## Current Behavior

The knowledge required to safely develop and test the native TUI — the `nx build nx` / native-file-cache build workflow, how to drive and inspect the live TUI from tmux, the grid-basis vs re-wrapped-lines coordinate trap, the parser locking discipline for the render thread, and the confirmed behaviors of the vt100 fork — lives only in commit messages and contributors' heads. New work on the TUI keeps rediscovering the same traps (stale native binaries, deadlocks from nested parser locks, positional tests masked by repetitive content).

## Expected Behavior

A `CLAUDE.md` next to the TUI code (`packages/nx/src/native/tui/CLAUDE.md`) documents:

- **Building & running**: `nx build nx` (not just `build-native`) is required for the running CLI to reflect native changes; the size-keyed native-file cache trap and the `NX_SKIP_NATIVE_FILE_CACHE=true NX_DAEMON=false` bypass; `NX_TUI=true` and `--tui-auto-exit false`.
- **The tmux recipe** for driving the real TUI headlessly and verifying styling via ANSI-preserving captures (`capture-pane -e -p`).
- **Test-suite patterns**: render-path tests over pure math tests, marker-row snapshots for style positions, the masking hazard with repetitive content, and mutation-checking regression tests.
- **The coordinate-system trap**: `get_total_content_rows()` (grid basis) vs re-wrapping `all_contents()` with `wrap_ansi`, why they diverge on `\r`/clear-to-EOL output, and the tall zero-scrollback re-parse that yields grid-exact positions.
- **Locking discipline**: the non-reentrant writer-preferring parser lock, reading values before taking the screen guard, and `try_read` + cached fallback for per-frame checks.
- **Performance-debugging recipes** and two measured examples where the intuitive suspect was innocent.
- **Confirmed vt100-fork behaviors** and **component conventions** (per-frame props from canonical `TuiState`, shared implementations for shared idioms).

## Related Issue(s)

Distilled from the development and multi-pass review of #36263.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/TUI-Status-Bar-Development-11a216a4)
<!-- polygraph-session-end -->