### PR TITLE
cleanup(core): extract the nx migrate execution engine into a separate module

### DIFF
--- a/packages/nx/src/command-line/migrate/execute-migration.ts
+++ b/packages/nx/src/command-line/migrate/execute-migration.ts
@@ -1,0 +1,547 @@
+import * as pc from 'picocolors';
+import { spawn } from 'child_process';
+import { dirname, join } from 'path';
+import { lt } from 'semver';
+import { handleImport } from '../../utils/handle-import';
+import { MigrationsJson } from '../../config/misc-interfaces';
+import {
+  FileChange,
+  flushChanges,
+  FsTree,
+  printChanges,
+} from '../../generators/tree';
+import { readJsonFile } from '../../utils/fileutils';
+import { logger } from '../../utils/logger';
+import {
+  ArrayPackageGroup,
+  NxMigrationsConfiguration,
+  PackageJson,
+  readModulePackageJson,
+  readNxMigrateConfig,
+} from '../../utils/package-json';
+import {
+  detectPackageManager,
+  getPackageManagerCommand,
+} from '../../utils/package-manager';
+import { output } from '../../utils/output';
+import { existsSync } from 'fs';
+import { getNxRequirePaths } from '../../utils/installation-directory';
+import {
+  createProjectGraphAsync,
+  readProjectsConfigurationFromProjectGraph,
+} from '../../project-graph/project-graph';
+import { normalizeVersion } from './version-utils';
+
+// Migration execution engine shared by the CLI migrate loop, the Console
+// API, and the single-migration child process.
+
+interface PackageMigrationConfig extends NxMigrationsConfiguration {
+  packageJson: PackageJson;
+  packageGroup: ArrayPackageGroup;
+}
+
+export function readPackageMigrationConfig(
+  packageName: string,
+  dir: string
+): PackageMigrationConfig {
+  const { path: packageJsonPath, packageJson: json } = readModulePackageJson(
+    packageName,
+    getNxRequirePaths(dir)
+  );
+
+  const config = readNxMigrateConfig(json);
+
+  if (!config) {
+    return { packageJson: json, migrations: null, packageGroup: [] };
+  }
+
+  try {
+    const migrationFile = require.resolve(config.migrations, {
+      paths: [dirname(packageJsonPath)],
+    });
+
+    return {
+      packageJson: json,
+      migrations: migrationFile,
+      packageGroup: config.packageGroup,
+      supportsOptionalMigrations: config.supportsOptionalMigrations,
+    };
+  } catch {
+    return {
+      packageJson: json,
+      migrations: null,
+      packageGroup: config.packageGroup,
+      supportsOptionalMigrations: config.supportsOptionalMigrations,
+    };
+  }
+}
+
+export function runInstall(
+  nxWorkspaceRoot?: string,
+  phase: MigrationInstallPhase = 'pre-migration'
+): Promise<void> {
+  const cwd = nxWorkspaceRoot ?? process.cwd();
+  const packageManager = detectPackageManager(cwd);
+  const pmCommands = getPackageManagerCommand(packageManager, cwd);
+
+  const installCommand = `${pmCommands.install} ${
+    pmCommands.ignoreScriptsFlag ?? ''
+  }`;
+  output.log({
+    title: `Running '${installCommand}' to make sure necessary packages are installed`,
+  });
+
+  return new Promise<void>((resolve, reject) => {
+    // For npm, pipe stderr so we can detect peer dependency errors while still
+    // mirroring it live to the user's terminal. Other package managers inherit
+    // stderr directly since we don't need to inspect their output.
+    const shouldCaptureStderr = packageManager === 'npm';
+    const child = spawn(installCommand, {
+      shell: true,
+      stdio: ['inherit', 'inherit', shouldCaptureStderr ? 'pipe' : 'inherit'],
+      windowsHide: true,
+      cwd,
+    });
+
+    const stderrChunks: Buffer[] = [];
+    child.stderr?.on('data', (chunk: Buffer) => {
+      process.stderr.write(chunk);
+      stderrChunks.push(chunk);
+    });
+
+    child.on('error', reject);
+
+    child.on('close', (code) => {
+      if (code === 0) {
+        resolve();
+        return;
+      }
+
+      if (shouldCaptureStderr) {
+        const stderr = Buffer.concat(stderrChunks).toString().trim();
+        if (isNpmPeerDepsError(stderr)) {
+          // Log the remediation guidance here so every caller of `runInstall`
+          // (CLI migrate, `nx repair`, single-migration runner, etc.) surfaces
+          // it consistently. Top-level callers catch `NpmPeerDepsInstallError`
+          // and return a non-zero exit code without re-logging.
+          logNpmPeerDepsError(phase);
+          reject(new NpmPeerDepsInstallError());
+          return;
+        }
+      }
+
+      reject(new Error(`Command failed: ${installCommand}`));
+    });
+  });
+}
+
+export type MigrationInstallPhase = 'pre-migration' | 'post-migration';
+
+export class NpmPeerDepsInstallError extends Error {
+  constructor() {
+    super('npm install failed due to peer dependency conflicts.');
+    this.name = 'NpmPeerDepsInstallError';
+  }
+}
+
+/**
+ * Detects npm peer-dependency resolution failures. Keyed on the `ERESOLVE`
+ * error code, which npm consistently emits for this class of failure across
+ * v7+ (`npm ERR! code ERESOLVE` / `npm error code ERESOLVE`). Falls back to a
+ * small set of stable phrases in case the code line is missing from the
+ * captured output.
+ */
+export function isNpmPeerDepsError(stderr: string): boolean {
+  if (/\bERESOLVE\b/.test(stderr)) {
+    return true;
+  }
+  const lowerStderr = stderr.toLowerCase();
+  return (
+    lowerStderr.includes('unable to resolve dependency tree') ||
+    lowerStderr.includes('could not resolve dependency') ||
+    lowerStderr.includes('conflicting peer dependency')
+  );
+}
+
+export function logNpmPeerDepsError(phase: MigrationInstallPhase): void {
+  const peerDepsResolutionSteps = [
+    'Recommended approaches (in order of preference):',
+    '',
+    '1. Use "overrides" in package.json to force compatible versions across the dependency tree.',
+    '   See https://docs.npmjs.com/cli/configuring-npm/package-json#overrides',
+    '2. Persist legacy peer deps resolution in the project ".npmrc":',
+    '   npm config set legacy-peer-deps=true --location=project',
+    '   (bypasses peer dependency resolution; use with caution)',
+    '3. As a last resort, force the installation by running "npm install --force".',
+    '   (does not persist and may produce broken installs)',
+  ];
+  const manualInstallHint = [
+    'If you installed the dependencies manually, pass "--skip-install" to avoid re-installing them:',
+    '   nx migrate --run-migrations --skip-install',
+  ];
+
+  if (phase === 'pre-migration') {
+    output.error({
+      title:
+        'You need to resolve the peer dependency conflicts before the migration can continue',
+      bodyLines: [
+        ...peerDepsResolutionSteps,
+        '',
+        'Once the conflicts are resolved, re-run the migrations:',
+        '   nx migrate --run-migrations',
+        '',
+        ...manualInstallHint,
+      ],
+    });
+  } else {
+    output.error({
+      title:
+        'Some migrations have been applied, but installing the updated dependencies failed',
+      bodyLines: [
+        ...peerDepsResolutionSteps,
+        '',
+        'Once the conflicts are resolved, run "npm install" to install the updated dependencies.',
+        'If the migration was interrupted before completing, re-run the remaining migrations:',
+        '   nx migrate --run-migrations',
+        '',
+        ...manualInstallHint,
+      ],
+    });
+  }
+}
+
+export class ChangedDepInstaller {
+  private initialDeps: string;
+  private _skippedInstall = false;
+
+  constructor(
+    private readonly root: string,
+    private readonly shouldSkipInstall = false
+  ) {
+    this.initialDeps = getStringifiedPackageJsonDeps(root);
+  }
+
+  public get skippedInstall(): boolean {
+    return this._skippedInstall;
+  }
+
+  public async installDepsIfChanged(): Promise<void> {
+    const currentDeps = getStringifiedPackageJsonDeps(this.root);
+    if (this.initialDeps !== currentDeps) {
+      if (this.shouldSkipInstall) {
+        this._skippedInstall = true;
+      } else {
+        await runInstall(this.root, 'post-migration');
+      }
+    }
+    this.initialDeps = currentDeps;
+  }
+}
+
+export async function runNxOrAngularMigration(
+  root: string,
+  migration: {
+    package: string;
+    name: string;
+    description?: string;
+    version: string;
+  },
+  isVerbose: boolean,
+  captureGeneratorOutput = false,
+  resolvedCollection?: { collection: MigrationsJson; collectionPath: string }
+): Promise<{
+  changes: FileChange[];
+  nextSteps: string[];
+  agentContext: string[];
+  logs: string;
+  madeChanges: boolean;
+}> {
+  const { collection, collectionPath } =
+    resolvedCollection ?? readMigrationCollection(migration.package, root);
+  let changes: FileChange[] = [];
+  let nextSteps: string[] = [];
+  let agentContext: string[] = [];
+  let logs = '';
+  // Angular's `ngResult.changes` is synthesized from the schematic's
+  // DryRunEvent stream so Nx and Angular paths can share commit/validation
+  // gating via `changes.length > 0`.
+  let madeChanges = false;
+  logger.info(pc.dim('→ Running generator…'));
+  if (!isAngularMigration(collection, migration.name)) {
+    ({ nextSteps, changes, agentContext, logs } = await runNxMigration(
+      root,
+      collectionPath,
+      collection,
+      migration.name,
+      migration.version,
+      captureGeneratorOutput
+    ));
+    madeChanges = changes.length > 0;
+
+    logger.info(`Ran ${migration.name} from ${migration.package}`);
+    if (migration.description) {
+      logger.info(`  ${migration.description}`);
+    }
+    logger.info('');
+    if (!madeChanges) {
+      logger.info(`No changes were made\n`);
+      return { changes, nextSteps, agentContext, logs, madeChanges };
+    }
+
+    logger.info('Changes:');
+    printChanges(changes, '  ');
+    logger.info('');
+  } else {
+    const ngCliAdapter = await getNgCompatLayer();
+    const migrationProjectGraph = await createProjectGraphAsync();
+    const ngResult = await ngCliAdapter.runMigration(
+      root,
+      migration.package,
+      migration.name,
+      readProjectsConfigurationFromProjectGraph(migrationProjectGraph).projects,
+      isVerbose,
+      migrationProjectGraph
+    );
+    changes = ngResult.changes;
+    madeChanges = ngResult.madeChanges;
+    logs = ngResult.loggingQueue.join('\n');
+
+    logger.info(`Ran ${migration.name} from ${migration.package}`);
+    if (migration.description) {
+      logger.info(`  ${migration.description}`);
+    }
+    logger.info('');
+    if (!madeChanges) {
+      logger.info(`No changes were made\n`);
+      return { changes, nextSteps, agentContext, logs, madeChanges };
+    }
+
+    logger.info('Changes:');
+    ngResult.loggingQueue.forEach((log) => logger.info('  ' + log));
+    logger.info('');
+  }
+
+  return { changes, nextSteps, agentContext, logs, madeChanges };
+}
+
+export function getStringifiedPackageJsonDeps(root: string): string {
+  try {
+    const { dependencies, devDependencies } = readJsonFile<PackageJson>(
+      join(root, 'package.json')
+    );
+
+    return JSON.stringify([dependencies, devDependencies]);
+  } catch {
+    // We don't really care if the .nx/installation property changes,
+    // whenever nxw is invoked it will handle the dep updates.
+    return '';
+  }
+}
+
+export async function runNxMigration(
+  root: string,
+  collectionPath: string,
+  collection: MigrationsJson,
+  name: string,
+  migrationVersion: string | undefined,
+  captureGeneratorOutput: boolean
+) {
+  const { path: implPath, fnSymbol } = getImplementationPath(
+    collection,
+    collectionPath,
+    name,
+    migrationVersion
+  );
+  const fn = require(implPath)[fnSymbol];
+  const host = new FsTree(
+    root,
+    process.env.NX_VERBOSE_LOGGING === 'true',
+    `migration ${collection.name}:${name}`
+  );
+  let result: unknown;
+  let logs = '';
+  if (captureGeneratorOutput) {
+    const { withGeneratorOutputCapture } =
+      require('./agentic/capture-generator-output') as typeof import('./agentic/capture-generator-output');
+    ({ result, logs } = await withGeneratorOutputCapture(() => fn(host, {})));
+  } else {
+    result = await fn(host, {});
+  }
+  const { nextSteps, agentContext } = parseMigrationReturn(result);
+  host.lock();
+  const changes = host.listChanges();
+  flushChanges(root, changes);
+  return { changes, nextSteps, agentContext, logs };
+}
+
+export function parseMigrationReturn(value: unknown): {
+  nextSteps: string[];
+  agentContext: string[];
+} {
+  if (Array.isArray(value)) {
+    return { nextSteps: filterStrings(value), agentContext: [] };
+  }
+  if (value && typeof value === 'object') {
+    const obj = value as Record<string, unknown>;
+    return {
+      nextSteps: filterStrings(obj.nextSteps),
+      agentContext: filterStrings(obj.agentContext),
+    };
+  }
+  // Catches `void`, mistakenly-returned generator callbacks, malformed values.
+  return { nextSteps: [], agentContext: [] };
+}
+
+// Bucket-level tolerance: a single non-string entry shouldn't discard the
+// whole `nextSteps` / `agentContext` array. Migration authors occasionally
+// push `null` / `undefined` / a number into the array; we drop the bad entries
+// and keep the rest so end-of-run guidance isn't silently lost.
+export function filterStrings(value: unknown): string[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((v): v is string => typeof v === 'string');
+}
+
+export function readMigrationCollection(packageName: string, root: string) {
+  const collectionPath = readPackageMigrationConfig(
+    packageName,
+    root
+  ).migrations;
+  const collection = readJsonFile<MigrationsJson>(collectionPath);
+  collection.name ??= packageName;
+  return {
+    collection,
+    collectionPath,
+  };
+}
+
+export function getImplementationPath(
+  collection: MigrationsJson,
+  collectionPath: string,
+  name: string,
+  migrationVersion?: string
+): { path: string; fnSymbol: string } {
+  const g = collection.generators?.[name] || collection.schematics?.[name];
+  if (!g) {
+    throw new MigrationImplementationMissingError(
+      `Unable to determine implementation path for "${collectionPath}:${name}"`,
+      collectionPath,
+      migrationVersion
+    );
+  }
+  const implRelativePathAndMaybeSymbol = g.implementation || g.factory;
+  const [implRelativePath, fnSymbol = 'default'] =
+    implRelativePathAndMaybeSymbol.split('#');
+
+  let implPath: string;
+
+  try {
+    implPath = require.resolve(implRelativePath, {
+      paths: [dirname(collectionPath)],
+    });
+  } catch (e) {
+    try {
+      // workaround for a bug in node 12
+      implPath = require.resolve(
+        `${dirname(collectionPath)}/${implRelativePath}`
+      );
+    } catch {
+      throw new MigrationImplementationMissingError(
+        `Could not resolve implementation for migration "${name}" from "${collectionPath}"`,
+        collectionPath,
+        migrationVersion ?? g.version
+      );
+    }
+  }
+
+  return { path: implPath, fnSymbol };
+}
+
+export class MigrationImplementationMissingError extends Error {
+  constructor(
+    baseMessage: string,
+    collectionPath: string,
+    migrationVersion: string | undefined
+  ) {
+    super(
+      buildMigrationMissingMessage(
+        baseMessage,
+        collectionPath,
+        migrationVersion
+      )
+    );
+    this.name = 'MigrationImplementationMissingError';
+  }
+}
+
+function buildMigrationMissingMessage(
+  baseMessage: string,
+  collectionPath: string,
+  migrationVersion: string | undefined
+): string {
+  if (!migrationVersion) {
+    return baseMessage;
+  }
+
+  try {
+    const packageJsonPath = join(dirname(collectionPath), 'package.json');
+    if (!existsSync(packageJsonPath)) {
+      return baseMessage;
+    }
+    const packageJson = readJsonFile<PackageJson>(packageJsonPath);
+    const installedVersion = packageJson.version;
+
+    if (
+      installedVersion &&
+      lt(normalizeVersion(installedVersion), normalizeVersion(migrationVersion))
+    ) {
+      const packageManager = detectPackageManager();
+      const pmc = getPackageManagerCommand(packageManager);
+      const overrideFieldName = getOverrideFieldName(packageManager);
+
+      return (
+        `${baseMessage}\n\n` +
+        `The installed version of "${packageJson.name}" is ${installedVersion}, ` +
+        `but this migration requires version ${migrationVersion}. ` +
+        `This likely means the package version is being held back by an ${overrideFieldName} ` +
+        `in your package.json. ` +
+        `Remove the ${overrideFieldName} and run "${pmc.install}" to install the correct version.`
+      );
+    }
+  } catch {
+    // Fall through to return the base message if we can't read package info
+  }
+
+  return baseMessage;
+}
+
+function getOverrideFieldName(
+  packageManager: ReturnType<typeof detectPackageManager>
+): string {
+  switch (packageManager) {
+    case 'pnpm':
+      return '"pnpm.overrides"';
+    case 'yarn':
+      return '"resolutions"';
+    case 'npm':
+    case 'bun':
+      return '"overrides"';
+  }
+}
+
+export function isAngularMigration(collection: MigrationsJson, name: string) {
+  return !collection.generators?.[name] && collection.schematics?.[name];
+}
+
+export const getNgCompatLayer = (() => {
+  let _ngCliAdapter: typeof import('../../adapter/ngcli-adapter');
+  return async function getNgCompatLayer() {
+    if (!_ngCliAdapter) {
+      _ngCliAdapter = await handleImport(
+        '../../adapter/ngcli-adapter.js',
+        __dirname
+      );
+      require('../../adapter/compat');
+    }
+    return _ngCliAdapter;
+  };
+})();

--- a/packages/nx/src/command-line/migrate/migrate-contracts.spec.ts
+++ b/packages/nx/src/command-line/migrate/migrate-contracts.spec.ts
@@ -1,0 +1,47 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import * as migrateModule from './migrate';
+import * as engine from './execute-migration';
+import { runSingleMigration } from './migrate-ui-api';
+
+describe('execute-migration re-export contract', () => {
+  it('re-exports every execute-migration export from migrate with the same reference', () => {
+    for (const key of Object.keys(engine)) {
+      expect(migrateModule).toHaveProperty(key);
+      expect((migrateModule as Record<string, unknown>)[key]).toBe(
+        (engine as Record<string, unknown>)[key]
+      );
+    }
+  });
+});
+
+describe('run-migration-process.js contract', () => {
+  // run-migration-process.js does:
+  //   const { runNxOrAngularMigration, ChangedDepInstaller } = require('./migrate');
+  it('exposes runNxOrAngularMigration and ChangedDepInstaller as functions on migrate', () => {
+    expect(typeof migrateModule.runNxOrAngularMigration).toBe('function');
+    expect(typeof migrateModule.ChangedDepInstaller).toBe('function');
+  });
+});
+
+describe('migrate-ui-api contract', () => {
+  it('keeps the (workspacePath, migration, configuration) signature', () => {
+    expect(typeof runSingleMigration).toBe('function');
+    expect(runSingleMigration.length).toBe(3);
+  });
+});
+
+describe('package.json exports map contract', () => {
+  it('keeps the run-migration-process export entries', () => {
+    const packageJsonPath = join(__dirname, '../../../package.json');
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, 'utf-8'));
+    // Keys contain dots, so index directly rather than using toHaveProperty's
+    // dot-path notation.
+    expect(
+      packageJson.exports['./src/command-line/migrate/run-migration-process']
+    ).toBeDefined();
+    expect(
+      packageJson.exports['./src/command-line/migrate/run-migration-process.js']
+    ).toBeDefined();
+  });
+});

--- a/packages/nx/src/command-line/migrate/migrate-execution.spec.ts
+++ b/packages/nx/src/command-line/migrate/migrate-execution.spec.ts
@@ -1,0 +1,689 @@
+const mockSpawn = jest.fn();
+jest.mock('child_process', () => ({
+  ...jest.requireActual('child_process'),
+  spawn: (...args: unknown[]) => mockSpawn(...args),
+}));
+
+const mockCommitMigrationIfRequested = jest.fn();
+const mockCommitCheckpointBeforeMigrations = jest.fn();
+jest.mock('./migrate-commits', () => ({
+  commitMigrationIfRequested: (...args: unknown[]) =>
+    mockCommitMigrationIfRequested(...args),
+  commitCheckpointBeforeMigrations: (...args: unknown[]) =>
+    mockCommitCheckpointBeforeMigrations(...args),
+}));
+
+const mockNgRunMigration = jest.fn();
+jest.mock('../../adapter/ngcli-adapter', () => ({
+  runMigration: (...args: unknown[]) => mockNgRunMigration(...args),
+}));
+jest.mock('../../adapter/compat', () => ({}));
+
+const mockCreateProjectGraphAsync = jest.fn();
+const mockReadProjectsConfigurationFromProjectGraph = jest.fn();
+jest.mock('../../project-graph/project-graph', () => ({
+  createProjectGraphAsync: (...args: unknown[]) =>
+    mockCreateProjectGraphAsync(...args),
+  readProjectsConfigurationFromProjectGraph: (...args: unknown[]) =>
+    mockReadProjectsConfigurationFromProjectGraph(...args),
+}));
+
+import { EventEmitter } from 'events';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  writeFileSync,
+} from 'fs';
+import { tmpdir } from 'os';
+import { dirname, join } from 'path';
+import type { MigrationsJson } from '../../config/misc-interfaces';
+import {
+  ChangedDepInstaller,
+  executeMigrations,
+  getImplementationPath,
+  parseMigrationReturn,
+  readMigrationCollection,
+  runNxOrAngularMigration,
+} from './migrate';
+
+function installMigrationPackage(
+  root: string,
+  pkgName: string,
+  migrationsJson: MigrationsJson
+): string {
+  const pkgDir = join(root, 'node_modules', pkgName);
+  mkdirSync(pkgDir, { recursive: true });
+  writeFileSync(
+    join(pkgDir, 'package.json'),
+    JSON.stringify({
+      name: pkgName,
+      version: '1.0.0',
+      'nx-migrations': './migrations.json',
+    })
+  );
+  writeFileSync(
+    join(pkgDir, 'migrations.json'),
+    JSON.stringify(migrationsJson)
+  );
+  return pkgDir;
+}
+
+function writeImplFile(pkgDir: string, relPath: string, source: string): void {
+  const abs = join(pkgDir, relPath);
+  mkdirSync(dirname(abs), { recursive: true });
+  writeFileSync(abs, source);
+}
+
+// child_process.spawn returns an EventEmitter with a `.stderr` stream; tests
+// drive install outcomes by emitting on these directly.
+class FakeChildProcess extends EventEmitter {
+  stderr: EventEmitter | null;
+  constructor(withStderr = false) {
+    super();
+    this.stderr = withStderr ? new EventEmitter() : null;
+  }
+}
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+describe('parseMigrationReturn', () => {
+  it.each<[string, unknown, { nextSteps: string[]; agentContext: string[] }]>([
+    [
+      'returns an array of strings as nextSteps with an empty agentContext',
+      ['a', 'b'],
+      { nextSteps: ['a', 'b'], agentContext: [] },
+    ],
+    [
+      'filters non-string entries out of an array return value',
+      ['a', 1, null, 'b', undefined, {}],
+      { nextSteps: ['a', 'b'], agentContext: [] },
+    ],
+    [
+      'filters non-string entries out of both nextSteps and agentContext',
+      { nextSteps: ['x', 2], agentContext: ['y', false] },
+      { nextSteps: ['x'], agentContext: ['y'] },
+    ],
+    [
+      'returns empty arrays for an object missing both keys',
+      {},
+      { nextSteps: [], agentContext: [] },
+    ],
+    [
+      'returns empty arrays for an object with unrelated keys',
+      { foo: 'bar' },
+      { nextSteps: [], agentContext: [] },
+    ],
+    [
+      'returns empty arrays for undefined',
+      undefined,
+      { nextSteps: [], agentContext: [] },
+    ],
+    [
+      'returns empty arrays for null',
+      null,
+      { nextSteps: [], agentContext: [] },
+    ],
+    [
+      'returns empty arrays for a number',
+      42,
+      { nextSteps: [], agentContext: [] },
+    ],
+    [
+      'returns empty arrays for a function',
+      () => {},
+      { nextSteps: [], agentContext: [] },
+    ],
+  ])('%s', (_title, input, expected) => {
+    expect(parseMigrationReturn(input)).toEqual(expected);
+  });
+});
+
+describe('readMigrationCollection and getImplementationPath', () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    // realpath so path assertions aren't defeated by the macOS /tmp ->
+    // /private/tmp symlink (require.resolve returns realpaths).
+    tmpRoot = realpathSync(
+      mkdtempSync(join(tmpdir(), 'nx-migrate-collection-'))
+    );
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('defaults collection.name to the package name when the migrations.json has none', () => {
+    installMigrationPackage(tmpRoot, 'pkg-a', { generators: {} });
+
+    const { collection } = readMigrationCollection('pkg-a', tmpRoot);
+
+    expect(collection.name).toBe('pkg-a');
+  });
+
+  it('prefers a generators entry over a schematics entry with the same name', () => {
+    const pkgDir = installMigrationPackage(tmpRoot, 'pkg-b', {
+      generators: {
+        mig: { version: '1.0.0', implementation: './gen-impl.js' },
+      },
+      schematics: {
+        mig: { version: '1.0.0', implementation: './schem-impl.js' },
+      },
+    });
+    writeImplFile(pkgDir, 'gen-impl.js', '');
+    writeImplFile(pkgDir, 'schem-impl.js', '');
+
+    const { collection, collectionPath } = readMigrationCollection(
+      'pkg-b',
+      tmpRoot
+    );
+    const { path } = getImplementationPath(collection, collectionPath, 'mig');
+
+    expect(path).toBe(join(pkgDir, 'gen-impl.js'));
+  });
+
+  it('prefers the implementation field over factory on the same entry', () => {
+    const pkgDir = installMigrationPackage(tmpRoot, 'pkg-c', {
+      generators: {
+        mig: {
+          version: '1.0.0',
+          implementation: './impl.js',
+          factory: './factory.js',
+        },
+      },
+    });
+    writeImplFile(pkgDir, 'impl.js', '');
+    writeImplFile(pkgDir, 'factory.js', '');
+
+    const { collection, collectionPath } = readMigrationCollection(
+      'pkg-c',
+      tmpRoot
+    );
+    const { path } = getImplementationPath(collection, collectionPath, 'mig');
+
+    expect(path).toBe(join(pkgDir, 'impl.js'));
+  });
+
+  it('defaults fnSymbol to "default" when the implementation has no #symbol suffix', () => {
+    const pkgDir = installMigrationPackage(tmpRoot, 'pkg-d', {
+      generators: { mig: { version: '1.0.0', implementation: './impl.js' } },
+    });
+    writeImplFile(pkgDir, 'impl.js', '');
+
+    const { collection, collectionPath } = readMigrationCollection(
+      'pkg-d',
+      tmpRoot
+    );
+    const { fnSymbol } = getImplementationPath(
+      collection,
+      collectionPath,
+      'mig'
+    );
+
+    expect(fnSymbol).toBe('default');
+  });
+
+  it('parses the #symbol suffix off the implementation path', () => {
+    const pkgDir = installMigrationPackage(tmpRoot, 'pkg-e', {
+      generators: {
+        mig: { version: '1.0.0', implementation: './impl.js#customExport' },
+      },
+    });
+    writeImplFile(pkgDir, 'impl.js', '');
+
+    const { collection, collectionPath } = readMigrationCollection(
+      'pkg-e',
+      tmpRoot
+    );
+    const { path, fnSymbol } = getImplementationPath(
+      collection,
+      collectionPath,
+      'mig'
+    );
+
+    expect(path).toBe(join(pkgDir, 'impl.js'));
+    expect(fnSymbol).toBe('customExport');
+  });
+
+  it('throws MigrationImplementationMissingError when the implementation cannot be resolved', () => {
+    installMigrationPackage(tmpRoot, 'pkg-f', {
+      generators: { mig: { version: '1.0.0', implementation: './missing.js' } },
+    });
+
+    const { collection, collectionPath } = readMigrationCollection(
+      'pkg-f',
+      tmpRoot
+    );
+    let thrown: unknown;
+    try {
+      getImplementationPath(collection, collectionPath, 'mig');
+    } catch (e) {
+      thrown = e;
+    }
+
+    expect(thrown).toBeInstanceOf(Error);
+    expect((thrown as Error).name).toBe('MigrationImplementationMissingError');
+  });
+});
+
+describe('runNxOrAngularMigration', () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'nx-migrate-run-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('runs the generator implementation, flushes changes to disk, and returns its next steps and agent context', async () => {
+    const pkgDir = installMigrationPackage(tmpRoot, 'pkg-gen', {
+      generators: {
+        'add-file': { version: '1.0.0', implementation: './impl.js' },
+      },
+    });
+    writeImplFile(
+      pkgDir,
+      'impl.js',
+      `module.exports.default = async function (tree) {
+        tree.write('generated.txt', 'hello');
+        return { nextSteps: ['step one'], agentContext: ['ctx one'] };
+      };`
+    );
+
+    const result = await runNxOrAngularMigration(
+      tmpRoot,
+      { package: 'pkg-gen', name: 'add-file', version: '1.0.0' },
+      false
+    );
+
+    expect(result.madeChanges).toBe(true);
+    expect(result.nextSteps).toEqual(['step one']);
+    expect(result.agentContext).toEqual(['ctx one']);
+    expect(existsSync(join(tmpRoot, 'generated.txt'))).toBe(true);
+    expect(readFileSync(join(tmpRoot, 'generated.txt'), 'utf-8')).toBe('hello');
+    expect(mockNgRunMigration).not.toHaveBeenCalled();
+  });
+
+  it('reports no changes for a no-op implementation', async () => {
+    const pkgDir = installMigrationPackage(tmpRoot, 'pkg-noop', {
+      generators: { noop: { version: '1.0.0', implementation: './impl.js' } },
+    });
+    writeImplFile(
+      pkgDir,
+      'impl.js',
+      `module.exports.default = async function () {
+        return [];
+      };`
+    );
+
+    const result = await runNxOrAngularMigration(
+      tmpRoot,
+      { package: 'pkg-noop', name: 'noop', version: '1.0.0' },
+      false
+    );
+
+    expect(result.madeChanges).toBe(false);
+    expect(result.changes).toEqual([]);
+  });
+
+  it('captures console output from the generator into logs when captureGeneratorOutput is true', async () => {
+    const pkgDir = installMigrationPackage(tmpRoot, 'pkg-logs', {
+      generators: {
+        'with-logs': { version: '1.0.0', implementation: './impl.js' },
+      },
+    });
+    writeImplFile(
+      pkgDir,
+      'impl.js',
+      `module.exports.default = async function (tree) {
+        console.log('log line from migration');
+        tree.write('a.txt', 'x');
+        return [];
+      };`
+    );
+
+    const result = await runNxOrAngularMigration(
+      tmpRoot,
+      { package: 'pkg-logs', name: 'with-logs', version: '1.0.0' },
+      false,
+      true
+    );
+
+    expect(result.logs).toContain('log line from migration');
+  });
+
+  it('uses a passed-in resolvedCollection without re-reading the package from node_modules', async () => {
+    // No node_modules entry exists for this package at all.
+    const collectionDir = join(tmpRoot, 'external-collection');
+    mkdirSync(collectionDir, { recursive: true });
+    writeFileSync(
+      join(collectionDir, 'impl.js'),
+      `module.exports.default = async function (tree) {
+        tree.write('from-external.txt', 'y');
+        return [];
+      };`
+    );
+    const collectionPath = join(collectionDir, 'migrations.json');
+    const collection: MigrationsJson = {
+      generators: {
+        'ext-mig': { version: '1.0.0', implementation: './impl.js' },
+      },
+    };
+    writeFileSync(collectionPath, JSON.stringify(collection));
+
+    const result = await runNxOrAngularMigration(
+      tmpRoot,
+      { package: 'not-installed-anywhere', name: 'ext-mig', version: '1.0.0' },
+      false,
+      false,
+      { collection, collectionPath }
+    );
+
+    expect(result.madeChanges).toBe(true);
+    expect(existsSync(join(tmpRoot, 'from-external.txt'))).toBe(true);
+  });
+
+  it('dispatches to the Angular compat layer when the collection has only a schematics entry', async () => {
+    installMigrationPackage(tmpRoot, 'pkg-ng', {
+      schematics: {
+        'ng-mig': { version: '1.0.0', factory: './does-not-matter' },
+      },
+    });
+    mockCreateProjectGraphAsync.mockResolvedValue({});
+    mockReadProjectsConfigurationFromProjectGraph.mockReturnValue({
+      projects: {},
+    });
+    mockNgRunMigration.mockResolvedValue({
+      changes: [{ type: 'CREATE', path: 'x.ts', content: Buffer.from('') }],
+      madeChanges: true,
+      loggingQueue: ['a', 'b'],
+    });
+
+    const result = await runNxOrAngularMigration(
+      tmpRoot,
+      { package: 'pkg-ng', name: 'ng-mig', version: '1.0.0' },
+      false
+    );
+
+    expect(mockNgRunMigration).toHaveBeenCalledTimes(1);
+    expect(result.madeChanges).toBe(true);
+    expect(result.logs).toBe('a\nb');
+    expect(result.changes).toHaveLength(1);
+    expect(result.nextSteps).toEqual([]);
+    expect(result.agentContext).toEqual([]);
+  });
+});
+
+describe('ChangedDepInstaller', () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'nx-migrate-deps-'));
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  const writePackageJson = (extra: Record<string, unknown> = {}): void => {
+    writeFileSync(
+      join(tmpRoot, 'package.json'),
+      JSON.stringify({
+        name: 'workspace',
+        version: '0.0.0',
+        dependencies: { foo: '1.0.0' },
+        ...extra,
+      })
+    );
+  };
+
+  it('does not install when dependencies are unchanged', async () => {
+    writePackageJson();
+    const installer = new ChangedDepInstaller(tmpRoot);
+
+    await installer.installDepsIfChanged();
+
+    expect(mockSpawn).not.toHaveBeenCalled();
+  });
+
+  it('skips the install and reports skippedInstall when shouldSkipInstall is true', async () => {
+    writePackageJson();
+    const installer = new ChangedDepInstaller(tmpRoot, true);
+    writePackageJson({ dependencies: { foo: '2.0.0' } });
+
+    await installer.installDepsIfChanged();
+
+    expect(installer.skippedInstall).toBe(true);
+    expect(mockSpawn).not.toHaveBeenCalled();
+  });
+
+  it('spawns the install command when dependencies changed', async () => {
+    writePackageJson();
+    const installer = new ChangedDepInstaller(tmpRoot, false);
+    writePackageJson({ dependencies: { foo: '2.0.0' } });
+    const child = new FakeChildProcess();
+    mockSpawn.mockReturnValue(child);
+
+    const promise = installer.installDepsIfChanged();
+    child.emit('close', 0);
+    await promise;
+
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+    expect(mockSpawn.mock.calls[0][0]).toContain('install');
+  });
+
+  it('does not spawn a second install when nothing changes after a prior install', async () => {
+    writePackageJson();
+    const installer = new ChangedDepInstaller(tmpRoot, false);
+    writePackageJson({ dependencies: { foo: '2.0.0' } });
+    const child = new FakeChildProcess();
+    mockSpawn.mockReturnValue(child);
+
+    const firstInstall = installer.installDepsIfChanged();
+    child.emit('close', 0);
+    await firstInstall;
+
+    await installer.installDepsIfChanged();
+
+    expect(mockSpawn).toHaveBeenCalledTimes(1);
+  });
+
+  it('treats a missing package.json as an empty dependency set, so writing one counts as a change', async () => {
+    // tmpRoot has no package.json at construction time.
+    const installer = new ChangedDepInstaller(tmpRoot, true);
+    writePackageJson();
+
+    await installer.installDepsIfChanged();
+
+    expect(installer.skippedInstall).toBe(true);
+  });
+
+  describe('install error classification', () => {
+    beforeEach(() => {
+      // package-lock.json makes detectPackageManager resolve to npm, which is
+      // the only package manager whose stderr is inspected for classification.
+      writeFileSync(join(tmpRoot, 'package-lock.json'), '{}');
+    });
+
+    it('rejects with NpmPeerDepsInstallError when npm stderr reports ERESOLVE', async () => {
+      writePackageJson();
+      const installer = new ChangedDepInstaller(tmpRoot, false);
+      writePackageJson({ dependencies: { foo: '2.0.0' } });
+      const child = new FakeChildProcess(true);
+      mockSpawn.mockReturnValue(child);
+
+      const promise = installer.installDepsIfChanged();
+      child.stderr!.emit(
+        'data',
+        Buffer.from('npm ERR! code ERESOLVE\nunable to resolve dependency tree')
+      );
+      child.emit('close', 1);
+
+      await expect(promise).rejects.toMatchObject({
+        name: 'NpmPeerDepsInstallError',
+      });
+    });
+
+    it('rejects with a generic command-failed error for non-ERESOLVE npm failures', async () => {
+      writePackageJson();
+      const installer = new ChangedDepInstaller(tmpRoot, false);
+      writePackageJson({ dependencies: { foo: '2.0.0' } });
+      const child = new FakeChildProcess(true);
+      mockSpawn.mockReturnValue(child);
+
+      const promise = installer.installDepsIfChanged();
+      child.stderr!.emit('data', Buffer.from('npm ERR! some other failure'));
+      child.emit('close', 1);
+
+      await expect(promise).rejects.toThrow(/^Command failed:/);
+    });
+  });
+});
+
+describe('executeMigrations', () => {
+  let tmpRoot: string;
+  let pkgDir: string;
+
+  beforeEach(() => {
+    tmpRoot = mkdtempSync(join(tmpdir(), 'nx-migrate-execute-'));
+    pkgDir = installMigrationPackage(tmpRoot, 'exec-plugin', {
+      generators: {
+        'mig-a': { version: '1.0.0', implementation: './mig-a.js' },
+        'mig-b': { version: '1.0.0', implementation: './mig-b.js' },
+        'mig-c': { version: '1.0.0', implementation: './mig-c.js' },
+        '15-7-0-split-configuration-into-project-json-files': {
+          version: '1.0.0',
+          implementation: './split.js',
+        },
+      },
+    });
+    for (const name of ['mig-a', 'mig-b', 'mig-c', 'split']) {
+      writeImplFile(
+        pkgDir,
+        `${name}.js`,
+        `module.exports.default = async function (tree) {
+          tree.write('${name}.txt', '${name}');
+          return [];
+        };`
+      );
+    }
+  });
+
+  afterEach(() => {
+    rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  const migration = (name: string, version: string) => ({
+    package: 'exec-plugin',
+    name,
+    version,
+  });
+
+  it('runs migrations in ascending version order regardless of input order', async () => {
+    mockCommitMigrationIfRequested.mockResolvedValue({
+      status: 'committed',
+      sha: 'sha',
+    });
+
+    await executeMigrations(
+      tmpRoot,
+      [
+        migration('mig-c', '3.0.0'),
+        migration('mig-a', '1.0.0'),
+        migration('mig-b', '2.0.0'),
+      ],
+      false,
+      true,
+      'chore(repo): ',
+      true
+    );
+
+    const order = mockCommitMigrationIfRequested.mock.calls.map(
+      (call) => call[1].name
+    );
+    expect(order).toEqual(['mig-a', 'mig-b', 'mig-c']);
+  });
+
+  it('always runs the split-configuration migration first regardless of version', async () => {
+    mockCommitMigrationIfRequested.mockResolvedValue({
+      status: 'committed',
+      sha: 'sha',
+    });
+
+    await executeMigrations(
+      tmpRoot,
+      [
+        migration('mig-a', '1.0.0'),
+        migration(
+          '15-7-0-split-configuration-into-project-json-files',
+          '99.0.0'
+        ),
+      ],
+      false,
+      true,
+      'chore(repo): ',
+      true
+    );
+
+    const order = mockCommitMigrationIfRequested.mock.calls.map(
+      (call) => call[1].name
+    );
+    expect(order[0]).toBe('15-7-0-split-configuration-into-project-json-files');
+  });
+
+  it('passes prior failed-commit migrations as pending to the next commit, and clears them once absorbed', async () => {
+    mockCommitMigrationIfRequested
+      .mockResolvedValueOnce({ status: 'failed', reason: 'boom' })
+      .mockResolvedValueOnce({ status: 'committed', sha: 'abc' })
+      .mockResolvedValueOnce({ status: 'committed', sha: 'def' });
+
+    await executeMigrations(
+      tmpRoot,
+      [
+        migration('mig-a', '1.0.0'),
+        migration('mig-b', '2.0.0'),
+        migration('mig-c', '3.0.0'),
+      ],
+      false,
+      true,
+      'chore(repo): ',
+      true
+    );
+
+    expect(mockCommitMigrationIfRequested.mock.calls[0][5]).toEqual([]);
+    expect(mockCommitMigrationIfRequested.mock.calls[1][5]).toEqual([
+      { package: 'exec-plugin', name: 'mig-a' },
+    ]);
+    expect(mockCommitMigrationIfRequested.mock.calls[2][5]).toEqual([]);
+  });
+
+  it('does not carry no-changes or disabled commit results into a later pending list', async () => {
+    mockCommitMigrationIfRequested
+      .mockResolvedValueOnce({ status: 'no-changes' })
+      .mockResolvedValueOnce({ status: 'disabled' })
+      .mockResolvedValueOnce({ status: 'committed', sha: 'xyz' });
+
+    await executeMigrations(
+      tmpRoot,
+      [
+        migration('mig-a', '1.0.0'),
+        migration('mig-b', '2.0.0'),
+        migration('mig-c', '3.0.0'),
+      ],
+      false,
+      true,
+      'chore(repo): ',
+      true
+    );
+
+    expect(mockCommitMigrationIfRequested.mock.calls[2][5]).toEqual([]);
+  });
+});

--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -1,7 +1,6 @@
 import * as pc from 'picocolors';
-import { exec, execSync, spawn, type StdioOptions } from 'child_process';
+import { exec, execSync, type StdioOptions } from 'child_process';
 import { canPrompt, migratePrompt } from './safe-prompt';
-import { handleImport } from '../../utils/handle-import';
 import { dirname, join, relative } from 'path';
 import { createRequire } from 'module';
 import { joinPathFragments } from '../../utils/path';
@@ -26,12 +25,6 @@ import {
   PackageJsonUpdates,
 } from '../../config/misc-interfaces';
 import { NxJsonConfiguration } from '../../config/nx-json';
-import {
-  FileChange,
-  flushChanges,
-  FsTree,
-  printChanges,
-} from '../../generators/tree';
 import {
   fileExists,
   JsonReadOptions,
@@ -93,10 +86,6 @@ import { readNxJson } from '../../config/configuration';
 import { runNxSync } from '../../utils/child-process';
 import { daemonClient } from '../../daemon/client/client';
 import { isNxCloudUsed, isNxCloudDisabled } from '../../utils/nx-cloud-utils';
-import {
-  createProjectGraphAsync,
-  readProjectsConfigurationFromProjectGraph,
-} from '../../project-graph/project-graph';
 import { formatFilesWithPrettierIfAvailable } from '../../generators/internal-utils/format-changed-files-with-prettier-if-available';
 import {
   ensurePackageHasProvenance,
@@ -176,7 +165,16 @@ import {
   normalizeVersion,
   normalizeVersionWithTagCheck,
 } from './version-utils';
+import {
+  ChangedDepInstaller,
+  NpmPeerDepsInstallError,
+  readMigrationCollection,
+  readPackageMigrationConfig,
+  runInstall,
+  runNxOrAngularMigration,
+} from './execute-migration';
 
+export * from './execute-migration';
 export { normalizeVersion };
 
 export interface ResolvedMigrationConfiguration extends MigrationsJson {
@@ -2013,47 +2011,6 @@ async function getPackageMigrationsUsingInstallImpl(
   return result;
 }
 
-interface PackageMigrationConfig extends NxMigrationsConfiguration {
-  packageJson: PackageJson;
-  packageGroup: ArrayPackageGroup;
-}
-
-function readPackageMigrationConfig(
-  packageName: string,
-  dir: string
-): PackageMigrationConfig {
-  const { path: packageJsonPath, packageJson: json } = readModulePackageJson(
-    packageName,
-    getNxRequirePaths(dir)
-  );
-
-  const config = readNxMigrateConfig(json);
-
-  if (!config) {
-    return { packageJson: json, migrations: null, packageGroup: [] };
-  }
-
-  try {
-    const migrationFile = require.resolve(config.migrations, {
-      paths: [dirname(packageJsonPath)],
-    });
-
-    return {
-      packageJson: json,
-      migrations: migrationFile,
-      packageGroup: config.packageGroup,
-      supportsOptionalMigrations: config.supportsOptionalMigrations,
-    };
-  } catch {
-    return {
-      packageJson: json,
-      migrations: null,
-      packageGroup: config.packageGroup,
-      supportsOptionalMigrations: config.supportsOptionalMigrations,
-    };
-  }
-}
-
 async function createMigrationsFile(
   root: string,
   migrations: {
@@ -2545,140 +2502,6 @@ function showConnectToCloudMessage() {
     return !!defaultRunnerIsUsed;
   } catch {
     return false;
-  }
-}
-
-function runInstall(
-  nxWorkspaceRoot?: string,
-  phase: MigrationInstallPhase = 'pre-migration'
-): Promise<void> {
-  const cwd = nxWorkspaceRoot ?? process.cwd();
-  const packageManager = detectPackageManager(cwd);
-  const pmCommands = getPackageManagerCommand(packageManager, cwd);
-
-  const installCommand = `${pmCommands.install} ${
-    pmCommands.ignoreScriptsFlag ?? ''
-  }`;
-  output.log({
-    title: `Running '${installCommand}' to make sure necessary packages are installed`,
-  });
-
-  return new Promise<void>((resolve, reject) => {
-    // For npm, pipe stderr so we can detect peer dependency errors while still
-    // mirroring it live to the user's terminal. Other package managers inherit
-    // stderr directly since we don't need to inspect their output.
-    const shouldCaptureStderr = packageManager === 'npm';
-    const child = spawn(installCommand, {
-      shell: true,
-      stdio: ['inherit', 'inherit', shouldCaptureStderr ? 'pipe' : 'inherit'],
-      windowsHide: true,
-      cwd,
-    });
-
-    const stderrChunks: Buffer[] = [];
-    child.stderr?.on('data', (chunk: Buffer) => {
-      process.stderr.write(chunk);
-      stderrChunks.push(chunk);
-    });
-
-    child.on('error', reject);
-
-    child.on('close', (code) => {
-      if (code === 0) {
-        resolve();
-        return;
-      }
-
-      if (shouldCaptureStderr) {
-        const stderr = Buffer.concat(stderrChunks).toString().trim();
-        if (isNpmPeerDepsError(stderr)) {
-          // Log the remediation guidance here so every caller of `runInstall`
-          // (CLI migrate, `nx repair`, single-migration runner, etc.) surfaces
-          // it consistently. Top-level callers catch `NpmPeerDepsInstallError`
-          // and return a non-zero exit code without re-logging.
-          logNpmPeerDepsError(phase);
-          reject(new NpmPeerDepsInstallError());
-          return;
-        }
-      }
-
-      reject(new Error(`Command failed: ${installCommand}`));
-    });
-  });
-}
-
-type MigrationInstallPhase = 'pre-migration' | 'post-migration';
-
-class NpmPeerDepsInstallError extends Error {
-  constructor() {
-    super('npm install failed due to peer dependency conflicts.');
-    this.name = 'NpmPeerDepsInstallError';
-  }
-}
-
-/**
- * Detects npm peer-dependency resolution failures. Keyed on the `ERESOLVE`
- * error code, which npm consistently emits for this class of failure across
- * v7+ (`npm ERR! code ERESOLVE` / `npm error code ERESOLVE`). Falls back to a
- * small set of stable phrases in case the code line is missing from the
- * captured output.
- */
-export function isNpmPeerDepsError(stderr: string): boolean {
-  if (/\bERESOLVE\b/.test(stderr)) {
-    return true;
-  }
-  const lowerStderr = stderr.toLowerCase();
-  return (
-    lowerStderr.includes('unable to resolve dependency tree') ||
-    lowerStderr.includes('could not resolve dependency') ||
-    lowerStderr.includes('conflicting peer dependency')
-  );
-}
-
-function logNpmPeerDepsError(phase: MigrationInstallPhase): void {
-  const peerDepsResolutionSteps = [
-    'Recommended approaches (in order of preference):',
-    '',
-    '1. Use "overrides" in package.json to force compatible versions across the dependency tree.',
-    '   See https://docs.npmjs.com/cli/configuring-npm/package-json#overrides',
-    '2. Persist legacy peer deps resolution in the project ".npmrc":',
-    '   npm config set legacy-peer-deps=true --location=project',
-    '   (bypasses peer dependency resolution; use with caution)',
-    '3. As a last resort, force the installation by running "npm install --force".',
-    '   (does not persist and may produce broken installs)',
-  ];
-  const manualInstallHint = [
-    'If you installed the dependencies manually, pass "--skip-install" to avoid re-installing them:',
-    '   nx migrate --run-migrations --skip-install',
-  ];
-
-  if (phase === 'pre-migration') {
-    output.error({
-      title:
-        'You need to resolve the peer dependency conflicts before the migration can continue',
-      bodyLines: [
-        ...peerDepsResolutionSteps,
-        '',
-        'Once the conflicts are resolved, re-run the migrations:',
-        '   nx migrate --run-migrations',
-        '',
-        ...manualInstallHint,
-      ],
-    });
-  } else {
-    output.error({
-      title:
-        'Some migrations have been applied, but installing the updated dependencies failed',
-      bodyLines: [
-        ...peerDepsResolutionSteps,
-        '',
-        'Once the conflicts are resolved, run "npm install" to install the updated dependencies.',
-        'If the migration was interrupted before completing, re-run the remaining migrations:',
-        '   nx migrate --run-migrations',
-        '',
-        ...manualInstallHint,
-      ],
-    });
   }
 }
 
@@ -3287,34 +3110,6 @@ export async function executeMigrations(
   };
 }
 
-export class ChangedDepInstaller {
-  private initialDeps: string;
-  private _skippedInstall = false;
-
-  constructor(
-    private readonly root: string,
-    private readonly shouldSkipInstall = false
-  ) {
-    this.initialDeps = getStringifiedPackageJsonDeps(root);
-  }
-
-  public get skippedInstall(): boolean {
-    return this._skippedInstall;
-  }
-
-  public async installDepsIfChanged(): Promise<void> {
-    const currentDeps = getStringifiedPackageJsonDeps(this.root);
-    if (this.initialDeps !== currentDeps) {
-      if (this.shouldSkipInstall) {
-        this._skippedInstall = true;
-      } else {
-        await runInstall(this.root, 'post-migration');
-      }
-    }
-    this.initialDeps = currentDeps;
-  }
-}
-
 function logSkippedPostMigrationInstall(root: string): void {
   const packageManager = detectPackageManager(root);
   const installCommand = getPackageManagerCommand(packageManager, root).install;
@@ -3322,92 +3117,6 @@ function logSkippedPostMigrationInstall(root: string): void {
     title: 'Migrations updated your dependencies, but the install was skipped',
     bodyLines: [`Run "${installCommand}" to install the updated dependencies.`],
   });
-}
-
-export async function runNxOrAngularMigration(
-  root: string,
-  migration: {
-    package: string;
-    name: string;
-    description?: string;
-    version: string;
-  },
-  isVerbose: boolean,
-  captureGeneratorOutput = false,
-  resolvedCollection?: { collection: MigrationsJson; collectionPath: string }
-): Promise<{
-  changes: FileChange[];
-  nextSteps: string[];
-  agentContext: string[];
-  logs: string;
-  madeChanges: boolean;
-}> {
-  const { collection, collectionPath } =
-    resolvedCollection ?? readMigrationCollection(migration.package, root);
-  let changes: FileChange[] = [];
-  let nextSteps: string[] = [];
-  let agentContext: string[] = [];
-  let logs = '';
-  // Angular's `ngResult.changes` is synthesized from the schematic's
-  // DryRunEvent stream so Nx and Angular paths can share commit/validation
-  // gating via `changes.length > 0`.
-  let madeChanges = false;
-  logger.info(pc.dim('→ Running generator…'));
-  if (!isAngularMigration(collection, migration.name)) {
-    ({ nextSteps, changes, agentContext, logs } = await runNxMigration(
-      root,
-      collectionPath,
-      collection,
-      migration.name,
-      migration.version,
-      captureGeneratorOutput
-    ));
-    madeChanges = changes.length > 0;
-
-    logger.info(`Ran ${migration.name} from ${migration.package}`);
-    if (migration.description) {
-      logger.info(`  ${migration.description}`);
-    }
-    logger.info('');
-    if (!madeChanges) {
-      logger.info(`No changes were made\n`);
-      return { changes, nextSteps, agentContext, logs, madeChanges };
-    }
-
-    logger.info('Changes:');
-    printChanges(changes, '  ');
-    logger.info('');
-  } else {
-    const ngCliAdapter = await getNgCompatLayer();
-    const migrationProjectGraph = await createProjectGraphAsync();
-    const ngResult = await ngCliAdapter.runMigration(
-      root,
-      migration.package,
-      migration.name,
-      readProjectsConfigurationFromProjectGraph(migrationProjectGraph).projects,
-      isVerbose,
-      migrationProjectGraph
-    );
-    changes = ngResult.changes;
-    madeChanges = ngResult.madeChanges;
-    logs = ngResult.loggingQueue.join('\n');
-
-    logger.info(`Ran ${migration.name} from ${migration.package}`);
-    if (migration.description) {
-      logger.info(`  ${migration.description}`);
-    }
-    logger.info('');
-    if (!madeChanges) {
-      logger.info(`No changes were made\n`);
-      return { changes, nextSteps, agentContext, logs, madeChanges };
-    }
-
-    logger.info('Changes:');
-    ngResult.loggingQueue.forEach((log) => logger.info('  ' + log));
-    logger.info('');
-  }
-
-  return { changes, nextSteps, agentContext, logs, madeChanges };
 }
 
 async function runMigrations(
@@ -3675,83 +3384,6 @@ async function runMigrations(
   });
 }
 
-function getStringifiedPackageJsonDeps(root: string): string {
-  try {
-    const { dependencies, devDependencies } = readJsonFile<PackageJson>(
-      join(root, 'package.json')
-    );
-
-    return JSON.stringify([dependencies, devDependencies]);
-  } catch {
-    // We don't really care if the .nx/installation property changes,
-    // whenever nxw is invoked it will handle the dep updates.
-    return '';
-  }
-}
-
-async function runNxMigration(
-  root: string,
-  collectionPath: string,
-  collection: MigrationsJson,
-  name: string,
-  migrationVersion: string | undefined,
-  captureGeneratorOutput: boolean
-) {
-  const { path: implPath, fnSymbol } = getImplementationPath(
-    collection,
-    collectionPath,
-    name,
-    migrationVersion
-  );
-  const fn = require(implPath)[fnSymbol];
-  const host = new FsTree(
-    root,
-    process.env.NX_VERBOSE_LOGGING === 'true',
-    `migration ${collection.name}:${name}`
-  );
-  let result: unknown;
-  let logs = '';
-  if (captureGeneratorOutput) {
-    const { withGeneratorOutputCapture } =
-      require('./agentic/capture-generator-output') as typeof import('./agentic/capture-generator-output');
-    ({ result, logs } = await withGeneratorOutputCapture(() => fn(host, {})));
-  } else {
-    result = await fn(host, {});
-  }
-  const { nextSteps, agentContext } = parseMigrationReturn(result);
-  host.lock();
-  const changes = host.listChanges();
-  flushChanges(root, changes);
-  return { changes, nextSteps, agentContext, logs };
-}
-
-export function parseMigrationReturn(value: unknown): {
-  nextSteps: string[];
-  agentContext: string[];
-} {
-  if (Array.isArray(value)) {
-    return { nextSteps: filterStrings(value), agentContext: [] };
-  }
-  if (value && typeof value === 'object') {
-    const obj = value as Record<string, unknown>;
-    return {
-      nextSteps: filterStrings(obj.nextSteps),
-      agentContext: filterStrings(obj.agentContext),
-    };
-  }
-  // Catches `void`, mistakenly-returned generator callbacks, malformed values.
-  return { nextSteps: [], agentContext: [] };
-}
-
-// Bucket-level tolerance: a single non-string entry shouldn't discard the
-// whole `nextSteps` / `agentContext` array. Migration authors occasionally
-// push `null` / `undefined` / a number into the array; we drop the bad entries
-// and keep the rest so end-of-run guidance isn't silently lost.
-function filterStrings(value: unknown): string[] {
-  if (!Array.isArray(value)) return [];
-  return value.filter((v): v is string => typeof v === 'string');
-}
-
 export async function migrate(
   root: string,
   args: { [k: string]: any },
@@ -3846,61 +3478,6 @@ export async function runMigration() {
   });
 }
 
-export function readMigrationCollection(packageName: string, root: string) {
-  const collectionPath = readPackageMigrationConfig(
-    packageName,
-    root
-  ).migrations;
-  const collection = readJsonFile<MigrationsJson>(collectionPath);
-  collection.name ??= packageName;
-  return {
-    collection,
-    collectionPath,
-  };
-}
-
-export function getImplementationPath(
-  collection: MigrationsJson,
-  collectionPath: string,
-  name: string,
-  migrationVersion?: string
-): { path: string; fnSymbol: string } {
-  const g = collection.generators?.[name] || collection.schematics?.[name];
-  if (!g) {
-    throw new MigrationImplementationMissingError(
-      `Unable to determine implementation path for "${collectionPath}:${name}"`,
-      collectionPath,
-      migrationVersion
-    );
-  }
-  const implRelativePathAndMaybeSymbol = g.implementation || g.factory;
-  const [implRelativePath, fnSymbol = 'default'] =
-    implRelativePathAndMaybeSymbol.split('#');
-
-  let implPath: string;
-
-  try {
-    implPath = require.resolve(implRelativePath, {
-      paths: [dirname(collectionPath)],
-    });
-  } catch (e) {
-    try {
-      // workaround for a bug in node 12
-      implPath = require.resolve(
-        `${dirname(collectionPath)}/${implRelativePath}`
-      );
-    } catch {
-      throw new MigrationImplementationMissingError(
-        `Could not resolve implementation for migration "${name}" from "${collectionPath}"`,
-        collectionPath,
-        migrationVersion ?? g.version
-      );
-    }
-  }
-
-  return { path: implPath, fnSymbol };
-}
-
 /**
  * Resolves a migration's collection once and derives everything the run loop
  * needs from that single read: the implementation context (`collection` +
@@ -3983,78 +3560,6 @@ export function resolveDocumentationFileToWorkspacePath(
   }
   const relativePath = relative(root, documentationFile);
   return relativePath.startsWith('..') ? documentationFile : relativePath;
-}
-
-class MigrationImplementationMissingError extends Error {
-  constructor(
-    baseMessage: string,
-    collectionPath: string,
-    migrationVersion: string | undefined
-  ) {
-    super(
-      buildMigrationMissingMessage(
-        baseMessage,
-        collectionPath,
-        migrationVersion
-      )
-    );
-    this.name = 'MigrationImplementationMissingError';
-  }
-}
-
-function buildMigrationMissingMessage(
-  baseMessage: string,
-  collectionPath: string,
-  migrationVersion: string | undefined
-): string {
-  if (!migrationVersion) {
-    return baseMessage;
-  }
-
-  try {
-    const packageJsonPath = join(dirname(collectionPath), 'package.json');
-    if (!existsSync(packageJsonPath)) {
-      return baseMessage;
-    }
-    const packageJson = readJsonFile<PackageJson>(packageJsonPath);
-    const installedVersion = packageJson.version;
-
-    if (
-      installedVersion &&
-      lt(normalizeVersion(installedVersion), normalizeVersion(migrationVersion))
-    ) {
-      const packageManager = detectPackageManager();
-      const pmc = getPackageManagerCommand(packageManager);
-      const overrideFieldName = getOverrideFieldName(packageManager);
-
-      return (
-        `${baseMessage}\n\n` +
-        `The installed version of "${packageJson.name}" is ${installedVersion}, ` +
-        `but this migration requires version ${migrationVersion}. ` +
-        `This likely means the package version is being held back by an ${overrideFieldName} ` +
-        `in your package.json. ` +
-        `Remove the ${overrideFieldName} and run "${pmc.install}" to install the correct version.`
-      );
-    }
-  } catch {
-    // Fall through to return the base message if we can't read package info
-  }
-
-  return baseMessage;
-}
-
-function getOverrideFieldName(
-  packageManager: ReturnType<typeof detectPackageManager>
-): string {
-  switch (packageManager) {
-    case 'pnpm':
-      return '"pnpm.overrides"';
-    case 'yarn':
-      return '"resolutions"';
-    case 'npm':
-    case 'bun':
-      return '"overrides"';
-  }
 }
 
 export async function nxCliPath(nxWorkspaceRoot?: string) {
@@ -4142,21 +3647,3 @@ function addToNodePath(dir: string) {
   // Update the env variable.
   process.env.NODE_PATH = paths.join(delimiter);
 }
-
-function isAngularMigration(collection: MigrationsJson, name: string) {
-  return !collection.generators?.[name] && collection.schematics?.[name];
-}
-
-const getNgCompatLayer = (() => {
-  let _ngCliAdapter: typeof import('../../adapter/ngcli-adapter');
-  return async function getNgCompatLayer() {
-    if (!_ngCliAdapter) {
-      _ngCliAdapter = await handleImport(
-        '../../adapter/ngcli-adapter.js',
-        __dirname
-      );
-      require('../../adapter/compat');
-    }
-    return _ngCliAdapter;
-  };
-})();


### PR DESCRIPTION
## Current Behavior

The migration execution logic (running a single nx or Angular migration, dependency-diff installs, install error classification) lives inline in migrate.ts and has no unit coverage.

## Expected Behavior

No behavior change. Characterization specs pin the execute zone's current behavior first (dispatch between nx generators and ng-compat schematics, ChangedDepInstaller's dep-diff detection and skip-install warning, commit and absorption semantics, install error classification), then the engine moves verbatim into execute-migration.ts. migrate.ts re-exports every moved symbol and a spec asserts the re-export set, so consumers (including Nx Console's runSingleMigration API and the run-migration-process child protocol, both pinned by contract tests) are unaffected.

> [!NOTE]
> Part 1 of 3: #36407 (nx migrate --run-migration) stacks on this, and #36403 (durable run state + dark orchestrator) stacks on #36407.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/nxc-4626-f17a61ba)
<!-- polygraph-session-end -->