### PR TITLE
chore(repo): stop eslint linting json files with no applicable rules

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -96,13 +96,10 @@ export const baseConfig = [
     },
   },
   {
-    files: ['**/*.json'],
+    files: ['**/executors/**/schema.json', '**/generators/**/schema.json'],
     languageOptions: {
       parser: jsoncEslintParser,
     },
-  },
-  {
-    files: ['**/executors/**/schema.json', '**/generators/**/schema.json'],
     rules: {
       '@nx/workspace-valid-schema-description': 'error',
     },

--- a/nx-dev/util-ai/eslint.config.mjs
+++ b/nx-dev/util-ai/eslint.config.mjs
@@ -4,7 +4,7 @@ import * as jsoncEslintParser from 'jsonc-eslint-parser';
 export default [
   ...baseConfig,
   {
-    files: ['**/*.json'],
+    files: ['./package.json'],
     rules: {
       '@nx/dependency-checks': 'error',
     },

--- a/packages/gradle/eslint.config.mjs
+++ b/packages/gradle/eslint.config.mjs
@@ -5,7 +5,7 @@ export default [
   ...baseConfig,
   { ignores: ['dist'] },
   {
-    files: ['**/*.json'],
+    files: ['./package.json'],
     rules: {
       '@nx/dependency-checks': [
         'error',

--- a/packages/maven/eslint.config.mjs
+++ b/packages/maven/eslint.config.mjs
@@ -4,7 +4,7 @@ import * as jsoncEslintParser from 'jsonc-eslint-parser';
 export default [
   ...baseConfig,
   {
-    files: ['**/*.json'],
+    files: ['./package.json'],
     rules: {
       '@nx/dependency-checks': [
         'error',

--- a/packages/nx/eslint.config.mjs
+++ b/packages/nx/eslint.config.mjs
@@ -153,6 +153,6 @@ export default [
     },
   },
   {
-    ignores: ['**/__fixtures__/**/*', 'dist'],
+    ignores: ['**/__fixtures__/**/*', 'dist', 'native-packages/**/*'],
   },
 ];

--- a/tools/workspace-plugin/eslint.config.mjs
+++ b/tools/workspace-plugin/eslint.config.mjs
@@ -4,7 +4,7 @@ import * as jsoncEslintParser from 'jsonc-eslint-parser';
 export default [
   ...baseConfig,
   {
-    files: ['**/*.json'],
+    files: ['./package.json'],
     rules: {
       '@nx/dependency-checks': [
         'error',


### PR DESCRIPTION
## Current Behavior

The root `eslint.config.mjs` registered the jsonc parser through a standalone `**/*.json` config block that carried no rules. In ESLint flat config, a `files` pattern that names a non-JS extension also turns those files into lint targets during directory traversal, so running `eslint .` in a project pulled in every `.json` beneath it. That includes the nested `packages/nx/native-packages/*/{project,package}.json`, which belong to 10 separate platform projects.

As a result `nx:lint` on `packages/nx` read `project.json` files it does not own. When a platform project's graph edge is absent on a CI agent (the agent's own platform resolves to the installed `@nx/nx-<platform>` package instead of the workspace project), that file is not among the task's declared inputs, so Nx Cloud sandboxing flagged the read as a violation. The read set is constant across agents while the input set varies by agent, which is why the violation was flaky.

## Expected Behavior

eslint only processes json files that have a json rule bound to them. The nested `native-packages` json (and other rule-free json such as `project.json` and `tsconfig.json`) are no longer linted, so `nx:lint` stops reading files it does not own and the sandbox violation cannot occur on any agent.

Lint coverage is unchanged: every json file dropped from linting had zero active json rules, and the json that carries rules (`package.json`, `executors.json`, `migrations.json`, and the executor/generator `schema.json`) is processed exactly as before.

## Implementation Details

- Root config: colocate the jsonc parser with the `@nx/workspace-valid-schema-description` rule block and remove the parser-only `**/*.json` block, the only json block in the repo that had no parser of its own.
- Narrow the four configs that bound `@nx/dependency-checks` to `**/*.json` (`nx-dev/util-ai`, `packages/gradle`, `packages/maven`, `tools/workspace-plugin`) to `./package.json`. The rule already self-filters to `/package.json`, and none of these projects have nested `package.json`, so this is coverage-neutral.
- `packages/nx`: ignore `native-packages/**/*` to state the ownership boundary explicitly.

Fixes NXC-4719.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/nxc-4719-df936a32)
<!-- polygraph-session-end -->