### PR TITLE
fix(core): mark all projects affected when a global package is not in the graph

### DIFF
--- a/packages/nx/src/plugins/js/project-graph/affected/npm-packages.spec.ts
+++ b/packages/nx/src/plugins/js/project-graph/affected/npm-packages.spec.ts
@@ -325,6 +325,74 @@ describe('getTouchedNpmPackages', () => {
     );
   });
 
+  it('should mark all projects as affected when nx itself is changed and is not in the project graph', () => {
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+    warnSpy.mockClear();
+
+    const result = getTouchedNpmPackages(
+      [
+        {
+          file: 'package.json',
+          getChanges: () => [
+            {
+              type: JsonDiffType.Modified,
+              path: ['devDependencies', 'nx'],
+              value: {
+                lhs: '22.7.5',
+                rhs: '23.1.0',
+              },
+            },
+          ],
+        },
+      ],
+      projectsConfigurations,
+      nxJson,
+      {
+        devDependencies: {
+          nx: '23.1.0',
+        },
+      },
+      projectGraph
+    );
+
+    expect(result).toEqual(['proj1', 'proj2']);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
+  it('should mark all projects as affected when a plugin package is changed and is not in the project graph', () => {
+    const warnSpy = jest.spyOn(logger, 'warn').mockImplementation(() => {});
+    warnSpy.mockClear();
+
+    const result = getTouchedNpmPackages(
+      [
+        {
+          file: 'package.json',
+          getChanges: () => [
+            {
+              type: JsonDiffType.Modified,
+              path: ['devDependencies', '@nx/happy-plugin'],
+              value: {
+                lhs: '0.0.1',
+                rhs: '0.0.2',
+              },
+            },
+          ],
+        },
+      ],
+      projectsConfigurations,
+      { ...nxJson, plugins: ['@nx/happy-plugin/plugin'] },
+      {
+        devDependencies: {
+          '@nx/happy-plugin': '0.0.2',
+        },
+      },
+      projectGraph
+    );
+
+    expect(result).toEqual(['proj1', 'proj2']);
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
   it('should mark all projects as affected when overrides are changed for unknown packages', () => {
     const result = getTouchedNpmPackages(
       [

--- a/packages/nx/src/plugins/js/project-graph/affected/npm-packages.ts
+++ b/packages/nx/src/plugins/js/project-graph/affected/npm-packages.ts
@@ -50,6 +50,11 @@ export const getTouchedNpmPackages: TouchedProjectLocator<
           npmPackage = nodes.find((n) => n.name === c.path[1]);
         }
         if (!npmPackage) {
+          // A global package affects all projects whether or not the graph
+          // has a node for it, so check it here rather than only below
+          if (globalPackages.has(c.path[1])) {
+            return Object.keys(projectGraph.nodes);
+          }
           missingTouchedNpmPackages.push(c.path[1]);
           continue;
         }


### PR DESCRIPTION
## Current Behavior

`getTouchedNpmPackages` only consults `globalPackages` **after** resolving the changed dependency to a node in the project graph. When neither `projectGraph.externalNodes` nor `projectGraph.nodes` has a match, it records the name in `missingTouchedNpmPackages` and `continue`s — so the check that returns every project is unreachable for a global package that has no node:

```ts
if (!npmPackage) {
  missingTouchedNpmPackages.push(c.path[1]);
  continue;                       // <- bails
}
...
if ('packageName' in npmPackage.data) {
  if (globalPackages.has(npmPackage.data.packageName)) {
    return Object.keys(projectGraph.nodes);   // <- never reached for those
  }
}
```

`getGlobalPackages` unconditionally appends `'nx'`, so bumping nx's own version in `package.json` is the common way to hit this: the run logs `The affected projects might have not been identified properly. The package(s) nx were not found.` and marks **nothing** affected, instead of invalidating the whole workspace.

## Expected Behavior

A change to a global package (an `nx.json` plugin package, or `nx` itself) marks every project affected regardless of whether that package happens to have a node in the graph, and does not emit the "not found" warning for it. Packages that are genuinely unknown still warn exactly as before.

The fix consults `globalPackages` with the changed key before falling through to the warning. This also makes the `dependencies`/`devDependencies` branch consistent with the `overrides`/`resolutions`/`pnpm.overrides` branch in the same function, which already treats an unresolvable package as "affects everything".

## Verification

Full disclosure on what was and wasn't verified locally: this machine cannot host an nx install (the pnpm install does not fit in the available disk), so `nx run-many -t test -p nx` and `nx affected -t lint` could **not** be run — CI is the first place the real jest suite executes. To avoid shipping unverified code, the two changed files were checked directly:

- **Type-check** — `tsc --noEmit` (TS 5.9, `tsconfig.base.json` settings) over both changed files: zero errors in them, and a before/after diff of the full error output is byte-identical, so the change introduces no new type errors.
- **Behavior** — the real `getTouchedNpmPackages` was compiled to CJS and executed against the exact inputs and expectations of the two new tests. Both **fail on `master`** (they return `[]`) and **pass with this change**; the two pre-existing tests covering "unknown package still warns" and "resolvable package returns just that package" pass in both.
- **Formatting** — `prettier --check` clean with the repo's `.prettierrc` options.
- **PR title** — `node ./scripts/validate-pr-title.js` exits 0.

## Related Issue(s)

Fixes #36415
