### PR TITLE
fix(linter): do not infer projects from package.json files outside the workspaces

### DIFF
--- a/packages/eslint/src/plugins/plugin.spec.ts
+++ b/packages/eslint/src/plugins/plugin.spec.ts
@@ -371,6 +371,23 @@ describe('@nx/eslint/plugin', () => {
       `);
     });
 
+    it('should not create a node for a package.json the package manager workspaces do not cover', async () => {
+      createFiles({
+        '.eslintrc.json': `{}`,
+        'package.json': `{"name":"root","private":true,"workspaces":["packages/*"]}`,
+        'packages/a/package.json': `{"name":"a"}`,
+        'packages/a/index.ts': `console.log('hello world')`,
+        // A bundler marker, not a project. It has no name, so promoting it to a
+        // project root fails the whole graph with ProjectsWithNoNameError.
+        'packages/a/src/runtime/polyfill/package.json': `{"sideEffects":true}`,
+        'packages/a/src/runtime/polyfill/index.ts': `console.log('polyfill')`,
+      });
+      const { projects } = await invokeCreateNodesOnMatchingFiles(context, {
+        targetName: 'lint',
+      });
+      expect(Object.keys(projects)).toEqual(['packages/a']);
+    });
+
     it('should not create a node for a nested project (with a package.json and no lintable files) which does not have its own eslint config if accompanied by a root level eslint config', async () => {
       createFiles({
         '.eslintrc.json': `{}`,

--- a/packages/eslint/src/plugins/plugin.ts
+++ b/packages/eslint/src/plugins/plugin.ts
@@ -21,6 +21,11 @@ import { existsSync } from 'node:fs';
 import { relative as nativeRelative, sep as nativeSep } from 'node:path';
 import { basename, dirname, join, normalize, sep } from 'node:path/posix';
 import { hashObject } from 'nx/src/hasher/file-hasher';
+import {
+  buildPackageJsonPatterns,
+  buildPackageJsonWorkspacesMatcher,
+} from 'nx/src/plugins/package-json/create-nodes';
+import { readJsonFile } from 'nx/src/utils/fileutils';
 import { workspaceDataDirectory } from 'nx/src/utils/cache-directory';
 import { combineGlobPatterns } from 'nx/src/utils/globs';
 import { globWithWorkspaceContext } from 'nx/src/utils/workspace-context';
@@ -167,7 +172,7 @@ export const createNodes: CreateNodes<EslintPluginOptions> = [
     const targetsCache = new PluginCache<EslintProjects>(cachePath);
 
     const { eslintConfigFiles, projectRoots, projectRootsByEslintRoots } =
-      splitConfigFiles(configFiles);
+      splitConfigFiles(configFiles, context.workspaceRoot);
     const lintableFilesPerProjectRoot = await collectLintableFilesByProjectRoot(
       projectRoots,
       options,
@@ -240,19 +245,51 @@ export const createNodes: CreateNodes<EslintPluginOptions> = [
 
 export const createNodesV2 = createNodes;
 
-function splitConfigFiles(configFiles: readonly string[]): {
+function splitConfigFiles(
+  configFiles: readonly string[],
+  workspaceRoot: string
+): {
   eslintConfigFiles: string[];
   projectRoots: string[];
   projectRootsByEslintRoots: Map<string, string[]>;
 } {
   const eslintConfigFiles: string[] = [];
-  const projectRoots = new Set<string>();
+  const packageJsonFiles: string[] = [];
+  const projectJsonRoots = new Set<string>();
 
   for (const configFile of configFiles) {
-    if (PROJECT_CONFIG_FILENAMES.includes(basename(configFile))) {
-      projectRoots.add(dirname(configFile));
+    const fileName = basename(configFile);
+    if (fileName === 'package.json') {
+      packageJsonFiles.push(configFile);
+    } else if (fileName === 'project.json') {
+      projectJsonRoots.add(dirname(configFile));
     } else {
       eslintConfigFiles.push(configFile);
+    }
+  }
+
+  // A package.json outside the package manager's workspaces is not a project —
+  // nested marker files (`{"sideEffects": false}` next to a bundle, say) have no
+  // `name`, and promoting one to a project root fails the whole graph with
+  // ProjectsWithNoNameError. Nx core's own package-json plugin applies the same
+  // filter. An empty `positive` means no workspaces are declared at all, i.e. a
+  // standalone repo whose root package.json *is* the project — filtering there
+  // would reject even that root, so skip the check entirely.
+  const patterns = buildPackageJsonPatterns(workspaceRoot, (f) =>
+    readJsonFile(join(workspaceRoot, f))
+  );
+  const isInPackageManagerWorkspaces = patterns.positive.length
+    ? buildPackageJsonWorkspacesMatcher(patterns)
+    : () => true;
+
+  const projectRoots = new Set<string>(projectJsonRoots);
+  for (const packageJsonFile of packageJsonFiles) {
+    // Next to a project.json it is a project regardless of the workspaces globs.
+    if (
+      isInPackageManagerWorkspaces(packageJsonFile) ||
+      projectJsonRoots.has(dirname(packageJsonFile))
+    ) {
+      projectRoots.add(dirname(packageJsonFile));
     }
   }
 


### PR DESCRIPTION
## Current Behavior

`@nx/eslint`'s inference plugin globs `**/package.json`, and `splitConfigFiles` promotes **every** matching directory to a project root:

```ts
const PROJECT_CONFIG_FILENAMES = ['project.json', 'package.json'];

for (const configFile of configFiles) {
  if (PROJECT_CONFIG_FILENAMES.includes(basename(configFile))) {
    projectRoots.add(dirname(configFile));   // <- no workspaces filter
  } else {
    eslintConfigFiles.push(configFile);
  }
}
```

Nested `package.json` files are very often **markers, not projects** — a `{"sideEffects": false}` beside a bundle, a polyfill directory stub, a `workers-site` folder. Those have no `name`, so once promoted they fail the entire graph:

```
NX   Failed to process project graph.
The projects in the following directories have no name provided:
  - fixtures/legacy-site-app/workers-site
  - packages/unenv-preset/src/runtime/polyfill
```

The throw is unconditional (`project-nodes-manager.ts:268`), so one stray marker file takes down the whole workspace — and the error names a directory the user never asked to be a project, which makes it hard to trace back to the linter plugin.

Nx core's own package-json plugin already guards against exactly this in `packages/nx/src/plugins/package-json/create-nodes.ts`:

```ts
if (!isInPackageManagerWorkspaces && !isNextToProjectJson(packageJsonPath)) {
  // Skip if package.json is not part of the package.json workspaces and not next to a project.json.
  return null;
}
```

`@nx/eslint` did not.

## Expected Behavior

Package.json files are filtered through the package manager's workspaces globs before becoming project roots, reusing the core helpers (`buildPackageJsonPatterns` / `buildPackageJsonWorkspacesMatcher`) so the two plugins cannot drift. A package.json sitting next to a `project.json` is still a project regardless of the globs.

### The non-obvious part

The "no workspaces declared" case has to skip the filter entirely:

```ts
const isInPackageManagerWorkspaces = patterns.positive.length
  ? buildPackageJsonWorkspacesMatcher(patterns)
  : () => true;
```

With no `workspaces` field, `buildPackageJsonPatterns` returns empty patterns and the matcher rejects *everything* — including the root `package.json` of a standalone repo that **is** the project. Filtering unconditionally deletes the root project and breaks the existing `'.'` tests. This guard is load-bearing, not defensive.

## Validation

**Test-first.** The new spec was confirmed red against the unfixed plugin, and the failure is precisely the bug:

```
- Expected  - 0
+ Received  + 1
  Array [
    "packages/a",
+   "packages/a/src/runtime/polyfill",
  ]
```

Green after the fix. `build`, `test` and `lint` all pass for `@nx/eslint` (31 tests; the single remaining lint warning is a pre-existing skipped test at `plugin.spec.ts:89`).

**No collateral damage.** I captured `nx show projects` for this repo with and without the change: **145 projects, byte-identical both ways.** The fix only removes bogus promotions — it does not drop a single real project. The pre-existing test asserting that a nameless `apps/my-app/package.json` *does* get a node (no workspaces declared) still passes, which is the guard above doing its job.

## Related Issue(s)

NXC-4746 — https://linear.app/nxdev/issue/NXC-4746/nxeslint-infers-projects-from-packagejson-files-outside-the-package

The same defect exists in `@nx/oxlint` and is being fixed on #36491, where it was originally found. This half is independent and ships today, so it is split out here.

<!-- polygraph-session-start -->
---
<p><picture><source media="(prefers-color-scheme: dark)" srcset="https://static.ops.cloud.nx.app/polygraph/session-logo-v4-dark.svg"><img src="https://static.ops.cloud.nx.app/polygraph/session-logo-v4-light.svg" width="16" height="22" align="middle" alt="Polygraph"></picture> <a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Graduate-nx-oxlint-from-labs-into-packages-oxlint-NXC-4312-33c21af4">View session ↗</a></p>
<!-- polygraph-session-end -->