### PR TITLE
fix(js): resolve the verdaccio bin through its package.json

### DIFF
--- a/packages/js/src/executors/verdaccio/verdaccio.impl.ts
+++ b/packages/js/src/executors/verdaccio/verdaccio.impl.ts
@@ -3,7 +3,8 @@ import { signalToCode } from '@nx/devkit/internal';
 import { ChildProcess, execSync, fork } from 'child_process';
 import detectPort from 'detect-port';
 import { existsSync, rmSync } from 'node:fs';
-import { join, resolve } from 'path';
+import { readModulePackageJson } from 'nx/src/devkit-internals';
+import { dirname, join, resolve } from 'path';
 
 import { VerdaccioExecutorSchema } from './schema';
 import { major } from 'semver';
@@ -77,6 +78,17 @@ export async function verdaccioExecutor(
   };
 }
 
+function getVerdaccioBinPath(): string {
+  const { packageJson, path: packageJsonPath } =
+    readModulePackageJson('verdaccio');
+  const bin =
+    typeof packageJson.bin === 'string'
+      ? packageJson.bin
+      : packageJson.bin['verdaccio'];
+
+  return join(dirname(packageJsonPath), bin);
+}
+
 /**
  * Fork the verdaccio process: https://verdaccio.org/docs/verdaccio-programmatically/#using-fork-from-child_process-module
  */
@@ -86,7 +98,7 @@ function startVerdaccio(
 ) {
   return new Promise((resolve, reject) => {
     childProcess = fork(
-      require.resolve('verdaccio/bin/verdaccio'),
+      getVerdaccioBinPath(),
       createVerdaccioOptions(options, workspaceRoot),
       {
         env: {


### PR DESCRIPTION
## Current Behavior

`verdaccio@6.9.0` (published 2026-07-26) added an `exports` map that only exposes `.` and `./package.json`. The local-registry executor resolves the bin by subpath:

```ts
fork(require.resolve('verdaccio/bin/verdaccio'), ...)
```

That subpath is no longer exported, so the call throws:

```
Failed to start verdaccio: Error [ERR_PACKAGE_PATH_NOT_EXPORTED]:
Package subpath './bin/verdaccio' is not defined by "exports" in .../node_modules/verdaccio/package.json
```

`verdaccioVersion` is pinned as `^6.3.2`, so every workspace installing today floats onto 6.9.0 and the local registry fails to start. This breaks `@nx/js:setup-verdaccio` and the `nx release` / custom-registries e2e suites on master.

## Expected Behavior

The bin is resolved from the package.json `bin` field instead of the blocked subpath. `./package.json` *is* exported by 6.9.0, and earlier 6.x releases have no `exports` map at all, so this works across the whole supported range.

Pinning away from 6.9.0 was considered and rejected: the bin file still ships in 6.9.0, only subpath *resolution* changed, so fixing resolution is the root-cause fix.

Verified against a real `verdaccio@6.9.0` install:

```
OLD (subpath)   : FAIL -> ERR_PACKAGE_PATH_NOT_EXPORTED
NEW (pkg.json)  : OK   -> bin exists .../verdaccio/bin/verdaccio
```

A repo-wide sweep found no other blocked `verdaccio/*` subpath — the `require.resolve('verdaccio')` presence check is fine, since `"."` is exported.

## Related Issue(s)

None — upstream dependency drift, not a reported issue.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Land-oxfmt-support-in-nx-format-PR-35089---NXC-4691-6035561b)
<!-- polygraph-session-end -->