### PR TITLE
fix(js): handle empty npm view output in release-publish executor

### DIFF
--- a/packages/js/src/executors/release-publish/release-publish.impl.spec.ts
+++ b/packages/js/src/executors/release-publish/release-publish.impl.spec.ts
@@ -325,6 +325,47 @@ describe('release-publish executor', () => {
     });
   });
 
+  describe('npm view empty output handling', () => {
+    it('should continue to publish when npm view returns empty output instead of crashing on JSON.parse', async () => {
+      // `npm view` can exit 0 with empty stdout when the package exists in the
+      // registry but has no published versions/dist-tags yet (e.g. GitHub
+      // Packages). Previously this crashed on `JSON.parse('')` and was reported
+      // as "Something unexpected went wrong when checking for existing
+      // dist-tags." See https://github.com/nrwl/nx/issues/36358
+      mockExecSync
+        .mockReturnValueOnce(Buffer.from('') as any) // npm view -> empty stdout
+        .mockReturnValueOnce(Buffer.from('{}') as any); // npm publish
+
+      jest.spyOn(extractModule, 'extractNpmPublishJsonData').mockReturnValue({
+        beforeJsonData: '',
+        jsonData: {
+          id: '@scope/test-package@1.0.0',
+          name: '@scope/test-package',
+          version: '1.0.0',
+          size: 100,
+          unpackedSize: 200,
+          shasum: 'abc123',
+          integrity: 'sha512-abc',
+          filename: 'test-package-1.0.0.tgz',
+          files: [],
+          entryCount: 1,
+          bundled: [],
+        },
+        afterJsonData: '',
+      } as any);
+
+      const result = await runExecutor(options, context);
+
+      expect(result.success).toBe(true);
+      expect(console.error).not.toHaveBeenCalledWith(
+        'Something unexpected went wrong when checking for existing dist-tags.\n',
+        expect.anything()
+      );
+      // Should have proceeded with npm --version, npm view, and publish
+      expect(mockExecSync).toHaveBeenCalledTimes(3);
+    });
+  });
+
   describe('npm availability check', () => {
     it('should continue without error when pm is bun and npm is not installed', async () => {
       mockDetectPackageManager.mockReturnValue('bun');

--- a/packages/js/src/executors/release-publish/release-publish.impl.ts
+++ b/packages/js/src/executors/release-publish/release-publish.impl.ts
@@ -224,7 +224,14 @@ Please update the local dependency on "${depName}" to be a valid semantic versio
         windowsHide: true,
       });
 
-      const resultJson = JSON.parse(result.toString());
+      // `npm view`/`bun info` can exit 0 with empty stdout when the package
+      // exists in the registry but has no published versions or dist-tags yet
+      // (observed with GitHub Packages). Treat empty output the same as the
+      // package not existing yet and continue to the publish step, rather than
+      // letting `JSON.parse('')` throw "Unexpected end of JSON input" and get
+      // surfaced as an unexpected dist-tag failure. See nrwl/nx#36358.
+      const resultStr = result.toString().trim();
+      const resultJson = resultStr ? JSON.parse(resultStr) : {};
       const distTags = resultJson['dist-tags'] || {};
       if (distTags[tag] === currentVersion) {
         console.warn(


### PR DESCRIPTION
## Current Behavior

`nx release publish` (the `@nx/js` release-publish executor) runs `npm view <pkg> versions dist-tags --json` to check for existing dist-tags before publishing. Some registries — notably GitHub Packages — return **empty stdout with a zero exit code** when the package exists but has no published versions/dist-tags yet.

In that case `JSON.parse('')` throws `SyntaxError: Unexpected end of JSON input`. Because the resulting `SyntaxError` carries no `stdout`/`stderr`, it falls through the `E404`/`404` guards in the surrounding `catch` block and is surfaced as:

```
Something unexpected went wrong when checking for existing dist-tags.
 SyntaxError: Unexpected end of JSON input
    at JSON.parse (<anonymous>)
    at runExecutor (.../@nx/js/src/executors/release-publish/release-publish.impl.js)
```

The publish then aborts, making it impossible to (re)publish a package that exists but has no `latest` tag yet (e.g. a pre-release that only has a `next` dist-tag).

## Expected Behavior

Empty `npm view` output is treated the same as the package not existing yet: the dist-tag lookup is skipped and publishing continues, so pre-release / first-time publishes to registries that return empty output succeed.

The `JSON.parse` is guarded with an empty-output check (`result.toString().trim()` → fall back to `{}`). A regression test mocks `npm view` returning empty stdout and asserts the executor proceeds to publish (three `execSync` calls: `npm --version`, `npm view`, publish) instead of reporting the spurious "Something unexpected went wrong when checking for existing dist-tags" failure.

## Related Issue(s)

Fixes #36358