### PR TITLE
fix(docker): skip unchanged version action projects

### DIFF
--- a/packages/docker/src/executors/release-publish/release-publish.impl.spec.ts
+++ b/packages/docker/src/executors/release-publish/release-publish.impl.spec.ts
@@ -1,0 +1,38 @@
+import type { ExecutorContext } from '@nx/devkit';
+import dockerReleasePublish from './release-publish.impl';
+
+describe('docker release-publish executor', () => {
+  it('skips publishing when release version data indicates no Docker version', async () => {
+    const warn = jest.spyOn(console, 'warn').mockImplementation();
+    const context = {
+      projectName: 'my-app',
+      projectGraph: {
+        nodes: {
+          'my-app': {
+            name: 'my-app',
+            type: 'app',
+            data: { root: 'apps/my-app' },
+          },
+        },
+      },
+    } as ExecutorContext;
+
+    await expect(
+      dockerReleasePublish(
+        {
+          nxReleaseVersionData: {
+            'my-app': {
+              currentVersion: '1.0.0',
+              newVersion: null,
+              dockerVersion: null,
+            },
+          },
+        },
+        context
+      )
+    ).resolves.toEqual({ success: true });
+    expect(warn).toHaveBeenCalledWith(
+      'Skipped Docker image for project "my-app", because no new Docker version was resolved for this project.'
+    );
+  });
+});

--- a/packages/docker/src/executors/release-publish/release-publish.impl.ts
+++ b/packages/docker/src/executors/release-publish/release-publish.impl.ts
@@ -22,8 +22,7 @@ export default async function dockerReleasePublish(
   schema: DockerReleasePublishSchema,
   context: ExecutorContext
 ) {
-  const projectVersionData =
-    schema.nxReleaseVersionData?.[context.projectName];
+  const projectVersionData = schema.nxReleaseVersionData?.[context.projectName];
   if (projectVersionData?.dockerVersion === null) {
     console.warn(
       `Skipped Docker image for project "${context.projectName}", because no new Docker version was resolved for this project.`

--- a/packages/docker/src/executors/release-publish/release-publish.impl.ts
+++ b/packages/docker/src/executors/release-publish/release-publish.impl.ts
@@ -22,6 +22,17 @@ export default async function dockerReleasePublish(
   schema: DockerReleasePublishSchema,
   context: ExecutorContext
 ) {
+  const projectVersionData =
+    schema.nxReleaseVersionData?.[context.projectName];
+  if (projectVersionData?.dockerVersion === null) {
+    console.warn(
+      `Skipped Docker image for project "${context.projectName}", because no new Docker version was resolved for this project.`
+    );
+    return {
+      success: true,
+    };
+  }
+
   const projectConfig = context.projectGraph.nodes[context.projectName];
   const options = await normalizeOptions(projectConfig, schema);
   if (!options.dryRun) {

--- a/packages/docker/src/executors/release-publish/schema.d.ts
+++ b/packages/docker/src/executors/release-publish/schema.d.ts
@@ -1,4 +1,13 @@
 export interface DockerReleasePublishSchema {
   dryRun?: boolean;
   quiet?: boolean;
+  nxReleaseVersionData?: Record<
+    string,
+    {
+      currentVersion: string | null;
+      newVersion: string | null;
+      dockerVersion: string | null;
+      [key: string]: any;
+    }
+  >;
 }

--- a/packages/docker/src/release/version-utils.spec.ts
+++ b/packages/docker/src/release/version-utils.spec.ts
@@ -78,6 +78,49 @@ describe('handleDockerVersion {versionActionsVersion} integration', () => {
     expect(newVersion).toBe('my-app-1.2.3');
   });
 
+  it('skips a project when the selected scheme requires a missing version actions version', async () => {
+    const finalConfigForProject: any = {
+      dockerOptions: {
+        repositoryName: 'repo',
+        registryUrl: undefined,
+        versionSchemes: { prod: '{versionActionsVersion}' },
+      },
+    };
+
+    const result = await handleDockerVersion(
+      process.cwd(),
+      mockProjectNode,
+      finalConfigForProject,
+      'prod'
+    );
+
+    expect(result).toEqual({
+      newVersion: null,
+      logs: [
+        'Skipped my-app, because no new version was resolved for this project.',
+      ],
+    });
+  });
+
+  it('still versions a project when its scheme does not require a version actions version', async () => {
+    const finalConfigForProject: any = {
+      dockerOptions: {
+        repositoryName: 'repo',
+        registryUrl: undefined,
+        versionSchemes: { prod: '{projectName}-latest' },
+      },
+    };
+
+    const { newVersion } = await handleDockerVersion(
+      process.cwd(),
+      mockProjectNode,
+      finalConfigForProject,
+      'prod'
+    );
+
+    expect(newVersion).toBe('my-app-latest');
+  });
+
   it('prompts for version scheme when multiple are available', async () => {
     const finalConfigForProject: any = {
       dockerOptions: {

--- a/packages/docker/src/release/version-utils.ts
+++ b/packages/docker/src/release/version-utils.ts
@@ -24,7 +24,7 @@ export async function handleDockerVersion(
   finalConfigForProject: FinalConfigForProject,
   dockerVersionScheme?: string,
   dockerVersion?: string,
-  versionActionsVersion?: string
+  versionActionsVersion?: string | null
 ) {
   // If the full docker image reference is provided, use it directly
   const nxDockerImageRefEnvOverride =
@@ -48,6 +48,19 @@ export async function handleDockerVersion(
                 availableVersionSchemes,
                 projectGraphNode.name
               );
+      if (
+        availableVersionSchemes[versionScheme].includes(
+          '{versionActionsVersion}'
+        ) &&
+        versionActionsVersion == null
+      ) {
+        return {
+          newVersion: null,
+          logs: [
+            `Skipped ${projectGraphNode.name}, because no new version was resolved for this project.`,
+          ],
+        };
+      }
       newVersion = calculateNewVersion(
         projectGraphNode.name,
         versionScheme,

--- a/packages/nx/src/command-line/release/version/release-group-processor.ts
+++ b/packages/nx/src/command-line/release/version/release-group-processor.ts
@@ -281,8 +281,8 @@ export class ReleaseGroupProcessor {
       finalConfigForProject: FinalConfigForProject,
       dockerVersionScheme?: string,
       dockerVersion?: string,
-      versionActionsVersion?: string
-    ) => Promise<{ newVersion: string; logs: string[] }>;
+      versionActionsVersion?: string | null
+    ) => Promise<{ newVersion: string | null; logs: string[] }>;
     try {
       const dockerVersionUtilsPath = '@nx/docker/release/version-utils';
       const { handleDockerVersion: _handleDockerVersion } = require(


### PR DESCRIPTION
## Current Behavior

Docker release schemes using `{versionActionsVersion}` attempt to tag unchanged projects with an empty Docker tag. Publishing then tries to read a Docker version file that was never validly produced.

## Expected Behavior

Projects are skipped when the selected Docker scheme requires a version-actions value but none was resolved. Date-, SHA-, explicit-, and Docker-only version flows continue to work without requiring a semantic version.

Focused verification covers both versioning and publishing boundaries: 2 Jest suites passed with 9 tests.

## Related Issue(s)

Fixes #34263
Fixes #33624
