### PR TITLE
chore(misc): harden global npm installs in ci workflows

### DIFF
--- a/.github/workflows/banner-monitor.yml
+++ b/.github/workflows/banner-monitor.yml
@@ -75,7 +75,7 @@ jobs:
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
         run: |
-          npm install -g netlify-cli
+          npm install -g netlify-cli@27.0.3 --ignore-scripts
 
           echo "Triggering nx-docs deploy..."
           netlify deploy --trigger --prod -s nx-docs

--- a/.github/workflows/e2e-matrix.yml
+++ b/.github/workflows/e2e-matrix.yml
@@ -57,7 +57,7 @@ jobs:
 
       - name: Enable corepack and install pnpm
         run: |
-          npm install -g corepack@latest
+          npm install -g corepack@0.35.0 --ignore-scripts
           corepack enable
           corepack prepare --activate
 
@@ -163,7 +163,7 @@ jobs:
 
       - name: Enable corepack and install pnpm
         run: |
-          npm install -g corepack@latest
+          npm install -g corepack@0.35.0 --ignore-scripts
           corepack enable
           corepack prepare --activate
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -627,7 +627,7 @@ jobs:
           corepack prepare --activate
 
       - name: Use npm 11.5.2
-        run: npm install -g npm@11.5.2
+        run: npm install -g npm@11.5.2 --ignore-scripts
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile


### PR DESCRIPTION
## Current Behavior
Four `npm install -g` steps run with npm lifecycle scripts enabled. Runners start with no `~/.npmrc`, so the global `ignore-scripts=true` convention does not apply. Two use unpinned `latest`. `publish.yml` sits in an `id-token: write` job that can mint an npm publish token.

## Expected Behavior
All four pass `--ignore-scripts`. The unpinned ones pin to exact versions.

## Related Issue(s)
Fixes NXC-4763