### PR TITLE
fix(core): apply legacy array-form targetDefaults instead of silently dropping them

### DIFF
--- a/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.spec.ts
@@ -1538,6 +1538,95 @@ describe('project-configuration-utils', () => {
       expect(errors).toEqual([]);
     });
 
+    it('should apply legacy array-form targetDefaults to an inferred target that project.json does not redeclare (#36489)', () => {
+      // Repro for #36489: nx.json still carries the top-level-array
+      // `targetDefaults` shape written by the Nx 23 beta migration
+      // (`23-0-0-convert-target-defaults-to-array`). @nx/docker infers
+      // `docker:build` with its own `dependsOn`, and project.json declares
+      // `build` and `prune` but never redeclares `docker:build`. Before the
+      // fix the array was read as a record, so its integer keys matched no
+      // target and the `docker:build` default was silently dropped — the
+      // resolved target kept only the plugin's `['build', '^build']`.
+      const specifiedResults = [
+        [
+          [
+            '@nx/docker',
+            'apps/api/Dockerfile',
+            {
+              projects: {
+                'apps/api': {
+                  root: 'apps/api',
+                  targets: {
+                    'docker:build': {
+                      dependsOn: ['build', '^build'],
+                      command: 'docker build .',
+                      options: {
+                        cwd: 'apps/api',
+                        args: ['--tag', 'api:latest'],
+                      },
+                      inputs: ['default', '^default'],
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        ],
+      ] as const;
+
+      const defaultResults = [
+        [
+          [
+            'nx/core/project-json',
+            'apps/api/project.json',
+            {
+              projects: {
+                'apps/api': {
+                  name: 'api',
+                  root: 'apps/api',
+                  targets: {
+                    build: {
+                      executor: 'nx:run-commands',
+                      options: { command: 'echo build' },
+                    },
+                    prune: {
+                      executor: 'nx:run-commands',
+                      options: { command: 'echo prune' },
+                    },
+                  },
+                },
+              },
+            },
+          ],
+        ],
+      ] as const;
+
+      const errors = [];
+      const result = mergeCreateNodesResults(
+        specifiedResults as any,
+        defaultResults as any,
+        {
+          targetDefaults: [
+            { target: 'lint', dependsOn: ['build'] },
+            { target: 'docker:build', dependsOn: ['build', 'prune'] },
+          ] as any,
+        },
+        '/tmp/test',
+        errors
+      );
+
+      const dockerBuild =
+        result.projectRootMap['apps/api'].targets!['docker:build'];
+      // The targetDefaults contribution replaces the inferred dependsOn.
+      expect(dockerBuild.dependsOn).toEqual(['build', 'prune']);
+      // The inferred target's identity is untouched.
+      expect(dockerBuild.executor).toEqual('nx:run-commands');
+      expect(dockerBuild.options).toEqual(
+        expect.objectContaining({ command: 'docker build .' })
+      );
+      expect(errors).toEqual([]);
+    });
+
     it('should merge multiple specified plugins contributing to the same project', () => {
       const specifiedResults = [
         [

--- a/packages/nx/src/project-graph/utils/project-configuration/target-defaults.spec.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-defaults.spec.ts
@@ -42,6 +42,95 @@ describe('normalizeTargetDefaults', () => {
       normalizeTargetDefaults({ test: [{ cache: false }] })
     );
   });
+
+  // The Nx 23 beta migration `23-0-0-convert-target-defaults-to-array`
+  // rewrote nx.json into a top-level array of `target`/`executor`-keyed
+  // entries before stable settled on the map form. Reading that array as a
+  // record produced integer keys that never matched a target, silently
+  // dropping every default.
+  describe('legacy top-level array form (#36489)', () => {
+    it('keys a target entry by its target name', () => {
+      expect(
+        normalizeTargetDefaults([
+          { target: 'docker:build', dependsOn: ['build', 'prune'] },
+        ])
+      ).toEqual({
+        'docker:build': [{ dependsOn: ['build', 'prune'] }],
+      });
+    });
+
+    it('keys an entry with no target by its executor, keeping the executor out of the config', () => {
+      expect(
+        normalizeTargetDefaults([
+          { executor: '@nx/js:tsc', cache: true, dependsOn: ['^build'] },
+        ])
+      ).toEqual({
+        '@nx/js:tsc': [{ cache: true, dependsOn: ['^build'] }],
+      });
+    });
+
+    it('keeps an executor alongside a target as a config value, matching the record form', () => {
+      expect(
+        normalizeTargetDefaults([
+          {
+            target: 'prune-lockfile',
+            executor: '@nx/js:prune-lockfile',
+            cache: true,
+          },
+        ])
+      ).toEqual({
+        'prune-lockfile': [{ executor: '@nx/js:prune-lockfile', cache: true }],
+      });
+    });
+
+    it('moves projects and plugin matchers into the filter namespace', () => {
+      expect(
+        normalizeTargetDefaults([
+          {
+            target: 'test',
+            projects: 'tag:test-runner:vite',
+            plugin: '@nx/vite',
+            inputs: ['vite.config.ts'],
+          },
+        ])
+      ).toEqual({
+        test: [
+          {
+            filter: {
+              projects: ['tag:test-runner:vite'],
+              plugin: '@nx/vite',
+            },
+            inputs: ['vite.config.ts'],
+          },
+        ],
+      });
+    });
+
+    it('accumulates repeated keys in document order', () => {
+      expect(
+        normalizeTargetDefaults([
+          { target: 'test', cache: true },
+          { target: 'test', plugin: '@nx/vite', inputs: ['vite.config.ts'] },
+        ])
+      ).toEqual({
+        test: [
+          { cache: true },
+          { filter: { plugin: '@nx/vite' }, inputs: ['vite.config.ts'] },
+        ],
+      });
+    });
+
+    it('skips entries with neither a target nor an executor', () => {
+      expect(
+        normalizeTargetDefaults([
+          { cache: true },
+          { target: 'build', dependsOn: ['^build'] },
+        ])
+      ).toEqual({
+        build: [{ dependsOn: ['^build'] }],
+      });
+    });
+  });
 });
 
 describe('readTargetDefaultsForTarget (nested-array)', () => {
@@ -55,6 +144,15 @@ describe('readTargetDefaultsForTarget (nested-array)', () => {
     expect(
       readTargetDefaultsForTarget('lint', { build: { cache: true } })
     ).toBeNull();
+  });
+
+  it('resolves defaults written in the legacy top-level array form (#36489)', () => {
+    expect(
+      readTargetDefaultsForTarget('docker:build', [
+        { target: 'lint', dependsOn: ['build'] },
+        { target: 'docker:build', dependsOn: ['build', 'prune'] },
+      ] as any)
+    ).toEqual({ dependsOn: ['build', 'prune'] });
   });
 
   describe('inner accumulate-and-merge', () => {

--- a/packages/nx/src/project-graph/utils/project-configuration/target-defaults.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-defaults.ts
@@ -155,7 +155,11 @@ export function createTargetDefaultsResults(
   // layers a key's entries in document order, later winning.
   const results: CreateNodesResultEntry[] = [];
   for (const key of Object.keys(syntheticProjectsByKeyIndex)) {
-    const isArrayForm = Array.isArray(targetDefaultsConfig[key]);
+    // The legacy top-level array form normalizes every key to an entry array,
+    // so its source locations are indexed like the map shape's array values.
+    const isArrayForm =
+      Array.isArray(targetDefaultsConfig) ||
+      Array.isArray(targetDefaultsConfig[key]);
     const indices = Object.keys(syntheticProjectsByKeyIndex[key])
       .map(Number)
       .sort((a, b) => a - b);
@@ -535,17 +539,75 @@ function stripFilter(
 }
 
 /**
+ * The top-level-array `targetDefaults` shape from the Nx 23 beta cycle. Each
+ * entry carries its own matcher: a `target` name/glob (or, when absent, its
+ * `executor`), plus optional `projects`/`plugin` matchers. The
+ * `23-0-0-convert-target-defaults-to-array` migration rewrote workspaces into
+ * this shape before the stable release replaced it with the map form, so
+ * migrated workspaces may still carry it in nx.json.
+ */
+type LegacyArrayTargetDefaultEntry = {
+  target?: string;
+  projects?: string | string[];
+  plugin?: string;
+} & Partial<TargetConfiguration>;
+
+/**
  * Normalize the public `targetDefaults` map to the internal shape: every
  * key's value becomes an array of entries (a bare object → a single catch-all
  * entry).
  */
 export function normalizeTargetDefaults(
-  raw: TargetDefaults | undefined
+  raw: TargetDefaults | LegacyArrayTargetDefaultEntry[] | undefined
 ): NormalizedTargetDefaults {
   if (!raw) return {};
+  // The Nx 23 betas stored `targetDefaults` as a top-level array (the
+  // `23-0-0-convert-target-defaults-to-array` migration rewrote workspaces
+  // into that shape before stable settled on the map form). Reading that
+  // array as a record would produce integer keys that never match a target,
+  // silently dropping every default (#36489) — convert it instead.
+  if (Array.isArray(raw)) {
+    return normalizeLegacyArrayTargetDefaults(raw);
+  }
   const normalized: NormalizedTargetDefaults = {};
   for (const key of Object.keys(raw)) {
     normalized[key] = normalizeTargetDefaultValue(raw[key]);
+  }
+  return normalized;
+}
+
+/**
+ * Converts the legacy top-level array form to the internal map shape — the
+ * inverse of the beta migration's `legacyKeyToEntries`: an entry's `target`
+ * becomes the map key (an entry may also set `executor` as a config value,
+ * matching the record form's target-name keys); with no `target`, the
+ * `executor` is the key itself and is not part of the config, matching the
+ * record form's executor keys. `projects`/`plugin` matchers move into the
+ * entry's `filter` namespace. Entries with no usable key cannot match any
+ * target and are skipped. Repeated keys accumulate in document order, which
+ * the in-key merge already resolves last-match-wins.
+ */
+function normalizeLegacyArrayTargetDefaults(
+  entries: LegacyArrayTargetDefaultEntry[]
+): NormalizedTargetDefaults {
+  const normalized: NormalizedTargetDefaults = {};
+  for (const entry of entries) {
+    if (!entry || typeof entry !== 'object') continue;
+    const { target, projects, plugin, ...config } = entry;
+    const key = target ?? config.executor;
+    if (typeof key !== 'string' || key === '') continue;
+    if (target === undefined) {
+      delete config.executor;
+    }
+    const filterProjects = typeof projects === 'string' ? [projects] : projects;
+    const normalizedEntry: TargetDefaultArrayEntry = { ...config };
+    if (filterProjects?.length || plugin) {
+      normalizedEntry.filter = {
+        ...(filterProjects?.length ? { projects: filterProjects } : {}),
+        ...(plugin ? { plugin } : {}),
+      };
+    }
+    (normalized[key] ??= []).push(normalizedEntry);
   }
   return normalized;
 }


### PR DESCRIPTION
Fixes #36489, reported by @thdk.

The Nx 23 beta shipped a migration (`23-0-0-convert-target-defaults-to-array`) that rewrote `nx.json` `targetDefaults` into an array of `{target/executor, ...config}` entries. Stable Nx 23 settled on the map shape and deleted the migration, but `normalizeTargetDefaults` reads a leftover array as a record, producing integer keys ("0", "1", ...) that never match any target, so every default, like the reporter's `docker:build` `dependsOn`, is silently dropped.

For what it's worth, the map form merges onto inferred @nx/docker targets correctly (verified with a harness), so the trigger is purely the leftover array shape; the reporter's demo repo has the beta migration in its git history.

The fix teaches `normalizeTargetDefaults` (the single choke point used by both graph-merge synthesis and `readTargetDefaultsForTarget`) to convert the legacy array back to map form: `target` (or `executor` when no target) becomes the key, and `projects`/`plugin` matchers map onto the filter namespace. Eight regression tests (six normalizer, one reader, one end-to-end repro of the issue's docker scenario) fail without the fix; 198 tests pass across the four related spec files with zero new failures. tsc and prettier clean.
