### PR TITLE
fix(misc): bump css-loader so npm can resolve rspack core 2

### DIFF
--- a/packages/react/plugins/component-testing/webpack-fallback.ts
+++ b/packages/react/plugins/component-testing/webpack-fallback.ts
@@ -86,6 +86,11 @@ const loaderModulesOptions = {
   modules: {
     mode: 'local',
     getLocalIdent: getCSSModuleLocalIdent,
+    // css-loader 7 defaults namedExport to true, and to camel-case-only
+    // locals when it is off. Generated components import the default
+    // export and reference class names as authored, so pin both.
+    namedExport: false,
+    exportLocalsConvention: 'asIs',
   },
   importLoaders: 1,
 };

--- a/packages/rspack/package.json
+++ b/packages/rspack/package.json
@@ -134,7 +134,7 @@
     "@phenomnomnominal/tsquery": "catalog:typescript",
     "autoprefixer": "catalog:css",
     "browserslist": "^4.26.0",
-    "css-loader": "^6.4.0",
+    "css-loader": "^7.1.4",
     "enquirer": "catalog:",
     "express": "^4.21.2",
     "http-proxy-middleware": "catalog:",

--- a/packages/rspack/src/plugins/utils/loaders/stylesheet-loaders.ts
+++ b/packages/rspack/src/plugins/utils/loaders/stylesheet-loaders.ts
@@ -31,6 +31,11 @@ export function getCommonLoadersForCssModules(
         modules: {
           mode: 'local',
           getLocalIdent: getCSSModuleLocalIdent,
+          // css-loader 7 defaults namedExport to true, and to camel-case-only
+          // locals when it is off. Generated components import the default
+          // export and reference class names as authored, so pin both.
+          namedExport: false,
+          exportLocalsConvention: 'asIs',
         },
         importLoaders: 1,
       },

--- a/packages/webpack/package.json
+++ b/packages/webpack/package.json
@@ -94,7 +94,7 @@
     "browserslist": "^4.26.0",
     "picocolors": "catalog:",
     "copy-webpack-plugin": "^14.0.0",
-    "css-loader": "^6.4.0",
+    "css-loader": "^7.1.4",
     "css-minimizer-webpack-plugin": "^8.0.0",
     "fork-ts-checker-webpack-plugin": "9.1.0",
     "less": ">=4.1.3 <4.9.0",

--- a/packages/webpack/src/plugins/nx-webpack-plugin/lib/stylesheet-loaders.ts
+++ b/packages/webpack/src/plugins/nx-webpack-plugin/lib/stylesheet-loaders.ts
@@ -33,6 +33,11 @@ export function getCommonLoadersForCssModules(
         modules: {
           mode: 'local',
           getLocalIdent: getCSSModuleLocalIdent,
+          // css-loader 7 defaults namedExport to true, and to camel-case-only
+          // locals when it is off. Generated components import the default
+          // export and reference class names as authored, so pin both.
+          namedExport: false,
+          exportLocalsConvention: 'asIs',
         },
         importLoaders: 1,
       },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3719,8 +3719,8 @@ importers:
         specifier: ^4.26.0
         version: 4.28.0
       css-loader:
-        specifier: ^6.4.0
-        version: 6.11.0(@rspack/core@1.6.8(@swc/helpers@0.5.23))(webpack@5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@7.0.3))
+        specifier: ^7.1.4
+        version: 7.1.4(@rspack/core@1.6.8(@swc/helpers@0.5.23))(webpack@5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@7.0.3))
       enquirer:
         specifier: 'catalog:'
         version: 2.3.6
@@ -4031,8 +4031,8 @@ importers:
         specifier: ^14.0.0
         version: 14.0.0(webpack@5.105.2)
       css-loader:
-        specifier: ^6.4.0
-        version: 6.11.0(@rspack/core@1.6.8(@swc/helpers@0.5.23))(webpack@5.105.2)
+        specifier: ^7.1.4
+        version: 7.1.4(@rspack/core@2.0.8(@module-federation/runtime-tools@2.3.3(node-fetch@3.3.2))(@swc/helpers@0.5.23))(webpack@5.105.2)
       css-minimizer-webpack-plugin:
         specifier: ^8.0.0
         version: 8.0.0(esbuild@0.25.0)(lightningcss@1.32.0)(webpack@5.105.2)
@@ -4044,7 +4044,7 @@ importers:
         version: 4.8.1
       less-loader:
         specifier: catalog:css
-        version: 12.3.1(@rspack/core@1.6.8(@swc/helpers@0.5.23))(less@4.8.1)(webpack@5.105.2)
+        version: 12.3.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.3.3(node-fetch@3.3.2))(@swc/helpers@0.5.23))(less@4.8.1)(webpack@5.105.2)
       license-webpack-plugin:
         specifier: ^4.0.2
         version: 4.0.2(webpack@5.105.2)
@@ -4068,7 +4068,7 @@ importers:
         version: 14.1.0(postcss@8.5.15)
       postcss-loader:
         specifier: catalog:css
-        version: 8.2.1(@rspack/core@1.6.8(@swc/helpers@0.5.23))(postcss@8.5.15)(typescript@6.0.3)(webpack@5.105.2)
+        version: 8.2.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.3.3(node-fetch@3.3.2))(@swc/helpers@0.5.23))(postcss@8.5.15)(typescript@6.0.3)(webpack@5.105.2)
       rxjs:
         specifier: 'catalog:'
         version: 7.8.2
@@ -4080,7 +4080,7 @@ importers:
         version: 1.97.2
       sass-loader:
         specifier: catalog:css
-        version: 16.0.7(@rspack/core@1.6.8(@swc/helpers@0.5.23))(sass-embedded@1.97.2)(sass@1.97.3)(webpack@5.105.2)
+        version: 16.0.7(@rspack/core@2.0.8(@module-federation/runtime-tools@2.3.3(node-fetch@3.3.2))(@swc/helpers@0.5.23))(sass-embedded@1.97.2)(sass@1.97.3)(webpack@5.105.2)
       source-map-loader:
         specifier: ^5.0.0
         version: 5.0.0(webpack@5.105.2)
@@ -43169,34 +43169,6 @@ snapshots:
     dependencies:
       postcss: 8.5.25
 
-  css-loader@6.11.0(@rspack/core@1.6.8(@swc/helpers@0.5.23))(webpack@5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@7.0.3)):
-    dependencies:
-      icss-utils: 5.1.0(postcss@8.5.15)
-      postcss: 8.5.15
-      postcss-modules-extract-imports: 3.1.0(postcss@8.5.15)
-      postcss-modules-local-by-default: 4.2.0(postcss@8.5.15)
-      postcss-modules-scope: 3.2.1(postcss@8.5.15)
-      postcss-modules-values: 4.0.0(postcss@8.5.15)
-      postcss-value-parser: 4.2.0
-      semver: 7.8.4
-    optionalDependencies:
-      '@rspack/core': 1.6.8(@swc/helpers@0.5.23)
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@7.0.3)
-
-  css-loader@6.11.0(@rspack/core@1.6.8(@swc/helpers@0.5.23))(webpack@5.105.2):
-    dependencies:
-      icss-utils: 5.1.0(postcss@8.5.15)
-      postcss: 8.5.15
-      postcss-modules-extract-imports: 3.1.0(postcss@8.5.15)
-      postcss-modules-local-by-default: 4.2.0(postcss@8.5.15)
-      postcss-modules-scope: 3.2.1(postcss@8.5.15)
-      postcss-modules-values: 4.0.0(postcss@8.5.15)
-      postcss-value-parser: 4.2.0
-      semver: 7.8.4
-    optionalDependencies:
-      '@rspack/core': 1.6.8(@swc/helpers@0.5.23)
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
-
   css-loader@6.11.0(@rspack/core@2.0.8(@module-federation/runtime-tools@0.21.2)(@swc/helpers@0.5.18))(webpack@5.105.2):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.15)
@@ -43225,6 +43197,20 @@ snapshots:
       '@rspack/core': 1.6.8(@swc/helpers@0.5.23)
       webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@7.0.3(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.105.2))
 
+  css-loader@7.1.4(@rspack/core@1.6.8(@swc/helpers@0.5.23))(webpack@5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@7.0.3)):
+    dependencies:
+      icss-utils: 5.1.0(postcss@8.5.25)
+      postcss: 8.5.25
+      postcss-modules-extract-imports: 3.1.0(postcss@8.5.25)
+      postcss-modules-local-by-default: 4.2.0(postcss@8.5.25)
+      postcss-modules-scope: 3.2.1(postcss@8.5.25)
+      postcss-modules-values: 4.0.0(postcss@8.5.25)
+      postcss-value-parser: 4.2.0
+      semver: 7.8.5
+    optionalDependencies:
+      '@rspack/core': 1.6.8(@swc/helpers@0.5.23)
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@7.0.3)
+
   css-loader@7.1.4(@rspack/core@2.0.8(@module-federation/runtime-tools@0.21.2)(@swc/helpers@0.5.18))(webpack@5.109.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@7.0.3)):
     dependencies:
       icss-utils: 5.1.0(postcss@8.5.25)
@@ -43252,6 +43238,20 @@ snapshots:
     optionalDependencies:
       '@rspack/core': 2.0.8(@module-federation/runtime-tools@0.21.2)(@swc/helpers@0.5.18)
       webpack: 5.109.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19)(webpack-cli@7.0.3)
+
+  css-loader@7.1.4(@rspack/core@2.0.8(@module-federation/runtime-tools@2.3.3(node-fetch@3.3.2))(@swc/helpers@0.5.23))(webpack@5.105.2):
+    dependencies:
+      icss-utils: 5.1.0(postcss@8.5.25)
+      postcss: 8.5.25
+      postcss-modules-extract-imports: 3.1.0(postcss@8.5.25)
+      postcss-modules-local-by-default: 4.2.0(postcss@8.5.25)
+      postcss-modules-scope: 3.2.1(postcss@8.5.25)
+      postcss-modules-values: 4.0.0(postcss@8.5.25)
+      postcss-value-parser: 4.2.0
+      semver: 7.8.5
+    optionalDependencies:
+      '@rspack/core': 2.0.8(@module-federation/runtime-tools@2.3.3(node-fetch@3.3.2))(@swc/helpers@0.5.23)
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
 
   css-loader@7.1.4(@rspack/core@2.0.8(@module-federation/runtime-tools@2.3.3(node-fetch@3.3.2))(@swc/helpers@0.5.23))(webpack@5.109.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19)(webpack-cli@7.0.3)):
     dependencies:
@@ -48121,19 +48121,19 @@ snapshots:
       '@rspack/core': 1.6.8(@swc/helpers@0.5.23)
       webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@7.0.3(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.105.2))
 
-  less-loader@12.3.1(@rspack/core@1.6.8(@swc/helpers@0.5.23))(less@4.8.1)(webpack@5.105.2):
-    dependencies:
-      less: 4.8.1
-    optionalDependencies:
-      '@rspack/core': 1.6.8(@swc/helpers@0.5.23)
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
-
   less-loader@12.3.1(@rspack/core@2.0.8(@module-federation/runtime-tools@0.21.2)(@swc/helpers@0.5.18))(less@4.8.1)(webpack@5.105.2):
     dependencies:
       less: 4.8.1
     optionalDependencies:
       '@rspack/core': 2.0.8(@module-federation/runtime-tools@0.21.2)(@swc/helpers@0.5.18)
       webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@7.0.3)
+
+  less-loader@12.3.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.3.3(node-fetch@3.3.2))(@swc/helpers@0.5.23))(less@4.8.1)(webpack@5.105.2):
+    dependencies:
+      less: 4.8.1
+    optionalDependencies:
+      '@rspack/core': 2.0.8(@module-federation/runtime-tools@2.3.3(node-fetch@3.3.2))(@swc/helpers@0.5.23)
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
 
   less-loader@12.3.2(@rspack/core@2.0.8(@module-federation/runtime-tools@0.21.2)(@swc/helpers@0.5.18))(less@4.8.1)(webpack@5.105.2):
     dependencies:
@@ -52443,18 +52443,6 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  postcss-loader@8.2.1(@rspack/core@1.6.8(@swc/helpers@0.5.23))(postcss@8.5.15)(typescript@6.0.3)(webpack@5.105.2):
-    dependencies:
-      cosmiconfig: 9.0.0(typescript@6.0.3)
-      jiti: 2.6.1
-      postcss: 8.5.15
-      semver: 7.8.4
-    optionalDependencies:
-      '@rspack/core': 1.6.8(@swc/helpers@0.5.23)
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
-    transitivePeerDependencies:
-      - typescript
-
   postcss-loader@8.2.1(@rspack/core@2.0.8(@module-federation/runtime-tools@0.21.2)(@swc/helpers@0.5.18))(postcss@8.5.19)(typescript@6.0.3)(webpack@5.109.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19)(webpack-cli@7.0.3)):
     dependencies:
       cosmiconfig: 9.0.0(typescript@6.0.3)
@@ -52476,6 +52464,18 @@ snapshots:
     optionalDependencies:
       '@rspack/core': 2.0.8(@module-federation/runtime-tools@0.21.2)(@swc/helpers@0.5.18)
       webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@7.0.3)
+    transitivePeerDependencies:
+      - typescript
+
+  postcss-loader@8.2.1(@rspack/core@2.0.8(@module-federation/runtime-tools@2.3.3(node-fetch@3.3.2))(@swc/helpers@0.5.23))(postcss@8.5.15)(typescript@6.0.3)(webpack@5.105.2):
+    dependencies:
+      cosmiconfig: 9.0.0(typescript@6.0.3)
+      jiti: 2.6.1
+      postcss: 8.5.15
+      semver: 7.8.4
+    optionalDependencies:
+      '@rspack/core': 2.0.8(@module-federation/runtime-tools@2.3.3(node-fetch@3.3.2))(@swc/helpers@0.5.23)
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
     transitivePeerDependencies:
       - typescript
 
@@ -54178,15 +54178,6 @@ snapshots:
       sass-embedded: 1.97.2
       webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@7.0.3(webpack-bundle-analyzer@4.10.2)(webpack-dev-server@5.2.4)(webpack@5.105.2))
 
-  sass-loader@16.0.7(@rspack/core@1.6.8(@swc/helpers@0.5.23))(sass-embedded@1.97.2)(sass@1.97.3)(webpack@5.105.2):
-    dependencies:
-      neo-async: 2.6.2
-    optionalDependencies:
-      '@rspack/core': 1.6.8(@swc/helpers@0.5.23)
-      sass: 1.97.3
-      sass-embedded: 1.97.2
-      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
-
   sass-loader@16.0.7(@rspack/core@2.0.8(@module-federation/runtime-tools@0.21.2)(@swc/helpers@0.5.18))(sass-embedded@1.97.2)(sass@1.101.0)(webpack@5.105.2):
     dependencies:
       neo-async: 2.6.2
@@ -54204,6 +54195,15 @@ snapshots:
       sass: 1.97.3
       sass-embedded: 1.97.2
       webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@7.0.3)
+
+  sass-loader@16.0.7(@rspack/core@2.0.8(@module-federation/runtime-tools@2.3.3(node-fetch@3.3.2))(@swc/helpers@0.5.23))(sass-embedded@1.97.2)(sass@1.97.3)(webpack@5.105.2):
+    dependencies:
+      neo-async: 2.6.2
+    optionalDependencies:
+      '@rspack/core': 2.0.8(@module-federation/runtime-tools@2.3.3(node-fetch@3.3.2))(@swc/helpers@0.5.23)
+      sass: 1.97.3
+      sass-embedded: 1.97.2
+      webpack: 5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@5.1.4)
 
   sass-loader@17.0.0(@rspack/core@2.0.8(@module-federation/runtime-tools@0.21.2)(@swc/helpers@0.5.18))(sass-embedded@1.97.2)(sass@1.101.0)(webpack@5.109.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.28.1)(lightningcss@1.32.0)(postcss@8.5.19)(webpack-cli@7.0.3)):
     optionalDependencies:


### PR DESCRIPTION
## Current Behavior

`css-loader` 6 declares `peerOptional @rspack/core: "0.x || 1.x"`, so npm pins the workspace to `@rspack/core@1.x`. The app generator then writes `@rspack/core@2.0.4` and `@rspack/cli@2.0.4`, whose peer is `^2.0.0-0`, and the install dies with ERESOLVE:

```
Found: @rspack/core@1.7.12
  dev @rspack/core@"2.0.4" from the root project
  5 more (css-loader, less-loader, postcss-loader, sass-loader, ts-checker-rspack-plugin)
Could not resolve dependency:
dev @rspack/cli@"2.0.4" from the root project
Conflicting peer dependency: @rspack/core@2.0.4
```

`css-loader` is the only one of those five still capping at 1.x - the other four already accept `^2.0.0-0`.

`@nx/webpack` ships the same `^6.4.0` range and the same css-modules loader options, so a workspace using both plugins keeps a css-loader 6 copy that can re-pin `@rspack/core`.

## Expected Behavior

Both plugins take `css-loader@^7.1.4`, the first release admitting `^2.0.0-0`, so npm resolves `@rspack/core@2.x`.

The bump carries two v7 default flips that would otherwise break generated components silently, so both are pinned back to the v6 behaviour on each plugin's CSS-modules rule:

| option | v6.11.0 | v7.1.4 | pinned to |
| --- | --- | --- | --- |
| `modules.namedExport` | `false` | `true` | `false` |
| `modules.exportLocalsConvention` (when namedExport off) | `asIs` | `camel-case-only` | `asIs` |

Nx generates `import styles from './x.module.css'`, which v7's `namedExport: true` removes. `asIs` is accepted by both majors, so the option is version-agnostic. Only the CSS-modules rule needs it - the rules are in a `oneOf`, so `.module.*` never reaches the global-css rule.

`packages/angular-rspack` is left alone: it already declares `^7.1.2` (resolving to 7.1.4) and never uses CSS modules (`exportType: 'string'`, `esModule: false`), so neither flip can reach it.

## Verification

Nightly run this fixes: https://github.com/nrwl/nx/actions/runs/31566779911 - `e2e-rspack` was the last remaining golden project (19 passing / 1 failing), on MacOS/npm/22 and Linux/npm/22.

Locally on npm:

| suite | result |
| --- | --- |
| e2e-rspack | 8 passed, 0 ERESOLVE, no `@rspack/core@1` pin |
| e2e-webpack | 19 passed, 0 ERESOLVE |

CSS-module behaviour was checked with real rspack and webpack builds rather than a green suite, since `namedExport: true` fails at runtime rather than at compile time. With the pinned options the authored class names resolve through the default export; with v7 defaults they do not.

## Related Issue(s)

NXC-4612
