### PR TITLE
fix(testing): prevent playwright from launching a redundant web server

### DIFF
--- a/astro-docs/src/content/docs/kb/merge-atomized-outputs.mdoc
+++ b/astro-docs/src/content/docs/kb/merge-atomized-outputs.mdoc
@@ -133,10 +133,14 @@ export default defineConfig({
   webServer: {
     command: 'npm run start',
     port: 4200,
-    reuseExistingServer: !process.env.CI,
+    reuseExistingServer: true,
   },
 });
 ```
+
+Set `reuseExistingServer` to `true` rather than `!process.env.CI`.
+When the `command` runs an Nx task, Nx then runs that task as a dependency and waits for the server before the tests start.
+See [the Playwright plugin page](/docs/technologies/test-tools/playwright/introduction#nxplaywright-configuration) for the command forms it recognizes.
 
 ```json
 // nx.json

--- a/astro-docs/src/content/docs/kb/playwright-web-server-readiness.mdoc
+++ b/astro-docs/src/content/docs/kb/playwright-web-server-readiness.mdoc
@@ -46,12 +46,18 @@ changes how the server would be probed.
 The same goes for the Playwright config itself, such as one that calls `dotenv.config()`, since it
 runs before Playwright probes.
 The variables that count are the proxy variables (`HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, and
-`NO_PROXY`) for a `webServer` with a `url`, and `NODE_EXTRA_CA_CERTS` and
-`NODE_TLS_REJECT_UNAUTHORIZED` unless every such `webServer` sets `ignoreHTTPSErrors`.
+`NO_PROXY`) for a `webServer` with a `url`, and `NODE_EXTRA_CA_CERTS` unless every such
+`webServer` sets `ignoreHTTPSErrors`.
 The proxy variables count in either spelling, and the lowercase one (`http_proxy`) wins over the
 uppercase one when both are set.
 That option doesn't cover the certificate of an `https` proxy that `HTTPS_PROXY` or `ALL_PROXY`
-routes through, so the TLS variables count whenever that's the route.
+routes through, so `NODE_EXTRA_CA_CERTS` counts whenever that's the route.
+That connection is also the only one either probe leaves to `NODE_TLS_REJECT_UNAUTHORIZED`, so it
+counts when that's the route and one side sets it to `0`.
+With `@playwright/test` below 1.59.0, a probe tunnelled through an `http` proxy never verifies the
+certificate, so `NODE_EXTRA_CA_CERTS` doesn't count while an `http` proxy handles the `https`
+route, no `https` proxy handles the `http` route, and no `NO_PROXY` entry can send a redirect target
+direct.
 Node reads `NODE_EXTRA_CA_CERTS` when the process starts, so only its value in an env file
 counts, not one the config sets.
 Both probes follow redirects, so a variable that plays no part at the configured URL, such as
@@ -106,6 +112,9 @@ Run `nx reset` to re-infer it.
 
 A task dependency can't carry a target configuration, so the address is always inferred without
 one and a configuration-scoped env file such as `.env.e2e.production` never affects it.
+When such a file moves the server to another address, running the task with that configuration
+leaves the wait task probing the unconfigured address until it times out and fails the run.
+Set the `waitForWebServer` plugin option to `false` for such a setup.
 
 The Playwright task runs from the project root, but Nx doesn't guarantee that the config is
 evaluated from there while computing the project graph.

--- a/astro-docs/src/content/docs/kb/playwright-web-server-readiness.mdoc
+++ b/astro-docs/src/content/docs/kb/playwright-web-server-readiness.mdoc
@@ -105,6 +105,13 @@ Run `nx reset` to re-infer it.
 A task dependency can't carry a target configuration, so the address is always inferred without
 one and a configuration-scoped env file such as `.env.e2e.production` never affects it.
 
+The Playwright task runs from the project root, but Nx doesn't guarantee that the config is
+evaluated from there while computing the project graph.
+An address that depends on the working directory, such as a port read from a file at a relative
+path, can differ between the two, and the wait task then waits for the wrong address.
+Derive such an address from `__dirname` instead, or set the `waitForWebServer` plugin option to
+`false`.
+
 Nx re-evaluates the config under the task's env only when the graph-time evaluation found a
 `webServer`, so a `webServer` that only exists under the task's env is not detected.
 That re-evaluation runs the config in a child process started under the task's env, so an env file

--- a/astro-docs/src/content/docs/kb/playwright-web-server-readiness.mdoc
+++ b/astro-docs/src/content/docs/kb/playwright-web-server-readiness.mdoc
@@ -1,0 +1,101 @@
+---
+title: Playwright web server readiness
+description: How Nx infers the web server dependency and readiness task from a Playwright config, when it skips them, and when it re-infers the server address.
+sidebar:
+  label: Playwright web server readiness
+filter: 'type:Guides'
+topics:
+  - 'Playwright'
+---
+
+When a Playwright config declares a `webServer` whose `command` runs an Nx task and that sets
+`reuseExistingServer` to `true`, `@nx/playwright` runs that task as a dependency of the Playwright
+tasks and infers a `<targetName>--wait-for-webserver` task that waits for the server to be ready.
+The [Playwright plugin page](/docs/technologies/test-tools/playwright/introduction#nxplaywright-configuration)
+covers the default workflow.
+
+## Recognized commands
+
+The `command` must be `nx run <project>:<target>` or `nx <target> <project>`, optionally prefixed
+by `npx`, `yarn`, `bun`, `pnpm`, `pnpm exec`, or `pnpx`.
+Nx doesn't recognize a command with extra arguments, such as `npx nx run my-app:serve --port=4200`,
+and infers neither the dependency nor the wait task for it.
+
+A trailing `:<configuration>` in the `nx run` form is accepted, but a task dependency can't carry a
+configuration, so the dependency runs the target without it.
+Nx skips the wait task for such a command, since the server may not listen at the configured
+address.
+
+## When Nx skips the wait task
+
+Nx infers the wait task from the `port` a `webServer` sets, or from its `url` when `port` is unset,
+which is when Playwright checks the URL rather than the port.
+When the `webServer` sets neither, Playwright has nothing to check and starts its own server, and
+Nx infers no wait task.
+
+Nx infers neither the dependency nor the wait task for a `webServer` that sets `wait.stdout` or
+`wait.stderr`.
+Playwright treats matching output from the server process it starts as the readiness signal and
+can capture values from it into the environment, so Nx leaves starting that server to Playwright.
+The same applies to a `webServer` that sets `env`.
+Only Playwright passes that environment to the command it starts, so a task-started server would
+run without it.
+
+Nx also skips the wait task, keeping the dependency, when an env file the Playwright task loads
+changes how the server would be probed.
+The variables that count are the proxy variables (`HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, and
+`NO_PROXY`) for a `webServer` with a `url`, and `NODE_EXTRA_CA_CERTS` and
+`NODE_TLS_REJECT_UNAUTHORIZED` unless every such `webServer` sets `ignoreHTTPSErrors`.
+Both probes follow redirects, so a variable that plays no part at the configured URL, such as
+`HTTPS_PROXY` for an `http` URL, still counts.
+Nx compares the routes those variables produce rather than their raw values.
+A variable that another one masks doesn't count, such as `NO_PROXY` when no proxy is configured
+or `ALL_PROXY` next to an explicit `HTTP_PROXY` and `HTTPS_PROXY`, and neither does a proxy value
+written with or without its scheme or a `NO_PROXY` list in a different order.
+The wait task runs with its own environment rather than the Playwright task's, so it can't
+reproduce that probe and the tests fall back to Playwright's own `reuseExistingServer` probe.
+
+## Configuring the wait task
+
+The `webServerTimeout` plugin option sets how long, in milliseconds, the wait task waits before
+failing.
+It defaults to each web server's configured `timeout`, or 60000 when neither is set.
+
+Set the `waitForWebServer` plugin option to `false` to opt out of the wait task.
+Nx still runs the web server as a task dependency, and the tests fall back to Playwright's own
+`reuseExistingServer` probe.
+Nx also still re-evaluates the config under the task's env, because the `webServer.command` the
+dependency is inferred from can itself read that env.
+
+## How the server address is inferred
+
+The readiness address comes from evaluating the Playwright config while Nx computes the project
+graph.
+Nx caches the result and rebuilds it when an env file the Playwright task would load, such as
+`.env` or `.env.e2e`, changes.
+An env file listed in `.nxignore` is an exception: Nx doesn't see it change, so the cached result
+stays stale.
+
+A variable set only in the shell is part of that cache too, so changing it re-infers the address.
+The exception is variables Nx filters out of the project graph environment, such as terminal
+session details or CI platform internals.
+Changing one of those doesn't re-infer the address.
+`CI` itself isn't filtered, so changing it re-infers the address.
+Running `nx reset` also discards the cached address.
+
+Files the config imports from outside its project, such as a shared helper in `tools/`, are not
+part of the cache either.
+Editing one doesn't refresh an already-cached address.
+Run `nx reset` to re-infer it.
+
+A task dependency can't carry a target configuration, so the address is always inferred without
+one and a configuration-scoped env file such as `.env.e2e.production` never affects it.
+
+Nx re-evaluates the config under the task's env only when the graph-time evaluation found a
+`webServer`, so a `webServer` that only exists under the task's env is not detected.
+That re-evaluation runs the config in a child process started under the task's env, so an env file
+that sets Node startup options such as `NODE_OPTIONS` has them applied while Nx computes the
+project graph, not only when the task runs.
+If that re-evaluation fails or times out, Nx logs a warning, infers the task dependencies from the
+graph-time evaluation, and skips the wait task.
+The failed result is not cached, so the next project graph computation retries the evaluation.

--- a/astro-docs/src/content/docs/kb/playwright-web-server-readiness.mdoc
+++ b/astro-docs/src/content/docs/kb/playwright-web-server-readiness.mdoc
@@ -52,8 +52,12 @@ Both probes follow redirects, so a variable that plays no part at the configured
 `HTTPS_PROXY` for an `http` URL, still counts.
 Nx compares the routes those variables produce rather than their raw values.
 A variable that another one masks doesn't count, such as `NO_PROXY` when no proxy is configured
-or `ALL_PROXY` next to an explicit `HTTP_PROXY` and `HTTPS_PROXY`, and neither does a proxy value
-written with or without its scheme or a `NO_PROXY` list in a different order.
+or `ALL_PROXY` next to an explicit `HTTP_PROXY` and `HTTPS_PROXY`, and neither does an
+`HTTP_PROXY` written with or without its `http://` scheme or a `NO_PROXY` list in a different
+order.
+A scheme-less proxy value takes the protocol it's used for.
+A scheme-less `HTTPS_PROXY` is an `https` proxy and a scheme-less `ALL_PROXY` follows each
+request's protocol, so either counts against the same value written with `http://`.
 The wait task runs with its own environment rather than the Playwright task's, so it can't
 reproduce that probe and the tests fall back to Playwright's own `reuseExistingServer` probe.
 
@@ -77,6 +81,9 @@ Nx caches the result and rebuilds it when an env file the Playwright task would 
 `.env` or `.env.e2e`, changes.
 An env file listed in `.nxignore` is an exception: Nx doesn't see it change, so the cached result
 stays stale.
+So is a workspace-root env file whose name comes from a target name containing `/`, such as
+`.env.e2e/smoke`, which Nx doesn't watch.
+The same file under a project root is watched.
 
 A variable set only in the shell is part of that cache too, so changing it re-infers the address.
 The exception is variables Nx filters out of the project graph environment, such as terminal

--- a/astro-docs/src/content/docs/kb/playwright-web-server-readiness.mdoc
+++ b/astro-docs/src/content/docs/kb/playwright-web-server-readiness.mdoc
@@ -43,11 +43,15 @@ run without it.
 
 Nx also skips the wait task, keeping the dependency, when an env file the Playwright task loads
 changes how the server would be probed.
+The same goes for the Playwright config itself, such as one that calls `dotenv.config()`, since it
+runs before Playwright probes.
 The variables that count are the proxy variables (`HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, and
 `NO_PROXY`) for a `webServer` with a `url`, and `NODE_EXTRA_CA_CERTS` and
 `NODE_TLS_REJECT_UNAUTHORIZED` unless every such `webServer` sets `ignoreHTTPSErrors`.
 That option doesn't cover the certificate of an `https` proxy that `HTTPS_PROXY` or `ALL_PROXY`
 routes through, so the TLS variables count whenever that's the route.
+Node reads `NODE_EXTRA_CA_CERTS` when the process starts, so only its value in an env file
+counts, not one the config sets.
 Both probes follow redirects, so a variable that plays no part at the configured URL, such as
 `HTTPS_PROXY` for an `http` URL, still counts.
 Nx compares the routes those variables produce rather than their raw values.
@@ -58,8 +62,9 @@ order.
 A scheme-less proxy value takes the protocol it's used for.
 A scheme-less `HTTPS_PROXY` is an `https` proxy and a scheme-less `ALL_PROXY` follows each
 request's protocol, so either counts against the same value written with `http://`.
-The wait task runs with its own environment rather than the Playwright task's, so it can't
-reproduce that probe and the tests fall back to Playwright's own `reuseExistingServer` probe.
+The wait task runs with its own environment (its own env files included) rather than the
+Playwright task's and never loads the config, so it can't reproduce that probe and the tests fall
+back to Playwright's own `reuseExistingServer` probe.
 
 ## Configuring the wait task
 

--- a/astro-docs/src/content/docs/kb/playwright-web-server-readiness.mdoc
+++ b/astro-docs/src/content/docs/kb/playwright-web-server-readiness.mdoc
@@ -1,6 +1,6 @@
 ---
 title: Playwright web server readiness
-description: How Nx infers the web server dependency and readiness task from a Playwright config, when it skips them, and when it re-infers the server address.
+description: How Nx infers, skips, and re-infers the Playwright web server dependency and wait task.
 sidebar:
   label: Playwright web server readiness
 filter: 'type:Guides'

--- a/astro-docs/src/content/docs/kb/playwright-web-server-readiness.mdoc
+++ b/astro-docs/src/content/docs/kb/playwright-web-server-readiness.mdoc
@@ -48,6 +48,8 @@ runs before Playwright probes.
 The variables that count are the proxy variables (`HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, and
 `NO_PROXY`) for a `webServer` with a `url`, and `NODE_EXTRA_CA_CERTS` and
 `NODE_TLS_REJECT_UNAUTHORIZED` unless every such `webServer` sets `ignoreHTTPSErrors`.
+The proxy variables count in either spelling, and the lowercase one (`http_proxy`) wins over the
+uppercase one when both are set.
 That option doesn't cover the certificate of an `https` proxy that `HTTPS_PROXY` or `ALL_PROXY`
 routes through, so the TLS variables count whenever that's the route.
 Node reads `NODE_EXTRA_CA_CERTS` when the process starts, so only its value in an env file
@@ -109,8 +111,9 @@ The Playwright task runs from the project root, but Nx doesn't guarantee that th
 evaluated from there while computing the project graph.
 An address that depends on the working directory, such as a port read from a file at a relative
 path, can differ between the two, and the wait task then waits for the wrong address.
-Derive such an address from `__dirname` instead, or set the `waitForWebServer` plugin option to
-`false`.
+Derive such an address from the config file's own directory instead: `import.meta.dirname` in an
+ESM config, such as the generated `playwright.config.mts`, or `__dirname` in a CommonJS one.
+Alternatively, set the `waitForWebServer` plugin option to `false`.
 
 Nx re-evaluates the config under the task's env only when the graph-time evaluation found a
 `webServer`, so a `webServer` that only exists under the task's env is not detected.

--- a/astro-docs/src/content/docs/kb/playwright-web-server-readiness.mdoc
+++ b/astro-docs/src/content/docs/kb/playwright-web-server-readiness.mdoc
@@ -46,6 +46,8 @@ changes how the server would be probed.
 The variables that count are the proxy variables (`HTTP_PROXY`, `HTTPS_PROXY`, `ALL_PROXY`, and
 `NO_PROXY`) for a `webServer` with a `url`, and `NODE_EXTRA_CA_CERTS` and
 `NODE_TLS_REJECT_UNAUTHORIZED` unless every such `webServer` sets `ignoreHTTPSErrors`.
+That option doesn't cover the certificate of an `https` proxy that `HTTPS_PROXY` or `ALL_PROXY`
+routes through, so the TLS variables count whenever that's the route.
 Both probes follow redirects, so a variable that plays no part at the configured URL, such as
 `HTTPS_PROXY` for an `http` URL, still counts.
 Nx compares the routes those variables produce rather than their raw values.

--- a/astro-docs/src/content/docs/kb/playwright-web-server-readiness.mdoc
+++ b/astro-docs/src/content/docs/kb/playwright-web-server-readiness.mdoc
@@ -54,6 +54,9 @@ That option doesn't cover the certificate of an `https` proxy that `HTTPS_PROXY`
 routes through, so `NODE_EXTRA_CA_CERTS` counts whenever that's the route.
 That connection is also the only one either probe leaves to `NODE_TLS_REJECT_UNAUTHORIZED`, so it
 counts when that's the route and one side sets it to `0`.
+With `@playwright/test` below 1.59.0, the probe also reads npm's `npm_config_http_proxy`,
+`npm_config_https_proxy`, `npm_config_proxy`, and `npm_config_no_proxy`, which `npm run` exports
+from an `.npmrc` `proxy` or `no-proxy` setting, so they count on those versions as well.
 With `@playwright/test` below 1.59.0, a probe tunnelled through an `http` proxy never verifies the
 certificate, so `NODE_EXTRA_CA_CERTS` doesn't count while an `http` proxy handles the `https`
 route, no `https` proxy handles the `http` route, and no `NO_PROXY` entry can send a redirect target

--- a/astro-docs/src/content/docs/technologies/test-tools/playwright/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/playwright/introduction.mdoc
@@ -83,8 +83,12 @@ The command must be exactly `nx run <project>:<target>` or `nx <target> <project
 prefixed by `npx`, `yarn`, `bun`, `pnpm`, `pnpm exec`, or `pnpx`.
 Nx doesn't recognize a command with extra arguments, such as `npx nx run my-app:serve --port=4200`.
 
-If that `webServer` also sets a `port` or a `url`, Nx infers an extra task that waits for the server
-to be ready.
+The Playwright docs suggest setting `reuseExistingServer` to `!process.env.CI`.
+Set it to `true` instead, since Nx already runs the web server as a task dependency.
+With `false`, Nx skips that task and Playwright starts its own server inside each Playwright task.
+
+If that `webServer` also sets a `port`, or a `url` with no `port`, Nx infers an extra task that waits
+for the server to be ready.
 Playwright then finds the server already running and reuses it.
 If the `webServer` sets neither, Playwright has nothing to check and starts its own server.
 
@@ -113,10 +117,12 @@ To generate an E2E project for an existing project, run the following generator
 nx g @nx/playwright:configuration --project=your-app-name
 ```
 
-Optionally, you can use the `--webServerCommand` and `--webServerAddress` option, to auto setup the [web server option](https://playwright.dev/docs/test-webserver) in the playwright config
+The generator prompts for the [web server option](https://playwright.dev/docs/test-webserver) to add
+to the Playwright config.
+Pass `--webServerCommand` and `--webServerAddress` to skip the prompts.
 
 ```shell
-nx g @nx/playwright:configuration --project=your-app-name --webServerCommand="npx serve your-project-name" --webServerAddress="http://localhost:4200"
+nx g @nx/playwright:configuration --project=your-app-name --webServerCommand="npx nx serve your-project-name" --webServerAddress="http://localhost:4200"
 ```
 
 ### Testing applications
@@ -209,9 +215,9 @@ export default defineConfig({
 
   // Run your local dev server before starting the tests
   webServer: {
-    command: 'npx serve <your-app-name>',
+    command: 'npx nx serve <your-app-name>',
     url: 'http://localhost:4200',
-    reuseExistingServer: !process.env.CI,
+    reuseExistingServer: true,
   },
   use: {
     baseURL: 'http://localhost:4200', // url playwright visits with `await page.goto('/')`;
@@ -225,24 +231,23 @@ In order to set different `baseURL` values for different environments you can pa
 import { defineConfig } from '@playwright/test';
 
 const baseUrl =
-  (process.env.BASE_URL ?? process.env.CI)
+  process.env.BASE_URL ??
+  (process.env.CI
     ? 'https://some-staging-url.example.com'
-    : 'http://localhost:4200';
+    : 'http://localhost:4200');
 
 export default defineConfig({
   // Rest of your config...
 
-  // Run your local dev server before starting the tests
-  webServer: {
-    command: 'npx serve <your-app-name>',
-    url: baseUrl,
-    reuseExistingServer: !process.env.CI,
-  },
   use: {
     baseURL: baseUrl, // url playwright visits with `await page.goto('/')`;
   },
 });
 ```
+
+Leave `webServer` out when the tests run against a deployed environment.
+There's no local server for Playwright to start, and pointing `webServer.url` at a URL that already
+answers makes Playwright fail unless `reuseExistingServer` is `true`.
 
 By default Nx, provides a `nxE2EPreset` with predefined configuration for Playwright.
 
@@ -275,7 +280,7 @@ export default defineConfig({
   webServer: {
     command: 'npx nx serve <your-app-name>',
     url: baseURL,
-    reuseExistingServer: !process.env.CI,
+    reuseExistingServer: true,
     cwd: workspaceRoot,
   },
 });

--- a/astro-docs/src/content/docs/technologies/test-tools/playwright/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/playwright/introduction.mdoc
@@ -77,13 +77,19 @@ The `@nx/playwright/plugin` is configured in the `plugins` array in `nx.json`.
 
 The `targetName` and `ciTargetName` options control the name of the inferred Playwright tasks. The default names are `e2e` and `e2e-ci`.
 
-When your Playwright config declares a `webServer` that sets `reuseExistingServer` and whose
-`command` runs an Nx task, such as `npx nx run my-app:serve`, Nx runs that task as a dependency of
-the Playwright tasks instead of letting Playwright start its own server.
+When your Playwright config declares a `webServer` that sets `reuseExistingServer` to `true` and
+whose `command` runs an Nx task, Nx runs that task as a dependency of the Playwright tasks.
+The command must be exactly `nx run <project>:<target>` or `nx <target> <project>`, optionally
+prefixed by `npx`, `yarn`, `bun`, `pnpm`, `pnpm exec`, or `pnpx`.
+Nx doesn't recognize a command with extra arguments, such as `npx nx run my-app:serve --port=4200`.
+
 If that `webServer` also sets a `port` or a `url`, Nx infers an extra task that waits for the server
-to accept connections before the tests run.
+to be ready.
+Playwright then finds the server already running and reuses it.
+If the `webServer` sets neither, Playwright has nothing to check and starts its own server.
+
 The `webServerTimeout` option sets how long, in milliseconds, that task waits before failing.
-It defaults to the `timeout` configured on the `webServer`, or 60000 when neither is set.
+It defaults to each web server's configured `timeout`, or 60000 when neither is set.
 
 ### Splitting E2E tests
 

--- a/astro-docs/src/content/docs/technologies/test-tools/playwright/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/playwright/introduction.mdoc
@@ -77,6 +77,14 @@ The `@nx/playwright/plugin` is configured in the `plugins` array in `nx.json`.
 
 The `targetName` and `ciTargetName` options control the name of the inferred Playwright tasks. The default names are `e2e` and `e2e-ci`.
 
+When your Playwright config declares a `webServer` that sets `reuseExistingServer` and whose
+`command` runs an Nx task, such as `npx nx run my-app:serve`, Nx runs that task as a dependency of
+the Playwright tasks instead of letting Playwright start its own server.
+If that `webServer` also sets a `port` or a `url`, Nx infers an extra task that waits for the server
+to accept connections before the tests run.
+The `webServerTimeout` option sets how long, in milliseconds, that task waits before failing.
+It defaults to the `timeout` configured on the `webServer`, or 60000 when neither is set.
+
 ### Splitting E2E tests
 
 `@nx/playwright/plugin` uses Nx Atomizer to automatically split your e2e tests into smaller tasks for more efficient distribution in CI. Read more about the [Atomizer feature](/docs/features/ci-features/split-e2e-tasks).

--- a/astro-docs/src/content/docs/technologies/test-tools/playwright/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/playwright/introduction.mdoc
@@ -87,8 +87,10 @@ The Playwright docs suggest setting `reuseExistingServer` to `!process.env.CI`.
 Set it to `true` instead, since Nx already runs the web server as a task dependency.
 With `false`, Nx skips that task and Playwright starts its own server inside each Playwright task.
 
-If that `webServer` also sets a `port`, or a `url` with no `port`, Nx infers an extra task that waits
-for the server to be ready.
+If that `webServer` also sets a `port` number, Nx infers an extra task that waits for the server to
+be ready.
+It infers the same task from a `url` when the `webServer` leaves `port` unset, which is when
+Playwright checks the URL rather than the port.
 Playwright then finds the server already running and reuses it.
 If the `webServer` sets neither, Playwright has nothing to check and starts its own server.
 

--- a/astro-docs/src/content/docs/technologies/test-tools/playwright/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/playwright/introduction.mdoc
@@ -81,8 +81,9 @@ The `targetName` and `ciTargetName` options control the name of the inferred Pla
 
 When your Playwright config declares a `webServer` that sets `reuseExistingServer` to `true` and
 whose `command` runs an Nx task, Nx runs that task as a dependency of the Playwright tasks.
-The command must be exactly `nx run <project>:<target>` or `nx <target> <project>`, optionally
+The command must be `nx run <project>:<target>` or `nx <target> <project>`, optionally
 prefixed by `npx`, `yarn`, `bun`, `pnpm`, `pnpm exec`, or `pnpx`.
+A trailing `:<configuration>` in the `nx run` form is accepted, but the dependency runs the target without the configuration.
 Nx doesn't recognize a command with extra arguments, such as `npx nx run my-app:serve --port=4200`.
 
 The Playwright docs suggest setting `reuseExistingServer` to `!process.env.CI`.
@@ -95,16 +96,23 @@ It infers the same task from a `url` when the `webServer` leaves `port` unset, w
 Playwright checks the URL rather than the port.
 Playwright then finds the server already running and reuses it.
 If the `webServer` sets neither, Playwright has nothing to check and starts its own server.
+Nx doesn't infer the task dependency or the wait task for a `webServer` that sets `wait.stdout` or `wait.stderr`.
+Playwright treats matching output from the server process it starts as the readiness signal and can capture values from it into the environment, so Nx leaves starting that server to Playwright.
 
 The `webServerTimeout` option sets how long, in milliseconds, that task waits before failing.
 It defaults to each web server's configured `timeout`, or 60000 when neither is set.
 
 Set the `waitForWebServer` option to `false` to opt out of that task.
 Nx still runs the web server as a task dependency, and the tests fall back to Playwright's own `reuseExistingServer` probe.
+The option also selects the config evaluation the dependencies come from: with it on, the `webServer` commands resolve under the env the Playwright task runs with; with it off, under the env Nx computes the project graph with.
 
 The readiness address comes from evaluating the Playwright config while Nx computes the project graph.
-Nx does not track a variable the config reads straight from the shell environment, so changing it does not refresh an already-cached address.
-Run `nx reset` after changing such a variable, or set the variable in an env file such as `.env`, which Nx tracks.
+Nx caches the result and rebuilds it when an env file the Playwright task would load, such as `.env` or `.env.e2e`, changes.
+A variable set only in the shell is not part of that cache.
+Changing it does not refresh an already-cached address, and shells holding different values share whichever address was cached last.
+Set such a variable in an env file instead; `nx reset` also discards the cached address.
+A task dependency cannot carry a target configuration, so the address is always inferred without one and a configuration-scoped env file such as `.env.e2e.production` never affects it.
+Nx re-evaluates the config under the task's env only when the graph-time evaluation found a `webServer`, so a `webServer` that only exists under the task's env is not detected.
 
 ### Splitting E2E tests
 

--- a/astro-docs/src/content/docs/technologies/test-tools/playwright/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/playwright/introduction.mdoc
@@ -94,6 +94,8 @@ With `false`, Nx skips that task and Playwright starts its own server inside eac
 If that `webServer` also sets a `port` number, Nx infers an extra task, named
 `<targetName>--wait-for-webserver` (`e2e--wait-for-webserver` by default), that waits for the
 server to be ready.
+The atomized CI tasks share that task, unless they resolve a different address, in which case
+they get their own `<ciTargetName>--wait-for-webserver` task.
 It infers the same task from a `url` when the `webServer` leaves `port` unset, which is when
 Playwright checks the URL rather than the port.
 Playwright then finds the server already running and reuses it.
@@ -117,16 +119,17 @@ dependency is inferred from can itself read that env.
 The readiness address comes from evaluating the Playwright config while Nx computes the project graph.
 Nx caches the result and rebuilds it when an env file the Playwright task would load, such as
 `.env` or `.env.e2e`, changes.
-An env file listed in `.nxignore` is an exception: Nx does not see it change, so the cached
+An env file listed in `.nxignore` is an exception: Nx doesn't see it change, so the cached
 result stays stale.
 A variable set only in the shell is part of that cache too, so changing it re-infers the address.
 The exception is variables Nx filters out of the project graph environment, such as terminal
 session details or CI platform internals.
-Changing one of those does not re-infer the address.
+Changing one of those doesn't re-infer the address.
+`CI` itself isn't filtered: changing it re-infers the address.
 Running `nx reset` also discards the cached address.
 Files the config imports from outside its project, such as a shared helper in `tools/`, are not
 part of the cache either.
-Editing one does not refresh an already-cached address.
+Editing one doesn't refresh an already-cached address.
 Run `nx reset` to re-infer it.
 A task dependency cannot carry a target configuration, so the address is always inferred without
 one and a configuration-scoped env file such as `.env.e2e.production` never affects it.

--- a/astro-docs/src/content/docs/technologies/test-tools/playwright/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/playwright/introduction.mdoc
@@ -79,13 +79,19 @@ The `@nx/playwright/plugin` is configured in the `plugins` array in `nx.json`.
 
 The `targetName` and `ciTargetName` options control the name of the inferred Playwright tasks. The default names are `e2e` and `e2e-ci`.
 
-When your Playwright config declares a `webServer` that sets `reuseExistingServer` and whose
-`command` runs an Nx task, such as `npx nx run my-app:serve`, Nx runs that task as a dependency of
-the Playwright tasks instead of letting Playwright start its own server.
+When your Playwright config declares a `webServer` that sets `reuseExistingServer` to `true` and
+whose `command` runs an Nx task, Nx runs that task as a dependency of the Playwright tasks.
+The command must be exactly `nx run <project>:<target>` or `nx <target> <project>`, optionally
+prefixed by `npx`, `yarn`, `bun`, `pnpm`, `pnpm exec`, or `pnpx`.
+Nx doesn't recognize a command with extra arguments, such as `npx nx run my-app:serve --port=4200`.
+
 If that `webServer` also sets a `port` or a `url`, Nx infers an extra task that waits for the server
-to accept connections before the tests run.
+to be ready.
+Playwright then finds the server already running and reuses it.
+If the `webServer` sets neither, Playwright has nothing to check and starts its own server.
+
 The `webServerTimeout` option sets how long, in milliseconds, that task waits before failing.
-It defaults to the `timeout` configured on the `webServer`, or 60000 when neither is set.
+It defaults to each web server's configured `timeout`, or 60000 when neither is set.
 
 ### Splitting E2E tests
 

--- a/astro-docs/src/content/docs/technologies/test-tools/playwright/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/playwright/introduction.mdoc
@@ -89,8 +89,10 @@ The Playwright docs suggest setting `reuseExistingServer` to `!process.env.CI`.
 Set it to `true` instead, since Nx already runs the web server as a task dependency.
 With `false`, Nx skips that task and Playwright starts its own server inside each Playwright task.
 
-If that `webServer` also sets a `port`, or a `url` with no `port`, Nx infers an extra task that waits
-for the server to be ready.
+If that `webServer` also sets a `port` number, Nx infers an extra task that waits for the server to
+be ready.
+It infers the same task from a `url` when the `webServer` leaves `port` unset, which is when
+Playwright checks the URL rather than the port.
 Playwright then finds the server already running and reuses it.
 If the `webServer` sets neither, Playwright has nothing to check and starts its own server.
 

--- a/astro-docs/src/content/docs/technologies/test-tools/playwright/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/playwright/introduction.mdoc
@@ -99,6 +99,13 @@ If the `webServer` sets neither, Playwright has nothing to check and starts its 
 The `webServerTimeout` option sets how long, in milliseconds, that task waits before failing.
 It defaults to each web server's configured `timeout`, or 60000 when neither is set.
 
+Set the `waitForWebServer` option to `false` to opt out of that task.
+Nx still runs the web server as a task dependency, and the tests fall back to Playwright's own `reuseExistingServer` probe.
+
+The readiness address comes from evaluating the Playwright config while Nx computes the project graph.
+Nx does not track a variable the config reads straight from the shell environment, so changing it does not refresh an already-cached address.
+Run `nx reset` after changing such a variable, or set the variable in an env file such as `.env`, which Nx tracks.
+
 ### Splitting E2E tests
 
 The `targetName` task runs the complete Playwright suite and caches the configured test and reporter

--- a/astro-docs/src/content/docs/technologies/test-tools/playwright/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/playwright/introduction.mdoc
@@ -111,8 +111,11 @@ Nx caches the result and rebuilds it when an env file the Playwright task would 
 A variable set only in the shell is not part of that cache.
 Changing it does not refresh an already-cached address, and shells holding different values share whichever address was cached last.
 Set such a variable in an env file instead; `nx reset` also discards the cached address.
+Files the config imports from outside its project, such as a shared helper in `tools/`, are not part of the cache either.
+Editing one does not refresh an already-cached address; run `nx reset` to re-infer it.
 A task dependency cannot carry a target configuration, so the address is always inferred without one and a configuration-scoped env file such as `.env.e2e.production` never affects it.
 Nx re-evaluates the config under the task's env only when the graph-time evaluation found a `webServer`, so a `webServer` that only exists under the task's env is not detected.
+If that re-evaluation fails or times out, Nx logs a warning, infers the task dependencies from the graph-time evaluation, and skips the wait task.
 
 ### Splitting E2E tests
 

--- a/astro-docs/src/content/docs/technologies/test-tools/playwright/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/playwright/introduction.mdoc
@@ -104,7 +104,6 @@ It defaults to each web server's configured `timeout`, or 60000 when neither is 
 
 Set the `waitForWebServer` option to `false` to opt out of that task.
 Nx still runs the web server as a task dependency, and the tests fall back to Playwright's own `reuseExistingServer` probe.
-The option also selects the config evaluation the dependencies come from: with it on, the `webServer` commands resolve under the env the Playwright task runs with; with it off, under the env Nx computes the project graph with.
 
 The readiness address comes from evaluating the Playwright config while Nx computes the project graph.
 Nx caches the result and rebuilds it when an env file the Playwright task would load, such as `.env` or `.env.e2e`, changes.

--- a/astro-docs/src/content/docs/technologies/test-tools/playwright/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/playwright/introduction.mdoc
@@ -106,6 +106,14 @@ Nx doesn't infer the task dependency or the wait task for a `webServer` that set
 or `wait.stderr`.
 Playwright treats matching output from the server process it starts as the readiness signal and
 can capture values from it into the environment, so Nx leaves starting that server to Playwright.
+The same applies to a `webServer` that sets `env`: only Playwright passes that environment to
+the command it starts, so a task-started server would run without it.
+Nx also skips the wait task, keeping the task dependency, when an env file the Playwright task
+loads changes how the server would be probed: through the proxy variables (`HTTP_PROXY`,
+`HTTPS_PROXY`, `ALL_PROXY`, `NO_PROXY`) for a `url`, or `NODE_EXTRA_CA_CERTS` and
+`NODE_TLS_REJECT_UNAUTHORIZED` for an `https` one.
+The wait task runs with its own environment rather than the Playwright task's, so it can't
+reproduce that probe and the tests fall back to Playwright's own `reuseExistingServer` probe.
 
 The `webServerTimeout` option sets how long, in milliseconds, that task waits before failing.
 It defaults to each web server's configured `timeout`, or 60000 when neither is set.
@@ -135,6 +143,9 @@ A task dependency cannot carry a target configuration, so the address is always 
 one and a configuration-scoped env file such as `.env.e2e.production` never affects it.
 Nx re-evaluates the config under the task's env only when the graph-time evaluation found a
 `webServer`, so a `webServer` that only exists under the task's env is not detected.
+That re-evaluation runs the config in a child process started under the task's env, so an env
+file that sets Node startup options such as `NODE_OPTIONS` has them applied while Nx computes
+the project graph, not only when the task runs.
 If that re-evaluation fails or times out, Nx logs a warning, infers the task dependencies from
 the graph-time evaluation, and skips the wait task.
 The failed result is not cached, so the next project graph computation retries the evaluation.

--- a/astro-docs/src/content/docs/technologies/test-tools/playwright/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/playwright/introduction.mdoc
@@ -85,8 +85,12 @@ The command must be exactly `nx run <project>:<target>` or `nx <target> <project
 prefixed by `npx`, `yarn`, `bun`, `pnpm`, `pnpm exec`, or `pnpx`.
 Nx doesn't recognize a command with extra arguments, such as `npx nx run my-app:serve --port=4200`.
 
-If that `webServer` also sets a `port` or a `url`, Nx infers an extra task that waits for the server
-to be ready.
+The Playwright docs suggest setting `reuseExistingServer` to `!process.env.CI`.
+Set it to `true` instead, since Nx already runs the web server as a task dependency.
+With `false`, Nx skips that task and Playwright starts its own server inside each Playwright task.
+
+If that `webServer` also sets a `port`, or a `url` with no `port`, Nx infers an extra task that waits
+for the server to be ready.
 Playwright then finds the server already running and reuses it.
 If the `webServer` sets neither, Playwright has nothing to check and starts its own server.
 
@@ -119,10 +123,12 @@ To generate an E2E project for an existing project, run the following generator
 nx g @nx/playwright:configuration --project=your-app-name
 ```
 
-Optionally, you can use the `--webServerCommand` and `--webServerAddress` option, to auto setup the [web server option](https://playwright.dev/docs/test-webserver) in the playwright config
+The generator prompts for the [web server option](https://playwright.dev/docs/test-webserver) to add
+to the Playwright config.
+Pass `--webServerCommand` and `--webServerAddress` to skip the prompts.
 
 ```shell
-nx g @nx/playwright:configuration --project=your-app-name --webServerCommand="npx serve your-project-name" --webServerAddress="http://localhost:4200"
+nx g @nx/playwright:configuration --project=your-app-name --webServerCommand="npx nx serve your-project-name" --webServerAddress="http://localhost:4200"
 ```
 
 ### Testing applications
@@ -215,9 +221,9 @@ export default defineConfig({
 
   // Run your local dev server before starting the tests
   webServer: {
-    command: 'npx serve <your-app-name>',
+    command: 'npx nx serve <your-app-name>',
     url: 'http://localhost:4200',
-    reuseExistingServer: !process.env.CI,
+    reuseExistingServer: true,
   },
   use: {
     baseURL: 'http://localhost:4200', // url playwright visits with `await page.goto('/')`;
@@ -231,24 +237,23 @@ In order to set different `baseURL` values for different environments you can pa
 import { defineConfig } from '@playwright/test';
 
 const baseUrl =
-  (process.env.BASE_URL ?? process.env.CI)
+  process.env.BASE_URL ??
+  (process.env.CI
     ? 'https://some-staging-url.example.com'
-    : 'http://localhost:4200';
+    : 'http://localhost:4200');
 
 export default defineConfig({
   // Rest of your config...
 
-  // Run your local dev server before starting the tests
-  webServer: {
-    command: 'npx serve <your-app-name>',
-    url: baseUrl,
-    reuseExistingServer: !process.env.CI,
-  },
   use: {
     baseURL: baseUrl, // url playwright visits with `await page.goto('/')`;
   },
 });
 ```
+
+Leave `webServer` out when the tests run against a deployed environment.
+There's no local server for Playwright to start, and pointing `webServer.url` at a URL that already
+answers makes Playwright fail unless `reuseExistingServer` is `true`.
 
 By default Nx, provides a `nxE2EPreset` with predefined configuration for Playwright.
 
@@ -281,7 +286,7 @@ export default defineConfig({
   webServer: {
     command: 'npx nx serve <your-app-name>',
     url: baseURL,
-    reuseExistingServer: !process.env.CI,
+    reuseExistingServer: true,
     cwd: workspaceRoot,
   },
 });

--- a/astro-docs/src/content/docs/technologies/test-tools/playwright/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/playwright/introduction.mdoc
@@ -83,39 +83,59 @@ When your Playwright config declares a `webServer` that sets `reuseExistingServe
 whose `command` runs an Nx task, Nx runs that task as a dependency of the Playwright tasks.
 The command must be `nx run <project>:<target>` or `nx <target> <project>`, optionally
 prefixed by `npx`, `yarn`, `bun`, `pnpm`, `pnpm exec`, or `pnpx`.
-A trailing `:<configuration>` in the `nx run` form is accepted, but the dependency runs the target without the configuration.
+A trailing `:<configuration>` in the `nx run` form is accepted, but the dependency runs the
+target without the configuration.
 Nx doesn't recognize a command with extra arguments, such as `npx nx run my-app:serve --port=4200`.
 
 The Playwright docs suggest setting `reuseExistingServer` to `!process.env.CI`.
 Set it to `true` instead, since Nx already runs the web server as a task dependency.
 With `false`, Nx skips that task and Playwright starts its own server inside each Playwright task.
 
-If that `webServer` also sets a `port` number, Nx infers an extra task that waits for the server to
-be ready.
+If that `webServer` also sets a `port` number, Nx infers an extra task, named
+`<targetName>--wait-for-webserver` (`e2e--wait-for-webserver` by default), that waits for the
+server to be ready.
 It infers the same task from a `url` when the `webServer` leaves `port` unset, which is when
 Playwright checks the URL rather than the port.
 Playwright then finds the server already running and reuses it.
 If the `webServer` sets neither, Playwright has nothing to check and starts its own server.
-Nx also skips the wait task for a `command` with a trailing `:<configuration>`: the dependency starts the server without the configuration, so it may not listen at the configured address.
-Nx doesn't infer the task dependency or the wait task for a `webServer` that sets `wait.stdout` or `wait.stderr`.
-Playwright treats matching output from the server process it starts as the readiness signal and can capture values from it into the environment, so Nx leaves starting that server to Playwright.
+Nx also skips the wait task for a `command` with a trailing `:<configuration>`: the dependency
+starts the server without the configuration, so it may not listen at the configured address.
+Nx doesn't infer the task dependency or the wait task for a `webServer` that sets `wait.stdout`
+or `wait.stderr`.
+Playwright treats matching output from the server process it starts as the readiness signal and
+can capture values from it into the environment, so Nx leaves starting that server to Playwright.
 
 The `webServerTimeout` option sets how long, in milliseconds, that task waits before failing.
 It defaults to each web server's configured `timeout`, or 60000 when neither is set.
 
 Set the `waitForWebServer` option to `false` to opt out of that task.
-Nx still runs the web server as a task dependency, and the tests fall back to Playwright's own `reuseExistingServer` probe.
+Nx still runs the web server as a task dependency, and the tests fall back to Playwright's own
+`reuseExistingServer` probe.
+Nx also still re-evaluates the config under the task's env, because the `webServer.command` the
+dependency is inferred from can itself read that env.
 
 The readiness address comes from evaluating the Playwright config while Nx computes the project graph.
-Nx caches the result and rebuilds it when an env file the Playwright task would load, such as `.env` or `.env.e2e`, changes.
-A variable set only in the shell is not part of that cache.
-Changing it does not refresh an already-cached address, and shells holding different values share whichever address was cached last.
-Set such a variable in an env file instead; `nx reset` also discards the cached address.
-Files the config imports from outside its project, such as a shared helper in `tools/`, are not part of the cache either.
-Editing one does not refresh an already-cached address; run `nx reset` to re-infer it.
-A task dependency cannot carry a target configuration, so the address is always inferred without one and a configuration-scoped env file such as `.env.e2e.production` never affects it.
-Nx re-evaluates the config under the task's env only when the graph-time evaluation found a `webServer`, so a `webServer` that only exists under the task's env is not detected.
-If that re-evaluation fails or times out, Nx logs a warning, infers the task dependencies from the graph-time evaluation, and skips the wait task.
+Nx caches the result and rebuilds it when an env file the Playwright task would load, such as
+`.env` or `.env.e2e`, changes.
+An env file listed in `.nxignore` is an exception: Nx does not see it change, so the cached
+result stays stale.
+Apart from `CI`, which Nx folds into the cache key, a variable set only in the shell is not part
+of that cache.
+Changing it does not refresh an already-cached address, and shells holding different values
+share whichever address was cached last.
+Set such a variable in an env file instead.
+Running `nx reset` also discards the cached address.
+Files the config imports from outside its project, such as a shared helper in `tools/`, are not
+part of the cache either.
+Editing one does not refresh an already-cached address.
+Run `nx reset` to re-infer it.
+A task dependency cannot carry a target configuration, so the address is always inferred without
+one and a configuration-scoped env file such as `.env.e2e.production` never affects it.
+Nx re-evaluates the config under the task's env only when the graph-time evaluation found a
+`webServer`, so a `webServer` that only exists under the task's env is not detected.
+If that re-evaluation fails or times out, Nx logs a warning, infers the task dependencies from
+the graph-time evaluation, and skips the wait task.
+The failed result is not cached, so the next project graph computation retries the evaluation.
 
 ### Splitting E2E tests
 

--- a/astro-docs/src/content/docs/technologies/test-tools/playwright/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/playwright/introduction.mdoc
@@ -79,6 +79,14 @@ The `@nx/playwright/plugin` is configured in the `plugins` array in `nx.json`.
 
 The `targetName` and `ciTargetName` options control the name of the inferred Playwright tasks. The default names are `e2e` and `e2e-ci`.
 
+When your Playwright config declares a `webServer` that sets `reuseExistingServer` and whose
+`command` runs an Nx task, such as `npx nx run my-app:serve`, Nx runs that task as a dependency of
+the Playwright tasks instead of letting Playwright start its own server.
+If that `webServer` also sets a `port` or a `url`, Nx infers an extra task that waits for the server
+to accept connections before the tests run.
+The `webServerTimeout` option sets how long, in milliseconds, that task waits before failing.
+It defaults to the `timeout` configured on the `webServer`, or 60000 when neither is set.
+
 ### Splitting E2E tests
 
 The `targetName` task runs the complete Playwright suite and caches the configured test and reporter

--- a/astro-docs/src/content/docs/technologies/test-tools/playwright/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/playwright/introduction.mdoc
@@ -96,6 +96,7 @@ It infers the same task from a `url` when the `webServer` leaves `port` unset, w
 Playwright checks the URL rather than the port.
 Playwright then finds the server already running and reuses it.
 If the `webServer` sets neither, Playwright has nothing to check and starts its own server.
+Nx also skips the wait task for a `command` with a trailing `:<configuration>`: the dependency starts the server without the configuration, so it may not listen at the configured address.
 Nx doesn't infer the task dependency or the wait task for a `webServer` that sets `wait.stdout` or `wait.stderr`.
 Playwright treats matching output from the server process it starts as the readiness signal and can capture values from it into the environment, so Nx leaves starting that server to Playwright.
 

--- a/astro-docs/src/content/docs/technologies/test-tools/playwright/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/playwright/introduction.mdoc
@@ -119,11 +119,10 @@ Nx caches the result and rebuilds it when an env file the Playwright task would 
 `.env` or `.env.e2e`, changes.
 An env file listed in `.nxignore` is an exception: Nx does not see it change, so the cached
 result stays stale.
-Apart from `CI`, which Nx folds into the cache key, a variable set only in the shell is not part
-of that cache.
-Changing it does not refresh an already-cached address, and shells holding different values
-share whichever address was cached last.
-Set such a variable in an env file instead.
+A variable set only in the shell is part of that cache too, so changing it re-infers the address.
+The exception is variables Nx filters out of the project graph environment, such as terminal
+session details or CI platform internals.
+Changing one of those does not re-infer the address.
 Running `nx reset` also discards the cached address.
 Files the config imports from outside its project, such as a shared helper in `tools/`, are not
 part of the cache either.

--- a/astro-docs/src/content/docs/technologies/test-tools/playwright/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/playwright/introduction.mdoc
@@ -81,74 +81,24 @@ The `targetName` and `ciTargetName` options control the name of the inferred Pla
 
 When your Playwright config declares a `webServer` that sets `reuseExistingServer` to `true` and
 whose `command` runs an Nx task, Nx runs that task as a dependency of the Playwright tasks.
-The command must be `nx run <project>:<target>` or `nx <target> <project>`, optionally
-prefixed by `npx`, `yarn`, `bun`, `pnpm`, `pnpm exec`, or `pnpx`.
-A trailing `:<configuration>` in the `nx run` form is accepted, but the dependency runs the
-target without the configuration.
-Nx doesn't recognize a command with extra arguments, such as `npx nx run my-app:serve --port=4200`.
+The command must be `nx run <project>:<target>` or `nx <target> <project>`, optionally prefixed
+by a package manager runner such as `npx` or `pnpm exec`, with no extra arguments.
 
 The Playwright docs suggest setting `reuseExistingServer` to `!process.env.CI`.
 Set it to `true` instead, since Nx already runs the web server as a task dependency.
 With `false`, Nx skips that task and Playwright starts its own server inside each Playwright task.
 
-If that `webServer` also sets a `port` number, Nx infers an extra task, named
+If that `webServer` also sets a `port` or `url`, Nx infers an extra task, named
 `<targetName>--wait-for-webserver` (`e2e--wait-for-webserver` by default), that waits for the
 server to be ready.
 The atomized CI tasks share that task, unless they resolve a different address, in which case
 they get their own `<ciTargetName>--wait-for-webserver` task.
-It infers the same task from a `url` when the `webServer` leaves `port` unset, which is when
-Playwright checks the URL rather than the port.
 Playwright then finds the server already running and reuses it.
-If the `webServer` sets neither, Playwright has nothing to check and starts its own server.
-Nx also skips the wait task for a `command` with a trailing `:<configuration>`: the dependency
-starts the server without the configuration, so it may not listen at the configured address.
-Nx doesn't infer the task dependency or the wait task for a `webServer` that sets `wait.stdout`
-or `wait.stderr`.
-Playwright treats matching output from the server process it starts as the readiness signal and
-can capture values from it into the environment, so Nx leaves starting that server to Playwright.
-The same applies to a `webServer` that sets `env`: only Playwright passes that environment to
-the command it starts, so a task-started server would run without it.
-Nx also skips the wait task, keeping the task dependency, when an env file the Playwright task
-loads changes how the server would be probed: through the proxy variables (`HTTP_PROXY`,
-`HTTPS_PROXY`, `ALL_PROXY`, `NO_PROXY`) for a `url`, or `NODE_EXTRA_CA_CERTS` and
-`NODE_TLS_REJECT_UNAUTHORIZED` for an `https` one.
-The wait task runs with its own environment rather than the Playwright task's, so it can't
-reproduce that probe and the tests fall back to Playwright's own `reuseExistingServer` probe.
 
 The `webServerTimeout` option sets how long, in milliseconds, that task waits before failing.
-It defaults to each web server's configured `timeout`, or 60000 when neither is set.
-
 Set the `waitForWebServer` option to `false` to opt out of that task.
-Nx still runs the web server as a task dependency, and the tests fall back to Playwright's own
-`reuseExistingServer` probe.
-Nx also still re-evaluates the config under the task's env, because the `webServer.command` the
-dependency is inferred from can itself read that env.
-
-The readiness address comes from evaluating the Playwright config while Nx computes the project graph.
-Nx caches the result and rebuilds it when an env file the Playwright task would load, such as
-`.env` or `.env.e2e`, changes.
-An env file listed in `.nxignore` is an exception: Nx doesn't see it change, so the cached
-result stays stale.
-A variable set only in the shell is part of that cache too, so changing it re-infers the address.
-The exception is variables Nx filters out of the project graph environment, such as terminal
-session details or CI platform internals.
-Changing one of those doesn't re-infer the address.
-`CI` itself isn't filtered: changing it re-infers the address.
-Running `nx reset` also discards the cached address.
-Files the config imports from outside its project, such as a shared helper in `tools/`, are not
-part of the cache either.
-Editing one doesn't refresh an already-cached address.
-Run `nx reset` to re-infer it.
-A task dependency cannot carry a target configuration, so the address is always inferred without
-one and a configuration-scoped env file such as `.env.e2e.production` never affects it.
-Nx re-evaluates the config under the task's env only when the graph-time evaluation found a
-`webServer`, so a `webServer` that only exists under the task's env is not detected.
-That re-evaluation runs the config in a child process started under the task's env, so an env
-file that sets Node startup options such as `NODE_OPTIONS` has them applied while Nx computes
-the project graph, not only when the task runs.
-If that re-evaluation fails or times out, Nx logs a warning, infers the task dependencies from
-the graph-time evaluation, and skips the wait task.
-The failed result is not cached, so the next project graph computation retries the evaluation.
+For the `webServer` shapes Nx leaves to Playwright and for how Nx caches and re-infers the server
+address, see [Playwright web server readiness](/docs/kb/playwright-web-server-readiness).
 
 ### Splitting E2E tests
 

--- a/astro-docs/src/content/docs/technologies/test-tools/playwright/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/playwright/introduction.mdoc
@@ -91,8 +91,9 @@ With `false`, Nx skips that task and Playwright starts its own server inside eac
 If that `webServer` also sets a `port` or `url`, Nx infers an extra task, named
 `<targetName>--wait-for-webserver` (`e2e--wait-for-webserver` by default), that waits for the
 server to be ready.
-The atomized CI tasks share that task, unless they resolve a different address, in which case
-they get their own `<ciTargetName>--wait-for-webserver` task.
+The atomized CI tasks share that task when it would wait for the same servers, depend on the
+same serve tasks, and load the same env files.
+Otherwise they get their own `<ciTargetName>--wait-for-webserver` task.
 Playwright then finds the server already running and reuses it.
 
 The `webServerTimeout` option sets how long, in milliseconds, that task waits before failing.

--- a/e2e/react/src/playwright.test.ts
+++ b/e2e/react/src/playwright.test.ts
@@ -1,4 +1,5 @@
 import {
+  createFile,
   runCLI,
   runE2ETests,
   cleanupProject,
@@ -23,6 +24,35 @@ describe('React Playwright e2e tests', () => {
   });
 
   afterAll(() => cleanupProject());
+
+  it('resolves the task dotenv env when baking the web server readiness gate', () => {
+    const e2eProject = `${appName}-e2e`;
+    const configPath = `${e2eProject}/playwright.config.mts`;
+    const gateAddress = 'http://localhost:4301';
+
+    // Write .env before editing the config: the config edit is what triggers
+    // the graph recompute, so the dotenv file has to be on disk beforehand.
+    createFile(`${e2eProject}/.env`, `BASE_URL=${gateAddress}\n`);
+    let originalConfig = '';
+    updateFile(configPath, (content) => {
+      originalConfig = content;
+      return content.replace(/url: 'http:\/\/[^']*'/, 'url: baseURL');
+    });
+
+    try {
+      const project = JSON.parse(runCLI(`show project ${e2eProject} --json`));
+      const gateTarget = Object.keys(project.targets).find((t) =>
+        t.endsWith('--wait-for-webserver')
+      );
+      expect(gateTarget).toBeDefined();
+      expect(project.targets[gateTarget].options.servers[0].url).toBe(
+        gateAddress
+      );
+    } finally {
+      updateFile(configPath, originalConfig);
+      updateFile(`${e2eProject}/.env`, '');
+    }
+  });
 
   it('should execute e2e tests using playwright', () => {
     if (runE2ETests()) {

--- a/e2e/react/src/playwright.test.ts
+++ b/e2e/react/src/playwright.test.ts
@@ -56,6 +56,41 @@ describe('React Playwright e2e tests', () => {
     }
   });
 
+  it('re-resolves the readiness gate when the ambient env changes between runs', () => {
+    const e2eProject = `${appName}-e2e`;
+    const configPath = `${e2eProject}/playwright.config.mts`;
+
+    let originalConfig = '';
+    updateFile(configPath, (content) => {
+      originalConfig = content;
+      return content.replace(/url: 'http:\/\/[^']*'/, 'url: baseURL');
+    });
+
+    try {
+      const showGateUrl = (env: Record<string, string>) => {
+        const project = JSON.parse(
+          runCLI(`show project ${e2eProject} --json`, { env })
+        );
+        const gateTarget = Object.keys(project.targets).find((t) =>
+          t.endsWith('--wait-for-webserver')
+        );
+        expect(gateTarget).toBeDefined();
+        return project.targets[gateTarget].options.servers[0].url;
+      };
+
+      // Sequential daemon clients with different ambient env: the second run
+      // must not be served the first run's cached gate.
+      expect(showGateUrl({ BASE_URL: 'http://localhost:4301' })).toBe(
+        'http://localhost:4301'
+      );
+      expect(showGateUrl({ BASE_URL: 'http://localhost:4302' })).toBe(
+        'http://localhost:4302'
+      );
+    } finally {
+      updateFile(configPath, originalConfig);
+    }
+  });
+
   it('should execute e2e tests using playwright', async () => {
     if (await runE2ETests()) {
       const result = runCLI(`e2e ${appName}-e2e --verbose`);

--- a/e2e/react/src/playwright.test.ts
+++ b/e2e/react/src/playwright.test.ts
@@ -1,4 +1,5 @@
 import {
+  createFile,
   runCLI,
   runE2ETests,
   cleanupProject,
@@ -23,6 +24,35 @@ describe('React Playwright e2e tests', () => {
   });
 
   afterAll(() => cleanupProject());
+
+  it('resolves the task dotenv env when baking the web server readiness gate', () => {
+    const e2eProject = `${appName}-e2e`;
+    const configPath = `${e2eProject}/playwright.config.mts`;
+    const gateAddress = 'http://localhost:4301';
+
+    // Write .env before editing the config: the config edit is what triggers
+    // the graph recompute, so the dotenv file has to be on disk beforehand.
+    createFile(`${e2eProject}/.env`, `BASE_URL=${gateAddress}\n`);
+    let originalConfig = '';
+    updateFile(configPath, (content) => {
+      originalConfig = content;
+      return content.replace(/url: 'http:\/\/[^']*'/, 'url: baseURL');
+    });
+
+    try {
+      const project = JSON.parse(runCLI(`show project ${e2eProject} --json`));
+      const gateTarget = Object.keys(project.targets).find((t) =>
+        t.endsWith('--wait-for-webserver')
+      );
+      expect(gateTarget).toBeDefined();
+      expect(project.targets[gateTarget].options.servers[0].url).toBe(
+        gateAddress
+      );
+    } finally {
+      updateFile(configPath, originalConfig);
+      updateFile(`${e2eProject}/.env`, '');
+    }
+  });
 
   it('should execute e2e tests using playwright', async () => {
     if (await runE2ETests()) {

--- a/e2e/react/src/playwright.test.ts
+++ b/e2e/react/src/playwright.test.ts
@@ -4,6 +4,7 @@ import {
   runE2ETests,
   cleanupProject,
   newProject,
+  removeFile,
   uniq,
   updateFile,
 } from '@nx/e2e-utils';
@@ -30,8 +31,9 @@ describe('React Playwright e2e tests', () => {
     const configPath = `${e2eProject}/playwright.config.mts`;
     const gateAddress = 'http://localhost:4301';
 
-    // Write .env before editing the config: the config edit is what triggers
-    // the graph recompute, so the dotenv file has to be on disk beforehand.
+    // Write .env before editing the config: both writes trigger a graph
+    // recompute, and this order guarantees the recompute the assertion reads
+    // has seen the dotenv file regardless of how the watcher batches them.
     createFile(`${e2eProject}/.env`, `BASE_URL=${gateAddress}\n`);
     let originalConfig = '';
     updateFile(configPath, (content) => {
@@ -50,7 +52,7 @@ describe('React Playwright e2e tests', () => {
       );
     } finally {
       updateFile(configPath, originalConfig);
-      updateFile(`${e2eProject}/.env`, '');
+      removeFile(`${e2eProject}/.env`);
     }
   });
 

--- a/e2e/react/src/playwright.test.ts
+++ b/e2e/react/src/playwright.test.ts
@@ -1,10 +1,13 @@
 import {
   createFile,
+  fileExists,
+  readFile,
   runCLI,
   runE2ETests,
   cleanupProject,
   newProject,
   removeFile,
+  tmpProjPath,
   uniq,
   updateFile,
 } from '@nx/e2e-utils';
@@ -97,6 +100,55 @@ describe('React Playwright e2e tests', () => {
       expect(result).toContain(
         `Successfully ran target e2e for project ${appName}-e2e`
       );
+    }
+  });
+
+  it('lets Playwright reuse the server the readiness gate waited for instead of starting its own', async () => {
+    if (!(await runE2ETests('playwright'))) {
+      return;
+    }
+    const e2eProject = `${appName}-e2e`;
+    const [, serveTarget] =
+      readFile(`${e2eProject}/playwright.config.mts`).match(
+        new RegExp(`nx run ${appName}:(\\S+)'`)
+      ) ?? [];
+    expect(serveTarget).toBeDefined();
+    // Delay the server so Playwright's own probe surely misses when nothing
+    // waited for the server first; the argument would break command inference
+    // on the webServer command, so it goes on the target instead. A different
+    // command replaces the inferred target rather than merging into it, so
+    // the target is spelled out.
+    const projectConfig = fileExists(tmpProjPath(`${appName}/project.json`))
+      ? `${appName}/project.json`
+      : `${appName}/package.json`;
+    let originalProjectConfig = '';
+    updateFile(projectConfig, (content) => {
+      originalProjectConfig = content;
+      const json = JSON.parse(content);
+      const targets = projectConfig.endsWith('package.json')
+        ? ((json.nx ??= {}).targets ??= {})
+        : (json.targets ??= {});
+      targets[serveTarget] = {
+        command: 'node -e "setTimeout(() => {}, 5000)" && vite',
+        options: { cwd: appName },
+        continuous: true,
+      };
+      return JSON.stringify(json, null, 2);
+    });
+
+    try {
+      // Playwright logs which of the two it did under this debug scope. The
+      // atomized target is refused without Nx Cloud unless told otherwise.
+      for (const target of ['e2e', 'e2e-ci']) {
+        const result = runCLI(`run ${e2eProject}:${target}`, {
+          env: { DEBUG: 'pw:webserver', NX_SKIP_ATOMIZER_VALIDATION: 'true' },
+          redirectStderr: true,
+        });
+        expect(result).toContain('WebServer is already available');
+        expect(result).not.toContain('Starting WebServer process');
+      }
+    } finally {
+      updateFile(projectConfig, originalProjectConfig);
     }
   });
 

--- a/e2e/react/src/playwright.test.ts
+++ b/e2e/react/src/playwright.test.ts
@@ -2,6 +2,7 @@ import {
   createFile,
   fileExists,
   readFile,
+  reservePort,
   runCLI,
   runE2ETests,
   cleanupProject,
@@ -108,11 +109,20 @@ describe('React Playwright e2e tests', () => {
       return;
     }
     const e2eProject = `${appName}-e2e`;
+    const port = await reservePort();
     const [, serveTarget] =
       readFile(`${e2eProject}/playwright.config.mts`).match(
         new RegExp(`nx run ${appName}:(\\S+)'`)
       ) ?? [];
     expect(serveTarget).toBeDefined();
+    let originalConfig = '';
+    updateFile(`${e2eProject}/playwright.config.mts`, (content) => {
+      originalConfig = content;
+      return content.replace(
+        /url: 'http:\/\/[^']*'/,
+        `url: 'http://localhost:${port}'`
+      );
+    });
     // Delay the server so Playwright's own probe surely misses when nothing
     // waited for the server first; the argument would break command inference
     // on the webServer command, so it goes on the target instead. A different
@@ -149,6 +159,7 @@ describe('React Playwright e2e tests', () => {
       }
     } finally {
       updateFile(projectConfig, originalProjectConfig);
+      updateFile(`${e2eProject}/playwright.config.mts`, originalConfig);
     }
   });
 

--- a/e2e/react/src/playwright.test.ts
+++ b/e2e/react/src/playwright.test.ts
@@ -155,7 +155,11 @@ describe('React Playwright e2e tests', () => {
       // atomized target is refused without Nx Cloud unless told otherwise.
       for (const target of ['e2e', 'e2e-ci']) {
         const result = runCLI(`run ${e2eProject}:${target}`, {
-          env: { DEBUG: 'pw:webserver', NX_SKIP_ATOMIZER_VALIDATION: 'true' },
+          env: {
+            DEBUG: 'pw:webserver',
+            NX_SKIP_ATOMIZER_VALIDATION: 'true',
+            BASE_URL: `http://localhost:${port}`,
+          },
           redirectStderr: true,
         });
         expect(result).toContain('WebServer is already available');

--- a/e2e/react/src/playwright.test.ts
+++ b/e2e/react/src/playwright.test.ts
@@ -139,12 +139,16 @@ describe('React Playwright e2e tests', () => {
         ? ((json.nx ??= {}).targets ??= {})
         : (json.targets ??= {});
       targets[serveTarget] = {
-        command: 'node -e "setTimeout(() => {}, 5000)" && vite',
+        command: `node -e "setTimeout(() => {}, 5000)" && vite preview --port ${port}`,
         options: { cwd: appName },
         continuous: true,
       };
       return JSON.stringify(json, null, 2);
     });
+    // Both the Playwright config and the target must be updated before Nx
+    // infers the readiness gate. Reset the daemon to discard the old 4300
+    // address that may still be cached from project generation.
+    runCLI('reset');
 
     try {
       // Playwright logs which of the two it did under this debug scope. The

--- a/examples/react/basic/.env.e2e
+++ b/examples/react/basic/.env.e2e
@@ -1,0 +1,4 @@
+# e2e-task-scoped: unlike a root .env, this is not loaded at graph construction,
+# so it exercises createNodes resolving the e2e task env when it bakes the
+# Playwright web server readiness gate.
+BASE_URL=http://localhost:4301

--- a/examples/react/basic/.env.e2e
+++ b/examples/react/basic/.env.e2e
@@ -1,4 +1,4 @@
-# e2e-task-scoped: unlike a root .env, this is not loaded at graph construction,
-# so it exercises createNodes resolving the e2e task env when it bakes the
-# Playwright web server readiness gate.
+# e2e-task-scoped: unlike a root .env, this is absent from the ambient
+# environment before createNodes, so it exercises createNodes resolving the e2e
+# task env when it bakes the Playwright web server readiness gate.
 BASE_URL=http://localhost:4301

--- a/examples/react/basic/README.md
+++ b/examples/react/basic/README.md
@@ -38,7 +38,7 @@ Targets are inferred by the plugins registered in this directory's `nx.json`:
 | Target    | Inferred by             | What it does                  |
 | --------- | ----------------------- | ----------------------------- |
 | `build`   | `@nx/vite/plugin`       | `vite build` → `dist/`        |
-| `serve`   | `@nx/vite/plugin`       | Vite dev server on port 4200  |
+| `serve`   | `@nx/vite/plugin`       | Vite dev server on port 4301  |
 | `preview` | `@nx/vite/plugin`       | Serves the production build   |
 | `test`    | `@nx/vitest`            | Runs the Vitest unit tests    |
 | `e2e`     | `@nx/playwright/plugin` | Runs the Playwright e2e tests |

--- a/examples/react/basic/playwright.config.ts
+++ b/examples/react/basic/playwright.config.ts
@@ -3,7 +3,7 @@ import { nxE2EPreset } from '@nx/playwright/preset';
 import { workspaceRoot } from '@nx/devkit';
 
 // For CI, you may want to set BASE_URL to the deployed application.
-const baseURL = process.env['BASE_URL'] || 'http://localhost:4200';
+const baseURL = process.env['BASE_URL'] || 'http://localhost:4301';
 
 /**
  * See https://playwright.dev/docs/test-configuration.

--- a/examples/react/basic/playwright.config.ts
+++ b/examples/react/basic/playwright.config.ts
@@ -22,7 +22,7 @@ export default defineConfig({
    * lets the @nx/playwright plugin derive a dependsOn on the serve target. */
   webServer: {
     command: 'npx nx run examples-react-basic:serve',
-    url: 'http://localhost:4200',
+    url: baseURL,
     reuseExistingServer: true,
     cwd: __dirname,
   },

--- a/examples/react/basic/playwright.config.ts
+++ b/examples/react/basic/playwright.config.ts
@@ -2,7 +2,9 @@ import { defineConfig, devices } from '@playwright/test';
 import { nxE2EPreset } from '@nx/playwright/preset';
 import { workspaceRoot } from '@nx/devkit';
 
-// For CI, you may want to set BASE_URL to the deployed application.
+// BASE_URL steers the tests and the webServer probe below. Pointing it at a
+// deployed application in CI still starts the local serve dependency Nx infers
+// from the command.
 const baseURL = process.env['BASE_URL'] || 'http://localhost:4301';
 
 /**

--- a/examples/react/basic/playwright.config.ts
+++ b/examples/react/basic/playwright.config.ts
@@ -4,8 +4,9 @@ import { workspaceRoot } from '@nx/devkit';
 
 // BASE_URL steers the tests and the webServer probe below. Pointing it at a
 // deployed application in CI still starts the local serve dependency Nx infers
-// from the command.
-const baseURL = process.env['BASE_URL'] || 'http://localhost:4301';
+// from the command. The fallback is not the serve port: the tests only pass
+// with the address the e2e task env file sets, which this example exercises.
+const baseURL = process.env['BASE_URL'] || 'http://localhost:4200';
 
 /**
  * See https://playwright.dev/docs/test-configuration.

--- a/examples/react/basic/vite.config.mts
+++ b/examples/react/basic/vite.config.mts
@@ -6,7 +6,7 @@ export default defineConfig(() => ({
   root: import.meta.dirname,
   cacheDir: '../../../node_modules/.vite/examples/react/basic',
   server: {
-    port: 4200,
+    port: 4301,
     host: 'localhost',
   },
   preview: {

--- a/packages/devkit/internal.ts
+++ b/packages/devkit/internal.ts
@@ -17,6 +17,7 @@ export {
   // ship to external plugins under the +/- 1 tolerance, so they must keep
   // importing nx/src/utils/catalog directly. See packages/devkit/CLAUDE.md.
   getCatalogManager,
+  getDaemonClientEnvGeneration,
   getGraphTimeDotEnvForTask,
   hashDaemonClientEnv,
 } from 'nx/src/devkit-internals';

--- a/packages/devkit/internal.ts
+++ b/packages/devkit/internal.ts
@@ -203,6 +203,7 @@ export {
   getCliPath,
   getCustomHasher,
   getDependencyConfigs,
+  getEnvPathsForTask,
   getExecutorForTask,
   getExecutorInformation,
   getExecutorNameForTask,

--- a/packages/devkit/internal.ts
+++ b/packages/devkit/internal.ts
@@ -207,6 +207,7 @@ export {
   getCliPath,
   getCustomHasher,
   getDependencyConfigs,
+  getEnvFilesForTask,
   getEnvPathsForTask,
   getExecutorForTask,
   getExecutorInformation,

--- a/packages/devkit/internal.ts
+++ b/packages/devkit/internal.ts
@@ -18,6 +18,8 @@ export {
   // importing nx/src/utils/catalog directly. See packages/devkit/CLAUDE.md.
   getCatalogManager,
   getDaemonClientEnvGeneration,
+  getAppliedDaemonClientEnv,
+  applyDaemonEnvFromClient,
   getGraphTimeDotEnvForTask,
   hashDaemonClientEnv,
 } from 'nx/src/devkit-internals';

--- a/packages/devkit/internal.ts
+++ b/packages/devkit/internal.ts
@@ -17,7 +17,7 @@ export {
   // ship to external plugins under the +/- 1 tolerance, so they must keep
   // importing nx/src/utils/catalog directly. See packages/devkit/CLAUDE.md.
   getCatalogManager,
-  getGraphTimeEnvForTask,
+  getGraphTimeDotEnvForTask,
 } from 'nx/src/devkit-internals';
 
 // Formatter detection and setup. `@nx/js` needs these to write and detect a

--- a/packages/devkit/internal.ts
+++ b/packages/devkit/internal.ts
@@ -17,6 +17,7 @@ export {
   // ship to external plugins under the +/- 1 tolerance, so they must keep
   // importing nx/src/utils/catalog directly. See packages/devkit/CLAUDE.md.
   getCatalogManager,
+  getGraphTimeEnvForTask,
 } from 'nx/src/devkit-internals';
 
 // Formatter detection and setup. `@nx/js` needs these to write and detect a

--- a/packages/devkit/internal.ts
+++ b/packages/devkit/internal.ts
@@ -18,6 +18,7 @@ export {
   // importing nx/src/utils/catalog directly. See packages/devkit/CLAUDE.md.
   getCatalogManager,
   getGraphTimeDotEnvForTask,
+  hashDaemonClientEnv,
 } from 'nx/src/devkit-internals';
 
 // Formatter detection and setup. `@nx/js` needs these to write and detect a

--- a/packages/nx/src/daemon/client/daemon-environment.spec.ts
+++ b/packages/nx/src/daemon/client/daemon-environment.spec.ts
@@ -497,6 +497,17 @@ describe('daemon environment', () => {
       expect(hashDaemonClientEnv()).toEqual(without);
     });
 
+    it('is stable across the two NX_LOAD_DOT_ENV_FILES spellings that mean the same', () => {
+      // The digest keys the plugin cache, so it has to collapse the stamped
+      // 'true' and an unset value exactly as getDaemonEnv does.
+      delete process.env.NX_LOAD_DOT_ENV_FILES;
+      const unset = hashDaemonClientEnv();
+      process.env.NX_LOAD_DOT_ENV_FILES = 'true';
+      expect(hashDaemonClientEnv()).toEqual(unset);
+      process.env.NX_LOAD_DOT_ENV_FILES = 'false';
+      expect(hashDaemonClientEnv()).not.toEqual(unset);
+    });
+
     it('is stable when an excluded env var changes', () => {
       delete process.env.NX_TUI;
       delete process.env.ITERM_SESSION_ID;

--- a/packages/nx/src/daemon/client/daemon-environment.spec.ts
+++ b/packages/nx/src/daemon/client/daemon-environment.spec.ts
@@ -371,9 +371,7 @@ describe('daemon environment', () => {
     });
 
     it('is cleared when a later client omits it (last-client-wins)', () => {
-      // While it was excluded, a prior client's value stuck around; now a
-      // client that does not set it must clear it so its graph does not use
-      // the previous client's opt-out.
+      // Or the new client's graph would run with the previous client's opt-out.
       process.env.NX_LOAD_DOT_ENV_FILES = 'false';
       const changed = applyDaemonEnvFromClient({});
       expect(process.env.NX_LOAD_DOT_ENV_FILES).toBeUndefined();

--- a/packages/nx/src/daemon/client/daemon-environment.spec.ts
+++ b/packages/nx/src/daemon/client/daemon-environment.spec.ts
@@ -1,5 +1,6 @@
 import {
   applyDaemonEnvFromClient,
+  getAppliedDaemonClientEnv,
   getDaemonClientEnvGeneration,
   getDaemonEnv,
   getDaemonSpawnEnv,
@@ -327,10 +328,12 @@ describe('daemon environment', () => {
       process.env.NX_PROJECT_GLOB_CACHE = 'false';
       process.env.NX_CACHE_PROJECTS_CONFIG = 'false';
 
-      const payload = { ...process.env, FOO: 'bar' };
-      delete payload.NX_PROJECT_GLOB_CACHE;
-      delete payload.NX_CACHE_PROJECTS_CONFIG;
-      const changed = applyDaemonEnvFromClient(payload);
+      // baseline the applied client env so only FOO is reported below
+      const base = { ...process.env };
+      delete base.NX_PROJECT_GLOB_CACHE;
+      delete base.NX_CACHE_PROJECTS_CONFIG;
+      applyDaemonEnvFromClient(base);
+      const changed = applyDaemonEnvFromClient({ ...base, FOO: 'bar' });
 
       expect(changed).toEqual(['FOO']);
       expect(process.env.NX_PROJECT_GLOB_CACHE).toBe('false');
@@ -347,6 +350,8 @@ describe('daemon environment', () => {
     });
 
     it('should apply and delete the Nx Cloud auth tokens like any forwarded var', () => {
+      // baseline the applied client env so only the token is reported below
+      applyDaemonEnvFromClient({ ...process.env });
       const added = applyDaemonEnvFromClient({
         ...process.env,
         NX_CLOUD_ACCESS_TOKEN: 'token',
@@ -391,6 +396,55 @@ describe('daemon environment', () => {
       // spanning only no-op applies must still be allowed to persist.
       applyDaemonEnvFromClient(withProbe);
       expect(getDaemonClientEnvGeneration()).toBe(base + 1);
+    });
+  });
+
+  describe('applyDaemonEnvFromClient', () => {
+    it('reports a client change that process.env already matches', () => {
+      // A config the daemon evaluated wrote the value the next client sends,
+      // so process.env has nothing to move on; the client-owned env did move
+      // and the graph computed under the previous client is stale.
+      const previous = { ...process.env };
+      applyDaemonEnvFromClient(previous);
+      process.env.MASKED_PROBE = 'from-config';
+      const generation = getDaemonClientEnvGeneration();
+
+      const changed = applyDaemonEnvFromClient({
+        ...previous,
+        MASKED_PROBE: 'from-config',
+      });
+
+      expect(changed).toEqual(['MASKED_PROBE']);
+      expect(getDaemonClientEnvGeneration()).toBe(generation + 1);
+    });
+  });
+
+  describe('getAppliedDaemonClientEnv', () => {
+    it('returns a copy of the last applied env, whether or not it changed anything', () => {
+      const applied = { ...process.env, APPLIED_PROBE: 'a' };
+      applyDaemonEnvFromClient(applied);
+      expect(getAppliedDaemonClientEnv().env).toEqual(applied);
+      // A no-op apply is still the last one applied.
+      applyDaemonEnvFromClient(applied);
+      const copy = getAppliedDaemonClientEnv().env;
+      expect(copy).toEqual(applied);
+      // A caller mutating the copy must not touch the stored env, which a
+      // later caller reads to undo what a user config wrote.
+      copy.APPLIED_PROBE = 'mutated';
+      expect(getAppliedDaemonClientEnv().env.APPLIED_PROBE).toBe('a');
+    });
+
+    it('advances the sequence on an apply that changes nothing, unlike the generation', () => {
+      // A config that already wrote the value a client then applies leaves
+      // the generation alone; the sequence is how a caller learns the apply
+      // happened at all.
+      const applied = { ...process.env, APPLIED_PROBE: 'a' };
+      applyDaemonEnvFromClient(applied);
+      const { sequence } = getAppliedDaemonClientEnv();
+      const generation = getDaemonClientEnvGeneration();
+      expect(applyDaemonEnvFromClient(applied)).toEqual([]);
+      expect(getDaemonClientEnvGeneration()).toBe(generation);
+      expect(getAppliedDaemonClientEnv().sequence).toBe(sequence + 1);
     });
   });
 

--- a/packages/nx/src/daemon/client/daemon-environment.spec.ts
+++ b/packages/nx/src/daemon/client/daemon-environment.spec.ts
@@ -384,6 +384,42 @@ describe('daemon environment', () => {
       expect(process.env.NX_LOAD_DOT_ENV_FILES).toBeUndefined();
       expect(changed).toContain('NX_LOAD_DOT_ENV_FILES');
     });
+
+    it('is sent as its meaning, so an unset shell and a stamped task child agree', () => {
+      delete process.env.NX_LOAD_DOT_ENV_FILES;
+      expect(getDaemonEnv().NX_LOAD_DOT_ENV_FILES).toBe('true');
+      // run-command stamps 'true' once the graph exists and task children
+      // inherit it; sending that spelling would read as an env change.
+      process.env.NX_LOAD_DOT_ENV_FILES = 'true';
+      expect(getDaemonEnv().NX_LOAD_DOT_ENV_FILES).toBe('true');
+    });
+
+    it('reports no change as a run alternates between the two spellings', () => {
+      // `nx build`, then a task child carrying the stamp, then `nx show`.
+      // getDaemonEnv reads the client's env while applyDaemonEnvFromClient
+      // writes the daemon's, so swap the client value in only for the send.
+      const send = (shellValue: string | undefined) => {
+        const daemonValue = process.env.NX_LOAD_DOT_ENV_FILES;
+        if (shellValue === undefined) delete process.env.NX_LOAD_DOT_ENV_FILES;
+        else process.env.NX_LOAD_DOT_ENV_FILES = shellValue;
+        const sent = getDaemonEnv() as Record<string, string>;
+        if (daemonValue === undefined) delete process.env.NX_LOAD_DOT_ENV_FILES;
+        else process.env.NX_LOAD_DOT_ENV_FILES = daemonValue;
+        return sent;
+      };
+
+      applyDaemonEnvFromClient(send(undefined));
+      expect(applyDaemonEnvFromClient(send('true'))).not.toContain(
+        'NX_LOAD_DOT_ENV_FILES'
+      );
+      expect(applyDaemonEnvFromClient(send(undefined))).not.toContain(
+        'NX_LOAD_DOT_ENV_FILES'
+      );
+      // A genuine opt-out is still a change.
+      expect(applyDaemonEnvFromClient(send('false'))).toContain(
+        'NX_LOAD_DOT_ENV_FILES'
+      );
+    });
   });
 
   describe('getDaemonClientEnvGeneration', () => {

--- a/packages/nx/src/daemon/client/daemon-environment.spec.ts
+++ b/packages/nx/src/daemon/client/daemon-environment.spec.ts
@@ -359,4 +359,25 @@ describe('daemon environment', () => {
       expect(process.env.NX_CLOUD_ACCESS_TOKEN).toBeUndefined();
     });
   });
+
+  // NX_LOAD_DOT_ENV_FILES must reach the daemon so createNodes resolves task
+  // dotenv the way the task will, and so the user's 'false' opt-out is honored
+  // at graph-construction time. It reads like a task-scoped var that cannot
+  // affect the graph, so guard against it being re-added to the exclusions.
+  describe('NX_LOAD_DOT_ENV_FILES', () => {
+    it('is forwarded to the daemon env', () => {
+      process.env.NX_LOAD_DOT_ENV_FILES = 'false';
+      expect(getDaemonEnv().NX_LOAD_DOT_ENV_FILES).toBe('false');
+    });
+
+    it('is cleared when a later client omits it (last-client-wins)', () => {
+      // While it was excluded, a prior client's value stuck around; now a
+      // client that does not set it must clear it so its graph does not use
+      // the previous client's opt-out.
+      process.env.NX_LOAD_DOT_ENV_FILES = 'false';
+      const changed = applyDaemonEnvFromClient({});
+      expect(process.env.NX_LOAD_DOT_ENV_FILES).toBeUndefined();
+      expect(changed).toContain('NX_LOAD_DOT_ENV_FILES');
+    });
+  });
 });

--- a/packages/nx/src/daemon/client/daemon-environment.spec.ts
+++ b/packages/nx/src/daemon/client/daemon-environment.spec.ts
@@ -2,6 +2,7 @@ import {
   applyDaemonEnvFromClient,
   getDaemonEnv,
   getDaemonSpawnEnv,
+  hashDaemonClientEnv,
 } from './daemon-environment';
 
 describe('daemon environment', () => {
@@ -376,6 +377,55 @@ describe('daemon environment', () => {
       const changed = applyDaemonEnvFromClient({});
       expect(process.env.NX_LOAD_DOT_ENV_FILES).toBeUndefined();
       expect(changed).toContain('NX_LOAD_DOT_ENV_FILES');
+    });
+  });
+
+  describe('hashDaemonClientEnv', () => {
+    it('changes when an allowed env var changes value, appears, or disappears', () => {
+      delete process.env.SOME_TOOL_HOME;
+      const without = hashDaemonClientEnv();
+      process.env.SOME_TOOL_HOME = '/usr/lib/tool';
+      const withVar = hashDaemonClientEnv();
+      expect(withVar).not.toEqual(without);
+      process.env.SOME_TOOL_HOME = '/opt/tool';
+      expect(hashDaemonClientEnv()).not.toEqual(withVar);
+      delete process.env.SOME_TOOL_HOME;
+      expect(hashDaemonClientEnv()).toEqual(without);
+    });
+
+    it('is stable when an excluded env var changes', () => {
+      delete process.env.NX_TUI;
+      delete process.env.ITERM_SESSION_ID;
+      const base = hashDaemonClientEnv();
+      process.env.NX_TUI = 'true';
+      process.env.ITERM_SESSION_ID = 'w0t1p0:12345';
+      expect(hashDaemonClientEnv()).toEqual(base);
+    });
+
+    it('changes when a prefix-exclusion override changes', () => {
+      delete process.env.NX_CLOUD_ACCESS_TOKEN;
+      const base = hashDaemonClientEnv();
+      process.env.NX_CLOUD_ACCESS_TOKEN = 'token';
+      expect(hashDaemonClientEnv()).not.toEqual(base);
+    });
+
+    // The daemon pins the required settings into its own and every plugin
+    // worker's env while daemonless plugin workers typically lack them;
+    // skipping them keeps the digest identical across modes.
+    it('is stable when a required daemon setting changes', () => {
+      delete process.env.NX_PROJECT_GLOB_CACHE;
+      const base = hashDaemonClientEnv();
+      process.env.NX_PROJECT_GLOB_CACHE = 'false';
+      expect(hashDaemonClientEnv()).toEqual(base);
+    });
+
+    // Pins that the overridable settings need no dedicated skip like the
+    // required ones above: they are already in the exclusion set.
+    it('is stable when an overridable daemon setting changes', () => {
+      delete process.env.NX_VERBOSE_LOGGING;
+      const base = hashDaemonClientEnv();
+      process.env.NX_VERBOSE_LOGGING = 'true';
+      expect(hashDaemonClientEnv()).toEqual(base);
     });
   });
 });

--- a/packages/nx/src/daemon/client/daemon-environment.spec.ts
+++ b/packages/nx/src/daemon/client/daemon-environment.spec.ts
@@ -1,5 +1,6 @@
 import {
   applyDaemonEnvFromClient,
+  getDaemonClientEnvGeneration,
   getDaemonEnv,
   getDaemonSpawnEnv,
   hashDaemonClientEnv,
@@ -377,6 +378,19 @@ describe('daemon environment', () => {
       const changed = applyDaemonEnvFromClient({});
       expect(process.env.NX_LOAD_DOT_ENV_FILES).toBeUndefined();
       expect(changed).toContain('NX_LOAD_DOT_ENV_FILES');
+    });
+  });
+
+  describe('getDaemonClientEnvGeneration', () => {
+    it('moves only when an apply changes the env', () => {
+      const base = getDaemonClientEnvGeneration();
+      const withProbe = { ...process.env, GEN_PROBE: 'a' };
+      applyDaemonEnvFromClient(withProbe);
+      expect(getDaemonClientEnvGeneration()).toBe(base + 1);
+      // The same env again changes nothing, so the count must hold: a pass
+      // spanning only no-op applies must still be allowed to persist.
+      applyDaemonEnvFromClient(withProbe);
+      expect(getDaemonClientEnvGeneration()).toBe(base + 1);
     });
   });
 

--- a/packages/nx/src/daemon/client/daemon-environment.ts
+++ b/packages/nx/src/daemon/client/daemon-environment.ts
@@ -27,7 +27,8 @@ const DAEMON_ENV_VARS_EXCLUSIONS = new Set([
   'NX_FORKED_TASK_EXECUTOR',
   'NX_SET_CLI',
   'NX_INVOKED_BY_RUNNER',
-  'NX_LOAD_DOT_ENV_FILES',
+  // NX_LOAD_DOT_ENV_FILES is intentionally NOT excluded: it must reach the
+  // daemon so graph-time dotenv resolution honors the user's opt-out.
   'NX_SKIP_NX_CACHE',
   'NX_CACHE_FAILURES',
   'NX_REJECT_UNKNOWN_LOCAL_CACHE',

--- a/packages/nx/src/daemon/client/daemon-environment.ts
+++ b/packages/nx/src/daemon/client/daemon-environment.ts
@@ -271,6 +271,17 @@ export function getDaemonEnv() {
   return Object.assign(env, DAEMON_ENV_REQUIRED_SETTINGS);
 }
 
+let clientEnvGeneration = 0;
+
+/**
+ * Count of client env applications this process has absorbed. Digest equality
+ * alone cannot guard a cache write: an env that changed and changed back
+ * mid-pass yields the pass-start digest again, while the count still moves.
+ */
+export function getDaemonClientEnvGeneration(): number {
+  return clientEnvGeneration;
+}
+
 /**
  * Env for spawning the daemon process. On top of the reflected env, it must
  * keep excluded vars the daemon needs to start correctly:
@@ -321,6 +332,9 @@ export function applyDaemonEnvFromClient(newEnv: NodeJS.ProcessEnv): string[] {
       delete process.env[key];
       changedKeys.push(key);
     }
+  }
+  if (changedKeys.length > 0) {
+    clientEnvGeneration++;
   }
   return changedKeys;
 }

--- a/packages/nx/src/daemon/client/daemon-environment.ts
+++ b/packages/nx/src/daemon/client/daemon-environment.ts
@@ -1,3 +1,5 @@
+import { hashObject } from '../../hasher/file-hasher';
+
 const DAEMON_ENV_REQUIRED_SETTINGS = {
   NX_PROJECT_GLOB_CACHE: 'false',
   NX_CACHE_PROJECTS_CONFIG: 'false',
@@ -237,6 +239,26 @@ function isExcludedEnvVar(key: string): boolean {
     return false;
   }
   return DAEMON_ENV_PREFIX_EXCLUSIONS.some((prefix) => key.startsWith(prefix));
+}
+
+/**
+ * Digest of the client-controlled portion of the daemon env: the vars
+ * `getDaemonEnv` would send, minus the required settings the daemon pins
+ * itself. Skipping those yields the same digest whether the process is a
+ * daemon plugin worker (which has them set) or a daemonless one (which
+ * typically does not).
+ */
+export function hashDaemonClientEnv(): string {
+  const env: Record<string, string> = {};
+  for (const key in process.env) {
+    if (
+      !isExcludedEnvVar(key) &&
+      !Object.hasOwn(DAEMON_ENV_REQUIRED_SETTINGS, key)
+    ) {
+      env[key] = process.env[key];
+    }
+  }
+  return hashObject(env);
 }
 
 export function getDaemonEnv() {

--- a/packages/nx/src/daemon/client/daemon-environment.ts
+++ b/packages/nx/src/daemon/client/daemon-environment.ts
@@ -30,7 +30,8 @@ const DAEMON_ENV_VARS_EXCLUSIONS = new Set([
   'NX_SET_CLI',
   'NX_INVOKED_BY_RUNNER',
   // NX_LOAD_DOT_ENV_FILES is intentionally NOT excluded: it must reach the
-  // daemon so graph-time dotenv resolution honors the user's opt-out.
+  // daemon so graph-time dotenv resolution honors the user's opt-out. It is
+  // sent normalized rather than reflected — see normalizedLoadDotEnvFiles.
   'NX_SKIP_NX_CACHE',
   'NX_CACHE_FAILURES',
   'NX_REJECT_UNKNOWN_LOCAL_CACHE',
@@ -258,7 +259,19 @@ export function hashDaemonClientEnv(): string {
       env[key] = process.env[key];
     }
   }
+  env.NX_LOAD_DOT_ENV_FILES = normalizedLoadDotEnvFiles();
   return hashObject(env);
+}
+
+/**
+ * `NX_LOAD_DOT_ENV_FILES` as its meaning rather than its spelling. `run-command`
+ * stamps `'true'` once the graph exists, so a task child sends it where its
+ * parent sent nothing; every reader outside the task runner treats both alike
+ * (`!== 'false'`). Reflecting the spelling would flip the daemon env on each
+ * alternation and discard the graph cache both ways.
+ */
+function normalizedLoadDotEnvFiles(): 'true' | 'false' {
+  return process.env.NX_LOAD_DOT_ENV_FILES === 'false' ? 'false' : 'true';
 }
 
 export function getDaemonEnv() {
@@ -268,6 +281,7 @@ export function getDaemonEnv() {
       env[key] = process.env[key];
     }
   }
+  env.NX_LOAD_DOT_ENV_FILES = normalizedLoadDotEnvFiles();
   return Object.assign(env, DAEMON_ENV_REQUIRED_SETTINGS);
 }
 

--- a/packages/nx/src/daemon/client/daemon-environment.ts
+++ b/packages/nx/src/daemon/client/daemon-environment.ts
@@ -272,12 +272,14 @@ export function getDaemonEnv() {
 }
 
 let clientEnvGeneration = 0;
+let clientEnvApplySequence = 0;
+let appliedClientEnv: NodeJS.ProcessEnv | undefined;
 
 /**
- * Count of client env applications that changed at least one variable. Digest
- * equality alone cannot guard a cache write: an env that changed and changed
- * back mid-pass yields the pass-start digest again, while the count still
- * moves.
+ * Count of client env applications that changed at least one variable, in
+ * `process.env` or against the previously applied client env. Digest equality
+ * alone cannot guard a cache write: an env that changed and changed back
+ * mid-pass yields the pass-start digest again, while the count still moves.
  */
 export function getDaemonClientEnvGeneration(): number {
   return clientEnvGeneration;
@@ -308,14 +310,35 @@ export function getDaemonSpawnEnv() {
 }
 
 /**
+ * A copy of the env the last `applyDaemonEnvFromClient` call applied, with a
+ * sequence that advances on every call, or `undefined` before the first. For a
+ * caller that let code it ran (a user config, say) write over `process.env`
+ * and has to put the client's env back: the generation cannot tell it an apply
+ * happened, since an apply whose values the config had already written changes
+ * nothing.
+ */
+export function getAppliedDaemonClientEnv():
+  | { sequence: number; env: NodeJS.ProcessEnv }
+  | undefined {
+  return appliedClientEnv
+    ? { sequence: clientEnvApplySequence, env: { ...appliedClientEnv } }
+    : undefined;
+}
+
+/**
  * Without the deletion step, a var set by one client (e.g.
  * `NX_PREFER_NODE_STRIP_TYPES=true` or `JAVA_TOOL_OPTIONS=...` for a single
  * command) would persist in the daemon and leak into every subsequent
  * client's project-graph computation. Deletion skips excluded vars and
  * required settings, which the daemon owns and clients should not control.
+ *
+ * The returned keys are those `process.env` moved on plus those the client's
+ * env moved on since the last applied one: a value a config wrote mid-load can
+ * already match what the next client sends, and the graph computed under the
+ * previous client is stale all the same.
  */
 export function applyDaemonEnvFromClient(newEnv: NodeJS.ProcessEnv): string[] {
-  const changedKeys: string[] = [];
+  const changedKeys = new Set<string>();
   const allKeys = new Set([
     ...Object.keys(process.env),
     ...Object.keys(newEnv),
@@ -324,18 +347,30 @@ export function applyDaemonEnvFromClient(newEnv: NodeJS.ProcessEnv): string[] {
     if (key in newEnv) {
       if (process.env[key] !== newEnv[key]) {
         process.env[key] = newEnv[key];
-        changedKeys.push(key);
+        changedKeys.add(key);
       }
     } else if (
       !isExcludedEnvVar(key) &&
       !Object.hasOwn(DAEMON_ENV_REQUIRED_SETTINGS, key)
     ) {
       delete process.env[key];
-      changedKeys.push(key);
+      changedKeys.add(key);
     }
   }
-  if (changedKeys.length > 0) {
+  if (appliedClientEnv) {
+    for (const key of new Set([
+      ...Object.keys(appliedClientEnv),
+      ...Object.keys(newEnv),
+    ])) {
+      if (appliedClientEnv[key] !== newEnv[key]) {
+        changedKeys.add(key);
+      }
+    }
+  }
+  if (changedKeys.size > 0) {
     clientEnvGeneration++;
   }
-  return changedKeys;
+  clientEnvApplySequence++;
+  appliedClientEnv = { ...newEnv };
+  return [...changedKeys];
 }

--- a/packages/nx/src/daemon/client/daemon-environment.ts
+++ b/packages/nx/src/daemon/client/daemon-environment.ts
@@ -274,9 +274,10 @@ export function getDaemonEnv() {
 let clientEnvGeneration = 0;
 
 /**
- * Count of client env applications this process has absorbed. Digest equality
- * alone cannot guard a cache write: an env that changed and changed back
- * mid-pass yields the pass-start digest again, while the count still moves.
+ * Count of client env applications that changed at least one variable. Digest
+ * equality alone cannot guard a cache write: an env that changed and changed
+ * back mid-pass yields the pass-start digest again, while the count still
+ * moves.
  */
 export function getDaemonClientEnvGeneration(): number {
   return clientEnvGeneration;

--- a/packages/nx/src/daemon/server/dotenv-graph-changes.spec.ts
+++ b/packages/nx/src/daemon/server/dotenv-graph-changes.spec.ts
@@ -126,6 +126,31 @@ describe('outputsChangeInvalidatesGraphEnv', () => {
     ).toBe(false);
   });
 
+  it('ignores a dot-directory artifact with the dotenv name shape', () => {
+    // `.{id}.env` with id `nx/cache/abc` has the dotenv name shape, but paths
+    // like this are tool caches written constantly, not dotenv files.
+    write('.nx/cache/abc.env', 'X=1\n');
+    expect(
+      outputsChangeInvalidatesGraphEnv(
+        [{ path: '.nx/cache/abc.env', type: EventType.create }],
+        undefined
+      )
+    ).toBe(false);
+  });
+
+  it('ignores a workspace-root dotenv path whose identifier contains a slash', () => {
+    // The cost of rejecting dot-directory artifacts: a workspace-root dotenv
+    // for a `/`-containing target identifier no longer invalidates. Project
+    // roots keep their slash identifiers via the root-ancestor walk.
+    write('.env.e2e/smoke', 'X=1\n');
+    expect(
+      outputsChangeInvalidatesGraphEnv(
+        [{ path: '.env.e2e/smoke', type: EventType.create }],
+        undefined
+      )
+    ).toBe(false);
+  });
+
   it('ignores a non-dotenv file at a root', () => {
     write('.eslintrc.json', '{}\n');
     expect(

--- a/packages/nx/src/daemon/server/dotenv-graph-changes.spec.ts
+++ b/packages/nx/src/daemon/server/dotenv-graph-changes.spec.ts
@@ -6,10 +6,10 @@ import { EventType } from '../../native';
 import { setWorkspaceRoot, workspaceRoot } from '../../utils/workspace-root';
 import {
   _resetDotEnvFileHashes,
-  outputsChangeInvalidatesGraphEnv,
+  outputsChangesInvalidatingGraphEnv,
 } from './dotenv-graph-changes';
 
-describe('outputsChangeInvalidatesGraphEnv', () => {
+describe('outputsChangesInvalidatingGraphEnv', () => {
   const originalWorkspaceRoot = workspaceRoot;
   let tempDir: string;
 
@@ -40,36 +40,42 @@ describe('outputsChangeInvalidatesGraphEnv', () => {
   it('invalidates on a changed workspace-root dotenv file', () => {
     write('.env.e2e', 'BASE_URL=http://localhost:4301\n');
     expect(
-      outputsChangeInvalidatesGraphEnv(
+      outputsChangesInvalidatingGraphEnv(
         [{ path: '.env.e2e', type: EventType.create }],
         undefined
       )
-    ).toBe(true);
+    ).toEqual(['.env.e2e']);
   });
 
   it('skips a byte-identical rewrite of a dotenv file', () => {
     write('.env.e2e', 'BASE_URL=http://localhost:4301\n');
     const events = [{ path: '.env.e2e', type: EventType.update }];
-    expect(outputsChangeInvalidatesGraphEnv(events, undefined)).toBe(true);
-    expect(outputsChangeInvalidatesGraphEnv(events, undefined)).toBe(false);
+    expect(outputsChangesInvalidatingGraphEnv(events, undefined)).toEqual([
+      '.env.e2e',
+    ]);
+    expect(outputsChangesInvalidatingGraphEnv(events, undefined)).toEqual([]);
   });
 
   it('invalidates again once the content actually changes', () => {
     write('.env.e2e', 'BASE_URL=http://localhost:4301\n');
     const events = [{ path: '.env.e2e', type: EventType.update }];
-    expect(outputsChangeInvalidatesGraphEnv(events, undefined)).toBe(true);
+    expect(outputsChangesInvalidatingGraphEnv(events, undefined)).toEqual([
+      '.env.e2e',
+    ]);
     write('.env.e2e', 'BASE_URL=http://localhost:4302\n');
-    expect(outputsChangeInvalidatesGraphEnv(events, undefined)).toBe(true);
+    expect(outputsChangesInvalidatingGraphEnv(events, undefined)).toEqual([
+      '.env.e2e',
+    ]);
   });
 
   it('invalidates on a changed project-root dotenv file', () => {
     write('apps/app1/.env', 'BASE_URL=http://localhost:4301\n');
     expect(
-      outputsChangeInvalidatesGraphEnv(
+      outputsChangesInvalidatingGraphEnv(
         [{ path: 'apps/app1/.env', type: EventType.create }],
         graphWithRoots(['apps/app1'])
       )
-    ).toBe(true);
+    ).toEqual(['apps/app1/.env']);
   });
 
   it('invalidates on a dotenv path whose identifier contains a slash', () => {
@@ -77,31 +83,31 @@ describe('outputsChangeInvalidatesGraphEnv', () => {
     // path like apps/app1/.env.e2e/smoke; it must still match relative to the root.
     write('apps/app1/.env.e2e/smoke', 'BASE_URL=http://localhost:4301\n');
     expect(
-      outputsChangeInvalidatesGraphEnv(
+      outputsChangesInvalidatingGraphEnv(
         [{ path: 'apps/app1/.env.e2e/smoke', type: EventType.create }],
         graphWithRoots(['apps/app1'])
       )
-    ).toBe(true);
+    ).toEqual(['apps/app1/.env.e2e/smoke']);
   });
 
   it('invalidates on a suffixed dotenv name', () => {
     write('apps/app1/.e2e.env', 'BASE_URL=http://localhost:4301\n');
     expect(
-      outputsChangeInvalidatesGraphEnv(
+      outputsChangesInvalidatingGraphEnv(
         [{ path: 'apps/app1/.e2e.env', type: EventType.create }],
         graphWithRoots(['apps/app1'])
       )
-    ).toBe(true);
+    ).toEqual(['apps/app1/.e2e.env']);
   });
 
   it('invalidates on a suffixed dotenv path whose identifier contains a slash', () => {
     write('apps/app1/.e2e/smoke.env', 'BASE_URL=http://localhost:4301\n');
     expect(
-      outputsChangeInvalidatesGraphEnv(
+      outputsChangesInvalidatingGraphEnv(
         [{ path: 'apps/app1/.e2e/smoke.env', type: EventType.create }],
         graphWithRoots(['apps/app1'])
       )
-    ).toBe(true);
+    ).toEqual(['apps/app1/.e2e/smoke.env']);
   });
 
   it('matches a parent-root dotenv when a nested root shadows the deepest dir', () => {
@@ -109,21 +115,21 @@ describe('outputsChangeInvalidatesGraphEnv', () => {
     // apps/app1's slash-identifier dotenv (.env.e2e/smoke).
     write('apps/app1/.env.e2e/smoke', 'BASE_URL=http://localhost:4301\n');
     expect(
-      outputsChangeInvalidatesGraphEnv(
+      outputsChangesInvalidatingGraphEnv(
         [{ path: 'apps/app1/.env.e2e/smoke', type: EventType.create }],
         graphWithRoots(['apps/app1', 'apps/app1/.env.e2e'])
       )
-    ).toBe(true);
+    ).toEqual(['apps/app1/.env.e2e/smoke']);
   });
 
   it('ignores a dotenv file that sits under no root', () => {
     write('apps/app1/nested/.env', 'X=1\n');
     expect(
-      outputsChangeInvalidatesGraphEnv(
+      outputsChangesInvalidatingGraphEnv(
         [{ path: 'apps/app1/nested/.env', type: EventType.create }],
         graphWithRoots(['apps/app1'])
       )
-    ).toBe(false);
+    ).toEqual([]);
   });
 
   it('ignores a dot-directory artifact with the dotenv name shape', () => {
@@ -131,11 +137,11 @@ describe('outputsChangeInvalidatesGraphEnv', () => {
     // like this are tool caches written constantly, not dotenv files.
     write('.nx/cache/abc.env', 'X=1\n');
     expect(
-      outputsChangeInvalidatesGraphEnv(
+      outputsChangesInvalidatingGraphEnv(
         [{ path: '.nx/cache/abc.env', type: EventType.create }],
         undefined
       )
-    ).toBe(false);
+    ).toEqual([]);
   });
 
   it('ignores a workspace-root dotenv path whose identifier contains a slash', () => {
@@ -144,29 +150,29 @@ describe('outputsChangeInvalidatesGraphEnv', () => {
     // roots keep their slash identifiers via the root-ancestor walk.
     write('.env.e2e/smoke', 'X=1\n');
     expect(
-      outputsChangeInvalidatesGraphEnv(
+      outputsChangesInvalidatingGraphEnv(
         [{ path: '.env.e2e/smoke', type: EventType.create }],
         undefined
       )
-    ).toBe(false);
+    ).toEqual([]);
   });
 
   it('ignores a non-dotenv file at a root', () => {
     write('.eslintrc.json', '{}\n');
     expect(
-      outputsChangeInvalidatesGraphEnv(
+      outputsChangesInvalidatingGraphEnv(
         [{ path: '.eslintrc.json', type: EventType.update }],
         undefined
       )
-    ).toBe(false);
+    ).toEqual([]);
   });
 
   it('invalidates when a root dotenv file is deleted', () => {
     expect(
-      outputsChangeInvalidatesGraphEnv(
+      outputsChangesInvalidatingGraphEnv(
         [{ path: '.env', type: EventType.delete }],
         undefined
       )
-    ).toBe(true);
+    ).toEqual(['.env']);
   });
 });

--- a/packages/nx/src/daemon/server/dotenv-graph-changes.spec.ts
+++ b/packages/nx/src/daemon/server/dotenv-graph-changes.spec.ts
@@ -133,12 +133,12 @@ describe('outputsChangesInvalidatingGraphEnv', () => {
   });
 
   it('ignores a dot-directory artifact with the dotenv name shape', () => {
-    // `.{id}.env` with id `nx/cache/abc` has the dotenv name shape, but paths
-    // like this are tool caches written constantly, not dotenv files.
-    write('.nx/cache/abc.env', 'X=1\n');
+    // `.{id}.env` with id `github/workflows/ci` has the dotenv name shape, but
+    // paths like this are ordinary dot-directory files, not dotenv files.
+    write('.github/workflows/ci.env', 'X=1\n');
     expect(
       outputsChangesInvalidatingGraphEnv(
-        [{ path: '.nx/cache/abc.env', type: EventType.create }],
+        [{ path: '.github/workflows/ci.env', type: EventType.create }],
         undefined
       )
     ).toEqual([]);

--- a/packages/nx/src/daemon/server/dotenv-graph-changes.spec.ts
+++ b/packages/nx/src/daemon/server/dotenv-graph-changes.spec.ts
@@ -84,6 +84,26 @@ describe('outputsChangeInvalidatesGraphEnv', () => {
     ).toBe(true);
   });
 
+  it('invalidates on a suffixed dotenv name', () => {
+    write('apps/app1/.e2e.env', 'BASE_URL=http://localhost:4301\n');
+    expect(
+      outputsChangeInvalidatesGraphEnv(
+        [{ path: 'apps/app1/.e2e.env', type: EventType.create }],
+        graphWithRoots(['apps/app1'])
+      )
+    ).toBe(true);
+  });
+
+  it('invalidates on a suffixed dotenv path whose identifier contains a slash', () => {
+    write('apps/app1/.e2e/smoke.env', 'BASE_URL=http://localhost:4301\n');
+    expect(
+      outputsChangeInvalidatesGraphEnv(
+        [{ path: 'apps/app1/.e2e/smoke.env', type: EventType.create }],
+        graphWithRoots(['apps/app1'])
+      )
+    ).toBe(true);
+  });
+
   it('matches a parent-root dotenv when a nested root shadows the deepest dir', () => {
     // A project rooted at apps/app1/.env.e2e must not shadow the parent
     // apps/app1's slash-identifier dotenv (.env.e2e/smoke).

--- a/packages/nx/src/daemon/server/dotenv-graph-changes.spec.ts
+++ b/packages/nx/src/daemon/server/dotenv-graph-changes.spec.ts
@@ -1,0 +1,127 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join } from 'node:path';
+import type { ProjectGraph } from '../../config/project-graph';
+import { EventType } from '../../native';
+import { setWorkspaceRoot, workspaceRoot } from '../../utils/workspace-root';
+import {
+  _resetDotEnvFileHashes,
+  outputsChangeInvalidatesGraphEnv,
+} from './dotenv-graph-changes';
+
+describe('outputsChangeInvalidatesGraphEnv', () => {
+  const originalWorkspaceRoot = workspaceRoot;
+  let tempDir: string;
+
+  const graphWithRoots = (roots: string[]): ProjectGraph =>
+    ({
+      nodes: Object.fromEntries(
+        roots.map((root, i) => [`p${i}`, { data: { root } }])
+      ),
+    }) as any as ProjectGraph;
+
+  beforeEach(() => {
+    _resetDotEnvFileHashes();
+    tempDir = mkdtempSync(join(tmpdir(), 'nx-dotenv-watch-'));
+    setWorkspaceRoot(tempDir);
+  });
+
+  afterEach(() => {
+    setWorkspaceRoot(originalWorkspaceRoot);
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  function write(rel: string, content: string): void {
+    const abs = join(tempDir, rel);
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, content);
+  }
+
+  it('invalidates on a changed workspace-root dotenv file', () => {
+    write('.env.e2e', 'BASE_URL=http://localhost:4301\n');
+    expect(
+      outputsChangeInvalidatesGraphEnv(
+        [{ path: '.env.e2e', type: EventType.create }],
+        undefined
+      )
+    ).toBe(true);
+  });
+
+  it('skips a byte-identical rewrite of a dotenv file', () => {
+    write('.env.e2e', 'BASE_URL=http://localhost:4301\n');
+    const events = [{ path: '.env.e2e', type: EventType.update }];
+    expect(outputsChangeInvalidatesGraphEnv(events, undefined)).toBe(true);
+    expect(outputsChangeInvalidatesGraphEnv(events, undefined)).toBe(false);
+  });
+
+  it('invalidates again once the content actually changes', () => {
+    write('.env.e2e', 'BASE_URL=http://localhost:4301\n');
+    const events = [{ path: '.env.e2e', type: EventType.update }];
+    expect(outputsChangeInvalidatesGraphEnv(events, undefined)).toBe(true);
+    write('.env.e2e', 'BASE_URL=http://localhost:4302\n');
+    expect(outputsChangeInvalidatesGraphEnv(events, undefined)).toBe(true);
+  });
+
+  it('invalidates on a changed project-root dotenv file', () => {
+    write('apps/app1/.env', 'BASE_URL=http://localhost:4301\n');
+    expect(
+      outputsChangeInvalidatesGraphEnv(
+        [{ path: 'apps/app1/.env', type: EventType.create }],
+        graphWithRoots(['apps/app1'])
+      )
+    ).toBe(true);
+  });
+
+  it('invalidates on a dotenv path whose identifier contains a slash', () => {
+    // A target/configuration named with a slash makes getEnvPathsForTask emit a
+    // path like apps/app1/.env.e2e/smoke; it must still match relative to the root.
+    write('apps/app1/.env.e2e/smoke', 'BASE_URL=http://localhost:4301\n');
+    expect(
+      outputsChangeInvalidatesGraphEnv(
+        [{ path: 'apps/app1/.env.e2e/smoke', type: EventType.create }],
+        graphWithRoots(['apps/app1'])
+      )
+    ).toBe(true);
+  });
+
+  it('matches a parent-root dotenv when a nested root shadows the deepest dir', () => {
+    // A project rooted at apps/app1/.env.e2e must not shadow the parent
+    // apps/app1's slash-identifier dotenv (.env.e2e/smoke).
+    write('apps/app1/.env.e2e/smoke', 'BASE_URL=http://localhost:4301\n');
+    expect(
+      outputsChangeInvalidatesGraphEnv(
+        [{ path: 'apps/app1/.env.e2e/smoke', type: EventType.create }],
+        graphWithRoots(['apps/app1', 'apps/app1/.env.e2e'])
+      )
+    ).toBe(true);
+  });
+
+  it('ignores a dotenv file that sits under no root', () => {
+    write('apps/app1/nested/.env', 'X=1\n');
+    expect(
+      outputsChangeInvalidatesGraphEnv(
+        [{ path: 'apps/app1/nested/.env', type: EventType.create }],
+        graphWithRoots(['apps/app1'])
+      )
+    ).toBe(false);
+  });
+
+  it('ignores a non-dotenv file at a root', () => {
+    write('.eslintrc.json', '{}\n');
+    expect(
+      outputsChangeInvalidatesGraphEnv(
+        [{ path: '.eslintrc.json', type: EventType.update }],
+        undefined
+      )
+    ).toBe(false);
+  });
+
+  it('invalidates when a root dotenv file is deleted', () => {
+    expect(
+      outputsChangeInvalidatesGraphEnv(
+        [{ path: '.env', type: EventType.delete }],
+        undefined
+      )
+    ).toBe(true);
+  });
+});

--- a/packages/nx/src/daemon/server/dotenv-graph-changes.spec.ts
+++ b/packages/nx/src/daemon/server/dotenv-graph-changes.spec.ts
@@ -5,11 +5,16 @@ import type { ProjectGraph } from '../../config/project-graph';
 import { EventType } from '../../native';
 import { setWorkspaceRoot, workspaceRoot } from '../../utils/workspace-root';
 import {
-  _resetDotEnvFileHashes,
-  outputsChangesInvalidatingGraphEnv,
+  clearDotEnvFileHashes,
+  _resetPendingDotEnvEvents,
+  classifyDotEnvChanges,
+  drainPendingDotEnvEvents,
+  hasPendingDotEnvEvidence,
+  hasRelevantPendingDotEnvEvidence,
+  queuePendingDotEnvEvents,
 } from './dotenv-graph-changes';
 
-describe('outputsChangesInvalidatingGraphEnv', () => {
+describe('classifyDotEnvChanges', () => {
   const originalWorkspaceRoot = workspaceRoot;
   let tempDir: string;
 
@@ -21,7 +26,7 @@ describe('outputsChangesInvalidatingGraphEnv', () => {
     }) as any as ProjectGraph;
 
   beforeEach(() => {
-    _resetDotEnvFileHashes();
+    clearDotEnvFileHashes();
     tempDir = mkdtempSync(join(tmpdir(), 'nx-dotenv-watch-'));
     setWorkspaceRoot(tempDir);
   });
@@ -40,42 +45,63 @@ describe('outputsChangesInvalidatingGraphEnv', () => {
   it('invalidates on a changed workspace-root dotenv file', () => {
     write('.env.e2e', 'BASE_URL=http://localhost:4301\n');
     expect(
-      outputsChangesInvalidatingGraphEnv(
+      classifyDotEnvChanges(
         [{ path: '.env.e2e', type: EventType.create }],
         undefined
       )
-    ).toEqual(['.env.e2e']);
+    ).toEqual({ invalidating: ['.env.e2e'], unclassified: [] });
   });
 
   it('skips a byte-identical rewrite of a dotenv file', () => {
     write('.env.e2e', 'BASE_URL=http://localhost:4301\n');
     const events = [{ path: '.env.e2e', type: EventType.update }];
-    expect(outputsChangesInvalidatingGraphEnv(events, undefined)).toEqual([
-      '.env.e2e',
-    ]);
-    expect(outputsChangesInvalidatingGraphEnv(events, undefined)).toEqual([]);
+    expect(classifyDotEnvChanges(events, undefined)).toEqual({
+      invalidating: ['.env.e2e'],
+      unclassified: [],
+    });
+    expect(classifyDotEnvChanges(events, undefined)).toEqual({
+      invalidating: [],
+      unclassified: [],
+    });
   });
 
   it('invalidates again once the content actually changes', () => {
     write('.env.e2e', 'BASE_URL=http://localhost:4301\n');
     const events = [{ path: '.env.e2e', type: EventType.update }];
-    expect(outputsChangesInvalidatingGraphEnv(events, undefined)).toEqual([
-      '.env.e2e',
-    ]);
+    expect(classifyDotEnvChanges(events, undefined)).toEqual({
+      invalidating: ['.env.e2e'],
+      unclassified: [],
+    });
     write('.env.e2e', 'BASE_URL=http://localhost:4302\n');
-    expect(outputsChangesInvalidatingGraphEnv(events, undefined)).toEqual([
-      '.env.e2e',
-    ]);
+    expect(classifyDotEnvChanges(events, undefined)).toEqual({
+      invalidating: ['.env.e2e'],
+      unclassified: [],
+    });
   });
 
   it('invalidates on a changed project-root dotenv file', () => {
     write('apps/app1/.env', 'BASE_URL=http://localhost:4301\n');
     expect(
-      outputsChangesInvalidatingGraphEnv(
+      classifyDotEnvChanges(
         [{ path: 'apps/app1/.env', type: EventType.create }],
         graphWithRoots(['apps/app1'])
       )
-    ).toEqual(['apps/app1/.env']);
+    ).toEqual({ invalidating: ['apps/app1/.env'], unclassified: [] });
+  });
+
+  it('leaves a project-root dotenv unclassified without a graph, then invalidates once a graph classifies it', () => {
+    // The in-flight window: the daemon's first computation has not committed a
+    // graph when the event arrives, so the root is unknown. The recomputation
+    // replays the unclassified event before serving a graph.
+    write('apps/app1/.env.e2e', 'BASE_URL=http://localhost:4301\n');
+    const event = { path: 'apps/app1/.env.e2e', type: EventType.update };
+    expect(classifyDotEnvChanges([event], undefined)).toEqual({
+      invalidating: [],
+      unclassified: [event],
+    });
+    expect(
+      classifyDotEnvChanges([event], graphWithRoots(['apps/app1']))
+    ).toEqual({ invalidating: ['apps/app1/.env.e2e'], unclassified: [] });
   });
 
   it('invalidates on a dotenv path whose identifier contains a slash', () => {
@@ -83,31 +109,31 @@ describe('outputsChangesInvalidatingGraphEnv', () => {
     // path like apps/app1/.env.e2e/smoke; it must still match relative to the root.
     write('apps/app1/.env.e2e/smoke', 'BASE_URL=http://localhost:4301\n');
     expect(
-      outputsChangesInvalidatingGraphEnv(
+      classifyDotEnvChanges(
         [{ path: 'apps/app1/.env.e2e/smoke', type: EventType.create }],
         graphWithRoots(['apps/app1'])
       )
-    ).toEqual(['apps/app1/.env.e2e/smoke']);
+    ).toEqual({ invalidating: ['apps/app1/.env.e2e/smoke'], unclassified: [] });
   });
 
   it('invalidates on a suffixed dotenv name', () => {
     write('apps/app1/.e2e.env', 'BASE_URL=http://localhost:4301\n');
     expect(
-      outputsChangesInvalidatingGraphEnv(
+      classifyDotEnvChanges(
         [{ path: 'apps/app1/.e2e.env', type: EventType.create }],
         graphWithRoots(['apps/app1'])
       )
-    ).toEqual(['apps/app1/.e2e.env']);
+    ).toEqual({ invalidating: ['apps/app1/.e2e.env'], unclassified: [] });
   });
 
   it('invalidates on a suffixed dotenv path whose identifier contains a slash', () => {
     write('apps/app1/.e2e/smoke.env', 'BASE_URL=http://localhost:4301\n');
     expect(
-      outputsChangesInvalidatingGraphEnv(
+      classifyDotEnvChanges(
         [{ path: 'apps/app1/.e2e/smoke.env', type: EventType.create }],
         graphWithRoots(['apps/app1'])
       )
-    ).toEqual(['apps/app1/.e2e/smoke.env']);
+    ).toEqual({ invalidating: ['apps/app1/.e2e/smoke.env'], unclassified: [] });
   });
 
   it('matches a parent-root dotenv when a nested root shadows the deepest dir', () => {
@@ -115,64 +141,318 @@ describe('outputsChangesInvalidatingGraphEnv', () => {
     // apps/app1's slash-identifier dotenv (.env.e2e/smoke).
     write('apps/app1/.env.e2e/smoke', 'BASE_URL=http://localhost:4301\n');
     expect(
-      outputsChangesInvalidatingGraphEnv(
+      classifyDotEnvChanges(
         [{ path: 'apps/app1/.env.e2e/smoke', type: EventType.create }],
         graphWithRoots(['apps/app1', 'apps/app1/.env.e2e'])
       )
-    ).toEqual(['apps/app1/.env.e2e/smoke']);
+    ).toEqual({ invalidating: ['apps/app1/.env.e2e/smoke'], unclassified: [] });
   });
 
-  it('ignores a dotenv file that sits under no root', () => {
+  it('does not invalidate on a dotenv file that sits under no root of the given graph', () => {
     write('apps/app1/nested/.env', 'X=1\n');
+    const event = { path: 'apps/app1/nested/.env', type: EventType.create };
     expect(
-      outputsChangesInvalidatingGraphEnv(
-        [{ path: 'apps/app1/nested/.env', type: EventType.create }],
-        graphWithRoots(['apps/app1'])
-      )
-    ).toEqual([]);
+      classifyDotEnvChanges([event], graphWithRoots(['apps/app1']))
+    ).toEqual({ invalidating: [], unclassified: [event] });
   });
 
-  it('ignores a dot-directory artifact with the dotenv name shape', () => {
+  it('does not invalidate on a dot-directory artifact with the dotenv name shape', () => {
     // `.{id}.env` with id `github/workflows/ci` has the dotenv name shape, but
-    // paths like this are ordinary dot-directory files, not dotenv files.
+    // paths like this are ordinary dot-directory files, not dotenv files. They
+    // come back unclassified and a committed graph re-rejects them.
     write('.github/workflows/ci.env', 'X=1\n');
+    const event = { path: '.github/workflows/ci.env', type: EventType.create };
+    expect(classifyDotEnvChanges([event], undefined)).toEqual({
+      invalidating: [],
+      unclassified: [event],
+    });
     expect(
-      outputsChangesInvalidatingGraphEnv(
-        [{ path: '.github/workflows/ci.env', type: EventType.create }],
-        undefined
-      )
-    ).toEqual([]);
+      classifyDotEnvChanges([event], graphWithRoots(['apps/app1']))
+    ).toEqual({ invalidating: [], unclassified: [event] });
   });
 
-  it('ignores a workspace-root dotenv path whose identifier contains a slash', () => {
+  it('does not invalidate on a workspace-root dotenv path whose identifier contains a slash', () => {
     // The cost of rejecting dot-directory artifacts: a workspace-root dotenv
-    // for a `/`-containing target identifier no longer invalidates. Project
+    // for a `/`-containing target identifier never invalidates. Project
     // roots keep their slash identifiers via the root-ancestor walk.
     write('.env.e2e/smoke', 'X=1\n');
+    const event = { path: '.env.e2e/smoke', type: EventType.create };
+    expect(classifyDotEnvChanges([event], undefined)).toEqual({
+      invalidating: [],
+      unclassified: [event],
+    });
+  });
+
+  it('invalidates a re-created file with unchanged bytes after its events went unclassified', () => {
+    // A hash recorded while the root was known stops being proof once an event
+    // for the path goes unclassified: the graph may have observed a different
+    // state (e.g. the file's absence) in between.
+    write('apps/app1/.env.e2e', 'BASE_URL=http://localhost:4301\n');
+    const graph = graphWithRoots(['apps/app1']);
     expect(
-      outputsChangesInvalidatingGraphEnv(
-        [{ path: '.env.e2e/smoke', type: EventType.create }],
-        undefined
+      classifyDotEnvChanges(
+        [{ path: 'apps/app1/.env.e2e', type: EventType.update }],
+        graph
       )
-    ).toEqual([]);
+    ).toEqual({ invalidating: ['apps/app1/.env.e2e'], unclassified: [] });
+    // The root is gone from the committed graph, so the delete goes
+    // unclassified (and may be dropped at the next pre-serve replay).
+    const deleteEvent = { path: 'apps/app1/.env.e2e', type: EventType.delete };
+    expect(classifyDotEnvChanges([deleteEvent], undefined)).toEqual({
+      invalidating: [],
+      unclassified: [deleteEvent],
+    });
+    // Re-created with the same bytes once a graph knows the root again: the
+    // previously recorded hash must not suppress the invalidation.
+    expect(
+      classifyDotEnvChanges(
+        [{ path: 'apps/app1/.env.e2e', type: EventType.create }],
+        graph
+      )
+    ).toEqual({ invalidating: ['apps/app1/.env.e2e'], unclassified: [] });
   });
 
   it('ignores a non-dotenv file at a root', () => {
     write('.eslintrc.json', '{}\n');
     expect(
-      outputsChangesInvalidatingGraphEnv(
+      classifyDotEnvChanges(
         [{ path: '.eslintrc.json', type: EventType.update }],
         undefined
       )
-    ).toEqual([]);
+    ).toEqual({ invalidating: [], unclassified: [] });
   });
 
   it('invalidates when a root dotenv file is deleted', () => {
     expect(
-      outputsChangesInvalidatingGraphEnv(
+      classifyDotEnvChanges(
         [{ path: '.env', type: EventType.delete }],
         undefined
       )
-    ).toEqual(['.env']);
+    ).toEqual({ invalidating: ['.env'], unclassified: [] });
+  });
+});
+
+describe('pending dotenv event queue', () => {
+  const originalWorkspaceRoot = workspaceRoot;
+  let tempDir: string;
+
+  const graphWithRoots = (roots: string[]): ProjectGraph =>
+    ({
+      nodes: Object.fromEntries(
+        roots.map((root, i) => [`p${i}`, { data: { root } }])
+      ),
+    }) as any as ProjectGraph;
+
+  beforeEach(() => {
+    clearDotEnvFileHashes();
+    _resetPendingDotEnvEvents();
+    tempDir = mkdtempSync(join(tmpdir(), 'nx-dotenv-queue-'));
+    setWorkspaceRoot(tempDir);
+  });
+
+  afterEach(() => {
+    setWorkspaceRoot(originalWorkspaceRoot);
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('invalidates drained paths under a known root, deduplicated and cleared', () => {
+    queuePendingDotEnvEvents(['apps/e2e/.env.e2e', 'dist/out/.env.report'], 1);
+    queuePendingDotEnvEvents(['apps/e2e/.env.e2e'], 1);
+
+    expect(drainPendingDotEnvEvents(graphWithRoots(['apps/e2e']), 1)).toEqual({
+      invalidating: ['apps/e2e/.env.e2e'],
+      overflowed: false,
+    });
+    expect(drainPendingDotEnvEvents(graphWithRoots(['apps/e2e']), 1)).toEqual({
+      invalidating: [],
+      overflowed: false,
+    });
+  });
+
+  it('drops a path queued before the serving computation claimed its generation', () => {
+    // The computation started (and so read the file) after the event was
+    // queued, which is after the edit landed: recomputing again would be
+    // redundant.
+    queuePendingDotEnvEvents(['apps/e2e/.env.e2e'], 1);
+
+    expect(drainPendingDotEnvEvents(graphWithRoots(['apps/e2e']), 2)).toEqual({
+      invalidating: [],
+      overflowed: false,
+    });
+  });
+
+  it('invalidates at drain regardless of a recorded content hash, and drops it', () => {
+    // The computation the drain chains to may read intermediate bytes the
+    // watcher never reports separately, so a hash matching the current bytes
+    // proves nothing about the graph being served: the drain must invalidate
+    // and clear the hash so the next classified event invalidates too.
+    const abs = join(tempDir, 'apps/app1/.env.e2e');
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, 'PORT=4201\n');
+    const graph = graphWithRoots(['apps/app1']);
+    const event = { path: 'apps/app1/.env.e2e', type: EventType.update };
+    // Records the content hash.
+    expect(classifyDotEnvChanges([event], graph)).toEqual({
+      invalidating: ['apps/app1/.env.e2e'],
+      unclassified: [],
+    });
+
+    queuePendingDotEnvEvents([event.path], 1);
+    expect(drainPendingDotEnvEvents(graph, 1)).toEqual({
+      invalidating: ['apps/app1/.env.e2e'],
+      overflowed: false,
+    });
+
+    expect(classifyDotEnvChanges([event], graph)).toEqual({
+      invalidating: ['apps/app1/.env.e2e'],
+      unclassified: [],
+    });
+  });
+
+  it('reports overflow past the cap and resets the flag on drain', () => {
+    queuePendingDotEnvEvents(
+      Array.from({ length: 1025 }, (_, i) => `dist/out/.env.${i}`),
+      1
+    );
+
+    expect(drainPendingDotEnvEvents(undefined, 1)).toEqual({
+      invalidating: [],
+      overflowed: true,
+    });
+    expect(drainPendingDotEnvEvents(undefined, 1)).toEqual({
+      invalidating: [],
+      overflowed: false,
+    });
+  });
+
+  it('drops an overflow recorded before the serving computation claimed its generation', () => {
+    // The lost events were lost at queue-attempt time, so a computation that
+    // claimed a later generation read every affected file after those edits.
+    queuePendingDotEnvEvents(
+      Array.from({ length: 1025 }, (_, i) => `dist/out/.env.${i}`),
+      1
+    );
+
+    expect(drainPendingDotEnvEvents(undefined, 2)).toEqual({
+      invalidating: [],
+      overflowed: false,
+    });
+  });
+
+  it('reports pending evidence by generation without consuming it', () => {
+    expect(hasPendingDotEnvEvidence(1)).toBe(false);
+
+    queuePendingDotEnvEvents(['apps/e2e/.env.e2e'], 3);
+    expect(hasPendingDotEnvEvidence(3)).toBe(true);
+    // Non-consuming: the same call answers again, and the drain still sees
+    // the entry.
+    expect(hasPendingDotEnvEvidence(3)).toBe(true);
+    expect(hasPendingDotEnvEvidence(4)).toBe(false);
+    expect(drainPendingDotEnvEvents(graphWithRoots(['apps/e2e']), 3)).toEqual({
+      invalidating: ['apps/e2e/.env.e2e'],
+      overflowed: false,
+    });
+  });
+
+  it('reports overflow as evidence under the same generation rule', () => {
+    queuePendingDotEnvEvents(
+      Array.from({ length: 1025 }, (_, i) => `dist/out/.env.${i}`),
+      5
+    );
+
+    expect(hasPendingDotEnvEvidence(5)).toBe(true);
+    expect(hasPendingDotEnvEvidence(6)).toBe(false);
+    // Non-consuming: the drain still sees the overflow.
+    expect(drainPendingDotEnvEvents(undefined, 5).overflowed).toBe(true);
+  });
+
+  it('reports relevant evidence only for paths under a root of the given graph', () => {
+    queuePendingDotEnvEvents(['dist/out/.env.report'], 3);
+    expect(
+      hasRelevantPendingDotEnvEvidence(graphWithRoots(['apps/e2e']), 3)
+    ).toBe(false);
+
+    queuePendingDotEnvEvents(['apps/e2e/.env.e2e'], 3);
+    expect(
+      hasRelevantPendingDotEnvEvidence(graphWithRoots(['apps/e2e']), 3)
+    ).toBe(true);
+    expect(
+      hasRelevantPendingDotEnvEvidence(graphWithRoots(['apps/e2e']), 4)
+    ).toBe(false);
+    // Non-consuming: the drain still sees both entries.
+    expect(drainPendingDotEnvEvents(graphWithRoots(['apps/e2e']), 3)).toEqual({
+      invalidating: ['apps/e2e/.env.e2e'],
+      overflowed: false,
+    });
+  });
+
+  it('reports overflow as relevant evidence regardless of roots', () => {
+    // The lost events have no identity left to classify, so relevance cannot
+    // be ruled out.
+    queuePendingDotEnvEvents(
+      Array.from({ length: 1025 }, (_, i) => `dist/out/.env.${i}`),
+      5
+    );
+
+    expect(hasRelevantPendingDotEnvEvidence(graphWithRoots([]), 5)).toBe(true);
+    expect(hasRelevantPendingDotEnvEvidence(graphWithRoots([]), 6)).toBe(false);
+  });
+
+  it('drops the recorded hash of a path lost to overflow', () => {
+    // A lost path never reaches a drain, so a retained hash would suppress a
+    // later byte-identical event even though the computation racing it may
+    // have read intermediate bytes. The suppressible event can arrive before
+    // any drain runs, so the hash must go at insertion time.
+    const abs = join(tempDir, 'apps/app1/.env.e2e');
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, 'PORT=4201\n');
+    const graph = graphWithRoots(['apps/app1']);
+    const event = { path: 'apps/app1/.env.e2e', type: EventType.update };
+    // Records the content hash.
+    expect(classifyDotEnvChanges([event], graph)).toEqual({
+      invalidating: ['apps/app1/.env.e2e'],
+      unclassified: [],
+    });
+
+    queuePendingDotEnvEvents(
+      Array.from({ length: 1024 }, (_, i) => `dist/out/.env.${i}`),
+      1
+    );
+    // Lost to overflow: only the generation stamp survives.
+    queuePendingDotEnvEvents(['apps/app1/.env.e2e'], 1);
+
+    // Same bytes, no drain in between: must still invalidate.
+    expect(classifyDotEnvChanges([event], graph)).toEqual({
+      invalidating: ['apps/app1/.env.e2e'],
+      unclassified: [],
+    });
+  });
+
+  it('clears the hash of a never-queued path when a relevant overflow is drained', () => {
+    // A path that invalidated directly never enters the queue, so neither the
+    // insertion-time nor the per-entry drain deletion touches its hash. Once
+    // events are lost, that hash could suppress a later event over
+    // intermediate bytes read by the successor the drain forces.
+    const abs = join(tempDir, 'apps/app1/.env.e2e');
+    mkdirSync(dirname(abs), { recursive: true });
+    writeFileSync(abs, 'PORT=4201\n');
+    const graph = graphWithRoots(['apps/app1']);
+    const event = { path: 'apps/app1/.env.e2e', type: EventType.update };
+    // Records the content hash; the path stays out of the queue.
+    expect(classifyDotEnvChanges([event], graph)).toEqual({
+      invalidating: ['apps/app1/.env.e2e'],
+      unclassified: [],
+    });
+
+    queuePendingDotEnvEvents(
+      Array.from({ length: 1025 }, (_, i) => `dist/out/.env.${i}`),
+      1
+    );
+    expect(drainPendingDotEnvEvents(graph, 1).overflowed).toBe(true);
+
+    expect(classifyDotEnvChanges([event], graph)).toEqual({
+      invalidating: ['apps/app1/.env.e2e'],
+      unclassified: [],
+    });
   });
 });

--- a/packages/nx/src/daemon/server/dotenv-graph-changes.ts
+++ b/packages/nx/src/daemon/server/dotenv-graph-changes.ts
@@ -84,8 +84,9 @@ function graphTimeDotEnvRoots(
 /**
  * If `path` is a dotenv file that getEnvPathsForTask would load from the
  * workspace root or a project root, returns its name relative to that root;
- * otherwise null. The deepest matching root wins (nested projects), and the
- * relative name may contain `/` because a target/configuration identifier can.
+ * otherwise null. The deepest root that yields a dotenv name wins, so a nested
+ * project root does not shadow a parent's slash-identifier dotenv. The relative
+ * name may contain `/` because a target/configuration identifier can.
  */
 function dotEnvNameUnderRoot(path: string, roots: Set<string>): string | null {
   for (
@@ -94,9 +95,8 @@ function dotEnvNameUnderRoot(path: string, roots: Set<string>): string | null {
     slash = path.lastIndexOf('/', slash - 1)
   ) {
     const dir = path.slice(0, slash);
-    // A root closer to the file is checked first, but a non-match there must
-    // keep walking: the same path can be a slash-identifier dotenv for a
-    // shallower (parent) root.
+    // Keep walking past a closer root that yields no dotenv name: the same path
+    // can still be a slash-identifier dotenv for a shallower (parent) root.
     if (roots.has(dir)) {
       const name = path.slice(slash + 1);
       if (isDotEnvName(name)) {

--- a/packages/nx/src/daemon/server/dotenv-graph-changes.ts
+++ b/packages/nx/src/daemon/server/dotenv-graph-changes.ts
@@ -19,11 +19,11 @@ function isDotEnvName(name: string): boolean {
 }
 
 /**
- * Whether any change event touches a file with the dotenv name shape
+ * The paths among the change events with the dotenv name shape
  * getEnvPathsForTask loads (`.env[.<id>]` / `.<id>.env` variants) whose content
  * actually changed. The names are a superset of what any task loads: target and
- * configuration names are unknown here, so `.env.staging` invalidates whether
- * or not a task loads it. The daemon uses this to invalidate its graph cache so
+ * configuration names are unknown here, so `.env.staging` is reported whether
+ * or not a task loads it. The daemon uses this to refresh its graph cache so
  * createNodes re-resolves config that reads process.env.
  *
  * Only the workspace root and project roots are considered: getEnvPathsForTask
@@ -35,21 +35,21 @@ function isDotEnvName(name: string): boolean {
  * edit of one does not invalidate the graph. The cold path still resolves it:
  * getGraphTimeDotEnvForTask reads dotenv from disk directly.
  */
-export function outputsChangeInvalidatesGraphEnv(
+export function outputsChangesInvalidatingGraphEnv(
   changeEvents: WatchEvent[],
   projectGraph: ProjectGraph | undefined
-): boolean {
+): string[] {
   // Outputs batches rarely touch dotenv files, so the O(projects) roots set is
   // only built once a path clears this superset-of-dotenv-names check.
   const candidates = changeEvents.filter((event) =>
     mayBeDotEnvPath(event.path)
   );
   if (candidates.length === 0) {
-    return false;
+    return [];
   }
 
   const roots = graphTimeDotEnvRoots(projectGraph);
-  let invalidate = false;
+  const invalidatingPaths: string[] = [];
 
   for (const { path, type } of candidates) {
     if (!isDotEnvUnderRoot(path, roots)) {
@@ -60,7 +60,7 @@ export function outputsChangeInvalidatesGraphEnv(
       // A removed dotenv file drops the vars it set, so the config resolves
       // differently; there is no content to hash.
       dotEnvFileHashes.delete(path);
-      invalidate = true;
+      invalidatingPaths.push(path);
       continue;
     }
 
@@ -69,16 +69,16 @@ export function outputsChangeInvalidatesGraphEnv(
       continue;
     }
     // hashFile returns null on a vanished/unreadable file; when we cannot prove
-    // the content is unchanged, invalidate rather than risk a stale graph.
+    // the content is unchanged, report the path rather than risk a stale graph.
     if (hash !== null) {
       dotEnvFileHashes.set(path, hash);
     } else {
       dotEnvFileHashes.delete(path);
     }
-    invalidate = true;
+    invalidatingPaths.push(path);
   }
 
-  return invalidate;
+  return invalidatingPaths;
 }
 
 // Superset of the names both regexes accept: a prefixed name's first segment

--- a/packages/nx/src/daemon/server/dotenv-graph-changes.ts
+++ b/packages/nx/src/daemon/server/dotenv-graph-changes.ts
@@ -109,10 +109,11 @@ function graphTimeDotEnvRoots(
 
 /**
  * Whether `path` is a dotenv file that getEnvPathsForTask would load from the
- * workspace root or a project root. The name relative to the root may contain
- * `/` because a target/configuration identifier can, and every root ancestor is
- * tried, so a nested project root does not shadow a parent's slash-identifier
- * dotenv.
+ * workspace root or a project root. For a project root, the name relative to
+ * the root may contain `/` because a target/configuration identifier can, and
+ * every root ancestor is tried, so a nested project root does not shadow a
+ * parent's slash-identifier dotenv. At the workspace root, only
+ * single-segment names match.
  */
 function isDotEnvUnderRoot(path: string, roots: Set<string>): boolean {
   for (

--- a/packages/nx/src/daemon/server/dotenv-graph-changes.ts
+++ b/packages/nx/src/daemon/server/dotenv-graph-changes.ts
@@ -36,10 +36,19 @@ export function outputsChangeInvalidatesGraphEnv(
   changeEvents: WatchEvent[],
   projectGraph: ProjectGraph | undefined
 ): boolean {
+  // Outputs batches rarely touch dotenv files, so the O(projects) roots set is
+  // only built once a path clears this superset-of-dotenv-names check.
+  const candidates = changeEvents.filter((event) =>
+    mayBeDotEnvPath(event.path)
+  );
+  if (candidates.length === 0) {
+    return false;
+  }
+
   const roots = graphTimeDotEnvRoots(projectGraph);
   let invalidate = false;
 
-  for (const { path, type } of changeEvents) {
+  for (const { path, type } of candidates) {
     if (dotEnvNameUnderRoot(path, roots) === null) {
       continue;
     }
@@ -67,6 +76,15 @@ export function outputsChangeInvalidatesGraphEnv(
   }
 
   return invalidate;
+}
+
+// Superset of the names both regexes accept: a prefixed name's first segment
+// starts with `.env` and a suffixed name's last segment ends with `.env`, even
+// when the target/configuration identifier contains `/`.
+function mayBeDotEnvPath(path: string): boolean {
+  return path
+    .split('/')
+    .some((segment) => segment.startsWith('.env') || segment.endsWith('.env'));
 }
 
 function graphTimeDotEnvRoots(

--- a/packages/nx/src/daemon/server/dotenv-graph-changes.ts
+++ b/packages/nx/src/daemon/server/dotenv-graph-changes.ts
@@ -85,6 +85,11 @@ export function outputsChangesInvalidatingGraphEnv(
 // starts with `.env` and a suffixed name's last segment ends with `.env`, even
 // when the target/configuration identifier contains `/`.
 function mayBeDotEnvPath(path: string): boolean {
+  // Nearly every outputs path lacks the substring, so check it before the
+  // per-segment split: this runs for every path in every outputs batch.
+  if (!path.includes('.env')) {
+    return false;
+  }
   return path
     .split('/')
     .some((segment) => segment.startsWith('.env') || segment.endsWith('.env'));
@@ -123,9 +128,9 @@ function isDotEnvUnderRoot(path: string, roots: Set<string>): boolean {
     }
   }
   // No project-root ancestor: a workspace-root dotenv, single-segment names
-  // only. A deeper path (`.nx/cache/abc.env`, `.github/workflows/ci.env`) has
-  // the dotenv name shape only for a target identifier containing `/`;
-  // accepting those would invalidate on every write under such dot-directories.
+  // only. A deeper path (e.g. `.github/workflows/ci.env`) has the dotenv name
+  // shape only for a target identifier containing `/`; accepting those would
+  // invalidate on every write under such dot-directories.
   return roots.has('.') && !path.includes('/') && isDotEnvName(path);
 }
 

--- a/packages/nx/src/daemon/server/dotenv-graph-changes.ts
+++ b/packages/nx/src/daemon/server/dotenv-graph-changes.ts
@@ -19,9 +19,12 @@ function isDotEnvName(name: string): boolean {
 }
 
 /**
- * Whether any change event touches a dotenv file that a task chain would load
- * with content that actually changed. The daemon uses this to invalidate its
- * graph cache so createNodes re-resolves config that reads process.env.
+ * Whether any change event touches a file with the dotenv name shape
+ * getEnvPathsForTask loads (`.env[.<id>]` / `.<id>.env` variants) whose content
+ * actually changed. The names are a superset of what any task loads: target and
+ * configuration names are unknown here, so `.env.staging` invalidates whether
+ * or not a task loads it. The daemon uses this to invalidate its graph cache so
+ * createNodes re-resolves config that reads process.env.
  *
  * Only the workspace root and project roots are considered: getEnvPathsForTask
  * loads dotenv files from those, never from an arbitrary subdirectory (e.g. one
@@ -30,7 +33,7 @@ function isDotEnvName(name: string): boolean {
  * Known limitation: a `.nxignore`d dotenv file never reaches this watcher (the
  * native watcher applies `.nxignore` even with `use_ignore: false`), so a warm
  * edit of one does not invalidate the graph. The cold path still resolves it:
- * getGraphTimeEnvForTask reads dotenv from disk directly.
+ * getGraphTimeDotEnvForTask reads dotenv from disk directly.
  */
 export function outputsChangeInvalidatesGraphEnv(
   changeEvents: WatchEvent[],
@@ -49,7 +52,7 @@ export function outputsChangeInvalidatesGraphEnv(
   let invalidate = false;
 
   for (const { path, type } of candidates) {
-    if (dotEnvNameUnderRoot(path, roots) === null) {
+    if (!isDotEnvUnderRoot(path, roots)) {
       continue;
     }
 
@@ -100,13 +103,13 @@ function graphTimeDotEnvRoots(
 }
 
 /**
- * If `path` is a dotenv file that getEnvPathsForTask would load from the
- * workspace root or a project root, returns its name relative to that root;
- * otherwise null. The deepest root that yields a dotenv name wins, so a nested
- * project root does not shadow a parent's slash-identifier dotenv. The relative
- * name may contain `/` because a target/configuration identifier can.
+ * Whether `path` is a dotenv file that getEnvPathsForTask would load from the
+ * workspace root or a project root. The name relative to the root may contain
+ * `/` because a target/configuration identifier can, and every root ancestor is
+ * tried, so a nested project root does not shadow a parent's slash-identifier
+ * dotenv.
  */
-function dotEnvNameUnderRoot(path: string, roots: Set<string>): string | null {
+function isDotEnvUnderRoot(path: string, roots: Set<string>): boolean {
   for (
     let slash = path.lastIndexOf('/');
     slash > 0;
@@ -115,15 +118,15 @@ function dotEnvNameUnderRoot(path: string, roots: Set<string>): string | null {
     const dir = path.slice(0, slash);
     // Keep walking past a closer root that yields no dotenv name: the same path
     // can still be a slash-identifier dotenv for a shallower (parent) root.
-    if (roots.has(dir)) {
-      const name = path.slice(slash + 1);
-      if (isDotEnvName(name)) {
-        return name;
-      }
+    if (roots.has(dir) && isDotEnvName(path.slice(slash + 1))) {
+      return true;
     }
   }
-  // No project-root ancestor: treat as a workspace-root-relative path.
-  return roots.has('.') && isDotEnvName(path) ? path : null;
+  // No project-root ancestor: a workspace-root dotenv, single-segment names
+  // only. A deeper path (`.nx/cache/abc.env`, `.github/workflows/ci.env`) has
+  // the dotenv name shape only for a target identifier containing `/`;
+  // accepting those would invalidate on every write under such dot-directories.
+  return roots.has('.') && !path.includes('/') && isDotEnvName(path);
 }
 
 // Test helper: the hash map is daemon-lived module state.

--- a/packages/nx/src/daemon/server/dotenv-graph-changes.ts
+++ b/packages/nx/src/daemon/server/dotenv-graph-changes.ts
@@ -1,0 +1,114 @@
+import { join } from 'node:path';
+import type { ProjectGraph } from '../../config/project-graph';
+import { EventType, hashFile, type WatchEvent } from '../../native';
+import { workspaceRoot } from '../../utils/workspace-root';
+
+// Last-seen content hash per dotenv file, so a byte-identical rewrite (an editor
+// save that changes nothing) does not invalidate the graph cache.
+const dotEnvFileHashes = new Map<string, string>();
+
+// getEnvPathsForTask loads `.env`, `.env.local`, `.local.env` and the
+// target-scoped `.env.<id>[.local]` / `.<id>[.local].env` variants. The `<id>`
+// (a target or configuration name) may itself contain `/`, so the name is
+// matched relative to the owning root rather than by basename.
+const DOTENV_PREFIXED = /^\.env(\..+)?$/;
+const DOTENV_SUFFIXED = /^\..+\.env$/;
+
+function isDotEnvName(name: string): boolean {
+  return DOTENV_PREFIXED.test(name) || DOTENV_SUFFIXED.test(name);
+}
+
+/**
+ * Whether any change event touches a dotenv file that a task chain would load
+ * with content that actually changed. The daemon uses this to invalidate its
+ * graph cache so createNodes re-resolves config that reads process.env.
+ *
+ * Only the workspace root and project roots are considered: getEnvPathsForTask
+ * loads dotenv files from those, never from an arbitrary subdirectory (e.g. one
+ * under node_modules), and the outputs watcher spans the whole workspace root.
+ *
+ * Known limitation: a `.nxignore`d dotenv file never reaches this watcher (the
+ * native watcher applies `.nxignore` even with `use_ignore: false`), so a warm
+ * edit of one does not invalidate the graph. The cold path still resolves it:
+ * getGraphTimeEnvForTask reads dotenv from disk directly.
+ */
+export function outputsChangeInvalidatesGraphEnv(
+  changeEvents: WatchEvent[],
+  projectGraph: ProjectGraph | undefined
+): boolean {
+  const roots = graphTimeDotEnvRoots(projectGraph);
+  let invalidate = false;
+
+  for (const { path, type } of changeEvents) {
+    if (dotEnvNameUnderRoot(path, roots) === null) {
+      continue;
+    }
+
+    if (type === EventType.delete) {
+      // A removed dotenv file drops the vars it set, so the config resolves
+      // differently; there is no content to hash.
+      dotEnvFileHashes.delete(path);
+      invalidate = true;
+      continue;
+    }
+
+    const hash = hashFile(join(workspaceRoot, path));
+    if (hash !== null && dotEnvFileHashes.get(path) === hash) {
+      continue;
+    }
+    // hashFile returns null on a vanished/unreadable file; when we cannot prove
+    // the content is unchanged, invalidate rather than risk a stale graph.
+    if (hash !== null) {
+      dotEnvFileHashes.set(path, hash);
+    } else {
+      dotEnvFileHashes.delete(path);
+    }
+    invalidate = true;
+  }
+
+  return invalidate;
+}
+
+function graphTimeDotEnvRoots(
+  projectGraph: ProjectGraph | undefined
+): Set<string> {
+  const roots = new Set<string>(['.']);
+  if (projectGraph) {
+    for (const node of Object.values(projectGraph.nodes)) {
+      roots.add(node.data.root);
+    }
+  }
+  return roots;
+}
+
+/**
+ * If `path` is a dotenv file that getEnvPathsForTask would load from the
+ * workspace root or a project root, returns its name relative to that root;
+ * otherwise null. The deepest matching root wins (nested projects), and the
+ * relative name may contain `/` because a target/configuration identifier can.
+ */
+function dotEnvNameUnderRoot(path: string, roots: Set<string>): string | null {
+  for (
+    let slash = path.lastIndexOf('/');
+    slash > 0;
+    slash = path.lastIndexOf('/', slash - 1)
+  ) {
+    const dir = path.slice(0, slash);
+    // A root closer to the file is checked first, but a non-match there must
+    // keep walking: the same path can be a slash-identifier dotenv for a
+    // shallower (parent) root.
+    if (roots.has(dir)) {
+      const name = path.slice(slash + 1);
+      if (isDotEnvName(name)) {
+        return name;
+      }
+    }
+  }
+  // No project-root ancestor: treat as a workspace-root-relative path.
+  return roots.has('.') && isDotEnvName(path) ? path : null;
+}
+
+// Test helper: the hash map is daemon-lived module state.
+export function _resetDotEnvFileHashes(): void {
+  dotEnvFileHashes.clear();
+}

--- a/packages/nx/src/daemon/server/dotenv-graph-changes.ts
+++ b/packages/nx/src/daemon/server/dotenv-graph-changes.ts
@@ -307,11 +307,12 @@ export function hasRelevantPendingDotEnvEvidence(
 }
 
 /**
- * Drops every recorded content hash. The error-path retry and the warm-reuse
- * check force a successor while preserving the queue for its drain, but a
- * recorded hash is not proof the graph that successor serves observed those
- * bytes; kept, it could suppress a callback that lands while the successor
- * reads.
+ * Drops every recorded content hash. Each computation clears on claiming its
+ * generation, bounding every hash to the window since the last claim: an
+ * older hash is not proof the graph a successor serves observed those bytes,
+ * and kept, it could suppress a callback that lands while the successor
+ * reads. The error-path retry and the warm-reuse check also clear when they
+ * force a successor while preserving the queue for its drain.
  */
 export function clearDotEnvFileHashes(): void {
   dotEnvFileHashes.clear();

--- a/packages/nx/src/daemon/server/dotenv-graph-changes.ts
+++ b/packages/nx/src/daemon/server/dotenv-graph-changes.ts
@@ -18,41 +18,62 @@ function isDotEnvName(name: string): boolean {
   return DOTENV_PREFIXED.test(name) || DOTENV_SUFFIXED.test(name);
 }
 
+export interface DotEnvChangeClassification {
+  invalidating: string[];
+  unclassified: WatchEvent[];
+}
+
 /**
- * The paths among the change events with the dotenv name shape
- * getEnvPathsForTask loads (`.env[.<id>]` / `.<id>.env` variants) whose content
- * actually changed. The names are a superset of what any task loads: target and
+ * Splits the change events into `invalidating`: the paths with the dotenv name
+ * shape getEnvPathsForTask loads (`.env[.<id>]` / `.<id>.env` variants), under
+ * the workspace root or a project root, whose content actually changed; and
+ * `unclassified`: the dotenv-shaped events under no known root. The
+ * invalidating names are a superset of what any task loads: target and
  * configuration names are unknown here, so `.env.staging` is reported whether
  * or not a task loads it. The daemon uses this to refresh its graph cache so
  * createNodes re-resolves config that reads process.env.
  *
- * Only the workspace root and project roots are considered: getEnvPathsForTask
+ * Only the workspace root and project roots invalidate: getEnvPathsForTask
  * loads dotenv files from those, never from an arbitrary subdirectory (e.g. one
  * under node_modules), and the outputs watcher spans the whole workspace root.
+ * An unclassified event is not necessarily irrelevant, though: the graph it was
+ * classified against can predate the file's project root (none is committed
+ * during the initial computation, and a replaced graph lacks a project that
+ * computation is adding), so the caller queues it for replay against the next
+ * graph a computation is about to serve rather than dropping it.
  *
  * Known limitation: a `.nxignore`d dotenv file never reaches this watcher (the
  * native watcher applies `.nxignore` even with `use_ignore: false`), so a warm
  * edit of one does not invalidate the graph. The cold path still resolves it:
  * getGraphTimeDotEnvForTask reads dotenv from disk directly.
  */
-export function outputsChangesInvalidatingGraphEnv(
+export function classifyDotEnvChanges(
   changeEvents: WatchEvent[],
   projectGraph: ProjectGraph | undefined
-): string[] {
+): DotEnvChangeClassification {
   // Outputs batches rarely touch dotenv files, so the O(projects) roots set is
   // only built once a path clears this superset-of-dotenv-names check.
   const candidates = changeEvents.filter((event) =>
     mayBeDotEnvPath(event.path)
   );
   if (candidates.length === 0) {
-    return [];
+    return { invalidating: [], unclassified: [] };
   }
 
   const roots = graphTimeDotEnvRoots(projectGraph);
-  const invalidatingPaths: string[] = [];
+  const invalidating: string[] = [];
+  const unclassified: WatchEvent[] = [];
 
-  for (const { path, type } of candidates) {
+  for (const event of candidates) {
+    const { path, type } = event;
     if (!isDotEnvUnderRoot(path, roots)) {
+      // A recorded hash stops being proof the graph observed the current
+      // content once an event for the path cannot be classified: the pending
+      // replay can drop it, and a later classified event with the same bytes
+      // would then be suppressed as an unchanged rewrite over a graph that
+      // observed a different state (e.g. the file's absence).
+      dotEnvFileHashes.delete(path);
+      unclassified.push(event);
       continue;
     }
 
@@ -60,7 +81,7 @@ export function outputsChangesInvalidatingGraphEnv(
       // A removed dotenv file drops the vars it set, so the config resolves
       // differently; there is no content to hash.
       dotEnvFileHashes.delete(path);
-      invalidatingPaths.push(path);
+      invalidating.push(path);
       continue;
     }
 
@@ -75,10 +96,10 @@ export function outputsChangesInvalidatingGraphEnv(
     } else {
       dotEnvFileHashes.delete(path);
     }
-    invalidatingPaths.push(path);
+    invalidating.push(path);
   }
 
-  return invalidatingPaths;
+  return { invalidating, unclassified };
 }
 
 // Superset of the names both regexes accept: a prefixed name's first segment
@@ -135,7 +156,169 @@ function isDotEnvUnderRoot(path: string, roots: Set<string>): boolean {
   return roots.has('.') && !path.includes('/') && isDotEnvName(path);
 }
 
-// Test helper: the hash map is daemon-lived module state.
-export function _resetDotEnvFileHashes(): void {
+// Paths of dotenv-shaped events whose graph refresh is not provably scheduled:
+// paths under no known root on arrival (the next graph may know the root) and
+// edits to tracked files (the workspace watcher schedules the refresh, but a
+// computation already in flight may have read the file before the edit). Each
+// maps to the recomputation generation current at queue time, so the pre-serve
+// replay can prove whether a computation started before the event arrived.
+const pendingDotEnvEvents = new Map<string, number>();
+// Bounds daemon-lived growth when nothing drains for a long time. The
+// generation current when the last event was lost stands in for the lost
+// stamps, so overflow follows the same freshness rule as a queued entry.
+const MAX_PENDING_DOTENV_EVENTS = 1024;
+let pendingDotEnvEventsOverflowedAtGeneration: number | undefined;
+
+/**
+ * `generation` is the recomputation generation current at queue time; the
+ * drain compares it against the serving computation's generation to prove
+ * whether that computation started before the event arrived.
+ */
+export function queuePendingDotEnvEvents(
+  paths: string[],
+  generation: number
+): void {
+  for (const path of paths) {
+    if (
+      pendingDotEnvEvents.size >= MAX_PENDING_DOTENV_EVENTS &&
+      !pendingDotEnvEvents.has(path)
+    ) {
+      pendingDotEnvEventsOverflowedAtGeneration = generation;
+      // A lost path never reaches a drain, so its recorded hash would outlive
+      // the queue's deletion discipline and could suppress a later event over
+      // a graph that observed different bytes. Drop it while the identity is
+      // still known.
+      dotEnvFileHashes.delete(path);
+    } else {
+      pendingDotEnvEvents.set(path, generation);
+    }
+  }
+}
+
+/**
+ * Takes and clears the queued unclassified events, returning the paths that
+ * are dotenv files under a root of `projectGraph` and were queued at or after
+ * `sinceGeneration` (the serving computation's generation). A path queued
+ * earlier is dropped safely: the computation claimed its generation after the
+ * event was queued, so it read the file after the edit landed. Content hashes
+ * are neither consulted nor recorded here, and any hash recorded for a
+ * drained path is dropped: a hash taken mid-computation is not proof any
+ * served graph observed those bytes (the computation may read intermediate
+ * content), so suppressing a later event on it could leave the graph stale.
+ * `overflowed` means events were lost at or after `sinceGeneration`, so the
+ * caller cannot prove its graph fresh and must invalidate; an overflow
+ * recorded earlier is dropped by the same rule as a queued entry. A relevant
+ * overflow also drops every recorded hash: with events lost, a retained hash
+ * (even for a path that invalidated directly and never entered the queue)
+ * could suppress a later event over intermediate bytes read by the successor
+ * this drain forces. That successor is already being forced, so clearing
+ * adds no recomputation.
+ *
+ * A stamp records callback time, not edit time, so an event whose edit a
+ * workspace-watcher-triggered computation already observed can still
+ * invalidate it: one redundant recompute, accepted because the callback
+ * cannot prove which side of that computation's file read the edit landed on.
+ */
+export function drainPendingDotEnvEvents(
+  projectGraph: ProjectGraph | undefined,
+  sinceGeneration: number
+): { invalidating: string[]; overflowed: boolean } {
+  const entries = Array.from(pendingDotEnvEvents.entries());
+  const overflowed =
+    pendingDotEnvEventsOverflowedAtGeneration !== undefined &&
+    pendingDotEnvEventsOverflowedAtGeneration >= sinceGeneration;
+  pendingDotEnvEvents.clear();
+  pendingDotEnvEventsOverflowedAtGeneration = undefined;
+  if (overflowed) {
+    dotEnvFileHashes.clear();
+  }
+  if (entries.length === 0) {
+    return { invalidating: [], overflowed };
+  }
+  const roots = graphTimeDotEnvRoots(projectGraph);
+  const invalidating: string[] = [];
+  for (const [path, generation] of entries) {
+    dotEnvFileHashes.delete(path);
+    if (generation >= sinceGeneration && isDotEnvUnderRoot(path, roots)) {
+      invalidating.push(path);
+    }
+  }
+  return { invalidating, overflowed };
+}
+
+/**
+ * Whether the queue holds evidence that a computation at `sinceGeneration`
+ * may have read a dotenv file before a reported edit landed: an entry or an
+ * overflow stamped at or after that generation. Consumes nothing and
+ * classifies against no roots: the error paths use this to decide on a retry,
+ * where there may be no graph to classify against, and a spurious retry costs
+ * one recompute on an already failing path. A persistent error retries once,
+ * because the retry's successor claims a generation above every stamp
+ * recorded so far.
+ */
+export function hasPendingDotEnvEvidence(sinceGeneration: number): boolean {
+  if (
+    pendingDotEnvEventsOverflowedAtGeneration !== undefined &&
+    pendingDotEnvEventsOverflowedAtGeneration >= sinceGeneration
+  ) {
+    return true;
+  }
+  for (const generation of pendingDotEnvEvents.values()) {
+    if (generation >= sinceGeneration) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Like hasPendingDotEnvEvidence, but classifies each entry against the roots
+ * of `projectGraph`: evidence is an overflow stamped at or after
+ * `sinceGeneration`, or an entry so stamped whose path is a dotenv file under
+ * one of the graph's roots. The warm-reuse check uses this, where the graph
+ * the cache serves exists and is exactly what a recompute would refresh;
+ * skipping paths under none of its roots avoids recomputing for events only
+ * a future graph could classify, and consuming nothing leaves those entries
+ * queued for that computation's drain.
+ */
+export function hasRelevantPendingDotEnvEvidence(
+  projectGraph: ProjectGraph | undefined,
+  sinceGeneration: number
+): boolean {
+  if (
+    pendingDotEnvEventsOverflowedAtGeneration !== undefined &&
+    pendingDotEnvEventsOverflowedAtGeneration >= sinceGeneration
+  ) {
+    return true;
+  }
+  let roots: Set<string> | undefined;
+  for (const [path, generation] of pendingDotEnvEvents) {
+    if (generation < sinceGeneration) {
+      continue;
+    }
+    if (!roots) {
+      roots = graphTimeDotEnvRoots(projectGraph);
+    }
+    if (isDotEnvUnderRoot(path, roots)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+/**
+ * Drops every recorded content hash. The error-path retry and the warm-reuse
+ * check force a successor while preserving the queue for its drain, but a
+ * recorded hash is not proof the graph that successor serves observed those
+ * bytes; kept, it could suppress a callback that lands while the successor
+ * reads.
+ */
+export function clearDotEnvFileHashes(): void {
   dotEnvFileHashes.clear();
+}
+
+// Test helper: the queue is daemon-lived module state.
+export function _resetPendingDotEnvEvents(): void {
+  pendingDotEnvEvents.clear();
+  pendingDotEnvEventsOverflowedAtGeneration = undefined;
 }

--- a/packages/nx/src/daemon/server/handle-client-env.spec.ts
+++ b/packages/nx/src/daemon/server/handle-client-env.spec.ts
@@ -1,0 +1,114 @@
+import { getPluginsIfLoadedOrLoading } from '../../project-graph/plugins/get-plugins';
+import { applyDaemonEnvFromClient } from '../client/daemon-environment';
+import { serverLogger } from '../logger';
+import { handleClientEnv } from './handle-client-env';
+import {
+  invalidateGraphCache,
+  markInFlightRecomputationsStale,
+} from './project-graph-incremental-recomputation';
+
+jest.mock('../client/daemon-environment', () => ({
+  applyDaemonEnvFromClient: jest.fn(),
+}));
+jest.mock('../../project-graph/plugins/get-plugins', () => ({
+  getPluginsIfLoadedOrLoading: jest.fn(),
+}));
+jest.mock('./project-graph-incremental-recomputation', () => ({
+  invalidateGraphCache: jest.fn(),
+  markInFlightRecomputationsStale: jest.fn(),
+}));
+jest.mock('../logger', () => ({
+  serverLogger: { log: jest.fn() },
+}));
+
+describe('handleClientEnv', () => {
+  const env = { FOO: 'bar' };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (applyDaemonEnvFromClient as jest.Mock).mockReturnValue(['FOO']);
+    (getPluginsIfLoadedOrLoading as jest.Mock).mockReturnValue(undefined);
+  });
+
+  it('does nothing beyond applying the env when no keys changed', async () => {
+    (applyDaemonEnvFromClient as jest.Mock).mockReturnValue([]);
+
+    await handleClientEnv(env);
+
+    expect(applyDaemonEnvFromClient).toHaveBeenCalledWith(env);
+    expect(getPluginsIfLoadedOrLoading).not.toHaveBeenCalled();
+    expect(invalidateGraphCache).not.toHaveBeenCalled();
+    expect(markInFlightRecomputationsStale).not.toHaveBeenCalled();
+  });
+
+  it('awaits worker forwarding before discarding the cached graph', async () => {
+    let resolveForward: () => void = () => {};
+    const setWorkerEnv = jest.fn().mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveForward = resolve;
+      })
+    );
+    (getPluginsIfLoadedOrLoading as jest.Mock).mockReturnValue(
+      Promise.resolve([{ name: 'a', setWorkerEnv }])
+    );
+
+    const done = handleClientEnv(env);
+    await Promise.resolve();
+    expect(setWorkerEnv).toHaveBeenCalledWith(env);
+    expect(invalidateGraphCache).not.toHaveBeenCalled();
+    expect(markInFlightRecomputationsStale).not.toHaveBeenCalled();
+
+    resolveForward();
+    await done;
+    expect(invalidateGraphCache).toHaveBeenCalled();
+    expect(markInFlightRecomputationsStale).toHaveBeenCalled();
+  });
+
+  it('settles when a worker fails to receive the env', async () => {
+    (getPluginsIfLoadedOrLoading as jest.Mock).mockReturnValue(
+      Promise.resolve([
+        {
+          name: 'dead',
+          setWorkerEnv: jest.fn().mockRejectedValue(new Error('worker exited')),
+        },
+        { name: 'alive', setWorkerEnv: jest.fn().mockResolvedValue(undefined) },
+      ])
+    );
+
+    await handleClientEnv(env);
+
+    expect(serverLogger.log).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'Failed to forward env to plugin worker "dead": worker exited'
+      )
+    );
+    expect(invalidateGraphCache).toHaveBeenCalled();
+    expect(markInFlightRecomputationsStale).toHaveBeenCalled();
+  });
+
+  it('discards the cached graph even when no plugins are loaded', async () => {
+    await handleClientEnv(env);
+
+    expect(invalidateGraphCache).toHaveBeenCalled();
+    expect(markInFlightRecomputationsStale).toHaveBeenCalled();
+  });
+
+  it('settles when an in-flight plugin load fails', async () => {
+    (getPluginsIfLoadedOrLoading as jest.Mock).mockReturnValue(
+      Promise.reject(new Error('load failed'))
+    );
+
+    await expect(handleClientEnv(env)).resolves.toBeUndefined();
+    expect(invalidateGraphCache).toHaveBeenCalled();
+    expect(markInFlightRecomputationsStale).toHaveBeenCalled();
+  });
+
+  it('skips plugins without a worker to forward to', async () => {
+    (getPluginsIfLoadedOrLoading as jest.Mock).mockReturnValue(
+      Promise.resolve([{ name: 'in-process' }])
+    );
+
+    await expect(handleClientEnv(env)).resolves.toBeUndefined();
+    expect(invalidateGraphCache).toHaveBeenCalled();
+  });
+});

--- a/packages/nx/src/daemon/server/handle-client-env.spec.ts
+++ b/packages/nx/src/daemon/server/handle-client-env.spec.ts
@@ -1,11 +1,8 @@
 import { getPluginsIfLoadedOrLoading } from '../../project-graph/plugins/get-plugins';
 import { applyDaemonEnvFromClient } from '../client/daemon-environment';
 import { serverLogger } from '../logger';
-import { handleClientEnv } from './handle-client-env';
-import {
-  invalidateGraphCache,
-  markInFlightRecomputationsStale,
-} from './project-graph-incremental-recomputation';
+import { handleClientEnv, _setEnvForwardTimeoutMs } from './handle-client-env';
+import { invalidateGraphCache } from './project-graph-incremental-recomputation';
 
 jest.mock('../client/daemon-environment', () => ({
   applyDaemonEnvFromClient: jest.fn(),
@@ -15,7 +12,6 @@ jest.mock('../../project-graph/plugins/get-plugins', () => ({
 }));
 jest.mock('./project-graph-incremental-recomputation', () => ({
   invalidateGraphCache: jest.fn(),
-  markInFlightRecomputationsStale: jest.fn(),
 }));
 jest.mock('../logger', () => ({
   serverLogger: { log: jest.fn() },
@@ -23,6 +19,7 @@ jest.mock('../logger', () => ({
 
 describe('handleClientEnv', () => {
   const env = { FOO: 'bar' };
+  const flushMicrotasks = () => new Promise(setImmediate);
 
   beforeEach(() => {
     jest.clearAllMocks();
@@ -38,7 +35,6 @@ describe('handleClientEnv', () => {
     expect(applyDaemonEnvFromClient).toHaveBeenCalledWith(env);
     expect(getPluginsIfLoadedOrLoading).not.toHaveBeenCalled();
     expect(invalidateGraphCache).not.toHaveBeenCalled();
-    expect(markInFlightRecomputationsStale).not.toHaveBeenCalled();
   });
 
   it('awaits worker forwarding before discarding the cached graph', async () => {
@@ -53,15 +49,65 @@ describe('handleClientEnv', () => {
     );
 
     const done = handleClientEnv(env);
-    await Promise.resolve();
+    await flushMicrotasks();
     expect(setWorkerEnv).toHaveBeenCalledWith(env);
     expect(invalidateGraphCache).not.toHaveBeenCalled();
-    expect(markInFlightRecomputationsStale).not.toHaveBeenCalled();
 
     resolveForward();
     await done;
     expect(invalidateGraphCache).toHaveBeenCalled();
-    expect(markInFlightRecomputationsStale).toHaveBeenCalled();
+  });
+
+  it('holds a no-change client until the in-flight apply completes', async () => {
+    let resolveForward: () => void = () => {};
+    const setWorkerEnv = jest.fn().mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveForward = resolve;
+      })
+    );
+    (getPluginsIfLoadedOrLoading as jest.Mock).mockReturnValue(
+      Promise.resolve([{ name: 'a', setWorkerEnv }])
+    );
+
+    const first = handleClientEnv(env);
+    // The second client carries the same env the first already wrote to
+    // process.env, so its own apply reports no changed keys.
+    (applyDaemonEnvFromClient as jest.Mock).mockReturnValue([]);
+    let secondSettled = false;
+    const second = handleClientEnv(env).then(() => {
+      secondSettled = true;
+    });
+
+    await flushMicrotasks();
+    expect(secondSettled).toBe(false);
+    expect(invalidateGraphCache).not.toHaveBeenCalled();
+
+    resolveForward();
+    await first;
+    await second;
+    expect(secondSettled).toBe(true);
+    expect(invalidateGraphCache).toHaveBeenCalled();
+  });
+
+  it('proceeds after the forward timeout when a worker never acknowledges', async () => {
+    _setEnvForwardTimeoutMs(50);
+    try {
+      const setWorkerEnv = jest.fn().mockReturnValue(new Promise(() => {}));
+      (getPluginsIfLoadedOrLoading as jest.Mock).mockReturnValue(
+        Promise.resolve([{ name: 'wedged', setWorkerEnv }])
+      );
+
+      await handleClientEnv(env);
+
+      expect(invalidateGraphCache).toHaveBeenCalled();
+      expect(serverLogger.log).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'Timed out forwarding the new env to plugin workers'
+        )
+      );
+    } finally {
+      _setEnvForwardTimeoutMs(10_000);
+    }
   });
 
   it('settles when a worker fails to receive the env', async () => {
@@ -83,14 +129,12 @@ describe('handleClientEnv', () => {
       )
     );
     expect(invalidateGraphCache).toHaveBeenCalled();
-    expect(markInFlightRecomputationsStale).toHaveBeenCalled();
   });
 
   it('discards the cached graph even when no plugins are loaded', async () => {
     await handleClientEnv(env);
 
     expect(invalidateGraphCache).toHaveBeenCalled();
-    expect(markInFlightRecomputationsStale).toHaveBeenCalled();
   });
 
   it('settles when an in-flight plugin load fails', async () => {
@@ -100,7 +144,6 @@ describe('handleClientEnv', () => {
 
     await expect(handleClientEnv(env)).resolves.toBeUndefined();
     expect(invalidateGraphCache).toHaveBeenCalled();
-    expect(markInFlightRecomputationsStale).toHaveBeenCalled();
   });
 
   it('skips plugins without a worker to forward to', async () => {

--- a/packages/nx/src/daemon/server/handle-client-env.spec.ts
+++ b/packages/nx/src/daemon/server/handle-client-env.spec.ts
@@ -27,6 +27,31 @@ describe('handleClientEnv', () => {
     (getPluginsIfLoadedOrLoading as jest.Mock).mockReturnValue(undefined);
   });
 
+  it('discards the cached graph for a client change a config write already matches', async () => {
+    // With plugins running in the daemon, a config can write the value the
+    // next client sends before that client's env arrives; process.env then
+    // has nothing to move on, but the graph in flight was computed under the
+    // previous client and must not be served to this one.
+    (applyDaemonEnvFromClient as jest.Mock).mockImplementation(
+      jest.requireActual('../client/daemon-environment')
+        .applyDaemonEnvFromClient
+    );
+    const originalEnv = process.env;
+    process.env = { ...originalEnv };
+    try {
+      const previous = { ...process.env };
+      await handleClientEnv(previous);
+      jest.clearAllMocks();
+      process.env.MASKED_PROBE = 'from-config';
+
+      await handleClientEnv({ ...previous, MASKED_PROBE: 'from-config' });
+
+      expect(invalidateGraphCache).toHaveBeenCalled();
+    } finally {
+      process.env = originalEnv;
+    }
+  });
+
   it('does nothing beyond applying the env when no keys changed', async () => {
     (applyDaemonEnvFromClient as jest.Mock).mockReturnValue([]);
 

--- a/packages/nx/src/daemon/server/handle-client-env.spec.ts
+++ b/packages/nx/src/daemon/server/handle-client-env.spec.ts
@@ -1,20 +1,21 @@
+import type { Mock } from 'vitest';
 import { getPluginsIfLoadedOrLoading } from '../../project-graph/plugins/get-plugins';
 import { applyDaemonEnvFromClient } from '../client/daemon-environment';
 import { serverLogger } from '../logger';
 import { handleClientEnv, _setEnvForwardTimeoutMs } from './handle-client-env';
 import { invalidateGraphCache } from './project-graph-incremental-recomputation';
 
-jest.mock('../client/daemon-environment', () => ({
-  applyDaemonEnvFromClient: jest.fn(),
+vi.mock('../client/daemon-environment', () => ({
+  applyDaemonEnvFromClient: vi.fn(),
 }));
-jest.mock('../../project-graph/plugins/get-plugins', () => ({
-  getPluginsIfLoadedOrLoading: jest.fn(),
+vi.mock('../../project-graph/plugins/get-plugins', () => ({
+  getPluginsIfLoadedOrLoading: vi.fn(),
 }));
-jest.mock('./project-graph-incremental-recomputation', () => ({
-  invalidateGraphCache: jest.fn(),
+vi.mock('./project-graph-incremental-recomputation', () => ({
+  invalidateGraphCache: vi.fn(),
 }));
-jest.mock('../logger', () => ({
-  serverLogger: { log: jest.fn() },
+vi.mock('../logger', () => ({
+  serverLogger: { log: vi.fn() },
 }));
 
 describe('handleClientEnv', () => {
@@ -22,9 +23,9 @@ describe('handleClientEnv', () => {
   const flushMicrotasks = () => new Promise(setImmediate);
 
   beforeEach(() => {
-    jest.clearAllMocks();
-    (applyDaemonEnvFromClient as jest.Mock).mockReturnValue(['FOO']);
-    (getPluginsIfLoadedOrLoading as jest.Mock).mockReturnValue(undefined);
+    vi.clearAllMocks();
+    (applyDaemonEnvFromClient as Mock).mockReturnValue(['FOO']);
+    (getPluginsIfLoadedOrLoading as Mock).mockReturnValue(undefined);
   });
 
   it('discards the cached graph for a client change a config write already matches', async () => {
@@ -32,16 +33,18 @@ describe('handleClientEnv', () => {
     // next client sends before that client's env arrives; process.env then
     // has nothing to move on, but the graph in flight was computed under the
     // previous client and must not be served to this one.
-    (applyDaemonEnvFromClient as jest.Mock).mockImplementation(
-      jest.requireActual('../client/daemon-environment')
-        .applyDaemonEnvFromClient
+    const actual = await vi.importActual<
+      typeof import('../client/daemon-environment')
+    >('../client/daemon-environment');
+    (applyDaemonEnvFromClient as Mock).mockImplementation(
+      actual.applyDaemonEnvFromClient
     );
     const originalEnv = process.env;
     process.env = { ...originalEnv };
     try {
       const previous = { ...process.env };
       await handleClientEnv(previous);
-      jest.clearAllMocks();
+      vi.clearAllMocks();
       process.env.MASKED_PROBE = 'from-config';
 
       await handleClientEnv({ ...previous, MASKED_PROBE: 'from-config' });
@@ -53,7 +56,7 @@ describe('handleClientEnv', () => {
   });
 
   it('does nothing beyond applying the env when no keys changed', async () => {
-    (applyDaemonEnvFromClient as jest.Mock).mockReturnValue([]);
+    (applyDaemonEnvFromClient as Mock).mockReturnValue([]);
 
     await handleClientEnv(env);
 
@@ -64,12 +67,12 @@ describe('handleClientEnv', () => {
 
   it('awaits worker forwarding before discarding the cached graph', async () => {
     let resolveForward: () => void = () => {};
-    const setWorkerEnv = jest.fn().mockReturnValue(
+    const setWorkerEnv = vi.fn().mockReturnValue(
       new Promise<void>((resolve) => {
         resolveForward = resolve;
       })
     );
-    (getPluginsIfLoadedOrLoading as jest.Mock).mockReturnValue(
+    (getPluginsIfLoadedOrLoading as Mock).mockReturnValue(
       Promise.resolve([{ name: 'a', setWorkerEnv }])
     );
 
@@ -85,19 +88,19 @@ describe('handleClientEnv', () => {
 
   it('holds a no-change client until the in-flight apply completes', async () => {
     let resolveForward: () => void = () => {};
-    const setWorkerEnv = jest.fn().mockReturnValue(
+    const setWorkerEnv = vi.fn().mockReturnValue(
       new Promise<void>((resolve) => {
         resolveForward = resolve;
       })
     );
-    (getPluginsIfLoadedOrLoading as jest.Mock).mockReturnValue(
+    (getPluginsIfLoadedOrLoading as Mock).mockReturnValue(
       Promise.resolve([{ name: 'a', setWorkerEnv }])
     );
 
     const first = handleClientEnv(env);
     // The second client carries the same env the first already wrote to
     // process.env, so its own apply reports no changed keys.
-    (applyDaemonEnvFromClient as jest.Mock).mockReturnValue([]);
+    (applyDaemonEnvFromClient as Mock).mockReturnValue([]);
     let secondSettled = false;
     const second = handleClientEnv(env).then(() => {
       secondSettled = true;
@@ -117,8 +120,8 @@ describe('handleClientEnv', () => {
   it('proceeds after the forward timeout when a worker never acknowledges', async () => {
     _setEnvForwardTimeoutMs(50);
     try {
-      const setWorkerEnv = jest.fn().mockReturnValue(new Promise(() => {}));
-      (getPluginsIfLoadedOrLoading as jest.Mock).mockReturnValue(
+      const setWorkerEnv = vi.fn().mockReturnValue(new Promise(() => {}));
+      (getPluginsIfLoadedOrLoading as Mock).mockReturnValue(
         Promise.resolve([{ name: 'wedged', setWorkerEnv }])
       );
 
@@ -136,13 +139,13 @@ describe('handleClientEnv', () => {
   });
 
   it('settles when a worker fails to receive the env', async () => {
-    (getPluginsIfLoadedOrLoading as jest.Mock).mockReturnValue(
+    (getPluginsIfLoadedOrLoading as Mock).mockReturnValue(
       Promise.resolve([
         {
           name: 'dead',
-          setWorkerEnv: jest.fn().mockRejectedValue(new Error('worker exited')),
+          setWorkerEnv: vi.fn().mockRejectedValue(new Error('worker exited')),
         },
-        { name: 'alive', setWorkerEnv: jest.fn().mockResolvedValue(undefined) },
+        { name: 'alive', setWorkerEnv: vi.fn().mockResolvedValue(undefined) },
       ])
     );
 
@@ -163,7 +166,7 @@ describe('handleClientEnv', () => {
   });
 
   it('settles when an in-flight plugin load fails', async () => {
-    (getPluginsIfLoadedOrLoading as jest.Mock).mockReturnValue(
+    (getPluginsIfLoadedOrLoading as Mock).mockReturnValue(
       Promise.reject(new Error('load failed'))
     );
 
@@ -172,7 +175,7 @@ describe('handleClientEnv', () => {
   });
 
   it('skips plugins without a worker to forward to', async () => {
-    (getPluginsIfLoadedOrLoading as jest.Mock).mockReturnValue(
+    (getPluginsIfLoadedOrLoading as Mock).mockReturnValue(
       Promise.resolve([{ name: 'in-process' }])
     );
 

--- a/packages/nx/src/daemon/server/handle-client-env.ts
+++ b/packages/nx/src/daemon/server/handle-client-env.ts
@@ -2,10 +2,19 @@ import { getPluginsIfLoadedOrLoading } from '../../project-graph/plugins/get-plu
 import type { LoadedNxPlugin } from '../../project-graph/plugins/loaded-nx-plugin';
 import { applyDaemonEnvFromClient } from '../client/daemon-environment';
 import { serverLogger } from '../logger';
-import {
-  invalidateGraphCache,
-  markInFlightRecomputationsStale,
-} from './project-graph-incremental-recomputation';
+import { invalidateGraphCache } from './project-graph-incremental-recomputation';
+
+// Bounds the wait for worker acknowledgements so a wedged worker cannot hold
+// every env-carrying client message for the 10-minute plugin-hook timeout. A
+// healthy worker applies the env synchronously and acks in milliseconds.
+let envForwardTimeoutMs = 10_000;
+
+// Test seam: the production timeout would stall the suite.
+export function _setEnvForwardTimeoutMs(ms: number): void {
+  envForwardTimeoutMs = ms;
+}
+
+let inFlightApply: Promise<void> | undefined;
 
 /**
  * Applies an env-carrying client message to the daemon. Must be awaited
@@ -16,6 +25,13 @@ import {
 export async function handleClientEnv(
   env: Record<string, string>
 ): Promise<void> {
+  // A client whose env matches one an in-flight apply already wrote to
+  // process.env sees zero changed keys, yet the graph cache is only discarded
+  // once that apply's forwarding completes. Wait for it so such a client
+  // cannot be served the graph computed under the previous env.
+  while (inFlightApply) {
+    await inFlightApply;
+  }
   const changedEnvKeys = applyDaemonEnvFromClient(env);
   if (changedEnvKeys.length === 0) {
     return;
@@ -25,12 +41,23 @@ export async function handleClientEnv(
       ', '
     )}`
   );
+  const apply = applyEnvChange(env);
+  inFlightApply = apply;
+  try {
+    await apply;
+  } finally {
+    if (inFlightApply === apply) {
+      inFlightApply = undefined;
+    }
+  }
+}
+
+async function applyEnvChange(env: Record<string, string>): Promise<void> {
   await forwardEnvToPluginWorkers(env);
-  // Both discards are needed: clearing the cache makes the next request
-  // recompute under the new env, and the generation bump chains any in-flight
-  // compute (started under the old env) to that successor.
+  // Discarding the cached graph makes the next request recompute under the
+  // new env, and chains any in-flight compute (started under the old env) to
+  // that successor.
   invalidateGraphCache();
-  markInFlightRecomputationsStale();
 }
 
 // Covers committed workers and an in-flight load, whose workers forked under
@@ -38,8 +65,28 @@ export async function handleClientEnv(
 // load started after this needs no forwarding: its workers fork with the
 // daemon's already-updated process.env. Each forward settles rather than
 // rejects so one dead worker (or a failed load) cannot fail every env-carrying
-// client message.
+// client message. Timing out is safe: each worker socket delivers the already
+// sent env update before any later graph message, and the plugin cache write
+// guard drops a pass the update lands in the middle of.
 async function forwardEnvToPluginWorkers(
+  env: Record<string, string>
+): Promise<void> {
+  let timer: NodeJS.Timeout;
+  const timedOut = await Promise.race([
+    forwardEnvToPluginWorkersUnbounded(env).then(() => false),
+    new Promise<true>((resolve) => {
+      timer = setTimeout(() => resolve(true), envForwardTimeoutMs);
+      timer.unref();
+    }),
+  ]).finally(() => clearTimeout(timer));
+  if (timedOut) {
+    serverLogger.log(
+      `Timed out forwarding the new env to plugin workers after ${envForwardTimeoutMs}ms; continuing without their acknowledgement.`
+    );
+  }
+}
+
+async function forwardEnvToPluginWorkersUnbounded(
   env: Record<string, string>
 ): Promise<void> {
   const pluginsPromise = getPluginsIfLoadedOrLoading();

--- a/packages/nx/src/daemon/server/handle-client-env.ts
+++ b/packages/nx/src/daemon/server/handle-client-env.ts
@@ -1,0 +1,65 @@
+import { getPluginsIfLoadedOrLoading } from '../../project-graph/plugins/get-plugins';
+import type { LoadedNxPlugin } from '../../project-graph/plugins/loaded-nx-plugin';
+import { applyDaemonEnvFromClient } from '../client/daemon-environment';
+import { serverLogger } from '../logger';
+import {
+  invalidateGraphCache,
+  markInFlightRecomputationsStale,
+} from './project-graph-incremental-recomputation';
+
+/**
+ * Applies an env-carrying client message to the daemon. Must be awaited
+ * before dispatching the message's handler: plugin workers key their disk
+ * caches on their own process env, so a graph request must not reach a worker
+ * whose env still reflects the previous client.
+ */
+export async function handleClientEnv(
+  env: Record<string, string>
+): Promise<void> {
+  const changedEnvKeys = applyDaemonEnvFromClient(env);
+  if (changedEnvKeys.length === 0) {
+    return;
+  }
+  serverLogger.log(
+    `Graph recompute necessary due to env variable refresh. Changed keys: ${changedEnvKeys.join(
+      ', '
+    )}`
+  );
+  await forwardEnvToPluginWorkers(env);
+  // Both discards are needed: clearing the cache makes the next request
+  // recompute under the new env, and the generation bump chains any in-flight
+  // compute (started under the old env) to that successor.
+  invalidateGraphCache();
+  markInFlightRecomputationsStale();
+}
+
+// Covers committed workers and an in-flight load, whose workers forked under
+// the previous env before this apply and would otherwise keep it for good. A
+// load started after this needs no forwarding: its workers fork with the
+// daemon's already-updated process.env. Each forward settles rather than
+// rejects so one dead worker (or a failed load) cannot fail every env-carrying
+// client message.
+async function forwardEnvToPluginWorkers(
+  env: Record<string, string>
+): Promise<void> {
+  const pluginsPromise = getPluginsIfLoadedOrLoading();
+  if (!pluginsPromise) {
+    return;
+  }
+  let plugins: LoadedNxPlugin[];
+  try {
+    plugins = await pluginsPromise;
+  } catch {
+    // The load failed, so there are no workers to forward to.
+    return;
+  }
+  await Promise.all(
+    plugins.map((plugin) =>
+      plugin.setWorkerEnv?.(env)?.catch((e) => {
+        serverLogger.log(
+          `Failed to forward env to plugin worker "${plugin.name}": ${e.message}`
+        );
+      })
+    )
+  );
+}

--- a/packages/nx/src/daemon/server/handle-outputs-changes.spec.ts
+++ b/packages/nx/src/daemon/server/handle-outputs-changes.spec.ts
@@ -1,0 +1,94 @@
+import { EventType, type WatchEvent } from '../../native';
+
+jest.mock('../logger', () => ({
+  serverLogger: { watcherLog: jest.fn() },
+}));
+jest.mock('./outputs-tracking', () => ({
+  disableOutputsTracking: jest.fn(),
+  processFileChangesInOutputs: jest.fn(),
+}));
+jest.mock('./project-graph-incremental-recomputation', () => ({
+  currentProjectGraph: undefined,
+  invalidateGraphCache: jest.fn(),
+  isKnownWorkspaceFile: jest.fn(() => true),
+}));
+jest.mock('./dotenv-graph-changes', () => ({
+  outputsChangesInvalidatingGraphEnv: jest.fn(() => []),
+}));
+
+describe('handleOutputsChanges', () => {
+  let handleOutputsChanges: typeof import('./handle-outputs-changes').handleOutputsChanges;
+  let getOutputsWatcherTerminalError: typeof import('./handle-outputs-changes').getOutputsWatcherTerminalError;
+  let outputsTracking: {
+    disableOutputsTracking: jest.Mock;
+    processFileChangesInOutputs: jest.Mock;
+  };
+  let recomputation: {
+    invalidateGraphCache: jest.Mock;
+    isKnownWorkspaceFile: jest.Mock;
+  };
+  let dotenvChanges: { outputsChangesInvalidatingGraphEnv: jest.Mock };
+  let consoleError: jest.SpyInstance;
+
+  const events: WatchEvent[] = [{ path: '.env.e2e', type: EventType.update }];
+
+  beforeEach(() => {
+    // The watcher error flags are module state, so each test gets a fresh
+    // module registry, with the mocks re-required from the same registry the
+    // module under test resolves.
+    jest.resetModules();
+    ({ handleOutputsChanges, getOutputsWatcherTerminalError } =
+      require('./handle-outputs-changes') as typeof import('./handle-outputs-changes'));
+    outputsTracking = require('./outputs-tracking');
+    recomputation = require('./project-graph-incremental-recomputation');
+    dotenvChanges = require('./dotenv-graph-changes');
+    consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleError.mockRestore();
+  });
+
+  it('records a native watcher error as terminal, preserving its message, and disables outputs tracking', async () => {
+    await handleOutputsChanges(
+      'inotify_add_watch failed registering new directory watch: limit',
+      null
+    );
+
+    expect(getOutputsWatcherTerminalError().message).toContain(
+      'inotify_add_watch'
+    );
+    expect(outputsTracking.disableOutputsTracking).toHaveBeenCalled();
+  });
+
+  it('does not record an empty delivery as terminal', async () => {
+    await handleOutputsChanges(null, []);
+
+    expect(getOutputsWatcherTerminalError()).toBeUndefined();
+    expect(outputsTracking.disableOutputsTracking).toHaveBeenCalled();
+  });
+
+  it('keeps invalidating the graph for dotenv edits after a processing failure, which is not terminal', async () => {
+    // A processing failure happens with the native watcher still alive, so
+    // later events keep arriving; only their outputs processing stays off.
+    outputsTracking.processFileChangesInOutputs.mockImplementationOnce(() => {
+      throw new Error('boom');
+    });
+    await handleOutputsChanges(null, events);
+
+    expect(getOutputsWatcherTerminalError()).toBeUndefined();
+    expect(outputsTracking.disableOutputsTracking).toHaveBeenCalled();
+
+    dotenvChanges.outputsChangesInvalidatingGraphEnv.mockReturnValue([
+      '.env.e2e',
+    ]);
+    recomputation.isKnownWorkspaceFile.mockReturnValue(false);
+    await handleOutputsChanges(null, events);
+
+    expect(recomputation.invalidateGraphCache).toHaveBeenCalled();
+    expect(getOutputsWatcherTerminalError()).toBeUndefined();
+    expect(outputsTracking.processFileChangesInOutputs).toHaveBeenCalledTimes(
+      1
+    );
+  });
+});

--- a/packages/nx/src/daemon/server/handle-outputs-changes.spec.ts
+++ b/packages/nx/src/daemon/server/handle-outputs-changes.spec.ts
@@ -9,11 +9,16 @@ jest.mock('./outputs-tracking', () => ({
 }));
 jest.mock('./project-graph-incremental-recomputation', () => ({
   currentProjectGraph: undefined,
+  getRecomputationGeneration: jest.fn(() => 7),
   invalidateGraphCache: jest.fn(),
   isKnownWorkspaceFile: jest.fn(() => true),
 }));
 jest.mock('./dotenv-graph-changes', () => ({
-  outputsChangesInvalidatingGraphEnv: jest.fn(() => []),
+  classifyDotEnvChanges: jest.fn(() => ({
+    invalidating: [],
+    unclassified: [],
+  })),
+  queuePendingDotEnvEvents: jest.fn(),
 }));
 
 describe('handleOutputsChanges', () => {
@@ -27,7 +32,10 @@ describe('handleOutputsChanges', () => {
     invalidateGraphCache: jest.Mock;
     isKnownWorkspaceFile: jest.Mock;
   };
-  let dotenvChanges: { outputsChangesInvalidatingGraphEnv: jest.Mock };
+  let dotenvChanges: {
+    classifyDotEnvChanges: jest.Mock;
+    queuePendingDotEnvEvents: jest.Mock;
+  };
   let consoleError: jest.SpyInstance;
 
   const events: WatchEvent[] = [{ path: '.env.e2e', type: EventType.update }];
@@ -79,9 +87,10 @@ describe('handleOutputsChanges', () => {
     expect(getOutputsWatcherTerminalError()).toBeUndefined();
     expect(outputsTracking.disableOutputsTracking).toHaveBeenCalled();
 
-    dotenvChanges.outputsChangesInvalidatingGraphEnv.mockReturnValue([
-      '.env.e2e',
-    ]);
+    dotenvChanges.classifyDotEnvChanges.mockReturnValue({
+      invalidating: ['.env.e2e'],
+      unclassified: [],
+    });
     recomputation.isKnownWorkspaceFile.mockReturnValue(false);
     await handleOutputsChanges(null, events);
 
@@ -90,5 +99,41 @@ describe('handleOutputsChanges', () => {
     expect(outputsTracking.processFileChangesInOutputs).toHaveBeenCalledTimes(
       1
     );
+  });
+
+  it('forwards unclassified dotenv events to the pending queue without invalidating', async () => {
+    const event: WatchEvent = {
+      path: 'apps/e2e/.env.e2e',
+      type: EventType.update,
+    };
+    dotenvChanges.classifyDotEnvChanges.mockReturnValueOnce({
+      invalidating: [],
+      unclassified: [event],
+    });
+    await handleOutputsChanges(null, [event]);
+
+    expect(dotenvChanges.queuePendingDotEnvEvents).toHaveBeenCalledWith(
+      ['apps/e2e/.env.e2e'],
+      7
+    );
+    expect(recomputation.invalidateGraphCache).not.toHaveBeenCalled();
+  });
+
+  it('queues an invalidating edit of a tracked dotenv file instead of invalidating', async () => {
+    // The workspace watcher schedules the recomputation for a tracked file,
+    // but a computation already in flight may have read the file before the
+    // edit; only the queued evidence lets the pre-serve replay prove that.
+    dotenvChanges.classifyDotEnvChanges.mockReturnValueOnce({
+      invalidating: ['libs/foo/.env.e2e'],
+      unclassified: [],
+    });
+    recomputation.isKnownWorkspaceFile.mockReturnValue(true);
+    await handleOutputsChanges(null, events);
+
+    expect(dotenvChanges.queuePendingDotEnvEvents).toHaveBeenCalledWith(
+      ['libs/foo/.env.e2e'],
+      7
+    );
+    expect(recomputation.invalidateGraphCache).not.toHaveBeenCalled();
   });
 });

--- a/packages/nx/src/daemon/server/handle-outputs-changes.spec.ts
+++ b/packages/nx/src/daemon/server/handle-outputs-changes.spec.ts
@@ -1,56 +1,59 @@
+import type { Mock, MockInstance } from 'vitest';
 import { EventType, type WatchEvent } from '../../native';
 
-jest.mock('../logger', () => ({
-  serverLogger: { watcherLog: jest.fn() },
+vi.mock('../logger', () => ({
+  serverLogger: { watcherLog: vi.fn() },
 }));
-jest.mock('./outputs-tracking', () => ({
-  disableOutputsTracking: jest.fn(),
-  processFileChangesInOutputs: jest.fn(),
+vi.mock('./outputs-tracking', () => ({
+  disableOutputsTracking: vi.fn(),
+  processFileChangesInOutputs: vi.fn(),
 }));
-jest.mock('./project-graph-incremental-recomputation', () => ({
+vi.mock('./project-graph-incremental-recomputation', () => ({
   currentProjectGraph: undefined,
-  getRecomputationGeneration: jest.fn(() => 7),
-  invalidateGraphCache: jest.fn(),
-  isKnownWorkspaceFile: jest.fn(() => true),
+  getRecomputationGeneration: vi.fn(() => 7),
+  invalidateGraphCache: vi.fn(),
+  isKnownWorkspaceFile: vi.fn(() => true),
 }));
-jest.mock('./dotenv-graph-changes', () => ({
-  classifyDotEnvChanges: jest.fn(() => ({
+vi.mock('./dotenv-graph-changes', () => ({
+  classifyDotEnvChanges: vi.fn(() => ({
     invalidating: [],
     unclassified: [],
   })),
-  queuePendingDotEnvEvents: jest.fn(),
+  queuePendingDotEnvEvents: vi.fn(),
 }));
 
 describe('handleOutputsChanges', () => {
   let handleOutputsChanges: typeof import('./handle-outputs-changes').handleOutputsChanges;
   let getOutputsWatcherTerminalError: typeof import('./handle-outputs-changes').getOutputsWatcherTerminalError;
   let outputsTracking: {
-    disableOutputsTracking: jest.Mock;
-    processFileChangesInOutputs: jest.Mock;
+    disableOutputsTracking: Mock;
+    processFileChangesInOutputs: Mock;
   };
   let recomputation: {
-    invalidateGraphCache: jest.Mock;
-    isKnownWorkspaceFile: jest.Mock;
+    invalidateGraphCache: Mock;
+    isKnownWorkspaceFile: Mock;
   };
   let dotenvChanges: {
-    classifyDotEnvChanges: jest.Mock;
-    queuePendingDotEnvEvents: jest.Mock;
+    classifyDotEnvChanges: Mock;
+    queuePendingDotEnvEvents: Mock;
   };
-  let consoleError: jest.SpyInstance;
+  let consoleError: MockInstance;
 
   const events: WatchEvent[] = [{ path: '.env.e2e', type: EventType.update }];
 
-  beforeEach(() => {
+  beforeEach(async () => {
     // The watcher error flags are module state, so each test gets a fresh
-    // module registry, with the mocks re-required from the same registry the
-    // module under test resolves.
-    jest.resetModules();
+    // module registry. resetModules does not re-run the vi.mock factories, so
+    // the mock fns persist across tests and their recorded calls are cleared.
+    vi.resetModules();
+    vi.clearAllMocks();
     ({ handleOutputsChanges, getOutputsWatcherTerminalError } =
-      require('./handle-outputs-changes') as typeof import('./handle-outputs-changes'));
-    outputsTracking = require('./outputs-tracking');
-    recomputation = require('./project-graph-incremental-recomputation');
-    dotenvChanges = require('./dotenv-graph-changes');
-    consoleError = jest.spyOn(console, 'error').mockImplementation(() => {});
+      await import('./handle-outputs-changes'));
+    outputsTracking = (await import('./outputs-tracking')) as any;
+    recomputation =
+      (await import('./project-graph-incremental-recomputation')) as any;
+    dotenvChanges = (await import('./dotenv-graph-changes')) as any;
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => {});
   });
 
   afterEach(() => {

--- a/packages/nx/src/daemon/server/handle-outputs-changes.ts
+++ b/packages/nx/src/daemon/server/handle-outputs-changes.ts
@@ -1,11 +1,15 @@
 import { serverLogger } from '../logger';
-import { outputsChangesInvalidatingGraphEnv } from './dotenv-graph-changes';
+import {
+  classifyDotEnvChanges,
+  queuePendingDotEnvEvents,
+} from './dotenv-graph-changes';
 import {
   disableOutputsTracking,
   processFileChangesInOutputs,
 } from './outputs-tracking';
 import {
   currentProjectGraph,
+  getRecomputationGeneration,
   invalidateGraphCache,
   isKnownWorkspaceFile,
 } from './project-graph-incremental-recomputation';
@@ -58,21 +62,32 @@ export const handleOutputsChanges: FileWatcherCallback = async (
     // disabled outputs tracker must not leave the graph stale on a dotenv edit.
     // A change to a file the workspace watcher tracks already schedules a
     // recomputation that reads the new content; invalidating for it here too
-    // would discard that recomputation at commit and force a second one. The
-    // committed file map approximates what the watcher tracks: a file it does
-    // not know is either gitignored (never reaches the workspace watcher, so it
-    // needs the invalidation) or created since the last recompute (the watcher
-    // handles it; the extra invalidation is fail-safe). Its own try/catch so a
-    // fault here cannot trip the outputs-tracking kill switch below, which
-    // belongs to an unrelated subsystem, and it fails safe by invalidating: a
-    // stale graph on a dotenv edit is the bug this prevents.
+    // would discard that recomputation at commit and force a second one. It is
+    // queued instead of dropped: the two watchers deliver independently, so a
+    // computation already in flight may have read the file before the edit,
+    // and only the pre-serve replay can prove that. The committed file map
+    // approximates what the watcher tracks: a file it does not know is either
+    // gitignored (never reaches the workspace watcher, so it needs the
+    // invalidation) or created since the last recompute (the watcher handles
+    // it; the extra invalidation is fail-safe). Its own try/catch so a fault
+    // here cannot trip the outputs-tracking kill switch below, which belongs
+    // to an unrelated subsystem, and it fails safe by invalidating: a stale
+    // graph on a dotenv edit is the bug this prevents.
     try {
-      if (
-        outputsChangesInvalidatingGraphEnv(
-          changeEvents,
-          currentProjectGraph
-        ).some((path) => !isKnownWorkspaceFile(path))
-      ) {
+      const { invalidating, unclassified } = classifyDotEnvChanges(
+        changeEvents,
+        currentProjectGraph
+      );
+      const generation = getRecomputationGeneration();
+      queuePendingDotEnvEvents(
+        unclassified.map((event) => event.path),
+        generation
+      );
+      const knownInvalidating = invalidating.filter((path) =>
+        isKnownWorkspaceFile(path)
+      );
+      queuePendingDotEnvEvents(knownInvalidating, generation);
+      if (knownInvalidating.length < invalidating.length) {
         invalidateGraphCache();
       }
     } catch (e) {

--- a/packages/nx/src/daemon/server/handle-outputs-changes.ts
+++ b/packages/nx/src/daemon/server/handle-outputs-changes.ts
@@ -1,0 +1,99 @@
+import { serverLogger } from '../logger';
+import { outputsChangesInvalidatingGraphEnv } from './dotenv-graph-changes';
+import {
+  disableOutputsTracking,
+  processFileChangesInOutputs,
+} from './outputs-tracking';
+import {
+  currentProjectGraph,
+  invalidateGraphCache,
+  isKnownWorkspaceFile,
+} from './project-graph-incremental-recomputation';
+import type { FileWatcherCallback } from './watcher';
+
+let outputsWatcherError: Error | undefined;
+let outputsWatcherTerminalError: Error | undefined;
+
+/**
+ * The error a native outputs watcher failure delivered, if one has. Such an
+ * error is terminal (the native watch loop exits after delivering it), so the
+ * gitignored dotenv edits only that watcher reports stop arriving and a warm
+ * graph would go stale silently. The server fails requests closed on it, like
+ * a workspace watcher error.
+ */
+export function getOutputsWatcherTerminalError(): Error | undefined {
+  return outputsWatcherTerminalError;
+}
+
+export const handleOutputsChanges: FileWatcherCallback = async (
+  err,
+  changeEvents
+) => {
+  try {
+    if (err || !changeEvents || !changeEvents.length) {
+      let error = typeof err === 'string' ? new Error(err) : err;
+      serverLogger.watcherLog(
+        'Unexpected outputs watcher error',
+        error.message
+      );
+      console.error(error);
+      outputsWatcherError = error;
+      disableOutputsTracking();
+      if (err) {
+        // A native error is terminal: the watch loop has exited, so the
+        // gitignored dotenv edits only this watcher reports stop arriving and
+        // the graph invalidation below can never run again. Fail requests
+        // closed like a workspace watcher error rather than serving a graph
+        // that silently goes stale. The original error is preserved so an
+        // inotify_add_watch failure still makes the client disable the daemon
+        // and rebuild without it.
+        outputsWatcherTerminalError = error;
+      }
+      return;
+    }
+
+    // A dotenv change that a task chain loads must refresh the graph so
+    // createNodes re-resolves config reading process.env. This runs above the
+    // outputsWatcherError guard: the two concerns are independent, and a
+    // disabled outputs tracker must not leave the graph stale on a dotenv edit.
+    // A change to a file the workspace watcher tracks already schedules a
+    // recomputation that reads the new content; invalidating for it here too
+    // would discard that recomputation at commit and force a second one. The
+    // committed file map approximates what the watcher tracks: a file it does
+    // not know is either gitignored (never reaches the workspace watcher, so it
+    // needs the invalidation) or created since the last recompute (the watcher
+    // handles it; the extra invalidation is fail-safe). Its own try/catch so a
+    // fault here cannot trip the outputs-tracking kill switch below, which
+    // belongs to an unrelated subsystem, and it fails safe by invalidating: a
+    // stale graph on a dotenv edit is the bug this prevents.
+    try {
+      if (
+        outputsChangesInvalidatingGraphEnv(
+          changeEvents,
+          currentProjectGraph
+        ).some((path) => !isKnownWorkspaceFile(path))
+      ) {
+        invalidateGraphCache();
+      }
+    } catch (e) {
+      serverLogger.watcherLog(
+        'Failed to evaluate dotenv changes for graph invalidation; invalidating the graph cache to be safe',
+        e instanceof Error ? e.message : String(e)
+      );
+      console.error(e);
+      invalidateGraphCache();
+    }
+
+    if (outputsWatcherError) {
+      return;
+    }
+
+    serverLogger.watcherLog('Processing file changes in outputs');
+    processFileChangesInOutputs(changeEvents);
+  } catch (err) {
+    serverLogger.watcherLog(`Unexpected outputs watcher error`, err.message);
+    console.error(err);
+    outputsWatcherError = err;
+    disableOutputsTracking();
+  }
+};

--- a/packages/nx/src/daemon/server/project-graph-incremental-recomputation.spec.ts
+++ b/packages/nx/src/daemon/server/project-graph-incremental-recomputation.spec.ts
@@ -7,7 +7,7 @@ import { TempFs } from '../../internal-testing-utils/temp-fs';
 // which registers a process-global PerformanceObserver. That observer outlives
 // each test's isolated module registry, so a measure emitted by the last real
 // compute would dispatch after teardown and its lazy requires would throw.
-jest.mock('../../utils/perf-logging', () => ({}));
+vi.mock('../../utils/perf-logging', () => ({}));
 
 describe('getCachedSerializedProjectGraphPromise — watcher race coverage', () => {
   let fs: TempFs;
@@ -256,39 +256,38 @@ describe('isKnownWorkspaceFile', () => {
       'libs/foo/src/index.ts': '',
     });
 
-    await jest.isolateModulesAsync(async () => {
-      // The plugin-loader mocks jest.doMock installs in the tests above are
-      // registry-wide and outlive their isolated module graphs.
-      jest.dontMock('../../project-graph/plugins/get-plugins');
-      const { setWorkspaceRoot } = require('../../utils/workspace-root');
-      setWorkspaceRoot(fs.tempDir);
+    vi.resetModules();
+    // The plugin-loader mocks vi.doMock installs in the tests above are
+    // registry-wide and outlive vi.resetModules.
+    vi.doUnmock('../../project-graph/plugins/get-plugins');
+    const { setWorkspaceRoot } = await import('../../utils/workspace-root');
+    setWorkspaceRoot(fs.tempDir);
 
-      const {
-        getCachedSerializedProjectGraphPromise,
-        scheduleProjectGraphRecomputation,
-        isKnownWorkspaceFile,
-      } = require('./project-graph-incremental-recomputation');
+    const {
+      getCachedSerializedProjectGraphPromise,
+      scheduleProjectGraphRecomputation,
+      isKnownWorkspaceFile,
+    } = await import('./project-graph-incremental-recomputation');
 
-      // Nothing is known before the first recompute commits a map; the caller
-      // (server.ts) then fails safe by invalidating.
-      expect(isKnownWorkspaceFile('package.json')).toBe(false);
+    // Nothing is known before the first recompute commits a map; the caller
+    // (server.ts) then fails safe by invalidating.
+    expect(isKnownWorkspaceFile('package.json')).toBe(false);
 
-      const committed = await getCachedSerializedProjectGraphPromise();
-      expect(committed.error).toBeNull();
+    const committed = await getCachedSerializedProjectGraphPromise();
+    expect(committed.error).toBeNull();
 
-      expect(isKnownWorkspaceFile('package.json')).toBe(true);
-      expect(isKnownWorkspaceFile('libs/foo/src/index.ts')).toBe(true);
-      // Ignored, so filtered out of the map (and never watched).
-      expect(isKnownWorkspaceFile('.env')).toBe(false);
-      expect(isKnownWorkspaceFile('never-existed.env')).toBe(false);
+    expect(isKnownWorkspaceFile('package.json')).toBe(true);
+    expect(isKnownWorkspaceFile('libs/foo/src/index.ts')).toBe(true);
+    // Ignored, so filtered out of the map (and never watched).
+    expect(isKnownWorkspaceFile('.env')).toBe(false);
+    expect(isKnownWorkspaceFile('never-existed.env')).toBe(false);
 
-      // A later commit replaces the map; membership must follow the new map,
-      // not a lookup structure built from the old one.
-      fs.createFileSync('libs/foo/src/other.ts', '');
-      scheduleProjectGraphRecomputation(['libs/foo/src/other.ts'], [], []);
-      await getCachedSerializedProjectGraphPromise();
-      expect(isKnownWorkspaceFile('libs/foo/src/other.ts')).toBe(true);
-    });
+    // A later commit replaces the map; membership must follow the new map,
+    // not a lookup structure built from the old one.
+    fs.createFileSync('libs/foo/src/other.ts', '');
+    scheduleProjectGraphRecomputation(['libs/foo/src/other.ts'], [], []);
+    await getCachedSerializedProjectGraphPromise();
+    expect(isKnownWorkspaceFile('libs/foo/src/other.ts')).toBe(true);
   });
 });
 
@@ -313,25 +312,27 @@ describe('invalidateGraphCache', () => {
       'package.json': JSON.stringify({ name: 'root' }),
     });
 
-    await jest.isolateModulesAsync(async () => {
-      // The plugin-loader mocks jest.doMock installs in the tests above are
-      // registry-wide and outlive their isolated module graphs.
-      jest.dontMock('../../project-graph/plugins/get-plugins');
-      const { setWorkspaceRoot } = require('../../utils/workspace-root');
-      setWorkspaceRoot(fs.tempDir);
+    vi.resetModules();
+    // The plugin-loader mocks vi.doMock installs in the tests above are
+    // registry-wide and outlive vi.resetModules.
+    vi.doUnmock('../../project-graph/plugins/get-plugins');
+    const { setWorkspaceRoot } = await import('../../utils/workspace-root');
+    setWorkspaceRoot(fs.tempDir);
 
-      // Park the first compute inside its config retrieval, after it claimed
-      // its generation — the window an env-carrying client message can land
-      // in. The mock controls timing, not logic; the real retrieval runs.
-      let releaseFirstRetrieve: () => void;
-      const firstRetrieveGate = new Promise<void>((resolve) => {
-        releaseFirstRetrieve = resolve;
-      });
-      let retrieveCallCount = 0;
-      jest.doMock('../../project-graph/utils/retrieve-workspace-files', () => {
-        const actual = jest.requireActual(
+    // Park the first compute inside its config retrieval, after it claimed
+    // its generation — the window an env-carrying client message can land
+    // in. The mock controls timing, not logic; the real retrieval runs.
+    let releaseFirstRetrieve: () => void;
+    const firstRetrieveGate = new Promise<void>((resolve) => {
+      releaseFirstRetrieve = resolve;
+    });
+    let retrieveCallCount = 0;
+    vi.doMock(
+      '../../project-graph/utils/retrieve-workspace-files',
+      async () => {
+        const actual = (await vi.importActual(
           '../../project-graph/utils/retrieve-workspace-files'
-        );
+        )) as any;
         return {
           ...actual,
           retrieveProjectConfigurations: async (...args: unknown[]) => {
@@ -342,28 +343,26 @@ describe('invalidateGraphCache', () => {
             return actual.retrieveProjectConfigurations(...args);
           },
         };
-      });
-
-      const {
-        getCachedSerializedProjectGraphPromise,
-        invalidateGraphCache,
-      } = require('./project-graph-incremental-recomputation');
-
-      const first = getCachedSerializedProjectGraphPromise();
-      while (retrieveCallCount === 0) {
-        await new Promise((r) => setImmediate(r));
       }
+    );
 
-      invalidateGraphCache();
-      releaseFirstRetrieve!();
+    const { getCachedSerializedProjectGraphPromise, invalidateGraphCache } =
+      await import('./project-graph-incremental-recomputation');
 
-      const result = await first;
-      expect(result.error).toBeNull();
-      expect(result.projectGraph).toBeDefined();
-      // The successor's retrieval, proving the parked compute discarded its
-      // own result and chained instead of committing.
-      expect(retrieveCallCount).toBeGreaterThanOrEqual(2);
-    });
+    const first = getCachedSerializedProjectGraphPromise();
+    while (retrieveCallCount === 0) {
+      await new Promise((r) => setImmediate(r));
+    }
+
+    invalidateGraphCache();
+    releaseFirstRetrieve!();
+
+    const result = await first;
+    expect(result.error).toBeNull();
+    expect(result.projectGraph).toBeDefined();
+    // The successor's retrieval, proving the parked compute discarded its
+    // own result and chained instead of committing.
+    expect(retrieveCallCount).toBeGreaterThanOrEqual(2);
   });
 });
 
@@ -396,27 +395,29 @@ describe('pending dotenv replay before serving a graph', () => {
       'libs/foo/.env.e2e': 'PORT=4200\n',
     });
 
-    await jest.isolateModulesAsync(async () => {
-      // The plugin-loader mocks jest.doMock installs in the tests above are
-      // registry-wide and outlive their isolated module graphs.
-      jest.dontMock('../../project-graph/plugins/get-plugins');
-      const { setWorkspaceRoot } = require('../../utils/workspace-root');
-      setWorkspaceRoot(fs.tempDir);
+    vi.resetModules();
+    // The plugin-loader mocks vi.doMock installs in the tests above are
+    // registry-wide and outlive vi.resetModules.
+    vi.doUnmock('../../project-graph/plugins/get-plugins');
+    const { setWorkspaceRoot } = await import('../../utils/workspace-root');
+    setWorkspaceRoot(fs.tempDir);
 
-      // Park the first compute after its config retrieval read the old dotenv
-      // content — the window the edit lands in. The injected tag stands in
-      // for a plugin resolving config from the dotenv file at createNodes
-      // time; the mock controls timing and the marker, not the retrieval.
-      let releaseFirstRetrieve: () => void;
-      const firstRetrieveGate = new Promise<void>((resolve) => {
-        releaseFirstRetrieve = resolve;
-      });
-      let firstRetrieveDone = false;
-      let retrieveCallCount = 0;
-      jest.doMock('../../project-graph/utils/retrieve-workspace-files', () => {
-        const actual = jest.requireActual(
+    // Park the first compute after its config retrieval read the old dotenv
+    // content — the window the edit lands in. The injected tag stands in
+    // for a plugin resolving config from the dotenv file at createNodes
+    // time; the mock controls timing and the marker, not the retrieval.
+    let releaseFirstRetrieve: () => void;
+    const firstRetrieveGate = new Promise<void>((resolve) => {
+      releaseFirstRetrieve = resolve;
+    });
+    let firstRetrieveDone = false;
+    let retrieveCallCount = 0;
+    vi.doMock(
+      '../../project-graph/utils/retrieve-workspace-files',
+      async () => {
+        const actual = (await vi.importActual(
           '../../project-graph/utils/retrieve-workspace-files'
-        );
+        )) as any;
         return {
           ...actual,
           retrieveProjectConfigurations: async (...args: unknown[]) => {
@@ -434,50 +435,49 @@ describe('pending dotenv replay before serving a graph', () => {
             return result;
           },
         };
-      });
-
-      const {
-        getCachedSerializedProjectGraphPromise,
-        registerProjectGraphRecomputationListener,
-      } = require('./project-graph-incremental-recomputation');
-      const { handleOutputsChanges } = require('./handle-outputs-changes');
-      const { nxProjectGraph } = require('../../project-graph/nx-deps-cache');
-      const { EventType } = require('../../native');
-
-      const notifiedTags: string[][] = [];
-      registerProjectGraphRecomputationListener(
-        (graph: import('../../config/project-graph').ProjectGraph) => {
-          notifiedTags.push(graph.nodes.foo.data.tags);
-        }
-      );
-
-      const first = getCachedSerializedProjectGraphPromise();
-      while (!firstRetrieveDone) {
-        await new Promise((r) => setImmediate(r));
       }
+    );
 
-      writeFileSync(join(fs.tempDir, 'libs/foo/.env.e2e'), 'PORT=4201\n');
-      // The outputs watcher is the only reporter of gitignored files. No
-      // graph is committed yet, so the event goes unclassified and is queued.
-      await handleOutputsChanges(null, [
-        { path: 'libs/foo/.env.e2e', type: EventType.update },
-      ]);
-      releaseFirstRetrieve!();
+    const {
+      getCachedSerializedProjectGraphPromise,
+      registerProjectGraphRecomputationListener,
+    } = await import('./project-graph-incremental-recomputation');
+    const { handleOutputsChanges } = await import('./handle-outputs-changes');
+    const { nxProjectGraph } =
+      await import('../../project-graph/nx-deps-cache');
+    const { EventType } = await import('../../native');
 
-      const result = await first;
-      expect(result.error).toBeNull();
-      expect(result.projectGraph.nodes.foo.data.tags).toEqual([
-        'env:PORT=4201',
-      ]);
-      // The successor's retrieval, proving the first compute did not serve
-      // the graph built from the old content.
-      expect(retrieveCallCount).toBeGreaterThanOrEqual(2);
-      // The stale graph must be neither notified to listeners nor persisted.
-      expect(notifiedTags).toEqual([['env:PORT=4201']]);
-      const persisted = readFileSync(nxProjectGraph, 'utf-8');
-      expect(persisted).toContain('PORT=4201');
-      expect(persisted).not.toContain('PORT=4200');
-    });
+    const notifiedTags: string[][] = [];
+    registerProjectGraphRecomputationListener(
+      (graph: import('../../config/project-graph').ProjectGraph) => {
+        notifiedTags.push(graph.nodes.foo.data.tags);
+      }
+    );
+
+    const first = getCachedSerializedProjectGraphPromise();
+    while (!firstRetrieveDone) {
+      await new Promise((r) => setImmediate(r));
+    }
+
+    writeFileSync(join(fs.tempDir, 'libs/foo/.env.e2e'), 'PORT=4201\n');
+    // The outputs watcher is the only reporter of gitignored files. No
+    // graph is committed yet, so the event goes unclassified and is queued.
+    await handleOutputsChanges(null, [
+      { path: 'libs/foo/.env.e2e', type: EventType.update },
+    ]);
+    releaseFirstRetrieve!();
+
+    const result = await first;
+    expect(result.error).toBeNull();
+    expect(result.projectGraph.nodes.foo.data.tags).toEqual(['env:PORT=4201']);
+    // The successor's retrieval, proving the first compute did not serve
+    // the graph built from the old content.
+    expect(retrieveCallCount).toBeGreaterThanOrEqual(2);
+    // The stale graph must be neither notified to listeners nor persisted.
+    expect(notifiedTags).toEqual([['env:PORT=4201']]);
+    const persisted = readFileSync(nxProjectGraph, 'utf-8');
+    expect(persisted).toContain('PORT=4201');
+    expect(persisted).not.toContain('PORT=4200');
   });
 
   // The successor itself can read intermediate bytes the watcher never
@@ -498,30 +498,32 @@ describe('pending dotenv replay before serving a graph', () => {
       'libs/foo/.env.e2e': 'PORT=4200\n',
     });
 
-    await jest.isolateModulesAsync(async () => {
-      // The plugin-loader mocks jest.doMock installs in the tests above are
-      // registry-wide and outlive their isolated module graphs.
-      jest.dontMock('../../project-graph/plugins/get-plugins');
-      const { setWorkspaceRoot } = require('../../utils/workspace-root');
-      setWorkspaceRoot(fs.tempDir);
+    vi.resetModules();
+    // The plugin-loader mocks vi.doMock installs in the tests above are
+    // registry-wide and outlive vi.resetModules.
+    vi.doUnmock('../../project-graph/plugins/get-plugins');
+    const { setWorkspaceRoot } = await import('../../utils/workspace-root');
+    setWorkspaceRoot(fs.tempDir);
 
-      const makeGate = () => {
-        let release: () => void;
-        const promise = new Promise<void>((resolve) => {
-          release = resolve;
-        });
-        return { promise, release: () => release(), reached: false };
-      };
-      // Park compute A after its read, compute B before and after its read,
-      // so edits land in each window; compute C runs unimpeded.
-      const aExit = makeGate();
-      const bEntry = makeGate();
-      const bExit = makeGate();
-      let retrieveCallCount = 0;
-      jest.doMock('../../project-graph/utils/retrieve-workspace-files', () => {
-        const actual = jest.requireActual(
+    const makeGate = () => {
+      let release: () => void;
+      const promise = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      return { promise, release: () => release(), reached: false };
+    };
+    // Park compute A after its read, compute B before and after its read,
+    // so edits land in each window; compute C runs unimpeded.
+    const aExit = makeGate();
+    const bEntry = makeGate();
+    const bExit = makeGate();
+    let retrieveCallCount = 0;
+    vi.doMock(
+      '../../project-graph/utils/retrieve-workspace-files',
+      async () => {
+        const actual = (await vi.importActual(
           '../../project-graph/utils/retrieve-workspace-files'
-        );
+        )) as any;
         return {
           ...actual,
           retrieveProjectConfigurations: async (...args: unknown[]) => {
@@ -547,63 +549,62 @@ describe('pending dotenv replay before serving a graph', () => {
             return result;
           },
         };
-      });
+      }
+    );
 
-      const {
-        getCachedSerializedProjectGraphPromise,
-        registerProjectGraphRecomputationListener,
-      } = require('./project-graph-incremental-recomputation');
-      const { handleOutputsChanges } = require('./handle-outputs-changes');
-      const { nxProjectGraph } = require('../../project-graph/nx-deps-cache');
-      const { EventType } = require('../../native');
+    const {
+      getCachedSerializedProjectGraphPromise,
+      registerProjectGraphRecomputationListener,
+    } = await import('./project-graph-incremental-recomputation');
+    const { handleOutputsChanges } = await import('./handle-outputs-changes');
+    const { nxProjectGraph } =
+      await import('../../project-graph/nx-deps-cache');
+    const { EventType } = await import('../../native');
 
-      const notifiedTags: string[][] = [];
-      registerProjectGraphRecomputationListener(
-        (graph: import('../../config/project-graph').ProjectGraph) => {
-          notifiedTags.push(graph.nodes.foo.data.tags);
-        }
-      );
+    const notifiedTags: string[][] = [];
+    registerProjectGraphRecomputationListener(
+      (graph: import('../../config/project-graph').ProjectGraph) => {
+        notifiedTags.push(graph.nodes.foo.data.tags);
+      }
+    );
 
-      const waitFor = async (cond: () => boolean) => {
-        while (!cond()) {
-          await new Promise((r) => setImmediate(r));
-        }
-      };
-      const envPath = join(fs.tempDir, 'libs/foo/.env.e2e');
-      const envEvent = { path: 'libs/foo/.env.e2e', type: EventType.update };
+    const waitFor = async (cond: () => boolean) => {
+      while (!cond()) {
+        await new Promise((r) => setImmediate(r));
+      }
+    };
+    const envPath = join(fs.tempDir, 'libs/foo/.env.e2e');
+    const envEvent = { path: 'libs/foo/.env.e2e', type: EventType.update };
 
-      // Compute A reads 4200 and parks; the edit to 4201 is queued.
-      const first = getCachedSerializedProjectGraphPromise();
-      await waitFor(() => aExit.reached);
-      writeFileSync(envPath, 'PORT=4201\n');
-      await handleOutputsChanges(null, [envEvent]);
-      aExit.release();
+    // Compute A reads 4200 and parks; the edit to 4201 is queued.
+    const first = getCachedSerializedProjectGraphPromise();
+    await waitFor(() => aExit.reached);
+    writeFileSync(envPath, 'PORT=4201\n');
+    await handleOutputsChanges(null, [envEvent]);
+    aExit.release();
 
-      // A's drain chains to compute B, which reads an intermediate 4202
-      // whose write the watcher never reports.
-      await waitFor(() => bEntry.reached);
-      writeFileSync(envPath, 'PORT=4202\n');
-      bEntry.release();
-      await waitFor(() => bExit.reached);
+    // A's drain chains to compute B, which reads an intermediate 4202
+    // whose write the watcher never reports.
+    await waitFor(() => bEntry.reached);
+    writeFileSync(envPath, 'PORT=4202\n');
+    bEntry.release();
+    await waitFor(() => bExit.reached);
 
-      // Back to the drain-time bytes; this event is B's only chance to be
-      // marked stale, and A committed a graph so it classifies directly.
-      writeFileSync(envPath, 'PORT=4201\n');
-      await handleOutputsChanges(null, [envEvent]);
-      bExit.release();
+    // Back to the drain-time bytes; this event is B's only chance to be
+    // marked stale, and A committed a graph so it classifies directly.
+    writeFileSync(envPath, 'PORT=4201\n');
+    await handleOutputsChanges(null, [envEvent]);
+    bExit.release();
 
-      const result = await first;
-      expect(result.error).toBeNull();
-      expect(result.projectGraph.nodes.foo.data.tags).toEqual([
-        'env:PORT=4201',
-      ]);
-      expect(retrieveCallCount).toBeGreaterThanOrEqual(3);
-      expect(notifiedTags).toEqual([['env:PORT=4201']]);
-      const persisted = readFileSync(nxProjectGraph, 'utf-8');
-      expect(persisted).toContain('PORT=4201');
-      expect(persisted).not.toContain('PORT=4200');
-      expect(persisted).not.toContain('PORT=4202');
-    });
+    const result = await first;
+    expect(result.error).toBeNull();
+    expect(result.projectGraph.nodes.foo.data.tags).toEqual(['env:PORT=4201']);
+    expect(retrieveCallCount).toBeGreaterThanOrEqual(3);
+    expect(notifiedTags).toEqual([['env:PORT=4201']]);
+    const persisted = readFileSync(nxProjectGraph, 'utf-8');
+    expect(persisted).toContain('PORT=4201');
+    expect(persisted).not.toContain('PORT=4200');
+    expect(persisted).not.toContain('PORT=4202');
   });
 
   // The outputs and workspace watchers deliver independently, so an edit to a
@@ -623,23 +624,25 @@ describe('pending dotenv replay before serving a graph', () => {
       'libs/foo/.env.e2e': 'PORT=4200\n',
     });
 
-    await jest.isolateModulesAsync(async () => {
-      // The plugin-loader mocks jest.doMock installs in the tests above are
-      // registry-wide and outlive their isolated module graphs.
-      jest.dontMock('../../project-graph/plugins/get-plugins');
-      const { setWorkspaceRoot } = require('../../utils/workspace-root');
-      setWorkspaceRoot(fs.tempDir);
+    vi.resetModules();
+    // The plugin-loader mocks vi.doMock installs in the tests above are
+    // registry-wide and outlive vi.resetModules.
+    vi.doUnmock('../../project-graph/plugins/get-plugins');
+    const { setWorkspaceRoot } = await import('../../utils/workspace-root');
+    setWorkspaceRoot(fs.tempDir);
 
-      let releaseFirstRetrieve: () => void;
-      const firstRetrieveGate = new Promise<void>((resolve) => {
-        releaseFirstRetrieve = resolve;
-      });
-      let firstRetrieveDone = false;
-      let retrieveCallCount = 0;
-      jest.doMock('../../project-graph/utils/retrieve-workspace-files', () => {
-        const actual = jest.requireActual(
+    let releaseFirstRetrieve: () => void;
+    const firstRetrieveGate = new Promise<void>((resolve) => {
+      releaseFirstRetrieve = resolve;
+    });
+    let firstRetrieveDone = false;
+    let retrieveCallCount = 0;
+    vi.doMock(
+      '../../project-graph/utils/retrieve-workspace-files',
+      async () => {
+        const actual = (await vi.importActual(
           '../../project-graph/utils/retrieve-workspace-files'
-        );
+        )) as any;
         return {
           ...actual,
           retrieveProjectConfigurations: async (...args: unknown[]) => {
@@ -657,33 +660,30 @@ describe('pending dotenv replay before serving a graph', () => {
             return result;
           },
         };
-      });
-
-      const {
-        getCachedSerializedProjectGraphPromise,
-      } = require('./project-graph-incremental-recomputation');
-      const { handleOutputsChanges } = require('./handle-outputs-changes');
-      const { EventType } = require('../../native');
-
-      const first = getCachedSerializedProjectGraphPromise();
-      while (!firstRetrieveDone) {
-        await new Promise((r) => setImmediate(r));
       }
+    );
 
-      writeFileSync(join(fs.tempDir, 'libs/foo/.env.e2e'), 'PORT=4201\n');
-      // Only the outputs watcher delivers; the workspace watcher is silent.
-      await handleOutputsChanges(null, [
-        { path: 'libs/foo/.env.e2e', type: EventType.update },
-      ]);
-      releaseFirstRetrieve!();
+    const { getCachedSerializedProjectGraphPromise } =
+      await import('./project-graph-incremental-recomputation');
+    const { handleOutputsChanges } = await import('./handle-outputs-changes');
+    const { EventType } = await import('../../native');
 
-      const result = await first;
-      expect(result.error).toBeNull();
-      expect(result.projectGraph.nodes.foo.data.tags).toEqual([
-        'env:PORT=4201',
-      ]);
-      expect(retrieveCallCount).toBeGreaterThanOrEqual(2);
-    });
+    const first = getCachedSerializedProjectGraphPromise();
+    while (!firstRetrieveDone) {
+      await new Promise((r) => setImmediate(r));
+    }
+
+    writeFileSync(join(fs.tempDir, 'libs/foo/.env.e2e'), 'PORT=4201\n');
+    // Only the outputs watcher delivers; the workspace watcher is silent.
+    await handleOutputsChanges(null, [
+      { path: 'libs/foo/.env.e2e', type: EventType.update },
+    ]);
+    releaseFirstRetrieve!();
+
+    const result = await first;
+    expect(result.error).toBeNull();
+    expect(result.projectGraph.nodes.foo.data.tags).toEqual(['env:PORT=4201']);
+    expect(retrieveCallCount).toBeGreaterThanOrEqual(2);
   });
 
   // Once a computation has committed a graph and the file map, a tracked
@@ -703,29 +703,31 @@ describe('pending dotenv replay before serving a graph', () => {
       'libs/foo/.env.e2e': 'PORT=4200\n',
     });
 
-    await jest.isolateModulesAsync(async () => {
-      // The plugin-loader mocks jest.doMock installs in the tests above are
-      // registry-wide and outlive their isolated module graphs.
-      jest.dontMock('../../project-graph/plugins/get-plugins');
-      const { setWorkspaceRoot } = require('../../utils/workspace-root');
-      setWorkspaceRoot(fs.tempDir);
+    vi.resetModules();
+    // The plugin-loader mocks vi.doMock installs in the tests above are
+    // registry-wide and outlive vi.resetModules.
+    vi.doUnmock('../../project-graph/plugins/get-plugins');
+    const { setWorkspaceRoot } = await import('../../utils/workspace-root');
+    setWorkspaceRoot(fs.tempDir);
 
-      const makeGate = () => {
-        let release: () => void;
-        const promise = new Promise<void>((resolve) => {
-          release = resolve;
-        });
-        return { promise, release: () => release(), reached: false };
-      };
-      // Park computes A and B after their reads so an edit lands in each
-      // window; compute C runs unimpeded.
-      const aExit = makeGate();
-      const bExit = makeGate();
-      let retrieveCallCount = 0;
-      jest.doMock('../../project-graph/utils/retrieve-workspace-files', () => {
-        const actual = jest.requireActual(
+    const makeGate = () => {
+      let release: () => void;
+      const promise = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      return { promise, release: () => release(), reached: false };
+    };
+    // Park computes A and B after their reads so an edit lands in each
+    // window; compute C runs unimpeded.
+    const aExit = makeGate();
+    const bExit = makeGate();
+    let retrieveCallCount = 0;
+    vi.doMock(
+      '../../project-graph/utils/retrieve-workspace-files',
+      async () => {
+        const actual = (await vi.importActual(
           '../../project-graph/utils/retrieve-workspace-files'
-        );
+        )) as any;
         return {
           ...actual,
           retrieveProjectConfigurations: async (...args: unknown[]) => {
@@ -747,59 +749,58 @@ describe('pending dotenv replay before serving a graph', () => {
             return result;
           },
         };
-      });
+      }
+    );
 
-      const {
-        getCachedSerializedProjectGraphPromise,
-        registerProjectGraphRecomputationListener,
-      } = require('./project-graph-incremental-recomputation');
-      const { handleOutputsChanges } = require('./handle-outputs-changes');
-      const { nxProjectGraph } = require('../../project-graph/nx-deps-cache');
-      const { EventType } = require('../../native');
+    const {
+      getCachedSerializedProjectGraphPromise,
+      registerProjectGraphRecomputationListener,
+    } = await import('./project-graph-incremental-recomputation');
+    const { handleOutputsChanges } = await import('./handle-outputs-changes');
+    const { nxProjectGraph } =
+      await import('../../project-graph/nx-deps-cache');
+    const { EventType } = await import('../../native');
 
-      const notifiedTags: string[][] = [];
-      registerProjectGraphRecomputationListener(
-        (graph: import('../../config/project-graph').ProjectGraph) => {
-          notifiedTags.push(graph.nodes.foo.data.tags);
-        }
-      );
+    const notifiedTags: string[][] = [];
+    registerProjectGraphRecomputationListener(
+      (graph: import('../../config/project-graph').ProjectGraph) => {
+        notifiedTags.push(graph.nodes.foo.data.tags);
+      }
+    );
 
-      const waitFor = async (cond: () => boolean) => {
-        while (!cond()) {
-          await new Promise((r) => setImmediate(r));
-        }
-      };
-      const envPath = join(fs.tempDir, 'libs/foo/.env.e2e');
-      const envEvent = { path: 'libs/foo/.env.e2e', type: EventType.update };
+    const waitFor = async (cond: () => boolean) => {
+      while (!cond()) {
+        await new Promise((r) => setImmediate(r));
+      }
+    };
+    const envPath = join(fs.tempDir, 'libs/foo/.env.e2e');
+    const envEvent = { path: 'libs/foo/.env.e2e', type: EventType.update };
 
-      // Compute A reads 4200 and parks; no graph is committed yet, so the
-      // edit to 4201 goes unclassified and is queued.
-      const first = getCachedSerializedProjectGraphPromise();
-      await waitFor(() => aExit.reached);
-      writeFileSync(envPath, 'PORT=4201\n');
-      await handleOutputsChanges(null, [envEvent]);
-      aExit.release();
+    // Compute A reads 4200 and parks; no graph is committed yet, so the
+    // edit to 4201 goes unclassified and is queued.
+    const first = getCachedSerializedProjectGraphPromise();
+    await waitFor(() => aExit.reached);
+    writeFileSync(envPath, 'PORT=4201\n');
+    await handleOutputsChanges(null, [envEvent]);
+    aExit.release();
 
-      // A's drain chains to compute B, which reads 4201 and parks. A
-      // committed its graph and file map, so this edit classifies as
-      // invalidating for a tracked file; only the outputs watcher delivers.
-      await waitFor(() => bExit.reached);
-      writeFileSync(envPath, 'PORT=4202\n');
-      await handleOutputsChanges(null, [envEvent]);
-      bExit.release();
+    // A's drain chains to compute B, which reads 4201 and parks. A
+    // committed its graph and file map, so this edit classifies as
+    // invalidating for a tracked file; only the outputs watcher delivers.
+    await waitFor(() => bExit.reached);
+    writeFileSync(envPath, 'PORT=4202\n');
+    await handleOutputsChanges(null, [envEvent]);
+    bExit.release();
 
-      const result = await first;
-      expect(result.error).toBeNull();
-      expect(result.projectGraph.nodes.foo.data.tags).toEqual([
-        'env:PORT=4202',
-      ]);
-      expect(retrieveCallCount).toBeGreaterThanOrEqual(3);
-      expect(notifiedTags).toEqual([['env:PORT=4202']]);
-      const persisted = readFileSync(nxProjectGraph, 'utf-8');
-      expect(persisted).toContain('PORT=4202');
-      expect(persisted).not.toContain('PORT=4200');
-      expect(persisted).not.toContain('PORT=4201');
-    });
+    const result = await first;
+    expect(result.error).toBeNull();
+    expect(result.projectGraph.nodes.foo.data.tags).toEqual(['env:PORT=4202']);
+    expect(retrieveCallCount).toBeGreaterThanOrEqual(3);
+    expect(notifiedTags).toEqual([['env:PORT=4202']]);
+    const persisted = readFileSync(nxProjectGraph, 'utf-8');
+    expect(persisted).toContain('PORT=4202');
+    expect(persisted).not.toContain('PORT=4200');
+    expect(persisted).not.toContain('PORT=4201');
   });
 
   // An error result is never cached, notified, or persisted, so when a queued
@@ -818,29 +819,30 @@ describe('pending dotenv replay before serving a graph', () => {
       'libs/foo/.env.e2e': 'MODE=bad\n',
     });
 
-    await jest.isolateModulesAsync(async () => {
-      // The plugin-loader mocks jest.doMock installs in the tests above are
-      // registry-wide and outlive their isolated module graphs.
-      jest.dontMock('../../project-graph/plugins/get-plugins');
-      const { setWorkspaceRoot } = require('../../utils/workspace-root');
-      setWorkspaceRoot(fs.tempDir);
-      const {
-        ProjectConfigurationsError,
-      } = require('../../project-graph/error-types');
+    vi.resetModules();
+    // The plugin-loader mocks vi.doMock installs in the tests above are
+    // registry-wide and outlive vi.resetModules.
+    vi.doUnmock('../../project-graph/plugins/get-plugins');
+    const { setWorkspaceRoot } = await import('../../utils/workspace-root');
+    setWorkspaceRoot(fs.tempDir);
+    const { ProjectConfigurationsError } =
+      await import('../../project-graph/error-types');
 
-      let releaseFirstRetrieve: () => void;
-      const firstRetrieveGate = new Promise<void>((resolve) => {
-        releaseFirstRetrieve = resolve;
-      });
-      let firstRetrieveDone = false;
-      let retrieveCallCount = 0;
-      // Stands in for a plugin whose createNodes fails on the dotenv-derived
-      // config: the retrieval reads the file and throws the structured error
-      // while its content is bad.
-      jest.doMock('../../project-graph/utils/retrieve-workspace-files', () => {
-        const actual = jest.requireActual(
+    let releaseFirstRetrieve: () => void;
+    const firstRetrieveGate = new Promise<void>((resolve) => {
+      releaseFirstRetrieve = resolve;
+    });
+    let firstRetrieveDone = false;
+    let retrieveCallCount = 0;
+    // Stands in for a plugin whose createNodes fails on the dotenv-derived
+    // config: the retrieval reads the file and throws the structured error
+    // while its content is bad.
+    vi.doMock(
+      '../../project-graph/utils/retrieve-workspace-files',
+      async () => {
+        const actual = (await vi.importActual(
           '../../project-graph/utils/retrieve-workspace-files'
-        );
+        )) as any;
         return {
           ...actual,
           retrieveProjectConfigurations: async (...args: unknown[]) => {
@@ -864,34 +866,31 @@ describe('pending dotenv replay before serving a graph', () => {
             return result;
           },
         };
-      });
-
-      const {
-        getCachedSerializedProjectGraphPromise,
-      } = require('./project-graph-incremental-recomputation');
-      const { handleOutputsChanges } = require('./handle-outputs-changes');
-      const { EventType } = require('../../native');
-
-      const first = getCachedSerializedProjectGraphPromise();
-      while (!firstRetrieveDone) {
-        await new Promise((r) => setImmediate(r));
       }
+    );
 
-      writeFileSync(join(fs.tempDir, 'libs/foo/.env.e2e'), 'MODE=good\n');
-      // Only the outputs watcher reports the gitignored file; no graph is
-      // committed yet, so the event is queued.
-      await handleOutputsChanges(null, [
-        { path: 'libs/foo/.env.e2e', type: EventType.update },
-      ]);
-      releaseFirstRetrieve!();
+    const { getCachedSerializedProjectGraphPromise } =
+      await import('./project-graph-incremental-recomputation');
+    const { handleOutputsChanges } = await import('./handle-outputs-changes');
+    const { EventType } = await import('../../native');
 
-      const result = await first;
-      expect(result.error).toBeNull();
-      expect(result.projectGraph.nodes.foo.data.tags).toEqual([
-        'env:MODE=good',
-      ]);
-      expect(retrieveCallCount).toBeGreaterThanOrEqual(2);
-    });
+    const first = getCachedSerializedProjectGraphPromise();
+    while (!firstRetrieveDone) {
+      await new Promise((r) => setImmediate(r));
+    }
+
+    writeFileSync(join(fs.tempDir, 'libs/foo/.env.e2e'), 'MODE=good\n');
+    // Only the outputs watcher reports the gitignored file; no graph is
+    // committed yet, so the event is queued.
+    await handleOutputsChanges(null, [
+      { path: 'libs/foo/.env.e2e', type: EventType.update },
+    ]);
+    releaseFirstRetrieve!();
+
+    const result = await first;
+    expect(result.error).toBeNull();
+    expect(result.projectGraph.nodes.foo.data.tags).toEqual(['env:MODE=good']);
+    expect(retrieveCallCount).toBeGreaterThanOrEqual(2);
   });
 
   // Overflow carries a generation stamp like a queued entry, so a persistent
@@ -910,26 +909,27 @@ describe('pending dotenv replay before serving a graph', () => {
       'libs/foo/.env.e2e': 'MODE=bad\n',
     });
 
-    await jest.isolateModulesAsync(async () => {
-      // The plugin-loader mocks jest.doMock installs in the tests above are
-      // registry-wide and outlive their isolated module graphs.
-      jest.dontMock('../../project-graph/plugins/get-plugins');
-      const { setWorkspaceRoot } = require('../../utils/workspace-root');
-      setWorkspaceRoot(fs.tempDir);
-      const {
-        ProjectConfigurationsError,
-      } = require('../../project-graph/error-types');
+    vi.resetModules();
+    // The plugin-loader mocks vi.doMock installs in the tests above are
+    // registry-wide and outlive vi.resetModules.
+    vi.doUnmock('../../project-graph/plugins/get-plugins');
+    const { setWorkspaceRoot } = await import('../../utils/workspace-root');
+    setWorkspaceRoot(fs.tempDir);
+    const { ProjectConfigurationsError } =
+      await import('../../project-graph/error-types');
 
-      let releaseFirstRetrieve: () => void;
-      const firstRetrieveGate = new Promise<void>((resolve) => {
-        releaseFirstRetrieve = resolve;
-      });
-      let firstRetrieveDone = false;
-      let retrieveCallCount = 0;
-      jest.doMock('../../project-graph/utils/retrieve-workspace-files', () => {
-        const actual = jest.requireActual(
+    let releaseFirstRetrieve: () => void;
+    const firstRetrieveGate = new Promise<void>((resolve) => {
+      releaseFirstRetrieve = resolve;
+    });
+    let firstRetrieveDone = false;
+    let retrieveCallCount = 0;
+    vi.doMock(
+      '../../project-graph/utils/retrieve-workspace-files',
+      async () => {
+        const actual = (await vi.importActual(
           '../../project-graph/utils/retrieve-workspace-files'
-        );
+        )) as any;
         return {
           ...actual,
           retrieveProjectConfigurations: async (...args: unknown[]) => {
@@ -953,33 +953,33 @@ describe('pending dotenv replay before serving a graph', () => {
             return result;
           },
         };
-      });
-
-      const {
-        getCachedSerializedProjectGraphPromise,
-        getRecomputationGeneration,
-      } = require('./project-graph-incremental-recomputation');
-      const { queuePendingDotEnvEvents } = require('./dotenv-graph-changes');
-
-      const first = getCachedSerializedProjectGraphPromise();
-      while (!firstRetrieveDone) {
-        await new Promise((r) => setImmediate(r));
       }
+    );
 
-      // Overflow the queue mid-computation: the lost events could concern any
-      // dotenv file, so the erroring compute cannot prove its inputs fresh.
-      queuePendingDotEnvEvents(
-        Array.from({ length: 1025 }, (_, i) => `dist/out/.env.${i}`),
-        getRecomputationGeneration()
-      );
-      releaseFirstRetrieve!();
+    const {
+      getCachedSerializedProjectGraphPromise,
+      getRecomputationGeneration,
+    } = await import('./project-graph-incremental-recomputation');
+    const { queuePendingDotEnvEvents } = await import('./dotenv-graph-changes');
 
-      const result = await first;
-      expect(result.error?.name).toBe('DaemonProjectGraphError');
-      expect(result.projectGraph).toBeNull();
-      // Exactly one retry: the second compute outranks the overflow stamp.
-      expect(retrieveCallCount).toBe(2);
-    });
+    const first = getCachedSerializedProjectGraphPromise();
+    while (!firstRetrieveDone) {
+      await new Promise((r) => setImmediate(r));
+    }
+
+    // Overflow the queue mid-computation: the lost events could concern any
+    // dotenv file, so the erroring compute cannot prove its inputs fresh.
+    queuePendingDotEnvEvents(
+      Array.from({ length: 1025 }, (_, i) => `dist/out/.env.${i}`),
+      getRecomputationGeneration()
+    );
+    releaseFirstRetrieve!();
+
+    const result = await first;
+    expect(result.error?.name).toBe('DaemonProjectGraphError');
+    expect(result.projectGraph).toBeNull();
+    // Exactly one retry: the second compute outranks the overflow stamp.
+    expect(retrieveCallCount).toBe(2);
   });
 
   // The error-path retry preserves the queue for the successor's drain, but a
@@ -998,33 +998,34 @@ describe('pending dotenv replay before serving a graph', () => {
       'libs/foo/.env.e2e': 'PORT=4200\n',
     });
 
-    await jest.isolateModulesAsync(async () => {
-      // The plugin-loader mocks jest.doMock installs in the tests above are
-      // registry-wide and outlive their isolated module graphs.
-      jest.dontMock('../../project-graph/plugins/get-plugins');
-      const { setWorkspaceRoot } = require('../../utils/workspace-root');
-      setWorkspaceRoot(fs.tempDir);
-      const {
-        ProjectConfigurationsError,
-      } = require('../../project-graph/error-types');
+    vi.resetModules();
+    // The plugin-loader mocks vi.doMock installs in the tests above are
+    // registry-wide and outlive vi.resetModules.
+    vi.doUnmock('../../project-graph/plugins/get-plugins');
+    const { setWorkspaceRoot } = await import('../../utils/workspace-root');
+    setWorkspaceRoot(fs.tempDir);
+    const { ProjectConfigurationsError } =
+      await import('../../project-graph/error-types');
 
-      const makeGate = () => {
-        let release: () => void;
-        const promise = new Promise<void>((resolve) => {
-          release = resolve;
-        });
-        return { promise, release: () => release(), reached: false };
-      };
-      // B parks after its read and then fails; C parks before and after its
-      // read so the intermediate write and the revert land in each window.
-      const bExit = makeGate();
-      const cEntry = makeGate();
-      const cExit = makeGate();
-      let retrieveCallCount = 0;
-      jest.doMock('../../project-graph/utils/retrieve-workspace-files', () => {
-        const actual = jest.requireActual(
+    const makeGate = () => {
+      let release: () => void;
+      const promise = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      return { promise, release: () => release(), reached: false };
+    };
+    // B parks after its read and then fails; C parks before and after its
+    // read so the intermediate write and the revert land in each window.
+    const bExit = makeGate();
+    const cEntry = makeGate();
+    const cExit = makeGate();
+    let retrieveCallCount = 0;
+    vi.doMock(
+      '../../project-graph/utils/retrieve-workspace-files',
+      async () => {
+        const actual = (await vi.importActual(
           '../../project-graph/utils/retrieve-workspace-files'
-        );
+        )) as any;
         return {
           ...actual,
           retrieveProjectConfigurations: async (...args: unknown[]) => {
@@ -1054,60 +1055,57 @@ describe('pending dotenv replay before serving a graph', () => {
             return result;
           },
         };
-      });
+      }
+    );
 
-      const {
-        getCachedSerializedProjectGraphPromise,
-        invalidateGraphCache,
-      } = require('./project-graph-incremental-recomputation');
-      const { handleOutputsChanges } = require('./handle-outputs-changes');
-      const { nxProjectGraph } = require('../../project-graph/nx-deps-cache');
-      const { EventType } = require('../../native');
+    const { getCachedSerializedProjectGraphPromise, invalidateGraphCache } =
+      await import('./project-graph-incremental-recomputation');
+    const { handleOutputsChanges } = await import('./handle-outputs-changes');
+    const { nxProjectGraph } =
+      await import('../../project-graph/nx-deps-cache');
+    const { EventType } = await import('../../native');
 
-      const waitFor = async (cond: () => boolean) => {
-        while (!cond()) {
-          await new Promise((r) => setImmediate(r));
-        }
-      };
-      const envPath = join(fs.tempDir, 'libs/foo/.env.e2e');
-      const envEvent = { path: 'libs/foo/.env.e2e', type: EventType.update };
+    const waitFor = async (cond: () => boolean) => {
+      while (!cond()) {
+        await new Promise((r) => setImmediate(r));
+      }
+    };
+    const envPath = join(fs.tempDir, 'libs/foo/.env.e2e');
+    const envEvent = { path: 'libs/foo/.env.e2e', type: EventType.update };
 
-      // Compute A commits a warm graph at 4200.
-      const warm = await getCachedSerializedProjectGraphPromise();
-      expect(warm.error).toBeNull();
+    // Compute A commits a warm graph at 4200.
+    const warm = await getCachedSerializedProjectGraphPromise();
+    expect(warm.error).toBeNull();
 
-      // Compute B reads 4200 and parks; the edit to 4201 arrives mid-flight,
-      // classified against A's committed graph, recording its hash and
-      // queueing the tracked path. B then fails transiently.
-      invalidateGraphCache();
-      const second = getCachedSerializedProjectGraphPromise();
-      await waitFor(() => bExit.reached);
-      writeFileSync(envPath, 'PORT=4201\n');
-      await handleOutputsChanges(null, [envEvent]);
-      bExit.release();
+    // Compute B reads 4200 and parks; the edit to 4201 arrives mid-flight,
+    // classified against A's committed graph, recording its hash and
+    // queueing the tracked path. B then fails transiently.
+    invalidateGraphCache();
+    const second = getCachedSerializedProjectGraphPromise();
+    await waitFor(() => bExit.reached);
+    writeFileSync(envPath, 'PORT=4201\n');
+    await handleOutputsChanges(null, [envEvent]);
+    bExit.release();
 
-      // B's retry starts C, which reads an intermediate 4202 the watcher
-      // never reports separately; the file returns to 4201 before the
-      // callback hashes it.
-      await waitFor(() => cEntry.reached);
-      writeFileSync(envPath, 'PORT=4202\n');
-      cEntry.release();
-      await waitFor(() => cExit.reached);
-      writeFileSync(envPath, 'PORT=4201\n');
-      await handleOutputsChanges(null, [envEvent]);
-      cExit.release();
+    // B's retry starts C, which reads an intermediate 4202 the watcher
+    // never reports separately; the file returns to 4201 before the
+    // callback hashes it.
+    await waitFor(() => cEntry.reached);
+    writeFileSync(envPath, 'PORT=4202\n');
+    cEntry.release();
+    await waitFor(() => cExit.reached);
+    writeFileSync(envPath, 'PORT=4201\n');
+    await handleOutputsChanges(null, [envEvent]);
+    cExit.release();
 
-      const result = await second;
-      expect(result.error).toBeNull();
-      expect(result.projectGraph.nodes.foo.data.tags).toEqual([
-        'env:PORT=4201',
-      ]);
-      expect(retrieveCallCount).toBeGreaterThanOrEqual(4);
-      const persisted = readFileSync(nxProjectGraph, 'utf-8');
-      expect(persisted).toContain('PORT=4201');
-      expect(persisted).not.toContain('PORT=4200');
-      expect(persisted).not.toContain('PORT=4202');
-    });
+    const result = await second;
+    expect(result.error).toBeNull();
+    expect(result.projectGraph.nodes.foo.data.tags).toEqual(['env:PORT=4201']);
+    expect(retrieveCallCount).toBeGreaterThanOrEqual(4);
+    const persisted = readFileSync(nxProjectGraph, 'utf-8');
+    expect(persisted).toContain('PORT=4201');
+    expect(persisted).not.toContain('PORT=4200');
+    expect(persisted).not.toContain('PORT=4202');
   });
 
   // With the graph warm and no computation in flight, a tracked dotenv edit
@@ -1127,18 +1125,20 @@ describe('pending dotenv replay before serving a graph', () => {
       'libs/foo/.env.e2e': 'PORT=4200\n',
     });
 
-    await jest.isolateModulesAsync(async () => {
-      // The plugin-loader mocks jest.doMock installs in the tests above are
-      // registry-wide and outlive their isolated module graphs.
-      jest.dontMock('../../project-graph/plugins/get-plugins');
-      const { setWorkspaceRoot } = require('../../utils/workspace-root');
-      setWorkspaceRoot(fs.tempDir);
+    vi.resetModules();
+    // The plugin-loader mocks vi.doMock installs in the tests above are
+    // registry-wide and outlive vi.resetModules.
+    vi.doUnmock('../../project-graph/plugins/get-plugins');
+    const { setWorkspaceRoot } = await import('../../utils/workspace-root');
+    setWorkspaceRoot(fs.tempDir);
 
-      let retrieveCallCount = 0;
-      jest.doMock('../../project-graph/utils/retrieve-workspace-files', () => {
-        const actual = jest.requireActual(
+    let retrieveCallCount = 0;
+    vi.doMock(
+      '../../project-graph/utils/retrieve-workspace-files',
+      async () => {
+        const actual = (await vi.importActual(
           '../../project-graph/utils/retrieve-workspace-files'
-        );
+        )) as any;
         return {
           ...actual,
           retrieveProjectConfigurations: async (...args: unknown[]) => {
@@ -1152,35 +1152,33 @@ describe('pending dotenv replay before serving a graph', () => {
             return result;
           },
         };
-      });
+      }
+    );
 
-      const {
-        getCachedSerializedProjectGraphPromise,
-      } = require('./project-graph-incremental-recomputation');
-      const { handleOutputsChanges } = require('./handle-outputs-changes');
-      const { nxProjectGraph } = require('../../project-graph/nx-deps-cache');
-      const { EventType } = require('../../native');
+    const { getCachedSerializedProjectGraphPromise } =
+      await import('./project-graph-incremental-recomputation');
+    const { handleOutputsChanges } = await import('./handle-outputs-changes');
+    const { nxProjectGraph } =
+      await import('../../project-graph/nx-deps-cache');
+    const { EventType } = await import('../../native');
 
-      const first = await getCachedSerializedProjectGraphPromise();
-      expect(first.projectGraph.nodes.foo.data.tags).toEqual(['env:PORT=4200']);
-      expect(retrieveCallCount).toBe(1);
+    const first = await getCachedSerializedProjectGraphPromise();
+    expect(first.projectGraph.nodes.foo.data.tags).toEqual(['env:PORT=4200']);
+    expect(retrieveCallCount).toBe(1);
 
-      writeFileSync(join(fs.tempDir, 'libs/foo/.env.e2e'), 'PORT=4201\n');
-      // Only the outputs watcher delivers; the workspace watcher is silent.
-      await handleOutputsChanges(null, [
-        { path: 'libs/foo/.env.e2e', type: EventType.update },
-      ]);
+    writeFileSync(join(fs.tempDir, 'libs/foo/.env.e2e'), 'PORT=4201\n');
+    // Only the outputs watcher delivers; the workspace watcher is silent.
+    await handleOutputsChanges(null, [
+      { path: 'libs/foo/.env.e2e', type: EventType.update },
+    ]);
 
-      const second = await getCachedSerializedProjectGraphPromise();
-      expect(second.error).toBeNull();
-      expect(second.projectGraph.nodes.foo.data.tags).toEqual([
-        'env:PORT=4201',
-      ]);
-      expect(retrieveCallCount).toBe(2);
-      const persisted = readFileSync(nxProjectGraph, 'utf-8');
-      expect(persisted).toContain('PORT=4201');
-      expect(persisted).not.toContain('PORT=4200');
-    });
+    const second = await getCachedSerializedProjectGraphPromise();
+    expect(second.error).toBeNull();
+    expect(second.projectGraph.nodes.foo.data.tags).toEqual(['env:PORT=4201']);
+    expect(retrieveCallCount).toBe(2);
+    const persisted = readFileSync(nxProjectGraph, 'utf-8');
+    expect(persisted).toContain('PORT=4201');
+    expect(persisted).not.toContain('PORT=4200');
   });
 
   // The reuse-triggered successor can read intermediate bytes the watcher
@@ -1200,29 +1198,31 @@ describe('pending dotenv replay before serving a graph', () => {
       'libs/foo/.env.e2e': 'PORT=4200\n',
     });
 
-    await jest.isolateModulesAsync(async () => {
-      // The plugin-loader mocks jest.doMock installs in the tests above are
-      // registry-wide and outlive their isolated module graphs.
-      jest.dontMock('../../project-graph/plugins/get-plugins');
-      const { setWorkspaceRoot } = require('../../utils/workspace-root');
-      setWorkspaceRoot(fs.tempDir);
+    vi.resetModules();
+    // The plugin-loader mocks vi.doMock installs in the tests above are
+    // registry-wide and outlive vi.resetModules.
+    vi.doUnmock('../../project-graph/plugins/get-plugins');
+    const { setWorkspaceRoot } = await import('../../utils/workspace-root');
+    setWorkspaceRoot(fs.tempDir);
 
-      const makeGate = () => {
-        let release: () => void;
-        const promise = new Promise<void>((resolve) => {
-          release = resolve;
-        });
-        return { promise, release: () => release(), reached: false };
-      };
-      // Park the reuse-triggered compute B before and after its read so an
-      // edit lands in each window; computes A and C run unimpeded.
-      const bEntry = makeGate();
-      const bExit = makeGate();
-      let retrieveCallCount = 0;
-      jest.doMock('../../project-graph/utils/retrieve-workspace-files', () => {
-        const actual = jest.requireActual(
+    const makeGate = () => {
+      let release: () => void;
+      const promise = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      return { promise, release: () => release(), reached: false };
+    };
+    // Park the reuse-triggered compute B before and after its read so an
+    // edit lands in each window; computes A and C run unimpeded.
+    const bEntry = makeGate();
+    const bExit = makeGate();
+    let retrieveCallCount = 0;
+    vi.doMock(
+      '../../project-graph/utils/retrieve-workspace-files',
+      async () => {
+        const actual = (await vi.importActual(
           '../../project-graph/utils/retrieve-workspace-files'
-        );
+        )) as any;
         return {
           ...actual,
           retrieveProjectConfigurations: async (...args: unknown[]) => {
@@ -1244,57 +1244,55 @@ describe('pending dotenv replay before serving a graph', () => {
             return result;
           },
         };
-      });
+      }
+    );
 
-      const {
-        getCachedSerializedProjectGraphPromise,
-      } = require('./project-graph-incremental-recomputation');
-      const { handleOutputsChanges } = require('./handle-outputs-changes');
-      const { nxProjectGraph } = require('../../project-graph/nx-deps-cache');
-      const { EventType } = require('../../native');
+    const { getCachedSerializedProjectGraphPromise } =
+      await import('./project-graph-incremental-recomputation');
+    const { handleOutputsChanges } = await import('./handle-outputs-changes');
+    const { nxProjectGraph } =
+      await import('../../project-graph/nx-deps-cache');
+    const { EventType } = await import('../../native');
 
-      const waitFor = async (cond: () => boolean) => {
-        while (!cond()) {
-          await new Promise((r) => setImmediate(r));
-        }
-      };
-      const envPath = join(fs.tempDir, 'libs/foo/.env.e2e');
-      const envEvent = { path: 'libs/foo/.env.e2e', type: EventType.update };
+    const waitFor = async (cond: () => boolean) => {
+      while (!cond()) {
+        await new Promise((r) => setImmediate(r));
+      }
+    };
+    const envPath = join(fs.tempDir, 'libs/foo/.env.e2e');
+    const envEvent = { path: 'libs/foo/.env.e2e', type: EventType.update };
 
-      const first = await getCachedSerializedProjectGraphPromise();
-      expect(first.projectGraph.nodes.foo.data.tags).toEqual(['env:PORT=4200']);
+    const first = await getCachedSerializedProjectGraphPromise();
+    expect(first.projectGraph.nodes.foo.data.tags).toEqual(['env:PORT=4200']);
 
-      // Classifying this edit records the hash of the 4201 bytes and queues
-      // the tracked path.
-      writeFileSync(envPath, 'PORT=4201\n');
-      await handleOutputsChanges(null, [envEvent]);
+    // Classifying this edit records the hash of the 4201 bytes and queues
+    // the tracked path.
+    writeFileSync(envPath, 'PORT=4201\n');
+    await handleOutputsChanges(null, [envEvent]);
 
-      // The request finds the queued evidence and triggers compute B, which
-      // reads an intermediate 4202 whose write the watcher never reports.
-      const second = getCachedSerializedProjectGraphPromise();
-      await waitFor(() => bEntry.reached);
-      writeFileSync(envPath, 'PORT=4202\n');
-      bEntry.release();
-      await waitFor(() => bExit.reached);
+    // The request finds the queued evidence and triggers compute B, which
+    // reads an intermediate 4202 whose write the watcher never reports.
+    const second = getCachedSerializedProjectGraphPromise();
+    await waitFor(() => bEntry.reached);
+    writeFileSync(envPath, 'PORT=4202\n');
+    bEntry.release();
+    await waitFor(() => bExit.reached);
 
-      // Back to the queued bytes; with the pre-successor hash retained this
-      // event would be suppressed as a byte-identical rewrite and B would
-      // serve the intermediate content.
-      writeFileSync(envPath, 'PORT=4201\n');
-      await handleOutputsChanges(null, [envEvent]);
-      bExit.release();
+    // Back to the queued bytes; with the pre-successor hash retained this
+    // event would be suppressed as a byte-identical rewrite and B would
+    // serve the intermediate content.
+    writeFileSync(envPath, 'PORT=4201\n');
+    await handleOutputsChanges(null, [envEvent]);
+    bExit.release();
 
-      const result = await second;
-      expect(result.error).toBeNull();
-      expect(result.projectGraph.nodes.foo.data.tags).toEqual([
-        'env:PORT=4201',
-      ]);
-      expect(retrieveCallCount).toBeGreaterThanOrEqual(3);
-      const persisted = readFileSync(nxProjectGraph, 'utf-8');
-      expect(persisted).toContain('PORT=4201');
-      expect(persisted).not.toContain('PORT=4200');
-      expect(persisted).not.toContain('PORT=4202');
-    });
+    const result = await second;
+    expect(result.error).toBeNull();
+    expect(result.projectGraph.nodes.foo.data.tags).toEqual(['env:PORT=4201']);
+    expect(retrieveCallCount).toBeGreaterThanOrEqual(3);
+    const persisted = readFileSync(nxProjectGraph, 'utf-8');
+    expect(persisted).toContain('PORT=4201');
+    expect(persisted).not.toContain('PORT=4200');
+    expect(persisted).not.toContain('PORT=4202');
   });
 
   // A gitignored dotenv edit classified over a committed graph invalidates
@@ -1314,29 +1312,31 @@ describe('pending dotenv replay before serving a graph', () => {
       'libs/foo/.env.e2e': 'PORT=4200\n',
     });
 
-    await jest.isolateModulesAsync(async () => {
-      // The plugin-loader mocks jest.doMock installs in the tests above are
-      // registry-wide and outlive their isolated module graphs.
-      jest.dontMock('../../project-graph/plugins/get-plugins');
-      const { setWorkspaceRoot } = require('../../utils/workspace-root');
-      setWorkspaceRoot(fs.tempDir);
+    vi.resetModules();
+    // The plugin-loader mocks vi.doMock installs in the tests above are
+    // registry-wide and outlive vi.resetModules.
+    vi.doUnmock('../../project-graph/plugins/get-plugins');
+    const { setWorkspaceRoot } = await import('../../utils/workspace-root');
+    setWorkspaceRoot(fs.tempDir);
 
-      const makeGate = () => {
-        let release: () => void;
-        const promise = new Promise<void>((resolve) => {
-          release = resolve;
-        });
-        return { promise, release: () => release(), reached: false };
-      };
-      // Park the invalidation-triggered compute B before and after its read
-      // so an edit lands in each window; computes A and C run unimpeded.
-      const bEntry = makeGate();
-      const bExit = makeGate();
-      let retrieveCallCount = 0;
-      jest.doMock('../../project-graph/utils/retrieve-workspace-files', () => {
-        const actual = jest.requireActual(
+    const makeGate = () => {
+      let release: () => void;
+      const promise = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      return { promise, release: () => release(), reached: false };
+    };
+    // Park the invalidation-triggered compute B before and after its read
+    // so an edit lands in each window; computes A and C run unimpeded.
+    const bEntry = makeGate();
+    const bExit = makeGate();
+    let retrieveCallCount = 0;
+    vi.doMock(
+      '../../project-graph/utils/retrieve-workspace-files',
+      async () => {
+        const actual = (await vi.importActual(
           '../../project-graph/utils/retrieve-workspace-files'
-        );
+        )) as any;
         return {
           ...actual,
           retrieveProjectConfigurations: async (...args: unknown[]) => {
@@ -1358,58 +1358,56 @@ describe('pending dotenv replay before serving a graph', () => {
             return result;
           },
         };
-      });
+      }
+    );
 
-      const {
-        getCachedSerializedProjectGraphPromise,
-      } = require('./project-graph-incremental-recomputation');
-      const { handleOutputsChanges } = require('./handle-outputs-changes');
-      const { nxProjectGraph } = require('../../project-graph/nx-deps-cache');
-      const { EventType } = require('../../native');
+    const { getCachedSerializedProjectGraphPromise } =
+      await import('./project-graph-incremental-recomputation');
+    const { handleOutputsChanges } = await import('./handle-outputs-changes');
+    const { nxProjectGraph } =
+      await import('../../project-graph/nx-deps-cache');
+    const { EventType } = await import('../../native');
 
-      const waitFor = async (cond: () => boolean) => {
-        while (!cond()) {
-          await new Promise((r) => setImmediate(r));
-        }
-      };
-      const envPath = join(fs.tempDir, 'libs/foo/.env.e2e');
-      const envEvent = { path: 'libs/foo/.env.e2e', type: EventType.update };
+    const waitFor = async (cond: () => boolean) => {
+      while (!cond()) {
+        await new Promise((r) => setImmediate(r));
+      }
+    };
+    const envPath = join(fs.tempDir, 'libs/foo/.env.e2e');
+    const envEvent = { path: 'libs/foo/.env.e2e', type: EventType.update };
 
-      const first = await getCachedSerializedProjectGraphPromise();
-      expect(first.projectGraph.nodes.foo.data.tags).toEqual(['env:PORT=4200']);
+    const first = await getCachedSerializedProjectGraphPromise();
+    expect(first.projectGraph.nodes.foo.data.tags).toEqual(['env:PORT=4200']);
 
-      // Classifying this edit records the hash of the 4301 bytes; the file is
-      // gitignored, so the committed file map does not know it and the path
-      // invalidates directly instead of queueing.
-      writeFileSync(envPath, 'PORT=4301\n');
-      await handleOutputsChanges(null, [envEvent]);
+    // Classifying this edit records the hash of the 4301 bytes; the file is
+    // gitignored, so the committed file map does not know it and the path
+    // invalidates directly instead of queueing.
+    writeFileSync(envPath, 'PORT=4301\n');
+    await handleOutputsChanges(null, [envEvent]);
 
-      // The request finds no cached graph and triggers compute B, which reads
-      // an intermediate 4302 whose write the watcher never reports.
-      const second = getCachedSerializedProjectGraphPromise();
-      await waitFor(() => bEntry.reached);
-      writeFileSync(envPath, 'PORT=4302\n');
-      bEntry.release();
-      await waitFor(() => bExit.reached);
+    // The request finds no cached graph and triggers compute B, which reads
+    // an intermediate 4302 whose write the watcher never reports.
+    const second = getCachedSerializedProjectGraphPromise();
+    await waitFor(() => bEntry.reached);
+    writeFileSync(envPath, 'PORT=4302\n');
+    bEntry.release();
+    await waitFor(() => bExit.reached);
 
-      // Back to the classified bytes; with the classification-time hash
-      // retained this event would be suppressed as a byte-identical rewrite
-      // and B would serve the intermediate content.
-      writeFileSync(envPath, 'PORT=4301\n');
-      await handleOutputsChanges(null, [envEvent]);
-      bExit.release();
+    // Back to the classified bytes; with the classification-time hash
+    // retained this event would be suppressed as a byte-identical rewrite
+    // and B would serve the intermediate content.
+    writeFileSync(envPath, 'PORT=4301\n');
+    await handleOutputsChanges(null, [envEvent]);
+    bExit.release();
 
-      const result = await second;
-      expect(result.error).toBeNull();
-      expect(result.projectGraph.nodes.foo.data.tags).toEqual([
-        'env:PORT=4301',
-      ]);
-      expect(retrieveCallCount).toBeGreaterThanOrEqual(3);
-      const persisted = readFileSync(nxProjectGraph, 'utf-8');
-      expect(persisted).toContain('PORT=4301');
-      expect(persisted).not.toContain('PORT=4200');
-      expect(persisted).not.toContain('PORT=4302');
-    });
+    const result = await second;
+    expect(result.error).toBeNull();
+    expect(result.projectGraph.nodes.foo.data.tags).toEqual(['env:PORT=4301']);
+    expect(retrieveCallCount).toBeGreaterThanOrEqual(3);
+    const persisted = readFileSync(nxProjectGraph, 'utf-8');
+    expect(persisted).toContain('PORT=4301');
+    expect(persisted).not.toContain('PORT=4200');
+    expect(persisted).not.toContain('PORT=4302');
   });
 
   // A tracked dotenv edit queued in the same batch as (or before) a gitignored
@@ -1431,29 +1429,31 @@ describe('pending dotenv replay before serving a graph', () => {
       'libs/foo/.env.e2e': 'UPORT=9000\n',
     });
 
-    await jest.isolateModulesAsync(async () => {
-      // The plugin-loader mocks jest.doMock installs in the tests above are
-      // registry-wide and outlive their isolated module graphs.
-      jest.dontMock('../../project-graph/plugins/get-plugins');
-      const { setWorkspaceRoot } = require('../../utils/workspace-root');
-      setWorkspaceRoot(fs.tempDir);
+    vi.resetModules();
+    // The plugin-loader mocks vi.doMock installs in the tests above are
+    // registry-wide and outlive vi.resetModules.
+    vi.doUnmock('../../project-graph/plugins/get-plugins');
+    const { setWorkspaceRoot } = await import('../../utils/workspace-root');
+    setWorkspaceRoot(fs.tempDir);
 
-      const makeGate = () => {
-        let release: () => void;
-        const promise = new Promise<void>((resolve) => {
-          release = resolve;
-        });
-        return { promise, release: () => release(), reached: false };
-      };
-      // Park the invalidation-triggered compute B before and after its read
-      // so an edit lands in each window; computes A and C run unimpeded.
-      const bEntry = makeGate();
-      const bExit = makeGate();
-      let retrieveCallCount = 0;
-      jest.doMock('../../project-graph/utils/retrieve-workspace-files', () => {
-        const actual = jest.requireActual(
+    const makeGate = () => {
+      let release: () => void;
+      const promise = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      return { promise, release: () => release(), reached: false };
+    };
+    // Park the invalidation-triggered compute B before and after its read
+    // so an edit lands in each window; computes A and C run unimpeded.
+    const bEntry = makeGate();
+    const bExit = makeGate();
+    let retrieveCallCount = 0;
+    vi.doMock(
+      '../../project-graph/utils/retrieve-workspace-files',
+      async () => {
+        const actual = (await vi.importActual(
           '../../project-graph/utils/retrieve-workspace-files'
-        );
+        )) as any;
         return {
           ...actual,
           retrieveProjectConfigurations: async (...args: unknown[]) => {
@@ -1479,65 +1479,65 @@ describe('pending dotenv replay before serving a graph', () => {
             return result;
           },
         };
-      });
+      }
+    );
 
-      const {
-        getCachedSerializedProjectGraphPromise,
-      } = require('./project-graph-incremental-recomputation');
-      const { handleOutputsChanges } = require('./handle-outputs-changes');
-      const { nxProjectGraph } = require('../../project-graph/nx-deps-cache');
-      const { EventType } = require('../../native');
+    const { getCachedSerializedProjectGraphPromise } =
+      await import('./project-graph-incremental-recomputation');
+    const { handleOutputsChanges } = await import('./handle-outputs-changes');
+    const { nxProjectGraph } =
+      await import('../../project-graph/nx-deps-cache');
+    const { EventType } = await import('../../native');
 
-      const waitFor = async (cond: () => boolean) => {
-        while (!cond()) {
-          await new Promise((r) => setImmediate(r));
-        }
-      };
-      const trackedPath = join(fs.tempDir, 'libs/foo/.env.k');
-      const ignoredPath = join(fs.tempDir, 'libs/foo/.env.e2e');
-      const trackedEvent = { path: 'libs/foo/.env.k', type: EventType.update };
-      const ignoredEvent = {
-        path: 'libs/foo/.env.e2e',
-        type: EventType.update,
-      };
+    const waitFor = async (cond: () => boolean) => {
+      while (!cond()) {
+        await new Promise((r) => setImmediate(r));
+      }
+    };
+    const trackedPath = join(fs.tempDir, 'libs/foo/.env.k');
+    const ignoredPath = join(fs.tempDir, 'libs/foo/.env.e2e');
+    const trackedEvent = { path: 'libs/foo/.env.k', type: EventType.update };
+    const ignoredEvent = {
+      path: 'libs/foo/.env.e2e',
+      type: EventType.update,
+    };
 
-      const first = await getCachedSerializedProjectGraphPromise();
-      expect(first.projectGraph.nodes.foo.data.tags).toEqual([
-        'env:KPORT=4200|UPORT=9000',
-      ]);
+    const first = await getCachedSerializedProjectGraphPromise();
+    expect(first.projectGraph.nodes.foo.data.tags).toEqual([
+      'env:KPORT=4200|UPORT=9000',
+    ]);
 
-      // One batch: the tracked edit queues with its 4301 hash recorded while
-      // the gitignored edit invalidates directly, forcing a successor.
-      writeFileSync(trackedPath, 'KPORT=4301\n');
-      writeFileSync(ignoredPath, 'UPORT=9001\n');
-      await handleOutputsChanges(null, [trackedEvent, ignoredEvent]);
+    // One batch: the tracked edit queues with its 4301 hash recorded while
+    // the gitignored edit invalidates directly, forcing a successor.
+    writeFileSync(trackedPath, 'KPORT=4301\n');
+    writeFileSync(ignoredPath, 'UPORT=9001\n');
+    await handleOutputsChanges(null, [trackedEvent, ignoredEvent]);
 
-      // The request finds no cached graph and triggers compute B, which reads
-      // an intermediate 4302 whose write the watcher never reports.
-      const second = getCachedSerializedProjectGraphPromise();
-      await waitFor(() => bEntry.reached);
-      writeFileSync(trackedPath, 'KPORT=4302\n');
-      bEntry.release();
-      await waitFor(() => bExit.reached);
+    // The request finds no cached graph and triggers compute B, which reads
+    // an intermediate 4302 whose write the watcher never reports.
+    const second = getCachedSerializedProjectGraphPromise();
+    await waitFor(() => bEntry.reached);
+    writeFileSync(trackedPath, 'KPORT=4302\n');
+    bEntry.release();
+    await waitFor(() => bExit.reached);
 
-      // Back to the queued bytes; with the tracked path's hash retained this
-      // event would be suppressed as a byte-identical rewrite, and B's drain
-      // would drop the earlier queued entry as safely pre-dating B.
-      writeFileSync(trackedPath, 'KPORT=4301\n');
-      await handleOutputsChanges(null, [trackedEvent]);
-      bExit.release();
+    // Back to the queued bytes; with the tracked path's hash retained this
+    // event would be suppressed as a byte-identical rewrite, and B's drain
+    // would drop the earlier queued entry as safely pre-dating B.
+    writeFileSync(trackedPath, 'KPORT=4301\n');
+    await handleOutputsChanges(null, [trackedEvent]);
+    bExit.release();
 
-      const result = await second;
-      expect(result.error).toBeNull();
-      expect(result.projectGraph.nodes.foo.data.tags).toEqual([
-        'env:KPORT=4301|UPORT=9001',
-      ]);
-      expect(retrieveCallCount).toBeGreaterThanOrEqual(3);
-      const persisted = readFileSync(nxProjectGraph, 'utf-8');
-      expect(persisted).toContain('KPORT=4301');
-      expect(persisted).not.toContain('KPORT=4200');
-      expect(persisted).not.toContain('KPORT=4302');
-    });
+    const result = await second;
+    expect(result.error).toBeNull();
+    expect(result.projectGraph.nodes.foo.data.tags).toEqual([
+      'env:KPORT=4301|UPORT=9001',
+    ]);
+    expect(retrieveCallCount).toBeGreaterThanOrEqual(3);
+    const persisted = readFileSync(nxProjectGraph, 'utf-8');
+    expect(persisted).toContain('KPORT=4301');
+    expect(persisted).not.toContain('KPORT=4200');
+    expect(persisted).not.toContain('KPORT=4302');
   });
 
   // A tracked dotenv edit classified after a direct invalidation but before
@@ -1559,29 +1559,31 @@ describe('pending dotenv replay before serving a graph', () => {
       'libs/foo/.env.e2e': 'UPORT=9000\n',
     });
 
-    await jest.isolateModulesAsync(async () => {
-      // The plugin-loader mocks jest.doMock installs in the tests above are
-      // registry-wide and outlive their isolated module graphs.
-      jest.dontMock('../../project-graph/plugins/get-plugins');
-      const { setWorkspaceRoot } = require('../../utils/workspace-root');
-      setWorkspaceRoot(fs.tempDir);
+    vi.resetModules();
+    // The plugin-loader mocks vi.doMock installs in the tests above are
+    // registry-wide and outlive vi.resetModules.
+    vi.doUnmock('../../project-graph/plugins/get-plugins');
+    const { setWorkspaceRoot } = await import('../../utils/workspace-root');
+    setWorkspaceRoot(fs.tempDir);
 
-      const makeGate = () => {
-        let release: () => void;
-        const promise = new Promise<void>((resolve) => {
-          release = resolve;
-        });
-        return { promise, release: () => release(), reached: false };
-      };
-      // Park the invalidation-triggered compute B before and after its read
-      // so an edit lands in each window; computes A and C run unimpeded.
-      const bEntry = makeGate();
-      const bExit = makeGate();
-      let retrieveCallCount = 0;
-      jest.doMock('../../project-graph/utils/retrieve-workspace-files', () => {
-        const actual = jest.requireActual(
+    const makeGate = () => {
+      let release: () => void;
+      const promise = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      return { promise, release: () => release(), reached: false };
+    };
+    // Park the invalidation-triggered compute B before and after its read
+    // so an edit lands in each window; computes A and C run unimpeded.
+    const bEntry = makeGate();
+    const bExit = makeGate();
+    let retrieveCallCount = 0;
+    vi.doMock(
+      '../../project-graph/utils/retrieve-workspace-files',
+      async () => {
+        const actual = (await vi.importActual(
           '../../project-graph/utils/retrieve-workspace-files'
-        );
+        )) as any;
         return {
           ...actual,
           retrieveProjectConfigurations: async (...args: unknown[]) => {
@@ -1607,67 +1609,67 @@ describe('pending dotenv replay before serving a graph', () => {
             return result;
           },
         };
-      });
+      }
+    );
 
-      const {
-        getCachedSerializedProjectGraphPromise,
-      } = require('./project-graph-incremental-recomputation');
-      const { handleOutputsChanges } = require('./handle-outputs-changes');
-      const { nxProjectGraph } = require('../../project-graph/nx-deps-cache');
-      const { EventType } = require('../../native');
+    const { getCachedSerializedProjectGraphPromise } =
+      await import('./project-graph-incremental-recomputation');
+    const { handleOutputsChanges } = await import('./handle-outputs-changes');
+    const { nxProjectGraph } =
+      await import('../../project-graph/nx-deps-cache');
+    const { EventType } = await import('../../native');
 
-      const waitFor = async (cond: () => boolean) => {
-        while (!cond()) {
-          await new Promise((r) => setImmediate(r));
-        }
-      };
-      const trackedPath = join(fs.tempDir, 'libs/foo/.env.k');
-      const ignoredPath = join(fs.tempDir, 'libs/foo/.env.e2e');
-      const trackedEvent = { path: 'libs/foo/.env.k', type: EventType.update };
-      const ignoredEvent = {
-        path: 'libs/foo/.env.e2e',
-        type: EventType.update,
-      };
+    const waitFor = async (cond: () => boolean) => {
+      while (!cond()) {
+        await new Promise((r) => setImmediate(r));
+      }
+    };
+    const trackedPath = join(fs.tempDir, 'libs/foo/.env.k');
+    const ignoredPath = join(fs.tempDir, 'libs/foo/.env.e2e');
+    const trackedEvent = { path: 'libs/foo/.env.k', type: EventType.update };
+    const ignoredEvent = {
+      path: 'libs/foo/.env.e2e',
+      type: EventType.update,
+    };
 
-      const first = await getCachedSerializedProjectGraphPromise();
-      expect(first.projectGraph.nodes.foo.data.tags).toEqual([
-        'env:KPORT=4200|UPORT=9000',
-      ]);
+    const first = await getCachedSerializedProjectGraphPromise();
+    expect(first.projectGraph.nodes.foo.data.tags).toEqual([
+      'env:KPORT=4200|UPORT=9000',
+    ]);
 
-      // The gitignored edit invalidates directly, clearing the hashes; the
-      // tracked edit lands in a later callback, so its 4301 hash is recorded
-      // after every handler-side clear has run.
-      writeFileSync(ignoredPath, 'UPORT=9001\n');
-      await handleOutputsChanges(null, [ignoredEvent]);
-      writeFileSync(trackedPath, 'KPORT=4301\n');
-      await handleOutputsChanges(null, [trackedEvent]);
+    // The gitignored edit invalidates directly, clearing the hashes; the
+    // tracked edit lands in a later callback, so its 4301 hash is recorded
+    // after every handler-side clear has run.
+    writeFileSync(ignoredPath, 'UPORT=9001\n');
+    await handleOutputsChanges(null, [ignoredEvent]);
+    writeFileSync(trackedPath, 'KPORT=4301\n');
+    await handleOutputsChanges(null, [trackedEvent]);
 
-      // The request finds no cached graph and triggers compute B, which reads
-      // an intermediate 4302 whose write the watcher never reports.
-      const second = getCachedSerializedProjectGraphPromise();
-      await waitFor(() => bEntry.reached);
-      writeFileSync(trackedPath, 'KPORT=4302\n');
-      bEntry.release();
-      await waitFor(() => bExit.reached);
+    // The request finds no cached graph and triggers compute B, which reads
+    // an intermediate 4302 whose write the watcher never reports.
+    const second = getCachedSerializedProjectGraphPromise();
+    await waitFor(() => bEntry.reached);
+    writeFileSync(trackedPath, 'KPORT=4302\n');
+    bEntry.release();
+    await waitFor(() => bExit.reached);
 
-      // Back to the queued bytes; with the post-invalidation hash retained
-      // this event would be suppressed as a byte-identical rewrite, and B's
-      // drain would drop the earlier queued entry as safely pre-dating B.
-      writeFileSync(trackedPath, 'KPORT=4301\n');
-      await handleOutputsChanges(null, [trackedEvent]);
-      bExit.release();
+    // Back to the queued bytes; with the post-invalidation hash retained
+    // this event would be suppressed as a byte-identical rewrite, and B's
+    // drain would drop the earlier queued entry as safely pre-dating B.
+    writeFileSync(trackedPath, 'KPORT=4301\n');
+    await handleOutputsChanges(null, [trackedEvent]);
+    bExit.release();
 
-      const result = await second;
-      expect(result.error).toBeNull();
-      expect(result.projectGraph.nodes.foo.data.tags).toEqual([
-        'env:KPORT=4301|UPORT=9001',
-      ]);
-      expect(retrieveCallCount).toBeGreaterThanOrEqual(3);
-      const persisted = readFileSync(nxProjectGraph, 'utf-8');
-      expect(persisted).toContain('KPORT=4301');
-      expect(persisted).not.toContain('KPORT=4200');
-      expect(persisted).not.toContain('KPORT=4302');
-    });
+    const result = await second;
+    expect(result.error).toBeNull();
+    expect(result.projectGraph.nodes.foo.data.tags).toEqual([
+      'env:KPORT=4301|UPORT=9001',
+    ]);
+    expect(retrieveCallCount).toBeGreaterThanOrEqual(3);
+    const persisted = readFileSync(nxProjectGraph, 'utf-8');
+    expect(persisted).toContain('KPORT=4301');
+    expect(persisted).not.toContain('KPORT=4200');
+    expect(persisted).not.toContain('KPORT=4302');
   });
 
   // The clear that bounds the recorded hashes must run at the generation
@@ -1688,44 +1690,46 @@ describe('pending dotenv replay before serving a graph', () => {
       'libs/foo/.env.e2e': 'UPORT=9000\n',
     });
 
-    await jest.isolateModulesAsync(async () => {
-      const { setWorkspaceRoot } = require('../../utils/workspace-root');
-      setWorkspaceRoot(fs.tempDir);
+    vi.resetModules();
+    const { setWorkspaceRoot } = await import('../../utils/workspace-root');
+    setWorkspaceRoot(fs.tempDir);
 
-      const makeGate = () => {
-        let release: () => void;
-        const promise = new Promise<void>((resolve) => {
-          release = resolve;
-        });
-        return { promise, release: () => release(), reached: false };
-      };
-      // Park compute B while it loads plugins (before its generation claim)
-      // and before and after its read; computes A and C run unimpeded.
-      const bPlugins = makeGate();
-      const bEntry = makeGate();
-      const bExit = makeGate();
-      let pluginsCallCount = 0;
-      jest.doMock('../../project-graph/plugins/get-plugins', () => {
-        const actual = jest.requireActual(
-          '../../project-graph/plugins/get-plugins'
-        );
-        return {
-          ...actual,
-          getPluginsSeparated: async (...args: unknown[]) => {
-            const call = ++pluginsCallCount;
-            if (call === 2) {
-              bPlugins.reached = true;
-              await bPlugins.promise;
-            }
-            return actual.getPluginsSeparated(...args);
-          },
-        };
+    const makeGate = () => {
+      let release: () => void;
+      const promise = new Promise<void>((resolve) => {
+        release = resolve;
       });
-      let retrieveCallCount = 0;
-      jest.doMock('../../project-graph/utils/retrieve-workspace-files', () => {
-        const actual = jest.requireActual(
+      return { promise, release: () => release(), reached: false };
+    };
+    // Park compute B while it loads plugins (before its generation claim)
+    // and before and after its read; computes A and C run unimpeded.
+    const bPlugins = makeGate();
+    const bEntry = makeGate();
+    const bExit = makeGate();
+    let pluginsCallCount = 0;
+    vi.doMock('../../project-graph/plugins/get-plugins', async () => {
+      const actual = (await vi.importActual(
+        '../../project-graph/plugins/get-plugins'
+      )) as any;
+      return {
+        ...actual,
+        getPluginsSeparated: async (...args: unknown[]) => {
+          const call = ++pluginsCallCount;
+          if (call === 2) {
+            bPlugins.reached = true;
+            await bPlugins.promise;
+          }
+          return actual.getPluginsSeparated(...args);
+        },
+      };
+    });
+    let retrieveCallCount = 0;
+    vi.doMock(
+      '../../project-graph/utils/retrieve-workspace-files',
+      async () => {
+        const actual = (await vi.importActual(
           '../../project-graph/utils/retrieve-workspace-files'
-        );
+        )) as any;
         return {
           ...actual,
           retrieveProjectConfigurations: async (...args: unknown[]) => {
@@ -1751,69 +1755,69 @@ describe('pending dotenv replay before serving a graph', () => {
             return result;
           },
         };
-      });
+      }
+    );
 
-      const {
-        getCachedSerializedProjectGraphPromise,
-      } = require('./project-graph-incremental-recomputation');
-      const { handleOutputsChanges } = require('./handle-outputs-changes');
-      const { nxProjectGraph } = require('../../project-graph/nx-deps-cache');
-      const { EventType } = require('../../native');
+    const { getCachedSerializedProjectGraphPromise } =
+      await import('./project-graph-incremental-recomputation');
+    const { handleOutputsChanges } = await import('./handle-outputs-changes');
+    const { nxProjectGraph } =
+      await import('../../project-graph/nx-deps-cache');
+    const { EventType } = await import('../../native');
 
-      const waitFor = async (cond: () => boolean) => {
-        while (!cond()) {
-          await new Promise((r) => setImmediate(r));
-        }
-      };
-      const trackedPath = join(fs.tempDir, 'libs/foo/.env.k');
-      const ignoredPath = join(fs.tempDir, 'libs/foo/.env.e2e');
-      const trackedEvent = { path: 'libs/foo/.env.k', type: EventType.update };
-      const ignoredEvent = {
-        path: 'libs/foo/.env.e2e',
-        type: EventType.update,
-      };
+    const waitFor = async (cond: () => boolean) => {
+      while (!cond()) {
+        await new Promise((r) => setImmediate(r));
+      }
+    };
+    const trackedPath = join(fs.tempDir, 'libs/foo/.env.k');
+    const ignoredPath = join(fs.tempDir, 'libs/foo/.env.e2e');
+    const trackedEvent = { path: 'libs/foo/.env.k', type: EventType.update };
+    const ignoredEvent = {
+      path: 'libs/foo/.env.e2e',
+      type: EventType.update,
+    };
 
-      const first = await getCachedSerializedProjectGraphPromise();
-      expect(first.projectGraph.nodes.foo.data.tags).toEqual([
-        'env:KPORT=4200|UPORT=9000',
-      ]);
+    const first = await getCachedSerializedProjectGraphPromise();
+    expect(first.projectGraph.nodes.foo.data.tags).toEqual([
+      'env:KPORT=4200|UPORT=9000',
+    ]);
 
-      // The gitignored edit invalidates directly, so the request kicks
-      // compute B, which parks while loading plugins.
-      writeFileSync(ignoredPath, 'UPORT=9001\n');
-      await handleOutputsChanges(null, [ignoredEvent]);
-      const second = getCachedSerializedProjectGraphPromise();
-      await waitFor(() => bPlugins.reached);
+    // The gitignored edit invalidates directly, so the request kicks
+    // compute B, which parks while loading plugins.
+    writeFileSync(ignoredPath, 'UPORT=9001\n');
+    await handleOutputsChanges(null, [ignoredEvent]);
+    const second = getCachedSerializedProjectGraphPromise();
+    await waitFor(() => bPlugins.reached);
 
-      // The tracked edit is classified while B loads plugins: after B was
-      // kicked, before B claims its generation and clears the hashes.
-      writeFileSync(trackedPath, 'KPORT=4301\n');
-      await handleOutputsChanges(null, [trackedEvent]);
-      bPlugins.release();
+    // The tracked edit is classified while B loads plugins: after B was
+    // kicked, before B claims its generation and clears the hashes.
+    writeFileSync(trackedPath, 'KPORT=4301\n');
+    await handleOutputsChanges(null, [trackedEvent]);
+    bPlugins.release();
 
-      // B claims and reads an intermediate 4302 the watcher never reports.
-      await waitFor(() => bEntry.reached);
-      writeFileSync(trackedPath, 'KPORT=4302\n');
-      bEntry.release();
-      await waitFor(() => bExit.reached);
+    // B claims and reads an intermediate 4302 the watcher never reports.
+    await waitFor(() => bEntry.reached);
+    writeFileSync(trackedPath, 'KPORT=4302\n');
+    bEntry.release();
+    await waitFor(() => bExit.reached);
 
-      // Back to the classified bytes; a hash surviving B's claim would
-      // suppress this event and let B serve the intermediate content.
-      writeFileSync(trackedPath, 'KPORT=4301\n');
-      await handleOutputsChanges(null, [trackedEvent]);
-      bExit.release();
+    // Back to the classified bytes; a hash surviving B's claim would
+    // suppress this event and let B serve the intermediate content.
+    writeFileSync(trackedPath, 'KPORT=4301\n');
+    await handleOutputsChanges(null, [trackedEvent]);
+    bExit.release();
 
-      const result = await second;
-      expect(result.error).toBeNull();
-      expect(result.projectGraph.nodes.foo.data.tags).toEqual([
-        'env:KPORT=4301|UPORT=9001',
-      ]);
-      expect(retrieveCallCount).toBeGreaterThanOrEqual(3);
-      const persisted = readFileSync(nxProjectGraph, 'utf-8');
-      expect(persisted).toContain('KPORT=4301');
-      expect(persisted).not.toContain('KPORT=4200');
-      expect(persisted).not.toContain('KPORT=4302');
-    });
+    const result = await second;
+    expect(result.error).toBeNull();
+    expect(result.projectGraph.nodes.foo.data.tags).toEqual([
+      'env:KPORT=4301|UPORT=9001',
+    ]);
+    expect(retrieveCallCount).toBeGreaterThanOrEqual(3);
+    const persisted = readFileSync(nxProjectGraph, 'utf-8');
+    expect(persisted).toContain('KPORT=4301');
+    expect(persisted).not.toContain('KPORT=4200');
+    expect(persisted).not.toContain('KPORT=4302');
   });
 
   // A slow stale computation assigns currentProjectGraph before it discovers
@@ -1833,30 +1837,32 @@ describe('pending dotenv replay before serving a graph', () => {
       }),
     });
 
-    await jest.isolateModulesAsync(async () => {
-      // The plugin-loader mocks jest.doMock installs in the tests above are
-      // registry-wide and outlive their isolated module graphs.
-      jest.dontMock('../../project-graph/plugins/get-plugins');
-      const { setWorkspaceRoot } = require('../../utils/workspace-root');
-      setWorkspaceRoot(fs.tempDir);
+    vi.resetModules();
+    // The plugin-loader mocks vi.doMock installs in the tests above are
+    // registry-wide and outlive vi.resetModules.
+    vi.doUnmock('../../project-graph/plugins/get-plugins');
+    const { setWorkspaceRoot } = await import('../../utils/workspace-root');
+    setWorkspaceRoot(fs.tempDir);
 
-      const makeGate = () => {
-        let release: () => void;
-        const promise = new Promise<void>((resolve) => {
-          release = resolve;
-        });
-        return { promise, release: () => release(), reached: false };
-      };
-      // Park compute A inside createAndSerializeProjectGraph, before its
-      // graph is built and assigned to currentProjectGraph. getPlugins is
-      // awaited there right before the build, after every earlier staleness
-      // gate, so the park keeps A's late assignment as the last write.
-      const aPark = makeGate();
-      let retrieveCallCount = 0;
-      jest.doMock('../../project-graph/utils/retrieve-workspace-files', () => {
-        const actual = jest.requireActual(
+    const makeGate = () => {
+      let release: () => void;
+      const promise = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      return { promise, release: () => release(), reached: false };
+    };
+    // Park compute A inside createAndSerializeProjectGraph, before its
+    // graph is built and assigned to currentProjectGraph. getPlugins is
+    // awaited there right before the build, after every earlier staleness
+    // gate, so the park keeps A's late assignment as the last write.
+    const aPark = makeGate();
+    let retrieveCallCount = 0;
+    vi.doMock(
+      '../../project-graph/utils/retrieve-workspace-files',
+      async () => {
+        const actual = (await vi.importActual(
           '../../project-graph/utils/retrieve-workspace-files'
-        );
+        )) as any;
         return {
           ...actual,
           retrieveProjectConfigurations: async (...args: unknown[]) => {
@@ -1873,79 +1879,81 @@ describe('pending dotenv replay before serving a graph', () => {
             return result;
           },
         };
-      });
-      // A plain factory: the module sits in a require cycle, so resolving
-      // the actual inside the factory recurses. getPluginsSeparated resolves
-      // it lazily at call time instead (project discovery needs the real
-      // default plugins); the faked getPlugins only skips dependency hooks
-      // these assertions never read.
-      let pluginsCallCount = 0;
-      jest.doMock('../../project-graph/plugins/get-plugins', () => ({
-        __esModule: true,
-        getPlugins: async () => {
-          const call = ++pluginsCallCount;
-          if (call === 1) {
-            aPark.reached = true;
-            await aPark.promise;
-          }
-          return [];
-        },
-        getPluginsSeparated: (...args: unknown[]) =>
-          jest
-            .requireActual('../../project-graph/plugins/get-plugins')
-            .getPluginsSeparated(...args),
-      }));
-
-      const pgir = require('./project-graph-incremental-recomputation');
-      const {
-        getCachedSerializedProjectGraphPromise,
-        scheduleProjectGraphRecomputation,
-      } = pgir;
-      const { handleOutputsChanges } = require('./handle-outputs-changes');
-      const { EventType } = require('../../native');
-
-      const waitFor = async (cond: () => boolean) => {
-        while (!cond()) {
-          await new Promise((r) => setImmediate(r));
+      }
+    );
+    // A plain factory: the module sits in a require cycle, so resolving
+    // the actual inside the factory recurses. getPluginsSeparated resolves
+    // it lazily at call time instead (project discovery needs the real
+    // default plugins); the faked getPlugins only skips dependency hooks
+    // these assertions never read.
+    let pluginsCallCount = 0;
+    vi.doMock('../../project-graph/plugins/get-plugins', async () => ({
+      __esModule: true,
+      getPlugins: async () => {
+        const call = ++pluginsCallCount;
+        if (call === 1) {
+          aPark.reached = true;
+          await aPark.promise;
         }
-      };
+        return [];
+      },
+      getPluginsSeparated: async (...args: unknown[]) =>
+        (
+          await vi.importActual<
+            typeof import('../../project-graph/plugins/get-plugins')
+          >('../../project-graph/plugins/get-plugins')
+        ).getPluginsSeparated(...args),
+    }));
 
-      // Compute A sees only foo and parks before building and assigning its
-      // graph.
-      const first = getCachedSerializedProjectGraphPromise();
-      await waitFor(() => aPark.reached);
+    const pgir = await import('./project-graph-incremental-recomputation');
+    const {
+      getCachedSerializedProjectGraphPromise,
+      scheduleProjectGraphRecomputation,
+    } = pgir;
+    const { handleOutputsChanges } = await import('./handle-outputs-changes');
+    const { EventType } = await import('../../native');
 
-      // The workspace watcher delivers a new project; the winning compute
-      // builds the graph the cache will serve, with bar as a root.
-      mkdirSync(join(fs.tempDir, 'libs/bar'), { recursive: true });
-      writeFileSync(
-        join(fs.tempDir, 'libs/bar/project.json'),
-        JSON.stringify({ name: 'bar', root: 'libs/bar' })
-      );
-      scheduleProjectGraphRecomputation(['libs/bar/project.json'], [], []);
-      const second = await getCachedSerializedProjectGraphPromise();
-      expect(second.projectGraph.nodes.bar).toBeDefined();
+    const waitFor = async (cond: () => boolean) => {
+      while (!cond()) {
+        await new Promise((r) => setImmediate(r));
+      }
+    };
 
-      // The stale A resumes, builds and assigns its bar-less graph over
-      // currentProjectGraph, and only then chains away.
-      aPark.release();
-      await first;
-      expect(pgir.currentProjectGraph.nodes.bar).toBeUndefined();
+    // Compute A sees only foo and parks before building and assigning its
+    // graph.
+    const first = getCachedSerializedProjectGraphPromise();
+    await waitFor(() => aPark.reached);
 
-      // A gitignored dotenv edit under bar: only the outputs watcher
-      // reports it, and against the overwritten currentProjectGraph the
-      // path classifies under no root, so it queues.
-      writeFileSync(join(fs.tempDir, 'libs/bar/.env.e2e'), 'PORT=7777\n');
-      await handleOutputsChanges(null, [
-        { path: 'libs/bar/.env.e2e', type: EventType.update },
-      ]);
+    // The workspace watcher delivers a new project; the winning compute
+    // builds the graph the cache will serve, with bar as a root.
+    mkdirSync(join(fs.tempDir, 'libs/bar'), { recursive: true });
+    writeFileSync(
+      join(fs.tempDir, 'libs/bar/project.json'),
+      JSON.stringify({ name: 'bar', root: 'libs/bar' })
+    );
+    scheduleProjectGraphRecomputation(['libs/bar/project.json'], [], []);
+    const second = await getCachedSerializedProjectGraphPromise();
+    expect(second.projectGraph.nodes.bar).toBeDefined();
 
-      const countBeforeThird = retrieveCallCount;
-      const third = await getCachedSerializedProjectGraphPromise();
-      expect(third.error).toBeNull();
-      expect(third.projectGraph.nodes.bar.data.tags).toEqual(['env:PORT=7777']);
-      expect(retrieveCallCount).toBe(countBeforeThird + 1);
-    });
+    // The stale A resumes, builds and assigns its bar-less graph over
+    // currentProjectGraph, and only then chains away.
+    aPark.release();
+    await first;
+    expect(pgir.currentProjectGraph.nodes.bar).toBeUndefined();
+
+    // A gitignored dotenv edit under bar: only the outputs watcher
+    // reports it, and against the overwritten currentProjectGraph the
+    // path classifies under no root, so it queues.
+    writeFileSync(join(fs.tempDir, 'libs/bar/.env.e2e'), 'PORT=7777\n');
+    await handleOutputsChanges(null, [
+      { path: 'libs/bar/.env.e2e', type: EventType.update },
+    ]);
+
+    const countBeforeThird = retrieveCallCount;
+    const third = await getCachedSerializedProjectGraphPromise();
+    expect(third.error).toBeNull();
+    expect(third.projectGraph.nodes.bar.data.tags).toEqual(['env:PORT=7777']);
+    expect(retrieveCallCount).toBe(countBeforeThird + 1);
   });
 
   // When the workspace watcher delivers the tracked edit too, its
@@ -1964,29 +1972,31 @@ describe('pending dotenv replay before serving a graph', () => {
       'libs/foo/.env.e2e': 'PORT=4200\n',
     });
 
-    await jest.isolateModulesAsync(async () => {
-      // The plugin-loader mocks jest.doMock installs in the tests above are
-      // registry-wide and outlive their isolated module graphs.
-      jest.dontMock('../../project-graph/plugins/get-plugins');
-      const { setWorkspaceRoot } = require('../../utils/workspace-root');
-      setWorkspaceRoot(fs.tempDir);
+    vi.resetModules();
+    // The plugin-loader mocks vi.doMock installs in the tests above are
+    // registry-wide and outlive vi.resetModules.
+    vi.doUnmock('../../project-graph/plugins/get-plugins');
+    const { setWorkspaceRoot } = await import('../../utils/workspace-root');
+    setWorkspaceRoot(fs.tempDir);
 
-      const makeGate = () => {
-        let release: () => void;
-        const promise = new Promise<void>((resolve) => {
-          release = resolve;
-        });
-        return { promise, release: () => release(), reached: false };
-      };
-      // Park the workspace-scheduled compute B at its getPlugins await, past
-      // its file read and its collected-file cleanup, so a request races an
-      // in-flight computation deterministically.
-      const bPark = makeGate();
-      let retrieveCallCount = 0;
-      jest.doMock('../../project-graph/utils/retrieve-workspace-files', () => {
-        const actual = jest.requireActual(
+    const makeGate = () => {
+      let release: () => void;
+      const promise = new Promise<void>((resolve) => {
+        release = resolve;
+      });
+      return { promise, release: () => release(), reached: false };
+    };
+    // Park the workspace-scheduled compute B at its getPlugins await, past
+    // its file read and its collected-file cleanup, so a request races an
+    // in-flight computation deterministically.
+    const bPark = makeGate();
+    let retrieveCallCount = 0;
+    vi.doMock(
+      '../../project-graph/utils/retrieve-workspace-files',
+      async () => {
+        const actual = (await vi.importActual(
           '../../project-graph/utils/retrieve-workspace-files'
-        );
+        )) as any;
         return {
           ...actual,
           retrieveProjectConfigurations: async (...args: unknown[]) => {
@@ -2000,77 +2010,77 @@ describe('pending dotenv replay before serving a graph', () => {
             return result;
           },
         };
-      });
-      // A plain factory: the module sits in a require cycle, so resolving
-      // the actual inside the factory recurses. getPluginsSeparated resolves
-      // it lazily at call time instead (project discovery needs the real
-      // default plugins); the faked getPlugins only skips dependency hooks
-      // these assertions never read.
-      let pluginsCallCount = 0;
-      jest.doMock('../../project-graph/plugins/get-plugins', () => ({
-        __esModule: true,
-        getPlugins: async () => {
-          const call = ++pluginsCallCount;
-          if (call === 2) {
-            bPark.reached = true;
-            await bPark.promise;
-          }
-          return [];
-        },
-        getPluginsSeparated: (...args: unknown[]) =>
-          jest
-            .requireActual('../../project-graph/plugins/get-plugins')
-            .getPluginsSeparated(...args),
-      }));
-
-      const {
-        getCachedSerializedProjectGraphPromise,
-        scheduleProjectGraphRecomputation,
-      } = require('./project-graph-incremental-recomputation');
-      const { handleOutputsChanges } = require('./handle-outputs-changes');
-      const { EventType } = require('../../native');
-
-      const waitFor = async (cond: () => boolean) => {
-        while (!cond()) {
-          await new Promise((r) => setImmediate(r));
+      }
+    );
+    // A plain factory: the module sits in a require cycle, so resolving
+    // the actual inside the factory recurses. getPluginsSeparated resolves
+    // it lazily at call time instead (project discovery needs the real
+    // default plugins); the faked getPlugins only skips dependency hooks
+    // these assertions never read.
+    let pluginsCallCount = 0;
+    vi.doMock('../../project-graph/plugins/get-plugins', async () => ({
+      __esModule: true,
+      getPlugins: async () => {
+        const call = ++pluginsCallCount;
+        if (call === 2) {
+          bPark.reached = true;
+          await bPark.promise;
         }
-      };
-      const envPath = join(fs.tempDir, 'libs/foo/.env.e2e');
+        return [];
+      },
+      getPluginsSeparated: async (...args: unknown[]) =>
+        (
+          await vi.importActual<
+            typeof import('../../project-graph/plugins/get-plugins')
+          >('../../project-graph/plugins/get-plugins')
+        ).getPluginsSeparated(...args),
+    }));
 
-      const first = await getCachedSerializedProjectGraphPromise();
-      expect(first.projectGraph.nodes.foo.data.tags).toEqual(['env:PORT=4200']);
-      expect(retrieveCallCount).toBe(1);
+    const {
+      getCachedSerializedProjectGraphPromise,
+      scheduleProjectGraphRecomputation,
+    } = await import('./project-graph-incremental-recomputation');
+    const { handleOutputsChanges } = await import('./handle-outputs-changes');
+    const { EventType } = await import('../../native');
 
-      writeFileSync(envPath, 'PORT=4201\n');
-      // Outputs watcher first: the event queues. Workspace watcher second:
-      // the recomputation it schedules reads the new content.
-      await handleOutputsChanges(null, [
-        { path: 'libs/foo/.env.e2e', type: EventType.update },
-      ]);
-      scheduleProjectGraphRecomputation([], ['libs/foo/.env.e2e'], []);
-      await waitFor(() => bPark.reached);
-
-      // A request while B is parked mid-build must chain onto B, not start
-      // a competitor from the queued twin event. The yields let it run its
-      // reuse decision before B is released.
-      const second = getCachedSerializedProjectGraphPromise();
-      for (let i = 0; i < 5; i++) {
+    const waitFor = async (cond: () => boolean) => {
+      while (!cond()) {
         await new Promise((r) => setImmediate(r));
       }
-      bPark.release();
+    };
+    const envPath = join(fs.tempDir, 'libs/foo/.env.e2e');
 
-      const result = await second;
-      expect(result.error).toBeNull();
-      expect(result.projectGraph.nodes.foo.data.tags).toEqual([
-        'env:PORT=4201',
-      ]);
-      expect(retrieveCallCount).toBe(2);
+    const first = await getCachedSerializedProjectGraphPromise();
+    expect(first.projectGraph.nodes.foo.data.tags).toEqual(['env:PORT=4200']);
+    expect(retrieveCallCount).toBe(1);
 
-      // After B settles, the drained queue holds no evidence against it.
-      const third = await getCachedSerializedProjectGraphPromise();
-      expect(third.projectGraph.nodes.foo.data.tags).toEqual(['env:PORT=4201']);
-      expect(retrieveCallCount).toBe(2);
-    });
+    writeFileSync(envPath, 'PORT=4201\n');
+    // Outputs watcher first: the event queues. Workspace watcher second:
+    // the recomputation it schedules reads the new content.
+    await handleOutputsChanges(null, [
+      { path: 'libs/foo/.env.e2e', type: EventType.update },
+    ]);
+    scheduleProjectGraphRecomputation([], ['libs/foo/.env.e2e'], []);
+    await waitFor(() => bPark.reached);
+
+    // A request while B is parked mid-build must chain onto B, not start
+    // a competitor from the queued twin event. The yields let it run its
+    // reuse decision before B is released.
+    const second = getCachedSerializedProjectGraphPromise();
+    for (let i = 0; i < 5; i++) {
+      await new Promise((r) => setImmediate(r));
+    }
+    bPark.release();
+
+    const result = await second;
+    expect(result.error).toBeNull();
+    expect(result.projectGraph.nodes.foo.data.tags).toEqual(['env:PORT=4201']);
+    expect(retrieveCallCount).toBe(2);
+
+    // After B settles, the drained queue holds no evidence against it.
+    const third = await getCachedSerializedProjectGraphPromise();
+    expect(third.projectGraph.nodes.foo.data.tags).toEqual(['env:PORT=4201']);
+    expect(retrieveCallCount).toBe(2);
   });
 
   // An event under a root no served graph knows cannot make the cached graph
@@ -2089,18 +2099,20 @@ describe('pending dotenv replay before serving a graph', () => {
       }),
     });
 
-    await jest.isolateModulesAsync(async () => {
-      // The plugin-loader mocks jest.doMock installs in the tests above are
-      // registry-wide and outlive their isolated module graphs.
-      jest.dontMock('../../project-graph/plugins/get-plugins');
-      const { setWorkspaceRoot } = require('../../utils/workspace-root');
-      setWorkspaceRoot(fs.tempDir);
+    vi.resetModules();
+    // The plugin-loader mocks vi.doMock installs in the tests above are
+    // registry-wide and outlive vi.resetModules.
+    vi.doUnmock('../../project-graph/plugins/get-plugins');
+    const { setWorkspaceRoot } = await import('../../utils/workspace-root');
+    setWorkspaceRoot(fs.tempDir);
 
-      let retrieveCallCount = 0;
-      jest.doMock('../../project-graph/utils/retrieve-workspace-files', () => {
-        const actual = jest.requireActual(
+    let retrieveCallCount = 0;
+    vi.doMock(
+      '../../project-graph/utils/retrieve-workspace-files',
+      async () => {
+        const actual = (await vi.importActual(
           '../../project-graph/utils/retrieve-workspace-files'
-        );
+        )) as any;
         return {
           ...actual,
           retrieveProjectConfigurations: async (...args: unknown[]) => {
@@ -2117,67 +2129,65 @@ describe('pending dotenv replay before serving a graph', () => {
             return result;
           },
         };
-      });
+      }
+    );
 
-      const {
-        getCachedSerializedProjectGraphPromise,
-        registerProjectGraphRecomputationListener,
-        scheduleProjectGraphRecomputation,
-      } = require('./project-graph-incremental-recomputation');
-      const { handleOutputsChanges } = require('./handle-outputs-changes');
-      const { EventType } = require('../../native');
+    const {
+      getCachedSerializedProjectGraphPromise,
+      registerProjectGraphRecomputationListener,
+      scheduleProjectGraphRecomputation,
+    } = await import('./project-graph-incremental-recomputation');
+    const { handleOutputsChanges } = await import('./handle-outputs-changes');
+    const { EventType } = await import('../../native');
 
-      const notifiedGraphs: import('../../config/project-graph').ProjectGraph[] =
-        [];
-      registerProjectGraphRecomputationListener(
-        (graph: import('../../config/project-graph').ProjectGraph) => {
-          notifiedGraphs.push(graph);
-        }
-      );
-      const waitFor = async (cond: () => boolean) => {
-        while (!cond()) {
-          await new Promise((r) => setImmediate(r));
-        }
-      };
+    const notifiedGraphs: import('../../config/project-graph').ProjectGraph[] =
+      [];
+    registerProjectGraphRecomputationListener(
+      (graph: import('../../config/project-graph').ProjectGraph) => {
+        notifiedGraphs.push(graph);
+      }
+    );
+    const waitFor = async (cond: () => boolean) => {
+      while (!cond()) {
+        await new Promise((r) => setImmediate(r));
+      }
+    };
 
-      const first = await getCachedSerializedProjectGraphPromise();
-      expect(first.projectGraph.nodes.bar).toBeUndefined();
-      expect(retrieveCallCount).toBe(1);
+    const first = await getCachedSerializedProjectGraphPromise();
+    expect(first.projectGraph.nodes.bar).toBeUndefined();
+    expect(retrieveCallCount).toBe(1);
 
-      // A gitignored dotenv file under a directory that is not a project
-      // root yet: only the outputs watcher reports it, and no root of the
-      // served graph classifies it.
-      mkdirSync(join(fs.tempDir, 'libs/bar'), { recursive: true });
-      writeFileSync(join(fs.tempDir, 'libs/bar/.env.e2e'), 'PORT=7777\n');
-      await handleOutputsChanges(null, [
-        { path: 'libs/bar/.env.e2e', type: EventType.update },
-      ]);
+    // A gitignored dotenv file under a directory that is not a project
+    // root yet: only the outputs watcher reports it, and no root of the
+    // served graph classifies it.
+    mkdirSync(join(fs.tempDir, 'libs/bar'), { recursive: true });
+    writeFileSync(join(fs.tempDir, 'libs/bar/.env.e2e'), 'PORT=7777\n');
+    await handleOutputsChanges(null, [
+      { path: 'libs/bar/.env.e2e', type: EventType.update },
+    ]);
 
-      const second = await getCachedSerializedProjectGraphPromise();
-      expect(second.projectGraph.nodes.bar).toBeUndefined();
-      expect(retrieveCallCount).toBe(1);
+    const second = await getCachedSerializedProjectGraphPromise();
+    expect(second.projectGraph.nodes.bar).toBeUndefined();
+    expect(retrieveCallCount).toBe(1);
 
-      // The project lands; the workspace watcher schedules the computation
-      // that knows the root, and its read observes the dotenv content.
-      writeFileSync(
-        join(fs.tempDir, 'libs/bar/project.json'),
-        JSON.stringify({ name: 'bar', root: 'libs/bar' })
-      );
-      scheduleProjectGraphRecomputation(['libs/bar/project.json'], [], []);
-      await waitFor(() =>
-        notifiedGraphs.some((graph) => graph.nodes.bar !== undefined)
-      );
+    // The project lands; the workspace watcher schedules the computation
+    // that knows the root, and its read observes the dotenv content.
+    writeFileSync(
+      join(fs.tempDir, 'libs/bar/project.json'),
+      JSON.stringify({ name: 'bar', root: 'libs/bar' })
+    );
+    scheduleProjectGraphRecomputation(['libs/bar/project.json'], [], []);
+    await waitFor(() =>
+      notifiedGraphs.some((graph) => graph.nodes.bar !== undefined)
+    );
 
-      const third = await getCachedSerializedProjectGraphPromise();
-      expect(third.error).toBeNull();
-      expect(third.projectGraph.nodes.bar.data.tags).toEqual(['env:PORT=7777']);
-      expect(retrieveCallCount).toBe(2);
+    const third = await getCachedSerializedProjectGraphPromise();
+    expect(third.error).toBeNull();
+    expect(third.projectGraph.nodes.bar.data.tags).toEqual(['env:PORT=7777']);
+    expect(retrieveCallCount).toBe(2);
 
-      const fourth = await getCachedSerializedProjectGraphPromise();
-      expect(fourth.projectGraph.nodes.bar.data.tags).toEqual([
-        'env:PORT=7777',
-      ]);
-      expect(retrieveCallCount).toBe(2);
-    });
+    const fourth = await getCachedSerializedProjectGraphPromise();
+    expect(fourth.projectGraph.nodes.bar.data.tags).toEqual(['env:PORT=7777']);
+    expect(retrieveCallCount).toBe(2);
   });
 });

--- a/packages/nx/src/daemon/server/project-graph-incremental-recomputation.spec.ts
+++ b/packages/nx/src/daemon/server/project-graph-incremental-recomputation.spec.ts
@@ -12,6 +12,8 @@ vi.mock('../../utils/perf-logging', () => ({}));
 // These cases drive a real compute, so they need working plugin-worker
 // isolation. Where forked workers cannot start (containers, agent sandboxes)
 // every case stalls to the suite timeout; run with NX_ISOLATE_PLUGINS=false.
+// The first case additionally needs real watcher event delivery, which a
+// container filesystem does not provide, and fails there either way.
 describe('getCachedSerializedProjectGraphPromise — watcher race coverage', () => {
   let fs: TempFs;
 

--- a/packages/nx/src/daemon/server/project-graph-incremental-recomputation.spec.ts
+++ b/packages/nx/src/daemon/server/project-graph-incremental-recomputation.spec.ts
@@ -1297,6 +1297,525 @@ describe('pending dotenv replay before serving a graph', () => {
     });
   });
 
+  // A gitignored dotenv edit classified over a committed graph invalidates
+  // directly instead of queueing, so no drain ever drops the hash recorded at
+  // classification. Retained, that hash would suppress a coalesced revert
+  // callback landing while the forced successor reads, and the successor
+  // would serve intermediate content the disk no longer holds.
+  it('recomputes for a revert delivered while a direct-invalidation successor is reading', async () => {
+    fs.createFilesSync({
+      'nx.json': JSON.stringify({}),
+      'package.json': JSON.stringify({ name: 'root' }),
+      '.gitignore': '.env.e2e\n',
+      'libs/foo/project.json': JSON.stringify({
+        name: 'foo',
+        root: 'libs/foo',
+      }),
+      'libs/foo/.env.e2e': 'PORT=4200\n',
+    });
+
+    await jest.isolateModulesAsync(async () => {
+      // The plugin-loader mocks jest.doMock installs in the tests above are
+      // registry-wide and outlive their isolated module graphs.
+      jest.dontMock('../../project-graph/plugins/get-plugins');
+      const { setWorkspaceRoot } = require('../../utils/workspace-root');
+      setWorkspaceRoot(fs.tempDir);
+
+      const makeGate = () => {
+        let release: () => void;
+        const promise = new Promise<void>((resolve) => {
+          release = resolve;
+        });
+        return { promise, release: () => release(), reached: false };
+      };
+      // Park the invalidation-triggered compute B before and after its read
+      // so an edit lands in each window; computes A and C run unimpeded.
+      const bEntry = makeGate();
+      const bExit = makeGate();
+      let retrieveCallCount = 0;
+      jest.doMock('../../project-graph/utils/retrieve-workspace-files', () => {
+        const actual = jest.requireActual(
+          '../../project-graph/utils/retrieve-workspace-files'
+        );
+        return {
+          ...actual,
+          retrieveProjectConfigurations: async (...args: unknown[]) => {
+            const call = ++retrieveCallCount;
+            if (call === 2) {
+              bEntry.reached = true;
+              await bEntry.promise;
+            }
+            const result = await actual.retrieveProjectConfigurations(...args);
+            const env = readFileSync(
+              join(fs.tempDir, 'libs/foo/.env.e2e'),
+              'utf-8'
+            ).trim();
+            result.projects['libs/foo'].tags = [`env:${env}`];
+            if (call === 2) {
+              bExit.reached = true;
+              await bExit.promise;
+            }
+            return result;
+          },
+        };
+      });
+
+      const {
+        getCachedSerializedProjectGraphPromise,
+      } = require('./project-graph-incremental-recomputation');
+      const { handleOutputsChanges } = require('./handle-outputs-changes');
+      const { nxProjectGraph } = require('../../project-graph/nx-deps-cache');
+      const { EventType } = require('../../native');
+
+      const waitFor = async (cond: () => boolean) => {
+        while (!cond()) {
+          await new Promise((r) => setImmediate(r));
+        }
+      };
+      const envPath = join(fs.tempDir, 'libs/foo/.env.e2e');
+      const envEvent = { path: 'libs/foo/.env.e2e', type: EventType.update };
+
+      const first = await getCachedSerializedProjectGraphPromise();
+      expect(first.projectGraph.nodes.foo.data.tags).toEqual(['env:PORT=4200']);
+
+      // Classifying this edit records the hash of the 4301 bytes; the file is
+      // gitignored, so the committed file map does not know it and the path
+      // invalidates directly instead of queueing.
+      writeFileSync(envPath, 'PORT=4301\n');
+      await handleOutputsChanges(null, [envEvent]);
+
+      // The request finds no cached graph and triggers compute B, which reads
+      // an intermediate 4302 whose write the watcher never reports.
+      const second = getCachedSerializedProjectGraphPromise();
+      await waitFor(() => bEntry.reached);
+      writeFileSync(envPath, 'PORT=4302\n');
+      bEntry.release();
+      await waitFor(() => bExit.reached);
+
+      // Back to the classified bytes; with the classification-time hash
+      // retained this event would be suppressed as a byte-identical rewrite
+      // and B would serve the intermediate content.
+      writeFileSync(envPath, 'PORT=4301\n');
+      await handleOutputsChanges(null, [envEvent]);
+      bExit.release();
+
+      const result = await second;
+      expect(result.error).toBeNull();
+      expect(result.projectGraph.nodes.foo.data.tags).toEqual([
+        'env:PORT=4301',
+      ]);
+      expect(retrieveCallCount).toBeGreaterThanOrEqual(3);
+      const persisted = readFileSync(nxProjectGraph, 'utf-8');
+      expect(persisted).toContain('PORT=4301');
+      expect(persisted).not.toContain('PORT=4200');
+      expect(persisted).not.toContain('PORT=4302');
+    });
+  });
+
+  // A tracked dotenv edit queued in the same batch as (or before) a gitignored
+  // one keeps its classification-time hash while the gitignored path forces a
+  // successor, and its stamp predates that successor, so the drain deletes the
+  // hash without marking the successor stale. Only clearing every recorded
+  // hash at the direct invalidation keeps a coalesced revert of the tracked
+  // file from being suppressed while the successor reads.
+  it('recomputes for a tracked-file revert delivered while a successor forced by a gitignored edit is reading', async () => {
+    fs.createFilesSync({
+      'nx.json': JSON.stringify({}),
+      'package.json': JSON.stringify({ name: 'root' }),
+      '.gitignore': '.env.e2e\n',
+      'libs/foo/project.json': JSON.stringify({
+        name: 'foo',
+        root: 'libs/foo',
+      }),
+      'libs/foo/.env.k': 'KPORT=4200\n',
+      'libs/foo/.env.e2e': 'UPORT=9000\n',
+    });
+
+    await jest.isolateModulesAsync(async () => {
+      // The plugin-loader mocks jest.doMock installs in the tests above are
+      // registry-wide and outlive their isolated module graphs.
+      jest.dontMock('../../project-graph/plugins/get-plugins');
+      const { setWorkspaceRoot } = require('../../utils/workspace-root');
+      setWorkspaceRoot(fs.tempDir);
+
+      const makeGate = () => {
+        let release: () => void;
+        const promise = new Promise<void>((resolve) => {
+          release = resolve;
+        });
+        return { promise, release: () => release(), reached: false };
+      };
+      // Park the invalidation-triggered compute B before and after its read
+      // so an edit lands in each window; computes A and C run unimpeded.
+      const bEntry = makeGate();
+      const bExit = makeGate();
+      let retrieveCallCount = 0;
+      jest.doMock('../../project-graph/utils/retrieve-workspace-files', () => {
+        const actual = jest.requireActual(
+          '../../project-graph/utils/retrieve-workspace-files'
+        );
+        return {
+          ...actual,
+          retrieveProjectConfigurations: async (...args: unknown[]) => {
+            const call = ++retrieveCallCount;
+            if (call === 2) {
+              bEntry.reached = true;
+              await bEntry.promise;
+            }
+            const result = await actual.retrieveProjectConfigurations(...args);
+            const tracked = readFileSync(
+              join(fs.tempDir, 'libs/foo/.env.k'),
+              'utf-8'
+            ).trim();
+            const ignored = readFileSync(
+              join(fs.tempDir, 'libs/foo/.env.e2e'),
+              'utf-8'
+            ).trim();
+            result.projects['libs/foo'].tags = [`env:${tracked}|${ignored}`];
+            if (call === 2) {
+              bExit.reached = true;
+              await bExit.promise;
+            }
+            return result;
+          },
+        };
+      });
+
+      const {
+        getCachedSerializedProjectGraphPromise,
+      } = require('./project-graph-incremental-recomputation');
+      const { handleOutputsChanges } = require('./handle-outputs-changes');
+      const { nxProjectGraph } = require('../../project-graph/nx-deps-cache');
+      const { EventType } = require('../../native');
+
+      const waitFor = async (cond: () => boolean) => {
+        while (!cond()) {
+          await new Promise((r) => setImmediate(r));
+        }
+      };
+      const trackedPath = join(fs.tempDir, 'libs/foo/.env.k');
+      const ignoredPath = join(fs.tempDir, 'libs/foo/.env.e2e');
+      const trackedEvent = { path: 'libs/foo/.env.k', type: EventType.update };
+      const ignoredEvent = {
+        path: 'libs/foo/.env.e2e',
+        type: EventType.update,
+      };
+
+      const first = await getCachedSerializedProjectGraphPromise();
+      expect(first.projectGraph.nodes.foo.data.tags).toEqual([
+        'env:KPORT=4200|UPORT=9000',
+      ]);
+
+      // One batch: the tracked edit queues with its 4301 hash recorded while
+      // the gitignored edit invalidates directly, forcing a successor.
+      writeFileSync(trackedPath, 'KPORT=4301\n');
+      writeFileSync(ignoredPath, 'UPORT=9001\n');
+      await handleOutputsChanges(null, [trackedEvent, ignoredEvent]);
+
+      // The request finds no cached graph and triggers compute B, which reads
+      // an intermediate 4302 whose write the watcher never reports.
+      const second = getCachedSerializedProjectGraphPromise();
+      await waitFor(() => bEntry.reached);
+      writeFileSync(trackedPath, 'KPORT=4302\n');
+      bEntry.release();
+      await waitFor(() => bExit.reached);
+
+      // Back to the queued bytes; with the tracked path's hash retained this
+      // event would be suppressed as a byte-identical rewrite, and B's drain
+      // would drop the earlier queued entry as safely pre-dating B.
+      writeFileSync(trackedPath, 'KPORT=4301\n');
+      await handleOutputsChanges(null, [trackedEvent]);
+      bExit.release();
+
+      const result = await second;
+      expect(result.error).toBeNull();
+      expect(result.projectGraph.nodes.foo.data.tags).toEqual([
+        'env:KPORT=4301|UPORT=9001',
+      ]);
+      expect(retrieveCallCount).toBeGreaterThanOrEqual(3);
+      const persisted = readFileSync(nxProjectGraph, 'utf-8');
+      expect(persisted).toContain('KPORT=4301');
+      expect(persisted).not.toContain('KPORT=4200');
+      expect(persisted).not.toContain('KPORT=4302');
+    });
+  });
+
+  // A tracked dotenv edit classified after a direct invalidation but before
+  // the forced successor starts records a fresh hash that no handler-side
+  // clear has seen. Only clearing the hashes when a computation claims its
+  // generation bounds every hash to the window since the last claim, so a
+  // coalesced revert of the tracked file cannot be suppressed while that
+  // successor reads.
+  it('recomputes for a tracked-file revert when the tracked edit was classified between an invalidation and the successor', async () => {
+    fs.createFilesSync({
+      'nx.json': JSON.stringify({}),
+      'package.json': JSON.stringify({ name: 'root' }),
+      '.gitignore': '.env.e2e\n',
+      'libs/foo/project.json': JSON.stringify({
+        name: 'foo',
+        root: 'libs/foo',
+      }),
+      'libs/foo/.env.k': 'KPORT=4200\n',
+      'libs/foo/.env.e2e': 'UPORT=9000\n',
+    });
+
+    await jest.isolateModulesAsync(async () => {
+      // The plugin-loader mocks jest.doMock installs in the tests above are
+      // registry-wide and outlive their isolated module graphs.
+      jest.dontMock('../../project-graph/plugins/get-plugins');
+      const { setWorkspaceRoot } = require('../../utils/workspace-root');
+      setWorkspaceRoot(fs.tempDir);
+
+      const makeGate = () => {
+        let release: () => void;
+        const promise = new Promise<void>((resolve) => {
+          release = resolve;
+        });
+        return { promise, release: () => release(), reached: false };
+      };
+      // Park the invalidation-triggered compute B before and after its read
+      // so an edit lands in each window; computes A and C run unimpeded.
+      const bEntry = makeGate();
+      const bExit = makeGate();
+      let retrieveCallCount = 0;
+      jest.doMock('../../project-graph/utils/retrieve-workspace-files', () => {
+        const actual = jest.requireActual(
+          '../../project-graph/utils/retrieve-workspace-files'
+        );
+        return {
+          ...actual,
+          retrieveProjectConfigurations: async (...args: unknown[]) => {
+            const call = ++retrieveCallCount;
+            if (call === 2) {
+              bEntry.reached = true;
+              await bEntry.promise;
+            }
+            const result = await actual.retrieveProjectConfigurations(...args);
+            const tracked = readFileSync(
+              join(fs.tempDir, 'libs/foo/.env.k'),
+              'utf-8'
+            ).trim();
+            const ignored = readFileSync(
+              join(fs.tempDir, 'libs/foo/.env.e2e'),
+              'utf-8'
+            ).trim();
+            result.projects['libs/foo'].tags = [`env:${tracked}|${ignored}`];
+            if (call === 2) {
+              bExit.reached = true;
+              await bExit.promise;
+            }
+            return result;
+          },
+        };
+      });
+
+      const {
+        getCachedSerializedProjectGraphPromise,
+      } = require('./project-graph-incremental-recomputation');
+      const { handleOutputsChanges } = require('./handle-outputs-changes');
+      const { nxProjectGraph } = require('../../project-graph/nx-deps-cache');
+      const { EventType } = require('../../native');
+
+      const waitFor = async (cond: () => boolean) => {
+        while (!cond()) {
+          await new Promise((r) => setImmediate(r));
+        }
+      };
+      const trackedPath = join(fs.tempDir, 'libs/foo/.env.k');
+      const ignoredPath = join(fs.tempDir, 'libs/foo/.env.e2e');
+      const trackedEvent = { path: 'libs/foo/.env.k', type: EventType.update };
+      const ignoredEvent = {
+        path: 'libs/foo/.env.e2e',
+        type: EventType.update,
+      };
+
+      const first = await getCachedSerializedProjectGraphPromise();
+      expect(first.projectGraph.nodes.foo.data.tags).toEqual([
+        'env:KPORT=4200|UPORT=9000',
+      ]);
+
+      // The gitignored edit invalidates directly, clearing the hashes; the
+      // tracked edit lands in a later callback, so its 4301 hash is recorded
+      // after every handler-side clear has run.
+      writeFileSync(ignoredPath, 'UPORT=9001\n');
+      await handleOutputsChanges(null, [ignoredEvent]);
+      writeFileSync(trackedPath, 'KPORT=4301\n');
+      await handleOutputsChanges(null, [trackedEvent]);
+
+      // The request finds no cached graph and triggers compute B, which reads
+      // an intermediate 4302 whose write the watcher never reports.
+      const second = getCachedSerializedProjectGraphPromise();
+      await waitFor(() => bEntry.reached);
+      writeFileSync(trackedPath, 'KPORT=4302\n');
+      bEntry.release();
+      await waitFor(() => bExit.reached);
+
+      // Back to the queued bytes; with the post-invalidation hash retained
+      // this event would be suppressed as a byte-identical rewrite, and B's
+      // drain would drop the earlier queued entry as safely pre-dating B.
+      writeFileSync(trackedPath, 'KPORT=4301\n');
+      await handleOutputsChanges(null, [trackedEvent]);
+      bExit.release();
+
+      const result = await second;
+      expect(result.error).toBeNull();
+      expect(result.projectGraph.nodes.foo.data.tags).toEqual([
+        'env:KPORT=4301|UPORT=9001',
+      ]);
+      expect(retrieveCallCount).toBeGreaterThanOrEqual(3);
+      const persisted = readFileSync(nxProjectGraph, 'utf-8');
+      expect(persisted).toContain('KPORT=4301');
+      expect(persisted).not.toContain('KPORT=4200');
+      expect(persisted).not.toContain('KPORT=4302');
+    });
+  });
+
+  // The clear that bounds the recorded hashes must run at the generation
+  // claim, not earlier in the kickoff: plugin loading awaits between the two,
+  // and a tracked edit classified in that window records a hash an earlier
+  // clear has already run for, which would then suppress a coalesced revert
+  // landing while the computation reads.
+  it('recomputes for a tracked-file revert when the tracked edit was classified while the successor loads plugins', async () => {
+    fs.createFilesSync({
+      'nx.json': JSON.stringify({}),
+      'package.json': JSON.stringify({ name: 'root' }),
+      '.gitignore': '.env.e2e\n',
+      'libs/foo/project.json': JSON.stringify({
+        name: 'foo',
+        root: 'libs/foo',
+      }),
+      'libs/foo/.env.k': 'KPORT=4200\n',
+      'libs/foo/.env.e2e': 'UPORT=9000\n',
+    });
+
+    await jest.isolateModulesAsync(async () => {
+      const { setWorkspaceRoot } = require('../../utils/workspace-root');
+      setWorkspaceRoot(fs.tempDir);
+
+      const makeGate = () => {
+        let release: () => void;
+        const promise = new Promise<void>((resolve) => {
+          release = resolve;
+        });
+        return { promise, release: () => release(), reached: false };
+      };
+      // Park compute B while it loads plugins (before its generation claim)
+      // and before and after its read; computes A and C run unimpeded.
+      const bPlugins = makeGate();
+      const bEntry = makeGate();
+      const bExit = makeGate();
+      let pluginsCallCount = 0;
+      jest.doMock('../../project-graph/plugins/get-plugins', () => {
+        const actual = jest.requireActual(
+          '../../project-graph/plugins/get-plugins'
+        );
+        return {
+          ...actual,
+          getPluginsSeparated: async (...args: unknown[]) => {
+            const call = ++pluginsCallCount;
+            if (call === 2) {
+              bPlugins.reached = true;
+              await bPlugins.promise;
+            }
+            return actual.getPluginsSeparated(...args);
+          },
+        };
+      });
+      let retrieveCallCount = 0;
+      jest.doMock('../../project-graph/utils/retrieve-workspace-files', () => {
+        const actual = jest.requireActual(
+          '../../project-graph/utils/retrieve-workspace-files'
+        );
+        return {
+          ...actual,
+          retrieveProjectConfigurations: async (...args: unknown[]) => {
+            const call = ++retrieveCallCount;
+            if (call === 2) {
+              bEntry.reached = true;
+              await bEntry.promise;
+            }
+            const result = await actual.retrieveProjectConfigurations(...args);
+            const tracked = readFileSync(
+              join(fs.tempDir, 'libs/foo/.env.k'),
+              'utf-8'
+            ).trim();
+            const ignored = readFileSync(
+              join(fs.tempDir, 'libs/foo/.env.e2e'),
+              'utf-8'
+            ).trim();
+            result.projects['libs/foo'].tags = [`env:${tracked}|${ignored}`];
+            if (call === 2) {
+              bExit.reached = true;
+              await bExit.promise;
+            }
+            return result;
+          },
+        };
+      });
+
+      const {
+        getCachedSerializedProjectGraphPromise,
+      } = require('./project-graph-incremental-recomputation');
+      const { handleOutputsChanges } = require('./handle-outputs-changes');
+      const { nxProjectGraph } = require('../../project-graph/nx-deps-cache');
+      const { EventType } = require('../../native');
+
+      const waitFor = async (cond: () => boolean) => {
+        while (!cond()) {
+          await new Promise((r) => setImmediate(r));
+        }
+      };
+      const trackedPath = join(fs.tempDir, 'libs/foo/.env.k');
+      const ignoredPath = join(fs.tempDir, 'libs/foo/.env.e2e');
+      const trackedEvent = { path: 'libs/foo/.env.k', type: EventType.update };
+      const ignoredEvent = {
+        path: 'libs/foo/.env.e2e',
+        type: EventType.update,
+      };
+
+      const first = await getCachedSerializedProjectGraphPromise();
+      expect(first.projectGraph.nodes.foo.data.tags).toEqual([
+        'env:KPORT=4200|UPORT=9000',
+      ]);
+
+      // The gitignored edit invalidates directly, so the request kicks
+      // compute B, which parks while loading plugins.
+      writeFileSync(ignoredPath, 'UPORT=9001\n');
+      await handleOutputsChanges(null, [ignoredEvent]);
+      const second = getCachedSerializedProjectGraphPromise();
+      await waitFor(() => bPlugins.reached);
+
+      // The tracked edit is classified while B loads plugins: after B was
+      // kicked, before B claims its generation and clears the hashes.
+      writeFileSync(trackedPath, 'KPORT=4301\n');
+      await handleOutputsChanges(null, [trackedEvent]);
+      bPlugins.release();
+
+      // B claims and reads an intermediate 4302 the watcher never reports.
+      await waitFor(() => bEntry.reached);
+      writeFileSync(trackedPath, 'KPORT=4302\n');
+      bEntry.release();
+      await waitFor(() => bExit.reached);
+
+      // Back to the classified bytes; a hash surviving B's claim would
+      // suppress this event and let B serve the intermediate content.
+      writeFileSync(trackedPath, 'KPORT=4301\n');
+      await handleOutputsChanges(null, [trackedEvent]);
+      bExit.release();
+
+      const result = await second;
+      expect(result.error).toBeNull();
+      expect(result.projectGraph.nodes.foo.data.tags).toEqual([
+        'env:KPORT=4301|UPORT=9001',
+      ]);
+      expect(retrieveCallCount).toBeGreaterThanOrEqual(3);
+      const persisted = readFileSync(nxProjectGraph, 'utf-8');
+      expect(persisted).toContain('KPORT=4301');
+      expect(persisted).not.toContain('KPORT=4200');
+      expect(persisted).not.toContain('KPORT=4302');
+    });
+  });
+
   // A slow stale computation assigns currentProjectGraph before it discovers
   // it lost, so after the winner settles that variable can describe an older
   // graph until the loser chains away. The warm-reuse check must classify

--- a/packages/nx/src/daemon/server/project-graph-incremental-recomputation.spec.ts
+++ b/packages/nx/src/daemon/server/project-graph-incremental-recomputation.spec.ts
@@ -9,6 +9,9 @@ import { TempFs } from '../../internal-testing-utils/temp-fs';
 // compute would dispatch after teardown and its lazy requires would throw.
 vi.mock('../../utils/perf-logging', () => ({}));
 
+// These cases drive a real compute, so they need working plugin-worker
+// isolation. Where forked workers cannot start (containers, agent sandboxes)
+// every case stalls to the suite timeout; run with NX_ISOLATE_PLUGINS=false.
 describe('getCachedSerializedProjectGraphPromise — watcher race coverage', () => {
   let fs: TempFs;
 

--- a/packages/nx/src/daemon/server/project-graph-incremental-recomputation.spec.ts
+++ b/packages/nx/src/daemon/server/project-graph-incremental-recomputation.spec.ts
@@ -225,3 +225,63 @@ describe('getCachedSerializedProjectGraphPromise — watcher race coverage', () 
     }
   });
 });
+
+describe('isKnownWorkspaceFile', () => {
+  let fs: TempFs;
+
+  beforeEach(() => {
+    fs = new TempFs('pgir-known-files');
+  });
+
+  afterEach(() => {
+    fs.cleanup();
+  });
+
+  it('answers membership from the committed ignore-filtered file map', async () => {
+    fs.createFilesSync({
+      'nx.json': JSON.stringify({}),
+      'package.json': JSON.stringify({ name: 'root' }),
+      '.nxignore': '.env\n',
+      '.env': 'A=1\n',
+      'libs/foo/project.json': JSON.stringify({
+        name: 'foo',
+        root: 'libs/foo',
+      }),
+      'libs/foo/src/index.ts': '',
+    });
+
+    await jest.isolateModulesAsync(async () => {
+      // The plugin-loader mocks jest.doMock installs in the tests above are
+      // registry-wide and outlive their isolated module graphs.
+      jest.dontMock('../../project-graph/plugins/get-plugins');
+      const { setWorkspaceRoot } = require('../../utils/workspace-root');
+      setWorkspaceRoot(fs.tempDir);
+
+      const {
+        getCachedSerializedProjectGraphPromise,
+        scheduleProjectGraphRecomputation,
+        isKnownWorkspaceFile,
+      } = require('./project-graph-incremental-recomputation');
+
+      // Nothing is known before the first recompute commits a map; the caller
+      // (server.ts) then fails safe by invalidating.
+      expect(isKnownWorkspaceFile('package.json')).toBe(false);
+
+      const committed = await getCachedSerializedProjectGraphPromise();
+      expect(committed.error).toBeNull();
+
+      expect(isKnownWorkspaceFile('package.json')).toBe(true);
+      expect(isKnownWorkspaceFile('libs/foo/src/index.ts')).toBe(true);
+      // Ignored, so filtered out of the map (and never watched).
+      expect(isKnownWorkspaceFile('.env')).toBe(false);
+      expect(isKnownWorkspaceFile('never-existed.env')).toBe(false);
+
+      // A later commit replaces the map; membership must follow the new map,
+      // not a lookup structure built from the old one.
+      fs.createFileSync('libs/foo/src/other.ts', '');
+      scheduleProjectGraphRecomputation(['libs/foo/src/other.ts'], [], []);
+      await getCachedSerializedProjectGraphPromise();
+      expect(isKnownWorkspaceFile('libs/foo/src/other.ts')).toBe(true);
+    });
+  });
+});

--- a/packages/nx/src/daemon/server/project-graph-incremental-recomputation.spec.ts
+++ b/packages/nx/src/daemon/server/project-graph-incremental-recomputation.spec.ts
@@ -3,6 +3,12 @@ import { join } from 'node:path';
 
 import { TempFs } from '../../internal-testing-utils/temp-fs';
 
+// Loading the module under test pulls in the daemon server (via ./watcher),
+// which registers a process-global PerformanceObserver. That observer outlives
+// each test's isolated module registry, so a measure emitted by the last real
+// compute would dispatch after teardown and its lazy requires would throw.
+jest.mock('../../utils/perf-logging', () => ({}));
+
 describe('getCachedSerializedProjectGraphPromise — watcher race coverage', () => {
   let fs: TempFs;
 
@@ -282,6 +288,81 @@ describe('isKnownWorkspaceFile', () => {
       scheduleProjectGraphRecomputation(['libs/foo/src/other.ts'], [], []);
       await getCachedSerializedProjectGraphPromise();
       expect(isKnownWorkspaceFile('libs/foo/src/other.ts')).toBe(true);
+    });
+  });
+});
+
+describe('invalidateGraphCache', () => {
+  let fs: TempFs;
+
+  beforeEach(() => {
+    fs = new TempFs('pgir-invalidate');
+  });
+
+  afterEach(() => {
+    fs.cleanup();
+  });
+
+  // The generation bump is what chains an in-flight compute to a successor:
+  // clearing the cached promise alone lets the compute pass its chainToLatest
+  // checks and hand its result — built under the pre-invalidation input — to
+  // whoever already awaits it, with no successor ever started.
+  it('chains an in-flight compute to a successor instead of serving its result', async () => {
+    fs.createFilesSync({
+      'nx.json': JSON.stringify({}),
+      'package.json': JSON.stringify({ name: 'root' }),
+    });
+
+    await jest.isolateModulesAsync(async () => {
+      // The plugin-loader mocks jest.doMock installs in the tests above are
+      // registry-wide and outlive their isolated module graphs.
+      jest.dontMock('../../project-graph/plugins/get-plugins');
+      const { setWorkspaceRoot } = require('../../utils/workspace-root');
+      setWorkspaceRoot(fs.tempDir);
+
+      // Park the first compute inside its config retrieval, after it claimed
+      // its generation — the window an env-carrying client message can land
+      // in. The mock controls timing, not logic; the real retrieval runs.
+      let releaseFirstRetrieve: () => void;
+      const firstRetrieveGate = new Promise<void>((resolve) => {
+        releaseFirstRetrieve = resolve;
+      });
+      let retrieveCallCount = 0;
+      jest.doMock('../../project-graph/utils/retrieve-workspace-files', () => {
+        const actual = jest.requireActual(
+          '../../project-graph/utils/retrieve-workspace-files'
+        );
+        return {
+          ...actual,
+          retrieveProjectConfigurations: async (...args: unknown[]) => {
+            retrieveCallCount++;
+            if (retrieveCallCount === 1) {
+              await firstRetrieveGate;
+            }
+            return actual.retrieveProjectConfigurations(...args);
+          },
+        };
+      });
+
+      const {
+        getCachedSerializedProjectGraphPromise,
+        invalidateGraphCache,
+      } = require('./project-graph-incremental-recomputation');
+
+      const first = getCachedSerializedProjectGraphPromise();
+      while (retrieveCallCount === 0) {
+        await new Promise((r) => setImmediate(r));
+      }
+
+      invalidateGraphCache();
+      releaseFirstRetrieve!();
+
+      const result = await first;
+      expect(result.error).toBeNull();
+      expect(result.projectGraph).toBeDefined();
+      // The successor's retrieval, proving the parked compute discarded its
+      // own result and chained instead of committing.
+      expect(retrieveCallCount).toBeGreaterThanOrEqual(2);
     });
   });
 });

--- a/packages/nx/src/daemon/server/project-graph-incremental-recomputation.spec.ts
+++ b/packages/nx/src/daemon/server/project-graph-incremental-recomputation.spec.ts
@@ -1,4 +1,4 @@
-import { mkdirSync, writeFileSync } from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
 import { join } from 'node:path';
 
 import { TempFs } from '../../internal-testing-utils/temp-fs';
@@ -363,6 +363,1302 @@ describe('invalidateGraphCache', () => {
       // The successor's retrieval, proving the parked compute discarded its
       // own result and chained instead of committing.
       expect(retrieveCallCount).toBeGreaterThanOrEqual(2);
+    });
+  });
+});
+
+describe('pending dotenv replay before serving a graph', () => {
+  let fs: TempFs;
+
+  beforeEach(() => {
+    fs = new TempFs('pgir-dotenv-replay');
+  });
+
+  afterEach(() => {
+    fs.cleanup();
+  });
+
+  // A gitignored project-root dotenv edit arriving while the initial
+  // computation is in flight matches no committed root, so it is queued
+  // rather than invalidating. The compute must replay the queue against the
+  // graph it is about to serve and chain every awaiting caller to a successor
+  // that reads the new content; committing instead would serve, notify, and
+  // persist config derived from the old file.
+  it('chains the first awaiting caller to a successor that observes the dotenv edit', async () => {
+    fs.createFilesSync({
+      'nx.json': JSON.stringify({}),
+      'package.json': JSON.stringify({ name: 'root' }),
+      '.gitignore': '.env.e2e\n',
+      'libs/foo/project.json': JSON.stringify({
+        name: 'foo',
+        root: 'libs/foo',
+      }),
+      'libs/foo/.env.e2e': 'PORT=4200\n',
+    });
+
+    await jest.isolateModulesAsync(async () => {
+      // The plugin-loader mocks jest.doMock installs in the tests above are
+      // registry-wide and outlive their isolated module graphs.
+      jest.dontMock('../../project-graph/plugins/get-plugins');
+      const { setWorkspaceRoot } = require('../../utils/workspace-root');
+      setWorkspaceRoot(fs.tempDir);
+
+      // Park the first compute after its config retrieval read the old dotenv
+      // content — the window the edit lands in. The injected tag stands in
+      // for a plugin resolving config from the dotenv file at createNodes
+      // time; the mock controls timing and the marker, not the retrieval.
+      let releaseFirstRetrieve: () => void;
+      const firstRetrieveGate = new Promise<void>((resolve) => {
+        releaseFirstRetrieve = resolve;
+      });
+      let firstRetrieveDone = false;
+      let retrieveCallCount = 0;
+      jest.doMock('../../project-graph/utils/retrieve-workspace-files', () => {
+        const actual = jest.requireActual(
+          '../../project-graph/utils/retrieve-workspace-files'
+        );
+        return {
+          ...actual,
+          retrieveProjectConfigurations: async (...args: unknown[]) => {
+            const call = ++retrieveCallCount;
+            const result = await actual.retrieveProjectConfigurations(...args);
+            const env = readFileSync(
+              join(fs.tempDir, 'libs/foo/.env.e2e'),
+              'utf-8'
+            ).trim();
+            result.projects['libs/foo'].tags = [`env:${env}`];
+            if (call === 1) {
+              firstRetrieveDone = true;
+              await firstRetrieveGate;
+            }
+            return result;
+          },
+        };
+      });
+
+      const {
+        getCachedSerializedProjectGraphPromise,
+        registerProjectGraphRecomputationListener,
+      } = require('./project-graph-incremental-recomputation');
+      const { handleOutputsChanges } = require('./handle-outputs-changes');
+      const { nxProjectGraph } = require('../../project-graph/nx-deps-cache');
+      const { EventType } = require('../../native');
+
+      const notifiedTags: string[][] = [];
+      registerProjectGraphRecomputationListener(
+        (graph: import('../../config/project-graph').ProjectGraph) => {
+          notifiedTags.push(graph.nodes.foo.data.tags);
+        }
+      );
+
+      const first = getCachedSerializedProjectGraphPromise();
+      while (!firstRetrieveDone) {
+        await new Promise((r) => setImmediate(r));
+      }
+
+      writeFileSync(join(fs.tempDir, 'libs/foo/.env.e2e'), 'PORT=4201\n');
+      // The outputs watcher is the only reporter of gitignored files. No
+      // graph is committed yet, so the event goes unclassified and is queued.
+      await handleOutputsChanges(null, [
+        { path: 'libs/foo/.env.e2e', type: EventType.update },
+      ]);
+      releaseFirstRetrieve!();
+
+      const result = await first;
+      expect(result.error).toBeNull();
+      expect(result.projectGraph.nodes.foo.data.tags).toEqual([
+        'env:PORT=4201',
+      ]);
+      // The successor's retrieval, proving the first compute did not serve
+      // the graph built from the old content.
+      expect(retrieveCallCount).toBeGreaterThanOrEqual(2);
+      // The stale graph must be neither notified to listeners nor persisted.
+      expect(notifiedTags).toEqual([['env:PORT=4201']]);
+      const persisted = readFileSync(nxProjectGraph, 'utf-8');
+      expect(persisted).toContain('PORT=4201');
+      expect(persisted).not.toContain('PORT=4200');
+    });
+  });
+
+  // The successor itself can read intermediate bytes the watcher never
+  // reports separately: the file changes again mid-successor and returns to
+  // the drain-time bytes before the coalesced event arrives. A content hash
+  // recorded at drain time would suppress that final event and let the
+  // successor serve the intermediate content, so the drain must not record
+  // hashes.
+  it('recomputes for a post-drain edit whose final bytes match the drain-time content', async () => {
+    fs.createFilesSync({
+      'nx.json': JSON.stringify({}),
+      'package.json': JSON.stringify({ name: 'root' }),
+      '.gitignore': '.env.e2e\n',
+      'libs/foo/project.json': JSON.stringify({
+        name: 'foo',
+        root: 'libs/foo',
+      }),
+      'libs/foo/.env.e2e': 'PORT=4200\n',
+    });
+
+    await jest.isolateModulesAsync(async () => {
+      // The plugin-loader mocks jest.doMock installs in the tests above are
+      // registry-wide and outlive their isolated module graphs.
+      jest.dontMock('../../project-graph/plugins/get-plugins');
+      const { setWorkspaceRoot } = require('../../utils/workspace-root');
+      setWorkspaceRoot(fs.tempDir);
+
+      const makeGate = () => {
+        let release: () => void;
+        const promise = new Promise<void>((resolve) => {
+          release = resolve;
+        });
+        return { promise, release: () => release(), reached: false };
+      };
+      // Park compute A after its read, compute B before and after its read,
+      // so edits land in each window; compute C runs unimpeded.
+      const aExit = makeGate();
+      const bEntry = makeGate();
+      const bExit = makeGate();
+      let retrieveCallCount = 0;
+      jest.doMock('../../project-graph/utils/retrieve-workspace-files', () => {
+        const actual = jest.requireActual(
+          '../../project-graph/utils/retrieve-workspace-files'
+        );
+        return {
+          ...actual,
+          retrieveProjectConfigurations: async (...args: unknown[]) => {
+            const call = ++retrieveCallCount;
+            if (call === 2) {
+              bEntry.reached = true;
+              await bEntry.promise;
+            }
+            const result = await actual.retrieveProjectConfigurations(...args);
+            const env = readFileSync(
+              join(fs.tempDir, 'libs/foo/.env.e2e'),
+              'utf-8'
+            ).trim();
+            result.projects['libs/foo'].tags = [`env:${env}`];
+            if (call === 1) {
+              aExit.reached = true;
+              await aExit.promise;
+            }
+            if (call === 2) {
+              bExit.reached = true;
+              await bExit.promise;
+            }
+            return result;
+          },
+        };
+      });
+
+      const {
+        getCachedSerializedProjectGraphPromise,
+        registerProjectGraphRecomputationListener,
+      } = require('./project-graph-incremental-recomputation');
+      const { handleOutputsChanges } = require('./handle-outputs-changes');
+      const { nxProjectGraph } = require('../../project-graph/nx-deps-cache');
+      const { EventType } = require('../../native');
+
+      const notifiedTags: string[][] = [];
+      registerProjectGraphRecomputationListener(
+        (graph: import('../../config/project-graph').ProjectGraph) => {
+          notifiedTags.push(graph.nodes.foo.data.tags);
+        }
+      );
+
+      const waitFor = async (cond: () => boolean) => {
+        while (!cond()) {
+          await new Promise((r) => setImmediate(r));
+        }
+      };
+      const envPath = join(fs.tempDir, 'libs/foo/.env.e2e');
+      const envEvent = { path: 'libs/foo/.env.e2e', type: EventType.update };
+
+      // Compute A reads 4200 and parks; the edit to 4201 is queued.
+      const first = getCachedSerializedProjectGraphPromise();
+      await waitFor(() => aExit.reached);
+      writeFileSync(envPath, 'PORT=4201\n');
+      await handleOutputsChanges(null, [envEvent]);
+      aExit.release();
+
+      // A's drain chains to compute B, which reads an intermediate 4202
+      // whose write the watcher never reports.
+      await waitFor(() => bEntry.reached);
+      writeFileSync(envPath, 'PORT=4202\n');
+      bEntry.release();
+      await waitFor(() => bExit.reached);
+
+      // Back to the drain-time bytes; this event is B's only chance to be
+      // marked stale, and A committed a graph so it classifies directly.
+      writeFileSync(envPath, 'PORT=4201\n');
+      await handleOutputsChanges(null, [envEvent]);
+      bExit.release();
+
+      const result = await first;
+      expect(result.error).toBeNull();
+      expect(result.projectGraph.nodes.foo.data.tags).toEqual([
+        'env:PORT=4201',
+      ]);
+      expect(retrieveCallCount).toBeGreaterThanOrEqual(3);
+      expect(notifiedTags).toEqual([['env:PORT=4201']]);
+      const persisted = readFileSync(nxProjectGraph, 'utf-8');
+      expect(persisted).toContain('PORT=4201');
+      expect(persisted).not.toContain('PORT=4200');
+      expect(persisted).not.toContain('PORT=4202');
+    });
+  });
+
+  // The outputs and workspace watchers deliver independently, so an edit to a
+  // NON-ignored dotenv file can reach the outputs callback first and sit in
+  // the pending queue while the workspace watcher has not scheduled anything
+  // yet. The drain must treat the queued evidence as decisive: membership in
+  // the file map proves the workspace watcher tracks the file, not that its
+  // recomputation was already scheduled.
+  it('chains for a queued edit of a tracked dotenv file the workspace watcher has not delivered yet', async () => {
+    fs.createFilesSync({
+      'nx.json': JSON.stringify({}),
+      'package.json': JSON.stringify({ name: 'root' }),
+      'libs/foo/project.json': JSON.stringify({
+        name: 'foo',
+        root: 'libs/foo',
+      }),
+      'libs/foo/.env.e2e': 'PORT=4200\n',
+    });
+
+    await jest.isolateModulesAsync(async () => {
+      // The plugin-loader mocks jest.doMock installs in the tests above are
+      // registry-wide and outlive their isolated module graphs.
+      jest.dontMock('../../project-graph/plugins/get-plugins');
+      const { setWorkspaceRoot } = require('../../utils/workspace-root');
+      setWorkspaceRoot(fs.tempDir);
+
+      let releaseFirstRetrieve: () => void;
+      const firstRetrieveGate = new Promise<void>((resolve) => {
+        releaseFirstRetrieve = resolve;
+      });
+      let firstRetrieveDone = false;
+      let retrieveCallCount = 0;
+      jest.doMock('../../project-graph/utils/retrieve-workspace-files', () => {
+        const actual = jest.requireActual(
+          '../../project-graph/utils/retrieve-workspace-files'
+        );
+        return {
+          ...actual,
+          retrieveProjectConfigurations: async (...args: unknown[]) => {
+            const call = ++retrieveCallCount;
+            const result = await actual.retrieveProjectConfigurations(...args);
+            const env = readFileSync(
+              join(fs.tempDir, 'libs/foo/.env.e2e'),
+              'utf-8'
+            ).trim();
+            result.projects['libs/foo'].tags = [`env:${env}`];
+            if (call === 1) {
+              firstRetrieveDone = true;
+              await firstRetrieveGate;
+            }
+            return result;
+          },
+        };
+      });
+
+      const {
+        getCachedSerializedProjectGraphPromise,
+      } = require('./project-graph-incremental-recomputation');
+      const { handleOutputsChanges } = require('./handle-outputs-changes');
+      const { EventType } = require('../../native');
+
+      const first = getCachedSerializedProjectGraphPromise();
+      while (!firstRetrieveDone) {
+        await new Promise((r) => setImmediate(r));
+      }
+
+      writeFileSync(join(fs.tempDir, 'libs/foo/.env.e2e'), 'PORT=4201\n');
+      // Only the outputs watcher delivers; the workspace watcher is silent.
+      await handleOutputsChanges(null, [
+        { path: 'libs/foo/.env.e2e', type: EventType.update },
+      ]);
+      releaseFirstRetrieve!();
+
+      const result = await first;
+      expect(result.error).toBeNull();
+      expect(result.projectGraph.nodes.foo.data.tags).toEqual([
+        'env:PORT=4201',
+      ]);
+      expect(retrieveCallCount).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  // Once a computation has committed a graph and the file map, a tracked
+  // dotenv edit classifies as invalidating on arrival, and the arrival path
+  // defers to the workspace watcher instead of invalidating. That deferral is
+  // only sound for the cached graph: a successor already in flight may have
+  // read the file before the edit, so the event must be queued for its
+  // pre-serve replay rather than dropped.
+  it('chains when a tracked dotenv edit is classified while a successor is in flight', async () => {
+    fs.createFilesSync({
+      'nx.json': JSON.stringify({}),
+      'package.json': JSON.stringify({ name: 'root' }),
+      'libs/foo/project.json': JSON.stringify({
+        name: 'foo',
+        root: 'libs/foo',
+      }),
+      'libs/foo/.env.e2e': 'PORT=4200\n',
+    });
+
+    await jest.isolateModulesAsync(async () => {
+      // The plugin-loader mocks jest.doMock installs in the tests above are
+      // registry-wide and outlive their isolated module graphs.
+      jest.dontMock('../../project-graph/plugins/get-plugins');
+      const { setWorkspaceRoot } = require('../../utils/workspace-root');
+      setWorkspaceRoot(fs.tempDir);
+
+      const makeGate = () => {
+        let release: () => void;
+        const promise = new Promise<void>((resolve) => {
+          release = resolve;
+        });
+        return { promise, release: () => release(), reached: false };
+      };
+      // Park computes A and B after their reads so an edit lands in each
+      // window; compute C runs unimpeded.
+      const aExit = makeGate();
+      const bExit = makeGate();
+      let retrieveCallCount = 0;
+      jest.doMock('../../project-graph/utils/retrieve-workspace-files', () => {
+        const actual = jest.requireActual(
+          '../../project-graph/utils/retrieve-workspace-files'
+        );
+        return {
+          ...actual,
+          retrieveProjectConfigurations: async (...args: unknown[]) => {
+            const call = ++retrieveCallCount;
+            const result = await actual.retrieveProjectConfigurations(...args);
+            const env = readFileSync(
+              join(fs.tempDir, 'libs/foo/.env.e2e'),
+              'utf-8'
+            ).trim();
+            result.projects['libs/foo'].tags = [`env:${env}`];
+            if (call === 1) {
+              aExit.reached = true;
+              await aExit.promise;
+            }
+            if (call === 2) {
+              bExit.reached = true;
+              await bExit.promise;
+            }
+            return result;
+          },
+        };
+      });
+
+      const {
+        getCachedSerializedProjectGraphPromise,
+        registerProjectGraphRecomputationListener,
+      } = require('./project-graph-incremental-recomputation');
+      const { handleOutputsChanges } = require('./handle-outputs-changes');
+      const { nxProjectGraph } = require('../../project-graph/nx-deps-cache');
+      const { EventType } = require('../../native');
+
+      const notifiedTags: string[][] = [];
+      registerProjectGraphRecomputationListener(
+        (graph: import('../../config/project-graph').ProjectGraph) => {
+          notifiedTags.push(graph.nodes.foo.data.tags);
+        }
+      );
+
+      const waitFor = async (cond: () => boolean) => {
+        while (!cond()) {
+          await new Promise((r) => setImmediate(r));
+        }
+      };
+      const envPath = join(fs.tempDir, 'libs/foo/.env.e2e');
+      const envEvent = { path: 'libs/foo/.env.e2e', type: EventType.update };
+
+      // Compute A reads 4200 and parks; no graph is committed yet, so the
+      // edit to 4201 goes unclassified and is queued.
+      const first = getCachedSerializedProjectGraphPromise();
+      await waitFor(() => aExit.reached);
+      writeFileSync(envPath, 'PORT=4201\n');
+      await handleOutputsChanges(null, [envEvent]);
+      aExit.release();
+
+      // A's drain chains to compute B, which reads 4201 and parks. A
+      // committed its graph and file map, so this edit classifies as
+      // invalidating for a tracked file; only the outputs watcher delivers.
+      await waitFor(() => bExit.reached);
+      writeFileSync(envPath, 'PORT=4202\n');
+      await handleOutputsChanges(null, [envEvent]);
+      bExit.release();
+
+      const result = await first;
+      expect(result.error).toBeNull();
+      expect(result.projectGraph.nodes.foo.data.tags).toEqual([
+        'env:PORT=4202',
+      ]);
+      expect(retrieveCallCount).toBeGreaterThanOrEqual(3);
+      expect(notifiedTags).toEqual([['env:PORT=4202']]);
+      const persisted = readFileSync(nxProjectGraph, 'utf-8');
+      expect(persisted).toContain('PORT=4202');
+      expect(persisted).not.toContain('PORT=4200');
+      expect(persisted).not.toContain('PORT=4201');
+    });
+  });
+
+  // An error result is never cached, notified, or persisted, so when a queued
+  // dotenv edit landed mid-computation the failing input may already be fixed
+  // on disk: the computation must retry instead of surfacing the error to its
+  // awaiting callers.
+  it('retries a config error when a queued dotenv edit may have fixed it', async () => {
+    fs.createFilesSync({
+      'nx.json': JSON.stringify({}),
+      'package.json': JSON.stringify({ name: 'root' }),
+      '.gitignore': '.env.e2e\n',
+      'libs/foo/project.json': JSON.stringify({
+        name: 'foo',
+        root: 'libs/foo',
+      }),
+      'libs/foo/.env.e2e': 'MODE=bad\n',
+    });
+
+    await jest.isolateModulesAsync(async () => {
+      // The plugin-loader mocks jest.doMock installs in the tests above are
+      // registry-wide and outlive their isolated module graphs.
+      jest.dontMock('../../project-graph/plugins/get-plugins');
+      const { setWorkspaceRoot } = require('../../utils/workspace-root');
+      setWorkspaceRoot(fs.tempDir);
+      const {
+        ProjectConfigurationsError,
+      } = require('../../project-graph/error-types');
+
+      let releaseFirstRetrieve: () => void;
+      const firstRetrieveGate = new Promise<void>((resolve) => {
+        releaseFirstRetrieve = resolve;
+      });
+      let firstRetrieveDone = false;
+      let retrieveCallCount = 0;
+      // Stands in for a plugin whose createNodes fails on the dotenv-derived
+      // config: the retrieval reads the file and throws the structured error
+      // while its content is bad.
+      jest.doMock('../../project-graph/utils/retrieve-workspace-files', () => {
+        const actual = jest.requireActual(
+          '../../project-graph/utils/retrieve-workspace-files'
+        );
+        return {
+          ...actual,
+          retrieveProjectConfigurations: async (...args: unknown[]) => {
+            const call = ++retrieveCallCount;
+            const result = await actual.retrieveProjectConfigurations(...args);
+            const env = readFileSync(
+              join(fs.tempDir, 'libs/foo/.env.e2e'),
+              'utf-8'
+            ).trim();
+            result.projects['libs/foo'].tags = [`env:${env}`];
+            if (call === 1) {
+              firstRetrieveDone = true;
+              await firstRetrieveGate;
+            }
+            if (env === 'MODE=bad') {
+              throw new ProjectConfigurationsError(
+                [new Error('cannot resolve config: MODE=bad')],
+                result
+              );
+            }
+            return result;
+          },
+        };
+      });
+
+      const {
+        getCachedSerializedProjectGraphPromise,
+      } = require('./project-graph-incremental-recomputation');
+      const { handleOutputsChanges } = require('./handle-outputs-changes');
+      const { EventType } = require('../../native');
+
+      const first = getCachedSerializedProjectGraphPromise();
+      while (!firstRetrieveDone) {
+        await new Promise((r) => setImmediate(r));
+      }
+
+      writeFileSync(join(fs.tempDir, 'libs/foo/.env.e2e'), 'MODE=good\n');
+      // Only the outputs watcher reports the gitignored file; no graph is
+      // committed yet, so the event is queued.
+      await handleOutputsChanges(null, [
+        { path: 'libs/foo/.env.e2e', type: EventType.update },
+      ]);
+      releaseFirstRetrieve!();
+
+      const result = await first;
+      expect(result.error).toBeNull();
+      expect(result.projectGraph.nodes.foo.data.tags).toEqual([
+        'env:MODE=good',
+      ]);
+      expect(retrieveCallCount).toBeGreaterThanOrEqual(2);
+    });
+  });
+
+  // Overflow carries a generation stamp like a queued entry, so a persistent
+  // structured error retries exactly once: the retry claims a generation
+  // above the recorded stamp and surfaces the error instead of chaining
+  // forever.
+  it('retries once for lost events, then surfaces a persistent config error', async () => {
+    fs.createFilesSync({
+      'nx.json': JSON.stringify({}),
+      'package.json': JSON.stringify({ name: 'root' }),
+      '.gitignore': '.env.e2e\n',
+      'libs/foo/project.json': JSON.stringify({
+        name: 'foo',
+        root: 'libs/foo',
+      }),
+      'libs/foo/.env.e2e': 'MODE=bad\n',
+    });
+
+    await jest.isolateModulesAsync(async () => {
+      // The plugin-loader mocks jest.doMock installs in the tests above are
+      // registry-wide and outlive their isolated module graphs.
+      jest.dontMock('../../project-graph/plugins/get-plugins');
+      const { setWorkspaceRoot } = require('../../utils/workspace-root');
+      setWorkspaceRoot(fs.tempDir);
+      const {
+        ProjectConfigurationsError,
+      } = require('../../project-graph/error-types');
+
+      let releaseFirstRetrieve: () => void;
+      const firstRetrieveGate = new Promise<void>((resolve) => {
+        releaseFirstRetrieve = resolve;
+      });
+      let firstRetrieveDone = false;
+      let retrieveCallCount = 0;
+      jest.doMock('../../project-graph/utils/retrieve-workspace-files', () => {
+        const actual = jest.requireActual(
+          '../../project-graph/utils/retrieve-workspace-files'
+        );
+        return {
+          ...actual,
+          retrieveProjectConfigurations: async (...args: unknown[]) => {
+            const call = ++retrieveCallCount;
+            const result = await actual.retrieveProjectConfigurations(...args);
+            const env = readFileSync(
+              join(fs.tempDir, 'libs/foo/.env.e2e'),
+              'utf-8'
+            ).trim();
+            result.projects['libs/foo'].tags = [`env:${env}`];
+            if (call === 1) {
+              firstRetrieveDone = true;
+              await firstRetrieveGate;
+            }
+            if (env === 'MODE=bad') {
+              throw new ProjectConfigurationsError(
+                [new Error('cannot resolve config: MODE=bad')],
+                result
+              );
+            }
+            return result;
+          },
+        };
+      });
+
+      const {
+        getCachedSerializedProjectGraphPromise,
+        getRecomputationGeneration,
+      } = require('./project-graph-incremental-recomputation');
+      const { queuePendingDotEnvEvents } = require('./dotenv-graph-changes');
+
+      const first = getCachedSerializedProjectGraphPromise();
+      while (!firstRetrieveDone) {
+        await new Promise((r) => setImmediate(r));
+      }
+
+      // Overflow the queue mid-computation: the lost events could concern any
+      // dotenv file, so the erroring compute cannot prove its inputs fresh.
+      queuePendingDotEnvEvents(
+        Array.from({ length: 1025 }, (_, i) => `dist/out/.env.${i}`),
+        getRecomputationGeneration()
+      );
+      releaseFirstRetrieve!();
+
+      const result = await first;
+      expect(result.error?.name).toBe('DaemonProjectGraphError');
+      expect(result.projectGraph).toBeNull();
+      // Exactly one retry: the second compute outranks the overflow stamp.
+      expect(retrieveCallCount).toBe(2);
+    });
+  });
+
+  // The error-path retry preserves the queue for the successor's drain, but a
+  // content hash recorded during the failed computation must not survive into
+  // the retry: the successor can read intermediate bytes, and a revert back
+  // to the hashed content would then be suppressed after the drain's chance
+  // to catch it has passed.
+  it('recomputes for a revert delivered while an error retry is reading', async () => {
+    fs.createFilesSync({
+      'nx.json': JSON.stringify({}),
+      'package.json': JSON.stringify({ name: 'root' }),
+      'libs/foo/project.json': JSON.stringify({
+        name: 'foo',
+        root: 'libs/foo',
+      }),
+      'libs/foo/.env.e2e': 'PORT=4200\n',
+    });
+
+    await jest.isolateModulesAsync(async () => {
+      // The plugin-loader mocks jest.doMock installs in the tests above are
+      // registry-wide and outlive their isolated module graphs.
+      jest.dontMock('../../project-graph/plugins/get-plugins');
+      const { setWorkspaceRoot } = require('../../utils/workspace-root');
+      setWorkspaceRoot(fs.tempDir);
+      const {
+        ProjectConfigurationsError,
+      } = require('../../project-graph/error-types');
+
+      const makeGate = () => {
+        let release: () => void;
+        const promise = new Promise<void>((resolve) => {
+          release = resolve;
+        });
+        return { promise, release: () => release(), reached: false };
+      };
+      // B parks after its read and then fails; C parks before and after its
+      // read so the intermediate write and the revert land in each window.
+      const bExit = makeGate();
+      const cEntry = makeGate();
+      const cExit = makeGate();
+      let retrieveCallCount = 0;
+      jest.doMock('../../project-graph/utils/retrieve-workspace-files', () => {
+        const actual = jest.requireActual(
+          '../../project-graph/utils/retrieve-workspace-files'
+        );
+        return {
+          ...actual,
+          retrieveProjectConfigurations: async (...args: unknown[]) => {
+            const call = ++retrieveCallCount;
+            if (call === 3) {
+              cEntry.reached = true;
+              await cEntry.promise;
+            }
+            const result = await actual.retrieveProjectConfigurations(...args);
+            const env = readFileSync(
+              join(fs.tempDir, 'libs/foo/.env.e2e'),
+              'utf-8'
+            ).trim();
+            result.projects['libs/foo'].tags = [`env:${env}`];
+            if (call === 2) {
+              bExit.reached = true;
+              await bExit.promise;
+              throw new ProjectConfigurationsError(
+                [new Error('transient failure')],
+                result
+              );
+            }
+            if (call === 3) {
+              cExit.reached = true;
+              await cExit.promise;
+            }
+            return result;
+          },
+        };
+      });
+
+      const {
+        getCachedSerializedProjectGraphPromise,
+        invalidateGraphCache,
+      } = require('./project-graph-incremental-recomputation');
+      const { handleOutputsChanges } = require('./handle-outputs-changes');
+      const { nxProjectGraph } = require('../../project-graph/nx-deps-cache');
+      const { EventType } = require('../../native');
+
+      const waitFor = async (cond: () => boolean) => {
+        while (!cond()) {
+          await new Promise((r) => setImmediate(r));
+        }
+      };
+      const envPath = join(fs.tempDir, 'libs/foo/.env.e2e');
+      const envEvent = { path: 'libs/foo/.env.e2e', type: EventType.update };
+
+      // Compute A commits a warm graph at 4200.
+      const warm = await getCachedSerializedProjectGraphPromise();
+      expect(warm.error).toBeNull();
+
+      // Compute B reads 4200 and parks; the edit to 4201 arrives mid-flight,
+      // classified against A's committed graph, recording its hash and
+      // queueing the tracked path. B then fails transiently.
+      invalidateGraphCache();
+      const second = getCachedSerializedProjectGraphPromise();
+      await waitFor(() => bExit.reached);
+      writeFileSync(envPath, 'PORT=4201\n');
+      await handleOutputsChanges(null, [envEvent]);
+      bExit.release();
+
+      // B's retry starts C, which reads an intermediate 4202 the watcher
+      // never reports separately; the file returns to 4201 before the
+      // callback hashes it.
+      await waitFor(() => cEntry.reached);
+      writeFileSync(envPath, 'PORT=4202\n');
+      cEntry.release();
+      await waitFor(() => cExit.reached);
+      writeFileSync(envPath, 'PORT=4201\n');
+      await handleOutputsChanges(null, [envEvent]);
+      cExit.release();
+
+      const result = await second;
+      expect(result.error).toBeNull();
+      expect(result.projectGraph.nodes.foo.data.tags).toEqual([
+        'env:PORT=4201',
+      ]);
+      expect(retrieveCallCount).toBeGreaterThanOrEqual(4);
+      const persisted = readFileSync(nxProjectGraph, 'utf-8');
+      expect(persisted).toContain('PORT=4201');
+      expect(persisted).not.toContain('PORT=4200');
+      expect(persisted).not.toContain('PORT=4202');
+    });
+  });
+
+  // With the graph warm and no computation in flight, a tracked dotenv edit
+  // the outputs watcher delivers first queues without invalidating, and only
+  // the workspace watcher's later delivery schedules a recomputation. A
+  // request landing inside that lag must not reuse the cached graph: the
+  // queued evidence is classified against the exact graph the cache serves
+  // and forces the recomputation the lagging watcher has not scheduled yet.
+  it('recomputes when a tracked dotenv edit reaches only the outputs watcher while the graph is warm', async () => {
+    fs.createFilesSync({
+      'nx.json': JSON.stringify({}),
+      'package.json': JSON.stringify({ name: 'root' }),
+      'libs/foo/project.json': JSON.stringify({
+        name: 'foo',
+        root: 'libs/foo',
+      }),
+      'libs/foo/.env.e2e': 'PORT=4200\n',
+    });
+
+    await jest.isolateModulesAsync(async () => {
+      // The plugin-loader mocks jest.doMock installs in the tests above are
+      // registry-wide and outlive their isolated module graphs.
+      jest.dontMock('../../project-graph/plugins/get-plugins');
+      const { setWorkspaceRoot } = require('../../utils/workspace-root');
+      setWorkspaceRoot(fs.tempDir);
+
+      let retrieveCallCount = 0;
+      jest.doMock('../../project-graph/utils/retrieve-workspace-files', () => {
+        const actual = jest.requireActual(
+          '../../project-graph/utils/retrieve-workspace-files'
+        );
+        return {
+          ...actual,
+          retrieveProjectConfigurations: async (...args: unknown[]) => {
+            ++retrieveCallCount;
+            const result = await actual.retrieveProjectConfigurations(...args);
+            const env = readFileSync(
+              join(fs.tempDir, 'libs/foo/.env.e2e'),
+              'utf-8'
+            ).trim();
+            result.projects['libs/foo'].tags = [`env:${env}`];
+            return result;
+          },
+        };
+      });
+
+      const {
+        getCachedSerializedProjectGraphPromise,
+      } = require('./project-graph-incremental-recomputation');
+      const { handleOutputsChanges } = require('./handle-outputs-changes');
+      const { nxProjectGraph } = require('../../project-graph/nx-deps-cache');
+      const { EventType } = require('../../native');
+
+      const first = await getCachedSerializedProjectGraphPromise();
+      expect(first.projectGraph.nodes.foo.data.tags).toEqual(['env:PORT=4200']);
+      expect(retrieveCallCount).toBe(1);
+
+      writeFileSync(join(fs.tempDir, 'libs/foo/.env.e2e'), 'PORT=4201\n');
+      // Only the outputs watcher delivers; the workspace watcher is silent.
+      await handleOutputsChanges(null, [
+        { path: 'libs/foo/.env.e2e', type: EventType.update },
+      ]);
+
+      const second = await getCachedSerializedProjectGraphPromise();
+      expect(second.error).toBeNull();
+      expect(second.projectGraph.nodes.foo.data.tags).toEqual([
+        'env:PORT=4201',
+      ]);
+      expect(retrieveCallCount).toBe(2);
+      const persisted = readFileSync(nxProjectGraph, 'utf-8');
+      expect(persisted).toContain('PORT=4201');
+      expect(persisted).not.toContain('PORT=4200');
+    });
+  });
+
+  // The reuse-triggered successor can read intermediate bytes the watcher
+  // never reports separately. The content hash recorded when the queued edit
+  // was classified must be dropped before that successor starts: kept, a
+  // revert back to the queued bytes landing mid-read would be suppressed as a
+  // byte-identical rewrite and the successor would serve the intermediate
+  // content.
+  it('recomputes for a revert delivered while a warm-reuse successor is reading', async () => {
+    fs.createFilesSync({
+      'nx.json': JSON.stringify({}),
+      'package.json': JSON.stringify({ name: 'root' }),
+      'libs/foo/project.json': JSON.stringify({
+        name: 'foo',
+        root: 'libs/foo',
+      }),
+      'libs/foo/.env.e2e': 'PORT=4200\n',
+    });
+
+    await jest.isolateModulesAsync(async () => {
+      // The plugin-loader mocks jest.doMock installs in the tests above are
+      // registry-wide and outlive their isolated module graphs.
+      jest.dontMock('../../project-graph/plugins/get-plugins');
+      const { setWorkspaceRoot } = require('../../utils/workspace-root');
+      setWorkspaceRoot(fs.tempDir);
+
+      const makeGate = () => {
+        let release: () => void;
+        const promise = new Promise<void>((resolve) => {
+          release = resolve;
+        });
+        return { promise, release: () => release(), reached: false };
+      };
+      // Park the reuse-triggered compute B before and after its read so an
+      // edit lands in each window; computes A and C run unimpeded.
+      const bEntry = makeGate();
+      const bExit = makeGate();
+      let retrieveCallCount = 0;
+      jest.doMock('../../project-graph/utils/retrieve-workspace-files', () => {
+        const actual = jest.requireActual(
+          '../../project-graph/utils/retrieve-workspace-files'
+        );
+        return {
+          ...actual,
+          retrieveProjectConfigurations: async (...args: unknown[]) => {
+            const call = ++retrieveCallCount;
+            if (call === 2) {
+              bEntry.reached = true;
+              await bEntry.promise;
+            }
+            const result = await actual.retrieveProjectConfigurations(...args);
+            const env = readFileSync(
+              join(fs.tempDir, 'libs/foo/.env.e2e'),
+              'utf-8'
+            ).trim();
+            result.projects['libs/foo'].tags = [`env:${env}`];
+            if (call === 2) {
+              bExit.reached = true;
+              await bExit.promise;
+            }
+            return result;
+          },
+        };
+      });
+
+      const {
+        getCachedSerializedProjectGraphPromise,
+      } = require('./project-graph-incremental-recomputation');
+      const { handleOutputsChanges } = require('./handle-outputs-changes');
+      const { nxProjectGraph } = require('../../project-graph/nx-deps-cache');
+      const { EventType } = require('../../native');
+
+      const waitFor = async (cond: () => boolean) => {
+        while (!cond()) {
+          await new Promise((r) => setImmediate(r));
+        }
+      };
+      const envPath = join(fs.tempDir, 'libs/foo/.env.e2e');
+      const envEvent = { path: 'libs/foo/.env.e2e', type: EventType.update };
+
+      const first = await getCachedSerializedProjectGraphPromise();
+      expect(first.projectGraph.nodes.foo.data.tags).toEqual(['env:PORT=4200']);
+
+      // Classifying this edit records the hash of the 4201 bytes and queues
+      // the tracked path.
+      writeFileSync(envPath, 'PORT=4201\n');
+      await handleOutputsChanges(null, [envEvent]);
+
+      // The request finds the queued evidence and triggers compute B, which
+      // reads an intermediate 4202 whose write the watcher never reports.
+      const second = getCachedSerializedProjectGraphPromise();
+      await waitFor(() => bEntry.reached);
+      writeFileSync(envPath, 'PORT=4202\n');
+      bEntry.release();
+      await waitFor(() => bExit.reached);
+
+      // Back to the queued bytes; with the pre-successor hash retained this
+      // event would be suppressed as a byte-identical rewrite and B would
+      // serve the intermediate content.
+      writeFileSync(envPath, 'PORT=4201\n');
+      await handleOutputsChanges(null, [envEvent]);
+      bExit.release();
+
+      const result = await second;
+      expect(result.error).toBeNull();
+      expect(result.projectGraph.nodes.foo.data.tags).toEqual([
+        'env:PORT=4201',
+      ]);
+      expect(retrieveCallCount).toBeGreaterThanOrEqual(3);
+      const persisted = readFileSync(nxProjectGraph, 'utf-8');
+      expect(persisted).toContain('PORT=4201');
+      expect(persisted).not.toContain('PORT=4200');
+      expect(persisted).not.toContain('PORT=4202');
+    });
+  });
+
+  // A slow stale computation assigns currentProjectGraph before it discovers
+  // it lost, so after the winner settles that variable can describe an older
+  // graph until the loser chains away. The warm-reuse check must classify
+  // queued evidence against the graph the cache actually serves: against the
+  // overwritten currentProjectGraph, an edit under a root only the served
+  // graph knows would be dismissed and the stale cache reused.
+  it('classifies warm-reuse evidence against the served graph, not one a stale computation left behind', async () => {
+    fs.createFilesSync({
+      'nx.json': JSON.stringify({}),
+      'package.json': JSON.stringify({ name: 'root' }),
+      '.gitignore': '.env.e2e\n',
+      'libs/foo/project.json': JSON.stringify({
+        name: 'foo',
+        root: 'libs/foo',
+      }),
+    });
+
+    await jest.isolateModulesAsync(async () => {
+      // The plugin-loader mocks jest.doMock installs in the tests above are
+      // registry-wide and outlive their isolated module graphs.
+      jest.dontMock('../../project-graph/plugins/get-plugins');
+      const { setWorkspaceRoot } = require('../../utils/workspace-root');
+      setWorkspaceRoot(fs.tempDir);
+
+      const makeGate = () => {
+        let release: () => void;
+        const promise = new Promise<void>((resolve) => {
+          release = resolve;
+        });
+        return { promise, release: () => release(), reached: false };
+      };
+      // Park compute A inside createAndSerializeProjectGraph, before its
+      // graph is built and assigned to currentProjectGraph. getPlugins is
+      // awaited there right before the build, after every earlier staleness
+      // gate, so the park keeps A's late assignment as the last write.
+      const aPark = makeGate();
+      let retrieveCallCount = 0;
+      jest.doMock('../../project-graph/utils/retrieve-workspace-files', () => {
+        const actual = jest.requireActual(
+          '../../project-graph/utils/retrieve-workspace-files'
+        );
+        return {
+          ...actual,
+          retrieveProjectConfigurations: async (...args: unknown[]) => {
+            ++retrieveCallCount;
+            const result = await actual.retrieveProjectConfigurations(...args);
+            for (const [root, project] of Object.entries(result.projects)) {
+              const envFile = join(fs.tempDir, root, '.env.e2e');
+              if (existsSync(envFile)) {
+                (project as { tags?: string[] }).tags = [
+                  `env:${readFileSync(envFile, 'utf-8').trim()}`,
+                ];
+              }
+            }
+            return result;
+          },
+        };
+      });
+      // A plain factory: the module sits in a require cycle, so resolving
+      // the actual inside the factory recurses. getPluginsSeparated resolves
+      // it lazily at call time instead (project discovery needs the real
+      // default plugins); the faked getPlugins only skips dependency hooks
+      // these assertions never read.
+      let pluginsCallCount = 0;
+      jest.doMock('../../project-graph/plugins/get-plugins', () => ({
+        __esModule: true,
+        getPlugins: async () => {
+          const call = ++pluginsCallCount;
+          if (call === 1) {
+            aPark.reached = true;
+            await aPark.promise;
+          }
+          return [];
+        },
+        getPluginsSeparated: (...args: unknown[]) =>
+          jest
+            .requireActual('../../project-graph/plugins/get-plugins')
+            .getPluginsSeparated(...args),
+      }));
+
+      const pgir = require('./project-graph-incremental-recomputation');
+      const {
+        getCachedSerializedProjectGraphPromise,
+        scheduleProjectGraphRecomputation,
+      } = pgir;
+      const { handleOutputsChanges } = require('./handle-outputs-changes');
+      const { EventType } = require('../../native');
+
+      const waitFor = async (cond: () => boolean) => {
+        while (!cond()) {
+          await new Promise((r) => setImmediate(r));
+        }
+      };
+
+      // Compute A sees only foo and parks before building and assigning its
+      // graph.
+      const first = getCachedSerializedProjectGraphPromise();
+      await waitFor(() => aPark.reached);
+
+      // The workspace watcher delivers a new project; the winning compute
+      // builds the graph the cache will serve, with bar as a root.
+      mkdirSync(join(fs.tempDir, 'libs/bar'), { recursive: true });
+      writeFileSync(
+        join(fs.tempDir, 'libs/bar/project.json'),
+        JSON.stringify({ name: 'bar', root: 'libs/bar' })
+      );
+      scheduleProjectGraphRecomputation(['libs/bar/project.json'], [], []);
+      const second = await getCachedSerializedProjectGraphPromise();
+      expect(second.projectGraph.nodes.bar).toBeDefined();
+
+      // The stale A resumes, builds and assigns its bar-less graph over
+      // currentProjectGraph, and only then chains away.
+      aPark.release();
+      await first;
+      expect(pgir.currentProjectGraph.nodes.bar).toBeUndefined();
+
+      // A gitignored dotenv edit under bar: only the outputs watcher
+      // reports it, and against the overwritten currentProjectGraph the
+      // path classifies under no root, so it queues.
+      writeFileSync(join(fs.tempDir, 'libs/bar/.env.e2e'), 'PORT=7777\n');
+      await handleOutputsChanges(null, [
+        { path: 'libs/bar/.env.e2e', type: EventType.update },
+      ]);
+
+      const countBeforeThird = retrieveCallCount;
+      const third = await getCachedSerializedProjectGraphPromise();
+      expect(third.error).toBeNull();
+      expect(third.projectGraph.nodes.bar.data.tags).toEqual(['env:PORT=7777']);
+      expect(retrieveCallCount).toBe(countBeforeThird + 1);
+    });
+  });
+
+  // When the workspace watcher delivers the tracked edit too, its
+  // recomputation alone must satisfy a request racing it: the queued twin
+  // event describes an edit that recomputation's read already observes, so
+  // the reuse check must neither discard the in-flight computation nor force
+  // a second one after it settles.
+  it('does not add a recomputation when the workspace watcher schedules one for the same edit', async () => {
+    fs.createFilesSync({
+      'nx.json': JSON.stringify({}),
+      'package.json': JSON.stringify({ name: 'root' }),
+      'libs/foo/project.json': JSON.stringify({
+        name: 'foo',
+        root: 'libs/foo',
+      }),
+      'libs/foo/.env.e2e': 'PORT=4200\n',
+    });
+
+    await jest.isolateModulesAsync(async () => {
+      // The plugin-loader mocks jest.doMock installs in the tests above are
+      // registry-wide and outlive their isolated module graphs.
+      jest.dontMock('../../project-graph/plugins/get-plugins');
+      const { setWorkspaceRoot } = require('../../utils/workspace-root');
+      setWorkspaceRoot(fs.tempDir);
+
+      const makeGate = () => {
+        let release: () => void;
+        const promise = new Promise<void>((resolve) => {
+          release = resolve;
+        });
+        return { promise, release: () => release(), reached: false };
+      };
+      // Park the workspace-scheduled compute B at its getPlugins await, past
+      // its file read and its collected-file cleanup, so a request races an
+      // in-flight computation deterministically.
+      const bPark = makeGate();
+      let retrieveCallCount = 0;
+      jest.doMock('../../project-graph/utils/retrieve-workspace-files', () => {
+        const actual = jest.requireActual(
+          '../../project-graph/utils/retrieve-workspace-files'
+        );
+        return {
+          ...actual,
+          retrieveProjectConfigurations: async (...args: unknown[]) => {
+            ++retrieveCallCount;
+            const result = await actual.retrieveProjectConfigurations(...args);
+            const env = readFileSync(
+              join(fs.tempDir, 'libs/foo/.env.e2e'),
+              'utf-8'
+            ).trim();
+            result.projects['libs/foo'].tags = [`env:${env}`];
+            return result;
+          },
+        };
+      });
+      // A plain factory: the module sits in a require cycle, so resolving
+      // the actual inside the factory recurses. getPluginsSeparated resolves
+      // it lazily at call time instead (project discovery needs the real
+      // default plugins); the faked getPlugins only skips dependency hooks
+      // these assertions never read.
+      let pluginsCallCount = 0;
+      jest.doMock('../../project-graph/plugins/get-plugins', () => ({
+        __esModule: true,
+        getPlugins: async () => {
+          const call = ++pluginsCallCount;
+          if (call === 2) {
+            bPark.reached = true;
+            await bPark.promise;
+          }
+          return [];
+        },
+        getPluginsSeparated: (...args: unknown[]) =>
+          jest
+            .requireActual('../../project-graph/plugins/get-plugins')
+            .getPluginsSeparated(...args),
+      }));
+
+      const {
+        getCachedSerializedProjectGraphPromise,
+        scheduleProjectGraphRecomputation,
+      } = require('./project-graph-incremental-recomputation');
+      const { handleOutputsChanges } = require('./handle-outputs-changes');
+      const { EventType } = require('../../native');
+
+      const waitFor = async (cond: () => boolean) => {
+        while (!cond()) {
+          await new Promise((r) => setImmediate(r));
+        }
+      };
+      const envPath = join(fs.tempDir, 'libs/foo/.env.e2e');
+
+      const first = await getCachedSerializedProjectGraphPromise();
+      expect(first.projectGraph.nodes.foo.data.tags).toEqual(['env:PORT=4200']);
+      expect(retrieveCallCount).toBe(1);
+
+      writeFileSync(envPath, 'PORT=4201\n');
+      // Outputs watcher first: the event queues. Workspace watcher second:
+      // the recomputation it schedules reads the new content.
+      await handleOutputsChanges(null, [
+        { path: 'libs/foo/.env.e2e', type: EventType.update },
+      ]);
+      scheduleProjectGraphRecomputation([], ['libs/foo/.env.e2e'], []);
+      await waitFor(() => bPark.reached);
+
+      // A request while B is parked mid-build must chain onto B, not start
+      // a competitor from the queued twin event. The yields let it run its
+      // reuse decision before B is released.
+      const second = getCachedSerializedProjectGraphPromise();
+      for (let i = 0; i < 5; i++) {
+        await new Promise((r) => setImmediate(r));
+      }
+      bPark.release();
+
+      const result = await second;
+      expect(result.error).toBeNull();
+      expect(result.projectGraph.nodes.foo.data.tags).toEqual([
+        'env:PORT=4201',
+      ]);
+      expect(retrieveCallCount).toBe(2);
+
+      // After B settles, the drained queue holds no evidence against it.
+      const third = await getCachedSerializedProjectGraphPromise();
+      expect(third.projectGraph.nodes.foo.data.tags).toEqual(['env:PORT=4201']);
+      expect(retrieveCallCount).toBe(2);
+    });
+  });
+
+  // An event under a root no served graph knows cannot make the cached graph
+  // stale, so it must not force a recomputation on its own. It stays queued
+  // for the computation that adds its root, whose own read observes the file
+  // content, so the generation rule retires the entry there without another
+  // recomputation.
+  it('leaves an unclassifiable queued event for the computation that adds its root', async () => {
+    fs.createFilesSync({
+      'nx.json': JSON.stringify({}),
+      'package.json': JSON.stringify({ name: 'root' }),
+      '.gitignore': '.env.e2e\n',
+      'libs/foo/project.json': JSON.stringify({
+        name: 'foo',
+        root: 'libs/foo',
+      }),
+    });
+
+    await jest.isolateModulesAsync(async () => {
+      // The plugin-loader mocks jest.doMock installs in the tests above are
+      // registry-wide and outlive their isolated module graphs.
+      jest.dontMock('../../project-graph/plugins/get-plugins');
+      const { setWorkspaceRoot } = require('../../utils/workspace-root');
+      setWorkspaceRoot(fs.tempDir);
+
+      let retrieveCallCount = 0;
+      jest.doMock('../../project-graph/utils/retrieve-workspace-files', () => {
+        const actual = jest.requireActual(
+          '../../project-graph/utils/retrieve-workspace-files'
+        );
+        return {
+          ...actual,
+          retrieveProjectConfigurations: async (...args: unknown[]) => {
+            ++retrieveCallCount;
+            const result = await actual.retrieveProjectConfigurations(...args);
+            for (const [root, project] of Object.entries(result.projects)) {
+              const envFile = join(fs.tempDir, root, '.env.e2e');
+              if (existsSync(envFile)) {
+                (project as { tags?: string[] }).tags = [
+                  `env:${readFileSync(envFile, 'utf-8').trim()}`,
+                ];
+              }
+            }
+            return result;
+          },
+        };
+      });
+
+      const {
+        getCachedSerializedProjectGraphPromise,
+        registerProjectGraphRecomputationListener,
+        scheduleProjectGraphRecomputation,
+      } = require('./project-graph-incremental-recomputation');
+      const { handleOutputsChanges } = require('./handle-outputs-changes');
+      const { EventType } = require('../../native');
+
+      const notifiedGraphs: import('../../config/project-graph').ProjectGraph[] =
+        [];
+      registerProjectGraphRecomputationListener(
+        (graph: import('../../config/project-graph').ProjectGraph) => {
+          notifiedGraphs.push(graph);
+        }
+      );
+      const waitFor = async (cond: () => boolean) => {
+        while (!cond()) {
+          await new Promise((r) => setImmediate(r));
+        }
+      };
+
+      const first = await getCachedSerializedProjectGraphPromise();
+      expect(first.projectGraph.nodes.bar).toBeUndefined();
+      expect(retrieveCallCount).toBe(1);
+
+      // A gitignored dotenv file under a directory that is not a project
+      // root yet: only the outputs watcher reports it, and no root of the
+      // served graph classifies it.
+      mkdirSync(join(fs.tempDir, 'libs/bar'), { recursive: true });
+      writeFileSync(join(fs.tempDir, 'libs/bar/.env.e2e'), 'PORT=7777\n');
+      await handleOutputsChanges(null, [
+        { path: 'libs/bar/.env.e2e', type: EventType.update },
+      ]);
+
+      const second = await getCachedSerializedProjectGraphPromise();
+      expect(second.projectGraph.nodes.bar).toBeUndefined();
+      expect(retrieveCallCount).toBe(1);
+
+      // The project lands; the workspace watcher schedules the computation
+      // that knows the root, and its read observes the dotenv content.
+      writeFileSync(
+        join(fs.tempDir, 'libs/bar/project.json'),
+        JSON.stringify({ name: 'bar', root: 'libs/bar' })
+      );
+      scheduleProjectGraphRecomputation(['libs/bar/project.json'], [], []);
+      await waitFor(() =>
+        notifiedGraphs.some((graph) => graph.nodes.bar !== undefined)
+      );
+
+      const third = await getCachedSerializedProjectGraphPromise();
+      expect(third.error).toBeNull();
+      expect(third.projectGraph.nodes.bar.data.tags).toEqual(['env:PORT=7777']);
+      expect(retrieveCallCount).toBe(2);
+
+      const fourth = await getCachedSerializedProjectGraphPromise();
+      expect(fourth.projectGraph.nodes.bar.data.tags).toEqual([
+        'env:PORT=7777',
+      ]);
+      expect(retrieveCallCount).toBe(2);
     });
   });
 });

--- a/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
+++ b/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
@@ -424,6 +424,17 @@ export function invalidateGraphCache() {
   cachedSerializedProjectGraphPromise = null;
 }
 
+/**
+ * Marks any in-flight recomputation stale so it chains to a successor instead
+ * of committing. Pair with invalidateGraphCache when a graph input outside the
+ * file watcher's view (e.g. the daemon env) changes: clearing the cached
+ * promise alone leaves an in-flight compute passing its chainToLatest checks
+ * and serving a graph built under the old input to whoever already awaits it.
+ */
+export function markInFlightRecomputationsStale() {
+  ++recomputationGeneration;
+}
+
 // isKnownWorkspaceFile's membership set, derived lazily from the map object it
 // was built from; every commit assigns a fresh `fileMapWithFiles`, so an
 // identity change is what invalidates it.

--- a/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
+++ b/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
@@ -415,29 +415,26 @@ async function processCollectedUpdatedAndDeletedFiles(
   }
 }
 
+/**
+ * Discards the cached graph when a graph input outside the file watcher's view
+ * (e.g. the daemon env) changes. Clearing the cached promise makes the next
+ * request trigger a fresh computation; the generation bump marks any in-flight
+ * compute stale so it chains to that successor instead of committing, because
+ * a compute passing its chainToLatest checks would serve a graph built under
+ * the old input to whoever already awaits it.
+ */
 export function invalidateGraphCache() {
-  // Clear the cached promise so the next request triggers a fresh computation.
   // We intentionally do NOT call getCachedSerializedProjectGraphPromise() here
   // because assigning its return Promise to the module-level variable causes a
   // deadlock: the async function resumes, sees the variable is non-null (pointing
   // at its own Promise), takes the "reuse" branch, and awaits itself forever.
   cachedSerializedProjectGraphPromise = null;
-}
-
-/**
- * Marks any in-flight recomputation stale so it chains to a successor instead
- * of committing. Pair with invalidateGraphCache when a graph input outside the
- * file watcher's view (e.g. the daemon env) changes: clearing the cached
- * promise alone leaves an in-flight compute passing its chainToLatest checks
- * and serving a graph built under the old input to whoever already awaits it.
- */
-export function markInFlightRecomputationsStale() {
   ++recomputationGeneration;
 }
 
 // isKnownWorkspaceFile's membership set, derived lazily from the map object it
-// was built from; every commit assigns a fresh `fileMapWithFiles`, so an
-// identity change is what invalidates it.
+// was built from; every `fileMapWithFiles` write clears it, so a replaced map
+// generation is not retained through the memo.
 let knownWorkspaceFiles: Set<string> | undefined;
 let knownWorkspaceFilesSource: typeof fileMapWithFiles;
 
@@ -548,6 +545,8 @@ async function processFilesAndCreateAndSerializeProjectGraph(
     // chainToLatest above without touching `fileMapWithFiles`, so they
     // can't clobber a newer compute's write.
     fileMapWithFiles = fileMapUpdate.fileMap;
+    knownWorkspaceFiles = undefined;
+    knownWorkspaceFilesSource = undefined;
     storedWorkspaceConfigHash = fileMapUpdate.configHash;
     if (fileMapUpdate.knownExternalNodes) {
       knownExternalNodes = fileMapUpdate.knownExternalNodes;
@@ -719,6 +718,8 @@ async function createAndSerializeProjectGraph({
 async function resetInternalState() {
   cachedSerializedProjectGraphPromise = undefined;
   fileMapWithFiles = undefined;
+  knownWorkspaceFiles = undefined;
+  knownWorkspaceFilesSource = undefined;
   currentProjectFileMapCache = undefined;
   currentProjectGraph = undefined;
   currentSourceMaps = undefined;

--- a/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
+++ b/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
@@ -424,6 +424,28 @@ export function invalidateGraphCache() {
   cachedSerializedProjectGraphPromise = null;
 }
 
+/**
+ * Whether the ignore-filtered workspace file map knows `path`. The workspace
+ * watcher applies the same ignore rules, so a change to a known file also
+ * reaches scheduleProjectGraphRecomputation; a change to an unknown (ignored)
+ * file does not.
+ */
+export function isKnownWorkspaceFile(path: string): boolean {
+  if (!fileMapWithFiles) {
+    return false;
+  }
+  const { projectFileMap, nonProjectFiles } = fileMapWithFiles.fileMap;
+  if (nonProjectFiles.some((f) => f.file === path)) {
+    return true;
+  }
+  for (const files of Object.values(projectFileMap)) {
+    if (files.some((f) => f.file === path)) {
+      return true;
+    }
+  }
+  return false;
+}
+
 async function processFilesAndCreateAndSerializeProjectGraph(
   separatedPlugins: SeparatedPlugins
 ): Promise<SerializedProjectGraph> {

--- a/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
+++ b/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
@@ -424,26 +424,36 @@ export function invalidateGraphCache() {
   cachedSerializedProjectGraphPromise = null;
 }
 
+// isKnownWorkspaceFile's membership set, derived lazily from the map object it
+// was built from; every commit assigns a fresh `fileMapWithFiles`, so an
+// identity change is what invalidates it.
+let knownWorkspaceFiles: Set<string> | undefined;
+let knownWorkspaceFilesSource: typeof fileMapWithFiles;
+
 /**
  * Whether the ignore-filtered workspace file map knows `path`. The workspace
  * watcher applies the same ignore rules, so a change to a known file also
- * reaches scheduleProjectGraphRecomputation; a change to an unknown (ignored)
- * file does not.
+ * reaches scheduleProjectGraphRecomputation; an unknown file is either
+ * ignored, or created since the last recompute committed.
  */
 export function isKnownWorkspaceFile(path: string): boolean {
   if (!fileMapWithFiles) {
     return false;
   }
-  const { projectFileMap, nonProjectFiles } = fileMapWithFiles.fileMap;
-  if (nonProjectFiles.some((f) => f.file === path)) {
-    return true;
-  }
-  for (const files of Object.values(projectFileMap)) {
-    if (files.some((f) => f.file === path)) {
-      return true;
+  if (knownWorkspaceFilesSource !== fileMapWithFiles) {
+    const { projectFileMap, nonProjectFiles } = fileMapWithFiles.fileMap;
+    knownWorkspaceFiles = new Set<string>();
+    for (const { file } of nonProjectFiles) {
+      knownWorkspaceFiles.add(file);
     }
+    for (const files of Object.values(projectFileMap)) {
+      for (const { file } of files) {
+        knownWorkspaceFiles.add(file);
+      }
+    }
+    knownWorkspaceFilesSource = fileMapWithFiles;
   }
-  return false;
+  return knownWorkspaceFiles.has(path);
 }
 
 async function processFilesAndCreateAndSerializeProjectGraph(

--- a/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
+++ b/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
@@ -47,6 +47,12 @@ import {
   subscribeClientToTopic,
   unsubscribeClientFromTopic,
 } from './client-socket-context';
+import {
+  clearDotEnvFileHashes,
+  drainPendingDotEnvEvents,
+  hasPendingDotEnvEvidence,
+  hasRelevantPendingDotEnvEvidence,
+} from './dotenv-graph-changes';
 import { notifyFileChangeListeners } from './file-watching/file-change-events';
 import { notifyFileWatcherSockets } from './file-watching/file-watcher-sockets';
 import { notifyProjectGraphListenerSockets } from './project-graph-listener-sockets';
@@ -94,6 +100,19 @@ let knownExternalNodes: Record<string, ProjectGraphExternalNode> = {};
 let fileChangeCounter = 0;
 let recomputationGeneration = 0;
 
+// The graph the settled cached promise serves, with the generation its
+// computation claimed. Set only when a computation's own success becomes the
+// cached result; any newer kickoff or invalidation clears it, so non-null
+// means the cached promise is settled and this is exactly what it serves. The
+// warm-reuse dotenv check classifies against this, never against
+// `currentProjectGraph`: a slow stale computation overwrites that after the
+// winner settles and only then chains away. The candidate is written by the
+// computation itself (which knows its generation) and promoted by
+// kickOffRecompute after the outer plugin-hash and cached-pointer identity
+// checks, which can still reject the result.
+let servedGraphState: { graph: ProjectGraph; generation: number } | null = null;
+let servedGraphCandidate: typeof servedGraphState = null;
+
 // True after the first successful persistProjectGraphToDisk call. Until
 // that happens, "project-graph.json missing on disk" is the expected
 // state (we just haven't written it yet) and must not trigger a reset.
@@ -108,6 +127,9 @@ let cacheHasBeenPersisted = false;
  * (see spread.test.ts "middle plugin" flake).
  */
 function kickOffRecompute() {
+  // The cached pointer is about to hold an unsettled promise, so whatever the
+  // previous state described is no longer what the cache serves.
+  servedGraphState = null;
   let myPromise: Promise<SerializedProjectGraph>;
   myPromise = (async () => {
     // Must resolve, never reject: kickOffRecompute() runs fire-and-forget, so
@@ -136,6 +158,12 @@ function kickOffRecompute() {
         cachedSerializedProjectGraphPromise === myPromise &&
         result.projectGraph
       ) {
+        // The graph identity ties the candidate's generation to exactly this
+        // result; a chained result never matches (its computation's kickoff
+        // replaced the cached pointer, failing the identity check above).
+        if (servedGraphCandidate?.graph === result.projectGraph) {
+          servedGraphState = servedGraphCandidate;
+        }
         notifyProjectGraphRecomputationListeners(
           result.projectGraph,
           result.sourceMaps,
@@ -202,6 +230,37 @@ export async function getCachedSerializedProjectGraphPromise(
     // stale graph. Placed right before the read so no microtask gap
     // separates them.
     await new Promise(setImmediate);
+
+    // The queue can hold evidence against the settled cached graph itself: a
+    // tracked dotenv edit only the outputs watcher has delivered yet queues
+    // without invalidating, and the workspace watcher's recomputation may lag
+    // this request. Classified against the exact graph the cache serves; an
+    // in-flight computation needs no check here because its own pre-serve
+    // replay consumes the queue. Content hashes are dropped before the
+    // successor can read, as in the error retry: one recorded when the edit
+    // was classified could suppress a revert landing mid-read. Fails toward
+    // recomputing, since a stale graph on a dotenv edit is the bug this
+    // prevents.
+    try {
+      if (
+        servedGraphState &&
+        hasRelevantPendingDotEnvEvidence(
+          servedGraphState.graph,
+          servedGraphState.generation
+        )
+      ) {
+        clearDotEnvFileHashes();
+        invalidateGraphCache();
+      }
+    } catch (e) {
+      serverLogger.log(
+        `Failed to check pending dotenv changes against the cached graph; recomputing to be safe: ${
+          e instanceof Error ? e.message : e
+        }`
+      );
+      clearDotEnvFileHashes();
+      invalidateGraphCache();
+    }
 
     // If no compute exists or events are still in collected*, kick one off.
     // Otherwise reuse whatever is already in flight or cached.
@@ -430,6 +489,16 @@ export function invalidateGraphCache() {
   // at its own Promise), takes the "reuse" branch, and awaits itself forever.
   cachedSerializedProjectGraphPromise = null;
   ++recomputationGeneration;
+  servedGraphState = null;
+}
+
+/**
+ * The current recomputation generation, stamped on queued dotenv events so
+ * the pre-serve drain can prove whether a computation started before an
+ * event arrived.
+ */
+export function getRecomputationGeneration(): number {
+  return recomputationGeneration;
 }
 
 // isKnownWorkspaceFile's membership set, derived lazily from the map object it
@@ -584,16 +653,71 @@ async function processFilesAndCreateAndSerializeProjectGraph(
       g.error && isAggregateProjectGraphError(g.error) && g.error.errors?.length
         ? g.error
         : null;
-    if (g.error && !aggregate) return errorResult(g.error);
+
+    // An error result is never cached, notified, or persisted, so a queued
+    // dotenv edit that may already have fixed the failing input earns one
+    // retry instead of surfacing the error. The peek consumes nothing (a
+    // successful successor's drain classifies the entries against a real
+    // graph, which these branches may lack: `g.projectGraph` can be null
+    // here) and a persistent error retries once, because the successor
+    // claims a generation above every recorded stamp. Content hashes are
+    // dropped, though: one recorded during this failed computation could
+    // suppress a callback landing while the successor reads. The catch at
+    // the end of this function stays excluded: a throw there can predate
+    // projectConfigurationsResult and the plugin hooks' balancing, and the
+    // next request recomputes at a fresh generation anyway.
+    const retryForPendingDotEnv = () => {
+      if (!hasPendingDotEnvEvidence(myGeneration)) return null;
+      clearDotEnvFileHashes();
+      invalidateGraphCache();
+      return chainToLatest(false);
+    };
+
+    if (g.error && !aggregate) {
+      return retryForPendingDotEnv() ?? errorResult(g.error);
+    }
     if (aggregate) errors.push(...aggregate.errors);
-    if (errors.length === 0) return g;
-    return errorResult(
-      new DaemonProjectGraphError(
-        errors,
-        g.projectGraph,
-        projectConfigurationsResult.sourceMaps
-      )
-    );
+    if (errors.length > 0) {
+      return (
+        retryForPendingDotEnv() ??
+        errorResult(
+          new DaemonProjectGraphError(
+            errors,
+            g.projectGraph,
+            projectConfigurationsResult.sourceMaps
+          )
+        )
+      );
+    }
+
+    // Replay the dotenv events no committed root could classify on arrival
+    // against the graph about to be served. Runs after the last staleness
+    // gate so a stale compute leaves the queue for its successor, and only
+    // on the success path: an error result is never notified or persisted.
+    // Queue evidence is decisive here even for files the workspace watcher
+    // tracks: the two watchers deliver independently, so tracking alone does
+    // not prove that watcher's recomputation was already scheduled.
+    let staleDotEnv: boolean;
+    try {
+      const pending = drainPendingDotEnvEvents(g.projectGraph, myGeneration);
+      staleDotEnv = pending.overflowed || pending.invalidating.length > 0;
+    } catch (e) {
+      serverLogger.log(
+        `Failed to re-check pending dotenv changes; recomputing to be safe: ${
+          e instanceof Error ? e.message : e
+        }`
+      );
+      staleDotEnv = true;
+    }
+    if (staleDotEnv) {
+      // This graph read the file before the queued edit landed. The bump plus
+      // chain hands every awaiting caller the successor's result and keeps
+      // this one from being notified or persisted.
+      invalidateGraphCache();
+      return chainToLatest(false);
+    }
+    servedGraphCandidate = { graph: g.projectGraph, generation: myGeneration };
+    return g;
   } catch (err) {
     return errorResult(err);
   }
@@ -717,6 +841,8 @@ async function createAndSerializeProjectGraph({
 
 async function resetInternalState() {
   cachedSerializedProjectGraphPromise = undefined;
+  servedGraphState = null;
+  servedGraphCandidate = null;
   fileMapWithFiles = undefined;
   knownWorkspaceFiles = undefined;
   knownWorkspaceFilesSource = undefined;

--- a/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
+++ b/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
@@ -541,6 +541,14 @@ async function processFilesAndCreateAndSerializeProjectGraph(
     ...separatedPlugins.defaultPlugins,
   ];
   const myGeneration = ++recomputationGeneration;
+  // A hash recorded before this claim can describe bytes this computation
+  // never reads (a callback classified between a forced invalidation and this
+  // claim records one no handler-side clear has seen), and retained it could
+  // suppress a coalesced revert landing mid-read. Bounding every hash to the
+  // window since the last claim closes that for any successor, however it was
+  // forced. A callback landing after this claim re-records and re-queues, and
+  // its stamp then marks this computation stale at the drain.
+  clearDotEnvFileHashes();
 
   // A newer kickOffRecompute has already replaced
   // cachedSerializedProjectGraphPromise. Returning it lets the async

--- a/packages/nx/src/daemon/server/server.ts
+++ b/packages/nx/src/daemon/server/server.ts
@@ -677,9 +677,12 @@ const handleOutputsChanges: FileWatcherCallback = async (err, changeEvents) => {
     // disabled outputs tracker must not leave the graph stale on a dotenv edit.
     // A change to a file the workspace watcher tracks already schedules a
     // recomputation that reads the new content; invalidating for it here too
-    // would discard that recomputation at commit and force a second one, so
-    // only an ignored file (which never reaches the workspace watcher) needs
-    // the cache invalidated. Its own try/catch so a fault here cannot trip the
+    // would discard that recomputation at commit and force a second one. The
+    // committed file map approximates what the watcher tracks: a file it does
+    // not know is either ignored (never reaches the watcher, so it needs the
+    // invalidation) or created since the last recompute (the watcher handles
+    // it; the extra invalidation is fail-safe). Its own try/catch so a fault
+    // here cannot trip the
     // outputs-tracking kill switch below, which belongs to an unrelated
     // subsystem. It fails safe by invalidating: a stale graph on a dotenv edit
     // is the bug this prevents, and invalidateGraphCache only clears the

--- a/packages/nx/src/daemon/server/server.ts
+++ b/packages/nx/src/daemon/server/server.ts
@@ -668,8 +668,8 @@ const handleOutputsChanges: FileWatcherCallback = async (err, changeEvents) => {
     // recomputation that reads the new content; invalidating for it here too
     // would discard that recomputation at commit and force a second one. The
     // committed file map approximates what the watcher tracks: a file it does
-    // not know is either gitignored (never reaches the watcher, so it needs the
-    // invalidation) or created since the last recompute (the watcher handles
+    // not know is either gitignored (never reaches the workspace watcher, so it
+    // needs the invalidation) or created since the last recompute (the watcher handles
     // it; the extra invalidation is fail-safe). Its own try/catch so a fault
     // here cannot trip the
     // outputs-tracking kill switch below, which belongs to an unrelated

--- a/packages/nx/src/daemon/server/server.ts
+++ b/packages/nx/src/daemon/server/server.ts
@@ -147,9 +147,10 @@ import {
   scheduleProjectGraphRecomputation,
   registerProjectGraphRecomputationListener,
   invalidateGraphCache,
+  isKnownWorkspaceFile,
   currentProjectGraph,
 } from './project-graph-incremental-recomputation';
-import { outputsChangeInvalidatesGraphEnv } from './dotenv-graph-changes';
+import { outputsChangesInvalidatingGraphEnv } from './dotenv-graph-changes';
 import {
   hasRegisteredProjectGraphListenerSockets,
   registeredProjectGraphListenerSockets,
@@ -670,16 +671,26 @@ const handleOutputsChanges: FileWatcherCallback = async (err, changeEvents) => {
       return;
     }
 
-    // A dotenv change that a task chain loads must invalidate the graph cache so
+    // A dotenv change that a task chain loads must refresh the graph so
     // createNodes re-resolves config reading process.env. This runs above the
     // outputsWatcherError guard: the two concerns are independent, and a
     // disabled outputs tracker must not leave the graph stale on a dotenv edit.
-    // Its own try/catch so a fault here cannot trip the outputs-tracking kill
-    // switch below, which belongs to an unrelated subsystem. It fails safe by
-    // invalidating: a stale graph on a dotenv edit is the bug this prevents, and
-    // invalidateGraphCache only clears the cached promise (idempotent, lazy).
+    // A change to a file the workspace watcher tracks already schedules a
+    // recomputation that reads the new content; invalidating for it here too
+    // would discard that recomputation at commit and force a second one, so
+    // only an ignored file (which never reaches the workspace watcher) needs
+    // the cache invalidated. Its own try/catch so a fault here cannot trip the
+    // outputs-tracking kill switch below, which belongs to an unrelated
+    // subsystem. It fails safe by invalidating: a stale graph on a dotenv edit
+    // is the bug this prevents, and invalidateGraphCache only clears the
+    // cached promise (idempotent, lazy).
     try {
-      if (outputsChangeInvalidatesGraphEnv(changeEvents, currentProjectGraph)) {
+      if (
+        outputsChangesInvalidatingGraphEnv(
+          changeEvents,
+          currentProjectGraph
+        ).some((path) => !isKnownWorkspaceFile(path))
+      ) {
         invalidateGraphCache();
       }
     } catch (e) {

--- a/packages/nx/src/daemon/server/server.ts
+++ b/packages/nx/src/daemon/server/server.ts
@@ -687,6 +687,7 @@ const handleOutputsChanges: FileWatcherCallback = async (err, changeEvents) => {
         'Failed to evaluate dotenv changes for graph invalidation; invalidating the graph cache to be safe',
         e instanceof Error ? e.message : String(e)
       );
+      console.error(e);
       invalidateGraphCache();
     }
 

--- a/packages/nx/src/daemon/server/server.ts
+++ b/packages/nx/src/daemon/server/server.ts
@@ -668,7 +668,7 @@ const handleOutputsChanges: FileWatcherCallback = async (err, changeEvents) => {
     // recomputation that reads the new content; invalidating for it here too
     // would discard that recomputation at commit and force a second one. The
     // committed file map approximates what the watcher tracks: a file it does
-    // not know is either ignored (never reaches the watcher, so it needs the
+    // not know is either gitignored (never reaches the watcher, so it needs the
     // invalidation) or created since the last recompute (the watcher handles
     // it; the extra invalidation is fail-safe). Its own try/catch so a fault
     // here cannot trip the

--- a/packages/nx/src/daemon/server/server.ts
+++ b/packages/nx/src/daemon/server/server.ts
@@ -669,13 +669,11 @@ const handleOutputsChanges: FileWatcherCallback = async (err, changeEvents) => {
     // would discard that recomputation at commit and force a second one. The
     // committed file map approximates what the watcher tracks: a file it does
     // not know is either gitignored (never reaches the workspace watcher, so it
-    // needs the invalidation) or created since the last recompute (the watcher handles
-    // it; the extra invalidation is fail-safe). Its own try/catch so a fault
-    // here cannot trip the
-    // outputs-tracking kill switch below, which belongs to an unrelated
-    // subsystem. It fails safe by invalidating: a stale graph on a dotenv edit
-    // is the bug this prevents, and invalidateGraphCache only clears the
-    // cached promise (idempotent, lazy).
+    // needs the invalidation) or created since the last recompute (the watcher
+    // handles it; the extra invalidation is fail-safe). Its own try/catch so a
+    // fault here cannot trip the outputs-tracking kill switch below, which
+    // belongs to an unrelated subsystem, and it fails safe by invalidating: a
+    // stale graph on a dotenv edit is the bug this prevents.
     try {
       if (
         outputsChangesInvalidatingGraphEnv(

--- a/packages/nx/src/daemon/server/server.ts
+++ b/packages/nx/src/daemon/server/server.ts
@@ -13,8 +13,6 @@ import '../../utils/perf-logging';
 import { nxVersion } from '../../utils/versions';
 import { setupWorkspaceContext } from '../../utils/workspace-context';
 import { workspaceRoot } from '../../utils/workspace-root';
-import { readNxJson } from '../../config/nx-json';
-import { getPlugins } from '../../project-graph/plugins/get-plugins';
 import { getDaemonProcessIdSync, writeDaemonJsonProcessCache } from '../cache';
 import { isNxVersionMismatch } from '../is-nx-version-mismatch';
 import { getInstalledNxVersion } from '../../utils/installed-nx-version';
@@ -25,7 +23,6 @@ import {
   isHandleResetConfigureAiAgentsStatusMessage,
   RESET_CONFIGURE_AI_AGENTS_STATUS,
 } from '../message-types/configure-ai-agents';
-import { applyDaemonEnvFromClient } from '../client/daemon-environment';
 import {
   assertNotForeignWorkspaceMessage,
   isDaemonMessage,
@@ -111,6 +108,7 @@ import {
 import { handleContextFileData } from './handle-context-file-data';
 import { handleFlushSyncGeneratorChangesToDisk } from './handle-flush-sync-generator-changes-to-disk';
 import { handleForceShutdown } from './handle-force-shutdown';
+import { handleClientEnv } from './handle-client-env';
 import { handleGetFilesInDirectory } from './handle-get-files-in-directory';
 import { handleGetRegisteredSyncGenerators } from './handle-get-registered-sync-generators';
 import { handleGetSyncGeneratorChanges } from './handle-get-sync-generator-changes';
@@ -276,16 +274,7 @@ async function handleMessage(socket: Socket, data: string) {
   }
 
   if (isDaemonMessage(payload) && payload.env) {
-    const changedEnvKeys = applyDaemonEnvFromClient(payload.env);
-    if (changedEnvKeys.length > 0) {
-      serverLogger.log(
-        `Graph recompute necessary due to env variable refresh. Changed keys: ${changedEnvKeys.join(
-          ', '
-        )}`
-      );
-      forwardEnvToPluginWorkers(payload.env);
-      invalidateGraphCache();
-    }
+    await handleClientEnv(payload.env);
   }
 
   if (payload.type === 'PING') {
@@ -846,22 +835,6 @@ export async function startServer(): Promise<Server> {
     }
   });
 }
-function forwardEnvToPluginWorkers(env: Record<string, string>) {
-  getPlugins(readNxJson(workspaceRoot))
-    .then((plugins) => {
-      for (const plugin of plugins) {
-        plugin.setWorkerEnv?.(env)?.catch((e) => {
-          serverLogger.log(
-            `Failed to forward env to plugin worker "${plugin.name}": ${e.message}`
-          );
-        });
-      }
-    })
-    .catch(() => {
-      // Plugins may not be loaded yet — env will be picked up on next load
-    });
-}
-
 function serializeUnserializedResult(
   response: boolean | object,
   mode: 'json' | 'v8'

--- a/packages/nx/src/daemon/server/server.ts
+++ b/packages/nx/src/daemon/server/server.ts
@@ -674,7 +674,19 @@ const handleOutputsChanges: FileWatcherCallback = async (err, changeEvents) => {
     // createNodes re-resolves config reading process.env. This runs above the
     // outputsWatcherError guard: the two concerns are independent, and a
     // disabled outputs tracker must not leave the graph stale on a dotenv edit.
-    if (outputsChangeInvalidatesGraphEnv(changeEvents, currentProjectGraph)) {
+    // Its own try/catch so a fault here cannot trip the outputs-tracking kill
+    // switch below, which belongs to an unrelated subsystem. It fails safe by
+    // invalidating: a stale graph on a dotenv edit is the bug this prevents, and
+    // invalidateGraphCache only clears the cached promise (idempotent, lazy).
+    try {
+      if (outputsChangeInvalidatesGraphEnv(changeEvents, currentProjectGraph)) {
+        invalidateGraphCache();
+      }
+    } catch (e) {
+      serverLogger.watcherLog(
+        'Failed to evaluate dotenv changes for graph invalidation; invalidating the graph cache to be safe',
+        e instanceof Error ? e.message : String(e)
+      );
       invalidateGraphCache();
     }
 

--- a/packages/nx/src/daemon/server/server.ts
+++ b/packages/nx/src/daemon/server/server.ts
@@ -147,7 +147,9 @@ import {
   scheduleProjectGraphRecomputation,
   registerProjectGraphRecomputationListener,
   invalidateGraphCache,
+  currentProjectGraph,
 } from './project-graph-incremental-recomputation';
+import { outputsChangeInvalidatesGraphEnv } from './dotenv-graph-changes';
 import {
   hasRegisteredProjectGraphListenerSockets,
   registeredProjectGraphListenerSockets,
@@ -667,6 +669,15 @@ const handleOutputsChanges: FileWatcherCallback = async (err, changeEvents) => {
       disableOutputsTracking();
       return;
     }
+
+    // A dotenv change that a task chain loads must invalidate the graph cache so
+    // createNodes re-resolves config reading process.env. This runs above the
+    // outputsWatcherError guard: the two concerns are independent, and a
+    // disabled outputs tracker must not leave the graph stale on a dotenv edit.
+    if (outputsChangeInvalidatesGraphEnv(changeEvents, currentProjectGraph)) {
+      invalidateGraphCache();
+    }
+
     if (outputsWatcherError) {
       return;
     }

--- a/packages/nx/src/daemon/server/server.ts
+++ b/packages/nx/src/daemon/server/server.ts
@@ -138,17 +138,13 @@ import {
 } from './handle-tasks-execution-hooks';
 import { handleUpdateWorkspaceContext } from './handle-update-workspace-context';
 import {
-  disableOutputsTracking,
-  processFileChangesInOutputs,
-} from './outputs-tracking';
+  getOutputsWatcherTerminalError,
+  handleOutputsChanges,
+} from './handle-outputs-changes';
 import {
   scheduleProjectGraphRecomputation,
   registerProjectGraphRecomputationListener,
-  invalidateGraphCache,
-  isKnownWorkspaceFile,
-  currentProjectGraph,
 } from './project-graph-incremental-recomputation';
-import { outputsChangesInvalidatingGraphEnv } from './dotenv-graph-changes';
 import {
   hasRegisteredProjectGraphListenerSockets,
   registeredProjectGraphListenerSockets,
@@ -179,7 +175,6 @@ import {
 } from './watcher';
 
 let workspaceWatcherError: Error | undefined;
-let outputsWatcherError: Error | undefined;
 
 global.NX_DAEMON = true;
 process.env.NX_DAEMON_PROCESS = 'true';
@@ -233,6 +228,14 @@ async function handleMessage(socket: Socket, data: string) {
       socket,
       `File watcher error in the workspace '${workspaceRoot}'.`,
       workspaceWatcherError
+    );
+  }
+  const outputsWatcherTerminalError = getOutputsWatcherTerminalError();
+  if (outputsWatcherTerminalError) {
+    await respondWithErrorAndExit(
+      socket,
+      `File watcher error in the workspace '${workspaceRoot}'.`,
+      outputsWatcherTerminalError
     );
   }
 
@@ -643,66 +646,6 @@ const handleWorkspaceChanges: FileWatcherCallback = async (
     console.error(err);
     workspaceWatcherError = err;
     notifyFileWatcherSocketsOfError(err);
-  }
-};
-
-const handleOutputsChanges: FileWatcherCallback = async (err, changeEvents) => {
-  try {
-    if (err || !changeEvents || !changeEvents.length) {
-      let error = typeof err === 'string' ? new Error(err) : err;
-      serverLogger.watcherLog(
-        'Unexpected outputs watcher error',
-        error.message
-      );
-      console.error(error);
-      outputsWatcherError = error;
-      disableOutputsTracking();
-      return;
-    }
-
-    // A dotenv change that a task chain loads must refresh the graph so
-    // createNodes re-resolves config reading process.env. This runs above the
-    // outputsWatcherError guard: the two concerns are independent, and a
-    // disabled outputs tracker must not leave the graph stale on a dotenv edit.
-    // A change to a file the workspace watcher tracks already schedules a
-    // recomputation that reads the new content; invalidating for it here too
-    // would discard that recomputation at commit and force a second one. The
-    // committed file map approximates what the watcher tracks: a file it does
-    // not know is either gitignored (never reaches the workspace watcher, so it
-    // needs the invalidation) or created since the last recompute (the watcher
-    // handles it; the extra invalidation is fail-safe). Its own try/catch so a
-    // fault here cannot trip the outputs-tracking kill switch below, which
-    // belongs to an unrelated subsystem, and it fails safe by invalidating: a
-    // stale graph on a dotenv edit is the bug this prevents.
-    try {
-      if (
-        outputsChangesInvalidatingGraphEnv(
-          changeEvents,
-          currentProjectGraph
-        ).some((path) => !isKnownWorkspaceFile(path))
-      ) {
-        invalidateGraphCache();
-      }
-    } catch (e) {
-      serverLogger.watcherLog(
-        'Failed to evaluate dotenv changes for graph invalidation; invalidating the graph cache to be safe',
-        e instanceof Error ? e.message : String(e)
-      );
-      console.error(e);
-      invalidateGraphCache();
-    }
-
-    if (outputsWatcherError) {
-      return;
-    }
-
-    serverLogger.watcherLog('Processing file changes in outputs');
-    processFileChangesInOutputs(changeEvents);
-  } catch (err) {
-    serverLogger.watcherLog(`Unexpected outputs watcher error`, err.message);
-    console.error(err);
-    outputsWatcherError = err;
-    disableOutputsTracking();
   }
 };
 

--- a/packages/nx/src/devkit-internals.ts
+++ b/packages/nx/src/devkit-internals.ts
@@ -90,6 +90,7 @@ export {
   requireWithTsconfigFallback,
 } from './plugins/js/utils/register';
 export { interpolate } from './tasks-runner/utils';
+export { getGraphTimeEnvForTask } from './tasks-runner/task-env';
 export { isCI } from './utils/is-ci';
 export {
   isUsingPrettierInTree,

--- a/packages/nx/src/devkit-internals.ts
+++ b/packages/nx/src/devkit-internals.ts
@@ -90,7 +90,10 @@ export {
   requireWithTsconfigFallback,
 } from './plugins/js/utils/register';
 export { interpolate } from './tasks-runner/utils';
-export { getGraphTimeDotEnvForTask } from './tasks-runner/task-env';
+export {
+  getEnvFilesForTask,
+  getGraphTimeDotEnvForTask,
+} from './tasks-runner/task-env';
 export { getEnvPathsForTask } from './tasks-runner/task-env-paths';
 export {
   hashDaemonClientEnv,

--- a/packages/nx/src/devkit-internals.ts
+++ b/packages/nx/src/devkit-internals.ts
@@ -91,6 +91,7 @@ export {
 } from './plugins/js/utils/register';
 export { interpolate } from './tasks-runner/utils';
 export { getGraphTimeDotEnvForTask } from './tasks-runner/task-env';
+export { getEnvPathsForTask } from './tasks-runner/task-env-paths';
 export { isCI } from './utils/is-ci';
 export {
   isUsingPrettierInTree,

--- a/packages/nx/src/devkit-internals.ts
+++ b/packages/nx/src/devkit-internals.ts
@@ -92,6 +92,7 @@ export {
 export { interpolate } from './tasks-runner/utils';
 export { getGraphTimeDotEnvForTask } from './tasks-runner/task-env';
 export { getEnvPathsForTask } from './tasks-runner/task-env-paths';
+export { hashDaemonClientEnv } from './daemon/client/daemon-environment';
 export { isCI } from './utils/is-ci';
 export {
   isUsingPrettierInTree,

--- a/packages/nx/src/devkit-internals.ts
+++ b/packages/nx/src/devkit-internals.ts
@@ -90,7 +90,7 @@ export {
   requireWithTsconfigFallback,
 } from './plugins/js/utils/register';
 export { interpolate } from './tasks-runner/utils';
-export { getGraphTimeEnvForTask } from './tasks-runner/task-env';
+export { getGraphTimeDotEnvForTask } from './tasks-runner/task-env';
 export { isCI } from './utils/is-ci';
 export {
   isUsingPrettierInTree,

--- a/packages/nx/src/devkit-internals.ts
+++ b/packages/nx/src/devkit-internals.ts
@@ -95,6 +95,8 @@ export { getEnvPathsForTask } from './tasks-runner/task-env-paths';
 export {
   hashDaemonClientEnv,
   getDaemonClientEnvGeneration,
+  getAppliedDaemonClientEnv,
+  applyDaemonEnvFromClient,
 } from './daemon/client/daemon-environment';
 export { isCI } from './utils/is-ci';
 export {

--- a/packages/nx/src/devkit-internals.ts
+++ b/packages/nx/src/devkit-internals.ts
@@ -92,7 +92,10 @@ export {
 export { interpolate } from './tasks-runner/utils';
 export { getGraphTimeDotEnvForTask } from './tasks-runner/task-env';
 export { getEnvPathsForTask } from './tasks-runner/task-env-paths';
-export { hashDaemonClientEnv } from './daemon/client/daemon-environment';
+export {
+  hashDaemonClientEnv,
+  getDaemonClientEnvGeneration,
+} from './daemon/client/daemon-environment';
 export { isCI } from './utils/is-ci';
 export {
   isUsingPrettierInTree,

--- a/packages/nx/src/plugins/js/utils/register.spec.ts
+++ b/packages/nx/src/plugins/js/utils/register.spec.ts
@@ -1,3 +1,4 @@
+import type { MockInstance } from 'vitest';
 import type { CompilerOptions } from 'typescript';
 import { JsxEmit, ModuleKind, ScriptTarget } from 'typescript';
 import {
@@ -516,10 +517,10 @@ describe('resolveTsNodeEsmCompilerOptions', () => {
 
 describe('forceRegisterEsmLoader', () => {
   const originalEnv = { ...process.env };
-  let registerSpy: jest.SpyInstance;
+  let registerSpy: MockInstance;
 
   beforeEach(() => {
-    registerSpy = jest
+    registerSpy = vi
       .spyOn(require('node:module'), 'register')
       .mockImplementation(() => undefined);
   });
@@ -529,12 +530,9 @@ describe('forceRegisterEsmLoader', () => {
     process.env = { ...originalEnv };
   });
 
-  function loadForceRegisterEsmLoader(): () => void {
-    let fn: () => void;
-    jest.isolateModules(() => {
-      fn = require('./register').forceRegisterEsmLoader;
-    });
-    return fn;
+  async function loadForceRegisterEsmLoader(): Promise<() => void> {
+    vi.resetModules();
+    return (await import('./register')).forceRegisterEsmLoader;
   }
 
   function registeredSetterOptions(): unknown {
@@ -550,10 +548,10 @@ describe('forceRegisterEsmLoader', () => {
     return JSON.parse(JSON.parse(rhs));
   }
 
-  it('registers a compiler-options setter module before the ts-node/esm loader', () => {
+  it('registers a compiler-options setter module before the ts-node/esm loader', async () => {
     delete process.env.TS_NODE_COMPILER_OPTIONS;
 
-    loadForceRegisterEsmLoader()();
+    (await loadForceRegisterEsmLoader())();
 
     expect(registerSpy).toHaveBeenCalledTimes(2);
     expect(String(registerSpy.mock.calls[1][0])).toMatch(/ts-node\/esm\.mjs$/);
@@ -563,14 +561,14 @@ describe('forceRegisterEsmLoader', () => {
     });
   });
 
-  it('forces nodenext module and resolution over an inherited value', () => {
+  it('forces nodenext module and resolution over an inherited value', async () => {
     process.env.TS_NODE_COMPILER_OPTIONS = JSON.stringify({
       moduleResolution: 'node10',
       module: 'commonjs',
       customConditions: null,
     });
 
-    loadForceRegisterEsmLoader()();
+    (await loadForceRegisterEsmLoader())();
 
     expect(registeredSetterOptions()).toEqual({
       moduleResolution: 'nodenext',
@@ -587,10 +585,10 @@ describe('forceRegisterEsmLoader', () => {
     );
   });
 
-  it('passes a malformed inherited value through for ts-node to reject', () => {
+  it('passes a malformed inherited value through for ts-node to reject', async () => {
     process.env.TS_NODE_COMPILER_OPTIONS = '{oops';
 
-    loadForceRegisterEsmLoader()();
+    (await loadForceRegisterEsmLoader())();
 
     const source = decodeURIComponent(
       String(registerSpy.mock.calls[0][0]).replace('data:text/javascript,', '')
@@ -598,10 +596,10 @@ describe('forceRegisterEsmLoader', () => {
     expect(source).toBe('process.env.TS_NODE_COMPILER_OPTIONS = "{oops";');
   });
 
-  it('does not write a default value into the process env', () => {
+  it('does not write a default value into the process env', async () => {
     delete process.env.TS_NODE_COMPILER_OPTIONS;
 
-    loadForceRegisterEsmLoader()();
+    (await loadForceRegisterEsmLoader())();
 
     expect(process.env.TS_NODE_COMPILER_OPTIONS).toBeUndefined();
   });

--- a/packages/nx/src/plugins/js/utils/register.spec.ts
+++ b/packages/nx/src/plugins/js/utils/register.spec.ts
@@ -606,3 +606,87 @@ describe('forceRegisterEsmLoader', () => {
     expect(process.env.TS_NODE_COMPILER_OPTIONS).toBeUndefined();
   });
 });
+
+// A real `ts-node/esm` registration in a child process. `@swc-node/register`
+// loads the TypeScript source there and is hidden from the ESM loader pick so
+// `ts-node/esm` is the loader under test.
+describe('forceRegisterEsmLoader with ts-node/esm', () => {
+  const {
+    mkdtempSync,
+    realpathSync,
+    rmSync,
+    writeFileSync,
+  } = require('node:fs');
+  const { tmpdir } = require('node:os');
+  const { join } = require('node:path');
+  let dir: string;
+
+  beforeAll(() => {
+    // Real path: the loader reports the resolved url.
+    dir = realpathSync(mkdtempSync(join(tmpdir(), 'nx-ts-node-esm-')));
+    writeFileSync(
+      join(dir, 'config.mts'),
+      'export enum Kind { Esm = 1 }\nexport const url = import.meta.url;\n'
+    );
+    writeFileSync(
+      join(dir, 'entry.cjs'),
+      `
+const Module = require('node:module');
+const resolveFilename = Module._resolveFilename;
+Module._resolveFilename = function (request, ...rest) {
+  if (request === '@swc-node/register/esm') {
+    throw Object.assign(new Error('hidden'), { code: 'MODULE_NOT_FOUND' });
+  }
+  return resolveFilename.call(this, request, ...rest);
+};
+const { forceRegisterEsmLoader } = require(process.argv[2]);
+process.env.TS_NODE_COMPILER_OPTIONS = JSON.stringify({
+  module: 'commonjs',
+  moduleResolution: 'node10',
+});
+forceRegisterEsmLoader();
+// Kept out of the transpiled source: a CommonJS transform would turn it into
+// a require, and the file exists to exercise the ESM loader.
+new Function('s', 'return import(s)')(process.argv[3]).then(
+  (m) => process.send({ ok: true, url: m.url, kind: m.Kind.Esm }),
+  (e) => process.send({ ok: false, message: String(e.diagnosticText ?? e) })
+);
+`
+    );
+  });
+
+  afterAll(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('loads an ESM config despite an inherited CommonJS TS_NODE_COMPILER_OPTIONS', async () => {
+    const { fork } = require('node:child_process');
+    const { pathToFileURL } = require('node:url');
+    const configUrl = pathToFileURL(join(dir, 'config.mts')).href;
+    // The child sets the inherited value itself, after its own CommonJS loader
+    // has started, so that loader's options play no part.
+    const { TS_NODE_COMPILER_OPTIONS, NODE_OPTIONS, ...env } = process.env;
+    const child = fork(
+      join(dir, 'entry.cjs'),
+      [require.resolve('./register'), configUrl],
+      {
+        cwd: process.cwd(),
+        env,
+        execArgv: ['--require', '@swc-node/register'],
+        stdio: ['ignore', 'ignore', 'pipe', 'ipc'],
+      }
+    );
+    let stderr = '';
+    child.stderr.on('data', (chunk) => (stderr += chunk));
+    const result = await new Promise<any>((resolve, reject) => {
+      child.once('message', resolve);
+      child.once('error', reject);
+      child.once('exit', (code) =>
+        reject(new Error(`exited with ${code} before replying:\n${stderr}`))
+      );
+    });
+    child.kill();
+
+    expect(result).toEqual({ ok: true, url: configUrl, kind: 1 });
+  }, 60_000);
+});

--- a/packages/nx/src/plugins/js/utils/register.spec.ts
+++ b/packages/nx/src/plugins/js/utils/register.spec.ts
@@ -10,6 +10,7 @@ import {
   isTsEsmSyntaxError,
   NODENEXT_ESM_RESOLVER_SOURCE,
   nodeNextEsmResolveHook,
+  resolveTsNodeEsmCompilerOptions,
 } from './register';
 
 // Avoid a real swc registration side effect when exercising getTranspiler.
@@ -479,5 +480,129 @@ describe('NodeNext ESM resolve hook (nodeNextEsmResolveHook, sync)', () => {
         makeNextResolve([])
       )
     ).toThrow(expect.objectContaining({ code: 'ERR_MODULE_NOT_FOUND' }));
+  });
+});
+
+describe('resolveTsNodeEsmCompilerOptions', () => {
+  it('defaults to nodenext when no value is inherited', () => {
+    expect(JSON.parse(resolveTsNodeEsmCompilerOptions(undefined))).toEqual({
+      moduleResolution: 'nodenext',
+      module: 'nodenext',
+    });
+  });
+
+  it('forces nodenext while preserving other inherited options', () => {
+    const raw = JSON.stringify({
+      moduleResolution: 'node10',
+      module: 'commonjs',
+      customConditions: null,
+      paths: { '@lib': ['libs/lib'] },
+    });
+    expect(JSON.parse(resolveTsNodeEsmCompilerOptions(raw))).toEqual({
+      moduleResolution: 'nodenext',
+      module: 'nodenext',
+      customConditions: null,
+      paths: { '@lib': ['libs/lib'] },
+    });
+  });
+
+  it.each(['{oops', 'null', '7', 'true', '"hello"', '["commonjs"]'])(
+    'passes %s through unchanged for ts-node to handle',
+    (raw) => {
+      expect(resolveTsNodeEsmCompilerOptions(raw)).toBe(raw);
+    }
+  );
+});
+
+describe('forceRegisterEsmLoader', () => {
+  const originalEnv = { ...process.env };
+  let registerSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    registerSpy = jest
+      .spyOn(require('node:module'), 'register')
+      .mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    registerSpy.mockRestore();
+    process.env = { ...originalEnv };
+  });
+
+  function loadForceRegisterEsmLoader(): () => void {
+    let fn: () => void;
+    jest.isolateModules(() => {
+      fn = require('./register').forceRegisterEsmLoader;
+    });
+    return fn;
+  }
+
+  function registeredSetterOptions(): unknown {
+    expect(String(registerSpy.mock.calls[0][0])).toMatch(
+      /^data:text\/javascript,/
+    );
+    const source = decodeURIComponent(
+      String(registerSpy.mock.calls[0][0]).replace('data:text/javascript,', '')
+    );
+    const rhs = source.match(
+      /^process\.env\.TS_NODE_COMPILER_OPTIONS = (.*);$/
+    )[1];
+    return JSON.parse(JSON.parse(rhs));
+  }
+
+  it('registers a compiler-options setter module before the ts-node/esm loader', () => {
+    delete process.env.TS_NODE_COMPILER_OPTIONS;
+
+    loadForceRegisterEsmLoader()();
+
+    expect(registerSpy).toHaveBeenCalledTimes(2);
+    expect(String(registerSpy.mock.calls[1][0])).toMatch(/ts-node\/esm\.mjs$/);
+    expect(registeredSetterOptions()).toEqual({
+      moduleResolution: 'nodenext',
+      module: 'nodenext',
+    });
+  });
+
+  it('forces nodenext module and resolution over an inherited value', () => {
+    process.env.TS_NODE_COMPILER_OPTIONS = JSON.stringify({
+      moduleResolution: 'node10',
+      module: 'commonjs',
+      customConditions: null,
+    });
+
+    loadForceRegisterEsmLoader()();
+
+    expect(registeredSetterOptions()).toEqual({
+      moduleResolution: 'nodenext',
+      module: 'nodenext',
+      customConditions: null,
+    });
+    // Child processes must keep seeing the inherited value.
+    expect(process.env.TS_NODE_COMPILER_OPTIONS).toBe(
+      JSON.stringify({
+        moduleResolution: 'node10',
+        module: 'commonjs',
+        customConditions: null,
+      })
+    );
+  });
+
+  it('passes a malformed inherited value through for ts-node to reject', () => {
+    process.env.TS_NODE_COMPILER_OPTIONS = '{oops';
+
+    loadForceRegisterEsmLoader()();
+
+    const source = decodeURIComponent(
+      String(registerSpy.mock.calls[0][0]).replace('data:text/javascript,', '')
+    );
+    expect(source).toBe('process.env.TS_NODE_COMPILER_OPTIONS = "{oops";');
+  });
+
+  it('does not write a default value into the process env', () => {
+    delete process.env.TS_NODE_COMPILER_OPTIONS;
+
+    loadForceRegisterEsmLoader()();
+
+    expect(process.env.TS_NODE_COMPILER_OPTIONS).toBeUndefined();
   });
 });

--- a/packages/nx/src/plugins/js/utils/register.ts
+++ b/packages/nx/src/plugins/js/utils/register.ts
@@ -51,13 +51,6 @@ function ensureEsmLoaderRegistered(opts: { required: boolean }): void {
     return;
   }
 
-  // ts-node reads compilerOptions from this env var. Setting nodenext
-  // module/resolution avoids surprises when ts-node is the chosen loader.
-  process.env.TS_NODE_COMPILER_OPTIONS ??= JSON.stringify({
-    moduleResolution: 'nodenext',
-    module: 'nodenext',
-  });
-
   // Prefer @swc-node/register/esm (faster) over ts-node/esm.
   const swcEsm = tryResolveLoader('@swc-node/register/esm');
   const tsNodeEsm = tryResolveLoader('ts-node/esm');
@@ -83,8 +76,59 @@ function ensureEsmLoaderRegistered(opts: { required: boolean }): void {
   }
 
   const url = require('node:url') as typeof import('node:url');
+  if (!swcEsm) {
+    // ts-node/esm reads TS_NODE_COMPILER_OPTIONS from its hooks thread, which
+    // snapshots process.env only when the first hook in the process registers,
+    // possibly long before this call. A registered setter module runs on the
+    // hooks thread itself, so the value lands there without mutating this
+    // process's env (which an existing hooks thread would never see, and
+    // child processes would inherit).
+    module.register(
+      'data:text/javascript,' +
+        encodeURIComponent(
+          `process.env.TS_NODE_COMPILER_OPTIONS = ${JSON.stringify(
+            resolveTsNodeEsmCompilerOptions(
+              process.env.TS_NODE_COMPILER_OPTIONS
+            )
+          )};`
+        )
+    );
+  }
   module.register(url.pathToFileURL(loaderPath));
   isTsEsmLoaderRegistered = true;
+}
+
+/**
+ * Effective `TS_NODE_COMPILER_OPTIONS` value for `ts-node/esm`. CommonJS emit
+ * can never work for the true-ESM loads the loader exists for (`import.meta`
+ * fails with TS1343), and CommonJS-format files are deferred to the `require`
+ * pipeline untouched, so `module`/`moduleResolution` are forced to `nodenext`
+ * over any inherited value. Values that are not a JSON object pass through
+ * unchanged for ts-node to handle.
+ *
+ * Exported so the merge semantics can be exercised directly in unit tests.
+ */
+export function resolveTsNodeEsmCompilerOptions(
+  raw: string | undefined
+): string {
+  if (raw === undefined) {
+    return JSON.stringify({ moduleResolution: 'nodenext', module: 'nodenext' });
+  }
+  try {
+    const parsed = JSON.parse(raw);
+    if (
+      typeof parsed === 'object' &&
+      parsed !== null &&
+      !Array.isArray(parsed)
+    ) {
+      return JSON.stringify({
+        ...parsed,
+        module: 'nodenext',
+        moduleResolution: 'nodenext',
+      });
+    }
+  } catch {}
+  return raw;
 }
 
 /**

--- a/packages/nx/src/project-graph/plugins/get-plugins.spec.ts
+++ b/packages/nx/src/project-graph/plugins/get-plugins.spec.ts
@@ -58,6 +58,7 @@ describe('reasonToError', () => {
 
 describe('getPluginsSeparated', () => {
   let getPluginsSeparated: typeof import('./get-plugins').getPluginsSeparated;
+  let getPluginsIfLoadedOrLoading: typeof import('./get-plugins').getPluginsIfLoadedOrLoading;
   let loadNxPlugin: Mock;
   // Resolver for each deferred specified-plugin load, keyed by plugin name.
   let pendingPluginLoads: Map<string, (plugin: unknown) => void>;
@@ -89,7 +90,8 @@ describe('getPluginsSeparated', () => {
       return [promise, () => {}];
     });
 
-    ({ getPluginsSeparated } = await import('./get-plugins'));
+    ({ getPluginsSeparated, getPluginsIfLoadedOrLoading } =
+      await import('./get-plugins'));
   });
 
   function finishLoading(pluginName: string) {
@@ -150,5 +152,35 @@ describe('getPluginsSeparated', () => {
     // resolution would be resolved against a stale project layout — missing
     // its own project — and collapse to the workspace root.
     expect(resetResolvePluginCache).toHaveBeenCalled();
+  });
+
+  describe('getPluginsIfLoadedOrLoading', () => {
+    it('returns undefined before any load and does not trigger one', () => {
+      expect(getPluginsIfLoadedOrLoading()).toBeUndefined();
+      expect(loadNxPlugin).not.toHaveBeenCalled();
+    });
+
+    it('returns an in-flight load without starting a second one', async () => {
+      const load = getPluginsSeparated({ plugins: ['test-a'] });
+      const peek = getPluginsIfLoadedOrLoading();
+      expect(peek).toBeDefined();
+      const loadsWhilePending = loadNxPlugin.mock.calls.length;
+
+      finishLoading('test-a');
+      await load;
+
+      const plugins = await peek;
+      expect(plugins.map((p) => p.name)).toContain('test-a');
+      expect(loadNxPlugin.mock.calls.length).toBe(loadsWhilePending);
+    });
+
+    it('returns the committed set once a load resolves', async () => {
+      const load = getPluginsSeparated({ plugins: ['test-a'] });
+      finishLoading('test-a');
+      await load;
+
+      const plugins = await getPluginsIfLoadedOrLoading();
+      expect(plugins.map((p) => p.name)).toContain('test-a');
+    });
   });
 });

--- a/packages/nx/src/project-graph/plugins/get-plugins.ts
+++ b/packages/nx/src/project-graph/plugins/get-plugins.ts
@@ -202,6 +202,28 @@ export async function getOnlyDefaultPlugins(root = workspaceRoot) {
   return result;
 }
 
+/**
+ * The plugins from an in-flight load (whose workers may already be forked) or
+ * the last committed one, without triggering a load. Undefined when neither
+ * exists or plugins were cleaned up. After a plugins-config change the
+ * committed set can be the previous, already-disposed one until the new load
+ * commits, so callers must tolerate a disposed worker.
+ */
+export function getPluginsIfLoadedOrLoading():
+  | Promise<LoadedNxPlugin[]>
+  | undefined {
+  const separated = pendingSeparatedPlugins
+    ? pendingSeparatedPlugins.promise
+    : cachedSeparatedPlugins;
+  if (!separated) {
+    return undefined;
+  }
+  return Promise.resolve(separated).then(
+    ({ specifiedPlugins, defaultPlugins }) =>
+      specifiedPlugins.concat(defaultPlugins)
+  );
+}
+
 export function cleanupPlugins() {
   cleanupSpecifiedPlugins?.();
   cleanupDefaultPlugins?.();

--- a/packages/nx/src/tasks-runner/task-env.spec.ts
+++ b/packages/nx/src/tasks-runner/task-env.spec.ts
@@ -369,6 +369,28 @@ describe('getGraphTimeDotEnvForTask', () => {
 
     expect(env.BASE_URL).toBeUndefined();
   });
+
+  it('bases the reconstruction on the given base env, not the live process.env', () => {
+    // A caller running config files in-process passes the snapshot it took
+    // under its load lock; a concurrent load's transient write to the live env
+    // must not be read as ambient, where it would mask the task file's value.
+    writeFileSync(
+      join(tempDir, '.env.e2e'),
+      'BASE_URL=http://localhost:4301\n'
+    );
+    const snapshot = { ...process.env };
+    process.env.BASE_URL = 'http://localhost:9999';
+
+    const env = getGraphTimeDotEnvForTask(
+      '.',
+      'e2e',
+      undefined,
+      undefined,
+      snapshot
+    );
+
+    expect(env.BASE_URL).toBe('http://localhost:4301');
+  });
 });
 
 describe('getForceColorForChild', () => {

--- a/packages/nx/src/tasks-runner/task-env.spec.ts
+++ b/packages/nx/src/tasks-runner/task-env.spec.ts
@@ -8,7 +8,7 @@ import {
   getEnvFilesForTask,
   getEnvVariablesForTask,
   getForceColorForChild,
-  getGraphTimeEnvForTask,
+  getGraphTimeDotEnvForTask,
   loadAndExpandDotEnvFile,
 } from './task-env';
 
@@ -308,7 +308,7 @@ describe('getEnvFilesForTask', () => {
   });
 });
 
-describe('getGraphTimeEnvForTask', () => {
+describe('getGraphTimeDotEnvForTask', () => {
   const originalEnv = process.env;
   const originalWorkspaceRoot = workspaceRoot;
   let tempDir: string;
@@ -337,7 +337,23 @@ describe('getGraphTimeEnvForTask', () => {
       'BASE_URL=http://localhost:4301\n'
     );
 
-    const env = getGraphTimeEnvForTask('.', 'e2e');
+    const env = getGraphTimeDotEnvForTask('.', 'e2e');
+
+    expect(env.BASE_URL).toBe('http://localhost:4301');
+  });
+
+  it('resolves a task-scoped value shadowed by an ambient root .env variable', () => {
+    // At Nx init the root .env was loaded into the ambient env. Reconstruction
+    // must unload it so the task-scoped file wins the way it does at run time:
+    // dotenv loading never overrides a key that is already set.
+    writeFileSync(join(tempDir, '.env'), 'BASE_URL=http://localhost:4200\n');
+    process.env.BASE_URL = 'http://localhost:4200';
+    writeFileSync(
+      join(tempDir, '.env.e2e'),
+      'BASE_URL=http://localhost:4301\n'
+    );
+
+    const env = getGraphTimeDotEnvForTask('.', 'e2e');
 
     expect(env.BASE_URL).toBe('http://localhost:4301');
   });
@@ -349,7 +365,7 @@ describe('getGraphTimeEnvForTask', () => {
       'BASE_URL=http://localhost:4301\n'
     );
 
-    const env = getGraphTimeEnvForTask('.', 'e2e');
+    const env = getGraphTimeDotEnvForTask('.', 'e2e');
 
     expect(env.BASE_URL).toBeUndefined();
   });

--- a/packages/nx/src/tasks-runner/task-env.spec.ts
+++ b/packages/nx/src/tasks-runner/task-env.spec.ts
@@ -3,10 +3,12 @@ import { tmpdir } from 'node:os';
 import { join } from 'node:path';
 import { ProjectGraph } from '../config/project-graph';
 import { Task } from '../config/task-graph';
+import { setWorkspaceRoot, workspaceRoot } from '../utils/workspace-root';
 import {
   getEnvFilesForTask,
   getEnvVariablesForTask,
   getForceColorForChild,
+  getGraphTimeEnvForTask,
   loadAndExpandDotEnvFile,
 } from './task-env';
 
@@ -303,6 +305,53 @@ describe('getEnvFilesForTask', () => {
         },
       } as any as ProjectGraph)
     );
+  });
+});
+
+describe('getGraphTimeEnvForTask', () => {
+  const originalEnv = process.env;
+  const originalWorkspaceRoot = workspaceRoot;
+  let tempDir: string;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    // The 'true' marker is only stamped once the graph exists; graph-time
+    // resolution must not depend on it being set.
+    delete process.env.NX_LOAD_DOT_ENV_FILES;
+    delete process.env.BASE_URL;
+    tempDir = mkdtempSync(join(tmpdir(), 'nx-graph-env-'));
+    setWorkspaceRoot(tempDir);
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    setWorkspaceRoot(originalWorkspaceRoot);
+    if (tempDir) {
+      rmSync(tempDir, { recursive: true, force: true });
+    }
+  });
+
+  it('loads a target-scoped .env before the run-time marker is stamped', () => {
+    writeFileSync(
+      join(tempDir, '.env.e2e'),
+      'BASE_URL=http://localhost:4301\n'
+    );
+
+    const env = getGraphTimeEnvForTask('.', 'e2e');
+
+    expect(env.BASE_URL).toBe('http://localhost:4301');
+  });
+
+  it('does not load dotenv files when NX_LOAD_DOT_ENV_FILES is "false"', () => {
+    process.env.NX_LOAD_DOT_ENV_FILES = 'false';
+    writeFileSync(
+      join(tempDir, '.env.e2e'),
+      'BASE_URL=http://localhost:4301\n'
+    );
+
+    const env = getGraphTimeEnvForTask('.', 'e2e');
+
+    expect(env.BASE_URL).toBeUndefined();
   });
 });
 

--- a/packages/nx/src/tasks-runner/task-env.spec.ts
+++ b/packages/nx/src/tasks-runner/task-env.spec.ts
@@ -370,6 +370,29 @@ describe('getGraphTimeDotEnvForTask', () => {
     expect(env.BASE_URL).toBeUndefined();
   });
 
+  it('honors the opt-out from the live env when the base env snapshot lacks it', () => {
+    // Windows resolves process.env case-insensitively while a plain snapshot
+    // keeps whichever spelling was exported, so a lowercase opt-out is absent
+    // from the snapshot the playwright plugin passes but live all the same.
+    process.env.NX_LOAD_DOT_ENV_FILES = 'false';
+    writeFileSync(
+      join(tempDir, '.env.e2e'),
+      'BASE_URL=http://localhost:4301\n'
+    );
+    const snapshotWithoutTheKey = { ...process.env };
+    delete snapshotWithoutTheKey.NX_LOAD_DOT_ENV_FILES;
+
+    const env = getGraphTimeDotEnvForTask(
+      '.',
+      'e2e',
+      undefined,
+      undefined,
+      snapshotWithoutTheKey
+    );
+
+    expect(env.BASE_URL).toBeUndefined();
+  });
+
   it('bases the reconstruction on the given base env, not the live process.env', () => {
     // A caller running config files in-process passes the snapshot it took
     // under its load lock; a concurrent load's transient write to the live env

--- a/packages/nx/src/tasks-runner/task-env.ts
+++ b/packages/nx/src/tasks-runner/task-env.ts
@@ -71,18 +71,20 @@ export function getTaskSpecificEnv(task: Task, graph: ProjectGraph) {
 }
 
 /**
- * Computes the env a task will run with, at graph-construction time.
+ * Reconstructs, at graph-construction time, the ambient env plus the dotenv
+ * files a task would load (`.env.<target>`, project-scoped `.env`, ...).
  *
- * `createNodes` runs before any task, so the per-task dotenv files
- * (`.env.<target>`, project-scoped `.env`, ...) that `getTaskSpecificEnv` loads
- * at run time are not in `process.env` yet. A plugin inferring targets from a
- * config that reads `process.env` needs those values to resolve the config the
- * way the task will. This mirrors `loadDotEnvFilesForTask` but takes the target
- * coordinates directly (there is no `Task`/graph yet) and gates on `!== 'false'`
- * rather than `=== 'true'`: the `'true'` marker is only stamped once the graph
- * exists (`run-command.ts`), which is after this runs.
+ * `createNodes` runs before any task, so the per-task dotenv files that
+ * `getTaskSpecificEnv` loads at run time are not in `process.env` yet. A plugin
+ * inferring targets from a config that reads `process.env` needs those values
+ * to resolve the config the way the task will. This mirrors
+ * `loadDotEnvFilesForTask` but takes the target coordinates directly (there is
+ * no `Task`/graph yet) and gates on `!== 'false'` rather than `=== 'true'`: the
+ * `'true'` marker is only stamped once the graph exists (`run-command.ts`),
+ * which is after this runs. Only the dotenv overlay is reconstructed: run-time
+ * env like `NX_TASK_TARGET_*` or `NX_TASK_HASH` is not included.
  */
-export function getGraphTimeEnvForTask(
+export function getGraphTimeDotEnvForTask(
   projectRoot: string,
   target: string,
   configuration?: string,

--- a/packages/nx/src/tasks-runner/task-env.ts
+++ b/packages/nx/src/tasks-runner/task-env.ts
@@ -71,8 +71,11 @@ export function getTaskSpecificEnv(task: Task, graph: ProjectGraph) {
 }
 
 /**
- * Reconstructs, at graph-construction time, the ambient env plus the dotenv
- * files a task would load (`.env.<target>`, project-scoped `.env`, ...).
+ * Reconstructs, at graph-construction time, the env a task would see: the
+ * root dotenv files Nx loaded at init are unloaded from the ambient env, then
+ * the dotenv files the task would load (`.env.<target>`, project-scoped
+ * `.env`, ...) are applied, so a task-scoped file wins over an init-time root
+ * load while a genuinely shell-set value still wins over both.
  *
  * `createNodes` runs before any task, so the per-task dotenv files that
  * `getTaskSpecificEnv` loads at run time are not in `process.env` yet. A plugin

--- a/packages/nx/src/tasks-runner/task-env.ts
+++ b/packages/nx/src/tasks-runner/task-env.ts
@@ -70,6 +70,42 @@ export function getTaskSpecificEnv(task: Task, graph: ProjectGraph) {
   return env;
 }
 
+/**
+ * Computes the env a task will run with, at graph-construction time.
+ *
+ * `createNodes` runs before any task, so the per-task dotenv files
+ * (`.env.<target>`, project-scoped `.env`, ...) that `getTaskSpecificEnv` loads
+ * at run time are not in `process.env` yet. A plugin inferring targets from a
+ * config that reads `process.env` needs those values to resolve the config the
+ * way the task will. This mirrors `loadDotEnvFilesForTask` but takes the target
+ * coordinates directly (there is no `Task`/graph yet) and gates on `!== 'false'`
+ * rather than `=== 'true'`: the `'true'` marker is only stamped once the graph
+ * exists (`run-command.ts`), which is after this runs.
+ */
+export function getGraphTimeEnvForTask(
+  projectRoot: string,
+  target: string,
+  configuration?: string,
+  nonAtomizedTarget?: string
+): NodeJS.ProcessEnv {
+  // Unload the root dotenv files loaded on init of Nx so the task-scoped files win.
+  const env = unloadDotEnvFiles({ ...process.env });
+  if (process.env.NX_LOAD_DOT_ENV_FILES === 'false') {
+    return env;
+  }
+  const dotEnvFiles = getEnvPathsForTask(
+    projectRoot,
+    target,
+    configuration,
+    nonAtomizedTarget
+  );
+  loadAndExpandDotEnvFile(
+    dotEnvFiles.map((file) => join(workspaceRoot, file)),
+    env
+  );
+  return env;
+}
+
 export function getEnvVariablesForTask(
   task: Task,
   taskSpecificEnv: NodeJS.ProcessEnv,

--- a/packages/nx/src/tasks-runner/task-env.ts
+++ b/packages/nx/src/tasks-runner/task-env.ts
@@ -75,7 +75,9 @@ export function getTaskSpecificEnv(task: Task, graph: ProjectGraph) {
  * root dotenv files Nx loaded at init are unloaded from the ambient env, then
  * the dotenv files the task would load (`.env.<target>`, project-scoped
  * `.env`, ...) are applied, so a task-scoped file wins over an init-time root
- * load while a genuinely shell-set value still wins over both.
+ * load. The unload compares values, not provenance: a variable whose value
+ * differs from the root file's is kept and wins over the task files, while a
+ * shell-set value equal to the root file's is unloaded like the file's own.
  *
  * `createNodes` runs before any task, so the per-task dotenv files that
  * `getTaskSpecificEnv` loads at run time are not in `process.env` yet. A plugin

--- a/packages/nx/src/tasks-runner/task-env.ts
+++ b/packages/nx/src/tasks-runner/task-env.ts
@@ -88,16 +88,22 @@ export function getTaskSpecificEnv(task: Task, graph: ProjectGraph) {
  * `'true'` marker is only stamped once the graph exists (`run-command.ts`),
  * which is after this runs. Only the dotenv overlay is reconstructed: run-time
  * env like `NX_TASK_TARGET_*` or `NX_TASK_HASH` is not included.
+ *
+ * `baseEnv` is the ambient env the overlay applies to, defaulting to the live
+ * `process.env`. A caller that runs config files in-process passes a snapshot
+ * taken under its load lock instead: a concurrent load's transient env writes
+ * would otherwise be read as ambient and mask the task files' values.
  */
 export function getGraphTimeDotEnvForTask(
   projectRoot: string,
   target: string,
   configuration?: string,
-  nonAtomizedTarget?: string
+  nonAtomizedTarget?: string,
+  baseEnv: NodeJS.ProcessEnv = process.env
 ): NodeJS.ProcessEnv {
   // Unload the root dotenv files loaded on init of Nx so the task-scoped files win.
-  const env = unloadDotEnvFiles({ ...process.env });
-  if (process.env.NX_LOAD_DOT_ENV_FILES === 'false') {
+  const env = unloadDotEnvFiles({ ...baseEnv });
+  if (baseEnv.NX_LOAD_DOT_ENV_FILES === 'false') {
     return env;
   }
   const dotEnvFiles = getEnvPathsForTask(

--- a/packages/nx/src/tasks-runner/task-env.ts
+++ b/packages/nx/src/tasks-runner/task-env.ts
@@ -103,7 +103,13 @@ export function getGraphTimeDotEnvForTask(
 ): NodeJS.ProcessEnv {
   // Unload the root dotenv files loaded on init of Nx so the task-scoped files win.
   const env = unloadDotEnvFiles({ ...baseEnv });
-  if (baseEnv.NX_LOAD_DOT_ENV_FILES === 'false') {
+  // Fall back to the live env when the snapshot has no entry: Windows resolves
+  // `process.env` case-insensitively but a plain snapshot keeps whichever
+  // spelling was exported, so a lowercase opt-out is invisible here otherwise.
+  if (
+    (baseEnv.NX_LOAD_DOT_ENV_FILES ?? process.env.NX_LOAD_DOT_ENV_FILES) ===
+    'false'
+  ) {
     return env;
   }
   const dotEnvFiles = getEnvPathsForTask(

--- a/packages/playwright/executors.json
+++ b/packages/playwright/executors.json
@@ -10,6 +10,12 @@
       "schema": "./dist/src/executors/merge-reports/schema.json",
       "description": "Merge Playwright blob reports to produce unified reports for the configured reporters (excluding the `blob` reporter).",
       "hidden": true
+    },
+    "wait-for-webserver": {
+      "implementation": "./dist/src/executors/wait-for-webserver/wait-for-webserver.impl",
+      "schema": "./dist/src/executors/wait-for-webserver/schema.json",
+      "description": "Wait for the E2E web server(s) to accept connections before running the Playwright CI test tasks.",
+      "hidden": true
     }
   }
 }

--- a/packages/playwright/executors.json
+++ b/packages/playwright/executors.json
@@ -14,7 +14,7 @@
     "wait-for-webserver": {
       "implementation": "./dist/src/executors/wait-for-webserver/wait-for-webserver.impl",
       "schema": "./dist/src/executors/wait-for-webserver/schema.json",
-      "description": "Wait for the E2E web server(s) to accept connections before running the Playwright CI test tasks.",
+      "description": "Wait for the E2E web server(s) to accept connections before running the Playwright test tasks.",
       "hidden": true
     }
   }

--- a/packages/playwright/executors.json
+++ b/packages/playwright/executors.json
@@ -14,7 +14,7 @@
     "wait-for-webserver": {
       "implementation": "./dist/src/executors/wait-for-webserver/wait-for-webserver.impl",
       "schema": "./dist/src/executors/wait-for-webserver/schema.json",
-      "description": "Wait for the E2E web server(s) to accept connections before running the Playwright test tasks.",
+      "description": "Wait for the E2E web server(s) to be ready.",
       "hidden": true
     }
   }

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -79,6 +79,7 @@
     "@nx/eslint": "workspace:*",
     "@nx/js": "workspace:*",
     "tslib": "catalog:typescript",
+    "https-proxy-agent": "catalog:",
     "minimatch": "catalog:",
     "semver": "catalog:"
   },

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -78,10 +78,10 @@
     "@nx/devkit": "workspace:*",
     "@nx/eslint": "workspace:*",
     "@nx/js": "workspace:*",
-    "tslib": "catalog:typescript",
     "https-proxy-agent": "catalog:",
     "minimatch": "catalog:",
-    "semver": "catalog:"
+    "semver": "catalog:",
+    "tslib": "catalog:typescript"
   },
   "devDependencies": {
     "nx": "workspace:*"

--- a/packages/playwright/src/executors/wait-for-webserver/proxy.spec.ts
+++ b/packages/playwright/src/executors/wait-for-webserver/proxy.spec.ts
@@ -1,0 +1,237 @@
+import { resolveProxyForUrl } from './proxy';
+
+const PROXY_VARS = [
+  'http_proxy',
+  'HTTP_PROXY',
+  'https_proxy',
+  'HTTPS_PROXY',
+  'all_proxy',
+  'ALL_PROXY',
+  'no_proxy',
+  'NO_PROXY',
+];
+
+describe('resolveProxyForUrl', () => {
+  let originalEnv: Record<string, string | undefined>;
+
+  beforeEach(() => {
+    originalEnv = {};
+    for (const name of PROXY_VARS) {
+      originalEnv[name] = process.env[name];
+      delete process.env[name];
+    }
+  });
+
+  afterEach(() => {
+    for (const name of PROXY_VARS) {
+      if (originalEnv[name] === undefined) {
+        delete process.env[name];
+      } else {
+        process.env[name] = originalEnv[name];
+      }
+    }
+  });
+
+  it('goes direct when nothing is configured', () => {
+    expect(resolveProxyForUrl(new URL('http://localhost:4200'))).toEqual({
+      kind: 'direct',
+    });
+  });
+
+  it.each(['http_proxy', 'HTTP_PROXY'])(
+    'uses the proxy from %s for an http url',
+    (name) => {
+      process.env[name] = 'http://proxy.example:8080';
+
+      expect(resolveProxyForUrl(new URL('http://localhost:4200'))).toEqual({
+        kind: 'proxy',
+        proxy: new URL('http://proxy.example:8080'),
+      });
+    }
+  );
+
+  it('keys the lookup on the protocol, like Playwright', () => {
+    process.env.HTTPS_PROXY = 'http://proxy.example:8080';
+
+    expect(resolveProxyForUrl(new URL('http://localhost:4200'))).toEqual({
+      kind: 'direct',
+    });
+    expect(resolveProxyForUrl(new URL('https://localhost:4200'))).toEqual({
+      kind: 'proxy',
+      proxy: new URL('http://proxy.example:8080'),
+    });
+  });
+
+  it('falls back to all_proxy only when the protocol variable is unset', () => {
+    process.env.ALL_PROXY = 'http://fallback.example:8080';
+
+    expect(resolveProxyForUrl(new URL('http://localhost:4200'))).toEqual({
+      kind: 'proxy',
+      proxy: new URL('http://fallback.example:8080'),
+    });
+
+    process.env.HTTP_PROXY = 'http://specific.example:8080';
+
+    expect(resolveProxyForUrl(new URL('http://localhost:4200'))).toEqual({
+      kind: 'proxy',
+      proxy: new URL('http://specific.example:8080'),
+    });
+  });
+
+  it('treats an empty value as unset', () => {
+    process.env.HTTP_PROXY = '';
+
+    expect(resolveProxyForUrl(new URL('http://localhost:4200'))).toEqual({
+      kind: 'direct',
+    });
+  });
+
+  it.each([
+    { target: 'http://localhost:4200', expected: 'http://proxy.example:8080/' },
+    {
+      target: 'https://localhost:4200',
+      expected: 'https://proxy.example:8080/',
+    },
+  ])(
+    'gives a schemeless value the target protocol for $target',
+    ({ target, expected }) => {
+      process.env.HTTP_PROXY = 'proxy.example:8080';
+      process.env.HTTPS_PROXY = 'proxy.example:8080';
+
+      const resolution = resolveProxyForUrl(new URL(target));
+
+      expect(resolution).toEqual({ kind: 'proxy', proxy: new URL(expected) });
+    }
+  );
+
+  it('reports a proxy value that cannot be parsed instead of going direct', () => {
+    process.env.HTTP_PROXY = 'http://not a proxy';
+
+    expect(resolveProxyForUrl(new URL('http://localhost:4200'))).toEqual({
+      kind: 'unusable',
+      variable: 'HTTP_PROXY',
+      value: 'http://not a proxy',
+      reason: 'is not a valid url',
+    });
+  });
+
+  it('reports credentials that cannot be percent-decoded', () => {
+    // Playwright decodes these too, so the request would fail on them either
+    // way. Catching it here is what keeps the failure legible.
+    process.env.http_proxy = 'http://user:100%@proxy.example:8080';
+
+    expect(resolveProxyForUrl(new URL('http://localhost:4200'))).toEqual({
+      kind: 'unusable',
+      variable: 'http_proxy',
+      value: '***@proxy.example:8080',
+      // The redaction takes the offending character with it, so the value on
+      // its own would not show what is wrong.
+      reason: 'has credentials that are not valid percent-encoding',
+    });
+  });
+
+  it('keeps credentials out of the value it reports', () => {
+    process.env.ALL_PROXY = 'http://user:s3cr3t@not a proxy:8080';
+
+    expect(resolveProxyForUrl(new URL('http://localhost:4200'))).toEqual({
+      kind: 'unusable',
+      variable: 'ALL_PROXY',
+      value: '***@not a proxy:8080',
+      reason: 'is not a valid url',
+    });
+  });
+
+  it.each(['socks5://127.0.0.1:1080', 'ftp://proxy.example:2121'])(
+    'reports %s as a scheme it cannot send a request over',
+    (value) => {
+      process.env.HTTPS_PROXY = value;
+
+      // Neither scheme fails on its own account otherwise, and which way it
+      // fails late depends on the target rather than the value: an http one
+      // throws out of `http.request`, and an https one has the agent dial the
+      // proxy as if it spoke plain http.
+      expect(resolveProxyForUrl(new URL('https://localhost:4200'))).toEqual({
+        kind: 'unusable',
+        variable: 'HTTPS_PROXY',
+        value,
+        reason: 'is not an http or https url',
+      });
+    }
+  );
+
+  describe('no_proxy', () => {
+    beforeEach(() => {
+      process.env.HTTP_PROXY = 'http://proxy.example:8080';
+    });
+
+    it('bypasses everything for *', () => {
+      process.env.NO_PROXY = '*';
+
+      expect(resolveProxyForUrl(new URL('http://localhost:4200'))).toEqual({
+        kind: 'direct',
+      });
+    });
+
+    it('bypasses an exact host', () => {
+      process.env.NO_PROXY = 'localhost';
+
+      expect(resolveProxyForUrl(new URL('http://localhost:4200'))).toEqual({
+        kind: 'direct',
+      });
+      expect(resolveProxyForUrl(new URL('http://elsewhere:4200'))).toEqual({
+        kind: 'proxy',
+        proxy: new URL('http://proxy.example:8080'),
+      });
+    });
+
+    it.each(['.example.com', '*.example.com'])(
+      'bypasses a suffix written as %s',
+      (entry) => {
+        process.env.NO_PROXY = entry;
+
+        expect(resolveProxyForUrl(new URL('http://app.example.com'))).toEqual({
+          kind: 'direct',
+        });
+      }
+    );
+
+    it.each([', ', ' ', ','])(
+      'accepts entries separated by "%s"',
+      (separator) => {
+        process.env.NO_PROXY = ['other.example', 'localhost'].join(separator);
+
+        expect(resolveProxyForUrl(new URL('http://localhost:4200'))).toEqual({
+          kind: 'direct',
+        });
+      }
+    );
+
+    it('honours a port on the entry', () => {
+      process.env.NO_PROXY = 'localhost:4200';
+
+      expect(resolveProxyForUrl(new URL('http://localhost:4200'))).toEqual({
+        kind: 'direct',
+      });
+      expect(resolveProxyForUrl(new URL('http://localhost:5200'))).toEqual({
+        kind: 'proxy',
+        proxy: new URL('http://proxy.example:8080'),
+      });
+    });
+
+    it('compares against the protocol default port when the url has none', () => {
+      process.env.NO_PROXY = 'localhost:80';
+
+      expect(resolveProxyForUrl(new URL('http://localhost'))).toEqual({
+        kind: 'direct',
+      });
+    });
+
+    it('keeps the brackets on an ipv6 host', () => {
+      process.env.NO_PROXY = '[::1]';
+
+      expect(resolveProxyForUrl(new URL('http://[::1]:4200'))).toEqual({
+        kind: 'direct',
+      });
+    });
+  });
+});

--- a/packages/playwright/src/executors/wait-for-webserver/proxy.spec.ts
+++ b/packages/playwright/src/executors/wait-for-webserver/proxy.spec.ts
@@ -38,6 +38,28 @@ describe('resolveProxyForUrl', () => {
     });
   });
 
+  it('resolves from an explicit env instead of process.env when one is passed', () => {
+    process.env.HTTP_PROXY = 'http://ambient.example:8080';
+
+    expect(
+      resolveProxyForUrl(new URL('http://localhost:4200'), {
+        HTTP_PROXY: 'http://task.example:8080',
+      })
+    ).toEqual({
+      kind: 'proxy',
+      proxy: new URL('http://task.example:8080'),
+    });
+    expect(
+      resolveProxyForUrl(new URL('http://localhost:4200'), {
+        HTTP_PROXY: 'http://task.example:8080',
+        NO_PROXY: 'localhost',
+      })
+    ).toEqual({ kind: 'direct' });
+    expect(resolveProxyForUrl(new URL('http://localhost:4200'), {})).toEqual({
+      kind: 'direct',
+    });
+  });
+
   it.each(['http_proxy', 'HTTP_PROXY'])(
     'uses the proxy from %s for an http url',
     (name) => {

--- a/packages/playwright/src/executors/wait-for-webserver/proxy.spec.ts
+++ b/packages/playwright/src/executors/wait-for-webserver/proxy.spec.ts
@@ -9,6 +9,12 @@ const PROXY_VARS = [
   'ALL_PROXY',
   'no_proxy',
   'NO_PROXY',
+  'npm_config_http_proxy',
+  'NPM_CONFIG_HTTP_PROXY',
+  'npm_config_proxy',
+  'NPM_CONFIG_PROXY',
+  'npm_config_no_proxy',
+  'NPM_CONFIG_NO_PROXY',
 ];
 
 describe('resolveProxyForUrl', () => {
@@ -253,6 +259,70 @@ describe('resolveProxyForUrl', () => {
 
       expect(resolveProxyForUrl(new URL('http://[::1]:4200'))).toEqual({
         kind: 'direct',
+      });
+    });
+  });
+
+  describe('npm_config proxy variables', () => {
+    const url = new URL('http://localhost:4200');
+    const legacy = (target: URL) =>
+      resolveProxyForUrl(target, process.env, true);
+
+    it('ignores them unless asked, like Playwright 1.59.0 and later', () => {
+      process.env.npm_config_http_proxy = 'http://npm.example:8080';
+      process.env.npm_config_proxy = 'http://npm.example:8080';
+
+      expect(resolveProxyForUrl(url)).toEqual({ kind: 'direct' });
+    });
+
+    it('reads them in the order Playwright below 1.59.0 does', () => {
+      // npm_config_<protocol>_proxy, <protocol>_proxy, npm_config_proxy,
+      // all_proxy.
+      process.env.ALL_PROXY = 'http://all.example:8080';
+      expect(legacy(url)).toEqual({
+        kind: 'proxy',
+        proxy: new URL('http://all.example:8080'),
+      });
+
+      process.env.npm_config_proxy = 'http://npm.example:8080';
+      expect(legacy(url)).toEqual({
+        kind: 'proxy',
+        proxy: new URL('http://npm.example:8080'),
+      });
+
+      process.env.HTTP_PROXY = 'http://specific.example:8080';
+      expect(legacy(url)).toEqual({
+        kind: 'proxy',
+        proxy: new URL('http://specific.example:8080'),
+      });
+
+      process.env.npm_config_http_proxy = 'http://npm-specific.example:8080';
+      expect(legacy(url)).toEqual({
+        kind: 'proxy',
+        proxy: new URL('http://npm-specific.example:8080'),
+      });
+    });
+
+    it('lets npm_config_no_proxy override no_proxy', () => {
+      process.env.HTTP_PROXY = 'http://proxy.example:8080';
+      process.env.NO_PROXY = 'localhost';
+      process.env.npm_config_no_proxy = 'other.example';
+
+      expect(legacy(url)).toEqual({
+        kind: 'proxy',
+        proxy: new URL('http://proxy.example:8080'),
+      });
+      expect(resolveProxyForUrl(url)).toEqual({ kind: 'direct' });
+    });
+
+    it('names the npm variable a bad value came from', () => {
+      process.env.npm_config_proxy = 'http://not a proxy';
+
+      expect(legacy(url)).toEqual({
+        kind: 'unusable',
+        variable: 'npm_config_proxy',
+        value: 'http://not a proxy',
+        reason: 'is not a valid url',
       });
     });
   });

--- a/packages/playwright/src/executors/wait-for-webserver/proxy.ts
+++ b/packages/playwright/src/executors/wait-for-webserver/proxy.ts
@@ -1,0 +1,137 @@
+// Playwright routes its readiness poll through a proxy configured in the
+// environment, so a gate that always connected directly would be answering a
+// different question than the check it exists to satisfy. Selection mirrors the
+// `proxy-from-env` copy Playwright bundles (`getProxyForUrl`) together with its
+// own `normalizeProxyURL`, checked against playwright-core 1.60.0. The
+// transport is left to `https-proxy-agent`, the agent Playwright itself hands
+// to `https.request` for a proxied https target.
+
+const DEFAULT_PORTS: Record<string, number> = {
+  ftp: 21,
+  gopher: 70,
+  http: 80,
+  https: 443,
+  ws: 80,
+  wss: 443,
+};
+
+export type ProxyResolution =
+  | { kind: 'direct' }
+  | { kind: 'proxy'; proxy: URL }
+  | { kind: 'unusable'; variable: string; value: string; reason: string };
+
+export function resolveProxyForUrl(url: URL): ProxyResolution {
+  const protocol = url.protocol.split(':')[0];
+  // Matched on the host with any port stripped, which keeps the brackets on an
+  // IPv6 literal.
+  const hostname = url.host.replace(/:\d*$/, '');
+  if (!hostname || !protocol) {
+    return { kind: 'direct' };
+  }
+
+  const port = parseInt(url.port) || DEFAULT_PORTS[protocol] || 0;
+  if (!shouldProxy(hostname, port)) {
+    return { kind: 'direct' };
+  }
+
+  let source = readEnv(`${protocol}_proxy`);
+  if (!source.value) {
+    source = readEnv('all_proxy');
+  }
+  if (!source.value) {
+    return { kind: 'direct' };
+  }
+
+  // A value with no scheme takes the target's protocol, which is where this
+  // differs from `normalizeProxyURL` alone: that only defaults to http.
+  const scheme = source.value.includes('://') ? '' : `${protocol}://`;
+  const normalized = `${scheme}${source.value}`.trim();
+  // Playwright's own probe errors out on a proxy URL it cannot use instead of
+  // falling back to a direct request, so the gate must not clear here. Each
+  // cause is named, because the value alone often does not show it: redacting
+  // the credentials takes the offending character with them.
+  const unusable = (reason: string): ProxyResolution => ({
+    kind: 'unusable',
+    variable: source.variable,
+    value: withoutCredentials(source.value),
+    reason,
+  });
+
+  let proxy: URL;
+  try {
+    proxy = new URL(
+      /^\w+:\/\//.test(normalized) ? normalized : `http://${normalized}`
+    );
+  } catch {
+    return unusable('is not a valid url');
+  }
+  // Anything else parses but cannot be dialled: an http target throws out of
+  // `http.request`, and an https one gets `CONNECT` spoken at a port that is
+  // not answering HTTP, which surfaces much later as a refused server.
+  if (proxy.protocol !== 'http:' && proxy.protocol !== 'https:') {
+    return unusable('is not an http or https url');
+  }
+  // Credentials are percent-decoded when the request is built, far from the
+  // configuration that produced them, so a value that cannot be decoded is
+  // rejected here where the failure can still name where it came from.
+  try {
+    decodeURIComponent(proxy.username);
+    decodeURIComponent(proxy.password);
+  } catch {
+    return unusable('has credentials that are not valid percent-encoding');
+  }
+  return { kind: 'proxy', proxy };
+}
+
+// Probing both routes and taking whichever answers would avoid porting this,
+// but `no_proxy` is a directive about where traffic may go, not a hint: sending
+// the target URL to an excluded proxy would disclose it even when the direct
+// probe is the one that succeeds.
+function shouldProxy(hostname: string, port: number): boolean {
+  const noProxy = readEnv('no_proxy').value.toLowerCase();
+  if (!noProxy) {
+    return true;
+  }
+  if (noProxy === '*') {
+    return false;
+  }
+
+  return noProxy.split(/[,\s]/).every((entry) => {
+    if (!entry) {
+      return true;
+    }
+    const withPort = entry.match(/^(.+):(\d+)$/);
+    let host = withPort ? withPort[1] : entry;
+    const entryPort = withPort ? parseInt(withPort[2]) : 0;
+    if (entryPort && entryPort !== port) {
+      return true;
+    }
+    if (!/^[.*]/.test(host)) {
+      return hostname !== host;
+    }
+    if (host.charAt(0) === '*') {
+      host = host.slice(1);
+    }
+    return !hostname.endsWith(host);
+  });
+}
+
+// The executor runs in its own process, so a proxy variable the Playwright
+// config sets while loading (through `dotenv`, say) reaches Playwright's probe
+// and not this one. The name that was read is reported alongside the value so a
+// bad one can be found among the eight this looks at.
+function readEnv(name: string): { variable: string; value: string } {
+  const lower = name.toLowerCase();
+  if (process.env[lower]) {
+    return { variable: lower, value: process.env[lower] };
+  }
+  const upper = name.toUpperCase();
+  return { variable: upper, value: process.env[upper] || '' };
+}
+
+// A rejected value is echoed back so it can be recognized in the environment,
+// and it reaches the task log, so the credentials come off first.
+function withoutCredentials(value: string): string {
+  const at = value.lastIndexOf('@');
+  return at === -1 ? value : `***@${value.slice(at + 1)}`;
+}

--- a/packages/playwright/src/executors/wait-for-webserver/proxy.ts
+++ b/packages/playwright/src/executors/wait-for-webserver/proxy.ts
@@ -20,7 +20,10 @@ export type ProxyResolution =
   | { kind: 'proxy'; proxy: URL }
   | { kind: 'unusable'; variable: string; value: string; reason: string };
 
-export function resolveProxyForUrl(url: URL): ProxyResolution {
+export function resolveProxyForUrl(
+  url: URL,
+  env: NodeJS.ProcessEnv = process.env
+): ProxyResolution {
   const protocol = url.protocol.split(':')[0];
   // Matched on the host with any port stripped, which keeps the brackets on an
   // IPv6 literal.
@@ -30,13 +33,13 @@ export function resolveProxyForUrl(url: URL): ProxyResolution {
   }
 
   const port = parseInt(url.port) || DEFAULT_PORTS[protocol] || 0;
-  if (!shouldProxy(hostname, port)) {
+  if (!shouldProxy(hostname, port, env)) {
     return { kind: 'direct' };
   }
 
-  let source = readEnv(`${protocol}_proxy`);
+  let source = readEnv(`${protocol}_proxy`, env);
   if (!source.value) {
-    source = readEnv('all_proxy');
+    source = readEnv('all_proxy', env);
   }
   if (!source.value) {
     return { kind: 'direct' };
@@ -86,8 +89,12 @@ export function resolveProxyForUrl(url: URL): ProxyResolution {
 // `no_proxy` governs where traffic may go. Sending the target URL to an
 // excluded proxy would disclose it even when the direct probe is the one that
 // succeeds.
-function shouldProxy(hostname: string, port: number): boolean {
-  const noProxy = readEnv('no_proxy').value.toLowerCase();
+function shouldProxy(
+  hostname: string,
+  port: number,
+  env: NodeJS.ProcessEnv
+): boolean {
+  const noProxy = readEnv('no_proxy', env).value.toLowerCase();
   if (!noProxy) {
     return true;
   }
@@ -119,13 +126,16 @@ function shouldProxy(hostname: string, port: number): boolean {
 // config sets while loading (through `dotenv`, say) reaches Playwright's probe
 // and not this one. The name that was read is reported alongside the value so a
 // bad one can be found among the eight this looks at.
-function readEnv(name: string): { variable: string; value: string } {
+function readEnv(
+  name: string,
+  env: NodeJS.ProcessEnv
+): { variable: string; value: string } {
   const lower = name.toLowerCase();
-  if (process.env[lower]) {
-    return { variable: lower, value: process.env[lower] };
+  if (env[lower]) {
+    return { variable: lower, value: env[lower] };
   }
   const upper = name.toUpperCase();
-  return { variable: upper, value: process.env[upper] || '' };
+  return { variable: upper, value: env[upper] || '' };
 }
 
 // A rejected value is echoed back so it can be recognized in the environment,

--- a/packages/playwright/src/executors/wait-for-webserver/proxy.ts
+++ b/packages/playwright/src/executors/wait-for-webserver/proxy.ts
@@ -83,9 +83,9 @@ export function resolveProxyForUrl(url: URL): ProxyResolution {
   return { kind: 'proxy', proxy };
 }
 
-// `no_proxy` is a directive about where traffic may go, not a hint: sending the
-// target URL to an excluded proxy would disclose it even when the direct probe
-// is the one that succeeds.
+// `no_proxy` governs where traffic may go. Sending the target URL to an
+// excluded proxy would disclose it even when the direct probe is the one that
+// succeeds.
 function shouldProxy(hostname: string, port: number): boolean {
   const noProxy = readEnv('no_proxy').value.toLowerCase();
   if (!noProxy) {

--- a/packages/playwright/src/executors/wait-for-webserver/proxy.ts
+++ b/packages/playwright/src/executors/wait-for-webserver/proxy.ts
@@ -83,10 +83,9 @@ export function resolveProxyForUrl(url: URL): ProxyResolution {
   return { kind: 'proxy', proxy };
 }
 
-// Probing both routes and taking whichever answers would avoid porting this,
-// but `no_proxy` is a directive about where traffic may go, not a hint: sending
-// the target URL to an excluded proxy would disclose it even when the direct
-// probe is the one that succeeds.
+// `no_proxy` is a directive about where traffic may go, not a hint: sending the
+// target URL to an excluded proxy would disclose it even when the direct probe
+// is the one that succeeds.
 function shouldProxy(hostname: string, port: number): boolean {
   const noProxy = readEnv('no_proxy').value.toLowerCase();
   if (!noProxy) {

--- a/packages/playwright/src/executors/wait-for-webserver/proxy.ts
+++ b/packages/playwright/src/executors/wait-for-webserver/proxy.ts
@@ -130,7 +130,7 @@ function readEnv(name: string): { variable: string; value: string } {
 
 // A rejected value is echoed back so it can be recognized in the environment,
 // and it reaches the task log, so the credentials come off first.
-function withoutCredentials(value: string): string {
+export function withoutCredentials(value: string): string {
   const at = value.lastIndexOf('@');
   return at === -1 ? value : `***@${value.slice(at + 1)}`;
 }

--- a/packages/playwright/src/executors/wait-for-webserver/proxy.ts
+++ b/packages/playwright/src/executors/wait-for-webserver/proxy.ts
@@ -1,8 +1,8 @@
 // Playwright routes its readiness poll through a proxy configured in the
 // environment, so a gate that always connected directly would be answering a
 // different question than the check it exists to satisfy. Selection mirrors the
-// `proxy-from-env` copy Playwright bundles (`getProxyForUrl`) together with its
-// own `normalizeProxyURL`, checked against playwright-core 1.60.0. The
+// `proxy-from-env` copy playwright-core 1.60.0 bundles (`getProxyForUrl`)
+// together with its own `normalizeProxyURL`. The
 // transport is left to `https-proxy-agent`, the agent Playwright itself hands
 // to `https.request` for a proxied https target.
 

--- a/packages/playwright/src/executors/wait-for-webserver/proxy.ts
+++ b/packages/playwright/src/executors/wait-for-webserver/proxy.ts
@@ -2,9 +2,11 @@
 // environment, so a gate that always connected directly would be answering a
 // different question than the check it exists to satisfy. Selection mirrors the
 // `proxy-from-env` copy playwright-core 1.60.0 bundles (`getProxyForUrl`)
-// together with its own `normalizeProxyURL`. The
-// transport is left to `https-proxy-agent`, the agent Playwright itself hands
-// to `https.request` for a proxied https target.
+// together with its own `normalizeProxyURL`; with `npmConfigProxy` it mirrors
+// the copy bundled before 1.59.0, which read npm's `npm_config_*` proxy
+// variables ahead of the standard ones. The transport is left to
+// `https-proxy-agent`, the agent Playwright itself hands to `https.request`
+// for a proxied https target.
 
 const DEFAULT_PORTS: Record<string, number> = {
   ftp: 21,
@@ -22,7 +24,8 @@ export type ProxyResolution =
 
 export function resolveProxyForUrl(
   url: URL,
-  env: NodeJS.ProcessEnv = process.env
+  env: NodeJS.ProcessEnv = process.env,
+  npmConfigProxy = false
 ): ProxyResolution {
   const protocol = url.protocol.split(':')[0];
   // Matched on the host with any port stripped, which keeps the brackets on an
@@ -33,25 +36,35 @@ export function resolveProxyForUrl(
   }
 
   const port = parseInt(url.port) || DEFAULT_PORTS[protocol] || 0;
-  if (!shouldProxy(hostname, port, env)) {
+  if (!shouldProxy(hostname, port, env, npmConfigProxy)) {
     return { kind: 'direct' };
   }
-  return resolveProxyForProtocol(protocol, env);
+  return resolveProxyForProtocol(protocol, env, npmConfigProxy);
 }
 
 /**
  * The proxy `env` configures for `protocol`, before any `no_proxy` exclusion:
  * `<protocol>_proxy`, falling back to `all_proxy`, normalized as the probe
- * would use it (a value with no scheme takes the target's protocol).
+ * would use it (a value with no scheme takes the target's protocol). With
+ * `npmConfigProxy`, `npm_config_<protocol>_proxy` comes first and
+ * `npm_config_proxy` sits between the two.
  */
 export function resolveProxyForProtocol(
   protocol: string,
-  env: NodeJS.ProcessEnv = process.env
+  env: NodeJS.ProcessEnv = process.env,
+  npmConfigProxy = false
 ): ProxyResolution {
-  let source = readEnv(`${protocol}_proxy`, env);
-  if (!source.value) {
-    source = readEnv('all_proxy', env);
-  }
+  const source = readEnv(
+    npmConfigProxy
+      ? [
+          `npm_config_${protocol}_proxy`,
+          `${protocol}_proxy`,
+          'npm_config_proxy',
+          'all_proxy',
+        ]
+      : [`${protocol}_proxy`, 'all_proxy'],
+    env
+  );
   if (!source.value) {
     return { kind: 'direct' };
   }
@@ -103,9 +116,10 @@ export function resolveProxyForProtocol(
 function shouldProxy(
   hostname: string,
   port: number,
-  env: NodeJS.ProcessEnv
+  env: NodeJS.ProcessEnv,
+  npmConfigProxy: boolean
 ): boolean {
-  const noProxy = readEnv('no_proxy', env).value.toLowerCase();
+  const noProxy = readNoProxy(env, npmConfigProxy).toLowerCase();
   if (!noProxy) {
     return true;
   }
@@ -113,7 +127,7 @@ function shouldProxy(
     return false;
   }
 
-  return noProxyEntries(env).every((entry) => {
+  return noProxyEntries(env, npmConfigProxy).every((entry) => {
     const withPort = entry.match(/^(.+):(\d+)$/);
     let host = withPort ? withPort[1] : entry;
     const entryPort = withPort ? parseInt(withPort[2]) : 0;
@@ -131,31 +145,45 @@ function shouldProxy(
 }
 
 /**
- * The `no_proxy` entries `env` configures, lowercased and with the empty
- * entries a separator run leaves dropped. Each entry excludes hosts on its own,
- * so their order carries no meaning.
+ * The `no_proxy` entries `env` configures (`npm_config_no_proxy` first with
+ * `npmConfigProxy`), lowercased and with the empty entries a separator run
+ * leaves dropped. Each entry excludes hosts on its own, so their order carries
+ * no meaning.
  */
-export function noProxyEntries(env: NodeJS.ProcessEnv): string[] {
-  return readEnv('no_proxy', env)
-    .value.toLowerCase()
+export function noProxyEntries(
+  env: NodeJS.ProcessEnv,
+  npmConfigProxy = false
+): string[] {
+  return readNoProxy(env, npmConfigProxy)
+    .toLowerCase()
     .split(/[,\s]/)
     .filter(Boolean);
+}
+
+function readNoProxy(env: NodeJS.ProcessEnv, npmConfigProxy: boolean): string {
+  return readEnv(
+    npmConfigProxy ? ['npm_config_no_proxy', 'no_proxy'] : ['no_proxy'],
+    env
+  ).value;
 }
 
 // The executor runs in its own process, so a proxy variable the Playwright
 // config sets while loading (through `dotenv`, say) reaches Playwright's probe
 // and not this one. The name that was read is reported alongside the value so a
-// bad one can be found among the eight this looks at.
+// bad one can be found among the variables this looks at. The first name with
+// a value wins, in the lowercase spelling before the uppercase one.
 function readEnv(
-  name: string,
+  names: string[],
   env: NodeJS.ProcessEnv
 ): { variable: string; value: string } {
-  const lower = name.toLowerCase();
-  if (env[lower]) {
-    return { variable: lower, value: env[lower] };
+  for (const name of names) {
+    for (const variable of [name.toLowerCase(), name.toUpperCase()]) {
+      if (env[variable]) {
+        return { variable, value: env[variable] };
+      }
+    }
   }
-  const upper = name.toUpperCase();
-  return { variable: upper, value: env[upper] || '' };
+  return { variable: names[names.length - 1].toUpperCase(), value: '' };
 }
 
 // A rejected value is echoed back so it can be recognized in the environment,

--- a/packages/playwright/src/executors/wait-for-webserver/proxy.ts
+++ b/packages/playwright/src/executors/wait-for-webserver/proxy.ts
@@ -36,7 +36,18 @@ export function resolveProxyForUrl(
   if (!shouldProxy(hostname, port, env)) {
     return { kind: 'direct' };
   }
+  return resolveProxyForProtocol(protocol, env);
+}
 
+/**
+ * The proxy `env` configures for `protocol`, before any `no_proxy` exclusion:
+ * `<protocol>_proxy`, falling back to `all_proxy`, normalized as the probe
+ * would use it (a value with no scheme takes the target's protocol).
+ */
+export function resolveProxyForProtocol(
+  protocol: string,
+  env: NodeJS.ProcessEnv = process.env
+): ProxyResolution {
   let source = readEnv(`${protocol}_proxy`, env);
   if (!source.value) {
     source = readEnv('all_proxy', env);
@@ -102,10 +113,7 @@ function shouldProxy(
     return false;
   }
 
-  return noProxy.split(/[,\s]/).every((entry) => {
-    if (!entry) {
-      return true;
-    }
+  return noProxyEntries(env).every((entry) => {
     const withPort = entry.match(/^(.+):(\d+)$/);
     let host = withPort ? withPort[1] : entry;
     const entryPort = withPort ? parseInt(withPort[2]) : 0;
@@ -120,6 +128,18 @@ function shouldProxy(
     }
     return !hostname.endsWith(host);
   });
+}
+
+/**
+ * The `no_proxy` entries `env` configures, lowercased and with the empty
+ * entries a separator run leaves dropped. Each entry excludes hosts on its own,
+ * so their order carries no meaning.
+ */
+export function noProxyEntries(env: NodeJS.ProcessEnv): string[] {
+  return readEnv('no_proxy', env)
+    .value.toLowerCase()
+    .split(/[,\s]/)
+    .filter(Boolean);
 }
 
 // The executor runs in its own process, so a proxy variable the Playwright

--- a/packages/playwright/src/executors/wait-for-webserver/schema.d.ts
+++ b/packages/playwright/src/executors/wait-for-webserver/schema.d.ts
@@ -1,0 +1,8 @@
+export type Schema = {
+  servers: Array<{
+    port?: number;
+    url?: string;
+    ignoreHTTPSErrors?: boolean;
+  }>;
+  timeout?: number;
+};

--- a/packages/playwright/src/executors/wait-for-webserver/schema.d.ts
+++ b/packages/playwright/src/executors/wait-for-webserver/schema.d.ts
@@ -3,6 +3,7 @@ export type Schema = {
     port?: number;
     url?: string;
     ignoreHTTPSErrors?: boolean;
+    timeout?: number;
   }>;
   timeout?: number;
 };

--- a/packages/playwright/src/executors/wait-for-webserver/schema.json
+++ b/packages/playwright/src/executors/wait-for-webserver/schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/schema",
   "version": 2,
   "title": "Schema for Playwright Wait For Web Server Executor",
-  "description": "Waits for the E2E web server(s) to be ready before the Playwright test tasks run.",
+  "description": "Waits for the E2E web server(s) to be ready.",
   "type": "object",
   "properties": {
     "servers": {
@@ -14,7 +14,7 @@
           "port": {
             "type": "number",
             "description": "The port to wait for TCP connections on.",
-            "minimum": 0,
+            "minimum": 1,
             "maximum": 65535,
             "multipleOf": 1
           },

--- a/packages/playwright/src/executors/wait-for-webserver/schema.json
+++ b/packages/playwright/src/executors/wait-for-webserver/schema.json
@@ -20,7 +20,7 @@
           },
           "url": {
             "type": "string",
-            "description": "The URL to poll. Redirects are followed and the server is ready once the final response has a status below 404."
+            "description": "The URL to poll. Redirects are followed and the server is ready once the final response has a status from 200 to 403."
           },
           "ignoreHTTPSErrors": {
             "type": "boolean",

--- a/packages/playwright/src/executors/wait-for-webserver/schema.json
+++ b/packages/playwright/src/executors/wait-for-webserver/schema.json
@@ -2,7 +2,7 @@
   "$schema": "https://json-schema.org/schema",
   "version": 2,
   "title": "Schema for Playwright Wait For Web Server Executor",
-  "description": "Waits for the E2E web server(s) to be ready before the Playwright CI test tasks run.",
+  "description": "Waits for the E2E web server(s) to be ready before the Playwright test tasks run.",
   "type": "object",
   "properties": {
     "servers": {
@@ -13,24 +13,31 @@
         "properties": {
           "port": {
             "type": "number",
-            "description": "The port to wait for TCP connections on."
+            "description": "The port to wait for TCP connections on.",
+            "minimum": 0,
+            "maximum": 65535,
+            "multipleOf": 1
           },
           "url": {
             "type": "string",
-            "description": "The URL to poll until the server responds with a 2xx, 3xx, or early 4xx status."
+            "description": "The URL to poll. Redirects are followed and the server is ready once the final response has a status below 404."
           },
           "ignoreHTTPSErrors": {
             "type": "boolean",
             "description": "Whether to ignore HTTPS errors (e.g. a self-signed certificate) when polling the URL.",
             "default": false
+          },
+          "timeout": {
+            "type": "number",
+            "description": "The maximum time to wait for this server in milliseconds. Defaults to 60000.",
+            "default": 60000
           }
         }
       }
     },
     "timeout": {
       "type": "number",
-      "description": "The maximum time to wait in milliseconds before failing.",
-      "default": 60000
+      "description": "The maximum time to wait in milliseconds before failing. Overrides the timeout configured on every server."
     }
   },
   "required": ["servers"]

--- a/packages/playwright/src/executors/wait-for-webserver/schema.json
+++ b/packages/playwright/src/executors/wait-for-webserver/schema.json
@@ -1,0 +1,37 @@
+{
+  "$schema": "https://json-schema.org/schema",
+  "version": 2,
+  "title": "Schema for Playwright Wait For Web Server Executor",
+  "description": "Waits for the E2E web server(s) to be ready before the Playwright CI test tasks run.",
+  "type": "object",
+  "properties": {
+    "servers": {
+      "type": "array",
+      "description": "The web servers to wait for.",
+      "items": {
+        "type": "object",
+        "properties": {
+          "port": {
+            "type": "number",
+            "description": "The port to wait for TCP connections on."
+          },
+          "url": {
+            "type": "string",
+            "description": "The URL to poll until the server responds with a 2xx, 3xx, or early 4xx status."
+          },
+          "ignoreHTTPSErrors": {
+            "type": "boolean",
+            "description": "Whether to ignore HTTPS errors (e.g. a self-signed certificate) when polling the URL.",
+            "default": false
+          }
+        }
+      }
+    },
+    "timeout": {
+      "type": "number",
+      "description": "The maximum time to wait in milliseconds before failing.",
+      "default": 60000
+    }
+  },
+  "required": ["servers"]
+}

--- a/packages/playwright/src/executors/wait-for-webserver/schema.json
+++ b/packages/playwright/src/executors/wait-for-webserver/schema.json
@@ -29,7 +29,7 @@
           },
           "timeout": {
             "type": "number",
-            "description": "The maximum time to wait for this server in milliseconds. Defaults to 60000.",
+            "description": "The maximum time to wait for this server in milliseconds. A value of 0 means unset, as it does for Playwright's webServer.timeout. Defaults to 60000.",
             "default": 60000
           }
         }
@@ -37,7 +37,7 @@
     },
     "timeout": {
       "type": "number",
-      "description": "The maximum time to wait in milliseconds before failing. Overrides the timeout configured on every server."
+      "description": "The maximum time to wait in milliseconds before failing. Overrides the timeout configured on every server. A value of 0 means unset, as it does for Playwright's webServer.timeout."
     }
   },
   "required": ["servers"]

--- a/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.spec.ts
+++ b/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.spec.ts
@@ -1,4 +1,3 @@
-import { EventEmitter } from 'node:events';
 import { createServer as createHttpServer, type Server } from 'node:http';
 import * as https from 'node:https';
 import { createServer as createTcpServer } from 'node:net';
@@ -7,11 +6,12 @@ import { logger, type ExecutorContext } from '@nx/devkit';
 import waitForWebserverExecutor from './wait-for-webserver.impl';
 
 // Replaces the module registry entry rather than spying on the namespace, which
-// the transpiler copies per importer.
-jest.mock('node:https', () => ({
-  ...jest.requireActual('node:https'),
-  request: jest.fn(),
-}));
+// the transpiler copies per importer. The spy calls through, so a test can read
+// what the request became on the wire instead of only what it was asked for.
+jest.mock('node:https', () => {
+  const actual = jest.requireActual('node:https');
+  return { ...actual, request: jest.fn(actual.request) };
+});
 
 const context = {} as ExecutorContext;
 
@@ -20,13 +20,28 @@ const openServers = new Set<AnyServer>();
 
 describe('waitForWebserverExecutor', () => {
   let errorSpy: jest.SpyInstance;
+  let savedProxyEnv: Record<string, string | undefined>;
 
   beforeEach(() => {
     errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => {});
+    // Every url probe reads these now, so a developer with a proxy configured
+    // would otherwise have loopback probes routed at it for the whole file.
+    savedProxyEnv = {};
+    for (const name of PROXY_VARS) {
+      savedProxyEnv[name] = process.env[name];
+      delete process.env[name];
+    }
   });
 
   afterEach(async () => {
     errorSpy.mockRestore();
+    for (const [name, value] of Object.entries(savedProxyEnv)) {
+      if (value === undefined) {
+        delete process.env[name];
+      } else {
+        process.env[name] = value;
+      }
+    }
     // Closing at the end of a test would be skipped by a failing assertion,
     // leaving a listening handle behind for the rest of the worker's life.
     await Promise.all(
@@ -136,14 +151,39 @@ describe('waitForWebserverExecutor', () => {
 
     expect(result).toEqual({ success: false });
     expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining('redirected more than')
+      expect.stringContaining('times without resolving')
     );
+  });
+
+  it('follows a redirect chain past ten hops, like Playwright', async () => {
+    const server = createHttpServer((req, res) => {
+      const hop = Number(req.url.slice(1)) || 0;
+      if (hop < 15) {
+        res.statusCode = 302;
+        res.setHeader('location', `/${hop + 1}`);
+        res.end();
+        return;
+      }
+      res.statusCode = 200;
+      res.end();
+    });
+    await listen(server, 0);
+    const { port } = server.address() as AddressInfo;
+
+    const result = await waitForWebserverExecutor(
+      { servers: [{ url: `http://127.0.0.1:${port}` }] },
+      context
+    );
+
+    expect(result).toEqual({ success: true });
   });
 
   it('does not treat a redirect to an unparseable location as ready', async () => {
     const server = createHttpServer((_req, res) => {
       res.statusCode = 302;
-      res.setHeader('location', 'http://');
+      // Node's parser accepts the C1 controls in a header value, and this one
+      // opens an escape sequence on the terminal the message is read on.
+      res.setHeader('location', 'http://[\u009b31mred');
       res.end();
     });
     await listen(server, 0);
@@ -155,8 +195,33 @@ describe('waitForWebserverExecutor', () => {
     );
 
     expect(result).toEqual({ success: false });
+    const [message] = errorSpy.mock.calls[0];
+    expect(message).toContain(
+      'redirected to an invalid location "http://[31mred"'
+    );
+    expect(message).not.toContain('\u009b');
+  });
+
+  it('reports how far a redirect chain got when a hop fails to connect', async () => {
+    const deadPort = await closedPort();
+    const server = createHttpServer((_req, res) => {
+      res.statusCode = 302;
+      res.setHeader('location', `http://127.0.0.1:${deadPort}/`);
+      res.end();
+    });
+    await listen(server, 0);
+    const { port } = server.address() as AddressInfo;
+
+    const result = await waitForWebserverExecutor(
+      { servers: [{ url: `http://127.0.0.1:${port}` }], timeout: 300 },
+      context
+    );
+
+    // Without the hop count this reads as the configured server refusing
+    // connections, which is the one thing it is known not to be doing.
+    expect(result).toEqual({ success: false });
     expect(errorSpy).toHaveBeenCalledWith(
-      expect.stringContaining('redirected to an invalid location')
+      expect.stringContaining('ECONNREFUSED after 1 redirects')
     );
   });
 
@@ -458,11 +523,11 @@ describe('waitForWebserverExecutor', () => {
     'polls https urls with ignoreHTTPSErrors $ignoreHTTPSErrors',
     async ({ ignoreHTTPSErrors, rejectUnauthorized }) => {
       const request = https.request as unknown as jest.Mock;
-      request.mockImplementation(unreachableRequest);
+      const port = await closedPort();
 
       const result = await waitForWebserverExecutor(
         {
-          servers: [{ url: 'https://127.0.0.1:9999', ignoreHTTPSErrors }],
+          servers: [{ url: `https://127.0.0.1:${port}`, ignoreHTTPSErrors }],
           timeout: 300,
         },
         context
@@ -474,28 +539,337 @@ describe('waitForWebserverExecutor', () => {
         expect.objectContaining({ rejectUnauthorized }),
         expect.any(Function)
       );
-      request.mockReset();
+      request.mockClear();
     }
   );
+
+  describe('with a proxy configured', () => {
+    // The origin answers 503 and the proxy answers 200, so the result alone
+    // says which route the probe took.
+    async function startSplitRoutes() {
+      const origin = createHttpServer((_req, res) => {
+        res.statusCode = 503;
+        res.end();
+      });
+      await listen(origin, 0);
+
+      const forwarded: string[] = [];
+      const proxy = createHttpServer((req, res) => {
+        forwarded.push(req.url);
+        res.statusCode = 200;
+        res.end();
+      });
+      await listen(proxy, 0);
+
+      return {
+        forwarded,
+        originUrl: `http://127.0.0.1:${(origin.address() as AddressInfo).port}`,
+        proxyUrl: `http://127.0.0.1:${(proxy.address() as AddressInfo).port}`,
+      };
+    }
+
+    it('polls an http url through the proxy instead of directly', async () => {
+      const { forwarded, originUrl, proxyUrl } = await startSplitRoutes();
+      process.env.HTTP_PROXY = proxyUrl;
+
+      const result = await waitForWebserverExecutor(
+        { servers: [{ url: originUrl }], timeout: 2000 },
+        context
+      );
+
+      expect(result).toEqual({ success: true });
+      // An absolute-form target is what a proxy is given, so this also proves
+      // the request was not simply sent to the origin.
+      expect(forwarded).toEqual([`${originUrl}/`]);
+    });
+
+    it('goes direct when no_proxy covers the host', async () => {
+      const { forwarded, originUrl, proxyUrl } = await startSplitRoutes();
+      process.env.HTTP_PROXY = proxyUrl;
+      process.env.NO_PROXY = '127.0.0.1';
+
+      const result = await waitForWebserverExecutor(
+        { servers: [{ url: originUrl }], timeout: 300 },
+        context
+      );
+
+      expect(result).toEqual({ success: false });
+      expect(forwarded).toEqual([]);
+    });
+
+    it('fails rather than falling back to a direct request when the proxy is unreachable', async () => {
+      const ready = createHttpServer((_req, res) => {
+        res.statusCode = 200;
+        res.end();
+      });
+      await listen(ready, 0);
+      const url = `http://127.0.0.1:${(ready.address() as AddressInfo).port}`;
+      process.env.HTTP_PROXY = 'http://127.0.0.1:1';
+
+      const result = await waitForWebserverExecutor(
+        { servers: [{ url }], timeout: 300 },
+        context
+      );
+
+      expect(result).toEqual({ success: false });
+    });
+
+    // Answers the tunnel request and then nothing, which is as far as a probe
+    // can get without a certificate for the origin behind it.
+    async function startTunnellingProxy(answer = true) {
+      const tunnelled: string[] = [];
+      const credentials: Array<string | undefined> = [];
+      // Nothing on this side of the tunnel owns these, and the proxy cannot
+      // finish closing while they are open.
+      const tunnels: Array<{ destroy: () => void }> = [];
+      const proxy = createHttpServer();
+      proxy.on('connect', (req, socket) => {
+        tunnelled.push(req.url);
+        credentials.push(req.headers['proxy-authorization']);
+        tunnels.push(socket);
+        if (answer) {
+          socket.write('HTTP/1.1 200 Connection Established\r\n\r\n');
+        }
+      });
+      await listen(proxy, 0);
+
+      return {
+        tunnelled,
+        credentials,
+        release: () => tunnels.forEach((tunnel) => tunnel.destroy()),
+        proxyUrl: `http://127.0.0.1:${(proxy.address() as AddressInfo).port}`,
+      };
+    }
+
+    it('tunnels an https url through the proxy and addresses the origin', async () => {
+      const { tunnelled, release, proxyUrl } = await startTunnellingProxy();
+      process.env.HTTPS_PROXY = proxyUrl;
+      const request = https.request as unknown as jest.Mock;
+
+      const result = await waitForWebserverExecutor(
+        { servers: [{ url: 'https://example.test:8443' }], timeout: 300 },
+        context
+      );
+      release();
+
+      expect(result).toEqual({ success: false });
+      expect(tunnelled).toContain('example.test:8443');
+      // A tunnelled request has to name the origin rather than the proxy it
+      // travelled through. Reading the header back off the request is what
+      // separates that from merely intending to.
+      expect(request.mock.results[0].value.getHeader('host')).toBe(
+        'example.test:8443'
+      );
+      request.mockClear();
+    });
+
+    it('tunnels to a host given as an ip address', async () => {
+      const { tunnelled, release, proxyUrl } = await startTunnellingProxy();
+      process.env.HTTPS_PROXY = proxyUrl;
+
+      const result = await waitForWebserverExecutor(
+        { servers: [{ url: 'https://127.0.0.1:8443' }], timeout: 300 },
+        context
+      );
+      release();
+
+      // An ip address is not a valid TLS server name, and the agent leaves it
+      // off rather than failing over it, so the tunnel is asked for the same
+      // way as one to a host name. Nothing answers behind it, so the probe ends
+      // on the readiness budget.
+      expect(tunnelled).toContain('127.0.0.1:8443');
+      expect(result).toEqual({ success: false });
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Timed out after 300ms')
+      );
+    });
+
+    it('sends proxy credentials on the tunnel request', async () => {
+      const { credentials, release, proxyUrl } = await startTunnellingProxy();
+      process.env.HTTPS_PROXY = proxyUrl.replace(
+        'http://',
+        'http://user:pa%3Ass@'
+      );
+
+      await waitForWebserverExecutor(
+        { servers: [{ url: 'https://example.test:8443' }], timeout: 300 },
+        context
+      );
+      release();
+
+      // Decoded before they are encoded again, so a credential containing a
+      // reserved character survives the round trip.
+      expect(credentials[0]).toBe(
+        `Basic ${Buffer.from('user:pa:ss').toString('base64')}`
+      );
+    });
+
+    it('sends proxy credentials on an absolute-form request', async () => {
+      const seen: Array<string | undefined> = [];
+      const proxy = createHttpServer((req, res) => {
+        seen.push(req.headers.authorization);
+        res.statusCode = 200;
+        res.end();
+      });
+      await listen(proxy, 0);
+      const { port } = proxy.address() as AddressInfo;
+      process.env.HTTP_PROXY = `http://user:pa%3Ass@127.0.0.1:${port}`;
+
+      const result = await waitForWebserverExecutor(
+        { servers: [{ url: 'http://example.test:4200' }], timeout: 300 },
+        context
+      );
+
+      // Playwright hands the proxy url straight to `http.request`, so Node
+      // derives the header from its userinfo and names it `Authorization`.
+      expect(result).toEqual({ success: true });
+      expect(seen[0]).toBe(
+        `Basic ${Buffer.from('user:pa:ss').toString('base64')}`
+      );
+    });
+
+    it('gives up on a proxy that accepts the connection and never answers', async () => {
+      const { release, proxyUrl } = await startTunnellingProxy(false);
+      process.env.HTTPS_PROXY = proxyUrl;
+      const request = https.request as unknown as jest.Mock;
+
+      const result = await waitForWebserverExecutor(
+        { servers: [{ url: 'https://example.test:8443' }], timeout: 300 },
+        context
+      );
+      const { agent } = request.mock.calls[0][1];
+      release();
+
+      // A request still waiting on the tunnel holds no socket to time itself
+      // out on, so the wait has to end from the outside. Destroying the request
+      // cannot reach the connection the agent opened either, since the agent
+      // keeps it private until `CONNECT` returns, so aborting the signal the
+      // agent was given is what closes it.
+      expect(result).toEqual({ success: false });
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Timed out after 300ms')
+      );
+      expect(agent.connectOpts.signal.aborted).toBe(true);
+      request.mockClear();
+    });
+
+    it('names the proxy when it is the one refusing the connection', async () => {
+      const ready = createHttpServer((_req, res) => {
+        res.statusCode = 200;
+        res.end();
+      });
+      await listen(ready, 0);
+      const url = `http://127.0.0.1:${(ready.address() as AddressInfo).port}`;
+      process.env.HTTP_PROXY = 'http://127.0.0.1:1';
+
+      await waitForWebserverExecutor(
+        { servers: [{ url }], timeout: 300 },
+        context
+      );
+
+      // The server here is up and serving, so blaming it would send whoever
+      // reads this looking in the wrong place.
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('ECONNREFUSED via the proxy at 127.0.0.1:1')
+      );
+    });
+
+    it('names the proxy when it answers instead of the server', async () => {
+      const proxy = createHttpServer((_req, res) => {
+        res.statusCode = 407;
+        res.setHeader('proxy-authenticate', 'Basic realm="corp"');
+        res.end();
+      });
+      await listen(proxy, 0);
+      const { port } = proxy.address() as AddressInfo;
+      process.env.HTTP_PROXY = `http://127.0.0.1:${port}`;
+
+      await waitForWebserverExecutor(
+        { servers: [{ url: 'http://example.test:4200' }], timeout: 300 },
+        context
+      );
+
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          `responded with status 407 via the proxy at 127.0.0.1:${port}`
+        )
+      );
+    });
+
+    it('names the proxy when a redirect through it cannot be followed', async () => {
+      const proxy = createHttpServer((_req, res) => {
+        res.statusCode = 302;
+        res.setHeader('location', 'http://');
+        res.end();
+      });
+      await listen(proxy, 0);
+      const { port } = proxy.address() as AddressInfo;
+      process.env.HTTP_PROXY = `http://127.0.0.1:${port}`;
+
+      await waitForWebserverExecutor(
+        { servers: [{ url: 'http://example.test:4200' }], timeout: 300 },
+        context
+      );
+
+      // The redirect came from the proxy, so the server named in the config had
+      // no part in it.
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          `redirected to an invalid location "http://" via the proxy at 127.0.0.1:${port}`
+        )
+      );
+    });
+
+    it('rejects a proxy url it cannot use instead of waiting on the server', async () => {
+      process.env.HTTP_PROXY = 'http://user:100%@corp:8080';
+
+      const result = await waitForWebserverExecutor(
+        { servers: [{ url: 'http://127.0.0.1:4200' }], timeout: 30000 },
+        context
+      );
+
+      expect(result).toEqual({ success: false });
+      const [message] = errorSpy.mock.calls[0];
+      // Naming the variable is what makes it findable among the eight that are
+      // read; the timeout wording would mean the value was retried instead.
+      expect(message).toContain(
+        'cannot use the proxy configured in HTTP_PROXY: ***@corp:8080 has credentials that are not valid percent-encoding'
+      );
+      expect(message).not.toContain('Timed out');
+      expect(message).not.toContain('100%');
+    });
+
+    it('rejects a proxy scheme neither request can be sent over', async () => {
+      process.env.HTTP_PROXY = 'socks5://127.0.0.1:1080';
+
+      const result = await waitForWebserverExecutor(
+        { servers: [{ url: 'http://127.0.0.1:4200' }], timeout: 30000 },
+        context
+      );
+
+      // Left to run, this throws out of `http.request` with a message naming
+      // neither the server nor the variable that caused it.
+      expect(result).toEqual({ success: false });
+      // Matched whole: a message worded as a timeout would mean the value was
+      // retried for 30 seconds first, and the wait appends the sentence's own
+      // full stop.
+      expect(errorSpy.mock.calls[0][0]).toBe(
+        '@nx/playwright:wait-for-webserver cannot use the proxy configured in HTTP_PROXY: socks5://127.0.0.1:1080 is not an http or https url.'
+      );
+    });
+  });
 });
 
-// Stands in for an https endpoint that refuses connections, so the TLS options
-// the executor builds can be asserted without a certificate.
-function unreachableRequest(): any {
-  const request = new EventEmitter() as any;
-  request.destroy = () => {};
-  request.end = () =>
-    setImmediate(() =>
-      request.emit(
-        'error',
-        Object.assign(new Error('connect ECONNREFUSED'), {
-          code: 'ECONNREFUSED',
-        })
-      )
-    );
-
-  return request;
-}
+const PROXY_VARS = [
+  'http_proxy',
+  'HTTP_PROXY',
+  'https_proxy',
+  'HTTPS_PROXY',
+  'all_proxy',
+  'ALL_PROXY',
+  'no_proxy',
+  'NO_PROXY',
+];
 
 function listen(server: AnyServer, port: number): Promise<void> {
   return new Promise<void>((resolve, reject) => {
@@ -508,6 +882,16 @@ function listen(server: AnyServer, port: number): Promise<void> {
       resolve();
     });
   });
+}
+
+// Bound and released rather than picked, so the probe cannot land on whatever
+// the developer running the suite happens to have listening.
+async function closedPort(): Promise<number> {
+  const server = createTcpServer();
+  await listen(server, 0);
+  const { port } = server.address() as AddressInfo;
+  await close(server);
+  return port;
 }
 
 function close(server: AnyServer): Promise<void> {

--- a/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.spec.ts
+++ b/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.spec.ts
@@ -15,6 +15,9 @@ jest.mock('node:https', () => ({
 
 const context = {} as ExecutorContext;
 
+type AnyServer = Server | ReturnType<typeof createTcpServer>;
+const openServers = new Set<AnyServer>();
+
 describe('waitForWebserverExecutor', () => {
   let errorSpy: jest.SpyInstance;
 
@@ -22,8 +25,13 @@ describe('waitForWebserverExecutor', () => {
     errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => {});
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     errorSpy.mockRestore();
+    // Closing at the end of a test would be skipped by a failing assertion,
+    // leaving a listening handle behind for the rest of the worker's life.
+    await Promise.all(
+      [...openServers].map((server) => close(server).catch(() => {}))
+    );
   });
 
   it('resolves once a TCP server accepts connections on the port', async () => {
@@ -37,7 +45,6 @@ describe('waitForWebserverExecutor', () => {
     );
 
     expect(result).toEqual({ success: true });
-    await close(server);
   });
 
   it('resolves once an HTTP server responds with a 2xx status', async () => {
@@ -51,7 +58,6 @@ describe('waitForWebserverExecutor', () => {
     );
 
     expect(result).toEqual({ success: true });
-    await close(server);
   });
 
   it('treats an early 4xx (e.g. 403) response as ready, like Playwright', async () => {
@@ -68,7 +74,6 @@ describe('waitForWebserverExecutor', () => {
     );
 
     expect(result).toEqual({ success: true });
-    await close(server);
   });
 
   it('falls back to /index.html when the root url returns 404', async () => {
@@ -85,7 +90,6 @@ describe('waitForWebserverExecutor', () => {
     );
 
     expect(result).toEqual({ success: true });
-    await close(server);
   });
 
   it('follows redirects and evaluates the destination status, like Playwright', async () => {
@@ -113,7 +117,6 @@ describe('waitForWebserverExecutor', () => {
     // The 302 alone already sits inside the ready window, so only the request
     // to the destination proves the chain was actually followed.
     expect(requested).toEqual(['/', '/ready']);
-    await close(server);
   });
 
   it('does not treat an endless redirect loop as ready', async () => {
@@ -135,7 +138,6 @@ describe('waitForWebserverExecutor', () => {
     expect(errorSpy).toHaveBeenCalledWith(
       expect.stringContaining('redirected more than')
     );
-    await close(server);
   });
 
   it('does not treat a redirect to an unparseable location as ready', async () => {
@@ -156,7 +158,6 @@ describe('waitForWebserverExecutor', () => {
     expect(errorSpy).toHaveBeenCalledWith(
       expect.stringContaining('redirected to an invalid location')
     );
-    await close(server);
   });
 
   it('waits for every configured server, not just the first', async () => {
@@ -177,7 +178,6 @@ describe('waitForWebserverExecutor', () => {
     );
 
     expect(result).toEqual({ success: false });
-    await close(ready);
   });
 
   it('does not treat a redirect to an unavailable destination as ready', async () => {
@@ -200,7 +200,6 @@ describe('waitForWebserverExecutor', () => {
     );
 
     expect(result).toEqual({ success: false });
-    await close(server);
   });
 
   it('waits for a slow endpoint that responds past the retry interval, like Playwright', async () => {
@@ -219,7 +218,6 @@ describe('waitForWebserverExecutor', () => {
     );
 
     expect(result).toEqual({ success: true });
-    await close(server);
   }, 10000);
 
   it('does not treat a 5xx response as ready', async () => {
@@ -236,7 +234,6 @@ describe('waitForWebserverExecutor', () => {
     );
 
     expect(result).toEqual({ success: false });
-    await close(server);
   });
 
   it('fails when the server never becomes reachable before the timeout', async () => {
@@ -288,16 +285,67 @@ describe('waitForWebserverExecutor', () => {
     await listen(server, 0);
     const { port } = server.address() as AddressInfo;
 
+    // Room for at least one full request/response, otherwise the wait ends
+    // without ever observing the status it is meant to report.
     await waitForWebserverExecutor(
-      { servers: [{ url: `http://127.0.0.1:${port}` }], timeout: 300 },
+      { servers: [{ url: `http://127.0.0.1:${port}` }], timeout: 1000 },
       context
     );
 
     expect(errorSpy).toHaveBeenCalledWith(
       expect.stringContaining('responded with status 503')
     );
-    await close(server);
   });
+
+  it('keeps the observed status when a later probe is cut short before it can learn anything', async () => {
+    let responses = 0;
+    const server = createHttpServer((_req, res) => {
+      // Only the first request is answered. The next one is still waiting when
+      // the deadline arrives, too early to call the server unresponsive.
+      if (responses++ === 0) {
+        res.statusCode = 503;
+        res.end();
+      }
+    });
+    await listen(server, 0);
+    const { port } = server.address() as AddressInfo;
+
+    await waitForWebserverExecutor(
+      { servers: [{ url: `http://127.0.0.1:${port}` }], timeout: 500 },
+      context
+    );
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('responded with status 503')
+    );
+  });
+
+  it('reports a server that answers nothing rather than an earlier failure it has moved past', async () => {
+    // Bind and release a port so the first probe is refused, then listen on
+    // it with a handler that never answers.
+    const placeholder = createTcpServer();
+    await listen(placeholder, 0);
+    const { port } = placeholder.address() as AddressInfo;
+    await close(placeholder);
+    const server = createHttpServer(() => {});
+    const timer = setTimeout(
+      () => void listen(server, port).catch(() => {}),
+      50
+    );
+
+    await waitForWebserverExecutor(
+      { servers: [{ url: `http://127.0.0.1:${port}` }], timeout: 2000 },
+      context
+    );
+
+    clearTimeout(timer);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('did not respond')
+    );
+    expect(errorSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('ECONNREFUSED')
+    );
+  }, 10000);
 
   it('reports the connection error when a port never accepts connections', async () => {
     const server = createTcpServer();
@@ -347,7 +395,7 @@ describe('waitForWebserverExecutor', () => {
     expect(Date.now() - start).toBeLessThan(3000);
   });
 
-  it.each([NaN, -1, 65536, 1.5])(
+  it.each([NaN, -1, 0, 65536, 1.5])(
     'fails immediately when the port (%p) cannot be connected to rather than retrying it',
     async (port) => {
       const start = Date.now();
@@ -385,7 +433,10 @@ describe('waitForWebserverExecutor', () => {
       await close(server);
       // Comes up after the first probe has already failed, so a 0 read as
       // "give up immediately" would never see it.
-      const timer = setTimeout(() => void listen(server, port), 300);
+      const timer = setTimeout(
+        () => void listen(server, port).catch(() => {}),
+        300
+      );
 
       const result = await waitForWebserverExecutor(
         level === 'the server'
@@ -396,7 +447,6 @@ describe('waitForWebserverExecutor', () => {
 
       expect(result).toEqual({ success: true });
       clearTimeout(timer);
-      await close(server);
     },
     10000
   );
@@ -447,18 +497,21 @@ function unreachableRequest(): any {
   return request;
 }
 
-function listen(
-  server: Server | ReturnType<typeof createTcpServer>,
-  port: number
-): Promise<void> {
-  return new Promise<void>((resolve) =>
-    server.listen(port, '127.0.0.1', () => resolve())
-  );
+function listen(server: AnyServer, port: number): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    // A released port can be taken again before a test re-listens on it, which
+    // would otherwise surface as an uncaught EADDRINUSE and kill the worker.
+    server.once('error', reject);
+    server.listen(port, '127.0.0.1', () => {
+      server.removeListener('error', reject);
+      openServers.add(server);
+      resolve();
+    });
+  });
 }
 
-function close(
-  server: Server | ReturnType<typeof createTcpServer>
-): Promise<void> {
+function close(server: AnyServer): Promise<void> {
+  openServers.delete(server);
   return new Promise<void>((resolve, reject) =>
     server.close((err) => (err ? reject(err) : resolve()))
   );

--- a/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.spec.ts
+++ b/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.spec.ts
@@ -1,0 +1,194 @@
+import { createServer as createHttpServer, type Server } from 'node:http';
+import { createServer as createTcpServer } from 'node:net';
+import type { AddressInfo } from 'node:net';
+import type { ExecutorContext } from '@nx/devkit';
+import waitForWebserverExecutor from './wait-for-webserver.impl';
+
+const context = {} as ExecutorContext;
+
+describe('waitForWebserverExecutor', () => {
+  it('resolves once a TCP server accepts connections on the port', async () => {
+    const server = createTcpServer();
+    await listen(server, 0);
+    const { port } = server.address() as AddressInfo;
+
+    const result = await waitForWebserverExecutor(
+      { servers: [{ port }] },
+      context
+    );
+
+    expect(result).toEqual({ success: true });
+    await close(server);
+  });
+
+  it('resolves once an HTTP server responds with a 2xx status', async () => {
+    const server = createHttpServer((_req, res) => res.end('ok'));
+    await listen(server, 0);
+    const { port } = server.address() as AddressInfo;
+
+    const result = await waitForWebserverExecutor(
+      { servers: [{ url: `http://127.0.0.1:${port}` }] },
+      context
+    );
+
+    expect(result).toEqual({ success: true });
+    await close(server);
+  });
+
+  it('treats an early 4xx (e.g. 403) response as ready, like Playwright', async () => {
+    const server = createHttpServer((_req, res) => {
+      res.statusCode = 403;
+      res.end();
+    });
+    await listen(server, 0);
+    const { port } = server.address() as AddressInfo;
+
+    const result = await waitForWebserverExecutor(
+      { servers: [{ url: `http://127.0.0.1:${port}` }] },
+      context
+    );
+
+    expect(result).toEqual({ success: true });
+    await close(server);
+  });
+
+  it('falls back to /index.html when the root url returns 404', async () => {
+    const server = createHttpServer((req, res) => {
+      res.statusCode = req.url === '/index.html' ? 200 : 404;
+      res.end();
+    });
+    await listen(server, 0);
+    const { port } = server.address() as AddressInfo;
+
+    const result = await waitForWebserverExecutor(
+      { servers: [{ url: `http://127.0.0.1:${port}` }] },
+      context
+    );
+
+    expect(result).toEqual({ success: true });
+    await close(server);
+  });
+
+  it('follows redirects and evaluates the destination status, like Playwright', async () => {
+    const server = createHttpServer((req, res) => {
+      if (req.url === '/') {
+        res.statusCode = 302;
+        res.setHeader('location', '/ready');
+        res.end();
+        return;
+      }
+      res.statusCode = 200;
+      res.end();
+    });
+    await listen(server, 0);
+    const { port } = server.address() as AddressInfo;
+
+    const result = await waitForWebserverExecutor(
+      { servers: [{ url: `http://127.0.0.1:${port}` }] },
+      context
+    );
+
+    expect(result).toEqual({ success: true });
+    await close(server);
+  });
+
+  it('does not treat a redirect to an unavailable destination as ready', async () => {
+    const server = createHttpServer((req, res) => {
+      if (req.url === '/') {
+        res.statusCode = 302;
+        res.setHeader('location', '/still-booting');
+        res.end();
+        return;
+      }
+      res.statusCode = 503;
+      res.end();
+    });
+    await listen(server, 0);
+    const { port } = server.address() as AddressInfo;
+
+    const result = await waitForWebserverExecutor(
+      { servers: [{ url: `http://127.0.0.1:${port}` }], timeout: 300 },
+      context
+    );
+
+    expect(result).toEqual({ success: false });
+    await close(server);
+  });
+
+  it('waits for a slow endpoint that responds past the retry interval, like Playwright', async () => {
+    const server = createHttpServer((_req, res) => {
+      setTimeout(() => {
+        res.statusCode = 200;
+        res.end();
+      }, 1200);
+    });
+    await listen(server, 0);
+    const { port } = server.address() as AddressInfo;
+
+    const result = await waitForWebserverExecutor(
+      { servers: [{ url: `http://127.0.0.1:${port}` }], timeout: 4000 },
+      context
+    );
+
+    expect(result).toEqual({ success: true });
+    await close(server);
+  }, 10000);
+
+  it('does not treat a 5xx response as ready', async () => {
+    const server = createHttpServer((_req, res) => {
+      res.statusCode = 503;
+      res.end();
+    });
+    await listen(server, 0);
+    const { port } = server.address() as AddressInfo;
+
+    const result = await waitForWebserverExecutor(
+      { servers: [{ url: `http://127.0.0.1:${port}` }], timeout: 300 },
+      context
+    );
+
+    expect(result).toEqual({ success: false });
+    await close(server);
+  });
+
+  it('fails when the server never becomes reachable before the timeout', async () => {
+    // Bind then release a port so nothing is listening on it.
+    const server = createTcpServer();
+    await listen(server, 0);
+    const { port } = server.address() as AddressInfo;
+    await close(server);
+
+    const result = await waitForWebserverExecutor(
+      { servers: [{ port }], timeout: 300 },
+      context
+    );
+
+    expect(result).toEqual({ success: false });
+  });
+
+  it('fails when a server defines neither a port nor a url', async () => {
+    const result = await waitForWebserverExecutor(
+      { servers: [{}], timeout: 300 },
+      context
+    );
+
+    expect(result).toEqual({ success: false });
+  });
+});
+
+function listen(
+  server: Server | ReturnType<typeof createTcpServer>,
+  port: number
+): Promise<void> {
+  return new Promise<void>((resolve) =>
+    server.listen(port, '127.0.0.1', () => resolve())
+  );
+}
+
+function close(
+  server: Server | ReturnType<typeof createTcpServer>
+): Promise<void> {
+  return new Promise<void>((resolve, reject) =>
+    server.close((err) => (err ? reject(err) : resolve()))
+  );
+}

--- a/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.spec.ts
+++ b/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.spec.ts
@@ -1,12 +1,31 @@
+import { EventEmitter } from 'node:events';
 import { createServer as createHttpServer, type Server } from 'node:http';
+import * as https from 'node:https';
 import { createServer as createTcpServer } from 'node:net';
 import type { AddressInfo } from 'node:net';
-import type { ExecutorContext } from '@nx/devkit';
+import { logger, type ExecutorContext } from '@nx/devkit';
 import waitForWebserverExecutor from './wait-for-webserver.impl';
+
+// Replaces the module registry entry rather than spying on the namespace, which
+// the transpiler copies per importer.
+jest.mock('node:https', () => ({
+  ...jest.requireActual('node:https'),
+  request: jest.fn(),
+}));
 
 const context = {} as ExecutorContext;
 
 describe('waitForWebserverExecutor', () => {
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    errorSpy = jest.spyOn(logger, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    errorSpy.mockRestore();
+  });
+
   it('resolves once a TCP server accepts connections on the port', async () => {
     const server = createTcpServer();
     await listen(server, 0);
@@ -70,7 +89,9 @@ describe('waitForWebserverExecutor', () => {
   });
 
   it('follows redirects and evaluates the destination status, like Playwright', async () => {
+    const requested: string[] = [];
     const server = createHttpServer((req, res) => {
+      requested.push(req.url);
       if (req.url === '/') {
         res.statusCode = 302;
         res.setHeader('location', '/ready');
@@ -89,7 +110,74 @@ describe('waitForWebserverExecutor', () => {
     );
 
     expect(result).toEqual({ success: true });
+    // The 302 alone already sits inside the ready window, so only the request
+    // to the destination proves the chain was actually followed.
+    expect(requested).toEqual(['/', '/ready']);
     await close(server);
+  });
+
+  it('does not treat an endless redirect loop as ready', async () => {
+    let hops = 0;
+    const server = createHttpServer((_req, res) => {
+      res.statusCode = 302;
+      res.setHeader('location', `/hop-${++hops}`);
+      res.end();
+    });
+    await listen(server, 0);
+    const { port } = server.address() as AddressInfo;
+
+    const result = await waitForWebserverExecutor(
+      { servers: [{ url: `http://127.0.0.1:${port}` }], timeout: 300 },
+      context
+    );
+
+    expect(result).toEqual({ success: false });
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('redirected more than')
+    );
+    await close(server);
+  });
+
+  it('does not treat a redirect to an unparseable location as ready', async () => {
+    const server = createHttpServer((_req, res) => {
+      res.statusCode = 302;
+      res.setHeader('location', 'http://');
+      res.end();
+    });
+    await listen(server, 0);
+    const { port } = server.address() as AddressInfo;
+
+    const result = await waitForWebserverExecutor(
+      { servers: [{ url: `http://127.0.0.1:${port}` }], timeout: 300 },
+      context
+    );
+
+    expect(result).toEqual({ success: false });
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('redirected to an invalid location')
+    );
+    await close(server);
+  });
+
+  it('waits for every configured server, not just the first', async () => {
+    const ready = createTcpServer();
+    await listen(ready, 0);
+    const readyPort = (ready.address() as AddressInfo).port;
+    const slow = createTcpServer();
+    await listen(slow, 0);
+    const slowPort = (slow.address() as AddressInfo).port;
+    await close(slow);
+
+    const result = await waitForWebserverExecutor(
+      {
+        servers: [{ port: readyPort }, { port: slowPort }],
+        timeout: 300,
+      },
+      context
+    );
+
+    expect(result).toEqual({ success: false });
+    await close(ready);
   });
 
   it('does not treat a redirect to an unavailable destination as ready', async () => {
@@ -174,7 +262,190 @@ describe('waitForWebserverExecutor', () => {
 
     expect(result).toEqual({ success: false });
   });
+
+  it('fails immediately when a url cannot be parsed rather than retrying it', async () => {
+    const start = Date.now();
+
+    // no timeout, so retrying a url that can never become valid would block
+    // for the full default budget.
+    const result = await waitForWebserverExecutor(
+      { servers: [{ url: 'http://' }] },
+      context
+    );
+
+    expect(result).toEqual({ success: false });
+    expect(Date.now() - start).toBeLessThan(1000);
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('invalid "url": http://')
+    );
+  });
+
+  it('reports the status the url responded with when the wait times out', async () => {
+    const server = createHttpServer((_req, res) => {
+      res.statusCode = 503;
+      res.end();
+    });
+    await listen(server, 0);
+    const { port } = server.address() as AddressInfo;
+
+    await waitForWebserverExecutor(
+      { servers: [{ url: `http://127.0.0.1:${port}` }], timeout: 300 },
+      context
+    );
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('responded with status 503')
+    );
+    await close(server);
+  });
+
+  it('reports the connection error when a port never accepts connections', async () => {
+    const server = createTcpServer();
+    await listen(server, 0);
+    const { port } = server.address() as AddressInfo;
+    await close(server);
+
+    await waitForWebserverExecutor(
+      { servers: [{ port }], timeout: 300 },
+      context
+    );
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('ECONNREFUSED')
+    );
+  });
+
+  it('bounds each server by its own timeout', async () => {
+    const server = createTcpServer();
+    await listen(server, 0);
+    const { port } = server.address() as AddressInfo;
+    await close(server);
+    const start = Date.now();
+
+    const result = await waitForWebserverExecutor(
+      { servers: [{ port, timeout: 300 }] },
+      context
+    );
+
+    expect(result).toEqual({ success: false });
+    expect(Date.now() - start).toBeLessThan(3000);
+  });
+
+  it('lets the executor timeout override a per-server timeout', async () => {
+    const server = createTcpServer();
+    await listen(server, 0);
+    const { port } = server.address() as AddressInfo;
+    await close(server);
+    const start = Date.now();
+
+    const result = await waitForWebserverExecutor(
+      { servers: [{ port, timeout: 60_000 }], timeout: 300 },
+      context
+    );
+
+    expect(result).toEqual({ success: false });
+    expect(Date.now() - start).toBeLessThan(3000);
+  });
+
+  it.each([NaN, -1, 65536, 1.5])(
+    'fails immediately when the port (%p) cannot be connected to rather than retrying it',
+    async (port) => {
+      const start = Date.now();
+
+      // no timeout, so retrying a port that can never be valid would block for
+      // the full default budget.
+      const result = await waitForWebserverExecutor(
+        { servers: [{ port }] },
+        context
+      );
+
+      expect(result).toEqual({ success: false });
+      expect(Date.now() - start).toBeLessThan(1000);
+      expect(errorSpy).toHaveBeenCalledWith(
+        expect.stringContaining(`invalid "port": ${port}`)
+      );
+    }
+  );
+
+  it('fails when there is no server to wait for', async () => {
+    const result = await waitForWebserverExecutor({ servers: [] }, context);
+
+    expect(result).toEqual({ success: false });
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('at least one server')
+    );
+  });
+
+  it.each(['the server', 'the executor'])(
+    'treats a timeout of 0 on %s as unset, like Playwright',
+    async (level) => {
+      const server = createTcpServer();
+      await listen(server, 0);
+      const { port } = server.address() as AddressInfo;
+      await close(server);
+      // Comes up after the first probe has already failed, so a 0 read as
+      // "give up immediately" would never see it.
+      const timer = setTimeout(() => void listen(server, port), 300);
+
+      const result = await waitForWebserverExecutor(
+        level === 'the server'
+          ? { servers: [{ port, timeout: 0 }] }
+          : { servers: [{ port }], timeout: 0 },
+        context
+      );
+
+      expect(result).toEqual({ success: true });
+      clearTimeout(timer);
+      await close(server);
+    },
+    10000
+  );
+
+  it.each([
+    { ignoreHTTPSErrors: true, rejectUnauthorized: false },
+    { ignoreHTTPSErrors: false, rejectUnauthorized: true },
+  ])(
+    'polls https urls with ignoreHTTPSErrors $ignoreHTTPSErrors',
+    async ({ ignoreHTTPSErrors, rejectUnauthorized }) => {
+      const request = https.request as unknown as jest.Mock;
+      request.mockImplementation(unreachableRequest);
+
+      const result = await waitForWebserverExecutor(
+        {
+          servers: [{ url: 'https://127.0.0.1:9999', ignoreHTTPSErrors }],
+          timeout: 300,
+        },
+        context
+      );
+
+      expect(result).toEqual({ success: false });
+      expect(request).toHaveBeenCalledWith(
+        expect.anything(),
+        expect.objectContaining({ rejectUnauthorized }),
+        expect.any(Function)
+      );
+      request.mockReset();
+    }
+  );
 });
+
+// Stands in for an https endpoint that refuses connections, so the TLS options
+// the executor builds can be asserted without a certificate.
+function unreachableRequest(): any {
+  const request = new EventEmitter() as any;
+  request.destroy = () => {};
+  request.end = () =>
+    setImmediate(() =>
+      request.emit(
+        'error',
+        Object.assign(new Error('connect ECONNREFUSED'), {
+          code: 'ECONNREFUSED',
+        })
+      )
+    );
+
+  return request;
+}
 
 function listen(
   server: Server | ReturnType<typeof createTcpServer>,

--- a/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.spec.ts
+++ b/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.spec.ts
@@ -426,6 +426,9 @@ describe('waitForWebserverExecutor', () => {
     expect(errorSpy).toHaveBeenCalledWith(
       expect.stringContaining('ECONNREFUSED')
     );
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('run "nx reset" so the gate is re-inferred')
+    );
   });
 
   it('bounds each server by its own timeout', async () => {

--- a/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.spec.ts
+++ b/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.spec.ts
@@ -1,6 +1,10 @@
 import { createServer as createHttpServer, type Server } from 'node:http';
 import * as https from 'node:https';
-import { createServer as createTcpServer } from 'node:net';
+import {
+  createServer as createTcpServer,
+  getDefaultAutoSelectFamily,
+  setDefaultAutoSelectFamily,
+} from 'node:net';
 import type { AddressInfo } from 'node:net';
 import { logger, type ExecutorContext } from '@nx/devkit';
 import waitForWebserverExecutor from './wait-for-webserver.impl';
@@ -73,6 +77,28 @@ describe('waitForWebserverExecutor', () => {
     );
 
     expect(result).toEqual({ success: true });
+  });
+
+  it('reaches a 127.0.0.1-only server through http://localhost with global family autoselection off', async () => {
+    // macOS resolves `localhost` to ::1 first; the per-request Happy Eyeballs
+    // opt-in must connect anyway, the way Playwright's probe agent does, even
+    // when the process-wide default is off (as it is on some Node lines).
+    const originalAutoSelect = getDefaultAutoSelectFamily();
+    setDefaultAutoSelectFamily(false);
+    try {
+      const server = createHttpServer((_req, res) => res.end('ok'));
+      await listen(server, 0);
+      const { port } = server.address() as AddressInfo;
+
+      const result = await waitForWebserverExecutor(
+        { servers: [{ url: `http://localhost:${port}`, timeout: 2000 }] },
+        context
+      );
+
+      expect(result).toEqual({ success: true });
+    } finally {
+      setDefaultAutoSelectFamily(originalAutoSelect);
+    }
   });
 
   it('treats an early 4xx (e.g. 403) response as ready, like Playwright', async () => {

--- a/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.spec.ts
+++ b/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.spec.ts
@@ -1,3 +1,4 @@
+import * as http from 'node:http';
 import { createServer as createHttpServer, type Server } from 'node:http';
 import * as https from 'node:https';
 import {
@@ -14,6 +15,10 @@ import waitForWebserverExecutor from './wait-for-webserver.impl';
 // what the request became on the wire instead of only what it was asked for.
 jest.mock('node:https', () => {
   const actual = jest.requireActual('node:https');
+  return { ...actual, request: jest.fn(actual.request) };
+});
+jest.mock('node:http', () => {
+  const actual = jest.requireActual('node:http');
   return { ...actual, request: jest.fn(actual.request) };
 });
 
@@ -98,6 +103,30 @@ describe('waitForWebserverExecutor', () => {
       expect(result).toEqual({ success: true });
     } finally {
       setDefaultAutoSelectFamily(originalAutoSelect);
+    }
+  });
+
+  it('opts every direct probe request into family autoselection', async () => {
+    // The localhost test above only discriminates where the resolver orders
+    // ::1 first (macOS); on Linux 127.0.0.1 comes first and the connection
+    // succeeds either way. Assert the request options instead, which is
+    // deterministic on every platform.
+    const requestSpy = http.request as jest.Mock;
+    requestSpy.mockClear();
+    const server = createHttpServer((_req, res) => res.end('ok'));
+    await listen(server, 0);
+    const { port } = server.address() as AddressInfo;
+
+    await waitForWebserverExecutor(
+      { servers: [{ url: `http://127.0.0.1:${port}` }] },
+      context
+    );
+
+    expect(requestSpy).toHaveBeenCalled();
+    for (const call of requestSpy.mock.calls) {
+      expect(call[1]).toEqual(
+        expect.objectContaining({ autoSelectFamily: true })
+      );
     }
   });
 

--- a/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.spec.ts
+++ b/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.spec.ts
@@ -733,6 +733,30 @@ describe('waitForWebserverExecutor', () => {
       expect(forwarded).toEqual([`${originUrl}/`]);
     });
 
+    it('opts the plain-http proxy dial into family autoselection', async () => {
+      // Playwright's Happy Eyeballs agent dials the proxy on this route, so
+      // an IPv4-only proxy named `localhost` stays reachable; assert the
+      // request options like the direct-probe test, which is deterministic on
+      // every platform.
+      const { originUrl, proxyUrl } = await startSplitRoutes();
+      process.env.HTTP_PROXY = proxyUrl;
+      const requestSpy = http.request as jest.Mock;
+      requestSpy.mockClear();
+
+      const result = await waitForWebserverExecutor(
+        { servers: [{ url: originUrl }], timeout: 2000 },
+        context
+      );
+
+      expect(result).toEqual({ success: true });
+      expect(requestSpy).toHaveBeenCalled();
+      for (const call of requestSpy.mock.calls) {
+        expect(call[1]).toEqual(
+          expect.objectContaining({ autoSelectFamily: true })
+        );
+      }
+    });
+
     it('goes direct when no_proxy covers the host', async () => {
       const { forwarded, originUrl, proxyUrl } = await startSplitRoutes();
       process.env.HTTP_PROXY = proxyUrl;

--- a/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.spec.ts
+++ b/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.spec.ts
@@ -257,6 +257,26 @@ describe('waitForWebserverExecutor', () => {
     expect(message).not.toContain('\u009b');
   });
 
+  it('redacts credentials from an unparseable redirect location', async () => {
+    const server = createHttpServer((_req, res) => {
+      res.statusCode = 302;
+      res.setHeader('location', 'http://user:secret@[]');
+      res.end();
+    });
+    await listen(server, 0);
+    const { port } = server.address() as AddressInfo;
+
+    const result = await waitForWebserverExecutor(
+      { servers: [{ url: `http://127.0.0.1:${port}` }], timeout: 300 },
+      context
+    );
+
+    expect(result).toEqual({ success: false });
+    const [message] = errorSpy.mock.calls[0];
+    expect(message).toContain('redirected to an invalid location "***@[]"');
+    expect(message).not.toContain('secret');
+  });
+
   it('does not treat a redirect to a non-http(s) location as ready', async () => {
     const server = createHttpServer((_req, res) => {
       res.statusCode = 302;
@@ -462,6 +482,30 @@ describe('waitForWebserverExecutor', () => {
 
     expect(errorSpy).toHaveBeenCalledWith(
       expect.stringContaining('responded with status 503')
+    );
+  });
+
+  it('redacts url credentials from the failure it reports', async () => {
+    const server = createHttpServer((_req, res) => {
+      res.statusCode = 503;
+      res.end();
+    });
+    await listen(server, 0);
+    const { port } = server.address() as AddressInfo;
+
+    await waitForWebserverExecutor(
+      {
+        servers: [{ url: `http://user:secret@127.0.0.1:${port}` }],
+        timeout: 1000,
+      },
+      context
+    );
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining(`http://***@127.0.0.1:${port}`)
+    );
+    expect(errorSpy).not.toHaveBeenCalledWith(
+      expect.stringContaining('secret')
     );
   });
 

--- a/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.spec.ts
+++ b/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.spec.ts
@@ -202,6 +202,54 @@ describe('waitForWebserverExecutor', () => {
     expect(message).not.toContain('\u009b');
   });
 
+  it('does not treat a redirect to a non-http(s) location as ready', async () => {
+    const server = createHttpServer((_req, res) => {
+      res.statusCode = 302;
+      res.setHeader('location', 'ftp://example.com/');
+      res.end();
+    });
+    await listen(server, 0);
+    const { port } = server.address() as AddressInfo;
+
+    const result = await waitForWebserverExecutor(
+      { servers: [{ url: `http://127.0.0.1:${port}` }], timeout: 300 },
+      context
+    );
+
+    expect(result).toEqual({ success: false });
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'redirected to "ftp://example.com/", which is not an http or https url'
+      )
+    );
+  });
+
+  it('retries past a boot-time redirect to a non-http(s) location', async () => {
+    // Following the location into http.request would throw and end the wait on
+    // the first probe; classifying it keeps probing until the server is ready.
+    let requests = 0;
+    const server = createHttpServer((_req, res) => {
+      if (++requests === 1) {
+        res.statusCode = 302;
+        res.setHeader('location', 'ftp://example.com/');
+        res.end();
+        return;
+      }
+      res.statusCode = 200;
+      res.end();
+    });
+    await listen(server, 0);
+    const { port } = server.address() as AddressInfo;
+
+    const result = await waitForWebserverExecutor(
+      { servers: [{ url: `http://127.0.0.1:${port}` }] },
+      context
+    );
+
+    expect(result).toEqual({ success: true });
+    expect(requests).toBeGreaterThan(1);
+  });
+
   it('reports how far a redirect chain got when a hop fails to connect', async () => {
     const deadPort = await closedPort();
     const server = createHttpServer((_req, res) => {

--- a/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.spec.ts
+++ b/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.spec.ts
@@ -1,6 +1,9 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
 import * as http from 'node:http';
 import { createServer as createHttpServer, type Server } from 'node:http';
 import * as https from 'node:https';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import {
   createServer as createTcpServer,
   getDefaultAutoSelectFamily,
@@ -876,6 +879,69 @@ describe('waitForWebserverExecutor', () => {
       expect(credentials[0]).toBe(
         `Basic ${Buffer.from('user:pa:ss').toString('base64')}`
       );
+    });
+
+    // A workspace whose installed @playwright/test is `version`, for the
+    // probe's version-dependent proxied TLS semantics.
+    const writePlaywrightFixture = (version: string): string => {
+      const dir = mkdtempSync(join(tmpdir(), 'pw-wait-version-'));
+      mkdirSync(join(dir, 'node_modules', '@playwright', 'test'), {
+        recursive: true,
+      });
+      writeFileSync(
+        join(dir, 'node_modules', '@playwright', 'test', 'package.json'),
+        JSON.stringify({ name: '@playwright/test', version })
+      );
+      return dir;
+    };
+    const versionedContext = (root: string) =>
+      ({
+        root,
+        projectName: 'app',
+        projectsConfigurations: { projects: { app: { root: '.' } } },
+      }) as unknown as ExecutorContext;
+
+    it('skips certificate verification for a tunnelled probe when the installed Playwright does', async () => {
+      // Playwright before 1.59.0 forces `rejectUnauthorized` off for a probe
+      // tunnelled to an https url; verifying here would fail a wait that
+      // version's own probe passes.
+      const { release, proxyUrl } = await startTunnellingProxy();
+      process.env.HTTPS_PROXY = proxyUrl;
+      const request = https.request as unknown as jest.Mock;
+      request.mockClear();
+      const root = writePlaywrightFixture('1.36.0');
+
+      try {
+        await waitForWebserverExecutor(
+          { servers: [{ url: 'https://example.test:8443' }], timeout: 300 },
+          versionedContext(root)
+        );
+        release();
+
+        expect(request.mock.calls[0][1].rejectUnauthorized).toBe(false);
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
+    });
+
+    it('keeps certificate verification for a tunnelled probe on versions that honor it', async () => {
+      const { release, proxyUrl } = await startTunnellingProxy();
+      process.env.HTTPS_PROXY = proxyUrl;
+      const request = https.request as unknown as jest.Mock;
+      request.mockClear();
+      const root = writePlaywrightFixture('1.59.0');
+
+      try {
+        await waitForWebserverExecutor(
+          { servers: [{ url: 'https://example.test:8443' }], timeout: 300 },
+          versionedContext(root)
+        );
+        release();
+
+        expect(request.mock.calls[0][1].rejectUnauthorized).toBe(true);
+      } finally {
+        rmSync(root, { recursive: true, force: true });
+      }
     });
 
     it('sends proxy credentials on an absolute-form request', async () => {

--- a/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.spec.ts
+++ b/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.spec.ts
@@ -579,6 +579,13 @@ describe('waitForWebserverExecutor', () => {
     expect(errorSpy).toHaveBeenCalledWith(
       expect.stringContaining('run "nx reset" so the gate is re-inferred')
     );
+    // A configuration-scoped env file never reaches the inference, so the
+    // message names the way out of that setup too.
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining(
+        'set "waitForWebServer" to false on @nx/playwright/plugin'
+      )
+    );
   });
 
   it('bounds each server by its own timeout', async () => {
@@ -882,7 +889,7 @@ describe('waitForWebserverExecutor', () => {
     });
 
     // A workspace whose installed @playwright/test is `version`, for the
-    // probe's version-dependent proxied TLS semantics.
+    // probe's version-dependent semantics.
     const writePlaywrightFixture = (version: string): string => {
       const dir = mkdtempSync(join(tmpdir(), 'pw-wait-version-'));
       mkdirSync(join(dir, 'node_modules', '@playwright', 'test'), {
@@ -943,6 +950,42 @@ describe('waitForWebserverExecutor', () => {
         rmSync(root, { recursive: true, force: true });
       }
     });
+
+    it.each([
+      ['1.36.0', 1],
+      ['1.59.0', 0],
+    ])(
+      'routes by npm_config_http_proxy the way the installed Playwright %s does',
+      async (version, proxied) => {
+        // Playwright before 1.59.0 reads npm's proxy variables ahead of the
+        // standard ones; later versions ignore them.
+        const server = createHttpServer((_req, res) => res.end('ok'));
+        await listen(server, 0);
+        const { port } = server.address() as AddressInfo;
+        const seen: string[] = [];
+        const proxy = createHttpServer((req, res) => {
+          seen.push(req.url);
+          res.statusCode = 200;
+          res.end();
+        });
+        await listen(proxy, 0);
+        const { port: proxyPort } = proxy.address() as AddressInfo;
+        process.env.npm_config_http_proxy = `http://127.0.0.1:${proxyPort}`;
+        const root = writePlaywrightFixture(version);
+
+        try {
+          const result = await waitForWebserverExecutor(
+            { servers: [{ url: `http://127.0.0.1:${port}` }], timeout: 300 },
+            versionedContext(root)
+          );
+
+          expect(result).toEqual({ success: true });
+          expect(seen).toHaveLength(proxied);
+        } finally {
+          rmSync(root, { recursive: true, force: true });
+        }
+      }
+    );
 
     it('sends proxy credentials on an absolute-form request', async () => {
       const seen: Array<string | undefined> = [];
@@ -1109,6 +1152,14 @@ const PROXY_VARS = [
   'ALL_PROXY',
   'no_proxy',
   'NO_PROXY',
+  'npm_config_http_proxy',
+  'NPM_CONFIG_HTTP_PROXY',
+  'npm_config_https_proxy',
+  'NPM_CONFIG_HTTPS_PROXY',
+  'npm_config_proxy',
+  'NPM_CONFIG_PROXY',
+  'npm_config_no_proxy',
+  'NPM_CONFIG_NO_PROXY',
 ];
 
 function listen(server: AnyServer, port: number): Promise<void> {

--- a/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.ts
+++ b/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.ts
@@ -15,8 +15,8 @@ type Server = Schema['servers'][number];
 // A probe resolves to `null` when the server is ready, or to a short
 // description of why it is not, which is surfaced when the wait times out.
 type ProbeFailure = string | null;
-// A probe that ran out of budget before reaching the server observed nothing,
-// so it must not replace what the previous probe saw.
+// A probe the deadline cut short before it could learn anything observed
+// nothing, so it must not replace what the previous probe saw.
 const NO_OBSERVATION = 'the deadline passed before the server responded';
 
 export async function waitForWebserverExecutor(
@@ -72,8 +72,9 @@ function findServerProblem(server: Server): string | undefined {
   }
 }
 
+// 0 is not a connectable port, so it is rejected rather than probed.
 function isValidPort(port: number): boolean {
-  return Number.isInteger(port) && port >= 0 && port <= 65535;
+  return Number.isInteger(port) && port >= 1 && port <= 65535;
 }
 
 async function waitForServer(server: Server, timeout: number): Promise<void> {
@@ -92,7 +93,7 @@ async function waitForServer(server: Server, timeout: number): Promise<void> {
     }
     if (Date.now() >= deadline) {
       throw new Error(
-        `Timed out after ${timeout}ms waiting for the E2E web server at ${label} to be ready. Last probe: ${
+        `Timed out after ${timeout}ms waiting for the E2E web server at ${label} to be ready. Last observation: ${
           lastObserved ?? failure
         }.`
       );
@@ -102,9 +103,8 @@ async function waitForServer(server: Server, timeout: number): Promise<void> {
   }
 }
 
-// Match Playwright's own check so the gate only clears once Playwright would
-// reuse the running server: connect to the port on both loopback addresses,
-// or poll the URL for an HTTP status below 404.
+// Mirror Playwright's own readiness check: connect to the port on both
+// loopback addresses, or poll the URL for an HTTP status below 404.
 function probeServer(server: Server, deadline: number): Promise<ProbeFailure> {
   return server.port != null
     ? probePort(server.port)
@@ -187,9 +187,9 @@ function requestStatus(
   redirectsRemaining = MAX_REDIRECTS
 ): Promise<UrlResponse> {
   return new Promise((resolve) => {
-    // Bound each request by the overall readiness deadline, not a fixed
-    // interval, so an endpoint that legitimately responds slowly is not
-    // aborted before Playwright itself would give up.
+    // Give each request the rest of the readiness budget as its idle timeout,
+    // rather than a fixed interval, so an endpoint that legitimately responds
+    // slowly is not aborted before Playwright itself would give up.
     const remaining = deadline - Date.now();
     if (remaining <= 0) {
       resolve({ href: url.href, status: 0, failure: NO_OBSERVATION });
@@ -251,7 +251,18 @@ function requestStatus(
     );
     request.once('timeout', () => {
       request.destroy();
-      resolve({ href: url.href, status: 0, failure: `${url.href} timed out` });
+      // Staying silent for the window the port probe allows is something the
+      // server did. Going quiet with a sliver of budget left is not: that is
+      // the deadline arriving mid-request, and it says nothing about a server
+      // an earlier probe may have already reached.
+      resolve({
+        href: url.href,
+        status: 0,
+        failure:
+          remaining >= FALLBACK_RETRY_DELAY
+            ? `${url.href} did not respond`
+            : NO_OBSERVATION,
+      });
     });
     request.once('error', (error: NodeJS.ErrnoException) => {
       request.destroy();

--- a/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.ts
+++ b/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.ts
@@ -1,7 +1,9 @@
 import { logger, type ExecutorContext } from '@nx/devkit';
+import { HttpsProxyAgent } from 'https-proxy-agent';
 import * as http from 'node:http';
 import * as https from 'node:https';
 import { connect } from 'node:net';
+import { resolveProxyForUrl, type ProxyResolution } from './proxy';
 import type { Schema } from './schema';
 
 const DEFAULT_TIMEOUT = 60_000;
@@ -9,7 +11,6 @@ const DEFAULT_TIMEOUT = 60_000;
 // up front, then a steady interval.
 const RETRY_SCHEDULE = [100, 250, 500];
 const FALLBACK_RETRY_DELAY = 1_000;
-const MAX_REDIRECTS = 10;
 
 type Server = Schema['servers'][number];
 // A probe resolves to `null` when the server is ready, or to a short
@@ -56,10 +57,11 @@ export async function waitForWebserverExecutor(
 
 export default waitForWebserverExecutor;
 
-// Neither a malformed URL nor an out-of-range port can become valid, so they
-// are rejected up front instead of being retried until the timeout and
-// reported as a slow server. An unusable port is also the only input that makes
-// `connect` throw synchronously, which no probe could turn into a failure.
+// A malformed URL, an out-of-range port and a proxy that cannot be used are all
+// inputs that can never become valid, so they are rejected up front instead of
+// being retried until the timeout and reported as a slow server. An unusable
+// port is also the only input that makes `connect` throw synchronously, which
+// no probe could turn into a failure.
 function findServerProblem(server: Server): string | undefined {
   if (server.port == null && !server.url) {
     return 'requires each server to define a "port" or a "url".';
@@ -67,9 +69,29 @@ function findServerProblem(server: Server): string | undefined {
   if (server.port != null && !isValidPort(server.port)) {
     return `received an invalid "port": ${server.port}.`;
   }
-  if (server.url && !canParseUrl(server.url)) {
-    return `received an invalid "url": ${server.url}.`;
+  if (server.url) {
+    let url: URL;
+    try {
+      url = new URL(server.url);
+    } catch {
+      return `received an invalid "url": ${server.url}.`;
+    }
+    // Only the address the wait starts from is checked here. A redirect can
+    // cross to a protocol with its own proxy variable, which the probe reports
+    // when it gets there.
+    const resolution = resolveProxyForUrl(url);
+    if (resolution.kind === 'unusable') {
+      return `${unusableProxyProblem(resolution)}.`;
+    }
   }
+}
+
+// Left unpunctuated because a probe failure is also quoted mid-sentence when
+// the wait times out.
+function unusableProxyProblem(
+  resolution: Extract<ProxyResolution, { kind: 'unusable' }>
+): string {
+  return `cannot use the proxy configured in ${resolution.variable}: ${resolution.value} ${resolution.reason}`;
 }
 
 // 0 is not a connectable port, so it is rejected rather than probed.
@@ -103,8 +125,10 @@ async function waitForServer(server: Server, timeout: number): Promise<void> {
   }
 }
 
-// Mirror Playwright's own readiness check: connect to the port on both
-// loopback addresses, or poll the URL for an HTTP status below 404.
+// Probe the way Playwright does: connect to the port on both loopback
+// addresses, or poll the URL for a status from 200 to 403, through whatever
+// proxy the environment configures for it. A port is always probed directly,
+// because Playwright checks one with a raw socket too.
 function probeServer(server: Server, deadline: number): Promise<ProbeFailure> {
   return server.port != null
     ? probePort(server.port)
@@ -168,8 +192,16 @@ async function probeUrl(
   }
   return (
     response.failure ??
-    `${response.href} responded with status ${response.status}`
+    `${response.href} responded with status ${response.status}${viaProxy(
+      response.via
+    )}`
   );
+}
+
+// The one place the phrase is written, so a failure the probe words and one the
+// request words cannot drift apart.
+function viaProxy(via: string | undefined): string {
+  return via ? ` via the proxy at ${via}` : '';
 }
 
 interface UrlResponse {
@@ -178,111 +210,202 @@ interface UrlResponse {
   href: string;
   status: number;
   failure?: string;
+  // The proxy the status came back through, if any. A proxy that answers in the
+  // server's place produces one that reads as the server's own until the
+  // message says otherwise.
+  via?: string;
 }
 
 function requestStatus(
   url: URL,
   ignoreHTTPSErrors: boolean,
   deadline: number,
-  redirectsRemaining = MAX_REDIRECTS
+  redirects = 0
 ): Promise<UrlResponse> {
+  // A chain that ran out of budget still told us the server is answering, so it
+  // is a real observation rather than silence, whether the budget ran out
+  // between hops or inside the last one.
+  const redirectFailure =
+    redirects > 0
+      ? `${url.href} redirected ${redirects} times without resolving`
+      : undefined;
+  const remaining = deadline - Date.now();
+  if (remaining <= 0) {
+    return Promise.resolve({
+      href: url.href,
+      status: 0,
+      failure: redirectFailure ?? NO_OBSERVATION,
+    });
+  }
+
+  // Resolved per URL rather than once per probe so a redirect that changes
+  // protocol re-selects the way Playwright's own recursion does.
+  const resolution = resolveProxyForUrl(url);
+  if (resolution.kind === 'unusable') {
+    return Promise.resolve({
+      href: url.href,
+      status: 0,
+      failure: `${url.href} ${unusableProxyProblem(resolution)}`,
+    });
+  }
+
+  const via = resolution.kind === 'proxy' ? resolution.proxy.host : undefined;
+  const describe = (detail: string) => `${url.href} ${detail}${viaProxy(via)}`;
+
   return new Promise((resolve) => {
-    // Give each request the rest of the readiness budget as its idle timeout,
-    // rather than a fixed interval, so an endpoint that legitimately responds
-    // slowly is not aborted before Playwright itself would give up.
-    const remaining = deadline - Date.now();
-    if (remaining <= 0) {
-      resolve({ href: url.href, status: 0, failure: NO_OBSERVATION });
-      return;
-    }
-    const isHttps = url.protocol === 'https:';
     const requestOptions: https.RequestOptions = {
       method: 'GET',
       headers: { Accept: '*/*' },
-      timeout: remaining,
+      rejectUnauthorized: !ignoreHTTPSErrors,
     };
-    if (isHttps) {
-      requestOptions.rejectUnauthorized = !ignoreHTTPSErrors;
-    }
 
-    const request = (isHttps ? https.request : http.request)(
-      url,
-      requestOptions,
-      (response) => {
-        const status = response.statusCode ?? 0;
-        const location = response.headers.location;
-        response.resume();
-        request.destroy();
-        // Follow redirects like Playwright and evaluate the final
-        // destination, so a redirect to an unavailable page is not read as
-        // ready. Treat an exhausted or malformed chain as not ready.
-        if (status >= 300 && status < 400 && location) {
-          if (redirectsRemaining <= 0) {
-            resolve({
-              href: url.href,
-              status: 0,
-              failure: `${url.href} redirected more than ${MAX_REDIRECTS} times`,
-            });
-            return;
-          }
-          let redirectUrl: URL;
-          try {
-            redirectUrl = new URL(location, url);
-          } catch {
-            resolve({
-              href: url.href,
-              status: 0,
-              failure: `${url.href} redirected to an invalid location "${location}"`,
-            });
-            return;
-          }
-          resolve(
-            requestStatus(
-              redirectUrl,
-              ignoreHTTPSErrors,
-              deadline,
-              redirectsRemaining - 1
-            )
-          );
-          return;
-        }
-        resolve({ href: url.href, status });
+    let request: http.ClientRequest | undefined;
+    let settled = false;
+    // Until the agent finishes `CONNECT` the request holds no socket, so
+    // destroying it cannot reach the connection to the proxy. Aborting is what
+    // closes that leg; without it a proxy that never answers leaves a live
+    // socket nothing else can reach.
+    const connecting = new AbortController();
+    // Declared ahead of the settle it is cleared by, which the timer's own
+    // callback in turn calls.
+    let budget: NodeJS.Timeout;
+    const settle = (response: UrlResponse | Promise<UrlResponse>) => {
+      if (settled) {
+        return;
       }
-    );
-    request.once('timeout', () => {
-      request.destroy();
+      settled = true;
+      clearTimeout(budget);
+      request?.destroy();
+      connecting.abort();
+      resolve(response);
+    };
+
+    // The rest of the readiness budget bounds the request in wall-clock time. A
+    // request arms its own idle timeout only once it holds a socket, and one
+    // waiting on a proxy that accepted the connection but never answered
+    // `CONNECT` never gets that far. Unreferenced because it is a bound rather
+    // than work of its own: it still fires while a request is in flight, and
+    // cannot hold the process open once nothing else does.
+    budget = setTimeout(() => {
       // Staying silent for the window the port probe allows is something the
       // server did. Going quiet with a sliver of budget left is not: that is
       // the deadline arriving mid-request, and it says nothing about a server
       // an earlier probe may have already reached.
-      resolve({
+      settle({
         href: url.href,
         status: 0,
         failure:
-          remaining >= FALLBACK_RETRY_DELAY
-            ? `${url.href} did not respond`
-            : NO_OBSERVATION,
+          redirectFailure ??
+          (remaining >= FALLBACK_RETRY_DELAY
+            ? describe('did not respond')
+            : NO_OBSERVATION),
       });
-    });
-    request.once('error', (error: NodeJS.ErrnoException) => {
-      request.destroy();
-      resolve({
+    }, remaining).unref();
+
+    const onResponse = (response: http.IncomingMessage) => {
+      const status = response.statusCode ?? 0;
+      const location = response.headers.location;
+      response.resume();
+      // Follow redirects like Playwright and evaluate the final
+      // destination, so a redirect to an unavailable page is not read as
+      // ready. The readiness deadline bounds the chain instead of a hop
+      // count, which would fail a long chain Playwright follows to a
+      // ready server. Treat a malformed chain as not ready.
+      if (status >= 300 && status < 400 && location) {
+        let redirectUrl: URL;
+        try {
+          redirectUrl = new URL(location, url);
+        } catch {
+          settle({
+            href: url.href,
+            status: 0,
+            // Node's header parser passes tab and the C1 controls through, and
+            // the value reaches a terminal from here.
+            failure: describe(
+              `redirected to an invalid location "${location.replace(
+                /[\x00-\x1f\x7f-\x9f]/g,
+                ''
+              )}"`
+            ),
+          });
+          return;
+        }
+        settle(
+          requestStatus(redirectUrl, ignoreHTTPSErrors, deadline, redirects + 1)
+        );
+        return;
+      }
+      settle({ href: url.href, via, status });
+    };
+
+    switch (resolution.kind) {
+      case 'direct':
+        request = (url.protocol === 'https:' ? https : http).request(
+          url,
+          requestOptions,
+          onResponse
+        );
+        break;
+      case 'proxy':
+        request = proxiedRequest(
+          url,
+          resolution.proxy,
+          requestOptions,
+          connecting.signal,
+          onResponse
+        );
+        break;
+      default: {
+        // Both kinds that reach here route the request somewhere; a new one has
+        // to say where.
+        const unhandled: never = resolution;
+        throw new Error(
+          `Unhandled proxy resolution ${JSON.stringify(unhandled)}`
+        );
+      }
+    }
+
+    // Not `once`: aborting the connection raises a second error on a request
+    // that has already been settled, and an emitter left without a listener
+    // would throw it at the process.
+    request.on('error', (error: NodeJS.ErrnoException) => {
+      const detail = error.code ?? error.message;
+      settle({
         href: url.href,
         status: 0,
-        failure: `${url.href} ${error.code ?? error.message}`,
+        failure: describe(
+          redirects > 0 ? `${detail} after ${redirects} redirects` : detail
+        ),
       });
     });
     request.end();
   });
 }
 
-function canParseUrl(url: string): boolean {
-  try {
-    new URL(url);
-    return true;
-  } catch {
-    return false;
+// An http target is named in the request line and the request itself goes to
+// the proxy, which is what Playwright does. An https target cannot be named
+// that way, so the agent opens a tunnel with `CONNECT` and TLS runs over it.
+// Proxy credentials travel differently on the two routes, on the URL for the
+// first and as `Proxy-Authorization` for the second, and both match Playwright.
+function proxiedRequest(
+  url: URL,
+  proxy: URL,
+  options: https.RequestOptions,
+  signal: AbortSignal,
+  onResponse: (response: http.IncomingMessage) => void
+): http.ClientRequest {
+  if (url.protocol === 'https:') {
+    const agent = new HttpsProxyAgent(proxy);
+    // The agent dials the proxy itself, so this is the only handle on that
+    // connection. A signal in the request options does not reach it.
+    agent.connectOpts.signal = signal;
+    return https.request(url, { ...options, agent }, onResponse);
   }
+  return (proxy.protocol === 'https:' ? https : http).request(
+    proxy,
+    { ...options, path: url.href },
+    onResponse
+  );
 }
 
 function sleep(ms: number): Promise<void> {

--- a/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.ts
+++ b/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.ts
@@ -1,0 +1,197 @@
+import { logger, type ExecutorContext } from '@nx/devkit';
+import * as http from 'node:http';
+import * as https from 'node:https';
+import { connect } from 'node:net';
+import type { Schema } from './schema';
+
+const DEFAULT_TIMEOUT = 60_000;
+// Retry cadence mirrors Playwright's web server readiness loop: a short ramp
+// up front, then a steady interval.
+const RETRY_SCHEDULE = [100, 250, 500];
+const FALLBACK_RETRY_DELAY = 1_000;
+const MAX_REDIRECTS = 10;
+
+type Server = Schema['servers'][number];
+
+export async function waitForWebserverExecutor(
+  options: Schema,
+  _context: ExecutorContext
+): Promise<{ success: boolean }> {
+  const servers = options.servers ?? [];
+  const invalidServer = servers.find(
+    (server) => server.port == null && !server.url
+  );
+  if (invalidServer) {
+    logger.error(
+      '@nx/playwright:wait-for-webserver requires each server to define a "port" or a "url".'
+    );
+    return { success: false };
+  }
+
+  const timeout = options.timeout ?? DEFAULT_TIMEOUT;
+
+  try {
+    await Promise.all(servers.map((server) => waitForServer(server, timeout)));
+    return { success: true };
+  } catch (e) {
+    logger.error(e instanceof Error ? e.message : String(e));
+    return { success: false };
+  }
+}
+
+export default waitForWebserverExecutor;
+
+async function waitForServer(server: Server, timeout: number): Promise<void> {
+  const label = server.url ?? `port ${server.port}`;
+  const deadline = Date.now() + timeout;
+  const schedule = [...RETRY_SCHEDULE];
+
+  while (true) {
+    if (await isServerReady(server, deadline)) {
+      return;
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `Timed out after ${timeout}ms waiting for the E2E web server at ${label} to be ready.`
+      );
+    }
+    const delay = schedule.shift() ?? FALLBACK_RETRY_DELAY;
+    await sleep(Math.min(delay, Math.max(0, deadline - Date.now())));
+  }
+}
+
+// Match Playwright's own check so the gate only clears once Playwright would
+// reuse the running server: connect to the port on both loopback addresses,
+// or poll the URL for an HTTP status in the 200-403 range.
+function isServerReady(server: Server, deadline: number): Promise<boolean> {
+  return server.port != null
+    ? isPortUsed(server.port)
+    : isUrlAvailable(server.url, server.ignoreHTTPSErrors ?? false, deadline);
+}
+
+function isPortUsed(port: number): Promise<boolean> {
+  const canConnect = (host: string) =>
+    new Promise<boolean>((resolve) => {
+      const socket = connect({ port, host });
+      const settle = (result: boolean) => {
+        socket.removeAllListeners();
+        socket.destroy();
+        resolve(result);
+      };
+      socket.setTimeout(FALLBACK_RETRY_DELAY);
+      socket.once('connect', () => settle(true));
+      socket.once('timeout', () => settle(false));
+      socket.once('error', () => settle(false));
+    });
+
+  return new Promise<boolean>((resolve) => {
+    let pending = 2;
+    const onResult = (connected: boolean) => {
+      if (connected) {
+        resolve(true);
+      } else if (--pending === 0) {
+        resolve(false);
+      }
+    };
+    void canConnect('127.0.0.1').then(onResult);
+    void canConnect('::1').then(onResult);
+  });
+}
+
+async function isUrlAvailable(
+  url: string,
+  ignoreHTTPSErrors: boolean,
+  deadline: number
+): Promise<boolean> {
+  let parsedUrl: URL;
+  try {
+    parsedUrl = new URL(url);
+  } catch {
+    return false;
+  }
+
+  let statusCode = await httpStatusCode(parsedUrl, ignoreHTTPSErrors, deadline);
+  if (statusCode === 404 && parsedUrl.pathname === '/') {
+    const indexUrl = new URL(parsedUrl);
+    indexUrl.pathname = '/index.html';
+    statusCode = await httpStatusCode(indexUrl, ignoreHTTPSErrors, deadline);
+  }
+  return statusCode >= 200 && statusCode < 404;
+}
+
+function httpStatusCode(
+  url: URL,
+  ignoreHTTPSErrors: boolean,
+  deadline: number,
+  redirectsRemaining = MAX_REDIRECTS
+): Promise<number> {
+  return new Promise((resolve) => {
+    // Bound each request by the overall readiness deadline, not a fixed
+    // interval, so an endpoint that legitimately responds slowly is not
+    // aborted before Playwright itself would give up.
+    const remaining = deadline - Date.now();
+    if (remaining <= 0) {
+      resolve(0);
+      return;
+    }
+    const isHttps = url.protocol === 'https:';
+    const requestOptions: https.RequestOptions = {
+      method: 'GET',
+      headers: { Accept: '*/*' },
+      timeout: remaining,
+    };
+    if (isHttps) {
+      requestOptions.rejectUnauthorized = !ignoreHTTPSErrors;
+    }
+
+    const request = (isHttps ? https.request : http.request)(
+      url,
+      requestOptions,
+      (response) => {
+        const statusCode = response.statusCode ?? 0;
+        const location = response.headers.location;
+        response.resume();
+        request.destroy();
+        // Follow redirects like Playwright and evaluate the final
+        // destination, so a redirect to an unavailable page is not read as
+        // ready. Treat an exhausted or malformed chain as not ready.
+        if (statusCode >= 300 && statusCode < 400 && location) {
+          if (redirectsRemaining <= 0) {
+            resolve(0);
+            return;
+          }
+          let redirectUrl: URL;
+          try {
+            redirectUrl = new URL(location, url);
+          } catch {
+            resolve(0);
+            return;
+          }
+          resolve(
+            httpStatusCode(
+              redirectUrl,
+              ignoreHTTPSErrors,
+              deadline,
+              redirectsRemaining - 1
+            )
+          );
+          return;
+        }
+        resolve(statusCode);
+      }
+    );
+    request.once('timeout', () => {
+      request.destroy();
+      resolve(0);
+    });
+    request.once('error', () => {
+      request.destroy();
+      resolve(0);
+    });
+    request.end();
+  });
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.ts
+++ b/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.ts
@@ -12,26 +12,41 @@ const FALLBACK_RETRY_DELAY = 1_000;
 const MAX_REDIRECTS = 10;
 
 type Server = Schema['servers'][number];
+// A probe resolves to `null` when the server is ready, or to a short
+// description of why it is not, which is surfaced when the wait times out.
+type ProbeFailure = string | null;
+// A probe that ran out of budget before reaching the server observed nothing,
+// so it must not replace what the previous probe saw.
+const NO_OBSERVATION = 'the deadline passed before the server responded';
 
 export async function waitForWebserverExecutor(
   options: Schema,
   _context: ExecutorContext
 ): Promise<{ success: boolean }> {
   const servers = options.servers ?? [];
-  const invalidServer = servers.find(
-    (server) => server.port == null && !server.url
-  );
-  if (invalidServer) {
+  if (servers.length === 0) {
     logger.error(
-      '@nx/playwright:wait-for-webserver requires each server to define a "port" or a "url".'
+      '@nx/playwright:wait-for-webserver requires at least one server to wait for.'
     );
     return { success: false };
   }
-
-  const timeout = options.timeout ?? DEFAULT_TIMEOUT;
+  const problem = servers.map(findServerProblem).find(Boolean);
+  if (problem) {
+    logger.error(`@nx/playwright:wait-for-webserver ${problem}`);
+    return { success: false };
+  }
 
   try {
-    await Promise.all(servers.map((server) => waitForServer(server, timeout)));
+    await Promise.all(
+      servers.map((server) =>
+        // A zero timeout means "unset" rather than "give up immediately", which
+        // is how Playwright reads it (`this._options.timeout || 60 * 1e3`).
+        waitForServer(
+          server,
+          options.timeout || server.timeout || DEFAULT_TIMEOUT
+        )
+      )
+    );
     return { success: true };
   } catch (e) {
     logger.error(e instanceof Error ? e.message : String(e));
@@ -41,18 +56,45 @@ export async function waitForWebserverExecutor(
 
 export default waitForWebserverExecutor;
 
+// Neither a malformed URL nor an out-of-range port can become valid, so they
+// are rejected up front instead of being retried until the timeout and
+// reported as a slow server. An unusable port is also the only input that makes
+// `connect` throw synchronously, which no probe could turn into a failure.
+function findServerProblem(server: Server): string | undefined {
+  if (server.port == null && !server.url) {
+    return 'requires each server to define a "port" or a "url".';
+  }
+  if (server.port != null && !isValidPort(server.port)) {
+    return `received an invalid "port": ${server.port}.`;
+  }
+  if (server.url && !canParseUrl(server.url)) {
+    return `received an invalid "url": ${server.url}.`;
+  }
+}
+
+function isValidPort(port: number): boolean {
+  return Number.isInteger(port) && port >= 0 && port <= 65535;
+}
+
 async function waitForServer(server: Server, timeout: number): Promise<void> {
   const label = server.url ?? `port ${server.port}`;
   const deadline = Date.now() + timeout;
   const schedule = [...RETRY_SCHEDULE];
+  let lastObserved: string | undefined;
 
   while (true) {
-    if (await isServerReady(server, deadline)) {
+    const failure = await probeServer(server, deadline);
+    if (failure === null) {
       return;
+    }
+    if (failure !== NO_OBSERVATION) {
+      lastObserved = failure;
     }
     if (Date.now() >= deadline) {
       throw new Error(
-        `Timed out after ${timeout}ms waiting for the E2E web server at ${label} to be ready.`
+        `Timed out after ${timeout}ms waiting for the E2E web server at ${label} to be ready. Last probe: ${
+          lastObserved ?? failure
+        }.`
       );
     }
     const delay = schedule.shift() ?? FALLBACK_RETRY_DELAY;
@@ -62,35 +104,44 @@ async function waitForServer(server: Server, timeout: number): Promise<void> {
 
 // Match Playwright's own check so the gate only clears once Playwright would
 // reuse the running server: connect to the port on both loopback addresses,
-// or poll the URL for an HTTP status in the 200-403 range.
-function isServerReady(server: Server, deadline: number): Promise<boolean> {
+// or poll the URL for an HTTP status below 404.
+function probeServer(server: Server, deadline: number): Promise<ProbeFailure> {
   return server.port != null
-    ? isPortUsed(server.port)
-    : isUrlAvailable(server.url, server.ignoreHTTPSErrors ?? false, deadline);
+    ? probePort(server.port)
+    : probeUrl(server.url, server.ignoreHTTPSErrors ?? false, deadline);
 }
 
-function isPortUsed(port: number): Promise<boolean> {
+function probePort(port: number): Promise<ProbeFailure> {
   const canConnect = (host: string) =>
-    new Promise<boolean>((resolve) => {
+    new Promise<ProbeFailure>((resolve) => {
+      const address = host.includes(':')
+        ? `[${host}]:${port}`
+        : `${host}:${port}`;
       const socket = connect({ port, host });
-      const settle = (result: boolean) => {
+      const settle = (failure: ProbeFailure) => {
         socket.removeAllListeners();
         socket.destroy();
-        resolve(result);
+        resolve(failure);
       };
       socket.setTimeout(FALLBACK_RETRY_DELAY);
-      socket.once('connect', () => settle(true));
-      socket.once('timeout', () => settle(false));
-      socket.once('error', () => settle(false));
+      socket.once('connect', () => settle(null));
+      socket.once('timeout', () => settle(`${address} timed out`));
+      socket.once('error', (error: NodeJS.ErrnoException) =>
+        settle(`${address} ${error.code ?? error.message}`)
+      );
     });
 
-  return new Promise<boolean>((resolve) => {
+  return new Promise<ProbeFailure>((resolve) => {
+    const failures: string[] = [];
     let pending = 2;
-    const onResult = (connected: boolean) => {
-      if (connected) {
-        resolve(true);
-      } else if (--pending === 0) {
-        resolve(false);
+    const onResult = (failure: ProbeFailure) => {
+      if (failure === null) {
+        resolve(null);
+      } else {
+        failures.push(failure);
+        if (--pending === 0) {
+          resolve(failures.join('; '));
+        }
       }
     };
     void canConnect('127.0.0.1').then(onResult);
@@ -98,40 +149,50 @@ function isPortUsed(port: number): Promise<boolean> {
   });
 }
 
-async function isUrlAvailable(
+async function probeUrl(
   url: string,
   ignoreHTTPSErrors: boolean,
   deadline: number
-): Promise<boolean> {
-  let parsedUrl: URL;
-  try {
-    parsedUrl = new URL(url);
-  } catch {
-    return false;
-  }
+): Promise<ProbeFailure> {
+  // Validated before any server is probed, so this cannot throw.
+  const parsedUrl = new URL(url);
 
-  let statusCode = await httpStatusCode(parsedUrl, ignoreHTTPSErrors, deadline);
-  if (statusCode === 404 && parsedUrl.pathname === '/') {
+  let response = await requestStatus(parsedUrl, ignoreHTTPSErrors, deadline);
+  if (response.status === 404 && parsedUrl.pathname === '/') {
     const indexUrl = new URL(parsedUrl);
     indexUrl.pathname = '/index.html';
-    statusCode = await httpStatusCode(indexUrl, ignoreHTTPSErrors, deadline);
+    response = await requestStatus(indexUrl, ignoreHTTPSErrors, deadline);
   }
-  return statusCode >= 200 && statusCode < 404;
+  if (response.status >= 200 && response.status < 404) {
+    return null;
+  }
+  return (
+    response.failure ??
+    `${response.href} responded with status ${response.status}`
+  );
 }
 
-function httpStatusCode(
+interface UrlResponse {
+  // The URL that produced the response, which is the redirect destination when
+  // the chain was followed.
+  href: string;
+  status: number;
+  failure?: string;
+}
+
+function requestStatus(
   url: URL,
   ignoreHTTPSErrors: boolean,
   deadline: number,
   redirectsRemaining = MAX_REDIRECTS
-): Promise<number> {
+): Promise<UrlResponse> {
   return new Promise((resolve) => {
     // Bound each request by the overall readiness deadline, not a fixed
     // interval, so an endpoint that legitimately responds slowly is not
     // aborted before Playwright itself would give up.
     const remaining = deadline - Date.now();
     if (remaining <= 0) {
-      resolve(0);
+      resolve({ href: url.href, status: 0, failure: NO_OBSERVATION });
       return;
     }
     const isHttps = url.protocol === 'https:';
@@ -148,27 +209,35 @@ function httpStatusCode(
       url,
       requestOptions,
       (response) => {
-        const statusCode = response.statusCode ?? 0;
+        const status = response.statusCode ?? 0;
         const location = response.headers.location;
         response.resume();
         request.destroy();
         // Follow redirects like Playwright and evaluate the final
         // destination, so a redirect to an unavailable page is not read as
         // ready. Treat an exhausted or malformed chain as not ready.
-        if (statusCode >= 300 && statusCode < 400 && location) {
+        if (status >= 300 && status < 400 && location) {
           if (redirectsRemaining <= 0) {
-            resolve(0);
+            resolve({
+              href: url.href,
+              status: 0,
+              failure: `${url.href} redirected more than ${MAX_REDIRECTS} times`,
+            });
             return;
           }
           let redirectUrl: URL;
           try {
             redirectUrl = new URL(location, url);
           } catch {
-            resolve(0);
+            resolve({
+              href: url.href,
+              status: 0,
+              failure: `${url.href} redirected to an invalid location "${location}"`,
+            });
             return;
           }
           resolve(
-            httpStatusCode(
+            requestStatus(
               redirectUrl,
               ignoreHTTPSErrors,
               deadline,
@@ -177,19 +246,32 @@ function httpStatusCode(
           );
           return;
         }
-        resolve(statusCode);
+        resolve({ href: url.href, status });
       }
     );
     request.once('timeout', () => {
       request.destroy();
-      resolve(0);
+      resolve({ href: url.href, status: 0, failure: `${url.href} timed out` });
     });
-    request.once('error', () => {
+    request.once('error', (error: NodeJS.ErrnoException) => {
       request.destroy();
-      resolve(0);
+      resolve({
+        href: url.href,
+        status: 0,
+        failure: `${url.href} ${error.code ?? error.message}`,
+      });
     });
     request.end();
   });
+}
+
+function canParseUrl(url: string): boolean {
+  try {
+    new URL(url);
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 function sleep(ms: number): Promise<void> {

--- a/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.ts
+++ b/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.ts
@@ -210,9 +210,7 @@ interface UrlResponse {
   href: string;
   status: number;
   failure?: string;
-  // The proxy the status came back through, if any. A proxy that answers in the
-  // server's place produces one that reads as the server's own until the
-  // message says otherwise.
+  // The proxy the status came back through, if any.
   via?: string;
 }
 

--- a/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.ts
+++ b/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.ts
@@ -50,7 +50,11 @@ export async function waitForWebserverExecutor(
     );
     return { success: true };
   } catch (e) {
-    logger.error(e instanceof Error ? e.message : String(e));
+    logger.error(
+      `@nx/playwright:wait-for-webserver ${
+        e instanceof Error ? e.message : String(e)
+      }`
+    );
     return { success: false };
   }
 }
@@ -285,10 +289,10 @@ function requestStatus(
     // than work of its own: it still fires while a request is in flight, and
     // cannot hold the process open once nothing else does.
     budget = setTimeout(() => {
-      // Staying silent for the window the port probe allows is something the
-      // server did. Going quiet with a sliver of budget left is not: that is
-      // the deadline arriving mid-request, and it says nothing about a server
-      // an earlier probe may have already reached.
+      // Silence for the window the port probe allows is an observation of the
+      // server. A request cut off with less budget than that only means the
+      // deadline arrived mid-flight, and must not displace what an earlier
+      // probe saw.
       settle({
         href: url.href,
         status: 0,

--- a/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.ts
+++ b/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.ts
@@ -135,11 +135,19 @@ async function waitForServer(server: Server, timeout: number): Promise<void> {
 // because Playwright checks one with a raw socket too.
 function probeServer(server: Server, deadline: number): Promise<ProbeFailure> {
   return server.port != null
-    ? probePort(server.port)
+    ? probePort(server.port, deadline)
     : probeUrl(server.url, server.ignoreHTTPSErrors ?? false, deadline);
 }
 
-function probePort(port: number): Promise<ProbeFailure> {
+function probePort(port: number, deadline: number): Promise<ProbeFailure> {
+  // Silence for the retry-delay window is the probe's observation; clamp it so
+  // a connect that hangs (e.g. a firewalled port) cannot run past the
+  // readiness deadline. Floored at 1ms because setTimeout(0) disables the
+  // socket's idle timeout instead.
+  const timeout = Math.max(
+    1,
+    Math.min(FALLBACK_RETRY_DELAY, deadline - Date.now())
+  );
   const canConnect = (host: string) =>
     new Promise<ProbeFailure>((resolve) => {
       const address = host.includes(':')
@@ -151,7 +159,7 @@ function probePort(port: number): Promise<ProbeFailure> {
         socket.destroy();
         resolve(failure);
       };
-      socket.setTimeout(FALLBACK_RETRY_DELAY);
+      socket.setTimeout(timeout);
       socket.once('connect', () => settle(null));
       socket.once('timeout', () => settle(`${address} timed out`));
       socket.once('error', (error: NodeJS.ErrnoException) =>

--- a/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.ts
+++ b/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.ts
@@ -370,8 +370,9 @@ function requestStatus(
         // `localhost` can resolve to ::1 first while the server listens on
         // 127.0.0.1 only; Happy Eyeballs tries both families the way
         // Playwright's probe agent does, on every Node line regardless of the
-        // process-wide default. A proxied request connects to the proxy
-        // instead, where Playwright drops it too.
+        // process-wide default. A proxied request dials the proxy instead;
+        // Playwright keeps its Happy Eyeballs agent for that dial on the
+        // plain-http route and drops it on the CONNECT route.
         // The cast is needed because @types/node's RequestOptions omits the
         // option; Node forwards request options to socket.connect, which
         // honors it.

--- a/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.ts
+++ b/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.ts
@@ -3,7 +3,11 @@ import { HttpsProxyAgent } from 'https-proxy-agent';
 import * as http from 'node:http';
 import * as https from 'node:https';
 import { connect } from 'node:net';
-import { resolveProxyForUrl, type ProxyResolution } from './proxy';
+import {
+  resolveProxyForUrl,
+  withoutCredentials,
+  type ProxyResolution,
+} from './proxy';
 import type { Schema } from './schema';
 
 const DEFAULT_TIMEOUT = 60_000;
@@ -78,7 +82,7 @@ function findServerProblem(server: Server): string | undefined {
     try {
       url = new URL(server.url);
     } catch {
-      return `received an invalid "url": ${server.url}.`;
+      return `received an invalid "url": ${withoutCredentials(server.url)}.`;
     }
     // Only the address the wait starts from is checked here. A redirect can
     // cross to a protocol with its own proxy variable, which the probe reports
@@ -104,7 +108,8 @@ function isValidPort(port: number): boolean {
 }
 
 async function waitForServer(server: Server, timeout: number): Promise<void> {
-  const label = server.url ?? `port ${server.port}`;
+  const label =
+    server.url != null ? redactedHref(server.url) : `port ${server.port}`;
   const deadline = Date.now() + timeout;
   const schedule = [...RETRY_SCHEDULE];
   let lastObserved: string | undefined;
@@ -204,9 +209,9 @@ async function probeUrl(
   }
   return (
     response.failure ??
-    `${response.href} responded with status ${response.status}${viaProxy(
-      response.via
-    )}`
+    `${redactedHref(response.href)} responded with status ${
+      response.status
+    }${viaProxy(response.via)}`
   );
 }
 
@@ -214,6 +219,18 @@ async function probeUrl(
 // request words cannot drift apart.
 function viaProxy(via: string | undefined): string {
   return via ? ` via the proxy at ${via}` : '';
+}
+
+// Probe failures reach the task log, so a URL's credentials come off before it
+// enters one. Callers only pass URLs that already round-tripped through `URL`.
+function redactedHref(href: string): string {
+  const url = new URL(href);
+  if (!url.username && !url.password) {
+    return href;
+  }
+  url.username = '***';
+  url.password = '';
+  return url.href;
 }
 
 interface UrlResponse {
@@ -237,7 +254,7 @@ function requestStatus(
   // between hops or inside the last one.
   const redirectFailure =
     redirects > 0
-      ? `${url.href} redirected ${redirects} times without resolving`
+      ? `${redactedHref(url.href)} redirected ${redirects} times without resolving`
       : undefined;
   const remaining = deadline - Date.now();
   if (remaining <= 0) {
@@ -255,12 +272,13 @@ function requestStatus(
     return Promise.resolve({
       href: url.href,
       status: 0,
-      failure: `${url.href} ${unusableProxyProblem(resolution)}`,
+      failure: `${redactedHref(url.href)} ${unusableProxyProblem(resolution)}`,
     });
   }
 
   const via = resolution.kind === 'proxy' ? resolution.proxy.host : undefined;
-  const describe = (detail: string) => `${url.href} ${detail}${viaProxy(via)}`;
+  const describe = (detail: string) =>
+    `${redactedHref(url.href)} ${detail}${viaProxy(via)}`;
 
   return new Promise((resolve) => {
     const requestOptions: https.RequestOptions = {
@@ -330,11 +348,11 @@ function requestStatus(
             href: url.href,
             status: 0,
             // Node's header parser passes tab and the C1 controls through, and
-            // the value reaches a terminal from here.
+            // the value reaches a terminal from here. Unparseable for URL, so
+            // credentials come off with the string-based treatment.
             failure: describe(
-              `redirected to an invalid location "${location.replace(
-                /[\x00-\x1f\x7f-\x9f]/g,
-                ''
+              `redirected to an invalid location "${withoutCredentials(
+                location.replace(/[\x00-\x1f\x7f-\x9f]/g, '')
               )}"`
             ),
           });
@@ -352,7 +370,9 @@ function requestStatus(
             href: url.href,
             status: 0,
             failure: describe(
-              `redirected to "${redirectUrl.href}", which is not an http or https url`
+              `redirected to "${redactedHref(
+                redirectUrl.href
+              )}", which is not an http or https url`
             ),
           });
           return;

--- a/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.ts
+++ b/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.ts
@@ -117,7 +117,7 @@ async function waitForServer(server: Server, timeout: number): Promise<void> {
       throw new Error(
         `Timed out after ${timeout}ms waiting for the E2E web server at ${label} to be ready. Last observation: ${
           lastObserved ?? failure
-        }.`
+        }. If the server now listens at a different address, run "nx reset" so the gate is re-inferred from the Playwright config.`
       );
     }
     const delay = schedule.shift() ?? FALLBACK_RETRY_DELAY;

--- a/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.ts
+++ b/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.ts
@@ -359,9 +359,20 @@ function requestStatus(
 
     switch (resolution.kind) {
       case 'direct':
+        // `localhost` can resolve to ::1 first while the server listens on
+        // 127.0.0.1 only; Happy Eyeballs tries both families the way
+        // Playwright's probe agent does, on every Node line regardless of the
+        // process-wide default. A proxied request connects to the proxy
+        // instead, where Playwright drops it too.
+        // The cast is needed because @types/node's RequestOptions omits the
+        // option; Node forwards request options to socket.connect, which
+        // honors it.
         request = (url.protocol === 'https:' ? https : http).request(
           url,
-          requestOptions,
+          {
+            ...requestOptions,
+            autoSelectFamily: true,
+          } as https.RequestOptions,
           onResponse
         );
         break;

--- a/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.ts
+++ b/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.ts
@@ -332,6 +332,23 @@ function requestStatus(
           });
           return;
         }
+        if (
+          redirectUrl.protocol !== 'http:' &&
+          redirectUrl.protocol !== 'https:'
+        ) {
+          // Classified like an unparseable location rather than followed into
+          // `http.request`, which would throw synchronously and fail the wait
+          // outright. A boot-time redirect can still settle into a ready
+          // server within the budget.
+          settle({
+            href: url.href,
+            status: 0,
+            failure: describe(
+              `redirected to "${redirectUrl.href}", which is not an http or https url`
+            ),
+          });
+          return;
+        }
         settle(
           requestStatus(redirectUrl, ignoreHTTPSErrors, deadline, redirects + 1)
         );

--- a/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.ts
+++ b/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.ts
@@ -390,9 +390,7 @@ function requestStatus(
         // `localhost` can resolve to ::1 first while the server listens on
         // 127.0.0.1 only; Happy Eyeballs tries both families the way
         // Playwright's probe agent does, on every Node line regardless of the
-        // process-wide default. A proxied request dials the proxy instead;
-        // Playwright keeps its Happy Eyeballs agent for that dial on the
-        // plain-http route and drops it on the CONNECT route.
+        // process-wide default.
         // The cast is needed because @types/node's RequestOptions omits the
         // option; Node forwards request options to socket.connect, which
         // honors it.
@@ -460,9 +458,16 @@ function proxiedRequest(
     agent.connectOpts.signal = signal;
     return https.request(url, { ...options, agent }, onResponse);
   }
+  // Playwright's Happy Eyeballs agent also dials the proxy on this route (its
+  // CONNECT route above drops it, so that one stays default). Same cast as the
+  // direct probe: @types/node's RequestOptions omits the option.
   return (proxy.protocol === 'https:' ? https : http).request(
     proxy,
-    { ...options, path: url.href },
+    {
+      ...options,
+      path: url.href,
+      autoSelectFamily: true,
+    } as https.RequestOptions,
     onResponse
   );
 }

--- a/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.ts
+++ b/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.ts
@@ -540,6 +540,7 @@ function proxiedRequest(
         ...options,
         // Playwright before 1.59.0 never verifies the origin certificate on
         // this route, whatever the caller asked for.
+        // TODO(v25): drop once minSupportedPlaywrightVersion reaches 1.59.0.
         ...(skipProxiedTls ? { rejectUnauthorized: false } : {}),
         agent,
       },

--- a/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.ts
+++ b/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.ts
@@ -4,6 +4,8 @@ import * as http from 'node:http';
 import * as https from 'node:https';
 import { connect } from 'node:net';
 import { join } from 'node:path';
+import { installedPlaywrightVersion } from '../../utils/installed-playwright';
+import { installedPlaywrightReadsNpmConfigProxy } from '../../utils/npm-config-proxy';
 import { installedPlaywrightSkipsProxiedTls } from '../../utils/proxied-tls-verification';
 import {
   resolveProxyForUrl,
@@ -37,14 +39,18 @@ export async function waitForWebserverExecutor(
     );
     return { success: false };
   }
-  const problem = servers.map(findServerProblem).find(Boolean);
+  const playwright = installedPlaywrightVersion(
+    playwrightRequirePaths(context)
+  );
+  const skipProxiedTls = installedPlaywrightSkipsProxiedTls(playwright);
+  const npmConfigProxy = installedPlaywrightReadsNpmConfigProxy(playwright);
+  const problem = servers
+    .map((server) => findServerProblem(server, npmConfigProxy))
+    .find(Boolean);
   if (problem) {
     logger.error(`@nx/playwright:wait-for-webserver ${problem}`);
     return { success: false };
   }
-  const skipProxiedTls = installedPlaywrightSkipsProxiedTls(
-    playwrightRequirePaths(context)
-  );
 
   try {
     await Promise.all(
@@ -54,7 +60,8 @@ export async function waitForWebserverExecutor(
         waitForServer(
           server,
           options.timeout || server.timeout || DEFAULT_TIMEOUT,
-          skipProxiedTls
+          skipProxiedTls,
+          npmConfigProxy
         )
       )
     );
@@ -76,7 +83,10 @@ export default waitForWebserverExecutor;
 // being retried until the timeout and reported as a slow server. An unusable
 // port is also the only input that makes `connect` throw synchronously, which
 // no probe could turn into a failure.
-function findServerProblem(server: Server): string | undefined {
+function findServerProblem(
+  server: Server,
+  npmConfigProxy: boolean
+): string | undefined {
   if (server.port == null && !server.url) {
     return 'requires each server to define a "port" or a "url".';
   }
@@ -93,7 +103,7 @@ function findServerProblem(server: Server): string | undefined {
     // Only the address the wait starts from is checked here. A redirect can
     // cross to a protocol with its own proxy variable, which the probe reports
     // when it gets there.
-    const resolution = resolveProxyForUrl(url);
+    const resolution = resolveProxyForUrl(url, process.env, npmConfigProxy);
     if (resolution.kind === 'unusable') {
       return `${unusableProxyProblem(resolution)}.`;
     }
@@ -131,16 +141,23 @@ function playwrightRequirePaths(context: ExecutorContext): string[] {
 async function waitForServer(
   server: Server,
   timeout: number,
-  skipProxiedTls: boolean
+  skipProxiedTls: boolean,
+  npmConfigProxy: boolean
 ): Promise<void> {
+  // Named the way it is probed: a port wins over a url when both are set.
   const label =
-    server.url != null ? redactedHref(server.url) : `port ${server.port}`;
+    server.port != null ? `port ${server.port}` : redactedHref(server.url);
   const deadline = Date.now() + timeout;
   const schedule = [...RETRY_SCHEDULE];
   let lastObserved: string | undefined;
 
   while (true) {
-    const failure = await probeServer(server, deadline, skipProxiedTls);
+    const failure = await probeServer(
+      server,
+      deadline,
+      skipProxiedTls,
+      npmConfigProxy
+    );
     if (failure === null) {
       return;
     }
@@ -151,7 +168,7 @@ async function waitForServer(
       throw new Error(
         `Timed out after ${timeout}ms waiting for the E2E web server at ${label} to be ready. Last observation: ${
           lastObserved ?? failure
-        }. If the server now listens at a different address, run "nx reset" so the gate is re-inferred from the Playwright config.`
+        }. If the server now listens at a different address, run "nx reset" so the gate is re-inferred from the Playwright config. If a configuration-scoped env file (".env.<target>.<configuration>") sets the address, the gate is inferred without it; set "waitForWebServer" to false on @nx/playwright/plugin instead.`
       );
     }
     const delay = schedule.shift() ?? FALLBACK_RETRY_DELAY;
@@ -166,7 +183,8 @@ async function waitForServer(
 function probeServer(
   server: Server,
   deadline: number,
-  skipProxiedTls: boolean
+  skipProxiedTls: boolean,
+  npmConfigProxy: boolean
 ): Promise<ProbeFailure> {
   return server.port != null
     ? probePort(server.port, deadline)
@@ -174,7 +192,8 @@ function probeServer(
         server.url,
         server.ignoreHTTPSErrors ?? false,
         deadline,
-        skipProxiedTls
+        skipProxiedTls,
+        npmConfigProxy
       );
 }
 
@@ -228,7 +247,8 @@ async function probeUrl(
   url: string,
   ignoreHTTPSErrors: boolean,
   deadline: number,
-  skipProxiedTls: boolean
+  skipProxiedTls: boolean,
+  npmConfigProxy: boolean
 ): Promise<ProbeFailure> {
   // Validated before any server is probed, so this cannot throw.
   const parsedUrl = new URL(url);
@@ -237,7 +257,8 @@ async function probeUrl(
     parsedUrl,
     ignoreHTTPSErrors,
     deadline,
-    skipProxiedTls
+    skipProxiedTls,
+    npmConfigProxy
   );
   if (response.status === 404 && parsedUrl.pathname === '/') {
     const indexUrl = new URL(parsedUrl);
@@ -246,7 +267,8 @@ async function probeUrl(
       indexUrl,
       ignoreHTTPSErrors,
       deadline,
-      skipProxiedTls
+      skipProxiedTls,
+      npmConfigProxy
     );
   }
   if (response.status >= 200 && response.status < 404) {
@@ -293,6 +315,7 @@ function requestStatus(
   ignoreHTTPSErrors: boolean,
   deadline: number,
   skipProxiedTls: boolean,
+  npmConfigProxy: boolean,
   redirects = 0
 ): Promise<UrlResponse> {
   // A chain that ran out of budget still told us the server is answering, so it
@@ -313,7 +336,7 @@ function requestStatus(
 
   // Resolved per URL rather than once per probe so a redirect that changes
   // protocol re-selects the way Playwright's own recursion does.
-  const resolution = resolveProxyForUrl(url);
+  const resolution = resolveProxyForUrl(url, process.env, npmConfigProxy);
   if (resolution.kind === 'unusable') {
     return Promise.resolve({
       href: url.href,
@@ -429,6 +452,7 @@ function requestStatus(
             ignoreHTTPSErrors,
             deadline,
             skipProxiedTls,
+            npmConfigProxy,
             redirects + 1
           )
         );

--- a/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.ts
+++ b/packages/playwright/src/executors/wait-for-webserver/wait-for-webserver.impl.ts
@@ -3,6 +3,8 @@ import { HttpsProxyAgent } from 'https-proxy-agent';
 import * as http from 'node:http';
 import * as https from 'node:https';
 import { connect } from 'node:net';
+import { join } from 'node:path';
+import { installedPlaywrightSkipsProxiedTls } from '../../utils/proxied-tls-verification';
 import {
   resolveProxyForUrl,
   withoutCredentials,
@@ -26,7 +28,7 @@ const NO_OBSERVATION = 'the deadline passed before the server responded';
 
 export async function waitForWebserverExecutor(
   options: Schema,
-  _context: ExecutorContext
+  context: ExecutorContext
 ): Promise<{ success: boolean }> {
   const servers = options.servers ?? [];
   if (servers.length === 0) {
@@ -40,6 +42,9 @@ export async function waitForWebserverExecutor(
     logger.error(`@nx/playwright:wait-for-webserver ${problem}`);
     return { success: false };
   }
+  const skipProxiedTls = installedPlaywrightSkipsProxiedTls(
+    playwrightRequirePaths(context)
+  );
 
   try {
     await Promise.all(
@@ -48,7 +53,8 @@ export async function waitForWebserverExecutor(
         // is how Playwright reads it (`this._options.timeout || 60 * 1e3`).
         waitForServer(
           server,
-          options.timeout || server.timeout || DEFAULT_TIMEOUT
+          options.timeout || server.timeout || DEFAULT_TIMEOUT,
+          skipProxiedTls
         )
       )
     );
@@ -107,7 +113,26 @@ function isValidPort(port: number): boolean {
   return Number.isInteger(port) && port >= 1 && port <= 65535;
 }
 
-async function waitForServer(server: Server, timeout: number): Promise<void> {
+// The directories the task's Playwright install resolves from: the project
+// root, where `playwright test` runs, then the workspace root.
+function playwrightRequirePaths(context: ExecutorContext): string[] {
+  if (context.root == null) {
+    return [];
+  }
+  const projectRoot =
+    context.projectName != null
+      ? context.projectsConfigurations?.projects?.[context.projectName]?.root
+      : undefined;
+  return projectRoot != null
+    ? [join(context.root, projectRoot), context.root]
+    : [context.root];
+}
+
+async function waitForServer(
+  server: Server,
+  timeout: number,
+  skipProxiedTls: boolean
+): Promise<void> {
   const label =
     server.url != null ? redactedHref(server.url) : `port ${server.port}`;
   const deadline = Date.now() + timeout;
@@ -115,7 +140,7 @@ async function waitForServer(server: Server, timeout: number): Promise<void> {
   let lastObserved: string | undefined;
 
   while (true) {
-    const failure = await probeServer(server, deadline);
+    const failure = await probeServer(server, deadline, skipProxiedTls);
     if (failure === null) {
       return;
     }
@@ -138,10 +163,19 @@ async function waitForServer(server: Server, timeout: number): Promise<void> {
 // addresses, or poll the URL for a status from 200 to 403, through whatever
 // proxy the environment configures for it. A port is always probed directly,
 // because Playwright checks one with a raw socket too.
-function probeServer(server: Server, deadline: number): Promise<ProbeFailure> {
+function probeServer(
+  server: Server,
+  deadline: number,
+  skipProxiedTls: boolean
+): Promise<ProbeFailure> {
   return server.port != null
     ? probePort(server.port, deadline)
-    : probeUrl(server.url, server.ignoreHTTPSErrors ?? false, deadline);
+    : probeUrl(
+        server.url,
+        server.ignoreHTTPSErrors ?? false,
+        deadline,
+        skipProxiedTls
+      );
 }
 
 function probePort(port: number, deadline: number): Promise<ProbeFailure> {
@@ -193,16 +227,27 @@ function probePort(port: number, deadline: number): Promise<ProbeFailure> {
 async function probeUrl(
   url: string,
   ignoreHTTPSErrors: boolean,
-  deadline: number
+  deadline: number,
+  skipProxiedTls: boolean
 ): Promise<ProbeFailure> {
   // Validated before any server is probed, so this cannot throw.
   const parsedUrl = new URL(url);
 
-  let response = await requestStatus(parsedUrl, ignoreHTTPSErrors, deadline);
+  let response = await requestStatus(
+    parsedUrl,
+    ignoreHTTPSErrors,
+    deadline,
+    skipProxiedTls
+  );
   if (response.status === 404 && parsedUrl.pathname === '/') {
     const indexUrl = new URL(parsedUrl);
     indexUrl.pathname = '/index.html';
-    response = await requestStatus(indexUrl, ignoreHTTPSErrors, deadline);
+    response = await requestStatus(
+      indexUrl,
+      ignoreHTTPSErrors,
+      deadline,
+      skipProxiedTls
+    );
   }
   if (response.status >= 200 && response.status < 404) {
     return null;
@@ -247,6 +292,7 @@ function requestStatus(
   url: URL,
   ignoreHTTPSErrors: boolean,
   deadline: number,
+  skipProxiedTls: boolean,
   redirects = 0
 ): Promise<UrlResponse> {
   // A chain that ran out of budget still told us the server is answering, so it
@@ -378,7 +424,13 @@ function requestStatus(
           return;
         }
         settle(
-          requestStatus(redirectUrl, ignoreHTTPSErrors, deadline, redirects + 1)
+          requestStatus(
+            redirectUrl,
+            ignoreHTTPSErrors,
+            deadline,
+            skipProxiedTls,
+            redirects + 1
+          )
         );
         return;
       }
@@ -408,6 +460,7 @@ function requestStatus(
           url,
           resolution.proxy,
           requestOptions,
+          skipProxiedTls,
           connecting.signal,
           onResponse
         );
@@ -448,6 +501,7 @@ function proxiedRequest(
   url: URL,
   proxy: URL,
   options: https.RequestOptions,
+  skipProxiedTls: boolean,
   signal: AbortSignal,
   onResponse: (response: http.IncomingMessage) => void
 ): http.ClientRequest {
@@ -456,7 +510,17 @@ function proxiedRequest(
     // The agent dials the proxy itself, so this is the only handle on that
     // connection. A signal in the request options does not reach it.
     agent.connectOpts.signal = signal;
-    return https.request(url, { ...options, agent }, onResponse);
+    return https.request(
+      url,
+      {
+        ...options,
+        // Playwright before 1.59.0 never verifies the origin certificate on
+        // this route, whatever the caller asked for.
+        ...(skipProxiedTls ? { rejectUnauthorized: false } : {}),
+        agent,
+      },
+      onResponse
+    );
   }
   // Playwright's Happy Eyeballs agent also dials the proxy on this route (its
   // CONNECT route above drops it, so that one stays default). Same cast as the

--- a/packages/playwright/src/plugins/plugin.spec.ts
+++ b/packages/playwright/src/plugins/plugin.spec.ts
@@ -1054,9 +1054,14 @@ describe('@nx/playwright/plugin', () => {
   it.each([
     { port: 0 },
     { url: '' },
-    // Playwright probes the url's port over TCP here, which is not the check
-    // the readiness task would run.
+    // Playwright probes the url's port over TCP whenever `port` is defined,
+    // which is not the check the readiness task would run.
     { port: 0, url: 'http://127.0.0.1:4200' },
+    { port: null, url: 'http://127.0.0.1:4200' },
+    // A `playwright.config.js` is not type-checked, so either can arrive as a
+    // type Playwright coerces but the readiness task can't probe.
+    { port: '4200' as unknown as number },
+    { url: 4200 as unknown as string },
   ])(
     'should not infer a wait-for-webserver task when the webServer sets %p',
     async (server) => {

--- a/packages/playwright/src/plugins/plugin.spec.ts
+++ b/packages/playwright/src/plugins/plugin.spec.ts
@@ -930,6 +930,239 @@ describe('@nx/playwright/plugin', () => {
     `);
   });
 
+  it('should infer a wait-for-webserver task and wire the atomized CI tasks to it when the webServer defines a port', async () => {
+    await mockPlaywrightConfig(tempFs, {
+      testDir: 'tests',
+      webServer: {
+        command: 'npx nx run app1:serve',
+        port: 4200,
+        reuseExistingServer: true,
+      },
+    });
+    await tempFs.createFiles({
+      'tests/run-me.spec.ts': '',
+      'tests/run-me-2.spec.ts': '',
+    });
+
+    const results = await createNodesFunction(
+      ['playwright.config.js'],
+      {
+        targetName: 'e2e',
+        ciTargetName: 'e2e-ci',
+      },
+      context
+    );
+    const project = results[0][1].projects['.'];
+    const { targets } = project;
+
+    expect(targets['e2e-ci--wait-for-webserver']).toEqual({
+      executor: '@nx/playwright:wait-for-webserver',
+      cache: false,
+      options: { servers: [{ port: 4200 }] },
+      dependsOn: [{ projects: ['app1'], target: 'serve' }],
+      metadata: {
+        technologies: ['playwright'],
+        description:
+          'Waits for the E2E web server(s) to be ready before the Playwright CI test tasks run.',
+      },
+    });
+    // atomized CI tasks keep the continuous serve dependency (to keep it alive)
+    // and add the discrete readiness gate as a barrier.
+    expect(targets['e2e-ci--tests/run-me.spec.ts'].dependsOn).toEqual([
+      { projects: ['app1'], target: 'serve' },
+      { target: 'e2e-ci--wait-for-webserver' },
+    ]);
+    expect(targets['e2e-ci--tests/run-me-2.spec.ts'].dependsOn).toEqual([
+      { projects: ['app1'], target: 'serve' },
+      { target: 'e2e-ci--wait-for-webserver' },
+    ]);
+    // the non-CI e2e target is unchanged: it only depends on the serve task.
+    expect(targets['e2e'].dependsOn).toEqual([
+      { projects: ['app1'], target: 'serve' },
+    ]);
+    expect(project.metadata.targetGroups['E2E (CI)']).toContain(
+      'e2e-ci--wait-for-webserver'
+    );
+  });
+
+  it('should infer a wait-for-webserver task using the url when the webServer defines a url', async () => {
+    await mockPlaywrightConfig(tempFs, {
+      testDir: 'tests',
+      webServer: {
+        command: 'npx nx run app1:serve',
+        url: 'http://localhost:4200',
+        reuseExistingServer: true,
+      },
+    });
+    await tempFs.createFiles({ 'tests/run-me.spec.ts': '' });
+
+    const results = await createNodesFunction(
+      ['playwright.config.js'],
+      {
+        targetName: 'e2e',
+        ciTargetName: 'e2e-ci',
+      },
+      context
+    );
+    const { targets } = results[0][1].projects['.'];
+
+    expect(targets['e2e-ci--wait-for-webserver'].options).toEqual({
+      servers: [{ url: 'http://localhost:4200' }],
+    });
+    expect(targets['e2e-ci--tests/run-me.spec.ts'].dependsOn).toEqual([
+      { projects: ['app1'], target: 'serve' },
+      { target: 'e2e-ci--wait-for-webserver' },
+    ]);
+  });
+
+  it('should not infer a wait-for-webserver task when the webServer has no port or url', async () => {
+    await mockPlaywrightConfig(tempFs, {
+      testDir: 'tests',
+      webServer: {
+        command: 'npx nx run app1:serve',
+        reuseExistingServer: true,
+      },
+    });
+    await tempFs.createFiles({ 'tests/run-me.spec.ts': '' });
+
+    const results = await createNodesFunction(
+      ['playwright.config.js'],
+      {
+        targetName: 'e2e',
+        ciTargetName: 'e2e-ci',
+      },
+      context
+    );
+    const project = results[0][1].projects['.'];
+    const { targets } = project;
+
+    expect(targets['e2e-ci--wait-for-webserver']).toBeUndefined();
+    // falls back to depending on the serve task only, as before.
+    expect(targets['e2e-ci--tests/run-me.spec.ts'].dependsOn).toEqual([
+      { projects: ['app1'], target: 'serve' },
+    ]);
+    expect(project.metadata.targetGroups['E2E (CI)']).not.toContain(
+      'e2e-ci--wait-for-webserver'
+    );
+  });
+
+  it('should default the wait-for-webserver timeout to the configured webServer.timeout', async () => {
+    await mockPlaywrightConfig(tempFs, {
+      testDir: 'tests',
+      webServer: {
+        command: 'npx nx run app1:serve',
+        port: 4200,
+        reuseExistingServer: true,
+        timeout: 120000,
+      },
+    });
+    await tempFs.createFiles({ 'tests/run-me.spec.ts': '' });
+
+    const results = await createNodesFunction(
+      ['playwright.config.js'],
+      {
+        targetName: 'e2e',
+        ciTargetName: 'e2e-ci',
+      },
+      context
+    );
+    const { targets } = results[0][1].projects['.'];
+
+    expect(targets['e2e-ci--wait-for-webserver'].options).toEqual({
+      servers: [{ port: 4200 }],
+      timeout: 120000,
+    });
+  });
+
+  it('should use the longest configured webServer.timeout across servers', async () => {
+    await mockPlaywrightConfig(tempFs, {
+      testDir: 'tests',
+      webServer: [
+        {
+          command: 'npx nx run app1:serve',
+          port: 4200,
+          reuseExistingServer: true,
+          timeout: 30000,
+        },
+        {
+          command: 'npx nx run api1:serve',
+          port: 3333,
+          reuseExistingServer: true,
+          timeout: 120000,
+        },
+      ],
+    });
+    await tempFs.createFiles({ 'tests/run-me.spec.ts': '' });
+
+    const results = await createNodesFunction(
+      ['playwright.config.js'],
+      {
+        targetName: 'e2e',
+        ciTargetName: 'e2e-ci',
+      },
+      context
+    );
+    const { targets } = results[0][1].projects['.'];
+
+    expect(targets['e2e-ci--wait-for-webserver'].options.timeout).toBe(120000);
+  });
+
+  it('should let the webServerTimeout plugin option override the configured webServer.timeout', async () => {
+    await mockPlaywrightConfig(tempFs, {
+      testDir: 'tests',
+      webServer: {
+        command: 'npx nx run app1:serve',
+        port: 4200,
+        reuseExistingServer: true,
+        timeout: 120000,
+      },
+    });
+    await tempFs.createFiles({ 'tests/run-me.spec.ts': '' });
+
+    const results = await createNodesFunction(
+      ['playwright.config.js'],
+      {
+        targetName: 'e2e',
+        ciTargetName: 'e2e-ci',
+        webServerTimeout: 300000,
+      },
+      context
+    );
+    const { targets } = results[0][1].projects['.'];
+
+    expect(targets['e2e-ci--wait-for-webserver'].options).toEqual({
+      servers: [{ port: 4200 }],
+      timeout: 300000,
+    });
+  });
+
+  it('should pass ignoreHTTPSErrors through to the wait-for-webserver task when set', async () => {
+    await mockPlaywrightConfig(tempFs, {
+      testDir: 'tests',
+      webServer: {
+        command: 'npx nx run app1:serve',
+        url: 'https://localhost:4200',
+        ignoreHTTPSErrors: true,
+        reuseExistingServer: true,
+      },
+    });
+    await tempFs.createFiles({ 'tests/run-me.spec.ts': '' });
+
+    const results = await createNodesFunction(
+      ['playwright.config.js'],
+      {
+        targetName: 'e2e',
+        ciTargetName: 'e2e-ci',
+      },
+      context
+    );
+    const { targets } = results[0][1].projects['.'];
+
+    expect(targets['e2e-ci--wait-for-webserver'].options.servers).toEqual([
+      { url: 'https://localhost:4200', ignoreHTTPSErrors: true },
+    ]);
+  });
+
   it('should not set parallelism to false and should infer dependsOn using the tasks run in the different webServer.command that have reuseExistingServer set to true', async () => {
     await mockPlaywrightConfig(tempFs, {
       testDir: 'tests',

--- a/packages/playwright/src/plugins/plugin.spec.ts
+++ b/packages/playwright/src/plugins/plugin.spec.ts
@@ -1074,12 +1074,11 @@ describe('@nx/playwright/plugin', () => {
     const { targets } = results[0][1].projects['.'];
 
     expect(targets['e2e--wait-for-webserver'].options).toEqual({
-      servers: [{ port: 4200 }],
-      timeout: 120000,
+      servers: [{ port: 4200, timeout: 120000 }],
     });
   });
 
-  it('should use the longest configured webServer.timeout across servers', async () => {
+  it('should keep each configured webServer.timeout on its own server', async () => {
     await mockPlaywrightConfig(tempFs, {
       testDir: 'tests',
       webServer: [
@@ -1109,7 +1108,13 @@ describe('@nx/playwright/plugin', () => {
     );
     const { targets } = results[0][1].projects['.'];
 
-    expect(targets['e2e--wait-for-webserver'].options.timeout).toBe(120000);
+    // a fast server must not inherit a slower server's budget.
+    expect(targets['e2e--wait-for-webserver'].options).toEqual({
+      servers: [
+        { port: 4200, timeout: 30000 },
+        { port: 3333, timeout: 120000 },
+      ],
+    });
   });
 
   it('should let the webServerTimeout plugin option override the configured webServer.timeout', async () => {
@@ -1136,7 +1141,7 @@ describe('@nx/playwright/plugin', () => {
     const { targets } = results[0][1].projects['.'];
 
     expect(targets['e2e--wait-for-webserver'].options).toEqual({
-      servers: [{ port: 4200 }],
+      servers: [{ port: 4200, timeout: 120000 }],
       timeout: 300000,
     });
   });

--- a/packages/playwright/src/plugins/plugin.spec.ts
+++ b/packages/playwright/src/plugins/plugin.spec.ts
@@ -930,7 +930,7 @@ describe('@nx/playwright/plugin', () => {
     `);
   });
 
-  it('should infer a wait-for-webserver task and wire the atomized CI tasks to it when the webServer defines a port', async () => {
+  it('should infer a wait-for-webserver task and wire the e2e and atomized CI tasks to it when the webServer defines a port', async () => {
     await mockPlaywrightConfig(tempFs, {
       testDir: 'tests',
       webServer: {
@@ -955,7 +955,7 @@ describe('@nx/playwright/plugin', () => {
     const project = results[0][1].projects['.'];
     const { targets } = project;
 
-    expect(targets['e2e-ci--wait-for-webserver']).toEqual({
+    expect(targets['e2e--wait-for-webserver']).toEqual({
       executor: '@nx/playwright:wait-for-webserver',
       cache: false,
       options: { servers: [{ port: 4200 }] },
@@ -963,25 +963,27 @@ describe('@nx/playwright/plugin', () => {
       metadata: {
         technologies: ['playwright'],
         description:
-          'Waits for the E2E web server(s) to be ready before the Playwright CI test tasks run.',
+          'Waits for the E2E web server(s) to be ready before the Playwright test tasks run.',
       },
     });
     // atomized CI tasks keep the continuous serve dependency (to keep it alive)
     // and add the discrete readiness gate as a barrier.
     expect(targets['e2e-ci--tests/run-me.spec.ts'].dependsOn).toEqual([
       { projects: ['app1'], target: 'serve' },
-      { target: 'e2e-ci--wait-for-webserver' },
+      { target: 'e2e--wait-for-webserver' },
     ]);
     expect(targets['e2e-ci--tests/run-me-2.spec.ts'].dependsOn).toEqual([
       { projects: ['app1'], target: 'serve' },
-      { target: 'e2e-ci--wait-for-webserver' },
+      { target: 'e2e--wait-for-webserver' },
     ]);
-    // the non-CI e2e target is unchanged: it only depends on the serve task.
+    // the non-CI e2e task shares the same readiness gate as a barrier on top of
+    // the continuous serve dependency.
     expect(targets['e2e'].dependsOn).toEqual([
       { projects: ['app1'], target: 'serve' },
+      { target: 'e2e--wait-for-webserver' },
     ]);
     expect(project.metadata.targetGroups['E2E (CI)']).toContain(
-      'e2e-ci--wait-for-webserver'
+      'e2e--wait-for-webserver'
     );
   });
 
@@ -1006,12 +1008,12 @@ describe('@nx/playwright/plugin', () => {
     );
     const { targets } = results[0][1].projects['.'];
 
-    expect(targets['e2e-ci--wait-for-webserver'].options).toEqual({
+    expect(targets['e2e--wait-for-webserver'].options).toEqual({
       servers: [{ url: 'http://localhost:4200' }],
     });
     expect(targets['e2e-ci--tests/run-me.spec.ts'].dependsOn).toEqual([
       { projects: ['app1'], target: 'serve' },
-      { target: 'e2e-ci--wait-for-webserver' },
+      { target: 'e2e--wait-for-webserver' },
     ]);
   });
 
@@ -1036,13 +1038,16 @@ describe('@nx/playwright/plugin', () => {
     const project = results[0][1].projects['.'];
     const { targets } = project;
 
-    expect(targets['e2e-ci--wait-for-webserver']).toBeUndefined();
-    // falls back to depending on the serve task only, as before.
+    expect(targets['e2e--wait-for-webserver']).toBeUndefined();
+    // both tasks fall back to depending on the serve task only, as before.
     expect(targets['e2e-ci--tests/run-me.spec.ts'].dependsOn).toEqual([
       { projects: ['app1'], target: 'serve' },
     ]);
+    expect(targets['e2e'].dependsOn).toEqual([
+      { projects: ['app1'], target: 'serve' },
+    ]);
     expect(project.metadata.targetGroups['E2E (CI)']).not.toContain(
-      'e2e-ci--wait-for-webserver'
+      'e2e--wait-for-webserver'
     );
   });
 
@@ -1068,7 +1073,7 @@ describe('@nx/playwright/plugin', () => {
     );
     const { targets } = results[0][1].projects['.'];
 
-    expect(targets['e2e-ci--wait-for-webserver'].options).toEqual({
+    expect(targets['e2e--wait-for-webserver'].options).toEqual({
       servers: [{ port: 4200 }],
       timeout: 120000,
     });
@@ -1104,7 +1109,7 @@ describe('@nx/playwright/plugin', () => {
     );
     const { targets } = results[0][1].projects['.'];
 
-    expect(targets['e2e-ci--wait-for-webserver'].options.timeout).toBe(120000);
+    expect(targets['e2e--wait-for-webserver'].options.timeout).toBe(120000);
   });
 
   it('should let the webServerTimeout plugin option override the configured webServer.timeout', async () => {
@@ -1130,7 +1135,7 @@ describe('@nx/playwright/plugin', () => {
     );
     const { targets } = results[0][1].projects['.'];
 
-    expect(targets['e2e-ci--wait-for-webserver'].options).toEqual({
+    expect(targets['e2e--wait-for-webserver'].options).toEqual({
       servers: [{ port: 4200 }],
       timeout: 300000,
     });
@@ -1158,7 +1163,7 @@ describe('@nx/playwright/plugin', () => {
     );
     const { targets } = results[0][1].projects['.'];
 
-    expect(targets['e2e-ci--wait-for-webserver'].options.servers).toEqual([
+    expect(targets['e2e--wait-for-webserver'].options.servers).toEqual([
       { url: 'https://localhost:4200', ignoreHTTPSErrors: true },
     ]);
   });

--- a/packages/playwright/src/plugins/plugin.spec.ts
+++ b/packages/playwright/src/plugins/plugin.spec.ts
@@ -1051,6 +1051,49 @@ describe('@nx/playwright/plugin', () => {
     );
   });
 
+  it.each([
+    { port: 0 },
+    { url: '' },
+    // Playwright probes the url's port over TCP here, which is not the check
+    // the readiness task would run.
+    { port: 0, url: 'http://127.0.0.1:4200' },
+  ])(
+    'should not infer a wait-for-webserver task when the webServer sets %p',
+    async (server) => {
+      await mockPlaywrightConfig(tempFs, {
+        testDir: 'tests',
+        webServer: {
+          command: 'npx nx run app1:serve',
+          reuseExistingServer: true,
+          ...server,
+        },
+      });
+      await tempFs.createFiles({ 'tests/run-me.spec.ts': '' });
+
+      const results = await createNodesFunction(
+        ['playwright.config.js'],
+        {
+          targetName: 'e2e',
+          ciTargetName: 'e2e-ci',
+        },
+        context
+      );
+      const project = results[0][1].projects['.'];
+      const { targets } = project;
+
+      expect(targets['e2e--wait-for-webserver']).toBeUndefined();
+      expect(targets['e2e-ci--tests/run-me.spec.ts'].dependsOn).toEqual([
+        { projects: ['app1'], target: 'serve' },
+      ]);
+      expect(targets['e2e'].dependsOn).toEqual([
+        { projects: ['app1'], target: 'serve' },
+      ]);
+      expect(project.metadata.targetGroups['E2E (CI)']).not.toContain(
+        'e2e--wait-for-webserver'
+      );
+    }
+  );
+
   it('should default the wait-for-webserver timeout to the configured webServer.timeout', async () => {
     await mockPlaywrightConfig(tempFs, {
       testDir: 'tests',

--- a/packages/playwright/src/plugins/plugin.spec.ts
+++ b/packages/playwright/src/plugins/plugin.spec.ts
@@ -1,11 +1,11 @@
-import { CreateNodesContext, logger } from '@nx/devkit';
+import { CreateNodesContext, logger, workspaceRoot } from '@nx/devkit';
+import { setWorkspaceRoot } from '@nx/devkit/internal';
+import * as devkitInternal from '@nx/devkit/internal';
 import { TempFs } from '@nx/devkit/internal-testing-utils';
 import * as jsUtils from '@nx/js';
 import { PlaywrightTestConfig } from '@playwright/test';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { setWorkspaceRoot, workspaceRoot } from 'nx/src/utils/workspace-root';
-import * as workspaceContext from 'nx/src/utils/workspace-context';
 import { createNodesV2 } from './plugin';
 import { _setChildEval, normalizeWebServers } from './webserver-readiness';
 
@@ -1458,7 +1458,7 @@ describe('@nx/playwright/plugin', () => {
     // jest's module registry pins to its first evaluation. Observe the rebuild
     // through the test-file listing instead, which only a cache miss reaches.
     const listTestFiles = jest.spyOn(
-      workspaceContext,
+      devkitInternal,
       'getFilesInDirectoryUsingContext'
     );
 

--- a/packages/playwright/src/plugins/plugin.spec.ts
+++ b/packages/playwright/src/plugins/plugin.spec.ts
@@ -1017,6 +1017,51 @@ describe('@nx/playwright/plugin', () => {
     ]);
   });
 
+  it('resolves the task dotenv env before baking the wait-for-webserver gate', async () => {
+    const originalBaseUrl = process.env.BASE_URL;
+    // Isolate the .env as the only source of BASE_URL; a value left in the
+    // ambient env would satisfy the config on its own and mask the dotenv load.
+    delete process.env.BASE_URL;
+
+    try {
+      await mockPlaywrightConfig(
+        tempFs,
+        `module.exports = {
+  testDir: 'tests',
+  webServer: {
+    command: 'npx nx run app1:serve',
+    url: process.env.BASE_URL || 'http://localhost:4200',
+    reuseExistingServer: true,
+  },
+};`
+      );
+      await tempFs.createFiles({
+        'tests/run-me.spec.ts': '',
+        '.env': 'BASE_URL=http://localhost:4301\n',
+      });
+
+      const results = await createNodesFunction(
+        ['playwright.config.js'],
+        {
+          targetName: 'e2e',
+          ciTargetName: 'e2e-ci',
+        },
+        context
+      );
+      const { targets } = results[0][1].projects['.'];
+
+      expect(targets['e2e--wait-for-webserver'].options).toEqual({
+        servers: [{ url: 'http://localhost:4301' }],
+      });
+    } finally {
+      if (originalBaseUrl === undefined) {
+        delete process.env.BASE_URL;
+      } else {
+        process.env.BASE_URL = originalBaseUrl;
+      }
+    }
+  });
+
   it('should not infer a wait-for-webserver task when the webServer has no port or url', async () => {
     await mockPlaywrightConfig(tempFs, {
       testDir: 'tests',

--- a/packages/playwright/src/plugins/plugin.spec.ts
+++ b/packages/playwright/src/plugins/plugin.spec.ts
@@ -2,8 +2,28 @@ import { CreateNodesContext } from '@nx/devkit';
 import { TempFs } from '@nx/devkit/internal-testing-utils';
 import * as jsUtils from '@nx/js';
 import { PlaywrightTestConfig } from '@playwright/test';
+import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+import { setWorkspaceRoot, workspaceRoot } from 'nx/src/utils/workspace-root';
 import { createNodesV2 } from './plugin';
+import { _setChildEval, normalizeWebServers } from './webserver-readiness';
+
+// The production resolver forks a child whose worker only exists in dist. In
+// tests, mirror the child by evaluating the config source in a fresh scope under
+// the task env; the in-process module cache would otherwise return the ambient
+// evaluation. Only handles the simple CJS configs the env tests use.
+function installFreshConfigEval(): void {
+  _setChildEval(async (configFilePath, wsRoot, env) => {
+    const source = readFileSync(join(wsRoot, configFilePath), 'utf8');
+    const moduleShim: { exports: PlaywrightTestConfig } = { exports: {} };
+    new Function('module', 'exports', 'process', source)(
+      moduleShim,
+      moduleShim.exports,
+      { ...process, env }
+    );
+    return normalizeWebServers(moduleShim.exports.webServer);
+  });
+}
 
 describe('@nx/playwright/plugin', () => {
   let createNodesFunction = createNodesV2[1];
@@ -1019,9 +1039,13 @@ describe('@nx/playwright/plugin', () => {
 
   it('resolves the task dotenv env before baking the wait-for-webserver gate', async () => {
     const originalBaseUrl = process.env.BASE_URL;
+    const originalWorkspaceRoot = workspaceRoot;
     // Isolate the .env as the only source of BASE_URL; a value left in the
     // ambient env would satisfy the config on its own and mask the dotenv load.
     delete process.env.BASE_URL;
+    // getGraphTimeEnvForTask resolves dotenv relative to the workspace root.
+    setWorkspaceRoot(tempFs.tempDir);
+    installFreshConfigEval();
 
     try {
       await mockPlaywrightConfig(
@@ -1054,6 +1078,115 @@ describe('@nx/playwright/plugin', () => {
         servers: [{ url: 'http://localhost:4301' }],
       });
     } finally {
+      _setChildEval(null);
+      setWorkspaceRoot(originalWorkspaceRoot);
+      if (originalBaseUrl === undefined) {
+        delete process.env.BASE_URL;
+      } else {
+        process.env.BASE_URL = originalBaseUrl;
+      }
+    }
+  });
+
+  it('creates a separate gate per chain when e2e and e2e-ci resolve different addresses', async () => {
+    const originalBaseUrl = process.env.BASE_URL;
+    const originalWorkspaceRoot = workspaceRoot;
+    delete process.env.BASE_URL;
+    setWorkspaceRoot(tempFs.tempDir);
+    installFreshConfigEval();
+
+    try {
+      await mockPlaywrightConfig(
+        tempFs,
+        `module.exports = {
+  testDir: 'tests',
+  webServer: {
+    command: 'npx nx run app1:serve',
+    url: process.env.BASE_URL || 'http://localhost:4200',
+    reuseExistingServer: true,
+  },
+};`
+      );
+      // The e2e-ci chain also loads .env.e2e-ci, which wins over .env.e2e, so
+      // the two chains resolve different addresses and each gets its own gate.
+      await tempFs.createFiles({
+        'tests/run-me.spec.ts': '',
+        '.env.e2e': 'BASE_URL=http://localhost:4301\n',
+        '.env.e2e-ci': 'BASE_URL=http://localhost:4302\n',
+      });
+
+      const results = await createNodesFunction(
+        ['playwright.config.js'],
+        {
+          targetName: 'e2e',
+          ciTargetName: 'e2e-ci',
+        },
+        context
+      );
+      const { targets } = results[0][1].projects['.'];
+
+      expect(targets['e2e--wait-for-webserver'].options.servers).toEqual([
+        { url: 'http://localhost:4301' },
+      ]);
+      expect(targets['e2e-ci--wait-for-webserver'].options.servers).toEqual([
+        { url: 'http://localhost:4302' },
+      ]);
+      expect(targets['e2e'].dependsOn).toContainEqual({
+        target: 'e2e--wait-for-webserver',
+      });
+      expect(targets['e2e-ci--tests/run-me.spec.ts'].dependsOn).toContainEqual({
+        target: 'e2e-ci--wait-for-webserver',
+      });
+    } finally {
+      _setChildEval(null);
+      setWorkspaceRoot(originalWorkspaceRoot);
+      if (originalBaseUrl === undefined) {
+        delete process.env.BASE_URL;
+      } else {
+        process.env.BASE_URL = originalBaseUrl;
+      }
+    }
+  });
+
+  it('fails createNodes when the config cannot be evaluated under the task env', async () => {
+    const originalBaseUrl = process.env.BASE_URL;
+    const originalWorkspaceRoot = workspaceRoot;
+    delete process.env.BASE_URL;
+    setWorkspaceRoot(tempFs.tempDir);
+    // A failed evaluation must surface, not bake a wrong gate into the graph.
+    _setChildEval(async () => {
+      throw new Error('boom');
+    });
+
+    try {
+      await mockPlaywrightConfig(
+        tempFs,
+        `module.exports = {
+  testDir: 'tests',
+  webServer: {
+    command: 'npx nx run app1:serve',
+    url: process.env.BASE_URL || 'http://localhost:4200',
+    reuseExistingServer: true,
+  },
+};`
+      );
+      await tempFs.createFiles({
+        'tests/run-me.spec.ts': '',
+        '.env': 'BASE_URL=http://localhost:4301\n',
+      });
+
+      const error = await createNodesFunction(
+        ['playwright.config.js'],
+        { targetName: 'e2e', ciTargetName: 'e2e-ci' },
+        context
+      ).catch((e) => e);
+      const innerMessages = (error.errors ?? [])
+        .map(([, e]: [unknown, Error]) => e.message)
+        .join('\n');
+      expect(innerMessages).toMatch(/could not evaluate/);
+    } finally {
+      _setChildEval(null);
+      setWorkspaceRoot(originalWorkspaceRoot);
       if (originalBaseUrl === undefined) {
         delete process.env.BASE_URL;
       } else {

--- a/packages/playwright/src/plugins/plugin.spec.ts
+++ b/packages/playwright/src/plugins/plugin.spec.ts
@@ -1007,6 +1007,45 @@ describe('@nx/playwright/plugin', () => {
     );
   });
 
+  it('does not infer a wait-for-webserver task when waitForWebServer is false', async () => {
+    await mockPlaywrightConfig(tempFs, {
+      testDir: 'tests',
+      webServer: {
+        command: 'npx nx run app1:serve',
+        port: 4200,
+        reuseExistingServer: true,
+      },
+    });
+    await tempFs.createFiles({
+      'tests/run-me.spec.ts': '',
+    });
+
+    const results = await createNodesFunction(
+      ['playwright.config.js'],
+      {
+        targetName: 'e2e',
+        ciTargetName: 'e2e-ci',
+        waitForWebServer: false,
+      },
+      context
+    );
+    const project = results[0][1].projects['.'];
+    const { targets } = project;
+
+    // No gate is inferred; the serve dependency stays so the tests still start
+    // the server, but readiness falls back to Playwright's own probe.
+    expect(targets['e2e--wait-for-webserver']).toBeUndefined();
+    expect(targets['e2e'].dependsOn).toEqual([
+      { projects: ['app1'], target: 'serve' },
+    ]);
+    expect(targets['e2e-ci--tests/run-me.spec.ts'].dependsOn).toEqual([
+      { projects: ['app1'], target: 'serve' },
+    ]);
+    expect(project.metadata.targetGroups['E2E (CI)']).not.toContain(
+      'e2e--wait-for-webserver'
+    );
+  });
+
   it('should infer a wait-for-webserver task using the url when the webServer defines a url', async () => {
     await mockPlaywrightConfig(tempFs, {
       testDir: 'tests',

--- a/packages/playwright/src/plugins/plugin.spec.ts
+++ b/packages/playwright/src/plugins/plugin.spec.ts
@@ -1,4 +1,4 @@
-import { CreateNodesContext, logger, workspaceRoot } from '@nx/devkit';
+import { CreateNodesContext, workspaceRoot } from '@nx/devkit';
 import { setWorkspaceRoot } from '@nx/devkit/internal';
 import * as devkitInternal from '@nx/devkit/internal';
 import { TempFs } from '@nx/devkit/internal-testing-utils';
@@ -6,7 +6,7 @@ import * as jsUtils from '@nx/js';
 import { PlaywrightTestConfig } from '@playwright/test';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-import { createNodesV2 } from './plugin';
+import { _clearWarnedUnparseableCommands, createNodesV2 } from './plugin';
 import { _setChildEval, normalizeWebServers } from './webserver-readiness';
 
 // The plugin writes its disk cache under `workspaceDataDirectory`, which is
@@ -29,9 +29,11 @@ jest.mock('nx/src/utils/cache-directory', () => {
 // tests, mirror the child by evaluating the config source in a fresh scope under
 // the task env; the in-process module cache would otherwise return the ambient
 // evaluation. Only handles the simple CJS configs the env tests use.
-function installFreshConfigEval(onEval?: () => void): void {
+function installFreshConfigEval(
+  onEval?: (env: NodeJS.ProcessEnv) => void
+): void {
   _setChildEval(async (configFilePath, wsRoot, env) => {
-    onEval?.();
+    onEval?.(env);
     const source = readFileSync(join(wsRoot, configFilePath), 'utf8');
     const moduleShim: { exports: PlaywrightTestConfig } = { exports: {} };
     new Function('module', 'exports', 'process', source)(
@@ -72,6 +74,9 @@ describe('@nx/playwright/plugin', () => {
     mockWorkspaceDataDir = join(tempFs.tempDir, '.nx', 'workspace-data');
     originalCacheProjectGraph = process.env.NX_CACHE_PROJECT_GRAPH;
     process.env.NX_CACHE_PROJECT_GRAPH = 'false';
+    // The warn-once set outlives a test; without the reset, a warn assertion
+    // is coupled to its (config, command) pair being unique in the file.
+    _clearWarnedUnparseableCommands();
   });
 
   afterEach(() => {
@@ -1620,7 +1625,11 @@ describe('@nx/playwright/plugin', () => {
     _setChildEval(async () => {
       throw new Error('boom');
     });
-    const warn = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+    // The plugin warns through emitPluginWorkerLog so the message survives the
+    // daemon, where `logger.warn` routes to the daemon log file.
+    const warn = jest
+      .spyOn(devkitInternal, 'emitPluginWorkerLog')
+      .mockImplementation(() => {});
 
     try {
       await mockPlaywrightConfig(
@@ -1657,9 +1666,151 @@ describe('@nx/playwright/plugin', () => {
         { projects: ['app1'], target: 'serve' },
       ]);
       expect(warn).toHaveBeenCalledWith(
+        'warn',
         expect.stringMatching(/could not evaluate playwright\.config\.js/)
       );
-      expect(warn).toHaveBeenCalledWith(expect.stringMatching(/boom/));
+      expect(warn).toHaveBeenCalledWith('warn', expect.stringMatching(/boom/));
+    } finally {
+      warn.mockRestore();
+      _setChildEval(null);
+      setWorkspaceRoot(originalWorkspaceRoot);
+      if (originalBaseUrl === undefined) {
+        delete process.env.BASE_URL;
+      } else {
+        process.env.BASE_URL = originalBaseUrl;
+      }
+    }
+  });
+
+  it('retries the task-env evaluation on the next pass instead of caching the failed fallback', async () => {
+    const originalBaseUrl = process.env.BASE_URL;
+    const originalWorkspaceRoot = workspaceRoot;
+    delete process.env.BASE_URL;
+    setWorkspaceRoot(tempFs.tempDir);
+    process.env.NX_CACHE_PROJECT_GRAPH = 'true';
+    let failEval = true;
+    let evals = 0;
+    installFreshConfigEval(() => {
+      evals++;
+      if (failEval) {
+        throw new Error('boom');
+      }
+    });
+    const warn = jest
+      .spyOn(devkitInternal, 'emitPluginWorkerLog')
+      .mockImplementation(() => {});
+
+    try {
+      await mockPlaywrightConfig(
+        tempFs,
+        `module.exports = {
+  testDir: 'tests',
+  webServer: {
+    command: 'npx nx run app1:serve',
+    url: process.env.BASE_URL || 'http://localhost:4200',
+    reuseExistingServer: true,
+  },
+};`
+      );
+      await tempFs.createFiles({
+        'tests/run-me.spec.ts': '',
+        '.env': 'BASE_URL=http://localhost:4301\n',
+      });
+
+      const run = async () =>
+        (
+          await createNodesFunction(
+            ['playwright.config.js'],
+            { targetName: 'e2e', ciTargetName: 'e2e-ci' },
+            context
+          )
+        )[0][1].projects['.'].targets;
+
+      // The failure degrades this pass to the ambient config with no gate.
+      const first = await run();
+      expect(first['e2e--wait-for-webserver']).toBeUndefined();
+      expect(evals).toBe(1);
+
+      // Nothing about the failed pass may be cached: a transient fault (a
+      // timeout, a fork error) must not permanently disable the gate, so the
+      // next pass re-attempts the evaluation and infers the gate.
+      failEval = false;
+      const second = await run();
+      expect(evals).toBe(2);
+      expect(second['e2e--wait-for-webserver'].options.servers).toEqual([
+        { url: 'http://localhost:4301' },
+      ]);
+    } finally {
+      warn.mockRestore();
+      _setChildEval(null);
+      setWorkspaceRoot(originalWorkspaceRoot);
+      process.env.NX_CACHE_PROJECT_GRAPH = 'false';
+      if (originalBaseUrl === undefined) {
+        delete process.env.BASE_URL;
+      } else {
+        process.env.BASE_URL = originalBaseUrl;
+      }
+    }
+  });
+
+  it('keeps a successful chain gated when only the other chain fails to evaluate', async () => {
+    const originalBaseUrl = process.env.BASE_URL;
+    const originalWorkspaceRoot = workspaceRoot;
+    delete process.env.BASE_URL;
+    setWorkspaceRoot(tempFs.tempDir);
+    installFreshConfigEval((env) => {
+      if (env.FAIL_CI === '1') {
+        throw new Error('ci-chain boom');
+      }
+    });
+    const warn = jest
+      .spyOn(devkitInternal, 'emitPluginWorkerLog')
+      .mockImplementation(() => {});
+
+    try {
+      await mockPlaywrightConfig(
+        tempFs,
+        `module.exports = {
+  testDir: 'tests',
+  webServer: {
+    command: 'npx nx run app1:serve',
+    url: process.env.BASE_URL || 'http://localhost:4200',
+    reuseExistingServer: true,
+  },
+};`
+      );
+      // The ci-only dotenv makes the chains diverge, so each evaluates on its
+      // own; the marker makes only the ci evaluation fail.
+      await tempFs.createFiles({
+        'tests/run-me.spec.ts': '',
+        '.env': 'BASE_URL=http://localhost:4301\n',
+        '.env.e2e-ci': 'FAIL_CI=1\n',
+      });
+
+      const results = await createNodesFunction(
+        ['playwright.config.js'],
+        { targetName: 'e2e', ciTargetName: 'e2e-ci' },
+        context
+      );
+      const { targets } = results[0][1].projects['.'];
+
+      // The e2e chain resolved under its task env and keeps its gate.
+      expect(targets['e2e--wait-for-webserver'].options.servers).toEqual([
+        { url: 'http://localhost:4301' },
+      ]);
+      expect(targets['e2e'].dependsOn).toContainEqual({
+        target: 'e2e--wait-for-webserver',
+      });
+      // The failed ci chain degrades to the ambient serve dependency, no gate.
+      expect(targets['e2e-ci--wait-for-webserver']).toBeUndefined();
+      expect(targets['e2e-ci--tests/run-me.spec.ts'].dependsOn).toEqual([
+        { projects: ['app1'], target: 'serve' },
+      ]);
+      expect(warn).toHaveBeenCalledTimes(1);
+      expect(warn).toHaveBeenCalledWith(
+        'warn',
+        expect.stringMatching(/for e2e-ci\b[\s\S]*ci-chain boom/)
+      );
     } finally {
       warn.mockRestore();
       _setChildEval(null);
@@ -1939,7 +2090,9 @@ describe('@nx/playwright/plugin', () => {
   });
 
   it('warns when a reuseExistingServer webServer command cannot be inferred', async () => {
-    const warn = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+    const warn = jest
+      .spyOn(devkitInternal, 'emitPluginWorkerLog')
+      .mockImplementation(() => {});
     try {
       await mockPlaywrightConfig(tempFs, {
         testDir: 'tests',
@@ -1964,8 +2117,42 @@ describe('@nx/playwright/plugin', () => {
       expect(targets['e2e'].dependsOn).toBeUndefined();
       expect(targets['e2e'].parallelism).toBe(false);
       expect(warn).toHaveBeenCalledWith(
+        'warn',
         expect.stringContaining('npx nx run app1:serve --port=4200')
       );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('does not warn for a webServer command that is not an Nx invocation', async () => {
+    const warn = jest
+      .spyOn(devkitInternal, 'emitPluginWorkerLog')
+      .mockImplementation(() => {});
+    try {
+      await mockPlaywrightConfig(tempFs, {
+        testDir: 'tests',
+        webServer: {
+          command: 'npm run start',
+          port: 4200,
+          reuseExistingServer: true,
+        },
+      });
+      await tempFs.createFiles({ 'tests/run-me.spec.ts': '' });
+
+      const results = await createNodesFunction(
+        ['playwright.config.js'],
+        { targetName: 'e2e', ciTargetName: 'e2e-ci' },
+        context
+      );
+      const { targets } = results[0][1].projects['.'];
+
+      // A non-Nx command was never meant to map to a task, so the skip is not
+      // worth announcing; the serialization guard still applies.
+      expect(warn).not.toHaveBeenCalled();
+      expect(targets['e2e--wait-for-webserver']).toBeUndefined();
+      expect(targets['e2e'].dependsOn).toBeUndefined();
+      expect(targets['e2e'].parallelism).toBe(false);
     } finally {
       warn.mockRestore();
     }
@@ -2028,6 +2215,12 @@ describe('@nx/playwright/plugin', () => {
     expect(targets['e2e'].dependsOn).not.toContainEqual(
       expect.objectContaining({ projects: expect.arrayContaining(['worker1']) })
     );
+    // The wait-based server gets no inferred task, so nothing in the graph
+    // starts it; the consuming tasks stay serialized even though the app1
+    // dependency was inferred.
+    expect(targets['e2e'].parallelism).toBe(false);
+    expect(targets['e2e-ci--tests/run-me.spec.ts'].parallelism).toBe(false);
+    expect(targets['e2e-ci'].parallelism).toBe(false);
   });
 
   it('should leave a config whose only webServer waits for command output entirely to Playwright', async () => {

--- a/packages/playwright/src/plugins/plugin.spec.ts
+++ b/packages/playwright/src/plugins/plugin.spec.ts
@@ -8,12 +8,29 @@ import { setWorkspaceRoot, workspaceRoot } from 'nx/src/utils/workspace-root';
 import { createNodesV2 } from './plugin';
 import { _setChildEval, normalizeWebServers } from './webserver-readiness';
 
+// The plugin writes its disk cache under `workspaceDataDirectory`, which is
+// resolved from the real workspace root at import time. Redirect it into the
+// test's temp dir so cache round-trips stay isolated from the repo. `var` so
+// import-time readers of the export (nx's daemon tmp-dir) see the hoisted
+// empty value and fall back to the actual path instead of hitting the TDZ.
+var mockWorkspaceDataDir = '';
+jest.mock('nx/src/utils/cache-directory', () => {
+  const actual = jest.requireActual('nx/src/utils/cache-directory');
+  return {
+    ...actual,
+    get workspaceDataDirectory() {
+      return mockWorkspaceDataDir || actual.workspaceDataDirectory;
+    },
+  };
+});
+
 // The production resolver forks a child whose worker only exists in dist. In
 // tests, mirror the child by evaluating the config source in a fresh scope under
 // the task env; the in-process module cache would otherwise return the ambient
 // evaluation. Only handles the simple CJS configs the env tests use.
-function installFreshConfigEval(): void {
+function installFreshConfigEval(onEval?: () => void): void {
   _setChildEval(async (configFilePath, wsRoot, env) => {
+    onEval?.();
     const source = readFileSync(join(wsRoot, configFilePath), 'utf8');
     const moduleShim: { exports: PlaywrightTestConfig } = { exports: {} };
     new Function('module', 'exports', 'process', source)(
@@ -51,6 +68,7 @@ describe('@nx/playwright/plugin', () => {
     };
 
     process.chdir(tempFs.tempDir);
+    mockWorkspaceDataDir = join(tempFs.tempDir, '.nx', 'workspace-data');
     originalCacheProjectGraph = process.env.NX_CACHE_PROJECT_GRAPH;
     process.env.NX_CACHE_PROJECT_GRAPH = 'false';
   });
@@ -1179,6 +1197,74 @@ describe('@nx/playwright/plugin', () => {
     } finally {
       _setChildEval(null);
       setWorkspaceRoot(originalWorkspaceRoot);
+      if (originalBaseUrl === undefined) {
+        delete process.env.BASE_URL;
+      } else {
+        process.env.BASE_URL = originalBaseUrl;
+      }
+    }
+  });
+
+  it('rebuilds a cached gate when a dotenv outside the project changes', async () => {
+    const originalBaseUrl = process.env.BASE_URL;
+    const originalWorkspaceRoot = workspaceRoot;
+    delete process.env.BASE_URL;
+    setWorkspaceRoot(tempFs.tempDir);
+    // The disk cache is what carries a stale gate across runs, so this test
+    // needs it on, unlike the rest of the suite.
+    process.env.NX_CACHE_PROJECT_GRAPH = 'true';
+    let evals = 0;
+    installFreshConfigEval(() => evals++);
+
+    try {
+      // A nested project whose config reads a workspace-root .env: the .env is
+      // outside the project's createNodes hash, so only the dotenv overlay in
+      // the plugin cache key can pick up a change to it.
+      await tempFs.createFiles({
+        'apps/e2e/project.json': '{}',
+        'apps/e2e/playwright.config.js': `module.exports = {
+  testDir: 'tests',
+  webServer: {
+    command: 'npx nx run app1:serve',
+    url: process.env.BASE_URL || 'http://localhost:4200',
+    reuseExistingServer: true,
+  },
+};`,
+        'apps/e2e/tests/run-me.spec.ts': '',
+        '.env': 'BASE_URL=http://localhost:4301\n',
+      });
+
+      const run = async () =>
+        (
+          await createNodesFunction(
+            ['apps/e2e/playwright.config.js'],
+            { targetName: 'e2e', ciTargetName: 'e2e-ci' },
+            context
+          )
+        )[0][1].projects['apps/e2e'].targets;
+
+      const first = await run();
+      expect(first['e2e--wait-for-webserver'].options.servers).toEqual([
+        { url: 'http://localhost:4301' },
+      ]);
+      const evalsAfterFirst = evals;
+
+      const second = await run();
+      expect(second['e2e--wait-for-webserver'].options.servers).toEqual([
+        { url: 'http://localhost:4301' },
+      ]);
+      expect(evals).toBe(evalsAfterFirst);
+
+      await tempFs.createFile('.env', 'BASE_URL=http://localhost:4302\n');
+      const third = await run();
+      expect(third['e2e--wait-for-webserver'].options.servers).toEqual([
+        { url: 'http://localhost:4302' },
+      ]);
+      expect(evals).toBeGreaterThan(evalsAfterFirst);
+    } finally {
+      _setChildEval(null);
+      setWorkspaceRoot(originalWorkspaceRoot);
+      process.env.NX_CACHE_PROJECT_GRAPH = 'false';
       if (originalBaseUrl === undefined) {
         delete process.env.BASE_URL;
       } else {

--- a/packages/playwright/src/plugins/plugin.spec.ts
+++ b/packages/playwright/src/plugins/plugin.spec.ts
@@ -1526,6 +1526,150 @@ describe('@nx/playwright/plugin', () => {
     }
   });
 
+  it('rebuilds cached targets when an allowed ambient env var changes', async () => {
+    const originalToolHome = process.env.TOOL_HOME;
+    const originalWorkspaceRoot = workspaceRoot;
+    delete process.env.TOOL_HOME;
+    setWorkspaceRoot(tempFs.tempDir);
+    process.env.NX_CACHE_PROJECT_GRAPH = 'true';
+    // The cache hit/miss is not observable through the returned targets (the
+    // in-process config load is pinned to its first evaluation), so observe it
+    // through the test-file listing, which only a cache miss reaches.
+    const listTestFiles = jest.spyOn(
+      devkitInternal,
+      'getFilesInDirectoryUsingContext'
+    );
+
+    try {
+      await tempFs.createFiles({
+        'apps/e2e/project.json': '{}',
+        'apps/e2e/playwright.config.js': 'module.exports = {}',
+      });
+
+      const run = () =>
+        createNodesFunction(
+          ['apps/e2e/playwright.config.js'],
+          { targetName: 'e2e', ciTargetName: 'e2e-ci' },
+          context
+        );
+
+      await run();
+      const rebuildsAfterFirst = listTestFiles.mock.calls.length;
+
+      // A rerun with nothing changed stays cached.
+      await run();
+      expect(listTestFiles.mock.calls.length).toBe(rebuildsAfterFirst);
+
+      process.env.TOOL_HOME = '/usr/lib/tool';
+      await run();
+      expect(listTestFiles.mock.calls.length).toBeGreaterThan(
+        rebuildsAfterFirst
+      );
+    } finally {
+      listTestFiles.mockRestore();
+      setWorkspaceRoot(originalWorkspaceRoot);
+      process.env.NX_CACHE_PROJECT_GRAPH = 'false';
+      if (originalToolHome === undefined) {
+        delete process.env.TOOL_HOME;
+      } else {
+        process.env.TOOL_HOME = originalToolHome;
+      }
+    }
+  });
+
+  it('keeps cached targets when an excluded ambient env var changes', async () => {
+    const originalItermProfile = process.env.ITERM_PROFILE;
+    const originalWorkspaceRoot = workspaceRoot;
+    delete process.env.ITERM_PROFILE;
+    setWorkspaceRoot(tempFs.tempDir);
+    process.env.NX_CACHE_PROJECT_GRAPH = 'true';
+    const listTestFiles = jest.spyOn(
+      devkitInternal,
+      'getFilesInDirectoryUsingContext'
+    );
+
+    try {
+      await tempFs.createFiles({
+        'apps/e2e/project.json': '{}',
+        'apps/e2e/playwright.config.js': 'module.exports = {}',
+      });
+
+      const run = () =>
+        createNodesFunction(
+          ['apps/e2e/playwright.config.js'],
+          { targetName: 'e2e', ciTargetName: 'e2e-ci' },
+          context
+        );
+
+      await run();
+      const rebuildsAfterFirst = listTestFiles.mock.calls.length;
+
+      process.env.ITERM_PROFILE = 'Default';
+      await run();
+      expect(listTestFiles.mock.calls.length).toBe(rebuildsAfterFirst);
+    } finally {
+      listTestFiles.mockRestore();
+      setWorkspaceRoot(originalWorkspaceRoot);
+      process.env.NX_CACHE_PROJECT_GRAPH = 'false';
+      if (originalItermProfile === undefined) {
+        delete process.env.ITERM_PROFILE;
+      } else {
+        process.env.ITERM_PROFILE = originalItermProfile;
+      }
+    }
+  });
+
+  it('does not persist a pass whose ambient env changed mid-pass', async () => {
+    const originalBootFlag = process.env.BOOT_FLAG;
+    const originalWorkspaceRoot = workspaceRoot;
+    delete process.env.BOOT_FLAG;
+    setWorkspaceRoot(tempFs.tempDir);
+    process.env.NX_CACHE_PROJECT_GRAPH = 'true';
+    const listTestFiles = jest.spyOn(
+      devkitInternal,
+      'getFilesInDirectoryUsingContext'
+    );
+
+    try {
+      // The config mutates an allowed env var when evaluated, so the pass's
+      // entries are keyed under a digest that no longer matches the env they
+      // were built in. The pass must not persist them: a later pass under the
+      // original env would otherwise hit an entry built under the mutated one.
+      await tempFs.createFiles({
+        'apps/e2e/project.json': '{}',
+        'apps/e2e/playwright.config.js': `process.env.BOOT_FLAG = 'set';
+module.exports = {};`,
+      });
+
+      const run = () =>
+        createNodesFunction(
+          ['apps/e2e/playwright.config.js'],
+          { targetName: 'e2e', ciTargetName: 'e2e-ci' },
+          context
+        );
+
+      await run();
+      const rebuildsAfterFirst = listTestFiles.mock.calls.length;
+
+      // Back on the pass-start env: the same cache key, so only the skipped
+      // persist can force this re-evaluation.
+      delete process.env.BOOT_FLAG;
+      await run();
+      expect(listTestFiles.mock.calls.length).toBeGreaterThan(
+        rebuildsAfterFirst
+      );
+    } finally {
+      listTestFiles.mockRestore();
+      setWorkspaceRoot(originalWorkspaceRoot);
+      process.env.NX_CACHE_PROJECT_GRAPH = 'false';
+      if (originalBootFlag === undefined) {
+        delete process.env.BOOT_FLAG;
+      } else {
+        process.env.BOOT_FLAG = originalBootFlag;
+      }
+    }
+  });
+
   it('shares one config re-evaluation when both chains load the same dotenv inputs', async () => {
     const originalBaseUrl = process.env.BASE_URL;
     const originalWorkspaceRoot = workspaceRoot;

--- a/packages/playwright/src/plugins/plugin.spec.ts
+++ b/packages/playwright/src/plugins/plugin.spec.ts
@@ -1,4 +1,4 @@
-import { CreateNodesContext } from '@nx/devkit';
+import { CreateNodesContext, logger } from '@nx/devkit';
 import { TempFs } from '@nx/devkit/internal-testing-utils';
 import * as jsUtils from '@nx/js';
 import { PlaywrightTestConfig } from '@playwright/test';
@@ -1495,15 +1495,17 @@ describe('@nx/playwright/plugin', () => {
     }
   });
 
-  it('fails createNodes when the config cannot be evaluated under the task env', async () => {
+  it('falls back to the ambient config and skips the gate when the config cannot be evaluated under the task env', async () => {
     const originalBaseUrl = process.env.BASE_URL;
     const originalWorkspaceRoot = workspaceRoot;
     delete process.env.BASE_URL;
     setWorkspaceRoot(tempFs.tempDir);
-    // A failed evaluation must surface, not bake a wrong gate into the graph.
+    // An unverified address must not become a gate the daemon then caches, but
+    // graph construction must survive the failed evaluation.
     _setChildEval(async () => {
       throw new Error('boom');
     });
+    const warn = jest.spyOn(logger, 'warn').mockImplementation(() => {});
 
     try {
       await mockPlaywrightConfig(
@@ -1522,17 +1524,29 @@ describe('@nx/playwright/plugin', () => {
         '.env': 'BASE_URL=http://localhost:4301\n',
       });
 
-      const error = await createNodesFunction(
+      const results = await createNodesFunction(
         ['playwright.config.js'],
         { targetName: 'e2e', ciTargetName: 'e2e-ci' },
         context
-      ).catch((e) => e);
-      const innerMessages = (error.errors ?? [])
-        .map(([, e]: [unknown, Error]) => e.message)
-        .join('\n');
-      expect(innerMessages).toMatch(/could not evaluate/);
-      expect(innerMessages).toMatch(/"waitForWebServer": false/);
+      );
+      const { targets } = results[0][1].projects['.'];
+
+      // The serve dependency comes from the ambient evaluation; no gate is
+      // inferred for the failed chain.
+      expect(targets['e2e--wait-for-webserver']).toBeUndefined();
+      expect(targets['e2e-ci--wait-for-webserver']).toBeUndefined();
+      expect(targets['e2e'].dependsOn).toEqual([
+        { projects: ['app1'], target: 'serve' },
+      ]);
+      expect(targets['e2e-ci--tests/run-me.spec.ts'].dependsOn).toEqual([
+        { projects: ['app1'], target: 'serve' },
+      ]);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringMatching(/could not evaluate playwright\.config\.js/)
+      );
+      expect(warn).toHaveBeenCalledWith(expect.stringMatching(/boom/));
     } finally {
+      warn.mockRestore();
       _setChildEval(null);
       setWorkspaceRoot(originalWorkspaceRoot);
       if (originalBaseUrl === undefined) {

--- a/packages/playwright/src/plugins/plugin.spec.ts
+++ b/packages/playwright/src/plugins/plugin.spec.ts
@@ -1326,6 +1326,253 @@ describe('@nx/playwright/plugin', () => {
     }
   });
 
+  it('skips the gate but keeps the dependency when a task env file changes how the server would be probed', async () => {
+    const savedEnv = saveEnv([
+      'HTTP_PROXY',
+      'http_proxy',
+      'NO_PROXY',
+      'no_proxy',
+    ]);
+    const originalWorkspaceRoot = workspaceRoot;
+    // The gate task runs under its own dotenv, so a task-scoped proxy
+    // exclusion never reaches it: probing through the ambient proxy could time
+    // out where Playwright's own probe (under the task env) goes direct.
+    process.env.HTTP_PROXY = 'http://proxy.example:8080';
+    setWorkspaceRoot(tempFs.tempDir);
+    installFreshConfigEval();
+    const warn = jest
+      .spyOn(devkitInternal, 'emitPluginWorkerLog')
+      .mockImplementation(() => {});
+
+    try {
+      await mockPlaywrightConfig(
+        tempFs,
+        `module.exports = {
+  testDir: 'tests',
+  webServer: [
+    { command: 'npx nx run app1:serve', port: 4200, reuseExistingServer: true },
+    { command: 'npx nx run api1:serve', url: 'http://localhost:4300', reuseExistingServer: true },
+  ],
+};`
+      );
+      await tempFs.createFiles({
+        'tests/run-me.spec.ts': '',
+        '.env.e2e': 'NO_PROXY=localhost\n',
+      });
+
+      const results = await createNodesFunction(
+        ['playwright.config.js'],
+        {
+          targetName: 'e2e',
+          ciTargetName: 'e2e-ci',
+        },
+        context
+      );
+      const { targets } = results[0][1].projects['.'];
+
+      // The whole chain's gate is skipped, the port-only server included: the
+      // gate is a single task and a partial wait would claim readiness it
+      // never checked.
+      expect(targets['e2e--wait-for-webserver']).toBeUndefined();
+      expect(targets['e2e-ci--wait-for-webserver']).toBeUndefined();
+      expect(targets['e2e'].dependsOn).toContainEqual({
+        projects: ['app1', 'api1'],
+        target: 'serve',
+      });
+      expect(targets['e2e'].parallelism).toBeUndefined();
+      // The warning names the diverging variables, never their values.
+      expect(warn).toHaveBeenCalledWith(
+        'warn',
+        expect.stringContaining('NO_PROXY')
+      );
+      expect(warn).not.toHaveBeenCalledWith(
+        'warn',
+        expect.stringContaining('localhost')
+      );
+    } finally {
+      warn.mockRestore();
+      _setChildEval(null);
+      setWorkspaceRoot(originalWorkspaceRoot);
+      restoreEnv(savedEnv);
+    }
+  });
+
+  it('keeps the gate of a chain whose task env does not change the probe', async () => {
+    const savedEnv = saveEnv([
+      'HTTP_PROXY',
+      'http_proxy',
+      'NO_PROXY',
+      'no_proxy',
+    ]);
+    const originalWorkspaceRoot = workspaceRoot;
+    process.env.HTTP_PROXY = 'http://proxy.example:8080';
+    setWorkspaceRoot(tempFs.tempDir);
+    installFreshConfigEval();
+    const warn = jest
+      .spyOn(devkitInternal, 'emitPluginWorkerLog')
+      .mockImplementation(() => {});
+
+    try {
+      await mockPlaywrightConfig(
+        tempFs,
+        `module.exports = {
+  testDir: 'tests',
+  webServer: {
+    command: 'npx nx run app1:serve',
+    url: 'http://localhost:4200',
+    reuseExistingServer: true,
+  },
+};`
+      );
+      // Only the atomized chain loads the exclusion, so only its gate is
+      // skipped; the e2e chain keeps its own.
+      await tempFs.createFiles({
+        'tests/run-me.spec.ts': '',
+        '.env.e2e-ci': 'NO_PROXY=localhost\n',
+      });
+
+      const results = await createNodesFunction(
+        ['playwright.config.js'],
+        {
+          targetName: 'e2e',
+          ciTargetName: 'e2e-ci',
+        },
+        context
+      );
+      const { targets } = results[0][1].projects['.'];
+
+      expect(targets['e2e--wait-for-webserver'].options.servers).toEqual([
+        { url: 'http://localhost:4200' },
+      ]);
+      expect(targets['e2e'].dependsOn).toContainEqual({
+        target: 'e2e--wait-for-webserver',
+      });
+      expect(targets['e2e-ci--wait-for-webserver']).toBeUndefined();
+      expect(targets['e2e-ci--tests/run-me.spec.ts'].dependsOn).toContainEqual({
+        projects: ['app1'],
+        target: 'serve',
+      });
+      expect(
+        targets['e2e-ci--tests/run-me.spec.ts'].dependsOn
+      ).not.toContainEqual(
+        expect.objectContaining({ target: expect.stringContaining('wait-for') })
+      );
+      expect(warn).toHaveBeenCalledWith(
+        'warn',
+        expect.stringContaining('e2e-ci')
+      );
+    } finally {
+      warn.mockRestore();
+      _setChildEval(null);
+      setWorkspaceRoot(originalWorkspaceRoot);
+      restoreEnv(savedEnv);
+    }
+  });
+
+  it('keeps a port-only gate under a task env that only changes url probing', async () => {
+    const savedEnv = saveEnv([
+      'HTTP_PROXY',
+      'http_proxy',
+      'NO_PROXY',
+      'no_proxy',
+    ]);
+    const originalWorkspaceRoot = workspaceRoot;
+    process.env.HTTP_PROXY = 'http://proxy.example:8080';
+    setWorkspaceRoot(tempFs.tempDir);
+    installFreshConfigEval();
+
+    try {
+      await mockPlaywrightConfig(
+        tempFs,
+        `module.exports = {
+  testDir: 'tests',
+  webServer: {
+    command: 'npx nx run app1:serve',
+    port: 4200,
+    reuseExistingServer: true,
+  },
+};`
+      );
+      // A port is probed with a raw TCP connect, which no proxy or TLS env
+      // affects.
+      await tempFs.createFiles({
+        'tests/run-me.spec.ts': '',
+        '.env.e2e': 'NO_PROXY=localhost\n',
+      });
+
+      const results = await createNodesFunction(
+        ['playwright.config.js'],
+        {
+          targetName: 'e2e',
+          ciTargetName: 'e2e-ci',
+        },
+        context
+      );
+      const { targets } = results[0][1].projects['.'];
+
+      expect(targets['e2e--wait-for-webserver'].options.servers).toEqual([
+        { port: 4200 },
+      ]);
+    } finally {
+      _setChildEval(null);
+      setWorkspaceRoot(originalWorkspaceRoot);
+      restoreEnv(savedEnv);
+    }
+  });
+
+  it('skips the gate when a task env file changes the TLS material of a verifying https probe', async () => {
+    const savedEnv = saveEnv(['NODE_EXTRA_CA_CERTS']);
+    const originalWorkspaceRoot = workspaceRoot;
+    setWorkspaceRoot(tempFs.tempDir);
+    installFreshConfigEval();
+    const warn = jest
+      .spyOn(devkitInternal, 'emitPluginWorkerLog')
+      .mockImplementation(() => {});
+
+    try {
+      await mockPlaywrightConfig(
+        tempFs,
+        `module.exports = {
+  testDir: 'tests',
+  webServer: {
+    command: 'npx nx run app1:serve',
+    url: 'https://localhost:4200',
+    reuseExistingServer: true,
+  },
+};`
+      );
+      await tempFs.createFiles({
+        'tests/run-me.spec.ts': '',
+        '.env.e2e': 'NODE_EXTRA_CA_CERTS=./certs/ca.pem\n',
+      });
+
+      const results = await createNodesFunction(
+        ['playwright.config.js'],
+        {
+          targetName: 'e2e',
+          ciTargetName: 'e2e-ci',
+        },
+        context
+      );
+      const { targets } = results[0][1].projects['.'];
+
+      expect(targets['e2e--wait-for-webserver']).toBeUndefined();
+      expect(targets['e2e'].dependsOn).toContainEqual({
+        projects: ['app1'],
+        target: 'serve',
+      });
+      expect(warn).toHaveBeenCalledWith(
+        'warn',
+        expect.stringContaining('NODE_EXTRA_CA_CERTS')
+      );
+    } finally {
+      warn.mockRestore();
+      _setChildEval(null);
+      setWorkspaceRoot(originalWorkspaceRoot);
+      restoreEnv(savedEnv);
+    }
+  });
+
   it('serializes the atomized tasks when only the CI chain adds an uncovered server', async () => {
     const originalCiExtra = process.env.CI_EXTRA;
     const originalWorkspaceRoot = workspaceRoot;
@@ -2538,6 +2785,86 @@ module.exports = {};`,
     expect(targets['e2e'].parallelism).toBe(false);
   });
 
+  it('should not gate or depend on a webServer that sets env, leaving its launch to Playwright', async () => {
+    // Only Playwright passes `webServer.env` to the command it starts. A
+    // task-started server would run without it, listening at a different
+    // address (a PORT) or silently reused missing the env the tests rely on.
+    await mockPlaywrightConfig(tempFs, {
+      testDir: 'tests',
+      webServer: [
+        {
+          command: 'npx nx run app1:serve',
+          port: 4200,
+          reuseExistingServer: true,
+        },
+        {
+          command: 'npx nx run api1:serve',
+          url: 'http://localhost:4300',
+          reuseExistingServer: true,
+          env: { PORT: '4300' },
+        },
+      ],
+    });
+    await tempFs.createFiles({ 'tests/run-me.spec.ts': '' });
+
+    const results = await createNodesFunction(
+      ['playwright.config.js'],
+      {
+        targetName: 'e2e',
+        ciTargetName: 'e2e-ci',
+      },
+      context
+    );
+    const { targets } = results[0][1].projects['.'];
+
+    expect(targets['e2e--wait-for-webserver'].options.servers).toEqual([
+      { port: 4200 },
+    ]);
+    expect(targets['e2e'].dependsOn).toContainEqual({
+      projects: ['app1'],
+      target: 'serve',
+    });
+    expect(targets['e2e'].dependsOn).not.toContainEqual(
+      expect.objectContaining({ projects: expect.arrayContaining(['api1']) })
+    );
+    // Playwright starts the env-carrying server itself, so nothing in the
+    // graph covers it; serialize so parallel atomized runs cannot race it.
+    expect(targets['e2e'].parallelism).toBe(false);
+    expect(targets['e2e-ci'].parallelism).toBe(false);
+  });
+
+  it('should still gate a webServer whose env is empty', async () => {
+    await mockPlaywrightConfig(tempFs, {
+      testDir: 'tests',
+      webServer: {
+        command: 'npx nx run app1:serve',
+        port: 4200,
+        reuseExistingServer: true,
+        env: {},
+      },
+    });
+    await tempFs.createFiles({ 'tests/run-me.spec.ts': '' });
+
+    const results = await createNodesFunction(
+      ['playwright.config.js'],
+      {
+        targetName: 'e2e',
+        ciTargetName: 'e2e-ci',
+      },
+      context
+    );
+    const { targets } = results[0][1].projects['.'];
+
+    expect(targets['e2e--wait-for-webserver'].options.servers).toEqual([
+      { port: 4200 },
+    ]);
+    expect(targets['e2e'].dependsOn).toContainEqual({
+      projects: ['app1'],
+      target: 'serve',
+    });
+    expect(targets['e2e'].parallelism).toBeUndefined();
+  });
+
   it('should not set parallelism to false and should infer dependsOn using the tasks run in the different webServer.command that have reuseExistingServer set to true', async () => {
     await mockPlaywrightConfig(tempFs, {
       testDir: 'tests',
@@ -2959,4 +3286,25 @@ async function mockPlaywrightConfig(
       ? config
       : `module.exports = ${JSON.stringify(config)}`
   );
+}
+
+// Clears the named variables so a developer's ambient proxy or TLS env cannot
+// leak into the probe-divergence assertions.
+function saveEnv(names: string[]): Record<string, string | undefined> {
+  const saved: Record<string, string | undefined> = {};
+  for (const name of names) {
+    saved[name] = process.env[name];
+    delete process.env[name];
+  }
+  return saved;
+}
+
+function restoreEnv(saved: Record<string, string | undefined>): void {
+  for (const [name, value] of Object.entries(saved)) {
+    if (value === undefined) {
+      delete process.env[name];
+    } else {
+      process.env[name] = value;
+    }
+  }
 }

--- a/packages/playwright/src/plugins/plugin.spec.ts
+++ b/packages/playwright/src/plugins/plugin.spec.ts
@@ -1938,6 +1938,58 @@ describe('@nx/playwright/plugin', () => {
     ]);
   });
 
+  it('warns when a reuseExistingServer webServer command cannot be inferred', async () => {
+    const warn = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+    try {
+      await mockPlaywrightConfig(tempFs, {
+        testDir: 'tests',
+        webServer: {
+          command: 'npx nx run app1:serve --port=4200',
+          port: 4200,
+          reuseExistingServer: true,
+        },
+      });
+      await tempFs.createFiles({ 'tests/run-me.spec.ts': '' });
+
+      const results = await createNodesFunction(
+        ['playwright.config.js'],
+        { targetName: 'e2e', ciTargetName: 'e2e-ci' },
+        context
+      );
+      const { targets } = results[0][1].projects['.'];
+
+      // The command was meant to be reused as a task, so its silent drop would
+      // read as the feature not working; the skip itself matches master.
+      expect(targets['e2e--wait-for-webserver']).toBeUndefined();
+      expect(targets['e2e'].dependsOn).toBeUndefined();
+      expect(targets['e2e'].parallelism).toBe(false);
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('npx nx run app1:serve --port=4200')
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('should not crash on a webServer without a command', async () => {
+    await mockPlaywrightConfig(tempFs, {
+      testDir: 'tests',
+      webServer: { port: 4200, reuseExistingServer: true } as any,
+    });
+    await tempFs.createFiles({ 'tests/run-me.spec.ts': '' });
+
+    const results = await createNodesFunction(
+      ['playwright.config.js'],
+      { targetName: 'e2e', ciTargetName: 'e2e-ci' },
+      context
+    );
+    const { targets } = results[0][1].projects['.'];
+
+    expect(targets['e2e--wait-for-webserver']).toBeUndefined();
+    expect(targets['e2e'].dependsOn).toBeUndefined();
+    expect(targets['e2e'].parallelism).toBe(false);
+  });
+
   it('should not gate or depend on a webServer that waits for command output', async () => {
     // Playwright treats a `wait.stdout`/`wait.stderr` server as ready when the
     // regex matches (raced against the address probe) and stores named capture

--- a/packages/playwright/src/plugins/plugin.spec.ts
+++ b/packages/playwright/src/plugins/plugin.spec.ts
@@ -1326,6 +1326,64 @@ describe('@nx/playwright/plugin', () => {
     }
   });
 
+  it('serializes the atomized tasks when only the CI chain adds an uncovered server', async () => {
+    const originalCiExtra = process.env.CI_EXTRA;
+    const originalWorkspaceRoot = workspaceRoot;
+    delete process.env.CI_EXTRA;
+    setWorkspaceRoot(tempFs.tempDir);
+    installFreshConfigEval();
+
+    try {
+      await mockPlaywrightConfig(
+        tempFs,
+        `module.exports = {
+  testDir: 'tests',
+  webServer: [
+    {
+      command: 'npx nx run app1:serve',
+      url: 'http://localhost:4200',
+      reuseExistingServer: true,
+    },
+    ...(process.env.CI_EXTRA
+      ? [{ command: 'node worker.js', reuseExistingServer: true }]
+      : []),
+  ],
+};`
+      );
+      // Both chains resolve the same inferred server and address, so they
+      // share the gate; only the CI chain sees the extra uncovered server.
+      await tempFs.createFiles({
+        'tests/run-me.spec.ts': '',
+        '.env.e2e-ci': 'CI_EXTRA=1\n',
+      });
+
+      const results = await createNodesFunction(
+        ['playwright.config.js'],
+        { targetName: 'e2e', ciTargetName: 'e2e-ci' },
+        context
+      );
+      const { targets } = results[0][1].projects['.'];
+
+      expect(targets['e2e--wait-for-webserver']).toBeDefined();
+      expect(targets['e2e-ci--wait-for-webserver']).toBeUndefined();
+      expect(targets['e2e'].parallelism).toBeUndefined();
+      // The uncovered worker server races parallel atomized runs, so they
+      // must serialize even though the gate is shared.
+      expect(targets['e2e-ci--tests/run-me.spec.ts'].parallelism).toBe(false);
+      expect(targets['e2e-ci--tests/run-me.spec.ts'].dependsOn).toContainEqual({
+        target: 'e2e--wait-for-webserver',
+      });
+    } finally {
+      _setChildEval(null);
+      setWorkspaceRoot(originalWorkspaceRoot);
+      if (originalCiExtra === undefined) {
+        delete process.env.CI_EXTRA;
+      } else {
+        process.env.CI_EXTRA = originalCiExtra;
+      }
+    }
+  });
+
   it('clears the inherited parallelism when only the CI chain resolves serve tasks', async () => {
     const originalServeCommand = process.env.SERVE_COMMAND;
     const originalWorkspaceRoot = workspaceRoot;
@@ -1667,6 +1725,56 @@ module.exports = {};`,
       } else {
         process.env.BOOT_FLAG = originalBootFlag;
       }
+    }
+  });
+
+  it('does not persist a pass during which the daemon swapped the env away and back', async () => {
+    const originalWorkspaceRoot = workspaceRoot;
+    setWorkspaceRoot(tempFs.tempDir);
+    process.env.NX_CACHE_PROJECT_GRAPH = 'true';
+    const listTestFiles = jest.spyOn(
+      devkitInternal,
+      'getFilesInDirectoryUsingContext'
+    );
+    // Another client's env landing on the worker mid-pass and being restored
+    // before the pass ends reproduces the pass-start digest, so only the
+    // application count can reveal that entries were built under the interim
+    // env. Simulated through the count alone: it moves between the pass-start
+    // read and the write-guard read.
+    const envGeneration = jest.spyOn(
+      devkitInternal,
+      'getDaemonClientEnvGeneration'
+    );
+    envGeneration.mockReturnValueOnce(0);
+    envGeneration.mockReturnValue(1);
+
+    try {
+      await tempFs.createFiles({
+        'apps/e2e/project.json': '{}',
+        'apps/e2e/playwright.config.js': 'module.exports = {}',
+      });
+
+      const run = () =>
+        createNodesFunction(
+          ['apps/e2e/playwright.config.js'],
+          { targetName: 'e2e', ciTargetName: 'e2e-ci' },
+          context
+        );
+
+      await run();
+      const rebuildsAfterFirst = listTestFiles.mock.calls.length;
+
+      // The env (and so the cache key) matches the first pass, so only the
+      // skipped persist can force this re-evaluation.
+      await run();
+      expect(listTestFiles.mock.calls.length).toBeGreaterThan(
+        rebuildsAfterFirst
+      );
+    } finally {
+      listTestFiles.mockRestore();
+      envGeneration.mockRestore();
+      setWorkspaceRoot(originalWorkspaceRoot);
+      process.env.NX_CACHE_PROJECT_GRAPH = 'false';
     }
   });
 
@@ -2263,6 +2371,38 @@ module.exports = {};`,
       expect(warn).toHaveBeenCalledWith(
         'warn',
         expect.stringContaining('npx nx run app1:serve --port=4200')
+      );
+    } finally {
+      warn.mockRestore();
+    }
+  });
+
+  it('warns for a versioned nx invocation that cannot be inferred', async () => {
+    const warn = jest
+      .spyOn(devkitInternal, 'emitPluginWorkerLog')
+      .mockImplementation(() => {});
+    try {
+      await mockPlaywrightConfig(tempFs, {
+        testDir: 'tests',
+        webServer: {
+          // `nx@latest` is still an Nx invocation, so its skip warrants the
+          // same warning as a bare `nx` one.
+          command: 'npx nx@latest run app1:serve --port=4200',
+          port: 4200,
+          reuseExistingServer: true,
+        },
+      });
+      await tempFs.createFiles({ 'tests/run-me.spec.ts': '' });
+
+      await createNodesFunction(
+        ['playwright.config.js'],
+        { targetName: 'e2e', ciTargetName: 'e2e-ci' },
+        context
+      );
+
+      expect(warn).toHaveBeenCalledWith(
+        'warn',
+        expect.stringContaining('npx nx@latest run app1:serve --port=4200')
       );
     } finally {
       warn.mockRestore();

--- a/packages/playwright/src/plugins/plugin.spec.ts
+++ b/packages/playwright/src/plugins/plugin.spec.ts
@@ -1908,6 +1908,36 @@ describe('@nx/playwright/plugin', () => {
     ]);
   });
 
+  it('should keep the dependency but not gate a webServer command with a trailing configuration', async () => {
+    await mockPlaywrightConfig(tempFs, {
+      testDir: 'tests',
+      webServer: {
+        command: 'npx nx run app1:serve:production',
+        port: 4200,
+        reuseExistingServer: true,
+      },
+    });
+    await tempFs.createFiles({ 'tests/run-me.spec.ts': '' });
+
+    const results = await createNodesFunction(
+      ['playwright.config.js'],
+      { targetName: 'e2e', ciTargetName: 'e2e-ci' },
+      context
+    );
+    const { targets } = results[0][1].projects['.'];
+
+    // The dependency runs the target without the configuration, so the
+    // started server may not listen at the configured address; readiness is
+    // left to Playwright's own probe.
+    expect(targets['e2e--wait-for-webserver']).toBeUndefined();
+    expect(targets['e2e'].dependsOn).toEqual([
+      { projects: ['app1'], target: 'serve' },
+    ]);
+    expect(targets['e2e-ci--tests/run-me.spec.ts'].dependsOn).toEqual([
+      { projects: ['app1'], target: 'serve' },
+    ]);
+  });
+
   it('should not gate or depend on a webServer that waits for command output', async () => {
     // Playwright treats a `wait.stdout`/`wait.stderr` server as ready when the
     // regex matches (raced against the address probe) and stores named capture

--- a/packages/playwright/src/plugins/plugin.spec.ts
+++ b/packages/playwright/src/plugins/plugin.spec.ts
@@ -1223,6 +1223,7 @@ describe('@nx/playwright/plugin', () => {
         .map(([, e]: [unknown, Error]) => e.message)
         .join('\n');
       expect(innerMessages).toMatch(/could not evaluate/);
+      expect(innerMessages).toMatch(/"waitForWebServer": false/);
     } finally {
       _setChildEval(null);
       setWorkspaceRoot(originalWorkspaceRoot);

--- a/packages/playwright/src/plugins/plugin.spec.ts
+++ b/packages/playwright/src/plugins/plugin.spec.ts
@@ -5,6 +5,7 @@ import { PlaywrightTestConfig } from '@playwright/test';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { setWorkspaceRoot, workspaceRoot } from 'nx/src/utils/workspace-root';
+import * as workspaceContext from 'nx/src/utils/workspace-context';
 import { createNodesV2 } from './plugin';
 import { _setChildEval, normalizeWebServers } from './webserver-readiness';
 
@@ -1100,7 +1101,7 @@ describe('@nx/playwright/plugin', () => {
     // Isolate the .env as the only source of BASE_URL; a value left in the
     // ambient env would satisfy the config on its own and mask the dotenv load.
     delete process.env.BASE_URL;
-    // getGraphTimeEnvForTask resolves dotenv relative to the workspace root.
+    // getGraphTimeDotEnvForTask resolves dotenv relative to the workspace root.
     setWorkspaceRoot(tempFs.tempDir);
     installFreshConfigEval();
 
@@ -1205,6 +1206,64 @@ describe('@nx/playwright/plugin', () => {
     }
   });
 
+  it('clears the inherited parallelism when only the CI chain resolves serve tasks', async () => {
+    const originalServeCommand = process.env.SERVE_COMMAND;
+    const originalWorkspaceRoot = workspaceRoot;
+    delete process.env.SERVE_COMMAND;
+    setWorkspaceRoot(tempFs.tempDir);
+    installFreshConfigEval();
+
+    try {
+      await mockPlaywrightConfig(
+        tempFs,
+        `module.exports = {
+  testDir: 'tests',
+  webServer: {
+    command: process.env.SERVE_COMMAND || 'node server.js',
+    url: 'http://localhost:4200',
+    reuseExistingServer: true,
+  },
+};`
+      );
+      // Only the e2e-ci chain resolves an inferrable serve command, so the
+      // atomized tasks must swap the inherited parallelism: false for the CI
+      // chain's dependsOn rather than carry both.
+      await tempFs.createFiles({
+        'tests/run-me.spec.ts': '',
+        '.env.e2e-ci': 'SERVE_COMMAND=npx nx run app1:serve\n',
+      });
+
+      const results = await createNodesFunction(
+        ['playwright.config.js'],
+        {
+          targetName: 'e2e',
+          ciTargetName: 'e2e-ci',
+        },
+        context
+      );
+      const { targets } = results[0][1].projects['.'];
+
+      expect(targets['e2e'].parallelism).toBe(false);
+      expect(targets['e2e'].dependsOn).toBeUndefined();
+      expect(targets['e2e--wait-for-webserver']).toBeUndefined();
+
+      const atomized = targets['e2e-ci--tests/run-me.spec.ts'];
+      expect(atomized.dependsOn).toEqual([
+        { projects: ['app1'], target: 'serve' },
+        { target: 'e2e-ci--wait-for-webserver' },
+      ]);
+      expect(atomized.parallelism).toBeUndefined();
+    } finally {
+      _setChildEval(null);
+      setWorkspaceRoot(originalWorkspaceRoot);
+      if (originalServeCommand === undefined) {
+        delete process.env.SERVE_COMMAND;
+      } else {
+        process.env.SERVE_COMMAND = originalServeCommand;
+      }
+    }
+  });
+
   it('rebuilds a cached gate when a dotenv outside the project changes', async () => {
     const originalBaseUrl = process.env.BASE_URL;
     const originalWorkspaceRoot = workspaceRoot;
@@ -1218,8 +1277,8 @@ describe('@nx/playwright/plugin', () => {
 
     try {
       // A nested project whose config reads a workspace-root .env: the .env is
-      // outside the project's createNodes hash, so only the dotenv overlay in
-      // the plugin cache key can pick up a change to it.
+      // outside the project's createNodes hash, so only the dotenv fingerprint
+      // in the plugin cache key can pick up a change to it.
       await tempFs.createFiles({
         'apps/e2e/project.json': '{}',
         'apps/e2e/playwright.config.js': `module.exports = {
@@ -1265,6 +1324,169 @@ describe('@nx/playwright/plugin', () => {
       _setChildEval(null);
       setWorkspaceRoot(originalWorkspaceRoot);
       process.env.NX_CACHE_PROJECT_GRAPH = 'false';
+      if (originalBaseUrl === undefined) {
+        delete process.env.BASE_URL;
+      } else {
+        process.env.BASE_URL = originalBaseUrl;
+      }
+    }
+  });
+
+  it('rebuilds a cached gate when a dotenv change round-trips through the ambient env', async () => {
+    const originalBaseUrl = process.env.BASE_URL;
+    const originalWorkspaceRoot = workspaceRoot;
+    setWorkspaceRoot(tempFs.tempDir);
+    process.env.NX_CACHE_PROJECT_GRAPH = 'true';
+    installFreshConfigEval();
+    // The task env matches ambient in this scenario, so no child evaluation
+    // runs and the gate's address comes from the in-process config load, which
+    // jest's module registry pins to its first evaluation. Observe the rebuild
+    // through the test-file listing instead, which only a cache miss reaches.
+    const listTestFiles = jest.spyOn(
+      workspaceContext,
+      'getFilesInDirectoryUsingContext'
+    );
+
+    try {
+      // The daemon loads the root .env into its own env at startup, so the
+      // ambient env and the file agree and the task env matches ambient. After
+      // an edit plus a daemon restart they agree again on the new value: only
+      // the file content in the plugin cache key can tell the two runs apart,
+      // an env-delta digest sees an empty delta in both.
+      process.env.BASE_URL = 'http://localhost:4301';
+      await tempFs.createFiles({
+        'apps/e2e/project.json': '{}',
+        'apps/e2e/playwright.config.js': `module.exports = {
+  testDir: 'tests',
+  webServer: {
+    command: 'npx nx run app1:serve',
+    url: process.env.BASE_URL || 'http://localhost:4200',
+    reuseExistingServer: true,
+  },
+};`,
+        'apps/e2e/tests/run-me.spec.ts': '',
+        '.env': 'BASE_URL=http://localhost:4301\n',
+      });
+
+      const run = async () =>
+        (
+          await createNodesFunction(
+            ['apps/e2e/playwright.config.js'],
+            { targetName: 'e2e', ciTargetName: 'e2e-ci' },
+            context
+          )
+        )[0][1].projects['apps/e2e'].targets;
+
+      const first = await run();
+      expect(first['e2e--wait-for-webserver'].options.servers).toEqual([
+        { url: 'http://localhost:4301' },
+      ]);
+      const rebuildsAfterFirst = listTestFiles.mock.calls.length;
+
+      // A rerun with nothing changed stays cached.
+      await run();
+      expect(listTestFiles.mock.calls.length).toBe(rebuildsAfterFirst);
+
+      process.env.BASE_URL = 'http://localhost:4302';
+      await tempFs.createFile('.env', 'BASE_URL=http://localhost:4302\n');
+      await run();
+      expect(listTestFiles.mock.calls.length).toBeGreaterThan(
+        rebuildsAfterFirst
+      );
+    } finally {
+      listTestFiles.mockRestore();
+      _setChildEval(null);
+      setWorkspaceRoot(originalWorkspaceRoot);
+      process.env.NX_CACHE_PROJECT_GRAPH = 'false';
+      if (originalBaseUrl === undefined) {
+        delete process.env.BASE_URL;
+      } else {
+        process.env.BASE_URL = originalBaseUrl;
+      }
+    }
+  });
+
+  it('shares one config re-evaluation when both chains load the same dotenv inputs', async () => {
+    const originalBaseUrl = process.env.BASE_URL;
+    const originalWorkspaceRoot = workspaceRoot;
+    delete process.env.BASE_URL;
+    setWorkspaceRoot(tempFs.tempDir);
+    let evals = 0;
+    installFreshConfigEval(() => evals++);
+
+    try {
+      await mockPlaywrightConfig(
+        tempFs,
+        `module.exports = {
+  testDir: 'tests',
+  webServer: {
+    command: 'npx nx run app1:serve',
+    url: process.env.BASE_URL || 'http://localhost:4200',
+    reuseExistingServer: true,
+  },
+};`
+      );
+      await tempFs.createFiles({
+        'tests/run-me.spec.ts': '',
+        '.env': 'BASE_URL=http://localhost:4301\n',
+      });
+
+      const results = await createNodesFunction(
+        ['playwright.config.js'],
+        { targetName: 'e2e', ciTargetName: 'e2e-ci' },
+        context
+      );
+      const { targets } = results[0][1].projects['.'];
+
+      expect(evals).toBe(1);
+      expect(targets['e2e--wait-for-webserver'].options.servers).toEqual([
+        { url: 'http://localhost:4301' },
+      ]);
+      expect(targets['e2e-ci--wait-for-webserver']).toBeUndefined();
+      expect(targets['e2e-ci--tests/run-me.spec.ts'].dependsOn).toContainEqual({
+        target: 'e2e--wait-for-webserver',
+      });
+    } finally {
+      _setChildEval(null);
+      setWorkspaceRoot(originalWorkspaceRoot);
+      if (originalBaseUrl === undefined) {
+        delete process.env.BASE_URL;
+      } else {
+        process.env.BASE_URL = originalBaseUrl;
+      }
+    }
+  });
+
+  it('skips the task-env config re-evaluation when the config has no webServer', async () => {
+    const originalBaseUrl = process.env.BASE_URL;
+    const originalWorkspaceRoot = workspaceRoot;
+    delete process.env.BASE_URL;
+    setWorkspaceRoot(tempFs.tempDir);
+    let evals = 0;
+    installFreshConfigEval(() => evals++);
+
+    try {
+      await mockPlaywrightConfig(tempFs, { testDir: 'tests' });
+      // The dotenv makes the task env diverge from ambient, but with no
+      // ambient webServer there is nothing to gate, so no re-evaluation runs.
+      await tempFs.createFiles({
+        'tests/run-me.spec.ts': '',
+        '.env': 'BASE_URL=http://localhost:4301\n',
+      });
+
+      const results = await createNodesFunction(
+        ['playwright.config.js'],
+        { targetName: 'e2e', ciTargetName: 'e2e-ci' },
+        context
+      );
+      const { targets } = results[0][1].projects['.'];
+
+      expect(evals).toBe(0);
+      expect(targets['e2e--wait-for-webserver']).toBeUndefined();
+      expect(targets['e2e'].parallelism).toBe(false);
+    } finally {
+      _setChildEval(null);
+      setWorkspaceRoot(originalWorkspaceRoot);
       if (originalBaseUrl === undefined) {
         delete process.env.BASE_URL;
       } else {
@@ -1498,6 +1720,38 @@ describe('@nx/playwright/plugin', () => {
     });
   });
 
+  it('should drop a non-number webServer.timeout an unchecked config can carry', async () => {
+    // The gate task's schema rejects a string timeout at run time, so it must
+    // not be baked into the target.
+    await mockPlaywrightConfig(
+      tempFs,
+      `module.exports = {
+        testDir: 'tests',
+        webServer: {
+          command: 'npx nx run app1:serve',
+          port: 4200,
+          reuseExistingServer: true,
+          timeout: '120000',
+        },
+      };`
+    );
+    await tempFs.createFiles({ 'tests/run-me.spec.ts': '' });
+
+    const results = await createNodesFunction(
+      ['playwright.config.js'],
+      {
+        targetName: 'e2e',
+        ciTargetName: 'e2e-ci',
+      },
+      context
+    );
+    const { targets } = results[0][1].projects['.'];
+
+    expect(targets['e2e--wait-for-webserver'].options.servers).toEqual([
+      { port: 4200 },
+    ]);
+  });
+
   it('should pass ignoreHTTPSErrors through to the wait-for-webserver task when set', async () => {
     await mockPlaywrightConfig(tempFs, {
       testDir: 'tests',
@@ -1523,6 +1777,77 @@ describe('@nx/playwright/plugin', () => {
     expect(targets['e2e--wait-for-webserver'].options.servers).toEqual([
       { url: 'https://localhost:4200', ignoreHTTPSErrors: true },
     ]);
+  });
+
+  it('should not gate or depend on a webServer that waits for command output', async () => {
+    // Playwright treats a `wait.stdout`/`wait.stderr` server as ready when the
+    // regex matches (raced against the address probe) and stores named capture
+    // groups in the env, both tied to the process Playwright starts itself. A
+    // task-started server would be reused without either, so the server is
+    // left entirely to Playwright.
+    await mockPlaywrightConfig(
+      tempFs,
+      `module.exports = {
+        testDir: 'tests',
+        webServer: [
+          { command: 'npx nx run app1:serve', port: 4200, reuseExistingServer: true },
+          { command: 'npx nx run worker1:serve', port: 5000, reuseExistingServer: true, wait: { stdout: /ready/ } },
+        ],
+      };`
+    );
+    await tempFs.createFiles({ 'tests/run-me.spec.ts': '' });
+
+    const results = await createNodesFunction(
+      ['playwright.config.js'],
+      {
+        targetName: 'e2e',
+        ciTargetName: 'e2e-ci',
+      },
+      context
+    );
+    const { targets } = results[0][1].projects['.'];
+
+    expect(targets['e2e--wait-for-webserver'].options.servers).toEqual([
+      { port: 4200 },
+    ]);
+    expect(targets['e2e'].dependsOn).toContainEqual({
+      projects: ['app1'],
+      target: 'serve',
+    });
+    expect(targets['e2e'].dependsOn).not.toContainEqual(
+      expect.objectContaining({ projects: expect.arrayContaining(['worker1']) })
+    );
+  });
+
+  it('should leave a config whose only webServer waits for command output entirely to Playwright', async () => {
+    await mockPlaywrightConfig(
+      tempFs,
+      `module.exports = {
+        testDir: 'tests',
+        webServer: {
+          command: 'npx nx run app1:serve',
+          port: 4200,
+          reuseExistingServer: true,
+          wait: { stdout: /ready/ },
+        },
+      };`
+    );
+    await tempFs.createFiles({ 'tests/run-me.spec.ts': '' });
+
+    const results = await createNodesFunction(
+      ['playwright.config.js'],
+      {
+        targetName: 'e2e',
+        ciTargetName: 'e2e-ci',
+      },
+      context
+    );
+    const { targets } = results[0][1].projects['.'];
+
+    expect(targets['e2e--wait-for-webserver']).toBeUndefined();
+    expect(targets['e2e'].dependsOn).toBeUndefined();
+    // Serialized so parallel atomized runs cannot race to start the server.
+    expect(targets['e2e'].parallelism).toBe(false);
   });
 
   it('should not set parallelism to false and should infer dependsOn using the tasks run in the different webServer.command that have reuseExistingServer set to true', async () => {

--- a/packages/playwright/src/plugins/plugin.spec.ts
+++ b/packages/playwright/src/plugins/plugin.spec.ts
@@ -1065,6 +1065,121 @@ describe('@nx/playwright/plugin', () => {
     );
   });
 
+  it('resolves the serve dependency under the task env even when waitForWebServer is false', async () => {
+    const originalServeTarget = process.env.SERVE_TARGET;
+    const originalWorkspaceRoot = workspaceRoot;
+    delete process.env.SERVE_TARGET;
+    setWorkspaceRoot(tempFs.tempDir);
+    installFreshConfigEval();
+
+    try {
+      await mockPlaywrightConfig(
+        tempFs,
+        `module.exports = {
+  testDir: 'tests',
+  webServer: {
+    command: process.env.SERVE_TARGET === 'mock'
+      ? 'npx nx run app1:serve-mock'
+      : 'npx nx run app1:serve',
+    port: 4200,
+    reuseExistingServer: true,
+  },
+};`
+      );
+      await tempFs.createFiles({
+        'tests/run-me.spec.ts': '',
+        '.env': 'SERVE_TARGET=mock\n',
+      });
+
+      const results = await createNodesFunction(
+        ['playwright.config.js'],
+        { targetName: 'e2e', ciTargetName: 'e2e-ci', waitForWebServer: false },
+        context
+      );
+      const { targets } = results[0][1].projects['.'];
+
+      // The flag opts out of the gate only; the dependency still comes from
+      // the config as the task's env would evaluate it.
+      expect(targets['e2e--wait-for-webserver']).toBeUndefined();
+      expect(targets['e2e'].dependsOn).toEqual([
+        { projects: ['app1'], target: 'serve-mock' },
+      ]);
+      expect(targets['e2e-ci--tests/run-me.spec.ts'].dependsOn).toEqual([
+        { projects: ['app1'], target: 'serve-mock' },
+      ]);
+    } finally {
+      _setChildEval(null);
+      setWorkspaceRoot(originalWorkspaceRoot);
+      if (originalServeTarget === undefined) {
+        delete process.env.SERVE_TARGET;
+      } else {
+        process.env.SERVE_TARGET = originalServeTarget;
+      }
+    }
+  });
+
+  it('rebuilds cached dependencies on a dotenv change when waitForWebServer is false', async () => {
+    const originalServeTarget = process.env.SERVE_TARGET;
+    const originalWorkspaceRoot = workspaceRoot;
+    delete process.env.SERVE_TARGET;
+    setWorkspaceRoot(tempFs.tempDir);
+    // With the gate opted out the dotenv still selects the dependencies, so
+    // the disk cache key must fold it in; only a cache miss re-resolves.
+    process.env.NX_CACHE_PROJECT_GRAPH = 'true';
+    installFreshConfigEval();
+
+    try {
+      await tempFs.createFiles({
+        'apps/e2e/project.json': '{}',
+        'apps/e2e/playwright.config.js': `module.exports = {
+  testDir: 'tests',
+  webServer: {
+    command: process.env.SERVE_TARGET === 'mock'
+      ? 'npx nx run app1:serve-mock'
+      : 'npx nx run app1:serve',
+    port: 4200,
+    reuseExistingServer: true,
+  },
+};`,
+        'apps/e2e/tests/run-me.spec.ts': '',
+        '.env': 'SERVE_TARGET=mock\n',
+      });
+
+      const run = async () =>
+        (
+          await createNodesFunction(
+            ['apps/e2e/playwright.config.js'],
+            {
+              targetName: 'e2e',
+              ciTargetName: 'e2e-ci',
+              waitForWebServer: false,
+            },
+            context
+          )
+        )[0][1].projects['apps/e2e'].targets;
+
+      const first = await run();
+      expect(first['e2e'].dependsOn).toEqual([
+        { projects: ['app1'], target: 'serve-mock' },
+      ]);
+
+      await tempFs.createFile('.env', 'SERVE_TARGET=other\n');
+      const second = await run();
+      expect(second['e2e'].dependsOn).toEqual([
+        { projects: ['app1'], target: 'serve' },
+      ]);
+    } finally {
+      _setChildEval(null);
+      setWorkspaceRoot(originalWorkspaceRoot);
+      process.env.NX_CACHE_PROJECT_GRAPH = 'false';
+      if (originalServeTarget === undefined) {
+        delete process.env.SERVE_TARGET;
+      } else {
+        process.env.SERVE_TARGET = originalServeTarget;
+      }
+    }
+  });
+
   it('should infer a wait-for-webserver task using the url when the webServer defines a url', async () => {
     await mockPlaywrightConfig(tempFs, {
       testDir: 'tests',

--- a/packages/playwright/src/plugins/plugin.spec.ts
+++ b/packages/playwright/src/plugins/plugin.spec.ts
@@ -1091,6 +1091,43 @@ describe('@nx/playwright/plugin', () => {
     ).toEqual(getEnvPathsForTask('.', 'e2e-ci', undefined, 'e2e'));
   });
 
+  it('resolves testMatch and testIgnore whose elements read env the config wrote while loading', async () => {
+    // The getters run when the pattern elements are read, not when the config
+    // loads, so they only see the config's env writes if the plugin reads
+    // every pattern element before those writes are restored.
+    await mockPlaywrightConfig(
+      tempFs,
+      `process.env.PW_FROM_CONFIG_MATCH = '**/*.spec.ts';
+process.env.PW_FROM_CONFIG_IGNORE = '**/skip-me.spec.ts';
+const testMatch = [];
+Object.defineProperty(testMatch, '0', {
+  enumerable: true,
+  get: () => process.env.PW_FROM_CONFIG_MATCH,
+});
+const testIgnore = [];
+Object.defineProperty(testIgnore, '0', {
+  enumerable: true,
+  get: () => process.env.PW_FROM_CONFIG_IGNORE,
+});
+module.exports = { testDir: 'tests', testMatch, testIgnore };`
+    );
+    await tempFs.createFiles({
+      'tests/run-me.spec.ts': '',
+      'tests/skip-me.spec.ts': '',
+    });
+
+    const results = await createNodesFunction(
+      ['playwright.config.js'],
+      { targetName: 'e2e', ciTargetName: 'e2e-ci' },
+      context
+    );
+
+    const targets = results[0][1].projects['.'].targets;
+    expect(targets['e2e-ci--tests/run-me.spec.ts']).toBeDefined();
+    expect(targets['e2e-ci--tests/skip-me.spec.ts']).toBeUndefined();
+    expect(process.env.PW_FROM_CONFIG_MATCH).toBeUndefined();
+  });
+
   it('does not infer a wait-for-webserver task when waitForWebServer is false', async () => {
     await mockPlaywrightConfig(tempFs, {
       testDir: 'tests',

--- a/packages/playwright/src/plugins/plugin.spec.ts
+++ b/packages/playwright/src/plugins/plugin.spec.ts
@@ -1792,6 +1792,66 @@ module.exports = { testDir: 'tests', testMatch, testIgnore };`
     }
   });
 
+  it('skips the gate for a legacy Playwright whose probe reads an npm proxy variable from a task env file', async () => {
+    // Playwright before 1.59.0 routes its probe by npm's `npm_config_*` proxy
+    // variables, which a task env file can set where the gate's own env
+    // never has them.
+    const savedEnv = saveEnv(PROXY_ENV_NAMES);
+    const originalWorkspaceRoot = workspaceRoot;
+    setWorkspaceRoot(tempFs.tempDir);
+    installFreshConfigEval();
+    const warn = jest
+      .spyOn(devkitInternal, 'emitPluginWorkerLog')
+      .mockImplementation(() => {});
+
+    try {
+      await tempFs.createFiles({
+        'apps/e2e/project.json': '{}',
+        'apps/e2e/playwright.config.js': `module.exports = {
+  testDir: 'tests',
+  webServer: {
+    command: 'npx nx run app1:serve',
+    url: 'http://localhost:4200',
+    reuseExistingServer: true,
+  },
+};`,
+        'apps/e2e/tests/run-me.spec.ts': '',
+        '.env.e2e': 'npm_config_http_proxy=http://proxy.example:8080\n',
+        'apps/e2e/node_modules/@playwright/test/package.json':
+          playwrightPackageJson('1.36.0'),
+      });
+
+      const run = async () =>
+        (
+          await createNodesFunction(
+            ['apps/e2e/playwright.config.js'],
+            { targetName: 'e2e' },
+            context
+          )
+        )[0][1].projects['apps/e2e'].targets;
+
+      expect((await run())['e2e--wait-for-webserver']).toBeUndefined();
+      expect(warn).toHaveBeenCalledWith(
+        'warn',
+        expect.stringContaining('npm_config_http_proxy')
+      );
+
+      // Current versions ignore the variable, so it changes neither probe.
+      await tempFs.createFile(
+        'apps/e2e/node_modules/@playwright/test/package.json',
+        playwrightPackageJson('1.59.0')
+      );
+      expect((await run())['e2e--wait-for-webserver'].options.servers).toEqual([
+        { url: 'http://localhost:4200' },
+      ]);
+    } finally {
+      warn.mockRestore();
+      _setChildEval(null);
+      setWorkspaceRoot(originalWorkspaceRoot);
+      restoreEnv(savedEnv);
+    }
+  });
+
   it('rebuilds a cached gate when the installed Playwright starts verifying the tunnelled probe', async () => {
     const savedEnv = saveEnv(['NODE_EXTRA_CA_CERTS', ...PROXY_ENV_NAMES]);
     const originalWorkspaceRoot = workspaceRoot;
@@ -3781,6 +3841,10 @@ const PROXY_ENV_NAMES = [
   'https_proxy',
   'all_proxy',
   'no_proxy',
+  'npm_config_http_proxy',
+  'npm_config_https_proxy',
+  'npm_config_proxy',
+  'npm_config_no_proxy',
 ].flatMap((name) => [name, name.toUpperCase()]);
 
 // An https server behind the http proxy the legacy TLS tests route through.

--- a/packages/playwright/src/plugins/plugin.spec.ts
+++ b/packages/playwright/src/plugins/plugin.spec.ts
@@ -1363,6 +1363,87 @@ module.exports = { testDir: 'tests', testMatch, testIgnore };`
     }
   });
 
+  it('keeps the gate when a concurrent config load writes a probe variable mid-resolution', async () => {
+    const originalBaseUrl = process.env.BASE_URL;
+    const originalWorkspaceRoot = workspaceRoot;
+    delete process.env.BASE_URL;
+    // Start from no probe variables: an inherited value could mask the
+    // injected proxy divergence (a bare `*` NO_PROXY collapses every route),
+    // letting the test pass against a live-env gate read.
+    const probeVariables = [
+      ...['http_proxy', 'https_proxy', 'all_proxy', 'no_proxy'].flatMap(
+        (name) => [name, name.toUpperCase()]
+      ),
+      'NODE_EXTRA_CA_CERTS',
+      'NODE_TLS_REJECT_UNAUTHORIZED',
+    ];
+    // Snapshot before any delete: Windows env keys are case-insensitive, so
+    // deleting one spelling also clears its alias.
+    const originalProbeValues: Record<string, string | undefined> = {};
+    for (const variable of probeVariables) {
+      originalProbeValues[variable] = process.env[variable];
+    }
+    for (const variable of probeVariables) {
+      delete process.env[variable];
+    }
+    setWorkspaceRoot(tempFs.tempDir);
+    // Config loads run in this process, so another project's load can write
+    // env between this chain's child evaluation and its gate env read. The
+    // gate env must come from the locked ambient snapshot: read from the live
+    // env, the transient write registers as a probe divergence and drops a
+    // gate the task env never diverged on.
+    installFreshConfigEval(() => {
+      process.env.HTTP_PROXY = 'http://transient.example:8080';
+    });
+
+    try {
+      await mockPlaywrightConfig(
+        tempFs,
+        `module.exports = {
+  testDir: 'tests',
+  webServer: {
+    command: 'npx nx run app1:serve',
+    url: process.env.BASE_URL || 'http://localhost:4200',
+    reuseExistingServer: true,
+  },
+};`
+      );
+      await tempFs.createFiles({
+        'tests/run-me.spec.ts': '',
+        '.env.e2e': 'BASE_URL=http://localhost:4301\n',
+      });
+
+      const results = await createNodesFunction(
+        ['playwright.config.js'],
+        { targetName: 'e2e' },
+        context
+      );
+      const { targets } = results[0][1].projects['.'];
+
+      expect(targets['e2e--wait-for-webserver'].options).toEqual({
+        servers: [{ url: 'http://localhost:4301' }],
+      });
+    } finally {
+      _setChildEval(null);
+      setWorkspaceRoot(originalWorkspaceRoot);
+      // Delete every spelling first, then restore the recorded values, so a
+      // restore is never undone through a case-insensitive alias.
+      for (const variable of probeVariables) {
+        delete process.env[variable];
+      }
+      for (const variable of probeVariables) {
+        if (originalProbeValues[variable] !== undefined) {
+          process.env[variable] = originalProbeValues[variable];
+        }
+      }
+      if (originalBaseUrl === undefined) {
+        delete process.env.BASE_URL;
+      } else {
+        process.env.BASE_URL = originalBaseUrl;
+      }
+    }
+  });
+
   it('creates a separate gate per chain when e2e and e2e-ci resolve different addresses', async () => {
     const originalBaseUrl = process.env.BASE_URL;
     const originalWorkspaceRoot = workspaceRoot;
@@ -1666,6 +1747,93 @@ module.exports = { testDir: 'tests', testMatch, testIgnore };`
       warn.mockRestore();
       _setChildEval(null);
       setWorkspaceRoot(originalWorkspaceRoot);
+      restoreEnv(savedEnv);
+    }
+  });
+
+  it('keeps the gate for a legacy Playwright whose tunnelled probe never verifies the TLS material', async () => {
+    // Playwright before 1.59.0 skips certificate verification behind an http
+    // proxy tunnel, as does the gate on that version, so a task-scoped CA
+    // bundle changes neither probe and must not cost the gate.
+    const savedEnv = saveEnv(['NODE_EXTRA_CA_CERTS', ...PROXY_ENV_NAMES]);
+    const originalWorkspaceRoot = workspaceRoot;
+    process.env.HTTPS_PROXY = 'http://proxy.example:8080';
+    setWorkspaceRoot(tempFs.tempDir);
+    installFreshConfigEval();
+
+    try {
+      // The project's own copy decides, as it does for the Playwright binary
+      // the task runs, so it sits next to a current workspace-root copy.
+      await tempFs.createFiles({
+        'apps/e2e/project.json': '{}',
+        'apps/e2e/playwright.config.js': LEGACY_TLS_CONFIG,
+        'apps/e2e/tests/run-me.spec.ts': '',
+        '.env.e2e': 'NODE_EXTRA_CA_CERTS=./certs/ca.pem\n',
+        'apps/e2e/node_modules/@playwright/test/package.json':
+          playwrightPackageJson('1.36.0'),
+        'node_modules/@playwright/test/package.json':
+          playwrightPackageJson('1.59.0'),
+      });
+
+      const results = await createNodesFunction(
+        ['apps/e2e/playwright.config.js'],
+        { targetName: 'e2e' },
+        context
+      );
+      const { targets } = results[0][1].projects['apps/e2e'];
+
+      expect(targets['e2e--wait-for-webserver'].options.servers).toEqual([
+        { url: 'https://localhost:4200' },
+      ]);
+    } finally {
+      _setChildEval(null);
+      setWorkspaceRoot(originalWorkspaceRoot);
+      restoreEnv(savedEnv);
+    }
+  });
+
+  it('rebuilds a cached gate when the installed Playwright starts verifying the tunnelled probe', async () => {
+    const savedEnv = saveEnv(['NODE_EXTRA_CA_CERTS', ...PROXY_ENV_NAMES]);
+    const originalWorkspaceRoot = workspaceRoot;
+    process.env.HTTPS_PROXY = 'http://proxy.example:8080';
+    setWorkspaceRoot(tempFs.tempDir);
+    process.env.NX_CACHE_PROJECT_GRAPH = 'true';
+    installFreshConfigEval();
+
+    try {
+      // A linked install can change version without touching the lockfile,
+      // which is the only install input the createNodes hash covers.
+      await tempFs.createFiles({
+        'apps/e2e/project.json': '{}',
+        'apps/e2e/playwright.config.js': LEGACY_TLS_CONFIG,
+        'apps/e2e/tests/run-me.spec.ts': '',
+        '.env.e2e': 'NODE_EXTRA_CA_CERTS=./certs/ca.pem\n',
+        'node_modules/@playwright/test/package.json':
+          playwrightPackageJson('1.36.0'),
+      });
+
+      const run = async () =>
+        (
+          await createNodesFunction(
+            ['apps/e2e/playwright.config.js'],
+            { targetName: 'e2e' },
+            context
+          )
+        )[0][1].projects['apps/e2e'].targets;
+
+      expect((await run())['e2e--wait-for-webserver'].options.servers).toEqual([
+        { url: 'https://localhost:4200' },
+      ]);
+
+      await tempFs.createFile(
+        'node_modules/@playwright/test/package.json',
+        playwrightPackageJson('1.59.0')
+      );
+      expect((await run())['e2e--wait-for-webserver']).toBeUndefined();
+    } finally {
+      _setChildEval(null);
+      setWorkspaceRoot(originalWorkspaceRoot);
+      process.env.NX_CACHE_PROJECT_GRAPH = 'false';
       restoreEnv(savedEnv);
     }
   });
@@ -3606,6 +3774,27 @@ async function mockPlaywrightConfig(
       ? config
       : `module.exports = ${JSON.stringify(config)}`
   );
+}
+
+const PROXY_ENV_NAMES = [
+  'http_proxy',
+  'https_proxy',
+  'all_proxy',
+  'no_proxy',
+].flatMap((name) => [name, name.toUpperCase()]);
+
+// An https server behind the http proxy the legacy TLS tests route through.
+const LEGACY_TLS_CONFIG = `module.exports = {
+  testDir: 'tests',
+  webServer: {
+    command: 'npx nx run app1:serve',
+    url: 'https://localhost:4200',
+    reuseExistingServer: true,
+  },
+};`;
+
+function playwrightPackageJson(version: string): string {
+  return JSON.stringify({ name: '@playwright/test', version });
 }
 
 // Clears the named variables so a developer's ambient proxy or TLS env cannot

--- a/packages/playwright/src/plugins/plugin.spec.ts
+++ b/packages/playwright/src/plugins/plugin.spec.ts
@@ -7,7 +7,11 @@ import { PlaywrightTestConfig } from '@playwright/test';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
 import { _clearWarnedUnparseableCommands, createNodesV2 } from './plugin';
-import { _setChildEval, normalizeWebServers } from './webserver-readiness';
+import {
+  _setChildEval,
+  normalizeWebServers,
+  pickProbeEnv,
+} from './webserver-readiness';
 
 // The plugin writes its disk cache under `workspaceDataDirectory`, which is
 // resolved from the real workspace root at import time. Redirect it into the
@@ -41,7 +45,10 @@ function installFreshConfigEval(
       moduleShim.exports,
       { ...process, env }
     );
-    return normalizeWebServers(moduleShim.exports.webServer);
+    return {
+      webServers: normalizeWebServers(moduleShim.exports.webServer),
+      probeEnv: pickProbeEnv(env),
+    };
   });
 }
 
@@ -1573,6 +1580,234 @@ describe('@nx/playwright/plugin', () => {
     }
   });
 
+  it('skips the gate when the config itself changes how the server would be probed while loading', async () => {
+    const savedEnv = saveEnv([
+      'HTTP_PROXY',
+      'http_proxy',
+      'NO_PROXY',
+      'no_proxy',
+    ]);
+    const originalWorkspaceRoot = workspaceRoot;
+    // No task env file: the write happens while the config loads (as a
+    // `dotenv.config()` call in the config would), so it reaches Playwright's
+    // probe and not the gate, which never loads the config.
+    process.env.HTTP_PROXY = 'http://proxy.example:8080';
+    delete process.env.NO_PROXY;
+    delete process.env.no_proxy;
+    setWorkspaceRoot(tempFs.tempDir);
+    const warn = jest
+      .spyOn(devkitInternal, 'emitPluginWorkerLog')
+      .mockImplementation(() => {});
+
+    try {
+      await mockPlaywrightConfig(
+        tempFs,
+        `process.env.NO_PROXY = 'localhost';
+module.exports = {
+  testDir: 'tests',
+  webServer: {
+    command: 'npx nx run app1:serve',
+    url: 'http://localhost:4200',
+    reuseExistingServer: true,
+  },
+};`
+      );
+      await tempFs.createFiles({ 'tests/run-me.spec.ts': '' });
+
+      const results = await createNodesFunction(
+        ['playwright.config.js'],
+        { targetName: 'e2e', ciTargetName: 'e2e-ci' },
+        context
+      );
+      const { targets } = results[0][1].projects['.'];
+
+      expect(targets['e2e--wait-for-webserver']).toBeUndefined();
+      expect(targets['e2e-ci--wait-for-webserver']).toBeUndefined();
+      expect(targets['e2e'].dependsOn).toContainEqual({
+        projects: ['app1'],
+        target: 'serve',
+      });
+      expect(warn).toHaveBeenCalledWith(
+        'warn',
+        expect.stringContaining('NO_PROXY')
+      );
+      // The write does not outlive the load.
+      expect(process.env.NO_PROXY).toBeUndefined();
+    } finally {
+      warn.mockRestore();
+      setWorkspaceRoot(originalWorkspaceRoot);
+      restoreEnv(savedEnv);
+    }
+  });
+
+  it('keeps the gate when the config only writes NODE_EXTRA_CA_CERTS, which Node read at startup', async () => {
+    const savedEnv = saveEnv(['NODE_EXTRA_CA_CERTS']);
+    const originalWorkspaceRoot = workspaceRoot;
+    delete process.env.NODE_EXTRA_CA_CERTS;
+    setWorkspaceRoot(tempFs.tempDir);
+
+    try {
+      await mockPlaywrightConfig(
+        tempFs,
+        `process.env.NODE_EXTRA_CA_CERTS = './certs/ca.pem';
+module.exports = {
+  testDir: 'tests',
+  webServer: {
+    command: 'npx nx run app1:serve',
+    url: 'https://localhost:4200',
+    reuseExistingServer: true,
+  },
+};`
+      );
+      await tempFs.createFiles({ 'tests/run-me.spec.ts': '' });
+
+      const results = await createNodesFunction(
+        ['playwright.config.js'],
+        { targetName: 'e2e', ciTargetName: 'e2e-ci' },
+        context
+      );
+      const { targets } = results[0][1].projects['.'];
+
+      expect(targets['e2e--wait-for-webserver'].options.servers).toEqual([
+        { url: 'https://localhost:4200' },
+      ]);
+      expect(process.env.NODE_EXTRA_CA_CERTS).toBeUndefined();
+    } finally {
+      setWorkspaceRoot(originalWorkspaceRoot);
+      restoreEnv(savedEnv);
+    }
+  });
+
+  it('compares the probe against the env of the gate target, own dotenv included', async () => {
+    const savedEnv = saveEnv([
+      'HTTP_PROXY',
+      'http_proxy',
+      'NO_PROXY',
+      'no_proxy',
+    ]);
+    const originalWorkspaceRoot = workspaceRoot;
+    process.env.HTTP_PROXY = 'http://proxy.example:8080';
+    delete process.env.NO_PROXY;
+    delete process.env.no_proxy;
+    setWorkspaceRoot(tempFs.tempDir);
+    installFreshConfigEval();
+
+    try {
+      await mockPlaywrightConfig(
+        tempFs,
+        `module.exports = {
+  testDir: 'tests',
+  webServer: {
+    command: 'npx nx run app1:serve',
+    url: 'http://localhost:4200',
+    reuseExistingServer: true,
+  },
+};`
+      );
+      // The e2e gate loads the same exclusion its task does, so it probes the
+      // same way; the ci gate loads nothing, so the ci chain's probe diverges
+      // and the two chains cannot share the e2e gate either.
+      await tempFs.createFiles({
+        'tests/run-me.spec.ts': '',
+        '.env.e2e': 'NO_PROXY=localhost\n',
+        '.env.e2e--wait-for-webserver': 'NO_PROXY=localhost\n',
+        '.env.e2e-ci': 'NO_PROXY=localhost\n',
+      });
+
+      const results = await createNodesFunction(
+        ['playwright.config.js'],
+        { targetName: 'e2e', ciTargetName: 'e2e-ci' },
+        context
+      );
+      const { targets } = results[0][1].projects['.'];
+
+      expect(targets['e2e--wait-for-webserver'].options.servers).toEqual([
+        { url: 'http://localhost:4200' },
+      ]);
+      expect(targets['e2e-ci--wait-for-webserver']).toBeUndefined();
+      expect(
+        targets['e2e-ci--tests/run-me.spec.ts'].dependsOn
+      ).not.toContainEqual(
+        expect.objectContaining({ target: expect.stringContaining('wait-for') })
+      );
+    } finally {
+      _setChildEval(null);
+      setWorkspaceRoot(originalWorkspaceRoot);
+      restoreEnv(savedEnv);
+    }
+  });
+
+  it('expands the gate env without the variables the config wrote while loading', async () => {
+    const savedEnv = saveEnv([
+      'HTTP_PROXY',
+      'http_proxy',
+      'NO_PROXY',
+      'no_proxy',
+      'PROXY_HOST',
+    ]);
+    const originalWorkspaceRoot = workspaceRoot;
+    delete process.env.HTTP_PROXY;
+    delete process.env.http_proxy;
+    delete process.env.NO_PROXY;
+    delete process.env.no_proxy;
+    delete process.env.PROXY_HOST;
+    setWorkspaceRoot(tempFs.tempDir);
+    installFreshConfigEval();
+    const warn = jest
+      .spyOn(devkitInternal, 'emitPluginWorkerLog')
+      .mockImplementation(() => {});
+
+    try {
+      // The gate's env file references a variable only the config sets. Left
+      // in process.env after the load, it would expand at graph time to the
+      // task's proxy and the gate would be inferred; the gate's own process
+      // never runs the config, so it expands to nothing there.
+      await mockPlaywrightConfig(
+        tempFs,
+        `process.env.PROXY_HOST = 'http://proxy.example:8080';
+module.exports = {
+  testDir: 'tests',
+  webServer: {
+    command: 'npx nx run app1:serve',
+    url: 'http://localhost:4200',
+    reuseExistingServer: true,
+  },
+};`
+      );
+      await tempFs.createFiles({
+        'tests/run-me.spec.ts': '',
+        '.env.e2e': 'HTTP_PROXY=http://proxy.example:8080\n',
+        '.env.e2e--wait-for-webserver': 'HTTP_PROXY=${PROXY_HOST}\n',
+      });
+
+      const results = await createNodesFunction(
+        ['playwright.config.js'],
+        { targetName: 'e2e', ciTargetName: 'e2e-ci' },
+        context
+      );
+      const { targets } = results[0][1].projects['.'];
+
+      expect(targets['e2e--wait-for-webserver']).toBeUndefined();
+      expect(targets['e2e'].dependsOn).toContainEqual({
+        projects: ['app1'],
+        target: 'serve',
+      });
+      expect(targets['e2e'].dependsOn).not.toContainEqual(
+        expect.objectContaining({ target: expect.stringContaining('wait-for') })
+      );
+      expect(warn).toHaveBeenCalledWith(
+        'warn',
+        expect.stringContaining('HTTP_PROXY')
+      );
+      expect(process.env.PROXY_HOST).toBeUndefined();
+    } finally {
+      warn.mockRestore();
+      _setChildEval(null);
+      setWorkspaceRoot(originalWorkspaceRoot);
+      restoreEnv(savedEnv);
+    }
+  });
+
   it('serializes the atomized tasks when only the CI chain adds an uncovered server', async () => {
     const originalCiExtra = process.env.CI_EXTRA;
     const originalWorkspaceRoot = workspaceRoot;
@@ -1924,7 +2159,7 @@ describe('@nx/playwright/plugin', () => {
     }
   });
 
-  it('does not persist a pass whose ambient env changed mid-pass', async () => {
+  it('persists a pass whose config wrote to the env while loading', async () => {
     const originalBootFlag = process.env.BOOT_FLAG;
     const originalWorkspaceRoot = workspaceRoot;
     delete process.env.BOOT_FLAG;
@@ -1936,10 +2171,9 @@ describe('@nx/playwright/plugin', () => {
     );
 
     try {
-      // The config mutates an allowed env var when evaluated, so the pass's
-      // entries are keyed under a digest that no longer matches the env they
-      // were built in. The pass must not persist them: a later pass under the
-      // original env would otherwise hit an entry built under the mutated one.
+      // The write is undone once the config has loaded, so the pass ends on
+      // the digest it started with and its entries are keyed correctly: the
+      // next pass under the same env is a cache hit.
       await tempFs.createFiles({
         'apps/e2e/project.json': '{}',
         'apps/e2e/playwright.config.js': `process.env.BOOT_FLAG = 'set';
@@ -1954,15 +2188,11 @@ module.exports = {};`,
         );
 
       await run();
+      expect(process.env.BOOT_FLAG).toBeUndefined();
       const rebuildsAfterFirst = listTestFiles.mock.calls.length;
 
-      // Back on the pass-start env: the same cache key, so only the skipped
-      // persist can force this re-evaluation.
-      delete process.env.BOOT_FLAG;
       await run();
-      expect(listTestFiles.mock.calls.length).toBeGreaterThan(
-        rebuildsAfterFirst
-      );
+      expect(listTestFiles.mock.calls.length).toBe(rebuildsAfterFirst);
     } finally {
       listTestFiles.mockRestore();
       setWorkspaceRoot(originalWorkspaceRoot);

--- a/packages/playwright/src/plugins/plugin.spec.ts
+++ b/packages/playwright/src/plugins/plugin.spec.ts
@@ -1,11 +1,20 @@
-import { CreateNodesContext, workspaceRoot } from '@nx/devkit';
-import { setWorkspaceRoot } from '@nx/devkit/internal';
+import {
+  CreateNodesContext,
+  ProjectGraph,
+  Task,
+  workspaceRoot,
+} from '@nx/devkit';
+import { getEnvPathsForTask, setWorkspaceRoot } from '@nx/devkit/internal';
 import * as devkitInternal from '@nx/devkit/internal';
 import { TempFs } from '@nx/devkit/internal-testing-utils';
 import * as jsUtils from '@nx/js';
 import { PlaywrightTestConfig } from '@playwright/test';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
+// The run-time dotenv owner resolution lives in the task runner, which the
+// devkit barrels do not re-export.
+// eslint-disable-next-line @typescript-eslint/no-restricted-imports
+import { getEnvFilesForTask } from 'nx/src/tasks-runner/task-env';
 import { _clearWarnedUnparseableCommands, createNodesV2 } from './plugin';
 import {
   _setChildEval,
@@ -1033,9 +1042,53 @@ describe('@nx/playwright/plugin', () => {
       { projects: ['app1'], target: 'serve' },
       { target: 'e2e--wait-for-webserver' },
     ]);
-    expect(project.metadata.targetGroups['E2E (CI)']).toContain(
+    expect(project.metadata.targetGroups['E2E (CI)']).not.toContain(
       'e2e--wait-for-webserver'
     );
+  });
+
+  it("runs the wait-for-webserver task under its own env files, not the atomized target group's", async () => {
+    // A task in the CI target group loads the group's `nonAtomizedTarget`
+    // dotenv files at run time; the gate's probe env is checked at graph time
+    // against the files named after the gate, so the two must agree.
+    await mockPlaywrightConfig(tempFs, {
+      testDir: 'tests',
+      webServer: {
+        command: 'npx nx run app1:serve',
+        port: 4200,
+        reuseExistingServer: true,
+      },
+    });
+    await tempFs.createFiles({ 'tests/run-me.spec.ts': '' });
+
+    const results = await createNodesFunction(
+      ['playwright.config.js'],
+      { targetName: 'e2e', ciTargetName: 'e2e-ci' },
+      context
+    );
+    const project = results[0][1].projects['.'];
+    const graph: ProjectGraph = {
+      nodes: {
+        proj: { name: 'proj', type: 'app', data: { root: '.', ...project } },
+      },
+      dependencies: {},
+    };
+    const taskFor = (target: string): Task =>
+      ({
+        id: `proj:${target}`,
+        target: { project: 'proj', target },
+        projectRoot: '.',
+        overrides: {},
+        outputs: [],
+        parallelism: true,
+      }) as Task;
+
+    expect(
+      getEnvFilesForTask(taskFor('e2e--wait-for-webserver'), graph)
+    ).toEqual(getEnvPathsForTask('.', 'e2e--wait-for-webserver'));
+    expect(
+      getEnvFilesForTask(taskFor('e2e-ci--tests/run-me.spec.ts'), graph)
+    ).toEqual(getEnvPathsForTask('.', 'e2e-ci', undefined, 'e2e'));
   });
 
   it('does not infer a wait-for-webserver task when waitForWebServer is false', async () => {

--- a/packages/playwright/src/plugins/plugin.spec.ts
+++ b/packages/playwright/src/plugins/plugin.spec.ts
@@ -4,17 +4,17 @@ import {
   Task,
   workspaceRoot,
 } from '@nx/devkit';
-import { getEnvPathsForTask, setWorkspaceRoot } from '@nx/devkit/internal';
+import {
+  getEnvFilesForTask,
+  getEnvPathsForTask,
+  setWorkspaceRoot,
+} from '@nx/devkit/internal';
 import * as devkitInternal from '@nx/devkit/internal';
 import { TempFs } from '@nx/devkit/internal-testing-utils';
 import * as jsUtils from '@nx/js';
 import { PlaywrightTestConfig } from '@playwright/test';
 import { readFileSync } from 'node:fs';
 import { join } from 'node:path';
-// The run-time dotenv owner resolution lives in the task runner, which the
-// devkit barrels do not re-export.
-// eslint-disable-next-line @typescript-eslint/no-restricted-imports
-import { getEnvFilesForTask } from 'nx/src/tasks-runner/task-env';
 import { _clearWarnedUnparseableCommands, createNodesV2 } from './plugin';
 import {
   _setChildEval,

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -27,6 +27,7 @@ import { hashObject } from 'nx/src/hasher/file-hasher';
 import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
 import { PluginCache } from 'nx/src/utils/plugin-cache-utils';
 import { getFilesInDirectoryUsingContext } from 'nx/src/utils/workspace-context';
+import type { Schema as WaitForWebserverSchema } from '../executors/wait-for-webserver/schema';
 import { getReporterOutputs, type ReporterOutput } from '../utils/reporters';
 
 export interface PlaywrightPluginOptions {
@@ -59,12 +60,7 @@ interface WebserverCommandTask {
   timeout?: number;
 }
 
-interface WebserverReadinessServer {
-  port?: number;
-  url?: string;
-  ignoreHTTPSErrors?: boolean;
-  timeout?: number;
-}
+type WebserverReadinessServer = WaitForWebserverSchema['servers'][number];
 
 const playwrightConfigGlob = '**/playwright.config.{js,ts,cjs,cts,mjs,mts}';
 export const createNodes: CreateNodes<PlaywrightPluginOptions> = [
@@ -614,16 +610,21 @@ function getWebserverCommandTasks(
 // Playwright picks a web server's readiness probe by presence rather than
 // truthiness: a defined `port` makes it check that port over TCP even when the
 // value is falsy and the address comes from `url`, and a web server it can
-// address neither way gets no probe at all. Gate only on what both read the
-// same way, so the gate cannot fail where Playwright would have found the
-// server.
+// address neither way gets no probe at all. An unchecked `playwright.config.js`
+// can also carry a `port` Playwright coerces but the readiness task can't
+// probe. Gate only on the shapes the task probes the same way; the rest is
+// left to Playwright.
 function toReadinessServer(
   task: WebserverCommandTask
 ): WebserverReadinessServer | undefined {
   let server: WebserverReadinessServer;
-  if (task.port) {
+  if (typeof task.port === 'number' && task.port) {
     server = { port: task.port };
-  } else if (task.url && task.port == null) {
+  } else if (
+    typeof task.url === 'string' &&
+    task.url &&
+    task.port === undefined
+  ) {
     server = { url: task.url };
   } else {
     return undefined;

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -208,9 +208,16 @@ async function buildPlaywrightTargets(
       port?: number;
       url?: string;
       ignoreHTTPSErrors?: boolean;
+      timeout?: number;
     } = task.port != null ? { port: task.port } : { url: task.url };
     if (task.ignoreHTTPSErrors) {
       server.ignoreHTTPSErrors = true;
+    }
+    // Carry each server's own `webServer.timeout` (the budget Playwright waits
+    // for a server it starts) so a slow server is not cut short and a fast one
+    // is not given another server's budget.
+    if (task.timeout != null) {
+      server.timeout = task.timeout;
     }
     return server;
   });
@@ -218,17 +225,6 @@ async function buildPlaywrightTargets(
     webserverReadinessServers.length > 0
       ? `${options.targetName}--wait-for-webserver`
       : undefined;
-  // Honor Playwright's own `webServer.timeout` (the budget it waits for a
-  // server it starts) so a slow server is not cut short. The plugin option
-  // overrides it; use the longest configured timeout across servers.
-  const configuredTimeouts = webserverReadinessTasks
-    .map((task) => task.timeout)
-    .filter((timeout): timeout is number => timeout != null);
-  const webserverReadinessTimeout =
-    options.webServerTimeout ??
-    (configuredTimeouts.length > 0
-      ? Math.max(...configuredTimeouts)
-      : undefined);
 
   const baseTargetConfig: TargetConfiguration = {
     command: 'playwright test',
@@ -284,8 +280,8 @@ async function buildPlaywrightTargets(
       cache: false,
       options: {
         servers: webserverReadinessServers,
-        ...(webserverReadinessTimeout != null
-          ? { timeout: webserverReadinessTimeout }
+        ...(options.webServerTimeout != null
+          ? { timeout: options.webServerTimeout }
           : {}),
       },
       dependsOn: getDependsOn(webserverCommandTasks),

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -194,6 +194,42 @@ async function buildPlaywrightTargets(
   const testOutput = getTestOutput(playwrightConfig);
   const reporterOutputs = getReporterOutputs(playwrightConfig);
   const webserverCommandTasks = getWebserverCommandTasks(playwrightConfig);
+
+  // When an inferred web server exposes a port/url, add a task that waits for
+  // it to accept connections. Playwright's `reuseExistingServer` probe
+  // otherwise races the server boot, misses, and spawns its own nested server
+  // command whose I/O then leaks into the task. Both the `e2e` task and the
+  // atomized CI tasks depend on it.
+  const webserverReadinessTasks = webserverCommandTasks.filter(
+    (task) => task.port != null || task.url != null
+  );
+  const webserverReadinessServers = webserverReadinessTasks.map((task) => {
+    const server: {
+      port?: number;
+      url?: string;
+      ignoreHTTPSErrors?: boolean;
+    } = task.port != null ? { port: task.port } : { url: task.url };
+    if (task.ignoreHTTPSErrors) {
+      server.ignoreHTTPSErrors = true;
+    }
+    return server;
+  });
+  const webserverReadyTargetName =
+    webserverReadinessServers.length > 0
+      ? `${options.targetName}--wait-for-webserver`
+      : undefined;
+  // Honor Playwright's own `webServer.timeout` (the budget it waits for a
+  // server it starts) so a slow server is not cut short. The plugin option
+  // overrides it; use the longest configured timeout across servers.
+  const configuredTimeouts = webserverReadinessTasks
+    .map((task) => task.timeout)
+    .filter((timeout): timeout is number => timeout != null);
+  const webserverReadinessTimeout =
+    options.webServerTimeout ??
+    (configuredTimeouts.length > 0
+      ? Math.max(...configuredTimeouts)
+      : undefined);
+
   const baseTargetConfig: TargetConfiguration = {
     command: 'playwright test',
     options: {
@@ -214,7 +250,12 @@ async function buildPlaywrightTargets(
   };
 
   if (webserverCommandTasks.length) {
-    baseTargetConfig.dependsOn = getDependsOn(webserverCommandTasks);
+    baseTargetConfig.dependsOn = webserverReadyTargetName
+      ? [
+          ...getDependsOn(webserverCommandTasks),
+          { target: webserverReadyTargetName },
+        ]
+      : getDependsOn(webserverCommandTasks);
   } else {
     baseTargetConfig.parallelism = false;
   }
@@ -236,6 +277,25 @@ async function buildPlaywrightTargets(
       projectRoot
     ),
   };
+
+  if (webserverReadyTargetName) {
+    targets[webserverReadyTargetName] = {
+      executor: '@nx/playwright:wait-for-webserver',
+      cache: false,
+      options: {
+        servers: webserverReadinessServers,
+        ...(webserverReadinessTimeout != null
+          ? { timeout: webserverReadinessTimeout }
+          : {}),
+      },
+      dependsOn: getDependsOn(webserverCommandTasks),
+      metadata: {
+        technologies: ['playwright'],
+        description:
+          'Waits for the E2E web server(s) to be ready before the Playwright test tasks run.',
+      },
+    };
+  }
 
   if (options.ciTargetName) {
     // ensure the blob reporter output is the directory containing the blob
@@ -277,47 +337,6 @@ async function buildPlaywrightTargets(
 
     const dependsOn: TargetDependencyConfig[] = [];
 
-    // When the inferred web server task(s) expose a port/url, add a task that
-    // waits for the server to accept connections. Playwright's
-    // `reuseExistingServer` probe otherwise races the server boot on the first
-    // CI task per agent and spawns its own nested server command, whose I/O
-    // then leaks into that task.
-    const readinessTasks = webserverCommandTasks.filter(
-      (task) => task.port != null || task.url != null
-    );
-    const webserverReadinessServers = readinessTasks.map((task) => {
-      const server: {
-        port?: number;
-        url?: string;
-        ignoreHTTPSErrors?: boolean;
-      } = task.port != null ? { port: task.port } : { url: task.url };
-      if (task.ignoreHTTPSErrors) {
-        server.ignoreHTTPSErrors = true;
-      }
-      return server;
-    });
-    const webserverReadyTargetName =
-      webserverReadinessServers.length > 0
-        ? `${options.ciTargetName}--wait-for-webserver`
-        : undefined;
-    // Honor Playwright's own `webServer.timeout` (the budget it waits for a
-    // server it starts) so a slow server is not cut short. The plugin option
-    // overrides it; use the longest configured timeout across servers.
-    const configuredTimeouts = readinessTasks
-      .map((task) => task.timeout)
-      .filter((timeout): timeout is number => timeout != null);
-    const webserverReadinessTimeout =
-      options.webServerTimeout ??
-      (configuredTimeouts.length > 0
-        ? Math.max(...configuredTimeouts)
-        : undefined);
-    const ciDependsOn = webserverReadyTargetName
-      ? [
-          ...getDependsOn(webserverCommandTasks),
-          { target: webserverReadyTargetName },
-        ]
-      : undefined;
-
     const testFiles = await getAllTestFiles({
       context,
       path: testDir,
@@ -353,7 +372,6 @@ async function buildPlaywrightTargets(
       ciTargetGroup.push(targetName);
       targets[targetName] = {
         ...ciBaseTargetConfig,
-        ...(ciDependsOn ? { dependsOn: ciDependsOn } : {}),
         options: {
           ...ciBaseTargetConfig.options,
           env: getAtomizedTaskEnvVars(reporterOutputs, outputSubfolder),
@@ -390,25 +408,6 @@ async function buildPlaywrightTargets(
         params: 'forward',
         options: 'forward',
       });
-    }
-
-    if (webserverReadyTargetName) {
-      targets[webserverReadyTargetName] = {
-        executor: '@nx/playwright:wait-for-webserver',
-        cache: false,
-        options: {
-          servers: webserverReadinessServers,
-          ...(webserverReadinessTimeout != null
-            ? { timeout: webserverReadinessTimeout }
-            : {}),
-        },
-        dependsOn: getDependsOn(webserverCommandTasks),
-        metadata: {
-          technologies: ['playwright'],
-          description:
-            'Waits for the E2E web server(s) to be ready before the Playwright CI test tasks run.',
-        },
-      };
     }
 
     targets[options.ciTargetName] ??= {};

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -34,9 +34,9 @@ export interface PlaywrightPluginOptions {
   ciTargetName?: string;
   /**
    * Maximum time in milliseconds the inferred web server readiness task waits
-   * for the server to accept connections before failing. Overrides the
-   * `timeout` configured on Playwright's `webServer`. Defaults to that
-   * configured timeout, or 60000 when neither is set.
+   * for a server to be ready before failing. Overrides the `timeout` each
+   * Playwright `webServer` configures. Defaults to that configured timeout,
+   * or 60000 when neither is set.
    */
   webServerTimeout?: number;
 }
@@ -53,6 +53,13 @@ type PlaywrightTargets = Pick<ProjectConfiguration, 'targets' | 'metadata'>;
 interface WebserverCommandTask {
   project: string;
   target: string;
+  port?: number;
+  url?: string;
+  ignoreHTTPSErrors?: boolean;
+  timeout?: number;
+}
+
+interface WebserverReadinessServer {
   port?: number;
   url?: string;
   ignoreHTTPSErrors?: boolean;
@@ -196,31 +203,13 @@ async function buildPlaywrightTargets(
   const webserverCommandTasks = getWebserverCommandTasks(playwrightConfig);
 
   // When an inferred web server exposes a port/url, add a task that waits for
-  // it to accept connections. Playwright's `reuseExistingServer` probe
+  // it to be ready. Playwright's `reuseExistingServer` probe
   // otherwise races the server boot, misses, and spawns its own nested server
   // command whose I/O then leaks into the task. Both the `e2e` task and the
   // atomized CI tasks depend on it.
-  const webserverReadinessTasks = webserverCommandTasks.filter(
-    (task) => task.port != null || task.url != null
-  );
-  const webserverReadinessServers = webserverReadinessTasks.map((task) => {
-    const server: {
-      port?: number;
-      url?: string;
-      ignoreHTTPSErrors?: boolean;
-      timeout?: number;
-    } = task.port != null ? { port: task.port } : { url: task.url };
-    if (task.ignoreHTTPSErrors) {
-      server.ignoreHTTPSErrors = true;
-    }
-    // Carry each server's own `webServer.timeout` (the budget Playwright waits
-    // for a server it starts) so a slow server is not cut short and a fast one
-    // is not given another server's budget.
-    if (task.timeout != null) {
-      server.timeout = task.timeout;
-    }
-    return server;
-  });
+  const webserverReadinessServers = webserverCommandTasks
+    .map(toReadinessServer)
+    .filter(Boolean);
   const webserverReadyTargetName =
     webserverReadinessServers.length > 0
       ? `${options.targetName}--wait-for-webserver`
@@ -620,6 +609,37 @@ function getWebserverCommandTasks(
   }
 
   return tasks;
+}
+
+// Playwright picks a web server's readiness probe by presence rather than
+// truthiness: a defined `port` makes it check that port over TCP even when the
+// value is falsy and the address comes from `url`, and a web server it can
+// address neither way gets no probe at all. Gate only on what both read the
+// same way, so the gate cannot fail where Playwright would have found the
+// server.
+function toReadinessServer(
+  task: WebserverCommandTask
+): WebserverReadinessServer | undefined {
+  let server: WebserverReadinessServer;
+  if (task.port) {
+    server = { port: task.port };
+  } else if (task.url && task.port == null) {
+    server = { url: task.url };
+  } else {
+    return undefined;
+  }
+
+  if (task.ignoreHTTPSErrors) {
+    server.ignoreHTTPSErrors = true;
+  }
+  // Carry each server's own `webServer.timeout` (the budget Playwright waits
+  // for a server it starts) so a slow server is not cut short and a fast one
+  // is not given another server's budget.
+  if (task.timeout != null) {
+    server.timeout = task.timeout;
+  }
+
+  return server;
 }
 
 function parseTaskFromCommand(command: string): {

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -32,15 +32,32 @@ import { getReporterOutputs, type ReporterOutput } from '../utils/reporters';
 export interface PlaywrightPluginOptions {
   targetName?: string;
   ciTargetName?: string;
+  /**
+   * Maximum time in milliseconds the inferred web server readiness task waits
+   * for the server to accept connections before failing. Overrides the
+   * `timeout` configured on Playwright's `webServer`. Defaults to that
+   * configured timeout, or 60000 when neither is set.
+   */
+  webServerTimeout?: number;
 }
 
 interface NormalizedOptions {
   targetName: string;
   ciTargetName: string;
   mergeReportsTargetName: string;
+  webServerTimeout?: number;
 }
 
 type PlaywrightTargets = Pick<ProjectConfiguration, 'targets' | 'metadata'>;
+
+interface WebserverCommandTask {
+  project: string;
+  target: string;
+  port?: number;
+  url?: string;
+  ignoreHTTPSErrors?: boolean;
+  timeout?: number;
+}
 
 const playwrightConfigGlob = '**/playwright.config.{js,ts,cjs,cts,mjs,mts}';
 export const createNodes: CreateNodes<PlaywrightPluginOptions> = [
@@ -260,6 +277,47 @@ async function buildPlaywrightTargets(
 
     const dependsOn: TargetDependencyConfig[] = [];
 
+    // When the inferred web server task(s) expose a port/url, add a task that
+    // waits for the server to accept connections. Playwright's
+    // `reuseExistingServer` probe otherwise races the server boot on the first
+    // CI task per agent and spawns its own nested server command, whose I/O
+    // then leaks into that task.
+    const readinessTasks = webserverCommandTasks.filter(
+      (task) => task.port != null || task.url != null
+    );
+    const webserverReadinessServers = readinessTasks.map((task) => {
+      const server: {
+        port?: number;
+        url?: string;
+        ignoreHTTPSErrors?: boolean;
+      } = task.port != null ? { port: task.port } : { url: task.url };
+      if (task.ignoreHTTPSErrors) {
+        server.ignoreHTTPSErrors = true;
+      }
+      return server;
+    });
+    const webserverReadyTargetName =
+      webserverReadinessServers.length > 0
+        ? `${options.ciTargetName}--wait-for-webserver`
+        : undefined;
+    // Honor Playwright's own `webServer.timeout` (the budget it waits for a
+    // server it starts) so a slow server is not cut short. The plugin option
+    // overrides it; use the longest configured timeout across servers.
+    const configuredTimeouts = readinessTasks
+      .map((task) => task.timeout)
+      .filter((timeout): timeout is number => timeout != null);
+    const webserverReadinessTimeout =
+      options.webServerTimeout ??
+      (configuredTimeouts.length > 0
+        ? Math.max(...configuredTimeouts)
+        : undefined);
+    const ciDependsOn = webserverReadyTargetName
+      ? [
+          ...getDependsOn(webserverCommandTasks),
+          { target: webserverReadyTargetName },
+        ]
+      : undefined;
+
     const testFiles = await getAllTestFiles({
       context,
       path: testDir,
@@ -295,6 +353,7 @@ async function buildPlaywrightTargets(
       ciTargetGroup.push(targetName);
       targets[targetName] = {
         ...ciBaseTargetConfig,
+        ...(ciDependsOn ? { dependsOn: ciDependsOn } : {}),
         options: {
           ...ciBaseTargetConfig.options,
           env: getAtomizedTaskEnvVars(reporterOutputs, outputSubfolder),
@@ -333,6 +392,25 @@ async function buildPlaywrightTargets(
       });
     }
 
+    if (webserverReadyTargetName) {
+      targets[webserverReadyTargetName] = {
+        executor: '@nx/playwright:wait-for-webserver',
+        cache: false,
+        options: {
+          servers: webserverReadinessServers,
+          ...(webserverReadinessTimeout != null
+            ? { timeout: webserverReadinessTimeout }
+            : {}),
+        },
+        dependsOn: getDependsOn(webserverCommandTasks),
+        metadata: {
+          technologies: ['playwright'],
+          description:
+            'Waits for the E2E web server(s) to be ready before the Playwright CI test tasks run.',
+        },
+      };
+    }
+
     targets[options.ciTargetName] ??= {};
 
     targets[options.ciTargetName] = {
@@ -360,6 +438,9 @@ async function buildPlaywrightTargets(
       targets[options.ciTargetName].parallelism = false;
     }
     ciTargetGroup.push(options.ciTargetName);
+    if (webserverReadyTargetName) {
+      ciTargetGroup.push(webserverReadyTargetName);
+    }
 
     // infer the task to merge the reports from the atomized tasks
     const mergeReportsTargetOutputs = new Set<string>();
@@ -515,12 +596,12 @@ function addSubfolderToOutput(output: string, subfolder: string): string {
 
 function getWebserverCommandTasks(
   playwrightConfig: PlaywrightTestConfig
-): Array<{ project: string; target: string }> {
+): WebserverCommandTask[] {
   if (!playwrightConfig.webServer) {
     return [];
   }
 
-  const tasks: Array<{ project: string; target: string }> = [];
+  const tasks: WebserverCommandTask[] = [];
 
   const webServer = Array.isArray(playwrightConfig.webServer)
     ? playwrightConfig.webServer
@@ -533,7 +614,13 @@ function getWebserverCommandTasks(
 
     const task = parseTaskFromCommand(server.command);
     if (task) {
-      tasks.push(task);
+      tasks.push({
+        ...task,
+        port: server.port,
+        url: server.url,
+        ignoreHTTPSErrors: server.ignoreHTTPSErrors,
+        timeout: server.timeout,
+      });
     }
   }
 

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -72,6 +72,7 @@ type PlaywrightTargets = Pick<ProjectConfiguration, 'targets' | 'metadata'>;
 interface WebserverCommandTask {
   project: string;
   target: string;
+  hasConfiguration: boolean;
   port?: number;
   url?: string;
   ignoreHTTPSErrors?: boolean;
@@ -839,6 +840,15 @@ function getWebserverCommandTasks(
 function toReadinessServer(
   task: WebserverCommandTask
 ): WebserverReadinessServer | undefined {
+  // The inferred dependency runs the target without the command's trailing
+  // `:configuration` (a task dependency cannot carry one), so the server it
+  // starts can listen at a different address than the configured one. Gating
+  // on that address would wait out the whole budget; leave readiness to
+  // Playwright's own probe instead.
+  if (task.hasConfiguration) {
+    return undefined;
+  }
+
   let server: WebserverReadinessServer;
   if (typeof task.port === 'number' && task.port) {
     server = { port: task.port };
@@ -870,6 +880,7 @@ function toReadinessServer(
 function parseTaskFromCommand(command: string): {
   project: string;
   target: string;
+  hasConfiguration: boolean;
 } | null {
   const nxRunRegex =
     /^(?:(?:npx|yarn|bun|pnpm|pnpm exec|pnpx) )?nx run (\S+:\S+)$/;
@@ -877,14 +888,14 @@ function parseTaskFromCommand(command: string): {
 
   const nxRunMatch = command.match(nxRunRegex);
   if (nxRunMatch) {
-    const [project, target] = nxRunMatch[1].split(':');
-    return { project, target };
+    const [project, target, configuration] = nxRunMatch[1].split(':');
+    return { project, target, hasConfiguration: configuration !== undefined };
   }
 
   const infixMatch = command.match(infixRegex);
   if (infixMatch) {
     const [target, project] = infixMatch[1].split(' ');
-    return { project, target };
+    return { project, target, hasConfiguration: false };
   }
 
   return null;

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -167,15 +167,14 @@ async function createNodesInternal(
   // The createNodes hash covers projectRoot files, the lockfile, and tsconfig,
   // but a workspace-root dotenv a nested project loads is outside it. Fold the
   // consumer chains' dotenv fingerprints into the cache key so a dotenv change
-  // (which the daemon invalidates the graph on) rebuilds the gate instead of
-  // returning a stale one. Only when the readiness gate is enabled can a
-  // dotenv change affect the output.
-  const chainDotEnvPairs = normalizedOptions.waitForWebServer
-    ? getChainDotEnvPairs(context.workspaceRoot, projectRoot, normalizedOptions)
-    : undefined;
-  const cacheKey = chainDotEnvPairs
-    ? `${hash}-${hashObject(chainDotEnvPairs)}`
-    : hash;
+  // (which the daemon invalidates the graph on) rebuilds the inferred targets
+  // instead of returning stale ones.
+  const chainDotEnvPairs = getChainDotEnvPairs(
+    context.workspaceRoot,
+    projectRoot,
+    normalizedOptions
+  );
+  const cacheKey = `${hash}-${hashObject(chainDotEnvPairs)}`;
 
   if (!pluginCache.has(cacheKey)) {
     pluginCache.set(
@@ -211,7 +210,7 @@ async function buildPlaywrightTargets(
   context: CreateNodesContext,
   pmc: ReturnType<typeof getPackageManagerCommand>,
   externalTsconfigInputs: string[],
-  chainDotEnvPairs: ChainDotEnvPairs | undefined
+  chainDotEnvPairs: ChainDotEnvPairs
 ): Promise<PlaywrightTargets> {
   // Playwright forbids importing the `@playwright/test` module twice. This would affect running the tests,
   // but we're just reading the config so let's delete the variable they are using to detect this.
@@ -242,17 +241,17 @@ async function buildPlaywrightTargets(
   // command whose I/O then leaks into the task. Both the `e2e` task and the
   // atomized CI tasks depend on it.
   //
-  // The address can be read from process.env, but createNodes evaluates the
-  // config without the e2e task's dotenv loaded. Resolve each consumer chain's
-  // servers under that chain's task env so the gate probes the address the task
-  // will actually serve. `e2e` and the atomized `e2e-ci` tasks can load
+  // The command and address can be read from process.env, but createNodes
+  // evaluates the config without the e2e task's dotenv loaded. Resolve each
+  // consumer chain's servers under that chain's task env so the dependencies
+  // and the gate match what the task will actually run and probe.
+  // `e2e` and the atomized `e2e-ci` tasks can load
   // different dotenv, so a distinct resolved address gets its own gate. When
   // both chains load the same dotenv inputs they resolve to the same servers,
   // so a single resolution is shared; distinct inputs resolve concurrently.
   const chainsShareDotEnv =
-    !chainDotEnvPairs ||
     JSON.stringify(chainDotEnvPairs.target) ===
-      JSON.stringify(chainDotEnvPairs.ciTarget);
+    JSON.stringify(chainDotEnvPairs.ciTarget);
   let e2eChain: ChainWebserver;
   let ciChain: ChainWebserver;
   if (!options.ciTargetName || chainsShareDotEnv) {
@@ -660,8 +659,8 @@ function addSubfolderToOutput(output: string, subfolder: string): string {
 // The dotenv files a chain's task would load, as sorted (workspace-relative
 // path, content hash) pairs of the files that exist. Hashed into the
 // PluginCache key so a dotenv change the createNodes hash does not cover still
-// rebuilds the gate, and compared across the two chains so identical dotenv
-// inputs share one config resolution.
+// rebuilds the inferred targets, and compared across the two chains so
+// identical dotenv inputs share one config resolution.
 type DotEnvPairs = Array<[path: string, hash: string]>;
 
 interface ChainDotEnvPairs {
@@ -715,16 +714,16 @@ function getDotEnvPairsForTask(
 // (`e2e` or the atomized `e2e-ci`) would see. A config with no ambient
 // `webServer` yields nothing to depend on or gate, so the task-env resolution
 // is skipped entirely: a `webServer` entry whose existence (not address)
-// depends on task-scoped env is not detected. When `inferReadiness` is false
-// the gate is opted out: this skips the task-env resolution, keeps the ambient
-// command tasks, and returns no readiness servers. Otherwise, when the chain's
+// depends on task-scoped env is not detected. Otherwise, when the chain's
 // task env differs from the graph-time ambient env, the config is re-evaluated
-// in a child under that env so an env-derived address resolves the way the task
-// will; a matching env reuses the ambient config. A failed re-evaluation falls
-// back to the ambient servers and skips the gate for the chain: an unverified
-// address must not become a gate the daemon then caches, but a config bug or
-// timeout should degrade to master's behavior, not kill graph construction for
-// most commands.
+// in a child under that env so an env-derived command or address resolves the
+// way the task will; a matching env reuses the ambient config. When
+// `inferReadiness` is false the gate is opted out: the resolved command tasks
+// still become dependencies, but no readiness servers are returned. A failed
+// re-evaluation falls back to the ambient servers and skips the gate for the
+// chain: an unverified address must not become a gate the daemon then caches,
+// but a config bug or timeout should degrade to master's behavior, not kill
+// graph construction for most commands.
 async function resolveChainWebserver(
   configFilePath: string,
   projectRoot: string,
@@ -739,27 +738,25 @@ async function resolveChainWebserver(
   }
   let webServers = ambientWebServers;
   let taskEnvEvalFailed = false;
-  if (inferReadiness) {
-    const taskEnv = getGraphTimeDotEnvForTask(
-      projectRoot,
-      target,
-      undefined,
-      nonAtomizedTarget
-    );
-    if (taskEnvDivergesFromAmbient(taskEnv)) {
-      try {
-        webServers = await resolveWebServersUnderEnv(
-          configFilePath,
-          workspaceRoot,
-          taskEnv
-        );
-      } catch (e) {
-        taskEnvEvalFailed = true;
-        const detail = e instanceof Error ? e.message : String(e);
-        logger.warn(
-          `@nx/playwright: could not evaluate ${configFilePath} under the ${target} task env to resolve the web server address. Targets are inferred from the ambient config evaluation and no web server readiness task is inferred for ${target}.\n${detail}`
-        );
-      }
+  const taskEnv = getGraphTimeDotEnvForTask(
+    projectRoot,
+    target,
+    undefined,
+    nonAtomizedTarget
+  );
+  if (taskEnvDivergesFromAmbient(taskEnv)) {
+    try {
+      webServers = await resolveWebServersUnderEnv(
+        configFilePath,
+        workspaceRoot,
+        taskEnv
+      );
+    } catch (e) {
+      taskEnvEvalFailed = true;
+      const detail = e instanceof Error ? e.message : String(e);
+      logger.warn(
+        `@nx/playwright: could not evaluate ${configFilePath} under the ${target} task env to resolve the web server address. Targets are inferred from the ambient config evaluation and no web server readiness task is inferred for ${target}.\n${detail}`
+      );
     }
   }
 

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -674,17 +674,23 @@ function getChainDotEnvPairs(
   projectRoot: string,
   options: NormalizedOptions
 ): ChainDotEnvPairs {
+  // The ci chain's candidate paths include the e2e chain's, so hash each file
+  // at most once per pass.
+  const fileHashes = new Map<string, string | null>();
   const target = getDotEnvPairsForTask(
     workspaceRoot,
     projectRoot,
-    options.targetName
+    options.targetName,
+    undefined,
+    fileHashes
   );
   const ciTarget = options.ciTargetName
     ? getDotEnvPairsForTask(
         workspaceRoot,
         projectRoot,
         options.ciTargetName,
-        options.targetName
+        options.targetName,
+        fileHashes
       )
     : target;
   return { target, ciTarget };
@@ -694,7 +700,8 @@ function getDotEnvPairsForTask(
   workspaceRoot: string,
   projectRoot: string,
   target: string,
-  nonAtomizedTarget?: string
+  nonAtomizedTarget: string | undefined,
+  fileHashes: Map<string, string | null>
 ): DotEnvPairs {
   const pairs: DotEnvPairs = [];
   for (const file of getEnvPathsForTask(
@@ -703,7 +710,11 @@ function getDotEnvPairsForTask(
     undefined,
     nonAtomizedTarget
   )) {
-    const fileHash = hashFile(join(workspaceRoot, file));
+    let fileHash = fileHashes.get(file);
+    if (fileHash === undefined) {
+      fileHash = hashFile(join(workspaceRoot, file));
+      fileHashes.set(file, fileHash);
+    }
     if (fileHash !== null) {
       pairs.push([file, fileHash]);
     }

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -74,6 +74,36 @@ interface ChainWebserver {
   readinessServers: WebserverReadinessServer[];
 }
 
+// getGraphTimeEnvForTask reads dotenv files from disk, and within one config's
+// createNodes the cache-key digest and each consumer chain resolve the same task
+// envs. Memoize by target coordinates in a cache scoped to that single config
+// eval, so a dotenv snapshot is never shared across concurrent createNodes
+// passes. Callers only read/spread the returned env.
+type GraphTimeEnvCache = Map<string, NodeJS.ProcessEnv>;
+
+function getCachedGraphTimeEnvForTask(
+  cache: GraphTimeEnvCache,
+  projectRoot: string,
+  target: string,
+  configuration?: string,
+  nonAtomizedTarget?: string
+): NodeJS.ProcessEnv {
+  const key = `${projectRoot}\0${target}\0${configuration ?? ''}\0${
+    nonAtomizedTarget ?? ''
+  }`;
+  let env = cache.get(key);
+  if (!env) {
+    env = getGraphTimeEnvForTask(
+      projectRoot,
+      target,
+      configuration,
+      nonAtomizedTarget
+    );
+    cache.set(key, env);
+  }
+  return env;
+}
+
 const playwrightConfigGlob = '**/playwright.config.{js,ts,cjs,cts,mjs,mts}';
 export const createNodes: CreateNodes<PlaywrightPluginOptions> = [
   playwrightConfigGlob,
@@ -152,12 +182,19 @@ async function createNodesInternal(
   hash: string
 ) {
   const projectRoot = dirname(configFilePath);
+  // Scoped to this single config eval so the memoized task envs are never shared
+  // across concurrent createNodes passes.
+  const graphTimeEnvCache: GraphTimeEnvCache = new Map();
 
   // The createNodes hash covers projectRoot files, the lockfile, and tsconfig,
   // but a workspace-root dotenv a nested project loads is outside it. Fold the
   // task dotenv overlay into the cache key so a dotenv change (which the daemon
   // invalidates the graph on) rebuilds the gate instead of returning a stale one.
-  const cacheKey = `${hash}-${dotEnvOverlayDigest(projectRoot, normalizedOptions)}`;
+  const cacheKey = `${hash}-${dotEnvOverlayDigest(
+    projectRoot,
+    normalizedOptions,
+    graphTimeEnvCache
+  )}`;
 
   if (!pluginCache.has(cacheKey)) {
     pluginCache.set(
@@ -168,7 +205,8 @@ async function createNodesInternal(
         normalizedOptions,
         context,
         pmc,
-        externalTsconfigInputs
+        externalTsconfigInputs,
+        graphTimeEnvCache
       )
     );
   }
@@ -191,7 +229,8 @@ async function buildPlaywrightTargets(
   options: NormalizedOptions,
   context: CreateNodesContext,
   pmc: ReturnType<typeof getPackageManagerCommand>,
-  externalTsconfigInputs: string[]
+  externalTsconfigInputs: string[],
+  graphTimeEnvCache: GraphTimeEnvCache
 ): Promise<PlaywrightTargets> {
   // Playwright forbids importing the `@playwright/test` module twice. This would affect running the tests,
   // but we're just reading the config so let's delete the variable they are using to detect this.
@@ -232,7 +271,9 @@ async function buildPlaywrightTargets(
     projectRoot,
     context.workspaceRoot,
     ambientWebServers,
-    options.targetName
+    options.targetName,
+    undefined,
+    graphTimeEnvCache
   );
   const ciChain = options.ciTargetName
     ? await resolveChainWebserver(
@@ -241,7 +282,8 @@ async function buildPlaywrightTargets(
         context.workspaceRoot,
         ambientWebServers,
         options.ciTargetName,
-        options.targetName
+        options.targetName,
+        graphTimeEnvCache
       )
     : e2eChain;
 
@@ -632,12 +674,20 @@ function addSubfolderToOutput(output: string, subfolder: string): string {
 // dotenv change the createNodes hash does not cover still rebuilds the gate.
 function dotEnvOverlayDigest(
   projectRoot: string,
-  options: NormalizedOptions
+  options: NormalizedOptions,
+  graphTimeEnvCache: GraphTimeEnvCache
 ): string {
   return hashObject({
-    e2e: dotEnvOverlay(getGraphTimeEnvForTask(projectRoot, options.targetName)),
+    e2e: dotEnvOverlay(
+      getCachedGraphTimeEnvForTask(
+        graphTimeEnvCache,
+        projectRoot,
+        options.targetName
+      )
+    ),
     'e2e-ci': dotEnvOverlay(
-      getGraphTimeEnvForTask(
+      getCachedGraphTimeEnvForTask(
+        graphTimeEnvCache,
         projectRoot,
         options.ciTargetName,
         undefined,
@@ -673,10 +723,12 @@ async function resolveChainWebserver(
   workspaceRoot: string,
   ambientWebServers: ResolvedWebServer[],
   target: string,
-  nonAtomizedTarget?: string
+  nonAtomizedTarget: string | undefined,
+  graphTimeEnvCache: GraphTimeEnvCache
 ): Promise<ChainWebserver> {
   let webServers = ambientWebServers;
-  const taskEnv = getGraphTimeEnvForTask(
+  const taskEnv = getCachedGraphTimeEnvForTask(
+    graphTimeEnvCache,
     projectRoot,
     target,
     undefined,

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -845,13 +845,13 @@ function getWebserverCommandTasks(
   return tasks;
 }
 
-// Playwright picks a web server's readiness probe by presence rather than
-// truthiness: a defined `port` makes it check that port over TCP even when the
-// value is falsy and the address comes from `url`, and a web server it can
-// address neither way gets no probe at all. An unchecked `playwright.config.js`
-// can also carry a `port` Playwright coerces but the readiness task can't
-// probe. Gate only on the shapes the task probes the same way; the rest is
-// left to Playwright.
+// Playwright throws when `port` and `url` are both truthy, but a present
+// `port` (even 0) still selects its TCP-only probe, whose target comes from
+// the derived url rather than the option: the url's port for `port: 0` plus
+// `url`, and 0, which can never connect, when that url carries no explicit
+// port. An unchecked `playwright.config.js` can also carry a `port` Playwright
+// coerces but the readiness task can't probe. Gate only on the shapes the task
+// probes the same way; the rest is left to Playwright.
 function toReadinessServer(
   task: WebserverCommandTask
 ): WebserverReadinessServer | undefined {

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -690,8 +690,11 @@ async function resolveChainWebserver(
         taskEnv
       );
     } catch (e) {
+      // Nx's createNodes error formatter renders `message`/`stack` but not
+      // `cause`, so fold the child's failure into the message to surface it.
+      const detail = e instanceof Error ? e.message : String(e);
       throw new Error(
-        `@nx/playwright: could not evaluate ${configFilePath} under the ${target} task env to resolve the web server readiness address.`,
+        `@nx/playwright: could not evaluate ${configFilePath} under the ${target} task env to resolve the web server readiness address.\n${detail}`,
         { cause: e }
       );
     }
@@ -793,8 +796,10 @@ function toReadinessServer(
   }
   // Carry each server's own `webServer.timeout` (the budget Playwright waits
   // for a server it starts) so a slow server is not cut short and a fast one
-  // is not given another server's budget.
-  if (task.timeout != null) {
+  // is not given another server's budget. Guard the type like `port`/`url`
+  // above: an unchecked `.js` config can carry a non-number the gate task's
+  // schema would then reject at run time.
+  if (typeof task.timeout === 'number' && Number.isFinite(task.timeout)) {
     server.timeout = task.timeout;
   }
 

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -3,6 +3,7 @@ import {
   emitPluginWorkerLog,
   loadConfigFile,
   getNamedInputs,
+  getDaemonClientEnvGeneration,
   getGraphTimeDotEnvForTask,
   getEnvPathsForTask,
   hashDaemonClientEnv,
@@ -114,6 +115,7 @@ export const createNodes: CreateNodes<PlaywrightPluginOptions> = [
     // daemon swaps per client). Key the cache on the daemon-allowed env set so
     // an ambient change re-evaluates instead of serving stale targets.
     const ambientEnvHash = hashDaemonClientEnv();
+    const ambientEnvGeneration = getDaemonClientEnvGeneration();
     // The workspace-root dotenv candidates are the same for every config, so
     // hash each file at most once per pass rather than once per config.
     const dotEnvFileHashes = new Map<string, string | null>();
@@ -166,16 +168,16 @@ export const createNodes: CreateNodes<PlaywrightPluginOptions> = [
       return results;
     } finally {
       // The daemon can apply another client's env mid-pass (worker message
-      // dispatch is unserialized), so entries built after the change would be
-      // keyed under the stale pass-start digest. Drop the write; the next
-      // pass recomputes under a coherent key.
-      if (hashDaemonClientEnv() === ambientEnvHash) {
+      // dispatch is unserialized) and a config can mutate the env while
+      // evaluating; entries built after either change are keyed under the
+      // stale pass-start digest, so drop the write and let the next pass
+      // rebuild under a coherent key. The generation catches an env that
+      // changed and changed back mid-pass, which the digest misses.
+      if (
+        getDaemonClientEnvGeneration() === ambientEnvGeneration &&
+        hashDaemonClientEnv() === ambientEnvHash
+      ) {
         pluginCache.writeToDisk();
-      } else if (process.env.NX_VERBOSE_LOGGING === 'true') {
-        emitPluginWorkerLog(
-          'log',
-          '@nx/playwright: the ambient environment changed while inferring targets; skipping the disk cache write for this pass.'
-        );
       }
     }
   },
@@ -419,12 +421,10 @@ async function buildPlaywrightTargets(
       ),
     };
 
-    // The atomized tasks inherit the e2e chain's dependsOn and parallelism.
-    // When the CI chain resolves differently it has its own gate (or none), so
-    // re-derive both from it.
-    if (!chainsShareGate) {
-      applyChainDependsOn(ciBaseTargetConfig, ciChain, ciReadyTargetName);
-    }
+    // Unconditionally: the chains can differ in ways the shared-gate check
+    // deliberately ignores (an extra uncovered server flips parallelism), and
+    // re-deriving is a no-op when they match.
+    applyChainDependsOn(ciBaseTargetConfig, ciChain, ciReadyTargetName);
 
     const groupName = 'E2E (CI)';
     metadata = { targetGroups: { [groupName]: [] } };
@@ -834,7 +834,10 @@ async function resolveChainWebserver(
 // Two chains share a gate only when both the readiness servers and the serve
 // command tasks (which become the gate's and the tasks' dependsOn) match.
 function sameChain(a: ChainWebserver, b: ChainWebserver): boolean {
-  return JSON.stringify(a) === JSON.stringify(b);
+  return (
+    JSON.stringify(a.commandTasks) === JSON.stringify(b.commandTasks) &&
+    JSON.stringify(a.readinessServers) === JSON.stringify(b.readinessServers)
+  );
 }
 
 function buildWaitForWebserverTarget(
@@ -907,7 +910,7 @@ function getWebserverCommandTasks(
       uncoveredServers++;
       // A command that never invokes nx (`npm run start`, `vite`) was never
       // meant to map to a task, so its skip warrants no warning.
-      if (/(^|\s)nx\s/.test(server.command)) {
+      if (/(^|\s)nx(@\S+)?\s/.test(server.command)) {
         const warnedKey = `${configFilePath}|${server.command}`;
         if (!warnedUnparseableCommands.has(warnedKey)) {
           warnedUnparseableCommands.add(warnedKey);

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -2,6 +2,7 @@ import {
   calculateHashesForCreateNodes,
   loadConfigFile,
   getNamedInputs,
+  getGraphTimeEnvForTask,
   hashObject,
   workspaceDataDirectory,
   PluginCache,
@@ -29,6 +30,12 @@ import { existsSync, readdirSync } from 'node:fs';
 import { dirname, join, parse, relative, resolve, sep } from 'node:path';
 import type { Schema as WaitForWebserverSchema } from '../executors/wait-for-webserver/schema';
 import { getReporterOutputs, type ReporterOutput } from '../utils/reporters';
+import {
+  normalizeWebServers,
+  resolveWebServersUnderEnv,
+  taskEnvDivergesFromAmbient,
+  type ResolvedWebServer,
+} from './webserver-readiness';
 
 export interface PlaywrightPluginOptions {
   targetName?: string;
@@ -61,6 +68,11 @@ interface WebserverCommandTask {
 }
 
 type WebserverReadinessServer = WaitForWebserverSchema['servers'][number];
+
+interface ChainWebserver {
+  commandTasks: WebserverCommandTask[];
+  readinessServers: WebserverReadinessServer[];
+}
 
 const playwrightConfigGlob = '**/playwright.config.{js,ts,cjs,cts,mjs,mts}';
 export const createNodes: CreateNodes<PlaywrightPluginOptions> = [
@@ -141,9 +153,15 @@ async function createNodesInternal(
 ) {
   const projectRoot = dirname(configFilePath);
 
-  if (!pluginCache.has(hash)) {
+  // The createNodes hash covers projectRoot files, the lockfile, and tsconfig,
+  // but a workspace-root dotenv a nested project loads is outside it. Fold the
+  // task dotenv overlay into the cache key so a dotenv change (which the daemon
+  // invalidates the graph on) rebuilds the gate instead of returning a stale one.
+  const cacheKey = `${hash}-${dotEnvOverlayDigest(projectRoot, normalizedOptions)}`;
+
+  if (!pluginCache.has(cacheKey)) {
     pluginCache.set(
-      hash,
+      cacheKey,
       await buildPlaywrightTargets(
         configFilePath,
         projectRoot,
@@ -154,7 +172,7 @@ async function createNodesInternal(
       )
     );
   }
-  const { targets, metadata } = pluginCache.get(hash);
+  const { targets, metadata } = pluginCache.get(cacheKey);
 
   return {
     projects: {
@@ -196,19 +214,47 @@ async function buildPlaywrightTargets(
 
   const testOutput = getTestOutput(playwrightConfig);
   const reporterOutputs = getReporterOutputs(playwrightConfig);
-  const webserverCommandTasks = getWebserverCommandTasks(playwrightConfig);
+  const ambientWebServers = normalizeWebServers(playwrightConfig.webServer);
 
   // When an inferred web server exposes a port/url, add a task that waits for
   // it to be ready. Playwright's `reuseExistingServer` probe
   // otherwise races the server boot, misses, and spawns its own nested server
   // command whose I/O then leaks into the task. Both the `e2e` task and the
   // atomized CI tasks depend on it.
-  const webserverReadinessServers = webserverCommandTasks
-    .map(toReadinessServer)
-    .filter(Boolean);
-  const webserverReadyTargetName =
-    webserverReadinessServers.length > 0
+  //
+  // The address can be read from process.env, but createNodes evaluates the
+  // config without the e2e task's dotenv loaded. Resolve each consumer chain's
+  // servers under that chain's task env so the gate probes the address the task
+  // will actually serve. `e2e` and the atomized `e2e-ci` tasks can load
+  // different dotenv, so a distinct resolved address gets its own gate.
+  const e2eChain = await resolveChainWebserver(
+    configFilePath,
+    projectRoot,
+    context.workspaceRoot,
+    ambientWebServers,
+    options.targetName
+  );
+  const ciChain = options.ciTargetName
+    ? await resolveChainWebserver(
+        configFilePath,
+        projectRoot,
+        context.workspaceRoot,
+        ambientWebServers,
+        options.ciTargetName,
+        options.targetName
+      )
+    : e2eChain;
+
+  const e2eReadyTargetName =
+    e2eChain.readinessServers.length > 0
       ? `${options.targetName}--wait-for-webserver`
+      : undefined;
+  const chainsShareGate = sameChain(e2eChain, ciChain);
+  const ciReadyTargetName =
+    ciChain.readinessServers.length > 0
+      ? chainsShareGate
+        ? e2eReadyTargetName
+        : `${options.ciTargetName}--wait-for-webserver`
       : undefined;
 
   const baseTargetConfig: TargetConfiguration = {
@@ -230,13 +276,10 @@ async function buildPlaywrightTargets(
     },
   };
 
-  if (webserverCommandTasks.length) {
-    baseTargetConfig.dependsOn = webserverReadyTargetName
-      ? [
-          ...getDependsOn(webserverCommandTasks),
-          { target: webserverReadyTargetName },
-        ]
-      : getDependsOn(webserverCommandTasks);
+  if (e2eChain.commandTasks.length) {
+    baseTargetConfig.dependsOn = e2eReadyTargetName
+      ? [...getDependsOn(e2eChain.commandTasks), { target: e2eReadyTargetName }]
+      : getDependsOn(e2eChain.commandTasks);
   } else {
     baseTargetConfig.parallelism = false;
   }
@@ -259,23 +302,17 @@ async function buildPlaywrightTargets(
     ),
   };
 
-  if (webserverReadyTargetName) {
-    targets[webserverReadyTargetName] = {
-      executor: '@nx/playwright:wait-for-webserver',
-      cache: false,
-      options: {
-        servers: webserverReadinessServers,
-        ...(options.webServerTimeout != null
-          ? { timeout: options.webServerTimeout }
-          : {}),
-      },
-      dependsOn: getDependsOn(webserverCommandTasks),
-      metadata: {
-        technologies: ['playwright'],
-        description:
-          'Waits for the E2E web server(s) to be ready before the Playwright test tasks run.',
-      },
-    };
+  if (e2eReadyTargetName) {
+    targets[e2eReadyTargetName] = buildWaitForWebserverTarget(
+      e2eChain,
+      options.webServerTimeout
+    );
+  }
+  if (ciReadyTargetName && ciReadyTargetName !== e2eReadyTargetName) {
+    targets[ciReadyTargetName] = buildWaitForWebserverTarget(
+      ciChain,
+      options.webServerTimeout
+    );
   }
 
   if (options.ciTargetName) {
@@ -304,6 +341,22 @@ async function buildPlaywrightTargets(
         projectRoot
       ),
     };
+
+    // The atomized tasks inherit the e2e chain's dependsOn. When the CI chain
+    // resolves a different address it has its own gate, so point them at it.
+    if (!chainsShareGate) {
+      if (ciChain.commandTasks.length) {
+        ciBaseTargetConfig.dependsOn = ciReadyTargetName
+          ? [
+              ...getDependsOn(ciChain.commandTasks),
+              { target: ciReadyTargetName },
+            ]
+          : getDependsOn(ciChain.commandTasks);
+      } else {
+        delete ciBaseTargetConfig.dependsOn;
+        ciBaseTargetConfig.parallelism = false;
+      }
+    }
 
     const groupName = 'E2E (CI)';
     metadata = { targetGroups: { [groupName]: [] } };
@@ -414,12 +467,12 @@ async function buildPlaywrightTargets(
       },
     };
 
-    if (!webserverCommandTasks.length) {
+    if (!ciChain.commandTasks.length) {
       targets[options.ciTargetName].parallelism = false;
     }
     ciTargetGroup.push(options.ciTargetName);
-    if (webserverReadyTargetName) {
-      ciTargetGroup.push(webserverReadyTargetName);
+    if (ciReadyTargetName) {
+      ciTargetGroup.push(ciReadyTargetName);
     }
 
     // infer the task to merge the reports from the atomized tasks
@@ -572,6 +625,111 @@ function addSubfolderToOutput(output: string, subfolder: string): string {
     return joinPathFragments(parts.dir, subfolder, parts.base);
   }
   return joinPathFragments(output, subfolder);
+}
+
+// Digest of the task dotenv overlay (the keys that differ from the graph-time
+// ambient env) for the consumer chains, folded into the PluginCache key so a
+// dotenv change the createNodes hash does not cover still rebuilds the gate.
+function dotEnvOverlayDigest(
+  projectRoot: string,
+  options: NormalizedOptions
+): string {
+  return hashObject({
+    e2e: dotEnvOverlay(getGraphTimeEnvForTask(projectRoot, options.targetName)),
+    'e2e-ci': dotEnvOverlay(
+      getGraphTimeEnvForTask(
+        projectRoot,
+        options.ciTargetName,
+        undefined,
+        options.targetName
+      )
+    ),
+  });
+}
+
+function dotEnvOverlay(taskEnv: NodeJS.ProcessEnv): Record<string, string> {
+  const overlay: Record<string, string> = {};
+  for (const key of new Set([
+    ...Object.keys(process.env),
+    ...Object.keys(taskEnv),
+  ])) {
+    if (process.env[key] !== taskEnv[key]) {
+      overlay[key] = taskEnv[key];
+    }
+  }
+  return overlay;
+}
+
+// Resolves the web server command tasks and readiness servers a consumer chain
+// (`e2e` or the atomized `e2e-ci`) would see. When the chain's task env differs
+// from the graph-time ambient env, the config is re-evaluated in a child under
+// that env so an env-derived address resolves the way the task will; otherwise
+// the ambient config is reused. A failed re-evaluation throws: the daemon caches
+// the resulting graph, so a silent fallback would bake a wrong gate that no
+// retry corrects until the graph is invalidated.
+async function resolveChainWebserver(
+  configFilePath: string,
+  projectRoot: string,
+  workspaceRoot: string,
+  ambientWebServers: ResolvedWebServer[],
+  target: string,
+  nonAtomizedTarget?: string
+): Promise<ChainWebserver> {
+  let webServers = ambientWebServers;
+  const taskEnv = getGraphTimeEnvForTask(
+    projectRoot,
+    target,
+    undefined,
+    nonAtomizedTarget
+  );
+  if (taskEnvDivergesFromAmbient(taskEnv)) {
+    try {
+      webServers = await resolveWebServersUnderEnv(
+        configFilePath,
+        workspaceRoot,
+        taskEnv
+      );
+    } catch (e) {
+      throw new Error(
+        `@nx/playwright: could not evaluate ${configFilePath} under the ${target} task env to resolve the web server readiness address.`,
+        { cause: e }
+      );
+    }
+  }
+
+  const commandTasks = getWebserverCommandTasks({
+    webServer: webServers as PlaywrightTestConfig['webServer'],
+  });
+  const readinessServers = commandTasks
+    .map(toReadinessServer)
+    .filter(Boolean) as WebserverReadinessServer[];
+  return { commandTasks, readinessServers };
+}
+
+// Two chains share a gate only when both the readiness servers and the serve
+// command tasks (which become the gate's and the tasks' dependsOn) match.
+function sameChain(a: ChainWebserver, b: ChainWebserver): boolean {
+  return JSON.stringify(a) === JSON.stringify(b);
+}
+
+function buildWaitForWebserverTarget(
+  chain: ChainWebserver,
+  webServerTimeout: number | undefined
+): TargetConfiguration {
+  return {
+    executor: '@nx/playwright:wait-for-webserver',
+    cache: false,
+    options: {
+      servers: chain.readinessServers,
+      ...(webServerTimeout != null ? { timeout: webServerTimeout } : {}),
+    },
+    dependsOn: getDependsOn(chain.commandTasks),
+    metadata: {
+      technologies: ['playwright'],
+      description:
+        'Waits for the E2E web server(s) to be ready before the Playwright test tasks run.',
+    },
+  };
 }
 
 function getWebserverCommandTasks(

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -1,5 +1,6 @@
 import {
   calculateHashesForCreateNodes,
+  emitPluginWorkerLog,
   loadConfigFile,
   getNamedInputs,
   getGraphTimeDotEnvForTask,
@@ -19,7 +20,6 @@ import {
   detectPackageManager,
   getPackageManagerCommand,
   joinPathFragments,
-  logger,
   normalizePath,
   type ProjectConfiguration,
   type TargetConfiguration,
@@ -84,6 +84,15 @@ type WebserverReadinessServer = WaitForWebserverSchema['servers'][number];
 interface ChainWebserver {
   commandTasks: WebserverCommandTask[];
   readinessServers: WebserverReadinessServer[];
+  // Count of `reuseExistingServer` servers no task could be inferred for.
+  uncoveredServers: number;
+}
+
+interface ResolvedChainWebserver {
+  chain: ChainWebserver;
+  // Outside ChainWebserver so a failed evaluation does not split `sameChain`'s
+  // structural comparison of two otherwise identical chains.
+  taskEnvEvalFailed: boolean;
 }
 
 const playwrightConfigGlob = '**/playwright.config.{js,ts,cjs,cts,mjs,mts}';
@@ -100,6 +109,9 @@ export const createNodes: CreateNodes<PlaywrightPluginOptions> = [
     const pmc = getPackageManagerCommand(packageManager);
     const lockFileName = getLockFileName(packageManager);
     const normalizedOptions = normalizeOptions(options);
+    // The workspace-root dotenv candidates are the same for every config, so
+    // hash each file at most once per pass rather than once per config.
+    const dotEnvFileHashes = new Map<string, string | null>();
 
     try {
       const { entries, preErrors } = await filterPlaywrightConfigs(
@@ -126,7 +138,8 @@ export const createNodes: CreateNodes<PlaywrightPluginOptions> = [
               pluginCache,
               pmc,
               entries[idx].externalTsconfigInputs,
-              projectHashes[idx]
+              projectHashes[idx],
+              dotEnvFileHashes
             ),
           entries.map((e) => e.configFile),
           options,
@@ -161,37 +174,43 @@ async function createNodesInternal(
   pluginCache: PluginCache<PlaywrightTargets>,
   pmc: ReturnType<typeof getPackageManagerCommand>,
   externalTsconfigInputs: string[],
-  hash: string
+  hash: string,
+  dotEnvFileHashes: Map<string, string | null>
 ) {
   const projectRoot = dirname(configFilePath);
 
   // The createNodes hash covers projectRoot files, the lockfile, and tsconfig,
   // but a workspace-root dotenv a nested project loads is outside it. Fold the
   // consumer chains' dotenv fingerprints into the cache key so a dotenv change
-  // (which the daemon invalidates the graph on) rebuilds the inferred targets
-  // instead of returning stale ones.
+  // rebuilds the inferred targets instead of returning stale ones.
   const chainDotEnvPairs = getChainDotEnvPairs(
     context.workspaceRoot,
     projectRoot,
-    normalizedOptions
+    normalizedOptions,
+    dotEnvFileHashes
   );
   const cacheKey = `${hash}-${hashObject(chainDotEnvPairs)}`;
 
-  if (!pluginCache.has(cacheKey)) {
-    pluginCache.set(
-      cacheKey,
-      await buildPlaywrightTargets(
-        configFilePath,
-        projectRoot,
-        normalizedOptions,
-        context,
-        pmc,
-        externalTsconfigInputs,
-        chainDotEnvPairs
-      )
+  let playwrightTargets = pluginCache.get(cacheKey);
+  if (!playwrightTargets) {
+    const { taskEnvEvalFailed, ...built } = await buildPlaywrightTargets(
+      configFilePath,
+      projectRoot,
+      normalizedOptions,
+      context,
+      pmc,
+      externalTsconfigInputs,
+      chainDotEnvPairs
     );
+    // The key encodes nothing about evaluation success, so caching a failed
+    // evaluation's gate-less fallback would make a transient failure (a
+    // timeout, a fork error) permanent; leave it out so the next pass retries.
+    if (!taskEnvEvalFailed) {
+      pluginCache.set(cacheKey, built);
+    }
+    playwrightTargets = built;
   }
-  const { targets, metadata } = pluginCache.get(cacheKey);
+  const { targets, metadata } = playwrightTargets;
 
   return {
     projects: {
@@ -212,7 +231,7 @@ async function buildPlaywrightTargets(
   pmc: ReturnType<typeof getPackageManagerCommand>,
   externalTsconfigInputs: string[],
   chainDotEnvPairs: ChainDotEnvPairs
-): Promise<PlaywrightTargets> {
+): Promise<PlaywrightTargets & { taskEnvEvalFailed: boolean }> {
   // Playwright forbids importing the `@playwright/test` module twice. This would affect running the tests,
   // but we're just reading the config so let's delete the variable they are using to detect this.
   // See: https://github.com/microsoft/playwright/pull/11218/files
@@ -253,10 +272,10 @@ async function buildPlaywrightTargets(
   const chainsShareDotEnv =
     JSON.stringify(chainDotEnvPairs.target) ===
     JSON.stringify(chainDotEnvPairs.ciTarget);
-  let e2eChain: ChainWebserver;
-  let ciChain: ChainWebserver;
+  let e2eResolved: ResolvedChainWebserver;
+  let ciResolved: ResolvedChainWebserver;
   if (!options.ciTargetName || chainsShareDotEnv) {
-    e2eChain = await resolveChainWebserver(
+    e2eResolved = await resolveChainWebserver(
       configFilePath,
       projectRoot,
       context.workspaceRoot,
@@ -265,9 +284,9 @@ async function buildPlaywrightTargets(
       undefined,
       options.waitForWebServer
     );
-    ciChain = e2eChain;
+    ciResolved = e2eResolved;
   } else {
-    [e2eChain, ciChain] = await Promise.all([
+    [e2eResolved, ciResolved] = await Promise.all([
       resolveChainWebserver(
         configFilePath,
         projectRoot,
@@ -288,6 +307,10 @@ async function buildPlaywrightTargets(
       ),
     ]);
   }
+  const e2eChain = e2eResolved.chain;
+  const ciChain = ciResolved.chain;
+  const taskEnvEvalFailed =
+    e2eResolved.taskEnvEvalFailed || ciResolved.taskEnvEvalFailed;
 
   const e2eReadyTargetName =
     e2eChain.readinessServers.length > 0
@@ -496,7 +519,7 @@ async function buildPlaywrightTargets(
       },
     };
 
-    if (!ciChain.commandTasks.length) {
+    if (chainRequiresSerialization(ciChain)) {
       targets[options.ciTargetName].parallelism = false;
     }
     ciTargetGroup.push(options.ciTargetName);
@@ -532,7 +555,7 @@ async function buildPlaywrightTargets(
     ciTargetGroup.push(options.mergeReportsTargetName);
   }
 
-  return { targets, metadata };
+  return { targets, metadata, taskEnvEvalFailed };
 }
 
 async function getAllTestFiles(opts: {
@@ -672,11 +695,9 @@ interface ChainDotEnvPairs {
 function getChainDotEnvPairs(
   workspaceRoot: string,
   projectRoot: string,
-  options: NormalizedOptions
+  options: NormalizedOptions,
+  fileHashes: Map<string, string | null>
 ): ChainDotEnvPairs {
-  // The ci chain's candidate paths include the e2e chain's, so hash each file
-  // at most once per pass.
-  const fileHashes = new Map<string, string | null>();
   const target = getDotEnvPairsForTask(
     workspaceRoot,
     projectRoot,
@@ -735,7 +756,9 @@ function getDotEnvPairsForTask(
 // re-evaluation falls back to the ambient servers and skips the gate for the
 // chain: an unverified address must not become a gate the daemon then caches,
 // but a config bug or timeout should degrade to master's behavior, not kill
-// graph construction for most commands.
+// graph construction for most commands. The returned `taskEnvEvalFailed` flag
+// keeps that degraded result out of the plugin cache so a later pass retries
+// the evaluation.
 async function resolveChainWebserver(
   configFilePath: string,
   projectRoot: string,
@@ -744,9 +767,12 @@ async function resolveChainWebserver(
   target: string,
   nonAtomizedTarget: string | undefined,
   inferReadiness: boolean
-): Promise<ChainWebserver> {
+): Promise<ResolvedChainWebserver> {
   if (ambientWebServers.length === 0) {
-    return { commandTasks: [], readinessServers: [] };
+    return {
+      chain: { commandTasks: [], readinessServers: [], uncoveredServers: 0 },
+      taskEnvEvalFailed: false,
+    };
   }
   let webServers = ambientWebServers;
   let taskEnvEvalFailed = false;
@@ -766,20 +792,27 @@ async function resolveChainWebserver(
     } catch (e) {
       taskEnvEvalFailed = true;
       const detail = e instanceof Error ? e.message : String(e);
-      logger.warn(
+      emitPluginWorkerLog(
+        'warn',
         `@nx/playwright: could not evaluate ${configFilePath} under the ${target} task env to resolve the web server address. Targets are inferred from the ambient config evaluation and no web server readiness task is inferred for ${target}.\n${detail}`
       );
     }
   }
 
-  const commandTasks = getWebserverCommandTasks(webServers, configFilePath);
+  const { commandTasks, uncoveredServers } = getWebserverCommandTasks(
+    webServers,
+    configFilePath
+  );
   const readinessServers =
     inferReadiness && !taskEnvEvalFailed
       ? (commandTasks
           .map(toReadinessServer)
           .filter(Boolean) as WebserverReadinessServer[])
       : [];
-  return { commandTasks, readinessServers };
+  return {
+    chain: { commandTasks, readinessServers, uncoveredServers },
+    taskEnvEvalFailed,
+  };
 }
 
 // Two chains share a gate only when both the readiness servers and the serve
@@ -813,11 +846,17 @@ function buildWaitForWebserverTarget(
 // warning is about the config's content, not about any single run.
 const warnedUnparseableCommands = new Set<string>();
 
+// Test seam: the warn-once set outlives a spec file's cases.
+export function _clearWarnedUnparseableCommands(): void {
+  warnedUnparseableCommands.clear();
+}
+
 function getWebserverCommandTasks(
   webServers: ResolvedWebServer[],
   configFilePath: string
-): WebserverCommandTask[] {
-  const tasks: WebserverCommandTask[] = [];
+): { commandTasks: WebserverCommandTask[]; uncoveredServers: number } {
+  const commandTasks: WebserverCommandTask[] = [];
+  let uncoveredServers = 0;
 
   for (const server of webServers) {
     if (!server.reuseExistingServer) {
@@ -826,6 +865,7 @@ function getWebserverCommandTasks(
     // An unchecked config can omit `command` (Playwright's own type requires
     // it); nothing runs, so there is nothing to depend on or gate.
     if (typeof server.command !== 'string') {
+      uncoveredServers++;
       continue;
     }
     // Playwright races a `wait.stdout`/`wait.stderr` regex against the address
@@ -834,12 +874,13 @@ function getWebserverCommandTasks(
     // reused without them, or raced by a duplicate launch while it boots, so
     // such a server gets no inferred dependency and no gate.
     if (server.waitsForOutput) {
+      uncoveredServers++;
       continue;
     }
 
     const task = parseTaskFromCommand(server.command);
     if (task) {
-      tasks.push({
+      commandTasks.push({
         ...task,
         port: server.port,
         url: server.url,
@@ -847,17 +888,23 @@ function getWebserverCommandTasks(
         timeout: server.timeout,
       });
     } else {
-      const warnedKey = `${configFilePath}|${server.command}`;
-      if (!warnedUnparseableCommands.has(warnedKey)) {
-        warnedUnparseableCommands.add(warnedKey);
-        logger.warn(
-          `@nx/playwright: could not infer an Nx task from the webServer command "${server.command}" in ${configFilePath}, so no serve dependency or readiness wait is inferred for it.`
-        );
+      uncoveredServers++;
+      // A command that never invokes nx (`npm run start`, `vite`) was never
+      // meant to map to a task, so its skip warrants no warning.
+      if (/(^|\s)nx\s/.test(server.command)) {
+        const warnedKey = `${configFilePath}|${server.command}`;
+        if (!warnedUnparseableCommands.has(warnedKey)) {
+          warnedUnparseableCommands.add(warnedKey);
+          emitPluginWorkerLog(
+            'warn',
+            `@nx/playwright: could not infer an Nx task from the webServer command "${server.command}" in ${configFilePath}, so no serve dependency or readiness wait is inferred for it.`
+          );
+        }
       }
     }
   }
 
-  return tasks;
+  return { commandTasks, uncoveredServers };
 }
 
 // Playwright throws when `port` and `url` are both truthy, but a present
@@ -918,8 +965,10 @@ function parseTaskFromCommand(command: string): {
 
   const nxRunMatch = command.match(nxRunRegex);
   if (nxRunMatch) {
+    // Truthiness rather than `!== undefined`: a trailing colon (`app:serve:`)
+    // splits to an empty configuration, which behaves as none.
     const [project, target, configuration] = nxRunMatch[1].split(':');
-    return { project, target, hasConfiguration: configuration !== undefined };
+    return { project, target, hasConfiguration: !!configuration };
   }
 
   const infixMatch = command.match(infixRegex);
@@ -931,11 +980,18 @@ function parseTaskFromCommand(command: string): {
   return null;
 }
 
+// Whether tasks consuming the chain's servers must not run in parallel: with
+// no inferred serve task, or with any reused server no task covers, something
+// the graph cannot see starts a server, and concurrent consumers would race
+// it (each launching its own copy, or tearing it down under the others).
+function chainRequiresSerialization(chain: ChainWebserver): boolean {
+  return !chain.commandTasks.length || chain.uncoveredServers > 0;
+}
+
 // A chain with inferred serve tasks depends on them (and its gate, when one
-// was inferred); one without cannot know what starts the server, so the target
-// must not run in parallel with whatever does. Set together so a config that
-// inherits one state (the atomized CI base copies the e2e config) cannot end
-// up carrying both.
+// was inferred). Set together with parallelism so a config that inherits one
+// state (the atomized CI base copies the e2e config) cannot end up carrying
+// both.
 function applyChainDependsOn(
   targetConfig: TargetConfiguration,
   chain: ChainWebserver,
@@ -945,10 +1001,13 @@ function applyChainDependsOn(
     targetConfig.dependsOn = readyTargetName
       ? [...getDependsOn(chain.commandTasks), { target: readyTargetName }]
       : getDependsOn(chain.commandTasks);
-    delete targetConfig.parallelism;
   } else {
     delete targetConfig.dependsOn;
+  }
+  if (chainRequiresSerialization(chain)) {
     targetConfig.parallelism = false;
+  } else {
+    delete targetConfig.parallelism;
   }
 }
 

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -2,7 +2,8 @@ import {
   calculateHashesForCreateNodes,
   loadConfigFile,
   getNamedInputs,
-  getGraphTimeEnvForTask,
+  getGraphTimeDotEnvForTask,
+  hashFile,
   hashObject,
   workspaceDataDirectory,
   PluginCache,
@@ -28,6 +29,7 @@ import type { PlaywrightTestConfig } from '@playwright/test';
 import { minimatch } from 'minimatch';
 import { existsSync, readdirSync } from 'node:fs';
 import { dirname, join, parse, relative, resolve, sep } from 'node:path';
+import { getEnvPathsForTask } from 'nx/src/tasks-runner/task-env-paths';
 import type { Schema as WaitForWebserverSchema } from '../executors/wait-for-webserver/schema';
 import { getReporterOutputs, type ReporterOutput } from '../utils/reporters';
 import {
@@ -80,36 +82,6 @@ type WebserverReadinessServer = WaitForWebserverSchema['servers'][number];
 interface ChainWebserver {
   commandTasks: WebserverCommandTask[];
   readinessServers: WebserverReadinessServer[];
-}
-
-// getGraphTimeEnvForTask reads dotenv files from disk, and within one config's
-// createNodes the cache-key digest and each consumer chain resolve the same task
-// envs. Memoize by target coordinates in a cache scoped to that single config
-// eval, so a dotenv snapshot is never shared across concurrent createNodes
-// passes. Callers only read/spread the returned env.
-type GraphTimeEnvCache = Map<string, NodeJS.ProcessEnv>;
-
-function getCachedGraphTimeEnvForTask(
-  cache: GraphTimeEnvCache,
-  projectRoot: string,
-  target: string,
-  configuration?: string,
-  nonAtomizedTarget?: string
-): NodeJS.ProcessEnv {
-  const key = `${projectRoot}\0${target}\0${configuration ?? ''}\0${
-    nonAtomizedTarget ?? ''
-  }`;
-  let env = cache.get(key);
-  if (!env) {
-    env = getGraphTimeEnvForTask(
-      projectRoot,
-      target,
-      configuration,
-      nonAtomizedTarget
-    );
-    cache.set(key, env);
-  }
-  return env;
 }
 
 const playwrightConfigGlob = '**/playwright.config.{js,ts,cjs,cts,mjs,mts}';
@@ -190,19 +162,18 @@ async function createNodesInternal(
   hash: string
 ) {
   const projectRoot = dirname(configFilePath);
-  const graphTimeEnvCache: GraphTimeEnvCache = new Map();
 
   // The createNodes hash covers projectRoot files, the lockfile, and tsconfig,
   // but a workspace-root dotenv a nested project loads is outside it. Fold the
-  // task dotenv overlay into the cache key so a dotenv change (which the daemon
-  // invalidates the graph on) rebuilds the gate instead of returning a stale one.
-  // Only when a gate is inferred does a dotenv change affect the output.
-  const cacheKey = normalizedOptions.waitForWebServer
-    ? `${hash}-${dotEnvOverlayDigest(
-        projectRoot,
-        normalizedOptions,
-        graphTimeEnvCache
-      )}`
+  // consumer chains' dotenv fingerprints into the cache key so a dotenv change
+  // (which the daemon invalidates the graph on) rebuilds the gate instead of
+  // returning a stale one. Only when the readiness gate is enabled can a
+  // dotenv change affect the output.
+  const chainDotEnvPairs = normalizedOptions.waitForWebServer
+    ? getChainDotEnvPairs(context.workspaceRoot, projectRoot, normalizedOptions)
+    : undefined;
+  const cacheKey = chainDotEnvPairs
+    ? `${hash}-${hashObject(chainDotEnvPairs)}`
     : hash;
 
   if (!pluginCache.has(cacheKey)) {
@@ -215,7 +186,7 @@ async function createNodesInternal(
         context,
         pmc,
         externalTsconfigInputs,
-        graphTimeEnvCache
+        chainDotEnvPairs
       )
     );
   }
@@ -239,7 +210,7 @@ async function buildPlaywrightTargets(
   context: CreateNodesContext,
   pmc: ReturnType<typeof getPackageManagerCommand>,
   externalTsconfigInputs: string[],
-  graphTimeEnvCache: GraphTimeEnvCache
+  chainDotEnvPairs: ChainDotEnvPairs | undefined
 ): Promise<PlaywrightTargets> {
   // Playwright forbids importing the `@playwright/test` module twice. This would affect running the tests,
   // but we're just reading the config so let's delete the variable they are using to detect this.
@@ -274,29 +245,48 @@ async function buildPlaywrightTargets(
   // config without the e2e task's dotenv loaded. Resolve each consumer chain's
   // servers under that chain's task env so the gate probes the address the task
   // will actually serve. `e2e` and the atomized `e2e-ci` tasks can load
-  // different dotenv, so a distinct resolved address gets its own gate.
-  const e2eChain = await resolveChainWebserver(
-    configFilePath,
-    projectRoot,
-    context.workspaceRoot,
-    ambientWebServers,
-    options.targetName,
-    undefined,
-    graphTimeEnvCache,
-    options.waitForWebServer
-  );
-  const ciChain = options.ciTargetName
-    ? await resolveChainWebserver(
+  // different dotenv, so a distinct resolved address gets its own gate. When
+  // both chains load the same dotenv inputs they resolve to the same servers,
+  // so a single resolution is shared; distinct inputs resolve concurrently.
+  const chainsShareDotEnv =
+    !chainDotEnvPairs ||
+    JSON.stringify(chainDotEnvPairs.target) ===
+      JSON.stringify(chainDotEnvPairs.ciTarget);
+  let e2eChain: ChainWebserver;
+  let ciChain: ChainWebserver;
+  if (!options.ciTargetName || chainsShareDotEnv) {
+    e2eChain = await resolveChainWebserver(
+      configFilePath,
+      projectRoot,
+      context.workspaceRoot,
+      ambientWebServers,
+      options.targetName,
+      undefined,
+      options.waitForWebServer
+    );
+    ciChain = e2eChain;
+  } else {
+    [e2eChain, ciChain] = await Promise.all([
+      resolveChainWebserver(
+        configFilePath,
+        projectRoot,
+        context.workspaceRoot,
+        ambientWebServers,
+        options.targetName,
+        undefined,
+        options.waitForWebServer
+      ),
+      resolveChainWebserver(
         configFilePath,
         projectRoot,
         context.workspaceRoot,
         ambientWebServers,
         options.ciTargetName,
         options.targetName,
-        graphTimeEnvCache,
         options.waitForWebServer
-      )
-    : e2eChain;
+      ),
+    ]);
+  }
 
   const e2eReadyTargetName =
     e2eChain.readinessServers.length > 0
@@ -329,13 +319,7 @@ async function buildPlaywrightTargets(
     },
   };
 
-  if (e2eChain.commandTasks.length) {
-    baseTargetConfig.dependsOn = e2eReadyTargetName
-      ? [...getDependsOn(e2eChain.commandTasks), { target: e2eReadyTargetName }]
-      : getDependsOn(e2eChain.commandTasks);
-  } else {
-    baseTargetConfig.parallelism = false;
-  }
+  applyChainDependsOn(baseTargetConfig, e2eChain, e2eReadyTargetName);
 
   targets[options.targetName] = {
     ...baseTargetConfig,
@@ -395,20 +379,11 @@ async function buildPlaywrightTargets(
       ),
     };
 
-    // The atomized tasks inherit the e2e chain's dependsOn. When the CI chain
-    // resolves a different address it has its own gate, so point them at it.
+    // The atomized tasks inherit the e2e chain's dependsOn and parallelism.
+    // When the CI chain resolves differently it has its own gate (or none), so
+    // re-derive both from it.
     if (!chainsShareGate) {
-      if (ciChain.commandTasks.length) {
-        ciBaseTargetConfig.dependsOn = ciReadyTargetName
-          ? [
-              ...getDependsOn(ciChain.commandTasks),
-              { target: ciReadyTargetName },
-            ]
-          : getDependsOn(ciChain.commandTasks);
-      } else {
-        delete ciBaseTargetConfig.dependsOn;
-        ciBaseTargetConfig.parallelism = false;
-      }
+      applyChainDependsOn(ciBaseTargetConfig, ciChain, ciReadyTargetName);
     }
 
     const groupName = 'E2E (CI)';
@@ -681,50 +656,66 @@ function addSubfolderToOutput(output: string, subfolder: string): string {
   return joinPathFragments(output, subfolder);
 }
 
-// Digest of the task dotenv overlay (the keys that differ from the graph-time
-// ambient env) for the consumer chains, folded into the PluginCache key so a
-// dotenv change the createNodes hash does not cover still rebuilds the gate.
-function dotEnvOverlayDigest(
-  projectRoot: string,
-  options: NormalizedOptions,
-  graphTimeEnvCache: GraphTimeEnvCache
-): string {
-  return hashObject({
-    e2e: dotEnvOverlay(
-      getCachedGraphTimeEnvForTask(
-        graphTimeEnvCache,
-        projectRoot,
-        options.targetName
-      )
-    ),
-    'e2e-ci': dotEnvOverlay(
-      getCachedGraphTimeEnvForTask(
-        graphTimeEnvCache,
-        projectRoot,
-        options.ciTargetName,
-        undefined,
-        options.targetName
-      )
-    ),
-  });
+// The dotenv files a chain's task would load, as sorted (workspace-relative
+// path, content hash) pairs of the files that exist. Hashed into the
+// PluginCache key so a dotenv change the createNodes hash does not cover still
+// rebuilds the gate, and compared across the two chains so identical dotenv
+// inputs share one config resolution.
+type DotEnvPairs = Array<[path: string, hash: string]>;
+
+interface ChainDotEnvPairs {
+  target: DotEnvPairs;
+  ciTarget: DotEnvPairs;
 }
 
-function dotEnvOverlay(taskEnv: NodeJS.ProcessEnv): Record<string, string> {
-  const overlay: Record<string, string> = {};
-  for (const key of new Set([
-    ...Object.keys(process.env),
-    ...Object.keys(taskEnv),
-  ])) {
-    if (process.env[key] !== taskEnv[key]) {
-      overlay[key] = taskEnv[key];
+function getChainDotEnvPairs(
+  workspaceRoot: string,
+  projectRoot: string,
+  options: NormalizedOptions
+): ChainDotEnvPairs {
+  const target = getDotEnvPairsForTask(
+    workspaceRoot,
+    projectRoot,
+    options.targetName
+  );
+  const ciTarget = options.ciTargetName
+    ? getDotEnvPairsForTask(
+        workspaceRoot,
+        projectRoot,
+        options.ciTargetName,
+        options.targetName
+      )
+    : target;
+  return { target, ciTarget };
+}
+
+function getDotEnvPairsForTask(
+  workspaceRoot: string,
+  projectRoot: string,
+  target: string,
+  nonAtomizedTarget?: string
+): DotEnvPairs {
+  const pairs: DotEnvPairs = [];
+  for (const file of getEnvPathsForTask(
+    projectRoot,
+    target,
+    undefined,
+    nonAtomizedTarget
+  )) {
+    const fileHash = hashFile(join(workspaceRoot, file));
+    if (fileHash !== null) {
+      pairs.push([file, fileHash]);
     }
   }
-  return overlay;
+  return pairs.sort(([a], [b]) => (a < b ? -1 : a > b ? 1 : 0));
 }
 
 // Resolves the web server command tasks and readiness servers a consumer chain
-// (`e2e` or the atomized `e2e-ci`) would see. When `inferReadiness` is false the
-// gate is opted out: this skips the task-env resolution, keeps the ambient
+// (`e2e` or the atomized `e2e-ci`) would see. A config with no ambient
+// `webServer` yields nothing to depend on or gate, so the task-env resolution
+// is skipped entirely: a `webServer` entry whose existence (not address)
+// depends on task-scoped env is not detected. When `inferReadiness` is false
+// the gate is opted out: this skips the task-env resolution, keeps the ambient
 // command tasks, and returns no readiness servers. Otherwise, when the chain's
 // task env differs from the graph-time ambient env, the config is re-evaluated
 // in a child under that env so an env-derived address resolves the way the task
@@ -738,13 +729,14 @@ async function resolveChainWebserver(
   ambientWebServers: ResolvedWebServer[],
   target: string,
   nonAtomizedTarget: string | undefined,
-  graphTimeEnvCache: GraphTimeEnvCache,
   inferReadiness: boolean
 ): Promise<ChainWebserver> {
+  if (ambientWebServers.length === 0) {
+    return { commandTasks: [], readinessServers: [] };
+  }
   let webServers = ambientWebServers;
   if (inferReadiness) {
-    const taskEnv = getCachedGraphTimeEnvForTask(
-      graphTimeEnvCache,
+    const taskEnv = getGraphTimeDotEnvForTask(
       projectRoot,
       target,
       undefined,
@@ -769,9 +761,7 @@ async function resolveChainWebserver(
     }
   }
 
-  const commandTasks = getWebserverCommandTasks({
-    webServer: webServers,
-  });
+  const commandTasks = getWebserverCommandTasks(webServers);
   const readinessServers = inferReadiness
     ? (commandTasks
         .map(toReadinessServer)
@@ -807,20 +797,20 @@ function buildWaitForWebserverTarget(
 }
 
 function getWebserverCommandTasks(
-  playwrightConfig: PlaywrightTestConfig
+  webServers: ResolvedWebServer[]
 ): WebserverCommandTask[] {
-  if (!playwrightConfig.webServer) {
-    return [];
-  }
-
   const tasks: WebserverCommandTask[] = [];
 
-  const webServer = Array.isArray(playwrightConfig.webServer)
-    ? playwrightConfig.webServer
-    : [playwrightConfig.webServer];
-
-  for (const server of webServer) {
+  for (const server of webServers) {
     if (!server.reuseExistingServer) {
+      continue;
+    }
+    // Playwright races a `wait.stdout`/`wait.stderr` regex against the address
+    // probe and stores the match's named capture groups in the env, both tied
+    // to the process Playwright starts itself. A task-started server would be
+    // reused without them, or raced by a duplicate launch while it boots, so
+    // such a server gets no inferred dependency and no gate.
+    if (server.waitsForOutput) {
       continue;
     }
 
@@ -898,6 +888,27 @@ function parseTaskFromCommand(command: string): {
   }
 
   return null;
+}
+
+// A chain with inferred serve tasks depends on them (and its gate, when one
+// was inferred); one without cannot know what starts the server, so the target
+// must not run in parallel with whatever does. Set together so a config that
+// inherits one state (the atomized CI base copies the e2e config) cannot end
+// up carrying both.
+function applyChainDependsOn(
+  targetConfig: TargetConfiguration,
+  chain: ChainWebserver,
+  readyTargetName: string | undefined
+): void {
+  if (chain.commandTasks.length) {
+    targetConfig.dependsOn = readyTargetName
+      ? [...getDependsOn(chain.commandTasks), { target: readyTargetName }]
+      : getDependsOn(chain.commandTasks);
+    delete targetConfig.parallelism;
+  } else {
+    delete targetConfig.dependsOn;
+    targetConfig.parallelism = false;
+  }
 }
 
 function getDependsOn(

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -3,6 +3,7 @@ import {
   loadConfigFile,
   getNamedInputs,
   getGraphTimeDotEnvForTask,
+  getEnvPathsForTask,
   hashFile,
   hashObject,
   workspaceDataDirectory,
@@ -30,7 +31,6 @@ import type { PlaywrightTestConfig } from '@playwright/test';
 import { minimatch } from 'minimatch';
 import { existsSync, readdirSync } from 'node:fs';
 import { dirname, join, parse, relative, resolve, sep } from 'node:path';
-import { getEnvPathsForTask } from 'nx/src/tasks-runner/task-env-paths';
 import type { Schema as WaitForWebserverSchema } from '../executors/wait-for-webserver/schema';
 import { getReporterOutputs, type ReporterOutput } from '../utils/reporters';
 import {

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -47,6 +47,13 @@ export interface PlaywrightPluginOptions {
    * or 60000 when neither is set.
    */
   webServerTimeout?: number;
+  /**
+   * Whether to infer a task that waits for the web server to be ready before the
+   * Playwright test tasks run. When false, no readiness task is inferred and the
+   * tests fall back to Playwright's own `reuseExistingServer` probe. Defaults to
+   * true.
+   */
+  waitForWebServer?: boolean;
 }
 
 interface NormalizedOptions {
@@ -54,6 +61,7 @@ interface NormalizedOptions {
   ciTargetName: string;
   mergeReportsTargetName: string;
   webServerTimeout?: number;
+  waitForWebServer: boolean;
 }
 
 type PlaywrightTargets = Pick<ProjectConfiguration, 'targets' | 'metadata'>;
@@ -190,11 +198,14 @@ async function createNodesInternal(
   // but a workspace-root dotenv a nested project loads is outside it. Fold the
   // task dotenv overlay into the cache key so a dotenv change (which the daemon
   // invalidates the graph on) rebuilds the gate instead of returning a stale one.
-  const cacheKey = `${hash}-${dotEnvOverlayDigest(
-    projectRoot,
-    normalizedOptions,
-    graphTimeEnvCache
-  )}`;
+  // Only when a gate is inferred does a dotenv change affect the output.
+  const cacheKey = normalizedOptions.waitForWebServer
+    ? `${hash}-${dotEnvOverlayDigest(
+        projectRoot,
+        normalizedOptions,
+        graphTimeEnvCache
+      )}`
+    : hash;
 
   if (!pluginCache.has(cacheKey)) {
     pluginCache.set(
@@ -273,7 +284,8 @@ async function buildPlaywrightTargets(
     ambientWebServers,
     options.targetName,
     undefined,
-    graphTimeEnvCache
+    graphTimeEnvCache,
+    options.waitForWebServer
   );
   const ciChain = options.ciTargetName
     ? await resolveChainWebserver(
@@ -283,7 +295,8 @@ async function buildPlaywrightTargets(
         ambientWebServers,
         options.ciTargetName,
         options.targetName,
-        graphTimeEnvCache
+        graphTimeEnvCache,
+        options.waitForWebServer
       )
     : e2eChain;
 
@@ -589,6 +602,7 @@ function normalizeOptions(options: PlaywrightPluginOptions): NormalizedOptions {
     targetName: options?.targetName ?? 'e2e',
     ciTargetName,
     mergeReportsTargetName: `${ciTargetName}--merge-reports`,
+    waitForWebServer: options?.waitForWebServer ?? true,
   };
 }
 
@@ -711,12 +725,14 @@ function dotEnvOverlay(taskEnv: NodeJS.ProcessEnv): Record<string, string> {
 }
 
 // Resolves the web server command tasks and readiness servers a consumer chain
-// (`e2e` or the atomized `e2e-ci`) would see. When the chain's task env differs
-// from the graph-time ambient env, the config is re-evaluated in a child under
-// that env so an env-derived address resolves the way the task will; otherwise
-// the ambient config is reused. A failed re-evaluation throws: the daemon caches
-// the resulting graph, so a silent fallback would bake a wrong gate that no
-// retry corrects until the graph is invalidated.
+// (`e2e` or the atomized `e2e-ci`) would see. When `inferReadiness` is false the
+// gate is opted out: this skips the task-env resolution, keeps the ambient
+// command tasks, and returns no readiness servers. Otherwise, when the chain's
+// task env differs from the graph-time ambient env, the config is re-evaluated
+// in a child under that env so an env-derived address resolves the way the task
+// will; a matching env reuses the ambient config. A failed re-evaluation throws:
+// the daemon caches the resulting graph, so a silent fallback would bake a wrong
+// gate that no retry corrects until the graph is invalidated.
 async function resolveChainWebserver(
   configFilePath: string,
   projectRoot: string,
@@ -724,40 +740,49 @@ async function resolveChainWebserver(
   ambientWebServers: ResolvedWebServer[],
   target: string,
   nonAtomizedTarget: string | undefined,
-  graphTimeEnvCache: GraphTimeEnvCache
+  graphTimeEnvCache: GraphTimeEnvCache,
+  inferReadiness: boolean
 ): Promise<ChainWebserver> {
   let webServers = ambientWebServers;
-  const taskEnv = getCachedGraphTimeEnvForTask(
-    graphTimeEnvCache,
-    projectRoot,
-    target,
-    undefined,
-    nonAtomizedTarget
-  );
-  if (taskEnvDivergesFromAmbient(taskEnv)) {
-    try {
-      webServers = await resolveWebServersUnderEnv(
-        configFilePath,
-        workspaceRoot,
-        taskEnv
-      );
-    } catch (e) {
-      // Nx's createNodes error formatter renders `message`/`stack` but not
-      // `cause`, so fold the child's failure into the message to surface it.
-      const detail = e instanceof Error ? e.message : String(e);
-      throw new Error(
-        `@nx/playwright: could not evaluate ${configFilePath} under the ${target} task env to resolve the web server readiness address.\n${detail}`,
-        { cause: e }
-      );
+  // Only resolve under the task env when a gate will be inferred. The task env
+  // matters solely for the readiness address, so skipping it (and the readiness
+  // servers below) restores the pre-inference behavior when the gate is opted
+  // out.
+  if (inferReadiness) {
+    const taskEnv = getCachedGraphTimeEnvForTask(
+      graphTimeEnvCache,
+      projectRoot,
+      target,
+      undefined,
+      nonAtomizedTarget
+    );
+    if (taskEnvDivergesFromAmbient(taskEnv)) {
+      try {
+        webServers = await resolveWebServersUnderEnv(
+          configFilePath,
+          workspaceRoot,
+          taskEnv
+        );
+      } catch (e) {
+        // Nx's createNodes error formatter renders `message`/`stack` but not
+        // `cause`, so fold the child's failure into the message to surface it.
+        const detail = e instanceof Error ? e.message : String(e);
+        throw new Error(
+          `@nx/playwright: could not evaluate ${configFilePath} under the ${target} task env to resolve the web server readiness address.\n${detail}`,
+          { cause: e }
+        );
+      }
     }
   }
 
   const commandTasks = getWebserverCommandTasks({
     webServer: webServers as PlaywrightTestConfig['webServer'],
   });
-  const readinessServers = commandTasks
-    .map(toReadinessServer)
-    .filter(Boolean) as WebserverReadinessServer[];
+  const readinessServers = inferReadiness
+    ? (commandTasks
+        .map(toReadinessServer)
+        .filter(Boolean) as WebserverReadinessServer[])
+    : [];
   return { commandTasks, readinessServers };
 }
 

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -768,7 +768,7 @@ async function resolveChainWebserver(
         // `cause`, so fold the child's failure into the message to surface it.
         const detail = e instanceof Error ? e.message : String(e);
         throw new Error(
-          `@nx/playwright: could not evaluate ${configFilePath} under the ${target} task env to resolve the web server readiness address.\n${detail}`,
+          `@nx/playwright: could not evaluate ${configFilePath} under the ${target} task env to resolve the web server readiness address. Set "waitForWebServer": false in the @nx/playwright plugin options in nx.json to opt out of the readiness gate.\n${detail}`,
           { cause: e }
         );
       }

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -27,6 +27,7 @@ import type { PlaywrightTestConfig } from '@playwright/test';
 import { minimatch } from 'minimatch';
 import { existsSync, readdirSync } from 'node:fs';
 import { dirname, join, parse, relative, resolve, sep } from 'node:path';
+import type { Schema as WaitForWebserverSchema } from '../executors/wait-for-webserver/schema';
 import { getReporterOutputs, type ReporterOutput } from '../utils/reporters';
 
 export interface PlaywrightPluginOptions {
@@ -59,12 +60,7 @@ interface WebserverCommandTask {
   timeout?: number;
 }
 
-interface WebserverReadinessServer {
-  port?: number;
-  url?: string;
-  ignoreHTTPSErrors?: boolean;
-  timeout?: number;
-}
+type WebserverReadinessServer = WaitForWebserverSchema['servers'][number];
 
 const playwrightConfigGlob = '**/playwright.config.{js,ts,cjs,cts,mjs,mts}';
 export const createNodes: CreateNodes<PlaywrightPluginOptions> = [
@@ -614,16 +610,21 @@ function getWebserverCommandTasks(
 // Playwright picks a web server's readiness probe by presence rather than
 // truthiness: a defined `port` makes it check that port over TCP even when the
 // value is falsy and the address comes from `url`, and a web server it can
-// address neither way gets no probe at all. Gate only on what both read the
-// same way, so the gate cannot fail where Playwright would have found the
-// server.
+// address neither way gets no probe at all. An unchecked `playwright.config.js`
+// can also carry a `port` Playwright coerces but the readiness task can't
+// probe. Gate only on the shapes the task probes the same way; the rest is
+// left to Playwright.
 function toReadinessServer(
   task: WebserverCommandTask
 ): WebserverReadinessServer | undefined {
   let server: WebserverReadinessServer;
-  if (task.port) {
+  if (typeof task.port === 'number' && task.port) {
     server = { port: task.port };
-  } else if (task.url && task.port == null) {
+  } else if (
+    typeof task.url === 'string' &&
+    task.url &&
+    task.port === undefined
+  ) {
     server = { url: task.url };
   } else {
     return undefined;

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -18,6 +18,7 @@ import {
   detectPackageManager,
   getPackageManagerCommand,
   joinPathFragments,
+  logger,
   normalizePath,
   type ProjectConfiguration,
   type TargetConfiguration,
@@ -719,9 +720,11 @@ function getDotEnvPairsForTask(
 // command tasks, and returns no readiness servers. Otherwise, when the chain's
 // task env differs from the graph-time ambient env, the config is re-evaluated
 // in a child under that env so an env-derived address resolves the way the task
-// will; a matching env reuses the ambient config. A failed re-evaluation throws:
-// the daemon caches the resulting graph, so a silent fallback would bake a wrong
-// gate that no retry corrects until the graph is invalidated.
+// will; a matching env reuses the ambient config. A failed re-evaluation falls
+// back to the ambient servers and skips the gate for the chain: an unverified
+// address must not become a gate the daemon then caches, but a config bug or
+// timeout should degrade to master's behavior, not kill graph construction for
+// most commands.
 async function resolveChainWebserver(
   configFilePath: string,
   projectRoot: string,
@@ -735,6 +738,7 @@ async function resolveChainWebserver(
     return { commandTasks: [], readinessServers: [] };
   }
   let webServers = ambientWebServers;
+  let taskEnvEvalFailed = false;
   if (inferReadiness) {
     const taskEnv = getGraphTimeDotEnvForTask(
       projectRoot,
@@ -750,23 +754,22 @@ async function resolveChainWebserver(
           taskEnv
         );
       } catch (e) {
-        // Nx's createNodes error formatter renders `message`/`stack` but not
-        // `cause`, so fold the child's failure into the message to surface it.
+        taskEnvEvalFailed = true;
         const detail = e instanceof Error ? e.message : String(e);
-        throw new Error(
-          `@nx/playwright: could not evaluate ${configFilePath} under the ${target} task env to resolve the web server readiness address. Set "waitForWebServer": false in the @nx/playwright plugin options in nx.json to opt out of the readiness gate.\n${detail}`,
-          { cause: e }
+        logger.warn(
+          `@nx/playwright: could not evaluate ${configFilePath} under the ${target} task env to resolve the web server address. Targets are inferred from the ambient config evaluation and no web server readiness task is inferred for ${target}.\n${detail}`
         );
       }
     }
   }
 
   const commandTasks = getWebserverCommandTasks(webServers);
-  const readinessServers = inferReadiness
-    ? (commandTasks
-        .map(toReadinessServer)
-        .filter(Boolean) as WebserverReadinessServer[])
-    : [];
+  const readinessServers =
+    inferReadiness && !taskEnvEvalFailed
+      ? (commandTasks
+          .map(toReadinessServer)
+          .filter(Boolean) as WebserverReadinessServer[])
+      : [];
   return { commandTasks, readinessServers };
 }
 

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -36,6 +36,7 @@ import { dirname, join, parse, relative, resolve, sep } from 'node:path';
 import type { Schema as WaitForWebserverSchema } from '../executors/wait-for-webserver/schema';
 import { getReporterOutputs, type ReporterOutput } from '../utils/reporters';
 import {
+  getProbeEnvDivergence,
   normalizeWebServers,
   resolveWebServersUnderEnv,
   taskEnvDivergesFromAmbient,
@@ -273,20 +274,14 @@ async function buildPlaywrightTargets(
   const reporterOutputs = getReporterOutputs(playwrightConfig);
   const ambientWebServers = normalizeWebServers(playwrightConfig.webServer);
 
-  // When an inferred web server exposes a port/url, add a task that waits for
-  // it to be ready. Playwright's `reuseExistingServer` probe
-  // otherwise races the server boot, misses, and spawns its own nested server
-  // command whose I/O then leaks into the task. Both the `e2e` task and the
-  // atomized CI tasks depend on it.
+  // The readiness gate: Playwright's `reuseExistingServer` probe otherwise
+  // races the server boot, misses, and spawns its own nested server command
+  // whose I/O then leaks into the task.
   //
-  // The command and address can be read from process.env, but createNodes
-  // evaluates the config without the e2e task's dotenv loaded. Resolve each
-  // consumer chain's servers under that chain's task env so the dependencies
-  // and the gate match what the task will actually run and probe.
-  // `e2e` and the atomized `e2e-ci` tasks can load
-  // different dotenv, so a distinct resolved address gets its own gate. When
-  // both chains load the same dotenv inputs they resolve to the same servers,
-  // so a single resolution is shared; distinct inputs resolve concurrently.
+  // The command and address can read process.env, and createNodes runs without
+  // the task's dotenv loaded, so each consumer chain's servers resolve under
+  // that chain's task env. Chains loading the same dotenv inputs share one
+  // resolution; distinct inputs resolve concurrently and can gate separately.
   const chainsShareDotEnv =
     JSON.stringify(chainDotEnvPairs.target) ===
     JSON.stringify(chainDotEnvPairs.ciTarget);
@@ -819,12 +814,26 @@ async function resolveChainWebserver(
     webServers,
     configFilePath
   );
-  const readinessServers =
-    inferReadiness && !taskEnvEvalFailed
-      ? (commandTasks
-          .map(toReadinessServer)
-          .filter(Boolean) as WebserverReadinessServer[])
-      : [];
+  let readinessServers: WebserverReadinessServer[] = [];
+  if (inferReadiness && !taskEnvEvalFailed) {
+    readinessServers = commandTasks
+      .map(toReadinessServer)
+      .filter(Boolean) as WebserverReadinessServer[];
+    // The gate runs as its own target under its own dotenv, so a task-scoped
+    // change to the probe transport (a proxy exclusion, a CA bundle) never
+    // reaches it and the gate could fail where Playwright's own probe passes.
+    // The dependencies stay; readiness falls back to Playwright's probe.
+    const divergingProbeVars = getProbeEnvDivergence(readinessServers, taskEnv);
+    if (divergingProbeVars.length > 0) {
+      readinessServers = [];
+      emitPluginWorkerLog(
+        'warn',
+        `@nx/playwright: the ${target} task env changes how its web server would be probed (${divergingProbeVars.join(
+          ', '
+        )}), which the readiness task cannot reproduce. No web server readiness task is inferred for ${target}.`
+      );
+    }
+  }
   return {
     chain: { commandTasks, readinessServers, uncoveredServers },
     taskEnvEvalFailed,
@@ -893,6 +902,14 @@ function getWebserverCommandTasks(
     // reused without them, or raced by a duplicate launch while it boots, so
     // such a server gets no inferred dependency and no gate.
     if (server.waitsForOutput) {
+      uncoveredServers++;
+      continue;
+    }
+    // A `webServer.env` only reaches the process Playwright starts itself. A
+    // task-started server would run without it, listening at a different
+    // address or silently reused missing the env the tests rely on, so only
+    // Playwright can launch such a server: no inferred dependency and no gate.
+    if (server.hasEnv) {
       uncoveredServers++;
       continue;
     }

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -761,7 +761,7 @@ async function resolveChainWebserver(
     }
   }
 
-  const commandTasks = getWebserverCommandTasks(webServers);
+  const commandTasks = getWebserverCommandTasks(webServers, configFilePath);
   const readinessServers =
     inferReadiness && !taskEnvEvalFailed
       ? (commandTasks
@@ -797,13 +797,24 @@ function buildWaitForWebserverTarget(
   };
 }
 
+// One entry per (config, command) for the lifetime of the process: the two
+// chains and every graph recomputation re-derive the same tasks, and the
+// warning is about the config's content, not about any single run.
+const warnedUnparseableCommands = new Set<string>();
+
 function getWebserverCommandTasks(
-  webServers: ResolvedWebServer[]
+  webServers: ResolvedWebServer[],
+  configFilePath: string
 ): WebserverCommandTask[] {
   const tasks: WebserverCommandTask[] = [];
 
   for (const server of webServers) {
     if (!server.reuseExistingServer) {
+      continue;
+    }
+    // An unchecked config can omit `command` (Playwright's own type requires
+    // it); nothing runs, so there is nothing to depend on or gate.
+    if (typeof server.command !== 'string') {
       continue;
     }
     // Playwright races a `wait.stdout`/`wait.stderr` regex against the address
@@ -824,6 +835,14 @@ function getWebserverCommandTasks(
         ignoreHTTPSErrors: server.ignoreHTTPSErrors,
         timeout: server.timeout,
       });
+    } else {
+      const warnedKey = `${configFilePath}|${server.command}`;
+      if (!warnedUnparseableCommands.has(warnedKey)) {
+        warnedUnparseableCommands.add(warnedKey);
+        logger.warn(
+          `@nx/playwright: could not infer an Nx task from the webServer command "${server.command}" in ${configFilePath}, so no serve dependency or readiness wait is inferred for it.`
+        );
+      }
     }
   }
 

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -5,6 +5,7 @@ import {
   getNamedInputs,
   getGraphTimeDotEnvForTask,
   getEnvPathsForTask,
+  hashDaemonClientEnv,
   hashFile,
   hashObject,
   workspaceDataDirectory,
@@ -109,6 +110,10 @@ export const createNodes: CreateNodes<PlaywrightPluginOptions> = [
     const pmc = getPackageManagerCommand(packageManager);
     const lockFileName = getLockFileName(packageManager);
     const normalizedOptions = normalizeOptions(options);
+    // A config can read process.env, which no file hash covers (and which the
+    // daemon swaps per client). Key the cache on the daemon-allowed env set so
+    // an ambient change re-evaluates instead of serving stale targets.
+    const ambientEnvHash = hashDaemonClientEnv();
     // The workspace-root dotenv candidates are the same for every config, so
     // hash each file at most once per pass rather than once per config.
     const dotEnvFileHashes = new Map<string, string | null>();
@@ -121,7 +126,7 @@ export const createNodes: CreateNodes<PlaywrightPluginOptions> = [
 
       const projectHashes = await calculateHashesForCreateNodes(
         entries.map((e) => e.projectRoot),
-        { ...normalizedOptions, CI: process.env.CI },
+        { ...normalizedOptions, ambientEnvHash },
         context,
         entries.map((e) => [lockFileName, ...e.externalTsconfigInputs])
       );
@@ -160,7 +165,18 @@ export const createNodes: CreateNodes<PlaywrightPluginOptions> = [
       }
       return results;
     } finally {
-      pluginCache.writeToDisk();
+      // The daemon can apply another client's env mid-pass (worker message
+      // dispatch is unserialized), so entries built after the change would be
+      // keyed under the stale pass-start digest. Drop the write; the next
+      // pass recomputes under a coherent key.
+      if (hashDaemonClientEnv() === ambientEnvHash) {
+        pluginCache.writeToDisk();
+      } else if (process.env.NX_VERBOSE_LOGGING === 'true') {
+        emitPluginWorkerLog(
+          'log',
+          '@nx/playwright: the ambient environment changed while inferring targets; skipping the disk cache write for this pass.'
+        );
+      }
     }
   },
 ];

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -190,8 +190,6 @@ async function createNodesInternal(
   hash: string
 ) {
   const projectRoot = dirname(configFilePath);
-  // Scoped to this single config eval so the memoized task envs are never shared
-  // across concurrent createNodes passes.
   const graphTimeEnvCache: GraphTimeEnvCache = new Map();
 
   // The createNodes hash covers projectRoot files, the lockfile, and tsconfig,
@@ -744,10 +742,6 @@ async function resolveChainWebserver(
   inferReadiness: boolean
 ): Promise<ChainWebserver> {
   let webServers = ambientWebServers;
-  // Only resolve under the task env when a gate will be inferred. The task env
-  // matters solely for the readiness address, so skipping it (and the readiness
-  // servers below) restores the pre-inference behavior when the gate is opted
-  // out.
   if (inferReadiness) {
     const taskEnv = getCachedGraphTimeEnvForTask(
       graphTimeEnvCache,
@@ -776,7 +770,7 @@ async function resolveChainWebserver(
   }
 
   const commandTasks = getWebserverCommandTasks({
-    webServer: webServers as PlaywrightTestConfig['webServer'],
+    webServer: webServers,
   });
   const readinessServers = inferReadiness
     ? (commandTasks

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -34,6 +34,7 @@ import { minimatch } from 'minimatch';
 import { existsSync, readdirSync } from 'node:fs';
 import { dirname, join, parse, relative, resolve, sep } from 'node:path';
 import type { Schema as WaitForWebserverSchema } from '../executors/wait-for-webserver/schema';
+import { installedPlaywrightSkipsProxiedTls } from '../utils/proxied-tls-verification';
 import { getReporterOutputs, type ReporterOutput } from '../utils/reporters';
 import {
   getProbeEnvDivergence,
@@ -222,7 +223,14 @@ async function createNodesInternal(
     normalizedOptions,
     dotEnvFileHashes
   );
-  const cacheKey = `${hash}-${hashObject(chainDotEnvPairs)}`;
+  // The gate follows the installed Playwright's probe semantics. A linked
+  // install can cross the version floor without touching the lockfile, so the
+  // key carries the decision rather than trusting the hash to notice.
+  const legacyProxiedTls = installedPlaywrightSkipsProxiedTls([
+    join(context.workspaceRoot, projectRoot),
+    context.workspaceRoot,
+  ]);
+  const cacheKey = `${hash}-${hashObject({ chainDotEnvPairs, legacyProxiedTls })}`;
 
   let playwrightTargets = pluginCache.get(cacheKey);
   if (!playwrightTargets) {
@@ -233,7 +241,8 @@ async function createNodesInternal(
       context,
       pmc,
       externalTsconfigInputs,
-      chainDotEnvPairs
+      chainDotEnvPairs,
+      legacyProxiedTls
     );
     // The key encodes nothing about evaluation success, so caching a failed
     // evaluation's gate-less fallback would make a transient failure (a
@@ -263,7 +272,8 @@ async function buildPlaywrightTargets(
   context: CreateNodesContext,
   pmc: ReturnType<typeof getPackageManagerCommand>,
   externalTsconfigInputs: string[],
-  chainDotEnvPairs: ChainDotEnvPairs
+  chainDotEnvPairs: ChainDotEnvPairs,
+  legacyProxiedTls: boolean
 ): Promise<PlaywrightTargets & { taskEnvEvalFailed: boolean }> {
   // Playwright forbids importing the `@playwright/test` module twice. This would affect running the tests,
   // but we're just reading the config so let's delete the variable they are using to detect this.
@@ -283,6 +293,7 @@ async function buildPlaywrightTargets(
       testIgnore,
     },
     probeEnv: ambientProbeEnv,
+    ambientEnv,
   } = await loadConfigWithProbeEnv(
     join(context.workspaceRoot, configFilePath),
     (config: PlaywrightTestConfig) => ({
@@ -337,6 +348,8 @@ async function buildPlaywrightTargets(
       context.workspaceRoot,
       ambientWebServers,
       ambientProbeEnv,
+      ambientEnv,
+      legacyProxiedTls,
       options.targetName,
       undefined,
       e2eGateName,
@@ -351,6 +364,8 @@ async function buildPlaywrightTargets(
         context.workspaceRoot,
         ambientWebServers,
         ambientProbeEnv,
+        ambientEnv,
+        legacyProxiedTls,
         options.targetName,
         undefined,
         e2eGateName,
@@ -362,6 +377,8 @@ async function buildPlaywrightTargets(
         context.workspaceRoot,
         ambientWebServers,
         ambientProbeEnv,
+        ambientEnv,
+        legacyProxiedTls,
         options.ciTargetName,
         options.targetName,
         ciGateName,
@@ -844,6 +861,8 @@ async function resolveChainWebserver(
   workspaceRoot: string,
   ambientWebServers: ResolvedWebServer[],
   ambientProbeEnv: ProbeEnv,
+  ambientEnv: NodeJS.ProcessEnv,
+  legacyProxiedTls: boolean,
   target: string,
   nonAtomizedTarget: string | undefined,
   gateTarget: string,
@@ -858,13 +877,18 @@ async function resolveChainWebserver(
   let webServers = ambientWebServers;
   let probeEnv = ambientProbeEnv;
   let taskEnvEvalFailed = false;
+  // Base every env reconstruction on the locked ambient snapshot, never on the
+  // live process.env: another config's in-process load can be writing env
+  // concurrently, and a transient write read as ambient would mask the values
+  // this chain's dotenv files set.
   const taskEnv = getGraphTimeDotEnvForTask(
     projectRoot,
     target,
     undefined,
-    nonAtomizedTarget
+    nonAtomizedTarget,
+    ambientEnv
   );
-  if (taskEnvDivergesFromAmbient(taskEnv)) {
+  if (taskEnvDivergesFromAmbient(taskEnv, ambientEnv)) {
     try {
       ({ webServers, probeEnv } = await resolveWebServersUnderEnv(
         configFilePath,
@@ -900,7 +924,14 @@ async function resolveChainWebserver(
     const divergingProbeVars = getProbeEnvDivergence(
       readinessServers,
       { ...probeEnv, NODE_EXTRA_CA_CERTS: taskEnv.NODE_EXTRA_CA_CERTS },
-      getGraphTimeDotEnvForTask(projectRoot, gateTarget)
+      getGraphTimeDotEnvForTask(
+        projectRoot,
+        gateTarget,
+        undefined,
+        undefined,
+        ambientEnv
+      ),
+      legacyProxiedTls
     );
     if (divergingProbeVars.length > 0) {
       readinessServers = [];

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -1,7 +1,7 @@
 import {
   calculateHashesForCreateNodes,
+  clearRequireCache,
   emitPluginWorkerLog,
-  loadConfigFile,
   getNamedInputs,
   getDaemonClientEnvGeneration,
   getGraphTimeDotEnvForTask,
@@ -37,9 +37,11 @@ import type { Schema as WaitForWebserverSchema } from '../executors/wait-for-web
 import { getReporterOutputs, type ReporterOutput } from '../utils/reporters';
 import {
   getProbeEnvDivergence,
+  loadConfigWithProbeEnv,
   normalizeWebServers,
   resolveWebServersUnderEnv,
   taskEnvDivergesFromAmbient,
+  type ProbeEnv,
   type ResolvedWebServer,
 } from './webserver-readiness';
 
@@ -134,6 +136,19 @@ export const createNodes: CreateNodes<PlaywrightPluginOptions> = [
         entries.map((e) => [lockFileName, ...e.externalTsconfigInputs])
       );
 
+      // A TypeScript config is `require`d without clearing the module cache, so
+      // a process that already evaluated it (the daemon, with plugin isolation
+      // off) gets that evaluation back: an edited config would keep its old
+      // targets and the env writes it makes while loading would not run again.
+      // Once per pass, so every config loads fresh.
+      if (
+        entries.some(
+          (e) => require.cache[join(context.workspaceRoot, e.configFile)]
+        )
+      ) {
+        clearRequireCache();
+      }
+
       let results: CreateNodesResultArray = [];
       let nodeErrors: Array<[string | null, Error]> = [];
       try {
@@ -169,9 +184,8 @@ export const createNodes: CreateNodes<PlaywrightPluginOptions> = [
       return results;
     } finally {
       // The daemon can apply another client's env mid-pass (worker message
-      // dispatch is unserialized) and a config can mutate the env while
-      // evaluating; entries built after either change are keyed under the
-      // stale pass-start digest, so drop the write and let the next pass
+      // dispatch is unserialized); entries built after that are keyed under
+      // the stale pass-start digest, so drop the write and let the next pass
       // rebuild under a coherent key. The generation catches an env that
       // changed and changed back mid-pass, which the digest misses.
       if (
@@ -256,9 +270,10 @@ async function buildPlaywrightTargets(
   // See: https://github.com/microsoft/playwright/pull/11218/files
   delete (process as any)['__pw_initiator__'];
 
-  const playwrightConfig = await loadConfigFile<PlaywrightTestConfig>(
-    join(context.workspaceRoot, configFilePath)
-  );
+  const { config: playwrightConfig, probeEnv: ambientProbeEnv } =
+    await loadConfigWithProbeEnv<PlaywrightTestConfig>(
+      join(context.workspaceRoot, configFilePath)
+    );
 
   const namedInputs = getNamedInputs(projectRoot, context);
 
@@ -280,11 +295,18 @@ async function buildPlaywrightTargets(
   //
   // The command and address can read process.env, and createNodes runs without
   // the task's dotenv loaded, so each consumer chain's servers resolve under
-  // that chain's task env. Chains loading the same dotenv inputs share one
-  // resolution; distinct inputs resolve concurrently and can gate separately.
+  // that chain's task env. Chains whose tasks and gates load the same dotenv
+  // inputs share one resolution; distinct inputs resolve concurrently and can
+  // gate separately.
+  const gatesShareDotEnv =
+    JSON.stringify(chainDotEnvPairs.gate) ===
+    JSON.stringify(chainDotEnvPairs.ciGate);
   const chainsShareDotEnv =
+    gatesShareDotEnv &&
     JSON.stringify(chainDotEnvPairs.target) ===
-    JSON.stringify(chainDotEnvPairs.ciTarget);
+      JSON.stringify(chainDotEnvPairs.ciTarget);
+  const e2eGateName = `${options.targetName}--wait-for-webserver`;
+  const ciGateName = `${options.ciTargetName}--wait-for-webserver`;
   let e2eResolved: ResolvedChainWebserver;
   let ciResolved: ResolvedChainWebserver;
   if (!options.ciTargetName || chainsShareDotEnv) {
@@ -293,8 +315,10 @@ async function buildPlaywrightTargets(
       projectRoot,
       context.workspaceRoot,
       ambientWebServers,
+      ambientProbeEnv,
       options.targetName,
       undefined,
+      e2eGateName,
       options.waitForWebServer
     );
     ciResolved = e2eResolved;
@@ -305,8 +329,10 @@ async function buildPlaywrightTargets(
         projectRoot,
         context.workspaceRoot,
         ambientWebServers,
+        ambientProbeEnv,
         options.targetName,
         undefined,
+        e2eGateName,
         options.waitForWebServer
       ),
       resolveChainWebserver(
@@ -314,8 +340,10 @@ async function buildPlaywrightTargets(
         projectRoot,
         context.workspaceRoot,
         ambientWebServers,
+        ambientProbeEnv,
         options.ciTargetName,
         options.targetName,
+        ciGateName,
         options.waitForWebServer
       ),
     ]);
@@ -326,15 +354,15 @@ async function buildPlaywrightTargets(
     e2eResolved.taskEnvEvalFailed || ciResolved.taskEnvEvalFailed;
 
   const e2eReadyTargetName =
-    e2eChain.readinessServers.length > 0
-      ? `${options.targetName}--wait-for-webserver`
-      : undefined;
-  const chainsShareGate = sameChain(e2eChain, ciChain);
+    e2eChain.readinessServers.length > 0 ? e2eGateName : undefined;
+  // A shared gate runs under the e2e gate's dotenv, which the ci chain's probe
+  // env was only compared against when both gates load the same files.
+  const chainsShareGate = gatesShareDotEnv && sameChain(e2eChain, ciChain);
   const ciReadyTargetName =
     ciChain.readinessServers.length > 0
       ? chainsShareGate
         ? e2eReadyTargetName
-        : `${options.ciTargetName}--wait-for-webserver`
+        : ciGateName
       : undefined;
 
   const baseTargetConfig: TargetConfiguration = {
@@ -698,9 +726,13 @@ function addSubfolderToOutput(output: string, subfolder: string): string {
 // identical dotenv inputs share one config resolution.
 type DotEnvPairs = Array<[path: string, hash: string]>;
 
+// The dotenv files each consumer chain's task loads and the ones its readiness
+// gate target loads. The gate's decide the env its probe runs under.
 interface ChainDotEnvPairs {
   target: DotEnvPairs;
   ciTarget: DotEnvPairs;
+  gate: DotEnvPairs;
+  ciGate: DotEnvPairs;
 }
 
 function getChainDotEnvPairs(
@@ -709,23 +741,26 @@ function getChainDotEnvPairs(
   options: NormalizedOptions,
   fileHashes: Map<string, string | null>
 ): ChainDotEnvPairs {
-  const target = getDotEnvPairsForTask(
-    workspaceRoot,
-    projectRoot,
-    options.targetName,
-    undefined,
-    fileHashes
-  );
-  const ciTarget = options.ciTargetName
-    ? getDotEnvPairsForTask(
-        workspaceRoot,
-        projectRoot,
-        options.ciTargetName,
-        options.targetName,
-        fileHashes
-      )
-    : target;
-  return { target, ciTarget };
+  const pairsFor = (target: string, nonAtomizedTarget?: string) =>
+    getDotEnvPairsForTask(
+      workspaceRoot,
+      projectRoot,
+      target,
+      nonAtomizedTarget,
+      fileHashes
+    );
+  const target = pairsFor(options.targetName);
+  const gate = pairsFor(`${options.targetName}--wait-for-webserver`);
+  return {
+    target,
+    ciTarget: options.ciTargetName
+      ? pairsFor(options.ciTargetName, options.targetName)
+      : target,
+    gate,
+    ciGate: options.ciTargetName
+      ? pairsFor(`${options.ciTargetName}--wait-for-webserver`)
+      : gate,
+  };
 }
 
 function getDotEnvPairsForTask(
@@ -775,8 +810,10 @@ async function resolveChainWebserver(
   projectRoot: string,
   workspaceRoot: string,
   ambientWebServers: ResolvedWebServer[],
+  ambientProbeEnv: ProbeEnv,
   target: string,
   nonAtomizedTarget: string | undefined,
+  gateTarget: string,
   inferReadiness: boolean
 ): Promise<ResolvedChainWebserver> {
   if (ambientWebServers.length === 0) {
@@ -786,6 +823,7 @@ async function resolveChainWebserver(
     };
   }
   let webServers = ambientWebServers;
+  let probeEnv = ambientProbeEnv;
   let taskEnvEvalFailed = false;
   const taskEnv = getGraphTimeDotEnvForTask(
     projectRoot,
@@ -795,11 +833,11 @@ async function resolveChainWebserver(
   );
   if (taskEnvDivergesFromAmbient(taskEnv)) {
     try {
-      webServers = await resolveWebServersUnderEnv(
+      ({ webServers, probeEnv } = await resolveWebServersUnderEnv(
         configFilePath,
         workspaceRoot,
         taskEnv
-      );
+      ));
     } catch (e) {
       taskEnvEvalFailed = true;
       const detail = e instanceof Error ? e.message : String(e);
@@ -819,18 +857,25 @@ async function resolveChainWebserver(
     readinessServers = commandTasks
       .map(toReadinessServer)
       .filter(Boolean) as WebserverReadinessServer[];
-    // The gate runs as its own target under its own dotenv, so a task-scoped
-    // change to the probe transport (a proxy exclusion, a CA bundle) never
-    // reaches it and the gate could fail where Playwright's own probe passes.
-    // The dependencies stay; readiness falls back to Playwright's probe.
-    const divergingProbeVars = getProbeEnvDivergence(readinessServers, taskEnv);
+    // The gate runs as its own target under its own dotenv and never loads the
+    // config, so a change to the probe transport (a proxy exclusion, a CA
+    // bundle) the task's dotenv or its config makes never reaches it and the
+    // gate could fail where Playwright's own probe passes. The dependencies
+    // stay; readiness falls back to Playwright's probe. Node reads
+    // NODE_EXTRA_CA_CERTS once at startup, so the value the task starts with
+    // is the one its probe trusts, whatever the config writes.
+    const divergingProbeVars = getProbeEnvDivergence(
+      readinessServers,
+      { ...probeEnv, NODE_EXTRA_CA_CERTS: taskEnv.NODE_EXTRA_CA_CERTS },
+      getGraphTimeDotEnvForTask(projectRoot, gateTarget)
+    );
     if (divergingProbeVars.length > 0) {
       readinessServers = [];
       emitPluginWorkerLog(
         'warn',
-        `@nx/playwright: the ${target} task env changes how its web server would be probed (${divergingProbeVars.join(
+        `@nx/playwright: under the ${target} task, ${divergingProbeVars.join(
           ', '
-        )}), which the readiness task cannot reproduce. No web server readiness task is inferred for ${target}.`
+        )} changes how its web server would be probed, which the readiness task cannot reproduce. No web server readiness task is inferred for ${target}.`
       );
     }
   }

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -561,10 +561,9 @@ async function buildPlaywrightTargets(
     if (chainRequiresSerialization(ciChain)) {
       targets[options.ciTargetName].parallelism = false;
     }
+    // The gate stays out of the group: a group member runs under the atomized
+    // target's dotenv files, and the gate's env was checked against its own.
     ciTargetGroup.push(options.ciTargetName);
-    if (ciReadyTargetName) {
-      ciTargetGroup.push(ciReadyTargetName);
-    }
 
     // infer the task to merge the reports from the atomized tasks
     const mergeReportsTargetOutputs = new Set<string>();

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -270,10 +270,35 @@ async function buildPlaywrightTargets(
   // See: https://github.com/microsoft/playwright/pull/11218/files
   delete (process as any)['__pw_initiator__'];
 
-  const { config: playwrightConfig, probeEnv: ambientProbeEnv } =
-    await loadConfigWithProbeEnv<PlaywrightTestConfig>(
-      join(context.workspaceRoot, configFilePath)
-    );
+  // The reads happen inside the consume callback, before the load's env
+  // writes are restored: the config object can expose getters that read env
+  // it set while loading, so it must not escape the protected scope.
+  const {
+    consumed: {
+      testOutput,
+      reporterOutputs,
+      ambientWebServers,
+      testDir: configTestDir,
+      testMatch,
+      testIgnore,
+    },
+    probeEnv: ambientProbeEnv,
+  } = await loadConfigWithProbeEnv(
+    join(context.workspaceRoot, configFilePath),
+    (config: PlaywrightTestConfig) => ({
+      testOutput: getTestOutput(config),
+      reporterOutputs: getReporterOutputs(config),
+      ambientWebServers: normalizeWebServers(config.webServer),
+      testDir: config.testDir,
+      // Playwright defaults to the following pattern.
+      testMatch: materializeTestPattern(
+        config.testMatch ?? '**/*.@(spec|test).?(c|m)[jt]s?(x)'
+      ),
+      testIgnore: config.testIgnore
+        ? materializeTestPattern(config.testIgnore)
+        : undefined,
+    })
+  );
 
   const namedInputs = getNamedInputs(projectRoot, context);
 
@@ -284,10 +309,6 @@ async function buildPlaywrightTargets(
 
   const targets: ProjectConfiguration['targets'] = {};
   let metadata: ProjectConfiguration['metadata'];
-
-  const testOutput = getTestOutput(playwrightConfig);
-  const reporterOutputs = getReporterOutputs(playwrightConfig);
-  const ambientWebServers = normalizeWebServers(playwrightConfig.webServer);
 
   // The readiness gate: Playwright's `reuseExistingServer` probe otherwise
   // races the server boot, misses, and spawns its own nested server command
@@ -453,19 +474,17 @@ async function buildPlaywrightTargets(
     metadata = { targetGroups: { [groupName]: [] } };
     const ciTargetGroup = metadata.targetGroups[groupName];
 
-    const testDir = playwrightConfig.testDir
-      ? joinPathFragments(projectRoot, playwrightConfig.testDir)
+    const testDir = configTestDir
+      ? joinPathFragments(projectRoot, configTestDir)
       : projectRoot;
-
-    // Playwright defaults to the following pattern.
-    playwrightConfig.testMatch ??= '**/*.@(spec|test).?(c|m)[jt]s?(x)';
 
     const dependsOn: TargetDependencyConfig[] = [];
 
     const testFiles = await getAllTestFiles({
       context,
       path: testDir,
-      config: playwrightConfig,
+      testMatch,
+      testIgnore,
     });
 
     for (const testFile of testFiles) {
@@ -485,7 +504,9 @@ async function buildPlaywrightTargets(
                 testFile,
                 testFiles,
                 context,
-                config: playwrightConfig,
+                testDir,
+                testMatch,
+                testIgnore,
               },
               null,
               2
@@ -599,17 +620,30 @@ async function buildPlaywrightTargets(
 async function getAllTestFiles(opts: {
   context: CreateNodesContext;
   path: string;
-  config: PlaywrightTestConfig;
+  testMatch: PlaywrightTestConfig['testMatch'];
+  testIgnore: PlaywrightTestConfig['testIgnore'];
 }) {
   const files = await getFilesInDirectoryUsingContext(
     opts.context.workspaceRoot,
     opts.path
   );
-  const matcher = createMatcher(opts.config.testMatch);
-  const ignoredMatcher = opts.config.testIgnore
-    ? createMatcher(opts.config.testIgnore)
+  const matcher = createMatcher(opts.testMatch);
+  const ignoredMatcher = opts.testIgnore
+    ? createMatcher(opts.testIgnore)
     : () => false;
   return files.filter((file) => matcher(file) && !ignoredMatcher(file));
+}
+
+// Copies a test file pattern off a just-loaded config: an array element or a
+// property can be a getter reading env the load wrote, so every read has to
+// happen before that env is restored, and a cloned RegExp leaves no
+// config-owned object behind.
+function materializeTestPattern(
+  pattern: string | RegExp | Array<string | RegExp>
+): string | RegExp | Array<string | RegExp> {
+  const clone = (p: string | RegExp) =>
+    typeof p === 'string' ? p : new RegExp(p.source, p.flags);
+  return Array.isArray(pattern) ? Array.from(pattern, clone) : clone(pattern);
 }
 
 function createMatcher(pattern: string | RegExp | Array<string | RegExp>) {

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -34,6 +34,8 @@ import { minimatch } from 'minimatch';
 import { existsSync, readdirSync } from 'node:fs';
 import { dirname, join, parse, relative, resolve, sep } from 'node:path';
 import type { Schema as WaitForWebserverSchema } from '../executors/wait-for-webserver/schema';
+import { installedPlaywrightVersion } from '../utils/installed-playwright';
+import { installedPlaywrightReadsNpmConfigProxy } from '../utils/npm-config-proxy';
 import { installedPlaywrightSkipsProxiedTls } from '../utils/proxied-tls-verification';
 import { getReporterOutputs, type ReporterOutput } from '../utils/reporters';
 import {
@@ -226,11 +228,17 @@ async function createNodesInternal(
   // The gate follows the installed Playwright's probe semantics. A linked
   // install can cross the version floor without touching the lockfile, so the
   // key carries the decision rather than trusting the hash to notice.
-  const legacyProxiedTls = installedPlaywrightSkipsProxiedTls([
+  const playwright = installedPlaywrightVersion([
     join(context.workspaceRoot, projectRoot),
     context.workspaceRoot,
   ]);
-  const cacheKey = `${hash}-${hashObject({ chainDotEnvPairs, legacyProxiedTls })}`;
+  const legacyProxiedTls = installedPlaywrightSkipsProxiedTls(playwright);
+  const npmConfigProxy = installedPlaywrightReadsNpmConfigProxy(playwright);
+  const cacheKey = `${hash}-${hashObject({
+    chainDotEnvPairs,
+    legacyProxiedTls,
+    npmConfigProxy,
+  })}`;
 
   let playwrightTargets = pluginCache.get(cacheKey);
   if (!playwrightTargets) {
@@ -242,7 +250,8 @@ async function createNodesInternal(
       pmc,
       externalTsconfigInputs,
       chainDotEnvPairs,
-      legacyProxiedTls
+      legacyProxiedTls,
+      npmConfigProxy
     );
     // The key encodes nothing about evaluation success, so caching a failed
     // evaluation's gate-less fallback would make a transient failure (a
@@ -273,7 +282,8 @@ async function buildPlaywrightTargets(
   pmc: ReturnType<typeof getPackageManagerCommand>,
   externalTsconfigInputs: string[],
   chainDotEnvPairs: ChainDotEnvPairs,
-  legacyProxiedTls: boolean
+  legacyProxiedTls: boolean,
+  npmConfigProxy: boolean
 ): Promise<PlaywrightTargets & { taskEnvEvalFailed: boolean }> {
   // Playwright forbids importing the `@playwright/test` module twice. This would affect running the tests,
   // but we're just reading the config so let's delete the variable they are using to detect this.
@@ -350,6 +360,7 @@ async function buildPlaywrightTargets(
       ambientProbeEnv,
       ambientEnv,
       legacyProxiedTls,
+      npmConfigProxy,
       options.targetName,
       undefined,
       e2eGateName,
@@ -366,6 +377,7 @@ async function buildPlaywrightTargets(
         ambientProbeEnv,
         ambientEnv,
         legacyProxiedTls,
+        npmConfigProxy,
         options.targetName,
         undefined,
         e2eGateName,
@@ -379,6 +391,7 @@ async function buildPlaywrightTargets(
         ambientProbeEnv,
         ambientEnv,
         legacyProxiedTls,
+        npmConfigProxy,
         options.ciTargetName,
         options.targetName,
         ciGateName,
@@ -863,6 +876,7 @@ async function resolveChainWebserver(
   ambientProbeEnv: ProbeEnv,
   ambientEnv: NodeJS.ProcessEnv,
   legacyProxiedTls: boolean,
+  npmConfigProxy: boolean,
   target: string,
   nonAtomizedTarget: string | undefined,
   gateTarget: string,
@@ -931,7 +945,8 @@ async function resolveChainWebserver(
         undefined,
         ambientEnv
       ),
-      legacyProxiedTls
+      legacyProxiedTls,
+      npmConfigProxy
     );
     if (divergingProbeVars.length > 0) {
       readinessServers = [];

--- a/packages/playwright/src/plugins/webserver-config-worker.spec.ts
+++ b/packages/playwright/src/plugins/webserver-config-worker.spec.ts
@@ -1,0 +1,113 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { evaluateAndSendWebserverConfig } from './webserver-config-worker';
+
+describe('webserver-config-worker', () => {
+  let dir: string;
+  const originalArgv = process.argv;
+  const originalSend = process.send;
+  const originalUrl = process.env.NX_PW_WORKER_TEST_URL;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'pw-config-worker-'));
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv;
+    process.send = originalSend;
+    if (originalUrl === undefined) {
+      delete process.env.NX_PW_WORKER_TEST_URL;
+    } else {
+      process.env.NX_PW_WORKER_TEST_URL = originalUrl;
+    }
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function workerArgs(): void {
+    process.argv = ['node', 'worker.js', 'playwright.config.js', dir];
+  }
+
+  it('evaluates the config from argv under the spawned env and sends the normalized webServers', async () => {
+    writeFileSync(
+      join(dir, 'playwright.config.js'),
+      `module.exports = {
+  webServer: {
+    command: 'npx nx run app1:serve',
+    url: process.env.NX_PW_WORKER_TEST_URL || 'http://localhost:4200',
+    reuseExistingServer: true,
+    cwd: '/tmp/app',
+    wait: { stdout: /ready/ },
+  },
+};`
+    );
+    const sent: unknown[] = [];
+    process.send = ((
+      message: unknown,
+      callback: (error: Error | null) => void
+    ) => {
+      sent.push(message);
+      callback(null);
+      return true;
+    }) as typeof process.send;
+    workerArgs();
+    process.env.NX_PW_WORKER_TEST_URL = 'http://localhost:4305';
+
+    await evaluateAndSendWebserverConfig();
+
+    expect(sent).toEqual([
+      {
+        type: 'webserver-config-result',
+        webServers: [
+          {
+            command: 'npx nx run app1:serve',
+            url: 'http://localhost:4305',
+            reuseExistingServer: true,
+            waitsForOutput: true,
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('rejects when the channel reports a delivery failure', async () => {
+    writeFileSync(join(dir, 'playwright.config.js'), 'module.exports = {};');
+    process.send = ((
+      _message: unknown,
+      callback: (error: Error | null) => void
+    ) => {
+      callback(new Error('EPIPE'));
+      return true;
+    }) as typeof process.send;
+    workerArgs();
+
+    await expect(evaluateAndSendWebserverConfig()).rejects.toThrow('EPIPE');
+  });
+
+  it('rejects when the config cannot be loaded', async () => {
+    writeFileSync(
+      join(dir, 'playwright.config.js'),
+      'throw new Error("config boom");'
+    );
+    process.send = ((
+      _message: unknown,
+      callback: (error: Error | null) => void
+    ) => {
+      callback(null);
+      return true;
+    }) as typeof process.send;
+    workerArgs();
+
+    await expect(evaluateAndSendWebserverConfig()).rejects.toThrow(
+      /config boom/
+    );
+  });
+
+  it('resolves without an IPC channel', async () => {
+    writeFileSync(join(dir, 'playwright.config.js'), 'module.exports = {};');
+    process.send = undefined;
+    workerArgs();
+
+    await expect(evaluateAndSendWebserverConfig()).resolves.toBeUndefined();
+  });
+});

--- a/packages/playwright/src/plugins/webserver-config-worker.spec.ts
+++ b/packages/playwright/src/plugins/webserver-config-worker.spec.ts
@@ -8,6 +8,7 @@ describe('webserver-config-worker', () => {
   const originalArgv = process.argv;
   const originalSend = process.send;
   const originalUrl = process.env.NX_PW_WORKER_TEST_URL;
+  const originalNoProxy = process.env.NO_PROXY;
 
   beforeEach(() => {
     dir = mkdtempSync(join(tmpdir(), 'pw-config-worker-'));
@@ -21,6 +22,11 @@ describe('webserver-config-worker', () => {
     } else {
       process.env.NX_PW_WORKER_TEST_URL = originalUrl;
     }
+    if (originalNoProxy === undefined) {
+      delete process.env.NO_PROXY;
+    } else {
+      process.env.NO_PROXY = originalNoProxy;
+    }
     rmSync(dir, { recursive: true, force: true });
   });
 
@@ -28,10 +34,12 @@ describe('webserver-config-worker', () => {
     process.argv = ['node', 'worker.js', 'playwright.config.js', dir];
   }
 
-  it('evaluates the config from argv under the spawned env and sends the normalized webServers', async () => {
+  it('evaluates the config from argv under the spawned env and sends the normalized webServers with the probe env the config left', async () => {
+    delete process.env.NO_PROXY;
     writeFileSync(
       join(dir, 'playwright.config.js'),
-      `module.exports = {
+      `process.env.NO_PROXY = 'localhost';
+module.exports = {
   webServer: {
     command: 'npx nx run app1:serve',
     url: process.env.NX_PW_WORKER_TEST_URL || 'http://localhost:4200',
@@ -66,6 +74,7 @@ describe('webserver-config-worker', () => {
             waitsForOutput: true,
           },
         ],
+        probeEnv: expect.objectContaining({ NO_PROXY: 'localhost' }),
       },
     ]);
   });

--- a/packages/playwright/src/plugins/webserver-config-worker.ts
+++ b/packages/playwright/src/plugins/webserver-config-worker.ts
@@ -1,0 +1,30 @@
+import { loadConfigFile } from '@nx/devkit/internal';
+import type { PlaywrightTestConfig } from '@playwright/test';
+import { join } from 'node:path';
+import { normalizeWebServers } from './webserver-readiness';
+
+/**
+ * Forked child that evaluates a Playwright config under the env it was spawned
+ * with (see resolveWebServersUnderEnv) and returns the resolved `webServer`
+ * addresses. A child is used rather than an in-process re-evaluation because
+ * createNodes evaluates configs concurrently: a shared `process.env` swap would
+ * race across them, and the module cache would hand back the first evaluation.
+ *
+ * argv: [configFilePath (workspace-relative), workspaceRoot]. The result is
+ * sent over the IPC channel as ResolvedWebServer[].
+ */
+async function main(): Promise<void> {
+  const [configFilePath, workspaceRoot] = process.argv.slice(2);
+  const config = await loadConfigFile<PlaywrightTestConfig>(
+    join(workspaceRoot, configFilePath)
+  );
+  process.send?.(normalizeWebServers(config.webServer));
+}
+
+main().then(
+  () => process.exit(0),
+  (error) => {
+    process.send?.({ error: error?.stack ?? String(error) });
+    process.exit(1);
+  }
+);

--- a/packages/playwright/src/plugins/webserver-config-worker.ts
+++ b/packages/playwright/src/plugins/webserver-config-worker.ts
@@ -17,7 +17,7 @@ import {
  * sent over the IPC channel as a tagged `webserver-config-result` message, or
  * `webserver-config-error` on failure.
  */
-async function main(): Promise<void> {
+export async function evaluateAndSendWebserverConfig(): Promise<void> {
   const [configFilePath, workspaceRoot] = process.argv.slice(2);
   const config = await loadConfigFile<PlaywrightTestConfig>(
     join(workspaceRoot, configFilePath)
@@ -41,19 +41,23 @@ function send(message: WebserverConfigWorkerMessage): Promise<void> {
   });
 }
 
-main().then(
-  () => process.exit(0),
-  async (error) => {
-    // A non-empty message so the failure the parent surfaces stays diagnosable.
-    const detail =
-      (error && (error.stack || error.message)) ||
-      String(error) ||
-      'Unknown error while evaluating the Playwright config.';
-    try {
-      await send({ type: 'webserver-config-error', error: detail });
-    } catch {
-      // The channel is gone; the nonzero exit below still signals the failure.
+// Only the forked entrypoint runs the evaluation; importing the module (as the
+// tests do) must not.
+if (require.main === module) {
+  evaluateAndSendWebserverConfig().then(
+    () => process.exit(0),
+    async (error) => {
+      // A non-empty message so the failure the parent surfaces stays diagnosable.
+      const detail =
+        (error && (error.stack || error.message)) ||
+        String(error) ||
+        'Unknown error while evaluating the Playwright config.';
+      try {
+        await send({ type: 'webserver-config-error', error: detail });
+      } catch {
+        // The channel is gone; the nonzero exit below still signals the failure.
+      }
+      process.exit(1);
     }
-    process.exit(1);
-  }
-);
+  );
+}

--- a/packages/playwright/src/plugins/webserver-config-worker.ts
+++ b/packages/playwright/src/plugins/webserver-config-worker.ts
@@ -1,7 +1,10 @@
 import { loadConfigFile } from '@nx/devkit/internal';
 import type { PlaywrightTestConfig } from '@playwright/test';
 import { join } from 'node:path';
-import { normalizeWebServers } from './webserver-readiness';
+import {
+  normalizeWebServers,
+  type ResolvedWebServer,
+} from './webserver-readiness';
 
 /**
  * Forked child that evaluates a Playwright config under the env it was spawned
@@ -11,20 +14,42 @@ import { normalizeWebServers } from './webserver-readiness';
  * race across them, and the module cache would hand back the first evaluation.
  *
  * argv: [configFilePath (workspace-relative), workspaceRoot]. The result is
- * sent over the IPC channel as ResolvedWebServer[].
+ * sent over the IPC channel as ResolvedWebServer[], or `{ error }` on failure.
  */
 async function main(): Promise<void> {
   const [configFilePath, workspaceRoot] = process.argv.slice(2);
   const config = await loadConfigFile<PlaywrightTestConfig>(
     join(workspaceRoot, configFilePath)
   );
-  process.send?.(normalizeWebServers(config.webServer));
+  await send(normalizeWebServers(config.webServer));
+}
+
+// process.exit can truncate an IPC message that has not been flushed to the
+// parent, so wait for the send to be acknowledged before exiting. A delivery
+// failure rejects so the caller exits nonzero rather than reporting success.
+function send(message: ResolvedWebServer[] | { error: string }): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (!process.send) {
+      resolve();
+      return;
+    }
+    process.send(message, (error) => (error ? reject(error) : resolve()));
+  });
 }
 
 main().then(
   () => process.exit(0),
-  (error) => {
-    process.send?.({ error: error?.stack ?? String(error) });
+  async (error) => {
+    // A non-empty message so the failure the parent surfaces stays diagnosable.
+    const detail =
+      (error && (error.stack || error.message)) ||
+      String(error) ||
+      'Unknown error while evaluating the Playwright config.';
+    try {
+      await send({ error: detail });
+    } catch {
+      // The channel is gone; the nonzero exit below still signals the failure.
+    }
     process.exit(1);
   }
 );

--- a/packages/playwright/src/plugins/webserver-config-worker.ts
+++ b/packages/playwright/src/plugins/webserver-config-worker.ts
@@ -3,7 +3,7 @@ import type { PlaywrightTestConfig } from '@playwright/test';
 import { join } from 'node:path';
 import {
   normalizeWebServers,
-  type ResolvedWebServer,
+  type WebserverConfigWorkerMessage,
 } from './webserver-readiness';
 
 /**
@@ -14,20 +14,24 @@ import {
  * race across them, and the module cache would hand back the first evaluation.
  *
  * argv: [configFilePath (workspace-relative), workspaceRoot]. The result is
- * sent over the IPC channel as ResolvedWebServer[], or `{ error }` on failure.
+ * sent over the IPC channel as a tagged `webserver-config-result` message, or
+ * `webserver-config-error` on failure.
  */
 async function main(): Promise<void> {
   const [configFilePath, workspaceRoot] = process.argv.slice(2);
   const config = await loadConfigFile<PlaywrightTestConfig>(
     join(workspaceRoot, configFilePath)
   );
-  await send(normalizeWebServers(config.webServer));
+  await send({
+    type: 'webserver-config-result',
+    webServers: normalizeWebServers(config.webServer),
+  });
 }
 
 // process.exit can truncate an IPC message that has not been flushed to the
 // parent, so wait for the send to be acknowledged before exiting. A delivery
 // failure rejects so the caller exits nonzero rather than reporting success.
-function send(message: ResolvedWebServer[] | { error: string }): Promise<void> {
+function send(message: WebserverConfigWorkerMessage): Promise<void> {
   return new Promise((resolve, reject) => {
     if (!process.send) {
       resolve();
@@ -46,7 +50,7 @@ main().then(
       String(error) ||
       'Unknown error while evaluating the Playwright config.';
     try {
-      await send({ error: detail });
+      await send({ type: 'webserver-config-error', error: detail });
     } catch {
       // The channel is gone; the nonzero exit below still signals the failure.
     }

--- a/packages/playwright/src/plugins/webserver-config-worker.ts
+++ b/packages/playwright/src/plugins/webserver-config-worker.ts
@@ -3,15 +3,17 @@ import type { PlaywrightTestConfig } from '@playwright/test';
 import { join } from 'node:path';
 import {
   normalizeWebServers,
+  pickProbeEnv,
   type WebserverConfigWorkerMessage,
 } from './webserver-readiness';
 
 /**
  * Forked child that evaluates a Playwright config under the env it was spawned
  * with (see resolveWebServersUnderEnv) and returns the resolved `webServer`
- * addresses. A child is used rather than an in-process re-evaluation because
- * createNodes evaluates configs concurrently: a shared `process.env` swap would
- * race across them, and the module cache would hand back the first evaluation.
+ * addresses along with the probe env the config left behind. A child is used
+ * rather than an in-process re-evaluation because createNodes evaluates configs
+ * concurrently: a shared `process.env` swap would race across them, and the
+ * module cache would hand back the first evaluation.
  *
  * argv: [configFilePath (workspace-relative), workspaceRoot]. The result is
  * sent over the IPC channel as a tagged `webserver-config-result` message, or
@@ -25,6 +27,7 @@ export async function evaluateAndSendWebserverConfig(): Promise<void> {
   await send({
     type: 'webserver-config-result',
     webServers: normalizeWebServers(config.webServer),
+    probeEnv: pickProbeEnv(process.env),
   });
 }
 

--- a/packages/playwright/src/plugins/webserver-readiness.spec.ts
+++ b/packages/playwright/src/plugins/webserver-readiness.spec.ts
@@ -32,6 +32,34 @@ describe('normalizeWebServers', () => {
     expect(normalizeWebServers(server)).toEqual([server]);
     expect(normalizeWebServers([server])).toEqual([server]);
   });
+
+  it('projects `wait` to a boolean and drops run-only fields like cwd and env', () => {
+    expect(
+      normalizeWebServers({
+        command: 'nx serve app',
+        url: 'http://localhost:4300',
+        reuseExistingServer: true,
+        cwd: '/tmp/app',
+        env: { FOO: 'bar' },
+        wait: { stdout: /ready/ },
+      })
+    ).toEqual([
+      {
+        command: 'nx serve app',
+        url: 'http://localhost:4300',
+        reuseExistingServer: true,
+        waitsForOutput: true,
+      },
+    ]);
+  });
+
+  it('sets waitsForOutput for either stdio regex and not for an empty wait', () => {
+    const normalized = (wait: object) =>
+      normalizeWebServers({ command: 'x', wait })[0].waitsForOutput;
+    expect(normalized({ stdout: /ready/ })).toBe(true);
+    expect(normalized({ stderr: /ready/ })).toBe(true);
+    expect(normalized({})).toBeUndefined();
+  });
 });
 
 describe('taskEnvDivergesFromAmbient', () => {
@@ -131,11 +159,11 @@ describe('forkChildEval (real fork)', () => {
   afterAll(() => rmSync(fixtureDir, { recursive: true, force: true }));
   afterEach(() => _setWorkerScriptPath(null));
 
-  it('resolves with the message the worker sends', async () => {
+  it('resolves with the result message the worker sends', async () => {
     _setWorkerScriptPath(
       writeWorker(
         'ok.js',
-        `process.send([{ command: 'x', url: 'http://localhost:4301' }], () => process.exit(0));`
+        `process.send({ type: 'webserver-config-result', webServers: [{ command: 'x', url: 'http://localhost:4301' }] }, () => process.exit(0));`
       )
     );
     await expect(
@@ -143,13 +171,30 @@ describe('forkChildEval (real fork)', () => {
     ).resolves.toEqual([{ command: 'x', url: 'http://localhost:4301' }]);
   });
 
-  it('rejects an `{ error }` message even when the string is empty', async () => {
+  it('ignores messages without the worker tag', async () => {
+    // The evaluated config runs arbitrary user code that can call process.send
+    // itself. A primitive or an untagged object must neither settle nor crash
+    // the resolution; only the tagged result does.
+    _setWorkerScriptPath(
+      writeWorker(
+        'chatty.js',
+        `process.send('ready');
+process.send({ event: 'progress' });
+process.send({ type: 'webserver-config-result', webServers: [{ command: 'x', url: 'http://localhost:4301' }] }, () => process.exit(0));`
+      )
+    );
+    await expect(
+      resolveWebServersUnderEnv('config.ts', 'root', {})
+    ).resolves.toEqual([{ command: 'x', url: 'http://localhost:4301' }]);
+  });
+
+  it('rejects a tagged error message even when the string is empty', async () => {
     // Guards the throw-don't-fall-back design: an empty error string must not
     // read as a successful (empty) result.
     _setWorkerScriptPath(
       writeWorker(
         'empty-error.js',
-        `process.send({ error: '' }, () => process.exit(0));`
+        `process.send({ type: 'webserver-config-error', error: '' }, () => process.exit(0));`
       )
     );
     await expect(

--- a/packages/playwright/src/plugins/webserver-readiness.spec.ts
+++ b/packages/playwright/src/plugins/webserver-readiness.spec.ts
@@ -4,6 +4,7 @@ import { join } from 'node:path';
 import {
   _setChildEval,
   _setWorkerScriptPath,
+  getProbeEnvDivergence,
   normalizeWebServers,
   resolveWebServersUnderEnv,
   taskEnvDivergesFromAmbient,
@@ -33,7 +34,7 @@ describe('normalizeWebServers', () => {
     expect(normalizeWebServers([server])).toEqual([server]);
   });
 
-  it('projects `wait` to a boolean and drops run-only fields like cwd and env', () => {
+  it('projects `wait` and `env` to booleans and drops run-only fields like cwd', () => {
     expect(
       normalizeWebServers({
         command: 'nx serve app',
@@ -49,6 +50,7 @@ describe('normalizeWebServers', () => {
         url: 'http://localhost:4300',
         reuseExistingServer: true,
         waitsForOutput: true,
+        hasEnv: true,
       },
     ]);
   });
@@ -59,6 +61,126 @@ describe('normalizeWebServers', () => {
     expect(normalized({ stdout: /ready/ })).toBe(true);
     expect(normalized({ stderr: /ready/ })).toBe(true);
     expect(normalized({})).toBeUndefined();
+  });
+
+  it('sets hasEnv only for a non-empty env', () => {
+    const normalized = (server: object) =>
+      normalizeWebServers({ command: 'x', ...server })[0].hasEnv;
+    expect(normalized({ env: { PORT: '4300' } })).toBe(true);
+    expect(normalized({ env: {} })).toBeUndefined();
+    expect(normalized({})).toBeUndefined();
+  });
+});
+
+describe('getProbeEnvDivergence', () => {
+  const httpUrl = { url: 'http://localhost:4200' };
+  const httpsUrl = { url: 'https://localhost:4200' };
+
+  it('reports nothing for port-only servers', () => {
+    expect(
+      getProbeEnvDivergence(
+        [{}],
+        { HTTP_PROXY: 'http://proxy.example:8080' },
+        {}
+      )
+    ).toEqual([]);
+  });
+
+  it('names a no_proxy exclusion that reroutes the probe', () => {
+    const ambient = { HTTP_PROXY: 'http://proxy.example:8080' };
+    expect(
+      getProbeEnvDivergence(
+        [httpUrl],
+        { ...ambient, NO_PROXY: 'localhost' },
+        ambient
+      )
+    ).toEqual(['NO_PROXY']);
+  });
+
+  it('reports nothing when no_proxy differs but no proxy is configured', () => {
+    // The routing decision is direct on both sides; the raw difference cannot
+    // change how the server is probed.
+    expect(
+      getProbeEnvDivergence([httpUrl], { NO_PROXY: 'localhost' }, {})
+    ).toEqual([]);
+  });
+
+  it('names a proxy the task env adds', () => {
+    expect(
+      getProbeEnvDivergence(
+        [httpUrl],
+        { http_proxy: 'http://proxy.example:8080' },
+        {}
+      )
+    ).toEqual(['http_proxy']);
+  });
+
+  it('names the all_proxy fallback when it drives the decision', () => {
+    expect(
+      getProbeEnvDivergence(
+        [httpUrl],
+        { ALL_PROXY: 'http://proxy.example:8080' },
+        {}
+      )
+    ).toEqual(['ALL_PROXY']);
+  });
+
+  it('ignores a proxy variable for a protocol the url does not use', () => {
+    expect(
+      getProbeEnvDivergence(
+        [httpUrl],
+        { HTTPS_PROXY: 'http://proxy.example:8080' },
+        {}
+      )
+    ).toEqual([]);
+  });
+
+  it('names TLS material for a verifying https probe only', () => {
+    const taskEnv = { NODE_EXTRA_CA_CERTS: '/certs/ca.pem' };
+    expect(getProbeEnvDivergence([httpsUrl], taskEnv, {})).toEqual([
+      'NODE_EXTRA_CA_CERTS',
+    ]);
+    expect(getProbeEnvDivergence([httpUrl], taskEnv, {})).toEqual([]);
+    expect(
+      getProbeEnvDivergence(
+        [{ ...httpsUrl, ignoreHTTPSErrors: true }],
+        taskEnv,
+        {}
+      )
+    ).toEqual([]);
+  });
+
+  it('names NODE_TLS_REJECT_UNAUTHORIZED for an https probe', () => {
+    expect(
+      getProbeEnvDivergence(
+        [httpsUrl],
+        { NODE_TLS_REJECT_UNAUTHORIZED: '0' },
+        {}
+      )
+    ).toEqual(['NODE_TLS_REJECT_UNAUTHORIZED']);
+  });
+
+  it('ignores a malformed url', () => {
+    expect(
+      getProbeEnvDivergence(
+        [{ url: 'not a url' }],
+        { HTTP_PROXY: 'http://proxy.example:8080' },
+        {}
+      )
+    ).toEqual([]);
+  });
+
+  it('accumulates sorted names across servers', () => {
+    expect(
+      getProbeEnvDivergence(
+        [httpUrl, httpsUrl],
+        {
+          http_proxy: 'http://proxy.example:8080',
+          NODE_EXTRA_CA_CERTS: '/certs/ca.pem',
+        },
+        {}
+      )
+    ).toEqual(['NODE_EXTRA_CA_CERTS', 'http_proxy']);
   });
 });
 

--- a/packages/playwright/src/plugins/webserver-readiness.spec.ts
+++ b/packages/playwright/src/plugins/webserver-readiness.spec.ts
@@ -124,6 +124,51 @@ describe('resolveWebServersUnderEnv concurrency', () => {
     expect(startOrder).toEqual(ids);
   });
 
+  it('keeps the cap when a new caller barges in between a release and the woken waiter', async () => {
+    let active = 0;
+    let peak = 0;
+    const releasers: Array<() => void> = [];
+    _setChildEval(
+      () =>
+        new Promise((resolve) => {
+          active++;
+          peak = Math.max(peak, active);
+          releasers.push(() => {
+            active--;
+            resolve([]);
+          });
+        })
+    );
+
+    const all: Array<Promise<unknown>> = [];
+    for (let i = 0; i < MAX_CONCURRENT_EVALS + 1; i++) {
+      all.push(resolveWebServersUnderEnv(String(i), 'root', {}));
+    }
+    await flush();
+    expect(active).toBe(MAX_CONCURRENT_EVALS);
+
+    // Free a slot, then queue a new call as a microtask so it runs after the
+    // release's continuation but before the woken waiter resumes; without the
+    // waiter's re-check both would claim the single free slot.
+    releasers.shift()!();
+    await new Promise<void>((resolve) =>
+      queueMicrotask(() => {
+        all.push(resolveWebServersUnderEnv('barge', 'root', {}));
+        resolve();
+      })
+    );
+
+    let done = false;
+    void Promise.all(all).then(() => (done = true));
+    while (!done) {
+      await flush();
+      while (releasers.length > 0) {
+        releasers.shift()!();
+      }
+    }
+    expect(peak).toBe(MAX_CONCURRENT_EVALS);
+  });
+
   it('releases the slot when an evaluation rejects', async () => {
     _setChildEval((configFilePath) =>
       configFilePath === 'reject'

--- a/packages/playwright/src/plugins/webserver-readiness.spec.ts
+++ b/packages/playwright/src/plugins/webserver-readiness.spec.ts
@@ -234,8 +234,8 @@ process.send({ type: 'webserver-config-result', webServers: [{ command: 'x', url
   });
 
   it('rejects a tagged error message even when the string is empty', async () => {
-    // Guards the throw-don't-fall-back design: an empty error string must not
-    // read as a successful (empty) result.
+    // Guards the fork's reject contract: an empty error string must not read
+    // as a successful (empty) result.
     _setWorkerScriptPath(
       writeWorker(
         'empty-error.js',
@@ -257,5 +257,26 @@ process.send({ type: 'webserver-config-result', webServers: [{ command: 'x', url
     await expect(
       resolveWebServersUnderEnv('config.ts', 'root', {})
     ).rejects.toThrow(/exited with code 3[\s\S]*boom-detail/);
+  });
+
+  it('kills a hung worker and rejects when the evaluation times out', async () => {
+    jest.useFakeTimers();
+    try {
+      // Holds the event loop open and never reports, like a config stuck in a
+      // busy loop or awaiting something that never resolves.
+      _setWorkerScriptPath(
+        writeWorker('hang.js', `setInterval(() => {}, 1000);`)
+      );
+      const evaluation = resolveWebServersUnderEnv('config.ts', 'root', {});
+      // Attach the rejection expectation before firing the timer so the
+      // rejection is never unhandled.
+      const assertion = expect(evaluation).rejects.toThrow(
+        'Timed out evaluating the Playwright config'
+      );
+      jest.advanceTimersByTime(30_000);
+      await assertion;
+    } finally {
+      jest.useRealTimers();
+    }
   });
 });

--- a/packages/playwright/src/plugins/webserver-readiness.spec.ts
+++ b/packages/playwright/src/plugins/webserver-readiness.spec.ts
@@ -1,0 +1,171 @@
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { cpus, tmpdir } from 'node:os';
+import { join } from 'node:path';
+import {
+  _setChildEval,
+  _setWorkerScriptPath,
+  normalizeWebServers,
+  resolveWebServersUnderEnv,
+  taskEnvDivergesFromAmbient,
+} from './webserver-readiness';
+
+// Mirrors the module's own cap so the concurrency assertions don't depend on
+// the host's core count.
+const MAX_CONCURRENT_EVALS = Math.max(1, Math.min(cpus().length, 8));
+
+const flush = () => new Promise((resolve) => setImmediate(resolve));
+
+describe('normalizeWebServers', () => {
+  it('returns [] when there is no web server', () => {
+    expect(normalizeWebServers(undefined)).toEqual([]);
+  });
+
+  it('normalizes a single web server and an array the same way', () => {
+    const server = {
+      command: 'nx serve app',
+      url: 'http://localhost:4300',
+      port: 4300,
+      reuseExistingServer: true,
+      ignoreHTTPSErrors: true,
+      timeout: 1000,
+    };
+    expect(normalizeWebServers(server)).toEqual([server]);
+    expect(normalizeWebServers([server])).toEqual([server]);
+  });
+});
+
+describe('taskEnvDivergesFromAmbient', () => {
+  it('is false for an env identical to process.env', () => {
+    expect(taskEnvDivergesFromAmbient({ ...process.env })).toBe(false);
+  });
+
+  it('is true when a key is added, changed, or removed', () => {
+    expect(taskEnvDivergesFromAmbient({ ...process.env, NX_TEST: '1' })).toBe(
+      true
+    );
+    const withoutOne = { ...process.env };
+    const [firstKey] = Object.keys(withoutOne);
+    if (firstKey) {
+      delete withoutOne[firstKey];
+      expect(taskEnvDivergesFromAmbient(withoutOne)).toBe(true);
+    }
+  });
+});
+
+describe('resolveWebServersUnderEnv concurrency', () => {
+  afterEach(() => _setChildEval(null));
+
+  it('never exceeds the cap and drains the queue in submission order', async () => {
+    let active = 0;
+    let peak = 0;
+    const startOrder: string[] = [];
+    const releasers: Array<() => void> = [];
+    _setChildEval(
+      (configFilePath) =>
+        new Promise((resolve) => {
+          active++;
+          peak = Math.max(peak, active);
+          startOrder.push(configFilePath);
+          releasers.push(() => {
+            active--;
+            resolve([]);
+          });
+        })
+    );
+
+    const total = MAX_CONCURRENT_EVALS + 3;
+    const ids = Array.from({ length: total }, (_, i) => String(i));
+    const all = ids.map((id) => resolveWebServersUnderEnv(id, 'root', {}));
+
+    await flush();
+    // Only the cap started; the rest are queued and have not called childEval.
+    expect(active).toBe(MAX_CONCURRENT_EVALS);
+
+    for (let i = 0; i < total; i++) {
+      while (releasers.length === 0) {
+        await flush();
+      }
+      releasers.shift()!();
+      await flush();
+    }
+
+    await Promise.all(all);
+    expect(peak).toBe(MAX_CONCURRENT_EVALS);
+    // A LIFO queue (pop instead of shift) would start the queued evals in
+    // reverse submission order.
+    expect(startOrder).toEqual(ids);
+  });
+
+  it('releases the slot when an evaluation rejects', async () => {
+    _setChildEval((configFilePath) =>
+      configFilePath === 'reject'
+        ? Promise.reject(new Error('boom'))
+        : Promise.resolve([])
+    );
+
+    const results = await Promise.allSettled([
+      ...Array.from({ length: MAX_CONCURRENT_EVALS }, () =>
+        resolveWebServersUnderEnv('reject', 'root', {})
+      ),
+      resolveWebServersUnderEnv('ok', 'root', {}),
+    ]);
+
+    // The final call is queued behind the cap; it only runs if the rejected
+    // evaluations release their slots.
+    expect(results[MAX_CONCURRENT_EVALS].status).toBe('fulfilled');
+  });
+});
+
+describe('forkChildEval (real fork)', () => {
+  let fixtureDir: string;
+
+  const writeWorker = (name: string, body: string): string => {
+    const path = join(fixtureDir, name);
+    writeFileSync(path, body);
+    return path;
+  };
+
+  beforeAll(() => {
+    fixtureDir = mkdtempSync(join(tmpdir(), 'pw-webserver-readiness-'));
+  });
+  afterAll(() => rmSync(fixtureDir, { recursive: true, force: true }));
+  afterEach(() => _setWorkerScriptPath(null));
+
+  it('resolves with the message the worker sends', async () => {
+    _setWorkerScriptPath(
+      writeWorker(
+        'ok.js',
+        `process.send([{ command: 'x', url: 'http://localhost:4301' }], () => process.exit(0));`
+      )
+    );
+    await expect(
+      resolveWebServersUnderEnv('config.ts', 'root', {})
+    ).resolves.toEqual([{ command: 'x', url: 'http://localhost:4301' }]);
+  });
+
+  it('rejects an `{ error }` message even when the string is empty', async () => {
+    // Guards the throw-don't-fall-back design: an empty error string must not
+    // read as a successful (empty) result.
+    _setWorkerScriptPath(
+      writeWorker(
+        'empty-error.js',
+        `process.send({ error: '' }, () => process.exit(0));`
+      )
+    );
+    await expect(
+      resolveWebServersUnderEnv('config.ts', 'root', {})
+    ).rejects.toThrow();
+  });
+
+  it('folds the worker stderr into a nonzero-exit rejection', async () => {
+    _setWorkerScriptPath(
+      writeWorker(
+        'crash.js',
+        `process.stderr.write('boom-detail', () => process.exit(3));`
+      )
+    );
+    await expect(
+      resolveWebServersUnderEnv('config.ts', 'root', {})
+    ).rejects.toThrow(/exited with code 3[\s\S]*boom-detail/);
+  });
+});

--- a/packages/playwright/src/plugins/webserver-readiness.spec.ts
+++ b/packages/playwright/src/plugins/webserver-readiness.spec.ts
@@ -381,14 +381,87 @@ describe('getProbeEnvDivergence', () => {
     ).toEqual([]);
   });
 
-  it('names NODE_TLS_REJECT_UNAUTHORIZED for an https probe', () => {
+  it('ignores TLS material for a legacy tunnel through an http proxy that no redirect can escape', () => {
+    // Playwright before 1.59.0 never verifies the origin behind an http proxy
+    // tunnel, and neither does the gate on that version, so the material can
+    // only matter where a hop can leave that tunnel.
+    const proxy = { HTTPS_PROXY: 'http://proxy.example:8080' };
+    const taskEnv = { ...proxy, NODE_EXTRA_CA_CERTS: '/certs/ca.pem' };
+    expect(getProbeEnvDivergence([httpsUrl], taskEnv, proxy, true)).toEqual([]);
+    // An http url can only redirect into the same tunnel.
+    expect(getProbeEnvDivergence([httpUrl], taskEnv, proxy, true)).toEqual([]);
+    // A bypass can send a redirect target direct, where it is verified.
+    expect(
+      getProbeEnvDivergence(
+        [httpsUrl],
+        { ...taskEnv, NO_PROXY: 'localhost' },
+        { ...proxy, NO_PROXY: 'localhost' },
+        true
+      )
+    ).toEqual(['NODE_EXTRA_CA_CERTS']);
+    // An https proxy on the http route is dialled with verification.
+    expect(
+      getProbeEnvDivergence(
+        [httpsUrl],
+        { ...taskEnv, HTTP_PROXY: 'https://proxy.example:8443' },
+        { ...proxy, HTTP_PROXY: 'https://proxy.example:8443' },
+        true
+      )
+    ).toEqual(['NODE_EXTRA_CA_CERTS']);
+    // Current versions honor the setting and verify the origin.
+    expect(getProbeEnvDivergence([httpsUrl], taskEnv, proxy)).toEqual([
+      'NODE_EXTRA_CA_CERTS',
+    ]);
+  });
+
+  it('names NODE_TLS_REJECT_UNAUTHORIZED only for the connection to an https proxy', () => {
+    // Every request sets `rejectUnauthorized` itself, which overrides the env
+    // default, so a direct origin verifies the same on both sides.
     expect(
       getProbeEnvDivergence(
         [httpsUrl],
         { NODE_TLS_REJECT_UNAUTHORIZED: '0' },
         {}
       )
+    ).toEqual([]);
+    expect(
+      getProbeEnvDivergence(
+        [httpsUrl],
+        {
+          HTTPS_PROXY: 'http://proxy.example:8080',
+          NODE_TLS_REJECT_UNAUTHORIZED: '0',
+        },
+        { HTTPS_PROXY: 'http://proxy.example:8080' }
+      )
+    ).toEqual([]);
+    const proxy = { HTTPS_PROXY: 'https://proxy.example:8443' };
+    expect(
+      getProbeEnvDivergence(
+        [httpsUrl],
+        { ...proxy, NODE_TLS_REJECT_UNAUTHORIZED: '0' },
+        proxy
+      )
     ).toEqual(['NODE_TLS_REJECT_UNAUTHORIZED']);
+    // Node reads exactly '0'; any other value is the default.
+    expect(
+      getProbeEnvDivergence(
+        [httpsUrl],
+        { ...proxy, NODE_TLS_REJECT_UNAUTHORIZED: '1' },
+        proxy
+      )
+    ).toEqual([]);
+    // An https proxy on the http route only is dialled with the request's own
+    // `rejectUnauthorized`.
+    expect(
+      getProbeEnvDivergence(
+        [httpUrl],
+        {
+          HTTP_PROXY: 'https://proxy.example:8443',
+          NODE_TLS_REJECT_UNAUTHORIZED: '0',
+        },
+        { HTTP_PROXY: 'https://proxy.example:8443' }
+      )
+    ).toEqual([]);
   });
 
   it('ignores a malformed url', () => {
@@ -416,19 +489,33 @@ describe('getProbeEnvDivergence', () => {
 });
 
 describe('taskEnvDivergesFromAmbient', () => {
-  it('is false for an env identical to process.env', () => {
-    expect(taskEnvDivergesFromAmbient({ ...process.env })).toBe(false);
+  it('is false for an env identical to the ambient snapshot', () => {
+    const ambient = { ...process.env };
+    expect(taskEnvDivergesFromAmbient({ ...ambient }, ambient)).toBe(false);
   });
 
   it('is true when a key is added, changed, or removed', () => {
-    expect(taskEnvDivergesFromAmbient({ ...process.env, NX_TEST: '1' })).toBe(
-      true
-    );
-    const withoutOne = { ...process.env };
+    const ambient = { ...process.env };
+    expect(
+      taskEnvDivergesFromAmbient({ ...ambient, NX_TEST: '1' }, ambient)
+    ).toBe(true);
+    const withoutOne = { ...ambient };
     const [firstKey] = Object.keys(withoutOne);
     if (firstKey) {
       delete withoutOne[firstKey];
-      expect(taskEnvDivergesFromAmbient(withoutOne)).toBe(true);
+      expect(taskEnvDivergesFromAmbient(withoutOne, ambient)).toBe(true);
+    }
+  });
+
+  it('compares against the given snapshot, not the live process.env', () => {
+    // A concurrent config load can be mutating the live env; a transient write
+    // there must not register as a divergence of this chain's task env.
+    const ambient = { ...process.env };
+    process.env.NX_TEST_LIVE_WRITE = 'transient';
+    try {
+      expect(taskEnvDivergesFromAmbient({ ...ambient }, ambient)).toBe(false);
+    } finally {
+      delete process.env.NX_TEST_LIVE_WRITE;
     }
   });
 });
@@ -647,6 +734,47 @@ module.exports = {};`
     await loadConfigWithProbeEnv(path, () => undefined);
 
     expect(process.env.PROXY_HOST).toBeUndefined();
+  });
+
+  it('returns an ambient snapshot free of the variables the load wrote', async () => {
+    // Task-env reconstruction after the lock releases bases on this snapshot;
+    // one taken before the restore would carry the config's writes as ambient.
+    process.env.PW_AMBIENT_TEST = 'ambient';
+    const path = writeConfig(
+      'writes-for-snapshot.cjs',
+      `process.env.NO_PROXY = 'localhost';
+process.env.PROXY_HOST = 'proxy.example';
+module.exports = {};`
+    );
+
+    try {
+      const { ambientEnv } = await loadConfigWithProbeEnv(
+        path,
+        () => undefined
+      );
+
+      expect(ambientEnv.NO_PROXY).toBeUndefined();
+      expect(ambientEnv.PROXY_HOST).toBeUndefined();
+      expect(ambientEnv.PW_AMBIENT_TEST).toBe('ambient');
+    } finally {
+      delete process.env.PW_AMBIENT_TEST;
+    }
+  });
+
+  it('includes a client env applied mid-load in the ambient snapshot', async () => {
+    // The client env survives the restore, so the tasks run under it; a
+    // snapshot taken before its reapplication would miss it.
+    const path = writeConfig(
+      'writes-for-client-snapshot.cjs',
+      `${applyClientEnv}({ ...process.env, HTTP_PROXY: 'http://client.example:8080' });
+process.env.NO_PROXY = 'localhost';
+module.exports = {};`
+    );
+
+    const { ambientEnv } = await loadConfigWithProbeEnv(path, () => undefined);
+
+    expect(ambientEnv.HTTP_PROXY).toBe('http://client.example:8080');
+    expect(ambientEnv.NO_PROXY).toBeUndefined();
   });
 
   it('re-applies the client env applied mid-load over the pre-load values', async () => {

--- a/packages/playwright/src/plugins/webserver-readiness.spec.ts
+++ b/packages/playwright/src/plugins/webserver-readiness.spec.ts
@@ -414,6 +414,23 @@ describe('getProbeEnvDivergence', () => {
     ]);
   });
 
+  it('compares the npm_config proxy variables only for a Playwright that reads them', () => {
+    // Playwright before 1.59.0 routes by npm's variables ahead of the standard
+    // ones, as does the gate on that version.
+    const npmProxy = { npm_config_http_proxy: 'http://proxy.example:8080' };
+    expect(getProbeEnvDivergence([httpUrl], npmProxy, {})).toEqual([]);
+    expect(getProbeEnvDivergence([httpUrl], npmProxy, {}, false, true)).toEqual(
+      ['npm_config_http_proxy']
+    );
+    // An npm exclusion that reroutes a proxied probe counts on its own.
+    const ambient = { HTTP_PROXY: 'http://proxy.example:8080' };
+    const excluded = { ...ambient, npm_config_no_proxy: 'localhost' };
+    expect(getProbeEnvDivergence([httpUrl], excluded, ambient)).toEqual([]);
+    expect(
+      getProbeEnvDivergence([httpUrl], excluded, ambient, false, true)
+    ).toEqual(['npm_config_no_proxy']);
+  });
+
   it('names NODE_TLS_REJECT_UNAUTHORIZED only for the connection to an https proxy', () => {
     // Every request sets `rejectUnauthorized` itself, which overrides the env
     // default, so a direct origin verifies the same on both sides.

--- a/packages/playwright/src/plugins/webserver-readiness.spec.ts
+++ b/packages/playwright/src/plugins/webserver-readiness.spec.ts
@@ -11,9 +11,12 @@ import {
   _setChildEval,
   _setWorkerScriptPath,
   getProbeEnvDivergence,
+  loadConfigWithProbeEnv,
   normalizeWebServers,
+  pickProbeEnv,
   resolveWebServersUnderEnv,
   taskEnvDivergesFromAmbient,
+  type ConfigEvaluation,
 } from './webserver-readiness';
 
 // Mirrors the module's own cap so the concurrency assertions don't depend on
@@ -430,6 +433,8 @@ describe('taskEnvDivergesFromAmbient', () => {
   });
 });
 
+const emptyEvaluation: ConfigEvaluation = { webServers: [], probeEnv: {} };
+
 describe('resolveWebServersUnderEnv concurrency', () => {
   afterEach(() => _setChildEval(null));
 
@@ -446,7 +451,7 @@ describe('resolveWebServersUnderEnv concurrency', () => {
           startOrder.push(configFilePath);
           releasers.push(() => {
             active--;
-            resolve([]);
+            resolve(emptyEvaluation);
           });
         })
     );
@@ -485,7 +490,7 @@ describe('resolveWebServersUnderEnv concurrency', () => {
           peak = Math.max(peak, active);
           releasers.push(() => {
             active--;
-            resolve([]);
+            resolve(emptyEvaluation);
           });
         })
     );
@@ -523,7 +528,7 @@ describe('resolveWebServersUnderEnv concurrency', () => {
     _setChildEval((configFilePath) =>
       configFilePath === 'reject'
         ? Promise.reject(new Error('boom'))
-        : Promise.resolve([])
+        : Promise.resolve(emptyEvaluation)
     );
 
     const results = await Promise.allSettled([
@@ -536,6 +541,141 @@ describe('resolveWebServersUnderEnv concurrency', () => {
     // The final call is queued behind the cap; it only runs if the rejected
     // evaluations release their slots.
     expect(results[MAX_CONCURRENT_EVALS].status).toBe('fulfilled');
+  });
+});
+
+describe('loadConfigWithProbeEnv', () => {
+  let dir: string;
+  let originalProbeEnv: Record<string, string>;
+  // A config that stands in for the daemon delivering a client env while the
+  // load is in flight: it applies one itself, through the same call the
+  // plugin worker makes.
+  const applyClientEnv = `require(${JSON.stringify(
+    require.resolve('@nx/devkit/internal')
+  )}).applyDaemonEnvFromClient`;
+
+  const writeConfig = (name: string, body: string): string => {
+    const path = join(dir, name);
+    writeFileSync(path, body);
+    return path;
+  };
+
+  beforeAll(() => {
+    dir = realpathSync(mkdtempSync(join(tmpdir(), 'pw-load-probe-env-')));
+  });
+  afterAll(() => rmSync(dir, { recursive: true, force: true }));
+  beforeEach(() => {
+    // Start from no probe variables at all: the host (a sandbox, a corporate
+    // shell) may set some, and the assertions below are absolute.
+    originalProbeEnv = pickProbeEnv(process.env);
+    for (const variable of Object.keys(originalProbeEnv)) {
+      delete process.env[variable];
+    }
+  });
+  afterEach(() => {
+    for (const variable of ['NO_PROXY', 'HTTP_PROXY', 'PROXY_HOST']) {
+      delete process.env[variable];
+    }
+    Object.assign(process.env, originalProbeEnv);
+  });
+
+  it('returns the config with the probe env its evaluation wrote, then restores the variables', async () => {
+    const path = writeConfig(
+      'writes.cjs',
+      `process.env.NO_PROXY = 'localhost';
+module.exports = { webServer: { command: 'x' } };`
+    );
+
+    const { config, probeEnv } = await loadConfigWithProbeEnv<{
+      webServer: { command: string };
+    }>(path);
+
+    expect(config.webServer.command).toBe('x');
+    expect(probeEnv).toEqual({ NO_PROXY: 'localhost' });
+    expect(process.env.NO_PROXY).toBeUndefined();
+  });
+
+  it("serializes concurrent loads so one config's writes never reach another's probe env", async () => {
+    // Without the lock the first config's write lands before the second load
+    // snapshots, so the second load reads it as its own and restores to it.
+    const writes = writeConfig(
+      'writes-first.cjs',
+      `process.env.NO_PROXY = 'localhost';
+module.exports = {};`
+    );
+    const reads = writeConfig('reads.cjs', `module.exports = {};`);
+
+    const [writesResult, readsResult] = await Promise.all([
+      loadConfigWithProbeEnv(writes),
+      loadConfigWithProbeEnv(reads),
+    ]);
+
+    expect(writesResult.probeEnv).toEqual({ NO_PROXY: 'localhost' });
+    expect(readsResult.probeEnv).toEqual({});
+    expect(process.env.NO_PROXY).toBeUndefined();
+  });
+
+  it('restores every variable the config wrote, not only the probe ones', async () => {
+    // The task and gate dotenv files expand against process.env, so a helper
+    // variable left behind would resolve a reference in them at graph time
+    // that the task's own process never sees.
+    const path = writeConfig(
+      'writes-helper.cjs',
+      `process.env.PROXY_HOST = 'proxy.example';
+module.exports = {};`
+    );
+
+    await loadConfigWithProbeEnv(path);
+
+    expect(process.env.PROXY_HOST).toBeUndefined();
+  });
+
+  it('re-applies the client env applied mid-load over the pre-load values', async () => {
+    // A restore to the pre-load values alone would revert the client's env;
+    // the config's writes go, but the client's stay.
+    const path = writeConfig(
+      'writes-under-swap.cjs',
+      `${applyClientEnv}({ ...process.env, HTTP_PROXY: 'http://client.example:8080' });
+process.env.NO_PROXY = 'localhost';
+process.env.HTTP_PROXY = 'http://config.example:8080';
+module.exports = {};`
+    );
+
+    const { probeEnv } = await loadConfigWithProbeEnv(path);
+
+    expect(probeEnv).toEqual({
+      NO_PROXY: 'localhost',
+      HTTP_PROXY: 'http://config.example:8080',
+    });
+    expect(process.env.NO_PROXY).toBeUndefined();
+    expect(process.env.HTTP_PROXY).toBe('http://client.example:8080');
+  });
+
+  it('re-applies a mid-load client env whose values the config had already written', async () => {
+    // Such an apply changes nothing at the time, so nothing but the apply
+    // sequence records it; a restore keyed on changed values would then delete
+    // the client's variable along with the config's copy of it.
+    const path = writeConfig(
+      'writes-then-client-matches.cjs',
+      `process.env.NO_PROXY = 'localhost';
+${applyClientEnv}({ ...process.env });
+module.exports = {};`
+    );
+
+    await loadConfigWithProbeEnv(path);
+
+    expect(process.env.NO_PROXY).toBe('localhost');
+  });
+
+  it('restores the variables when the load throws', async () => {
+    const path = writeConfig(
+      'throws.cjs',
+      `process.env.NO_PROXY = 'localhost';
+throw new Error('config boom');`
+    );
+
+    await expect(loadConfigWithProbeEnv(path)).rejects.toThrow('config boom');
+    expect(process.env.NO_PROXY).toBeUndefined();
   });
 });
 
@@ -561,12 +701,15 @@ describe('forkChildEval (real fork)', () => {
     _setWorkerScriptPath(
       writeWorker(
         'ok.js',
-        `process.send({ type: 'webserver-config-result', webServers: [{ command: 'x', url: 'http://localhost:4301' }] }, () => process.exit(0));`
+        `process.send({ type: 'webserver-config-result', webServers: [{ command: 'x', url: 'http://localhost:4301' }], probeEnv: { NO_PROXY: 'localhost' } }, () => process.exit(0));`
       )
     );
     await expect(
       resolveWebServersUnderEnv('config.ts', fixtureDir, {})
-    ).resolves.toEqual([{ command: 'x', url: 'http://localhost:4301' }]);
+    ).resolves.toEqual({
+      webServers: [{ command: 'x', url: 'http://localhost:4301' }],
+      probeEnv: { NO_PROXY: 'localhost' },
+    });
   });
 
   it('runs the worker from the project root, not the parent cwd', async () => {
@@ -575,7 +718,7 @@ describe('forkChildEval (real fork)', () => {
     _setWorkerScriptPath(
       writeWorker(
         'cwd.js',
-        `process.send({ type: 'webserver-config-result', webServers: [{ command: process.cwd() }] }, () => process.exit(0));`
+        `process.send({ type: 'webserver-config-result', webServers: [{ command: process.cwd() }], probeEnv: {} }, () => process.exit(0));`
       )
     );
     const projectRoot = join(fixtureDir, 'apps', 'e2e');
@@ -583,24 +726,32 @@ describe('forkChildEval (real fork)', () => {
     expect(projectRoot).not.toBe(process.cwd());
     await expect(
       resolveWebServersUnderEnv('apps/e2e/playwright.config.ts', fixtureDir, {})
-    ).resolves.toEqual([{ command: projectRoot }]);
+    ).resolves.toEqual({
+      webServers: [{ command: projectRoot }],
+      probeEnv: {},
+    });
   });
 
-  it('ignores messages without the worker tag', async () => {
+  it('ignores messages without the worker tag or the result shape', async () => {
     // The evaluated config runs arbitrary user code that can call process.send
-    // itself. A primitive or an untagged object must neither settle nor crash
-    // the resolution; only the tagged result does.
+    // itself. A primitive, an untagged object or a tagged object missing a
+    // field must neither settle nor crash the resolution; only the full result
+    // does.
     _setWorkerScriptPath(
       writeWorker(
         'chatty.js',
         `process.send('ready');
 process.send({ event: 'progress' });
-process.send({ type: 'webserver-config-result', webServers: [{ command: 'x', url: 'http://localhost:4301' }] }, () => process.exit(0));`
+process.send({ type: 'webserver-config-result', webServers: [] });
+process.send({ type: 'webserver-config-result', webServers: [{ command: 'x', url: 'http://localhost:4301' }], probeEnv: {} }, () => process.exit(0));`
       )
     );
     await expect(
       resolveWebServersUnderEnv('config.ts', fixtureDir, {})
-    ).resolves.toEqual([{ command: 'x', url: 'http://localhost:4301' }]);
+    ).resolves.toEqual({
+      webServers: [{ command: 'x', url: 'http://localhost:4301' }],
+      probeEnv: {},
+    });
   });
 
   it('rejects a tagged error message even when the string is empty', async () => {

--- a/packages/playwright/src/plugins/webserver-readiness.spec.ts
+++ b/packages/playwright/src/plugins/webserver-readiness.spec.ts
@@ -579,20 +579,39 @@ describe('loadConfigWithProbeEnv', () => {
     Object.assign(process.env, originalProbeEnv);
   });
 
-  it('returns the config with the probe env its evaluation wrote, then restores the variables', async () => {
+  it('returns the consumed config with the probe env its evaluation wrote, then restores the variables', async () => {
     const path = writeConfig(
       'writes.cjs',
       `process.env.NO_PROXY = 'localhost';
 module.exports = { webServer: { command: 'x' } };`
     );
 
-    const { config, probeEnv } = await loadConfigWithProbeEnv<{
-      webServer: { command: string };
-    }>(path);
+    const { consumed, probeEnv } = await loadConfigWithProbeEnv(
+      path,
+      (config: { webServer: { command: string } }) => config.webServer.command
+    );
 
-    expect(config.webServer.command).toBe('x');
+    expect(consumed).toBe('x');
     expect(probeEnv).toEqual({ NO_PROXY: 'localhost' });
     expect(process.env.NO_PROXY).toBeUndefined();
+  });
+
+  it('consumes the config before restoring, so a getter reading env the load wrote sees it', async () => {
+    // The consumer's reads are the last moment that env exists: after the
+    // restore a lazy getter would read the pre-load value.
+    const path = writeConfig(
+      'getter.cjs',
+      `process.env.PROXY_HOST = 'proxy.example';
+module.exports = { get command() { return process.env.PROXY_HOST; } };`
+    );
+
+    const { consumed } = await loadConfigWithProbeEnv(
+      path,
+      (config: { command: string }) => config.command
+    );
+
+    expect(consumed).toBe('proxy.example');
+    expect(process.env.PROXY_HOST).toBeUndefined();
   });
 
   it("serializes concurrent loads so one config's writes never reach another's probe env", async () => {
@@ -606,8 +625,8 @@ module.exports = {};`
     const reads = writeConfig('reads.cjs', `module.exports = {};`);
 
     const [writesResult, readsResult] = await Promise.all([
-      loadConfigWithProbeEnv(writes),
-      loadConfigWithProbeEnv(reads),
+      loadConfigWithProbeEnv(writes, () => undefined),
+      loadConfigWithProbeEnv(reads, () => undefined),
     ]);
 
     expect(writesResult.probeEnv).toEqual({ NO_PROXY: 'localhost' });
@@ -625,7 +644,7 @@ module.exports = {};`
 module.exports = {};`
     );
 
-    await loadConfigWithProbeEnv(path);
+    await loadConfigWithProbeEnv(path, () => undefined);
 
     expect(process.env.PROXY_HOST).toBeUndefined();
   });
@@ -641,7 +660,7 @@ process.env.HTTP_PROXY = 'http://config.example:8080';
 module.exports = {};`
     );
 
-    const { probeEnv } = await loadConfigWithProbeEnv(path);
+    const { probeEnv } = await loadConfigWithProbeEnv(path, () => undefined);
 
     expect(probeEnv).toEqual({
       NO_PROXY: 'localhost',
@@ -662,7 +681,7 @@ ${applyClientEnv}({ ...process.env });
 module.exports = {};`
     );
 
-    await loadConfigWithProbeEnv(path);
+    await loadConfigWithProbeEnv(path, () => undefined);
 
     expect(process.env.NO_PROXY).toBe('localhost');
   });
@@ -674,7 +693,9 @@ module.exports = {};`
 throw new Error('config boom');`
     );
 
-    await expect(loadConfigWithProbeEnv(path)).rejects.toThrow('config boom');
+    await expect(loadConfigWithProbeEnv(path, () => undefined)).rejects.toThrow(
+      'config boom'
+    );
     expect(process.env.NO_PROXY).toBeUndefined();
   });
 });

--- a/packages/playwright/src/plugins/webserver-readiness.spec.ts
+++ b/packages/playwright/src/plugins/webserver-readiness.spec.ts
@@ -1,4 +1,10 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import {
+  mkdirSync,
+  mkdtempSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { cpus, tmpdir } from 'node:os';
 import { join } from 'node:path';
 import {
@@ -97,11 +103,30 @@ describe('getProbeEnvDivergence', () => {
     ).toEqual(['NO_PROXY']);
   });
 
-  it('reports nothing when no_proxy differs but no proxy is configured', () => {
-    // The routing decision is direct on both sides; the raw difference cannot
-    // change how the server is probed.
+  it('names a no_proxy exclusion for a proxy that only routes another protocol', () => {
+    // A redirect to https would be routed through https_proxy; the exclusion
+    // decides that hop.
+    const ambient = { HTTPS_PROXY: 'http://proxy.example:8080' };
+    expect(
+      getProbeEnvDivergence(
+        [httpUrl],
+        { ...ambient, NO_PROXY: 'localhost' },
+        ambient
+      )
+    ).toEqual(['NO_PROXY']);
+  });
+
+  it('reports nothing when no_proxy differs but neither env configures a proxy', () => {
+    // Every hop is direct on both sides.
     expect(
       getProbeEnvDivergence([httpUrl], { NO_PROXY: 'localhost' }, {})
+    ).toEqual([]);
+    expect(
+      getProbeEnvDivergence(
+        [httpUrl],
+        { NO_PROXY: 'localhost', HTTP_PROXY: '' },
+        {}
+      )
     ).toEqual([]);
   });
 
@@ -115,7 +140,7 @@ describe('getProbeEnvDivergence', () => {
     ).toEqual(['http_proxy']);
   });
 
-  it('names the all_proxy fallback when it drives the decision', () => {
+  it('names the all_proxy fallback', () => {
     expect(
       getProbeEnvDivergence(
         [httpUrl],
@@ -125,22 +150,175 @@ describe('getProbeEnvDivergence', () => {
     ).toEqual(['ALL_PROXY']);
   });
 
-  it('ignores a proxy variable for a protocol the url does not use', () => {
+  it('names a proxy variable for a protocol the configured url does not use', () => {
+    // An http url can redirect to https, where https_proxy decides the route.
     expect(
       getProbeEnvDivergence(
         [httpUrl],
         { HTTPS_PROXY: 'http://proxy.example:8080' },
         {}
       )
+    ).toEqual(['HTTPS_PROXY']);
+  });
+
+  it('reports nothing for a differing case-variant with the same effective value', () => {
+    // The probe reads the lowercase name first, so an uppercase value it never
+    // reads is not a difference.
+    expect(
+      getProbeEnvDivergence(
+        [httpUrl],
+        {
+          http_proxy: 'http://proxy.example:8080',
+          HTTP_PROXY: 'http://other.example:8080',
+        },
+        { http_proxy: 'http://proxy.example:8080' }
+      )
     ).toEqual([]);
   });
 
-  it('names TLS material for a verifying https probe only', () => {
+  it('reports nothing for an empty value against an unset one', () => {
+    // The probe treats an empty value as unset.
+    expect(getProbeEnvDivergence([httpUrl], { HTTP_PROXY: '' }, {})).toEqual(
+      []
+    );
+  });
+
+  it('reports nothing for a proxy that no_proxy=* masks on both sides', () => {
+    // Every hop is direct on both sides, whatever the proxy variables say.
+    expect(
+      getProbeEnvDivergence(
+        [httpUrl],
+        { HTTP_PROXY: 'http://a.example:8080', NO_PROXY: '*' },
+        { HTTP_PROXY: 'http://b.example:8080', NO_PROXY: '*' }
+      )
+    ).toEqual([]);
+    expect(
+      getProbeEnvDivergence(
+        [httpUrl],
+        { HTTP_PROXY: 'http://a.example:8080', NO_PROXY: '*' },
+        {}
+      )
+    ).toEqual([]);
+  });
+
+  it('reports nothing when a * entry among others excludes every host on both sides', () => {
+    expect(
+      getProbeEnvDivergence(
+        [httpUrl],
+        { HTTP_PROXY: 'http://a.example:8080', NO_PROXY: 'localhost,*' },
+        { HTTP_PROXY: 'http://b.example:8080', NO_PROXY: '*,other.example' }
+      )
+    ).toEqual([]);
+  });
+
+  it('names a no_proxy=* that turns a configured proxy off on one side only', () => {
+    const proxy = { HTTP_PROXY: 'http://proxy.example:8080' };
+    expect(
+      getProbeEnvDivergence([httpUrl], { ...proxy, NO_PROXY: '*' }, proxy)
+    ).toEqual(['NO_PROXY']);
+  });
+
+  it('reports nothing for an all_proxy that explicit protocol proxies mask', () => {
+    const explicit = {
+      http_proxy: 'http://proxy.example:8080',
+      https_proxy: 'http://proxy.example:8080',
+    };
+    expect(
+      getProbeEnvDivergence(
+        [httpUrl],
+        { ...explicit, ALL_PROXY: 'http://a.example:8080' },
+        { ...explicit, ALL_PROXY: 'http://b.example:8080' }
+      )
+    ).toEqual([]);
+  });
+
+  it('names an all_proxy that decides the route for the other protocol', () => {
+    const explicit = { http_proxy: 'http://proxy.example:8080' };
+    expect(
+      getProbeEnvDivergence(
+        [httpUrl],
+        { ...explicit, ALL_PROXY: 'http://a.example:8080' },
+        explicit
+      )
+    ).toEqual(['ALL_PROXY']);
+  });
+
+  it('compares no_proxy case-insensitively, as the probe reads it', () => {
+    const proxy = { HTTP_PROXY: 'http://proxy.example:8080' };
+    expect(
+      getProbeEnvDivergence(
+        [httpUrl],
+        { ...proxy, NO_PROXY: 'LOCALHOST' },
+        { ...proxy, NO_PROXY: 'localhost' }
+      )
+    ).toEqual([]);
+  });
+
+  it('reports nothing for proxy values that normalize to the same url', () => {
+    expect(
+      getProbeEnvDivergence(
+        [httpUrl],
+        { HTTP_PROXY: 'proxy.example:8080' },
+        { HTTP_PROXY: 'http://proxy.example:8080/' }
+      )
+    ).toEqual([]);
+  });
+
+  it('names a scheme-less all_proxy that dials https through a different scheme', () => {
+    // Without a scheme the value takes the target protocol, so the https route
+    // becomes an https proxy on one side and an http proxy on the other.
+    expect(
+      getProbeEnvDivergence(
+        [httpUrl],
+        { ALL_PROXY: 'proxy.example:8080' },
+        { ALL_PROXY: 'http://proxy.example:8080' }
+      )
+    ).toEqual(['ALL_PROXY']);
+  });
+
+  it('names a no_proxy suffix entry against an exact-host one', () => {
+    // `*example.com` excludes every host ending in example.com; `example.com`
+    // only that host.
+    const proxy = { HTTP_PROXY: 'http://proxy.example:8080' };
+    expect(
+      getProbeEnvDivergence(
+        [httpUrl],
+        { ...proxy, NO_PROXY: '*example.com' },
+        { ...proxy, NO_PROXY: 'example.com' }
+      )
+    ).toEqual(['NO_PROXY']);
+  });
+
+  it('reports nothing for no_proxy entries that differ only in order, separators, or a *. prefix', () => {
+    const proxy = { HTTP_PROXY: 'http://proxy.example:8080' };
+    expect(
+      getProbeEnvDivergence(
+        [httpUrl],
+        { ...proxy, NO_PROXY: 'localhost,*.example.com' },
+        { ...proxy, NO_PROXY: '.example.com, localhost' }
+      )
+    ).toEqual([]);
+  });
+
+  it('names only the case-variant that carries the differing value', () => {
+    expect(
+      getProbeEnvDivergence(
+        [httpUrl],
+        { http_proxy: 'http://a.example:8080', HTTP_PROXY: 'same' },
+        { http_proxy: 'http://b.example:8080', HTTP_PROXY: 'same' }
+      )
+    ).toEqual(['http_proxy']);
+  });
+
+  it('names TLS material for any url probe unless every url server ignores HTTPS errors', () => {
     const taskEnv = { NODE_EXTRA_CA_CERTS: '/certs/ca.pem' };
     expect(getProbeEnvDivergence([httpsUrl], taskEnv, {})).toEqual([
       'NODE_EXTRA_CA_CERTS',
     ]);
-    expect(getProbeEnvDivergence([httpUrl], taskEnv, {})).toEqual([]);
+    // An http url can redirect to https, where the certificate is verified.
+    expect(getProbeEnvDivergence([httpUrl], taskEnv, {})).toEqual([
+      'NODE_EXTRA_CA_CERTS',
+    ]);
     expect(
       getProbeEnvDivergence(
         [{ ...httpsUrl, ignoreHTTPSErrors: true }],
@@ -148,6 +326,13 @@ describe('getProbeEnvDivergence', () => {
         {}
       )
     ).toEqual([]);
+    expect(
+      getProbeEnvDivergence(
+        [{ ...httpUrl, ignoreHTTPSErrors: true }, httpsUrl],
+        taskEnv,
+        {}
+      )
+    ).toEqual(['NODE_EXTRA_CA_CERTS']);
   });
 
   it('names NODE_TLS_REJECT_UNAUTHORIZED for an https probe', () => {
@@ -321,7 +506,10 @@ describe('forkChildEval (real fork)', () => {
   };
 
   beforeAll(() => {
-    fixtureDir = mkdtempSync(join(tmpdir(), 'pw-webserver-readiness-'));
+    // Resolved so the child's cwd (as getcwd reports it) compares equal.
+    fixtureDir = realpathSync(
+      mkdtempSync(join(tmpdir(), 'pw-webserver-readiness-'))
+    );
   });
   afterAll(() => rmSync(fixtureDir, { recursive: true, force: true }));
   afterEach(() => _setWorkerScriptPath(null));
@@ -334,8 +522,25 @@ describe('forkChildEval (real fork)', () => {
       )
     );
     await expect(
-      resolveWebServersUnderEnv('config.ts', 'root', {})
+      resolveWebServersUnderEnv('config.ts', fixtureDir, {})
     ).resolves.toEqual([{ command: 'x', url: 'http://localhost:4301' }]);
+  });
+
+  it('runs the worker from the project root, not the parent cwd', async () => {
+    // Without plugin isolation the parent is the nx CLI process, whose cwd is
+    // wherever nx was invoked; the inferred task runs from the project root.
+    _setWorkerScriptPath(
+      writeWorker(
+        'cwd.js',
+        `process.send({ type: 'webserver-config-result', webServers: [{ command: process.cwd() }] }, () => process.exit(0));`
+      )
+    );
+    const projectRoot = join(fixtureDir, 'apps', 'e2e');
+    mkdirSync(projectRoot, { recursive: true });
+    expect(projectRoot).not.toBe(process.cwd());
+    await expect(
+      resolveWebServersUnderEnv('apps/e2e/playwright.config.ts', fixtureDir, {})
+    ).resolves.toEqual([{ command: projectRoot }]);
   });
 
   it('ignores messages without the worker tag', async () => {
@@ -351,7 +556,7 @@ process.send({ type: 'webserver-config-result', webServers: [{ command: 'x', url
       )
     );
     await expect(
-      resolveWebServersUnderEnv('config.ts', 'root', {})
+      resolveWebServersUnderEnv('config.ts', fixtureDir, {})
     ).resolves.toEqual([{ command: 'x', url: 'http://localhost:4301' }]);
   });
 
@@ -365,7 +570,7 @@ process.send({ type: 'webserver-config-result', webServers: [{ command: 'x', url
       )
     );
     await expect(
-      resolveWebServersUnderEnv('config.ts', 'root', {})
+      resolveWebServersUnderEnv('config.ts', fixtureDir, {})
     ).rejects.toThrow();
   });
 
@@ -377,7 +582,7 @@ process.send({ type: 'webserver-config-result', webServers: [{ command: 'x', url
       )
     );
     await expect(
-      resolveWebServersUnderEnv('config.ts', 'root', {})
+      resolveWebServersUnderEnv('config.ts', fixtureDir, {})
     ).rejects.toThrow(/exited with code 3[\s\S]*boom-detail/);
   });
 
@@ -389,7 +594,7 @@ process.send({ type: 'webserver-config-result', webServers: [{ command: 'x', url
       _setWorkerScriptPath(
         writeWorker('hang.js', `setInterval(() => {}, 1000);`)
       );
-      const evaluation = resolveWebServersUnderEnv('config.ts', 'root', {});
+      const evaluation = resolveWebServersUnderEnv('config.ts', fixtureDir, {});
       // Attach the rejection expectation before firing the timer so the
       // rejection is never unhandled.
       const assertion = expect(evaluation).rejects.toThrow(

--- a/packages/playwright/src/plugins/webserver-readiness.spec.ts
+++ b/packages/playwright/src/plugins/webserver-readiness.spec.ts
@@ -335,6 +335,49 @@ describe('getProbeEnvDivergence', () => {
     ).toEqual(['NODE_EXTRA_CA_CERTS']);
   });
 
+  it('names TLS material behind an https proxy tunnel even when every server ignores HTTPS errors', () => {
+    const proxy = { HTTPS_PROXY: 'https://proxy.example:8443' };
+    // The tunnel to the proxy is verified with the process defaults, which
+    // `ignoreHTTPSErrors` does not reach.
+    expect(
+      getProbeEnvDivergence(
+        [{ ...httpsUrl, ignoreHTTPSErrors: true }],
+        { ...proxy, NODE_EXTRA_CA_CERTS: '/certs/proxy-ca.pem' },
+        proxy
+      )
+    ).toEqual(['NODE_EXTRA_CA_CERTS']);
+    // An http url can redirect to https and take that tunnel.
+    expect(
+      getProbeEnvDivergence(
+        [{ ...httpUrl, ignoreHTTPSErrors: true }],
+        { ...proxy, NODE_TLS_REJECT_UNAUTHORIZED: '0' },
+        proxy
+      )
+    ).toEqual(['NODE_TLS_REJECT_UNAUTHORIZED']);
+    // An http proxy needs no TLS, and an https proxy on the http route only is
+    // dialled with the request's own `rejectUnauthorized`.
+    expect(
+      getProbeEnvDivergence(
+        [{ ...httpsUrl, ignoreHTTPSErrors: true }],
+        {
+          HTTPS_PROXY: 'http://proxy.example:8080',
+          NODE_EXTRA_CA_CERTS: '/certs/proxy-ca.pem',
+        },
+        { HTTPS_PROXY: 'http://proxy.example:8080' }
+      )
+    ).toEqual([]);
+    expect(
+      getProbeEnvDivergence(
+        [{ ...httpsUrl, ignoreHTTPSErrors: true }],
+        {
+          HTTP_PROXY: 'https://proxy.example:8443',
+          NODE_EXTRA_CA_CERTS: '/certs/proxy-ca.pem',
+        },
+        { HTTP_PROXY: 'https://proxy.example:8443' }
+      )
+    ).toEqual([]);
+  });
+
   it('names NODE_TLS_REJECT_UNAUTHORIZED for an https probe', () => {
     expect(
       getProbeEnvDivergence(

--- a/packages/playwright/src/plugins/webserver-readiness.ts
+++ b/packages/playwright/src/plugins/webserver-readiness.ts
@@ -1,0 +1,143 @@
+import type { PlaywrightTestConfig } from '@playwright/test';
+import { fork } from 'node:child_process';
+import { cpus } from 'node:os';
+import { join } from 'node:path';
+
+/**
+ * The serializable subset of a Playwright `webServer` entry that the readiness
+ * gate needs. Passed back from the config-eval child over IPC.
+ */
+export interface ResolvedWebServer {
+  command: string;
+  url?: string;
+  port?: number;
+  reuseExistingServer?: boolean;
+  ignoreHTTPSErrors?: boolean;
+  timeout?: number;
+}
+
+export function normalizeWebServers(
+  webServer: PlaywrightTestConfig['webServer']
+): ResolvedWebServer[] {
+  if (!webServer) {
+    return [];
+  }
+  const servers = Array.isArray(webServer) ? webServer : [webServer];
+  return servers.map((server) => ({
+    command: server.command,
+    url: server.url,
+    port: server.port,
+    reuseExistingServer: server.reuseExistingServer,
+    ignoreHTTPSErrors: server.ignoreHTTPSErrors,
+    timeout: server.timeout,
+  }));
+}
+
+/**
+ * Whether the task env a chain would run with differs from the graph-time
+ * ambient env. Only a difference can change how the config resolves, so an
+ * identical env skips the (expensive) child evaluation entirely.
+ */
+export function taskEnvDivergesFromAmbient(
+  taskEnv: NodeJS.ProcessEnv
+): boolean {
+  const keys = new Set([...Object.keys(process.env), ...Object.keys(taskEnv)]);
+  for (const key of keys) {
+    if (process.env[key] !== taskEnv[key]) {
+      return true;
+    }
+  }
+  return false;
+}
+
+type ChildEval = (
+  configFilePath: string,
+  workspaceRoot: string,
+  env: NodeJS.ProcessEnv
+) => Promise<ResolvedWebServer[]>;
+
+// A forked config evaluation holds a full config module graph in memory
+// (hundreds of MB for a large config), so cap how many run at once.
+const MAX_CONCURRENT_EVALS = Math.max(1, Math.min(cpus().length, 8));
+const CHILD_EVAL_TIMEOUT = 30_000;
+
+let activeEvals = 0;
+const evalQueue: Array<() => void> = [];
+let childEval: ChildEval = forkChildEval;
+
+/**
+ * Evaluates `configFilePath`'s `webServer` addresses under `taskEnv`, bounded by
+ * the concurrency cap. Used only when the env diverges from ambient.
+ */
+export async function resolveWebServersUnderEnv(
+  configFilePath: string,
+  workspaceRoot: string,
+  taskEnv: NodeJS.ProcessEnv
+): Promise<ResolvedWebServer[]> {
+  if (activeEvals >= MAX_CONCURRENT_EVALS) {
+    await new Promise<void>((resolve) => evalQueue.push(resolve));
+  }
+  activeEvals++;
+  try {
+    return await childEval(configFilePath, workspaceRoot, taskEnv);
+  } finally {
+    activeEvals--;
+    evalQueue.shift()?.();
+  }
+}
+
+function forkChildEval(
+  configFilePath: string,
+  workspaceRoot: string,
+  env: NodeJS.ProcessEnv
+): Promise<ResolvedWebServer[]> {
+  return new Promise((resolve, reject) => {
+    const child = fork(
+      join(__dirname, 'webserver-config-worker.js'),
+      [configFilePath, workspaceRoot],
+      { env, stdio: ['ignore', 'ignore', 'ignore', 'ipc'] }
+    );
+    let settled = false;
+    const finish = (fn: () => void) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      child.removeAllListeners();
+      if (child.connected) {
+        child.disconnect();
+      }
+      fn();
+    };
+    const timer = setTimeout(() => {
+      child.kill();
+      finish(() =>
+        reject(new Error('Timed out evaluating the Playwright config'))
+      );
+    }, CHILD_EVAL_TIMEOUT);
+
+    child.on('message', (message: ResolvedWebServer[] | { error: string }) => {
+      if (!Array.isArray(message) && message?.error) {
+        finish(() => reject(new Error(message.error)));
+      } else {
+        finish(() => resolve(message as ResolvedWebServer[]));
+      }
+    });
+    child.on('error', (error) => finish(() => reject(error)));
+    child.on('exit', (code) => {
+      if (code !== 0) {
+        finish(() =>
+          reject(new Error(`Config evaluation worker exited with code ${code}`))
+        );
+      }
+    });
+  });
+}
+
+// Test seam: the fork cannot run inside the unit test harness (the worker is
+// only compiled in dist). Tests replace it with an in-process evaluation, which
+// is safe there because the harness evaluates a single config at a time.
+export function _setChildEval(impl: ChildEval | null): void {
+  childEval = impl ?? forkChildEval;
+}

--- a/packages/playwright/src/plugins/webserver-readiness.ts
+++ b/packages/playwright/src/plugins/webserver-readiness.ts
@@ -92,7 +92,10 @@ export async function resolveWebServersUnderEnv(
   workspaceRoot: string,
   taskEnv: NodeJS.ProcessEnv
 ): Promise<ResolvedWebServer[]> {
-  if (activeEvals >= MAX_CONCURRENT_EVALS) {
+  // `while` rather than `if`: a caller arriving between a slot's release and
+  // the woken waiter's resume can claim the slot first, so the waiter must
+  // re-check before taking it.
+  while (activeEvals >= MAX_CONCURRENT_EVALS) {
     await new Promise<void>((resolve) => evalQueue.push(resolve));
   }
   activeEvals++;

--- a/packages/playwright/src/plugins/webserver-readiness.ts
+++ b/packages/playwright/src/plugins/webserver-readiness.ts
@@ -14,6 +14,9 @@ export interface ResolvedWebServer {
   reuseExistingServer?: boolean;
   ignoreHTTPSErrors?: boolean;
   timeout?: number;
+  // `wait.stdout`/`wait.stderr` presence projected to a boolean: the RegExp
+  // values do not survive the JSON IPC channel.
+  waitsForOutput?: boolean;
 }
 
 export function normalizeWebServers(
@@ -30,6 +33,8 @@ export function normalizeWebServers(
     reuseExistingServer: server.reuseExistingServer,
     ignoreHTTPSErrors: server.ignoreHTTPSErrors,
     timeout: server.timeout,
+    waitsForOutput:
+      server.wait?.stdout || server.wait?.stderr ? true : undefined,
   }));
 }
 
@@ -49,6 +54,16 @@ export function taskEnvDivergesFromAmbient(
   }
   return false;
 }
+
+/**
+ * The messages the config-eval worker sends over IPC. Tagged so the parent can
+ * tell them apart from anything else on the channel: the user's config module
+ * runs in the child and can itself call `process.send` during evaluation, and
+ * such a message must not settle the resolution.
+ */
+export type WebserverConfigWorkerMessage =
+  | { type: 'webserver-config-result'; webServers: ResolvedWebServer[] }
+  | { type: 'webserver-config-error'; error: string };
 
 type ChildEval = (
   configFilePath: string,
@@ -126,7 +141,9 @@ function forkChildEval(
       fn();
     };
     const timer = setTimeout(() => {
-      child.kill();
+      // SIGKILL: the eval child holds no state that needs graceful teardown,
+      // and a config stuck in a busy loop would ignore SIGTERM anyway.
+      child.kill('SIGKILL');
       finish(() =>
         reject(
           new Error(withStderr('Timed out evaluating the Playwright config'))
@@ -134,12 +151,19 @@ function forkChildEval(
       );
     }, CHILD_EVAL_TIMEOUT);
 
-    child.on('message', (message: ResolvedWebServer[] | { error: string }) => {
-      if (!Array.isArray(message) && message && 'error' in message) {
-        finish(() => reject(new Error(withStderr(message.error))));
-      } else {
-        finish(() => resolve(message as ResolvedWebServer[]));
+    child.on('message', (message: WebserverConfigWorkerMessage) => {
+      if (typeof message !== 'object' || message === null) {
+        return;
       }
+      if (message.type === 'webserver-config-error') {
+        finish(() => reject(new Error(withStderr(message.error))));
+      } else if (
+        message.type === 'webserver-config-result' &&
+        Array.isArray(message.webServers)
+      ) {
+        finish(() => resolve(message.webServers));
+      }
+      // Anything else came from the evaluated config itself; ignore it.
     });
     child.on('error', (error) => finish(() => reject(error)));
     // `close` rather than `exit` so the stderr the failure folds in has fully
@@ -162,9 +186,10 @@ function forkChildEval(
   });
 }
 
-// Test seam: the fork cannot run inside the unit test harness (the worker is
-// only compiled in dist). Tests replace it with an in-process evaluation, which
-// is safe there because the harness evaluates a single config at a time.
+// Test seam: plugin unit tests replace the fork with an in-process evaluation
+// (the compiled worker only exists in dist) and concurrency tests use it to
+// control completion order. The fork itself is exercised against fixture
+// workers via _setWorkerScriptPath below.
 export function _setChildEval(impl: ChildEval | null): void {
   childEval = impl ?? forkChildEval;
 }

--- a/packages/playwright/src/plugins/webserver-readiness.ts
+++ b/packages/playwright/src/plugins/webserver-readiness.ts
@@ -56,14 +56,17 @@ type ChildEval = (
   env: NodeJS.ProcessEnv
 ) => Promise<ResolvedWebServer[]>;
 
-// A forked config evaluation holds a full config module graph in memory
-// (hundreds of MB for a large config), so cap how many run at once.
+// A forked config evaluation holds a full config module graph in memory, so cap
+// how many run at once.
 const MAX_CONCURRENT_EVALS = Math.max(1, Math.min(cpus().length, 8));
 const CHILD_EVAL_TIMEOUT = 30_000;
+// Cap the worker stderr buffered to fold into a failure message.
+const MAX_STDERR = 8192;
 
 let activeEvals = 0;
 const evalQueue: Array<() => void> = [];
 let childEval: ChildEval = forkChildEval;
+let workerScriptPath = join(__dirname, 'webserver-config-worker.js');
 
 /**
  * Evaluates `configFilePath`'s `webServer` addresses under `taskEnv`, bounded by
@@ -92,11 +95,23 @@ function forkChildEval(
   env: NodeJS.ProcessEnv
 ): Promise<ResolvedWebServer[]> {
   return new Promise((resolve, reject) => {
-    const child = fork(
-      join(__dirname, 'webserver-config-worker.js'),
-      [configFilePath, workspaceRoot],
-      { env, stdio: ['ignore', 'ignore', 'ignore', 'ipc'] }
-    );
+    const child = fork(workerScriptPath, [configFilePath, workspaceRoot], {
+      env,
+      stdio: ['ignore', 'ignore', 'pipe', 'ipc'],
+    });
+    let stderr = '';
+    child.stderr?.on('data', (chunk: Buffer) => {
+      if (stderr.length < MAX_STDERR) {
+        stderr += chunk.toString().slice(0, MAX_STDERR - stderr.length);
+      }
+    });
+    // Fold the worker's stderr into a failure so a crash before it can report
+    // over IPC (a missing module, a syntax error, a signal kill) is not
+    // surfaced as a bare exit code.
+    const withStderr = (message: string) => {
+      const tail = stderr.trim();
+      return tail ? `${message}\n${tail}` : message;
+    };
     let settled = false;
     const finish = (fn: () => void) => {
       if (settled) {
@@ -113,24 +128,36 @@ function forkChildEval(
     const timer = setTimeout(() => {
       child.kill();
       finish(() =>
-        reject(new Error('Timed out evaluating the Playwright config'))
+        reject(
+          new Error(withStderr('Timed out evaluating the Playwright config'))
+        )
       );
     }, CHILD_EVAL_TIMEOUT);
 
     child.on('message', (message: ResolvedWebServer[] | { error: string }) => {
-      if (!Array.isArray(message) && message?.error) {
-        finish(() => reject(new Error(message.error)));
+      if (!Array.isArray(message) && message && 'error' in message) {
+        finish(() => reject(new Error(withStderr(message.error))));
       } else {
         finish(() => resolve(message as ResolvedWebServer[]));
       }
     });
     child.on('error', (error) => finish(() => reject(error)));
-    child.on('exit', (code) => {
-      if (code !== 0) {
-        finish(() =>
-          reject(new Error(`Config evaluation worker exited with code ${code}`))
-        );
-      }
+    // `close` rather than `exit` so the stderr the failure folds in has fully
+    // flushed before the message is built. A worker that closes before sending a
+    // result (even with code 0, e.g. an IPC delivery failure) rejects here
+    // rather than hanging to the timeout; finish() no-ops once a result settled.
+    child.on('close', (code) => {
+      finish(() =>
+        reject(
+          new Error(
+            withStderr(
+              code
+                ? `Config evaluation worker exited with code ${code}`
+                : 'Config evaluation worker exited without resolving the web server address'
+            )
+          )
+        )
+      );
     });
   });
 }
@@ -140,4 +167,10 @@ function forkChildEval(
 // is safe there because the harness evaluates a single config at a time.
 export function _setChildEval(impl: ChildEval | null): void {
   childEval = impl ?? forkChildEval;
+}
+
+// Test seam: point the fork at a fixture worker so forkChildEval's own timeout,
+// exit and stderr handling can be exercised without the compiled worker.
+export function _setWorkerScriptPath(path: string | null): void {
+  workerScriptPath = path ?? join(__dirname, 'webserver-config-worker.js');
 }

--- a/packages/playwright/src/plugins/webserver-readiness.ts
+++ b/packages/playwright/src/plugins/webserver-readiness.ts
@@ -2,6 +2,7 @@ import type { PlaywrightTestConfig } from '@playwright/test';
 import { fork } from 'node:child_process';
 import { cpus } from 'node:os';
 import { join } from 'node:path';
+import { resolveProxyForUrl } from '../executors/wait-for-webserver/proxy';
 
 /**
  * The serializable subset of a Playwright `webServer` entry that the readiness
@@ -17,6 +18,9 @@ export interface ResolvedWebServer {
   // `wait.stdout`/`wait.stderr` presence projected to a boolean: the RegExp
   // values do not survive the JSON IPC channel.
   waitsForOutput?: boolean;
+  // Non-empty `env` presence. Only Playwright can launch such a command with
+  // its environment, so the values themselves are not needed.
+  hasEnv?: boolean;
 }
 
 export function normalizeWebServers(
@@ -35,7 +39,69 @@ export function normalizeWebServers(
     timeout: server.timeout,
     waitsForOutput:
       server.wait?.stdout || server.wait?.stderr ? true : undefined,
+    hasEnv: server.env && Object.keys(server.env).length > 0 ? true : undefined,
   }));
+}
+
+// The TLS material Node reads when a probe verifies an https certificate.
+const TLS_PROBE_VARS = ['NODE_EXTRA_CA_CERTS', 'NODE_TLS_REJECT_UNAUTHORIZED'];
+
+/**
+ * The env var names whose task-env values would make the readiness gate probe
+ * `servers` differently than the consuming task's own Playwright probe. The
+ * gate runs as its own target, so it loads its own dotenv files, not the
+ * consumer's: a task-scoped proxy exclusion or CA bundle never reaches it, and
+ * a gate probing through the wrong route can fail where Playwright would pass.
+ * A non-empty result means the gate cannot reproduce the task's probe and must
+ * not be inferred.
+ *
+ * Proxy env is compared as the effective routing decision per url (an
+ * `https_proxy` that differs cannot change how an http url is probed); TLS env
+ * only for a verifying https probe (`ignoreHTTPSErrors` turns verification off
+ * on both sides). Like the executor's own up-front validation, only the
+ * address the wait starts from is considered, not addresses a redirect could
+ * reach.
+ */
+export function getProbeEnvDivergence(
+  servers: Array<{ url?: string; ignoreHTTPSErrors?: boolean }>,
+  taskEnv: NodeJS.ProcessEnv,
+  ambientEnv: NodeJS.ProcessEnv = process.env
+): string[] {
+  const diverging = new Set<string>();
+  for (const server of servers) {
+    // A port is probed with a raw TCP connect; no env is involved.
+    if (!server.url) {
+      continue;
+    }
+    let url: URL;
+    try {
+      url = new URL(server.url);
+    } catch {
+      // The executor rejects a malformed url up front; env plays no part.
+      continue;
+    }
+    const protocol = url.protocol.split(':')[0];
+    if (
+      JSON.stringify(resolveProxyForUrl(url, taskEnv)) !==
+      JSON.stringify(resolveProxyForUrl(url, ambientEnv))
+    ) {
+      for (const name of [`${protocol}_proxy`, 'all_proxy', 'no_proxy']) {
+        for (const variable of [name.toLowerCase(), name.toUpperCase()]) {
+          if (taskEnv[variable] !== ambientEnv[variable]) {
+            diverging.add(variable);
+          }
+        }
+      }
+    }
+    if (url.protocol === 'https:' && !server.ignoreHTTPSErrors) {
+      for (const variable of TLS_PROBE_VARS) {
+        if (taskEnv[variable] !== ambientEnv[variable]) {
+          diverging.add(variable);
+        }
+      }
+    }
+  }
+  return [...diverging].sort();
 }
 
 /**

--- a/packages/playwright/src/plugins/webserver-readiness.ts
+++ b/packages/playwright/src/plugins/webserver-readiness.ts
@@ -113,9 +113,14 @@ function isWorkerMessage(
   if (typeof message !== 'object' || message === null) {
     return false;
   }
-  const candidate = message as { type?: unknown; webServers?: unknown };
+  const candidate = message as {
+    type?: unknown;
+    error?: unknown;
+    webServers?: unknown;
+  };
   return (
-    candidate.type === 'webserver-config-error' ||
+    (candidate.type === 'webserver-config-error' &&
+      typeof candidate.error === 'string') ||
     (candidate.type === 'webserver-config-result' &&
       Array.isArray(candidate.webServers))
   );

--- a/packages/playwright/src/plugins/webserver-readiness.ts
+++ b/packages/playwright/src/plugins/webserver-readiness.ts
@@ -107,6 +107,20 @@ export async function resolveWebServersUnderEnv(
   }
 }
 
+function isWorkerMessage(
+  message: unknown
+): message is WebserverConfigWorkerMessage {
+  if (typeof message !== 'object' || message === null) {
+    return false;
+  }
+  const candidate = message as { type?: unknown; webServers?: unknown };
+  return (
+    candidate.type === 'webserver-config-error' ||
+    (candidate.type === 'webserver-config-result' &&
+      Array.isArray(candidate.webServers))
+  );
+}
+
 function forkChildEval(
   configFilePath: string,
   workspaceRoot: string,
@@ -154,19 +168,27 @@ function forkChildEval(
       );
     }, CHILD_EVAL_TIMEOUT);
 
-    child.on('message', (message: WebserverConfigWorkerMessage) => {
-      if (typeof message !== 'object' || message === null) {
+    child.on('message', (message: unknown) => {
+      // Anything that fails the guard came from the evaluated config itself;
+      // ignore it.
+      if (!isWorkerMessage(message)) {
         return;
       }
-      if (message.type === 'webserver-config-error') {
-        finish(() => reject(new Error(withStderr(message.error))));
-      } else if (
-        message.type === 'webserver-config-result' &&
-        Array.isArray(message.webServers)
-      ) {
-        finish(() => resolve(message.webServers));
+      switch (message.type) {
+        case 'webserver-config-error':
+          finish(() => reject(new Error(withStderr(message.error))));
+          break;
+        case 'webserver-config-result':
+          finish(() => resolve(message.webServers));
+          break;
+        default: {
+          // A new message variant has to say how it settles the resolution.
+          const unhandled: never = message;
+          throw new Error(
+            `Unhandled worker message ${JSON.stringify(unhandled)}`
+          );
+        }
       }
-      // Anything else came from the evaluated config itself; ignore it.
     });
     child.on('error', (error) => finish(() => reject(error)));
     // `close` rather than `exit` so the stderr the failure folds in has fully

--- a/packages/playwright/src/plugins/webserver-readiness.ts
+++ b/packages/playwright/src/plugins/webserver-readiness.ts
@@ -90,19 +90,23 @@ export interface ConfigEvaluation {
 let inProcessLoad: Promise<void> = Promise.resolve();
 
 /**
- * Loads a Playwright config in this process and returns it with the probe env
- * its evaluation left in `process.env`, then puts `process.env` back the way
- * it was: the task and gate dotenv files expand against it, and a later env
- * comparison has to see the graph-time env, not whatever the last config
- * wrote. Loads are serialized because createNodes evaluates configs
- * concurrently and a concurrent load's writes would be misattributed. A
- * client env applied mid-load (the daemon forwards it as it arrives) is
+ * Loads a Playwright config in this process, hands it to `consume`, and
+ * returns the consumed value with the probe env the evaluation left in
+ * `process.env`, then puts `process.env` back the way it was: the task and
+ * gate dotenv files expand against it, and a later env comparison has to see
+ * the graph-time env, not whatever the last config wrote. `consume` must be
+ * synchronous and must not let the config object escape: a config can expose
+ * getters that read env it set while loading, so every read has to happen
+ * before the restore. Loads are serialized because createNodes evaluates
+ * configs concurrently and a concurrent load's writes would be misattributed.
+ * A client env applied mid-load (the daemon forwards it as it arrives) is
  * re-applied over the restored env; restoring the pre-load values alone would
  * revert it.
  */
-export async function loadConfigWithProbeEnv<T extends object>(
-  configPath: string
-): Promise<{ config: T; probeEnv: ProbeEnv }> {
+export async function loadConfigWithProbeEnv<T extends object, R>(
+  configPath: string,
+  consume: (config: T) => R
+): Promise<{ consumed: R; probeEnv: ProbeEnv }> {
   const previous = inProcessLoad;
   let release: () => void;
   inProcessLoad = new Promise<void>((resolve) => (release = resolve));
@@ -112,7 +116,7 @@ export async function loadConfigWithProbeEnv<T extends object>(
     const before = { ...process.env };
     try {
       const config = await loadConfigFile<T>(configPath);
-      return { config, probeEnv: pickProbeEnv(process.env) };
+      return { consumed: consume(config), probeEnv: pickProbeEnv(process.env) };
     } finally {
       restoreEnv(before);
       const applied = getAppliedDaemonClientEnv();

--- a/packages/playwright/src/plugins/webserver-readiness.ts
+++ b/packages/playwright/src/plugins/webserver-readiness.ts
@@ -53,10 +53,19 @@ export function normalizeWebServers(
 
 // The TLS material Node reads when a probe verifies an https certificate.
 const TLS_PROBE_VARS = ['NODE_EXTRA_CA_CERTS', 'NODE_TLS_REJECT_UNAUTHORIZED'];
-// Every variable a url probe reads to route and verify a request, in both
-// spellings the proxy resolution accepts.
+// The variables a url probe routes a request by, in both spellings the proxy
+// resolution accepts.
+const ROUTE_VARS = ['http_proxy', 'https_proxy', 'all_proxy', 'no_proxy'];
+// The npm-exported ones a Playwright below 1.59.0 reads ahead of them.
+const NPM_CONFIG_ROUTE_VARS = [
+  'npm_config_http_proxy',
+  'npm_config_https_proxy',
+  'npm_config_proxy',
+  'npm_config_no_proxy',
+];
+// Every variable a url probe reads to route and verify a request.
 const PROBE_ENV_VARS = [
-  ...['http_proxy', 'https_proxy', 'all_proxy', 'no_proxy'].flatMap((name) => [
+  ...[...ROUTE_VARS, ...NPM_CONFIG_ROUTE_VARS].flatMap((name) => [
     name,
     name.toUpperCase(),
   ]),
@@ -156,17 +165,21 @@ function restoreEnv(snapshot: NodeJS.ProcessEnv): void {
  * The routes a probe under `env` can take, read as the executor's proxy
  * resolution reads them: the proxy for each protocol a redirect can reach
  * (`<protocol>_proxy`, falling back to `all_proxy`, normalized as it would be
- * dialled) and the `no_proxy` filter as its set of entries. A `no_proxy` that
- * excludes every host, or no proxy at all, sends every hop direct, so both
- * collapse to empty routes and a masked variable never counts as a difference.
+ * dialled) and the `no_proxy` filter as its set of entries, the `npm_config_*`
+ * variables included with `npmConfigProxy`. A `no_proxy` that excludes every
+ * host, or no proxy at all, sends every hop direct, so both collapse to empty
+ * routes and a masked variable never counts as a difference.
  */
-function proxyRoutes(env: NodeJS.ProcessEnv): {
+function proxyRoutes(
+  env: NodeJS.ProcessEnv,
+  npmConfigProxy: boolean
+): {
   http: string;
   https: string;
   no_proxy: string;
 } {
   const route = (protocol: string) => {
-    const resolution = resolveProxyForProtocol(protocol, env);
+    const resolution = resolveProxyForProtocol(protocol, env, npmConfigProxy);
     switch (resolution.kind) {
       case 'direct':
         return '';
@@ -187,7 +200,11 @@ function proxyRoutes(env: NodeJS.ProcessEnv): {
   // `*host` (any suffix) and `host` (exact) are not. A bare `*` excludes every
   // host.
   const entries = [
-    ...new Set(noProxyEntries(env).map((entry) => entry.replace(/^\*\./, '.'))),
+    ...new Set(
+      noProxyEntries(env, npmConfigProxy).map((entry) =>
+        entry.replace(/^\*\./, '.')
+      )
+    ),
   ].sort();
   if (entries.includes('*') || !(http || https)) {
     return { http: '', https: '', no_proxy: '' };
@@ -220,13 +237,17 @@ function proxyRoutes(env: NodeJS.ProcessEnv): {
  * https proxy on the http route, and no `no_proxy` entry that could send a
  * redirect target direct. `NODE_TLS_REJECT_UNAUTHORIZED` only reaches that
  * tunnel to an https proxy, since every request sets `rejectUnauthorized`
- * itself, and only its `'0'` state counts.
+ * itself, and only its `'0'` state counts. With `npmConfigProxy` (an installed
+ * Playwright below 1.59.0, whose probe reads npm's `npm_config_*` proxy
+ * variables ahead of the standard ones, as the gate does on that version) those
+ * variables route the probe and are compared too.
  */
 export function getProbeEnvDivergence(
   servers: Array<{ url?: string; ignoreHTTPSErrors?: boolean }>,
   taskEnv: NodeJS.ProcessEnv,
   gateEnv: NodeJS.ProcessEnv,
-  legacyProxiedTls = false
+  legacyProxiedTls = false,
+  npmConfigProxy = false
 ): string[] {
   // A port is probed with a raw TCP connect, and the executor rejects a
   // malformed url up front; env plays no part in either.
@@ -237,16 +258,19 @@ export function getProbeEnvDivergence(
     return [];
   }
   const diverging = new Set<string>();
-  const taskRoutes = proxyRoutes(taskEnv);
-  const gateRoutes = proxyRoutes(gateEnv);
+  const taskRoutes = proxyRoutes(taskEnv, npmConfigProxy);
+  const gateRoutes = proxyRoutes(gateEnv, npmConfigProxy);
   // Name the raw variables behind a differing route. A proxy route is decided
   // by every proxy variable (`no_proxy` can mask them all); the filter only by
   // `no_proxy`.
+  const readVars = npmConfigProxy
+    ? [...ROUTE_VARS, ...NPM_CONFIG_ROUTE_VARS]
+    : ROUTE_VARS;
   const routeVars =
     taskRoutes.http !== gateRoutes.http || taskRoutes.https !== gateRoutes.https
-      ? ['http_proxy', 'https_proxy', 'all_proxy', 'no_proxy']
+      ? readVars
       : taskRoutes.no_proxy !== gateRoutes.no_proxy
-        ? ['no_proxy']
+        ? readVars.filter((name) => name.endsWith('no_proxy'))
         : [];
   for (const name of routeVars) {
     for (const variable of [name, name.toUpperCase()]) {

--- a/packages/playwright/src/plugins/webserver-readiness.ts
+++ b/packages/playwright/src/plugins/webserver-readiness.ts
@@ -106,7 +106,8 @@ function proxyRoutes(env: NodeJS.ProcessEnv): {
  * configured url takes: an `https_proxy` for an http url or a `no_proxy` entry
  * for another host can still decide how a redirect target is reached. TLS env
  * is compared unless every url server sets `ignoreHTTPSErrors`, which turns
- * verification off on both sides for every hop.
+ * verification off on both sides for every hop, except that the tunnel to an
+ * https proxy is verified with the process defaults either way.
  */
 export function getProbeEnvDivergence(
   servers: Array<{ url?: string; ignoreHTTPSErrors?: boolean }>,
@@ -141,7 +142,17 @@ export function getProbeEnvDivergence(
       }
     }
   }
-  if (urlServers.some((server) => !server.ignoreHTTPSErrors)) {
+  // `ignoreHTTPSErrors` reaches the target's certificate only. An https target
+  // is tunnelled through an https proxy over a TLS connection the proxy agent
+  // opens with the process defaults, on both sides, so that certificate is
+  // verified regardless.
+  const tunnelsThroughTlsProxy = [taskRoutes.https, ambientRoutes.https].some(
+    (route) => route.startsWith('https:')
+  );
+  if (
+    tunnelsThroughTlsProxy ||
+    urlServers.some((server) => !server.ignoreHTTPSErrors)
+  ) {
     for (const variable of TLS_PROBE_VARS) {
       if (taskEnv[variable] !== ambientEnv[variable]) {
         diverging.add(variable);

--- a/packages/playwright/src/plugins/webserver-readiness.ts
+++ b/packages/playwright/src/plugins/webserver-readiness.ts
@@ -1,8 +1,11 @@
 import type { PlaywrightTestConfig } from '@playwright/test';
 import { fork } from 'node:child_process';
 import { cpus } from 'node:os';
-import { join } from 'node:path';
-import { resolveProxyForUrl } from '../executors/wait-for-webserver/proxy';
+import { dirname, join } from 'node:path';
+import {
+  noProxyEntries,
+  resolveProxyForProtocol,
+} from '../executors/wait-for-webserver/proxy';
 
 /**
  * The serializable subset of a Playwright `webServer` entry that the readiness
@@ -47,6 +50,49 @@ export function normalizeWebServers(
 const TLS_PROBE_VARS = ['NODE_EXTRA_CA_CERTS', 'NODE_TLS_REJECT_UNAUTHORIZED'];
 
 /**
+ * The routes a probe under `env` can take, read as the executor's proxy
+ * resolution reads them: the proxy for each protocol a redirect can reach
+ * (`<protocol>_proxy`, falling back to `all_proxy`, normalized as it would be
+ * dialled) and the `no_proxy` filter as its set of entries. A `no_proxy` that
+ * excludes every host, or no proxy at all, sends every hop direct, so both
+ * collapse to empty routes and a masked variable never counts as a difference.
+ */
+function proxyRoutes(env: NodeJS.ProcessEnv): {
+  http: string;
+  https: string;
+  no_proxy: string;
+} {
+  const route = (protocol: string) => {
+    const resolution = resolveProxyForProtocol(protocol, env);
+    switch (resolution.kind) {
+      case 'direct':
+        return '';
+      case 'proxy':
+        return resolution.proxy.href;
+      case 'unusable':
+        return `unusable ${resolution.value}`;
+      default: {
+        const unhandled: never = resolution;
+        throw new Error(`Unhandled resolution ${JSON.stringify(unhandled)}`);
+      }
+    }
+  };
+  const http = route('http');
+  const https = route('https');
+  // Entries exclude hosts independently, so a differing order or separator is
+  // not a difference. `*.host` and `.host` are the same suffix match, whereas
+  // `*host` (any suffix) and `host` (exact) are not. A bare `*` excludes every
+  // host.
+  const entries = [
+    ...new Set(noProxyEntries(env).map((entry) => entry.replace(/^\*\./, '.'))),
+  ].sort();
+  if (entries.includes('*') || !(http || https)) {
+    return { http: '', https: '', no_proxy: '' };
+  }
+  return { http, https, no_proxy: entries.join(',') };
+}
+
+/**
  * The env var names whose task-env values would make the readiness gate probe
  * `servers` differently than the consuming task's own Playwright probe. The
  * gate runs as its own target, so it loads its own dotenv files, not the
@@ -55,49 +101,50 @@ const TLS_PROBE_VARS = ['NODE_EXTRA_CA_CERTS', 'NODE_TLS_REJECT_UNAUTHORIZED'];
  * A non-empty result means the gate cannot reproduce the task's probe and must
  * not be inferred.
  *
- * Proxy env is compared as the effective routing decision per url (an
- * `https_proxy` that differs cannot change how an http url is probed); TLS env
- * only for a verifying https probe (`ignoreHTTPSErrors` turns verification off
- * on both sides). Like the executor's own up-front validation, only the
- * address the wait starts from is considered, not addresses a redirect could
- * reach.
+ * Both probes follow redirects, so as soon as one server probes a url the
+ * routes for every protocol and host are compared, not only the route the
+ * configured url takes: an `https_proxy` for an http url or a `no_proxy` entry
+ * for another host can still decide how a redirect target is reached. TLS env
+ * is compared unless every url server sets `ignoreHTTPSErrors`, which turns
+ * verification off on both sides for every hop.
  */
 export function getProbeEnvDivergence(
   servers: Array<{ url?: string; ignoreHTTPSErrors?: boolean }>,
   taskEnv: NodeJS.ProcessEnv,
   ambientEnv: NodeJS.ProcessEnv = process.env
 ): string[] {
+  // A port is probed with a raw TCP connect, and the executor rejects a
+  // malformed url up front; env plays no part in either.
+  const urlServers = servers.filter(
+    (server) => server.url && URL.canParse(server.url)
+  );
+  if (urlServers.length === 0) {
+    return [];
+  }
   const diverging = new Set<string>();
-  for (const server of servers) {
-    // A port is probed with a raw TCP connect; no env is involved.
-    if (!server.url) {
-      continue;
-    }
-    let url: URL;
-    try {
-      url = new URL(server.url);
-    } catch {
-      // The executor rejects a malformed url up front; env plays no part.
-      continue;
-    }
-    const protocol = url.protocol.split(':')[0];
-    if (
-      JSON.stringify(resolveProxyForUrl(url, taskEnv)) !==
-      JSON.stringify(resolveProxyForUrl(url, ambientEnv))
-    ) {
-      for (const name of [`${protocol}_proxy`, 'all_proxy', 'no_proxy']) {
-        for (const variable of [name.toLowerCase(), name.toUpperCase()]) {
-          if (taskEnv[variable] !== ambientEnv[variable]) {
-            diverging.add(variable);
-          }
-        }
+  const taskRoutes = proxyRoutes(taskEnv);
+  const ambientRoutes = proxyRoutes(ambientEnv);
+  // Name the raw variables behind a differing route. A proxy route is decided
+  // by every proxy variable (`no_proxy` can mask them all); the filter only by
+  // `no_proxy`.
+  const routeVars =
+    taskRoutes.http !== ambientRoutes.http ||
+    taskRoutes.https !== ambientRoutes.https
+      ? ['http_proxy', 'https_proxy', 'all_proxy', 'no_proxy']
+      : taskRoutes.no_proxy !== ambientRoutes.no_proxy
+        ? ['no_proxy']
+        : [];
+  for (const name of routeVars) {
+    for (const variable of [name, name.toUpperCase()]) {
+      if (taskEnv[variable] !== ambientEnv[variable]) {
+        diverging.add(variable);
       }
     }
-    if (url.protocol === 'https:' && !server.ignoreHTTPSErrors) {
-      for (const variable of TLS_PROBE_VARS) {
-        if (taskEnv[variable] !== ambientEnv[variable]) {
-          diverging.add(variable);
-        }
+  }
+  if (urlServers.some((server) => !server.ignoreHTTPSErrors)) {
+    for (const variable of TLS_PROBE_VARS) {
+      if (taskEnv[variable] !== ambientEnv[variable]) {
+        diverging.add(variable);
       }
     }
   }
@@ -198,7 +245,12 @@ function forkChildEval(
   env: NodeJS.ProcessEnv
 ): Promise<ResolvedWebServer[]> {
   return new Promise((resolve, reject) => {
+    // Startup env and project-root cwd mirror the inferred task, which runs
+    // `playwright test` from the project root: a NODE_OPTIONS loader runs at
+    // process start and resolves a relative path from there, whichever
+    // directory nx was invoked from.
     const child = fork(workerScriptPath, [configFilePath, workspaceRoot], {
+      cwd: join(workspaceRoot, dirname(configFilePath)),
       env,
       stdio: ['ignore', 'ignore', 'pipe', 'ipc'],
     });

--- a/packages/playwright/src/plugins/webserver-readiness.ts
+++ b/packages/playwright/src/plugins/webserver-readiness.ts
@@ -102,11 +102,17 @@ let inProcessLoad: Promise<void> = Promise.resolve();
  * A client env applied mid-load (the daemon forwards it as it arrives) is
  * re-applied over the restored env; restoring the pre-load values alone would
  * revert it.
+ *
+ * `ambientEnv` is a snapshot of the restored env, taken while still holding
+ * the load lock. Task-env reconstruction and comparison after this returns
+ * must base on it rather than on the live `process.env`: the lock is released
+ * on return, so a sibling load's transient writes can be visible in the live
+ * env by then and would be read as ambient.
  */
 export async function loadConfigWithProbeEnv<T extends object, R>(
   configPath: string,
   consume: (config: T) => R
-): Promise<{ consumed: R; probeEnv: ProbeEnv }> {
+): Promise<{ consumed: R; probeEnv: ProbeEnv; ambientEnv: NodeJS.ProcessEnv }> {
   const previous = inProcessLoad;
   let release: () => void;
   inProcessLoad = new Promise<void>((resolve) => (release = resolve));
@@ -114,9 +120,12 @@ export async function loadConfigWithProbeEnv<T extends object, R>(
   try {
     const applySequence = getAppliedDaemonClientEnv()?.sequence;
     const before = { ...process.env };
+    let consumed: R;
+    let probeEnv: ProbeEnv;
     try {
       const config = await loadConfigFile<T>(configPath);
-      return { consumed: consume(config), probeEnv: pickProbeEnv(process.env) };
+      consumed = consume(config);
+      probeEnv = pickProbeEnv(process.env);
     } finally {
       restoreEnv(before);
       const applied = getAppliedDaemonClientEnv();
@@ -124,6 +133,7 @@ export async function loadConfigWithProbeEnv<T extends object, R>(
         applyDaemonEnvFromClient(applied.env);
       }
     }
+    return { consumed, probeEnv, ambientEnv: { ...process.env } };
   } finally {
     release();
   }
@@ -199,15 +209,24 @@ function proxyRoutes(env: NodeJS.ProcessEnv): {
  * Both probes follow redirects, so as soon as one server probes a url the
  * routes for every protocol and host are compared, not only the route the
  * configured url takes: an `https_proxy` for an http url or a `no_proxy` entry
- * for another host can still decide how a redirect target is reached. TLS env
- * is compared unless every url server sets `ignoreHTTPSErrors`, which turns
- * verification off on both sides for every hop, except that the tunnel to an
- * https proxy is verified with the process defaults either way.
+ * for another host can still decide how a redirect target is reached.
+ * `NODE_EXTRA_CA_CERTS` is compared unless every url server sets
+ * `ignoreHTTPSErrors`, which turns verification off on both sides for every
+ * hop, except that the tunnel to an https proxy is verified with the process
+ * defaults either way. With `legacyProxiedTls` (an installed Playwright below
+ * 1.59.0, whose probe never verifies the origin behind a proxy tunnel, and
+ * neither does the gate on that version) it is also left out while every
+ * https hop can only take such a tunnel: an http proxy on the https route, no
+ * https proxy on the http route, and no `no_proxy` entry that could send a
+ * redirect target direct. `NODE_TLS_REJECT_UNAUTHORIZED` only reaches that
+ * tunnel to an https proxy, since every request sets `rejectUnauthorized`
+ * itself, and only its `'0'` state counts.
  */
 export function getProbeEnvDivergence(
   servers: Array<{ url?: string; ignoreHTTPSErrors?: boolean }>,
   taskEnv: NodeJS.ProcessEnv,
-  gateEnv: NodeJS.ProcessEnv
+  gateEnv: NodeJS.ProcessEnv,
+  legacyProxiedTls = false
 ): string[] {
   // A port is probed with a raw TCP connect, and the executor rejects a
   // malformed url up front; env plays no part in either.
@@ -243,15 +262,31 @@ export function getProbeEnvDivergence(
   const tunnelsThroughTlsProxy = [taskRoutes.https, gateRoutes.https].some(
     (route) => route.startsWith('https:')
   );
+  const onlyUnverifiedLegacyTunnels =
+    legacyProxiedTls &&
+    [taskRoutes, gateRoutes].every(
+      (routes) =>
+        routes.https.startsWith('http:') &&
+        !routes.http.startsWith('https:') &&
+        routes.no_proxy === ''
+    );
   if (
-    tunnelsThroughTlsProxy ||
-    urlServers.some((server) => !server.ignoreHTTPSErrors)
+    (tunnelsThroughTlsProxy ||
+      (urlServers.some((server) => !server.ignoreHTTPSErrors) &&
+        !onlyUnverifiedLegacyTunnels)) &&
+    taskEnv.NODE_EXTRA_CA_CERTS !== gateEnv.NODE_EXTRA_CA_CERTS
   ) {
-    for (const variable of TLS_PROBE_VARS) {
-      if (taskEnv[variable] !== gateEnv[variable]) {
-        diverging.add(variable);
-      }
-    }
+    diverging.add('NODE_EXTRA_CA_CERTS');
+  }
+  // Both probes pass `rejectUnauthorized` on every request, which overrides
+  // the env default. Only the proxy agent's own connection to an https proxy
+  // is left to it, and Node reads it as exactly '0'.
+  if (
+    tunnelsThroughTlsProxy &&
+    (taskEnv.NODE_TLS_REJECT_UNAUTHORIZED === '0') !==
+      (gateEnv.NODE_TLS_REJECT_UNAUTHORIZED === '0')
+  ) {
+    diverging.add('NODE_TLS_REJECT_UNAUTHORIZED');
   }
   return [...diverging].sort();
 }
@@ -259,14 +294,17 @@ export function getProbeEnvDivergence(
 /**
  * Whether the task env a chain would run with differs from the graph-time
  * ambient env. Only a difference can change how the config resolves, so an
- * identical env skips the (expensive) child evaluation entirely.
+ * identical env skips the (expensive) child evaluation entirely. `ambientEnv`
+ * is the locked snapshot loadConfigWithProbeEnv returned, not the live
+ * `process.env`, which a concurrent load may be mutating.
  */
 export function taskEnvDivergesFromAmbient(
-  taskEnv: NodeJS.ProcessEnv
+  taskEnv: NodeJS.ProcessEnv,
+  ambientEnv: NodeJS.ProcessEnv
 ): boolean {
-  const keys = new Set([...Object.keys(process.env), ...Object.keys(taskEnv)]);
+  const keys = new Set([...Object.keys(ambientEnv), ...Object.keys(taskEnv)]);
   for (const key of keys) {
-    if (process.env[key] !== taskEnv[key]) {
+    if (ambientEnv[key] !== taskEnv[key]) {
       return true;
     }
   }

--- a/packages/playwright/src/plugins/webserver-readiness.ts
+++ b/packages/playwright/src/plugins/webserver-readiness.ts
@@ -1,3 +1,8 @@
+import {
+  applyDaemonEnvFromClient,
+  getAppliedDaemonClientEnv,
+  loadConfigFile,
+} from '@nx/devkit/internal';
 import type { PlaywrightTestConfig } from '@playwright/test';
 import { fork } from 'node:child_process';
 import { cpus } from 'node:os';
@@ -48,6 +53,90 @@ export function normalizeWebServers(
 
 // The TLS material Node reads when a probe verifies an https certificate.
 const TLS_PROBE_VARS = ['NODE_EXTRA_CA_CERTS', 'NODE_TLS_REJECT_UNAUTHORIZED'];
+// Every variable a url probe reads to route and verify a request, in both
+// spellings the proxy resolution accepts.
+const PROBE_ENV_VARS = [
+  ...['http_proxy', 'https_proxy', 'all_proxy', 'no_proxy'].flatMap((name) => [
+    name,
+    name.toUpperCase(),
+  ]),
+  ...TLS_PROBE_VARS,
+];
+
+/** The values of the probe variables set in an env. */
+export type ProbeEnv = Record<string, string>;
+
+export function pickProbeEnv(env: NodeJS.ProcessEnv): ProbeEnv {
+  const picked: ProbeEnv = {};
+  for (const variable of PROBE_ENV_VARS) {
+    if (env[variable] !== undefined) {
+      picked[variable] = env[variable];
+    }
+  }
+  return picked;
+}
+
+/**
+ * The webServer entries a config evaluation resolved and the probe env it left
+ * behind, which is what Playwright's own probe runs under: the config runs
+ * before the probe and can write env (through `dotenv`, say) that the readiness
+ * task, its own target in its own process, never sees.
+ */
+export interface ConfigEvaluation {
+  webServers: ResolvedWebServer[];
+  probeEnv: ProbeEnv;
+}
+
+let inProcessLoad: Promise<void> = Promise.resolve();
+
+/**
+ * Loads a Playwright config in this process and returns it with the probe env
+ * its evaluation left in `process.env`, then puts `process.env` back the way
+ * it was: the task and gate dotenv files expand against it, and a later env
+ * comparison has to see the graph-time env, not whatever the last config
+ * wrote. Loads are serialized because createNodes evaluates configs
+ * concurrently and a concurrent load's writes would be misattributed. A
+ * client env applied mid-load (the daemon forwards it as it arrives) is
+ * re-applied over the restored env; restoring the pre-load values alone would
+ * revert it.
+ */
+export async function loadConfigWithProbeEnv<T extends object>(
+  configPath: string
+): Promise<{ config: T; probeEnv: ProbeEnv }> {
+  const previous = inProcessLoad;
+  let release: () => void;
+  inProcessLoad = new Promise<void>((resolve) => (release = resolve));
+  await previous;
+  try {
+    const applySequence = getAppliedDaemonClientEnv()?.sequence;
+    const before = { ...process.env };
+    try {
+      const config = await loadConfigFile<T>(configPath);
+      return { config, probeEnv: pickProbeEnv(process.env) };
+    } finally {
+      restoreEnv(before);
+      const applied = getAppliedDaemonClientEnv();
+      if (applied && applied.sequence !== applySequence) {
+        applyDaemonEnvFromClient(applied.env);
+      }
+    }
+  } finally {
+    release();
+  }
+}
+
+function restoreEnv(snapshot: NodeJS.ProcessEnv): void {
+  for (const key of Object.keys(process.env)) {
+    if (!(key in snapshot)) {
+      delete process.env[key];
+    }
+  }
+  for (const [key, value] of Object.entries(snapshot)) {
+    if (process.env[key] !== value) {
+      process.env[key] = value;
+    }
+  }
+}
 
 /**
  * The routes a probe under `env` can take, read as the executor's proxy
@@ -93,13 +182,15 @@ function proxyRoutes(env: NodeJS.ProcessEnv): {
 }
 
 /**
- * The env var names whose task-env values would make the readiness gate probe
- * `servers` differently than the consuming task's own Playwright probe. The
- * gate runs as its own target, so it loads its own dotenv files, not the
- * consumer's: a task-scoped proxy exclusion or CA bundle never reaches it, and
- * a gate probing through the wrong route can fail where Playwright would pass.
- * A non-empty result means the gate cannot reproduce the task's probe and must
- * not be inferred.
+ * The env var names whose values would make the readiness gate probe `servers`
+ * differently than the consuming task's own Playwright probe: `taskEnv` is the
+ * env that probe runs under (the task env after its config loaded) and
+ * `gateEnv` the env the gate target runs under. The gate is its own target, so
+ * it loads its own dotenv files, not the consumer's, and it never loads the
+ * config: a task-scoped or config-written proxy exclusion or CA bundle never
+ * reaches it, and a gate probing through the wrong route can fail where
+ * Playwright would pass. A non-empty result means the gate cannot reproduce
+ * the task's probe and must not be inferred.
  *
  * Both probes follow redirects, so as soon as one server probes a url the
  * routes for every protocol and host are compared, not only the route the
@@ -112,7 +203,7 @@ function proxyRoutes(env: NodeJS.ProcessEnv): {
 export function getProbeEnvDivergence(
   servers: Array<{ url?: string; ignoreHTTPSErrors?: boolean }>,
   taskEnv: NodeJS.ProcessEnv,
-  ambientEnv: NodeJS.ProcessEnv = process.env
+  gateEnv: NodeJS.ProcessEnv
 ): string[] {
   // A port is probed with a raw TCP connect, and the executor rejects a
   // malformed url up front; env plays no part in either.
@@ -124,20 +215,19 @@ export function getProbeEnvDivergence(
   }
   const diverging = new Set<string>();
   const taskRoutes = proxyRoutes(taskEnv);
-  const ambientRoutes = proxyRoutes(ambientEnv);
+  const gateRoutes = proxyRoutes(gateEnv);
   // Name the raw variables behind a differing route. A proxy route is decided
   // by every proxy variable (`no_proxy` can mask them all); the filter only by
   // `no_proxy`.
   const routeVars =
-    taskRoutes.http !== ambientRoutes.http ||
-    taskRoutes.https !== ambientRoutes.https
+    taskRoutes.http !== gateRoutes.http || taskRoutes.https !== gateRoutes.https
       ? ['http_proxy', 'https_proxy', 'all_proxy', 'no_proxy']
-      : taskRoutes.no_proxy !== ambientRoutes.no_proxy
+      : taskRoutes.no_proxy !== gateRoutes.no_proxy
         ? ['no_proxy']
         : [];
   for (const name of routeVars) {
     for (const variable of [name, name.toUpperCase()]) {
-      if (taskEnv[variable] !== ambientEnv[variable]) {
+      if (taskEnv[variable] !== gateEnv[variable]) {
         diverging.add(variable);
       }
     }
@@ -146,7 +236,7 @@ export function getProbeEnvDivergence(
   // is tunnelled through an https proxy over a TLS connection the proxy agent
   // opens with the process defaults, on both sides, so that certificate is
   // verified regardless.
-  const tunnelsThroughTlsProxy = [taskRoutes.https, ambientRoutes.https].some(
+  const tunnelsThroughTlsProxy = [taskRoutes.https, gateRoutes.https].some(
     (route) => route.startsWith('https:')
   );
   if (
@@ -154,7 +244,7 @@ export function getProbeEnvDivergence(
     urlServers.some((server) => !server.ignoreHTTPSErrors)
   ) {
     for (const variable of TLS_PROBE_VARS) {
-      if (taskEnv[variable] !== ambientEnv[variable]) {
+      if (taskEnv[variable] !== gateEnv[variable]) {
         diverging.add(variable);
       }
     }
@@ -186,14 +276,14 @@ export function taskEnvDivergesFromAmbient(
  * such a message must not settle the resolution.
  */
 export type WebserverConfigWorkerMessage =
-  | { type: 'webserver-config-result'; webServers: ResolvedWebServer[] }
+  | ({ type: 'webserver-config-result' } & ConfigEvaluation)
   | { type: 'webserver-config-error'; error: string };
 
 type ChildEval = (
   configFilePath: string,
   workspaceRoot: string,
   env: NodeJS.ProcessEnv
-) => Promise<ResolvedWebServer[]>;
+) => Promise<ConfigEvaluation>;
 
 // A forked config evaluation holds a full config module graph in memory, so cap
 // how many run at once.
@@ -215,7 +305,7 @@ export async function resolveWebServersUnderEnv(
   configFilePath: string,
   workspaceRoot: string,
   taskEnv: NodeJS.ProcessEnv
-): Promise<ResolvedWebServer[]> {
+): Promise<ConfigEvaluation> {
   // `while` rather than `if`: a caller arriving between a slot's release and
   // the woken waiter's resume can claim the slot first, so the waiter must
   // re-check before taking it.
@@ -241,12 +331,15 @@ function isWorkerMessage(
     type?: unknown;
     error?: unknown;
     webServers?: unknown;
+    probeEnv?: unknown;
   };
   return (
     (candidate.type === 'webserver-config-error' &&
       typeof candidate.error === 'string') ||
     (candidate.type === 'webserver-config-result' &&
-      Array.isArray(candidate.webServers))
+      Array.isArray(candidate.webServers) &&
+      typeof candidate.probeEnv === 'object' &&
+      candidate.probeEnv !== null)
   );
 }
 
@@ -254,7 +347,7 @@ function forkChildEval(
   configFilePath: string,
   workspaceRoot: string,
   env: NodeJS.ProcessEnv
-): Promise<ResolvedWebServer[]> {
+): Promise<ConfigEvaluation> {
   return new Promise((resolve, reject) => {
     // Startup env and project-root cwd mirror the inferred task, which runs
     // `playwright test` from the project root: a NODE_OPTIONS loader runs at
@@ -313,7 +406,12 @@ function forkChildEval(
           finish(() => reject(new Error(withStderr(message.error))));
           break;
         case 'webserver-config-result':
-          finish(() => resolve(message.webServers));
+          finish(() =>
+            resolve({
+              webServers: message.webServers,
+              probeEnv: message.probeEnv,
+            })
+          );
           break;
         default: {
           // A new message variant has to say how it settles the resolution.

--- a/packages/playwright/src/utils/installed-playwright.ts
+++ b/packages/playwright/src/utils/installed-playwright.ts
@@ -1,0 +1,26 @@
+import { getInstalledPackageVersion } from '@nx/devkit/internal';
+import { lt, valid } from 'semver';
+
+/**
+ * The version of the `@playwright/test` resolved from `requirePaths`, the
+ * directories the install is resolved from, the project root first so a
+ * pnpm-isolated copy wins over a hoisted one. `null` when none resolves or its
+ * version does not parse.
+ */
+export function installedPlaywrightVersion(
+  requirePaths: string[]
+): string | null {
+  if (requirePaths.length === 0) {
+    return null;
+  }
+  const version = getInstalledPackageVersion('@playwright/test', requirePaths);
+  return version !== null && valid(version) !== null ? version : null;
+}
+
+/** Whether an installed version read by `installedPlaywrightVersion` is older than `floor`. */
+export function installedPlaywrightIsBelow(
+  version: string | null,
+  floor: string
+): boolean {
+  return version !== null && lt(version, floor);
+}

--- a/packages/playwright/src/utils/npm-config-proxy.ts
+++ b/packages/playwright/src/utils/npm-config-proxy.ts
@@ -1,0 +1,21 @@
+import { installedPlaywrightIsBelow } from './installed-playwright';
+import { minPlaywrightVersionIgnoringNpmConfigProxy } from './versions';
+
+/**
+ * Whether the installed Playwright routes its probe by npm's `npm_config_*`
+ * proxy variables as well as the standard ones, which it did until 1.59.0
+ * dropped them. The readiness gate and its graph-time inference follow the
+ * installed version: ignoring a variable that version's own probe reads would
+ * send the gate a different way than Playwright. `version` is the installed
+ * version as `installedPlaywrightVersion` reads it; an unresolvable or
+ * unparseable installation (`null`) reads as ignoring them, the semantics of
+ * current versions.
+ */
+export function installedPlaywrightReadsNpmConfigProxy(
+  version: string | null
+): boolean {
+  return installedPlaywrightIsBelow(
+    version,
+    minPlaywrightVersionIgnoringNpmConfigProxy
+  );
+}

--- a/packages/playwright/src/utils/proxied-tls-verification.ts
+++ b/packages/playwright/src/utils/proxied-tls-verification.ts
@@ -1,0 +1,29 @@
+import { getInstalledPackageVersion } from '@nx/devkit/internal';
+import { lt, valid } from 'semver';
+import { minPlaywrightVersionVerifyingProxiedTls } from './versions';
+
+/**
+ * Whether the installed Playwright probes an https url tunnelled through a
+ * proxy without verifying the origin certificate, which it did until 1.59.0
+ * started honoring the caller's setting. The readiness gate and its graph-time
+ * inference follow the installed version: verifying where that version's own
+ * probe does not would fail a wait Playwright itself would pass, and counting
+ * TLS material that probe never reads would drop a gate for nothing.
+ * `requirePaths` are the directories the install is resolved from, the
+ * project root first so a pnpm-isolated copy wins over a hoisted one. An
+ * unresolvable or unparseable installation reads as verifying, the semantics
+ * of current versions.
+ */
+export function installedPlaywrightSkipsProxiedTls(
+  requirePaths: string[]
+): boolean {
+  if (requirePaths.length === 0) {
+    return false;
+  }
+  const version = getInstalledPackageVersion('@playwright/test', requirePaths);
+  return (
+    version !== null &&
+    valid(version) !== null &&
+    lt(version, minPlaywrightVersionVerifyingProxiedTls)
+  );
+}

--- a/packages/playwright/src/utils/proxied-tls-verification.ts
+++ b/packages/playwright/src/utils/proxied-tls-verification.ts
@@ -1,5 +1,4 @@
-import { getInstalledPackageVersion } from '@nx/devkit/internal';
-import { lt, valid } from 'semver';
+import { installedPlaywrightIsBelow } from './installed-playwright';
 import { minPlaywrightVersionVerifyingProxiedTls } from './versions';
 
 /**
@@ -9,21 +8,15 @@ import { minPlaywrightVersionVerifyingProxiedTls } from './versions';
  * inference follow the installed version: verifying where that version's own
  * probe does not would fail a wait Playwright itself would pass, and counting
  * TLS material that probe never reads would drop a gate for nothing.
- * `requirePaths` are the directories the install is resolved from, the
- * project root first so a pnpm-isolated copy wins over a hoisted one. An
- * unresolvable or unparseable installation reads as verifying, the semantics
- * of current versions.
+ * `version` is the installed version as `installedPlaywrightVersion` reads it;
+ * an unresolvable or unparseable installation (`null`) reads as verifying, the
+ * semantics of current versions.
  */
 export function installedPlaywrightSkipsProxiedTls(
-  requirePaths: string[]
+  version: string | null
 ): boolean {
-  if (requirePaths.length === 0) {
-    return false;
-  }
-  const version = getInstalledPackageVersion('@playwright/test', requirePaths);
-  return (
-    version !== null &&
-    valid(version) !== null &&
-    lt(version, minPlaywrightVersionVerifyingProxiedTls)
+  return installedPlaywrightIsBelow(
+    version,
+    minPlaywrightVersionVerifyingProxiedTls
   );
 }

--- a/packages/playwright/src/utils/versions.ts
+++ b/packages/playwright/src/utils/versions.ts
@@ -7,9 +7,13 @@ export const minSupportedPlaywrightVersion = '1.36.0';
 export const minPlaywrightVersionForBlobReports = '1.37.0';
 // Earlier versions never verify the origin certificate of an https url probed
 // through a proxy tunnel, whatever the caller asked for.
+// TODO(v25): drop with the unverified-tunnel branch once
+// minSupportedPlaywrightVersion reaches 1.59.0.
 export const minPlaywrightVersionVerifyingProxiedTls = '1.59.0';
 // Earlier versions bundle a `proxy-from-env` that also reads npm's
 // `npm_config_*` proxy variables ahead of the standard ones.
+// TODO(v25): drop with the npm_config_* proxy handling once
+// minSupportedPlaywrightVersion reaches 1.59.0.
 export const minPlaywrightVersionIgnoringNpmConfigProxy = '1.59.0';
 export const playwrightVersion = '^1.37.0';
 export const eslintPluginPlaywrightVersion = '^1.6.2';

--- a/packages/playwright/src/utils/versions.ts
+++ b/packages/playwright/src/utils/versions.ts
@@ -8,5 +8,8 @@ export const minPlaywrightVersionForBlobReports = '1.37.0';
 // Earlier versions never verify the origin certificate of an https url probed
 // through a proxy tunnel, whatever the caller asked for.
 export const minPlaywrightVersionVerifyingProxiedTls = '1.59.0';
+// Earlier versions bundle a `proxy-from-env` that also reads npm's
+// `npm_config_*` proxy variables ahead of the standard ones.
+export const minPlaywrightVersionIgnoringNpmConfigProxy = '1.59.0';
 export const playwrightVersion = '^1.37.0';
 export const eslintPluginPlaywrightVersion = '^1.6.2';

--- a/packages/playwright/src/utils/versions.ts
+++ b/packages/playwright/src/utils/versions.ts
@@ -5,5 +5,8 @@ export const nxVersion = require(
 ).version;
 export const minSupportedPlaywrightVersion = '1.36.0';
 export const minPlaywrightVersionForBlobReports = '1.37.0';
+// Earlier versions never verify the origin certificate of an https url probed
+// through a proxy tunnel, whatever the caller asked for.
+export const minPlaywrightVersionVerifyingProxiedTls = '1.59.0';
 export const playwrightVersion = '^1.37.0';
 export const eslintPluginPlaywrightVersion = '^1.6.2';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,9 @@ catalogs:
     http-server:
       specifier: ^14.1.0
       version: 14.1.0
+    https-proxy-agent:
+      specifier: ^7.0.6
+      version: 7.0.6
     jsonc-parser:
       specifier: ^3.2.0
       version: 3.3.1
@@ -3355,6 +3358,9 @@ importers:
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.60.0
+      https-proxy-agent:
+        specifier: 'catalog:'
+        version: 7.0.6
       minimatch:
         specifier: ^10.2.5
         version: 10.2.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -156,6 +156,9 @@ catalogs:
     http-server:
       specifier: ^14.1.0
       version: 14.1.0
+    https-proxy-agent:
+      specifier: ^7.0.6
+      version: 7.0.6
     jsonc-parser:
       specifier: ^3.2.0
       version: 3.3.1
@@ -3366,6 +3369,9 @@ importers:
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.60.0
+      https-proxy-agent:
+        specifier: 'catalog:'
+        version: 7.0.6
       minimatch:
         specifier: ^10.2.5
         version: 10.2.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3371,7 +3371,7 @@ importers:
         version: 1.60.0
       https-proxy-agent:
         specifier: 'catalog:'
-        version: 7.0.6
+        version: 7.0.6(supports-color@10.2.2)
       minimatch:
         specifier: ^10.2.5
         version: 10.2.5

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -49,6 +49,7 @@ catalog:
   gpt3-tokenizer: '^1.1.5'
   http-proxy-middleware: '^3.0.5'
   http-server: '^14.1.0'
+  https-proxy-agent: '^7.0.6'
   jsonc-parser: '^3.2.0'
   minimatch: '10.2.5'
   next-seo: '^5.13.0'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -57,6 +57,7 @@ catalog:
   gpt3-tokenizer: '^1.1.5'
   http-proxy-middleware: '^3.0.7'
   http-server: '^14.1.0'
+  https-proxy-agent: '^7.0.6'
   jsonc-parser: '^3.2.0'
   minimatch: '10.2.5'
   next-seo: '^5.13.0'


### PR DESCRIPTION
## Current Behavior

Playwright's `webServer` with `reuseExistingServer` probes the server once, right before the tests start. When Nx starts that server as a continuous task dependency, the dependency counts as satisfied as soon as the process spawns, not once it accepts connections. The probe misses, so Playwright launches a second server from the same command inside the e2e task, and its build I/O lands there too.

This hits the first atomized `e2e-ci` task on each CI agent, where the extra server shows up in the Nx Cloud sandboxing report, and the plain `e2e` task, which only depended on the serve task.

## Expected Behavior

The `e2e` task and the atomized `e2e-ci` tasks wait until the web server is ready before they start, so Playwright reuses the running server and never launches its own.

## Related Issue(s)

Fixes #34698
NXC-4682

## Implementation Notes

- The plugin infers a `<target>--wait-for-webserver` task from a `webServer` that reuses an existing server and probes a `port` or `url`. Both chains depend on it next to the serve task. A plugin-local gate keeps the serve task a visible, reused continuous dependency; a scheduler-level readiness protocol would touch every executor for one plugin's need.
- The hidden executor probes the way Playwright does: TCP on both loopback families for a port, HTTP with redirects, `/index.html` on a 404 at `/`, proxies and `ignoreHTTPSErrors` for a url, ready on 200-403. Anything stricter would fail where Playwright's own probe passes; requests are bounded by the remaining deadline so a slow first response is not cut short.
- The command and address can read `process.env`, and `createNodes` runs without the task's dotenv files loaded. Each chain's `webServer` is resolved under that chain's dotenv env, in a child process from the project directory when it differs from the daemon's. Resolving at graph time rather than in the executor is deliberate: the serve dependency itself can be env-derived and must be right before the graph is built.
- A failed evaluation warns, keeps the dependencies, skips the gate and is not cached, so a config bug degrades to master's behavior instead of failing graph construction.
- The gate runs under its own dotenv files and never loads the config. When the task's env files, or the config while it loads, change how the url would be probed, the gate is skipped and Playwright's probe takes over. A gate probing through another proxy or trust store would block a passing run. Rules and limits: [web server readiness page](https://nx.dev/docs/kb/playwright-web-server-readiness).
- To see what a config writes, in-process loads are serialized and `process.env` is restored after each, with every config value read before the restore: a config can expose getters that read the env it wrote. A client env the daemon applied mid-load is re-applied, and a client change a config already wrote still invalidates the cached graph.
- The client env the daemon accepts is part of the plugin cache key, and an env-carrying client message is applied to plugin workers before its handler runs. An env change re-runs the plugin cold, about 0.8s at 279 projects; a stale entry would otherwise serve an address inferred under another env.
- Gitignored dotenv edits reach the graph through the outputs watcher. An edit that lands while a computation is in flight, or while a warm graph sits cached, is queued and replayed before any graph is served, so no delivery window drops it. A native error in that watcher is terminal for it; the daemon then fails requests closed, like a workspace watcher error, instead of serving a stale graph, and an inotify failure still degrades to daemonless runs.
- The gate follows the installed `@playwright/test`. Below 1.59.0 its probe never verifies the origin behind a proxy tunnel and reads npm's `npm_config_*` proxy variables ahead of the standard ones; the executor and the graph-time comparison do the same on those versions, and the installed version is part of the plugin cache key.
- A hand-written gate target may set both `port` and `url`; the plugin never emits both. The port is probed, as Playwright does, and the timeout names it.
- The `ts-node/esm` fallback loader forces `nodenext` over an inherited CommonJS `TS_NODE_COMPILER_OPTIONS`; a stale warm cache had hidden that `.mts` configs failed to load under it once they re-evaluated.
- Not handled, each with `waitForWebServer: false` as the opt-out:
  - An address that depends on the working directory. Evaluating from the project root would fork a child per gated project on every cold pass, or `chdir` in a process other plugins share. The page documents deriving the address from the config file's directory instead; revisit if such configs turn out common.
  - An address read from a variable the daemon filters out of the graph env; the filter list gets its own PR.
  - A `webServer` that only exists under the task env; it is not detected, as on master.
  - Concurrent daemon clients with differing envs; they resolve last-client-wins, as before.
  - A configuration-scoped env file (`.env.<target>.<configuration>`). A task dependency carries no configuration, so the address is inferred without it; the timeout message points at the opt-out.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/nxc-4682-8bf958a9)
<!-- polygraph-session-end -->



