### PR TITLE
fix(angular): keep buildable libraries private

### DIFF
--- a/e2e/release/src/release-publishable-libraries.test.ts
+++ b/e2e/release/src/release-publishable-libraries.test.ts
@@ -215,8 +215,12 @@ describe('release publishable libraries', () => {
     `);
   });
 
-  it('should be able to release publishable angular library', async () => {
+  it('should only release publishable angular libraries', async () => {
+    const angularBuildableLib = uniq('my-pkg-');
     const angularLib = uniq('my-pkg-');
+    runCLI(
+      `generate @nx/angular:lib packages/${angularBuildableLib} --buildable --importPath=@proj/${angularBuildableLib} --no-interactive`
+    );
     runCLI(
       `generate @nx/angular:lib packages/${angularLib} --publishable --importPath=@proj/${angularLib} --no-interactive`
     );
@@ -274,6 +278,10 @@ describe('release publishable libraries', () => {
       Critical path: {DURATION} (1 task)
       Recoverable time: {DURATION}
     `);
+
+    expect(() =>
+      execSync(`npm view @proj/${angularBuildableLib} version`)
+    ).toThrow(/npm (ERR!|error) code E404/);
   });
 
   it('should be able to release publishable vue library', async () => {

--- a/packages/angular/src/generators/library/lib/create-files.ts
+++ b/packages/angular/src/generators/library/lib/create-files.ts
@@ -4,6 +4,7 @@ import {
   joinPathFragments,
   names,
   offsetFromRoot,
+  updateJson,
 } from '@nx/devkit';
 import { getRootTsConfigFileName } from '@nx/js';
 import { getProjectSourceRoot } from '@nx/js/internal';
@@ -63,6 +64,14 @@ export function createFiles(
     options.libraryOptions.projectRoot,
     substitutions
   );
+
+  if (options.libraryOptions.buildable && !options.libraryOptions.publishable) {
+    updateJson(
+      tree,
+      joinPathFragments(options.libraryOptions.projectRoot, 'package.json'),
+      (json) => ({ ...json, private: true })
+    );
+  }
 
   if (options.libraryOptions.standalone) {
     generateFiles(

--- a/packages/angular/src/generators/library/library.spec.ts
+++ b/packages/angular/src/generators/library/library.spec.ts
@@ -195,6 +195,9 @@ describe('lib', () => {
       expect(packageJson.devDependencies['ng-packagr']).toBeDefined();
       expect(packageJson.devDependencies['postcss']).toBeDefined();
       expect(packageJson.devDependencies['autoprefixer']).toBeDefined();
+
+      const libPackageJson = readJson(tree, 'my-lib/package.json');
+      expect(libPackageJson.private).toBeUndefined();
     });
 
     it('should update package.json when buildable', async () => {
@@ -209,6 +212,7 @@ describe('lib', () => {
 
       const libPackageJson = readJson(tree, 'my-lib/package.json');
       expect(libPackageJson.dependencies?.['tslib']).toBeFalsy();
+      expect(libPackageJson.private).toBe(true);
     });
 
     it('should create project configuration', async () => {


### PR DESCRIPTION
## Current Behavior

Angular libraries generated with `--buildable` receive a source-level `package.json` without `"private": true`. Nx Release therefore discovers them as public packages and infers an `nx-release-publish` target rooted at the source project, which can publish source files even though the library was not generated with `--publishable`.

## Expected Behavior

Buildable-only Angular libraries are generated as private and are excluded from default release and publish discovery. Libraries generated with `--publishable` remain public and continue publishing their compiled output from `dist/{projectRoot}`.

## Related Issue(s)

Fixes #34004