### PR TITLE
fix(release): honor commit scope configuration (#36425)

### DIFF
--- a/packages/nx/src/command-line/release/utils/shared.spec.ts
+++ b/packages/nx/src/command-line/release/utils/shared.spec.ts
@@ -1326,6 +1326,32 @@ describe('shared', () => {
       expect(scopedCommits?.[0].isProjectScopedCommit).toBe(true);
     });
 
+    it('should ignore commit scope when useCommitScope is disabled', async () => {
+      mockReleaseConfig!.conventionalCommits = {
+        ...mockReleaseConfig!.conventionalCommits,
+        useCommitScope: false,
+      };
+      const commits: GitCommit[] = [
+        createMockCommit(
+          'scopeoff',
+          ['libs/lib-a/src/index.ts'],
+          'feat(lib-b): scope should be ignored',
+          'lib-b'
+        ),
+      ];
+
+      const result = await getCommitsRelevantToProjects(
+        mockProjectGraph,
+        commits,
+        ['lib-a'],
+        mockReleaseConfig!,
+        mockReleaseGraph
+      );
+
+      expect(result.get('lib-a')).toHaveLength(1);
+      expect(result.get('lib-a')?.[0].isProjectScopedCommit).toBe(false);
+    });
+
     it('should throw when commit scope matches multiple projects (ambiguous scope)', async () => {
       const commits: GitCommit[] = [
         createMockCommit(

--- a/packages/nx/src/command-line/release/utils/shared.ts
+++ b/packages/nx/src/command-line/release/utils/shared.ts
@@ -494,7 +494,10 @@ Promise<Map<string, { commit: GitCommit; isProjectScopedCommit: boolean }[]>> {
 
     let scopedProjects: Set<string> | null = null;
 
-    if (scopePatterns.length > 0) {
+    if (
+      scopePatterns.length > 0 &&
+      nxReleaseConfig.conventionalCommits.useCommitScope
+    ) {
       const matches = findMatchingProjects(scopePatterns, projectGraph.nodes);
 
       // Detect ambiguity, but only within the active release group's
@@ -534,7 +537,9 @@ Promise<Map<string, { commit: GitCommit; isProjectScopedCommit: boolean }[]>> {
         }
 
         const isProjectScopedCommit =
-          scopedProjects === null || scopedProjects.has(projectName);
+          scopedProjects === null
+            ? nxReleaseConfig.conventionalCommits.useCommitScope
+            : scopedProjects.has(projectName);
 
         relevantCommits
           .get(projectName)


### PR DESCRIPTION
## Current Behavior

nx release currently always checks for `scopePatterns` even when `useCommitScope` is set to `false`
 https://github.com/nrwl/nx/blob/a6dd4f0bde4a57be1008dcf8bbabe1c494086fc2/packages/nx/src/command-line/release/utils/shared.ts#L497
 thus running into the ambiguity check where `feat(*)` would trigger a throw.
 
## Expected Behavior

I would expect that when setting `useCommitScope` to falls my scopes are not checked and we would directly fall back to the file-affectedness path matching. Even when we commit `feat(lib-b)` with a lib-a file i would expect it to be ignored and match against lib-a.

## Related Issue(s)
#36425