### PR TITLE
fix(release): preserve package.json formatting

### DIFF
--- a/e2e/release/src/circular-dependencies.test.ts
+++ b/e2e/release/src/circular-dependencies.test.ts
@@ -147,7 +147,6 @@ xdescribe('nx release circular dependencies', () => {
         +     "@proj/{project-name}": "2.0.0"
         }
         }
-        +
 
 
         "name": "@proj/{project-name}",
@@ -160,7 +159,6 @@ xdescribe('nx release circular dependencies', () => {
         +     "@proj/{project-name}": "2.0.0"
         }
         }
-        +
 
 
         Skipped lock file update because {PACKAGE_MANAGER_WORKSPACES} are not enabled.
@@ -329,7 +327,6 @@ xdescribe('nx release circular dependencies', () => {
         +     "@proj/{project-name}": "2.0.0"
         }
         }
-        +
 
 
         "name": "@proj/{project-name}",
@@ -342,7 +339,6 @@ xdescribe('nx release circular dependencies', () => {
         +     "@proj/{project-name}": "2.0.0"
         }
         }
-        +
 
 
         Skipped lock file update because {PACKAGE_MANAGER_WORKSPACES} are not enabled.
@@ -512,7 +508,6 @@ xdescribe('nx release circular dependencies', () => {
         +     "@proj/{project-name}": "2.0.0"
         }
         }
-        +
 
 
         "name": "@proj/{project-name}",
@@ -525,7 +520,6 @@ xdescribe('nx release circular dependencies', () => {
         +     "@proj/{project-name}": "2.0.0"
         }
         }
-        +
 
 
         Skipped lock file update because {PACKAGE_MANAGER_WORKSPACES} are not enabled.
@@ -685,7 +679,6 @@ xdescribe('nx release circular dependencies', () => {
         "exports": {
 
         }
-        +
 
 
         Skipped lock file update because {PACKAGE_MANAGER_WORKSPACES} are not enabled.
@@ -815,7 +808,6 @@ xdescribe('nx release circular dependencies', () => {
         +     "@proj/{project-name}": "2.0.0"
         }
         }
-        +
 
 
         "name": "@proj/{project-name}",
@@ -828,7 +820,6 @@ xdescribe('nx release circular dependencies', () => {
         +     "@proj/{project-name}": "2.0.0"
         }
         }
-        +
 
 
         Skipped lock file update because {PACKAGE_MANAGER_WORKSPACES} are not enabled.
@@ -1000,7 +991,6 @@ xdescribe('nx release circular dependencies', () => {
         +     "@proj/{project-name}": "1.0.1"
         }
         }
-        +
 
 
         "name": "@proj/{project-name}",
@@ -1013,7 +1003,6 @@ xdescribe('nx release circular dependencies', () => {
         +     "@proj/{project-name}": "2.0.0"
         }
         }
-        +
 
 
         Skipped lock file update because {PACKAGE_MANAGER_WORKSPACES} are not enabled.

--- a/e2e/release/src/circular-dependencies.test.ts
+++ b/e2e/release/src/circular-dependencies.test.ts
@@ -147,6 +147,7 @@ xdescribe('nx release circular dependencies', () => {
         +     "@proj/{project-name}": "2.0.0"
         }
         }
+        +
 
 
         "name": "@proj/{project-name}",
@@ -159,6 +160,7 @@ xdescribe('nx release circular dependencies', () => {
         +     "@proj/{project-name}": "2.0.0"
         }
         }
+        +
 
 
         Skipped lock file update because {PACKAGE_MANAGER_WORKSPACES} are not enabled.
@@ -327,6 +329,7 @@ xdescribe('nx release circular dependencies', () => {
         +     "@proj/{project-name}": "2.0.0"
         }
         }
+        +
 
 
         "name": "@proj/{project-name}",
@@ -339,6 +342,7 @@ xdescribe('nx release circular dependencies', () => {
         +     "@proj/{project-name}": "2.0.0"
         }
         }
+        +
 
 
         Skipped lock file update because {PACKAGE_MANAGER_WORKSPACES} are not enabled.
@@ -508,6 +512,7 @@ xdescribe('nx release circular dependencies', () => {
         +     "@proj/{project-name}": "2.0.0"
         }
         }
+        +
 
 
         "name": "@proj/{project-name}",
@@ -520,6 +525,7 @@ xdescribe('nx release circular dependencies', () => {
         +     "@proj/{project-name}": "2.0.0"
         }
         }
+        +
 
 
         Skipped lock file update because {PACKAGE_MANAGER_WORKSPACES} are not enabled.
@@ -679,6 +685,7 @@ xdescribe('nx release circular dependencies', () => {
         "exports": {
 
         }
+        +
 
 
         Skipped lock file update because {PACKAGE_MANAGER_WORKSPACES} are not enabled.
@@ -808,6 +815,7 @@ xdescribe('nx release circular dependencies', () => {
         +     "@proj/{project-name}": "2.0.0"
         }
         }
+        +
 
 
         "name": "@proj/{project-name}",
@@ -820,6 +828,7 @@ xdescribe('nx release circular dependencies', () => {
         +     "@proj/{project-name}": "2.0.0"
         }
         }
+        +
 
 
         Skipped lock file update because {PACKAGE_MANAGER_WORKSPACES} are not enabled.
@@ -991,6 +1000,7 @@ xdescribe('nx release circular dependencies', () => {
         +     "@proj/{project-name}": "1.0.1"
         }
         }
+        +
 
 
         "name": "@proj/{project-name}",
@@ -1003,6 +1013,7 @@ xdescribe('nx release circular dependencies', () => {
         +     "@proj/{project-name}": "2.0.0"
         }
         }
+        +
 
 
         Skipped lock file update because {PACKAGE_MANAGER_WORKSPACES} are not enabled.

--- a/e2e/release/src/independent-projects.test.ts
+++ b/e2e/release/src/independent-projects.test.ts
@@ -170,9 +170,6 @@ describe('nx release - independent projects', () => {
         +   "version": "999.9.9-package.2",
         "exports": {
 
-        }
-        +
-
 
         NX   Staging changed files with git
 

--- a/e2e/release/src/independent-projects.workspaces.test.ts
+++ b/e2e/release/src/independent-projects.workspaces.test.ts
@@ -182,9 +182,6 @@ describe('nx release - independent projects - workspaces', () => {
           +   "version": "999.9.9-package.2",
           "exports": {
 
-          }
-          +
-
 
           NX   Updating {package-manager} lock file
 

--- a/e2e/release/src/multiple-release-branches.test.ts
+++ b/e2e/release/src/multiple-release-branches.test.ts
@@ -192,9 +192,6 @@ describe('nx release multiple release branches', () => {
       +   "version": "0.1.0",
       "exports": {
 
-      }
-      +
-
 
       "name": "@proj/{project-name}",
       -   "version": "0.0.7",
@@ -332,9 +329,6 @@ describe('nx release multiple release branches', () => {
       +   "version": "0.1.0",
       "exports": {
 
-      }
-      +
-
 
       "name": "@proj/{project-name}",
       -   "version": "0.0.0",
@@ -386,9 +380,6 @@ describe('nx release multiple release branches', () => {
       -   "version": "0.0.0",
       +   "version": "1.0.0",
       "exports": {
-
-      }
-      +
 
 
       "name": "@proj/{project-name}",

--- a/e2e/release/src/preserve-local-dependency-protocols.test.ts
+++ b/e2e/release/src/preserve-local-dependency-protocols.test.ts
@@ -163,8 +163,6 @@ describe('nx release preserve local dependency protocols', () => {
       -     "@proj/{project-name}": "workspace:*"
       +     "@proj/{project-name}": "0.1.0"
       }
-      }
-      +
       NX   Updating PM lock file
       Would update pnpm-lock.yaml with the following command, but --dry-run was set:
       pnpm install --lockfile-only
@@ -206,8 +204,6 @@ describe('nx release preserve local dependency protocols', () => {
       -   "version": "0.0.0",
       +   "version": "0.1.0",
       "exports": {
-      }
-      +
       NX   Updating PM lock file
       Would update pnpm-lock.yaml with the following command, but --dry-run was set:
       pnpm install --lockfile-only

--- a/e2e/release/src/preserve-matching-dependency-ranges.test.ts
+++ b/e2e/release/src/preserve-matching-dependency-ranges.test.ts
@@ -159,8 +159,6 @@ describe('nx release preserve matching dependency ranges', () => {
         -     "@proj/{project-name}": "^1.0.0"
         +     "@proj/{project-name}": "^1.1.0"
         }
-        }
-        +
         "name": "@proj/{project-name}",
         -   "version": "1.0.0",
         +   "version": "1.1.0",
@@ -169,8 +167,6 @@ describe('nx release preserve matching dependency ranges', () => {
         -     "@proj/{project-name}": ">=1.0.0 <2.0.0"
         +     "@proj/{project-name}": "1.1.0"
         }
-        }
-        +
         "name": "@proj/{project-name}",
         -   "version": "1.0.0",
         +   "version": "1.1.0",
@@ -185,8 +181,6 @@ describe('nx release preserve matching dependency ranges', () => {
         -     "@proj/{project-name}": "^1.0.0"
         +     "@proj/{project-name}": "^1.1.0"
         }
-        }
-        +
         NX   Staging changed files with git
       `);
     });
@@ -233,20 +227,14 @@ describe('nx release preserve matching dependency ranges', () => {
         -   "version": "1.0.0",
         +   "version": "1.1.0",
         "exports": {
-        }
-        +
         "name": "@proj/{project-name}",
         -   "version": "1.0.0",
         +   "version": "1.1.0",
         "exports": {
-        }
-        +
         "name": "@proj/{project-name}",
         -   "version": "1.0.0",
         +   "version": "1.1.0",
         "exports": {
-        }
-        +
         NX   Staging changed files with git
       `);
     });
@@ -298,8 +286,6 @@ describe('nx release preserve matching dependency ranges', () => {
         -     "@proj/{project-name}": "^1.0.0"
         +     "@proj/{project-name}": "^1.0.1"
         }
-        }
-        +
         "name": "@proj/{project-name}",
         -   "version": "1.0.0",
         +   "version": "1.0.1",
@@ -308,14 +294,10 @@ describe('nx release preserve matching dependency ranges', () => {
         -     "@proj/{project-name}": ">=1.0.0 <2.0.0"
         +     "@proj/{project-name}": "1.0.1"
         }
-        }
-        +
         "name": "@proj/{project-name}",
         -   "version": "1.0.0",
         +   "version": "1.0.1",
         "exports": {
-        }
-        +
         NX   Staging changed files with git
       `);
     });
@@ -361,8 +343,6 @@ describe('nx release preserve matching dependency ranges', () => {
         -     "@proj/{project-name}": "^1.0.0"
         +     "@proj/{project-name}": "^1.1.0"
         }
-        }
-        +
         "name": "@proj/{project-name}",
         -   "version": "1.0.0",
         +   "version": "1.1.0",
@@ -371,8 +351,6 @@ describe('nx release preserve matching dependency ranges', () => {
         -     "@proj/{project-name}": ">=1.0.0 <2.0.0"
         +     "@proj/{project-name}": "1.1.0"
         }
-        }
-        +
         "name": "@proj/{project-name}",
         -   "version": "1.0.0",
         +   "version": "1.1.0",
@@ -387,8 +365,6 @@ describe('nx release preserve matching dependency ranges', () => {
         -     "@proj/{project-name}": "^1.0.0"
         +     "@proj/{project-name}": "^1.1.0"
         }
-        }
-        +
         NX   Staging changed files with git
       `);
     });
@@ -432,20 +408,14 @@ describe('nx release preserve matching dependency ranges', () => {
         -   "version": "1.0.0",
         +   "version": "1.0.1",
         "exports": {
-        }
-        +
         "name": "@proj/{project-name}",
         -   "version": "1.0.0",
         +   "version": "1.0.1",
         "exports": {
-        }
-        +
         "name": "@proj/{project-name}",
         -   "version": "1.0.0",
         +   "version": "1.0.1",
         "exports": {
-        }
-        +
         NX   Staging changed files with git
       `);
     });
@@ -497,14 +467,10 @@ describe('nx release preserve matching dependency ranges', () => {
         -   "version": "1.0.0",
         +   "version": "1.0.1",
         "exports": {
-        }
-        +
         "name": "@proj/{project-name}",
         -   "version": "1.0.0",
         +   "version": "1.0.1",
         "exports": {
-        }
-        +
         "name": "@proj/{project-name}",
         -   "version": "1.0.0",
         +   "version": "1.0.1",
@@ -513,8 +479,6 @@ describe('nx release preserve matching dependency ranges', () => {
         -     "@proj/{project-name}": "1.0.0"
         +     "@proj/{project-name}": "1.0.1"
         },
-        }
-        +
         NX   Staging changed files with git
       `);
     });
@@ -579,20 +543,14 @@ describe('nx release preserve matching dependency ranges', () => {
         -   "version": "1.0.0",
         +   "version": "2.0.0",
         "exports": {
-        }
-        +
         "name": "@proj/{project-name}",
         -   "version": "1.0.0",
         +   "version": "2.0.0",
         "exports": {
-        }
-        +
         "name": "@proj/{project-name}",
         -   "version": "1.0.0",
         +   "version": "2.0.0",
         "exports": {
-        }
-        +
         NX   Staging changed files with git
       `);
     });

--- a/e2e/release/src/release-publishable-libraries.test.ts
+++ b/e2e/release/src/release-publishable-libraries.test.ts
@@ -110,8 +110,6 @@ describe('release publishable libraries', () => {
       -   "version": "0.0.1",
       +   "version": "0.0.2",
       "type": "commonjs",
-      }
-      +
       NX   Staging changed files with git
       No files to stage. Skipping git add.
       NX   Generating an entry in CHANGELOG.md for v0.0.2
@@ -171,8 +169,6 @@ describe('release publishable libraries', () => {
       -   "version": "0.0.1",
       +   "version": "0.0.3",
       "module": "./index.esm.js",
-      }
-      +
       NX   Staging changed files with git
       No files to stage. Skipping git add.
       NX   Generating an entry in CHANGELOG.md for v0.0.3
@@ -234,8 +230,6 @@ describe('release publishable libraries', () => {
       -   "version": "0.0.1",
       +   "version": "0.0.4",
       "peerDependencies": {
-      }
-      +
       NX   Staging changed files with git
       No files to stage. Skipping git add.
       NX   Generating an entry in CHANGELOG.md for v0.0.4
@@ -354,8 +348,6 @@ describe('release publishable libraries', () => {
       -   "version": "0.0.1",
       +   "version": "0.0.6",
       "peerDependencies": {
-      }
-      +
       NX   Staging changed files with git
       No files to stage. Skipping git add.
       NX   Generating an entry in CHANGELOG.md for v0.0.6

--- a/packages/js/src/release/version-actions.spec.ts
+++ b/packages/js/src/release/version-actions.spec.ts
@@ -79,6 +79,29 @@ describe('JsVersionActions', () => {
     );
   });
 
+  it('preserves comments and trailing commas in a valid manifest', async () => {
+    const tree = createTreeWithEmptyWorkspace();
+    tree.write(
+      'packages/my-lib/package.json',
+      `{
+  // This comment should be preserved.
+  "name": "my-lib",
+  "version": "1.0.0",
+}
+`
+    );
+    const versionActions = await createVersionActions(tree);
+
+    await versionActions.updateProjectVersion(tree, '1.1.0');
+
+    expect(tree.read('packages/my-lib/package.json', 'utf-8')).toBe(`{
+  // This comment should be preserved.
+  "name": "my-lib",
+  "version": "1.1.0",
+}
+`);
+  });
+
   it('preserves a dependency range that already contains the new version', async () => {
     const tree = createTreeWithEmptyWorkspace();
     const manifest = `{

--- a/packages/js/src/release/version-actions.spec.ts
+++ b/packages/js/src/release/version-actions.spec.ts
@@ -102,6 +102,51 @@ describe('JsVersionActions', () => {
 `);
   });
 
+  it('rejects a version update shadowed by a duplicate key', async () => {
+    const tree = createTreeWithEmptyWorkspace();
+    const manifest = `{
+  "name": "my-lib",
+  "version": "1.0.0",
+  "version": "5.5.5"
+}
+`;
+    tree.write('packages/my-lib/package.json', manifest);
+    const versionActions = await createVersionActions(tree);
+
+    await expect(
+      versionActions.updateProjectVersion(tree, '1.1.0')
+    ).rejects.toThrow(
+      'Cannot update packages/my-lib/package.json: "version" resolves to "5.5.5" instead of "1.1.0"'
+    );
+    expect(tree.read('packages/my-lib/package.json', 'utf-8')).toBe(manifest);
+  });
+
+  it('rejects a dependency update shadowed by a duplicate key', async () => {
+    const tree = createTreeWithEmptyWorkspace();
+    const manifest = `{
+  "name": "my-lib",
+  "version": "1.0.0",
+  "dependencies": {
+    "dependency": "^1.0.0"
+  },
+  "dependencies": {
+    "dependency": "^5.0.0"
+  }
+}
+`;
+    tree.write('packages/my-lib/package.json', manifest);
+    const versionActions = await createVersionActions(tree);
+
+    await expect(
+      versionActions.updateProjectDependencies(tree, createProjectGraph(), {
+        dependency: '^2.0.0',
+      })
+    ).rejects.toThrow(
+      'Cannot update packages/my-lib/package.json: "dependencies.dependency" resolves to "^5.0.0" instead of "^2.0.0"'
+    );
+    expect(tree.read('packages/my-lib/package.json', 'utf-8')).toBe(manifest);
+  });
+
   it('preserves a dependency range that already contains the new version', async () => {
     const tree = createTreeWithEmptyWorkspace();
     const manifest = `{

--- a/packages/js/src/release/version-actions.spec.ts
+++ b/packages/js/src/release/version-actions.spec.ts
@@ -1,0 +1,72 @@
+import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import JsVersionActions from './version-actions';
+
+describe('JsVersionActions', () => {
+  it('preserves package.json formatting when updating versions and dependencies', async () => {
+    const tree = createTreeWithEmptyWorkspace();
+    tree.write(
+      'packages/my-lib/package.json',
+      `{
+    "name": "my-lib",
+    "version": "1.0.0",
+    "files": [
+        "dist"
+    ],
+    "dependencies": {
+        "dependency": "^1.0.0"
+    }
+}
+`
+    );
+
+    const versionActions = new JsVersionActions(
+      {
+        name: 'release-group',
+        projects: ['my-lib'],
+        projectsRelationship: 'independent',
+      } as any,
+      {
+        name: 'my-lib',
+        type: 'lib',
+        data: { root: 'packages/my-lib' },
+      },
+      {
+        manifestRootsToUpdate: [],
+        preserveLocalDependencyProtocols: false,
+        preserveMatchingDependencyRanges: false,
+      } as any
+    );
+    await versionActions.init(tree);
+
+    await versionActions.updateProjectVersion(tree, '1.1.0');
+    await versionActions.updateProjectDependencies(
+      tree,
+      {
+        nodes: {
+          dependency: {
+            name: 'dependency',
+            type: 'lib',
+            data: {
+              root: 'packages/dependency',
+              metadata: { js: { packageName: 'dependency' } },
+            },
+          },
+        },
+        dependencies: {},
+      },
+      { dependency: '^2.0.0' }
+    );
+
+    expect(tree.read('packages/my-lib/package.json', 'utf-8')).toBe(`{
+    "name": "my-lib",
+    "version": "1.1.0",
+    "files": [
+        "dist"
+    ],
+    "dependencies": {
+        "dependency": "^2.0.0"
+    }
+}
+`);
+  });
+});

--- a/packages/js/src/release/version-actions.spec.ts
+++ b/packages/js/src/release/version-actions.spec.ts
@@ -1,4 +1,5 @@
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
+import type { Tree } from '@nx/devkit';
 import JsVersionActions from './version-actions';
 
 describe('JsVersionActions', () => {
@@ -18,44 +19,12 @@ describe('JsVersionActions', () => {
 }
 `
     );
-
-    const versionActions = new JsVersionActions(
-      {
-        name: 'release-group',
-        projects: ['my-lib'],
-        projectsRelationship: 'independent',
-      } as any,
-      {
-        name: 'my-lib',
-        type: 'lib',
-        data: { root: 'packages/my-lib' },
-      },
-      {
-        manifestRootsToUpdate: [],
-        preserveLocalDependencyProtocols: false,
-        preserveMatchingDependencyRanges: false,
-      } as any
-    );
-    await versionActions.init(tree);
+    const versionActions = await createVersionActions(tree);
 
     await versionActions.updateProjectVersion(tree, '1.1.0');
-    await versionActions.updateProjectDependencies(
-      tree,
-      {
-        nodes: {
-          dependency: {
-            name: 'dependency',
-            type: 'lib',
-            data: {
-              root: 'packages/dependency',
-              metadata: { js: { packageName: 'dependency' } },
-            },
-          },
-        },
-        dependencies: {},
-      },
-      { dependency: '^2.0.0' }
-    );
+    await versionActions.updateProjectDependencies(tree, createProjectGraph(), {
+      dependency: '^2.0.0',
+    });
 
     expect(tree.read('packages/my-lib/package.json', 'utf-8')).toBe(`{
     "name": "my-lib",
@@ -69,4 +38,131 @@ describe('JsVersionActions', () => {
 }
 `);
   });
+
+  it.each([
+    {
+      name: 'spaces and LF endings',
+      input: '{\n    "name": "my-lib",\n    "private": true\n}\n',
+      expected:
+        '{\n    "name": "my-lib",\n    "private": true,\n    "version": "1.1.0"\n}\n',
+    },
+    {
+      name: 'tabs and CRLF endings',
+      input: '{\r\n\t"name": "my-lib",\r\n\t"private": true\r\n}\r\n',
+      expected:
+        '{\r\n\t"name": "my-lib",\r\n\t"private": true,\r\n\t"version": "1.1.0"\r\n}\r\n',
+    },
+  ])('formats an inserted version using $name', async ({ input, expected }) => {
+    const tree = createTreeWithEmptyWorkspace();
+    tree.write('packages/my-lib/package.json', input);
+    const versionActions = await createVersionActions(tree);
+
+    await versionActions.updateProjectVersion(tree, '1.1.0');
+
+    expect(tree.read('packages/my-lib/package.json', 'utf-8')).toBe(expected);
+  });
+
+  it('rejects a malformed manifest without changing it', async () => {
+    const tree = createTreeWithEmptyWorkspace();
+    const malformedManifest = `{
+  "name": "my-lib",
+  "version": "1.0.0"
+`;
+    tree.write('packages/my-lib/package.json', malformedManifest);
+    const versionActions = await createVersionActions(tree);
+
+    await expect(
+      versionActions.updateProjectVersion(tree, '1.1.0')
+    ).rejects.toThrow('Cannot parse packages/my-lib/package.json');
+    expect(tree.read('packages/my-lib/package.json', 'utf-8')).toBe(
+      malformedManifest
+    );
+  });
+
+  it('preserves a dependency range that already contains the new version', async () => {
+    const tree = createTreeWithEmptyWorkspace();
+    const manifest = `{
+  "name": "my-lib",
+  "version": "1.0.0",
+  "dependencies": {
+    "dependency": "^1.0.0"
+  }
+}
+`;
+    tree.write('packages/my-lib/package.json', manifest);
+    const versionActions = await createVersionActions(tree, {
+      preserveMatchingDependencyRanges: true,
+    });
+
+    await versionActions.updateProjectDependencies(tree, createProjectGraph(), {
+      dependency: '1.1.0',
+    });
+
+    expect(tree.read('packages/my-lib/package.json', 'utf-8')).toBe(manifest);
+  });
+
+  it('rejects a dependency version outside a preserved range', async () => {
+    const tree = createTreeWithEmptyWorkspace();
+    const manifest = `{
+  "name": "my-lib",
+  "version": "1.0.0",
+  "dependencies": {
+    "dependency": "^1.0.0"
+  }
+}
+`;
+    tree.write('packages/my-lib/package.json', manifest);
+    const versionActions = await createVersionActions(tree, {
+      preserveMatchingDependencyRanges: true,
+    });
+
+    await expect(
+      versionActions.updateProjectDependencies(tree, createProjectGraph(), {
+        dependency: '2.0.0',
+      })
+    ).rejects.toThrow('is outside the current range');
+    expect(tree.read('packages/my-lib/package.json', 'utf-8')).toBe(manifest);
+  });
 });
+
+async function createVersionActions(
+  tree: Tree,
+  config: Record<string, unknown> = {}
+): Promise<JsVersionActions> {
+  const versionActions = new JsVersionActions(
+    {
+      name: 'release-group',
+      projects: ['my-lib'],
+      projectsRelationship: 'independent',
+    } as any,
+    {
+      name: 'my-lib',
+      type: 'lib',
+      data: { root: 'packages/my-lib' },
+    },
+    {
+      manifestRootsToUpdate: [],
+      preserveLocalDependencyProtocols: false,
+      preserveMatchingDependencyRanges: false,
+      ...config,
+    } as any
+  );
+  await versionActions.init(tree);
+  return versionActions;
+}
+
+function createProjectGraph() {
+  return {
+    nodes: {
+      dependency: {
+        name: 'dependency',
+        type: 'lib',
+        data: {
+          root: 'packages/dependency',
+          metadata: { js: { packageName: 'dependency' } },
+        },
+      },
+    },
+    dependencies: {},
+  } as any;
+}

--- a/packages/js/src/release/version-actions.ts
+++ b/packages/js/src/release/version-actions.ts
@@ -5,11 +5,11 @@ import {
   ProjectGraph,
   readJson,
   Tree,
-  updateJson,
   workspaceRoot,
 } from '@nx/devkit';
 import { exec } from 'node:child_process';
 import { join } from 'node:path';
+import { applyEdits, modify } from 'jsonc-parser';
 import { AfterAllProjectsVersioned, VersionActions } from 'nx/release';
 import type { NxReleaseVersionConfiguration } from 'nx/src/config/nx-json';
 import { parseRegistryOptions } from '../utils/npm-config';
@@ -193,10 +193,9 @@ export default class JsVersionActions extends VersionActions {
   ): Promise<string[]> {
     const logMessages: string[] = [];
     for (const manifestToUpdate of this.manifestsToUpdate) {
-      updateJson(tree, manifestToUpdate.manifestPath, (json) => {
-        json.version = newVersion;
-        return json;
-      });
+      this.updateManifestValues(tree, manifestToUpdate.manifestPath, [
+        { path: ['version'], value: newVersion },
+      ]);
       logMessages.push(
         `✍️  New version ${newVersion} written to manifest: ${manifestToUpdate.manifestPath}`
       );
@@ -223,82 +222,92 @@ export default class JsVersionActions extends VersionActions {
     const catalogManager = getCatalogManager(tree.root);
 
     for (const manifestToUpdate of this.manifestsToUpdate) {
-      updateJson(tree, manifestToUpdate.manifestPath, (json) => {
-        const dependencyTypes = [
-          'dependencies',
-          'devDependencies',
-          'peerDependencies',
-          'optionalDependencies',
-        ];
+      const json = readJson(tree, manifestToUpdate.manifestPath);
+      const manifestUpdates: Array<{
+        path: string[];
+        value: string;
+      }> = [];
+      const dependencyTypes = [
+        'dependencies',
+        'devDependencies',
+        'peerDependencies',
+        'optionalDependencies',
+      ];
 
-        const preserveMatchingDependencyRanges =
-          this.finalConfigForProject.preserveMatchingDependencyRanges === true
-            ? dependencyTypes
-            : this.finalConfigForProject.preserveMatchingDependencyRanges ===
-                false
-              ? []
-              : this.finalConfigForProject.preserveMatchingDependencyRanges ||
-                dependencyTypes;
+      const preserveMatchingDependencyRanges =
+        this.finalConfigForProject.preserveMatchingDependencyRanges === true
+          ? dependencyTypes
+          : this.finalConfigForProject.preserveMatchingDependencyRanges ===
+              false
+            ? []
+            : this.finalConfigForProject.preserveMatchingDependencyRanges ||
+              dependencyTypes;
 
-        for (const depType of dependencyTypes) {
-          if (json[depType]) {
-            for (const [dep, version] of Object.entries(dependenciesToUpdate)) {
-              // Resolve the package name from the project graph metadata, as it may not match the project name
-              const packageName =
-                projectGraph.nodes[dep].data.metadata?.js?.packageName;
-              if (!packageName) {
-                throw new Error(
-                  `Unable to determine the package name for project "${dep}" from the project graph metadata, please ensure that the "@nx/js" plugin is installed and the project graph has been built. If the issue persists, please report this issue on https://github.com/nrwl/nx/issues`
-                );
+      for (const depType of dependencyTypes) {
+        if (json[depType]) {
+          for (const [dep, version] of Object.entries(dependenciesToUpdate)) {
+            // Resolve the package name from the project graph metadata, as it may not match the project name
+            const packageName =
+              projectGraph.nodes[dep].data.metadata?.js?.packageName;
+            if (!packageName) {
+              throw new Error(
+                `Unable to determine the package name for project "${dep}" from the project graph metadata, please ensure that the "@nx/js" plugin is installed and the project graph has been built. If the issue persists, please report this issue on https://github.com/nrwl/nx/issues`
+              );
+            }
+            const currentVersion = json[depType][packageName];
+            if (currentVersion) {
+              if (catalogManager?.isCatalogReference(currentVersion)) {
+                // collect the catalog updates so we can update the catalog definitions later
+                const catalogRef =
+                  catalogManager.parseCatalogReference(currentVersion)!;
+                catalogUpdates.push({
+                  packageName,
+                  version,
+                  catalogName: catalogRef.catalogName,
+                });
+
+                numDependenciesToUpdate--;
+                continue;
               }
-              const currentVersion = json[depType][packageName];
-              if (currentVersion) {
-                if (catalogManager?.isCatalogReference(currentVersion)) {
-                  // collect the catalog updates so we can update the catalog definitions later
-                  const catalogRef =
-                    catalogManager.parseCatalogReference(currentVersion)!;
-                  catalogUpdates.push({
-                    packageName,
-                    version,
-                    catalogName: catalogRef.catalogName,
-                  });
-
-                  numDependenciesToUpdate--;
+              // Check if other local dependency protocols should be preserved
+              else if (
+                manifestToUpdate.preserveLocalDependencyProtocols &&
+                this.isLocalDependencyProtocol(currentVersion)
+              ) {
+                // Reduce the count appropriately to avoid confusing user-facing logs
+                numDependenciesToUpdate--;
+                continue;
+              } else if (
+                preserveMatchingDependencyRanges.includes(depType) &&
+                !this.isLocalDependencyProtocol(currentVersion)
+              ) {
+                // If the dependency is specified using a range, do some additional processing to determine whether to update the version
+                if (
+                  isValidRange(currentVersion) &&
+                  !isMatchingDependencyRange(version, currentVersion)
+                ) {
+                  throw new Error(
+                    `"preserveMatchingDependencyRanges" is enabled for "${depType}" and the new version "${version}" is outside the current range for "${packageName}" in manifest "${manifestToUpdate.manifestPath}". Please update the range before releasing.`
+                  );
+                } else if (isValidRange(currentVersion)) {
+                  // it is a range, but it is valid
                   continue;
                 }
-                // Check if other local dependency protocols should be preserved
-                else if (
-                  manifestToUpdate.preserveLocalDependencyProtocols &&
-                  this.isLocalDependencyProtocol(currentVersion)
-                ) {
-                  // Reduce the count appropriately to avoid confusing user-facing logs
-                  numDependenciesToUpdate--;
-                  continue;
-                } else if (
-                  preserveMatchingDependencyRanges.includes(depType) &&
-                  !this.isLocalDependencyProtocol(currentVersion)
-                ) {
-                  // If the dependency is specified using a range, do some additional processing to determine whether to update the version
-                  if (
-                    isValidRange(currentVersion) &&
-                    !isMatchingDependencyRange(version, currentVersion)
-                  ) {
-                    throw new Error(
-                      `"preserveMatchingDependencyRanges" is enabled for "${depType}" and the new version "${version}" is outside the current range for "${packageName}" in manifest "${manifestToUpdate.manifestPath}". Please update the range before releasing.`
-                    );
-                  } else if (isValidRange(currentVersion)) {
-                    // it is a range, but it is valid
-                    continue;
-                  }
-                }
-                json[depType][packageName] = version;
               }
+              manifestUpdates.push({
+                path: [depType, packageName],
+                value: version,
+              });
             }
           }
         }
+      }
 
-        return json;
-      });
+      this.updateManifestValues(
+        tree,
+        manifestToUpdate.manifestPath,
+        manifestUpdates
+      );
 
       // If we ignored local dependecy protocols, then we could have dynamically ended up with zero here and we should not log anything related to dependencies
       if (numDependenciesToUpdate === 0) {
@@ -327,6 +336,24 @@ export default class JsVersionActions extends VersionActions {
     }
 
     return logMessages;
+  }
+
+  private updateManifestValues(
+    tree: Tree,
+    manifestPath: string,
+    updates: Array<{ path: string[]; value: string }>
+  ): void {
+    if (updates.length === 0) {
+      return;
+    }
+    let content = tree.read(manifestPath, 'utf-8');
+    for (const update of updates) {
+      content = applyEdits(
+        content,
+        modify(content, update.path, update.value, {})
+      );
+    }
+    tree.write(manifestPath, content);
   }
 
   // NOTE: The TODOs were carried over from the original implementation, they are not yet implemented

--- a/packages/js/src/release/version-actions.ts
+++ b/packages/js/src/release/version-actions.ts
@@ -9,7 +9,7 @@ import {
 } from '@nx/devkit';
 import { exec } from 'node:child_process';
 import { join } from 'node:path';
-import { applyEdits, modify } from 'jsonc-parser';
+import { applyEdits, FormattingOptions, modify } from 'jsonc-parser';
 import { AfterAllProjectsVersioned, VersionActions } from 'nx/release';
 import type { NxReleaseVersionConfiguration } from 'nx/src/config/nx-json';
 import { parseRegistryOptions } from '../utils/npm-config';
@@ -42,6 +42,7 @@ let pm: PackageManager | undefined;
 
 export default class JsVersionActions extends VersionActions {
   validManifestFilenames = ['package.json'];
+  preservesManifestFormatting = true;
 
   async readCurrentVersionFromSourceManifest(tree: Tree): Promise<{
     currentVersion: string;
@@ -346,14 +347,31 @@ export default class JsVersionActions extends VersionActions {
     if (updates.length === 0) {
       return;
     }
+    // Preserve the previous updateJson behavior of rejecting malformed
+    // manifests before writing any changes. readJson also retains Nx's support
+    // for comments and trailing commas.
+    readJson(tree, manifestPath);
     let content = tree.read(manifestPath, 'utf-8');
+    const formattingOptions = this.detectFormattingOptions(content);
     for (const update of updates) {
       content = applyEdits(
         content,
-        modify(content, update.path, update.value, {})
+        modify(content, update.path, update.value, { formattingOptions })
       );
     }
     tree.write(manifestPath, content);
+  }
+
+  private detectFormattingOptions(content: string): FormattingOptions {
+    const indentation = content.match(/^[\t ]+(?=")/m)?.[0] ?? '  ';
+    const insertSpaces = !indentation.includes('\t');
+
+    return {
+      eol: content.includes('\r\n') ? '\r\n' : '\n',
+      insertFinalNewline: content.endsWith('\n'),
+      insertSpaces,
+      tabSize: insertSpaces ? indentation.length : 1,
+    };
   }
 
   // NOTE: The TODOs were carried over from the original implementation, they are not yet implemented

--- a/packages/js/src/release/version-actions.ts
+++ b/packages/js/src/release/version-actions.ts
@@ -2,6 +2,7 @@ import { getCatalogManager } from '@nx/devkit/internal';
 import {
   detectPackageManager,
   PackageManager,
+  parseJson,
   ProjectGraph,
   readJson,
   Tree,
@@ -42,7 +43,7 @@ let pm: PackageManager | undefined;
 
 export default class JsVersionActions extends VersionActions {
   validManifestFilenames = ['package.json'];
-  preservesManifestFormatting = true;
+  excludeManifestsFromFormatting = true;
 
   async readCurrentVersionFromSourceManifest(tree: Tree): Promise<{
     currentVersion: string;
@@ -347,11 +348,7 @@ export default class JsVersionActions extends VersionActions {
     if (updates.length === 0) {
       return;
     }
-    // Preserve the previous updateJson behavior of rejecting malformed
-    // manifests before writing any changes. readJson also retains Nx's support
-    // for comments and trailing commas.
-    readJson(tree, manifestPath);
-    let content = tree.read(manifestPath, 'utf-8');
+    let content = this.readAndValidateManifest(tree, manifestPath);
     const formattingOptions = this.detectFormattingOptions(content);
     for (const update of updates) {
       content = applyEdits(
@@ -360,6 +357,18 @@ export default class JsVersionActions extends VersionActions {
       );
     }
     tree.write(manifestPath, content);
+  }
+
+  private readAndValidateManifest(tree: Tree, manifestPath: string): string {
+    const content = tree.read(manifestPath, 'utf-8');
+    try {
+      // Match readJson's support for comments and trailing commas while
+      // retaining the original text for targeted edits.
+      parseJson(content);
+    } catch (error) {
+      throw new Error(`Cannot parse ${manifestPath}: ${error.message}`);
+    }
+    return content;
   }
 
   private detectFormattingOptions(content: string): FormattingOptions {

--- a/packages/js/src/release/version-actions.ts
+++ b/packages/js/src/release/version-actions.ts
@@ -356,6 +356,7 @@ export default class JsVersionActions extends VersionActions {
         modify(content, update.path, update.value, { formattingOptions })
       );
     }
+    this.validateManifestUpdates(content, manifestPath, updates);
     tree.write(manifestPath, content);
   }
 
@@ -371,13 +372,44 @@ export default class JsVersionActions extends VersionActions {
     return content;
   }
 
+  private validateManifestUpdates(
+    content: string,
+    manifestPath: string,
+    updates: Array<{ path: string[]; value: string }>
+  ): void {
+    const manifest = parseJson(content);
+    for (const update of updates) {
+      let actualValue: unknown = manifest;
+      for (const pathSegment of update.path) {
+        if (
+          actualValue === null ||
+          typeof actualValue !== 'object' ||
+          !(pathSegment in actualValue)
+        ) {
+          actualValue = undefined;
+          break;
+        }
+        actualValue = (actualValue as Record<string, unknown>)[pathSegment];
+      }
+      if (actualValue !== update.value) {
+        throw new Error(
+          `Cannot update ${manifestPath}: "${update.path.join(
+            '.'
+          )}" resolves to ${JSON.stringify(
+            actualValue
+          )} instead of ${JSON.stringify(
+            update.value
+          )} after editing. The manifest may contain duplicate keys.`
+        );
+      }
+    }
+  }
+
   private detectFormattingOptions(content: string): FormattingOptions {
     const indentation = content.match(/^[\t ]+(?=")/m)?.[0] ?? '  ';
     const insertSpaces = !indentation.includes('\t');
 
     return {
-      eol: content.includes('\r\n') ? '\r\n' : '\n',
-      insertFinalNewline: content.endsWith('\n'),
       insertSpaces,
       tabSize: insertSpaces ? indentation.length : 1,
     };

--- a/packages/nx/src/command-line/release/version.ts
+++ b/packages/nx/src/command-line/release/version.ts
@@ -267,10 +267,10 @@ export function createAPI(
 
     // A version actions implementation can opt its manifests out of this final
     // pass when it already preserves their formatting while updating values.
-    const manifestsToPreserveFormatting = new Set(
+    const manifestsToExcludeFromFormatting = new Set(
       Array.from(releaseGraph.projectsToVersionActions.values()).flatMap(
         (versionActions) =>
-          versionActions.preservesManifestFormatting
+          versionActions.excludeManifestsFromFormatting
             ? versionActions.manifestsToUpdate.map(
                 ({ manifestPath }) => manifestPath
               )
@@ -279,7 +279,7 @@ export function createAPI(
     );
     await formatChangedFilesWithPrettierIfAvailable(tree, {
       silent: true,
-      excludePaths: manifestsToPreserveFormatting,
+      excludePaths: manifestsToExcludeFromFormatting,
     });
 
     printAndFlushChanges(tree, !!args.dryRun);

--- a/packages/nx/src/command-line/release/version.ts
+++ b/packages/nx/src/command-line/release/version.ts
@@ -1,7 +1,6 @@
 import * as pc from 'picocolors';
 import { execSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
-import { basename } from 'node:path';
 import {
   NxReleaseConfiguration,
   NxReleaseVersionConfiguration,
@@ -266,21 +265,21 @@ export function createAPI(
       throw err;
     }
 
-    /**
-     * Format other changed files, but leave package manifests to their version
-     * actions so existing indentation and array layout remain untouched.
-     */
-    const packageJsonManifestsToPreserve = new Set(
+    // A version actions implementation can opt its manifests out of this final
+    // pass when it already preserves their formatting while updating values.
+    const manifestsToPreserveFormatting = new Set(
       Array.from(releaseGraph.projectsToVersionActions.values()).flatMap(
         (versionActions) =>
-          versionActions.manifestsToUpdate
-            .map(({ manifestPath }) => manifestPath)
-            .filter((manifestPath) => basename(manifestPath) === 'package.json')
+          versionActions.preservesManifestFormatting
+            ? versionActions.manifestsToUpdate.map(
+                ({ manifestPath }) => manifestPath
+              )
+            : []
       )
     );
     await formatChangedFilesWithPrettierIfAvailable(tree, {
       silent: true,
-      excludePaths: packageJsonManifestsToPreserve,
+      excludePaths: manifestsToPreserveFormatting,
     });
 
     printAndFlushChanges(tree, !!args.dryRun);

--- a/packages/nx/src/command-line/release/version.ts
+++ b/packages/nx/src/command-line/release/version.ts
@@ -1,6 +1,7 @@
 import * as pc from 'picocolors';
 import { execSync } from 'node:child_process';
 import { readFileSync } from 'node:fs';
+import { basename } from 'node:path';
 import {
   NxReleaseConfiguration,
   NxReleaseVersionConfiguration,
@@ -266,10 +267,21 @@ export function createAPI(
     }
 
     /**
-     * Ensure that formatting is applied so that version bump diffs are as minimal as possible
-     * within the context of the user's workspace.
+     * Format other changed files, but leave package manifests to their version
+     * actions so existing indentation and array layout remain untouched.
      */
-    await formatChangedFilesWithPrettierIfAvailable(tree, { silent: true });
+    const packageJsonManifestsToPreserve = new Set(
+      Array.from(releaseGraph.projectsToVersionActions.values()).flatMap(
+        (versionActions) =>
+          versionActions.manifestsToUpdate
+            .map(({ manifestPath }) => manifestPath)
+            .filter((manifestPath) => basename(manifestPath) === 'package.json')
+      )
+    );
+    await formatChangedFilesWithPrettierIfAvailable(tree, {
+      silent: true,
+      excludePaths: packageJsonManifestsToPreserve,
+    });
 
     printAndFlushChanges(tree, !!args.dryRun);
 

--- a/packages/nx/src/command-line/release/version/test-utils.ts
+++ b/packages/nx/src/command-line/release/version/test-utils.ts
@@ -281,8 +281,9 @@ export class MockJsVersionActions extends VersionActions {
   private read = (tree: Tree, manifestPath: string): any =>
     JSON.parse(tree.read(manifestPath, 'utf-8')!.toString());
 
-  // Match `@nx/devkit`'s `updateJson` formatting (2-space indent + trailing
-  // newline) so existing snapshots continue to match.
+  // Normalize JSON to a stable two-space format for orchestration snapshots.
+  // Formatting preservation is JS-specific behavior covered against the real
+  // implementation in packages/js.
   private write = (tree: Tree, manifestPath: string, json: any): void =>
     tree.write(manifestPath, JSON.stringify(json, null, 2) + '\n');
 

--- a/packages/nx/src/command-line/release/version/version-actions.ts
+++ b/packages/nx/src/command-line/release/version/version-actions.ts
@@ -188,6 +188,15 @@ export abstract class VersionActions {
    */
   abstract validManifestFilenames: string[] | null;
   /**
+   * Whether this implementation preserves the formatting of manifests it
+   * updates. When true, those manifests are excluded from the final Prettier
+   * pass performed by Nx Release.
+   *
+   * Custom implementations must opt in explicitly. This defaults to false so
+   * their existing formatting behavior does not change.
+   */
+  preservesManifestFormatting = false;
+  /**
    * The interpolated manifest paths to update, if applicable based on the user's configuration, when new
    * versions and dependencies are determined. If no manifest files should be updated based on the user's
    * configuration, this will be an empty array.

--- a/packages/nx/src/command-line/release/version/version-actions.ts
+++ b/packages/nx/src/command-line/release/version/version-actions.ts
@@ -188,14 +188,13 @@ export abstract class VersionActions {
    */
   abstract validManifestFilenames: string[] | null;
   /**
-   * Whether this implementation preserves the formatting of manifests it
-   * updates. When true, those manifests are excluded from the final Prettier
-   * pass performed by Nx Release.
+   * Whether manifests updated by this implementation should be excluded from
+   * the final Prettier pass performed by Nx Release.
    *
    * Custom implementations must opt in explicitly. This defaults to false so
    * their existing formatting behavior does not change.
    */
-  preservesManifestFormatting = false;
+  excludeManifestsFromFormatting = false;
   /**
    * The interpolated manifest paths to update, if applicable based on the user's configuration, when new
    * versions and dependencies are determined. If no manifest files should be updated based on the user's

--- a/packages/nx/src/generators/internal-utils/format-changed-files-with-prettier-if-available.spec.ts
+++ b/packages/nx/src/generators/internal-utils/format-changed-files-with-prettier-if-available.spec.ts
@@ -1,0 +1,37 @@
+import type { Tree } from '../tree';
+import { formatChangedFilesWithPrettierIfAvailable } from './format-changed-files-with-prettier-if-available';
+
+describe('formatChangedFilesWithPrettierIfAvailable', () => {
+  it('does not format excluded files', async () => {
+    const originalSkipFormat = process.env.NX_SKIP_FORMAT;
+    delete process.env.NX_SKIP_FORMAT;
+    const write = jest.fn();
+    const listChanges = jest.fn(() => [
+      {
+        path: 'package.json',
+        type: 'UPDATE' as const,
+        content: Buffer.from('{"version":"1.1.0"}'),
+      },
+    ]);
+    const tree = {
+      root: process.cwd(),
+      listChanges,
+      write,
+    } as unknown as Tree;
+
+    try {
+      await formatChangedFilesWithPrettierIfAvailable(tree, {
+        excludePaths: new Set(['package.json']),
+      });
+
+      expect(listChanges).toHaveBeenCalledTimes(1);
+      expect(write).not.toHaveBeenCalled();
+    } finally {
+      if (originalSkipFormat === undefined) {
+        delete process.env.NX_SKIP_FORMAT;
+      } else {
+        process.env.NX_SKIP_FORMAT = originalSkipFormat;
+      }
+    }
+  });
+});

--- a/packages/nx/src/generators/internal-utils/format-changed-files-with-prettier-if-available.spec.ts
+++ b/packages/nx/src/generators/internal-utils/format-changed-files-with-prettier-if-available.spec.ts
@@ -28,7 +28,7 @@ describe('formatChangedFilesWithPrettierIfAvailable', () => {
     rmSync(root, { recursive: true, force: true });
   });
 
-  it('does not format excluded nested paths with platform-native separators', async () => {
+  it('does not format excluded paths given with Windows separators', async () => {
     const write = jest.fn();
     const tree = {
       root,

--- a/packages/nx/src/generators/internal-utils/format-changed-files-with-prettier-if-available.spec.ts
+++ b/packages/nx/src/generators/internal-utils/format-changed-files-with-prettier-if-available.spec.ts
@@ -1,37 +1,61 @@
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import type { Tree } from '../tree';
-import { formatChangedFilesWithPrettierIfAvailable } from './format-changed-files-with-prettier-if-available';
+import {
+  formatChangedFilesWithPrettierIfAvailable,
+  formatFilesWithPrettierIfAvailable,
+} from './format-changed-files-with-prettier-if-available';
 
 describe('formatChangedFilesWithPrettierIfAvailable', () => {
-  it('does not format excluded files', async () => {
-    const originalSkipFormat = process.env.NX_SKIP_FORMAT;
+  let originalSkipFormat: string | undefined;
+  let root: string;
+
+  beforeEach(() => {
+    originalSkipFormat = process.env.NX_SKIP_FORMAT;
     delete process.env.NX_SKIP_FORMAT;
+    root = mkdtempSync(join(tmpdir(), 'nx-prettier-'));
+    mkdirSync(join(root, 'packages/my-lib'), { recursive: true });
+    writeFileSync(join(root, 'package.json'), JSON.stringify({ prettier: {} }));
+  });
+
+  afterEach(() => {
+    if (originalSkipFormat === undefined) {
+      delete process.env.NX_SKIP_FORMAT;
+    } else {
+      process.env.NX_SKIP_FORMAT = originalSkipFormat;
+    }
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it('does not format excluded nested paths with platform-native separators', async () => {
     const write = jest.fn();
-    const listChanges = jest.fn(() => [
-      {
-        path: 'package.json',
-        type: 'UPDATE' as const,
-        content: Buffer.from('{"version":"1.1.0"}'),
-      },
-    ]);
     const tree = {
-      root: process.cwd(),
-      listChanges,
+      root,
+      listChanges: jest.fn(() => [
+        {
+          path: 'packages/my-lib/package.json',
+          type: 'UPDATE' as const,
+          content: Buffer.from('{"version":"1.1.0"}'),
+        },
+      ]),
       write,
     } as unknown as Tree;
 
-    try {
-      await formatChangedFilesWithPrettierIfAvailable(tree, {
-        excludePaths: new Set(['package.json']),
-      });
+    await formatChangedFilesWithPrettierIfAvailable(tree);
+    expect(write).toHaveBeenCalledTimes(1);
 
-      expect(listChanges).toHaveBeenCalledTimes(1);
-      expect(write).not.toHaveBeenCalled();
-    } finally {
-      if (originalSkipFormat === undefined) {
-        delete process.env.NX_SKIP_FORMAT;
-      } else {
-        process.env.NX_SKIP_FORMAT = originalSkipFormat;
-      }
-    }
+    write.mockClear();
+    await formatChangedFilesWithPrettierIfAvailable(tree, {
+      excludePaths: new Set(['packages\\my-lib\\package.json']),
+    });
+
+    expect(write).not.toHaveBeenCalled();
+  });
+
+  it('returns immediately when there are no files to format', async () => {
+    await expect(formatFilesWithPrettierIfAvailable([], root)).resolves.toEqual(
+      new Map()
+    );
   });
 });

--- a/packages/nx/src/generators/internal-utils/format-changed-files-with-prettier-if-available.ts
+++ b/packages/nx/src/generators/internal-utils/format-changed-files-with-prettier-if-available.ts
@@ -1,6 +1,7 @@
 import * as path from 'path';
 import type * as Prettier from 'prettier';
 import { isUsingPrettier } from '../../utils/is-using-prettier';
+import { normalizePath } from '../../utils/path';
 import type { Tree } from '../tree';
 import { getNxRequirePaths } from '../../utils/installation-directory';
 
@@ -17,6 +18,10 @@ export async function formatChangedFilesWithPrettierIfAvailable(
   tree: Tree,
   options?: {
     silent?: boolean;
+    /**
+     * Tree-relative paths to leave untouched. Both platform-native and
+     * forward-slash separators are accepted.
+     */
     excludePaths?: Set<string>;
   }
 ): Promise<void> {
@@ -24,12 +29,16 @@ export async function formatChangedFilesWithPrettierIfAvailable(
     return;
   }
 
+  const excludedPaths = options?.excludePaths
+    ? new Set(Array.from(options.excludePaths, normalizePath))
+    : undefined;
   const files = new Set(
     tree
       .listChanges()
       .filter(
         (file) =>
-          file.type !== 'DELETE' && !options?.excludePaths?.has(file.path)
+          file.type !== 'DELETE' &&
+          !excludedPaths?.has(normalizePath(file.path))
       )
   );
 

--- a/packages/nx/src/generators/internal-utils/format-changed-files-with-prettier-if-available.ts
+++ b/packages/nx/src/generators/internal-utils/format-changed-files-with-prettier-if-available.ts
@@ -17,6 +17,7 @@ export async function formatChangedFilesWithPrettierIfAvailable(
   tree: Tree,
   options?: {
     silent?: boolean;
+    excludePaths?: Set<string>;
   }
 ): Promise<void> {
   if (process.env.NX_SKIP_FORMAT === 'true') {
@@ -24,7 +25,12 @@ export async function formatChangedFilesWithPrettierIfAvailable(
   }
 
   const files = new Set(
-    tree.listChanges().filter((file) => file.type !== 'DELETE')
+    tree
+      .listChanges()
+      .filter(
+        (file) =>
+          file.type !== 'DELETE' && !options?.excludePaths?.has(file.path)
+      )
   );
 
   const results = await formatFilesWithPrettierIfAvailable(
@@ -48,7 +54,7 @@ export async function formatFilesWithPrettierIfAvailable(
   const results = new Map<string, string>();
 
   // Check here as well for direct callers of this function
-  if (process.env.NX_SKIP_FORMAT === 'true') {
+  if (process.env.NX_SKIP_FORMAT === 'true' || files.length === 0) {
     return results;
   }
 


### PR DESCRIPTION
## Current Behavior

`nx release version` rewrites the whole `package.json` when updating version and dependency values. This can replace the user's indentation and create noisy diffs unrelated to the release.

## Expected Behavior

The JavaScript version actions update only the intended scalar values while preserving the package manifest's existing indentation, line endings, comments, and surrounding layout. Missing `version` fields are inserted using the document's formatting, malformed manifests still fail before being changed, and the final Prettier pass skips only manifests whose version actions explicitly preserve formatting.

Focused tests cover existing and missing version fields, dependency updates and preserved ranges, malformed manifests, Windows-style nested manifest paths, and formatter exclusion.

## Related Issue(s)

Fixes #26425