### PR TITLE
fix(repo): serialize cypress installs and skip the binary when unused

### DIFF
--- a/e2e/angular/src/cypress-component-tests-app.test.ts
+++ b/e2e/angular/src/cypress-component-tests-app.test.ts
@@ -14,13 +14,13 @@ describe('Angular Cypress Component Tests - App', () => {
 
   afterAll(() => cleanupCypressComponentTests());
 
-  it('should test app', () => {
+  it('should test app', async () => {
     const { appName } = setup;
 
     runCLI(
       `generate @nx/angular:cypress-component-configuration --project=${appName} --generate-tests --no-interactive`
     );
-    if (runE2ETests('cypress')) {
+    if (await runE2ETests('cypress')) {
       expect(runCLI(`component-test ${appName}`)).toContain(
         'All specs passed!'
       );

--- a/e2e/angular/src/cypress-component-tests-buildable.test.ts
+++ b/e2e/angular/src/cypress-component-tests-buildable.test.ts
@@ -15,7 +15,7 @@ describe('Angular Cypress Component Tests - Buildable Lib', () => {
 
   afterAll(() => cleanupCypressComponentTests());
 
-  it('should test buildable lib not being used in app', () => {
+  it('should test buildable lib not being used in app', async () => {
     const { appName, buildableLibName } = setup;
 
     expect(() => {
@@ -30,7 +30,7 @@ describe('Angular Cypress Component Tests - Buildable Lib', () => {
     runCLI(
       `generate @nx/angular:cypress-component-configuration --project=${buildableLibName} --generate-tests --build-target=${appName}:build --no-interactive`
     );
-    if (runE2ETests('cypress')) {
+    if (await runE2ETests('cypress')) {
       expect(runCLI(`component-test ${buildableLibName}`)).toContain(
         'All specs passed!'
       );

--- a/e2e/angular/src/cypress-component-tests-implicit-dep.test.ts
+++ b/e2e/angular/src/cypress-component-tests-implicit-dep.test.ts
@@ -25,7 +25,7 @@ describe('Angular Cypress Component Tests - Implicit Dep', () => {
 
   afterAll(() => cleanupCypressComponentTests());
 
-  it('should test lib with implicit dep on buildTarget', () => {
+  it('should test lib with implicit dep on buildTarget', async () => {
     const { projectName, appName, buildableLibName, usedInAppLibName } = setup;
 
     // creates graph like buildableLib -> lib -> app
@@ -35,7 +35,7 @@ describe('Angular Cypress Component Tests - Implicit Dep', () => {
 
     updateBuilableLibTestsToAssertAppStyles(appName, buildableLibName);
 
-    if (runE2ETests('cypress')) {
+    if (await runE2ETests('cypress')) {
       expect(runCLI(`component-test ${buildableLibName}`)).toContain(
         'All specs passed!'
       );

--- a/e2e/angular/src/cypress-component-tests-lib.test.ts
+++ b/e2e/angular/src/cypress-component-tests-lib.test.ts
@@ -14,13 +14,13 @@ describe('Angular Cypress Component Tests - Lib', () => {
 
   afterAll(() => cleanupCypressComponentTests());
 
-  it('should successfully component test lib being used in app', () => {
+  it('should successfully component test lib being used in app', async () => {
     const { usedInAppLibName } = setup;
 
     runCLI(
       `generate @nx/angular:cypress-component-configuration --project=${usedInAppLibName} --generate-tests --no-interactive`
     );
-    if (runE2ETests('cypress')) {
+    if (await runE2ETests('cypress')) {
       expect(runCLI(`component-test ${usedInAppLibName}`)).toContain(
         'All specs passed!'
       );

--- a/e2e/angular/src/cypress-component-tests-zone-projects.test.ts
+++ b/e2e/angular/src/cypress-component-tests-zone-projects.test.ts
@@ -14,26 +14,26 @@ describe('Angular Cypress Component Tests - Zone.js projects', () => {
 
   afterAll(() => cleanupCypressComponentTests());
 
-  it('should successfully run for an app', () => {
+  it('should successfully run for an app', async () => {
     const { appName } = setup;
 
     runCLI(
       `generate @nx/angular:cypress-component-configuration --project=${appName} --generate-tests --no-interactive`
     );
-    if (runE2ETests('cypress')) {
+    if (await runE2ETests('cypress')) {
       expect(runCLI(`component-test ${appName}`)).toContain(
         'All specs passed!'
       );
     }
   }, 300_000);
 
-  it('should successfully run for a lib', () => {
+  it('should successfully run for a lib', async () => {
     const { usedInAppLibName } = setup;
 
     runCLI(
       `generate @nx/angular:cypress-component-configuration --project=${usedInAppLibName} --generate-tests --no-interactive`
     );
-    if (runE2ETests('cypress')) {
+    if (await runE2ETests('cypress')) {
       expect(runCLI(`component-test ${usedInAppLibName}`)).toContain(
         'All specs passed!'
       );

--- a/e2e/angular/src/module-federation-lib.test.ts
+++ b/e2e/angular/src/module-federation-lib.test.ts
@@ -86,7 +86,7 @@ describe('Angular Module Federation - Federated Libraries', () => {
     const buildRemoteOutput = runCLI(`build ${remote}`);
     expect(buildRemoteOutput).toContain('Successfully ran target build');
 
-    if (runE2ETests('cypress')) {
+    if (await runE2ETests('cypress')) {
       const e2eProcess = await runCommandUntil(
         `e2e ${host}-e2e`,
         (output) => output.includes('All specs passed!'),
@@ -177,7 +177,7 @@ describe('Angular Module Federation - Federated Libraries', () => {
     const buildRemoteOutput = runCLI(`build ${remote}`);
     expect(buildRemoteOutput).toContain('Successfully ran target build');
 
-    if (runE2ETests('cypress')) {
+    if (await runE2ETests('cypress')) {
       const e2eProcess = await runCommandUntil(
         `e2e ${host}-e2e`,
         (output) => output.includes('All specs passed!'),

--- a/e2e/angular/src/module-federation-ssr.test.ts
+++ b/e2e/angular/src/module-federation-ssr.test.ts
@@ -89,7 +89,7 @@ test('renders remotes', async ({ page }) => {
   expect(await items.nth(2).innerText()).toContain('${capitalize(remote2)}');
 });`
     );
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       const e2eProcess = await runCommandUntil(
         `e2e ${host}-e2e`,
         (output) =>

--- a/e2e/angular/src/module-federation.rspack.test.ts
+++ b/e2e/angular/src/module-federation.rspack.test.ts
@@ -215,7 +215,7 @@ describe('Angular Module Federation', () => {
       `
     );
 
-    if (runE2ETests('playwright')) {
+    if (await runE2ETests('playwright')) {
       const e2eProcess = await runCommandUntil(
         `e2e ${hostApp}-e2e`,
         (output) => output.includes('Successfully ran target e2e for project'),

--- a/e2e/angular/src/projects-build-and-test.test.ts
+++ b/e2e/angular/src/projects-build-and-test.test.ts
@@ -91,7 +91,7 @@ describe('Angular Projects - Build and Test', () => {
     );
 
     // check e2e tests
-    if (runE2ETests('playwright')) {
+    if (await runE2ETests('playwright')) {
       // app1 was generated with --port=app1Port, so its e2e serves there
       expect(() => runCLI(`e2e ${app1}-e2e`)).not.toThrow();
       expect(await killPort(app1Port)).toBeTruthy();
@@ -153,7 +153,7 @@ describe('Angular Projects - Build and Test', () => {
     expect(componentSource).toBeDefined();
     expect(componentSource.content).not.toContain('ɵcmp');
 
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       expect(() => runCLI(`e2e ${app}-e2e`)).not.toThrow();
       expect(await killPort(port)).toBeTruthy();
     }
@@ -187,7 +187,7 @@ describe('Angular Projects - Build and Test', () => {
       `generate @nx/angular:app ${app} --port=${port} --e2eTestRunner=playwright --no-interactive`
     );
 
-    if (runE2ETests('playwright')) {
+    if (await runE2ETests('playwright')) {
       expect(() => runCLI(`e2e ${app}-e2e`)).not.toThrow();
       expect(await killPort(port)).toBeTruthy();
     }

--- a/e2e/cypress/src/cypress-legacy.test.ts
+++ b/e2e/cypress/src/cypress-legacy.test.ts
@@ -31,7 +31,7 @@ describe('Cypress E2E Test runner (legacy)', () => {
         { env: { NX_ADD_PLUGINS: 'false' } }
       );
 
-      if (runE2ETests('cypress')) {
+      if (await runE2ETests('cypress')) {
         const results = runCLI(
           `run-many --target=e2e --parallel=2 --port=cypress-auto --output-style=stream`
         );
@@ -61,7 +61,7 @@ describe('Cypress E2E Test runner (legacy)', () => {
         env: { NX_ADD_PLUGINS: 'false' },
       });
 
-      if (runE2ETests('cypress')) {
+      if (await runE2ETests('cypress')) {
         expect(runCLI(`run ${appName}:component-test`)).toContain(
           'All specs passed!'
         );

--- a/e2e/cypress/src/cypress.test.ts
+++ b/e2e/cypress/src/cypress.test.ts
@@ -93,7 +93,7 @@ describe('env vars', () => {
 });`
       );
 
-      if (runE2ETests('cypress')) {
+      if (await runE2ETests('cypress')) {
         // contains the correct output and works
         const run1 = runCLI(
           `e2e ${myapp}-e2e --config \\'{\\"env\\":{\\"cliArg\\":\\"i am from the cli args\\"}}\\'`
@@ -185,7 +185,7 @@ export default defineConfig({
         `generate @nx/cypress:configuration --project=${appName} --devServerTarget=${appName}:dev --baseUrl=http://localhost:3000 --no-interactive`
       );
 
-      if (runE2ETests('cypress')) {
+      if (await runE2ETests('cypress')) {
         expect(runCLI(`run ${appName}:component-test`)).toContain(
           'All specs passed!'
         );
@@ -214,7 +214,7 @@ export default defineConfig({
         `generate @nx/cypress:e2e --project=${appName} --baseUrl=http://localhost:4200 --no-interactive`
       );
 
-      if (runE2ETests('cypress')) {
+      if (await runE2ETests('cypress')) {
         expect(runCLI(`run ${appName}:component-test`)).toContain(
           'All specs passed!'
         );

--- a/e2e/expo/src/expo-legacy.test.ts
+++ b/e2e/expo/src/expo-legacy.test.ts
@@ -264,7 +264,7 @@ describe('@nx/expo (legacy)', () => {
   });
 
   it('should run e2e for cypress', async () => {
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       const results = runCLI(`e2e ${appName}-e2e`);
       expect(results).toContain('Successfully ran target e2e');
 
@@ -278,7 +278,7 @@ describe('@nx/expo (legacy)', () => {
   });
 
   it('should run e2e for cypress with configuration ci', async () => {
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       const results = runCLI(`e2e ${appName}-e2e --configuration=ci`);
       expect(results).toContain('Successfully ran target e2e');
 
@@ -300,7 +300,7 @@ describe('@nx/expo (legacy)', () => {
     // Build first to speed up static-serve
     runCLI(`export ${appName2}`);
 
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       const results = runCLI(`e2e ${appName2}-e2e`, { verbose: true });
       expect(results).toContain('Successfully ran target e2e');
 

--- a/e2e/expo/src/expo.test.ts
+++ b/e2e/expo/src/expo.test.ts
@@ -191,7 +191,7 @@ describe('@nx/expo', () => {
   });
 
   it('should run e2e for cypress', async () => {
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       const results = runCLI(`e2e ${appName}-e2e`);
       expect(results).toContain('Successfully ran target e2e');
 

--- a/e2e/jest.preset.e2e.js
+++ b/e2e/jest.preset.e2e.js
@@ -6,4 +6,12 @@ delete preset.moduleNameMapper;
 
 module.exports = {
   ...preset,
+  // The root preset's timeout is meant for unit tests. Creating a workspace on
+  // its own takes longer than that, and because Jest cannot interrupt
+  // synchronous work, a hook that has already overrun only fails once it awaits
+  // something - which made waiting on a lock, or any other await, look like the
+  // culprit. This is high enough to cover setting a workspace up and low enough
+  // to still fail a suite that has genuinely hung; suites that need longer set
+  // their own.
+  testTimeout: 120_000,
 };

--- a/e2e/module-federation/src/rsbuild.test.ts
+++ b/e2e/module-federation/src/rsbuild.test.ts
@@ -35,7 +35,7 @@ describe('@nx/module-federation v2 - Rsbuild', () => {
       `apps/${provider}/package.json`
     );
 
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       const serve = await runCommandUntil(
         `serve ${provider}`,
         (output) => output.includes('Local:'),
@@ -63,7 +63,7 @@ describe('@nx/module-federation v2 - Rsbuild', () => {
       `apps/${provider}/src/App.tsx`
     );
 
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       let consumerReady = false;
       let providerReady = false;
       const serve = await runCommandUntil(

--- a/e2e/module-federation/src/rspack.test.ts
+++ b/e2e/module-federation/src/rspack.test.ts
@@ -35,7 +35,7 @@ describe('@nx/module-federation v2 - Rspack', () => {
       `apps/${provider}/package.json`
     );
 
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       const serve = await runCommandUntil(
         `serve ${provider}`,
         (output) =>
@@ -65,7 +65,7 @@ describe('@nx/module-federation v2 - Rspack', () => {
       `apps/${provider}/src/App.tsx`
     );
 
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       // `nx serve <provider>` brings the consumer up via provider.serve.dependsOn.
       // Both apps compile separately; wait for both compile-success messages.
       let compileCount = 0;

--- a/e2e/module-federation/src/vite.test.ts
+++ b/e2e/module-federation/src/vite.test.ts
@@ -36,7 +36,7 @@ describe('@nx/module-federation v2 - Vite', () => {
       `apps/${provider}/tsconfig.json`
     );
 
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       const serve = await runCommandUntil(
         `serve ${provider}`,
         (output) => output.includes('Local:') || output.includes('ready in'),
@@ -66,7 +66,7 @@ describe('@nx/module-federation v2 - Vite', () => {
       `apps/${provider}/src/App.tsx`
     );
 
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       // `nx serve <provider>` brings the consumer up via provider.serve.dependsOn.
       // Wait for both Vite "Local:" lines (one per app) to confirm the chain
       // is fully up before killing.

--- a/e2e/next/src/next-appdir.test.ts
+++ b/e2e/next/src/next-appdir.test.ts
@@ -72,7 +72,7 @@ describe('Next.js App Router', () => {
     const lintResults = runCLI(`lint ${appName}`);
     expect(lintResults).toContain('Successfully ran target lint');
 
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       const e2eResults = runCLI(
         `e2e ${appName}-e2e --configuration=production`
       );

--- a/e2e/next/src/next-component-tests.test.ts
+++ b/e2e/next/src/next-component-tests.test.ts
@@ -20,22 +20,22 @@ describe('NextJs Component Testing', () => {
   afterAll(() => cleanupProject());
 
   // TODO(nicholas): this is erroring out due to useState error when serving the app in CI. It passes for me locally.
-  xit('should test a NextJs app', () => {
+  xit('should test a NextJs app', async () => {
     const appName = uniq('next-app');
     createAppWithCt(appName);
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       expect(runCLI(`component-test ${appName}`)).toContain(
         'All specs passed!'
       );
     }
   });
 
-  it('should test a NextJs app using babel compiler', () => {
+  it('should test a NextJs app using babel compiler', async () => {
     const appName = uniq('next-app');
     createAppWithCt(appName);
     //  add bable compiler to app
     addBabelSupport(`apps/${appName}`);
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       expect(runCLI(`component-test ${appName}`)).toContain(
         'All specs passed!'
       );
@@ -47,7 +47,7 @@ describe('NextJs Component Testing', () => {
     createLibWithCt(libName, false);
     //  add bable compiler to lib
     addBabelSupport(`libs/${libName}`);
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       expect(runCLI(`component-test ${libName}`)).toContain(
         'All specs passed!'
       );
@@ -57,7 +57,7 @@ describe('NextJs Component Testing', () => {
   it('should test a NextJs lib', async () => {
     const libName = uniq('next-lib');
     createLibWithCt(libName, false);
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       expect(runCLI(`component-test ${libName}`)).toContain(
         'All specs passed!'
       );
@@ -67,7 +67,7 @@ describe('NextJs Component Testing', () => {
   it('should test a NextJs buildable lib', async () => {
     const buildableLibName = uniq('next-buildable-lib');
     createLibWithCt(buildableLibName, true);
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       expect(runCLI(`component-test ${buildableLibName}`)).toContain(
         'All specs passed!'
       );
@@ -77,7 +77,7 @@ describe('NextJs Component Testing', () => {
   it('should test a NextJs server component that uses router', async () => {
     const lib = uniq('next-lib');
     createLibWithCtCypress(lib);
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       expect(runCLI(`component-test ${lib}`)).toContain('All specs passed!');
     }
   }, 600_000);

--- a/e2e/next/src/next-e2e-and-snapshots.test.ts
+++ b/e2e/next/src/next-e2e-and-snapshots.test.ts
@@ -36,7 +36,7 @@ describe('Next.js Applications - E2E and Snapshots', () => {
       `generate @nx/next:app ${appName} --no-interactive --style=css --linter=eslint --unitTestRunner=jest`
     );
 
-    if (runE2ETests('playwright')) {
+    if (await runE2ETests('playwright')) {
       const e2eResults = runCLI(`e2e-ci ${appName}-e2e --verbose`, {
         verbose: true,
         env: {

--- a/e2e/next/src/next-playwright.test.ts
+++ b/e2e/next/src/next-playwright.test.ts
@@ -24,8 +24,8 @@ describe('Next Playwright e2e tests', () => {
 
   afterAll(() => cleanupProject());
 
-  it('should execute e2e tests using playwright', () => {
-    if (runE2ETests('playwright')) {
+  it('should execute e2e tests using playwright', async () => {
+    if (await runE2ETests('playwright')) {
       const result = runCLI(`e2e ${appName}-e2e --verbose`);
       expect(result).toContain(
         `Successfully ran target e2e for project ${appName}-e2e`
@@ -33,7 +33,7 @@ describe('Next Playwright e2e tests', () => {
     }
   });
 
-  it('should execute e2e tests using playwright with a library used in the app', () => {
+  it('should execute e2e tests using playwright with a library used in the app', async () => {
     runCLI(
       `generate @nx/js:library ${usedInAppLibName} --unitTestRunner=none --importPath=@mylib --no-interactive`
     );
@@ -53,7 +53,7 @@ describe('Next Playwright e2e tests', () => {
       `
     );
 
-    if (runE2ETests('playwright')) {
+    if (await runE2ETests('playwright')) {
       const result = runCLI(`e2e ${appName}-e2e --verbose`);
       expect(result).toContain(
         `Successfully ran target e2e for project ${appName}-e2e`

--- a/e2e/next/src/utils.ts
+++ b/e2e/next/src/utils.ts
@@ -49,7 +49,7 @@ export async function checkApp(
     expect(packageJson.dependencies.next).toBeDefined();
   }
 
-  if (opts.checkE2E && runE2ETests()) {
+  if (opts.checkE2E && (await runE2ETests())) {
     const e2eResults = runCLI(
       `e2e ${appName}-e2e --no-watch --configuration=production`
     );

--- a/e2e/nx/src/workspace-legacy.test.ts
+++ b/e2e/nx/src/workspace-legacy.test.ts
@@ -53,7 +53,7 @@ describe('@nx/workspace:convert-to-monorepo', () => {
     expect(() => runCLI(`test ${reactApp}`)).not.toThrow();
     expect(() => runCLI(`lint ${reactApp}`)).not.toThrow();
     expect(() => runCLI(`lint e2e`)).not.toThrow();
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       expect(() => runCLI(`e2e e2e`)).not.toThrow();
     }
   });

--- a/e2e/nx/src/workspace.test.ts
+++ b/e2e/nx/src/workspace.test.ts
@@ -190,7 +190,7 @@ describe('@nx/workspace:convert-to-monorepo', () => {
     expect(() => runCLI(`test ${reactApp}`)).not.toThrow();
     expect(() => runCLI(`lint ${reactApp}`)).not.toThrow();
     expect(() => runCLI(`lint e2e`)).not.toThrow();
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       expect(() => runCLI(`e2e e2e`)).not.toThrow();
     }
   });

--- a/e2e/playwright/src/playwright.test.ts
+++ b/e2e/playwright/src/playwright.test.ts
@@ -30,7 +30,7 @@ describe('Playwright E2E Test runner', () => {
     'should test and lint example app',
 
     async () => {
-      ensurePlaywrightBrowsersInstallation();
+      await ensurePlaywrightBrowsersInstallation();
 
       const port = await reservePort();
       runCLI(
@@ -52,7 +52,7 @@ describe('Playwright E2E Test runner', () => {
   it(
     'should test and lint example app with js',
     async () => {
-      ensurePlaywrightBrowsersInstallation();
+      await ensurePlaywrightBrowsersInstallation();
 
       const port = await reservePort();
       runCLI(
@@ -95,7 +95,7 @@ describe('Playwright E2E Test Runner - legacy', () => {
     'should test and lint example app',
 
     async () => {
-      ensurePlaywrightBrowsersInstallation();
+      await ensurePlaywrightBrowsersInstallation();
 
       const pmc = getPackageManagerCommand();
       const port = await reservePort();
@@ -119,7 +119,7 @@ describe('Playwright E2E Test Runner - legacy', () => {
   it(
     'should test and lint example app with js',
     async () => {
-      ensurePlaywrightBrowsersInstallation();
+      await ensurePlaywrightBrowsersInstallation();
 
       const pmc = getPackageManagerCommand();
       const port = await reservePort();

--- a/e2e/playwright/src/playwright.test.ts
+++ b/e2e/playwright/src/playwright.test.ts
@@ -30,7 +30,7 @@ describe('Playwright E2E Test runner', () => {
     'should test and lint example app',
 
     async () => {
-      await ensurePlaywrightBrowsersInstallation();
+      ensurePlaywrightBrowsersInstallation();
 
       const port = await reservePort();
       runCLI(
@@ -52,7 +52,7 @@ describe('Playwright E2E Test runner', () => {
   it(
     'should test and lint example app with js',
     async () => {
-      await ensurePlaywrightBrowsersInstallation();
+      ensurePlaywrightBrowsersInstallation();
 
       const port = await reservePort();
       runCLI(
@@ -95,7 +95,7 @@ describe('Playwright E2E Test Runner - legacy', () => {
     'should test and lint example app',
 
     async () => {
-      await ensurePlaywrightBrowsersInstallation();
+      ensurePlaywrightBrowsersInstallation();
 
       const pmc = getPackageManagerCommand();
       const port = await reservePort();
@@ -119,7 +119,7 @@ describe('Playwright E2E Test Runner - legacy', () => {
   it(
     'should test and lint example app with js',
     async () => {
-      await ensurePlaywrightBrowsersInstallation();
+      ensurePlaywrightBrowsersInstallation();
 
       const pmc = getPackageManagerCommand();
       const port = await reservePort();

--- a/e2e/react-native/src/react-native-legacy.test.ts
+++ b/e2e/react-native/src/react-native-legacy.test.ts
@@ -105,7 +105,7 @@ describe('@nx/react-native (legacy)', () => {
   });
 
   it('should run e2e for cypress', async () => {
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       expect(() => runCLI(`e2e ${appName}-e2e`)).not.toThrow();
 
       expect(() =>
@@ -322,7 +322,7 @@ describe('@nx/react-native (legacy)', () => {
       `generate @nx/react-native:application ${appName2} --directory=apps/${appName2} --bundler=vite --e2eTestRunner=playwright --install=false --no-interactive --unitTestRunner=jest --linter=eslint`
     );
     expect(() => runCLI(`build ${appName2}`)).not.toThrow();
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       expect(() => runCLI(`e2e ${appName2}-e2e`)).not.toThrow();
     }
 

--- a/e2e/react-native/src/react-native.test.ts
+++ b/e2e/react-native/src/react-native.test.ts
@@ -145,7 +145,7 @@ describe('@nx/react-native', () => {
   });
 
   it('should run e2e for cypress', async () => {
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       expect(() => runCLI(`e2e ${appName}-e2e`)).not.toThrow();
 
       expect(() =>
@@ -203,7 +203,7 @@ describe('@nx/react-native', () => {
       `generate @nx/react:application ${appName2} --directory=apps/${appName2} --bundler=vite --e2eTestRunner=playwright --install=false --no-interactive --unitTestRunner=jest --linter=eslint`
     );
     expect(() => runCLI(`build ${appName2}`)).not.toThrow();
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       expect(() => runCLI(`e2e ${appName2}-e2e`)).not.toThrow();
       // port and process cleanup
       try {

--- a/e2e/react/src/cypress-component-tests.test.ts
+++ b/e2e/react/src/cypress-component-tests.test.ts
@@ -24,7 +24,7 @@ describe('React Cypress Component Tests', () => {
       name: uniq('cy-react'),
       packages: ['@nx/react', '@nx/webpack', '@nx/jest', '@nx/cypress'],
     });
-    ensureCypressInstallation();
+    await ensureCypressInstallation();
 
     runCLI(
       `generate @nx/react:app apps/${appName} --bundler=webpack --no-interactive`
@@ -152,29 +152,29 @@ export default Input;
     delete process.env.NX_ADD_PLUGINS;
   });
 
-  it('should test app', () => {
+  it('should test app', async () => {
     runCLI(
       `generate @nx/react:cypress-component-configuration --project=${appName} --generate-tests`
     );
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       expect(runCLI(`component-test ${appName} --no-watch`)).toContain(
         'All specs passed!'
       );
     }
   }, 300_000);
 
-  it('should successfully component test lib being used in app', () => {
+  it('should successfully component test lib being used in app', async () => {
     runCLI(
       `generate @nx/react:cypress-component-configuration --project=${usedInAppLibName} --generate-tests`
     );
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       expect(runCLI(`component-test ${usedInAppLibName} --no-watch`)).toContain(
         'All specs passed!'
       );
     }
   }, 300_000);
 
-  it('should successfully component test lib being used in app using babel compiler', () => {
+  it('should successfully component test lib being used in app using babel compiler', async () => {
     runCLI(
       `generate @nx/react:cypress-component-configuration --project=${usedInAppLibName} --generate-tests`
     );
@@ -185,14 +185,14 @@ export default Input;
         'nxComponentTestingPreset(__filename, {compiler: "babel"})'
       );
     });
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       expect(runCLI(`component-test ${usedInAppLibName} --no-watch`)).toContain(
         'All specs passed!'
       );
     }
   }, 300_000);
 
-  it('should test buildable lib not being used in app', () => {
+  it('should test buildable lib not being used in app', async () => {
     createFile(
       `libs/${buildableLibName}/src/lib/input/input.cy.tsx`,
       `
@@ -205,7 +205,7 @@ describe(Input.name, () => {
     cy.mount(<Input readOnly={false} />)
     cy.get('label').should('have.css', 'color', 'rgb(0, 0, 0)');
   })
-  it('should be read only', () => {
+  it('should be read only', async () => {
     cy.mount(<Input readOnly={true}/>)
     cy.get('input').should('have.attr', 'readonly');
   })
@@ -217,7 +217,7 @@ describe(Input.name, () => {
       `generate @nx/react:cypress-component-configuration --project=${buildableLibName} --generate-tests --build-target=${appName}:build`
     );
 
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       expect(runCLI(`component-test ${buildableLibName} --no-watch`)).toContain(
         'All specs passed!'
       );
@@ -255,7 +255,7 @@ describe(Input.name, () => {
       return config;
     });
 
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       const results = runCLI(`component-test ${appName}`);
       expect(results).toContain('I am from the custom async Webpack config');
       expect(results).toContain('All specs passed!');
@@ -263,7 +263,7 @@ describe(Input.name, () => {
   });
 
   // flaky bc of upstream issue https://github.com/cypress-io/cypress/issues/25913
-  it.skip('should CT vite projects importing other projects', () => {
+  it.skip('should CT vite projects importing other projects', async () => {
     const viteLibName = uniq('vite-lib');
     runCLI(
       `generate @nx/react:lib ${viteLibName} --bundler=vite --no-interactive`
@@ -286,7 +286,7 @@ export default MyComponent;`;
     runCLI(
       `generate @nx/react:cypress-component-configuration --project=${viteLibName} --generate-tests --bundler=vite --build-target=${appName}:build`
     );
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       expect(runCLI(`component-test ${viteLibName}`)).toContain(
         'All specs passed!'
       );

--- a/e2e/react/src/module-federation/core-rspack-basic-host-remote-generation.test.ts
+++ b/e2e/react/src/module-federation/core-rspack-basic-host-remote-generation.test.ts
@@ -114,7 +114,7 @@ describe('React Rspack Module Federation - Basic - Host Remote Generation', () =
 
       await killProcessAndPorts(serveResult.pid, readPort(shell));
 
-      if (runE2ETests()) {
+      if (await runE2ETests()) {
         const e2eResultsSwc = await runCommandUntil(
           `e2e ${shell}-e2e --verbose`,
           (output) => output.includes('All specs passed!')

--- a/e2e/react/src/module-federation/core-rspack-basic-playwright.test.ts
+++ b/e2e/react/src/module-federation/core-rspack-basic-playwright.test.ts
@@ -83,7 +83,7 @@ describe('React Rspack Module Federation - Basic - Playwright', () => {
       `
     );
 
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       const e2eResultsSwc = await runCommandUntil(
         `e2e ${shell}-e2e`,
         (output) => output.includes('Successfully ran target e2e for project'),

--- a/e2e/react/src/module-federation/core-webpack-basic-host-remote-generation.test.ts
+++ b/e2e/react/src/module-federation/core-webpack-basic-host-remote-generation.test.ts
@@ -116,7 +116,7 @@ describe('React Module Federation - Webpack Basic - Host Remote Generation', () 
 
       await killProcessAndPorts(serveResult.pid, readPort(shell));
 
-      if (runE2ETests()) {
+      if (await runE2ETests()) {
         const e2eResultsSwc = await runCommandUntil(
           `e2e ${shell}-e2e --no-watch --verbose`,
           (output) => output.includes('All specs passed!')

--- a/e2e/react/src/module-federation/core-webpack-basic-playwright.test.ts
+++ b/e2e/react/src/module-federation/core-webpack-basic-playwright.test.ts
@@ -86,7 +86,7 @@ describe('React Module Federation - Webpack Basic - Playwright', () => {
       `
     );
 
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       console.log(
         `[core-webpack-basic-playwright] Starting e2e (swc) for ${shell}-e2e`
       );

--- a/e2e/react/src/module-federation/core-webpack-ssr.test.ts
+++ b/e2e/react/src/module-federation/core-webpack-ssr.test.ts
@@ -172,7 +172,7 @@ describe('React Module Federation - Webpack SSR', () => {
         `;
     });
 
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       const hostE2eResults = await runCommandUntil(
         `e2e ${shell}-e2e --no-watch --verbose`,
         (output) => output.includes('All specs passed!'),

--- a/e2e/react/src/module-federation/dynamic-federation.rspack.test.ts
+++ b/e2e/react/src/module-federation/dynamic-federation.rspack.test.ts
@@ -93,7 +93,7 @@ describe('Dynamic Module Federation', () => {
     expect(buildOutput).toContain('Successfully ran target build');
     expect(remoteOutput).toContain('Successfully ran target build');
 
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       // Serve Remote since it is dynamic and won't be started with the host
       const remoteProcess = await runCommandUntil(
         `serve ${remote} --verbose`,

--- a/e2e/react/src/module-federation/dynamic-federation.webpack.test.ts
+++ b/e2e/react/src/module-federation/dynamic-federation.webpack.test.ts
@@ -98,7 +98,7 @@ describe('Dynamic Module Federation', () => {
     expect(buildOutput).toContain('Successfully ran target build');
     expect(remoteOutput).toContain('Successfully ran target build');
 
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       // Serve Remote since it is dynamic and won't be started with the host
       console.log(
         `[dynamic-federation.webpack] Starting serve-static for ${remote} on port ${remotePort}`

--- a/e2e/react/src/module-federation/federate-module.rspack.test.ts
+++ b/e2e/react/src/module-federation/federate-module.rspack.test.ts
@@ -111,7 +111,7 @@ describe('Federate Module', () => {
     expect(buildOutput).toContain('Successfully ran target build');
     expect(remoteOutput).toContain('Successfully ran target build');
 
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       const hostE2eResults = await runCommandUntil(
         `e2e ${host}-e2e --verbose`,
         (output) => output.includes('All specs passed!')
@@ -213,7 +213,7 @@ describe('Federate Module', () => {
     expect(buildOutput).toContain('Successfully ran target build');
     expect(remoteOutput).toContain('Successfully ran target build');
 
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       const hostE2eResults = await runCommandUntil(
         `e2e ${host}-e2e --verbose`,
         (output) => output.includes('All specs passed!')

--- a/e2e/react/src/module-federation/federate-module.webpack.test.ts
+++ b/e2e/react/src/module-federation/federate-module.webpack.test.ts
@@ -111,7 +111,7 @@ describe('Federate Module', () => {
     expect(buildOutput).toContain('Successfully ran target build');
     expect(remoteOutput).toContain('Successfully ran target build');
 
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       const hostE2eResults = await runCommandUntil(
         `e2e ${host}-e2e --no-watch --verbose`,
         (output) => output.includes('All specs passed!'),
@@ -216,7 +216,7 @@ describe('Federate Module', () => {
     expect(buildOutput).toContain('Successfully ran target build');
     expect(remoteOutput).toContain('Successfully ran target build');
 
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       const hostE2eResults = await runCommandUntil(
         `e2e ${host}-e2e --no-watch --verbose`,
         (output) => output.includes('All specs passed!'),

--- a/e2e/react/src/module-federation/independent-deployability.rspack.test.ts
+++ b/e2e/react/src/module-federation/independent-deployability.rspack.test.ts
@@ -129,7 +129,7 @@ describe('Independent Deployability', () => {
     expect(buildOutput).toContain('Successfully ran target build');
     expect(remoteOutput).toContain('Successfully ran target build');
 
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       const hostE2eResults = await runCommandUntil(
         `e2e ${host}-e2e --verbose`,
         (output) => output.includes('All specs passed!'),
@@ -267,7 +267,7 @@ describe('Independent Deployability', () => {
       `
     );
 
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       // test remote e2e
       const remoteE2eResults = await runCommandUntil(
         `e2e ${remote}-e2e --verbose`,
@@ -393,7 +393,7 @@ describe('Independent Deployability', () => {
     expect(buildOutput).toContain('Successfully ran target build');
     expect(remoteOutput).toContain('Successfully ran target build');
 
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       const hostE2eResultsSwc = await runCommandUntil(
         `e2e ${shell}-e2e --verbose`,
         (output) =>

--- a/e2e/react/src/module-federation/independent-deployability.webpack.test.ts
+++ b/e2e/react/src/module-federation/independent-deployability.webpack.test.ts
@@ -149,7 +149,7 @@ describe('Independent Deployability', () => {
     expect(buildOutput).toContain('Successfully ran target build');
     expect(remoteOutput).toContain('Successfully ran target build');
 
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       const remoteProcess = await runCommandUntil(
         `serve-static ${remote} --no-watch --verbose`,
         () => {
@@ -289,7 +289,7 @@ describe('Independent Deployability', () => {
       `
     );
 
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       // test remote e2e
       const remoteE2eResults = await runCommandUntil(
         `e2e ${remote}-e2e --no-watch --verbose`,
@@ -413,7 +413,7 @@ describe('Independent Deployability', () => {
     expect(buildOutput).toContain('Successfully ran target build');
     expect(remoteOutput).toContain('Successfully ran target build');
 
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       const hostE2eResultsSwc = await runCommandUntil(
         `e2e ${shell}-e2e --no-watch --verbose`,
         (output) => output.includes('All specs passed!'),

--- a/e2e/react/src/module-federation/misc-rspack-convert-to-rspack.test.ts
+++ b/e2e/react/src/module-federation/misc-rspack-convert-to-rspack.test.ts
@@ -61,7 +61,7 @@ describe('React Rspack Module Federation Misc - Convert To Rspack', () => {
       `
     );
 
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       const e2eResultsSwc = await runCommandUntil(
         `e2e ${shell}-e2e`,
         (output) => output.includes('Successfully ran target e2e for project'),

--- a/e2e/react/src/module-federation/misc-rspack-interoperability.test.ts
+++ b/e2e/react/src/module-federation/misc-rspack-interoperability.test.ts
@@ -87,7 +87,7 @@ describe('React Rspack Module Federation Misc - Interoperability', () => {
 
     await killProcessAndPorts(serveResult.pid, readPort(shell));
 
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       const e2eResultsSwc = await runCommandUntil(
         `e2e ${shell}-e2e --verbose`,
         (output) => output.includes('All specs passed!'),
@@ -147,7 +147,7 @@ describe('React Rspack Module Federation Misc - Interoperability', () => {
       `
     );
 
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       const e2eResultsSwc = await runCommandUntil(
         `e2e ${shell}-e2e --verbose`,
         (output) => output.includes('Successfully ran target e2e'),

--- a/e2e/react/src/module-federation/ssr.rspack.test.ts
+++ b/e2e/react/src/module-federation/ssr.rspack.test.ts
@@ -99,7 +99,7 @@ describe('React Rspack SSR Module Federation', () => {
         `;
       });
 
-      if (runE2ETests()) {
+      if (await runE2ETests()) {
         const hostE2eResults = await runCommandUntil(
           `e2e ${shell}-e2e --verbose`,
           (output) => output.includes('All specs passed!')

--- a/e2e/react/src/module-federation/ts-solution-mf.test.ts
+++ b/e2e/react/src/module-federation/ts-solution-mf.test.ts
@@ -154,7 +154,7 @@ describe('React Rspack Module Federation - TS Solution + PM Workspaces', () => {
     // ========================================
     // Test 11: Run E2E tests (if configured)
     // ========================================
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       updateFile(
         `${shell}-e2e/src/integration/app.spec.ts`,
         stripIndents`

--- a/e2e/react/src/playwright.test.ts
+++ b/e2e/react/src/playwright.test.ts
@@ -24,8 +24,8 @@ describe('React Playwright e2e tests', () => {
 
   afterAll(() => cleanupProject());
 
-  it('should execute e2e tests using playwright', () => {
-    if (runE2ETests()) {
+  it('should execute e2e tests using playwright', async () => {
+    if (await runE2ETests()) {
       const result = runCLI(`e2e ${appName}-e2e --verbose`);
       expect(result).toContain(
         `Successfully ran target e2e for project ${appName}-e2e`
@@ -33,7 +33,7 @@ describe('React Playwright e2e tests', () => {
     }
   });
 
-  it('should execute e2e tests using playwright with a library used in the app', () => {
+  it('should execute e2e tests using playwright with a library used in the app', async () => {
     runCLI(
       `generate @nx/js:library ${usedInAppLibName} --unitTestRunner=none --importPath=@mylib --no-interactive`
     );
@@ -53,7 +53,7 @@ describe('React Playwright e2e tests', () => {
     `
     );
 
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       const result = runCLI(`e2e ${appName}-e2e --verbose`);
       expect(result).toContain(
         `Successfully ran target e2e for project ${appName}-e2e`

--- a/e2e/react/src/react-router-ts-paths.test.ts
+++ b/e2e/react/src/react-router-ts-paths.test.ts
@@ -12,7 +12,7 @@ import {
 
 describe('React Router Applications - TS paths', () => {
   const appName = uniq('app');
-  beforeAll(() => {
+  beforeAll(async () => {
     newProject({
       packages: [
         '@nx/react',
@@ -24,7 +24,7 @@ describe('React Router Applications - TS paths', () => {
         '@nx/eslint',
       ],
     });
-    ensurePlaywrightBrowsersInstallation();
+    await ensurePlaywrightBrowsersInstallation();
     runCLI(
       `generate @nx/react:app ${appName} --use-react-router --routing --linter=eslint --unit-test-runner=vitest --e2e-test-runner=playwright --no-interactive`
     );
@@ -72,8 +72,8 @@ describe('React Router Applications - TS paths', () => {
     expect(typeCheckResult).toContain('Successfully ran target typecheck');
   });
 
-  it('should execute e2e tests using playwright', () => {
-    if (runE2ETests()) {
+  it('should execute e2e tests using playwright', async () => {
+    if (await runE2ETests()) {
       const result = runCLI(`e2e ${appName}-e2e --verbose`);
       expect(result).toContain(
         `Successfully ran target e2e for project ${appName}-e2e`
@@ -81,13 +81,13 @@ describe('React Router Applications - TS paths', () => {
     }
   });
 
-  it('should execute e2e tests using cypress', () => {
+  it('should execute e2e tests using cypress', async () => {
     const cypressAppName = uniq('cypress-app');
-    ensureCypressInstallation();
+    await ensureCypressInstallation();
     runCLI(
       `generate @nx/react:app ${cypressAppName} --use-react-router --routing --linter=eslint --unit-test-runner=none  --no-interactive`
     );
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       const result = runCLI(`e2e ${cypressAppName}-e2e --verbose`);
       expect(result).toContain(
         `Successfully ran target e2e for project ${cypressAppName}-e2e`

--- a/e2e/react/src/react-router-ts-paths.test.ts
+++ b/e2e/react/src/react-router-ts-paths.test.ts
@@ -24,7 +24,7 @@ describe('React Router Applications - TS paths', () => {
         '@nx/eslint',
       ],
     });
-    await ensurePlaywrightBrowsersInstallation();
+    ensurePlaywrightBrowsersInstallation();
     runCLI(
       `generate @nx/react:app ${appName} --use-react-router --routing --linter=eslint --unit-test-runner=vitest --e2e-test-runner=playwright --no-interactive`
     );

--- a/e2e/react/src/react-router-ts-solution.test.ts
+++ b/e2e/react/src/react-router-ts-solution.test.ts
@@ -25,7 +25,7 @@ describe('React Router Applications - TS Solution', () => {
         '@nx/eslint',
       ],
     });
-    await ensurePlaywrightBrowsersInstallation();
+    ensurePlaywrightBrowsersInstallation();
     runCLI(
       `generate @nx/react:app ${appName} --use-react-router --routing --linter=eslint --unit-test-runner=vitest --e2e-test-runner=playwright --no-interactive`
     );

--- a/e2e/react/src/react-router-ts-solution.test.ts
+++ b/e2e/react/src/react-router-ts-solution.test.ts
@@ -12,7 +12,7 @@ import {
 
 describe('React Router Applications - TS Solution', () => {
   const appName = uniq('app');
-  beforeAll(() => {
+  beforeAll(async () => {
     newProject({
       preset: 'ts',
       packages: [
@@ -25,7 +25,7 @@ describe('React Router Applications - TS Solution', () => {
         '@nx/eslint',
       ],
     });
-    ensurePlaywrightBrowsersInstallation();
+    await ensurePlaywrightBrowsersInstallation();
     runCLI(
       `generate @nx/react:app ${appName} --use-react-router --routing --linter=eslint --unit-test-runner=vitest --e2e-test-runner=playwright --no-interactive`
     );
@@ -72,8 +72,8 @@ describe('React Router Applications - TS Solution', () => {
     expect(typeCheckResult).toContain('Successfully ran target typecheck');
   });
 
-  it('should execute e2e tests using playwright', () => {
-    if (runE2ETests()) {
+  it('should execute e2e tests using playwright', async () => {
+    if (await runE2ETests()) {
       const result = runCLI(`e2e ${appName}-e2e --verbose`);
       expect(result).toContain(
         `Successfully ran target e2e for project @proj/${appName}-e2e`
@@ -81,13 +81,13 @@ describe('React Router Applications - TS Solution', () => {
     }
   });
 
-  it('should execute e2e tests using cypress', () => {
+  it('should execute e2e tests using cypress', async () => {
     const cypressAppName = uniq('cypress-app');
-    ensureCypressInstallation();
+    await ensureCypressInstallation();
     runCLI(
       `generate @nx/react:app ${cypressAppName} --use-react-router --routing --linter=eslint --unit-test-runner=none  --no-interactive`
     );
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       const result = runCLI(`e2e ${cypressAppName}-e2e --verbose`);
       expect(result).toContain(
         `Successfully ran target e2e for project @proj/${cypressAppName}-e2e`

--- a/e2e/react/src/react-rsbuild.test.ts
+++ b/e2e/react/src/react-rsbuild.test.ts
@@ -88,7 +88,7 @@ describe('Build React applications and libraries with Rsbuild', () => {
     await runCLIAsync(`build ${rsbuildApp}`);
     checkFilesExist(`apps/${rsbuildApp}/dist/index.html`);
 
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       const result = runCLI(`e2e ${rsbuildApp}-e2e --verbose`);
       expect(result).toContain(
         `Successfully ran target e2e for project ${rsbuildApp}-e2e`

--- a/e2e/react/src/react-rspack.test.ts
+++ b/e2e/react/src/react-rspack.test.ts
@@ -41,7 +41,7 @@ describe('Build React applications and libraries with Rspack', () => {
     const rspackConfig = readFile(`${appName}/rspack.config.js`);
     expect(rspackConfig).toContain(`port: ${customPort}`);
 
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       const e2eResults = runCLI(`e2e ${appName}-e2e`, {
         verbose: true,
       });
@@ -78,7 +78,7 @@ describe('Build React applications and libraries with Rspack', () => {
 
     checkFilesExist(`dist/${appName}/index.html`);
 
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       const e2eResults = runCLI(`e2e ${appName}-e2e`, {
         verbose: true,
       });

--- a/e2e/react/src/react-vite.test.ts
+++ b/e2e/react/src/react-vite.test.ts
@@ -82,7 +82,7 @@ describe('Build React applications and libraries with Vite', () => {
     const viteConfig = readFile(`apps/${viteApp}/vite.config.mts`);
     expect(viteConfig).toContain(`port: ${customPort}`);
 
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       const e2eResults = runCLI(`e2e ${viteApp}-e2e`, {
         verbose: true,
       });

--- a/e2e/react/src/react-webpack.test.ts
+++ b/e2e/react/src/react-webpack.test.ts
@@ -34,7 +34,7 @@ describe('Build React applications and libraries with Webpack', () => {
     const webpackConfig = readFile(`apps/${appName}/webpack.config.js`);
     expect(webpackConfig).toContain(`port: ${customPort}`);
 
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       const e2eResults = runCLI(`e2e ${appName}-e2e`, {
         verbose: true,
       });

--- a/e2e/react/src/react.test.ts
+++ b/e2e/react/src/react.test.ts
@@ -21,7 +21,7 @@ import { join } from 'path';
 describe('React Applications', () => {
   let proj: string;
   describe('Crystal Supported Tests', () => {
-    beforeAll(() => {
+    beforeAll(async () => {
       proj = newProject({
         packages: [
           '@nx/react',
@@ -33,7 +33,7 @@ describe('React Applications', () => {
           '@nx/eslint',
         ],
       });
-      ensureCypressInstallation();
+      await ensureCypressInstallation();
     });
 
     afterAll(() => cleanupProject());
@@ -64,7 +64,7 @@ describe('React Applications', () => {
 
       checkFilesExist(`dist/apps/${appName}/index.html`);
 
-      if (runE2ETests()) {
+      if (await runE2ETests()) {
         const e2eResults = runCLI(`e2e ${appName}-e2e`);
         expect(e2eResults).toContain('Successfully ran target e2e for project');
         expect(await killPorts()).toBeTruthy();
@@ -276,7 +276,7 @@ describe('React Applications', () => {
 
   // TODO(colum): Revisit when cypress --js works with crystal
   describe('Non-Crystal Tests', () => {
-    beforeAll(() => {
+    beforeAll(async () => {
       process.env.NX_ADD_PLUGINS = 'false';
       proj = newProject({
         packages: [
@@ -287,7 +287,7 @@ describe('React Applications', () => {
           '@nx/eslint',
         ],
       });
-      ensureCypressInstallation();
+      await ensureCypressInstallation();
     });
 
     afterAll(() => {
@@ -454,7 +454,7 @@ async function testGeneratedApp(
     'Test Suites: 1 passed, 1 total'
   );
 
-  if (opts.checkE2E && runE2ETests()) {
+  if (opts.checkE2E && (await runE2ETests())) {
     const e2eResults = runCLI(`e2e ${appName}-e2e`);
     expect(e2eResults).toContain('Successfully ran target e2e');
     expect(await killPorts()).toBeTruthy();

--- a/e2e/utils/command-utils.ts
+++ b/e2e/utils/command-utils.ts
@@ -208,13 +208,15 @@ export function getPackageManagerCommand({
   }[packageManager.trim() as PackageManager];
 }
 
-export function runE2ETests(runner?: 'cypress' | 'playwright') {
+export async function runE2ETests(runner?: 'cypress' | 'playwright') {
   if (process.env.NX_E2E_RUN_E2E === 'true') {
+    // Both installs take a lock, so a suite that has to wait for another one
+    // must not start running tests until the binaries are actually there.
     if (!runner || runner === 'cypress') {
-      ensureCypressInstallation();
+      await ensureCypressInstallation();
     }
     if (!runner || runner === 'playwright') {
-      ensurePlaywrightBrowsersInstallation();
+      await ensurePlaywrightBrowsersInstallation();
     }
     return true;
   }

--- a/e2e/utils/command-utils.ts
+++ b/e2e/utils/command-utils.ts
@@ -210,13 +210,16 @@ export function getPackageManagerCommand({
 
 export async function runE2ETests(runner?: 'cypress' | 'playwright') {
   if (process.env.NX_E2E_RUN_E2E === 'true') {
-    // Both installs take a lock, so a suite that has to wait for another one
-    // must not start running tests until the binaries are actually there.
+    // Cypress unzips into a cache shared by the whole machine, so this has to
+    // finish before the suite starts running tests.
     if (!runner || runner === 'cypress') {
       await ensureCypressInstallation();
     }
+    // Playwright is deliberately not awaited: `npx playwright install
+    // --with-deps` takes longer than a test's timeout, so waiting on it here
+    // fails the suite outright.
     if (!runner || runner === 'playwright') {
-      await ensurePlaywrightBrowsersInstallation();
+      ensurePlaywrightBrowsersInstallation();
     }
     return true;
   }

--- a/e2e/utils/ensure-browser-installation.ts
+++ b/e2e/utils/ensure-browser-installation.ts
@@ -20,6 +20,11 @@ import { isVerbose } from './get-env-info';
 const LOCK_DIR = join(tmpdir(), 'nx-e2e-locks');
 const PLAYWRIGHT_LOCK_FILE = join(LOCK_DIR, 'playwright-install.lock');
 const PLAYWRIGHT_STATUS_FILE = join(LOCK_DIR, 'playwright-install.status');
+// Cypress needs the same treatment: it unzips into one cache directory shared by
+// everything on the machine, and a second install clears that directory while the
+// first is still unzipping into it.
+const CYPRESS_LOCK_FILE = join(LOCK_DIR, 'cypress-install.lock');
+const CYPRESS_STATUS_FILE = join(LOCK_DIR, 'cypress-install.status');
 const POLL_INTERVAL_MS = 5000;
 const MAX_WAIT_MS = 5 * 60 * 1000;
 
@@ -131,28 +136,88 @@ async function waitForInstallation(
   );
 }
 
+/**
+ * Blocks the calling process. `ensureCypressInstallation` is synchronous, and
+ * every caller of `runE2ETests` relies on that, so the wait cannot be awaited.
+ */
+function sleepSync(ms: number) {
+  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
+}
+
+function waitForInstallationSync(
+  lockFile: string,
+  statusFile: string,
+  toolName: string
+): void {
+  const startTime = Date.now();
+
+  while (Date.now() - startTime < MAX_WAIT_MS) {
+    if (!existsSync(lockFile)) {
+      const status = readInstallStatus(statusFile);
+
+      if (status?.status === 'success') {
+        e2eConsoleLogger(`${toolName} installed by process ${status.pid}`);
+        return;
+      }
+
+      if (status?.status === 'failed') {
+        const errorMsg = `${toolName} installation failed in process ${
+          status.pid
+        }: ${status.error || 'Unknown error'}`;
+        e2eConsoleLogger(errorMsg);
+        throw new Error(errorMsg);
+      }
+    }
+
+    sleepSync(POLL_INTERVAL_MS);
+  }
+
+  throw new Error(`Timeout waiting for ${toolName} installation to complete`);
+}
+
 export function ensureCypressInstallation() {
-  let cypressVerified = true;
+  // Only one process on the machine may unzip into the Cypress cache at a time,
+  // for the same reason Playwright installs are serialized below.
+  if (!tryAcquireLock(CYPRESS_LOCK_FILE, CYPRESS_STATUS_FILE)) {
+    e2eConsoleLogger(
+      `Process ${process.pid} waiting for Cypress installation...`
+    );
+    waitForInstallationSync(CYPRESS_LOCK_FILE, CYPRESS_STATUS_FILE, 'Cypress');
+    return;
+  }
+
   try {
-    const r = execSync('npx cypress verify', {
-      stdio: isVerbose() ? 'inherit' : 'pipe',
-      encoding: 'utf-8',
-      cwd: tmpProjPath(),
-    });
-    if (r.indexOf('Verified Cypress!') === -1) {
+    let cypressVerified = true;
+    try {
+      const r = execSync('npx cypress verify', {
+        stdio: isVerbose() ? 'inherit' : 'pipe',
+        encoding: 'utf-8',
+        cwd: tmpProjPath(),
+      });
+      if (r.indexOf('Verified Cypress!') === -1) {
+        cypressVerified = false;
+      }
+    } catch {
       cypressVerified = false;
     }
-  } catch {
-    cypressVerified = false;
-  } finally {
+
     if (!cypressVerified) {
       e2eConsoleLogger('Cypress was not verified. Installing Cypress now.');
       execSync('npx cypress install', {
         stdio: isVerbose() ? 'inherit' : 'pipe',
         encoding: 'utf-8',
         cwd: tmpProjPath(),
+        // The binary is skipped while workspaces are installed, so this call
+        // has to be allowed to fetch it.
+        env: { ...process.env, CYPRESS_INSTALL_BINARY: undefined },
       });
     }
+
+    releaseLock(CYPRESS_LOCK_FILE, CYPRESS_STATUS_FILE, true);
+  } catch (error) {
+    e2eConsoleLogger('Failed to install Cypress:', error);
+    releaseLock(CYPRESS_LOCK_FILE, CYPRESS_STATUS_FILE, false, error.message);
+    throw error;
   }
 }
 

--- a/e2e/utils/ensure-browser-installation.ts
+++ b/e2e/utils/ensure-browser-installation.ts
@@ -168,6 +168,13 @@ async function waitForInstallation(
 }
 
 export async function ensureCypressInstallation() {
+  // Nothing runs Cypress unless e2e tests are enabled, and the binary is not
+  // fetched while workspaces install in that case, so pulling it here would
+  // download and unzip ~100MB that no test is going to use.
+  if (process.env.NX_E2E_RUN_E2E !== 'true') {
+    return;
+  }
+
   // Only one process on the machine may unzip into the Cypress cache at a time,
   // for the same reason Playwright installs are serialized below.
   if (!tryAcquireLock(CYPRESS_LOCK_FILE, CYPRESS_STATUS_FILE)) {

--- a/e2e/utils/ensure-browser-installation.ts
+++ b/e2e/utils/ensure-browser-installation.ts
@@ -112,50 +112,6 @@ async function waitForInstallation(
       const status = readInstallStatus(statusFile);
 
       if (status?.status === 'success') {
-        e2eConsoleLogger(
-          `${toolName} browsers installed by process ${status.pid}`
-        );
-        return;
-      }
-
-      if (status?.status === 'failed') {
-        const errorMsg = `${toolName} browser installation failed in process ${
-          status.pid
-        }: ${status.error || 'Unknown error'}`;
-        e2eConsoleLogger(errorMsg);
-        throw new Error(errorMsg);
-      }
-    }
-
-    // Wait before polling again
-    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
-  }
-
-  throw new Error(
-    `Timeout waiting for ${toolName} browser installation to complete`
-  );
-}
-
-/**
- * Blocks the calling process. `ensureCypressInstallation` is synchronous, and
- * every caller of `runE2ETests` relies on that, so the wait cannot be awaited.
- */
-function sleepSync(ms: number) {
-  Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, ms);
-}
-
-function waitForInstallationSync(
-  lockFile: string,
-  statusFile: string,
-  toolName: string
-): void {
-  const startTime = Date.now();
-
-  while (Date.now() - startTime < MAX_WAIT_MS) {
-    if (!existsSync(lockFile)) {
-      const status = readInstallStatus(statusFile);
-
-      if (status?.status === 'success') {
         e2eConsoleLogger(`${toolName} installed by process ${status.pid}`);
         return;
       }
@@ -169,20 +125,25 @@ function waitForInstallationSync(
       }
     }
 
-    sleepSync(POLL_INTERVAL_MS);
+    // Wait before polling again
+    await new Promise((resolve) => setTimeout(resolve, POLL_INTERVAL_MS));
   }
 
   throw new Error(`Timeout waiting for ${toolName} installation to complete`);
 }
 
-export function ensureCypressInstallation() {
+export async function ensureCypressInstallation() {
   // Only one process on the machine may unzip into the Cypress cache at a time,
   // for the same reason Playwright installs are serialized below.
   if (!tryAcquireLock(CYPRESS_LOCK_FILE, CYPRESS_STATUS_FILE)) {
     e2eConsoleLogger(
       `Process ${process.pid} waiting for Cypress installation...`
     );
-    waitForInstallationSync(CYPRESS_LOCK_FILE, CYPRESS_STATUS_FILE, 'Cypress');
+    await waitForInstallation(
+      CYPRESS_LOCK_FILE,
+      CYPRESS_STATUS_FILE,
+      'Cypress'
+    );
     return;
   }
 

--- a/e2e/utils/ensure-browser-installation.ts
+++ b/e2e/utils/ensure-browser-installation.ts
@@ -41,8 +41,40 @@ function ensureLockDir() {
   }
 }
 
+/**
+ * A process that is killed mid-install leaves its lock behind, and every later
+ * process would then wait out the full timeout for an install that is never
+ * coming. Treat a lock as abandoned once its holder is gone.
+ */
+function isStaleLock(statusFile: string): boolean {
+  const status = readInstallStatus(statusFile);
+  if (!status) {
+    return true;
+  }
+  if (status.status !== 'installing') {
+    return true;
+  }
+  try {
+    // Signal 0 checks that the process exists without touching it.
+    process.kill(status.pid, 0);
+    return false;
+  } catch {
+    return true;
+  }
+}
+
 function tryAcquireLock(lockFile: string, statusFile: string): boolean {
   ensureLockDir();
+
+  if (existsSync(lockFile) && isStaleLock(statusFile)) {
+    e2eConsoleLogger('Reclaiming an abandoned browser installation lock.');
+    try {
+      unlinkSync(lockFile);
+    } catch {
+      // Another process got there first, which is just as good.
+    }
+  }
+
   try {
     // Atomic operation - fails if file exists
     const fd = openSync(lockFile, 'wx');
@@ -103,7 +135,7 @@ async function waitForInstallation(
   lockFile: string,
   statusFile: string,
   toolName: string
-): Promise<void> {
+): Promise<'installed' | 'abandoned'> {
   const startTime = Date.now();
 
   while (Date.now() - startTime < MAX_WAIT_MS) {
@@ -113,7 +145,7 @@ async function waitForInstallation(
 
       if (status?.status === 'success') {
         e2eConsoleLogger(`${toolName} installed by process ${status.pid}`);
-        return;
+        return 'installed';
       }
 
       if (status?.status === 'failed') {
@@ -123,6 +155,9 @@ async function waitForInstallation(
         e2eConsoleLogger(errorMsg);
         throw new Error(errorMsg);
       }
+    } else if (isStaleLock(statusFile)) {
+      // Whoever held the lock is gone, so waiting on them is pointless.
+      return 'abandoned';
     }
 
     // Wait before polling again
@@ -139,12 +174,18 @@ export async function ensureCypressInstallation() {
     e2eConsoleLogger(
       `Process ${process.pid} waiting for Cypress installation...`
     );
-    await waitForInstallation(
+    const outcome = await waitForInstallation(
       CYPRESS_LOCK_FILE,
       CYPRESS_STATUS_FILE,
       'Cypress'
     );
-    return;
+    if (outcome === 'installed') {
+      return;
+    }
+    // The lock was abandoned, so try once more to do the install here.
+    if (!tryAcquireLock(CYPRESS_LOCK_FILE, CYPRESS_STATUS_FILE)) {
+      return;
+    }
   }
 
   try {

--- a/e2e/utils/global-setup.ts
+++ b/e2e/utils/global-setup.ts
@@ -100,6 +100,15 @@ export default async function (globalConfig: Config.ConfigGlobals) {
 
     process.env.NX_SKIP_PROVENANCE_CHECK = 'true';
 
+    // Installing a workspace unzips the Cypress binary into a cache directory
+    // shared by everything on the machine, so two suites running side by side
+    // can clear that directory out from under each other mid-unzip. Suites that
+    // never run e2e tests do not need the binary at all; the ones that do get it
+    // from `ensureCypressInstallation`, which takes a lock first.
+    if (process.env.NX_E2E_RUN_E2E !== 'true') {
+      process.env.CYPRESS_INSTALL_BINARY = '0';
+    }
+
     global.e2eTeardown = () => {
       // Clean up environment variable instead of npm config command
       delete process.env[`npm_config_//${listenAddress}:${port}/:_authToken`];

--- a/e2e/vue/src/vue.test.ts
+++ b/e2e/vue/src/vue.test.ts
@@ -40,7 +40,7 @@ describe('Vue Plugin', () => {
       `Successfully ran target build for project ${app}`
     );
 
-    if (runE2ETests('playwright')) {
+    if (await runE2ETests('playwright')) {
       const availablePort = await reservePort();
 
       updateFile(`${app}-e2e/playwright.config.mts`, (content) => {
@@ -82,7 +82,7 @@ describe('Vue Plugin', () => {
       `Successfully ran target build for project ${app}`
     );
 
-    if (runE2ETests('playwright')) {
+    if (await runE2ETests('playwright')) {
       const availablePort = await reservePort();
 
       updateFile(`${app}-e2e/playwright.config.mts`, (content) => {

--- a/e2e/web/src/web-vite.test.ts
+++ b/e2e/web/src/web-vite.test.ts
@@ -50,7 +50,7 @@ describe('Web Components Applications with bundler set as vite', () => {
 
     expect(lintE2eResults).toContain('Successfully ran target lint');
 
-    if (isNotWindows() && runE2ETests()) {
+    if (isNotWindows() && (await runE2ETests())) {
       const e2eResults = runCLI(`e2e ${appName}-e2e`);
       expect(e2eResults).toContain('Successfully ran target e2e for project');
       await killPorts();

--- a/e2e/web/src/web.test.ts
+++ b/e2e/web/src/web.test.ts
@@ -53,7 +53,7 @@ describe('Web Components Applications', () => {
 
     expect(lintE2eResults).toContain('Successfully ran target lint');
 
-    if (isNotWindows() && runE2ETests()) {
+    if (isNotWindows() && (await runE2ETests())) {
       const e2eResults = runCLI(`e2e ${appName}-e2e`);
       expect(e2eResults).toContain('Successfully ran target e2e for project');
       await killPorts();

--- a/e2e/webpack/src/webpack.legacy.test.ts
+++ b/e2e/webpack/src/webpack.legacy.test.ts
@@ -53,7 +53,7 @@ describe('Webpack Plugin (legacy)', () => {
     // TODO: figure out why this test hangs in CI (maybe down to sudo prompt?)
     // expect(() => runCLI(`build ${appName}`)).not.toThrow();
 
-    // if (runE2ETests()) {
+    // if (await runE2ETests()) {
     //   runCLI(`e2e ${appName}-e2e --watch=false --verbose`);
     // }
   }, 500_000);
@@ -119,7 +119,7 @@ describe('Webpack Plugin (legacy)', () => {
     }).toThrow();
   });
 
-  it('should support standard webpack config with executors', () => {
+  it('should support standard webpack config with executors', async () => {
     const appName = uniq('app');
     runCLI(
       `generate @nx/web:app ${appName} --bundler webpack --e2eTestRunner=playwright --unitTestRunner=jest --linter=eslint`
@@ -155,7 +155,7 @@ describe('Webpack Plugin (legacy)', () => {
       runCLI(`build ${appName} --outputHashing none`);
     }).not.toThrow();
 
-    if (runE2ETests()) {
+    if (await runE2ETests()) {
       expect(() => {
         runCLI(`e2e ${appName}-e2e`);
       }).not.toThrow();
@@ -163,7 +163,7 @@ describe('Webpack Plugin (legacy)', () => {
   });
 
   describe('ConvertConfigToWebpackPlugin,', () => {
-    it('should convert withNx webpack config to a standard config using NxWebpackPlugin', () => {
+    it('should convert withNx webpack config to a standard config using NxWebpackPlugin', async () => {
       const appName = 'app3224373'; // Needs to be reserved so that the snapshot projectName matches
       runCLI(
         `generate @nx/web:app ${appName} --bundler webpack --e2eTestRunner=playwright --unitTestRunner=vitest --linter=eslint`
@@ -195,7 +195,7 @@ describe('Webpack Plugin (legacy)', () => {
         runCLI(`build ${appName}`);
       }).not.toThrow();
 
-      if (runE2ETests()) {
+      if (await runE2ETests()) {
         expect(() => {
           runCLI(`e2e ${appName}-e2e`);
         }).not.toThrow();


### PR DESCRIPTION
## Current Behavior

The macOS e2e job runs two suites at once (`--parallel=2`, added in #36368), and every generated e2e workspace unzips the Cypress binary into one cache directory shared by the whole machine (`~/Library/Caches/Cypress/<version>`).

When two suites install Cypress at the same time, the second install clears the version directory while the first is still unzipping into it, and the first fails:

```
[STARTED]  Unzipping Cypress
The Cypress App could not be unzipped.

Error: ENOENT: no such file or directory, open
'/Users/runner/Library/Caches/Cypress/15.18.1/Cypress.app/Contents/Resources/app/node_modules/zod/v4/locales/zh-CN.d.cts'
```

The file it reports missing is a different one each run (`eo.cjs`, `zh-CN.d.cts`, ...), which is what distinguishes this from a genuinely broken Cypress release — the same failure reproduces across Cypress versions.

Playwright installs are already serialized behind a lock for this same reason ("Helper files to prevent multiple `npx playwright install` on the same machine"); Cypress never got the equivalent.

Separately, the macOS job does not set `NX_E2E_RUN_E2E`, so those suites download and unzip a ~100MB Cypress binary that they never use.

## Expected Behavior

- Cypress installs are serialized behind the same lock helpers Playwright installs use, so only one process on a machine unzips into the cache at a time.
- Suites that do not run e2e tests skip fetching the binary entirely (`CYPRESS_INSTALL_BINARY=0`), so they cannot collide over the cache and do not pay for a download they never use. Suites that do run e2e tests are unchanged — they get the binary from `ensureCypressInstallation`, which now takes the lock first.

The Linux job is unaffected: it diparate agents, so no two share a
cache, and it sets `NX_E2E_RUN_E2Els the binary.

### Why the diff touches so many f

A process that loses the install rnner to finish before it starts
running tests, and waiting for tha blocking the thread. So
`runE2ETests` and both `ensure*Ins `async`, and their call sites await
them — that is where the file couna single `await`, plus the
enclosing `it`/`beforeAll` becomin already.

This also closes a gap on the PlayightBrowsersInstallation` was
already asynchronous but was never begin while another process was
still installing.

## Related Issue(s)

No issue filed; found while invest on an unrelated PR. Caused by theparallelism added in #36368.