### PR TITLE
fix(core): handle colons in target name when resolving inputs to generate graph

### DIFF
--- a/packages/nx/src/command-line/graph/graph.spec.ts
+++ b/packages/nx/src/command-line/graph/graph.spec.ts
@@ -1,0 +1,219 @@
+import type { FileData } from '../../config/project-graph';
+import { HashPlanner } from '../../native';
+import { createProjectGraphAsync } from '../../project-graph/project-graph';
+import { createTaskGraph } from '../../tasks-runner/create-task-graph';
+import { allFileData } from '../../utils/all-file-data';
+import { getExpandedTaskInputs, ProjectGraphClientResponse } from './graph';
+
+jest.mock('../../native', () => ({
+  HashPlanner: jest.fn(),
+  transferProjectGraph: jest.fn((g) => g),
+}));
+jest.mock('../../native/transform-objects', () => ({
+  transformProjectGraphForRust: jest.fn((g) => g),
+}));
+jest.mock('../../project-graph/project-graph', () => ({
+  createProjectGraphAsync: jest.fn(),
+  createProjectGraphAndSourceMapsAsync: jest.fn(),
+  handleProjectGraphError: jest.fn(),
+}));
+jest.mock('../../config/configuration', () => ({
+  readNxJson: jest.fn(() => ({})),
+  workspaceLayout: jest.fn(() => ({ appsDir: '', libsDir: '' })),
+}));
+jest.mock('../../tasks-runner/create-task-graph', () => ({
+  createTaskGraph: jest.fn(),
+}));
+jest.mock('../../utils/all-file-data', () => ({
+  allFileData: jest.fn(),
+}));
+
+const createProjectGraphAsyncMock = createProjectGraphAsync as jest.Mock;
+const createTaskGraphMock = createTaskGraph as jest.Mock;
+const allFileDataMock = allFileData as jest.Mock;
+const HashPlannerMock = HashPlanner as unknown as jest.Mock;
+
+describe('getExpandedTaskInputs', () => {
+  let getPlansMock: jest.Mock;
+
+  // A workspace with a single project `myproj` that has a `build` target and a
+  // `test:integration` target (whose name contains a colon).
+  function makeResponse(
+    overrides: Partial<ProjectGraphClientResponse> = {}
+  ): ProjectGraphClientResponse {
+    return {
+      hash: 'hash',
+      projects: [
+        {
+          name: 'myproj',
+          type: 'lib',
+          data: {
+            root: 'libs/myproj',
+            targets: { build: {}, 'test:integration': {} },
+          },
+        } as any,
+      ],
+      dependencies: {},
+      fileMap: {
+        myproj: [
+          { file: 'libs/myproj/src/index.ts', hash: 'a' },
+          { file: 'libs/myproj/project.json', hash: 'b' },
+        ],
+      },
+      layout: { appsDir: '', libsDir: '' },
+      affected: [],
+      focus: null,
+      groupByFolder: false,
+      exclude: [],
+      isPartial: false,
+      errors: [],
+      ...overrides,
+    };
+  }
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    getPlansMock = jest.fn().mockReturnValue({});
+    HashPlannerMock.mockImplementation(() => ({ getPlans: getPlansMock }));
+
+    createProjectGraphAsyncMock.mockResolvedValue({
+      nodes: {},
+      dependencies: {},
+    });
+
+    // By default the task graph contains the requested task so a plan is
+    // produced. Individual tests override the returned plan.
+    createTaskGraphMock.mockImplementation(
+      (_graph, _overrides, projects, targets) => ({
+        tasks: { [`${projects[0]}:${targets[0]}`]: {} },
+        dependencies: {},
+        continuousDependencies: {},
+        roots: [],
+      })
+    );
+
+    allFileDataMock.mockResolvedValue([] as FileData[]);
+  });
+
+  it('returns the cached value without recomputing when the task is already cached', async () => {
+    const cache = new Map<string, Record<string, string[]>>();
+    const cached = { general: ['already-cached.ts'] };
+    cache.set('myproj:build', cached);
+
+    const result = await getExpandedTaskInputs(
+      makeResponse(),
+      cache,
+      'myproj:build'
+    );
+
+    // Exact same object reference is handed back
+    expect(result).toBe(cached);
+    // None of the expensive downstream work ran
+    expect(createProjectGraphAsyncMock).not.toHaveBeenCalled();
+    expect(createTaskGraphMock).not.toHaveBeenCalled();
+    expect(allFileDataMock).not.toHaveBeenCalled();
+    expect(getPlansMock).not.toHaveBeenCalled();
+  });
+
+  it('caches and returns an empty object when the task has no plan', async () => {
+    // Task graph has no tasks -> no plan is generated for the task id
+    createTaskGraphMock.mockReturnValue({
+      tasks: {},
+      dependencies: {},
+      continuousDependencies: {},
+      roots: [],
+    });
+
+    const cache = new Map<string, Record<string, string[]>>();
+    const result = await getExpandedTaskInputs(
+      makeResponse(),
+      cache,
+      'myproj:build'
+    );
+
+    expect(result).toEqual({});
+    // The empty result is still cached so we don't recompute next time
+    expect(cache.get('myproj:build')).toBe(result);
+    // With no task ids there is no need to ask the planner for plans
+    expect(getPlansMock).not.toHaveBeenCalled();
+  });
+
+  it('expands workspace root, project root, other and external inputs', async () => {
+    getPlansMock.mockReturnValue({
+      'myproj:build': [
+        // grouped workspace inputs: exact file + top-level glob
+        'workspace:[{workspaceRoot}/package.json,{workspaceRoot}/*.md]',
+        // project root fileset
+        'myproj:{projectRoot}/src/**/*',
+        // "other" named input
+        'ProjectConfiguration',
+        // external dependency (has a modifier prefix)
+        'npm:some-pkg',
+      ],
+    });
+
+    allFileDataMock.mockResolvedValue([
+      { file: 'package.json', hash: '1' },
+      { file: 'readme.md', hash: '2' },
+      // nested markdown must NOT match the top-level `*.md` glob
+      { file: 'docs/guide.md', hash: '3' },
+    ] as FileData[]);
+
+    const cache = new Map<string, Record<string, string[]>>();
+    const result = await getExpandedTaskInputs(
+      makeResponse(),
+      cache,
+      'myproj:build'
+    );
+
+    expect(result).toEqual({
+      // workspace roots are sorted, then the ProjectConfiguration file is appended
+      general: ['package.json', 'readme.md', 'libs/myproj/project.json'],
+      // project root glob only matches files under libs/myproj/src
+      myproj: ['libs/myproj/src/index.ts'],
+      external: ['npm:some-pkg'],
+    });
+    // and the same result is stored in the cache
+    expect(cache.get('myproj:build')).toBe(result);
+  });
+
+  it('memoizes: a second call for the same task reuses the cached result', async () => {
+    getPlansMock.mockReturnValue({
+      'myproj:build': ['npm:some-pkg'],
+    });
+
+    const cache = new Map<string, Record<string, string[]>>();
+    const response = makeResponse();
+
+    const first = await getExpandedTaskInputs(response, cache, 'myproj:build');
+    const second = await getExpandedTaskInputs(response, cache, 'myproj:build');
+
+    expect(second).toBe(first);
+    // The heavy work happened exactly once
+    expect(createProjectGraphAsyncMock).toHaveBeenCalledTimes(1);
+    expect(getPlansMock).toHaveBeenCalledTimes(1);
+    expect(allFileDataMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('splits a task id whose target name contains a colon using the project nodes', async () => {
+    getPlansMock.mockReturnValue({
+      'myproj:test:integration': ['npm:some-pkg'],
+    });
+
+    const cache = new Map<string, Record<string, string[]>>();
+    const result = await getExpandedTaskInputs(
+      makeResponse(),
+      cache,
+      'myproj:test:integration'
+    );
+
+    // "test:integration" is parsed as the target (not target + configuration)
+    const [, , projectsArg, targetsArg] = createTaskGraphMock.mock.calls[0];
+    expect(projectsArg).toEqual(['myproj']);
+    expect(targetsArg).toEqual(['test:integration']);
+
+    expect(result).toEqual({ general: [], external: ['npm:some-pkg'] });
+    expect(cache.get('myproj:test:integration')).toBe(result);
+  });
+});

--- a/packages/nx/src/command-line/graph/graph.ts
+++ b/packages/nx/src/command-line/graph/graph.ts
@@ -60,6 +60,7 @@ import { createTaskHasher } from '../../hasher/create-task-hasher';
 import { getTaskSpecificEnv } from '../../tasks-runner/task-env';
 import { ProjectGraphError } from '../../project-graph/error-types';
 import { isNxCloudUsed } from '../../utils/nx-cloud-utils';
+import { splitTargetFromNodes } from '../../utils/split-target';
 
 export interface GraphError {
   message: string;
@@ -705,7 +706,11 @@ async function startServer(
 
       const taskId = parsedUrl.searchParams.get('taskId');
       res.writeHead(200, { 'Content-Type': 'application/json' });
-      const inputs = await getExpandedTaskInputs(taskId);
+      const inputs = await getExpandedTaskInputs(
+        currentProjectGraphClientResponse,
+        expandedTaskInputsCache,
+        taskId
+      );
       performance.mark('task input generation:end');
 
       res.end(JSON.stringify({ [taskId]: inputs }));
@@ -1282,7 +1287,9 @@ async function createTaskGraphForTargetsAndProjects(
   }
 }
 
-async function getExpandedTaskInputs(
+export async function getExpandedTaskInputs(
+  depGraphClientResponse: ProjectGraphClientResponse,
+  expandedTaskInputsCache: Map<string, Record<string, string[]>>,
   taskId: string
 ): Promise<Record<string, string[]>> {
   // Check cache first
@@ -1291,7 +1298,17 @@ async function getExpandedTaskInputs(
   }
 
   // Use the optimized version that only creates the specific task graph needed
-  const [projectName, targetName, configuration] = taskId.split(':');
+  // Use colon-aware splitting so that target names containing colons
+  // (e.g. "test:integration") are parsed correctly instead of being
+  // mistaken for a target + configuration pair.
+  const projectNodes = Object.fromEntries(
+    depGraphClientResponse.projects.map((p) => [p.name, p])
+  );
+  const [projectName, targetName, configuration] = splitTargetFromNodes(
+    taskId,
+    projectNodes,
+    { silent: true }
+  );
   const taskGraphResponse = await createTaskGraphForTargetsAndProjects(
     [targetName],
     [projectName],
@@ -1306,11 +1323,9 @@ async function getExpandedTaskInputs(
   if (inputs) {
     result = expandInputs(
       inputs,
-      currentProjectGraphClientResponse.projects.find(
-        (p) => p.name === projectName
-      ),
+      depGraphClientResponse.projects.find((p) => p.name === projectName),
       allWorkspaceFiles,
-      currentProjectGraphClientResponse
+      depGraphClientResponse
     );
   }
 


### PR DESCRIPTION
## Current Behavior

If a project target has a colon in its name, its input are not computed correctly when using the `graph` command.

## Expected Behavior

Targets with colons in their name should be computed correctly.

## Related Issue(s)

Fixes #33710
