### PR TITLE
fix(expo): derive metro projectRoot and node_modules from the app being bundled

### DIFF
--- a/e2e/expo/src/expo.test.ts
+++ b/e2e/expo/src/expo.test.ts
@@ -1,4 +1,5 @@
 import { ChildProcess } from 'child_process';
+import { renameSync } from 'fs';
 import {
   runCLI,
   cleanupProject,
@@ -13,7 +14,10 @@ import {
   runE2ETests,
   killPorts,
   createFile,
+  exists,
   removeFile,
+  runCommand,
+  tmpProjPath,
   reservePort,
 } from '@nx/e2e-utils';
 import { join } from 'path';
@@ -147,6 +151,124 @@ describe('@nx/expo', () => {
     // port and process cleanup
     if (process && process.pid) {
       await killProcessAndPorts(process.pid, port);
+    }
+  });
+
+  it('should derive metro projectRoot and node_modules from the app being bundled', () => {
+    createFile(
+      'check-metro.js',
+      `const { realpathSync } = require('fs');
+const { join, resolve } = require('path');
+const config = require(join(process.cwd(), process.argv[2], 'metro.config.js'));
+console.log(
+  'METRO_CHECK ' +
+    JSON.stringify({
+      projectRoot: config.projectRoot,
+      nodeModulesPaths: config.resolver.nodeModulesPaths,
+      processExpoMetro: require.resolve('@expo/metro/metro-config'),
+      appRoot: realpathSync(resolve(process.argv[2])),
+      workspaceRoot: realpathSync(resolve('.')),
+      workspaceNodeModules: realpathSync(resolve('node_modules')),
+    })
+);
+`
+    );
+    const readMergedConfig = () => {
+      const output = runCommand(`node check-metro.js ${appName}`, {
+        failOnError: true,
+      });
+      return JSON.parse(output.match(/METRO_CHECK (.*)/)[1]);
+    };
+    const hadAppNodeModules = exists(
+      tmpProjPath(join(appName, 'node_modules'))
+    );
+
+    try {
+      // SDK 55+ app keeps its own projectRoot
+      let config = readMergedConfig();
+      expect(config.projectRoot).toBe(config.appRoot);
+      expect(config.nodeModulesPaths).toContain(config.workspaceNodeModules);
+
+      // an app pinning its own expo copy stays anchored at the app
+      createFile(
+        `${appName}/node_modules/expo/package.json`,
+        JSON.stringify({ name: 'expo', version: '54.0.0' })
+      );
+      // shim the subpath metro.config.js requires so the pinned copy still
+      // loads the real implementation
+      createFile(
+        `${appName}/node_modules/expo/metro-config.js`,
+        `module.exports = require(require('path').join(__dirname, '..', '..', '..', 'node_modules', 'expo', 'metro-config'));`
+      );
+      config = readMergedConfig();
+      expect(config.projectRoot).toBe(config.appRoot);
+      expect(config.nodeModulesPaths[0]).toBe(
+        join(config.appRoot, 'node_modules')
+      );
+
+      // an SDK 54 app relying on hoisted Expo uses the workspace root even
+      // when a sibling app keeps @expo/metro process-resolvable
+      removeFile(join(appName, 'node_modules', 'expo'));
+      const hoistedExpoPackage = readJson('node_modules/expo/package.json');
+      try {
+        updateFile(
+          'node_modules/expo/package.json',
+          JSON.stringify({ ...hoistedExpoPackage, version: '54.0.0' })
+        );
+        config = readMergedConfig();
+        expect(config.processExpoMetro).toBeDefined();
+        expect(config.projectRoot).toBe(config.workspaceRoot);
+      } finally {
+        updateFile(
+          'node_modules/expo/package.json',
+          JSON.stringify(hoistedExpoPackage)
+        );
+      }
+
+      // no hoisted expo at all: the app-local copy is the only one, so the
+      // app keeps its projectRoot. The workspace expo is hidden while probing,
+      // so call withNxMetro directly - the app's metro.config.js cannot load
+      // without the hoisted @expo/metro-config resolving expo.
+      createFile(
+        `${appName}/node_modules/expo/package.json`,
+        JSON.stringify({ name: 'expo', version: '54.0.0' })
+      );
+      createFile(
+        'check-metro-direct.js',
+        `const { realpathSync } = require('fs');
+const { resolve } = require('path');
+const { withNxMetro } = require('@nx/expo');
+const appRoot = realpathSync(resolve(process.argv[2]));
+const config = withNxMetro({
+  projectRoot: appRoot,
+  resolver: {},
+  transformer: { babelTransformerPath: 'babel-transformer' },
+});
+console.log(
+  'METRO_CHECK ' + JSON.stringify({ projectRoot: config.projectRoot, appRoot })
+);
+`
+      );
+      const wsExpo = tmpProjPath(join('node_modules', 'expo'));
+      const wsExpoHidden = tmpProjPath(join('node_modules', '.expo-hidden'));
+      renameSync(wsExpo, wsExpoHidden);
+      try {
+        const output = runCommand(`node check-metro-direct.js ${appName}`, {
+          failOnError: true,
+        });
+        config = JSON.parse(output.match(/METRO_CHECK (.*)/)[1]);
+        expect(config.projectRoot).toBe(config.appRoot);
+      } finally {
+        renameSync(wsExpoHidden, wsExpo);
+        removeFile('check-metro-direct.js');
+      }
+    } finally {
+      // remove only what this test created
+      removeFile(join(appName, 'node_modules', 'expo'));
+      if (!hadAppNodeModules) {
+        removeFile(join(appName, 'node_modules'));
+      }
+      removeFile('check-metro.js');
     }
   });
 

--- a/packages/expo/eslint.config.mjs
+++ b/packages/expo/eslint.config.mjs
@@ -41,6 +41,10 @@ export default [
             '@expo/cli',
             'eas-cli',
             'util',
+            // resolved dynamically (per-app) in plugins/with-nx-metro.ts and
+            // plugins/metro-resolver.ts
+            'metro-config',
+            'metro-resolver',
           ],
         },
       ],

--- a/packages/expo/plugins/metro-resolver.ts
+++ b/packages/expo/plugins/metro-resolver.ts
@@ -7,30 +7,32 @@ import { dirname, join } from 'path';
 import * as fs from 'fs';
 import { workspaceRoot } from '@nx/devkit';
 
-// Cache for metro-resolver module
-let metroResolver: any = null;
+const metroResolverCache = new Map<string, any>();
 
-/**
- * Lazily require the Metro resolver.
- *
- * Expo SDK 55+ ships Metro through `@expo/metro`, so the resolver must come
- * from the same Metro instance Expo uses. Older SDKs (53/54) use the standalone
- * `metro-resolver` package. We prefer `@expo/metro` and fall back to the
- * standalone package to stay compatible with both.
- */
-function getMetroResolver() {
+// The resolver must come from the same Metro instance Expo uses: `@expo/metro`
+// on SDK 55+, standalone `metro-resolver` on 53/54. Resolve from the app root
+// so each app gets its own SDK's copy.
+function getMetroResolver(appRoot: string | undefined, usesExpoMetro: boolean) {
+  const cacheKey = `${appRoot ?? ''}|${usesExpoMetro}`;
+  let metroResolver = metroResolverCache.get(cacheKey);
   if (!metroResolver) {
-    try {
-      metroResolver = require('@expo/metro/metro-resolver');
-    } catch {
+    const candidates = usesExpoMetro
+      ? ['@expo/metro/metro-resolver', 'metro-resolver']
+      : ['metro-resolver', '@expo/metro/metro-resolver'];
+    for (const candidate of candidates) {
       try {
-        metroResolver = require('metro-resolver');
-      } catch (error) {
-        throw new Error(
-          'Unable to load Metro resolver. Install `@expo/metro` (Expo SDK 55+) or `metro-resolver` (>= 0.82.0).'
+        metroResolver = require(
+          require.resolve(candidate, appRoot ? { paths: [appRoot] } : undefined)
         );
-      }
+        break;
+      } catch {}
     }
+    if (!metroResolver) {
+      throw new Error(
+        'Unable to load Metro resolver. Install `@expo/metro` (Expo SDK 55+) or `metro-resolver` (>= 0.82.0).'
+      );
+    }
+    metroResolverCache.set(cacheKey, metroResolver);
   }
   return metroResolver;
 }
@@ -44,7 +46,11 @@ function getMetroResolver() {
 export function getResolveRequest(
   extensions: string[],
   exportsConditionNames: string[] = [],
-  mainFields: string[] = []
+  mainFields: string[] = [],
+  // which app is being bundled; default keeps the process-wide preference
+  anchor: { appRoot?: string; usesExpoMetro: boolean } = {
+    usesExpoMetro: true,
+  }
 ) {
   return function (
     _context: any,
@@ -63,13 +69,14 @@ export function getResolveRequest(
         platform,
         debug
       ) ??
-      defaultMetroResolver(context, realModuleName, platform, debug) ??
+      defaultMetroResolver(context, realModuleName, platform, debug, anchor) ??
       tsconfigPathsResolver(
         context,
         extensions,
         realModuleName,
         platform,
-        debug
+        debug,
+        anchor
       ) ??
       pnpmResolver(
         extensions,
@@ -118,10 +125,11 @@ function defaultMetroResolver(
   context: any,
   realModuleName: string,
   platform: string | null,
-  debug: boolean
+  debug: boolean,
+  anchor: { appRoot?: string; usesExpoMetro: boolean }
 ) {
   try {
-    const resolver = getMetroResolver();
+    const resolver = getMetroResolver(anchor.appRoot, anchor.usesExpoMetro);
     return resolver.resolve(context, realModuleName, platform);
   } catch {
     if (debug)
@@ -187,7 +195,8 @@ function tsconfigPathsResolver(
   extensions: string[],
   realModuleName: string,
   platform: string | null,
-  debug: boolean
+  debug: boolean,
+  anchor: { appRoot?: string; usesExpoMetro: boolean }
 ) {
   try {
     const tsConfigPathMatcher = getMatcher(debug);
@@ -197,7 +206,7 @@ function tsconfigPathsResolver(
       undefined,
       extensions.map((ext) => `.${ext}`)
     );
-    const resolver = getMetroResolver();
+    const resolver = getMetroResolver(anchor.appRoot, anchor.usesExpoMetro);
     return resolver.resolve(context, match, platform);
   } catch {
     if (debug) {

--- a/packages/expo/plugins/with-nx-metro.spec.ts
+++ b/packages/expo/plugins/with-nx-metro.spec.ts
@@ -1,0 +1,128 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+
+describe('withNxMetro', () => {
+  let testWorkspaceRoot: string;
+
+  beforeEach(() => {
+    testWorkspaceRoot = mkdtempSync(join(tmpdir(), 'nx-expo-metro-'));
+  });
+
+  afterEach(() => {
+    jest.dontMock('@nx/devkit');
+    jest.resetModules();
+    rmSync(testWorkspaceRoot, { recursive: true, force: true });
+  });
+
+  it('keeps Metro config and resolver families separate across apps', () => {
+    const legacyAppRoot = join(testWorkspaceRoot, 'apps', 'legacy');
+    const modernAppRoot = join(testWorkspaceRoot, 'apps', 'modern');
+    mkdirSync(join(legacyAppRoot, 'node_modules'), { recursive: true });
+    mkdirSync(modernAppRoot, { recursive: true });
+
+    createPackage(testWorkspaceRoot, 'expo', '54.0.0');
+    createPackage(testWorkspaceRoot, 'metro-config', '0.82.0', {
+      'index.js': metroConfigModule('standalone-54'),
+    });
+    createPackage(testWorkspaceRoot, 'metro-resolver', '0.82.0', {
+      'index.js': metroResolverModule('standalone-54'),
+    });
+    createPackage(testWorkspaceRoot, '@expo/metro', '57.0.0', {
+      'metro-config.js': metroConfigModule('hoisted-expo-metro'),
+      'metro-resolver.js': metroResolverModule('hoisted-expo-metro'),
+    });
+
+    createPackage(modernAppRoot, 'expo', '57.0.0');
+    createPackage(modernAppRoot, '@expo/metro', '57.0.0', {
+      'metro-config.js': metroConfigModule('expo-57'),
+      'metro-resolver.js': metroResolverModule('expo-57'),
+    });
+
+    jest.resetModules();
+    jest.doMock('@nx/devkit', () => ({ workspaceRoot: testWorkspaceRoot }));
+    const { withNxMetro } =
+      require('./with-nx-metro') as typeof import('./with-nx-metro');
+
+    const legacyConfig = withNxMetro({
+      projectRoot: legacyAppRoot,
+      resolver: {},
+    });
+    const modernConfig = withNxMetro({
+      projectRoot: modernAppRoot,
+      resolver: {},
+    });
+    const legacyConfigAgain = withNxMetro({
+      projectRoot: legacyAppRoot,
+      resolver: {},
+    });
+
+    expect(legacyConfig.projectRoot).toBe(testWorkspaceRoot);
+    expect(modernConfig.projectRoot).toBe(modernAppRoot);
+    expect(legacyConfig.metroConfigFamily).toBe('standalone-54');
+    expect(modernConfig.metroConfigFamily).toBe('expo-57');
+    expect(legacyConfigAgain.metroConfigFamily).toBe('standalone-54');
+    expect(resolveWith(legacyConfig, legacyAppRoot)).toEqual({
+      type: 'sourceFile',
+      filePath: 'standalone-54:fixture-module',
+    });
+    expect(resolveWith(modernConfig, modernAppRoot)).toEqual({
+      type: 'sourceFile',
+      filePath: 'expo-57:fixture-module',
+    });
+    expect(resolveWith(legacyConfigAgain, legacyAppRoot)).toEqual({
+      type: 'sourceFile',
+      filePath: 'standalone-54:fixture-module',
+    });
+  });
+});
+
+function createPackage(
+  root: string,
+  name: string,
+  version: string,
+  files: Record<string, string> = {}
+) {
+  const packageRoot = join(root, 'node_modules', ...name.split('/'));
+  mkdirSync(packageRoot, { recursive: true });
+  writeFileSync(
+    join(packageRoot, 'package.json'),
+    JSON.stringify({ name, version })
+  );
+  for (const [file, contents] of Object.entries(files)) {
+    writeFileSync(join(packageRoot, file), contents);
+  }
+}
+
+function metroConfigModule(family: string) {
+  return `module.exports = {
+  mergeConfig(userConfig, nxConfig) {
+    return {
+      ...userConfig,
+      ...nxConfig,
+      resolver: { ...userConfig.resolver, ...nxConfig.resolver },
+      metroConfigFamily: ${JSON.stringify(family)},
+    };
+  },
+};`;
+}
+
+function metroResolverModule(family: string) {
+  return `exports.resolve = (_context, moduleName) => ({
+  type: 'sourceFile',
+  filePath: ${JSON.stringify(family)} + ':' + moduleName,
+});`;
+}
+
+function resolveWith(config: any, appRoot: string) {
+  return config.resolver.resolveRequest(
+    {
+      originModulePath: join(appRoot, 'index.js'),
+      resolveRequest() {
+        throw new Error('Use the Metro resolver');
+      },
+    },
+    'fixture-module',
+    'ios'
+  );
+}

--- a/packages/expo/plugins/with-nx-metro.ts
+++ b/packages/expo/plugins/with-nx-metro.ts
@@ -1,34 +1,67 @@
 import { workspaceRoot } from '@nx/devkit';
-import { existsSync, readdirSync, statSync } from 'node:fs';
+import { existsSync, readdirSync, realpathSync, statSync } from 'node:fs';
 import { join } from 'path';
 
-// Cache for metro-config module
-let metroConfig: any = null;
+const metroConfigCache = new Map<string, any>();
 
-/**
- * Lazily require the Metro config helpers.
- *
- * Expo SDK 55+ ships Metro through the `@expo/metro` package family, so the
- * `mergeConfig` used here must come from the same Metro instance that
- * `@expo/metro-config`'s `getDefaultConfig` is built against. Older SDKs
- * (53/54) use the standalone `metro-config` package. We prefer `@expo/metro`
- * and fall back to the standalone package to stay compatible with both.
- */
-function getMetroConfig() {
+// `mergeConfig` must come from the same Metro instance as the app's
+// `getDefaultConfig`: `@expo/metro` on SDK 55+, standalone `metro-config` on
+// 53/54. Resolve from the app root so each app gets its own SDK's copy.
+function getMetroConfig(appRoot: string | undefined, usesExpoMetro: boolean) {
+  const cacheKey = `${appRoot ?? ''}|${usesExpoMetro}`;
+  let metroConfig = metroConfigCache.get(cacheKey);
   if (!metroConfig) {
-    try {
-      metroConfig = require('@expo/metro/metro-config');
-    } catch {
+    const candidates = usesExpoMetro
+      ? ['@expo/metro/metro-config', 'metro-config']
+      : ['metro-config', '@expo/metro/metro-config'];
+    for (const candidate of candidates) {
       try {
-        metroConfig = require('metro-config');
-      } catch (error) {
-        throw new Error(
-          'Unable to load Metro config. Install `@expo/metro` (Expo SDK 55+) or `metro-config` (>= 0.82.0).'
+        metroConfig = require(
+          require.resolve(candidate, appRoot ? { paths: [appRoot] } : undefined)
         );
-      }
+        break;
+      } catch {}
     }
+    if (!metroConfig) {
+      throw new Error(
+        'Unable to load Metro config. Install `@expo/metro` (Expo SDK 55+) or `metro-config` (>= 0.82.0).'
+      );
+    }
+    metroConfigCache.set(cacheKey, metroConfig);
   }
   return metroConfig;
+}
+
+// SDK 55+ ships Metro through `@expo/metro`. Resolve `expo` from the app's
+// own root: probing from this plugin's location reads whichever copy is
+// hoisted, which can belong to a sibling app on a different SDK.
+export function appUsesExpoMetro(appRoot: string | undefined): boolean {
+  try {
+    const expoPkgPath = require.resolve(
+      'expo/package.json',
+      appRoot ? { paths: [appRoot] } : undefined
+    );
+    return parseInt(require(expoPkgPath).version, 10) >= 55;
+  } catch {
+    // expo not resolvable; probe `@expo/metro` process-wide (no root entry
+    // point, so resolve a known subpath)
+    try {
+      require.resolve('@expo/metro/metro-config');
+      return true;
+    } catch {
+      return false;
+    }
+  }
+}
+
+function appOwnsExpo(appNodeModules: string): boolean {
+  const appExpo = join(appNodeModules, 'expo');
+  if (!existsSync(appExpo)) return false;
+  const hoistedExpo = join(workspaceRoot, 'node_modules', 'expo');
+  // no hoisted copy: the app-local one is the only expo, and Expo's HMR
+  // rewrite resolves strictly from `projectRoot`, so anchor at the app
+  if (!existsSync(hoistedExpo)) return true;
+  return realpathSync(appExpo) !== realpathSync(hoistedExpo);
 }
 
 type MetroConfig = any; // We'll use any to avoid importing the type
@@ -83,35 +116,38 @@ export function withNxMetro(userConfig: MetroConfig, opts: WithNxOptions = {}) {
     existsSync(folder)
   );
 
-  // Expo SDK 55+ ships Metro via `@expo/metro` and resolves the project's
-  // Babel config relative to `projectRoot`. Forcing `projectRoot` to the
-  // workspace root breaks that lookup, because the app's `.babelrc.js` lives in
-  // the project directory, not the workspace root (Metro's babel transformer
-  // does `path.resolve(projectRoot, '.babelrc.js')`). So only override
-  // `projectRoot` for older SDKs (53/54). Workspace libraries remain resolvable
-  // via `watchFolders`, `nodeModulesPaths`, and the custom `resolveRequest`.
-  // `@expo/metro` has no root entry point (only subpath exports), so resolve a
-  // known subpath to detect it — `require.resolve('@expo/metro')` would throw
-  // ERR_PACKAGE_PATH_NOT_EXPORTED even when the package is installed.
-  let usesExpoMetro = false;
-  try {
-    require.resolve('@expo/metro/metro-config');
-    usesExpoMetro = true;
-  } catch {}
+  // `getDefaultConfig(__dirname)` set this to the app directory
+  const appRoot: string | undefined = userConfig.projectRoot;
+  const usesExpoMetro = appUsesExpoMetro(appRoot);
 
+  const appNodeModules = appRoot ? join(appRoot, 'node_modules') : null;
+  const hasAppNodeModules = !!appNodeModules && existsSync(appNodeModules);
+  // an app pinning its own `expo` must stay anchored at the app, or the
+  // bundle picks up the hoisted copy alongside its own. Compare real paths:
+  // `ensureNodeModulesSymlink` links the whole app node_modules to the
+  // workspace's, which is not an app-owned copy.
+  const ownsExpo = hasAppNodeModules && appOwnsExpo(appNodeModules);
+
+  // SDK 55+ resolves Babel config and the HMR client relative to
+  // `projectRoot`; SDK 53/54 apps relying on hoisted Expo need the workspace
+  // root so `originModulePath` stays workspace-relative for the Nx resolver.
   const nxConfig: MetroConfig = {
-    ...(usesExpoMetro ? {} : { projectRoot: workspaceRoot }),
+    ...(usesExpoMetro || ownsExpo ? {} : { projectRoot: workspaceRoot }),
     resolver: {
       resolveRequest: getResolveRequest(
         extensions,
         opts.exportsConditionNames,
-        opts.mainFields
+        opts.mainFields,
+        { appRoot, usesExpoMetro }
       ),
-      nodeModulesPaths: [join(workspaceRoot, 'node_modules')],
+      nodeModulesPaths: [
+        ...(hasAppNodeModules ? [appNodeModules] : []),
+        join(workspaceRoot, 'node_modules'),
+      ],
     },
     watchFolders,
   };
 
-  const { mergeConfig } = getMetroConfig();
+  const { mergeConfig } = getMetroConfig(appRoot, usesExpoMetro);
   return mergeConfig(userConfig, nxConfig);
 }


### PR DESCRIPTION
## Current Behavior

`withNxMetro` probes `@expo/metro` from the plugin's own location, so the hoisted copy answers for every app in the workspace. In a mixed-SDK workspace an app pinning its own Expo SDK bundles two copies of `expo` (redbox at `hmr.ts`), and an SDK 53/54 app loses its workspace-root `projectRoot` when a sibling app hoists `@expo/metro`.

## Expected Behavior

Expo SDK is detected per app by resolving `expo` from the wrapped config's `projectRoot`. SDK 55+ apps and apps that pin their own `expo` copy keep their `projectRoot`; SDK 53/54 apps still get `projectRoot: workspaceRoot`, and `nodeModulesPaths` lists the app's own `node_modules` first.

## Related Issue(s)

NXC-4793

Fixes #36531
