### PR TITLE
fix(core): prune git linked worktrees from workspace walks

### DIFF
--- a/packages/nx/src/native/utils/git.rs
+++ b/packages/nx/src/native/utils/git.rs
@@ -116,6 +116,25 @@ fn common_git_dir(git_dir: &Path) -> PathBuf {
     }
 }
 
+/// Whether `path` is the root of a git linked worktree.
+///
+/// A worktree's gitfile points at `<git-dir>/worktrees/<name>`, while a
+/// submodule's points at `<git-dir>/modules/<name>` - the parent segment is
+/// what separates them. Costs one read, so it suits deciding about a single
+/// directory (a watch event) rather than scanning a whole workspace; use
+/// [`nested_linked_worktrees`] for that.
+pub fn is_linked_worktree_root<P: AsRef<Path>>(path: P) -> bool {
+    let path = path.as_ref();
+    let Some(git_dir) = read_gitfile(&path.join(".git"), path) else {
+        return false;
+    };
+
+    git_dir
+        .parent()
+        .and_then(Path::file_name)
+        .is_some_and(|segment| segment == "worktrees")
+}
+
 /// Roots of git's linked worktrees (`git worktree add`) that live inside
 /// `workspace_root`, relative to it.
 ///
@@ -192,6 +211,29 @@ mod test {
             format!("gitdir: {}\n", metadata_dir.display()),
         )
         .unwrap();
+    }
+
+    #[test]
+    fn identifies_linked_worktree_roots() {
+        let temp = TempDir::new().unwrap();
+        create_dir_all(temp.path().join(".git")).unwrap();
+
+        let worktree = temp.path().join("wt");
+        register_worktree(temp.path(), "wt", &worktree);
+        assert!(is_linked_worktree_root(&worktree));
+
+        // A submodule's gitfile is identical in shape - only the segment it
+        // points into differs.
+        let submodule = temp.path().join("libs/sub");
+        create_dir_all(&submodule).unwrap();
+        write(
+            submodule.join(".git"),
+            "gitdir: ../../.git/modules/libs/sub\n",
+        )
+        .unwrap();
+        assert!(!is_linked_worktree_root(&submodule));
+
+        assert!(!is_linked_worktree_root(temp.path().join("libs")));
     }
 
     #[test]

--- a/packages/nx/src/native/utils/git.rs
+++ b/packages/nx/src/native/utils/git.rs
@@ -1,4 +1,9 @@
+use std::fs::read_to_string;
 use std::path::{Path, PathBuf};
+
+/// Prefix of a "gitfile" - the plain file git writes in place of a `.git`
+/// directory for linked worktrees and submodules.
+const GITDIR_PREFIX: &str = "gitdir:";
 
 /// Find the nearest git repository root by walking up the directory tree
 fn find_git_root<P: AsRef<Path>>(start_path: P) -> Option<PathBuf> {
@@ -48,4 +53,192 @@ pub fn parent_gitignore_files<P: AsRef<Path>>(workspace_root: P) -> Option<Vec<P
     }
 
     Some(result)
+}
+
+fn canonicalize_or_own(path: &Path) -> PathBuf {
+    path.canonicalize().unwrap_or_else(|_| path.to_path_buf())
+}
+
+/// Resolve a path git recorded in its metadata against `base`. Submodules
+/// always write a relative path; worktrees write an absolute one unless
+/// created with `--relative-paths` (git 2.48+).
+fn resolve_recorded_path(raw: &str, base: &Path) -> Option<PathBuf> {
+    if raw.is_empty() {
+        return None;
+    }
+
+    let target = Path::new(raw);
+    Some(if target.is_absolute() {
+        target.to_path_buf()
+    } else {
+        canonicalize_or_own(&base.join(target))
+    })
+}
+
+/// Read a file holding a bare path, such as `<git-dir>/worktrees/<name>/gitdir`.
+fn read_path_file(file: &Path, base: &Path) -> Option<PathBuf> {
+    resolve_recorded_path(read_to_string(file).ok()?.trim(), base)
+}
+
+/// Read a gitfile - the `gitdir: <path>` form git writes in place of a `.git`
+/// directory. Only the working tree side carries the prefix; the metadata
+/// side records a bare path.
+fn read_gitfile(gitfile: &Path, base: &Path) -> Option<PathBuf> {
+    let contents = read_to_string(gitfile).ok()?;
+    resolve_recorded_path(contents.trim().strip_prefix(GITDIR_PREFIX)?.trim(), base)
+}
+
+/// Resolve the git directory for a repository root. Usually `<root>/.git`,
+/// but a linked worktree or submodule has a gitfile there instead.
+fn resolve_git_dir(git_root: &Path) -> Option<PathBuf> {
+    let dot_git = git_root.join(".git");
+
+    if dot_git.metadata().ok()?.is_dir() {
+        return Some(dot_git);
+    }
+
+    read_gitfile(&dot_git, git_root)
+}
+
+/// The git directory shared by every worktree of a repository. Walking from
+/// inside a linked worktree lands on `<main>/.git/worktrees/<name>`, whose
+/// `commondir` points back at the main `.git`.
+fn common_git_dir(git_dir: &Path) -> PathBuf {
+    let Ok(contents) = read_to_string(git_dir.join("commondir")) else {
+        return git_dir.to_path_buf();
+    };
+
+    let target = Path::new(contents.trim());
+    if target.is_absolute() {
+        target.to_path_buf()
+    } else {
+        canonicalize_or_own(&git_dir.join(target))
+    }
+}
+
+/// Roots of git's linked worktrees (`git worktree add`) that live inside
+/// `workspace_root`, relative to it.
+///
+/// Git records every linked worktree under `<git-dir>/worktrees/<name>`, so
+/// reading that directory costs one `read_dir` plus a tiny file per worktree
+/// - no per-directory probing of the workspace, and no subprocess. Worktrees
+/// outside `workspace_root` are dropped: the walker never reaches them.
+///
+/// Submodules are deliberately not included. They use the same gitfile
+/// mechanism but are registered under `<git-dir>/modules/`, and their
+/// contents are real workspace files that Nx should keep scanning.
+pub fn nested_linked_worktrees<P: AsRef<Path>>(workspace_root: P) -> Vec<PathBuf> {
+    let workspace_root = workspace_root.as_ref();
+
+    let Some(git_dir) = find_git_root(workspace_root)
+        .as_deref()
+        .and_then(resolve_git_dir)
+    else {
+        return Vec::new();
+    };
+
+    let Ok(entries) = common_git_dir(&git_dir).join("worktrees").read_dir() else {
+        return Vec::new();
+    };
+
+    // `gitdir` files hold canonical paths, while the walk root may reach the
+    // same directory through a symlink or a relative path - canonicalize both
+    // sides so the prefix comparison lines up.
+    let canonical_root = canonicalize_or_own(workspace_root);
+
+    entries
+        .filter_map(|entry| {
+            let metadata_dir = entry.ok()?.path();
+            // Points at the worktree's own `.git` gitfile, so its parent is
+            // the worktree root.
+            let gitfile = read_path_file(&metadata_dir.join("gitdir"), &metadata_dir)?;
+            // A registration outlives a worktree deleted by hand, so only
+            // prune while the gitfile is actually there. Otherwise an
+            // ordinary directory later created at the same path - before
+            // anyone ran `git worktree prune` - would vanish from the graph.
+            if !gitfile.is_file() {
+                return None;
+            }
+
+            let worktree_root = canonicalize_or_own(gitfile.parent()?);
+
+            let relative = worktree_root.strip_prefix(&canonical_root).ok()?;
+            // An empty path means the workspace root *is* the worktree.
+            // Pruning that would discard the whole walk.
+            (!relative.as_os_str().is_empty()).then(|| relative.to_path_buf())
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod test {
+    use std::fs::{create_dir_all, write};
+
+    use assert_fs::TempDir;
+
+    use super::*;
+
+    fn register_worktree(repo: &Path, name: &str, worktree_root: &Path) {
+        let metadata_dir = repo.join(".git").join("worktrees").join(name);
+        create_dir_all(&metadata_dir).unwrap();
+        create_dir_all(worktree_root).unwrap();
+        write(
+            metadata_dir.join("gitdir"),
+            format!("{}\n", worktree_root.join(".git").display()),
+        )
+        .unwrap();
+        write(
+            worktree_root.join(".git"),
+            format!("gitdir: {}\n", metadata_dir.display()),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn returns_nothing_without_a_git_repo() {
+        let temp = TempDir::new().unwrap();
+        assert!(nested_linked_worktrees(temp.path()).is_empty());
+    }
+
+    #[test]
+    fn returns_nothing_when_the_repo_has_no_worktrees() {
+        let temp = TempDir::new().unwrap();
+        create_dir_all(temp.path().join(".git")).unwrap();
+        assert!(nested_linked_worktrees(temp.path()).is_empty());
+    }
+
+    #[test]
+    fn drops_worktrees_outside_the_workspace() {
+        let temp = TempDir::new().unwrap();
+        let workspace = temp.path().join("workspace");
+        create_dir_all(workspace.join(".git")).unwrap();
+
+        register_worktree(&workspace, "inside", &workspace.join("nested/wt"));
+        // `git worktree add ../elsewhere` - registered, but the walker never
+        // reaches it, so it must not turn into a bogus relative path.
+        register_worktree(&workspace, "outside", &temp.path().join("elsewhere"));
+
+        assert_eq!(
+            nested_linked_worktrees(&workspace),
+            vec![PathBuf::from("nested/wt")]
+        );
+    }
+
+    #[test]
+    fn ignores_a_stale_worktree_registration() {
+        let temp = TempDir::new().unwrap();
+        create_dir_all(temp.path().join(".git")).unwrap();
+        register_worktree(temp.path(), "gone", &temp.path().join("wt"));
+        // Worktree deleted by hand, before `git worktree prune` ran.
+        std::fs::remove_dir_all(temp.path().join("wt")).unwrap();
+
+        assert!(nested_linked_worktrees(temp.path()).is_empty());
+
+        // The registration still names `wt`. Recreated as ordinary source, it
+        // has to stay scannable - pruning it would drop projects silently.
+        create_dir_all(temp.path().join("wt")).unwrap();
+        write(temp.path().join("wt").join("lib.ts"), "x").unwrap();
+
+        assert!(nested_linked_worktrees(temp.path()).is_empty());
+    }
 }

--- a/packages/nx/src/native/utils/git.rs
+++ b/packages/nx/src/native/utils/git.rs
@@ -104,30 +104,37 @@ fn resolve_git_dir(git_root: &Path) -> Option<PathBuf> {
 /// inside a linked worktree lands on `<main>/.git/worktrees/<name>`, whose
 /// `commondir` points back at the main `.git`.
 ///
-/// Only a linked worktree's metadata directory carries `commondir`. Anywhere
-/// else (the main repository's own `.git`, a submodule's `.git/modules/<..>`)
-/// its absence is git's way of saying this *is* the common directory, which
-/// is what the fallback returns. Call this only for a git dir already known
-/// to belong to a worktree ([`is_linked_worktree_root`]), or that fallback
-/// answers a different question than the caller asked.
-pub fn common_git_dir(git_dir: &Path) -> PathBuf {
-    read_path_file(&git_dir.join("commondir"), git_dir).unwrap_or_else(|| git_dir.to_path_buf())
+/// `None` means `git_dir` carries no `commondir`. For the main repository's
+/// own `.git` or a submodule's `.git/modules/<..>` that is git's way of
+/// saying this *is* the common directory; for a worktree it means git has
+/// not finished registering it yet. Only the caller can tell those apart, so
+/// neither is answered here.
+pub fn common_git_dir(git_dir: &Path) -> Option<PathBuf> {
+    read_path_file(&git_dir.join("commondir"), git_dir)
 }
 
 /// Whether `path` is the root of a git linked worktree.
 ///
 /// A worktree and a submodule both replace `.git` with a gitfile, so the
-/// gitfile alone can't separate them - what does is that git writes
-/// `commondir` into a worktree's metadata directory and never into a
-/// submodule's. The path a gitfile points *at* is not a reliable
-/// discriminator: a submodule at `packages/worktrees/foo` is registered under
-/// `.git/modules/packages/worktrees/foo`, whose parent segment is
-/// `worktrees` too.
+/// gitfile alone can't separate them - what does is the `gitdir` file git
+/// writes into a worktree's metadata directory, pointing back at the
+/// checkout. A submodule's `.git/modules/<..>` holds no such file; it records
+/// its checkout in `config` as `core.worktree`. The path a gitfile points
+/// *at* is not a reliable discriminator either: a submodule at
+/// `packages/worktrees/foo` is registered under
+/// `.git/modules/packages/worktrees/foo`, whose parent segment is `worktrees`
+/// too.
+///
+/// `commondir` would separate the two just as well, but it cannot be used
+/// here: `git worktree add` writes it *after* the checkout's gitfile, and the
+/// watcher asks this question the moment that gitfile appears. `gitdir` is
+/// written before it, so a worktree is recognized from the first event it
+/// produces rather than a few microseconds later.
 ///
 /// A dangling worktree - one whose main clone has been moved or deleted,
 /// which the absolute path in the gitfile does nothing to survive - answers
 /// `false`, because the metadata directory it names isn't there to hold a
-/// `commondir`.
+/// `gitdir`.
 ///
 /// Costs one read plus one stat, so it suits deciding about a single
 /// directory (a watch event) rather than scanning a whole workspace; use
@@ -138,7 +145,7 @@ pub fn is_linked_worktree_root<P: AsRef<Path>>(path: P) -> bool {
         return false;
     };
 
-    git_dir.join("commondir").is_file()
+    git_dir.join("gitdir").is_file()
 }
 
 /// Roots of git's linked worktrees (`git worktree add`) that live inside
@@ -163,7 +170,11 @@ pub fn nested_linked_worktrees<P: AsRef<Path>>(workspace_root: P) -> Vec<PathBuf
         return Vec::new();
     };
 
-    let Ok(entries) = common_git_dir(&git_dir).join("worktrees").read_dir() else {
+    // No `commondir` means `git_dir` is already the common directory - the
+    // ordinary case of running from the main repository rather than a
+    // worktree of it.
+    let common_dir = common_git_dir(&git_dir).unwrap_or(git_dir);
+    let Ok(entries) = common_dir.join("worktrees").read_dir() else {
         return Vec::new();
     };
 
@@ -207,12 +218,25 @@ pub fn nested_linked_worktrees<P: AsRef<Path>>(workspace_root: P) -> Vec<PathBuf
 #[cfg(test)]
 pub(crate) mod test_support {
     use std::fs::{create_dir_all, write};
-    use std::path::Path;
+    use std::path::{Path, PathBuf};
 
     /// Registers `worktree_root` as a linked worktree of `repo`, byte-for-byte
     /// the way `git worktree add` does: an absolute path in each of the two
     /// gitfiles, and a relative `commondir` pointing back at the main `.git`.
     pub fn register_worktree(repo: &Path, name: &str, worktree_root: &Path) {
+        let metadata_dir = register_worktree_mid_write(repo, name, worktree_root);
+        // `commondir` is how a worktree finds the repository it belongs to.
+        write(metadata_dir.join("commondir"), "../..\n").unwrap();
+    }
+
+    /// The state `git worktree add` leaves behind between writing the
+    /// checkout's gitfile and writing `commondir`, returning the metadata
+    /// directory. The watcher sees a worktree in exactly this state: it acts
+    /// on the gitfile's creation event, and git writes `commondir` after it.
+    ///
+    /// Ordering verified against git 2.44 by mtime - `gitdir`, then the
+    /// checkout's `.git`, then `commondir`.
+    pub fn register_worktree_mid_write(repo: &Path, name: &str, worktree_root: &Path) -> PathBuf {
         let metadata_dir = repo.join(".git").join("worktrees").join(name);
         create_dir_all(&metadata_dir).unwrap();
         create_dir_all(worktree_root).unwrap();
@@ -226,9 +250,7 @@ pub(crate) mod test_support {
             format!("gitdir: {}\n", metadata_dir.display()),
         )
         .unwrap();
-        // `commondir` is how a worktree finds the repository it belongs to,
-        // and the marker that separates it from a submodule.
-        write(metadata_dir.join("commondir"), "../..\n").unwrap();
+        metadata_dir
     }
 
     /// Registers `submodule_path` (relative to `repo`) as a submodule, the way
@@ -255,8 +277,26 @@ mod test {
 
     use assert_fs::TempDir;
 
-    use super::test_support::{register_submodule, register_worktree};
+    use super::test_support::{register_submodule, register_worktree, register_worktree_mid_write};
     use super::*;
+
+    #[test]
+    fn a_worktree_is_a_worktree_before_git_writes_commondir() {
+        // Regression: the discriminator used to be `commondir`, which
+        // `git worktree add` writes *after* the checkout's gitfile. The
+        // watcher acts on that gitfile's creation event, so it asked while
+        // `commondir` was still missing and let the whole new checkout
+        // through - the exact workflow the prune exists for. Timing decided
+        // it, so CI failed on Linux (fast inotify) and passed on macOS.
+        let temp = TempDir::new().unwrap();
+        create_dir_all(temp.path().join(".git")).unwrap();
+
+        let worktree = temp.path().join("wt");
+        let metadata_dir = register_worktree_mid_write(temp.path(), "wt", &worktree);
+        assert!(!metadata_dir.join("commondir").exists());
+
+        assert!(is_linked_worktree_root(&worktree));
+    }
 
     #[test]
     fn identifies_linked_worktree_roots() {

--- a/packages/nx/src/native/utils/git.rs
+++ b/packages/nx/src/native/utils/git.rs
@@ -125,11 +125,12 @@ pub fn common_git_dir(git_dir: &Path) -> Option<PathBuf> {
 /// `.git/modules/packages/worktrees/foo`, whose parent segment is `worktrees`
 /// too.
 ///
-/// `commondir` would separate the two just as well, but it cannot be used
-/// here: `git worktree add` writes it *after* the checkout's gitfile, and the
-/// watcher asks this question the moment that gitfile appears. `gitdir` is
-/// written before it, so a worktree is recognized from the first event it
-/// produces rather than a few microseconds later.
+/// `commondir` separates the two just as well. `gitdir` is preferred only
+/// because `git worktree add` writes it first, so this answers `true` for
+/// every state a half-registered worktree passes through rather than all but
+/// the first ~66us of it. No caller is known to observe that window - the
+/// watcher reaches here from an event already queued and dequeued - so treat
+/// this as ordering hygiene, not a fix for a race anyone has measured.
 ///
 /// A dangling worktree - one whose main clone has been moved or deleted,
 /// which the absolute path in the gitfile does nothing to survive - answers

--- a/packages/nx/src/native/utils/git.rs
+++ b/packages/nx/src/native/utils/git.rs
@@ -103,24 +103,33 @@ fn resolve_git_dir(git_root: &Path) -> Option<PathBuf> {
 /// The git directory shared by every worktree of a repository. Walking from
 /// inside a linked worktree lands on `<main>/.git/worktrees/<name>`, whose
 /// `commondir` points back at the main `.git`.
+///
+/// Only a linked worktree's metadata directory carries `commondir`. Anywhere
+/// else (the main repository's own `.git`, a submodule's `.git/modules/<..>`)
+/// its absence is git's way of saying this *is* the common directory, which
+/// is what the fallback returns. Call this only for a git dir already known
+/// to belong to a worktree ([`is_linked_worktree_root`]), or that fallback
+/// answers a different question than the caller asked.
 pub fn common_git_dir(git_dir: &Path) -> PathBuf {
-    let Ok(contents) = read_to_string(git_dir.join("commondir")) else {
-        return git_dir.to_path_buf();
-    };
-
-    let target = Path::new(contents.trim());
-    if target.is_absolute() {
-        target.to_path_buf()
-    } else {
-        canonicalize_or_own(&git_dir.join(target))
-    }
+    read_path_file(&git_dir.join("commondir"), git_dir).unwrap_or_else(|| git_dir.to_path_buf())
 }
 
 /// Whether `path` is the root of a git linked worktree.
 ///
-/// A worktree's gitfile points at `<git-dir>/worktrees/<name>`, while a
-/// submodule's points at `<git-dir>/modules/<name>` - the parent segment is
-/// what separates them. Costs one read, so it suits deciding about a single
+/// A worktree and a submodule both replace `.git` with a gitfile, so the
+/// gitfile alone can't separate them - what does is that git writes
+/// `commondir` into a worktree's metadata directory and never into a
+/// submodule's. The path a gitfile points *at* is not a reliable
+/// discriminator: a submodule at `packages/worktrees/foo` is registered under
+/// `.git/modules/packages/worktrees/foo`, whose parent segment is
+/// `worktrees` too.
+///
+/// A dangling worktree - one whose main clone has been moved or deleted,
+/// which the absolute path in the gitfile does nothing to survive - answers
+/// `false`, because the metadata directory it names isn't there to hold a
+/// `commondir`.
+///
+/// Costs one read plus one stat, so it suits deciding about a single
 /// directory (a watch event) rather than scanning a whole workspace; use
 /// [`nested_linked_worktrees`] for that.
 pub fn is_linked_worktree_root<P: AsRef<Path>>(path: P) -> bool {
@@ -129,19 +138,17 @@ pub fn is_linked_worktree_root<P: AsRef<Path>>(path: P) -> bool {
         return false;
     };
 
-    git_dir
-        .parent()
-        .and_then(Path::file_name)
-        .is_some_and(|segment| segment == "worktrees")
+    git_dir.join("commondir").is_file()
 }
 
 /// Roots of git's linked worktrees (`git worktree add`) that live inside
 /// `workspace_root`, relative to it.
 ///
 /// Git records every linked worktree under `<git-dir>/worktrees/<name>`, so
-/// reading that directory costs one `read_dir` plus a tiny file per worktree
-/// - no per-directory probing of the workspace, and no subprocess. Worktrees
-/// outside `workspace_root` are dropped: the walker never reaches them.
+/// reading that directory costs one `read_dir` plus a tiny file per worktree,
+/// with no per-directory probing of the workspace and no subprocess.
+/// Worktrees outside `workspace_root` are dropped: the walker never reaches
+/// them.
 ///
 /// Submodules are deliberately not included. They use the same gitfile
 /// mechanism but are registered under `<git-dir>/modules/`, and their
@@ -182,22 +189,30 @@ pub fn nested_linked_worktrees<P: AsRef<Path>>(workspace_root: P) -> Vec<PathBuf
             let worktree_root = canonicalize_or_own(gitfile.parent()?);
 
             let relative = worktree_root.strip_prefix(&canonical_root).ok()?;
-            // An empty path means the workspace root *is* the worktree.
-            // Pruning that would discard the whole walk.
+            // An empty path means the workspace root *is* the worktree -
+            // running Nx from inside one is ordinary. The watcher joins these
+            // onto its origin and blocks every path under them, so an empty
+            // entry would silence the watcher permanently. (The walker is
+            // unharmed on its own: `ignore` never applies `filter_entry` to
+            // the walk root.)
             (!relative.as_os_str().is_empty()).then(|| relative.to_path_buf())
         })
         .collect()
 }
 
+/// Fixtures shared by every test module that needs a repository laid out the
+/// way git lays one out. Kept in one place because the layout is exactly what
+/// the production code reads: a fixture that omits `commondir` or `gitdir`
+/// silently stops exercising the real discriminators.
 #[cfg(test)]
-mod test {
+pub(crate) mod test_support {
     use std::fs::{create_dir_all, write};
+    use std::path::Path;
 
-    use assert_fs::TempDir;
-
-    use super::*;
-
-    fn register_worktree(repo: &Path, name: &str, worktree_root: &Path) {
+    /// Registers `worktree_root` as a linked worktree of `repo`, byte-for-byte
+    /// the way `git worktree add` does: an absolute path in each of the two
+    /// gitfiles, and a relative `commondir` pointing back at the main `.git`.
+    pub fn register_worktree(repo: &Path, name: &str, worktree_root: &Path) {
         let metadata_dir = repo.join(".git").join("worktrees").join(name);
         create_dir_all(&metadata_dir).unwrap();
         create_dir_all(worktree_root).unwrap();
@@ -211,7 +226,37 @@ mod test {
             format!("gitdir: {}\n", metadata_dir.display()),
         )
         .unwrap();
+        // `commondir` is how a worktree finds the repository it belongs to,
+        // and the marker that separates it from a submodule.
+        write(metadata_dir.join("commondir"), "../..\n").unwrap();
     }
+
+    /// Registers `submodule_path` (relative to `repo`) as a submodule, the way
+    /// `git submodule add` does: a *relative* gitfile pointing into
+    /// `<git-dir>/modules/<submodule-path>`, and no `commondir`.
+    pub fn register_submodule(repo: &Path, submodule_path: &str) {
+        let git_dir = repo.join(".git").join("modules").join(submodule_path);
+        create_dir_all(&git_dir).unwrap();
+        let submodule_root = repo.join(submodule_path);
+        create_dir_all(&submodule_root).unwrap();
+
+        let up = "../".repeat(Path::new(submodule_path).components().count());
+        write(
+            submodule_root.join(".git"),
+            format!("gitdir: {up}.git/modules/{submodule_path}\n"),
+        )
+        .unwrap();
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use std::fs::{create_dir_all, remove_dir_all, write};
+
+    use assert_fs::TempDir;
+
+    use super::test_support::{register_submodule, register_worktree};
+    use super::*;
 
     #[test]
     fn identifies_linked_worktree_roots() {
@@ -222,18 +267,46 @@ mod test {
         register_worktree(temp.path(), "wt", &worktree);
         assert!(is_linked_worktree_root(&worktree));
 
-        // A submodule's gitfile is identical in shape - only the segment it
-        // points into differs.
-        let submodule = temp.path().join("libs/sub");
-        create_dir_all(&submodule).unwrap();
-        write(
-            submodule.join(".git"),
-            "gitdir: ../../.git/modules/libs/sub\n",
-        )
-        .unwrap();
-        assert!(!is_linked_worktree_root(&submodule));
+        // A submodule's gitfile is identical in shape - only the directory it
+        // points at differs, and only by what git writes inside it.
+        register_submodule(temp.path(), "libs/sub");
+        assert!(!is_linked_worktree_root(temp.path().join("libs/sub")));
 
         assert!(!is_linked_worktree_root(temp.path().join("libs")));
+    }
+
+    #[test]
+    fn a_submodule_under_a_worktrees_path_is_not_a_worktree() {
+        // Git registers a submodule at `<git-dir>/modules/<its path>`, so a
+        // submodule anywhere below a directory named `worktrees` resolves to
+        // `.git/modules/packages/worktrees/foo` - whose parent segment is
+        // `worktrees`. Misreading that as a worktree drops a real project's
+        // files from the watcher.
+        let temp = TempDir::new().unwrap();
+        create_dir_all(temp.path().join(".git")).unwrap();
+        register_submodule(temp.path(), "packages/worktrees/foo");
+
+        assert!(!is_linked_worktree_root(
+            temp.path().join("packages/worktrees/foo")
+        ));
+    }
+
+    #[test]
+    fn a_dangling_worktree_is_not_a_worktree_root() {
+        // `git worktree add` writes an *absolute* path into the worktree's
+        // gitfile, so moving or deleting the main clone leaves the worktree
+        // pointing at nothing. Answering `true` here would send callers on to
+        // resolve a repository root out of a directory that isn't there.
+        let temp = TempDir::new().unwrap();
+        let repo = temp.path().join("repo");
+        create_dir_all(repo.join(".git")).unwrap();
+        let worktree = repo.join("other/wt");
+        register_worktree(&repo, "wt", &worktree);
+        assert!(is_linked_worktree_root(&worktree));
+
+        remove_dir_all(repo.join(".git")).unwrap();
+
+        assert!(!is_linked_worktree_root(&worktree));
     }
 
     #[test]
@@ -260,10 +333,10 @@ mod test {
         // reaches it, so it must not turn into a bogus relative path.
         register_worktree(&workspace, "outside", &temp.path().join("elsewhere"));
 
-        assert_eq!(
-            nested_linked_worktrees(&workspace),
-            vec![PathBuf::from("nested/wt")]
-        );
+        // `read_dir` order is not defined, so compare as a set.
+        let mut found = nested_linked_worktrees(&workspace);
+        found.sort();
+        assert_eq!(found, vec![PathBuf::from("nested/wt")]);
     }
 
     #[test]
@@ -272,7 +345,7 @@ mod test {
         create_dir_all(temp.path().join(".git")).unwrap();
         register_worktree(temp.path(), "gone", &temp.path().join("wt"));
         // Worktree deleted by hand, before `git worktree prune` ran.
-        std::fs::remove_dir_all(temp.path().join("wt")).unwrap();
+        remove_dir_all(temp.path().join("wt")).unwrap();
 
         assert!(nested_linked_worktrees(temp.path()).is_empty());
 

--- a/packages/nx/src/native/utils/git.rs
+++ b/packages/nx/src/native/utils/git.rs
@@ -1,5 +1,8 @@
+use dashmap::DashMap;
 use std::fs::read_to_string;
 use std::path::{Path, PathBuf};
+use std::sync::LazyLock;
+use std::time::SystemTime;
 
 /// Prefix of a "gitfile" - the plain file git writes in place of a `.git`
 /// directory for linked worktrees and submodules.
@@ -164,25 +167,75 @@ pub fn is_linked_worktree_root<P: AsRef<Path>>(path: P) -> bool {
 pub fn nested_linked_worktrees<P: AsRef<Path>>(workspace_root: P) -> Vec<PathBuf> {
     let workspace_root = workspace_root.as_ref();
 
-    let Some(git_dir) = find_git_root(workspace_root)
-        .as_deref()
-        .and_then(resolve_git_dir)
-    else {
-        return Vec::new();
-    };
-
-    // No `commondir` means `git_dir` is already the common directory - the
-    // ordinary case of running from the main repository rather than a
-    // worktree of it.
-    let common_dir = common_git_dir(&git_dir).unwrap_or(git_dir);
-    let Ok(entries) = common_dir.join("worktrees").read_dir() else {
-        return Vec::new();
-    };
+    // Revalidating costs one `stat` of the registry git already tracks. Every
+    // other step - the walk up to the git root, the `commondir` read, the
+    // `read_dir` - is skipped, which is the whole point: those are what made
+    // this measurable on walks that can never contain a worktree.
+    if let Some(cached) = NESTED_WORKTREES.get(workspace_root) {
+        if modified_at(&cached.registry) == cached.signature {
+            return cached.roots.clone();
+        }
+    }
 
     // `gitdir` files hold canonical paths, while the walk root may reach the
     // same directory through a symlink or a relative path - canonicalize both
     // sides so the prefix comparison lines up.
     let canonical_root = canonicalize_or_own(workspace_root);
+    // Where a `read_dir` would look, and the path whose mtime decides whether
+    // a cached answer is still good. Absent when the root is in no repository
+    // at all, in which case `.git` appearing is the thing to watch for.
+    let registry = registry_dir(workspace_root).unwrap_or_else(|| canonical_root.join(".git"));
+    let signature = modified_at(&registry);
+
+    let roots = read_nested_linked_worktrees(&registry, &canonical_root);
+    NESTED_WORKTREES.insert(
+        workspace_root.to_path_buf(),
+        CachedWorktrees {
+            registry,
+            signature,
+            roots: roots.clone(),
+        },
+    );
+    roots
+}
+
+/// `<git-dir>/worktrees` for `workspace_root`, wherever git keeps it.
+fn registry_dir(workspace_root: &Path) -> Option<PathBuf> {
+    let git_dir = find_git_root(workspace_root)
+        .as_deref()
+        .and_then(resolve_git_dir)?;
+    // No `commondir` means `git_dir` is already the common directory - the
+    // ordinary case of running from the main repository rather than a
+    // worktree of it.
+    let common_dir = common_git_dir(&git_dir).unwrap_or(git_dir);
+    Some(common_dir.join("worktrees"))
+}
+
+fn modified_at(path: &Path) -> Option<SystemTime> {
+    std::fs::metadata(path).ok()?.modified().ok()
+}
+
+struct CachedWorktrees {
+    registry: PathBuf,
+    signature: Option<SystemTime>,
+    roots: Vec<PathBuf>,
+}
+
+/// Answers for one workspace root, revalidated on every call.
+///
+/// Resolving from scratch is a walk up to the git root, a `commondir` read
+/// and a `read_dir` - measured at ~7us, and paid on every walk including the
+/// task-output walks in `expand_outputs`, which can never contain a worktree.
+/// Git touches `<git-dir>/worktrees` whenever one is added or removed, so one
+/// `stat` of that directory stands in for all of it. A worktree created while
+/// the daemon is running is still picked up on the next walk, which is the
+/// property resolving per walk was for.
+static NESTED_WORKTREES: LazyLock<DashMap<PathBuf, CachedWorktrees>> = LazyLock::new(DashMap::new);
+
+fn read_nested_linked_worktrees(registry: &Path, canonical_root: &Path) -> Vec<PathBuf> {
+    let Ok(entries) = registry.read_dir() else {
+        return Vec::new();
+    };
 
     entries
         .filter_map(|entry| {
@@ -348,6 +401,43 @@ mod test {
         remove_dir_all(repo.join(".git")).unwrap();
 
         assert!(!is_linked_worktree_root(&worktree));
+    }
+
+    #[test]
+    fn sees_a_worktree_created_after_an_earlier_answer_was_cached() {
+        // The per-walk resolution existed so a worktree added while the daemon
+        // runs is picked up on the next graph construction. The cache keeps
+        // that by revalidating against the registry's mtime.
+        let temp = TempDir::new().unwrap();
+        create_dir_all(temp.path().join(".git")).unwrap();
+
+        assert!(nested_linked_worktrees(temp.path()).is_empty());
+
+        register_worktree(temp.path(), "wt", &temp.path().join("nested/wt"));
+
+        assert_eq!(
+            nested_linked_worktrees(temp.path()),
+            vec![PathBuf::from("nested/wt")]
+        );
+    }
+
+    #[test]
+    fn sees_a_second_worktree_added_after_the_first() {
+        let temp = TempDir::new().unwrap();
+        create_dir_all(temp.path().join(".git")).unwrap();
+        register_worktree(temp.path(), "one", &temp.path().join("wt1"));
+
+        assert_eq!(nested_linked_worktrees(temp.path()).len(), 1);
+
+        register_worktree(temp.path(), "two", &temp.path().join("wt2"));
+
+        let mut found = nested_linked_worktrees(temp.path());
+        found.sort();
+        assert_eq!(
+            found,
+            vec![PathBuf::from("wt1"), PathBuf::from("wt2")],
+            "a worktree added after a cached answer must still be seen"
+        );
     }
 
     #[test]

--- a/packages/nx/src/native/utils/git.rs
+++ b/packages/nx/src/native/utils/git.rs
@@ -83,7 +83,7 @@ fn read_path_file(file: &Path, base: &Path) -> Option<PathBuf> {
 /// Read a gitfile - the `gitdir: <path>` form git writes in place of a `.git`
 /// directory. Only the working tree side carries the prefix; the metadata
 /// side records a bare path.
-fn read_gitfile(gitfile: &Path, base: &Path) -> Option<PathBuf> {
+pub fn read_gitfile(gitfile: &Path, base: &Path) -> Option<PathBuf> {
     let contents = read_to_string(gitfile).ok()?;
     resolve_recorded_path(contents.trim().strip_prefix(GITDIR_PREFIX)?.trim(), base)
 }
@@ -103,7 +103,7 @@ fn resolve_git_dir(git_root: &Path) -> Option<PathBuf> {
 /// The git directory shared by every worktree of a repository. Walking from
 /// inside a linked worktree lands on `<main>/.git/worktrees/<name>`, whose
 /// `commondir` points back at the main `.git`.
-fn common_git_dir(git_dir: &Path) -> PathBuf {
+pub fn common_git_dir(git_dir: &Path) -> PathBuf {
     let Ok(contents) = read_to_string(git_dir.join("commondir")) else {
         return git_dir.to_path_buf();
     };

--- a/packages/nx/src/native/utils/git.rs
+++ b/packages/nx/src/native/utils/git.rs
@@ -171,10 +171,10 @@ pub fn nested_linked_worktrees<P: AsRef<Path>>(workspace_root: P) -> Vec<PathBuf
     // other step - the walk up to the git root, the `commondir` read, the
     // `read_dir` - is skipped, which is the whole point: those are what made
     // this measurable on walks that can never contain a worktree.
-    if let Some(cached) = NESTED_WORKTREES.get(workspace_root) {
-        if modified_at(&cached.registry) == cached.signature {
-            return cached.roots.clone();
-        }
+    if let Some(cached) = NESTED_WORKTREES.get(workspace_root)
+        && modified_at(&cached.registry) == cached.signature
+    {
+        return cached.roots.clone();
     }
 
     // `gitdir` files hold canonical paths, while the walk root may reach the
@@ -232,6 +232,17 @@ struct CachedWorktrees {
 /// property resolving per walk was for.
 static NESTED_WORKTREES: LazyLock<DashMap<PathBuf, CachedWorktrees>> = LazyLock::new(DashMap::new);
 
+/// Whether the checkout's `gitfile` names `metadata_dir` as its git directory,
+/// which only the matching half of the same worktree does.
+fn points_back_at(gitfile: &Path, metadata_dir: &Path) -> bool {
+    let Some(parent) = gitfile.parent() else {
+        return false;
+    };
+
+    read_gitfile(gitfile, parent)
+        .is_some_and(|named| canonicalize_or_own(&named) == canonicalize_or_own(metadata_dir))
+}
+
 fn read_nested_linked_worktrees(registry: &Path, canonical_root: &Path) -> Vec<PathBuf> {
     let Ok(entries) = registry.read_dir() else {
         return Vec::new();
@@ -243,17 +254,21 @@ fn read_nested_linked_worktrees(registry: &Path, canonical_root: &Path) -> Vec<P
             // Points at the worktree's own `.git` gitfile, so its parent is
             // the worktree root.
             let gitfile = read_path_file(&metadata_dir.join("gitdir"), &metadata_dir)?;
-            // A registration outlives a worktree deleted by hand, so only
-            // prune while the gitfile is actually there. Otherwise an
-            // ordinary directory later created at the same path - before
-            // anyone ran `git worktree prune` - would vanish from the graph.
-            if !gitfile.is_file() {
+            // A registration outlives a worktree deleted by hand -
+            // `gc.worktreePruneExpire` defaults to three months - so whatever
+            // holds the path now has to earn being pruned. Only the two halves
+            // of one worktree name each other, so requiring the gitfile to
+            // point back here is what earns it. A submodule added at the path
+            // since is the case this catches: its `.git` is a file too, so it
+            // satisfies any check that only asks whether something is there,
+            // but it names `<git-dir>/modules/<..>` and stays in the graph.
+            if !points_back_at(&gitfile, &metadata_dir) {
                 return None;
             }
 
             let worktree_root = canonicalize_or_own(gitfile.parent()?);
 
-            let relative = worktree_root.strip_prefix(&canonical_root).ok()?;
+            let relative = worktree_root.strip_prefix(canonical_root).ok()?;
             // An empty path means the workspace root *is* the worktree -
             // running Nx from inside one is ordinary. The watcher joins these
             // onto its origin and blocks every path under them, so an empty
@@ -438,6 +453,58 @@ mod test {
             vec![PathBuf::from("wt1"), PathBuf::from("wt2")],
             "a worktree added after a cached answer must still be seen"
         );
+    }
+
+    #[test]
+    fn keeps_a_submodule_that_reoccupied_a_stale_worktree_path() {
+        // The registration outlives the worktree by up to three months of
+        // `gc.worktreePruneExpire`. A submodule added at the path in the
+        // meantime has a `.git` file of its own, so a liveness check that only
+        // asks whether the gitfile exists prunes it and its sources leave the
+        // graph - which is exactly what this module promises never to do.
+        let temp = TempDir::new().unwrap();
+        create_dir_all(temp.path().join(".git")).unwrap();
+
+        register_worktree(temp.path(), "gone", &temp.path().join("libs/sub"));
+        remove_dir_all(temp.path().join("libs/sub")).unwrap();
+
+        register_submodule(temp.path(), "libs/sub");
+        write(temp.path().join("libs/sub/lib.ts"), "x").unwrap();
+
+        assert!(
+            nested_linked_worktrees(temp.path()).is_empty(),
+            "a submodule at a stale worktree path must stay in the graph"
+        );
+        assert!(!is_linked_worktree_root(temp.path().join("libs/sub")));
+    }
+
+    #[test]
+    fn keeps_a_worktree_whose_registration_names_a_different_checkout() {
+        // Two halves that do not name each other are not one worktree. Git
+        // does not write this, but a hand-edited or half-copied `.git` reaches
+        // the same state, and pruning on it drops real sources.
+        let temp = TempDir::new().unwrap();
+        create_dir_all(temp.path().join(".git")).unwrap();
+        register_worktree(temp.path(), "wt", &temp.path().join("real"));
+
+        // Point the registration at a checkout that belongs to another one.
+        let other = temp.path().join("other");
+        create_dir_all(&other).unwrap();
+        write(
+            other.join(".git"),
+            format!(
+                "gitdir: {}\n",
+                temp.path().join(".git/worktrees/elsewhere").display()
+            ),
+        )
+        .unwrap();
+        write(
+            temp.path().join(".git/worktrees/wt/gitdir"),
+            format!("{}\n", other.join(".git").display()),
+        )
+        .unwrap();
+
+        assert!(nested_linked_worktrees(temp.path()).is_empty());
     }
 
     #[test]

--- a/packages/nx/src/native/utils/git.rs
+++ b/packages/nx/src/native/utils/git.rs
@@ -2,7 +2,7 @@ use dashmap::DashMap;
 use std::fs::read_to_string;
 use std::path::{Path, PathBuf};
 use std::sync::LazyLock;
-use std::time::SystemTime;
+use std::time::{Duration, SystemTime};
 
 /// Prefix of a "gitfile" - the plain file git writes in place of a `.git`
 /// directory for linked worktrees and submodules.
@@ -188,15 +188,46 @@ pub fn nested_linked_worktrees<P: AsRef<Path>>(workspace_root: P) -> Vec<PathBuf
     let signature = modified_at(&registry);
 
     let roots = read_nested_linked_worktrees(&registry, &canonical_root);
-    NESTED_WORKTREES.insert(
-        workspace_root.to_path_buf(),
-        CachedWorktrees {
-            registry,
-            signature,
-            roots: roots.clone(),
-        },
-    );
+    if is_settled(signature) {
+        NESTED_WORKTREES.insert(
+            workspace_root.to_path_buf(),
+            CachedWorktrees {
+                registry,
+                signature,
+                roots: roots.clone(),
+            },
+        );
+    } else {
+        NESTED_WORKTREES.remove(workspace_root);
+    }
     roots
+}
+
+/// How long a registry's mtime has to have stood before it can stand in for
+/// the registry's contents.
+///
+/// Wider than the coarsest filesystem timestamp anyone runs this on; the cost
+/// of being wrong the other way is one ~7us resolution.
+const RACY_WINDOW: Duration = Duration::from_secs(2);
+
+/// Whether `mtime` is old enough that a later change is guaranteed to move it.
+///
+/// A change landing in the same filesystem clock tick as the mtime we recorded
+/// writes back the value we already hold, so a later comparison sees no change
+/// and the cache serves an answer that is wrong until the next one. Git has
+/// the same problem with index entries and calls them "racily clean".
+/// Declining to cache inside that window closes it on every filesystem,
+/// without a second signature component to be wrong about.
+fn is_settled(mtime: Option<SystemTime>) -> bool {
+    // No registry to time. Its appearance moves the signature off `None`,
+    // which no granularity can hide.
+    let Some(mtime) = mtime else {
+        return true;
+    };
+
+    SystemTime::now()
+        .duration_since(mtime)
+        .is_ok_and(|age| age > RACY_WINDOW)
 }
 
 /// `<git-dir>/worktrees` for `workspace_root`, wherever git keeps it.
@@ -227,9 +258,11 @@ struct CachedWorktrees {
 /// and a `read_dir` - measured at ~7us, and paid on every walk including the
 /// task-output walks in `expand_outputs`, which can never contain a worktree.
 /// Git touches `<git-dir>/worktrees` whenever it adds or removes a
-/// registration, so one `stat` of that directory stands in for all of it. A
-/// worktree created while the daemon is running is still picked up on the next
-/// walk, which is the property resolving per walk was for.
+/// registration, so one `stat` of that directory stands in for all of it, once
+/// that timestamp has stood still long enough to be trusted - see
+/// [`is_settled`]. A worktree created while the daemon is running is still
+/// picked up on the next walk, which is the property resolving per walk was
+/// for.
 ///
 /// Deleting a checkout with `rm -rf` rather than `git worktree remove` leaves
 /// the registration and the mtime untouched, so a warm entry keeps pruning a
@@ -437,6 +470,26 @@ mod test {
         assert_eq!(
             nested_linked_worktrees(temp.path()),
             vec![PathBuf::from("nested/wt")]
+        );
+    }
+
+    #[test]
+    fn does_not_cache_a_registry_that_was_just_modified() {
+        // The mtime of a registry that changed moments ago cannot yet stand in
+        // for its contents: a second change landing in the same clock tick
+        // writes back the value we would have stored, and the comparison that
+        // is supposed to catch it sees no change. Caching only once the
+        // timestamp has stood still is what closes that window, so the absence
+        // of an entry here is the fix, not an accident of timing.
+        let temp = TempDir::new().unwrap();
+        create_dir_all(temp.path().join(".git")).unwrap();
+        register_worktree(temp.path(), "one", &temp.path().join("wt1"));
+
+        assert_eq!(nested_linked_worktrees(temp.path()).len(), 1);
+
+        assert!(
+            NESTED_WORKTREES.get(temp.path()).is_none(),
+            "a registry modified moments ago must not be cached"
         );
     }
 

--- a/packages/nx/src/native/utils/git.rs
+++ b/packages/nx/src/native/utils/git.rs
@@ -226,10 +226,14 @@ struct CachedWorktrees {
 /// Resolving from scratch is a walk up to the git root, a `commondir` read
 /// and a `read_dir` - measured at ~7us, and paid on every walk including the
 /// task-output walks in `expand_outputs`, which can never contain a worktree.
-/// Git touches `<git-dir>/worktrees` whenever one is added or removed, so one
-/// `stat` of that directory stands in for all of it. A worktree created while
-/// the daemon is running is still picked up on the next walk, which is the
-/// property resolving per walk was for.
+/// Git touches `<git-dir>/worktrees` whenever it adds or removes a
+/// registration, so one `stat` of that directory stands in for all of it. A
+/// worktree created while the daemon is running is still picked up on the next
+/// walk, which is the property resolving per walk was for.
+///
+/// Deleting a checkout with `rm -rf` rather than `git worktree remove` leaves
+/// the registration and the mtime untouched, so a warm entry keeps pruning a
+/// path a cold resolve rejects, until the next add or remove.
 static NESTED_WORKTREES: LazyLock<DashMap<PathBuf, CachedWorktrees>> = LazyLock::new(DashMap::new);
 
 /// Whether the checkout's `gitfile` names `metadata_dir` as its git directory,

--- a/packages/nx/src/native/walker.rs
+++ b/packages/nx/src/native/walker.rs
@@ -44,12 +44,36 @@ where
 
     let ignore_glob_set = build_glob_set(&base_ignores).expect("Should be valid globs");
 
+    // Same prune as `create_walker`, for the same reason: a linked worktree is
+    // a full second checkout, and walking it multiplies the file set for no
+    // gain. It matters more here than it looks. The daemon expands a
+    // directory-creation event by walking the new directory
+    // (`transform_event_to_watch_events`) and backfills a newly watched
+    // directory the same way, so without this a `git worktree add` inside the
+    // workspace reports every file of the new checkout as created.
+    let walk_root = base_dir.clone();
+    let worktrees: HashSet<PathBuf> = nested_linked_worktrees(&base_dir).into_iter().collect();
+
     // Use WalkDir instead of ignore::WalkBuilder because it's faster
     WalkDir::new(&base_dir)
         .into_iter()
         .filter_entry(move |entry| {
             let path = entry.path().to_string_lossy();
-            !ignore_glob_set.is_match(path.as_ref())
+            if ignore_glob_set.is_match(path.as_ref()) {
+                return false;
+            }
+
+            if worktrees.is_empty() {
+                return true;
+            }
+
+            // `filter_entry` prunes the entry's whole subtree, so matching the
+            // worktree root is enough to keep the checkout out.
+            entry
+                .path()
+                .strip_prefix(&walk_root)
+                .map(|relative| !worktrees.contains(relative))
+                .unwrap_or(true)
         })
         .filter_map(move |entry| {
             entry.ok().and_then(|e| {
@@ -357,6 +381,23 @@ mod test {
             files,
             vec!["libs/sub/lib.ts".to_string(), "test.txt".to_string()]
         );
+    }
+
+    #[test]
+    fn nx_walker_sync_skips_linked_worktrees() {
+        // The daemon expands a directory-creation event, and backfills a newly
+        // watched directory, by walking it with `nx_walker_sync`. Both run over
+        // whatever `git worktree add` just wrote, so a walk that descends into
+        // a checkout reports every file in it as created.
+        let temp_dir = setup_worktree_fs();
+
+        let mut files = nx_walker_sync(temp_dir.path(), None)
+            .map(|p| p.to_string_lossy().replace('\\', "/"))
+            .filter(|p| p.ends_with(".ts"))
+            .collect::<Vec<_>>();
+        files.sort();
+
+        assert_eq!(files, vec!["libs/sub/lib.ts".to_string()]);
     }
 
     #[test]

--- a/packages/nx/src/native/walker.rs
+++ b/packages/nx/src/native/walker.rs
@@ -1,4 +1,5 @@
 use ignore::WalkBuilder;
+use std::collections::HashSet;
 use std::fmt::Debug;
 use std::path::{Path, PathBuf};
 
@@ -6,7 +7,10 @@ use crate::native::glob::build_glob_set;
 
 #[cfg(not(target_arch = "wasm32"))]
 use crate::native::logger::enable_logger;
-use crate::native::utils::{Normalize, get_mod_time, git::parent_gitignore_files};
+use crate::native::utils::{
+    Normalize, get_mod_time,
+    git::{nested_linked_worktrees, parent_gitignore_files},
+};
 use walkdir::WalkDir;
 
 #[derive(PartialEq, Debug, Ord, PartialOrd, Eq, Clone)]
@@ -209,6 +213,16 @@ where
     walker.require_git(false);
     walker.hidden(false);
 
+    // Linked worktrees are full checkouts of the workspace nested inside it.
+    // Walking one multiplies the file set for no gain. Only resolved for
+    // workspace walks - `use_ignores: false` callers (cache output expansion)
+    // walk task outputs, which never contain a worktree.
+    let worktrees: HashSet<PathBuf> = if use_ignores {
+        nested_linked_worktrees(&directory).into_iter().collect()
+    } else {
+        HashSet::new()
+    };
+
     if use_ignores {
         // Handle parent .gitignore files based on git repository boundaries
         if let Some(gitignore_paths) = parent_gitignore_files(&directory) {
@@ -229,9 +243,24 @@ where
     }
 
     // We should make sure to always ignore node_modules and the .git folder
+    let walk_root = directory.clone();
     walker.filter_entry(move |entry| {
         let path = entry.path().to_string_lossy();
-        !ignore_glob_set.is_match(path.as_ref())
+        if ignore_glob_set.is_match(path.as_ref()) {
+            return false;
+        }
+
+        if worktrees.is_empty() {
+            return true;
+        }
+
+        // Entry paths are built from the walk root, so stripping it back off
+        // yields the same relative form the worktree roots were stored in.
+        entry
+            .path()
+            .strip_prefix(&walk_root)
+            .map(|relative| !worktrees.contains(relative))
+            .unwrap_or(true)
     });
     walker
 }
@@ -286,6 +315,65 @@ mod test {
                 (temp_dir.join("foo.txt"), PathBuf::from("foo.txt")),
                 (temp_dir.join("test.txt"), PathBuf::from("test.txt")),
             ]
+        );
+    }
+
+    /// Registers `relative_path` as a linked worktree of `repo`, mirroring
+    /// the on-disk layout `git worktree add` produces.
+    fn add_linked_worktree(repo: &Path, name: &str, relative_path: &str) {
+        use std::fs::{create_dir_all, write};
+
+        let worktree_root = repo.join(relative_path);
+        let metadata_dir = repo.join(".git").join("worktrees").join(name);
+        create_dir_all(&worktree_root).unwrap();
+        create_dir_all(&metadata_dir).unwrap();
+
+        // The worktree's gitfile points at its metadata directory...
+        write(
+            worktree_root.join(".git"),
+            format!("gitdir: {}\n", metadata_dir.display()),
+        )
+        .unwrap();
+        // ...and the metadata directory points back at that gitfile.
+        write(
+            metadata_dir.join("gitdir"),
+            format!("{}\n", worktree_root.join(".git").display()),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn it_skips_linked_worktrees_but_keeps_submodules() {
+        let temp_dir = TempDir::new().unwrap();
+        temp_dir
+            .child(".git/HEAD")
+            .write_str("ref: refs/heads/main")
+            .unwrap();
+        temp_dir.child("test.txt").write_str("content").unwrap();
+
+        // Agent tooling nests worktrees under `.claude/worktrees`, but a
+        // worktree is just as valid anywhere else - both have to be pruned.
+        for (name, path) in [("wt1", ".claude/worktrees/wt1"), ("wt2", "other/wt2")] {
+            add_linked_worktree(temp_dir.path(), name, path);
+            temp_dir.child(path).child("app.ts").write_str("x").unwrap();
+        }
+
+        // A submodule uses the very same gitfile mechanism, but its contents
+        // are real workspace files that must keep being scanned.
+        temp_dir
+            .child("libs/sub/.git")
+            .write_str("gitdir: ../../.git/modules/libs/sub\n")
+            .unwrap();
+        temp_dir.child("libs/sub/lib.ts").write_str("x").unwrap();
+
+        let mut files = nx_walker(&temp_dir, true)
+            .map(|f| f.normalized_path)
+            .collect::<Vec<_>>();
+        files.sort();
+
+        assert_eq!(
+            files,
+            vec!["libs/sub/lib.ts".to_string(), "test.txt".to_string()]
         );
     }
 

--- a/packages/nx/src/native/walker.rs
+++ b/packages/nx/src/native/walker.rs
@@ -214,14 +214,14 @@ where
     walker.hidden(false);
 
     // Linked worktrees are full checkouts of the workspace nested inside it.
-    // Walking one multiplies the file set for no gain. Only resolved for
-    // workspace walks - `use_ignores: false` callers (cache output expansion)
-    // walk task outputs, which never contain a worktree.
-    let worktrees: HashSet<PathBuf> = if use_ignores {
-        nested_linked_worktrees(&directory).into_iter().collect()
-    } else {
-        HashSet::new()
-    };
+    // Walking one multiplies the file set for no gain. This applies whatever
+    // `use_ignores` says: the daemon's output watcher walks the workspace
+    // root with `use_ignores: false` (`watchOutputFiles` in
+    // daemon/server/watcher.ts) and takes a non-recursive inotify descriptor
+    // per directory the walk yields, where exhausting the limit is fatal.
+    // Resolution costs a handful of syscalls and nothing per entry when the
+    // repository has no worktrees.
+    let worktrees: HashSet<PathBuf> = nested_linked_worktrees(&directory).into_iter().collect();
 
     if use_ignores {
         // Handle parent .gitignore files based on git repository boundaries
@@ -318,32 +318,10 @@ mod test {
         );
     }
 
-    /// Registers `relative_path` as a linked worktree of `repo`, mirroring
-    /// the on-disk layout `git worktree add` produces.
-    fn add_linked_worktree(repo: &Path, name: &str, relative_path: &str) {
-        use std::fs::{create_dir_all, write};
+    /// A workspace with two linked worktrees and one submodule nested in it.
+    fn setup_worktree_fs() -> TempDir {
+        use crate::native::utils::git::test_support::{register_submodule, register_worktree};
 
-        let worktree_root = repo.join(relative_path);
-        let metadata_dir = repo.join(".git").join("worktrees").join(name);
-        create_dir_all(&worktree_root).unwrap();
-        create_dir_all(&metadata_dir).unwrap();
-
-        // The worktree's gitfile points at its metadata directory...
-        write(
-            worktree_root.join(".git"),
-            format!("gitdir: {}\n", metadata_dir.display()),
-        )
-        .unwrap();
-        // ...and the metadata directory points back at that gitfile.
-        write(
-            metadata_dir.join("gitdir"),
-            format!("{}\n", worktree_root.join(".git").display()),
-        )
-        .unwrap();
-    }
-
-    #[test]
-    fn it_skips_linked_worktrees_but_keeps_submodules() {
         let temp_dir = TempDir::new().unwrap();
         temp_dir
             .child(".git/HEAD")
@@ -354,17 +332,21 @@ mod test {
         // Agent tooling nests worktrees under `.claude/worktrees`, but a
         // worktree is just as valid anywhere else - both have to be pruned.
         for (name, path) in [("wt1", ".claude/worktrees/wt1"), ("wt2", "other/wt2")] {
-            add_linked_worktree(temp_dir.path(), name, path);
+            register_worktree(temp_dir.path(), name, &temp_dir.path().join(path));
             temp_dir.child(path).child("app.ts").write_str("x").unwrap();
         }
 
         // A submodule uses the very same gitfile mechanism, but its contents
         // are real workspace files that must keep being scanned.
-        temp_dir
-            .child("libs/sub/.git")
-            .write_str("gitdir: ../../.git/modules/libs/sub\n")
-            .unwrap();
+        register_submodule(temp_dir.path(), "libs/sub");
         temp_dir.child("libs/sub/lib.ts").write_str("x").unwrap();
+
+        temp_dir
+    }
+
+    #[test]
+    fn it_skips_linked_worktrees_but_keeps_submodules() {
+        let temp_dir = setup_worktree_fs();
 
         let mut files = nx_walker(&temp_dir, true)
             .map(|f| f.normalized_path)
@@ -374,6 +356,29 @@ mod test {
         assert_eq!(
             files,
             vec!["libs/sub/lib.ts".to_string(), "test.txt".to_string()]
+        );
+    }
+
+    #[test]
+    fn it_skips_linked_worktrees_without_ignores() {
+        // `watchOutputFiles` builds its watcher over the workspace root with
+        // ignores off, and every directory the walk yields costs an inotify
+        // descriptor. Gating the prune on `use_ignores` handed a worktree's
+        // whole checkout back to it.
+        let temp_dir = setup_worktree_fs();
+
+        let mut files = nx_walker(&temp_dir, false)
+            .map(|f| f.normalized_path)
+            .collect::<Vec<_>>();
+        files.sort();
+
+        assert!(
+            !files.iter().any(|f| f.contains("wt1") || f.contains("wt2")),
+            "worktree contents must be pruned with ignores off too; got {files:?}"
+        );
+        assert!(
+            files.iter().any(|f| f == "libs/sub/lib.ts"),
+            "submodule contents must still be walked; got {files:?}"
         );
     }
 

--- a/packages/nx/src/native/walker.rs
+++ b/packages/nx/src/native/walker.rs
@@ -239,12 +239,14 @@ where
 
     // Linked worktrees are full checkouts of the workspace nested inside it.
     // Walking one multiplies the file set for no gain. This applies whatever
-    // `use_ignores` says: the daemon's output watcher walks the workspace
-    // root with `use_ignores: false` (`watchOutputFiles` in
-    // daemon/server/watcher.ts) and takes a non-recursive inotify descriptor
-    // per directory the walk yields, where exhausting the limit is fatal.
-    // Resolution costs a handful of syscalls and nothing per entry when the
-    // repository has no worktrees.
+    // `use_ignores` says, because that flag does not mean "not the workspace":
+    // the daemon's output watcher (`watchOutputFiles` in
+    // daemon/server/watcher.ts) walks the workspace root with it false, and
+    // takes a non-recursive inotify descriptor per directory the walk yields,
+    // where exhausting the limit is fatal. Cache output expansion
+    // (`expand_outputs`) passes it false too and walks task outputs, which
+    // hold no worktree - it pays the resolution for nothing, which is a
+    // handful of syscalls per walk and nothing per entry.
     let worktrees: HashSet<PathBuf> = nested_linked_worktrees(&directory).into_iter().collect();
 
     if use_ignores {

--- a/packages/nx/src/native/walker.rs
+++ b/packages/nx/src/native/walker.rs
@@ -1,4 +1,5 @@
 use ignore::WalkBuilder;
+use std::collections::HashSet;
 use std::fmt::Debug;
 use std::path::{Path, PathBuf};
 
@@ -6,7 +7,10 @@ use crate::native::glob::build_glob_set;
 
 #[cfg(not(target_arch = "wasm32"))]
 use crate::native::logger::enable_logger;
-use crate::native::utils::{Normalize, get_mod_time, git::parent_gitignore_files};
+use crate::native::utils::{
+    Normalize, get_mod_time,
+    git::{nested_linked_worktrees, parent_gitignore_files},
+};
 use walkdir::WalkDir;
 
 #[derive(PartialEq, Debug, Ord, PartialOrd, Eq, Clone)]
@@ -195,6 +199,16 @@ where
     walker.require_git(false);
     walker.hidden(false);
 
+    // Linked worktrees are full checkouts of the workspace nested inside it.
+    // Walking one multiplies the file set for no gain. Only resolved for
+    // workspace walks - `use_ignores: false` callers (cache output expansion)
+    // walk task outputs, which never contain a worktree.
+    let worktrees: HashSet<PathBuf> = if use_ignores {
+        nested_linked_worktrees(&directory).into_iter().collect()
+    } else {
+        HashSet::new()
+    };
+
     if use_ignores {
         // Handle parent .gitignore files based on git repository boundaries
         if let Some(gitignore_paths) = parent_gitignore_files(&directory) {
@@ -215,9 +229,24 @@ where
     }
 
     // We should make sure to always ignore node_modules and the .git folder
+    let walk_root = directory.clone();
     walker.filter_entry(move |entry| {
         let path = entry.path().to_string_lossy();
-        !ignore_glob_set.is_match(path.as_ref())
+        if ignore_glob_set.is_match(path.as_ref()) {
+            return false;
+        }
+
+        if worktrees.is_empty() {
+            return true;
+        }
+
+        // Entry paths are built from the walk root, so stripping it back off
+        // yields the same relative form the worktree roots were stored in.
+        entry
+            .path()
+            .strip_prefix(&walk_root)
+            .map(|relative| !worktrees.contains(relative))
+            .unwrap_or(true)
     });
     walker
 }
@@ -272,6 +301,65 @@ mod test {
                 (temp_dir.join("foo.txt"), PathBuf::from("foo.txt")),
                 (temp_dir.join("test.txt"), PathBuf::from("test.txt")),
             ]
+        );
+    }
+
+    /// Registers `relative_path` as a linked worktree of `repo`, mirroring
+    /// the on-disk layout `git worktree add` produces.
+    fn add_linked_worktree(repo: &Path, name: &str, relative_path: &str) {
+        use std::fs::{create_dir_all, write};
+
+        let worktree_root = repo.join(relative_path);
+        let metadata_dir = repo.join(".git").join("worktrees").join(name);
+        create_dir_all(&worktree_root).unwrap();
+        create_dir_all(&metadata_dir).unwrap();
+
+        // The worktree's gitfile points at its metadata directory...
+        write(
+            worktree_root.join(".git"),
+            format!("gitdir: {}\n", metadata_dir.display()),
+        )
+        .unwrap();
+        // ...and the metadata directory points back at that gitfile.
+        write(
+            metadata_dir.join("gitdir"),
+            format!("{}\n", worktree_root.join(".git").display()),
+        )
+        .unwrap();
+    }
+
+    #[test]
+    fn it_skips_linked_worktrees_but_keeps_submodules() {
+        let temp_dir = TempDir::new().unwrap();
+        temp_dir
+            .child(".git/HEAD")
+            .write_str("ref: refs/heads/main")
+            .unwrap();
+        temp_dir.child("test.txt").write_str("content").unwrap();
+
+        // Agent tooling nests worktrees under `.claude/worktrees`, but a
+        // worktree is just as valid anywhere else - both have to be pruned.
+        for (name, path) in [("wt1", ".claude/worktrees/wt1"), ("wt2", "other/wt2")] {
+            add_linked_worktree(temp_dir.path(), name, path);
+            temp_dir.child(path).child("app.ts").write_str("x").unwrap();
+        }
+
+        // A submodule uses the very same gitfile mechanism, but its contents
+        // are real workspace files that must keep being scanned.
+        temp_dir
+            .child("libs/sub/.git")
+            .write_str("gitdir: ../../.git/modules/libs/sub\n")
+            .unwrap();
+        temp_dir.child("libs/sub/lib.ts").write_str("x").unwrap();
+
+        let mut files = nx_walker(&temp_dir, true)
+            .map(|f| f.normalized_path)
+            .collect::<Vec<_>>();
+        files.sort();
+
+        assert_eq!(
+            files,
+            vec!["libs/sub/lib.ts".to_string(), "test.txt".to_string()]
         );
     }
 

--- a/packages/nx/src/native/watch/types.rs
+++ b/packages/nx/src/native/watch/types.rs
@@ -174,11 +174,19 @@ pub(super) fn transform_event_to_watch_events(
 
     #[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
     {
+        use crate::native::utils::git::is_linked_worktree_root;
         use crate::native::walker::nx_walker_sync;
         use ignore::Match;
         use ignore::gitignore::GitignoreBuilder;
 
         if matches!(event_kind, EventKind::Create(CreateKind::Folder)) {
+            // A worktree root reaches the walk below as the walk's own root,
+            // where the prune is deliberately empty - Nx running from inside a
+            // worktree has to see its own files.
+            if is_linked_worktree_root(path_ref) {
+                return Ok(vec![]);
+            }
+
             let mut result = vec![];
 
             let mut gitignore_builder = GitignoreBuilder::new(origin);
@@ -249,4 +257,41 @@ fn relative_to_origin(path: &Path, origin: &str) -> PathBuf {
     path.strip_prefix(origin)
         .map(Path::to_path_buf)
         .unwrap_or_else(|_| path.to_path_buf())
+}
+
+#[cfg(test)]
+#[cfg(all(not(target_os = "macos"), not(target_os = "windows")))]
+mod test {
+    use super::*;
+    use crate::native::utils::git::test_support::register_worktree;
+    use std::path::MAIN_SEPARATOR;
+    use tempfile::tempdir;
+
+    #[test]
+    fn a_folder_event_for_a_worktree_root_expands_to_nothing() {
+        // Driving the watcher end to end cannot witness this: `git worktree
+        // add` makes the directory before it registers the worktree, so an
+        // idle ingest loop dequeues the event while the root still looks
+        // ordinary and the registration path handles it. The leak needs the
+        // event to arrive after git finished, which only a busy daemon
+        // produces. Handing the transform that state directly is the same
+        // question without the race.
+        let dir = tempdir().expect("tempdir");
+        let root = dir.path().canonicalize().expect("canonicalize");
+        let worktree = root.join(".claude/worktrees/wt");
+        register_worktree(&root, "wt", &worktree);
+        fs::create_dir_all(worktree.join("packages/app")).expect("mkdir checkout");
+        fs::write(worktree.join("packages/app/main.ts"), "x").expect("populate checkout");
+
+        let origin = format!("{}{}", root.display(), MAIN_SEPARATOR);
+        let event = Event::new(EventKind::Create(CreateKind::Folder)).add_path(worktree.clone());
+        let raw = RawWatchEvent::new(event);
+
+        let events = transform_event_to_watch_events(&raw, &origin).expect("transform");
+
+        assert!(
+            events.is_empty(),
+            "expected a worktree root to expand to nothing; got {events:?}"
+        );
+    }
 }

--- a/packages/nx/src/native/watch/watch_filterer.rs
+++ b/packages/nx/src/native/watch/watch_filterer.rs
@@ -229,3 +229,108 @@ pub(super) fn create_filter(
             .collect(),
     })
 }
+
+#[cfg(test)]
+mod test {
+    use std::path::{Path, PathBuf};
+
+    use assert_fs::TempDir;
+
+    use super::*;
+
+    fn filterer(origin: &Path, worktrees: &[PathBuf]) -> WatchFilterer {
+        create_filter(origin.to_str().unwrap(), &[], worktrees, false).expect("filter builds")
+    }
+
+    fn temp_origin(temp: &TempDir) -> PathBuf {
+        temp.path()
+            .canonicalize()
+            .unwrap_or_else(|_| temp.path().to_path_buf())
+    }
+
+    #[test]
+    fn blocks_everything_under_a_worktree_seeded_at_boot() {
+        // The only defence on macOS, where the root is watched recursively and
+        // the walker's prune never gets a say.
+        let temp = TempDir::new().unwrap();
+        let origin = temp_origin(&temp);
+        let worktree = origin.join(".claude/worktrees/wt");
+
+        let filterer = filterer(&origin, std::slice::from_ref(&worktree));
+
+        assert!(!filterer.filter_path(&worktree, true));
+        assert!(!filterer.filter_path(&worktree.join("libs/proj/src/app.ts"), false));
+        assert!(filterer.filter_path(&origin.join("libs/proj/src/app.ts"), false));
+    }
+
+    #[test]
+    fn matches_whole_path_components_only() {
+        // A prefix comparison on strings would swallow `wt-other` too.
+        let temp = TempDir::new().unwrap();
+        let origin = temp_origin(&temp);
+        let worktree = origin.join("nested/wt");
+
+        let filterer = filterer(&origin, std::slice::from_ref(&worktree));
+
+        assert!(!filterer.filter_path(&worktree.join("app.ts"), false));
+        assert!(filterer.filter_path(&origin.join("nested/wt-other/app.ts"), false));
+    }
+
+    #[test]
+    fn track_worktree_blocks_one_that_appears_after_boot() {
+        let temp = TempDir::new().unwrap();
+        let origin = temp_origin(&temp);
+        let worktree = origin.join(".claude/worktrees/wt");
+        let inside = worktree.join("app.ts");
+
+        let mut filterer = filterer(&origin, &[]);
+        assert!(filterer.filter_path(&inside, false));
+
+        filterer.track_worktree(&worktree);
+
+        assert!(!filterer.filter_path(&inside, false));
+    }
+
+    #[test]
+    fn track_worktree_refuses_the_origin() {
+        // Blocking the origin would silence the watcher for the whole session.
+        let temp = TempDir::new().unwrap();
+        let origin = temp_origin(&temp);
+
+        let mut filterer = filterer(&origin, &[]);
+        filterer.track_worktree(&origin);
+
+        assert!(filterer.worktrees.is_empty());
+        assert!(filterer.filter_path(&origin.join("nx.json"), false));
+    }
+
+    #[test]
+    fn track_worktree_refuses_paths_outside_the_origin() {
+        // `git worktree add ../elsewhere` is ordinary. Its events are not ours
+        // to block, and containment is what keeps them out.
+        let temp = TempDir::new().unwrap();
+        let elsewhere = TempDir::new().unwrap();
+        let origin = temp_origin(&temp);
+        let outside = temp_origin(&elsewhere).join("wt");
+
+        let mut filterer = filterer(&origin, &[]);
+        filterer.track_worktree(&outside);
+
+        assert!(filterer.worktrees.is_empty());
+    }
+
+    #[test]
+    fn track_worktree_does_not_accumulate_duplicates() {
+        // Called from the event stream and from every backfill, so the same
+        // root arrives repeatedly.
+        let temp = TempDir::new().unwrap();
+        let origin = temp_origin(&temp);
+        let worktree = origin.join("nested/wt");
+
+        let mut filterer = filterer(&origin, &[]);
+        filterer.track_worktree(&worktree);
+        filterer.track_worktree(&worktree);
+
+        assert_eq!(filterer.worktrees.len(), 1);
+    }
+}

--- a/packages/nx/src/native/watch/watch_filterer.rs
+++ b/packages/nx/src/native/watch/watch_filterer.rs
@@ -16,11 +16,25 @@ pub struct WatchFilterer {
     /// Per-directory gitignore instances, sorted deepest-first (most path components first).
     /// Each entry is (directory the .gitignore applies in, compiled Gitignore).
     git_ignores: Vec<(PathBuf, Gitignore)>,
+    /// Roots of linked worktrees resolved when the watcher booted. Matched as
+    /// path prefixes rather than compiled into the synthetic gitignore above,
+    /// so a worktree directory containing gitignore metacharacters can't
+    /// produce a bad pattern - or fail the watcher's construction outright.
+    worktrees: Vec<PathBuf>,
 }
 
 impl WatchFilterer {
     fn filter_path(&self, path: &std::path::Path, is_dir: bool) -> bool {
         let path = dunce::simplified(path);
+
+        if self
+            .worktrees
+            .iter()
+            .any(|worktree| path.starts_with(worktree))
+        {
+            trace!(?path, "inside a linked worktree - blocked");
+            return false;
+        }
 
         // .nxignore takes precedence over .gitignore. Only consult it for
         // paths under the origin — gitignore-style matchers are scoped to
@@ -119,6 +133,7 @@ impl WatchFilterer {
 pub(super) fn create_filter(
     origin: &str,
     additional_globs: &[String],
+    worktrees: &[PathBuf],
     use_ignore: bool,
 ) -> anyhow::Result<WatchFilterer> {
     let ignore_files = use_ignore.then(|| get_gitignore_files(origin));
@@ -188,5 +203,9 @@ pub(super) fn create_filter(
         origin: PathBuf::from(origin),
         git_ignores,
         nx_ignore,
+        worktrees: worktrees
+            .iter()
+            .map(|worktree| dunce::simplified(worktree).to_path_buf())
+            .collect(),
     })
 }

--- a/packages/nx/src/native/watch/watch_filterer.rs
+++ b/packages/nx/src/native/watch/watch_filterer.rs
@@ -16,7 +16,8 @@ pub struct WatchFilterer {
     /// Per-directory gitignore instances, sorted deepest-first (most path components first).
     /// Each entry is (directory the .gitignore applies in, compiled Gitignore).
     git_ignores: Vec<(PathBuf, Gitignore)>,
-    /// Roots of linked worktrees resolved when the watcher booted. Matched as
+    /// Roots of linked worktrees, seeded when the watcher booted and topped up
+    /// from the event stream by [`WatchFilterer::track_worktree`]. Matched as
     /// path prefixes rather than compiled into the synthetic gitignore above,
     /// so a worktree directory containing gitignore metacharacters can't
     /// produce a bad pattern - or fail the watcher's construction outright.
@@ -24,6 +25,25 @@ pub struct WatchFilterer {
 }
 
 impl WatchFilterer {
+    /// Start blocking everything under `root`. The boot-time list only covers
+    /// worktrees that already existed, and agent tooling runs
+    /// `git worktree add` against a running daemon - on macOS, where the root
+    /// is watched recursively, this is the only thing that keeps the new
+    /// checkout's events out until a restart.
+    pub fn track_worktree(&mut self, root: &std::path::Path) {
+        let root = dunce::simplified(root);
+
+        // Blocking the origin would silence the watcher permanently, and a
+        // path we can't place under the origin is not ours to block.
+        if !root.starts_with(&self.origin) || root == self.origin {
+            return;
+        }
+
+        if !self.worktrees.iter().any(|known| known == root) {
+            self.worktrees.push(root.to_path_buf());
+        }
+    }
+
     fn filter_path(&self, path: &std::path::Path, is_dir: bool) -> bool {
         let path = dunce::simplified(path);
 

--- a/packages/nx/src/native/watch/watch_filterer.rs
+++ b/packages/nx/src/native/watch/watch_filterer.rs
@@ -44,6 +44,20 @@ impl WatchFilterer {
         }
     }
 
+    /// Replace the tracked set with git's registry, which is authoritative.
+    /// [`WatchFilterer::track_worktree`] only ever adds, so a removed worktree
+    /// would stay blocked while the walker re-admits its path.
+    ///
+    /// Clearing loses nothing the event stream found: a path is only tracked
+    /// after `is_linked_worktree_root` read a `gitdir` for it, and that is a
+    /// registry entry.
+    pub fn set_worktrees(&mut self, roots: &[PathBuf]) {
+        self.worktrees.clear();
+        for root in roots {
+            self.track_worktree(root);
+        }
+    }
+
     fn filter_path(&self, path: &std::path::Path, is_dir: bool) -> bool {
         let path = dunce::simplified(path);
 
@@ -317,6 +331,26 @@ mod test {
         filterer.track_worktree(&outside);
 
         assert!(filterer.worktrees.is_empty());
+    }
+
+    #[test]
+    fn set_worktrees_stops_blocking_one_that_is_gone() {
+        // `track_worktree` only ever adds. Once a worktree is removed the
+        // walker admits its path again, so the filterer has to let go of it -
+        // otherwise those files sit in the graph with no event able to
+        // invalidate them until the daemon restarts.
+        let temp = TempDir::new().unwrap();
+        let origin = temp_origin(&temp);
+        let gone = origin.join(".claude/worktrees/gone");
+        let live = origin.join(".claude/worktrees/live");
+
+        let mut filterer = filterer(&origin, std::slice::from_ref(&gone));
+        assert!(!filterer.filter_path(&gone.join("app.ts"), false));
+
+        filterer.set_worktrees(std::slice::from_ref(&live));
+
+        assert!(filterer.filter_path(&gone.join("app.ts"), false));
+        assert!(!filterer.filter_path(&live.join("app.ts"), false));
     }
 
     #[test]

--- a/packages/nx/src/native/watch/watcher.rs
+++ b/packages/nx/src/native/watch/watcher.rs
@@ -212,10 +212,34 @@ impl WatchPipeline {
     /// worktree and the daemon, and `new_directories_from_event` below - which
     /// covers the Linux/Windows per-directory registration - is not compiled
     /// there.
+    ///
+    /// Two filters run before [`is_linked_worktree_root`], and both exist to
+    /// keep this from feeding itself. It runs ahead of the filterer - it has
+    /// to, or the gitfile would be discarded as a `.git` path before it was
+    /// read - so nothing else stops a `.git` event here, and answering one by
+    /// opening a `.git` publishes another. That is a closed loop: the
+    /// workspace's own `.git` produced ~2M events per run, starving every real
+    /// change behind them.
+    ///
+    /// Only a *file* can be a gitfile, and the event already carries the stat
+    /// (`fs::metadata` publishes nothing, unlike a read), so the main
+    /// repository's `.git` directory is skipped without touching the disk.
+    /// Only a *create* can be the moment a worktree appears, which keeps the
+    /// modify and access events on a worktree's own gitfile - the same loop,
+    /// one directory over - from reopening it.
     fn track_new_worktrees(&mut self, event: &RawWatchEvent) {
+        use crate::native::watch::types::meta_is_dir;
+        use notify::EventKind;
+
+        if !matches!(event.kind(), EventKind::Create(_)) {
+            return;
+        }
+
         let new_worktrees: Vec<PathBuf> = event
             .paths()
-            .filter(|(path, _)| path.file_name().is_some_and(|name| name == ".git"))
+            .filter(|(path, metadata)| {
+                !meta_is_dir(metadata) && path.file_name().is_some_and(|name| name == ".git")
+            })
             .filter_map(|(path, _)| path.parent())
             .filter(|root| is_linked_worktree_root(root))
             .map(Path::to_path_buf)

--- a/packages/nx/src/native/watch/watcher.rs
+++ b/packages/nx/src/native/watch/watcher.rs
@@ -12,6 +12,9 @@ use tracing::{debug, trace};
 
 #[cfg(not(target_os = "macos"))]
 use crate::native::glob::{NxGlobSet, build_glob_set};
+#[cfg(not(target_os = "macos"))]
+use crate::native::utils::git::is_linked_worktree_root;
+use crate::native::utils::git::nested_linked_worktrees;
 use crate::native::walker::HARDCODED_IGNORE_PATTERNS;
 #[cfg(not(target_os = "macos"))]
 use crate::native::walker::create_walker;
@@ -126,8 +129,18 @@ impl WatchPipeline {
         additional_globs: &[String],
         use_ignore: bool,
     ) -> std::result::Result<Self, String> {
-        let filterer = watch_filterer::create_filter(&origin, additional_globs, use_ignore)
-            .map_err(|e| format!("failed to create watch filter: {e}"))?;
+        // Linked worktrees are full checkouts nested in the workspace. The
+        // walker prunes them from the initial registration, but the filterer
+        // needs them too: macOS watches the root recursively, so pruning the
+        // walk alone would not keep their events out.
+        let worktrees: Vec<PathBuf> = nested_linked_worktrees(&origin)
+            .into_iter()
+            .map(|relative| Path::new(&origin).join(relative))
+            .collect();
+
+        let filterer =
+            watch_filterer::create_filter(&origin, additional_globs, &worktrees, use_ignore)
+                .map_err(|e| format!("failed to create watch filter: {e}"))?;
 
         let (notify_tx, notify_rx) = unbounded::<NotifyResult>();
         let mut watcher = notify::recommended_watcher(move |event| {
@@ -207,6 +220,10 @@ impl WatchPipeline {
             .paths()
             .filter(|(path, metadata)| meta_is_dir(metadata) && !self.ignore_globs.is_match(path))
             .map(|(path, _)| path.to_path_buf())
+            // The filterer only knows the worktrees that existed at boot, so
+            // a worktree created since would otherwise be registered here and
+            // backfilled file by file.
+            .filter(|path| !is_linked_worktree_root(path))
             .collect()
     }
 
@@ -905,6 +922,49 @@ mod tests {
             matches!(new_evt.r#type, EventType::create),
             "rename destination should classify as Create; got {:?}",
             new_evt.r#type
+        );
+    }
+
+    #[test]
+    fn linked_worktree_paths_never_reach_callback() {
+        // The walker keeps a worktree's directories out of the initial
+        // registration, but macOS watches the root recursively - the filterer
+        // has to block them on its own.
+        let dir = tempdir().expect("tempdir");
+        let root = dir.path().canonicalize().expect("canonicalize");
+
+        let worktree = root.join("other/wt");
+        let metadata_dir = root.join(".git/worktrees/wt");
+        fs::create_dir_all(&worktree).expect("mkdir worktree");
+        fs::create_dir_all(&metadata_dir).expect("mkdir worktree metadata");
+        fs::write(
+            worktree.join(".git"),
+            format!("gitdir: {}\n", metadata_dir.display()),
+        )
+        .expect("write gitfile");
+        fs::write(
+            metadata_dir.join("gitdir"),
+            format!("{}\n", worktree.join(".git").display()),
+        )
+        .expect("write gitdir");
+        fs::write(worktree.join("seed.txt"), "x").expect("seed write");
+
+        let (_watcher, captured) = start_watcher(&root);
+
+        fs::write(worktree.join("touched.txt"), "y").expect("worktree write");
+        // Un-ignored write proves the watcher is alive.
+        fs::write(root.join("alive.txt"), "z").expect("alive write");
+
+        let events = collect(&captured);
+        assert!(
+            events.iter().any(|e| e.path == "alive.txt"),
+            "expected an event for alive.txt; got {events:?}"
+        );
+
+        let leaked: Vec<_> = events.iter().filter(|e| e.path.contains("wt/")).collect();
+        assert!(
+            leaked.is_empty(),
+            "expected no events inside the worktree; got {leaked:?}"
         );
     }
 

--- a/packages/nx/src/native/watch/watcher.rs
+++ b/packages/nx/src/native/watch/watcher.rs
@@ -12,9 +12,7 @@ use tracing::{debug, trace};
 
 #[cfg(not(target_os = "macos"))]
 use crate::native::glob::{NxGlobSet, build_glob_set};
-#[cfg(not(target_os = "macos"))]
-use crate::native::utils::git::is_linked_worktree_root;
-use crate::native::utils::git::nested_linked_worktrees;
+use crate::native::utils::git::{is_linked_worktree_root, nested_linked_worktrees};
 use crate::native::walker::HARDCODED_IGNORE_PATTERNS;
 #[cfg(not(target_os = "macos"))]
 use crate::native::walker::create_walker;
@@ -132,7 +130,8 @@ impl WatchPipeline {
         // Linked worktrees are full checkouts nested in the workspace. The
         // walker prunes them from the initial registration, but the filterer
         // needs them too: macOS watches the root recursively, so pruning the
-        // walk alone would not keep their events out.
+        // walk alone would not keep their events out. This is only the
+        // starting set - `track_new_worktrees` adds any created later.
         let worktrees: Vec<PathBuf> = nested_linked_worktrees(&origin)
             .into_iter()
             .map(|relative| Path::new(&origin).join(relative))
@@ -204,6 +203,30 @@ impl WatchPipeline {
         self.flush_deadline = None;
     }
 
+    /// Teach the filterer about a worktree created since it booted.
+    ///
+    /// `git worktree add` writes the checkout's `.git` gitfile before it
+    /// populates the tree, so catching that one event keeps the rest of the
+    /// checkout out. Runs on every platform: on macOS the recursive watch on
+    /// the root means the filterer is the *only* thing standing between a new
+    /// worktree and the daemon, and `new_directories_from_event` below - which
+    /// covers the Linux/Windows per-directory registration - is not compiled
+    /// there.
+    fn track_new_worktrees(&mut self, event: &RawWatchEvent) {
+        let new_worktrees: Vec<PathBuf> = event
+            .paths()
+            .filter(|(path, _)| path.file_name().is_some_and(|name| name == ".git"))
+            .filter_map(|(path, _)| path.parent())
+            .filter(|root| is_linked_worktree_root(root))
+            .map(Path::to_path_buf)
+            .collect();
+
+        for root in new_worktrees {
+            debug!(?root, "linked worktree appeared - blocking its events");
+            self.filterer.track_worktree(&root);
+        }
+    }
+
     #[cfg(not(target_os = "macos"))]
     fn new_directories_from_event(&self, event: &RawWatchEvent) -> Vec<PathBuf> {
         use crate::native::watch::types::meta_is_dir;
@@ -220,9 +243,11 @@ impl WatchPipeline {
             .paths()
             .filter(|(path, metadata)| meta_is_dir(metadata) && !self.ignore_globs.is_match(path))
             .map(|(path, _)| path.to_path_buf())
-            // The filterer only knows the worktrees that existed at boot, so
-            // a worktree created since would otherwise be registered here and
-            // backfilled file by file.
+            // Registering a worktree root would take a descriptor per
+            // directory in it and backfill the checkout file by file.
+            // `track_new_worktrees` handles the case where the directory
+            // arrives before its gitfile: everything under it is filtered out
+            // before reaching here, so nothing deeper gets registered.
             .filter(|path| !is_linked_worktree_root(path))
             .collect()
     }
@@ -284,6 +309,10 @@ impl WatchPipeline {
         };
 
         let raw = RawWatchEvent::new(event);
+
+        // Before the filter, so the gitfile of a worktree created just now
+        // registers it rather than being discarded as a `.git` path.
+        self.track_new_worktrees(&raw);
 
         if !self.filterer.check_event(&raw) {
             return Ok(());
@@ -559,6 +588,7 @@ impl Watcher {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::native::utils::git::test_support::register_worktree;
     use crate::native::watch::types::EventType;
     use std::fs;
     use std::sync::Mutex;
@@ -934,19 +964,7 @@ mod tests {
         let root = dir.path().canonicalize().expect("canonicalize");
 
         let worktree = root.join("other/wt");
-        let metadata_dir = root.join(".git/worktrees/wt");
-        fs::create_dir_all(&worktree).expect("mkdir worktree");
-        fs::create_dir_all(&metadata_dir).expect("mkdir worktree metadata");
-        fs::write(
-            worktree.join(".git"),
-            format!("gitdir: {}\n", metadata_dir.display()),
-        )
-        .expect("write gitfile");
-        fs::write(
-            metadata_dir.join("gitdir"),
-            format!("{}\n", worktree.join(".git").display()),
-        )
-        .expect("write gitdir");
+        register_worktree(&root, "wt", &worktree);
         fs::write(worktree.join("seed.txt"), "x").expect("seed write");
 
         let (_watcher, captured) = start_watcher(&root);
@@ -965,6 +983,45 @@ mod tests {
         assert!(
             leaked.is_empty(),
             "expected no events inside the worktree; got {leaked:?}"
+        );
+    }
+
+    #[test]
+    fn a_worktree_created_after_boot_is_blocked() {
+        // The motivating workflow: agent tooling runs `git worktree add`
+        // against a daemon that is already watching. The boot-time snapshot
+        // can't know about it, and on macOS the root is watched recursively,
+        // so without picking it up from the event stream the whole checkout
+        // floods the pipeline until the daemon restarts.
+        let dir = tempdir().expect("tempdir");
+        let root = dir.path().canonicalize().expect("canonicalize");
+        fs::create_dir_all(root.join(".git")).expect("mkdir .git");
+
+        let (_watcher, captured) = start_watcher(&root);
+
+        let worktree = root.join(".claude/worktrees/wt");
+        register_worktree(&root, "wt", &worktree);
+        // Let the gitfile's event land before the checkout is populated,
+        // the way `git worktree add` orders it.
+        std::thread::sleep(Duration::from_millis(300));
+
+        fs::write(worktree.join("app.ts"), "x").expect("worktree write");
+        // Un-ignored write proves the watcher is alive.
+        fs::write(root.join("alive.txt"), "z").expect("alive write");
+
+        let events = collect(&captured);
+        assert!(
+            events.iter().any(|e| e.path == "alive.txt"),
+            "expected an event for alive.txt; got {events:?}"
+        );
+
+        let leaked: Vec<_> = events
+            .iter()
+            .filter(|e| e.path.contains("worktrees/wt/"))
+            .collect();
+        assert!(
+            leaked.is_empty(),
+            "expected no events inside a worktree created after boot; got {leaked:?}"
         );
     }
 

--- a/packages/nx/src/native/watch/watcher.rs
+++ b/packages/nx/src/native/watch/watcher.rs
@@ -252,6 +252,23 @@ impl WatchPipeline {
             .collect()
     }
 
+    /// Roots of the linked worktrees nested in the workspace, absolute.
+    ///
+    /// Read from git's registry rather than accumulated from the event
+    /// stream. `track_new_worktrees` only learns of a worktree from its
+    /// `.git` gitfile's creation event, and on Linux and Windows that event
+    /// is never generated: the checkout is created and its gitfile written
+    /// before the directory has a watch, so there is nothing to notice. The
+    /// registry is state, so it cannot be missed the same way.
+    #[cfg(not(target_os = "macos"))]
+    fn resolve_worktrees(&self) -> Vec<PathBuf> {
+        let origin = Path::new(self.origin_path.trim_end_matches(MAIN_SEPARATOR));
+        nested_linked_worktrees(origin)
+            .into_iter()
+            .map(|relative| origin.join(relative))
+            .collect()
+    }
+
     /// Synchronously register watches for new directories, walk them to
     /// backfill files written before the watch was active, and recurse
     /// into any nested subdirectories. Returns Err on `MaxFilesWatch`.
@@ -264,6 +281,21 @@ impl WatchPipeline {
 
         debug!(?dirs, "registering watches for new directories");
         register_watches(&mut self.watcher, dirs)?;
+
+        // `nx_walker_sync` keeps the worktrees themselves out of the walk
+        // below; telling the filterer about them is the other half. A watch
+        // registered before the checkout existed still delivers events from
+        // inside it, and the gitfile `track_new_worktrees` relies on is
+        // written before any watch on that directory exists, so its creation
+        // event is never generated here. Git's registry is state rather than
+        // a notification, so it cannot be missed the same way.
+        for root in self.resolve_worktrees() {
+            debug!(
+                ?root,
+                "linked worktree found while backfilling - blocking it"
+            );
+            self.filterer.track_worktree(&root);
+        }
 
         let mut nested_dirs: HashSet<PathBuf> = HashSet::new();
         let mut backfilled_paths: Vec<PathBuf> = Vec::new();
@@ -1022,6 +1054,46 @@ mod tests {
         assert!(
             leaked.is_empty(),
             "expected no events inside a worktree created after boot; got {leaked:?}"
+        );
+    }
+
+    #[test]
+    fn a_populated_worktree_created_after_boot_is_not_backfilled() {
+        // The checkout is populated immediately after its gitfile, the way
+        // `git worktree add` does it, rather than after a settle. That lands
+        // the files before any watch on the worktree exists, so they arrive
+        // through the backfill walk instead of the event stream - which
+        // prunes only the hardcoded ignores and would otherwise report every
+        // file in the checkout as created, and take an inotify descriptor for
+        // every directory in it.
+        let dir = tempdir().expect("tempdir");
+        let root = dir.path().canonicalize().expect("canonicalize");
+        fs::create_dir_all(root.join(".git")).expect("mkdir .git");
+
+        let (_watcher, captured) = start_watcher(&root);
+
+        let worktree = root.join(".claude/worktrees/wt");
+        register_worktree(&root, "wt", &worktree);
+        fs::create_dir_all(worktree.join("packages/app/src")).expect("mkdir checkout");
+        for file in ["package.json", "packages/app/src/main.ts"] {
+            fs::write(worktree.join(file), "x").expect("populate checkout");
+        }
+        // Un-ignored write proves the watcher is alive.
+        fs::write(root.join("alive.txt"), "z").expect("alive write");
+
+        let events = collect(&captured);
+        assert!(
+            events.iter().any(|e| e.path == "alive.txt"),
+            "expected an event for alive.txt; got {events:?}"
+        );
+
+        let leaked: Vec<_> = events
+            .iter()
+            .filter(|e| e.path.contains("worktrees/wt/"))
+            .collect();
+        assert!(
+            leaked.is_empty(),
+            "expected no events from a worktree populated after boot; got {leaked:?}"
         );
     }
 

--- a/packages/nx/src/native/watch/watcher.rs
+++ b/packages/nx/src/native/watch/watcher.rs
@@ -321,12 +321,38 @@ impl WatchPipeline {
             self.filterer.track_worktree(&root);
         }
 
+        // A worktree still being created is invisible to both of the above:
+        // `git worktree add` registers it and writes the checkout's gitfile
+        // only after making the directory, so a walk that started in between
+        // finds nothing and hands the checkout back. Asking each directory
+        // directly, at the moment its watch would be registered, is the last
+        // point where the answer is current - and by then git has written the
+        // gitfile, because it does that before populating the tree.
+        let mut late_worktrees: Vec<PathBuf> = Vec::new();
+
         let mut nested_dirs: HashSet<PathBuf> = HashSet::new();
         let mut backfilled_paths: Vec<PathBuf> = Vec::new();
         for dir in dirs {
             for rel_path in nx_walker_sync(dir, None) {
                 let full_path = dir.join(&rel_path);
+                // `nx_walker_sync` yields parents before their children, so a
+                // root recorded here always precedes what it should exclude.
+                if late_worktrees
+                    .iter()
+                    .any(|worktree| full_path.starts_with(worktree))
+                {
+                    continue;
+                }
                 if full_path.is_dir() {
+                    if is_linked_worktree_root(&full_path) {
+                        debug!(
+                            ?full_path,
+                            "worktree finished appearing mid-walk - blocking it"
+                        );
+                        self.filterer.track_worktree(&full_path);
+                        late_worktrees.push(full_path);
+                        continue;
+                    }
                     nested_dirs.insert(full_path);
                 } else if full_path.is_file() {
                     let path = full_path
@@ -1119,6 +1145,84 @@ mod tests {
             leaked.is_empty(),
             "expected no events from a worktree populated after boot; got {leaked:?}"
         );
+    }
+
+    #[test]
+    fn a_real_git_worktree_added_after_boot_is_blocked() {
+        // Every other worktree test builds the layout by hand, which writes
+        // the gitfile before the watcher can react. Real `git worktree add`
+        // makes the directory first and registers it a moment later, so the
+        // walk that registers a watch can land in between and hand the
+        // checkout back. Only driving git reproduces that ordering.
+        //
+        // The window is small: without the fix this caught the leak once in
+        // ten runs, with it ten out of ten. A pass is weak evidence on its
+        // own - it is the cheapest honest coverage of real git, not a proof.
+        let Some(git) = git_or_skip() else { return };
+
+        let dir = tempdir().expect("tempdir");
+        let root = dir.path().canonicalize().expect("canonicalize");
+        let run = |args: &[&str]| {
+            let out = std::process::Command::new(&git)
+                .args(args)
+                .current_dir(&root)
+                .output()
+                .expect("run git");
+            assert!(
+                out.status.success(),
+                "git {args:?}: {}",
+                String::from_utf8_lossy(&out.stderr)
+            );
+        };
+        run(&["init", "-q", "."]);
+        run(&["config", "user.email", "test@example.com"]);
+        run(&["config", "user.name", "test"]);
+        fs::write(root.join("tracked.txt"), "x").expect("seed");
+        run(&["add", "-A"]);
+        run(&["commit", "-qm", "init"]);
+
+        let (_watcher, captured) = start_watcher(&root);
+
+        run(&[
+            "worktree",
+            "add",
+            "-q",
+            ".claude/worktrees/wt",
+            "-b",
+            "wt-branch",
+        ]);
+        std::thread::sleep(Duration::from_millis(400));
+        fs::write(root.join(".claude/worktrees/wt/app.ts"), "y").expect("worktree write");
+        // Un-ignored write proves the watcher is alive.
+        fs::write(root.join("alive.txt"), "z").expect("alive write");
+
+        let events = collect(&captured);
+        assert!(
+            events.iter().any(|e| e.path == "alive.txt"),
+            "expected an event for alive.txt; got {events:?}"
+        );
+
+        let leaked: Vec<_> = events
+            .iter()
+            .filter(|e| e.path.contains("worktrees/wt/"))
+            .collect();
+        assert!(
+            leaked.is_empty(),
+            "expected no events from a real git worktree; got {leaked:?}"
+        );
+    }
+
+    /// `git` is present on every CI image this suite runs on, but a contributor
+    /// without it should see the rest of the suite rather than a failure.
+    fn git_or_skip() -> Option<String> {
+        let git = std::env::var("GIT_EXECUTABLE").unwrap_or_else(|_| "git".to_string());
+        match std::process::Command::new(&git).arg("--version").output() {
+            Ok(out) if out.status.success() => Some(git),
+            _ => {
+                eprintln!("skipping: no usable `git` on PATH");
+                None
+            }
+        }
     }
 
     #[test]

--- a/packages/nx/src/native/watch/watcher.rs
+++ b/packages/nx/src/native/watch/watcher.rs
@@ -267,12 +267,6 @@ impl WatchPipeline {
             .paths()
             .filter(|(path, metadata)| meta_is_dir(metadata) && !self.ignore_globs.is_match(path))
             .map(|(path, _)| path.to_path_buf())
-            // Registering a worktree root would take a descriptor per
-            // directory in it and backfill the checkout file by file.
-            // `track_new_worktrees` handles the case where the directory
-            // arrives before its gitfile: everything under it is filtered out
-            // before reaching here, so nothing deeper gets registered.
-            .filter(|path| !is_linked_worktree_root(path))
             .collect()
     }
 
@@ -313,13 +307,9 @@ impl WatchPipeline {
         // written before any watch on that directory exists, so its creation
         // event is never generated here. Git's registry is state rather than
         // a notification, so it cannot be missed the same way.
-        for root in self.resolve_worktrees() {
-            debug!(
-                ?root,
-                "linked worktree found while backfilling - blocking it"
-            );
-            self.filterer.track_worktree(&root);
-        }
+        let worktrees = self.resolve_worktrees();
+        debug!(?worktrees, "blocking the linked worktrees git knows about");
+        self.filterer.set_worktrees(&worktrees);
 
         // A worktree still being created is invisible to both of the above:
         // `git worktree add` registers it and writes the checkout's gitfile
@@ -415,7 +405,20 @@ impl WatchPipeline {
 
         #[cfg(not(target_os = "macos"))]
         {
-            let new_dirs = self.new_directories_from_event(&raw);
+            // Registering a worktree root would take a descriptor per directory
+            // in it and backfill the checkout file by file. Blocking rather
+            // than skipping matters: `track_new_worktrees` needs a gitfile
+            // event, so this is the only place the root's own is recognized.
+            let (worktree_roots, new_dirs): (Vec<PathBuf>, Vec<PathBuf>) = self
+                .new_directories_from_event(&raw)
+                .into_iter()
+                .partition(|path| is_linked_worktree_root(path));
+
+            for root in worktree_roots {
+                debug!(?root, "linked worktree directory appeared - blocking it");
+                self.filterer.track_worktree(&root);
+            }
+
             if !new_dirs.is_empty() {
                 self.register_and_backfill_new_dirs(&new_dirs)
                     // Error message contains "inotify_add_watch" so the
@@ -1162,35 +1165,22 @@ mod tests {
 
         let dir = tempdir().expect("tempdir");
         let root = dir.path().canonicalize().expect("canonicalize");
-        let run = |args: &[&str]| {
-            let out = std::process::Command::new(&git)
-                .args(args)
-                .current_dir(&root)
-                .output()
-                .expect("run git");
-            assert!(
-                out.status.success(),
-                "git {args:?}: {}",
-                String::from_utf8_lossy(&out.stderr)
-            );
-        };
-        run(&["init", "-q", "."]);
-        run(&["config", "user.email", "test@example.com"]);
-        run(&["config", "user.name", "test"]);
-        fs::write(root.join("tracked.txt"), "x").expect("seed");
-        run(&["add", "-A"]);
-        run(&["commit", "-qm", "init"]);
+        seed_repo(&git, &root);
 
         let (_watcher, captured) = start_watcher(&root);
 
-        run(&[
-            "worktree",
-            "add",
-            "-q",
-            ".claude/worktrees/wt",
-            "-b",
-            "wt-branch",
-        ]);
+        run_git(
+            &git,
+            &root,
+            &[
+                "worktree",
+                "add",
+                "-q",
+                ".claude/worktrees/wt",
+                "-b",
+                "wt-branch",
+            ],
+        );
         std::thread::sleep(Duration::from_millis(400));
         fs::write(root.join(".claude/worktrees/wt/app.ts"), "y").expect("worktree write");
         // Un-ignored write proves the watcher is alive.
@@ -1210,6 +1200,82 @@ mod tests {
             leaked.is_empty(),
             "expected no events from a real git worktree; got {leaked:?}"
         );
+    }
+
+    #[test]
+    fn a_worktree_added_under_a_watched_parent_is_blocked() {
+        // Every other worktree test starts with no `.claude/`, so the directory
+        // event is for a parent that did not exist yet. Here the parent is
+        // already watched, which is every worktree after the first. Which guard
+        // catches it depends on whether the ingest loop dequeues the directory
+        // event before git finishes registering, so only the outcome is
+        // asserted - `types.rs` holds the deterministic witness.
+        let Some(git) = git_or_skip() else { return };
+
+        let dir = tempdir().expect("tempdir");
+        let root = dir.path().canonicalize().expect("canonicalize");
+        seed_repo(&git, &root);
+        // Exists, and has a watch, before the worktree appears under it.
+        fs::create_dir_all(root.join(".claude/worktrees")).expect("mkdir parent");
+
+        let (_watcher, captured) = start_watcher(&root);
+
+        run_git(
+            &git,
+            &root,
+            &[
+                "worktree",
+                "add",
+                "-q",
+                ".claude/worktrees/wt",
+                "-b",
+                "wt-branch",
+            ],
+        );
+        std::thread::sleep(Duration::from_millis(400));
+        fs::write(root.join(".claude/worktrees/wt/app.ts"), "y").expect("worktree write");
+        // Un-ignored write proves the watcher is alive.
+        fs::write(root.join("alive.txt"), "z").expect("alive write");
+
+        let events = collect(&captured);
+        assert!(
+            events.iter().any(|e| e.path == "alive.txt"),
+            "expected an event for alive.txt; got {events:?}"
+        );
+
+        let leaked: Vec<_> = events
+            .iter()
+            .filter(|e| e.path.contains("worktrees/wt/"))
+            .collect();
+        assert!(
+            leaked.is_empty(),
+            "expected no events from a worktree added under a watched parent; got {leaked:?}"
+        );
+    }
+
+    fn run_git(git: &str, root: &Path, args: &[&str]) {
+        let out = std::process::Command::new(git)
+            .args(args)
+            .current_dir(root)
+            .output()
+            .expect("run git");
+        assert!(
+            out.status.success(),
+            "git {args:?}: {}",
+            String::from_utf8_lossy(&out.stderr)
+        );
+    }
+
+    /// A repository with one commit, so `git worktree add` has something to
+    /// check out - an empty checkout would leak nothing whether or not the
+    /// prune works.
+    fn seed_repo(git: &str, root: &Path) {
+        run_git(git, root, &["init", "-q", "."]);
+        run_git(git, root, &["config", "user.email", "test@example.com"]);
+        run_git(git, root, &["config", "user.name", "test"]);
+        fs::write(root.join("tracked.txt"), "x").expect("seed");
+        run_git(git, root, &["add", "-A"]);
+        run_git(git, root, &["commit", "-qm", "init"]);
     }
 
     /// `git` is present on every CI image this suite runs on, but a contributor

--- a/packages/nx/src/native/worktree.rs
+++ b/packages/nx/src/native/worktree.rs
@@ -31,9 +31,13 @@ fn resolve_main_worktree_root(workspace_root: &str) -> Option<String> {
     }
 
     // The gitfile points at `<main>/.git/worktrees/<name>`, whose `commondir`
-    // points back at `<main>/.git`.
+    // points back at `<main>/.git`. Without it there is no answer to give:
+    // treating `<main>/.git/worktrees/<name>` as the common dir would name
+    // `<main>/.git/worktrees` as the repo root and site the cache and the
+    // workspace-data database under it - a path git reads as a worktree
+    // registration and `git worktree prune`, and so `git gc`, deletes.
     let git_dir = read_gitfile(&root.join(".git"), root)?;
-    let common_dir = common_git_dir(&git_dir);
+    let common_dir = common_git_dir(&git_dir)?;
 
     // Resolve symlinks and ".." segments so the path is clean and
     // comparable across worktrees (e.g., in reset's equality check).
@@ -53,7 +57,9 @@ mod test {
     use assert_fs::TempDir;
 
     use crate::native::utils::command::create_command;
-    use crate::native::utils::git::test_support::{register_submodule, register_worktree};
+    use crate::native::utils::git::test_support::{
+        register_submodule, register_worktree, register_worktree_mid_write,
+    };
 
     use super::*;
 
@@ -161,6 +167,22 @@ mod test {
         register_worktree(&repo, "wt", &worktree);
 
         remove_dir_all(repo.join(".git")).unwrap();
+
+        assert_eq!(resolve_main_worktree_root(worktree.to_str().unwrap()), None);
+    }
+
+    #[test]
+    fn a_half_registered_worktree_has_no_main_root() {
+        // `is_linked_worktree_root` answers yes from `gitdir` alone, so this
+        // is reachable in the window before `git worktree add` writes
+        // `commondir`. Guessing the root from the metadata directory would
+        // name `<main>/.git/worktrees` and put the cache where `git gc`
+        // deletes it, so the answer has to be "don't know" instead.
+        let temp = TempDir::new().unwrap();
+        let repo = temp.path().join("repo");
+        create_dir_all(repo.join(".git")).unwrap();
+        let worktree = repo.join("wt");
+        register_worktree_mid_write(&repo, "wt", &worktree);
 
         assert_eq!(resolve_main_worktree_root(worktree.to_str().unwrap()), None);
     }

--- a/packages/nx/src/native/worktree.rs
+++ b/packages/nx/src/native/worktree.rs
@@ -1,62 +1,59 @@
-use crate::native::utils::command::create_command;
-use std::path::{Path, PathBuf};
-use std::sync::OnceLock;
+use crate::native::utils::git::{common_git_dir, is_linked_worktree_root, read_gitfile};
+use dashmap::DashMap;
+use std::path::Path;
+use std::sync::LazyLock;
 
-static MAIN_WORKTREE_ROOT: OnceLock<Option<String>> = OnceLock::new();
+/// Keyed by workspace root: a process can resolve more than one, and the
+/// answer is only stable per root.
+static MAIN_WORKTREE_ROOT: LazyLock<DashMap<String, Option<String>>> = LazyLock::new(DashMap::new);
 
 /// If `workspace_root` is inside a git worktree, returns the main repo root.
 /// Returns `None` when already in the main repo (or not in a git repo at all).
 #[napi]
 pub fn get_main_worktree_root(workspace_root: String) -> anyhow::Result<Option<String>> {
-    Ok(MAIN_WORKTREE_ROOT
-        .get_or_init(|| resolve_main_worktree_root(&workspace_root).unwrap_or(None))
-        .clone())
+    if let Some(cached) = MAIN_WORKTREE_ROOT.get(&workspace_root) {
+        return Ok(cached.clone());
+    }
+
+    let resolved = resolve_main_worktree_root(&workspace_root);
+    MAIN_WORKTREE_ROOT.insert(workspace_root, resolved.clone());
+    Ok(resolved)
 }
 
-fn resolve_main_worktree_root(workspace_root: &str) -> anyhow::Result<Option<String>> {
-    let git_path = Path::new(workspace_root).join(".git");
+fn resolve_main_worktree_root(workspace_root: &str) -> Option<String> {
+    let root = Path::new(workspace_root);
 
-    // If .git is a directory (not a file), this is the main repo — not a worktree
-    if !git_path.is_file() {
-        return Ok(None);
+    // Only a linked worktree shares a repository with a main root. A
+    // submodule also replaces `.git` with a gitfile, but it is an
+    // independent repository - its cache belongs to itself.
+    if !is_linked_worktree_root(root) {
+        return None;
     }
 
-    // In a worktree, .git is a file pointing to the main repo's .git dir.
-    // Use git to find the common dir shared across all worktrees.
-    let output = create_command("git")
-        .args(["rev-parse", "--git-common-dir"])
-        .current_dir(workspace_root)
-        .output()?;
-
-    if !output.status.success() {
-        return Ok(None);
-    }
-
-    let git_common_dir = String::from_utf8(output.stdout)?.trim().to_string();
-    let abs_path = if Path::new(&git_common_dir).is_absolute() {
-        PathBuf::from(&git_common_dir)
-    } else {
-        PathBuf::from(workspace_root).join(&git_common_dir)
-    };
+    // The gitfile points at `<main>/.git/worktrees/<name>`, whose `commondir`
+    // points back at `<main>/.git`.
+    let git_dir = read_gitfile(&root.join(".git"), root)?;
+    let common_dir = common_git_dir(&git_dir);
 
     // Resolve symlinks and ".." segments so the path is clean and
     // comparable across worktrees (e.g., in reset's equality check).
     // dunce, not std: std returns a `\\?\` verbatim path on Windows, which
     // Node's module resolution walks past the drive root on (nx#35637).
-    let abs_path = dunce::canonicalize(&abs_path).unwrap_or(abs_path);
+    let common_dir = dunce::canonicalize(&common_dir).unwrap_or(common_dir);
 
     // The common dir is the .git directory — its parent is the repo root
-    let main_root = abs_path
-        .parent()
-        .ok_or_else(|| anyhow::anyhow!("Cannot determine main repo root"))?;
-
-    Ok(Some(main_root.to_string_lossy().to_string()))
+    Some(common_dir.parent()?.to_string_lossy().to_string())
 }
 
 #[cfg(test)]
-mod tests {
+mod test {
+    use std::fs::{create_dir_all, write};
+    use std::path::PathBuf;
+
+    use assert_fs::TempDir;
+
     use super::*;
-    use tempfile::TempDir;
+    use crate::native::utils::command::create_command;
 
     fn git(dir: &Path, args: &[&str]) {
         let output = create_command("git")
@@ -89,16 +86,101 @@ mod tests {
         );
     }
 
+    /// Builds `<repo>/.git` plus a linked worktree at `worktree_root`, the
+    /// way `git worktree add` lays it out.
+    fn add_worktree(repo: &Path, name: &str, worktree_root: &Path) {
+        let metadata_dir = repo.join(".git").join("worktrees").join(name);
+        create_dir_all(&metadata_dir).unwrap();
+        create_dir_all(worktree_root).unwrap();
+        write(
+            worktree_root.join(".git"),
+            format!("gitdir: {}\n", metadata_dir.display()),
+        )
+        .unwrap();
+        write(
+            metadata_dir.join("gitdir"),
+            format!("{}\n", worktree_root.join(".git").display()),
+        )
+        .unwrap();
+        // `commondir` is how a worktree finds the repository it belongs to.
+        write(metadata_dir.join("commondir"), "../..\n").unwrap();
+    }
+
+    #[test]
+    fn main_repo_has_no_main_worktree_root() {
+        let temp = TempDir::new().unwrap();
+        create_dir_all(temp.path().join(".git")).unwrap();
+
+        assert_eq!(
+            resolve_main_worktree_root(temp.path().to_str().unwrap()),
+            None
+        );
+    }
+
+    #[test]
+    fn resolves_the_repo_root_from_inside_a_worktree() {
+        let temp = TempDir::new().unwrap();
+        let repo = temp.path().join("repo");
+        create_dir_all(repo.join(".git")).unwrap();
+        let worktree = repo.join("other/wt");
+        add_worktree(&repo, "wt", &worktree);
+
+        let resolved = resolve_main_worktree_root(worktree.to_str().unwrap()).unwrap();
+
+        assert_eq!(
+            Path::new(&resolved),
+            repo.canonicalize().unwrap_or(repo.clone())
+        );
+    }
+
+    #[test]
+    fn a_submodule_is_not_a_worktree() {
+        let temp = TempDir::new().unwrap();
+        create_dir_all(temp.path().join(".git/modules/libs/sub")).unwrap();
+        let submodule = temp.path().join("libs/sub");
+        create_dir_all(&submodule).unwrap();
+        write(
+            submodule.join(".git"),
+            "gitdir: ../../.git/modules/libs/sub\n",
+        )
+        .unwrap();
+
+        // A submodule is its own repository - colocating its cache under the
+        // superproject's `.git/modules` would be wrong.
+        assert_eq!(
+            resolve_main_worktree_root(submodule.to_str().unwrap()),
+            None
+        );
+    }
+
+    #[test]
+    fn caches_per_workspace_root() {
+        let temp = TempDir::new().unwrap();
+        let repo = temp.path().join("repo");
+        create_dir_all(repo.join(".git")).unwrap();
+        let worktree = repo.join("wt");
+        add_worktree(&repo, "wt", &worktree);
+
+        // The main repo answers None while the worktree answers the repo
+        // root; a cache shared across roots would return one for both.
+        let from_main = get_main_worktree_root(repo.to_str().unwrap().to_string()).unwrap();
+        let from_worktree = get_main_worktree_root(worktree.to_str().unwrap().to_string()).unwrap();
+
+        assert_eq!(from_main, None);
+        assert!(from_worktree.is_some());
+        assert_eq!(
+            get_main_worktree_root(repo.to_str().unwrap().to_string()).unwrap(),
+            None
+        );
+    }
+
     #[test]
     fn returns_none_when_not_in_a_worktree() {
         let tmp = TempDir::new().unwrap();
         let main = tmp.path().join("main");
         init_repo(&main);
 
-        assert_eq!(
-            resolve_main_worktree_root(main.to_str().unwrap()).unwrap(),
-            None
-        );
+        assert_eq!(resolve_main_worktree_root(main.to_str().unwrap()), None);
     }
 
     #[test]
@@ -111,7 +193,6 @@ mod tests {
         git(&main, &["worktree", "add", worktree.to_str().unwrap()]);
 
         let resolved = resolve_main_worktree_root(worktree.to_str().unwrap())
-            .unwrap()
             .expect("a linked worktree should resolve to the main repo root");
 
         assert_eq!(

--- a/packages/nx/src/native/worktree.rs
+++ b/packages/nx/src/native/worktree.rs
@@ -47,13 +47,15 @@ fn resolve_main_worktree_root(workspace_root: &str) -> Option<String> {
 
 #[cfg(test)]
 mod test {
-    use std::fs::{create_dir_all, write};
+    use std::fs::{create_dir_all, remove_dir_all};
     use std::path::PathBuf;
 
     use assert_fs::TempDir;
 
-    use super::*;
     use crate::native::utils::command::create_command;
+    use crate::native::utils::git::test_support::{register_submodule, register_worktree};
+
+    use super::*;
 
     fn git(dir: &Path, args: &[&str]) {
         let output = create_command("git")
@@ -86,26 +88,6 @@ mod test {
         );
     }
 
-    /// Builds `<repo>/.git` plus a linked worktree at `worktree_root`, the
-    /// way `git worktree add` lays it out.
-    fn add_worktree(repo: &Path, name: &str, worktree_root: &Path) {
-        let metadata_dir = repo.join(".git").join("worktrees").join(name);
-        create_dir_all(&metadata_dir).unwrap();
-        create_dir_all(worktree_root).unwrap();
-        write(
-            worktree_root.join(".git"),
-            format!("gitdir: {}\n", metadata_dir.display()),
-        )
-        .unwrap();
-        write(
-            metadata_dir.join("gitdir"),
-            format!("{}\n", worktree_root.join(".git").display()),
-        )
-        .unwrap();
-        // `commondir` is how a worktree finds the repository it belongs to.
-        write(metadata_dir.join("commondir"), "../..\n").unwrap();
-    }
-
     #[test]
     fn main_repo_has_no_main_worktree_root() {
         let temp = TempDir::new().unwrap();
@@ -123,7 +105,7 @@ mod test {
         let repo = temp.path().join("repo");
         create_dir_all(repo.join(".git")).unwrap();
         let worktree = repo.join("other/wt");
-        add_worktree(&repo, "wt", &worktree);
+        register_worktree(&repo, "wt", &worktree);
 
         let resolved = resolve_main_worktree_root(worktree.to_str().unwrap()).unwrap();
 
@@ -136,21 +118,51 @@ mod test {
     #[test]
     fn a_submodule_is_not_a_worktree() {
         let temp = TempDir::new().unwrap();
-        create_dir_all(temp.path().join(".git/modules/libs/sub")).unwrap();
-        let submodule = temp.path().join("libs/sub");
-        create_dir_all(&submodule).unwrap();
-        write(
-            submodule.join(".git"),
-            "gitdir: ../../.git/modules/libs/sub\n",
-        )
-        .unwrap();
+        create_dir_all(temp.path().join(".git")).unwrap();
+        register_submodule(temp.path(), "libs/sub");
 
         // A submodule is its own repository - colocating its cache under the
         // superproject's `.git/modules` would be wrong.
         assert_eq!(
-            resolve_main_worktree_root(submodule.to_str().unwrap()),
+            resolve_main_worktree_root(temp.path().join("libs/sub").to_str().unwrap()),
             None
         );
+    }
+
+    #[test]
+    fn a_submodule_under_a_worktrees_path_is_not_a_worktree() {
+        // `.git/modules/packages/worktrees/foo` has `worktrees` as its parent
+        // segment, exactly like a real worktree's metadata directory. Reading
+        // it as one would put this submodule workspace's cache and SQLite
+        // database inside the superproject's git directory.
+        let temp = TempDir::new().unwrap();
+        create_dir_all(temp.path().join(".git")).unwrap();
+        register_submodule(temp.path(), "packages/worktrees/foo");
+
+        assert_eq!(
+            resolve_main_worktree_root(
+                temp.path().join("packages/worktrees/foo").to_str().unwrap()
+            ),
+            None
+        );
+    }
+
+    #[test]
+    fn a_dangling_worktree_has_no_main_root() {
+        // `git worktree add` records an absolute path, so moving or deleting
+        // the main clone dangles every worktree it created. Guessing a root
+        // here lands Nx's cache and workspace-data under
+        // `<main>/.git/worktrees/.nx` - a path `git worktree prune` (and so
+        // `git gc`) deletes, taking the database with it.
+        let temp = TempDir::new().unwrap();
+        let repo = temp.path().join("repo");
+        create_dir_all(repo.join(".git")).unwrap();
+        let worktree = repo.join("other/wt");
+        register_worktree(&repo, "wt", &worktree);
+
+        remove_dir_all(repo.join(".git")).unwrap();
+
+        assert_eq!(resolve_main_worktree_root(worktree.to_str().unwrap()), None);
     }
 
     #[test]
@@ -159,7 +171,7 @@ mod test {
         let repo = temp.path().join("repo");
         create_dir_all(repo.join(".git")).unwrap();
         let worktree = repo.join("wt");
-        add_worktree(&repo, "wt", &worktree);
+        register_worktree(&repo, "wt", &worktree);
 
         // The main repo answers None while the worktree answers the repo
         // root; a cache shared across roots would return one for both.

--- a/packages/nx/src/native/worktree.rs
+++ b/packages/nx/src/native/worktree.rs
@@ -1,52 +1,141 @@
-use crate::native::utils::command::create_command;
-use std::path::{Path, PathBuf};
-use std::sync::OnceLock;
+use crate::native::utils::git::{common_git_dir, is_linked_worktree_root, read_gitfile};
+use dashmap::DashMap;
+use std::path::Path;
+use std::sync::LazyLock;
 
-static MAIN_WORKTREE_ROOT: OnceLock<Option<String>> = OnceLock::new();
+/// Keyed by workspace root: a process can resolve more than one, and the
+/// answer is only stable per root.
+static MAIN_WORKTREE_ROOT: LazyLock<DashMap<String, Option<String>>> = LazyLock::new(DashMap::new);
 
 /// If `workspace_root` is inside a git worktree, returns the main repo root.
 /// Returns `None` when already in the main repo (or not in a git repo at all).
 #[napi]
 pub fn get_main_worktree_root(workspace_root: String) -> anyhow::Result<Option<String>> {
-    Ok(MAIN_WORKTREE_ROOT
-        .get_or_init(|| resolve_main_worktree_root(&workspace_root).unwrap_or(None))
-        .clone())
+    if let Some(cached) = MAIN_WORKTREE_ROOT.get(&workspace_root) {
+        return Ok(cached.clone());
+    }
+
+    let resolved = resolve_main_worktree_root(&workspace_root);
+    MAIN_WORKTREE_ROOT.insert(workspace_root, resolved.clone());
+    Ok(resolved)
 }
 
-fn resolve_main_worktree_root(workspace_root: &str) -> anyhow::Result<Option<String>> {
-    let git_path = Path::new(workspace_root).join(".git");
+fn resolve_main_worktree_root(workspace_root: &str) -> Option<String> {
+    let root = Path::new(workspace_root);
 
-    // If .git is a directory (not a file), this is the main repo — not a worktree
-    if !git_path.is_file() {
-        return Ok(None);
+    // Only a linked worktree shares a repository with a main root. A
+    // submodule also replaces `.git` with a gitfile, but it is an
+    // independent repository - its cache belongs to itself.
+    if !is_linked_worktree_root(root) {
+        return None;
     }
 
-    // In a worktree, .git is a file pointing to the main repo's .git dir.
-    // Use git to find the common dir shared across all worktrees.
-    let output = create_command("git")
-        .args(["rev-parse", "--git-common-dir"])
-        .current_dir(workspace_root)
-        .output()?;
-
-    if !output.status.success() {
-        return Ok(None);
-    }
-
-    let git_common_dir = String::from_utf8(output.stdout)?.trim().to_string();
-    let abs_path = if Path::new(&git_common_dir).is_absolute() {
-        PathBuf::from(&git_common_dir)
-    } else {
-        PathBuf::from(workspace_root).join(&git_common_dir)
-    };
+    // The gitfile points at `<main>/.git/worktrees/<name>`, whose `commondir`
+    // points back at `<main>/.git`.
+    let git_dir = read_gitfile(&root.join(".git"), root)?;
+    let common_dir = common_git_dir(&git_dir);
 
     // Resolve symlinks and ".." segments so the path is clean and
     // comparable across worktrees (e.g., in reset's equality check)
-    let abs_path = abs_path.canonicalize().unwrap_or(abs_path);
+    let common_dir = common_dir.canonicalize().unwrap_or(common_dir);
 
     // The common dir is the .git directory — its parent is the repo root
-    let main_root = abs_path
-        .parent()
-        .ok_or_else(|| anyhow::anyhow!("Cannot determine main repo root"))?;
+    Some(common_dir.parent()?.to_string_lossy().to_string())
+}
 
-    Ok(Some(main_root.to_string_lossy().to_string()))
+#[cfg(test)]
+mod test {
+    use std::fs::{create_dir_all, write};
+
+    use assert_fs::TempDir;
+
+    use super::*;
+
+    /// Builds `<repo>/.git` plus a linked worktree at `worktree_root`, the
+    /// way `git worktree add` lays it out.
+    fn add_worktree(repo: &Path, name: &str, worktree_root: &Path) {
+        let metadata_dir = repo.join(".git").join("worktrees").join(name);
+        create_dir_all(&metadata_dir).unwrap();
+        create_dir_all(worktree_root).unwrap();
+        write(
+            worktree_root.join(".git"),
+            format!("gitdir: {}\n", metadata_dir.display()),
+        )
+        .unwrap();
+        write(
+            metadata_dir.join("gitdir"),
+            format!("{}\n", worktree_root.join(".git").display()),
+        )
+        .unwrap();
+        // `commondir` is how a worktree finds the repository it belongs to.
+        write(metadata_dir.join("commondir"), "../..\n").unwrap();
+    }
+
+    #[test]
+    fn main_repo_has_no_main_worktree_root() {
+        let temp = TempDir::new().unwrap();
+        create_dir_all(temp.path().join(".git")).unwrap();
+
+        assert_eq!(
+            resolve_main_worktree_root(temp.path().to_str().unwrap()),
+            None
+        );
+    }
+
+    #[test]
+    fn resolves_the_repo_root_from_inside_a_worktree() {
+        let temp = TempDir::new().unwrap();
+        let repo = temp.path().join("repo");
+        create_dir_all(repo.join(".git")).unwrap();
+        let worktree = repo.join("other/wt");
+        add_worktree(&repo, "wt", &worktree);
+
+        let resolved = resolve_main_worktree_root(worktree.to_str().unwrap()).unwrap();
+
+        assert_eq!(
+            Path::new(&resolved),
+            repo.canonicalize().unwrap_or(repo.clone())
+        );
+    }
+
+    #[test]
+    fn a_submodule_is_not_a_worktree() {
+        let temp = TempDir::new().unwrap();
+        create_dir_all(temp.path().join(".git/modules/libs/sub")).unwrap();
+        let submodule = temp.path().join("libs/sub");
+        create_dir_all(&submodule).unwrap();
+        write(
+            submodule.join(".git"),
+            "gitdir: ../../.git/modules/libs/sub\n",
+        )
+        .unwrap();
+
+        // A submodule is its own repository - colocating its cache under the
+        // superproject's `.git/modules` would be wrong.
+        assert_eq!(
+            resolve_main_worktree_root(submodule.to_str().unwrap()),
+            None
+        );
+    }
+
+    #[test]
+    fn caches_per_workspace_root() {
+        let temp = TempDir::new().unwrap();
+        let repo = temp.path().join("repo");
+        create_dir_all(repo.join(".git")).unwrap();
+        let worktree = repo.join("wt");
+        add_worktree(&repo, "wt", &worktree);
+
+        // The main repo answers None while the worktree answers the repo
+        // root; a cache shared across roots would return one for both.
+        let from_main = get_main_worktree_root(repo.to_str().unwrap().to_string()).unwrap();
+        let from_worktree = get_main_worktree_root(worktree.to_str().unwrap().to_string()).unwrap();
+
+        assert_eq!(from_main, None);
+        assert!(from_worktree.is_some());
+        assert_eq!(
+            get_main_worktree_root(repo.to_str().unwrap().to_string()).unwrap(),
+            None
+        );
+    }
 }


### PR DESCRIPTION
## Current Behavior

A linked worktree created inside the workspace is a full second checkout of the repository, and Nx walks it like any other directory. `git worktree add ./wt/feature`, or the `.claude/worktrees` directory agent tooling uses, means the project graph hashes the entire workspace twice and the daemon registers watches for every directory in the worktree.

Nothing filters these today. A worktree is not ignored by git — `git check-ignore` reports it as untracked, not ignored — so it does not fall out of the existing `.gitignore` handling unless someone adds it by hand.

## Expected Behavior

Linked worktrees nested inside the workspace are pruned from the walk, and their events are kept out of the daemon.

Git already records every linked worktree under `<git-dir>/worktrees/<name>`, so the roots are read from there rather than probed for on disk — no subprocess and no new dependency. The list is revalidated against that directory's mtime, which git touches whenever a worktree is added or removed: a worktree created while the daemon runs is still picked up on the next graph construction, while a walk that finds nothing costs one `stat` (1.79µs, against 7.06µs resolving from scratch).

**Walking** — `walker.rs`

`create_walker` and `nx_walker_sync` both prune worktree roots. The second matters more than it looks: the daemon expands a directory-creation event by walking the new directory, and backfills a newly watched directory the same way, so without it a `git worktree add` reports every file of the new checkout as created. This applies whatever `use_ignores` says — that flag does not mean "not the workspace", and the daemon's output watcher passes it false while walking the workspace root. Cache output expansion passes it false too and pays the revalidation for nothing, which is now one `stat`.

**Watching** — `watcher.rs`, `watch_filterer.rs`

The filterer blocks everything under a known worktree root. That is the only defence on macOS, where the root is watched recursively and the walker's prune never gets a say. Roots reach it three ways, because no one of them is sufficient:

- seeded at boot from the registry;
- from the event stream, when a checkout's gitfile is created under an existing watch;
- checked once more at the moment a watch would be registered, because `git worktree add` makes the directory first and registers it a moment later, so a walk can land in between and see something that is not yet a worktree.

`track_new_worktrees` runs ahead of the filterer — it has to, or the gitfile would be discarded as a `.git` path before it could be read — so it does no filesystem I/O on a `.git` it has not already established is a file created just now. Answering a `.git` event by opening a `.git` publishes another one, and that loop produced ~1.9M events per run.

**Cache siting** — `worktree.rs`

`get_main_worktree_root` uses the shared gitfile helpers instead of shelling out to `git rev-parse --git-common-dir`. Two bugs fall out of the consolidation: a submodule was read as a worktree and resolved its cache and workspace-data database into `<superproject>/.git/modules/…`, and the memoized root was a `OnceLock` that returned the first caller's answer to every later call regardless of its argument.

`common_git_dir` no longer fails open. It returned the git dir it was handed when `commondir` was missing or unparseable, which named `<repo>/.git/worktrees` as a repository root — a path `git worktree prune`, and so `git gc`, deletes.

### Deliberately handled

- **Submodules keep being scanned.** They use the very same gitfile mechanism (`.git` is a regular file containing `gitdir: …`, identical in shape to a worktree's), but they are registered under `<git-dir>/modules/`. Reading the worktree registry rather than sniffing `.git` files means submodule contents are never mistaken for a worktree — their files are real workspace sources.
- **Stale registrations do not prune real directories.** A registration outlives a worktree deleted by hand, and `gc.worktreePruneExpire` defaults to three months. Pruning a path that no longer exists is harmless, but an ordinary directory later created there must stay in the graph, so the worktree's gitfile has to still be present for the path to be pruned.

### Testing

Fixtures build the layouts git builds, so the suite does not need a `git` binary — with one exception. `a_real_git_worktree_added_after_boot_is_blocked` drives real `git worktree add`, because no fixture reproduces git's ordering (directory, then registration, then gitfile, then checkout), and that ordering is what the last of the three defences above exists for. It skips itself when `git` is unavailable.

`watch_filterer.rs` has unit tests on the filterer itself rather than through a watcher, so the macOS-only half has a witness that fails on Linux, which is the only platform where CI runs cargo.

## Related Issue(s)

N/A — found while looking at directories Nx should never scan or watch.

Fixes NXC-4730
