### PR TITLE
fix(release): allow pnpm v11+ to publish without npm on PATH

### DIFF
--- a/e2e/release/src/first-release.test.ts
+++ b/e2e/release/src/first-release.test.ts
@@ -125,7 +125,10 @@ describe('nx release first run', () => {
       ).toEqual(1);
       expect(
         releaseOutput1.match(
-          new RegExp('Skipped npm view because --first-release was set', 'g')
+          new RegExp(
+            'Skipped (?:npm|pnpm) view because --first-release was set',
+            'g'
+          )
         ).length
       ).toEqual(3);
 
@@ -160,7 +163,10 @@ describe('nx release first run', () => {
       ).toEqual(1);
       expect(
         releaseOutput2.match(
-          new RegExp('Skipped npm view because --first-release was set', 'g')
+          new RegExp(
+            'Skipped (?:npm|pnpm) view because --first-release was set',
+            'g'
+          )
         ).length
       ).toEqual(3);
     });
@@ -196,7 +202,10 @@ describe('nx release first run', () => {
       ).toEqual(1);
       expect(
         releaseOutput1.match(
-          new RegExp('Skipped npm view because --first-release was set', 'g')
+          new RegExp(
+            'Skipped (?:npm|pnpm) view because --first-release was set',
+            'g'
+          )
         ).length
       ).toEqual(3);
 
@@ -231,7 +240,10 @@ describe('nx release first run', () => {
       ).toEqual(1);
       expect(
         releaseOutput2.match(
-          new RegExp('Skipped npm view because --first-release was set', 'g')
+          new RegExp(
+            'Skipped (?:npm|pnpm) view because --first-release was set',
+            'g'
+          )
         ).length
       ).toEqual(3);
     });

--- a/packages/js/src/executors/release-publish/release-publish.impl.spec.ts
+++ b/packages/js/src/executors/release-publish/release-publish.impl.spec.ts
@@ -113,6 +113,51 @@ describe('release-publish executor', () => {
       });
     }
 
+    it('should publish a new package when pnpm v11 reports ERR_PNPM_FETCH_404', async () => {
+      mockDetectPackageManager.mockReturnValue('pnpm');
+      mockIsPnpmV11Plus.mockReturnValue(true);
+      mockExecSync.mockReset();
+
+      mockExecSync
+        .mockImplementationOnce(() => {
+          const error: any = new Error('pnpm view failed');
+          error.stdout = Buffer.from(
+            JSON.stringify({
+              error: { code: 'ERR_PNPM_FETCH_404' },
+            })
+          );
+          error.stderr = Buffer.from('');
+          throw error;
+        })
+        .mockReturnValueOnce(Buffer.from('{}') as any);
+
+      jest.spyOn(extractModule, 'extractNpmPublishJsonData').mockReturnValue({
+        beforeJsonData: '',
+        jsonData: {
+          id: '@scope/test-package@1.0.0',
+          name: '@scope/test-package',
+          version: '1.0.0',
+          size: 100,
+          unpackedSize: 200,
+          shasum: 'abc123',
+          integrity: 'sha512-abc',
+          filename: 'test-package-1.0.0.tgz',
+          files: [],
+          entryCount: 1,
+          bundled: [],
+        },
+        afterJsonData: '',
+      } as any);
+
+      const result = await runExecutor(options, context);
+
+      expect(result.success).toBe(true);
+      expect(mockExecSync).toHaveBeenCalledWith(
+        expect.stringMatching(/^pnpm publish/),
+        expect.anything()
+      );
+    });
+
     it('should skip publishing when pnpm reports that the version was previously published', async () => {
       mockDetectPackageManager.mockReturnValue('pnpm');
       mockNpmViewNotFound();

--- a/packages/js/src/executors/release-publish/release-publish.impl.spec.ts
+++ b/packages/js/src/executors/release-publish/release-publish.impl.spec.ts
@@ -30,6 +30,10 @@ describe('release-publish executor', () => {
   const mockDetectPackageManager = detectPackageManager as jest.MockedFunction<
     typeof detectPackageManager
   >;
+  const mockIsPnpmV11Plus =
+    npmConfigModule.isPnpmV11Plus as jest.MockedFunction<
+      typeof npmConfigModule.isPnpmV11Plus
+    >;
   const mockParseRegistryOptions =
     npmConfigModule.parseRegistryOptions as jest.MockedFunction<
       typeof npmConfigModule.parseRegistryOptions
@@ -41,6 +45,7 @@ describe('release-publish executor', () => {
   beforeEach(() => {
     jest.clearAllMocks();
     mockDetectPackageManager.mockReturnValue('npm');
+    mockIsPnpmV11Plus.mockReturnValue(false);
     jest.spyOn(console, 'log').mockImplementation();
     jest.spyOn(console, 'warn').mockImplementation();
     jest.spyOn(console, 'error').mockImplementation();
@@ -511,8 +516,8 @@ describe('release-publish executor', () => {
       );
     });
 
-    it('should return failure when pm is not bun and npm is not installed', async () => {
-      mockDetectPackageManager.mockReturnValue('pnpm');
+    it('should return failure when pm requires npm (npm/yarn) and npm is not installed', async () => {
+      mockDetectPackageManager.mockReturnValue('yarn');
       mockExecSync.mockReset();
 
       // npm --version throws (npm not installed)
@@ -527,8 +532,118 @@ describe('release-publish executor', () => {
         expect.stringContaining('npm was not found in the current environment')
       );
       expect(console.error).toHaveBeenCalledWith(
-        expect.stringContaining('"pnpm"')
+        expect.stringContaining('`yarn`')
       );
+    });
+
+    it('should return failure for pnpm < v11 without npm (pnpm 10 and below still need npm)', async () => {
+      mockDetectPackageManager.mockReturnValue('pnpm');
+      mockIsPnpmV11Plus.mockReturnValue(false);
+      mockExecSync.mockReset();
+
+      // npm --version throws (npm not installed)
+      mockExecSync.mockImplementationOnce(() => {
+        throw new Error('Command not found: npm');
+      });
+
+      const result = await runExecutor(options, context);
+
+      expect(result.success).toBe(false);
+      expect(console.error).toHaveBeenCalledWith(
+        expect.stringContaining('npm was not found in the current environment')
+      );
+    });
+
+    it('should publish via pnpm v11+ without npm on PATH (pnpm provides its own view/dist-tag)', async () => {
+      mockDetectPackageManager.mockReturnValue('pnpm');
+      mockIsPnpmV11Plus.mockReturnValue(true);
+      mockExecSync.mockReset();
+
+      mockExecSync
+        // pnpm view call (no npm --version probe at all for pnpm v11+)
+        .mockReturnValueOnce(
+          Buffer.from(
+            JSON.stringify({
+              versions: ['0.9.0'],
+              'dist-tags': { latest: '0.9.0' },
+            })
+          )
+        )
+        // pnpm publish call
+        .mockReturnValueOnce(Buffer.from('{}') as any);
+
+      jest.spyOn(extractModule, 'extractNpmPublishJsonData').mockReturnValue({
+        beforeJsonData: '',
+        jsonData: {
+          id: '@scope/test-package@1.0.0',
+          name: '@scope/test-package',
+          version: '1.0.0',
+          size: 100,
+          unpackedSize: 200,
+          shasum: 'abc123',
+          integrity: 'sha512-abc',
+          filename: 'test-package-1.0.0.tgz',
+          files: [],
+          entryCount: 1,
+          bundled: [],
+        },
+        afterJsonData: '',
+      } as any);
+
+      const result = await runExecutor(options, context);
+
+      expect(result.success).toBe(true);
+      // npm is never invoked for pnpm v11+ — not even the availability probe
+      expect(mockExecSync).not.toHaveBeenCalledWith(
+        'npm --version',
+        expect.anything()
+      );
+      // view used pnpm, not npm (anchor to avoid "pnpm view" matching "npm view")
+      expect(mockExecSync).toHaveBeenCalledWith(
+        expect.stringMatching(/^pnpm view/),
+        expect.anything()
+      );
+      expect(mockExecSync).not.toHaveBeenCalledWith(
+        expect.stringMatching(/^npm view/),
+        expect.anything()
+      );
+      // publish used pnpm
+      expect(mockExecSync).toHaveBeenCalledWith(
+        expect.stringContaining('pnpm publish'),
+        expect.anything()
+      );
+      // did not hard-error about missing npm
+      expect(console.error).not.toHaveBeenCalledWith(
+        expect.stringContaining('npm was not found in the current environment')
+      );
+    });
+
+    it('should never invoke npm for pnpm v11+ even when npm is installed', async () => {
+      mockDetectPackageManager.mockReturnValue('pnpm');
+      mockIsPnpmV11Plus.mockReturnValue(true);
+      mockExecSync.mockReset();
+
+      mockExecSync
+        // pnpm view: latest dist-tag already points at the current version
+        .mockReturnValueOnce(
+          Buffer.from(
+            JSON.stringify({
+              versions: ['1.0.0'],
+              'dist-tags': { latest: '1.0.0' },
+            })
+          )
+        );
+
+      const result = await runExecutor(options, context);
+
+      expect(result.success).toBe(true);
+      expect(console.warn).toHaveBeenCalledWith(
+        expect.stringContaining('already exists')
+      );
+      // no npm invocation whatsoever: no probe, no view, no dist-tag, no publish
+      const invokedCommands = mockExecSync.mock.calls.map((c) => c[0]);
+      expect(invokedCommands).toHaveLength(1);
+      expect(invokedCommands[0]).toMatch(/^pnpm view/);
     });
   });
 });

--- a/packages/js/src/executors/release-publish/release-publish.impl.ts
+++ b/packages/js/src/executors/release-publish/release-publish.impl.ts
@@ -9,7 +9,7 @@ import { statSync } from 'fs';
 import { env as appendLocalEnv } from 'npm-run-path';
 import { join } from 'path';
 import { isLocallyLinkedPackageVersion } from '../../utils/is-locally-linked-package-version';
-import { parseRegistryOptions } from '../../utils/npm-config';
+import { isPnpmV11Plus, parseRegistryOptions } from '../../utils/npm-config';
 import { extractNpmPublishJsonData } from './extract-npm-publish-json-data';
 import { logTar } from './log-tar';
 import { PublishExecutorSchema } from './schema';
@@ -62,24 +62,36 @@ export default async function runExecutor(
 ) {
   const pm = detectPackageManager();
 
+  // pnpm v11+ resolves registry metadata, config, and publishing through pnpm itself,
+  // so npm is never invoked — not even when it is installed. pnpm v10 and below still
+  // require npm. bun always publishes via its own binary (npm only as an auth fallback).
+  const usePnpmNatively = pm === 'pnpm' && isPnpmV11Plus(context.root);
+
   // Check if npm is installed (needed for dist-tag management and as fallback for view command)
   let isNpmInstalled = false;
-  try {
-    isNpmInstalled =
-      execSync('npm --version', {
-        encoding: 'utf-8',
-        windowsHide: true,
-        stdio: ['ignore', 'pipe', 'ignore'],
-      }).trim() !== '';
-  } catch {
-    // Allow missing npm only when using bun
-    if (pm !== 'bun') {
-      console.error(
-        `npm was not found in the current environment. This is only supported when using \`bun\` as a package manager, but your detected package manager is "${pm}"`
-      );
-      return {
-        success: false,
-      };
+  if (!usePnpmNatively) {
+    try {
+      isNpmInstalled =
+        execSync('npm --version', {
+          encoding: 'utf-8',
+          windowsHide: true,
+          stdio: ['ignore', 'pipe', 'ignore'],
+        }).trim() !== '';
+    } catch {
+      // bun can publish without npm, and only uses it as an auth-error fallback (best effort).
+      // For everyone else: npm and yarn both invoke `npm publish` under the hood, and pnpm
+      // v10 and below rely on npm for registry metadata, so npm is required on PATH.
+      // pnpm v11+ (above) never probes npm at all, which matters for environments provisioned
+      // via `pnpm runtime` / the `pnpm/setup` action (pnpm v11+), which intentionally do not
+      // extract the bundled npm, npx, or corepack.
+      if (pm !== 'bun') {
+        console.error(
+          `npm was not found in the current environment. This is required when using \`${pm}\` as a package manager, unless you are using pnpm v11+ or bun, which can publish without npm on PATH. Install npm, or upgrade to pnpm v11+ / switch to bun.`
+        );
+        return {
+          success: false,
+        };
+      }
     }
   }
 
@@ -194,16 +206,18 @@ Please update the local dependency on "${depName}" to be a valid semantic versio
     warnFn
   );
 
-  // Use bun info when bun is the package manager, otherwise use npm view
-  // (npm view works across npm/pnpm/yarn environments and is the established default)
+  // pnpm v11+ resolves registry metadata through pnpm itself, even when npm is installed.
+  // npm view / npm dist-tag remain the default for every other package manager.
+  // (bun uses `bun info` for view and has no dist-tag command.)
+  const metadataBin = usePnpmNatively ? 'pnpm' : 'npm';
   const npmViewCommandSegments =
     pm === 'bun'
       ? ['bun info', packageName, `--json --"${registryConfigKey}=${registry}"`]
       : [
-          `npm view ${packageName} versions dist-tags --json --"${registryConfigKey}=${registry}"`,
+          `${metadataBin} view ${packageName} versions dist-tags --json --"${registryConfigKey}=${registry}"`,
         ];
   const npmDistTagAddCommandSegments = [
-    `npm dist-tag add ${packageName}@${packageJson.version} ${tag} --"${registryConfigKey}=${registry}"`,
+    `${metadataBin} dist-tag add ${packageName}@${packageJson.version} ${tag} --"${registryConfigKey}=${registry}"`,
   ];
 
   /**
@@ -235,7 +249,7 @@ Please update the local dependency on "${depName}" to be a valid semantic versio
         };
       }
 
-      if (isNpmInstalled) {
+      if (isNpmInstalled || usePnpmNatively) {
         // If only one version of a package exists in the registry, versions will be a string instead of an array.
         const versions = Array.isArray(resultJson.versions)
           ? resultJson.versions
@@ -280,7 +294,7 @@ Please update the local dependency on "${depName}" to be a valid semantic versio
                   err.stderr?.toString().includes('no such package available')
                 )
               ) {
-                console.error('npm dist-tag add error:');
+                console.error(`${metadataBin} dist-tag add error:`);
                 // npm returns error.summary and error.detail
                 if (stdoutData.error?.summary) {
                   console.error(stdoutData.error.summary);
@@ -297,7 +311,7 @@ Please update the local dependency on "${depName}" to be a valid semantic versio
                 }
 
                 if (context.isVerbose) {
-                  console.error('npm dist-tag add stdout:');
+                  console.error(`${metadataBin} dist-tag add stdout:`);
                   console.error(JSON.stringify(stdoutData, null, 2));
                 }
                 return {
@@ -368,7 +382,9 @@ Please update the local dependency on "${depName}" to be a valid semantic versio
   }
 
   if (options.firstRelease && context.isVerbose) {
-    console.log('Skipped npm view because --first-release was set');
+    console.log(
+      `Skipped ${pm === 'bun' ? 'bun info' : metadataBin} view because --first-release was set`
+    );
   }
 
   /**

--- a/packages/js/src/executors/release-publish/release-publish.impl.ts
+++ b/packages/js/src/executors/release-publish/release-publish.impl.ts
@@ -339,6 +339,8 @@ Please update the local dependency on "${depName}" to be a valid semantic versio
             stdoutData.error?.code?.includes('E404') &&
             stdoutData.error?.summary?.toLowerCase().includes('not found')
           ) &&
+          // pnpm v11+ returns ERR_PNPM_FETCH_404 for packages not in the registry.
+          !(stdoutData.error?.code === 'ERR_PNPM_FETCH_404') &&
           !(
             err.stderr?.toString().includes('E404') &&
             err.stderr?.toString().toLowerCase().includes('not found')

--- a/packages/js/src/utils/npm-config.spec.ts
+++ b/packages/js/src/utils/npm-config.spec.ts
@@ -1,8 +1,20 @@
 import { ExecException } from 'child_process';
 import { join } from 'path';
-import { getNpmRegistry, getNpmTag, parseRegistryOptions } from './npm-config';
+import {
+  getNpmRegistry,
+  getNpmTag,
+  isPnpmV11Plus,
+  parseRegistryOptions,
+} from './npm-config';
 import { TempFs } from '@nx/devkit/internal-testing-utils';
+import { detectPackageManager, getPackageManagerVersion } from '@nx/devkit';
 import { PackageJson } from '@nx/devkit/internal';
+
+jest.mock('@nx/devkit', () => ({
+  ...jest.requireActual('@nx/devkit'),
+  detectPackageManager: jest.fn(() => 'npm'),
+  getPackageManagerVersion: jest.fn(() => '11.0.0'),
+}));
 
 jest.mock('child_process', () => {
   const original = jest.requireActual('child_process');
@@ -33,6 +45,15 @@ jest.mock('child_process', () => {
             case 'npm config get tag':
               callback(null, 'next', null);
               break;
+            case 'pnpm config get @scope:registry':
+              callback(null, 'https://pnpm-scoped-registry.com', null);
+              break;
+            case 'pnpm config get registry':
+              callback(null, 'https://pnpm-registry.com', null);
+              break;
+            case 'pnpm config get tag':
+              callback(null, 'pnpm-next', null);
+              break;
             default:
               callback(
                 new Error(`unexpected command: ${command}`),
@@ -47,9 +68,68 @@ jest.mock('child_process', () => {
 
 describe('npm-config', () => {
   let tempFs: TempFs;
+  const mockDetectPackageManager = detectPackageManager as jest.MockedFunction<
+    typeof detectPackageManager
+  >;
+  const mockGetPackageManagerVersion =
+    getPackageManagerVersion as jest.MockedFunction<
+      typeof getPackageManagerVersion
+    >;
 
   beforeEach(() => {
     tempFs = new TempFs('npm-config');
+    mockDetectPackageManager.mockReset();
+    mockGetPackageManagerVersion.mockReset();
+    mockDetectPackageManager.mockReturnValue('npm');
+    mockGetPackageManagerVersion.mockReturnValue('11.0.0');
+  });
+
+  describe('isPnpmV11Plus', () => {
+    it('should return true for pnpm v11+', () => {
+      mockGetPackageManagerVersion.mockReturnValue('11.0.0');
+      expect(isPnpmV11Plus(tempFs.tempDir)).toBe(true);
+    });
+
+    it('should return false for pnpm v10 and below', () => {
+      mockGetPackageManagerVersion.mockReturnValue('10.15.0');
+      expect(isPnpmV11Plus(tempFs.tempDir)).toBe(false);
+    });
+
+    it('should return false when the pnpm version cannot be determined', () => {
+      mockGetPackageManagerVersion.mockImplementation(() => {
+        throw new Error('pnpm not found');
+      });
+      expect(isPnpmV11Plus(tempFs.tempDir)).toBe(false);
+    });
+  });
+
+  describe('pnpm v11+ config resolution', () => {
+    it('should resolve scoped registry via pnpm for pnpm v11+', async () => {
+      mockDetectPackageManager.mockReturnValue('pnpm');
+      mockGetPackageManagerVersion.mockReturnValue('11.2.1');
+      const registry = await getNpmRegistry(tempFs.tempDir, '@scope');
+      expect(registry).toEqual('https://pnpm-scoped-registry.com');
+    });
+
+    it('should resolve tag via pnpm for pnpm v11+', async () => {
+      mockDetectPackageManager.mockReturnValue('pnpm');
+      mockGetPackageManagerVersion.mockReturnValue('11.2.1');
+      const tag = await getNpmTag(tempFs.tempDir);
+      expect(tag).toEqual('pnpm-next');
+    });
+
+    it('should resolve registry via npm for pnpm v10 and below', async () => {
+      mockDetectPackageManager.mockReturnValue('pnpm');
+      mockGetPackageManagerVersion.mockReturnValue('10.15.0');
+      const registry = await getNpmRegistry(tempFs.tempDir, '@scope');
+      expect(registry).toEqual('https://scoped-registry.com');
+    });
+
+    it('should resolve registry via npm for npm workspaces', async () => {
+      mockDetectPackageManager.mockReturnValue('npm');
+      const registry = await getNpmRegistry(tempFs.tempDir, '@scope');
+      expect(registry).toEqual('https://scoped-registry.com');
+    });
   });
 
   describe('getNpmRegistry', () => {

--- a/packages/js/src/utils/npm-config.spec.ts
+++ b/packages/js/src/utils/npm-config.spec.ts
@@ -1,4 +1,4 @@
-import { ExecException } from 'child_process';
+import { exec, ExecException } from 'child_process';
 import { join } from 'path';
 import {
   getNpmRegistry,
@@ -46,10 +46,10 @@ jest.mock('child_process', () => {
               callback(null, 'next', null);
               break;
             case 'pnpm config get @scope:registry':
-              callback(null, 'https://pnpm-scoped-registry.com', null);
+              callback(null, 'https://pnpm-scoped-registry.com/', null);
               break;
             case 'pnpm config get registry':
-              callback(null, 'https://pnpm-registry.com', null);
+              callback(null, 'https://pnpm-registry.com/', null);
               break;
             case 'pnpm config get tag':
               callback(null, 'pnpm-next', null);
@@ -75,6 +75,7 @@ describe('npm-config', () => {
     getPackageManagerVersion as jest.MockedFunction<
       typeof getPackageManagerVersion
     >;
+  const mockExec = exec as jest.MockedFunction<typeof exec>;
 
   beforeEach(() => {
     tempFs = new TempFs('npm-config');
@@ -108,7 +109,7 @@ describe('npm-config', () => {
       mockDetectPackageManager.mockReturnValue('pnpm');
       mockGetPackageManagerVersion.mockReturnValue('11.2.1');
       const registry = await getNpmRegistry(tempFs.tempDir, '@scope');
-      expect(registry).toEqual('https://pnpm-scoped-registry.com');
+      expect(registry).toEqual('https://pnpm-scoped-registry.com/');
     });
 
     it('should resolve tag via pnpm for pnpm v11+', async () => {
@@ -116,6 +117,19 @@ describe('npm-config', () => {
       mockGetPackageManagerVersion.mockReturnValue('11.2.1');
       const tag = await getNpmTag(tempFs.tempDir);
       expect(tag).toEqual('pnpm-next');
+    });
+
+    it('should default to latest when pnpm has no configured tag', async () => {
+      mockDetectPackageManager.mockReturnValue('pnpm');
+      mockGetPackageManagerVersion.mockReturnValue('11.2.1');
+      mockExec.mockImplementationOnce((_: any, __: any, callback: any) => {
+        callback(null, 'undefined', null);
+        return undefined as any;
+      });
+
+      const tag = await getNpmTag(tempFs.tempDir);
+
+      expect(tag).toEqual('latest');
     });
 
     it('should resolve registry via npm for pnpm v10 and below', async () => {

--- a/packages/js/src/utils/npm-config.spec.ts
+++ b/packages/js/src/utils/npm-config.spec.ts
@@ -105,11 +105,11 @@ describe('npm-config', () => {
   });
 
   describe('pnpm v11+ config resolution', () => {
-    it('should resolve scoped registry via pnpm for pnpm v11+', async () => {
+    it('should resolve scoped registry via pnpm for pnpm v11+, stripping the trailing slash pnpm appends', async () => {
       mockDetectPackageManager.mockReturnValue('pnpm');
       mockGetPackageManagerVersion.mockReturnValue('11.2.1');
       const registry = await getNpmRegistry(tempFs.tempDir, '@scope');
-      expect(registry).toEqual('https://pnpm-scoped-registry.com/');
+      expect(registry).toEqual('https://pnpm-scoped-registry.com');
     });
 
     it('should resolve tag via pnpm for pnpm v11+', async () => {

--- a/packages/js/src/utils/npm-config.ts
+++ b/packages/js/src/utils/npm-config.ts
@@ -95,10 +95,13 @@ export async function getNpmRegistry(
  */
 export async function getNpmTag(cwd: string): Promise<string> {
   // npm does not support '@scope:tag' in the npm config, so we only need to check for 'tag'.
-  return getNpmConfigValue('tag', cwd);
+  return (await getNpmConfigValue('tag', cwd)) ?? 'latest';
 }
 
-async function getNpmConfigValue(key: string, cwd: string): Promise<string> {
+async function getNpmConfigValue(
+  key: string,
+  cwd: string
+): Promise<string | undefined> {
   // pnpm v11+ resolves config itself and may be the only binary on PATH (e.g. Node
   // provisioned via `pnpm runtime` / the `pnpm/setup` action, which ships no bundled
   // npm). Everything else resolves config through npm.

--- a/packages/js/src/utils/npm-config.ts
+++ b/packages/js/src/utils/npm-config.ts
@@ -1,6 +1,8 @@
 import { exec } from 'child_process';
 import { existsSync } from 'fs';
 import { join, relative } from 'path';
+import { detectPackageManager, getPackageManagerVersion } from '@nx/devkit';
+import { gte } from 'semver';
 import { PackageJson } from '@nx/devkit/internal';
 
 export async function parseRegistryOptions(
@@ -97,11 +99,29 @@ export async function getNpmTag(cwd: string): Promise<string> {
 }
 
 async function getNpmConfigValue(key: string, cwd: string): Promise<string> {
+  // pnpm v11+ resolves config itself and may be the only binary on PATH (e.g. Node
+  // provisioned via `pnpm runtime` / the `pnpm/setup` action, which ships no bundled
+  // npm). Everything else resolves config through npm.
+  const pm = detectPackageManager(cwd);
+  const bin = pm === 'pnpm' && isPnpmV11Plus(cwd) ? 'pnpm' : 'npm';
   try {
-    const result = await execAsync(`npm config get ${key}`, cwd);
-    return result === 'undefined' ? undefined : result;
-  } catch (e) {
-    return Promise.resolve(undefined);
+    const result = await execAsync(`${bin} config get ${key}`, cwd);
+    return result && result !== 'undefined' ? result : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
+ * Whether the workspace's pnpm is v11+, which can publish, resolve registry
+ * metadata, and resolve config without npm on PATH. pnpm v10 and below still
+ * require npm.
+ */
+export function isPnpmV11Plus(cwd: string): boolean {
+  try {
+    return gte(getPackageManagerVersion('pnpm', cwd), '11.0.0');
+  } catch {
+    return false;
   }
 }
 

--- a/packages/js/src/utils/npm-config.ts
+++ b/packages/js/src/utils/npm-config.ts
@@ -85,7 +85,9 @@ export async function getNpmRegistry(
     registry = await getNpmConfigValue('registry', cwd);
   }
 
-  return registry;
+  // `pnpm config get registry` normalizes the URL with a trailing slash while npm
+  // returns the raw value; strip it so pnpm v11+ workspaces match npm's output.
+  return registry?.replace(/\/$/, '');
 }
 
 /**


### PR DESCRIPTION
## Current Behavior

`@nx/js:release-publish` hard-required the `npm` binary for every package manager except `bun`. Since pnpm v11.0.0, provisioning Node via `pnpm runtime set node` / the `pnpm/setup` action intentionally does not extract the bundled `npm`, so `nx release publish` failed immediately in such environments even though the workspace uses pnpm and never needs `npm publish`.

## Expected Behavior

For pnpm v11+ the entire publish flow runs through pnpm — `pnpm view`, `pnpm dist-tag add`, `pnpm config get`, `pnpm publish` — and npm is never invoked, even when it is installed. `npm` is only required for package managers whose publish is npm-backed (`npm`, `yarn`); pnpm v10 and below still require npm; bun keeps npm solely as an auth-error fallback.

## Summary of changes

- `release-publish.impl.ts`: `usePnpmNatively` gate (pnpm v11+ via shared `isPnpmV11Plus()`); the `npm --version` probe is skipped entirely; view/dist-tag commands and error labels route through pnpm.
- `npm-config.ts`: exported `isPnpmV11Plus()` helper; `getNpmConfigValue` uses `pnpm config get` for pnpm v11+, `npm config get` otherwise.
- Tests (38 passing): pnpm v11+ with and without npm on PATH (asserting zero npm invocations), pnpm v10 without npm fails, yarn without npm fails, `isPnpmV11Plus` unit tests, config resolution via the correct binary.

## Related Issue(s)

Fixes #36613