### PR TITLE
fix(core): widen enquirer catalog range to ^2.4.1

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -145,8 +145,8 @@ catalogs:
       specifier: ^4.1.0
       version: 4.1.2
     enquirer:
-      specifier: ~2.3.6
-      version: 2.3.6
+      specifier: ^2.4.1
+      version: 2.4.1
     gpt3-tokenizer:
       specifier: ^1.1.5
       version: 1.1.5
@@ -421,7 +421,7 @@ importers:
         version: 3.36.1
       enquirer:
         specifier: 'catalog:'
-        version: 2.3.6
+        version: 2.4.1
       form-data:
         specifier: ^4.0.6
         version: 4.0.6
@@ -2153,7 +2153,7 @@ importers:
         version: 8.59.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       enquirer:
         specifier: 'catalog:'
-        version: 2.3.6
+        version: 2.4.1
       jsonc-parser:
         specifier: 'catalog:'
         version: 3.3.1
@@ -2342,7 +2342,7 @@ importers:
         version: link:../create-nx-workspace
       enquirer:
         specifier: 'catalog:'
-        version: 2.3.6
+        version: 2.4.1
       picocolors:
         specifier: 'catalog:'
         version: 1.1.1
@@ -2363,7 +2363,7 @@ importers:
         version: 4.1.2
       enquirer:
         specifier: 'catalog:'
-        version: 2.3.6
+        version: 2.4.1
       flat:
         specifier: ^5.0.2
         version: 5.0.2
@@ -2458,7 +2458,7 @@ importers:
         version: 5.0.1
       enquirer:
         specifier: 'catalog:'
-        version: 2.3.6
+        version: 2.4.1
       minimatch:
         specifier: ^10.2.5
         version: 10.2.5
@@ -2486,7 +2486,7 @@ importers:
         version: link:../devkit
       enquirer:
         specifier: 'catalog:'
-        version: 2.3.6
+        version: 2.4.1
       tslib:
         specifier: catalog:typescript
         version: 2.8.1
@@ -3221,7 +3221,7 @@ importers:
         version: 5.0.1
       enquirer:
         specifier: 'catalog:'
-        version: 2.3.6
+        version: 2.4.1
       figures:
         specifier: 3.2.0
         version: 3.2.0
@@ -3723,7 +3723,7 @@ importers:
         version: 6.11.0(@rspack/core@1.6.8(@swc/helpers@0.5.23))(webpack@5.105.2(@swc/core@1.15.10(@swc/helpers@0.5.18))(esbuild@0.25.0)(lightningcss@1.32.0)(postcss@8.5.15)(webpack-cli@7.0.3))
       enquirer:
         specifier: 'catalog:'
-        version: 2.3.6
+        version: 2.4.1
       express:
         specifier: ^4.21.2
         version: 4.21.2
@@ -3845,7 +3845,7 @@ importers:
         version: 8.18.0
       enquirer:
         specifier: 'catalog:'
-        version: 2.3.6
+        version: 2.4.1
       picomatch:
         specifier: 'catalog:'
         version: 4.0.4
@@ -4132,7 +4132,7 @@ importers:
         version: 4.1.2
       enquirer:
         specifier: 'catalog:'
-        version: 2.3.6
+        version: 2.4.1
       picomatch:
         specifier: 'catalog:'
         version: 4.0.4

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -47,7 +47,7 @@ catalog:
   '@zkochan/js-yaml': '0.0.7'
   ajv: '^8.0.0'
   chalk: '^4.1.0'
-  enquirer: '~2.3.6'
+  enquirer: '^2.4.1'
   gpt3-tokenizer: '^1.1.5'
   http-proxy-middleware: '^3.0.7'
   http-server: '^14.1.0'


### PR DESCRIPTION
## Current Behavior

The pnpm catalog pins `enquirer: '~2.3.6'`. The tilde range admits only 2.3.x, so:

- the workspace resolves `enquirer@2.3.6`, three years old, while 2.4.1 is the latest release
- any future patched 2.4.x could not be picked up without another manual catalog edit

## Expected Behavior

The catalog allows the current major-compatible range, `^2.4.1`, so the workspace resolves
`enquirer@2.4.1` and automatically absorbs future patch releases.

### What this does not do

**This does not resolve CVE-2026-15187 / GHSA-5727-r6pv-59f5, and is not claimed to.** That
advisory describes the flaw as affecting enquirer *up to 2.4.1* — the latest published version —
and carries no `first_patched_version`, so there is nothing to upgrade to. Upstream
(enquirer/enquirer#487) is closed, with the maintainer disputing the report.

Nx is not exploitable by it in any case. The vulnerability requires attacker-controlled data to
reach `question.name`, and every prompt name in Nx is a string literal. The one call site that
looks dynamic is `packages/nx/src/command-line/init/ai-agent-prompts.ts`:

```ts
name: 'agents',                       // the question.name — a literal
choices: supportedAgents.map((a) => ({
  name: a,                            // a *choice* label, from a hardcoded array
```

`name: a` is a choice label, not the path passed to enquirer's internal setter, and
`supportedAgents` is a fixed list. No user input reaches `question.name`.

This PR is therefore dependency hygiene plus future-proofing, not a security fix.

### Compatibility

2.4.1 is API-compatible with 2.3.6 for everything Nx uses — verified `prompt`, the `Confirm`
class, and the full prompt-type set including `multiselect`. It adds one transitive dependency,
`strip-ansi@^6.0.1`.

The lockfile still contains an `enquirer@2.3.6` entry. That comes from published `@nx/*` packages
consumed as devDependencies of this repo (`@nx/angular`, `@nx/devkit@22.6.5`, `@nx/rspack`,
`@nx/workspace`), which were released carrying the old catalog value. It resolves once those are
republished from this catalog; packages published from this branch declare `^2.4.1`.

### Testing

- `nx run-many -t test -p create-nx-workspace,devkit` — pass
- `nx test nx` — 5122 passed, 5 failed in `workspace-id.spec.ts` and `watch-before-scan.spec.ts`.
  Both are **pre-existing**: the identical 5 failures reproduce on unmodified `master`
  (`4aacbd056b`) and are unrelated to enquirer (git-remote derivation and a native watcher timing
  test).

## Related Issue(s)

Related to #36592 — deliberately not `Fixes`, since the advisory in that issue has no patched
version and this change cannot clear it. The remaining work there is documenting the
non-exploitability analysis above so users can suppress the finding in their scanners with a
justification.

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Widen-enquirer-catalog-range-to-2.4.1-7e76ca89">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->