### PR TITLE
fix(core): stop pruneProjectGraph from mutating the source project graph

### DIFF
--- a/packages/nx/src/plugins/js/lock-file/project-graph-pruning.spec.ts
+++ b/packages/nx/src/plugins/js/lock-file/project-graph-pruning.spec.ts
@@ -912,5 +912,94 @@ describe('project-graph-pruning', () => {
       expect(prunedGraph.externalNodes?.['npm:lodash@4.17.21']).toBeDefined();
       expect(prunedGraph.externalNodes?.['npm:lodash@4.17.20']).toBeDefined();
     });
+
+    describe('when a rehoist happens', () => {
+      const externalNode = (
+        name: string,
+        packageName: string,
+        version: string
+      ) => ({
+        type: 'npm' as const,
+        name,
+        data: { version, packageName, hash: `sha512-${packageName}${version}` },
+      });
+
+      // A package resolved to two versions, with the nested one reachable only
+      // through another dependency. Pruning to just that dependency leaves 1.1.1
+      // as the sole version, which triggers the rehoist.
+      const createGraph = (): ProjectGraph => ({
+        nodes: {},
+        externalNodes: {
+          'npm:cookie': externalNode('npm:cookie', 'cookie', '2.0.1'),
+          'npm:cookie@1.1.1': externalNode(
+            'npm:cookie@1.1.1',
+            'cookie',
+            '1.1.1'
+          ),
+          'npm:light-my-request': externalNode(
+            'npm:light-my-request',
+            'light-my-request',
+            '6.6.0'
+          ),
+        },
+        dependencies: {
+          'npm:light-my-request': [
+            {
+              source: 'npm:light-my-request',
+              target: 'npm:cookie@1.1.1',
+              type: 'static' as any,
+            },
+          ],
+        },
+      });
+
+      // Prunes down to a single cookie version, so the rehoist runs.
+      const rehoistingPackageJson: PackageJson = {
+        name: 'app-b',
+        version: '1.0.0',
+        dependencies: { 'light-my-request': '6.6.0' },
+      };
+
+      // Needs both cookie versions, so it depends on the source graph being intact.
+      const multiVersionPackageJson: PackageJson = {
+        name: 'app-a',
+        version: '1.0.0',
+        dependencies: { cookie: '2.0.1', 'light-my-request': '6.6.0' },
+      };
+
+      it('does not mutate the source graph', () => {
+        const graph = createGraph();
+
+        pruneProjectGraph(graph, rehoistingPackageJson);
+
+        expect(graph.externalNodes['npm:cookie@1.1.1'].name).toEqual(
+          'npm:cookie@1.1.1'
+        );
+        expect(graph.externalNodes['npm:cookie'].name).toEqual('npm:cookie');
+      });
+
+      it('stays deterministic when the same graph is pruned repeatedly', () => {
+        const graph = createGraph();
+
+        const first = pruneProjectGraph(graph, multiVersionPackageJson);
+        pruneProjectGraph(graph, rehoistingPackageJson);
+        const third = pruneProjectGraph(graph, multiVersionPackageJson);
+
+        expect(Object.keys(third.externalNodes ?? {}).sort()).toEqual(
+          Object.keys(first.externalNodes ?? {}).sort()
+        );
+        expect(third.dependencies).toEqual(first.dependencies);
+      });
+
+      it('keeps both versions resolvable after an earlier prune rehoisted one', () => {
+        const graph = createGraph();
+
+        pruneProjectGraph(graph, rehoistingPackageJson);
+
+        expect(() =>
+          pruneProjectGraph(graph, multiVersionPackageJson)
+        ).not.toThrow();
+      });
+    });
   });
 });

--- a/packages/nx/src/plugins/js/lock-file/project-graph-pruning.ts
+++ b/packages/nx/src/plugins/js/lock-file/project-graph-pruning.ts
@@ -280,18 +280,24 @@ function switchNodeToHoisted(
   builder.removeNode(node.name);
   invBuilder.removeNode(node.name);
 
-  // modify the node and re-add it
-  node.name = `npm:${node.data.packageName}`;
-  builder.addExternalNode(node);
-  invBuilder.addExternalNode(node);
+  // Re-add under the hoisted name as a new object. The node is shared by
+  // reference with the caller's graph, so renaming it in place would leave that
+  // graph with a node keyed `npm:<pkg>@<version>` but named `npm:<pkg>`, and
+  // every later prune of the same graph would fail to resolve the edge.
+  const hoistedNode: ProjectGraphExternalNode = {
+    ...node,
+    name: `npm:${node.data.packageName}`,
+  };
+  builder.addExternalNode(hoistedNode);
+  invBuilder.addExternalNode(hoistedNode);
 
   targets.forEach((target) => {
-    builder.addStaticDependency(node.name, target);
-    invBuilder.addStaticDependency(target, node.name);
+    builder.addStaticDependency(hoistedNode.name, target);
+    invBuilder.addStaticDependency(target, hoistedNode.name);
   });
   sources.forEach((source) => {
-    builder.addStaticDependency(source, node.name);
-    invBuilder.addStaticDependency(node.name, source);
+    builder.addStaticDependency(source, hoistedNode.name);
+    invBuilder.addStaticDependency(hoistedNode.name, source);
   });
 }
 


### PR DESCRIPTION
## Current Behavior

`pruneProjectGraph` mutates the `ProjectGraph` it is handed, so pruning one project changes the result of pruning the next.

`switchNodeToHoisted` renames the node in place:

```ts
node.name = `npm:${node.data.packageName}`;
```

but `traverseNode` adds nodes to the builder **by reference** from the caller's graph (`builder.addExternalNode(node)`, no copy). The rename therefore lands on the source graph, which is left holding a node keyed `npm:<pkg>@<version>` whose `name` is now `npm:<pkg>`. Every later prune against that same graph object resolves the node by key, registers it under the mutated `name`, and the dependency edge no longer resolves:

```
NX   An error occurred while creating pruned lockfile
Original error: Target project does not exist: npm:cookie@1.1.1
```

The preconditions are a package resolving to more than one version, where at least one project prunes down to a single version (triggering the rehoist) while another still needs the multi-version shape.

This is worse than a thrown error, because Nx swallows it and writes the **full workspace lockfile** into the build output. The generated `package.json` then has the pruned dependency set while the lockfile has the root one, so Docker builds fail later and further from the cause:

```
ERR_PNPM_OUTDATED_LOCKFILE: Cannot install with "frozen-lockfile" because
pnpm-lock.yaml is not up to date with <ROOT>/package.json
```

It also explains why this is typically seen on the *second* build rather than the first.

## Expected Behavior

`pruneProjectGraph` is a pure function of `(graph, packageJson)`. Pruning for project A does not change the result of pruning for project B, and the caller-supplied `ProjectGraph` is never mutated.

## What changed

`switchNodeToHoisted` now re-adds the node under the hoisted name as a **new object** rather than renaming the shared one:

```ts
const hoistedNode: ProjectGraphExternalNode = {
  ...node,
  name: `npm:${node.data.packageName}`,
};
```

`node.name` on that line was the only mutation of caller-owned state in the file (I grepped for others), so this is sufficient to make the function pure with respect to its `graph` argument. Behaviour inside a single prune is unchanged — the same node content is registered under the same hoisted name, and the dependency rewiring just uses `hoistedNode.name`.

## Verification

Three regression tests added from the reproduction in the issue, all of which fail on `master`:

```
● when a rehoist happens › does not mutate the source graph
● when a rehoist happens › stays deterministic when the same graph is pruned repeatedly
● when a rehoist happens › keeps both versions resolvable after an earlier prune rehoisted one

    expect(received).not.toThrow()
    Error message: "Target project does not exist: npm:cookie@1.1.1"

Tests:       3 failed, 26 skipped, 4 passed, 33 total
```

That last message is the reported error verbatim. With the fix:

```
$ npx jest --config packages/nx/jest.config.cts --testPathPatterns "project-graph-pruning"
Tests:       33 passed, 33 total
```

And the whole lock-file suite, since this function is shared by every parser:

```
$ npx jest --config packages/nx/jest.config.cts --testPathPatterns "lock-file"
Test Suites: 6 passed, 6 total
Tests:       216 passed, 216 total
Snapshots:   61 passed, 61 total
```

`prettier` reports both changed files unchanged.

I ran the focused package suites rather than `nx affected`, because the local `@nx/dotnet` and `@nx/gradle` plugins fail to create nodes without `dotnet`/`gradle` installed, which drowns the run in unrelated errors. Happy to add anything else CI flags.

## Related Issue(s)

Fixes #36470

This also looks like the mechanism behind #20421, which was closed as `not planned` for lack of a reproduction — note that reporter also saw it only on the second compile, consistent with a first prune poisoning the shared graph. It is distinct from #34322 (the `closest === undefined` crash in `rehoistNodes`), which is already fixed.
