### PR TITLE
fix(core): keep real dependencies when omitting peers from npm temp installs

### DIFF
--- a/packages/nx/src/utils/package-json.spec.ts
+++ b/packages/nx/src/utils/package-json.spec.ts
@@ -125,13 +125,15 @@ describe('installPackageToTmp', () => {
       .spyOn(childProcess, 'execSync')
       .mockReturnValue('' as any);
 
-    // npm: peers are omitted via `--omit=peer`
+    // npm: `--legacy-peer-deps`, not `--omit=peer`. npm marks a package as a peer
+    // if anything in the tree peer-depends on it, so `--omit=peer` also prunes
+    // packages that are real dependencies of the installed package.
     installPackageToTmp('@nx/cypress', '1.0.0', 'npm');
     expect(execSyncSpy.mock.calls[0][0]).toBe(
-      'npm install -D @nx/cypress@1.0.0 --omit=peer --ignore-scripts'
+      'npm install -D @nx/cypress@1.0.0 --legacy-peer-deps --ignore-scripts'
     );
 
-    // bun: also accepts `--omit=peer`
+    // bun: `--omit=peer` is safe here, bun does not over-prune the way npm does
     execSyncSpy.mockClear();
     jest.spyOn(pacakgeManager, 'getPackageManagerCommand').mockReturnValue({
       addDev: 'bun add -D',

--- a/packages/nx/src/utils/package-json.ts
+++ b/packages/nx/src/utils/package-json.ts
@@ -417,20 +417,23 @@ function preparePackageInstallation(
   const pmCommands = getPackageManagerCommand(packageManager);
   const preInstallCommand = pmCommands.preInstall;
 
-  // Omit peer dependencies from the temp install. `ensurePackage` puts the
+  // Keep peer dependencies out of the temp install. `ensurePackage` puts the
   // workspace's `node_modules` on `NODE_PATH`, so a loaded package resolves its
   // peers from the workspace instead of pulling its own (possibly incompatible)
   // copies into the temp dir.
-  const omitPeerDependenciesFlag =
-    packageManager === 'npm' || packageManager === 'bun'
-      ? '--omit=peer'
-      : packageManager === 'pnpm'
-        ? '--config.auto-install-peers=false'
-        : '';
+  //
+  // npm needs `--legacy-peer-deps` rather than `--omit=peer`: npm marks a package
+  // as a peer if anything in the tree peer-depends on it, so `--omit=peer` also
+  // prunes packages that are real dependencies. Bun's `--omit=peer` does not.
+  const skipPeerDependenciesFlags: Partial<Record<PackageManager, string>> = {
+    npm: '--legacy-peer-deps',
+    bun: '--omit=peer',
+    pnpm: '--config.auto-install-peers=false',
+  };
   const installCommand = [
     pmCommands.addDev,
     `${pkg}@${requiredVersion}`,
-    omitPeerDependenciesFlag,
+    skipPeerDependenciesFlags[packageManager],
     pmCommands.ignoreScriptsFlag,
   ]
     .filter(Boolean)


### PR DESCRIPTION
## Current Behavior

`ensurePackage` installs on-demand plugins into a temp dir. Since #36295 that install passes `--omit=peer` for npm, so peers resolve from the workspace instead of being duplicated into the temp dir.

npm flags a package as a peer if **anything** in the tree peer-depends on it — a real `dependencies` edge does not clear the flag. `--omit=peer` therefore also prunes packages that are genuine dependencies of the package being installed.

`@nx/detox` hard-depends on `@nx/jest` and `@nx/eslint`; `@nx/web` declares both as optional peers. So installing `@nx/detox` on npm silently drops both:

```console
$ npm i -D @nx/detox@22.7.7 --omit=peer --ignore-scripts
$ ls node_modules/@nx
detox devkit js module-federation nx-darwin-arm64 react rollup vitest web workspace
# @nx/jest and @nx/eslint are missing
```

They are still written to `package-lock.json` with `"peer": true`, are absent from `node_modules/.package-lock.json`, and the install exits 0 with no warning.

Generating a React Native app with Detox then fails. Observed on 22.7.x, where `ensure-dependencies.ts` imports `@nx/jest/src/utils/versions`:

```
NX  Cannot find module '@nx/jest/src/utils/versions'

Require stack:
- <tmp>/node_modules/@nx/detox/src/generators/application/lib/ensure-dependencies.js
```

On master the same file imports `@nx/jest/internal` instead — a different subpath of the same pruned package, so it fails the same way.

This is not Detox-specific: 14 first-party plugins hard-depend on `@nx/jest` or `@nx/eslint`, and several deep-import `@nx/eslint/src/*` at runtime. Any of them fetched on demand in an npm workspace can lose a dependency it needs.

## Expected Behavior

npm uses `--legacy-peer-deps` instead. That ignores `peerDependencies` — the intent of #36295 — without pruning real dependencies:

```console
$ npm i -D @nx/detox@22.7.7 --legacy-peer-deps --ignore-scripts
$ ls node_modules/@nx
detox devkit eslint jest js module-federation nx-darwin-arm64 react rollup vite vitest web workspace
```

bun does not over-prune (verified against the same tree), so bun keeps `--omit=peer`. pnpm and yarn are unchanged.

## Related Issue(s)

N/A — regression from #36295, which has not been released yet.

## Notes for reviewers

**CI will not exercise this change.** Two independent reasons:

1. The macOS Detox e2e only runs when the diff touches `packages/detox`, `packages/react-native`, `packages/expo`, or their e2e projects (`scripts/check-react-native-changes.js`). #36295 touched only `packages/nx`, so the gate skipped it — and it skips this PR too.
2. Even when that job does run, master's e2e uses a shared base workspace that preinstalls the plugins (`<e2e>/nx/proj-backup/npm/node_modules/@nx/` contains detox, jest, eslint, react-native). So `ensurePackage` short-circuits on `require('@nx/detox')` and the temp-install path never executes at all.

Verified locally instead. The end-to-end run was done on **22.7.x**, which has no shared base workspace and so genuinely fetches `@nx/detox` on demand — same branch, same e2e, only the flag differing:

| temp dir | `node_modules/@nx/` contents | result |
| --- | --- | --- |
| `--omit=peer` | detox devkit js module-federation nx-darwin-arm64 react rollup vitest web workspace | 4 tests failed |
| `--legacy-peer-deps` | detox devkit **eslint jest** js module-federation nx-darwin-arm64 react rollup vite vitest web workspace | 4 tests passed |

`ensurePackage` never calls `cleanup()`, so these temp dirs survive and are the reliable signal — `Fetching ...` log lines are absent from passing runs either way because `runCLI` swallows child stdout on success.

Also run:

- `nx run e2e-detox:e2e-macos-local` on 22.7.x with this change — 2 suites / 4 tests pass
- `nx test nx --testPathPatterns=src/utils/package-json.spec.ts` — passes
- `tsc -p packages/nx/tsconfig.lib.json --noEmit` — clean
- `nx prepush` — passes
- the two `npm i` runs above, against published 22.7.7

**Needs backporting to 22.7.x**, which carries the same flag via `74311e713d` and is the active patch line. Neither line has released `--omit=peer` yet (`nx@22.7.7` still ships the old flag-less install command), so there is no user impact today.

<!-- polygraph-session-start -->
---
<p><picture><source media="(prefers-color-scheme: dark)" srcset="https://static.ops.cloud.nx.app/polygraph/session-logo-v4-dark.svg"><img src="https://static.ops.cloud.nx.app/polygraph/session-logo-v4-light.svg" width="16" height="22" align="middle" alt="Polygraph"></picture> <a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Fix-npm-temp-install-pruning-real-dependencies-via---omitpeer-f7aff304">View session ↗</a></p>
<!-- polygraph-session-end -->