### PR TITLE
fix(release): support custom conventional commit types

### DIFF
--- a/packages/nx/src/command-line/release/utils/git.spec.ts
+++ b/packages/nx/src/command-line/release/utils/git.spec.ts
@@ -1,6 +1,7 @@
 import {
   extractReferencesFromCommit,
   getLatestGitTagForPattern,
+  parseConventionalCommitsMessage,
   sanitizeProjectNameForGitTag,
 } from './git';
 import { RepoGitTags } from './repository-git-tags';
@@ -43,6 +44,53 @@ gradle/common/lib@1.5.0
 }));
 
 describe('git utils', () => {
+  describe('parseConventionalCommitsMessage', () => {
+    it.each([
+      [
+        '✨ (package-a): Add new feature',
+        {
+          type: '✨',
+          scope: 'package-a',
+          description: 'Add new feature',
+          breaking: false,
+        },
+      ],
+      [
+        '2026_A: Task: #1234 - message',
+        {
+          type: '2026_A',
+          scope: '',
+          description: 'Task: #1234 - message',
+          breaking: false,
+        },
+      ],
+    ])('should parse the configured custom type in "%s"', (message, result) => {
+      expect(parseConventionalCommitsMessage(message)).toEqual(result);
+    });
+
+    it('should preserve standard scoped and breaking commit syntax', () => {
+      expect(
+        parseConventionalCommitsMessage('feat(core)!: Add new feature')
+      ).toEqual({
+        type: 'feat',
+        scope: 'core',
+        description: 'Add new feature',
+        breaking: true,
+      });
+    });
+
+    it('should classify a non-conventional message as invalid', () => {
+      expect(
+        parseConventionalCommitsMessage('This is not a conventional commit')
+      ).toEqual({
+        type: '__INVALID__',
+        scope: '',
+        description: 'This is not a conventional commit',
+        breaking: false,
+      });
+    });
+  });
+
   describe('extractReferencesFromCommit', () => {
     it('should include the given short commit hash even if no other references are found', () => {
       const references = extractReferencesFromCommit({

--- a/packages/nx/src/command-line/release/utils/git.ts
+++ b/packages/nx/src/command-line/release/utils/git.ts
@@ -636,7 +636,7 @@ function getAllAuthorsForCommit(commit: RawGitCommit): GitCommitAuthor[] {
 // https://www.conventionalcommits.org/en/v1.0.0/
 // https://regex101.com/r/FSfNvA/1
 const ConventionalCommitRegex =
-  /(?<type>[a-z]+)(\((?<scope>.+)\))?(?<breaking>!)?: (?<description>.+)/i;
+  /^(?<type>[^\s():!]+)(?:\s*\((?<scope>.+)\))?(?<breaking>!)?: (?<description>.+)$/u;
 const CoAuthoredByRegex = /co-authored-by:\s*(?<name>.+)(<(?<email>.+)>)/gim;
 // GitHub style PR references
 const PullRequestRE = /\([ a-z]*(#\d+)\s*\)/gm;


### PR DESCRIPTION
## Current Behavior

Nx Release only recognizes conventional commit types containing ASCII letters. Configured types such as `✨` are rejected, while identifiers such as `2026_A` can be misparsed as a suffix.

## Expected Behavior

Configured custom commit types are parsed as complete tokens, including gitmoji and identifiers containing digits or underscores. Standard scoped and breaking-change syntax continues to work, and the reported optional whitespace before a scope is supported.

Focused parser unit coverage passes for both reported formats, standard syntax, and invalid messages.

## Related Issue(s)

Fixes #32512
