### PR TITLE
docs(misc): document bun dependency catalog support

### DIFF
--- a/astro-docs/src/content/docs/getting-started/Tutorials/managing-dependencies.mdoc
+++ b/astro-docs/src/content/docs/getting-started/Tutorials/managing-dependencies.mdoc
@@ -208,14 +208,13 @@ catalog:
 {% /tabitem %}
 {% tabitem label="yarn" %}
 
-Define catalogs in `.yarnrc.yml`:
+Define the default catalog under the `catalog` key in `.yarnrc.yml` (Yarn 4.10+):
 
 ```yaml
 # .yarnrc.yml
-catalogs:
-  default:
-    react: ^19.0.0
-    react-dom: ^19.0.0
+catalog:
+  react: ^19.0.0
+  react-dom: ^19.0.0
 ```
 
 ```jsonc
@@ -236,7 +235,27 @@ npm does not have catalog support. Enforce a single version policy by defining a
 {% /tabitem %}
 {% tabitem label="bun" %}
 
-Bun does not currently support catalogs. Define shared dependency versions in the root `package.json` and reference them using `workspace:*` for internal packages.
+Define the default catalog under the `catalog` field in the root `package.json` (Nx 23.2+):
+
+```jsonc
+// package.json
+{
+  "catalog": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+  },
+}
+```
+
+```jsonc
+// apps/my-app/package.json
+{
+  "dependencies": {
+    "react": "catalog:",
+    "react-dom": "catalog:",
+  },
+}
+```
 
 {% /tabitem %}
 {% /tabs %}

--- a/astro-docs/src/content/docs/kb/bun-workspaces.mdoc
+++ b/astro-docs/src/content/docs/kb/bun-workspaces.mdoc
@@ -75,6 +75,43 @@ bun install --filter 'pkg-*'      # install deps only for matching packages
 
 Filters accept globs and compose: pass `--filter` multiple times, and prefix a pattern with `!` to exclude it, as in `bun install --filter 'pkg-*' --filter '!pkg-c'`.
 
+## Share dependency versions with Bun catalogs
+
+Catalogs define a dependency version once and reference it from every package, so packages can't drift onto different versions of the same dependency. Bun reads catalogs from the root `package.json`: the `catalog` field holds the default catalog, and `catalogs` holds named catalogs. Nx resolves these references (`catalog:` in generators, migrations, release versioning, and the `@nx/dependency-checks` lint rule) starting in Nx 23.2.
+
+```jsonc
+// package.json
+{
+  "catalog": {
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+  },
+  "catalogs": {
+    "testing": {
+      "vitest": "^3.0.0",
+    },
+  },
+}
+```
+
+```jsonc
+// apps/web/package.json
+{
+  "name": "web",
+  "dependencies": {
+    "react": "catalog:",
+    "vitest": "catalog:testing",
+  },
+}
+```
+
+`catalog:` points at the `catalog` field and `catalog:testing` at a named catalog. Two Bun behaviors differ from pnpm:
+
+- **`default` is not a special name.** `catalog:` resolves only against the `catalog` field, and `catalog:default` addresses a named catalog literally called `default`. Bun does not treat `catalogs.default` as the default catalog.
+- **Definition locations are all-or-nothing.** You can also nest `catalog`/`catalogs` under the object form of the `workspaces` field. If either field exists there, Bun ignores the top-level fields entirely rather than merging the two locations.
+
+The same `catalog` vs `catalogs.default` distinction applies to [Yarn catalogs](/docs/kb/yarn-workspaces#share-dependency-versions-with-yarn-catalogs) (Yarn 4.10+).
+
 ## How mature are Bun workspaces?
 
 Bun workspaces are the newest of the four implementations. Setup, linking, the `workspace:` protocol, and `--filter` cover the everyday workflows, but there's no filtering by dependency relationship or by what changed in git, which the pnpm `--filter` flag offers. Bun workspaces also have less production mileage overall, and some ecosystem tools expect an npm, Yarn, or pnpm lockfile rather than the Bun lockfile.

--- a/astro-docs/src/content/docs/kb/bun-workspaces.mdoc
+++ b/astro-docs/src/content/docs/kb/bun-workspaces.mdoc
@@ -3,7 +3,8 @@ title: 'Bun Workspaces: Setup, Commands, and Best Practices'
 description: 'Learn Bun workspaces: setup, linking packages with workspace:*, running scripts with --filter, and best practices for fast monorepos.'
 filter: 'type:Guides'
 topics:
-  - 'Recipes'
+  - 'Package managers'
+  - 'Dependencies'
 ---
 
 Bun workspaces let you manage multiple packages in a single repository (or a monorepo) using the same `workspaces` field npm and Yarn read. `bun install` resolves every package in a single pass, dedupes shared dependencies to the root `node_modules`, and links local packages declared with the `workspace:` protocol.

--- a/astro-docs/src/content/docs/kb/dependency-management.mdoc
+++ b/astro-docs/src/content/docs/kb/dependency-management.mdoc
@@ -49,7 +49,7 @@ The main challenge with this approach is coordinating dependency updates across 
 
 {% aside type="tip" title="Dependency Catalog Support" %}
 
-When using pnpm or Yarn, use [pnpm catalogs](https://pnpm.io/catalogs) or [Yarn catalogs](https://yarnpkg.com/features/catalogs) to maintain single version policy. Define versions in `pnpm-workspace.yaml` or `.yarnrc.yml` respectively and reference them as `"<package>": "catalog:"` in project `package.json` files (Nx 22+ for pnpm and Nx 22.6+ for Yarn).
+When using pnpm, Yarn, or Bun, use [pnpm catalogs](https://pnpm.io/catalogs), [Yarn catalogs](https://yarnpkg.com/features/catalogs), or [Bun catalogs](https://bun.com/docs/install/catalogs) to maintain single version policy. Define versions in `pnpm-workspace.yaml`, `.yarnrc.yml`, or the root `package.json` `catalog` field respectively, and reference them as `"<package>": "catalog:"` in project `package.json` files (Nx 22+ for pnpm, Nx 22.6+ for Yarn, and Nx 23.2+ for Bun).
 
 {% /aside %}
 

--- a/astro-docs/src/content/docs/kb/npm-workspaces.mdoc
+++ b/astro-docs/src/content/docs/kb/npm-workspaces.mdoc
@@ -3,7 +3,8 @@ title: 'npm Workspaces: Setup, Commands, and Best Practices'
 description: 'Learn npm workspaces: the workspaces field, installing and linking local packages, running scripts with --workspace flags, and best practices that scale.'
 filter: 'type:Guides'
 topics:
-  - 'Recipes'
+  - 'Package managers'
+  - 'Dependencies'
 ---
 
 npm workspaces manage multiple packages in a single repository (or a monorepo) from one root `package.json`. You list package folders in the `workspaces` field, and `npm install` installs all of their dependencies in one pass, symlinking local packages into the root `node_modules` so they can depend on each other without publishing to a registry.

--- a/astro-docs/src/content/docs/kb/pnpm-workspaces.mdoc
+++ b/astro-docs/src/content/docs/kb/pnpm-workspaces.mdoc
@@ -3,7 +3,8 @@ title: 'pnpm Workspaces: Setup, Commands, and Best Practices'
 description: 'Learn pnpm workspaces: pnpm-workspace.yaml setup, the workspace: protocol, running scripts with --filter, catalogs, and best practices that scale.'
 filter: 'type:Guides'
 topics:
-  - 'Recipes'
+  - 'Package managers'
+  - 'Dependencies'
 ---
 
 pnpm workspaces let you develop multiple packages in a single repository (or a monorepo). You declare package locations in `pnpm-workspace.yaml`, link local packages with the `workspace:` protocol, and pnpm installs everything into one content-addressable store, so each package gets a strict `node_modules` without duplicating dependencies on disk.

--- a/astro-docs/src/content/docs/kb/yarn-workspaces.mdoc
+++ b/astro-docs/src/content/docs/kb/yarn-workspaces.mdoc
@@ -3,7 +3,8 @@ title: 'Yarn Workspaces: Setup, Commands, and Best Practices'
 description: 'Learn Yarn workspaces: setup, linking packages, running scripts with yarn workspaces foreach, hoisting behavior, and best practices for growing monorepos.'
 filter: 'type:Guides'
 topics:
-  - 'Recipes'
+  - 'Package managers'
+  - 'Dependencies'
 ---
 
 Yarn workspaces let a single repository (or a monorepo) hold multiple packages that are developed together. You declare them in the root `package.json` `workspaces` field, and `yarn install` resolves the whole project at once, hoisting shared dependencies to the root and linking workspace packages to each other.

--- a/astro-docs/src/content/docs/kb/yarn-workspaces.mdoc
+++ b/astro-docs/src/content/docs/kb/yarn-workspaces.mdoc
@@ -77,6 +77,33 @@ yarn workspace web run build            # a single workspace
 
 Yarn 4 ships `foreach` out of the box. On Yarn 3, add it first with `yarn plugin import workspace-tools`. On Yarn 1 (Classic), the equivalent is `yarn workspaces run build`.
 
+## Share dependency versions with Yarn catalogs
+
+Catalogs (Yarn 4.10+) define a dependency version once in `.yarnrc.yml` and reference it from every package, so packages can't drift onto different versions of the same dependency. The `catalog` key holds the default catalog and `catalogs` holds named catalogs. Nx resolves these references (`catalog:` in generators, migrations, release versioning, and the `@nx/dependency-checks` lint rule) starting in Nx 22.6.
+
+```yaml
+# .yarnrc.yml
+catalog:
+  react: ^19.0.0
+  react-dom: ^19.0.0
+catalogs:
+  testing:
+    vitest: ^3.0.0
+```
+
+```jsonc
+// apps/web/package.json
+{
+  "name": "web",
+  "dependencies": {
+    "react": "catalog:",
+    "vitest": "catalog:testing",
+  },
+}
+```
+
+`catalog:` points at the `catalog` key and `catalog:testing` at a named catalog. Unlike pnpm, `default` is not a special name: `catalog:` resolves only against the `catalog` key, and `catalog:default` addresses a named catalog literally called `default`. Yarn does not treat `catalogs.default` as the default catalog.
+
 ## Do Yarn workspaces hoist dependencies?
 
 Yes. With the default node-modules linker, Yarn hoists shared dependencies to the root `node_modules`, so each version is installed once and packages resolve it by walking up the directory tree. Only conflicting versions get nested inside an individual workspace's `node_modules` folder.

--- a/astro-docs/src/data/knowledge-base-topics.json
+++ b/astro-docs/src/data/knowledge-base-topics.json
@@ -129,5 +129,15 @@
     "id": "comparisons",
     "label": "Comparisons",
     "description": "Compare Nx and Nx Cloud with build tools, task runners, and CI acceleration products."
+  },
+  {
+    "id": "package-managers",
+    "label": "Package managers",
+    "description": "Set up and run npm, pnpm, Yarn, and Bun workspaces with Nx."
+  },
+  {
+    "id": "dependencies",
+    "label": "Dependencies",
+    "description": "Link local packages and manage external dependency versions in an Nx workspace."
   }
 ]


### PR DESCRIPTION
## Current Behavior

Catalog docs cover pnpm and Yarn only; bun is documented as unsupported, and the Yarn example uses `catalogs.default`, which does not resolve on Yarn 4.10+. The npm/pnpm/yarn/bun workspace guides sit under the generic Recipes topic, and the KB article list shows every article's last-modified as the KB-rework move date.

## Expected Behavior

Document bun catalogs and correct the Yarn default-catalog example. Add Package managers and Dependencies KB topics and recategorize the four workspace guides. Compute KB last-modified from the newest non-rename (`--follow`) commit so a bulk move no longer resets every date.

## Related Issue(s)

Fixes DOC-557

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/ready-wren-435ce5a1)
<!-- polygraph-session-end -->