### PR TITLE
fix(core): avoid bogus duplicate project name errors when generating nested apps

### DIFF
--- a/packages/devkit/src/generators/project-name-and-root-utils.spec.ts
+++ b/packages/devkit/src/generators/project-name-and-root-utils.spec.ts
@@ -1,6 +1,7 @@
 import { createTreeWithEmptyWorkspace } from 'nx/src/generators/testing-utils/create-tree-with-empty-workspace';
 import type { Tree } from 'nx/src/generators/tree';
 import { updateJson } from 'nx/src/generators/utils/json';
+import { addProjectConfiguration } from 'nx/src/generators/utils/project-configuration';
 import { workspaceRoot } from 'nx/src/utils/workspace-root';
 import { join } from 'path';
 import { setCwd } from '../../internal-testing-utils';
@@ -286,6 +287,53 @@ describe('determineProjectNameAndRootOptions', () => {
         projectType: 'library',
       })
     ).rejects.toThrow(/name should match/);
+  });
+
+  it('should throw when the derived name conflicts with an existing project', async () => {
+    addProjectConfiguration(tree, 'server', {
+      root: 'apps/server',
+    });
+
+    await expect(
+      determineProjectNameAndRootOptions(tree, {
+        directory: 'apps/a2v-migration/server',
+        projectType: 'application',
+      })
+    ).rejects.toThrow(
+      'The name "server" was derived from the provided directory "apps/a2v-migration/server", but it is already used by the project at "apps/server". Please provide a unique name for the new project with the "--name" option.'
+    );
+  });
+
+  it('should throw when the provided name conflicts with an existing project', async () => {
+    addProjectConfiguration(tree, 'server', {
+      root: 'apps/server',
+    });
+
+    await expect(
+      determineProjectNameAndRootOptions(tree, {
+        directory: 'apps/a2v-migration/api',
+        name: 'server',
+        projectType: 'application',
+      })
+    ).rejects.toThrow(
+      'The provided name "server" is already used by the project at "apps/server". Please provide a unique name for the new project.'
+    );
+  });
+
+  it('should not throw a name conflict error when the existing project is at the resolved project root', async () => {
+    // generating on top of an existing project is handled elsewhere with a
+    // more accurate error
+    addProjectConfiguration(tree, 'server', {
+      root: 'apps/server',
+    });
+
+    const result = await determineProjectNameAndRootOptions(tree, {
+      directory: 'apps/server',
+      projectType: 'application',
+    });
+
+    expect(result.projectName).toBe('server');
+    expect(result.projectRoot).toBe('apps/server');
   });
 
   it('should handle providing a path including multiple "@" as the project name', async () => {

--- a/packages/devkit/src/generators/project-name-and-root-utils.ts
+++ b/packages/devkit/src/generators/project-name-and-root-utils.ts
@@ -1,5 +1,6 @@
 import { prompt } from 'enquirer';
 import {
+  getProjects,
   joinPathFragments,
   normalizePath,
   type ProjectType,
@@ -101,6 +102,8 @@ export async function determineProjectNameAndRootOptions(
     );
   }
 
+  validateUniqueName(tree, name, projectRoot, options);
+
   const importPath =
     options.importPath ?? resolveImportPath(tree, name, projectRoot);
 
@@ -178,6 +181,27 @@ function validateOptions(
       `The derived name from the provided directory should match the pattern "${pattern}". The derived name "${derivedName}" from the provided value "${directory}" does not match.`
     );
   }
+}
+
+function validateUniqueName(
+  tree: Tree,
+  name: string,
+  projectRoot: string,
+  options: ProjectGenerationOptions
+): void {
+  const existingProject = getProjects(tree).get(name);
+  // A project at the resolved root is handled elsewhere with a more
+  // accurate error, so only error when the name is taken by a project
+  // located somewhere else.
+  if (!existingProject || existingProject.root === projectRoot) {
+    return;
+  }
+
+  throw new Error(
+    options.name
+      ? `The provided name "${name}" is already used by the project at "${existingProject.root}". Please provide a unique name for the new project.`
+      : `The name "${name}" was derived from the provided directory "${options.directory}", but it is already used by the project at "${existingProject.root}". Please provide a unique name for the new project with the "--name" option.`
+  );
 }
 
 function getImportPath(npmScope: string | undefined, name: string) {

--- a/packages/devkit/src/utils/add-plugin.spec.ts
+++ b/packages/devkit/src/utils/add-plugin.spec.ts
@@ -124,6 +124,64 @@ describe('addPlugin', () => {
     });
   });
 
+  it('should add the plugin when inferred projects resolve to conflicting names', async () => {
+    // When a single plugin runs in isolation, the project.json plugin does
+    // not run, so inferred projects might not resolve to their real,
+    // unique names. Any resulting duplicate-name conflict is irrelevant to
+    // determining the plugin options and should not fail the generator.
+    await fs.createFiles({
+      'libs/a/ui/project.json': '{}',
+      'libs/b/ui/project.json': '{}',
+      'libs/a/ui/next.config.js': '',
+      'libs/b/ui/next.config.js': '',
+    });
+    createNodes = [
+      '**/next.config.{ts,js,cjs,mjs}',
+      (_, { targetName }) => [
+        [
+          'libs/a/ui/next.config.js',
+          {
+            projects: {
+              'libs/a/ui': {
+                root: 'libs/a/ui',
+                targets: { [targetName]: { command: 'next build' } },
+              },
+            },
+          },
+        ],
+        [
+          'libs/b/ui/next.config.js',
+          {
+            projects: {
+              'libs/b/ui': {
+                root: 'libs/b/ui',
+                targets: { [targetName]: { command: 'next build' } },
+              },
+            },
+          },
+        ],
+      ],
+    ];
+
+    await addPlugin(
+      tree,
+      graph,
+      '@nx/next/plugin',
+      createNodes,
+      {
+        targetName: ['build'],
+      },
+      false
+    );
+
+    expect(readJson(tree, 'nx.json').plugins).toContainEqual({
+      plugin: '@nx/next/plugin',
+      options: {
+        targetName: 'build',
+      },
+    });
+  });
+
   it('should throw an error if no non-conflicting options are provided', async () => {
     graph.nodes.app1.data.targets.build = {};
 

--- a/packages/devkit/src/utils/add-plugin.ts
+++ b/packages/devkit/src/utils/add-plugin.ts
@@ -14,6 +14,7 @@ import {
   writeJson,
 } from 'nx/src/devkit-exports';
 import {
+  isMultipleProjectsWithSameNameError,
   isProjectConfigurationsError,
   isProjectsWithNoNameError,
   LoadedNxPlugin,
@@ -135,8 +136,10 @@ async function _addPluginInternal<PluginOptions>(
         // Errors are okay for this because we're only running 1 plugin
         if (isProjectConfigurationsError(e)) {
           projConfigs = e.partialProjectConfigurationsResult;
-          // ignore errors from projects with no name
-          if (!e.errors.every(isProjectsWithNoNameError)) {
+          // Ignore errors about project names: running a single plugin in
+          // isolation cannot resolve the real project names, and they are
+          // irrelevant for determining the plugin options.
+          if (!e.errors.every(isProjectNameError)) {
             throw e;
           }
         } else {
@@ -183,8 +186,10 @@ async function _addPluginInternal<PluginOptions>(
       // Errors are okay for this because we're only running 1 plugin
       if (isProjectConfigurationsError(e)) {
         projConfigs = e.partialProjectConfigurationsResult;
-        // ignore errors from projects with no name
-        if (!e.errors.every(isProjectsWithNoNameError)) {
+        // Ignore errors about project names: running a single plugin in
+        // isolation cannot resolve the real project names, and they are
+        // irrelevant for determining the plugin options.
+        if (!e.errors.every(isProjectNameError)) {
           throw e;
         }
       } else {
@@ -210,6 +215,10 @@ async function _addPluginInternal<PluginOptions>(
   if (shouldUpdatePackageJsonScripts) {
     updatePackageScripts(tree, projConfigs);
   }
+}
+
+function isProjectNameError(e: unknown): boolean {
+  return isProjectsWithNoNameError(e) || isMultipleProjectsWithSameNameError(e);
 }
 
 type TargetCommand = {

--- a/packages/nx/src/project-graph/utils/project-configuration/target-normalization.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-normalization.spec.ts
@@ -1,5 +1,9 @@
+import { TempFs } from '../../../internal-testing-utils/temp-fs';
 import { workspaceRoot } from '../../../utils/workspace-root';
-import { normalizeTarget } from './target-normalization';
+import {
+  normalizeTarget,
+  validateAndNormalizeProjectRootMap,
+} from './target-normalization';
 
 describe('normalizeTarget', () => {
   it('should support {projectRoot}, {workspaceRoot}, and {projectName} tokens', () => {
@@ -56,5 +60,82 @@ describe('normalizeTarget', () => {
     normalizeTarget(config.targets.foo, config, workspaceRoot, {}, '');
     normalizeTarget(config.targets.bar, config, workspaceRoot, {}, '');
     expect(JSON.stringify(config, null, 2)).toEqual(originalConfig);
+  });
+});
+
+describe('validateAndNormalizeProjectRootMap', () => {
+  let tempFs: TempFs;
+
+  beforeEach(() => {
+    tempFs = new TempFs('target-normalization');
+  });
+
+  afterEach(() => {
+    tempFs.cleanup();
+  });
+
+  it('should name unnamed projects from the name in project.json rather than the folder name', () => {
+    // Simulates a single plugin run (e.g. `addPlugin` during generators)
+    // where projects are inferred from config files other than project.json,
+    // so no name is attached even though project.json files with unique
+    // names exist on disk.
+    tempFs.createFilesSync({
+      'libs/a/ui/project.json': JSON.stringify({ name: 'a-ui' }),
+      'libs/b/ui/project.json': JSON.stringify({ name: 'b-ui' }),
+    });
+
+    const projectRootMap = {
+      'libs/a/ui': { root: 'libs/a/ui' },
+      'libs/b/ui': { root: 'libs/b/ui' },
+    };
+
+    validateAndNormalizeProjectRootMap(tempFs.tempDir, projectRootMap, {});
+
+    expect(projectRootMap['libs/a/ui'].name).toEqual('a-ui');
+    expect(projectRootMap['libs/b/ui'].name).toEqual('b-ui');
+  });
+
+  it('should fall back to the folder name when project.json has no name', () => {
+    tempFs.createFilesSync({
+      'libs/a/ui/project.json': JSON.stringify({}),
+    });
+
+    const projectRootMap = {
+      'libs/a/ui': { root: 'libs/a/ui' },
+    };
+
+    validateAndNormalizeProjectRootMap(tempFs.tempDir, projectRootMap, {});
+
+    expect(projectRootMap['libs/a/ui'].name).toEqual('ui');
+  });
+
+  it('should fall back to the folder name when project.json cannot be parsed', () => {
+    tempFs.createFilesSync({
+      'libs/a/ui/project.json': 'not json',
+    });
+
+    const projectRootMap = {
+      'libs/a/ui': { root: 'libs/a/ui' },
+    };
+
+    validateAndNormalizeProjectRootMap(tempFs.tempDir, projectRootMap, {});
+
+    expect(projectRootMap['libs/a/ui'].name).toEqual('ui');
+  });
+
+  it('should still report projects whose project.json files declare the same name', () => {
+    tempFs.createFilesSync({
+      'libs/a/ui/project.json': JSON.stringify({ name: 'ui' }),
+      'libs/b/ui/project.json': JSON.stringify({ name: 'ui' }),
+    });
+
+    const projectRootMap = {
+      'libs/a/ui': { root: 'libs/a/ui' },
+      'libs/b/ui': { root: 'libs/b/ui' },
+    };
+
+    expect(() =>
+      validateAndNormalizeProjectRootMap(tempFs.tempDir, projectRootMap, {})
+    ).toThrow(AggregateError);
   });
 });

--- a/packages/nx/src/project-graph/utils/project-configuration/target-normalization.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-normalization.ts
@@ -189,11 +189,21 @@ export function validateAndNormalizeProjectRootMap(
     // We initially did this in the project.json plugin, but
     // that resulted in project.json files without names causing
     // the resulting project to change names from earlier plugins...
-    if (
-      !project.name &&
-      existsSync(join(workspaceRoot, project.root, 'project.json'))
-    ) {
-      project.name = toProjectName(join(root, 'project.json'));
+    if (!project.name) {
+      const projectJsonPath = join(workspaceRoot, project.root, 'project.json');
+      if (existsSync(projectJsonPath)) {
+        // The project.json plugin may not have run (e.g. when a single
+        // plugin is run in isolation via `addPlugin` from a generator), so
+        // prefer the name declared in project.json before deriving one from
+        // the directory name.
+        let nameFromProjectJson: string | undefined;
+        try {
+          nameFromProjectJson =
+            readJsonFile<ProjectConfiguration>(projectJsonPath).name;
+        } catch {}
+        project.name =
+          nameFromProjectJson ?? toProjectName(join(root, 'project.json'));
+      }
     }
 
     try {


### PR DESCRIPTION
## Current Behavior

Generating an app in a nested folder in a workspace where different projects share a leaf folder name fails with a bogus error, even though every project has a unique name in its `project.json`:

```
npx nx g @nx/nest:app apps/a2v-migration/server --name=a2v-migration-server

 NX   Failed to create project configurations.

The following projects are defined in multiple locations:
- ui:
  - libs/adherence/ui
  - libs/process-mining/ui
...
```

This happens because `addPlugin` (used by `initEsLint`, jest init, etc.) runs a single plugin in isolation via `retrieveProjectConfigurations`. The `project.json` plugin does not run, so every inferred project reaches `validateAndNormalizeProjectRootMap` without a name and is named after its leaf folder — colliding with every other project sharing that folder name.

Additionally, when the name derived from the directory genuinely collides with an existing project (`nx g @nx/nest:app apps/a2v-migration/server` deriving `server` while `apps/server` exists), the generator only fails later during project graph construction with the same confusing "defined in multiple locations" error.

## Expected Behavior

- `validateAndNormalizeProjectRootMap` names unnamed inferred projects using the `name` declared in the `project.json` at their root, only falling back to the leaf folder name when the file has no name or cannot be parsed. Single-plugin runs now resolve real, unique names.
- `addPlugin` treats `MultipleProjectsWithSameNameError` like `ProjectsWithNoNameError`: running one plugin in isolation cannot resolve real project names, and names are irrelevant for determining plugin options (target conflicts are matched by project root).
- `determineProjectNameAndRootOptions` fails fast, before any files are written, with an actionable error when the derived or provided project name is already used by another project:

```
The name "server" was derived from the provided directory "apps/a2v-migration/server", but it is already used by the project at "apps/server". Please provide a unique name for the new project with the "--name" option.
```

## Related Issue(s)

Fixes NXC-4723 (https://linear.app/nxdev/issue/NXC-4723/nested-app-generation-reports-duplicate-project-name)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/celonis-generator-issue-9815fc85)
<!-- polygraph-session-end -->