### PR TITLE
fix(ci): replace invalid Actions pin with the commit SHA it resolves to

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
             ${{ runner.os }}-pnpm-store-
 
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@48b5f213c81028ace310571dc5ec0fbbca0b2947 # v4.4.3
+        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3
 
       - name: Install project dependencies
         run: pnpm install --frozen-lockfile

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -398,7 +398,7 @@ jobs:
 
       - name: Setup tmate session
         if: ${{ github.event_name == 'workflow_dispatch' && inputs.debug_enabled && failure() }}
-        uses: mxschmitt/action-tmate@1fb8b1023602bf1fd0e2994d7f1e93015cb5bbec # v3.22
+        uses: mxschmitt/action-tmate@7b6a61a73bbb9793cb80ad69b8dd8ac19261834c # v3.22
         timeout-minutes: 15
         with:
           sudo: ${{ matrix.os != 'windows-latest' }} # disable sudo for windows debugging

--- a/.github/workflows/generate-embeddings.yml
+++ b/.github/workflows/generate-embeddings.yml
@@ -23,7 +23,7 @@ jobs:
           package-manager-cache: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@7088e561eb65bb68695d245aa206f005ef30921d # v4.1.0
+        uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
         id: pnpm-install
         with:
           version: 11.2.2

--- a/.github/workflows/issue-notifier.yml
+++ b/.github/workflows/issue-notifier.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
 
-      - uses: pnpm/action-setup@7088e561eb65bb68695d245aa206f005ef30921d # v4.1.0
+      - uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
         with:
           version: 11.2.2
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -429,7 +429,7 @@ jobs:
 
       - name: Build
         id: build
-        uses: cross-platform-actions/action@462ed697694d2ac9aa49e1225f395f7bb6dd49fe # v0.29.0
+        uses: cross-platform-actions/action@e8a7b572196ff79ded1979dc2bb9ee67d1ddb252 # v0.29.0
         env:
           DEBUG: napi:*
           RUSTUP_IO_THREADS: 1


### PR DESCRIPTION
## Problem

These workflow `uses:` pins are invalid as written. Each item below shows the current value, why it is wrong, and the correct ref that must be used instead.

### 1. `.github/workflows/ci.yml`

**Current (invalid):**

```yaml
uses: gradle/actions/setup-gradle@48b5f213c81028ace310571dc5ec0fbbca0b2947 # v4.4.3
```

**Why this is wrong:**

- `48b5f213c81028ace310571dc5ec0fbbca0b2947` is **not a commit SHA**. It is the Git object SHA of an **annotated tag** (`v4.4.3`).
- GitHub Actions does not accept annotated tag *object* SHAs in `uses:` pins (Commits API returns `No commit found for SHA`).
- The correct pin is the **commit SHA that tag `v4.4.3` points to**: `ed408507eac070d1f99cc633dbcf757c94c7933a`.

**Correct pin:**

```yaml
uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3
```

### 2. `.github/workflows/e2e-matrix.yml`

**Current (invalid):**

```yaml
uses: mxschmitt/action-tmate@1fb8b1023602bf1fd0e2994d7f1e93015cb5bbec # v3.22
```

**Why this is wrong:**

- `1fb8b1023602bf1fd0e2994d7f1e93015cb5bbec` is **not a commit SHA**. It is the Git object SHA of an **annotated tag** (`v3.22`).
- GitHub Actions does not accept annotated tag *object* SHAs in `uses:` pins (Commits API returns `No commit found for SHA`).
- The correct pin is the **commit SHA that tag `v3.22` points to**: `7b6a61a73bbb9793cb80ad69b8dd8ac19261834c`.

**Correct pin:**

```yaml
uses: mxschmitt/action-tmate@7b6a61a73bbb9793cb80ad69b8dd8ac19261834c # v3.22
```

### 3. `.github/workflows/generate-embeddings.yml`

**Current (invalid):**

```yaml
uses: pnpm/action-setup@7088e561eb65bb68695d245aa206f005ef30921d # v4.1.0
```

**Why this is wrong:**

- `7088e561eb65bb68695d245aa206f005ef30921d` is **not a commit SHA**. It is the Git object SHA of an **annotated tag** (`v4.1.0`).
- GitHub Actions does not accept annotated tag *object* SHAs in `uses:` pins (Commits API returns `No commit found for SHA`).
- The correct pin is the **commit SHA that tag `v4.1.0` points to**: `a7487c7e89a18df4991f7f222e4898a00d66ddda`.

**Correct pin:**

```yaml
uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
```

### 4. `.github/workflows/issue-notifier.yml`

**Current (invalid):**

```yaml
uses: pnpm/action-setup@7088e561eb65bb68695d245aa206f005ef30921d # v4.1.0
```

**Why this is wrong:**

- `7088e561eb65bb68695d245aa206f005ef30921d` is **not a commit SHA**. It is the Git object SHA of an **annotated tag** (`v4.1.0`).
- GitHub Actions does not accept annotated tag *object* SHAs in `uses:` pins (Commits API returns `No commit found for SHA`).
- The correct pin is the **commit SHA that tag `v4.1.0` points to**: `a7487c7e89a18df4991f7f222e4898a00d66ddda`.

**Correct pin:**

```yaml
uses: pnpm/action-setup@a7487c7e89a18df4991f7f222e4898a00d66ddda # v4.1.0
```

### 5. `.github/workflows/publish.yml`

**Current (invalid):**

```yaml
uses: cross-platform-actions/action@462ed697694d2ac9aa49e1225f395f7bb6dd49fe # v0.29.0
```

**Why this is wrong:**

- `462ed697694d2ac9aa49e1225f395f7bb6dd49fe` is **not a commit SHA**. It is the Git object SHA of an **annotated tag** (`v0.29.0`).
- GitHub Actions does not accept annotated tag *object* SHAs in `uses:` pins (Commits API returns `No commit found for SHA`).
- The correct pin is the **commit SHA that tag `v0.29.0` points to**: `e8a7b572196ff79ded1979dc2bb9ee67d1ddb252`.

**Correct pin:**

```yaml
uses: cross-platform-actions/action@e8a7b572196ff79ded1979dc2bb9ee67d1ddb252 # v0.29.0
```

## Test plan

- [ ] Each updated `uses:` ref resolves as a commit via the GitHub Commits API
- [ ] Relevant CI jobs on this branch look healthy
