### PR TITLE
fix(core): never scan or watch .claude/worktrees

### DIFF
--- a/packages/nx/src/native/walker.rs
+++ b/packages/nx/src/native/walker.rs
@@ -180,6 +180,7 @@ pub(crate) const HARDCODED_IGNORE_PATTERNS: &[&str] = &[
     "**/.nx/cache",
     "**/.nx/workspace-data",
     "**/.yarn/cache",
+    "**/.claude/worktrees",
 ];
 
 pub(crate) fn create_walker<P>(directory: P, use_ignores: bool) -> WalkBuilder
@@ -272,6 +273,42 @@ mod test {
                 (temp_dir.join("foo.txt"), PathBuf::from("foo.txt")),
                 (temp_dir.join("test.txt"), PathBuf::from("test.txt")),
             ]
+        );
+    }
+
+    #[test]
+    fn it_skips_hardcoded_ignored_directories() {
+        let temp_dir = TempDir::new().unwrap();
+        temp_dir.child("test.txt").write_str("content").unwrap();
+        for ignored in [
+            "node_modules",
+            ".git",
+            ".nx/cache",
+            ".nx/workspace-data",
+            ".yarn/cache",
+            ".claude/worktrees",
+        ] {
+            temp_dir
+                .child(ignored)
+                .child("file.txt")
+                .write_str("content")
+                .unwrap();
+        }
+        // Only worktrees are ignored under .claude, not the whole directory.
+        temp_dir
+            .child(".claude")
+            .child("settings.json")
+            .write_str("{}")
+            .unwrap();
+
+        let mut files = nx_walker(&temp_dir, true)
+            .map(|f| f.normalized_path)
+            .collect::<Vec<_>>();
+        files.sort();
+
+        assert_eq!(
+            files,
+            vec![".claude/settings.json".to_string(), "test.txt".to_string()]
         );
     }
 

--- a/packages/nx/src/native/watch/watcher.rs
+++ b/packages/nx/src/native/watch/watcher.rs
@@ -911,8 +911,8 @@ mod tests {
     #[test]
     fn hardcoded_ignored_paths_never_reach_callback() {
         // Guards against the filterer regressing — node_modules,
-        // .git, .nx/cache, .nx/workspace-data, .yarn/cache must never
-        // surface events.
+        // .git, .nx/cache, .nx/workspace-data, .yarn/cache,
+        // .claude/worktrees must never surface events.
         let dir = tempdir().expect("tempdir");
 
         // Create dirs before the watcher starts.
@@ -922,6 +922,7 @@ mod tests {
             ".nx/cache",
             ".nx/workspace-data",
             ".yarn/cache",
+            ".claude/worktrees",
         ] {
             let d = dir.path().join(ignored);
             fs::create_dir_all(&d).expect("mkdir ignored");
@@ -936,6 +937,7 @@ mod tests {
             ".nx/cache",
             ".nx/workspace-data",
             ".yarn/cache",
+            ".claude/worktrees",
         ] {
             fs::write(dir.path().join(ignored).join("touched.txt"), "y")
                 .unwrap_or_else(|e| panic!("failed write in {ignored}: {e}"));
@@ -955,6 +957,7 @@ mod tests {
             ".nx/cache/",
             ".nx/workspace-data/",
             ".yarn/cache/",
+            ".claude/worktrees/",
         ] {
             let leaked: Vec<_> = events.iter().filter(|e| e.path.contains(ignored)).collect();
             assert!(


### PR DESCRIPTION
Agent worktrees created under .claude/worktrees are full checkouts of the
workspace. Walking and watching them multiplies the file set the project
graph hashes and the number of paths the daemon watches. Add the directory
to the hardcoded ignore patterns shared by the walker and the watcher.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_011kgSn1ebFhZyguoKS5eeBs

Fixes NXC-4730