### PR TITLE
fix(testing): reserve dev-server ports in the react-router e2e suite

### DIFF
--- a/e2e/react/src/react-router-ts-paths.test.ts
+++ b/e2e/react/src/react-router-ts-paths.test.ts
@@ -3,8 +3,10 @@ import {
   cleanupProject,
   ensureCypressInstallation,
   ensurePlaywrightBrowsersInstallation,
+  killPorts,
   newProject,
   readFile,
+  reservePort,
   runCLI,
   runE2ETests,
   uniq,
@@ -12,6 +14,10 @@ import {
 
 describe('React Router Applications - TS paths', () => {
   const appName = uniq('app');
+  // Both e2e cases start a dev server. Without a reserved port they both take the
+  // 4200 default, so the second one relocates itself while Playwright keeps
+  // navigating to 4200.
+  let appPort: number;
   beforeAll(async () => {
     newProject({
       packages: [
@@ -25,8 +31,9 @@ describe('React Router Applications - TS paths', () => {
       ],
     });
     ensurePlaywrightBrowsersInstallation();
+    appPort = await reservePort();
     runCLI(
-      `generate @nx/react:app ${appName} --use-react-router --routing --linter=eslint --unit-test-runner=vitest --e2e-test-runner=playwright --no-interactive`
+      `generate @nx/react:app ${appName} --use-react-router --routing --linter=eslint --unit-test-runner=vitest --e2e-test-runner=playwright --port=${appPort} --no-interactive`
     );
   });
 
@@ -78,20 +85,25 @@ describe('React Router Applications - TS paths', () => {
       expect(result).toContain(
         `Successfully ran target e2e for project ${appName}-e2e`
       );
+      // Hygiene, not correctness: the reserved ports already keep the two cases
+      // apart, this just stops dev servers accumulating on the agent.
+      expect(await killPorts(appPort)).toBeTruthy();
     }
   });
 
   it('should execute e2e tests using cypress', async () => {
     const cypressAppName = uniq('cypress-app');
+    const cypressAppPort = await reservePort();
     await ensureCypressInstallation();
     runCLI(
-      `generate @nx/react:app ${cypressAppName} --use-react-router --routing --linter=eslint --unit-test-runner=none  --no-interactive`
+      `generate @nx/react:app ${cypressAppName} --use-react-router --routing --linter=eslint --unit-test-runner=none --port=${cypressAppPort} --no-interactive`
     );
     if (await runE2ETests()) {
       const result = runCLI(`e2e ${cypressAppName}-e2e --verbose`);
       expect(result).toContain(
         `Successfully ran target e2e for project ${cypressAppName}-e2e`
       );
+      expect(await killPorts(cypressAppPort)).toBeTruthy();
     }
   });
 });

--- a/e2e/react/src/react-router-ts-paths.test.ts
+++ b/e2e/react/src/react-router-ts-paths.test.ts
@@ -14,9 +14,9 @@ import {
 
 describe('React Router Applications - TS paths', () => {
   const appName = uniq('app');
-  // Both e2e cases start a dev server. Without a reserved port they both take the
-  // 4200 default, so the second one relocates itself while Playwright keeps
-  // navigating to 4200.
+  // Every case here starts a dev server on the 4200 default, as does the sibling
+  // react-router-ts-solution suite running in parallel on the same agent. Whoever
+  // loses the race relocates to 4201 while Playwright still navigates to 4200.
   let appPort: number;
   beforeAll(async () => {
     newProject({

--- a/e2e/react/src/react-router-ts-solution.test.ts
+++ b/e2e/react/src/react-router-ts-solution.test.ts
@@ -3,8 +3,10 @@ import {
   cleanupProject,
   ensureCypressInstallation,
   ensurePlaywrightBrowsersInstallation,
+  killPorts,
   newProject,
   readFile,
+  reservePort,
   runCLI,
   runE2ETests,
   uniq,
@@ -12,6 +14,10 @@ import {
 
 describe('React Router Applications - TS Solution', () => {
   const appName = uniq('app');
+  // Every case here starts a dev server on the 4200 default, as does the sibling
+  // react-router-ts-paths suite running in parallel on the same agent. Whoever
+  // loses the race relocates to 4201 while Playwright still navigates to 4200.
+  let appPort: number;
   beforeAll(async () => {
     newProject({
       preset: 'ts',
@@ -26,8 +32,9 @@ describe('React Router Applications - TS Solution', () => {
       ],
     });
     ensurePlaywrightBrowsersInstallation();
+    appPort = await reservePort();
     runCLI(
-      `generate @nx/react:app ${appName} --use-react-router --routing --linter=eslint --unit-test-runner=vitest --e2e-test-runner=playwright --no-interactive`
+      `generate @nx/react:app ${appName} --use-react-router --routing --linter=eslint --unit-test-runner=vitest --e2e-test-runner=playwright --port=${appPort} --no-interactive`
     );
   });
 
@@ -78,20 +85,25 @@ describe('React Router Applications - TS Solution', () => {
       expect(result).toContain(
         `Successfully ran target e2e for project @proj/${appName}-e2e`
       );
+      // Hygiene, not correctness: the reserved ports already keep the runs
+      // apart, this just stops dev servers accumulating on the agent.
+      expect(await killPorts(appPort)).toBeTruthy();
     }
   });
 
   it('should execute e2e tests using cypress', async () => {
     const cypressAppName = uniq('cypress-app');
+    const cypressAppPort = await reservePort();
     await ensureCypressInstallation();
     runCLI(
-      `generate @nx/react:app ${cypressAppName} --use-react-router --routing --linter=eslint --unit-test-runner=none  --no-interactive`
+      `generate @nx/react:app ${cypressAppName} --use-react-router --routing --linter=eslint --unit-test-runner=none --port=${cypressAppPort} --no-interactive`
     );
     if (await runE2ETests()) {
       const result = runCLI(`e2e ${cypressAppName}-e2e --verbose`);
       expect(result).toContain(
         `Successfully ran target e2e for project @proj/${cypressAppName}-e2e`
       );
+      expect(await killPorts(cypressAppPort)).toBeTruthy();
     }
   });
 });


### PR DESCRIPTION
## Current Behavior

Both e2e cases in `e2e/react/src/react-router-ts-paths.test.ts` generate their app without `--port`, so both take the `4200` default: the `should execute e2e tests using playwright` case, and the `should execute e2e tests using cypress` case that runs right after it.

When the first case's dev server has not released `4200` by the time the second case's server probes it, the second server relocates itself — but nothing tells Playwright, whose `baseURL` is still `4200`:

```
Port 4200 is in use, trying another one...
  ➜  Local:   http://localhost:4201/
...
Error: page.goto: Could not connect to localhost: Connection refused
  - navigating to "http://localhost:4200/", waiting until "load"
```

A detail worth noting, because it makes the failure look stranger than it is: **two of the three browsers pass.** Chromium and Firefox connect to `4200` fine and only webkit fails. The leftover server from the previous case is still serving `4200`, and since it is the same generated react-router app the `h1` says "Welcome" and the assertions hold — until that server exits mid-run and the last browser hits a dead port.

Observed on 2026-08-05, and this suite also failed in master run [30947753956](https://github.com/nrwl/nx/actions/runs/30947753956) (2026-08-04), though I did not keep that log so I cannot confirm the same cause.

## Expected Behavior

Each app gets its own reserved dev-server port, so the two cases cannot contend for `4200` at all.

`reservePort()` (`e2e/utils/port-utils.ts`) claims a port via an atomic lock file and verifies the OS port is actually free, scanning from `6100` — deliberately outside the framework-default zone of `3000`/`4200`/`5173`/`8080`. So the reserved ports collide neither with each other nor with a parallel suite that generated an app on a framework default.

The port is passed as `--port`, which `@nx/react:app` already threads into both ends of the problem — the vite dev server (`createOrEditViteConfig`'s `port`/`previewPort`) and the Playwright config's `baseURL` and `webServer.url` (via `getReactRouterE2EWebServerInfo`). No config file surgery needed; this is the same approach `react-vite.test.ts` already uses for its custom-port case.

`killPorts()` is called after each e2e run. That part is hygiene rather than correctness — the distinct reserved ports are what make the collision structurally impossible — it just stops dev servers accumulating on the agent.

## Related Issue(s)

N/A

<!-- polygraph-session-start -->
---
<p><picture><source media="(prefers-color-scheme: dark)" srcset="https://static.ops.cloud.nx.app/polygraph/session-logo-v4-dark.svg"><img src="https://static.ops.cloud.nx.app/polygraph/session-logo-v4-light.svg" width="16" height="22" align="middle" alt="Polygraph"></picture> <a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Reserve-dev-server-ports-in-the-react-router-e2e-suite-be8f4ac5">View session ↗</a></p>
<!-- polygraph-session-end -->