### PR TITLE
chore(repo): point e2e-docker at the local-registry-e2e target

### DIFF
--- a/e2e/docker/project.json
+++ b/e2e/docker/project.json
@@ -10,7 +10,7 @@
       "inputs": ["e2eInputs", "^production"],
       "dependsOn": [
         "@nx/nx-source:populate-local-registry-storage",
-        "@nx/nx-source:local-registry",
+        "@nx/nx-source:local-registry-e2e",
         "@nx/nx-source:start-docker-registry"
       ]
     },
@@ -19,7 +19,7 @@
       "inputs": ["e2eInputs", "^production"],
       "dependsOn": [
         "@nx/nx-source:populate-local-registry-storage",
-        "@nx/nx-source:local-registry",
+        "@nx/nx-source:local-registry-e2e",
         "@nx/nx-source:start-docker-registry"
       ]
     }


### PR DESCRIPTION
## Current Behavior

The `e2e-docker` project depends on the `local-registry` target, while its `populate-local-registry-storage` dependency pulls in `local-registry-e2e`. Both serve verdaccio on port 4873, so the two tasks start milliseconds apart and race for the port. Verdaccio's busy-port fallback does not save this: both probe the port before either has bound, and the loser then fails at bind time with `EADDRINUSE`, which fails the run before any test executes. The nightly docker npm and pnpm jobs have failed this way on every run since #36302 landed.

## Expected Behavior

`e2e-docker` depends on `local-registry-e2e`, the same target every other e2e project uses, so only one verdaccio server starts.

## Implementation Details

#36302 introduced `local-registry-e2e` and migrated `nx.json`, `e2e/gradle/project.json` and `e2e/maven/project.json`, but left `e2e/docker/project.json` on the old target.

Verified against the task graph (`nx run e2e-docker:e2e-local --graph=<file>`): `@nx/nx-source:local-registry` is gone from both the task list and `continuousDependencies`, and `@nx/nx-source:local-registry-e2e` remains. A full e2e-docker run was not executed locally.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/fix-e2e-docker-local-registry-target-ecd65894)
<!-- polygraph-session-end -->