### PR TITLE
fix(core): update brace-expansion to 5.0.9 for CVE-2026-14257

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -355,7 +355,7 @@ overrides:
   handlebars: 4.7.9
   minimist: ^1.2.6
   underscore: ^1.13.8
-  brace-expansion: 5.0.8
+  brace-expansion: 5.0.9
   axios: 1.18.1
   minimatch: ^10.2.5
   shell-quote: ^1.8.4
@@ -16181,8 +16181,8 @@ packages:
     resolution: {integrity: sha512-apC2+fspHGI3mMKj+dGevkGo/tCqVB8jMb6i+OX+E29p0Iposz07fABkRIfVUPNd5A5VbuOz1bZbnmkKLYF+wQ==}
     engines: {node: '>= 5.10.0'}
 
-  brace-expansion@5.0.8:
-    resolution: {integrity: sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==}
+  brace-expansion@5.0.9:
+    resolution: {integrity: sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==}
     engines: {node: 20 || >=22}
 
   braces@3.0.3:
@@ -43235,7 +43235,7 @@ snapshots:
     dependencies:
       big-integer: 1.6.52
 
-  brace-expansion@5.0.8:
+  brace-expansion@5.0.9:
     dependencies:
       balanced-match: 4.0.3
 
@@ -51161,7 +51161,7 @@ snapshots:
 
   minimatch@10.2.5:
     dependencies:
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
 
   minimist@1.2.8: {}
 
@@ -52177,7 +52177,7 @@ snapshots:
       balanced-match: 4.0.3
       base64-js: 1.5.1
       bl: 4.1.0
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
       buffer: 5.7.1
       call-bind-apply-helpers: 1.0.2
       chalk: 4.1.2
@@ -52307,7 +52307,7 @@ snapshots:
       balanced-match: 4.0.3
       base64-js: 1.5.1
       bl: 4.1.0
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
       buffer: 5.7.1
       bundle-name: 4.1.0
       call-bind-apply-helpers: 1.0.2
@@ -52443,7 +52443,7 @@ snapshots:
       balanced-match: 4.0.3
       base64-js: 1.5.1
       bl: 4.1.0
-      brace-expansion: 5.0.8
+      brace-expansion: 5.0.9
       buffer: 5.7.1
       bundle-name: 4.1.0
       call-bind-apply-helpers: 1.0.2

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -20,7 +20,7 @@ overrides:
   handlebars: '4.7.9'
   minimist: '^1.2.6'
   underscore: '^1.13.8'
-  brace-expansion: '5.0.8'
+  brace-expansion: '5.0.9'
   axios: '1.18.1'
   minimatch: '^10.2.5'
   shell-quote: '^1.8.4'


### PR DESCRIPTION
## Current Behavior

The Nx monorepo currently depends on `brace-expansion` version **5.0.8** through the dependency tree. This version is affected by **CVE-2026-14257**, resulting in a known security vulnerability being reported by dependency scanners.

## Expected Behavior

Update the dependency to **`brace-expansion` 5.0.9**, which includes the security fix for **CVE-2026-14257**. This removes the reported vulnerability while preserving existing functionality and ensuring the dependency tree uses the patched version.

## Related Issue(s)

