### PR TITLE
fix(core): normalize resolved module paths

### DIFF
--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.spec.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.spec.ts
@@ -1024,6 +1024,33 @@ describe('TargetProjectLocator', () => {
       expect(result2).toEqual('@org/proj1');
     });
 
+    it('should not match Windows node_modules paths to the workspace root project', () => {
+      const targetProjectLocator = new TargetProjectLocator(
+        {
+          ...projects,
+          root: {
+            name: 'root',
+            type: 'app',
+            data: {
+              root: '.',
+            },
+          },
+        },
+        {}
+      );
+
+      jest
+        .spyOn(targetProjectLocator as any, 'resolveImportWithRequire')
+        .mockReturnValue('node_modules\\external-package\\index.js');
+
+      const result = targetProjectLocator.findProjectFromImport(
+        'external-package',
+        'libs/proj1/index.ts'
+      );
+
+      expect(result).toBeUndefined();
+    });
+
     it('should be able to npm dependencies', () => {
       const result1 = targetProjectLocator.findProjectFromImport(
         '@ng/core',

--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.spec.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.spec.ts
@@ -1049,6 +1049,11 @@ describe('TargetProjectLocator', () => {
       );
 
       expect(result).toBeUndefined();
+      expect(
+        (targetProjectLocator as any).findProjectOfResolvedModule(
+          '..\\..\\node_modules\\external-package\\index.js'
+        )
+      ).toBeUndefined();
     });
 
     it('should be able to npm dependencies', () => {

--- a/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.ts
+++ b/packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.ts
@@ -12,6 +12,7 @@ import {
 import { isRelativePath, readJsonFile } from '../../../../utils/fileutils';
 import { getPackageNameFromImportPath } from '../../../../utils/get-package-name-from-import-path';
 import type { PackageJson } from '../../../../utils/package-json';
+import { normalizePath } from '../../../../utils/path';
 import { workspaceRoot } from '../../../../utils/workspace-root';
 import {
   getWorkspacePackagesMetadata,
@@ -506,6 +507,7 @@ export class TargetProjectLocator {
   private findProjectOfResolvedModule(
     resolvedModule: string
   ): string | undefined {
+    resolvedModule = normalizePath(resolvedModule);
     if (
       resolvedModule.startsWith('node_modules/') ||
       resolvedModule.includes('/node_modules/')


### PR DESCRIPTION
## Current Behavior

On Windows, `resolveImportWithRequire` can return a workspace-relative path containing backslashes, such as `node_modules\\vue\\index.js`.

`findProjectOfResolvedModule` only checked for POSIX `node_modules/` separators before matching the path to a workspace project. When the workspace root is also a project node, that Windows-style external module path can walk up to `.` and be misclassified as the root project.

## Expected Behavior

Resolved module paths should be separator-normalized before the `node_modules` guard runs, so external package paths are ignored consistently on Windows and POSIX.

## Related Issue(s)

Fixes #36549

## Tests

- `./node_modules/.bin/jest --config packages/nx/jest.config.cts packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.spec.ts -t "Windows node_modules" --runInBand`
- `./node_modules/.bin/jest --config packages/nx/jest.config.cts packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.spec.ts --runInBand`
- `./node_modules/.bin/prettier --check packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.ts packages/nx/src/plugins/js/project-graph/build-dependencies/target-project-locator.spec.ts`
- `git diff --check`

## AI assistance disclosure

Codex via Jeeves assisted with implementation and local verification; Harsh reviewed and submitted the PR from his account.
