### PR TITLE
fix(release): Don't attribute commits with no author email to `@find`

### DIFF
--- a/packages/nx/release/changelog-renderer/index.spec.ts
+++ b/packages/nx/release/changelog-renderer/index.spec.ts
@@ -185,6 +185,64 @@ describe('ChangelogRenderer', () => {
               `);
       });
 
+      it('should not collect empty author emails (which would otherwise be attributed to the "find" user via ungh)', async () => {
+        const applyUsernameSpy = jest
+          .spyOn(remoteReleaseClient, 'applyUsernameToAuthors')
+          .mockResolvedValue(undefined);
+        const renderer = new DefaultChangelogRenderer({
+          changes: [
+            {
+              shortHash: 'abc1234',
+              authors: [
+                {
+                  name: 'Test User',
+                  email: '',
+                },
+              ],
+              body: '"\n\nM\tpackages/pkg-a/src/index.ts\n"',
+              description: 'a change with no author email',
+              type: 'fix',
+              scope: 'pkg-a',
+              githubReferences: [{ value: 'abc1234', type: 'hash' }],
+              isBreaking: false,
+              revertedHashes: [],
+              affectedProjects: ['pkg-a'],
+            },
+          ],
+          remoteReleaseClient,
+          changelogEntryVersion: 'v1.1.0',
+          project: null,
+          isVersionPlans: false,
+          entryWhenNoChanges: false,
+          changelogRenderOptions: {
+            authors: true,
+            applyUsernameToAuthors: true,
+          },
+          conventionalCommitsConfig: DEFAULT_CONVENTIONAL_COMMITS_CONFIG,
+        });
+        const markdown = await renderer.render();
+
+        expect(applyUsernameSpy).toHaveBeenCalledTimes(1);
+        const passedAuthors = applyUsernameSpy.mock.calls[0][0];
+        // The empty email must not have been collected, so there is nothing to
+        // look up against ungh and no chance of attributing it to the "find" user.
+        expect([...passedAuthors.get('Test User').email]).toEqual([]);
+        // The author is still credited, just without an @handle.
+        expect(markdown).toMatchInlineSnapshot(`
+          "## v1.1.0
+
+          ### 🩹 Fixes
+
+          - **pkg-a:** a change with no author email
+
+          ### ❤️ Thank You
+
+          - Test User"
+        `);
+
+        applyUsernameSpy.mockRestore();
+      });
+
       it('should not generate a Thank You section when changelogRenderOptions.authors is false', async () => {
         const renderer = new DefaultChangelogRenderer({
           changes,

--- a/packages/nx/release/changelog-renderer/index.ts
+++ b/packages/nx/release/changelog-renderer/index.ts
@@ -332,11 +332,11 @@ export default class DefaultChangelogRenderer {
         if (!name || name.includes('[bot]')) {
           continue;
         }
-        if (_authors.has(name)) {
-          const entry = _authors.get(name);
-          entry.email.add(author.email);
-        } else {
-          _authors.set(name, { email: new Set([author.email]) });
+        if (!_authors.has(name)) {
+          _authors.set(name, { email: new Set<string>() });
+        }
+        if (author.email) {
+          _authors.get(name).email.add(author.email);
         }
       }
     }

--- a/packages/nx/src/command-line/release/utils/remote-release-clients/github.spec.ts
+++ b/packages/nx/src/command-line/release/utils/remote-release-clients/github.spec.ts
@@ -101,6 +101,56 @@ describe('GithubRemoteReleaseClient', () => {
     expect(authors.get('Test User')?.username).toBe('from-gh');
   });
 
+  it('should skip empty author emails without querying ungh or the gh api', async () => {
+    // An empty email makes the ungh lookup URL `https://ungh.cc/users/find/`,
+    // so it attributes the commit to the "find" user rather than the real
+    // author. It must be skipped entirely.
+    const authors = new Map<string, { email: Set<string>; username?: string }>([
+      ['Test User', { email: new Set(['']) }],
+    ]);
+
+    await client.applyUsernameToAuthors(authors);
+
+    expect(authors.get('Test User')?.username).toBeUndefined();
+    expect(axiosGetMock).not.toHaveBeenCalled();
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  it('should skip non-email author values without querying ungh or the gh api', async () => {
+    const authors = new Map<string, { email: Set<string>; username?: string }>([
+      ['Test User', { email: new Set(['not-an-email']) }],
+    ]);
+
+    await client.applyUsernameToAuthors(authors);
+
+    expect(authors.get('Test User')?.username).toBeUndefined();
+    expect(axiosGetMock).not.toHaveBeenCalled();
+    expect(execFileSyncMock).not.toHaveBeenCalled();
+  });
+
+  it('should skip a bad email but still resolve a valid one in the same set', async () => {
+    // The guard must `continue` past the empty email, not `break` out of the
+    // loop, so a valid email later in the set is still looked up.
+    axiosGetMock.mockResolvedValue({
+      data: {
+        user: {
+          username: 'from-ungh',
+        },
+      },
+    });
+    const authors = new Map<string, { email: Set<string>; username?: string }>([
+      ['Test User', { email: new Set(['', 'test@example.com']) }],
+    ]);
+
+    await client.applyUsernameToAuthors(authors);
+
+    expect(authors.get('Test User')?.username).toBe('from-ungh');
+    expect(axiosGetMock).toHaveBeenCalledTimes(1);
+    expect(axiosGetMock).toHaveBeenCalledWith(
+      'https://ungh.cc/users/find/test@example.com'
+    );
+  });
+
   it('should leave the username unset when both lookups fail', async () => {
     axiosGetMock.mockRejectedValue(new Error('ungh unavailable'));
     execFileSyncMock.mockImplementation(() => {

--- a/packages/nx/src/command-line/release/utils/remote-release-clients/github.ts
+++ b/packages/nx/src/command-line/release/utils/remote-release-clients/github.ts
@@ -169,6 +169,12 @@ export class GithubRemoteReleaseClient extends RemoteReleaseClient<GithubRemoteR
       [...authors.keys()].map(async (authorName) => {
         const meta = authors.get(authorName);
         for (const email of meta.email) {
+          // An empty email makes the URL `/users/find/`, so ungh attributes
+          // the commit to the "find" user rather than the real author.
+          // Non-emails just 404, but skip those too to avoid a wasted lookup.
+          if (!email || !email.includes('@')) {
+            continue;
+          }
           if (email.endsWith('@users.noreply.github.com')) {
             const match = email.match(
               /^(\d+\+)?([^@]+)@users\.noreply\.github\.com$/


### PR DESCRIPTION
## Current Behavior

Release changelogs can thank the wrong person. A GitHub user named `find` — a real, unrelated account — gets credited in the "Thank You" section for commits they had nothing to do with.

The trigger is a commit whose author has no email. Author emails are resolved to GitHub handles through ungh at `https://ungh.cc/users/find/<email>`. An empty email collapses that to the bare route `https://ungh.cc/users/find/`, which ungh resolves to the account literally named `find`:

```shell
# empty email -> collapses to the bare route, resolves to an unrelated real user
$ curl -s "https://ungh.cc/users/find/"
{"user":{"id":1464145,"username":"find","name":null,"twitter":null,"avatar":"..."}}

# a well-formed email with no matching GitHub account -> 404, correctly unresolved
$ curl -s "https://ungh.cc/users/find/no-such-user@example.invalid"
{
  "error": true,
  "status": 404,
  "statusText": "User Not Found",
  "message": "User Not Found"
}
```


## Expected Behavior

Empty and non-email author values are skipped: they're never collected into the author set in the changelog renderer, and the GitHub client guards the lookup so it never builds the `/users/find/` URL. The author is still credited in the "Thank You" section, just without a resolved `@handle`. A valid email later in the same set is still resolved (the guard `continue`s rather than `break`s).

## Related Issue(s)

No linked issue — submitting the fix directly per the contributing guidelines.
