### PR TITLE
fix(react): make module federation packages optional peer dependencies

### DIFF
--- a/packages/module-federation/package.json
+++ b/packages/module-federation/package.json
@@ -131,12 +131,12 @@
     "express": "^4.21.2",
     "http-proxy-middleware": "catalog:",
     "picocolors": "catalog:",
-    "tslib": "catalog:typescript",
-    "webpack": "catalog:"
+    "tslib": "catalog:typescript"
   },
   "peerDependencies": {
     "@module-federation/enhanced": "^2.0.0",
-    "@module-federation/node": "^2.0.0"
+    "@module-federation/node": "^2.0.0",
+    "webpack": "^5.0.0"
   },
   "peerDependenciesMeta": {
     "@module-federation/enhanced": {
@@ -144,10 +144,14 @@
     },
     "@module-federation/node": {
       "optional": true
+    },
+    "webpack": {
+      "optional": true
     }
   },
   "devDependencies": {
-    "nx": "workspace:*"
+    "nx": "workspace:*",
+    "webpack": "catalog:"
   },
   "nx-migrations": {
     "migrations": "./migrations.json",

--- a/packages/next/migrations.json
+++ b/packages/next/migrations.json
@@ -29,6 +29,12 @@
       "description": "Create AI instructions to help migrate workspaces from Next.js 14 to 15.",
       "prompt": "./dist/src/migrations/update-23-1-0/ai-instructions-for-next-15.md",
       "documentation": "./dist/src/migrations/update-23-1-0/upgrade-to-next-15.md"
+    },
+    "update-23-2-0-add-svgr-webpack-if-used": {
+      "version": "23.2.0-beta.4",
+      "description": "Add `@svgr/webpack` when a next config references it.",
+      "implementation": "./dist/src/migrations/update-23-2-0/add-svgr-webpack-if-used",
+      "documentation": "./dist/src/migrations/update-23-2-0/add-svgr-webpack-if-used.md"
     }
   },
   "packageJsonUpdates": {

--- a/packages/next/package.json
+++ b/packages/next/package.json
@@ -67,12 +67,17 @@
     "supportsOptionalMigrations": true
   },
   "peerDependencies": {
-    "next": ">=14.0.0 <17.0.0"
+    "next": ">=14.0.0 <17.0.0",
+    "@nx/webpack": "workspace:*"
+  },
+  "peerDependenciesMeta": {
+    "@nx/webpack": {
+      "optional": true
+    }
   },
   "dependencies": {
     "@nx/devkit": "workspace:*",
     "@babel/plugin-proposal-decorators": "^7.22.7",
-    "@svgr/webpack": "catalog:",
     "copy-webpack-plugin": "^14.0.0",
     "ignore": "^7.0.5",
     "semver": "catalog:",
@@ -82,12 +87,12 @@
     "@nx/eslint": "workspace:*",
     "@nx/react": "workspace:*",
     "@nx/web": "workspace:*",
-    "@nx/webpack": "workspace:*",
     "@phenomnomnominal/tsquery": "catalog:typescript"
   },
   "devDependencies": {
     "@nx/cypress": "workspace:*",
     "@nx/playwright": "workspace:*",
+    "@nx/webpack": "workspace:*",
     "nx": "workspace:*"
   },
   "publishConfig": {

--- a/packages/next/plugins/component-testing.ts
+++ b/packages/next/plugins/component-testing.ts
@@ -18,14 +18,14 @@ import {
 } from '@nx/devkit';
 import { getProjectSourceRoot } from '@nx/js/internal';
 import { withReact } from '@nx/react';
-import { suppressReactComposeHelperWarnings } from '@nx/react/internal';
 import {
+  assertPackageIsInstalled,
+  suppressReactComposeHelperWarnings,
+} from '@nx/react/internal';
+import type {
   AssetGlobPattern,
-  composePluginsSync,
   NormalizedWebpackExecutorOptions,
-  withNx,
 } from '@nx/webpack';
-import { suppressWebpackComposeHelperWarnings } from '@nx/webpack/internal';
 import { readNxJson } from 'nx/src/config/configuration';
 import { join } from 'path';
 import { NextBuildBuilderOptions } from '../src/utils/types';
@@ -39,6 +39,15 @@ export function nxComponentTestingPreset(
     // options, cast to any to avoid type errors
     return nxBaseCypressPreset(pathToConfig) as any;
   }
+
+  assertPackageIsInstalled('@nx/webpack', '@nx/next/plugins/component-testing');
+  const {
+    composePluginsSync,
+    withNx,
+  }: typeof import('@nx/webpack') = require('@nx/webpack');
+  const {
+    suppressWebpackComposeHelperWarnings,
+  }: typeof import('@nx/webpack/internal') = require('@nx/webpack/internal');
 
   const graph = readCachedProjectGraph();
   const { targets: ctTargets, name: ctProjectName } = getProjectConfigByPath(

--- a/packages/next/src/migrations/update-23-2-0/add-svgr-webpack-if-used.md
+++ b/packages/next/src/migrations/update-23-2-0/add-svgr-webpack-if-used.md
@@ -1,0 +1,28 @@
+#### Add `@svgr/webpack` If Used
+
+Adds `@svgr/webpack` to the workspace when a next config references it.
+
+`@svgr/webpack` is no longer a dependency of `@nx/next`, so workspaces whose next configs resolve it - which is what the Nx 22 `add-svgr-to-next-config` migration inlined - must declare it themselves. This migration backfills it for those workspaces. Workspaces that already have `@svgr/webpack` are left untouched.
+
+#### Examples
+
+##### Before
+
+```jsonc title="package.json"
+{
+  "devDependencies": {
+    "@nx/next": "23.1.0",
+  },
+}
+```
+
+##### After
+
+```jsonc title="package.json"
+{
+  "devDependencies": {
+    "@nx/next": "23.1.0",
+    "@svgr/webpack": "^8.0.1",
+  },
+}
+```

--- a/packages/next/src/migrations/update-23-2-0/add-svgr-webpack-if-used.spec.ts
+++ b/packages/next/src/migrations/update-23-2-0/add-svgr-webpack-if-used.spec.ts
@@ -1,0 +1,74 @@
+import {
+  addProjectConfiguration,
+  readJson,
+  updateJson,
+  type Tree,
+} from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import addSvgrWebpackIfUsed from './add-svgr-webpack-if-used';
+
+describe('add-svgr-webpack-if-used migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+    updateJson(tree, 'package.json', (json) => {
+      json.devDependencies = { '@nx/next': '23.1.0' };
+      return json;
+    });
+    addProjectConfiguration(tree, 'app1', {
+      root: 'apps/app1',
+      targets: { build: { executor: '@nx/next:build' } },
+    });
+  });
+
+  it('should not add @svgr/webpack when no next config references it', async () => {
+    tree.write('apps/app1/next.config.js', 'module.exports = {};');
+
+    await addSvgrWebpackIfUsed(tree);
+
+    expect(readJson(tree, 'package.json').devDependencies).toEqual({
+      '@nx/next': '23.1.0',
+    });
+  });
+
+  it('should add @svgr/webpack when a next config resolves it', async () => {
+    tree.write(
+      'apps/app1/next.config.js',
+      `const loader = require.resolve('@svgr/webpack');`
+    );
+
+    await addSvgrWebpackIfUsed(tree);
+
+    expect(
+      readJson(tree, 'package.json').devDependencies['@svgr/webpack']
+    ).toBeDefined();
+  });
+
+  it('should check other next config extensions', async () => {
+    tree.write('apps/app1/next.config.mjs', `const loader = '@svgr/webpack';`);
+
+    await addSvgrWebpackIfUsed(tree);
+
+    expect(
+      readJson(tree, 'package.json').devDependencies['@svgr/webpack']
+    ).toBeDefined();
+  });
+
+  it('should leave an already installed @svgr/webpack untouched', async () => {
+    updateJson(tree, 'package.json', (json) => {
+      json.devDependencies['@svgr/webpack'] = '^7.0.0';
+      return json;
+    });
+    tree.write(
+      'apps/app1/next.config.js',
+      `const loader = require.resolve('@svgr/webpack');`
+    );
+
+    await addSvgrWebpackIfUsed(tree);
+
+    expect(
+      readJson(tree, 'package.json').devDependencies['@svgr/webpack']
+    ).toBe('^7.0.0');
+  });
+});

--- a/packages/next/src/migrations/update-23-2-0/add-svgr-webpack-if-used.ts
+++ b/packages/next/src/migrations/update-23-2-0/add-svgr-webpack-if-used.ts
@@ -1,0 +1,47 @@
+import {
+  addDependenciesToPackageJson,
+  getProjects,
+  joinPathFragments,
+  type Tree,
+} from '@nx/devkit';
+import { svgrWebpackVersion } from '../../utils/versions';
+
+// The Nx 22 `add-svgr-to-next-config` migration inlined a `withSvgr` helper
+// that resolves `@svgr/webpack` into user next configs, but never added the
+// package to the workspace - it only resolved transitively through `@nx/next`.
+// Now that `@nx/next` no longer depends on it, backfill it where a next config
+// actually references it.
+const nextConfigFileNames = [
+  'next.config.js',
+  'next.config.cjs',
+  'next.config.mjs',
+  'next.config.ts',
+];
+
+export default async function addSvgrWebpackIfUsed(tree: Tree) {
+  let needsSvgr = false;
+
+  for (const [, project] of getProjects(tree)) {
+    for (const fileName of nextConfigFileNames) {
+      const path = joinPathFragments(project.root, fileName);
+      needsSvgr ||=
+        tree.exists(path) && tree.read(path, 'utf-8').includes('@svgr/webpack');
+    }
+
+    if (needsSvgr) {
+      break;
+    }
+  }
+
+  if (!needsSvgr) {
+    return;
+  }
+
+  return addDependenciesToPackageJson(
+    tree,
+    {},
+    { '@svgr/webpack': svgrWebpackVersion },
+    undefined,
+    true
+  );
+}

--- a/packages/next/src/utils/versions.ts
+++ b/packages/next/src/utils/versions.ts
@@ -15,3 +15,4 @@ export const eslintConfigNext14Version = '^15.5.18';
 export const eslintConfigNextVersion = eslintConfigNext16Version;
 export const sassVersion = '1.97.2';
 export const tsLibVersion = '^2.3.0';
+export const svgrWebpackVersion = '^8.0.1';

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -58,7 +58,6 @@
     "@nx/js": "workspace:*",
     "@nx/eslint": "workspace:*",
     "@nx/react": "workspace:*",
-    "@nx/webpack": "workspace:*",
     "ajv": "catalog:",
     "enhanced-resolve": "^5.8.3",
     "ignore": "^7.0.5",
@@ -79,6 +78,7 @@
     }
   },
   "devDependencies": {
+    "@nx/webpack": "workspace:*",
     "nx": "workspace:*"
   },
   "optionalDependencies": {

--- a/packages/react/eslint.config.mjs
+++ b/packages/react/eslint.config.mjs
@@ -68,7 +68,6 @@ export default [
             '@nx/vite',
             '@nx/vitest',
             '@nx/webpack',
-            '@babel/preset-react',
             '@module-federation/node',
             '@phenomnomnominal/tsquery',
             '@pmmmwh/react-refresh-webpack-plugin',

--- a/packages/react/internal.ts
+++ b/packages/react/internal.ts
@@ -6,6 +6,7 @@
 
 export { addE2e } from './src/generators/application/lib/add-e2e';
 export { addRollupBuildTarget } from './src/generators/library/lib/add-rollup-build-target';
+export { assertPackageIsInstalled } from './src/utils/assert-package';
 export { isComponent } from './src/utils/ct-utils';
 export { suppressReactComposeHelperWarnings } from './src/utils/deprecation';
 export { hasWebpackPlugin } from './src/utils/has-webpack-plugin';

--- a/packages/react/migrations.json
+++ b/packages/react/migrations.json
@@ -39,6 +39,18 @@
       "description": "Create AI instructions to help migrate workspaces from React 18 to 19.",
       "prompt": "./dist/src/migrations/update-23-1-0/ai-instructions-for-react-19.md",
       "documentation": "./dist/src/migrations/update-23-1-0/upgrade-to-react-19.md"
+    },
+    "update-23-2-0-add-optional-module-federation-packages": {
+      "version": "23.2.0-beta.4",
+      "description": "Add optional Module Federation packages when existing targets require them.",
+      "implementation": "./dist/src/migrations/update-23-2-0/add-optional-module-federation-packages",
+      "documentation": "./dist/src/migrations/update-23-2-0/add-optional-module-federation-packages.md"
+    },
+    "update-23-2-0-add-svgr-webpack-if-used": {
+      "version": "23.2.0-beta.4",
+      "description": "Add `@svgr/webpack` when a webpack config references it.",
+      "implementation": "./dist/src/migrations/update-23-2-0/add-svgr-webpack-if-used",
+      "documentation": "./dist/src/migrations/update-23-2-0/add-svgr-webpack-if-used.md"
     }
   },
   "packageJsonUpdates": {

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -93,36 +93,48 @@
   "peerDependencies": {
     "babel-plugin-react-compiler": "^1.0.0",
     "react": ">=18.0.0 <20.0.0",
-    "react-dom": ">=18.0.0 <20.0.0"
+    "react-dom": ">=18.0.0 <20.0.0",
+    "@nx/module-federation": "workspace:*",
+    "express": "^4.21.2",
+    "http-proxy-middleware": "catalog:"
   },
   "peerDependenciesMeta": {
     "babel-plugin-react-compiler": {
       "optional": true
+    },
+    "@nx/module-federation": {
+      "optional": true
+    },
+    "express": {
+      "optional": true
+    },
+    "http-proxy-middleware": {
+      "optional": true
     }
   },
   "dependencies": {
+    "@babel/preset-react": "^7.22.5",
     "@phenomnomnominal/tsquery": "catalog:typescript",
-    "@svgr/webpack": "catalog:",
     "minimatch": "catalog:",
     "tslib": "catalog:typescript",
     "@nx/devkit": "workspace:*",
     "@nx/js": "workspace:*",
     "@nx/eslint": "workspace:*",
     "@nx/web": "workspace:*",
-    "@nx/module-federation": "workspace:*",
-    "@nx/rollup": "workspace:*",
-    "express": "^4.21.2",
-    "http-proxy-middleware": "catalog:",
     "semver": "catalog:"
   },
   "devDependencies": {
     "@nx/cypress": "workspace:*",
+    "@nx/module-federation": "workspace:*",
     "@nx/playwright": "workspace:*",
+    "@nx/rollup": "workspace:*",
     "@nx/rsbuild": "workspace:*",
     "@nx/vite": "workspace:*",
     "@nx/vitest": "workspace:*",
     "@nx/webpack": "workspace:*",
     "@nx/storybook": "workspace:*",
+    "express": "^4.21.2",
+    "http-proxy-middleware": "catalog:",
     "nx": "workspace:*"
   },
   "optionalDependencies": {

--- a/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
+++ b/packages/react/src/executors/module-federation-dev-server/module-federation-dev-server.impl.ts
@@ -4,19 +4,27 @@ import {
   createAsyncIterable,
 } from '@nx/devkit/internal';
 import { getProjectSourceRoot } from '@nx/js/internal';
-import { startRemoteIterators } from '@nx/module-federation/internal';
 import { fileServerExecutor, waitForPortOpen } from '@nx/web/internal';
-import { devServerExecutor } from '@nx/webpack';
 import { existsSync } from 'fs';
 import { extname, join } from 'path';
 import { normalizeOptions, startRemotes } from './lib';
 import { ModuleFederationDevServerOptions } from './schema';
+import { assertPackageIsInstalled } from '../../utils/assert-package';
 import { warnReactMfDevServerExecutorDeprecation } from '../../utils/module-federation-deprecation';
+
+const executorName = '@nx/react:module-federation-dev-server';
 
 export default async function* moduleFederationDevServer(
   schema: ModuleFederationDevServerOptions,
   context: ExecutorContext
 ): AsyncIterableIterator<{ success: boolean; baseUrl?: string }> {
+  assertPackageIsInstalled('@nx/module-federation', executorName);
+  assertPackageIsInstalled('@nx/webpack', executorName);
+  const { startRemoteIterators } = await import(
+    '@nx/module-federation/internal'
+  );
+  const { devServerExecutor } = await import('@nx/webpack');
+
   warnReactMfDevServerExecutorDeprecation();
   const options = normalizeOptions(schema);
   const currIter = options.static

--- a/packages/react/src/executors/module-federation-ssr-dev-server/module-federation-ssr-dev-server.impl.ts
+++ b/packages/react/src/executors/module-federation-ssr-dev-server/module-federation-ssr-dev-server.impl.ts
@@ -4,19 +4,27 @@ import {
   createAsyncIterable,
 } from '@nx/devkit/internal';
 import { getProjectSourceRoot } from '@nx/js/internal';
-import { startRemoteIterators } from '@nx/module-federation/internal';
 import { waitForPortOpen } from '@nx/web/internal';
-import { ssrDevServerExecutor } from '@nx/webpack/internal';
 import { existsSync } from 'fs';
 import { extname, join } from 'path';
 import { normalizeOptions, startRemotes } from './lib';
 import { ModuleFederationSsrDevServerOptions } from './schema';
+import { assertPackageIsInstalled } from '../../utils/assert-package';
 import { warnReactMfSsrDevServerExecutorDeprecation } from '../../utils/module-federation-deprecation';
+
+const executorName = '@nx/react:module-federation-ssr-dev-server';
 
 export default async function* moduleFederationSsrDevServer(
   ssrDevServerOptions: ModuleFederationSsrDevServerOptions,
   context: ExecutorContext
 ) {
+  assertPackageIsInstalled('@nx/module-federation', executorName);
+  assertPackageIsInstalled('@nx/webpack', executorName);
+  const { startRemoteIterators } = await import(
+    '@nx/module-federation/internal'
+  );
+  const { ssrDevServerExecutor } = await import('@nx/webpack/internal');
+
   warnReactMfSsrDevServerExecutorDeprecation();
   const options = normalizeOptions(ssrDevServerOptions);
   // TODO(JamesHenry): remove type assertion once the nx repo is updated to use https://github.com/nrwl/nx/pull/33095

--- a/packages/react/src/executors/module-federation-static-server/module-federation-static-server.impl.ts
+++ b/packages/react/src/executors/module-federation-static-server/module-federation-static-server.impl.ts
@@ -10,14 +10,9 @@ import {
   workspaceRoot,
 } from '@nx/devkit';
 import { getProjectSourceRoot } from '@nx/js/internal';
-import {
-  buildStaticRemotes,
-  getModuleFederationConfig,
-  getRemotes,
-  parseStaticRemotesConfig,
-  StaticRemotesConfig,
-} from '@nx/module-federation/internal';
+import type { StaticRemotesConfig } from '@nx/module-federation/internal';
 import { fileServerExecutor, waitForPortOpen } from '@nx/web/internal';
+import { assertPackageIsInstalled } from '../../utils/assert-package';
 import { warnReactMfStaticServerExecutorDeprecation } from '../../utils/module-federation-deprecation';
 import type { WebpackExecutorOptions } from '@nx/webpack';
 import { fork } from 'child_process';
@@ -245,6 +240,17 @@ export default async function* moduleFederationStaticServer(
   schema: ModuleFederationStaticServerSchema,
   context: ExecutorContext
 ) {
+  const executorName = '@nx/react:module-federation-static-server';
+  assertPackageIsInstalled('@nx/module-federation', executorName);
+  assertPackageIsInstalled('express', executorName);
+  assertPackageIsInstalled('http-proxy-middleware', executorName);
+  const {
+    buildStaticRemotes,
+    getModuleFederationConfig,
+    getRemotes,
+    parseStaticRemotesConfig,
+  } = await import('@nx/module-federation/internal');
+
   warnReactMfStaticServerExecutorDeprecation();
   // Force Node to resolve to look for the nx binary that is inside node_modules
   const nxBin = require.resolve('nx/bin/nx');

--- a/packages/react/src/generators/host/host.ts
+++ b/packages/react/src/generators/host/host.ts
@@ -31,6 +31,8 @@ import { addMfEnvToTargetDefaultInputs } from '../../utils/add-mf-env-to-inputs'
 import { isValidVariable } from '@nx/js';
 import { isUsingTsSolutionSetup } from '@nx/js/internal';
 import {
+  expressVersion,
+  httpProxyMiddlewareVersion,
   moduleFederationEnhancedVersion,
   nxVersion,
 } from '../../utils/versions';
@@ -181,6 +183,14 @@ export async function hostGenerator(
     {
       '@nx/web': nxVersion,
       '@nx/module-federation': nxVersion,
+      // The webpack path also generates a `serve-static` target running the
+      // `module-federation-static-server` executor, which proxies via express.
+      ...(options.bundler !== 'rspack'
+        ? {
+            express: expressVersion,
+            'http-proxy-middleware': httpProxyMiddlewareVersion,
+          }
+        : {}),
     },
     undefined,
     true

--- a/packages/react/src/generators/remote/lib/setup-tspath-for-remote.ts
+++ b/packages/react/src/generators/remote/lib/setup-tspath-for-remote.ts
@@ -1,11 +1,18 @@
 import type { Tree } from '@nx/devkit';
-import { joinPathFragments, readProjectConfiguration } from '@nx/devkit';
+import {
+  ensurePackage,
+  joinPathFragments,
+  readProjectConfiguration,
+} from '@nx/devkit';
 import { addTsConfigPath } from '@nx/js';
 import { maybeJs } from '../../../utils/maybe-js';
 import { NormalizedSchema } from '../../application/schema';
-import { normalizeProjectName } from '@nx/module-federation';
+import { nxVersion } from '../../../utils/versions';
 
 export function setupTspathForRemote(tree: Tree, options: NormalizedSchema) {
+  const { normalizeProjectName } = ensurePackage<
+    typeof import('@nx/module-federation')
+  >('@nx/module-federation', nxVersion);
   const project = readProjectConfiguration(tree, options.projectName);
 
   const exportPath = maybeJs(options, './src/remote-entry.ts');

--- a/packages/react/src/generators/remote/remote.ts
+++ b/packages/react/src/generators/remote/remote.ts
@@ -26,6 +26,8 @@ import { normalizeRemoteName } from '../../utils/normalize-remote';
 import { maybeJs } from '../../utils/maybe-js';
 import { warnReactRemoteGeneratorDeprecation } from '../../utils/module-federation-deprecation';
 import {
+  expressVersion,
+  httpProxyMiddlewareVersion,
   moduleFederationEnhancedVersion,
   nxVersion,
 } from '../../utils/versions';
@@ -289,6 +291,14 @@ export async function remoteGenerator(host: Tree, schema: Schema) {
       '@module-federation/enhanced': moduleFederationEnhancedVersion,
       '@nx/web': nxVersion,
       '@nx/module-federation': nxVersion,
+      // The webpack path also generates a `serve-static` target running the
+      // `module-federation-static-server` executor, which proxies via express.
+      ...(options.bundler !== 'rspack'
+        ? {
+            express: expressVersion,
+            'http-proxy-middleware': httpProxyMiddlewareVersion,
+          }
+        : {}),
     },
     undefined,
     true

--- a/packages/react/src/migrations/update-23-2-0/add-optional-module-federation-packages.md
+++ b/packages/react/src/migrations/update-23-2-0/add-optional-module-federation-packages.md
@@ -1,0 +1,37 @@
+#### Add Optional Module Federation Packages
+
+Adds `@nx/module-federation`, `express`, and `http-proxy-middleware` to the workspace when existing targets require them.
+
+These packages are no longer direct dependencies of `@nx/react`; they are now optional peer dependencies, so installing `@nx/react` no longer pulls the Module Federation toolchain into workspaces that never use it. This migration backfills them for workspaces that already use Module Federation so those builds keep working after upgrading. Packages that are already present are left untouched.
+
+A package is added only when a matching target exists:
+
+- `@nx/module-federation`: an `@nx/react:module-federation-dev-server`, `@nx/react:module-federation-ssr-dev-server`, or `@nx/react:module-federation-static-server` target, or a project with a `module-federation.config.{js,ts}` file (covers remotes whose host lives in another workspace).
+- `express` and `http-proxy-middleware`: an `@nx/react:module-federation-static-server` target, which proxies the static remotes.
+
+Targets that inherit their executor from an `nx.json` `targetDefaults` entry are detected too.
+
+#### Examples
+
+For a workspace with an `@nx/react:module-federation-dev-server` serve target, the migration adds the Module Federation packages to `devDependencies`.
+
+##### Before
+
+```jsonc title="package.json"
+{
+  "devDependencies": {
+    "@nx/react": "23.1.0",
+  },
+}
+```
+
+##### After
+
+```jsonc title="package.json"
+{
+  "devDependencies": {
+    "@nx/module-federation": "23.2.0",
+    "@nx/react": "23.1.0",
+  },
+}
+```

--- a/packages/react/src/migrations/update-23-2-0/add-optional-module-federation-packages.spec.ts
+++ b/packages/react/src/migrations/update-23-2-0/add-optional-module-federation-packages.spec.ts
@@ -1,0 +1,121 @@
+import {
+  addProjectConfiguration,
+  readJson,
+  updateJson,
+  updateNxJson,
+  type Tree,
+} from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import addOptionalModuleFederationPackages from './add-optional-module-federation-packages';
+
+describe('add-optional-module-federation-packages migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+    updateJson(tree, 'package.json', (json) => {
+      json.devDependencies = { '@nx/react': '23.1.0' };
+      return json;
+    });
+  });
+
+  it('should not add any package when nothing requires them', async () => {
+    addProjectConfiguration(tree, 'app1', {
+      root: 'apps/app1',
+      targets: { build: { executor: '@nx/vite:build' } },
+    });
+
+    await addOptionalModuleFederationPackages(tree);
+
+    expect(readJson(tree, 'package.json').devDependencies).toEqual({
+      '@nx/react': '23.1.0',
+    });
+  });
+
+  it('should add @nx/module-federation for a module federation dev server target', async () => {
+    addProjectConfiguration(tree, 'app1', {
+      root: 'apps/app1',
+      targets: {
+        serve: { executor: '@nx/react:module-federation-dev-server' },
+      },
+    });
+
+    await addOptionalModuleFederationPackages(tree);
+
+    const { devDependencies } = readJson(tree, 'package.json');
+    expect(devDependencies['@nx/module-federation']).toBeDefined();
+    expect(devDependencies['express']).toBeUndefined();
+  });
+
+  it('should add express and http-proxy-middleware for a static server target', async () => {
+    addProjectConfiguration(tree, 'app1', {
+      root: 'apps/app1',
+      targets: {
+        'serve-static': {
+          executor: '@nx/react:module-federation-static-server',
+        },
+      },
+    });
+
+    await addOptionalModuleFederationPackages(tree);
+
+    const { devDependencies } = readJson(tree, 'package.json');
+    expect(devDependencies['@nx/module-federation']).toBeDefined();
+    expect(devDependencies['express']).toBeDefined();
+    expect(devDependencies['http-proxy-middleware']).toBeDefined();
+  });
+
+  it('should add @nx/module-federation for a project with a module federation config file', async () => {
+    addProjectConfiguration(tree, 'remote1', {
+      root: 'apps/remote1',
+      targets: { serve: { executor: '@nx/webpack:dev-server' } },
+    });
+    tree.write(
+      'apps/remote1/module-federation.config.ts',
+      'export default {};'
+    );
+
+    await addOptionalModuleFederationPackages(tree);
+
+    expect(
+      readJson(tree, 'package.json').devDependencies['@nx/module-federation']
+    ).toBeDefined();
+  });
+
+  it('should detect executors inherited from targetDefaults', async () => {
+    addProjectConfiguration(tree, 'app1', {
+      root: 'apps/app1',
+      targets: { serve: {} },
+    });
+    updateNxJson(tree, {
+      targetDefaults: {
+        serve: { executor: '@nx/react:module-federation-dev-server' },
+      },
+    });
+
+    await addOptionalModuleFederationPackages(tree);
+
+    expect(
+      readJson(tree, 'package.json').devDependencies['@nx/module-federation']
+    ).toBeDefined();
+  });
+
+  it('should leave an already installed package untouched', async () => {
+    updateJson(tree, 'package.json', (json) => {
+      json.devDependencies['@nx/module-federation'] = '23.0.0';
+      return json;
+    });
+    addProjectConfiguration(tree, 'app1', {
+      root: 'apps/app1',
+      targets: {
+        serve: { executor: '@nx/react:module-federation-dev-server' },
+      },
+    });
+
+    await addOptionalModuleFederationPackages(tree);
+
+    expect(
+      readJson(tree, 'package.json').devDependencies['@nx/module-federation']
+    ).toBe('23.0.0');
+  });
+});

--- a/packages/react/src/migrations/update-23-2-0/add-optional-module-federation-packages.ts
+++ b/packages/react/src/migrations/update-23-2-0/add-optional-module-federation-packages.ts
@@ -1,0 +1,92 @@
+import {
+  addDependenciesToPackageJson,
+  getProjects,
+  joinPathFragments,
+  type NxJsonConfiguration,
+  readNxJson,
+  type Tree,
+} from '@nx/devkit';
+import {
+  expressVersion,
+  httpProxyMiddlewareVersion,
+  nxVersion,
+} from '../../utils/versions';
+
+const moduleFederationExecutors = new Set([
+  '@nx/react:module-federation-dev-server',
+  '@nx/react:module-federation-ssr-dev-server',
+  '@nx/react:module-federation-static-server',
+]);
+const staticServerExecutor = '@nx/react:module-federation-static-server';
+
+function collectExecutors(
+  targetDefaults: NxJsonConfiguration['targetDefaults']
+): string[] {
+  // targetDefaults are keyed by target name or executor, and a default can set
+  // an executor that an empty project target inherits, so scan the keys and any
+  // executor on the default (both the object and array forms).
+  const executors: string[] = [];
+  for (const [targetOrExecutor, config] of Object.entries(
+    targetDefaults ?? {}
+  )) {
+    executors.push(targetOrExecutor);
+    for (const entry of Array.isArray(config) ? config : [config]) {
+      if (entry.executor != null) {
+        executors.push(entry.executor);
+      }
+    }
+  }
+
+  return executors;
+}
+
+export default async function addOptionalModuleFederationPackages(tree: Tree) {
+  const projects = getProjects(tree);
+  const nxJson = readNxJson(tree);
+  let needsModuleFederation = false;
+  let needsStaticServer = false;
+
+  for (const [, project] of projects) {
+    for (const target of Object.values(project.targets ?? {})) {
+      needsModuleFederation ||= moduleFederationExecutors.has(target.executor);
+      needsStaticServer ||= target.executor === staticServerExecutor;
+    }
+
+    // Remotes get a plain dev-server (no Module Federation executor) but still
+    // generate a module-federation.config that requires @nx/module-federation
+    // at build time, so detect them by that config file too. This covers
+    // remotes whose host lives in a different workspace.
+    needsModuleFederation ||=
+      tree.exists(
+        joinPathFragments(project.root, 'module-federation.config.ts')
+      ) ||
+      tree.exists(
+        joinPathFragments(project.root, 'module-federation.config.js')
+      );
+  }
+
+  for (const executor of collectExecutors(nxJson?.targetDefaults)) {
+    needsModuleFederation ||= moduleFederationExecutors.has(executor);
+    needsStaticServer ||= executor === staticServerExecutor;
+  }
+
+  if (!needsModuleFederation && !needsStaticServer) {
+    return;
+  }
+
+  return addDependenciesToPackageJson(
+    tree,
+    {},
+    {
+      ...(needsModuleFederation ? { '@nx/module-federation': nxVersion } : {}),
+      ...(needsStaticServer
+        ? {
+            express: expressVersion,
+            'http-proxy-middleware': httpProxyMiddlewareVersion,
+          }
+        : {}),
+    },
+    undefined,
+    true
+  );
+}

--- a/packages/react/src/migrations/update-23-2-0/add-svgr-webpack-if-used.md
+++ b/packages/react/src/migrations/update-23-2-0/add-svgr-webpack-if-used.md
@@ -1,0 +1,28 @@
+#### Add `@svgr/webpack` If Used
+
+Adds `@svgr/webpack` to the workspace when a webpack config references it.
+
+`@svgr/webpack` is no longer a dependency of `@nx/react`, so workspaces whose webpack configs resolve it - which is what the Nx 22 `add-svgr-to-webpack-config` migration inlined - must declare it themselves. This migration backfills it for those workspaces. Configs referenced by executor targets are checked, as well as the conventional config file names at each project root. Workspaces that already have `@svgr/webpack` are left untouched.
+
+#### Examples
+
+##### Before
+
+```jsonc title="package.json"
+{
+  "devDependencies": {
+    "@nx/react": "23.1.0",
+  },
+}
+```
+
+##### After
+
+```jsonc title="package.json"
+{
+  "devDependencies": {
+    "@nx/react": "23.1.0",
+    "@svgr/webpack": "^8.0.1",
+  },
+}
+```

--- a/packages/react/src/migrations/update-23-2-0/add-svgr-webpack-if-used.spec.ts
+++ b/packages/react/src/migrations/update-23-2-0/add-svgr-webpack-if-used.spec.ts
@@ -1,0 +1,123 @@
+import {
+  addProjectConfiguration,
+  readJson,
+  updateJson,
+  type Tree,
+} from '@nx/devkit';
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import addSvgrWebpackIfUsed from './add-svgr-webpack-if-used';
+
+describe('add-svgr-webpack-if-used migration', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+    updateJson(tree, 'package.json', (json) => {
+      json.devDependencies = { '@nx/react': '23.1.0' };
+      return json;
+    });
+  });
+
+  it('should not add @svgr/webpack when no webpack config references it', async () => {
+    addProjectConfiguration(tree, 'app1', {
+      root: 'apps/app1',
+      targets: {
+        build: {
+          executor: '@nx/webpack:webpack',
+          options: { webpackConfig: 'apps/app1/webpack.config.js' },
+        },
+      },
+    });
+    tree.write('apps/app1/webpack.config.js', 'module.exports = {};');
+
+    await addSvgrWebpackIfUsed(tree);
+
+    expect(readJson(tree, 'package.json').devDependencies).toEqual({
+      '@nx/react': '23.1.0',
+    });
+  });
+
+  it('should add @svgr/webpack when a webpack config referenced by a target resolves it', async () => {
+    addProjectConfiguration(tree, 'app1', {
+      root: 'apps/app1',
+      targets: {
+        build: {
+          executor: '@nx/webpack:webpack',
+          options: { webpackConfig: 'apps/app1/custom.webpack.js' },
+        },
+      },
+    });
+    tree.write(
+      'apps/app1/custom.webpack.js',
+      `const loader = require.resolve('@svgr/webpack');`
+    );
+
+    await addSvgrWebpackIfUsed(tree);
+
+    expect(
+      readJson(tree, 'package.json').devDependencies['@svgr/webpack']
+    ).toBeDefined();
+  });
+
+  it('should find webpack configs referenced only by a target configuration', async () => {
+    addProjectConfiguration(tree, 'app1', {
+      root: 'apps/app1',
+      targets: {
+        build: {
+          executor: '@nx/webpack:webpack',
+          configurations: {
+            production: { webpackConfig: 'apps/app1/webpack.config.prod.js' },
+          },
+        },
+      },
+    });
+    tree.write(
+      'apps/app1/webpack.config.prod.js',
+      `const loader = require.resolve('@svgr/webpack');`
+    );
+
+    await addSvgrWebpackIfUsed(tree);
+
+    expect(
+      readJson(tree, 'package.json').devDependencies['@svgr/webpack']
+    ).toBeDefined();
+  });
+
+  it('should find a conventional webpack config on a project with no executor targets', async () => {
+    addProjectConfiguration(tree, 'app1', {
+      root: 'apps/app1',
+      targets: {},
+    });
+    tree.write(
+      'apps/app1/webpack.config.js',
+      `const loader = require.resolve('@svgr/webpack');`
+    );
+
+    await addSvgrWebpackIfUsed(tree);
+
+    expect(
+      readJson(tree, 'package.json').devDependencies['@svgr/webpack']
+    ).toBeDefined();
+  });
+
+  it('should leave an already installed @svgr/webpack untouched', async () => {
+    updateJson(tree, 'package.json', (json) => {
+      json.devDependencies['@svgr/webpack'] = '^7.0.0';
+      return json;
+    });
+    addProjectConfiguration(tree, 'app1', {
+      root: 'apps/app1',
+      targets: {},
+    });
+    tree.write(
+      'apps/app1/webpack.config.js',
+      `const loader = require.resolve('@svgr/webpack');`
+    );
+
+    await addSvgrWebpackIfUsed(tree);
+
+    expect(
+      readJson(tree, 'package.json').devDependencies['@svgr/webpack']
+    ).toBe('^7.0.0');
+  });
+});

--- a/packages/react/src/migrations/update-23-2-0/add-svgr-webpack-if-used.ts
+++ b/packages/react/src/migrations/update-23-2-0/add-svgr-webpack-if-used.ts
@@ -1,0 +1,75 @@
+import {
+  addDependenciesToPackageJson,
+  getProjects,
+  joinPathFragments,
+  type Tree,
+} from '@nx/devkit';
+import { svgrWebpackVersion } from '../../utils/versions';
+
+// The Nx 22 `add-svgr-to-webpack-config` migration inlined a `withSvgr` helper
+// that resolves `@svgr/webpack` into user webpack configs, but never added the
+// package to the workspace - it only resolved transitively through `@nx/react`.
+// Now that `@nx/react` no longer depends on it, backfill it where a webpack
+// config actually references it.
+const webpackConfigFileNames = [
+  'webpack.config.js',
+  'webpack.config.ts',
+  'webpack.config.cjs',
+  'webpack.config.mjs',
+  'webpack.config.prod.js',
+  'webpack.config.prod.ts',
+  'webpack.server.config.js',
+  'webpack.server.config.ts',
+];
+
+export default async function addSvgrWebpackIfUsed(tree: Tree) {
+  let needsSvgr = false;
+
+  for (const [, project] of getProjects(tree)) {
+    // Configs referenced by executor targets can live anywhere.
+    for (const target of Object.values(project.targets ?? {})) {
+      for (const options of [
+        target.options,
+        ...Object.values(target.configurations ?? {}),
+      ]) {
+        const webpackConfig = options?.webpackConfig;
+        if (typeof webpackConfig === 'string') {
+          needsSvgr ||= referencesSvgrWebpack(tree, webpackConfig);
+        }
+      }
+    }
+
+    // Inferred setups have no executor options pointing at a config, so also
+    // check the conventional config file names at the project root.
+    for (const fileName of webpackConfigFileNames) {
+      needsSvgr ||= referencesSvgrWebpack(
+        tree,
+        joinPathFragments(project.root, fileName)
+      );
+    }
+
+    if (needsSvgr) {
+      break;
+    }
+  }
+
+  if (!needsSvgr) {
+    return;
+  }
+
+  return addDependenciesToPackageJson(
+    tree,
+    {},
+    { '@svgr/webpack': svgrWebpackVersion },
+    undefined,
+    true
+  );
+}
+
+function referencesSvgrWebpack(tree: Tree, path: string): boolean {
+  if (!tree.exists(path)) {
+    return false;
+  }
+
+  return tree.read(path, 'utf-8').includes('@svgr/webpack');
+}

--- a/packages/react/src/utils/assert-package.spec.ts
+++ b/packages/react/src/utils/assert-package.spec.ts
@@ -1,0 +1,20 @@
+import { assertPackageIsInstalled } from './assert-package';
+
+describe('assertPackageIsInstalled', () => {
+  it('should not throw when the package is resolvable', () => {
+    expect(() =>
+      assertPackageIsInstalled('path', '@nx/react:module-federation-dev-server')
+    ).not.toThrow();
+  });
+
+  it('should throw naming the package and the requiring executor when not installed', () => {
+    expect(() =>
+      assertPackageIsInstalled(
+        '@nx/not-a-real-package',
+        '@nx/react:module-federation-dev-server'
+      )
+    ).toThrow(
+      'The "@nx/not-a-real-package" package is required by "@nx/react:module-federation-dev-server" but is not installed. Please install it and try again.'
+    );
+  });
+});

--- a/packages/react/src/utils/assert-package.ts
+++ b/packages/react/src/utils/assert-package.ts
@@ -1,0 +1,18 @@
+export function assertPackageIsInstalled(
+  packageName: string,
+  requiredBy: string
+): void {
+  try {
+    require.resolve(packageName);
+  } catch (e) {
+    // Only a missing module means "not installed"; surface other resolution
+    // errors (e.g. a malformed package's exports) as-is instead of mislabeling.
+    const code = (e as NodeJS.ErrnoException).code;
+    if (code !== 'MODULE_NOT_FOUND' && code !== 'ERR_MODULE_NOT_FOUND') {
+      throw e;
+    }
+    throw new Error(
+      `The "${packageName}" package is required by "${requiredBy}" but is not installed. Please install it and try again.`
+    );
+  }
+}

--- a/packages/react/src/utils/versions.ts
+++ b/packages/react/src/utils/versions.ts
@@ -50,6 +50,7 @@ export const autoprefixerVersion = '10.4.13';
 // SSR and Module Federation
 export const expressVersion = '^4.21.2';
 export const typesExpressVersion = '^4.17.21';
+export const httpProxyMiddlewareVersion = '^3.0.5';
 export const isbotVersion = '^3.6.5';
 export const corsVersion = '~2.8.5';
 export const typesCorsVersion = '~2.8.12';
@@ -62,3 +63,4 @@ export const sassVersion = '^1.97.2';
 // rollup plugins (if needed)
 export const rollupPluginUrlVersion = '^8.0.2';
 export const svgrRollupVersion = '^8.1.0';
+export const svgrWebpackVersion = '^8.0.1';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2230,7 +2230,7 @@ importers:
         version: 2.3.0
       '@angular/build':
         specifier: catalog:angular-supported-versions
-        version: 22.0.1(b2f3e257ef1870bc9b8c76c3fa3c7ab8)
+        version: 22.0.1(cd4974f6894966ad10e467061487b3b3)
       '@angular/localize':
         specifier: catalog:angular-supported-versions
         version: 22.0.1(@angular/compiler-cli@22.0.1(@angular/compiler@22.0.1)(typescript@6.0.3))(@angular/compiler@22.0.1)
@@ -2333,7 +2333,7 @@ importers:
     dependencies:
       '@angular/build':
         specifier: catalog:angular-supported-versions
-        version: 22.0.1(bd417b232286b9ec70e8c5a3a3501783)
+        version: 22.0.1(9415c92e86a7c8afc4fd3f2e0da3ef58)
       '@angular/compiler-cli':
         specifier: catalog:angular-supported-versions
         version: 22.0.1(@angular/compiler@22.0.1)(typescript@6.0.3)
@@ -3000,13 +3000,13 @@ importers:
       tslib:
         specifier: catalog:typescript
         version: 2.8.1
-      webpack:
-        specifier: 'catalog:'
-        version: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@7.0.3)
     devDependencies:
       nx:
         specifier: workspace:*
         version: link:../nx
+      webpack:
+        specifier: 'catalog:'
+        version: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@7.0.3)
 
   packages/nest:
     dependencies:
@@ -3064,15 +3064,9 @@ importers:
       '@nx/web':
         specifier: workspace:*
         version: link:../web
-      '@nx/webpack':
-        specifier: workspace:*
-        version: link:../webpack
       '@phenomnomnominal/tsquery':
         specifier: catalog:typescript
         version: 6.2.0(typescript@6.0.3)
-      '@svgr/webpack':
-        specifier: 'catalog:'
-        version: 8.1.0(typescript@6.0.3)
       copy-webpack-plugin:
         specifier: ^14.0.0
         version: 14.0.0(webpack@5.105.2)
@@ -3098,6 +3092,9 @@ importers:
       '@nx/playwright':
         specifier: workspace:*
         version: link:../playwright
+      '@nx/webpack':
+        specifier: workspace:*
+        version: link:../webpack
       nx:
         specifier: workspace:*
         version: link:../nx
@@ -3411,6 +3408,9 @@ importers:
 
   packages/react:
     dependencies:
+      '@babel/preset-react':
+        specifier: ^7.22.5
+        version: 7.27.1(@babel/core@7.29.0)
       '@nx/devkit':
         specifier: workspace:*
         version: link:../devkit
@@ -3420,30 +3420,15 @@ importers:
       '@nx/js':
         specifier: workspace:*
         version: link:../js
-      '@nx/module-federation':
-        specifier: workspace:*
-        version: link:../module-federation
-      '@nx/rollup':
-        specifier: workspace:*
-        version: link:../rollup
       '@nx/web':
         specifier: workspace:*
         version: link:../web
       '@phenomnomnominal/tsquery':
         specifier: catalog:typescript
         version: 6.2.0(typescript@6.0.3)
-      '@svgr/webpack':
-        specifier: 'catalog:'
-        version: 8.1.0(typescript@6.0.3)
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
-      express:
-        specifier: ^4.21.2
-        version: 4.21.2
-      http-proxy-middleware:
-        specifier: 'catalog:'
-        version: 3.0.5
       minimatch:
         specifier: ^10.2.5
         version: 10.2.5
@@ -3463,9 +3448,15 @@ importers:
       '@nx/cypress':
         specifier: workspace:*
         version: link:../cypress
+      '@nx/module-federation':
+        specifier: workspace:*
+        version: link:../module-federation
       '@nx/playwright':
         specifier: workspace:*
         version: link:../playwright
+      '@nx/rollup':
+        specifier: workspace:*
+        version: link:../rollup
       '@nx/rsbuild':
         specifier: workspace:*
         version: link:../rsbuild
@@ -3478,6 +3469,12 @@ importers:
       '@nx/webpack':
         specifier: workspace:*
         version: link:../webpack
+      express:
+        specifier: ^4.21.2
+        version: 4.21.2
+      http-proxy-middleware:
+        specifier: 'catalog:'
+        version: 3.0.5
       nx:
         specifier: workspace:*
         version: link:../nx
@@ -3500,9 +3497,6 @@ importers:
       '@nx/react':
         specifier: workspace:*
         version: link:../react
-      '@nx/webpack':
-        specifier: workspace:*
-        version: link:../webpack
       ajv:
         specifier: 'catalog:'
         version: 8.18.0
@@ -3537,6 +3531,9 @@ importers:
         specifier: catalog:typescript
         version: 2.8.1
     devDependencies:
+      '@nx/webpack':
+        specifier: workspace:*
+        version: link:../webpack
       nx:
         specifier: workspace:*
         version: link:../nx
@@ -27531,7 +27528,7 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@angular-devkit/architect': 0.2200.1(chokidar@5.0.0)
-      '@angular-devkit/build-webpack': 0.2200.1(chokidar@5.0.0)(webpack-dev-server@5.2.3(tslib@2.8.1)(webpack-cli@7.0.3)(webpack@5.106.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.13)(webpack-cli@7.0.3)))(webpack@5.106.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.13)(webpack-cli@7.0.3))
+      '@angular-devkit/build-webpack': 0.2200.1(chokidar@5.0.0)(webpack-dev-server@5.2.3(tslib@2.8.1)(webpack-cli@7.0.3(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.105.2))(webpack@5.106.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.13)(webpack-cli@7.0.3)))(webpack@5.106.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.13)(webpack-cli@7.0.3))
       '@angular-devkit/core': 22.0.1(chokidar@5.0.0)
       '@angular/build': 22.0.1(742645c8c883ac2cb2bb7fe388547190)
       '@angular/compiler-cli': 22.0.1(@angular/compiler@22.0.1)(typescript@6.0.3)
@@ -27632,7 +27629,7 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@angular-devkit/build-webpack@0.2200.1(chokidar@5.0.0)(webpack-dev-server@5.2.3(tslib@2.8.1)(webpack-cli@7.0.3)(webpack@5.106.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.13)(webpack-cli@7.0.3)))(webpack@5.106.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.13)(webpack-cli@7.0.3))':
+  '@angular-devkit/build-webpack@0.2200.1(chokidar@5.0.0)(webpack-dev-server@5.2.3(tslib@2.8.1)(webpack-cli@7.0.3(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.105.2))(webpack@5.106.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.13)(webpack-cli@7.0.3)))(webpack@5.106.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.28.0)(lightningcss@1.32.0)(postcss@8.5.13)(webpack-cli@7.0.3))':
     dependencies:
       '@angular-devkit/architect': 0.2200.1(chokidar@5.0.0)
       rxjs: 7.8.2
@@ -27992,10 +27989,10 @@ snapshots:
       - tsx
       - yaml
 
-  '@angular/build@22.0.1(b2f3e257ef1870bc9b8c76c3fa3c7ab8)':
+  '@angular/build@22.0.1(cd4974f6894966ad10e467061487b3b3)':
     dependencies:
       '@ampproject/remapping': 2.3.0
-      '@angular-devkit/architect': 0.2200.1(chokidar@3.6.0)
+      '@angular-devkit/architect': 0.2200.1(chokidar@5.0.0)
       '@angular/compiler': 22.0.1
       '@angular/compiler-cli': 22.0.1(@angular/compiler@22.0.1)(typescript@6.0.3)
       '@babel/core': 7.29.0
@@ -28036,63 +28033,6 @@ snapshots:
       postcss: 8.5.15
       tailwindcss: 4.1.11
       vitest: 4.1.2(@types/node@24.12.2)(jsdom@26.1.0)(vite@8.0.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(less@4.5.1)(sass-embedded@1.97.2)(sass@1.97.3)(terser@5.46.2)(tsx@4.20.5)(yaml@2.9.0))
-    transitivePeerDependencies:
-      - '@types/node'
-      - chokidar
-      - jiti
-      - lightningcss
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
-  '@angular/build@22.0.1(bd417b232286b9ec70e8c5a3a3501783)':
-    dependencies:
-      '@ampproject/remapping': 2.3.0
-      '@angular-devkit/architect': 0.2200.1(chokidar@3.6.0)
-      '@angular/compiler': 22.0.1
-      '@angular/compiler-cli': 22.0.1(@angular/compiler@22.0.1)(typescript@6.0.3)
-      '@babel/core': 7.29.0
-      '@babel/helper-annotate-as-pure': 7.27.3
-      '@babel/helper-split-export-declaration': 7.24.7
-      '@inquirer/confirm': 6.0.12(@types/node@24.12.2)
-      '@vitejs/plugin-basic-ssl': 2.3.0(vite@7.3.2(@types/node@24.12.2)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.97.2)(sass@1.99.0)(terser@5.46.2)(tsx@4.20.5)(yaml@2.9.0))
-      beasties: 0.4.2
-      browserslist: 4.28.1
-      esbuild: 0.28.0
-      https-proxy-agent: 9.0.0
-      jsonc-parser: 3.3.1
-      listr2: 10.2.1
-      magic-string: 0.30.21
-      mrmime: 2.0.1
-      parse5-html-rewriting-stream: 8.0.1
-      picomatch: 4.0.4
-      piscina: 5.1.4
-      rollup: 4.60.2
-      sass: 1.99.0
-      semver: 7.7.4
-      source-map-support: 0.5.21
-      tinyglobby: 0.2.16
-      tslib: 2.8.1
-      typescript: 6.0.3
-      vite: 7.3.2(@types/node@24.12.2)(jiti@2.6.1)(less@4.6.4)(lightningcss@1.32.0)(sass-embedded@1.97.2)(sass@1.99.0)(terser@5.46.2)(tsx@4.20.5)(yaml@2.9.0)
-      watchpack: 2.5.1
-    optionalDependencies:
-      '@angular/core': 22.0.1(@angular/compiler@22.0.1)(rxjs@7.8.2)(zone.js@0.16.2)
-      '@angular/localize': 22.0.1(@angular/compiler-cli@22.0.1(@angular/compiler@22.0.1)(typescript@6.0.3))(@angular/compiler@22.0.1)
-      '@angular/platform-browser': 22.0.1(@angular/common@22.0.1(@angular/core@22.0.1(@angular/compiler@22.0.1)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.1(@angular/compiler@22.0.1)(rxjs@7.8.2)(zone.js@0.16.2))
-      '@angular/platform-server': 22.0.1(@angular/common@22.0.1(@angular/core@22.0.1(@angular/compiler@22.0.1)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/compiler@22.0.1)(@angular/core@22.0.1(@angular/compiler@22.0.1)(rxjs@7.8.2)(zone.js@0.16.2))(@angular/platform-browser@22.0.1(@angular/common@22.0.1(@angular/core@22.0.1(@angular/compiler@22.0.1)(rxjs@7.8.2)(zone.js@0.16.2))(rxjs@7.8.2))(@angular/core@22.0.1(@angular/compiler@22.0.1)(rxjs@7.8.2)(zone.js@0.16.2)))(rxjs@7.8.2)
-      '@angular/ssr': 22.0.1(73ec6ea6b69c2d745740f894b43590ff)
-      istanbul-lib-instrument: 6.0.3
-      less: 4.6.4
-      lmdb: 3.5.4
-      ng-packagr: 22.0.0(@angular/compiler-cli@22.0.1(@angular/compiler@22.0.1)(typescript@6.0.3))(tailwindcss@4.1.11)(tslib@2.8.1)(typescript@6.0.3)
-      postcss: 8.5.15
-      tailwindcss: 4.1.11
-      vitest: 4.1.2(@types/node@24.12.2)(jsdom@26.1.0)(vite@8.0.0(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@24.12.2)(esbuild@0.27.3)(jiti@2.6.1)(less@4.6.4)(sass-embedded@1.97.2)(sass@1.99.0)(terser@5.46.2)(tsx@4.20.5)(yaml@2.9.0))
     transitivePeerDependencies:
       - '@types/node'
       - chokidar


### PR DESCRIPTION
## Current Behavior

Installing `@nx/react` pulls `@nx/module-federation`, `express`, `http-proxy-middleware`, `@svgr/webpack` and `@nx/rollup` as direct dependencies. Installing `@nx/next` pulls `@nx/webpack` and `@svgr/webpack`. Workspaces on esbuild, Vite or Rspack never run any of it. `@nx/module-federation` also pins `webpack` exactly while `@nx/webpack` installs a floating range, so workspaces end up with two webpack copies and Module Federation builds fail.

## Expected Behavior

Module Federation packages become optional peers loaded lazily behind an `assertPackageIsInstalled` guard; `@svgr/webpack` is removed outright (SVGR support was removed in v23 and the v22 migrations inlined it to userland); `@nx/module-federation` declares `webpack` as an optional peer so it shares the app's copy. `23.2.0` migrations backfill the Module Federation packages for workspaces that need them, and `@svgr/webpack` for workspaces whose webpack or next configs reference it (the v22 migrations inlined the `require.resolve` without declaring the package). Same shape as #36310 for `@nx/angular`.

## Related Issue(s)

NXC-4688