### PR TITLE
fix(nx-dev): keep the kb index working for uncommitted articles

### DIFF
--- a/astro-docs/src/utils/knowledge-base.ts
+++ b/astro-docs/src/utils/knowledge-base.ts
@@ -146,10 +146,20 @@ export function getKnowledgeBaseArticles(
       topics: doc.data.topics ?? [],
       featured: doc.data.featured ?? false,
       // Falls back to the starlight date when the file has no history of its
-      // own (shallow clone, or a page that isn't committed yet).
-      lastModified: lastModified.get(filePath) ?? getNewestCommitDate(filePath),
+      // own, such as in a shallow clone.
+      lastModified: lastModified.get(filePath) ?? getLastModifiedDate(filePath),
     };
   });
+}
+
+// Starlight throws rather than returning a date when a file has no commits at
+// all, which is any page that isn't committed yet.
+function getLastModifiedDate(filePath: string): Date {
+  try {
+    return getNewestCommitDate(filePath);
+  } catch {
+    return new Date();
+  }
 }
 
 export function getTopicId(label: string): string {


### PR DESCRIPTION
## Current Behavior

One uncommitted article takes down the whole Knowledge Base index. The batched `git log` has no entry for it, and the starlight fallback throws instead of returning a date, so `/docs/kb` 500s and `astro-docs:validate-links` fails.

Hits anyone drafting a new KB page.

## Expected Behavior

Uncommitted articles date to now. Committed articles keep their commit date.

## Related Issue(s)

N/A

<!-- polygraph-session-start -->
---
<p><picture><source media="(prefers-color-scheme: dark)" srcset="https://static.ops.cloud.nx.app/polygraph/session-logo-v4-dark.svg"><img src="https://static.ops.cloud.nx.app/polygraph/session-logo-v4-light.svg" width="16" height="22" align="middle" alt="Polygraph"></picture> <a href="https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/vivid-moose-c9937bd5">View session ↗</a></p>
<!-- polygraph-session-end -->