### PR TITLE
feat(nx-cloud): add nx start-nx-agents as an alias for nx-cloud start-nx-agents

### DIFF
--- a/packages/nx/bin/nx.ts
+++ b/packages/nx/bin/nx.ts
@@ -265,6 +265,7 @@ function resolveNx(workspace: WorkspaceTypeAndRoot | null) {
 function isNxCloudCommand(command: string): boolean {
   const nxCloudCommands = [
     'start-ci-run',
+    'start-nx-agents',
     'start-agent',
     'stop-all-agents',
     'complete-ci-run',

--- a/packages/nx/src/command-line/nx-cloud/start-nx-agents/command-object.ts
+++ b/packages/nx/src/command-line/nx-cloud/start-nx-agents/command-object.ts
@@ -1,0 +1,21 @@
+import { CommandModule } from 'yargs';
+import { handleImport } from '../../../utils/handle-import';
+import { withVerbose } from '../../yargs-utils/shared-options';
+
+export const yargsStartNxAgentsCommand: CommandModule = {
+  command: 'start-nx-agents [options]',
+  describe:
+    'Provisions Nx Agents for distributed task execution, reading configuration from `.nx/ci-config.yaml`. This command is an alias for [`nx-cloud start-nx-agents`](/docs/reference/nx-cloud-cli#nx-cloud-start-nx-agents).',
+  builder: (yargs) =>
+    withVerbose(yargs)
+      .help(false)
+      .showHelpOnFail(false)
+      .option('help', { describe: 'Show help.', type: 'boolean' }),
+  handler: async (args: any) => {
+    process.exit(
+      await (
+        await handleImport('./start-nx-agents.js', __dirname)
+      ).startNxAgentsHandler(args)
+    );
+  },
+};

--- a/packages/nx/src/command-line/nx-cloud/start-nx-agents/start-nx-agents.ts
+++ b/packages/nx/src/command-line/nx-cloud/start-nx-agents/start-nx-agents.ts
@@ -1,0 +1,15 @@
+import { readNxJson } from '../../../config/nx-json';
+import { isNxCloudUsed } from '../../../utils/nx-cloud-utils';
+import { executeNxCloudCommand, warnNotConnectedToCloud } from '../utils';
+
+export interface StartNxAgentsArgs {
+  verbose?: boolean;
+}
+
+export function startNxAgentsHandler(args: StartNxAgentsArgs): Promise<number> {
+  if (!isNxCloudUsed(readNxJson())) {
+    warnNotConnectedToCloud();
+    return Promise.resolve(0);
+  }
+  return executeNxCloudCommand('start-nx-agents', args.verbose);
+}

--- a/packages/nx/src/command-line/nx-commands.ts
+++ b/packages/nx/src/command-line/nx-commands.ts
@@ -46,6 +46,7 @@ import { yargsLogoutCommand } from './nx-cloud/logout/command-object';
 import { yargsRecordCommand } from './nx-cloud/record/command-object';
 import { yargsStartAgentCommand } from './nx-cloud/start-agent/command-object';
 import { yargsStartCiRunCommand } from './nx-cloud/start-ci-run/command-object';
+import { yargsStartNxAgentsCommand } from './nx-cloud/start-nx-agents/command-object';
 import { yargsRegisterCommand } from './register/command-object';
 import { yargsReleaseCommand } from './release/command-object';
 import { yargsRepairCommand } from './repair/command-object';
@@ -116,6 +117,7 @@ export const commandsObject = yargs
   .command(yargsLogoutCommand)
   .command(yargsRecordCommand)
   .command(yargsStartCiRunCommand)
+  .command(yargsStartNxAgentsCommand)
   .command(yargsStartAgentCommand)
   .command(yargsStopAllAgentsCommand)
   .command(yargsFixCiCommand)


### PR DESCRIPTION
## Current Behavior

[#36504](https://github.com/nrwl/nx/pull/36504) (`c07a3dd3d1`) updated the `ci-workflow` generator templates to emit `nx start-nx-agents`, but `packages/nx` does not define a `start-nx-agents` command.

Because the command is unrecognized, the CLI falls through to task resolution and the generated workflows fail:

```
NX   Cannot find configuration for task @nx/nx-source:start-nx-agents
```

`start-nx-agents` is an Nx Cloud command. Nx can only invoke it the same way it invokes `start-ci-run`.

## Expected Behavior

`nx start-nx-agents` works as an alias for [`nx-cloud start-nx-agents`](https://nx.dev/docs/reference/nx-cloud-cli#nx-cloud-start-nx-agents), mirroring the existing `start-ci-run` alias.

## Related Issue(s)

Fixes the generator output shipped in #36504.

<!-- polygraph-session-start -->
---
<p><picture><source media="(prefers-color-scheme: dark)" srcset="https://static.ops.cloud.nx.app/polygraph/session-logo-v4-dark.svg"><img src="https://static.ops.cloud.nx.app/polygraph/session-logo-v4-light.svg" width="16" height="22" align="middle" alt="Polygraph"></picture> <a href="https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/free-sparrow-1a9be01d">View session ↗</a></p>
<!-- polygraph-session-end -->