### PR TITLE
fix(js): resolve tsconfig to absolute path so ${configDir} paths type…

### DIFF
--- a/packages/js/src/utils/typescript/run-type-check.spec.ts
+++ b/packages/js/src/utils/typescript/run-type-check.spec.ts
@@ -89,6 +89,61 @@ describe('runTypeCheck', () => {
     expect(existsSync(join(cacheDir, '.tsbuildinfo'))).toBe(true);
   });
 
+  it('should type-check a baseUrl-less config using ${configDir} paths passed via a relative path', async () => {
+    // The relative config path esbuild passes here must not trip TS5090.
+    writeFileSync(
+      join(workspaceRoot, 'tsconfig.base.json'),
+      JSON.stringify(
+        {
+          compilerOptions: {
+            skipLibCheck: true,
+            strict: false,
+            module: 'esnext',
+            moduleResolution: 'bundler',
+            paths: {
+              '@/*': ['${configDir}/src/*'],
+              '~/*': ['${configDir}/src/*'],
+            },
+          },
+        },
+        null,
+        2
+      )
+    );
+    const relativeTsConfigPath = 'proj/tsconfig.json';
+    writeFileSync(
+      join(workspaceRoot, relativeTsConfigPath),
+      JSON.stringify(
+        {
+          extends: '../tsconfig.base.json',
+          include: ['src/**/*.ts'],
+        },
+        null,
+        2
+      )
+    );
+    mkdirSync(join(projectRoot, 'src'), { recursive: true });
+    writeFileSync(
+      join(projectRoot, 'src', 'valid-source.ts'),
+      `export const msg = 'Hello';`
+    );
+
+    // chdir so the relative tsConfigPath resolves from the workspace root.
+    const originalCwd = process.cwd();
+    process.chdir(workspaceRoot);
+    try {
+      const result = await runTypeCheck({
+        workspaceRoot,
+        tsConfigPath: relativeTsConfigPath,
+        mode: 'noEmit',
+      });
+
+      expect(result.errors).toHaveLength(0);
+    } finally {
+      process.chdir(originalCwd);
+    }
+  });
+
   it('should support emitting declarations', async () => {
     const outDir = join(workspaceRoot, 'dist');
     writeFileSync(

--- a/packages/js/src/utils/typescript/ts-config.spec.ts
+++ b/packages/js/src/utils/typescript/ts-config.spec.ts
@@ -1,6 +1,10 @@
 import { TempFs } from 'nx/src/internal-testing-utils/temp-fs';
-import { readTsConfigPaths, resolvePathsBaseUrl } from './ts-config';
-import { join } from 'path';
+import {
+  readTsConfig,
+  readTsConfigPaths,
+  resolvePathsBaseUrl,
+} from './ts-config';
+import { isAbsolute, join } from 'path';
 
 describe('resolvePathsBaseUrl', () => {
   let tempFs: TempFs;
@@ -314,5 +318,86 @@ describe('readTsConfigPaths', () => {
     );
 
     expect(readTsConfigPaths(join(tempFs.tempDir, 'tsconfig.json'))).toBeNull();
+  });
+});
+
+describe('readTsConfig', () => {
+  let tempFs: TempFs;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    tempFs = new TempFs('read-ts-config', false);
+    originalCwd = process.cwd();
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    tempFs.cleanup();
+  });
+
+  it('should expand ${configDir} paths to absolute values when a baseUrl-less config is read via a relative path', () => {
+    // A relative basePath would leave `paths` non-relative and trip TS5090.
+    tempFs.createFileSync(
+      'tsconfig.base.json',
+      JSON.stringify({
+        compilerOptions: {
+          paths: {
+            '@/*': ['${configDir}/src/*'],
+            '~/*': ['${configDir}/src/*'],
+          },
+        },
+      })
+    );
+    tempFs.createFileSync(
+      'proj/tsconfig.json',
+      JSON.stringify({
+        extends: '../tsconfig.base.json',
+        include: ['src/**/*.ts'],
+      })
+    );
+    tempFs.createFileSync('proj/src/index.ts', `export const a = 1;`);
+
+    process.chdir(tempFs.tempDir);
+    const parsed = readTsConfig('proj/tsconfig.json');
+
+    expect(parsed.errors).toHaveLength(0);
+    for (const values of Object.values(parsed.options.paths ?? {})) {
+      for (const value of values) {
+        expect(isAbsolute(value)).toBe(true);
+      }
+    }
+  });
+
+  it('should not report option diagnostics for a baseUrl-less ${configDir} config read via a relative path', () => {
+    const ts = require('typescript') as typeof import('typescript');
+    tempFs.createFileSync(
+      'tsconfig.base.json',
+      JSON.stringify({
+        compilerOptions: {
+          skipLibCheck: true,
+          module: 'esnext',
+          moduleResolution: 'bundler',
+          paths: { '@/*': ['${configDir}/src/*'] },
+        },
+      })
+    );
+    tempFs.createFileSync(
+      'proj/tsconfig.json',
+      JSON.stringify({
+        extends: '../tsconfig.base.json',
+        include: ['src/**/*.ts'],
+      })
+    );
+    tempFs.createFileSync('proj/src/index.ts', `export const a = 1;`);
+
+    process.chdir(tempFs.tempDir);
+    const parsed = readTsConfig('proj/tsconfig.json');
+    const program = ts.createProgram(parsed.fileNames, {
+      ...parsed.options,
+      noEmit: true,
+    });
+
+    const optionDiagnostics = program.getOptionsDiagnostics();
+    expect(optionDiagnostics.map((d) => d.code)).not.toContain(5090);
   });
 });

--- a/packages/js/src/utils/typescript/ts-config.spec.ts
+++ b/packages/js/src/utils/typescript/ts-config.spec.ts
@@ -9,11 +9,12 @@ import {
 import { tmpdir } from 'os';
 import {
   createTreeParseConfigHost,
+  readTsConfig,
   readTsConfigPaths,
   resolvePathsBaseUrl,
   type TreeParseConfigHost,
 } from './ts-config';
-import { join } from 'path';
+import { isAbsolute, join } from 'path';
 import * as ts from 'typescript';
 import { TempFs } from '@nx/devkit/internal-testing-utils';
 
@@ -443,5 +444,85 @@ describe('createTreeParseConfigHost', () => {
       ts.ModuleResolutionKind.Node10
     );
     expect(parsed.options.declaration).toBeUndefined();
+  });
+});
+
+describe('readTsConfig', () => {
+  let tempFs: TempFs;
+  let originalCwd: string;
+
+  beforeEach(() => {
+    tempFs = new TempFs('read-ts-config', false);
+    originalCwd = process.cwd();
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    tempFs.cleanup();
+  });
+
+  it('should expand ${configDir} paths to absolute values when a baseUrl-less config is read via a relative path', () => {
+    // A relative basePath would leave `paths` non-relative and trip TS5090.
+    tempFs.createFileSync(
+      'tsconfig.base.json',
+      JSON.stringify({
+        compilerOptions: {
+          paths: {
+            '@/*': ['${configDir}/src/*'],
+            '~/*': ['${configDir}/src/*'],
+          },
+        },
+      })
+    );
+    tempFs.createFileSync(
+      'proj/tsconfig.json',
+      JSON.stringify({
+        extends: '../tsconfig.base.json',
+        include: ['src/**/*.ts'],
+      })
+    );
+    tempFs.createFileSync('proj/src/index.ts', `export const a = 1;`);
+
+    process.chdir(tempFs.tempDir);
+    const parsed = readTsConfig('proj/tsconfig.json');
+
+    expect(parsed.errors).toHaveLength(0);
+    for (const values of Object.values(parsed.options.paths ?? {})) {
+      for (const value of values) {
+        expect(isAbsolute(value)).toBe(true);
+      }
+    }
+  });
+
+  it('should not report option diagnostics for a baseUrl-less ${configDir} config read via a relative path', () => {
+    tempFs.createFileSync(
+      'tsconfig.base.json',
+      JSON.stringify({
+        compilerOptions: {
+          skipLibCheck: true,
+          module: 'esnext',
+          moduleResolution: 'bundler',
+          paths: { '@/*': ['${configDir}/src/*'] },
+        },
+      })
+    );
+    tempFs.createFileSync(
+      'proj/tsconfig.json',
+      JSON.stringify({
+        extends: '../tsconfig.base.json',
+        include: ['src/**/*.ts'],
+      })
+    );
+    tempFs.createFileSync('proj/src/index.ts', `export const a = 1;`);
+
+    process.chdir(tempFs.tempDir);
+    const parsed = readTsConfig('proj/tsconfig.json');
+    const program = ts.createProgram(parsed.fileNames, {
+      ...parsed.options,
+      noEmit: true,
+    });
+
+    const optionDiagnostics = program.getOptionsDiagnostics();
+    expect(optionDiagnostics.map((d) => d.code)).not.toContain(5090);
   });
 });

--- a/packages/js/src/utils/typescript/ts-config.ts
+++ b/packages/js/src/utils/typescript/ts-config.ts
@@ -20,13 +20,23 @@ export function readTsConfig(
     tsModule = require('typescript');
   }
 
+  // A tree-backed `sys` (readTsConfigFromTree) reads via `FsTree.read`, which
+  // re-roots an absolute path and breaks, so only absolutize the default sys.
+  const usingDefaultSys = !sys || sys === tsModule.sys;
   sys ??= tsModule.sys;
 
-  const readResult = tsModule.readConfigFile(tsConfigPath, sys.readFile);
+  // Resolve to absolute so `${configDir}` in `paths` expands to absolute
+  // values. A relative basePath produces the TS5090 "no baseUrl" error.
+  //
+  // Don't also pass `configPath` as `configFileName` (5th arg). It doesn't
+  // affect `${configDir}`, only shifts emit output paths (dist/src vs dist).
+  const configPath = usingDefaultSys ? resolve(tsConfigPath) : tsConfigPath;
+
+  const readResult = tsModule.readConfigFile(configPath, sys.readFile);
   return tsModule.parseJsonConfigFileContent(
     readResult.config,
     sys,
-    dirname(tsConfigPath)
+    dirname(configPath)
   );
 }
 


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

## Current Behavior

In a workspace whose tsconfigs have **no `baseUrl`** (the TypeScript 6 migration path — `baseUrl` is deprecated in TS 6 and removed in TS 7) and whose base tsconfig uses `${configDir}` in `paths`, e.g.:

```jsonc
// tsconfig.base.json (no baseUrl)
"paths": {
  "@/*": ["${configDir}/src/*"],
  "~/*": ["${configDir}/src/*"]
}
```

every `@nx/esbuild:esbuild` build fails its type check with a **location-less** error:

```
error TS5090: Non-relative paths are not allowed when 'baseUrl' is not set. Did you forget a leading './'?
Found 1 error.
```

The error has no file/line because it comes from `program.getOptionsDiagnostics()` — it is a diagnostic about the compiler `options` (the `paths` map), not about any source file. A plain `tsc -p <tsconfig>` on the exact same config **passes**, which makes the failure look like an Nx-only problem.

### Root cause

Two things compose to produce the bug:

1. **The esbuild executor relativizes the config path.** `packages/esbuild/src/executors/esbuild/esbuild.impl.ts` → `getTypeCheckOptions()` sets `tsConfigPath: relative(process.cwd(), join(context.root, tsConfig))`, i.e. a value like `"apps/my-app/tsconfig.app.json"`. This is then handed to `runTypeCheck()`.

2. **`readTsConfig()` parses with a relative `basePath` and no `configFileName`.** `packages/js/src/utils/typescript/ts-config.ts` did:

   ```ts
   const readResult = tsModule.readConfigFile(tsConfigPath, sys.readFile);
   return tsModule.parseJsonConfigFileContent(
     readResult.config,
     sys,
     dirname(tsConfigPath) // relative basePath, e.g. "apps/my-app"
   );
   ```

   TypeScript substitutes `${configDir}` in `paths` using that `basePath`, so `${configDir}/src/*` becomes `"apps/my-app/src/*"` — a value that is **neither absolute nor `./`-relative**. `parseJsonConfigFileContent` returns **zero errors** for this. The TS5090 diagnostic only surfaces later, when `runTypeCheck()` (`packages/js/src/utils/typescript/run-type-check.ts`) builds the program and something reads `program.getOptionsDiagnostics()`/`getPreEmitDiagnostics()`.

`tsc -p <path>` does not hit this because it resolves the config path to absolute and passes the config source file, so `${configDir}` expands to an absolute directory and the resulting `paths` values are absolute (which TS5090 allows without a `baseUrl`).

Minimal isolated repro of the diagnostic:

```js
const ts = require('typescript');
const parsed = ts.parseJsonConfigFileContent(
  ts.readConfigFile(relativeCfgPath, ts.sys.readFile).config,
  ts.sys,
  path.dirname(relativeCfgPath) // relative basePath
);
// parsed.errors === []  BUT  parsed.options.paths['@/*'] === ['apps/my-app/src/*'] (non-relative!)
const program = ts.createProgram(parsed.fileNames.slice(0, 1), { ...parsed.options, noEmit: true });
program.getOptionsDiagnostics(); // → TS5090
```

### Affected versions

Reproduced against installed **nx 23.1.0** and published **@nx/js + @nx/esbuild 23.2.0-beta.2** — the relevant code (`getTypeCheckOptions`, `readTsConfig`) is identical, and the same bug is present on `master`.

### Precedent inside Nx

`packages/js/src/utils/buildable-libs-utils.ts` → `readTsConfigWithRemappedPaths()` already absolutizes all remapped `paths` values (with an explicit comment about not needing `baseUrl` because it is deprecated in TS 6), so the generated tmp tsconfig it produces is correct. The `readTsConfig` → `runTypeCheck` route used by the esbuild executor's type check was simply missed.

## Expected Behavior

Type-checking a `baseUrl`-less workspace that uses `${configDir}` in `paths` succeeds — the `@nx/esbuild:esbuild` type check behaves like `tsc -p`, with no spurious location-less TS5090.

## Fix

Make `readTsConfig()` in `packages/js/src/utils/typescript/ts-config.ts` resolve the tsconfig path to **absolute** before parsing, so the `basePath` passed to `parseJsonConfigFileContent` is absolute and `${configDir}` expands to an absolute directory (matching `tsc`). This is a central fix: it repairs **every** `runTypeCheck` consumer (the `@nx/esbuild` executor at minimum), not just one call site.

```ts
const usingDefaultSys = !sys || sys === tsModule.sys;
sys ??= tsModule.sys;

const configPath = usingDefaultSys ? resolve(tsConfigPath) : tsConfigPath;

const readResult = tsModule.readConfigFile(configPath, sys.readFile);
return tsModule.parseJsonConfigFileContent(
  readResult.config,
  sys,
  dirname(configPath)
);
```

### Two deliberate constraints on the fix

1. **Absolutization is gated to the default (real) filesystem `sys`.** `readTsConfigFromTree()` calls `readTsConfig(tsConfigPath, treeBackedSys)` with a `sys` whose `readFile` is `(path) => tree.read(path, 'utf-8')`, and `FsTree.read` normalizes via `relative(root, join(root, path))` — passing it an **absolute** path re-roots it (`join('/root', '/root/x')` → `/root/root/x`) and breaks the read. So we only absolutize when using the default `ts.sys`; any caller that supplies a custom `sys` (tree-backed or otherwise) keeps the previous relative behavior. All the affected `runTypeCheck` consumers use the default `sys`, so the bug is fixed for them without touching the Tree path.

2. **`configFileName` (the 5th arg) is intentionally *not* passed.** Only the `basePath` needs to be absolute for `${configDir}` to expand correctly. Passing `tsConfigPath` as `configFileName` would additionally set `options.configFilePath`, which changes how TypeScript infers the common source directory and **alters declaration emit output paths** — this was caught by the existing `runTypeCheck` "should support emitting declarations" spec, which started emitting to `dist/proj/…` instead of `dist/…`. Leaving `configFileName` unset keeps emit behavior unchanged while still fixing the diagnostic. (Trade-off: TS5090-class option diagnostics remain location-less, exactly as before — this PR does not attach them to the config file.)

The esbuild executor's `relative(process.cwd(), …)` wrapper in `getTypeCheckOptions()` is left as-is; with `readTsConfig` now absolutizing, the relative path it produces is handled correctly, and centralizing the fix avoids touching each consumer individually.

## Tests

Added to `packages/js/src/utils/typescript/`:

- **`ts-config.spec.ts`** — a new `describe('readTsConfig')` block: parsing a `baseUrl`-less config whose `paths` use `${configDir}`, read via a **relative** path (with `process.cwd()` set to the workspace), yields **absolute** `options.paths` values and no parse errors; and building a program from that parsed config produces **no TS5090** in `program.getOptionsDiagnostics()`.
- **`run-type-check.spec.ts`** — a new end-to-end case exercising the actual esbuild path (`runTypeCheck` → `readTsConfig`): a `baseUrl`-less base tsconfig with `${configDir}` `paths`, type-checked via a **relative** `tsConfigPath`, returns **zero errors** (before the fix it returned the location-less TS5090).

### Test runs

All runs go through the workspace's own Nx (`pnpm nx test <project>`), with the jest 30 path filter passed through via `--testPathPatterns`:

- `pnpm nx test js --testPathPatterns="typescript/(ts-config|run-type-check)"` — the new/edited `ts-config.spec.ts` and `run-type-check.spec.ts`: **2 suites, 22 tests passed**.
- `pnpm nx test esbuild` — the full `@nx/esbuild` package suite (the primary consumer of the fixed code path, exercised as a regression sweep): **7 suites, 36 tests passed**.

Reverting only the `ts-config.ts` change makes the three new assertions fail with the location-less TS5090, while the pre-existing `runTypeCheck` "should support emitting declarations" spec continues to pass — confirming the `configFileName` trade-off noted above. Edited files were formatted with the repo's Prettier.

## Related Issue(s)

<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Related: #35272 (same TS5090 symptom, closed as fixed by #34965 — that PR absolutized the remapped paths written by `readTsConfigWithRemappedPaths` and stopped generating `baseUrl`, but did not cover `readTsConfig` itself, which is the path `runTypeCheck` consumers like `@nx/esbuild` go through; this PR fixes that remaining case)

<!-- If a fresh issue is filed per the bot's suggestion on #35272, replace with: Fixes #<new-issue-number> -->
