### PR TITLE
fix(core): quote args unless they parse as one shell word

### DIFF
--- a/packages/nx/jest.config.cts
+++ b/packages/nx/jest.config.cts
@@ -5,6 +5,8 @@ module.exports = {
   displayName: 'nx',
   preset: '../../jest.preset.js',
   resolver: './jest-resolver.js',
+  // unbash is ESM-only, so let swc transform it rather than ignoring it
+  transformIgnorePatterns: ['node_modules/(?!(\\.pnpm/)?unbash)'],
   // Ensure cargo insta snapshots do not get picked up by jest
   testPathIgnorePatterns: ['<rootDir>/src/native/tui'],
 };

--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -80,7 +80,7 @@
     "tmp": "catalog:",
     "tsconfig-paths": "catalog:typescript",
     "tslib": "catalog:typescript",
-    "unbash": "^4.0.3",
+    "unbash": "^4.0.4",
     "which": "catalog:",
     "yaml": "^2.8.3",
     "yargs": "catalog:",

--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -80,6 +80,7 @@
     "tmp": "catalog:",
     "tsconfig-paths": "catalog:typescript",
     "tslib": "catalog:typescript",
+    "unbash": "^4.0.3",
     "which": "catalog:",
     "yaml": "^2.8.3",
     "yargs": "catalog:",

--- a/packages/nx/src/utils/shell-quoting.spec.ts
+++ b/packages/nx/src/utils/shell-quoting.spec.ts
@@ -1,4 +1,4 @@
-import { needsShellQuoting } from './shell-quoting';
+import { isAlreadyQuoted, needsShellQuoting } from './shell-quoting';
 
 describe('needsShellQuoting', () => {
   it.each([
@@ -39,5 +39,35 @@ describe('needsShellQuoting', () => {
     ['empty string', ''],
   ])('returns false for %s: %j', (_, value) => {
     expect(needsShellQuoting(value)).toBe(false);
+  });
+});
+
+describe('isAlreadyQuoted', () => {
+  it.each([
+    ['double quoted value', '"@tag1|@tag2"'],
+    ['single quoted value', "'a&b'"],
+    ['double quoted with spaces', '"hello world"'],
+    ['double quoted variable', '"$HOME"'],
+    ['quoted JSON', '\'{"env":{"a":"b"}}\''],
+    ['single quotes inside double quotes', `"it's fine"`],
+  ])('returns true for %s: %j', (_, value) => {
+    expect(isAlreadyQuoted(value)).toBe(true);
+  });
+
+  it.each([
+    ['bare word', 'plain'],
+    ['unquoted metacharacters', 'a|b'],
+    ['empty string', ''],
+    ['a single quote character', '"'],
+    ['unterminated quote', '"abc'],
+    // Each of these starts and ends with a quote but is not one word.
+    ['two quoted words', '"a" "b"'],
+    ['quoted words around a bare word', '"a" b "c"'],
+    ['a command separated by &&', '"x" && echo hi ; echo "y"'],
+    ['a pipeline', '"a" | tee "b"'],
+    ['a redirect', '"a" > "out.txt"'],
+    ['an assignment prefix', 'FOO="a" "b"'],
+  ])('returns false for %s: %j', (_, value) => {
+    expect(isAlreadyQuoted(value)).toBe(false);
   });
 });

--- a/packages/nx/src/utils/shell-quoting.spec.ts
+++ b/packages/nx/src/utils/shell-quoting.spec.ts
@@ -60,6 +60,7 @@ describe('isAlreadyQuoted', () => {
     ['empty string', ''],
     ['a single quote character', '"'],
     ['unterminated quote', '"abc'],
+    ['unterminated command substitution', '"x"$(foo'],
     // Each of these starts and ends with a quote but is not one word.
     ['two quoted words', '"a" "b"'],
     ['quoted words around a bare word', '"a" b "c"'],

--- a/packages/nx/src/utils/shell-quoting.ts
+++ b/packages/nx/src/utils/shell-quoting.ts
@@ -1,3 +1,5 @@
+import { parse } from 'unbash';
+
 /**
  * Shell metacharacters that have special meaning and require quoting.
  *
@@ -30,12 +32,46 @@ export function needsShellQuoting(str: string): boolean {
 }
 
 /**
- * Check if a string is already wrapped in matching quotes (single or double).
+ * Check if a string is already a single, quoted shell word.
+ *
+ * A value is only safe to forward verbatim if the shell will read it as exactly
+ * one word of one command. Comparing the first and last character cannot
+ * establish that: `"a" "b"` is two words and `"x" && rm -rf / ; echo "y"` is
+ * three commands, yet both start and end with a quote.
  */
 export function isAlreadyQuoted(str: string): boolean {
+  if (str.length < 2) {
+    return false;
+  }
+
+  const script = parse(str);
+  if (script.errors?.length || script.commands.length !== 1) {
+    return false;
+  }
+
+  const statement = script.commands[0];
+  if (statement.type !== 'Statement' || statement.redirects?.length) {
+    return false;
+  }
+
+  const command = statement.command;
+  if (
+    command?.type !== 'Command' ||
+    command.prefix?.length ||
+    command.suffix?.length ||
+    command.redirects?.length
+  ) {
+    return false;
+  }
+
+  // The single word has to span the whole value, and it has to actually be
+  // quoted. A bare word such as `plain` is not "already quoted".
+  const word = command.name;
   return (
-    str.length >= 2 &&
-    ((str[0] === "'" && str[str.length - 1] === "'") ||
-      (str[0] === '"' && str[str.length - 1] === '"'))
+    word?.pos === 0 &&
+    word.end === str.length &&
+    !!word.parts?.some(
+      (part) => part.type === 'SingleQuoted' || part.type === 'DoubleQuoted'
+    )
   );
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3291,6 +3291,9 @@ importers:
       tslib:
         specifier: catalog:typescript
         version: 2.8.1
+      unbash:
+        specifier: ^4.0.3
+        version: 4.0.4
       which:
         specifier: 'catalog:'
         version: 3.0.1
@@ -25859,6 +25862,10 @@ packages:
 
   ultrahtml@1.7.0:
     resolution: {integrity: sha512-2xRd0VHoAQE4M+vF/DvFFB7pUV0ZxTW1TLi7lHQWnF/Sb5TPeEUV/l+hxcNnGO00ZXGnR0voCMmYRKQf+rvJ2g==}
+
+  unbash@4.0.4:
+    resolution: {integrity: sha512-60m9IVGbavD6jholbxt0jVBXZkEB/HsMZq7Tyaghseve2/Sf0zQRAIfWsD34sde+DKP2tBxJS2wP88ZM0D1FhA==}
+    engines: {node: '>=14'}
 
   unbox-primitive@1.1.0:
     resolution: {integrity: sha512-nWJ91DjeOkej/TA8pXQ3myruKpKEYgqvpw9lz4OPHj/NWFNluYrjbz9j01CJ8yKQd2g4jFoOkINCTW2I5LEEyw==}
@@ -56616,6 +56623,8 @@ snapshots:
   ultrahtml@1.6.0: {}
 
   ultrahtml@1.7.0: {}
+
+  unbash@4.0.4: {}
 
   unbox-primitive@1.1.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3292,7 +3292,7 @@ importers:
         specifier: catalog:typescript
         version: 2.8.1
       unbash:
-        specifier: ^4.0.3
+        specifier: ^4.0.4
         version: 4.0.4
       which:
         specifier: 'catalog:'


### PR DESCRIPTION
## Current Behavior

`isAlreadyQuoted` accepts any value with matching first and last quotes. Both argument forwarding in `run-commands` and task override serialization use it to skip quoting, and the result is concatenated into a shell command string.

A single forwarded argument can become two arguments:

```text
forwarded argument   --opt="a" "b"
Nx emits             --opt="a" "b"
child receives       ["--opt=a", "b"]
```

It can also execute additional commands:

```text
forwarded argument   --opt="x" && echo INJECTED ; echo "y"
Nx emits             --opt="x" && echo INJECTED ; echo "y"
child receives       ["--opt=x"]
extra shell output   INJECTED
                     y
```

## Expected Behavior

Parse quoted-looking values with [unbash](https://github.com/webpro-nl/unbash) and pass them through only when they occupy one command word, with no extra statements, arguments, assignments, or redirects.

Both examples now reach the child as a single argument, and neither extra `echo` command runs:

```text
Nx emits         --opt="\"a\" \"b\""
child receives   ["--opt=\"a\" \"b\""]

Nx emits         --opt="\"x\" && echo INJECTED ; echo \"y\""
child receives   ["--opt=\"x\" && echo INJECTED ; echo \"y\""]
```

Existing expansion behavior inside double quotes is preserved.

This adds `unbash@^4.0.11`, a synchronous Bash parser with no runtime dependencies. I maintain unbash.

Verification: all 165 tests across `shell-quoting`, `serialize-overrides-into-command-line`, and `run-commands` pass. Package type checking, formatting, lockfile lint, and `pnpm install --frozen-lockfile --ignore-scripts` pass. Oxlint passes with module-boundary checks skipped because the workspace graph is unavailable. The two examples above were also checked against master using Bash 5.3.20. `nx prepush` cannot construct the workspace graph locally because Java and .NET runtimes are unavailable.

## Related Issue(s)

Extends the argument quoting work in https://github.com/nrwl/nx/pull/34491.
