### PR TITLE
chore(repo): harden first-party migration validators

### DIFF
--- a/nx.json
+++ b/nx.json
@@ -482,6 +482,9 @@
         }
       },
       {
+        "rule": "./tools/workspace-plugin/dist/src/conformance-rules/nx-package-group"
+      },
+      {
         "rule": "./tools/workspace-plugin/dist/src/conformance-rules/no-ignored-tracked-files"
       },
       {

--- a/packages/docker/migrations.spec.ts
+++ b/packages/docker/migrations.spec.ts
@@ -1,0 +1,8 @@
+import json = require('./migrations.json');
+
+import { assertValidMigrationPaths } from '@nx/devkit/internal-testing-utils';
+import { MigrationsJson } from '@nx/devkit';
+
+describe('docker migrations', () => {
+  assertValidMigrationPaths(json as MigrationsJson, __dirname);
+});

--- a/packages/dotnet/migrations.spec.ts
+++ b/packages/dotnet/migrations.spec.ts
@@ -1,0 +1,8 @@
+import json = require('./migrations.json');
+
+import { assertValidMigrationPaths } from '@nx/devkit/internal-testing-utils';
+import { MigrationsJson } from '@nx/devkit';
+
+describe('dotnet migrations', () => {
+  assertValidMigrationPaths(json as MigrationsJson, __dirname);
+});

--- a/packages/eslint-plugin/src/rules/nx-plugin-checks.spec.ts
+++ b/packages/eslint-plugin/src/rules/nx-plugin-checks.spec.ts
@@ -1,6 +1,10 @@
 import 'nx/src/internal-testing-utils/mock-fs';
 import { vol } from 'memfs';
-import { checkIfIdentifierIsFunction } from './nx-plugin-checks';
+import { parseForESLint } from 'jsonc-eslint-parser';
+import {
+  checkIfIdentifierIsFunction,
+  validateNoDuplicateKeys,
+} from './nx-plugin-checks';
 
 jest.mock('@nx/devkit', () => ({
   ...jest.requireActual<any>('@nx/devkit'),
@@ -114,5 +118,94 @@ describe('checkIfIdentifierIsFunction', () => {
 
     const result = checkIfIdentifierIsFunction(filePath, 'myGenerator');
     expect(result).toBe(false);
+  });
+});
+
+describe('validateNoDuplicateKeys', () => {
+  function collectReports(json: string): { messageId: string; key: string }[] {
+    const rootNode = (parseForESLint(json).ast.body[0] as any).expression;
+    const reports: any[] = [];
+    const context = { report: (r: any) => reports.push(r) } as any;
+    validateNoDuplicateKeys(rootNode, context);
+    return reports.map((r) => ({ messageId: r.messageId, key: r.data.key }));
+  }
+
+  it('should report a duplicated entry key', () => {
+    const reports = collectReports(`{
+      "generators": {
+        "update-1-0-0-foo": { "version": "1.0.0-beta.1" },
+        "update-1-0-0-foo": { "version": "1.0.0-beta.2" }
+      }
+    }`);
+
+    expect(reports).toEqual([
+      { messageId: 'duplicateKey', key: 'update-1-0-0-foo' },
+    ]);
+  });
+
+  it('should report a duplicated top-level section key', () => {
+    const reports = collectReports(`{
+      "generators": {},
+      "generators": {}
+    }`);
+
+    expect(reports).toEqual([{ messageId: 'duplicateKey', key: 'generators' }]);
+  });
+
+  it('should report duplicated keys in nested objects', () => {
+    const reports = collectReports(`{
+      "packageJsonUpdates": {
+        "1.0.0": {
+          "version": "1.0.0-beta.1",
+          "packages": {
+            "@acme/foo": { "version": "2.0.0" },
+            "@acme/foo": { "version": "3.0.0" }
+          }
+        }
+      }
+    }`);
+
+    expect(reports).toEqual([{ messageId: 'duplicateKey', key: '@acme/foo' }]);
+  });
+
+  it('should report duplicated keys inside objects nested in arrays', () => {
+    const reports = collectReports(`{
+      "nx-migrations": {
+        "packageGroup": [
+          { "package": "@acme/foo", "version": "*", "version": "latest" }
+        ]
+      }
+    }`);
+
+    expect(reports).toEqual([{ messageId: 'duplicateKey', key: 'version' }]);
+  });
+
+  it('should not report the same key name in sibling objects', () => {
+    const reports = collectReports(`{
+      "generators": {
+        "update-1-0-0-foo": { "version": "1.0.0-beta.1" },
+        "update-1-0-0-bar": { "version": "1.0.0-beta.1" }
+      },
+      "schematics": {
+        "update-1-0-0-foo": { "version": "1.0.0-beta.1" }
+      }
+    }`);
+
+    expect(reports).toEqual([]);
+  });
+
+  it('should report each extra occurrence of a key', () => {
+    const reports = collectReports(`{
+      "executors": {
+        "build": { "schema": "./a.json" },
+        "build": { "schema": "./b.json" },
+        "build": { "schema": "./c.json" }
+      }
+    }`);
+
+    expect(reports).toEqual([
+      { messageId: 'duplicateKey', key: 'build' },
+      { messageId: 'duplicateKey', key: 'build' },
+    ]);
   });
 });

--- a/packages/eslint-plugin/src/rules/nx-plugin-checks.ts
+++ b/packages/eslint-plugin/src/rules/nx-plugin-checks.ts
@@ -59,7 +59,8 @@ export type MessageIds =
   | 'missingVersion'
   | 'noGeneratorsOrSchematicsFound'
   | 'noExecutorsOrBuildersFound'
-  | 'valueShouldBeObject';
+  | 'valueShouldBeObject'
+  | 'duplicateKey';
 
 export const RULE_NAME = 'nx-plugin-checks';
 
@@ -128,6 +129,8 @@ export default ESLintUtils.RuleCreator(() => ``)<Options, MessageIds>({
         '{{ key }}: Missing required property - `implementation`',
       invalidPromptPath: '{{ key }}: Prompt path should point to a valid file',
       missingVersion: '{{ key }}: Missing required property - `version`',
+      duplicateKey:
+        '{{ key }}: Duplicate key. JSON parsers keep only the last occurrence, silently dropping the earlier one',
     },
   },
   defaultOptions: [DEFAULT_OPTIONS],
@@ -175,6 +178,7 @@ export default ESLintUtils.RuleCreator(() => ``)<Options, MessageIds>({
       ['JSONExpressionStatement > JSONObjectExpression'](
         node: AST.JSONObjectExpression
       ) {
+        validateNoDuplicateKeys(node, context);
         if (sourceFilePath === generatorsJson) {
           checkCollectionFileNode(node, 'generator', context, projects);
         } else if (sourceFilePath === migrationsJson) {
@@ -582,6 +586,51 @@ export function validatePackageGroup(
             node: propertyNode.value as any,
           });
         }
+      }
+    }
+  }
+}
+
+/**
+ * A duplicate key anywhere in these manifests silently drops data:
+ * JSON parsers keep only the last occurrence, so a duplicated generator,
+ * executor, or migration entry key discards the earlier definition with no
+ * error at runtime.
+ */
+export function validateNoDuplicateKeys(
+  node: AST.JSONObjectExpression | AST.JSONArrayExpression,
+  context: TSESLint.RuleContext<MessageIds, Options>
+): void {
+  if (node.type === 'JSONObjectExpression') {
+    const seen = new Set<string>();
+    for (const property of node.properties) {
+      const key =
+        property.key.type === 'JSONLiteral'
+          ? String(property.key.value)
+          : property.key.name;
+      if (seen.has(key)) {
+        context.report({
+          messageId: 'duplicateKey',
+          data: { key },
+          node: property.key as any,
+        });
+      }
+      seen.add(key);
+      if (
+        property.value.type === 'JSONObjectExpression' ||
+        property.value.type === 'JSONArrayExpression'
+      ) {
+        validateNoDuplicateKeys(property.value, context);
+      }
+    }
+  } else {
+    for (const element of node.elements) {
+      if (
+        element &&
+        (element.type === 'JSONObjectExpression' ||
+          element.type === 'JSONArrayExpression')
+      ) {
+        validateNoDuplicateKeys(element, context);
       }
     }
   }

--- a/packages/maven/migrations.spec.ts
+++ b/packages/maven/migrations.spec.ts
@@ -1,0 +1,8 @@
+import json = require('./migrations.json');
+
+import { assertValidMigrationPaths } from '@nx/devkit/internal-testing-utils';
+import { MigrationsJson } from '@nx/devkit';
+
+describe('maven migrations', () => {
+  assertValidMigrationPaths(json as MigrationsJson, __dirname);
+});

--- a/packages/module-federation/migrations.spec.ts
+++ b/packages/module-federation/migrations.spec.ts
@@ -1,0 +1,8 @@
+import json = require('./migrations.json');
+
+import { assertValidMigrationPaths } from '@nx/devkit/internal-testing-utils';
+import { MigrationsJson } from '@nx/devkit';
+
+describe('module-federation migrations', () => {
+  assertValidMigrationPaths(json as MigrationsJson, __dirname);
+});

--- a/packages/nx/src/internal-testing-utils/assert-valid-migrations.ts
+++ b/packages/nx/src/internal-testing-utils/assert-valid-migrations.ts
@@ -47,7 +47,11 @@ export function assertValidMigrationPaths(json: MigrationsJson, root: string) {
     for (const m of Object.values(entries)) {
       const impl = m.factory ?? m.implementation;
       if (impl) {
-        referenced.add(normalizeMigrationImplPath(impl));
+        referenced.add(
+          normalizeMigrationImplPath(
+            toSourcePath(root, impl.split('#')[0], '.ts')
+          )
+        );
       }
     }
 
@@ -65,7 +69,7 @@ function validateMigration(m: MigrationsJsonEntry, root: string) {
     let [implPath, implMember] = impl.includes('#')
       ? impl.split('#')
       : [impl, null];
-    implPath = implPath.replace(/dist\//, '');
+    implPath = toSourcePath(root, implPath, '.ts');
     let implModule;
     expect(() => {
       implModule = require(path.join(root, `${implPath}.ts`));
@@ -75,21 +79,37 @@ function validateMigration(m: MigrationsJsonEntry, root: string) {
     }
   }
   if (m.prompt) {
-    // migrations.json is the published shape — prompt paths point at the
-    // built `./dist/src/.../foo.md`. The spec runs against the source tree,
-    // so map the published path back to its source location.
-    const promptSourcePath = m.prompt.replace(/^\.?\/?dist\//, '');
+    const promptSourcePath = toSourcePath(root, m.prompt, '');
     expect(fs.existsSync(path.join(root, promptSourcePath))).toBe(true);
   }
   if (m.documentation) {
-    // Same published-shape mapping as `prompt`: documentation paths point at
-    // the built `./dist/src/.../foo.md`, so map back to the source tree.
-    const documentationSourcePath = m.documentation.replace(
-      /^\.?\/?dist\//,
-      ''
-    );
+    const documentationSourcePath = toSourcePath(root, m.documentation, '');
     expect(fs.existsSync(path.join(root, documentationSourcePath))).toBe(true);
   }
+}
+
+/**
+ * migrations.json carries published paths. The spec runs against the source
+ * tree, so map them back: strip `dist/` (`./dist/src/...` -> `src/...`), and
+ * for rootDir:"src" packages whose build strips the `src/` segment
+ * (`./dist/migrations/...` with sources under `src/migrations/...`),
+ * re-prefix `src/` when the direct mapping does not resolve. Unresolvable
+ * paths return the direct mapping so the caller's assertion reports it.
+ */
+function toSourcePath(
+  root: string,
+  publishedPath: string,
+  ext: string
+): string {
+  const stripped = publishedPath.replace(/^\.?\/?/, '').replace(/^dist\//, '');
+  if (fs.existsSync(path.join(root, `${stripped}${ext}`))) {
+    return stripped;
+  }
+  const srcPrefixed = `src/${stripped}`;
+  if (fs.existsSync(path.join(root, `${srcPrefixed}${ext}`))) {
+    return srcPrefixed;
+  }
+  return stripped;
 }
 
 /**

--- a/packages/playwright/migrations.spec.ts
+++ b/packages/playwright/migrations.spec.ts
@@ -1,0 +1,8 @@
+import json = require('./migrations.json');
+
+import { assertValidMigrationPaths } from '@nx/devkit/internal-testing-utils';
+import { MigrationsJson } from '@nx/devkit';
+
+describe('playwright migrations', () => {
+  assertValidMigrationPaths(json as MigrationsJson, __dirname);
+});

--- a/packages/playwright/tsconfig.lib.json
+++ b/packages/playwright/tsconfig.lib.json
@@ -16,8 +16,8 @@
     "node_modules",
     "dist",
     "jest.config.cts",
-    "src/**/*.spec.ts",
-    "src/**/*.test.ts",
+    "**/*.spec.ts",
+    "**/*.test.ts",
     ".eslintrc.json"
   ],
   "references": [

--- a/packages/plugin/migrations.spec.ts
+++ b/packages/plugin/migrations.spec.ts
@@ -1,0 +1,8 @@
+import json = require('./migrations.json');
+
+import { assertValidMigrationPaths } from '@nx/devkit/internal-testing-utils';
+import { MigrationsJson } from '@nx/devkit';
+
+describe('plugin migrations', () => {
+  assertValidMigrationPaths(json as MigrationsJson, __dirname);
+});

--- a/packages/remix/migrations.spec.ts
+++ b/packages/remix/migrations.spec.ts
@@ -1,0 +1,8 @@
+import json = require('./migrations.json');
+
+import { assertValidMigrationPaths } from '@nx/devkit/internal-testing-utils';
+import { MigrationsJson } from '@nx/devkit';
+
+describe('remix migrations', () => {
+  assertValidMigrationPaths(json as MigrationsJson, __dirname);
+});

--- a/packages/rsbuild/migrations.spec.ts
+++ b/packages/rsbuild/migrations.spec.ts
@@ -1,0 +1,8 @@
+import json = require('./migrations.json');
+
+import { assertValidMigrationPaths } from '@nx/devkit/internal-testing-utils';
+import { MigrationsJson } from '@nx/devkit';
+
+describe('rsbuild migrations', () => {
+  assertValidMigrationPaths(json as MigrationsJson, __dirname);
+});

--- a/packages/vue/migrations.spec.ts
+++ b/packages/vue/migrations.spec.ts
@@ -1,0 +1,8 @@
+import json = require('./migrations.json');
+
+import { assertValidMigrationPaths } from '@nx/devkit/internal-testing-utils';
+import { MigrationsJson } from '@nx/devkit';
+
+describe('vue migrations', () => {
+  assertValidMigrationPaths(json as MigrationsJson, __dirname);
+});

--- a/tools/workspace-plugin/src/conformance-rules/nx-package-group/index.spec.ts
+++ b/tools/workspace-plugin/src/conformance-rules/nx-package-group/index.spec.ts
@@ -1,0 +1,73 @@
+import { validatePackageGroupMembership } from './index';
+
+describe('nx-package-group', () => {
+  describe('validatePackageGroupMembership()', () => {
+    const nxPackageJsonPath = '/root/packages/nx/package.json';
+    const packageGroup = new Set(['@nx/foo', '@nx/bar']);
+
+    it('should not report a package listed in the group', () => {
+      const violations = validatePackageGroupMembership(
+        { name: '@nx/foo' },
+        'foo',
+        nxPackageJsonPath,
+        packageGroup
+      );
+
+      expect(violations).toHaveLength(0);
+    });
+
+    it('should not report private packages', () => {
+      const violations = validatePackageGroupMembership(
+        { name: '@nx/internal-tool', private: true },
+        'internal-tool',
+        nxPackageJsonPath,
+        packageGroup
+      );
+
+      expect(violations).toHaveLength(0);
+    });
+
+    it('should not report packages outside the @nx scope', () => {
+      for (const name of ['nx', 'create-nx-plugin', 'create-nx-workspace']) {
+        const violations = validatePackageGroupMembership(
+          { name },
+          name,
+          nxPackageJsonPath,
+          packageGroup
+        );
+
+        expect(violations).toHaveLength(0);
+      }
+    });
+
+    it('should not report packages without a name', () => {
+      const violations = validatePackageGroupMembership(
+        {},
+        'unnamed',
+        nxPackageJsonPath,
+        packageGroup
+      );
+
+      expect(violations).toHaveLength(0);
+    });
+
+    it('should report a published @nx/* package missing from the group', () => {
+      const violations = validatePackageGroupMembership(
+        { name: '@nx/baz' },
+        'baz',
+        nxPackageJsonPath,
+        packageGroup
+      );
+
+      expect(violations).toMatchInlineSnapshot(`
+        [
+          {
+            "file": "/root/packages/nx/package.json",
+            "message": "@nx/baz is missing from the "nx-migrations".packageGroup in packages/nx/package.json, so "nx migrate" will not update it together with the other Nx packages. Add it to the group.",
+            "sourceProject": "baz",
+          },
+        ]
+      `);
+    });
+  });
+});

--- a/tools/workspace-plugin/src/conformance-rules/nx-package-group/index.ts
+++ b/tools/workspace-plugin/src/conformance-rules/nx-package-group/index.ts
@@ -1,0 +1,81 @@
+import {
+  createConformanceRule,
+  type ConformanceViolation,
+} from '@nx/conformance';
+import { readJsonFile, workspaceRoot } from '@nx/devkit';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+
+export default createConformanceRule({
+  name: 'nx-package-group',
+  category: 'consistency',
+  description:
+    'Ensures every published @nx/* plugin is listed in the nx package group so that "nx migrate" bumps it together with nx',
+  implementation: async ({ projectGraph }) => {
+    const nxPackageJsonPath = join(workspaceRoot, 'packages/nx/package.json');
+    const nxPackageJson = readJsonFile(nxPackageJsonPath);
+    const packageGroup = new Set<string>(
+      (nxPackageJson['nx-migrations']?.packageGroup ?? []).map(
+        (entry: string | { package: string }) =>
+          typeof entry === 'string' ? entry : entry.package
+      )
+    );
+
+    const violations: ConformanceViolation[] = [];
+    for (const project of Object.values(projectGraph.nodes)) {
+      // Plugins live directly at packages/<name>. Deeper roots (the native
+      // platform packages under packages/nx/native-packages) are published
+      // under @nx/* but are versioned by nx itself, not by "nx migrate".
+      if (!/^packages\/[^/]+$/.test(project.data.root)) {
+        continue;
+      }
+      const packageJsonPath = join(
+        workspaceRoot,
+        project.data.root,
+        'package.json'
+      );
+      if (!existsSync(packageJsonPath)) {
+        continue;
+      }
+      violations.push(
+        ...validatePackageGroupMembership(
+          readJsonFile(packageJsonPath),
+          project.name,
+          nxPackageJsonPath,
+          packageGroup
+        )
+      );
+    }
+
+    return {
+      severity: 'high',
+      details: {
+        violations,
+      },
+    };
+  },
+});
+
+export function validatePackageGroupMembership(
+  packageJson: { name?: string; private?: boolean },
+  sourceProject: string,
+  nxPackageJsonPath: string,
+  packageGroup: Set<string>
+): ConformanceViolation[] {
+  if (packageJson.private) {
+    return [];
+  }
+  if (!packageJson.name?.startsWith('@nx/')) {
+    return [];
+  }
+  if (packageGroup.has(packageJson.name)) {
+    return [];
+  }
+  return [
+    {
+      sourceProject,
+      file: nxPackageJsonPath,
+      message: `${packageJson.name} is missing from the "nx-migrations".packageGroup in packages/nx/package.json, so "nx migrate" will not update it together with the other Nx packages. Add it to the group.`,
+    },
+  ];
+}

--- a/tools/workspace-plugin/src/conformance-rules/nx-package-group/schema.json
+++ b/tools/workspace-plugin/src/conformance-rules/nx-package-group/schema.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "type": "object",
+  "properties": {},
+  "additionalProperties": false
+}


### PR DESCRIPTION
## Current Behavior

Migration manifests get little static validation:

- `assertValidMigrationPaths` cannot resolve paths for packages built with rootDir "src" (maven, dotnet), and 9 plugins that ship a migrations.json (docker, dotnet, maven, module-federation, playwright, plugin, remix, rsbuild, vue) have no root `migrations.spec.ts` at all, so a wrong implementation, prompt, or documentation path ships unnoticed.
- A duplicated key in generators.json, executors.json, migrations.json, or package.json parses cleanly and silently drops the earlier entry (JSON parsers keep only the last occurrence). Nothing flags it, and for migrations.json that means a silently dropped migration.
- Nothing checks that published `@nx/*` plugins are listed in the `"nx-migrations".packageGroup` of the `nx` package, so a new plugin can be silently left behind by `nx migrate`.

## Expected Behavior

- `assertValidMigrationPaths` maps published paths back to the source tree for both build layouts, and every plugin with a migrations.json runs it through a root `migrations.spec.ts`.
- `@nx/nx-plugin-checks` reports duplicate keys in the manifest files it validates, including nested objects and arrays. The whole repo currently has zero duplicates, so this lands green.
- An `nx-package-group` conformance rule enforces packageGroup completeness for non-private `@nx/*` packages under `packages/`. Native platform packages are excluded since nx itself pins their versions.

## Related Issue(s)

Fixes NXC-4711

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/nxc-4618-98faa68a)
<!-- polygraph-session-end -->