### PR TITLE
fix(vitest): generate the requested e2e target in inferred workspaces and de-flake the generated plugin e2e

### DIFF
--- a/packages/plugin/src/generators/create-package/create-package.spec.ts
+++ b/packages/plugin/src/generators/create-package/create-package.spec.ts
@@ -143,4 +143,35 @@ describe('NxPlugin Create Package Generator', () => {
       })
     );
   });
+
+  it('should budget the e2e test for a cold package manager cache', async () => {
+    await pluginGenerator(tree, {
+      name: 'with-e2e',
+      directory: 'packages/with-e2e',
+      compiler: 'tsc',
+      skipTsConfig: false,
+      skipFormat: false,
+      skipLintChecks: false,
+      linter: 'eslint',
+      unitTestRunner: 'jest',
+      e2eTestRunner: 'jest',
+    });
+
+    await createPackageGenerator(
+      tree,
+      getSchema({ project: 'with-e2e', e2eProject: 'with-e2e-e2e' })
+    );
+
+    // The test shells out synchronously, which jest cannot interrupt but vitest
+    // fails after the fact, so an under-budgeted test is an intermittent
+    // failure rather than a consistent one.
+    const spec = tree.read(
+      'packages/with-e2e-e2e/src/create-a-workspace.spec.ts',
+      'utf-8'
+    );
+    const budget = /\}, (\d[\d_]*)\);/.exec(spec);
+
+    expect(budget).not.toBeNull();
+    expect(Number(budget[1].replace(/_/g, ''))).toBeGreaterThanOrEqual(120_000);
+  });
 });

--- a/packages/plugin/src/generators/create-package/files/e2e/__cliName__.spec.ts__tmpl__
+++ b/packages/plugin/src/generators/create-package/files/e2e/__cliName__.spec.ts__tmpl__
@@ -16,6 +16,8 @@ describe('<%= cliName %>', () => {
   });
 
 
+  // This test shells out synchronously, so its budget has to cover a cold
+  // package manager cache. Otherwise work that succeeded still fails on return.
   it('should be installed', () => {
     projectDirectory = createTestProject();
 
@@ -24,7 +26,7 @@ describe('<%= cliName %>', () => {
       cwd: projectDirectory,
       stdio: 'inherit',
     });
-  });
+  }, 180_000);
 });
 
 /**

--- a/packages/plugin/src/generators/e2e-project/e2e.spec.ts
+++ b/packages/plugin/src/generators/e2e-project/e2e.spec.ts
@@ -67,6 +67,24 @@ describe('NxPlugin e2e-project Generator', () => {
     expect(tree.exists('my-plugin-e2e/src/my-plugin.spec.ts')).toBeTruthy();
   });
 
+  it('should budget the setup hook for a cold package manager cache', async () => {
+    await e2eProjectGenerator(tree, {
+      pluginName: 'my-plugin',
+      pluginOutputPath: `dist/libs/my-plugin`,
+      npmPackageName: '@proj/my-plugin',
+      addPlugin: true,
+    });
+
+    // The hook shells out synchronously, which jest cannot interrupt but vitest
+    // fails after the fact, so an under-budgeted hook is an intermittent failure
+    // rather than a consistent one. It has to cover two installs.
+    const spec = tree.read('my-plugin-e2e/src/my-plugin.spec.ts', 'utf-8');
+    const budget = /\}, (\d[\d_]*)\);/.exec(spec);
+
+    expect(budget).not.toBeNull();
+    expect(Number(budget[1].replace(/_/g, ''))).toBeGreaterThanOrEqual(240_000);
+  });
+
   it('should extend from root tsconfig.base.json', async () => {
     await e2eProjectGenerator(tree, {
       pluginName: 'my-plugin',
@@ -231,15 +249,14 @@ describe('NxPlugin e2e-project Generator', () => {
     const project = readProjectConfiguration(tree, 'my-plugin-e2e');
 
     expect(project.targets.e2e.executor).toBe('@nx/vitest:test');
+    // The suites share a tmp/test-project directory, so they must not run in
+    // parallel. These have to stay scalar: vitest 4 removed `poolOptions`, and
+    // the executor serializes nested options into a string vitest cannot read.
     expect(project.targets.e2e).toMatchObject({
       dependsOn: ['^build'],
       options: expect.objectContaining({
-        pool: 'forks',
-        poolOptions: {
-          forks: {
-            singleFork: true,
-          },
-        },
+        maxWorkers: 1,
+        isolate: false,
       }),
     });
 
@@ -270,6 +287,30 @@ describe('NxPlugin e2e-project Generator', () => {
     expect(globalSetup).toContain(
       "export { default as teardown } from './stop-local-registry'"
     );
+  });
+
+  it('should add a vitest e2e target when the inferred plugin is registered', async () => {
+    await e2eProjectGenerator(tree, {
+      pluginName: 'my-plugin',
+      pluginOutputPath: `dist/libs/my-plugin`,
+      npmPackageName: '@proj/my-plugin',
+      testRunner: 'vitest',
+      addPlugin: true,
+    });
+
+    // `@nx/vitest` only infers `test`, so without an explicit target `nx e2e`
+    // does not exist and `^build` never runs before the local registry
+    // publishes the plugin.
+    const project = readProjectConfiguration(tree, 'my-plugin-e2e');
+
+    expect(project.targets.e2e).toMatchObject({
+      executor: '@nx/vitest:test',
+      dependsOn: ['^build'],
+      options: expect.objectContaining({
+        maxWorkers: 1,
+        isolate: false,
+      }),
+    });
   });
 
   it('should setup the eslint builder', async () => {

--- a/packages/plugin/src/generators/e2e-project/e2e.ts
+++ b/packages/plugin/src/generators/e2e-project/e2e.ts
@@ -322,17 +322,16 @@ export { default as teardown } from './stop-local-registry';
   if (project.targets.e2e) {
     const e2eTarget = project.targets.e2e;
 
+    // The suites share a single tmp/test-project directory, so they have to run
+    // one at a time. Vitest 4 removed `poolOptions`, and nested options do not
+    // survive the executor's argv round-trip anyway, so use the scalar options.
     project.targets.e2e = {
       ...e2eTarget,
       dependsOn: [`^build`],
       options: {
         ...e2eTarget.options,
-        pool: 'forks',
-        poolOptions: {
-          forks: {
-            singleFork: true,
-          },
-        },
+        maxWorkers: 1,
+        isolate: false,
       },
     };
 

--- a/packages/plugin/src/generators/e2e-project/files/src/__simplePluginName__.spec.ts__tmpl__
+++ b/packages/plugin/src/generators/e2e-project/files/src/__simplePluginName__.spec.ts__tmpl__
@@ -5,6 +5,9 @@ import { mkdirSync, rmSync } from 'fs';
 describe('<%= pluginName %>', () => {
   let projectDirectory: string;
 
+  // This hook shells out synchronously twice, so its budget has to cover both
+  // installs on a cold package manager cache. Otherwise work that succeeded
+  // still fails on return.
   beforeAll(() => {
     projectDirectory = createTestProject();
 
@@ -15,7 +18,7 @@ describe('<%= pluginName %>', () => {
       stdio: 'inherit',
       env: process.env,
     });
-  }, 30_000);
+  }, 300_000);
 
   afterAll(() => {
     if (projectDirectory) {

--- a/packages/vitest/src/utils/generator-utils.spec.ts
+++ b/packages/vitest/src/utils/generator-utils.spec.ts
@@ -1,6 +1,15 @@
-import { addProjectConfiguration, Tree } from '@nx/devkit';
+import {
+  addProjectConfiguration,
+  readNxJson,
+  readProjectConfiguration,
+  Tree,
+  updateNxJson,
+} from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
-import { createOrEditViteConfig } from './generator-utils';
+import {
+  addOrChangeTestTarget,
+  createOrEditViteConfig,
+} from './generator-utils';
 
 jest.mock('@nx/js/src/utils/typescript/ts-solution-setup', () => ({
   isUsingTsSolutionSetup: jest.fn(() => false),
@@ -245,5 +254,92 @@ describe('createOrEditViteConfig', () => {
 
       expect(config).toMatchSnapshot();
     });
+  });
+});
+
+describe('addOrChangeTestTarget', () => {
+  let tree: Tree;
+
+  beforeEach(() => {
+    tree = createTreeWithEmptyWorkspace();
+    addProjectConfiguration(tree, 'my-app-e2e', {
+      root: 'apps/my-app-e2e',
+      sourceRoot: 'apps/my-app-e2e/src',
+      projectType: 'application',
+    });
+  });
+
+  function registerVitestPlugin(options?: Record<string, string>) {
+    const nxJson = readNxJson(tree);
+    nxJson.plugins = [
+      options ? { plugin: '@nx/vitest', options } : '@nx/vitest',
+    ];
+    updateNxJson(tree, nxJson);
+  }
+
+  function targetsOf(project: string) {
+    return readProjectConfiguration(tree, project).targets ?? {};
+  }
+
+  it('should add the requested target when the plugin infers a different name', () => {
+    registerVitestPlugin();
+
+    addOrChangeTestTarget(
+      tree,
+      { project: 'my-app-e2e', testTarget: 'e2e', coverageProvider: 'none' },
+      false
+    );
+
+    expect(targetsOf('my-app-e2e').e2e).toEqual({
+      executor: '@nx/vitest:test',
+      outputs: ['{options.reportsDirectory}'],
+      options: { reportsDirectory: 'coverage/apps/my-app-e2e' },
+    });
+  });
+
+  it('should not add a target when the plugin infers the requested name', () => {
+    registerVitestPlugin();
+
+    addOrChangeTestTarget(
+      tree,
+      { project: 'my-app-e2e', coverageProvider: 'none' },
+      false
+    );
+
+    expect(targetsOf('my-app-e2e').test).toBeUndefined();
+  });
+
+  it('should match the requested target against the plugin testTargetName', () => {
+    registerVitestPlugin({ testTargetName: 'e2e' });
+
+    addOrChangeTestTarget(
+      tree,
+      { project: 'my-app-e2e', testTarget: 'e2e', coverageProvider: 'none' },
+      false
+    );
+
+    expect(targetsOf('my-app-e2e').e2e).toBeUndefined();
+  });
+
+  it('should match the requested target against the plugin ciTargetName', () => {
+    registerVitestPlugin({ ciTargetName: 'e2e-ci' });
+
+    addOrChangeTestTarget(
+      tree,
+      { project: 'my-app-e2e', testTarget: 'e2e-ci', coverageProvider: 'none' },
+      false
+    );
+
+    expect(targetsOf('my-app-e2e')['e2e-ci']).toBeUndefined();
+  });
+
+  it('should keep the caller verdict when nx.json registers no plugins', () => {
+    addOrChangeTestTarget(
+      tree,
+      { project: 'my-app-e2e', coverageProvider: 'none' },
+      true
+    );
+
+    expect(targetsOf('my-app-e2e').test).toBeUndefined();
   });
 });

--- a/packages/vitest/src/utils/generator-utils.ts
+++ b/packages/vitest/src/utils/generator-utils.ts
@@ -13,6 +13,7 @@ import {
 } from '@nx/devkit';
 import { isUsingTsSolutionSetup } from '@nx/js/internal';
 import { VitestExecutorOptions } from '../executors/test/schema';
+import type { VitestPluginOptions } from '../plugins/plugin';
 import { ensureViteConfigIsCorrect } from './vite-config-edit-utils';
 import { warnVitestExecutorGenerating } from './deprecation';
 import { nxVersion } from './versions';
@@ -41,19 +42,30 @@ export function addOrChangeTestTarget(
   hasPlugin: boolean
 ) {
   const nxJson = readNxJson(tree);
+  const target = options.testTarget ?? 'test';
 
-  hasPlugin = nxJson.plugins?.some((p) =>
-    typeof p === 'string'
-      ? p === '@nx/vitest'
-      : p.plugin === '@nx/vitest' || hasPlugin
-  );
+  // The plugin only infers the target names it is registered for, so a request
+  // for any other name still needs an explicit target.
+  hasPlugin ||=
+    nxJson.plugins?.some((p) => {
+      if (typeof p === 'string') {
+        return p === '@nx/vitest' && target === 'test';
+      }
+      if (p.plugin !== '@nx/vitest') {
+        return false;
+      }
+      const pluginOptions = p.options as VitestPluginOptions;
+      return (
+        (pluginOptions?.testTargetName ?? 'test') === target ||
+        pluginOptions?.ciTargetName === target
+      );
+    }) ?? false;
 
   if (hasPlugin) {
     return;
   }
 
   const project = readProjectConfiguration(tree, options.project);
-  const target = options.testTarget ?? 'test';
 
   const reportsDirectory = joinPathFragments(
     'coverage',


### PR DESCRIPTION
## Current Behavior

Two related defects in the `@nx/plugin` + `@nx/vitest` e2e path.

**1. Inferred (TS solution) workspaces get no `e2e` target at all.**

`nx g @nx/plugin:plugin foo --e2eTestRunner=vitest` in a TS solution workspace — the default for new workspaces, where `@nx/plugin` defaults `addPlugin` to true — produces an e2e project with no `e2e` target:

| workspace | runner | addPlugin | e2e target written |
| -- | -- | -- | -- |
| `--preset apps` | jest | false | `@nx/jest:jest` ✅ |
| `--preset apps` | vitest | false | `@nx/vitest:test` ✅ |
| TS solution | jest | true | `@nx/jest:jest` ✅ |
| TS solution | vitest | true | **none** ❌ |

`addOrChangeTestTarget` only checked whether `@nx/vitest` was registered *at all*, ignoring `options.testTarget`. It returned early and wrote nothing, while the plugin infers `test` / `test-ci` — never `e2e`. Consequences: `nx e2e <plugin>-e2e` does not exist, and the `e2e: { dependsOn: ['^build'] }` targetDefault is keyed to a target that is never created, so the plugin is not rebuilt before `start-local-registry` publishes it — the e2e installs stale or missing `dist/` output.

The same function discarded the caller-passed `hasPlugin` whenever `nxJson.plugins` was undefined, and the `|| hasPlugin` inside the callback made every object entry match once it became true.

CI did not catch any of this: `e2e/plugin/src/nx-plugin.test.ts` uses `newProject()` → `--preset apps` → `addPlugin=false`, which only exercises the top half of the table.

**2. The generated e2e suite is flaky.**

The generated `beforeAll` carried a 30s budget while doing two installs. That budget was decorative under jest and binding under vitest 4: `@vitest/runner`'s `withTimeout` re-checks `now() - startTime >= timeout` *after* a hook resolves and rejects even though the work completed, whereas jest never fired the timer because a synchronous `execSync` blocks the event loop. The result is a log showing workspace creation succeeding, followed by `Hook timed out in 30000ms`.

`create-package`'s `it('should be installed')` had the same latent bug in a worse form — a full `dlx <cli>@e2e` workspace creation on vitest's **default 5s** budget.

Separately, `pool: 'forks'` / `poolOptions.forks.singleFork` never applied on *any* path, including `--preset apps` where the target does exist. The `@nx/vitest:test` executor does not pass options to vitest's API; `getOptionsAsArgv` flattens them to `--key=value` strings and round-trips through `parseCLI`. The object branch emits `--poolOptions='{...}'` with literal single quotes — shell syntax, not argv syntax — so vitest parses it back as a *string*. Workers therefore raced on the shared `tmp/test-project` directory regardless.

## Expected Behavior

**`fix(vitest)`** — `addOrChangeTestTarget` compares the requested target against the registered plugin's `testTargetName` / `ciTargetName`, mirroring the `@nx/jest` check in `packages/jest/src/generators/configuration/configuration.ts`. A request for a name the plugin does not infer now gets an explicit target; a request for one it does infer still correctly returns early. The caller-passed `hasPlugin` is preserved (`||=`) rather than overwritten.

`packages/plugin/src/generators/e2e-project/e2e.ts` is the only caller in the repo passing a custom `testTarget`, so the behavior change is scoped to this bug.

**`fix(nx-plugin)`** — the `beforeAll` budget covers both installs (`300_000`), `create-package`'s install test gets `180_000`, and the pool options become the scalar `maxWorkers: 1, isolate: false` — which survive the argv round-trip and are what Nx's own vitest 4 migration already prescribes (`packages/vitest/src/migrations/update-22-1-0/ai-instructions-for-vitest-4.md`).

No new migration is needed: the vitest 4 migration is prompt-based and already instructs the agent to check `project.json` for inline vitest config and to replace `singleFork: true` with `maxWorkers: 1, isolate: false`.

### Tests

Six new tests, covering the inferred path the existing suite missed:

- `packages/vitest/src/utils/generator-utils.spec.ts` — five cases around `addOrChangeTestTarget`: the requested target is created when the plugin infers a different name; it is not created when the plugin infers that name; matching honours `testTargetName` and `ciTargetName`; the caller verdict survives an nx.json with no plugins.
- `packages/plugin/src/generators/e2e-project/e2e.spec.ts` — the e2e-project generator produces an `e2e` target with `addPlugin: true`, the combination that previously produced nothing.

Stashing the fix confirms the two tests covering the real defects fail without it; the other three are guards pinning behavior the change could have over-corrected. Budget regression tests from the flake work assert the generated timeouts stay above 240s / 120s.

## Related Issue(s)

- NXC-4750 — `@nx/plugin --e2eTestRunner=vitest` generates no e2e target in inferred (TS solution) workspaces
- NXC-4764 — generated `@nx/plugin` e2e is flaky (30s `beforeAll` budget covers two installs), closed as a duplicate of NXC-4750

Follow-up to #34041 (`feat(nx-plugin): add vitest support for e2e tests`), shipped in 23.2.0-beta.2.

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/vitest-plugin-timeouts-eb06fc74">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->