### PR TITLE
fix(core): fix entryWhenNoChanges from adding empty lines to changelogs

### DIFF
--- a/packages/nx/src/command-line/release/changelog.ts
+++ b/packages/nx/src/command-line/release/changelog.ts
@@ -1055,7 +1055,9 @@ async function generateChangelogForWorkspace({
         );
       } else {
         // No existing version, simply prepend the new release to the top of the file
-        rootChangelogContents = `${contents}\n\n${rootChangelogContents}`;
+        rootChangelogContents = contents
+          ? `${contents}\n\n${rootChangelogContents}`
+          : rootChangelogContents;
       }
     } else {
       // No existing changelog contents, or replaceExistingContents is true, simply use the generated contents directly
@@ -1222,7 +1224,9 @@ async function generateChangelogForProjects({
           );
         } else {
           // No existing version, simply prepend the new release to the top of the file
-          changelogContents = `${contents}\n\n${changelogContents}`;
+          changelogContents = contents
+            ? `${contents}\n\n${changelogContents}`
+            : changelogContents;
         }
       } else {
         // No existing changelog contents, simply create a new one using the generated contents


### PR DESCRIPTION
<!-- Please make sure you have read the submission guidelines before posting an PR -->
<!-- https://github.com/nrwl/nx/blob/master/CONTRIBUTING.md#-submitting-a-pr -->

<!-- Please make sure that your commit message follows our format -->
<!-- Example: `fix(nx): must begin with lowercase` -->

<!-- If this is a particularly complex change or feature addition, you can request a dedicated Nx release for this pull request branch. Mention someone from the Nx team or the `@nrwl/nx-pipelines-reviewers` and they will confirm if the PR warrants its own release for testing purposes, and generate it for you if appropriate. -->

## Current Behavior
Steps to reproduce:
- `release.changelog.projectChangelogs.entryWhenNoChanges` is set to `false` in `nx.json`
- Create an `nx` workspace where:
    - Some `project-a` has a dependency on some `project-b`
    - There are existing changelogs for both `project-a` and `project-b`
- Make changes to `project-a`, commit them
- Execute `nx release`
- Notice that the existing changelog for `package-b` has two additional newlines prepended to the top of the file

## Expected Behavior
When using `entryWhenNoChanges` and there are no changes to a project being released, no changes are made to the changelog and additional newlines are not added to the top of the file.

## Changes
In `packages/nx/src/command-line/release/changelog.ts` update where the new changelog content is prepended to the existing changelog content to only add the newline characters when there is new content.

## Testing
1. Setup a sample `nx` workspace with 2 projects. `pkg-a` depends on `pkg-b`.
2. Set `release` config in `nx.json` to:

```json
"release": {
    "projects": [
      "packages/*"
    ],
    "version": {
      "conventionalCommits": true,
      "fallbackCurrentVersionResolver": "disk"
    },
    "changelog": {
      "workspaceChangelog": {
        "entryWhenNoChanges": false
      },
      "projectChangelogs": {
        "entryWhenNoChanges": false
      }
    }
  },
```

3. Executed an initial release for the 2 packages to the local registry:

```
git add packages/pkg-a packages/pkg-b
git commit -m "feat: add pkg-a and pkg-b"

npx nx release --first-release --specifier minor
```

4. Made changes to just `pkg-a`

```bash
echo "// new feature" >> packages/pkg-a/src/index.ts
git add packages/pkg-a/
git commit -m "feat(pkg-a): add new feature"
```

5. Run release again: `npx nx release`

Testing with the latest version of `nx`, I see:

```bash
 NX   Generating an entry in packages/pkg-b/CHANGELOG.md for v0.0.4


UPDATE packages/pkg-b/CHANGELOG.md

+
+
  ## 0.0.2 (2026-07-29)

  ### 🚀 Features
```

Testing with the changes from this PR published to local registry

```bash
 NX   Generating an entry in packages/pkg-b/CHANGELOG.md for v0.0.3



```

## Related Issue(s)
<!-- Please link the issue being fixed so it gets closed when this is merged. -->

Fixes #