### PR TITLE
fix(linter): avoid reloading the project graph on every linted file outside terminal runs

### DIFF
--- a/packages/devkit/internal.ts
+++ b/packages/devkit/internal.ts
@@ -226,6 +226,8 @@ export {
   normalizeDependencyConfigDefinition,
   normalizeDependencyConfigProjects,
   normalizeTargetDependencyWithStringProjects,
+  nxFileMap,
+  nxProjectGraph,
   nxVersion,
   orange,
   parseExecutor,

--- a/packages/eslint-plugin/src/utils/project-graph-utils.spec.ts
+++ b/packages/eslint-plugin/src/utils/project-graph-utils.spec.ts
@@ -1,0 +1,147 @@
+import { readCachedProjectGraph } from '@nx/devkit';
+import { statSync } from 'node:fs';
+import { isTerminalRun } from './runtime-lint-utils';
+import { readProjectGraph } from './project-graph-utils';
+
+jest.mock('@nx/devkit', () => ({
+  readCachedProjectGraph: jest.fn(),
+  workspaceRoot: '/root',
+}));
+
+jest.mock('@nx/devkit/internal', () => ({
+  createProjectRootMappings: jest.fn(),
+  readNxJsonFromDisk: jest.fn(),
+  readFileMapCache: jest.fn(),
+  nxProjectGraph: '/root/.nx/workspace-data/project-graph.json',
+  nxFileMap: '/root/.nx/workspace-data/file-map.json',
+}));
+
+jest.mock('@nx/js/internal', () => ({
+  TargetProjectLocator: jest.fn(),
+}));
+
+jest.mock('./runtime-lint-utils', () => ({
+  isTerminalRun: jest.fn(),
+}));
+
+jest.mock('node:fs', () => ({
+  ...jest.requireActual('node:fs'),
+  statSync: jest.fn(),
+}));
+
+const mockReadCachedProjectGraph = readCachedProjectGraph as jest.Mock;
+const mockIsTerminalRun = isTerminalRun as jest.Mock;
+const mockStatSync = statSync as unknown as jest.Mock;
+const { createProjectRootMappings, readNxJsonFromDisk, readFileMapCache } =
+  jest.requireMock('@nx/devkit/internal');
+
+const GRAPH_FILE = '/root/.nx/workspace-data/project-graph.json';
+const FILE_MAP_FILE = '/root/.nx/workspace-data/file-map.json';
+const NX_JSON_FILE = '/root/nx.json';
+
+describe('readProjectGraph', () => {
+  let fileStats: Record<string, { mtimeMs: number; size: number } | undefined>;
+  let stdoutSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    for (const key of [
+      'projectGraph',
+      'projectRootMappings',
+      'projectFileMap',
+      'targetProjectLocator',
+      'projectGraphFingerprint',
+      'workspaceLayout',
+    ]) {
+      delete (globalThis as any)[key];
+    }
+
+    fileStats = {
+      [GRAPH_FILE]: { mtimeMs: 100, size: 1000 },
+      [FILE_MAP_FILE]: { mtimeMs: 100, size: 2000 },
+      [NX_JSON_FILE]: { mtimeMs: 50, size: 300 },
+    };
+    mockStatSync.mockImplementation((path: string) => fileStats[path]);
+    mockIsTerminalRun.mockReturnValue(false);
+    mockReadCachedProjectGraph.mockReturnValue({
+      nodes: {},
+      externalNodes: {},
+      dependencies: {},
+    });
+    readNxJsonFromDisk.mockReturnValue({
+      workspaceLayout: { appsDir: 'apps', libsDir: 'libs' },
+    });
+    readFileMapCache.mockReturnValue({ fileMap: { projectFileMap: {} } });
+    createProjectRootMappings.mockReturnValue(new Map());
+    stdoutSpy = jest.spyOn(process.stdout, 'write').mockReturnValue(true);
+  });
+
+  afterEach(() => {
+    stdoutSpy.mockRestore();
+  });
+
+  it('should load the project graph on first invocation', () => {
+    const result = readProjectGraph('enforce-module-boundaries');
+
+    expect(mockReadCachedProjectGraph).toHaveBeenCalledTimes(1);
+    expect(result.projectGraph).toBeDefined();
+    expect(result.projectRootMappings).toBeDefined();
+    expect(result.projectFileMap).toBeDefined();
+    expect(result.targetProjectLocator).toBeDefined();
+  });
+
+  it('should reuse the cached graph without re-reading it during terminal runs', () => {
+    mockIsTerminalRun.mockReturnValue(true);
+
+    readProjectGraph('enforce-module-boundaries');
+    const statCallsAfterFirstRun = mockStatSync.mock.calls.length;
+    readProjectGraph('enforce-module-boundaries');
+
+    expect(mockReadCachedProjectGraph).toHaveBeenCalledTimes(1);
+    expect(mockStatSync.mock.calls.length).toBe(statCallsAfterFirstRun);
+  });
+
+  it('should reuse the cached graph while cache files are unchanged outside terminal runs', () => {
+    readProjectGraph('enforce-module-boundaries');
+    readProjectGraph('enforce-module-boundaries');
+    readProjectGraph('enforce-module-boundaries');
+
+    expect(mockReadCachedProjectGraph).toHaveBeenCalledTimes(1);
+  });
+
+  it('should reload the graph when a cache file changes outside terminal runs', () => {
+    readProjectGraph('enforce-module-boundaries');
+
+    fileStats[GRAPH_FILE] = { mtimeMs: 200, size: 1024 };
+    readProjectGraph('enforce-module-boundaries');
+    expect(mockReadCachedProjectGraph).toHaveBeenCalledTimes(2);
+
+    readProjectGraph('enforce-module-boundaries');
+    expect(mockReadCachedProjectGraph).toHaveBeenCalledTimes(2);
+  });
+
+  it('should reload the graph when nx.json changes outside terminal runs', () => {
+    readProjectGraph('enforce-module-boundaries');
+
+    fileStats[NX_JSON_FILE] = { mtimeMs: 51, size: 305 };
+    readProjectGraph('enforce-module-boundaries');
+
+    expect(mockReadCachedProjectGraph).toHaveBeenCalledTimes(2);
+  });
+
+  it('should warn and retry on the next invocation when no cached graph is available', () => {
+    fileStats = {};
+    mockReadCachedProjectGraph.mockImplementation(() => {
+      throw new Error('No cached ProjectGraph is available');
+    });
+
+    const result = readProjectGraph('enforce-module-boundaries');
+    expect(result.projectGraph).toBeUndefined();
+    expect(stdoutSpy).toHaveBeenCalledWith(
+      expect.stringContaining('No cached ProjectGraph is available')
+    );
+
+    readProjectGraph('enforce-module-boundaries');
+    expect(mockReadCachedProjectGraph).toHaveBeenCalledTimes(2);
+  });
+});

--- a/packages/eslint-plugin/src/utils/project-graph-utils.ts
+++ b/packages/eslint-plugin/src/utils/project-graph-utils.ts
@@ -2,6 +2,7 @@ import {
   ProjectFileMap,
   ProjectGraph,
   readCachedProjectGraph,
+  workspaceRoot,
 } from '@nx/devkit';
 import { isTerminalRun } from './runtime-lint-utils';
 import pc from 'picocolors';
@@ -11,45 +12,71 @@ import {
   ProjectRootMappings,
   readNxJsonFromDisk as readNxJson,
   readFileMapCache,
+  nxFileMap,
+  nxProjectGraph,
 } from '@nx/devkit/internal';
+import { statSync } from 'node:fs';
+import { join } from 'node:path';
+
+/**
+ * nx.json is fingerprinted alongside the graph caches because workspaceLayout
+ * is read from it whenever the graph is (re)loaded.
+ */
+function graphCacheFingerprint(): string {
+  return [nxProjectGraph, nxFileMap, join(workspaceRoot, 'nx.json')]
+    .map((file) => {
+      const stat = statSync(file, { throwIfNoEntry: false });
+      return stat ? `${stat.mtimeMs}-${stat.size}` : 'missing';
+    })
+    .join(';');
+}
 
 export function ensureGlobalProjectGraph(ruleName: string) {
-  /**
-   * Only reuse graph when running from terminal
-   * Enforce every IDE change to get a fresh nxdeps.json
-   */
-  if (
-    !globalThis.projectGraph ||
-    !globalThis.projectRootMappings ||
-    !globalThis.projectFileMap ||
-    !isTerminalRun()
-  ) {
-    const nxJson = readNxJson();
-    globalThis.workspaceLayout = nxJson.workspaceLayout;
+  const hasCachedGraph =
+    !!globalThis.projectGraph &&
+    !!globalThis.projectRootMappings &&
+    !!globalThis.projectFileMap;
 
-    /**
-     * Because there are a number of ways in which the rule can be invoked (executor vs ESLint CLI vs IDE Plugin),
-     * the ProjectGraph may or may not exist by the time the lint rule is invoked for the first time.
-     */
-    try {
-      const projectGraph = readCachedProjectGraph();
-      globalThis.projectGraph = projectGraph;
-      globalThis.projectRootMappings = createProjectRootMappings(
-        projectGraph.nodes
-      );
-      globalThis.projectFileMap = readFileMapCache().fileMap.projectFileMap;
-      globalThis.targetProjectLocator = new TargetProjectLocator(
-        projectGraph.nodes,
-        projectGraph.externalNodes
-      );
-    } catch {
-      const WARNING_PREFIX = `${pc.reset(pc.yellow('warning'))}`;
-      const RULE_NAME_SUFFIX = `${pc.reset(pc.dim(`@nx/${ruleName}`))}`;
-      process.stdout
-        .write(`${WARNING_PREFIX} No cached ProjectGraph is available. The rule will be skipped.
+  // Terminal runs (ESLint CLI, jest, nx executor) keep the first graph for the
+  // life of the process so every file is linted against a consistent graph.
+  if (hasCachedGraph && isTerminalRun()) {
+    return;
+  }
+
+  // Long-lived hosts (IDE language servers, other lint runners) must pick up
+  // workspace changes, but only the cache files on disk can deliver them —
+  // reload when those change rather than re-parsing them for every linted file.
+  const fingerprint = graphCacheFingerprint();
+  if (hasCachedGraph && globalThis.projectGraphFingerprint === fingerprint) {
+    return;
+  }
+
+  const nxJson = readNxJson();
+  globalThis.workspaceLayout = nxJson.workspaceLayout;
+
+  /**
+   * Because there are a number of ways in which the rule can be invoked (executor vs ESLint CLI vs IDE Plugin),
+   * the ProjectGraph may or may not exist by the time the lint rule is invoked for the first time.
+   */
+  try {
+    const projectGraph = readCachedProjectGraph();
+    globalThis.projectGraph = projectGraph;
+    globalThis.projectRootMappings = createProjectRootMappings(
+      projectGraph.nodes
+    );
+    globalThis.projectFileMap = readFileMapCache().fileMap.projectFileMap;
+    globalThis.targetProjectLocator = new TargetProjectLocator(
+      projectGraph.nodes,
+      projectGraph.externalNodes
+    );
+    globalThis.projectGraphFingerprint = fingerprint;
+  } catch {
+    const WARNING_PREFIX = `${pc.reset(pc.yellow('warning'))}`;
+    const RULE_NAME_SUFFIX = `${pc.reset(pc.dim(`@nx/${ruleName}`))}`;
+    process.stdout
+      .write(`${WARNING_PREFIX} No cached ProjectGraph is available. The rule will be skipped.
           If you encounter this error as part of running standard \`nx\` commands then please open an issue on https://github.com/nrwl/nx
           ${RULE_NAME_SUFFIX}\n`);
-    }
   }
 }
 

--- a/packages/nx/src/devkit-internals.ts
+++ b/packages/nx/src/devkit-internals.ts
@@ -174,7 +174,11 @@ export {
   readPackageJson,
 } from './project-graph/file-utils';
 export type { FileMapCache } from './project-graph/nx-deps-cache';
-export { readFileMapCache } from './project-graph/nx-deps-cache';
+export {
+  nxFileMap,
+  nxProjectGraph,
+  readFileMapCache,
+} from './project-graph/nx-deps-cache';
 export { isNpmProject } from './project-graph/operators';
 export {
   buildProjectGraphAndSourceMapsWithoutDaemon,


### PR DESCRIPTION
## Current Behavior

`@nx/enforce-module-boundaries` caches the ProjectGraph in `globalThis`, but the cache is
only reused when `process.argv[1]` matches a known terminal entrypoint (the ESLint CLI,
jest, or nx's run-executor). Under any other host — IDE ESLint language servers,
`eslint_d`, oxlint's JS-plugin host — `ensureGlobalProjectGraph` re-reads and re-parses
nx.json, the project-graph cache, the file-map cache, and the root tsconfig for **every
linted file**, and rebuilds the `TargetProjectLocator` and the circular-dependency
reachability matrix along with them.

Measured in a ~4,100-file workspace (66 projects) running the rule under oxlint's JS-plugin
host: ~11ms of fixed overhead per file, ~47s per full run, scaling linearly with file
count (27 files → 1.5s, 529 → 10.1s, 4,101 → 47s; the same run with a no-op JS plugin
takes 1.1s). The same per-file cost applies to the VSCode ESLint server and `eslint_d`,
which also fail the argv check.

## Expected Behavior

The in-memory graph is reused until the cache files can actually contain new data. Outside
recognized terminal runs, the rule fingerprints `project-graph.json`, `file-map.json`, and
`nx.json` (mtime + size, ~µs) and reloads only when the fingerprint changes. Freshness is
preserved: whenever the daemon rewrites the cache after a workspace change, the fingerprint
changes and the graph is reloaded — the previous behavior re-read the same unchanged files
per file, so no staleness is introduced that did not already exist.

Terminal runs keep their existing behavior (load once, reuse for the life of the process),
and the warn-and-skip path when no cached graph exists is unchanged.

Covered by a new spec for `ensureGlobalProjectGraph`/`readProjectGraph`: terminal reuse,
fingerprint reuse, reload on graph-cache and nx.json changes, and the missing-cache
retry/warning path.

## Related Issue(s)

Fixes #36611
