### PR TITLE
chore(repo): cut duplicated verification work in the review-pr skill

### DIFF
--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -77,7 +77,7 @@ Parse out:
 - `title`, `author.login`, `headRefOid` (the head SHA), `headRefName`, `baseRefName`, `url`
 - `isDraft` — if true, exit early (don't review drafts)
 - **Local dedup:** if `$TRIAGE_DIR/<NUMBER>.md` exists, its frontmatter `head_sha` equals `headRefOid`, its `pipeline_version` equals the current `PIPELINE_VERSION` (see below), and its `verdict` is not `failed`, this PR was already reviewed at this commit — exit with no draft change; log "ALREADY_REVIEWED". A `failed` draft never blocks a retry. To deliberately re-review an unchanged PR, delete the draft file or just say so in the session.
-- **`PIPELINE_VERSION: 3`** — the current review-criteria generation. A draft whose frontmatter has an older `pipeline_version` (or none) was produced by a weaker pipeline: re-review even at an unchanged `head_sha`, treating the old draft as a prior review (Step 4). Bump this constant whenever the review criteria change materially (new agents, new calibrations, new required sections) so stale drafts age out instead of being pinned forever by the SHA dedup.
+- **`PIPELINE_VERSION: 4`** — the current review-criteria generation. A draft whose frontmatter has an older `pipeline_version` (or none) was produced by a weaker pipeline: re-review even at an unchanged `head_sha`, treating the old draft as a prior review (Step 4). Bump this constant whenever the review criteria change materially (new agents, new calibrations, new required sections) so stale drafts age out instead of being pinned forever by the SHA dedup.
 
 ## Step 3: Check the PR out inside the sandbox container
 
@@ -120,7 +120,34 @@ docker exec "$CONTAINER" bash -lc '
   git worktree add --detach /work/base "origin/<BASE_REF_NAME>"
   git rev-parse HEAD          # HEAD_SHA
 '
+
+# Install the workspace ONCE, here, before any agent is dispatched. Agents run test
+# suites, mutate sources to prove a test can fail, and execute the repo's own eslint
+# and tsc — all of which need node_modules. Installing on demand instead means several
+# agents racing `pnpm install` in the same directory, which can corrupt node_modules,
+# and gives them whatever versions they happen to pick rather than the repo's pinned ones.
+# The image bakes the mise toolchain but no node_modules, so nothing is installed until this runs.
+# cwd must sit under a mise.toml or the shims report "No version is set for shim: npm".
+# No `mise trust` needed: the image sets MISE_YES=1, which auto-trusts the PR's mise.toml on first
+# use. Without it, a PR that edits mise.toml fails with "Config files ... are not trusted".
+docker exec "$CONTAINER" bash -lc '
+  cd /work/nx
+  mise install >/dev/null 2>&1                    # installs any tool version the PR bumped
+  if   pnpm install --frozen-lockfile >/dev/null 2>&1; then
+    echo "workspace install OK"
+  elif pnpm install >/dev/null 2>&1; then
+    echo "workspace install OK — but only WITHOUT --frozen-lockfile: the lockfile is out of sync with package.json (a review signal; note it)"
+  else
+    echo "workspace install FAILED — agents cannot run tests or the repo eslint"
+  fi
+'
 ```
+
+This is the slowest step in the skill, but the image ships a warm pnpm store, so it mostly links rather than downloads. It buys correctness as much as speed: one deterministic install instead of N racing ones, at the versions the repo pins. Skip it only for a diff with nothing runnable (docs-only), and say so in the charter so agents don't discover it one failed command at a time.
+
+If it is unexpectedly slow, the image predates the warm store — rebuild it via `setup-review-sandbox`.
+
+`/work/base` is deliberately left uninstalled. Only the reproduce-verifier executes base-side, and pnpm's content-addressable store makes that second install cheap when it does.
 
 Use `origin/<BASE_REF_NAME>` here, **not** `FETCH_HEAD`. `FETCH_HEAD` is a per-worktree pseudoref written into the main worktree's git dir, so it is invisible from a linked worktree — any later command that re-points `/work/base` via `FETCH_HEAD` fails, and git compounds it by reinterpreting the unresolvable token as a pathspec (`--detach does not take a path argument`), which points nowhere near the real cause. Remote-tracking refs live in the common git dir and resolve from every worktree.
 
@@ -128,7 +155,9 @@ Notes:
 
 - **No `-v` host mounts** — the checkout must live only in the container. All caps dropped, no privilege escalation, resources bounded.
 - **Efficiency:** the gh-only close-without-merge signals (Step 4.5, signals 1–4 and 6–8) need no container. For a **first** review, you may run those cheap signals first and only start the container if no strong close signal fired — a superseded/unnecessary PR then costs no sandbox. For a **re-review**, Step 4's incremental diff needs the container, so start it before Step 4. Either way, once created it must be torn down in Step 9.
-- The image carries the repo toolchain (node/java/dotnet/rust/bun via mise) baked from `mise.toml`, and `mise` auto-installs the PR's _pinned_ toolchain on first exec, so in-container execution (repro, builds) works without host help.
+- The image carries the repo toolchain (node/java/dotnet/rust/bun via mise) baked from `mise.toml`, and `mise` auto-installs the PR's _pinned_ toolchain on first exec, so in-container execution (repro, builds) works without host help. It bakes **no** `node_modules` — that is what the install step above is for.
+- `tsc` and `eslint` come from the workspace install, so agents get the versions the repo pins rather than an arbitrary latest. Report the install's outcome in the charter (Step 5).
+- **Run every in-container command with cwd inside `/work/nx`.** mise resolves tool versions by walking up from cwd, so a command run from `/tmp` (or any path outside a `mise.toml` tree) fails with `No version is set for shim: npm` even though `node` happens to resolve — a confusing error with nothing to do with the PR.
 - The `--depth 1` PR-head fetch gives the full working tree at HEAD — enough for reading every changed and surrounding file. This step also adds the base ref as a second worktree at `/work/base` in the same container, before any agent is dispatched — one container per PR holds everything. The agents never create, move, or re-point either checkout; they only read them (only the reproduce-verifier also runs things).
 - **Read base state from `/work/base`, not from a host clone.** It is fetched fresh from the remote on every run, so it is always the PR's actual base. A maintainer's local clone can be weeks stale, which would silently answer "was this behavior already there?" against the wrong tree — the question calibration 7 exists to settle.
 
@@ -367,6 +396,65 @@ If all signals are cheap-negative, skip emitting the section entirely (no noise 
 
 If **superseded (strong)** or **unnecessary (strong)** fired, skip Steps 5 through 5b entirely (toolkit, alternative-approach, performance-analyzer, security-analyzer, reproduce-verifier, reconciliation). The verdict precedence in Step 7 already decides the outcome, so agent findings can't change it — and nobody acts on code feedback for a PR that won't merge. Set `$REVIEW_BODY` to just the `### Close-without-merge check` section and continue with Steps 6-10 as normal.
 
+## Step 4.7: Measure shared load-bearing claims ONCE, before dispatching
+
+Some PRs turn on a single mechanical fact that **every** agent would otherwise re-derive
+independently: what a module graph actually loads, what a changed lint config actually blocks,
+whether a deleted user-facing message is still emitted somewhere else. These are expensive to
+establish (install a toolchain, compile, instrument, run a matrix) and cheap to check once you have
+the answer.
+
+Left alone, the pipeline pays for that establishment once per agent, and every one of them reaches
+the same answer. So: measure first, then hand the result to the agents **as a claim to attack**.
+
+### When this step applies
+
+Only when the diff makes a **mechanical, globally-relevant assertion** that more than one agent's
+dimension depends on. Signals that it does:
+
+- A comment or PR-body claim about **module load order or laziness** ("non-agentic runs never load
+  X", "this import is deferred").
+- A changed **lint / CI / build config** whose effect is the point of the change.
+- A **removed** log, warning, or error, justified as "the sink already reports it".
+- A claimed **behavioral parity** between two code paths ("the worker mirrors the classic loop").
+
+If the diff makes no such claim, skip this step entirely — most PRs will.
+
+### How to do it
+
+1. **Snapshot first.** Copy the tree inside the container (`cp -a /work/nx/packages /snap/packages`)
+   and measure against the snapshot. Agents run concurrently and some mutate `/work/nx` (the test
+   analyzer mutates source deliberately to prove tests can fail); measuring the live checkout makes
+   your result a race.
+2. **Use the workspace install** from Step 3 — `cd /work/nx` first so mise resolves the toolchain.
+3. **Prefer the method that reproduces the real build.** For "is this import lazy?", transpile the
+   entry module with `tsc --module commonjs` and walk `require()` calls at **column 0** of the emit
+   (indented ⇒ inside a function ⇒ lazy). Only TypeScript's own emit applies its real elision rules,
+   so a hand-written import parser over-approximates and a grep is simply wrong.
+4. **Measure the comparison points too** — the base (`/work/base`) and, on a re-review, the prior
+   SHA (`git worktree add --detach /work/prior <PRIOR_SHA>`). A number without its baseline cannot
+   answer "is this net-new?", which is calibration 7's question.
+5. **Record the method, not just the number.** The charter entry must let an agent re-run it.
+
+### How to write it into the charter
+
+Add an `## Established measurements` section (see the Step 5 template). Frame every entry as a
+**measured claim the agent is invited to falsify** — never as settled truth:
+
+> Measured, not asserted. Do NOT re-derive these from scratch; that duplication is the single
+> largest avoidable cost in this pipeline. DO challenge any of them if your own reading of the
+> code contradicts it — say so explicitly and show what you saw. A contradiction is a finding.
+
+That phrasing is load-bearing. "Here is the answer" makes agents incurious; "here is my
+measurement, break it if you can" keeps the adversarial value at a fraction of the cost. The
+independence that matters — `alternative-approach`, `security-analyzer` and `performance-analyzer`
+arriving uninformed about the _author's reasoning_ — is untouched, because a mechanical measurement
+is not a rationale. Keep giving them the measurement; keep withholding the Polygraph session until
+Step 5c.
+
+**Never put a conclusion here that you did not personally run.** This section is trusted by nine
+agents at once, so an error in it is nine wrong reviews rather than one.
+
 ## Step 5: Run the review toolkit
 
 First, write a review charter at `/tmp/pr-<NUMBER>.review-charter.md` (host-side) so the agents self-filter up front instead of generating findings that get trimmed later. **The charter must open with the sandbox reading protocol** so every downstream agent knows where the code is and never runs it on the host:
@@ -380,7 +468,8 @@ The PR is checked out at `/work/nx` **inside a sandbox container named `nx-revie
 NOT on the host filesystem. Your native Read/Grep/Glob tools will NOT find the PR source. Reach it
 only with `docker exec` against that container:
 
-- Primary review surface — the diff — is on the host at `/tmp/pr-<NUMBER>.diff`; read it with `Read`.
+- Primary review surface — a diff — is on the host; your dispatch prompt names it as REVIEW TARGET
+  (`/tmp/pr-<NUMBER>.diff`, or the incremental diff on a re-review). Read it with `Read`.
 - To read any PR source file for context:
   - `docker exec nx-review-pr-<NUMBER> cat /work/nx/<path>`
   - `docker exec nx-review-pr-<NUMBER> grep -rn "<pattern>" /work/nx/<subdir>`
@@ -390,6 +479,38 @@ only with `docker exec` against that container:
   the reproduction) MUST go through
   `docker exec nx-review-pr-<NUMBER> bash -lc 'export PATH="/root/.local/bin:/root/.local/share/mise/shims:$PATH"; cd /work/nx && <cmd>'`.
   Running it bare on the host is a protocol violation.
+
+## Toolchain (already installed — do not install your own)
+
+The workspace is installed at `/work/nx`, so `tsc`, `eslint`, `jest` and the repo's own scripts are
+available at the versions the repo pins. Do not install your own copies — you would get different
+versions and could corrupt `node_modules` for the agents running alongside you.
+
+**Always `cd /work/nx` first.** mise resolves tool versions by walking up from cwd, so a command run
+from elsewhere fails with `No version is set for shim: npm` even though `node` resolves:
+
+    docker exec nx-review-pr-<NUMBER> bash -lc 'cd /work/nx && pnpm --version'
+
+<IF the Step 3 install did not report OK, REPLACE the first paragraph with what actually happened —
+"the workspace install failed, so you cannot run tests or eslint; restrict yourself to reading" —
+rather than leaving agents to discover it one failed command at a time.>
+
+## Established measurements
+
+<OMIT THIS SECTION ENTIRELY unless Step 4.7 ran. When it did, paste its results here.>
+
+Measured by the caller before you were dispatched — **not asserted, and not the author's word.**
+
+Do NOT re-derive these from scratch — that duplication is the single largest avoidable cost in this
+pipeline.
+
+DO challenge any of them if your own reading of the code contradicts what is written here. Say so
+explicitly and show what you saw — a contradiction between this section and the code is itself a
+finding, and a valuable one. Reuse these as a _starting point_ for your own dimension's questions,
+not as a place to stop.
+
+<For each measurement: the claim, the method (specific enough to re-run), and the result —
+including the base and, on a re-review, the prior SHA, so "is this net-new?" is answerable.>
 
 ## Review methodology (mandatory)
 
@@ -410,6 +531,26 @@ only with `docker exec` against that container:
   this same change where the same class of defect could occur. A fix that closes a hole at the
   sink routinely leaves the identical class open one hop upstream.
 
+## Proof of work (every agent, every report)
+
+Open your report with exactly these three plain-text lines — not markdown headings, and do NOT wrap
+the evidence in a code span or backticks:
+
+    REVIEWED: <how many changed files you actually opened>
+    EVIDENCE_LINE: <the line number in <EVIDENCE_FILE> of the line you quote below>
+    EVIDENCE_TEXT: <that exact line, verbatim — MUST begin with `+` or `-`, 20+ chars after
+                    the sign, and MUST NOT be a `diff --git`, `index`, `---`, `+++`, or `@@` line>
+
+`<EVIDENCE_FILE>` is named in your dispatch prompt. The caller reads that file at EVIDENCE_LINE and
+checks it equals EVIDENCE_TEXT.
+
+The line **number** is the proof: it appears in no prompt and in no prior-review text, so only
+opening the file yields it. A filename or a `diff --git` header is derivable from the prompt and
+proves nothing. A report that does not verify is discarded and the agent recorded as failed —
+**including a report that found no issues**, and including an endorsement verdict (`*_SOUND`,
+`NOT_ATTEMPTED`). An endorsement asserts "I checked and found nothing", which is exactly the claim
+an agent that read nothing produces most fluently, so it costs more evidence, not less.
+
 ## What to report
 
 Report **critical** and **important** findings, plus **strengths**. Concrete,
@@ -425,7 +566,11 @@ these is advisory at most and not worth writing up:
 <COPY THE FULL "Nx-specific calibration" LIST FROM THIS SKILL, VERBATIM>
 ```
 
-Substitute the real PR number for **every** `<NUMBER>` in the template — do not work from a count, and do not assume they are all inside `docker exec` commands. They are not: one is the container-name sentence and one is `/tmp/pr-<NUMBER>.diff`, the primary review surface. Leaving that last one literal points every agent at a nonexistent file, so no agent can produce a verifiable EVIDENCE line and the whole run degrades to all-agents-failed. (There is deliberately no `<CONTAINER>` token; the container name is spelled out so a half-done substitution is visible rather than silent.)
+Substitute the real PR number for **every** `<NUMBER>` in the template — do not work from a count, and do not assume they are all inside `docker exec` commands. They are not: they include the container-name sentence, the toolchain paths, and `/tmp/pr-<NUMBER>.diff`, the primary review surface. Leaving that last one literal points every agent at a nonexistent file, so no agent can produce a verifiable EVIDENCE line and the whole run degrades to all-agents-failed. (There is deliberately no `<CONTAINER>` token; the container name is spelled out so a half-done substitution is visible rather than silent.)
+
+Also resolve the `<IF …>` / `<OMIT …>` / `<For each …>` placeholders in the template — the toolchain-unavailable branch and the `## Established measurements` body. A charter shipped with an unresolved angle-bracket instruction tells nine agents to follow an instruction meant for you.
+
+**`<EVIDENCE_FILE>` is the one token that stays literal in the charter.** It differs per agent (the reproduce-verifier keeps the full diff while the others may get the incremental one), so the charter deliberately defers it — "named in your dispatch prompt" — and each _dispatch prompt_ resolves it to a real path. Substituting a single path into the charter would silently point some agents at a file they were never given.
 
 ### Dispatch the review agents directly — NOT via the toolkit command
 
@@ -445,6 +590,28 @@ populated diff hands every agent a `CHANGED FILES:` heading followed by nothing.
 `wc -l < /tmp/pr-<NUMBER>.files` does not equal the `changedFiles` count parsed in Step 2 — that
 mismatch means one of the two `gh` calls silently returned a partial answer.
 
+**Pass the file list by path, not by value.** Agents have `Read` and the list is a host file, so
+pasting its contents into every prompt buys nothing and costs the whole list once per agent. The one
+thing the paste bought — an agent noticing an empty scope — is already covered by the abort above,
+which fires before any dispatch.
+
+### Choose the EVIDENCE surface
+
+The proof-of-work line number (charter: "Proof of work") is checked against **one** file, named per
+dispatch as `<EVIDENCE_FILE>`:
+
+- **First review**, or no usable incremental diff → `/tmp/pr-<NUMBER>.diff`.
+- **Re-review** where Step 4 set `HAS_PRIOR_CONTEXT=true` **and**
+  `wc -l < /tmp/pr-<NUMBER>-incremental.diff` is at least 40 → `/tmp/pr-<NUMBER>-incremental.diff`.
+
+Pointing the proof at the incremental diff on a re-review does two things at once: it proves the
+agent opened the surface that actually matters this round, and it stops agents grazing the full diff
+for a quotable line. Below ~40 lines the far-half retry (see below) has too little room, so fall
+back to the full diff.
+
+The full diff stays available either way — as **reference**, not as the review target. Say which is
+which; agents that are handed both without a hierarchy read both in full.
+
 Then dispatch each agent with this prompt shape:
 
 ```
@@ -458,27 +625,24 @@ SCOPE — review exactly these changes. Do NOT run `git status` or `git diff` to
 the host working tree is clean and unrelated to this PR, so host git reports no changes. If you
 find yourself with an empty file list, you have the wrong scope — re-read the inputs below.
 
-- DIFF: /tmp/pr-<NUMBER>.diff  (host file — the complete PR diff; read it with `Read`)
-- CHANGED FILES: <PASTE the contents of /tmp/pr-<NUMBER>.files>
+- REVIEW TARGET: <EVIDENCE_FILE>  (host file — read it with `Read`; this is what you review)
+- CHANGED FILES: /tmp/pr-<NUMBER>.files  (host file — one path per line; `Read` it)
 - CONTAINER: nx-review-pr-<NUMBER>  (PR checked out at /work/nx inside this sandbox container; base ref at /work/base)
 - BASE_REF: <BASE_REF_NAME>
+<ONLY IF <EVIDENCE_FILE> is the incremental diff, ADD:>
+- FULL DIFF (reference only): /tmp/pr-<NUMBER>.diff — the whole PR against its base. Consult it to
+  understand context around a delta hunk; do NOT review it end to end. Prior rounds already reviewed
+  it, and this round's job is the delta.
 
-Read /tmp/pr-<NUMBER>.review-charter.md (host file) first — it carries the severity policy, the
-maintainer calibrations, and the mandatory sandbox reading protocol. The PR source is NOT on the
-host: reach it only via `docker exec nx-review-pr-<NUMBER> cat/grep/find/sed /work/nx/…`, and
-never run PR code on the host.
+Read /tmp/pr-<NUMBER>.review-charter.md (host file) FIRST. It carries the sandbox reading protocol,
+the pre-installed analysis toolchain, any measurements already established for you, the severity
+policy and the maintainer calibrations. The PR source is NOT on the host: reach it only via
+`docker exec nx-review-pr-<NUMBER> cat/grep/find/sed /work/nx/…`, and never run PR code on the host.
 
-REQUIRED — open your report with exactly these three lines:
-
-  REVIEWED: <how many changed files you actually opened>
-  EVIDENCE_LINE: <the line number in /tmp/pr-<NUMBER>.diff of the line you quote below>
-  EVIDENCE_TEXT: <that exact line, verbatim — MUST begin with `+` or `-`, 20+ chars after the sign,
-                  and MUST NOT be a `diff --git`, `index`, `---`, `+++`, or `@@` line>
-
-The caller reads the diff at EVIDENCE_LINE and checks it equals EVIDENCE_TEXT. The line NUMBER is the
-proof: it is in no prompt and in no prior-review text, so only opening the diff yields it. A filename
-or a `diff --git` header is derivable from this prompt and proves nothing. A report that does not
-verify is discarded and the agent recorded as failed — including a report that found no issues.
+REQUIRED — open your report with the three proof-of-work lines exactly as the charter's
+"Proof of work" section specifies, with <EVIDENCE_FILE> as the file the line number refers to.
+A report without a verifying pair is discarded and the agent recorded as failed — including one
+that found no issues.
 <ONLY IF Step 4 set $HAS_PRIOR_CONTEXT=true, ADD:>
 Also read /tmp/pr-<NUMBER>.review-context.md — a distilled carry-forward from prior reviews of this
 PR: what is still open, what was already fixed, and which trade-offs are settled. Focus on what
@@ -502,14 +666,16 @@ Dispatch these in parallel:
 
 A silent "looks good" from an agent that read nothing is the one outcome this pipeline must never produce: it turns a missing review into an apparent endorsement. Every agent — the toolkit agents here (four, or five when `type-design-analyzer` applies), **and** the four in Steps 5a–5a.5 — must prove it opened the artifact.
 
-**Demand a line number, not just a line.** A filename is not evidence: the changed-file list is pasted into every agent's prompt, so an agent that read nothing can cite one. Neither is a `diff --git` header (reconstructible from that list) nor — on a re-review — a bare code line (the prior-review context file quotes applied fixes, so the _content_ of a `+` line is in the agent's sanctioned reading set even when its container reads fail). The one thing an agent cannot produce without opening `/tmp/pr-<NUMBER>.diff` is the **line number** of a `+`/`-` content line: line numbers appear in no prompt and in no prose. Require both:
+**Demand a line number, not just a line.** A filename is not evidence: the changed-file list is a host file every agent is told to `Read`, so an agent that opened nothing else can still cite one. Neither is a `diff --git` header (reconstructible from that list) nor — on a re-review — a bare code line (the prior-review context file quotes applied fixes, so the _content_ of a `+` line is in the agent's sanctioned reading set even when its container reads fail). The one thing an agent cannot produce without opening `<EVIDENCE_FILE>` is the **line number** of a `+`/`-` content line: line numbers appear in no prompt and in no prose. Require both:
 
 ```
 REVIEWED: <N> changed files
-EVIDENCE_LINE: <the line number in /tmp/pr-<NUMBER>.diff, e.g. 214>
+EVIDENCE_LINE: <the line number in <EVIDENCE_FILE>, e.g. 214>
 EVIDENCE_TEXT: <that exact line, verbatim — must begin with `+` or `-`, 20+ chars after the sign,
                and not a `diff --git` / `index` / `---` / `+++` / `@@` line>
 ```
+
+`<EVIDENCE_FILE>` is whichever surface you named as REVIEW TARGET for that agent — the full diff on a first review, the incremental diff on a re-review. Use the **same** file when you verify; checking a line number against a different file than the agent was pointed at fails every honest agent at once.
 
 **Verify by reading the diff yourself at that number.** BOTH `EVIDENCE_LINE` and `EVIDENCE_TEXT` are agent-authored and untrusted — get them into shell variables **only via the `Write` tool + `$(cat …)`, never a bare `LINE=<paste>`**. A bare assignment of the agent's line number is itself host RCE before any gate runs: `LINE=1e touch /tmp/x #` is bash assignment-prefix syntax — it sets `LINE=1e` and _runs_ `touch /tmp/x`. So write both fields to files with the **`Write` tool** (no shell parses their bytes), then read them back with `$(cat …)`. Run everything below as **one** shell invocation — the `LINE=$(cat …)` read and the `case` are a single block, because this harness does not persist shell variables between separate Bash calls (split them and `$LINE` is empty in the `case`, which fails an honest agent). It must emit **exactly one token**; do not paraphrase the checks into separate `echo FAILED` lines:
 
@@ -521,7 +687,7 @@ verdict=FAILED
 case "$LINE" in
   ''|*[!0-9]*) ;;                                  # non-numeric → stays FAILED; sed must NOT run (see below)
   *)
-    sed -n "${LINE}p" /tmp/pr-<NUMBER>.diff > /tmp/pr-<NUMBER>.diffline
+    sed -n "${LINE}p" <EVIDENCE_FILE> > /tmp/pr-<NUMBER>.diffline
     line=$(cat /tmp/pr-<NUMBER>.diffline)          # $(…) strips the trailing newline sed adds
     ev=$(cat /tmp/pr-<NUMBER>.evidence 2>/dev/null)
     if   printf '%s' "$line" | grep -qE '^[+-]' \
@@ -544,13 +710,15 @@ Each element defeats a specific failure that real reviews of this skill actually
 - **`^[+-]` and the header exclusion together**: a `@@` hunk line is caught by `^[+-]` (it starts with `@`); `diff --git`/`index`/`+++`/`---` lines are caught by the header exclusion. Both are derivable from the file list, so only a real content line counts.
 - **Both agent fields reach the shell only through `Write` + `$(cat)`**: `EVIDENCE_LINE` and `EVIDENCE_TEXT` are untrusted, and a bare `LINE=<paste>` executes the value via bash assignment-prefix syntax _before_ the `case` gate. Round-tripping through a file keeps every agent byte out of any shell word.
 
+**One tolerated deviation: a markdown code-span wrapper.** Agents recurrently return `EVIDENCE_TEXT` wrapped in backticks, sometimes also backslash-escaping the inner ones, despite the prompt saying not to. Strip an outer code span and any such escaping, then run the comparison unchanged. This concedes nothing: the **line number** is the proof of work, and the unwrapped text must still match the file byte-for-byte. Failing an honest agent over a formatting habit costs a whole re-review — Step 7 flips the verdict to `failed`, the one value that defeats Step 2's dedup. Record it as a protocol deviation in `## Failures`, not as a failure.
+
 **This applies to endorsements too, and especially to them.** `APPROACH_SOUND`, `PERFORMANCE_SOUND`, `SECURITY_SOUND`, and a `NOT_ATTEMPTED` reproduction all assert _"I checked and found nothing"_ — a claim an agent that read nothing produces just as fluently, and which Steps 5a–5a.3 fold into **Strengths** as an affirmative statement that the dimension was audited. An endorsement must cost more evidence than a finding, not less. A `*_SOUND` verdict with no verified EVIDENCE line is recorded **failed**, never as a strength.
 
 **If EVIDENCE fails to verify, re-dispatch once — but never paste the answer.** Restating the changed-file list is a no-op; the agent already had it. Pasting diff content into the retry prompt is worse than a no-op: it makes the retry's own check unfalsifiable, because the premise the whole mechanism rests on — _the diff content is not in the prompt_ — becomes false exactly for the agent under suspicion. A retry that hands over the evidence launders a failed agent into a pass, and since `verdict: failed` only fires after two failures, it also means that verdict can essentially never fire.
 
 Instead, keep the evidence out of reach and make the demand more specific:
 
-> Your previous EVIDENCE did not verify. Re-read `/tmp/pr-<NUMBER>.diff` and give the EVIDENCE_LINE /
+> Your previous EVIDENCE did not verify. Re-read `<EVIDENCE_FILE>` and give the EVIDENCE_LINE /
 > EVIDENCE_TEXT pair for a `+` or `-` line in the **second half** of the file (line number > <N/2>).
 
 Verify exactly as above (same single-`verdict` block). Add the far-half check as an extra clause **inside** the numeric `*)` branch's `if` — e.g. `&& [ "$LINE" -gt <N/2> ]` — where `$LINE` is already known to be pure digits. Do NOT put it before the `case`: there `$LINE` is unvalidated, so a `[ "$LINE" -gt … ]` on non-numeric input errors, and a standalone reject reintroduces the non-aggregating pattern the block exists to avoid. The line-number requirement already means an agent whose tools return nothing cannot pass; the far-half clause just stops it from replaying a number it kept from the first attempt.
@@ -603,21 +771,16 @@ Evaluate whether PR <NUMBER> in nrwl/nx takes the right approach to the problem 
 Inputs:
 - PR_NUMBER: <NUMBER>
 - CONTAINER: nx-review-pr-<NUMBER>  (PR checked out at /work/nx inside this sandbox container; base ref at /work/base)
-- DIFF: /tmp/pr-<NUMBER>.diff  (host file — the diff, readable with Read)
-- CHARTER: /tmp/pr-<NUMBER>.review-charter.md  (host file — severity policy, calibrations, sandbox protocol)
+- REVIEW TARGET: <EVIDENCE_FILE>  (host file — read it with Read; this is what you review)
+- FULL DIFF (reference only, and only when REVIEW TARGET is the incremental diff): /tmp/pr-<NUMBER>.diff
+- CHARTER: /tmp/pr-<NUMBER>.review-charter.md  (host file — sandbox protocol, pre-installed analysis toolchain, established measurements, severity policy, calibrations)
 - BASE_REF: <BASE_REF_NAME>  (checked out at /work/base in the same container — read base state there)
 
 Read /tmp/pr-<NUMBER>.review-charter.md (a host file) first — it carries the mandatory sandbox reading protocol. The PR source is NOT on the host; reach it only via `docker exec nx-review-pr-<NUMBER> cat/grep/find/sed /work/nx/…`.
 
 You are READ-ONLY. Use only `cat`/`grep`/`find`/`sed`/`git show` inside the container. Never run installs, builds, tests, or the reproduction — not in the container, and not on the host. Only the reproduce-verifier executes anything.
 
-REQUIRED — open your report with exactly these three lines:
-
-  REVIEWED: <how many changed files you actually opened>
-  EVIDENCE_LINE: <the line number in /tmp/pr-<NUMBER>.diff of the line you quote below>
-  EVIDENCE_TEXT: <that exact line, verbatim — MUST begin with `+` or `-`, 20+ chars after the sign, and MUST NOT be a `diff --git`, `index`, `---`, `+++`, or `@@` line>
-
-The caller reads the diff at EVIDENCE_LINE and checks it equals EVIDENCE_TEXT; the line NUMBER is the proof, since it appears in no prompt. This applies to an endorsement verdict exactly as to a finding: a `*_SOUND` report that does not verify is recorded as failed, not folded into Strengths.
+REQUIRED — open your report with the three proof-of-work lines exactly as the charter's "Proof of work" section specifies, with <EVIDENCE_FILE> as the file the line number refers to. This applies to an endorsement verdict exactly as to a finding: a `*_SOUND` report that does not verify is recorded as failed, not folded into Strengths.
 
 Follow your standard workflow and return the structured report.
 """
@@ -644,21 +807,16 @@ Analyze the runtime performance of PR <NUMBER> in nrwl/nx: CPU/memory footprint 
 Inputs:
 - PR_NUMBER: <NUMBER>
 - CONTAINER: nx-review-pr-<NUMBER>  (PR checked out at /work/nx inside this sandbox container; base ref at /work/base)
-- DIFF: /tmp/pr-<NUMBER>.diff  (host file — the diff, readable with Read)
-- CHARTER: /tmp/pr-<NUMBER>.review-charter.md  (host file — severity policy, calibrations, sandbox protocol)
+- REVIEW TARGET: <EVIDENCE_FILE>  (host file — read it with Read; this is what you review)
+- FULL DIFF (reference only, and only when REVIEW TARGET is the incremental diff): /tmp/pr-<NUMBER>.diff
+- CHARTER: /tmp/pr-<NUMBER>.review-charter.md  (host file — sandbox protocol, pre-installed analysis toolchain, established measurements, severity policy, calibrations)
 - BASE_REF: <BASE_REF_NAME>  (checked out at /work/base in the same container — read base state there)
 
 Read /tmp/pr-<NUMBER>.review-charter.md (a host file) first — it carries the mandatory sandbox reading protocol. The PR source is NOT on the host; reach it only via `docker exec nx-review-pr-<NUMBER> cat/grep/find/sed /work/nx/…`.
 
 You are READ-ONLY. Use only `cat`/`grep`/`find`/`sed`/`git show` inside the container. Never run installs, builds, tests, or the reproduction — not in the container, and not on the host. Only the reproduce-verifier executes anything.
 
-REQUIRED — open your report with exactly these three lines:
-
-  REVIEWED: <how many changed files you actually opened>
-  EVIDENCE_LINE: <the line number in /tmp/pr-<NUMBER>.diff of the line you quote below>
-  EVIDENCE_TEXT: <that exact line, verbatim — MUST begin with `+` or `-`, 20+ chars after the sign, and MUST NOT be a `diff --git`, `index`, `---`, `+++`, or `@@` line>
-
-The caller reads the diff at EVIDENCE_LINE and checks it equals EVIDENCE_TEXT; the line NUMBER is the proof, since it appears in no prompt. This applies to an endorsement verdict exactly as to a finding: a `*_SOUND` report that does not verify is recorded as failed, not folded into Strengths.
+REQUIRED — open your report with the three proof-of-work lines exactly as the charter's "Proof of work" section specifies, with <EVIDENCE_FILE> as the file the line number refers to. This applies to an endorsement verdict exactly as to a finding: a `*_SOUND` report that does not verify is recorded as failed, not folded into Strengths.
 
 Follow your standard workflow and return the structured report.
 """
@@ -685,21 +843,16 @@ Analyze PR <NUMBER> in nrwl/nx for injection-class vulnerabilities and data expo
 Inputs:
 - PR_NUMBER: <NUMBER>
 - CONTAINER: nx-review-pr-<NUMBER>  (PR checked out at /work/nx inside this sandbox container; base ref at /work/base)
-- DIFF: /tmp/pr-<NUMBER>.diff  (host file — the diff, readable with Read)
-- CHARTER: /tmp/pr-<NUMBER>.review-charter.md  (host file — severity policy, calibrations, sandbox protocol)
+- REVIEW TARGET: <EVIDENCE_FILE>  (host file — read it with Read; this is what you review)
+- FULL DIFF (reference only, and only when REVIEW TARGET is the incremental diff): /tmp/pr-<NUMBER>.diff
+- CHARTER: /tmp/pr-<NUMBER>.review-charter.md  (host file — sandbox protocol, pre-installed analysis toolchain, established measurements, severity policy, calibrations)
 - BASE_REF: <BASE_REF_NAME>  (checked out at /work/base in the same container — read base state there)
 
 Read /tmp/pr-<NUMBER>.review-charter.md (a host file) first — it carries the mandatory sandbox reading protocol. The PR source is NOT on the host; reach it only via `docker exec nx-review-pr-<NUMBER> cat/grep/find/sed /work/nx/…`.
 
 You are READ-ONLY. Use only `cat`/`grep`/`find`/`sed`/`git show` inside the container. Never run installs, builds, tests, or the reproduction — not in the container, and not on the host. Only the reproduce-verifier executes anything.
 
-REQUIRED — open your report with exactly these three lines:
-
-  REVIEWED: <how many changed files you actually opened>
-  EVIDENCE_LINE: <the line number in /tmp/pr-<NUMBER>.diff of the line you quote below>
-  EVIDENCE_TEXT: <that exact line, verbatim — MUST begin with `+` or `-`, 20+ chars after the sign, and MUST NOT be a `diff --git`, `index`, `---`, `+++`, or `@@` line>
-
-The caller reads the diff at EVIDENCE_LINE and checks it equals EVIDENCE_TEXT; the line NUMBER is the proof, since it appears in no prompt. This applies to an endorsement verdict exactly as to a finding: a `*_SOUND` report that does not verify is recorded as failed, not folded into Strengths.
+REQUIRED — open your report with the three proof-of-work lines exactly as the charter's "Proof of work" section specifies, with <EVIDENCE_FILE> as the file the line number refers to. This applies to an endorsement verdict exactly as to a finding: a `*_SOUND` report that does not verify is recorded as failed, not folded into Strengths.
 
 Follow your standard workflow and return the structured report.
 """
@@ -751,9 +904,12 @@ Inputs:
 - PR_NUMBER: <NUMBER>
 - CONTAINER: nx-review-pr-<NUMBER>  (one sandbox container; HEAD at /work/nx, base worktree at /work/base)
 - DIFF: /tmp/pr-<NUMBER>.diff  (host file — the complete PR diff; read it with Read)
+- CHARTER: /tmp/pr-<NUMBER>.review-charter.md  (host file — sandbox protocol, pre-installed analysis toolchain, established measurements)
 - HEAD_SHA: <HEAD_REF_OID>
 - BASE_REF: <BASE_REF_NAME>
 - RUN_LEVEL_2: <true|false — see gate above>
+
+**This agent alone keeps the FULL diff as both its review surface and its `<EVIDENCE_FILE>`, even on a re-review** — its job is mapping every claim in the PR body to code, and those claims span the whole PR, not the delta. Verify its EVIDENCE against `/tmp/pr-<NUMBER>.diff` accordingly; using the incremental diff here would fail an honest verifier.
 
 Use the DIFF file for all "does the diff address the bug?" reasoning. Do NOT reconstruct the diff
 yourself with `git diff` inside the container: both checkouts are `--depth 1`, so `BASE...HEAD`
@@ -804,6 +960,8 @@ REQUIRED — open your report with exactly these three lines:
   EVIDENCE_LINE: <the line number in /tmp/pr-<NUMBER>.diff of the line you quote below>
   EVIDENCE_TEXT: <that exact line, verbatim — MUST begin with `+` or `-`, 20+ chars after the sign,
                   and MUST NOT be a `diff --git`, `index`, `---`, `+++`, or `@@` line>
+
+Return them as plain text — no markdown headings, and do NOT wrap EVIDENCE_TEXT in backticks.
 
 The caller reads the diff at EVIDENCE_LINE and checks it equals EVIDENCE_TEXT; the line NUMBER is the
 proof. This applies to a NOT_ATTEMPTED reproduction exactly as to a confirmed one — "there was

--- a/.claude/skills/setup-review-sandbox/SKILL.md
+++ b/.claude/skills/setup-review-sandbox/SKILL.md
@@ -74,11 +74,15 @@ docker image inspect nx-review-sandbox:latest >/dev/null 2>&1 && echo "image OK"
 If MISSING (or stale — check the `created` date against the Dockerfile), build it. The Dockerfile only needs `mise.toml`, so build from a **minimal context** — do NOT pass `.` (the repo root), which would ship the whole monorepo (node_modules / .git / dist — many GB) to the daemon:
 
 ```bash
-mkdir -p tmp/review-sandbox-ctx && cp mise.toml tmp/review-sandbox-ctx/
+mkdir -p tmp/review-sandbox-ctx
+cp mise.toml package.json pnpm-lock.yaml pnpm-workspace.yaml tmp/review-sandbox-ctx/
+cp -r patches tmp/review-sandbox-ctx/
 docker build -t nx-review-sandbox:latest -f tools/review-sandbox/Dockerfile tmp/review-sandbox-ctx
 ```
 
-This installs the repo's exact toolchain — node/java/dotnet/maven/rust/bun via mise — and takes a while + several GB. Requires steps 1 + 3 to pass first (build needs working networking). If disk is tight, `/sandbox-prune` first.
+The context is still minimal — five entries, ~2 MB, almost all of it the lockfile — and deliberately excludes the repo itself. All five are load-bearing; the Dockerfile explains what each omission breaks.
+
+This installs the repo's exact toolchain — node/java/dotnet/maven/rust/bun via mise — and warms the pnpm store so reviews link packages instead of downloading them. Takes a while and several GB (the warm store is ~2.6 GB of that). Requires steps 1 + 3 to pass first (build needs working networking). If disk is tight, `/sandbox-prune` first.
 
 ## 5. Verify (smoke test)
 

--- a/tools/review-sandbox/Dockerfile
+++ b/tools/review-sandbox/Dockerfile
@@ -40,3 +40,25 @@ RUN mise trust /work/mise.toml \
     && mise install \
     && mise reshim \
     && mise ls
+
+# Warm the pnpm content-addressable store from master's lockfile, so a review's
+# `pnpm install` links out of the store instead of downloading ~4200 packages.
+#
+# The store is a CACHE, not a build output: the PR checkout still installs against its
+# OWN lockfile, so entries it doesn't need are merely unused and new deps are fetched
+# normally. node_modules is deliberately NOT baked — it must match the PR's lockfile
+# exactly, master's changes most days, and a stale one fails in the worst direction
+# (tests green against versions the PR never specified).
+#
+# All four files are needed; each omission fails differently:
+#   package.json         corepack reads `packageManager` to activate the pinned pnpm.
+#                        Without it corepack silently activates the LATEST pnpm.
+#   pnpm-lock.yaml       what `pnpm fetch` resolves.
+#   pnpm-workspace.yaml  declares patchedDependencies (and the catalog).
+#   patches/             without it the fetch aborts: ERR_PNPM_PATCH_FILE_PATH_MISSING.
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml /work/
+COPY patches /work/patches
+RUN corepack prepare --activate \
+    && pnpm fetch --lockfile-dir /work \
+    && rm -rf /work/node_modules \
+    && pnpm store path


### PR DESCRIPTION
## Current Behavior

Every agent the `review-pr` skill dispatches establishes shared facts for itself. In a real run (review of #36407, attempt 3), that meant:

- **seven** agents each independently rebuilt the same module-load graph — each installing TypeScript into the container, compiling, and writing its own `require()` walker;
- **six** agents each independently installed ESLint to run the same import-boundary matrix;
- four separately re-derived that a given helper still logs a failure.

Every one reached the identical conclusion. That duplication was roughly a third of the run's token cost and produced no finding a single measurement would not have produced.

Two smaller leaks compound it: the changed-file list is pasted verbatim into all nine prompts (33 paths x 9 on that PR), and on a re-review agents are handed the full PR diff as the primary surface even though the round's job is the delta (5,843 lines vs 685).

## Expected Behavior

**Measure once, then hand agents the result as a claim to attack.** New Step 4.7 fires only when the diff makes a mechanical, globally-relevant assertion — module laziness, a changed lint/CI config, a removed log, claimed parity between two paths. The orchestrator measures it against a snapshot, records the method alongside the result, and the charter frames it as *"measured, not asserted — do not re-derive, but do challenge it if the code contradicts it; a contradiction is a finding."* The independence that actually matters is untouched: the analyzers still arrive uninformed about the author's reasoning, because a mechanical measurement is not a rationale, and the Polygraph session stays sealed until Step 5c.

**Pre-install the analysis toolchain once** (`tsc`, `eslint`, `typescript-eslint`) at container creation, into `/tmp/tools` so it can never be mistaken for a PR dependency. Records the mise gotcha that makes a bare `npm` fail there while `node` resolves.

**Scope re-reviews to the incremental diff.** It becomes both the review target and the proof-of-work surface, with the full diff explicitly reference-only. The `reproduce-verifier` keeps the full diff, since its claim-to-code mapping spans the whole PR.

**Stop pasting the file list** into nine prompts (agents can `Read` it), and move the proof-of-work spec into the charter instead of repeating it verbatim five times.

**Tolerate a markdown code-span wrapper around `EVIDENCE_TEXT`.** Three agents across two consecutive rounds returned one despite the prompt saying not to. The line *number* is the proof of work and the unwrapped text must still match byte-for-byte, so this concedes nothing — while failing an honest agent over a formatting habit flips the whole review to `failed` and buys a needless re-review.

Also fixes a latent markdown bug: the charter template is itself inside a ```` ```markdown ```` fence, so nested ``` fences would terminate it early. The new template blocks use indentation instead.

`PIPELINE_VERSION` goes to 4 so drafts produced under the old criteria age out rather than being pinned by the SHA dedup.

Drafts-only behaviour, the sandbox trust model, and the evidence-verification gate are all unchanged.

## Related Issue(s)

N/A — follow-up to #36525, from measured token usage on a real run.

<!-- polygraph-session-start -->
---
<p><picture><source media="(prefers-color-scheme: dark)" srcset="https://static.ops.cloud.nx.app/polygraph/session-logo-v4-dark.svg"><img src="https://static.ops.cloud.nx.app/polygraph/session-logo-v4-light.svg" width="16" height="22" align="middle" alt="Polygraph"></picture> <a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Cut-duplicated-verification-work-in-the-review-pr-skill-d3373d3f">View session ↗</a></p>
<!-- polygraph-session-end -->