### PR TITLE
fix(js): do not report non-composite projects as missing root references

### DIFF
--- a/packages/js/src/generators/typescript-sync/typescript-sync.spec.ts
+++ b/packages/js/src/generators/typescript-sync/typescript-sync.spec.ts
@@ -225,6 +225,27 @@ describe('syncGenerator()', () => {
       `);
     });
 
+    it('should not report a non-composite project as a missing reference', async () => {
+      addProject('not-composite', [], [], 'packages/not-composite');
+      writeJson(tree, 'packages/not-composite/tsconfig.json', {
+        compilerOptions: {},
+      });
+
+      const result = await syncGenerator(tree);
+
+      // It is dropped before writing, so it must never be named as a reason
+      // the workspace is out of sync.
+      expect((result as any).outOfSyncDetails).toStrictEqual([
+        'tsconfig.json:',
+        '  - Missing references: packages/a/tsconfig.json, packages/b/tsconfig.json',
+        'packages/b/tsconfig.json:',
+        '  - Missing references: packages/a/tsconfig.json',
+      ]);
+      expect(readJson(tree, 'tsconfig.json').references).not.toContainEqual({
+        path: './packages/not-composite',
+      });
+    });
+
     it('should respect existing project references and discard non-existing ones in the tsconfig.json', async () => {
       writeJson(tree, 'tsconfig.json', {
         compilerOptions: {

--- a/packages/js/src/generators/typescript-sync/typescript-sync.ts
+++ b/packages/js/src/generators/typescript-sync/typescript-sync.ts
@@ -170,6 +170,17 @@ export async function syncGenerator(tree: Tree): Promise<SyncGeneratorResult> {
       const normalizedPath = normalizeReferencePath(node.data.root);
       // Skip the root tsconfig itself
       if (node.data.root !== '.' && !referencesSet.has(normalizedPath)) {
+        // Non-composite projects are dropped when writing below, so reporting
+        // them here would name a reference that can never be satisfied.
+        if (
+          !hasCompositeEnabled(
+            tsSysFromTree,
+            tsconfigInfoCaches,
+            joinPathFragments(normalizedPath, 'tsconfig.json')
+          )
+        ) {
+          continue;
+        }
         referencesSet.add(normalizedPath);
         addChangedFile(
           changedFiles,
@@ -182,7 +193,7 @@ export async function syncGenerator(tree: Tree): Promise<SyncGeneratorResult> {
 
     if (changedFiles.size > 0) {
       const updatedReferences = Array.from(referencesSet)
-        // Check composite is true in the internal reference before proceeding
+        // Pre-existing references skip the check above, so still filter here.
         .filter((ref) =>
           hasCompositeEnabled(
             tsSysFromTree,


### PR DESCRIPTION
## Current Behavior

The root `tsconfig.json`'s project references are filtered by `composite` only when the generator decides what to *write*:

```ts
if (changedFiles.size > 0) {
  const updatedReferences = Array.from(referencesSet)
    // Check composite is true in the internal reference before proceeding
    .filter((ref) => hasCompositeEnabled(...))
```

But `changedFiles` — which drives both the out-of-sync verdict and the user-facing message — is populated in an earlier pass with no composite filter:

```ts
if (node.data.root !== '.' && !referencesSet.has(normalizedPath)) {
  referencesSet.add(normalizedPath);
  addChangedFile(changedFiles, rootTsconfigPath, ..., 'missing');
}
```

A non-composite project can therefore be named as a missing root reference that sync would never actually add. The message asks for something it will not do, and there is no way to satisfy it.

This is visible in this repo. Adding `"composite": true` to `examples/react/basic/tsconfig.base.json` and running `sync:check` reports **13** missing references, but only `examples/react/basic` was ever a real candidate — the other 12 are `angular-rspack` examples that are not composite and would have been dropped before writing.

## Expected Behavior

The composite check runs in the first pass, so `changedFiles` only ever contains references that could really be written. A non-composite project is no longer named as a reason the workspace is out of sync.

Pre-existing references still skip that pass, so the filter at write time stays.

## Verification

One new test, which fails on `master` and passes here:

```
- "  - Missing references: packages/a/tsconfig.json, packages/b/tsconfig.json",
+ "  - Missing references: packages/a/tsconfig.json, packages/b/tsconfig.json, packages/not-composite/tsconfig.json",
```

`nx run-many -t test,lint -p js` passes (830 tests).

## Related Issue(s)

Split out of NXC-4734. This half is independent of the approach discussion on that ticket and stands on its own.

<!-- polygraph-session-start -->
---
<p><picture><source media="(prefers-color-scheme: dark)" srcset="https://static.ops.cloud.nx.app/polygraph/session-logo-v4-dark.svg"><img src="https://static.ops.cloud.nx.app/polygraph/session-logo-v4-light.svg" width="16" height="22" align="middle" alt="Polygraph"></picture> <a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Fix-typescript-sync-to-respect-plugin-include-exclude-NXC-4734-bf9d07aa">View session ↗</a></p>
<!-- polygraph-session-end -->