### PR TITLE
chore(repo): sort tailwind classes to match prettier

### DIFF
--- a/astro-docs/src/components/PluginDirectory.tsx
+++ b/astro-docs/src/components/PluginDirectory.tsx
@@ -202,7 +202,7 @@ function PluginCard({ plugin }: { plugin: Plugin }) {
       <div className="flex h-full flex-col">
         <div className="mb-3 flex items-center gap-3">
           <GitHubIcon className="h-6 w-6 flex-shrink-0 text-gray-600 dark:text-slate-400" />
-          <h3 className="text-base font-medium leading-tight text-gray-900 dark:text-slate-100">
+          <h3 className="text-base leading-tight font-medium text-gray-900 dark:text-slate-100">
             {plugin.name}
           </h3>
         </div>
@@ -228,15 +228,15 @@ function PluginCard({ plugin }: { plugin: Plugin }) {
           </div>
           <div className="my-1 ml-1 flex flex-1 justify-end text-nowrap">
             {plugin.pluginType === 'official' ? (
-              <span className="inline-flex items-center rounded-full bg-green-50 px-2 py-1 text-xs font-medium text-green-700 ring-1 ring-inset ring-green-600/20 dark:bg-green-500/10 dark:text-green-400 dark:ring-green-500/20">
+              <span className="inline-flex items-center rounded-full bg-green-50 px-2 py-1 text-xs font-medium text-green-700 ring-1 ring-green-600/20 ring-inset dark:bg-green-500/10 dark:text-green-400 dark:ring-green-500/20">
                 Nx Open Source
               </span>
             ) : plugin.nxVersion ? (
-              <span className="inline-flex items-center rounded-full bg-amber-50 px-2 py-1 text-xs font-medium text-amber-700 ring-1 ring-inset ring-amber-600/20 dark:bg-amber-500/10 dark:text-amber-400 dark:ring-amber-500/20">
+              <span className="inline-flex items-center rounded-full bg-amber-50 px-2 py-1 text-xs font-medium text-amber-700 ring-1 ring-amber-600/20 ring-inset dark:bg-amber-500/10 dark:text-amber-400 dark:ring-amber-500/20">
                 Nx {plugin.nxVersion}
               </span>
             ) : (
-              <span className="inline-flex items-center rounded-full bg-blue-50 px-2 py-1 text-xs font-medium text-blue-700 ring-1 ring-inset ring-blue-600/20 dark:bg-blue-500/10 dark:text-blue-400 dark:ring-blue-500/20">
+              <span className="inline-flex items-center rounded-full bg-blue-50 px-2 py-1 text-xs font-medium text-blue-700 ring-1 ring-blue-600/20 ring-inset dark:bg-blue-500/10 dark:text-blue-400 dark:ring-blue-500/20">
                 Community
               </span>
             )}
@@ -404,7 +404,7 @@ export function PluginDirectory({
           <input
             id="plugin-search"
             name="search"
-            className="block w-full rounded-md border border-slate-300 bg-white py-1.5 pl-8 pr-3 text-sm placeholder-slate-500 transition focus:border-blue-500 focus:outline-none focus:ring-1 focus:ring-blue-500 dark:border-slate-700 dark:bg-slate-800 dark:placeholder-slate-400 dark:focus:border-blue-400 dark:focus:ring-blue-400"
+            className="block w-full rounded-md border border-slate-300 bg-white py-1.5 pr-3 pl-8 text-sm placeholder-slate-500 transition focus:border-blue-500 focus:ring-1 focus:ring-blue-500 focus:outline-none dark:border-slate-700 dark:bg-slate-800 dark:placeholder-slate-400 dark:focus:border-blue-400 dark:focus:ring-blue-400"
             placeholder="Search..."
             value={modifiers.term}
             onChange={(event) =>

--- a/graph/client/src/app/feature-projects/projects-shell.tsx
+++ b/graph/client/src/app/feature-projects/projects-shell.tsx
@@ -303,7 +303,7 @@ function ProjectsShellInner() {
               toolPopoverPanelItemActiveClassName="text-slate-200 bg-sky-500 dark:bg-sky-600"
             />
           </NxGraphToolbarItemGroup>
-          <NxGraphToolbarItemGroup className="pl-2 pr-0">
+          <NxGraphToolbarItemGroup className="pr-0 pl-2">
             <NxGraphResetLayoutTool toolClassName="text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 hover:bg-slate-50 dark:hover:bg-slate-800 border-slate-300 dark:border-slate-600" />
             <NxGraphResetGraphTool toolClassName="text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 hover:bg-slate-50 dark:hover:bg-slate-800 border-slate-300 dark:border-slate-600" />
             <NxGraphShareTool
@@ -312,7 +312,7 @@ function ProjectsShellInner() {
               toolPopoverPanelItemClassName="hover:bg-sky-500 dark:hover:bg-sky-600 hover:text-slate-200 dark:text-slate-300"
             />
           </NxGraphToolbarItemGroup>
-          <NxGraphToolbarItemGroup className="pl-2 pr-0">
+          <NxGraphToolbarItemGroup className="pr-0 pl-2">
             <NxGraphProjectModeTool
               toolPopoverButtonClassName="text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 hover:bg-slate-50 dark:hover:bg-slate-800 border-slate-300 dark:border-slate-600"
               toolPopoverPanelClassName="bg-white dark:bg-slate-900 border-slate-200 dark:border-slate-700 z-50"
@@ -353,8 +353,8 @@ function ProjectsShellInner() {
         {handleEventResult.rendererConfig.platform === 'nx-console' ? (
           <ProjectGraphControlsPanel handleEventResult={handleEventResult} />
         ) : (
-          <div className="absolute bottom-0 left-0 top-4 flex flex-col">
-            <div className="mb-2 ml-4 min-w-96 max-w-96">
+          <div className="absolute top-4 bottom-0 left-0 flex flex-col">
+            <div className="mb-2 ml-4 max-w-96 min-w-96">
               <TabGroup>
                 <TabList className="flex rounded-lg bg-slate-100 p-1 dark:bg-slate-800">
                   <Tab

--- a/graph/client/src/app/feature-tasks/tasks-shell.tsx
+++ b/graph/client/src/app/feature-tasks/tasks-shell.tsx
@@ -368,7 +368,7 @@ function TasksShellInner() {
               toolPopoverPanelItemActiveClassName="text-slate-200 bg-sky-500 dark:bg-sky-600"
             />
           </NxGraphToolbarItemGroup>
-          <NxGraphToolbarItemGroup className="pl-2 pr-0">
+          <NxGraphToolbarItemGroup className="pr-0 pl-2">
             <NxGraphGroupByProjectTool
               toolClassName="text-slate-600 dark:text-slate-400 hover:text-slate-900 dark:hover:text-slate-100 hover:bg-slate-50 dark:hover:bg-slate-800 border-slate-300 dark:border-slate-600"
               toolActiveClassName="bg-sky-500 dark:bg-sky-600 text-white dark:text-white"
@@ -403,8 +403,8 @@ function TasksShellInner() {
             onToggleProject={onToggleProject}
           />
         ) : (
-          <div className="absolute bottom-0 left-0 top-4 z-50 flex flex-col">
-            <TabGroup className="mb-2 ml-4 min-w-96 max-w-96">
+          <div className="absolute top-4 bottom-0 left-0 z-50 flex flex-col">
+            <TabGroup className="mb-2 ml-4 max-w-96 min-w-96">
               <TabList className="flex rounded-lg bg-slate-100 p-1 dark:bg-slate-800">
                 <Tab
                   className={classNames(

--- a/graph/migrate/src/lib/components/migration-init.tsx
+++ b/graph/migrate/src/lib/components/migration-init.tsx
@@ -46,7 +46,7 @@ export function MigrationInit({ onStart }: { onStart: () => void }) {
         animate={{ opacity: 1 }}
         transition={{ delay: 0.8 }}
         onClick={onStart}
-        className="mt-4 rounded-md bg-blue-600 px-6 py-3 text-sm font-medium text-white shadow-md transition-colors hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 dark:bg-blue-500 dark:hover:bg-blue-600"
+        className="mt-4 rounded-md bg-blue-600 px-6 py-3 text-sm font-medium text-white shadow-md transition-colors hover:bg-blue-700 focus:ring-2 focus:ring-blue-400 focus:ring-offset-2 focus:outline-none dark:bg-blue-500 dark:hover:bg-blue-600"
       >
         Start Migration
       </motion.button>

--- a/graph/ui-code-block/src/lib/json-code-block.tsx
+++ b/graph/ui-code-block/src/lib/json-code-block.tsx
@@ -35,7 +35,7 @@ export function JsonCodeBlock(props: JsonCodeBlockProps): JSX.Element {
   );
   return (
     <div className="code-block group relative w-full">
-      <div className="absolute right-0 top-0 z-10 flex">
+      <div className="absolute top-0 right-0 z-10 flex">
         <CopyToClipboardButton
           text={jsonString}
           tooltipAlignment="right"

--- a/graph/ui-common/src/lib/debounced-text-input.tsx
+++ b/graph/ui-common/src/lib/debounced-text-input.tsx
@@ -54,7 +54,7 @@ export function DebouncedTextInput({
 
   return (
     <form
-      className="shadow-xs group relative flex rounded-md"
+      className="group relative flex rounded-md shadow-xs"
       onSubmit={(event) => event.preventDefault()}
     >
       <span className="inline-flex items-center rounded-l-md border border-r-0 border-slate-300 bg-slate-50 p-2 dark:border-slate-900 dark:bg-slate-800">
@@ -75,7 +75,7 @@ export function DebouncedTextInput({
           data-cy="textFilterReset"
           type="reset"
           onClick={resetClicked}
-          className="absolute right-1 top-1 inline-block rounded-md bg-slate-50 p-1 text-slate-400 dark:bg-slate-800"
+          className="absolute top-1 right-1 inline-block rounded-md bg-slate-50 p-1 text-slate-400 dark:bg-slate-800"
         >
           <BackspaceIcon className="h-5 w-5"></BackspaceIcon>
         </button>

--- a/graph/ui-common/src/lib/dropdown.tsx
+++ b/graph/ui-common/src/lib/dropdown.tsx
@@ -8,7 +8,7 @@ export function Dropdown(props: DropdownProps) {
   const { className, children, ...rest } = props;
   return (
     <select
-      className={`form-select shadow-xs flex items-center rounded-md border border-slate-300 bg-white py-2 pl-4 pr-8 text-sm font-medium text-slate-700 hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300 hover:dark:bg-slate-700 ${className}`}
+      className={`form-select flex items-center rounded-md border border-slate-300 bg-white py-2 pr-8 pl-4 text-sm font-medium text-slate-700 shadow-xs hover:bg-slate-50 dark:border-slate-600 dark:bg-slate-800 dark:text-slate-300 hover:dark:bg-slate-700 ${className}`}
       {...rest}
     >
       {children}

--- a/graph/ui-common/src/lib/error-renderer/error-renderer.tsx
+++ b/graph/ui-common/src/lib/error-renderer/error-renderer.tsx
@@ -15,14 +15,14 @@ export function ErrorRenderer({ errors }: { errors: GraphError[] }) {
             : error.fileName;
         return (
           <div className="overflow-hidden pb-4" key={index}>
-            <span className="inline-flex max-w-full flex-col break-words font-bold font-normal text-gray-900 md:inline dark:text-slate-200">
+            <span className="inline-flex max-w-full flex-col font-bold font-normal break-words text-gray-900 md:inline dark:text-slate-200">
               <span>{errorHeading}</span>
               {fileSpecifier && (
                 <span className="hidden px-1 md:inline">-</span>
               )}
               <span>{fileSpecifier}</span>
             </span>
-            <pre className="overflow-x-scroll pl-4 pt-3">
+            <pre className="overflow-x-scroll pt-3 pl-4">
               {isCauseWithErrors(error.cause) &&
               error.cause.errors.length === 1 ? (
                 <div>

--- a/graph/ui-common/src/lib/modal.tsx
+++ b/graph/ui-common/src/lib/modal.tsx
@@ -69,7 +69,7 @@ export const Modal = forwardRef(
           </TransitionChild>
 
           <div className="fixed inset-0 z-[9999] w-screen overflow-y-auto">
-            <div className="flex h-full min-h-full items-end items-center justify-center p-4 text-center sm:p-0">
+            <div className="flex h-full min-h-full items-center items-end justify-center p-4 text-center sm:p-0">
               <TransitionChild
                 as={Fragment}
                 enter="ease-out duration-300"
@@ -85,7 +85,7 @@ export const Modal = forwardRef(
                   <div className="flex items-center justify-between rounded-t border-b bg-white p-2 pb-1 md:p-4 md:pb-2 dark:border-gray-600 dark:bg-slate-900">
                     <DialogTitle
                       as="h3"
-                      className="text-lg font-medium leading-6 text-gray-900 dark:text-slate-200"
+                      className="text-lg leading-6 font-medium text-gray-900 dark:text-slate-200"
                     >
                       {title}
                     </DialogTitle>

--- a/graph/ui-common/src/lib/tag.tsx
+++ b/graph/ui-common/src/lib/tag.tsx
@@ -9,7 +9,7 @@ export type TagProps = Partial<{
 export function Tag({ className, children, ...rest }: TagProps) {
   return (
     <span
-      className={`${className} inline-block rounded-md bg-slate-300 p-2 font-sans text-xs font-semibold uppercase leading-4 tracking-wide text-slate-700`}
+      className={`${className} inline-block rounded-md bg-slate-300 p-2 font-sans text-xs leading-4 font-semibold tracking-wide text-slate-700 uppercase`}
       {...rest}
     >
       {children}

--- a/graph/ui-common/src/lib/tooltips/tooltip.tsx
+++ b/graph/ui-common/src/lib/tooltips/tooltip.tsx
@@ -135,7 +135,7 @@ export function Tooltip({
         width: 'max-content',
         ...animationStyles,
       }}
-      className="z-20 min-w-[250px] max-w-prose rounded-md border border-slate-500"
+      className="z-20 max-w-prose min-w-[250px] rounded-md border border-slate-500"
       {...getFloatingProps()}
     >
       {showTooltipArrow && (
@@ -151,7 +151,7 @@ export function Tooltip({
           ref={arrowRef}
         ></div>
       )}
-      <div className="select-text rounded-md bg-white p-3 dark:bg-slate-900 dark:text-slate-400">
+      <div className="rounded-md bg-white p-3 select-text dark:bg-slate-900 dark:text-slate-400">
         {content}
       </div>
     </div>

--- a/graph/ui-project-details/src/lib/owners-list/owners-list.tsx
+++ b/graph/ui-project-details/src/lib/owners-list/owners-list.tsx
@@ -37,7 +37,7 @@ export function OwnersList({ owners, className }: OwnersListProps) {
 
   return (
     <div className={twMerge('relative max-w-full', className)}>
-      <p className="flex min-w-0 font-medium leading-loose">
+      <p className="flex min-w-0 leading-loose font-medium">
         <span className="inline-block">Owners:</span>
 
         <span

--- a/graph/ui-project-details/src/lib/project-details/project-details.tsx
+++ b/graph/ui-project-details/src/lib/project-details/project-details.tsx
@@ -109,7 +109,7 @@ export const ProjectDetails = ({
         <div className="flex flex-wrap justify-between py-2">
           <div className="min-w-0">
             {projectData.metadata?.description ? (
-              <p className="mb-2 text-sm capitalize text-gray-500 dark:text-slate-400">
+              <p className="mb-2 text-sm text-gray-500 capitalize dark:text-slate-400">
                 {projectData.metadata?.description}
               </p>
             ) : null}
@@ -183,7 +183,7 @@ export default ProjectDetails;
 function ViewInProjectGraphButton({ onClick }: { onClick: () => void }) {
   return (
     <button
-      className="inline-flex cursor-pointer items-center gap-2 rounded-md px-2 py-1 text-base text-slate-600 ring-2 ring-inset ring-slate-400/40 hover:bg-slate-50 dark:text-slate-300 dark:ring-slate-400/30 dark:hover:bg-slate-800/60"
+      className="inline-flex cursor-pointer items-center gap-2 rounded-md px-2 py-1 text-base text-slate-600 ring-2 ring-slate-400/40 ring-inset hover:bg-slate-50 dark:text-slate-300 dark:ring-slate-400/30 dark:hover:bg-slate-800/60"
       onClick={() => onClick()}
     >
       <EyeIcon className="h-5 w-5"></EyeIcon>

--- a/graph/ui-project-details/src/lib/tag-list/tag-list.tsx
+++ b/graph/ui-project-details/src/lib/tag-list/tag-list.tsx
@@ -37,7 +37,7 @@ export function TagList({ tags, className }: TagListProps) {
 
   return (
     <div className={twMerge('relative max-w-full', className)}>
-      <p className="flex min-w-0 font-medium leading-loose">
+      <p className="flex min-w-0 leading-loose font-medium">
         <span className="inline-block">Tags:</span>
 
         <span

--- a/graph/ui-project-details/src/lib/target-configuration-details-group-list/target-configuration-details-group-list.tsx
+++ b/graph/ui-project-details/src/lib/target-configuration-details-group-list/target-configuration-details-group-list.tsx
@@ -129,7 +129,7 @@ export function TargetConfigurationGroupList({
         <p className="mb-2">No targets configured.</p>
         <p>
           There are two ways to create targets:
-          <ul className="ml-6 mt-2 list-disc space-y-2">
+          <ul className="mt-2 ml-6 list-disc space-y-2">
             <li>
               <a
                 href="https://nx.dev/plugin-registry"

--- a/graph/ui-project-details/src/lib/target-configuration-details/fading-collapsible.tsx
+++ b/graph/ui-project-details/src/lib/target-configuration-details/fading-collapsible.tsx
@@ -43,7 +43,7 @@ export function FadingCollapsible({ children }: { children: ReactNode }) {
       </div>
       {isCollapsible && (
         <div
-          className="absolute bottom-2 right-1/2 h-4 w-4 cursor-pointer"
+          className="absolute right-1/2 bottom-2 h-4 w-4 cursor-pointer"
           onClick={(e) => {
             e.stopPropagation();
             toggleCollapsed();

--- a/graph/ui-project-details/src/lib/target-configuration-details/target-configuration-details.tsx
+++ b/graph/ui-project-details/src/lib/target-configuration-details/target-configuration-details.tsx
@@ -367,7 +367,7 @@ export default function TargetConfigurationDetails({
                   </span>
                 </Tooltip>
               </h4>
-              <div className="group/line overflow-hidden whitespace-nowrap pl-5">
+              <div className="group/line overflow-hidden pl-5 whitespace-nowrap">
                 <TargetConfigurationProperty data={{ parallelism: false }}>
                   <TargetSourceInfo
                     className="min-w-0 flex-1 pl-4 opacity-0 transition-opacity duration-150 ease-in-out group-hover/line:opacity-100"
@@ -418,7 +418,7 @@ export default function TargetConfigurationDetails({
                         data={generator}
                         disabled={true}
                         disabledTooltip={
-                          <p className="max-w-sm whitespace-pre-wrap py-2 font-mono text-sm normal-case text-slate-700 dark:text-slate-400">
+                          <p className="max-w-sm py-2 font-mono text-sm whitespace-pre-wrap text-slate-700 normal-case dark:text-slate-400">
                             The Sync Generator is disabled in the{' '}
                             <code className="font-bold italic">
                               sync.disabledTaskSyncGenerators

--- a/graph/ui-render-config/src/lib/theme-panel.tsx
+++ b/graph/ui-render-config/src/lib/theme-panel.tsx
@@ -21,7 +21,7 @@ export function ThemePanel(): JSX.Element {
     <Menu as="div" className="relative inline-block text-left">
       <div>
         <MenuButton
-          className="inline-flex w-full justify-center rounded-md p-2 text-sm font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-white focus-visible:ring-opacity-75 dark:text-sky-500"
+          className="focus-visible:ring-opacity-75 inline-flex w-full justify-center rounded-md p-2 text-sm font-medium focus:outline-none focus-visible:ring-2 focus-visible:ring-white dark:text-sky-500"
           data-cy="theme-open-modal-button"
         >
           <span className="sr-only">Theme switcher</span>
@@ -45,7 +45,7 @@ export function ThemePanel(): JSX.Element {
         leaveFrom="transform opacity-100 scale-100"
         leaveTo="transform opacity-0 scale-95"
       >
-        <MenuItems className="absolute right-0 z-50 mt-2 w-36 origin-top-right rounded-md bg-white text-slate-500 shadow-lg ring-1 ring-slate-900/10 ring-opacity-5 focus:outline-none dark:bg-slate-800 dark:text-slate-400 dark:ring-0">
+        <MenuItems className="ring-opacity-5 absolute right-0 z-50 mt-2 w-36 origin-top-right rounded-md bg-white text-slate-500 shadow-lg ring-1 ring-slate-900/10 focus:outline-none dark:bg-slate-800 dark:text-slate-400 dark:ring-0">
           <div className="px-1 py-1">
             <MenuItem>
               {({ focus }) => (

--- a/nx-dev/feature-ai/src/lib/feed-container.tsx
+++ b/nx-dev/feature-ai/src/lib/feed-container.tsx
@@ -128,7 +128,7 @@ export function FeedContainer(): JSX.Element {
 
                 <div
                   className={cx(
-                    'left0 fixed bottom-0 right-0 w-full px-4 py-4 lg:px-0 lg:py-6',
+                    'left0 fixed right-0 bottom-0 w-full px-4 py-4 lg:px-0 lg:py-6',
                     'bg-gradient-to-t from-white via-white/75 dark:from-zinc-900 dark:via-zinc-900/75'
                   )}
                 >

--- a/nx-dev/feature-ai/src/lib/feed/feed-question.tsx
+++ b/nx-dev/feature-ai/src/lib/feed/feed-question.tsx
@@ -1,7 +1,7 @@
 export function FeedQuestion({ content }: { content: string }) {
   return (
     <div className="flex w-full justify-end">
-      <p className="whitespace-pre-wrap break-words rounded-lg bg-blue-500 px-4 py-2 text-base text-white selection:bg-blue-900 dark:bg-blue-500">
+      <p className="rounded-lg bg-blue-500 px-4 py-2 text-base break-words whitespace-pre-wrap text-white selection:bg-blue-900 dark:bg-blue-500">
         {content}
       </p>
     </div>

--- a/nx-dev/feature-ai/src/lib/prompt.tsx
+++ b/nx-dev/feature-ai/src/lib/prompt.tsx
@@ -124,7 +124,7 @@ export function Prompt({
           name="query"
           maxLength={500}
           disabled={isGenerating}
-          className="block w-full resize-none border-none bg-transparent p-0 py-3 pl-2 text-sm placeholder-zinc-500 focus-within:outline-none focus:placeholder-zinc-400 focus:outline-none focus:ring-0 disabled:cursor-not-allowed dark:text-white dark:focus:placeholder-zinc-300"
+          className="block w-full resize-none border-none bg-transparent p-0 py-3 pl-2 text-sm placeholder-zinc-500 focus-within:outline-none focus:placeholder-zinc-400 focus:ring-0 focus:outline-none disabled:cursor-not-allowed dark:text-white dark:focus:placeholder-zinc-300"
           placeholder="How does caching work?"
           rows={1}
         />

--- a/nx-dev/nx-dev/pages/_app.tsx
+++ b/nx-dev/nx-dev/pages/_app.tsx
@@ -65,7 +65,7 @@ export default function CustomApp({
         id="skip-to-content-link"
         href="#main"
         tabIndex={0}
-        className="absolute left-8 top-3 -translate-y-24 rounded-md bg-green-400 px-4 py-2 text-white transition focus:translate-y-0"
+        className="absolute top-3 left-8 -translate-y-24 rounded-md bg-green-400 px-4 py-2 text-white transition focus:translate-y-0"
       >
         Skip to content
       </Link>

--- a/nx-dev/ui-animations/src/lib/animated-beam.tsx
+++ b/nx-dev/ui-animations/src/lib/animated-beam.tsx
@@ -193,7 +193,7 @@ export const AnimatedCurvedBeam: FC<AnimatedCurvedBeamProps> = ({
       height={svgDimensions.height}
       xmlns="http://www.w3.org/2000/svg"
       className={cx(
-        'pointer-events-none absolute left-0 top-0 transform-gpu stroke-2',
+        'pointer-events-none absolute top-0 left-0 transform-gpu stroke-2',
         className
       )}
       viewBox={`0 0 ${svgDimensions.width} ${svgDimensions.height}`}
@@ -405,7 +405,7 @@ export const AnimatedAngledBeam: FC<AnimatedAngledBeamProps> = ({
       height={svgDimensions.height}
       xmlns="http://www.w3.org/2000/svg"
       className={cx(
-        'pointer-events-none absolute left-0 top-0 transform-gpu stroke-2',
+        'pointer-events-none absolute top-0 left-0 transform-gpu stroke-2',
         className
       )}
       viewBox={`0 0 ${svgDimensions.width} ${svgDimensions.height}`}

--- a/nx-dev/ui-animations/src/lib/fit-text.tsx
+++ b/nx-dev/ui-animations/src/lib/fit-text.tsx
@@ -56,7 +56,7 @@ export function FitText({
     >
       <motion.span
         className={cx(
-          'transform whitespace-nowrap text-center font-bold',
+          'transform text-center font-bold whitespace-nowrap',
           className
         )}
         ref={textRef}

--- a/nx-dev/ui-animations/src/lib/marquee.tsx
+++ b/nx-dev/ui-animations/src/lib/marquee.tsx
@@ -40,7 +40,7 @@ export function Marquee({
     <div
       {...props}
       className={cx(
-        'group flex overflow-hidden p-2 [--duration:40s] [--gap:1rem] [gap:var(--gap)]',
+        'group flex [gap:var(--gap)] overflow-hidden p-2 [--duration:40s] [--gap:1rem]',
         {
           'flex-row': !vertical,
           'flex-col': vertical,

--- a/nx-dev/ui-animations/src/lib/shine-border.tsx
+++ b/nx-dev/ui-animations/src/lib/shine-border.tsx
@@ -57,7 +57,7 @@ export function ShineBorder({
             },transparent,transparent)`,
           } as CSSProperties
         }
-        className={`before:bg-shine-size before:absolute before:inset-[0] before:aspect-square before:h-full before:w-full before:rounded-[--border-radius] before:p-[--border-width] before:will-change-[background-position] before:content-[""] before:![-webkit-mask-composite:xor] before:[background-image:var(--background-radial-gradient)] before:[background-size:300%_300%] before:![mask-composite:exclude] before:[mask:var(--mask-linear-gradient)] motion-safe:before:animate-[shine-pulse_var(--shine-pulse-duration)_infinite_linear]`}
+        className={`before:bg-shine-size before:absolute before:inset-[0] before:aspect-square before:h-full before:w-full before:rounded-[--border-radius] before:[background-image:var(--background-radial-gradient)] before:[background-size:300%_300%] before:![mask-composite:exclude] before:p-[--border-width] before:will-change-[background-position] before:content-[""] before:![-webkit-mask-composite:xor] before:[mask:var(--mask-linear-gradient)] motion-safe:before:animate-[shine-pulse_var(--shine-pulse-duration)_infinite_linear]`}
       ></div>
       <div className={'z-[1] h-full w-full rounded-[--border-radius-child]'}>
         {children}

--- a/nx-dev/ui-blog/src/lib/blog-container.tsx
+++ b/nx-dev/ui-blog/src/lib/blog-container.tsx
@@ -74,7 +74,7 @@ export function BlogContainer({ blogPosts, tags }: BlogContainerProps) {
     <main id="main" role="main" className="w-full py-8">
       <div className="mx-auto mb-8 w-full max-w-[1088px] px-8">
         <>
-          <header className="mb-8 mt-20">
+          <header className="mt-20 mb-8">
             <h1
               id="blog-title"
               className="text-xl font-semibold tracking-tight text-zinc-900 md:text-2xl dark:text-zinc-100"
@@ -100,7 +100,7 @@ export function BlogContainer({ blogPosts, tags }: BlogContainerProps) {
         <FeaturedBlogs blogs={firstFiveBlogs} />
         {!!remainingBlogs.length && (
           <>
-            <div className="mx-auto mb-8 mt-20 flex items-center justify-between border-b-2 border-zinc-300 pb-3 text-sm dark:border-zinc-700">
+            <div className="mx-auto mt-20 mb-8 flex items-center justify-between border-b-2 border-zinc-300 pb-3 text-sm dark:border-zinc-700">
               <h2 className="font-semibold">All blogs</h2>
               <div className="flex gap-2">
                 <Link

--- a/nx-dev/ui-blog/src/lib/more-blogs.tsx
+++ b/nx-dev/ui-blog/src/lib/more-blogs.tsx
@@ -27,7 +27,7 @@ export function MoreBlogs({ blogs }: MoreBlogsProps) {
               className="relative flex items-center gap-6 border-b border-zinc-200 py-5 text-sm before:absolute before:inset-x-[-16px] before:inset-y-[-2px] before:z-[-1] before:rounded-xl before:bg-zinc-200 before:opacity-0 last:border-0 before:hover:opacity-100 dark:border-zinc-800 dark:before:bg-zinc-800/50"
               prefetch={false}
             >
-              <span className="w-1/2 flex-none text-balance font-medium text-zinc-500 sm:w-5/12 dark:text-white">
+              <span className="w-1/2 flex-none font-medium text-balance text-zinc-500 sm:w-5/12 dark:text-white">
                 {post.title}
               </span>
               <span className="w-1/2 flex-none sm:w-3/12">

--- a/nx-dev/ui-common/src/lib/champion-perks.tsx
+++ b/nx-dev/ui-common/src/lib/champion-perks.tsx
@@ -63,7 +63,7 @@ export function ChampionPerks(): JSX.Element {
                   aria-hidden="true"
                 />
                 <HeartIcon
-                  className="absolute inset-0 h-8 w-8 text-purple-500 opacity-0 transition-all group-hover:-translate-y-1 group-hover:translate-x-8 group-hover:opacity-100 dark:text-fuchsia-500"
+                  className="absolute inset-0 h-8 w-8 text-purple-500 opacity-0 transition-all group-hover:translate-x-8 group-hover:-translate-y-1 group-hover:opacity-100 dark:text-fuchsia-500"
                   aria-hidden="true"
                 />
                 <GiftIcon
@@ -71,7 +71,7 @@ export function ChampionPerks(): JSX.Element {
                   aria-hidden="true"
                 />
               </div>
-              <p className="relative mt-4 text-base font-medium leading-6 text-zinc-900 dark:text-zinc-100">
+              <p className="relative mt-4 text-base leading-6 font-medium text-zinc-900 dark:text-zinc-100">
                 <span className="absolute -left-4 h-full w-0.5 bg-blue-500 dark:bg-blue-500"></span>
                 Recognition as a Leader
               </p>
@@ -89,7 +89,7 @@ export function ChampionPerks(): JSX.Element {
                   aria-hidden="true"
                 />
                 <VideoCameraIcon
-                  className="absolute inset-0 h-8 w-8 text-purple-500 opacity-0 transition-all group-hover:-translate-y-1 group-hover:translate-x-8 group-hover:opacity-100 dark:text-fuchsia-500"
+                  className="absolute inset-0 h-8 w-8 text-purple-500 opacity-0 transition-all group-hover:translate-x-8 group-hover:-translate-y-1 group-hover:opacity-100 dark:text-fuchsia-500"
                   aria-hidden="true"
                 />
                 <MicrophoneIcon
@@ -97,7 +97,7 @@ export function ChampionPerks(): JSX.Element {
                   aria-hidden="true"
                 />
               </div>
-              <p className="relative mt-4 text-base font-medium leading-6 text-zinc-900 dark:text-zinc-100">
+              <p className="relative mt-4 text-base leading-6 font-medium text-zinc-900 dark:text-zinc-100">
                 <span className="absolute -left-4 h-full w-0.5 bg-blue-500 dark:bg-blue-500"></span>
                 Content Promotion
               </p>
@@ -116,7 +116,7 @@ export function ChampionPerks(): JSX.Element {
                   aria-hidden="true"
                 />
                 <LightBulbIcon
-                  className="absolute inset-0 h-8 w-8 text-purple-500 opacity-0 transition-all group-hover:-translate-y-1 group-hover:translate-x-8 group-hover:opacity-100 dark:text-fuchsia-500"
+                  className="absolute inset-0 h-8 w-8 text-purple-500 opacity-0 transition-all group-hover:translate-x-8 group-hover:-translate-y-1 group-hover:opacity-100 dark:text-fuchsia-500"
                   aria-hidden="true"
                 />
                 <ChatBubbleBottomCenterTextIcon
@@ -124,7 +124,7 @@ export function ChampionPerks(): JSX.Element {
                   aria-hidden="true"
                 />
               </div>
-              <p className="relative mt-4 text-base font-medium leading-6 text-zinc-900 dark:text-zinc-100">
+              <p className="relative mt-4 text-base leading-6 font-medium text-zinc-900 dark:text-zinc-100">
                 <span className="absolute -left-4 h-full w-0.5 bg-blue-500 dark:bg-blue-500"></span>
                 Special Access
               </p>
@@ -143,7 +143,7 @@ export function ChampionPerks(): JSX.Element {
                   aria-hidden="true"
                 />
                 <UsersIcon
-                  className="absolute inset-0 h-8 w-8 text-purple-500 opacity-0 transition-all group-hover:-translate-y-1 group-hover:translate-x-8 group-hover:opacity-100 dark:text-fuchsia-500"
+                  className="absolute inset-0 h-8 w-8 text-purple-500 opacity-0 transition-all group-hover:translate-x-8 group-hover:-translate-y-1 group-hover:opacity-100 dark:text-fuchsia-500"
                   aria-hidden="true"
                 />
                 <UserPlusIcon
@@ -151,7 +151,7 @@ export function ChampionPerks(): JSX.Element {
                   aria-hidden="true"
                 />
               </div>
-              <p className="relative mt-4 text-base font-medium leading-6 text-zinc-900 dark:text-zinc-100">
+              <p className="relative mt-4 text-base leading-6 font-medium text-zinc-900 dark:text-zinc-100">
                 <span className="absolute -left-4 h-full w-0.5 bg-blue-500 dark:bg-blue-500"></span>
                 Join the Program
               </p>

--- a/nx-dev/ui-common/src/lib/flip-card.tsx
+++ b/nx-dev/ui-common/src/lib/flip-card.tsx
@@ -66,7 +66,7 @@ export function FlipCard({
 
 export function FlipCardFront({ children }: { children: ReactNode }) {
   return (
-    <div className="backface-hidden absolute flex h-full w-full flex-col items-center justify-center px-2 text-center text-3xl font-bold">
+    <div className="absolute flex h-full w-full flex-col items-center justify-center px-2 text-center text-3xl font-bold backface-hidden">
       {children}
     </div>
   );
@@ -76,7 +76,7 @@ export function FlipCardBack({ children }: { children: ReactNode }) {
   return (
     <FlipCardContext.Consumer>
       {() => (
-        <div className="my-rotate-y-180 backface-hidden h-full w-full overflow-hidden rounded-md bg-white text-3xl text-zinc-900 dark:bg-zinc-800 dark:text-zinc-100">
+        <div className="my-rotate-y-180 h-full w-full overflow-hidden rounded-md bg-white text-3xl text-zinc-900 backface-hidden dark:bg-zinc-800 dark:text-zinc-100">
           <div className="p-4 text-sm sm:text-sm md:text-sm lg:text-lg">
             {children}
           </div>

--- a/nx-dev/ui-common/src/lib/headers/default-menu-item.tsx
+++ b/nx-dev/ui-common/src/lib/headers/default-menu-item.tsx
@@ -40,7 +40,7 @@ export function DefaultMenuItem({
         >
           {item.name}
           {item.isNew ? (
-            <span className="float-right inline-flex items-center rounded-md bg-blue-50 px-2 py-1 text-xs font-medium text-blue-700 ring-1 ring-inset ring-blue-700/10 dark:bg-blue-400/10 dark:text-blue-400 dark:ring-blue-400/30">
+            <span className="float-right inline-flex items-center rounded-md bg-blue-50 px-2 py-1 text-xs font-medium text-blue-700 ring-1 ring-blue-700/10 ring-inset dark:bg-blue-400/10 dark:text-blue-400 dark:ring-blue-400/30">
               new
             </span>
           ) : null}

--- a/nx-dev/ui-common/src/lib/headers/documentation-header.tsx
+++ b/nx-dev/ui-common/src/lib/headers/documentation-header.tsx
@@ -45,7 +45,7 @@ function Menu({ tabs }: { tabs: any[] }): ReactElement {
               tab.current
                 ? 'border-blue-500 text-blue-600 dark:border-blue-500 dark:text-blue-500'
                 : 'border-transparent hover:text-zinc-900 dark:hover:text-blue-400',
-              'whitespace-nowrap border-b-2 py-2 text-sm font-medium'
+              'border-b-2 py-2 text-sm font-medium whitespace-nowrap'
             )}
             aria-current={tab.current ? 'page' : undefined}
             prefetch={false}
@@ -224,7 +224,7 @@ export function DocumentationHeader({
         <div className="flex w-full items-center lg:hidden">
           <button
             type="button"
-            className="flex px-4 py-4 focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500"
+            className="flex px-4 py-4 focus:ring-2 focus:ring-indigo-500 focus:outline-none focus:ring-inset"
             onClick={() => toggleNav(!isNavOpen)}
           >
             <span className="sr-only">Open sidebar</span>
@@ -265,7 +265,7 @@ export function DocumentationHeader({
               )
             }
           >
-            <span className="text-xl font-bold uppercase tracking-wide">
+            <span className="text-xl font-bold tracking-wide uppercase">
               Docs
             </span>
           </Link>
@@ -282,7 +282,7 @@ export function DocumentationHeader({
             <Link
               href="/blog"
               title="Blog"
-              className="hidden px-3 py-2 font-medium leading-tight hover:text-blue-500 md:inline-flex dark:text-zinc-200 dark:hover:text-blue-500"
+              className="hidden px-3 py-2 leading-tight font-medium hover:text-blue-500 md:inline-flex dark:text-zinc-200 dark:hover:text-blue-500"
               prefetch={false}
             >
               Blog
@@ -294,7 +294,7 @@ export function DocumentationHeader({
                   <PopoverButton
                     className={cx(
                       open ? 'text-blue-500 dark:text-blue-500' : '',
-                      'group inline-flex items-center px-3 py-2 font-medium leading-tight outline-0 dark:text-zinc-200'
+                      'group inline-flex items-center px-3 py-2 leading-tight font-medium outline-0 dark:text-zinc-200'
                     )}
                   >
                     <span className="transition duration-150 ease-in-out group-hover:text-blue-500 dark:group-hover:text-blue-500">
@@ -331,7 +331,7 @@ export function DocumentationHeader({
             <Link
               href="/ai"
               title="AI"
-              className="hidden gap-2 px-3 py-2 font-medium leading-tight hover:text-blue-500 md:inline-flex dark:text-zinc-200 dark:hover:text-blue-500"
+              className="hidden gap-2 px-3 py-2 leading-tight font-medium hover:text-blue-500 md:inline-flex dark:text-zinc-200 dark:hover:text-blue-500"
               prefetch={false}
             >
               AI
@@ -339,7 +339,7 @@ export function DocumentationHeader({
             <Link
               href="/nx-cloud"
               title="Nx Cloud"
-              className="hidden gap-2 px-3 py-2 font-medium leading-tight hover:text-blue-500 md:inline-flex dark:text-zinc-200 dark:hover:text-blue-500"
+              className="hidden gap-2 px-3 py-2 leading-tight font-medium hover:text-blue-500 md:inline-flex dark:text-zinc-200 dark:hover:text-blue-500"
               prefetch={false}
             >
               Nx Cloud
@@ -348,7 +348,7 @@ export function DocumentationHeader({
             <Link
               href="/enterprise"
               title="Enterprise"
-              className="hidden gap-2 px-3 py-2 font-medium leading-tight hover:text-blue-500 md:inline-flex dark:text-zinc-200 dark:hover:text-blue-500"
+              className="hidden gap-2 px-3 py-2 leading-tight font-medium hover:text-blue-500 md:inline-flex dark:text-zinc-200 dark:hover:text-blue-500"
               prefetch={false}
             >
               Enterprise

--- a/nx-dev/ui-common/src/lib/headers/mobile-menu-item.tsx
+++ b/nx-dev/ui-common/src/lib/headers/mobile-menu-item.tsx
@@ -38,7 +38,7 @@ export function MobileMenuItem({
         >
           {item.name}
           {item.isNew ? (
-            <span className="float-right inline-flex items-center rounded-md bg-blue-50 px-2 py-1 text-xs font-medium text-blue-700 ring-1 ring-inset ring-blue-700/10 dark:bg-blue-400/10 dark:text-blue-400 dark:ring-blue-400/30">
+            <span className="float-right inline-flex items-center rounded-md bg-blue-50 px-2 py-1 text-xs font-medium text-blue-700 ring-1 ring-blue-700/10 ring-inset dark:bg-blue-400/10 dark:text-blue-400 dark:ring-blue-400/30">
               new
             </span>
           ) : null}

--- a/nx-dev/ui-common/src/lib/live-stream-notifier.tsx
+++ b/nx-dev/ui-common/src/lib/live-stream-notifier.tsx
@@ -42,13 +42,13 @@ export function LiveStreamNotifier(): ReactElement | null {
         damping: 30,
         mass: 1,
       }}
-      className="fixed bottom-0 left-0 right-0 z-30 w-full overflow-hidden bg-zinc-950 text-white shadow-lg md:bottom-4 md:left-auto md:right-4 md:w-[512px] md:rounded-lg"
+      className="fixed right-0 bottom-0 left-0 z-30 w-full overflow-hidden bg-zinc-950 text-white shadow-lg md:right-4 md:bottom-4 md:left-auto md:w-[512px] md:rounded-lg"
       style={{ originY: 1 }}
     >
       <div className="relative p-4">
         <button
           onClick={closeNotifier}
-          className="absolute right-2 top-2 rounded-full p-1 hover:bg-zinc-800 focus:outline-none focus:ring-2 focus:ring-white"
+          className="absolute top-2 right-2 rounded-full p-1 hover:bg-zinc-800 focus:ring-2 focus:ring-white focus:outline-none"
         >
           <XMarkIcon className="size-5" aria-hidden="true" />
           <span className="sr-only">Close</span>

--- a/nx-dev/ui-common/src/lib/sidebar.tsx
+++ b/nx-dev/ui-common/src/lib/sidebar.tsx
@@ -63,7 +63,7 @@ function SidebarSection({ section }: { section: MenuSection }): JSX.Element {
       {section.hideSectionHeader ? null : (
         <h4
           data-testid={`section-h4:${section.id}`}
-          className="mb-3 mt-8 border-b border-solid border-zinc-200 pb-2 text-xl font-bold dark:border-zinc-700 dark:text-zinc-100"
+          className="mt-8 mb-3 border-b border-solid border-zinc-200 pb-2 text-xl font-bold dark:border-zinc-700 dark:text-zinc-100"
         >
           {section.name}
         </h4>
@@ -362,7 +362,7 @@ export function SidebarMobile({
                 {/*CLOSE BUTTON*/}
                 <button
                   type="button"
-                  className="flex focus:outline-none focus:ring-2 focus:ring-inset focus:ring-indigo-500"
+                  className="flex focus:ring-2 focus:ring-indigo-500 focus:outline-none focus:ring-inset"
                   onClick={() => toggleNav(!navIsOpen)}
                 >
                   <span className="sr-only">Close sidebar</span>
@@ -394,7 +394,7 @@ export function SidebarMobile({
                           section.current
                             ? 'text-blue-600 dark:text-blue-500'
                             : 'hover:text-zinc-900 dark:hover:text-blue-400',
-                          'whitespace-nowrap p-4 text-center text-sm font-medium'
+                          'p-4 text-center text-sm font-medium whitespace-nowrap'
                         )}
                         aria-current={section.current ? 'page' : undefined}
                         prefetch={false}
@@ -412,7 +412,7 @@ export function SidebarMobile({
                           section.current
                             ? 'text-blue-600 dark:text-blue-500'
                             : 'hover:text-zinc-900 dark:hover:text-blue-400',
-                          'whitespace-nowrap p-4 text-center text-sm font-medium'
+                          'p-4 text-center text-sm font-medium whitespace-nowrap'
                         )}
                         aria-current={section.current ? 'page' : undefined}
                         prefetch={false}

--- a/nx-dev/ui-common/src/lib/square-dotted-pattern.tsx
+++ b/nx-dev/ui-common/src/lib/square-dotted-pattern.tsx
@@ -3,7 +3,7 @@ import { FC, SVGProps } from 'react';
 export const SquareDottedPattern: FC<SVGProps<SVGSVGElement>> = (props) => (
   <>
     <svg
-      className="absolute left-full top-12 translate-x-32 transform"
+      className="absolute top-12 left-full translate-x-32 transform"
       width={404}
       height={384}
       fill="none"
@@ -36,7 +36,7 @@ export const SquareDottedPattern: FC<SVGProps<SVGSVGElement>> = (props) => (
       />
     </svg>
     <svg
-      className="absolute right-full top-1/2 -translate-x-32 -translate-y-1/2 transform"
+      className="absolute top-1/2 right-full -translate-x-32 -translate-y-1/2 transform"
       width={404}
       height={384}
       fill="none"

--- a/nx-dev/ui-common/src/lib/testimonials.tsx
+++ b/nx-dev/ui-common/src/lib/testimonials.tsx
@@ -16,7 +16,7 @@ export function Testimonials(): JSX.Element {
           , Nx will keep your CI fast and your workspace maintainable.
         </SectionHeading>
       </header>
-      <div className="md:px-62 mx-auto grid max-w-7xl grid-cols-1 items-stretch gap-8 px-4 py-12 md:grid-cols-3 lg:px-8 lg:py-16">
+      <div className="mx-auto grid max-w-7xl grid-cols-1 items-stretch gap-8 px-4 py-12 md:grid-cols-3 md:px-62 lg:px-8 lg:py-16">
         <div className="rounded-xl bg-zinc-50 p-10 dark:bg-zinc-800/60">
           <ChatBubbleLeftEllipsisIcon className="h-8 w-8 text-blue-500 dark:text-blue-500" />
           <p className="mt-4">

--- a/nx-dev/ui-common/src/lib/trusted-by.tsx
+++ b/nx-dev/ui-common/src/lib/trusted-by.tsx
@@ -118,7 +118,7 @@ export function TrustedBy({
             href={`/customers?utm_source=${utmSource}&utm_medium=website&utm_campaign=${utmCampaign}&utm_content=our_customers`}
             title="Our customers"
             prefetch={false}
-            className="group font-semibold leading-6 text-zinc-950 transition-all duration-200 dark:text-white"
+            className="group leading-6 font-semibold text-zinc-950 transition-all duration-200 dark:text-white"
           >
             Learn about our customers{' '}
             <span

--- a/nx-dev/ui-common/src/lib/video-player/video-player.tsx
+++ b/nx-dev/ui-common/src/lib/video-player/video-player.tsx
@@ -430,14 +430,14 @@ export function VideoPlayerButton({
           aria-hidden="true"
           className={cx(
             'absolute',
-            isSmall ? 'left-3 top-3 size-4' : 'left-6 top-6 size-8'
+            isSmall ? 'top-3 left-3 size-4' : 'top-6 left-6 size-8'
           )}
         />
         <motion.div
           variants={child}
           className={cx(
             'absolute',
-            isSmall ? 'left-10 top-3 w-48' : 'left-20 top-4 w-48'
+            isSmall ? 'top-3 left-10 w-48' : 'top-4 left-20 w-48'
           )}
         >
           <p className={cx('font-medium', isSmall ? 'text-xs' : 'text-base')}>
@@ -703,14 +703,14 @@ export function VideoPlayerInlineButton({
           aria-hidden="true"
           className={cx(
             'absolute',
-            isSmall ? 'left-3 top-3 size-4' : 'left-6 top-6 size-8'
+            isSmall ? 'top-3 left-3 size-4' : 'top-6 left-6 size-8'
           )}
         />
         <motion.div
           variants={child}
           className={cx(
             'absolute',
-            isSmall ? 'left-10 top-2 w-24' : 'left-20 top-4 w-48'
+            isSmall ? 'top-2 left-10 w-24' : 'top-4 left-20 w-48'
           )}
         >
           <p className={cx('font-medium', isSmall ? 'text-sm' : 'text-base')}>

--- a/nx-dev/ui-common/src/lib/youtube.component.tsx
+++ b/nx-dev/ui-common/src/lib/youtube.component.tsx
@@ -90,7 +90,7 @@ const youtubeIcon = (
     role="img"
     viewBox="0 0 24 24"
     xmlns="http://www.w3.org/2000/svg"
-    className="absolute left-1/2 top-1/2 h-12 w-12 -translate-x-1/2 -translate-y-1/2 transform"
+    className="absolute top-1/2 left-1/2 h-12 w-12 -translate-x-1/2 -translate-y-1/2 transform"
   >
     <path d="M23.5 6.19a3.02 3.02 0 0 0-2.12-2.14c-1.88-.5-9.38-.5-9.38-.5s-7.5 0-9.38.5A3.02 3.02 0 0 0 .5 6.19C0 8.07 0 12 0 12s0 3.93.5 5.81a3.02 3.02 0 0 0 2.12 2.14c1.87.5 9.38.5 9.38.5s7.5 0 9.38-.5a3.02 3.02 0 0 0 2.12-2.14C24 15.93 24 12 24 12s0-3.93-.5-5.81zM9.54 15.57V8.43L15.82 12l-6.28 3.57z" />
   </svg>

--- a/nx-dev/ui-courses/src/lib/lessons-list.tsx
+++ b/nx-dev/ui-courses/src/lib/lessons-list.tsx
@@ -53,7 +53,7 @@ export function LessonsList({
                 <span className="inline-block min-w-[2rem] flex-shrink-0 text-sm font-medium text-zinc-400 dark:text-zinc-600">
                   {(index + 1).toString().padStart(1, '0')}
                 </span>
-                <span className="text-[15px] font-medium leading-normal">
+                <span className="text-[15px] leading-normal font-medium">
                   {courseLesson.title}
                 </span>
               </Link>

--- a/nx-dev/ui-fence/src/lib/fence.tsx
+++ b/nx-dev/ui-fence/src/lib/fence.tsx
@@ -183,11 +183,11 @@ export function Fence({
     <div
       className={cx(
         'code-block group relative mb-4',
-        isWithinTab ? '-ml-4 -mr-4 w-[calc(100%+2rem)]' : 'w-auto'
+        isWithinTab ? '-mr-4 -ml-4 w-[calc(100%+2rem)]' : 'w-auto'
       )}
     >
       <div>
-        <div className="absolute right-0 top-0 z-10 flex">
+        <div className="absolute top-0 right-0 z-10 flex">
           {enableCopy && enableCopy === true && (
             <CopyToClipboard
               text={command && command !== '' ? command : children}

--- a/nx-dev/ui-fence/src/lib/fences/code-output.tsx
+++ b/nx-dev/ui-fence/src/lib/fences/code-output.tsx
@@ -14,11 +14,11 @@ export function CodeOutput({
     <div
       className={cx(
         'hljs not-prose w-full overflow-x-auto border-zinc-200 bg-zinc-50/50 font-mono text-sm dark:border-zinc-700 dark:bg-zinc-800/60',
-        isWithinTab ? 'border-b border-t' : 'rounded-lg border'
+        isWithinTab ? 'border-t border-b' : 'rounded-lg border'
       )}
     >
       {!!fileName && (
-        <div className="flex border-b border-zinc-200 bg-zinc-50 px-4 py-2 italic text-zinc-400 dark:border-zinc-700 dark:bg-zinc-800/80 dark:text-zinc-500">
+        <div className="flex border-b border-zinc-200 bg-zinc-50 px-4 py-2 text-zinc-400 italic dark:border-zinc-700 dark:bg-zinc-800/80 dark:text-zinc-500">
           {fileName}
         </div>
       )}

--- a/nx-dev/ui-fence/src/lib/fences/terminal-shell.tsx
+++ b/nx-dev/ui-fence/src/lib/fences/terminal-shell.tsx
@@ -10,7 +10,7 @@ export function TerminalShellWrapper({
   return (
     <div className="hljs not-prose w-full overflow-x-auto rounded-lg border border-zinc-200 bg-zinc-50/50 font-mono text-sm dark:border-zinc-700 dark:bg-zinc-800/60">
       <div className="relative flex justify-center border-b border-zinc-200 bg-zinc-100/50 p-2 text-zinc-400 dark:border-zinc-700 dark:bg-zinc-700/50 dark:text-zinc-500">
-        <div className="absolute left-2 top-3 flex items-center gap-2">
+        <div className="absolute top-3 left-2 flex items-center gap-2">
           <span className="h-2 w-2 rounded-full bg-red-400 dark:bg-red-600" />
           <span className="h-2 w-2 rounded-full bg-yellow-400 dark:bg-yellow-600" />
           <span className="h-2 w-2 rounded-full bg-green-400 dark:bg-green-600" />

--- a/nx-dev/ui-markdoc/src/lib/tags/callout.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/callout.component.tsx
@@ -140,7 +140,7 @@ export function Callout({
         onClick={toggleOpen}
         className={cx(
           'flex w-full items-center justify-between p-4',
-          'transition-colors duration-200 hover:bg-opacity-80',
+          'hover:bg-opacity-80 transition-colors duration-200',
           { 'cursor-pointer': isCollapsible }
         )}
       >
@@ -158,7 +158,7 @@ export function Callout({
           ))}
       </div>
       {isOpen && (
-        <div className="px-4 pb-4 pt-0">
+        <div className="px-4 pt-0 pb-4">
           <span className={cx('prose-sm block', ui.textColor)}>{children}</span>
         </div>
       )}

--- a/nx-dev/ui-markdoc/src/lib/tags/steps.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/steps.component.tsx
@@ -15,7 +15,7 @@ export function Steps({ children }: StepsProps) {
           {/* Vertical line connecting steps */}
           {index < stepsCount - 1 && (
             <div
-              className="absolute left-5 top-10 h-full w-0.5 bg-zinc-200 dark:bg-zinc-700"
+              className="absolute top-10 left-5 h-full w-0.5 bg-zinc-200 dark:bg-zinc-700"
               aria-hidden="true"
             />
           )}

--- a/nx-dev/ui-markdoc/src/lib/tags/tabs.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/tabs.component.tsx
@@ -64,7 +64,7 @@ export function Tabs({ labels, children }: TabsProps) {
             aria-selected={label === currentTab}
             onClick={() => handleTabClick(label)}
             className={cx(
-              'whitespace-nowrap border-b-2 p-2 text-sm font-medium',
+              'border-b-2 p-2 text-sm font-medium whitespace-nowrap',
               label === currentTab
                 ? 'border-blue-500 text-zinc-800 dark:border-blue-500 dark:text-zinc-300'
                 : 'border-transparent text-zinc-500 hover:border-blue-500 hover:text-zinc-800 dark:text-zinc-400 dark:hover:border-blue-500 dark:hover:text-zinc-300'
@@ -76,10 +76,10 @@ export function Tabs({ labels, children }: TabsProps) {
       </nav>
       <div
         className={cx(
-          'border border-zinc-200 pb-2 pl-4 pr-4 pt-2 dark:border-zinc-700',
+          'border border-zinc-200 pt-2 pr-4 pb-2 pl-4 dark:border-zinc-700',
           currentTab === labels[0]
-            ? 'rounded-b-md rounded-tr-md'
-            : 'rounded-b-md rounded-t-md'
+            ? 'rounded-tr-md rounded-b-md'
+            : 'rounded-t-md rounded-b-md'
         )}
       >
         {children}

--- a/nx-dev/ui-markdoc/src/lib/tags/testimonial.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/testimonial.component.tsx
@@ -50,7 +50,7 @@ export function Testimonial({
         </svg>
 
         <div className="relative z-10">
-          <div className="text-xl font-medium italic text-zinc-800 md:text-2xl md:leading-normal xl:text-3xl xl:leading-normal dark:text-neutral-200">
+          <div className="text-xl font-medium text-zinc-800 italic md:text-2xl md:leading-normal xl:text-3xl xl:leading-normal dark:text-neutral-200">
             {children}
           </div>
         </div>

--- a/nx-dev/ui-markdoc/src/lib/tags/video-link.component.tsx
+++ b/nx-dev/ui-markdoc/src/lib/tags/video-link.component.tsx
@@ -37,7 +37,7 @@ export function VideoLink({ text, link }: VideoLinkProps) {
         rel="noopener noreferrer"
         className="flex items-center space-x-2 border-transparent !text-inherit !no-underline dark:text-white"
       >
-        <div className="flex items-center justify-between space-x-2 rounded-md border border-zinc-200 py-1 pl-2 pl-3 pr-2 transition hover:border-zinc-500 dark:border-zinc-700/40 dark:hover:border-zinc-700">
+        <div className="flex items-center justify-between space-x-2 rounded-md border border-zinc-200 py-1 pr-2 pl-2 pl-3 transition hover:border-zinc-500 dark:border-zinc-700/40 dark:hover:border-zinc-700">
           {youtubeIcon}
           <span className="text-md font-semibold hover:text-zinc-900 dark:hover:text-blue-400">
             {text || 'Jump to section in video'}

--- a/nx-dev/ui-theme/src/lib/theme-switcher.component.tsx
+++ b/nx-dev/ui-theme/src/lib/theme-switcher.component.tsx
@@ -75,7 +75,7 @@ export function ThemeSwitcher(): JSX.Element {
             leaveFrom="transform opacity-100 scale-100"
             leaveTo="transform opacity-0 scale-95"
           >
-            <ListboxOptions className="absolute -right-10 top-full z-50 mt-2 w-36 origin-top-right divide-y divide-zinc-100 rounded-md bg-white shadow-lg ring-1 ring-black/5 focus:outline-none dark:divide-zinc-800 dark:bg-zinc-900 dark:ring-white/5">
+            <ListboxOptions className="absolute top-full -right-10 z-50 mt-2 w-36 origin-top-right divide-y divide-zinc-100 rounded-md bg-white shadow-lg ring-1 ring-black/5 focus:outline-none dark:divide-zinc-800 dark:bg-zinc-900 dark:ring-white/5">
               {availableThemes.map((t) => (
                 <ListboxOption key={t.value} value={t.value} as={Fragment}>
                   {({ focus, selected }) => (


### PR DESCRIPTION
## Current Behavior

50 `.tsx` files across `nx-dev`, `graph` and `astro-docs` have drifted from `prettier-plugin-tailwindcss` output. They pass CI today only because `nx format:check` gates *changed* files — so the drift is invisible until an unrelated change touches one of them, at which point that PR is forced to carry an unrelated reformat.

That is exactly what happened in #36624: a two-line import fix in `nx-dev/ui-blog/src/lib/blog-details.tsx` had to ship with three unrelated `className` reorderings to keep `format:check` green.

## Expected Behavior

The drift is cleared, so touching any of these files no longer conscripts the author into reformatting it.

The cause is **Tailwind v4 sort order** — v4 reordered the inset and layout groups, so the plugin now sorts differently than when these files were last written:

```diff
-<header className="mx-auto mb-16 mt-8 px-4">
+<header className="mx-auto mt-8 mb-16 px-4">

-'pointer-events-none absolute left-0 top-0 transform-gpu stroke-2'
+'pointer-events-none absolute top-0 left-0 transform-gpu stroke-2'

-'whitespace-nowrap border-b-2 py-2 text-sm font-medium'
+'border-b-2 py-2 text-sm font-medium whitespace-nowrap'
```

## Why this is safe to merge on sight

**Formatting only — 97 insertions, 97 deletions.** Every changed line is a rewrite of an existing line; none is added or removed.

**Every changed line was verified to be a pure permutation.** For all 97 changed line pairs, the multiset of whitespace-separated class tokens is identical before and after — no class added, dropped, or altered. Reordering utility classes cannot change rendered output: Tailwind emits each utility once, and precedence comes from the generated stylesheet's order, not from the order in `className`.

## Scope notes

- **`nx-dev/ui-blog/src/lib/blog-details.tsx` is deliberately excluded** — #36624 already reformats it. The two PRs are disjoint by file, so merge order does not matter.
- **`packages/gradle/batch-runner/build/nx/gradle-batch-runner.json` is excluded** — `nx format:check --all` flags it, but it is an untracked, gitignored build artifact. Worth knowing that `--all` does not respect `.gitignore`.

## Verification

| Check | Scope | Result |
| --- | --- | --- |
| Pure-permutation check | 97 changed line pairs | all identical token multisets |
| Insertions / deletions | 50 files | 97 / 97 |
| `nx format:check --all` | whole repo | clean* |
| `lint` | 16 owning projects, 149 tasks | 0 errors |

\* apart from `blog-details.tsx` (owned by #36624) and the untracked gradle artifact.

## Related Issue(s)

No filed issue. Follow-up to #36624, which surfaced the drift.

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/fix-double-exports-c05225fb">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->