### PR TITLE
cleanup(core): remove the unread task graph cache from the graph command

### DIFF
--- a/packages/nx/src/command-line/graph/graph.ts
+++ b/packages/nx/src/command-line/graph/graph.ts
@@ -1190,15 +1190,11 @@ async function createExpandedTaskInputResponse(
 
 // Performance optimized functions for lazy loading task graphs
 
-// In-memory cache for task graphs to avoid regeneration
-const taskGraphCache = new Map<string, TaskGraphClientResponse>();
-
 // In-memory cache for expanded task inputs to avoid regeneration
 const expandedTaskInputsCache = new Map<string, Record<string, string[]>>();
 
 // Clear cache when project graph changes
 function clearTaskGraphCache() {
-  taskGraphCache.clear();
   expandedTaskInputsCache.clear();
 }
 


### PR DESCRIPTION
## Current Behavior

`packages/nx/src/command-line/graph/graph.ts` declares two module-level caches side by side:

```ts
// In-memory cache for task graphs to avoid regeneration
const taskGraphCache = new Map<string, TaskGraphClientResponse>();

// In-memory cache for expanded task inputs to avoid regeneration
const expandedTaskInputsCache = new Map<string, Record<string, string[]>>();

// Clear cache when project graph changes
function clearTaskGraphCache() {
  taskGraphCache.clear();
  expandedTaskInputsCache.clear();
}
```

`expandedTaskInputsCache` is still doing its job — it is passed into `expandInputs`, read with `has`/`get`, and written with `set`.

`taskGraphCache` is not. Across the whole repository it appears exactly twice: the declaration above and the `.clear()` call. Its `get`/`has`/`set` sites were removed in a2770741 ("feat(graph): task graph support multiple targets", #32418) when `createTaskGraphForTargetsAndProjects` replaced the per-task lookup, and the declaration was left behind.

So the comment says the graph command caches task graphs, and it does not — the only cache actually working there is the one next to it.

## Expected Behavior

The declaration and its `.clear()` go away; `clearTaskGraphCache()` keeps clearing `expandedTaskInputsCache`. No behaviour changes — nothing read from the map, so nothing can observe its absence — and the file stops claiming a cache that is not there.

If the intent is the opposite, that lazy task-graph caching should come back for the multi-target path, that is a change I would rather leave to the team; this PR only removes what is currently unreachable.

## Related Issue(s)

None — found while auditing collections that are written but never read.
