### PR TITLE
fix(devkit): honour cascading ignore files in tree walks and generator formatting

### DIFF
--- a/packages/devkit/src/generators/format-files.spec.ts
+++ b/packages/devkit/src/generators/format-files.spec.ts
@@ -93,6 +93,45 @@ describe('formatFiles', () => {
     });
   });
 
+  describe('ignore files', () => {
+    // These assert on formatted output, which needs prettier's parser loading
+    // to work - it uses a dynamic import that jest only permits under
+    // NODE_OPTIONS=--experimental-vm-modules. `nx test devkit` sets that
+    // (nx.json), a bare `npx jest` does not, and without it nothing formats and
+    // every case here is vacuous. The unformatted `kept` assertions are what
+    // catch that: they fail rather than silently passing.
+    const unformatted = 'const   x   =   1';
+    const formatted = 'const x = 1;\n';
+
+    it('should skip files covered by .gitignore or .prettierignore', async () => {
+      tree.write('.gitignore', 'by-git.ts\n');
+      tree.write('.prettierignore', 'by-prettier.ts\n');
+      tree.write('by-git.ts', unformatted);
+      tree.write('by-prettier.ts', unformatted);
+      tree.write('kept.ts', unformatted);
+
+      await formatFiles(tree);
+
+      expect(tree.read('kept.ts', 'utf-8')).toBe(formatted);
+      expect(tree.read('by-git.ts', 'utf-8')).toBe(unformatted);
+      expect(tree.read('by-prettier.ts', 'utf-8')).toBe(unformatted);
+    });
+
+    it('should honour an ignore file in a subdirectory', async () => {
+      tree.write('apps/foo/.gitignore', '/generated/\n');
+      tree.write('apps/foo/generated/a.ts', unformatted);
+      tree.write('apps/foo/kept.ts', unformatted);
+      // The same trailing segments outside that directory are unaffected.
+      tree.write('generated/b.ts', unformatted);
+
+      await formatFiles(tree);
+
+      expect(tree.read('apps/foo/kept.ts', 'utf-8')).toBe(formatted);
+      expect(tree.read('generated/b.ts', 'utf-8')).toBe(formatted);
+      expect(tree.read('apps/foo/generated/a.ts', 'utf-8')).toBe(unformatted);
+    });
+  });
+
   describe('sortRootTsconfigPaths', () => {
     it('should sort tsconfig paths when sortRootTsconfigPaths option is true', async () => {
       tree.write(

--- a/packages/devkit/src/generators/format-files.spec.ts
+++ b/packages/devkit/src/generators/format-files.spec.ts
@@ -138,9 +138,9 @@ describe('formatFiles', () => {
 
     it('should not let .prettierignore negate .gitignore', async () => {
       // prettier builds an ignorer per ignore file and ORs them, so a `!` in
-      // one cannot re-include what another excluded. This is the only test that
-      // reaches `merge: false` - without it the flag can be flipped to `true`
-      // with the whole suite still green.
+      // one cannot re-include what another excluded. `ignore.spec.ts` pins
+      // `merge: false` directly; this is the end-to-end check that prettier
+      // really behaves that way.
       tree.write('.gitignore', 'a.ts\n');
       tree.write('.prettierignore', '!a.ts\n');
       tree.write('a.ts', unformatted);

--- a/packages/devkit/src/generators/format-files.spec.ts
+++ b/packages/devkit/src/generators/format-files.spec.ts
@@ -139,8 +139,8 @@ describe('formatFiles', () => {
     it('should not let .prettierignore negate .gitignore', async () => {
       // prettier builds an ignorer per ignore file and ORs them, so a `!` in
       // one cannot re-include what another excluded. This is the only test that
-      // reaches `combine: 'separate'` - without it the mode can be flipped to
-      // `'merged'` with the whole suite still green.
+      // reaches `merge: false` - without it the flag can be flipped to `true`
+      // with the whole suite still green.
       tree.write('.gitignore', 'a.ts\n');
       tree.write('.prettierignore', '!a.ts\n');
       tree.write('a.ts', unformatted);

--- a/packages/devkit/src/generators/format-files.spec.ts
+++ b/packages/devkit/src/generators/format-files.spec.ts
@@ -136,6 +136,22 @@ describe('formatFiles', () => {
       expect(tree.read('apps/foo/nested.ts', 'utf-8')).toBe(formatted);
     });
 
+    it('should not let .prettierignore negate .gitignore', async () => {
+      // prettier builds an ignorer per ignore file and ORs them, so a `!` in
+      // one cannot re-include what another excluded. This is the only test that
+      // reaches `combine: 'separate'` - without it the mode can be flipped to
+      // `'merged'` with the whole suite still green.
+      tree.write('.gitignore', 'a.ts\n');
+      tree.write('.prettierignore', '!a.ts\n');
+      tree.write('a.ts', unformatted);
+      tree.write('kept.ts', unformatted);
+
+      await formatFiles(tree);
+
+      expect(tree.read('kept.ts', 'utf-8')).toBe(formatted);
+      expect(tree.read('a.ts', 'utf-8')).toBe(unformatted);
+    });
+
     it('should apply a root ignore file to a nested path', async () => {
       tree.write('.gitignore', 'generated/\n');
       tree.write('apps/foo/generated/a.ts', unformatted);

--- a/packages/devkit/src/generators/format-files.spec.ts
+++ b/packages/devkit/src/generators/format-files.spec.ts
@@ -98,8 +98,8 @@ describe('formatFiles', () => {
     // to work - it uses a dynamic import that jest only permits under
     // NODE_OPTIONS=--experimental-vm-modules. `nx test devkit` sets that
     // (nx.json), a bare `npx jest` does not, and without it nothing formats and
-    // every case here is vacuous. The unformatted `kept` assertions are what
-    // catch that: they fail rather than silently passing.
+    // every case here is vacuous. The `kept` assertions - the ones expecting
+    // *formatted* output - are what catch that: they fail rather than passing.
     const unformatted = 'const   x   =   1';
     const formatted = 'const x = 1;\n';
 
@@ -117,18 +117,44 @@ describe('formatFiles', () => {
       expect(tree.read('by-prettier.ts', 'utf-8')).toBe(unformatted);
     });
 
-    it('should honour an ignore file in a subdirectory', async () => {
+    // Prettier resolves ignore files from the workspace root only - it has no
+    // nested-ignore-file concept, so `prettier --check` flags a file a nested
+    // `.prettierignore` names. Skipping it here would leave it committed
+    // unformatted and fail `nx format:check` on a file the generator author
+    // never touched, so generator formatting has to stay root-only too.
+    it('should ignore a nested ignore file, as prettier does', async () => {
       tree.write('apps/foo/.gitignore', '/generated/\n');
+      tree.write('apps/foo/.prettierignore', 'nested.ts\n');
       tree.write('apps/foo/generated/a.ts', unformatted);
+      tree.write('apps/foo/nested.ts', unformatted);
       tree.write('apps/foo/kept.ts', unformatted);
-      // The same trailing segments outside that directory are unaffected.
-      tree.write('generated/b.ts', unformatted);
 
       await formatFiles(tree);
 
       expect(tree.read('apps/foo/kept.ts', 'utf-8')).toBe(formatted);
-      expect(tree.read('generated/b.ts', 'utf-8')).toBe(formatted);
+      expect(tree.read('apps/foo/generated/a.ts', 'utf-8')).toBe(formatted);
+      expect(tree.read('apps/foo/nested.ts', 'utf-8')).toBe(formatted);
+    });
+
+    it('should apply a root ignore file to a nested path', async () => {
+      tree.write('.gitignore', 'generated/\n');
+      tree.write('apps/foo/generated/a.ts', unformatted);
+      tree.write('apps/foo/kept.ts', unformatted);
+
+      await formatFiles(tree);
+
+      expect(tree.read('apps/foo/kept.ts', 'utf-8')).toBe(formatted);
       expect(tree.read('apps/foo/generated/a.ts', 'utf-8')).toBe(unformatted);
+    });
+
+    it('should never format files under node_modules', async () => {
+      tree.write('node_modules/pkg/a.ts', unformatted);
+      tree.write('kept.ts', unformatted);
+
+      await formatFiles(tree);
+
+      expect(tree.read('kept.ts', 'utf-8')).toBe(formatted);
+      expect(tree.read('node_modules/pkg/a.ts', 'utf-8')).toBe(unformatted);
     });
   });
 

--- a/packages/devkit/src/generators/format-files.ts
+++ b/packages/devkit/src/generators/format-files.ts
@@ -1,5 +1,6 @@
 import { readJson, Tree, writeJson } from 'nx/src/devkit-exports';
 import {
+  createTreeIgnoreChecker,
   isUsingPrettierInTree,
   sortObjectByKeys,
 } from 'nx/src/devkit-internals';
@@ -67,8 +68,19 @@ export async function formatFiles(
 
   if (!prettier) return;
 
+  // Both prettier's CLI and oxfmt's skip files covered by `.gitignore` or
+  // `.prettierignore` (measured), so a generator that formatted them anyway
+  // would rewrite files `nx format:check` never looks at. `getFileInfo` below
+  // does not do this for us: without an `ignorePath` its `ignored` is always
+  // false.
+  const isIgnored = createTreeIgnoreChecker(tree, [
+    '.gitignore',
+    '.prettierignore',
+  ]);
   const files = new Set(
-    tree.listChanges().filter((file) => file.type !== 'DELETE')
+    tree
+      .listChanges()
+      .filter((file) => file.type !== 'DELETE' && !isIgnored(file.path))
   );
 
   const changedPrettierInTree = getChangedPrettierConfigInTree(tree);

--- a/packages/devkit/src/generators/format-files.ts
+++ b/packages/devkit/src/generators/format-files.ts
@@ -22,8 +22,9 @@ async function importPrettier(): Promise<typeof Prettier | null> {
 }
 
 /**
- * Formats the created or updated files using Prettier, skipping any the
- * workspace's `.gitignore` or `.prettierignore` covers
+ * Formats the created or updated files using Prettier, skipping `node_modules`,
+ * `.git`, the nx and yarn caches, and anything the workspace's root
+ * `.gitignore` or `.prettierignore` covers
  * @param tree - the file system tree
  * @param options - options for the formatFiles function
  *

--- a/packages/devkit/src/generators/format-files.ts
+++ b/packages/devkit/src/generators/format-files.ts
@@ -68,22 +68,10 @@ export async function formatFiles(
 
   if (!prettier) return;
 
-  // Prettier's CLI skips files covered by the workspace-root `.gitignore` or
-  // `.prettierignore`, so formatting them here would rewrite files
-  // `nx format:check` never looks at. `getFileInfo` below does not do this for
-  // us: with no `ignorePath` its `ignored` is always false (measured).
-  //
-  // Root-only, deliberately. Prettier has no nested-ignore-file concept
-  // (measured: a nested `.prettierignore` does not stop `prettier --check`
-  // flagging the file), so cascading here would leave files unformatted that
-  // `nx format:check` still fails on.
-  const { isIgnoredFile } = createTreeIgnoreChecker(
-    tree,
-    ['.gitignore', '.prettierignore'],
-    // `separate`: prettier ORs one ignorer per `--ignore-path`, so neither
-    // file's negation can undo the other's exclusion.
-    { cascade: false, combine: 'separate' }
-  );
+  // Must skip exactly what `nx format:check` skips, or a generator leaves files
+  // it will later fail on. `getFileInfo` below does not do it: with no
+  // `ignorePath` its `ignored` is always false (measured).
+  const { isIgnoredFile } = createTreeIgnoreChecker(tree, 'prettier');
   const files = new Set(
     tree
       .listChanges()

--- a/packages/devkit/src/generators/format-files.ts
+++ b/packages/devkit/src/generators/format-files.ts
@@ -1,6 +1,6 @@
 import { readJson, Tree, writeJson } from 'nx/src/devkit-exports';
 import {
-  createTreeIgnoreChecker,
+  createPrettierIgnoreChecker,
   isUsingPrettierInTree,
   sortObjectByKeys,
 } from 'nx/src/devkit-internals';
@@ -74,7 +74,7 @@ export async function formatFiles(
   // own built-in `node_modules` skip: with no `ignorePath` it never reads the
   // workspace's ignore files, so `ignored` is false for everything else
   // (measured).
-  const { isIgnoredFile } = createTreeIgnoreChecker(tree, 'prettier');
+  const { isIgnoredFile } = createPrettierIgnoreChecker(tree);
   const files = new Set(
     tree
       .listChanges()

--- a/packages/devkit/src/generators/format-files.ts
+++ b/packages/devkit/src/generators/format-files.ts
@@ -6,6 +6,7 @@ import {
 } from 'nx/src/devkit-internals';
 import * as path from 'path';
 import type * as Prettier from 'prettier';
+import { assertNxSupportsIgnoreCheckers } from '../utils/nx-ignore-internals';
 
 // Prettier v3 (ESM) exposes its API as named exports; v2 (CJS) exposes it under
 // `.default` when loaded via `import()`. Return whichever carries the API, or
@@ -69,6 +70,8 @@ export async function formatFiles(
   } catch {}
 
   if (!prettier) return;
+
+  assertNxSupportsIgnoreCheckers();
 
   // `getFileInfo` below looks like it filters ignored files but only covers its
   // own built-in `node_modules` skip: with no `ignorePath` it never reads the

--- a/packages/devkit/src/generators/format-files.ts
+++ b/packages/devkit/src/generators/format-files.ts
@@ -80,7 +80,9 @@ export async function formatFiles(
   const isIgnored = createTreeIgnoreChecker(
     tree,
     ['.gitignore', '.prettierignore'],
-    { cascade: false }
+    // `separate`: prettier ORs one ignorer per `--ignore-path`, so neither
+    // file's negation can undo the other's exclusion.
+    { cascade: false, combine: 'separate' }
   );
   const files = new Set(
     tree

--- a/packages/devkit/src/generators/format-files.ts
+++ b/packages/devkit/src/generators/format-files.ts
@@ -68,15 +68,20 @@ export async function formatFiles(
 
   if (!prettier) return;
 
-  // Both prettier's CLI and oxfmt's skip files covered by `.gitignore` or
-  // `.prettierignore` (measured), so a generator that formatted them anyway
-  // would rewrite files `nx format:check` never looks at. `getFileInfo` below
-  // does not do this for us: without an `ignorePath` its `ignored` is always
-  // false.
-  const isIgnored = createTreeIgnoreChecker(tree, [
-    '.gitignore',
-    '.prettierignore',
-  ]);
+  // Prettier's CLI skips files covered by the workspace-root `.gitignore` or
+  // `.prettierignore`, so formatting them here would rewrite files
+  // `nx format:check` never looks at. `getFileInfo` below does not do this for
+  // us: with no `ignorePath` its `ignored` is always false (measured).
+  //
+  // Root-only, deliberately. Prettier has no nested-ignore-file concept
+  // (measured: a nested `.prettierignore` does not stop `prettier --check`
+  // flagging the file), so cascading here would leave files unformatted that
+  // `nx format:check` still fails on.
+  const isIgnored = createTreeIgnoreChecker(
+    tree,
+    ['.gitignore', '.prettierignore'],
+    { cascade: false }
+  );
   const files = new Set(
     tree
       .listChanges()

--- a/packages/devkit/src/generators/format-files.ts
+++ b/packages/devkit/src/generators/format-files.ts
@@ -68,8 +68,10 @@ export async function formatFiles(
 
   if (!prettier) return;
 
-  // `getFileInfo` below looks like it filters ignored files but does not: with
-  // no `ignorePath` its `ignored` is always false (measured).
+  // `getFileInfo` below looks like it filters ignored files but only covers its
+  // own built-in `node_modules` skip: with no `ignorePath` it never reads the
+  // workspace's ignore files, so `ignored` is false for everything else
+  // (measured).
   const { isIgnoredFile } = createTreeIgnoreChecker(tree, 'prettier');
   const files = new Set(
     tree

--- a/packages/devkit/src/generators/format-files.ts
+++ b/packages/devkit/src/generators/format-files.ts
@@ -22,7 +22,8 @@ async function importPrettier(): Promise<typeof Prettier | null> {
 }
 
 /**
- * Formats all the created or updated files using Prettier
+ * Formats the created or updated files using Prettier, skipping any the
+ * workspace's `.gitignore` or `.prettierignore` covers
  * @param tree - the file system tree
  * @param options - options for the formatFiles function
  *

--- a/packages/devkit/src/generators/format-files.ts
+++ b/packages/devkit/src/generators/format-files.ts
@@ -77,7 +77,7 @@ export async function formatFiles(
   // (measured: a nested `.prettierignore` does not stop `prettier --check`
   // flagging the file), so cascading here would leave files unformatted that
   // `nx format:check` still fails on.
-  const isIgnored = createTreeIgnoreChecker(
+  const { isIgnoredFile } = createTreeIgnoreChecker(
     tree,
     ['.gitignore', '.prettierignore'],
     // `separate`: prettier ORs one ignorer per `--ignore-path`, so neither
@@ -87,7 +87,7 @@ export async function formatFiles(
   const files = new Set(
     tree
       .listChanges()
-      .filter((file) => file.type !== 'DELETE' && !isIgnored(file.path))
+      .filter((file) => file.type !== 'DELETE' && !isIgnoredFile(file.path))
   );
 
   const changedPrettierInTree = getChangedPrettierConfigInTree(tree);

--- a/packages/devkit/src/generators/format-files.ts
+++ b/packages/devkit/src/generators/format-files.ts
@@ -68,9 +68,8 @@ export async function formatFiles(
 
   if (!prettier) return;
 
-  // Must skip exactly what `nx format:check` skips, or a generator leaves files
-  // it will later fail on. `getFileInfo` below does not do it: with no
-  // `ignorePath` its `ignored` is always false (measured).
+  // `getFileInfo` below looks like it filters ignored files but does not: with
+  // no `ignorePath` its `ignored` is always false (measured).
   const { isIgnoredFile } = createTreeIgnoreChecker(tree, 'prettier');
   const files = new Set(
     tree

--- a/packages/devkit/src/generators/format-files.ts
+++ b/packages/devkit/src/generators/format-files.ts
@@ -6,7 +6,7 @@ import {
 } from 'nx/src/devkit-internals';
 import * as path from 'path';
 import type * as Prettier from 'prettier';
-import { assertNxSupportsIgnoreCheckers } from '../utils/nx-ignore-internals';
+import { NOTHING_IGNORED } from '../utils/nx-ignore-internals';
 
 // Prettier v3 (ESM) exposes its API as named exports; v2 (CJS) exposes it under
 // `.default` when loaded via `import()`. Return whichever carries the API, or
@@ -71,13 +71,14 @@ export async function formatFiles(
 
   if (!prettier) return;
 
-  assertNxSupportsIgnoreCheckers();
-
   // `getFileInfo` below looks like it filters ignored files but only covers its
   // own built-in `node_modules` skip: with no `ignorePath` it never reads the
   // workspace's ignore files, so `ignored` is false for everything else
   // (measured).
-  const { isIgnoredFile } = createPrettierIgnoreChecker(tree);
+  //
+  // The optional call is the older-nx path - see `NOTHING_IGNORED`.
+  const { isIgnoredFile } =
+    createPrettierIgnoreChecker?.(tree) ?? NOTHING_IGNORED;
   const files = new Set(
     tree
       .listChanges()

--- a/packages/devkit/src/generators/ignore-nx-skew.spec.ts
+++ b/packages/devkit/src/generators/ignore-nx-skew.spec.ts
@@ -1,0 +1,67 @@
+import { createTreeWithEmptyWorkspace } from 'nx/src/generators/testing-utils/create-tree-with-empty-workspace';
+import type { Tree } from 'nx/src/generators/tree';
+import { formatFiles } from './format-files';
+import { visitNotIgnoredFiles } from './visit-not-ignored-files';
+
+// devkit's `nx` peer spans a major either side, so it runs against an nx that
+// predates the ignore checkers. Those reach devkit as `undefined` rather than as
+// a load failure, so without a guard the first call is `undefined is not a
+// function` thrown from inside whatever generator happened to run.
+//
+// The names stripped here are the whole contract of this file; the
+// `guards the simulation itself` test asserts on the same list so the two cannot
+// drift, which is the failure that made the sibling formatter skew spec certify
+// a version of nx that never existed.
+// A checker added later must be added here and to `assertNxSupportsIgnoreCheckers`
+// together, or the guard silently stops covering it.
+const ABSENT_ON_OLDER_NX = [
+  'createGitIgnoreChecker',
+  'createPrettierIgnoreChecker',
+] as const;
+
+jest.mock('nx/src/devkit-internals', () => {
+  const actual = jest.requireActual('nx/src/devkit-internals');
+  const olderNx = { ...actual };
+  for (const name of [
+    'createGitIgnoreChecker',
+    'createPrettierIgnoreChecker',
+  ]) {
+    delete olderNx[name];
+  }
+  return olderNx;
+});
+
+describe('ignore checkers against an nx without them', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+  });
+
+  it('guards the simulation itself', () => {
+    const internals = require('nx/src/devkit-internals');
+
+    for (const name of ABSENT_ON_OLDER_NX) {
+      expect(internals[name]).toBeUndefined();
+    }
+    // Something must survive, or the mock is testing an empty module.
+    expect(internals.isUsingPrettierInTree).toBeDefined();
+  });
+
+  it('should tell visitNotIgnoredFiles callers what to do rather than throwing a TypeError', () => {
+    tree.write('src/a.ts', '');
+
+    expect(() => visitNotIgnoredFiles(tree, '', () => {})).toThrow(
+      /does not export the ignore checkers.*nx migrate latest/s
+    );
+  });
+
+  it('should tell formatFiles callers the same', async () => {
+    tree.write('.prettierrc', '{}');
+    tree.write('test.ts', 'const   x   =   1');
+
+    await expect(formatFiles(tree)).rejects.toThrow(
+      /does not export the ignore checkers.*nx migrate latest/s
+    );
+  });
+});

--- a/packages/devkit/src/generators/ignore-nx-skew.spec.ts
+++ b/packages/devkit/src/generators/ignore-nx-skew.spec.ts
@@ -48,7 +48,11 @@ describe('ignore checkers against an nx without them', () => {
     expect(internals.isUsingPrettierInTree).toBeDefined();
   });
 
-  it('should tell visitNotIgnoredFiles callers what to do rather than throwing a TypeError', () => {
+  // The two callers degrade in opposite directions on purpose.
+
+  it('should fail the walk by name rather than with a TypeError', () => {
+    // Without a checker nothing is ignored, so the walk would descend into
+    // node_modules and hand a migration every file in it. Failing beats that.
     tree.write('src/a.ts', '');
 
     expect(() => visitNotIgnoredFiles(tree, '', () => {})).toThrow(
@@ -56,12 +60,13 @@ describe('ignore checkers against an nx without them', () => {
     );
   });
 
-  it('should tell formatFiles callers the same', async () => {
+  it('should still format, filtering nothing, rather than failing', async () => {
+    // Filtering nothing is what this nx pairing always did, so a generator that
+    // formats is the right answer here - not one that refuses to run.
     tree.write('.prettierrc', '{}');
-    tree.write('test.ts', 'const   x   =   1');
+    tree.write('.gitignore', 'ignored.ts\n');
+    tree.write('ignored.ts', 'const   x   =   1');
 
-    await expect(formatFiles(tree)).rejects.toThrow(
-      /does not export the ignore checkers.*nx migrate latest/s
-    );
+    await expect(formatFiles(tree)).resolves.toBeUndefined();
   });
 });

--- a/packages/devkit/src/generators/visit-not-ignored-files.spec.ts
+++ b/packages/devkit/src/generators/visit-not-ignored-files.spec.ts
@@ -273,8 +273,12 @@ describe('visitNotIgnoredFiles', () => {
       'a.ts',
       'keep.ts',
       // `/generated/` matches nothing without this, so those cases would assert
-      // only that the walker ignores nothing.
+      // only that the walker ignores nothing. The nested copy is what makes the
+      // leading slash observable: git anchors it to the root, so this one is
+      // visited and `generated/a.ts` is not. Without the pair, stripping every
+      // anchor from every pattern leaves the whole suite green.
       'generated/a.ts',
+      'apps/generated/a.ts',
       'dist/a.ts',
       'dist/keep.ts',
       'apps/a.ts',
@@ -330,6 +334,13 @@ describe('visitNotIgnoredFiles', () => {
         GIT_CONFIG_PARAMETERS: '',
         GIT_TEMPLATE_DIR: '',
       };
+      // These point git at a different repo entirely - git exports them to its
+      // own subprocesses, so a suite run from a hook or `git bisect run` would
+      // otherwise re-init the ambient repo instead of `repo`. They have to be
+      // removed rather than emptied: git rejects `''` as an invalid path.
+      delete env.GIT_DIR;
+      delete env.GIT_WORK_TREE;
+      delete env.GIT_INDEX_FILE;
       // No `stdio: 'ignore'`: `-q` already silences the success path, and
       // discarding stderr would report every failure here - a missing git, a
       // read-only TMPDIR, `safe.directory` - as a bare "Command failed".
@@ -356,11 +367,20 @@ describe('visitNotIgnoredFiles', () => {
       return new Set(seen.filter((f) => FILES.includes(f)));
     }
 
+    // The label is pre-escaped rather than left to `%p`, which renders the
+    // multi-line pattern across three lines and breaks `jest -t` filtering.
     it.each(
       PATTERNS.flatMap((pattern) =>
-        NEGATIONS.map((negation) => [pattern, negation] as const)
+        NEGATIONS.map(
+          (negation) =>
+            [
+              `${JSON.stringify(pattern)} + ${JSON.stringify(negation)}`,
+              pattern,
+              negation,
+            ] as const
+        )
       )
-    )('matches git for %p + %p', (pattern, negation) => {
+    )('matches git for %s', (_label, pattern, negation) => {
       const gitignore = [pattern, negation].filter(Boolean).join('\n') + '\n';
 
       expect([...walkerVisits(gitignore)].sort()).toEqual(

--- a/packages/devkit/src/generators/visit-not-ignored-files.spec.ts
+++ b/packages/devkit/src/generators/visit-not-ignored-files.spec.ts
@@ -315,32 +315,30 @@ describe('visitNotIgnoredFiles', () => {
         mkdirSync(dirname(join(repo, file)), { recursive: true });
         writeFileSync(join(repo, file), '');
       }
-      // `--exclude-standard` reads four sources the walker knows nothing about,
-      // and each needs pinning separately or the result depends on whoever is
-      // running the suite: the config files; `core.excludesFile`, whose default
-      // `~/.config/git/ignore` is a path fallback rather than config and so
-      // survives dropping them; git's two independent config-injection channels
-      // (`GIT_CONFIG_COUNT` and the older `GIT_CONFIG_PARAMETERS`); and the
-      // template dir, which is what seeds `.git/info/exclude` - with templates
-      // off the repo has none at all. `GIT_TEMPLATE_DIR` is empty rather than a
-      // nonexistent path because a missing template warns on every case.
-      const env = {
-        ...process.env,
+      // Every ambient `GIT_*` is dropped and the ones below are the only ones
+      // set, so the oracle cannot depend on whoever is running the suite. An
+      // allowlist rather than a denylist because git has more of these than is
+      // practical to enumerate - `GIT_DIR` and `GIT_COMMON_DIR` relocate the
+      // repo, `GIT_INDEX_FILE` makes corpus files look tracked so `-o` drops
+      // them silently, and git exports all of them to its own subprocesses, so
+      // a run from a hook or `git bisect run` inherits them.
+      //
+      // What survives the filter and still needs pinning: the config files, and
+      // `core.excludesFile`, whose default `~/.config/git/ignore` is a path
+      // fallback rather than config. `GIT_TEMPLATE_DIR` is empty rather than a
+      // nonexistent path - both stop `.git/info/exclude` being seeded, but a
+      // missing template warns on every case.
+      const env: NodeJS.ProcessEnv = {
+        ...Object.fromEntries(
+          Object.entries(process.env).filter(([key]) => !key.startsWith('GIT_'))
+        ),
         GIT_CONFIG_GLOBAL: join(repo, 'no-such-gitconfig'),
         GIT_CONFIG_SYSTEM: join(repo, 'no-such-gitconfig'),
         GIT_CONFIG_COUNT: '1',
         GIT_CONFIG_KEY_0: 'core.excludesFile',
         GIT_CONFIG_VALUE_0: join(repo, 'no-such-gitignore'),
-        GIT_CONFIG_PARAMETERS: '',
         GIT_TEMPLATE_DIR: '',
       };
-      // These point git at a different repo entirely - git exports them to its
-      // own subprocesses, so a suite run from a hook or `git bisect run` would
-      // otherwise re-init the ambient repo instead of `repo`. They have to be
-      // removed rather than emptied: git rejects `''` as an invalid path.
-      delete env.GIT_DIR;
-      delete env.GIT_WORK_TREE;
-      delete env.GIT_INDEX_FILE;
       // No `stdio: 'ignore'`: `-q` already silences the success path, and
       // discarding stderr would report every failure here - a missing git, a
       // read-only TMPDIR, `safe.directory` - as a bare "Command failed".

--- a/packages/devkit/src/generators/visit-not-ignored-files.spec.ts
+++ b/packages/devkit/src/generators/visit-not-ignored-files.spec.ts
@@ -258,6 +258,12 @@ describe('visitNotIgnoredFiles', () => {
     const PATTERNS = [
       'dist/',
       'dist',
+      // `dist/` excludes the directory, so git refuses to re-include anything
+      // under it; `dist/**` excludes only the contents, so a later negation
+      // does work. Without this entry the pair is never distinguished, and a
+      // walker that stopped probing directories with a trailing slash would
+      // still pass every other case.
+      'dist/**',
       '*.log',
       'build',
       '/generated/',

--- a/packages/devkit/src/generators/visit-not-ignored-files.spec.ts
+++ b/packages/devkit/src/generators/visit-not-ignored-files.spec.ts
@@ -1,3 +1,7 @@
+import { execSync } from 'child_process';
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { dirname, join } from 'path';
 import { createTree } from 'nx/src/generators/testing-utils/create-tree';
 import type { Tree } from 'nx/src/generators/tree';
 import { visitNotIgnoredFiles } from './visit-not-ignored-files';
@@ -241,6 +245,84 @@ describe('visitNotIgnoredFiles', () => {
       tree.write('node_modules/pkg/index.js', '');
 
       expect(visitAll()).not.toContain('node_modules/pkg/index.js');
+    });
+  });
+
+  // Differential test against real git rather than against hand-written
+  // expectations. The cases above encode what we believe git does; this one
+  // asks it. Every defect this walker has shipped was a disagreement with an
+  // authority, and a sweep finds those without anyone having to think of the
+  // specific pattern first - the allowlist idiom below went unnoticed through
+  // four rounds of hand-written tests.
+  describe('agreement with git', () => {
+    const PATTERNS = [
+      'dist/',
+      'dist',
+      '*.log',
+      'build',
+      '/generated/',
+      '**/tmp/',
+      '*',
+    ];
+    const NEGATIONS = ['', '!keep.ts', '!apps/', '!apps/**', '!dist/'];
+    const FILES = [
+      'a.ts',
+      'keep.ts',
+      'dist/a.ts',
+      'dist/keep.ts',
+      'apps/a.ts',
+      'apps/dist/a.ts',
+      'build/a.ts',
+      'x.log',
+      'apps/tmp/a.ts',
+    ];
+
+    let repo: string;
+
+    beforeEach(() => {
+      repo = mkdtempSync(join(tmpdir(), 'nx-ignore-oracle-'));
+    });
+
+    afterEach(() => {
+      rmSync(repo, { recursive: true, force: true });
+    });
+
+    /** What real git leaves untracked, i.e. does not ignore. */
+    function gitVisits(gitignore: string): Set<string> {
+      writeFileSync(join(repo, '.gitignore'), gitignore);
+      for (const file of FILES) {
+        mkdirSync(dirname(join(repo, file)), { recursive: true });
+        writeFileSync(join(repo, file), '');
+      }
+      execSync('git init -q .', { cwd: repo, stdio: 'ignore' });
+      const listed = execSync('git ls-files -o --exclude-standard', {
+        cwd: repo,
+        encoding: 'utf-8',
+      });
+      return new Set(listed.split('\n').filter((f) => FILES.includes(f)));
+    }
+
+    function walkerVisits(gitignore: string): Set<string> {
+      tree.write('.gitignore', gitignore);
+      for (const file of FILES) {
+        tree.write(file, '');
+      }
+      const seen: string[] = [];
+      visitNotIgnoredFiles(tree, '', (path) => seen.push(path));
+      // `createTree` seeds files of its own; compare only the corpus.
+      return new Set(seen.filter((f) => FILES.includes(f)));
+    }
+
+    it.each(
+      PATTERNS.flatMap((pattern) =>
+        NEGATIONS.map((negation) => [pattern, negation] as const)
+      )
+    )('matches git for %p + %p', (pattern, negation) => {
+      const gitignore = [pattern, negation].filter(Boolean).join('\n') + '\n';
+
+      expect([...walkerVisits(gitignore)].sort()).toEqual(
+        [...gitVisits(gitignore)].sort()
+      );
     });
   });
 });

--- a/packages/devkit/src/generators/visit-not-ignored-files.spec.ts
+++ b/packages/devkit/src/generators/visit-not-ignored-files.spec.ts
@@ -248,12 +248,12 @@ describe('visitNotIgnoredFiles', () => {
     });
   });
 
-  // Differential test against real git rather than against hand-written
-  // expectations. The cases above encode what we believe git does; this one
-  // asks it. Every defect this walker has shipped was a disagreement with an
-  // authority, and a sweep finds those without anyone having to think of the
-  // specific pattern first - the allowlist idiom below went unnoticed through
-  // four rounds of hand-written tests.
+  // Differential against real git rather than hand-written expectations: the
+  // cases above encode what we believe git does, this one asks it.
+  //
+  // Covers pattern semantics, file-vs-directory probing and the cascade. It
+  // cannot cover how `.nxignore` merges with `.gitignore` - git has no
+  // `.nxignore` - so the cases above are what pin that.
   describe('agreement with git', () => {
     const PATTERNS = [
       'dist/',
@@ -263,19 +263,30 @@ describe('visitNotIgnoredFiles', () => {
       '/generated/',
       '**/tmp/',
       '*',
+      'keep.ts',
+      // The allowlist idiom needs both negations together, so it cannot be
+      // reached by pairing one pattern with one negation.
+      '*\n!apps/\n!apps/**',
     ];
     const NEGATIONS = ['', '!keep.ts', '!apps/', '!apps/**', '!dist/'];
     const FILES = [
       'a.ts',
       'keep.ts',
+      // `/generated/` matches nothing without this, so those cases would assert
+      // only that the walker ignores nothing.
+      'generated/a.ts',
       'dist/a.ts',
       'dist/keep.ts',
       'apps/a.ts',
+      'apps/keep.ts',
       'apps/dist/a.ts',
       'build/a.ts',
       'x.log',
       'apps/tmp/a.ts',
     ];
+    // A nested ignore file, so the cascade is under test too. Without one every
+    // case resolves the same root-only chain and `cascade` is never exercised.
+    const NESTED = { 'apps/.gitignore': '!keep.ts\n' };
 
     let repo: string;
 
@@ -284,26 +295,45 @@ describe('visitNotIgnoredFiles', () => {
     });
 
     afterEach(() => {
-      rmSync(repo, { recursive: true, force: true });
+      // git object files are read-only, which makes removal flaky on Windows.
+      rmSync(repo, { recursive: true, force: true, maxRetries: 3 });
     });
 
     /** What real git leaves untracked, i.e. does not ignore. */
     function gitVisits(gitignore: string): Set<string> {
       writeFileSync(join(repo, '.gitignore'), gitignore);
+      for (const [path, contents] of Object.entries(NESTED)) {
+        mkdirSync(dirname(join(repo, path)), { recursive: true });
+        writeFileSync(join(repo, path), contents);
+      }
       for (const file of FILES) {
         mkdirSync(dirname(join(repo, file)), { recursive: true });
         writeFileSync(join(repo, file), '');
       }
-      execSync('git init -q .', { cwd: repo, stdio: 'ignore' });
+      // `--exclude-standard` also honours the user's global excludesFile and
+      // `.git/info/exclude`, which the walker knows nothing about - without
+      // this the test passes or fails on whatever the developer has in
+      // `~/.gitignore`. Pointing at a path that does not exist keeps it
+      // portable; `/dev/null` would not be.
+      const env = {
+        ...process.env,
+        GIT_CONFIG_GLOBAL: join(repo, 'no-such-gitconfig'),
+        GIT_CONFIG_SYSTEM: join(repo, 'no-such-gitconfig'),
+      };
+      execSync('git init -q .', { cwd: repo, stdio: 'ignore', env });
       const listed = execSync('git ls-files -o --exclude-standard', {
         cwd: repo,
         encoding: 'utf-8',
+        env,
       });
       return new Set(listed.split('\n').filter((f) => FILES.includes(f)));
     }
 
     function walkerVisits(gitignore: string): Set<string> {
       tree.write('.gitignore', gitignore);
+      for (const [path, contents] of Object.entries(NESTED)) {
+        tree.write(path, contents);
+      }
       for (const file of FILES) {
         tree.write(file, '');
       }

--- a/packages/devkit/src/generators/visit-not-ignored-files.spec.ts
+++ b/packages/devkit/src/generators/visit-not-ignored-files.spec.ts
@@ -295,7 +295,8 @@ describe('visitNotIgnoredFiles', () => {
     });
 
     afterEach(() => {
-      // git object files are read-only, which makes removal flaky on Windows.
+      // Windows can hold a handle on a freshly written `.git` file past the
+      // process that wrote it, which surfaces as a transient EBUSY/EPERM.
       rmSync(repo, { recursive: true, force: true, maxRetries: 3 });
     });
 
@@ -310,17 +311,24 @@ describe('visitNotIgnoredFiles', () => {
         mkdirSync(dirname(join(repo, file)), { recursive: true });
         writeFileSync(join(repo, file), '');
       }
-      // `--exclude-standard` also honours the user's global excludesFile and
-      // `.git/info/exclude`, which the walker knows nothing about - without
-      // this the test passes or fails on whatever the developer has in
-      // `~/.gitignore`. Pointing at a path that does not exist keeps it
-      // portable; `/dev/null` would not be.
+      // `--exclude-standard` honours the developer's global `core.excludesFile`,
+      // which the walker knows nothing about, so without this the test passes or
+      // fails on whatever is in `~/.gitignore`. Pointing config at a path that
+      // does not exist drops it, and `init.templateDir` with it; `/dev/null`
+      // would not be portable. `GIT_CONFIG_COUNT` outranks `GIT_CONFIG_GLOBAL`,
+      // so it has to be cleared too. `.git/info/exclude` is repo state rather
+      // than config and is *not* covered - the repo is created fresh here, so
+      // there is none.
       const env = {
         ...process.env,
         GIT_CONFIG_GLOBAL: join(repo, 'no-such-gitconfig'),
         GIT_CONFIG_SYSTEM: join(repo, 'no-such-gitconfig'),
+        GIT_CONFIG_COUNT: '0',
       };
-      execSync('git init -q .', { cwd: repo, stdio: 'ignore', env });
+      // No `stdio: 'ignore'`: `-q` already silences the success path, and
+      // discarding stderr would report every failure here - a missing git, a
+      // read-only TMPDIR, `safe.directory` - as a bare "Command failed".
+      execSync('git init -q .', { cwd: repo, env });
       const listed = execSync('git ls-files -o --exclude-standard', {
         cwd: repo,
         encoding: 'utf-8',

--- a/packages/devkit/src/generators/visit-not-ignored-files.spec.ts
+++ b/packages/devkit/src/generators/visit-not-ignored-files.spec.ts
@@ -148,6 +148,50 @@ describe('visitNotIgnoredFiles', () => {
       children.mockRestore();
     });
 
+    it('should prune a directory excluded with a trailing slash', () => {
+      // `dist/` is the form git documents for directories, and `ignore` will not
+      // match it against the slash-less path `dist`. Without probing directories
+      // with a trailing slash the walk descends, and the nested negation below
+      // then re-includes a file git would never have looked at.
+      tree.write('.gitignore', 'dist/\n');
+      tree.write('apps/foo/dist/.gitignore', '!keep.ts\n');
+      tree.write('apps/foo/dist/keep.ts', '');
+      tree.write('apps/foo/src/b.ts', '');
+
+      const visited = visitAll();
+
+      expect(visited).not.toContain('apps/foo/dist/keep.ts');
+      expect(visited).toContain('apps/foo/src/b.ts');
+    });
+
+    it('should visit nothing when started inside a trailing-slash exclusion', () => {
+      // Same leak as above, reached through the caller's `dirPath` instead of
+      // the walk - the loop below never sees this directory, so the entry guard
+      // is the only thing that can prune it.
+      tree.write('.gitignore', 'dist/\n');
+      tree.write('apps/foo/dist/.gitignore', '!keep.ts\n');
+      tree.write('apps/foo/dist/keep.ts', '');
+
+      const visited: string[] = [];
+      visitNotIgnoredFiles(tree, 'apps/foo/dist', (p) => visited.push(p));
+
+      expect(visited).toEqual([]);
+    });
+
+    it('should let a .nxignore negation re-include a .gitignore exclusion', () => {
+      // The native walker gives `.nxignore` precedence, and master merged both
+      // files into one matcher so it won there too.
+      tree.write('.gitignore', 'generated\n');
+      tree.write('.nxignore', '!generated\n');
+      tree.write('generated/a.ts', '');
+      tree.write('src/b.ts', '');
+
+      const visited = visitAll();
+
+      expect(visited).toContain('generated/a.ts');
+      expect(visited).toContain('src/b.ts');
+    });
+
     it('should not re-include a file under an excluded directory', () => {
       // git's rule, and the `ignore` package implements it: `!build/keep.ts`
       // cannot resurrect a file whose directory `build` already excluded.

--- a/packages/devkit/src/generators/visit-not-ignored-files.spec.ts
+++ b/packages/devkit/src/generators/visit-not-ignored-files.spec.ts
@@ -125,14 +125,27 @@ describe('visitNotIgnoredFiles', () => {
       expect(visited).toContain('apps/foo/src/b.ts');
     });
 
-    it('should never visit .git, even with no .gitignore present', () => {
+    it('should never visit the hardcoded directories, with no ignore file present', () => {
+      // Shared with the native walker, so a tree walk and a filesystem walk
+      // agree on what is never worth visiting.
       tree.write('.git/config', '');
+      tree.write('node_modules/pkg/index.js', '');
+      tree.write('.nx/cache/x.js', '');
       tree.write('a.ts', '');
 
       const visited = visitAll();
 
       expect(visited).not.toContain('.git/config');
+      expect(visited).not.toContain('node_modules/pkg/index.js');
+      expect(visited).not.toContain('.nx/cache/x.js');
       expect(visited).toContain('a.ts');
+    });
+
+    it('should not let a negation re-include a hardcoded directory', () => {
+      tree.write('.gitignore', '!node_modules\n');
+      tree.write('node_modules/pkg/index.js', '');
+
+      expect(visitAll()).not.toContain('node_modules/pkg/index.js');
     });
   });
 });

--- a/packages/devkit/src/generators/visit-not-ignored-files.spec.ts
+++ b/packages/devkit/src/generators/visit-not-ignored-files.spec.ts
@@ -178,6 +178,21 @@ describe('visitNotIgnoredFiles', () => {
       expect(visited).toEqual([]);
     });
 
+    it('should support the allowlist idiom', () => {
+      // `*` then `!apps/` is how you opt in rather than out. It only works if
+      // directories are asked about as `apps/` - probed as `apps`, the `*`
+      // matches and `!apps/` cannot, so the whole tree is pruned. Verified
+      // against real git, which visits `apps/a.ts` here.
+      tree.write('.gitignore', '*\n!apps/\n!apps/**\n');
+      tree.write('apps/a.ts', '');
+      tree.write('other/b.ts', '');
+
+      const visited = visitAll();
+
+      expect(visited).toContain('apps/a.ts');
+      expect(visited).not.toContain('other/b.ts');
+    });
+
     it('should let a .nxignore negation re-include a .gitignore exclusion', () => {
       // The native walker gives `.nxignore` precedence, and master merged both
       // files into one matcher so it won there too.

--- a/packages/devkit/src/generators/visit-not-ignored-files.spec.ts
+++ b/packages/devkit/src/generators/visit-not-ignored-files.spec.ts
@@ -114,7 +114,11 @@ describe('visitNotIgnoredFiles', () => {
       expect(visited).toContain('apps/foo/kept.ts');
     });
 
-    it('should skip a directory a nested ignore file excludes', () => {
+    it('should skip files under a directory a nested ignore file excludes', () => {
+      // `dist/` is the canonical gitignore directory form, but the `ignore`
+      // package cannot tell a slash-suffixed pattern targets a directory when
+      // handed a path with no trailing slash, so the walker still descends and
+      // skips each file individually. See the next case for actual pruning.
       tree.write('apps/foo/.gitignore', 'dist/\n');
       tree.write('apps/foo/dist/deep/a.ts', '');
       tree.write('apps/foo/src/b.ts', '');
@@ -122,6 +126,38 @@ describe('visitNotIgnoredFiles', () => {
       const visited = visitAll();
 
       expect(visited).not.toContain('apps/foo/dist/deep/a.ts');
+      expect(visited).toContain('apps/foo/src/b.ts');
+    });
+
+    it('should not descend into a directory the chain excludes by name', () => {
+      // No trailing slash, so the directory path itself matches. `children` is
+      // spied on because asserting only on visited files cannot distinguish
+      // "never descended" from "descended and skipped each file".
+      tree.write('apps/foo/.gitignore', 'build\n');
+      tree.write('apps/foo/build/deep/a.ts', '');
+      tree.write('apps/foo/src/b.ts', '');
+      const children = jest.spyOn(tree, 'children');
+
+      const visited = visitAll();
+
+      expect(visited).not.toContain('apps/foo/build/deep/a.ts');
+      expect(visited).toContain('apps/foo/src/b.ts');
+      expect(children.mock.calls.map(([p]) => p)).not.toContain(
+        'apps/foo/build'
+      );
+      children.mockRestore();
+    });
+
+    it('should not re-include a file under an excluded directory', () => {
+      // git's rule, and the `ignore` package implements it: `!build/keep.ts`
+      // cannot resurrect a file whose directory `build` already excluded.
+      tree.write('apps/foo/.gitignore', 'build\n!build/keep.ts\n');
+      tree.write('apps/foo/build/keep.ts', '');
+      tree.write('apps/foo/src/b.ts', '');
+
+      const visited = visitAll();
+
+      expect(visited).not.toContain('apps/foo/build/keep.ts');
       expect(visited).toContain('apps/foo/src/b.ts');
     });
 

--- a/packages/devkit/src/generators/visit-not-ignored-files.spec.ts
+++ b/packages/devkit/src/generators/visit-not-ignored-files.spec.ts
@@ -311,19 +311,24 @@ describe('visitNotIgnoredFiles', () => {
         mkdirSync(dirname(join(repo, file)), { recursive: true });
         writeFileSync(join(repo, file), '');
       }
-      // `--exclude-standard` honours the developer's global `core.excludesFile`,
-      // which the walker knows nothing about, so without this the test passes or
-      // fails on whatever is in `~/.gitignore`. Pointing config at a path that
-      // does not exist drops it, and `init.templateDir` with it; `/dev/null`
-      // would not be portable. `GIT_CONFIG_COUNT` outranks `GIT_CONFIG_GLOBAL`,
-      // so it has to be cleared too. `.git/info/exclude` is repo state rather
-      // than config and is *not* covered - the repo is created fresh here, so
-      // there is none.
+      // `--exclude-standard` reads four sources the walker knows nothing about,
+      // and each needs pinning separately or the result depends on whoever is
+      // running the suite: the config files; `core.excludesFile`, whose default
+      // `~/.config/git/ignore` is a path fallback rather than config and so
+      // survives dropping them; git's two independent config-injection channels
+      // (`GIT_CONFIG_COUNT` and the older `GIT_CONFIG_PARAMETERS`); and the
+      // template dir, which is what seeds `.git/info/exclude` - with templates
+      // off the repo has none at all. `GIT_TEMPLATE_DIR` is empty rather than a
+      // nonexistent path because a missing template warns on every case.
       const env = {
         ...process.env,
         GIT_CONFIG_GLOBAL: join(repo, 'no-such-gitconfig'),
         GIT_CONFIG_SYSTEM: join(repo, 'no-such-gitconfig'),
-        GIT_CONFIG_COUNT: '0',
+        GIT_CONFIG_COUNT: '1',
+        GIT_CONFIG_KEY_0: 'core.excludesFile',
+        GIT_CONFIG_VALUE_0: join(repo, 'no-such-gitignore'),
+        GIT_CONFIG_PARAMETERS: '',
+        GIT_TEMPLATE_DIR: '',
       };
       // No `stdio: 'ignore'`: `-q` already silences the success path, and
       // discarding stderr would report every failure here - a missing git, a

--- a/packages/devkit/src/generators/visit-not-ignored-files.spec.ts
+++ b/packages/devkit/src/generators/visit-not-ignored-files.spec.ts
@@ -53,4 +53,86 @@ describe('visitNotIgnoredFiles', () => {
       expect(visitor).not.toHaveBeenCalledWith('dir/node_modules/file1.ts');
     }
   );
+
+  describe('nested ignore files', () => {
+    function visitAll() {
+      const visited: string[] = [];
+      visitNotIgnoredFiles(tree, '', (p) => visited.push(p));
+      return visited;
+    }
+
+    it('should honour a .gitignore in a subdirectory', () => {
+      tree.write('apps/foo/.gitignore', 'skip.ts\n');
+      tree.write('apps/foo/skip.ts', '');
+      tree.write('apps/foo/kept.ts', '');
+      // The same name elsewhere is outside that file's reach.
+      tree.write('apps/bar/skip.ts', '');
+
+      const visited = visitAll();
+
+      expect(visited).not.toContain('apps/foo/skip.ts');
+      expect(visited).toContain('apps/foo/kept.ts');
+      expect(visited).toContain('apps/bar/skip.ts');
+    });
+
+    it('should anchor a nested pattern at its own directory', () => {
+      // A bare filename matches at any depth, so it passes whether or not the
+      // path is rebased. A leading slash is what actually pins the rebasing.
+      tree.write('apps/foo/.gitignore', '/generated/\n');
+      tree.write('apps/foo/generated/a.ts', '');
+      tree.write('generated/b.ts', '');
+
+      const visited = visitAll();
+
+      expect(visited).not.toContain('apps/foo/generated/a.ts');
+      expect(visited).toContain('generated/b.ts');
+    });
+
+    it('should let a nested negation re-include a file the root ignored', () => {
+      // git overrides higher-level patterns with lower-level ones.
+      tree.write('.gitignore', '*.log\n');
+      tree.write('apps/foo/.gitignore', '!keep.log\n');
+      tree.write('apps/foo/keep.log', '');
+      tree.write('apps/foo/other.log', '');
+      tree.write('apps/bar/keep.log', '');
+
+      const visited = visitAll();
+
+      expect(visited).toContain('apps/foo/keep.log');
+      expect(visited).not.toContain('apps/foo/other.log');
+      expect(visited).not.toContain('apps/bar/keep.log');
+    });
+
+    it('should honour a .nxignore in a subdirectory', () => {
+      tree.write('apps/foo/.nxignore', 'skip.ts\n');
+      tree.write('apps/foo/skip.ts', '');
+      tree.write('apps/foo/kept.ts', '');
+
+      const visited = visitAll();
+
+      expect(visited).not.toContain('apps/foo/skip.ts');
+      expect(visited).toContain('apps/foo/kept.ts');
+    });
+
+    it('should skip a directory a nested ignore file excludes', () => {
+      tree.write('apps/foo/.gitignore', 'dist/\n');
+      tree.write('apps/foo/dist/deep/a.ts', '');
+      tree.write('apps/foo/src/b.ts', '');
+
+      const visited = visitAll();
+
+      expect(visited).not.toContain('apps/foo/dist/deep/a.ts');
+      expect(visited).toContain('apps/foo/src/b.ts');
+    });
+
+    it('should never visit .git, even with no .gitignore present', () => {
+      tree.write('.git/config', '');
+      tree.write('a.ts', '');
+
+      const visited = visitAll();
+
+      expect(visited).not.toContain('.git/config');
+      expect(visited).toContain('a.ts');
+    });
+  });
 });

--- a/packages/devkit/src/generators/visit-not-ignored-files.spec.ts
+++ b/packages/devkit/src/generators/visit-not-ignored-files.spec.ts
@@ -319,18 +319,18 @@ describe('visitNotIgnoredFiles', () => {
       // set, so the oracle cannot depend on whoever is running the suite. An
       // allowlist rather than a denylist because git has more of these than is
       // practical to enumerate - `GIT_DIR` and `GIT_COMMON_DIR` relocate the
-      // repo, `GIT_INDEX_FILE` makes corpus files look tracked so `-o` drops
-      // them silently, and git exports all of them to its own subprocesses, so
-      // a run from a hook or `git bisect run` inherits them.
+      // repo, and `GIT_INDEX_FILE`, which git does export to its hooks, makes
+      // corpus files look tracked so `-o` drops them silently.
       //
-      // What survives the filter and still needs pinning: the config files, and
-      // `core.excludesFile`, whose default `~/.config/git/ignore` is a path
-      // fallback rather than config. `GIT_TEMPLATE_DIR` is empty rather than a
-      // nonexistent path - both stop `.git/info/exclude` being seeded, but a
-      // missing template warns on every case.
+      // Three things survive the filter and still need pinning: the config
+      // files; `core.excludesFile`, whose default `~/.config/git/ignore` is a
+      // path fallback rather than config; and git's built-in template dir.
+      // `GIT_TEMPLATE_DIR` is empty rather than a nonexistent path - both stop
+      // `.git/info/exclude` being seeded, but a missing template warns on every
+      // case.
       const env: NodeJS.ProcessEnv = {
         ...Object.fromEntries(
-          Object.entries(process.env).filter(([key]) => !key.startsWith('GIT_'))
+          Object.entries(process.env).filter(([key]) => !/^GIT_/i.test(key))
         ),
         GIT_CONFIG_GLOBAL: join(repo, 'no-such-gitconfig'),
         GIT_CONFIG_SYSTEM: join(repo, 'no-such-gitconfig'),

--- a/packages/devkit/src/generators/visit-not-ignored-files.ts
+++ b/packages/devkit/src/generators/visit-not-ignored-files.ts
@@ -1,31 +1,77 @@
 import type { Tree } from 'nx/src/devkit-exports';
-import { getIgnoreObjectForTree } from 'nx/src/devkit-internals';
+import {
+  createIgnoreChainResolver,
+  isIgnoredByChain,
+  posixDirname,
+  type ScopedIgnoreMatcher,
+} from 'nx/src/devkit-internals';
 import { join, relative, sep } from 'path';
+
+/** Matches a `.git` directory at any depth, as the pattern `.git` would. */
+const GIT_DIR = /(^|\/)\.git(\/|$)/;
+
+type ResolveIgnores = (dir: string) => ScopedIgnoreMatcher[];
 
 /**
  * Utility to act on all files in a tree that are not ignored by git.
+ *
+ * Ignore files cascade: a `.gitignore` applies to its own directory and below,
+ * so a nested one is consulted for the files under it and a nested negation
+ * overrides the root. Reading them from the tree rather than disk matters
+ * because a generator can create or amend one in the same run.
  */
 export function visitNotIgnoredFiles(
   tree: Tree,
   dirPath: string = tree.root,
   visitor: (path: string) => void
 ): void {
-  const ig = getIgnoreObjectForTree(tree);
-  dirPath = normalizePathRelativeToRoot(dirPath, tree.root);
-  if (dirPath !== '' && ig?.ignores(dirPath)) {
+  // Built once for the whole traversal. The recursion used to call this
+  // function again per directory, which rebuilt the matcher every time.
+  const resolveIgnores = createIgnoreChainResolver(
+    (path) => (tree.exists(path) ? tree.read(path, 'utf-8') : null),
+    ['.gitignore', '.nxignore']
+  );
+
+  visitDirectory(
+    tree,
+    normalizePathRelativeToRoot(dirPath, tree.root),
+    visitor,
+    resolveIgnores
+  );
+}
+
+function visitDirectory(
+  tree: Tree,
+  dirPath: string,
+  visitor: (path: string) => void,
+  resolveIgnores: ResolveIgnores
+): void {
+  if (dirPath !== '' && isIgnored(dirPath, resolveIgnores)) {
     return;
   }
+
   for (const child of tree.children(dirPath)) {
-    const fullPath = join(dirPath, child);
-    if (ig?.ignores(fullPath)) {
+    // Joined as POSIX rather than with `path.join`: tree paths are POSIX, and
+    // on Windows a backslash-separated path silently matches nothing.
+    const fullPath = dirPath ? `${dirPath}/${child}` : child;
+    if (isIgnored(fullPath, resolveIgnores)) {
       continue;
     }
     if (tree.isFile(fullPath)) {
       visitor(fullPath);
     } else {
-      visitNotIgnoredFiles(tree, fullPath, visitor);
+      visitDirectory(tree, fullPath, visitor, resolveIgnores);
     }
   }
+}
+
+function isIgnored(path: string, resolveIgnores: ResolveIgnores): boolean {
+  // Unconditional, where it used to ride along on the root `.gitignore` being
+  // present - a workspace without one had its `.git` directory walked.
+  if (GIT_DIR.test(path)) {
+    return true;
+  }
+  return isIgnoredByChain(resolveIgnores(posixDirname(path)), path);
 }
 
 function normalizePathRelativeToRoot(path: string, root: string): string {

--- a/packages/devkit/src/generators/visit-not-ignored-files.ts
+++ b/packages/devkit/src/generators/visit-not-ignored-files.ts
@@ -22,13 +22,15 @@ export function visitNotIgnoredFiles(
 ): void {
   // Built once for the whole traversal.
   const isIgnored = createGitIgnoreChecker(tree);
+  const start = normalizePathRelativeToRoot(dirPath, tree.root);
 
-  visitDirectory(
-    tree,
-    normalizePathRelativeToRoot(dirPath, tree.root),
-    visitor,
-    isIgnored
-  );
+  // The caller's own directory is the only one nothing has checked - every
+  // deeper one is checked before it is descended into.
+  if (start !== '' && isIgnored.isIgnoredDirectory(start)) {
+    return;
+  }
+
+  visitDirectory(tree, start, visitor, isIgnored);
 }
 
 function visitDirectory(
@@ -37,10 +39,6 @@ function visitDirectory(
   visitor: (path: string) => void,
   isIgnored: TreeIgnoreChecker
 ): void {
-  if (dirPath !== '' && isIgnored.isIgnoredDirectory(dirPath)) {
-    return;
-  }
-
   for (const child of tree.children(dirPath)) {
     // Joined as POSIX rather than with `path.join`: tree paths are POSIX, and
     // on Windows a backslash-separated path silently matches nothing.

--- a/packages/devkit/src/generators/visit-not-ignored-files.ts
+++ b/packages/devkit/src/generators/visit-not-ignored-files.ts
@@ -36,6 +36,15 @@ export function visitNotIgnoredFiles(
   visitDirectory(tree, start, visitor, isIgnored);
 }
 
+/**
+ * Callers must have cleared `dirPath` already - both call sites do.
+ *
+ * Not descending into an ignored directory is what makes the answers match git,
+ * not just what makes them fast: git refuses to re-include a file inside an
+ * excluded directory, and `isIgnoredFile` alone does not implement that rule
+ * (see `isIgnoredByChain`). Flattening this into a per-file filter would start
+ * visiting files git ignores.
+ */
 function visitDirectory(
   tree: Tree,
   dirPath: string,

--- a/packages/devkit/src/generators/visit-not-ignored-files.ts
+++ b/packages/devkit/src/generators/visit-not-ignored-files.ts
@@ -5,19 +5,22 @@ import { join, relative, sep } from 'path';
 /**
  * Utility to act on all files in a tree that are not ignored by git.
  *
- * Ignore files cascade: a `.gitignore` applies to its own directory and below,
- * so a nested one is consulted for the files under it and a nested negation
- * overrides the root. Reading them from the tree rather than disk matters
- * because a generator can create or amend one in the same run.
+ * Ignore files cascade, so a nested `.gitignore` covers the files under it and a
+ * nested negation overrides the root. They are read from the tree, not disk, so
+ * one a generator wrote in the same run counts.
+ *
+ * `node_modules`, `.git` and the nx caches are never visited, whatever the
+ * workspace's ignore files say.
  */
 export function visitNotIgnoredFiles(
   tree: Tree,
   dirPath: string = tree.root,
   visitor: (path: string) => void
 ): void {
-  // Built once for the whole traversal. The recursion used to call this
-  // function again per directory, which rebuilt the matcher every time.
-  const isIgnored = createTreeIgnoreChecker(tree, ['.gitignore', '.nxignore']);
+  // Built once for the whole traversal.
+  const isIgnored = createTreeIgnoreChecker(tree, ['.gitignore', '.nxignore'], {
+    cascade: true,
+  });
 
   visitDirectory(
     tree,
@@ -33,6 +36,10 @@ function visitDirectory(
   visitor: (path: string) => void,
   isIgnored: (path: string) => boolean
 ): void {
+  // A short-circuit, not a correctness guard: every child would be skipped
+  // individually anyway, since a pattern that excludes a directory also
+  // excludes its contents. It saves the `children` call for the entry
+  // directory, which is the only one not already filtered by the loop below.
   if (dirPath !== '' && isIgnored(dirPath)) {
     return;
   }

--- a/packages/devkit/src/generators/visit-not-ignored-files.ts
+++ b/packages/devkit/src/generators/visit-not-ignored-files.ts
@@ -35,18 +35,15 @@ export function visitNotIgnoredFiles(
   );
 }
 
+type IgnoreChecker = ReturnType<typeof createTreeIgnoreChecker>;
+
 function visitDirectory(
   tree: Tree,
   dirPath: string,
   visitor: (path: string) => void,
-  isIgnored: (path: string) => boolean
+  isIgnored: IgnoreChecker
 ): void {
-  // Probed as `dist/`, which is the spelling git documents for a directory and
-  // the only one a trailing-slash pattern matches. Load-bearing: without it the
-  // walk descends, and a negation in an ignore file *inside* the excluded
-  // directory becomes the nearest opinion and re-includes children git would
-  // never have looked at.
-  if (dirPath !== '' && isIgnored(asDirectory(dirPath))) {
+  if (dirPath !== '' && isIgnored.isIgnoredDirectory(dirPath)) {
     return;
   }
 
@@ -54,22 +51,14 @@ function visitDirectory(
     // Joined as POSIX rather than with `path.join`: tree paths are POSIX, and
     // on Windows a backslash-separated path silently matches nothing.
     const fullPath = dirPath ? `${dirPath}/${child}` : child;
-    if (isIgnored(fullPath)) {
-      continue;
-    }
     if (tree.isFile(fullPath)) {
-      visitor(fullPath);
-    } else {
-      // A directory excluded as `dist/` is not caught above - `ignore` will not
-      // match a trailing-slash pattern against a slash-less path - so the guard
-      // at the top of `visitDirectory` re-tests it as `dist/`.
+      if (!isIgnored.isIgnoredFile(fullPath)) {
+        visitor(fullPath);
+      }
+    } else if (!isIgnored.isIgnoredDirectory(fullPath)) {
       visitDirectory(tree, fullPath, visitor, isIgnored);
     }
   }
-}
-
-function asDirectory(path: string): string {
-  return path.endsWith('/') ? path : `${path}/`;
 }
 
 function normalizePathRelativeToRoot(path: string, root: string): string {

--- a/packages/devkit/src/generators/visit-not-ignored-files.ts
+++ b/packages/devkit/src/generators/visit-not-ignored-files.ts
@@ -1,5 +1,8 @@
 import type { Tree } from 'nx/src/devkit-exports';
-import { createTreeIgnoreChecker } from 'nx/src/devkit-internals';
+import {
+  createGitIgnoreChecker,
+  type TreeIgnoreChecker,
+} from 'nx/src/devkit-internals';
 import { join, relative, sep } from 'path';
 
 /**
@@ -18,7 +21,7 @@ export function visitNotIgnoredFiles(
   visitor: (path: string) => void
 ): void {
   // Built once for the whole traversal.
-  const isIgnored = createTreeIgnoreChecker(tree, 'git');
+  const isIgnored = createGitIgnoreChecker(tree);
 
   visitDirectory(
     tree,
@@ -28,13 +31,11 @@ export function visitNotIgnoredFiles(
   );
 }
 
-type IgnoreChecker = ReturnType<typeof createTreeIgnoreChecker>;
-
 function visitDirectory(
   tree: Tree,
   dirPath: string,
   visitor: (path: string) => void,
-  isIgnored: IgnoreChecker
+  isIgnored: TreeIgnoreChecker
 ): void {
   if (dirPath !== '' && isIgnored.isIgnoredDirectory(dirPath)) {
     return;

--- a/packages/devkit/src/generators/visit-not-ignored-files.ts
+++ b/packages/devkit/src/generators/visit-not-ignored-files.ts
@@ -1,16 +1,6 @@
 import type { Tree } from 'nx/src/devkit-exports';
-import {
-  createIgnoreChainResolver,
-  isIgnoredByChain,
-  posixDirname,
-  type ScopedIgnoreMatcher,
-} from 'nx/src/devkit-internals';
+import { createTreeIgnoreChecker } from 'nx/src/devkit-internals';
 import { join, relative, sep } from 'path';
-
-/** Matches a `.git` directory at any depth, as the pattern `.git` would. */
-const GIT_DIR = /(^|\/)\.git(\/|$)/;
-
-type ResolveIgnores = (dir: string) => ScopedIgnoreMatcher[];
 
 /**
  * Utility to act on all files in a tree that are not ignored by git.
@@ -27,16 +17,13 @@ export function visitNotIgnoredFiles(
 ): void {
   // Built once for the whole traversal. The recursion used to call this
   // function again per directory, which rebuilt the matcher every time.
-  const resolveIgnores = createIgnoreChainResolver(
-    (path) => (tree.exists(path) ? tree.read(path, 'utf-8') : null),
-    ['.gitignore', '.nxignore']
-  );
+  const isIgnored = createTreeIgnoreChecker(tree, ['.gitignore', '.nxignore']);
 
   visitDirectory(
     tree,
     normalizePathRelativeToRoot(dirPath, tree.root),
     visitor,
-    resolveIgnores
+    isIgnored
   );
 }
 
@@ -44,9 +31,9 @@ function visitDirectory(
   tree: Tree,
   dirPath: string,
   visitor: (path: string) => void,
-  resolveIgnores: ResolveIgnores
+  isIgnored: (path: string) => boolean
 ): void {
-  if (dirPath !== '' && isIgnored(dirPath, resolveIgnores)) {
+  if (dirPath !== '' && isIgnored(dirPath)) {
     return;
   }
 
@@ -54,24 +41,15 @@ function visitDirectory(
     // Joined as POSIX rather than with `path.join`: tree paths are POSIX, and
     // on Windows a backslash-separated path silently matches nothing.
     const fullPath = dirPath ? `${dirPath}/${child}` : child;
-    if (isIgnored(fullPath, resolveIgnores)) {
+    if (isIgnored(fullPath)) {
       continue;
     }
     if (tree.isFile(fullPath)) {
       visitor(fullPath);
     } else {
-      visitDirectory(tree, fullPath, visitor, resolveIgnores);
+      visitDirectory(tree, fullPath, visitor, isIgnored);
     }
   }
-}
-
-function isIgnored(path: string, resolveIgnores: ResolveIgnores): boolean {
-  // Unconditional, where it used to ride along on the root `.gitignore` being
-  // present - a workspace without one had its `.git` directory walked.
-  if (GIT_DIR.test(path)) {
-    return true;
-  }
-  return isIgnoredByChain(resolveIgnores(posixDirname(path)), path);
 }
 
 function normalizePathRelativeToRoot(path: string, root: string): string {

--- a/packages/devkit/src/generators/visit-not-ignored-files.ts
+++ b/packages/devkit/src/generators/visit-not-ignored-files.ts
@@ -12,8 +12,8 @@ import { join, relative, sep } from 'path';
  * nested negation overrides the root. They are read from the tree, not disk, so
  * one a generator wrote in the same run counts.
  *
- * `node_modules`, `.git` and the nx caches are never visited, whatever the
- * workspace's ignore files say.
+ * `node_modules`, `.git` and the nx and yarn caches are never visited, whatever
+ * the workspace's ignore files say.
  */
 export function visitNotIgnoredFiles(
   tree: Tree,

--- a/packages/devkit/src/generators/visit-not-ignored-files.ts
+++ b/packages/devkit/src/generators/visit-not-ignored-files.ts
@@ -17,15 +17,8 @@ export function visitNotIgnoredFiles(
   dirPath: string = tree.root,
   visitor: (path: string) => void
 ): void {
-  // Built once for the whole traversal. `.nxignore` last and `merged` so its
-  // patterns win: the native walker registers it through
-  // `add_custom_ignore_filename`, which outranks `.gitignore`, so a `!x` there
-  // has to re-include an `x` that `.gitignore` excluded. Merging is also exactly
-  // what the helper this replaced did.
-  const isIgnored = createTreeIgnoreChecker(tree, ['.gitignore', '.nxignore'], {
-    cascade: true,
-    combine: 'merged',
-  });
+  // Built once for the whole traversal.
+  const isIgnored = createTreeIgnoreChecker(tree, 'git');
 
   visitDirectory(
     tree,

--- a/packages/devkit/src/generators/visit-not-ignored-files.ts
+++ b/packages/devkit/src/generators/visit-not-ignored-files.ts
@@ -4,6 +4,7 @@ import {
   type TreeIgnoreChecker,
 } from 'nx/src/devkit-internals';
 import { join, relative, sep } from 'path';
+import { assertNxSupportsIgnoreCheckers } from '../utils/nx-ignore-internals';
 
 /**
  * Utility to act on all files in a tree that are not ignored by git.
@@ -20,6 +21,8 @@ export function visitNotIgnoredFiles(
   dirPath: string = tree.root,
   visitor: (path: string) => void
 ): void {
+  assertNxSupportsIgnoreCheckers();
+
   // Built once for the whole traversal.
   const isIgnored = createGitIgnoreChecker(tree);
   const start = normalizePathRelativeToRoot(dirPath, tree.root);

--- a/packages/devkit/src/generators/visit-not-ignored-files.ts
+++ b/packages/devkit/src/generators/visit-not-ignored-files.ts
@@ -36,10 +36,11 @@ function visitDirectory(
   visitor: (path: string) => void,
   isIgnored: (path: string) => boolean
 ): void {
-  // A short-circuit, not a correctness guard: every child would be skipped
-  // individually anyway, since a pattern that excludes a directory also
-  // excludes its contents. It saves the `children` call for the entry
-  // directory, which is the only one not already filtered by the loop below.
+  // Fires only for the entry directory - every deeper one is already filtered
+  // by the loop below. Not redundant: an ignore file *inside* an excluded
+  // directory can un-ignore its own children, since the chain stops at the
+  // nearest opinion. git never descends that far, so pruning here is what
+  // matches it.
   if (dirPath !== '' && isIgnored(dirPath)) {
     return;
   }

--- a/packages/devkit/src/generators/visit-not-ignored-files.ts
+++ b/packages/devkit/src/generators/visit-not-ignored-files.ts
@@ -17,9 +17,14 @@ export function visitNotIgnoredFiles(
   dirPath: string = tree.root,
   visitor: (path: string) => void
 ): void {
-  // Built once for the whole traversal.
+  // Built once for the whole traversal. `.nxignore` last and `merged` so its
+  // patterns win: the native walker registers it through
+  // `add_custom_ignore_filename`, which outranks `.gitignore`, so a `!x` there
+  // has to re-include an `x` that `.gitignore` excluded. Merging is also exactly
+  // what the helper this replaced did.
   const isIgnored = createTreeIgnoreChecker(tree, ['.gitignore', '.nxignore'], {
     cascade: true,
+    combine: 'merged',
   });
 
   visitDirectory(
@@ -36,12 +41,12 @@ function visitDirectory(
   visitor: (path: string) => void,
   isIgnored: (path: string) => boolean
 ): void {
-  // Fires only for the entry directory - every deeper one is already filtered
-  // by the loop below. Not redundant: an ignore file *inside* an excluded
-  // directory can un-ignore its own children, since the chain stops at the
-  // nearest opinion. git never descends that far, so pruning here is what
-  // matches it.
-  if (dirPath !== '' && isIgnored(dirPath)) {
+  // Probed as `dist/`, which is the spelling git documents for a directory and
+  // the only one a trailing-slash pattern matches. Load-bearing: without it the
+  // walk descends, and a negation in an ignore file *inside* the excluded
+  // directory becomes the nearest opinion and re-includes children git would
+  // never have looked at.
+  if (dirPath !== '' && isIgnored(asDirectory(dirPath))) {
     return;
   }
 
@@ -55,9 +60,16 @@ function visitDirectory(
     if (tree.isFile(fullPath)) {
       visitor(fullPath);
     } else {
+      // A directory excluded as `dist/` is not caught above - `ignore` will not
+      // match a trailing-slash pattern against a slash-less path - so the guard
+      // at the top of `visitDirectory` re-tests it as `dist/`.
       visitDirectory(tree, fullPath, visitor, isIgnored);
     }
   }
+}
+
+function asDirectory(path: string): string {
+  return path.endsWith('/') ? path : `${path}/`;
 }
 
 function normalizePathRelativeToRoot(path: string, root: string): string {

--- a/packages/devkit/src/utils/invoke-nx-generator.spec.ts
+++ b/packages/devkit/src/utils/invoke-nx-generator.spec.ts
@@ -56,6 +56,11 @@ describe('Convert Nx Generator', () => {
     expect(results.encoded).toBeNull();
     expect(results.raw).toBeNull();
     expect(results.present).toEqual('const hello = "hello world";');
+    expect(results.presentRaw).toEqual(
+      Buffer.from('const hello = "hello world";')
+    );
+    expect(results.emptyEncoded).toEqual('');
+    expect(results.emptyRaw).toEqual(Buffer.alloc(0));
   });
 
   it('should let visitNotIgnoredFiles walk the adapter tree', async () => {
@@ -92,13 +97,19 @@ async function newFileGenerator(tree: Tree, options: {}) {
 async function readsAMissingFileGenerator(tree: Tree, options: {}) {
   // The schematics tree returns null here; the adapter must not dereference it.
   // `visitNotIgnoredFiles` and `formatFiles` both probe for ignore files that
-  // are usually absent, so this is the path every converted generator takes.
+  // are usually absent, so this is the path any converted generator that walks
+  // or formats takes.
   results.encoded = tree.read('.nxignore', 'utf-8');
   results.raw = tree.read('.nxignore');
   // A present file must still come back decoded, so the null path is not just
   // swallowing everything.
   tree.write('present.ts', 'const hello = "hello world";');
   results.present = tree.read('present.ts', 'utf-8');
+  results.presentRaw = tree.read('present.ts');
+  // Empty is not missing. A falsy check here would collapse the two.
+  tree.write('empty.ts', '');
+  results.emptyEncoded = tree.read('empty.ts', 'utf-8');
+  results.emptyRaw = tree.read('empty.ts');
 }
 
 async function walksTheTreeGenerator(tree: Tree, options: {}) {

--- a/packages/devkit/src/utils/invoke-nx-generator.spec.ts
+++ b/packages/devkit/src/utils/invoke-nx-generator.spec.ts
@@ -29,8 +29,49 @@ describe('Convert Nx Generator', () => {
     // ASSERT
     expect(tree.files).toContain(`/my-file.ts`);
   });
+
+  it('should return null from read() for a missing file rather than throwing', async () => {
+    // ARRANGE
+    const {
+      SchematicTestRunner,
+    } = require('@angular-devkit/schematics/testing');
+    const ngSchematicRunner = new SchematicTestRunner(
+      '@schematics/angular',
+      require.resolve('@schematics/angular/collection.json')
+    );
+    const appTree = await ngSchematicRunner.runSchematic('workspace', {
+      name: 'workspace',
+      newProjectRoot: 'projects',
+      version: '6.0.0',
+    });
+
+    // ACT
+    const convertedGenerator = convertNxGenerator(readsAMissingFileGenerator);
+    await lastValueFrom(
+      ngSchematicRunner.callRule(convertedGenerator, appTree)
+    );
+
+    // ASSERT
+    expect(results.encoded).toBeNull();
+    expect(results.raw).toBeNull();
+    expect(results.present).toEqual('const hello = "hello world";');
+  });
 });
 
 async function newFileGenerator(tree: Tree, options: {}) {
   tree.write('my-file.ts', `const hello = "hello world";`);
 }
+
+async function readsAMissingFileGenerator(tree: Tree, options: {}) {
+  // The schematics tree returns null here; the adapter must not dereference it.
+  // `visitNotIgnoredFiles` and `formatFiles` both probe for ignore files that
+  // are usually absent, so this is the path every converted generator takes.
+  results.encoded = tree.read('.nxignore', 'utf-8');
+  results.raw = tree.read('.nxignore');
+  // A present file must still come back decoded, so the null path is not just
+  // swallowing everything.
+  tree.write('present.ts', 'const hello = "hello world";');
+  results.present = tree.read('present.ts', 'utf-8');
+}
+
+const results: Record<string, unknown> = {};

--- a/packages/devkit/src/utils/invoke-nx-generator.spec.ts
+++ b/packages/devkit/src/utils/invoke-nx-generator.spec.ts
@@ -1,5 +1,6 @@
 import type { Tree } from 'nx/src/generators/tree';
 import { convertNxGenerator } from './invoke-nx-generator';
+import { visitNotIgnoredFiles } from '../generators/visit-not-ignored-files';
 import { lastValueFrom } from 'rxjs';
 
 describe('Convert Nx Generator', () => {
@@ -56,6 +57,32 @@ describe('Convert Nx Generator', () => {
     expect(results.raw).toBeNull();
     expect(results.present).toEqual('const hello = "hello world";');
   });
+
+  it('should let visitNotIgnoredFiles walk the adapter tree', async () => {
+    // The walker probes for ignore files in every directory and most are
+    // absent, so it is the consumer that notices if the adapter throws rather
+    // than returning null for a missing file.
+    const {
+      SchematicTestRunner,
+    } = require('@angular-devkit/schematics/testing');
+    const ngSchematicRunner = new SchematicTestRunner(
+      '@schematics/angular',
+      require.resolve('@schematics/angular/collection.json')
+    );
+    const appTree = await ngSchematicRunner.runSchematic('workspace', {
+      name: 'workspace',
+      newProjectRoot: 'projects',
+      version: '6.0.0',
+    });
+
+    const convertedGenerator = convertNxGenerator(walksTheTreeGenerator);
+    await lastValueFrom(
+      ngSchematicRunner.callRule(convertedGenerator, appTree)
+    );
+
+    expect(visited).toContain('src/a.ts');
+    expect(visited).not.toContain('dist/out.js');
+  });
 });
 
 async function newFileGenerator(tree: Tree, options: {}) {
@@ -74,4 +101,12 @@ async function readsAMissingFileGenerator(tree: Tree, options: {}) {
   results.present = tree.read('present.ts', 'utf-8');
 }
 
+async function walksTheTreeGenerator(tree: Tree, options: {}) {
+  tree.write('src/a.ts', '');
+  tree.write('dist/out.js', '');
+  tree.write('.gitignore', 'dist\n');
+  visitNotIgnoredFiles(tree, '', (p) => visited.push(p));
+}
+
 const results: Record<string, unknown> = {};
+const visited: string[] = [];

--- a/packages/devkit/src/utils/invoke-nx-generator.ts
+++ b/packages/devkit/src/utils/invoke-nx-generator.ts
@@ -178,10 +178,8 @@ class DevkitTreeFromAngularDevkitTree implements Tree {
   read(filePath: string): Buffer | null;
   read(filePath: string, encoding: BufferEncoding): string | null;
   read(filePath: string, encoding?: BufferEncoding) {
-    // The devkit `Tree` contract returns null for a missing file, and callers
-    // rely on it - reading an ignore file that is usually absent, for one. The
-    // underlying schematics tree returns null too, so the only thing needed is
-    // to not dereference it.
+    // The schematics tree already returns null for a missing file, so honouring
+    // the `Tree` contract is a matter of not dereferencing it.
     const content = this.tree.read(filePath);
     if (content === null) {
       return null;

--- a/packages/devkit/src/utils/invoke-nx-generator.ts
+++ b/packages/devkit/src/utils/invoke-nx-generator.ts
@@ -175,12 +175,18 @@ class DevkitTreeFromAngularDevkitTree implements Tree {
     return relative(this.root, join(this.root, path));
   }
 
-  read(filePath: string): Buffer;
-  read(filePath: string, encoding: BufferEncoding): string;
+  read(filePath: string): Buffer | null;
+  read(filePath: string, encoding: BufferEncoding): string | null;
   read(filePath: string, encoding?: BufferEncoding) {
-    return encoding
-      ? this.tree.read(filePath).toString(encoding)
-      : this.tree.read(filePath);
+    // The devkit `Tree` contract returns null for a missing file, and callers
+    // rely on it - reading an ignore file that is usually absent, for one. The
+    // underlying schematics tree returns null too, so the only thing needed is
+    // to not dereference it.
+    const content = this.tree.read(filePath);
+    if (content === null) {
+      return null;
+    }
+    return encoding ? content.toString(encoding) : content;
   }
 
   rename(from: string, to: string): void {

--- a/packages/devkit/src/utils/nx-ignore-internals.ts
+++ b/packages/devkit/src/utils/nx-ignore-internals.ts
@@ -1,17 +1,20 @@
-import {
-  createGitIgnoreChecker,
-  createPrettierIgnoreChecker,
-} from 'nx/src/devkit-internals';
+import type { TreeIgnoreChecker } from 'nx/src/devkit-internals';
+import { createGitIgnoreChecker } from 'nx/src/devkit-internals';
 
 /**
  * `@nx/devkit`'s `nx` peer spans a major either side, so an older nx that
- * predates the ignore checkers can legally be installed alongside it. A missing
- * CommonJS named export arrives as `undefined` rather than as a load error, so
- * the first use would otherwise be a bare `undefined is not a function` thrown
- * from inside a generator, naming neither the package nor the cause.
+ * predates the ignore checkers can legally be installed alongside it, and a
+ * missing CommonJS named export arrives as `undefined` rather than as a load
+ * error. The two callers want opposite things from that, so they get different
+ * helpers - see `NOTHING_IGNORED` for the other half.
+ *
+ * A tree walk cannot degrade: without a checker nothing would be ignored, and
+ * the walker would descend into `node_modules` and hand a migration every file
+ * in it to rewrite. That is worse than the older nx's own behaviour, which at
+ * least read the root `.gitignore`, so this fails instead - once, by name.
  */
 export function assertNxSupportsIgnoreCheckers(): void {
-  if (createGitIgnoreChecker && createPrettierIgnoreChecker) {
+  if (createGitIgnoreChecker) {
     return;
   }
 
@@ -20,3 +23,16 @@ export function assertNxSupportsIgnoreCheckers(): void {
       'This happens when nx and @nx/devkit are on different major versions. Run `nx migrate latest` to bring them into line.'
   );
 }
+
+/**
+ * The degrade the other way, for formatting.
+ *
+ * Filtering nothing is what devkit did before the checkers existed - with no
+ * `ignorePath`, prettier's own `getFileInfo` never read the workspace's ignore
+ * files either (measured) - so an older nx gets the formatting behaviour it has
+ * always had rather than a generator that refuses to run.
+ */
+export const NOTHING_IGNORED: TreeIgnoreChecker = {
+  isIgnoredFile: () => false,
+  isIgnoredDirectory: () => false,
+};

--- a/packages/devkit/src/utils/nx-ignore-internals.ts
+++ b/packages/devkit/src/utils/nx-ignore-internals.ts
@@ -1,0 +1,22 @@
+import {
+  createGitIgnoreChecker,
+  createPrettierIgnoreChecker,
+} from 'nx/src/devkit-internals';
+
+/**
+ * `@nx/devkit`'s `nx` peer spans a major either side, so an older nx that
+ * predates the ignore checkers can legally be installed alongside it. A missing
+ * CommonJS named export arrives as `undefined` rather than as a load error, so
+ * the first use would otherwise be a bare `undefined is not a function` thrown
+ * from inside a generator, naming neither the package nor the cause.
+ */
+export function assertNxSupportsIgnoreCheckers(): void {
+  if (createGitIgnoreChecker && createPrettierIgnoreChecker) {
+    return;
+  }
+
+  throw new Error(
+    'The installed version of nx does not export the ignore checkers that @nx/devkit needs to decide which files a generator may touch. ' +
+      'This happens when nx and @nx/devkit are on different major versions. Run `nx migrate latest` to bring them into line.'
+  );
+}

--- a/packages/nx/src/devkit-internals.ts
+++ b/packages/nx/src/devkit-internals.ts
@@ -30,10 +30,11 @@ export { readProjectConfigurationsFromRootMap } from './project-graph/utils/proj
 export { findMatchingConfigFiles } from './project-graph/utils/project-configuration-utils';
 export { findMatchingProjects } from './utils/find-matching-projects';
 export { readTargetDefaultsForTarget } from './project-graph/utils/project-configuration/target-defaults';
-// Only the bound predicate crosses the boundary. The primitives it is built
-// from carry preconditions a caller can violate - a chain must be resolved from
-// the file's own directory, and the array it returns is the memo cache itself -
-// and nothing outside this package needs them.
+// Only the tree-bound checkers and their type cross the boundary. The
+// primitives they are built from carry preconditions a caller can violate - a
+// chain must be resolved from the file's own directory, and the array it
+// returns is the memo cache itself - and nothing outside this package needs
+// them.
 export {
   createGitIgnoreChecker,
   createPrettierIgnoreChecker,

--- a/packages/nx/src/devkit-internals.ts
+++ b/packages/nx/src/devkit-internals.ts
@@ -34,10 +34,7 @@ export { readTargetDefaultsForTarget } from './project-graph/utils/project-confi
 // from carry preconditions a caller can violate - a chain must be resolved from
 // the file's own directory, and the array it returns is the memo cache itself -
 // and nothing outside this package needs them.
-export {
-  getIgnoreObjectForTree,
-  createTreeIgnoreChecker,
-} from './utils/ignore';
+export { createTreeIgnoreChecker } from './utils/ignore';
 export { splitTarget } from './utils/split-target';
 export { combineOptionsForExecutor } from './utils/params';
 export { sortObjectByKeys } from './utils/object-sort';

--- a/packages/nx/src/devkit-internals.ts
+++ b/packages/nx/src/devkit-internals.ts
@@ -30,7 +30,13 @@ export { readProjectConfigurationsFromRootMap } from './project-graph/utils/proj
 export { findMatchingConfigFiles } from './project-graph/utils/project-configuration-utils';
 export { findMatchingProjects } from './utils/find-matching-projects';
 export { readTargetDefaultsForTarget } from './project-graph/utils/project-configuration/target-defaults';
-export { getIgnoreObjectForTree } from './utils/ignore';
+export {
+  getIgnoreObjectForTree,
+  createIgnoreChainResolver,
+  isIgnoredByChain,
+  posixDirname,
+  type ScopedIgnoreMatcher,
+} from './utils/ignore';
 export { splitTarget } from './utils/split-target';
 export { combineOptionsForExecutor } from './utils/params';
 export { sortObjectByKeys } from './utils/object-sort';

--- a/packages/nx/src/devkit-internals.ts
+++ b/packages/nx/src/devkit-internals.ts
@@ -34,7 +34,11 @@ export { readTargetDefaultsForTarget } from './project-graph/utils/project-confi
 // from carry preconditions a caller can violate - a chain must be resolved from
 // the file's own directory, and the array it returns is the memo cache itself -
 // and nothing outside this package needs them.
-export { createTreeIgnoreChecker } from './utils/ignore';
+export {
+  createGitIgnoreChecker,
+  createPrettierIgnoreChecker,
+  type TreeIgnoreChecker,
+} from './utils/ignore';
 export { splitTarget } from './utils/split-target';
 export { combineOptionsForExecutor } from './utils/params';
 export { sortObjectByKeys } from './utils/object-sort';

--- a/packages/nx/src/devkit-internals.ts
+++ b/packages/nx/src/devkit-internals.ts
@@ -30,14 +30,13 @@ export { readProjectConfigurationsFromRootMap } from './project-graph/utils/proj
 export { findMatchingConfigFiles } from './project-graph/utils/project-configuration-utils';
 export { findMatchingProjects } from './utils/find-matching-projects';
 export { readTargetDefaultsForTarget } from './project-graph/utils/project-configuration/target-defaults';
+// Only the bound predicate crosses the boundary. The primitives it is built
+// from carry preconditions a caller can violate - a chain must be resolved from
+// the file's own directory, and the array it returns is the memo cache itself -
+// and nothing outside this package needs them.
 export {
   getIgnoreObjectForTree,
-  createIgnoreChainResolver,
   createTreeIgnoreChecker,
-  isAlwaysIgnored,
-  isIgnoredByChain,
-  posixDirname,
-  type ScopedIgnoreMatcher,
 } from './utils/ignore';
 export { splitTarget } from './utils/split-target';
 export { combineOptionsForExecutor } from './utils/params';

--- a/packages/nx/src/devkit-internals.ts
+++ b/packages/nx/src/devkit-internals.ts
@@ -33,6 +33,8 @@ export { readTargetDefaultsForTarget } from './project-graph/utils/project-confi
 export {
   getIgnoreObjectForTree,
   createIgnoreChainResolver,
+  createTreeIgnoreChecker,
+  isAlwaysIgnored,
   isIgnoredByChain,
   posixDirname,
   type ScopedIgnoreMatcher,

--- a/packages/nx/src/generators/tree.ts
+++ b/packages/nx/src/generators/tree.ts
@@ -35,13 +35,15 @@ export interface Tree {
   root: string;
 
   /**
-   * Read the contents of a file.
+   * Read the contents of a file. `null` when the file does not exist - an
+   * empty file reads as empty, not as missing.
    * @param filePath A path to a file.
    */
   read(filePath: string): Buffer | null;
 
   /**
-   * Read the contents of a file as string.
+   * Read the contents of a file as string. `null` when the file does not
+   * exist - an empty file reads as `''`, not as missing.
    * @param filePath A path to a file.
    * @param encoding the encoding for the result
    */

--- a/packages/nx/src/native/index.d.ts
+++ b/packages/nx/src/native/index.d.ts
@@ -417,6 +417,16 @@ export declare function getEventDimensions(): EventDimensions
 export declare function getFilesForOutputsBatch(directory: string, entriesBatch: Array<Array<string>>): Array<Array<string>>
 
 /**
+ * The same list, for JavaScript callers that walk a tree rather than the
+ * filesystem - `visitNotIgnoredFiles` - so both sides apply one baseline
+ * instead of maintaining a second copy that drifts.
+ *
+ * The patterns are gitignore-shaped, so they read the same to the `ignore`
+ * crate here and the `ignore` npm package there.
+ */
+export declare function getHardcodedIgnorePatterns(): Array<string>
+
+/**
  * If `workspace_root` is inside a git worktree, returns the main repo root.
  * Returns `None` when already in the main repo (or not in a git repo at all).
  */

--- a/packages/nx/src/native/native-bindings.js
+++ b/packages/nx/src/native/native-bindings.js
@@ -610,6 +610,7 @@ module.exports.getBinaryTarget = nativeBinding.getBinaryTarget
 module.exports.getDefaultMaxCacheSize = nativeBinding.getDefaultMaxCacheSize
 module.exports.getEventDimensions = nativeBinding.getEventDimensions
 module.exports.getFilesForOutputsBatch = nativeBinding.getFilesForOutputsBatch
+module.exports.getHardcodedIgnorePatterns = nativeBinding.getHardcodedIgnorePatterns
 module.exports.getMainWorktreeRoot = nativeBinding.getMainWorktreeRoot
 module.exports.getTransformableOutputs = nativeBinding.getTransformableOutputs
 module.exports.GroupType = nativeBinding.GroupType

--- a/packages/nx/src/native/walker.rs
+++ b/packages/nx/src/native/walker.rs
@@ -182,6 +182,20 @@ pub(crate) const HARDCODED_IGNORE_PATTERNS: &[&str] = &[
     "**/.yarn/cache",
 ];
 
+/// The same list, for JavaScript callers that walk a tree rather than the
+/// filesystem - `visitNotIgnoredFiles` - so both sides apply one baseline
+/// instead of maintaining a second copy that drifts.
+///
+/// The patterns are gitignore-shaped, so they read the same to the `ignore`
+/// crate here and the `ignore` npm package there.
+#[napi]
+pub fn get_hardcoded_ignore_patterns() -> Vec<String> {
+    HARDCODED_IGNORE_PATTERNS
+        .iter()
+        .map(|pattern| pattern.to_string())
+        .collect()
+}
+
 pub(crate) fn create_walker<P>(directory: P, use_ignores: bool) -> WalkBuilder
 where
     P: AsRef<Path>,

--- a/packages/nx/src/utils/ignore.spec.ts
+++ b/packages/nx/src/utils/ignore.spec.ts
@@ -196,7 +196,7 @@ describe('posixDirname', () => {
 // Each constructor bundles three values - which files it reads, whether they
 // cascade, and whether they merge. They are unreachable from a caller, so the
 // only way to pin them is through what the returned predicates do.
-describe('the ignore authorities', () => {
+describe('the ignore checkers', () => {
   function treeWith(files: Record<string, string>) {
     const tree = createTree();
     for (const [path, contents] of Object.entries(files)) {

--- a/packages/nx/src/utils/ignore.spec.ts
+++ b/packages/nx/src/utils/ignore.spec.ts
@@ -8,17 +8,23 @@ describe('createIgnoreChainResolver', () => {
   /** Builds a resolver over an in-memory `path -> contents` map. */
   function resolverFor(
     files: Record<string, string>,
-    filenames = ['.gitignore']
+    filenames = ['.gitignore'],
+    combine: 'separate' | 'merged' = 'separate'
   ) {
-    return createIgnoreChainResolver((path) => files[path] ?? null, filenames);
+    return createIgnoreChainResolver(
+      (path) => files[path] ?? null,
+      filenames,
+      combine
+    );
   }
 
   function ignores(
     files: Record<string, string>,
     filePath: string,
-    filenames?: string[]
+    filenames?: string[],
+    combine: 'separate' | 'merged' = 'separate'
   ) {
-    const resolve = resolverFor(files, filenames);
+    const resolve = resolverFor(files, filenames, combine);
     return isIgnoredByChain(resolve(posixDirname(filePath)), filePath);
   }
 
@@ -88,6 +94,40 @@ describe('createIgnoreChainResolver', () => {
     expect(ignores(files, 'both.ts', [...filenames].reverse())).toBe(true);
   });
 
+  it('lets a later file override an earlier one when merged', () => {
+    // The native walker registers `.nxignore` via `add_custom_ignore_filename`,
+    // which outranks `.gitignore` - measured against `WorkspaceContext` in both
+    // directions - and master merged both files into one matcher so `.nxignore`
+    // won there too. `separate` would let `.gitignore`'s exclusion win instead.
+    const names = ['.gitignore', '.nxignore'];
+
+    expect(
+      ignores(
+        { '.gitignore': 'x.ts\n', '.nxignore': '!x.ts\n' },
+        'x.ts',
+        names,
+        'merged'
+      )
+    ).toBe(false);
+    expect(
+      ignores(
+        { '.gitignore': '!x.ts\n', '.nxignore': 'x.ts\n' },
+        'x.ts',
+        names,
+        'merged'
+      )
+    ).toBe(true);
+    // A file with no opinion falls through to the next one.
+    expect(
+      ignores(
+        { '.gitignore': 'x.ts\n', '.nxignore': 'other.ts\n' },
+        'x.ts',
+        names,
+        'merged'
+      )
+    ).toBe(true);
+  });
+
   it('still honours a negation within a single file', () => {
     const files = { '.gitignore': '*.log\n!keep.log\n' };
 
@@ -114,7 +154,8 @@ describe('createIgnoreChainResolver', () => {
         reads.push(path);
         return path === '.gitignore' ? 'dist\n' : null;
       },
-      ['.gitignore']
+      ['.gitignore'],
+      'separate'
     );
 
     resolve('apps/foo/src');

--- a/packages/nx/src/utils/ignore.spec.ts
+++ b/packages/nx/src/utils/ignore.spec.ts
@@ -9,12 +9,12 @@ describe('createIgnoreChainResolver', () => {
   function resolverFor(
     files: Record<string, string>,
     filenames = ['.gitignore'],
-    combine: 'separate' | 'merged' = 'separate'
+    merge = false
   ) {
     return createIgnoreChainResolver(
       (path) => files[path] ?? null,
       filenames,
-      combine
+      merge
     );
   }
 
@@ -22,9 +22,9 @@ describe('createIgnoreChainResolver', () => {
     files: Record<string, string>,
     filePath: string,
     filenames?: string[],
-    combine: 'separate' | 'merged' = 'separate'
+    merge = false
   ) {
-    const resolve = resolverFor(files, filenames, combine);
+    const resolve = resolverFor(files, filenames, merge);
     return isIgnoredByChain(resolve(posixDirname(filePath)), filePath);
   }
 
@@ -98,7 +98,7 @@ describe('createIgnoreChainResolver', () => {
     // The native walker registers `.nxignore` via `add_custom_ignore_filename`,
     // which outranks `.gitignore` - measured against `WorkspaceContext` in both
     // directions - and master merged both files into one matcher so `.nxignore`
-    // won there too. `separate` would let `.gitignore`'s exclusion win instead.
+    // won there too. Without the merge `.gitignore`'s exclusion would win.
     const names = ['.gitignore', '.nxignore'];
 
     expect(
@@ -106,7 +106,7 @@ describe('createIgnoreChainResolver', () => {
         { '.gitignore': 'x.ts\n', '.nxignore': '!x.ts\n' },
         'x.ts',
         names,
-        'merged'
+        true
       )
     ).toBe(false);
     expect(
@@ -114,7 +114,7 @@ describe('createIgnoreChainResolver', () => {
         { '.gitignore': '!x.ts\n', '.nxignore': 'x.ts\n' },
         'x.ts',
         names,
-        'merged'
+        true
       )
     ).toBe(true);
     // A file with no opinion falls through to the next one.
@@ -123,7 +123,7 @@ describe('createIgnoreChainResolver', () => {
         { '.gitignore': 'x.ts\n', '.nxignore': 'other.ts\n' },
         'x.ts',
         names,
-        'merged'
+        true
       )
     ).toBe(true);
   });
@@ -155,7 +155,7 @@ describe('createIgnoreChainResolver', () => {
         return path === '.gitignore' ? 'dist\n' : null;
       },
       ['.gitignore'],
-      'separate'
+      false
     );
 
     resolve('apps/foo/src');

--- a/packages/nx/src/utils/ignore.spec.ts
+++ b/packages/nx/src/utils/ignore.spec.ts
@@ -208,11 +208,16 @@ describe('the ignore authorities', () => {
   describe('createGitIgnoreChecker', () => {
     it('reads .gitignore and .nxignore', () => {
       const git = createGitIgnoreChecker(
-        treeWith({ '.gitignore': 'a.ts\n', '.nxignore': 'b.ts\n' })
+        treeWith({
+          '.gitignore': 'a.ts\n',
+          '.nxignore': 'b.ts\n',
+          '.prettierignore': 'c.ts\n',
+        })
       );
 
       expect(git.isIgnoredFile('a.ts')).toBe(true);
       expect(git.isIgnoredFile('b.ts')).toBe(true);
+      // git knows nothing about .prettierignore - the set is exact, not a floor.
       expect(git.isIgnoredFile('c.ts')).toBe(false);
     });
 

--- a/packages/nx/src/utils/ignore.spec.ts
+++ b/packages/nx/src/utils/ignore.spec.ts
@@ -1,5 +1,8 @@
+import { createTree } from '../generators/testing-utils/create-tree';
 import {
+  createGitIgnoreChecker,
   createIgnoreChainResolver,
+  createPrettierIgnoreChecker,
   isIgnoredByChain,
   posixDirname,
 } from './ignore';
@@ -187,5 +190,90 @@ describe('posixDirname', () => {
     ['apps/a.ts', 'apps'],
   ])('maps %s to %s', (input, expected) => {
     expect(posixDirname(input)).toBe(expected);
+  });
+});
+
+// Each constructor bundles three values - which files it reads, whether they
+// cascade, and whether they merge. They are unreachable from a caller, so the
+// only way to pin them is through what the returned predicates do.
+describe('the ignore authorities', () => {
+  function treeWith(files: Record<string, string>) {
+    const tree = createTree();
+    for (const [path, contents] of Object.entries(files)) {
+      tree.write(path, contents);
+    }
+    return tree;
+  }
+
+  describe('createGitIgnoreChecker', () => {
+    it('reads .gitignore and .nxignore', () => {
+      const git = createGitIgnoreChecker(
+        treeWith({ '.gitignore': 'a.ts\n', '.nxignore': 'b.ts\n' })
+      );
+
+      expect(git.isIgnoredFile('a.ts')).toBe(true);
+      expect(git.isIgnoredFile('b.ts')).toBe(true);
+      expect(git.isIgnoredFile('c.ts')).toBe(false);
+    });
+
+    it('cascades, so a nested ignore file covers its own directory', () => {
+      const git = createGitIgnoreChecker(
+        treeWith({ 'apps/foo/.gitignore': 'nested.ts\n' })
+      );
+
+      expect(git.isIgnoredFile('apps/foo/nested.ts')).toBe(true);
+      // The same name elsewhere is untouched - the nested file is not global.
+      expect(git.isIgnoredFile('apps/bar/nested.ts')).toBe(false);
+    });
+
+    it('merges the files of one directory, so .nxignore outranks .gitignore', () => {
+      const git = createGitIgnoreChecker(
+        treeWith({ '.gitignore': 'a.ts\n', '.nxignore': '!a.ts\n' })
+      );
+
+      expect(git.isIgnoredFile('a.ts')).toBe(false);
+    });
+  });
+
+  describe('createPrettierIgnoreChecker', () => {
+    it('reads .gitignore and .prettierignore, not .nxignore', () => {
+      const prettier = createPrettierIgnoreChecker(
+        treeWith({
+          '.gitignore': 'a.ts\n',
+          '.prettierignore': 'b.ts\n',
+          '.nxignore': 'c.ts\n',
+        })
+      );
+
+      expect(prettier.isIgnoredFile('a.ts')).toBe(true);
+      expect(prettier.isIgnoredFile('b.ts')).toBe(true);
+      expect(prettier.isIgnoredFile('c.ts')).toBe(false);
+    });
+
+    it('does not cascade - prettier resolves from the workspace root only', () => {
+      const prettier = createPrettierIgnoreChecker(
+        treeWith({ 'apps/foo/.prettierignore': 'nested.ts\n' })
+      );
+
+      expect(prettier.isIgnoredFile('apps/foo/nested.ts')).toBe(false);
+    });
+
+    it('keeps the files separate, so .prettierignore cannot re-include', () => {
+      const prettier = createPrettierIgnoreChecker(
+        treeWith({ '.gitignore': 'a.ts\n', '.prettierignore': '!a.ts\n' })
+      );
+
+      expect(prettier.isIgnoredFile('a.ts')).toBe(true);
+    });
+  });
+
+  it.each([
+    ['git', createGitIgnoreChecker],
+    ['prettier', createPrettierIgnoreChecker],
+  ])('%s always ignores the hardcoded directories', (_name, create) => {
+    const checker = create(treeWith({ '.gitignore': '!node_modules\n' }));
+
+    expect(checker.isIgnoredFile('node_modules/pkg/a.ts')).toBe(true);
+    expect(checker.isIgnoredDirectory('node_modules')).toBe(true);
   });
 });

--- a/packages/nx/src/utils/ignore.spec.ts
+++ b/packages/nx/src/utils/ignore.spec.ts
@@ -1,0 +1,128 @@
+import {
+  createIgnoreChainResolver,
+  isIgnoredByChain,
+  posixDirname,
+} from './ignore';
+
+describe('createIgnoreChainResolver', () => {
+  /** Builds a resolver over an in-memory `path -> contents` map. */
+  function resolverFor(
+    files: Record<string, string>,
+    filenames = ['.gitignore']
+  ) {
+    return createIgnoreChainResolver((path) => files[path] ?? null, filenames);
+  }
+
+  function ignores(
+    files: Record<string, string>,
+    filePath: string,
+    filenames?: string[]
+  ) {
+    const resolve = resolverFor(files, filenames);
+    return isIgnoredByChain(resolve(posixDirname(filePath)), filePath);
+  }
+
+  it('applies the root ignore file to a nested file', () => {
+    expect(ignores({ '.gitignore': 'dist\n' }, 'apps/foo/dist/a.ts')).toBe(
+      true
+    );
+    expect(ignores({ '.gitignore': 'dist\n' }, 'apps/foo/src/a.ts')).toBe(
+      false
+    );
+  });
+
+  it('applies a nested ignore file', () => {
+    const files = { 'apps/foo/.gitignore': 'skip.ts\n' };
+
+    expect(ignores(files, 'apps/foo/skip.ts')).toBe(true);
+    // The same name outside that directory is untouched by it.
+    expect(ignores(files, 'apps/bar/skip.ts')).toBe(false);
+  });
+
+  it('anchors a nested pattern at its own directory', () => {
+    // A leading slash anchors to the file holding it. Matching against the
+    // workspace-relative path instead would never hit here - and a bare
+    // filename would hit either way, so this is what pins the rebasing.
+    const files = { 'apps/foo/.gitignore': '/generated/\n' };
+
+    expect(ignores(files, 'apps/foo/generated/a.ts')).toBe(true);
+    expect(ignores(files, 'generated/a.ts')).toBe(false);
+    expect(ignores(files, 'apps/foo/src/generated/a.ts')).toBe(false);
+  });
+
+  it('combines a root and a nested ignore file', () => {
+    const files = {
+      '.gitignore': 'dist\n',
+      'apps/foo/.gitignore': 'tmp\n',
+    };
+
+    expect(ignores(files, 'apps/foo/dist/a.ts')).toBe(true);
+    expect(ignores(files, 'apps/foo/tmp/a.ts')).toBe(true);
+    // The nested file's patterns must not escape upwards.
+    expect(ignores(files, 'apps/bar/tmp/a.ts')).toBe(false);
+  });
+
+  it('lets a nested negation re-include a file the root ignored', () => {
+    const files = {
+      '.gitignore': '*.log\n',
+      'apps/foo/.gitignore': '!keep.log\n',
+    };
+
+    expect(ignores(files, 'apps/foo/keep.log')).toBe(false);
+    expect(ignores(files, 'apps/foo/other.log')).toBe(true);
+    expect(ignores(files, 'apps/bar/keep.log')).toBe(true);
+  });
+
+  it('reads every configured filename in a directory', () => {
+    const files = {
+      'apps/foo/.gitignore': 'a.ts\n',
+      'apps/foo/.nxignore': 'b.ts\n',
+    };
+    const filenames = ['.gitignore', '.nxignore'];
+
+    expect(ignores(files, 'apps/foo/a.ts', filenames)).toBe(true);
+    expect(ignores(files, 'apps/foo/b.ts', filenames)).toBe(true);
+    expect(ignores(files, 'apps/foo/c.ts', filenames)).toBe(false);
+  });
+
+  it('reads each directory once across sibling leaves', () => {
+    const reads: string[] = [];
+    const resolve = createIgnoreChainResolver(
+      (path) => {
+        reads.push(path);
+        return path === '.gitignore' ? 'dist\n' : null;
+      },
+      ['.gitignore']
+    );
+
+    resolve('apps/foo/src');
+    resolve('apps/foo/lib');
+
+    // The shared trunk - apps/foo, apps, root - is walked once, not once per
+    // leaf, so only the second leaf's own directory is newly read.
+    expect(reads).toEqual([
+      'apps/foo/src/.gitignore',
+      'apps/foo/.gitignore',
+      'apps/.gitignore',
+      '.gitignore',
+      'apps/foo/lib/.gitignore',
+    ]);
+  });
+
+  it('returns an empty chain when nothing is ignored anywhere', () => {
+    const resolve = resolverFor({});
+
+    expect(resolve('apps/foo')).toEqual([]);
+    expect(isIgnoredByChain([], 'apps/foo/a.ts')).toBe(false);
+  });
+});
+
+describe('posixDirname', () => {
+  it.each([
+    ['apps/foo/a.ts', 'apps/foo'],
+    ['a.ts', ''],
+    ['apps/a.ts', 'apps'],
+  ])('maps %s to %s', (input, expected) => {
+    expect(posixDirname(input)).toBe(expected);
+  });
+});

--- a/packages/nx/src/utils/ignore.spec.ts
+++ b/packages/nx/src/utils/ignore.spec.ts
@@ -73,6 +73,28 @@ describe('createIgnoreChainResolver', () => {
     expect(ignores(files, 'apps/bar/keep.log')).toBe(true);
   });
 
+  it('does not let one file negate another file in the same directory', () => {
+    // prettier builds an ignorer per ignore file and ORs them, so a `!` in one
+    // cannot re-include what another excluded. Merging them into one matcher
+    // would, and would reformat a file the user deliberately excluded.
+    const files = {
+      '.gitignore': 'both.ts\n',
+      '.prettierignore': '!both.ts\n',
+    };
+    const filenames = ['.gitignore', '.prettierignore'];
+
+    expect(ignores(files, 'both.ts', filenames)).toBe(true);
+    // Order must not matter either.
+    expect(ignores(files, 'both.ts', [...filenames].reverse())).toBe(true);
+  });
+
+  it('still honours a negation within a single file', () => {
+    const files = { '.gitignore': '*.log\n!keep.log\n' };
+
+    expect(ignores(files, 'keep.log')).toBe(false);
+    expect(ignores(files, 'other.log')).toBe(true);
+  });
+
   it('reads every configured filename in a directory', () => {
     const files = {
       'apps/foo/.gitignore': 'a.ts\n',

--- a/packages/nx/src/utils/ignore.ts
+++ b/packages/nx/src/utils/ignore.ts
@@ -150,13 +150,14 @@ export function isAlwaysIgnored(path: string): boolean {
 }
 
 /**
- * Which files to read, whether they cascade, and how the files of one directory
- * relate are all decided by one fact - the tool the decision has to agree with -
- * so they are passed together, per tool. The two constructors below are the only
- * way in and neither takes any of them as an argument, so one tool's value for
- * one axis cannot reach another's.
+ * Not independent options despite the name: which files to read, whether they
+ * cascade, and how the files of one directory relate are all decided by one
+ * fact - the tool the decision has to agree with - so a whole set belongs to one
+ * tool and mixing two tools' values gives you neither. The constructors below
+ * are the only way in and none of them takes any of these as an argument, which
+ * is what keeps one tool's value for one axis from reaching another's.
  */
-type IgnoreAuthority = {
+type IgnoreCheckerOptions = {
   filenames: string[];
   cascade: boolean;
   merge: boolean;
@@ -215,7 +216,7 @@ export function createPrettierIgnoreChecker(tree: Tree): TreeIgnoreChecker {
 
 function createTreeIgnoreChecker(
   tree: Tree,
-  { filenames, cascade, merge }: IgnoreAuthority
+  { filenames, cascade, merge }: IgnoreCheckerOptions
 ): TreeIgnoreChecker {
   const resolve = createIgnoreChainResolver(
     (path) => tree.read(path, 'utf-8'),

--- a/packages/nx/src/utils/ignore.ts
+++ b/packages/nx/src/utils/ignore.ts
@@ -13,11 +13,27 @@ export function getIgnoreObject(
   return ig;
 }
 
+/**
+ * How the ignore files *within one directory* combine. The two consumers answer
+ * to different authorities and genuinely need different rules:
+ *
+ * - `separate` is prettier's: one matcher per file, any of them excluding wins,
+ *   and a negation counts only if none excluded. `createIsIgnoredFunction`
+ *   builds an ignorer per `--ignore-path` and ORs them, so a `!x` in
+ *   `.prettierignore` cannot re-include an `x` that `.gitignore` excluded.
+ * - `merged` is git's and the native walker's: all files in one matcher, later
+ *   ones winning, so `.nxignore`'s `!x` re-includes `.gitignore`'s `x`. It has
+ *   to be a merge rather than a precedence check between separate matchers,
+ *   because a lone `!x` reports an opinion on `x/` but *none* on `x/a.ts`
+ *   (measured) - only a merge carries the negation down to the children.
+ */
+export type IgnoreCombineMode = 'separate' | 'merged';
+
 /** One directory's ignore files, and the directory its patterns are rooted at. */
 export type ScopedIgnoreMatcher = {
   /** Workspace-relative POSIX directory, `''` for the workspace root. */
   dir: string;
-  /** One matcher per ignore file, never merged - see `isIgnoredByChain`. */
+  /** How they relate is decided at build time - see `IgnoreCombineMode`. */
   matchers: ReturnType<typeof ignore>[];
 };
 
@@ -41,7 +57,8 @@ export type ScopedIgnoreMatcher = {
  */
 export function createIgnoreChainResolver(
   read: (path: string) => string | null | undefined,
-  filenames: string[]
+  filenames: string[],
+  combine: IgnoreCombineMode
 ): (dir: string) => ScopedIgnoreMatcher[] {
   const cache = new Map<string, ScopedIgnoreMatcher[]>();
 
@@ -51,10 +68,15 @@ export function createIgnoreChainResolver(
       return cached;
     }
 
-    const matchers = filenames
+    const contents = filenames
       .map((name) => read(dir ? `${dir}/${name}` : name))
-      .filter((c): c is string => !!c)
-      .map((contents) => ignore().add(contents));
+      .filter((c): c is string => !!c);
+    const matchers =
+      combine === 'merged'
+        ? contents.length > 0
+          ? [contents.reduce((m, c) => m.add(c), ignore())]
+          : []
+        : contents.map((c) => ignore().add(c));
 
     const inherited = dir === '' ? [] : resolve(posixDirname(dir));
     const chain =
@@ -77,11 +99,9 @@ export function createIgnoreChainResolver(
  * Nearest directory with an *opinion* wins, not the first match: a nested
  * `!keep.log` must override the root's `*.log`, which is git's rule.
  *
- * Within one directory the files are never merged - any one of them excluding
- * the file wins, and a negation only counts if none of them excluded it. That is
- * prettier's rule (`createIsIgnoredFunction` builds an ignorer per
- * `--ignore-path` and ORs them), so a `!x` in `.prettierignore` cannot
- * re-include an `x` that `.gitignore` excluded.
+ * How the files of one directory combine is decided when the chain is built -
+ * see `IgnoreCombineMode`. Here they are simply the entry's matchers: any one
+ * excluding wins, and a negation counts only if none excluded.
  *
  * `filePath` is workspace-relative POSIX and must sit under every `dir` in the
  * chain - which holds when the chain came from that file's own directory.
@@ -137,22 +157,30 @@ export function isAlwaysIgnored(path: string): boolean {
  * (measured), so cascading here would skip files `nx format:check` still checks,
  * leaving them committed unformatted.
  *
- * `filenames` are kept as separate matchers, so one of them excluding a file
- * cannot be undone by a negation in another - see `isIgnoredByChain`.
+ * `combine` decides how the files of one directory relate - see
+ * `IgnoreCombineMode`. For `merged`, order `filenames` lowest-authority first.
  */
 export function createTreeIgnoreChecker(
   tree: Tree,
   filenames: string[],
-  { cascade }: { cascade: boolean }
+  { cascade, combine }: { cascade: boolean; combine: IgnoreCombineMode }
 ): (path: string) => boolean {
   const resolve = createIgnoreChainResolver(
     (path) => (tree.exists(path) ? tree.read(path, 'utf-8') : null),
-    filenames
+    filenames,
+    combine
   );
 
-  return (path) =>
-    isAlwaysIgnored(path) ||
-    isIgnoredByChain(resolve(cascade ? posixDirname(path) : ''), path);
+  return (path) => {
+    // A directory is probed as `dist/` so a trailing-slash pattern matches it,
+    // but the chain is keyed by real directories - `posixDirname('dist/')` is
+    // `'dist'`, not `''` - so the lookup uses the bare path.
+    const bare = path.endsWith('/') ? path.slice(0, -1) : path;
+    return (
+      isAlwaysIgnored(path) ||
+      isIgnoredByChain(resolve(cascade ? posixDirname(bare) : ''), path)
+    );
+  };
 }
 
 /**

--- a/packages/nx/src/utils/ignore.ts
+++ b/packages/nx/src/utils/ignore.ts
@@ -1,4 +1,5 @@
 import ignore = require('ignore');
+import { getHardcodedIgnorePatterns } from '../native/index';
 import { readFileIfExisting } from './fileutils';
 import { workspaceRoot } from './workspace-root';
 import { Tree } from '../generators/tree';
@@ -105,6 +106,49 @@ export function isIgnoredByChain(
     }
   }
   return false;
+}
+
+let alwaysIgnored: ReturnType<typeof ignore> | undefined;
+
+/**
+ * Directories that should never be walked, whatever the workspace's own ignore
+ * files say - `node_modules`, `.git`, the nx caches.
+ *
+ * The list comes from the native walker rather than a second copy here, so a
+ * filesystem walk and a tree walk cannot drift apart.
+ *
+ * Checked ahead of the cascading chain rather than folded into it: these are not
+ * re-includable, and as ordinary patterns a nested negation could resurrect
+ * `node_modules`.
+ */
+export function isAlwaysIgnored(path: string): boolean {
+  alwaysIgnored ??= ignore().add(getHardcodedIgnorePatterns());
+  return alwaysIgnored.ignores(path);
+}
+
+/**
+ * The cascading chain bound to a tree, as a predicate over workspace-relative
+ * POSIX paths.
+ *
+ * Reads from the tree rather than disk because a generator can create or amend
+ * an ignore file in the same run, which would leave the on-disk copy stale.
+ *
+ * `filenames` differs by caller: git-facing walks want `.nxignore`, while a
+ * formatter wants `.prettierignore` - both prettier and oxfmt honour it, and
+ * `.gitignore`, in their CLIs.
+ */
+export function createTreeIgnoreChecker(
+  tree: Tree,
+  filenames: string[]
+): (path: string) => boolean {
+  const resolve = createIgnoreChainResolver(
+    (path) => (tree.exists(path) ? tree.read(path, 'utf-8') : null),
+    filenames
+  );
+
+  return (path) =>
+    isAlwaysIgnored(path) ||
+    isIgnoredByChain(resolve(posixDirname(path)), path);
 }
 
 /** `path.dirname` for the workspace-relative POSIX paths the chain is keyed by. */

--- a/packages/nx/src/utils/ignore.ts
+++ b/packages/nx/src/utils/ignore.ts
@@ -21,11 +21,14 @@ export function getIgnoreObject(
  *   and a negation counts only if none excluded. `createIsIgnoredFunction`
  *   builds an ignorer per `--ignore-path` and ORs them, so a `!x` in
  *   `.prettierignore` cannot re-include an `x` that `.gitignore` excluded.
- * - `merged` is git's and the native walker's: all files in one matcher, later
- *   ones winning, so `.nxignore`'s `!x` re-includes `.gitignore`'s `x`. It has
+ * - `merged` is git's and the native walker's: all files in one matcher, so
+ *   `.nxignore`'s `!x` removes `.gitignore`'s exclusion of `x` outright. It has
  *   to be a merge rather than a precedence check between separate matchers,
- *   because a lone `!x` reports an opinion on `x/` but *none* on `x/a.ts`
- *   (measured) - only a merge carries the negation down to the children.
+ *   because a lone `!x` in its own matcher reports an opinion on `x/` but *none*
+ *   on `x/a.ts` (measured), so the exclusion would still reach the children.
+ *   Note the merge only removes the exclusion within that one directory - a
+ *   negation in a nested file still loses to an ancestor's exclusion, matching
+ *   what the helper this replaced did.
  */
 export type IgnoreCombineMode = 'separate' | 'merged';
 
@@ -97,7 +100,9 @@ export function createIgnoreChainResolver(
  * rather than the workspace's.
  *
  * Nearest directory with an *opinion* wins, not the first match: a nested
- * `!keep.log` must override the root's `*.log`, which is git's rule.
+ * `!keep.log` must override the root's `*.log`, which is git's rule for files.
+ * A nested negation of a *directory* does not reach its children - see
+ * `IgnoreCombineMode`.
  *
  * How the files of one directory combine is decided when the chain is built -
  * see `IgnoreCombineMode`. Here they are simply the entry's matchers: any one
@@ -159,27 +164,36 @@ export function isAlwaysIgnored(path: string): boolean {
  *
  * `combine` decides how the files of one directory relate - see
  * `IgnoreCombineMode`. For `merged`, order `filenames` lowest-authority first.
+ *
+ * Files and directories are asked separately because the answers differ: a
+ * pattern is only directory-only if it ends in a slash, and `ignore` will not
+ * match `dist/` against the path `dist`. Callers must not have to know that, so
+ * the slash is appended here and never leaves this module.
  */
 export function createTreeIgnoreChecker(
   tree: Tree,
   filenames: string[],
   { cascade, combine }: { cascade: boolean; combine: IgnoreCombineMode }
-): (path: string) => boolean {
+): {
+  isIgnoredFile: (path: string) => boolean;
+  isIgnoredDirectory: (path: string) => boolean;
+} {
   const resolve = createIgnoreChainResolver(
     (path) => (tree.exists(path) ? tree.read(path, 'utf-8') : null),
     filenames,
     combine
   );
 
-  return (path) => {
-    // A directory is probed as `dist/` so a trailing-slash pattern matches it,
-    // but the chain is keyed by real directories - `posixDirname('dist/')` is
-    // `'dist'`, not `''` - so the lookup uses the bare path.
-    const bare = path.endsWith('/') ? path.slice(0, -1) : path;
-    return (
-      isAlwaysIgnored(path) ||
-      isIgnoredByChain(resolve(cascade ? posixDirname(bare) : ''), path)
-    );
+  // `probe` may carry a trailing slash; `path` never does. The chain is keyed by
+  // real directories, and `posixDirname('dist/')` is `'dist'` rather than the
+  // parent, so the lookup always uses the slash-less form.
+  const check = (path: string, probe: string) =>
+    isAlwaysIgnored(probe) ||
+    isIgnoredByChain(resolve(cascade ? posixDirname(path) : ''), probe);
+
+  return {
+    isIgnoredFile: (path) => check(path, path),
+    isIgnoredDirectory: (path) => check(path, `${path}/`),
   };
 }
 

--- a/packages/nx/src/utils/ignore.ts
+++ b/packages/nx/src/utils/ignore.ts
@@ -57,6 +57,10 @@ export type ScopedIgnoreMatcher = {
  * `read` decides where the files come from - `tree.read` for a generator, disk
  * for a caller with no tree - and returns an empty string or null when there is
  * no such file. Paths handed to it are workspace-relative POSIX.
+ *
+ * `filenames` order matters when `combine` is `merged`: they go into one matcher
+ * in order and the last matching pattern decides, so list them
+ * lowest-authority first.
  */
 export function createIgnoreChainResolver(
   read: (path: string) => string | null | undefined,
@@ -153,9 +157,9 @@ export function isAlwaysIgnored(path: string): boolean {
 /**
  * Which files to read, whether they cascade, and how the files of one directory
  * relate are all decided by one fact - the tool this has to agree with - so the
- * caller states that and nothing else. Offering them as separate options would
- * make four incoherent combinations representable, and picking the wrong value
- * for one of them is a silent behaviour change across every caller.
+ * caller states that and nothing else. As separate options the two consumers'
+ * values could be mixed, and picking one wrong is a silent behaviour change
+ * across every caller.
  */
 const AUTHORITIES = {
   // git, and the native walker: ignore files cascade, and `.nxignore` outranks
@@ -167,8 +171,11 @@ const AUTHORITIES = {
     combine: 'merged',
   },
   // prettier: resolves ignore files from the workspace root only, and ORs one
-  // ignorer per `--ignore-path` rather than merging them (both measured). A
-  // formatter has to skip exactly what `nx format:check` skips.
+  // ignorer per `--ignore-path` rather than merging them (both measured), which
+  // is the CLI `nx format:check` shells out to. Not an exact match for that
+  // command: `isAlwaysIgnored` below also skips the nx and yarn caches, and
+  // `format.ts` filters its own patterns through `.nxignore`, which this does
+  // not read.
   prettier: {
     filenames: ['.gitignore', '.prettierignore'],
     cascade: false,
@@ -179,7 +186,10 @@ const AUTHORITIES = {
   { filenames: string[]; cascade: boolean; combine: IgnoreCombineMode }
 >;
 
-/** The tool an ignore decision has to agree with. */
+/**
+ * The tool an ignore decision has to agree with. `git` also covers the native
+ * walker, which is where `.nxignore` comes from - git itself does not read it.
+ */
 export type IgnoreAuthority = keyof typeof AUTHORITIES;
 
 /**

--- a/packages/nx/src/utils/ignore.ts
+++ b/packages/nx/src/utils/ignore.ts
@@ -13,30 +13,11 @@ export function getIgnoreObject(
   return ig;
 }
 
-/**
- * How the ignore files *within one directory* combine. The two consumers answer
- * to different authorities and genuinely need different rules:
- *
- * - `separate` is prettier's: one matcher per file, any of them excluding wins,
- *   and a negation counts only if none excluded. `createIsIgnoredFunction`
- *   builds an ignorer per `--ignore-path` and ORs them, so a `!x` in
- *   `.prettierignore` cannot re-include an `x` that `.gitignore` excluded.
- * - `merged` is git's and the native walker's: all files in one matcher, so
- *   `.nxignore`'s `!x` removes `.gitignore`'s exclusion of `x` outright. It has
- *   to be a merge rather than a precedence check between separate matchers,
- *   because a lone `!x` in its own matcher reports an opinion on `x/` but *none*
- *   on `x/a.ts` (measured), so the exclusion would still reach the children.
- *   Note the merge only removes the exclusion within that one directory - a
- *   negation in a nested file still loses to an ancestor's exclusion, matching
- *   what the helper this replaced did.
- */
-export type IgnoreCombineMode = 'separate' | 'merged';
-
 /** One directory's ignore files, and the directory its patterns are rooted at. */
 export type ScopedIgnoreMatcher = {
   /** Workspace-relative POSIX directory, `''` for the workspace root. */
   dir: string;
-  /** How they relate is decided at build time - see `IgnoreCombineMode`. */
+  /** How they relate is decided at build time - see `merge`. */
   matchers: ReturnType<typeof ignore>[];
 };
 
@@ -58,14 +39,29 @@ export type ScopedIgnoreMatcher = {
  * for a caller with no tree - and returns an empty string or null when there is
  * no such file. Paths handed to it are workspace-relative POSIX.
  *
- * `filenames` order matters when `combine` is `merged`: they go into one matcher
- * in order and the last matching pattern decides, so list them
- * lowest-authority first.
+ * `merge` decides how the files *within one directory* relate, and the two
+ * consumers genuinely need different rules:
+ *
+ * - `false` is prettier's: one matcher per file, any of them excluding wins, and
+ *   a negation counts only if none excluded. `createIsIgnoredFunction` builds an
+ *   ignorer per `--ignore-path` and ORs them, so a `!x` in `.prettierignore`
+ *   cannot re-include an `x` that `.gitignore` excluded.
+ * - `true` is git's and the native walker's: all files in one matcher, so
+ *   `.nxignore`'s `!x` removes `.gitignore`'s exclusion of `x` outright. It has
+ *   to be a merge rather than a precedence check between separate matchers,
+ *   because a lone `!x` in its own matcher reports an opinion on `x/` but *none*
+ *   on `x/a.ts` (measured), so the exclusion would still reach the children.
+ *   The merge only removes the exclusion within that one directory - a negation
+ *   in a nested file still loses to an ancestor's exclusion.
+ *
+ * When `merge` is true, `filenames` order matters: they go into one matcher in
+ * order and the last matching pattern decides, so list them lowest-authority
+ * first.
  */
 export function createIgnoreChainResolver(
   read: (path: string) => string | null | undefined,
   filenames: string[],
-  combine: IgnoreCombineMode
+  merge: boolean
 ): (dir: string) => ScopedIgnoreMatcher[] {
   const cache = new Map<string, ScopedIgnoreMatcher[]>();
 
@@ -78,12 +74,11 @@ export function createIgnoreChainResolver(
     const contents = filenames
       .map((name) => read(dir ? `${dir}/${name}` : name))
       .filter((c): c is string => !!c);
-    const matchers =
-      combine === 'merged'
-        ? contents.length > 0
-          ? [contents.reduce((m, c) => m.add(c), ignore())]
-          : []
-        : contents.map((c) => ignore().add(c));
+    const matchers = merge
+      ? contents.length > 0
+        ? [contents.reduce((m, c) => m.add(c), ignore())]
+        : []
+      : contents.map((c) => ignore().add(c));
 
     const inherited = dir === '' ? [] : resolve(posixDirname(dir));
     const chain =
@@ -105,12 +100,12 @@ export function createIgnoreChainResolver(
  *
  * Nearest directory with an *opinion* wins, not the first match: a nested
  * `!keep.log` must override the root's `*.log`, which is git's rule for files.
- * A nested negation of a *directory* does not reach its children - see
- * `IgnoreCombineMode`.
+ * A nested negation of a *directory* does not reach its children - see the
+ * `merge` note on `createIgnoreChainResolver`.
  *
- * How the files of one directory combine is decided when the chain is built -
- * see `IgnoreCombineMode`. Here they are simply the entry's matchers: any one
- * excluding wins, and a negation counts only if none excluded.
+ * How the files of one directory relate is decided when the chain is built - see
+ * that same note. Here they are simply the entry's matchers: any one excluding
+ * wins, and a negation counts only if none excluded.
  *
  * `filePath` is workspace-relative POSIX and must sit under every `dir` in the
  * chain - which holds when the chain came from that file's own directory.
@@ -156,65 +151,76 @@ export function isAlwaysIgnored(path: string): boolean {
 
 /**
  * Which files to read, whether they cascade, and how the files of one directory
- * relate are all decided by one fact - the tool this has to agree with - so the
- * caller states that and nothing else. As separate options the two consumers'
- * values could be mixed, and picking one wrong is a silent behaviour change
- * across every caller.
+ * relate are all decided by one fact - the tool the decision has to agree with -
+ * so they are passed together, per tool. The two constructors below are the only
+ * way in and neither takes any of them as an argument, so one tool's value for
+ * one axis cannot reach another's.
  */
-const AUTHORITIES = {
-  // git, and the native walker: ignore files cascade, and `.nxignore` outranks
-  // `.gitignore` (`walker.rs` registers it with `add_custom_ignore_filename`),
-  // which a merge with `.nxignore` last reproduces.
-  git: {
-    filenames: ['.gitignore', '.nxignore'],
-    cascade: true,
-    combine: 'merged',
-  },
-  // prettier: resolves ignore files from the workspace root only, and ORs one
-  // ignorer per `--ignore-path` rather than merging them (both measured), which
-  // is the CLI `nx format:check` shells out to. Not an exact match for that
-  // command: `isAlwaysIgnored` below also skips the nx and yarn caches, and
-  // `format.ts` filters its own patterns through `.nxignore`, which this does
-  // not read.
-  prettier: {
-    filenames: ['.gitignore', '.prettierignore'],
-    cascade: false,
-    combine: 'separate',
-  },
-} satisfies Record<
-  string,
-  { filenames: string[]; cascade: boolean; combine: IgnoreCombineMode }
->;
-
-/**
- * The tool an ignore decision has to agree with. `git` also covers the native
- * walker, which is where `.nxignore` comes from - git itself does not read it.
- */
-export type IgnoreAuthority = keyof typeof AUTHORITIES;
+type IgnoreAuthority = {
+  filenames: string[];
+  cascade: boolean;
+  merge: boolean;
+};
 
 /**
  * The chain bound to a tree, as predicates over workspace-relative POSIX paths.
  *
- * Reads from the tree rather than disk because a generator can create or amend
- * an ignore file in the same run, which would leave the on-disk copy stale.
- *
  * Files and directories are asked separately because the answers differ: a
  * pattern is only directory-only if it ends in a slash, and `ignore` will not
  * match `dist/` against the path `dist`. Callers must not have to know that, so
- * the slash is appended here and never leaves this module.
+ * the slash is appended inside and never leaves this module.
  */
-export function createTreeIgnoreChecker(
-  tree: Tree,
-  authority: IgnoreAuthority
-): {
+export type TreeIgnoreChecker = {
   isIgnoredFile: (path: string) => boolean;
   isIgnoredDirectory: (path: string) => boolean;
-} {
-  const { filenames, cascade, combine } = AUTHORITIES[authority];
+};
+
+/**
+ * What git ignores, which is also what the native walker ignores.
+ *
+ * `.nxignore` outranks `.gitignore` - `walker.rs` registers it with
+ * `add_custom_ignore_filename` - which a merge with `.nxignore` last reproduces.
+ * git itself does not read it.
+ *
+ * Reads from the tree rather than disk because a generator can create or amend
+ * an ignore file in the same run, which would leave the on-disk copy stale.
+ */
+export function createGitIgnoreChecker(tree: Tree): TreeIgnoreChecker {
+  return createTreeIgnoreChecker(tree, {
+    filenames: ['.gitignore', '.nxignore'],
+    cascade: true,
+    merge: true,
+  });
+}
+
+/**
+ * What prettier ignores: the workspace root only, and one ignorer per
+ * `--ignore-path` ORed rather than merged (both measured), so a `!` in
+ * `.prettierignore` cannot re-include what `.gitignore` excluded. That is the
+ * CLI `nx format:check` shells out to.
+ *
+ * Not an exact match for that command: `isAlwaysIgnored` is wider than
+ * prettier's built-ins, and `format.ts` filters its own patterns through
+ * `.nxignore`, which this does not read.
+ *
+ * Reads from the tree rather than disk, as above.
+ */
+export function createPrettierIgnoreChecker(tree: Tree): TreeIgnoreChecker {
+  return createTreeIgnoreChecker(tree, {
+    filenames: ['.gitignore', '.prettierignore'],
+    cascade: false,
+    merge: false,
+  });
+}
+
+function createTreeIgnoreChecker(
+  tree: Tree,
+  { filenames, cascade, merge }: IgnoreAuthority
+): TreeIgnoreChecker {
   const resolve = createIgnoreChainResolver(
     (path) => tree.read(path, 'utf-8'),
     filenames,
-    combine
+    merge
   );
 
   // `probe` may carry a trailing slash; `path` never does. The chain is keyed by

--- a/packages/nx/src/utils/ignore.ts
+++ b/packages/nx/src/utils/ignore.ts
@@ -52,9 +52,9 @@ export function createIgnoreChainResolver(
 
     const contents = filenames
       .map((name) => read(dir ? `${dir}/${name}` : name))
-      .filter((c) => !!c && c.length > 0);
+      .filter((c): c is string => !!c);
 
-    const inherited = dir === '' ? [] : resolve(parentDir(dir));
+    const inherited = dir === '' ? [] : resolve(posixDirname(dir));
     let chain = inherited;
     if (contents.length > 0) {
       const matcher = ignore();
@@ -78,12 +78,8 @@ export function createIgnoreChainResolver(
  * is what makes a nested pattern like `/build` mean that directory's `build`
  * rather than the workspace's.
  *
- * The first file with an *opinion* decides, rather than the first file that
- * ignores: git overrides higher-level patterns with lower-level ones, so a
- * nested `!keep.log` re-includes a file the root's `*.log` excluded. Stopping at
- * the first match instead would let the root win and silently drop the
- * negation. A file that matches nothing in a directory carries no opinion, so
- * the search continues upwards.
+ * First file with an *opinion* wins, not first match: a nested `!keep.log` must
+ * override the root's `*.log`, which is git's rule.
  *
  * `filePath` is workspace-relative POSIX and must sit under every `dir` in the
  * chain - which holds when the chain came from that file's own directory.
@@ -94,9 +90,6 @@ export function isIgnoredByChain(
 ): boolean {
   for (const { dir, matcher } of chain) {
     const relative = dir === '' ? filePath : filePath.slice(dir.length + 1);
-    if (!relative) {
-      continue;
-    }
     const result = matcher.test(relative);
     if (result.ignored) {
       return true;
@@ -127,19 +120,24 @@ export function isAlwaysIgnored(path: string): boolean {
 }
 
 /**
- * The cascading chain bound to a tree, as a predicate over workspace-relative
- * POSIX paths.
+ * The chain bound to a tree, as a predicate over workspace-relative POSIX paths.
  *
  * Reads from the tree rather than disk because a generator can create or amend
  * an ignore file in the same run, which would leave the on-disk copy stale.
  *
- * `filenames` differs by caller: git-facing walks want `.nxignore`, while a
- * formatter wants `.prettierignore` - both prettier and oxfmt honour it, and
- * `.gitignore`, in their CLIs.
+ * `cascade` has to match whatever the caller must agree with. A tree walk wants
+ * `true`, matching git and the native walker. A formatter wants `false`:
+ * prettier resolves `.gitignore`/`.prettierignore` from the workspace root only
+ * (measured), so cascading here would skip files `nx format:check` still checks,
+ * leaving them committed unformatted.
+ *
+ * `filenames` are merged into one matcher per directory, in array order, so a
+ * later file's negation beats an earlier file's pattern.
  */
 export function createTreeIgnoreChecker(
   tree: Tree,
-  filenames: string[]
+  filenames: string[],
+  { cascade }: { cascade: boolean }
 ): (path: string) => boolean {
   const resolve = createIgnoreChainResolver(
     (path) => (tree.exists(path) ? tree.read(path, 'utf-8') : null),
@@ -148,18 +146,17 @@ export function createTreeIgnoreChecker(
 
   return (path) =>
     isAlwaysIgnored(path) ||
-    isIgnoredByChain(resolve(posixDirname(path)), path);
+    isIgnoredByChain(resolve(cascade ? posixDirname(path) : ''), path);
 }
 
-/** `path.dirname` for the workspace-relative POSIX paths the chain is keyed by. */
+/**
+ * `path.dirname` for the workspace-relative POSIX paths the chain is keyed by,
+ * except that the workspace root is `''` rather than `.` - that is the key
+ * `createIgnoreChainResolver` terminates on.
+ */
 export function posixDirname(relativePath: string): string {
   const separator = relativePath.lastIndexOf('/');
   return separator === -1 ? '' : relativePath.slice(0, separator);
-}
-
-function parentDir(dir: string): string {
-  const separator = dir.lastIndexOf('/');
-  return separator === -1 ? '' : dir.slice(0, separator);
 }
 
 export function getIgnoreObjectForTree(tree: Tree) {

--- a/packages/nx/src/utils/ignore.ts
+++ b/packages/nx/src/utils/ignore.ts
@@ -212,7 +212,7 @@ export function createTreeIgnoreChecker(
 } {
   const { filenames, cascade, combine } = AUTHORITIES[authority];
   const resolve = createIgnoreChainResolver(
-    (path) => (tree.exists(path) ? tree.read(path, 'utf-8') : null),
+    (path) => tree.read(path, 'utf-8'),
     filenames,
     combine
   );

--- a/packages/nx/src/utils/ignore.ts
+++ b/packages/nx/src/utils/ignore.ts
@@ -26,8 +26,8 @@ export type ScopedIgnoreMatcher = {
  *
  * Ignore files cascade - a `.gitignore` covers its own directory and below, and
  * its patterns are relative to *itself*, not to the workspace root. Reading only
- * the root file, which is what `getIgnoreObject` and `getIgnoreObjectForTree`
- * do, silently misses every nested one.
+ * the root file, which is what `getIgnoreObject` does, silently misses every
+ * nested one.
  *
  * A directory's answer is its own files plus its parent's, so every directory on
  * the way up is memoized rather than only the one asked for: sibling leaves
@@ -157,21 +157,6 @@ export function createTreeIgnoreChecker(
 export function posixDirname(relativePath: string): string {
   const separator = relativePath.lastIndexOf('/');
   return separator === -1 ? '' : relativePath.slice(0, separator);
-}
-
-export function getIgnoreObjectForTree(tree: Tree) {
-  let ig: ReturnType<typeof ignore>;
-  if (tree.exists('.gitignore')) {
-    ig = ignore();
-    ig.add('.git');
-    ig.add(tree.read('.gitignore', 'utf-8'));
-  }
-  if (tree.exists('.nxignore')) {
-    ig ??= ignore();
-    ig.add(tree.read('.nxignore', 'utf-8'));
-  }
-
-  return ig;
 }
 
 /**

--- a/packages/nx/src/utils/ignore.ts
+++ b/packages/nx/src/utils/ignore.ts
@@ -13,11 +13,12 @@ export function getIgnoreObject(
   return ig;
 }
 
-/** An ignore matcher paired with the directory its patterns are rooted at. */
+/** One directory's ignore files, and the directory its patterns are rooted at. */
 export type ScopedIgnoreMatcher = {
   /** Workspace-relative POSIX directory, `''` for the workspace root. */
   dir: string;
-  matcher: ReturnType<typeof ignore>;
+  /** One matcher per ignore file, never merged - see `isIgnoredByChain`. */
+  matchers: ReturnType<typeof ignore>[];
 };
 
 /**
@@ -50,19 +51,14 @@ export function createIgnoreChainResolver(
       return cached;
     }
 
-    const contents = filenames
+    const matchers = filenames
       .map((name) => read(dir ? `${dir}/${name}` : name))
-      .filter((c): c is string => !!c);
+      .filter((c): c is string => !!c)
+      .map((contents) => ignore().add(contents));
 
     const inherited = dir === '' ? [] : resolve(posixDirname(dir));
-    let chain = inherited;
-    if (contents.length > 0) {
-      const matcher = ignore();
-      for (const c of contents) {
-        matcher.add(c);
-      }
-      chain = [{ dir, matcher }, ...inherited];
-    }
+    const chain =
+      matchers.length > 0 ? [{ dir, matchers }, ...inherited] : inherited;
 
     cache.set(dir, chain);
     return chain;
@@ -78,8 +74,14 @@ export function createIgnoreChainResolver(
  * is what makes a nested pattern like `/build` mean that directory's `build`
  * rather than the workspace's.
  *
- * First file with an *opinion* wins, not first match: a nested `!keep.log` must
- * override the root's `*.log`, which is git's rule.
+ * Nearest directory with an *opinion* wins, not the first match: a nested
+ * `!keep.log` must override the root's `*.log`, which is git's rule.
+ *
+ * Within one directory the files are never merged - any one of them excluding
+ * the file wins, and a negation only counts if none of them excluded it. That is
+ * prettier's rule (`createIsIgnoredFunction` builds an ignorer per
+ * `--ignore-path` and ORs them), so a `!x` in `.prettierignore` cannot
+ * re-include an `x` that `.gitignore` excluded.
  *
  * `filePath` is workspace-relative POSIX and must sit under every `dir` in the
  * chain - which holds when the chain came from that file's own directory.
@@ -88,13 +90,17 @@ export function isIgnoredByChain(
   chain: ScopedIgnoreMatcher[],
   filePath: string
 ): boolean {
-  for (const { dir, matcher } of chain) {
+  for (const { dir, matchers } of chain) {
     const relative = dir === '' ? filePath : filePath.slice(dir.length + 1);
-    const result = matcher.test(relative);
-    if (result.ignored) {
-      return true;
+    let unignored = false;
+    for (const matcher of matchers) {
+      const result = matcher.test(relative);
+      if (result.ignored) {
+        return true;
+      }
+      unignored ||= result.unignored;
     }
-    if (result.unignored) {
+    if (unignored) {
       return false;
     }
   }
@@ -131,8 +137,8 @@ export function isAlwaysIgnored(path: string): boolean {
  * (measured), so cascading here would skip files `nx format:check` still checks,
  * leaving them committed unformatted.
  *
- * `filenames` are merged into one matcher per directory, in array order, so a
- * later file's negation beats an earlier file's pattern.
+ * `filenames` are kept as separate matchers, so one of them excluding a file
+ * cannot be undone by a negation in another - see `isIgnoredByChain`.
  */
 export function createTreeIgnoreChecker(
   tree: Tree,

--- a/packages/nx/src/utils/ignore.ts
+++ b/packages/nx/src/utils/ignore.ts
@@ -107,8 +107,17 @@ export function createIgnoreChainResolver(
  * that same note. Here they are simply the entry's matchers: any one excluding
  * wins, and a negation counts only if none excluded.
  *
- * `filePath` is workspace-relative POSIX and must sit under every `dir` in the
- * chain - which holds when the chain came from that file's own directory.
+ * Two preconditions, both satisfied by a pruning walk and neither enforced:
+ *
+ * - `filePath` is workspace-relative POSIX and must sit under every `dir` in the
+ *   chain, which holds when the chain came from that file's own directory.
+ * - No ancestor directory of `filePath` may itself be ignored. git refuses to
+ *   re-include a file inside an excluded directory, and this does not implement
+ *   that rule: asked directly about `dist/keep.ts` with a root `dist/` and a
+ *   nested `dist/.gitignore` holding `!keep.ts`, it answers "not ignored" where
+ *   git says ignored (measured). `visitNotIgnoredFiles` never asks, because it
+ *   prunes `dist/` before descending - which is what makes its answers match
+ *   git, and why that pruning is load-bearing for correctness rather than speed.
  */
 export function isIgnoredByChain(
   chain: ScopedIgnoreMatcher[],

--- a/packages/nx/src/utils/ignore.ts
+++ b/packages/nx/src/utils/ignore.ts
@@ -151,19 +151,42 @@ export function isAlwaysIgnored(path: string): boolean {
 }
 
 /**
- * The chain bound to a tree, as a predicate over workspace-relative POSIX paths.
+ * Which files to read, whether they cascade, and how the files of one directory
+ * relate are all decided by one fact - the tool this has to agree with - so the
+ * caller states that and nothing else. Offering them as separate options would
+ * make four incoherent combinations representable, and picking the wrong value
+ * for one of them is a silent behaviour change across every caller.
+ */
+const AUTHORITIES = {
+  // git, and the native walker: ignore files cascade, and `.nxignore` outranks
+  // `.gitignore` (`walker.rs` registers it with `add_custom_ignore_filename`),
+  // which a merge with `.nxignore` last reproduces.
+  git: {
+    filenames: ['.gitignore', '.nxignore'],
+    cascade: true,
+    combine: 'merged',
+  },
+  // prettier: resolves ignore files from the workspace root only, and ORs one
+  // ignorer per `--ignore-path` rather than merging them (both measured). A
+  // formatter has to skip exactly what `nx format:check` skips.
+  prettier: {
+    filenames: ['.gitignore', '.prettierignore'],
+    cascade: false,
+    combine: 'separate',
+  },
+} satisfies Record<
+  string,
+  { filenames: string[]; cascade: boolean; combine: IgnoreCombineMode }
+>;
+
+/** The tool an ignore decision has to agree with. */
+export type IgnoreAuthority = keyof typeof AUTHORITIES;
+
+/**
+ * The chain bound to a tree, as predicates over workspace-relative POSIX paths.
  *
  * Reads from the tree rather than disk because a generator can create or amend
  * an ignore file in the same run, which would leave the on-disk copy stale.
- *
- * `cascade` has to match whatever the caller must agree with. A tree walk wants
- * `true`, matching git and the native walker. A formatter wants `false`:
- * prettier resolves `.gitignore`/`.prettierignore` from the workspace root only
- * (measured), so cascading here would skip files `nx format:check` still checks,
- * leaving them committed unformatted.
- *
- * `combine` decides how the files of one directory relate - see
- * `IgnoreCombineMode`. For `merged`, order `filenames` lowest-authority first.
  *
  * Files and directories are asked separately because the answers differ: a
  * pattern is only directory-only if it ends in a slash, and `ignore` will not
@@ -172,12 +195,12 @@ export function isAlwaysIgnored(path: string): boolean {
  */
 export function createTreeIgnoreChecker(
   tree: Tree,
-  filenames: string[],
-  { cascade, combine }: { cascade: boolean; combine: IgnoreCombineMode }
+  authority: IgnoreAuthority
 ): {
   isIgnoredFile: (path: string) => boolean;
   isIgnoredDirectory: (path: string) => boolean;
 } {
+  const { filenames, cascade, combine } = AUTHORITIES[authority];
   const resolve = createIgnoreChainResolver(
     (path) => (tree.exists(path) ? tree.read(path, 'utf-8') : null),
     filenames,

--- a/packages/nx/src/utils/ignore.ts
+++ b/packages/nx/src/utils/ignore.ts
@@ -12,6 +12,112 @@ export function getIgnoreObject(
   return ig;
 }
 
+/** An ignore matcher paired with the directory its patterns are rooted at. */
+export type ScopedIgnoreMatcher = {
+  /** Workspace-relative POSIX directory, `''` for the workspace root. */
+  dir: string;
+  matcher: ReturnType<typeof ignore>;
+};
+
+/**
+ * Resolves the ignore files that apply to a directory: its own and every one
+ * above it, up to the workspace root.
+ *
+ * Ignore files cascade - a `.gitignore` covers its own directory and below, and
+ * its patterns are relative to *itself*, not to the workspace root. Reading only
+ * the root file, which is what `getIgnoreObject` and `getIgnoreObjectForTree`
+ * do, silently misses every nested one.
+ *
+ * A directory's answer is its own files plus its parent's, so every directory on
+ * the way up is memoized rather than only the one asked for: sibling leaves
+ * share the whole trunk, and a later walk stops at the first directory already
+ * known.
+ *
+ * `read` decides where the files come from - `tree.read` for a generator, disk
+ * for a caller with no tree - and returns an empty string or null when there is
+ * no such file. Paths handed to it are workspace-relative POSIX.
+ */
+export function createIgnoreChainResolver(
+  read: (path: string) => string | null | undefined,
+  filenames: string[]
+): (dir: string) => ScopedIgnoreMatcher[] {
+  const cache = new Map<string, ScopedIgnoreMatcher[]>();
+
+  const resolve = (dir: string): ScopedIgnoreMatcher[] => {
+    const cached = cache.get(dir);
+    if (cached) {
+      return cached;
+    }
+
+    const contents = filenames
+      .map((name) => read(dir ? `${dir}/${name}` : name))
+      .filter((c) => !!c && c.length > 0);
+
+    const inherited = dir === '' ? [] : resolve(parentDir(dir));
+    let chain = inherited;
+    if (contents.length > 0) {
+      const matcher = ignore();
+      for (const c of contents) {
+        matcher.add(c);
+      }
+      chain = [{ dir, matcher }, ...inherited];
+    }
+
+    cache.set(dir, chain);
+    return chain;
+  };
+
+  return resolve;
+}
+
+/**
+ * True when the file is ignored, resolving the chain nearest file first.
+ *
+ * Each matcher is tested against the path relative to its own directory, which
+ * is what makes a nested pattern like `/build` mean that directory's `build`
+ * rather than the workspace's.
+ *
+ * The first file with an *opinion* decides, rather than the first file that
+ * ignores: git overrides higher-level patterns with lower-level ones, so a
+ * nested `!keep.log` re-includes a file the root's `*.log` excluded. Stopping at
+ * the first match instead would let the root win and silently drop the
+ * negation. A file that matches nothing in a directory carries no opinion, so
+ * the search continues upwards.
+ *
+ * `filePath` is workspace-relative POSIX and must sit under every `dir` in the
+ * chain - which holds when the chain came from that file's own directory.
+ */
+export function isIgnoredByChain(
+  chain: ScopedIgnoreMatcher[],
+  filePath: string
+): boolean {
+  for (const { dir, matcher } of chain) {
+    const relative = dir === '' ? filePath : filePath.slice(dir.length + 1);
+    if (!relative) {
+      continue;
+    }
+    const result = matcher.test(relative);
+    if (result.ignored) {
+      return true;
+    }
+    if (result.unignored) {
+      return false;
+    }
+  }
+  return false;
+}
+
+/** `path.dirname` for the workspace-relative POSIX paths the chain is keyed by. */
+export function posixDirname(relativePath: string): string {
+  const separator = relativePath.lastIndexOf('/');
+  return separator === -1 ? '' : relativePath.slice(0, separator);
+}
+
+function parentDir(dir: string): string {
+  const separator = dir.lastIndexOf('/');
+  return separator === -1 ? '' : dir.slice(0, separator);
+}
+
 export function getIgnoreObjectForTree(tree: Tree) {
   let ig: ReturnType<typeof ignore>;
   if (tree.exists('.gitignore')) {


### PR DESCRIPTION
## Current Behavior

Nx reads ignore files only at the workspace root, but ignore files cascade: a `.gitignore` covers its own directory and below, its patterns are relative to *itself*, and a lower-level file overrides a higher one. Three consequences, each measured:

**`visitNotIgnoredFiles` misses every nested ignore file.** It builds one matcher from the tree root and then recurses into every subdirectory applying only those patterns. With `.gitignore` at the root and `apps/foo/.gitignore` listing `nested-ignored.ts`:

```
VISITED: ["apps/foo/kept.ts", "apps/foo/nested-ignored.ts"]
```

The nested file is visited despite the `.gitignore` beside it naming it. Its doc comment promises "all files in a tree that are not ignored by git", and git honours nested files. ~100 invocations across 91 non-spec files, mostly migrations that walk and rewrite, so a vendored or generated subtree excluded by a nested `.gitignore` gets rewritten.

It also rebuilt that matcher at every directory, because the recursion re-entered the public function.

**With no ignore file at all, nothing is filtered.** `getIgnoreObjectForTree` returned `undefined` when neither `.gitignore` nor `.nxignore` existed, so the traversal walked everything:

```
VISITED: [".nx/cache/x.js", "dist/out.js", "node_modules/pkg/index.js", "src/a.ts"]
```

The native walker already keeps a list of directories that should never be visited (`**/node_modules`, `**/.git`, `**/.nx/cache`, …); the tree side just never used it.

**`formatFiles` rewrites ignored files.** It hands every changed file to prettier. The `getFileInfo` call looks like it filters ignored ones, but with no `ignorePath` passed the `ignored` flag is always `false` — measured — so it has never skipped anything. Both CLIs *do* skip them (prettier 3.6.2 and oxfmt 0.60.0, both measured on `.gitignore` and `.prettierignore` with controls), so generator formatting rewrote files `nx format:check` never looks at, including ones a user excluded on purpose.

## Expected Behavior

One cascading resolver, used by both callers.

`createIgnoreChainResolver` walks from a directory upwards, memoizing every directory on the way rather than only the leaf, so sibling leaves share the trunk and a later walk stops at the first directory already known. `isIgnoredByChain` rebases each path onto the directory its matcher came from, and resolves nearest-first by the first file with an *opinion* — so a nested `!keep.log` re-includes a file the root's `*.log` excluded, matching git's rule that lower-level files override higher ones.

`createGitIgnoreChecker(tree)` and `createPrettierIgnoreChecker(tree)` bind that to a tree. Reading from the tree rather than disk matters because a generator can create or amend an ignore file in the same run.

### One constructor per tool, no knobs

Which files to read, whether they cascade, and whether the files of one directory merge are not independent — they are all decided by the one tool the decision has to agree with:

| constructor | files | cascades | merges |
| --- | --- | --- | --- |
| `createGitIgnoreChecker` (also the native walker) | `.gitignore`, `.nxignore` | yes | yes — `.nxignore` outranks `.gitignore`, matching `add_custom_ignore_filename` in `walker.rs` |
| `createPrettierIgnoreChecker` | `.gitignore`, `.prettierignore` | no (root only) | no — one matcher per file, ORed, so a `!` in one cannot re-include what another excluded |

Each inlines its own config into a private helper, so a caller picks a tool rather than a set of values and cannot reach any axis at all. Both of the regressions caught during review of this PR were one axis set to the other consumer's value; that is now unrepresentable rather than merely tested against.

The checker exposes `isIgnoredFile` and `isIgnoredDirectory` separately, because the answers genuinely differ: a pattern is directory-only when it ends in a slash, and `ignore` will not match `dist/` against the path `dist`. The trailing slash is appended inside the module and never crosses the package boundary.

The native walker's hardcoded list is exposed through napi and applied on the tree side too, rather than copied into TypeScript where it would drift. It is checked ahead of the chain because these are not re-includable — as ordinary patterns a nested negation could resurrect `node_modules`.

Two smaller fixes ride along in `visitNotIgnoredFiles`:

- `.git` is excluded unconditionally. It used to ride on the root `.gitignore` existing, so a workspace without one had `.git` walked.
- Child paths are joined as POSIX. Tree paths are POSIX, and `path.join` on Windows produced backslashes that matched no pattern, so nested matching was likely broken there regardless.

`getIgnoreObjectForTree` is deleted — the new checker replaces its only callers.

### Reading the ignore files

The resolver asks the tree for each ignore filename directly rather than probing with `exists()` first. `FsTree.exists` scans every recorded change when the path is not one of them, and the cascade asks about two filenames in every directory with nearly all of them missing, so the guard was paying an O(changes) scan to answer what `read` answers by returning `null`. Walking a 24k-entry tree drops from 30.9s to 11.3s — master, which probes two fixed paths per directory, takes 18.7s.

That relies on `Tree.read` honouring its own contract of returning `null` for a missing file. `DevkitTreeFromAngularDevkitTree` did not — it dereferenced the schematics tree's `Buffer | null` and declared non-null return types — so any generator exposed as an Angular schematic through the public `convertNxGenerator` would have thrown at the first missing ignore file. That is fixed here, and covered by two tests that run a generator through `convertNxGenerator`: one reading a missing file directly, one walking a whole tree.

### Behaviour change to be aware of

This only ever skips *more* files. For workspaces built from nx generators the effect is close to nil — the only nested `.gitignore` templates nx ships (remix, react-router-ssr) list build outputs that do not exist in a generator's tree. The real change is for user-authored nested ignore files, which is the point; a migration that used to rewrite a vendored subtree now leaves it alone.

### Testing

`packages/nx/src/utils/ignore.spec.ts` goes to 22 tests, six of which pin one config value each — flip any one and a test fails. `visitNotIgnoredFiles` goes from 6 tests to 64 — 19 hand-written plus the 45 differential cases below; `formatFiles` goes from 6 to 11; `invoke-nx-generator` from 1 to 3.

The important one is a **differential test against real git**. Rather than asserting hand-written expectations, it materialises each workspace on disk, runs `git ls-files -o --exclude-standard`, runs `visitNotIgnoredFiles` over the same tree, and diffs the two sets — 45 pattern × negation combinations over a fixed corpus that includes a nested `.gitignore`, with ambient user/system git config disabled so a developer's global `core.excludesFile` cannot change the answer. git is the authority the walker claims to match, so any disagreement is either a defect or a divergence that has to be documented. It independently catches the directory-probe, cascade, and rebasing behaviour; hand-written tests pin each constructor's three values and the `formatFiles` filter.

The `formatFiles` tests assert real formatted output, which needs `NODE_OPTIONS=--experimental-vm-modules` — `nx test devkit` sets it via `nx.json`, a bare `npx jest` does not, and without it nothing formats. That is recorded in a comment, and the positive assertions are what fail loudly if the flag goes missing.

### Not addressed here

`getIgnoreObject` is still root-only and still used by `format.ts`, `file-utils.ts`, and the release code. Same bug class, left for a follow-up.

## Related Issue(s)

N/A — found while implementing per-directory oxfmt config resolution.

<!-- polygraph-session-start -->
---
<p><picture><source media="(prefers-color-scheme: dark)" srcset="https://static.ops.cloud.nx.app/polygraph/session-logo-v4-dark.svg"><img src="https://static.ops.cloud.nx.app/polygraph/session-logo-v4-light.svg" width="16" height="22" align="middle" alt="Polygraph"></picture> <a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Serialize-Cypress-installs-in-macOS-e2e-cd59f4f3">View session ↗</a></p>
<!-- polygraph-session-end -->

