### PR TITLE
chore(nx-dev): sync docs kb articles into the pylon knowledge base

### DIFF
--- a/.github/workflows/pylon-kb-sync.yml
+++ b/.github/workflows/pylon-kb-sync.yml
@@ -2,6 +2,13 @@ name: Pylon KB Sync
 
 # Mirrors astro-docs/src/content/docs/kb into the Pylon knowledge base so the
 # support widget can suggest these articles as answers. nx.dev stays canonical.
+#
+# Deliberately not run on pull requests: a docs change should not be gated on
+# the knowledge base mirror. A conversion regression surfaces here and gets
+# fixed then. To check a change before it lands, run this locally:
+#
+#   nx run astro-docs:pylon-preview -- --strict     # convert, no API token
+#   nx run astro-docs:pylon-sync -- --dry-run       # diff against live Pylon
 
 on:
   schedule:
@@ -19,47 +26,13 @@ on:
 
 permissions: {}
 
-# Deliberately not run on pull requests. A docs change should not be gated on
-# the knowledge base mirror; if a conversion regresses, the nightly reports it
-# and gets fixed then. `render-preview.ts --strict` covers it locally.
 jobs:
-  # Separates a conversion failure from an API failure, so a broken nightly
-  # says which half went wrong without reading the log.
-  preview:
-    if: ${{ github.repository_owner == 'nrwl' }}
-    permissions:
-      contents: read # to fetch code (actions/checkout)
-    runs-on: ubuntu-latest
-    name: Render articles
-    steps:
-      - name: Checkout
-        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
-
-      - name: Setup dev tools with mise
-        uses: jdx/mise-action@146a28175021df8ca24f8ee1828cc2a60f980bd5 # v3
-
-      - name: Enable corepack and install pnpm
-        run: |
-          corepack enable
-          corepack prepare --activate
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      # Not --strict: sync depends on this job, and one article with an
-      # unsupported tag should not stop the other 183 from updating. Warnings
-      # are reported by the sync step instead.
-      - name: Convert every article
-        working-directory: astro-docs
-        run: pnpm exec tsx scripts/pylon/render-preview.ts
-
   sync:
     # Pinned to master: the token lives in an environment that admits any
     # protected branch, which includes every release branch, and a dispatch
     # from one of those would publish that branch's docs over the live
     # knowledge base.
     if: ${{ github.repository_owner == 'nrwl' && github.ref == 'refs/heads/master' }}
-    needs: preview
     environment: pylon
     permissions:
       contents: read # to fetch code (actions/checkout)
@@ -103,17 +76,17 @@ jobs:
           pnpm exec tsx scripts/pylon/sync-kb.ts $args
 
   report:
+    # Cancelled and skipped count as failure too, so a nightly that never
+    # reached the sync step cannot pass silently.
     if: ${{ always() && github.repository_owner == 'nrwl' && github.event_name == 'schedule' }}
-    # Both jobs, because a failing preview leaves sync skipped rather than
-    # failed, and a skipped result would notify nobody.
-    needs: [preview, sync]
+    needs: sync
     runs-on: ubuntu-latest
     name: Report status
     steps:
       - name: Send notification
         uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2 # v11
         with:
-          status: ${{ (contains(needs.*.result, 'failure') || contains(needs.*.result, 'skipped') || contains(needs.*.result, 'cancelled')) && 'failure' || 'success' }}
+          status: ${{ needs.sync.result == 'success' && 'success' || 'failure' }}
           message_format: '{emoji} Pylon KB sync has {status_message}'
           notification_title: '{workflow}'
           footer: '<{run_url}|View Run> / Last commit <{commit_url}|{commit_sha}>'

--- a/.github/workflows/pylon-kb-sync.yml
+++ b/.github/workflows/pylon-kb-sync.yml
@@ -16,23 +16,15 @@ on:
         description: 'Delete Pylon articles whose source page no longer exists'
         type: boolean
         default: false
-  # Changes to the tooling or to the articles it converts are converted on the
-  # PR itself. Only the preview job runs there; nothing reaches Pylon.
-  # Assets are included because a removed or renamed image is a conversion
-  # warning, and the article that references it lives elsewhere in the tree.
-  pull_request:
-    paths:
-      - 'astro-docs/scripts/pylon/**'
-      - 'astro-docs/src/content/docs/kb/**'
-      - 'astro-docs/src/assets/**'
-      - 'astro-docs/public/img/**'
-      - '.github/workflows/pylon-kb-sync.yml'
 
 permissions: {}
 
+# Deliberately not run on pull requests. A docs change should not be gated on
+# the knowledge base mirror; if a conversion regresses, the nightly reports it
+# and gets fixed then. `render-preview.ts --strict` covers it locally.
 jobs:
-  # Conversion is worth checking on every PR, including forks, and needs no
-  # credentials to do it.
+  # Separates a conversion failure from an API failure, so a broken nightly
+  # says which half went wrong without reading the log.
   preview:
     if: ${{ github.repository_owner == 'nrwl' }}
     permissions:
@@ -54,24 +46,19 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      # Strict on a pull request so a bad tag fails review. Not on a schedule,
-      # where sync depends on this job and one bad article would otherwise
-      # block the other 183 from updating.
+      # Not --strict: sync depends on this job, and one article with an
+      # unsupported tag should not stop the other 183 from updating. Warnings
+      # are reported by the sync step instead.
       - name: Convert every article
         working-directory: astro-docs
-        run: |
-          pnpm exec tsx scripts/pylon/render-preview.ts \
-            ${{ github.event_name == 'pull_request' && '--strict' || '' }}
+        run: pnpm exec tsx scripts/pylon/render-preview.ts
 
   sync:
-    # Never on a pull request. The token can delete every article, so it lives
-    # in an environment and pull requests get the preview job instead, which
-    # needs no credentials.
-    #
-    # Pinned to master as well: the environment admits any protected branch,
-    # which includes every release branch, and a dispatch from one of those
-    # would publish that branch's docs over the live knowledge base.
-    if: ${{ github.repository_owner == 'nrwl' && github.event_name != 'pull_request' && github.ref == 'refs/heads/master' }}
+    # Pinned to master: the token lives in an environment that admits any
+    # protected branch, which includes every release branch, and a dispatch
+    # from one of those would publish that branch's docs over the live
+    # knowledge base.
+    if: ${{ github.repository_owner == 'nrwl' && github.ref == 'refs/heads/master' }}
     needs: preview
     environment: pylon
     permissions:

--- a/.github/workflows/pylon-kb-sync.yml
+++ b/.github/workflows/pylon-kb-sync.yml
@@ -84,6 +84,19 @@ jobs:
           DRY_RUN: ${{ github.event_name == 'pull_request' || inputs.dry-run }}
           PRUNE: ${{ inputs.prune }}
         run: |
+          # A PR has nothing to authenticate with until the secret exists, and
+          # conversion is already covered by the preview job. A scheduled or
+          # manual run without a token is a real failure.
+          if [ -z "$PYLON_API_TOKEN" ]; then
+            if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
+              echo "No PYLON_API_TOKEN available, skipping the live dry run." \
+                | tee -a "$GITHUB_STEP_SUMMARY"
+              exit 0
+            fi
+            echo "PYLON_API_TOKEN is required for scheduled and manual runs" >&2
+            exit 1
+          fi
+
           # Both variables arrive as the literal strings "true"/"false"/"", so
           # they have to be compared rather than tested for emptiness.
           args=""

--- a/.github/workflows/pylon-kb-sync.yml
+++ b/.github/workflows/pylon-kb-sync.yml
@@ -80,7 +80,6 @@ jobs:
         working-directory: astro-docs
         env:
           PYLON_API_TOKEN: ${{ secrets.PYLON_API_TOKEN }}
-          PYLON_AUTHOR_USER_ID: ${{ vars.PYLON_AUTHOR_USER_ID }}
           DRY_RUN: ${{ github.event_name == 'pull_request' || inputs.dry-run }}
           PRUNE: ${{ inputs.prune }}
         run: |

--- a/.github/workflows/pylon-kb-sync.yml
+++ b/.github/workflows/pylon-kb-sync.yml
@@ -18,10 +18,14 @@ on:
         default: false
   # Changes to the tooling or to the articles it converts are converted on the
   # PR itself. Only the preview job runs there; nothing reaches Pylon.
+  # Assets are included because a removed or renamed image is a conversion
+  # warning, and the article that references it lives elsewhere in the tree.
   pull_request:
     paths:
       - 'astro-docs/scripts/pylon/**'
       - 'astro-docs/src/content/docs/kb/**'
+      - 'astro-docs/src/assets/**'
+      - 'astro-docs/public/img/**'
       - '.github/workflows/pylon-kb-sync.yml'
 
 permissions: {}
@@ -50,9 +54,14 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
+      # Strict on a pull request so a bad tag fails review. Not on a schedule,
+      # where sync depends on this job and one bad article would otherwise
+      # block the other 183 from updating.
       - name: Convert every article
         working-directory: astro-docs
-        run: pnpm exec tsx scripts/pylon/render-preview.ts --strict
+        run: |
+          pnpm exec tsx scripts/pylon/render-preview.ts \
+            ${{ github.event_name == 'pull_request' && '--strict' || '' }}
 
   sync:
     # Never on a pull request. The token can delete every article, so it lives

--- a/.github/workflows/pylon-kb-sync.yml
+++ b/.github/workflows/pylon-kb-sync.yml
@@ -65,9 +65,13 @@ jobs:
 
   sync:
     # Never on a pull request. The token can delete every article, so it lives
-    # in an environment restricted to master and is unreachable from a branch.
-    # Pull requests get the preview job, which needs no credentials.
-    if: ${{ github.repository_owner == 'nrwl' && github.event_name != 'pull_request' }}
+    # in an environment and pull requests get the preview job instead, which
+    # needs no credentials.
+    #
+    # Pinned to master as well: the environment admits any protected branch,
+    # which includes every release branch, and a dispatch from one of those
+    # would publish that branch's docs over the live knowledge base.
+    if: ${{ github.repository_owner == 'nrwl' && github.event_name != 'pull_request' && github.ref == 'refs/heads/master' }}
     needs: preview
     environment: pylon
     permissions:

--- a/.github/workflows/pylon-kb-sync.yml
+++ b/.github/workflows/pylon-kb-sync.yml
@@ -16,8 +16,8 @@ on:
         description: 'Delete Pylon articles whose source page no longer exists'
         type: boolean
         default: false
-  # Changes to the tooling or to the articles it converts are exercised on the
-  # PR itself, always as a dry run so a review never writes to Pylon.
+  # Changes to the tooling or to the articles it converts are converted on the
+  # PR itself. Only the preview job runs there; nothing reaches Pylon.
   pull_request:
     paths:
       - 'astro-docs/scripts/pylon/**'
@@ -55,9 +55,12 @@ jobs:
         run: pnpm exec tsx scripts/pylon/render-preview.ts
 
   sync:
-    # Fork PRs get no secrets, so the sync would only fail on a missing token.
-    if: ${{ github.repository_owner == 'nrwl' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    # Never on a pull request. The token can delete every article, so it lives
+    # in an environment restricted to master and is unreachable from a branch.
+    # Pull requests get the preview job, which needs no credentials.
+    if: ${{ github.repository_owner == 'nrwl' && github.event_name != 'pull_request' }}
     needs: preview
+    environment: pylon
     permissions:
       contents: read # to fetch code (actions/checkout)
     runs-on: ubuntu-latest
@@ -80,19 +83,14 @@ jobs:
         working-directory: astro-docs
         env:
           PYLON_API_TOKEN: ${{ secrets.PYLON_API_TOKEN }}
-          DRY_RUN: ${{ github.event_name == 'pull_request' || inputs.dry-run }}
+          DRY_RUN: ${{ inputs.dry-run }}
           PRUNE: ${{ inputs.prune }}
         run: |
-          # A PR has nothing to authenticate with until the secret exists, and
-          # conversion is already covered by the preview job. A scheduled or
-          # manual run without a token is a real failure.
+          # This job only runs where the environment grants the secret, so a
+          # missing token means the environment is misconfigured. Failing here
+          # keeps that from turning the nightly into a silent no-op.
           if [ -z "$PYLON_API_TOKEN" ]; then
-            if [ "$GITHUB_EVENT_NAME" = "pull_request" ]; then
-              echo "No PYLON_API_TOKEN available, skipping the live dry run." \
-                | tee -a "$GITHUB_STEP_SUMMARY"
-              exit 0
-            fi
-            echo "PYLON_API_TOKEN is required for scheduled and manual runs" >&2
+            echo "PYLON_API_TOKEN is not available from the pylon environment" >&2
             exit 1
           fi
 

--- a/.github/workflows/pylon-kb-sync.yml
+++ b/.github/workflows/pylon-kb-sync.yml
@@ -11,17 +11,53 @@ on:
       dry-run:
         description: 'Report changes without writing to Pylon'
         type: boolean
-        default: false
+        default: true
       prune:
         description: 'Delete Pylon articles whose source page no longer exists'
         type: boolean
         default: false
+  # Changes to the tooling or to the articles it converts are exercised on the
+  # PR itself, always as a dry run so a review never writes to Pylon.
+  pull_request:
+    paths:
+      - 'astro-docs/scripts/pylon/**'
+      - 'astro-docs/src/content/docs/kb/**'
+      - '.github/workflows/pylon-kb-sync.yml'
 
 permissions: {}
 
 jobs:
-  sync:
+  # Conversion is worth checking on every PR, including forks, and needs no
+  # credentials to do it.
+  preview:
     if: ${{ github.repository_owner == 'nrwl' }}
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+    runs-on: ubuntu-latest
+    name: Render articles
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Setup dev tools with mise
+        uses: jdx/mise-action@146a28175021df8ca24f8ee1828cc2a60f980bd5 # v3
+
+      - name: Enable corepack and install pnpm
+        run: |
+          corepack enable
+          corepack prepare --activate
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Convert every article
+        working-directory: astro-docs
+        run: pnpm exec tsx scripts/pylon/render-preview.ts
+
+  sync:
+    # Fork PRs get no secrets, so the sync would only fail on a missing token.
+    if: ${{ github.repository_owner == 'nrwl' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository) }}
+    needs: preview
     permissions:
       contents: read # to fetch code (actions/checkout)
     runs-on: ubuntu-latest
@@ -45,13 +81,19 @@ jobs:
         env:
           PYLON_API_TOKEN: ${{ secrets.PYLON_API_TOKEN }}
           PYLON_AUTHOR_USER_ID: ${{ vars.PYLON_AUTHOR_USER_ID }}
+          DRY_RUN: ${{ github.event_name == 'pull_request' || inputs.dry-run }}
+          PRUNE: ${{ inputs.prune }}
         run: |
-          pnpm exec tsx scripts/pylon/sync-kb.ts \
-            ${{ inputs.dry-run && '--dry-run' || '' }} \
-            ${{ inputs.prune && '--prune' || '' }}
+          # Both variables arrive as the literal strings "true"/"false"/"", so
+          # they have to be compared rather than tested for emptiness.
+          args=""
+          if [ "$DRY_RUN" = "true" ]; then args="$args --dry-run"; fi
+          if [ "$PRUNE" = "true" ]; then args="$args --prune"; fi
+          echo "sync-kb.ts$args"
+          pnpm exec tsx scripts/pylon/sync-kb.ts $args
 
   report:
-    if: ${{ always() && github.repository_owner == 'nrwl' && github.event_name != 'workflow_dispatch' }}
+    if: ${{ always() && github.repository_owner == 'nrwl' && github.event_name == 'schedule' }}
     needs: sync
     runs-on: ubuntu-latest
     name: Report status

--- a/.github/workflows/pylon-kb-sync.yml
+++ b/.github/workflows/pylon-kb-sync.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Convert every article
         working-directory: astro-docs
-        run: pnpm exec tsx scripts/pylon/render-preview.ts
+        run: pnpm exec tsx scripts/pylon/render-preview.ts --strict
 
   sync:
     # Never on a pull request. The token can delete every article, so it lives
@@ -104,14 +104,16 @@ jobs:
 
   report:
     if: ${{ always() && github.repository_owner == 'nrwl' && github.event_name == 'schedule' }}
-    needs: sync
+    # Both jobs, because a failing preview leaves sync skipped rather than
+    # failed, and a skipped result would notify nobody.
+    needs: [preview, sync]
     runs-on: ubuntu-latest
     name: Report status
     steps:
       - name: Send notification
         uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2 # v11
         with:
-          status: ${{ needs.sync.result }}
+          status: ${{ (contains(needs.*.result, 'failure') || contains(needs.*.result, 'skipped') || contains(needs.*.result, 'cancelled')) && 'failure' || 'success' }}
           message_format: '{emoji} Pylon KB sync has {status_message}'
           notification_title: '{workflow}'
           footer: '<{run_url}|View Run> / Last commit <{commit_url}|{commit_sha}>'

--- a/.github/workflows/pylon-kb-sync.yml
+++ b/.github/workflows/pylon-kb-sync.yml
@@ -1,0 +1,68 @@
+name: Pylon KB Sync
+
+# Mirrors astro-docs/src/content/docs/kb into the Pylon knowledge base so the
+# support widget can suggest these articles as answers. nx.dev stays canonical.
+
+on:
+  schedule:
+    - cron: '0 7 * * *'
+  workflow_dispatch:
+    inputs:
+      dry-run:
+        description: 'Report changes without writing to Pylon'
+        type: boolean
+        default: false
+      prune:
+        description: 'Delete Pylon articles whose source page no longer exists'
+        type: boolean
+        default: false
+
+permissions: {}
+
+jobs:
+  sync:
+    if: ${{ github.repository_owner == 'nrwl' }}
+    permissions:
+      contents: read # to fetch code (actions/checkout)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@08c6903cd8c0fde910a37f88322edcfb5dd907a8 # v5.0.0
+
+      - name: Setup dev tools with mise
+        uses: jdx/mise-action@146a28175021df8ca24f8ee1828cc2a60f980bd5 # v3
+
+      - name: Enable corepack and install pnpm
+        run: |
+          corepack enable
+          corepack prepare --activate
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Sync knowledge base
+        working-directory: astro-docs
+        env:
+          PYLON_API_TOKEN: ${{ secrets.PYLON_API_TOKEN }}
+          PYLON_AUTHOR_USER_ID: ${{ vars.PYLON_AUTHOR_USER_ID }}
+        run: |
+          pnpm exec tsx scripts/pylon/sync-kb.ts \
+            ${{ inputs.dry-run && '--dry-run' || '' }} \
+            ${{ inputs.prune && '--prune' || '' }}
+
+  report:
+    if: ${{ always() && github.repository_owner == 'nrwl' && github.event_name != 'workflow_dispatch' }}
+    needs: sync
+    runs-on: ubuntu-latest
+    name: Report status
+    steps:
+      - name: Send notification
+        uses: ravsamhq/notify-slack-action@be814b201e233b2dc673608aa46e5447c8ab13f2 # v11
+        with:
+          status: ${{ needs.sync.result }}
+          message_format: '{emoji} Pylon KB sync has {status_message}'
+          notification_title: '{workflow}'
+          footer: '<{run_url}|View Run> / Last commit <{commit_url}|{commit_sha}>'
+          notify_when: 'failure'
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.ACTION_MONITORING_SLACK }}

--- a/astro-docs/project.json
+++ b/astro-docs/project.json
@@ -171,6 +171,22 @@
         "{projectRoot}/scripts/vale-changed.mjs"
       ]
     },
+    "pylon-sync": {
+      "//": "Mirrors src/content/docs/kb into the Pylon knowledge base. Needs PYLON_API_TOKEN. Runs nightly via .github/workflows/pylon-kb-sync.yml",
+      "cache": false,
+      "command": "tsx scripts/pylon/sync-kb.ts",
+      "options": {
+        "cwd": "astro-docs"
+      }
+    },
+    "pylon-preview": {
+      "//": "Renders kb articles through the Pylon converter offline, no API token needed",
+      "cache": false,
+      "command": "tsx scripts/pylon/render-preview.ts",
+      "options": {
+        "cwd": "astro-docs"
+      }
+    },
     "format": {
       "cache": true,
       "//": "nx format doesn't respect overrides, so we manually run prettier for mdoc files",

--- a/astro-docs/scripts/pylon/markdoc-to-html.ts
+++ b/astro-docs/scripts/pylon/markdoc-to-html.ts
@@ -538,6 +538,7 @@ function escapeText(value: string): string {
     .replaceAll('>', '&gt;');
 }
 
-function escapeAttribute(value: string): string {
+/** Exported so asset URLs substituted later escape exactly like the rest. */
+export function escapeAttribute(value: string): string {
   return escapeText(value).replaceAll('"', '&quot;');
 }

--- a/astro-docs/scripts/pylon/markdoc-to-html.ts
+++ b/astro-docs/scripts/pylon/markdoc-to-html.ts
@@ -1,0 +1,541 @@
+/**
+ * Converts a `/docs/kb` Markdoc article into the HTML Pylon stores as an
+ * article body.
+ *
+ * Pylon persists `body_html` verbatim - create, patch and publish all round
+ * trip byte for byte - so the output is compared directly against the live
+ * article to decide whether a push is needed. Anything emitted here must
+ * therefore be deterministic.
+ *
+ * Interactive tags (project graphs, generated card indexes) have no HTML
+ * equivalent and become a pointer back to the canonical nx.dev page.
+ */
+
+import Markdoc, { type Node } from '@markdoc/markdoc';
+import { createHash } from 'node:crypto';
+import { existsSync, readFileSync } from 'node:fs';
+import { dirname, relative, resolve } from 'node:path';
+
+/** An image the sync has to make reachable from Pylon's CDN. */
+export interface AssetRef {
+  /**
+   * Identity of the image contents, embedded in the emitted `data-nx-src` so a
+   * later run can reuse the URL already uploaded for it.
+   */
+  key: string;
+  absolutePath: string;
+  fileName: string;
+  contentType: string;
+}
+
+export interface ConvertOptions {
+  /** Absolute path of the `.mdoc` file, used to resolve relative image paths. */
+  sourcePath: string;
+  /** Absolute path of `astro-docs/public`, the root for `/`-prefixed images. */
+  publicDir: string;
+  /** Repository root, used to build stable asset keys. */
+  repoRoot: string;
+  /** Canonical page on nx.dev, e.g. `https://nx.dev/docs/kb/caching`. */
+  canonicalUrl: string;
+  /** Origin used to absolutize root-relative links, e.g. `https://nx.dev`. */
+  siteUrl: string;
+}
+
+export interface ConvertResult {
+  title: string;
+  description: string;
+  /** Image `src` values are `nx-asset:<key>` placeholders the caller resolves. */
+  html: string;
+  assets: AssetRef[];
+  warnings: string[];
+}
+
+export const ASSET_PLACEHOLDER_PREFIX = 'nx-asset:';
+
+const CONTENT_TYPES: Record<string, string> = {
+  avif: 'image/avif',
+  gif: 'image/gif',
+  jpeg: 'image/jpeg',
+  jpg: 'image/jpeg',
+  png: 'image/png',
+  svg: 'image/svg+xml',
+  webp: 'image/webp',
+};
+
+/** Fallback headings for `aside`/`callout` blocks that carry no title. */
+const CALLOUT_LABELS: Record<string, string> = {
+  announcement: 'Announcement',
+  caution: 'Caution',
+  check: 'Check',
+  danger: 'Danger',
+  deepdive: 'Deep dive',
+  note: 'Note',
+  tip: 'Tip',
+  warning: 'Warning',
+};
+
+export function convertArticle(
+  source: string,
+  options: ConvertOptions
+): ConvertResult {
+  const ast = Markdoc.parse(stripHtmlComments(source));
+  const frontmatter = parseFrontmatter(ast.attributes?.frontmatter ?? '');
+  const converter = new Converter(options);
+  const body = converter.renderChildren(ast);
+
+  return {
+    title: frontmatter.title,
+    description: frontmatter.description,
+    html: body + converter.renderCanonicalFooter(),
+    assets: [...converter.assets.values()],
+    warnings: converter.warnings,
+  };
+}
+
+class Converter {
+  readonly assets = new Map<string, AssetRef>();
+  readonly warnings: string[] = [];
+  #options: ConvertOptions;
+
+  constructor(options: ConvertOptions) {
+    this.#options = options;
+  }
+
+  renderCanonicalFooter(): string {
+    return (
+      `<hr /><p><em>This article mirrors the Nx documentation. ` +
+      `Read the latest version at <a href="${escapeAttribute(this.#options.canonicalUrl)}">` +
+      `${escapeText(this.#options.canonicalUrl)}</a>.</em></p>`
+    );
+  }
+
+  renderChildren(node: Node): string {
+    return (node.children ?? []).map((child) => this.render(child)).join('');
+  }
+
+  render(node: Node): string {
+    const attributes = (node.attributes ?? {}) as Record<string, unknown>;
+
+    switch (node.type) {
+      case 'document':
+      case 'inline':
+        return this.renderChildren(node);
+
+      case 'text':
+        return escapeText(String(attributes.content ?? ''));
+
+      case 'softbreak':
+        return '\n';
+      case 'hardbreak':
+        return '<br />';
+
+      case 'paragraph':
+        return `<p>${this.renderChildren(node)}</p>`;
+
+      case 'heading': {
+        // Pylon renders the article title as the page h1, so demote any h1.
+        const level = Math.min(Math.max(Number(attributes.level ?? 2), 2), 6);
+        return `<h${level}>${this.renderChildren(node)}</h${level}>`;
+      }
+
+      case 'strong':
+        return `<strong>${this.renderChildren(node)}</strong>`;
+      case 'em':
+        return `<em>${this.renderChildren(node)}</em>`;
+      case 's':
+        return `<s>${this.renderChildren(node)}</s>`;
+
+      case 'code':
+        return `<code>${escapeText(String(attributes.content ?? ''))}</code>`;
+
+      case 'fence':
+        return this.#renderFence(attributes);
+
+      case 'link': {
+        const href = this.#absolutizeLink(String(attributes.href ?? ''));
+        return `<a href="${escapeAttribute(href)}">${this.renderChildren(node)}</a>`;
+      }
+
+      case 'image':
+        return this.#renderImage(attributes);
+
+      case 'list':
+        return attributes.ordered
+          ? `<ol>${this.renderChildren(node)}</ol>`
+          : `<ul>${this.renderChildren(node)}</ul>`;
+      case 'item':
+        return `<li>${unwrapSingleParagraph(this.renderChildren(node))}</li>`;
+
+      case 'blockquote':
+        return `<blockquote>${this.renderChildren(node)}</blockquote>`;
+
+      case 'table':
+        return `<table>${this.renderChildren(node)}</table>`;
+      case 'thead':
+        return `<thead>${this.renderChildren(node)}</thead>`;
+      case 'tbody':
+        return `<tbody>${this.renderChildren(node)}</tbody>`;
+      case 'tr':
+        return `<tr>${this.renderChildren(node)}</tr>`;
+      case 'th':
+      case 'td': {
+        const align = attributes.align
+          ? ` align="${escapeAttribute(String(attributes.align))}"`
+          : '';
+        return `<${node.type}${align}>${this.renderChildren(node)}</${node.type}>`;
+      }
+
+      case 'hr':
+        return '<hr />';
+
+      case 'comment':
+      case 'error':
+        return '';
+
+      case 'tag':
+        return this.#renderTag(node, attributes);
+
+      default:
+        this.warnings.push(`unhandled node type "${node.type}"`);
+        return this.renderChildren(node);
+    }
+  }
+
+  #renderFence(attributes: Record<string, unknown>): string {
+    const language = String(attributes.language ?? '').trim();
+    const languageClass = language
+      ? ` class="language-${escapeAttribute(language)}"`
+      : '';
+    const code = `<pre><code${languageClass}>${escapeText(String(attributes.content ?? ''))}</code></pre>`;
+
+    // `title` names the file or terminal the snippet belongs to; keep it as a
+    // caption. `meta` carries line-highlight ranges with no HTML equivalent.
+    const title = attributes.title ? String(attributes.title) : '';
+    return title ? `<p><code>${escapeText(title)}</code></p>${code}` : code;
+  }
+
+  #renderImage(attributes: Record<string, unknown>): string {
+    const src = String(attributes.src ?? '');
+    const alt = escapeAttribute(String(attributes.alt ?? ''));
+
+    const absolutePath = src.startsWith('/')
+      ? resolve(this.#options.publicDir, src.slice(1))
+      : resolve(dirname(this.#options.sourcePath), src);
+
+    if (!existsSync(absolutePath)) {
+      this.warnings.push(`image not found on disk: ${src}`);
+      return `<img src="${escapeAttribute(this.#absolutizeLink(src))}" alt="${alt}" />`;
+    }
+
+    const extension = absolutePath.split('.').pop()?.toLowerCase() ?? '';
+    const repoRelative = relative(this.#options.repoRoot, absolutePath);
+    const digest = createHash('sha256')
+      .update(readFileSync(absolutePath))
+      .digest('hex')
+      .slice(0, 16);
+    const key = `${repoRelative}#${digest}`;
+
+    this.assets.set(key, {
+      key,
+      absolutePath,
+      fileName: absolutePath.split('/').pop() ?? 'image',
+      contentType: CONTENT_TYPES[extension] ?? 'application/octet-stream',
+    });
+
+    return (
+      `<img src="${ASSET_PLACEHOLDER_PREFIX}${escapeAttribute(key)}" ` +
+      `alt="${alt}" data-nx-src="${escapeAttribute(key)}" />`
+    );
+  }
+
+  #renderTag(node: Node, attributes: Record<string, unknown>): string {
+    const attribute = (name: string): string =>
+      attributes[name] === undefined ? '' : String(attributes[name]);
+
+    switch (node.tag) {
+      // Starlight asides and the Nx callout render the same way: a quoted
+      // block led by its title.
+      case 'aside':
+      case 'callout': {
+        const label =
+          attribute('title') ||
+          CALLOUT_LABELS[attribute('type')] ||
+          CALLOUT_LABELS.note;
+        return (
+          `<blockquote><p><strong>${escapeText(label)}</strong></p>` +
+          `${this.renderChildren(node)}</blockquote>`
+        );
+      }
+
+      // Tab groups flatten to sequential sections - each panel keeps its label
+      // as a heading so the alternatives stay distinguishable.
+      case 'tabs':
+        return this.renderChildren(node);
+      case 'tabitem':
+        return (
+          `<h4>${escapeText(attribute('label'))}</h4>` +
+          this.renderChildren(node)
+        );
+
+      // A file tree is already authored as a nested list.
+      case 'filetree':
+        return this.renderChildren(node);
+
+      case 'youtube': {
+        const embedUrl = toYoutubeEmbedUrl(attribute('src'));
+        const caption = attribute('caption');
+        return (
+          `<iframe src="${escapeAttribute(embedUrl)}" ` +
+          `title="${escapeAttribute(attribute('title'))}" width="100%" height="400" ` +
+          `frameborder="0" allowfullscreen></iframe>` +
+          (caption ? `<p><em>${escapeText(caption)}</em></p>` : '')
+        );
+      }
+
+      case 'course_video':
+        return this.#renderLinkParagraph(
+          attribute('courseUrl') || attribute('src'),
+          attribute('courseTitle') || 'Watch the course'
+        );
+
+      case 'github_repository':
+        return this.#renderLinkParagraph(
+          attribute('url'),
+          attribute('title') || attribute('url')
+        );
+
+      case 'call_to_action': {
+        const description = attribute('description');
+        return (
+          `<p>${this.#renderLink(attribute('url'), attribute('title'))}` +
+          (description ? ` - ${escapeText(description)}` : '') +
+          `</p>`
+        );
+      }
+
+      // Card grids are link lists once the layout is gone.
+      case 'cards':
+      case 'cardgrid':
+        return `<ul>${this.renderChildren(node)}</ul>`;
+      case 'card':
+      case 'linkcard': {
+        const description = attribute('description');
+        return (
+          `<li>${this.#renderLink(attribute('url') || attribute('href'), attribute('title'))}` +
+          (description ? `: ${escapeText(description)}` : '') +
+          `</li>`
+        );
+      }
+
+      case 'badge':
+        return `<strong>${escapeText(attribute('text'))}</strong>`;
+
+      // A prompt is meant to be copied verbatim, so keep it preformatted.
+      // `{pageUrl}` is substituted on nx.dev with the page's markdown source.
+      case 'llm_copy_prompt': {
+        const prompt = plainText(node)
+          .replaceAll('{pageUrl}', `${this.#options.canonicalUrl}.md`)
+          .trim();
+        return (
+          `<p><strong>${escapeText(attribute('title'))}</strong></p>` +
+          `<pre><code>${escapeText(prompt)}</code></pre>`
+        );
+      }
+
+      // Hidden from human readers on nx.dev; keep it that way here.
+      case 'llm_only':
+        return '';
+
+      // No static equivalent - point at the page that can render them.
+      case 'graph':
+      case 'project_details':
+      case 'index_page_cards':
+        return this.#renderCanonicalPointer(node.tag, attribute('title'));
+
+      default:
+        this.warnings.push(`unsupported Markdoc tag "${node.tag}"`);
+        return this.renderChildren(node);
+    }
+  }
+
+  #renderCanonicalPointer(tag: string, title: string): string {
+    const labels: Record<string, string> = {
+      graph: 'project graph',
+      project_details: 'project details view',
+      index_page_cards: 'list of related pages',
+    };
+    const label = title || labels[tag] || tag;
+    return (
+      `<p><em>This section shows an interactive ${escapeText(label)}. ` +
+      `View it on <a href="${escapeAttribute(this.#options.canonicalUrl)}">nx.dev</a>.</em></p>`
+    );
+  }
+
+  #renderLinkParagraph(href: string, label: string): string {
+    return `<p>${this.#renderLink(href, label)}</p>`;
+  }
+
+  #renderLink(href: string, label: string): string {
+    const url = this.#absolutizeLink(href);
+    return `<a href="${escapeAttribute(url)}">${escapeText(label || url)}</a>`;
+  }
+
+  /**
+   * Pylon serves these articles off help.nx.app, so every in-repo link has to
+   * become absolute against nx.dev. Bare fragments resolve against the
+   * canonical page rather than the Pylon article, whose heading anchors differ.
+   */
+  #absolutizeLink(href: string): string {
+    if (!href) return this.#options.canonicalUrl;
+    if (/^[a-z][a-z0-9+.-]*:/i.test(href) || href.startsWith('//')) return href;
+    if (href.startsWith('#')) return this.#options.canonicalUrl + href;
+    if (href.startsWith('/')) return this.#options.siteUrl + href;
+
+    this.warnings.push(`relative link left unresolved: ${href}`);
+    return href;
+  }
+}
+
+/**
+ * Markdoc keeps `<!-- ... -->` as ordinary text, so without this the site's
+ * editorial notes and vale directives would show up as article copy. Comments
+ * inside fenced blocks are real sample code and must survive.
+ */
+function stripHtmlComments(source: string): string {
+  const lines: string[] = [];
+  let openFence: string | null = null;
+  let insideComment = false;
+
+  for (const line of source.split('\n')) {
+    const fence = line.match(/^\s*(`{3,}|~{3,})/)?.[1];
+
+    if (openFence) {
+      lines.push(line);
+      if (
+        fence &&
+        fence[0] === openFence[0] &&
+        fence.length >= openFence.length
+      ) {
+        openFence = null;
+      }
+      continue;
+    }
+
+    if (fence && !insideComment) {
+      openFence = fence;
+      lines.push(line);
+      continue;
+    }
+
+    let remaining = line;
+    let kept = '';
+    while (remaining) {
+      if (insideComment) {
+        const end = remaining.indexOf('-->');
+        if (end === -1) break;
+        insideComment = false;
+        remaining = remaining.slice(end + '-->'.length);
+      } else {
+        const start = remaining.indexOf('<!--');
+        if (start === -1) {
+          kept += remaining;
+          break;
+        }
+        kept += remaining.slice(0, start);
+        insideComment = true;
+        remaining = remaining.slice(start + '<!--'.length);
+      }
+    }
+    lines.push(kept);
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Only `title` and `description` are read; the sync does not map the remaining
+ * docs frontmatter (sidebar, filter, topics) onto Pylon fields.
+ */
+function parseFrontmatter(raw: string): { title: string; description: string } {
+  const read = (field: string): string => {
+    const match = raw.match(new RegExp(`^${field}:[ \\t]*(.*)$`, 'm'));
+    if (!match) return '';
+    return match[1].trim().replace(/^['"]|['"]$/g, '');
+  };
+  return { title: read('title'), description: read('description') };
+}
+
+/**
+ * Flattens a subtree to text, for content that must survive as a code block.
+ * List markers are rebuilt because a numbered prompt reads as instructions.
+ */
+function plainText(
+  node: Node,
+  listContext?: { ordered: boolean; index: number }
+): string {
+  const attributes = (node.attributes ?? {}) as Record<string, unknown>;
+  const children = node.children ?? [];
+
+  switch (node.type) {
+    case 'text':
+    case 'code':
+    case 'fence':
+      return String(attributes.content ?? '');
+    case 'softbreak':
+    case 'hardbreak':
+      return '\n';
+    case 'paragraph':
+      return children.map((child) => plainText(child)).join('') + '\n';
+    case 'list': {
+      const ordered = attributes.ordered === true;
+      return (
+        children
+          .map((child, index) =>
+            plainText(child, { ordered, index: index + 1 })
+          )
+          .join('') + '\n'
+      );
+    }
+    case 'item': {
+      const marker = listContext?.ordered ? `${listContext.index}. ` : '- ';
+      return (
+        marker +
+        children
+          .map((child) => plainText(child))
+          .join('')
+          .trimEnd() +
+        '\n'
+      );
+    }
+    default:
+      return children.map((child) => plainText(child)).join('');
+  }
+}
+
+/** `{% youtube src="https://youtu.be/ID" %}` also appears in embed form. */
+function toYoutubeEmbedUrl(src: string): string {
+  const shortLink = src.match(/^https?:\/\/youtu\.be\/([\w-]+)/);
+  if (shortLink) return `https://www.youtube.com/embed/${shortLink[1]}`;
+
+  const watchLink = src.match(/[?&]v=([\w-]+)/);
+  if (watchLink) return `https://www.youtube.com/embed/${watchLink[1]}`;
+
+  return src;
+}
+
+/** List items hold a paragraph per Markdoc; inline them so lists stay tight. */
+function unwrapSingleParagraph(html: string): string {
+  const match = html.match(/^<p>([\s\S]*?)<\/p>([\s\S]*)$/);
+  return match && !match[1].includes('<p>') ? match[1] + match[2] : html;
+}
+
+function escapeText(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;');
+}
+
+function escapeAttribute(value: string): string {
+  return escapeText(value).replaceAll('"', '&quot;');
+}

--- a/astro-docs/scripts/pylon/markdoc-to-html.ts
+++ b/astro-docs/scripts/pylon/markdoc-to-html.ts
@@ -342,9 +342,11 @@ class Converter {
         );
       }
 
-      // Hidden from human readers on nx.dev; keep it that way here.
+      // nx.dev hides this from readers and keeps it for the machine-readable
+      // copy. This article IS the machine-readable copy, and the blocks carry
+      // the safety steps a suggested answer most needs to repeat.
       case 'llm_only':
-        return '';
+        return this.renderChildren(node);
 
       // No static equivalent - point at the page that can render them.
       case 'graph':

--- a/astro-docs/scripts/pylon/pylon-client.ts
+++ b/astro-docs/scripts/pylon/pylon-client.ts
@@ -1,0 +1,207 @@
+/**
+ * Minimal REST client for the Pylon API, scoped to what the knowledge base sync
+ * needs. Spec: https://static.usepylon.com/openapi.json
+ */
+
+const API_BASE = 'https://api.usepylon.com';
+const REQUEST_TIMEOUT_MS = 30_000;
+const MAX_RETRIES = 3;
+
+export interface PylonArticle {
+  id: string;
+  title: string;
+  slug: string;
+  url: string;
+  collection_id?: string;
+  is_published: boolean;
+  is_unlisted?: boolean;
+  current_published_content_html?: string;
+  current_draft_content_html?: string;
+}
+
+export interface CreateArticleInput {
+  title: string;
+  author_user_id: string;
+  body_html: string;
+  slug: string;
+  collection_id: string;
+  is_published: boolean;
+  is_unlisted: boolean;
+}
+
+/**
+ * PATCH accepts no slug or collection_id - those are fixed at creation time.
+ * Content edits stay in draft unless publish_updated_body_html is set.
+ */
+export interface UpdateArticleInput {
+  title?: string;
+  body_html?: string;
+  is_published?: boolean;
+  is_unlisted?: boolean;
+  publish_updated_body_html?: boolean;
+}
+
+export class PylonClient {
+  #token: string;
+  #knowledgeBaseId: string;
+  #writeDelayMs: number;
+  #lastWriteAt = 0;
+
+  constructor(options: {
+    token: string;
+    knowledgeBaseId: string;
+    writeDelayMs?: number;
+  }) {
+    this.#token = options.token;
+    this.#knowledgeBaseId = options.knowledgeBaseId;
+    this.#writeDelayMs = options.writeDelayMs ?? 250;
+  }
+
+  async #request<T>(
+    method: string,
+    path: string,
+    body?: unknown,
+    formData?: FormData
+  ): Promise<T> {
+    let lastError: Error | undefined;
+
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      if (attempt > 0) await sleep(2 ** (attempt - 1) * 1000);
+
+      let response: Response;
+      try {
+        response = await fetch(`${API_BASE}${path}`, {
+          method,
+          headers: {
+            Authorization: `Bearer ${this.#token}`,
+            ...(formData ? {} : { 'Content-Type': 'application/json' }),
+          },
+          body:
+            formData ?? (body === undefined ? undefined : JSON.stringify(body)),
+          signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
+        });
+      } catch (error) {
+        // Timeouts and socket errors only - a completed HTTP response never
+        // lands here, so everything caught is worth another attempt.
+        lastError = new Error(
+          `${method} ${path} failed: ${error instanceof Error ? error.message : String(error)}`
+        );
+        continue;
+      }
+
+      if (response.ok) {
+        const text = await response.text();
+        return (text ? JSON.parse(text) : {}) as T;
+      }
+
+      const detail = (await response.text()).slice(0, 500);
+      lastError = new Error(
+        `${method} ${path} returned ${response.status}: ${detail}`
+      );
+
+      // 4xx other than throttling means the request itself is wrong.
+      if (response.status !== 429 && response.status < 500) throw lastError;
+
+      const retryAfter = Number(response.headers.get('retry-after'));
+      if (Number.isFinite(retryAfter) && retryAfter > 0) {
+        await sleep(retryAfter * 1000);
+      }
+    }
+
+    throw lastError ?? new Error('unreachable');
+  }
+
+  /** Space out mutations so a 184-article run does not trip rate limits. */
+  async #throttleWrite(): Promise<void> {
+    const waitMs = this.#lastWriteAt + this.#writeDelayMs - Date.now();
+    if (waitMs > 0) await sleep(waitMs);
+    this.#lastWriteAt = Date.now();
+  }
+
+  async getAuthenticatedUserId(): Promise<string> {
+    const response = await this.#request<{ data: { user: { id: string } } }>(
+      'GET',
+      '/me'
+    );
+    return response.data.user.id;
+  }
+
+  async listArticles(): Promise<PylonArticle[]> {
+    const articles: PylonArticle[] = [];
+    let cursor: string | undefined;
+
+    do {
+      const query = new URLSearchParams({ limit: '500' });
+      if (cursor) query.set('cursor', cursor);
+      const response = await this.#request<{
+        data: PylonArticle[];
+        pagination?: { cursor?: string; has_next_page?: boolean };
+      }>('GET', `/knowledge-bases/${this.#knowledgeBaseId}/articles?${query}`);
+      articles.push(...(response.data ?? []));
+      cursor = response.pagination?.has_next_page
+        ? response.pagination.cursor
+        : undefined;
+    } while (cursor);
+
+    return articles;
+  }
+
+  async createArticle(input: CreateArticleInput): Promise<PylonArticle> {
+    await this.#throttleWrite();
+    const response = await this.#request<{ data: PylonArticle }>(
+      'POST',
+      `/knowledge-bases/${this.#knowledgeBaseId}/articles`,
+      input
+    );
+    return response.data;
+  }
+
+  async updateArticle(
+    articleId: string,
+    input: UpdateArticleInput
+  ): Promise<PylonArticle> {
+    await this.#throttleWrite();
+    const response = await this.#request<{ data: PylonArticle }>(
+      'PATCH',
+      `/knowledge-bases/${this.#knowledgeBaseId}/articles/${articleId}`,
+      input
+    );
+    return response.data;
+  }
+
+  async deleteArticle(articleId: string): Promise<void> {
+    await this.#throttleWrite();
+    await this.#request(
+      'DELETE',
+      `/knowledge-bases/${this.#knowledgeBaseId}/articles/${articleId}`
+    );
+  }
+
+  /** Uploads a binary and returns a long-lived CDN URL usable in body_html. */
+  async uploadAttachment(
+    fileName: string,
+    bytes: Uint8Array,
+    contentType: string
+  ): Promise<string> {
+    await this.#throttleWrite();
+    const form = new FormData();
+    // Copied into a plain Uint8Array because a Node Buffer's backing store is
+    // not the ArrayBuffer that Blob requires.
+    form.append(
+      'file',
+      new Blob([new Uint8Array(bytes)], { type: contentType }),
+      fileName
+    );
+    const response = await this.#request<{ data: { url: string } }>(
+      'POST',
+      '/attachments',
+      undefined,
+      form
+    );
+    return response.data.url;
+  }
+}
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}

--- a/astro-docs/scripts/pylon/pylon-client.ts
+++ b/astro-docs/scripts/pylon/pylon-client.ts
@@ -7,6 +7,25 @@ const API_BASE = 'https://api.usepylon.com';
 const REQUEST_TIMEOUT_MS = 30_000;
 const MAX_RETRIES = 3;
 
+/**
+ * Requests per minute each endpoint documents in
+ * https://static.usepylon.com/openapi.json. Pacing is per bucket because the
+ * limits differ by an order of magnitude, and a first sync issues hundreds of
+ * writes.
+ */
+const RATE_LIMITS = {
+  articleCreate: 10,
+  articleUpdate: 20,
+  articleDelete: 20,
+  articleList: 20,
+  attachmentCreate: 10,
+} as const;
+
+type RateBucket = keyof typeof RATE_LIMITS;
+
+/** Keeps pacing just inside the documented ceiling rather than exactly on it. */
+const RATE_LIMIT_MARGIN = 1.05;
+
 export interface PylonArticle {
   id: string;
   title: string;
@@ -44,29 +63,33 @@ export interface UpdateArticleInput {
 export class PylonClient {
   #token: string;
   #knowledgeBaseId: string;
-  #writeDelayMs: number;
-  #lastWriteAt = 0;
+  #lastRequestAt = new Map<RateBucket, number>();
 
-  constructor(options: {
-    token: string;
-    knowledgeBaseId: string;
-    writeDelayMs?: number;
-  }) {
+  constructor(options: { token: string; knowledgeBaseId: string }) {
     this.#token = options.token;
     this.#knowledgeBaseId = options.knowledgeBaseId;
-    this.#writeDelayMs = options.writeDelayMs ?? 250;
   }
 
   async #request<T>(
     method: string,
     path: string,
-    body?: unknown,
-    formData?: FormData
+    options: {
+      body?: unknown;
+      formData?: FormData;
+      bucket: RateBucket;
+      /**
+       * False for requests that may commit server side even when the response
+       * is lost. Those are retried only when the API states it rejected them.
+       */
+      idempotent?: boolean;
+    }
   ): Promise<T> {
+    const { body, formData, bucket, idempotent = true } = options;
     let lastError: Error | undefined;
 
     for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
       if (attempt > 0) await sleep(2 ** (attempt - 1) * 1000);
+      await this.#throttle(bucket);
 
       let response: Response;
       try {
@@ -81,11 +104,12 @@ export class PylonClient {
           signal: AbortSignal.timeout(REQUEST_TIMEOUT_MS),
         });
       } catch (error) {
-        // Timeouts and socket errors only - a completed HTTP response never
-        // lands here, so everything caught is worth another attempt.
+        // A timeout or socket error says nothing about whether the server
+        // acted on the request, so a non-idempotent call must not be repeated.
         lastError = new Error(
           `${method} ${path} failed: ${error instanceof Error ? error.message : String(error)}`
         );
+        if (!idempotent) throw lastError;
         continue;
       }
 
@@ -102,6 +126,10 @@ export class PylonClient {
       // 4xx other than throttling means the request itself is wrong.
       if (response.status !== 429 && response.status < 500) throw lastError;
 
+      // 429 is the one failure that proves the request was rejected rather
+      // than applied, so repeating it is safe whatever the method.
+      if (response.status !== 429 && !idempotent) throw lastError;
+
       const retryAfter = Number(response.headers.get('retry-after'));
       if (Number.isFinite(retryAfter) && retryAfter > 0) {
         await sleep(retryAfter * 1000);
@@ -111,17 +139,20 @@ export class PylonClient {
     throw lastError ?? new Error('unreachable');
   }
 
-  /** Space out mutations so a 184-article run does not trip rate limits. */
-  async #throttleWrite(): Promise<void> {
-    const waitMs = this.#lastWriteAt + this.#writeDelayMs - Date.now();
+  /** Paces each endpoint to the rate its documentation allows. */
+  async #throttle(bucket: RateBucket): Promise<void> {
+    const intervalMs = (60_000 / RATE_LIMITS[bucket]) * RATE_LIMIT_MARGIN;
+    const waitMs =
+      (this.#lastRequestAt.get(bucket) ?? 0) + intervalMs - Date.now();
     if (waitMs > 0) await sleep(waitMs);
-    this.#lastWriteAt = Date.now();
+    this.#lastRequestAt.set(bucket, Date.now());
   }
 
   async getAuthenticatedUserId(): Promise<string> {
     const response = await this.#request<{ data: { user: { id: string } } }>(
       'GET',
-      '/me'
+      '/me',
+      { bucket: 'articleList' }
     );
     return response.data.user.id;
   }
@@ -136,7 +167,9 @@ export class PylonClient {
       const response = await this.#request<{
         data: PylonArticle[];
         pagination?: { cursor?: string; has_next_page?: boolean };
-      }>('GET', `/knowledge-bases/${this.#knowledgeBaseId}/articles?${query}`);
+      }>('GET', `/knowledge-bases/${this.#knowledgeBaseId}/articles?${query}`, {
+        bucket: 'articleList',
+      });
       articles.push(...(response.data ?? []));
       cursor = response.pagination?.has_next_page
         ? response.pagination.cursor
@@ -146,12 +179,16 @@ export class PylonClient {
     return articles;
   }
 
+  /**
+   * Not retried on an ambiguous failure. A lost response for a committed
+   * create would duplicate the article; leaving it for the next run to
+   * reconcile by slug is the safer recovery.
+   */
   async createArticle(input: CreateArticleInput): Promise<PylonArticle> {
-    await this.#throttleWrite();
     const response = await this.#request<{ data: PylonArticle }>(
       'POST',
       `/knowledge-bases/${this.#knowledgeBaseId}/articles`,
-      input
+      { body: input, bucket: 'articleCreate', idempotent: false }
     );
     return response.data;
   }
@@ -160,20 +197,19 @@ export class PylonClient {
     articleId: string,
     input: UpdateArticleInput
   ): Promise<PylonArticle> {
-    await this.#throttleWrite();
     const response = await this.#request<{ data: PylonArticle }>(
       'PATCH',
       `/knowledge-bases/${this.#knowledgeBaseId}/articles/${articleId}`,
-      input
+      { body: input, bucket: 'articleUpdate' }
     );
     return response.data;
   }
 
   async deleteArticle(articleId: string): Promise<void> {
-    await this.#throttleWrite();
     await this.#request(
       'DELETE',
-      `/knowledge-bases/${this.#knowledgeBaseId}/articles/${articleId}`
+      `/knowledge-bases/${this.#knowledgeBaseId}/articles/${articleId}`,
+      { bucket: 'articleDelete' }
     );
   }
 
@@ -183,7 +219,6 @@ export class PylonClient {
     bytes: Uint8Array,
     contentType: string
   ): Promise<string> {
-    await this.#throttleWrite();
     const form = new FormData();
     // Copied into a plain Uint8Array because a Node Buffer's backing store is
     // not the ArrayBuffer that Blob requires.
@@ -192,11 +227,12 @@ export class PylonClient {
       new Blob([new Uint8Array(bytes)], { type: contentType }),
       fileName
     );
+    // Retried like any other request: a duplicate upload only leaves an unused
+    // file behind, and the URL that gets embedded is the one returned here.
     const response = await this.#request<{ data: { url: string } }>(
       'POST',
       '/attachments',
-      undefined,
-      form
+      { formData: form, bucket: 'attachmentCreate' }
     );
     return response.data.url;
   }

--- a/astro-docs/scripts/pylon/render-preview.ts
+++ b/astro-docs/scripts/pylon/render-preview.ts
@@ -4,6 +4,7 @@
  *
  * Usage:
  *   tsx scripts/pylon/render-preview.ts                 # census + warnings
+ *   tsx scripts/pylon/render-preview.ts --strict        # fail on any warning
  *   tsx scripts/pylon/render-preview.ts <slug>          # print one article
  *   tsx scripts/pylon/render-preview.ts <slug> --out=f  # write it to a file
  */
@@ -84,4 +85,13 @@ if (only) {
       ? `\nwarnings (${allWarnings.length}):\n  ${allWarnings.join('\n  ')}`
       : '\nno warnings'
   );
+
+  // An unsupported tag or a missing image degrades the synced article, so CI
+  // should reject it here rather than let the nightly publish it.
+  if (args.includes('--strict') && allWarnings.length) {
+    console.error(
+      `\n${allWarnings.length} conversion warning(s) with --strict`
+    );
+    process.exit(1);
+  }
 }

--- a/astro-docs/scripts/pylon/render-preview.ts
+++ b/astro-docs/scripts/pylon/render-preview.ts
@@ -1,0 +1,87 @@
+/**
+ * Renders `/docs/kb` articles through the Pylon converter without touching the
+ * API, so conversion changes can be reviewed offline.
+ *
+ * Usage:
+ *   tsx scripts/pylon/render-preview.ts                 # census + warnings
+ *   tsx scripts/pylon/render-preview.ts <slug>          # print one article
+ *   tsx scripts/pylon/render-preview.ts <slug> --out=f  # write it to a file
+ */
+
+import { readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { basename, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { convertArticle } from './markdoc-to-html.ts';
+
+const scriptDir = fileURLToPath(new URL('.', import.meta.url));
+const astroDocsRoot = resolve(scriptDir, '../..');
+const repoRoot = resolve(astroDocsRoot, '..');
+const kbDir = resolve(astroDocsRoot, 'src/content/docs/kb');
+const publicDir = resolve(astroDocsRoot, 'public');
+
+const args = process.argv.slice(2);
+const outFile = args
+  .find((arg) => arg.startsWith('--out='))
+  ?.slice('--out='.length);
+const only = args.find((arg) => !arg.startsWith('--'));
+
+function convert(slug: string) {
+  const sourcePath = resolve(kbDir, `${slug}.mdoc`);
+  return convertArticle(readFileSync(sourcePath, 'utf8'), {
+    sourcePath,
+    publicDir,
+    repoRoot,
+    canonicalUrl: `https://nx.dev/docs/kb/${slug}`,
+    siteUrl: 'https://nx.dev',
+  });
+}
+
+if (only) {
+  const result = convert(only);
+  const html = result.html;
+  if (outFile) {
+    writeFileSync(outFile, html);
+    console.log(`wrote ${html.length} bytes to ${outFile}`);
+  } else {
+    console.log(html);
+  }
+  console.log(`\ntitle: ${result.title}`);
+  console.log(`assets: ${result.assets.length}`);
+  if (result.warnings.length)
+    console.log(`warnings:\n  ${result.warnings.join('\n  ')}`);
+} else {
+  const slugs = readdirSync(kbDir)
+    .filter((file) => file.endsWith('.mdoc'))
+    .map((file) => basename(file, '.mdoc'))
+    .sort();
+
+  const elementCounts: Record<string, number> = {};
+  const allWarnings: string[] = [];
+  let totalBytes = 0;
+  let totalAssets = 0;
+
+  for (const slug of slugs) {
+    const result = convert(slug);
+    totalBytes += result.html.length;
+    totalAssets += result.assets.length;
+    for (const warning of result.warnings)
+      allWarnings.push(`${slug}: ${warning}`);
+    for (const [, tag] of result.html.matchAll(/<([a-z][a-z0-9]*)[\s/>]/g))
+      elementCounts[tag] = (elementCounts[tag] ?? 0) + 1;
+  }
+
+  console.log(`articles: ${slugs.length}`);
+  console.log(`html bytes: ${totalBytes.toLocaleString()}`);
+  console.log(`image references: ${totalAssets}`);
+  console.log(
+    `\nelements:\n  ${Object.entries(elementCounts)
+      .sort((a, b) => b[1] - a[1])
+      .map(([tag, count]) => `${tag}:${count}`)
+      .join('  ')}`
+  );
+  console.log(
+    allWarnings.length
+      ? `\nwarnings (${allWarnings.length}):\n  ${allWarnings.join('\n  ')}`
+      : '\nno warnings'
+  );
+}

--- a/astro-docs/scripts/pylon/sync-kb.ts
+++ b/astro-docs/scripts/pylon/sync-kb.ts
@@ -21,6 +21,7 @@ import { fileURLToPath } from 'node:url';
 import {
   ASSET_PLACEHOLDER_PREFIX,
   convertArticle,
+  escapeAttribute,
   type AssetRef,
 } from './markdoc-to-html.ts';
 import { PylonClient, type PylonArticle } from './pylon-client.ts';
@@ -189,9 +190,11 @@ async function resolveAssets(
       uploaded.set(asset.key, url);
       uploads++;
     }
-    html = html.replaceAll(
-      `${ASSET_PLACEHOLDER_PREFIX}${asset.key}`,
-      url.replaceAll('&', '&amp;')
+    // A replacer function, because a string replacement would treat $&, $`,
+    // $' and $$ in the URL as substitution directives. Escaped the same way
+    // the converter escapes every other attribute.
+    html = html.replaceAll(`${ASSET_PLACEHOLDER_PREFIX}${asset.key}`, () =>
+      escapeAttribute(url)
     );
   }
 

--- a/astro-docs/scripts/pylon/sync-kb.ts
+++ b/astro-docs/scripts/pylon/sync-kb.ts
@@ -146,7 +146,10 @@ function collectUploadedAssets(articles: PylonArticle[]): Map<string, string> {
   for (const article of articles) {
     for (const [, url, key] of bodyOf(article).matchAll(imgPattern)) {
       if (!url.startsWith(ASSET_PLACEHOLDER_PREFIX)) {
-        uploaded.set(decodeAttribute(key), url);
+        // Both are attribute values. Signed CDN URLs carry `&` between query
+        // parameters, so recovering one without decoding would re-escape it on
+        // every run and the article would never compare equal.
+        uploaded.set(decodeAttribute(key), decodeAttribute(url));
       }
     }
   }

--- a/astro-docs/scripts/pylon/sync-kb.ts
+++ b/astro-docs/scripts/pylon/sync-kb.ts
@@ -1,0 +1,335 @@
+/**
+ * Mirrors `astro-docs/src/content/docs/kb` into the Pylon knowledge base.
+ *
+ * nx.dev stays canonical: this only pushes copies so Pylon can suggest them as
+ * answers in the support widget. Nothing outside `/docs/kb` is touched, and
+ * writes are confined to a single Pylon collection so the hand-written
+ * enterprise articles that live beside them are never modified.
+ *
+ * Usage:
+ *   PYLON_API_TOKEN=... tsx scripts/pylon/sync-kb.ts [options]
+ *
+ *   --dry-run          report what would change without writing
+ *   --prune            delete articles whose source page no longer exists
+ *   --strict           exit non-zero when any article produces a warning
+ *   --only=<slug>      restrict the run to one article
+ */
+
+import { readdirSync, readFileSync } from 'node:fs';
+import { basename, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import {
+  ASSET_PLACEHOLDER_PREFIX,
+  convertArticle,
+  type AssetRef,
+} from './markdoc-to-html.ts';
+import { PylonClient, type PylonArticle } from './pylon-client.ts';
+
+/** "Nrwl Knowledge Base" on help.nx.app. */
+const KNOWLEDGE_BASE_ID = 'e35aaa8d-4b65-4024-98c0-8e508846a027';
+/**
+ * "Nx Knowledge Base". Every article this script owns lives here; the
+ * hand-written "Nx Cloud Enterprise" collection is deliberately out of scope.
+ */
+const COLLECTION_ID = 'bd2e85a6-896a-457f-9540-8bc5a5cb4e8b';
+
+const SITE_URL = 'https://nx.dev';
+const DOCS_BASE = '/docs/kb';
+
+/**
+ * Articles stay unlisted so nx.dev remains the SEO canonical for this content.
+ * Unlisted articles are still reachable by direct link, which is how a
+ * suggested answer surfaces them.
+ */
+const IS_UNLISTED = true;
+
+/** A prune this large means the source directory failed to resolve, not a real deletion. */
+const MAX_PRUNE_RATIO = 0.25;
+
+const scriptDir = fileURLToPath(new URL('.', import.meta.url));
+const astroDocsRoot = resolve(scriptDir, '../..');
+const repoRoot = resolve(astroDocsRoot, '..');
+const kbDir = resolve(astroDocsRoot, 'src/content/docs/kb');
+const publicDir = resolve(astroDocsRoot, 'public');
+
+interface Options {
+  dryRun: boolean;
+  prune: boolean;
+  strict: boolean;
+  only?: string;
+}
+
+interface SourceArticle {
+  slug: string;
+  title: string;
+  html: string;
+  assets: AssetRef[];
+  warnings: string[];
+}
+
+function parseOptions(argv: string[]): Options {
+  const only = argv
+    .find((arg) => arg.startsWith('--only='))
+    ?.slice('--only='.length);
+  const unknown = argv.filter(
+    (arg) =>
+      !['--dry-run', '--prune', '--strict'].includes(arg) &&
+      !arg.startsWith('--only=')
+  );
+  if (unknown.length) {
+    throw new Error(`Unknown option(s): ${unknown.join(', ')}`);
+  }
+  return {
+    dryRun: argv.includes('--dry-run'),
+    prune: argv.includes('--prune'),
+    strict: argv.includes('--strict'),
+    only,
+  };
+}
+
+function readSourceArticles(options: Options): SourceArticle[] {
+  const files = readdirSync(kbDir)
+    .filter((file) => file.endsWith('.mdoc'))
+    .sort();
+
+  const articles: SourceArticle[] = [];
+  for (const file of files) {
+    const slug = basename(file, '.mdoc');
+    if (options.only && options.only !== slug) continue;
+
+    const sourcePath = resolve(kbDir, file);
+    const converted = convertArticle(readFileSync(sourcePath, 'utf8'), {
+      sourcePath,
+      publicDir,
+      repoRoot,
+      canonicalUrl: `${SITE_URL}${DOCS_BASE}/${slug}`,
+      siteUrl: SITE_URL,
+    });
+
+    if (!converted.title) {
+      throw new Error(`${file} has no title in its frontmatter`);
+    }
+
+    articles.push({
+      slug,
+      title: converted.title,
+      html: converted.html,
+      assets: converted.assets,
+      warnings: converted.warnings,
+    });
+  }
+
+  if (options.only && articles.length === 0) {
+    throw new Error(`No article matches --only=${options.only}`);
+  }
+  return articles;
+}
+
+function bodyOf(article: PylonArticle): string {
+  return (
+    article.current_published_content_html ||
+    article.current_draft_content_html ||
+    ''
+  );
+}
+
+/**
+ * Recovers the CDN URL already uploaded for each image, keyed by the
+ * `data-nx-src` marker a previous run embedded next to it. Without this every
+ * nightly run would re-upload the same files under new URLs and every article
+ * would look changed.
+ */
+function collectUploadedAssets(articles: PylonArticle[]): Map<string, string> {
+  const uploaded = new Map<string, string>();
+  const imgPattern = /<img[^>]*\ssrc="([^"]+)"[^>]*\sdata-nx-src="([^"]+)"/g;
+
+  for (const article of articles) {
+    for (const [, url, key] of bodyOf(article).matchAll(imgPattern)) {
+      if (!url.startsWith(ASSET_PLACEHOLDER_PREFIX)) {
+        uploaded.set(decodeAttribute(key), url);
+      }
+    }
+  }
+  return uploaded;
+}
+
+function decodeAttribute(value: string): string {
+  return value
+    .replaceAll('&quot;', '"')
+    .replaceAll('&gt;', '>')
+    .replaceAll('&lt;', '<')
+    .replaceAll('&amp;', '&');
+}
+
+async function resolveAssets(
+  article: SourceArticle,
+  uploaded: Map<string, string>,
+  client: PylonClient,
+  options: Options
+): Promise<{ html: string; uploads: number }> {
+  let html = article.html;
+  let uploads = 0;
+
+  for (const asset of article.assets) {
+    let url = uploaded.get(asset.key);
+    if (!url) {
+      if (options.dryRun) {
+        // Leave the placeholder in place; the comparison below will report the
+        // article as changed, which is the honest answer for a new image.
+        continue;
+      }
+      url = await client.uploadAttachment(
+        asset.fileName,
+        readFileSync(asset.absolutePath),
+        asset.contentType
+      );
+      uploaded.set(asset.key, url);
+      uploads++;
+    }
+    html = html.replaceAll(
+      `${ASSET_PLACEHOLDER_PREFIX}${asset.key}`,
+      url.replaceAll('&', '&amp;')
+    );
+  }
+
+  return { html, uploads };
+}
+
+async function main(): Promise<void> {
+  const options = parseOptions(process.argv.slice(2));
+
+  const token = process.env.PYLON_API_TOKEN;
+  if (!token) throw new Error('PYLON_API_TOKEN is not set');
+
+  const client = new PylonClient({ token, knowledgeBaseId: KNOWLEDGE_BASE_ID });
+  const authorUserId =
+    process.env.PYLON_AUTHOR_USER_ID ?? (await client.getAuthenticatedUserId());
+
+  const sources = readSourceArticles(options);
+  const allRemote = await client.listArticles();
+  const remote = allRemote.filter(
+    (article) => article.collection_id === COLLECTION_ID
+  );
+  const remoteBySlug = new Map(
+    remote.map((article) => [article.slug, article])
+  );
+  const uploaded = collectUploadedAssets(allRemote);
+
+  console.log(
+    `${sources.length} source article(s), ${remote.length} already in the Pylon collection` +
+      (options.dryRun ? ' (dry run)' : '')
+  );
+
+  const created: string[] = [];
+  const updated: string[] = [];
+  const skipped: string[] = [];
+  const warnings: string[] = [];
+  let uploads = 0;
+
+  for (const source of sources) {
+    for (const warning of source.warnings) {
+      warnings.push(`${source.slug}: ${warning}`);
+    }
+
+    const resolved = await resolveAssets(source, uploaded, client, options);
+    uploads += resolved.uploads;
+
+    const existing = remoteBySlug.get(source.slug);
+    if (!existing) {
+      created.push(source.slug);
+      if (!options.dryRun) {
+        await client.createArticle({
+          title: source.title,
+          slug: source.slug,
+          author_user_id: authorUserId,
+          collection_id: COLLECTION_ID,
+          body_html: resolved.html,
+          is_published: true,
+          is_unlisted: IS_UNLISTED,
+        });
+      }
+      continue;
+    }
+
+    const unchanged =
+      bodyOf(existing) === resolved.html &&
+      existing.title === source.title &&
+      existing.is_published &&
+      existing.is_unlisted === IS_UNLISTED;
+
+    if (unchanged) {
+      skipped.push(source.slug);
+      continue;
+    }
+
+    updated.push(source.slug);
+    if (!options.dryRun) {
+      await client.updateArticle(existing.id, {
+        title: source.title,
+        body_html: resolved.html,
+        is_published: true,
+        is_unlisted: IS_UNLISTED,
+        publish_updated_body_html: true,
+      });
+    }
+  }
+
+  const sourceSlugs = new Set(sources.map((source) => source.slug));
+  // A partial run cannot tell a deleted page from one it was told to skip.
+  const orphans = options.only
+    ? []
+    : remote.filter((article) => !sourceSlugs.has(article.slug));
+
+  if (orphans.length && options.prune) {
+    if (orphans.length > remote.length * MAX_PRUNE_RATIO) {
+      throw new Error(
+        `Refusing to prune ${orphans.length} of ${remote.length} articles. ` +
+          `Re-run without --prune and confirm the source directory resolved correctly.`
+      );
+    }
+    for (const orphan of orphans) {
+      if (!options.dryRun) await client.deleteArticle(orphan.id);
+    }
+  }
+
+  console.log(
+    [
+      '',
+      `created: ${created.length}`,
+      `updated: ${updated.length}`,
+      `unchanged: ${skipped.length}`,
+      `images uploaded: ${uploads}`,
+      `orphaned in Pylon: ${orphans.length}${
+        orphans.length
+          ? options.prune
+            ? ' (pruned)'
+            : ' (use --prune to delete)'
+          : ''
+      }`,
+    ].join('\n')
+  );
+
+  for (const [label, slugs] of [
+    ['create', created],
+    ['update', updated],
+  ] as const) {
+    if (slugs.length) console.log(`\n${label}:\n  ${slugs.join('\n  ')}`);
+  }
+  if (orphans.length) {
+    console.log(
+      `\norphaned:\n  ${orphans.map((article) => article.slug).join('\n  ')}`
+    );
+  }
+  if (warnings.length) {
+    console.log(`\nwarnings (${warnings.length}):\n  ${warnings.join('\n  ')}`);
+  }
+
+  if (options.strict && warnings.length) {
+    throw new Error(`${warnings.length} warning(s) with --strict`);
+  }
+}
+
+main().catch((error) => {
+  console.error(`\npylon kb sync failed: ${error.message}`);
+  process.exit(1);
+});

--- a/astro-docs/scripts/pylon/sync-kb.ts
+++ b/astro-docs/scripts/pylon/sync-kb.ts
@@ -205,10 +205,10 @@ async function main(): Promise<void> {
   if (!token) throw new Error('PYLON_API_TOKEN is not set');
 
   const client = new PylonClient({ token, knowledgeBaseId: KNOWLEDGE_BASE_ID });
-  // Falsy rather than nullish: an unset Actions variable arrives as an empty
-  // string, which would otherwise be sent as the author of every new article.
-  const authorUserId =
-    process.env.PYLON_AUTHOR_USER_ID || (await client.getAuthenticatedUserId());
+  // The API requires an author on create. The token belongs to an Nx service
+  // identity rather than a person, and Pylon does not render the author on the
+  // published article, so there is nothing to attribute elsewhere.
+  const authorUserId = await client.getAuthenticatedUserId();
 
   const sources = readSourceArticles(options);
   const allRemote = await client.listArticles();

--- a/astro-docs/scripts/pylon/sync-kb.ts
+++ b/astro-docs/scripts/pylon/sync-kb.ts
@@ -202,8 +202,10 @@ async function main(): Promise<void> {
   if (!token) throw new Error('PYLON_API_TOKEN is not set');
 
   const client = new PylonClient({ token, knowledgeBaseId: KNOWLEDGE_BASE_ID });
+  // Falsy rather than nullish: an unset Actions variable arrives as an empty
+  // string, which would otherwise be sent as the author of every new article.
   const authorUserId =
-    process.env.PYLON_AUTHOR_USER_ID ?? (await client.getAuthenticatedUserId());
+    process.env.PYLON_AUTHOR_USER_ID || (await client.getAuthenticatedUserId());
 
   const sources = readSourceArticles(options);
   const allRemote = await client.listArticles();

--- a/astro-docs/scripts/pylon/sync-kb.ts
+++ b/astro-docs/scripts/pylon/sync-kb.ts
@@ -204,13 +204,26 @@ async function main(): Promise<void> {
   const token = process.env.PYLON_API_TOKEN;
   if (!token) throw new Error('PYLON_API_TOKEN is not set');
 
+  const sources = readSourceArticles(options);
+
+  // Conversion happens before anything is written, so --strict can reject a
+  // degraded article rather than publish it and report the damage afterwards.
+  const warnings = sources.flatMap((source) =>
+    source.warnings.map((warning) => `${source.slug}: ${warning}`)
+  );
+  if (options.strict && warnings.length) {
+    throw new Error(
+      `${warnings.length} conversion warning(s), nothing written:\n  ` +
+        warnings.join('\n  ')
+    );
+  }
+
   const client = new PylonClient({ token, knowledgeBaseId: KNOWLEDGE_BASE_ID });
   // The API requires an author on create. The token belongs to an Nx service
   // identity rather than a person, and Pylon does not render the author on the
   // published article, so there is nothing to attribute elsewhere.
   const authorUserId = await client.getAuthenticatedUserId();
 
-  const sources = readSourceArticles(options);
   const allRemote = await client.listArticles();
   const remote = allRemote.filter(
     (article) => article.collection_id === COLLECTION_ID
@@ -228,14 +241,9 @@ async function main(): Promise<void> {
   const created: string[] = [];
   const updated: string[] = [];
   const skipped: string[] = [];
-  const warnings: string[] = [];
   let uploads = 0;
 
   for (const source of sources) {
-    for (const warning of source.warnings) {
-      warnings.push(`${source.slug}: ${warning}`);
-    }
-
     const resolved = await resolveAssets(source, uploaded, client, options);
     uploads += resolved.uploads;
 
@@ -327,10 +335,6 @@ async function main(): Promise<void> {
   }
   if (warnings.length) {
     console.log(`\nwarnings (${warnings.length}):\n  ${warnings.join('\n  ')}`);
-  }
-
-  if (options.strict && warnings.length) {
-    throw new Error(`${warnings.length} warning(s) with --strict`);
   }
 }
 


### PR DESCRIPTION
## Current Behavior

Pylon crawls nx.dev, but crawled training data does not feed the support widget's suggested-answer feature - only real KB articles are eligible. The 173 articles left in Pylon from the closed #36277 migration are stale copies of pre-DOC-552 doc paths with no way to refresh them.

## Expected Behavior

A nightly job mirrors `astro-docs/src/content/docs/kb` into Pylon. nx.dev stays canonical - copy only, no source deletion and no redirects.

Pylon stores `body_html` verbatim, so change detection is a byte compare with no state file. Images carry a `data-nx-src` content-hash marker so re-runs reuse the uploaded CDN URL. Writes are confined to one collection, keeping the hand-written enterprise articles out of reach, and `--prune` is opt-in and refuses to delete more than a quarter of the collection.

All 184 articles convert with no warnings. Articles stay unlisted so nx.dev remains SEO-canonical.

Still needed before the nightly can run: `PYLON_API_TOKEN` as an environment secret in a `pylon` environment whose deployment branches are limited to `master`, with no required reviewers so the schedule is not blocked. A repo secret would satisfy the job but bypass that branch isolation.

Sample article:
- https://help.nx.app/articles/9326606694-Nx-CLI-and-CI-Access-Tokens#github-actions

## Related Issue(s)

DOC-542

<!-- polygraph-session-start -->
---
<p><picture><source media="(prefers-color-scheme: dark)" srcset="https://static.ops.cloud.nx.app/polygraph/session-logo-v4-dark.svg"><img src="https://static.ops.cloud.nx.app/polygraph/session-logo-v4-light.svg" width="16" height="22" align="middle" alt="Polygraph"></picture> <a href="https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/docs-pylon-kb-sync-68df0065">View session ↗</a></p>
<!-- polygraph-session-end -->