### PR TITLE
docs(misc): keep versioned docs snapshots out of search results

### DIFF
--- a/astro-docs/astro.config.mjs
+++ b/astro-docs/astro.config.mjs
@@ -16,6 +16,10 @@ process.env.NX_DEV_URL = resolveNxDevUrl();
 
 const BASE = '/docs';
 
+// Set on non-production builds (versioned snapshots, canary) so the archived
+// pages don't compete with nx.dev in search results.
+const NO_INDEX = process.env.NX_DOCS_NO_INDEX === 'true';
+
 // This is exposed as window.__CONFIG
 const PUBLIC_CONFIG = {
   gtmMeasurementId: 'GTM-KW8423B6',
@@ -104,6 +108,14 @@ export default defineConfig({
       disable404Route: true,
       lastUpdated: true,
       head: [
+        ...(NO_INDEX
+          ? [
+              {
+                tag: 'meta',
+                attrs: { name: 'robots', content: 'noindex' },
+              },
+            ]
+          : []),
         {
           tag: 'script',
           content: `window.__CONFIG = ${JSON.stringify(PUBLIC_CONFIG)};`,

--- a/scripts/create-versioned-docs.mts
+++ b/scripts/create-versioned-docs.mts
@@ -31,6 +31,10 @@
  * NOT include @netlify/plugin-nextjs, so Netlify serves pure static files.
  *
  * The resulting branch is deployed via Netlify branch deploys at v{major}.nx.dev.
+ *
+ * Archived docs are kept out of search results two ways: the build runs with
+ * the site's no-index env var so every page emits a robots meta tag, and the
+ * generated netlify.toml sends `X-Robots-Tag: noindex` for all paths.
  */
 
 import { execSync } from 'node:child_process';
@@ -38,6 +42,7 @@ import {
   cpSync,
   existsSync,
   mkdirSync,
+  readdirSync,
   readFileSync,
   rmSync,
   writeFileSync,
@@ -55,6 +60,12 @@ const FIRST_ASTRO_MAJOR = 21;
 process.env.NX_GRADLE_DISABLE = 'true';
 process.env.NX_MAVEN_DISABLE = 'true';
 process.env.NX_DOTNET_DISABLE = 'true';
+
+// Emit `<meta name="robots" content="noindex">` on every page. Archived docs
+// must not compete with nx.dev in search results. NEXT_PUBLIC_NO_INDEX is the
+// legacy nx-dev flag, NX_DOCS_NO_INDEX the astro-docs one.
+process.env.NEXT_PUBLIC_NO_INDEX = 'true';
+process.env.NX_DOCS_NO_INDEX = 'true';
 
 // Must match the Netlify UI publish directory setting
 const PUBLISH_DIR = 'nx-dev/nx-dev/.next';
@@ -100,6 +111,72 @@ function findLatestStableTag(major: string): string | null {
   });
 
   return tags[tags.length - 1];
+}
+
+/**
+ * Force every built page to `noindex`.
+ *
+ * The no-index env var covers almost everything, but a page's own `head`
+ * frontmatter wins over the global config — self-hosted-cache-packages.mdoc
+ * pins `index, follow` — and non-Starlight artifacts have no head at all.
+ */
+function normalizeRobotsMeta(publishDir: string): void {
+  const tag = '<meta name="robots" content="noindex"/>';
+  const robotsMeta = /<meta\s[^>]*name=["']robots["'][^>]*>/gi;
+  let rewritten = 0;
+
+  const walk = (dir: string): void => {
+    for (const entry of readdirSync(dir, { withFileTypes: true })) {
+      const path = resolve(dir, entry.name);
+      if (entry.isDirectory()) {
+        walk(path);
+        continue;
+      }
+      if (!entry.name.endsWith('.html')) continue;
+
+      const original = readFileSync(path, 'utf-8');
+      let updated: string;
+      if (robotsMeta.test(original)) {
+        robotsMeta.lastIndex = 0;
+        updated = original.replace(robotsMeta, tag);
+      } else if (/<\/head>/i.test(original)) {
+        updated = original.replace(/<\/head>/i, (m) => tag + m);
+      } else {
+        // Headless stubs: the parser hoists a leading meta into the implicit head.
+        updated = original.replace(/<!doctype html>/i, (m) => m + tag);
+      }
+      if (updated !== original) {
+        writeFileSync(path, updated);
+        rewritten++;
+      }
+    }
+  };
+
+  walk(publishDir);
+  console.log(`Forced noindex on ${rewritten} HTML pages.`);
+}
+
+/**
+ * Add `X-Robots-Tag: noindex` to the netlify.toml headers block. The header
+ * backstops the per-page meta tag: it applies to non-HTML assets too, and JS
+ * running on the page can't override it.
+ */
+function ensureNoindexHeader(headersAndRedirects: string): string {
+  if (headersAndRedirects.includes('X-Robots-Tag')) {
+    return headersAndRedirects;
+  }
+  if (/\[headers\.values\]\n/.test(headersAndRedirects)) {
+    return headersAndRedirects.replace(
+      /\[headers\.values\]\n/,
+      '[headers.values]\n    X-Robots-Tag = "noindex"\n'
+    );
+  }
+  return `[[headers]]
+  for = "/*"
+  [headers.values]
+    X-Robots-Tag = "noindex"
+
+${headersAndRedirects}`;
 }
 
 /**
@@ -178,7 +255,8 @@ function writeSharedScaffolding(
 [build.environment]
   NETLIFY_NEXT_PLUGIN_SKIP = "true"
 
-${headersAndRedirects}`
+${ensureNoindexHeader(headersAndRedirects)}
+`
   );
 }
 
@@ -200,6 +278,7 @@ function stageRedirectToProd(tmpDir: string): void {
   <head>
     <meta charset="utf-8">
     <title>Redirecting to nx.dev/docs</title>
+    <meta name="robots" content="noindex">
     <meta http-equiv="refresh" content="0; url=https://nx.dev/docs">
     <link rel="canonical" href="https://nx.dev/docs">
     <script>window.location.replace("https://nx.dev/docs");</script>
@@ -490,6 +569,8 @@ if (redirectToProd) {
 } else {
   buildAndStageNextjs(tmpDir);
 }
+
+normalizeRobotsMeta(resolve(tmpDir, PUBLISH_DIR));
 
 // --- Step 2: Create orphan branch ---
 console.log('\n=== Step 2: Creating orphan branch ===\n');


### PR DESCRIPTION
## Current Behavior

`create-versioned-docs` builds the archived docs site without a no-index flag, so every page on `v{major}.nx.dev` is indexable and the legacy nx-dev snapshots emit `index,follow`. The generated `netlify.toml` has no `X-Robots-Tag`.

## Expected Behavior

The build runs with `NEXT_PUBLIC_NO_INDEX` (nx-dev) and a new `NX_DOCS_NO_INDEX` (astro-docs), the generated `netlify.toml` sends `X-Robots-Tag: noindex`, and a post-build sweep forces `noindex` on the few pages that pin their own robots meta via frontmatter (`self-hosted-cache-packages.mdoc` hardcodes `index, follow`) or have no `<head>` at all.

Verified with a full `nx build astro-docs`: 801 of 804 pages get the meta from the env var alone, 804 of 804 after the sweep.

The already-published 19/20/21/22 branches were fixed directly in separate commits.

## Related Issue(s)

N/A
