### PR TITLE
fix(vitest): discover named config files

### DIFF
--- a/packages/vitest/src/plugins/plugin-vitest.spec.ts
+++ b/packages/vitest/src/plugins/plugin-vitest.spec.ts
@@ -105,6 +105,12 @@ describe('@nx/vitest', () => {
   let createNodesFunction = createNodesV2[1];
   let context: CreateNodesContext;
 
+  it('should discover named Vite and Vitest config files', () => {
+    expect(createNodesV2[0]).toEqual(
+      '**/{vite,vitest}.?(*.)config.{js,ts,mjs,mts,cjs,cts}'
+    );
+  });
+
   describe('root project', () => {
     beforeEach(async () => {
       context = {

--- a/packages/vitest/src/plugins/plugin.ts
+++ b/packages/vitest/src/plugins/plugin.ts
@@ -85,7 +85,7 @@ export const createDependencies: CreateDependencies = () => {
   return [];
 };
 
-const vitestConfigGlob = '**/{vite,vitest}.config.{js,ts,mjs,mts,cjs,cts}';
+const vitestConfigGlob = '**/{vite,vitest}.?(*.)config.{js,ts,mjs,mts,cjs,cts}';
 
 export const createNodes: CreateNodes<VitestPluginOptions> = [
   vitestConfigGlob,


### PR DESCRIPTION
## Current Behavior

The `@nx/vitest` inferred plugin only discovers `vite.config.*` and `vitest.config.*` files. That misses valid Vitest 4 migration patterns where one Nx project has multiple named Vitest configs such as `vitest.unit.config.ts` and `vitest.integration.config.ts` for different test groups.

## Expected Behavior

Nx should discover named Vite/Vitest config files for the Vitest inferred plugin, so a workspace can expose separate targets/includes/excludes from the same Nx project without falling back to manual target wiring.

## Related Issue(s)

Fixes #36438

## This PR

Root cause: the discovery glob was restricted to the canonical `vite.config.*` / `vitest.config.*` filenames, so named config files were invisible before plugin target inference ran.

The fix is intentionally small:

- relax the Vitest config discovery glob to include named Vite/Vitest config files
- add a focused assertion covering the expanded glob behavior

## Validation

Local checks run:

- `git diff --check`
- `node` glob intent smoke check for `vitest.unit.config.ts`, `vitest.integration.config.mts`, and standard `vitest.config.ts`

Local full dependency install was blocked by disk space in this checkout:

- `pnpm install --frozen-lockfile` failed with `ERR_PNPM_ENOSPC`
- `NODE_OPTIONS=--max-old-space-size=4096 pnpm install --filter @nx/vitest --frozen-lockfile --ignore-scripts` also failed with `ERR_PNPM_ENOSPC`

CI evidence currently visible on the PR:

- `Socket Security: Project Report` passed
- `Socket Security: Pull Request Alerts` passed
- Netlify deploys are pending maintainer approval

## Risk / compatibility

This only broadens discovery to additional existing config-file names. Standard `vite.config.*` and `vitest.config.*` projects keep the same behavior; the main risk is surfacing additional Vitest targets that users intentionally named but Nx previously skipped.

cc @FrozenPandaz for the `@nx/vitest` inferred-plugin path.
