### PR TITLE
fix(core): handle CRLF line endings in pnpm multi-document lockfiles

### DIFF
--- a/packages/nx/src/plugins/js/lock-file/pnpm-parser.spec.ts
+++ b/packages/nx/src/plugins/js/lock-file/pnpm-parser.spec.ts
@@ -2029,6 +2029,62 @@ snapshots:
       });
       expect(nodes['npm:pnpm']).toBeUndefined();
     });
+
+    it('should handle CRLF line endings', () => {
+      const lockFile = `---
+lockfileVersion: '9.0'
+
+importers:
+
+  .:
+    configDependencies: {}
+    packageManagerDependencies:
+      pnpm:
+        specifier: 11.0.0-rc.0
+        version: 11.0.0-rc.0
+
+packages:
+
+  pnpm@11.0.0-rc.0:
+    resolution: {integrity: sha512-pnpm-metadata}
+
+---
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    dependencies:
+      lodash:
+        specifier: ^4.17.21
+        version: 4.17.21
+
+packages:
+
+  lodash@4.17.21:
+    resolution: {integrity: sha512-lodash}
+
+snapshots:
+
+  lodash@4.17.21: {}`.replace(/\n/g, '\r\n');
+
+      const { nodes } = getPnpmLockfileNodes(lockFile, 'pnpm-11-crlf');
+
+      expect(nodes['npm:lodash']).toMatchObject({
+        data: {
+          packageName: 'lodash',
+          version: '4.17.21',
+          hash: 'sha512-lodash',
+        },
+        name: 'npm:lodash',
+        type: 'npm',
+      });
+      expect(nodes['npm:pnpm']).toBeUndefined();
+    });
   });
 
   describe('patched dependencies', () => {

--- a/packages/nx/src/plugins/js/lock-file/utils/pnpm-normalizer.ts
+++ b/packages/nx/src/plugins/js/lock-file/utils/pnpm-normalizer.ts
@@ -71,6 +71,9 @@ const YAML_DOCUMENT_SEPARATOR = '\n---\n';
 // always read the workspace document.
 // https://github.com/pnpm/pnpm/blob/main/lockfile/fs/src/yamlDocuments.ts
 function extractMainLockfileDocument(content: string): string {
+  // Lockfiles written on Windows may use CRLF line endings, which would never
+  // match the LF-only document markers.
+  content = content.replace(/\r\n/g, '\n');
   if (!content.startsWith(YAML_DOCUMENT_START)) {
     return content;
   }


### PR DESCRIPTION
## Current Behavior

`extractMainLockfileDocument` matches the pnpm multi-document markers with LF-only strings (`'---\n'` and `'\n---\n'`). When `pnpm-lock.yaml` is written with CRLF line endings (common on Windows), the markers never match: `startsWith('---\n')` is false, so the raw two-document content flows into YAML parsing and project-graph construction fails with `expected a single document in the stream, but found more`.

## Expected Behavior

Line endings are normalized to LF before the document markers are matched, so multi-document lockfiles written with CRLF are split correctly and the workspace lock document is parsed on Windows. A CRLF variant of the multi-document lockfile test pins the behavior.

## Related Issue(s)

Fixes #35828

Closes #35840

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Fix-CRLF-pnpm-lockfile-parsing-on-Windows-0e926b99)
<!-- polygraph-session-end -->