### PR TITLE
fix(nx): prefer exact dependsOn target names over globs

### DIFF
--- a/packages/nx/src/tasks-runner/create-task-graph.spec.ts
+++ b/packages/nx/src/tasks-runner/create-task-graph.spec.ts
@@ -2931,6 +2931,50 @@ describe('createTaskGraph', () => {
     ]);
   });
 
+  function getApp1CompileDependencies() {
+    return createTaskGraph(projectGraph, {}, ['app1'], ['compile'], null, {})
+      .dependencies['app1:compile'];
+  }
+
+  it('should prefer an exact target name containing glob characters', () => {
+    const target = 'test-ci--src/app/projects/[id]/page.test.tsx';
+    const targets = projectGraph.nodes.app1.data.targets;
+    targets.compile.dependsOn = [target];
+    targets[target] = { executor: 'nx:noop' };
+
+    expect(getApp1CompileDependencies()).toEqual([`app1:${target}`]);
+  });
+
+  it('should ignore exact target names from unrelated projects when expanding globs', () => {
+    const targets = projectGraph.nodes.app1.data.targets;
+    targets.compile.dependsOn = ['test-*'];
+    targets['test-one'] = { executor: 'nx:noop' };
+    projectGraph.nodes.lib1.data.targets['test-*'] = { executor: 'nx:noop' };
+
+    expect(getApp1CompileDependencies()).toEqual(['app1:test-one']);
+  });
+
+  it('should prefer an exact target name in transitive dependencies', () => {
+    const target = 'test-[id]';
+    projectGraph.nodes.app1.data.targets.compile.dependsOn = [`^${target}`];
+    projectGraph.nodes.lib2 = {
+      name: 'lib2',
+      type: 'lib',
+      data: {
+        root: 'lib2-root',
+        targets: {
+          [target]: { executor: 'nx:noop' },
+        },
+      },
+    };
+    projectGraph.dependencies.lib1 = [
+      { source: 'lib1', target: 'lib2', type: 'static' },
+    ];
+    projectGraph.dependencies.lib2 = [];
+
+    expect(getApp1CompileDependencies()).toEqual([`lib2:${target}`]);
+  });
+
   it('should handle negative patterns in dependsOn', () => {
     const graph: ProjectGraph = {
       nodes: {

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -19,6 +19,7 @@ import {
 } from '../native';
 import { isRelativePath } from '../utils/fileutils';
 import { findMatchingProjects } from '../utils/find-matching-projects';
+import { findAllProjectNodeDependencies } from '../utils/project-graph-utils';
 import {
   LegacyDependsOnLocation,
   LegacyDependsOnViolation,
@@ -77,14 +78,36 @@ export function normalizeDependencyConfigDefinition(
   allTargetNames: string[],
   location?: DependsOnEntryLocation
 ): NormalizedTargetDependencyConfig[] {
-  return expandWildcardTargetConfiguration(
-    normalizeDependencyConfigProjects(
-      expandDependencyConfigSyntaxSugar(definition, graph, currentProject),
-      currentProject,
-      graph,
-      location
-    ),
-    allTargetNames
+  const dependencyConfig = normalizeDependencyConfigProjects(
+    expandDependencyConfigSyntaxSugar(definition, graph, currentProject),
+    currentProject,
+    graph,
+    location
+  );
+
+  if (
+    isGlobPattern(dependencyConfig.target) &&
+    allTargetNames.includes(dependencyConfig.target) &&
+    hasExactTargetInDependencyScope(dependencyConfig, currentProject, graph)
+  ) {
+    return [dependencyConfig];
+  }
+
+  return expandWildcardTargetConfiguration(dependencyConfig, allTargetNames);
+}
+
+function hasExactTargetInDependencyScope(
+  dependencyConfig: NormalizedTargetDependencyConfig,
+  currentProject: string,
+  graph: ProjectGraph
+): boolean {
+  const projectNames = dependencyConfig.dependencies
+    ? findAllProjectNodeDependencies(currentProject, graph)
+    : dependencyConfig.projects;
+
+  return projectNames.some(
+    (projectName) =>
+      dependencyConfig.target in (graph.nodes[projectName]?.data.targets ?? {})
   );
 }
 


### PR DESCRIPTION
## Current Behavior

Target names containing glob characters are interpreted as wildcard patterns in `dependsOn`, even when an exact target with that name exists.

For atomized Jest targets generated from Next.js dynamic routes, such as `test-ci--src/app/projects/[id]/page.test.tsx`, this can match no targets and silently omit the dependency from the task graph.

## Expected Behavior

Prefer an existing exact target name before attempting wildcard expansion. Wildcard target dependencies continue to expand when no exact target exists.

This adds regression coverage for an atomized Jest target generated from a Next.js dynamic route.

## Related Issue(s)

Fixes #36498