### PR TITLE
chore(repo): harden the release and publish workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,6 +9,9 @@ on:
     branches:
       - "**"
 
+permissions:
+  contents: read
+
 env:
   NX_CLOUD_ACCESS_TOKEN: ${{ secrets.NX_CLOUD_ACCESS_TOKEN }}
   NX_CLOUD_ENABLE_METRICS_COLLECTION: 'true'

--- a/.github/workflows/do-not-merge.yml
+++ b/.github/workflows/do-not-merge.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     types: [synchronize, opened, reopened, labeled, unlabeled]
 
+permissions: {}
+
 jobs:
   do-not-merge:
     if: ${{ github.repository_owner == 'nrwl' }}

--- a/.github/workflows/generate-embeddings.yml
+++ b/.github/workflows/generate-embeddings.yml
@@ -4,6 +4,9 @@ on:
   schedule:
     - cron: "0 5 * * 0,4" # sunday, thursday 5AM
 
+permissions:
+  contents: read
+
 jobs:
   cache-and-install:
     if: github.repository == 'nrwl/nx'

--- a/.github/workflows/issue-notifier.yml
+++ b/.github/workflows/issue-notifier.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Download artifact
         id: download-artifact
-        uses: dawidd6/action-download-artifact@268677152d06ba59fcec7a7f0b5d961b6ccd7e1e # v2 # Needed since we are downloading artifact from a different workflow run, official actions/download-artifact doesn't support this.
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21 # Needed since we are downloading artifact from a different workflow run, official actions/download-artifact doesn't support this.
         with:
           name: cached-issue-data
           path: ${{ github.workspace }}/scripts/issues-scraper/cached

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -352,7 +352,10 @@ jobs:
             ~/.cargo/git/db/
             .cargo-cache
             target/
-          key: ${{ matrix.settings.target }}-cargo-registry
+          # Scoped to the ref being released, so a release build only restores a
+          # cache written from that same ref rather than any branch that shares
+          # the target name.
+          key: ${{ matrix.settings.target }}-cargo-registry-${{ github.ref_name }}
 
       - name: Setup toolchain
         run: ${{ matrix.settings.setup }}
@@ -375,7 +378,6 @@ jobs:
         with:
           node-version: ${{ env.NODE_VERSION }}
           check-latest: true
-          cache: pnpm
           architecture: x86
 
       - name: Build in docker

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -14,6 +14,11 @@ on:
   release:
     types: [ published ]
 
+# Default for jobs that do not declare their own. The publish, PR comment
+# and data resolution jobs override this with exactly what they use.
+permissions:
+  contents: read
+
 # Dynamically generate the display name for the GitHub UI based on the event type and inputs
 run-name: ${{ github.event.inputs.pr && format('PR Release for {0}', github.event.inputs.pr) || github.event_name == 'schedule' && 'Canary Release' || github.event_name == 'workflow_dispatch' && !github.event.inputs.pr && 'Release Dry-Run' || github.ref_name }}
 
@@ -45,6 +50,9 @@ jobs:
     name: Resolve Required Data
     if: ${{ github.repository_owner == 'nrwl' }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read # publish-resolve-data.js calls pulls.get
     outputs:
       version: ${{ steps.script.outputs.version }}
       dry_run_flag: ${{ steps.script.outputs.dry_run_flag }}
@@ -697,6 +705,7 @@ jobs:
       - build-freebsd
       - build
     runs-on: ubuntu-latest
+    permissions: {} # posts to Slack only
     timeout-minutes: 10
     continue-on-error: true  # Don't fail the workflow if notification fails
     outputs:
@@ -792,6 +801,7 @@ jobs:
       - publish
       - report-pending-publish
     runs-on: ubuntu-latest
+    permissions: {} # posts to Slack only
     timeout-minutes: 10
     continue-on-error: true  # Don't fail the workflow if notification fails
     steps:


### PR DESCRIPTION
## Current Behavior

**1. `dawidd6/action-download-artifact` is pinned to v2, which is in an advisory range.** `issue-notifier.yml` uses it to download an artifact from a different workflow run with `search_artifacts`. Versions before v6 are affected by [GHSA-5xr6-xhww-33m4](https://github.com/advisories/GHSA-5xr6-xhww-33m4) (artifact poisoning, high), where the action can be made to unpack an artifact uploaded by an untrusted run into the workspace. That is the pattern this step uses.

**2. The release build's cargo cache key is shared across branches.** In `publish.yml`, the job that builds the published native binaries restores a cargo cache keyed only on the target triple, so every branch that runs the job shares one entry per target.

**3. Four workflows declare no `permissions:` block.** `ci.yml`, `do-not-merge.yml`, `generate-embeddings.yml` and `publish.yml` fall back to the repository default token scope for every job, including the jobs that build and publish the native binaries.

## Expected Behavior

**1.** Bumped to v21, the current release. It keeps every input used here (`name`, `path`, `search_artifacts`, `allow_forks`), so this is a pin change and nothing else.

**2.** The ref is added to the cache key, so a release build only restores what that same ref produced. Canary releases from `master` keep hitting the cache exactly as before, since the ref does not change. The `cache: pnpm` line on the x86 Windows `setup-node` step has no equivalent key to scope, so it is dropped. That matrix leg is currently commented out, so it only matters if it is switched back on.

**3.** Scopes are read off what each job actually does rather than applied uniformly:

- `ci.yml` checks out and builds, with no API calls anywhere in the file, so `contents: read`.
- `do-not-merge.yml` reads labels from the event payload and never checks out, so it needs no token.
- `generate-embeddings.yml` checks out and talks to Supabase and OpenAI through their own secrets, so `contents: read`.
- `publish.yml` takes `contents: read` as the default. `resolve-required-data` adds `pull-requests: read` because `publish-resolve-data.js` calls `pulls.get`, and the two Slack reporters get an empty block since they only use the Slack bot token. The `publish` and `pr_failure_comment` jobs already scope themselves and are untouched.

One thing worth knowing if you use a repository-level Actions allowlist: entries written as tag patterns (`owner/action@v1`) stop matching once a workflow pins a SHA, and every workflow using that action then fails at startup. Nothing here changes an existing pin, so it should not bite, but the fix is `owner/action@*` in settings.

Found and fixed by [Plumber](https://github.com/getplumber/plumber)'s analysis, reviewed and submitted by me.

## Related Issue(s)

No existing issue, this came out of reading the workflows. Happy to open one first if you prefer that for changes like this.
