### PR TITLE
fix(core): replace minimatch with picomatch

### DIFF
--- a/astro-docs/src/content/docs/reference/nx-json.mdoc
+++ b/astro-docs/src/content/docs/reference/nx-json.mdoc
@@ -602,7 +602,7 @@ By default, Nx checks for matching tags on the current branch. If no tags are fo
 | ---------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `true`     | Always check all branches for the latest matching tag                                                                                                                     |
 | `false`    | Only check the current branch (no fallback to all branches)                                                                                                               |
-| `string[]` | Check all branches when the current branch matches any of the provided names or [glob patterns](https://github.com/isaacs/minimatch). Otherwise, use the default behavior |
+| `string[]` | Check all branches when the current branch matches any of the provided names or [glob patterns](https://github.com/micromatch/picomatch#globbing-features). Otherwise, use the default behavior |
 
 This option is useful when release tags may exist on multiple branches. Setting `checkAllBranchesWhen` to `true` or to a list of branch patterns ensures Nx finds the latest tag regardless of which branch it was created on.
 

--- a/astro-docs/src/content/docs/reference/project-configuration.mdoc
+++ b/astro-docs/src/content/docs/reference/project-configuration.mdoc
@@ -746,7 +746,7 @@ belonging to `myteam` are not depended on by libraries belong to `theirteam`.
 
 ### implicitDependencies
 
-Nx uses powerful source-code analysis to figure out your workspace's project graph. Some dependencies cannot be deduced statically, so you can set them manually like this. The `implicitDependencies` property is parsed with the [minimatch](https://github.com/isaacs/minimatch) library, so you can review that syntax for more advanced use cases.
+Nx uses powerful source-code analysis to figure out your workspace's project graph. Some dependencies cannot be deduced statically, so you can set them manually like this. The `implicitDependencies` property is parsed with the [picomatch](https://github.com/micromatch/picomatch#globbing-features) library, so you can review that syntax for more advanced use cases.
 
 {% tabs syncKey="project-config-file"  %}
 {% tabitem label="package.json" %}

--- a/package.json
+++ b/package.json
@@ -250,7 +250,6 @@
     "metro-config": "~0.82.4",
     "metro-resolver": "~0.82.4",
     "mini-css-extract-plugin": "~2.4.7",
-    "minimatch": "catalog:",
     "next-sitemap": "^3.1.10",
     "ng-packagr": "catalog:angular",
     "nuxt": "^3.21.10",

--- a/packages/devkit/internal.ts
+++ b/packages/devkit/internal.ts
@@ -78,6 +78,7 @@ export {
 } from './src/utils/calculate-hash-for-create-nodes';
 export { loadConfigFile, clearRequireCache } from './src/utils/config-utils';
 export { findPluginForConfigFile } from './src/utils/find-plugin-for-config-file';
+export { splitGlobPatterns } from './src/utils/glob-patterns';
 export { getNamedInputs } from './src/utils/get-named-inputs';
 export { logShowProjectCommand } from './src/utils/log-show-project-command';
 export { eachValueFrom } from './src/utils/rxjs-for-await';

--- a/packages/devkit/internal.ts
+++ b/packages/devkit/internal.ts
@@ -189,6 +189,8 @@ export {
   getFilesInDirectoryUsingContext,
   getGeneratorInformation,
   getGlobPatternsFromPackageManagerWorkspaces,
+  buildPackageJsonPatterns,
+  buildPackageJsonWorkspacesMatcher,
   getLastValueFromAsyncIterableIterator,
   getLatestCommitSha,
   getLockFileName,

--- a/packages/devkit/package.json
+++ b/packages/devkit/package.json
@@ -63,7 +63,7 @@
     "tslib": "catalog:typescript",
     "semver": "catalog:",
     "yargs-parser": "catalog:",
-    "minimatch": "catalog:",
+    "picomatch": "catalog:",
     "enquirer": "catalog:"
   },
   "devDependencies": {

--- a/packages/devkit/src/generators/plugin-migrations/executor-to-plugin-migrator.ts
+++ b/packages/devkit/src/generators/plugin-migrations/executor-to-plugin-migrator.ts
@@ -1,4 +1,4 @@
-import { minimatch } from 'minimatch';
+import picomatch from 'picomatch';
 import { deepStrictEqual } from 'node:assert';
 import { join } from 'node:path/posix';
 import type {
@@ -610,7 +610,7 @@ async function addPluginRegistrations<T>(
     } else if (existingPlugin.include) {
       if (
         !existingPlugin.include.some((include) =>
-          minimatch(projectIncludeGlob, include, { dot: true })
+          picomatch.isMatch(projectIncludeGlob, include, { dot: true })
         )
       ) {
         existingPlugin.include.push(projectIncludeGlob);

--- a/packages/devkit/src/generators/target-defaults-utils.ts
+++ b/packages/devkit/src/generators/target-defaults-utils.ts
@@ -18,7 +18,8 @@ import {
   findMatchingProjects,
   readTargetDefaultsForTarget as readTargetDefaultsForTargetFromNx,
 } from 'nx/src/devkit-internals';
-import { minimatch } from 'minimatch';
+import { splitGlobPatterns } from '../utils/glob-patterns';
+import picomatch from 'picomatch';
 
 /**
  * Upsert a `targetDefaults` entry on the provided `nxJson`. Mutates
@@ -567,7 +568,9 @@ export async function addE2eCiTargetDefaults(
   // include/exclude filters are applied.
   const e2eConfigMatchesPluginGlob =
     !e2ePluginGlob ||
-    minimatch(pathToE2EConfigFile, e2ePluginGlob, { dot: true });
+    picomatch.isMatch(pathToE2EConfigFile, splitGlobPatterns(e2ePluginGlob), {
+      dot: true,
+    });
 
   let foundPluginForApplication: PluginConfiguration;
   for (let i = 0; i < e2ePluginRegistrations.length; i++) {

--- a/packages/devkit/src/utils/find-plugin-for-config-file.ts
+++ b/packages/devkit/src/utils/find-plugin-for-config-file.ts
@@ -5,7 +5,8 @@ import {
   CreateNodes,
 } from 'nx/src/devkit-exports';
 import { findMatchingConfigFiles } from 'nx/src/devkit-internals';
-import { minimatch } from 'minimatch';
+import { splitGlobPatterns } from './glob-patterns';
+import picomatch from 'picomatch';
 export async function findPluginForConfigFile(
   tree: Tree,
   pluginName: string,
@@ -40,7 +41,10 @@ export async function findPluginForConfigFile(
       // the plugin's createNodes glob) before the registration's include/exclude
       // filters are applied.
       const matchingConfigFile =
-        !pluginGlob || minimatch(pathToConfigFile, pluginGlob, { dot: true })
+        !pluginGlob ||
+        picomatch.isMatch(pathToConfigFile, splitGlobPatterns(pluginGlob), {
+          dot: true,
+        })
           ? findMatchingConfigFiles(
               [pathToConfigFile],
               plugin.include,

--- a/packages/devkit/src/utils/glob-patterns.spec.ts
+++ b/packages/devkit/src/utils/glob-patterns.spec.ts
@@ -1,0 +1,22 @@
+import { splitGlobPatterns } from './glob-patterns';
+
+describe('splitGlobPatterns', () => {
+  it.each([
+    [
+      ['**/project.json', '**/package.json'],
+      '{**/project.json,**/package.json}',
+    ],
+    [
+      ['**/tsconfig*{.json,.*.json}', '**/x'],
+      '{**/tsconfig*{.json,.*.json},**/x}',
+    ],
+    [['**/*.ts'], '**/*.ts'],
+    [['{a,b}/c'], '{a,b}/c'],
+    [['{a,b}/{c,d}'], '{a,b}/{c,d}'],
+    [['{a,{b}'], '{a,{b}'],
+    [['a', 'b'], '{a,b}'],
+    [[''], ''],
+  ])('should return %j for %s', (expected, pattern) => {
+    expect(splitGlobPatterns(pattern)).toEqual(expected);
+  });
+});

--- a/packages/devkit/src/utils/glob-patterns.spec.ts
+++ b/packages/devkit/src/utils/glob-patterns.spec.ts
@@ -15,7 +15,9 @@ describe('splitGlobPatterns', () => {
     [['{a,b}/{c,d}'], '{a,b}/{c,d}'],
     [['{a,{b}'], '{a,{b}'],
     [['a', 'b'], '{a,b}'],
-    [[''], ''],
+    // never an empty pattern - picomatch throws on '', every caller counts length
+    [[], ''],
+    [['a', 'b'], '{a,,b}'],
   ])('should return %j for %s', (expected, pattern) => {
     expect(splitGlobPatterns(pattern)).toEqual(expected);
   });

--- a/packages/devkit/src/utils/glob-patterns.ts
+++ b/packages/devkit/src/utils/glob-patterns.ts
@@ -3,10 +3,13 @@
  * individual patterns. picomatch drops the `**\/` zero-segment match inside
  * brace alternation, so `{**\/a,**\/b}` misses root-level files unless split.
  * Local copy: the nx version is not available in all supported nx majors.
+ * Keep in sync with packages/nx/src/utils/globs.ts.
  */
 export function splitGlobPatterns(pattern: string): string[] {
   if (!pattern.startsWith('{') || !pattern.endsWith('}')) {
-    return [pattern];
+    // never emit an empty pattern - picomatch throws on '', where minimatch
+    // matched nothing
+    return pattern ? [pattern] : [];
   }
   const inner = pattern.slice(1, -1);
   const parts: string[] = [];
@@ -26,5 +29,5 @@ export function splitGlobPatterns(pattern: string): string[] {
   }
   if (depth !== 0) return [pattern];
   parts.push(inner.slice(start));
-  return parts;
+  return parts.filter(Boolean);
 }

--- a/packages/devkit/src/utils/glob-patterns.ts
+++ b/packages/devkit/src/utils/glob-patterns.ts
@@ -1,0 +1,30 @@
+/**
+ * Splits a combined `{a,b}` glob (from nx's combineGlobPatterns) into its
+ * individual patterns. picomatch drops the `**\/` zero-segment match inside
+ * brace alternation, so `{**\/a,**\/b}` misses root-level files unless split.
+ * Local copy: the nx version is not available in all supported nx majors.
+ */
+export function splitGlobPatterns(pattern: string): string[] {
+  if (!pattern.startsWith('{') || !pattern.endsWith('}')) {
+    return [pattern];
+  }
+  const inner = pattern.slice(1, -1);
+  const parts: string[] = [];
+  let depth = 0;
+  let start = 0;
+  for (let i = 0; i < inner.length; i++) {
+    const c = inner[i];
+    if (c === '{') {
+      depth++;
+    } else if (c === '}') {
+      // outer brace closes mid-pattern (e.g. `{a,b}/{c,d}`) - not combined
+      if (--depth < 0) return [pattern];
+    } else if (c === ',' && depth === 0) {
+      parts.push(inner.slice(start, i));
+      start = i + 1;
+    }
+  }
+  if (depth !== 0) return [pattern];
+  parts.push(inner.slice(start));
+  return parts;
+}

--- a/packages/eslint/src/plugins/plugin.spec.ts
+++ b/packages/eslint/src/plugins/plugin.spec.ts
@@ -1,5 +1,5 @@
 import { CreateNodesContext } from '@nx/devkit';
-import { splitGlobPatterns } from 'nx/src/utils/globs';
+import { splitGlobPatterns } from '@nx/devkit/internal';
 import picomatch from 'picomatch';
 import { TempFs } from '@nx/devkit/internal-testing-utils';
 import { createNodesV2, EslintPluginOptions } from './plugin';

--- a/packages/eslint/src/plugins/plugin.spec.ts
+++ b/packages/eslint/src/plugins/plugin.spec.ts
@@ -1,5 +1,6 @@
 import { CreateNodesContext } from '@nx/devkit';
-import { minimatch } from 'minimatch';
+import { splitGlobPatterns } from 'nx/src/utils/globs';
+import picomatch from 'picomatch';
 import { TempFs } from '@nx/devkit/internal-testing-utils';
 import { createNodesV2, EslintPluginOptions } from './plugin';
 import { mkdirSync, rmSync } from 'fs';
@@ -1180,7 +1181,9 @@ describe('@nx/eslint/plugin', () => {
 
   function getMatchingFiles(allConfigFiles: string[]): string[] {
     return allConfigFiles.filter((file) =>
-      minimatch(file, createNodesV2[0], { dot: true })
+      picomatch.isMatch(file, splitGlobPatterns(createNodesV2[0]), {
+        dot: true,
+      })
     );
   }
 

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -113,7 +113,7 @@
     "jest-resolve": "catalog:jest",
     "jest-util": "catalog:jest",
     "jsonc-parser": "catalog:",
-    "minimatch": "catalog:",
+    "picomatch": "catalog:",
     "picocolors": "catalog:",
     "resolve.exports": "2.0.3",
     "semver": "catalog:",

--- a/packages/jest/package.json
+++ b/packages/jest/package.json
@@ -113,7 +113,6 @@
     "jest-resolve": "catalog:jest",
     "jest-util": "catalog:jest",
     "jsonc-parser": "catalog:",
-    "picomatch": "catalog:",
     "picocolors": "catalog:",
     "resolve.exports": "2.0.3",
     "semver": "catalog:",

--- a/packages/jest/src/plugins/plugin.spec.ts
+++ b/packages/jest/src/plugins/plugin.spec.ts
@@ -471,6 +471,27 @@ describe.each([true, false])('@nx/jest/plugin', (disableJestRuntime) => {
     }
   );
 
+  it('should not create nodes for packages outside the package manager workspaces', async () => {
+    await tempFs.createFiles({
+      'package.json': JSON.stringify({
+        name: 'root',
+        workspaces: ['packages/*', '!packages/excluded'],
+      }),
+      'packages/excluded/jest.config.js': `module.exports = {}`,
+      'packages/excluded/package.json': '{}',
+      'tools/proj/jest.config.js': `module.exports = {}`,
+      'tools/proj/package.json': '{}',
+    });
+
+    const results = await createNodesFunction(
+      ['packages/excluded/jest.config.js', 'tools/proj/jest.config.js'],
+      { targetName: 'test', disableJestRuntime },
+      context
+    );
+
+    expect(results).toEqual([]);
+  });
+
   describe('ciGroupName', () => {
     it('should name atomized tasks group using provided group name', async () => {
       mockJestConfig(

--- a/packages/jest/src/plugins/plugin.spec.ts
+++ b/packages/jest/src/plugins/plugin.spec.ts
@@ -492,6 +492,27 @@ describe.each([true, false])('@nx/jest/plugin', (disableJestRuntime) => {
     expect(results).toEqual([]);
   });
 
+  it('should create nodes for packages inside the package manager workspaces', async () => {
+    await tempFs.createFiles({
+      'package.json': JSON.stringify({
+        name: 'root',
+        workspaces: ['packages/*', '!packages/excluded'],
+      }),
+      'packages/included/jest.config.js': `module.exports = {}`,
+      'packages/included/package.json': '{}',
+    });
+
+    const results = await createNodesFunction(
+      ['packages/included/jest.config.js'],
+      { targetName: 'test', disableJestRuntime },
+      context
+    );
+
+    expect(results.map(([file]) => file)).toEqual([
+      'packages/included/jest.config.js',
+    ]);
+  });
+
   describe('ciGroupName', () => {
     it('should name atomized tasks group using provided group name', async () => {
       mockJestConfig(

--- a/packages/jest/src/plugins/plugin.ts
+++ b/packages/jest/src/plugins/plugin.ts
@@ -5,7 +5,8 @@ import {
   getNamedInputs,
   PluginCache,
   hashObject,
-  getGlobPatternsFromPackageManagerWorkspaces,
+  buildPackageJsonPatterns,
+  buildPackageJsonWorkspacesMatcher as buildWorkspacesMatcher,
   getNxRequirePaths,
   deriveGroupNameFromTarget,
   globWithWorkspaceContext,
@@ -21,9 +22,9 @@ import {
   normalizePath,
   NxJsonConfiguration,
   ProjectConfiguration,
+  readJsonFile,
   TargetConfiguration,
 } from '@nx/devkit';
-import picomatch from 'picomatch';
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import {
   dirname,
@@ -235,22 +236,13 @@ function buildPackageJsonWorkspacesMatcher(
     return () => true;
   }
 
-  const packageManagerWorkspacesGlobs =
-    getGlobPatternsFromPackageManagerWorkspaces(workspaceRoot);
-
-  // mixing negations into one picomatch call would let any path match via
-  // "not excluded"; require a positive match, then reject negated ones.
-  // an empty positive list matches nothing, same as the empty combined glob
-  // did with minimatch
-  const positive = packageManagerWorkspacesGlobs.filter(
-    (p) => !p.startsWith('!')
+  // Reuse nx core's matcher so @nx/jest and nx/core/package-json can never
+  // disagree about which package.json files are inside the workspaces.
+  return buildWorkspacesMatcher(
+    buildPackageJsonPatterns(workspaceRoot, (f) =>
+      readJsonFile(join(workspaceRoot, f))
+    )
   );
-  const negated = packageManagerWorkspacesGlobs
-    .filter((p) => p.startsWith('!'))
-    .map((p) => p.substring(1));
-  const isPositive = picomatch(positive);
-  const isNegated = negated.length ? picomatch(negated) : () => false;
-  return (path: string) => isPositive(path) && !isNegated(path);
 }
 
 function checkIfConfigFileShouldBeProject(

--- a/packages/jest/src/plugins/plugin.ts
+++ b/packages/jest/src/plugins/plugin.ts
@@ -6,7 +6,6 @@ import {
   PluginCache,
   hashObject,
   getGlobPatternsFromPackageManagerWorkspaces,
-  combineGlobPatterns,
   getNxRequirePaths,
   deriveGroupNameFromTarget,
   globWithWorkspaceContext,
@@ -24,7 +23,7 @@ import {
   ProjectConfiguration,
   TargetConfiguration,
 } from '@nx/devkit';
-import { minimatch } from 'minimatch';
+import picomatch from 'picomatch';
 import { existsSync, readdirSync, readFileSync } from 'node:fs';
 import {
   dirname,
@@ -236,11 +235,22 @@ function buildPackageJsonWorkspacesMatcher(
     return () => true;
   }
 
-  const packageManagerWorkspacesGlob = combineGlobPatterns(
-    getGlobPatternsFromPackageManagerWorkspaces(workspaceRoot)
-  );
+  const packageManagerWorkspacesGlobs =
+    getGlobPatternsFromPackageManagerWorkspaces(workspaceRoot);
 
-  return (path: string) => minimatch(path, packageManagerWorkspacesGlob);
+  // mixing negations into one picomatch call would let any path match via
+  // "not excluded"; require a positive match, then reject negated ones.
+  // an empty positive list matches nothing, same as the empty combined glob
+  // did with minimatch
+  const positive = packageManagerWorkspacesGlobs.filter(
+    (p) => !p.startsWith('!')
+  );
+  const negated = packageManagerWorkspacesGlobs
+    .filter((p) => p.startsWith('!'))
+    .map((p) => p.substring(1));
+  const isPositive = picomatch(positive);
+  const isNegated = negated.length ? picomatch(negated) : () => false;
+  return (path: string) => isPositive(path) && !isNegated(path);
 }
 
 function checkIfConfigFileShouldBeProject(

--- a/packages/nx/package.json
+++ b/packages/nx/package.json
@@ -69,7 +69,7 @@
     "@jest/diff-sequences": "30.0.1",
     "jsonc-parser": "catalog:",
     "lines-and-columns": "2.0.3",
-    "minimatch": "catalog:",
+    "picomatch": "catalog:",
     "npm-run-path": "^4.0.1",
     "open": "^10.1.0",
     "ora": "catalog:",

--- a/packages/nx/src/command-line/graph/graph.ts
+++ b/packages/nx/src/command-line/graph/graph.ts
@@ -10,7 +10,7 @@ import {
 } from 'node:fs';
 import { VersionMismatchError } from '../../daemon/client/daemon-socket-messenger';
 import * as http from 'node:http';
-import { minimatch } from 'minimatch';
+import picomatch from 'picomatch';
 import { URL } from 'node:url';
 import {
   basename,
@@ -1469,15 +1469,15 @@ function getExpandedWorkspaceRoots(
     const matchingFile = allWorkspaceFiles.find((t) => t.file === pattern);
     if (
       matchingFile &&
-      !negativeWRPatterns.some((p) => minimatch(matchingFile.file, p))
+      !negativeWRPatterns.some((p) => picomatch.isMatch(matchingFile.file, p))
     ) {
       workspaceRootsExpanded.push(matchingFile.file);
     } else {
       allWorkspaceFiles
         .filter(
           (f) =>
-            minimatch(f.file, pattern) &&
-            !negativeWRPatterns.some((p) => minimatch(f.file, p))
+            picomatch.isMatch(f.file, pattern) &&
+            !negativeWRPatterns.some((p) => picomatch.isMatch(f.file, p))
         )
         .forEach((f) => {
           workspaceRootsExpanded.push(f.file);

--- a/packages/nx/src/command-line/import/import.ts
+++ b/packages/nx/src/command-line/import/import.ts
@@ -26,7 +26,7 @@ import { runInstall } from '../init/implementation/utils';
 import { getBaseRef } from '../../utils/command-line-utils';
 import { prepareSourceRepo } from './utils/prepare-source-repo';
 import { mergeRemoteSource } from './utils/merge-remote-source';
-import { minimatch } from 'minimatch';
+import picomatch from 'picomatch';
 import {
   configurePlugins,
   installPluginPackages,
@@ -788,7 +788,7 @@ async function handleMissingWorkspacesEntry(
     });
   } else {
     let workspaces: string[] = getPackageWorkspaces(pm, workspaceRoot);
-    const isPkgIncluded = workspaces.some((w) => minimatch(pkgPath, w));
+    const isPkgIncluded = workspaces.some((w) => picomatch.isMatch(pkgPath, w));
     if (isPkgIncluded) {
       return;
     }

--- a/packages/nx/src/command-line/release/utils/repository-git-tags.ts
+++ b/packages/nx/src/command-line/release/utils/repository-git-tags.ts
@@ -1,4 +1,4 @@
-import { minimatch } from 'minimatch';
+import picomatch from 'picomatch';
 import { execCommand } from './exec-command';
 
 /**
@@ -132,11 +132,11 @@ export class RepoGitTags {
         // Check if any glob pattern matches next
         if (!alwaysCheckAllBranches) {
           alwaysCheckAllBranches = checkAllBranchesWhen.some((pattern) => {
-            const r = minimatch.makeRe(pattern, { dot: true });
-            if (!r) {
+            // minimatch.makeRe returned false for empty patterns; picomatch throws
+            if (!pattern) {
               return false;
             }
-            return r.test(currentBranch);
+            return picomatch.makeRe(pattern, { dot: true }).test(currentBranch);
           });
         }
       }

--- a/packages/nx/src/devkit-internals.ts
+++ b/packages/nx/src/devkit-internals.ts
@@ -145,7 +145,11 @@ export {
 } from './plugins/js/project-graph/build-dependencies/target-project-locator';
 export { getWorkspacePackagesFromGraph } from './plugins/js/utils/get-workspace-packages-from-graph';
 export { registerTsConfigPaths } from './plugins/js/utils/register';
-export { getGlobPatternsFromPackageManagerWorkspaces } from './plugins/package-json';
+export {
+  getGlobPatternsFromPackageManagerWorkspaces,
+  buildPackageJsonPatterns,
+  buildPackageJsonWorkspacesMatcher,
+} from './plugins/package-json';
 // NOTE: distinct from @nx/devkit's public FileChange (generators/tree.ts), which
 // describes a pending Tree write ({ path, type: 'CREATE' | 'DELETE' | 'UPDATE',
 // content }). This one describes a per-file diff ({ file, getChanges }). The two

--- a/packages/nx/src/generators/utils/glob.spec.ts
+++ b/packages/nx/src/generators/utils/glob.spec.ts
@@ -65,4 +65,21 @@ describe('glob', () => {
       ]
     `);
   });
+
+  it('should not match tree files that only satisfy a negated pattern', async () => {
+    tree.write('packages/a/package.json', '{}');
+    tree.write('packages/excluded/package.json', '{}');
+    tree.write('tools/package.json', '{}');
+
+    const withTree = glob(tree, [
+      'packages/*/package.json',
+      '!packages/excluded/package.json',
+    ]).sort();
+
+    expect(withTree).toMatchInlineSnapshot(`
+      [
+        "packages/a/package.json",
+      ]
+    `);
+  });
 });

--- a/packages/nx/src/generators/utils/glob.spec.ts
+++ b/packages/nx/src/generators/utils/glob.spec.ts
@@ -82,4 +82,50 @@ describe('glob', () => {
       ]
     `);
   });
+
+  it('should match root-level tree files against a combined brace pattern', async () => {
+    tree.write('package.json', '{}');
+    tree.write('libs/a/package.json', '{}');
+    tree.write('libs/a/other.md', '');
+
+    const withTree = glob(tree, ['{**/package.json,**/project.json}']).sort();
+
+    expect(withTree).toEqual(['libs/a/package.json', 'package.json']);
+  });
+
+  it('should hide a deleted root-level file for a combined brace pattern', async () => {
+    fs.createFilesSync({
+      'package.json': '{}',
+      'libs/a/package.json': '{}',
+    });
+    tree.delete('package.json');
+
+    const withTree = glob(tree, ['{**/package.json,**/project.json}']).sort();
+
+    expect(withTree).toEqual(['libs/a/package.json']);
+  });
+
+  it('should treat a list of only negations as everything not excluded', async () => {
+    tree.write('keep.txt', '1');
+    tree.write('drop.txt', '2');
+
+    const withTree = glob(tree, ['!drop.txt']).sort();
+
+    expect(withTree).toEqual(['keep.txt']);
+  });
+
+  it('should treat a leading "!(" as an extglob, not a negation', async () => {
+    tree.write('tools/a/package.json', '{}');
+    tree.write('libs/a/package.json', '{}');
+
+    const withTree = glob(tree, ['!(tools)/**/package.json']).sort();
+
+    expect(withTree).toEqual(['libs/a/package.json']);
+  });
+
+  it('should name the offending entry when a pattern is empty', async () => {
+    expect(() => glob(tree, ['**/*.ts', ''])).toThrow(
+      'Invalid glob pattern: ""'
+    );
+  });
 });

--- a/packages/nx/src/generators/utils/glob.ts
+++ b/packages/nx/src/generators/utils/glob.ts
@@ -1,4 +1,4 @@
-import { minimatch } from 'minimatch';
+import picomatch from 'picomatch';
 import { Tree } from '../tree';
 import { combineGlobPatterns } from '../../utils/globs';
 import {
@@ -51,15 +51,27 @@ function combineGlobResultsWithTree(
 ) {
   const matches = new Set(results);
 
-  const combinedGlob = combineGlobPatterns(patterns);
-  const matcher = minimatch.makeRe(combinedGlob);
-
-  if (!matcher) {
-    throw new Error('Invalid glob pattern: ' + combinedGlob);
+  let matcher: (path: string) => boolean;
+  try {
+    if (!patterns.length) {
+      throw new Error('no patterns');
+    }
+    // mixing negations into one picomatch call would let any path match via
+    // "not excluded"; require a positive match, then reject negated ones
+    const positive = patterns.filter((p) => !p.startsWith('!'));
+    const negated = patterns
+      .filter((p) => p.startsWith('!'))
+      .map((p) => p.substring(1));
+    const isPositive = picomatch(positive);
+    const isNegated = negated.length ? picomatch(negated) : () => false;
+    matcher = (path) => isPositive(path) && !isNegated(path);
+  } catch {
+    // picomatch throws on empty patterns where minimatch.makeRe returned false
+    throw new Error('Invalid glob pattern: ' + combineGlobPatterns(patterns));
   }
 
   for (const change of tree.listChanges()) {
-    if (change.type !== 'UPDATE' && matcher.test(change.path)) {
+    if (change.type !== 'UPDATE' && matcher(change.path)) {
       if (change.type === 'CREATE') {
         matches.add(change.path);
       } else if (change.type === 'DELETE') {

--- a/packages/nx/src/generators/utils/glob.ts
+++ b/packages/nx/src/generators/utils/glob.ts
@@ -1,6 +1,6 @@
 import picomatch from 'picomatch';
 import { Tree } from '../tree';
-import { combineGlobPatterns } from '../../utils/globs';
+import { combineGlobPatterns, splitGlobPatterns } from '../../utils/globs';
 import {
   globWithWorkspaceContext,
   globWithWorkspaceContextSync,
@@ -52,23 +52,27 @@ function combineGlobResultsWithTree(
   const matches = new Set(results);
 
   let matcher: (path: string) => boolean;
-  try {
-    if (!patterns.length) {
-      throw new Error('no patterns');
-    }
-    // mixing negations into one picomatch call would let any path match via
-    // "not excluded"; require a positive match, then reject negated ones
-    const positive = patterns.filter((p) => !p.startsWith('!'));
-    const negated = patterns
-      .filter((p) => p.startsWith('!'))
-      .map((p) => p.substring(1));
-    const isPositive = picomatch(positive);
-    const isNegated = negated.length ? picomatch(negated) : () => false;
-    matcher = (path) => isPositive(path) && !isNegated(path);
-  } catch {
-    // picomatch throws on empty patterns where minimatch.makeRe returned false
-    throw new Error('Invalid glob pattern: ' + combineGlobPatterns(patterns));
+  const invalid = patterns.find((p) => !p);
+  if (!patterns.length || invalid !== undefined) {
+    // picomatch throws on an empty pattern where minimatch.makeRe returned false
+    throw new Error(
+      'Invalid glob pattern: ' +
+        JSON.stringify(invalid ?? combineGlobPatterns(patterns))
+    );
   }
+  // Mirror NxGlobSet::is_match in src/native/glob.rs, which produced `results`:
+  // a positive glob must match and no negation may, and a list of only
+  // negations matches everything it does not exclude. Folding the negations
+  // into one picomatch call instead would let any path match via "not
+  // excluded". `!(` opens an extglob, not a negation.
+  const isNegation = (p: string) => p.startsWith('!') && !p.startsWith('!(');
+  const positive = patterns
+    .filter((p) => !isNegation(p))
+    .flatMap(splitGlobPatterns);
+  const negators = patterns.filter(isNegation).map((p) => picomatch(p));
+  const isPositive =
+    negators.length && !positive.length ? () => true : picomatch(positive);
+  matcher = (path) => isPositive(path) && negators.every((m) => m(path));
 
   for (const change of tree.listChanges()) {
     if (change.type !== 'UPDATE' && matcher(change.path)) {

--- a/packages/nx/src/generators/utils/project-configuration.ts
+++ b/packages/nx/src/generators/utils/project-configuration.ts
@@ -1,4 +1,4 @@
-import { minimatch } from 'minimatch';
+import picomatch from 'picomatch';
 import { basename, dirname, join, relative } from 'path';
 
 import { getGlobPatternsFromPackageManagerWorkspaces } from '../../plugins/package-json';
@@ -369,7 +369,7 @@ function findCreatedProjectFiles(tree: Tree, globPatterns: string[]) {
       const fileName = basename(change.path);
       if (
         globPatterns.some((pattern) =>
-          minimatch(change.path, pattern, { dot: true })
+          picomatch.isMatch(change.path, pattern, { dot: true })
         )
       ) {
         createdProjectFiles.push(change.path);
@@ -398,7 +398,7 @@ function findDeletedProjectFiles(tree: Tree, globPatterns: string[]) {
     .filter((f) => {
       return (
         f.type === 'DELETE' &&
-        globPatterns.some((pattern) => minimatch(f.path, pattern))
+        globPatterns.some((pattern) => picomatch.isMatch(f.path, pattern))
       );
     })
     .map((r) => r.path);

--- a/packages/nx/src/hasher/task-hasher.spec.ts
+++ b/packages/nx/src/hasher/task-hasher.spec.ts
@@ -269,6 +269,23 @@ describe('TaskHasher', () => {
       expect(filtered.map((f) => f.file)).toEqual(['root/a.ts', 'root/b.js']);
     });
 
+    it('should match root-level files against brace patterns with globstars', () => {
+      const filtered = filterUsingGlobPatterns(
+        'libs/a',
+        [
+          { file: 'libs/a/index.ts' },
+          { file: 'libs/a/nested/comp.tsx' },
+          { file: 'libs/a/readme.md' },
+        ] as any,
+        ['{projectRoot}/{**/*.ts,**/*.tsx}']
+      );
+
+      expect(filtered.map((f) => f.file)).toEqual([
+        'libs/a/index.ts',
+        'libs/a/nested/comp.tsx',
+      ]);
+    });
+
     it('should OR all positive patterns and AND all negative patterns (when negative patterns)', () => {
       const filtered = filterUsingGlobPatterns(
         'root',

--- a/packages/nx/src/hasher/task-hasher.spec.ts
+++ b/packages/nx/src/hasher/task-hasher.spec.ts
@@ -286,6 +286,66 @@ describe('TaskHasher', () => {
       ]);
     });
 
+    it('should expand braces in negative patterns so root-level files are excluded', () => {
+      const filtered = filterUsingGlobPatterns(
+        'libs/a',
+        [
+          { file: 'libs/a/index.ts' },
+          { file: 'libs/a/nested/comp.tsx' },
+          { file: 'libs/a/readme.md' },
+        ] as any,
+        ['{projectRoot}/**/*', '!{projectRoot}/{**/*.ts,**/*.tsx}']
+      );
+
+      expect(filtered.map((f) => f.file)).toEqual(['libs/a/readme.md']);
+    });
+
+    it('should treat an empty pattern as matching nothing rather than throwing', () => {
+      expect(
+        filterUsingGlobPatterns('.', [{ file: 'index.ts' }] as any, [
+          '{projectRoot}/',
+        ])
+      ).toEqual([]);
+    });
+
+    it('should treat an empty brace alternative as matching nothing rather than throwing', () => {
+      const filtered = filterUsingGlobPatterns(
+        'libs/a',
+        [{ file: 'libs/a/index.ts' }, { file: 'libs/a/readme.md' }] as any,
+        ['{projectRoot}/{,**/*.ts}']
+      );
+
+      expect(filtered.map((f) => f.file)).toEqual(['libs/a/index.ts']);
+    });
+
+    it('should treat a bare "!" as excluding nothing rather than throwing', () => {
+      const files = [{ file: 'libs/a/index.ts' }] as any;
+
+      expect(
+        filterUsingGlobPatterns('libs/a', files, ['{projectRoot}/**/*', '!'])
+      ).toEqual(files);
+    });
+
+    it('should read [!...] as a negated character class, as minimatch did', () => {
+      const filtered = filterUsingGlobPatterns(
+        'libs/a',
+        [{ file: 'libs/a/index.ts' }, { file: 'libs/a/_private.ts' }] as any,
+        ['{projectRoot}/[!_]*.ts']
+      );
+
+      expect(filtered.map((f) => f.file)).toEqual(['libs/a/index.ts']);
+    });
+
+    it('should match root-level project files whose patterns expand to "./"', () => {
+      const filtered = filterUsingGlobPatterns(
+        '.',
+        [{ file: 'index.ts' }, { file: 'nested/a.ts' }] as any,
+        ['{projectRoot}/**/*.ts']
+      );
+
+      expect(filtered.map((f) => f.file)).toEqual(['index.ts', 'nested/a.ts']);
+    });
+
     it('should OR all positive patterns and AND all negative patterns (when negative patterns)', () => {
       const filtered = filterUsingGlobPatterns(
         'root',

--- a/packages/nx/src/hasher/task-hasher.ts
+++ b/packages/nx/src/hasher/task-hasher.ts
@@ -8,7 +8,8 @@ import { Task, TaskGraph } from '../config/task-graph';
 import { DaemonClient } from '../daemon/client/client';
 import { hashArray } from './file-hasher';
 import { InputDefinition } from '../config/workspace-json-project-json';
-import { minimatch } from 'minimatch';
+import picomatch from 'picomatch';
+import { expandGlobPatternBraces } from '../utils/globs';
 import { NativeTaskHasherImpl } from './native-task-hasher-impl';
 import { workspaceRoot } from '../utils/workspace-root';
 import { HashInputs, NxWorkspaceFilesExternals } from '../native';
@@ -493,7 +494,7 @@ export function filterUsingGlobPatterns(
   const filesetWithExpandedProjectRoot = patterns
     .map((f) => f.replace('{projectRoot}', root))
     .map((r) => {
-      // handling root level projects that create './' pattern that doesn't work with minimatch
+      // normalize './'-prefixed patterns from root level projects
       if (r.startsWith('./')) return r.substring(2);
       if (r.startsWith('!./')) return '!' + r.substring(3);
       return r;
@@ -513,6 +514,15 @@ export function filterUsingGlobPatterns(
     return files;
   }
 
+  // expand braces so `x/{**/*.ts,**/*.tsx}` matches `x/index.ts` (see
+  // expandGlobPatternBraces), and compile each pattern once
+  const positiveMatchers = positive.map((p) =>
+    picomatch(expandGlobPatternBraces(p))
+  );
+  const negativeMatchers = negative.map((p) =>
+    picomatch(expandGlobPatternBraces(p.substring(1)))
+  );
+
   return files.filter((f) => {
     let matchedPositive = false;
     if (
@@ -521,11 +531,11 @@ export function filterUsingGlobPatterns(
     ) {
       matchedPositive = true;
     } else {
-      matchedPositive = positive.some((pattern) => minimatch(f.file, pattern));
+      matchedPositive = positiveMatchers.some((m) => m(f.file));
     }
 
     if (!matchedPositive) return false;
 
-    return negative.every((pattern) => minimatch(f.file, pattern));
+    return negativeMatchers.every((m) => !m(f.file));
   });
 }

--- a/packages/nx/src/hasher/task-hasher.ts
+++ b/packages/nx/src/hasher/task-hasher.ts
@@ -491,14 +491,11 @@ export function filterUsingGlobPatterns(
   files: FileData[],
   patterns: string[]
 ): FileData[] {
-  const filesetWithExpandedProjectRoot = patterns
-    .map((f) => f.replace('{projectRoot}', root))
-    .map((r) => {
-      // normalize './'-prefixed patterns from root level projects
-      if (r.startsWith('./')) return r.substring(2);
-      if (r.startsWith('!./')) return '!' + r.substring(3);
-      return r;
-    });
+  // picomatch normalizes a leading './' itself, unlike minimatch, so root-level
+  // projects need no rewriting here
+  const filesetWithExpandedProjectRoot = patterns.map((f) =>
+    f.replace('{projectRoot}', root)
+  );
 
   const positive = [];
   const negative = [];
@@ -514,27 +511,26 @@ export function filterUsingGlobPatterns(
     return files;
   }
 
-  // expand braces so `x/{**/*.ts,**/*.tsx}` matches `x/index.ts` (see
-  // expandGlobPatternBraces), and compile each pattern once
-  const positiveMatchers = positive.map((p) =>
-    picomatch(expandGlobPatternBraces(p))
-  );
-  const negativeMatchers = negative.map((p) =>
-    picomatch(expandGlobPatternBraces(p.substring(1)))
-  );
+  const matchesEveryFile =
+    positive.length === 0 ||
+    (positive.length === 1 && positive[0] === `${root}/**/*`);
+
+  // Expand braces so `x/{**/*.ts,**/*.tsx}` matches `x/index.ts` (see
+  // expandGlobPatternBraces), and compile each pattern once. Empty products
+  // (`{,a}`, a bare `!`) are dropped - picomatch rejects '', where minimatch
+  // matched nothing. `posix` keeps `[!a]` a negated class rather than a
+  // literal '!', as minimatch read it.
+  const compile = (pattern: string) =>
+    picomatch(expandGlobPatternBraces(pattern).filter(Boolean), {
+      posix: true,
+    });
+  const positiveMatchers = matchesEveryFile ? [] : positive.map(compile);
+  const negativeMatchers = negative.map((p) => compile(p.substring(1)));
 
   return files.filter((f) => {
-    let matchedPositive = false;
-    if (
-      positive.length === 0 ||
-      (positive.length === 1 && positive[0] === `${root}/**/*`)
-    ) {
-      matchedPositive = true;
-    } else {
-      matchedPositive = positiveMatchers.some((m) => m(f.file));
+    if (!matchesEveryFile && !positiveMatchers.some((m) => m(f.file))) {
+      return false;
     }
-
-    if (!matchedPositive) return false;
 
     return negativeMatchers.every((m) => !m(f.file));
   });

--- a/packages/nx/src/plugins/package-json/create-nodes.ts
+++ b/packages/nx/src/plugins/package-json/create-nodes.ts
@@ -1,4 +1,4 @@
-import { Minimatch } from 'minimatch';
+import picomatch from 'picomatch';
 import { existsSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 
@@ -161,13 +161,13 @@ export function buildPackageJsonWorkspacesMatcher(
   patterns: PackageJsonPatterns
 ) {
   // Compile each glob once; the returned matcher runs per package.json path.
-  const positive = patterns.positive.map((p) => new Minimatch(p));
-  const negative = patterns.negative.map((p) => new Minimatch(p));
+  const positive = patterns.positive.map((p) => picomatch(p));
+  const negative = patterns.negative.map((p) => picomatch(p));
   return (p) =>
-    // use lookup to avoid unnecessary minimatch calls
-    (patterns.positiveLookup[p] || positive.some((m) => m.match(p))) &&
+    // use lookup to avoid unnecessary glob-match calls
+    (patterns.positiveLookup[p] || positive.some((m) => m(p))) &&
     /**
-     * minimatch will return true if the given p is NOT excluded by the negative pattern.
+     * picomatch will return true if the given p is NOT excluded by the negative pattern.
      *
      * For example if the negative pattern is "!packages/vite", then the given p "packages/vite" will return false,
      * the given p "packages/something-else/package.json" will return true.
@@ -176,7 +176,7 @@ export function buildPackageJsonWorkspacesMatcher(
      * excluded by any of the negative patterns.
      */
     !patterns.negativeLookup[p] &&
-    negative.every((m) => m.match(p));
+    negative.every((m) => m(p));
 }
 
 export function createNodeFromPackageJson(

--- a/packages/nx/src/plugins/package-json/create-nodes.ts
+++ b/packages/nx/src/plugins/package-json/create-nodes.ts
@@ -125,7 +125,8 @@ export function buildPackageJsonPatterns(
   const negativePatternLookup: Record<string, boolean> = {};
 
   for (const pattern of patterns) {
-    if (pattern.startsWith('!')) {
+    // `!(` opens an extglob, not a negation - leave those to picomatch
+    if (pattern.startsWith('!') && !pattern.startsWith('!(')) {
       negativePatterns.push(pattern);
       negativePatternLookup[pattern.slice(1)] = true;
     } else {

--- a/packages/nx/src/project-graph/affected/locators/project-glob-changes.ts
+++ b/packages/nx/src/project-graph/affected/locators/project-glob-changes.ts
@@ -37,7 +37,7 @@ export const getTouchedProjectsFromProjectGlobChanges: TouchedProjectLocator =
     })();
 
     if (!globPatterns.length) {
-      // no plugins with createNodes patterns; picomatch throws on empty patterns
+      // no plugins with createNodes patterns, so no file can belong to a project
       return [];
     }
 

--- a/packages/nx/src/project-graph/affected/locators/project-glob-changes.ts
+++ b/packages/nx/src/project-graph/affected/locators/project-glob-changes.ts
@@ -1,11 +1,11 @@
 import { TouchedProjectLocator } from '../affected-project-graph-models';
-import { minimatch } from 'minimatch';
+import picomatch from 'picomatch';
 import { readNxJson } from '../../../config/nx-json';
 import { workspaceRoot } from '../../../utils/workspace-root';
 import { join } from 'path';
 import { existsSync } from 'fs';
 import { getGlobPatternsOfPlugins } from '../../utils/retrieve-workspace-files';
-import { combineGlobPatterns } from '../../../utils/globs';
+import { splitGlobPatterns } from '../../../utils/globs';
 import { getPlugins } from '../../plugins/get-plugins';
 
 export const getTouchedProjectsFromProjectGlobChanges: TouchedProjectLocator =
@@ -17,28 +17,34 @@ export const getTouchedProjectsFromProjectGlobChanges: TouchedProjectLocator =
     _projectGraph,
     projectDeletionAffectsAllProjects = true
   ): Promise<string[]> => {
-    const globPattern = await (async () => {
+    const globPatterns = await (async () => {
       // TODO: We need a quicker way to get patterns that should not
       // require starting up plugin workers
       if (process.env.NX_FORCE_REUSE_CACHED_GRAPH === 'true') {
-        return combineGlobPatterns([
+        return [
           '**/package.json',
           '**/project.json',
           'project.json',
           'package.json',
-        ]);
+        ];
       }
       const plugins = (await getPlugins(readNxJson(workspaceRoot))).filter(
         (p) => !!p.createNodes
       );
-      return combineGlobPatterns(getGlobPatternsOfPlugins(plugins));
+      // plugin globs may be combined `{a,b}` patterns; split so leading `**/`
+      // keeps matching root-level files (see splitGlobPatterns)
+      return getGlobPatternsOfPlugins(plugins).flatMap(splitGlobPatterns);
     })();
 
+    if (!globPatterns.length) {
+      // no plugins with createNodes patterns; picomatch throws on empty patterns
+      return [];
+    }
+
+    const isProjectFilePattern = picomatch(globPatterns, { dot: true });
     const touchedProjects = new Set<string>();
     for (const touchedFile of touchedFiles) {
-      const isProjectFile = minimatch(touchedFile.file, globPattern, {
-        dot: true,
-      });
+      const isProjectFile = isProjectFilePattern(touchedFile.file);
       if (isProjectFile) {
         // If the file no longer exists on disk, then it was deleted
         if (!existsSync(join(workspaceRoot, touchedFile.file))) {

--- a/packages/nx/src/project-graph/affected/locators/workspace-projects.ts
+++ b/packages/nx/src/project-graph/affected/locators/workspace-projects.ts
@@ -1,4 +1,4 @@
-import { minimatch } from 'minimatch';
+import picomatch from 'picomatch';
 import { TouchedProjectLocator } from '../affected-project-graph-models';
 import {
   createProjectRootMappings,
@@ -50,7 +50,7 @@ export const getImplicitlyTouchedProjects: TouchedProjectLocator = (
 
   for (const [pattern, projects] of Object.entries(implicits)) {
     const implicitDependencyWasChanged = fileChanges.some((f) =>
-      minimatch(f.file, pattern, { dot: true })
+      picomatch.isMatch(f.file, pattern, { dot: true })
     );
     if (!implicitDependencyWasChanged) {
       continue;

--- a/packages/nx/src/project-graph/utils/project-configuration-utils.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration-utils.ts
@@ -9,7 +9,7 @@ import {
 } from './project-configuration/project-nodes-manager';
 import { validateAndNormalizeProjectRootMap } from './project-configuration/target-normalization';
 
-import { Minimatch } from 'minimatch';
+import picomatch from 'picomatch';
 import { performance } from 'perf_hooks';
 
 import { DelayedSpinner } from '../../utils/delayed-spinner';
@@ -530,7 +530,7 @@ function createMatcher(
       const isNegation = pattern.startsWith('!');
       return {
         isNegation,
-        matcher: new Minimatch(isNegation ? pattern.substring(1) : pattern, {
+        matcher: picomatch(isNegation ? pattern.substring(1) : pattern, {
           dot: true,
         }),
       };
@@ -539,7 +539,7 @@ function createMatcher(
     return (file: string) => {
       let isMatch = initialMatch;
       for (const { isNegation, matcher } of compiled) {
-        if (matcher.match(file)) {
+        if (matcher(file)) {
           isMatch = !isNegation;
         }
       }
@@ -547,8 +547,8 @@ function createMatcher(
     };
   }
 
-  const compiled = patterns.map((p) => new Minimatch(p, { dot: true }));
-  return (file: string) => compiled.some((m) => m.match(file));
+  const compiled = patterns.map((p) => picomatch(p, { dot: true }));
+  return (file: string) => compiled.some((m) => m(file));
 }
 
 export function findMatchingConfigFiles(

--- a/packages/nx/src/project-graph/utils/project-configuration/project-nodes-manager.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/project-nodes-manager.ts
@@ -18,7 +18,7 @@ import {
   targetSourceMapKey,
 } from './source-maps';
 
-import { minimatch } from 'minimatch';
+import picomatch from 'picomatch';
 import { isGlobPattern } from '../../../utils/globs';
 
 export { validateProject } from './target-normalization';
@@ -197,7 +197,7 @@ export function mergeProjectConfigurationIntoRootMap(
         // this will map atomized targets to the glob pattern same as it does for targetDefaults
         matchingTargets = Object.keys(
           updatedProjectConfiguration.targets
-        ).filter((key) => minimatch(key, targetName));
+        ).filter((key) => picomatch.isMatch(key, targetName));
       }
       // If no matching targets were found, we can assume that the target name is not (meant to be) a glob pattern
       if (!matchingTargets.length) {

--- a/packages/nx/src/project-graph/utils/project-configuration/target-defaults.ts
+++ b/packages/nx/src/project-graph/utils/project-configuration/target-defaults.ts
@@ -1,4 +1,4 @@
-import { minimatch } from 'minimatch';
+import picomatch from 'picomatch';
 import { join } from 'path';
 import { toProjectName } from '../../../config/to-project-name';
 import {
@@ -464,7 +464,7 @@ function* orderedMatchingKeys(
         key !== targetName &&
         key !== executor &&
         isGlobPattern(key) &&
-        minimatch(targetName, key)
+        picomatch.isMatch(targetName, key)
     )
     .sort((a, b) => b.length - a.length);
   yield* globKeys;

--- a/packages/nx/src/tasks-runner/utils.ts
+++ b/packages/nx/src/tasks-runner/utils.ts
@@ -1,4 +1,4 @@
-import { minimatch } from 'minimatch';
+import picomatch from 'picomatch';
 import { relative } from 'node:path';
 import { join } from 'node:path/posix';
 import {
@@ -161,7 +161,7 @@ function findMatchingTargets(pattern: string, allTargetNames: string[]) {
     return cachedResult;
   }
 
-  const matcher = minimatch.filter(pattern);
+  const matcher = picomatch(pattern);
 
   const matchingTargets = allTargetNames.filter((t) => matcher(t));
   cache.set(pattern, matchingTargets);

--- a/packages/nx/src/utils/find-matching-projects.spec.ts
+++ b/packages/nx/src/utils/find-matching-projects.spec.ts
@@ -3,7 +3,7 @@ import {
   getMatchingStringsWithCache,
 } from './find-matching-projects';
 import type { ProjectGraphProjectNode } from '../config/project-graph';
-import { minimatch } from 'minimatch';
+import picomatch from 'picomatch';
 
 describe('findMatchingProjects', () => {
   let projectGraph: Record<string, ProjectGraphProjectNode> = {
@@ -352,20 +352,28 @@ describe.each([
     pattern: 'libs/*',
   },
 ])('getMatchingStringsWithCache', ({ items, pattern }) => {
-  it(`should be faster than using minimatch directly multiple times (${pattern})`, () => {
+  it(`should be faster than using picomatch directly multiple times (${pattern})`, () => {
     const iterations = 100;
     const cacheTime = time(
       () => getMatchingStringsWithCache(pattern, items),
       iterations
     );
-    const directTime = time(() => minimatch.match(items, pattern), iterations);
-    // Using minimatch directly is slower than using the cache.
+    const directTime = time(() => {
+      // don't pass the matcher to filter directly - the index argument lands
+      // in picomatch's returnObject param and every item matches
+      const isMatch = picomatch(pattern, { dot: true });
+      items.filter((item) => isMatch(item));
+    }, iterations);
+    // Using picomatch directly is slower than using the cache.
     expect(directTime / cacheTime).toBeGreaterThan(1);
   });
 
-  it(`should be comparable to using minimatch a single time (${pattern})`, () => {
+  it(`should be comparable to using picomatch a single time (${pattern})`, () => {
     const cacheTime = time(() => getMatchingStringsWithCache(pattern, items));
-    const directTime = time(() => minimatch.match(items, pattern));
+    const directTime = time(() => {
+      const isMatch = picomatch(pattern, { dot: true });
+      items.filter((item) => isMatch(item));
+    });
     // We are dealing with really small file sets here, with such a small
     // difference it time, the system variablility can make this flaky for
     // smaller values. If we are within 1ms, we are good.

--- a/packages/nx/src/utils/find-matching-projects.ts
+++ b/packages/nx/src/utils/find-matching-projects.ts
@@ -1,4 +1,4 @@
-import { minimatch } from 'minimatch';
+import picomatch from 'picomatch';
 import type { ProjectGraphProjectNode } from '../config/project-graph';
 import { isGlobPattern } from './globs';
 
@@ -278,20 +278,19 @@ function isValidPatternType(type: string): type is ProjectPatternType {
 
 export const getMatchingStringsWithCache = (() => {
   // Map< Pattern, Map< Item, Result >>
-  const minimatchCache = new Map<string, Map<string, boolean>>();
+  const matchCache = new Map<string, Map<string, boolean>>();
   const regexCache = new Map<string, RegExp>();
   return (pattern: string, items: string[]) => {
-    if (!minimatchCache.has(pattern)) {
-      minimatchCache.set(pattern, new Map());
+    if (!matchCache.has(pattern)) {
+      matchCache.set(pattern, new Map());
     }
-    const patternCache = minimatchCache.get(pattern)!;
+    const patternCache = matchCache.get(pattern)!;
     if (!regexCache.has(pattern)) {
-      const regex = minimatch.makeRe(pattern, { dot: true });
-      if (regex) {
-        regexCache.set(pattern, regex);
-      } else {
+      // minimatch.makeRe returned false for empty patterns; picomatch throws
+      if (!pattern) {
         throw new Error('Invalid glob pattern ' + pattern);
       }
+      regexCache.set(pattern, picomatch.makeRe(pattern, { dot: true }));
     }
     const matcher = regexCache.get(pattern);
     return items.filter((item) => {

--- a/packages/nx/src/utils/globs.spec.ts
+++ b/packages/nx/src/utils/globs.spec.ts
@@ -1,4 +1,8 @@
-import { isGlobPattern } from './globs';
+import {
+  expandGlobPatternBraces,
+  isGlobPattern,
+  splitGlobPatterns,
+} from './globs';
 
 describe('isGlobPattern', () => {
   it.each([
@@ -7,5 +11,41 @@ describe('isGlobPattern', () => {
     [false, 'some-project'],
   ])('should return %s for %s', (expected, pattern) => {
     expect(isGlobPattern(pattern)).toBe(expected);
+  });
+});
+
+describe('splitGlobPatterns', () => {
+  it.each([
+    [
+      ['**/project.json', '**/package.json'],
+      '{**/project.json,**/package.json}',
+    ],
+    [
+      ['**/tsconfig*{.json,.*.json}', '**/x'],
+      '{**/tsconfig*{.json,.*.json},**/x}',
+    ],
+    [['**/*.ts'], '**/*.ts'],
+    [['{a,b}/c'], '{a,b}/c'],
+    [['{a,b}/{c,d}'], '{a,b}/{c,d}'],
+    [['{a,{b}'], '{a,{b}'],
+    [['a', 'b'], '{a,b}'],
+    [[''], ''],
+  ])('should return %j for %s', (expected, pattern) => {
+    expect(splitGlobPatterns(pattern)).toEqual(expected);
+  });
+});
+
+describe('expandGlobPatternBraces', () => {
+  it.each([
+    [['libs/a/**/*.ts', 'libs/a/**/*.tsx'], 'libs/a/{**/*.ts,**/*.tsx}'],
+    [['a/c', 'b/c'], '{a,b}/c'],
+    [['a/c', 'a/d', 'b/c', 'b/d'], '{a,b}/{c,d}'],
+    [['**/*.ts'], '**/*.ts'],
+    [['x/{1..3}/y'], 'x/{1..3}/y'],
+    [['{a,{b}'], '{a,{b}'],
+    [['x/a.json', 'x/b{c}d.json'], 'x/{a,b{c}d}.json'],
+    [[''], ''],
+  ])('should return %j for %s', (expected, pattern) => {
+    expect(expandGlobPatternBraces(pattern)).toEqual(expected);
   });
 });

--- a/packages/nx/src/utils/globs.spec.ts
+++ b/packages/nx/src/utils/globs.spec.ts
@@ -29,7 +29,9 @@ describe('splitGlobPatterns', () => {
     [['{a,b}/{c,d}'], '{a,b}/{c,d}'],
     [['{a,{b}'], '{a,{b}'],
     [['a', 'b'], '{a,b}'],
-    [[''], ''],
+    // never an empty pattern - picomatch throws on '', every caller counts length
+    [[], ''],
+    [['a', 'b'], '{a,,b}'],
   ])('should return %j for %s', (expected, pattern) => {
     expect(splitGlobPatterns(pattern)).toEqual(expected);
   });
@@ -45,6 +47,16 @@ describe('expandGlobPatternBraces', () => {
     [['{a,{b}'], '{a,{b}'],
     [['x/a.json', 'x/b{c}d.json'], 'x/{a,b{c}d}.json'],
     [[''], ''],
+    // a comma-free group before an alternation must not stop the expansion
+    [['x/{1..3}/**/*.ts', 'x/{1..3}/**/*.tsx'], 'x/{1..3}/{**/*.ts,**/*.tsx}'],
+    [['a{b}/c', 'a{b}/d'], 'a{b}/{c,d}'],
+    // nested alternation flattens; only depth-1 commas split
+    [['a', 'b', 'c'], '{a,{b,c}}'],
+    [['x/a/z', 'x/b/z', 'x/c/z'], 'x/{a,{b,c}}/z'],
+    // escaped braces are literal, not an alternation
+    [['libs/a/\\{a,b\\}/x'], 'libs/a/\\{a,b\\}/x'],
+    // an empty alternative yields an empty pattern; callers must drop it
+    [['', 'a'], '{,a}'],
   ])('should return %j for %s', (expected, pattern) => {
     expect(expandGlobPatternBraces(pattern)).toEqual(expected);
   });

--- a/packages/nx/src/utils/globs.ts
+++ b/packages/nx/src/utils/globs.ts
@@ -3,6 +3,78 @@ export function combineGlobPatterns(...patterns: (string | string[])[]) {
   return p.length > 1 ? '{' + p.join(',') + '}' : p.length === 1 ? p[0] : '';
 }
 
+/**
+ * Splits a combined `{a,b}` glob (from {@link combineGlobPatterns}) into its
+ * individual patterns. picomatch drops the `**\/` zero-segment match inside
+ * brace alternation, so `{**\/a,**\/b}` misses root-level files unless split.
+ */
+export function splitGlobPatterns(pattern: string): string[] {
+  if (!pattern.startsWith('{') || !pattern.endsWith('}')) {
+    return [pattern];
+  }
+  const inner = pattern.slice(1, -1);
+  const parts: string[] = [];
+  let depth = 0;
+  let start = 0;
+  for (let i = 0; i < inner.length; i++) {
+    const c = inner[i];
+    if (c === '{') {
+      depth++;
+    } else if (c === '}') {
+      // outer brace closes mid-pattern (e.g. `{a,b}/{c,d}`) - not combined
+      if (--depth < 0) return [pattern];
+    } else if (c === ',' && depth === 0) {
+      parts.push(inner.slice(start, i));
+      start = i + 1;
+    }
+  }
+  if (depth !== 0) return [pattern];
+  parts.push(inner.slice(start));
+  return parts;
+}
+
+/**
+ * Expands `{a,b}` alternations into separate brace-free patterns
+ * (`x/{a,b}/z` -> `x/a/z`, `x/b/z`). picomatch drops the `**\/` zero-segment
+ * match inside brace alternation, so `x/{**\/*.ts,**\/*.tsx}` misses
+ * `x/index.ts` unless expanded. Range groups (`{1..3}`) are left alone.
+ */
+export function expandGlobPatternBraces(pattern: string): string[] {
+  const open = pattern.indexOf('{');
+  if (open === -1) {
+    return [pattern];
+  }
+  let depth = 0;
+  let close = -1;
+  const commas: number[] = [];
+  for (let i = open; i < pattern.length; i++) {
+    const c = pattern[i];
+    if (c === '{') {
+      depth++;
+    } else if (c === '}') {
+      if (--depth === 0) {
+        close = i;
+        break;
+      }
+    } else if (c === ',' && depth === 1) {
+      commas.push(i);
+    }
+  }
+  // unbalanced braces or no alternation to expand
+  if (close === -1 || !commas.length) {
+    return [pattern];
+  }
+  const prefix = pattern.slice(0, open);
+  const suffix = pattern.slice(close + 1);
+  const bounds = [open, ...commas, close];
+  const results: string[] = [];
+  for (let i = 0; i < bounds.length - 1; i++) {
+    const part = pattern.slice(bounds[i] + 1, bounds[i + 1]);
+    results.push(...expandGlobPatternBraces(prefix + part + suffix));
+  }
+  return results;
+}
+
 export const GLOB_CHARACTERS = new Set(['*', '|', '{', '}', '(', ')', '[']);
 
 export function isGlobPattern(pattern: string) {

--- a/packages/nx/src/utils/globs.ts
+++ b/packages/nx/src/utils/globs.ts
@@ -10,7 +10,9 @@ export function combineGlobPatterns(...patterns: (string | string[])[]) {
  */
 export function splitGlobPatterns(pattern: string): string[] {
   if (!pattern.startsWith('{') || !pattern.endsWith('}')) {
-    return [pattern];
+    // never emit an empty pattern - picomatch throws on '', where minimatch
+    // matched nothing
+    return pattern ? [pattern] : [];
   }
   const inner = pattern.slice(1, -1);
   const parts: string[] = [];
@@ -30,49 +32,69 @@ export function splitGlobPatterns(pattern: string): string[] {
   }
   if (depth !== 0) return [pattern];
   parts.push(inner.slice(start));
-  return parts;
+  return parts.filter(Boolean);
 }
 
 /**
- * Expands `{a,b}` alternations into separate brace-free patterns
+ * Expands every `{a,b}` alternation into one pattern per combination
  * (`x/{a,b}/z` -> `x/a/z`, `x/b/z`). picomatch drops the `**\/` zero-segment
  * match inside brace alternation, so `x/{**\/*.ts,**\/*.tsx}` misses
- * `x/index.ts` unless expanded. Range groups (`{1..3}`) are left alone.
+ * `x/index.ts` unless expanded. Groups with no top-level comma (`{1..3}`,
+ * `{projectRoot}`), escaped braces (`\{a,b\}`) and unbalanced braces are left
+ * alone, so results are not necessarily brace-free. Output size is the product
+ * of the alternation widths, and an empty alternative yields an empty pattern
+ * (`{,a}` -> `['', 'a']`) which picomatch rejects - callers must drop those.
  */
 export function expandGlobPatternBraces(pattern: string): string[] {
-  const open = pattern.indexOf('{');
-  if (open === -1) {
-    return [pattern];
-  }
-  let depth = 0;
-  let close = -1;
-  const commas: number[] = [];
-  for (let i = open; i < pattern.length; i++) {
-    const c = pattern[i];
-    if (c === '{') {
-      depth++;
-    } else if (c === '}') {
-      if (--depth === 0) {
-        close = i;
-        break;
+  let search = 0;
+  while (search < pattern.length) {
+    let open = -1;
+    let depth = 0;
+    let close = -1;
+    const commas: number[] = [];
+    for (let i = search; i < pattern.length; i++) {
+      const c = pattern[i];
+      // a backslash escapes the next character, so it opens/closes nothing
+      if (c === '\\') {
+        i++;
+      } else if (c === '{') {
+        if (open === -1) {
+          open = i;
+        }
+        depth++;
+      } else if (c === '}' && open !== -1) {
+        if (--depth === 0) {
+          close = i;
+          break;
+        }
+      } else if (c === ',' && depth === 1) {
+        commas.push(i);
       }
-    } else if (c === ',' && depth === 1) {
-      commas.push(i);
     }
+    // no group left, or an unbalanced one - nothing further is safe to expand
+    if (open === -1 || close === -1) {
+      return [pattern];
+    }
+    // not an alternation (a range, or a `{token}`) - look past it
+    if (!commas.length) {
+      search = close + 1;
+      continue;
+    }
+    const prefix = pattern.slice(0, open);
+    const suffix = pattern.slice(close + 1);
+    const bounds = [open, ...commas, close];
+    const results: string[] = [];
+    for (let i = 0; i < bounds.length - 1; i++) {
+      const part = pattern.slice(bounds[i] + 1, bounds[i + 1]);
+      // a loop rather than push(...spread) - the spread hits the argument
+      // limit and reports a misleading RangeError on large products
+      for (const expanded of expandGlobPatternBraces(prefix + part + suffix)) {
+        results.push(expanded);
+      }
+    }
+    return results;
   }
-  // unbalanced braces or no alternation to expand
-  if (close === -1 || !commas.length) {
-    return [pattern];
-  }
-  const prefix = pattern.slice(0, open);
-  const suffix = pattern.slice(close + 1);
-  const bounds = [open, ...commas, close];
-  const results: string[] = [];
-  for (let i = 0; i < bounds.length - 1; i++) {
-    const part = pattern.slice(bounds[i] + 1, bounds[i + 1]);
-    results.push(...expandGlobPatternBraces(prefix + part + suffix));
-  }
-  return results;
+  return [pattern];
 }
 
 export const GLOB_CHARACTERS = new Set(['*', '|', '{', '}', '(', ')', '[']);

--- a/packages/nx/src/utils/min-release-age/behavior/yarn.ts
+++ b/packages/nx/src/utils/min-release-age/behavior/yarn.ts
@@ -2,7 +2,7 @@ import { execSync } from 'child_process';
 import { existsSync, readFileSync } from 'fs';
 import { homedir } from 'os';
 import { dirname, join } from 'path';
-import { minimatch } from 'minimatch';
+import picomatch from 'picomatch';
 import { lt, rcompare, satisfies, validRange } from 'semver';
 import { MS_PER_MINUTE } from '../constants';
 import { MinReleaseAgeViolationError } from '../errors';
@@ -231,12 +231,12 @@ function parseExcludeEntry(entry: string): ExcludeMatcher | null {
     return null;
   }
   // checkIdent matches the ident first (exact identHash OR an unconditional
-  // micromatch) and only then applies the range, so run minimatch on every
-  // entry - no isGlob gate - to catch extglobs (`+(...)`, `@(...)`) yarn would
-  // glob-match. Residual: minimatch and micromatch disagree on `!(foo)`
-  // negation, which cannot be reconciled without micromatch (not an allowed
-  // dep).
-  const nameMatches = (pkg: string) => pkg === name || minimatch(pkg, name);
+  // micromatch) and only then applies the range, so glob-match every entry -
+  // no isGlob gate - to catch extglobs (`+(...)`, `@(...)`) yarn would
+  // glob-match. picomatch is micromatch's engine, so `!(foo)` negation now
+  // matches yarn's behavior too.
+  const nameMatches = (pkg: string) =>
+    pkg === name || picomatch.isMatch(pkg, name);
   if (range) {
     if (!validRange(range)) {
       // yarn parses the version part as a semver range; an invalid one bypasses

--- a/packages/playwright/package.json
+++ b/packages/playwright/package.json
@@ -79,7 +79,7 @@
     "@nx/eslint": "workspace:*",
     "@nx/js": "workspace:*",
     "tslib": "catalog:typescript",
-    "minimatch": "catalog:",
+    "picomatch": "catalog:",
     "semver": "catalog:"
   },
   "devDependencies": {

--- a/packages/playwright/src/plugins/plugin.ts
+++ b/packages/playwright/src/plugins/plugin.ts
@@ -24,7 +24,7 @@ import {
 import { getLockFileName, getRootTsConfigFileName } from '@nx/js';
 import { walkTsconfigExtendsChain } from '@nx/js/internal';
 import type { PlaywrightTestConfig } from '@playwright/test';
-import { minimatch } from 'minimatch';
+import picomatch from 'picomatch';
 import { existsSync, readdirSync } from 'node:fs';
 import { dirname, join, parse, relative, resolve, sep } from 'node:path';
 import { getReporterOutputs, type ReporterOutput } from '../utils/reporters';
@@ -417,7 +417,7 @@ function createMatcher(pattern: string | RegExp | Array<string | RegExp>) {
   } else {
     return (path: string) => {
       try {
-        return minimatch(path, pattern);
+        return picomatch.isMatch(path, pattern);
       } catch (e) {
         throw new Error(`Error matching ${path} with ${pattern}: ${e.message}`);
       }

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -115,7 +115,7 @@
   "dependencies": {
     "@babel/preset-react": "^7.22.5",
     "@phenomnomnominal/tsquery": "catalog:typescript",
-    "minimatch": "catalog:",
+    "picomatch": "catalog:",
     "tslib": "catalog:typescript",
     "@nx/devkit": "workspace:*",
     "@nx/js": "workspace:*",

--- a/packages/react/src/generators/stories/stories.ts
+++ b/packages/react/src/generators/stories/stories.ts
@@ -11,7 +11,7 @@ import {
   getProjectSourceRoot,
   getProjectType,
 } from '@nx/js/internal';
-import { minimatch } from 'minimatch';
+import picomatch from 'picomatch';
 import { basename, join } from 'path';
 import {
   findExportDeclarationsForJsx,
@@ -98,7 +98,8 @@ export async function createAllStories(
     // Ignore private files starting with "_".
     if (basename(path).startsWith('_')) return;
 
-    if (schema.ignorePaths?.some((pattern) => minimatch(path, pattern))) return;
+    if (schema.ignorePaths?.some((pattern) => picomatch.isMatch(path, pattern)))
+      return;
 
     if (
       (path.endsWith('.tsx') && !path.endsWith('.spec.tsx')) ||

--- a/packages/rsbuild/package.json
+++ b/packages/rsbuild/package.json
@@ -56,7 +56,7 @@
     "tslib": "catalog:typescript",
     "@nx/devkit": "workspace:*",
     "@nx/js": "workspace:*",
-    "minimatch": "catalog:",
+    "picomatch": "catalog:",
     "semver": "catalog:",
     "@phenomnomnominal/tsquery": "catalog:typescript"
   },

--- a/packages/rsbuild/src/plugins/plugin.ts
+++ b/packages/rsbuild/src/plugins/plugin.ts
@@ -24,7 +24,7 @@ import {
 import { getLockFileName } from '@nx/js';
 import { readdirSync } from 'fs';
 import { join, dirname, isAbsolute, relative } from 'path';
-import { minimatch } from 'minimatch';
+import picomatch from 'picomatch';
 import type { RsbuildConfig } from '@rsbuild/core';
 export interface RsbuildPluginOptions {
   buildTargetName?: string;
@@ -369,7 +369,7 @@ async function filterRsbuildConfigs(
         }
         const tsConfigFiles =
           siblingFiles.filter((p) =>
-            minimatch(p, 'tsconfig*{.json,.*.json}')
+            picomatch.isMatch(p, 'tsconfig*{.json,.*.json}')
           ) ?? [];
         return { configFile, projectRoot, tsConfigFiles };
       } catch (e) {

--- a/packages/rsbuild/src/utils/has-rsbuild-plugin.ts
+++ b/packages/rsbuild/src/utils/has-rsbuild-plugin.ts
@@ -8,20 +8,25 @@ export function hasRsbuildPlugin(tree: Tree, projectPath?: string) {
       typeof p === 'string' ? p === '@nx/rsbuild' : p.plugin === '@nx/rsbuild'
     );
   }
+  // projectPath is a directory, not a file: `strictSlashes` keeps `<root>/**`
+  // from matching `<root>` itself, as minimatch did
+  const matchesProject = (pattern: string) =>
+    picomatch.isMatch(projectPath, pattern, { strictSlashes: true });
+
   return !!nxJson.plugins?.some((p) => {
     if (typeof p === 'string') {
       return p === '@nx/rsbuild';
     }
     if (p.exclude) {
       for (const exclude of p.exclude) {
-        if (picomatch.isMatch(projectPath, exclude)) {
+        if (matchesProject(exclude)) {
           return false;
         }
       }
     }
     if (p.include) {
       for (const include of p.include) {
-        if (picomatch.isMatch(projectPath, include)) {
+        if (matchesProject(include)) {
           return true;
         }
       }

--- a/packages/rsbuild/src/utils/has-rsbuild-plugin.ts
+++ b/packages/rsbuild/src/utils/has-rsbuild-plugin.ts
@@ -1,5 +1,5 @@
 import { type Tree, readNxJson } from '@nx/devkit';
-import { minimatch } from 'minimatch';
+import picomatch from 'picomatch';
 
 export function hasRsbuildPlugin(tree: Tree, projectPath?: string) {
   const nxJson = readNxJson(tree);
@@ -14,14 +14,14 @@ export function hasRsbuildPlugin(tree: Tree, projectPath?: string) {
     }
     if (p.exclude) {
       for (const exclude of p.exclude) {
-        if (minimatch(projectPath, exclude)) {
+        if (picomatch.isMatch(projectPath, exclude)) {
           return false;
         }
       }
     }
     if (p.include) {
       for (const include of p.include) {
-        if (minimatch(projectPath, include)) {
+        if (picomatch.isMatch(projectPath, include)) {
           return true;
         }
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -355,7 +355,7 @@ overrides:
   handlebars: 4.7.9
   minimist: ^1.2.6
   underscore: ^1.13.8
-  brace-expansion: 5.0.8
+  brace-expansion: 5.0.9
   axios: 1.18.1
   minimatch: ^10.2.5
   shell-quote: ^1.8.4
@@ -1152,9 +1152,6 @@ importers:
       mini-css-extract-plugin:
         specifier: ~2.4.7
         version: 2.4.7(webpack@5.105.2)
-      minimatch:
-        specifier: ^10.2.5
-        version: 10.2.5
       next-sitemap:
         specifier: ^3.1.10
         version: 3.1.55(@next/env@16.2.7)(next@16.2.7(@babel/core@7.29.0)(@playwright/test@1.60.0)(babel-plugin-macros@3.1.0)(babel-plugin-react-compiler@1.0.0)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)(sass@1.97.3))
@@ -2489,9 +2486,9 @@ importers:
       enquirer:
         specifier: 'catalog:'
         version: 2.3.6
-      minimatch:
-        specifier: ^10.2.5
-        version: 10.2.5
+      picomatch:
+        specifier: 'catalog:'
+        version: 4.0.4
       semver:
         specifier: 'catalog:'
         version: 7.8.4
@@ -2798,12 +2795,12 @@ importers:
       jsonc-parser:
         specifier: 'catalog:'
         version: 3.3.1
-      minimatch:
-        specifier: ^10.2.5
-        version: 10.2.5
       picocolors:
         specifier: 'catalog:'
         version: 1.1.1
+      picomatch:
+        specifier: 'catalog:'
+        version: 4.0.4
       resolve.exports:
         specifier: 2.0.3
         version: 2.0.3
@@ -3246,9 +3243,6 @@ importers:
       lines-and-columns:
         specifier: 2.0.3
         version: 2.0.3
-      minimatch:
-        specifier: ^10.2.5
-        version: 10.2.5
       npm-run-path:
         specifier: ^4.0.1
         version: 4.0.1
@@ -3261,6 +3255,9 @@ importers:
       picocolors:
         specifier: 'catalog:'
         version: 1.1.1
+      picomatch:
+        specifier: 'catalog:'
+        version: 4.0.4
       resolve.exports:
         specifier: 2.0.3
         version: 2.0.3
@@ -3363,9 +3360,9 @@ importers:
       '@playwright/test':
         specifier: 'catalog:'
         version: 1.60.0
-      minimatch:
-        specifier: ^10.2.5
-        version: 10.2.5
+      picomatch:
+        specifier: 'catalog:'
+        version: 4.0.4
       semver:
         specifier: 'catalog:'
         version: 7.8.4
@@ -3425,9 +3422,9 @@ importers:
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
-      minimatch:
-        specifier: ^10.2.5
-        version: 10.2.5
+      picomatch:
+        specifier: 'catalog:'
+        version: 4.0.4
       react:
         specifier: '>=18.0.0 <20.0.0'
         version: 18.3.1
@@ -3656,9 +3653,9 @@ importers:
       '@rsbuild/core':
         specifier: ^1.0.0 || ^2.0.0
         version: 1.1.8
-      minimatch:
-        specifier: ^10.2.5
-        version: 10.2.5
+      picomatch:
+        specifier: 'catalog:'
+        version: 4.0.4
       semver:
         specifier: 'catalog:'
         version: 7.8.4
@@ -16181,8 +16178,8 @@ packages:
     resolution: {integrity: sha512-apC2+fspHGI3mMKj+dGevkGo/tCqVB8jMb6i+OX+E29p0Iposz07fABkRIfVUPNd5A5VbuOz1bZbnmkKLYF+wQ==}
     engines: {node: '>= 5.10.0'}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -43235,7 +43232,7 @@ snapshots:
     dependencies:
       big-integer: 1.6.52
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.3
 
@@ -51161,7 +51158,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimist@1.2.8: {}
 
@@ -52177,7 +52174,7 @@ snapshots:
       balanced-match: 4.0.3
       base64-js: 1.5.1
       bl: 4.1.0
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
       buffer: 5.7.1
       call-bind-apply-helpers: 1.0.2
       chalk: 4.1.2
@@ -52307,7 +52304,7 @@ snapshots:
       balanced-match: 4.0.3
       base64-js: 1.5.1
       bl: 4.1.0
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
       buffer: 5.7.1
       bundle-name: 4.1.0
       call-bind-apply-helpers: 1.0.2
@@ -52443,7 +52440,7 @@ snapshots:
       balanced-match: 4.0.3
       base64-js: 1.5.1
       bl: 4.1.0
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
       buffer: 5.7.1
       bundle-name: 4.1.0
       call-bind-apply-helpers: 1.0.2
@@ -58276,8 +58273,8 @@ snapshots:
   vite@7.1.3(@types/node@24.12.2)(jiti@2.7.0)(less@4.6.7)(lightningcss@1.32.0)(sass-embedded@1.97.2)(sass@1.101.0)(terser@5.49.0)(tsx@4.20.5)(yaml@2.9.0):
     dependencies:
       esbuild: 0.25.0
-      fdir: 6.5.0(picomatch@4.0.4)
-      picomatch: 4.0.4
+      fdir: 6.5.0(picomatch@4.0.5)
+      picomatch: 4.0.5
       postcss: 8.5.15
       rollup: 4.59.0
       tinyglobby: 0.2.15

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,7 +20,9 @@ overrides:
   handlebars: '4.7.9'
   minimist: '^1.2.6'
   underscore: '^1.13.8'
-  brace-expansion: '5.0.8'
+  # brace-expansion + minimatch pins cover transitive dev-tree copies (eslint,
+  # glob, verdaccio, etc.); nx itself no longer depends on minimatch.
+  brace-expansion: '5.0.9'
   axios: '1.18.1'
   minimatch: '^10.2.5'
   shell-quote: '^1.8.4'
@@ -52,7 +54,6 @@ catalog:
   http-proxy-middleware: '^3.0.5'
   http-server: '^14.1.0'
   jsonc-parser: '^3.2.0'
-  minimatch: '10.2.5'
   next-seo: '^5.13.0'
   ora: '^5.3.0'
   picomatch: '4.0.4'


### PR DESCRIPTION
## Current Behavior

nx and several plugins depend on minimatch, which pulls brace-expansion (GHSA-rgw5-rvv9-x895 DoS, third CVE in that package this year).

## Expected Behavior

All minimatch usages replaced with picomatch (nx, devkit, jest, playwright, react, rsbuild); minimatch/brace-expansion/balanced-match leave the published `nx` runtime dependency closure (some `@nx/*` plugins still pull minimatch transitively via upstream deps, e.g. @nx/jest via @jest/reporters). Not pure 1:1: picomatch does not give `**/` zero-segment treatment inside `{a,b}` brace alternation, so combined plugin globs are split (splitGlobPatterns) and hasher filesets are brace-expanded (expandGlobPatternBraces); empty-pattern throws are guarded. The jest workspaces matcher and tree-aware glob now honor negated patterns correctly (previously negations made everything match), which can change inferred jest targets for workspaces using negated entries. brace-expansion override bumped to patched 5.0.9 for the remaining dev-tree transitives.

## Related Issue(s)

Fixes NXC-4762

---

[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/lucid-ocelot-5a65ca7d).