### PR TITLE
fix(core): pin typescript in preset dependencies so npm cannot hoist typescript 7

### DIFF
--- a/packages/workspace/src/generators/new/generate-preset.ts
+++ b/packages/workspace/src/generators/new/generate-preset.ts
@@ -113,18 +113,34 @@ export function generatePreset(host: Tree, opts: NormalizedSchema) {
   }
 }
 
+// `typescript` is pinned here rather than left to `@nx/js:init` so it lands in
+// package.json before the first install. Otherwise npm resolves tsquery's
+// `typescript: >3.0.0` peer to 7.x, whose entry point dropped the compiler API.
 function getPresetDependencies({
   preset,
   presetVersion,
   bundler,
   e2eTestRunner,
+  js,
 }: NormalizedSchema) {
   switch (preset) {
+    // Empty workspaces — no preset generator runs, so `@nx/js:init` never adds
+    // typescript and pinning it here would be net-new.
     case Preset.Apps:
     case Preset.NPM:
+      return { dependencies: {}, dev: { '@nx/js': nxVersion } };
+
     case Preset.TS:
     case Preset.TsStandalone:
-      return { dependencies: {}, dev: { '@nx/js': nxVersion } };
+      return {
+        dependencies: {},
+        dev: {
+          '@nx/js': nxVersion,
+          // ts-standalone prompts for JS vs TS; mirror `@nx/js:init`, which
+          // skips typescript when `js` is set.
+          typescript: js ? undefined : typescriptVersion,
+        },
+      };
 
     case Preset.AngularMonorepo:
     case Preset.AngularStandalone:
@@ -140,7 +156,10 @@ function getPresetDependencies({
       };
 
     case Preset.Express:
-      return { dependencies: {}, dev: { '@nx/express': nxVersion } };
+      return {
+        dependencies: {},
+        dev: { '@nx/express': nxVersion, typescript: typescriptVersion },
+      };
 
     case Preset.Nest:
       return {
@@ -150,7 +169,10 @@ function getPresetDependencies({
 
     case Preset.NextJs:
     case Preset.NextJsStandalone:
-      return { dependencies: { '@nx/next': nxVersion }, dev: {} };
+      return {
+        dependencies: { '@nx/next': nxVersion },
+        dev: { typescript: typescriptVersion },
+      };
 
     case Preset.VueMonorepo:
     case Preset.VueStandalone:
@@ -162,6 +184,7 @@ function getPresetDependencies({
           '@nx/playwright':
             e2eTestRunner === 'playwright' ? nxVersion : undefined,
           '@nx/vite': nxVersion,
+          typescript: typescriptVersion,
         },
       };
 
@@ -174,6 +197,7 @@ function getPresetDependencies({
           '@nx/cypress': e2eTestRunner === 'cypress' ? nxVersion : undefined,
           '@nx/playwright':
             e2eTestRunner === 'playwright' ? nxVersion : undefined,
+          typescript: typescriptVersion,
         },
       };
 
@@ -189,14 +213,21 @@ function getPresetDependencies({
           '@nx/jest': bundler !== 'vite' ? nxVersion : undefined,
           '@nx/vite': bundler === 'vite' ? nxVersion : undefined,
           '@nx/webpack': bundler === 'webpack' ? nxVersion : undefined,
+          typescript: typescriptVersion,
         },
       };
 
     case Preset.ReactNative:
-      return { dependencies: {}, dev: { '@nx/react-native': nxVersion } };
+      return {
+        dependencies: {},
+        dev: { '@nx/react-native': nxVersion, typescript: typescriptVersion },
+      };
 
     case Preset.Expo:
-      return { dependencies: {}, dev: { '@nx/expo': nxVersion } };
+      return {
+        dependencies: {},
+        dev: { '@nx/expo': nxVersion, typescript: typescriptVersion },
+      };
 
     case Preset.WebComponents:
       return {
@@ -211,6 +242,7 @@ function getPresetDependencies({
         dev: {
           '@nx/node': nxVersion,
           '@nx/webpack': bundler === 'webpack' ? nxVersion : undefined,
+          typescript: typescriptVersion,
         },
       };
 

--- a/packages/workspace/src/generators/new/new.spec.ts
+++ b/packages/workspace/src/generators/new/new.spec.ts
@@ -95,6 +95,56 @@ describe('new', () => {
       expect(readJson(tree, 'my-workspace/package.json')).toMatchSnapshot();
     });
 
+    it('should not add typescript for presets that scaffold nothing', async () => {
+      for (const preset of [Preset.Apps, Preset.NPM]) {
+        tree = createTree();
+        tree.root = process.cwd();
+
+        await newGenerator(tree, {
+          ...defaultOptions,
+          name: 'my-workspace',
+          directory: 'my-workspace',
+          appName: 'app',
+          preset,
+        });
+
+        const { devDependencies } = readJson(tree, 'my-workspace/package.json');
+        expect(devDependencies).not.toHaveProperty('typescript');
+      }
+    });
+
+    it('should generate necessary npm dependencies for ts preset', async () => {
+      await newGenerator(tree, {
+        ...defaultOptions,
+        name: 'my-workspace',
+        directory: 'my-workspace',
+        appName: 'app',
+        preset: Preset.TS,
+      });
+
+      const { devDependencies } = readJson(tree, 'my-workspace/package.json');
+      expect(devDependencies).toStrictEqual({
+        '@nx/js': nxVersion,
+        '@nx/workspace': nxVersion,
+        nx: nxVersion,
+        typescript: typescriptVersion,
+      });
+    });
+
+    it('should not add typescript for ts-standalone preset when using js', async () => {
+      await newGenerator(tree, {
+        ...defaultOptions,
+        name: 'my-workspace',
+        directory: 'my-workspace',
+        appName: 'app',
+        preset: Preset.TsStandalone,
+        js: true,
+      });
+
+      const { devDependencies } = readJson(tree, 'my-workspace/package.json');
+      expect(devDependencies).not.toHaveProperty('typescript');
+    });
+
     it('should generate necessary npm dependencies for react preset', async () => {
       await newGenerator(tree, {
         ...defaultOptions,
@@ -111,6 +161,7 @@ describe('new', () => {
         '@nx/vite': nxVersion,
         '@nx/workspace': nxVersion,
         nx: nxVersion,
+        typescript: typescriptVersion,
       });
     });
 
@@ -131,6 +182,7 @@ describe('new', () => {
         '@nx/vite': nxVersion,
         '@nx/workspace': nxVersion,
         nx: nxVersion,
+        typescript: typescriptVersion,
       });
     });
 
@@ -150,6 +202,7 @@ describe('new', () => {
         '@nx/cypress': nxVersion,
         '@nx/workspace': nxVersion,
         nx: nxVersion,
+        typescript: typescriptVersion,
       });
     });
 


### PR DESCRIPTION
## Current Behavior

`create-nx-workspace` fails for most framework presets:

```
✔ Installing dependencies with npm
✖ Creating your workspace in test

 NX   Failed to create workspace

Failed to create a workspace:
 NX   ts.readConfigFile is not a function
```

TypeScript 7 is now `latest` on npm. Its main entry point exports only `version` and `versionMajorMinor` — the compiler API moved to `typescript/unstable/*` and is not a drop-in replacement (no `readConfigFile`, `parseJsonConfigFileContent`, `resolveModuleName`, `createProgram`, or `createCompilerHost` anywhere in those subpaths, including today's `7.1.0-dev` nightly).

`@phenomnomnominal/tsquery` declares `typescript: >3.0.0` as a peer dependency. npm auto-installs peers, so when the new workspace's `package.json` has no `typescript` entry, npm resolves that peer to the newest major — 7.x — and hoists it to the workspace root. The preset generator then reaches `getNeededCompilerOptionOverrides` and calls `ts.readConfigFile` on a module that no longer has it.

Whether this bites depends on npm hoisting order, which is why only some presets break:

```
next:   @nx/next → tsquery → typescript@7.0.2      ← depth 1, wins the root slot
        @nx/next → @nx/eslint → typescript@6.0.3   ← depth 2, gets nested

node:   @nx/node → @nx/eslint → typescript@6.0.3   ← wins the root slot
        @nx/node → @nx/jest → tsquery              ← deduped to 6.0.3
```

`angular`, `nest` and `web-components` already pinned `typescript` in their preset dependencies and were unaffected. Verified on `create-nx-workspace@23.1.0` with npm:

| preset | result |
| --- | --- |
| `angular-monorepo` (pinned) | exit 0, root `typescript` 6.0.3 |
| `next` (unpinned) | exit 1, `ts.readConfigFile is not a function` |

## Expected Behavior

`getPresetDependencies` pins `typescript` for the remaining presets that scaffold a TypeScript project: express, next (+ standalone), vue, nuxt, react (+ standalone), react-native, expo, node, ts and ts-standalone. The pin lands in `package.json` before the first install, so npm resolves tsquery's peer against it instead of against `latest`.

This adds nothing to the final workspace. `@nx/js:init` already installs the same `~6.0.3`; the pin only changes *when* it is written — before the install rather than after — which is what npm needs in order to resolve the peer correctly.

`apps` and `npm` are split out of the case they shared with the TS presets and deliberately left unpinned: neither runs a preset generator (`preset.ts` returns immediately for `apps`, and `new.ts` skips `generatePreset` for `npm`), so `@nx/js:init` never runs and `typescript` would be net-new there. Neither pulls tsquery, so neither is exposed.

`ts-standalone` is the only preset that forwards `js` to its generator (`preset.ts:324`) and the only one that prompts for JS vs TS, so its pin mirrors `@nx/js:init` and is skipped when `js` is set.

### Notes for reviewers

- This makes workspace creation deterministic; it does not add TypeScript 7 support. A workspace that installs TypeScript 7 deliberately still hits the same `TypeError` from the project graph via the bare `require('typescript')` in `packages/nx/src/plugins/js/utils/typescript.ts`. That is #36306 and is out of scope here.
- Tests: 3 existing assertions in `new.spec.ts` (react/vue/nuxt) updated to include `typescript`, matching the existing angular assertion. 3 new tests cover the split — `apps`/`npm` stay TypeScript-free, `ts` gets the pin, and `ts-standalone --js` does not.

## Related Issue(s)

Related to #36306 (Nx does not yet support the TypeScript 7 API). That issue is **not** fixed by this PR and should stay open.

Fixes N/A

<!-- polygraph-session-start -->
---
[View session information ↗](https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Pin-typescript-in-create-nx-workspace-preset-dependencies-84db677c)
<!-- polygraph-session-end -->