### PR TITLE
fix(core): keep nx migrate on the requested version when release-age gates interfere

### DIFF
--- a/packages/nx/src/command-line/migrate/migrate.spec.ts
+++ b/packages/nx/src/command-line/migrate/migrate.spec.ts
@@ -3631,6 +3631,44 @@ describe('Migration', () => {
       const fetch = createFetcher({} as any);
       await expect(fetch('mypackage', 'latest')).rejects.toBe(err);
     });
+
+    it('the fetcher rejects when an exact requested version comes back as a different version', async () => {
+      // A config surface (registry proxy, override, cooldown gate) silently
+      // substituting another version must fail the run, not corrupt the plan.
+      jest
+        .spyOn(packageMgrUtils, 'resolvePackageVersionUsingRegistry')
+        .mockResolvedValue('2.0.1');
+      jest.spyOn(packageMgrUtils, 'packageRegistryView').mockResolvedValue(
+        JSON.stringify({
+          dist: {
+            tarball:
+              'https://registry.npmjs.org/mypackage/-/mypackage-2.0.1.tgz',
+          },
+        })
+      );
+      const fetch = createFetcher({} as any);
+      await expect(fetch('mypackage', '2.0.0')).rejects.toThrow(
+        'resolved to version 2.0.1'
+      );
+    });
+
+    it('the fetcher passes through tag and range specs that resolve to a different version', async () => {
+      jest
+        .spyOn(packageMgrUtils, 'resolvePackageVersionUsingRegistry')
+        .mockResolvedValue('2.0.1');
+      jest.spyOn(packageMgrUtils, 'packageRegistryView').mockResolvedValue(
+        JSON.stringify({
+          dist: {
+            tarball:
+              'https://registry.npmjs.org/mypackage/-/mypackage-2.0.1.tgz',
+          },
+        })
+      );
+      const fetch = createFetcher({} as any);
+      await expect(fetch('mypackage', 'latest')).resolves.toMatchObject({
+        version: '2.0.1',
+      });
+    });
   });
 
   describe('multi-major migration prompt', () => {

--- a/packages/nx/src/command-line/migrate/migrate.ts
+++ b/packages/nx/src/command-line/migrate/migrate.ts
@@ -1739,6 +1739,19 @@ export function createFetcher(pmc: PackageManagerCommands) {
 
     migrations = fetchMigrations(packageName, packageVersion, setCache).then(
       (result) => {
+        // An exact requested version must come back verbatim; a mismatch means
+        // a config surface (registry proxy, override, cooldown gate) silently
+        // substituted another version, which would corrupt the whole plan.
+        if (
+          valid(packageVersion) &&
+          result.version &&
+          result.version !== packageVersion
+        ) {
+          throw new Error(
+            `Fetching ${packageName}@${packageVersion} resolved to version ${result.version}. ` +
+              `Check for registry, override, or minimum-release-age configuration that hides the requested version.`
+          );
+        }
         if (result.schematics) {
           result.generators = { ...result.schematics, ...result.generators };
           delete result.schematics;
@@ -1851,7 +1864,13 @@ async function downloadPackageMigrationsFromRegistry(
     const { tarballPath } = await packageRegistryPack(
       dir,
       packageName,
-      packageVersion
+      packageVersion,
+      // packageVersion is exact and already resolved through the workspace
+      // package manager's min-release-age policy by the fetcher. In an npm
+      // workspace the pack gate IS that policy, so leave it enforcing; for
+      // other package managers npm's gate is foreign config with no
+      // exclusions and would wrongly re-judge the vetted version.
+      { bypassMinReleaseAge: detectPackageManager() !== 'npm' }
     );
 
     const fullTarballPath = join(dir, tarballPath);

--- a/packages/nx/src/utils/package-manager.spec.ts
+++ b/packages/nx/src/utils/package-manager.spec.ts
@@ -460,6 +460,31 @@ describe('package-manager', () => {
       expect(result).toContain('minimumReleaseAge: 1440');
     });
 
+    it('should drop link:/file: overrides but keep version overrides', () => {
+      // `pnpm link` writes a relative link: override; in the temp dir it points
+      // at a non-existent path and hijacks exact-version adds.
+      const result = modifyPnpmWorkspaceYamlToFitNewDirectory(
+        [
+          'overrides:',
+          '  nx: link:packages/nx',
+          '  foo: file:../foo',
+          "  minimist: '^1.2.6'",
+          'minimumReleaseAge: 1440',
+        ].join('\n')
+      );
+      expect(result).not.toContain('link:packages/nx');
+      expect(result).not.toContain('file:../foo');
+      expect(parse(result).overrides).toEqual({ minimist: '^1.2.6' });
+      expect(result).toContain('minimumReleaseAge: 1440');
+    });
+
+    it('should drop the overrides map entirely when only link: entries exist', () => {
+      const result = modifyPnpmWorkspaceYamlToFitNewDirectory(
+        ['overrides:', '  nx: link:packages/nx'].join('\n')
+      );
+      expect(parse(result).overrides).toBeUndefined();
+    });
+
     it('should add a packages field to an empty or comments-only manifest', () => {
       // An empty/comments-only source has null doc contents; older pnpm still
       // rejects a packages-less manifest, so `packages: ['.']` must be added.
@@ -895,6 +920,22 @@ describe('package-manager', () => {
       const [cmd, options] = execMock.mock.calls[0];
       expect(cmd).toContain('npm pack');
       expect(options.env.npm_config_force).toBe('true');
+    });
+
+    it('should leave npm min-release-age alone by default', async () => {
+      await packageRegistryPack('/tmp/pack', 'nx', '1.0.0');
+
+      const [, options] = execMock.mock.calls[0];
+      expect(options.env.npm_config_min_release_age).toBeUndefined();
+    });
+
+    it('should disable npm min-release-age when the caller vouches for the version', async () => {
+      await packageRegistryPack('/tmp/pack', 'nx', '1.0.0', {
+        bypassMinReleaseAge: true,
+      });
+
+      const [, options] = execMock.mock.calls[0];
+      expect(options.env.npm_config_min_release_age).toBe('0');
     });
   });
 });

--- a/packages/nx/src/utils/package-manager.ts
+++ b/packages/nx/src/utils/package-manager.ts
@@ -428,6 +428,20 @@ export function modifyPnpmWorkspaceYamlToFitNewDirectory(
   doc.set('packages', ['.']);
   // Relative patch paths don't resolve in the temp dir.
   doc.delete('patchedDependencies');
+  // link:/file: overrides (e.g. written by `pnpm link`) point at paths that
+  // don't exist in the temp dir, and an override would hijack an exact-version
+  // add (`pnpm add pkg@x.y.z` would install the linked dir instead).
+  const overrides = doc.toJS()?.overrides;
+  if (overrides && typeof overrides === 'object') {
+    for (const [name, spec] of Object.entries(overrides)) {
+      if (typeof spec === 'string' && /^(link|file):/.test(spec)) {
+        doc.deleteIn(['overrides', name]);
+      }
+    }
+    if (Object.keys(doc.toJS()?.overrides ?? {}).length === 0) {
+      doc.delete('overrides');
+    }
+  }
   return doc.toString();
 }
 
@@ -652,7 +666,15 @@ export async function packageRegistryView(
 export async function packageRegistryPack(
   cwd: string,
   pkg: string,
-  version: string
+  version: string,
+  options?: {
+    // Only pass when `version` is exact, was already resolved through the
+    // workspace package manager's min-release-age policy, AND that package
+    // manager is not npm: npm's own gate is then foreign config (no
+    // exclusions) that would wrongly re-judge the vetted version. In an npm
+    // workspace the gate IS the workspace policy — leave it enforcing.
+    bypassMinReleaseAge?: boolean;
+  }
 ): Promise<{ tarballPath: string }> {
   /**
    * Only `npm pack` supports downloading a tarball of a specified remote
@@ -668,7 +690,13 @@ export async function packageRegistryPack(
     windowsHide: true,
     // npm enforces `devEngines.packageManager` even on `pack`; force keeps the
     // download working in workspaces that pin a non-npm manager (onFail: error).
-    env: { ...process.env, npm_config_force: 'true' },
+    env: {
+      ...process.env,
+      npm_config_force: 'true',
+      ...(options?.bypassMinReleaseAge
+        ? { npm_config_min_release_age: '0' }
+        : {}),
+    },
   });
 
   const tarballPath = stdout.trim();


### PR DESCRIPTION
## Current Behavior

When a user runs `nx migrate <version>` targeting a version that is younger than a configured minimum-release-age window (e.g. a beta published a few hours ago), the run can silently land on the wrong version even when the workspace's own policy allows the target via `minimumReleaseAgeExclude`:

1. `packageRegistryPack` downloads migration tarballs via `npm pack`, which applies a global `~/.npmrc` `min-release-age` — foreign config with no exclusion support — and fails with `ETARGET` even though nx already vetted the exact version against the workspace policy.
2. The install fallback runs in a temp dir whose copied `pnpm-workspace.yaml` still contains relative `link:`/`file:` overrides (e.g. written by `pnpm link`); the override hijacks the exact-version `pnpm add` and installs the linked directory (version `0.0.0`) from a non-existent path.
3. When a fetch surface substitutes a different version for an explicitly requested exact version, the run continues silently and can conclude "No updates were applied" or generate a plan for the wrong version.

## Expected Behavior

1. `npm pack` of a policy-vetted exact version disables npm's own min-release-age gate for that single exact-version download (`npm_config_min_release_age=0`) — the version was already resolved through the workspace's policy, including exclusions.
2. `modifyPnpmWorkspaceYamlToFitNewDirectory` drops relative `link:`/`file:` overrides, exactly as it already drops `patchedDependencies` for the same reason.
3. The migrate fetcher throws when an exact requested version comes back as a different version, pointing at registry/override/minimum-release-age configuration — instead of silently building a plan for the wrong version. Tag and range specs still resolve freely.

Verified end-to-end: with a `<24h`-old target, `minimumReleaseAge: 1440` + `minimumReleaseAgeExclude: [nx, @nx/*]` in `pnpm-workspace.yaml`, and a global `~/.npmrc` `min-release-age=1`, `nx migrate 23.2.0-beta.2` now lands on exactly `23.2.0-beta.2` with no per-command env bypasses.

## Related Issue(s)

Discovered while migrating five repos to a fresh beta: the un-bypassed migrate silently resolved `latest` (23.1.0) instead of the requested `23.2.0-beta.2`.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Migrate-repos-to-nx-23.2.0-beta.2-2feb17c3)
<!-- polygraph-session-end -->