### PR TITLE
feat(core): add nx migrate --run-migration to run a single migration

### DIFF
--- a/e2e/nx/src/misc.test.ts
+++ b/e2e/nx/src/misc.test.ts
@@ -1,5 +1,6 @@
 import type { NxJsonConfiguration, ProjectConfiguration } from '@nx/devkit';
 import {
+  checkFilesDoNotExist,
   cleanupProject,
   createNonNxProjectDirectory,
   e2eCwd,
@@ -1024,6 +1025,50 @@ describe('migrate', () => {
       expect(recentCommits).toContain('chore(core): AUTOMATED - run11');
       expect(recentCommits).toContain('chore(core): AUTOMATED - run20');
     }
+  });
+
+  it('should run a single migration with --run-migration without recording run state', () => {
+    runCLI(
+      'migrate migrate-parent-package@2.0.0 --from="migrate-parent-package@1.0.0"',
+      {
+        env: {
+          NX_MIGRATE_SKIP_INSTALL: 'true',
+          NX_MIGRATE_USE_LOCAL: 'true',
+        },
+      }
+    );
+
+    runCLI('migrate --run-migration=migrate-parent-package:run20', {
+      env: {
+        NX_MIGRATE_SKIP_INSTALL: 'true',
+        NX_MIGRATE_USE_LOCAL: 'true',
+      },
+    });
+
+    // only the requested migration runs
+    expect(readFile('file-20')).toEqual('content20');
+    checkFilesDoNotExist('file-11');
+    // stateless: no durable run dir and no commit without --create-commits
+    checkFilesDoNotExist('.nx/migrate-runs');
+    expect(runCommand('git --no-pager log --oneline -n 10')).not.toContain(
+      'chore: [nx migration] run20'
+    );
+
+    // commits are opt-in with --create-commits
+    runCLI(
+      'migrate --run-migration=migrate-parent-package:run11 --create-commits',
+      {
+        env: {
+          NX_MIGRATE_SKIP_INSTALL: 'true',
+          NX_MIGRATE_USE_LOCAL: 'true',
+        },
+      }
+    );
+
+    expect(readFile('file-11')).toEqual('content11');
+    const recentCommits = runCommand('git --no-pager log --oneline -n 10');
+    expect(recentCommits).toContain('chore: [nx migration] run11');
+    expect(recentCommits).not.toContain('chore: [nx migration] run20');
   });
 
   it('should fail if a custom commit prefix is provided when --create-commits is not enabled', () => {

--- a/packages/nx/eslint.config.mjs
+++ b/packages/nx/eslint.config.mjs
@@ -62,6 +62,91 @@ export default [
     ignores: ['**/*.spec.ts'],
   },
   {
+    // Siblings under migrate/ (including subtrees like agentic/) must go
+    // through migrate/run/'s barrel rather than reaching into its internal
+    // modules directly. run/ itself is excluded via ignores: importing those
+    // modules directly is the normal intra-directory pattern there.
+    files: ['src/command-line/migrate/**/*.ts'],
+    rules: {
+      '@typescript-eslint/no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: 'typescript',
+              message:
+                'TypeScript is an optional dependency for Nx. If you need to use it, make sure its installed first with ensureTypescript.',
+              allowTypeImports: true,
+            },
+          ],
+          patterns: [
+            {
+              group: ['nx/*'],
+              message: "Circular import in 'nx' found. Use relative path.",
+            },
+            {
+              group: ['**/native-bindings', '**/native-bindings.js'],
+              message:
+                'Direct imports from native-bindings.js are not allowed. Import from index.js instead.',
+            },
+            {
+              // Depth-independent: matches the relative form from migrate/
+              // itself ('./run/*') and from any nested subtree
+              // ('../run/*', '../../run/*', ...).
+              group: ['**/run/*'],
+              message:
+                "Import migrate/run's public surface from its barrel ('./run'), not its internal modules directly.",
+            },
+            {
+              group: ['**/execute-migration', '**/execute-migration.js'],
+              message:
+                "Import the execution engine through './migrate', which re-exports its whole surface.",
+            },
+          ],
+        },
+      ],
+    },
+    ignores: ['**/*.spec.ts', '**/migrate.ts', '**/migrate/run/**'],
+  },
+  {
+    // The inverse boundary: run/ must not import migrate.ts, which would
+    // close an import cycle (migrate.ts already imports run/'s barrel).
+    // Importing other shared helpers under migrate/ (execute-migration,
+    // migrate-commits, sort-migrations, agentic/*, etc.) is fine.
+    files: ['src/command-line/migrate/run/**/*.ts'],
+    rules: {
+      '@typescript-eslint/no-restricted-imports': [
+        'error',
+        {
+          paths: [
+            {
+              name: 'typescript',
+              message:
+                'TypeScript is an optional dependency for Nx. If you need to use it, make sure its installed first with ensureTypescript.',
+              allowTypeImports: true,
+            },
+          ],
+          patterns: [
+            {
+              group: ['nx/*'],
+              message: "Circular import in 'nx' found. Use relative path.",
+            },
+            {
+              group: ['**/native-bindings', '**/native-bindings.js'],
+              message:
+                'Direct imports from native-bindings.js are not allowed. Import from index.js instead.',
+            },
+            {
+              group: ['**/migrate', '**/migrate.js'],
+              message:
+                "Importing migrate.ts from migrate/run closes an import cycle: migrate.ts already imports run's barrel. Import the shared helper modules under migrate/ directly instead.",
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
     files: ['./package.json', './executors.json', './migrations.json'],
     rules: {
       '@nx/nx-plugin-checks': [

--- a/packages/nx/src/command-line/migrate/command-object.ts
+++ b/packages/nx/src/command-line/migrate/command-object.ts
@@ -9,7 +9,8 @@ export const yargsMigrateCommand: CommandModule = {
   command: 'migrate [packageAndVersion]',
   describe: `Creates a migrations file or runs migrations from the migrations file.
   - Migrate packages and create migrations.json (e.g., nx migrate @nx/workspace@latest)
-  - Run migrations (e.g., nx migrate --run-migrations=migrations.json). Use flag --if-exists to run migrations only if the migrations file exists.`,
+  - Run migrations (e.g., nx migrate --run-migrations=migrations.json). Use flag --if-exists to run migrations only if the migrations file exists.
+  - Run a single migration from the migrations file by id (e.g., nx migrate --run-migration=@nx/js:my-migration).`,
   builder: (yargs) =>
     linkToNxDevAndExamples(withMigrationOptions(yargs), 'migrate'),
   handler: async () =>
@@ -48,6 +49,7 @@ export type MultiMajorMode = (typeof MULTI_MAJOR_MODES)[number];
 export interface MigrateArgs {
   packageAndVersion?: string;
   runMigrations?: string;
+  runMigration?: string;
   include?: MigrateInclude;
   /**
    * nx.json `migrate.include` default. Consumed by `resolveInclude` only when the
@@ -98,6 +100,11 @@ function withMigrationOptions(yargs: Argv) {
     })
     .option('runMigrations', {
       describe: `Execute migrations from a file (when the file isn't provided, execute migrations from migrations.json).`,
+      type: 'string',
+    })
+    .option('runMigration', {
+      describe:
+        "Run a single migration from the migrations file by id. The id is '<package>:<name>'; a bare '<name>' is accepted when it matches exactly one migration.",
       type: 'string',
     })
     .option('ifExists', {

--- a/packages/nx/src/command-line/migrate/execute-migration.ts
+++ b/packages/nx/src/command-line/migrate/execute-migration.ts
@@ -210,6 +210,15 @@ export function logNpmPeerDepsError(phase: MigrationInstallPhase): void {
   }
 }
 
+export function logSkippedPostMigrationInstall(root: string): void {
+  const packageManager = detectPackageManager(root);
+  const installCommand = getPackageManagerCommand(packageManager, root).install;
+  output.warn({
+    title: 'Migrations updated your dependencies, but the install was skipped',
+    bodyLines: [`Run "${installCommand}" to install the updated dependencies.`],
+  });
+}
+
 export class ChangedDepInstaller {
   private initialDeps: string;
   private _skippedInstall = false;

--- a/packages/nx/src/command-line/migrate/migrate-analytics.spec.ts
+++ b/packages/nx/src/command-line/migrate/migrate-analytics.spec.ts
@@ -87,6 +87,7 @@ describe('GA4 event name length cap', () => {
       'migrate_generate_complete',
       'migrate_run_start',
       'migrate_run_complete',
+      'migrate_single_migration_run_standalone',
       ...Object.keys(PROMPT_NAMES).map((p) => `migrate_prompt_${p}`),
       ...Object.keys(GENERATE_ERROR_CODES).map(
         (c) => `migrate_generate_error_${c}`
@@ -438,6 +439,16 @@ describe('migrate-analytics events', () => {
       expect(paramsFor('migrate_run_error_migration_exec')).not.toHaveProperty(
         'migrationName'
       );
+    });
+  });
+
+  describe('single-migration events', () => {
+    it('reports the migration type on a standalone run', () => {
+      const a = load();
+      a.reportMigrateSingleMigrationRun({ migrationType: 'prompt' });
+      expect(paramsFor('migrate_single_migration_run_standalone')).toEqual({
+        promptChoice: 'prompt',
+      });
     });
   });
 });

--- a/packages/nx/src/command-line/migrate/migrate-analytics.ts
+++ b/packages/nx/src/command-line/migrate/migrate-analytics.ts
@@ -276,6 +276,21 @@ export function reportMigrateRunError(opts: {
   });
 }
 
+/**
+ * A single migration executed standalone by the worker. The migration's type
+ * rides the prompt-choice dimension.
+ */
+export function reportMigrateSingleMigrationRun(opts: {
+  migrationType: 'generator' | 'prompt' | 'hybrid';
+}): void {
+  safeReport(() => {
+    if (!customDimensions) return;
+    reportEvent('migrate_single_migration_run_standalone', {
+      [customDimensions.promptChoice]: opts.migrationType,
+    });
+  });
+}
+
 // `_migrate` runs either from a temp install of the latest CLI or from the
 // workspace-local installation; same signal as the run-phase re-dispatch
 // check in migrate.ts.

--- a/packages/nx/src/command-line/migrate/migrate-config.spec.ts
+++ b/packages/nx/src/command-line/migrate/migrate-config.spec.ts
@@ -227,6 +227,44 @@ describe('applyNxJsonMigrateDefaults', () => {
     });
   });
 
+  describe('single-migration phase', () => {
+    const base = { runMigration: '@nx/js:some-migration' };
+
+    it('fills the commit options from config but not run-loop or generate-only options', () => {
+      const config: NxMigrateConfiguration = {
+        createCommits: true,
+        commitPrefix: 'chore: migrate ',
+        agentic: 'claude-code',
+        validate: false,
+        include: 'required',
+        multiMajorMode: 'gradual',
+      };
+      const result = applyNxJsonMigrateDefaults(base, config, noEnv);
+      expect(result.createCommits).toBe(true);
+      expect(result.commitPrefix).toBe('chore: migrate ');
+      expect(result.agentic).toBeUndefined();
+      expect(result.validate).toBeUndefined();
+      expect(result.include).toBeUndefined();
+      expect(result.includeFromConfig).toBeUndefined();
+      expect(result.multiMajorMode).toBeUndefined();
+    });
+
+    it('lets the CLI commit flags win over config', () => {
+      const args = {
+        ...base,
+        createCommits: false,
+        commitPrefix: 'cli prefix ',
+      };
+      const config: NxMigrateConfiguration = {
+        createCommits: true,
+        commitPrefix: 'config prefix ',
+      };
+      const result = applyNxJsonMigrateDefaults(args, config, noEnv);
+      expect(result.createCommits).toBe(false);
+      expect(result.commitPrefix).toBe('cli prefix ');
+    });
+  });
+
   describe('generate-migrations phase', () => {
     const base = { packageAndVersion: 'nx@latest' };
 

--- a/packages/nx/src/command-line/migrate/migrate-config.ts
+++ b/packages/nx/src/command-line/migrate/migrate-config.ts
@@ -17,10 +17,11 @@ const MULTI_MAJOR_MODE_ENV = 'NX_MULTI_MAJOR_MODE';
  * args object; the input is not mutated.
  *
  * Phase-aware: generate-only options (`include`, `multiMajorMode`) are applied only
- * when not running migrations; run-only options (`createCommits`,
- * `commitPrefix`, `agentic`, `validate`) only when running migrations. This
- * mirrors where each option is consumed and avoids tripping the "cannot be
- * combined with --run-migrations" guards in `parseMigrationsOptions`.
+ * in the generate phase; `agentic`/`validate` only when running the whole
+ * migrations file; `createCommits`/`commitPrefix` when running the file or a
+ * single migration (`--run-migration`). This mirrors where each option is
+ * consumed and avoids tripping the "cannot be combined with --run-migrations"
+ * guards in `parseMigrationsOptions`.
  *
  * `include` is carried as `includeFromConfig` rather than `include` so it is never
  * mistaken for an explicit `--include`: `resolveInclude` applies it only when the
@@ -40,8 +41,11 @@ export function applyNxJsonMigrateDefaults(
   // `--run-migrations` with no value is normalized to '' by yargs, so a defined
   // (even empty-string) value means we're in the run-migrations phase.
   const isRunMigrations = merged.runMigrations !== undefined;
+  // The single-migration worker (`--run-migration`) shares the commit options
+  // with the run-migrations loop but nothing else.
+  const isSingleMigration = merged.runMigration !== undefined;
 
-  if (isRunMigrations) {
+  if (isRunMigrations || isSingleMigration) {
     if (
       merged.createCommits === undefined &&
       migrateConfig.createCommits !== undefined
@@ -60,6 +64,9 @@ export function applyNxJsonMigrateDefaults(
       assertType(migrateConfig.commitPrefix, 'string', 'commitPrefix');
       merged.commitPrefix = migrateConfig.commitPrefix;
     }
+  }
+
+  if (isRunMigrations && !isSingleMigration) {
     if (merged.agentic === undefined && migrateConfig.agentic !== undefined) {
       assertValidAgentic(migrateConfig.agentic);
       merged.agentic = coerceAgenticArg(migrateConfig.agentic) as AgenticArg;
@@ -68,7 +75,9 @@ export function applyNxJsonMigrateDefaults(
       assertType(migrateConfig.validate, 'boolean', 'validate');
       merged.validate = migrateConfig.validate;
     }
-  } else {
+  }
+
+  if (!isRunMigrations && !isSingleMigration) {
     if (merged.include === undefined && migrateConfig.include !== undefined) {
       assertOneOf(migrateConfig.include, MIGRATE_INCLUDE_VALUES, 'include');
       merged.includeFromConfig = migrateConfig.include;

--- a/packages/nx/src/command-line/migrate/migrate-guard-wiring.spec.ts
+++ b/packages/nx/src/command-line/migrate/migrate-guard-wiring.spec.ts
@@ -1,0 +1,177 @@
+// Dispatch-level tests asserting the version-skew-guard call sites in
+// migrate.ts run with the invocation's raw argv and before their hand-off to
+// the temp/local nx. The guard functions' own behavior is covered by
+// version-skew-guard.spec.ts. Kept in its own file so the module mocks below
+// (workspace-root, child-process, provenance) don't leak into the other
+// migrate specs.
+
+const mockAssertTempCli = jest.fn();
+const mockAssertWorkspaceNx = jest.fn();
+jest.mock('./version-skew-guard', () => ({
+  ...jest.requireActual('./version-skew-guard'),
+  assertTempCliSupportsNewMigrateFlags: (...args: unknown[]) =>
+    mockAssertTempCli(...args),
+  assertWorkspaceNxSupportsNewMigrateFlags: (...args: unknown[]) =>
+    mockAssertWorkspaceNx(...args),
+}));
+
+const mockEnsurePackageHasProvenance = jest.fn();
+jest.mock('../../utils/provenance', () => ({
+  ...jest.requireActual('../../utils/provenance'),
+  ensurePackageHasProvenance: (...args: unknown[]) =>
+    mockEnsurePackageHasProvenance(...args),
+}));
+
+const mockRunNxSync = jest.fn();
+jest.mock('../../utils/child-process', () => ({
+  ...jest.requireActual('../../utils/child-process'),
+  runNxSync: (...args: unknown[]) => mockRunNxSync(...args),
+}));
+
+jest.mock('./run', () => ({
+  runSingleMigrationWorker: jest.fn(),
+}));
+
+jest.mock('../../daemon/client/client', () => ({
+  daemonClient: {
+    stop: jest.fn().mockResolvedValue(undefined),
+    enabled: () => false,
+    reset: jest.fn(),
+  },
+}));
+
+jest.mock('../../config/configuration', () => ({
+  ...jest.requireActual('../../config/configuration'),
+  readNxJson: () => ({}),
+}));
+
+import { output } from '../../utils/output';
+import {
+  setWorkspaceRoot,
+  workspaceRoot as originalWorkspaceRoot,
+} from '../../utils/workspace-root';
+import { migrate, runMigration } from './migrate';
+
+const ROOT = '/virtual-root';
+
+function restoreEnv(name: string, value: string | undefined) {
+  if (value === undefined) delete process.env[name];
+  else process.env[name] = value;
+}
+
+describe('migrate() version-skew-guard wiring (temp-installation hand-off)', () => {
+  const originalArgv = process.argv;
+
+  beforeEach(() => {
+    mockAssertWorkspaceNx.mockReset().mockReturnValue(undefined);
+    mockRunNxSync.mockReset();
+    jest.spyOn(output, 'log').mockImplementation(() => {});
+    jest.spyOn(output, 'warn').mockImplementation(() => {});
+    jest.spyOn(output, 'error').mockImplementation(() => {});
+    // Force the wrapper function into its guarded temp-installation branch:
+    // __dirname (under the repo) must not start with workspaceRoot.
+    setWorkspaceRoot('/__guard-wiring-spec-unrelated-root__');
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    setWorkspaceRoot(originalWorkspaceRoot);
+    process.argv = originalArgv;
+  });
+
+  describe('runSingleMigrationFromCli', () => {
+    it('runs the guard with the raw argv before handing off to the local nx', async () => {
+      const argv = ['--run-migration=@nx/js:gen'];
+      const exitCode = await migrate(
+        ROOT,
+        { runMigration: '@nx/js:gen', skipInstall: true },
+        argv
+      );
+
+      expect(exitCode).toBe(0);
+      expect(mockAssertWorkspaceNx).toHaveBeenCalledWith(
+        expect.objectContaining({ argv })
+      );
+      expect(mockRunNxSync).toHaveBeenCalledTimes(1);
+      expect(mockAssertWorkspaceNx.mock.invocationCallOrder[0]).toBeLessThan(
+        mockRunNxSync.mock.invocationCallOrder[0]
+      );
+    });
+
+    it('never hands off to the local nx when the guard refuses', async () => {
+      mockAssertWorkspaceNx.mockImplementation(() => {
+        throw new Error('workspace nx too old');
+      });
+
+      const exitCode = await migrate(
+        ROOT,
+        { runMigration: '@nx/js:gen', skipInstall: true },
+        ['--run-migration=@nx/js:gen']
+      );
+
+      expect(exitCode).toBe(1);
+      expect(mockRunNxSync).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe('runMigration() version-skew-guard wiring (temp-CLI install)', () => {
+  const originalArgv = process.argv;
+  const originalUseLocal = process.env.NX_USE_LOCAL;
+  const originalMigrateUseLocal = process.env.NX_MIGRATE_USE_LOCAL;
+  const originalCliVersion = process.env.NX_MIGRATE_CLI_VERSION;
+
+  beforeEach(() => {
+    mockAssertTempCli.mockReset();
+    mockEnsurePackageHasProvenance.mockReset();
+    jest.spyOn(output, 'log').mockImplementation(() => {});
+    jest.spyOn(output, 'warn').mockImplementation(() => {});
+    jest.spyOn(output, 'error').mockImplementation(() => {});
+    delete process.env.NX_USE_LOCAL;
+    delete process.env.NX_MIGRATE_USE_LOCAL;
+    delete process.env.NX_MIGRATE_CLI_VERSION;
+    process.argv = ['node', 'nx', 'migrate', '--run-migration=@nx/js:gen'];
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    process.argv = originalArgv;
+    restoreEnv('NX_USE_LOCAL', originalUseLocal);
+    restoreEnv('NX_MIGRATE_USE_LOCAL', originalMigrateUseLocal);
+    restoreEnv('NX_MIGRATE_CLI_VERSION', originalCliVersion);
+  });
+
+  it('runs the guard with the raw argv before installing the temp CLI', async () => {
+    mockAssertTempCli.mockResolvedValue(undefined);
+    // ensurePackageHasProvenance is the first thing the temp-CLI install does
+    // (nxCliPath); stub it to fail fast rather than exercise a real network
+    // install.
+    mockEnsurePackageHasProvenance.mockRejectedValue(
+      new Error('stub: no network in tests')
+    );
+
+    const exitCode = await runMigration();
+
+    expect(exitCode).toBe(1);
+    expect(mockAssertTempCli).toHaveBeenCalledWith(
+      expect.objectContaining({
+        argv: ['--run-migration=@nx/js:gen'],
+        cliVersionSpec: 'latest',
+        fromEnvOverride: false,
+      })
+    );
+    expect(mockEnsurePackageHasProvenance).toHaveBeenCalledWith('nx', 'latest');
+    expect(mockAssertTempCli.mock.invocationCallOrder[0]).toBeLessThan(
+      mockEnsurePackageHasProvenance.mock.invocationCallOrder[0]
+    );
+  });
+
+  it('never starts the temp-CLI install when the guard refuses', async () => {
+    mockAssertTempCli.mockRejectedValue(new Error('temp CLI too old'));
+
+    const exitCode = await runMigration();
+
+    expect(exitCode).toBe(1);
+    expect(mockEnsurePackageHasProvenance).not.toHaveBeenCalled();
+  });
+});

--- a/packages/nx/src/command-line/migrate/migrate-run-single-cli.spec.ts
+++ b/packages/nx/src/command-line/migrate/migrate-run-single-cli.spec.ts
@@ -1,0 +1,176 @@
+// Dispatch-level tests for `migrate()` on the run-phase entry points: commit
+// resolution and the default-branch confirmation for the standalone
+// single-migration worker, plus run-phase parse-error funnel routing. Kept in
+// its own file so the module mocks below don't leak into the main migrate spec.
+
+const mockRunSingleMigrationWorker = jest.fn();
+const mockReportRunError = jest.fn();
+const mockReportGenerateError = jest.fn();
+const mockIsGitRepository = jest.fn();
+const mockGetGitCurrentBranch = jest.fn();
+const mockGetBaseRef = jest.fn();
+const mockCanPrompt = jest.fn();
+const mockMigratePrompt = jest.fn();
+
+jest.mock('./run', () => ({
+  runSingleMigrationWorker: (...args: unknown[]) =>
+    mockRunSingleMigrationWorker(...args),
+}));
+
+jest.mock('../../daemon/client/client', () => ({
+  daemonClient: {
+    stop: jest.fn().mockResolvedValue(undefined),
+    enabled: () => false,
+    reset: jest.fn(),
+  },
+}));
+
+jest.mock('./migrate-analytics', () => ({
+  ...jest.requireActual('./migrate-analytics'),
+  reportMigrateRunError: (...args: unknown[]) => mockReportRunError(...args),
+  reportMigrateGenerateError: (...args: unknown[]) =>
+    mockReportGenerateError(...args),
+}));
+
+jest.mock('../../utils/git-utils', () => ({
+  ...jest.requireActual('../../utils/git-utils'),
+  isGitRepository: (...args: unknown[]) => mockIsGitRepository(...args),
+  getGitCurrentBranch: (...args: unknown[]) => mockGetGitCurrentBranch(...args),
+}));
+
+jest.mock('../../utils/command-line-utils', () => ({
+  ...jest.requireActual('../../utils/command-line-utils'),
+  getBaseRef: (...args: unknown[]) => mockGetBaseRef(...args),
+}));
+
+jest.mock('./safe-prompt', () => ({
+  ...jest.requireActual('./safe-prompt'),
+  canPrompt: (...args: unknown[]) => mockCanPrompt(...args),
+  migratePrompt: (...args: unknown[]) => mockMigratePrompt(...args),
+}));
+
+jest.mock('../../config/configuration', () => ({
+  ...jest.requireActual('../../config/configuration'),
+  readNxJson: () => ({}),
+}));
+
+import { output } from '../../utils/output';
+import { DEFAULT_MIGRATION_COMMIT_PREFIX } from './command-object';
+import { migrate } from './migrate';
+
+const ROOT = '/virtual-root';
+
+function standaloneArgs(overrides: { [k: string]: unknown } = {}) {
+  return {
+    runMigration: '@nx/js:gen',
+    createCommits: true,
+    commitPrefix: DEFAULT_MIGRATION_COMMIT_PREFIX,
+    skipInstall: true,
+    verbose: false,
+    ...overrides,
+  };
+}
+
+describe('migrate() single-migration dispatch', () => {
+  beforeEach(() => {
+    mockRunSingleMigrationWorker.mockReset().mockResolvedValue(undefined);
+    mockReportRunError.mockReset();
+    mockReportGenerateError.mockReset();
+    mockIsGitRepository.mockReset().mockReturnValue(true);
+    mockGetGitCurrentBranch.mockReset().mockReturnValue('feature/x');
+    mockGetBaseRef.mockReset().mockReturnValue('main');
+    mockCanPrompt.mockReset().mockReturnValue(false);
+    mockMigratePrompt.mockReset().mockResolvedValue({ proceed: true });
+    jest.spyOn(output, 'log').mockImplementation(() => {});
+    jest.spyOn(output, 'warn').mockImplementation(() => {});
+    jest.spyOn(output, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => jest.restoreAllMocks());
+
+  describe('commit resolution', () => {
+    it('errors and never runs the worker for --create-commits without git', async () => {
+      mockIsGitRepository.mockReturnValue(false);
+
+      const exit = await migrate(ROOT, standaloneArgs(), [
+        '--run-migration=@nx/js:gen',
+        '--create-commits',
+      ]);
+
+      expect(exit).toBe(1);
+      expect(mockRunSingleMigrationWorker).not.toHaveBeenCalled();
+      expect(output.error).toHaveBeenCalled();
+    });
+
+    it('passes the resolved effective create-commits flag to the worker', async () => {
+      mockIsGitRepository.mockReturnValue(true);
+      mockCanPrompt.mockReturnValue(false);
+
+      await migrate(ROOT, standaloneArgs(), ['--run-migration=@nx/js:gen']);
+
+      expect(mockRunSingleMigrationWorker).toHaveBeenCalledTimes(1);
+      expect(mockRunSingleMigrationWorker.mock.calls[0][0]).toMatchObject({
+        createCommits: true,
+      });
+    });
+  });
+
+  describe('default-branch confirmation', () => {
+    it('aborts without running the worker when the user declines on the default branch', async () => {
+      mockIsGitRepository.mockReturnValue(true);
+      mockCanPrompt.mockReturnValue(true);
+      mockGetGitCurrentBranch.mockReturnValue('main');
+      mockGetBaseRef.mockReturnValue('main');
+      mockMigratePrompt.mockResolvedValue({ proceed: false });
+
+      await migrate(ROOT, standaloneArgs(), ['--run-migration=@nx/js:gen']);
+
+      expect(mockRunSingleMigrationWorker).not.toHaveBeenCalled();
+      expect(output.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: expect.stringContaining('default branch'),
+        })
+      );
+    });
+
+    it('runs the worker when the user confirms on the default branch', async () => {
+      mockIsGitRepository.mockReturnValue(true);
+      mockCanPrompt.mockReturnValue(true);
+      mockGetGitCurrentBranch.mockReturnValue('main');
+      mockGetBaseRef.mockReturnValue('main');
+      mockMigratePrompt.mockResolvedValue({ proceed: true });
+
+      await migrate(ROOT, standaloneArgs(), ['--run-migration=@nx/js:gen']);
+
+      expect(mockRunSingleMigrationWorker).toHaveBeenCalledTimes(1);
+    });
+
+    it('does not prompt when prompting is not possible', async () => {
+      mockIsGitRepository.mockReturnValue(true);
+      mockCanPrompt.mockReturnValue(false);
+      mockGetGitCurrentBranch.mockReturnValue('main');
+      mockGetBaseRef.mockReturnValue('main');
+
+      await migrate(ROOT, standaloneArgs(), ['--run-migration=@nx/js:gen']);
+
+      expect(mockMigratePrompt).not.toHaveBeenCalled();
+      expect(mockRunSingleMigrationWorker).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('run-phase parse-error funnel routing', () => {
+    it('reports a run-phase parse error through the run funnel, not the generate funnel', async () => {
+      const exit = await migrate(
+        ROOT,
+        { runMigration: 'a', runMigrations: '' },
+        ['--run-migration=a', '--run-migrations']
+      );
+
+      expect(exit).toBe(1);
+      expect(mockReportRunError).toHaveBeenCalledWith(
+        expect.objectContaining({ code: 'other' })
+      );
+      expect(mockReportGenerateError).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/nx/src/command-line/migrate/migrate.spec.ts
+++ b/packages/nx/src/command-line/migrate/migrate.spec.ts
@@ -50,6 +50,7 @@ import {
   isHybridMigration,
   isNpmPeerDepsError,
   isPromptOnlyMigration,
+  isRunPhaseInvocation,
   Migrator,
   normalizeVersion,
   parseMigrationReturn,
@@ -61,7 +62,10 @@ import {
   resolveMigrationForRun,
   resolveInclude,
 } from './migrate';
-import { applyNxJsonMigrateDefaults } from './migrate-config';
+import {
+  applyNxJsonMigrateDefaults,
+  assertCommitPrefixHasCommits,
+} from './migrate-config';
 import { MinReleaseAgeViolationError } from '../../utils/min-release-age/errors';
 import {
   readPromptFilesFromInstall,
@@ -2179,6 +2183,68 @@ describe('Migration', () => {
       expect(r).toMatchObject({
         type: 'runMigrations',
         interactive: false,
+      });
+    });
+
+    it('should discriminate a single migration when --run-migration is set', async () => {
+      const r = await parseMigrationsOptions({
+        runMigration: '@nx/js:my-migration',
+      });
+      expect(r).toEqual({
+        type: 'runSingleMigration',
+        runMigration: '@nx/js:my-migration',
+      });
+    });
+
+    it('should reject an empty --run-migration', async () => {
+      await expect(() =>
+        parseMigrationsOptions({ runMigration: '' })
+      ).rejects.toThrow(/'--run-migration' requires a migration id/);
+    });
+
+    it('should reject --run-migration combined with --run-migrations', async () => {
+      await expect(() =>
+        parseMigrationsOptions({ runMigration: 'a', runMigrations: '' })
+      ).rejects.toThrow(/cannot be combined with '--run-migrations'/);
+    });
+
+    it('should reject --run-migration combined with --include', async () => {
+      await expect(() =>
+        parseMigrationsOptions({ runMigration: 'a', include: 'required' })
+      ).rejects.toThrow(/cannot be combined with '--include'/);
+    });
+
+    it('should reject --run-migration combined with --multi-major-mode', async () => {
+      await expect(() =>
+        parseMigrationsOptions({ runMigration: 'a', multiMajorMode: 'direct' })
+      ).rejects.toThrow(/cannot be combined with '--multi-major-mode'/);
+    });
+
+    describe('run-phase commit-prefix gating', () => {
+      it('classifies --run-migration as run-phase and everything else as not', () => {
+        expect(isRunPhaseInvocation({ runMigration: '@nx/js:x' })).toBe(true);
+        expect(isRunPhaseInvocation({ runMigrations: '' })).toBe(false);
+        expect(isRunPhaseInvocation({ packageAndVersion: 'nx@latest' })).toBe(
+          false
+        );
+      });
+
+      it('does not throw the commit-prefix assert for a run-phase invocation', () => {
+        // nx.json enables agentic + a custom prefix; a worker invocation gets
+        // the prefix overlaid but not agentic.
+        const config = { agentic: true, commitPrefix: 'custom: ' } as const;
+        const merged = applyNxJsonMigrateDefaults(
+          { runMigration: '@nx/js:x' },
+          config,
+          {}
+        );
+
+        // The overlay would otherwise wedge every worker invocation...
+        expect(() => assertCommitPrefixHasCommits(merged)).toThrow(
+          /requires commits to be enabled/i
+        );
+        // ...so migrate() skips the assert for run-phase invocations.
+        expect(isRunPhaseInvocation(merged)).toBe(true);
       });
     });
 

--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -135,10 +135,7 @@ import {
   assertCommitPrefixHasCommits,
 } from './migrate-config';
 import type { EnabledResolvedAgentic, ResolvedAgentic } from './agentic/types';
-import {
-  applyAgenticHandoffGitignoreFallback,
-  isHandoffGitignoreMigration,
-} from './agentic/handoff-gitignore';
+import { applyAgenticHandoffGitignoreFallback } from './agentic/handoff-gitignore';
 import {
   commitCheckpointBeforeMigrations,
   commitMigrationIfRequested,
@@ -167,12 +164,15 @@ import {
 } from './version-utils';
 import {
   ChangedDepInstaller,
+  logSkippedPostMigrationInstall,
   NpmPeerDepsInstallError,
   readMigrationCollection,
   readPackageMigrationConfig,
   runInstall,
   runNxOrAngularMigration,
 } from './execute-migration';
+import { runSingleMigrationWorker } from './run';
+import { sortMigrations } from './sort-migrations';
 
 export * from './execute-migration';
 export { normalizeVersion };
@@ -1204,12 +1204,44 @@ type RunMigrations = {
   interactive?: boolean;
 };
 
+type RunSingleMigration = {
+  type: 'runSingleMigration';
+  runMigration: string;
+};
+
 export async function parseMigrationsOptions(
   options: {
     [k: string]: any;
   },
   fetch?: MigratorOptions['fetch']
-): Promise<GenerateMigrations | RunMigrations> {
+): Promise<GenerateMigrations | RunMigrations | RunSingleMigration> {
+  if (options.runMigration !== undefined) {
+    if (options.runMigration === '') {
+      throw new Error(
+        `Error: '--run-migration' requires a migration id, e.g. '--run-migration=@nx/js:my-migration'.`
+      );
+    }
+    if (options.runMigrations !== undefined) {
+      throw new Error(
+        `Error: '--run-migration' (run a single migration) cannot be combined with '--run-migrations' (run the whole migrations file).`
+      );
+    }
+    if (options.include) {
+      throw new Error(
+        `Error: '--run-migration' cannot be combined with '--include'.`
+      );
+    }
+    if (options.multiMajorMode) {
+      throw new Error(
+        `Error: '--run-migration' cannot be combined with '--multi-major-mode'.`
+      );
+    }
+    return {
+      type: 'runSingleMigration',
+      runMigration: options.runMigration as string,
+    };
+  }
+
   if (options.runMigrations === '') {
     options.runMigrations = 'migrations.json';
   }
@@ -2667,28 +2699,8 @@ export async function executeMigrations(
   const changedDepInstaller = new ChangedDepInstaller(root, shouldSkipInstall);
 
   const migrationsWithNoChanges: ExecutableMigration[] = [];
-  const sortedMigrations = migrations.sort((a, b) => {
-    // Under `--agentic`, hoist the v23 migration that ignores
-    // `.nx/migrate-runs` to position 0 so its .gitignore update lands
-    // before any per-migration commit absorbs the run's handoff scratch.
-    // See `agentic/handoff-gitignore.ts` for the full rationale and the
-    // inline-fallback path that covers intra-pre-v23 agentic runs.
-    if (agentic?.kind === 'enabled') {
-      if (isHandoffGitignoreMigration(a)) return -1;
-      if (isHandoffGitignoreMigration(b)) return 1;
-    }
-
-    // special case for the split configuration migration to run first
-    if (a.name === '15-7-0-split-configuration-into-project-json-files') {
-      return -1;
-    }
-    if (b.name === '15-7-0-split-configuration-into-project-json-files') {
-      return 1;
-    }
-
-    return lt(normalizeVersion(a.version), normalizeVersion(b.version))
-      ? -1
-      : 1;
+  const sortedMigrations = sortMigrations(migrations, {
+    hoistHandoffGitignore: agentic?.kind === 'enabled',
   });
 
   // Lazy-load the agentic chain so non-agentic runs don't pay its startup cost.
@@ -3110,13 +3122,22 @@ export async function executeMigrations(
   };
 }
 
-function logSkippedPostMigrationInstall(root: string): void {
-  const packageManager = detectPackageManager(root);
-  const installCommand = getPackageManagerCommand(packageManager, root).install;
-  output.warn({
-    title: 'Migrations updated your dependencies, but the install was skipped',
-    bodyLines: [`Run "${installCommand}" to install the updated dependencies.`],
-  });
+// Forwards this invocation's raw argv to the workspace-local nx, used from
+// each run path's temp-installation check (`!__dirname.startsWith(workspaceRoot)`).
+// Returns the child's exit code when it is non-zero, undefined otherwise; the
+// caller returns this value directly to stop and let the local nx take over.
+function handOffToLocalNx(args: string[]): number | undefined {
+  const exitCode = runOrReturnExitCode(() =>
+    runNxSync(`migrate ${args.join(' ')}`, {
+      stdio: ['inherit', 'inherit', 'inherit'],
+      env: {
+        ...process.env,
+        NX_MIGRATE_SKIP_INSTALL: 'true',
+        NX_MIGRATE_USE_LOCAL: 'true',
+      },
+    })
+  );
+  return exitCode !== 0 ? exitCode : undefined;
 }
 
 async function runMigrations(
@@ -3141,20 +3162,7 @@ async function runMigrations(
   if (!__dirname.startsWith(workspaceRoot)) {
     // we are running from a temp installation with nx latest, switch to running
     // from local installation
-    const exitCode = runOrReturnExitCode(() =>
-      runNxSync(`migrate ${args.join(' ')}`, {
-        stdio: ['inherit', 'inherit', 'inherit'],
-        env: {
-          ...process.env,
-          NX_MIGRATE_SKIP_INSTALL: 'true',
-          NX_MIGRATE_USE_LOCAL: 'true',
-        },
-      })
-    );
-    if (exitCode !== 0) {
-      return exitCode;
-    }
-    return;
+    return handOffToLocalNx(args);
   }
 
   const migrationsExists: boolean = fileExists(opts.runMigrations);
@@ -3170,9 +3178,8 @@ async function runMigrations(
     );
   }
 
-  const migrations: ExecutableMigration[] = readJsonFile(
-    join(root, opts.runMigrations)
-  ).migrations;
+  const migrationsJson = readJsonFile(join(root, opts.runMigrations));
+  const migrations: ExecutableMigration[] = migrationsJson.migrations;
 
   reportMigrateRunStart({
     createCommits: shouldCreateCommits ?? false,
@@ -3384,6 +3391,14 @@ async function runMigrations(
   });
 }
 
+// A run-phase invocation drives an existing plan (a single migration) rather
+// than generating or running the whole migrations file. Its commit config
+// resolves downstream, so the top-level commit-prefix assert and the
+// error-funnel selection both key off this.
+export function isRunPhaseInvocation(args: { [k: string]: any }): boolean {
+  return args['runMigration'] !== undefined;
+}
+
 export async function migrate(
   root: string,
   args: { [k: string]: any },
@@ -3393,25 +3408,46 @@ export async function migrate(
 
   return handleErrors(process.env.NX_VERBOSE_LOGGING === 'true', async () => {
     const mergedArgs = applyNxJsonMigrateDefaults(args, readNxJson().migrate);
-    assertCommitPrefixHasCommits(mergedArgs);
+    // A run-phase invocation (--run-migration) resolves its commit config
+    // downstream via resolveCreateCommits, so the commit-prefix assert must
+    // not fire for it.
+    const runPhase = isRunPhaseInvocation(mergedArgs);
+    if (!runPhase) {
+      assertCommitPrefixHasCommits(mergedArgs);
+    }
     // One fetcher (registry-first, install fallback) shared by the `--include`
     // eligibility gate and the migration cascade so package metadata is fetched
     // at most once per package/version.
     const fetch = createFetcher(getPackageManagerCommand());
-    // `--run-migrations` without a value parses as '' - undefined means the
-    // generate phase.
-    const isGenerateInvocation = mergedArgs['runMigrations'] === undefined;
+    // A parse failure on a run-phase invocation belongs in the run funnel, not
+    // the generate funnel. `--run-migrations` without a value parses as '';
+    // undefined here (and no run-phase flag) means the generate phase.
+    const isGenerateInvocation =
+      mergedArgs['runMigrations'] === undefined && !runPhase;
     let opts: Awaited<ReturnType<typeof parseMigrationsOptions>>;
     try {
       opts = await parseMigrationsOptions(mergedArgs, fetch);
     } catch (e) {
       if (isGenerateInvocation) {
         reportMigrateGenerateError('resolve_version', e);
+      } else if (runPhase) {
+        reportMigrateRunError({ code: 'other', error: e });
       }
       throw e;
     }
     if (opts.type === 'generateMigrations') {
       await generateMigrationsJsonAndUpdatePackageJson(root, opts, fetch);
+    } else if (opts.type === 'runSingleMigration') {
+      try {
+        return await runSingleMigrationFromCli(root, opts, rawArgs, mergedArgs);
+      } catch (e) {
+        // Guidance is already logged by `runInstall`; return without a noisy
+        // stack after the friendly output.
+        if (e instanceof NpmPeerDepsInstallError) {
+          return 1;
+        }
+        throw e;
+      }
     } else {
       try {
         return await runMigrations(
@@ -3435,6 +3471,77 @@ export async function migrate(
         throw e;
       }
     }
+  });
+}
+
+// Mirrors `runMigrations`' pre-install + local-nx hand-off before dispatching
+// to the single-migration worker, so `nx migrate --run-migration` behaves the
+// same when invoked from a temp `nx@latest` installation.
+async function runSingleMigrationFromCli(
+  root: string,
+  opts: RunSingleMigration,
+  args: string[],
+  mergedArgs: { [k: string]: any }
+): Promise<number | void> {
+  const shouldSkipInstall = mergedArgs['skipInstall'];
+  if (!shouldSkipInstall && !process.env.NX_MIGRATE_SKIP_INSTALL) {
+    await runInstall();
+  }
+
+  if (!__dirname.startsWith(workspaceRoot)) {
+    // Running from a temp installation with nx latest; switch to the local
+    // installation.
+    return handOffToLocalNx(args);
+  }
+
+  const commitPrefix =
+    mergedArgs['commitPrefix'] ?? DEFAULT_MIGRATION_COMMIT_PREFIX;
+  // Standalone commits follow the CLI flags, resolved the same way the classic
+  // loop resolves them: --create-commits without a git repo is a hard error and
+  // a custom prefix without commits warns. Agentic never applies on this path.
+  const resolved = resolveCreateCommits({
+    createCommits: mergedArgs['createCommits'],
+    agenticKind: 'disabled',
+    isGitRepo: isGitRepository(root),
+    commitPrefixIsCustom: commitPrefix !== DEFAULT_MIGRATION_COMMIT_PREFIX,
+  });
+  if (resolved.error) {
+    throw new Error(resolved.error);
+  }
+  if (resolved.warning) {
+    output.warn({ title: resolved.warning });
+  }
+  const createCommits = resolved.effective;
+
+  // Confirm before committing on the default branch when prompting is
+  // possible; a decline aborts before the migration runs.
+  if (createCommits && canPrompt(mergedArgs['interactive'])) {
+    const currentBranch = getGitCurrentBranch(root);
+    // `getBaseRef` may carry an `origin/` prefix (set by the CI-workflow
+    // generator); compare against the local branch name.
+    const defaultBranch = getBaseRef(readNxJson(root)).replace(/^origin\//, '');
+    const proceed = await confirmCommitsOnDefaultBranch({
+      currentBranch,
+      defaultBranch,
+    });
+    if (!proceed) {
+      output.log({
+        title: `Skipped running the migration to avoid committing to the default branch '${currentBranch}'.`,
+        bodyLines: [
+          'Switch to a different branch and re-run, or re-run and confirm to proceed.',
+        ],
+      });
+      return;
+    }
+  }
+
+  await runSingleMigrationWorker({
+    root,
+    options: opts,
+    createCommits,
+    commitPrefix,
+    skipInstall: shouldSkipInstall,
+    isVerbose: mergedArgs['verbose'],
   });
 }
 

--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -173,6 +173,10 @@ import {
 } from './execute-migration';
 import { runSingleMigrationWorker } from './run';
 import { sortMigrations } from './sort-migrations';
+import {
+  assertTempCliSupportsNewMigrateFlags,
+  assertWorkspaceNxSupportsNewMigrateFlags,
+} from './version-skew-guard';
 
 export * from './execute-migration';
 export { normalizeVersion };
@@ -3474,6 +3478,17 @@ export async function migrate(
   });
 }
 
+// The workspace-local nx version, or undefined when it cannot be resolved from
+// the workspace root (Guard B treats that as "do not block").
+function readLocalNxVersion(root: string): string | undefined {
+  try {
+    return readModulePackageJson('nx', getNxRequirePaths(root)).packageJson
+      .version;
+  } catch {
+    return undefined;
+  }
+}
+
 // Mirrors `runMigrations`' pre-install + local-nx hand-off before dispatching
 // to the single-migration worker, so `nx migrate --run-migration` behaves the
 // same when invoked from a temp `nx@latest` installation.
@@ -3489,6 +3504,13 @@ async function runSingleMigrationFromCli(
   }
 
   if (!__dirname.startsWith(workspaceRoot)) {
+    // The workspace-local nx we are about to hand off to must be new enough to
+    // understand the new flags we forward to it.
+    assertWorkspaceNxSupportsNewMigrateFlags({
+      argv: args,
+      readLocalNxVersion: () => readLocalNxVersion(root),
+    });
+
     // Running from a temp installation with nx latest; switch to the local
     // installation.
     return handOffToLocalNx(args);
@@ -3558,6 +3580,17 @@ export async function runMigration() {
       process.env.NX_USE_LOCAL !== 'true' &&
       process.env.NX_MIGRATE_USE_LOCAL === undefined
     ) {
+      // The temp CLI about to be installed must be new enough to understand the
+      // new flags before we forward them to it (mirrors nxCliPath's spec).
+      const cliVersionSpec = process.env.NX_MIGRATE_CLI_VERSION || 'latest';
+      await assertTempCliSupportsNewMigrateFlags({
+        argv: process.argv.slice(3),
+        cliVersionSpec,
+        fromEnvOverride: !!process.env.NX_MIGRATE_CLI_VERSION,
+        resolveVersion: (spec) =>
+          resolvePackageVersionRespectingMinReleaseAge('nx', spec),
+      });
+
       const p = await nxCliPath();
       if (p === null) {
         return runLocalMigrate();

--- a/packages/nx/src/command-line/migrate/run/index.ts
+++ b/packages/nx/src/command-line/migrate/run/index.ts
@@ -1,0 +1,2 @@
+export { runSingleMigrationWorker } from './worker';
+export type { RunSingleMigrationWorkerInput } from './worker';

--- a/packages/nx/src/command-line/migrate/run/util.ts
+++ b/packages/nx/src/command-line/migrate/run/util.ts
@@ -1,0 +1,31 @@
+// Small helpers shared within run/. Not part of run/'s public surface (not
+// re-exported via ./index): import directly within run/.
+
+import {
+  detectPackageManager,
+  getPackageManagerCommand,
+} from '../../../utils/package-manager';
+
+// Migration package/name are user-authored; escape so a hostile value can't
+// break out of an XML attribute.
+export function escapeXmlAttr(value: string): string {
+  return value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&apos;');
+}
+
+const cachedPmExecPrefix = new Map<string, string>();
+
+// getPackageManagerCommand can shell out to detect a version, so cache the
+// result per root.
+export function pmExecPrefix(root: string): string {
+  let prefix = cachedPmExecPrefix.get(root);
+  if (prefix === undefined) {
+    prefix = getPackageManagerCommand(detectPackageManager(root), root).exec;
+    cachedPmExecPrefix.set(root, prefix);
+  }
+  return prefix;
+}

--- a/packages/nx/src/command-line/migrate/run/worker.spec.ts
+++ b/packages/nx/src/command-line/migrate/run/worker.spec.ts
@@ -1,0 +1,459 @@
+const mockRunMigration = jest.fn();
+const mockReadMigrationCollection = jest.fn();
+const mockLogSkippedInstall = jest.fn();
+let mockSkippedInstall = false;
+jest.mock('../execute-migration', () => ({
+  ChangedDepInstaller: jest.fn().mockImplementation(() => ({
+    installDepsIfChanged: jest.fn().mockResolvedValue(undefined),
+    get skippedInstall() {
+      return mockSkippedInstall;
+    },
+  })),
+  logSkippedPostMigrationInstall: (...args: unknown[]) =>
+    mockLogSkippedInstall(...args),
+  runNxOrAngularMigration: (...args: unknown[]) => mockRunMigration(...args),
+  readMigrationCollection: (...args: unknown[]) =>
+    mockReadMigrationCollection(...args),
+}));
+
+const mockCommit = jest.fn();
+const mockCheckpoint = jest.fn();
+jest.mock('../migrate-commits', () => ({
+  commitMigrationIfRequested: (...args: unknown[]) => mockCommit(...args),
+  commitCheckpointBeforeMigrations: (...args: unknown[]) =>
+    mockCheckpoint(...args),
+}));
+
+const mockIsInsideAgent = jest.fn();
+jest.mock('../agentic/inception', () => ({
+  isInsideAgent: () => mockIsInsideAgent(),
+}));
+
+jest.mock('../../../utils/package-manager', () => ({
+  detectPackageManager: () => 'npm',
+  getPackageManagerCommand: () => ({ exec: 'npx' }),
+}));
+
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { output } from '../../../utils/output';
+import { runSingleMigrationWorker } from './worker';
+
+interface PlannedMigration {
+  package: string;
+  name: string;
+  version: string;
+  implementation?: string;
+  prompt?: string;
+}
+
+const genMig = (pkg: string, name: string): PlannedMigration => ({
+  package: pkg,
+  name,
+  version: '1.0.0',
+  implementation: './impl.js',
+});
+const promptMig = (pkg: string, name: string): PlannedMigration => ({
+  package: pkg,
+  name,
+  version: '1.0.0',
+  prompt: `prompts/${name}.md`,
+});
+const hybridMig = (pkg: string, name: string): PlannedMigration => ({
+  package: pkg,
+  name,
+  version: '1.0.0',
+  implementation: './impl.js',
+  prompt: `prompts/${name}.md`,
+});
+
+const changeList = () => [
+  { type: 'UPDATE' as const, path: 'a.ts', content: Buffer.from('x') },
+];
+
+describe('runSingleMigrationWorker', () => {
+  let root: string;
+  let stdout: string;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), 'nx-migrate-worker-'));
+    stdout = '';
+    jest.spyOn(process.stdout, 'write').mockImplementation(((
+      chunk: unknown
+    ) => {
+      stdout += String(chunk);
+      return true;
+    }) as unknown as typeof process.stdout.write);
+    jest.spyOn(output, 'log').mockImplementation(() => {});
+    jest.spyOn(output, 'warn').mockImplementation(() => {});
+
+    mockRunMigration.mockReset().mockResolvedValue({
+      changes: [],
+      nextSteps: [],
+      agentContext: [],
+      logs: '',
+      madeChanges: false,
+    });
+    mockReadMigrationCollection.mockReset().mockImplementation(() => {
+      throw new Error('not mocked');
+    });
+    mockCommit.mockReset().mockResolvedValue({ status: 'no-changes' });
+    mockCheckpoint.mockReset();
+    mockIsInsideAgent.mockReset().mockReturnValue(false);
+    mockLogSkippedInstall.mockReset();
+    mockSkippedInstall = false;
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  function writeMigrations(migrations: PlannedMigration[]): void {
+    writeFileSync(
+      join(root, 'migrations.json'),
+      JSON.stringify({ migrations })
+    );
+  }
+
+  function standaloneInput(overrides: {
+    runMigration: string;
+    createCommits?: boolean;
+  }) {
+    return {
+      root,
+      options: { runMigration: overrides.runMigration },
+      createCommits: overrides.createCommits,
+      commitPrefix: 'chore: [nx migration] ',
+      skipInstall: true,
+      isVerbose: false,
+    };
+  }
+
+  describe('id resolution', () => {
+    it('resolves an exact <package>:<name> id', async () => {
+      writeMigrations([genMig('@nx/js', 'a'), genMig('@nx/react', 'b')]);
+
+      await runSingleMigrationWorker(
+        standaloneInput({ runMigration: '@nx/react:b' })
+      );
+
+      expect(mockRunMigration).toHaveBeenCalledTimes(1);
+      expect(mockRunMigration.mock.calls[0][1]).toMatchObject({
+        package: '@nx/react',
+        name: 'b',
+      });
+    });
+
+    it('resolves a bare name when exactly one migration matches', async () => {
+      writeMigrations([genMig('@nx/js', 'a'), genMig('@nx/react', 'b')]);
+
+      await runSingleMigrationWorker(standaloneInput({ runMigration: 'b' }));
+
+      expect(mockRunMigration.mock.calls[0][1]).toMatchObject({
+        package: '@nx/react',
+        name: 'b',
+      });
+    });
+
+    it('errors on a bare name matching multiple migrations, listing the matches', async () => {
+      writeMigrations([genMig('@nx/js', 'dup'), genMig('@nx/react', 'dup')]);
+
+      await expect(
+        runSingleMigrationWorker(standaloneInput({ runMigration: 'dup' }))
+      ).rejects.toThrow(/@nx\/js:dup[\s\S]*@nx\/react:dup/);
+      expect(mockRunMigration).not.toHaveBeenCalled();
+    });
+
+    it('errors on an unknown id, naming the id and the source', async () => {
+      writeMigrations([genMig('@nx/js', 'a')]);
+
+      await expect(
+        runSingleMigrationWorker(standaloneInput({ runMigration: 'nope' }))
+      ).rejects.toThrow(
+        /No migration matching 'nope' was found in migrations\.json/
+      );
+    });
+
+    it('errors when migrations.json is missing', async () => {
+      await expect(
+        runSingleMigrationWorker(standaloneInput({ runMigration: 'x' }))
+      ).rejects.toThrow(/File 'migrations\.json' doesn't exist/);
+    });
+  });
+
+  describe('standalone execution', () => {
+    it('runs a generator migration and prints its next steps', async () => {
+      writeMigrations([genMig('@nx/js', 'gen')]);
+      mockRunMigration.mockResolvedValue({
+        changes: changeList(),
+        nextSteps: ['do a thing'],
+        agentContext: [],
+        logs: '',
+        madeChanges: true,
+      });
+
+      await runSingleMigrationWorker(
+        standaloneInput({ runMigration: '@nx/js:gen' })
+      );
+
+      expect(mockRunMigration).toHaveBeenCalledTimes(1);
+      expect(output.log).toHaveBeenCalledWith(
+        expect.objectContaining({ bodyLines: ['- do a thing'] })
+      );
+    });
+
+    it('commits a generator migration only when create-commits is enabled', async () => {
+      writeMigrations([genMig('@nx/js', 'gen')]);
+      mockRunMigration.mockResolvedValue({
+        changes: changeList(),
+        nextSteps: [],
+        agentContext: [],
+        logs: '',
+        madeChanges: true,
+      });
+      mockCommit.mockResolvedValue({ status: 'committed', sha: 'abc' });
+
+      await runSingleMigrationWorker(
+        standaloneInput({ runMigration: '@nx/js:gen', createCommits: false })
+      );
+      expect(mockCommit).not.toHaveBeenCalled();
+
+      await runSingleMigrationWorker(
+        standaloneInput({ runMigration: '@nx/js:gen', createCommits: true })
+      );
+      expect(mockCommit).toHaveBeenCalledTimes(1);
+    });
+
+    it('checkpoints pre-existing working-tree state before the migration when commits are enabled', async () => {
+      writeMigrations([genMig('@nx/js', 'gen')]);
+      mockCommit.mockResolvedValue({ status: 'committed', sha: 'abc' });
+
+      await runSingleMigrationWorker(
+        standaloneInput({ runMigration: '@nx/js:gen', createCommits: true })
+      );
+
+      expect(mockCheckpoint).toHaveBeenCalledWith(
+        root,
+        'chore: [nx migration] '
+      );
+      expect(mockCheckpoint.mock.invocationCallOrder[0]).toBeLessThan(
+        mockRunMigration.mock.invocationCallOrder[0]
+      );
+    });
+
+    it('does not checkpoint when commits are not enabled', async () => {
+      writeMigrations([genMig('@nx/js', 'gen')]);
+
+      await runSingleMigrationWorker(
+        standaloneInput({ runMigration: '@nx/js:gen' })
+      );
+
+      expect(mockCheckpoint).not.toHaveBeenCalled();
+    });
+
+    it('forwards a generator-only migration agentContext to the outer agent', async () => {
+      mockIsInsideAgent.mockReturnValue(true);
+      writeMigrations([genMig('@nx/js', 'gen')]);
+      mockRunMigration.mockResolvedValue({
+        changes: changeList(),
+        nextSteps: [],
+        agentContext: ['hint one'],
+        logs: '',
+        madeChanges: true,
+      });
+
+      await runSingleMigrationWorker(
+        standaloneInput({ runMigration: '@nx/js:gen' })
+      );
+
+      expect(stdout).toContain('<agent_context migration="@nx/js:gen">');
+      expect(stdout).toContain('hint one');
+    });
+
+    it('does not forward agentContext outside an agent', async () => {
+      mockIsInsideAgent.mockReturnValue(false);
+      writeMigrations([genMig('@nx/js', 'gen')]);
+      mockRunMigration.mockResolvedValue({
+        changes: changeList(),
+        nextSteps: [],
+        agentContext: ['hint one'],
+        logs: '',
+        madeChanges: true,
+      });
+
+      await runSingleMigrationWorker(
+        standaloneInput({ runMigration: '@nx/js:gen' })
+      );
+
+      expect(stdout).not.toContain('<agent_context');
+    });
+
+    it('treats a failed commit as a warning, not a failure', async () => {
+      writeMigrations([genMig('@nx/js', 'gen')]);
+      mockRunMigration.mockResolvedValue({
+        changes: changeList(),
+        nextSteps: [],
+        agentContext: [],
+        logs: '',
+        madeChanges: true,
+      });
+      mockCommit.mockResolvedValue({ status: 'failed', reason: 'boom' });
+
+      await expect(
+        runSingleMigrationWorker(
+          standaloneInput({ runMigration: '@nx/js:gen', createCommits: true })
+        )
+      ).resolves.toBeUndefined();
+    });
+
+    it('emits a tagged prompt block for a prompt-only migration inside an agent', async () => {
+      mockIsInsideAgent.mockReturnValue(true);
+      writeMigrations([promptMig('@nx/js', 'p')]);
+
+      await runSingleMigrationWorker(
+        standaloneInput({ runMigration: '@nx/js:p' })
+      );
+
+      expect(mockRunMigration).not.toHaveBeenCalled();
+      expect(stdout).toContain('<nx_migrate_prompt migration="@nx/js:p">');
+      expect(stdout).toContain('"migrationId": "@nx/js:p"');
+      expect(stdout).toContain('"prompt": "prompts/p.md"');
+    });
+
+    it('prints prompt instructions for a prompt-only migration outside an agent', async () => {
+      mockIsInsideAgent.mockReturnValue(false);
+      writeMigrations([promptMig('@nx/js', 'p')]);
+
+      await runSingleMigrationWorker(
+        standaloneInput({ runMigration: '@nx/js:p' })
+      );
+
+      expect(mockRunMigration).not.toHaveBeenCalled();
+      expect(stdout).not.toContain('<nx_migrate_prompt');
+      expect(output.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: expect.stringContaining('must be applied manually'),
+        })
+      );
+    });
+
+    it('runs the generator half then emits the prompt block for a hybrid migration inside an agent', async () => {
+      mockIsInsideAgent.mockReturnValue(true);
+      writeMigrations([hybridMig('@nx/js', 'h')]);
+      mockRunMigration.mockResolvedValue({
+        changes: changeList(),
+        nextSteps: [],
+        agentContext: ['generator hint'],
+        logs: 'generator ran',
+        madeChanges: true,
+      });
+
+      await runSingleMigrationWorker(
+        standaloneInput({ runMigration: '@nx/js:h' })
+      );
+
+      expect(mockRunMigration).toHaveBeenCalledTimes(1);
+      expect(stdout).toContain('<nx_migrate_prompt migration="@nx/js:h">');
+      expect(stdout).toContain('"impl"');
+      // Hybrid agentContext rides inside the payload, not a separate block.
+      expect(stdout).toContain('"agentContext"');
+      expect(stdout).toContain('"generator hint"');
+      expect(stdout).not.toContain('<agent_context');
+    });
+
+    it('does not commit when the generator makes no changes, even with -C', async () => {
+      writeMigrations([genMig('@nx/js', 'gen')]);
+      // Default mockRunMigration returns madeChanges: false.
+
+      await runSingleMigrationWorker(
+        standaloneInput({ runMigration: '@nx/js:gen', createCommits: true })
+      );
+
+      expect(mockRunMigration).toHaveBeenCalledTimes(1);
+      expect(mockCommit).not.toHaveBeenCalled();
+    });
+
+    it('warns when a dependency-changing migration ran with the install skipped', async () => {
+      writeMigrations([genMig('@nx/js', 'gen')]);
+      mockRunMigration.mockResolvedValue({
+        changes: changeList(),
+        nextSteps: [],
+        agentContext: [],
+        logs: '',
+        madeChanges: true,
+      });
+      mockSkippedInstall = true;
+
+      await runSingleMigrationWorker(
+        standaloneInput({ runMigration: '@nx/js:gen' })
+      );
+
+      expect(mockLogSkippedInstall).toHaveBeenCalledWith(root);
+    });
+
+    it('does not warn about a skipped install when nothing was skipped', async () => {
+      writeMigrations([genMig('@nx/js', 'gen')]);
+      mockRunMigration.mockResolvedValue({
+        changes: changeList(),
+        nextSteps: [],
+        agentContext: [],
+        logs: '',
+        madeChanges: true,
+      });
+
+      await runSingleMigrationWorker(
+        standaloneInput({ runMigration: '@nx/js:gen' })
+      );
+
+      expect(mockLogSkippedInstall).not.toHaveBeenCalled();
+    });
+
+    it('prints the prompt file contents when it is readable', async () => {
+      writeMigrations([promptMig('@nx/js', 'p')]);
+      mkdirSync(join(root, 'prompts'), { recursive: true });
+      writeFileSync(join(root, 'prompts', 'p.md'), 'step one\nstep two');
+
+      await runSingleMigrationWorker(
+        standaloneInput({ runMigration: '@nx/js:p' })
+      );
+
+      expect(output.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          bodyLines: expect.arrayContaining([
+            'step one',
+            'step two',
+            'Review the instructions above and apply them manually.',
+          ]),
+        })
+      );
+    });
+
+    it('warns naming the prompt file and error code when it cannot be read', async () => {
+      // promptMig points at prompts/p.md, which is never created here.
+      writeMigrations([promptMig('@nx/js', 'p')]);
+
+      await runSingleMigrationWorker(
+        standaloneInput({ runMigration: '@nx/js:p' })
+      );
+
+      expect(output.log).toHaveBeenCalledWith(
+        expect.objectContaining({
+          bodyLines: expect.arrayContaining([
+            expect.stringMatching(
+              /The instructions file 'prompts\/p\.md' could not be read \(ENOENT\)/
+            ),
+          ]),
+        })
+      );
+      expect(output.log).not.toHaveBeenCalledWith(
+        expect.objectContaining({
+          bodyLines: expect.arrayContaining([
+            'Review the instructions above and apply them manually.',
+          ]),
+        })
+      );
+    });
+  });
+});

--- a/packages/nx/src/command-line/migrate/run/worker.ts
+++ b/packages/nx/src/command-line/migrate/run/worker.ts
@@ -1,0 +1,327 @@
+import { existsSync, readFileSync } from 'fs';
+import { dirname, join, relative } from 'path';
+import type { FileChange } from '../../../generators/tree';
+import { readJsonFile } from '../../../utils/fileutils';
+import { output } from '../../../utils/output';
+import { isInsideAgent } from '../agentic/inception';
+import { printDroppedAgentContextForOuterAgent } from '../agentic/print-dropped-agent-context';
+import {
+  ChangedDepInstaller,
+  logSkippedPostMigrationInstall,
+  readMigrationCollection,
+  runNxOrAngularMigration,
+} from '../execute-migration';
+import {
+  commitCheckpointBeforeMigrations,
+  commitMigrationIfRequested,
+} from '../migrate-commits';
+import { reportMigrateSingleMigrationRun } from '../migrate-analytics';
+import { isHybridMigration, isPromptOnlyMigration } from '../migration-shape';
+import { escapeXmlAttr, pmExecPrefix } from './util';
+
+// The `ng update <pkg> --migrate-only` analog: run exactly one migration from
+// the migrations file, standalone and stateless.
+
+/** A migration entry as written into the plan (migrations.json). */
+interface PlannedMigration {
+  package: string;
+  name: string;
+  version: string;
+  description?: string;
+  implementation?: string;
+  factory?: string;
+  prompt?: string;
+  documentation?: string;
+}
+
+export interface RunSingleMigrationWorkerInput {
+  root: string;
+  options: { runMigration: string };
+  createCommits: boolean | undefined;
+  commitPrefix: string;
+  skipInstall: boolean;
+  isVerbose: boolean;
+}
+
+export async function runSingleMigrationWorker(
+  input: RunSingleMigrationWorkerInput
+): Promise<void> {
+  const { root, options, createCommits, commitPrefix, skipInstall, isVerbose } =
+    input;
+
+  const { migrations, source } = readMigrationsSource(root);
+  const migration = resolveMigration(migrations, options.runMigration, source);
+
+  reportMigrateSingleMigrationRun({
+    migrationType: isPromptOnlyMigration(migration)
+      ? 'prompt'
+      : isHybridMigration(migration)
+        ? 'hybrid'
+        : 'generator',
+  });
+
+  await runStandalone(
+    root,
+    migration,
+    createCommits,
+    commitPrefix,
+    skipInstall,
+    isVerbose
+  );
+}
+
+function readMigrationsSource(root: string): {
+  migrations: PlannedMigration[];
+  source: string;
+} {
+  const migrationsPath = join(root, 'migrations.json');
+  if (!existsSync(migrationsPath)) {
+    throw new Error(
+      `File 'migrations.json' doesn't exist, can't run the migration. Run \`${pmExecPrefix(
+        root
+      )} nx migrate\` to generate it first.`
+    );
+  }
+  return {
+    migrations: readPlanMigrations(migrationsPath),
+    source: 'migrations.json',
+  };
+}
+
+function readPlanMigrations(path: string): PlannedMigration[] {
+  return (
+    readJsonFile<{ migrations?: PlannedMigration[] }>(path).migrations ?? []
+  );
+}
+
+function resolveMigration(
+  migrations: PlannedMigration[],
+  id: string,
+  source: string
+): PlannedMigration {
+  // '<package>:<name>' splits on the first ':', leaving names that themselves
+  // contain a ':' intact; a bare id matches on name only.
+  const colon = id.indexOf(':');
+  const matches =
+    colon === -1
+      ? migrations.filter((m) => m.name === id)
+      : migrations.filter(
+          (m) =>
+            m.package === id.slice(0, colon) && m.name === id.slice(colon + 1)
+        );
+
+  if (matches.length === 0) {
+    throw new Error(`No migration matching '${id}' was found in ${source}.`);
+  }
+  if (matches.length > 1) {
+    throw new Error(
+      [
+        `More than one migration matches '${id}' in ${source}. Re-run with the full '<package>:<name>' id:`,
+        ...matches.map((m) => `  - ${m.package}:${m.name}`),
+      ].join('\n')
+    );
+  }
+  return matches[0];
+}
+
+async function runStandalone(
+  root: string,
+  migration: PlannedMigration,
+  createCommits: boolean | undefined,
+  commitPrefix: string,
+  skipInstall: boolean,
+  isVerbose: boolean
+): Promise<void> {
+  if (isPromptOnlyMigration(migration)) {
+    emitOrPrintPrompt(root, migration);
+    return;
+  }
+
+  // Same guard as the classic loop: checkpoint pre-existing working-tree state
+  // so the commit's `git add -A` can't fold it into the migration's commit.
+  if (createCommits === true) {
+    commitCheckpointBeforeMigrations(root, commitPrefix);
+  }
+
+  const installer = new ChangedDepInstaller(root, skipInstall);
+  const { changes, nextSteps, agentContext, logs, madeChanges } =
+    await runNxOrAngularMigration(
+      root,
+      migration,
+      isVerbose,
+      isHybridMigration(migration)
+    );
+
+  if (!isHybridMigration(migration)) {
+    forwardDroppedAgentContext(migration, agentContext);
+  }
+
+  // Commit only with -C and only when the generator changed something: a no-op
+  // migration must not build a commit whose `git add -A` absorbs prior pending
+  // diffs under its name. When commits run, the install happens inside the
+  // commit; otherwise it runs on its own here.
+  if (createCommits === true && madeChanges) {
+    await commitMigrationIfRequested(root, migration, true, commitPrefix, () =>
+      installer.installDepsIfChanged()
+    );
+  } else {
+    await installer.installDepsIfChanged();
+  }
+
+  if (installer.skippedInstall) {
+    logSkippedPostMigrationInstall(root);
+  }
+
+  printNextSteps(migration, nextSteps);
+
+  if (isHybridMigration(migration)) {
+    emitOrPrintPrompt(root, migration, { logs, changes, agentContext });
+  }
+}
+
+// The classic loop's inside-agent path surfaces generator `agentContext` to
+// the outer agent; hybrids carry it in the prompt payload instead.
+function forwardDroppedAgentContext(
+  migration: PlannedMigration,
+  agentContext: string[]
+): void {
+  if (agentContext.length > 0 && isInsideAgent()) {
+    printDroppedAgentContextForOuterAgent({ migration, agentContext });
+  }
+}
+
+function printNextSteps(
+  migration: PlannedMigration,
+  nextSteps: string[]
+): void {
+  if (nextSteps.length === 0) return;
+  output.log({
+    title: `Next steps for ${migration.package}: ${migration.name}`,
+    bodyLines: nextSteps.map((line) => `- ${line}`),
+  });
+}
+
+// Surfaces a prompt-based migration that this worker doesn't apply itself:
+// under an outer AI agent, as a machine-readable tagged block it can act on;
+// otherwise as printed instructions for the user to apply by hand.
+function emitOrPrintPrompt(
+  root: string,
+  migration: PlannedMigration,
+  impl?: { logs: string; changes: FileChange[]; agentContext: string[] }
+): void {
+  const migrationId = `${migration.package}:${migration.name}`;
+  const promptPath = migration.prompt;
+  const documentationPath = resolveDocumentationPath(root, migration);
+
+  if (isInsideAgent()) {
+    emitPromptForOuterAgent(migrationId, promptPath, documentationPath, impl);
+  } else {
+    printPromptForUser(root, migration, promptPath, documentationPath);
+  }
+}
+
+function emitPromptForOuterAgent(
+  migrationId: string,
+  promptPath: string | undefined,
+  documentationPath: string | undefined,
+  impl:
+    | { logs: string; changes: FileChange[]; agentContext: string[] }
+    | undefined
+): void {
+  const payload: Record<string, unknown> = { migrationId, prompt: promptPath };
+  if (documentationPath) payload.documentationPath = documentationPath;
+  if (impl) {
+    payload.impl = {
+      logs: impl.logs,
+      changes: impl.changes.map((c) => ({ type: c.type, path: c.path })),
+      ...(impl.agentContext.length > 0
+        ? { agentContext: impl.agentContext }
+        : {}),
+    };
+  }
+  // A raw `<` in a migration-authored string could forge the closing tag.
+  // Replacing it with the JSON unicode escape leaves the payload valid JSON
+  // and strips every raw `<` a hostile value might break out with.
+  const json = JSON.stringify(payload, null, 2).replace(/</g, '\\u003c');
+  const block = [
+    `The following prompt-based migration was not applied automatically. Apply it to this workspace, then continue.`,
+    ``,
+    `<nx_migrate_prompt migration="${escapeXmlAttr(migrationId)}">`,
+    json,
+    `</nx_migrate_prompt>`,
+  ].join('\n');
+  // Bare newline pair frames the block so adjacent stdout doesn't run into it.
+  process.stdout.write(`\n${block}\n\n`);
+}
+
+function printPromptForUser(
+  root: string,
+  migration: PlannedMigration,
+  promptPath: string | undefined,
+  documentationPath: string | undefined
+): void {
+  const bodyLines: string[] = [];
+  if (promptPath) bodyLines.push(`Instructions file: ${promptPath}`);
+  if (documentationPath) bodyLines.push(`Documentation: ${documentationPath}`);
+
+  let content = '';
+  let readErrorCode: string | undefined;
+  if (promptPath) {
+    try {
+      content = readFileSync(join(root, promptPath), 'utf-8');
+    } catch (e) {
+      const err = e as NodeJS.ErrnoException;
+      readErrorCode = err.code ?? err.message;
+    }
+  }
+
+  if (readErrorCode) {
+    // The migration named a prompt file we can't read; point at it by path and
+    // error code rather than render empty "review the instructions" copy.
+    bodyLines.push(
+      '',
+      `The instructions file '${promptPath}' could not be read (${readErrorCode}). Open it manually and apply the instructions.`
+    );
+  } else {
+    if (content) {
+      bodyLines.push('', ...content.split('\n'));
+    }
+    bodyLines.push(
+      '',
+      'Review the instructions above and apply them manually.'
+    );
+  }
+  output.log({
+    title: `Prompt-based migration ${migration.package}: ${migration.name} must be applied manually`,
+    bodyLines,
+  });
+}
+
+// Mirrors migrate.ts's documentation resolution (which run/ can't import): the
+// migration's `documentation` ref is package-relative, so resolve it against
+// the collection dir and express it workspace-relative. Best-effort.
+function resolveDocumentationPath(
+  root: string,
+  migration: PlannedMigration
+): string | undefined {
+  if (!migration.documentation) return undefined;
+  let collectionPath: string;
+  try {
+    collectionPath = readMigrationCollection(
+      migration.package,
+      root
+    ).collectionPath;
+  } catch {
+    return undefined;
+  }
+  let resolved: string;
+  try {
+    resolved = require.resolve(migration.documentation, {
+      paths: [dirname(collectionPath)],
+    });
+  } catch {
+    return undefined;
+  }
+  const rel = relative(root, resolved);
+  return rel.startsWith('..') ? resolved : rel;
+}

--- a/packages/nx/src/command-line/migrate/sort-migrations.ts
+++ b/packages/nx/src/command-line/migrate/sort-migrations.ts
@@ -1,0 +1,48 @@
+import { lt } from 'semver';
+import { isHandoffGitignoreMigration } from './agentic/handoff-gitignore';
+import { normalizeVersion } from './version-utils';
+
+interface SortableMigration {
+  package: string;
+  name: string;
+  version: string;
+}
+
+/**
+ * Orders the migrations to run. Shared by the classic `executeMigrations` loop
+ * and the orchestrator so both apply migrations in the same order. Sorts in
+ * place (like `Array.prototype.sort`) and returns the same array.
+ *
+ * `hoistHandoffGitignore` is set for runs that write scratch under
+ * `.nx/migrate-runs` (agentic and orchestrated); see
+ * `agentic/handoff-gitignore.ts` for why the v23 gitignore migration must run
+ * first in those runs.
+ */
+export function sortMigrations<T extends SortableMigration>(
+  migrations: T[],
+  opts: { hoistHandoffGitignore: boolean }
+): T[] {
+  return migrations.sort((a, b) => {
+    // When hoisting is enabled, hoist the v23 migration that ignores
+    // `.nx/migrate-runs` to position 0 so its .gitignore update lands
+    // before any per-migration commit absorbs the run's handoff scratch.
+    // See `agentic/handoff-gitignore.ts` for the full rationale and the
+    // inline-fallback path that covers intra-pre-v23 agentic runs.
+    if (opts.hoistHandoffGitignore) {
+      if (isHandoffGitignoreMigration(a)) return -1;
+      if (isHandoffGitignoreMigration(b)) return 1;
+    }
+
+    // special case for the split configuration migration to run first
+    if (a.name === '15-7-0-split-configuration-into-project-json-files') {
+      return -1;
+    }
+    if (b.name === '15-7-0-split-configuration-into-project-json-files') {
+      return 1;
+    }
+
+    return lt(normalizeVersion(a.version), normalizeVersion(b.version))
+      ? -1
+      : 1;
+  });
+}

--- a/packages/nx/src/command-line/migrate/version-skew-guard.spec.ts
+++ b/packages/nx/src/command-line/migrate/version-skew-guard.spec.ts
@@ -1,0 +1,198 @@
+import {
+  assertTempCliSupportsNewMigrateFlags,
+  assertWorkspaceNxSupportsNewMigrateFlags,
+  findNewMigrateFlag,
+  NEW_MIGRATE_FLAGS,
+} from './version-skew-guard';
+
+describe('findNewMigrateFlag', () => {
+  it.each(NEW_MIGRATE_FLAGS)('matches the exact flag %s', (flag) => {
+    expect(findNewMigrateFlag(['migrate', flag])).toBe(flag);
+  });
+
+  it.each(NEW_MIGRATE_FLAGS)('matches %s with an inline value', (flag) => {
+    expect(findNewMigrateFlag([`${flag}=some-value`])).toBe(flag);
+  });
+
+  it('does not match --run-migrations (trailing s), exact or with a value', () => {
+    expect(findNewMigrateFlag(['--run-migrations'])).toBeUndefined();
+    expect(
+      findNewMigrateFlag(['--run-migrations=migrations.json'])
+    ).toBeUndefined();
+    expect(findNewMigrateFlag(['--runMigrations'])).toBeUndefined();
+  });
+
+  it('returns undefined when no new flag is present', () => {
+    expect(findNewMigrateFlag([])).toBeUndefined();
+    expect(
+      findNewMigrateFlag(['nx@latest', '--from=nx@22.0.0'])
+    ).toBeUndefined();
+  });
+
+  it('returns the first matching flag among several args', () => {
+    expect(
+      findNewMigrateFlag(['--verbose', '--runMigration=x', '--run-migration=x'])
+    ).toBe('--runMigration');
+  });
+
+  it('ignores everything after the -- separator', () => {
+    expect(findNewMigrateFlag(['--', '--run-migration=x'])).toBeUndefined();
+    expect(
+      findNewMigrateFlag(['--verbose', '--', '--run-migration=x'])
+    ).toBeUndefined();
+    expect(
+      findNewMigrateFlag(['--runMigration=x', '--', '--run-migration=x'])
+    ).toBe('--runMigration');
+  });
+});
+
+describe('assertTempCliSupportsNewMigrateFlags', () => {
+  it('does nothing and never resolves when no new flag is present', async () => {
+    const resolveVersion = jest.fn();
+    await expect(
+      assertTempCliSupportsNewMigrateFlags({
+        argv: ['nx@latest'],
+        cliVersionSpec: 'latest',
+        fromEnvOverride: false,
+        resolveVersion,
+      })
+    ).resolves.toBeUndefined();
+    expect(resolveVersion).not.toHaveBeenCalled();
+  });
+
+  it('refuses when latest resolves below the floor', async () => {
+    const resolveVersion = jest.fn().mockResolvedValue('23.1.0');
+    await expect(
+      assertTempCliSupportsNewMigrateFlags({
+        argv: ['--run-migration=@nx/js:x'],
+        cliVersionSpec: 'latest',
+        fromEnvOverride: false,
+        resolveVersion,
+      })
+    ).rejects.toThrow(
+      "The nx version 'nx migrate' is about to install (23.1.0) does not support --run-migration. This flag ships in nx 23.2.0 or newer."
+    );
+    expect(resolveVersion).toHaveBeenCalledWith('latest');
+  });
+
+  it('does not mention NX_MIGRATE_CLI_VERSION when latest is the source', async () => {
+    await expect(
+      assertTempCliSupportsNewMigrateFlags({
+        argv: ['--run-migration=@nx/js:x'],
+        cliVersionSpec: 'latest',
+        fromEnvOverride: false,
+        resolveVersion: jest.fn().mockResolvedValue('23.1.0'),
+      })
+    ).rejects.not.toThrow(/NX_MIGRATE_CLI_VERSION/);
+  });
+
+  it('mentions NX_MIGRATE_CLI_VERSION when it is the source', async () => {
+    await expect(
+      assertTempCliSupportsNewMigrateFlags({
+        argv: ['--run-migration=@nx/js:x'],
+        cliVersionSpec: '23.1.0',
+        fromEnvOverride: true,
+        // A concrete spec needs no resolution.
+        resolveVersion: jest.fn(),
+      })
+    ).rejects.toThrow(
+      "NX_MIGRATE_CLI_VERSION is set to '23.1.0'. Unset it or set it to nx 23.2.0 or newer."
+    );
+  });
+
+  it('does not resolve an already-concrete spec', async () => {
+    const resolveVersion = jest.fn();
+    await expect(
+      assertTempCliSupportsNewMigrateFlags({
+        argv: ['--run-migration=@nx/js:x'],
+        cliVersionSpec: '23.1.0',
+        fromEnvOverride: true,
+        resolveVersion,
+      })
+    ).rejects.toThrow(/does not support --run-migration/);
+    expect(resolveVersion).not.toHaveBeenCalled();
+  });
+
+  it('passes at the floor (its prerelease) and above', async () => {
+    for (const resolved of ['23.2.0-beta.0', '23.2.0', '23.3.0-beta.1']) {
+      await expect(
+        assertTempCliSupportsNewMigrateFlags({
+          argv: ['--run-migration=@nx/js:x'],
+          cliVersionSpec: 'next',
+          fromEnvOverride: false,
+          resolveVersion: jest.fn().mockResolvedValue(resolved),
+        })
+      ).resolves.toBeUndefined();
+    }
+  });
+
+  it('accepts a v-prefixed concrete spec at or above the floor without resolving', async () => {
+    const resolveVersion = jest.fn();
+    await expect(
+      assertTempCliSupportsNewMigrateFlags({
+        argv: ['--run-migration=@nx/js:x'],
+        cliVersionSpec: 'v23.2.0',
+        fromEnvOverride: true,
+        resolveVersion,
+      })
+    ).resolves.toBeUndefined();
+    expect(resolveVersion).not.toHaveBeenCalled();
+  });
+
+  it('skips the guard when resolution fails, leaving the local-nx fallback reachable', async () => {
+    await expect(
+      assertTempCliSupportsNewMigrateFlags({
+        argv: ['--run-migration=@nx/js:x'],
+        cliVersionSpec: 'latest',
+        fromEnvOverride: false,
+        resolveVersion: jest
+          .fn()
+          .mockRejectedValue(new Error('registry lookup failed')),
+      })
+    ).resolves.toBeUndefined();
+  });
+});
+
+describe('assertWorkspaceNxSupportsNewMigrateFlags', () => {
+  it('does nothing and never reads the version when no new flag is present', () => {
+    const readLocalNxVersion = jest.fn();
+    expect(() =>
+      assertWorkspaceNxSupportsNewMigrateFlags({
+        argv: ['nx@latest'],
+        readLocalNxVersion,
+      })
+    ).not.toThrow();
+    expect(readLocalNxVersion).not.toHaveBeenCalled();
+  });
+
+  it('refuses when the local nx is below the floor, with an update hint', () => {
+    expect(() =>
+      assertWorkspaceNxSupportsNewMigrateFlags({
+        argv: ['--run-migration=@nx/js:x'],
+        readLocalNxVersion: () => '22.5.0',
+      })
+    ).toThrow(
+      "The workspace's installed nx (22.5.0) does not support --run-migration. Update the workspace to nx 23.2.0 or newer first, for example by running 'nx migrate nx@latest' (without --run-migration) or by updating your dependencies."
+    );
+  });
+
+  it('passes when the local nx is at or above the floor', () => {
+    for (const version of ['23.2.0-beta.0', '23.2.0', '24.0.0']) {
+      expect(() =>
+        assertWorkspaceNxSupportsNewMigrateFlags({
+          argv: ['--run-migration=@nx/js:x'],
+          readLocalNxVersion: () => version,
+        })
+      ).not.toThrow();
+    }
+  });
+
+  it('does not block when the local nx version cannot be read', () => {
+    expect(() =>
+      assertWorkspaceNxSupportsNewMigrateFlags({
+        argv: ['--run-migration=@nx/js:x'],
+        readLocalNxVersion: () => undefined,
+      })
+    ).not.toThrow();
+  });
+});

--- a/packages/nx/src/command-line/migrate/version-skew-guard.ts
+++ b/packages/nx/src/command-line/migrate/version-skew-guard.ts
@@ -1,0 +1,116 @@
+import { lt, valid } from 'semver';
+import { normalizeVersion } from './version-utils';
+
+// First nx version shipping --run-migration. Bump this if the feature slips
+// to a later release.
+export const NEW_MIGRATE_FLAGS_FLOOR = '23.2.0-beta.0';
+
+// The release users see in guidance (floor without its prerelease suffix).
+const NEW_MIGRATE_FLAGS_FLOOR_RELEASE = NEW_MIGRATE_FLAGS_FLOOR.split('-')[0];
+
+// yargs accepts both `--run-migration` and `--runMigration`, and the raw argv is
+// forwarded verbatim across both migrate hops, so detection must catch every
+// spelling of the new flags.
+export const NEW_MIGRATE_FLAGS = ['--run-migration', '--runMigration'] as const;
+
+/**
+ * The first new migrate flag present in `argv`, or undefined when none is. A
+ * flag matches as an exact token or as `<flag>=<value>`; `--run-migrations`
+ * (note the trailing s) never matches.
+ */
+export function findNewMigrateFlag(argv: string[]): string | undefined {
+  for (const arg of argv) {
+    // Everything after the -- separator is positional data, not options.
+    if (arg === '--') {
+      return undefined;
+    }
+    for (const flag of NEW_MIGRATE_FLAGS) {
+      if (arg === flag || arg.startsWith(`${flag}=`)) {
+        return flag;
+      }
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Guard A (local side, before hop A). The current nx knows the new flags, but
+ * the temp CLI it is about to install may be older and would silently drop
+ * them. Resolve the temp CLI version and refuse up front when it predates the
+ * feature floor.
+ *
+ * `cliVersionSpec` is NX_MIGRATE_CLI_VERSION when set, else 'latest'. It is
+ * resolved through `resolveVersion` unless it is already a concrete version.
+ * A resolution failure skips the guard instead of blocking: it is not
+ * evidence of version skew, so the install and its own failure/fallback
+ * handling decide from here.
+ */
+export async function assertTempCliSupportsNewMigrateFlags(options: {
+  argv: string[];
+  cliVersionSpec: string;
+  fromEnvOverride: boolean;
+  resolveVersion: (spec: string) => Promise<string>;
+}): Promise<void> {
+  const flag = findNewMigrateFlag(options.argv);
+  if (!flag) {
+    return;
+  }
+
+  // valid() lets a concrete spec (e.g. '23.2.0' or 'v23.2.0') skip the
+  // registry round-trip below; a non-concrete spec like 'latest' is null here
+  // and falls through to resolveVersion.
+  const concrete = valid(options.cliVersionSpec);
+  let resolved: string;
+  try {
+    resolved =
+      concrete ?? (await options.resolveVersion(options.cliVersionSpec));
+  } catch {
+    return;
+  }
+
+  if (!lt(normalizeVersion(resolved), NEW_MIGRATE_FLAGS_FLOOR)) {
+    return;
+  }
+
+  let message =
+    `The nx version 'nx migrate' is about to install (${resolved}) does not support ${flag}. ` +
+    `This flag ships in nx ${NEW_MIGRATE_FLAGS_FLOOR_RELEASE} or newer.`;
+  if (options.fromEnvOverride) {
+    message +=
+      ` NX_MIGRATE_CLI_VERSION is set to '${options.cliVersionSpec}'. ` +
+      `Unset it or set it to nx ${NEW_MIGRATE_FLAGS_FLOOR_RELEASE} or newer.`;
+  }
+  throw new Error(message);
+}
+
+/**
+ * Guard B (temp side, before hop B). The temp CLI knows the new flags, but the
+ * workspace-local nx it is about to hand off to may be older and would silently
+ * drop them. Refuse when the local nx predates the feature floor.
+ *
+ * `readLocalNxVersion` returns undefined when the local nx version cannot be
+ * read; that case does not block (the downstream hand-off surfaces its own
+ * failure, with a clearer error).
+ */
+export function assertWorkspaceNxSupportsNewMigrateFlags(options: {
+  argv: string[];
+  readLocalNxVersion: () => string | undefined;
+}): void {
+  const flag = findNewMigrateFlag(options.argv);
+  if (!flag) {
+    return;
+  }
+
+  const localNxVersion = options.readLocalNxVersion();
+  if (!localNxVersion) {
+    return;
+  }
+
+  if (lt(normalizeVersion(localNxVersion), NEW_MIGRATE_FLAGS_FLOOR)) {
+    throw new Error(
+      `The workspace's installed nx (${localNxVersion}) does not support ${flag}. ` +
+        `Update the workspace to nx ${NEW_MIGRATE_FLAGS_FLOOR_RELEASE} or newer first, ` +
+        `for example by running 'nx migrate nx@latest' (without ${flag}) or by updating your dependencies.`
+    );
+  }
+}


### PR DESCRIPTION
## Current Behavior

`nx migrate --run-migrations` runs the whole migrations.json list in a single process. Running one migration from the CLI requires editing the file down to a single entry or driving the Console API.

## Expected Behavior

`nx migrate --run-migration=<package>:<name>` runs a single migration from migrations.json (a bare name is accepted when unambiguous; ambiguity errors and lists the matches). Runs are stateless: generator migrations execute through the engine with the classic loop's checkpoint-then-commit semantics when `--create-commits` is passed (a failed commit is a warning, and committing on the default branch asks for confirmation first); prompt-based migrations are emitted as a tagged block for a driving AI agent or printed with manual-apply guidance in a terminal; hybrid migrations run their generator half and carry its logs, changed files, and agent context into the prompt half. The nx.json migrate defaults overlay applies only createCommits/commitPrefix to the worker, and the wrapper hand-off to the workspace-local nx mirrors the classic run path.

Because migrate forwards raw argv across two wrapper hops and nx-commands has no yargs .strict(), an older nx would silently drop the new flag and run the full plan instead. Version-skew guards at both hops refuse instead: before installing the temp CLI when its resolved version predates the feature floor, and before handing off to a workspace-local nx that predates it.

The command is documented via `--help` here; the docs pages land with the follow-up runbook work.

> [!IMPORTANT]
> Stacked on #36404; merge that first. #36403 (durable run state + dark orchestrator) stacks on this.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/nxc-4626-f17a61ba)
<!-- polygraph-session-end -->