### PR TITLE
chore(repo): rebuild the review sandbox image instead of probing that it exists

### DIFF
--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: review-pr
 description: Deep code review of a single open PR in nrwl/nx. Checks out the PR inside an isolated sandbox container — gVisor on Linux, the Docker VM on macOS — never into the host working tree, runs the pr-review-toolkit review agents, the reproduce-verifier agent (grounds the review in the tracking ticket — a GitHub issue or a Linear NXC- ticket, fetched up front — and executes its repro inside the sandbox), the alternative-approach agent (independently designs competing solutions and contrasts them with the PR's choice), the performance-analyzer agent (checks the changes don't waste CPU or memory and execute quickly at workspace scale), and the security-analyzer agent (hunts injection-class vulnerabilities — command injection, zip-slip, SSRF, credential leakage — across real trust boundaries), then — only when a finding turns on why the author did something, and only once the review is finished — verifies that finding against the PR's Polygraph session (read-only, never resumed; it can downgrade a finding or raise a question but never add one, and its internal content never reaches the public draft), surfaces critical and important findings (plus strengths, a terse suggestions list, and explicit maintainer-call decisions), and saves a GitHub-flavored draft to ~/.nx-pr-reviews/<NUMBER>.md for the reviewer to read (nothing is posted). Claude runs on the host and reads/executes the PR code only through `docker exec` — untrusted PR code never runs on the host and Claude's credentials never enter the sandbox. Use when you want a thorough review of one PR.
-allowed-tools: Bash(gh pr view *), Bash(gh pr list *), Bash(gh pr diff *), Bash(gh issue view *), Bash(gh auth status*), Bash(polygraph whoami *), Bash(polygraph session search *), Bash(polygraph session show *), Bash(uname *), Bash(docker run *), Bash(docker exec *), Bash(docker rm *), Bash(docker ps *), Bash(docker inspect *), Bash(docker info *), Bash(docker images *), Bash(git -C *), Bash(git rev-parse *), Bash(mkdir -p *), Bash(rm -f /tmp/pr-*), Bash(rm -f /tmp/repro-*), Bash(mv /tmp/*), Bash(xargs *), Bash(ls *), Bash(printf *), Bash(date *), Bash(cd *), Bash(test *), Bash(echo *), Bash(head *), Bash(tail *), Bash(cat *), Bash(jq *), Bash(grep *), Bash(wc *), Bash(sed *), Write(~/.nx-pr-reviews/**), Write(/tmp/**), Edit(~/.nx-pr-reviews/**), Edit(/tmp/**), mcp__plugin_linear_linear__get_issue, mcp__plugin_linear_linear__list_comments, Read, Grep, Glob, Skill, Agent
+allowed-tools: Bash(gh pr view *), Bash(gh pr list *), Bash(gh pr diff *), Bash(gh issue view *), Bash(gh auth status*), Bash(polygraph whoami *), Bash(polygraph session search *), Bash(polygraph session show *), Bash(uname *), Bash(docker run *), Bash(docker exec *), Bash(docker rm *), Bash(docker ps *), Bash(docker inspect *), Bash(docker info *), Bash(docker images *), Bash(docker build *), Bash(bash tools/review-sandbox/*), Bash(git -C *), Bash(git rev-parse *), Bash(mkdir -p *), Bash(rm -f /tmp/pr-*), Bash(rm -f /tmp/repro-*), Bash(mv /tmp/*), Bash(xargs *), Bash(ls *), Bash(printf *), Bash(date *), Bash(cd *), Bash(test *), Bash(echo *), Bash(head *), Bash(tail *), Bash(cat *), Bash(jq *), Bash(grep *), Bash(wc *), Bash(sed *), Write(~/.nx-pr-reviews/**), Write(/tmp/**), Edit(~/.nx-pr-reviews/**), Edit(/tmp/**), mcp__plugin_linear_linear__get_issue, mcp__plugin_linear_linear__list_comments, Read, Grep, Glob, Skill, Agent
 argument-hint: '<PR_NUMBER> [--verify-repros]'
 ---
 
@@ -46,10 +46,23 @@ mkdir -p "$TRIAGE_DIR"
 uname -s                                                              # Linux → runsc REQUIRED; Darwin → Docker VM is the sandbox
 docker info >/dev/null 2>&1 && echo "docker OK" || echo "docker MISSING"
 docker info --format '{{range $k,$v := .Runtimes}}{{$k}} {{end}}' | grep -q runsc && echo "runsc OK" || echo "runsc ABSENT"
-test -n "$(docker images -q "$SANDBOX_IMAGE" 2>/dev/null)" && echo "image OK" || echo "image MISSING"
-```
 
-Use `docker images -q` (empty output ⇒ absent), **not** `docker image inspect`, to probe for the image. On Docker Desktop with Resource Saver, `docker image inspect` returns "No such image" for several seconds after the VM wakes even though the image is present — observed failing 5+ calls in a row while `docker images` and `docker run` both succeed. Probing with `inspect` there would send you to rebuild a ~5 GB image that already exists.
+# Bring the image up to date. Do NOT probe whether it exists and skip on a hit: an image
+# built from ANY older revision passes an existence check identically, so a missing
+# capability is invisible and shows up only as a review that is slower or quietly weaker.
+# Observed: an image predating the pnpm-store warming went unnoticed for two weeks and cost
+# ~25 min of package downloads on every review.
+#
+# Just build. Docker's layer cache makes this the right default rather than an expensive one:
+#   - nothing changed        -> ~0.6 s, every layer cached (measured)
+#   - Dockerfile/mise.toml   -> rebuilds from the changed instruction
+#   - pnpm-lock.yaml moved   -> re-runs `pnpm fetch`, which is the point: it keeps the warm
+#                               store matching the lockfile reviews actually install from
+# Concurrent runs are safe with no lock of our own — review-prs drives up to five parallel
+# `/review-pr` panes, and BuildKit deduplicates identical concurrent builds (measured: a 20 s
+# step ran ONCE across 5 simultaneous builds, all finishing in ~21 s rather than 100 s).
+bash "$(git rev-parse --show-toplevel)/tools/review-sandbox/build-image.sh"
+```
 
 **Set `RUNTIME_FLAG` explicitly, and fail closed.** Treat it as unset (`RUNTIME_FLAG=UNSET`) until `uname -s` has actually returned, then assign exactly once:
 
@@ -59,9 +72,9 @@ Use `docker images -q` (empty output ⇒ absent), **not** `docker image inspect`
 
 Never run `docker run` while `RUNTIME_FLAG` is still `UNSET`. This matters because an _unset_ variable expands to nothing, which is byte-identical to the correct macOS value — so a skipped or blocked `uname` would silently start the container under `runc` on Linux, running untrusted PR code with no gVisor and no error anywhere. The failure mode of this variable is "no isolation, reported as success", so it gets an explicit sentinel rather than a default.
 
-Fail fast with a clear message if: `gh` isn't authed; Docker is down; on Linux `runsc` is absent; or the image is missing. For the last three, point the user at the **`setup-review-sandbox`** skill (it installs Docker + gVisor + builds the image) — do not try to build it here.
+Fail fast with a clear message if: `gh` isn't authed; Docker is down; on Linux `runsc` is absent; or the image build fails. For the last three, point the user at the **`setup-review-sandbox`** skill — it installs Docker + gVisor, which the build above deliberately does not.
 
-(If `docker images -q` still comes back empty right after the daemon wakes, give it a few seconds and re-probe once before concluding the image is gone — the daemon can lag briefly on wake. Only treat a persistently empty result as truly MISSING.)
+The build prints one line on the fast path (`sandbox image up to date`), so a slow first run after a lockfile change is expected and self-explanatory rather than a mystery.
 
 ## Step 2: Fetch the PR metadata
 

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -485,6 +485,12 @@ dimension depends on. Signals that it does:
 - A changed **lint / CI / build config** whose effect is the point of the change.
 - A **removed** log, warning, or error, justified as "the sink already reports it".
 - A claimed **behavioral parity** between two code paths ("the worker mirrors the classic loop").
+- A factual claim about an **external dependency's behavior**, especially **across versions** — "the
+  upstream package never reports X in any mode", "that field only exists from v21". One `npm pack` +
+  `grep` settles it; left unmeasured, every agent whose dimension touches it packs the same tarballs.
+  This shape hides because the claim is usually in a _comment_, so it reads as the comment-analyzer's
+  private business — but reachability claims of this kind set the severity of the whole PR, which
+  means the reproduce-verifier and the code reviewer need them too.
 - A change to a **shared signature or call contract**: a new parameter, a widened argument list, a
   new option threaded through a function with several call sites.
 
@@ -500,6 +506,15 @@ itself**, so the diff contains the evidence; a signature change's expensive fact
   options-object refactor is even available, and it is invisible to a reader of the diff alone.
 
 If the diff makes no such claim, skip this step entirely — most PRs will.
+
+**Finish this step before you dispatch anyone.** A measurement taken after dispatch reaches nobody:
+the charter is read once, at the start of each agent's run, so a late `## Established measurements`
+entry is invisible to every agent already working, and they each re-derive it. Observed: an
+external-dependency version claim measured after dispatch was independently re-derived by three
+agents at roughly 5-7k tokens each. If you think of a measurement mid-flight, you have two options —
+neither is "write it to the charter and hope": either accept the duplication, or `SendMessage` the
+specific agents whose dimension needs it. Prefer to catch it here by walking the trigger list above
+once, deliberately, before the first `Agent` call.
 
 ### How to do it
 
@@ -532,6 +547,32 @@ If the diff makes no such claim, skip this step entirely — most PRs will.
 
 6. **Record the method, not just the number.** The charter entry must let an agent re-run it.
 
+7. **Leave the rig standing, and say where it is.** This is the highest-leverage part of the step and
+   the easiest to skip, because by the time you have your number the harness feels like scaffolding.
+   It is not — it is the expensive part, and every agent that wants to _run_ anything will rebuild it
+   from scratch.
+
+   Observed on a single PR: six separate harnesses were built to do the same thing — load the shipped
+   implementation by transpiling its real source and push inputs through it. The orchestrator, the
+   silent-failure hunter, the code reviewer, the type analyzer, the test analyzer and the
+   reproduce-verifier each solved module resolution, each wrote the transpile boilerplate, and
+   several each hit the same `cd`-outside-the-mise-tree failure first.
+
+   So: when your measurement needed a harness, save it in the container at a stable path
+   (`/work/nx/<something>-probe.js` — under `/work/nx`, or `require()` cannot resolve workspace
+   modules), make its inputs a parameter rather than a hard-coded list, and give the charter the
+   literal command that runs it.
+
+   **Reuse the plumbing, never the cases.** The adversarial value of nine agents lives entirely in
+   which inputs each one thinks to try; it lives not at all in who wrote the `ts.transpileModule`
+   call. Hand over the loader and the runner; let every agent bring its own matrix. Word the charter
+   entry that way explicitly — "here is a rig that executes the shipped code, bring your own inputs"
+   — because a rig presented alongside a case list invites agents to read the case list as the
+   territory and stop there.
+
+   The same applies to anything else you stood up that was expensive and is reusable: an installed
+   base-side dependency, an extracted tarball, a snapshot at `/snap`.
+
 ### How to write it into the charter
 
 Add an `## Established measurements` section (see the Step 5 template). Frame every entry as a
@@ -547,6 +588,15 @@ independence that matters — `alternative-approach`, `security-analyzer` and `p
 arriving uninformed about the _author's reasoning_ — is untouched, because a mechanical measurement
 is not a rationale. Keep giving them the measurement; keep withholding the Polygraph session until
 Step 5c.
+
+**Record what you tested and found clean, not only what you found.** A negative result is as
+suppressive as a positive one and costs an extra line. If your matrix covered a case that looks like
+the obvious place for this change to break — the shape a reader would reach for first — say that you
+tested it and that it held. Otherwise every agent that has the same good instinct spends the same
+tool calls confirming your silence. Observed working: a charter that recorded "the guard-shape
+difference produces no divergence, including the case that difference would most plausibly expose"
+drew zero re-tests from nine agents, while the one measurement left out of the charter was re-derived
+by three.
 
 **Never put a conclusion here that you did not personally run.** This section is trusted by nine
 agents at once, so an error in it is nine wrong reviews rather than one.
@@ -613,6 +663,11 @@ whether the change is good. Verify anything you intend to lean on; correct it if
 - **Who calls them** — the call sites, with paths, from one `grep` over `/work/nx/packages`. Note any
   reached through a dynamic `require`/`import`, across a package boundary, or from a test-only path.
 - **Base behavior** — what the same code did at `/work/base`, in a sentence per changed function.
+  Where a changed export's **type** moved, give the before and after explicitly, including a type that
+  was previously _inferred_ rather than written down. That fact decides whether the change is a
+  narrowing or a break, so several dimensions need it — type design, code quality, and whoever asks
+  why a now-redundant guard could be deleted — and each will otherwise reconstruct the old inference
+  by hand from deleted source. Observed re-derived three times on one PR.
 - **Where it sits in the flow** — the entry point that reaches this code, and what gates it.
 
 Leave OUT the PR body's rationale, the author's stated motivation, and any prior review's
@@ -634,7 +689,27 @@ finding, and a valuable one. Reuse these as a _starting point_ for your own dime
 not as a place to stop.
 
 <For each measurement: the claim, the method (specific enough to re-run), and the result —
-including the base and, on a re-review, the prior SHA, so "is this net-new?" is answerable.>
+including the base and, on a re-review, the prior SHA, so "is this net-new?" is answerable.
+
+Where the measurement was clean, say so — "tested X, no divergence" — so nobody re-tests your
+silence.>
+
+### Reusable rig
+
+<OMIT unless Step 4.7 left a harness or other expensive setup standing. When it did, list each one:
+the path, the literal command that runs it, and what it does.
+
+State plainly that the inputs are the agent's to choose — the rig exists so nobody rewrites the
+plumbing, NOT so everyone reuses one case list. Example wording:
+
+    /work/nx/<name>-probe.js executes the SHIPPED implementation (it transpiles the real source;
+    it is not a reimplementation). Run it with:
+        docker exec nx-review-pr-<NUMBER> bash -lc 'export PATH="/root/.local/bin:/root/.local/share/mise/shims:$PATH"; cd /work/nx && node <name>-probe.js'
+    Add your own cases to the matrix at the top. Bring inputs your dimension cares about — the
+    case list already there is mine, not a boundary on yours.
+
+Also list any expensive setup that is reusable rather than re-creatable: a base-side dependency you
+installed, an extracted tarball, a `/snap` snapshot.>
 
 ## Review methodology (mandatory)
 

--- a/.claude/skills/setup-review-sandbox/SKILL.md
+++ b/.claude/skills/setup-review-sandbox/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: setup-review-sandbox
 description: One-time setup of the sandbox prerequisites used by the reproduce-issue skill and the reproduce-verifier agent — Docker, the isolation runtime (gVisor on Linux / Colima on macOS), healthy container networking, and the nx-review-sandbox toolchain image (built from the repo's mise.toml). Idempotent; re-run any time to verify or repair. Use when the user says "set up the review sandbox", "install the sandbox prereqs", "build the sandbox image", or a reproduce-issue preflight reports something MISSING.
-allowed-tools: Read, Grep, Glob, Bash(uname *), Bash(docker info *), Bash(docker run *), Bash(docker build *), Bash(docker image inspect *), Bash(docker images *), Bash(command -v *), Bash(lsmod *)
+allowed-tools: Read, Grep, Glob, Bash(uname *), Bash(docker info *), Bash(docker run *), Bash(docker build *), Bash(docker image inspect *), Bash(docker images *), Bash(command -v *), Bash(lsmod *), Bash(bash tools/review-sandbox/*)
 ---
 
 # Set up the review sandbox (one-time)
@@ -67,20 +67,15 @@ If `modprobe` errors with a BTF / version mismatch (`failed to validate module [
 
 Needed only to **build an unreleased PR's nx** in the sandbox (reproduce-verifier Level 2). Reproducing against a published nx version does NOT need it.
 
-```bash
-docker image inspect nx-review-sandbox:latest >/dev/null 2>&1 && echo "image OK" || echo "image MISSING"
-```
-
-If MISSING (or stale — check the `created` date against the Dockerfile), build it. The Dockerfile only needs `mise.toml`, so build from a **minimal context** — do NOT pass `.` (the repo root), which would ship the whole monorepo (node_modules / .git / dist — many GB) to the daemon:
+Build it — unconditionally, without first checking whether it exists:
 
 ```bash
-mkdir -p tmp/review-sandbox-ctx
-cp mise.toml package.json pnpm-lock.yaml pnpm-workspace.yaml tmp/review-sandbox-ctx/
-cp -r patches tmp/review-sandbox-ctx/
-docker build -t nx-review-sandbox:latest -f tools/review-sandbox/Dockerfile tmp/review-sandbox-ctx
+bash tools/review-sandbox/build-image.sh
 ```
 
-The context is still minimal — five entries, ~2 MB, almost all of it the lockfile — and deliberately excludes the repo itself. All five are load-bearing; the Dockerfile explains what each omission breaks.
+**Don't gate this on an existence check.** An image built from any older revision passes one identically, so a missing capability stays invisible until a review is mysteriously slow — which is exactly how an image predating the pnpm-store warming went unnoticed for two weeks, costing ~25 minutes of package downloads on every review in between. Docker's layer cache already answers the question properly: ~0.6 s when nothing changed, a real rebuild when something did. `review-pr` calls the same script in its own pre-flight for that reason, so the image is kept current by every review rather than by remembering to re-run this skill.
+
+The script builds from a **minimal context** — five entries, ~2 MB, almost all of it the lockfile — and never `.` (the repo root), which would ship the whole monorepo (node_modules / .git / dist — many GB) to the daemon. All five entries are load-bearing; the Dockerfile explains what each omission breaks.
 
 This installs the repo's exact toolchain — node/java/dotnet/maven/rust/bun via mise — and warms the pnpm store so reviews link packages instead of downloading them. Takes a while and several GB (the warm store is ~2.6 GB of that). Requires steps 1 + 3 to pass first (build needs working networking). If disk is tight, `/sandbox-prune` first.
 

--- a/tools/review-sandbox/build-image.sh
+++ b/tools/review-sandbox/build-image.sh
@@ -1,0 +1,41 @@
+#!/usr/bin/env bash
+# Build the review sandbox image, bringing it up to date if anything it depends on moved.
+#
+# Called unconditionally by review-pr's pre-flight and by setup-review-sandbox, because
+# "does the image exist?" is the wrong question: an image built from any older revision
+# answers yes, so a missing capability is invisible until a review is mysteriously slow.
+# Docker's layer cache makes the unconditional build ~0.6 s when nothing changed, and
+# BuildKit deduplicates identical concurrent builds, so the five parallel review-prs panes
+# need no lock of their own.
+set -euo pipefail
+
+IMAGE="${SANDBOX_IMAGE:-nx-review-sandbox:latest}"
+repo_root=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+ctx="$repo_root/tmp/review-sandbox-ctx"
+
+# Minimal context — never the repo root, which would ship node_modules/.git/dist (many GB)
+# to the daemon. All five entries are load-bearing; the Dockerfile says what each omission
+# breaks. Rebuilt from scratch so a stale copy of a since-changed lockfile cannot linger.
+rm -rf "$ctx"
+mkdir -p "$ctx"
+cp "$repo_root"/{mise.toml,package.json,pnpm-lock.yaml,pnpm-workspace.yaml} "$ctx/"
+cp -r "$repo_root/patches" "$ctx/"
+
+# Image ID before/after is exact, where grepping the log for "CACHED" is a guess.
+before=$(docker images -q "$IMAGE" 2>/dev/null || true)
+
+if docker build -t "$IMAGE" -f "$repo_root/tools/review-sandbox/Dockerfile" "$ctx" \
+     >"$ctx/build.log" 2>&1; then
+  after=$(docker images -q "$IMAGE" 2>/dev/null || true)
+  # Say something either way: a review that pauses here should be self-explanatory.
+  if [ -n "$before" ] && [ "$before" = "$after" ]; then
+    echo "sandbox image up to date"
+  else
+    echo "sandbox image rebuilt (${before:-none} -> $after)"
+  fi
+  exit 0
+fi
+
+echo "sandbox image build FAILED — last 20 lines:"
+tail -20 "$ctx/build.log"
+exit 1


### PR DESCRIPTION
## Current Behavior

`review-pr`'s pre-flight asks whether the sandbox image exists:

```bash
test -n "$(docker images -q "$SANDBOX_IMAGE" 2>/dev/null)" && echo "image OK" || echo "image MISSING"
```

An image built from **any** older revision answers that identically. So a capability added to the Dockerfile never reaches an image that already exists, and nothing surfaces it — the only symptom is a review that is slower or quietly weaker.

That is not hypothetical. The pnpm-store warming (`pnpm fetch`) landed in `889f4cd45d` on **2026-07-31**; the local image was built **2026-07-16**. `docker history` showed no `pnpm fetch` layer at all and `/root/.local/share/pnpm` was 0 bytes, so the "warm store" the skill promises had never existed on that machine. Every review in the two weeks between downloaded ~4200 packages instead of linking them — about **25 minutes each** — and the skill's only hint was a symptom you had to notice yourself (*"If it is unexpectedly slow, the image predates the warm store"*).

`setup-review-sandbox` had the same gate, plus a manual *"check the `created` date against the Dockerfile"* that nobody does.

## Expected Behavior

Build unconditionally via a shared `tools/review-sandbox/build-image.sh`, and let Docker's layer cache decide what that costs. Both skills call it, so the image is kept current by every review rather than by remembering to re-run setup.

Measured on the real image:

| situation | cost |
| --- | --- |
| nothing changed | **0.66 s** — prints `sandbox image up to date` |
| missing store layer (the bug above) | **2 m 47 s** — apt/mise layers stayed cached |
| resulting store | **2.6 G**, matching the documented figure |

A `pnpm-lock.yaml` change re-runs `pnpm fetch`, which is the point: it keeps the warm store matching the lockfile reviews actually install from.

### No lock, because BuildKit already has one

`review-prs` drives up to five parallel `/review-pr` panes, so the obvious worry is five simultaneous multi-GB builds. Measured instead of assumed — 5 concurrent identical builds of a Dockerfile with a 20 s step:

```
pane3 done at 21s   pane2 done at 21s   pane5 done at 22s
pane1 done at 22s   pane4 done at 22s

$ docker run --rm bktest cat /marker.txt
slow step running at 1785862632781210805      <- one line, not five
```

The step ran **once** and all five returned in ~21 s rather than 100 s. An external lock would only duplicate that.

### Notes

- The build script writes to `tmp/review-sandbox-ctx` (gitignored) and keeps the same minimal five-entry context — never the repo root.
- `allowed-tools` updated in both skills, or every run prompts.
- Documentation/tooling only. No product code, no tests affected.

## Related Issue(s)

Follow-up to #36557, found while running the skill against #36370.

<!-- polygraph-session-start -->
---
<p><picture><source media="(prefers-color-scheme: dark)" srcset="https://static.ops.cloud.nx.app/polygraph/session-logo-v4-dark.svg"><img src="https://static.ops.cloud.nx.app/polygraph/session-logo-v4-light.svg" width="16" height="22" align="middle" alt="Polygraph"></picture> <a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Rebuild-the-review-sandbox-image-instead-of-probing-that-it-exists-c14dad6f">View session ↗</a></p>
<!-- polygraph-session-end -->