### PR TITLE
fix(core): replace the open package with a native URL opener

### DIFF
--- a/packages/create-nx-workspace/package.json
+++ b/packages/create-nx-workspace/package.json
@@ -41,7 +41,6 @@
     "chalk": "catalog:",
     "enquirer": "catalog:",
     "flat": "^5.0.2",
-    "open": "^8.4.0",
     "ora": "catalog:",
     "tar-stream": "~2.2.0",
     "tmp": "catalog:",

--- a/packages/create-nx-workspace/src/create-workspace.ts
+++ b/packages/create-nx-workspace/src/create-workspace.ts
@@ -344,7 +344,7 @@ export async function createWorkspace<T extends CreateWorkspaceOptions>(
 
     // Auto-open the Cloud setup URL in the browser when user selected 'yes'
     if (!options.skipCloudConnect) {
-      await openCloudSetupUrl(connectUrl);
+      await openCloudSetupUrl(connectUrl, directory);
     }
   } else if (isTemplate && (nxCloud === 'skip' || nxCloud === 'never')) {
     // Strip marker comments from README

--- a/packages/create-nx-workspace/src/create-workspace.ts
+++ b/packages/create-nx-workspace/src/create-workspace.ts
@@ -346,7 +346,7 @@ export async function createWorkspace<T extends CreateWorkspaceOptions>(
 
     // Auto-open the Cloud setup URL in the browser when user selected 'yes'
     if (!options.skipCloudConnect) {
-      await openCloudSetupUrl(connectUrl);
+      await openCloudSetupUrl(connectUrl, directory);
     }
   } else if (isTemplate && (nxCloud === 'skip' || nxCloud === 'never')) {
     // Strip marker comments from README

--- a/packages/create-nx-workspace/src/create-workspace.ts
+++ b/packages/create-nx-workspace/src/create-workspace.ts
@@ -346,7 +346,7 @@ export async function createWorkspace<T extends CreateWorkspaceOptions>(
 
     // Auto-open the Cloud setup URL in the browser when user selected 'yes'
     if (!options.skipCloudConnect) {
-      openCloudSetupUrl(connectUrl, directory);
+      openCloudSetupUrl({ connectUrl, workspaceDirectory: directory });
     }
   } else if (isTemplate && (nxCloud === 'skip' || nxCloud === 'never')) {
     // Strip marker comments from README

--- a/packages/create-nx-workspace/src/create-workspace.ts
+++ b/packages/create-nx-workspace/src/create-workspace.ts
@@ -346,7 +346,7 @@ export async function createWorkspace<T extends CreateWorkspaceOptions>(
 
     // Auto-open the Cloud setup URL in the browser when user selected 'yes'
     if (!options.skipCloudConnect) {
-      await openCloudSetupUrl(connectUrl, directory);
+      openCloudSetupUrl(connectUrl, directory);
     }
   } else if (isTemplate && (nxCloud === 'skip' || nxCloud === 'never')) {
     // Strip marker comments from README

--- a/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
+++ b/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
@@ -149,14 +149,26 @@ export function getSkippedNxCloudInfo() {
   return out.getOutput();
 }
 
-export async function openCloudSetupUrl(connectUrl: string): Promise<void> {
+export async function openCloudSetupUrl(
+  connectUrl: string,
+  workspaceDirectory: string
+): Promise<void> {
   if (isCI()) {
     return;
   }
 
   try {
-    const open = require('open');
-    await open(connectUrl);
+    // Reuse the workspace's freshly-installed native Nx opener rather than
+    // bundling our own `open` dependency. Nx is installed at the same version
+    // as this CLI, so `openUrl` is present; an older Nx without it just falls
+    // through to the catch, where the URL is already shown in the banner.
+    const nativePath = require.resolve('nx/src/native', {
+      paths: [workspaceDirectory],
+    });
+    const { openUrl } = require(nativePath) as {
+      openUrl?: (url: string) => boolean;
+    };
+    openUrl?.(connectUrl);
   } catch {
     // Fail gracefully — the URL is already displayed in the terminal banner
   }

--- a/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
+++ b/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
@@ -159,9 +159,10 @@ export async function openCloudSetupUrl(
 
   try {
     // Reuse the workspace's freshly-installed native Nx opener rather than
-    // bundling our own `open` dependency. Nx is installed at the same version
-    // as this CLI, so `openUrl` is present; an older Nx without it just falls
-    // through to the catch, where the URL is already shown in the banner.
+    // bundling our own `open` dependency. Nx is installed at the same version as
+    // this CLI, so `openUrl` is present; an older Nx that lacks it makes the
+    // optional call a silent no-op, while a missing native module throws and is
+    // caught. Either way the URL is already shown in the banner.
     const nativePath = require.resolve('nx/src/native', {
       paths: [workspaceDirectory],
     });

--- a/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
+++ b/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
@@ -165,10 +165,10 @@ export function openCloudSetupUrl(opts: {
     // carries the URL either way.
     //
     // Load the bindings directly: `nx/src/native` is a loader shim that copies
-    // the multi-MB .node into a cache keyed on cwd, which here is the parent of
-    // the new workspace — so the copy is written and never read. It also
-    // suppresses a WASI ExperimentalWarning we lose by skipping it, but that
-    // only surfaces on the wasm fallback, where `openUrl` is a stub anyway.
+    // the multi-MB .node into a cache and loads the copy. The key is derived from
+    // cwd, which here is the parent of the new workspace, so nothing ever reuses
+    // it. Skipping the shim also loses its WASI ExperimentalWarning filter, but
+    // that only surfaces on the wasm fallback, where `openUrl` is a stub anyway.
     // nx-ignore-next-line
     const nativePath = require.resolve('nx/src/native/native-bindings.js', {
       paths: [opts.workspaceDirectory],

--- a/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
+++ b/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
@@ -149,10 +149,10 @@ export function getSkippedNxCloudInfo() {
   return out.getOutput();
 }
 
-export function openCloudSetupUrl(
-  connectUrl: string,
-  workspaceDirectory: string
-): void {
+export function openCloudSetupUrl(opts: {
+  connectUrl: string;
+  workspaceDirectory: string;
+}): void {
   if (isCI()) {
     return;
   }
@@ -163,14 +163,19 @@ export function openCloudSetupUrl(
     // third-party presets install whatever Nx *they* pin, which may predate
     // `openUrl`, so the optional call no-ops. The banner printed after this
     // carries the URL either way.
+    //
+    // Load the bindings directly: `nx/src/native` is a loader shim that patches
+    // `process.emit` and `Module._load` process-wide and copies the .node into a
+    // cache keyed on cwd — all pointless here, since this process exits seconds
+    // later and its cwd isn't the new workspace.
     // nx-ignore-next-line
-    const nativePath = require.resolve('nx/src/native', {
-      paths: [workspaceDirectory],
+    const nativePath = require.resolve('nx/src/native/native-bindings.js', {
+      paths: [opts.workspaceDirectory],
     });
     const { openUrl } = require(nativePath) as {
       openUrl?: (url: string) => boolean;
     };
-    openUrl?.(connectUrl);
+    openUrl?.(opts.connectUrl);
   } catch {
     // Fail gracefully — the banner still carries the URL
   }

--- a/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
+++ b/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
@@ -149,20 +149,21 @@ export function getSkippedNxCloudInfo() {
   return out.getOutput();
 }
 
-export async function openCloudSetupUrl(
+export function openCloudSetupUrl(
   connectUrl: string,
   workspaceDirectory: string
-): Promise<void> {
+): void {
   if (isCI()) {
     return;
   }
 
   try {
-    // Reuse the workspace's freshly-installed native Nx opener rather than
-    // bundling our own `open` dependency. Nx is installed at the same version as
-    // this CLI, so `openUrl` is present; an older Nx that lacks it makes the
-    // optional call a silent no-op, while a missing native module throws and is
-    // caught. Either way the URL is already shown in the banner.
+    // Open through the workspace's own Nx rather than bundling a second opener
+    // here. Only the preset flow installs this CLI's version — `--template` and
+    // third-party presets install whatever Nx *they* pin, which may predate
+    // `openUrl`, so the optional call no-ops. The banner printed after this
+    // carries the URL either way.
+    // nx-ignore-next-line
     const nativePath = require.resolve('nx/src/native', {
       paths: [workspaceDirectory],
     });
@@ -171,7 +172,7 @@ export async function openCloudSetupUrl(
     };
     openUrl?.(connectUrl);
   } catch {
-    // Fail gracefully — the URL is already displayed in the terminal banner
+    // Fail gracefully — the banner still carries the URL
   }
 }
 

--- a/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
+++ b/packages/create-nx-workspace/src/utils/nx/nx-cloud.ts
@@ -164,10 +164,11 @@ export function openCloudSetupUrl(opts: {
     // `openUrl`, so the optional call no-ops. The banner printed after this
     // carries the URL either way.
     //
-    // Load the bindings directly: `nx/src/native` is a loader shim that patches
-    // `process.emit` and `Module._load` process-wide and copies the .node into a
-    // cache keyed on cwd — all pointless here, since this process exits seconds
-    // later and its cwd isn't the new workspace.
+    // Load the bindings directly: `nx/src/native` is a loader shim that copies
+    // the multi-MB .node into a cache keyed on cwd, which here is the parent of
+    // the new workspace — so the copy is written and never read. It also
+    // suppresses a WASI ExperimentalWarning we lose by skipping it, but that
+    // only surfaces on the wasm fallback, where `openUrl` is a stub anyway.
     // nx-ignore-next-line
     const nativePath = require.resolve('nx/src/native/native-bindings.js', {
       paths: [opts.workspaceDirectory],

--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -71,7 +71,6 @@
     "lines-and-columns": "2.0.3",
     "minimatch": "catalog:",
     "npm-run-path": "^4.0.1",
-    "open": "^10.1.0",
     "ora": "catalog:",
     "resolve.exports": "2.0.3",
     "semver": "catalog:",

--- a/packages/nx/src/command-line/graph/graph.ts
+++ b/packages/nx/src/command-line/graph/graph.ts
@@ -567,8 +567,9 @@ export async function generateGraph(
     });
 
     if (args.open) {
-      // Best-effort: openUrl never throws and returns false if no browser could
-      // be launched. The URL is already printed above, so a failure is silent.
+      // Best-effort: openUrl never throws and returns false if the opener
+      // process couldn't be spawned. The URL is already printed above, so a
+      // failure is silent.
       openUrl(url.toString());
     }
 

--- a/packages/nx/src/command-line/graph/graph.ts
+++ b/packages/nx/src/command-line/graph/graph.ts
@@ -12,6 +12,7 @@ import { VersionMismatchError } from '../../daemon/client/daemon-socket-messenge
 import * as http from 'node:http';
 import { minimatch } from 'minimatch';
 import { URL } from 'node:url';
+import { openUrl } from '../../native';
 import {
   basename,
   dirname,
@@ -566,15 +567,9 @@ export async function generateGraph(
     });
 
     if (args.open) {
-      (
-        new Function('return import("open")')() as Promise<
-          typeof import('open')
-        >
-      )
-        .then((m) => m.default(url.toString()))
-        .catch(() => {
-          // Ignore errors when opening browser (e.g. no browser available)
-        });
+      // Best-effort: openUrl never throws and returns false if no browser could
+      // be launched. The URL is already printed above, so a failure is silent.
+      openUrl(url.toString());
     }
 
     return new Promise((res) => {

--- a/packages/nx/src/command-line/graph/graph.ts
+++ b/packages/nx/src/command-line/graph/graph.ts
@@ -567,9 +567,8 @@ export async function generateGraph(
     });
 
     if (args.open) {
-      // Best-effort: openUrl never throws and returns false if the opener
-      // process couldn't be spawned. The URL is already printed above, so a
-      // failure is silent.
+      // Best-effort: openUrl never throws, returning false if no opener could be
+      // spawned. The URL is printed above, so a failure is silent.
       openUrl(url.toString());
     }
 

--- a/packages/nx/src/command-line/nx-cloud/connect/connect-to-nx-cloud.ts
+++ b/packages/nx/src/command-line/nx-cloud/connect/connect-to-nx-cloud.ts
@@ -22,7 +22,7 @@ import {
 } from '../../../utils/ab-testing';
 import { nxVersion } from '../../../utils/versions';
 import { isCI } from '../../../utils/is-ci';
-import { isAiAgent } from '../../../native';
+import { isAiAgent, openUrl } from '../../../native';
 import { detectPackageManager } from '../../../utils/package-manager';
 import { workspaceRoot } from '../../../utils/workspace-root';
 import { getVcsRemoteInfo } from '../../../utils/git-utils';
@@ -200,26 +200,28 @@ async function runConnectToNxCloud(
     undefined,
     options?.generateToken === true
   );
+  const manualConnectNote = {
+    title: `Your Nx Cloud workspace is ready.`,
+    bodyLines: [
+      `To claim it, connect it to your Nx Cloud account:`,
+      `- Go to the following URL to connect your workspace to Nx Cloud:`,
+      '',
+      `${connectCloudUrl}`,
+    ],
+  };
   try {
     const cloudConnectSpinner = ora(
       `Opening Nx Cloud ${connectCloudUrl} in your browser to connect your workspace.`
     ).start();
     await sleep(2000);
-    const { default: open } = await (new Function(
-      'return import("open")'
-    )() as Promise<typeof import('open')>);
-    await open(connectCloudUrl);
-    cloudConnectSpinner.succeed();
+    if (openUrl(connectCloudUrl)) {
+      cloudConnectSpinner.succeed();
+    } else {
+      cloudConnectSpinner.fail();
+      output.note(manualConnectNote);
+    }
   } catch (e) {
-    output.note({
-      title: `Your Nx Cloud workspace is ready.`,
-      bodyLines: [
-        `To claim it, connect it to your Nx Cloud account:`,
-        `- Go to the following URL to connect your workspace to Nx Cloud:`,
-        '',
-        `${connectCloudUrl}`,
-      ],
-    });
+    output.note(manualConnectNote);
   }
 
   return true;

--- a/packages/nx/src/command-line/release/utils/remote-release-clients/github.ts
+++ b/packages/nx/src/command-line/release/utils/remote-release-clients/github.ts
@@ -1,6 +1,7 @@
 import * as pc from 'picocolors';
 import { prompt } from 'enquirer';
 import { execFileSync, execSync } from 'node:child_process';
+import { openUrl } from '../../../../native';
 import { existsSync, promises as fsp } from 'node:fs';
 import { homedir } from 'node:os';
 import { orange, output } from '../../../../utils/output';
@@ -353,24 +354,19 @@ export class GithubRemoteReleaseClient extends RemoteReleaseClient<GithubRemoteR
       return;
     }
 
-    const { default: open } = await (new Function(
-      'return import("open")'
-    )() as Promise<typeof import('open')>);
-    await open(result.url)
-      .then(() => {
-        console.info(
-          `\nFollow up in the browser to manually create the release:\n\n` +
-            pc.underline(pc.cyan(result.url)) +
-            `\n`
-        );
-      })
-      .catch(() => {
-        console.info(
-          `Open this link to manually create a release: \n` +
-            pc.underline(pc.cyan(result.url)) +
-            '\n'
-        );
-      });
+    if (openUrl(result.url)) {
+      console.info(
+        `\nFollow up in the browser to manually create the release:\n\n` +
+          pc.underline(pc.cyan(result.url)) +
+          `\n`
+      );
+    } else {
+      console.info(
+        `Open this link to manually create a release: \n` +
+          pc.underline(pc.cyan(result.url)) +
+          '\n'
+      );
+    }
   }
 
   private async promptForContinueInGitHub(): Promise<boolean> {

--- a/packages/nx/src/command-line/release/utils/remote-release-clients/gitlab.ts
+++ b/packages/nx/src/command-line/release/utils/remote-release-clients/gitlab.ts
@@ -1,6 +1,7 @@
 import * as pc from 'picocolors';
 import { prompt } from 'enquirer';
 import { execSync } from 'node:child_process';
+import { openUrl } from '../../../../native';
 import { orange, output } from '../../../../utils/output';
 import type { PostGitTask } from '../../changelog';
 import type { ResolvedCreateRemoteReleaseProvider } from '../../config/config';
@@ -251,24 +252,19 @@ export class GitLabRemoteReleaseClient extends RemoteReleaseClient<GitLabRelease
       return;
     }
 
-    const { default: open } = await (new Function(
-      'return import("open")'
-    )() as Promise<typeof import('open')>);
-    await open(result.url)
-      .then(() => {
-        console.info(
-          `\nFollow up in the browser to manually create the release:\n\n` +
-            pc.underline(pc.cyan(result.url)) +
-            `\n`
-        );
-      })
-      .catch(() => {
-        console.info(
-          `Open this link to manually create a release: \n` +
-            pc.underline(pc.cyan(result.url)) +
-            '\n'
-        );
-      });
+    if (openUrl(result.url)) {
+      console.info(
+        `\nFollow up in the browser to manually create the release:\n\n` +
+          pc.underline(pc.cyan(result.url)) +
+          `\n`
+      );
+    } else {
+      console.info(
+        `Open this link to manually create a release: \n` +
+          pc.underline(pc.cyan(result.url)) +
+          '\n'
+      );
+    }
   }
 
   private async promptForContinueInGitLab(): Promise<boolean> {

--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -616,6 +616,13 @@ export interface NxWorkspaceFilesExternals {
   allWorkspaceFiles: ExternalObject<Array<FileData>>
 }
 
+/**
+ * Open `url` in the user's default browser. Returns `true` if an opener
+ * process was spawned, `false` if it couldn't be (e.g. no `xdg-open`), so the
+ * caller can tell the user instead of failing silently. Never throws.
+ */
+export declare function openUrl(url: string): boolean
+
 export declare function parseTaskStatus(stringStatus: string): TaskStatus
 
 /**

--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -618,8 +618,9 @@ export interface NxWorkspaceFilesExternals {
 
 /**
  * Open `url` in the user's default browser. Returns `true` if an opener
- * process was spawned, `false` if it couldn't be (e.g. no `xdg-open`), so the
- * caller can tell the user instead of failing silently. Never throws.
+ * process was spawned, `false` if none could be (e.g. no `xdg-open`) or `url`
+ * isn't `http(s)`, so the caller can tell the user instead of failing
+ * silently. Never throws.
  */
 export declare function openUrl(url: string): boolean
 

--- a/packages/nx/src/native/native-bindings.js
+++ b/packages/nx/src/native/native-bindings.js
@@ -627,6 +627,7 @@ module.exports.killProcessTreeGraceful = nativeBinding.killProcessTreeGraceful
 module.exports.logDebug = nativeBinding.logDebug
 module.exports.matchGlobPaths = nativeBinding.matchGlobPaths
 module.exports.matchOutputPaths = nativeBinding.matchOutputPaths
+module.exports.openUrl = nativeBinding.openUrl
 module.exports.parseTaskStatus = nativeBinding.parseTaskStatus
 module.exports.remove = nativeBinding.remove
 module.exports.restoreTerminal = nativeBinding.restoreTerminal

--- a/packages/nx/src/native/nx.wasi-browser.js
+++ b/packages/nx/src/native/nx.wasi-browser.js
@@ -124,6 +124,7 @@ export const installNxConsole = __napiModule.exports.installNxConsole
 export const IS_WASM = __napiModule.exports.IS_WASM
 export const isAiAgent = __napiModule.exports.isAiAgent
 export const logDebug = __napiModule.exports.logDebug
+export const openUrl = __napiModule.exports.openUrl
 export const remove = __napiModule.exports.remove
 export const testOnlyTransferFileMap = __napiModule.exports.testOnlyTransferFileMap
 export const transferProjectGraph = __napiModule.exports.transferProjectGraph

--- a/packages/nx/src/native/nx.wasi.cjs
+++ b/packages/nx/src/native/nx.wasi.cjs
@@ -154,6 +154,7 @@ module.exports.installNxConsole = __napiModule.exports.installNxConsole
 module.exports.IS_WASM = __napiModule.exports.IS_WASM
 module.exports.isAiAgent = __napiModule.exports.isAiAgent
 module.exports.logDebug = __napiModule.exports.logDebug
+module.exports.openUrl = __napiModule.exports.openUrl
 module.exports.remove = __napiModule.exports.remove
 module.exports.testOnlyTransferFileMap = __napiModule.exports.testOnlyTransferFileMap
 module.exports.transferProjectGraph = __napiModule.exports.transferProjectGraph

--- a/packages/nx/src/native/tests/native-bindings.spec.ts
+++ b/packages/nx/src/native/tests/native-bindings.spec.ts
@@ -33,9 +33,10 @@ describe('native bindings type definitions', () => {
 });
 
 describe('wasm bindings', () => {
-  // `build-native` and `build-native-wasm` generate separate shims, so a new
-  // `#[napi]` export can land in index.d.ts while the wasm ones stay stale —
-  // and JS that calls it under wasm gets a TypeError instead of a value.
+  // Both shims come out of the same `build-native-wasm` run, so they go stale
+  // together — comparing them catches a hand-edit to one, not a missed
+  // regeneration. Per-export assertions below are what cover that, and they are
+  // only worth adding for exports a caller invokes unguarded.
   function exportsOf(file: string, pattern: RegExp): string[] {
     const source = readFileSync(join(__dirname, '..', file), 'utf-8');
     return [...source.matchAll(pattern)].map(([, name]) => name).sort();
@@ -51,7 +52,9 @@ describe('wasm bindings', () => {
     expect(cjsExports()).toEqual(browserExports());
   });
 
-  it('should export openUrl, which has a wasm stub so callers get false rather than a TypeError', () => {
+  it('should export openUrl, which graph --open calls without a guard', () => {
+    // A missed regeneration here is a TypeError on `nx graph`, not a no-op:
+    // open_url.rs keeps a wasm stub so the export always exists to be bound.
     expect(cjsExports()).toContain('openUrl');
     expect(browserExports()).toContain('openUrl');
   });

--- a/packages/nx/src/native/tests/native-bindings.spec.ts
+++ b/packages/nx/src/native/tests/native-bindings.spec.ts
@@ -1,3 +1,4 @@
+import { readFileSync } from 'fs';
 import { join } from 'path';
 import * as ts from 'typescript';
 
@@ -28,5 +29,30 @@ describe('native bindings type definitions', () => {
       // jest 30 removed the global fail(); throwing keeps the diagnostics visible
       throw new Error(`index.d.ts has TypeScript errors:\n${formatted}`);
     }
+  });
+});
+
+describe('wasm bindings', () => {
+  // `build-native` and `build-native-wasm` generate separate shims, so a new
+  // `#[napi]` export can land in index.d.ts while the wasm ones stay stale —
+  // and JS that calls it under wasm gets a TypeError instead of a value.
+  function exportsOf(file: string, pattern: RegExp): string[] {
+    const source = readFileSync(join(__dirname, '..', file), 'utf-8');
+    return [...source.matchAll(pattern)].map(([, name]) => name).sort();
+  }
+
+  const cjsExports = () =>
+    exportsOf('nx.wasi.cjs', /^module\.exports\.(\w+)/gm);
+  const browserExports = () =>
+    exportsOf('nx.wasi-browser.js', /^export const (\w+)/gm);
+
+  it('should export the same names from both wasm shims', () => {
+    expect(cjsExports()).not.toHaveLength(0);
+    expect(cjsExports()).toEqual(browserExports());
+  });
+
+  it('should export openUrl, which has a wasm stub so callers get false rather than a TypeError', () => {
+    expect(cjsExports()).toContain('openUrl');
+    expect(browserExports()).toContain('openUrl');
   });
 });

--- a/packages/nx/src/native/tui/app.rs
+++ b/packages/nx/src/native/tui/app.rs
@@ -364,39 +364,9 @@ impl RegionSnapshot {
 const DOUBLE_CLICK_MS: u128 = 400;
 
 /// Open a URL in the user's default browser (NXC-3940). Best-effort: a missing
-/// opener can never crash the TUI. Returns `true` if the opener process was
-/// spawned, `false` if it couldn't be (e.g. no `xdg-open` on a headless box) so
-/// the caller can tell the user instead of failing silently. The child's stdio
-/// is detached to null so it can't corrupt the terminal we're drawing to.
-fn open_url(url: &str) -> bool {
-    use std::process::{Command, Stdio};
-
-    #[cfg(target_os = "macos")]
-    let mut cmd = {
-        let mut c = Command::new("open");
-        c.arg(url);
-        c
-    };
-    #[cfg(target_os = "windows")]
-    let mut cmd = {
-        let mut c = Command::new("cmd");
-        // The empty "" is the window title argument that `start` expects first.
-        c.args(["/C", "start", "", url]);
-        c
-    };
-    #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
-    let mut cmd = {
-        let mut c = Command::new("xdg-open");
-        c.arg(url);
-        c
-    };
-
-    cmd.stdin(Stdio::null())
-        .stdout(Stdio::null())
-        .stderr(Stdio::null())
-        .spawn()
-        .is_ok()
-}
+/// opener can never crash the TUI. The shared implementation is container-aware
+/// on WSL; see [`crate::native::utils::open_url`].
+use crate::native::utils::open_url::open_url_native as open_url;
 
 impl App {
     /// Create a new App with existing shared state (for mode switching)

--- a/packages/nx/src/native/tui/app.rs
+++ b/packages/nx/src/native/tui/app.rs
@@ -21,6 +21,9 @@ use tracing::{debug, trace};
 use tui_logger::{LevelFilter, TuiLoggerSmartWidget, TuiWidgetEvent, TuiWidgetState};
 
 use crate::native::tui::tui::Tui;
+// Opening a URL is best-effort (NXC-3940): a missing opener can never crash the
+// TUI. The shared impl walks a fallback chain and is container-aware on WSL.
+use crate::native::utils::open_url::open_url_native as open_url;
 use crate::native::{
     pseudo_terminal::pseudo_terminal::PtyHandles,
     tasks::types::{Task, TaskResult},
@@ -362,11 +365,6 @@ impl RegionSnapshot {
 /// double-click. crossterm reports individual button presses, so we detect
 /// double-clicks ourselves.
 const DOUBLE_CLICK_MS: u128 = 400;
-
-/// Open a URL in the user's default browser (NXC-3940). Best-effort: a missing
-/// opener can never crash the TUI. The shared implementation is container-aware
-/// on WSL; see [`crate::native::utils::open_url`].
-use crate::native::utils::open_url::open_url_native as open_url;
 
 impl App {
     /// Create a new App with existing shared state (for mode switching)

--- a/packages/nx/src/native/tui/app.rs
+++ b/packages/nx/src/native/tui/app.rs
@@ -22,7 +22,7 @@ use tui_logger::{LevelFilter, TuiLoggerSmartWidget, TuiWidgetEvent, TuiWidgetSta
 
 use crate::native::tui::tui::Tui;
 // Opening a URL is best-effort (NXC-3940): a missing opener can never crash the
-// TUI. The shared impl walks a fallback chain and is container-aware on WSL.
+// TUI. The shared impl is container-aware on WSL.
 use crate::native::utils::open_url::open_url_native as open_url;
 use crate::native::{
     pseudo_terminal::pseudo_terminal::PtyHandles,

--- a/packages/nx/src/native/utils/mod.rs
+++ b/packages/nx/src/native/utils/mod.rs
@@ -19,5 +19,6 @@ pub mod ci;
 pub mod command;
 pub mod file_lock;
 pub mod git;
+pub mod open_url;
 
 pub use atomics::*;

--- a/packages/nx/src/native/utils/open_url.rs
+++ b/packages/nx/src/native/utils/open_url.rs
@@ -1,0 +1,248 @@
+//! Open a URL in the user's default browser from native code.
+//!
+//! Replaces the JS `open` npm package (NXC-3940). Best-effort by contract: a
+//! missing or unreachable opener never panics, it just returns `false` so the
+//! caller can fall back to printing the URL.
+
+#[cfg(not(target_arch = "wasm32"))]
+use std::process::{Command, Stdio};
+#[cfg(not(target_arch = "wasm32"))]
+use std::sync::OnceLock;
+
+/// Open `url` in the user's default browser. Returns `true` if an opener
+/// process was spawned, `false` if it couldn't be (e.g. no `xdg-open`), so the
+/// caller can tell the user instead of failing silently. Never throws.
+#[cfg(not(target_arch = "wasm32"))]
+#[napi]
+pub fn open_url(url: String) -> bool {
+    open_url_native(&url)
+}
+
+/// Rust-facing entry point (the napi wrapper just forwards a `String`). Callers
+/// inside the native crate — e.g. the TUI — use this directly.
+#[cfg(not(target_arch = "wasm32"))]
+pub fn open_url_native(url: &str) -> bool {
+    build_open_command(url)
+        .stdin(Stdio::null())
+        // Detach stdio to null so a launched opener can't corrupt a terminal
+        // we may be drawing to (the TUI).
+        .stdout(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .is_ok()
+}
+
+#[cfg(all(not(target_arch = "wasm32"), target_os = "macos"))]
+fn build_open_command(url: &str) -> Command {
+    let mut c = Command::new("open");
+    c.arg(url);
+    c
+}
+
+#[cfg(all(not(target_arch = "wasm32"), target_os = "windows"))]
+fn build_open_command(url: &str) -> Command {
+    let mut c = Command::new("cmd");
+    // The empty "" is the window-title argument `start` expects first.
+    c.args(["/C", "start", "", url]);
+    c
+}
+
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    not(target_os = "macos"),
+    not(target_os = "windows")
+))]
+fn build_open_command(url: &str) -> Command {
+    // On a non-container WSL2 host the Linux `xdg-open` usually can't reach a
+    // browser, so hand the URL to the *Windows* host browser. Inside a
+    // Docker/Podman container the Windows interop path is absent and spawning
+    // it is exactly the crash this replaces (`open@8` misdetected Podman as
+    // bare WSL) — so containers must stay on `xdg-open`.
+    if is_wsl2() && !is_in_container() {
+        windows_browser_command(url)
+    } else {
+        let mut c = Command::new("xdg-open");
+        c.arg(url);
+        c
+    }
+}
+
+/// WSL2 has "WSL2" in `/proc/version`; WSL1's interop differs and is not
+/// targeted (its `xdg-open` path is left as the default fallback).
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    not(target_os = "macos"),
+    not(target_os = "windows")
+))]
+fn is_wsl2() -> bool {
+    static IS_WSL2: OnceLock<bool> = OnceLock::new();
+    *IS_WSL2.get_or_init(|| {
+        std::fs::read_to_string("/proc/version")
+            .map(|contents| contents.contains("WSL2"))
+            .unwrap_or(false)
+    })
+}
+
+/// Detects an OCI container (Docker `/​.dockerenv`, or Podman
+/// `/run/.containerenv`). This is the marker `open@8`'s `is-docker` missed for
+/// Podman, causing the original crash.
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    not(target_os = "macos"),
+    not(target_os = "windows")
+))]
+fn is_in_container() -> bool {
+    static IN_CONTAINER: OnceLock<bool> = OnceLock::new();
+    *IN_CONTAINER.get_or_init(|| {
+        std::path::Path::new("/.dockerenv").exists()
+            || std::path::Path::new("/run/.containerenv").exists()
+    })
+}
+
+/// Launch the Windows browser from WSL via the host PowerShell. The URL is
+/// handed over as a base64 UTF-16LE `-EncodedCommand` (the same mechanism the
+/// `open` package used) so shell metacharacters — notably `&` in a query
+/// string, a `cmd.exe` separator — can neither break the command line nor
+/// inject anything: the URL never appears on a command line as text.
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    not(target_os = "macos"),
+    not(target_os = "windows")
+))]
+fn windows_browser_command(url: &str) -> Command {
+    // Single-quoted PowerShell literal; the only in-literal escape is a single
+    // quote, doubled.
+    let script = format!("Start-Process '{}'", url.replace('\'', "''"));
+    let utf16le: Vec<u8> = script
+        .encode_utf16()
+        .flat_map(|unit| unit.to_le_bytes())
+        .collect();
+    let mut c = Command::new("powershell.exe");
+    c.args([
+        "-NoProfile",
+        "-NonInteractive",
+        "-EncodedCommand",
+        &base64_encode(&utf16le),
+    ]);
+    c
+}
+
+/// Minimal standard-alphabet base64 encoder (padded). Kept local to avoid a new
+/// crate dependency for the single WSL `-EncodedCommand` call site.
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    not(target_os = "macos"),
+    not(target_os = "windows")
+))]
+fn base64_encode(input: &[u8]) -> String {
+    const TABLE: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+    let mut out = String::with_capacity(input.len().div_ceil(3) * 4);
+    for chunk in input.chunks(3) {
+        let b0 = chunk[0] as u32;
+        let b1 = *chunk.get(1).unwrap_or(&0) as u32;
+        let b2 = *chunk.get(2).unwrap_or(&0) as u32;
+        let n = (b0 << 16) | (b1 << 8) | b2;
+        out.push(TABLE[((n >> 18) & 63) as usize] as char);
+        out.push(TABLE[((n >> 12) & 63) as usize] as char);
+        out.push(if chunk.len() > 1 {
+            TABLE[((n >> 6) & 63) as usize] as char
+        } else {
+            '='
+        });
+        out.push(if chunk.len() > 2 {
+            TABLE[(n & 63) as usize] as char
+        } else {
+            '='
+        });
+    }
+    out
+}
+
+#[cfg(all(
+    test,
+    not(target_arch = "wasm32"),
+    not(target_os = "macos"),
+    not(target_os = "windows")
+))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn base64_matches_known_vectors() {
+        assert_eq!(base64_encode(b""), "");
+        assert_eq!(base64_encode(b"f"), "Zg==");
+        assert_eq!(base64_encode(b"fo"), "Zm8=");
+        assert_eq!(base64_encode(b"foo"), "Zm9v");
+        assert_eq!(base64_encode(b"foob"), "Zm9vYg==");
+        assert_eq!(base64_encode(b"fooba"), "Zm9vYmE=");
+        assert_eq!(base64_encode(b"foobar"), "Zm9vYmFy");
+    }
+
+    #[test]
+    fn wsl_command_encodes_url_without_leaking_metacharacters() {
+        // A URL with `&` (cmd separator) and a single quote must round-trip
+        // through the encoded command untouched — the raw URL must never appear
+        // as a plain argument.
+        let url = "https://cloud.nx.app/connect?a=1&b=2&x='y";
+        let cmd = windows_browser_command(url);
+        let args: Vec<String> = cmd
+            .get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect();
+        assert_eq!(cmd.get_program(), "powershell.exe");
+        assert!(args.iter().any(|a| a == "-EncodedCommand"));
+        // No argument carries the raw URL or a bare `&`.
+        assert!(!args.iter().any(|a| a.contains("://")));
+        assert!(!args.iter().any(|a| a.contains('&')));
+
+        // The encoded payload decodes back to a single-quoted Start-Process
+        // with the quote doubled.
+        let encoded = args.last().unwrap();
+        let bytes = decode_base64(encoded);
+        let utf16: Vec<u16> = bytes
+            .chunks(2)
+            .map(|p| u16::from_le_bytes([p[0], p[1]]))
+            .collect();
+        let script = String::from_utf16(&utf16).unwrap();
+        assert_eq!(
+            script,
+            "Start-Process 'https://cloud.nx.app/connect?a=1&b=2&x=''y'"
+        );
+    }
+
+    // Test-only decoder to verify the encoder.
+    #[cfg(test)]
+    fn decode_base64(s: &str) -> Vec<u8> {
+        fn val(c: u8) -> Option<u32> {
+            match c {
+                b'A'..=b'Z' => Some((c - b'A') as u32),
+                b'a'..=b'z' => Some((c - b'a' + 26) as u32),
+                b'0'..=b'9' => Some((c - b'0' + 52) as u32),
+                b'+' => Some(62),
+                b'/' => Some(63),
+                _ => None,
+            }
+        }
+        let bytes: Vec<u8> = s.bytes().filter(|&c| c != b'=').collect();
+        let mut out = Vec::new();
+        for chunk in bytes.chunks(4) {
+            let mut n = 0u32;
+            let mut count = 0;
+            for &c in chunk {
+                n = (n << 6) | val(c).unwrap();
+                count += 1;
+            }
+            n <<= 6 * (4 - count);
+            if count >= 2 {
+                out.push((n >> 16) as u8);
+            }
+            if count >= 3 {
+                out.push((n >> 8) as u8);
+            }
+            if count >= 4 {
+                out.push(n as u8);
+            }
+        }
+        out
+    }
+}

--- a/packages/nx/src/native/utils/open_url.rs
+++ b/packages/nx/src/native/utils/open_url.rs
@@ -18,6 +18,16 @@ pub fn open_url(url: String) -> bool {
     open_url_native(&url)
 }
 
+/// wasm can't spawn a child process, so opening a browser is a no-op there. This
+/// stub keeps `openUrl` exported on the wasm binding, so JS callers get the
+/// documented `false` ("couldn't open") instead of a `TypeError` from calling a
+/// missing export.
+#[cfg(target_arch = "wasm32")]
+#[napi]
+pub fn open_url(_url: String) -> bool {
+    false
+}
+
 /// Rust-facing entry point (the napi wrapper just forwards a `String`). Callers
 /// inside the native crate — e.g. the TUI — use this directly.
 #[cfg(not(target_arch = "wasm32"))]
@@ -41,10 +51,11 @@ fn build_open_command(url: &str) -> Command {
 
 #[cfg(all(not(target_arch = "wasm32"), target_os = "windows"))]
 fn build_open_command(url: &str) -> Command {
-    let mut c = Command::new("cmd");
-    // The empty "" is the window-title argument `start` expects first.
-    c.args(["/C", "start", "", url]);
-    c
+    // Use PowerShell's Start-Process with the URL as a base64 -EncodedCommand
+    // rather than `cmd /C start "" <url>`: std spawns the URL unquoted, and
+    // `cmd` treats a `&` in a query string as a command separator, which both
+    // truncates real cloud/release URLs and is a command-injection sink.
+    powershell_start_process(url)
 }
 
 #[cfg(all(
@@ -59,7 +70,7 @@ fn build_open_command(url: &str) -> Command {
     // it is exactly the crash this replaces (`open@8` misdetected Podman as
     // bare WSL) — so containers must stay on `xdg-open`.
     if is_wsl2() && !is_in_container() {
-        windows_browser_command(url)
+        powershell_start_process(url)
     } else {
         let mut c = Command::new("xdg-open");
         c.arg(url);
@@ -83,7 +94,7 @@ fn is_wsl2() -> bool {
     })
 }
 
-/// Detects an OCI container (Docker `/​.dockerenv`, or Podman
+/// Detects an OCI container (Docker `/.dockerenv`, or Podman
 /// `/run/.containerenv`). This is the marker `open@8`'s `is-docker` missed for
 /// Podman, causing the original crash.
 #[cfg(all(
@@ -99,17 +110,14 @@ fn is_in_container() -> bool {
     })
 }
 
-/// Launch the Windows browser from WSL via the host PowerShell. The URL is
-/// handed over as a base64 UTF-16LE `-EncodedCommand` (the same mechanism the
-/// `open` package used) so shell metacharacters — notably `&` in a query
-/// string, a `cmd.exe` separator — can neither break the command line nor
-/// inject anything: the URL never appears on a command line as text.
-#[cfg(all(
-    not(target_arch = "wasm32"),
-    not(target_os = "macos"),
-    not(target_os = "windows")
-))]
-fn windows_browser_command(url: &str) -> Command {
+/// Launch the default browser via the Windows host PowerShell — used on native
+/// Windows and, through WSL interop, on non-container WSL2. The URL is handed
+/// over as a base64 UTF-16LE `-EncodedCommand` (the same mechanism the `open`
+/// package used) so shell metacharacters — notably `&` in a query string, a
+/// `cmd.exe` separator — can neither break the command line nor inject
+/// anything: the URL never appears on a command line as text.
+#[cfg(all(not(target_arch = "wasm32"), not(target_os = "macos")))]
+fn powershell_start_process(url: &str) -> Command {
     // Single-quoted PowerShell literal; the only in-literal escape is a single
     // quote, doubled.
     let script = format!("Start-Process '{}'", url.replace('\'', "''"));
@@ -128,12 +136,8 @@ fn windows_browser_command(url: &str) -> Command {
 }
 
 /// Minimal standard-alphabet base64 encoder (padded). Kept local to avoid a new
-/// crate dependency for the single WSL `-EncodedCommand` call site.
-#[cfg(all(
-    not(target_arch = "wasm32"),
-    not(target_os = "macos"),
-    not(target_os = "windows")
-))]
+/// crate dependency for the `-EncodedCommand` call site.
+#[cfg(all(not(target_arch = "wasm32"), not(target_os = "macos")))]
 fn base64_encode(input: &[u8]) -> String {
     const TABLE: &[u8; 64] = b"ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
     let mut out = String::with_capacity(input.len().div_ceil(3) * 4);
@@ -179,12 +183,12 @@ mod tests {
     }
 
     #[test]
-    fn wsl_command_encodes_url_without_leaking_metacharacters() {
+    fn powershell_command_encodes_url_without_leaking_metacharacters() {
         // A URL with `&` (cmd separator) and a single quote must round-trip
         // through the encoded command untouched — the raw URL must never appear
         // as a plain argument.
         let url = "https://cloud.nx.app/connect?a=1&b=2&x='y";
-        let cmd = windows_browser_command(url);
+        let cmd = powershell_start_process(url);
         let args: Vec<String> = cmd
             .get_args()
             .map(|a| a.to_string_lossy().into_owned())

--- a/packages/nx/src/native/utils/open_url.rs
+++ b/packages/nx/src/native/utils/open_url.rs
@@ -69,7 +69,7 @@ fn build_open_command(url: &str) -> Command {
     // Docker/Podman container the Windows interop path is absent and spawning
     // it is exactly the crash this replaces (`open@8` misdetected Podman as
     // bare WSL) — so containers must stay on `xdg-open`.
-    if is_wsl2() && !is_in_container() {
+    if is_wsl() && !is_in_container() {
         powershell_start_process(url)
     } else {
         let mut c = Command::new("xdg-open");
@@ -78,20 +78,32 @@ fn build_open_command(url: &str) -> Command {
     }
 }
 
-/// WSL2 has "WSL2" in `/proc/version`; WSL1's interop differs and is not
-/// targeted (its `xdg-open` path is left as the default fallback).
+/// Both WSL1 and WSL2 register a `WSLInterop` binfmt entry, so `powershell.exe`
+/// is launchable from either — hence no WSL1/WSL2 distinction here. Matches the
+/// `is-wsl` package (which the replaced `open` used) so no WSL flavour loses the
+/// Windows bridge. If interop is disabled via `wsl.conf`, the spawn simply fails
+/// and the caller falls back to printing the URL.
 #[cfg(all(
     not(target_arch = "wasm32"),
     not(target_os = "macos"),
     not(target_os = "windows")
 ))]
-fn is_wsl2() -> bool {
-    static IS_WSL2: OnceLock<bool> = OnceLock::new();
-    *IS_WSL2.get_or_init(|| {
+fn is_wsl() -> bool {
+    static IS_WSL: OnceLock<bool> = OnceLock::new();
+    *IS_WSL.get_or_init(|| {
         std::fs::read_to_string("/proc/version")
-            .map(|contents| contents.contains("WSL2"))
+            .map(|contents| proc_version_is_wsl(&contents))
             .unwrap_or(false)
     })
+}
+
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    not(target_os = "macos"),
+    not(target_os = "windows")
+))]
+fn proc_version_is_wsl(proc_version: &str) -> bool {
+    proc_version.to_lowercase().contains("microsoft")
 }
 
 /// Detects an OCI container (Docker `/.dockerenv`, or Podman
@@ -180,6 +192,23 @@ mod tests {
         assert_eq!(base64_encode(b"foob"), "Zm9vYg==");
         assert_eq!(base64_encode(b"fooba"), "Zm9vYmE=");
         assert_eq!(base64_encode(b"foobar"), "Zm9vYmFy");
+    }
+
+    #[test]
+    fn detects_both_wsl1_and_wsl2_but_not_plain_linux() {
+        // WSL1 and WSL2 both support Windows interop, so both must take the
+        // bridge. Real /proc/version strings: WSL1 capitalizes "Microsoft",
+        // WSL2 is lowercase in "microsoft-standard-WSL2".
+        let wsl1 = "Linux version 4.4.0-19041-Microsoft (Microsoft@Microsoft.com) \
+                    (gcc version 5.4.0 (GCC) ) #1237-Microsoft Sat Sep 11 14:32:00 PST 2021";
+        let wsl2 = "Linux version 5.15.90.1-microsoft-standard-WSL2 (oe-user@oe-host) \
+                    (gcc (GCC) 9.3.0) #1 SMP Fri Jan 27 02:56:13 UTC 2023";
+        let plain = "Linux version 6.1.0-18-amd64 (debian-kernel@lists.debian.org) \
+                     (gcc-12 (Debian 12.2.0-14) 12.2.0) #1 SMP PREEMPT_DYNAMIC Debian";
+
+        assert!(proc_version_is_wsl(wsl1));
+        assert!(proc_version_is_wsl(wsl2));
+        assert!(!proc_version_is_wsl(plain));
     }
 
     #[test]

--- a/packages/nx/src/native/utils/open_url.rs
+++ b/packages/nx/src/native/utils/open_url.rs
@@ -82,7 +82,7 @@ fn open_candidates(url: &str) -> Vec<Command> {
     // PowerShell rather than `cmd /C start "" <url>`: std leaves a URL unquoted
     // (it only quotes args with whitespace or quotes) and `cmd` reads the `&` in
     // a query string as a command separator.
-    vec![powershell_start_process("powershell.exe", url)]
+    vec![powershell_start_process(url)]
 }
 
 #[cfg(all(
@@ -92,10 +92,21 @@ fn open_candidates(url: &str) -> Vec<Command> {
 ))]
 fn open_candidates(url: &str) -> Vec<Command> {
     candidates_for(
-        is_wsl() && !is_in_container(),
+        use_windows_bridge(is_wsl(), is_in_container()),
         &std::env::var("BROWSER").unwrap_or_default(),
         url,
     )
+}
+
+/// #34502 was this predicate getting the container case wrong, so it is a named
+/// function rather than an inline `&&` — otherwise nothing can assert it.
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    not(target_os = "macos"),
+    not(target_os = "windows")
+))]
+fn use_windows_bridge(is_wsl: bool, in_container: bool) -> bool {
+    is_wsl && !in_container
 }
 
 /// Split from `open_candidates` so the two probes it can't fake — the WSL gate
@@ -113,10 +124,16 @@ fn candidates_for(use_windows_bridge: bool, browser: &str, url: &str) -> Vec<Com
     // (`open@8` misdetected Podman as bare WSL) — containers stay on the Linux
     // openers below.
     if use_windows_bridge {
-        // Off `PATH` when WSL's `[interop] appendWindowsPath` is disabled; that
-        // host falls through to the Linux openers below rather than resolving an
-        // absolute System32 path, so a browser still opens, just inside the distro.
-        candidates.push(powershell_start_process("powershell.exe", url));
+        candidates.push(powershell_start_process(url));
+        // `[interop] appendWindowsPath=false` takes powershell.exe off PATH while
+        // leaving interop working, and a stock WSL distro has no browser of its
+        // own to fall through to. `/mnt/` is the default `[automount] root`; a
+        // custom one isn't worth parsing wsl.conf for, since the candidate simply
+        // fails to spawn when the path is wrong.
+        candidates.push(powershell_start_process_at(
+            "/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe",
+            url,
+        ));
     }
     // Always fall through to the Linux openers: WSL interop can be off, and a
     // browser installed inside the distro still works.
@@ -151,9 +168,11 @@ fn proc_version_is_wsl(proc_version: &str) -> bool {
     proc_version.to_lowercase().contains("microsoft")
 }
 
-/// `/run/.containerenv` is the Podman marker `open@8`'s `is-docker` missed,
-/// which is what let #34502 take the WSL bridge and crash. A const so a test can
-/// assert it without a container to run in.
+/// `/run/.containerenv` is the Podman marker that let #34502 take the WSL bridge
+/// and crash. `open@8` did probe for it, but destructured `fs` from
+/// `require('fs').promises` and then called `fs.statSync`, so the probe threw
+/// into its own empty catch and only `is-docker`'s `/.dockerenv` ever counted.
+/// A const so a test can assert both without a container to run in.
 #[cfg(all(
     not(target_arch = "wasm32"),
     not(target_os = "macos"),
@@ -168,22 +187,33 @@ const CONTAINER_MARKERS: &[&str] = &["/.dockerenv", "/run/.containerenv"];
 ))]
 fn is_in_container() -> bool {
     static IN_CONTAINER: OnceLock<bool> = OnceLock::new();
-    *IN_CONTAINER.get_or_init(|| {
-        CONTAINER_MARKERS
-            .iter()
-            .any(|m| std::path::Path::new(m).exists())
-    })
+    *IN_CONTAINER.get_or_init(|| any_marker_exists(CONTAINER_MARKERS))
 }
 
-/// `xdg-open` leads because it is the standard entry point and dispatches to
-/// whatever handler the desktop has. `$BROWSER` is the documented override, but
-/// it only gets a turn once `xdg-open` is missing — `xdg-open` consults it
-/// itself, and trying it first would let `BROWSER=echo` (a common way to
-/// suppress auto-open) spawn happily and report a browser that never appeared.
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    not(target_os = "macos"),
+    not(target_os = "windows")
+))]
+fn any_marker_exists(markers: &[&str]) -> bool {
+    markers.iter().any(|m| std::path::Path::new(m).exists())
+}
+
+/// `xdg-open` leads: it is the standard entry point, and on a host with no
+/// desktop detected it consults `$BROWSER` itself. Our own `$BROWSER` rung is
+/// what covers the case where `xdg-open` is absent entirely. Trying it first
+/// instead would let `BROWSER=echo` (a common way to suppress auto-open) spawn
+/// happily and report a browser that never appeared.
 ///
-/// Deliberately no further rungs. A candidate only loses its turn by failing to
-/// spawn, so a terminal browser would "succeed" against the null stdio
-/// `spawn_detached` sets while rendering nowhere the user can see.
+/// Deliberately no rungs below these two. A candidate only loses its turn by
+/// failing to spawn, so anything that spawns and then declines to open — a
+/// desktop dispatcher with no handler, a terminal browser against the null stdio
+/// `spawn_detached` sets — buys a false `true` rather than a browser. `$BROWSER`
+/// is exempt because it is the user saying which program they meant.
+///
+/// The cost: a host with a browser but without `xdg-utils` used to be covered by
+/// the `open` package, which shipped its own copy of the freedesktop script
+/// rather than relying on the system one. That host now gets the printed URL.
 #[cfg(all(
     not(target_arch = "wasm32"),
     not(target_os = "macos"),
@@ -241,7 +271,14 @@ fn browser_env_candidates(browser: &str, url: &str) -> Vec<Command> {
 /// `-EncodedCommand`, so UTF-16LE here would cost 7.1 command-line bytes per URL
 /// byte against `CreateProcessW`'s 32767 cap — halving the openable URL.
 #[cfg(all(not(target_arch = "wasm32"), not(target_os = "macos")))]
-fn powershell_start_process(program: &str, url: &str) -> Command {
+fn powershell_start_process(url: &str) -> Command {
+    powershell_start_process_at("powershell.exe", url)
+}
+
+/// As above, but naming the interpreter — WSL needs an absolute path when
+/// `appendWindowsPath` is off.
+#[cfg(all(not(target_arch = "wasm32"), not(target_os = "macos")))]
+fn powershell_start_process_at(program: &str, url: &str) -> Command {
     let script = format!(
         "Start-Process ([Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('{}')))",
         base64_encode(url.as_bytes())
@@ -362,6 +399,8 @@ mod tests {
         assert!(!is_http_url("file:///etc/passwd"));
         assert!(!is_http_url("javascript:alert(1)"));
         assert!(!is_http_url(" http://leading-space.example"));
+        // Prefix, not substring — the scheme has to be exactly http(s).
+        assert!(!is_http_url("httpx://evil.example"));
         assert!(!open_url_native("calc.exe"));
     }
 
@@ -369,11 +408,11 @@ mod tests {
     fn powershell_carries_the_url_as_base64_not_as_a_quoted_literal() {
         // Every character PowerShell accepts as a single-quote delimiter, plus a
         // `&` (cmd separator). None may reach the command line or the script.
-        // The astral char pins the multi-byte round trip the UTF-8 payload rests
-        // on — it is two UTF-16 units, so an encoder split would corrupt it.
+        // The astral char rides the UTF-8 payload; `utf16le` never sees it, since
+        // the script is ASCII by the time it is encoded (asserted separately).
         let url =
             "https://cloud.nx.app/connect?a=1&b=2&q='\u{2018}\u{2019}\u{201A}\u{201B}\u{1F680}";
-        let cmd = powershell_start_process("powershell.exe", url);
+        let cmd = powershell_start_process(url);
         let args = args_of(&cmd);
 
         assert_eq!(cmd.get_program(), "powershell.exe");
@@ -404,15 +443,24 @@ mod tests {
             "https://github.com/nrwl/nx/releases/new?body={}",
             "a".repeat(8000)
         );
-        let cmd = powershell_start_process("powershell.exe", &url);
+        let cmd = powershell_start_process(&url);
         let line: usize =
             cmd.get_program().len() + args_of(&cmd).iter().map(|a| a.len() + 1).sum::<usize>();
         assert!(line < 32767, "command line was {line} chars");
     }
 
     #[test]
+    fn utf16le_emits_surrogate_pairs_for_astral_chars() {
+        // `-EncodedCommand` is UTF-16LE, so a `char as u16` encoder would silently
+        // truncate anything outside the BMP. ASCII today, but the outer layer is
+        // the only place a non-ASCII script could ever reach.
+        assert_eq!(utf16le("\u{1F680}"), vec![0x3D, 0xD8, 0x80, 0xDE]);
+        assert_eq!(utf16le("ab"), vec![0x61, 0x00, 0x62, 0x00]);
+    }
+
+    #[test]
     fn execution_policy_is_bypassed_for_gpo_locked_hosts() {
-        let cmd = powershell_start_process("powershell.exe", "https://nx.dev");
+        let cmd = powershell_start_process("https://nx.dev");
         let args = args_of(&cmd);
         let idx = args.iter().position(|a| a == "-ExecutionPolicy").unwrap();
         assert_eq!(args[idx + 1], "Bypass");
@@ -425,15 +473,33 @@ mod tests {
         let cmds = linux_open_candidates("", "https://nx.dev");
         assert_eq!(programs_of(&cmds), ["xdg-open"]);
         assert_eq!(args_of(&cmds[0]), vec!["https://nx.dev"]);
+
+        // With one set, it follows `xdg-open` rather than leading — and nothing
+        // else joins the chain.
+        let cmds = linux_open_candidates("firefox", "https://nx.dev");
+        assert_eq!(programs_of(&cmds), ["xdg-open", "firefox"]);
     }
 
     #[test]
     fn podman_and_docker_markers_are_both_probed() {
-        // #34502: `open@8`'s `is-docker` only looked for /.dockerenv, so Podman
-        // took the WSL bridge and crashed. Asserted on the const because a test
-        // process can't fake either marker's presence.
+        // #34502: only /.dockerenv was effectively checked, so Podman took the
+        // WSL bridge and crashed. A test process can't fake either marker, so
+        // assert the list and the probe that walks it separately.
         assert!(CONTAINER_MARKERS.contains(&"/run/.containerenv"));
         assert!(CONTAINER_MARKERS.contains(&"/.dockerenv"));
+        // `/` always exists, so a probe that stops at the first entry fails here.
+        assert!(any_marker_exists(&["/nx-no-such-marker", "/"]));
+        assert!(!any_marker_exists(&["/nx-no-such-marker"]));
+    }
+
+    #[test]
+    fn the_windows_bridge_is_gated_on_wsl_outside_a_container() {
+        // The whole of #34502 is this predicate: Podman-on-WSL is both, and must
+        // not take the bridge.
+        assert!(use_windows_bridge(true, false));
+        assert!(!use_windows_bridge(true, true));
+        assert!(!use_windows_bridge(false, false));
+        assert!(!use_windows_bridge(false, true));
     }
 
     #[test]
@@ -460,10 +526,17 @@ mod tests {
         assert!(!in_container.iter().any(|p| p.contains("powershell")));
         assert_eq!(in_container[0], "xdg-open");
 
-        // On a real WSL host the bridge leads, but the Linux openers still
-        // follow it — interop can be off, and that must not dead-end.
+        // On a real WSL host the bridge leads — bare name first, then the default
+        // automount path for hosts that keep powershell.exe off PATH. The `.exe`
+        // is load-bearing: binfmt interop only resolves Windows binaries with it.
         let on_wsl = programs_of(&candidates_for(true, "", "https://nx.dev"));
-        assert!(on_wsl[0].contains("powershell"));
+        assert_eq!(on_wsl[0], "powershell.exe");
+        assert_eq!(
+            on_wsl[1],
+            "/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe"
+        );
+        // The Linux openers still follow — interop can be off, and that must not
+        // dead-end.
         assert!(on_wsl.iter().any(|p| p == "xdg-open"));
     }
 

--- a/packages/nx/src/native/utils/open_url.rs
+++ b/packages/nx/src/native/utils/open_url.rs
@@ -91,13 +91,28 @@ fn open_candidates(url: &str) -> Vec<Command> {
     not(target_os = "windows")
 ))]
 fn open_candidates(url: &str) -> Vec<Command> {
+    candidates_for(
+        is_wsl() && !is_in_container(),
+        &std::env::var("BROWSER").unwrap_or_default(),
+        url,
+    )
+}
+
+/// Split from `open_candidates` so the two probes it can't fake — the WSL gate
+/// and `$BROWSER` — become test inputs.
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    not(target_os = "macos"),
+    not(target_os = "windows")
+))]
+fn candidates_for(use_windows_bridge: bool, browser: &str, url: &str) -> Vec<Command> {
     let mut candidates = Vec::new();
     // On a non-container WSL host the Linux openers can't reach a browser, so
     // try the Windows host's browser first. Inside a Docker/Podman container the
     // interop path is absent and spawning it is exactly the crash this replaces
     // (`open@8` misdetected Podman as bare WSL) — containers stay on the Linux
     // openers below.
-    if is_wsl() && !is_in_container() {
+    if use_windows_bridge {
         candidates.extend(
             wsl_powershell_programs()
                 .iter()
@@ -106,7 +121,7 @@ fn open_candidates(url: &str) -> Vec<Command> {
     }
     // Always fall through to the Linux openers: WSL interop can be off, and a
     // browser installed inside the distro still works.
-    candidates.extend(linux_open_candidates(url));
+    candidates.extend(linux_open_candidates(browser, url));
     candidates
 }
 
@@ -228,17 +243,16 @@ fn parse_automount_root(wsl_conf: &str) -> Option<String> {
     None
 }
 
-/// The opener chain `open@10` shipped: it vendored the freedesktop `xdg-open`
-/// script, which walks `$BROWSER` and then these desktop helpers. Trying only
-/// the system `xdg-open` loses the browser on minimal images, headless server
-/// distros and Termux, where it often isn't installed.
+/// The helpers `open@10`'s vendored freedesktop script falls through once
+/// `xdg-open` itself is unavailable. Trying only the system `xdg-open` loses the
+/// browser on minimal images, headless server distros and Termux, where it often
+/// isn't installed.
 #[cfg(all(
     not(target_arch = "wasm32"),
     not(target_os = "macos"),
     not(target_os = "windows")
 ))]
-const LINUX_OPENERS: &[&[&str]] = &[
-    &["xdg-open"],
+const FALLBACK_OPENERS: &[&[&str]] = &[
     &["gio", "open"],
     &["gvfs-open"],
     &["gnome-open"],
@@ -248,21 +262,37 @@ const LINUX_OPENERS: &[&[&str]] = &[
     &["www-browser"],
 ];
 
+/// `xdg-open` first, because it dispatches to the desktop's own handler — the
+/// branch the vendored script took whenever it detected a desktop environment.
+/// `$BROWSER` is consulted only after that, mirroring the script's `open_generic`
+/// path: putting it first would let `BROWSER=echo` (a common way to suppress
+/// auto-open) spawn successfully on a desktop and report a browser that never
+/// appeared, since a candidate only loses its turn by failing to spawn.
 #[cfg(all(
     not(target_arch = "wasm32"),
     not(target_os = "macos"),
     not(target_os = "windows")
 ))]
-fn linux_open_candidates(url: &str) -> Vec<Command> {
-    let browser = std::env::var("BROWSER").unwrap_or_default();
-    browser_env_candidates(&browser, url)
-        .into_iter()
-        .chain(LINUX_OPENERS.iter().map(|parts| {
-            let mut c = create_command(parts[0]);
-            c.args(&parts[1..]).arg(url);
-            c
-        }))
-        .collect()
+fn linux_open_candidates(browser: &str, url: &str) -> Vec<Command> {
+    let mut candidates = vec![opener_command(&["xdg-open"], url)];
+    candidates.extend(browser_env_candidates(browser, url));
+    candidates.extend(
+        FALLBACK_OPENERS
+            .iter()
+            .map(|parts| opener_command(parts, url)),
+    );
+    candidates
+}
+
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    not(target_os = "macos"),
+    not(target_os = "windows")
+))]
+fn opener_command(parts: &[&str], url: &str) -> Command {
+    let mut c = create_command(parts[0]);
+    c.args(&parts[1..]).arg(url);
+    c
 }
 
 /// `$BROWSER` is a colon-separated list of commands, each either a plain program
@@ -305,11 +335,17 @@ fn browser_env_candidates(browser: &str, url: &str) -> Vec<Command> {
 /// `U+2018`–`U+201B`) and lets any of them close a literal any other opened, so
 /// escaping by doubling the ASCII quote is not sufficient; base64's alphabet
 /// can't express a quote at all.
+///
+/// The inner payload is UTF-8, not UTF-16LE: both round-trip any URL, but the
+/// script is base64'd a second time for `-EncodedCommand`, so an inner UTF-16LE
+/// layer costs 7.1 bytes of command line per URL byte against `CreateProcessW`'s
+/// 32767 cap. `nx release` embeds a whole changelog in a GitHub URL, which put
+/// the ceiling under the size real changelogs reach.
 #[cfg(all(not(target_arch = "wasm32"), not(target_os = "macos")))]
 fn powershell_start_process(program: &str, url: &str) -> Command {
     let script = format!(
-        "Start-Process ([Text.Encoding]::Unicode.GetString([Convert]::FromBase64String('{}')))",
-        base64_encode(&utf16le(url))
+        "Start-Process ([Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('{}')))",
+        base64_encode(url.as_bytes())
     );
     let mut c = create_command(program);
     c.args([
@@ -448,19 +484,29 @@ mod tests {
         let script = decode_powershell_script(&cmd);
         let payload = script
             .strip_prefix(
-                "Start-Process ([Text.Encoding]::Unicode.GetString([Convert]::FromBase64String('",
+                "Start-Process ([Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('",
             )
             .and_then(|s| s.strip_suffix("')))"))
             .expect("script shape");
         assert!(!payload.contains(['\'', '\u{2018}', '\u{2019}', '\u{201A}', '\u{201B}']));
 
         // ...and decodes back to exactly the URL we were handed.
-        let bytes = decode_base64(payload);
-        let utf16: Vec<u16> = bytes
-            .chunks(2)
-            .map(|p| u16::from_le_bytes([p[0], p[1]]))
-            .collect();
-        assert_eq!(String::from_utf16(&utf16).unwrap(), url);
+        assert_eq!(String::from_utf8(decode_base64(payload)).unwrap(), url);
+    }
+
+    #[test]
+    fn command_line_stays_under_the_windows_cap_for_a_changelog_sized_url() {
+        // `nx release` without a token opens a GitHub "new release" URL with the
+        // whole percent-encoded changelog in the query string. Two base64 layers
+        // multiply that against CreateProcessW's 32767-char limit.
+        let url = format!(
+            "https://github.com/nrwl/nx/releases/new?body={}",
+            "a".repeat(8000)
+        );
+        let cmd = powershell_start_process("powershell.exe", &url);
+        let line: usize =
+            cmd.get_program().len() + args_of(&cmd).iter().map(|a| a.len() + 1).sum::<usize>();
+        assert!(line < 32767, "command line was {line} chars");
     }
 
     #[test]
@@ -473,23 +519,56 @@ mod tests {
 
     #[test]
     fn linux_falls_back_through_the_whole_opener_chain() {
-        let programs = programs_of(&linux_open_candidates("https://nx.dev"));
-        // `xdg-open` is only the first guess; the desktop helpers `open@10`
-        // vendored must still be reachable.
-        assert_eq!(programs[0], "xdg-open");
-        for expected in ["gio", "gvfs-open", "gnome-open", "kde-open", "exo-open"] {
-            assert!(programs.contains(&expected.to_string()), "{expected}");
-        }
+        // `$BROWSER` is passed in, never read from the environment, so this holds
+        // on a machine that has one set (Codespaces and VS Code Remote do).
+        let cmds = linux_open_candidates("", "https://nx.dev");
+        assert_eq!(
+            programs_of(&cmds),
+            [
+                "xdg-open",
+                "gio",
+                "gvfs-open",
+                "gnome-open",
+                "kde-open",
+                "exo-open",
+                "x-www-browser",
+                "www-browser"
+            ]
+        );
+        // `gio` needs its `open` subcommand — dropping it still spawns, so the
+        // chain would report success while nothing opened.
+        assert_eq!(args_of(&cmds[1]), vec!["open", "https://nx.dev"]);
     }
 
     #[test]
-    fn browser_env_entries_come_first_and_honor_the_s_placeholder() {
+    fn browser_env_entries_sit_behind_xdg_open_and_honor_the_s_placeholder() {
         let cmds = browser_env_candidates("firefox:my-opener --url=%s", "https://nx.dev");
         assert_eq!(programs_of(&cmds), vec!["firefox", "my-opener"]);
         // No placeholder: the URL is appended. With one: it's substituted.
         assert_eq!(args_of(&cmds[0]), vec!["https://nx.dev"]);
         assert_eq!(args_of(&cmds[1]), vec!["--url=https://nx.dev"]);
         assert!(browser_env_candidates("", "https://nx.dev").is_empty());
+
+        // `xdg-open` dispatches to the desktop's own handler, so it outranks
+        // `$BROWSER`; otherwise `BROWSER=echo` would "succeed" with no browser.
+        let chain = programs_of(&linux_open_candidates("echo", "https://nx.dev"));
+        assert_eq!(chain[0], "xdg-open");
+        assert_eq!(chain[1], "echo");
+    }
+
+    #[test]
+    fn the_windows_bridge_is_skipped_inside_a_container() {
+        // The #34502 crash was spawning powershell.exe from a Podman-on-WSL
+        // container, so the container arm must offer no PowerShell candidate.
+        let in_container = programs_of(&candidates_for(false, "", "https://nx.dev"));
+        assert!(!in_container.iter().any(|p| p.contains("powershell")));
+        assert_eq!(in_container[0], "xdg-open");
+
+        // On a real WSL host the bridge leads, but the Linux openers still
+        // follow it — interop can be off, and that must not dead-end.
+        let on_wsl = programs_of(&candidates_for(true, "", "https://nx.dev"));
+        assert!(on_wsl[0].contains("powershell"));
+        assert!(on_wsl.iter().any(|p| p == "xdg-open"));
     }
 
     #[test]

--- a/packages/nx/src/native/utils/open_url.rs
+++ b/packages/nx/src/native/utils/open_url.rs
@@ -5,13 +5,20 @@
 //! caller can fall back to printing the URL.
 
 #[cfg(not(target_arch = "wasm32"))]
-use std::process::{Command, Stdio};
+use crate::native::utils::command::create_command;
 #[cfg(not(target_arch = "wasm32"))]
+use std::process::{Command, Stdio};
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    not(target_os = "macos"),
+    not(target_os = "windows")
+))]
 use std::sync::OnceLock;
 
 /// Open `url` in the user's default browser. Returns `true` if an opener
-/// process was spawned, `false` if it couldn't be (e.g. no `xdg-open`), so the
-/// caller can tell the user instead of failing silently. Never throws.
+/// process was spawned, `false` if none could be (e.g. no `xdg-open`) or `url`
+/// isn't `http(s)`, so the caller can tell the user instead of failing
+/// silently. Never throws.
 #[cfg(not(target_arch = "wasm32"))]
 #[napi]
 pub fn open_url(url: String) -> bool {
@@ -32,7 +39,28 @@ pub fn open_url(_url: String) -> bool {
 /// inside the native crate — e.g. the TUI — use this directly.
 #[cfg(not(target_arch = "wasm32"))]
 pub fn open_url_native(url: &str) -> bool {
-    build_open_command(url)
+    if !is_http_url(url) {
+        return false;
+    }
+    open_candidates(url).into_iter().any(spawn_detached)
+}
+
+/// Openers take whatever string they're handed and will launch a local program
+/// as readily as a browser, so anything that isn't `http(s)` is refused here.
+/// URLs reach this from remote responses (Nx Cloud, GitHub/GitLab hosts) and
+/// from task output the TUI turns into clickable links.
+#[cfg(not(target_arch = "wasm32"))]
+fn is_http_url(url: &str) -> bool {
+    let lower = url.to_ascii_lowercase();
+    lower.starts_with("http://") || lower.starts_with("https://")
+}
+
+/// A spawn succeeds when the opener *binary* exists; we deliberately don't wait
+/// on it, since an opener that hands off to a browser may not exit until the
+/// browser does.
+#[cfg(not(target_arch = "wasm32"))]
+fn spawn_detached(mut command: Command) -> bool {
+    command
         .stdin(Stdio::null())
         // Detach stdio to null so a launched opener can't corrupt a terminal
         // we may be drawing to (the TUI).
@@ -43,19 +71,18 @@ pub fn open_url_native(url: &str) -> bool {
 }
 
 #[cfg(all(not(target_arch = "wasm32"), target_os = "macos"))]
-fn build_open_command(url: &str) -> Command {
-    let mut c = Command::new("open");
+fn open_candidates(url: &str) -> Vec<Command> {
+    let mut c = create_command("open");
     c.arg(url);
-    c
+    vec![c]
 }
 
 #[cfg(all(not(target_arch = "wasm32"), target_os = "windows"))]
-fn build_open_command(url: &str) -> Command {
-    // Use PowerShell's Start-Process with the URL as a base64 -EncodedCommand
-    // rather than `cmd /C start "" <url>`: std spawns the URL unquoted, and
-    // `cmd` treats a `&` in a query string as a command separator, which both
-    // truncates real cloud/release URLs and is a command-injection sink.
-    powershell_start_process(url)
+fn open_candidates(url: &str) -> Vec<Command> {
+    // PowerShell rather than `cmd /C start "" <url>`: std leaves a URL unquoted
+    // (it only quotes args with whitespace or quotes) and `cmd` reads the `&` in
+    // a query string as a command separator.
+    vec![powershell_start_process("powershell.exe", url)]
 }
 
 #[cfg(all(
@@ -63,26 +90,30 @@ fn build_open_command(url: &str) -> Command {
     not(target_os = "macos"),
     not(target_os = "windows")
 ))]
-fn build_open_command(url: &str) -> Command {
-    // On a non-container WSL2 host the Linux `xdg-open` usually can't reach a
-    // browser, so hand the URL to the *Windows* host browser. Inside a
-    // Docker/Podman container the Windows interop path is absent and spawning
-    // it is exactly the crash this replaces (`open@8` misdetected Podman as
-    // bare WSL) — so containers must stay on `xdg-open`.
+fn open_candidates(url: &str) -> Vec<Command> {
+    let mut candidates = Vec::new();
+    // On a non-container WSL host the Linux openers can't reach a browser, so
+    // try the Windows host's browser first. Inside a Docker/Podman container the
+    // interop path is absent and spawning it is exactly the crash this replaces
+    // (`open@8` misdetected Podman as bare WSL) — containers stay on the Linux
+    // openers below.
     if is_wsl() && !is_in_container() {
-        powershell_start_process(url)
-    } else {
-        let mut c = Command::new("xdg-open");
-        c.arg(url);
-        c
+        candidates.extend(
+            wsl_powershell_programs()
+                .iter()
+                .map(|program| powershell_start_process(program, url)),
+        );
     }
+    // Always fall through to the Linux openers: WSL interop can be off, and a
+    // browser installed inside the distro still works.
+    candidates.extend(linux_open_candidates(url));
+    candidates
 }
 
 /// Both WSL1 and WSL2 register a `WSLInterop` binfmt entry, so `powershell.exe`
 /// is launchable from either — hence no WSL1/WSL2 distinction here. Matches the
 /// `is-wsl` package (which the replaced `open` used) so no WSL flavour loses the
-/// Windows bridge. If interop is disabled via `wsl.conf`, the spawn simply fails
-/// and the caller falls back to printing the URL.
+/// Windows bridge.
 #[cfg(all(
     not(target_arch = "wasm32"),
     not(target_os = "macos"),
@@ -122,29 +153,184 @@ fn is_in_container() -> bool {
     })
 }
 
-/// Launch the default browser via the Windows host PowerShell — used on native
-/// Windows and, through WSL interop, on non-container WSL2. The URL is handed
-/// over as a base64 UTF-16LE `-EncodedCommand` (the same mechanism the `open`
-/// package used) so shell metacharacters — notably `&` in a query string, a
-/// `cmd.exe` separator — can neither break the command line nor inject
-/// anything: the URL never appears on a command line as text.
+/// `powershell.exe` is on `PATH` only while WSL's `[interop] appendWindowsPath`
+/// is left on, and turning it off is a common tweak that leaves interop itself
+/// working. So try the absolute System32 path first, the way `open@10` did, and
+/// keep the bare name as a fallback for unusual Windows layouts.
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    not(target_os = "macos"),
+    not(target_os = "windows")
+))]
+fn wsl_powershell_programs() -> Vec<String> {
+    let absolute = format!(
+        "{}c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe",
+        wsl_automount_root()
+    );
+    let mut programs = Vec::new();
+    if std::path::Path::new(&absolute).exists() {
+        programs.push(absolute);
+    }
+    programs.push("powershell.exe".to_string());
+    programs
+}
+
+/// WSL mounts the Windows drives under `[automount] root` from `/etc/wsl.conf`.
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    not(target_os = "macos"),
+    not(target_os = "windows")
+))]
+fn wsl_automount_root() -> String {
+    static ROOT: OnceLock<String> = OnceLock::new();
+    ROOT.get_or_init(|| {
+        std::fs::read_to_string("/etc/wsl.conf")
+            .ok()
+            .and_then(|conf| parse_automount_root(&conf))
+            .unwrap_or_else(|| "/mnt/".to_string())
+    })
+    .clone()
+}
+
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    not(target_os = "macos"),
+    not(target_os = "windows")
+))]
+fn parse_automount_root(wsl_conf: &str) -> Option<String> {
+    let mut in_automount = false;
+    for line in wsl_conf.lines() {
+        let line = line.trim();
+        if line.is_empty() || line.starts_with('#') || line.starts_with(';') {
+            continue;
+        }
+        if line.starts_with('[') {
+            in_automount = line.eq_ignore_ascii_case("[automount]");
+            continue;
+        }
+        if !in_automount {
+            continue;
+        }
+        if let Some((key, value)) = line.split_once('=') {
+            if key.trim().eq_ignore_ascii_case("root") {
+                let value = value.trim().trim_matches('"');
+                if value.is_empty() {
+                    return None;
+                }
+                return Some(if value.ends_with('/') {
+                    value.to_string()
+                } else {
+                    format!("{value}/")
+                });
+            }
+        }
+    }
+    None
+}
+
+/// The opener chain `open@10` shipped: it vendored the freedesktop `xdg-open`
+/// script, which walks `$BROWSER` and then these desktop helpers. Trying only
+/// the system `xdg-open` loses the browser on minimal images, headless server
+/// distros and Termux, where it often isn't installed.
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    not(target_os = "macos"),
+    not(target_os = "windows")
+))]
+const LINUX_OPENERS: &[&[&str]] = &[
+    &["xdg-open"],
+    &["gio", "open"],
+    &["gvfs-open"],
+    &["gnome-open"],
+    &["kde-open"],
+    &["exo-open"],
+    &["x-www-browser"],
+    &["www-browser"],
+];
+
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    not(target_os = "macos"),
+    not(target_os = "windows")
+))]
+fn linux_open_candidates(url: &str) -> Vec<Command> {
+    let browser = std::env::var("BROWSER").unwrap_or_default();
+    browser_env_candidates(&browser, url)
+        .into_iter()
+        .chain(LINUX_OPENERS.iter().map(|parts| {
+            let mut c = create_command(parts[0]);
+            c.args(&parts[1..]).arg(url);
+            c
+        }))
+        .collect()
+}
+
+/// `$BROWSER` is a colon-separated list of commands, each either a plain program
+/// or a template where `%s` stands in for the URL — the contract the freedesktop
+/// `xdg-open` script implements.
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    not(target_os = "macos"),
+    not(target_os = "windows")
+))]
+fn browser_env_candidates(browser: &str, url: &str) -> Vec<Command> {
+    browser
+        .split(':')
+        .filter_map(|entry| {
+            let mut tokens = entry.split_whitespace();
+            let program = tokens.next()?;
+            let mut c = create_command(program);
+            let mut substituted = false;
+            for token in tokens {
+                if token.contains("%s") {
+                    substituted = true;
+                    c.arg(token.replace("%s", url));
+                } else {
+                    c.arg(token);
+                }
+            }
+            if !substituted {
+                c.arg(url);
+            }
+            Some(c)
+        })
+        .collect()
+}
+
+/// Launch the default browser through the Windows host's PowerShell — used on
+/// native Windows and, over WSL interop, on non-container WSL.
+///
+/// The URL rides *inside* the script as base64 rather than in a quoted literal.
+/// PowerShell accepts five code points as single-quote delimiters (`U+0027` plus
+/// `U+2018`–`U+201B`) and lets any of them close a literal any other opened, so
+/// escaping by doubling the ASCII quote is not sufficient; base64's alphabet
+/// can't express a quote at all.
 #[cfg(all(not(target_arch = "wasm32"), not(target_os = "macos")))]
-fn powershell_start_process(url: &str) -> Command {
-    // Single-quoted PowerShell literal; the only in-literal escape is a single
-    // quote, doubled.
-    let script = format!("Start-Process '{}'", url.replace('\'', "''"));
-    let utf16le: Vec<u8> = script
-        .encode_utf16()
-        .flat_map(|unit| unit.to_le_bytes())
-        .collect();
-    let mut c = Command::new("powershell.exe");
+fn powershell_start_process(program: &str, url: &str) -> Command {
+    let script = format!(
+        "Start-Process ([Text.Encoding]::Unicode.GetString([Convert]::FromBase64String('{}')))",
+        base64_encode(&utf16le(url))
+    );
+    let mut c = create_command(program);
     c.args([
         "-NoProfile",
         "-NonInteractive",
+        // `open` set this too — a GPO-locked host otherwise refuses the command.
+        "-ExecutionPolicy",
+        "Bypass",
         "-EncodedCommand",
-        &base64_encode(&utf16le),
+        &base64_encode(&utf16le(&script)),
     ]);
     c
+}
+
+/// `-EncodedCommand` expects base64 of UTF-16LE, which is also what
+/// `[Text.Encoding]::Unicode` decodes.
+#[cfg(all(not(target_arch = "wasm32"), not(target_os = "macos")))]
+fn utf16le(s: &str) -> Vec<u8> {
+    s.encode_utf16()
+        .flat_map(|unit| unit.to_le_bytes())
+        .collect()
 }
 
 /// Minimal standard-alphabet base64 encoder (padded). Kept local to avoid a new
@@ -183,6 +369,28 @@ fn base64_encode(input: &[u8]) -> String {
 mod tests {
     use super::*;
 
+    fn args_of(cmd: &Command) -> Vec<String> {
+        cmd.get_args()
+            .map(|a| a.to_string_lossy().into_owned())
+            .collect()
+    }
+
+    fn programs_of(cmds: &[Command]) -> Vec<String> {
+        cmds.iter()
+            .map(|c| c.get_program().to_string_lossy().into_owned())
+            .collect()
+    }
+
+    fn decode_powershell_script(cmd: &Command) -> String {
+        let args = args_of(cmd);
+        let bytes = decode_base64(args.last().unwrap());
+        let utf16: Vec<u16> = bytes
+            .chunks(2)
+            .map(|p| u16::from_le_bytes([p[0], p[1]]))
+            .collect();
+        String::from_utf16(&utf16).unwrap()
+    }
+
     #[test]
     fn base64_matches_known_vectors() {
         assert_eq!(base64_encode(b""), "");
@@ -212,35 +420,95 @@ mod tests {
     }
 
     #[test]
-    fn powershell_command_encodes_url_without_leaking_metacharacters() {
-        // A URL with `&` (cmd separator) and a single quote must round-trip
-        // through the encoded command untouched — the raw URL must never appear
-        // as a plain argument.
-        let url = "https://cloud.nx.app/connect?a=1&b=2&x='y";
-        let cmd = powershell_start_process(url);
-        let args: Vec<String> = cmd
-            .get_args()
-            .map(|a| a.to_string_lossy().into_owned())
-            .collect();
+    fn only_http_urls_reach_an_opener() {
+        assert!(is_http_url("http://localhost:4211/projects"));
+        assert!(is_http_url("HTTPS://cloud.nx.app/connect/abc"));
+        // `Start-Process`/`xdg-open` would launch these as programs or files.
+        assert!(!is_http_url("calc.exe"));
+        assert!(!is_http_url("file:///etc/passwd"));
+        assert!(!is_http_url("javascript:alert(1)"));
+        assert!(!is_http_url(" http://leading-space.example"));
+        assert!(!open_url_native("calc.exe"));
+    }
+
+    #[test]
+    fn powershell_carries_the_url_as_base64_not_as_a_quoted_literal() {
+        // Every character PowerShell accepts as a single-quote delimiter, plus a
+        // `&` (cmd separator). None may reach the command line or the script.
+        let url = "https://cloud.nx.app/connect?a=1&b=2&q='\u{2018}\u{2019}\u{201A}\u{201B}";
+        let cmd = powershell_start_process("powershell.exe", url);
+        let args = args_of(&cmd);
+
         assert_eq!(cmd.get_program(), "powershell.exe");
         assert!(args.iter().any(|a| a == "-EncodedCommand"));
-        // No argument carries the raw URL or a bare `&`.
         assert!(!args.iter().any(|a| a.contains("://")));
         assert!(!args.iter().any(|a| a.contains('&')));
 
-        // The encoded payload decodes back to a single-quoted Start-Process
-        // with the quote doubled.
-        let encoded = args.last().unwrap();
-        let bytes = decode_base64(encoded);
+        // The script embeds the URL as base64, so no quote can escape it.
+        let script = decode_powershell_script(&cmd);
+        let payload = script
+            .strip_prefix(
+                "Start-Process ([Text.Encoding]::Unicode.GetString([Convert]::FromBase64String('",
+            )
+            .and_then(|s| s.strip_suffix("')))"))
+            .expect("script shape");
+        assert!(!payload.contains(['\'', '\u{2018}', '\u{2019}', '\u{201A}', '\u{201B}']));
+
+        // ...and decodes back to exactly the URL we were handed.
+        let bytes = decode_base64(payload);
         let utf16: Vec<u16> = bytes
             .chunks(2)
             .map(|p| u16::from_le_bytes([p[0], p[1]]))
             .collect();
-        let script = String::from_utf16(&utf16).unwrap();
+        assert_eq!(String::from_utf16(&utf16).unwrap(), url);
+    }
+
+    #[test]
+    fn execution_policy_is_bypassed_for_gpo_locked_hosts() {
+        let cmd = powershell_start_process("powershell.exe", "https://nx.dev");
+        let args = args_of(&cmd);
+        let idx = args.iter().position(|a| a == "-ExecutionPolicy").unwrap();
+        assert_eq!(args[idx + 1], "Bypass");
+    }
+
+    #[test]
+    fn linux_falls_back_through_the_whole_opener_chain() {
+        let programs = programs_of(&linux_open_candidates("https://nx.dev"));
+        // `xdg-open` is only the first guess; the desktop helpers `open@10`
+        // vendored must still be reachable.
+        assert_eq!(programs[0], "xdg-open");
+        for expected in ["gio", "gvfs-open", "gnome-open", "kde-open", "exo-open"] {
+            assert!(programs.contains(&expected.to_string()), "{expected}");
+        }
+    }
+
+    #[test]
+    fn browser_env_entries_come_first_and_honor_the_s_placeholder() {
+        let cmds = browser_env_candidates("firefox:my-opener --url=%s", "https://nx.dev");
+        assert_eq!(programs_of(&cmds), vec!["firefox", "my-opener"]);
+        // No placeholder: the URL is appended. With one: it's substituted.
+        assert_eq!(args_of(&cmds[0]), vec!["https://nx.dev"]);
+        assert_eq!(args_of(&cmds[1]), vec!["--url=https://nx.dev"]);
+        assert!(browser_env_candidates("", "https://nx.dev").is_empty());
+    }
+
+    #[test]
+    fn wsl_automount_root_defaults_and_parses() {
+        assert_eq!(parse_automount_root(""), None);
+        // Only the [automount] section counts, and a trailing slash is implied.
         assert_eq!(
-            script,
-            "Start-Process 'https://cloud.nx.app/connect?a=1&b=2&x=''y'"
+            parse_automount_root("[automount]\nroot = /windows"),
+            Some("/windows/".to_string())
         );
+        assert_eq!(
+            parse_automount_root("[automount]\nroot=\"/mnt/\"\n"),
+            Some("/mnt/".to_string())
+        );
+        assert_eq!(
+            parse_automount_root("[interop]\nroot = /nope\n[automount]\n# comment\nroot = /w"),
+            Some("/w/".to_string())
+        );
+        assert_eq!(parse_automount_root("[interop]\nroot = /nope"), None);
     }
 
     // Test-only decoder to verify the encoder.

--- a/packages/nx/src/native/utils/open_url.rs
+++ b/packages/nx/src/native/utils/open_url.rs
@@ -251,68 +251,26 @@ fn parse_automount_root(wsl_conf: &str) -> Option<String> {
     None
 }
 
-/// What the vendored freedesktop script reaches internally — desktop handlers
-/// from its `detectDE` dispatch, then the browsers its `open_generic` default
-/// list names. We retry them directly because that script ships inside `open`,
-/// and the system `xdg-open` that replaces it is often absent on minimal images,
-/// headless server distros and Termux.
-#[cfg(all(
-    not(target_arch = "wasm32"),
-    not(target_os = "macos"),
-    not(target_os = "windows")
-))]
-const FALLBACK_OPENERS: &[&[&str]] = &[
-    &["gio", "open"],
-    &["gvfs-open"],
-    &["gnome-open"],
-    &["kde-open"],
-    &["exo-open"],
-    &["x-www-browser"],
-    &["firefox"],
-    &["chromium"],
-    &["chromium-browser"],
-    &["google-chrome"],
-    &["epiphany"],
-    &["konqueror"],
-    &["www-browser"],
-    &["links2"],
-    &["elinks"],
-    &["links"],
-    &["lynx"],
-    &["w3m"],
-];
-
-/// `xdg-open` first, because it dispatches to the desktop's own handler — the
-/// branch the vendored script took whenever it detected a desktop environment.
-/// `$BROWSER` is consulted only after that, mirroring the script's `open_generic`
-/// path: putting it first would let `BROWSER=echo` (a common way to suppress
-/// auto-open) spawn successfully on a desktop and report a browser that never
-/// appeared, since a candidate only loses its turn by failing to spawn.
+/// `xdg-open` leads because it is the standard entry point and dispatches to
+/// whatever handler the desktop has. `$BROWSER` is the documented override, but
+/// it only gets a turn once `xdg-open` is missing — `xdg-open` consults it
+/// itself, and trying it first would let `BROWSER=echo` (a common way to
+/// suppress auto-open) spawn happily and report a browser that never appeared.
+///
+/// Deliberately no further rungs. A candidate only loses its turn by failing to
+/// spawn, so a terminal browser would "succeed" against the null stdio
+/// `spawn_detached` sets while rendering nowhere the user can see.
 #[cfg(all(
     not(target_arch = "wasm32"),
     not(target_os = "macos"),
     not(target_os = "windows")
 ))]
 fn linux_open_candidates(browser: &str, url: &str) -> Vec<Command> {
-    let mut candidates = vec![opener_command(&["xdg-open"], url)];
+    let mut xdg = create_command("xdg-open");
+    xdg.arg(url);
+    let mut candidates = vec![xdg];
     candidates.extend(browser_env_candidates(browser, url));
-    candidates.extend(
-        FALLBACK_OPENERS
-            .iter()
-            .map(|parts| opener_command(parts, url)),
-    );
     candidates
-}
-
-#[cfg(all(
-    not(target_arch = "wasm32"),
-    not(target_os = "macos"),
-    not(target_os = "windows")
-))]
-fn opener_command(parts: &[&str], url: &str) -> Command {
-    let mut c = create_command(parts[0]);
-    c.args(&parts[1..]).arg(url);
-    c
 }
 
 /// `$BROWSER` is a colon-separated list of commands, each either a plain program
@@ -537,37 +495,12 @@ mod tests {
     }
 
     #[test]
-    fn linux_falls_back_through_the_whole_opener_chain() {
+    fn linux_tries_xdg_open_then_the_browser_override() {
         // `$BROWSER` is passed in, never read from the environment, so this holds
         // on a machine that has one set (Codespaces and VS Code Remote do).
         let cmds = linux_open_candidates("", "https://nx.dev");
-        assert_eq!(
-            programs_of(&cmds),
-            [
-                "xdg-open",
-                "gio",
-                "gvfs-open",
-                "gnome-open",
-                "kde-open",
-                "exo-open",
-                "x-www-browser",
-                "firefox",
-                "chromium",
-                "chromium-browser",
-                "google-chrome",
-                "epiphany",
-                "konqueror",
-                "www-browser",
-                "links2",
-                "elinks",
-                "links",
-                "lynx",
-                "w3m"
-            ]
-        );
-        // `gio` needs its `open` subcommand — dropping it still spawns, so the
-        // chain would report success while nothing opened.
-        assert_eq!(args_of(&cmds[1]), vec!["open", "https://nx.dev"]);
+        assert_eq!(programs_of(&cmds), ["xdg-open"]);
+        assert_eq!(args_of(&cmds[0]), vec!["https://nx.dev"]);
     }
 
     #[test]

--- a/packages/nx/src/native/utils/open_url.rs
+++ b/packages/nx/src/native/utils/open_url.rs
@@ -152,9 +152,16 @@ fn proc_version_is_wsl(proc_version: &str) -> bool {
     proc_version.to_lowercase().contains("microsoft")
 }
 
-/// Detects an OCI container (Docker `/.dockerenv`, or Podman
-/// `/run/.containerenv`). This is the marker `open@8`'s `is-docker` missed for
-/// Podman, causing the original crash.
+/// `/run/.containerenv` is the Podman marker `open@8`'s `is-docker` missed,
+/// which is what let #34502 take the WSL bridge and crash. A const so a test can
+/// assert it without a container to run in.
+#[cfg(all(
+    not(target_arch = "wasm32"),
+    not(target_os = "macos"),
+    not(target_os = "windows")
+))]
+const CONTAINER_MARKERS: &[&str] = &["/.dockerenv", "/run/.containerenv"];
+
 #[cfg(all(
     not(target_arch = "wasm32"),
     not(target_os = "macos"),
@@ -163,8 +170,9 @@ fn proc_version_is_wsl(proc_version: &str) -> bool {
 fn is_in_container() -> bool {
     static IN_CONTAINER: OnceLock<bool> = OnceLock::new();
     *IN_CONTAINER.get_or_init(|| {
-        std::path::Path::new("/.dockerenv").exists()
-            || std::path::Path::new("/run/.containerenv").exists()
+        CONTAINER_MARKERS
+            .iter()
+            .any(|m| std::path::Path::new(m).exists())
     })
 }
 
@@ -243,10 +251,11 @@ fn parse_automount_root(wsl_conf: &str) -> Option<String> {
     None
 }
 
-/// The helpers `open@10`'s vendored freedesktop script falls through once
-/// `xdg-open` itself is unavailable. Trying only the system `xdg-open` loses the
-/// browser on minimal images, headless server distros and Termux, where it often
-/// isn't installed.
+/// What the vendored freedesktop script reaches internally — desktop handlers
+/// from its `detectDE` dispatch, then the browsers its `open_generic` default
+/// list names. We retry them directly because that script ships inside `open`,
+/// and the system `xdg-open` that replaces it is often absent on minimal images,
+/// headless server distros and Termux.
 #[cfg(all(
     not(target_arch = "wasm32"),
     not(target_os = "macos"),
@@ -259,7 +268,18 @@ const FALLBACK_OPENERS: &[&[&str]] = &[
     &["kde-open"],
     &["exo-open"],
     &["x-www-browser"],
+    &["firefox"],
+    &["chromium"],
+    &["chromium-browser"],
+    &["google-chrome"],
+    &["epiphany"],
+    &["konqueror"],
     &["www-browser"],
+    &["links2"],
+    &["elinks"],
+    &["links"],
+    &["lynx"],
+    &["w3m"],
 ];
 
 /// `xdg-open` first, because it dispatches to the desktop's own handler — the
@@ -330,17 +350,14 @@ fn browser_env_candidates(browser: &str, url: &str) -> Vec<Command> {
 /// Launch the default browser through the Windows host's PowerShell — used on
 /// native Windows and, over WSL interop, on non-container WSL.
 ///
-/// The URL rides *inside* the script as base64 rather than in a quoted literal.
-/// PowerShell accepts five code points as single-quote delimiters (`U+0027` plus
-/// `U+2018`–`U+201B`) and lets any of them close a literal any other opened, so
-/// escaping by doubling the ASCII quote is not sufficient; base64's alphabet
-/// can't express a quote at all.
+/// The URL rides *inside* the script as base64, never in a quoted literal:
+/// PowerShell takes five code points as single-quote delimiters (`U+0027`,
+/// `U+2018`–`U+201B`) and lets any close a literal any other opened, so doubling
+/// the ASCII quote is not enough. Base64's alphabet can't express one at all.
 ///
-/// The inner payload is UTF-8, not UTF-16LE: both round-trip any URL, but the
-/// script is base64'd a second time for `-EncodedCommand`, so an inner UTF-16LE
-/// layer costs 7.1 bytes of command line per URL byte against `CreateProcessW`'s
-/// 32767 cap. `nx release` embeds a whole changelog in a GitHub URL, which put
-/// the ceiling under the size real changelogs reach.
+/// Keep the inner payload UTF-8. The script is base64'd again for
+/// `-EncodedCommand`, so UTF-16LE here would cost 7.1 command-line bytes per URL
+/// byte against `CreateProcessW`'s 32767 cap — halving the openable URL.
 #[cfg(all(not(target_arch = "wasm32"), not(target_os = "macos")))]
 fn powershell_start_process(program: &str, url: &str) -> Command {
     let script = format!(
@@ -360,8 +377,7 @@ fn powershell_start_process(program: &str, url: &str) -> Command {
     c
 }
 
-/// `-EncodedCommand` expects base64 of UTF-16LE, which is also what
-/// `[Text.Encoding]::Unicode` decodes.
+/// `-EncodedCommand` expects base64 of UTF-16LE.
 #[cfg(all(not(target_arch = "wasm32"), not(target_os = "macos")))]
 fn utf16le(s: &str) -> Vec<u8> {
     s.encode_utf16()
@@ -471,7 +487,10 @@ mod tests {
     fn powershell_carries_the_url_as_base64_not_as_a_quoted_literal() {
         // Every character PowerShell accepts as a single-quote delimiter, plus a
         // `&` (cmd separator). None may reach the command line or the script.
-        let url = "https://cloud.nx.app/connect?a=1&b=2&q='\u{2018}\u{2019}\u{201A}\u{201B}";
+        // The astral char pins the multi-byte round trip the UTF-8 payload rests
+        // on — it is two UTF-16 units, so an encoder split would corrupt it.
+        let url =
+            "https://cloud.nx.app/connect?a=1&b=2&q='\u{2018}\u{2019}\u{201A}\u{201B}\u{1F680}";
         let cmd = powershell_start_process("powershell.exe", url);
         let args = args_of(&cmd);
 
@@ -532,12 +551,32 @@ mod tests {
                 "kde-open",
                 "exo-open",
                 "x-www-browser",
-                "www-browser"
+                "firefox",
+                "chromium",
+                "chromium-browser",
+                "google-chrome",
+                "epiphany",
+                "konqueror",
+                "www-browser",
+                "links2",
+                "elinks",
+                "links",
+                "lynx",
+                "w3m"
             ]
         );
         // `gio` needs its `open` subcommand — dropping it still spawns, so the
         // chain would report success while nothing opened.
         assert_eq!(args_of(&cmds[1]), vec!["open", "https://nx.dev"]);
+    }
+
+    #[test]
+    fn podman_and_docker_markers_are_both_probed() {
+        // #34502: `open@8`'s `is-docker` only looked for /.dockerenv, so Podman
+        // took the WSL bridge and crashed. Asserted on the const because a test
+        // process can't fake either marker's presence.
+        assert!(CONTAINER_MARKERS.contains(&"/run/.containerenv"));
+        assert!(CONTAINER_MARKERS.contains(&"/.dockerenv"));
     }
 
     #[test]

--- a/packages/nx/src/native/utils/open_url.rs
+++ b/packages/nx/src/native/utils/open_url.rs
@@ -113,11 +113,10 @@ fn candidates_for(use_windows_bridge: bool, browser: &str, url: &str) -> Vec<Com
     // (`open@8` misdetected Podman as bare WSL) — containers stay on the Linux
     // openers below.
     if use_windows_bridge {
-        candidates.extend(
-            wsl_powershell_programs()
-                .iter()
-                .map(|program| powershell_start_process(program, url)),
-        );
+        // Off `PATH` when WSL's `[interop] appendWindowsPath` is disabled; that
+        // host falls through to the Linux openers below rather than resolving an
+        // absolute System32 path, so a browser still opens, just inside the distro.
+        candidates.push(powershell_start_process("powershell.exe", url));
     }
     // Always fall through to the Linux openers: WSL interop can be off, and a
     // browser installed inside the distro still works.
@@ -174,81 +173,6 @@ fn is_in_container() -> bool {
             .iter()
             .any(|m| std::path::Path::new(m).exists())
     })
-}
-
-/// `powershell.exe` is on `PATH` only while WSL's `[interop] appendWindowsPath`
-/// is left on, and turning it off is a common tweak that leaves interop itself
-/// working. So try the absolute System32 path first, the way `open@10` did, and
-/// keep the bare name as a fallback for unusual Windows layouts.
-#[cfg(all(
-    not(target_arch = "wasm32"),
-    not(target_os = "macos"),
-    not(target_os = "windows")
-))]
-fn wsl_powershell_programs() -> Vec<String> {
-    let absolute = format!(
-        "{}c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe",
-        wsl_automount_root()
-    );
-    let mut programs = Vec::new();
-    if std::path::Path::new(&absolute).exists() {
-        programs.push(absolute);
-    }
-    programs.push("powershell.exe".to_string());
-    programs
-}
-
-/// WSL mounts the Windows drives under `[automount] root` from `/etc/wsl.conf`.
-#[cfg(all(
-    not(target_arch = "wasm32"),
-    not(target_os = "macos"),
-    not(target_os = "windows")
-))]
-fn wsl_automount_root() -> String {
-    static ROOT: OnceLock<String> = OnceLock::new();
-    ROOT.get_or_init(|| {
-        std::fs::read_to_string("/etc/wsl.conf")
-            .ok()
-            .and_then(|conf| parse_automount_root(&conf))
-            .unwrap_or_else(|| "/mnt/".to_string())
-    })
-    .clone()
-}
-
-#[cfg(all(
-    not(target_arch = "wasm32"),
-    not(target_os = "macos"),
-    not(target_os = "windows")
-))]
-fn parse_automount_root(wsl_conf: &str) -> Option<String> {
-    let mut in_automount = false;
-    for line in wsl_conf.lines() {
-        let line = line.trim();
-        if line.is_empty() || line.starts_with('#') || line.starts_with(';') {
-            continue;
-        }
-        if line.starts_with('[') {
-            in_automount = line.eq_ignore_ascii_case("[automount]");
-            continue;
-        }
-        if !in_automount {
-            continue;
-        }
-        if let Some((key, value)) = line.split_once('=') {
-            if key.trim().eq_ignore_ascii_case("root") {
-                let value = value.trim().trim_matches('"');
-                if value.is_empty() {
-                    return None;
-                }
-                return Some(if value.ends_with('/') {
-                    value.to_string()
-                } else {
-                    format!("{value}/")
-                });
-            }
-        }
-    }
-    None
 }
 
 /// `xdg-open` leads because it is the standard entry point and dispatches to
@@ -541,25 +465,6 @@ mod tests {
         let on_wsl = programs_of(&candidates_for(true, "", "https://nx.dev"));
         assert!(on_wsl[0].contains("powershell"));
         assert!(on_wsl.iter().any(|p| p == "xdg-open"));
-    }
-
-    #[test]
-    fn wsl_automount_root_defaults_and_parses() {
-        assert_eq!(parse_automount_root(""), None);
-        // Only the [automount] section counts, and a trailing slash is implied.
-        assert_eq!(
-            parse_automount_root("[automount]\nroot = /windows"),
-            Some("/windows/".to_string())
-        );
-        assert_eq!(
-            parse_automount_root("[automount]\nroot=\"/mnt/\"\n"),
-            Some("/mnt/".to_string())
-        );
-        assert_eq!(
-            parse_automount_root("[interop]\nroot = /nope\n[automount]\n# comment\nroot = /w"),
-            Some("/w/".to_string())
-        );
-        assert_eq!(parse_automount_root("[interop]\nroot = /nope"), None);
     }
 
     // Test-only decoder to verify the encoder.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2401,9 +2401,6 @@ importers:
       flat:
         specifier: ^5.0.2
         version: 5.0.2
-      open:
-        specifier: ^8.4.0
-        version: 8.4.2
       ora:
         specifier: 'catalog:'
         version: 5.4.1
@@ -3247,9 +3244,6 @@ importers:
       npm-run-path:
         specifier: ^4.0.1
         version: 4.0.1
-      open:
-        specifier: ^10.1.0
-        version: 10.1.0
       ora:
         specifier: 'catalog:'
         version: 5.4.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2397,9 +2397,6 @@ importers:
       flat:
         specifier: ^5.0.2
         version: 5.0.2
-      open:
-        specifier: ^8.4.0
-        version: 8.4.2
       ora:
         specifier: 'catalog:'
         version: 5.4.1
@@ -3252,9 +3249,6 @@ importers:
       npm-run-path:
         specifier: ^4.0.1
         version: 4.0.1
-      open:
-        specifier: ^10.1.0
-        version: 10.1.0
       ora:
         specifier: 'catalog:'
         version: 5.4.1


### PR DESCRIPTION
## Current Behavior

`nx` and `create-nx-workspace` both depend on the [`open`](https://github.com/sindresorhus/open) npm package to launch a browser (graph, Nx Cloud connect, GitHub/GitLab release notes, cloud setup).

#34639 fixed the Podman-on-WSL crash (#34502) by bumping `open` `8 → 10` in `nx`, but `open@10` is ESM-only, so every call site carries a `new Function('return import("open")')()` shim to load it from CJS. Nx also already ships its own native Rust URL opener for the TUI (`open_url`, NXC-3940), so the dependency and the shim are both redundant.

**`create-nx-workspace` was never fixed and still crashes today.** It pins `open: ^8.4.0` — resolving to the exact version #34502 reported — and calls it here:

```ts
try {
  const open = require('open');
  await open(connectUrl);
} catch {
  // Fail gracefully
}
```

That `catch` cannot help. `open@8` resolves as soon as the child is spawned, so the `await` completes; the `ENOENT` arrives afterwards as an `'error'` event on the returned `ChildProcess`, which has no listener. The process dies. So `npx create-nx-workspace` + Nx Cloud connect inside a Podman-on-WSL container still crashes on master — this PR fixes that, not just the dependency hygiene.

## Expected Behavior

Both packages drop `open` and use the native opener, exposed to JS via napi as `openUrl(url: string): boolean`:

- **`nx`** — graph, cloud connect and the GitHub/GitLab release clients call `openUrl` instead of `open`, removing the ESM shim. The TUI drops its private copy and uses the same shared implementation.
- **`create-nx-workspace`** — has no `nx` dependency (it is the standalone bootstrap installer), so it resolves the native bindings from the workspace it just created and calls them optionally, degrading to the printed banner otherwise.

What the opener does per platform:

| platform | behavior |
| --- | --- |
| macOS | `open <url>` |
| Windows | `powershell.exe … Start-Process` |
| WSL, not in a container | PowerShell over interop, then falls through to the Linux openers |
| WSL, in a container | Linux openers only — **this is the #34502 fix** |
| Linux | `xdg-open`, then `$BROWSER` if `xdg-open` is missing |

**The container gate is the root-cause fix.** `open@8` matched `microsoft` in `/proc/version`, concluded "bare WSL", and spawned a `powershell.exe` that does not exist inside the container. Its `is-docker` check only looked for `/.dockerenv`, so Podman's `/run/.containerenv` was missed. The native probe checks both.

**The crash *class* is also gone, independent of detection.** `Command::spawn()` reports `ENOENT` synchronously as a `Result`, so there is no emitter left to raise an unhandled `'error'` event. A missing opener can no longer be fatal, only `false`.

**URLs are passed to PowerShell as base64 inside the script**, never in a quoted literal:

```
Start-Process ([Text.Encoding]::UTF8.GetString([Convert]::FromBase64String('<b64>')))
```

PowerShell accepts five code points as single-quote delimiters (`U+0027`, `U+2018`–`U+201B`) and lets any of them close a literal any other opened, so escaping the ASCII quote is not sufficient. Base64's alphabet cannot express any of them, so the injection is impossible by construction rather than by escaping. Relevant because these URLs come from remote responses (Nx Cloud onboarding, the GitHub/GitLab APIs).

### Deliberate decisions worth flagging

- **`true` means an opener was *spawned*, not that a browser opened.** Waiting isn't safely available — an opener may not exit until the browser does. Callers treat `false` as "tell the user the URL"; four of the five surface it, and `create-nx-workspace` relies on the banner, which carries the URL either way.
- **Only `http(s)` URLs are opened.** `Start-Process` and `xdg-open` launch local programs just as readily. This is a behavior change: a non-`http(s)` URL now gets the manual-link message instead of an attempted open.
- **`$BROWSER` is consulted only when `xdg-open` is absent.** `xdg-open` consults it itself, and trying it first would let `BROWSER=echo` — a common way to suppress auto-open — spawn happily and report a browser that never appeared. No further openers are tried: a candidate only loses its turn by failing to spawn, so a terminal browser would "succeed" against null stdio while rendering nowhere visible.
- **On WSL with `[interop] appendWindowsPath` disabled**, `powershell.exe` is off `PATH`, so that host falls through to the Linux openers — a browser still opens, the in-distro one rather than the Windows one.
- **Windows/WSL command-line ceiling is ~9,100 characters**, versus ~12,200 for the `Start "<url>"` shape `open` used, because the script is base64'd a second time for `-EncodedCommand`. This matters only for `nx release` without a `GITHUB_TOKEN`, which embeds the whole percent-encoded changelog in a GitHub URL — roughly a 120-commit release rather than 160. Past the limit `spawn` fails and the link is printed instead.
- **`create-nx-workspace` loads `nx/src/native/native-bindings.js` directly** rather than the `nx/src/native` entry, whose loader shim patches `process.emit` and copies the multi-MB `.node` into a cache keyed on cwd — which here is the parent of the new workspace, so the copy is written and never read. The trade: on a wasm-fallback install the shim's WASI `ExperimentalWarning` suppression is lost, and that warning would print before the success banner.
- **The `open` dependency is removed from `nx` and `create-nx-workspace` only.** `@nx/angular-rspack` declares its own and is untouched.

## Related Issue(s)

Follow-up to #34639 (which fixed #34502 for `nx` only) — removes the `open` dependency and the ESM shim it required, and fixes the same crash in `create-nx-workspace`, which #34639 did not touch.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Replace-open-package-with-native-URL-opener-7e697f3f)
<!-- polygraph-session-end -->
