### PR TITLE
fix(docker): run release pipeline docker commands without a shell

### DIFF
--- a/e2e/docker/src/docker.test.ts
+++ b/e2e/docker/src/docker.test.ts
@@ -1,4 +1,5 @@
 import {
+  checkFilesDoNotExist,
   checkFilesExist,
   cleanupProject,
   createFile,
@@ -68,6 +69,28 @@ describe('Docker E2Es', () => {
       );
       expect(releaseResult.includes('Successfully ran target')).toBeTruthy();
     });
+
+    it(
+      'should not run shell metacharacters in a docker version',
+      () => {
+        const myapp = uniq('myapp');
+        createDockerApp(myapp);
+        addDockerReleaseConfiguration(myapp);
+        addDockerPluginIfNotExists();
+
+        runCLI(`reset`);
+        runCLI(`run ${myapp}:docker:build`);
+
+        // The ';' used to terminate the `docker tag` shell string, running the
+        // rest as a second command. Versioning now fails on the invalid ref.
+        runCLI(`release version --dockerVersion='1.0.0; touch injected.txt'`, {
+          silenceError: true,
+        });
+
+        checkFilesDoNotExist('injected.txt');
+      },
+      TEN_MINS_MS
+    );
 
     it(
       'should skip default tag when skipDefaultTag is true',

--- a/packages/docker/src/executors/release-publish/release-publish.impl.ts
+++ b/packages/docker/src/executors/release-publish/release-publish.impl.ts
@@ -5,7 +5,7 @@ import {
   workspaceRoot,
 } from '@nx/devkit';
 import { signalToCode } from '@nx/devkit/internal';
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 import type { DockerReleasePublishSchema } from './schema';
 import { existsSync, readFileSync } from 'fs';
 import { getDockerVersionPath } from '../../release/version-utils';
@@ -86,8 +86,11 @@ async function checkDockerImageExistsLocally(imageRef: string) {
       const normalizedImageRef = imageRef.startsWith('docker.io/')
         ? imageRef.split('docker.io/')[1]
         : imageRef;
-      const childProcess = exec(
-        `docker images --filter "reference=${normalizedImageRef}" --quiet`,
+      // Pass args as an array (no shell) so the reference read back from the
+      // .docker-version file can't break out into command injection.
+      const childProcess = execFile(
+        'docker',
+        ['images', '--filter', `reference=${normalizedImageRef}`, '--quiet'],
         { encoding: 'utf8', windowsHide: true }
       );
       let result = '';
@@ -113,8 +116,9 @@ async function checkDockerImageExistsLocally(imageRef: string) {
 async function dockerPush(imageReference: string, quiet: boolean) {
   try {
     return await new Promise((res, rej) => {
-      const childProcess = exec(
-        `docker push ${imageReference}${quiet ? ' --quiet' : ''}`,
+      const childProcess = execFile(
+        'docker',
+        ['push', imageReference, ...(quiet ? ['--quiet'] : [])],
         {
           encoding: 'utf8',
           maxBuffer: LARGE_BUFFER,

--- a/packages/docker/src/release/version-utils.ts
+++ b/packages/docker/src/release/version-utils.ts
@@ -1,4 +1,4 @@
-import { execSync } from 'child_process';
+import { execFileSync } from 'child_process';
 import { writeFileSync, mkdirSync } from 'fs';
 import { dirname, join } from 'path';
 import { prompt } from 'enquirer';
@@ -134,7 +134,9 @@ function updateProjectVersion(
   const fullImageRef =
     nxDockerImageRefEnvOverride ?? `${newImageRef}:${newVersion}`;
   if (!isDryRun) {
-    execSync(`docker tag ${imageRef} ${fullImageRef}`, {
+    // argv array, not a shell string - the image ref is assembled from workspace
+    // config, CLI flags and env, so it can't be trusted as shell input.
+    execFileSync('docker', ['tag', imageRef, fullImageRef], {
       windowsHide: true,
     });
   }


### PR DESCRIPTION
## Current Behavior

`docker tag`, `docker push` and `docker images` in the `@nx/docker` release pipeline are built as interpolated shell strings. Registry url, repository name, version scheme, `--docker-version` and `NX_DOCKER_IMAGE_REF` all flow in unescaped, so a `;` in any of them runs arbitrary commands on the release machine.

## Expected Behavior

Args passed as arrays via `execFile`/`execFileSync`. No shell, so metacharacters stay inside a single argument. Behavior unchanged for legitimate refs.

## Related Issue(s)

NXC-4736

<!-- polygraph-session-start -->
---
<p><picture><source media="(prefers-color-scheme: dark)" srcset="https://static.ops.cloud.nx.app/polygraph/session-logo-v4-dark.svg"><img src="https://static.ops.cloud.nx.app/polygraph/session-logo-v4-light.svg" width="16" height="22" align="middle" alt="Polygraph"></picture> <a href="https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/mighty-swan-7f62c2f9">View session ↗</a></p>
<!-- polygraph-session-end -->