### PR TITLE
chore(repo): fix migrations.json entry template in gradle bump skill

### DIFF
--- a/.claude/skills/nx-gradle-plugin-version-bump/SKILL.md
+++ b/.claude/skills/nx-gradle-plugin-version-bump/SKILL.md
@@ -123,13 +123,13 @@ Add a new entry at the end of the `generators` object (before the closing `}`), 
 ```json
 "change-plugin-version-NEW_VERSION": {
   "version": "NX_MIGRATION_VERSION",
-  "cli": "nx",
   "description": "Change dev.nx.gradle.project-graph to version NEW_VERSION in build file",
-  "factory": "./src/migrations/MIGRATION_FOLDER/change-plugin-version-NEW_VERSION"
+  "implementation": "./dist/src/migrations/MIGRATION_FOLDER/change-plugin-version-NEW_VERSION",
+  "documentation": "./dist/src/migrations/MIGRATION_FOLDER/change-plugin-version-NEW_VERSION.md"
 }
 ```
 
-The migration key uses the version with hyphens replacing dots (e.g., `0-1-16`).
+The migration key uses the version with hyphens replacing dots (e.g., `0-1-16`). The paths are dist-prefixed because the published package ships only `dist/`, and `documentation` is how the entry references the step-4 file. Older entries also carry `cli: "nx"` (deprecated in the migrations schema) and the `factory` alias for `implementation`; the template uses the primary key and omits `cli`. For the general entry shape see the [author-migration](../author-migration/SKILL.md) skill.
 
 ## Verification
 


### PR DESCRIPTION
## Current Behavior

The nx-gradle-plugin-version-bump skill's step-5 template emits a source-shaped `factory` path (`./src/migrations/...`) that does not resolve in the published package (only `dist/` ships), the deprecated `cli` key, and no `documentation` key for the .md file the skill authors in step 4. Recent bump PRs avoided this only because authors copy the previous live entry instead of the template.

## Expected Behavior

The template matches the shipped entries: dist-prefixed `implementation` and `documentation` keys and no `cli`, with a note explaining the dist prefix and pointing at the author-migration skill for the general entry shape.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/nxc-4618-98faa68a)
<!-- polygraph-session-end -->