### PR TITLE
chore(repo): merge duplicate import declarations and forbid them via lint

### DIFF
--- a/.github/workflows/nightly/analyze-failures.ts
+++ b/.github/workflows/nightly/analyze-failures.ts
@@ -1,5 +1,4 @@
-import { exec } from 'child_process';
-import { execSync } from 'child_process';
+import { exec, execSync } from 'child_process';
 
 const MAX_CONCURRENCY = 8;
 

--- a/e2e/utils/test-utils.ts
+++ b/e2e/utils/test-utils.ts
@@ -5,8 +5,7 @@ import {
   runCLIAsync,
   runCommand,
 } from './command-utils';
-import { uniq } from './create-project-utils';
-import { tmpProjPath } from './create-project-utils';
+import { uniq, tmpProjPath } from './create-project-utils';
 import { readFile, fileExists, updateFile } from './file-utils';
 
 type GeneratorsWithDefaultTests =

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -183,6 +183,9 @@ export const baseConfig = [
       ],
       '@nx/workspace-valid-command-object': 'error',
       '@nx/workspace-require-windows-hide': 'error',
+      // allowSeparateTypeImports keeps `import type` declarations distinct from
+      // value ones; collapsing that split would churn ~226 files.
+      'no-duplicate-imports': ['error', { allowSeparateTypeImports: true }],
     },
   },
   {

--- a/graph/client/src/app/console-project-details/project-details.app.tsx
+++ b/graph/client/src/app/console-project-details/project-details.app.tsx
@@ -1,7 +1,9 @@
-import { ProjectDetails } from '@nx/graph-internal-ui-project-details';
+import {
+  ProjectDetails,
+  ExpandedTargetsProvider,
+} from '@nx/graph-internal-ui-project-details';
 import { getExternalApiService } from '@nx/graph-shared';
 import { ErrorToastUI } from '@nx/graph-ui-common';
-import { ExpandedTargetsProvider } from '@nx/graph-internal-ui-project-details';
 import { useSelector } from '@xstate/react';
 import { useCallback } from 'react';
 import { Interpreter } from 'xstate';

--- a/nx-dev/nx-dev/lib/getTokenizedContext.ts
+++ b/nx-dev/nx-dev/lib/getTokenizedContext.ts
@@ -7,8 +7,9 @@ import {
   getUserQuery,
   MIN_CONTENT_LENGTH,
   PageSection,
+  getOpenAI,
+  getSupabaseClient,
 } from '@nx/nx-dev-util-ai';
-import { getOpenAI, getSupabaseClient } from '@nx/nx-dev-util-ai';
 import { SupabaseClient } from '@supabase/supabase-js';
 import GPT3Tokenizer from 'gpt3-tokenizer';
 import OpenAI from 'openai';

--- a/nx-dev/ui-blog/src/lib/blog-details.tsx
+++ b/nx-dev/ui-blog/src/lib/blog-details.tsx
@@ -3,13 +3,12 @@ import { BlogPostDataEntry } from '@nx/nx-dev-data-access-documents/node-only';
 import Image from 'next/image';
 import { BlogAuthors } from './authors';
 import { ChevronLeftIcon, ListBulletIcon } from '@heroicons/react/24/outline';
-import { renderMarkdown } from '@nx/nx-dev-ui-markdoc';
+import { renderMarkdown, Metrics } from '@nx/nx-dev-ui-markdoc';
 import { EpisodePlayer } from './episode-player';
 import { YouTube } from '@nx/nx-dev-ui-common';
 import { FeaturedBlogs } from './featured-blogs';
 import { MoreBlogs } from './more-blogs';
 import { ALL_TOPICS, type Topic } from './topics';
-import { Metrics } from '@nx/nx-dev-ui-markdoc';
 
 export interface BlogDetailsProps {
   post: BlogPostDataEntry;

--- a/nx-dev/ui-blog/src/lib/blog-details.tsx
+++ b/nx-dev/ui-blog/src/lib/blog-details.tsx
@@ -62,7 +62,7 @@ export function BlogDetails({ post, allPosts }: BlogDetailsProps) {
         </div>
 
         {/* Title */}
-        <header className="mx-auto mb-16 mt-8 px-4">
+        <header className="mx-auto mt-8 mb-16 px-4">
           <h1 className="text-center text-4xl font-semibold text-zinc-900 dark:text-white">
             {post.title}
           </h1>
@@ -104,7 +104,7 @@ export function BlogDetails({ post, allPosts }: BlogDetailsProps) {
         <div className="relative isolate grid grid-cols-1 gap-8 xl:grid-cols-[200px_minmax(0,1fr)_200px]">
           <div className="hidden min-h-full xl:block">
             {post.metrics && (
-              <div className="sticky top-28 pr-4 pt-8">
+              <div className="sticky top-28 pt-8 pr-4">
                 <Metrics metrics={post.metrics} variant="vertical" />
               </div>
             )}
@@ -136,7 +136,7 @@ export function BlogDetails({ post, allPosts }: BlogDetailsProps) {
 
       {/* Related Posts Section */}
       {post.tags.length > 0 && relatedPosts.length > 0 && (
-        <section className="mt-24 border-b border-t border-zinc-200 bg-zinc-50 py-24 sm:py-32 dark:border-zinc-800 dark:bg-zinc-900">
+        <section className="mt-24 border-t border-b border-zinc-200 bg-zinc-50 py-24 sm:py-32 dark:border-zinc-800 dark:bg-zinc-900">
           <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
             <div className="mx-auto max-w-2xl lg:mx-0 lg:max-w-none">
               <h2 className="mb-8 flex items-center gap-3 text-2xl font-semibold text-zinc-900 dark:text-white">

--- a/nx-dev/ui-courses/src/lib/lesson-player.tsx
+++ b/nx-dev/ui-courses/src/lib/lesson-player.tsx
@@ -4,9 +4,8 @@ import React, { useState } from 'react';
 import Link from 'next/link';
 import { Course, Lesson } from '@nx/nx-dev-data-access-courses';
 import { renderMarkdown } from '@nx/nx-dev-ui-markdoc';
-import { YouTube } from '@nx/nx-dev-ui-common';
+import { YouTube, Header } from '@nx/nx-dev-ui-common';
 import { cx } from '@nx/nx-dev-ui-primitives';
-import { Header } from '@nx/nx-dev-ui-common';
 
 interface LessonPlayerProps {
   course: Course;

--- a/nx-dev/ui-icons/src/lib/partners/briebug.tsx
+++ b/nx-dev/ui-icons/src/lib/partners/briebug.tsx
@@ -1,6 +1,4 @@
-import { FC } from 'react';
-
-import { SVGProps } from 'react';
+import { FC, SVGProps } from 'react';
 
 export const BriebugIcon: FC<SVGProps<SVGSVGElement>> = (props) => {
   return (

--- a/nx-dev/ui-markdoc/src/index.ts
+++ b/nx-dev/ui-markdoc/src/index.ts
@@ -1,5 +1,4 @@
-import { Node, RenderableTreeNode } from '@markdoc/markdoc';
-import markdoc from '@markdoc/markdoc';
+import markdoc, { Node, RenderableTreeNode } from '@markdoc/markdoc';
 import { load as yamlLoad } from '@zkochan/js-yaml';
 import React, { ReactNode } from 'react';
 import { Heading } from './lib/nodes/heading.component';

--- a/nx-dev/ui-markdoc/src/lib/nodes/fence.schema.tsx
+++ b/nx-dev/ui-markdoc/src/lib/nodes/fence.schema.tsx
@@ -1,5 +1,4 @@
-import { Schema } from '@markdoc/markdoc';
-import markdoc from '@markdoc/markdoc';
+import markdoc, { Schema } from '@markdoc/markdoc';
 const { Tag } = markdoc;
 
 export const fence: Schema = {

--- a/nx-dev/ui-markdoc/src/lib/nodes/heading.schema.ts
+++ b/nx-dev/ui-markdoc/src/lib/nodes/heading.schema.ts
@@ -1,5 +1,4 @@
-import { RenderableTreeNode, Schema } from '@markdoc/markdoc';
-import markdoc from '@markdoc/markdoc';
+import markdoc, { RenderableTreeNode, Schema } from '@markdoc/markdoc';
 const { Tag } = markdoc;
 
 export function generateID(

--- a/nx-dev/ui-markdoc/src/lib/nodes/image.schema.ts
+++ b/nx-dev/ui-markdoc/src/lib/nodes/image.schema.ts
@@ -1,6 +1,10 @@
-import { Config, Node, RenderableTreeNodes, Schema } from '@markdoc/markdoc';
+import markdoc, {
+  Config,
+  Node,
+  RenderableTreeNodes,
+  Schema,
+} from '@markdoc/markdoc';
 import { transformImagePath } from './helpers/transform-image-path';
-import markdoc from '@markdoc/markdoc';
 const { Tag } = markdoc;
 
 export const getImageSchema = (documentFilePath: string): Schema => ({

--- a/nx-dev/ui-markdoc/src/lib/tags/short-embed.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/short-embed.tsx
@@ -6,8 +6,7 @@ import {
   useLayoutEffect,
   useState,
 } from 'react';
-import { Schema } from '@markdoc/markdoc';
-import markdoc from '@markdoc/markdoc';
+import markdoc, { Schema } from '@markdoc/markdoc';
 import { Transition } from '@headlessui/react';
 import { Button } from '@nx/nx-dev-ui-common';
 import { XMarkIcon } from '@heroicons/react/24/outline';

--- a/nx-dev/ui-markdoc/src/lib/tags/steps.schema.ts
+++ b/nx-dev/ui-markdoc/src/lib/tags/steps.schema.ts
@@ -1,5 +1,4 @@
-import { Schema } from '@markdoc/markdoc';
-import markdoc from '@markdoc/markdoc';
+import markdoc, { Schema } from '@markdoc/markdoc';
 const { Tag } = markdoc;
 
 export const steps: Schema = {

--- a/nx-dev/ui-markdoc/src/lib/tags/tabs.schema.ts
+++ b/nx-dev/ui-markdoc/src/lib/tags/tabs.schema.ts
@@ -1,5 +1,4 @@
-import { Schema } from '@markdoc/markdoc';
-import markdoc from '@markdoc/markdoc';
+import markdoc, { Schema } from '@markdoc/markdoc';
 const { Tag } = markdoc;
 
 export const tabs: Schema = {

--- a/packages/angular-rspack-compiler/src/compilation/setup-compilation.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-compilation.ts
@@ -9,9 +9,9 @@ import {
   findTailwindConfiguration,
   generateSearchDirectories,
   loadPostcssConfiguration,
+  getSupportedBrowsers,
 } from '@angular/build/private';
 import { transformSupportedBrowsersToTargets } from '../utils/targets-from-browsers';
-import { getSupportedBrowsers } from '@angular/build/private';
 import { createRequire } from 'node:module';
 
 export interface StylesheetTransformResult {

--- a/packages/angular-rspack-compiler/src/utils/utils.spec.ts
+++ b/packages/angular-rspack-compiler/src/utils/utils.spec.ts
@@ -7,7 +7,6 @@ import {
 } from './utils';
 import * as nodeOSModule from 'node:os';
 import { ENV_NG_BUILD_MAX_WORKERS } from './constants.ts';
-import * as osModule from 'node:os';
 
 vi.mock('node:os');
 
@@ -97,7 +96,7 @@ describe('maxWorkers', () => {
 });
 
 describe('isUsingWindows', async () => {
-  const platformSpy = vi.spyOn(osModule, 'platform');
+  const platformSpy = vi.spyOn(nodeOSModule, 'platform');
 
   beforeEach(() => {
     platformSpy.mockClear();

--- a/packages/angular/src/generators/application/lib/add-e2e.ts
+++ b/packages/angular/src/generators/application/lib/add-e2e.ts
@@ -1,16 +1,16 @@
-import { Tree } from '@nx/devkit';
 import {
-  E2EWebServerDetails,
-  readTargetDefaultsForTarget,
-} from '@nx/devkit/internal';
-import { isTypedLintingEnabled } from '@nx/eslint/internal';
-import {
+  Tree,
   addProjectConfiguration,
   ensurePackage,
   getPackageManagerCommand,
   joinPathFragments,
   readNxJson,
 } from '@nx/devkit';
+import {
+  E2EWebServerDetails,
+  readTargetDefaultsForTarget,
+} from '@nx/devkit/internal';
+import { isTypedLintingEnabled } from '@nx/eslint/internal';
 import { nxVersion } from '../../../utils/versions';
 import type { NormalizedSchema } from './normalized-schema';
 

--- a/packages/angular/src/generators/ng-add/migrate-from-angular-cli.spec.ts
+++ b/packages/angular/src/generators/ng-add/migrate-from-angular-cli.spec.ts
@@ -1,7 +1,7 @@
 import '@nx/devkit/internal-testing-utils/mock-project-graph';
 
-import { Tree } from '@nx/devkit';
 import {
+  Tree,
   readJson,
   readProjectConfiguration,
   updateJson,

--- a/packages/angular/src/generators/ng-add/migrators/projects/e2e.migrator.spec.ts
+++ b/packages/angular/src/generators/ng-add/migrators/projects/e2e.migrator.spec.ts
@@ -16,8 +16,10 @@ jest.mock('fs', () => {
 });
 
 import { getInstalledCypressMajorVersion } from '@nx/cypress/internal';
-import { formatFiles, ProjectConfiguration, Tree } from '@nx/devkit';
 import {
+  formatFiles,
+  ProjectConfiguration,
+  Tree,
   joinPathFragments,
   readJson,
   readProjectConfiguration,

--- a/packages/angular/src/generators/ng-add/migrators/projects/lib.migrator.ts
+++ b/packages/angular/src/generators/ng-add/migrators/projects/lib.migrator.ts
@@ -1,5 +1,8 @@
-import { joinPathFragments, Tree } from '@nx/devkit';
-import { updateProjectConfiguration } from '@nx/devkit';
+import {
+  joinPathFragments,
+  Tree,
+  updateProjectConfiguration,
+} from '@nx/devkit';
 import type { GeneratorOptions } from '../../schema';
 import type {
   Logger,

--- a/packages/angular/src/generators/stories/stories-lib.spec.ts
+++ b/packages/angular/src/generators/stories/stories-lib.spec.ts
@@ -1,7 +1,6 @@
 import '@nx/devkit/internal-testing-utils/mock-project-graph';
 
-import { Tree } from '@nx/devkit';
-import { writeJson } from '@nx/devkit';
+import { Tree, writeJson } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { componentGenerator } from '../component/component';
 import { librarySecondaryEntryPointGenerator } from '../library-secondary-entry-point/library-secondary-entry-point';

--- a/packages/angular/src/migrations/update-20-2-0/migrate-mf-imports-to-new-package.ts
+++ b/packages/angular/src/migrations/update-20-2-0/migrate-mf-imports-to-new-package.ts
@@ -1,5 +1,9 @@
-import { createProjectGraphAsync, Tree } from '@nx/devkit';
-import { formatFiles, visitNotIgnoredFiles } from '@nx/devkit';
+import {
+  createProjectGraphAsync,
+  Tree,
+  formatFiles,
+  visitNotIgnoredFiles,
+} from '@nx/devkit';
 import { ast, query } from '@phenomnomnominal/tsquery';
 
 const MF_IMPORT_TO_UPDATE = 'ModuleFederationConfig';

--- a/packages/angular/src/migrations/update-21-0-0/change-data-persistence-operators-imports-to-ngrx-router-store-data-persistence.ts
+++ b/packages/angular/src/migrations/update-21-0-0/change-data-persistence-operators-imports-to-ngrx-router-store-data-persistence.ts
@@ -6,8 +6,7 @@ import {
   type Tree,
 } from '@nx/devkit';
 import { ensureTypescript } from '@nx/js/internal';
-import { fileDataDepTarget } from '@nx/devkit/internal';
-import { readFileMapCache } from '@nx/devkit/internal';
+import { fileDataDepTarget, readFileMapCache } from '@nx/devkit/internal';
 import type { ImportDeclaration, ImportSpecifier, Node } from 'typescript';
 import { versions } from '../../generators/utils/version-utils';
 import { FileChangeRecorder } from '../../utils/file-change-recorder';

--- a/packages/create-nx-workspace/src/create-workspace.ts
+++ b/packages/create-nx-workspace/src/create-workspace.ts
@@ -5,7 +5,7 @@ import { createPreset } from './create-preset';
 import { createSandbox } from './create-sandbox';
 import { CreateWorkspaceOptions } from './create-workspace-options';
 import { setupCI } from './utils/ci/setup-ci';
-import { mapErrorToBodyLines } from './utils/error-utils';
+import { mapErrorToBodyLines, CnwError } from './utils/error-utils';
 import {
   GitHubPushError,
   initializeGitRepo,
@@ -36,7 +36,6 @@ import {
 } from './utils/package-manager';
 import { isAiAgent, logProgress } from './utils/ai/ai-output';
 import { confirmThirdPartyPreset } from './internal-utils/prompts';
-import { CnwError } from './utils/error-utils';
 
 // State for SIGINT handler - only set after workspace is fully installed
 let workspaceDirectory: string | undefined;

--- a/packages/detox/src/executors/test/test.impl.ts
+++ b/packages/detox/src/executors/test/test.impl.ts
@@ -2,9 +2,9 @@ import {
   ExecutorContext,
   parseTargetString,
   readTargetOptions,
+  names,
 } from '@nx/devkit';
 import { signalToCode } from '@nx/devkit/internal';
-import { names } from '@nx/devkit';
 import { resolve as pathResolve } from 'path';
 import { ChildProcess, fork } from 'child_process';
 

--- a/packages/devkit/src/generators/plugin-migrations/executor-to-plugin-migrator.ts
+++ b/packages/devkit/src/generators/plugin-migrations/executor-to-plugin-migrator.ts
@@ -16,6 +16,7 @@ import {
   type ProjectGraph,
   type TargetConfiguration,
   type Tree,
+  logger as devkitLogger,
 } from 'nx/src/devkit-exports';
 import {
   LoadedNxPlugin,
@@ -29,7 +30,6 @@ import type { ConfigurationResult } from 'nx/src/project-graph/utils/project-con
 import { forEachExecutorOptions } from '../executor-options-utils';
 import { findTargetDefault } from '../target-defaults-utils';
 import { deleteMatchingProperties } from './plugin-migration-utils';
-import { logger as devkitLogger } from 'nx/src/devkit-exports';
 
 export type InferredTargetConfiguration = TargetConfiguration & {
   name: string;

--- a/packages/docker/src/plugins/plugin.ts
+++ b/packages/docker/src/plugins/plugin.ts
@@ -3,6 +3,8 @@ import {
   getNamedInputs,
   PluginCache,
   hashObject,
+  workspaceDataDirectory,
+  getLatestCommitSha,
 } from '@nx/devkit/internal';
 import {
   type CreateNodes,
@@ -15,10 +17,6 @@ import {
 } from '@nx/devkit';
 import { existsSync } from 'fs';
 import { dirname, join } from 'path';
-import {
-  workspaceDataDirectory,
-  getLatestCommitSha,
-} from '@nx/devkit/internal';
 import { interpolateObject } from '../utils/interpolate-pattern';
 
 export interface DockerTargetOptions {

--- a/packages/eslint-plugin/src/rules/enforce-module-boundaries.spec.ts
+++ b/packages/eslint-plugin/src/rules/enforce-module-boundaries.spec.ts
@@ -7,8 +7,10 @@ import * as parser from '@typescript-eslint/parser';
 import { TSESLint } from '@typescript-eslint/utils';
 import { vol } from 'memfs';
 import { join } from 'node:path';
-import { FileDataDependency } from '@nx/devkit/internal';
-import { createProjectRootMappings } from '@nx/devkit/internal';
+import {
+  FileDataDependency,
+  createProjectRootMappings,
+} from '@nx/devkit/internal';
 import enforceModuleBoundaries, {
   RULE_NAME as enforceModuleBoundariesRuleName,
 } from '../../src/rules/enforce-module-boundaries';

--- a/packages/js/src/executors/copy-workspace-modules/copy-workspace-modules.ts
+++ b/packages/js/src/executors/copy-workspace-modules/copy-workspace-modules.ts
@@ -6,7 +6,10 @@ import {
   readJsonFile,
   workspaceRoot,
 } from '@nx/devkit';
-import { interpolate } from '@nx/devkit/internal';
+import {
+  interpolate,
+  getWorkspacePackagesFromGraph,
+} from '@nx/devkit/internal';
 import { type CopyWorkspaceModulesOptions } from './schema';
 import {
   cpSync,
@@ -17,7 +20,6 @@ import {
 } from 'node:fs';
 import { dirname, join, relative, sep } from 'path';
 import { lstatSync } from 'fs';
-import { getWorkspacePackagesFromGraph } from '@nx/devkit/internal';
 import { stripGlobToBaseDir } from '../../utils/strip-glob-to-base-dir';
 
 export default async function copyWorkspaceModules(

--- a/packages/js/src/executors/node/node.impl.ts
+++ b/packages/js/src/executors/node/node.impl.ts
@@ -1,4 +1,10 @@
-import { createAsyncIterable } from '@nx/devkit/internal';
+import {
+  createAsyncIterable,
+  daemonClient,
+  killProcessTreeGraceful,
+  fileExists,
+  interpolate,
+} from '@nx/devkit/internal';
 import chalk from 'chalk';
 import { ChildProcess, fork } from 'child_process';
 import {
@@ -11,18 +17,14 @@ import {
   readTargetOptions,
   runExecutor,
 } from '@nx/devkit';
-import { daemonClient } from '@nx/devkit/internal';
 import { randomUUID } from 'crypto';
 import * as path from 'path';
 import { join } from 'path';
 
 import { InspectType, NodeExecutorOptions } from './schema';
 import { calculateProjectBuildableDependencies } from '../../utils/buildable-libs-utils';
-import { killProcessTreeGraceful } from '@nx/devkit/internal';
 import { LineAwareWriter } from './lib/line-aware-writer';
 import { createCoalescingDebounce } from './lib/coalescing-debounce';
-import { fileExists } from '@nx/devkit/internal';
-import { interpolate } from '@nx/devkit/internal';
 import { detectModuleFormat } from './lib/detect-module-format';
 import { getOutputFileName } from './lib/output-file';
 import { stripGlobToBaseDir } from '../../utils/strip-glob-to-base-dir';

--- a/packages/js/src/executors/prune-lockfile/prune-lockfile.spec.ts
+++ b/packages/js/src/executors/prune-lockfile/prune-lockfile.spec.ts
@@ -1,9 +1,8 @@
 import { type ExecutorContext } from '@nx/devkit';
 import { TempFs } from '@nx/devkit/internal-testing-utils';
-import { getCatalogManager } from '@nx/devkit/internal';
+import { getCatalogManager, type PackageJson } from '@nx/devkit/internal';
 import { readFileSync } from 'fs';
 import { join } from 'path';
-import { type PackageJson } from '@nx/devkit/internal';
 import pruneLockfileExecutor, {
   resolveCatalogReferences,
 } from './prune-lockfile';

--- a/packages/js/src/executors/prune-lockfile/prune-lockfile.ts
+++ b/packages/js/src/executors/prune-lockfile/prune-lockfile.ts
@@ -7,16 +7,17 @@ import {
   readJsonFile,
   workspaceRoot,
 } from '@nx/devkit';
-import { getCatalogManager } from '@nx/devkit/internal';
-import { existsSync, lstatSync, writeFileSync } from 'fs';
-import { dirname, join } from 'path';
-import { interpolate } from '@nx/devkit/internal';
 import {
+  getCatalogManager,
+  interpolate,
   type PackageJson,
   type PackageJsonDependencySection,
+  getLockFileName,
+  createLockFile,
+  getWorkspacePackagesFromGraph,
 } from '@nx/devkit/internal';
-import { getLockFileName, createLockFile } from '@nx/devkit/internal';
-import { getWorkspacePackagesFromGraph } from '@nx/devkit/internal';
+import { existsSync, lstatSync, writeFileSync } from 'fs';
+import { dirname, join } from 'path';
 import { type PruneLockfileOptions } from './schema';
 import { stripGlobToBaseDir } from '../../utils/strip-glob-to-base-dir';
 

--- a/packages/js/src/executors/verdaccio/verdaccio.impl.ts
+++ b/packages/js/src/executors/verdaccio/verdaccio.impl.ts
@@ -1,9 +1,8 @@
 import { ExecutorContext, logger } from '@nx/devkit';
-import { signalToCode } from '@nx/devkit/internal';
+import { signalToCode, readModulePackageJson } from '@nx/devkit/internal';
 import { ChildProcess, execSync, fork } from 'child_process';
 import detectPort from 'detect-port';
 import { existsSync, rmSync } from 'node:fs';
-import { readModulePackageJson } from '@nx/devkit/internal';
 import { dirname, join, resolve } from 'path';
 
 import { VerdaccioExecutorSchema } from './schema';

--- a/packages/js/src/plugins/typescript/plugin.spec.ts
+++ b/packages/js/src/plugins/typescript/plugin.spec.ts
@@ -2,8 +2,7 @@ import { detectPackageManager, type CreateNodesContext } from '@nx/devkit';
 import { TempFs } from '@nx/devkit/internal-testing-utils';
 import picomatch = require('picomatch');
 import { mkdirSync, rmSync } from 'node:fs';
-import { getLockFileName } from '@nx/devkit/internal';
-import { setupWorkspaceContext } from '@nx/devkit/internal';
+import { getLockFileName, setupWorkspaceContext } from '@nx/devkit/internal';
 import { PLUGIN_NAME, createNodesV2, type TscPluginOptions } from './plugin';
 
 jest.mock('nx/src/utils/cache-directory', () => ({

--- a/packages/js/src/plugins/typescript/plugin.ts
+++ b/packages/js/src/plugins/typescript/plugin.ts
@@ -1,4 +1,11 @@
-import { getNamedInputs } from '@nx/devkit/internal';
+import {
+  getNamedInputs,
+  hashFile,
+  hashObject,
+  getLockFileName,
+  workspaceDataDirectory,
+  getNxRequirePaths,
+} from '@nx/devkit/internal';
 import {
   createNodesFromFiles,
   detectPackageManager,
@@ -13,6 +20,7 @@ import {
   type NxJsonConfiguration,
   type ProjectConfiguration,
   type TargetConfiguration,
+  hashArray,
 } from '@nx/devkit';
 import {
   existsSync,
@@ -30,12 +38,7 @@ import {
   relative,
   resolve,
 } from 'node:path';
-import { hashArray } from '@nx/devkit';
-import { hashFile, hashObject } from '@nx/devkit/internal';
 import picomatch = require('picomatch');
-import { getLockFileName } from '@nx/devkit/internal';
-import { workspaceDataDirectory } from '@nx/devkit/internal';
-import { getNxRequirePaths } from '@nx/devkit/internal';
 import type { Extension, ParsedCommandLine, System } from 'typescript';
 import {
   addBuildAndWatchDepsTargets,

--- a/packages/js/src/release/utils/update-lock-file.ts
+++ b/packages/js/src/release/utils/update-lock-file.ts
@@ -6,8 +6,7 @@ import {
   output,
 } from '@nx/devkit';
 import { execSync } from 'child_process';
-import { daemonClient } from '@nx/devkit/internal';
-import { getLockFileName } from '@nx/devkit/internal';
+import { daemonClient, getLockFileName } from '@nx/devkit/internal';
 import { gte } from 'semver';
 
 export async function updateLockFile(

--- a/packages/js/src/utils/package-json/update-package-json.ts
+++ b/packages/js/src/utils/package-json/update-package-json.ts
@@ -1,5 +1,10 @@
-import { createLockFile, getLockFileName } from '@nx/devkit/internal';
-import { createPackageJson } from '@nx/devkit/internal';
+import {
+  createLockFile,
+  getLockFileName,
+  createPackageJson,
+  fileExists,
+  readFileMapCache,
+} from '@nx/devkit/internal';
 
 import {
   detectPackageManager,
@@ -18,9 +23,7 @@ import {
 import { DependentBuildableProjectNode } from '../buildable-libs-utils';
 import { existsSync, writeFileSync } from 'node:fs';
 import { basename, dirname, join, parse, relative } from 'path';
-import { fileExists } from '@nx/devkit/internal';
 import type { PackageJson } from '@nx/devkit/internal';
-import { readFileMapCache } from '@nx/devkit/internal';
 
 import { getRelativeDirectoryToProjectRoot } from '../get-main-file-dir';
 import { stripGlobToBaseDir } from '../strip-glob-to-base-dir';

--- a/packages/next/src/generators/application/application.ts
+++ b/packages/next/src/generators/application/application.ts
@@ -12,8 +12,8 @@ import { initGenerator as jsInitGenerator } from '@nx/js';
 import {
   testingLibraryDomVersion,
   testingLibraryReactVersion,
+  getReactDependenciesVersionsToInstall,
 } from '@nx/react/internal';
-import { getReactDependenciesVersionsToInstall } from '@nx/react/internal';
 
 import { normalizeOptions } from './lib/normalize-options';
 import { Schema } from './schema';

--- a/packages/next/src/generators/custom-server/custom-server.ts
+++ b/packages/next/src/generators/custom-server/custom-server.ts
@@ -1,6 +1,6 @@
-import { joinPathFragments, Tree } from '@nx/devkit';
-import { upsertTargetDefault } from '@nx/devkit/internal';
 import {
+  joinPathFragments,
+  Tree,
   updateJson,
   generateFiles,
   logger,
@@ -10,6 +10,7 @@ import {
   readNxJson,
   updateNxJson,
 } from '@nx/devkit';
+import { upsertTargetDefault } from '@nx/devkit/internal';
 import { CustomServerSchema } from './schema';
 import { join } from 'path';
 import { configureForSwc } from '../../utils/add-swc-to-custom-server';

--- a/packages/nx/src/command-line/import/import.ts
+++ b/packages/nx/src/command-line/import/import.ts
@@ -7,7 +7,7 @@ import { tmpdir } from 'tmp';
 import { prompt } from 'enquirer';
 import { output } from '../../utils/output';
 const createSpinner = require('ora');
-import { detectPlugins } from '../init/init-v2';
+import { detectPlugins, getPluginReason } from '../init/init-v2';
 import { readNxJson } from '../../config/nx-json';
 import { readJsonFile } from '../../utils/fileutils';
 import { PackageJson } from '../../utils/package-json';
@@ -46,7 +46,6 @@ import {
   determineImportErrorCode,
   type ImportWarning,
 } from './utils/ai-output';
-import { getPluginReason } from '../init/init-v2';
 
 const importRemoteName = '__tmp_nx_import__';
 

--- a/packages/nx/src/command-line/init/init-v2.ts
+++ b/packages/nx/src/command-line/init/init-v2.ts
@@ -8,7 +8,10 @@ import { readJsonFile, writeJsonFile } from '../../utils/fileutils';
 import { getPackageNameFromImportPath } from '../../utils/get-package-name-from-import-path';
 import { output } from '../../utils/output';
 import { installPackageToTmp, PackageJson } from '../../utils/package-json';
-import { getPackageManagerCommand } from '../../utils/package-manager';
+import {
+  getPackageManagerCommand,
+  detectPackageManager,
+} from '../../utils/package-manager';
 import { nxVersion } from '../../utils/versions';
 import { globWithWorkspaceContextSync } from '../../utils/workspace-context';
 import { connectExistingRepoToNxCloudPrompt } from '../nx-cloud/connect/connect-to-nx-cloud';
@@ -40,7 +43,6 @@ import { detectAiAgent } from '../../ai/detect-ai-agent';
 import { MessageOptionKey, recordStat } from '../../utils/ab-testing';
 import { ensureAnalyticsPreferenceSet } from '../../utils/analytics-prompt';
 import { isCI } from '../../utils/is-ci';
-import { detectPackageManager } from '../../utils/package-manager';
 import {
   logProgress,
   writeAiOutput,

--- a/packages/nx/src/daemon/client/client.spec.ts
+++ b/packages/nx/src/daemon/client/client.spec.ts
@@ -6,8 +6,7 @@ import {
   writeFileSync,
 } from 'node:fs';
 import { tmpdir } from 'node:os';
-import { join } from 'node:path';
-import { dirname } from 'node:path';
+import { join, dirname } from 'node:path';
 
 // Redirect the daemon log and its directory so both states — present and
 // missing — are reachable, and so startInBackground creates nothing in the

--- a/packages/plugin/src/utils/testing-utils/nx-project.ts
+++ b/packages/plugin/src/utils/testing-utils/nx-project.ts
@@ -1,5 +1,6 @@
-import { detectPackageManager, workspaceRoot } from '@nx/devkit';
 import {
+  detectPackageManager,
+  workspaceRoot,
   getPackageManagerCommand,
   readJsonFile,
   writeJsonFile,

--- a/packages/react/module-federation.ts
+++ b/packages/react/module-federation.ts
@@ -1,5 +1,7 @@
-import { withModuleFederation } from '@nx/module-federation/webpack';
-import { withModuleFederationForSSR } from '@nx/module-federation/webpack';
+import {
+  withModuleFederation,
+  withModuleFederationForSSR,
+} from '@nx/module-federation/webpack';
 
 /**
  * @deprecated Use `@nx/module-federation/webpack` instead. This will be removed in Nx v22.

--- a/packages/react/src/generators/application/application.ts
+++ b/packages/react/src/generators/application/application.ts
@@ -1,6 +1,7 @@
 import {
   logShowProjectCommand,
   promptWhenInteractive,
+  upsertTargetDefault,
 } from '@nx/devkit/internal';
 import { assertSupportedReactVersion } from '../../utils/assert-supported-react-version';
 import {
@@ -15,7 +16,6 @@ import {
   updateJson,
   updateNxJson,
 } from '@nx/devkit';
-import { upsertTargetDefault } from '@nx/devkit/internal';
 import { initGenerator as jsInitGenerator } from '@nx/js';
 import {
   addProjectToTsSolutionWorkspace,

--- a/packages/react/src/generators/application/lib/add-linting.ts
+++ b/packages/react/src/generators/application/lib/add-linting.ts
@@ -3,6 +3,8 @@ import {
   type GeneratorCallback,
   joinPathFragments,
   ensurePackage,
+  addDependenciesToPackageJson,
+  runTasksInSerial,
 } from '@nx/devkit';
 import {
   addExtendsToLintConfig,
@@ -12,7 +14,6 @@ import {
   isTypedLintingEnabled,
   useFlatConfig,
 } from '@nx/eslint/internal';
-import { addDependenciesToPackageJson, runTasksInSerial } from '@nx/devkit';
 import {
   addSwcDependencies,
   detectLinters,

--- a/packages/react/src/generators/host/host.rspack.spec.ts
+++ b/packages/react/src/generators/host/host.rspack.spec.ts
@@ -1,5 +1,10 @@
-import { Tree, updateJson, writeJson } from '@nx/devkit';
-import { ProjectGraph, readJson } from '@nx/devkit';
+import {
+  Tree,
+  updateJson,
+  writeJson,
+  ProjectGraph,
+  readJson,
+} from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import hostGenerator from './host';
 

--- a/packages/react/src/generators/host/lib/setup-ssr-for-host.ts
+++ b/packages/react/src/generators/host/lib/setup-ssr-for-host.ts
@@ -1,5 +1,7 @@
-import { GeneratorCallback, offsetFromRoot, Tree } from '@nx/devkit';
 import {
+  GeneratorCallback,
+  offsetFromRoot,
+  Tree,
   addDependenciesToPackageJson,
   generateFiles,
   joinPathFragments,

--- a/packages/react/src/generators/library/lib/update-app-routes.ts
+++ b/packages/react/src/generators/library/lib/update-app-routes.ts
@@ -12,8 +12,8 @@ import {
   addBrowserRouter,
   addRoute,
   findComponentImportPath,
+  addInitialRoutes,
 } from '../../../utils/ast-utils';
-import { addInitialRoutes } from '../../../utils/ast-utils';
 import { maybeJs } from '../../../utils/maybe-js';
 import { reactRouterDomVersion } from '../../../utils/versions';
 import { ensureTypescript } from '@nx/js/internal';

--- a/packages/react/src/generators/remote/lib/setup-ssr-for-remote.ts
+++ b/packages/react/src/generators/remote/lib/setup-ssr-for-remote.ts
@@ -1,5 +1,8 @@
-import { GeneratorCallback, names, offsetFromRoot, Tree } from '@nx/devkit';
 import {
+  GeneratorCallback,
+  names,
+  offsetFromRoot,
+  Tree,
   addDependenciesToPackageJson,
   generateFiles,
   joinPathFragments,

--- a/packages/remix/src/generators/init/init.spec.ts
+++ b/packages/remix/src/generators/init/init.spec.ts
@@ -2,8 +2,7 @@ import '@nx/devkit/internal-testing-utils/mock-project-graph';
 
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import { addDependenciesToPackageJson, readJson } from '@nx/devkit';
-import initGenerator from './init';
-import { remixInitGeneratorInternal } from './init';
+import initGenerator, { remixInitGeneratorInternal } from './init';
 
 describe('Remix Init Generator', () => {
   it('should setup the workspace and add dependencies', async () => {

--- a/packages/remix/src/generators/preset/preset.impl.ts
+++ b/packages/remix/src/generators/preset/preset.impl.ts
@@ -1,6 +1,11 @@
-import { formatFiles, GeneratorCallback, readNxJson, Tree } from '@nx/devkit';
+import {
+  formatFiles,
+  GeneratorCallback,
+  readNxJson,
+  Tree,
+  runTasksInSerial,
+} from '@nx/devkit';
 
-import { runTasksInSerial } from '@nx/devkit';
 import applicationGenerator from '../application/application.impl';
 import setupGenerator from '../setup/setup.impl';
 import { normalizeOptions } from './lib/normalize-options';

--- a/packages/rollup/src/plugins/package-json/update-package-json.ts
+++ b/packages/rollup/src/plugins/package-json/update-package-json.ts
@@ -1,8 +1,7 @@
 import { basename, join, parse } from 'path';
-import { writeJsonFile } from '@nx/devkit';
+import { writeJsonFile, stripIndents, workspaceRoot } from '@nx/devkit';
 import { writeFileSync } from 'fs';
 import { PackageJson } from '@nx/devkit/internal';
-import { stripIndents, workspaceRoot } from '@nx/devkit';
 
 export function updatePackageJson(
   options: {

--- a/packages/web/src/generators/application/application.spec.ts
+++ b/packages/web/src/generators/application/application.spec.ts
@@ -8,8 +8,9 @@ import {
   updateJson,
   updateNxJson,
   writeJson,
+  getProjects,
+  readJson,
 } from '@nx/devkit';
-import { getProjects, readJson } from '@nx/devkit';
 import { createTreeWithEmptyWorkspace } from '@nx/devkit/testing';
 import * as devkitExports from '@nx/devkit';
 

--- a/packages/workspace/src/generators/move/lib/update-project-root-files.ts
+++ b/packages/workspace/src/generators/move/lib/update-project-root-files.ts
@@ -1,5 +1,9 @@
-import { updateJson, ProjectConfiguration, Tree } from '@nx/devkit';
-import { workspaceRoot } from '@nx/devkit';
+import {
+  updateJson,
+  ProjectConfiguration,
+  Tree,
+  workspaceRoot,
+} from '@nx/devkit';
 import * as path from 'path';
 import { extname, join } from 'path';
 import { NormalizedSchema } from '../schema';

--- a/packages/workspace/src/generators/move/lib/update-storybook-config.ts
+++ b/packages/workspace/src/generators/move/lib/update-storybook-config.ts
@@ -1,5 +1,4 @@
-import { ProjectConfiguration, Tree } from '@nx/devkit';
-import { workspaceRoot } from '@nx/devkit';
+import { ProjectConfiguration, Tree, workspaceRoot } from '@nx/devkit';
 import * as path from 'path';
 import { join } from 'path';
 import { NormalizedSchema } from '../schema';

--- a/packages/workspace/src/generators/new/generate-workspace-files.ts
+++ b/packages/workspace/src/generators/new/generate-workspace-files.ts
@@ -11,6 +11,7 @@ import {
 import {
   connectToNxCloud,
   createNxCloudOnboardingURL,
+  setupAiAgentsGenerator,
 } from '@nx/devkit/internal';
 import { join } from 'path';
 import { gte } from 'semver';
@@ -18,7 +19,6 @@ import { deduceDefaultBase } from '../../utilities/default-base';
 import { nxVersion } from '../../utils/versions';
 import { Preset } from '../utils/presets';
 import type { NormalizedSchema } from './new';
-import { setupAiAgentsGenerator } from '@nx/devkit/internal';
 
 type PresetInfo = {
   generateAppCmd?: string;


### PR DESCRIPTION
## Current Behavior

Several modules are imported across multiple declarations in the same file:

```ts
import { getNamedInputs } from '@nx/devkit/internal';
// ...unrelated imports...
import { hashFile, hashObject } from '@nx/devkit/internal';
import { getLockFileName } from '@nx/devkit/internal';
import { workspaceDataDirectory } from '@nx/devkit/internal';
import { getNxRequirePaths } from '@nx/devkit/internal';
```

This is largely fallout from codemods that appended a new import beside each rewritten call site instead of merging into an existing declaration. `packages/js/src/plugins/typescript/plugin.ts` held 5 declarations of `@nx/devkit/internal` and 2 of `@nx/devkit`. Nothing in the lint config prevented it.

## Expected Behavior

One declaration per module per kind, and a lint rule that keeps it that way.

**1. `chore(repo): merge duplicate import declarations`** — 60 duplicate declarations across 48 files: `@nx/devkit` (19 files), `@nx/devkit/internal` (14), plus stragglers in nx-dev, graph, e2e and the nightly workflow.

Only same-kind declarations are merged — value with value, type with type. `import type` stays distinct from value imports: allowing that collapse would touch ~226 files, which indicates it is the prevailing convention here rather than an oversight.

Import bindings are unchanged. Every file was verified by comparing its set of `(local name, module, imported name, type-only)` tuples before and after — 57 of 58 identical, the one intentional difference noted below. This checks something a green build does not: that no import was accidentally *widened*.

**2. `chore(repo): forbid duplicate imports via lint rule`** — enables `no-duplicate-imports` in the shared `baseConfig`:

```js
'no-duplicate-imports': ['error', { allowSeparateTypeImports: true }],
```

`allowSeparateTypeImports` is load-bearing — without it the rule fires 201 times, demanding exactly the type/value collapse this PR deliberately avoids.

ESLint's core rule rather than `import/no-duplicates`: the latter compares *resolved paths*, and with no TypeScript resolver configured it resolves `./schema` (a `schema.d.ts`) to the adjacent `schema.json` and reports the pair as duplicated. Four such false positives had no valid merged form, and satisfying them would have meant adding a resolver dependency plus permanent suppressions.

The commit also fixes the 9 violations the rule surfaces, all shapes the first commit left alone by design:

- **8 × default merged into the sibling named import** — `@markdoc/markdoc` across 7 `nx-dev/ui-markdoc` files, and `./init` in the remix init spec.
- **1 × duplicate namespace alias consolidated** — `packages/angular-rspack-compiler/src/utils/utils.spec.ts` bound `node:os` twice, as `osModule` and `nodeOSModule`. Two namespace bindings have no legal merged form in ES modules, so the aliases are consolidated. Both named the same module object, so the `vi.spyOn` targets are unaffected. This is the one binding change in the PR.

**3. `chore(repo): format blog-details`** — `nx format:check` gates changed files, and `nx-dev/ui-blog/src/lib/blog-details.tsx` carried pre-existing prettier drift, so touching it at all requires reformatting it. The Tailwind class reordering is `prettier-plugin-tailwindcss` output, not an intentional style change; it is isolated in its own commit so the first commit's diff stays provably imports-only. 33 other nx-dev files carry the same drift and are left alone.

## Verification

| Check | Scope | Result |
| --- | --- | --- |
| Binding-set equivalence | 58 files | 57 identical, 1 intentional |
| `lint` | 91 projects, 164 tasks | 0 violations |
| `build` | 19 packages, 93 tasks | pass |
| `test` | js, nx, angular, react, eslint-plugin, web | pass |
| `test` | remix (27 suites, 171 tests) | pass |
| `test` | nx-dev-ui-markdoc, angular-rspack-compiler (188) | pass |
| `nx format:check --base=origin/master` | changed files | clean |
| `nx prepush` | full suite | pass |

## Related Issue(s)

N/A — no filed issue; cleanup prompted by the duplicate `@nx/devkit/internal` imports left behind by the devkit import-boundary work.

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/fix-double-exports-c05225fb">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->