### PR TITLE
feat(core): add bun dependency-catalog support

### DIFF
--- a/packages/devkit/src/utils/package-json.spec.ts
+++ b/packages/devkit/src/utils/package-json.spec.ts
@@ -2,7 +2,11 @@ import * as packageManagerUtils from 'nx/src/utils/package-manager';
 import { createTree } from 'nx/src/generators/testing-utils/create-tree';
 import type { Tree } from 'nx/src/generators/tree';
 import { readJson, writeJson } from 'nx/src/generators/utils/json';
-import { addDependenciesToPackageJson, ensurePackage } from './package-json';
+import {
+  addDependenciesToPackageJson,
+  ensurePackage,
+  getDependencyVersionFromPackageJson,
+} from './package-json';
 
 describe('addDependenciesToPackageJson', () => {
   let tree: Tree;
@@ -667,6 +671,102 @@ catalog:
         "Failed to resolve catalog reference 'catalog:nonexistent' for package 'react'"
       );
     });
+  });
+});
+
+describe('getDependencyVersionFromPackageJson', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTree();
+    tree.root = '/test-workspace';
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should resolve a bun catalog reference to the catalog version', () => {
+    jest
+      .spyOn(packageManagerUtils, 'detectPackageManager')
+      .mockReturnValue('bun');
+    writeJson(tree, 'package.json', {
+      workspaces: ['packages/*'],
+      catalog: { vite: '6.0.0' },
+    });
+    writeJson(tree, 'packages/app/package.json', {
+      devDependencies: { vite: 'catalog:' },
+    });
+
+    const version = getDependencyVersionFromPackageJson(
+      tree,
+      'vite',
+      'packages/app/package.json'
+    );
+
+    expect(version).toBe('6.0.0');
+  });
+
+  it('should resolve a bun named catalog reference', () => {
+    jest
+      .spyOn(packageManagerUtils, 'detectPackageManager')
+      .mockReturnValue('bun');
+    writeJson(tree, 'package.json', {
+      workspaces: ['packages/*'],
+      catalogs: { web: { react: '^18.2.0' } },
+    });
+    writeJson(tree, 'packages/app/package.json', {
+      dependencies: { react: 'catalog:web' },
+    });
+
+    const version = getDependencyVersionFromPackageJson(
+      tree,
+      'react',
+      'packages/app/package.json'
+    );
+
+    expect(version).toBe('^18.2.0');
+  });
+
+  it('should resolve a bun catalog reference nested under workspaces', () => {
+    jest
+      .spyOn(packageManagerUtils, 'detectPackageManager')
+      .mockReturnValue('bun');
+    writeJson(tree, 'package.json', {
+      workspaces: { packages: ['packages/*'], catalog: { vite: '6.0.0' } },
+    });
+    writeJson(tree, 'packages/app/package.json', {
+      devDependencies: { vite: 'catalog:' },
+    });
+
+    const version = getDependencyVersionFromPackageJson(
+      tree,
+      'vite',
+      'packages/app/package.json'
+    );
+
+    expect(version).toBe('6.0.0');
+  });
+
+  it('should return the raw specifier when no catalog manager applies', () => {
+    jest
+      .spyOn(packageManagerUtils, 'detectPackageManager')
+      .mockReturnValue('npm');
+    writeJson(tree, 'package.json', {
+      catalog: { vite: '6.0.0' },
+    });
+    writeJson(tree, 'packages/app/package.json', {
+      devDependencies: { vite: 'catalog:' },
+    });
+
+    const version = getDependencyVersionFromPackageJson(
+      tree,
+      'vite',
+      'packages/app/package.json'
+    );
+
+    // npm has no catalog manager, so the reference is left unresolved.
+    expect(version).toBe('catalog:');
   });
 });
 

--- a/packages/devkit/src/utils/package-json.ts
+++ b/packages/devkit/src/utils/package-json.ts
@@ -37,9 +37,10 @@ const NON_SEMVER_TAGS = {
 /**
  * Get the resolved version of a dependency from package.json.
  *
- * Retrieves a package version and automatically resolves PNPM catalog references
- * (e.g., "catalog:default") to their actual version strings. By default, searches
- * `dependencies` first, then falls back to `devDependencies`.
+ * Retrieves a package version and automatically resolves package manager
+ * catalog references (e.g., "catalog:default") to their actual version
+ * strings. By default, searches `dependencies` first, then falls back to
+ * `devDependencies`.
  *
  * **Tree-based usage** (generators and migrations):
  * Use when you have a `Tree` object, which is typical in Nx generators and migrations.

--- a/packages/eslint-plugin/src/rules/dependency-checks.spec.ts
+++ b/packages/eslint-plugin/src/rules/dependency-checks.spec.ts
@@ -2672,6 +2672,123 @@ describe('Dependency checks (eslint)', () => {
     });
   });
 
+  describe('bun catalogs', () => {
+    beforeEach(() => {
+      jest.spyOn(packageManager, 'detectPackageManager').mockReturnValue('bun');
+    });
+
+    afterEach(() => {
+      jest.clearAllMocks();
+    });
+
+    function runMissingDepRule(rootPackageJsonContent: object) {
+      const packageJson = {
+        name: '@mycompany/liba',
+        dependencies: {
+          external1: '^16.0.0',
+        },
+      };
+
+      const fileSys = {
+        './libs/liba/package.json': JSON.stringify(packageJson, null, 2),
+        './libs/liba/src/index.ts': '',
+        './package.json': JSON.stringify(rootPackageJsonContent, null, 2),
+      };
+      vol.fromJSON(fileSys, '/root');
+
+      const failures = runRule(
+        {},
+        `/root/libs/liba/package.json`,
+        JSON.stringify(packageJson, null, 2),
+        {
+          nodes: {
+            liba: {
+              name: 'liba',
+              type: 'lib',
+              data: {
+                root: 'libs/liba',
+                targets: {
+                  build: {},
+                },
+              },
+            },
+          },
+          externalNodes,
+          dependencies: {
+            liba: [
+              { source: 'liba', target: 'npm:external1', type: 'static' },
+              {
+                source: 'liba',
+                target: 'npm:random-external',
+                type: 'static',
+              },
+            ],
+          },
+        },
+        {
+          liba: [
+            createFile(`libs/liba/src/main.ts`, [
+              'npm:external1',
+              'npm:random-external',
+            ]),
+            createFile(`libs/liba/package.json`, ['npm:external1']),
+          ],
+        }
+      );
+
+      expect(failures.length).toEqual(1);
+      expect(failures[0].message).toContain('random-external');
+
+      const content = JSON.stringify(packageJson, null, 2);
+      return (
+        content.slice(0, failures[0].fix!.range[0]) +
+        failures[0].fix!.text +
+        content.slice(failures[0].fix!.range[1])
+      );
+    }
+
+    it('should use catalog: for missing dep when package is in the catalog field', () => {
+      const result = runMissingDepRule({
+        ...rootPackageJson,
+        catalog: { 'random-external': '^1.0.0' },
+      });
+
+      expect(result).toContain('"random-external": "catalog:"');
+    });
+
+    it('should use catalog:default for missing dep when package is in catalogs.default', () => {
+      // Unlike pnpm, bun's `catalog:` does not resolve from `catalogs.default`;
+      // it is an ordinary named catalog addressed as `catalog:default`.
+      const result = runMissingDepRule({
+        ...rootPackageJson,
+        catalogs: { default: { 'random-external': '^1.0.0' } },
+      });
+
+      expect(result).toContain('"random-external": "catalog:default"');
+    });
+
+    it('should use catalog:name for missing dep when package is in a named catalog', () => {
+      const result = runMissingDepRule({
+        ...rootPackageJson,
+        catalogs: { react: { 'random-external': '^1.0.0' } },
+      });
+
+      expect(result).toContain('"random-external": "catalog:react"');
+    });
+
+    it('should resolve from a workspaces-nested catalog', () => {
+      const result = runMissingDepRule({
+        ...rootPackageJson,
+        workspaces: {
+          packages: ['libs/*'],
+          catalog: { 'random-external': '^1.0.0' },
+        },
+      });
+
+      expect(result).toContain('"random-external": "catalog:"');
+    });
+  });
+
   it('should require swc if @nx/js:swc executor', () => {
     const packageJson = {
       name: '@mycompany/liba',

--- a/packages/eslint-plugin/src/rules/dependency-checks.ts
+++ b/packages/eslint-plugin/src/rules/dependency-checks.ts
@@ -188,7 +188,6 @@ export default ESLintUtils.RuleCreator(
     const rootPackageJsonDeps = getAllDependencies(rootPackageJson);
 
     const catalogManager = getCatalogManager(workspaceRoot);
-    const catalogDefs = catalogManager?.getCatalogDefinitions(workspaceRoot);
 
     function catalogEntryMatchesInstalled(
       catalogVersionSpec: string,
@@ -207,33 +206,11 @@ export default ESLintUtils.RuleCreator(
     }
 
     function getCatalogVersionForPackage(packageName: string): string | null {
-      if (!catalogDefs) {
-        return null;
-      }
-
-      const matches: { catalogRef: string; versionSpec: string }[] = [];
-
-      // Check default catalog — `catalog` takes precedence over `catalogs.default`.
-      // Both existing simultaneously is a pnpm error caught by validateCatalogReference.
-      const defaultEntry =
-        catalogDefs.catalog?.[packageName] ??
-        catalogDefs.catalogs?.default?.[packageName];
-      if (defaultEntry) {
-        matches.push({ catalogRef: 'catalog:', versionSpec: defaultEntry });
-      }
-
-      // Check named catalogs (skip "default" — handled above)
-      if (catalogDefs.catalogs) {
-        for (const [name, entries] of Object.entries(catalogDefs.catalogs)) {
-          if (name === 'default' || !entries?.[packageName]) {
-            continue;
-          }
-          matches.push({
-            catalogRef: `catalog:${name}`,
-            versionSpec: entries[packageName],
-          });
-        }
-      }
+      const matches =
+        catalogManager?.getCatalogReferencesForPackage(
+          workspaceRoot,
+          packageName
+        ) ?? [];
 
       if (!matches.length) {
         return null;

--- a/packages/js/src/release/version-actions.ts
+++ b/packages/js/src/release/version-actions.ts
@@ -313,14 +313,16 @@ export default class JsVersionActions extends VersionActions {
       );
     }
 
-    // Update catalog definitions in pnpm-workspace.yaml
+    // Update catalog definitions in the package manager's catalog file
     if (catalogUpdates.length > 0) {
       // catalogManager is guaranteed to be defined when there are catalog updates
       catalogManager!.updateCatalogVersions(tree, catalogUpdates);
 
       const catalogText = catalogUpdates.length === 1 ? 'entry' : 'entries';
       logMessages.push(
-        `✍️  Updated ${catalogUpdates.length} catalog ${catalogText} in pnpm-workspace.yaml`
+        `✍️  Updated ${catalogUpdates.length} catalog ${catalogText} in ${catalogManager!
+          .getCatalogDefinitionFilePaths()
+          .join(', ')}`
       );
     }
 

--- a/packages/nx/src/utils/catalog/bun-manager-utils.ts
+++ b/packages/nx/src/utils/catalog/bun-manager-utils.ts
@@ -1,0 +1,248 @@
+import { applyEdits, modify } from 'jsonc-parser';
+import { existsSync, readFileSync, writeFileSync } from 'node:fs';
+import { join } from 'node:path';
+import type { Tree } from '../../generators/tree';
+import { readJsonFile } from '../fileutils';
+import { parseJson } from '../json';
+import { output } from '../output';
+import type { CatalogDefinitions } from './types';
+
+// Bun catalogs live in package.json, either at the top level or nested under
+// the object form of `workspaces`.
+interface BunPackageJson {
+  workspaces?:
+    | string[]
+    | {
+        packages?: string[];
+        catalog?: Record<string, string>;
+        catalogs?: Record<string, Record<string, string>>;
+      };
+  catalog?: Record<string, string>;
+  catalogs?: Record<string, Record<string, string>>;
+}
+
+// Extracts catalog definitions from a parsed bun package.json, normalizing the
+// top-level and `workspaces`-nested locations into a single CatalogDefinitions.
+// Bun treats the locations as all-or-nothing: when either catalog field exists
+// under `workspaces`, the top-level fields are ignored entirely rather than
+// merged.
+function normalizeBunCatalogDefinitions(
+  packageJson: BunPackageJson
+): CatalogDefinitions | null {
+  const nested =
+    packageJson.workspaces && !Array.isArray(packageJson.workspaces)
+      ? packageJson.workspaces
+      : undefined;
+
+  const source =
+    nested?.catalog !== undefined || nested?.catalogs !== undefined
+      ? nested
+      : packageJson;
+  const { catalog, catalogs } = source;
+
+  if (!catalog && !catalogs) {
+    return null;
+  }
+
+  return { catalog, catalogs };
+}
+
+function readBunCatalogConfigFromFs(
+  filename: string,
+  fullPath: string
+): CatalogDefinitions | null {
+  try {
+    return normalizeBunCatalogDefinitions(
+      readJsonFile<BunPackageJson>(fullPath)
+    );
+  } catch (error) {
+    output.warn({
+      title: `Unable to parse ${filename}`,
+      bodyLines: [error.toString()],
+    });
+    return null;
+  }
+}
+
+function readBunCatalogConfigFromTree(
+  filename: string,
+  tree: Tree
+): CatalogDefinitions | null {
+  const content = tree.read(filename, 'utf-8');
+  try {
+    return normalizeBunCatalogDefinitions(parseJson<BunPackageJson>(content));
+  } catch (error) {
+    output.warn({
+      title: `Unable to parse ${filename}`,
+      bodyLines: [error.toString()],
+    });
+    return null;
+  }
+}
+
+// Mirror of readCatalogDefinitions for bun's package.json-based catalogs: the
+// fs (string-root) branch is cached per pass, the Tree branch stays live.
+export function readBunCatalogDefinitions(
+  filename: string,
+  treeOrRoot: Tree | string,
+  cache: Map<string, CatalogDefinitions | null>
+): CatalogDefinitions | null {
+  if (typeof treeOrRoot === 'string') {
+    if (cache.has(treeOrRoot)) {
+      return cache.get(treeOrRoot);
+    }
+    const configPath = join(treeOrRoot, filename);
+    const defs = existsSync(configPath)
+      ? readBunCatalogConfigFromFs(filename, configPath)
+      : null;
+    cache.set(treeOrRoot, defs);
+    return defs;
+  }
+
+  if (!treeOrRoot.exists(filename)) {
+    return null;
+  }
+  return readBunCatalogConfigFromTree(filename, treeOrRoot);
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+// Resolves the jsonc path a catalog update should target. Follows the same
+// all-or-nothing routing as the reader: updates land in the `workspaces`
+// location when it holds a catalog field, otherwise at the top level.
+function resolveBunCatalogTargetPath(
+  packageJson: BunPackageJson,
+  packageName: string,
+  catalogName: string | undefined
+): string[] {
+  const nested =
+    packageJson.workspaces && !Array.isArray(packageJson.workspaces)
+      ? packageJson.workspaces
+      : undefined;
+  const nestedIsActive =
+    nested?.catalog !== undefined || nested?.catalogs !== undefined;
+  const prefix = nestedIsActive ? ['workspaces'] : [];
+
+  return catalogName
+    ? [...prefix, 'catalogs', catalogName, packageName]
+    : [...prefix, 'catalog', packageName];
+}
+
+// jsonc-parser's `modify` creates missing intermediate objects but throws on
+// null (or other non-object) ones — the JSON counterpart of pnpm's empty
+// `catalog:` placeholder. Walk the target path and, at the first non-object
+// step, replace that node wholesale with the remaining path nested as fresh
+// objects.
+function planBunCatalogEdit(
+  packageJson: BunPackageJson,
+  targetPath: string[],
+  version: string
+): { path: string[]; value: unknown } {
+  let node: unknown = packageJson;
+  for (let i = 0; i < targetPath.length - 1; i++) {
+    if (!isRecord(node)) {
+      break;
+    }
+    const next = node[targetPath[i]];
+    if (next !== undefined && !isRecord(next)) {
+      const value = targetPath
+        .slice(i + 1)
+        .reduceRight((acc: unknown, key) => ({ [key]: acc }), version);
+      return { path: targetPath.slice(0, i + 1), value };
+    }
+    node = next;
+  }
+  return { path: targetPath, value: version };
+}
+
+export function updateBunCatalogVersionsInFile(
+  filename: string,
+  treeOrRoot: Tree | string,
+  updates: Array<{
+    packageName: string;
+    version: string;
+    catalogName?: string;
+  }>
+): void {
+  let checkExists: () => boolean;
+  let readContent: () => string;
+  let writeContent: (content: string) => void;
+
+  if (typeof treeOrRoot === 'string') {
+    const configPath = join(treeOrRoot, filename);
+    checkExists = () => existsSync(configPath);
+    readContent = () => readFileSync(configPath, 'utf-8');
+    writeContent = (content) => writeFileSync(configPath, content, 'utf-8');
+  } else {
+    checkExists = () => treeOrRoot.exists(filename);
+    readContent = () => treeOrRoot.read(filename, 'utf-8');
+    writeContent = (content) => treeOrRoot.write(filename, content);
+  }
+
+  if (!checkExists()) {
+    output.warn({
+      title: `No ${filename} found`,
+      bodyLines: [
+        `Cannot update catalog versions without a ${filename} file.`,
+        `Create a ${filename} file to use catalogs.`,
+      ],
+    });
+    return;
+  }
+
+  try {
+    let content = readContent();
+    // parseJson surfaces a genuine syntax error here rather than letting a
+    // broken file be silently rewritten.
+    let packageJson = parseJson<BunPackageJson>(content);
+
+    let hasChanges = false;
+    for (const update of updates) {
+      const { packageName, version, catalogName } = update;
+
+      const targetPath = resolveBunCatalogTargetPath(
+        packageJson,
+        packageName,
+        catalogName
+      );
+
+      // `modify` emits an edit even for an identical value, so check first to
+      // keep an already-matching file untouched.
+      const currentValue = targetPath.reduce(
+        (node: unknown, key) => (isRecord(node) ? node[key] : undefined),
+        packageJson
+      );
+      if (currentValue === version) {
+        continue;
+      }
+
+      const { path, value } = planBunCatalogEdit(
+        packageJson,
+        targetPath,
+        version
+      );
+      const edits = modify(content, path, value, {
+        formattingOptions: { insertSpaces: true, tabSize: 2 },
+      });
+      if (edits.length > 0) {
+        content = applyEdits(content, edits);
+        // Re-parse so the next update routes against the just-applied edit
+        // (e.g. a null `catalog` placeholder replaced with a fresh map).
+        packageJson = parseJson<BunPackageJson>(content);
+        hasChanges = true;
+      }
+    }
+
+    if (hasChanges) {
+      writeContent(content);
+    }
+  } catch (error) {
+    output.error({
+      title: 'Failed to update catalog versions',
+      bodyLines: [error instanceof Error ? error.message : String(error)],
+    });
+    throw error;
+  }
+}

--- a/packages/nx/src/utils/catalog/bun-manager.spec.ts
+++ b/packages/nx/src/utils/catalog/bun-manager.spec.ts
@@ -1,0 +1,608 @@
+import { createTreeWithEmptyWorkspace } from '../../generators/testing-utils/create-tree-with-empty-workspace';
+import type { Tree } from '../../generators/tree';
+import { readJson, writeJson } from '../../generators/utils/json';
+import { BunCatalogManager } from './bun-manager';
+
+describe('BunCatalogManager', () => {
+  let tree: Tree;
+  let manager: BunCatalogManager;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+    manager = new BunCatalogManager();
+  });
+
+  describe('isCatalogReference', () => {
+    it('should return true for catalog references', () => {
+      expect(manager.isCatalogReference('catalog:')).toBe(true);
+      expect(manager.isCatalogReference('catalog:web')).toBe(true);
+    });
+
+    it('should return false for non-catalog references', () => {
+      expect(manager.isCatalogReference('^18.0.0')).toBe(false);
+      expect(manager.isCatalogReference('latest')).toBe(false);
+      expect(manager.isCatalogReference('catalog')).toBe(false);
+      expect(manager.isCatalogReference('workspace:*')).toBe(false);
+    });
+  });
+
+  describe('parseCatalogReference', () => {
+    it('should parse default catalog reference', () => {
+      const result = manager.parseCatalogReference('catalog:');
+
+      expect(result).toStrictEqual({
+        catalogName: undefined,
+        isDefaultCatalog: true,
+      });
+    });
+
+    it('should treat catalog:default as a named catalog reference', () => {
+      // Unlike pnpm, bun does not treat "default" as an alias for the
+      // `catalog` field — it is an ordinary named catalog.
+      const result = manager.parseCatalogReference('catalog:default');
+
+      expect(result).toStrictEqual({
+        catalogName: 'default',
+        isDefaultCatalog: false,
+      });
+    });
+
+    it('should treat whitespace-only names as the default catalog', () => {
+      const result = manager.parseCatalogReference('catalog:  ');
+
+      expect(result).toStrictEqual({
+        catalogName: undefined,
+        isDefaultCatalog: true,
+      });
+    });
+
+    it('should parse named catalog reference', () => {
+      const result = manager.parseCatalogReference('catalog:web');
+
+      expect(result).toStrictEqual({
+        catalogName: 'web',
+        isDefaultCatalog: false,
+      });
+    });
+
+    it('should return null for non-catalog reference', () => {
+      expect(manager.parseCatalogReference('^18.0.0')).toBe(null);
+    });
+  });
+
+  describe('getCatalogDefinitions', () => {
+    it('should return null when no package.json exists', () => {
+      tree.delete('package.json');
+
+      expect(manager.getCatalogDefinitions(tree)).toBe(null);
+    });
+
+    it('should return null when package.json has no catalog fields', () => {
+      writeJson(tree, 'package.json', { dependencies: { lodash: '^4.17.21' } });
+
+      expect(manager.getCatalogDefinitions(tree)).toBe(null);
+    });
+
+    it('should parse top-level catalog and catalogs fields', () => {
+      writeJson(tree, 'package.json', {
+        name: 'root',
+        workspaces: ['packages/*'],
+        catalog: { react: '^18.0.0', lodash: '^4.17.21' },
+        catalogs: {
+          web: { react: '^18.0.0', 'react-dom': '^18.0.0' },
+          legacy: { react: '^17.0.0' },
+        },
+      });
+
+      expect(manager.getCatalogDefinitions(tree)).toStrictEqual({
+        catalog: { react: '^18.0.0', lodash: '^4.17.21' },
+        catalogs: {
+          web: { react: '^18.0.0', 'react-dom': '^18.0.0' },
+          legacy: { react: '^17.0.0' },
+        },
+      });
+    });
+
+    it('should parse catalog and catalogs nested under workspaces', () => {
+      writeJson(tree, 'package.json', {
+        name: 'root',
+        workspaces: {
+          packages: ['packages/*'],
+          catalog: { react: '^19.0.0' },
+          catalogs: { testing: { jest: '30.0.0' } },
+        },
+      });
+
+      expect(manager.getCatalogDefinitions(tree)).toStrictEqual({
+        catalog: { react: '^19.0.0' },
+        catalogs: { testing: { jest: '30.0.0' } },
+      });
+    });
+
+    it('should ignore top-level fields when workspaces-nested catalogs exist', () => {
+      // Bun's locations are all-or-nothing: any catalog field under
+      // `workspaces` disables both top-level fields.
+      writeJson(tree, 'package.json', {
+        name: 'root',
+        catalog: { react: '^18.0.0' },
+        workspaces: {
+          packages: ['packages/*'],
+          catalog: { react: '^17.0.0' },
+        },
+      });
+
+      expect(manager.getCatalogDefinitions(tree)).toStrictEqual({
+        catalog: { react: '^17.0.0' },
+        catalogs: undefined,
+      });
+    });
+
+    it('should ignore a top-level catalog when only nested catalogs exists', () => {
+      writeJson(tree, 'package.json', {
+        name: 'root',
+        catalog: { react: '^18.0.0' },
+        workspaces: {
+          packages: ['packages/*'],
+          catalogs: { testing: { jest: '30.0.0' } },
+        },
+      });
+
+      expect(manager.getCatalogDefinitions(tree)).toStrictEqual({
+        catalog: undefined,
+        catalogs: { testing: { jest: '30.0.0' } },
+      });
+    });
+
+    it('should handle parsing errors gracefully', () => {
+      tree.write('package.json', '{ not valid json');
+
+      expect(manager.getCatalogDefinitions(tree)).toBe(null);
+    });
+  });
+
+  describe('resolveCatalogReference', () => {
+    it('should resolve default catalog reference from top-level catalog field', () => {
+      writeJson(tree, 'package.json', { catalog: { react: '^18.0.0' } });
+
+      expect(manager.resolveCatalogReference(tree, 'react', 'catalog:')).toBe(
+        '^18.0.0'
+      );
+    });
+
+    it('should not resolve catalog:default from the catalog field', () => {
+      // "default" is an ordinary named catalog in bun, so it does not resolve
+      // against the singular `catalog` field.
+      writeJson(tree, 'package.json', { catalog: { react: '^18.0.0' } });
+
+      expect(
+        manager.resolveCatalogReference(tree, 'react', 'catalog:default')
+      ).toBe(null);
+    });
+
+    it('should not resolve catalog: from the catalogs.default field', () => {
+      // The inverse also holds: `catalog:` resolves only against the singular
+      // `catalog` field, never `catalogs.default`.
+      writeJson(tree, 'package.json', {
+        catalogs: { default: { react: '^18.0.0' } },
+      });
+
+      expect(manager.resolveCatalogReference(tree, 'react', 'catalog:')).toBe(
+        null
+      );
+    });
+
+    it('should resolve catalog:default from the catalogs.default field', () => {
+      writeJson(tree, 'package.json', {
+        catalogs: { default: { react: '^18.0.0' } },
+      });
+
+      expect(
+        manager.resolveCatalogReference(tree, 'react', 'catalog:default')
+      ).toBe('^18.0.0');
+    });
+
+    it('should resolve a whitespace-only name as the default catalog', () => {
+      writeJson(tree, 'package.json', { catalog: { react: '^18.0.0' } });
+
+      expect(manager.resolveCatalogReference(tree, 'react', 'catalog:  ')).toBe(
+        '^18.0.0'
+      );
+    });
+
+    it('should resolve named catalog reference', () => {
+      writeJson(tree, 'package.json', {
+        catalogs: { legacy: { react: '^17.0.0' } },
+      });
+
+      expect(
+        manager.resolveCatalogReference(tree, 'react', 'catalog:legacy')
+      ).toBe('^17.0.0');
+    });
+
+    it('should resolve from a workspaces-nested catalog', () => {
+      writeJson(tree, 'package.json', {
+        workspaces: {
+          packages: ['packages/*'],
+          catalog: { vite: '6.0.0' },
+        },
+      });
+
+      expect(manager.resolveCatalogReference(tree, 'vite', 'catalog:')).toBe(
+        '6.0.0'
+      );
+    });
+
+    it('should return null for non-catalog references', () => {
+      expect(manager.resolveCatalogReference(tree, 'react', '^18.0.0')).toBe(
+        null
+      );
+    });
+
+    it('should return null for missing catalog', () => {
+      expect(
+        manager.resolveCatalogReference(tree, 'react', 'catalog:nonexistent')
+      ).toBe(null);
+    });
+
+    it('should return null for missing package in catalog', () => {
+      writeJson(tree, 'package.json', { catalog: { react: '^18.0.0' } });
+
+      expect(
+        manager.resolveCatalogReference(tree, 'nonexistent', 'catalog:')
+      ).toBe(null);
+    });
+  });
+
+  describe('getCatalogReferencesForPackage', () => {
+    it('should return catalog:default for a package in catalogs.default', () => {
+      // Unlike pnpm, `catalogs.default` is an ordinary named catalog in bun.
+      writeJson(tree, 'package.json', {
+        catalogs: { default: { react: '^18.0.0' } },
+      });
+
+      expect(
+        manager.getCatalogReferencesForPackage(tree, 'react')
+      ).toStrictEqual([
+        { catalogRef: 'catalog:default', versionSpec: '^18.0.0' },
+      ]);
+    });
+
+    it('should return default and named references for a package in both', () => {
+      writeJson(tree, 'package.json', {
+        catalog: { react: '^18.0.0' },
+        catalogs: { legacy: { react: '^17.0.0' } },
+      });
+
+      expect(
+        manager.getCatalogReferencesForPackage(tree, 'react')
+      ).toStrictEqual([
+        { catalogRef: 'catalog:', versionSpec: '^18.0.0' },
+        { catalogRef: 'catalog:legacy', versionSpec: '^17.0.0' },
+      ]);
+    });
+
+    it('should return an empty array when the package is not catalogued', () => {
+      writeJson(tree, 'package.json', { catalog: { react: '^18.0.0' } });
+
+      expect(
+        manager.getCatalogReferencesForPackage(tree, 'lodash')
+      ).toStrictEqual([]);
+    });
+  });
+
+  describe('validateCatalogReference', () => {
+    it('should throw for non-catalog syntax', () => {
+      expect(() =>
+        manager.validateCatalogReference(tree, 'react', '^18.0.0')
+      ).toThrow(
+        'Invalid catalog reference syntax: "^18.0.0". Expected format: "catalog:" or "catalog:name"'
+      );
+    });
+
+    it('should throw when no catalog definitions exist', () => {
+      writeJson(tree, 'package.json', {});
+
+      expect(() =>
+        manager.validateCatalogReference(tree, 'react', 'catalog:')
+      ).toThrow(
+        'Cannot get Bun catalog definitions. No catalog defined in package.json.'
+      );
+    });
+
+    it('should allow catalog and catalogs.default to coexist', () => {
+      // Unlike pnpm, bun does not treat this as a duplicate default: the two
+      // are addressed independently via "catalog:" and "catalog:default".
+      writeJson(tree, 'package.json', {
+        catalog: { react: '^18.0.0' },
+        catalogs: { default: { lodash: '^4.17.21' } },
+      });
+
+      expect(() =>
+        manager.validateCatalogReference(tree, 'react', 'catalog:')
+      ).not.toThrow();
+      expect(() =>
+        manager.validateCatalogReference(tree, 'lodash', 'catalog:default')
+      ).not.toThrow();
+    });
+
+    it('should throw when default catalog not found', () => {
+      writeJson(tree, 'package.json', {
+        catalogs: { web: { react: '^18.0.0' } },
+      });
+
+      expect(() =>
+        manager.validateCatalogReference(tree, 'react', 'catalog:')
+      ).toThrow('No default catalog defined in package.json');
+    });
+
+    it('should throw when named catalog not found', () => {
+      writeJson(tree, 'package.json', { catalog: { react: '^18.0.0' } });
+
+      expect(() =>
+        manager.validateCatalogReference(tree, 'react', 'catalog:non-existent')
+      ).toThrow('Catalog "non-existent" not found in package.json');
+    });
+
+    it('should throw for a missing package in catalog', () => {
+      writeJson(tree, 'package.json', { catalog: { react: '^18.0.0' } });
+
+      expect(() =>
+        manager.validateCatalogReference(tree, 'lodash', 'catalog:')
+      ).toThrow('Package "lodash" not found in default catalog ("catalog")');
+    });
+
+    it('should not throw for an existing catalog entry', () => {
+      writeJson(tree, 'package.json', { catalog: { react: '^18.0.0' } });
+
+      expect(() =>
+        manager.validateCatalogReference(tree, 'react', 'catalog:')
+      ).not.toThrow();
+    });
+
+    it('should validate a workspaces-nested named catalog entry', () => {
+      writeJson(tree, 'package.json', {
+        workspaces: {
+          packages: ['packages/*'],
+          catalogs: { testing: { jest: '30.0.0' } },
+        },
+      });
+
+      expect(() =>
+        manager.validateCatalogReference(tree, 'jest', 'catalog:testing')
+      ).not.toThrow();
+    });
+  });
+
+  describe('updateCatalogVersions', () => {
+    it('should update an existing top-level catalog entry', () => {
+      writeJson(tree, 'package.json', {
+        catalog: { react: '^18.0.0', lodash: '^4.17.21' },
+      });
+
+      manager.updateCatalogVersions(tree, [
+        { packageName: 'react', version: '^18.3.0' },
+      ]);
+
+      const result = readJson(tree, 'package.json');
+      expect(result.catalog.react).toBe('^18.3.0');
+      expect(result.catalog.lodash).toBe('^4.17.21');
+    });
+
+    it('should update a catalogs.default entry via its literal name', () => {
+      // `catalogs.default` is an ordinary named catalog in bun, addressed by
+      // catalogName "default" — a default (unnamed) update goes to `catalog`.
+      writeJson(tree, 'package.json', {
+        catalogs: { default: { react: '^18.0.0' } },
+      });
+
+      manager.updateCatalogVersions(tree, [
+        { packageName: 'react', version: '^18.3.0', catalogName: 'default' },
+      ]);
+
+      const result = readJson(tree, 'package.json');
+      expect(result.catalogs.default.react).toBe('^18.3.0');
+    });
+
+    it('should create a top-level catalog field when none exists', () => {
+      writeJson(tree, 'package.json', {
+        name: 'root',
+        workspaces: ['packages/*'],
+      });
+
+      manager.updateCatalogVersions(tree, [
+        { packageName: 'react', version: '^18.0.0' },
+      ]);
+
+      const result = readJson(tree, 'package.json');
+      expect(result.catalog.react).toBe('^18.0.0');
+      expect(result.catalogs).toBeUndefined();
+    });
+
+    it('should update a named catalog', () => {
+      writeJson(tree, 'package.json', {
+        catalogs: { web: { react: '^18.0.0', 'react-dom': '^18.0.0' } },
+      });
+
+      manager.updateCatalogVersions(tree, [
+        { packageName: 'react', version: '^18.3.0', catalogName: 'web' },
+      ]);
+
+      const result = readJson(tree, 'package.json');
+      expect(result.catalogs.web.react).toBe('^18.3.0');
+      expect(result.catalogs.web['react-dom']).toBe('^18.0.0');
+    });
+
+    it('should update a workspaces-nested catalog in place', () => {
+      writeJson(tree, 'package.json', {
+        workspaces: {
+          packages: ['packages/*'],
+          catalog: { vite: '6.0.0' },
+        },
+      });
+
+      manager.updateCatalogVersions(tree, [
+        { packageName: 'vite', version: '6.1.0' },
+      ]);
+
+      const result = readJson(tree, 'package.json');
+      expect(result.workspaces.catalog.vite).toBe('6.1.0');
+      expect(result.catalog).toBeUndefined();
+    });
+
+    it('should create a named catalog in the nested location when it is active', () => {
+      // With any catalog field under `workspaces`, bun ignores the top-level
+      // fields, so a new named catalog must be created inside `workspaces`
+      // where bun will actually read it.
+      writeJson(tree, 'package.json', {
+        workspaces: {
+          packages: ['packages/*'],
+          catalog: { vite: '6.0.0' },
+        },
+      });
+
+      manager.updateCatalogVersions(tree, [
+        { packageName: 'jest', version: '30.0.0', catalogName: 'testing' },
+      ]);
+
+      const result = readJson(tree, 'package.json');
+      expect(result.workspaces.catalogs.testing.jest).toBe('30.0.0');
+      expect(result.catalogs).toBeUndefined();
+    });
+
+    it('should add a new package to an existing catalog', () => {
+      writeJson(tree, 'package.json', { catalog: { react: '^18.0.0' } });
+
+      manager.updateCatalogVersions(tree, [
+        { packageName: 'lodash', version: '^4.17.21' },
+      ]);
+
+      const result = readJson(tree, 'package.json');
+      expect(result.catalog.react).toBe('^18.0.0');
+      expect(result.catalog.lodash).toBe('^4.17.21');
+    });
+
+    it('should handle multiple updates at once', () => {
+      writeJson(tree, 'package.json', {
+        catalog: { react: '^18.0.0' },
+        catalogs: { legacy: { react: '^17.0.0' } },
+      });
+
+      manager.updateCatalogVersions(tree, [
+        { packageName: 'react', version: '^18.3.0' },
+        { packageName: 'react', version: '^17.0.2', catalogName: 'legacy' },
+      ]);
+
+      const result = readJson(tree, 'package.json');
+      expect(result.catalog.react).toBe('^18.3.0');
+      expect(result.catalogs.legacy.react).toBe('^17.0.2');
+    });
+
+    it('should preserve other package.json fields and formatting', () => {
+      tree.write(
+        'package.json',
+        `{
+  "name": "root",
+  "private": true,
+  "workspaces": ["packages/*"],
+  "catalog": {
+    "react": "^18.0.0"
+  }
+}
+`
+      );
+
+      manager.updateCatalogVersions(tree, [
+        { packageName: 'react', version: '^18.3.0' },
+      ]);
+
+      expect(tree.read('package.json', 'utf-8')).toBe(
+        `{
+  "name": "root",
+  "private": true,
+  "workspaces": ["packages/*"],
+  "catalog": {
+    "react": "^18.3.0"
+  }
+}
+`
+      );
+    });
+
+    it('should be a no-op when the target version already matches', () => {
+      const original = `{
+  "catalog": {
+    "react": "^18.0.0"
+  }
+}
+`;
+      tree.write('package.json', original);
+
+      manager.updateCatalogVersions(tree, [
+        { packageName: 'react', version: '^18.0.0' },
+      ]);
+
+      expect(tree.read('package.json', 'utf-8')).toBe(original);
+    });
+
+    it('should replace a null catalog placeholder with a populated map', () => {
+      writeJson(tree, 'package.json', { catalog: null });
+
+      manager.updateCatalogVersions(tree, [
+        { packageName: 'react', version: '^18.3.0' },
+      ]);
+
+      const result = readJson(tree, 'package.json');
+      expect(result.catalog.react).toBe('^18.3.0');
+    });
+
+    it('should route a default update to catalog even when catalogs.default exists', () => {
+      // The default catalog is only the `catalog` field in bun, so an unnamed
+      // update must not be redirected into the `catalogs.default` named
+      // catalog.
+      writeJson(tree, 'package.json', {
+        catalog: null,
+        catalogs: { default: { react: '^18.0.0' } },
+      });
+
+      manager.updateCatalogVersions(tree, [
+        { packageName: 'react', version: '^18.3.0' },
+      ]);
+
+      const result = readJson(tree, 'package.json');
+      expect(result.catalog.react).toBe('^18.3.0');
+      expect(result.catalogs.default.react).toBe('^18.0.0');
+    });
+
+    it('should replace a null named catalog placeholder', () => {
+      writeJson(tree, 'package.json', { catalogs: { legacy: null } });
+
+      manager.updateCatalogVersions(tree, [
+        { packageName: 'react', version: '^17.0.2', catalogName: 'legacy' },
+      ]);
+
+      const result = readJson(tree, 'package.json');
+      expect(result.catalogs.legacy.react).toBe('^17.0.2');
+    });
+
+    it('should create a named catalog when catalogs is absent', () => {
+      writeJson(tree, 'package.json', { name: 'root' });
+
+      manager.updateCatalogVersions(tree, [
+        { packageName: 'react', version: '^17.0.2', catalogName: 'legacy' },
+      ]);
+
+      const result = readJson(tree, 'package.json');
+      expect(result.catalogs.legacy.react).toBe('^17.0.2');
+    });
+
+    it('should throw on a malformed package.json', () => {
+      tree.write('package.json', '{ not valid json');
+
+      expect(() =>
+        manager.updateCatalogVersions(tree, [
+          { packageName: 'react', version: '^18.3.0' },
+        ])
+      ).toThrow();
+    });
+  });
+});

--- a/packages/nx/src/utils/catalog/bun-manager.ts
+++ b/packages/nx/src/utils/catalog/bun-manager.ts
@@ -5,9 +5,9 @@ import {
   type CatalogManager,
 } from './manager';
 import {
-  readCatalogDefinitions,
-  updateCatalogVersionsInFile,
-} from './manager-utils';
+  readBunCatalogDefinitions,
+  updateBunCatalogVersionsInFile,
+} from './bun-manager-utils';
 import type {
   CatalogDefinitions,
   CatalogEntry,
@@ -15,15 +15,20 @@ import type {
   CatalogReferenceMatch,
 } from './types';
 
-const YARNRC_FILENAME = '.yarnrc.yml';
+const BUN_CATALOG_FILENAME = 'package.json';
 
 /**
- * Yarn Berry (v4+) catalog manager implementation
+ * Bun-specific catalog manager implementation.
+ *
+ * Bun declares catalogs in the root package.json `catalog`/`catalogs` fields,
+ * either at the top level or nested under the object form of `workspaces`.
+ * Unlike pnpm, the name "default" is not special: `catalog:` resolves only
+ * against `catalog`, and `catalog:default` against `catalogs.default`.
  */
-export class YarnCatalogManager implements CatalogManager {
-  readonly name = 'yarn';
+export class BunCatalogManager implements CatalogManager {
+  readonly name = 'bun';
   readonly catalogProtocol = 'catalog:';
-  // Parsed fs-root definitions, cached per pass. See readCatalogDefinitions.
+  // Parsed fs-root definitions, cached per pass. See readBunCatalogDefinitions.
   private definitionsByRoot = new Map<string, CatalogDefinitions | null>();
 
   isCatalogReference(version: string): boolean {
@@ -35,9 +40,10 @@ export class YarnCatalogManager implements CatalogManager {
       return null;
     }
 
-    const catalogName = version.substring(this.catalogProtocol.length);
-    // Normalize both "catalog:" and "catalog:default" to the same representation
-    const isDefault = !catalogName || catalogName === 'default';
+    const catalogName = version.substring(this.catalogProtocol.length).trim();
+    // Only an empty/whitespace name selects the default catalog; "default" is
+    // a regular named catalog in bun.
+    const isDefault = !catalogName;
 
     return {
       catalogName: isDefault ? undefined : catalogName,
@@ -46,12 +52,12 @@ export class YarnCatalogManager implements CatalogManager {
   }
 
   getCatalogDefinitionFilePaths(): string[] {
-    return [YARNRC_FILENAME];
+    return [BUN_CATALOG_FILENAME];
   }
 
   getCatalogDefinitions(treeOrRoot: Tree | string): CatalogDefinitions | null {
-    return readCatalogDefinitions(
-      YARNRC_FILENAME,
+    return readBunCatalogDefinitions(
+      BUN_CATALOG_FILENAME,
       treeOrRoot,
       this.definitionsByRoot
     );
@@ -74,8 +80,7 @@ export class YarnCatalogManager implements CatalogManager {
 
     let catalogToUse: CatalogEntry | undefined;
     if (catalogRef.isDefaultCatalog) {
-      // Check both locations for default catalog
-      catalogToUse = catalogDefs.catalog ?? catalogDefs.catalogs?.default;
+      catalogToUse = catalogDefs.catalog;
     } else if (catalogRef.catalogName) {
       catalogToUse = catalogDefs.catalogs?.[catalogRef.catalogName];
     }
@@ -106,8 +111,10 @@ export class YarnCatalogManager implements CatalogManager {
     if (!catalogDefs) {
       throw new Error(
         formatCatalogError(
-          `Cannot get Yarn catalog definitions. No ${YARNRC_FILENAME} found in workspace root.`,
-          [`Create a ${YARNRC_FILENAME} file in your workspace root`]
+          `Cannot get Bun catalog definitions. No catalog defined in ${BUN_CATALOG_FILENAME}.`,
+          [
+            `Add a "catalog" or "catalogs" field to ${BUN_CATALOG_FILENAME} in your workspace root`,
+          ]
         )
       );
     }
@@ -115,22 +122,12 @@ export class YarnCatalogManager implements CatalogManager {
     let catalogToUse: CatalogEntry | undefined;
 
     if (catalogRef.isDefaultCatalog) {
-      const hasCatalog = !!catalogDefs.catalog;
-      const hasCatalogsDefault = !!catalogDefs.catalogs?.default;
-
-      // Error if both defined
-      if (hasCatalog && hasCatalogsDefault) {
-        throw new Error(
-          "The 'default' catalog was defined multiple times. Use the 'catalog' field or 'catalogs.default', but not both."
-        );
-      }
-
-      catalogToUse = catalogDefs.catalog ?? catalogDefs.catalogs?.default;
+      catalogToUse = catalogDefs.catalog;
       if (!catalogToUse) {
         const availableCatalogs = Object.keys(catalogDefs.catalogs || {});
 
         const suggestions = [
-          `Define a default catalog in ${YARNRC_FILENAME} under the "catalog" key`,
+          `Define a default catalog in ${BUN_CATALOG_FILENAME} under the "catalog" key`,
         ];
         if (availableCatalogs.length > 0) {
           suggestions.push(
@@ -142,7 +139,7 @@ export class YarnCatalogManager implements CatalogManager {
 
         throw new Error(
           formatCatalogError(
-            `No default catalog defined in ${YARNRC_FILENAME}`,
+            `No default catalog defined in ${BUN_CATALOG_FILENAME}`,
             suggestions
           )
         );
@@ -150,17 +147,10 @@ export class YarnCatalogManager implements CatalogManager {
     } else if (catalogRef.catalogName) {
       catalogToUse = catalogDefs.catalogs?.[catalogRef.catalogName];
       if (!catalogToUse) {
-        const availableCatalogs = Object.keys(
-          catalogDefs.catalogs || {}
-        ).filter((c) => c !== 'default');
-        const defaultCatalog = !!catalogDefs.catalog
-          ? 'catalog'
-          : !catalogDefs.catalogs?.default
-            ? 'catalogs.default'
-            : null;
+        const availableCatalogs = Object.keys(catalogDefs.catalogs || {});
 
         const suggestions = [
-          `Define the catalog in ${YARNRC_FILENAME} under the "catalogs" key`,
+          `Define the catalog in ${BUN_CATALOG_FILENAME} under the "catalogs" key`,
         ];
         if (availableCatalogs.length > 0) {
           suggestions.push(
@@ -169,13 +159,13 @@ export class YarnCatalogManager implements CatalogManager {
               .join(', ')}`
           );
         }
-        if (defaultCatalog) {
-          suggestions.push(`Or use the default catalog ("${defaultCatalog}")`);
+        if (catalogDefs.catalog) {
+          suggestions.push(`Or use the default catalog ("catalog:")`);
         }
 
         throw new Error(
           formatCatalogError(
-            `Catalog "${catalogRef.catalogName}" not found in ${YARNRC_FILENAME}`,
+            `Catalog "${catalogRef.catalogName}" not found in ${BUN_CATALOG_FILENAME}`,
             suggestions
           )
         );
@@ -183,20 +173,13 @@ export class YarnCatalogManager implements CatalogManager {
     }
 
     if (!catalogToUse![packageName]) {
-      let catalogName: string;
-      if (catalogRef.isDefaultCatalog) {
-        // Context-aware messaging based on which location exists
-        const hasCatalog = !!catalogDefs.catalog;
-        catalogName = hasCatalog
-          ? 'default catalog ("catalog")'
-          : 'default catalog ("catalogs.default")';
-      } else {
-        catalogName = `catalog '${catalogRef.catalogName}'`;
-      }
+      const catalogName = catalogRef.isDefaultCatalog
+        ? 'default catalog ("catalog")'
+        : `catalog '${catalogRef.catalogName}'`;
 
       const availablePackages = Object.keys(catalogToUse!);
       const suggestions = [
-        `Add "${packageName}" to ${catalogName} in ${YARNRC_FILENAME}`,
+        `Add "${packageName}" to ${catalogName} in ${BUN_CATALOG_FILENAME}`,
       ];
       if (availablePackages.length > 0) {
         suggestions.push(
@@ -223,6 +206,6 @@ export class YarnCatalogManager implements CatalogManager {
       catalogName?: string;
     }>
   ): void {
-    updateCatalogVersionsInFile(YARNRC_FILENAME, treeOrRoot, updates);
+    updateBunCatalogVersionsInFile(BUN_CATALOG_FILENAME, treeOrRoot, updates);
   }
 }

--- a/packages/nx/src/utils/catalog/index.spec.ts
+++ b/packages/nx/src/utils/catalog/index.spec.ts
@@ -2,6 +2,7 @@ import { createTreeWithEmptyWorkspace } from '../../generators/testing-utils/cre
 import type { Tree } from '../../generators/tree';
 import { writeJson } from '../../generators/utils/json';
 import { getCatalogDependenciesFromPackageJson } from './index';
+import { BunCatalogManager } from './bun-manager';
 import type { CatalogManager } from './manager';
 import { PnpmCatalogManager } from './pnpm-manager';
 import { YarnCatalogManager } from './yarn-manager';
@@ -164,6 +165,47 @@ catalogs:
             ['typescript', undefined],
             ['lodash', 'utils'],
             ['sharp', 'optional'],
+          ])
+        );
+      });
+    });
+
+    describe('with BunCatalogManager', () => {
+      let manager: CatalogManager;
+
+      beforeEach(() => {
+        manager = new BunCatalogManager();
+      });
+
+      it('should return empty map when package.json has no catalog dependencies', () => {
+        writeJson(tree, 'package.json', {
+          dependencies: { lodash: '^4.17.21' },
+        });
+
+        const result = getCatalogDependenciesFromPackageJson(
+          tree,
+          'package.json',
+          manager
+        );
+
+        expect(result).toStrictEqual(new Map());
+      });
+
+      it('should return map with catalog dependencies', () => {
+        writeJson(tree, 'package.json', {
+          dependencies: { react: 'catalog:', lodash: 'catalog:other' },
+        });
+
+        const result = getCatalogDependenciesFromPackageJson(
+          tree,
+          'package.json',
+          manager
+        );
+
+        expect(result).toStrictEqual(
+          new Map([
+            ['react', undefined],
+            ['lodash', 'other'],
           ])
         );
       });

--- a/packages/nx/src/utils/catalog/index.ts
+++ b/packages/nx/src/utils/catalog/index.ts
@@ -8,7 +8,7 @@ import { getCatalogManager } from './manager-factory';
 export { type CatalogManager, getCatalogManager };
 
 /**
- * Dereferences a pnpm/yarn catalog reference to a concrete version spec. Returns
+ * Dereferences a pnpm/yarn/bun catalog reference to a concrete version spec. Returns
  * the input unchanged when it is not a catalog reference (or no catalog manager
  * applies). Throws when the reference cannot be resolved.
  */

--- a/packages/nx/src/utils/catalog/manager-factory.ts
+++ b/packages/nx/src/utils/catalog/manager-factory.ts
@@ -1,4 +1,5 @@
 import { detectPackageManager } from '../package-manager';
+import { BunCatalogManager } from './bun-manager';
 import type { CatalogManager } from './manager';
 import { PnpmCatalogManager } from './pnpm-manager';
 import { YarnCatalogManager } from './yarn-manager';
@@ -16,6 +17,8 @@ export function getCatalogManager(
       return new PnpmCatalogManager();
     case 'yarn':
       return new YarnCatalogManager();
+    case 'bun':
+      return new BunCatalogManager();
     default:
       return null;
   }

--- a/packages/nx/src/utils/catalog/manager-utils.ts
+++ b/packages/nx/src/utils/catalog/manager-utils.ts
@@ -168,8 +168,17 @@ export function updateCatalogVersionsInFile(
     packageName: string;
     version: string;
     catalogName?: string;
-  }>
+  }>,
+  options?: {
+    /**
+     * Treat "default" as an alias for the `catalog` field and route default
+     * updates through a populated `catalogs.default` (pnpm semantics). When
+     * false, "default" is an ordinary named catalog (yarn semantics).
+     */
+    aliasDefaultCatalog?: boolean;
+  }
 ): void {
+  const aliasDefaultCatalog = options?.aliasDefaultCatalog ?? true;
   let checkExists: () => boolean;
   let readYaml: () => string;
   let writeYaml: (content: string) => void;
@@ -234,14 +243,18 @@ export function updateCatalogVersionsInFile(
     for (const update of updates) {
       const { packageName, version, catalogName } = update;
       const normalizedCatalogName =
-        catalogName === 'default' ? undefined : catalogName;
+        aliasDefaultCatalog && catalogName === 'default'
+          ? undefined
+          : catalogName;
 
       let targetPath: string[];
       if (!normalizedCatalogName) {
         // An empty `catalog:` placeholder must not claim the default route
         // when `catalogs.default` is populated; that would create a
-        // duplicate-default config rejected by pnpm.
-        if (isMapAt(doc, ['catalog'])) {
+        // duplicate-default config rejected by pnpm. Without the alias,
+        // "default" is an ordinary named catalog and the default route is
+        // always the `catalog` field.
+        if (!aliasDefaultCatalog || isMapAt(doc, ['catalog'])) {
           targetPath = ['catalog', packageName];
         } else if (existsAt(doc, ['catalogs', 'default'])) {
           targetPath = ['catalogs', 'default', packageName];

--- a/packages/nx/src/utils/catalog/manager.ts
+++ b/packages/nx/src/utils/catalog/manager.ts
@@ -1,5 +1,9 @@
 import type { Tree } from '../../generators/tree';
-import type { CatalogDefinitions, CatalogReference } from './types';
+import type {
+  CatalogDefinitions,
+  CatalogReference,
+  CatalogReferenceMatch,
+} from './types';
 
 export function formatCatalogError(
   error: string,
@@ -15,6 +19,46 @@ export function formatCatalogError(
   }
 
   return message;
+}
+
+/**
+ * Shared implementation of getCatalogReferencesForPackage: enumerates the
+ * default and named catalog references and keeps those the manager resolves,
+ * so per-manager default-catalog semantics apply without duplication.
+ */
+export function collectCatalogReferencesForPackage(
+  manager: CatalogManager,
+  treeOrRoot: Tree | string,
+  packageName: string
+): CatalogReferenceMatch[] {
+  // The overload pairs don't accept the Tree | string union directly.
+  const source = treeOrRoot as string;
+  const catalogDefs = manager.getCatalogDefinitions(source);
+  if (!catalogDefs) {
+    return [];
+  }
+
+  const catalogRefs = ['catalog:'];
+  for (const name of Object.keys(catalogDefs.catalogs ?? {})) {
+    // Skip names the manager treats as the default catalog (e.g. pnpm's
+    // "default") — already covered by the `catalog:` candidate.
+    if (!manager.parseCatalogReference(`catalog:${name}`)?.isDefaultCatalog) {
+      catalogRefs.push(`catalog:${name}`);
+    }
+  }
+
+  const matches: CatalogReferenceMatch[] = [];
+  for (const catalogRef of catalogRefs) {
+    const versionSpec = manager.resolveCatalogReference(
+      source,
+      packageName,
+      catalogRef
+    );
+    if (versionSpec) {
+      matches.push({ catalogRef, versionSpec });
+    }
+  }
+  return matches;
 }
 
 /**
@@ -48,6 +92,19 @@ export interface CatalogManager {
     packageName: string,
     version: string
   ): string | null;
+
+  /**
+   * Get every catalog reference that resolves to a version for a package,
+   * following the package manager's own default-catalog semantics.
+   */
+  getCatalogReferencesForPackage(
+    workspaceRoot: string,
+    packageName: string
+  ): CatalogReferenceMatch[];
+  getCatalogReferencesForPackage(
+    tree: Tree,
+    packageName: string
+  ): CatalogReferenceMatch[];
 
   /**
    * Check that a catalog reference is valid.

--- a/packages/nx/src/utils/catalog/pnpm-manager.spec.ts
+++ b/packages/nx/src/utils/catalog/pnpm-manager.spec.ts
@@ -229,6 +229,52 @@ catalogs:
     });
   });
 
+  describe('getCatalogReferencesForPackage', () => {
+    it('should return catalog: for a package in catalogs.default', () => {
+      // pnpm's `catalog:` also resolves from `catalogs.default`.
+      tree.write(
+        'pnpm-workspace.yaml',
+        `
+catalogs:
+  default:
+    react: ^18.0.0
+`
+      );
+
+      expect(
+        manager.getCatalogReferencesForPackage(tree, 'react')
+      ).toStrictEqual([{ catalogRef: 'catalog:', versionSpec: '^18.0.0' }]);
+    });
+
+    it('should return default and named references for a package in both', () => {
+      tree.write(
+        'pnpm-workspace.yaml',
+        `
+catalog:
+  react: ^18.0.0
+catalogs:
+  legacy:
+    react: ^17.0.0
+`
+      );
+
+      expect(
+        manager.getCatalogReferencesForPackage(tree, 'react')
+      ).toStrictEqual([
+        { catalogRef: 'catalog:', versionSpec: '^18.0.0' },
+        { catalogRef: 'catalog:legacy', versionSpec: '^17.0.0' },
+      ]);
+    });
+
+    it('should return an empty array when the package is not catalogued', () => {
+      tree.write('pnpm-workspace.yaml', `catalog:\n  react: ^18.0.0\n`);
+
+      expect(
+        manager.getCatalogReferencesForPackage(tree, 'lodash')
+      ).toStrictEqual([]);
+    });
+  });
+
   describe('validateCatalogReference', () => {
     it('should return invalid for non-catalog syntax', () => {
       expect(() =>

--- a/packages/nx/src/utils/catalog/pnpm-manager.ts
+++ b/packages/nx/src/utils/catalog/pnpm-manager.ts
@@ -1,5 +1,9 @@
 import type { Tree } from '../../generators/tree';
-import { formatCatalogError, type CatalogManager } from './manager';
+import {
+  collectCatalogReferencesForPackage,
+  formatCatalogError,
+  type CatalogManager,
+} from './manager';
 import {
   readCatalogDefinitions,
   updateCatalogVersionsInFile,
@@ -8,6 +12,7 @@ import type {
   CatalogDefinitions,
   CatalogEntry,
   CatalogReference,
+  CatalogReferenceMatch,
 } from './types';
 
 const PNPM_WORKSPACE_FILENAME = 'pnpm-workspace.yaml';
@@ -76,6 +81,13 @@ export class PnpmCatalogManager implements CatalogManager {
     }
 
     return catalogToUse?.[packageName] || null;
+  }
+
+  getCatalogReferencesForPackage(
+    treeOrRoot: Tree | string,
+    packageName: string
+  ): CatalogReferenceMatch[] {
+    return collectCatalogReferencesForPackage(this, treeOrRoot, packageName);
   }
 
   validateCatalogReference(

--- a/packages/nx/src/utils/catalog/types.ts
+++ b/packages/nx/src/utils/catalog/types.ts
@@ -3,6 +3,11 @@ export interface CatalogReference {
   isDefaultCatalog: boolean;
 }
 
+export interface CatalogReferenceMatch {
+  catalogRef: string;
+  versionSpec: string;
+}
+
 export interface CatalogEntry {
   [packageName: string]: string;
 }

--- a/packages/nx/src/utils/catalog/yarn-manager.spec.ts
+++ b/packages/nx/src/utils/catalog/yarn-manager.spec.ts
@@ -244,6 +244,36 @@ catalogs:
     });
   });
 
+  describe('getCatalogReferencesForPackage', () => {
+    it('should return default and named references for a package in both', () => {
+      tree.write(
+        '.yarnrc.yml',
+        `
+catalog:
+  react: ^18.0.0
+catalogs:
+  legacy:
+    react: ^17.0.0
+`
+      );
+
+      expect(
+        manager.getCatalogReferencesForPackage(tree, 'react')
+      ).toStrictEqual([
+        { catalogRef: 'catalog:', versionSpec: '^18.0.0' },
+        { catalogRef: 'catalog:legacy', versionSpec: '^17.0.0' },
+      ]);
+    });
+
+    it('should return an empty array when the package is not catalogued', () => {
+      tree.write('.yarnrc.yml', `catalog:\n  react: ^18.0.0\n`);
+
+      expect(
+        manager.getCatalogReferencesForPackage(tree, 'lodash')
+      ).toStrictEqual([]);
+    });
+  });
+
   describe('validateCatalogReference', () => {
     it('should throw for non-catalog syntax', () => {
       expect(() =>

--- a/packages/nx/src/utils/catalog/yarn-manager.spec.ts
+++ b/packages/nx/src/utils/catalog/yarn-manager.spec.ts
@@ -35,12 +35,14 @@ describe('YarnCatalogManager', () => {
       });
     });
 
-    it('should normalize catalog:default to default catalog reference', () => {
+    it('should treat catalog:default as a named catalog reference', () => {
+      // Unlike pnpm, yarn does not treat "default" as an alias for the
+      // `catalog` field — it is an ordinary named catalog.
       const result = manager.parseCatalogReference('catalog:default');
 
       expect(result).toStrictEqual({
-        catalogName: undefined,
-        isDefaultCatalog: true,
+        catalogName: 'default',
+        isDefaultCatalog: false,
       });
     });
 
@@ -146,7 +148,9 @@ catalog:
       expect(result).toBe('^18.0.0');
     });
 
-    it('should resolve catalog:default from top-level catalog field', () => {
+    it('should not resolve catalog:default from the catalog field', () => {
+      // "default" is an ordinary named catalog in yarn, so it does not
+      // resolve against the singular `catalog` field.
       tree.write(
         '.yarnrc.yml',
         `
@@ -161,10 +165,10 @@ catalog:
         'catalog:default'
       );
 
-      expect(result).toBe('^18.0.0');
+      expect(result).toBe(null);
     });
 
-    it('should resolve catalog: from catalogs.default field', () => {
+    it('should not resolve catalog: from the catalogs.default field', () => {
       tree.write(
         '.yarnrc.yml',
         `
@@ -176,10 +180,10 @@ catalogs:
 
       const result = manager.resolveCatalogReference(tree, 'react', 'catalog:');
 
-      expect(result).toBe('^18.0.0');
+      expect(result).toBe(null);
     });
 
-    it('should resolve catalog:default from catalogs.default field', () => {
+    it('should resolve catalog:default from the catalogs.default field', () => {
       tree.write(
         '.yarnrc.yml',
         `
@@ -245,6 +249,24 @@ catalogs:
   });
 
   describe('getCatalogReferencesForPackage', () => {
+    it('should return catalog:default for a package in catalogs.default', () => {
+      // Unlike pnpm, `catalogs.default` is an ordinary named catalog in yarn.
+      tree.write(
+        '.yarnrc.yml',
+        `
+catalogs:
+  default:
+    react: ^18.0.0
+`
+      );
+
+      expect(
+        manager.getCatalogReferencesForPackage(tree, 'react')
+      ).toStrictEqual([
+        { catalogRef: 'catalog:default', versionSpec: '^18.0.0' },
+      ]);
+    });
+
     it('should return default and named references for a package in both', () => {
       tree.write(
         '.yarnrc.yml',
@@ -291,7 +313,9 @@ catalogs:
       );
     });
 
-    it('should throw for catalog: when both definitions exist', () => {
+    it('should allow catalog and catalogs.default to coexist', () => {
+      // Unlike pnpm, yarn does not treat this as a duplicate default: the two
+      // are addressed independently via "catalog:" and "catalog:default".
       tree.write(
         '.yarnrc.yml',
         `
@@ -305,28 +329,10 @@ catalogs:
 
       expect(() =>
         manager.validateCatalogReference(tree, 'react', 'catalog:')
-      ).toThrow(
-        "The 'default' catalog was defined multiple times. Use the 'catalog' field or 'catalogs.default', but not both."
-      );
-    });
-
-    it('should throw for catalog:default when both definitions exist', () => {
-      tree.write(
-        '.yarnrc.yml',
-        `
-catalog:
-  react: ^18.0.0
-catalogs:
-  default:
-    lodash: ^4.17.21
-`
-      );
-
+      ).not.toThrow();
       expect(() =>
-        manager.validateCatalogReference(tree, 'react', 'catalog:default')
-      ).toThrow(
-        "The 'default' catalog was defined multiple times. Use the 'catalog' field or 'catalogs.default', but not both."
-      );
+        manager.validateCatalogReference(tree, 'lodash', 'catalog:default')
+      ).not.toThrow();
     });
 
     it('should throw when default catalog not found', () => {
@@ -383,7 +389,7 @@ catalog:
       ).not.toThrow();
     });
 
-    it('should validate catalog:default with top-level catalog field', () => {
+    it('should throw for catalog:default when only the catalog field exists', () => {
       tree.write(
         '.yarnrc.yml',
         `
@@ -394,10 +400,10 @@ catalog:
 
       expect(() =>
         manager.validateCatalogReference(tree, 'react', 'catalog:default')
-      ).not.toThrow();
+      ).toThrow('Catalog "default" not found in .yarnrc.yml');
     });
 
-    it('should validate catalog: with catalogs.default field', () => {
+    it('should throw for catalog: when only catalogs.default exists', () => {
       tree.write(
         '.yarnrc.yml',
         `
@@ -409,7 +415,7 @@ catalogs:
 
       expect(() =>
         manager.validateCatalogReference(tree, 'react', 'catalog:')
-      ).not.toThrow();
+      ).toThrow('No default catalog defined in .yarnrc.yml');
     });
 
     it('should validate catalog:default with catalogs.default field', () => {
@@ -449,7 +455,9 @@ catalog:
       expect(result.catalog.lodash).toBe('^4.17.21');
     });
 
-    it('should update existing catalogs.default field', () => {
+    it('should update a catalogs.default entry via its literal name', () => {
+      // `catalogs.default` is an ordinary named catalog in yarn, addressed by
+      // catalogName "default" — a default (unnamed) update goes to `catalog`.
       tree.write(
         '.yarnrc.yml',
         `
@@ -461,7 +469,7 @@ catalogs:
       );
 
       manager.updateCatalogVersions(tree, [
-        { packageName: 'react', version: '^18.3.0' },
+        { packageName: 'react', version: '^18.3.0', catalogName: 'default' },
       ]);
 
       const content = tree.read('.yarnrc.yml', 'utf-8');
@@ -606,11 +614,10 @@ catalog:
       expect(result.catalogs.legacy.react).toBe('^17.0.2');
     });
 
-    it('should write through catalogs.default when catalog is an empty placeholder', () => {
-      // Regression: with both keys present and `catalog:` as a null
-      // placeholder, the update must go to the populated catalogs.default
-      // and not seed a new top-level `catalog`, which would produce a
-      // duplicate-default config rejected by validateCatalogReference.
+    it('should route a default update to catalog even when catalogs.default exists', () => {
+      // The default catalog is only the `catalog` field in yarn, so an
+      // unnamed update must not be redirected into the `catalogs.default`
+      // named catalog.
       tree.write(
         '.yarnrc.yml',
         `catalog:
@@ -626,30 +633,8 @@ catalogs:
 
       const content = tree.read('.yarnrc.yml', 'utf-8');
       const result = load(content);
-      expect(result.catalogs.default.react).toBe('^18.3.0');
-      // The empty `catalog:` placeholder should remain empty, not be
-      // populated with a duplicate entry.
-      expect(result.catalog).toBeNull();
-    });
-
-    it('should handle an empty catalogs.default block', () => {
-      tree.write(
-        '.yarnrc.yml',
-        `catalogs:
-  default:
-`
-      );
-
-      manager.updateCatalogVersions(tree, [
-        { packageName: 'react', version: '^18.3.0' },
-      ]);
-
-      const content = tree.read('.yarnrc.yml', 'utf-8');
-      const result = load(content);
-      // Should write through the existing catalogs.default skeleton rather
-      // than creating a new shorthand `catalog:` key.
-      expect(result.catalogs.default.react).toBe('^18.3.0');
-      expect(result.catalog).toBeUndefined();
+      expect(result.catalog.react).toBe('^18.3.0');
+      expect(result.catalogs.default.react).toBe('^18.0.0');
     });
 
     it('should update through a YAML alias pointing at an anchored map', () => {
@@ -706,10 +691,8 @@ catalogs:
     });
 
     it('should update through an alias on the catalogs key itself', () => {
-      // Regression: when `catalogs:` is itself an alias to an anchored map
-      // containing `default`, the router must follow the alias to find the
-      // existing default rather than fall through and create a duplicate
-      // top-level `catalog`.
+      // When `catalogs:` is itself an alias to an anchored map, a named
+      // update must follow the alias to the existing entry.
       tree.write(
         '.yarnrc.yml',
         `_cats: &cats
@@ -720,7 +703,7 @@ catalogs: *cats
       );
 
       manager.updateCatalogVersions(tree, [
-        { packageName: 'react', version: '^18.3.0' },
+        { packageName: 'react', version: '^18.3.0', catalogName: 'default' },
       ]);
 
       const content = tree.read('.yarnrc.yml', 'utf-8');

--- a/packages/nx/src/utils/catalog/yarn-manager.ts
+++ b/packages/nx/src/utils/catalog/yarn-manager.ts
@@ -18,7 +18,10 @@ import type {
 const YARNRC_FILENAME = '.yarnrc.yml';
 
 /**
- * Yarn Berry (v4+) catalog manager implementation
+ * Yarn Berry (v4.10+) catalog manager implementation.
+ *
+ * Unlike pnpm, the name "default" is not special: `catalog:` resolves only
+ * against `catalog`, and `catalog:default` against `catalogs.default`.
  */
 export class YarnCatalogManager implements CatalogManager {
   readonly name = 'yarn';
@@ -36,8 +39,9 @@ export class YarnCatalogManager implements CatalogManager {
     }
 
     const catalogName = version.substring(this.catalogProtocol.length);
-    // Normalize both "catalog:" and "catalog:default" to the same representation
-    const isDefault = !catalogName || catalogName === 'default';
+    // Only an empty name selects the default catalog; unlike pnpm, "default"
+    // is a regular named catalog in yarn.
+    const isDefault = !catalogName;
 
     return {
       catalogName: isDefault ? undefined : catalogName,
@@ -74,8 +78,7 @@ export class YarnCatalogManager implements CatalogManager {
 
     let catalogToUse: CatalogEntry | undefined;
     if (catalogRef.isDefaultCatalog) {
-      // Check both locations for default catalog
-      catalogToUse = catalogDefs.catalog ?? catalogDefs.catalogs?.default;
+      catalogToUse = catalogDefs.catalog;
     } else if (catalogRef.catalogName) {
       catalogToUse = catalogDefs.catalogs?.[catalogRef.catalogName];
     }
@@ -115,17 +118,9 @@ export class YarnCatalogManager implements CatalogManager {
     let catalogToUse: CatalogEntry | undefined;
 
     if (catalogRef.isDefaultCatalog) {
-      const hasCatalog = !!catalogDefs.catalog;
-      const hasCatalogsDefault = !!catalogDefs.catalogs?.default;
-
-      // Error if both defined
-      if (hasCatalog && hasCatalogsDefault) {
-        throw new Error(
-          "The 'default' catalog was defined multiple times. Use the 'catalog' field or 'catalogs.default', but not both."
-        );
-      }
-
-      catalogToUse = catalogDefs.catalog ?? catalogDefs.catalogs?.default;
+      // Yarn's default catalog is only the `catalog` field; unlike pnpm,
+      // `catalogs.default` does not act as a fallback.
+      catalogToUse = catalogDefs.catalog;
       if (!catalogToUse) {
         const availableCatalogs = Object.keys(catalogDefs.catalogs || {});
 
@@ -150,14 +145,7 @@ export class YarnCatalogManager implements CatalogManager {
     } else if (catalogRef.catalogName) {
       catalogToUse = catalogDefs.catalogs?.[catalogRef.catalogName];
       if (!catalogToUse) {
-        const availableCatalogs = Object.keys(
-          catalogDefs.catalogs || {}
-        ).filter((c) => c !== 'default');
-        const defaultCatalog = !!catalogDefs.catalog
-          ? 'catalog'
-          : !catalogDefs.catalogs?.default
-            ? 'catalogs.default'
-            : null;
+        const availableCatalogs = Object.keys(catalogDefs.catalogs || {});
 
         const suggestions = [
           `Define the catalog in ${YARNRC_FILENAME} under the "catalogs" key`,
@@ -169,8 +157,8 @@ export class YarnCatalogManager implements CatalogManager {
               .join(', ')}`
           );
         }
-        if (defaultCatalog) {
-          suggestions.push(`Or use the default catalog ("${defaultCatalog}")`);
+        if (catalogDefs.catalog) {
+          suggestions.push(`Or use the default catalog ("catalog:")`);
         }
 
         throw new Error(
@@ -183,16 +171,9 @@ export class YarnCatalogManager implements CatalogManager {
     }
 
     if (!catalogToUse![packageName]) {
-      let catalogName: string;
-      if (catalogRef.isDefaultCatalog) {
-        // Context-aware messaging based on which location exists
-        const hasCatalog = !!catalogDefs.catalog;
-        catalogName = hasCatalog
-          ? 'default catalog ("catalog")'
-          : 'default catalog ("catalogs.default")';
-      } else {
-        catalogName = `catalog '${catalogRef.catalogName}'`;
-      }
+      const catalogName = catalogRef.isDefaultCatalog
+        ? 'default catalog ("catalog")'
+        : `catalog '${catalogRef.catalogName}'`;
 
       const availablePackages = Object.keys(catalogToUse!);
       const suggestions = [
@@ -223,6 +204,8 @@ export class YarnCatalogManager implements CatalogManager {
       catalogName?: string;
     }>
   ): void {
-    updateCatalogVersionsInFile(YARNRC_FILENAME, treeOrRoot, updates);
+    updateCatalogVersionsInFile(YARNRC_FILENAME, treeOrRoot, updates, {
+      aliasDefaultCatalog: false,
+    });
   }
 }


### PR DESCRIPTION
## Current Behavior

Bun supports dependency catalogs: the root `package.json` carries a `catalog` field (the default catalog) and/or a `catalogs` field (named catalogs), and dependencies reference them with the `catalog:` / `catalog:<name>` protocol. From bun 1.2.14 the fields are read from the object form of `workspaces`; from 1.2.19 they may also live at the top level of `package.json`.

Nx resolves `catalog:` references through per-package-manager catalog managers (pnpm and yarn exist today), but `getCatalogManager` returns `null` for bun. As a result, `getDependencyVersionFromPackageJson` returns the raw unresolved `"catalog:"` string in bun workspaces, and generators that feed that into `semver.coerce(...).version` without a null guard crash:

```
TypeError: Cannot read properties of null (reading 'version')
```

e.g. `@nx/vitest` `getInstalledViteVersion` and `@nx/react` `getInstalledReactVersion` crash when `vite` / `react` are catalogued in a bun workspace, so generators like `@nx/vitest:configuration` fail outright.

Additionally, the `dependency-checks` lint rule and the yarn catalog manager hardcode pnpm's rule that `"default"` aliases the `catalog` field. Verified against the real binaries, that rule holds only for pnpm — yarn berry (>= 4.10) and bun both treat `catalog` and `catalogs.default` as separate catalogs.

## Expected Behavior

- `getCatalogManager` returns a `BunCatalogManager` for bun workspaces, which reads/writes catalogs from the root `package.json`. Catalog references now resolve to their declared ranges in generators, migrations, release versioning, lockfile pruning, and lint dependency checks — matching the existing pnpm/yarn behavior. This alone fixes the `@nx/vitest` / `@nx/react` crashes, since the resolved range reaches semver instead of the raw `"catalog:"` string; no changes to those packages are needed.
- The bun JSON-based helpers live in a dedicated `bun-manager-utils.ts`, keeping `manager-utils.ts` scoped to the YAML-based pnpm/yarn logic.
- The manager follows bun's actual resolution semantics, verified empirically against bun 1.3.14 (they differ from pnpm in two ways):
  - **Locations are all-or-nothing:** when either catalog field exists nested inside the object form of `workspaces`, bun ignores the top-level fields entirely (no merging across locations). The manager reads, and routes updates to, whichever location is active.
  - **"default" is not special:** `catalog:` resolves only against the singular `catalog` field, and `catalog:default` addresses a named catalog literally called `default` (bun fails to resolve `catalog:` from `catalogs.default` and vice versa). Whitespace-only names (e.g. `catalog:  `) are treated as the default catalog.
- Catalog updates preserve the user's `package.json` formatting (surgical edits via `jsonc-parser`), tolerate null placeholders, and are no-ops when the version already matches.
- Default-catalog candidate selection in the `dependency-checks` lint rule moves behind the `CatalogManager` interface via a new `getCatalogReferencesForPackage` method, so `nx lint --fix` emits specifiers the workspace's package manager actually accepts (e.g. `catalog:default` rather than `catalog:` for a bun `catalogs.default` entry).
- A follow-up commit aligns the yarn manager with yarn berry's real semantics (same separate-catalogs rule as bun), removing its pnpm-style `"default"` aliasing; `updateCatalogVersionsInFile` gains an `aliasDefaultCatalog` option so pnpm keeps its behavior unchanged.
- `nx release` no longer logs the hardcoded `pnpm-workspace.yaml` filename for catalog updates; it derives the file from the active catalog manager.

Covered by new unit tests for the bun manager (reference parsing, default/named/`workspaces`-nested resolution, location precedence, validation, updates including null-placeholder edge cases), `getCatalogReferencesForPackage` tests for all three managers, `dependency-checks` bun fixtures, updated yarn manager tests asserting yarn's separate-catalogs semantics, catalog-dependency detection tests, and devkit `getDependencyVersionFromPackageJson` bun tests. Existing pnpm catalog suites pass unchanged. Also verified end-to-end in a real bun workspace: with published nx, `nx g @nx/vitest:configuration` reproduces the crash; with this branch's catalog module in place, the generator succeeds and the catalogued `vite` version resolves correctly for both definition locations.

## Related Issue(s)
