### PR TITLE
chore(repo): trim review-pr carry-forward and pin review agent models

### DIFF
--- a/.claude/agents/alternative-approach.md
+++ b/.claude/agents/alternative-approach.md
@@ -1,7 +1,7 @@
 ---
 name: alternative-approach
 description: Use this agent during PR review to independently design alternative solutions to the problem a PR solves and contrast them with the PR's chosen approach. It reports a finding only when an alternative is materially better (root-cause vs symptom fix, reuse of an existing utility, large complexity reduction) or when the chosen approach cannot fully solve the problem; otherwise it endorses the approach so the reviewer knows alternatives were considered and rejected. Read-only on the sandbox checkout.
-model: inherit
+model: opus
 tools: Read, Grep, Glob, Bash
 ---
 

--- a/.claude/agents/performance-analyzer.md
+++ b/.claude/agents/performance-analyzer.md
@@ -1,7 +1,7 @@
 ---
 name: performance-analyzer
 description: Use this agent during PR review to analyze the runtime performance of a PR's changes along two axes - (1) resource footprint (unnecessary CPU or memory usage) and (2) execution efficiency (does the code run quickly, avoid redundant work, and scale with workspace size). It reports a finding only when the cost is real on a hot path or scales with input size; micro-costs in cold paths are endorsed as sound so the reviewer knows performance was checked. Read-only on the sandbox checkout.
-model: inherit
+model: opus
 tools: Read, Grep, Glob, Bash
 ---
 

--- a/.claude/agents/security-analyzer.md
+++ b/.claude/agents/security-analyzer.md
@@ -1,7 +1,7 @@
 ---
 name: security-analyzer
 description: Use this agent during PR review to hunt injection-class vulnerabilities in a PR's changes - command injection, zip-slip and path traversal, prototype pollution, SSRF, credential leakage, and unsafe deserialization. It reports a finding only when untrusted data actually crosses a trust boundary into a dangerous sink; code that merely handles trusted workspace config is endorsed as sound so the reviewer knows security was checked. Read-only on the sandbox checkout.
-model: inherit
+model: opus
 tools: Read, Grep, Glob, Bash
 ---
 

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -165,10 +165,12 @@ If `$TRIAGE_DIR/<NUMBER>.md` already exists and its `verdict` is not `failed`, t
 
 (If the existing draft's `verdict` is `failed` **and its `## Review draft` body is empty or has no findings**, the prior attempt produced nothing usable — skip this step and review fresh. Do NOT discard it merely because the token says `failed`: since Step 7 now sets `failed` when any single agent fails its EVIDENCE check, a `failed` draft routinely still contains eight agents' worth of real findings, and throwing that away loses the reconciliation this step exists for. The file's history is preserved by Step 8 either way.)
 
-1. Read the existing triage file. Extract:
-   - The frontmatter `head_sha` (call it `$PRIOR_SHA`).
+1. Read the existing triage file **in full** — the whole `## Review draft` plus every entry under `## Prior reviews`. This is for **you**, the orchestrator: Step 5b reconciliation is explicitly yours to do ("don't dispatch another agent — you already have all the context"), so you need the complete history to sort findings into Addressed / Still concerning / New. Extract:
+   - The frontmatter `head_sha` (call it `$PRIOR_SHA`) and `verdict`.
    - The `## Review draft` section (the most recent review). This becomes "the prior review."
    - The full `## Prior reviews` section (older reviews, if any). All of them — no cap on history.
+
+   What you pass to the **agents** is a different, much smaller artifact — see step 3. Keep the two straight: full history in your head, distilled carry-forward on disk.
 
 2. Compute the incremental diff inside the container, writing it to a host file the agents can `Read`. `$PRIOR_SHA` isn't in the shallow checkout, so fetch it first — and branch on whether that fetch succeeded:
 
@@ -185,20 +187,35 @@ If `$TRIAGE_DIR/<NUMBER>.md` already exists and its `verdict` is not `failed`, t
 
    Set `HAS_PRIOR_CONTEXT=true` only on the success path. **Step 5 gates on that variable, never on the context file existing** — file existence is not a safe signal, because a prior review of the same PR leaves one behind and it would silently narrow this run's scope to a stale delta. (Step 3 also clears these paths up front, so the two defenses are independent.)
 
-3. Write a context file at `/tmp/pr-<NUMBER>.review-context.md` (host-side — the agents `Read` it directly; it is our file, not PR code):
+3. Write a context file at `/tmp/pr-<NUMBER>.review-context.md` (host-side — the agents `Read` it directly; it is our file, not PR code).
+
+   **Distill; do not paste.** Every byte here is read by all nine agents, so its cost is multiplied ninefold — on a PR with several prior attempts, pasting full bodies makes the carry-forward the single largest fixed charge in the run, larger for most agents than the diff they are meant to review. Worse, it is mostly inert: the bulk of a prior draft is that round's Reproduction / Approach / Performance / Security prose, which describes work already done and re-verified from scratch this round by the agents that own those dimensions. What an agent genuinely needs from history is short: what is still open, what was already fixed, and which trade-offs are settled so it does not re-litigate them.
+
+   Write this shape instead, and keep the whole file **under ~150 lines**:
 
    ```markdown
    # Re-review context
 
-   This PR has been reviewed before. The prior review's verdict was: <PRIOR_VERDICT>.
+   Attempt <N-1> reviewed `$PRIOR_SHA` and returned **<PRIOR_VERDICT>**. This is attempt <N>.
+   Earlier attempts: <one line per attempt, oldest first — "attempt 2 (1046ace) lgtm — daemon now
+   rejects foreign-workspace messages">.
 
-   ## Most recent prior review (head_sha=$PRIOR_SHA)
+   ## Open items — verify whether these still hold
 
-   <PASTE THE PRIOR REVIEW DRAFT VERBATIM>
+   <Every unresolved Critical/Important finding from ANY prior attempt, one bullet each.
+   Quote the finding's own one-line summary verbatim where it has one; add the file:line and
+   the specific ask. These are load-bearing — see the budget rule below.>
 
-   ## All earlier reviews (oldest first)
+   ## Already fixed — do not re-raise
 
-   <PASTE THE FULL ## Prior reviews SECTION VERBATIM>
+   <One line per finding a prior attempt raised and a later attempt confirmed closed, with what
+   closed it. Agents need these so they neither re-report them nor mistake the fix for new code.>
+
+   ## Settled maintainer calls — do not re-litigate
+
+   <One line each: the decision, and that it was reviewed and accepted. An agent that does not
+   know a trade-off is settled will re-report it every single round; this section is the cheapest
+   part of the file and prevents the most repeat noise.>
 
    ## Diff since last review (`$PRIOR_SHA..<HEAD>`)
 
@@ -206,9 +223,18 @@ If `$TRIAGE_DIR/<NUMBER>.md` already exists and its `verdict` is not `failed`, t
 
    ## Review focus
 
-   Focus on the diff since the last review. For unchanged code, only verify
-   whether the prior findings above still hold — do not re-analyze it from scratch.
+   Focus on the diff since the last review. For unchanged code, only verify whether the open
+   items above still hold — do not re-analyze it from scratch.
+
+   <Optionally: 2-4 specific questions this round should settle, phrased neutrally.>
    ```
+
+   Rules for the distillation:
+   - **The budget never evicts an open finding.** The ~150-line target governs _prose_, not the Open-items list. If open items alone exceed the budget, keep them all and cut elsewhere — dropping an unresolved finding silently converts it into a "new" finding next round, or into no finding at all, which is the one failure this file exists to prevent.
+   - **Compress by dropping sections, not by summarizing findings.** Prior Reproduction / Approach / Performance / Security narrative goes entirely; a finding's own wording is preserved. Never paraphrase a finding into something vaguer than the author wrote — the point of quoting is that the next agent can check the same claim.
+   - **Do not carry a prior verdict's reasoning as an instruction.** Say what was found, not what to conclude. An agent told "attempt 5 concluded this is sound" will confirm it; an agent told "attempt 5 found X at file:line" will check X.
+   - **Keep the questions neutral.** Asking "does the new suite actually exercise the rejection branches, and can it fail?" is fair; asking "confirm the new suite is good" is not.
+   - The full history is not lost — it stays in `$TRIAGE_DIR/<NUMBER>.md` (Step 8 keeps it uncapped) and in your own context from step 1. Only the agents' copy is trimmed.
 
 ## Step 4.5: Close-without-merge check
 
@@ -450,7 +476,10 @@ proof: it is in no prompt and in no prior-review text, so only opening the diff 
 or a `diff --git` header is derivable from this prompt and proves nothing. A report that does not
 verify is discarded and the agent recorded as failed — including a report that found no issues.
 <ONLY IF Step 4 set $HAS_PRIOR_CONTEXT=true, ADD:>
-Also read /tmp/pr-<NUMBER>.review-context.md — the prior review of this PR. Focus on what changed since.
+Also read /tmp/pr-<NUMBER>.review-context.md — a distilled carry-forward from prior reviews of this
+PR: what is still open, what was already fixed, and which trade-offs are settled. Focus on what
+changed since. It is deliberately NOT the full prior reviews — it lists only what carries forward, so
+treat it as a checklist to verify, never as a statement that anything absent from it is fine.
 """
 )
 ```
@@ -859,7 +888,7 @@ Write `$TRIAGE_DIR/<NUMBER>.md`. **If the file already exists** (re-review):
 4. Replace `## Review draft` with the new `$REVIEW_BODY` (formatted in Step 6).
 5. Update frontmatter: `head_sha`, `last_reviewed_at`, `verdict`, increment `attempt`. Preserve `posted_at` / `posted_url` (the user fills those in).
 
-**No cap on history** — every prior review accumulates under `## Prior reviews`, oldest at the bottom, newest at the top.
+**No cap on history** — every prior review accumulates under `## Prior reviews`, oldest at the bottom, newest at the top. This file is the archive and stays uncapped; it is read only by you and by the human reviewer, never by the nine agents. The trimming in Step 4 applies solely to the agents' `review-context.md`, which is a distilled carry-forward derived from this file — so keeping the archive complete is what makes trimming the derived copy safe.
 
 Format:
 


### PR DESCRIPTION
## Current Behavior

On a re-review, the `review-pr` skill built its agent context file by pasting the previous review draft **verbatim**, plus the entire `## Prior reviews` section verbatim ("All of them — no cap on history").

That file is read by all nine review agents, so its cost is multiplied ninefold and grows with every attempt. Most of what was being carried is inert: the bulk of a prior draft is that round's Reproduction / Approach / Performance / Security narrative, which describes work already done and which the agents owning those dimensions redo from scratch each round anyway.

Measured against a real six-attempt draft, the next re-review would have carried **128 lines / ~7.5k tokens × 9 ≈ 68k tokens** of history before a single agent looked at the diff — and climbing each attempt.

The three review agents defined in this repo were also `model: inherit`, so their model silently followed whatever model the session happened to be running.

## Expected Behavior

**Distilled carry-forward instead of verbatim paste.** Step 4 now writes four short sections under a ~150-line cap:

- **Open items** — unresolved findings from any prior attempt, to verify
- **Already fixed** — so agents neither re-raise them nor mistake a fix for new code
- **Settled maintainer calls** — so accepted trade-offs aren't re-litigated every round
- A one-line-per-attempt trail, the incremental diff pointer, and the review focus

This holds the carry-forward near ~16k tokens and stops it growing with attempt count.

Four guardrails keep the trim from losing signal:

- **The budget never evicts an open finding.** The cap governs prose; if open items alone exceed it, everything else gets cut first. Dropping an unresolved finding would silently convert it into a "new" finding next round, or into no finding at all — the exact failure the file exists to prevent.
- **Compress by dropping whole sections, not by summarizing findings.** A finding keeps its own wording so the next agent can check the same claim.
- **Don't carry a prior conclusion as an instruction.** "Attempt 5 concluded this is sound" gets confirmed; "attempt 5 found X at file:line" gets checked.
- **Keep the focus questions neutral.**

**What makes this safe:** Step 5b reconciliation is explicitly done in the main loop, not by a subagent, so the orchestrator still reads the complete triage file. Step 4 now says so directly, and Step 8 keeps the triage file uncapped as the archive — the derived copy is the only thing trimmed. Two dependent spots were updated to match: the Step 5 dispatch prompt now tells agents the file is a checklist to verify and never a statement that anything absent from it is fine, and Step 8 explains why an uncapped archive is what permits a trimmed derivative.

`PIPELINE_VERSION` is deliberately **not** bumped. It gates re-review of existing drafts at unchanged SHAs, and this changes context packaging rather than review criteria — bumping it would force exactly the re-runs this is meant to make cheaper.

**Agent models pinned.** The three review agents that live in this repo (`alternative-approach`, `performance-analyzer`, `security-analyzer`) move from `model: inherit` to `model: opus`, matching the already-pinned `reproduce-verifier`.

## Related Issue(s)

N/A — internal review tooling, no linked issue.

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Trim-review-pr-carry-forward-and-pin-review-agent-models-ae0f8c27)
<!-- polygraph-session-end -->