### PR TITLE
feat(dotnet): per-package affected and cache granularity for Central Package Management

### DIFF
--- a/astro-docs/src/content/docs/kb/project-graph-plugins.mdoc
+++ b/astro-docs/src/content/docs/kb/project-graph-plugins.mdoc
@@ -315,6 +315,40 @@ Breaking down this example, we can see that it follows this flow:
 7. Pushes it into the located dependency array
 8. Returns the located dependencies
 
+## Attributing manifest changes to specific dependencies
+
+A centralized dependency manifest, such as a lock file or a .NET `Directory.Packages.props`, lists versions for many packages in one file.
+By default, a change to a file like this marks every project that declares it as an input as affected, even when only one package version moved.
+
+Plugins that add external nodes can narrow this with `createTouchedDependencies`.
+Like `createNodes`, it's a tuple of a file pattern and a function, exported from the plugin's entry point:
+
+```typescript
+export const createTouchedDependencies: CreateTouchedDependencies = [
+  '**/Directory.Packages.props',
+  (touchedFiles, options, context) => {
+    const changed = new Set<string>();
+    for (const { baseContent, headContent } of touchedFiles) {
+      if (baseContent === null || headContent === null) {
+        // The manifest was added, deleted, or unreadable.
+        return '*';
+      }
+      diffVersions(baseContent, headContent).forEach((id) => changed.add(id));
+    }
+    return Array.from(changed);
+  },
+];
+```
+
+When `nx affected` runs and a changed file matches the pattern, Nx calls the function with the file's contents at the base and head revisions.
+The function returns the identifiers of the dependencies that changed.
+Nx matches each identifier against external node names first and their `packageName` second, then walks the project graph in reverse to mark only the consuming projects as affected.
+
+Return `'*'` when the change can't be attributed to specific dependencies, such as a malformed manifest or a missing base revision.
+Nx then marks every project as affected, which is the same behavior as not implementing the hook at all.
+
+The pattern is matched before your plugin is invoked, so workspaces where no matching file changed don't pay any cost for the hook.
+
 ## Accepting plugin options
 
 When looking at `createNodesV2`, and `createDependencies` you may notice a parameter called `options`. This is the first parameter for `createDependencies` or the second parameter for `createDependencies`.

--- a/astro-docs/src/content/docs/technologies/dotnet/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/dotnet/introduction.mdoc
@@ -111,6 +111,17 @@ The plugin analyzes your MSBuild project files to determine:
 - Available build targets (build, test, clean, etc.)
 - Project outputs and configuration
 
+### NuGet packages and Central Package Management
+
+When your workspace uses [Central Package Management](https://learn.microsoft.com/en-us/nuget/consume-packages/central-package-management), the plugin resolves each project's `PackageReference` items against the `PackageVersion` items in `Directory.Packages.props`.
+Each package becomes an external node in the project graph, and each project's cacheable targets declare only the packages that project references as inputs.
+
+Bumping one version in `Directory.Packages.props` then only affects the projects that reference that package.
+Other projects under the same manifest keep their cached results, and `nx affected` doesn't select them.
+
+If any referenced package's version can't be determined, the plugin falls back to declaring the whole `Directory.Packages.props` file as an input for that project.
+The fallback over-invalidates but never produces a stale build.
+
 ## View inferred tasks
 
 To view inferred tasks for a project, open the [project details view](/docs/features/explore-graph#explore-projects-in-your-workspace) in Nx Console or run `nx show project my-project` in the command line.

--- a/e2e/dotnet/src/dotnet-advanced-msbuild.test.ts
+++ b/e2e/dotnet/src/dotnet-advanced-msbuild.test.ts
@@ -430,7 +430,14 @@ describe('.NET Plugin - Advanced MSBuild Features', () => {
       expect(buildInputs).toContain(
         '{workspaceRoot}/DirBuildInputsApp/Directory.Build.targets'
       );
-      expect(buildInputs).toContain('{workspaceRoot}/Directory.Packages.props');
+
+      // Central Package Management resolved every package (this project has none), so the
+      // whole-file manifest input is replaced by a per-package externalDependencies input —
+      // an empty one here, keeping the project immune to unrelated version bumps.
+      expect(buildInputs).not.toContain(
+        '{workspaceRoot}/Directory.Packages.props'
+      );
+      expect(buildInputs).toContainEqual({ externalDependencies: [] });
 
       // Files that do NOT exist anywhere must not be declared — that was the point
       // of moving from the always-declare design to exists-only inputs.
@@ -448,9 +455,10 @@ describe('.NET Plugin - Advanced MSBuild Features', () => {
       expect(publishInputs).toContain(
         '{workspaceRoot}/DirBuildInputsApp/Directory.Build.targets'
       );
-      expect(publishInputs).toContain(
+      expect(publishInputs).not.toContain(
         '{workspaceRoot}/Directory.Packages.props'
       );
+      expect(publishInputs).toContainEqual({ externalDependencies: [] });
 
       // Targets without a declared inputs array (e.g. restore) are left untouched
       // so we don't accidentally narrow Nx's default-input fallback.

--- a/e2e/dotnet/src/dotnet-cpm-granularity.test.ts
+++ b/e2e/dotnet/src/dotnet-cpm-granularity.test.ts
@@ -1,0 +1,213 @@
+import {
+  cleanupProject,
+  newProject,
+  readJson,
+  runCLI,
+  runCommand,
+  tmpProjPath,
+  updateFile,
+} from '@nx/e2e-utils';
+
+import { createDotNetProject } from './utils/create-dotnet-project';
+
+/**
+ * Central Package Management moves every version into one Directory.Packages.props, so without
+ * per-package attribution a single bump marks every project under that manifest as affected —
+ * including projects that reference no packages at all.
+ *
+ * These tests pin the granular behavior end to end: the project graph gains one external node
+ * per package, `nx affected` selects only the consumers of the package that moved, and the
+ * cache invalidates on the same boundary.
+ */
+describe('.NET Plugin - Central Package Management granularity', () => {
+  const rootPackagesProps = (serilog: string, newtonsoft: string) => `<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Serilog" Version="${serilog}" />
+    <PackageVersion Include="Newtonsoft.Json" Version="${newtonsoft}" />
+  </ItemGroup>
+</Project>`;
+
+  function referencePackage(project: string, packageId: string) {
+    const path = `${project}/${project}.csproj`;
+    const csproj = require('fs').readFileSync(tmpProjPath(path), 'utf-8');
+    updateFile(
+      path,
+      csproj.replace(
+        '</Project>',
+        `  <ItemGroup>\n    <PackageReference Include="${packageId}" />\n  </ItemGroup>\n</Project>`
+      )
+    );
+  }
+
+  beforeAll(() => {
+    newProject({ packages: [] });
+    runCLI(`add @nx/dotnet`);
+
+    // PkgA -> Newtonsoft.Json, PkgB -> Serilog, PkgC -> nothing at all.
+    createDotNetProject({ name: 'PkgA', type: 'classlib' });
+    createDotNetProject({ name: 'PkgB', type: 'classlib' });
+    createDotNetProject({ name: 'PkgC', type: 'classlib' });
+
+    updateFile(
+      'Directory.Packages.props',
+      rootPackagesProps('3.1.1', '13.0.1')
+    );
+    referencePackage('PkgA', 'Newtonsoft.Json');
+    referencePackage('PkgB', 'Serilog');
+
+    for (const project of ['PkgA', 'PkgB', 'PkgC']) {
+      runCommand(`dotnet restore`, { cwd: tmpProjPath(project) });
+    }
+
+    runCommand('git init');
+    runCommand('git config user.email "test@test.com"');
+    runCommand('git config user.name "Test User"');
+    runCommand('git add .');
+    runCommand('git commit -m "Initial commit"');
+  });
+
+  afterAll(() => {
+    // A root Directory.Packages.props enables CPM workspace-wide; leaving it behind makes
+    // `dotnet restore` fail with NU1008 for every other .NET e2e project.
+    cleanupProject();
+  });
+
+  function bumpSerilog(version: string) {
+    updateFile(
+      'Directory.Packages.props',
+      rootPackagesProps(version, '13.0.1')
+    );
+    for (const project of ['PkgA', 'PkgB', 'PkgC']) {
+      runCommand(`dotnet restore`, { cwd: tmpProjPath(project) });
+    }
+  }
+
+  function restorePackagesProps() {
+    updateFile(
+      'Directory.Packages.props',
+      rootPackagesProps('3.1.1', '13.0.1')
+    );
+    for (const project of ['PkgA', 'PkgB', 'PkgC']) {
+      runCommand(`dotnet restore`, { cwd: tmpProjPath(project) });
+    }
+  }
+
+  describe('project graph', () => {
+    it('creates one external node per referenced package', () => {
+      // `nx graph --file` serializes only nodes and dependencies; external nodes live in the
+      // cached graph, so read the canonical artifact the CLI itself maintains.
+      runCLI('graph --file=graph.json');
+      const graph = readJson('.nx/workspace-data/project-graph.json');
+
+      const nugetNodes = Object.keys(graph.externalNodes ?? {}).filter((n) =>
+        n.startsWith('nuget:')
+      );
+
+      expect(nugetNodes).toEqual(
+        expect.arrayContaining([
+          'nuget:Serilog@3.1.1',
+          'nuget:Newtonsoft.Json@13.0.1',
+        ])
+      );
+
+      expect(graph.dependencies['PkgB']).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ target: 'nuget:Serilog@3.1.1' }),
+        ])
+      );
+      // PkgC references nothing, so it must not depend on any package.
+      expect(
+        (graph.dependencies['PkgC'] ?? []).filter((d: any) =>
+          d.target.startsWith('nuget:')
+        )
+      ).toEqual([]);
+    });
+
+    it('declares per-package externalDependencies instead of the manifest file', () => {
+      const build = JSON.parse(runCLI('show project PkgB --json')).targets
+        .build;
+
+      expect(build.inputs).toEqual(
+        expect.arrayContaining([
+          { externalDependencies: ['nuget:Serilog@3.1.1'] },
+        ])
+      );
+      // The whole-file input is what made every consumer invalidate each other.
+      expect(build.inputs).not.toContain(
+        '{workspaceRoot}/Directory.Packages.props'
+      );
+      // Everything above must be inferred — no project.json should have materialized.
+      expect(require('fs').existsSync(tmpProjPath('PkgB/project.json'))).toBe(
+        false
+      );
+    });
+
+    it('gives a project with no packages an empty externalDependencies input', () => {
+      // This also opts it out of Nx's AllExternalDependencies fallback, so unrelated npm
+      // churn in a mixed workspace stops invalidating it.
+      const build = JSON.parse(runCLI('show project PkgC --json')).targets
+        .build;
+
+      expect(build.inputs).toEqual(
+        expect.arrayContaining([{ externalDependencies: [] }])
+      );
+    });
+  });
+
+  describe('nx affected', () => {
+    afterEach(() => {
+      restorePackagesProps();
+      runCommand('git checkout -- Directory.Packages.props');
+    });
+
+    it('selects only the projects referencing the bumped package', () => {
+      bumpSerilog('4.0.0');
+
+      const affected = JSON.parse(
+        runCLI('show projects --affected --base=HEAD --json')
+      );
+
+      expect(affected).toContain('PkgB');
+      expect(affected).not.toContain('PkgA');
+      expect(affected).not.toContain('PkgC');
+    });
+
+    it('selects nothing when the manifest changes but no version does', () => {
+      updateFile(
+        'Directory.Packages.props',
+        `${rootPackagesProps('3.1.1', '13.0.1')}\n<!-- unrelated edit -->`
+      );
+
+      const affected = JSON.parse(
+        runCLI('show projects --affected --base=HEAD --json')
+      );
+
+      expect(affected).toEqual([]);
+    });
+  });
+
+  describe('caching', () => {
+    // Invalidation relies on the daemon's file watcher keeping the workspace context current,
+    // as with every other plugin's createNodes caching.
+    it('rebuilds only the projects referencing the bumped package', () => {
+      runCLI('run-many -t build -p PkgA,PkgB,PkgC');
+      expect(
+        runCLI('run-many -t build -p PkgA,PkgB,PkgC', { verbose: true })
+      ).toContain('3/3');
+
+      bumpSerilog('4.0.0');
+
+      const output = runCLI('run-many -t build -p PkgA,PkgB,PkgC', {
+        verbose: true,
+      });
+
+      // PkgA and PkgC stay cached; only PkgB references the package that moved.
+      expect(output).toContain('2/3');
+
+      restorePackagesProps();
+    });
+  });
+});

--- a/packages/dotnet/analyzer.Tests/CentralPackageManagementTests.cs
+++ b/packages/dotnet/analyzer.Tests/CentralPackageManagementTests.cs
@@ -1,0 +1,307 @@
+using MsbuildAnalyzer;
+using MsbuildAnalyzer.Models;
+using MsbuildAnalyzer.Utilities;
+using Xunit;
+
+namespace MsbuildAnalyzer.Tests;
+
+/// <summary>
+/// Central Package Management resolution, and the per-package externalDependencies inputs it
+/// produces in place of a whole-file Directory.Packages.props input.
+/// </summary>
+public class CentralPackageManagementTests
+{
+    private static readonly string WorkspaceRoot =
+        Path.Combine(Path.GetTempPath(), "nx-dotnet-ws");
+
+    private static Dictionary<string, string> CpmEnabled() =>
+        new() { ["ManagePackageVersionsCentrally"] = "true" };
+
+    private static PackageReference Ref(
+        string include,
+        string? version = null,
+        string? versionOverride = null) =>
+        new() { Include = include, Version = version, VersionOverride = versionOverride };
+
+    // ---------------------------------------------------------------------
+    // Version resolution
+    // ---------------------------------------------------------------------
+
+    [Fact]
+    public void ResolvesVersionsFromPackageVersionItems()
+    {
+        var resolved = Analyzer.ResolveCentralPackages(
+            CpmEnabled(),
+            new List<PackageReference> { Ref("Serilog"), Ref("Newtonsoft.Json") },
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Serilog"] = "4.0.0",
+                ["Newtonsoft.Json"] = "13.0.3",
+                ["Unused.Package"] = "1.0.0"
+            });
+
+        Assert.NotNull(resolved);
+        // Only referenced packages, sorted by id.
+        Assert.Equal(
+            new[] { ("Newtonsoft.Json", "13.0.3"), ("Serilog", "4.0.0") },
+            resolved!.Select(p => (p.Id, p.Version)).ToArray());
+    }
+
+    [Fact]
+    public void VersionOverride_WinsOverCentralVersion()
+    {
+        var resolved = Analyzer.ResolveCentralPackages(
+            CpmEnabled(),
+            new List<PackageReference> { Ref("Serilog", versionOverride: "2.0.0") },
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Serilog"] = "4.0.0"
+            });
+
+        Assert.NotNull(resolved);
+        Assert.Equal("2.0.0", Assert.Single(resolved!).Version);
+    }
+
+    [Fact]
+    public void InlineVersion_UsedWhenPresent()
+    {
+        var resolved = Analyzer.ResolveCentralPackages(
+            CpmEnabled(),
+            new List<PackageReference> { Ref("Serilog", version: "3.1.1") },
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase));
+
+        Assert.NotNull(resolved);
+        Assert.Equal("3.1.1", Assert.Single(resolved!).Version);
+    }
+
+    [Fact]
+    public void PackageIdMatching_IsCaseInsensitive_AndPrefersManifestCasing()
+    {
+        // The manifest's casing wins so the external node name agrees with what
+        // createTouchedDependencies parses out of the same manifest.
+        var resolved = Analyzer.ResolveCentralPackages(
+            CpmEnabled(),
+            new List<PackageReference> { Ref("serilog") },
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Serilog"] = "4.0.0"
+            });
+
+        Assert.NotNull(resolved);
+        var package = Assert.Single(resolved!);
+        Assert.Equal("Serilog", package.Id);
+        Assert.Equal("4.0.0", package.Version);
+    }
+
+    [Fact]
+    public void VersionOverride_KeepsManifestCasing()
+    {
+        var resolved = Analyzer.ResolveCentralPackages(
+            CpmEnabled(),
+            new List<PackageReference> { Ref("serilog", versionOverride: "2.0.0") },
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Serilog"] = "4.0.0"
+            });
+
+        Assert.NotNull(resolved);
+        var package = Assert.Single(resolved!);
+        Assert.Equal("Serilog", package.Id);
+        Assert.Equal("2.0.0", package.Version);
+    }
+
+    [Fact]
+    public void ProjectWithNoPackages_ResolvesToEmpty_NotNull()
+    {
+        // An empty list is meaningful: nothing in Directory.Packages.props should invalidate
+        // a project with no references.
+        var resolved = Analyzer.ResolveCentralPackages(
+            CpmEnabled(),
+            new List<PackageReference>(),
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Serilog"] = "4.0.0"
+            });
+
+        Assert.NotNull(resolved);
+        Assert.Empty(resolved!);
+    }
+
+    [Fact]
+    public void ReturnsNull_WhenCentralPackageManagementIsOff()
+    {
+        Assert.Null(Analyzer.ResolveCentralPackages(
+            new Dictionary<string, string>(),
+            new List<PackageReference> { Ref("Serilog", version: "4.0.0") },
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)));
+    }
+
+    [Fact]
+    public void ReturnsNull_WhenAVersionCannotBeDetermined()
+    {
+        // Unresolvable version — the caller must keep the whole-file input.
+        Assert.Null(Analyzer.ResolveCentralPackages(
+            CpmEnabled(),
+            new List<PackageReference> { Ref("Serilog"), Ref("Mystery.Package") },
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Serilog"] = "4.0.0"
+            }));
+    }
+
+    [Fact]
+    public void DuplicateReferences_AreCollapsed()
+    {
+        var resolved = Analyzer.ResolveCentralPackages(
+            CpmEnabled(),
+            new List<PackageReference> { Ref("Serilog"), Ref("Serilog") },
+            new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase)
+            {
+                ["Serilog"] = "4.0.0"
+            });
+
+        Assert.NotNull(resolved);
+        Assert.Single(resolved!);
+    }
+
+    // ---------------------------------------------------------------------
+    // externalDependencies inputs
+    // ---------------------------------------------------------------------
+
+    private static Dictionary<string, Target> BuildTargets(
+        List<ResolvedPackage>? resolvedPackages,
+        bool isExe = false,
+        bool isTest = false,
+        List<string>? directoryBuildInputs = null) =>
+        TargetBuilder.BuildTargets(
+            projectName: "MyProj",
+            fileName: "MyProj.csproj",
+            isTest: isTest,
+            isExe: isExe,
+            packageRefs: new List<PackageReference>(),
+            properties: new Dictionary<string, string>(),
+            projectDirectory: Path.Combine(WorkspaceRoot, "apps", "MyProj"),
+            workspaceRoot: WorkspaceRoot,
+            options: new PluginOptions(),
+            nxJson: null,
+            directoryBuildInputs: directoryBuildInputs ?? new List<string>(),
+            resolvedPackages: resolvedPackages);
+
+    private static string[]? ExternalDependencies(Target target)
+    {
+        foreach (var input in target.Inputs ?? Array.Empty<object>())
+        {
+            var property = input.GetType().GetProperty("externalDependencies");
+            if (property is not null)
+            {
+                return (string[]?)property.GetValue(input);
+            }
+        }
+        return null;
+    }
+
+    [Fact]
+    public void CacheableTargets_DeclareExternalDependencies()
+    {
+        var packages = new List<ResolvedPackage>
+        {
+            new() { Id = "Serilog", Version = "4.0.0" }
+        };
+
+        foreach (var targetName in new[] { "build", "build:release" })
+        {
+            var targets = BuildTargets(packages);
+            Assert.Equal(
+                new[] { "nuget:Serilog@4.0.0" },
+                ExternalDependencies(targets[targetName]));
+        }
+
+        // pack is only generated for libraries, publish only for executables
+        Assert.Equal(
+            new[] { "nuget:Serilog@4.0.0" },
+            ExternalDependencies(BuildTargets(packages)["pack"]));
+        Assert.Equal(
+            new[] { "nuget:Serilog@4.0.0" },
+            ExternalDependencies(BuildTargets(packages, isExe: true)["publish"]));
+        Assert.Equal(
+            new[] { "nuget:Serilog@4.0.0" },
+            ExternalDependencies(BuildTargets(packages, isTest: true)["test"]));
+    }
+
+    [Fact]
+    public void ExternalNodeNames_IncludeTheVersion()
+    {
+        // Two CPM scopes pinning one package to different versions must not collide on a
+        // shared node name, or one scope's version silently overwrites the other's.
+        var targets = BuildTargets(new List<ResolvedPackage>
+        {
+            new() { Id = "Serilog", Version = "3.1.1" }
+        });
+
+        Assert.Equal(new[] { "nuget:Serilog@3.1.1" }, ExternalDependencies(targets["build"]));
+    }
+
+    [Fact]
+    public void EmptyPackageList_StillDeclaresExternalDependencies()
+    {
+        // An empty array opts the target out of Nx's AllExternalDependencies fallback, so a
+        // project referencing no packages stops being invalidated by unrelated churn.
+        var targets = BuildTargets(new List<ResolvedPackage>());
+
+        Assert.Equal(Array.Empty<string>(), ExternalDependencies(targets["build"]));
+    }
+
+    [Fact]
+    public void NullResolution_LeavesInputsUnchanged()
+    {
+        var targets = BuildTargets(
+            resolvedPackages: null,
+            directoryBuildInputs: new List<string>
+            {
+                "{workspaceRoot}/Directory.Packages.props"
+            });
+
+        Assert.Null(ExternalDependencies(targets["build"]));
+        Assert.Contains(
+            "{workspaceRoot}/Directory.Packages.props",
+            targets["build"].Inputs!.OfType<string>());
+    }
+
+    [Fact]
+    public void NonCacheableTargets_StillDeclareNoInputs()
+    {
+        var targets = BuildTargets(
+            new List<ResolvedPackage> { new() { Id = "Serilog", Version = "4.0.0" } },
+            isExe: true);
+
+        Assert.Null(targets["restore"].Inputs);
+        Assert.Null(targets["clean"].Inputs);
+        Assert.Null(targets["watch"].Inputs);
+        Assert.Null(targets["run"].Inputs);
+    }
+
+    [Fact]
+    public void ExternalDependencies_ArePlacedBeforeDirectoryBuildInputs()
+    {
+        // The existing contract is that Directory.* inputs come last; anything spliced after
+        // them would break TargetBuilderDirectoryBuildInputsTests.
+        var targets = BuildTargets(
+            new List<ResolvedPackage> { new() { Id = "Serilog", Version = "4.0.0" } },
+            directoryBuildInputs: new List<string> { "{workspaceRoot}/Directory.Build.props" });
+
+        var inputs = targets["build"].Inputs!;
+        Assert.Equal("{workspaceRoot}/Directory.Build.props", inputs[^1] as string);
+        Assert.NotNull(ExternalDependencies(targets["build"]));
+    }
+
+    [Fact]
+    public void IsCentralPackagesInput_MatchesOnlyTheCpmManifest()
+    {
+        Assert.True(ProjectUtilities.IsCentralPackagesInput(
+            "{workspaceRoot}/Directory.Packages.props"));
+        Assert.True(ProjectUtilities.IsCentralPackagesInput(
+            "{workspaceRoot}/group/Directory.Packages.props"));
+        Assert.False(ProjectUtilities.IsCentralPackagesInput(
+            "{workspaceRoot}/Directory.Build.props"));
+    }
+}

--- a/packages/dotnet/analyzer/Analyzer.cs
+++ b/packages/dotnet/analyzer/Analyzer.cs
@@ -76,6 +76,7 @@ public static class Analyzer
 
         var nodesByFile = new Dictionary<string, NxProjectGraphNode>();
         var referencesByRoot = new Dictionary<string, ReferencesInfo>();
+        var packagesByRoot = new Dictionary<string, List<ResolvedPackage>>();
 
         // Group nodes by project file path to handle multi-targeting projects.
         // Multi-targeting projects (using TargetFrameworks plural) create multiple nodes:
@@ -158,6 +159,17 @@ public static class Analyzer
                         directoryFilesByDir
                     );
 
+                    // With every package version resolved, per-package externalDependencies
+                    // inputs replace the whole-file Directory.Packages.props input.
+                    var packageVersions = CollectPackageVersions(primaryNode.ProjectInstance!);
+                    var resolvedPackages = ResolveCentralPackages(properties, packageRefs, packageVersions);
+
+                    var targetDirectoryInputs = resolvedPackages is null
+                        ? directoryBuildInputs
+                        : directoryBuildInputs
+                            .Where(i => !ProjectUtilities.IsCentralPackagesInput(i))
+                            .ToList();
+
                     var targets = TargetBuilder.BuildTargets(
                         projectName,
                         Path.GetFileName(projectPath),
@@ -169,7 +181,8 @@ public static class Analyzer
                         workspaceRoot,
                         pluginOptions,
                         nxJson,
-                        directoryBuildInputs
+                        targetDirectoryInputs,
+                        resolvedPackages
                     );
 
                     nodesByFile[relativeProjectFile] = new NxProjectGraphNode
@@ -191,6 +204,11 @@ public static class Analyzer
                             SourceConfigFile = relativeProjectFile
                         };
                     }
+
+                    if (resolvedPackages is not null)
+                    {
+                        packagesByRoot[projectRoot] = resolvedPackages;
+                    }
                 }
                 catch (Exception ex)
                 {
@@ -202,7 +220,8 @@ public static class Analyzer
         return new AnalysisResult
         {
             NodesByFile = nodesByFile,
-            ReferencesByRoot = referencesByRoot
+            ReferencesByRoot = referencesByRoot,
+            PackagesByRoot = packagesByRoot
         };
     }
 
@@ -215,11 +234,91 @@ public static class Analyzer
             packageRefs.Add(new PackageReference
             {
                 Include = item.EvaluatedInclude,
-                Version = item.Metadata.FirstOrDefault(m => m.Name == "Version")?.EvaluatedValue
+                Version = item.Metadata.FirstOrDefault(m => m.Name == "Version")?.EvaluatedValue,
+                VersionOverride = item.Metadata.FirstOrDefault(m => m.Name == "VersionOverride")?.EvaluatedValue
             });
         }
 
         return packageRefs;
+    }
+
+    /// <summary>
+    /// Collects PackageVersion items. These are declared in Directory.Packages.props and are
+    /// what Central Package Management uses to version a bare PackageReference. MSBuild
+    /// evaluates them, so they are available here without running a restore.
+    /// </summary>
+    private static Dictionary<string, string> CollectPackageVersions(ProjectInstance project)
+    {
+        var packageVersions = new Dictionary<string, string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var item in project.GetItems("PackageVersion"))
+        {
+            var version = item.Metadata.FirstOrDefault(m => m.Name == "Version")?.EvaluatedValue;
+            if (!string.IsNullOrEmpty(item.EvaluatedInclude) && !string.IsNullOrEmpty(version))
+            {
+                // A case-insensitive Dictionary keeps the first key's casing on update; remove
+                // first so the latest item's casing wins along with its version.
+                packageVersions.Remove(item.EvaluatedInclude);
+                packageVersions[item.EvaluatedInclude] = version!;
+            }
+        }
+
+        return packageVersions;
+    }
+
+    /// <summary>
+    /// Joins PackageReference items with their resolved versions. Returns null when the project
+    /// is not using Central Package Management or any reference's version cannot be determined;
+    /// callers then keep the whole-file Directory.Packages.props input.
+    /// </summary>
+    internal static List<ResolvedPackage>? ResolveCentralPackages(
+        Dictionary<string, string> properties,
+        List<PackageReference> packageRefs,
+        Dictionary<string, string> packageVersions)
+    {
+        if (!string.Equals(
+                properties.GetValueOrDefault("ManagePackageVersionsCentrally"),
+                "true",
+                StringComparison.OrdinalIgnoreCase))
+        {
+            return null;
+        }
+
+        var resolved = new List<ResolvedPackage>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        // NuGet ids are case-insensitive; prefer the manifest's casing so external node names
+        // agree with what createTouchedDependencies parses out of the same manifest.
+        var manifestIds = packageVersions.Keys.ToDictionary(k => k, StringComparer.OrdinalIgnoreCase);
+
+        foreach (var packageRef in packageRefs)
+        {
+            if (string.IsNullOrEmpty(packageRef.Include))
+            {
+                continue;
+            }
+
+            var version = !string.IsNullOrEmpty(packageRef.VersionOverride)
+                ? packageRef.VersionOverride
+                : !string.IsNullOrEmpty(packageRef.Version)
+                    ? packageRef.Version
+                    : packageVersions.GetValueOrDefault(packageRef.Include);
+
+            if (string.IsNullOrEmpty(version))
+            {
+                // Unknown version — do not narrow this project's inputs.
+                return null;
+            }
+
+            var id = manifestIds.GetValueOrDefault(packageRef.Include!) ?? packageRef.Include!;
+            if (seen.Add(id))
+            {
+                resolved.Add(new ResolvedPackage { Id = id, Version = version! });
+            }
+        }
+
+        resolved.Sort((a, b) => string.CompareOrdinal(a.Id, b.Id));
+        return resolved;
     }
 
     /// <summary>
@@ -267,6 +366,10 @@ public static class Analyzer
             "OutputType",
             "AssemblyName",
             "IsTestProject",
+
+            // Central Package Management — when true, PackageReference items carry no Version
+            // and versions come from PackageVersion items in Directory.Packages.props.
+            "ManagePackageVersionsCentrally",
 
             // Build configuration
             "Configuration",

--- a/packages/dotnet/analyzer/Models/AnalysisResult.cs
+++ b/packages/dotnet/analyzer/Models/AnalysisResult.cs
@@ -14,6 +14,12 @@ public record AnalysisResult
     /// Maps project root (relative to workspace root) to referenced project roots.
     /// </summary>
     public Dictionary<string, ReferencesInfo> ReferencesByRoot { get; init; } = new();
+
+    /// <summary>
+    /// Maps project root (relative to workspace root) to resolved NuGet packages. Only
+    /// populated for Central Package Management projects whose versions all resolved.
+    /// </summary>
+    public Dictionary<string, List<ResolvedPackage>> PackagesByRoot { get; init; } = new();
 }
 
 public record ReferencesInfo

--- a/packages/dotnet/analyzer/Models/PackageReference.cs
+++ b/packages/dotnet/analyzer/Models/PackageReference.cs
@@ -11,7 +11,14 @@ public record PackageReference
     public string Include { get; init; } = string.Empty;
 
     /// <summary>
-    /// The package version.
+    /// The package version. Empty under Central Package Management, where the version is
+    /// sourced from a PackageVersion item instead.
     /// </summary>
     public string? Version { get; init; }
+
+    /// <summary>
+    /// A per-project override of the centrally managed version. Takes precedence over both
+    /// Version and the matching PackageVersion item.
+    /// </summary>
+    public string? VersionOverride { get; init; }
 }

--- a/packages/dotnet/analyzer/Models/ResolvedPackage.cs
+++ b/packages/dotnet/analyzer/Models/ResolvedPackage.cs
@@ -1,0 +1,19 @@
+namespace MsbuildAnalyzer.Models;
+
+/// <summary>
+/// A NuGet package a project depends on, with the version MSBuild resolved for it. Under
+/// Central Package Management the version lives on a PackageVersion item rather than the
+/// PackageReference.
+/// </summary>
+public record ResolvedPackage
+{
+    /// <summary>
+    /// The package id, e.g. "Serilog".
+    /// </summary>
+    public string Id { get; init; } = string.Empty;
+
+    /// <summary>
+    /// The resolved version, e.g. "4.0.0".
+    /// </summary>
+    public string Version { get; init; } = string.Empty;
+}

--- a/packages/dotnet/analyzer/MsbuildAnalyzer.csproj
+++ b/packages/dotnet/analyzer/MsbuildAnalyzer.csproj
@@ -12,6 +12,10 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <InternalsVisibleTo Include="MsbuildAnalyzer.Tests" />
+  </ItemGroup>
+
+  <ItemGroup>
     <!-- Microsoft.Build packages provide ProjectGraph and evaluation APIs -->
     <!-- Using 17.* versions that support .NET Core/Standard -->
     <!-- ExcludeAssets="runtime" prevents copying MSBuild assemblies; MSBuildLocator will load them -->

--- a/packages/dotnet/analyzer/Utilities/ProjectUtilities.cs
+++ b/packages/dotnet/analyzer/Utilities/ProjectUtilities.cs
@@ -78,6 +78,19 @@ public static class ProjectUtilities
     };
 
     /// <summary>
+    /// The Central Package Management manifest, treated separately from the other Directory.*
+    /// files because its contents can be attributed to individual packages.
+    /// </summary>
+    public const string CentralPackagesFileName = "Directory.Packages.props";
+
+    /// <summary>
+    /// Whether an input produced by <see cref="GetDirectoryBuildInputs"/> points at a
+    /// Directory.Packages.props file.
+    /// </summary>
+    public static bool IsCentralPackagesInput(string input) =>
+        input.EndsWith("/" + CentralPackagesFileName, StringComparison.OrdinalIgnoreCase);
+
+    /// <summary>
     /// .NET project file extensions. Used both to partition stdin input and to filter the MSBuild
     /// project graph — imported files such as Directory.Build.props can surface as graph nodes
     /// depending on the SDK version, and they must never be treated as buildable projects.

--- a/packages/dotnet/analyzer/Utilities/TargetBuilder.Build.cs
+++ b/packages/dotnet/analyzer/Utilities/TargetBuilder.Build.cs
@@ -21,7 +21,8 @@ public static partial class TargetBuilder
         string productionInput,
         string defaultConfiguration,
         string description,
-        List<string> directoryBuildInputs)
+        List<string> directoryBuildInputs,
+        object? externalDependenciesInput = null)
     {
         var outputPath = GetOutputPath(properties, projectName, projectDirectory, workspaceRoot);
         var intermediatePath = GetIntermediateOutputPath(properties, projectName, projectDirectory, workspaceRoot);
@@ -59,6 +60,7 @@ public static partial class TargetBuilder
                 "{workspaceRoot}/.editorconfig",
                 new { workingDirectory = "absolute" },
                 new { dependentTasksOutputFiles = "**/*" },
+                .. AsInputs(externalDependenciesInput),
                 .. directoryBuildInputs
             ],
             Outputs = new[] { outputPath, intermediatePath }
@@ -82,7 +84,8 @@ public static partial class TargetBuilder
         string workspaceRoot,
         PluginOptions options,
         string productionInput,
-        List<string> directoryBuildInputs)
+        List<string> directoryBuildInputs,
+        object? externalDependenciesInput = null)
     {
         var targetName = options.BuildTargetName;
         targets[targetName] = CreateBuildTarget(
@@ -96,7 +99,8 @@ public static partial class TargetBuilder
             productionInput,
             "Debug",
             "Build the .NET project",
-            directoryBuildInputs);
+            directoryBuildInputs,
+            externalDependenciesInput);
     }
 
     private static void AddBuildReleaseTarget(
@@ -109,7 +113,8 @@ public static partial class TargetBuilder
         string workspaceRoot,
         PluginOptions options,
         string productionInput,
-        List<string> directoryBuildInputs)
+        List<string> directoryBuildInputs,
+        object? externalDependenciesInput = null)
     {
         var releaseTargetName = $"{options.BuildTargetName}:release";
         targets[releaseTargetName] = CreateBuildTarget(
@@ -123,6 +128,7 @@ public static partial class TargetBuilder
             productionInput,
             "Release",
             "Build the .NET project in Release configuration",
-            directoryBuildInputs);
+            directoryBuildInputs,
+            externalDependenciesInput);
     }
 }

--- a/packages/dotnet/analyzer/Utilities/TargetBuilder.Pack.cs
+++ b/packages/dotnet/analyzer/Utilities/TargetBuilder.Pack.cs
@@ -16,7 +16,8 @@ public static partial class TargetBuilder
         string workspaceRoot,
         PluginOptions options,
         string productionInput,
-        List<string> directoryBuildInputs)
+        List<string> directoryBuildInputs,
+        object? externalDependenciesInput = null)
     {
         // Create a copy of properties with Configuration=Release
         var releaseProperties = new Dictionary<string, string>(properties)
@@ -59,6 +60,7 @@ public static partial class TargetBuilder
                 "{workspaceRoot}/.editorconfig",
                 new { workingDirectory = "absolute" },
                 new { dependentTasksOutputFiles = "**/*" },
+                .. AsInputs(externalDependenciesInput),
                 .. directoryBuildInputs
             ],
             Outputs = new[]

--- a/packages/dotnet/analyzer/Utilities/TargetBuilder.Publish.cs
+++ b/packages/dotnet/analyzer/Utilities/TargetBuilder.Publish.cs
@@ -17,7 +17,8 @@ public static partial class TargetBuilder
         string workspaceRoot,
         PluginOptions options,
         string productionInput,
-        List<string> directoryBuildInputs)
+        List<string> directoryBuildInputs,
+        object? externalDependenciesInput = null)
     {
         // Create a copy of properties with Configuration=Release
         var releaseProperties = new Dictionary<string, string>(properties)
@@ -63,6 +64,7 @@ public static partial class TargetBuilder
                 "{workspaceRoot}/.editorconfig",
                 new { workingDirectory = "absolute" },
                 new { dependentTasksOutputFiles = "**/*" },
+                .. AsInputs(externalDependenciesInput),
                 .. directoryBuildInputs
             ],
             Outputs = new[] { publishDir, intermediatePath }

--- a/packages/dotnet/analyzer/Utilities/TargetBuilder.Test.cs
+++ b/packages/dotnet/analyzer/Utilities/TargetBuilder.Test.cs
@@ -17,12 +17,9 @@ public static partial class TargetBuilder
         string workspaceRoot,
         PluginOptions options,
         string productionInput,
-        List<string> directoryBuildInputs)
+        List<string> directoryBuildInputs,
+        object? externalDependenciesInput = null)
     {
-        // TODO(@AgentEnder): We should add this back in after external deps
-        // support is fleshed out.
-        //
-        // var externalDeps = packageRefs.Select(p => p.Include).ToArray();
         var testResultsDir = GetTestResultsDirectory(properties, projectName, projectDirectory, workspaceRoot);
 
         string[] defaultFlags = ["--no-build", "--no-restore"];
@@ -44,7 +41,7 @@ public static partial class TargetBuilder
                 "{workspaceRoot}/.editorconfig",
                 new { workingDirectory = "absolute" },
                 new { dependentTasksOutputFiles = "**/*" },
-                // new { externalDependencies = externalDeps }
+                .. AsInputs(externalDependenciesInput),
                 .. directoryBuildInputs
             ],
             Outputs = testResultsDir is null ? [] : [testResultsDir],

--- a/packages/dotnet/analyzer/Utilities/TargetBuilder.cs
+++ b/packages/dotnet/analyzer/Utilities/TargetBuilder.cs
@@ -21,19 +21,23 @@ public static partial class TargetBuilder
         string workspaceRoot,
         PluginOptions options,
         NxJsonConfig? nxJson,
-        List<string> directoryBuildInputs)
+        List<string> directoryBuildInputs,
+        List<ResolvedPackage>? resolvedPackages = null)
     {
         var targets = new Dictionary<string, Target>();
 
         // Determine the appropriate input for production builds
         var productionInput = GetProductionInput(nxJson);
 
-        AddBuildTarget(targets, projectName, fileName, isTest, properties, projectDirectory, workspaceRoot, options, productionInput, directoryBuildInputs);
-        AddBuildReleaseTarget(targets, projectName, fileName, isTest, properties, projectDirectory, workspaceRoot, options, productionInput, directoryBuildInputs);
+        // Non-null only when the caller resolved every package version for this project.
+        var externalDependenciesInput = CreateExternalDependenciesInput(resolvedPackages);
+
+        AddBuildTarget(targets, projectName, fileName, isTest, properties, projectDirectory, workspaceRoot, options, productionInput, directoryBuildInputs, externalDependenciesInput);
+        AddBuildReleaseTarget(targets, projectName, fileName, isTest, properties, projectDirectory, workspaceRoot, options, productionInput, directoryBuildInputs, externalDependenciesInput);
 
         if (isTest)
         {
-            AddTestTarget(targets, projectName, fileName, packageRefs, properties, projectDirectory, workspaceRoot, options, productionInput, directoryBuildInputs);
+            AddTestTarget(targets, projectName, fileName, packageRefs, properties, projectDirectory, workspaceRoot, options, productionInput, directoryBuildInputs, externalDependenciesInput);
         }
 
         // restore/clean/watch/run intentionally omit Directory.* inputs — they don't declare an
@@ -45,17 +49,49 @@ public static partial class TargetBuilder
 
         if (isExe)
         {
-            AddPublishTarget(targets, projectName, fileName, isTest, properties, projectDirectory, workspaceRoot, options, productionInput, directoryBuildInputs);
+            AddPublishTarget(targets, projectName, fileName, isTest, properties, projectDirectory, workspaceRoot, options, productionInput, directoryBuildInputs, externalDependenciesInput);
             AddRunTarget(targets, fileName, options);
         }
 
         if (!isExe && !isTest)
         {
-            AddPackTarget(targets, projectName, fileName, properties, projectDirectory, workspaceRoot, options, productionInput, directoryBuildInputs);
+            AddPackTarget(targets, projectName, fileName, properties, projectDirectory, workspaceRoot, options, productionInput, directoryBuildInputs, externalDependenciesInput);
         }
 
         return targets;
     }
+
+    /// <summary>
+    /// Builds the Nx `{ "externalDependencies": [...] }` input for a project's NuGet packages.
+    /// Declaring it also opts the target out of Nx's `AllExternalDependencies` fallback.
+    /// Returns null when versions were not resolved; an empty list is preserved so a project
+    /// with no packages is not invalidated by unrelated dependency churn.
+    /// </summary>
+    private static object? CreateExternalDependenciesInput(List<ResolvedPackage>? resolvedPackages)
+    {
+        if (resolvedPackages is null)
+        {
+            return null;
+        }
+
+        // The version is part of the node name so CPM scopes pinning the same package to
+        // different versions produce distinct nodes, as npm does with `npm:pkg@version`.
+        var names = resolvedPackages
+            .Select(p => $"{NuGetExternalNodePrefix}{p.Id}@{p.Version}")
+            .ToArray();
+
+        return new { externalDependencies = names };
+    }
+
+    /// <summary>
+    /// Prefix for NuGet external node names, mirroring `npm:` for JS and `maven:` for Maven.
+    /// </summary>
+    public const string NuGetExternalNodePrefix = "nuget:";
+
+    /// <summary>
+    /// Splices an optional input into an Inputs collection expression.
+    /// </summary>
+    private static object[] AsInputs(object? input) => input is null ? [] : [input];
 
     /// <summary>
     /// Determines the appropriate input for production builds.

--- a/packages/dotnet/src/analyzer/analyzer-client.ts
+++ b/packages/dotnet/src/analyzer/analyzer-client.ts
@@ -8,6 +8,12 @@ import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
 import { hashObject } from 'nx/src/hasher/file-hasher';
 import { PluginCache } from 'nx/src/utils/plugin-cache-utils';
 
+/** A NuGet package a project references, with the version MSBuild resolved for it. */
+export interface ResolvedPackage {
+  id: string;
+  version: string;
+}
+
 export interface AnalysisSuccessResult {
   // Maps project file path -> node configuration
   nodesByFile: Record<string, ProjectConfiguration>;
@@ -16,6 +22,9 @@ export interface AnalysisSuccessResult {
     string,
     { refs: string[]; sourceConfigFile: string }
   >;
+  // Maps project root -> resolved NuGet packages. Only populated for Central Package
+  // Management projects whose versions all resolved.
+  packagesByRoot?: Record<string, ResolvedPackage[]>;
 }
 export interface AnalysisErrorResult {
   error: Error;

--- a/packages/dotnet/src/index.ts
+++ b/packages/dotnet/src/index.ts
@@ -2,6 +2,7 @@ export {
   createNodes,
   createNodesV2,
   createDependencies,
+  createTouchedDependencies,
 } from './plugins/plugin';
 
 export { DotNetPluginOptions } from './plugins/create-nodes';

--- a/packages/dotnet/src/plugins/create-dependencies.ts
+++ b/packages/dotnet/src/plugins/create-dependencies.ts
@@ -4,7 +4,7 @@ import {
   RawProjectGraphDependency,
 } from '@nx/devkit';
 
-import { DotNetPluginOptions } from './create-nodes';
+import { DotNetPluginOptions, nugetExternalNodeName } from './create-nodes';
 import {
   readCachedAnalysisResult,
   isAnalysisErrorResult,
@@ -29,7 +29,16 @@ export const createDependencies: CreateDependencies<
     );
   }
 
-  const { referencesByRoot } = cachedResult;
+  const { nodesByFile, referencesByRoot, packagesByRoot } = cachedResult;
+
+  // Dependencies from a workspace project require a sourceFile; a project with only package
+  // references has no referencesByRoot entry, so recover its csproj from nodesByFile.
+  const configFileByRoot = new Map<string, string>();
+  for (const [configFile, node] of Object.entries(nodesByFile)) {
+    if (node?.root !== undefined) {
+      configFileByRoot.set(node.root, configFile);
+    }
+  }
 
   // Map references to dependencies
   // The analyzer returns: { [projectRoot]: [referencedProjectRoot1, referencedProjectRoot2, ...] }
@@ -52,6 +61,28 @@ export const createDependencies: CreateDependencies<
           sourceFile: referencedRoots.sourceConfigFile,
         });
       }
+    }
+  }
+
+  // Edges from each project to the NuGet packages it references.
+  for (const [sourceRoot, packages] of Object.entries(packagesByRoot ?? {})) {
+    const sourceName = rootMap.get(sourceRoot);
+    if (!sourceName) {
+      continue;
+    }
+
+    const sourceConfigFile = configFileByRoot.get(sourceRoot);
+    if (!sourceConfigFile) {
+      continue;
+    }
+
+    for (const pkg of packages) {
+      dependencies.push({
+        source: sourceName,
+        target: nugetExternalNodeName(pkg),
+        type: DependencyType.static,
+        sourceFile: sourceConfigFile,
+      });
     }
   }
 

--- a/packages/dotnet/src/plugins/create-nodes.ts
+++ b/packages/dotnet/src/plugins/create-nodes.ts
@@ -2,11 +2,13 @@ import {
   CreateNodes,
   logger,
   ProjectConfiguration,
+  ProjectGraphExternalNode,
   TargetConfiguration,
 } from '@nx/devkit';
 import {
   analyzeProjects,
   isAnalysisErrorResult,
+  ResolvedPackage,
 } from '../analyzer/analyzer-client';
 import { mergeTargetConfigurations } from 'nx/src/project-graph/utils/project-configuration-utils';
 
@@ -175,6 +177,44 @@ function mergeUserTargetConfigurations(
   };
 }
 
+/**
+ * Kept in sync with `TargetBuilder.NuGetExternalNodePrefix` in the analyzer.
+ */
+export const NUGET_EXTERNAL_NODE_PREFIX = 'nuget:';
+
+/**
+ * The version is part of the node name so CPM scopes pinning the same package to different
+ * versions produce distinct nodes, as npm does with `npm:pkg@version`.
+ */
+export function nugetExternalNodeName(pkg: ResolvedPackage): string {
+  return `${NUGET_EXTERNAL_NODE_PREFIX}${pkg.id}@${pkg.version}`;
+}
+
+/**
+ * Builds one external node per (package, version) referenced anywhere in the workspace.
+ */
+function createNuGetExternalNodes(
+  packagesByRoot: Record<string, ResolvedPackage[]> | undefined
+): Record<string, ProjectGraphExternalNode> {
+  const externalNodes: Record<string, ProjectGraphExternalNode> = {};
+
+  for (const packages of Object.values(packagesByRoot ?? {})) {
+    for (const pkg of packages) {
+      const name = nugetExternalNodeName(pkg);
+      externalNodes[name] ??= {
+        type: 'nuget',
+        name,
+        data: {
+          packageName: pkg.id,
+          version: pkg.version,
+        },
+      };
+    }
+  }
+
+  return externalNodes;
+}
+
 export const createNodes: CreateNodes<DotNetPluginOptions> = [
   dotnetProjectGlob,
   async (configFilePaths, options, context) => {
@@ -219,15 +259,21 @@ export const createNodes: CreateNodes<DotNetPluginOptions> = [
         throw result.error;
       }
 
-      const { nodesByFile } = result;
+      const { nodesByFile, packagesByRoot } = result;
 
-      // Return array of [configFile, result] tuples
-      return configFilePaths.map((configFile) => {
+      const externalNodes = createNuGetExternalNodes(packagesByRoot);
+
+      // Return array of [configFile, result] tuples. Every tuple's externalNodes merge into
+      // the same graph, so the map is attached to the first tuple only — repeating it would
+      // inflate the serialized worker payload proportionally to the number of project files.
+      return configFilePaths.map((configFile, index) => {
+        const tupleExternalNodes = index === 0 ? { externalNodes } : undefined;
+
         const node = nodesByFile[configFile];
         if (!node) {
           // Directory.Build.* / Directory.Solution.* files contribute no projects of
           // their own; returning an empty config is the conventional "skip" response.
-          return [configFile, {}];
+          return [configFile, { ...tupleExternalNodes }];
         }
 
         // Merge user-specified target configurations with generated targets. The analyzer
@@ -243,6 +289,7 @@ export const createNodes: CreateNodes<DotNetPluginOptions> = [
             projects: {
               [mergedNode.root]: mergedNode,
             },
+            ...tupleExternalNodes,
           },
         ];
       });

--- a/packages/dotnet/src/plugins/create-touched-dependencies.spec.ts
+++ b/packages/dotnet/src/plugins/create-touched-dependencies.spec.ts
@@ -1,0 +1,182 @@
+import { createTouchedDependenciesFunction } from './create-touched-dependencies';
+import type { TouchedDependencyFile } from '@nx/devkit';
+
+const context = { nxJsonConfiguration: {}, workspaceRoot: '/ws' };
+
+function props(packages: Record<string, string>): string {
+  const entries = Object.entries(packages)
+    .map(
+      ([id, version]) =>
+        `    <PackageVersion Include="${id}" Version="${version}" />`
+    )
+    .join('\n');
+  return `<Project>
+  <PropertyGroup>
+    <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
+  </PropertyGroup>
+  <ItemGroup>
+${entries}
+  </ItemGroup>
+</Project>`;
+}
+
+function file(
+  baseContent: string | null,
+  headContent: string | null,
+  path = 'Directory.Packages.props'
+): TouchedDependencyFile {
+  return { file: path, baseContent, headContent };
+}
+
+function run(files: TouchedDependencyFile[]) {
+  return createTouchedDependenciesFunction(files, undefined, context);
+}
+
+describe('createTouchedDependencies', () => {
+  it('reports only the package whose version changed', () => {
+    const before = props({ 'Newtonsoft.Json': '13.0.1', Serilog: '3.1.1' });
+    const after = props({ 'Newtonsoft.Json': '13.0.1', Serilog: '4.0.0' });
+
+    expect(run([file(before, after)])).toEqual(['nuget:Serilog@4.0.0']);
+  });
+
+  it('reports nothing when the file changed but no version did', () => {
+    const before = props({ Serilog: '3.1.1' });
+    const after = `${props({ Serilog: '3.1.1' })}\n<!-- a comment -->`;
+
+    expect(run([file(before, after)])).toEqual([]);
+  });
+
+  it('reports added and removed packages', () => {
+    const before = props({ Serilog: '3.1.1', Removed: '1.0.0' });
+    const after = props({ Serilog: '3.1.1', Added: '2.0.0' });
+
+    expect(new Set(run([file(before, after)]))).toEqual(
+      new Set(['Removed', 'nuget:Added@2.0.0'])
+    );
+  });
+
+  it('handles the Update form and single-quoted attributes', () => {
+    const before = `<Project><ItemGroup><PackageVersion Update='Serilog' Version='3.1.1' /></ItemGroup></Project>`;
+    const after = `<Project><ItemGroup><PackageVersion Update='Serilog' Version='4.0.0' /></ItemGroup></Project>`;
+
+    expect(run([file(before, after)])).toEqual(['nuget:Serilog@4.0.0']);
+  });
+
+  it('handles reversed attribute order', () => {
+    const before = `<Project><ItemGroup><PackageVersion Version="3.1.1" Include="Serilog" /></ItemGroup></Project>`;
+    const after = `<Project><ItemGroup><PackageVersion Version="4.0.0" Include="Serilog" /></ItemGroup></Project>`;
+
+    expect(run([file(before, after)])).toEqual(['nuget:Serilog@4.0.0']);
+  });
+
+  it('aggregates across several manifests', () => {
+    const root = file(
+      props({ 'Newtonsoft.Json': '13.0.1' }),
+      props({ 'Newtonsoft.Json': '13.0.3' })
+    );
+    const nested = file(
+      props({ Serilog: '3.1.1' }),
+      props({ Serilog: '4.0.0' }),
+      'group/Directory.Packages.props'
+    );
+
+    expect(new Set(run([root, nested]))).toEqual(
+      new Set(['nuget:Newtonsoft.Json@13.0.3', 'nuget:Serilog@4.0.0'])
+    );
+  });
+
+  describe('falls back to marking everything affected', () => {
+    it('when the base revision could not be read', () => {
+      expect(run([file(null, props({ Serilog: '4.0.0' }))])).toBe('*');
+    });
+
+    it('when the manifest was deleted', () => {
+      expect(run([file(props({ Serilog: '3.1.1' }), null)])).toBe('*');
+    });
+
+    it('when neither side parses into package versions', () => {
+      expect(run([file('<Project>', 'not xml at all')])).toBe('*');
+    });
+
+    it('even when another manifest in the same change parsed cleanly', () => {
+      const parseable = file(
+        props({ Serilog: '3.1.1' }),
+        props({ Serilog: '4.0.0' })
+      );
+      const unreadable = file(
+        null,
+        props({ Other: '1.0.0' }),
+        'x/Directory.Packages.props'
+      );
+
+      expect(run([parseable, unreadable])).toBe('*');
+    });
+  });
+
+  it('treats a PackageVersion gaining an explicit version as a change', () => {
+    const before = `<Project><ItemGroup><PackageVersion Include="Serilog" /></ItemGroup></Project>`;
+    const after = props({ Serilog: '4.0.0' });
+
+    expect(run([file(before, after)])).toEqual(['nuget:Serilog@4.0.0']);
+  });
+  it('treats a casing-only rename as no change, matching NuGet id semantics', () => {
+    const before = props({ Serilog: '3.1.1' });
+    const after = props({ serilog: '3.1.1' });
+
+    expect(run([file(before, after)])).toEqual([]);
+  });
+
+  it('reports a version bump under the head casing when the id casing also changed', () => {
+    const before = props({ serilog: '3.1.1' });
+    const after = props({ Serilog: '4.0.0' });
+
+    expect(run([file(before, after)])).toEqual(['nuget:Serilog@4.0.0']);
+  });
+
+  it('falls back to the bare id when the new version is empty', () => {
+    const before = props({ Serilog: '4.0.0' });
+    const after = `<Project><ItemGroup><PackageVersion Include="Serilog" Version="" /></ItemGroup></Project>`;
+
+    expect(run([file(before, after)])).toEqual(['Serilog']);
+  });
+
+  describe('versions supplied by MSBuild expressions', () => {
+    it('treats an expression-versioned package as touched on every edit', () => {
+      const before = `<Project>
+  <PropertyGroup>
+    <SerilogVersion>3.1.1</SerilogVersion>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageVersion Include="Serilog" Version="$(SerilogVersion)" />
+    <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
+  </ItemGroup>
+</Project>`;
+      const after = before.replace(
+        '3.1.1</SerilogVersion>',
+        '4.0.0</SerilogVersion>'
+      );
+
+      expect(run([file(before, after)])).toEqual(['Serilog']);
+    });
+
+    it('keeps exact attribution for literal versions alongside an expression', () => {
+      const before = `<Project><ItemGroup>
+        <PackageVersion Include="Serilog" Version="$(SerilogVersion)" />
+        <PackageVersion Include="Newtonsoft.Json" Version="13.0.1" />
+      </ItemGroup></Project>`;
+      const after = before.replace('13.0.1', '13.0.3');
+
+      expect(new Set(run([file(before, after)]))).toEqual(
+        new Set(['Serilog', 'nuget:Newtonsoft.Json@13.0.3'])
+      );
+    });
+
+    it('does not emit a node name containing an unevaluated expression', () => {
+      const before = `<Project><ItemGroup><PackageVersion Include="Serilog" Version="$(OldVersion)" /></ItemGroup></Project>`;
+      const after = `<Project><ItemGroup><PackageVersion Include="Serilog" Version="$(NewVersion)" /></ItemGroup></Project>`;
+
+      expect(run([file(before, after)])).toEqual(['Serilog']);
+    });
+  });
+});

--- a/packages/dotnet/src/plugins/create-touched-dependencies.ts
+++ b/packages/dotnet/src/plugins/create-touched-dependencies.ts
@@ -1,0 +1,118 @@
+import type {
+  CreateTouchedDependenciesFunction,
+  TouchedDependencies,
+  TouchedDependencyFile,
+} from '@nx/devkit';
+
+import { DotNetPluginOptions, nugetExternalNodeName } from './create-nodes';
+
+/**
+ * Matches every Central Package Management manifest in the workspace.
+ */
+export const centralPackagesFilePattern = '**/Directory.Packages.props';
+
+/**
+ * `<PackageVersion Include="Serilog" Version="4.0.0" />`, tolerating attribute order, single or
+ * double quotes, and the `Update` form used to amend a version inherited from an outer manifest.
+ */
+const PACKAGE_VERSION_ELEMENT = /<PackageVersion\b([^>]*)\/?>/gi;
+const ATTRIBUTE = /(\w+)\s*=\s*("([^"]*)"|'([^']*)')/g;
+
+/**
+ * An MSBuild property, item, or metadata expression (`$(...)`, `@(...)`, `%(...)`). A version
+ * carrying one can resolve to a different value without this element's text changing, so it
+ * can't be diffed textually.
+ */
+const MSBUILD_EXPRESSION = /[$@%]\(/;
+
+/**
+ * Keyed by lowercased package id — NuGet ids are case-insensitive, so a casing-only rename of
+ * an Include is not a change. Values keep the manifest's casing for building identifiers.
+ */
+function parsePackageVersions(
+  content: string
+): Map<string, { id: string; version: string }> {
+  const versions = new Map<string, { id: string; version: string }>();
+
+  for (const [, attributeText] of content.matchAll(PACKAGE_VERSION_ELEMENT)) {
+    let id: string | undefined;
+    let version: string | undefined;
+
+    for (const [, name, , doubleQuoted, singleQuoted] of attributeText.matchAll(
+      ATTRIBUTE
+    )) {
+      const value = doubleQuoted ?? singleQuoted ?? '';
+      const lowered = name.toLowerCase();
+      if (lowered === 'include' || lowered === 'update') {
+        id = value;
+      } else if (lowered === 'version') {
+        version = value;
+      }
+    }
+
+    if (id) {
+      // The version may be supplied by a property elsewhere; record the id regardless so
+      // adding or removing the item still registers.
+      versions.set(id.toLowerCase(), { id, version: version ?? '' });
+    }
+  }
+
+  return versions;
+}
+
+/**
+ * Attributes a change in a Directory.Packages.props to the packages whose versions moved.
+ * Returns exact `nuget:<Id>@<Version>` node names when the new version is known, so a bump in
+ * one Central Package Management scope doesn't select consumers of the same package pinned to a
+ * different version in another scope. Falls back to the bare package id when the version can't
+ * be determined: removed packages, empty versions, and versions supplied by an MSBuild
+ * expression like `$(SerilogVersion)` — those can resolve differently without the element's
+ * text changing, so their packages count as touched on every edit of the manifest. Returns
+ * `'*'` (mark everything affected) when the change can't be attributed at all: an unreadable
+ * base revision, a deleted manifest, or content that parses to nothing.
+ */
+export const createTouchedDependenciesFunction: CreateTouchedDependenciesFunction<
+  DotNetPluginOptions
+> = (touchedFiles: TouchedDependencyFile[]): TouchedDependencies => {
+  const changed = new Set<string>();
+
+  for (const { baseContent, headContent } of touchedFiles) {
+    // Added, deleted, or unreadable on one side — not attributable to individual packages.
+    if (baseContent === null || headContent === null) {
+      return '*';
+    }
+
+    const before = parsePackageVersions(baseContent);
+    const after = parsePackageVersions(headContent);
+
+    // Content on both sides but no PackageVersion items parsed — treat as malformed.
+    if (before.size === 0 && after.size === 0) {
+      return '*';
+    }
+
+    for (const [key, { id, version }] of after) {
+      if (MSBUILD_EXPRESSION.test(version)) {
+        // The resolved version can move (e.g. a property bump) without this element's text
+        // changing, so any edit of the manifest may affect this package.
+        changed.add(id);
+      } else if (before.get(key)?.version !== version) {
+        changed.add(version ? nugetExternalNodeName({ id, version }) : id);
+      }
+    }
+    for (const [key, { id }] of before) {
+      if (!after.has(key)) {
+        // No head version exists for a removed package. The bare id over-selects across scopes,
+        // and consumers of the removed package fail resolution anyway, which drops them back to
+        // the whole-file input.
+        changed.add(id);
+      }
+    }
+  }
+
+  return Array.from(changed);
+};
+
+export const createTouchedDependencies = [
+  centralPackagesFilePattern,
+  createTouchedDependenciesFunction,
+] as const;

--- a/packages/dotnet/src/plugins/plugin.ts
+++ b/packages/dotnet/src/plugins/plugin.ts
@@ -1,5 +1,6 @@
 import { createNodes as createDotNetNodes } from './create-nodes';
 import { createDependencies as createDotNetDependencies } from './create-dependencies';
+import { createTouchedDependencies as createDotNetTouchedDependencies } from './create-touched-dependencies';
 
 // The plugin can be fully disabled (e.g. to debug graph issues) via the
 // NX_DOTNET_DISABLE environment variable. When disabled, no nodes or
@@ -15,3 +16,7 @@ export const createNodesV2 = disabled ? undefined : createDotNetNodes;
 export const createDependencies = disabled
   ? undefined
   : createDotNetDependencies;
+
+export const createTouchedDependencies = disabled
+  ? undefined
+  : createDotNetTouchedDependencies;

--- a/packages/nx/src/project-graph/affected/affected-project-graph.ts
+++ b/packages/nx/src/project-graph/affected/affected-project-graph.ts
@@ -13,6 +13,7 @@ import { ProjectGraph } from '../../config/project-graph';
 import { reverse } from '../operators';
 import { readNxJson } from '../../config/configuration';
 import { getTouchedProjectsFromProjectGlobChanges } from './locators/project-glob-changes';
+import { getTouchedDependencies } from './locators/touched-dependencies';
 
 export async function filterAffected(
   graph: ProjectGraph,
@@ -26,6 +27,7 @@ export async function filterAffected(
     getImplicitlyTouchedProjects,
     getTouchedProjectsFromProjectGlobChanges,
     getJSTouchedProjects,
+    getTouchedDependencies,
   ];
 
   const touchedProjects = [];

--- a/packages/nx/src/project-graph/affected/locators/touched-dependencies.spec.ts
+++ b/packages/nx/src/project-graph/affected/locators/touched-dependencies.spec.ts
@@ -1,0 +1,240 @@
+import { getTouchedDependencies } from './touched-dependencies';
+import { WholeFileChange } from '../../file-utils';
+import {
+  ProjectGraph,
+  ProjectGraphExternalNode,
+} from '../../../config/project-graph';
+
+const getPluginsMock = jest.fn();
+jest.mock('../../plugins/get-plugins', () => ({
+  getPlugins: (...args: unknown[]) => getPluginsMock(...args),
+}));
+
+function externalNode(
+  name: string,
+  packageName: string,
+  version: string
+): ProjectGraphExternalNode {
+  return { type: 'nuget', name, data: { packageName, version } };
+}
+
+const graph = {
+  nodes: {
+    PkgA: { name: 'PkgA', type: 'lib' as const, data: { root: 'PkgA' } },
+    PkgB: { name: 'PkgB', type: 'lib' as const, data: { root: 'PkgB' } },
+    PkgC: { name: 'PkgC', type: 'lib' as const, data: { root: 'PkgC' } },
+  },
+  externalNodes: {
+    'nuget:Serilog@4.0.0': externalNode(
+      'nuget:Serilog@4.0.0',
+      'Serilog',
+      '4.0.0'
+    ),
+    'nuget:Newtonsoft.Json@13.0.3': externalNode(
+      'nuget:Newtonsoft.Json@13.0.3',
+      'Newtonsoft.Json',
+      '13.0.3'
+    ),
+  },
+  dependencies: {},
+} as unknown as ProjectGraph;
+
+function fileChange(
+  file: string,
+  baseContent = 'before',
+  headContent = 'after'
+) {
+  return {
+    file,
+    getChanges: () => [new WholeFileChange()],
+    getContentAtBase: () => baseContent,
+    getContentAtHead: () => headContent,
+  };
+}
+
+function plugin(pattern: string, fn: jest.Mock, name = '@nx/dotnet'): unknown {
+  return { name, createTouchedDependencies: [pattern, fn] };
+}
+
+function run(changes: ReturnType<typeof fileChange>[]) {
+  return getTouchedDependencies(
+    changes,
+    graph.nodes,
+    {} as any,
+    undefined,
+    graph
+  );
+}
+
+describe('getTouchedDependencies', () => {
+  beforeEach(() => {
+    getPluginsMock.mockReset();
+  });
+
+  it('returns nothing when no plugin implements the hook', async () => {
+    const hook = jest.fn();
+    getPluginsMock.mockResolvedValue([
+      { name: '@nx/js' },
+      { name: '@nx/vite' },
+    ]);
+
+    expect(await run([fileChange('Directory.Packages.props')])).toEqual([]);
+    expect(hook).not.toHaveBeenCalled();
+  });
+
+  it('does not invoke the hook when no file matches the pattern', async () => {
+    // Matters for performance: invoking the hook can wake a plugin worker process.
+    const hook = jest.fn();
+    getPluginsMock.mockResolvedValue([
+      plugin('**/Directory.Packages.props', hook),
+    ]);
+
+    expect(await run([fileChange('src/Program.cs')])).toEqual([]);
+    expect(hook).not.toHaveBeenCalled();
+  });
+
+  it('maps returned package names onto external node names', async () => {
+    const hook = jest.fn().mockResolvedValue(['Serilog']);
+    getPluginsMock.mockResolvedValue([
+      plugin('**/Directory.Packages.props', hook),
+    ]);
+
+    expect(await run([fileChange('Directory.Packages.props')])).toEqual([
+      'nuget:Serilog@4.0.0',
+    ]);
+  });
+
+  it('accepts an exact external node name', async () => {
+    const hook = jest.fn().mockResolvedValue(['nuget:Serilog@4.0.0']);
+    getPluginsMock.mockResolvedValue([
+      plugin('**/Directory.Packages.props', hook),
+    ]);
+
+    expect(await run([fileChange('Directory.Packages.props')])).toEqual([
+      'nuget:Serilog@4.0.0',
+    ]);
+  });
+
+  it('passes only matching files, with both revisions', async () => {
+    const hook = jest.fn().mockResolvedValue([]);
+    getPluginsMock.mockResolvedValue([
+      plugin('**/Directory.Packages.props', hook),
+    ]);
+
+    await run([
+      fileChange('Directory.Packages.props', 'old', 'new'),
+      fileChange('src/Program.cs'),
+    ]);
+
+    expect(hook).toHaveBeenCalledWith(
+      [
+        {
+          file: 'Directory.Packages.props',
+          baseContent: 'old',
+          headContent: 'new',
+        },
+      ],
+      expect.objectContaining({ workspaceRoot: expect.any(String) })
+    );
+  });
+
+  it('marks every project affected when the plugin returns "*"', async () => {
+    const hook = jest.fn().mockResolvedValue('*');
+    getPluginsMock.mockResolvedValue([
+      plugin('**/Directory.Packages.props', hook),
+    ]);
+
+    expect(await run([fileChange('Directory.Packages.props')])).toEqual([
+      'PkgA',
+      'PkgB',
+      'PkgC',
+    ]);
+  });
+
+  it('marks every project affected when a dependency is not in the graph', async () => {
+    // We cannot tell who consumes an unknown package, so over-select rather than skip work.
+    const hook = jest.fn().mockResolvedValue(['Package.We.Do.Not.Know']);
+    getPluginsMock.mockResolvedValue([
+      plugin('**/Directory.Packages.props', hook),
+    ]);
+
+    expect(await run([fileChange('Directory.Packages.props')])).toEqual([
+      'PkgA',
+      'PkgB',
+      'PkgC',
+    ]);
+  });
+
+  it('still marks everything affected when projectGraphNodes is omitted', async () => {
+    // The locator contract makes projectGraphNodes optional; the conservative fallbacks
+    // must not collapse into an empty selection.
+    const hook = jest.fn().mockResolvedValue('*');
+    getPluginsMock.mockResolvedValue([
+      plugin('**/Directory.Packages.props', hook),
+    ]);
+
+    expect(
+      await getTouchedDependencies(
+        [fileChange('Directory.Packages.props')],
+        undefined,
+        {} as any,
+        undefined,
+        graph
+      )
+    ).toEqual(['PkgA', 'PkgB', 'PkgC']);
+  });
+
+  it('does not match identifiers against the object prototype chain', async () => {
+    // 'constructor' is a valid package id; without an own-property check the exact-name
+    // lookup would hit Object.prototype and emit a bogus node name.
+    const hook = jest.fn().mockResolvedValue(['constructor']);
+    getPluginsMock.mockResolvedValue([
+      plugin('**/Directory.Packages.props', hook),
+    ]);
+
+    expect(await run([fileChange('Directory.Packages.props')])).toEqual([
+      'PkgA',
+      'PkgB',
+      'PkgC',
+    ]);
+  });
+
+  it('marks every project affected when the plugin throws', async () => {
+    const hook = jest.fn().mockRejectedValue(new Error('malformed manifest'));
+    getPluginsMock.mockResolvedValue([
+      plugin('**/Directory.Packages.props', hook),
+    ]);
+
+    expect(await run([fileChange('Directory.Packages.props')])).toEqual([
+      'PkgA',
+      'PkgB',
+      'PkgC',
+    ]);
+  });
+
+  it('returns nothing when plugins cannot be loaded', async () => {
+    // Graph construction already reports plugin failures; this locator staying quiet lets the
+    // other locators still contribute their seeds.
+    getPluginsMock.mockRejectedValue(new Error('could not resolve plugin'));
+
+    expect(await run([fileChange('Directory.Packages.props')])).toEqual([]);
+  });
+
+  it('unions results across plugins and deduplicates', async () => {
+    getPluginsMock.mockResolvedValue([
+      plugin(
+        '**/Directory.Packages.props',
+        jest.fn().mockResolvedValue(['Serilog'])
+      ),
+      plugin(
+        '**/Directory.Packages.props',
+        jest.fn().mockResolvedValue(['Serilog', 'Newtonsoft.Json']),
+        '@acme/other'
+      ),
+    ]);
+
+    expect(
+      new Set(await run([fileChange('Directory.Packages.props')]))
+    ).toEqual(new Set(['nuget:Serilog@4.0.0', 'nuget:Newtonsoft.Json@13.0.3']));
+  });
+});

--- a/packages/nx/src/project-graph/affected/locators/touched-dependencies.ts
+++ b/packages/nx/src/project-graph/affected/locators/touched-dependencies.ts
@@ -1,0 +1,128 @@
+import { minimatch } from 'minimatch';
+import { TouchedProjectLocator } from '../affected-project-graph-models';
+import { FileChange } from '../../file-utils';
+import { ProjectGraphExternalNode } from '../../../config/project-graph';
+import { getPlugins } from '../../plugins/get-plugins';
+import { LoadedNxPlugin } from '../../plugins/loaded-nx-plugin';
+import { TouchedDependencyFile } from '../../plugins/public-api';
+import { output } from '../../../utils/output';
+import { workspaceRoot } from '../../../utils/workspace-root';
+import { readNxJson } from '../../../config/configuration';
+
+/**
+ * Lets a plugin attribute changes in a centralized dependency manifest (a lock file, a Central
+ * Package Management `Directory.Packages.props`, a version catalog) to the specific external
+ * dependencies that changed, so only the projects consuming them are marked affected.
+ *
+ * Returns external node names; the reverse-graph traversal in `filterAffected` walks from those
+ * back to the workspace projects that depend on them. Fallback paths return project names
+ * directly, following the same convention as `getTouchedNpmPackages`.
+ */
+export const getTouchedDependencies: TouchedProjectLocator = async (
+  fileChanges,
+  projectGraphNodes,
+  nxJson,
+  _packageJson,
+  projectGraph
+): Promise<string[]> => {
+  const nxJsonConfiguration = nxJson ?? readNxJson();
+
+  let plugins: LoadedNxPlugin[];
+  try {
+    plugins = (await getPlugins(nxJsonConfiguration)).filter(
+      (p) => p.createTouchedDependencies
+    );
+  } catch {
+    // Graph construction already surfaces plugin resolution failures.
+    return [];
+  }
+
+  if (!plugins.length) {
+    return [];
+  }
+
+  // Fall back to the graph's nodes so the mark-everything paths stay conservative even if a
+  // caller omits the optional projectGraphNodes argument.
+  const allProjectNames = Object.keys(
+    projectGraphNodes ?? projectGraph?.nodes ?? {}
+  );
+  const externalNodes = projectGraph?.externalNodes ?? {};
+  const touched = new Set<string>();
+
+  for (const plugin of plugins) {
+    const [manifestFilePattern, createTouchedDependencies] =
+      plugin.createTouchedDependencies;
+
+    const matchedFiles = fileChanges.filter((f) =>
+      minimatch(f.file, manifestFilePattern, { dot: true })
+    );
+    if (!matchedFiles.length) {
+      continue;
+    }
+
+    let result: Awaited<ReturnType<typeof createTouchedDependencies>>;
+    try {
+      result = await createTouchedDependencies(
+        matchedFiles.map(toTouchedDependencyFile),
+        { nxJsonConfiguration, workspaceRoot }
+      );
+    } catch (e) {
+      output.warn({
+        title: `"${plugin.name}" failed to determine which dependencies changed. All projects will be marked as affected.`,
+        bodyLines: [e instanceof Error ? e.message : String(e)],
+      });
+      return allProjectNames;
+    }
+
+    if (result === '*') {
+      return allProjectNames;
+    }
+
+    for (const identifier of result) {
+      const nodeNames = findExternalNodeNames(identifier, externalNodes);
+      if (!nodeNames.length) {
+        // An unknown dependency might be consumed anywhere. This also over-selects when a
+        // pinned-but-unreferenced package changes, but skipping those instead would turn any
+        // mismatch between plugin-constructed identifiers and node names into silently missed
+        // work — over-selecting is the recoverable side of that trade.
+        return allProjectNames;
+      }
+      for (const nodeName of nodeNames) {
+        touched.add(nodeName);
+      }
+    }
+  }
+
+  return Array.from(touched);
+};
+
+function toTouchedDependencyFile(change: FileChange): TouchedDependencyFile {
+  return {
+    file: change.file,
+    baseContent: change.getContentAtBase?.() ?? null,
+    headContent: change.getContentAtHead?.() ?? null,
+  };
+}
+
+/**
+ * Resolves a plugin-supplied identifier to external node names: exact node name first, then
+ * `data.packageName`, mirroring how `externalDependencies` inputs are resolved. A package-name
+ * match can return several nodes when the package is present at multiple versions.
+ */
+function findExternalNodeNames(
+  identifier: string,
+  externalNodes: Record<string, ProjectGraphExternalNode>
+): string[] {
+  // Own-property check: a package named e.g. `constructor` must not match the prototype chain.
+  if (Object.prototype.hasOwnProperty.call(externalNodes, identifier)) {
+    return [identifier];
+  }
+
+  const matches: string[] = [];
+  for (const [name, node] of Object.entries(externalNodes)) {
+    if (node.data?.packageName === identifier) {
+      matches.push(name);
+    }
+  }
+  return matches;
+}

--- a/packages/nx/src/project-graph/file-utils.spec.ts
+++ b/packages/nx/src/project-graph/file-utils.spec.ts
@@ -187,4 +187,65 @@ describe('calculateFileChanges', () => {
       );
     });
   });
+  describe('base and head content accessors', () => {
+    const readAtRevision = (path: string, revision: string | void) =>
+      revision ? `content at ${revision}` : 'working tree content';
+
+    it('should read base and head content when both revisions are provided', () => {
+      const changes = calculateFileChanges(
+        ['Directory.Packages.props'],
+        { base: 'sha1', head: 'sha2' },
+        readAtRevision
+      );
+
+      expect(changes[0].getContentAtBase()).toEqual('content at sha1');
+      expect(changes[0].getContentAtHead()).toEqual('content at sha2');
+    });
+
+    it('should return null base content when no base revision is provided', () => {
+      // Reading without a revision falls back to the working tree, which would make base and
+      // head contents identical and hide real changes from consumers that diff them.
+      const changes = calculateFileChanges(
+        ['Directory.Packages.props'],
+        {},
+        readAtRevision
+      );
+
+      expect(changes[0].getContentAtBase()).toBeNull();
+    });
+
+    it('should return null base content for files passed via --files', () => {
+      const changes = calculateFileChanges(
+        ['Directory.Packages.props'],
+        { base: 'sha1', head: 'sha2', files: ['Directory.Packages.props'] },
+        readAtRevision
+      );
+
+      expect(changes[0].getContentAtBase()).toBeNull();
+    });
+
+    it('should normalize whitespace the same way on both sides', () => {
+      // defaultReadFileAtRevision trims git show output but not working-tree reads; the
+      // accessors trim both so plugins comparing contents don't see phantom differences.
+      const changes = calculateFileChanges(
+        ['Directory.Packages.props'],
+        { base: 'sha1' },
+        (path, revision) => (revision ? 'same content' : 'same content\n')
+      );
+
+      expect(changes[0].getContentAtBase()).toEqual('same content');
+      expect(changes[0].getContentAtHead()).toEqual('same content');
+    });
+
+    it('should not expose the accessors without nxArgs', () => {
+      const changes = calculateFileChanges(
+        ['Directory.Packages.props'],
+        undefined,
+        readAtRevision
+      );
+
+      expect(changes[0].getContentAtBase).toBeUndefined();
+      expect(changes[0].getContentAtHead).toBeUndefined();
+    });
+  });
 });

--- a/packages/nx/src/project-graph/file-utils.ts
+++ b/packages/nx/src/project-graph/file-utils.ts
@@ -23,6 +23,17 @@ export interface Change {
 export interface FileChange<T extends Change = Change> {
   file: string;
   getChanges: () => T[];
+  /**
+   * Contents of the file at the comparison base, or null when there is no base revision to
+   * read from (including files passed via --files, which are marked changed without a
+   * revision comparison). Memoized. Undefined when the changes were not computed against a
+   * revision.
+   */
+  getContentAtBase?: () => string | null;
+  /**
+   * Contents of the file at the head revision, memoized. See {@link getContentAtBase}.
+   */
+  getContentAtHead?: () => string | null;
 }
 
 export class WholeFileChange implements Change {
@@ -78,8 +89,43 @@ export function calculateFileChanges(
     const ext = extname(f);
     const basename = f.split('/').pop() ?? f;
 
+    // Memoized per revision — each read shells out to `git show`.
+    const contentCache = new Map<string, string | null>();
+    const readAtRevision = (revision: string | undefined): string | null => {
+      const key = revision ?? '';
+      const cached = contentCache.get(key);
+      if (cached !== undefined) {
+        return cached;
+      }
+      let content: string | null;
+      try {
+        // Revision reads come back trimmed from defaultReadFileAtRevision while working-tree
+        // reads don't; trim here so both sides of a comparison are normalized the same way.
+        content = readFileAtRevision(f, revision).trim();
+      } catch {
+        content = null;
+      }
+      // The default reader swallows errors into '', so an empty string is ambiguous between a
+      // genuinely empty file and a failed read (e.g. the file not existing at that revision).
+      // Collapse both to null: diffing against '' would report removals as absent and let a
+      // consumer under-select, while null routes it to its conservative path.
+      content = content === '' ? null : content;
+      contentCache.set(key, content);
+      return content;
+    };
+
     return {
       file: f,
+      // Without a base revision the read would fall back to the working tree, making base and
+      // head contents identical. A consumer diffing them would see no changes and could skip
+      // work that needs to run, so return null and let it take its can't-attribute path.
+      getContentAtBase: nxArgs
+        ? () =>
+            nxArgs.base && !nxArgs.files?.includes(f)
+              ? readAtRevision(nxArgs.base)
+              : null
+        : undefined,
+      getContentAtHead: nxArgs ? () => readAtRevision(nxArgs.head) : undefined,
       getChanges: (): Change[] => {
         if (!existsSync(join(workspaceRoot, f))) {
           return [new DeletedFileChange()];

--- a/packages/nx/src/project-graph/plugins/isolation/isolated-plugin.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/isolated-plugin.ts
@@ -21,6 +21,9 @@ import { LoadedNxPlugin } from '../loaded-nx-plugin';
 import type {
   CreateDependenciesContext,
   CreateMetadataContext,
+  CreateTouchedDependenciesContext,
+  TouchedDependencies,
+  TouchedDependencyFile,
   CreateNodesContext,
   CreateNodesResult,
   PostTasksExecutionContext,
@@ -87,6 +90,13 @@ export class IsolatedPlugin implements LoadedNxPlugin {
     graph: ProjectGraph,
     context: CreateMetadataContext
   ) => Promise<ProjectsMetadata>;
+  readonly createTouchedDependencies?: [
+    manifestFilePattern: string,
+    fn: (
+      touchedFiles: TouchedDependencyFile[],
+      context: CreateTouchedDependenciesContext
+    ) => Promise<TouchedDependencies>,
+  ];
   readonly preTasksExecution?: (
     context: PreTasksExecutionContext
   ) => Promise<NodeJS.ProcessEnv>;
@@ -295,6 +305,7 @@ export class IsolatedPlugin implements LoadedNxPlugin {
       loadResult.createNodesPattern && 'createNodes',
       loadResult.hasCreateDependencies && 'createDependencies',
       loadResult.hasCreateMetadata && 'createMetadata',
+      !!loadResult.touchedDependenciesPattern && 'createTouchedDependencies',
       loadResult.hasPreTasksExecution && 'preTasksExecution',
       loadResult.hasPostTasksExecution && 'postTasksExecution'
     );
@@ -358,6 +369,26 @@ export class IsolatedPlugin implements LoadedNxPlugin {
         }
         return result.metadata;
       });
+    }
+
+    if (loadResult.touchedDependenciesPattern) {
+      (
+        this as {
+          createTouchedDependencies: IsolatedPlugin['createTouchedDependencies'];
+        }
+      ).createTouchedDependencies = [
+        loadResult.touchedDependenciesPattern,
+        wrap('createTouchedDependencies', async (touchedFiles, ctx) => {
+          const result = await this.sendRequest('createTouchedDependencies', {
+            touchedFiles,
+            context: ctx,
+          });
+          if (result.success === false) {
+            throw result.error;
+          }
+          return result.touchedDependencies;
+        }),
+      ];
     }
 
     if (loadResult.hasPreTasksExecution) {

--- a/packages/nx/src/project-graph/plugins/isolation/messaging.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/messaging.ts
@@ -8,6 +8,9 @@ import type { LoadedNxPlugin } from '../loaded-nx-plugin';
 import type {
   CreateDependenciesContext,
   CreateMetadataContext,
+  CreateTouchedDependenciesContext,
+  TouchedDependencies,
+  TouchedDependencyFile,
   CreateNodesContext,
   PostTasksExecutionContext,
   PreTasksExecutionContext,
@@ -50,6 +53,7 @@ type PluginMessageDefs = DefineMessages<{
           hasCreateDependencies: boolean;
           hasProcessProjectGraph: boolean;
           hasCreateMetadata: boolean;
+          touchedDependenciesPattern: string | null;
           hasPreTasksExecution: boolean;
           hasPostTasksExecution: boolean;
           success: true;
@@ -101,6 +105,22 @@ type PluginMessageDefs = DefineMessages<{
     result:
       | {
           metadata: Awaited<ReturnType<LoadedNxPlugin['createMetadata']>>;
+          success: true;
+        }
+      | {
+          success: false;
+          error: Error;
+        };
+  };
+
+  createTouchedDependencies: {
+    payload: {
+      touchedFiles: TouchedDependencyFile[];
+      context: CreateTouchedDependenciesContext;
+    };
+    result:
+      | {
+          touchedDependencies: TouchedDependencies;
           success: true;
         }
       | {
@@ -210,6 +230,7 @@ const MESSAGE_TYPES: ReadonlyArray<PluginWorkerMessage['type']> = [
   'createNodes',
   'createDependencies',
   'createMetadata',
+  'createTouchedDependencies',
   'preTasksExecution',
   'postTasksExecution',
   'setWorkerEnv',
@@ -220,6 +241,7 @@ const RESULT_TYPES: ReadonlyArray<PluginWorkerResult['type']> = [
   'createNodesResult',
   'createDependenciesResult',
   'createMetadataResult',
+  'createTouchedDependenciesResult',
   'preTasksExecutionResult',
   'postTasksExecutionResult',
   'setWorkerEnvResult',

--- a/packages/nx/src/project-graph/plugins/isolation/plugin-lifecycle-manager.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/plugin-lifecycle-manager.ts
@@ -5,6 +5,7 @@
  */
 const HOOKS_BY_PHASE = {
   graph: ['createNodes', 'createDependencies', 'createMetadata'],
+  affected: ['createTouchedDependencies'],
   'pre-task': ['preTasksExecution'],
   'post-task': ['postTasksExecution'],
 } as const;

--- a/packages/nx/src/project-graph/plugins/isolation/plugin-worker.ts
+++ b/packages/nx/src/project-graph/plugins/isolation/plugin-worker.ts
@@ -120,6 +120,8 @@ const server = createServer((socket) => {
                 'processProjectGraph' in plugin && !!plugin.processProjectGraph,
               hasCreateMetadata:
                 'createMetadata' in plugin && !!plugin.createMetadata,
+              touchedDependenciesPattern:
+                plugin.createTouchedDependencies?.[0] ?? null,
               hasPreTasksExecution:
                 'preTasksExecution' in plugin && !!plugin.preTasksExecution,
               hasPostTasksExecution:
@@ -142,6 +144,14 @@ const server = createServer((socket) => {
           withErrorHandling(async () => {
             const result = await plugin.createMetadata(graph, context);
             return { metadata: result, success: true as const };
+          }),
+        createTouchedDependencies: async ({ touchedFiles, context }) =>
+          withErrorHandling(async () => {
+            const result = await plugin.createTouchedDependencies[1](
+              touchedFiles,
+              context
+            );
+            return { touchedDependencies: result, success: true as const };
           }),
         preTasksExecution: async ({ context }) =>
           withErrorHandling(async () => {

--- a/packages/nx/src/project-graph/plugins/loaded-nx-plugin.ts
+++ b/packages/nx/src/project-graph/plugins/loaded-nx-plugin.ts
@@ -11,10 +11,13 @@ import type {
   CreateMetadataContext,
   CreateNodesContext,
   CreateNodesResult,
+  CreateTouchedDependenciesContext,
   NxPlugin,
   PostTasksExecutionContext,
   PreTasksExecutionContext,
   ProjectsMetadata,
+  TouchedDependencies,
+  TouchedDependencyFile,
 } from './public-api';
 import { isIsolationEnabled } from './isolation/enabled';
 import { isDaemonEnabled } from '../../daemon/client/client';
@@ -44,6 +47,13 @@ export class LoadedNxPlugin {
     graph: ProjectGraph,
     context: CreateMetadataContext
   ) => Promise<ProjectsMetadata>;
+  readonly createTouchedDependencies?: [
+    manifestFilePattern: string,
+    fn: (
+      touchedFiles: TouchedDependencyFile[],
+      context: CreateTouchedDependenciesContext
+    ) => Promise<TouchedDependencies>,
+  ];
   readonly preTasksExecution?: (
     context: PreTasksExecutionContext
   ) => Promise<NodeJS.ProcessEnv>;
@@ -149,6 +159,16 @@ export class LoadedNxPlugin {
     if (plugin.createMetadata) {
       this.createMetadata = async (graph, context) =>
         plugin.createMetadata(graph, this.options, context);
+    }
+
+    if (plugin.createTouchedDependencies) {
+      const [manifestFilePattern, createTouchedDependenciesFn] =
+        plugin.createTouchedDependencies;
+      this.createTouchedDependencies = [
+        manifestFilePattern,
+        async (touchedFiles, context) =>
+          createTouchedDependenciesFn(touchedFiles, this.options, context),
+      ];
     }
 
     if (plugin.preTasksExecution) {

--- a/packages/nx/src/project-graph/plugins/public-api.ts
+++ b/packages/nx/src/project-graph/plugins/public-api.ts
@@ -128,6 +128,68 @@ export type CreateMetadata<T = unknown> = (
 ) => ProjectsMetadata | Promise<ProjectsMetadata>;
 
 /**
+ * A file matched by {@link CreateTouchedDependencies}' file pattern, with the contents on both
+ * sides of the comparison so the plugin can diff it.
+ */
+export type TouchedDependencyFile = {
+  /**
+   * Path of the changed file, relative to the workspace root.
+   */
+  readonly file: string;
+
+  /**
+   * Contents at the comparison base, or null when there is no base revision to read
+   * (e.g. the file is newly added, or the comparison is against the working tree).
+   */
+  readonly baseContent: string | null;
+
+  /**
+   * Contents at the current revision, or null when the file was deleted.
+   */
+  readonly headContent: string | null;
+};
+
+export type CreateTouchedDependenciesContext = {
+  readonly nxJsonConfiguration: NxJsonConfiguration;
+  readonly workspaceRoot: string;
+};
+
+/**
+ * Identifiers of the external dependencies a change touched. Each entry is matched against
+ * external node names first and their `data.packageName` second, mirroring how
+ * `externalDependencies` inputs are resolved.
+ *
+ * Return `'*'` when the change cannot be attributed to specific dependencies (e.g. a malformed
+ * manifest or an unreadable base revision); every project will be marked affected.
+ */
+export type TouchedDependencies = string[] | '*';
+
+/**
+ * A function which determines which external dependencies a set of changed files touched, so
+ * that `nx affected` can select only the projects consuming them rather than every project
+ * sharing the manifest.
+ *
+ * The context deliberately excludes the project graph, which would otherwise be serialized
+ * across the plugin worker boundary on every invocation; Nx maps the returned identifiers
+ * onto external nodes itself.
+ */
+export type CreateTouchedDependenciesFunction<T = unknown> = (
+  touchedFiles: TouchedDependencyFile[],
+  options: T | undefined,
+  context: CreateTouchedDependenciesContext
+) => TouchedDependencies | Promise<TouchedDependencies>;
+
+/**
+ * A file pattern paired with the function that attributes changes to those files to specific
+ * external dependencies. The pattern is matched in the main process, so a plugin worker is
+ * only woken when a matching file changed.
+ */
+export type CreateTouchedDependencies<T = unknown> = readonly [
+  manifestFilePattern: string,
+  createTouchedDependenciesFunction: CreateTouchedDependenciesFunction<T>,
+];
+
+/**
  * A plugin which enhances the behavior of Nx
  */
 export type NxPlugin<TOptions = unknown> = {
@@ -156,6 +218,16 @@ export type NxPlugin<TOptions = unknown> = {
    * Provides a function to create metadata for the {@link ProjectGraph}
    */
   createMetadata?: CreateMetadata<TOptions>;
+
+  /**
+   * Provides a file pattern and a function that attributes changes to those files to specific
+   * external dependencies, so `nx affected` can select only the projects that consume them.
+   *
+   * Intended for centralized dependency manifests — a lock file, a Central Package Management
+   * `Directory.Packages.props`, a Gradle version catalog — where one file's version list is
+   * shared by many projects.
+   */
+  createTouchedDependencies?: CreateTouchedDependencies<TOptions>;
 
   /**
    * Provides a function to run before the Nx runs tasks


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
<!-- This is the behavior we have today -->

With Central Package Management, the dotnet plugin adds the whole `Directory.Packages.props` file as an input on every project's cacheable targets. Bumping a single package version invalidates the cache for every project, and `nx affected` selects everything under the manifest, including projects that don't reference the package at all.

## Expected Behavior
<!-- This is the behavior we should expect with the changes in this PR -->

Bumping a package version only affects the projects that actually reference that package.

To make that possible this adds a `createTouchedDependencies` hook to core. It's a `[filePattern, fn]` tuple like `createNodes`. When a matching file changes, `nx affected` hands the hook the file contents at the base and head revisions, and the hook returns which external dependencies changed (or `'*'` if it can't tell). A new locator maps those onto external nodes and the usual reverse traversal picks up the consuming projects. There's nothing dotnet-specific in core, and plugins that don't implement the hook behave exactly as before.

The dotnet plugin then uses the hook for CPM. The MSBuild analyzer already evaluates project files, so it joins PackageReference items with their PackageVersion entries (VersionOverride wins) and emits a `nuget:<Id>@<Version>` external node for each resolved package, with edges from the projects that reference it. Cacheable targets drop the whole-file input in favor of a per-package `externalDependencies` input, and the hook diffs the PackageVersion items between the two revisions.

Anything that can't be attributed cleanly falls back to the old behavior: malformed or deleted manifests, versions supplied through MSBuild properties, unreadable base revisions, or a version the analyzer can't resolve. In those cases rebuilding too much beats a stale cache hit.

Tested with unit tests on the core locator, the plugin, and the analyzer, plus an e2e suite: in a four-project CPM workspace, bumping a package referenced by one project rebuilds only that project, comment-only manifest edits select nothing, and a project with no package references is never invalidated by version bumps.

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

N/A