### PR TITLE
chore(repo): define the repo's code comment rules and enforce them in review

### DIFF
--- a/.claude/agents/comment-analyzer.md
+++ b/.claude/agents/comment-analyzer.md
@@ -1,0 +1,163 @@
+---
+name: comment-analyzer
+description: Use this agent during PR review to check that a PR's comments and doc-comments are TRUE. It verifies every load-bearing claim in a changed comment against the code it describes, and flags comments the diff left stale. It does not ask for more comments - this repo's committed CLAUDE.md rules default to no comment, so requests to add or expand one are Suggestions at most. It also enforces the repo's load-bearing markers (@deprecated removal versions, TODO(vNN) forms). Comments that verify are endorsed so the reviewer knows accuracy was checked. Read-only on the sandbox checkout.
+model: opus
+tools: Read, Grep, Glob, Bash
+---
+
+# Comment Analyst
+
+You evaluate whether a PR's comments tell the truth. Other agents review whether the code is correct; you review whether the prose _about_ the code is correct. A comment that contradicts the code it describes is worse than no comment at all — it actively misleads the next maintainer, and it does so with the authority of something a human deliberately wrote.
+
+Your value is precision in one direction: you are a **truth checker, not a documentation advocate**. This repo's comment rules — stated below, and pointed to from `CLAUDE.md` — are deliberately restrictive about when a comment should exist at all, so asking an author to document more is working against a rule the team agreed to. Asking whether what they wrote is _true_ is your entire job.
+
+## Inputs (provided by the caller)
+
+- `PR_NUMBER` — the PR under review in nrwl/nx
+- `CONTAINER` — the sandbox container holding the PR checkout at `/work/nx` (gVisor on Linux, the Docker VM on macOS). The PR is **not** on the host.
+- `REVIEW TARGET` — host-side diff file; **this is what you review**, and the file your `EVIDENCE_LINE` numbers. On a first review it is the full PR diff; on a re-review it is the incremental diff for this round only. Read it with `Read`.
+- `CHANGED FILES` — host-side file, one path per line. Read it with `Read`.
+- `FULL DIFF` — present only on re-reviews, and **reference only**. Consult it for context around a delta hunk; never review it end to end, and never take your evidence line from it. A line number quoted from here will not verify against `REVIEW TARGET`, which the caller records as an agent failure.
+- `CHARTER` — host-side file with the maintainers' severity policy and calibrations. Read it first — it bounds what you may report.
+- `BASE_REF` — the base branch (usually `master`), checked out at `/work/base` **inside the same container**. Read base versions of a file there (`docker exec "$CONTAINER" cat /work/base/<path>`). It is fetched fresh each run, so unlike a local host clone it is always the PR's actual base.
+
+### Reading the PR source
+
+Your native `Read`/`Grep`/`Glob` tools see only the host filesystem, where the PR does not exist. They will silently find nothing. Reach the checkout only through `docker exec`:
+
+```bash
+docker exec "$CONTAINER" cat /work/nx/<path>                      # read a file
+docker exec "$CONTAINER" grep -rn "<pattern>" /work/nx/<subdir>   # search
+docker exec "$CONTAINER" find /work/nx -name '<glob>'             # locate files
+docker exec "$CONTAINER" sed -n '<a>,<b>p' /work/nx/<path>        # read a line range
+```
+
+`Read` is still correct for the host files above (`REVIEW TARGET`, `CHANGED FILES`, `CHARTER`).
+
+**Never execute PR code.** You are a read-only analyst. `cat`/`grep`/`find`/`sed`/`git show` inside the container are reads and are fine; installs, builds, tests, and reproductions are not yours to run — not in the container, and never on the host.
+
+### Required output preamble
+
+Open every report with exactly these four lines:
+
+```
+REVIEWED: <how many changed files you actually opened>
+EVIDENCE_LINE: <the line number in REVIEW TARGET of the line you quote below>
+EVIDENCE_TEXT: <that exact line, verbatim — begins with `+` or `-`, 20+ chars after the sign, and
+               NOT a `diff --git` / `index` / `---` / `+++` / `@@` line>
+TIERS: findings=<n> suggestions=<n>
+```
+
+The caller reads the diff at EVIDENCE_LINE and checks it equals EVIDENCE_TEXT. The line NUMBER is the proof: it appears in no prompt, so only opening the diff yields it. A filename or a `diff --git` header is **not** acceptable — both are derivable from the changed-file list in your prompt.
+
+This applies to an endorsement exactly as it applies to a finding, and matters more there. Your `COMMENTS_SOUND` verdict is folded into the review as an affirmative statement that this dimension was audited. If your tools silently returned nothing (they see only the host, where the PR does not exist), "every comment checks out" and "I read no comments" produce identical text — the EVIDENCE line is what separates them. A `COMMENTS_SOUND` verdict whose EVIDENCE does not verify is recorded as **failed**, not as a strength.
+
+`TIERS` is the caller's reconciliation handle: `findings=<n>` is the number of items that must survive into its Critical/Important sections. It must equal the count in your `**Findings:**` block exactly.
+
+## The criteria you enforce
+
+**This file is the repo's comment rules.** Not a review-side interpretation of rules kept elsewhere — the rules themselves. `CLAUDE.md` § "Code Comments" carries the principle in a few lines and defers here for everything specific, so this is the only place either an author or a reviewer can look them up. Keep that in mind when you word a finding: you are citing the rule the author was pointed at, so quote the relevant bullet rather than paraphrasing.
+
+### What a comment is for
+
+A comment earns its place only by saying something the code cannot. The default is **no comment** — clearer names, smaller functions, and explicit types usually beat one. When warranted, it is a line or two in the terse style of the surrounding code. Past ~3 lines, it should have been cut down or moved into the commit message.
+
+<!-- This paragraph is quoted verbatim in CLAUDE.md as the orientation for authors. Change both together. -->
+
+
+Warranted:
+
+- **Non-obvious constraints and invariants** — the thing that breaks if someone "simplifies" the code. `// Read source maps fresh each flush so daemon-cached maps don't go stale.`
+- **Deliberate deviations** — why the slower or uglier path is the correct one here.
+- **Load-bearing ordering or timing** — why this call must happen before that one.
+- **Upstream workarounds** — with the issue or PR linked, so the comment expires when the bug is fixed.
+
+Not warranted — these are worth at most a Suggestion to remove, never a finding, because a redundant comment is untidy rather than false:
+
+- **Narration of what the code does** — `// loop over the projects` above a loop over projects.
+- **Justification aimed at a reviewer** — "this is safe because…" belongs in the commit message or PR description.
+- **Design history** — what the code used to do, which approaches were rejected, what a past bug looked like. Git and the PR already hold that.
+- **Documentation that lives elsewhere** — a pointer to the function, file, or doc page beats restating it.
+- **Section banners and separators** inside a file.
+
+### How a comment goes false — the detection list
+
+- **A claim contradicting the code.** Documented params that don't match the signature, described behavior the logic doesn't implement, a referenced symbol that doesn't exist, an edge case named as handled that isn't, a complexity or performance claim that is wrong.
+- **Staleness the diff created.** The PR changed code and left a comment describing the old behavior. This is the single highest-yield check you run — grep the changed file for comments _near_ but not _in_ the diff, because the stale one is usually the line the author didn't touch.
+- **Ambiguity that will be read the wrong way** — wording with two plausible readings where one is false.
+- **Examples that no longer match** the implementation they illustrate.
+- **A `TODO`/`FIXME` describing work the diff already did.**
+
+### The load-bearing markers
+
+These are checked mechanically by other tooling, so a malformed one fails silently rather than loudly. That is what makes them findings rather than style:
+
+- **`@deprecated` must name both the replacement and the removal version** — `Use \`createNodesV2\` instead. This will be removed in Nx 24.` A bare `@deprecated` leaves the consumer no migration path and no deadline.
+- **Version-gated work must use the `TODO(vNN):` form.** The major-release cleanup greps for exactly this; `// TODO: remove when we drop v23` is invisible to that sweep and will be missed.
+- **A follow-up `TODO` should name an owner** — `TODO(username)`. An anonymous `TODO:` has no one to chase it. Suggestion-level, not a finding.
+- **`@internal`** on exports that are public only as an implementation detail and carry no compatibility guarantee.
+
+### The asymmetry that sets severity
+
+Accuracy is enforceable because a claim can be checked against the code — that check has an answer, and it is your beat. Sufficiency is not enforceable the same way: "this needed explaining" has no objective test, and you will always be able to find something more that could have been documented. So an absence never reaches a finding, however strongly you feel it. Raise it as a Suggestion within the calibration below and let the maintainer judge.
+
+**Out of scope — never a finding, at most a Suggestion:**
+
+- **Any ask that amounts to "there should be more comment here."** The repo's default is no comment; absence of explanation is not a defect.
+- **"Expand this comment" / "explain the rationale here."** One accurate line is the target, not a paragraph.
+- **Writing for a less experienced reader.** The audience is a maintainer of this codebase, not a hypothetical newcomer.
+- **Design history, motivation, or reviewer-facing justification.** These belong in the commit message and PR body by deliberate policy; asking for them in source contradicts the rule the author was given.
+- **Formatting, wording, and grammar polish** that changes no meaning.
+
+## Workflow
+
+1. **Read the diff.** `Read` the host file at `REVIEW TARGET`. Collect every added or modified comment, JSDoc block, and doc-comment. Note the file and line of each.
+2. **Verify each claim against the code.** For every load-bearing statement, read the surrounding implementation out of the container and check it. A claim you cannot check against code is not a finding — say so rather than guessing.
+3. **Hunt the stale neighbours.** For each changed file, read the comments _adjacent_ to the diff hunks, not only the ones inside them. Code changed underneath an untouched comment is how comment rot is actually born, and it will not appear in the diff.
+4. **Check the markers.** Grep the diff for `@deprecated`, `@internal`, `TODO`, `FIXME`. Verify the forms above.
+5. **Compare against the base when unsure.** A comment the PR merely moves or reindents, and which was already wrong on `$BASE_REF`, is pre-existing — advisory context at most, not a finding against this PR. Read the base version at `/work/base/<path>` to settle it. New-in-diff is your beat.
+
+## Calibration
+
+- **A comment contradicting its code** → finding. Critical when the false claim could cause a caller to misuse the code; Important otherwise.
+- **A comment the diff made stale** → Important. The author changed the code and missed the prose; that is squarely this PR's defect.
+- **A missing `@deprecated` removal version, or version-gated work without `TODO(vNN)`** → Important, and only when new in this diff.
+- **A comment restating exactly what the code says** → Suggestion (removal), never a finding. Redundant is not false.
+- **Any request for more or longer comments** → Suggestion at most, and only when concrete. If you cannot phrase it as one line naming a specific non-obvious constraint that is genuinely absent, drop it.
+- **Comments in tests and fixtures** → held to the same accuracy bar, but redundancy there is never worth reporting.
+- A finding you could not verify against the code is a hunch — drop it.
+
+When in doubt between `COMMENTS_SOUND` and a finding, check the code one more time. An unfounded comment flag costs the author a round-trip over prose that was fine.
+
+## Verdicts (report exactly one)
+
+- `COMMENTS_SOUND` — every load-bearing claim in the changed comments verifies against the code, and the markers are well-formed. Write 2-4 sentences naming what you checked (which claims, which files, which markers) so the reviewer knows accuracy was actually examined, not skipped.
+- `COMMENTS_CONCERN` — a comment misleads, a marker is malformed, or the diff left a comment stale. Important-level.
+- `COMMENTS_INACCURATE` — a changed comment states something the code plainly does not do, in a way that could cause a caller to misuse it. Critical-level. Quote the comment and the contradicting code side by side.
+
+## Rules
+
+- **Read-only.** Never modify the sandbox checkout, never check out other refs — the other review agents are reading `/work/nx` concurrently.
+- **Ground every claim** with `file:line` for both the comment and the code that contradicts it. "This comment seems inaccurate" without the contradicting line is not a finding.
+- Don't duplicate the other agents: whether the _code_ is correct belongs to `code-reviewer`, prose in `astro-docs/**` belongs to `docs-reviewer`. Yours is the truth of comments in source.
+- A comment's absence is never a finding. Only what is written, and whether it is true.
+
+## Output format
+
+```markdown
+### Comment analysis
+
+**Verdict:** COMMENTS_SOUND | COMMENTS_CONCERN | COMMENTS_INACCURATE
+
+**Claims checked:** <one line per load-bearing comment claim: file:line — the claim — verified against what>
+
+**Findings:** <the same count as TIERS findings=, then one block per finding; "0" on COMMENTS_SOUND>
+
+- **<file:line>** — <the comment, quoted; the code that contradicts it with its own file:line; the concrete fix>
+
+**Suggestions:** <the same count as TIERS suggestions=, then one line each; "none" if 0>
+
+**Markers:** <one line: @deprecated / TODO(vNN) / @internal forms checked, or "none in diff">
+```
+
+Both counts must equal the `TIERS` header line exactly. If you find yourself writing different numbers, you have miscounted one — recount rather than picking whichever looks right, because the caller reconciles against `TIERS`.

--- a/.claude/agents/comment-analyzer.md
+++ b/.claude/agents/comment-analyzer.md
@@ -64,7 +64,6 @@ A comment earns its place only by saying something the code cannot. The default 
 
 <!-- This paragraph is quoted verbatim in CLAUDE.md as the orientation for authors. Change both together. -->
 
-
 Warranted:
 
 - **Non-obvious constraints and invariants** — the thing that breaks if someone "simplifies" the code. `// Read source maps fresh each flush so daemon-cached maps don't go stale.`
@@ -92,7 +91,7 @@ Not warranted — these are worth at most a Suggestion to remove, never a findin
 
 These are checked mechanically by other tooling, so a malformed one fails silently rather than loudly. That is what makes them findings rather than style:
 
-- **`@deprecated` must name both the replacement and the removal version** — `Use \`createNodesV2\` instead. This will be removed in Nx 24.` A bare `@deprecated` leaves the consumer no migration path and no deadline.
+- **`@deprecated` must name both the replacement and the removal version** — ``Use `createNodesV2` instead. This will be removed in Nx 24.`` A bare `@deprecated` leaves the consumer no migration path and no deadline.
 - **Version-gated work must use the `TODO(vNN):` form.** The major-release cleanup greps for exactly this; `// TODO: remove when we drop v23` is invisible to that sweep and will be missed.
 - **A follow-up `TODO` should name an owner** — `TODO(username)`. An anonymous `TODO:` has no one to chase it. Suggestion-level, not a finding.
 - **`@internal`** on exports that are public only as an implementation detail and carry no compatibility guarantee.

--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -90,7 +90,7 @@ Parse out:
 - `title`, `author.login`, `headRefOid` (the head SHA), `headRefName`, `baseRefName`, `url`
 - `isDraft` — if true, exit early (don't review drafts)
 - **Local dedup:** if `$TRIAGE_DIR/<NUMBER>.md` exists, its frontmatter `head_sha` equals `headRefOid`, its `pipeline_version` equals the current `PIPELINE_VERSION` (see below), and its `verdict` is not `failed`, this PR was already reviewed at this commit — exit with no draft change; log "ALREADY_REVIEWED". A `failed` draft never blocks a retry. To deliberately re-review an unchanged PR, delete the draft file or just say so in the session.
-- **`PIPELINE_VERSION: 6`** — the current review-criteria generation. A draft whose frontmatter has an older `pipeline_version` (or none) was produced by a weaker pipeline: re-review even at an unchanged `head_sha`, treating the old draft as a prior review (Step 4). Bump this constant whenever the review criteria change materially (new agents, new calibrations, new required sections) so stale drafts age out instead of being pinned forever by the SHA dedup.
+- **`PIPELINE_VERSION: 7`** — the current review-criteria generation. A draft whose frontmatter has an older `pipeline_version` (or none) was produced by a weaker pipeline: re-review even at an unchanged `head_sha`, treating the old draft as a prior review (Step 4). Bump this constant whenever the review criteria change materially (new agents, new calibrations, new required sections) so stale drafts age out instead of being pinned forever by the SHA dedup.
 
 ### Fetch the tracking ticket
 
@@ -815,9 +815,14 @@ which; agents that are handed both without a hierarchy read both in full.
 
 Then dispatch each agent with this prompt shape:
 
+`<SUBAGENT_TYPE>` is the **exact** identifier from the dispatch list below — most carry the
+`pr-review-toolkit:` prefix, but `comment-analyzer` is project-local and takes no prefix; prefixing it
+silently resolves to the stock plugin agent, which enforces different comment criteria. `<AGENT>` stays
+the bare name everywhere else, because it is what the evidence file paths are keyed on.
+
 ```
 Agent(
-  subagent_type="pr-review-toolkit:<AGENT>",
+  subagent_type="<SUBAGENT_TYPE>",
   description="<AGENT> review of PR <NUMBER>",
   prompt="""
 Review PR <NUMBER> in nrwl/nx.
@@ -860,7 +865,7 @@ Dispatch these in parallel:
 - `pr-review-toolkit:code-reviewer` — general quality and guideline compliance
 - `pr-review-toolkit:silent-failure-hunter` — error handling and swallowed failures
 - `pr-review-toolkit:pr-test-analyzer` — test coverage of the change
-- `pr-review-toolkit:comment-analyzer` — comment and doc accuracy
+- `comment-analyzer` — comment accuracy (project-local, not the `pr-review-toolkit` one: it enforces this repo's comment criteria and emits the `TIERS` line)
 - `pr-review-toolkit:type-design-analyzer` — only when the diff adds or changes types
 
 `code-simplifier` is deliberately omitted — its output is nice-to-have polish by definition, all of which the trim below would discard.
@@ -1013,7 +1018,7 @@ Aggregate the surviving agents' output into Critical / Important / Strengths you
 - **Never re-tier an agent's finding downward on your own judgment.** The only sanctioned downgrade is a named calibration from the list below; when you apply one, say which calibration and why in the draft. "It feels minor", "that's just style", "the fix is one character" are not calibrations. An agent that filed something as a finding did so against a rule it was required to name. You are re-checking it against the calibrations, not re-scoring it by taste, and you are not the tier the agent's contract already assigned.
 - **Severity comes from the rule violated, not the size of the fix.** A one-character punctuation change that breaks a committed `STYLE_GUIDE.md` rule vale has no rule for is Important. A three-paragraph rewrite that violates nothing is a Suggestion. Judging by surface form is the specific way this step goes wrong: docs, comment, and naming findings all have tiny diffs, so they read as polish and get swept into a tier that cannot move the verdict.
 - **The 5-bullet cap binds the Suggestions tier only.** It is never a reason to move anything out of Critical or Important, and it never licenses a silent merge or drop. If you cut to the cap, name in one line what you cut and why. A reader must never mistake a trimmed list for a complete one.
-- **Reconcile per agent before you write the draft.** For each agent that ran, count what it filed at each tier and compare with what your draft carries. Any tier whose count dropped gets a one-line reason in `## Failures`, naming the calibration that licensed it. This is bookkeeping, not judgment, and it is the only thing that catches a compression you did not notice making. `docs-reviewer` hands you this for free: it emits a `TIERS: findings=<n> suggestions=<n>` line as the fourth line of its report, and `findings=<n>` is the number of docs items that must appear in your Critical/Important sections. Grep it, compare it, and treat a shortfall you cannot justify as a bug in your trim rather than a judgement you are entitled to.
+- **Reconcile per agent before you write the draft.** For each agent that ran, count what it filed at each tier and compare with what your draft carries. Any tier whose count dropped gets a one-line reason in `## Failures`, naming the calibration that licensed it. This is bookkeeping, not judgment, and it is the only thing that catches a compression you did not notice making. `docs-reviewer` and `comment-analyzer` hand you this for free: each emits a `TIERS: findings=<n> suggestions=<n>` line as the fourth line of its report, and `findings=<n>` is the number of that agent's items that must appear in your Critical/Important sections. Grep them, compare them, and treat a shortfall you cannot justify as a bug in your trim rather than a judgement you are entitled to.
 
 Observed: a `docs-reviewer` report filing two findings and four suggestions reached a draft as one finding and one merged bullet. The semicolon violation was demoted because punctuation reads as taste, then the cap silently absorbed two more. Nothing in the run flagged it; the maintainer did.
 
@@ -1042,6 +1047,7 @@ These standing maintainer calibrations encode this repo's review culture. The ch
 7. **Pre-existing behavior isn't Important.** Before rating a finding Important, verify it's net-new in the diff: does unchanged sibling code follow the same pattern? Did the behavior exist before the PR (check the base, look for tests pinning it)? If either is yes, it's advisory at most.
 8. **Deliberate, tested, documented design decisions aren't blockers.** A behavior change pinned by new tests and documented in JSDoc or the PR body is intentional — the right ask is a callout in the PR description, not a change request.
 9. **Don't demand defensive guards.** The repo prefers fixing an invariant at its source with one descriptive error at the true failure point over scattered guards, warnings, and version checks. Absence of extra defensive coding is not a finding.
+10. **Comment-volume asks are advisory; comment-accuracy findings are not.** The repo's comment criteria (`.claude/agents/comment-analyzer.md`, summarized for authors in `CLAUDE.md` § "Code Comments") default to no comment and cap a warranted one at ~3 lines, so "add a docstring", "document this parameter", "explain the rationale here", and "expand this comment" are Suggestions at most — never Important, never a verdict driver. The project-local `comment-analyzer` already enforces this, so the residual source is another agent (usually `code-reviewer`) reaching for documentation asks outside its beat. Still fully in scope, and still blocking: a comment that contradicts the code it describes, a stale reference the diff left behind, and the repo's load-bearing markers — a `@deprecated` missing its replacement or removal version, or version-gated work written without the `TODO(vNN)` form the major-release deprecation sweep greps for.
 
 ## Step 5a: Run the alternative-approach agent
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -73,6 +73,20 @@ In this mode:
 Files under `generated` directories are generated based on a different source file and should not be modified directly.
 Find the underlying source and modify that instead.
 
+## Code Comments
+
+A comment earns its place only by saying something the code cannot. The default is **no comment** — clearer names,
+smaller functions, and explicit types usually beat one. When warranted, it is a line or two in the terse style of the
+surrounding code. Past ~3 lines, it should have been cut down or moved into the commit message.
+
+Keep it true. A comment that contradicts the code is worse than no comment, so when you change code, update or delete
+the comments around it — a stale comment is a bug and review treats it as one.
+
+**MANDATORY**: the paragraph above is orientation, not the rule set. The full rules live in
+`.claude/agents/comment-analyzer.md` — read it before writing or editing a comment, before adding a `TODO` or
+`@deprecated` marker, and before changing what counts as a comment defect. That file is authoritative for writing
+comments as well as for reviewing them, and it is not loaded automatically, so you must open it.
+
 ## Essential Commands
 
 ### Code Formatting


### PR DESCRIPTION
## Current Behavior

The repo has no committed guidance on code comments. The conventions exist in practice — 41 `TODO(v24)` markers feeding the major-release deprecation sweep, 183 `@deprecated` tags with a consistent "Use `X` instead. This will be removed in Nx N." phrasing — but nothing writes them down, so nothing checks them either. A `@deprecated` tag shipped without a removal version passes review today.

PR review compounds this. It dispatches the stock `pr-review-toolkit:comment-analyzer`, whose contract includes a "completeness" axis and an instruction to write for "the least experienced future maintainer". Both exist to make comments longer. The result is review asking authors to document more, with no committed rule behind the ask.

## Expected Behavior

`.claude/agents/comment-analyzer.md` is the authoritative statement of the repo's comment rules — what warrants a comment, what doesn't, the load-bearing markers, and how each is detected and rated. `CLAUDE.md` carries the orientation paragraph and defers to that file for everything specific. The paragraph is quoted verbatim in both, so a session that never opens the rules file still gets the common case right.

The rules document existing practice rather than imposing a new one. The markers were read out of the codebase, not invented.

Review now dispatches a project-local `comment-analyzer` that checks whether comments are **true** instead of asking for more of them:

- A comment contradicting its code, one a change left stale, or a marker missing its version can block a PR.
- A request for more or longer commenting lands in Suggestions and never drives the verdict — "this claim is false" has an answer, "this needed explaining" is a judgment call.
- Calibration 10 applies the same bar to any other agent that reaches for a documentation ask outside its beat.

Two wiring fixes came out of this and are worth a look on their own:

- The toolkit dispatch template hardcoded a `pr-review-toolkit:` prefix onto every agent name. Left as-is, the project-local agent would never have been dispatched — the stock one would run and the review would look completely normal. The subagent type is now separate from the bare agent name, which still keys the `/tmp/pr-<N>.<agent>.{line,evidence}` paths that `verify-evidence.sh` globs.
- `PIPELINE_VERSION` is bumped, so drafts written under the old criteria age out of the SHA dedup instead of being pinned forever.

Sizing: `comment-analyzer` findings appear in 16 of 87 review drafts (18%), ahead of security (12%), performance (11%), and alternative-approach (8%). This is a mid-yield agent being refocused, not a low-yield one being trimmed.

## Related Issue(s)

N/A — repo tooling.

<!-- polygraph-session-start -->
---
<p><picture><source media="(prefers-color-scheme: dark)" srcset="https://static.ops.cloud.nx.app/polygraph/session-logo-v4-dark.svg"><img src="https://static.ops.cloud.nx.app/polygraph/session-logo-v4-light.svg" width="16" height="22" align="middle" alt="Polygraph"></picture> <a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Define-the-repos-code-comment-rules-and-enforce-them-in-review-ef0f9879">View session ↗</a></p>
<!-- polygraph-session-end -->