### PR TITLE
fix(core): drain to stdout before exiting `nx affected`

### DIFF
--- a/packages/nx/src/command-line/affected/affected.ts
+++ b/packages/nx/src/command-line/affected/affected.ts
@@ -91,6 +91,7 @@ export async function affected(
             extraTargetDependencies,
             extraOptions
           );
+          await output.drain();
           process.exit(status);
         }
         break;


### PR DESCRIPTION
`nx affected` now runs `output.drain()` before exiting

This fix has been tested and resolves the issue.

Fixes #36568
