### PR TITLE
docs(misc): audit inferred plugin options and behavior across technology pages

### DIFF
--- a/astro-docs/src/content/docs/kb/react-router.mdoc
+++ b/astro-docs/src/content/docs/kb/react-router.mdoc
@@ -44,10 +44,19 @@ There is no need to install any additional plugins to use React Router with Nx. 
 
 ## Configure inferred React Router tasks
 
-The `@nx/react/router-plugin` plugin looks for `react-router.config.js`, `react-router.config.ts`, `react-router.config.cjs`, `react-router.config.cts`, `react-router.config.mjs`, and `react-router.config.mts`. The same directory must also contain:
+The `@nx/react/router-plugin` plugin looks for any of these files:
 
-- a `vite.config.*` file; and
-- either a `package.json` or `project.json`.
+- `react-router.config.js`
+- `react-router.config.ts`
+- `react-router.config.cjs`
+- `react-router.config.cts`
+- `react-router.config.mjs`
+- `react-router.config.mts`
+
+The same directory must also contain:
+
+- A `vite.config.*` file
+- Either a `package.json` or `project.json` file
 
 Nx creates a cached `build` task with outputs derived from the React Router configuration, continuous `dev` and `start` tasks, and a cached `typecheck` task. The `start` task is omitted when the React Router configuration sets `ssr: false`.
 

--- a/astro-docs/src/content/docs/kb/react-router.mdoc
+++ b/astro-docs/src/content/docs/kb/react-router.mdoc
@@ -42,9 +42,50 @@ nx g @nx/react:app apps/happynrwl --routing --use-react-router
 
 There is no need to install any additional plugins to use React Router with Nx. The `@nx/react` plugin already includes support for React Router.
 
+## Configure inferred React Router tasks
+
+The `@nx/react/router-plugin` plugin looks for `react-router.config.js`, `react-router.config.ts`, `react-router.config.cjs`, `react-router.config.cts`, `react-router.config.mjs`, and `react-router.config.mts`. The same directory must also contain:
+
+- a `vite.config.*` file; and
+- either a `package.json` or `project.json`.
+
+Nx creates a cached `build` task with outputs derived from the React Router configuration, continuous `dev` and `start` tasks, and a cached `typecheck` task. The `start` task is omitted when the React Router configuration sets `ssr: false`.
+
+Configure the plugin in `nx.json`:
+
+```json
+// nx.json
+{
+  "plugins": [
+    {
+      "plugin": "@nx/react/router-plugin",
+      "options": {
+        "buildTargetName": "build",
+        "devTargetName": "dev",
+        "startTargetName": "start",
+        "typecheckTargetName": "typecheck",
+        "buildDepsTargetName": "build-deps",
+        "watchDepsTargetName": "watch-deps"
+      }
+    }
+  ]
+}
+```
+
+| Option                | Type   | Default     | Description                                     |
+| --------------------- | ------ | ----------- | ----------------------------------------------- |
+| `buildTargetName`     | string | `build`     | Name of the cached production build task.       |
+| `devTargetName`       | string | `dev`       | Name of the continuous development server task. |
+| `startTargetName`     | string | `start`     | Name of the continuous production server task.  |
+| `typecheckTargetName` | string | `typecheck` | Name of the cached TypeScript typecheck task.   |
+| `buildDepsTargetName` | string | none        | Name of an optional dependency build task.      |
+| `watchDepsTargetName` | string | none        | Name of an optional dependency watch task.      |
+
+Use `include` and `exclude` glob patterns to scope the plugin. A [target defaults](/docs/reference/nx-json#target-defaults) `plugin` filter must use the exact identifier `@nx/react/router-plugin`.
+
 ## Running the application
 
-Now that you have created your React Router application with Nx you can build, serve and test with the following commands:
+Now that you have created your React Router application with Nx, you can build, serve, and test with the following commands:
 
 ### Build
 

--- a/astro-docs/src/content/docs/reference/nx-json.mdoc
+++ b/astro-docs/src/content/docs/reference/nx-json.mdoc
@@ -444,7 +444,7 @@ If two plugins expose a target with the same name (e.g. both `@nx/vitest` and `@
         "inputs": ["default", "^production"]
       },
       {
-        "filter": { "plugin": "@nx/jest" },
+        "filter": { "plugin": "@nx/jest/plugin" },
         "inputs": ["default", "^production", "{workspaceRoot}/jest.preset.js"]
       }
     ]

--- a/astro-docs/src/content/docs/technologies/angular/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/angular/introduction.mdoc
@@ -97,6 +97,48 @@ This scaffolds an Nx monorepo with an Angular app and Nx preconfigured for cachi
 For a guided, step-by-step walkthrough of building a monorepo with Nx, follow the [Learn Nx tutorial](/docs/getting-started/tutorials/crafting-your-workspace).
 {% /aside %}
 
+## Configure inferred Angular tasks
+
+The `@nx/angular/plugin` plugin reads `angular.json` files that are next to a `package.json`. It registers every Angular project in the file as an Nx project and converts each Angular CLI builder target into an Nx task. Nx preserves the Angular target's configurations and default configuration, then derives cache inputs, outputs, dependencies, and continuous task settings from the configured builder.
+
+Configure the plugin in the `plugins` array in `nx.json`:
+
+```json
+// nx.json
+{
+  "plugins": [
+    {
+      "plugin": "@nx/angular/plugin",
+      "options": {
+        "targetNamePrefix": "angular:"
+      }
+    }
+  ]
+}
+```
+
+| Option             | Type   | Default | Description                                                                         |
+| ------------------ | ------ | ------- | ----------------------------------------------------------------------------------- |
+| `targetNamePrefix` | string | none    | Prefix added to every target imported from `angular.json`, such as `angular:build`. |
+
+Omit `targetNamePrefix` to keep the target names from `angular.json`. Use `include` and `exclude` glob patterns on the plugin entry to scope which `angular.json` files it processes.
+
+To apply [target defaults](/docs/reference/nx-json#target-defaults) only to tasks from this plugin, use a `plugin` filter with the exact plugin identifier:
+
+```json
+// nx.json
+{
+  "targetDefaults": {
+    "build": [
+      {
+        "filter": { "plugin": "@nx/angular/plugin" },
+        "cache": true
+      }
+    ]
+  }
+}
+```
+
 ## Local development
 
 ### Generate an Angular application

--- a/astro-docs/src/content/docs/technologies/angular/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/angular/introduction.mdoc
@@ -123,21 +123,7 @@ Configure the plugin in the `plugins` array in `nx.json`:
 
 Omit `targetNamePrefix` to keep the target names from `angular.json`. Use `include` and `exclude` glob patterns on the plugin entry to scope which `angular.json` files it processes.
 
-To apply [target defaults](/docs/reference/nx-json#target-defaults) only to tasks from this plugin, use a `plugin` filter with the exact plugin identifier:
-
-```json
-// nx.json
-{
-  "targetDefaults": {
-    "build": [
-      {
-        "filter": { "plugin": "@nx/angular/plugin" },
-        "cache": true
-      }
-    ]
-  }
-}
-```
+A [target defaults](/docs/reference/nx-json#target-defaults) `plugin` filter must use the exact identifier `@nx/angular/plugin`.
 
 ## Local development
 

--- a/astro-docs/src/content/docs/technologies/build-tools/docker/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/docker/introduction.mdoc
@@ -59,7 +59,7 @@ The `buildTarget` and `runTarget` options control the names of the inferred Dock
 
 ### Advanced plugin configuration
 
-The `buildTarget` and `runTarget` options can be configured as objects to provide additional customization beyond just naming the targets. This allows you to pass custom arguments, set environment variables, and use pattern interpolation.
+Configure `buildTarget` and `runTarget` as objects to pass custom arguments, set environment variables, and use pattern interpolation.
 
 ```json
 // nx.json
@@ -104,6 +104,10 @@ When using the object format, the following properties are available:
 - **`env`** (object, optional): Environment variables to set when running the Docker command. Values support pattern interpolation.
 - **`envFile`** (string, optional): Path to an environment file to load
 - **`cwd`** (string, optional): Working directory for the command. Supports pattern interpolation.
+- **`configurations`** (object, optional): Named Nx configurations that override `args`, `env`, `envFile`, `cwd`, or `skipDefaultTag`.
+- **`skipDefaultTag`** (boolean, default `false`): Do not add the default Nx `--tag` argument to build commands. Supply a tag in `args`; opting out also disables Nx Release versioning and publishing for that Docker project.
+
+The build task depends on the project's `build` task and dependency builds. The run task depends on the inferred Docker build task. Nx also adds an `nx-release-publish` target that uses the `@nx/docker:release-publish` executor.
 
 #### Pattern interpolation
 
@@ -179,6 +183,8 @@ This configuration:
 - Tags images with a calendar version and commit SHA (e.g., `my-app:250130.abc1234`)
 - Enables Docker BuildKit for improved build performance
 - Injects build arguments and environment variables from the CI/CD pipeline
+
+Use `include` and `exclude` glob patterns on the plugin entry to scope inference. A [target defaults](/docs/reference/nx-json#target-defaults) `plugin` filter must use the exact identifier `@nx/docker`.
 
 ## Set up CI
 

--- a/astro-docs/src/content/docs/technologies/build-tools/rollup/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/rollup/introduction.mdoc
@@ -37,6 +37,59 @@ nx add @nx/rollup
 
 This will install the correct version of `@nx/rollup`.
 
+## Configure task inference
+
+The `@nx/rollup/plugin` plugin looks for these Rollup configuration files:
+
+- `rollup.config.js`
+- `rollup.config.cjs`
+- `rollup.config.mjs`
+- `rollup.config.ts`
+- `rollup.config.cts`
+- `rollup.config.mts`
+
+A configuration file is associated with a project when its directory also contains a `package.json` or `project.json`. Nx reads the Rollup outputs and creates a cached build task that runs `rollup -c`, depends on the same task in dependency projects, and records the configured output paths for cache restoration.
+
+Configure the plugin in `nx.json`:
+
+```json
+// nx.json
+{
+  "plugins": [
+    {
+      "plugin": "@nx/rollup/plugin",
+      "options": {
+        "buildTargetName": "build",
+        "buildDepsTargetName": "build-deps",
+        "watchDepsTargetName": "watch-deps"
+      }
+    }
+  ]
+}
+```
+
+| Option                | Type   | Default      | Description                                         |
+| --------------------- | ------ | ------------ | --------------------------------------------------- |
+| `buildTargetName`     | string | `build`      | Name of the cached Rollup build task.               |
+| `buildDepsTargetName` | string | `build-deps` | Name of the task that builds project dependencies.  |
+| `watchDepsTargetName` | string | `watch-deps` | Name of the task that watches project dependencies. |
+
+Use `include` and `exclude` glob patterns on the plugin entry to scope inference. To apply [target defaults](/docs/reference/nx-json#target-defaults) only to Rollup-inferred tasks, filter by the exact plugin identifier:
+
+```json
+// nx.json
+{
+  "targetDefaults": {
+    "build": [
+      {
+        "filter": { "plugin": "@nx/rollup/plugin" },
+        "options": { "sourcemap": true }
+      }
+    ]
+  }
+}
+```
+
 ## Using @nx/rollup
 
 ### Generate a new project using Rollup

--- a/astro-docs/src/content/docs/technologies/build-tools/rollup/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/rollup/introduction.mdoc
@@ -74,21 +74,9 @@ Configure the plugin in `nx.json`:
 | `buildDepsTargetName` | string | `build-deps` | Name of the task that builds project dependencies.  |
 | `watchDepsTargetName` | string | `watch-deps` | Name of the task that watches project dependencies. |
 
-Use `include` and `exclude` glob patterns on the plugin entry to scope inference. To apply [target defaults](/docs/reference/nx-json#target-defaults) only to Rollup-inferred tasks, filter by the exact plugin identifier:
-
-```json
-// nx.json
-{
-  "targetDefaults": {
-    "build": [
-      {
-        "filter": { "plugin": "@nx/rollup/plugin" },
-        "options": { "sourcemap": true }
-      }
-    ]
-  }
-}
-```
+Use `include` and `exclude` glob patterns on the plugin entry to scope inference.
+A [target defaults](/docs/reference/nx-json#target-defaults) `plugin` filter must use the exact
+identifier `@nx/rollup/plugin`.
 
 ## Using @nx/rollup
 

--- a/astro-docs/src/content/docs/technologies/build-tools/rsbuild/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/rsbuild/introduction.mdoc
@@ -37,6 +37,67 @@ nx add @nx/rsbuild
 
 This will install the correct version of `@nx/rsbuild`.
 
+## Configure task inference
+
+The `@nx/rsbuild` plugin looks for these configuration files in directories that also contain a `package.json` or `project.json`:
+
+- `rsbuild.config.js`
+- `rsbuild.config.ts`
+- `rsbuild.config.mjs`
+- `rsbuild.config.mts`
+- `rsbuild.config.cjs`
+- `rsbuild.config.cts`
+
+Nx creates a cached `build` task using the output directory from the Rsbuild configuration, continuous `dev` and `preview` tasks, and an `inspect` task. It also creates a cached `typecheck` task when the project has a `tsconfig*.json` file.
+
+Configure the plugin in `nx.json`:
+
+```json
+// nx.json
+{
+  "plugins": [
+    {
+      "plugin": "@nx/rsbuild",
+      "options": {
+        "buildTargetName": "build",
+        "devTargetName": "dev",
+        "previewTargetName": "preview",
+        "inspectTargetName": "inspect",
+        "typecheckTargetName": "typecheck",
+        "buildDepsTargetName": "build-deps",
+        "watchDepsTargetName": "watch-deps"
+      }
+    }
+  ]
+}
+```
+
+| Option                | Type   | Default     | Description                                        |
+| --------------------- | ------ | ----------- | -------------------------------------------------- |
+| `buildTargetName`     | string | `build`     | Name of the cached production build task.          |
+| `devTargetName`       | string | `dev`       | Name of the continuous development server task.    |
+| `previewTargetName`   | string | `preview`   | Name of the continuous production preview task.    |
+| `inspectTargetName`   | string | `inspect`   | Name of the Rsbuild configuration inspection task. |
+| `typecheckTargetName` | string | `typecheck` | Name of the cached TypeScript typecheck task.      |
+| `buildDepsTargetName` | string | none        | Name of an optional dependency build task.         |
+| `watchDepsTargetName` | string | none        | Name of an optional dependency watch task.         |
+
+Use `include` and `exclude` glob patterns on the plugin entry to scope inference. To apply [target defaults](/docs/reference/nx-json#target-defaults) only to these tasks, use the exact plugin identifier:
+
+```json
+// nx.json
+{
+  "targetDefaults": {
+    "build": [
+      {
+        "filter": { "plugin": "@nx/rsbuild" },
+        "cache": true
+      }
+    ]
+  }
+}
+```
+
 ## Using @nx/rsbuild
 
 ### Generate a new project using Rsbuild

--- a/astro-docs/src/content/docs/technologies/build-tools/rsbuild/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/rsbuild/introduction.mdoc
@@ -82,21 +82,9 @@ Configure the plugin in `nx.json`:
 | `buildDepsTargetName` | string | none        | Name of an optional dependency build task.         |
 | `watchDepsTargetName` | string | none        | Name of an optional dependency watch task.         |
 
-Use `include` and `exclude` glob patterns on the plugin entry to scope inference. To apply [target defaults](/docs/reference/nx-json#target-defaults) only to these tasks, use the exact plugin identifier:
-
-```json
-// nx.json
-{
-  "targetDefaults": {
-    "build": [
-      {
-        "filter": { "plugin": "@nx/rsbuild" },
-        "cache": true
-      }
-    ]
-  }
-}
-```
+Use `include` and `exclude` glob patterns on the plugin entry to scope inference.
+A [target defaults](/docs/reference/nx-json#target-defaults) `plugin` filter must use the exact
+identifier `@nx/rsbuild`.
 
 ## Using @nx/rsbuild
 

--- a/astro-docs/src/content/docs/technologies/build-tools/rspack/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/rspack/introduction.mdoc
@@ -77,14 +77,27 @@ The `@nx/rspack/plugin` is configured in the `plugins` array in `nx.json`.
         "buildTargetName": "build",
         "previewTargetName": "preview",
         "serveTargetName": "serve",
-        "serveStaticTargetName": "serve-static"
+        "serveStaticTargetName": "serve-static",
+        "buildDepsTargetName": "build-deps",
+        "watchDepsTargetName": "watch-deps"
       }
     }
   ]
 }
 ```
 
-The `buildTargetName`, `previewTargetName`, `serveTargetName` and `serveStaticTargetName` options control the names of the inferred Rspack tasks. The default names are `build`, `preview`, `serve` and `serve-static`.
+| Option                  | Default        | Inferred behavior                                           |
+| ----------------------- | -------------- | ----------------------------------------------------------- |
+| `buildTargetName`       | `build`        | Runs and caches `rspack build` with its configured outputs. |
+| `serveTargetName`       | `serve`        | Runs `rspack serve` continuously in development mode.       |
+| `previewTargetName`     | `preview`      | Runs `rspack serve` continuously in production mode.        |
+| `serveStaticTargetName` | `serve-static` | Serves the build output continuously after the build task.  |
+| `buildDepsTargetName`   | none           | Name of an optional dependency build task.                  |
+| `watchDepsTargetName`   | none           | Name of an optional dependency watch task.                  |
+
+The build target depends on builds of project dependencies. When TypeScript project references are enabled, the inferred targets also run the TypeScript sync generator.
+
+Use `include` and `exclude` glob patterns on the plugin entry to scope inference. A [target defaults](/docs/reference/nx-json#target-defaults) `plugin` filter must use the exact identifier `@nx/rspack/plugin`.
 
 ## Using @nx/rspack
 

--- a/astro-docs/src/content/docs/technologies/build-tools/vite/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/vite/introduction.mdoc
@@ -104,6 +104,8 @@ The `@nx/vite` plugin infers tasks by reading Vite config files. Any of the foll
 - `vite.config.cjs`
 - `vite.config.cts`
 
+The configuration directory must also contain a `package.json` or `project.json`.
+
 Build targets are only created when the project is buildable. A project is treated as buildable when any of the following are true:
 
 - `build.lib` is set in `vite.config.*`
@@ -132,6 +134,7 @@ Configure `@nx/vite/plugin` in the `plugins` array in `nx.json`:
         "devTargetName": "dev",
         "serveStaticTargetName": "serve-static",
         "typecheckTargetName": "typecheck",
+        "compiler": "tsc",
         "buildDepsTargetName": "build-deps",
         "watchDepsTargetName": "watch-deps"
       }
@@ -150,8 +153,11 @@ Configure `@nx/vite/plugin` in the `plugins` array in `nx.json`:
 | `devTargetName`         | Name of the Vite dev server target                   | `dev`          |
 | `serveStaticTargetName` | Name of the static file server target                | `serve-static` |
 | `typecheckTargetName`   | Name of the typecheck target                         | `typecheck`    |
+| `compiler`              | Typecheck compiler: `tsc`, `tsgo`, or `vue-tsc`      | auto-detected  |
 | `buildDepsTargetName`   | Name of the build-deps target for dependency builds  | none           |
 | `watchDepsTargetName`   | Name of the watch-deps target for dependency watches | none           |
+
+Build and typecheck tasks are cached with inputs and outputs derived from the Vite and TypeScript configuration. Development, preview, and static-server tasks are continuous. When `compiler` is omitted, Nx uses `vue-tsc` for Vue projects and `tsc` otherwise.
 
 ### Disable or scope inference
 
@@ -178,6 +184,8 @@ To see what tasks Nx inferred for a project, open the [project details view](/do
 ```shell
 nx show project my-app --web
 ```
+
+A [target defaults](/docs/reference/nx-json#target-defaults) `plugin` filter for these tasks must use the exact identifier `@nx/vite/plugin`.
 
 ## Set up CI for your Vite monorepo
 

--- a/astro-docs/src/content/docs/technologies/build-tools/vite/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/vite/introduction.mdoc
@@ -157,7 +157,11 @@ Configure `@nx/vite/plugin` in the `plugins` array in `nx.json`:
 | `buildDepsTargetName`   | Name of the build-deps target for dependency builds  | none           |
 | `watchDepsTargetName`   | Name of the watch-deps target for dependency watches | none           |
 
-Build and typecheck tasks are cached with inputs and outputs derived from the Vite and TypeScript configuration. Development, preview, and static-server tasks are continuous. When `compiler` is omitted, Nx uses `vue-tsc` for Vue projects and `tsc` otherwise.
+Build and typecheck tasks are cached.
+Build tasks declare the resolved Vite build output directory.
+Typecheck tasks do not declare cache outputs.
+Development, preview, and static-server tasks are continuous.
+When `compiler` is omitted, Nx uses `vue-tsc` when it detects a Vite Vue plugin and `tsc` otherwise.
 
 ### Disable or scope inference
 

--- a/astro-docs/src/content/docs/technologies/build-tools/webpack/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/webpack/introduction.mdoc
@@ -64,6 +64,8 @@ The `@nx/webpack` plugin will create a task for any project that has a Webpack c
 - `webpack.config.mjs`
 - `webpack.config.cjs`
 
+The configuration directory must also contain a `package.json` or `project.json`.
+
 ### View inferred tasks
 
 To view inferred tasks for a project, open the [project details view](/docs/concepts/inferred-tasks) in Nx Console or run `nx show project my-project --web` in the command line.
@@ -82,14 +84,27 @@ The `@nx/webpack/plugin` is configured in the `plugins` array in `nx.json`.
         "buildTargetName": "build",
         "previewTargetName": "preview",
         "serveTargetName": "serve",
-        "serveStaticTargetName": "serve-static"
+        "serveStaticTargetName": "serve-static",
+        "buildDepsTargetName": "build-deps",
+        "watchDepsTargetName": "watch-deps"
       }
     }
   ]
 }
 ```
 
-The `buildTargetName`, `previewTargetName`, `serveTargetName` and `serveStaticTargetName` options control the names of the inferred Webpack tasks. The default names are `build`, `preview`, `serve` and `serve-static`.
+| Option                  | Default        | Inferred behavior                                                |
+| ----------------------- | -------------- | ---------------------------------------------------------------- |
+| `buildTargetName`       | `build`        | Runs and caches `webpack-cli build` with its configured outputs. |
+| `serveTargetName`       | `serve`        | Runs `webpack-cli serve` continuously in development mode.       |
+| `previewTargetName`     | `preview`      | Runs `webpack-cli serve` continuously in production mode.        |
+| `serveStaticTargetName` | `serve-static` | Serves the build output continuously after the build task.       |
+| `buildDepsTargetName`   | `build-deps`   | Name of the dependency build task.                               |
+| `watchDepsTargetName`   | `watch-deps`   | Name of the dependency watch task.                               |
+
+The build target depends on builds of project dependencies. When TypeScript project references are enabled, the inferred targets also run the TypeScript sync generator.
+
+Use `include` and `exclude` glob patterns on the plugin entry to scope inference. A [target defaults](/docs/reference/nx-json#target-defaults) `plugin` filter must use the exact identifier `@nx/webpack/plugin`.
 
 ## Generate a new project using Webpack
 

--- a/astro-docs/src/content/docs/technologies/dotnet/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/dotnet/introduction.mdoc
@@ -164,6 +164,8 @@ Once a .NET project file has been identified, the targets are created with the c
 - `watch` - Watches the project for changes and rebuilds (automatically marked as continuous)
 - `run` - Runs the application (for executable projects)
 
+Use `include` and `exclude` glob patterns on the plugin entry to scope inference. A [target defaults](/docs/reference/nx-json#target-defaults) `plugin` filter must use the exact identifier `@nx/dotnet`.
+
 ### Target availability
 
 Not all targets are available for every project type. The plugin intelligently determines which targets to create based on the project type:

--- a/astro-docs/src/content/docs/technologies/eslint/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/eslint/introduction.mdoc
@@ -73,14 +73,22 @@ The `@nx/eslint/plugin` is configured in the `plugins` array in `nx.json`.
     {
       "plugin": "@nx/eslint/plugin",
       "options": {
-        "targetName": "lint"
+        "targetName": "lint",
+        "extensions": ["ts", "tsx", "js", "jsx", "html", "vue"]
       }
     }
   ]
 }
 ```
 
-- The `targetName` option controls the name of the inferred ESLint tasks. The default name is `lint`.
+| Option       | Type     | Default                                           | Description                                     |
+| ------------ | -------- | ------------------------------------------------- | ----------------------------------------------- |
+| `targetName` | string   | `lint`                                            | Name of the inferred ESLint task.               |
+| `extensions` | string[] | `ts, cts, mts, tsx, js, cjs, mjs, jsx, html, vue` | File extensions Nx checks before adding a task. |
+
+The inferred task runs ESLint from the project root and is cached. Its inputs include the applicable ESLint configuration, extended tsconfig files, custom workspace rules, project dependencies, and the installed `eslint` package. Its output tracks the `outputFile` CLI option.
+
+Use `include` and `exclude` glob patterns on the plugin entry to scope inference. A [target defaults](/docs/reference/nx-json#target-defaults) `plugin` filter must use the exact identifier `@nx/eslint/plugin`.
 
 ## Lint
 

--- a/astro-docs/src/content/docs/technologies/java/gradle/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/java/gradle/introduction.mdoc
@@ -175,6 +175,12 @@ Use `include`/`exclude` glob patterns to scope the plugin to specific projects:
 
 Individual Gradle projects can also configure Nx-specific settings using the `nx { }` DSL in `build.gradle` or `build.gradle.kts`.
 
+A [target defaults](/docs/reference/nx-json#target-defaults) `plugin` filter for inferred Gradle tasks must use the exact identifier `@nx/gradle`.
+
+{% aside type="caution" title="Legacy Gradle plugin" %}
+The public `@nx/gradle/plugin-v1` entry point is deprecated and will be removed in Nx 24. Replace it with `@nx/gradle`. The legacy entry recognizes Gradle build files and test files and supports `buildTargetName` (default `build`), `classesTargetName` (default `classes`), `testTargetName` (default `test`), `ciTargetName`, `includeSubprojectsTasks` (default `false`), and arbitrary `<taskName>TargetName` overrides.
+{% /aside %}
+
 ## Set up CI for your Gradle monorepo
 
 In CI, Nx runs [`nx affected`](/docs/features/ci-features/affected) to rebuild and retest only the projects a change touches, and [caches](/docs/features/cache-task-results) results to skip repeated work.

--- a/astro-docs/src/content/docs/technologies/java/maven/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/java/maven/introduction.mdoc
@@ -176,6 +176,8 @@ Use `include`/`exclude` glob patterns to scope the plugin to specific projects:
 
 There is no per-project disable for `@nx/maven`. To stop inference entirely, remove `@nx/maven` from the `plugins` array in `nx.json`.
 
+A [target defaults](/docs/reference/nx-json#target-defaults) `plugin` filter for inferred Maven tasks must use the exact identifier `@nx/maven`.
+
 ## Set up CI for your Maven monorepo
 
 In CI, Nx runs [`nx affected`](/docs/features/ci-features/affected) to rebuild and retest only the projects a change touches, and [caches](/docs/features/cache-task-results) results to skip repeated work.

--- a/astro-docs/src/content/docs/technologies/react/expo/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/react/expo/introduction.mdoc
@@ -49,9 +49,10 @@ This will install the correct version of `@nx/expo`.
 The `@nx/expo` plugin will create a task for any project that has an app configuration file present. Any of the following files will be recognized as an app configuration file:
 
 - `app.config.js`
+- `app.config.ts`
 - `app.json`
 
-In the app config file, it needs to have key `expo`:
+The directory must contain both `package.json` and `metro.config.js`. Nx treats the project as Expo only when the app configuration has an `expo` key and `package.json` lists `expo` as a dependency or development dependency:
 
 ```json
 // app.json
@@ -86,14 +87,30 @@ The `@nx/expo/plugin` is configured in the `plugins` array in `nx.json`.
         "prebuildTargetName": "prebuild",
         "installTargetName": "install",
         "buildTargetName": "build",
-        "submitTargetName": "submit"
+        "submitTargetName": "submit",
+        "buildDepsTargetName": "build-deps",
+        "watchDepsTargetName": "watch-deps"
       }
     }
   ]
 }
 ```
 
-Once a Expo configuration file has been identified, the targets are created with the name you specify under `startTargetName`, `serveTargetName`, `runIosTargetName`, `runAndroidTargetname`, `exportTargetName`, `prebuildTargetName`, `installTargetName`, `buildTargetName` or `submitTargetName` in the `nx.json` `plugins` array. The default names for the inferred targets are `start`, `serve`, `run-ios`, `run-anroid`, `export`, `prebuild`, `install`, `build` and `submit`.
+| Option                 | Default       | Inferred behavior                                     |
+| ---------------------- | ------------- | ----------------------------------------------------- |
+| `startTargetName`      | `start`       | Runs the `@nx/expo:start` executor continuously.      |
+| `serveTargetName`      | `serve`       | Runs `expo start --web` continuously.                 |
+| `runIosTargetName`     | `run-ios`     | Runs `expo run:ios` continuously.                     |
+| `runAndroidTargetName` | `run-android` | Runs `expo run:android` continuously.                 |
+| `exportTargetName`     | `export`      | Runs and caches `expo export`, including its outputs. |
+| `prebuildTargetName`   | `prebuild`    | Runs the `@nx/expo:prebuild` executor.                |
+| `installTargetName`    | `install`     | Runs the `@nx/expo:install` executor.                 |
+| `buildTargetName`      | `build`       | Runs the `@nx/expo:build` executor.                   |
+| `submitTargetName`     | `submit`      | Runs `eas submit`.                                    |
+| `buildDepsTargetName`  | none          | Name of an optional dependency build task.            |
+| `watchDepsTargetName`  | none          | Name of an optional dependency watch task.            |
+
+Use `include` and `exclude` glob patterns on the plugin entry to scope inference. A [target defaults](/docs/reference/nx-json#target-defaults) `plugin` filter must use the exact identifier `@nx/expo/plugin`.
 
 ### Creating applications
 

--- a/astro-docs/src/content/docs/technologies/react/expo/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/react/expo/introduction.mdoc
@@ -52,7 +52,9 @@ The `@nx/expo` plugin will create a task for any project that has an app configu
 - `app.config.ts`
 - `app.json`
 
-The directory must contain both `package.json` and `metro.config.js`. Nx treats the project as Expo only when the app configuration has an `expo` key and `package.json` lists `expo` as a dependency or development dependency:
+The directory must contain both `package.json` and `metro.config.js`.
+Nx treats the project as Expo when the app configuration has an `expo` key or `package.json` lists
+`expo` as a dependency or development dependency:
 
 ```json
 // app.json

--- a/astro-docs/src/content/docs/technologies/react/next/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/react/next/introduction.mdoc
@@ -146,6 +146,8 @@ The `@nx/next` plugin creates tasks for any project that has a Next.js configura
 - `next.config.mjs`
 - `next.config.ts`
 
+The configuration directory must also contain a `package.json` or `project.json`.
+
 ### Plugin options
 
 Configure `@nx/next/plugin` in the `plugins` array in `nx.json`:
@@ -160,19 +162,24 @@ Configure `@nx/next/plugin` in the `plugins` array in `nx.json`:
         "buildTargetName": "build",
         "devTargetName": "dev",
         "startTargetName": "start",
-        "serveStaticTargetName": "serve-static"
+        "buildDepsTargetName": "build-deps",
+        "watchDepsTargetName": "watch-deps"
       }
     }
   ]
 }
 ```
 
-| Option                  | Description                          | Default        |
-| ----------------------- | ------------------------------------ | -------------- |
-| `buildTargetName`       | Name of the production build task    | `build`        |
-| `devTargetName`         | Name of the development server task  | `dev`          |
-| `startTargetName`       | Name of the production server task   | `start`        |
-| `serveStaticTargetName` | Name of the static export serve task | `serve-static` |
+| Option                  | Description                                | Default        |
+| ----------------------- | ------------------------------------------ | -------------- |
+| `buildTargetName`       | Name of the cached `next build` task.      | `build`        |
+| `devTargetName`         | Name of the continuous `next dev` task.    | `dev`          |
+| `startTargetName`       | Name of the continuous `next start` task.  | `start`        |
+| `serveStaticTargetName` | Deprecated alias for `startTargetName`.    | `serve-static` |
+| `buildDepsTargetName`   | Name of an optional dependency build task. | none           |
+| `watchDepsTargetName`   | Name of an optional dependency watch task. | none           |
+
+The build task reads `distDir` from the Next.js configuration to declare cache outputs and depends on builds of project dependencies. The start task depends on the build task.
 
 ### Exclude or include specific projects
 
@@ -190,7 +197,8 @@ Use `include`/`exclude` glob patterns in the plugin configuration to scope which
         "buildTargetName": "build",
         "devTargetName": "dev",
         "startTargetName": "start",
-        "serveStaticTargetName": "serve-static"
+        "buildDepsTargetName": "build-deps",
+        "watchDepsTargetName": "watch-deps"
       }
     }
   ]
@@ -206,6 +214,8 @@ nx show project my-app
 ```
 
 Or open the [project details view in Nx Console](/docs/kb/console-project-details#_top).
+
+A [target defaults](/docs/reference/nx-json#target-defaults) `plugin` filter for these tasks must use the exact identifier `@nx/next/plugin`.
 
 ## Set up CI for your Next.js monorepo
 

--- a/astro-docs/src/content/docs/technologies/react/react-native/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/react/react-native/introduction.mdoc
@@ -67,7 +67,10 @@ Nx plugins can infer tasks for your projects based on the configuration of diffe
 The `@nx/react-native` plugin will create a task for any project that has an app configuration file present. Any of the following files will be recognized as an app configuration file:
 
 - `app.config.js`
+- `app.config.ts`
 - `app.json`
+
+The directory must contain both `package.json` and `metro.config.js`. React Native inference excludes projects whose app configuration has an `expo` key or whose package depends on `expo`. The `@nx/expo/plugin` handles projects that meet both Expo conditions.
 
 ### View inferred tasks
 
@@ -90,14 +93,28 @@ The `@nx/react-native/plugin` is configured in the `plugins` array in `nx.json`.
         "runIosTargetName": "run-ios",
         "runAndroidTargetName": "run-android",
         "buildIosTargetName": "build-ios",
-        "buildAndroidTargetName": "build-android"
+        "buildAndroidTargetName": "build-android",
+        "syncDepsTargetName": "sync-deps",
+        "upgradeTargetName": "upgrade"
       }
     }
   ]
 }
 ```
 
-Once a React Native configuration file has been identified, the targets are created with the name you specify under `startTargetName`, `podInstallTargetName`, `bundleTargetName`, `runIosTargetName`, `runAndroidTargetname`, `buildIosTargetName` or `buildAndroidTargetName` in the `nx.json` `plugins` array. The default names for the inferred targets are `start`, `pod-install`, `bundle`, `run-ios`, `run-android`, `build-ios` and `build-android`.
+| Option                   | Default         | Inferred behavior                                                    |
+| ------------------------ | --------------- | -------------------------------------------------------------------- |
+| `startTargetName`        | `start`         | Runs `react-native start` continuously.                              |
+| `podInstallTargetName`   | `pod-install`   | Runs `pod install` after the dependency synchronization task.        |
+| `bundleTargetName`       | `bundle`        | Runs `react-native bundle` after bundling project dependencies.      |
+| `runIosTargetName`       | `run-ios`       | Runs `react-native run-ios` continuously.                            |
+| `runAndroidTargetName`   | `run-android`   | Runs `react-native run-android` continuously.                        |
+| `buildIosTargetName`     | `build-ios`     | Runs and caches `react-native build-ios` with the iOS build outputs. |
+| `buildAndroidTargetName` | `build-android` | Runs and caches `react-native build-android` with Android outputs.   |
+| `syncDepsTargetName`     | `sync-deps`     | Runs the `@nx/react-native:sync-deps` executor.                      |
+| `upgradeTargetName`      | `upgrade`       | Runs `react-native upgrade`.                                         |
+
+Use `include` and `exclude` glob patterns on the plugin entry to scope inference. A [target defaults](/docs/reference/nx-json#target-defaults) `plugin` filter must use the exact identifier `@nx/react-native/plugin`.
 
 ### Generating applications
 

--- a/astro-docs/src/content/docs/technologies/react/react-native/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/react/react-native/introduction.mdoc
@@ -70,7 +70,10 @@ The `@nx/react-native` plugin will create a task for any project that has an app
 - `app.config.ts`
 - `app.json`
 
-The directory must contain both `package.json` and `metro.config.js`. React Native inference excludes projects whose app configuration has an `expo` key or whose package depends on `expo`. The `@nx/expo/plugin` handles projects that meet both Expo conditions.
+The directory must contain both `package.json` and `metro.config.js`.
+React Native inference excludes projects whose app configuration has an `expo` key or whose
+`package.json` lists `expo` as a dependency or development dependency.
+The `@nx/expo/plugin` handles those projects.
 
 ### View inferred tasks
 

--- a/astro-docs/src/content/docs/technologies/react/remix/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/react/remix/introduction.mdoc
@@ -167,6 +167,8 @@ The `@nx/remix` plugin creates tasks for any project that has a Remix configurat
 
 **Remix with Vite** -- looks for `vite.config.{js,ts,mjs,mts,cjs,cts}` files that import the Remix plugin from `@remix-run/dev`.
 
+The configuration directory must also contain a `package.json` or `project.json`.
+
 ### Plugin options
 
 Configure `@nx/remix/plugin` in the `plugins` array in `nx.json`:
@@ -181,19 +183,27 @@ Configure `@nx/remix/plugin` in the `plugins` array in `nx.json`:
         "buildTargetName": "build",
         "devTargetName": "dev",
         "startTargetName": "start",
-        "typecheckTargetName": "typecheck"
+        "typecheckTargetName": "typecheck",
+        "serveStaticTargetName": "serve-static",
+        "buildDepsTargetName": "build-deps",
+        "watchDepsTargetName": "watch-deps"
       }
     }
   ]
 }
 ```
 
-| Option                | Description                         | Default     |
-| --------------------- | ----------------------------------- | ----------- |
-| `buildTargetName`     | Name of the production build task   | `build`     |
-| `devTargetName`       | Name of the development server task | `dev`       |
-| `startTargetName`     | Name of the production server task  | `start`     |
-| `typecheckTargetName` | Name of the typecheck task          | `typecheck` |
+| Option                  | Description                                      | Default        |
+| ----------------------- | ------------------------------------------------ | -------------- |
+| `buildTargetName`       | Name of the cached production build task.        | `build`        |
+| `devTargetName`         | Name of the continuous development server task.  | `dev`          |
+| `startTargetName`       | Name of the continuous production server task.   | `start`        |
+| `typecheckTargetName`   | Name of the cached TypeScript typecheck task.    | `typecheck`    |
+| `serveStaticTargetName` | Name of an alias for the production server task. | `serve-static` |
+| `buildDepsTargetName`   | Name of an optional dependency build task.       | none           |
+| `watchDepsTargetName`   | Name of an optional dependency watch task.       | none           |
+
+Nx selects the classic Remix or Vite commands from the matched configuration, derives build outputs from that configuration, and makes the production server tasks depend on the build task.
 
 ### Exclude or include specific projects
 
@@ -211,7 +221,10 @@ Use `include`/`exclude` glob patterns in the plugin configuration:
         "buildTargetName": "build",
         "devTargetName": "dev",
         "startTargetName": "start",
-        "typecheckTargetName": "typecheck"
+        "typecheckTargetName": "typecheck",
+        "serveStaticTargetName": "serve-static",
+        "buildDepsTargetName": "build-deps",
+        "watchDepsTargetName": "watch-deps"
       }
     }
   ]
@@ -227,6 +240,8 @@ nx show project my-app
 ```
 
 Or open the [project details view in Nx Console](/docs/kb/console-project-details#_top).
+
+A [target defaults](/docs/reference/nx-json#target-defaults) `plugin` filter for these tasks must use the exact identifier `@nx/remix/plugin`.
 
 ## Set up CI for your Remix monorepo
 

--- a/astro-docs/src/content/docs/technologies/test-tools/cypress/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/cypress/introduction.mdoc
@@ -57,6 +57,8 @@ The `@nx/cypress` plugin will create a task for any project that has a Cypress c
 - `cypress.config.mjs`
 - `cypress.config.cjs`
 
+The configuration directory must also contain a `package.json` or `project.json`.
+
 ### View inferred tasks
 
 To view inferred tasks for a project, open the [project details view](/docs/concepts/inferred-tasks) in Nx Console or run `nx show project my-project --web` in the command line.
@@ -92,6 +94,10 @@ The options shown above control the names of the inferred Cypress tasks. The fol
 | `componentTestingTargetName`   | `"component-test"`                            |
 | `ciComponentTestingTargetName` | `undefined` (task is not inferred by default) |
 | `openTargetName`               | `"open-cypress"`                              |
+
+The e2e and component-test targets are cached and track Cypress screenshot and video outputs. The `openTargetName` task opens the interactive Cypress application. CI targets are no-op orchestration tasks that depend on one cached task per spec file.
+
+Use `include` and `exclude` glob patterns on the plugin entry to scope inference. A [target defaults](/docs/reference/nx-json#target-defaults) `plugin` filter must use the exact identifier `@nx/cypress/plugin`.
 
 ### Splitting E2E tasks by file
 

--- a/astro-docs/src/content/docs/technologies/test-tools/cypress/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/cypress/introduction.mdoc
@@ -95,13 +95,14 @@ The options shown above control the names of the inferred Cypress tasks. The fol
 | `ciComponentTestingTargetName` | `undefined` (task is not inferred by default) |
 | `openTargetName`               | `"open-cypress"`                              |
 
-The e2e and component-test targets are cached and track Cypress screenshot and video outputs. The `openTargetName` task opens the interactive Cypress application. CI targets are no-op orchestration tasks that depend on one cached task per spec file.
+The e2e and component-test targets are cached and track Cypress screenshot and video outputs.
+The `openTargetName` task opens the interactive Cypress application.
+The `ciTargetName` task uses the [Atomizer](/docs/features/ci-features/split-e2e-tasks).
+Set `ciComponentTestingTargetName` to atomize component tests as well.
 
 Use `include` and `exclude` glob patterns on the plugin entry to scope inference. A [target defaults](/docs/reference/nx-json#target-defaults) `plugin` filter must use the exact identifier `@nx/cypress/plugin`.
 
 ### Splitting E2E tasks by file
-
-The `@nx/cypress/plugin` will automatically split your e2e tasks by file. Read more about the [Atomizer feature](/docs/features/ci-features/split-e2e-tasks).
 
 To enable e2e task splitting, make sure there is a `ciWebServerCommand` property set in your `cypress.config.ts` file. It will look something like this:
 

--- a/astro-docs/src/content/docs/technologies/test-tools/detox/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/detox/introduction.mdoc
@@ -60,12 +60,14 @@ This will install the correct version of `@nx/detox`.
 
 ### How @nx/detox infers tasks
 
-The `@nx/detox` plugin will create a task for any project that has an ESLint configuration file present. Any of the following files will be recognized as an ESLint configuration file:
+The `@nx/detox/plugin` plugin creates tasks for projects with one of these Detox configuration files:
 
 - `.detoxrc.js`
 - `.detoxrc.json`
 - `detox.config.js`
 - `detox.config.json`
+
+It creates cached `build` and `test` tasks and a continuous `start` task. The cache inputs include the project and its dependencies together with the installed `detox` package.
 
 ### View inferred tasks
 
@@ -84,14 +86,24 @@ The `@nx/detox/plugin` is configured in the `plugins` array in `nx.json`.
       "options": {
         "buildTargetName": "build",
         "startTargetName": "start",
-        "testTargetName": "test"
+        "testTargetName": "test",
+        "buildDepsTargetName": "build-deps",
+        "watchDepsTargetName": "watch-deps"
       }
     }
   ]
 }
 ```
 
-Once a Detox configuration file has been identified, the targets are created with the name you specify under `buildTargetName`, `startTargetName` or `testTargetName` in the `nx.json` `plugins` array. The default names for the inferred targets are `build` and `test`.
+| Option                | Type   | Default | Description                                |
+| --------------------- | ------ | ------- | ------------------------------------------ |
+| `buildTargetName`     | string | `build` | Name of the cached `detox build` task.     |
+| `startTargetName`     | string | `start` | Name of the continuous `detox start` task. |
+| `testTargetName`      | string | `test`  | Name of the cached `detox test` task.      |
+| `buildDepsTargetName` | string | none    | Name of an optional dependency build task. |
+| `watchDepsTargetName` | string | none    | Name of an optional dependency watch task. |
+
+Use `include` and `exclude` glob patterns on the plugin entry to scope inference. A [target defaults](/docs/reference/nx-json#target-defaults) `plugin` filter must use the exact identifier `@nx/detox/plugin`.
 
 ## Using detox
 

--- a/astro-docs/src/content/docs/technologies/test-tools/jest/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/jest/introduction.mdoc
@@ -148,6 +148,8 @@ The `@nx/jest` plugin infers tasks for any project with a Jest configuration fil
 - `jest.config.cjs`
 - `jest.config.cts`
 
+The configuration directory must also contain a `project.json` or a workspace-package `package.json`. Root Jest configurations that only aggregate projects with `getJestProjectsAsync()` are not registered as projects.
+
 ### Plugin options
 
 Configure the plugin in `nx.json`:
@@ -175,6 +177,8 @@ Configure the plugin in `nx.json`:
 | `useJestResolver`    | boolean | `true` when runtime is enabled | Whether to use Jest's resolver for resolving config file references as task inputs. Follows symlinks and honors custom `moduleDirectories`/`modulePaths`. Faster path-based classification is used when `false`. |
 
 `disableJestRuntime` defaults to `true` because the plugin treats it as enabled only when `options.disableJestRuntime !== false`. This reduces computation time for inferred tasks; set it to `false` if you need Jest runtime inference.
+
+The inferred test target is cached. Nx derives its inputs and coverage outputs from the Jest configuration. When `ciTargetName` is set, the plugin also creates one cached task per test file and a no-op CI orchestration task that depends on them.
 
 ### Unit and e2e configurations
 
@@ -212,6 +216,8 @@ Open the project details view in Nx Console or run:
 ```shell
 nx show project my-app
 ```
+
+A [target defaults](/docs/reference/nx-json#target-defaults) `plugin` filter for these tasks must use the exact identifier `@nx/jest/plugin`.
 
 ## Set up CI
 

--- a/astro-docs/src/content/docs/technologies/test-tools/jest/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/jest/introduction.mdoc
@@ -178,7 +178,9 @@ Configure the plugin in `nx.json`:
 
 `disableJestRuntime` defaults to `true` because the plugin treats it as enabled only when `options.disableJestRuntime !== false`. This reduces computation time for inferred tasks; set it to `false` if you need Jest runtime inference.
 
-The inferred test target is cached. Nx derives its inputs and coverage outputs from the Jest configuration. When `ciTargetName` is set, the plugin also creates one cached task per test file and a no-op CI orchestration task that depends on them.
+The inferred test target is cached.
+Nx derives its inputs and coverage outputs from the Jest configuration.
+Set `ciTargetName` to enable the [Atomizer](/docs/features/ci-features/split-e2e-tasks).
 
 ### Unit and e2e configurations
 
@@ -207,7 +209,8 @@ Use two plugin entries to separate unit and E2E Jest tasks, and enable CI splitt
 }
 ```
 
-`ciTargetName` enables [split E2E tasks](/docs/features/ci-features/split-e2e-tasks) so each test file runs as its own CI task with better caching and retries. Use `ciGroupName` if you want a custom group label.
+Here `ciTargetName` atomizes only the E2E tasks.
+Use `ciGroupName` to set a custom group label.
 
 ### View inferred tasks
 

--- a/astro-docs/src/content/docs/technologies/test-tools/playwright/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/playwright/introduction.mdoc
@@ -52,6 +52,8 @@ The `@nx/playwright` plugin will create a task for any project that has a Playwr
 - `playwright.config.cjs`
 - `playwright.config.cts`
 
+The configuration directory must also contain a `package.json` or `project.json`.
+
 ### View inferred tasks
 
 To view inferred tasks for a project, open the [project details view](/docs/concepts/inferred-tasks) in Nx Console or run `nx show project my-project --web` in the command line.
@@ -79,9 +81,11 @@ The `targetName` and `ciTargetName` options control the name of the inferred Pla
 
 ### Splitting E2E tests
 
-`@nx/playwright/plugin` uses Nx Atomizer to automatically split your e2e tests into smaller tasks for more efficient distribution in CI. Read more about the [Atomizer feature](/docs/features/ci-features/split-e2e-tasks).
+The `targetName` task runs the complete Playwright suite and caches the configured test and reporter outputs. The `ciTargetName` task uses Nx Atomizer to create one cached task per test file, plus a report-merging task when the configured reporters produce mergeable output. Read more about the [Atomizer feature](/docs/features/ci-features/split-e2e-tasks).
 
-If you would like to disable Atomizer for Playwright tasks, set `ciTargetName` to `false`.
+Both options accept task names as strings. To run the non-atomized suite in CI, invoke the `targetName` task (the default is `e2e`) instead of the `ciTargetName` task.
+
+Use `include` and `exclude` glob patterns on the plugin entry to scope inference. A [target defaults](/docs/reference/nx-json#target-defaults) `plugin` filter must use the exact identifier `@nx/playwright/plugin`.
 
 ## E2E testing
 
@@ -125,7 +129,7 @@ nx e2e frontend-e2e --grepInvert="feat-a"
 {% /aside %}
 
 By default, Playwright will run in headless mode. You will have the result of all the tests and errors (if any) in your
-terminal. Test output such as reports, screenshots and videos, will be accessible in `dist/.playwright/apps/<your-app-name>/`. This can be configured with the `outputDir` configuration options.
+terminal. Test output such as reports, screenshots, and videos will be accessible in `dist/.playwright/apps/<your-app-name>/`. This can be configured with the `outputDir` configuration options.
 
 {% aside type="note" title="Output Caching" %}
 If changing the output directory or report output, make sure to update the [target outputs](/docs/concepts/how-caching-works#what-is-cached) so the artifacts are correctly cached

--- a/astro-docs/src/content/docs/technologies/test-tools/playwright/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/playwright/introduction.mdoc
@@ -81,7 +81,9 @@ The `targetName` and `ciTargetName` options control the name of the inferred Pla
 
 ### Splitting E2E tests
 
-The `targetName` task runs the complete Playwright suite and caches the configured test and reporter outputs. The `ciTargetName` task uses Nx Atomizer to create one cached task per test file, plus a report-merging task when the configured reporters produce mergeable output. Read more about the [Atomizer feature](/docs/features/ci-features/split-e2e-tasks).
+The `targetName` task runs the complete Playwright suite and caches the configured test and reporter
+outputs.
+The `ciTargetName` task uses the [Atomizer](/docs/features/ci-features/split-e2e-tasks).
 
 Both options accept task names as strings. To run the non-atomized suite in CI, invoke the `targetName` task (the default is `e2e`) instead of the `ciTargetName` task.
 

--- a/astro-docs/src/content/docs/technologies/test-tools/storybook/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/storybook/introduction.mdoc
@@ -48,6 +48,8 @@ The `@nx/storybook` plugin will create a task for any project that has a Storybo
 - `.storybook/main.mjs`
 - `.storybook/main.mts`
 
+The project directory that contains `.storybook` must also contain a `package.json` or `project.json`.
+
 ### View inferred tasks
 
 To view inferred tasks for a project, open the [project details view](/docs/concepts/inferred-tasks) in Nx Console or run `nx show project my-project --web` in the command line.
@@ -66,14 +68,25 @@ The `@nx/storybook/plugin` is configured in the `plugins` array in `nx.json`.
         "buildStorybookTargetName": "build-storybook",
         "serveStorybookTargetName": "storybook",
         "testStorybookTargetName": "test-storybook",
-        "staticStorybookTargetName": "static-storybook"
+        "staticStorybookTargetName": "static-storybook",
+        "buildDepsTargetName": "build-deps",
+        "watchDepsTargetName": "watch-deps"
       }
     }
   ]
 }
 ```
 
-The `builtStorybookTargetName`, `serveStorybookTargetName`, `testStorybookTargetName` and `staticStorybookTargetName` options control the names of the inferred Storybook tasks. The default names are `build-storybook`, `storybook`, `test-storybook` and `static-storybook`.
+| Option                      | Default            | Inferred behavior                                   |
+| --------------------------- | ------------------ | --------------------------------------------------- |
+| `buildStorybookTargetName`  | `build-storybook`  | Builds and caches the static Storybook output.      |
+| `serveStorybookTargetName`  | `storybook`        | Runs the Storybook development server continuously. |
+| `testStorybookTargetName`   | `test-storybook`   | Runs `test-storybook` when the project supports it. |
+| `staticStorybookTargetName` | `static-storybook` | Serves the built Storybook output continuously.     |
+| `buildDepsTargetName`       | `build-deps`       | Builds project dependencies.                        |
+| `watchDepsTargetName`       | `watch-deps`       | Watches project dependencies.                       |
+
+Use `include` and `exclude` glob patterns on the plugin entry to scope inference. A [target defaults](/docs/reference/nx-json#target-defaults) `plugin` filter must use the exact identifier `@nx/storybook/plugin`.
 
 ## Using Storybook
 

--- a/astro-docs/src/content/docs/technologies/test-tools/vitest/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/vitest/introduction.mdoc
@@ -194,7 +194,7 @@ There is no single "disable" flag for inference. Use `include` and `exclude` to 
 The inferred test target is cached and declares the configured coverage reports directory, or
 `coverage` by default, as its only cache output.
 Custom reporter output files are not inferred.
-When `ciTargetName` is set, the plugin creates one cached `vitest run` task per test file and a no-op CI orchestration task that depends on them.
+Set `ciTargetName` to enable the [Atomizer](/docs/features/ci-features/split-e2e-tasks).
 
 A [target defaults](/docs/reference/nx-json#target-defaults) `plugin` filter for these tasks must use the exact identifier `@nx/vitest`.
 

--- a/astro-docs/src/content/docs/technologies/test-tools/vitest/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/vitest/introduction.mdoc
@@ -191,7 +191,10 @@ The `glob` path reads the Nx workspace file index, so it never enumerates specs 
 
 There is no single "disable" flag for inference. Use `include` and `exclude` to scope which projects each plugin instance applies to.
 
-The inferred test target is cached and tracks Vitest's configured coverage and report outputs. When `ciTargetName` is set, the plugin creates one cached `vitest run` task per test file and a no-op CI orchestration task that depends on them.
+The inferred test target is cached and declares the configured coverage reports directory, or
+`coverage` by default, as its only cache output.
+Custom reporter output files are not inferred.
+When `ciTargetName` is set, the plugin creates one cached `vitest run` task per test file and a no-op CI orchestration task that depends on them.
 
 A [target defaults](/docs/reference/nx-json#target-defaults) `plugin` filter for these tasks must use the exact identifier `@nx/vitest`.
 

--- a/astro-docs/src/content/docs/technologies/test-tools/vitest/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/vitest/introduction.mdoc
@@ -152,6 +152,8 @@ The `@nx/vitest` plugin creates a target for any project that has a Vitest or Vi
 - `vite.config.cjs` (with `test` configuration)
 - `vite.config.cts` (with `test` configuration)
 
+The configuration directory must also contain a `package.json` or `project.json`. A root Vitest workspace configuration that only orchestrates child projects is not registered as its own project.
+
 To view inferred tasks, open the [project details view](/docs/concepts/inferred-tasks) in Nx Console or run `nx show project my-app`.
 
 ### Plugin options
@@ -188,6 +190,10 @@ When `discoverTestFiles` is `glob`, configs that a glob cannot reproduce faithfu
 The `glob` path reads the Nx workspace file index, so it never enumerates specs ignored by `.gitignore` or `.nxignore`, even ones Vitest itself would run. Set `discoverTestFiles` to `vitest` if you need those specs atomized.
 
 There is no single "disable" flag for inference. Use `include` and `exclude` to scope which projects each plugin instance applies to.
+
+The inferred test target is cached and tracks Vitest's configured coverage and report outputs. When `ciTargetName` is set, the plugin creates one cached `vitest run` task per test file and a no-op CI orchestration task that depends on them.
+
+A [target defaults](/docs/reference/nx-json#target-defaults) `plugin` filter for these tasks must use the exact identifier `@nx/vitest`.
 
 ### Configure unit and e2e separately
 

--- a/astro-docs/src/content/docs/technologies/typescript/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/typescript/introduction.mdoc
@@ -360,30 +360,40 @@ Configure `@nx/js/typescript` in the `plugins` array in `nx.json`:
     {
       "plugin": "@nx/js/typescript",
       "options": {
+        "compiler": "tsc",
         "typecheck": {
-          "targetName": "typecheck"
+          "targetName": "typecheck",
+          "configName": "tsconfig.json"
         },
         "build": {
           "targetName": "build",
           "configName": "tsconfig.lib.json",
           "buildDepsName": "build-deps",
-          "watchDepsName": "watch-deps"
-        }
+          "watchDepsName": "watch-deps",
+          "skipBuildCheck": false
+        },
+        "verboseOutput": false
       }
     }
   ]
 }
 ```
 
-| Option                 | Description                                               | Default             |
-| ---------------------- | --------------------------------------------------------- | ------------------- |
-| `typecheck.targetName` | Name of the typecheck task                                | `typecheck`         |
-| `build.targetName`     | Name of the build task                                    | `build`             |
-| `build.configName`     | The tsconfig file used for builds                         | `tsconfig.lib.json` |
-| `build.buildDepsName`  | Name of the task for building all dependencies            | `build-deps`        |
-| `build.watchDepsName`  | Name of the task for watching and rebuilding dependencies | `watch-deps`        |
+| Option                 | Description                                                                   | Default             |
+| ---------------------- | ----------------------------------------------------------------------------- | ------------------- |
+| `compiler`             | Compiler used by inferred tasks: `tsc` or `tsgo`.                             | `tsc`               |
+| `typecheck`            | Enables typecheck inference; set to `false` to disable it.                    | enabled             |
+| `typecheck.targetName` | Name of the cached typecheck task.                                            | `typecheck`         |
+| `typecheck.configName` | The tsconfig file used for typechecking.                                      | `tsconfig.json`     |
+| `build`                | Enables build inference; set to `false` or omit it to disable build tasks.    | disabled            |
+| `build.targetName`     | Name of the cached build task.                                                | `build`             |
+| `build.configName`     | The tsconfig file used for builds.                                            | `tsconfig.lib.json` |
+| `build.buildDepsName`  | Name of the task for building all dependencies.                               | `build-deps`        |
+| `build.watchDepsName`  | Name of the task for watching and rebuilding dependencies.                    | `watch-deps`        |
+| `build.skipBuildCheck` | Allows build inference without package exports that point to compiled output. | `false`             |
+| `verboseOutput`        | Adds TypeScript's `--verbose` flag to inferred commands.                      | `false`             |
 
-Set `typecheck` or `build` to `false` to disable that task entirely.
+The inferred `typecheck` and `build` tasks are cached, declare their tsconfig-derived inputs and outputs, and depend on the corresponding tasks in dependency projects.
 
 ### Exclude or include specific projects
 
@@ -429,6 +439,8 @@ nx show project <my-project>
 ```
 
 Or open the [project details view in Nx Console](/docs/kb/console-project-details#_top).
+
+A [target defaults](/docs/reference/nx-json#target-defaults) `plugin` filter for these tasks must use the exact identifier `@nx/js/typescript`.
 
 ## Set up CI for your TypeScript monorepo
 

--- a/astro-docs/src/content/docs/technologies/vue/nuxt/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/vue/nuxt/introduction.mdoc
@@ -56,6 +56,8 @@ The `@nx/nuxt` plugin will create a task for any project that has an Nuxt config
 - `nuxt.config.cjs`
 - `nuxt.config.cts`
 
+The configuration directory must also contain a `package.json` or `project.json`.
+
 ### View inferred tasks
 
 To view inferred tasks for a project, open the [project details view](/docs/concepts/inferred-tasks) in Nx Console or run `nx show project my-project --web` in the command line.
@@ -72,19 +74,27 @@ The `@nx/nuxt/plugin` is configured in the `plugins` array in `nx.json`.
       "plugin": "@nx/nuxt/plugin",
       "options": {
         "buildTargetName": "build",
-        "testTargetName": "test",
         "serveTargetName": "serve",
         "buildStaticTargetName": "build-static",
-        "serveStaticTargetName": "serve-static"
+        "serveStaticTargetName": "serve-static",
+        "buildDepsTargetName": "build-deps",
+        "watchDepsTargetName": "watch-deps"
       }
     }
   ]
 }
 ```
 
-The `buildTargetName`, `testTargetName` and `serveTargetName` options control the names of the inferred Nuxt tasks. The default names are `build`, `test` and `serve`.
+| Option                  | Type   | Default        | Inferred behavior                                              |
+| ----------------------- | ------ | -------------- | -------------------------------------------------------------- |
+| `buildTargetName`       | string | `build`        | Runs and caches `nuxt build`, including `.nuxt` and `.output`. |
+| `serveTargetName`       | string | `serve`        | Runs `nuxt dev` continuously.                                  |
+| `buildStaticTargetName` | string | `build-static` | Runs and caches `nuxt build --prerender`.                      |
+| `serveStaticTargetName` | string | `serve-static` | Serves `dist` continuously after the static build task.        |
+| `buildDepsTargetName`   | string | none           | Name of an optional dependency build task.                     |
+| `watchDepsTargetName`   | string | none           | Name of an optional dependency watch task.                     |
 
-The `buildStaticTargetName` and `serveStaticTargetName` options control the names of the inferred Nuxt static tasks. The default names are `build-static` and `serve-static`.
+Use `include` and `exclude` glob patterns on the plugin entry to scope inference. A [target defaults](/docs/reference/nx-json#target-defaults) `plugin` filter must use the exact identifier `@nx/nuxt/plugin`.
 
 ## Using Nuxt
 


### PR DESCRIPTION
## Current Behavior

the technology pages drifted from what the inferred plugins actually do. matching rules, option lists, and defaults were hand-written at different times and never re-checked against `createNodes`/`createNodesV2`, so some pages list options that don't exist and omit ones that do. the jest `targetDefaults` example in the nx-json reference filters on `@nx/jest`, which matches nothing, since the filter wants the configured entry point `@nx/jest/plugin`.

## Expected Behavior

each page says which identifier goes in `nx.json`, what files the plugin matches, its options and defaults, and what targets it configures, all read off plugin source instead of the previous docs.

- treated the implementation and its tests as authoritative wherever they disagreed with the docs
- rollup and rsbuild had no inferred-task section at all, now they do
- worth a look: playwright used to say set `ciTargetName` to `false` to disable atomizer. the option is typed `string` and nothing tests `false`, though `if (options.ciTargetName)` suggests it does work in practice. i dropped that line and pointed at running the `targetName` task instead, which is not the same thing (the atomized targets still get created). put it back if someone is relying on it.
- generating this from a schema is still blocked on NXC-3871, so this is the manual accuracy pass in the meantime

draft because i haven't run the docs style check over the final state of all 25 pages yet.

## Related Issue(s)

DOC-554
