### PR TITLE
fix(core): drain stdout before exiting nx run-many and nx run

### DIFF
--- a/packages/nx/src/command-line/run-many/run-many.ts
+++ b/packages/nx/src/command-line/run-many/run-many.ts
@@ -76,6 +76,7 @@ export async function runMany(
       extraTargetDependencies,
       extraOptions
     );
+    await output.drain();
     process.exit(status);
   }
 }

--- a/packages/nx/src/command-line/run/run-one.ts
+++ b/packages/nx/src/command-line/run/run-one.ts
@@ -100,6 +100,7 @@ export async function runOne(
       extraTargetDependencies,
       extraOptions
     );
+    await output.drain();
     process.exit(status);
   }
 }


### PR DESCRIPTION
## Current Behavior

`nx run-many` and `nx run` call `process.exit` as soon as the run finishes, without waiting for stdout to flush. When stdout is a pipe, everything past the pipe buffer is dropped mid-line, and Nx's own trailing summary goes with it.

Running a target that writes 200 KiB, from #36606:

```
$ nx run-many -t noisy --skip-nx-cache | tr -cd '@' | wc -c
65473                     # truncated at one pipe buffer, of 204800
```

Redirecting to a file hides it, since those writes are synchronous.

## Expected Behavior

Both commands await `output.drain()` before exiting, so all task output and the run summary make it out.

I was looking to fix just `run-many`, but I found that `run` had the same issue, so I fixed it while I was here.

## Related Issue(s)

Fixes #36606
