### PR TITLE
docs(misc): batch the git walk behind kb last-modified dates

### DIFF
--- a/astro-docs/src/utils/knowledge-base.ts
+++ b/astro-docs/src/utils/knowledge-base.ts
@@ -1,47 +1,104 @@
 import { execFileSync } from 'node:child_process';
+import { relative, resolve } from 'node:path';
 import type { CollectionEntry } from 'astro:content';
 import { getNewestCommitDate } from 'virtual:starlight/git-info';
 import knowledgeBaseTopics from '../data/knowledge-base-topics.json';
 
-const lastModifiedCache = new Map<string, Date>();
+// Vite invalidates this module whenever content changes, which would drop a
+// module-scoped cache and re-walk git on every dev navigation. Commit dates only
+// move when a commit lands, never when an author edits a file, so hang the cache
+// off globalThis and build it once per process.
+const CACHE_KEY = '__nxDocsLastModifiedIndex';
 
-// Plain newest-commit date follows bulk file moves (e.g. the KB rework), so
-// skip rename commits (R*) and take the newest real edit. Falls back to the
-// starlight date when history is unavailable (shallow clone).
-function getArticleLastModified(filePath: string): Date {
-  const cached = lastModifiedCache.get(filePath);
-  if (cached) return cached;
+// One `git log` for every article instead of one per article. Per-article
+// `--follow` forces full rename detection on each call, which cost ~105s across
+// the KB and blocked the event loop, since execFileSync is synchronous.
+//
+// The pathspec has to span the whole content root, not just `kb/`. Scoped to
+// `kb/` alone, git can't pair the two sides of the KB rework's moves and reports
+// every article as an add, which would date them all to the day of the move.
+function buildLastModifiedIndex(
+  repoRoot: string,
+  contentRoot: string,
+  // git path as of the commit being walked -> the file path the caller asked for
+  pathAtCommit: Map<string, string>
+): Map<string, Date> {
+  const lastModified = new Map<string, Date>();
 
-  let lastModified = getNewestCommitDate(filePath);
   try {
     // NUL-delimit records so each splits into date + its name-status lines.
     const log = execFileSync(
       'git',
-      [
-        'log',
-        '--follow',
-        '-M',
-        '--name-status',
-        '--format=%x00%cI',
-        '--',
-        filePath,
-      ],
-      { encoding: 'utf8', windowsHide: true }
+      ['log', '-M', '--name-status', '--format=%x00%cI', '--', contentRoot],
+      {
+        cwd: repoRoot,
+        encoding: 'utf8',
+        windowsHide: true,
+        maxBuffer: 8 * 1024 * 1024,
+      }
     );
+
     for (const record of log.split('\0')) {
       const [iso, ...statusLines] = record.split('\n').filter(Boolean);
       if (!iso) continue;
-      const status = statusLines[0]?.split('\t')[0] ?? '';
-      if (status.startsWith('R')) continue; // rename/move, not a content edit
-      lastModified = new Date(iso);
-      break;
+      const date = new Date(iso);
+
+      for (const line of statusLines) {
+        const fields = line.split('\t');
+
+        if (fields[0].startsWith('R')) {
+          // A move is not a content edit, so keep walking under the old path.
+          const [, from, to] = fields;
+          const current = pathAtCommit.get(to);
+          if (current === undefined) continue;
+          pathAtCommit.delete(to);
+          pathAtCommit.set(from, current);
+          continue;
+        }
+
+        const current = pathAtCommit.get(fields[fields.length - 1]);
+        // git logs newest first, so the first edit seen for a file is its latest.
+        if (current !== undefined && !lastModified.has(current)) {
+          lastModified.set(current, date);
+        }
+      }
     }
   } catch {
-    // Not a git checkout or no reachable history; keep the starlight date.
+    // Not a git checkout or no reachable history; callers fall back to starlight.
   }
 
-  lastModifiedCache.set(filePath, lastModified);
   return lastModified;
+}
+
+function getLastModifiedIndex(filePaths: string[]): Map<string, Date> {
+  const store = globalThis as Record<string, unknown>;
+  const cached = store[CACHE_KEY] as Map<string, Date> | undefined;
+  if (cached) return cached;
+
+  let index = new Map<string, Date>();
+  try {
+    const repoRoot = execFileSync('git', ['rev-parse', '--show-toplevel'], {
+      encoding: 'utf8',
+      windowsHide: true,
+    }).trim();
+
+    // git reports paths from the repository root, Astro reports them from the
+    // working directory. Match on git's form, return the caller's.
+    const pathAtCommit = new Map(
+      filePaths.map((path) => [relative(repoRoot, resolve(path)), path])
+    );
+
+    // Every article lives at <contentRoot>/kb/<slug>.mdoc.
+    const anyPath = pathAtCommit.keys().next().value as string;
+    const contentRoot = anyPath.slice(0, anyPath.lastIndexOf('/kb/'));
+
+    index = buildLastModifiedIndex(repoRoot, contentRoot, pathAtCommit);
+  } catch {
+    // Not a git checkout; callers fall back to starlight.
+  }
+
+  store[CACHE_KEY] = index;
+  return index;
 }
 
 export interface KnowledgeBaseTopic {
@@ -66,24 +123,33 @@ export const kbTopics = knowledgeBaseTopics as KnowledgeBaseTopic[];
 export function getKnowledgeBaseArticles(
   docs: CollectionEntry<'docs'>[]
 ): KnowledgeBaseArticle[] {
-  return docs
-    .filter((doc) => doc.id.startsWith('kb/'))
-    .map((doc) => {
-      if (!doc.filePath) {
-        throw new Error(`Could not resolve the source file for ${doc.id}`);
-      }
+  const kbDocs = docs.filter((doc) => doc.id.startsWith('kb/'));
+  for (const doc of kbDocs) {
+    if (!doc.filePath) {
+      throw new Error(`Could not resolve the source file for ${doc.id}`);
+    }
+  }
 
-      const slug = doc.id.slice('kb/'.length);
-      return {
-        slug,
-        title: doc.data.title,
-        description: doc.data.description,
-        href: `/docs/kb/${slug}`,
-        topics: doc.data.topics ?? [],
-        featured: doc.data.featured ?? false,
-        lastModified: getArticleLastModified(doc.filePath),
-      };
-    });
+  const filePaths = kbDocs.map((doc) => doc.filePath as string);
+  const lastModified = filePaths.length
+    ? getLastModifiedIndex(filePaths)
+    : new Map<string, Date>();
+
+  return kbDocs.map((doc) => {
+    const filePath = doc.filePath as string;
+    const slug = doc.id.slice('kb/'.length);
+    return {
+      slug,
+      title: doc.data.title,
+      description: doc.data.description,
+      href: `/docs/kb/${slug}`,
+      topics: doc.data.topics ?? [],
+      featured: doc.data.featured ?? false,
+      // Falls back to the starlight date when the file has no history of its
+      // own (shallow clone, or a page that isn't committed yet).
+      lastModified: lastModified.get(filePath) ?? getNewestCommitDate(filePath),
+    };
+  });
 }
 
 export function getTopicId(label: string): string {


### PR DESCRIPTION
## Current Behavior

`getKnowledgeBaseArticles` runs one synchronous `git log --follow` per KB article. At 184 articles that is ~105s of git, and because `execFileSync` blocks the event loop it stalls the whole dev server, not just `/docs/kb`. The cache is module-scoped, so Vite drops it whenever content changes and the walk runs again on the next navigation.

## Expected Behavior

One `git log` over the content root, following rename chains in a single pass. ~0.5s. Cached on `globalThis` so it survives Vite module invalidation and is paid once per process.

Two things the batched call has to get right, both of which cost me a wrong first draft:

- The pathspec has to span the whole content root, not `kb/`. Scoped to `kb/` alone git cannot pair the two sides of the KB rework's moves and reports every article as an add, dating them all to the day of the move.
- `git log` reports paths from the repository root while Astro reports them from the working directory, so paths are normalized before matching.

Verified all 184 articles render dates identical to the previous per-file `--follow` behavior (0 mismatches, 54 distinct dates) by parsing the built HTML and diffing every article against `git log --follow`.

## Related Issue(s)

Follow-up to #36452

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/grand-lizard-c6a71e63)
<!-- polygraph-session-end -->