### PR TITLE
chore(testing): stop e2e harness verbosity from adding --verbose to commands under test

### DIFF
--- a/e2e/utils/command-utils.ts
+++ b/e2e/utils/command-utils.ts
@@ -23,6 +23,7 @@ import {
   getPublishedVersion,
   getStrippedEnvironmentVariables,
   getYarnMajorVersion,
+  isVerbose,
   isVerboseE2ERun,
 } from './get-env-info';
 import { logError, logInfo } from './log-utils';
@@ -360,7 +361,7 @@ export function runCLIAsync(
 ): Promise<{ stdout: string; stderr: string; combinedOutput: string }> {
   const pm = getPackageManagerCommand();
   const commandToRun = `${opts.silent ? pm.runNxSilent : pm.runNx} ${command} ${
-    (opts.verbose ?? isVerboseE2ERun()) ? ' --verbose' : ''
+    (opts.verbose ?? isVerbose()) ? ' --verbose' : ''
   }${opts.redirectStderr ? ' 2>&1' : ''}`;
 
   return runCommandAsync(commandToRun, opts);
@@ -453,7 +454,9 @@ export function runCLI(
   try {
     const pm = getPackageManagerCommand();
     const commandToRun = `${pm.runNxSilent} ${command} ${
-      (opts.verbose ?? isVerboseE2ERun()) ? ' --verbose' : ''
+      // NX_E2E_VERBOSE_LOGGING controls harness echoing only. Adding --verbose to
+      // the command under test changes the output snapshots were recorded against.
+      (opts.verbose ?? isVerbose()) ? ' --verbose' : ''
     }${opts.redirectStderr ? ' 2>&1' : ''}`;
     logInfo(`Run Command: ${command}`);
     const startTime = performance.now();


### PR DESCRIPTION
## Current Behavior

The nightly E2E matrix sets `NX_E2E_VERBOSE_LOGGING=true`, which makes `runCLI`/`runCLIAsync` append `--verbose` to every nx command under test. Verbose-only output then appears in results whose snapshots were recorded without it, so 114 of the 302 distinct nightly failures are snapshot mismatches (mostly e2e-release inline snapshots plus `nx show target`).

## Expected Behavior

`NX_E2E_VERBOSE_LOGGING` controls harness echoing only. `--verbose` is appended only when the run asked for it (`NX_VERBOSE_LOGGING` / `--verbose`) or a call site passes `opts.verbose`. Tests that want verbose output already put `--verbose` in the command string.

## Related Issue(s)

NXC-4612

<!-- polygraph-session-start -->
---
<p><picture><source media="(prefers-color-scheme: dark)" srcset="https://static.ops.cloud.nx.app/polygraph/session-logo-v4-dark.svg"><img src="https://static.ops.cloud.nx.app/polygraph/session-logo-v4-light.svg" width="16" height="22" align="middle" alt="Polygraph"></picture> <a href="https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/tidy-condor-02183c70">View session ↗</a></p>
<!-- polygraph-session-end -->