### PR TITLE
fix(expo): keep the expo dev server alive under jest

### DIFF
--- a/e2e/expo/src/expo-legacy.test.ts
+++ b/e2e/expo/src/expo-legacy.test.ts
@@ -18,14 +18,18 @@ import {
 } from '@nx/e2e-utils';
 import { ChildProcess } from 'child_process';
 import { join } from 'path';
+import { setupExpoEnv } from './setup';
 
 describe('@nx/expo (legacy)', () => {
   let proj: string;
   let appName = uniq('my-app');
   let libName = uniq('lib');
   let originalEnv: string;
+  let restoreExpoEnv: () => void;
 
   beforeAll(() => {
+    restoreExpoEnv = setupExpoEnv();
+
     proj = newProject({
       packages: [
         '@nx/cypress',
@@ -63,6 +67,7 @@ describe('@nx/expo (legacy)', () => {
   });
   afterAll(() => {
     process.env.NX_ADD_PLUGINS = originalEnv;
+    restoreExpoEnv();
     cleanupProject();
   });
 

--- a/e2e/expo/src/expo.test.ts
+++ b/e2e/expo/src/expo.test.ts
@@ -17,12 +17,16 @@ import {
   reservePort,
 } from '@nx/e2e-utils';
 import { join } from 'path';
+import { setupExpoEnv } from './setup';
 
 describe('@nx/expo', () => {
   let appName: string;
   let libName: string;
+  let restoreExpoEnv: () => void;
 
   beforeAll(() => {
+    restoreExpoEnv = setupExpoEnv();
+
     newProject({
       packages: [
         '@nx/cypress',
@@ -45,7 +49,10 @@ describe('@nx/expo', () => {
     );
   });
 
-  afterAll(() => cleanupProject());
+  afterAll(() => {
+    restoreExpoEnv();
+    cleanupProject();
+  });
 
   it('nx.json should contain plugin configuration', () => {
     const nxJson = readJson('nx.json');

--- a/e2e/expo/src/setup.ts
+++ b/e2e/expo/src/setup.ts
@@ -1,0 +1,22 @@
+/**
+ * Puts spawned expo processes into headless mode, and returns a callback that
+ * restores the previous value.
+ *
+ * Jest sets NODE_ENV=test, which spawned expo processes inherit. @expo/cli then
+ * leaves the standalone fusebox shell experiment on, and dev-middleware 0.85+
+ * eagerly prepares the debugger shell, which throws "DefaultToolLauncher must be
+ * mocked or overridden in tests". EXPO_UNSTABLE_HEADLESS is @expo/cli's only
+ * switch for that experiment.
+ */
+export function setupExpoEnv(): () => void {
+  const original = process.env.EXPO_UNSTABLE_HEADLESS;
+  process.env.EXPO_UNSTABLE_HEADLESS = '1';
+
+  return () => {
+    if (original === undefined) {
+      delete process.env.EXPO_UNSTABLE_HEADLESS;
+    } else {
+      process.env.EXPO_UNSTABLE_HEADLESS = original;
+    }
+  };
+}

--- a/e2e/expo/tsconfig.spec.json
+++ b/e2e/expo/tsconfig.spec.json
@@ -16,6 +16,7 @@
     "**/*.test.js",
     "**/*.spec.jsx",
     "**/*.test.jsx",
+    "src/**/*.ts",
     "**/*.d.ts",
     "jest.config.ts"
   ]

--- a/packages/expo/src/executors/serve/serve.impl.ts
+++ b/packages/expo/src/executors/serve/serve.impl.ts
@@ -87,13 +87,39 @@ function serveAsync(
       }
     );
 
+    let settled = false;
+    const settleResolve = (cp: ChildProcess) => {
+      if (settled) return;
+      settled = true;
+      resolve(cp);
+    };
+    const settleReject = (err: unknown) => {
+      if (settled) return;
+      settled = true;
+      reject(err);
+    };
+
+    // Expo builds the web bundle on first request, so a consumer that only
+    // requests the page once this executor reports ready (e.g. @nx/cypress
+    // waiting on the dev server target) would deadlock against a bundle log
+    // line that can never arrive. Accepting connections is the real signal.
+    void (async () => {
+      while (!settled) {
+        if ((await isPackagerRunning(options.port)) === 'running') {
+          settleResolve(childProcess);
+          return;
+        }
+        await new Promise((r) => setTimeout(r, 500));
+      }
+    })();
+
     childProcess.stdout.on('data', (data) => {
       process.stdout.write(data);
       if (
         data.toString().includes('Bundling complete') ||
         data.toString().includes('Bundled')
       ) {
-        resolve(childProcess);
+        settleResolve(childProcess);
       }
     });
     childProcess.stderr.on('data', (data) => {
@@ -101,14 +127,14 @@ function serveAsync(
     });
 
     childProcess.on('error', (err) => {
-      reject(err);
+      settleReject(err);
     });
     childProcess.on('exit', (code, signal) => {
       if (code === null) code = signalToCode(signal);
       if (code === 0) {
-        resolve(childProcess);
+        settleResolve(childProcess);
       } else {
-        reject(code);
+        settleReject(code);
       }
     });
   });

--- a/packages/expo/src/executors/serve/serve.impl.ts
+++ b/packages/expo/src/executors/serve/serve.impl.ts
@@ -99,10 +99,9 @@ function serveAsync(
       reject(err);
     };
 
-    // Expo builds the web bundle on first request, so a consumer that only
-    // requests the page once this executor reports ready (e.g. @nx/cypress
-    // waiting on the dev server target) would deadlock against a bundle log
-    // line that can never arrive. Accepting connections is the real signal.
+    // Expo bundles on first request, so waiting on a bundle log line deadlocks
+    // against a consumer that only requests once we report ready (@nx/cypress).
+    // /status answers packager-status:running once Metro's bundler is ready.
     void (async () => {
       while (!settled) {
         if ((await isPackagerRunning(options.port)) === 'running') {


### PR DESCRIPTION
## Current Behavior

`e2e-expo` fails on its MacOS/npm combo. Jest's `NODE_ENV=test` leaves @expo/cli's fusebox debugger shell on, and `@react-native/dev-middleware` 0.85+ throws `DefaultToolLauncher must be mocked or overridden in tests` while eagerly preparing it.

Behind that, `@nx/expo:serve` only resolves on a `Bundling complete`/`Bundled` stdout line. Expo builds the web bundle on first request, and `@nx/cypress` will not request anything until the dev server target reports ready, so the two deadlock until the 5 minute `runCLI` timeout.

## Expected Behavior

Expo e2e sets `EXPO_UNSTABLE_HEADLESS=1` through a shared `setupExpoEnv` helper.

`@nx/expo:serve` resolves once the packager accepts connections.

## Nightly suite fixed

Failing run used for reproduction: https://github.com/nrwl/nx/actions/runs/31358783952 (commit `3298fd8`).

| Suite | Combo | Failure | Local result |
| --- | --- | --- | --- |
| e2e-expo | MacOS/npm | `DefaultToolLauncher must be mocked or overridden in tests`, `expo-legacy.test.ts` "should run e2e for cypress" | 22 passed, 0 `DefaultToolLauncher`, 0 `ETIMEDOUT` |

Latent since the Expo SDK 56 lane (#35904) landed on 2026-06-24: `@expo/cli` 56.1.x pins dev-middleware 0.85.3, and 0.84.0 has neither the assert nor the eager `prepareDebuggerShell()` call.

The dev-server deadlock is only reachable once the `DefaultToolLauncher` error is gone, so it never appeared in a nightly report - it is the next blocker behind it.

The npm/TypeScript 7 failures in the same nightly (e2e-vite, e2e-web, e2e-rspack) are handled by #36478, not here.

## Related Issue(s)

NXC-4612

<!-- polygraph-session-start -->
---
[View session information ↗](https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/nightly-golden-test-fixes-19ad82e5)
<!-- polygraph-session-end -->
