### PR TITLE
docs(misc): redirect ahrefs-reported 404s with external backlinks

### DIFF
--- a/astro-docs/netlify.toml
+++ b/astro-docs/netlify.toml
@@ -224,6 +224,12 @@ to = "https://trypolygraph.com"
 status = 301
 force = true
 
+# DOC-556: this page never existed under /docs. The deprecated nx.json `affected`
+# block is now documented on the nx.json reference page.
+[[redirects]]
+from = "/docs/reference/deprecated/affected-config"
+to = "/docs/reference/nx-json#default-base"
+
 # Rewrite for base path handling (keeps URL the same)
 [[redirects]]
 from = "/docs/*"

--- a/nx-dev/nx-dev/_redirects
+++ b/nx-dev/nx-dev/_redirects
@@ -588,9 +588,15 @@
 
 # --- deprecatedReferenceRedirects ---
 /deprecated/global-implicit-dependencies /docs/reference/deprecated/global-implicit-dependencies 301
-/deprecated/affected-config /docs/reference/deprecated/affected-config 301
+# DOC-556: /docs/reference/deprecated/affected-config does not exist. The dead page
+# documented the nx.json `affected` block, which now lives on the nx.json reference.
+/deprecated/affected-config /docs/reference/nx-json#default-base 301
 /deprecated/custom-tasks-runner /docs/reference/deprecated/custom-tasks-runner 301
 /deprecated/legacy-cache /docs/reference/deprecated/legacy-cache 301
+# DOC-556: broken backlink targets (Ahrefs, 2026-07-17)
+/deprecated/as-provided-vs-derived /docs/reference/deprecated/as-provided-vs-derived 301
+/deprecated/integrated-vs-package-based /docs/reference/deprecated/integrated-vs-package-based 301
+/deprecated/rescope /docs/reference/deprecated/rescope 301
 
 # --- commandRedirects ---
 /nx/affected /docs/reference/nx-commands#nx-affected 301
@@ -888,6 +894,8 @@
 /ci/getting-started/intro /docs/getting-started/nx-cloud 301
 /ci/features /docs/features/ci-features 301
 /ci/features/self-healing-ci /docs/features/ci-features/self-healing-ci 301
+# DOC-556: linked from the nrwl/nx README (21.5k referring pages)
+/ci/features/self-healing /docs/features/ci-features/self-healing-ci 301
 /ci/features/remote-cache /docs/features/ci-features/remote-cache 301
 /ci/features/distribute-task-execution /docs/features/ci-features/distribute-task-execution 301
 /ci/features/affected /docs/features/ci-features/affected 301
@@ -1344,3 +1352,12 @@
 /launch-nx / 301
 /ai / 301
 /webinar /webinars 301
+
+# --- DOC-556: broken backlink targets (Ahrefs site audit, 2026-07-17) ---
+# Legacy URLs with external referring pages that currently 404.
+/storybook/overview-react /docs/technologies/test-tools/storybook 301
+/angular /docs/technologies/angular/introduction 301
+/web /docs/getting-started/intro 301
+/nx/reset /docs/reference/nx-commands#nx-reset 301
+/core-concepts/computation-caching /docs/features/cache-task-results 301
+/nx-community /docs/getting-started/intro 301

--- a/packages/nx/src/config/nx-json.ts
+++ b/packages/nx/src/config/nx-json.ts
@@ -856,7 +856,7 @@ export interface NxJsonConfiguration<T = '*' | string[]> {
   targetDefaults?: TargetDefaults;
   /**
    * Default options for `nx affected`
-   * @deprecated use {@link defaultBase} instead. For more information see https://nx.dev/deprecated/affected-config#affected-config
+   * @deprecated use {@link defaultBase} instead. For more information see https://nx.dev/docs/reference/nx-json#default-base
    */
   affected?: NxAffectedConfig;
 


### PR DESCRIPTION
## Current Behavior

Legacy URLs with external referring pages 404. `/deprecated/affected-config` redirects to a page that does not exist.

## Expected Behavior

Redirects added for the dead URLs. `/deprecated/affected-config` points at the nx.json reference, which documents the deprecated `affected` block.

Note: only `/deprecated/*` and `/ci/*` reach the Netlify deploy today. The remaining prefixes are served by Framer and 404 before `_redirects` runs, so those rules stay inert until Framer forwards them.

## Related Issue(s)

Fixes DOC-556

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/easy-panther-7fb06e56)
<!-- polygraph-session-end -->