### PR TITLE
feat(core): show Cloud app link for remote cache instead of docs

### DIFF
--- a/packages/nx/src/native/tui/components/countdown_popup.rs
+++ b/packages/nx/src/native/tui/components/countdown_popup.rs
@@ -687,7 +687,7 @@ mod tests {
     // render and hyperlink exactly these.
     const CACHE_PHRASE: &str =
         "Drastically reduce your run duration by sharing a cache across your team and CI";
-    const CACHE_HREF: &str = "https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache";
+    const CACHE_HREF: &str = "https://cloud.nx.app/get-started?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache";
 
     fn summary_with(recommendations: Vec<String>) -> PerformanceSummaryPayload {
         PerformanceSummaryPayload {
@@ -875,7 +875,7 @@ mod tests {
             .map(|(x, y)| buffer.cell((x, y)).unwrap().symbol().to_string())
             .collect();
         assert!(
-            !visible.contains("https://nx.dev/ci/features/remote-cache"),
+            !visible.contains("https://cloud.nx.app/get-started"),
             "raw remote-cache URL must not be visible"
         );
     }

--- a/packages/nx/src/nx-cloud/utilities/url-shorten.ts
+++ b/packages/nx/src/nx-cloud/utilities/url-shorten.ts
@@ -11,13 +11,19 @@ export async function createNxCloudOnboardingURL(
   meta?: string,
   forceManual = false,
   forceGithub = false,
-  directory?: string
+  directory?: string,
+  // Aborting tears down the in-flight request; without it a caller that stops
+  // waiting (see prefetchRemoteCacheOnboardingUrl) leaves the socket holding
+  // the event loop open, since axios has no default timeout.
+  signal?: AbortSignal
 ) {
   const remoteInfo = getVcsRemoteInfo(directory);
   const apiUrl = getCloudUrl();
 
-  const installationSupportsGitHub =
-    await getInstallationSupportsGitHub(apiUrl);
+  const installationSupportsGitHub = await getInstallationSupportsGitHub(
+    apiUrl,
+    signal
+  );
 
   let usesGithub = false;
   if (forceGithub) {
@@ -39,7 +45,8 @@ export async function createNxCloudOnboardingURL(
         selectedRepositoryName: remoteInfo?.slug ?? null,
         repositoryDomain: remoteInfo?.domain ?? null,
         meta,
-      }
+      },
+      { signal }
     );
 
     if (!response?.data || response.data.message) {
@@ -93,10 +100,14 @@ export function getURLifShortenFailed(
   return `${apiUrl}/setup/connect-workspace/manual?accessToken=${accessToken}&source=${source}`;
 }
 
-async function getInstallationSupportsGitHub(apiUrl: string): Promise<boolean> {
+async function getInstallationSupportsGitHub(
+  apiUrl: string,
+  signal?: AbortSignal
+): Promise<boolean> {
   try {
     const response = await require('axios').get(
-      `${apiUrl}/nx-cloud/system/features`
+      `${apiUrl}/nx-cloud/system/features`,
+      { signal }
     );
     if (!response?.data || response.data.message) {
       throw new Error(

--- a/packages/nx/src/nx-cloud/utilities/url-shorten.ts
+++ b/packages/nx/src/nx-cloud/utilities/url-shorten.ts
@@ -2,9 +2,6 @@ import { logger } from '../../utils/logger';
 import { getCloudUrl } from './get-cloud-options';
 import { getVcsRemoteInfo } from '../../utils/git-utils';
 
-/**
- * This is currently duplicated in Nx Console. Please let @MaxKless know if you make changes here.
- */
 export async function createNxCloudOnboardingURL(
   onboardingSource: string,
   accessToken?: string,

--- a/packages/nx/src/tasks-runner/life-cycles/performance-life-cycle.spec.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/performance-life-cycle.spec.ts
@@ -739,7 +739,7 @@ describe('cache reporting', () => {
     // No-TTY jest env → no hyperlinks → the tagged URL prints verbatim.
     expect(report).toContain('sharing a cache across your team and CI');
     expect(report).toContain(
-      'https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache'
+      'https://cloud.nx.app/get-started?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache'
     );
   });
 
@@ -760,11 +760,11 @@ describe('cache reporting', () => {
       // the hidden target — never a raw URL. Sequence: ESC]8;; <target> BEL <phrase>.
       const OSC8 = ']8;;';
       expect(report).toContain(
-        `${OSC8}https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cacheDrastically reduce your run duration by sharing a cache across your team and CI`
+        `${OSC8}https://cloud.nx.app/get-started?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cacheDrastically reduce your run duration by sharing a cache across your team and CI`
       );
       // The URL must never appear as plain visible text: every occurrence is
       // immediately preceded by the OSC 8 target preamble.
-      const url = 'https://nx.dev/ci/features/remote-cache';
+      const url = 'https://cloud.nx.app/get-started';
       for (
         let i = report.indexOf(url);
         i !== -1;
@@ -882,7 +882,7 @@ describe('exit summary payload (TUI countdown)', () => {
       expect(payload.links).toEqual([
         {
           text: 'Drastically reduce your run duration by sharing a cache across your team and CI',
-          href: 'https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache',
+          href: 'https://cloud.nx.app/get-started?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache',
         },
       ]);
       expect(
@@ -1177,7 +1177,7 @@ describe('formatReport', () => {
           Recoverable time:  <1ms
 
           Recommendations:
-            - Drastically reduce your run duration by sharing a cache across your team and CI → https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache.
+            - Drastically reduce your run duration by sharing a cache across your team and CI → https://cloud.nx.app/get-started?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache.
             - Speed up or split the longest tasks on the critical path:
                 b    30.0s
                 a    10.0s"
@@ -1272,7 +1272,7 @@ describe('formatReportMarkdown', () => {
 
       ### Recommendations
 
-      - [Drastically reduce your run duration by sharing a cache across your team and CI](https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache).
+      - [Drastically reduce your run duration by sharing a cache across your team and CI](https://cloud.nx.app/get-started?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache).
       - Speed up or split the longest tasks on the critical path:
         - \`a\` — 45.0s"
     `);
@@ -1342,7 +1342,7 @@ describe('formatReportMarkdown', () => {
     })!;
 
     expect(formatReportMarkdown(s, '')).toContain(
-      '[Drastically reduce your run duration by sharing a cache across your team and CI](https://nx.dev/ci/features/remote-cache?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache)'
+      '[Drastically reduce your run duration by sharing a cache across your team and CI](https://cloud.nx.app/get-started?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=remote-cache)'
     );
   });
 });

--- a/packages/nx/src/tasks-runner/life-cycles/performance-report.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/performance-report.ts
@@ -31,7 +31,9 @@ let remoteCacheLink = NX_REMOTE_CACHE_LINK;
 
 // Give up on the short URL after this long so a slow/hung Cloud API never
 // lingers past the exit report. Covers two sequential round trips (features
-// GET, onboarding POST); the 30s CTA floor leaves room.
+// GET, onboarding POST); the 30s CTA floor leaves room. Timing out also aborts
+// the request - Promise.race alone would leave the socket holding the event
+// loop open, which strands programmatic callers that never process.exit.
 const ONBOARDING_URL_TIMEOUT = 5000;
 
 /**
@@ -53,12 +55,24 @@ export async function prefetchRemoteCacheOnboardingUrl(
   if (getVcsRemoteInfo()?.domain !== 'github.com') {
     return;
   }
+  const abortController = new AbortController();
   try {
     const url = await Promise.race([
-      createNxCloudOnboardingURL('nx-cli-perf-report'),
+      createNxCloudOnboardingURL(
+        'nx-cli-perf-report',
+        undefined,
+        undefined,
+        false,
+        false,
+        undefined,
+        abortController.signal
+      ),
       new Promise<null>((resolve) => {
         // unref so the pending timer never keeps the CLI alive on its own.
-        setTimeout(() => resolve(null), ONBOARDING_URL_TIMEOUT).unref();
+        setTimeout(() => {
+          abortController.abort();
+          resolve(null);
+        }, ONBOARDING_URL_TIMEOUT).unref();
       }),
     ]);
     // createNxCloudOnboardingURL never throws - on an unreachable API it returns a

--- a/packages/nx/src/tasks-runner/life-cycles/performance-report.ts
+++ b/packages/nx/src/tasks-runner/life-cycles/performance-report.ts
@@ -1,13 +1,21 @@
 import type { Link, PerformanceSummaryPayload } from '../../native';
 import { formatDuration } from '../../native';
+import type { NxJsonConfiguration } from '../../config/nx-json';
 import { supportsHyperlinks, terminalLink } from '../../utils/terminal-link';
+import { isNxCloudDisabled, isNxCloudUsed } from '../../utils/nx-cloud-utils';
+import { createNxCloudOnboardingURL } from '../../nx-cloud/utilities/url-shorten';
+import { getCloudUrl } from '../../nx-cloud/utilities/get-cloud-options';
+import { getVcsRemoteInfo } from '../../utils/git-utils';
+import { logger } from '../../utils/logger';
 import type {
   PerformanceSummary,
   TaskDurationRow,
 } from './performance-analysis';
 
 const NX_AGENTS_URL = 'https://nx.dev/ci/features/distribute-task-execution';
-const NX_REMOTE_CACHE_URL = 'https://nx.dev/ci/features/remote-cache';
+// Fallback for the remote-cache CTA when the short onboarding URL can't be
+// fetched: the generic Cloud get-started page (still drives to onboarding).
+const NX_CLOUD_GET_STARTED_URL = 'https://cloud.nx.app/get-started';
 const NX_PERFORMANCE_URL =
   'https://nx.dev/docs/concepts/ci-concepts/parallelization-distribution';
 /** utm tag attributing report clicks back to it; the content names the CTA clicked. */
@@ -15,7 +23,59 @@ const utm = (content: string) =>
   `?utm_source=nx-cli&utm_medium=cli&utm_campaign=performance-report&utm_content=${content}`;
 const NX_PERFORMANCE_LINK = `${NX_PERFORMANCE_URL}${utm('parallelization')}`;
 const NX_AGENTS_LINK = `${NX_AGENTS_URL}${utm('nx-agents')}`;
-const NX_REMOTE_CACHE_LINK = `${NX_REMOTE_CACHE_URL}${utm('remote-cache')}`;
+const NX_REMOTE_CACHE_LINK = `${NX_CLOUD_GET_STARTED_URL}${utm('remote-cache')}`;
+
+// Defaults to the get-started link; a disconnected workspace gets a short Nx
+// Cloud onboarding URL instead (see prefetchRemoteCacheOnboardingUrl).
+let remoteCacheLink = NX_REMOTE_CACHE_LINK;
+
+// Give up on the short URL after this long so a slow/hung Cloud API never
+// lingers past the exit report. Covers two sequential round trips (features
+// GET, onboarding POST); the 30s CTA floor leaves room.
+const ONBOARDING_URL_TIMEOUT = 5000;
+
+/**
+ * Point the remote-cache CTA at a short Nx Cloud onboarding URL for a
+ * disconnected GitHub workspace - the VCS flow where Cloud opens the nx.json PR.
+ * Non-GitHub remotes keep the get-started link (handles every provider) and skip
+ * the network entirely. Runs in CI too - terminal + job summary.
+ *
+ * Best-effort: the get-started link stays on failure/timeout. Fired at run start;
+ * the CTA needs a >30s run (MIN_RECOMMENDATION_RUN_DURATION), so the fetch
+ * always resolves first.
+ */
+export async function prefetchRemoteCacheOnboardingUrl(
+  nxJson: NxJsonConfiguration
+): Promise<void> {
+  if (isNxCloudDisabled(nxJson) || isNxCloudUsed(nxJson)) {
+    return;
+  }
+  if (getVcsRemoteInfo()?.domain !== 'github.com') {
+    return;
+  }
+  try {
+    const url = await Promise.race([
+      createNxCloudOnboardingURL('nx-cli-perf-report'),
+      new Promise<null>((resolve) => {
+        // unref so the pending timer never keeps the CLI alive on its own.
+        setTimeout(() => resolve(null), ONBOARDING_URL_TIMEOUT).unref();
+      }),
+    ]);
+    // createNxCloudOnboardingURL never throws - on an unreachable API it returns a
+    // paste-a-token URL (accessToken=undefined). Only accept a real short link.
+    if (url?.startsWith(`${getCloudUrl()}/connect/`)) {
+      remoteCacheLink = url;
+    } else {
+      logger.verbose(
+        `Keeping the get-started remote-cache link (${
+          url === null ? 'onboarding URL timed out' : `got: ${url}`
+        })`
+      );
+    }
+  } catch (e) {
+    logger.verbose(`Keeping the get-started remote-cache link: ${e}`);
+  }
+}
 /**
  * Whole-phrase CTA: the whole sentence is the link. The Rust TUI popup keeps no
  * copy of this string; it gets the phrase + href from the exit payload's `links`.
@@ -275,7 +335,7 @@ const RECOMMENDATIONS: RecommendationCandidate[] = [
       c.cacheableCount > 0 &&
       !c.remoteCacheEnabled &&
       c.cacheHits / c.cacheableCount <= LOW_CACHE_HIT_RATE,
-    build: () => [phraseLink(NX_REMOTE_CACHE_CTA, NX_REMOTE_CACHE_LINK), `.`],
+    build: () => [phraseLink(NX_REMOTE_CACHE_CTA, remoteCacheLink), `.`],
   },
   {
     // Cache skipped: drop the flag to restore unchanged tasks instantly.

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -64,6 +64,7 @@ import {
   PerformanceLifeCycle,
   flushPerformanceReport,
 } from './life-cycles/performance-life-cycle';
+import { prefetchRemoteCacheOnboardingUrl } from './life-cycles/performance-report';
 import { TaskResultsLifeCycle } from './life-cycles/task-results-life-cycle';
 import { TaskTelemetryLifeCycle } from './life-cycles/task-telemetry-life-cycle';
 import { TaskTimingsLifeCycle } from './life-cycles/task-timings-life-cycle';
@@ -130,6 +131,10 @@ async function getTerminalOutputLifeCycle(
   if (tasks.length === 1 && !ORIGINAL_TUI_ENV_VALUE) {
     process.env.NX_TUI = 'false';
   }
+
+  // Kick off in the background so the URL is ready by the exit report. A brief
+  // sync preamble (git remote + axios load) runs here; the network call does not.
+  prefetchRemoteCacheOnboardingUrl(nxJson);
 
   if (isTuiEnabled()) {
     const interceptedNxCloudLogs: (string | Uint8Array<ArrayBufferLike>)[] = [];


### PR DESCRIPTION
This PR swaps the docs link in the perf report with a Cloud link instead so the flow is smoother.

## Related Issue(s)

NXC-4701

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/ready-jackal-5efe8ef1)
<!-- polygraph-session-end -->