### PR TITLE
fix(core): keep pnpm-workspace.yaml comments and read package.json as jsonc

### DIFF
--- a/packages/nx/src/utils/acknowledge-build-scripts.spec.ts
+++ b/packages/nx/src/utils/acknowledge-build-scripts.spec.ts
@@ -74,6 +74,20 @@ describe('acknowledgeBuildScripts', () => {
     `);
   });
 
+  it('should preserve comments in a file that has no entries yet', () => {
+    tree.write('pnpm-workspace.yaml', '# team notes\n');
+
+    acknowledgeBuildScripts(tree, 'pnpm', { cypress: true });
+
+    expect(tree.read('pnpm-workspace.yaml', 'utf-8')).toMatchInlineSnapshot(`
+      "# team notes
+
+      allowBuilds:
+        cypress: true
+      "
+    `);
+  });
+
   it('should replace the placeholder stubs pnpm writes during non-strict installs', () => {
     tree.write(
       'pnpm-workspace.yaml',

--- a/packages/nx/src/utils/acknowledge-build-scripts.spec.ts
+++ b/packages/nx/src/utils/acknowledge-build-scripts.spec.ts
@@ -138,6 +138,23 @@ describe('acknowledgeBuildScripts', () => {
     expect(tree.read('pnpm-workspace.yaml', 'utf-8')).toBe(original);
   });
 
+  it('should read a package.json that JSON.parse rejects', () => {
+    // Nx reads JSON with a jsonc parser everywhere else, so a trailing comma
+    // must not make this the one place that refuses the workspace.
+    tree.write(
+      'package.json',
+      '{\n  "name": "proj",\n  "packageManager": "pnpm@11.2.2",\n}\n'
+    );
+
+    acknowledgeBuildScripts(tree, 'pnpm', { cypress: true });
+
+    expect(tree.read('pnpm-workspace.yaml', 'utf-8')).toMatchInlineSnapshot(`
+      "allowBuilds:
+        cypress: true
+      "
+    `);
+  });
+
   it('should probe the pnpm version when the packageManager pin is not exact', () => {
     tree.write(
       'package.json',

--- a/packages/nx/src/utils/acknowledge-build-scripts.ts
+++ b/packages/nx/src/utils/acknowledge-build-scripts.ts
@@ -9,6 +9,7 @@ import {
   parseVersionFromPackageManagerField,
 } from './package-manager';
 import { readJsonFile } from './fileutils';
+import { parseJson } from './json';
 
 const PNPM_WORKSPACE_FILE = 'pnpm-workspace.yaml';
 
@@ -104,7 +105,7 @@ function createHost(treeOrRoot: Tree | string): Host {
     exists: (p) => treeOrRoot.exists(p),
     read: (p) => treeOrRoot.read(p, 'utf-8'),
     write: (p, c) => treeOrRoot.write(p, c),
-    readJson: (p) => JSON.parse(treeOrRoot.read(p, 'utf-8')),
+    readJson: (p) => parseJson(treeOrRoot.read(p, 'utf-8')),
   };
 }
 

--- a/packages/nx/src/utils/acknowledge-build-scripts.ts
+++ b/packages/nx/src/utils/acknowledge-build-scripts.ts
@@ -1,6 +1,6 @@
 import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
-import { Document, parseDocument, YAMLMap } from 'yaml';
+import { parseDocument, YAMLMap } from 'yaml';
 import { gte } from 'semver';
 import type { Tree } from '../generators/tree';
 import type { PackageManager } from './package-manager';
@@ -57,26 +57,27 @@ function acknowledgePnpmBuildScripts(
   // A file that doesn't parse cleanly or whose root isn't a mapping is
   // malformed for pnpm; leave it alone rather than crashing or replacing the
   // user's content. pnpm's own error on the file is the actionable signal.
+  // Empty and comment-only files have no contents at all; setIn creates the
+  // mapping for them while keeping whatever comments they carry.
   if (
     parsed.errors.length > 0 ||
     (parsed.contents != null && !(parsed.contents instanceof YAMLMap))
   ) {
     return;
   }
-  const doc = parsed.contents instanceof YAMLMap ? parsed : new Document({});
 
   let changed = false;
   for (const [pkg, allowed] of Object.entries(entries)) {
     // Only a real boolean is a user decision. pnpm's non-strict installs stub
     // undecided packages with a placeholder string ("set this to true or
     // false"), which would fail the next strict install if left in place.
-    if (typeof doc.getIn(['allowBuilds', pkg]) !== 'boolean') {
-      doc.setIn(['allowBuilds', pkg], allowed);
+    if (typeof parsed.getIn(['allowBuilds', pkg]) !== 'boolean') {
+      parsed.setIn(['allowBuilds', pkg], allowed);
       changed = true;
     }
   }
   if (changed) {
-    host.write(PNPM_WORKSPACE_FILE, doc.toString());
+    host.write(PNPM_WORKSPACE_FILE, parsed.toString());
   }
 }
 


### PR DESCRIPTION
## Current Behavior

Two independent bugs in `acknowledgeBuildScripts`, the util every generator goes through when it records a pnpm `allowBuilds` decision (jest, vite, cypress, detox, esbuild, nest, js and `nx init`).

A `pnpm-workspace.yaml` holding only comments loses them the first time an entry is added. Such a file parses to a document with no contents, which is not a mapping, so the code built a fresh document and wrote it over the user's file. The comment-preserving behavior only held for files that already had entries.

Separately, the tree-backed host parsed `package.json` with `JSON.parse`, while the filesystem host went through `readJsonFile` and its jsonc fallback. A `package.json` with a trailing comma or a comment is read without complaint everywhere else in Nx, but threw here and aborted the run, on the path generators actually take.

## Expected Behavior

Comments survive when the first `allowBuilds` entry is added. The parsed document is mutated directly instead of being replaced; `setIn` creates the mapping when the document has no contents, so the fallback was never needed. The guard that leaves a genuinely malformed file untouched is unchanged.

The tree-backed host reads `package.json` through the shared `parseJson` helper, matching the filesystem host and the rest of Nx. Input that is genuinely broken still throws, as it does through `readJsonFile`.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/fix-jest-swc-core-peer-1fe697de)
<!-- polygraph-session-end -->