### PR TITLE
chore(repo): put the mise shims on PATH for the review-pr workspace install

### DIFF
--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -130,15 +130,22 @@ docker exec "$CONTAINER" bash -lc '
 # cwd must sit under a mise.toml or the shims report "No version is set for shim: npm".
 # No `mise trust` needed: the image sets MISE_YES=1, which auto-trusts the PR's mise.toml on first
 # use. Without it, a PR that edits mise.toml fails with "Config files ... are not trusted".
+# The PATH export is required, exactly as in every other docker exec here: `bash -lc` does not put
+# the mise shims on PATH by itself, so without it `pnpm` is not found and this reports FAILED for a
+# reason that has nothing to do with the PR.
 docker exec "$CONTAINER" bash -lc '
+  export PATH="/root/.local/bin:/root/.local/share/mise/shims:$PATH"
   cd /work/nx
   mise install >/dev/null 2>&1                    # installs any tool version the PR bumped
-  if   pnpm install --frozen-lockfile >/dev/null 2>&1; then
+  if   pnpm install --frozen-lockfile >/tmp/install.log 2>&1; then
     echo "workspace install OK"
-  elif pnpm install >/dev/null 2>&1; then
+  elif pnpm install >>/tmp/install.log 2>&1; then
     echo "workspace install OK — but only WITHOUT --frozen-lockfile: the lockfile is out of sync with package.json (a review signal; note it)"
   else
+    # Print the cause. A bare "FAILED" sends you diagnosing the PR when the fault is usually the
+    # environment, and the log is inside a container that Step 9 destroys.
     echo "workspace install FAILED — agents cannot run tests or the repo eslint"
+    tail -20 /tmp/install.log
   fi
 '
 ```


### PR DESCRIPTION
## Current Behavior

Step 3 of the `review-pr` skill installs the workspace once, up front, so the review agents can run tests, mutate sources to prove a test can fail, and execute the repo's own eslint and tsc.

That block is the **only** `docker exec` in the skill without the mise PATH export that every other one carries:

```bash
docker exec "$CONTAINER" bash -lc '
  cd /work/nx
  mise install >/dev/null 2>&1
  if   pnpm install --frozen-lockfile >/dev/null 2>&1; then
```

`bash -lc` does not put the mise shims on `PATH` by itself, so `pnpm` is not found and the block falls through to:

```
workspace install FAILED — agents cannot run tests or the repo eslint
```

That message reads as a problem with the PR being reviewed. It isn't — the real error is `pnpm: command not found`, and it is invisible because all three branches redirect to `/dev/null`.

The consequence is not just a confusing message. The skill's own guidance on a failed install is to tell the agents the workspace is unavailable and restrict them to reading, so a whole review silently degrades to a read-only pass with no one noticing why.

Observed on a real run of the skill against #36370.

## Expected Behavior

The install block exports `PATH` exactly like every other `docker exec` in the skill, so `pnpm` resolves and the install actually runs.

Verified in a `nx-review-sandbox` container, running the shipped bytes both ways:

| | `pnpm --version` |
| --- | --- |
| without the export (as shipped) | `bash: line 3: pnpm: command not found` |
| with the export (this change) | `11.20.0` |

Install output now also goes to a log whose tail is printed on failure. The log lives inside a container that Step 9 destroys, so a bare "FAILED" previously left nothing to diagnose from — which is exactly what made this take two runs to spot.

Documentation-only change to a `.claude/skills` file. No product code, no tests affected.

## Related Issue(s)

None — found while running the skill.

<!-- polygraph-session-start -->
---
<p><picture><source media="(prefers-color-scheme: dark)" srcset="https://static.ops.cloud.nx.app/polygraph/session-logo-v4-dark.svg"><img src="https://static.ops.cloud.nx.app/polygraph/session-logo-v4-light.svg" width="16" height="22" align="middle" alt="Polygraph"></picture> <a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Fix-review-pr-skills-workspace-install-missing-the-mise-PATH-export-7640b31d">View session ↗</a></p>
<!-- polygraph-session-end -->