### PR TITLE
fix(angular): import optional `ng-packagr` lazily

### DIFF
--- a/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ng-packagr.ts
+++ b/packages/angular/src/executors/ng-packagr-lite/ng-packagr-adjustments/ng-packagr.ts
@@ -1,10 +1,11 @@
-import { type NgPackagr, ngPackagr } from 'ng-packagr';
+import type { NgPackagr } from 'ng-packagr';
 
 export async function getNgPackagrInstance(): Promise<NgPackagr> {
   const { getWriteBundlesTransformProvider } =
     await import('./ng-package/entry-point/write-bundles.di.js');
   const { getStylesheetProcessorFactoryProvider } =
     await import('../../utilities/ng-packagr/stylesheet-processor.di.js');
+  const { ngPackagr } = await import('ng-packagr');
 
   const packagr = ngPackagr();
   packagr.withProviders([

--- a/packages/angular/src/executors/package/ng-packagr-adjustments/ng-packagr.ts
+++ b/packages/angular/src/executors/package/ng-packagr-adjustments/ng-packagr.ts
@@ -1,8 +1,9 @@
-import { type NgPackagr, ngPackagr } from 'ng-packagr';
+import type { NgPackagr } from 'ng-packagr';
 
 export async function getNgPackagrInstance(): Promise<NgPackagr> {
   const { getStylesheetProcessorFactoryProvider } =
     await import('../../utilities/ng-packagr/stylesheet-processor.di.js');
+  const { ngPackagr } = await import('ng-packagr');
 
   const packagr = ngPackagr();
   packagr.withProviders([getStylesheetProcessorFactoryProvider()]);


### PR DESCRIPTION
`@nx/angular/executors` eagerly loads the package executor path, which loads `ng-packagr` at module evaluation time via `packages/angular/src/executors/package/ng-packagr-adjustments/ng-packagr.ts`.

## Current Behavior
Today this can break Angular application builds in downstream wrappers that import `@nx/angular/executors` only to call the webpack browser builder, because the barrel import evaluates the package executor path and throws `Cannot find module 'ng-packagr'` before any library-packaging code is selected.

## Expected Behavior
- app-build imports from `@nx/angular/executors` should work without `ng-packagr`
- `ng-packagr` should only be required when `@nx/angular:package` or related library packaging executors actually run

## Related Issue(s)
none