### PR TITLE
chore(repo): re-enable e2e tests skipped for lodash@4.18.0 bug

### DIFF
--- a/e2e/angular/src/cypress-component-tests-app.test.ts
+++ b/e2e/angular/src/cypress-component-tests-app.test.ts
@@ -14,8 +14,7 @@ describe('Angular Cypress Component Tests - App', () => {
 
   afterAll(() => cleanupCypressComponentTests());
 
-  // TODO(jack): re-enable when lodash@4.18.0 assignWith bug is resolved
-  it.skip('should test app', () => {
+  it('should test app', () => {
     const { appName } = setup;
 
     runCLI(

--- a/e2e/angular/src/cypress-component-tests-buildable.test.ts
+++ b/e2e/angular/src/cypress-component-tests-buildable.test.ts
@@ -15,8 +15,7 @@ describe('Angular Cypress Component Tests - Buildable Lib', () => {
 
   afterAll(() => cleanupCypressComponentTests());
 
-  // TODO(jack): re-enable when lodash@4.18.0 assignWith bug is resolved
-  it.skip('should test buildable lib not being used in app', () => {
+  it('should test buildable lib not being used in app', () => {
     const { appName, buildableLibName } = setup;
 
     expect(() => {

--- a/e2e/angular/src/cypress-component-tests-implicit-dep.test.ts
+++ b/e2e/angular/src/cypress-component-tests-implicit-dep.test.ts
@@ -25,8 +25,7 @@ describe('Angular Cypress Component Tests - Implicit Dep', () => {
 
   afterAll(() => cleanupCypressComponentTests());
 
-  // TODO(jack): re-enable when lodash@4.18.0 assignWith bug is resolved
-  it.skip('should test lib with implicit dep on buildTarget', () => {
+  it('should test lib with implicit dep on buildTarget', () => {
     const { projectName, appName, buildableLibName, usedInAppLibName } = setup;
 
     // creates graph like buildableLib -> lib -> app

--- a/e2e/angular/src/cypress-component-tests-lib.test.ts
+++ b/e2e/angular/src/cypress-component-tests-lib.test.ts
@@ -14,8 +14,7 @@ describe('Angular Cypress Component Tests - Lib', () => {
 
   afterAll(() => cleanupCypressComponentTests());
 
-  // TODO(jack): re-enable when lodash@4.18.0 assignWith bug is resolved
-  it.skip('should successfully component test lib being used in app', () => {
+  it('should successfully component test lib being used in app', () => {
     const { usedInAppLibName } = setup;
 
     runCLI(

--- a/e2e/angular/src/cypress-component-tests-zone-projects.test.ts
+++ b/e2e/angular/src/cypress-component-tests-zone-projects.test.ts
@@ -14,8 +14,7 @@ describe('Angular Cypress Component Tests - Zone.js projects', () => {
 
   afterAll(() => cleanupCypressComponentTests());
 
-  // TODO(jack): re-enable when lodash@4.18.0 assignWith bug is resolved
-  it.skip('should successfully run for an app', () => {
+  it('should successfully run for an app', () => {
     const { appName } = setup;
 
     runCLI(
@@ -28,8 +27,7 @@ describe('Angular Cypress Component Tests - Zone.js projects', () => {
     }
   }, 300_000);
 
-  // TODO(jack): re-enable when lodash@4.18.0 assignWith bug is resolved
-  it.skip('should successfully run for a lib', () => {
+  it('should successfully run for a lib', () => {
     const { usedInAppLibName } = setup;
 
     runCLI(

--- a/e2e/cypress/src/cypress.test.ts
+++ b/e2e/cypress/src/cypress.test.ts
@@ -167,8 +167,7 @@ export default defineConfig({
     TEN_MINS_MS
   );
 
-  // TODO(jack): re-enable when lodash@4.18.0 assignWith bug is resolved
-  it.skip(
+  it(
     `should allow CT and e2e in same project for a next project`,
     async () => {
       const appName = uniq('next-cy-app');
@@ -197,8 +196,7 @@ export default defineConfig({
     TEN_MINS_MS
   );
 
-  // TODO(jack): re-enable when lodash@4.18.0 assignWith bug is resolved
-  it.skip(
+  it(
     `should allow CT and e2e in same project for an angular project`,
     async () => {
       let appName = uniq(`angular-cy-app`);

--- a/e2e/next/src/next-component-tests.test.ts
+++ b/e2e/next/src/next-component-tests.test.ts
@@ -30,8 +30,7 @@ describe('NextJs Component Testing', () => {
     }
   });
 
-  // TODO(jack): re-enable when lodash@4.18.0 assignWith bug is resolved
-  it.skip('should test a NextJs app using babel compiler', () => {
+  it('should test a NextJs app using babel compiler', () => {
     const appName = uniq('next-app');
     createAppWithCt(appName);
     //  add bable compiler to app
@@ -43,8 +42,7 @@ describe('NextJs Component Testing', () => {
     }
   });
 
-  // TODO(jack): re-enable when lodash@4.18.0 assignWith bug is resolved
-  it.skip('should test a NextJs lib using babel compiler', async () => {
+  it('should test a NextJs lib using babel compiler', async () => {
     const libName = uniq('next-lib');
     createLibWithCt(libName, false);
     //  add bable compiler to lib
@@ -56,8 +54,7 @@ describe('NextJs Component Testing', () => {
     }
   });
 
-  // TODO(jack): re-enable when lodash@4.18.0 assignWith bug is resolved
-  it.skip('should test a NextJs lib', async () => {
+  it('should test a NextJs lib', async () => {
     const libName = uniq('next-lib');
     createLibWithCt(libName, false);
     if (runE2ETests()) {
@@ -67,8 +64,7 @@ describe('NextJs Component Testing', () => {
     }
   });
 
-  // TODO(jack): re-enable when lodash@4.18.0 assignWith bug is resolved
-  it.skip('should test a NextJs buildable lib', async () => {
+  it('should test a NextJs buildable lib', async () => {
     const buildableLibName = uniq('next-buildable-lib');
     createLibWithCt(buildableLibName, true);
     if (runE2ETests()) {
@@ -78,8 +74,7 @@ describe('NextJs Component Testing', () => {
     }
   });
 
-  // TODO(jack): re-enable when lodash@4.18.0 assignWith bug is resolved
-  it.skip('should test a NextJs server component that uses router', async () => {
+  it('should test a NextJs server component that uses router', async () => {
     const lib = uniq('next-lib');
     createLibWithCtCypress(lib);
     if (runE2ETests()) {

--- a/e2e/react/src/cypress-component-tests.test.ts
+++ b/e2e/react/src/cypress-component-tests.test.ts
@@ -152,8 +152,7 @@ export default Input;
     delete process.env.NX_ADD_PLUGINS;
   });
 
-  // TODO(jack): re-enable when lodash@4.18.0 assignWith bug is resolved
-  it.skip('should test app', () => {
+  it('should test app', () => {
     runCLI(
       `generate @nx/react:cypress-component-configuration --project=${appName} --generate-tests`
     );
@@ -164,8 +163,7 @@ export default Input;
     }
   }, 300_000);
 
-  // TODO(jack): re-enable when lodash@4.18.0 assignWith bug is resolved
-  it.skip('should successfully component test lib being used in app', () => {
+  it('should successfully component test lib being used in app', () => {
     runCLI(
       `generate @nx/react:cypress-component-configuration --project=${usedInAppLibName} --generate-tests`
     );
@@ -176,8 +174,7 @@ export default Input;
     }
   }, 300_000);
 
-  // TODO(jack): re-enable when lodash@4.18.0 assignWith bug is resolved
-  it.skip('should successfully component test lib being used in app using babel compiler', () => {
+  it('should successfully component test lib being used in app using babel compiler', () => {
     runCLI(
       `generate @nx/react:cypress-component-configuration --project=${usedInAppLibName} --generate-tests`
     );
@@ -195,8 +192,7 @@ export default Input;
     }
   }, 300_000);
 
-  // TODO(jack): re-enable when lodash@4.18.0 assignWith bug is resolved
-  it.skip('should test buildable lib not being used in app', () => {
+  it('should test buildable lib not being used in app', () => {
     createFile(
       `libs/${buildableLibName}/src/lib/input/input.cy.tsx`,
       `
@@ -228,8 +224,7 @@ describe(Input.name, () => {
     }
   }, 300_000);
 
-  // TODO(jack): re-enable when lodash@4.18.0 assignWith bug is resolved
-  it.skip('should work with async webpack config', async () => {
+  it('should work with async webpack config', async () => {
     // TODO: (caleb) for whatever reason the MF webpack config + CT is running, but cypress is not starting up?
     // are they overriding some option on top of each other causing cypress to not see it's running?
     createFile(

--- a/e2e/storybook/src/storybook-angular.test.ts
+++ b/e2e/storybook/src/storybook-angular.test.ts
@@ -29,7 +29,7 @@ describe('Storybook executors for Angular', () => {
     let storybookPort: number;
     afterAll(() => storybookPort && killPorts(storybookPort));
 
-    // TODO(jack): re-enable when lodash@4.18.0 assignWith bug is resolved
+    // TODO(NXC-4690): re-enable when @storybook/angular peers resolve on Angular 22 + TS 6 workspaces
     it.skip('should serve an Angular based Storybook setup', async () => {
       storybookPort = await reservePort();
       const p = await runCommandUntil(

--- a/e2e/storybook/src/storybook.test.ts
+++ b/e2e/storybook/src/storybook.test.ts
@@ -49,16 +49,14 @@ describe('Storybook generators and executors for monorepos', () => {
   });
 
   describe('build storybook', () => {
-    // TODO(jack): re-enable when lodash@4.18.0 assignWith bug is resolved
-    it.skip('should build a React based storybook setup that uses webpack', () => {
+    it('should build a React based storybook setup that uses webpack', () => {
       // build
       runCLI(`run ${reactStorybookApp}:build-storybook --verbose`);
       checkFilesExist(`${reactStorybookApp}/storybook-static/index.html`);
     }, 300_000);
 
     // This test makes sure path resolution works
-    // TODO(jack): re-enable when lodash@4.18.0 assignWith bug is resolved
-    it.skip('should build a React based storybook that references another lib and uses rollup', () => {
+    it('should build a React based storybook that references another lib and uses rollup', () => {
       runCLI(
         `generate @nx/react:lib my-lib --bundler=rollup --unitTestRunner=none --no-interactive`
       );
@@ -111,8 +109,7 @@ describe('Storybook generators and executors for monorepos', () => {
       checkFilesExist(`${reactStorybookApp}/storybook-static/index.html`);
     }, 300_000);
 
-    // TODO(jack): re-enable when lodash@4.18.0 assignWith bug is resolved
-    it.skip('should not bundle in sensitive NX_ environment variables', () => {
+    it('should not bundle in sensitive NX_ environment variables', () => {
       updateFile(
         `${reactStorybookApp}/.storybook/main.ts`,
         (content) => `

--- a/e2e/utils/get-env-info.ts
+++ b/e2e/utils/get-env-info.ts
@@ -140,6 +140,13 @@ export {
   ensurePlaywrightBrowsersInstallation,
 } from './ensure-browser-installation';
 
+// webpack-dev-server's `port: 'auto'` probes from a fixed base (8080), so
+// concurrent e2e-ci tasks on one agent race to bind it (EADDRINUSE in Cypress
+// CT). Give each jest process its own base so probes start in disjoint ranges.
+process.env.WEBPACK_DEV_SERVER_BASE_PORT ??= String(
+  8080 + (process.pid % 5000) * 10
+);
+
 export function getStrippedEnvironmentVariables() {
   return Object.fromEntries(
     Object.entries(process.env).filter(([key]) => {

--- a/packages/cypress/src/utils/config.spec.ts
+++ b/packages/cypress/src/utils/config.spec.ts
@@ -66,6 +66,28 @@ export default defineConfig({});
     expect(actual).not.toContain('justInTimeCompile');
   });
 
+  it('should not add the preset import again when re-run on an existing CT config', async () => {
+    const firstRun = await addDefaultCTConfig(
+      `import { defineConfig } from 'cypress';
+
+export default defineConfig({});
+`,
+      { bundler: 'webpack' },
+      '@nx/react/plugins/component-testing',
+      15
+    );
+    const secondRun = await addDefaultCTConfig(
+      firstRun,
+      { bundler: 'webpack' },
+      '@nx/react/plugins/component-testing',
+      15
+    );
+    expect(secondRun).toBe(firstRun);
+    expect(
+      secondRun.match(/import \{ nxComponentTestingPreset \}/g)
+    ).toHaveLength(1);
+  });
+
   it('should add e2e config to existing CT config', async () => {
     const actual = await addDefaultE2EConfig(
       `import { defineConfig } from 'cypress';

--- a/packages/cypress/src/utils/config.ts
+++ b/packages/cypress/src/utils/config.ts
@@ -192,7 +192,15 @@ ${jitComment}
     );
   }
 
-  if (presetImportPath) {
+  // Re-running the generator must not prepend a second declaration - Cypress
+  // loads TS configs through esbuild, which rejects duplicate bindings.
+  const isPresetAlreadyDeclared =
+    tsquery.query(
+      updatedConfigContents,
+      ':matches(ImportSpecifier, BindingElement) Identifier[name="nxComponentTestingPreset"]'
+    ).length > 0;
+
+  if (presetImportPath && !isPresetAlreadyDeclared) {
     // Use the path verbatim - callers pass the public exported subpath. Don't
     // append `.js`: @nx/react and @nx/angular's package exports only declare
     // the bare `./plugins/component-testing` subpath, so a `.js` suffix


### PR DESCRIPTION
## Current Behavior

18 e2e tests skipped (#35104) due to the lodash@4.18.0 `assignWith is not defined` bug in `lodash/template`, pulled in via html-webpack-plugin.

## Expected Behavior

Tests re-enabled; lodash@4.18.1 fixes the bug. The storybook-angular serve test stays skipped for an unrelated @storybook/angular peer conflict on Angular 22 + TS 6 (NXC-4690).

## Related Issue(s)

NXC-4179

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/nimble-cheetah-04f2c982)
<!-- polygraph-session-end -->