### PR TITLE
fix(core): exclude volatile shell and editor env vars from the daemon

### DIFF
--- a/packages/nx/src/daemon/client/client.ts
+++ b/packages/nx/src/daemon/client/client.ts
@@ -128,7 +128,7 @@ import {
   VersionMismatchError,
 } from './daemon-socket-messenger';
 
-import { getDaemonEnv } from './daemon-environment';
+import { getDaemonEnv, getDaemonSpawnEnv } from './daemon-environment';
 
 /** A refused connect: the errno, and the path it was made against. */
 type ConnectRefusal = {
@@ -1398,7 +1398,7 @@ export class DaemonClient {
         detached: true,
         windowsHide: true,
         shell: false,
-        env: getDaemonEnv(),
+        env: getDaemonSpawnEnv(),
       }
     );
     // The child now owns dup'd copies of the descriptors, so release ours.

--- a/packages/nx/src/daemon/client/daemon-environment.spec.ts
+++ b/packages/nx/src/daemon/client/daemon-environment.spec.ts
@@ -154,6 +154,16 @@ describe('daemon environment', () => {
       expect(env.MISE_SHELL).toBeUndefined();
     });
 
+    it('should exclude editor preference vars', () => {
+      process.env.EDITOR = 'vim';
+      process.env.VISUAL = 'code --wait';
+
+      const env = getDaemonEnv();
+
+      expect(env.EDITOR).toBeUndefined();
+      expect(env.VISUAL).toBeUndefined();
+    });
+
     it('should exclude AI agent vars', () => {
       process.env.AI_AGENT = 'claude-code_2-1-228_agent';
       process.env.CODEX_THREAD_ID = 'per-session-id';

--- a/packages/nx/src/daemon/client/daemon-environment.spec.ts
+++ b/packages/nx/src/daemon/client/daemon-environment.spec.ts
@@ -1,0 +1,334 @@
+import {
+  applyDaemonEnvFromClient,
+  getDaemonEnv,
+  getDaemonSpawnEnv,
+} from './daemon-environment';
+
+describe('daemon environment', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  describe('getDaemonEnv', () => {
+    it('should exclude volatile shell-integration vars', () => {
+      process.env.ATUIN_HISTORY_ID = '0192d4d5-uuid-per-command';
+      process.env.ATUIN_SESSION = '0192d4d5-uuid-per-shell';
+      process.env.STARSHIP_SESSION_KEY = '1234567890123456';
+      process.env.STARSHIP_START_TIME = '1754990000000';
+      process.env.MCFLY_SESSION_ID = 'random-per-shell';
+      process.env.DIRENV_DIFF = 'per-directory-state';
+      process.env.__MISE_SESSION = 'per-shell-session';
+      process.env.__MISE_DIFF = 'per-hook-env-run';
+      process.env.FNM_MULTISHELL_PATH = '/tmp/fnm_multishells/1234_5678';
+      process.env.POSH_SESSION_ID = 'per-shell-session';
+
+      const env = getDaemonEnv();
+
+      expect(env.ATUIN_HISTORY_ID).toBeUndefined();
+      expect(env.ATUIN_SESSION).toBeUndefined();
+      expect(env.STARSHIP_SESSION_KEY).toBeUndefined();
+      expect(env.STARSHIP_START_TIME).toBeUndefined();
+      expect(env.MCFLY_SESSION_ID).toBeUndefined();
+      expect(env.DIRENV_DIFF).toBeUndefined();
+      expect(env.__MISE_SESSION).toBeUndefined();
+      expect(env.__MISE_DIFF).toBeUndefined();
+      expect(env.FNM_MULTISHELL_PATH).toBeUndefined();
+      expect(env.POSH_SESSION_ID).toBeUndefined();
+    });
+
+    it('should exclude per-directory and per-invocation vars', () => {
+      process.env.PWD = '/some/project/subdir';
+      process.env.INIT_CWD = '/some/project/subdir';
+      process.env.COLOR = '1';
+
+      const env = getDaemonEnv();
+
+      expect(env.PWD).toBeUndefined();
+      expect(env.INIT_CWD).toBeUndefined();
+      expect(env.COLOR).toBeUndefined();
+    });
+
+    it('should exclude terminal identification vars', () => {
+      process.env.TERM = 'xterm-ghostty';
+      process.env.TERM_PROGRAM = 'vscode';
+      process.env.TERM_PROGRAM_VERSION = '1.103.0';
+      process.env.COLORTERM = 'truecolor';
+      process.env.COLORFGBG = '15;0';
+      process.env.VTE_VERSION = '7802';
+      process.env.GNOME_TERMINAL_SCREEN = '/org/gnome/Terminal/screen/uuid';
+      process.env.GNOME_TERMINAL_SERVICE = ':1.123';
+      process.env.WT_SESSION = 'guid-per-tab';
+      process.env.WT_PROFILE_ID = 'profile-guid';
+      process.env.GHOSTTY_RESOURCES_DIR = '/Applications/Ghostty.app/resources';
+      process.env.TERMINAL_EMULATOR = 'JetBrains-JediTerm';
+      process.env.TERMINUS_SUBLIME = '1';
+      process.env.ConEmuTask = '{cmd::Cmder}';
+      process.env.ZELLIJ_PANE_ID = '3';
+      process.env.LC_TERMINAL = 'iTerm2';
+      process.env.LC_TERMINAL_VERSION = '3.5.0';
+
+      const env = getDaemonEnv();
+
+      expect(env.TERM).toBeUndefined();
+      expect(env.TERM_PROGRAM).toBeUndefined();
+      expect(env.TERM_PROGRAM_VERSION).toBeUndefined();
+      expect(env.COLORTERM).toBeUndefined();
+      expect(env.COLORFGBG).toBeUndefined();
+      expect(env.VTE_VERSION).toBeUndefined();
+      expect(env.GNOME_TERMINAL_SCREEN).toBeUndefined();
+      expect(env.GNOME_TERMINAL_SERVICE).toBeUndefined();
+      expect(env.WT_SESSION).toBeUndefined();
+      expect(env.WT_PROFILE_ID).toBeUndefined();
+      expect(env.GHOSTTY_RESOURCES_DIR).toBeUndefined();
+      expect(env.TERMINAL_EMULATOR).toBeUndefined();
+      expect(env.TERMINUS_SUBLIME).toBeUndefined();
+      expect(env.ConEmuTask).toBeUndefined();
+      expect(env.ZELLIJ_PANE_ID).toBeUndefined();
+      expect(env.LC_TERMINAL).toBeUndefined();
+      expect(env.LC_TERMINAL_VERSION).toBeUndefined();
+    });
+
+    it('should exclude vars injected by VS Code and its extensions', () => {
+      process.env.ELECTRON_RUN_AS_NODE = '1';
+      process.env.ELECTRON_NO_ASAR = '1';
+      process.env.CHROME_CRASHPAD_PIPE_NAME = '\\\\.\\pipe\\crashpad_21788_x';
+      process.env.COPILOT_OTEL_FILE_EXPORTER_PATH = '/tmp/copilot-otel';
+      process.env.COPILOT_DEBUG_NONCE = 'per-session-nonce';
+      process.env.MXC_BIN_DIR = '/path/to/extension/bin';
+      process.env.APPLICATION_INSIGHTS_NO_STATSBEAT = 'true';
+      process.env.GIT_ASKPASS = '/vscode/extensions/git/askpass.sh';
+      process.env.GIT_EDITOR = 'code --wait';
+      process.env.GIT_PAGER = 'cat';
+      process.env.GIT_MERGE_AUTOEDIT = 'no';
+
+      const env = getDaemonEnv();
+
+      expect(env.ELECTRON_RUN_AS_NODE).toBeUndefined();
+      expect(env.ELECTRON_NO_ASAR).toBeUndefined();
+      expect(env.CHROME_CRASHPAD_PIPE_NAME).toBeUndefined();
+      expect(env.COPILOT_OTEL_FILE_EXPORTER_PATH).toBeUndefined();
+      expect(env.COPILOT_DEBUG_NONCE).toBeUndefined();
+      expect(env.MXC_BIN_DIR).toBeUndefined();
+      expect(env.APPLICATION_INSIGHTS_NO_STATSBEAT).toBeUndefined();
+      expect(env.GIT_ASKPASS).toBeUndefined();
+      expect(env.GIT_EDITOR).toBeUndefined();
+      expect(env.GIT_PAGER).toBeUndefined();
+      expect(env.GIT_MERGE_AUTOEDIT).toBeUndefined();
+    });
+
+    it('should exclude pid-shaped EFC_ vars but keep other EFC_-prefixed vars', () => {
+      process.env.EFC_16880 = '1';
+      process.env.EFC_16880_4126798990 = '1';
+      process.env.EFC_PROJECT_MODE = 'strict';
+
+      const env = getDaemonEnv();
+
+      expect(env.EFC_16880).toBeUndefined();
+      expect(env.EFC_16880_4126798990).toBeUndefined();
+      expect(env.EFC_PROJECT_MODE).toBe('strict');
+    });
+
+    it('should exclude output-presentation vars', () => {
+      process.env.PAGER = 'less';
+      process.env.FORCE_COLOR = '0';
+      process.env.NO_COLOR = '1';
+      process.env.NODE_DISABLE_COLORS = '1';
+      process.env.FORCE_HYPERLINK = '1';
+      process.env.NX_ORIGINAL_FORCE_COLOR = '0';
+      process.env.MISE_SHELL = 'zsh';
+
+      const env = getDaemonEnv();
+
+      expect(env.PAGER).toBeUndefined();
+      expect(env.FORCE_COLOR).toBeUndefined();
+      expect(env.NO_COLOR).toBeUndefined();
+      expect(env.NODE_DISABLE_COLORS).toBeUndefined();
+      expect(env.FORCE_HYPERLINK).toBeUndefined();
+      expect(env.NX_ORIGINAL_FORCE_COLOR).toBeUndefined();
+      expect(env.MISE_SHELL).toBeUndefined();
+    });
+
+    it('should exclude AI agent vars', () => {
+      process.env.AI_AGENT = 'claude-code_2-1-228_agent';
+      process.env.CODEX_THREAD_ID = 'per-session-id';
+      process.env.CLAUDE_CODE_SESSION_ID = 'per-session-uuid';
+
+      const env = getDaemonEnv();
+
+      expect(env.AI_AGENT).toBeUndefined();
+      expect(env.CODEX_THREAD_ID).toBeUndefined();
+      expect(env.CLAUDE_CODE_SESSION_ID).toBeUndefined();
+    });
+
+    it('should exclude Nx CLI mechanics vars', () => {
+      process.env.NX_CLI_SET = 'true';
+      process.env.NX_WORKSPACE_ROOT_PATH = '/workspace/root';
+      process.env.PROMPT = '$P$G';
+
+      const env = getDaemonEnv();
+
+      expect(env.NX_CLI_SET).toBeUndefined();
+      expect(env.NX_WORKSPACE_ROOT_PATH).toBeUndefined();
+      expect(env.PROMPT).toBeUndefined();
+    });
+
+    it('should keep vars that can affect the project graph', () => {
+      process.env.PATH = '/usr/bin:/bin';
+      process.env.JAVA_HOME = '/opt/java';
+      process.env.GRADLE_HOME = '/opt/gradle';
+      // deliberately not covered by GIT_/CHROME_/FNM_ prefix exclusions
+      process.env.GIT_DIR = '/custom/.git';
+      process.env.CHROME_BIN = '/usr/bin/chromium';
+      process.env.FNM_DIR = '/home/user/.fnm';
+      process.env.NVM_BIN = '/home/user/.nvm/versions/node/v22.0.0/bin';
+      process.env.MISE_ENV = 'production';
+      // functional Copilot CLI config; deliberately no COPILOT_ prefix exclusion
+      process.env.COPILOT_HOME = '/home/user/.copilot';
+      process.env.COPILOT_GITHUB_TOKEN = 'token';
+
+      const env = getDaemonEnv();
+
+      expect(env.PATH).toBe('/usr/bin:/bin');
+      expect(env.JAVA_HOME).toBe('/opt/java');
+      expect(env.GRADLE_HOME).toBe('/opt/gradle');
+      expect(env.GIT_DIR).toBe('/custom/.git');
+      expect(env.CHROME_BIN).toBe('/usr/bin/chromium');
+      expect(env.FNM_DIR).toBe('/home/user/.fnm');
+      expect(env.NVM_BIN).toBe('/home/user/.nvm/versions/node/v22.0.0/bin');
+      expect(env.MISE_ENV).toBe('production');
+      expect(env.COPILOT_HOME).toBe('/home/user/.copilot');
+      expect(env.COPILOT_GITHUB_TOKEN).toBe('token');
+    });
+
+    it('should keep the Nx Cloud auth tokens despite the NX_CLOUD_ prefix exclusion', () => {
+      process.env.NX_CLOUD_ACCESS_TOKEN = 'token';
+      process.env.NX_CLOUD_AUTH_TOKEN = 'token';
+      process.env.NX_CLOUD_WORKER_ID = 'worker-1';
+
+      const env = getDaemonEnv();
+
+      expect(env.NX_CLOUD_ACCESS_TOKEN).toBe('token');
+      expect(env.NX_CLOUD_AUTH_TOKEN).toBe('token');
+      expect(env.NX_CLOUD_WORKER_ID).toBeUndefined();
+    });
+
+    it('should apply the required and overridable daemon settings', () => {
+      process.env.NX_PROJECT_GLOB_CACHE = 'true';
+      delete process.env.NX_VERBOSE_LOGGING;
+
+      const env = getDaemonEnv();
+
+      expect(env.NX_PROJECT_GLOB_CACHE).toBe('false');
+      expect(env.NX_CACHE_PROJECTS_CONFIG).toBe('false');
+      expect(env.NX_VERBOSE_LOGGING).toBe('true');
+    });
+  });
+
+  describe('getDaemonSpawnEnv', () => {
+    it('should keep ELECTRON_RUN_AS_NODE so an Electron execPath still runs the daemon entry point', () => {
+      process.env.ELECTRON_RUN_AS_NODE = '1';
+      process.env.ELECTRON_NO_ASAR = '1';
+
+      const env = getDaemonSpawnEnv();
+
+      expect(env.ELECTRON_RUN_AS_NODE).toBe('1');
+      // the rest of the reflected filter still applies
+      expect(env.ELECTRON_NO_ASAR).toBeUndefined();
+    });
+
+    it('should not add ELECTRON_RUN_AS_NODE when the client does not have it', () => {
+      delete process.env.ELECTRON_RUN_AS_NODE;
+
+      expect(getDaemonSpawnEnv().ELECTRON_RUN_AS_NODE).toBeUndefined();
+    });
+  });
+
+  describe('applyDaemonEnvFromClient', () => {
+    it('should report changed and deleted vars', () => {
+      process.env.FOO = 'old';
+      process.env.BAR = 'gone';
+
+      const changed = applyDaemonEnvFromClient({ FOO: 'new' });
+
+      expect(changed).toContain('FOO');
+      expect(changed).toContain('BAR');
+      expect(process.env.FOO).toBe('new');
+      expect(process.env.BAR).toBeUndefined();
+    });
+
+    it('should not delete or report excluded vars missing from the client env', () => {
+      process.env.ATUIN_SESSION = 'daemon-startup-value';
+      process.env.TERM_PROGRAM = 'ghostty';
+
+      const changed = applyDaemonEnvFromClient({});
+
+      expect(changed).not.toContain('ATUIN_SESSION');
+      expect(changed).not.toContain('TERM_PROGRAM');
+      expect(process.env.ATUIN_SESSION).toBe('daemon-startup-value');
+      expect(process.env.TERM_PROGRAM).toBe('ghostty');
+    });
+
+    it('should converge after one application of a client env payload', () => {
+      process.env.ATUIN_SESSION = 'daemon-startup-value';
+      process.env.JAVA_HOME = '/opt/java-client';
+      const payload = getDaemonEnv();
+      applyDaemonEnvFromClient(payload);
+
+      // simulate daemon-side drift from a previous client
+      process.env.JAVA_HOME = '/opt/java-daemon';
+      process.env.JAVA_TOOL_OPTIONS = '-Xmx1g';
+
+      const first = applyDaemonEnvFromClient(payload);
+
+      expect([...first].sort()).toEqual(['JAVA_HOME', 'JAVA_TOOL_OPTIONS']);
+      expect(process.env.JAVA_HOME).toBe('/opt/java-client');
+      expect(process.env.JAVA_TOOL_OPTIONS).toBeUndefined();
+      expect(process.env.ATUIN_SESSION).toBe('daemon-startup-value');
+      expect(applyDaemonEnvFromClient(payload)).toEqual([]);
+    });
+
+    it('should not delete required settings missing from the client env', () => {
+      process.env.NX_PROJECT_GLOB_CACHE = 'false';
+      process.env.NX_CACHE_PROJECTS_CONFIG = 'false';
+
+      const payload = { ...process.env, FOO: 'bar' };
+      delete payload.NX_PROJECT_GLOB_CACHE;
+      delete payload.NX_CACHE_PROJECTS_CONFIG;
+      const changed = applyDaemonEnvFromClient(payload);
+
+      expect(changed).toEqual(['FOO']);
+      expect(process.env.NX_PROJECT_GLOB_CACHE).toBe('false');
+      expect(process.env.NX_CACHE_PROJECTS_CONFIG).toBe('false');
+    });
+
+    it('should turn on the overridable logging settings on the daemon', () => {
+      process.env.NX_VERBOSE_LOGGING = 'false';
+
+      const changed = applyDaemonEnvFromClient(getDaemonEnv());
+
+      expect(changed).toContain('NX_VERBOSE_LOGGING');
+      expect(process.env.NX_VERBOSE_LOGGING).toBe('true');
+    });
+
+    it('should apply and delete the Nx Cloud auth tokens like any forwarded var', () => {
+      const added = applyDaemonEnvFromClient({
+        ...process.env,
+        NX_CLOUD_ACCESS_TOKEN: 'token',
+      });
+      expect(added).toEqual(['NX_CLOUD_ACCESS_TOKEN']);
+      expect(process.env.NX_CLOUD_ACCESS_TOKEN).toBe('token');
+
+      const clientEnvWithoutToken = { ...process.env };
+      delete clientEnvWithoutToken.NX_CLOUD_ACCESS_TOKEN;
+      const deleted = applyDaemonEnvFromClient(clientEnvWithoutToken);
+      expect(deleted).toEqual(['NX_CLOUD_ACCESS_TOKEN']);
+      expect(process.env.NX_CLOUD_ACCESS_TOKEN).toBeUndefined();
+    });
+  });
+});

--- a/packages/nx/src/daemon/client/daemon-environment.spec.ts
+++ b/packages/nx/src/daemon/client/daemon-environment.spec.ts
@@ -257,6 +257,22 @@ describe('daemon environment', () => {
 
       expect(getDaemonSpawnEnv().ELECTRON_RUN_AS_NODE).toBeUndefined();
     });
+
+    it('should keep NX_WORKSPACE_ROOT_PATH so the daemon starts with the pinned workspace root', () => {
+      process.env.NX_WORKSPACE_ROOT_PATH = '/workspace/root';
+
+      const env = getDaemonSpawnEnv();
+
+      expect(env.NX_WORKSPACE_ROOT_PATH).toBe('/workspace/root');
+      // still excluded from the reflected env
+      expect(getDaemonEnv().NX_WORKSPACE_ROOT_PATH).toBeUndefined();
+    });
+
+    it('should not add NX_WORKSPACE_ROOT_PATH when the client does not have it', () => {
+      delete process.env.NX_WORKSPACE_ROOT_PATH;
+
+      expect('NX_WORKSPACE_ROOT_PATH' in getDaemonSpawnEnv()).toBe(false);
+    });
   });
 
   describe('applyDaemonEnvFromClient', () => {

--- a/packages/nx/src/daemon/client/daemon-environment.spec.ts
+++ b/packages/nx/src/daemon/client/daemon-environment.spec.ts
@@ -27,6 +27,7 @@ describe('daemon environment', () => {
       process.env.__MISE_DIFF = 'per-hook-env-run';
       process.env.FNM_MULTISHELL_PATH = '/tmp/fnm_multishells/1234_5678';
       process.env.POSH_SESSION_ID = 'per-shell-session';
+      process.env.MISE_SHELL = 'zsh';
 
       const env = getDaemonEnv();
 
@@ -40,6 +41,7 @@ describe('daemon environment', () => {
       expect(env.__MISE_DIFF).toBeUndefined();
       expect(env.FNM_MULTISHELL_PATH).toBeUndefined();
       expect(env.POSH_SESSION_ID).toBeUndefined();
+      expect(env.MISE_SHELL).toBeUndefined();
     });
 
     it('should exclude per-directory and per-invocation vars', () => {
@@ -141,7 +143,6 @@ describe('daemon environment', () => {
       process.env.NODE_DISABLE_COLORS = '1';
       process.env.FORCE_HYPERLINK = '1';
       process.env.NX_ORIGINAL_FORCE_COLOR = '0';
-      process.env.MISE_SHELL = 'zsh';
 
       const env = getDaemonEnv();
 
@@ -151,7 +152,6 @@ describe('daemon environment', () => {
       expect(env.NODE_DISABLE_COLORS).toBeUndefined();
       expect(env.FORCE_HYPERLINK).toBeUndefined();
       expect(env.NX_ORIGINAL_FORCE_COLOR).toBeUndefined();
-      expect(env.MISE_SHELL).toBeUndefined();
     });
 
     it('should exclude editor preference vars', () => {
@@ -255,7 +255,7 @@ describe('daemon environment', () => {
     it('should not add ELECTRON_RUN_AS_NODE when the client does not have it', () => {
       delete process.env.ELECTRON_RUN_AS_NODE;
 
-      expect(getDaemonSpawnEnv().ELECTRON_RUN_AS_NODE).toBeUndefined();
+      expect('ELECTRON_RUN_AS_NODE' in getDaemonSpawnEnv()).toBe(false);
     });
 
     it('should keep NX_WORKSPACE_ROOT_PATH so the daemon starts with the pinned workspace root', () => {
@@ -303,6 +303,8 @@ describe('daemon environment', () => {
     it('should converge after one application of a client env payload', () => {
       process.env.ATUIN_SESSION = 'daemon-startup-value';
       process.env.JAVA_HOME = '/opt/java-client';
+      // isolate the payload from the developer's shell
+      delete process.env.JAVA_TOOL_OPTIONS;
       const payload = getDaemonEnv();
       applyDaemonEnvFromClient(payload);
 

--- a/packages/nx/src/daemon/client/daemon-environment.ts
+++ b/packages/nx/src/daemon/client/daemon-environment.ts
@@ -35,6 +35,11 @@ const DAEMON_ENV_VARS_EXCLUSIONS = new Set([
   'NX_BATCH_MODE',
   'NX_CI_EXECUTION_ID',
   'NX_DAEMON_PROCESS',
+  'NX_CLI_SET',
+  // Set by Nx Console on the extension host; always equals the daemon's own
+  // workspace root (foreign-workspace messages are rejected), and the daemon
+  // resolves its root at startup before any client env is applied.
+  'NX_WORKSPACE_ROOT_PATH',
 
   // Nx UI/logging vars (don't affect graph structure)
   'NX_TUI',
@@ -45,6 +50,7 @@ const DAEMON_ENV_VARS_EXCLUSIONS = new Set([
   'NX_NATIVE_LOGGING',
   'NX_PROFILE',
   'NX_DAEMON_VERBOSE_LOGGING',
+  'NX_ORIGINAL_FORCE_COLOR',
 
   // AI agent detection vars (the daemon itself is not an AI agent)
   'CLAUDECODE',
@@ -54,10 +60,13 @@ const DAEMON_ENV_VARS_EXCLUSIONS = new Set([
   'COMPOSER_NO_INTERACTION',
   'OPENCODE',
   'GEMINI_CLI',
+  'CODEX_THREAD_ID',
+  'AI_AGENT',
 
   // Shell mechanics
   '_',
   'SHLVL',
+  'PWD',
   'OLDPWD',
   'SHELL_SESSION_ID',
   'TERM_SESSION_ID',
@@ -67,6 +76,58 @@ const DAEMON_ENV_VARS_EXCLUSIONS = new Set([
   'COLUMNS',
   'LINES',
   'TMPDIR',
+  'PROMPT',
+
+  // Package-manager per-invocation vars not covered by the npm_/pnpm_ prefixes
+  'INIT_CWD',
+  'COLOR',
+
+  // Per-shell-session state; these tools' other vars are stable or can be
+  // meaningful (e.g. fnm's FNM_DIR), so no prefix exclusion
+  'FNM_MULTISHELL_PATH',
+  'POSH_SESSION_ID',
+  'MISE_SHELL',
+
+  // Output presentation
+  'PAGER',
+  'FORCE_COLOR',
+  'NO_COLOR',
+  'NODE_DISABLE_COLORS',
+  'FORCE_HYPERLINK',
+
+  // Terminal identification/presentation; differs per terminal app, so it
+  // churns whenever clients from different terminals share the daemon
+  'TERM',
+  'TERM_PROGRAM',
+  'TERM_PROGRAM_VERSION',
+  'COLORTERM',
+  'COLORFGBG',
+  'VTE_VERSION',
+  'GNOME_TERMINAL_SCREEN',
+  'GNOME_TERMINAL_SERVICE',
+  'WT_SESSION',
+  'WT_PROFILE_ID',
+  'TERMINAL_EMULATOR',
+  'TERMINUS_SUBLIME',
+  'ConEmuTask',
+  'ZELLIJ_PANE_ID',
+  'LC_TERMINAL',
+  'LC_TERMINAL_VERSION',
+
+  // Injected by VS Code and its extensions into integrated terminals. Single
+  // entries rather than GIT_/CHROME_/COPILOT_ prefixes: GIT_DIR, CHROME_BIN,
+  // COPILOT_HOME and COPILOT_GITHUB_TOKEN are functional inputs.
+  'GIT_ASKPASS',
+  'GIT_EDITOR',
+  'GIT_PAGER',
+  'GIT_MERGE_AUTOEDIT',
+  'APPLICATION_INSIGHTS_NO_STATSBEAT',
+  // Override for the @microsoft/mxc-sdk sandbox binaries; the SDK falls back
+  // to its bundled binaries when unset
+  'MXC_BIN_DIR',
+  'CHROME_CRASHPAD_PIPE_NAME',
+  'COPILOT_OTEL_FILE_EXPORTER_PATH',
+  'COPILOT_DEBUG_NONCE',
 
   // Session / auth
   'SSH_AUTH_SOCK',
@@ -110,6 +171,18 @@ const DAEMON_ENV_PREFIX_EXCLUSIONS = [
   // Editors / IDEs
   'VSCODE_',
   'JETBRAINS_',
+  'ELECTRON_',
+
+  // AI agent harnesses (per-session ids; the bare CLAUDECODE/CLAUDE_CODE
+  // detection vars are excluded above)
+  'CLAUDE_CODE_',
+
+  // Shell prompts / integrations (per-command and per-session state)
+  'ATUIN_',
+  'STARSHIP_',
+  'MCFLY_',
+  'DIRENV_',
+  '__MISE_',
 
   // Terminal emulators
   'ITERM_',
@@ -117,10 +190,22 @@ const DAEMON_ENV_PREFIX_EXCLUSIONS = [
   'WEZTERM_',
   'ALACRITTY_',
   'KONSOLE_',
+  'GHOSTTY_',
   'TMUX',
 
   // Benchmarking / profiling tools
   'HYPERFINE_', // hyperfine sets HYPERFINE_RANDOMIZED_ENVIRONMENT_OFFSET for each iteration
+];
+
+/**
+ * Env var name patterns that should never be sent to the daemon. For vars
+ * whose NAME embeds a process id, so neither an exact entry nor a safe
+ * prefix can match them.
+ */
+const DAEMON_ENV_PATTERN_EXCLUSIONS = [
+  // Set by Windows 11 explorer.exe as EFC_<pid> (observed as EFC_<pid>_<hash>
+  // in Electron-spawned shells); regenerated on every login
+  /^EFC_\d+(_\d+)?$/,
 ];
 
 /**
@@ -136,13 +221,16 @@ const DAEMON_ENV_PREFIX_EXCLUSION_OVERRIDES = new Set([
 ]);
 
 function isExcludedEnvVar(key: string): boolean {
+  if (
+    DAEMON_ENV_VARS_EXCLUSIONS.has(key) ||
+    DAEMON_ENV_PATTERN_EXCLUSIONS.some((pattern) => pattern.test(key))
+  ) {
+    return true;
+  }
   if (DAEMON_ENV_PREFIX_EXCLUSION_OVERRIDES.has(key)) {
     return false;
   }
-  return (
-    DAEMON_ENV_VARS_EXCLUSIONS.has(key) ||
-    DAEMON_ENV_PREFIX_EXCLUSIONS.some((prefix) => key.startsWith(prefix))
-  );
+  return DAEMON_ENV_PREFIX_EXCLUSIONS.some((prefix) => key.startsWith(prefix));
 }
 
 export function getDaemonEnv() {
@@ -153,6 +241,21 @@ export function getDaemonEnv() {
     }
   }
   return Object.assign(env, DAEMON_ENV_REQUIRED_SETTINGS);
+}
+
+/**
+ * Env for spawning the daemon process. On top of the reflected env, it must
+ * keep ELECTRON_RUN_AS_NODE (matched by the ELECTRON_ prefix exclusion):
+ * when the spawning client runs inside an Electron host, process.execPath is
+ * the Electron binary and only this var makes it run the daemon's Node entry
+ * point.
+ */
+export function getDaemonSpawnEnv() {
+  const env = getDaemonEnv();
+  if (process.env.ELECTRON_RUN_AS_NODE !== undefined) {
+    env.ELECTRON_RUN_AS_NODE = process.env.ELECTRON_RUN_AS_NODE;
+  }
+  return env;
 }
 
 /**

--- a/packages/nx/src/daemon/client/daemon-environment.ts
+++ b/packages/nx/src/daemon/client/daemon-environment.ts
@@ -38,7 +38,8 @@ const DAEMON_ENV_VARS_EXCLUSIONS = new Set([
   'NX_CLI_SET',
   // Set by Nx Console on the extension host; always equals the daemon's own
   // workspace root (foreign-workspace messages are rejected), and the daemon
-  // resolves its root at startup before any client env is applied.
+  // resolves its root at startup before any client env is applied. The spawn
+  // env keeps it so that startup resolution honors the pinned root.
   'NX_WORKSPACE_ROOT_PATH',
 
   // Nx UI/logging vars (don't affect graph structure)
@@ -249,15 +250,24 @@ export function getDaemonEnv() {
 
 /**
  * Env for spawning the daemon process. On top of the reflected env, it must
- * keep ELECTRON_RUN_AS_NODE (matched by the ELECTRON_ prefix exclusion):
- * when the spawning client runs inside an Electron host, process.execPath is
- * the Electron binary and only this var makes it run the daemon's Node entry
- * point.
+ * keep excluded vars the daemon needs to start correctly:
+ * - ELECTRON_RUN_AS_NODE (matched by the ELECTRON_ prefix exclusion): when
+ *   the spawning client runs inside an Electron host, process.execPath is
+ *   the Electron binary and only this var makes it run the daemon's Node
+ *   entry point.
+ * - NX_WORKSPACE_ROOT_PATH: the daemon resolves its workspace root at
+ *   startup by walking up from cwd looking for workspace markers; without
+ *   the pin, a root without markers under an ancestor that has them
+ *   resolves to the ancestor and the daemon publishes its socket under the
+ *   wrong workspace.
  */
 export function getDaemonSpawnEnv() {
   const env = getDaemonEnv();
   if (process.env.ELECTRON_RUN_AS_NODE !== undefined) {
     env.ELECTRON_RUN_AS_NODE = process.env.ELECTRON_RUN_AS_NODE;
+  }
+  if (process.env.NX_WORKSPACE_ROOT_PATH !== undefined) {
+    env.NX_WORKSPACE_ROOT_PATH = process.env.NX_WORKSPACE_ROOT_PATH;
   }
   return env;
 }

--- a/packages/nx/src/daemon/client/daemon-environment.ts
+++ b/packages/nx/src/daemon/client/daemon-environment.ts
@@ -88,6 +88,10 @@ const DAEMON_ENV_VARS_EXCLUSIONS = new Set([
   'POSH_SESSION_ID',
   'MISE_SHELL',
 
+  // Editor preference; graph computation is non-interactive
+  'EDITOR',
+  'VISUAL',
+
   // Output presentation
   'PAGER',
   'FORCE_COLOR',


### PR DESCRIPTION
## Current Behavior

The daemon invalidates its cached project graph whenever any env var forwarded by a client differs from the previous client's, including vars deleted because the new client lacks them. Volatile vars slip through the exclusion lists, so shells with integrations like atuin force a full graph recompute on every single command (`ATUIN_HISTORY_ID` changes per command), running nx from a subdirectory recomputes via `PWD`/`INIT_CWD`, and alternating between a terminal and VS Code/Nx Console recomputes on every switch (`TERM_PROGRAM`, `GIT_ASKPASS`, `ELECTRON_*` and other extension-host vars flip back and forth).

## Expected Behavior

Vars that cannot affect graph computation are excluded from the daemon environment, so the cached graph survives across invocations and client alternation:

- exact entries for presentation (`FORCE_COLOR`, `NO_COLOR`, `PAGER`), editor preference (`EDITOR`, `VISUAL`), terminal identification (`TERM`, `TERM_PROGRAM`, `WT_SESSION`, ...), per-invocation state (`PWD`, `INIT_CWD`, `PROMPT`), and vars injected by VS Code and its extensions (`GIT_ASKPASS`, `MXC_BIN_DIR`, `CHROME_CRASHPAD_PIPE_NAME`, ...)
- prefix entries for shell integrations (`ATUIN_`, `STARSHIP_`, `MCFLY_`, `DIRENV_`, `__MISE_`), terminals (`GHOSTTY_`), `ELECTRON_`, and AI harness session vars (`CLAUDE_CODE_`)
- a new pattern-exclusion mechanism for Windows' pid-shaped `EFC_<pid>` vars, which neither an exact entry nor a safe prefix can match

Functional inputs keep flowing to the daemon: `PATH`, `GIT_DIR`, `CHROME_BIN`, `FNM_DIR`, `MISE_ENV`, `COPILOT_HOME`, and the Nx Cloud auth tokens. `GIT_`/`CHROME_`/`COPILOT_` were deliberately not excluded as prefixes for that reason. `PSModulePath` is deliberately kept: it is PATH-like for PowerShell, so a graph-time config shelling out to a PowerShell script could depend on it. The accepted cost is one recompute per VS Code/terminal switch on Windows, where the two clients disagree on its value.

The env used to spawn the daemon process (the new `getDaemonSpawnEnv()`) re-adds two excluded vars the daemon needs at startup. `ELECTRON_RUN_AS_NODE`: when Nx Console's extension host spawns the daemon, `process.execPath` is the Electron binary and only that var makes it run the daemon's Node entry point. `NX_WORKSPACE_ROOT_PATH`: the daemon resolves its workspace root by walking up from cwd, so a pinned root without workspace markers would resolve to an ancestor and publish its socket under the wrong workspace. Neither flows into the reflected per-request env.

Exact and pattern exclusions now take precedence over the prefix-exclusion allow-list, so a future exact "never send" entry for an allow-listed var cannot be silently ignored; the allow-list bypasses prefix rules only.

> [!NOTE]
> Excluding `MXC_BIN_DIR` (and `ELECTRON_OVERRIDE_DIST_PATH` under the `ELECTRON_` prefix) means a graph-time config deliberately reading them would see the upstream fallback behavior on the daemon. No plugin or config in the ecosystem is known to do so; revisit the exact entries if one turns up.

Case-insensitive matching of Windows env-var names is a known gap of the exclusion mechanism that predates this change, and it will be addressed separately.

## Related Issue(s)

[NXC-4782](https://linear.app/nxdev/issue/NXC-4782/augment-the-daemon-env-var-exclusion-list-with-volatile-shell)

Fixes #36610

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/nxc-4782-31f24f56">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->

