### PR TITLE
fix(angular-rspack): rebuild components when their templates or styles change on Windows

### DIFF
--- a/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.ts
@@ -1,4 +1,5 @@
 import type { LoaderContext } from '@rspack/core';
+import { normalize } from 'node:path';
 import { NG_RSPACK_SYMBOL_NAME, NgRspackCompilation } from '../../models';
 import {
   StyleUrlsResolver,
@@ -51,9 +52,11 @@ export default function loader(
     if (resourceDeps !== undefined) {
       // The compiler tracked this file's template and stylesheet
       // dependencies; registering them keeps the module rebuilding when a
-      // resource changes, at no parsing cost.
+      // resource changes, at no parsing cost. The compiler reports them with
+      // POSIX separators, which the file watcher does not match on Windows,
+      // so normalize them to native separators.
       for (const dependency of resourceDeps) {
-        this.addDependency(dependency);
+        this.addDependency(normalize(dependency));
       }
     } else {
       const templateUrls = templateUrlsResolver.resolve(

--- a/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.windows.spec.ts
+++ b/packages/angular-rspack/src/lib/plugins/loaders/angular-transform.loader.windows.spec.ts
@@ -1,0 +1,76 @@
+import type { LoaderContext } from '@rspack/core';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { NG_RSPACK_SYMBOL_NAME, type NgRspackCompilation } from '../../models';
+import { default as angularTransformLoader } from './angular-transform.loader';
+import { toTypeScriptFileCacheKey } from '@nx/angular-rspack-compiler';
+
+// Simulate Windows path semantics regardless of the host platform: the
+// loader and the cache-key helper resolve `node:path` to the win32
+// implementation.
+vi.mock('node:path', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('node:path')>();
+  return {
+    ...actual.win32,
+    win32: actual.win32,
+    posix: actual.posix,
+    default: { ...actual.win32, win32: actual.win32, posix: actual.posix },
+  };
+});
+
+describe('angular-transform.loader (windows)', () => {
+  const callback = vi.fn();
+  const addDependency = vi.fn();
+  const typescriptFileCache = new Map<string, string>();
+  const javascriptTransformer = {
+    transformData: vi.fn(),
+  };
+  const thisValue = {
+    async: vi.fn(() => callback),
+  } as unknown as LoaderContext<unknown>;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    typescriptFileCache.clear();
+  });
+
+  it('should register compiler-tracked resource dependencies with native separators', () => {
+    // The compiler reports resource dependency paths with POSIX separators
+    // on Windows; the map is keyed like the emit cache.
+    const resourceDependencies = new Map([
+      [
+        toTypeScriptFileCacheKey('C:/proj/src/app/app.component.ts'),
+        [
+          'C:/proj/src/app/app.component.html',
+          'C:/proj/src/app/app.component.css',
+        ],
+      ],
+    ]);
+
+    angularTransformLoader.call(
+      {
+        ...thisValue,
+        _compilation: {
+          [NG_RSPACK_SYMBOL_NAME]: () => ({
+            typescriptFileCache,
+            javascriptTransformer,
+            useTypeScriptTranspilation: true,
+            resourceDependencies,
+          }),
+        } as unknown as NgRspackCompilation,
+        resourcePath: 'C:\\proj\\src\\app\\app.component.ts',
+        addDependency,
+      },
+      '@Component()'
+    );
+
+    expect(addDependency).toHaveBeenCalledTimes(2);
+    expect(addDependency).toHaveBeenNthCalledWith(
+      1,
+      'C:\\proj\\src\\app\\app.component.html'
+    );
+    expect(addDependency).toHaveBeenNthCalledWith(
+      2,
+      'C:\\proj\\src\\app\\app.component.css'
+    );
+  });
+});


### PR DESCRIPTION
## Current Behavior

On Windows, editing a component's external template or stylesheet while a watch build is running (`nx serve`) does not reach the served output. Depending on the project, either no rebuild is triggered at all, or a rebuild completes and emits unchanged content for the affected component. A browser refresh does not help; editing the component's TypeScript file flushes the pending change through. Regression introduced in 23.1.1.

## Expected Behavior

A change to an external template or stylesheet invalidates the owning component module and is reflected in the rebuilt output, as in 23.1.0 and in `@angular/build`'s application builder.

## Related Issue(s)

Fixes #36619

## Implementation Details

The loader fast path introduced in #36268 registers the compiler-tracked resource dependencies verbatim. The Angular compiler reports them with POSIX separators, and rspack's default watch backend matches watched files by verbatim-separator paths while emitting change events with native separators, so on Windows a registered resource dependency never matches its change events and edits to it go unnoticed. The fix normalizes the dependencies to native separators before registering them, as the URL-resolver fallback (the 23.1.0 behavior) already does.

The new spec simulates Windows path semantics by resolving `node:path` to the win32 implementation, so it fails on the pre-fix code on any platform. Verified against the rspack v2.0.8 watcher sources; rspack's rust-side module invalidation is separator-insensitive, so the watch layer is the only place the path form matters.

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/gh-36619-8a326eac">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->