### PR TITLE
feat(release): support tag-based project selection

### DIFF
--- a/e2e/release/src/tag-project-selection.test.ts
+++ b/e2e/release/src/tag-project-selection.test.ts
@@ -1,0 +1,55 @@
+import {
+  cleanupProject,
+  newProject,
+  runCLI,
+  uniq,
+  updateJson,
+} from '@nx/e2e-utils';
+
+describe('nx release - tag project selection', () => {
+  let apiPackage1: string;
+  let apiPackage2: string;
+  let otherPackage: string;
+
+  beforeAll(() => {
+    newProject({ packages: ['@nx/js'] });
+
+    apiPackage1 = uniq('api-package-1');
+    apiPackage2 = uniq('api-package-2');
+    otherPackage = uniq('other-package');
+
+    for (const project of [apiPackage1, apiPackage2, otherPackage]) {
+      runCLI(`generate @nx/workspace:npm-package ${project}`);
+      updateJson(`${project}/project.json`, (projectJson) => ({
+        ...projectJson,
+        tags: [project === otherPackage ? 'type:other' : 'type:api'],
+      }));
+    }
+
+    updateJson('nx.json', () => ({
+      release: {
+        projectsRelationship: 'independent',
+      },
+    }));
+  });
+
+  afterAll(() => cleanupProject());
+
+  it('versions every project matching the tag selector and excludes other projects', () => {
+    const output = runCLI(
+      'release 1.2.3 --projects=tag:type:api --dry-run --skip-publish'
+    );
+
+    expect(output).toContain(`- ${apiPackage1}`);
+    expect(output).toContain(`- ${apiPackage2}`);
+    expect(output).toContain(
+      `NX   Running release version for project: ${apiPackage1}`
+    );
+    expect(output).toContain(
+      `NX   Running release version for project: ${apiPackage2}`
+    );
+    expect(output).not.toContain(
+      `NX   Running release version for project: ${otherPackage}`
+    );
+  });
+});

--- a/packages/nx/src/command-line/release/utils/release-graph.spec.ts
+++ b/packages/nx/src/command-line/release/utils/release-graph.spec.ts
@@ -220,6 +220,138 @@ describe('ReleaseGraph', () => {
   });
 
   describe('filtering - independent release groups with updateDependents', () => {
+    it('should expand project tag patterns before filtering release projects', async () => {
+      const { nxReleaseConfig, projectGraph, filters } =
+        await createNxReleaseConfigAndPopulateWorkspace(
+          tree,
+          `
+          __default__ ({ "projectsRelationship": "independent" }):
+            - projectA@1.0.0 [js]
+            - projectB@1.0.0 [js]
+            - projectC@1.0.0 [js]
+        `,
+          {
+            version: {
+              conventionalCommits: true,
+            },
+          },
+          mockResolveCurrentVersion,
+          {
+            projects: ['tag:type:api'],
+          }
+        );
+
+      projectGraph.nodes.projectA.data.tags = ['type:api'];
+      projectGraph.nodes.projectB.data.tags = ['type:api'];
+      projectGraph.nodes.projectC.data.tags = ['type:other'];
+
+      const graph = await createReleaseGraph({
+        tree,
+        projectGraph,
+        nxReleaseConfig,
+        filters,
+        firstRelease: false,
+        preid: undefined,
+        verbose: false,
+      });
+
+      expect(graph.allProjectsToProcess).toEqual(
+        new Set(['projectA', 'projectB'])
+      );
+      expect(
+        graph.releaseGroupToFilteredProjects.get(graph.releaseGroups[0])
+      ).toEqual(new Set(['projectA', 'projectB']));
+      expect(graph.filterLog).toEqual({
+        title: 'Your filter "tag:type:api" matched the following projects:',
+        bodyLines: ['- projectA', '- projectB'],
+      });
+    });
+
+    it('should expand exclusion patterns without mutating the filter', async () => {
+      const { nxReleaseConfig, projectGraph, filters } =
+        await createNxReleaseConfigAndPopulateWorkspace(
+          tree,
+          `
+          __default__ ({ "projectsRelationship": "independent" }):
+            - projectA@1.0.0 [js]
+            - projectB@1.0.0 [js]
+            - projectC@1.0.0 [js]
+        `,
+          {
+            version: {
+              conventionalCommits: true,
+            },
+          },
+          mockResolveCurrentVersion,
+          {
+            projects: ['!tag:type:other'],
+          }
+        );
+
+      projectGraph.nodes.projectA.data.tags = ['type:api'];
+      projectGraph.nodes.projectB.data.tags = ['type:api'];
+      projectGraph.nodes.projectC.data.tags = ['type:other'];
+
+      const graph = await createReleaseGraph({
+        tree,
+        projectGraph,
+        nxReleaseConfig,
+        filters,
+        firstRelease: false,
+        preid: undefined,
+        verbose: false,
+      });
+
+      expect(graph.allProjectsToProcess).toEqual(
+        new Set(['projectA', 'projectB'])
+      );
+      expect(
+        graph.releaseGroupToFilteredProjects.get(graph.releaseGroups[0])
+      ).toEqual(new Set(['projectA', 'projectB']));
+      expect(graph.filterLog?.title).toBe(
+        'Your filter "!tag:type:other" matched the following projects:'
+      );
+      expect(filters.projects).toEqual(['!tag:type:other']);
+    });
+
+    it('should provide a friendly error when no projects match', async () => {
+      const { nxReleaseConfig, projectGraph, filters } =
+        await createNxReleaseConfigAndPopulateWorkspace(
+          tree,
+          `
+          __default__ ({ "projectsRelationship": "independent" }):
+            - projectA@1.0.0 [js]
+            - projectB@1.0.0 [js]
+        `,
+          {
+            version: {
+              conventionalCommits: true,
+            },
+          },
+          mockResolveCurrentVersion,
+          {
+            projects: ['tag:type:apo'],
+          }
+        );
+
+      projectGraph.nodes.projectA.data.tags = ['type:api'];
+      projectGraph.nodes.projectB.data.tags = ['type:api'];
+
+      await expect(
+        createReleaseGraph({
+          tree,
+          projectGraph,
+          nxReleaseConfig,
+          filters,
+          firstRelease: false,
+          preid: undefined,
+          verbose: false,
+        })
+      ).rejects.toThrow(
+        'Your --projects filter "tag:type:apo" did not match any projects in the workspace'
+      );
+    });
+
     describe('scenario: projectA depends on projectB, filter by [projectB]', () => {
       it('should include ONLY projectB when updateDependents=never (projectA should NOT be included)', async () => {
         const { nxReleaseConfig, projectGraph, filters } =

--- a/packages/nx/src/command-line/release/utils/release-graph.ts
+++ b/packages/nx/src/command-line/release/utils/release-graph.ts
@@ -10,6 +10,7 @@ import type { Tree } from '../../../generators/tree';
 import { filterAffected } from '../../../project-graph/affected/affected-project-graph';
 import { calculateFileChanges } from '../../../project-graph/file-utils';
 import { NxArgs } from '../../../utils/command-line-utils';
+import { findMatchingProjects } from '../../../utils/find-matching-projects';
 import {
   IMPLICIT_DEFAULT_RELEASE_GROUP,
   type NxReleaseConfig,
@@ -134,6 +135,7 @@ export class ReleaseGraph {
     Set<string>
   >();
   private originalFilteredProjects = new Set<string>();
+  private matchedProjectsForFilter = new Set<string>();
 
   /**
    * Store the affected graph per commit per project
@@ -163,6 +165,20 @@ export class ReleaseGraph {
    * @internal - Called by createReleaseGraph(), not meant for external use
    */
   async init(options: CreateReleaseGraphOptions): Promise<void> {
+    if (this.filters.projects?.length) {
+      this.matchedProjectsForFilter = new Set(
+        findMatchingProjects(
+          [...this.filters.projects],
+          options.projectGraph.nodes
+        )
+      );
+      if (this.matchedProjectsForFilter.size === 0) {
+        throw new Error(
+          `Your --projects filter "${this.filters.projects}" did not match any projects in the workspace`
+        );
+      }
+    }
+
     // Step 1: Setup project to release group mapping
     this.setupProjectReleaseGroupMapping();
 
@@ -259,7 +275,7 @@ export class ReleaseGraph {
       for (const project of releaseGroup.projects) {
         if (
           this.filters.projects?.length &&
-          !this.filters.projects.includes(project)
+          !this.matchedProjectsForFilter.has(project)
         ) {
           continue;
         }
@@ -318,7 +334,7 @@ export class ReleaseGraph {
 
         if (filters.groups?.includes(groupName)) {
           projectsToProcess.add(project);
-        } else if (filters.projects?.includes(project)) {
+        } else if (this.matchedProjectsForFilter.has(project)) {
           projectsToProcess.add(project);
         }
 


### PR DESCRIPTION
## Current Behavior

Nx Release treats values passed to `--projects` as exact project names. Standard Nx selectors such as tags, globs, directory patterns, exclusions, and fuzzy plain-name matches therefore do not work, even when they identify projects configured for release. A selector that matches nothing also falls through to a misleading internal bug error.

## Expected Behavior

Nx Release expands `--projects` values through Nx's standard project-matching logic, consistent with commands such as `nx run-many`. Tag, glob, directory, exclusion, and fuzzy plain-name selectors can select the intended release projects while the original selector remains visible in filter output. Selectors that match no workspace projects receive the existing friendly zero-match error.

The change includes focused release graph unit coverage for tag and exclusion selectors, filter-map population, input immutability, and the zero-match error, plus an end-to-end tag-selector test of:

```shell
nx release 1.2.3 --projects=tag:type:api --dry-run --skip-publish
```

## Related Issue(s)

Fixes #33975