### PR TITLE
fix(core): resolve main worktree root without a Windows verbatim prefix

### DIFF
--- a/packages/nx/src/native/worktree.rs
+++ b/packages/nx/src/native/worktree.rs
@@ -40,8 +40,10 @@ fn resolve_main_worktree_root(workspace_root: &str) -> anyhow::Result<Option<Str
     };
 
     // Resolve symlinks and ".." segments so the path is clean and
-    // comparable across worktrees (e.g., in reset's equality check)
-    let abs_path = abs_path.canonicalize().unwrap_or(abs_path);
+    // comparable across worktrees (e.g., in reset's equality check).
+    // dunce, not std: std returns a `\\?\` verbatim path on Windows, which
+    // Node's module resolution walks past the drive root on (nx#35637).
+    let abs_path = dunce::canonicalize(&abs_path).unwrap_or(abs_path);
 
     // The common dir is the .git directory — its parent is the repo root
     let main_root = abs_path
@@ -49,4 +51,78 @@ fn resolve_main_worktree_root(workspace_root: &str) -> anyhow::Result<Option<Str
         .ok_or_else(|| anyhow::anyhow!("Cannot determine main repo root"))?;
 
     Ok(Some(main_root.to_string_lossy().to_string()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn git(dir: &Path, args: &[&str]) {
+        let output = create_command("git")
+            .args(args)
+            .current_dir(dir)
+            .output()
+            .expect("failed to run git");
+        assert!(
+            output.status.success(),
+            "git {args:?} failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+
+    fn init_repo(path: &Path) {
+        std::fs::create_dir_all(path).unwrap();
+        git(path, &["init", "-b", "main"]);
+        git(
+            path,
+            &[
+                "-c",
+                "user.email=test@example.com",
+                "-c",
+                "user.name=Test",
+                "commit",
+                "--allow-empty",
+                "-m",
+                "init",
+            ],
+        );
+    }
+
+    #[test]
+    fn returns_none_when_not_in_a_worktree() {
+        let tmp = TempDir::new().unwrap();
+        let main = tmp.path().join("main");
+        init_repo(&main);
+
+        assert_eq!(
+            resolve_main_worktree_root(main.to_str().unwrap()).unwrap(),
+            None
+        );
+    }
+
+    #[test]
+    fn resolves_main_repo_root_from_a_worktree() {
+        let tmp = TempDir::new().unwrap();
+        let main = tmp.path().join("main");
+        init_repo(&main);
+
+        let worktree = tmp.path().join("wt");
+        git(&main, &["worktree", "add", worktree.to_str().unwrap()]);
+
+        let resolved = resolve_main_worktree_root(worktree.to_str().unwrap())
+            .unwrap()
+            .expect("a linked worktree should resolve to the main repo root");
+
+        assert_eq!(
+            PathBuf::from(&resolved),
+            dunce::canonicalize(&main).unwrap()
+        );
+        // A `\\?\` prefix here reaches cacheDir, and Node's module resolution
+        // walks past the drive root on such paths (nx#35637)
+        assert!(
+            !resolved.starts_with(r"\\?\"),
+            "expected a plain path, got verbatim: {resolved}"
+        );
+    }
 }


### PR DESCRIPTION
## Current Behavior

On Windows, running any cache-touching target from inside a **git worktree** with **Nx Cloud enabled** crashes after the tasks themselves have already succeeded:

```
 NX   Successfully ran target build for 3 projects

 NX   EISDIR: illegal operation on a directory, lstat 'C:'

Error: EISDIR: illegal operation on a directory, lstat 'C:'
    at Object.realpathSync (node:fs:2729:25)
    at toRealPath (node:internal/modules/helpers:65:13)
    at tryFile (node:internal/modules/cjs/loader:589:10)
    at tryPackage (node:internal/modules/cjs/loader:548:16)
    at Module._findPath (node:internal/modules/cjs/loader:823:18)
    at Module._resolveFilename (node:internal/modules/cjs/loader:1487:27)
```

This is a regression introduced in 22.7 and still present on 23.1.1. It makes Nx Cloud effectively unusable on Windows for anyone working in a worktree. The only workarounds are `NX_NO_CLOUD=true` or setting `NX_CACHE_DIRECTORY` by hand.

### Root cause

22.7 added worktree-shared caching, which routed `cacheDir` through `getMainWorktreeRoot`. That function resolves the main repo root with Rust's `std::fs::canonicalize` — which on Windows **always** returns a verbatim (extended-length) path:

```
\\?\C:\Users\Viktor\work\nx_test\nx_issue_demo\org
```

`path.win32.join` treats the device namespace as opaque and preserves that prefix, so it survives all the way down:

```
get_main_worktree_root  ->  cacheDir  ->  join(cacheDir, 'cloud')  ->  require(fullPath)
     (worktree.rs)         (cache-directory.ts)   (nx-cloud/update-manager.ts:185)   (:98, :114, :139, :155)
```

Node's CJS resolver does not recognize the drive boundary in `\\?\C:\`, so `Module._nodeModulePaths` walks *past* the filesystem root and ends up calling `realpathSync('C:')` — hence `EISDIR`.

The underlying defect is a long-standing Node bug ([nodejs/node#60438](https://github.com/nodejs/node/pull/60438), open for months; see also [#60435](https://github.com/nodejs/node/issues/60435), [#61165](https://github.com/nodejs/node/issues/61165)). Rather than wait on it, Nx should stop emitting the path form Node mishandles.

## Expected Behavior

Targets run normally in a worktree with Nx Cloud enabled.

`get_main_worktree_root` now canonicalizes via [`dunce`](https://lib.rs/crates/dunce) instead of `std`:

```rust
let abs_path = dunce::canonicalize(&abs_path).unwrap_or(abs_path);
```

`dunce` was already a dependency of the crate and already used elsewhere in the native code (`watch_filterer.rs`), so this adds nothing new to the dependency tree.

Importantly, this is **not** a blind prefix strip. `dunce` removes the `\\?\` prefix only when the result is still a valid Win32 path, and deliberately keeps it otherwise — so `\\?\UNC\server\share` is not mangled into a broken relative path, and paths that genuinely require the prefix are left intact.

This also adds the first tests for `resolve_main_worktree_root`, which previously had none: one covering the main-repo case, one covering resolution from a linked worktree plus the absence of a verbatim prefix.

### Notes for reviewers

Two limitations worth knowing, both deliberate:

1. **`dunce` keeps the prefix when the path exceeds 260 characters or contains a reserved DOS name** (`CON`, `NUL`, `COM1`…). Those workspaces will still hit this crash. There is no clean fix on the Nx side — such a path genuinely needs the prefix to work with Win32 APIs — so the residual case is left to the upstream Node fix.

2. **The new tests cannot fail in CI.** `dunce::canonicalize` is identical to `std::fs::canonicalize` on non-Windows, and `test-native` (`cargo test`, reached via `test` → `dependsOn: ["test-native", ...]`) runs on Linux only — there is no Windows Rust job. I verified this by reverting the fix locally and confirming the tests still passed on macOS. They add real first-time coverage of worktree resolution and document the constraint, but they are not a regression guard for this platform. **A Windows canary would be valuable before merge** — several people on the issue offered to test a fix.

## Related Issue(s)

Fixes #35637

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Fix-Windows-UNC-path-crash-in-Nx-Cloud-worktrees-nx35637-ac64aa6c">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->