### PR TITLE
chore(repo): make review sandbox skills container-backend agnostic

### DIFF
--- a/.claude/skills/reproduce-issue/SKILL.md
+++ b/.claude/skills/reproduce-issue/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: reproduce-issue
 description: The single skill for reproducing an nx issue. Given a GitHub issue number (human entry) OR explicit repro parameters (agent entry), it runs the reproduction ENTIRELY inside an isolated Docker sandbox — gVisor on Linux, the Docker VM on macOS — so the untrusted repro's install scripts and commands never execute on the host, then reports whether it reproduces. Called by humans via "/reproduce-issue #N", "reproduce this bug", "does this reproduce", and by the reproduce-verifier agent (Level 2). Nothing lands on the host.
-allowed-tools: Read, Grep, Glob, Bash(uname *), Bash(gh issue view *), Bash(gh issue list *), Bash(docker run *), Bash(docker cp *), Bash(docker rm *), Bash(docker info *), Bash(docker pull *)
+allowed-tools: Read, Grep, Glob, Bash(uname *), Bash(limactl *), Bash(docker context *), Bash(gh issue view *), Bash(gh issue list *), Bash(docker run *), Bash(docker cp *), Bash(docker rm *), Bash(docker info *), Bash(docker pull *)
 ---
 
 # Reproduce an issue (sandboxed)
@@ -36,7 +36,7 @@ The caller passes these directly:
 Run `uname -s` once:
 
 - **Linux** → add `--runtime=runsc` to `docker run` (gVisor is the sandbox).
-- **macOS (`Darwin`)** → **omit `--runtime=runsc`** (the Docker VM is the sandbox). Verify `docker info` works; if not, tell the user to `colima start` (or start Docker Desktop / OrbStack).
+- **macOS (`Darwin`)** → **omit `--runtime=runsc`** (the container VM is the sandbox — Docker Desktop, Colima, Lima and OrbStack are all fine). Verify `docker info` works; if not, wake whichever backend is installed yourself rather than asking first — every wake command is a no-op when already running.
 
 The command below shows the Linux form — on macOS drop `--runtime=runsc`, keep the rest.
 
@@ -50,7 +50,7 @@ Before running anything, verify prerequisites in order and **stop at the first m
    docker info >/dev/null 2>&1 && echo up || echo MISSING
    ```
 
-   Miss → Linux: `sudo systemctl start docker`. macOS: `colima start` (or open Docker Desktop). Or run `setup-review-sandbox`.
+   Miss → Linux: `sudo systemctl start docker`. macOS: start the installed backend — `open -ga Docker` (Desktop/OrbStack), `colima start`, or `limactl start docker -y && docker context use lima-docker`. A merely-stopped VM is the usual cause; only if no backend is installed at all is this a real setup gap → run `setup-review-sandbox`.
 
 2. **Container networking works** (the check that would have caught the `veth` breakage):
 
@@ -67,7 +67,7 @@ Before running anything, verify prerequisites in order and **stop at the first m
      docker info --format '{{range $k,$v := .Runtimes}}{{$k}} {{end}}' | grep -q runsc && echo ok || echo MISSING
      ```
      Miss → run `setup-review-sandbox` (installs + registers `runsc`).
-   - **macOS** — the Docker VM (Colima / Docker Desktop) _is_ the sandbox; step 1 already covered it. No `runsc`.
+   - **macOS** — the Lima VM _is_ the sandbox; step 1 already covered it. No `runsc`.
 
 4. **(PR-build mode ONLY) the toolchain image exists:**
    ```bash

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: review-pr
 description: Deep code review of a single open PR in nrwl/nx. Checks out the PR inside an isolated sandbox container — gVisor on Linux, the Docker VM on macOS — never into the host working tree, runs the pr-review-toolkit review agents, the reproduce-verifier agent (grounds the review in the linked issues and executes the repro inside the sandbox), the alternative-approach agent (independently designs competing solutions and contrasts them with the PR's choice), the performance-analyzer agent (checks the changes don't waste CPU or memory and execute quickly at workspace scale), and the security-analyzer agent (hunts injection-class vulnerabilities — command injection, zip-slip, SSRF, credential leakage — across real trust boundaries), surfaces critical and important findings (plus strengths, a terse suggestions list, and explicit maintainer-call decisions), and saves a GitHub-flavored draft to ~/.nx-pr-reviews/<NUMBER>.md for the reviewer to read (nothing is posted). Claude runs on the host and reads/executes the PR code only through `docker exec` — untrusted PR code never runs on the host and Claude's credentials never enter the sandbox. Use when you want a thorough review of one PR.
-allowed-tools: Bash(gh pr view *), Bash(gh pr list *), Bash(gh pr diff *), Bash(gh issue view *), Bash(gh auth status*), Bash(uname *), Bash(docker run *), Bash(docker exec *), Bash(docker rm *), Bash(docker ps *), Bash(docker inspect *), Bash(docker info *), Bash(docker images *), Bash(git -C *), Bash(git rev-parse *), Bash(mkdir -p *), Bash(rm -f /tmp/pr-*), Bash(rm -f /tmp/repro-*), Bash(mv /tmp/*), Bash(xargs *), Bash(ls *), Bash(printf *), Bash(date *), Bash(cd *), Bash(test *), Bash(echo *), Bash(head *), Bash(tail *), Bash(cat *), Bash(jq *), Bash(grep *), Bash(wc *), Bash(sed *), Write(~/.nx-pr-reviews/**), Write(/tmp/**), Edit(~/.nx-pr-reviews/**), Edit(/tmp/**), Read, Grep, Glob, Skill, Agent
+allowed-tools: Bash(gh pr view *), Bash(gh pr list *), Bash(gh pr diff *), Bash(gh issue view *), Bash(gh auth status*), Bash(uname *), Bash(limactl *), Bash(docker context *), Bash(docker run *), Bash(docker exec *), Bash(docker rm *), Bash(docker ps *), Bash(docker inspect *), Bash(docker info *), Bash(docker images *), Bash(git -C *), Bash(git rev-parse *), Bash(mkdir -p *), Bash(rm -f /tmp/pr-*), Bash(rm -f /tmp/repro-*), Bash(mv /tmp/*), Bash(xargs *), Bash(ls *), Bash(printf *), Bash(date *), Bash(cd *), Bash(test *), Bash(echo *), Bash(head *), Bash(tail *), Bash(cat *), Bash(jq *), Bash(grep *), Bash(wc *), Bash(sed *), Write(~/.nx-pr-reviews/**), Write(/tmp/**), Edit(~/.nx-pr-reviews/**), Edit(/tmp/**), Read, Grep, Glob, Skill, Agent
 argument-hint: '<PR_NUMBER> [--verify-repros]'
 ---
 
@@ -44,6 +44,16 @@ mkdir -p "$TRIAGE_DIR"
 
 # Sandbox prerequisites (same checks as setup-review-sandbox)
 uname -s                                                              # Linux → runsc REQUIRED; Darwin → Docker VM is the sandbox
+
+# macOS: the daemon lives in a VM that is often merely stopped. Wake whichever backend is
+# installed before judging it missing — each of these is a no-op if it is already running.
+if [ "$(uname -s)" = Darwin ] && ! docker info >/dev/null 2>&1; then
+  if   command -v colima  >/dev/null 2>&1; then colima start
+  elif command -v limactl >/dev/null 2>&1; then limactl start docker -y && docker context use lima-docker
+  elif [ -d /Applications/Docker.app ];   then open -ga Docker && sleep 15
+  fi
+fi
+
 docker info >/dev/null 2>&1 && echo "docker OK" || echo "docker MISSING"
 docker info --format '{{range $k,$v := .Runtimes}}{{$k}} {{end}}' | grep -q runsc && echo "runsc OK" || echo "runsc ABSENT"
 test -n "$(docker images -q "$SANDBOX_IMAGE" 2>/dev/null)" && echo "image OK" || echo "image MISSING"
@@ -60,6 +70,16 @@ Use `docker images -q` (empty output ⇒ absent), **not** `docker image inspect`
 Never run `docker run` while `RUNTIME_FLAG` is still `UNSET`. This matters because an _unset_ variable expands to nothing, which is byte-identical to the correct macOS value — so a skipped or blocked `uname` would silently start the container under `runc` on Linux, running untrusted PR code with no gVisor and no error anywhere. The failure mode of this variable is "no isolation, reported as success", so it gets an explicit sentinel rather than a default.
 
 Fail fast with a clear message if: `gh` isn't authed; Docker is down; on Linux `runsc` is absent; or the image is missing. For the last three, point the user at the **`setup-review-sandbox`** skill (it installs Docker + gVisor + builds the image) — do not try to build it here.
+
+**On macOS, try to wake the VM before declaring Docker missing.** Any of Docker Desktop, Colima, Lima, or OrbStack is fine here — they all present the same `docker` CLI and the same VM isolation boundary, so the skill never needs to care which one it is. A stopped VM and an absent runtime look identical from `docker info` alone, and only the latter is a real setup failure:
+
+| Symptom                                          | Cause               | Fix                                                           |
+| ------------------------------------------------ | ------------------- | ------------------------------------------------------------- |
+| the backend's own status command reports stopped | VM merely stopped   | the wake block above                                          |
+| VM running but `docker info` still fails         | wrong/stale context | `docker context ls`, then `docker context use <the live one>` |
+| no backend installed at all                      | never set up        | run `setup-review-sandbox`                                    |
+
+Two traps worth knowing when the probe result looks self-contradictory. First, if Docker Desktop was ever installed and removed, it leaves `/usr/local/bin/docker` and `/var/run/docker.sock` as **dangling symlinks** into a deleted `/Applications/Docker.app` — `ls -l` shows both (reads as "installed") while `which docker` reports not-found, since zsh will not resolve a broken link; that contradiction is the tell, and the live CLI is whichever one actually precedes `/usr/local/bin` on `PATH`. Second, a removed Desktop also leaves `"credsStore": "desktop"` and `"currentContext": "desktop-linux"` in `~/.docker/config.json`, both naming deleted binaries; delete those keys, because the errors they raise never mention the VM backend.
 
 (If `docker images -q` still comes back empty right after the daemon wakes, give it a few seconds and re-probe once before concluding the image is gone — the daemon can lag briefly on wake. Only treat a persistently empty result as truly MISSING.)
 

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -7,7 +7,7 @@ description: >-
   A reproduce-verifier executes a runnable repro only when verification identifies one. The skill
   saves a GitHub-flavored draft to ~/.nx-pr-reviews/<NUMBER>.md and never posts it. Claude
   reads/executes PR code only through `docker exec`; credentials never enter the sandbox.
-allowed-tools: Bash(gh pr view *), Bash(gh pr list *), Bash(gh pr diff *), Bash(gh issue view *), Bash(gh auth status*), Bash(polygraph whoami *), Bash(polygraph session search *), Bash(polygraph session show *), Bash(uname *), Bash(docker run *), Bash(docker exec *), Bash(docker rm *), Bash(docker ps *), Bash(docker inspect *), Bash(docker info *), Bash(docker images *), Bash(docker build *), Bash(bash tools/review-sandbox/*), Bash(git -C *), Bash(git rev-parse *), Bash(mkdir -p *), Bash(rm -f /tmp/pr-*), Bash(rm -f /tmp/repro-*), Bash(mv /tmp/*), Bash(xargs *), Bash(ls *), Bash(printf *), Bash(date *), Bash(cd *), Bash(test *), Bash(echo *), Bash(head *), Bash(tail *), Bash(cat *), Bash(jq *), Bash(grep *), Bash(wc *), Bash(sed *), Write(~/.nx-pr-reviews/**), Write(/tmp/**), Edit(~/.nx-pr-reviews/**), Edit(/tmp/**), mcp__plugin_linear_linear__get_issue, mcp__plugin_linear_linear__list_comments, Read, Grep, Glob, Skill, Agent
+allowed-tools: Bash(gh pr view *), Bash(gh pr list *), Bash(gh pr diff *), Bash(gh issue view *), Bash(gh auth status*), Bash(polygraph whoami *), Bash(polygraph session search *), Bash(polygraph session show *), Bash(uname *), Bash(limactl *), Bash(docker context *), Bash(docker run *), Bash(docker exec *), Bash(docker rm *), Bash(docker ps *), Bash(docker inspect *), Bash(docker info *), Bash(docker images *), Bash(docker build *), Bash(bash tools/review-sandbox/*), Bash(git -C *), Bash(git rev-parse *), Bash(mkdir -p *), Bash(rm -f /tmp/pr-*), Bash(rm -f /tmp/repro-*), Bash(mv /tmp/*), Bash(xargs *), Bash(ls *), Bash(printf *), Bash(date *), Bash(cd *), Bash(test *), Bash(echo *), Bash(head *), Bash(tail *), Bash(cat *), Bash(jq *), Bash(grep *), Bash(wc *), Bash(sed *), Write(~/.nx-pr-reviews/**), Write(/tmp/**), Edit(~/.nx-pr-reviews/**), Edit(/tmp/**), mcp__plugin_linear_linear__get_issue, mcp__plugin_linear_linear__list_comments, Read, Grep, Glob, Skill, Agent
 argument-hint: '<PR_NUMBER> [--verify-repros]'
 ---
 
@@ -50,6 +50,16 @@ mkdir -p "$TRIAGE_DIR"
 
 # Sandbox prerequisites (same checks as setup-review-sandbox)
 uname -s                                                              # Linux → runsc REQUIRED; Darwin → Docker VM is the sandbox
+
+# macOS: the daemon lives in a VM that is often merely stopped. Wake whichever backend is
+# installed before judging it missing — each of these is a no-op if it is already running.
+if [ "$(uname -s)" = Darwin ] && ! docker info >/dev/null 2>&1; then
+  if   command -v colima  >/dev/null 2>&1; then colima start
+  elif command -v limactl >/dev/null 2>&1; then limactl start docker -y && docker context use lima-docker
+  elif [ -d /Applications/Docker.app ];   then open -ga Docker && sleep 15
+  fi
+fi
+
 docker info >/dev/null 2>&1 && echo "docker OK" || echo "docker MISSING"
 docker info --format '{{range $k,$v := .Runtimes}}{{$k}} {{end}}' | grep -q runsc && echo "runsc OK" || echo "runsc ABSENT"
 
@@ -81,6 +91,16 @@ Never run `docker run` while `RUNTIME_FLAG` is still `UNSET`. This matters becau
 Fail fast with a clear message if: `gh` isn't authed; Docker is down; on Linux `runsc` is absent; or the image build fails. For the last three, point the user at the **`setup-review-sandbox`** skill — it installs Docker + gVisor, which the build above deliberately does not.
 
 The build prints one line on the fast path (`sandbox image up to date`), so a slow first run after a lockfile change is expected and self-explanatory rather than a mystery.
+
+**On macOS, try to wake the VM before declaring Docker missing.** Any of Docker Desktop, Colima, Lima, or OrbStack is fine here — they all present the same `docker` CLI and the same VM isolation boundary, so the skill never needs to care which one it is. A stopped VM and an absent runtime look identical from `docker info` alone, and only the latter is a real setup failure:
+
+| Symptom                                          | Cause               | Fix                                                           |
+| ------------------------------------------------ | ------------------- | ------------------------------------------------------------- |
+| the backend's own status command reports stopped | VM merely stopped   | the wake block above                                          |
+| VM running but `docker info` still fails         | wrong/stale context | `docker context ls`, then `docker context use <the live one>` |
+| no backend installed at all                      | never set up        | run `setup-review-sandbox`                                    |
+
+Two traps worth knowing when the probe result looks self-contradictory. First, if Docker Desktop was ever installed and removed, it leaves `/usr/local/bin/docker` and `/var/run/docker.sock` as **dangling symlinks** into a deleted `/Applications/Docker.app` — `ls -l` shows both (reads as "installed") while `which docker` reports not-found, since zsh will not resolve a broken link; that contradiction is the tell, and the live CLI is whichever one actually precedes `/usr/local/bin` on `PATH`. Second, a removed Desktop also leaves `"credsStore": "desktop"` and `"currentContext": "desktop-linux"` in `~/.docker/config.json`, both naming deleted binaries; delete those keys, because the errors they raise never mention the VM backend.
 
 ## Step 2: Fetch the PR metadata
 

--- a/.claude/skills/setup-review-sandbox/SKILL.md
+++ b/.claude/skills/setup-review-sandbox/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: setup-review-sandbox
-description: One-time setup of the sandbox prerequisites used by the reproduce-issue skill and the reproduce-verifier agent — Docker, the isolation runtime (gVisor on Linux / Colima on macOS), healthy container networking, and the nx-review-sandbox toolchain image (built from the repo's mise.toml). Idempotent; re-run any time to verify or repair. Use when the user says "set up the review sandbox", "install the sandbox prereqs", "build the sandbox image", or a reproduce-issue preflight reports something MISSING.
-allowed-tools: Read, Grep, Glob, Bash(uname *), Bash(docker info *), Bash(docker run *), Bash(docker build *), Bash(docker image inspect *), Bash(docker images *), Bash(command -v *), Bash(lsmod *)
+description: One-time setup of the sandbox prerequisites used by the reproduce-issue skill and the reproduce-verifier agent — Docker, the isolation runtime (gVisor on Linux / a container VM — Docker Desktop, Colima, Lima or OrbStack — on macOS), healthy container networking, and the nx-review-sandbox toolchain image (built from the repo's mise.toml). Idempotent; re-run any time to verify or repair. Use when the user says "set up the review sandbox", "install the sandbox prereqs", "build the sandbox image", or a reproduce-issue preflight reports something MISSING.
+allowed-tools: Read, Grep, Glob, Bash(uname *), Bash(limactl *), Bash(docker context *), Bash(docker info *), Bash(docker run *), Bash(docker build *), Bash(docker image inspect *), Bash(docker images *), Bash(command -v *), Bash(lsmod *)
 ---
 
 # Set up the review sandbox (one-time)
@@ -17,7 +17,32 @@ docker info >/dev/null 2>&1 && echo "docker OK" || echo "docker MISSING"
 ```
 
 - **MISSING, Linux:** install Docker Engine, then `sudo systemctl enable --now docker` and add yourself to the `docker` group (`sudo usermod -aG docker $USER`, then re-login).
-- **MISSING, macOS:** `brew install colima docker` then `colima start` (or install Docker Desktop).
+- **MISSING, macOS:** any VM backend works — Docker Desktop, Colima, Lima, and OrbStack all expose the same `docker` CLI and the same VM isolation boundary, so nothing else in these skills has to know which is in use. **Check what is already installed before installing anything** (`command -v colima limactl`, `ls -d /Applications/Docker.app /Applications/OrbStack.app`); if a backend is present it usually just needs starting, not replacing.
+
+  | Backend                   | Start it                                                                  |
+  | ------------------------- | ------------------------------------------------------------------------- |
+  | Docker Desktop / OrbStack | launch the app (`open -ga Docker`)                                        |
+  | Colima                    | `colima start`                                                            |
+  | Lima                      | `limactl start docker -y` (see recipe below if the VM does not exist yet) |
+
+  Only if none is installed, pick one — e.g. Colima (`brew install colima docker && colima start`) or Lima:
+
+  ```bash
+  brew install lima docker docker-buildx        # lima = VM; docker = CLI only; buildx = `docker build`
+  limactl start template://docker --name docker --cpus 6 --memory 12 --disk 100 -y
+  docker context create lima-docker --docker "host=unix://$HOME/.lima/docker/sock/docker.sock"
+  docker context use lima-docker
+  ```
+
+  Two notes that apply to the CLI-only backends (Colima/Lima), which Docker Desktop handles for you:
+  - **Size the VM above what the containers ask for.** `review-pr` runs them with `--memory 6g --cpus 4`, so a default 4 GiB VM cannot honour the limit. With Lima, `-y` (alias of `--tty=false`) is required for non-interactive use — without it `limactl` opens an editor and hangs.
+  - **Register Homebrew's `docker-buildx`**, which is not auto-discovered, or `docker build` in step 4 fails with `'buildx' is not a docker command`:
+
+    ```bash
+    node -e 'const f=require("fs"),p=process.env.HOME+"/.docker/config.json";const c=f.existsSync(p)?JSON.parse(f.readFileSync(p,"utf8")||"{}"):{};c.cliPluginsExtraDirs=[...new Set([...(c.cliPluginsExtraDirs||[]),"/opt/homebrew/lib/docker/cli-plugins"])];f.writeFileSync(p,JSON.stringify(c,null,2))'
+    ```
+
+  If Docker Desktop was previously installed and removed, it leaves `"credsStore": "desktop"` and `"currentContext": "desktop-linux"` in `~/.docker/config.json` plus dangling `/usr/local/bin/docker` and `/var/run/docker.sock` symlinks. Delete those two config keys — otherwise every `docker` call fails with a credential-helper or missing-context error that never mentions the backend you actually installed.
 
 ## 2. Isolation runtime
 
@@ -40,12 +65,20 @@ sudo systemctl restart docker
 
 Then re-check the runtime line above.
 
-### macOS — the Docker VM is the sandbox
+### macOS — the container VM is the sandbox
 
-No `runsc`. Just confirm the VM is up:
+No `runsc`; whichever VM backend you run is what isolates untrusted code, so `RUNTIME_FLAG` stays empty. Confirm the VM is up:
 
 ```bash
-docker info >/dev/null 2>&1 && echo "docker VM OK" || echo "start it: colima start"
+docker info >/dev/null 2>&1 && echo "docker VM OK" || echo "start it (see step 1 for your backend)"
+```
+
+The backend's own status command is the ground truth when that fails (`colima status`, `limactl list`, or the Docker Desktop/OrbStack menu bar item) — stopped means wake it, absent means create it with the step-1 recipe.
+
+If `docker info` reports `name=rootless` (Lima's `docker` template, Colima with `--rootless`), that is strictly _more_ isolation than a rootful daemon, not less. cgroup v2 delegation still honours the `--memory` / `--cpus` / `--pids-limit` caps `review-pr` sets, which is worth confirming once since a silently-ignored cap would let a runaway PR build starve the host:
+
+```bash
+docker run --rm --memory 6g alpine cat /sys/fs/cgroup/memory.max   # expect 6442450944
 ```
 
 ## 3. Container networking (catches the `veth` class of breakage)

--- a/.claude/skills/setup-review-sandbox/SKILL.md
+++ b/.claude/skills/setup-review-sandbox/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: setup-review-sandbox
-description: One-time setup of the sandbox prerequisites used by the reproduce-issue skill and the reproduce-verifier agent — Docker, the isolation runtime (gVisor on Linux / Colima on macOS), healthy container networking, and the nx-review-sandbox toolchain image (built from the repo's mise.toml). Idempotent; re-run any time to verify or repair. Use when the user says "set up the review sandbox", "install the sandbox prereqs", "build the sandbox image", or a reproduce-issue preflight reports something MISSING.
-allowed-tools: Read, Grep, Glob, Bash(uname *), Bash(docker info *), Bash(docker run *), Bash(docker build *), Bash(docker image inspect *), Bash(docker images *), Bash(command -v *), Bash(lsmod *), Bash(bash tools/review-sandbox/*)
+description: One-time setup of the sandbox prerequisites used by the reproduce-issue skill and the reproduce-verifier agent — Docker, the isolation runtime (gVisor on Linux / a container VM — Docker Desktop, Colima, Lima or OrbStack — on macOS), healthy container networking, and the nx-review-sandbox toolchain image (built from the repo's mise.toml). Idempotent; re-run any time to verify or repair. Use when the user says "set up the review sandbox", "install the sandbox prereqs", "build the sandbox image", or a reproduce-issue preflight reports something MISSING.
+allowed-tools: Read, Grep, Glob, Bash(uname *), Bash(limactl *), Bash(docker context *), Bash(docker info *), Bash(docker run *), Bash(docker build *), Bash(docker image inspect *), Bash(docker images *), Bash(command -v *), Bash(lsmod *), Bash(bash tools/review-sandbox/*)
 ---
 
 # Set up the review sandbox (one-time)
@@ -17,7 +17,32 @@ docker info >/dev/null 2>&1 && echo "docker OK" || echo "docker MISSING"
 ```
 
 - **MISSING, Linux:** install Docker Engine, then `sudo systemctl enable --now docker` and add yourself to the `docker` group (`sudo usermod -aG docker $USER`, then re-login).
-- **MISSING, macOS:** `brew install colima docker` then `colima start` (or install Docker Desktop).
+- **MISSING, macOS:** any VM backend works — Docker Desktop, Colima, Lima, and OrbStack all expose the same `docker` CLI and the same VM isolation boundary, so nothing else in these skills has to know which is in use. **Check what is already installed before installing anything** (`command -v colima limactl`, `ls -d /Applications/Docker.app /Applications/OrbStack.app`); if a backend is present it usually just needs starting, not replacing.
+
+  | Backend                   | Start it                                                                  |
+  | ------------------------- | ------------------------------------------------------------------------- |
+  | Docker Desktop / OrbStack | launch the app (`open -ga Docker`)                                        |
+  | Colima                    | `colima start`                                                            |
+  | Lima                      | `limactl start docker -y` (see recipe below if the VM does not exist yet) |
+
+  Only if none is installed, pick one — e.g. Colima (`brew install colima docker && colima start`) or Lima:
+
+  ```bash
+  brew install lima docker docker-buildx        # lima = VM; docker = CLI only; buildx = `docker build`
+  limactl start template://docker --name docker --cpus 6 --memory 12 --disk 100 -y
+  docker context create lima-docker --docker "host=unix://$HOME/.lima/docker/sock/docker.sock"
+  docker context use lima-docker
+  ```
+
+  Two notes that apply to the CLI-only backends (Colima/Lima), which Docker Desktop handles for you:
+  - **Size the VM above what the containers ask for.** `review-pr` runs them with `--memory 6g --cpus 4`, so a default 4 GiB VM cannot honour the limit. With Lima, `-y` (alias of `--tty=false`) is required for non-interactive use — without it `limactl` opens an editor and hangs.
+  - **Register Homebrew's `docker-buildx`**, which is not auto-discovered, or `docker build` in step 4 fails with `'buildx' is not a docker command`:
+
+    ```bash
+    node -e 'const f=require("fs"),p=process.env.HOME+"/.docker/config.json";const c=f.existsSync(p)?JSON.parse(f.readFileSync(p,"utf8")||"{}"):{};c.cliPluginsExtraDirs=[...new Set([...(c.cliPluginsExtraDirs||[]),"/opt/homebrew/lib/docker/cli-plugins"])];f.writeFileSync(p,JSON.stringify(c,null,2))'
+    ```
+
+  If Docker Desktop was previously installed and removed, it leaves `"credsStore": "desktop"` and `"currentContext": "desktop-linux"` in `~/.docker/config.json` plus dangling `/usr/local/bin/docker` and `/var/run/docker.sock` symlinks. Delete those two config keys — otherwise every `docker` call fails with a credential-helper or missing-context error that never mentions the backend you actually installed.
 
 ## 2. Isolation runtime
 
@@ -40,12 +65,20 @@ sudo systemctl restart docker
 
 Then re-check the runtime line above.
 
-### macOS — the Docker VM is the sandbox
+### macOS — the container VM is the sandbox
 
-No `runsc`. Just confirm the VM is up:
+No `runsc`; whichever VM backend you run is what isolates untrusted code, so `RUNTIME_FLAG` stays empty. Confirm the VM is up:
 
 ```bash
-docker info >/dev/null 2>&1 && echo "docker VM OK" || echo "start it: colima start"
+docker info >/dev/null 2>&1 && echo "docker VM OK" || echo "start it (see step 1 for your backend)"
+```
+
+The backend's own status command is the ground truth when that fails (`colima status`, `limactl list`, or the Docker Desktop/OrbStack menu bar item) — stopped means wake it, absent means create it with the step-1 recipe.
+
+If `docker info` reports `name=rootless` (Lima's `docker` template, Colima with `--rootless`), that is strictly _more_ isolation than a rootful daemon, not less. cgroup v2 delegation still honours the `--memory` / `--cpus` / `--pids-limit` caps `review-pr` sets, which is worth confirming once since a silently-ignored cap would let a runaway PR build starve the host:
+
+```bash
+docker run --rm --memory 6g alpine cat /sys/fs/cgroup/memory.max   # expect 6442450944
 ```
 
 ## 3. Container networking (catches the `veth` class of breakage)


### PR DESCRIPTION
## Current Behavior

The Claude sandbox skills (`review-pr`, `setup-review-sandbox`, `reproduce-issue`) assumed a specific macOS container backend. `setup-review-sandbox` recommended Colima outright, and the other two told the user to run `colima start` (or open Docker Desktop) when `docker info` failed.

Because these skills run untrusted PR code inside a container, they fail closed when the backend probe fails — which is correct. The problem is that a **stopped** VM and an **absent** runtime are indistinguishable from `docker info` alone, so a machine with a perfectly good backend already installed reported "docker MISSING" and stopped, when the right move was simply to start the VM.

## Expected Behavior

The skills no longer care which backend is in use. Docker Desktop, Colima, Lima and OrbStack all expose the same `docker` CLI and the same VM isolation boundary, so nothing downstream needs to know the difference — every `docker exec` in these skills stays literal.

- **`setup-review-sandbox`** checks what is already installed *before* installing anything, and documents all four backends as equally valid. Adds the Lima recipe, the Homebrew `docker-buildx` plugin registration that `docker build` needs, and a rootless cgroup-delegation check.
- **`review-pr`** wakes whichever backend is installed during pre-flight instead of reporting it missing, plus a short table separating a stopped VM from a stale `docker context` from a genuinely absent runtime. Every wake command is a no-op when the backend is already running, so it is safe to attempt unconditionally.
- **`reproduce-issue`** gets the same wake guidance in its preflight.
- `limactl` and `docker context` are added to all three `allowed-tools` lists.

Two footguns are also documented, because together they make an absent runtime look installed-but-broken: a removed Docker Desktop leaves dangling `/usr/local/bin/docker` and `/var/run/docker.sock` symlinks (so `ls -l` shows them while `which docker` reports not-found), and leaves `credsStore: desktop` / `currentContext: desktop-linux` in `~/.docker/config.json`, both naming deleted binaries.

The rootless cap check earns its place: a silently-ignored `--memory` limit would let a runaway PR build starve the host while the skill believes the container is bounded.

Docs-only change to `.claude/skills/**` — no runtime or package code is touched.

## Related Issue(s)

None — this came out of running `/review-pr` on a machine whose backend was installed but not detected.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Container-backend-agnostic-Claude-sandbox-skills-35183cd2)
<!-- polygraph-session-end -->