### PR TITLE
fix(core): keep real dependencies when omitting peers from npm temp installs

### DIFF
--- a/packages/nx/src/utils/package-json.spec.ts
+++ b/packages/nx/src/utils/package-json.spec.ts
@@ -124,13 +124,15 @@ describe('installPackageToTmp', () => {
       .spyOn(childProcess, 'execSync')
       .mockReturnValue('' as any);
 
-    // npm: peers are omitted via `--omit=peer`
+    // npm: `--legacy-peer-deps`, not `--omit=peer`. npm marks a package as a peer
+    // if anything in the tree peer-depends on it, so `--omit=peer` also prunes
+    // packages that are real dependencies of the installed package.
     installPackageToTmp('@nx/cypress', '1.0.0', 'npm');
     expect(execSyncSpy.mock.calls[0][0]).toBe(
-      'npm install -D @nx/cypress@1.0.0 --omit=peer --ignore-scripts'
+      'npm install -D @nx/cypress@1.0.0 --legacy-peer-deps --ignore-scripts'
     );
 
-    // bun: also accepts `--omit=peer`
+    // bun: `--omit=peer` is safe here, bun does not over-prune the way npm does
     execSyncSpy.mockClear();
     jest.spyOn(pacakgeManager, 'getPackageManagerCommand').mockReturnValue({
       addDev: 'bun add -D',

--- a/packages/nx/src/utils/package-json.ts
+++ b/packages/nx/src/utils/package-json.ts
@@ -385,20 +385,23 @@ function preparePackageInstallation(
   const pmCommands = getPackageManagerCommand(packageManager);
   const preInstallCommand = pmCommands.preInstall;
 
-  // Omit peer dependencies from the temp install. `ensurePackage` puts the
+  // Keep peer dependencies out of the temp install. `ensurePackage` puts the
   // workspace's `node_modules` on `NODE_PATH`, so a loaded package resolves its
   // peers from the workspace instead of pulling its own (possibly incompatible)
   // copies into the temp dir.
-  const omitPeerDependenciesFlag =
-    packageManager === 'npm' || packageManager === 'bun'
-      ? '--omit=peer'
-      : packageManager === 'pnpm'
-        ? '--config.auto-install-peers=false'
-        : '';
+  //
+  // npm needs `--legacy-peer-deps` rather than `--omit=peer`: npm marks a package
+  // as a peer if anything in the tree peer-depends on it, so `--omit=peer` also
+  // prunes packages that are real dependencies. Bun's `--omit=peer` does not.
+  const skipPeerDependenciesFlags: Partial<Record<PackageManager, string>> = {
+    npm: '--legacy-peer-deps',
+    bun: '--omit=peer',
+    pnpm: '--config.auto-install-peers=false',
+  };
   const installCommand = [
     pmCommands.addDev,
     `${pkg}@${requiredVersion}`,
-    omitPeerDependenciesFlag,
+    skipPeerDependenciesFlags[packageManager],
     pmCommands.ignoreScriptsFlag,
   ]
     .filter(Boolean)


### PR DESCRIPTION
Backport of #36518 to `22.7.x`.

Cherry-picked from `1a1fbe97eeb63d5d693a381a76c49a94cf6a6218` with `-x`. Applied cleanly; the changed lines are byte-identical to what merged on master.

## Current Behavior

`ensurePackage` installs on-demand plugins into a temp dir. Since #36295 — which is on this branch as `74311e713d` — that install passes `--omit=peer` for npm.

npm flags a package as a peer if **anything** in the tree peer-depends on it; a real `dependencies` edge does not clear the flag. `--omit=peer` therefore also prunes packages that are genuine dependencies of the package being installed.

`@nx/detox` hard-depends on `@nx/jest` and `@nx/eslint`; `@nx/web` declares both as optional peers. So installing `@nx/detox` on npm silently drops both:

```console
$ npm i -D @nx/detox@22.7.7 --omit=peer --ignore-scripts
$ ls node_modules/@nx
detox devkit js module-federation nx-darwin-arm64 react rollup vitest web workspace
# @nx/jest and @nx/eslint are missing
```

They are still written to `package-lock.json` with `"peer": true`, are absent from `node_modules/.package-lock.json`, and the install exits 0 with no warning.

`nx run e2e-detox:e2e-macos-local` on this branch fails all 4 tests as a result:

```
NX  Cannot find module '@nx/jest/src/utils/versions'

Require stack:
- <tmp>/node_modules/@nx/detox/src/generators/application/lib/ensure-dependencies.js
```

## Expected Behavior

npm uses `--legacy-peer-deps` instead. That ignores `peerDependencies` — the intent of #36295 — without pruning real dependencies. bun keeps `--omit=peer` (it does not over-prune); pnpm and yarn are unchanged.

`e2e-detox:e2e-macos-local` passes with the change. This branch is where the fix was originally validated end to end, because 22.7.x has no shared e2e base workspace and so genuinely fetches `@nx/detox` on demand — same branch, same e2e, only the flag differing:

| flag | temp dir `node_modules/@nx/` | result |
| --- | --- | --- |
| `--omit=peer` | detox devkit js module-federation nx-darwin-arm64 react rollup vitest web workspace | 4 tests failed |
| `--legacy-peer-deps` | detox devkit **eslint jest** js module-federation nx-darwin-arm64 react rollup vite vitest web workspace | 4 tests passed |

## Related Issue(s)

N/A — `--omit=peer` has not been released on this branch (`nx@22.7.7` still ships the old flag-less install command), so there is no user impact. This lands the fix before the next 22.7.x release.

## Validation on this branch

- `nx run e2e-detox:e2e-macos-local` — 2 suites / 4 tests pass
- `nx test nx --testPathPatterns=src/utils/package-json.spec.ts` — 339 tests pass
- `nx prepush` — passes

<!-- polygraph-session-start -->
---
<p><picture><source media="(prefers-color-scheme: dark)" srcset="https://static.ops.cloud.nx.app/polygraph/session-logo-v4-dark.svg"><img src="https://static.ops.cloud.nx.app/polygraph/session-logo-v4-light.svg" width="16" height="22" align="middle" alt="Polygraph"></picture> <a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Fix-npm-temp-install-pruning-real-dependencies-via---omitpeer-f7aff304">View session ↗</a></p>
<!-- polygraph-session-end -->