### PR TITLE
docs(misc): use real last-modified date for KB articles

### DIFF
--- a/astro-docs/src/utils/knowledge-base.ts
+++ b/astro-docs/src/utils/knowledge-base.ts
@@ -1,6 +1,48 @@
+import { execFileSync } from 'node:child_process';
 import type { CollectionEntry } from 'astro:content';
 import { getNewestCommitDate } from 'virtual:starlight/git-info';
 import knowledgeBaseTopics from '../data/knowledge-base-topics.json';
+
+const lastModifiedCache = new Map<string, Date>();
+
+// Plain newest-commit date follows bulk file moves (e.g. the KB rework), so
+// skip rename commits (R*) and take the newest real edit. Falls back to the
+// starlight date when history is unavailable (shallow clone).
+function getArticleLastModified(filePath: string): Date {
+  const cached = lastModifiedCache.get(filePath);
+  if (cached) return cached;
+
+  let lastModified = getNewestCommitDate(filePath);
+  try {
+    // NUL-delimit records so each splits into date + its name-status lines.
+    const log = execFileSync(
+      'git',
+      [
+        'log',
+        '--follow',
+        '-M',
+        '--name-status',
+        '--format=%x00%cI',
+        '--',
+        filePath,
+      ],
+      { encoding: 'utf8' }
+    );
+    for (const record of log.split('\0')) {
+      const [iso, ...statusLines] = record.split('\n').filter(Boolean);
+      if (!iso) continue;
+      const status = statusLines[0]?.split('\t')[0] ?? '';
+      if (status.startsWith('R')) continue; // rename/move, not a content edit
+      lastModified = new Date(iso);
+      break;
+    }
+  } catch {
+    // Not a git checkout or no reachable history; keep the starlight date.
+  }
+
+  lastModifiedCache.set(filePath, lastModified);
+  return lastModified;
+}
 
 export interface KnowledgeBaseTopic {
   id: string;
@@ -39,7 +81,7 @@ export function getKnowledgeBaseArticles(
         href: `/docs/kb/${slug}`,
         topics: doc.data.topics ?? [],
         featured: doc.data.featured ?? false,
-        lastModified: getNewestCommitDate(doc.filePath),
+        lastModified: getArticleLastModified(doc.filePath),
       };
     });
 }

--- a/astro-docs/src/utils/knowledge-base.ts
+++ b/astro-docs/src/utils/knowledge-base.ts
@@ -26,7 +26,7 @@ function getArticleLastModified(filePath: string): Date {
         '--',
         filePath,
       ],
-      { encoding: 'utf8' }
+      { encoding: 'utf8', windowsHide: true }
     );
     for (const record of log.split('\0')) {
       const [iso, ...statusLines] = record.split('\n').filter(Boolean);


### PR DESCRIPTION
## Current Behavior

The Knowledge Base article list derives each article's last-modified from the file's newest commit without following renames. After the KB rework (#36414) moved every article in one commit, all articles show that move date instead of their real last edit.

## Expected Behavior

Follow renames and skip rename commits (status `R*`) so the date reflects the last real content change. This is generic - any future bulk move is handled without a hardcoded commit - and falls back to the Starlight date when git history is unavailable.

## Related Issue(s)

Follow-up to #36414 (knowledge base rework).

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/ready-wren-435ce5a1)
<!-- polygraph-session-end -->