### PR TITLE
chore(repo): fix review-sandbox build context and smoke test

### DIFF
--- a/.claude/skills/setup-review-sandbox/SKILL.md
+++ b/.claude/skills/setup-review-sandbox/SKILL.md
@@ -71,13 +71,14 @@ Needed only to **build an unreleased PR's nx** in the sandbox (reproduce-verifie
 docker image inspect nx-review-sandbox:latest >/dev/null 2>&1 && echo "image OK" || echo "image MISSING"
 ```
 
-If MISSING, build it from the repo root (so `mise.toml` is in the build context). This installs the repo's exact toolchain — node/java/dotnet/maven/rust/bun via mise — and takes a while + several GB:
+If MISSING (or stale — check the `created` date against the Dockerfile), build it. The Dockerfile only needs `mise.toml`, so build from a **minimal context** — do NOT pass `.` (the repo root), which would ship the whole monorepo (node_modules / .git / dist — many GB) to the daemon:
 
 ```bash
-docker build -t nx-review-sandbox:latest -f tools/review-sandbox/Dockerfile .
+mkdir -p tmp/review-sandbox-ctx && cp mise.toml tmp/review-sandbox-ctx/
+docker build -t nx-review-sandbox:latest -f tools/review-sandbox/Dockerfile tmp/review-sandbox-ctx
 ```
 
-Requires steps 1 + 3 to pass first (build needs working networking). If disk is tight, `/sandbox-prune` first.
+This installs the repo's exact toolchain — node/java/dotnet/maven/rust/bun via mise — and takes a while + several GB. Requires steps 1 + 3 to pass first (build needs working networking). If disk is tight, `/sandbox-prune` first.
 
 ## 5. Verify (smoke test)
 
@@ -85,10 +86,11 @@ Confirm the sandbox actually isolates and carries the tools:
 
 ```bash
 # RUNTIME="--runtime=runsc"  on Linux, ""  on macOS
-docker run --rm $RUNTIME nx-review-sandbox:latest bash -lc '
+docker run --rm $RUNTIME nx-review-sandbox:latest bash -c '
+  cd /work    # mise resolves versions from the mise.toml here; do NOT use bash -l (a login shell resets PATH, dropping the mise dirs)
   echo "kernel: $(uname -r)"       # Linux+gVisor: 4.19.0-gvisor ; macOS: the VM kernel
-  mise ls 2>/dev/null | head
-  node --version; java -version 2>&1 | head -1; dotnet --version
+  mise ls | head
+  node --version; java --version 2>&1 | head -1; dotnet --version
 '
 ```
 

--- a/tools/review-sandbox/Dockerfile
+++ b/tools/review-sandbox/Dockerfile
@@ -9,8 +9,10 @@
 # what the repo actually uses. java + dotnet are required because nx dogfoods the
 # @nx/dotnet and @nx/gradle plugins in its own project graph.
 #
-# Build from the repo root so mise.toml is in the build context:
-#   docker build -t nx-review-sandbox:latest -f tools/review-sandbox/Dockerfile .
+# Build from a MINIMAL context (only mise.toml) — not the repo root, which would ship the
+# whole monorepo (node_modules/.git/dist) to the daemon:
+#   mkdir -p tmp/review-sandbox-ctx && cp mise.toml tmp/review-sandbox-ctx/
+#   docker build -t nx-review-sandbox:latest -f tools/review-sandbox/Dockerfile tmp/review-sandbox-ctx
 FROM debian:bookworm-slim
 
 # System libraries mise-managed tools do NOT provide:


### PR DESCRIPTION
## Current Behavior

Follow-up to #36382. Two bugs in the review-sandbox tooling that shipped there:

1. The `setup-review-sandbox` skill and `tools/review-sandbox/Dockerfile` said to build the image with `docker build … .` (the repo root as context). The Dockerfile only needs `mise.toml`, so `.` ships the **entire monorepo** (node_modules / .git / dist — many GB) to the Docker daemon.
2. The skill's step-5 smoke test used a **login shell** (`bash -l`), which resets `PATH` and drops the mise dirs, and it ran outside `/work` (where the baked `mise.toml` lives). So mise couldn't resolve the toolchain — the test reported every tool as `command not found` on a perfectly good image.

## Expected Behavior

1. Build from a minimal `mise.toml`-only context:
   ```bash
   mkdir -p tmp/review-sandbox-ctx && cp mise.toml tmp/review-sandbox-ctx/
   docker build -t nx-review-sandbox:latest -f tools/review-sandbox/Dockerfile tmp/review-sandbox-ctx
   ```
2. The smoke test uses `bash -c` in `/work` so mise resolves the toolchain.

Verified: the image builds (3.73 GB) and the corrected smoke test passes under gVisor — node 26.3.0, java 24.0.2, dotnet 9.0.316, rust 1.95.0, maven 3.9.11, bun 1.3.14.

## Related Issue(s)

N/A — follow-up to #36382 (internal review-pipeline tooling).

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Fix-review-sandbox-build-context--smoke-test-follow-up-to-36382-66da0e3e)
<!-- polygraph-session-end -->