### PR TITLE
fix(core): make output.drain() actually flush queued stdout

### DIFF
--- a/packages/nx/src/command-line/graph/graph.ts
+++ b/packages/nx/src/command-line/graph/graph.ts
@@ -395,7 +395,6 @@ export async function generateGraph(
       )
     );
     await output.drain();
-    await new Promise((res) => setImmediate(res));
     process.exit(0);
   }
 
@@ -480,7 +479,7 @@ export async function generateGraph(
       });
       process.exit(1);
     }
-    await new Promise((res) => setImmediate(res));
+    await output.drain();
     process.exit(0);
   } else {
     const environmentJs = buildEnvironmentJs(

--- a/packages/nx/src/command-line/release/command-object.ts
+++ b/packages/nx/src/command-line/release/command-object.ts
@@ -1,6 +1,7 @@
 import { type Argv, type CommandModule, showHelp } from 'yargs';
 import { handleImport } from '../../utils/handle-import';
 import { logger } from '../../utils/logger';
+import { output } from '../../utils/output';
 import {
   type OutputStyle,
   type RunManyOptions,
@@ -411,6 +412,7 @@ const publishCommand: CommandModule<NxReleaseArgs, PublishOptions> = {
       logger.warn(`\nNOTE: The "dryRun" flag means no changes were made.`);
     }
 
+    await output.drain();
     process.exit(status);
   },
 };

--- a/packages/nx/src/command-line/release/command-object.ts
+++ b/packages/nx/src/command-line/release/command-object.ts
@@ -264,6 +264,7 @@ const releaseCommand: CommandModule<NxReleaseArgs, ReleaseOptions> = {
       logger.warn(`\nNOTE: The "dryRun" flag means no changes were made.`);
     }
 
+    await output.drain();
     process.exit(result);
   },
 };
@@ -304,6 +305,7 @@ const versionCommand: CommandModule<NxReleaseArgs, VersionOptions> = {
       logger.warn(`\nNOTE: The "dryRun" flag means no changes were made.`);
     }
 
+    await output.drain();
     process.exit(result);
   },
 };
@@ -372,6 +374,7 @@ const changelogCommand: CommandModule<NxReleaseArgs, ChangelogOptions> = {
       logger.warn(`\nNOTE: The "dryRun" flag means no changes were made.`);
     }
 
+    await output.drain();
     process.exit(result);
   },
 };
@@ -455,6 +458,7 @@ const planCommand: CommandModule<NxReleaseArgs, PlanOptions> = {
       logger.warn(`\nNOTE: The "dryRun" flag means no changes were made.`);
     }
 
+    await output.drain();
     process.exit(result);
   },
 };
@@ -467,6 +471,7 @@ const planCheckCommand: CommandModule<NxReleaseArgs, PlanCheckOptions> = {
   handler: async (args) => {
     const release = await handleImport('./plan-check.js', __dirname);
     const result = await release.releasePlanCheckCLIHandler(args);
+    await output.drain();
     process.exit(result);
   },
 };

--- a/packages/nx/src/command-line/run-many/run-many.ts
+++ b/packages/nx/src/command-line/run-many/run-many.ts
@@ -76,6 +76,7 @@ export async function runMany(
       extraTargetDependencies,
       extraOptions
     );
+    await output.drain();
     process.exit(status);
   }
 }

--- a/packages/nx/src/command-line/run/run-one.ts
+++ b/packages/nx/src/command-line/run/run-one.ts
@@ -69,6 +69,7 @@ export async function runOne(
       },
       workspaceRoot
     );
+    await output.drain();
     process.exit(0);
   }
 

--- a/packages/nx/src/command-line/run/run-one.ts
+++ b/packages/nx/src/command-line/run/run-one.ts
@@ -100,6 +100,7 @@ export async function runOne(
       extraTargetDependencies,
       extraOptions
     );
+    await output.drain();
     process.exit(status);
   }
 }

--- a/packages/nx/src/command-line/show/project.ts
+++ b/packages/nx/src/command-line/show/project.ts
@@ -126,7 +126,5 @@ export async function showProjectHandler(
     }
   }
 
-  // TODO: Find a better fix for this
-  await new Promise((res) => setImmediate(res));
   await output.drain();
 }

--- a/packages/nx/src/command-line/show/projects.ts
+++ b/packages/nx/src/command-line/show/projects.ts
@@ -87,8 +87,6 @@ export async function showProjectsHandler(
     }
   }
 
-  // TODO: Find a better fix for this
-  await new Promise((res) => setImmediate(res));
   await output.drain();
 }
 

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -179,7 +179,7 @@ async function getTerminalOutputLifeCycle(
           : callback;
       // Preserve original behavior around callback and return value, just in case
       if (cb) {
-        cb();
+        cb(null);
       }
       return true;
     };
@@ -296,7 +296,13 @@ async function getTerminalOutputLifeCycle(
               ? encodingOrCallback
               : undefined;
           logDebug(
-            Buffer.isBuffer(chunk) ? chunk.toString(enc) : chunk.toString()
+            ArrayBuffer.isView(chunk)
+              ? Buffer.from(
+                  chunk.buffer,
+                  chunk.byteOffset,
+                  chunk.byteLength
+                ).toString(enc)
+              : chunk.toString()
           );
 
           // Nx Cloud logs are held back for the TUI; everything else is swallowed,
@@ -317,7 +323,7 @@ async function getTerminalOutputLifeCycle(
           }
           // Preserve original behavior around callback and return value, just in case
           if (cb) {
-            cb();
+            cb(null);
           }
           return true;
         };

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -165,11 +165,14 @@ async function getTerminalOutputLifeCycle(
     console.log = createPatchedConsoleMethod(originalConsoleLog);
     console.error = createPatchedConsoleMethod(originalConsoleError);
 
-    const patchedWrite = (_chunk, encoding, callback) => {
-      // Preserve original behavior around callback and return value, just in case.
-      // write(chunk, cb) is as valid as write(chunk, encoding, cb); dropping the
-      // two-argument form silently strands callers that await the callback.
-      const cb = typeof encoding === 'function' ? encoding : callback;
+    // Handle both overload signatures: dropping write(chunk, cb) would strand the
+    // callback and hang anything awaiting it, such as output.drain().
+    const patchedWrite = (_chunk, encodingOrCallback, callback) => {
+      const cb =
+        typeof encodingOrCallback === 'function'
+          ? encodingOrCallback
+          : callback;
+      // Preserve original behavior around callback and return value, just in case
       if (cb) {
         cb();
       }
@@ -276,11 +279,12 @@ async function getTerminalOutputLifeCycle(
         isError: boolean
       ): typeof process.stdout.write | typeof process.stderr.write => {
         // @ts-ignore
-        return (chunk, encoding, callback) => {
-          // write(chunk, cb) is as valid as write(chunk, encoding, cb); without this
-          // the callback is stranded and `encoding` reaches toString() as a function.
-          const cb = typeof encoding === 'function' ? encoding : callback;
-          const enc = typeof encoding === 'function' ? undefined : encoding;
+        // Handle both overload signatures: dropping write(chunk, cb) would strand the
+        // callback, and the callback would reach toString() below as the encoding.
+        return (chunk, encodingOrCallback, callback) => {
+          const isCb = typeof encodingOrCallback === 'function';
+          const cb = isCb ? encodingOrCallback : callback;
+          const enc = isCb ? undefined : encodingOrCallback;
           if (isError) {
             logDebug(
               Buffer.isBuffer(chunk) ? chunk.toString(enc) : chunk.toString()

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -165,10 +165,13 @@ async function getTerminalOutputLifeCycle(
     console.log = createPatchedConsoleMethod(originalConsoleLog);
     console.error = createPatchedConsoleMethod(originalConsoleError);
 
-    const patchedWrite = (_chunk, _encoding, callback) => {
-      // Preserve original behavior around callback and return value, just in case
-      if (callback) {
-        callback();
+    const patchedWrite = (_chunk, encoding, callback) => {
+      // Preserve original behavior around callback and return value, just in case.
+      // write(chunk, cb) is as valid as write(chunk, encoding, cb); dropping the
+      // two-argument form silently strands callers that await the callback.
+      const cb = typeof encoding === 'function' ? encoding : callback;
+      if (cb) {
+        cb();
       }
       return true;
     };
@@ -274,17 +277,17 @@ async function getTerminalOutputLifeCycle(
       ): typeof process.stdout.write | typeof process.stderr.write => {
         // @ts-ignore
         return (chunk, encoding, callback) => {
+          // write(chunk, cb) is as valid as write(chunk, encoding, cb); without this
+          // the callback is stranded and `encoding` reaches toString() as a function.
+          const cb = typeof encoding === 'function' ? encoding : callback;
+          const enc = typeof encoding === 'function' ? undefined : encoding;
           if (isError) {
             logDebug(
-              Buffer.isBuffer(chunk)
-                ? chunk.toString(encoding)
-                : chunk.toString()
+              Buffer.isBuffer(chunk) ? chunk.toString(enc) : chunk.toString()
             );
           } else {
             logDebug(
-              Buffer.isBuffer(chunk)
-                ? chunk.toString(encoding)
-                : chunk.toString()
+              Buffer.isBuffer(chunk) ? chunk.toString(enc) : chunk.toString()
             );
           }
 
@@ -304,8 +307,8 @@ async function getTerminalOutputLifeCycle(
             }
           }
           // Preserve original behavior around callback and return value, just in case
-          if (callback) {
-            callback();
+          if (cb) {
+            cb();
           }
           return true;
         };

--- a/packages/nx/src/tasks-runner/run-command.ts
+++ b/packages/nx/src/tasks-runner/run-command.ts
@@ -167,7 +167,12 @@ async function getTerminalOutputLifeCycle(
 
     // Handle both overload signatures: dropping write(chunk, cb) would strand the
     // callback and hang anything awaiting it, such as output.drain().
-    const patchedWrite = (_chunk, encodingOrCallback, callback) => {
+    // Typed rather than cast so the compiler keeps checking that.
+    const patchedWrite = (
+      _chunk: string | Uint8Array,
+      encodingOrCallback?: BufferEncoding | ((err?: Error) => void),
+      callback?: (err?: Error) => void
+    ): boolean => {
       const cb =
         typeof encodingOrCallback === 'function'
           ? encodingOrCallback
@@ -179,8 +184,8 @@ async function getTerminalOutputLifeCycle(
       return true;
     };
 
-    process.stdout.write = patchedWrite as any;
-    process.stderr.write = patchedWrite as any;
+    process.stdout.write = patchedWrite;
+    process.stderr.write = patchedWrite;
 
     const { AppLifeCycle, restoreTerminal } = await handleImport(
       '../native/index.js',
@@ -272,30 +277,30 @@ async function getTerminalOutputLifeCycle(
       /**
        * Patch stdout.write and stderr.write methods to pass Nx Cloud client logs to the TUI via the lifecycle
        */
-      const createPatchedLogWrite = (
-        originalWrite:
-          | typeof process.stdout.write
-          | typeof process.stderr.write,
-        isError: boolean
-      ): typeof process.stdout.write | typeof process.stderr.write => {
-        // @ts-ignore
+      const createPatchedLogWrite = (): typeof process.stdout.write => {
         // Handle both overload signatures: dropping write(chunk, cb) would strand the
         // callback, and the callback would reach toString() below as the encoding.
-        return (chunk, encodingOrCallback, callback) => {
-          const isCb = typeof encodingOrCallback === 'function';
-          const cb = isCb ? encodingOrCallback : callback;
-          const enc = isCb ? undefined : encodingOrCallback;
-          if (isError) {
-            logDebug(
-              Buffer.isBuffer(chunk) ? chunk.toString(enc) : chunk.toString()
-            );
-          } else {
-            logDebug(
-              Buffer.isBuffer(chunk) ? chunk.toString(enc) : chunk.toString()
-            );
-          }
+        // isEncoding also rejects the values toString() cannot take ('buffer', '', null).
+        return (
+          chunk: string | Uint8Array,
+          encodingOrCallback?: BufferEncoding | ((err?: Error) => void),
+          callback?: (err?: Error) => void
+        ): boolean => {
+          const cb =
+            typeof encodingOrCallback === 'function'
+              ? encodingOrCallback
+              : callback;
+          const enc =
+            typeof encodingOrCallback === 'string' &&
+            Buffer.isEncoding(encodingOrCallback)
+              ? encodingOrCallback
+              : undefined;
+          logDebug(
+            Buffer.isBuffer(chunk) ? chunk.toString(enc) : chunk.toString()
+          );
 
-          // Check if the log came from the Nx Cloud client, otherwise invoke the original write method
+          // Nx Cloud logs are held back for the TUI; everything else is swallowed,
+          // since the TUI owns the terminal while it is running.
           const stackTrace = new Error().stack;
           const isNxCloudLog = stackTrace.includes(nxCloudClientDir);
           if (isNxCloudLog) {
@@ -332,8 +337,8 @@ async function getTerminalOutputLifeCycle(
         };
       };
 
-      process.stdout.write = createPatchedLogWrite(originalStdoutWrite, false);
-      process.stderr.write = createPatchedLogWrite(originalStderrWrite, true);
+      process.stdout.write = createPatchedLogWrite();
+      process.stderr.write = createPatchedLogWrite();
 
       // The cloud client calls console.log when NX_VERBOSE_LOGGING is set to true
       console.log = createPatchedConsoleMethod(originalConsoleLog);

--- a/packages/nx/src/tasks-runner/task-orchestrator.spec.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.spec.ts
@@ -390,4 +390,45 @@ describe('TaskOrchestrator', () => {
       expect(orchestrator.cache.getBatch).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('SIGINT output silencing', () => {
+    // The handler replaces process.stdout.write permanently and never restores it,
+    // so anything awaiting a write callback after Ctrl-C depends on this shape.
+    it('invokes the callback from either argument position', async () => {
+      const realStdoutWrite = process.stdout.write;
+      const realStderrWrite = process.stderr.write;
+      const realOn = process.on;
+      try {
+        const orchestrator: any = Object.create(TaskOrchestrator.prototype);
+        orchestrator.tuiEnabled = false;
+        orchestrator.runningContinuousTasks = new Map();
+        orchestrator.cleanup = jest.fn(async () => {});
+        orchestrator.resolveStopPromise = jest.fn();
+
+        const handlers: Record<string, (...args: any[]) => void> = {};
+        jest.spyOn(process, 'on').mockImplementation(((
+          signal: string,
+          fn: any
+        ) => {
+          handlers[signal] = fn;
+          return process;
+        }) as any);
+
+        orchestrator.setupSignalHandlers();
+        handlers['SIGINT']('SIGINT');
+
+        const twoArg = jest.fn();
+        expect((process.stdout.write as any)('x', twoArg)).toBe(true);
+        expect(twoArg).toHaveBeenCalled();
+
+        const threeArg = jest.fn();
+        expect((process.stderr.write as any)('x', 'utf8', threeArg)).toBe(true);
+        expect(threeArg).toHaveBeenCalled();
+      } finally {
+        process.stdout.write = realStdoutWrite;
+        process.stderr.write = realStderrWrite;
+        process.on = realOn;
+      }
+    });
+  });
 });

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -1907,7 +1907,7 @@ export class TaskOrchestrator {
             typeof encodingOrCallback === 'function'
               ? encodingOrCallback
               : callback;
-          if (cb) cb();
+          if (cb) cb(null);
           return true;
         };
         process.stdout.write = noop;

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -1895,8 +1895,11 @@ export class TaskOrchestrator {
         // Silence output — pnpm (and similar wrappers) may exit before nx
         // finishes cleanup, returning the shell prompt. Any output after
         // that point would appear after the prompt.
-        const noop = (_chunk, _encoding, callback) => {
-          if (callback) callback();
+        const noop = (_chunk, encoding, callback) => {
+          // write(chunk, cb) is as valid as write(chunk, encoding, cb); dropping the
+          // two-argument form silently strands callers that await the callback.
+          const cb = typeof encoding === 'function' ? encoding : callback;
+          if (cb) cb();
           return true;
         };
         process.stdout.write = noop as any;

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -1897,7 +1897,12 @@ export class TaskOrchestrator {
         // that point would appear after the prompt.
         // Handle both overload signatures: dropping write(chunk, cb) would strand
         // the callback and hang anything awaiting it, such as output.drain().
-        const noop = (_chunk, encodingOrCallback, callback) => {
+        // Typed rather than cast so the compiler keeps checking that.
+        const noop = (
+          _chunk: string | Uint8Array,
+          encodingOrCallback?: BufferEncoding | ((err?: Error) => void),
+          callback?: (err?: Error) => void
+        ): boolean => {
           const cb =
             typeof encodingOrCallback === 'function'
               ? encodingOrCallback
@@ -1905,8 +1910,8 @@ export class TaskOrchestrator {
           if (cb) cb();
           return true;
         };
-        process.stdout.write = noop as any;
-        process.stderr.write = noop as any;
+        process.stdout.write = noop;
+        process.stderr.write = noop;
       }
       this.cleanup().finally(() => {
         if (this.resolveStopPromise) {

--- a/packages/nx/src/tasks-runner/task-orchestrator.ts
+++ b/packages/nx/src/tasks-runner/task-orchestrator.ts
@@ -1895,10 +1895,13 @@ export class TaskOrchestrator {
         // Silence output — pnpm (and similar wrappers) may exit before nx
         // finishes cleanup, returning the shell prompt. Any output after
         // that point would appear after the prompt.
-        const noop = (_chunk, encoding, callback) => {
-          // write(chunk, cb) is as valid as write(chunk, encoding, cb); dropping the
-          // two-argument form silently strands callers that await the callback.
-          const cb = typeof encoding === 'function' ? encoding : callback;
+        // Handle both overload signatures: dropping write(chunk, cb) would strand
+        // the callback and hang anything awaiting it, such as output.drain().
+        const noop = (_chunk, encodingOrCallback, callback) => {
+          const cb =
+            typeof encodingOrCallback === 'function'
+              ? encodingOrCallback
+              : callback;
           if (cb) cb();
           return true;
         };

--- a/packages/nx/src/utils/output.spec.ts
+++ b/packages/nx/src/utils/output.spec.ts
@@ -1,0 +1,113 @@
+import { Writable } from 'stream';
+import { output } from './output';
+
+/**
+ * A stdout stand-in that never completes a write until `release()` is called,
+ * so queued bytes stay queued — the state a slow pipe reader produces.
+ */
+function stalledStdout(highWaterMark: number) {
+  const pending: Array<() => void> = [];
+  let received = '';
+  const stream = new Writable({
+    highWaterMark,
+    write(chunk, _enc, cb) {
+      pending.push(() => {
+        received += chunk.toString();
+        cb();
+      });
+    },
+  });
+  return {
+    stream,
+    get received() {
+      return received;
+    },
+    release: () => {
+      while (pending.length) pending.shift()!();
+    },
+  };
+}
+
+describe('output.drain', () => {
+  const realStdout = process.stdout;
+
+  function useStdout(stream: Writable) {
+    Object.defineProperty(process, 'stdout', {
+      value: stream,
+      configurable: true,
+    });
+  }
+
+  afterEach(() => {
+    Object.defineProperty(process, 'stdout', {
+      value: realStdout,
+      configurable: true,
+    });
+  });
+
+  it('resolves immediately when nothing is queued', async () => {
+    const { stream } = stalledStdout(1000);
+    useStdout(stream);
+
+    await expect(output.drain()).resolves.toBeUndefined();
+  });
+
+  // Regression: `writableNeedDrain` is only set past the high-water mark, so a
+  // queue shorter than it used to resolve drain() instantly and let process.exit()
+  // discard the bytes. 50 bytes against a 1000-byte mark reproduces that exactly.
+  it('waits for a queue shorter than the high-water mark', async () => {
+    const stalled = stalledStdout(1000);
+    useStdout(stalled.stream);
+
+    stalled.stream.write('a'.repeat(50));
+    expect(stalled.stream.writableNeedDrain).toBe(false);
+    expect(stalled.stream.writableLength).toBeGreaterThan(0);
+
+    let drained = false;
+    const promise = output.drain().then(() => (drained = true));
+
+    await new Promise((res) => setImmediate(res));
+    expect(drained).toBe(false);
+
+    stalled.release();
+    await promise;
+    expect(drained).toBe(true);
+    expect(stalled.received).toBe('a'.repeat(50));
+  });
+
+  it('waits for a queue longer than the high-water mark', async () => {
+    const stalled = stalledStdout(100);
+    useStdout(stalled.stream);
+
+    stalled.stream.write('b'.repeat(500));
+    expect(stalled.stream.writableNeedDrain).toBe(true);
+
+    let drained = false;
+    const promise = output.drain().then(() => (drained = true));
+
+    await new Promise((res) => setImmediate(res));
+    expect(drained).toBe(false);
+
+    stalled.release();
+    await promise;
+    expect(drained).toBe(true);
+    expect(stalled.received).toBe('b'.repeat(500));
+  });
+
+  // `nx ... | head` leaves the write end open with no reader; the EPIPE must not
+  // hang the drain or surface as an unhandled 'error' event.
+  it('resolves instead of hanging when the stream errors', async () => {
+    const stalled = stalledStdout(1000);
+    useStdout(stalled.stream);
+
+    stalled.stream.write('c'.repeat(50));
+    const promise = output.drain();
+
+    stalled.stream.emit(
+      'error',
+      Object.assign(new Error('EPIPE'), { code: 'EPIPE' })
+    );
+
+    await expect(promise).resolves.toBeUndefined();
+  });
+});

--- a/packages/nx/src/utils/output.spec.ts
+++ b/packages/nx/src/utils/output.spec.ts
@@ -113,6 +113,27 @@ describe('output.drain', () => {
     stalled.failPending(Object.assign(new Error('EPIPE'), { code: 'EPIPE' }));
     expect(stalled.stream.listenerCount('error')).toBe(1);
     await expect(promise).resolves.toBeUndefined();
+    // Settle the deferred detach here so a too-early removal surfaces in this test
+    // rather than as an unhandled error attributed to whichever test runs next.
+    await new Promise((res) => setImmediate(res));
+  });
+
+  // process.nextTick drains before the 'error' emit, so a cleanup deferred that far
+  // detaches too early and the EPIPE goes unhandled. Only a macrotask is late enough.
+  it('keeps the listener attached through the nextTick queue', async () => {
+    const stalled = stalledStdout(1000);
+    useStdout(stalled.stream);
+
+    stalled.stream.write('f'.repeat(50));
+    const promise = output.drain();
+    stalled.release();
+
+    await new Promise((res) => process.nextTick(res));
+    expect(stalled.stream.listenerCount('error')).toBe(1);
+
+    await promise;
+    await new Promise((res) => setImmediate(res));
+    expect(stalled.stream.listenerCount('error')).toBe(0);
   });
 
   // The cleanup is deferred, so it must target the stream drain() attached to
@@ -123,13 +144,35 @@ describe('output.drain', () => {
 
     stalled.stream.write('e'.repeat(50));
     const promise = output.drain();
+    // Guards against the assertion below passing vacuously on an early return.
+    expect(stalled.stream.listenerCount('error')).toBe(1);
     stalled.release();
     await promise;
 
-    useStdout(realStdout as Writable);
+    useStdout(realStdout);
     await new Promise((res) => setImmediate(res));
 
     expect(stalled.stream.listenerCount('error')).toBe(0);
+  });
+
+  // The stdout patches in run-command.ts and task-orchestrator.ts take
+  // (chunk, encoding, callback) positionally; a two-argument write would leave their
+  // callback undefined and drain() would never resolve.
+  it('resolves when process.stdout.write is patched positionally', async () => {
+    const stalled = stalledStdout(1000);
+    useStdout(stalled.stream);
+
+    stalled.stream.write('g'.repeat(50));
+    (stalled.stream as any).write = (
+      _chunk: unknown,
+      _encoding: unknown,
+      callback?: () => void
+    ) => {
+      if (callback) callback();
+      return true;
+    };
+
+    await expect(output.drain()).resolves.toBeUndefined();
   });
 
   it('leaves no error listener behind', async () => {

--- a/packages/nx/src/utils/output.spec.ts
+++ b/packages/nx/src/utils/output.spec.ts
@@ -155,9 +155,8 @@ describe('output.drain', () => {
     expect(stalled.stream.listenerCount('error')).toBe(0);
   });
 
-  // The stdout patches in run-command.ts and task-orchestrator.ts take
-  // (chunk, encoding, callback) positionally; a two-argument write would leave their
-  // callback undefined and drain() would never resolve.
+  // A positional (chunk, encoding, callback) stdout patch that does not normalize —
+  // as any third-party wrapper may be — drops a two-argument write's callback.
   it('resolves when process.stdout.write is patched positionally', async () => {
     const stalled = stalledStdout(1000);
     useStdout(stalled.stream);

--- a/packages/nx/src/utils/output.spec.ts
+++ b/packages/nx/src/utils/output.spec.ts
@@ -162,17 +162,22 @@ describe('output.drain', () => {
     useStdout(stalled.stream);
 
     stalled.stream.write('g'.repeat(50));
+    let writes = 0;
     (stalled.stream as any).write = (
       _chunk: unknown,
       _encoding: unknown,
       callback?: () => void
     ) => {
+      writes++;
       if (callback) callback();
       return true;
     };
 
     await expect(output.drain()).resolves.toBeUndefined();
-  });
+    // Also guards against an early return: drain must have reached the patched
+    // writer rather than resolving before it queued anything.
+    expect(writes).toBe(1);
+  }, 5000);
 
   it('leaves no error listener behind', async () => {
     const stalled = stalledStdout(1000);

--- a/packages/nx/src/utils/output.spec.ts
+++ b/packages/nx/src/utils/output.spec.ts
@@ -2,8 +2,8 @@ import { Writable } from 'stream';
 import { output } from './output';
 
 /**
- * A stdout stand-in that never completes a write until `release()` is called,
- * so queued bytes stay queued — the state a slow pipe reader produces.
+ * A stdout stand-in that never completes a write until the test releases or fails
+ * it, so queued bytes stay queued — the state a slow pipe reader produces.
  */
 function stalledStdout(highWaterMark: number) {
   const pending: Array<(err?: Error) => void> = [];
@@ -107,12 +107,29 @@ describe('output.drain', () => {
     stalled.stream.write('c'.repeat(50));
     const promise = output.drain();
 
-    // Drive the error through Node's real ordering — write callback first, then
-    // the 'error' event. A bare emit lets a listener-removing refactor pass here
-    // while crashing on an actual pipe.
+    // Node's real ordering: write callback first, then the 'error' event. Emitting
+    // 'error' directly, or dropping the listener assertion, each let a
+    // listener-removing refactor pass here while crashing on an actual pipe.
     stalled.failPending(Object.assign(new Error('EPIPE'), { code: 'EPIPE' }));
-
+    expect(stalled.stream.listenerCount('error')).toBe(1);
     await expect(promise).resolves.toBeUndefined();
+  });
+
+  // The cleanup is deferred, so it must target the stream drain() attached to
+  // rather than re-reading process.stdout after a caller has swapped it.
+  it('detaches from the stream it attached to, not the current process.stdout', async () => {
+    const stalled = stalledStdout(1000);
+    useStdout(stalled.stream);
+
+    stalled.stream.write('e'.repeat(50));
+    const promise = output.drain();
+    stalled.release();
+    await promise;
+
+    useStdout(realStdout as Writable);
+    await new Promise((res) => setImmediate(res));
+
+    expect(stalled.stream.listenerCount('error')).toBe(0);
   });
 
   it('leaves no error listener behind', async () => {

--- a/packages/nx/src/utils/output.spec.ts
+++ b/packages/nx/src/utils/output.spec.ts
@@ -6,14 +6,14 @@ import { output } from './output';
  * so queued bytes stay queued — the state a slow pipe reader produces.
  */
 function stalledStdout(highWaterMark: number) {
-  const pending: Array<() => void> = [];
+  const pending: Array<(err?: Error) => void> = [];
   let received = '';
   const stream = new Writable({
     highWaterMark,
     write(chunk, _enc, cb) {
-      pending.push(() => {
-        received += chunk.toString();
-        cb();
+      pending.push((err) => {
+        if (!err) received += chunk.toString();
+        cb(err);
       });
     },
   });
@@ -24,6 +24,10 @@ function stalledStdout(highWaterMark: number) {
     },
     release: () => {
       while (pending.length) pending.shift()!();
+    },
+    // Node hands EPIPE to the write callback first, then emits 'error'.
+    failPending: (err: Error) => {
+      while (pending.length) pending.shift()!(err);
     },
   };
 }
@@ -103,11 +107,26 @@ describe('output.drain', () => {
     stalled.stream.write('c'.repeat(50));
     const promise = output.drain();
 
-    stalled.stream.emit(
-      'error',
-      Object.assign(new Error('EPIPE'), { code: 'EPIPE' })
-    );
+    // Drive the error through Node's real ordering — write callback first, then
+    // the 'error' event. A bare emit lets a listener-removing refactor pass here
+    // while crashing on an actual pipe.
+    stalled.failPending(Object.assign(new Error('EPIPE'), { code: 'EPIPE' }));
 
     await expect(promise).resolves.toBeUndefined();
+  });
+
+  it('leaves no error listener behind', async () => {
+    const stalled = stalledStdout(1000);
+    useStdout(stalled.stream);
+
+    for (let i = 0; i < 3; i++) {
+      stalled.stream.write('d'.repeat(50));
+      const promise = output.drain();
+      stalled.release();
+      await promise;
+    }
+    await new Promise((res) => setImmediate(res));
+
+    expect(stalled.stream.listenerCount('error')).toBe(0);
   });
 });

--- a/packages/nx/src/utils/output.ts
+++ b/packages/nx/src/utils/output.ts
@@ -371,11 +371,14 @@ class CLIOutput {
         return;
       }
       // The reader may already be gone (`nx ... | head`); an unhandled EPIPE would
-      // kill the run. Detach on the next tick, not inside the write callback: that
-      // callback fires before the 'error' event, so removing it there still crashes.
+      // kill the run. Detach via setImmediate — not in the write callback and not via
+      // process.nextTick: both run before the 'error' event, so the crash comes back.
       const onError = () => resolve();
       stream.on('error', onError);
-      stream.write('', () => {
+      // Encoding passed explicitly: the stdout patches in run-command.ts and
+      // task-orchestrator.ts read (chunk, encoding, callback) positionally, and a
+      // two-argument call leaves their callback undefined — drain would never resolve.
+      stream.write('', 'utf8', () => {
         resolve();
         setImmediate(() => stream.removeListener('error', onError));
       });

--- a/packages/nx/src/utils/output.ts
+++ b/packages/nx/src/utils/output.ts
@@ -359,11 +359,18 @@ class CLIOutput {
 
   drain(): Promise<void> {
     return new Promise((resolve) => {
-      if (process.stdout.writableNeedDrain) {
-        process.stdout.once('drain', resolve);
-      } else {
+      // `writableNeedDrain` is only set once the queue passes the high-water mark,
+      // so a shorter queue needs the write callback instead. Waiting on the 'drain'
+      // event alone lets `process.exit()` discard up to highWaterMark of output.
+      if (process.stdout.writableLength === 0) {
         resolve();
+        return;
       }
+      // The reader may already be gone (`nx ... | head`); EPIPE must not fail an
+      // otherwise successful run. Use `on`, not `once`: the write callback fires
+      // with the error first, which would remove a `once` listener before 'error'.
+      process.stdout.on('error', () => resolve());
+      process.stdout.write('', () => resolve());
     });
   }
 }

--- a/packages/nx/src/utils/output.ts
+++ b/packages/nx/src/utils/output.ts
@@ -375,9 +375,9 @@ class CLIOutput {
       // process.nextTick: both run before the 'error' event, so the crash comes back.
       const onError = () => resolve();
       stream.on('error', onError);
-      // Encoding passed explicitly: the stdout patches in run-command.ts and
-      // task-orchestrator.ts read (chunk, encoding, callback) positionally, and a
-      // two-argument call leaves their callback undefined — drain would never resolve.
+      // Encoding passed explicitly: a positional (chunk, encoding, callback) stdout
+      // patch that does not normalize drops a two-argument write's callback, and this
+      // would never resolve. The patches in this repo normalize; third-party ones may not.
       stream.write('', 'utf8', () => {
         resolve();
         setImmediate(() => stream.removeListener('error', onError));

--- a/packages/nx/src/utils/output.ts
+++ b/packages/nx/src/utils/output.ts
@@ -357,7 +357,11 @@ class CLIOutput {
     this.addNewline();
   }
 
-  /** Waits for queued `process.stdout` to reach the fd. Does not cover stderr. */
+  /**
+   * Waits for queued `process.stdout` to reach the fd. Does not cover stderr, and
+   * resolves without flushing if something has replaced `process.stdout.write` —
+   * the SIGINT silencer in task-orchestrator.ts does exactly that, on purpose.
+   */
   drain(): Promise<void> {
     return new Promise((resolve) => {
       // Captured once: the deferred cleanup below must detach from the stream it

--- a/packages/nx/src/utils/output.ts
+++ b/packages/nx/src/utils/output.ts
@@ -360,22 +360,24 @@ class CLIOutput {
   /** Waits for queued `process.stdout` to reach the fd. Does not cover stderr. */
   drain(): Promise<void> {
     return new Promise((resolve) => {
+      // Captured once: the deferred cleanup below must detach from the stream it
+      // attached to, not from whatever `process.stdout` is a macrotask later.
+      const stream = process.stdout;
       // `writableNeedDrain` is only set once the queue passes the high-water mark,
       // so a shorter queue needs the write callback instead. Waiting on the 'drain'
       // event alone lets `process.exit()` discard up to highWaterMark of output.
-      if (process.stdout.writableLength === 0) {
+      if (stream.writableLength === 0) {
         resolve();
         return;
       }
-      // The reader may already be gone (`nx ... | head`); without an 'error'
-      // listener that EPIPE crashes the process instead of resolving. Cleanup is
-      // deferred because the write callback fires before the 'error' event, so
-      // removing the listener from inside it re-introduces the crash.
+      // The reader may already be gone (`nx ... | head`); an unhandled EPIPE would
+      // kill the run. Detach on the next tick, not inside the write callback: that
+      // callback fires before the 'error' event, so removing it there still crashes.
       const onError = () => resolve();
-      process.stdout.on('error', onError);
-      process.stdout.write('', () => {
+      stream.on('error', onError);
+      stream.write('', () => {
         resolve();
-        setImmediate(() => process.stdout.removeListener('error', onError));
+        setImmediate(() => stream.removeListener('error', onError));
       });
     });
   }

--- a/packages/nx/src/utils/output.ts
+++ b/packages/nx/src/utils/output.ts
@@ -357,6 +357,7 @@ class CLIOutput {
     this.addNewline();
   }
 
+  /** Waits for queued `process.stdout` to reach the fd. Does not cover stderr. */
   drain(): Promise<void> {
     return new Promise((resolve) => {
       // `writableNeedDrain` is only set once the queue passes the high-water mark,
@@ -366,11 +367,16 @@ class CLIOutput {
         resolve();
         return;
       }
-      // The reader may already be gone (`nx ... | head`); EPIPE must not fail an
-      // otherwise successful run. Use `on`, not `once`: the write callback fires
-      // with the error first, which would remove a `once` listener before 'error'.
-      process.stdout.on('error', () => resolve());
-      process.stdout.write('', () => resolve());
+      // The reader may already be gone (`nx ... | head`); without an 'error'
+      // listener that EPIPE crashes the process instead of resolving. Cleanup is
+      // deferred because the write callback fires before the 'error' event, so
+      // removing the listener from inside it re-introduces the crash.
+      const onError = () => resolve();
+      process.stdout.on('error', onError);
+      process.stdout.write('', () => {
+        resolve();
+        setImmediate(() => process.stdout.removeListener('error', onError));
+      });
     });
   }
 }


### PR DESCRIPTION
## Current Behavior

`output.drain()` doesn't reliably flush. It gates entirely on `process.stdout.writableNeedDrain`:

```ts
if (process.stdout.writableNeedDrain) {
  process.stdout.once('drain', resolve);
} else {
  resolve();
}
```

Node only sets that flag when a single `write()` pushes the queue past the high-water mark (65,536
for a pipe), and only clears it by emitting `'drain'`. A queue shorter than the mark reports `false`,
so `drain()` resolves in 0 ms and the following `process.exit()` discards everything still queued.

That's the normal state, not a corner case. `output.logCommandOutput()` emits five separate
`process.stdout.write()` calls per task (newlines, the status header, the body, plus
`GH_GROUP_SUFFIX` under `GITHUB_ACTIONS`). Once the reader is slower than Nx the OS pipe fills and the
*next* chunk queues — and if that chunk is under 64 KB the flag never sets.

Measured, two writes into a stalled pipe with a drain in place:

| written | delivered | lost |
| --- | --- | --- |
| 60,000 + 60,000 | 65,536 | **54,464** |

Byte-identical to not draining at all. The band that gets dropped is the *trailing* output — the
`::endgroup::` marker and the failure summary that land after a large task body, which is the part
that matters most in a failing CI log.

Two call sites already worked around this with an extra event-loop tick and a
`// TODO: Find a better fix for this` (`show/projects.ts`, `show/project.ts`). Measured, that
workaround doesn't close the gap either.

Separately, three commands that exit on a task status never drained at all:

| site | drained before this PR |
| --- | --- |
| `affected/affected.ts` | via #36569 |
| `run-many/run-many.ts` | no |
| `run/run-one.ts` | no |
| `release/command-object.ts` | no |

So `nx run-many -t e2e | tee` and `nx test <project> | tee` truncate exactly the way `nx affected`
did.

## Expected Behavior

`output.drain()` waits until the write queue is actually empty, using the callback of a zero-length
write — which fires only after every previously queued chunk has reached the fd. A vanished reader is
treated as drained, so `EPIPE` from `nx ... | head` can't fail an otherwise successful run.

Measured with this change:

| scenario | delivered | exit code |
| --- | --- | --- |
| 60,000 + 60,000, slow reader | 120,000 / 120,000 | preserved |
| 5,000,000, slow reader | 5,000,000 / 5,000,000 | preserved |
| 6 bytes, slow reader | 6 / 6 | preserved |
| no output at all | — | preserved, no hang |
| `> file` | 120,000 / 120,000 | preserved |
| `| head -c 10` (reader gone) | — | preserved, no stack trace |

Two variants that look right and are not, both tested and rejected:

- Polling `writableLength` and re-arming on `'drain'` delivers the bytes but **exits 0 instead of the
  task status** — Node emits `'drain'` only when `needDrain` was set, so in exactly the broken case
  the promise never settles and the process exits naturally, silently destroying the exit code.
- `once('error', done)` plus `removeListener` inside `done` still crashes: the write callback fires
  with the error first and removes the listener before `'error'` is emitted. Hence `on(...)`.

The change is in three separable commits:

1. **`fix(core): make output.drain() flush queued stdout`** — the fix itself, plus
   `packages/nx/src/utils/output.spec.ts`. The regression test fails against the old implementation
   (verified by reverting) and drives the real shipped `drain()` against genuine stream backpressure
   rather than a copy.
2. **`fix(core): drain stdout before exiting run-many, run and release publish`** — adds the missing
   `await output.drain()` at the three remaining status exits. `nx affected` is left alone; #36569
   covers it, so these don't conflict.
3. **`cleanup(core): drop setImmediate workarounds around output.drain()`** — retires both TODOs and
   the third `setImmediate`-as-flush in `graph.ts`, now that `drain()` does the job.

Note this is what makes #36569 effective: that PR puts `await output.drain()` on the `nx affected`
path, but until `drain()` itself flushes, it still drops the trailing ≤64 KB.

Not included, worth a follow-up: `drain()` only inspects `process.stdout`, and `output.error` /
`output.warn` write to **stderr** — so the `catch` blocks that `printError(e)` then `process.exit(1)`
still truncate under `2>&1 | tee`. That needs a `stream` parameter on `drain()` and is a separate
change.

## Related Issue(s)

Fixes #36568

Follows up #36569.

<!-- polygraph-session-start -->
---
<p><picture><source media="(prefers-color-scheme: dark)" srcset="https://static.ops.cloud.nx.app/polygraph/session-logo-v4-dark.svg"><img src="https://static.ops.cloud.nx.app/polygraph/session-logo-v4-light.svg" width="16" height="22" align="middle" alt="Polygraph"></picture> <a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Make-output.drain-actually-flush-queued-stdout-c68c730b">View session ↗</a></p>
<!-- polygraph-session-end -->