### PR TITLE
docs(misc): adjust margins and reorder intro for "Add to existing project"

### DIFF
--- a/astro-docs/src/components/markdoc/Youtube.astro
+++ b/astro-docs/src/components/markdoc/Youtube.astro
@@ -30,3 +30,11 @@ type Props = YouTubeProps;
 
   customElements.define('youtube-jsapi', YouTubeJsapiElement);
 </script>
+
+<style>
+youtube-jsapi {
+  display: block;
+  margin-top: 1rem;
+}
+</style>
+

--- a/astro-docs/src/content/docs/getting-started/start-with-existing-project.mdoc
+++ b/astro-docs/src/content/docs/getting-started/start-with-existing-project.mdoc
@@ -7,8 +7,6 @@ sidebar:
 filter: 'type:Guides'
 ---
 
-{% course_video src="https://youtu.be/3hW53b1IJ84" courseTitle="From PNPM Workspaces to Distributed CI" courseUrl="https://nx.dev/courses/pnpm-nx-next/lessons-01-nx-init" /%}
-
 {% llm_copy_prompt title="Let an AI agent set it up for you" %}
 Help me add Nx to my existing repository.
 
@@ -23,6 +21,9 @@ Page: {pageUrl}
 {% /llm_copy_prompt %}
 
 Nx is designed for incremental adoption. Start with task running and [caching](/docs/features/cache-task-results), then add [plugins](/docs/technologies), CI integrations, or other capabilities as your needs grow.
+
+{% course_video src="https://youtu.be/3hW53b1IJ84" courseTitle="From PNPM Workspaces to Distributed CI" courseUrl="https://nx.dev/courses/pnpm-nx-next/lessons-01-nx-init" /%}
+
 
 Add Nx to any existing project with a single command:
 

--- a/astro-docs/src/content/docs/getting-started/start-with-existing-project.mdoc
+++ b/astro-docs/src/content/docs/getting-started/start-with-existing-project.mdoc
@@ -24,7 +24,6 @@ Nx is designed for incremental adoption. Start with task running and [caching](/
 
 {% course_video src="https://youtu.be/3hW53b1IJ84" courseTitle="From PNPM Workspaces to Distributed CI" courseUrl="https://nx.dev/courses/pnpm-nx-next/lessons-01-nx-init" /%}
 
-
 Add Nx to any existing project with a single command:
 
 ```shell {% meta="prompt=true" %}


### PR DESCRIPTION
While going through the getting started pages, I noticed a few issues.

1. Youtube player does not have margins around it, so spacing is too tight with intro paragraphs. 
<img width="822" height="645" alt="image" src="https://github.com/user-attachments/assets/fa22d40c-f5b9-4da2-a050-868066e254ab" />

2. `Start with an existing project` page should have prompt first, then intro sentence/paragraph, then video, like we do on other pages.
<img width="840" height="888" alt="image" src="https://github.com/user-attachments/assets/988399dc-e6a4-4368-a4f5-e11a6d767a11" />

---

Fixed 1:

<img width="774" height="656" alt="Screenshot 2026-08-07 at 9 01 58 AM" src="https://github.com/user-attachments/assets/00adac1e-f8bf-4ec2-882a-f39951836096" />

Fixed 2:
<img width="843" height="1059" alt="Screenshot 2026-08-07 at 9 02 08 AM" src="https://github.com/user-attachments/assets/5ff8d6af-5237-4e7c-b6a6-41390ff07a6a" />

