### PR TITLE
fix(angular-rspack): stop builds crashing on non-array styleUrls

### DIFF
--- a/packages/angular-rspack-compiler/package.json
+++ b/packages/angular-rspack-compiler/package.json
@@ -46,7 +46,6 @@
     "@nx/devkit": "workspace:*",
     "sass-embedded": "catalog:css",
     "semver": "catalog:",
-    "ts-morph": "catalog:typescript",
     "tslib": "catalog:typescript",
     "typescript": "catalog:typescript"
   },

--- a/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.ts
@@ -164,8 +164,9 @@ export async function setupCompilationWithAngularCompilation(
 
   // The compiler already tracks each source file's template and stylesheet
   // dependencies; re-key them like the emit cache so loaders can register
-  // watch dependencies without re-parsing sources. AOT only: JIT compilations
-  // do not report them and fall back to the URL resolvers.
+  // watch dependencies without re-parsing sources. JIT compilations do not
+  // report them, and neither does @angular/build 20 in any mode, so both fall
+  // back to the URL resolvers.
   let resourceDependencies: Map<string, readonly string[]> | undefined;
   if (componentResourcesDependencies) {
     resourceDependencies = new Map();

--- a/packages/angular-rspack-compiler/src/utils/component-resolvers.spec.ts
+++ b/packages/angular-rspack-compiler/src/utils/component-resolvers.spec.ts
@@ -1,4 +1,11 @@
 import { describe, expect, it, vi } from 'vitest';
+import * as ts from 'typescript';
+
+vi.mock('typescript', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('typescript')>();
+  return { ...actual, createSourceFile: vi.fn(actual.createSourceFile) };
+});
+
 import {
   getStyleUrls,
   getTemplateUrls,
@@ -48,6 +55,115 @@ describe('getStyleUrls', () => {
       export class ButtonComponent {}
       `;
     expect(getStyleUrls(code)).toStrictEqual([]);
+  });
+
+  // Angular's own resolver only reads array literals, so nothing else is
+  // treated as a list of style URLs.
+  it.each([
+    ['an identifier', 'SHARED_STYLES'],
+    ['a conditional', `isDark ? ['dark.scss'] : ['light.scss']`],
+    ['a call expression', 'getSharedStyles()'],
+    ['a property access', 'CONFIG.styles'],
+    ['a const assertion', `['color.scss'] as const`],
+    ['a satisfies expression', `['color.scss'] satisfies string[]`],
+    ['a string literal', `'color.scss'`],
+    ['a method call on an array', `[...SHARED_STYLES].concat('color.scss')`],
+  ])(
+    'should return empty array when styleUrls is %s',
+    (_description, initializer) => {
+      const code = `
+      @Component({
+        styleUrls: ${initializer},
+      })
+      export class ButtonComponent {}
+      `;
+      expect(() => getStyleUrls(code)).not.toThrow();
+      expect(getStyleUrls(code)).toStrictEqual([]);
+    }
+  );
+
+  it.each([
+    ['single-quoted', `'styleUrls'`],
+    ['double-quoted', `"styleUrls"`],
+  ])('should include values from a %s styleUrls key', (_description, key) => {
+    const code = `
+      @Component({
+        ${key}: ['color.scss'],
+      })
+      export class ButtonComponent {}
+      `;
+    expect(getStyleUrls(code)).toStrictEqual(['color.scss']);
+  });
+
+  it('should include values from a quoted styleUrl key', () => {
+    const code = `
+      @Component({
+        'styleUrl': 'theme.scss',
+      })
+      export class ButtonComponent {}
+      `;
+    expect(getStyleUrls(code)).toStrictEqual(['theme.scss']);
+  });
+
+  it('should ignore a computed styleUrls key', () => {
+    const code = `
+      @Component({
+        ['styleUrls']: ['color.scss'],
+      })
+      export class ButtonComponent {}
+      `;
+    expect(getStyleUrls(code)).toStrictEqual([]);
+  });
+
+  it.each([
+    ['a non-literal element', `[SHARED, 'color.scss']`],
+    ['an empty element', `['', 'color.scss']`],
+    ['a spread element', `[...SHARED, 'color.scss']`],
+    ['a substituted template literal', '[`./${theme}.scss`, `color.scss`]'],
+  ])('should skip %s in styleUrls', (_description, initializer) => {
+    const code = `
+      @Component({
+        styleUrls: ${initializer},
+      })
+      export class ButtonComponent {}
+      `;
+    expect(getStyleUrls(code)).toStrictEqual(['color.scss']);
+  });
+
+  it.each([
+    ['an identifier', 'SHARED_STYLE'],
+    ['an empty string', `''`],
+    ['a substituted template literal', '`./${theme}.scss`'],
+  ])('should ignore styleUrl when it is %s', (_description, initializer) => {
+    const code = `
+      @Component({
+        styleUrl: ${initializer},
+      })
+      export class ButtonComponent {}
+      `;
+    expect(getStyleUrls(code)).toStrictEqual([]);
+  });
+
+  it('should keep quotes that are part of the file name', () => {
+    const code = `
+      @Component({
+        styleUrl: "d'accord.scss",
+      })
+      export class ButtonComponent {}
+      `;
+    expect(getStyleUrls(code)).toStrictEqual([`d'accord.scss`]);
+  });
+
+  it('should return a new array on every call', () => {
+    const code = `
+      @Component({
+        styleUrls: ['color.scss'],
+      })
+      export class ButtonComponent {}
+      `;
+    getStyleUrls(code).push('mutated.scss');
+
+    expect(getStyleUrls(code)).toStrictEqual(['color.scss']);
   });
 });
 
@@ -116,6 +232,85 @@ describe('getTemplateUrls', () => {
       export class ButtonComponent {}
       `;
     expect(getTemplateUrls(code)).toStrictEqual([]);
+  });
+
+  it.each([
+    ['an identifier', 'TEMPLATE'],
+    ['an empty string', `''`],
+    ['a substituted template literal', '`./${name}.html`'],
+    ['a call expression', 'getTemplate()'],
+  ])('should ignore templateUrl when it is %s', (_description, initializer) => {
+    const code = `
+      @Component({
+        templateUrl: ${initializer},
+      })
+      export class ButtonComponent {}
+      `;
+    expect(getTemplateUrls(code)).toStrictEqual([]);
+  });
+
+  it('should read a templateUrl written as a template literal', () => {
+    const code = `
+      @Component({
+        templateUrl: \`button.component.html\`,
+      })
+      export class ButtonComponent {}
+      `;
+    expect(getTemplateUrls(code)).toStrictEqual(['button.component.html']);
+  });
+
+  it('should include values from a quoted templateUrl key', () => {
+    const code = `
+      @Component({
+        'templateUrl': 'button.component.html',
+      })
+      export class ButtonComponent {}
+      `;
+    expect(getTemplateUrls(code)).toStrictEqual(['button.component.html']);
+  });
+});
+
+describe('shared parse', () => {
+  it('should parse the code once when both resolvers read it', () => {
+    // unique source so the memo cannot already hold it from an earlier test
+    const code = `
+      @Component({
+        templateUrl: 'shared-parse.component.html',
+        styleUrls: ['shared-parse.component.scss'],
+      })
+      export class SharedParseComponent {}
+      `;
+    vi.mocked(ts.createSourceFile).mockClear();
+
+    getStyleUrls(code);
+    getTemplateUrls(code);
+
+    expect(ts.createSourceFile).toHaveBeenCalledTimes(1);
+  });
+
+  it('should give each resolver its own result for the same code', () => {
+    const code = `
+      @Component({
+        templateUrl: 'button.component.html',
+        styleUrls: ['color.scss'],
+      })
+      export class ButtonComponent {}
+      `;
+
+    expect(getStyleUrls(code)).toStrictEqual(['color.scss']);
+    expect(getTemplateUrls(code)).toStrictEqual(['button.component.html']);
+  });
+
+  it('should return a new array from getTemplateUrls on every call', () => {
+    const code = `
+      @Component({
+        templateUrl: 'button.component.html',
+      })
+      export class ButtonComponent {}
+      `;
+    getTemplateUrls(code).push('mutated.html');
+
+    expect(getTemplateUrls(code)).toStrictEqual(['button.component.html']);
   });
 });
 

--- a/packages/angular-rspack-compiler/src/utils/component-resolvers.ts
+++ b/packages/angular-rspack-compiler/src/utils/component-resolvers.ts
@@ -24,9 +24,8 @@
  */
 
 import { dirname, resolve } from 'node:path';
-import { Project, SyntaxKind } from 'ts-morph';
+import * as ts from 'typescript';
 import { normalize } from 'path';
-import { getAllTextByProperty, getTextByProperty } from './utils';
 
 interface StyleUrlsCacheEntry {
   matchedStyleUrls: string[];
@@ -34,23 +33,10 @@ interface StyleUrlsCacheEntry {
 }
 
 export class StyleUrlsResolver {
-  // These resolvers may be called multiple times during the same
-  // compilation for the same files. Caching is required because these
-  // resolvers use synchronous system calls to the filesystem, which can
-  // degrade performance when running compilations for multiple files.
   private readonly styleUrlsCache = new Map<string, StyleUrlsCacheEntry>();
 
   resolve(code: string, id: string): string[] {
-    // Given the code is the following:
-    // @Component({
-    //   styleUrls: [
-    //     './app.component.scss'
-    //   ]
-    // })
-    // The `matchedStyleUrls` would result in: `styleUrls: [\n    './app.component.scss'\n  ]`.
-    const matchedStyleUrls = getStyleUrls(code)
-      // for type narrowing
-      .filter((v) => v !== undefined);
+    const matchedStyleUrls = getStyleUrls(code);
     const entry = this.styleUrlsCache.get(id);
     // We're using `matchedStyleUrls` as a key because the code may be changing continuously,
     // resulting in the resolver being called multiple times. While the code changes, the
@@ -72,24 +58,91 @@ export class StyleUrlsResolver {
   }
 }
 
-export function getStyleUrls(code: string) {
-  const project = new Project({ useInMemoryFileSystem: true });
-  const sourceFile = project.createSourceFile('cmp.ts', code);
-  const properties = sourceFile.getDescendantsOfKind(
-    SyntaxKind.PropertyAssignment
+// readonly so a caller cannot mutate the memoized arrays out from under the
+// next caller
+interface ComponentResources {
+  readonly styleUrl: readonly string[];
+  readonly styleUrls: readonly string[];
+  readonly templateUrl: readonly string[];
+}
+
+let lastScan: { code: string; resources: ComponentResources } | undefined;
+
+// These resolvers run only when the Angular compilation did not report the
+// component's resource dependencies, so they follow @angular/build's JIT
+// resource transformer: a resource becomes a module only when its URL is a
+// plain string literal, and anything else names no file to watch. Empty is
+// skipped for all three properties because it resolves to the component's own
+// directory rather than a file; Angular skips it for `templateUrl` and
+// `styleUrls` entries but not for `styleUrl`.
+function collectUrl(urls: string[], node: ts.Expression): void {
+  if (ts.isStringLiteralLike(node) && node.text) {
+    urls.push(node.text);
+  }
+}
+
+// Both resolvers run back to back on the same source in the rspack loader, so
+// the last scan is memoized to parse each file once instead of twice.
+function scanComponentResources(code: string): ComponentResources {
+  if (lastScan !== undefined && lastScan.code === code) {
+    return lastScan.resources;
+  }
+
+  const sourceFile = ts.createSourceFile(
+    'cmp.ts',
+    code,
+    ts.ScriptTarget.Latest,
+    // parent pointers are unused: every value below is read off the node itself
+    false,
+    ts.ScriptKind.TS
   );
-  const styleUrl = getTextByProperty('styleUrl', properties);
-  const styleUrls = getAllTextByProperty('styleUrls', properties);
+  const styleUrl: string[] = [];
+  const styleUrls: string[] = [];
+  const templateUrl: string[] = [];
+
+  // Every property assignment in the file is considered, not just the ones in a
+  // @Component decorator: Angular identifies that decorator by resolving its
+  // symbol to @angular/core, which needs a type checker this parse has no
+  // program for.
+  const visit = (node: ts.Node): void => {
+    if (
+      ts.isPropertyAssignment(node) &&
+      // identifier and quoted keys name the same property, computed ones are
+      // dropped, matching how Angular reflects @Component metadata
+      (ts.isIdentifier(node.name) || ts.isStringLiteral(node.name))
+    ) {
+      const name = node.name.text;
+      if (name === 'styleUrl') {
+        collectUrl(styleUrl, node.initializer);
+      } else if (name === 'templateUrl') {
+        collectUrl(templateUrl, node.initializer);
+      } else if (
+        name === 'styleUrls' &&
+        ts.isArrayLiteralExpression(node.initializer)
+      ) {
+        for (const element of node.initializer.elements) {
+          collectUrl(styleUrls, element);
+        }
+      }
+    }
+    ts.forEachChild(node, visit);
+  };
+  ts.forEachChild(sourceFile, visit);
+
+  const resources: ComponentResources = { styleUrl, styleUrls, templateUrl };
+  lastScan = { code, resources };
+  return resources;
+}
+
+// the explicit return types keep the memoized `readonly string[]` arrays from
+// being handed to callers unspread
+export function getStyleUrls(code: string): string[] {
+  const { styleUrl, styleUrls } = scanComponentResources(code);
   return [...styleUrls, ...styleUrl];
 }
 
-export function getTemplateUrls(code: string) {
-  const project = new Project({ useInMemoryFileSystem: true });
-  const sourceFile = project.createSourceFile('cmp.ts', code);
-  const properties = sourceFile.getDescendantsOfKind(
-    SyntaxKind.PropertyAssignment
-  );
-  return getTextByProperty('templateUrl', properties);
+export function getTemplateUrls(code: string): string[] {
+  return [...scanComponentResources(code).templateUrl];
 }
 
 export interface TemplateUrlsCacheEntry {

--- a/packages/angular-rspack-compiler/src/utils/utils.spec.ts
+++ b/packages/angular-rspack-compiler/src/utils/utils.spec.ts
@@ -3,7 +3,6 @@ import {
   isPresent,
   isUsingWindows,
   maxWorkers,
-  normalizeQuotes,
   parseMaxWorkers,
 } from './utils';
 import * as nodeOSModule from 'node:os';
@@ -94,12 +93,6 @@ describe('maxWorkers', () => {
 
     expect(maxWorkers()).toBe(4); // Min(4, max(availableParallelism - 1, 1))
     expect(availableParallelismSpy).toHaveBeenCalledTimes(1);
-  });
-});
-
-describe('normalizeQuotes', () => {
-  it.each(["'", '"', '`'])('should remove (%s) quotes if given', (quote) => {
-    expect(normalizeQuotes(`${quote}test${quote}`)).toBe('test');
   });
 });
 

--- a/packages/angular-rspack-compiler/src/utils/utils.ts
+++ b/packages/angular-rspack-compiler/src/utils/utils.ts
@@ -1,34 +1,7 @@
 import { availableParallelism, platform } from 'node:os';
-import { ArrayLiteralExpression, PropertyAssignment } from 'ts-morph';
 import { ENV_NG_BUILD_MAX_WORKERS } from './constants';
 
 export const isUsingWindows = () => platform() === 'win32';
-
-export function getTextByProperty(
-  name: string,
-  properties: PropertyAssignment[]
-) {
-  return properties
-    .filter((property) => property.getName() === name)
-    .map((property) => normalizeQuotes(property.getInitializer()?.getText()))
-    .filter((url): url is string => url !== undefined);
-}
-
-export function getAllTextByProperty(
-  name: string,
-  properties: PropertyAssignment[]
-) {
-  return properties
-    .filter((property) => property.getName() === name)
-    .map((property) => property.getInitializer() as ArrayLiteralExpression)
-    .flatMap((array) =>
-      array.getElements().map((el) => normalizeQuotes(el.getText()))
-    );
-}
-
-export function normalizeQuotes(str?: string) {
-  return str ? str.replace(/['"`]/g, '') : str;
-}
 
 export function isPresent(variable: string | undefined): variable is string {
   return typeof variable === 'string' && variable.trim() !== '';

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -334,9 +334,6 @@ catalogs:
     '@types/node':
       specifier: ^24.11.0
       version: 24.12.2
-    ts-morph:
-      specifier: ^28.0.0
-      version: 28.0.0
     ts-node:
       specifier: 10.9.1
       version: 10.9.1
@@ -2351,9 +2348,6 @@ importers:
       semver:
         specifier: 'catalog:'
         version: 7.8.4
-      ts-morph:
-        specifier: catalog:typescript
-        version: 28.0.0
       tslib:
         specifier: catalog:typescript
         version: 2.8.1
@@ -13771,9 +13765,6 @@ packages:
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
     engines: {node: '>=10.13.0'}
 
-  '@ts-morph/common@0.29.0':
-    resolution: {integrity: sha512-35oUmphHbJvQ/+UTwFNme/t2p3FoKiGJ5auTjjpNTop2dyREspirjMy82PLSC1pnDJ8ah1GU98hwpVt64YXQsg==}
-
   '@tsconfig/node10@1.0.11':
     resolution: {integrity: sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==}
 
@@ -16338,9 +16329,6 @@ packages:
     resolution: {integrity: sha512-QVb0dM5HvG+uaxitm8wONl7jltx8dqhfU33DcqtOZcLSVIKSDDLDi7+0LbAKiyI8hD9u42m2YxXSkMGWThaecQ==}
     engines: {iojs: '>= 1.0.0', node: '>= 0.12.0'}
 
-  code-block-writer@13.0.3:
-    resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
-
   collapse-white-space@2.1.0:
     resolution: {integrity: sha512-loKTxY1zCOuG4j9f6EPnuyyYkf58RnhhWTvRoZEokgB+WbdXehfjFviyOVYkqzEWz1Q5kRiZdBYS5SwxbQYwzw==}
 
@@ -16677,6 +16665,7 @@ packages:
   cron-parser@4.9.0:
     resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
     engines: {node: '>=12.0.0'}
+    deprecated: v4 is no longer maintained, upgrade to v5
 
   croner@10.0.1:
     resolution: {integrity: sha512-ixNtAJndqh173VQ4KodSdJEI6nuioBWI0V1ITNKhZZsO0pEMoDxz539T4FTTbSZ/xIOSuDnzxLVRqBVSvPNE2g==}
@@ -25638,9 +25627,6 @@ packages:
     peerDependenciesMeta:
       loader-utils:
         optional: true
-
-  ts-morph@28.0.0:
-    resolution: {integrity: sha512-Wp3tnZ2bzwxyTZMtgWVzXDfm7lB1Drz+y9DmmYH/L702PQhPyVrp3pkou3yIz4qjS14GY9kcpmLiOOMvl8oG1g==}
 
   ts-node@10.9.1:
     resolution: {integrity: sha512-NtVysVPkxxrwFGUUxGYhfux8k78pQB3JqYBXlLRZgdGUqTO5wU/UyHop5p70iEbGhB7q5KmiZiU0Y3KlJrScEw==}
@@ -37511,7 +37497,7 @@ snapshots:
       metro: 0.84.4
       metro-config: 0.84.4
       metro-core: 0.84.4
-      semver: 7.8.4
+      semver: 7.8.5
     transitivePeerDependencies:
       - bufferutil
       - supports-color
@@ -39095,9 +39081,9 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  '@sveltejs/acorn-typescript@1.0.9(acorn@8.16.0)':
+  '@sveltejs/acorn-typescript@1.0.9(acorn@8.18.0)':
     dependencies:
-      acorn: 8.16.0
+      acorn: 8.18.0
 
   '@svgr/babel-plugin-add-jsx-attribute@8.0.0(@babel/core@7.29.0)':
     dependencies:
@@ -39589,12 +39575,6 @@ snapshots:
   '@tokenizer/token@0.3.0': {}
 
   '@trysound/sax@0.2.0': {}
-
-  '@ts-morph/common@0.29.0':
-    dependencies:
-      minimatch: 10.2.5
-      path-browserify: 1.0.1
-      tinyglobby: 0.2.16
 
   '@tsconfig/node10@1.0.11': {}
 
@@ -43091,8 +43071,6 @@ snapshots:
   cluster-key-slot@1.1.1: {}
 
   co@4.6.0: {}
-
-  code-block-writer@13.0.3: {}
 
   collapse-white-space@2.1.0: {}
 
@@ -53732,9 +53710,9 @@ snapshots:
       react-refresh: 0.14.2
       regenerator-runtime: 0.13.7
       scheduler: 0.27.0
-      semver: 7.8.4
+      semver: 7.8.5
       stacktrace-parser: 0.1.11
-      tinyglobby: 0.2.16
+      tinyglobby: 0.2.17
       whatwg-fetch: 3.6.20
       ws: 7.5.10
       yargs: 17.7.2
@@ -55831,9 +55809,9 @@ snapshots:
     dependencies:
       '@ampproject/remapping': 2.3.0
       '@jridgewell/sourcemap-codec': 1.5.5
-      '@sveltejs/acorn-typescript': 1.0.9(acorn@8.16.0)
+      '@sveltejs/acorn-typescript': 1.0.9(acorn@8.18.0)
       '@types/estree': 1.0.8
-      acorn: 8.16.0
+      acorn: 8.18.0
       aria-query: 5.3.2
       axobject-query: 4.1.0
       clsx: 2.1.1
@@ -56378,11 +56356,6 @@ snapshots:
       webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@7.0.3)
     optionalDependencies:
       loader-utils: 2.0.3
-
-  ts-morph@28.0.0:
-    dependencies:
-      '@ts-morph/common': 0.29.0
-      code-block-writer: 13.0.3
 
   ts-node@10.9.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(@types/node@24.12.2)(typescript@6.0.3):
     dependencies:

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -151,7 +151,6 @@ catalogs:
   typescript:
     '@phenomnomnominal/tsquery': '~6.2.0'
     '@types/node': '^24.11.0'
-    ts-morph: '^28.0.0'
     ts-node: '10.9.1'
     tsconfig-paths: '^4.1.2'
     tslib: '^2.3.0'


### PR DESCRIPTION
## Current Behavior

`@nx/angular-rspack-compiler` scrapes component `templateUrl`, `styleUrl` and `styleUrls` out of the source with `ts-morph` to register watch dependencies. Three problems:

1. `getAllTextByProperty` casts any `styleUrls` initializer to `ArrayLiteralExpression` and calls `.getElements()` on it. A `styleUrls` that is not an array literal (an identifier, a call, a conditional, `as const`, `satisfies`) throws `TypeError: array.getElements is not a function` inside a loader with no `try`/`catch`, failing the build. The scraper runs whenever the Angular compilation reported no resource dependencies, which is `aot: false` on any supported major plus every build on Angular 20, since `@angular/build` 20 never reports them.
2. The extracted URLs diverge from what Angular treats as a resource: a quoted key (`'styleUrls': [...]`) is ignored, non-literal elements and empty strings become URLs, and quotes are stripped from anywhere in the value, so `"d'accord.scss"` becomes `daccord.scss`.
3. `ts-morph` bundles its own TypeScript, so the package ships a second parser, and each file is parsed twice because the two resolvers run independently.

## Expected Behavior

The resolvers use the TypeScript compiler API, follow Angular's own rules, and parse each file once.

- No crash. A `styleUrls` that is not an array literal contributes no URLs.
- No dependency added: `typescript` is already a direct dependency, and `@angular/build` implements these rules against the same API. Dropping `ts-morph` takes its whole tree with it, which installed on its own is 10 packages and ~15 MB, 8.7 MB of that the TypeScript copy bundled in `@ts-morph/common`.
- Extraction matches `@angular/build`'s JIT resource transformer (`visitComponentMetadata`), checked against a transcription of it over 900 repo sources: 900/900 identical.

Behavior changes, all in the direction of not registering a dependency on a file that cannot exist:

| input | before | after |
| --- | --- | --- |
| `'styleUrls': ['a.scss']` (quoted key) | `[]` | `['a.scss']` |
| `styleUrls: SHARED` | throws | `[]` |
| `styleUrls: [SHARED, 'a.scss']` | `['SHARED', 'a.scss']` | `['a.scss']` |
| `styleUrls: ['', 'a.scss']` | `['', 'a.scss']` | `['a.scss']` |
| `templateUrl: CONST` | `['CONST']` | `[]` |
| `templateUrl: ''` | `['']` | `[]` |
| `templateUrl` as a substituted template literal | the raw source text | `[]` |
| `styleUrl: "d'accord.scss"` | `['daccord.scss']` | `["d'accord.scss"]` |

One deliberate deviation: Angular's `styleUrl` branch has no empty-string check while `templateUrl` and `styleUrls` entries do. We skip empty for all three, because an empty URL resolves to the component's own directory, which is not a file dependency.

`getStyleUrls` and `getTemplateUrls` are exported, so the extraction change is visible to external callers.

### Performance

Both resolvers per file in the loader's call order, median of 7 on node 26.3.0 and typescript 6.0.3:

| corpus | path | before | after | |
| --- | --- | --- | --- | --- |
| 900 repo TS files | cold | 1068.9 ms | 177.5 ms | 6.0x |
| 900 repo TS files | warm | 523.7 ms | 176.4 ms | 3.0x |
| 200 generated components | cold | 54.0 ms | 5.8 ms | 9.3x |
| 200 generated components | warm | 27.0 ms | 5.5 ms | 4.9x |

Cold is a first build or a changed file. Warm is a rebuild where `TemplateUrlsResolver` returns from its cache, but `StyleUrlsResolver` calls `getStyleUrls` before consulting its own, so one parse per file remains on both sides. The parser swap accounts for the 3.0x and applies on both paths; the shared parse doubles it, and is what the warm path gives up. Output is no longer identical on both sides, per the table above, so this compares two behaviors rather than one behavior twice.

### Known gaps

Both follow from parsing one file with no program, which is how these resolvers already worked. Neither is introduced or widened here, and closing either needs a type checker this path does not have.

- **No `@Component` gate.** Every property assignment is scanned, so an unrelated `{ path: 'a', templateUrl: 'admin/list.html' }` also registers a dependency. Angular resolves the decorator symbol to `@angular/core`; matching the name instead would miss an aliased import and drop a watch dependency that is real, a worse failure than the spurious one it removes. Narrowed here anyway, since non-literal values no longer produce URLs.
- **Angular 20 AOT.** No 20.x release reports `componentResourcesDependencies`, checked through 20.3.32, so these resolvers serve AOT builds there as well, where the compiler partially evaluates `templateUrl: CONST` and bundles a template this scan cannot see. Following that constant means partial evaluation without a program. Before this change the URL registered a phantom path, so the real file went unwatched either way, and the gap ages out with Angular 20.

### Note on the lockfile

The diff also re-points a few floating ranges (`semver`, `acorn`, `tinyglobby`). A clean tree reinstalls to a zero-line diff, so that is pnpm re-resolving on a manifest change, not pre-existing staleness.

## Related Issue(s)

NXC-4754

<!-- polygraph-session-start -->
---
<p><picture><source media="(prefers-color-scheme: dark)" srcset="https://static.ops.cloud.nx.app/polygraph/session-logo-v4-dark.svg"><img src="https://static.ops.cloud.nx.app/polygraph/session-logo-v4-light.svg" width="16" height="22" align="middle" alt="Polygraph"></picture> <a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/nxc-4754-83d60770">View session ↗</a></p>
<!-- polygraph-session-end -->
