### PR TITLE
fix(bundling): acknowledge @swc/core build scripts when configuring rollup

### DIFF
--- a/packages/rollup/src/utils/ensure-dependencies.spec.ts
+++ b/packages/rollup/src/utils/ensure-dependencies.spec.ts
@@ -1,12 +1,23 @@
-import { readJson, type Tree } from '@nx/devkit';
+import {
+  detectPackageManager,
+  readJson,
+  updateJson,
+  type Tree,
+} from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { ensureDependencies } from './ensure-dependencies';
+
+jest.mock('@nx/devkit', () => ({
+  ...jest.requireActual('@nx/devkit'),
+  detectPackageManager: jest.fn(),
+}));
 
 describe('ensureDependencies', () => {
   let tree: Tree;
 
   beforeEach(() => {
     tree = createTreeWithEmptyWorkspace({ layout: 'apps-libs' });
+    (detectPackageManager as jest.Mock).mockReturnValue('npm');
   });
 
   it('should support swc', () => {
@@ -22,6 +33,32 @@ describe('ensureDependencies', () => {
         'swc-loader': expect.any(String),
       },
     });
+  });
+
+  it('should deny the @swc/core build scripts when using pnpm', () => {
+    (detectPackageManager as jest.Mock).mockReturnValue('pnpm');
+    updateJson(tree, 'package.json', (json) => {
+      json.packageManager = 'pnpm@11.2.2';
+      return json;
+    });
+
+    ensureDependencies(tree, { compiler: 'swc' });
+
+    expect(tree.read('pnpm-workspace.yaml', 'utf-8')).toContain(
+      'allowBuilds:\n  "@swc/core": false'
+    );
+  });
+
+  it('should not write pnpm-workspace.yaml when not using the swc compiler', () => {
+    (detectPackageManager as jest.Mock).mockReturnValue('pnpm');
+    updateJson(tree, 'package.json', (json) => {
+      json.packageManager = 'pnpm@11.2.2';
+      return json;
+    });
+
+    ensureDependencies(tree, { compiler: 'tsc' });
+
+    expect(tree.exists('pnpm-workspace.yaml')).toBe(false);
   });
 
   it('should support tsc', () => {

--- a/packages/rollup/src/utils/ensure-dependencies.ts
+++ b/packages/rollup/src/utils/ensure-dependencies.ts
@@ -1,8 +1,10 @@
 import {
   addDependenciesToPackageJson,
+  detectPackageManager,
   type GeneratorCallback,
   type Tree,
 } from '@nx/devkit';
+import { acknowledgeBuildScripts } from '@nx/devkit/internal';
 import { swcCoreVersion, swcHelpersVersion } from '@nx/js/internal';
 import { coreJsVersion, swcLoaderVersion, tsLibVersion } from './versions';
 
@@ -16,6 +18,11 @@ export function ensureDependencies(
 ): GeneratorCallback {
   switch (options.compiler) {
     case 'swc':
+      // @swc/core's postinstall only installs a wasm fallback for platforms not
+      // covered by its prebuilt optional dependencies, so skip it.
+      acknowledgeBuildScripts(tree, detectPackageManager(tree.root), {
+        '@swc/core': false,
+      });
       return addDependenciesToPackageJson(
         tree,
         {},


### PR DESCRIPTION
## Current Behavior

Configuring rollup with the swc compiler adds `@swc/core` to `package.json` without recording a build-script decision for it. pnpm 11 refuses to install a dependency whose build scripts are neither allowed nor denied, so the install that follows the generator fails.

#36302 added these acknowledgements across the generators that pull in `@swc/core`, including `@nx/js`, but missed this call site.

## Expected Behavior

The generator records the decision alongside the dependency, matching what `@nx/js` already does, so the install succeeds.

The build script is denied rather than allowed: `@swc/core`'s postinstall only fetches a wasm fallback for platforms its prebuilt optional dependencies do not cover, so there is nothing to run on a supported platform. Existing decisions in `pnpm-workspace.yaml` are never overwritten, and this is a no-op for npm, yarn, bun, and for pnpm below 11.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/fix-jest-swc-core-peer-1fe697de)
<!-- polygraph-session-end -->