### PR TITLE
fix(maven): ignore comments and string literals when detecting test class names

### DIFF
--- a/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/targets/TestClassDiscovery.kt
+++ b/packages/maven/maven-plugin/src/main/kotlin/dev/nx/maven/targets/TestClassDiscovery.kt
@@ -90,11 +90,15 @@ class TestClassDiscovery() {
             return null
         }
 
+        // Comments and string literals contain prose like "a top-level class name", which string
+        // matching cannot tell apart from a declaration, so only scan actual code
+        val code = withoutCommentsAndLiterals(content)
+
         // Extract package name (simple approach)
-        val packageName = extractPackageName(content)
+        val packageName = extractPackageName(code)
 
         // Extract class name (simple approach)
-        val className = extractClassName(content) ?: return null
+        val className = extractClassName(code) ?: return null
 
         // Double check: does this class actually have test methods?
         if (!hasTestMethodsInClass(content, className)) {
@@ -112,6 +116,22 @@ class TestClassDiscovery() {
             packageName = packageName
         )
     }
+
+    // Line comment, block comment, text block, string literal. Leftmost-first matching is what
+    // keeps a literal's own comment markers from opening a comment, and """ must precede "
+    private val commentOrLiteral = Regex(
+        """//[^\n]*|/\*[\s\S]*?\*/|"{3}[\s\S]*?"{3}|"(?:\\.|[^"\\\n])*""""
+    )
+    private val nonLineBreak = Regex("[^\n]")
+
+    /**
+     * Blank out comments and string literals, keeping line breaks so the result can still be
+     * scanned line by line. Without this, a Javadoc block or a string literal that happens to
+     * contain "class " is read as the class declaration: two files whose comments both mention it
+     * end up with the same generated target name, which produces a cyclic task graph.
+     */
+    private fun withoutCommentsAndLiterals(content: String): String =
+        commentOrLiteral.replace(content) { it.value.replace(nonLineBreak, " ") }
 
     /**
      * Extract package name from Java file content using simple string matching

--- a/packages/maven/maven-plugin/src/test/kotlin/dev/nx/maven/targets/TestClassDiscoveryTest.kt
+++ b/packages/maven/maven-plugin/src/test/kotlin/dev/nx/maven/targets/TestClassDiscoveryTest.kt
@@ -1,0 +1,153 @@
+package dev.nx.maven.targets
+
+import org.apache.maven.project.MavenProject
+import org.junit.jupiter.api.Nested
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.io.TempDir
+import java.io.File
+import kotlin.test.assertEquals
+
+class TestClassDiscoveryTest {
+
+  @Nested
+  inner class ClassNameExtraction {
+
+    @Test
+    fun `resolves a plain package-private declaration`(@TempDir tempDir: File) {
+      val discovered = discover(tempDir, "FooTest.java", """
+        package com.example;
+
+        class FooTest {
+          @Test
+          void works() {}
+        }
+      """.trimIndent())
+
+      assertEquals(listOf("com.example.FooTest"), discovered.map { it.packagePath })
+    }
+
+    @Test
+    fun `ignores the word class inside a markdown javadoc comment`(@TempDir tempDir: File) {
+      val discovered = discover(tempDir, "FooTest.java", """
+        package com.example;
+
+        /// Named without the `${'$'}` of the class under test: a `${'$'}` in a top-level class
+        /// name is treated as a nested class by Surefire and the test is silently skipped.
+        class FooTest {
+          @Test
+          void works() {}
+        }
+      """.trimIndent())
+
+      assertEquals(listOf("com.example.FooTest"), discovered.map { it.packagePath })
+    }
+
+    @Test
+    fun `ignores the word class inside a block comment`(@TempDir tempDir: File) {
+      val discovered = discover(tempDir, "FooTest.java", """
+        package com.example;
+
+        /*
+         * This test class is a bit special, as it needs some manual actions.
+         */
+        class FooTest {
+          @Test
+          void works() {}
+        }
+      """.trimIndent())
+
+      assertEquals(listOf("com.example.FooTest"), discovered.map { it.packagePath })
+    }
+
+    @Test
+    fun `ignores the word class inside a string literal`(@TempDir tempDir: File) {
+      val discovered = discover(tempDir, "FooTest.java", """
+        package com.example;
+
+        @DisplayName("runs the class Bogus scenario")
+        class FooTest {
+          @Test
+          void works() {}
+        }
+      """.trimIndent())
+
+      assertEquals(listOf("com.example.FooTest"), discovered.map { it.packagePath })
+    }
+
+    @Test
+    fun `ignores the word class inside a text block`(@TempDir tempDir: File) {
+      val discovered = discover(tempDir, "FooTest.java", """
+        package com.example;
+
+        @DisplayName(""${'"'}
+            the class Bogus scenario
+            ""${'"'})
+        class FooTest {
+          @Test
+          void works() {}
+        }
+      """.trimIndent())
+
+      assertEquals(listOf("com.example.FooTest"), discovered.map { it.packagePath })
+    }
+
+    @Test
+    fun `does not treat comment markers inside a string literal as a comment`(
+      @TempDir tempDir: File
+    ) {
+      // The literal's /* would otherwise open a comment that swallows the declaration and only
+      // closes on the trailing */ below it
+      val discovered = discover(tempDir, "FooTest.java", """
+        package com.example;
+
+        @DisplayName("matches globs like src/*")
+        class FooTest {
+          @Test
+          void works() {} /* nothing to see here */
+        }
+      """.trimIndent())
+
+      assertEquals(listOf("com.example.FooTest"), discovered.map { it.packagePath })
+    }
+
+    @Test
+    fun `keeps sibling test classes distinct when both javadocs mention the word class`(
+      @TempDir tempDir: File
+    ) {
+      listOf("FirstTest", "SecondTest").forEach { name ->
+        writeSource(tempDir, "$name.java", """
+          package com.example;
+
+          /// Each nested class runs the full flow for one entity type.
+          class $name {
+            @Test
+            void works() {}
+          }
+        """.trimIndent())
+      }
+
+      val discovered = TestClassDiscovery().discoverTestClasses(projectWithTestRoot(tempDir))
+
+      assertEquals(
+        listOf("com.example.FirstTest", "com.example.SecondTest"),
+        discovered.map { it.packagePath }.sorted()
+      )
+    }
+  }
+
+  private fun discover(tempDir: File, fileName: String, source: String): List<TestClassInfo> {
+    writeSource(tempDir, fileName, source)
+
+    return TestClassDiscovery().discoverTestClasses(projectWithTestRoot(tempDir))
+  }
+
+  private fun writeSource(tempDir: File, fileName: String, source: String) =
+    File(tempDir, "src/test/java/com/example").apply { mkdirs() }
+      .resolve(fileName).writeText(source)
+
+  private fun projectWithTestRoot(tempDir: File): MavenProject =
+    MavenProject().apply {
+      file = File(tempDir, "pom.xml")
+      addTestCompileSourceRoot(File(tempDir, "src/test/java").absolutePath)
+    }
+}


### PR DESCRIPTION
## Current Behavior

`TestClassDiscovery.extractClassName` scans the raw text of each Java test file for the token `class` and takes the next token, so a comment or string literal containing "class " is read as the class declaration. A Javadoc comment mentioning "a top-level class name" above the real declaration produces the class name `name`.

Two files in one module whose comments both match then collapse onto the same generated target name. Since each atomized target is created with a `dependsOn` copy that already lists the previously generated atomized targets, the merged target ends up with edges to targets that already depend on it and `nx run-many -t test-ci` fails with "the task graph has a circular dependency". `extractPackageName` has the same flaw.

## Expected Behavior

Comments and string literals are blanked out before the package and class name are extracted, so the name always comes from the declaration. Line breaks are preserved, so the existing line-based scan is unchanged.

Against the reproduction in #36487, where 11 test classes collapsed into 9 targets and `test-ci` could not run: all 11 classes now get their own target and the task graph is valid. 7 unit tests are added, 5 of which fail without this change.

Three notes for reviewers:

- The fix lives in the Central-published `nx-maven-plugin` jar, so it only reaches users with a new plugin version plus a `mavenPluginVersion` bump and pom migration. Do you want that in this PR, or do you handle it at release?
- The Kotlin tests here do not run on PRs (`nx-maven-plugin` has no `test` target, and @nx/maven is not applied to this repo yet — #33412). They pass locally with `mvn -pl maven-plugin -am test`. Happy to wire up a `test` target if you want it.
- Building the plugin on JDK 24+ needs `-Dkotlin.version=2.1.20`; the pinned Kotlin 1.9.22 fails in IntelliJ's `JavaVersion.parse`. Unrelated to this change.

## Related Issue(s)

Fixes #36487
