### PR TITLE
chore(testing): set isolatedModules for ts-jest in e2e

### DIFF
--- a/e2e/angular/tsconfig.spec.json
+++ b/e2e/angular/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "isolatedModules": true,
     "outDir": "out-tsc/spec",
     "types": ["jest", "node"],
     "rootDir": "."

--- a/e2e/cypress/tsconfig.spec.json
+++ b/e2e/cypress/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "isolatedModules": true,
     "outDir": "out-tsc/spec",
     "types": ["jest", "node"],
     "rootDir": "."

--- a/e2e/detox/tsconfig.spec.json
+++ b/e2e/detox/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "isolatedModules": true,
     "outDir": "out-tsc/spec",
     "types": ["jest", "node"],
     "rootDir": "."

--- a/e2e/docker/tsconfig.spec.json
+++ b/e2e/docker/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "isolatedModules": true,
     "outDir": "out-tsc/spec",
     "types": ["jest", "node"],
     "rootDir": "."

--- a/e2e/dotnet/tsconfig.spec.json
+++ b/e2e/dotnet/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "isolatedModules": true,
     "outDir": "out-tsc/spec",
     "types": ["jest", "node"],
     "rootDir": "."

--- a/e2e/esbuild/tsconfig.spec.json
+++ b/e2e/esbuild/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "isolatedModules": true,
     "outDir": "out-tsc/spec",
     "types": ["jest", "node"],
     "rootDir": "."

--- a/e2e/eslint/tsconfig.spec.json
+++ b/e2e/eslint/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "isolatedModules": true,
     "outDir": "out-tsc/spec",
     "types": ["jest", "node"],
     "rootDir": "."

--- a/e2e/expo/tsconfig.spec.json
+++ b/e2e/expo/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "isolatedModules": true,
     "outDir": "out-tsc/spec",
     "types": ["jest", "node"],
     "rootDir": "."

--- a/e2e/gradle/tsconfig.spec.json
+++ b/e2e/gradle/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "isolatedModules": true,
     "outDir": "out-tsc/spec",
     "types": ["jest", "node"],
     "rootDir": "."

--- a/e2e/jest/tsconfig.spec.json
+++ b/e2e/jest/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "isolatedModules": true,
     "outDir": "out-tsc/spec",
     "types": ["jest", "node"],
     "rootDir": "."

--- a/e2e/js/tsconfig.spec.json
+++ b/e2e/js/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "isolatedModules": true,
     "outDir": "out-tsc/spec",
     "types": ["jest", "node"],
     "rootDir": "."

--- a/e2e/lerna-smoke-tests/tsconfig.spec.json
+++ b/e2e/lerna-smoke-tests/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "isolatedModules": true,
     "outDir": "out-tsc/spec",
     "types": ["jest", "node"],
     "rootDir": "."

--- a/e2e/maven/tsconfig.spec.json
+++ b/e2e/maven/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "isolatedModules": true,
     "outDir": "out-tsc/spec",
     "types": ["jest", "node"],
     "rootDir": "."

--- a/e2e/module-federation/tsconfig.spec.json
+++ b/e2e/module-federation/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "isolatedModules": true,
     "outDir": "out-tsc/spec",
     "types": ["jest", "node"],
     "rootDir": "."

--- a/e2e/next/tsconfig.spec.json
+++ b/e2e/next/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "isolatedModules": true,
     "outDir": "out-tsc/spec",
     "types": ["jest", "node"],
     "rootDir": "."

--- a/e2e/node/tsconfig.spec.json
+++ b/e2e/node/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "isolatedModules": true,
     "outDir": "out-tsc/spec",
     "types": ["jest", "node"],
     "rootDir": "."

--- a/e2e/nuxt/tsconfig.spec.json
+++ b/e2e/nuxt/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "isolatedModules": true,
     "outDir": "out-tsc/spec",
     "types": ["jest", "node"],
     "rootDir": "."

--- a/e2e/nx-build/tsconfig.spec.json
+++ b/e2e/nx-build/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "isolatedModules": true,
     "outDir": "out-tsc/spec",
     "types": ["jest", "node"],
     "rootDir": "."

--- a/e2e/nx-init/tsconfig.spec.json
+++ b/e2e/nx-init/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "isolatedModules": true,
     "outDir": "out-tsc/spec",
     "types": ["jest", "node"],
     "rootDir": "."

--- a/e2e/nx/tsconfig.spec.json
+++ b/e2e/nx/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "isolatedModules": true,
     "outDir": "out-tsc/spec",
     "types": ["jest", "node"],
     "rootDir": "."

--- a/e2e/playwright/tsconfig.spec.json
+++ b/e2e/playwright/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "isolatedModules": true,
     "outDir": "out-tsc/spec",
     "types": ["jest", "node"],
     "rootDir": "."

--- a/e2e/plugin/tsconfig.spec.json
+++ b/e2e/plugin/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "isolatedModules": true,
     "outDir": "out-tsc/spec",
     "types": ["jest", "node"],
     "rootDir": "."

--- a/e2e/react-native/tsconfig.spec.json
+++ b/e2e/react-native/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "isolatedModules": true,
     "outDir": "out-tsc/spec",
     "types": ["jest", "node"],
     "rootDir": "."

--- a/e2e/react/tsconfig.spec.json
+++ b/e2e/react/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "isolatedModules": true,
     "outDir": "out-tsc/spec",
     "types": ["jest", "node"],
     "rootDir": "."

--- a/e2e/release/tsconfig.spec.json
+++ b/e2e/release/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "isolatedModules": true,
     "outDir": "out-tsc/spec",
     "types": ["jest", "node"],
     "rootDir": "."

--- a/e2e/remix/tsconfig.spec.json
+++ b/e2e/remix/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "isolatedModules": true,
     "outDir": "out-tsc/spec",
     "types": ["jest", "node"],
     "rootDir": "."

--- a/e2e/rollup/tsconfig.spec.json
+++ b/e2e/rollup/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "isolatedModules": true,
     "outDir": "out-tsc/spec",
     "types": ["jest", "node"],
     "rootDir": "."

--- a/e2e/rspack/tsconfig.spec.json
+++ b/e2e/rspack/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "isolatedModules": true,
     "outDir": "out-tsc/spec",
     "types": ["jest", "node"],
     "rootDir": "."

--- a/e2e/storybook/tsconfig.spec.json
+++ b/e2e/storybook/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "isolatedModules": true,
     "outDir": "out-tsc/spec",
     "types": ["jest", "node"],
     "rootDir": "."

--- a/e2e/vite/tsconfig.spec.json
+++ b/e2e/vite/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "isolatedModules": true,
     "outDir": "out-tsc/spec",
     "types": ["jest", "node"],
     "rootDir": "."

--- a/e2e/vue/tsconfig.spec.json
+++ b/e2e/vue/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "isolatedModules": true,
     "outDir": "out-tsc/spec",
     "types": ["jest", "node"],
     "rootDir": "."

--- a/e2e/web/tsconfig.spec.json
+++ b/e2e/web/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "isolatedModules": true,
     "outDir": "out-tsc/spec",
     "types": ["jest", "node"],
     "rootDir": "."

--- a/e2e/webpack/tsconfig.spec.json
+++ b/e2e/webpack/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "isolatedModules": true,
     "outDir": "out-tsc/spec",
     "types": ["jest", "node"],
     "rootDir": "."

--- a/e2e/workspace-create/tsconfig.spec.json
+++ b/e2e/workspace-create/tsconfig.spec.json
@@ -1,6 +1,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "isolatedModules": true,
     "outDir": "out-tsc/spec",
     "types": ["jest", "node"],
     "rootDir": "."


### PR DESCRIPTION
## Current Behavior

`module: nodenext` without `isolatedModules` puts ts-jest on its language service path, which cannot honor nodenext per-file module resolution. ts-jest warns TS151002 once per transformed file - 372 lines in a single lerna-smoke-tests run - plus a fallback warning per untransformable .js file.

## Expected Behavior

ts-jest transpiles per file, which is the supported path for hybrid module kinds. No warnings, and e2e transform is about 2x faster. Specs stay typechecked by each e2e project's `typecheck` target.

Scoped to the e2e spec configs, matching what the `@nx/jest` update-23-1-0 migration writes for existing workspaces. Not set in `tsconfig.base.json`: `packages/nx` has ambient const enum access (TS2748) and type re-exports (TS1205) that fail under it.

See: https://staging.nx.app/runs/c2TLyeRUJb?utm_source=pull-request&utm_medium=comment&query=lerna&taskId=e2e-lerna-smoke-tests%3Ae2e-ci--src%2Flerna-smoke-tests.test.ts

## Related Issue(s)

NXC-4656
