### PR TITLE
feat(js): support nx.sync.ignoredProjects in typescript-sync

### DIFF
--- a/astro-docs/src/content/docs/kb/typescript-project-linking.mdoc
+++ b/astro-docs/src/content/docs/kb/typescript-project-linking.mdoc
@@ -231,6 +231,75 @@ The project's `tsconfig.spec.json` does not need to reference project dependenci
 }
 ```
 
+### Control what nx sync writes
+
+`nx sync` derives references from the project graph, so most workspaces never configure it. When the graph isn't the whole story, use one of four options to override it.
+
+#### Keep a project out of the root solution
+
+Some projects live inside the repository but outside its TypeScript build. A nested standalone workspace with its own lockfile and its own install is one example. Referencing it from the root `tsconfig.json` makes `tsc --build` walk into it. List it under `nx.sync.ignoredProjects` in the root `tsconfig.json` and sync leaves it alone:
+
+```jsonc title="tsconfig.json"
+{
+  "extends": "./tsconfig.base.json",
+  "files": [], // intentionally empty
+  "nx": {
+    "sync": {
+      "ignoredProjects": ["directory:examples/**"],
+    },
+  },
+  "references": [
+    // UPDATED BY NX SYNC
+    // All projects in the repository, except the ignored ones
+  ],
+}
+```
+
+Entries accept the same patterns as `targetDefaults` and `nx affected`: project names, name globs, `tag:foo`, and `directory:` patterns. Directory patterns match project roots as globs rather than prefixes, so `directory:examples/**` matches `examples/react/basic` and `directory:examples` doesn't.
+
+Sync also prunes an existing root reference to an ignored project, so you can add the option to a workspace that already has the reference and let sync clean it up.
+
+This option only governs the root `tsconfig.json`. A project that depends on an ignored project still references it from its own tsconfig, and imports keep type-checking.
+
+#### Adjust references on an individual project
+
+Two options apply to any project tsconfig, both under the same `nx.sync` key:
+
+- `ignoredReferences` keeps a reference you wrote by hand. Sync would otherwise prune anything it can't derive from the graph.
+- `ignoredDependencies` suppresses the reference for a named dependency. Reach for it when the project graph contains a deliberate cycle. TypeScript rejects circular project references with `TS6202`, and dropping the edge from the graph instead would hide a real dependency from every other tool.
+
+```jsonc title="packages/cart/tsconfig.json"
+{
+  "extends": "../../tsconfig.base.json",
+  "files": [], // intentionally empty
+  "nx": {
+    "sync": {
+      "ignoredReferences": ["../../some/manual/tsconfig.json"],
+      "ignoredDependencies": ["utils"],
+    },
+  },
+  "references": [
+    // UPDATED BY NX SYNC
+  ],
+}
+```
+
+#### Recognize a custom runtime tsconfig name
+
+Sync looks for runtime tsconfigs named `tsconfig.app.json`, `tsconfig.lib.json`, `tsconfig.build.json`, `tsconfig.cjs.json`, `tsconfig.esm.json`, or `tsconfig.runtime.json`. If your projects use a different name, set `runtimeTsConfigFileNames` in `nx.json`. The list replaces the defaults rather than extending them.
+
+```jsonc title="nx.json"
+{
+  "sync": {
+    "generatorOptions": {
+      "@nx/js:typescript-sync": {
+        "runtimeTsConfigFileNames": ["tsconfig.custom.json"],
+      },
+    },
+  },
+}
+```
+
 ### TypeScript project references performance benefits
 
 {% youtube src="https://youtu.be/O2xBQJMTs9E" title="Why TypeScript Project References Make Your CI Faster!" /%}

--- a/packages/js/src/generators/typescript-sync/typescript-sync.spec.ts
+++ b/packages/js/src/generators/typescript-sync/typescript-sync.spec.ts
@@ -225,6 +225,27 @@ describe('syncGenerator()', () => {
       `);
     });
 
+    it('should not report a non-composite project as a missing reference', async () => {
+      addProject('not-composite', [], [], 'packages/not-composite');
+      writeJson(tree, 'packages/not-composite/tsconfig.json', {
+        compilerOptions: {},
+      });
+
+      const result = await syncGenerator(tree);
+
+      // It is dropped before writing, so it must never be named as a reason
+      // the workspace is out of sync.
+      expect((result as any).outOfSyncDetails).toStrictEqual([
+        'tsconfig.json:',
+        '  - Missing references: packages/a/tsconfig.json, packages/b/tsconfig.json',
+        'packages/b/tsconfig.json:',
+        '  - Missing references: packages/a/tsconfig.json',
+      ]);
+      expect(readJson(tree, 'tsconfig.json').references).not.toContainEqual({
+        path: './packages/not-composite',
+      });
+    });
+
     it('should respect existing project references and discard non-existing ones in the tsconfig.json', async () => {
       writeJson(tree, 'tsconfig.json', {
         compilerOptions: {

--- a/packages/js/src/generators/typescript-sync/typescript-sync.spec.ts
+++ b/packages/js/src/generators/typescript-sync/typescript-sync.spec.ts
@@ -225,6 +225,102 @@ describe('syncGenerator()', () => {
       `);
     });
 
+    describe('nx.sync.ignoredProjects', () => {
+      beforeEach(() => {
+        addProject('nested-app', [], [], 'examples/nested/app');
+        addProject('nested-lib', [], [], 'examples/nested/lib');
+      });
+
+      function setIgnoredProjects(ignoredProjects: string[]) {
+        updateJson(tree, 'tsconfig.json', (json) => ({
+          ...json,
+          nx: { sync: { ignoredProjects } },
+        }));
+      }
+
+      it('should not add a reference for an ignored project', async () => {
+        setIgnoredProjects(['nested-app', 'nested-lib']);
+
+        await syncGenerator(tree);
+
+        expect(readJson(tree, 'tsconfig.json').references).toEqual([
+          { path: './packages/a' },
+          { path: './packages/b' },
+        ]);
+      });
+
+      it('should match by directory', async () => {
+        // directory patterns are globs against the project root, not prefixes
+        setIgnoredProjects(['directory:examples/**']);
+
+        await syncGenerator(tree);
+
+        expect(readJson(tree, 'tsconfig.json').references).toEqual([
+          { path: './packages/a' },
+          { path: './packages/b' },
+        ]);
+      });
+
+      it('should match by name glob', async () => {
+        setIgnoredProjects(['nested-*']);
+
+        await syncGenerator(tree);
+
+        expect(readJson(tree, 'tsconfig.json').references).toEqual([
+          { path: './packages/a' },
+          { path: './packages/b' },
+        ]);
+      });
+
+      it('should prune an existing reference to an ignored project', async () => {
+        updateJson(tree, 'tsconfig.json', (json) => ({
+          ...json,
+          nx: { sync: { ignoredProjects: ['nested-*'] } },
+          references: [
+            { path: './packages/a' },
+            { path: './examples/nested/app' },
+          ],
+        }));
+
+        const result = await syncGenerator(tree);
+
+        expect(readJson(tree, 'tsconfig.json').references).toEqual([
+          { path: './packages/a' },
+          { path: './packages/b' },
+        ]);
+        expect((result as any).outOfSyncDetails).toContain(
+          '  - Stale references: examples/nested/app/tsconfig.json'
+        );
+      });
+
+      it('should not affect references between projects', async () => {
+        // nested-lib is ignored at the root, but `a` genuinely depends on it,
+        // so `a`'s own tsconfig must still reference it.
+        addProject('depends-on-nested', ['nested-lib'], [], 'packages/dep');
+        setIgnoredProjects(['nested-lib']);
+
+        await syncGenerator(tree);
+
+        expect(readJson(tree, 'packages/dep/tsconfig.json').references).toEqual(
+          [{ path: '../../examples/nested/lib' }]
+        );
+        expect(readJson(tree, 'tsconfig.json').references).not.toContainEqual({
+          path: './examples/nested/lib',
+        });
+      });
+
+      it('should filter nothing when unset', async () => {
+        await syncGenerator(tree);
+
+        expect(readJson(tree, 'tsconfig.json').references).toEqual([
+          { path: './packages/a' },
+          { path: './packages/b' },
+          { path: './examples/nested/app' },
+          { path: './examples/nested/lib' },
+        ]);
+      });
+    });
+
     it('should not report a non-composite project as a missing reference', async () => {
       addProject('not-composite', [], [], 'packages/not-composite');
       writeJson(tree, 'packages/not-composite/tsconfig.json', {

--- a/packages/js/src/generators/typescript-sync/typescript-sync.spec.ts
+++ b/packages/js/src/generators/typescript-sync/typescript-sync.spec.ts
@@ -206,6 +206,78 @@ describe('syncGenerator()', () => {
     ]);
   });
 
+  describe('@nx/js/typescript plugin filters', () => {
+    it('should not reference a project the plugin excludes', async () => {
+      writeJson(tree, 'nx.json', {
+        plugins: [{ plugin: '@nx/js/typescript', exclude: ['examples/**/*'] }],
+      });
+      addProject('excluded-example', [], [], 'examples/basic');
+
+      await syncGenerator(tree);
+
+      expect(readJson(tree, 'tsconfig.json').references).toEqual([
+        { path: './packages/a' },
+        { path: './packages/b' },
+      ]);
+    });
+
+    it('should reference a project claimed by a second registration', async () => {
+      // The first registration excludes e2e, the second includes it. The
+      // plugin runs for the union, so the reference must be kept.
+      writeJson(tree, 'nx.json', {
+        plugins: [
+          { plugin: '@nx/js/typescript', exclude: ['e2e/**/*'] },
+          { plugin: '@nx/js/typescript', include: ['e2e/**/*'] },
+        ],
+      });
+      addProject('e2e-app', [], [], 'e2e/app');
+
+      await syncGenerator(tree);
+
+      expect(readJson(tree, 'tsconfig.json').references).toContainEqual({
+        path: './e2e/app',
+      });
+    });
+
+    it('should not filter anything for a bare string registration', async () => {
+      writeJson(tree, 'nx.json', { plugins: ['@nx/js/typescript'] });
+      addProject('anywhere', [], [], 'examples/basic');
+
+      await syncGenerator(tree);
+
+      expect(readJson(tree, 'tsconfig.json').references).toContainEqual({
+        path: './examples/basic',
+      });
+    });
+
+    it('should not filter anything when the plugin is not registered', async () => {
+      writeJson(tree, 'nx.json', { plugins: [] });
+      addProject('anywhere', [], [], 'examples/basic');
+
+      await syncGenerator(tree);
+
+      expect(readJson(tree, 'tsconfig.json').references).toContainEqual({
+        path: './examples/basic',
+      });
+    });
+
+    it('should not report a non-composite project as out of sync', async () => {
+      addProject('not-composite', [], [], 'packages/not-composite');
+      writeJson(tree, 'packages/not-composite/tsconfig.json', {
+        compilerOptions: {},
+      });
+
+      const result = await syncGenerator(tree);
+
+      // It is filtered out before writing, so it must never be named as the
+      // reason the workspace is out of sync.
+      expect(JSON.stringify(result ?? {})).not.toContain('not-composite');
+      expect(readJson(tree, 'tsconfig.json').references).not.toContainEqual({
+        path: './packages/not-composite',
+      });
+    });
+  });
+
   describe('root tsconfig.json', () => {
     it('should sync project references to the tsconfig.json', async () => {
       expect(readJson(tree, 'tsconfig.json').references).toBeUndefined();

--- a/packages/js/src/generators/typescript-sync/typescript-sync.ts
+++ b/packages/js/src/generators/typescript-sync/typescript-sync.ts
@@ -170,6 +170,17 @@ export async function syncGenerator(tree: Tree): Promise<SyncGeneratorResult> {
       const normalizedPath = normalizeReferencePath(node.data.root);
       // Skip the root tsconfig itself
       if (node.data.root !== '.' && !referencesSet.has(normalizedPath)) {
+        // Non-composite projects are dropped when writing below, so reporting
+        // them here would name a reference that can never be satisfied.
+        if (
+          !hasCompositeEnabled(
+            tsSysFromTree,
+            tsconfigInfoCaches,
+            joinPathFragments(normalizedPath, 'tsconfig.json')
+          )
+        ) {
+          continue;
+        }
         referencesSet.add(normalizedPath);
         addChangedFile(
           changedFiles,
@@ -182,7 +193,7 @@ export async function syncGenerator(tree: Tree): Promise<SyncGeneratorResult> {
 
     if (changedFiles.size > 0) {
       const updatedReferences = Array.from(referencesSet)
-        // Check composite is true in the internal reference before proceeding
+        // Pre-existing references skip the check above, so still filter here.
         .filter((ref) =>
           hasCompositeEnabled(
             tsSysFromTree,

--- a/packages/js/src/generators/typescript-sync/typescript-sync.ts
+++ b/packages/js/src/generators/typescript-sync/typescript-sync.ts
@@ -12,6 +12,7 @@ import {
 import ignore from 'ignore';
 import { applyEdits, modify } from 'jsonc-parser';
 import { dirname, normalize, relative } from 'node:path/posix';
+import { findMatchingProjects } from 'nx/src/utils/find-matching-projects';
 import {
   SyncError,
   type SyncGeneratorResult,
@@ -30,6 +31,7 @@ interface Tsconfig {
     sync?: {
       ignoredReferences?: string[];
       ignoredDependencies?: string[];
+      ignoredProjects?: string[];
     };
   };
 }
@@ -99,6 +101,17 @@ export async function syncGenerator(tree: Tree): Promise<SyncGeneratorResult> {
     }
   );
 
+  // Projects the user has opted out of the root solution, e.g. a nested
+  // standalone workspace that must not be pulled into the root `tsc --build`.
+  // Scoped to the root tsconfig: projects that genuinely depend on an ignored
+  // project still reference it from their own tsconfig.
+  const ignoredProjectRoots = new Set(
+    findMatchingProjects(
+      rootTsconfig.nx?.sync?.ignoredProjects ?? [],
+      projectGraph.nodes
+    ).map((name) => normalizeReferencePath(projectGraph.nodes[name].data.root))
+  );
+
   const tsSysFromTree: ts.System = {
     ...ts.sys,
     fileExists(path) {
@@ -153,7 +166,10 @@ export async function syncGenerator(tree: Tree): Promise<SyncGeneratorResult> {
         continue;
       }
 
-      if (tsconfigExists(tree, tsconfigInfoCaches, resolvedRefPath)) {
+      if (
+        tsconfigExists(tree, tsconfigInfoCaches, resolvedRefPath) &&
+        !ignoredProjectRoots.has(normalizedPath)
+      ) {
         // we only keep the references that still exist
         referencesSet.add(normalizedPath);
       } else {
@@ -169,7 +185,11 @@ export async function syncGenerator(tree: Tree): Promise<SyncGeneratorResult> {
     for (const node of tsconfigProjectNodeValues) {
       const normalizedPath = normalizeReferencePath(node.data.root);
       // Skip the root tsconfig itself
-      if (node.data.root !== '.' && !referencesSet.has(normalizedPath)) {
+      if (
+        node.data.root !== '.' &&
+        !referencesSet.has(normalizedPath) &&
+        !ignoredProjectRoots.has(normalizedPath)
+      ) {
         // Non-composite projects are dropped when writing below, so reporting
         // them here would name a reference that can never be satisfied.
         if (

--- a/packages/js/src/generators/typescript-sync/typescript-sync.ts
+++ b/packages/js/src/generators/typescript-sync/typescript-sync.ts
@@ -5,6 +5,8 @@ import {
   logger,
   parseJson,
   readNxJson,
+  type ExpandedPluginConfiguration,
+  type NxJsonConfiguration,
   type ProjectGraph,
   type ProjectGraphProjectNode,
   type Tree,
@@ -12,6 +14,7 @@ import {
 import ignore from 'ignore';
 import { applyEdits, modify } from 'jsonc-parser';
 import { dirname, normalize, relative } from 'node:path/posix';
+import { findMatchingConfigFiles } from 'nx/src/project-graph/utils/project-configuration-utils';
 import {
   SyncError,
   type SyncGeneratorResult,
@@ -48,6 +51,50 @@ type GeneratorOptions = {
 };
 
 type NormalizedGeneratorOptions = Required<GeneratorOptions>;
+
+const TS_PLUGIN_NAME = '@nx/js/typescript';
+
+/**
+ * Builds a predicate for whether a tsconfig is managed by `@nx/js/typescript`,
+ * honoring the `include`/`exclude` filters on its `nx.json` registrations.
+ *
+ * A project the plugin was told to skip must not be pulled into the root
+ * tsconfig's references — nested standalone workspaces are excluded there
+ * precisely because they are not part of this workspace's TypeScript build.
+ *
+ * Fails open: when the plugin is registered without filters, or not registered
+ * at all, nothing is filtered out.
+ */
+function createTypeScriptPluginFilter(
+  nxJson: NxJsonConfiguration
+): (tsconfigPath: string) => boolean {
+  const plugins = nxJson.plugins ?? [];
+
+  // A bare string registration carries no filters, so it claims everything.
+  if (plugins.some((p) => p === TS_PLUGIN_NAME)) {
+    return () => true;
+  }
+
+  const registrations = plugins
+    .filter(
+      (p): p is ExpandedPluginConfiguration =>
+        typeof p !== 'string' && p.plugin === TS_PLUGIN_NAME
+    )
+    .map((p) => ({ include: p.include ?? [], exclude: p.exclude ?? [] }));
+
+  if (registrations.length === 0) {
+    return () => true;
+  }
+
+  // Registrations are additive: one may exclude a directory that another
+  // includes, and the plugin runs for the union of what they claim.
+  return (tsconfigPath) =>
+    registrations.some(
+      ({ include, exclude }) =>
+        findMatchingConfigFiles([tsconfigPath], include, exclude).length > 0
+    );
+}
+
 type TsconfigInfoCaches = {
   composite: Map<string, boolean>;
   content: Map<string, string>;
@@ -88,6 +135,7 @@ export async function syncGenerator(tree: Tree): Promise<SyncGeneratorResult> {
   const projectGraph = await createProjectGraphAsync();
   const projectRoots = new Set<string>();
 
+  const isManagedByTypeScriptPlugin = createTypeScriptPluginFilter(nxJson);
   const tsconfigProjectNodeValues = Object.values(projectGraph.nodes).filter(
     (node) => {
       projectRoots.add(node.data.root);
@@ -95,7 +143,10 @@ export async function syncGenerator(tree: Tree): Promise<SyncGeneratorResult> {
         node.data.root,
         'tsconfig.json'
       );
-      return tsconfigExists(tree, tsconfigInfoCaches, projectTsconfigPath);
+      return (
+        tsconfigExists(tree, tsconfigInfoCaches, projectTsconfigPath) &&
+        isManagedByTypeScriptPlugin(projectTsconfigPath)
+      );
     }
   );
 
@@ -170,6 +221,18 @@ export async function syncGenerator(tree: Tree): Promise<SyncGeneratorResult> {
       const normalizedPath = normalizeReferencePath(node.data.root);
       // Skip the root tsconfig itself
       if (node.data.root !== '.' && !referencesSet.has(normalizedPath)) {
+        // Check composite here rather than only when writing, so a reference
+        // that would be filtered out below never reports the workspace as out
+        // of sync — it can never be satisfied.
+        if (
+          !hasCompositeEnabled(
+            tsSysFromTree,
+            tsconfigInfoCaches,
+            joinPathFragments(normalizedPath, 'tsconfig.json')
+          )
+        ) {
+          continue;
+        }
         referencesSet.add(normalizedPath);
         addChangedFile(
           changedFiles,
@@ -182,7 +245,7 @@ export async function syncGenerator(tree: Tree): Promise<SyncGeneratorResult> {
 
     if (changedFiles.size > 0) {
       const updatedReferences = Array.from(referencesSet)
-        // Check composite is true in the internal reference before proceeding
+        // Existing references are not re-checked above, so still filter here.
         .filter((ref) =>
           hasCompositeEnabled(
             tsSysFromTree,


### PR DESCRIPTION
> **Stacked on #36559.** The first commit here is that PR; review only [`25980ab`](https://github.com/nrwl/nx/commit/25980ab6c6). This branch previously proposed filtering root references by the `@nx/js/typescript` plugin's `include`/`exclude` — that approach was dropped, see [Discussion](#discussion) below.

## Current Behavior

The root `tsconfig.json`'s project references are derived from the project graph alone, so every project with a composite tsconfig is pulled into the root solution. There is no way to say "this project should not be referenced from the root".

That matters for a project that lives in the repository but outside its TypeScript build. `examples/react/basic` in this repo is a deliberately standalone pnpm workspace — its own `pnpm-lock.yaml`, its own install, `link:` deps — precisely because it sits outside the root workspace. Referencing it from the root makes `tsc --build` walk into a separately-installed workspace.

Nothing available today covers this:

| mechanism | why it doesn't work |
| --- | --- |
| `nx.sync.ignoredReferences` | only read for per-project tsconfigs, never the root. And it *keeps* a hand-written reference rather than suppressing one. |
| `.nxignore` | removes the project from the project graph entirely — no tasks, no caching. |
| not setting `composite` | the only real lever, and it's exactly what a project needs to change to become a TS solution. |

## Expected Behavior

The root `tsconfig.json` accepts `nx.sync.ignoredProjects`, a sibling of the existing `nx.sync.ignoredReferences` and `ignoredDependencies`:

```jsonc
// tsconfig.json
{
  "nx": {
    "sync": {
      "ignoredProjects": ["directory:examples/**"]
    }
  }
}
```

Entries resolve through `findMatchingProjects`, the same matcher behind `targetDefaults` and `nx affected`, so project names, name globs, `tag:` and `directory:` patterns all work.

Three details worth calling out:

- **Both adds and keeps are suppressed.** An existing root reference to an ignored project is pruned, so you can add the option to a workspace that already has the reference and let sync clean it up.
- **Scoped to the root tsconfig.** A project that genuinely depends on an ignored project still references it from its own tsconfig, so imports keep type-checking.
- **`directory:` patterns are globs against the project root, not prefixes.** `directory:examples/**` matches `examples/react/basic`; `directory:examples` does not. This is existing `findMatchingProjects` behavior and is called out in the docs.

## Verification

Six new tests. Five fail without the implementation; `should filter nothing when unset` is a regression guard that passes either way by design.

`nx run-many -t test,lint -p js` passes — 830 tests, including the 44 pre-existing `typescript-sync` specs.

`nx sync:check` in this repo runs the *published* `@nx/js`, so it can't exercise this change until release. Instead the built generator was driven against the real workspace through an in-memory `FsTree` (nothing flushed to disk), with `composite: true` added to `examples/react/basic`:

| scenario | example references demanded |
| --- | --- |
| no opt-out | 1 — `./examples/react/basic` |
| `ignoredProjects: ["directory:examples/**"]` | 0 |

The root reference set went 112 → 112 in the opt-out case, with nothing added and nothing removed — the option is surgical.

## Documentation

`nx.sync.ignoredProjects` is documented in the TypeScript project linking guide, along with `ignoredReferences`, `ignoredDependencies` and `runtimeTsConfigFileNames`, none of which were documented before.

## Discussion

This branch originally filtered root references through the `@nx/js/typescript` plugin's `include`/`exclude`. @leosvelperez pushed back, and he was right: plugin filters mean "don't infer Nx tasks here", not "don't reference this from the root tsconfig". Projects get excluded from the plugin for unrelated reasons.

Measured against this repo's real `nx.json`, that filter would have treated **21 of 112** root references as unmanaged — every `nx-dev/*` project, excluded from the plugin only to avoid tsc typecheck/build tasks. Existing references would have survived (the first pass keeps any reference whose file exists), but a newly added `nx-dev` lib would silently never get one, making the behavior depend on whether a project predated the change.

The design here instead follows #35401, which added `nx.sync.ignoredDependencies` for the same shape of problem one level down — no way to tell the generator "don't add this reference" — and rejected `implicitDependencies: ["!name"]` for the same reason `.nxignore` is wrong here.

## Related Issue(s)

Fixes NXC-4734

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Fix-typescript-sync-to-respect-plugin-include-exclude-NXC-4734-bf9d07aa)
<!-- polygraph-session-end -->