### PR TITLE
fix(devkit): resolve ensurePackage against the workspace

### DIFF
--- a/packages/devkit/src/utils/ensure-package.spec.ts
+++ b/packages/devkit/src/utils/ensure-package.spec.ts
@@ -1,0 +1,63 @@
+import { mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+
+// Recomputed inside the factory because `jest.mock` is hoisted above any
+// module-scope const it would otherwise close over.
+const fixtureRoot = join(tmpdir(), `nx-ensure-package-${process.pid}`);
+
+jest.mock('nx/src/devkit-exports', () => ({
+  ...jest.requireActual('nx/src/devkit-exports'),
+  workspaceRoot: require('path').join(
+    require('os').tmpdir(),
+    `nx-ensure-package-${process.pid}`
+  ),
+}));
+
+jest.mock('nx/src/devkit-internals', () => ({
+  ...jest.requireActual('nx/src/devkit-internals'),
+  installPackageToTmp: jest.fn(() => {
+    throw new Error('installPackageToTmp should not have been reached');
+  }),
+}));
+
+import { ensurePackage } from './package-json';
+
+describe('ensurePackage resolution', () => {
+  beforeAll(() => {
+    const packageDir = join(
+      fixtureRoot,
+      'node_modules',
+      'ensure-package-fixture'
+    );
+    mkdirSync(packageDir, { recursive: true });
+    writeFileSync(
+      join(packageDir, 'package.json'),
+      JSON.stringify({
+        name: 'ensure-package-fixture',
+        version: '1.0.0',
+        main: 'index.js',
+      })
+    );
+    writeFileSync(
+      join(packageDir, 'index.js'),
+      `module.exports = { resolvedFrom: 'workspace' };`
+    );
+  });
+
+  afterAll(() => {
+    rmSync(fixtureRoot, { recursive: true, force: true });
+  });
+
+  it('should resolve a package installed in the workspace but not next to @nx/devkit', () => {
+    expect(ensurePackage('ensure-package-fixture', '1.0.0')).toEqual({
+      resolvedFrom: 'workspace',
+    });
+  });
+
+  it('should still resolve packages that are only next to @nx/devkit', () => {
+    expect(ensurePackage('@nx/devkit', '>=15.0.0')).toEqual(
+      require('@nx/devkit')
+    );
+  });
+});

--- a/packages/devkit/src/utils/package-json.ts
+++ b/packages/devkit/src/utils/package-json.ts
@@ -894,7 +894,11 @@ export function ensurePackage<T extends any = any>(
   }
 
   try {
-    return require(pkg);
+    // The workspace comes first so its installed version wins; `__dirname`
+    // keeps the old behaviour as a fallback. A bare `require` would only
+    // resolve from wherever `@nx/devkit` sits, which in a monorepo can be a
+    // different copy of the package than the workspace depends on.
+    return require(require.resolve(pkg, { paths: [workspaceRoot, __dirname] }));
   } catch (e) {
     if (e.code === 'ERR_REQUIRE_ESM') {
       // The package is installed, but is an ESM package.


### PR DESCRIPTION
## Current Behavior

`ensurePackage` loads plugins with a bare `require(pkg)`, which resolves from the module that calls it — `@nx/devkit` — rather than from the workspace being generated into. When those resolve to different copies of a package, a generator loads a different version of a plugin than the workspace depends on, and nothing reports it.

The failure is silent by construction: the generator passes options the plugin it *thinks* it loaded understands, and the plugin that actually loaded ignores what it doesn't recognize.

Concretely, in this repo, `@nx/react` generating an app with `--linter oxlint` calls `ensurePackage('@nx/playwright')`. Resolution starts at `packages/devkit/`, whose `node_modules` is empty, so it walks up to the repo root and finds the published `@nx/playwright` instead of the local one — even though `packages/react/node_modules/@nx/playwright` is correctly linked and declared `workspace:*`. The published copy has no oxlint support, so it received `linter: "oxlint"`, ignored it, and wrote an ESLint config.

This is also internally inconsistent: the install fallback further down already resolves with explicit `paths`, only the fast path does not.

## Expected Behavior

The workspace's installed version wins:

```ts
return require(require.resolve(pkg, { paths: [workspaceRoot, __dirname] }));
```

`__dirname` is kept as a fallback, so a package that is resolvable only next to `@nx/devkit` still loads exactly as before, and a package in neither place still falls through to `installPackageToTmp`.

Beyond this repo, the same skew can occur in nested workspaces, linked/`file:` installs, globally-installed Nx, and monorepos that develop plugins alongside apps.

Considered and rejected: also resolving from the *calling* package, via stack introspection or a new parameter. It would help only this monorepo's layout — real user workspaces keep declared deps at the workspace root, and under strict pnpm the caller's `node_modules` would not have it either, since plugins like `@nx/playwright` are only devDependencies of `@nx/react` and devDeps aren't installed for consumers. Not worth stack introspection in a core utility or a signature change at every call site.

## Related Issue(s)

https://linear.app/nxdev/issue/NXC-4737

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Fix-typescript-sync-to-respect-plugin-include-exclude-NXC-4734-bf9d07aa)
<!-- polygraph-session-end -->