### PR TITLE
docs(misc): apply review feedback on inferred task wording

### DIFF
--- a/astro-docs/src/content/docs/technologies/build-tools/docker/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/docker/introduction.mdoc
@@ -99,7 +99,7 @@ Configure `buildTarget` and `runTarget` as objects to pass custom arguments, set
 
 When using the object format, the following properties are available:
 
-- **`name`** (string, required): The name of the inferred target
+- **`name`** (string, required): The name of the task
 - **`args`** (string[], optional): Additional arguments to pass to the Docker command. Supports pattern interpolation.
 - **`env`** (object, optional): Environment variables to set when running the Docker command. Values support pattern interpolation.
 - **`envFile`** (string, optional): Path to an environment file to load
@@ -107,7 +107,7 @@ When using the object format, the following properties are available:
 - **`configurations`** (object, optional): Named Nx configurations that override `args`, `env`, `envFile`, `cwd`, or `skipDefaultTag`.
 - **`skipDefaultTag`** (boolean, default `false`): Do not add the default Nx `--tag` argument to build commands. Supply a tag in `args`; opting out also disables Nx Release versioning and publishing for that Docker project.
 
-The build task depends on the project's `build` task and dependency builds. The run task depends on the inferred Docker build task. Nx also adds an `nx-release-publish` target that uses the `@nx/docker:release-publish` executor.
+The build task depends on the project's `build` task and dependency builds. The run task depends on the Docker build task. Nx also adds an `nx-release-publish` task for publishing images with [Nx Release](/docs/features/manage-releases).
 
 #### Pattern interpolation
 

--- a/astro-docs/src/content/docs/technologies/build-tools/rollup/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/rollup/introduction.mdoc
@@ -48,7 +48,7 @@ The `@nx/rollup/plugin` plugin looks for these Rollup configuration files:
 - `rollup.config.cts`
 - `rollup.config.mts`
 
-A configuration file is associated with a project when its directory also contains a `package.json` or `project.json`. Nx reads the Rollup outputs and creates a cached build task that runs `rollup -c`, depends on the same task in dependency projects, and records the configured output paths for cache restoration.
+A configuration file is associated with a project when its directory also contains a `package.json` or `project.json`. Nx creates a cached build task that runs `rollup -c`, with outputs based on your Rollup configuration, and depends on the same task in dependency projects.
 
 Configure the plugin in `nx.json`:
 

--- a/astro-docs/src/content/docs/technologies/build-tools/rspack/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/rspack/introduction.mdoc
@@ -95,7 +95,7 @@ The `@nx/rspack/plugin` is configured in the `plugins` array in `nx.json`.
 | `buildDepsTargetName`   | none           | Name of an optional dependency build task.                  |
 | `watchDepsTargetName`   | none           | Name of an optional dependency watch task.                  |
 
-The build target depends on builds of project dependencies. When TypeScript project references are enabled, the inferred targets also run the TypeScript sync generator.
+The build task depends on builds of project dependencies. When TypeScript project references are enabled, the tasks also run the TypeScript sync generator.
 
 Use `include` and `exclude` glob patterns on the plugin entry to scope inference. A [target defaults](/docs/reference/nx-json#target-defaults) `plugin` filter must use the exact identifier `@nx/rspack/plugin`.
 

--- a/astro-docs/src/content/docs/technologies/build-tools/vite/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/vite/introduction.mdoc
@@ -9,7 +9,7 @@ filter: 'type:References'
 
 [Vite](https://vite.dev/) is a fast build tool and dev server for modern web apps. In a Vite monorepo, Nx runs and caches Vite tasks across every project so you only rebuild what changed.
 
-The `@nx/vite` plugin adds [inferred targets](#configuration) and [project configuration generators](#setup).
+The `@nx/vite` plugin adds [inferred tasks](#configuration) and [project configuration generators](#setup).
 
 {% aside type="note" title="Vitest is now in @nx/vitest" %}
 Starting with Nx v22, Vitest support has moved to the dedicated [`@nx/vitest` plugin](/docs/technologies/test-tools/vitest/introduction). In Nx v21 and prior, `@nx/vite` contained what is now in `@nx/vitest`. If you are upgrading, see the [migration guide](/docs/kb/migrating-from-nx-vite).
@@ -106,16 +106,16 @@ The `@nx/vite` plugin infers tasks by reading Vite config files. Any of the foll
 
 The configuration directory must also contain a `package.json` or `project.json`.
 
-Build targets are only created when the project is buildable. A project is treated as buildable when any of the following are true:
+Build tasks are only created when the project is buildable. A project is treated as buildable when any of the following are true:
 
 - `build.lib` is set in `vite.config.*`
 - `build.rollupOptions.input` or `build.rolldownOptions.input` is set (Vite 8 uses `rolldownOptions`)
 - `builder.buildApp` is set
 - an `index.html` file exists at the project root
 
-Dev, preview, and serve-static targets are created for buildable projects. If you are in library mode (`build.lib`), these targets are skipped unless you explicitly configure a dev server (e.g. `server.host` or `server.port`).
+Dev, preview, and serve-static tasks are created for buildable projects. If you are in library mode (`build.lib`), these tasks are skipped unless you explicitly configure a dev server (e.g. `server.host` or `server.port`).
 
-Typecheck targets are created when a `tsconfig*.json` file exists in the project.
+Typecheck tasks are created when a `tsconfig*.json` file exists in the project.
 
 ### Plugin options
 
@@ -143,24 +143,22 @@ Configure `@nx/vite/plugin` in the `plugins` array in `nx.json`:
 }
 ```
 
-`serveTargetName` is deprecated; use `devTargetName` instead. `buildDepsTargetName` and `watchDepsTargetName` create targets that build or watch project dependencies.
+`serveTargetName` is deprecated; use `devTargetName` instead. `buildDepsTargetName` and `watchDepsTargetName` create tasks that build or watch project dependencies.
 
-| Option                  | Description                                          | Default        |
-| ----------------------- | ---------------------------------------------------- | -------------- |
-| `buildTargetName`       | Name of the Vite build target                        | `build`        |
-| `previewTargetName`     | Name of the Vite preview target                      | `preview`      |
-| `serveTargetName`       | Name of the deprecated Vite serve target             | `serve`        |
-| `devTargetName`         | Name of the Vite dev server target                   | `dev`          |
-| `serveStaticTargetName` | Name of the static file server target                | `serve-static` |
-| `typecheckTargetName`   | Name of the typecheck target                         | `typecheck`    |
-| `compiler`              | Typecheck compiler: `tsc`, `tsgo`, or `vue-tsc`      | auto-detected  |
-| `buildDepsTargetName`   | Name of the build-deps target for dependency builds  | none           |
-| `watchDepsTargetName`   | Name of the watch-deps target for dependency watches | none           |
+| Option                  | Description                                        | Default        |
+| ----------------------- | -------------------------------------------------- | -------------- |
+| `buildTargetName`       | Name of the Vite build task                        | `build`        |
+| `previewTargetName`     | Name of the Vite preview task                      | `preview`      |
+| `serveTargetName`       | Name of the deprecated Vite serve task             | `serve`        |
+| `devTargetName`         | Name of the Vite dev server task                   | `dev`          |
+| `serveStaticTargetName` | Name of the static file server task                | `serve-static` |
+| `typecheckTargetName`   | Name of the typecheck task                         | `typecheck`    |
+| `compiler`              | Typecheck compiler: `tsc`, `tsgo`, or `vue-tsc`    | auto-detected  |
+| `buildDepsTargetName`   | Name of the build-deps task for dependency builds  | none           |
+| `watchDepsTargetName`   | Name of the watch-deps task for dependency watches | none           |
 
-Build and typecheck tasks are cached.
-Build tasks declare the resolved Vite build output directory.
-Typecheck tasks do not declare cache outputs.
-Development, preview, and static-server tasks are continuous.
+The build and typecheck tasks are cached, with build outputs based on your Vite configuration.
+The dev, preview, and static-server tasks are continuous.
 When `compiler` is omitted, Nx uses `vue-tsc` when it detects a Vite Vue plugin and `tsc` otherwise.
 
 ### Disable or scope inference

--- a/astro-docs/src/content/docs/technologies/build-tools/webpack/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/build-tools/webpack/introduction.mdoc
@@ -102,7 +102,7 @@ The `@nx/webpack/plugin` is configured in the `plugins` array in `nx.json`.
 | `buildDepsTargetName`   | `build-deps`   | Name of the dependency build task.                               |
 | `watchDepsTargetName`   | `watch-deps`   | Name of the dependency watch task.                               |
 
-The build target depends on builds of project dependencies. When TypeScript project references are enabled, the inferred targets also run the TypeScript sync generator.
+The build task depends on builds of project dependencies. When TypeScript project references are enabled, the tasks also run the TypeScript sync generator.
 
 Use `include` and `exclude` glob patterns on the plugin entry to scope inference. A [target defaults](/docs/reference/nx-json#target-defaults) `plugin` filter must use the exact identifier `@nx/webpack/plugin`.
 

--- a/astro-docs/src/content/docs/technologies/eslint/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/eslint/introduction.mdoc
@@ -83,10 +83,10 @@ The `@nx/eslint/plugin` is configured in the `plugins` array in `nx.json`.
 
 | Option       | Type     | Default                                           | Description                                     |
 | ------------ | -------- | ------------------------------------------------- | ----------------------------------------------- |
-| `targetName` | string   | `lint`                                            | Name of the inferred ESLint task.               |
+| `targetName` | string   | `lint`                                            | Name of the ESLint task.                        |
 | `extensions` | string[] | `ts, cts, mts, tsx, js, cjs, mjs, jsx, html, vue` | File extensions Nx checks before adding a task. |
 
-The inferred task runs ESLint from the project root and is cached. Its inputs include the applicable ESLint configuration, extended tsconfig files, custom workspace rules, project dependencies, and the installed `eslint` package. Its output tracks the `outputFile` CLI option.
+The lint task runs ESLint from the project root and is cached, with inputs and outputs based on your ESLint configuration.
 
 Use `include` and `exclude` glob patterns on the plugin entry to scope inference. A [target defaults](/docs/reference/nx-json#target-defaults) `plugin` filter must use the exact identifier `@nx/eslint/plugin`.
 

--- a/astro-docs/src/content/docs/technologies/react/next/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/react/next/introduction.mdoc
@@ -46,7 +46,7 @@ Verify the plugin is setup:
    nx report
    ```
 
-2. Ensure inferred project targets are working:
+2. Ensure inferred tasks are working:
 
    ```shell
    nx show projects --with-target=build
@@ -179,7 +179,7 @@ Configure `@nx/next/plugin` in the `plugins` array in `nx.json`:
 | `buildDepsTargetName`   | Name of an optional dependency build task. | none           |
 | `watchDepsTargetName`   | Name of an optional dependency watch task. | none           |
 
-The build task reads `distDir` from the Next.js configuration to declare cache outputs and depends on builds of project dependencies. The start task depends on the build task.
+The build task is cached, with outputs based on your Next.js configuration, and depends on builds of project dependencies. The start task depends on the build task.
 
 ### Exclude or include specific projects
 

--- a/astro-docs/src/content/docs/technologies/react/remix/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/react/remix/introduction.mdoc
@@ -50,13 +50,13 @@ Verify the plugin is setup:
    nx report
    ```
 
-2. Ensure inferred project targets are working:
+2. Ensure inferred tasks are working:
 
    ```shell
    nx show projects --with-target=build
    ```
 
-3. Inspect a specific project configuration for the inferred targets:
+3. Inspect a specific project configuration for the inferred tasks:
 
    ```shell
    nx show project my-remix-app
@@ -203,7 +203,7 @@ Configure `@nx/remix/plugin` in the `plugins` array in `nx.json`:
 | `buildDepsTargetName`   | Name of an optional dependency build task.       | none           |
 | `watchDepsTargetName`   | Name of an optional dependency watch task.       | none           |
 
-Nx selects the classic Remix or Vite commands from the matched configuration, derives build outputs from that configuration, and makes the production server tasks depend on the build task.
+The build and typecheck tasks are cached, with build outputs based on your Remix configuration. The production server tasks depend on the build task.
 
 ### Exclude or include specific projects
 

--- a/astro-docs/src/content/docs/technologies/test-tools/cypress/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/cypress/introduction.mdoc
@@ -95,7 +95,7 @@ The options shown above control the names of the inferred Cypress tasks. The fol
 | `ciComponentTestingTargetName` | `undefined` (task is not inferred by default) |
 | `openTargetName`               | `"open-cypress"`                              |
 
-The e2e and component-test targets are cached and track Cypress screenshot and video outputs.
+The e2e and component-test tasks are cached and track Cypress screenshot and video outputs.
 The `openTargetName` task opens the interactive Cypress application.
 The `ciTargetName` task uses the [Atomizer](/docs/features/ci-features/split-e2e-tasks).
 Set `ciComponentTestingTargetName` to atomize component tests as well.

--- a/astro-docs/src/content/docs/technologies/test-tools/detox/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/detox/introduction.mdoc
@@ -67,7 +67,7 @@ The `@nx/detox/plugin` plugin creates tasks for projects with one of these Detox
 - `detox.config.js`
 - `detox.config.json`
 
-It creates cached `build` and `test` tasks and a continuous `start` task. The cache inputs include the project and its dependencies together with the installed `detox` package.
+It creates cached `build` and `test` tasks and a continuous `start` task.
 
 ### View inferred tasks
 

--- a/astro-docs/src/content/docs/technologies/test-tools/jest/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/jest/introduction.mdoc
@@ -36,7 +36,7 @@ Using `nx add` helps ensure the correct version is installed and configured.
 nx add @nx/jest
 ```
 
-Verify the inferred test target in the project details view:
+Verify the inferred test task in the project details view:
 
 ```shell
 nx show project my-app
@@ -170,16 +170,15 @@ Configure the plugin in `nx.json`:
 
 | Option               | Type    | Default                        | Description                                                                                                                                                                                                      |
 | -------------------- | ------- | ------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `targetName`         | string  | `test`                         | Name of the inferred Jest target.                                                                                                                                                                                |
-| `ciTargetName`       | string  | none                           | Creates a CI-only target for atomized test tasks.                                                                                                                                                                |
+| `targetName`         | string  | `test`                         | Name of the test task.                                                                                                                                                                                           |
+| `ciTargetName`       | string  | none                           | Creates a CI-only task for atomized test runs.                                                                                                                                                                   |
 | `ciGroupName`        | string  | none                           | Custom group name for atomized tasks in Nx Cloud/UI.                                                                                                                                                             |
 | `disableJestRuntime` | boolean | `true`                         | When `true`, Nx skips creating the Jest runtime and computes inputs/outputs itself. Set to `false` to enable the Jest runtime.                                                                                   |
 | `useJestResolver`    | boolean | `true` when runtime is enabled | Whether to use Jest's resolver for resolving config file references as task inputs. Follows symlinks and honors custom `moduleDirectories`/`modulePaths`. Faster path-based classification is used when `false`. |
 
 `disableJestRuntime` defaults to `true` because the plugin treats it as enabled only when `options.disableJestRuntime !== false`. This reduces computation time for inferred tasks; set it to `false` if you need Jest runtime inference.
 
-The inferred test target is cached.
-Nx derives its inputs and coverage outputs from the Jest configuration.
+The test task is cached, with inputs and outputs based on your Jest configuration.
 Set `ciTargetName` to enable the [Atomizer](/docs/features/ci-features/split-e2e-tasks).
 
 ### Unit and e2e configurations

--- a/astro-docs/src/content/docs/technologies/test-tools/vitest/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/test-tools/vitest/introduction.mdoc
@@ -179,8 +179,8 @@ Configure the plugin in `nx.json`:
 
 | Option              | Type               | Default                     | Description                                                                                                                                                                                               |
 | ------------------- | ------------------ | --------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `testTargetName`    | string             | `test`                      | Name of the inferred local target.                                                                                                                                                                        |
-| `ciTargetName`      | string             | none                        | Creates a CI-only target used for atomized runs.                                                                                                                                                          |
+| `testTargetName`    | string             | `test`                      | Name of the test task.                                                                                                                                                                                    |
+| `ciTargetName`      | string             | none                        | Creates a CI-only task used for atomized runs.                                                                                                                                                            |
 | `ciGroupName`       | string             | derived from `ciTargetName` | Display name for the atomized CI group.                                                                                                                                                                   |
 | `testMode`          | `watch` or `run`   | `watch`                     | Determines whether Nx runs `vitest` (watch) or `vitest run` (single run).                                                                                                                                 |
 | `discoverTestFiles` | `glob` or `vitest` | `glob`                      | How atomized test files are discovered. `glob` mirrors Vitest's resolution without booting Vitest per project, which is faster during graph creation. Set to `vitest` to always enumerate through Vitest. |
@@ -191,8 +191,7 @@ The `glob` path reads the Nx workspace file index, so it never enumerates specs 
 
 There is no single "disable" flag for inference. Use `include` and `exclude` to scope which projects each plugin instance applies to.
 
-The inferred test target is cached and declares the configured coverage reports directory, or
-`coverage` by default, as its only cache output.
+The test task is cached, with outputs based on your Vitest coverage configuration.
 Custom reporter output files are not inferred.
 Set `ciTargetName` to enable the [Atomizer](/docs/features/ci-features/split-e2e-tasks).
 

--- a/astro-docs/src/content/docs/technologies/typescript/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/typescript/introduction.mdoc
@@ -166,13 +166,13 @@ Verify the plugin is setup:
    nx report
    ```
 
-2. Ensure inferred project targets are working:
+2. Ensure inferred tasks are working:
 
    ```shell
    nx show projects --with-target=typecheck
    ```
 
-3. Inspect a specific project configuration for the `typecheck`/`build` target, depending on your project configuration:
+3. Inspect a specific project configuration for the `typecheck`/`build` task, depending on your project configuration:
 
    ```shell
    nx show project <ts-project-name>
@@ -381,7 +381,7 @@ Configure `@nx/js/typescript` in the `plugins` array in `nx.json`:
 
 | Option                 | Description                                                                   | Default             |
 | ---------------------- | ----------------------------------------------------------------------------- | ------------------- |
-| `compiler`             | Compiler used by inferred tasks: `tsc` or `tsgo`.                             | `tsc`               |
+| `compiler`             | Compiler used by the typecheck and build tasks: `tsc` or `tsgo`.              | `tsc`               |
 | `typecheck`            | Enables typecheck inference; set to `false` to disable it.                    | enabled             |
 | `typecheck.targetName` | Name of the cached typecheck task.                                            | `typecheck`         |
 | `typecheck.configName` | The tsconfig file used for typechecking.                                      | `tsconfig.json`     |
@@ -391,9 +391,9 @@ Configure `@nx/js/typescript` in the `plugins` array in `nx.json`:
 | `build.buildDepsName`  | Name of the task for building all dependencies.                               | `build-deps`        |
 | `build.watchDepsName`  | Name of the task for watching and rebuilding dependencies.                    | `watch-deps`        |
 | `build.skipBuildCheck` | Allows build inference without package exports that point to compiled output. | `false`             |
-| `verboseOutput`        | Adds TypeScript's `--verbose` flag to inferred commands.                      | `false`             |
+| `verboseOutput`        | Adds TypeScript's `--verbose` flag to the underlying commands.                | `false`             |
 
-The inferred `typecheck` and `build` tasks are cached, declare their tsconfig-derived inputs and outputs, and depend on the corresponding tasks in dependency projects.
+The `typecheck` and `build` tasks are cached, with inputs and outputs based on your TypeScript configuration, and depend on the corresponding tasks in dependency projects.
 
 ### Exclude or include specific projects
 


### PR DESCRIPTION
## Current Behavior

jack's review comments on #36399 landed after the merge: the inferred-task sections mix "task" and "target", say "inferred" redundantly inside the inferred sections, and describe which config property drives inputs/outputs (distDir, tsconfig-derived, the eslint input list).

## Expected Behavior

behavior notes stick to what users act on: whether the task is cached, that inputs/outputs come from the tool's config, and what depends on what. `nx show project` covers the exact properties.

- standardized on "task" in prose across the 13 touched pages (option names like `buildTargetName` unchanged)
- vale is clean on all touched files

## Related Issue(s)

follow-up to #36399 (DOC-554)