### PR TITLE
fix(testing): add @swc/core when configuring jest with the swc compiler

### DIFF
--- a/packages/jest/src/generators/configuration/lib/ensure-dependencies.spec.ts
+++ b/packages/jest/src/generators/configuration/lib/ensure-dependencies.spec.ts
@@ -1,12 +1,23 @@
-import { readJson, type Tree } from '@nx/devkit';
+import {
+  detectPackageManager,
+  readJson,
+  updateJson,
+  type Tree,
+} from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { ensureDependencies } from './ensure-dependencies';
+
+jest.mock('@nx/devkit', () => ({
+  ...jest.requireActual('@nx/devkit'),
+  detectPackageManager: jest.fn(),
+}));
 
 describe('ensureDependencies', () => {
   let tree: Tree;
 
   beforeEach(() => {
     tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    (detectPackageManager as jest.Mock).mockReturnValue('npm');
   });
 
   describe('Deprecated: --babelJest', () => {
@@ -38,6 +49,35 @@ describe('ensureDependencies', () => {
 
       const packageJson = readJson(tree, 'package.json');
       expect(packageJson.devDependencies['@swc/jest']).toBeDefined();
+      // required peer of @swc/jest. Package managers that don't auto-install
+      // peers (yarn) otherwise leave jest unable to load the transformer
+      expect(packageJson.devDependencies['@swc/core']).toBeDefined();
+    });
+
+    it('should deny the @swc/core build scripts when using pnpm', () => {
+      (detectPackageManager as jest.Mock).mockReturnValue('pnpm');
+      updateJson(tree, 'package.json', (json) => {
+        json.packageManager = 'pnpm@11.2.2';
+        return json;
+      });
+
+      ensureDependencies(tree, { compiler: 'swc' });
+
+      expect(tree.read('pnpm-workspace.yaml', 'utf-8')).toContain(
+        'allowBuilds:\n  "@swc/core": false'
+      );
+    });
+
+    it('should not write pnpm-workspace.yaml when not using the swc compiler', () => {
+      (detectPackageManager as jest.Mock).mockReturnValue('pnpm');
+      updateJson(tree, 'package.json', (json) => {
+        json.packageManager = 'pnpm@11.2.2';
+        return json;
+      });
+
+      ensureDependencies(tree, { compiler: 'tsc' });
+
+      expect(tree.exists('pnpm-workspace.yaml')).toBe(false);
     });
   });
 

--- a/packages/jest/src/generators/configuration/lib/ensure-dependencies.ts
+++ b/packages/jest/src/generators/configuration/lib/ensure-dependencies.ts
@@ -1,4 +1,10 @@
-import { addDependenciesToPackageJson, type Tree } from '@nx/devkit';
+import {
+  addDependenciesToPackageJson,
+  detectPackageManager,
+  type Tree,
+} from '@nx/devkit';
+import { acknowledgeBuildScripts } from '@nx/devkit/internal';
+import { swcCoreVersion } from '@nx/js/internal';
 import { versions } from '../../../utils/versions';
 import type { NormalizedJestProjectSchema } from '../schema';
 
@@ -46,6 +52,13 @@ export function ensureDependencies(
     devDeps['@nx/js'] = nxVersion;
   } else if (options.compiler === 'swc') {
     devDeps['@swc/jest'] = swcJestVersion;
+    // peer dependency of @swc/jest
+    devDeps['@swc/core'] = swcCoreVersion;
+    // @swc/core's postinstall only installs a wasm fallback for platforms not
+    // covered by its prebuilt optional dependencies, so skip it.
+    acknowledgeBuildScripts(tree, detectPackageManager(tree.root), {
+      '@swc/core': false,
+    });
   }
 
   return addDependenciesToPackageJson(


### PR DESCRIPTION
## Current Behavior

When the jest generator configures a project with the swc compiler, it adds `@swc/jest` but not `@swc/core`, which `@swc/jest` declares as a required peer and requires at runtime. Package managers that auto-install peers (npm, pnpm) hide the omission. Yarn does not, so the generated workspace cannot run any test:

```
Error: Cannot find module '@swc/core'
Require stack:
- <workspace>/node_modules/@swc/jest/index.js
```

TS solution setups hit this implicitly. They select the swc jest transformer regardless of the bundler, so they never go through `addSwcDependencies`, which is where `@swc/core` otherwise comes from. The nightly `Linux/yarn` e2e jobs for `e2e-node` and `e2e-remix` fail this way, while their npm and pnpm counterparts pass.

## Expected Behavior

`@swc/core` is added alongside `@swc/jest`, so the generated jest setup works on any package manager. Its build scripts are acknowledged at the same time, since pnpm 11 refuses to install a dependency whose build scripts are neither allowed nor denied.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/fix-jest-swc-core-peer-1fe697de)
<!-- polygraph-session-end -->