### PR TITLE
fix(core): parse pnpm lockfiles that omit the packages block

### DIFF
--- a/packages/nx/src/plugins/js/lock-file/pnpm-parser.spec.ts
+++ b/packages/nx/src/plugins/js/lock-file/pnpm-parser.spec.ts
@@ -3017,4 +3017,54 @@ snapshots:
       ).toThrow(/was not installed with pnpm/);
     });
   });
+
+  describe('workspace-only lockfile', () => {
+    // pnpm omits the `packages` block entirely when every dependency resolves
+    // to a `link:`/`workspace:` reference, so there is nothing external to lock.
+    const lockFile = `lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      my-plugin:
+        specifier: link:../my-plugin
+        version: link:../my-plugin
+`;
+
+    beforeEach(() => {
+      // The parser requires `.modules.yaml` to exist; a workspace with no
+      // external packages hoists nothing.
+      vol.fromJSON(
+        { 'node_modules/.modules.yaml': 'hoistedDependencies: {}\n' },
+        '/root'
+      );
+    });
+
+    it('should produce no external nodes', () => {
+      const result = getPnpmLockfileNodes(lockFile, '__workspace_only__');
+
+      expect(result.nodes).toEqual({});
+    });
+
+    it('should produce no dependencies', () => {
+      const { keyMap } = getPnpmLockfileNodes(lockFile, '__workspace_only__');
+      const ctx: CreateDependenciesContext = {
+        projects: {},
+        externalNodes: {},
+        fileMap: { nonProjectFiles: [], projectFileMap: {} },
+        filesToProcess: { nonProjectFiles: [], projectFileMap: {} },
+        nxJsonConfiguration: null,
+        workspaceRoot: '/virtual',
+      };
+
+      expect(
+        getPnpmLockfileDependencies(lockFile, '__workspace_only__', ctx, keyMap)
+      ).toEqual([]);
+    });
+  });
 });

--- a/packages/nx/src/plugins/js/lock-file/pnpm-parser.ts
+++ b/packages/nx/src/plugins/js/lock-file/pnpm-parser.ts
@@ -306,7 +306,8 @@ function getNodes(
     hash?: string;
     alias?: boolean;
   }>();
-  for (const [key, snapshot] of Object.entries(data.packages)) {
+  // pnpm omits the packages block for workspace-only lockfiles (no external deps)
+  for (const [key, snapshot] of Object.entries(data.packages ?? {})) {
     let packageNameObj;
     const originalPackageName = extractNameFromKey(key, isV5);
     if (!originalPackageName) {
@@ -539,7 +540,8 @@ function getDependencies(
   ctx: CreateDependenciesContext
 ): RawProjectGraphDependency[] {
   const results: RawProjectGraphDependency[] = [];
-  Object.keys(data.packages).forEach((key) => {
+  // pnpm omits the packages block for workspace-only lockfiles (no external deps)
+  Object.keys(data.packages ?? {}).forEach((key) => {
     const snapshot = data.packages[key];
     const nodes = keyMap.get(key);
     nodes.forEach((node) => {


### PR DESCRIPTION
## Current Behavior

pnpm omits the `packages:` block entirely when every dependency resolves to a `link:`/`workspace:` reference — there is nothing external to lock. Nx's pnpm parser iterates that block unguarded, so any such workspace fails to build a project graph at all:

```
NX   Failed to process project graph.

     - pnpm-lock.yaml:
       TypeError: Cannot convert undefined or null to object
           at Object.entries (<anonymous>)
           at getNodes (.../plugins/js/lock-file/pnpm-parser.js:186:42)
           at getPnpmLockfileNodes (.../plugins/js/lock-file/pnpm-parser.js:39:12)
           at getLockFileNodesForName (.../plugins/js/lock-file/lock-file.js:82:55)
           at getLockFileNodes (.../plugins/js/lock-file/lock-file.js:61:16)
```

`pnpm-parser.ts` reads `data.packages` in three places, and only one of them handled it being absent:

| line | function | |
| --- | --- | --- |
| 309 | `getNodes` | `Object.entries(data.packages)` — unguarded |
| 542 | `getDependencies` | `Object.keys(data.packages)` — unguarded |
| 590 | stringify path | `data.packages ?? {}` — already guarded |

The guarded site even carries a comment naming this exact situation, so the invariant was known and written down — the other two call sites were simply missed.

## Expected Behavior

A workspace-only lockfile parses cleanly, contributing no external nodes and no dependencies, instead of throwing.

Adds a `workspace-only lockfile` spec covering both `getPnpmLockfileNodes` and `getPnpmLockfileDependencies`.

## Related Issue(s)

Fixes NXC-4747

<!-- polygraph-session-start -->
---
<p><picture><source media="(prefers-color-scheme: dark)" srcset="https://static.ops.cloud.nx.app/polygraph/session-logo-v4-dark.svg"><img src="https://static.ops.cloud.nx.app/polygraph/session-logo-v4-light.svg" width="16" height="22" align="middle" alt="Polygraph"></picture> <a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Fix-pnpm-parser-crash-on-workspace-only-lockfiles-NXC-4747-3cb39813">View session ↗</a></p>
<!-- polygraph-session-end -->