### PR TITLE
fix(repo): tell review-pr agents to compare base and HEAD with git

### DIFF
--- a/.claude/skills/review-pr/SKILL.md
+++ b/.claude/skills/review-pr/SKILL.md
@@ -657,6 +657,12 @@ only with `docker exec` against that container:
   - `docker exec nx-review-pr-<NUMBER> grep -rn "<pattern>" /work/nx/<subdir>`
   - `docker exec nx-review-pr-<NUMBER> find /work/nx -name '<glob>'`
   - `docker exec nx-review-pr-<NUMBER> sed -n '<a>,<b>p' /work/nx/<path>`
+- To compare base against HEAD, use git — both paths are worktrees of one repo, so `refs/review/base`
+  resolves from either. Never compare them with a recursive filesystem `diff`: both trees are fully
+  installed, so `diff -r` walks two complete `node_modules` trees for minutes, and piping through
+  `grep -v node_modules` does not help because the walk is the cost.
+  - `docker exec nx-review-pr-<NUMBER> git -C /work/nx diff --name-only refs/review/base..HEAD`
+  - `docker exec nx-review-pr-<NUMBER> git -C /work/nx diff refs/review/base..HEAD -- <path>`
 - NEVER run PR code on the host. Any command that executes the checkout (install, build, nx, tests,
   the reproduction) MUST go through
   `docker exec nx-review-pr-<NUMBER> bash -lc 'export PATH="/root/.local/bin:/root/.local/share/mise/shims:$PATH"; cd /work/nx && <cmd>'`.


### PR DESCRIPTION
## Current Behavior

The review charter's sandbox reading protocol in `.claude/skills/review-pr/SKILL.md` gives review agents four verbs for reaching PR source — `cat`, `grep`, `find`, `sed` — and every one of them reads a **single** tree. The skill separately and repeatedly instructs agents to read base state from `/work/base` (SKILL.md:236, :715).

So an agent that needs to answer *"what differs between base and HEAD?"* finds no prescribed verb for it and improvises one. Observed in a live review of #36626:

```
diff -rq /work/base/packages /work/nx/packages | grep -v node_modules
```

Both `/work/base` and `/work/nx` receive a full `pnpm install` (SKILL.md:217, :677), so this walks two complete `node_modules` trees file by file. The `grep -v node_modules` filters *after* the walk, so it saves nothing — the walk is the entire cost.

Measured on the running container: **~148s of CPU, 4GB read / 6GB written**, with the container pegged at 100% for the duration. On macOS the whole cost surfaces as `com.apple.Virtualization` in Activity Monitor, which makes it look like a Docker VM problem rather than a review-skill one.

## Expected Behavior

Agents compare the two worktrees with git. `/work/nx` and `/work/base` are worktrees of the same `/work/repo.git` (SKILL.md:175), so `refs/review/base` resolves from either, git compares tree hashes instead of walking files, and `node_modules` is gitignored so it never enters the comparison at all.

Verified in the same container that was burning 148s:

```
$ time docker exec nx-review-pr-36626 git -C /work/nx diff --name-only refs/review/base..HEAD
packages/gradle/src/utils/exec-gradle.ts
packages/maven/src/plugins/maven-analyzer.ts
...
0.07s total
```

Same answer, roughly 2000x cheaper.

This PR adds the missing comparison verb to that same bullet list, alongside the existing read verbs, and states plainly why a recursive filesystem `diff` is the wrong tool here — including that piping through `grep` does not avoid the cost.

Docs-only change to a repo skill file; no runtime code is touched.

## Related Issue(s)

None — found while investigating unexplained CPU load from a running review sandbox.

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Fix-review-pr-base-vs-HEAD-diff-verb-30efd553">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->