### PR TITLE
fix(core): recover from kernel watch-event overflow via rescan

### DIFF
--- a/packages/nx/src/daemon/server/handle-outputs-changes.spec.ts
+++ b/packages/nx/src/daemon/server/handle-outputs-changes.spec.ts
@@ -5,6 +5,7 @@ vi.mock('../logger', () => ({
   serverLogger: { watcherLog: vi.fn() },
 }));
 vi.mock('./outputs-tracking', () => ({
+  clearRecordedOutputsHashes: vi.fn(),
   disableOutputsTracking: vi.fn(),
   processFileChangesInOutputs: vi.fn(),
 }));
@@ -26,6 +27,7 @@ describe('handleOutputsChanges', () => {
   let handleOutputsChanges: typeof import('./handle-outputs-changes').handleOutputsChanges;
   let getOutputsWatcherTerminalError: typeof import('./handle-outputs-changes').getOutputsWatcherTerminalError;
   let outputsTracking: {
+    clearRecordedOutputsHashes: Mock;
     disableOutputsTracking: Mock;
     processFileChangesInOutputs: Mock;
   };
@@ -58,6 +60,18 @@ describe('handleOutputsChanges', () => {
 
   afterEach(() => {
     consoleError.mockRestore();
+  });
+
+  it('starts the tracker over and invalidates the graph on a rescan, without processing per-path events', async () => {
+    await handleOutputsChanges(null, [{ path: '', type: EventType.rescan }]);
+
+    expect(outputsTracking.clearRecordedOutputsHashes).toHaveBeenCalled();
+    expect(recomputation.invalidateGraphCache).toHaveBeenCalled();
+    expect(outputsTracking.processFileChangesInOutputs).not.toHaveBeenCalled();
+    expect(dotenvChanges.classifyDotEnvChanges).not.toHaveBeenCalled();
+    // A rescan is recoverable: the watch stream is still alive.
+    expect(getOutputsWatcherTerminalError()).toBeUndefined();
+    expect(outputsTracking.disableOutputsTracking).not.toHaveBeenCalled();
   });
 
   it('records a native watcher error as terminal, preserving its message, and disables outputs tracking', async () => {

--- a/packages/nx/src/daemon/server/handle-outputs-changes.ts
+++ b/packages/nx/src/daemon/server/handle-outputs-changes.ts
@@ -4,6 +4,7 @@ import {
   queuePendingDotEnvEvents,
 } from './dotenv-graph-changes';
 import {
+  clearRecordedOutputsHashes,
   disableOutputsTracking,
   processFileChangesInOutputs,
 } from './outputs-tracking';
@@ -73,6 +74,18 @@ export const handleOutputsChanges: FileWatcherCallback = async (
     // here cannot trip the outputs-tracking kill switch below, which belongs
     // to an unrelated subsystem, and it fails safe by invalidating: a stale
     // graph on a dotenv edit is the bug this prevents.
+    if (changeEvents.some((event) => event.type === 'rescan')) {
+      // Dropped events cannot be classified: any recorded output hash and any
+      // gitignored dotenv file may have changed unseen. Start the tracker
+      // over and invalidate the graph rather than trust either.
+      serverLogger.watcherLog(
+        'The outputs watcher reported dropped events; clearing recorded output hashes and invalidating the graph cache.'
+      );
+      clearRecordedOutputsHashes();
+      invalidateGraphCache();
+      return;
+    }
+
     try {
       const { invalidating, unclassified } = classifyDotEnvChanges(
         changeEvents,

--- a/packages/nx/src/daemon/server/outputs-tracking.ts
+++ b/packages/nx/src/daemon/server/outputs-tracking.ts
@@ -130,6 +130,24 @@ export function recordOutputsHashBatch(
   }
 }
 
+/**
+ * One-shot reset for a watcher rescan: recorded hashes may describe outputs
+ * whose change events were dropped, so none can be trusted. Unlike
+ * `disableOutputsTracking` the tracker keeps running; it just starts over.
+ */
+export function clearRecordedOutputsHashes() {
+  for (const store of [
+    dirsContainingOutputs,
+    recordedHashes,
+    timestamps,
+    numberOfExpandedOutputs,
+  ]) {
+    for (const key of Object.keys(store)) {
+      delete store[key];
+    }
+  }
+}
+
 export function disableOutputsTracking() {
   disabled = true;
 }

--- a/packages/nx/src/daemon/server/project-graph-incremental-recomputation.spec.ts
+++ b/packages/nx/src/daemon/server/project-graph-incremental-recomputation.spec.ts
@@ -1,4 +1,10 @@
-import { existsSync, mkdirSync, readFileSync, writeFileSync } from 'node:fs';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
 import { join } from 'node:path';
 
 import { TempFs } from '../../internal-testing-utils/temp-fs';
@@ -1947,5 +1953,124 @@ describe('pending dotenv replay before serving a graph', () => {
     const fourth = await getCachedSerializedProjectGraphPromise();
     expect(fourth.projectGraph.nodes.bar.data.tags).toEqual(['env:PORT=7777']);
     expect(retrieveCallCount).toBe(2);
+  });
+});
+
+describe('handleWatcherRescan', () => {
+  let fs: TempFs;
+
+  beforeEach(() => {
+    fs = new TempFs('pgir-rescan');
+  });
+
+  afterEach(() => {
+    fs.cleanup();
+    delete (global as any).NX_DAEMON;
+  });
+
+  it('recovers file changes the watcher never delivered', async () => {
+    fs.createFilesSync({
+      'nx.json': JSON.stringify({}),
+      'package.json': JSON.stringify({ name: 'root' }),
+      'libs/foo/project.json': JSON.stringify({
+        name: 'foo',
+        root: 'libs/foo',
+      }),
+      'libs/foo/src/index.ts': 'original',
+      'libs/foo/src/stale.ts': '',
+    });
+
+    vi.resetModules();
+    // The plugin-loader mocks vi.doMock installs in the tests above are
+    // registry-wide and outlive vi.resetModules.
+    vi.doUnmock('../../project-graph/plugins/get-plugins');
+    // handleWatcherRescan runs on the daemon, where the context wrappers
+    // take their direct path.
+    (global as any).NX_DAEMON = true;
+    const { setWorkspaceRoot } = await import('../../utils/workspace-root');
+    setWorkspaceRoot(fs.tempDir);
+
+    const {
+      getCachedSerializedProjectGraphPromise,
+      handleWatcherRescan,
+      isKnownWorkspaceFile,
+    } = await import('./project-graph-incremental-recomputation');
+
+    const first = await getCachedSerializedProjectGraphPromise();
+    expect(first.error).toBeNull();
+    expect(first.projectGraph.nodes.foo).toBeDefined();
+    expect(isKnownWorkspaceFile('libs/bar/project.json')).toBe(false);
+
+    // Dropped events: the workspace moves on with no watcher batch at all.
+    writeFileSync(join(fs.tempDir, 'libs/foo/src/index.ts'), 'changed');
+    mkdirSync(join(fs.tempDir, 'libs/bar'), { recursive: true });
+    writeFileSync(
+      join(fs.tempDir, 'libs/bar/project.json'),
+      JSON.stringify({ name: 'bar', root: 'libs/bar' })
+    );
+    rmSync(join(fs.tempDir, 'libs/foo/src/stale.ts'));
+
+    await handleWatcherRescan();
+
+    const second = await getCachedSerializedProjectGraphPromise();
+    expect(second.error).toBeNull();
+    expect(second.projectGraph.nodes.bar).toBeDefined();
+    expect(isKnownWorkspaceFile('libs/bar/project.json')).toBe(true);
+    expect(isKnownWorkspaceFile('libs/foo/src/stale.ts')).toBe(false);
+  });
+
+  it('keeps the cached graph when the re-walk finds no differences', async () => {
+    fs.createFilesSync({
+      'nx.json': JSON.stringify({}),
+      'package.json': JSON.stringify({ name: 'root' }),
+    });
+
+    vi.resetModules();
+    vi.doUnmock('../../project-graph/plugins/get-plugins');
+    (global as any).NX_DAEMON = true;
+    const { setWorkspaceRoot } = await import('../../utils/workspace-root');
+    setWorkspaceRoot(fs.tempDir);
+
+    const { getCachedSerializedProjectGraphPromise, handleWatcherRescan } =
+      await import('./project-graph-incremental-recomputation');
+
+    const first = await getCachedSerializedProjectGraphPromise();
+    expect(first.error).toBeNull();
+
+    await handleWatcherRescan();
+
+    // Same result object: no invalidation happened, the cached compute
+    // survived the rescan.
+    const second = await getCachedSerializedProjectGraphPromise();
+    expect(second).toBe(first);
+  });
+});
+
+describe('diffFileData', () => {
+  it('classifies created, updated, unchanged and deleted files', async () => {
+    const { diffFileData } =
+      await import('./project-graph-incremental-recomputation');
+
+    const diff = diffFileData(
+      [
+        { file: 'a.ts', hash: '1' },
+        { file: 'b.ts', hash: '2' },
+        { file: 'c.ts', hash: '3' },
+      ],
+      [
+        { file: 'b.ts', hash: '2' },
+        { file: 'c.ts', hash: 'changed' },
+        { file: 'd.ts', hash: '4' },
+      ]
+    );
+
+    expect(diff.createdFiles).toEqual(['d.ts']);
+    // Created files carry their hash too: the collector needs one for every
+    // file it records, created or updated.
+    expect(diff.updatedFiles).toEqual([
+      { file: 'c.ts', hash: 'changed' },
+      { file: 'd.ts', hash: '4' },
+    ]);
+    expect(diff.deletedFiles).toEqual(['a.ts']);
   });
 });

--- a/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
+++ b/packages/nx/src/daemon/server/project-graph-incremental-recomputation.ts
@@ -38,7 +38,9 @@ import {
 } from '../../project-graph/utils/retrieve-workspace-files';
 import { fileExists } from '../../utils/fileutils';
 import {
+  getAllFileDataInContext,
   resetWorkspaceContext,
+  setupWorkspaceContext,
   updateFilesInContext,
 } from '../../utils/workspace-context';
 import { workspaceRoot } from '../../utils/workspace-root';
@@ -393,6 +395,99 @@ export function scheduleProjectGraphRecomputation(
       kickOffRecompute();
     }
   }
+}
+
+export interface FileDataDiff {
+  createdFiles: string[];
+  updatedFiles: Array<{ file: string; hash: string }>;
+  deletedFiles: string[];
+}
+
+export function diffFileData(
+  before: FileData[],
+  after: FileData[]
+): FileDataDiff {
+  const beforeHashes = new Map(before.map((f) => [f.file, f.hash]));
+  const createdFiles: string[] = [];
+  const updatedFiles: Array<{ file: string; hash: string }> = [];
+  for (const f of after) {
+    const previousHash = beforeHashes.get(f.file);
+    if (previousHash === undefined) {
+      createdFiles.push(f.file);
+      updatedFiles.push({ file: f.file, hash: f.hash });
+    } else {
+      if (previousHash !== f.hash) {
+        updatedFiles.push({ file: f.file, hash: f.hash });
+      }
+      beforeHashes.delete(f.file);
+    }
+  }
+  return {
+    createdFiles,
+    updatedFiles,
+    deletedFiles: [...beforeHashes.keys()],
+  };
+}
+
+/**
+ * The watcher reported dropped events (a kernel event-queue overflow), so the
+ * per-path stream cannot be trusted complete. Recover by re-walking the
+ * workspace and diffing it against the context's known files, then feed the
+ * synthesized changes through the same collection and notification path a
+ * normal watcher batch takes.
+ */
+export async function handleWatcherRescan(): Promise<void> {
+  performance.mark('watcher-rescan-start');
+  const before = await getAllFileDataInContext(workspaceRoot);
+  resetWorkspaceContext();
+  setupWorkspaceContext(workspaceRoot);
+  const after = await getAllFileDataInContext(workspaceRoot);
+  performance.mark('watcher-rescan-end');
+  performance.measure(
+    're-walk workspace after watcher rescan',
+    'watcher-rescan-start',
+    'watcher-rescan-end'
+  );
+
+  const { createdFiles, updatedFiles, deletedFiles } = diffFileData(
+    before,
+    after
+  );
+  if (updatedFiles.length === 0 && deletedFiles.length === 0) {
+    serverLogger.watcherLog(
+      'Rescan re-walk found no differences; keeping the cached graph.'
+    );
+    return;
+  }
+  serverLogger.watcherLog(
+    `Rescan re-walk recovered ${createdFiles.length} created, ${
+      updatedFiles.length - createdFiles.length
+    } updated and ${deletedFiles.length} deleted file(s).`
+  );
+
+  ++fileChangeCounter;
+  const createdFileSet = new Set(createdFiles);
+  const updatedFileNames: string[] = [];
+  for (const { file, hash } of updatedFiles) {
+    collectedDeletedFiles.delete(file);
+    collectedUpdatedFiles.set(file, { version: fileChangeCounter, hash });
+    if (!createdFileSet.has(file)) {
+      updatedFileNames.push(file);
+    }
+  }
+  for (const file of deletedFiles) {
+    collectedUpdatedFiles.delete(file);
+    collectedDeletedFiles.set(file, fileChangeCounter);
+  }
+
+  notifyFileChangeListeners({
+    createdFiles,
+    updatedFiles: updatedFileNames,
+    deletedFiles,
+  });
+  notifyFileWatcherSockets(createdFiles, updatedFileNames, deletedFiles);
+  ++recomputationGeneration;
+  kickOffRecompute();
 }
 
 export function registerProjectGraphRecomputationListener(

--- a/packages/nx/src/daemon/server/server.ts
+++ b/packages/nx/src/daemon/server/server.ts
@@ -146,6 +146,7 @@ import {
   handleOutputsChanges,
 } from './handle-outputs-changes';
 import {
+  handleWatcherRescan,
   scheduleProjectGraphRecomputation,
   registerProjectGraphRecomputationListener,
 } from './project-graph-incremental-recomputation';
@@ -658,6 +659,14 @@ const handleWorkspaceChanges: FileWatcherCallback = async (
       console.error(error);
       workspaceWatcherError = error;
       notifyFileWatcherSocketsOfError(error);
+      return;
+    }
+
+    if (changeEvents.some((event) => event.type === 'rescan')) {
+      serverLogger.watcherLog(
+        'The watcher reported dropped events; re-walking the workspace to recover the missed changes.'
+      );
+      await handleWatcherRescan();
       return;
     }
 

--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -357,7 +357,12 @@ export interface EventDimensions {
 export declare const enum EventType {
   delete = 'delete',
   update = 'update',
-  create = 'create'
+  create = 'create',
+  /**
+   * The kernel dropped events (e.g. an inotify queue overflow); per-path
+   * events cannot be trusted complete and consumers must re-walk.
+   */
+  rescan = 'rescan'
 }
 
 export declare function expandOutputs(directory: string, entries: Array<string>): Array<string>

--- a/packages/nx/src/native/watch/types.rs
+++ b/packages/nx/src/native/watch/types.rs
@@ -58,6 +58,10 @@ pub enum EventType {
     update,
     #[allow(non_camel_case_types)]
     create,
+    /// The kernel dropped events (e.g. an inotify queue overflow); per-path
+    /// events cannot be trusted complete and consumers must re-walk.
+    #[allow(non_camel_case_types)]
+    rescan,
 }
 
 #[derive(Debug, Clone)]

--- a/packages/nx/src/native/watch/watcher.rs
+++ b/packages/nx/src/native/watch/watcher.rs
@@ -116,6 +116,10 @@ struct WatchPipeline {
     ignore_globs: Arc<NxGlobSet>,
 
     accumulator: HashMap<PathBuf, WatchEventInternal>,
+    /// The backend reported dropped events (notify's Rescan flag, e.g. an
+    /// inotify queue overflow). Per-path events are incomplete from that
+    /// moment, so the next flush emits a single rescan event instead.
+    pending_rescan: bool,
     burst_start: Option<Instant>,
     flush_deadline: Option<Instant>,
 }
@@ -156,6 +160,7 @@ impl WatchPipeline {
             #[cfg(not(target_os = "macos"))]
             ignore_globs: build_ignore_glob_set(),
             accumulator: HashMap::new(),
+            pending_rescan: false,
             burst_start: None,
             flush_deadline: None,
         })
@@ -182,11 +187,24 @@ impl WatchPipeline {
     }
 
     fn snapshot_events(&self) -> Vec<WatchEvent> {
+        // A rescan supersedes the accumulated events: the consumer re-walks,
+        // which covers everything a per-path event could have said.
+        if self.pending_rescan {
+            return vec![WatchEvent {
+                path: String::new(),
+                r#type: EventType::rescan,
+            }];
+        }
         self.accumulator.values().map(|e| e.into()).collect()
+    }
+
+    fn has_pending(&self) -> bool {
+        !self.accumulator.is_empty() || self.pending_rescan
     }
 
     fn reset_burst(&mut self) {
         self.accumulator.clear();
+        self.pending_rescan = false;
         self.burst_start = None;
         self.flush_deadline = None;
     }
@@ -265,6 +283,15 @@ impl WatchPipeline {
                 return Ok(());
             }
         };
+
+        if event.need_rescan() {
+            tracing::warn!("backend dropped events (rescan flag); scheduling a rescan flush");
+            self.pending_rescan = true;
+            let now = Instant::now();
+            let bs = *self.burst_start.get_or_insert(now);
+            self.flush_deadline = Some((now + IDLE_WINDOW).min(bs + MAX_WAIT));
+            return Ok(());
+        }
 
         let raw = RawWatchEvent::new(event);
 
@@ -353,7 +380,7 @@ impl WatchPipeline {
                         // FORCE_FLUSH_QUIET window so a trickle isn't cut
                         // mid-stream. Bounded by FORCE_FLUSH_MAX.
                         let deadline = handler_started_at + FORCE_FLUSH_MAX;
-                        let mut burst_in_progress = !self.accumulator.is_empty();
+                        let mut burst_in_progress = self.has_pending();
                         while fatal.is_none() {
                             let now = Instant::now();
                             if now >= deadline {
@@ -406,7 +433,7 @@ impl WatchPipeline {
                     Err(_) => break, // struct dropped or stop() called
                 },
                 default(idle_wait) => {
-                    if !self.accumulator.is_empty() {
+                    if self.has_pending() {
                         let events = self.snapshot_events();
                         debug!(count = events.len(), "idle-window emitting events");
                         for e in &events {
@@ -588,6 +615,37 @@ mod tests {
 
     fn find_event<'a>(events: &'a [WatchEvent], name: &str) -> Option<&'a WatchEvent> {
         events.iter().find(|e| e.path.ends_with(name))
+    }
+
+    #[test]
+    fn rescan_flag_supersedes_accumulated_events() {
+        use notify::event::{CreateKind, Flag};
+
+        let dir = tempdir().expect("tempdir");
+        let canonical = dir.path().canonicalize().expect("canonicalize tempdir");
+        let mut pipeline = WatchPipeline::new(
+            canonical.to_str().expect("utf-8 path").to_string(),
+            &[],
+            false,
+        )
+        .expect("pipeline");
+
+        let file = canonical.join("file.txt");
+        fs::write(&file, "x").expect("write");
+        let create = notify::Event::new(notify::EventKind::Create(CreateKind::File)).add_path(file);
+        pipeline.ingest_event(Ok(create)).expect("ingest create");
+        assert!(pipeline.has_pending());
+
+        let overflow = notify::Event::new(notify::EventKind::Other).set_flag(Flag::Rescan);
+        pipeline.ingest_event(Ok(overflow)).expect("ingest rescan");
+
+        let events = pipeline.snapshot_events();
+        assert_eq!(events.len(), 1);
+        assert!(matches!(events[0].r#type, EventType::rescan));
+        assert_eq!(events[0].path, "");
+
+        pipeline.reset_burst();
+        assert!(!pipeline.has_pending());
     }
 
     #[test]


### PR DESCRIPTION

## Current Behavior

When the kernel cannot deliver every file event, Nx loses the difference silently and permanently.

- On Linux this is live today: an inotify queue overflow arrives as notify's rescan flag and Nx discards it. Forced with `fs.inotify.max_queued_events=16` against Nx's real watcher, a 5,000-file burst delivered 2,026-2,745 per-path events across runs and a 20,000-file burst delivered 7,731 - 45-61% of changes lost with no signal of any kind.
- On Windows the loss mode measured during #36811's review (16.7% under bulk writes with a recursive root) is structurally invisible: notify 8 never raises rescan on Windows and Nx handles rescan on no platform.

In both cases the daemon's view of the workspace diverges from disk and stays wrong until someone diagnoses the mystery and runs `nx reset`.

## Expected Behavior

Overflow becomes visible and bounded, per the triage guidance on #36563 ("#36811's strategy change plus something that makes the event loss either visible or bounded"):

1. The native watcher recognises notify's rescan flag and emits a single rescan event that supersedes the accumulated batch - it is emitted in place of, never alongside, per-path events. The new `rescan` member of the napi `EventType` string enum is additive; the regenerated `index.d.ts` is included.
2. The daemon intercepts a rescan ahead of normal change routing, re-walks the workspace, diffs it against the known file map, and synthesizes exactly the missed create/update/delete events through the same recomputation path ordinary changes take. A rescan that finds no differences preserves the cached graph promise untouched.
3. Recorded output hashes are cleared once, so cache restoration re-verifies instead of trusting possibly stale output state - the cost is a single re-verify per affected task, not the permanent copy-mode fallback of `disableOutputsTracking()`. Because the outputs watcher is also the only reporter of gitignored dotenv edits, its rescan additionally invalidates the graph cache as a fail-safe.

This PR deliberately does not change watch registration: the recovery hangs off each watcher's event pipeline, so it remains correct under any registration strategy - including #36811's recursive root and the single-shared-registration direction discussed in #36810. The per-directory handle slope is removed by #36811, and the two compose - validated by applying #36811's changes onto this branch and running the full suites and measurements on the combined tree (Windows 11 ARM64, real watcher). Footprint on that tree is flat at 3 handles / ~0.2 MB up to 192,206 directories (one-time warm-up of 4 handles / 2.8 MB at the 1,000-directory rung), with watcher startup flat at 1.8s against 34.1s on main at the top rung. With the notify 9 pin also applied (Windows rescan requires notify 9; see below), a genuine `ReadDirectoryChangesW` buffer overflow - a four-thread rename storm against the 16 KB buffer - produced exactly one rescan event. The same recovery on Linux under the current notify 8 pin: exactly one rescan per forced overflow at both burst sizes.

Recovery cost, measured at 129,348 files: 2.2s cold / 0.3s warm (5.2s / 0.8s at double). Before this PR the comparable number does not exist, because there is no recovery.

notify versions: the Linux rescan flag arrives under notify 8, so that path is live with this PR alone. The Windows rescan flag requires notify 9 (notify-rs/notify#964, first in 9.0.0-rc.5); a branch bumping the pin is validated end to end and can follow when notify 9.0.0 stable is released.

Tests: a Rust unit test for rescan superseding the accumulated batch; daemon integration tests proving missed changes are recovered exactly and a no-change rescan preserves the cached graph; an outputs-watcher rescan test. Full Rust suite 576/576, all daemon suites 268/268, watch integration tests 16/16 on Windows 11 ARM64; prepush, lint and typecheck green.

## Related Issue(s)

Addresses the recovery half of #36563; composes with #36811.
