### PR TITLE
fix(core): run the nx exec re-invocation from the workspace root

### DIFF
--- a/packages/nx/src/command-line/exec/exec.spec.ts
+++ b/packages/nx/src/command-line/exec/exec.spec.ts
@@ -34,6 +34,7 @@ import { execSync } from 'child_process';
 import { existsSync } from 'fs';
 import { calculateDefaultProjectName } from '../../config/calculate-default-project-name';
 import { ProjectGraph } from '../../config/project-graph';
+import { withEnvironmentVariables } from '../../internal-testing-utils/with-environment';
 import { createProjectGraphAsync } from '../../project-graph/project-graph';
 import { splitArgsIntoNxArgsAndOverrides } from '../../utils/command-line-utils';
 import { readJsonFile } from '../../utils/fileutils';
@@ -44,6 +45,10 @@ import {
 } from '../../utils/package-manager';
 import { nxExecCommand } from './exec';
 
+// A package script that calls `nx exec` runs with the project directory as its
+// cwd, so the re-invocation nx builds has to name the workspace root itself
+// rather than inherit that cwd — both for the package manager it picks and for
+// the directory it spawns in.
 describe('nx exec', () => {
   const projectGraph: ProjectGraph = {
     nodes: {
@@ -59,20 +64,20 @@ describe('nx exec', () => {
     dependencies: {},
   };
 
-  let originalArgv: string[];
-  let originalLifecycleEvent: string | undefined;
-  let originalTargetProject: string | undefined;
+  // `npm_lifecycle_event` is the package script nx was invoked from, and an
+  // unset NX_TASK_TARGET_PROJECT is what tells nx it is not already running
+  // inside a task, so it re-invokes itself for that script's project.
+  const packageScriptEnv = {
+    npm_lifecycle_event: 'hello',
+    NX_TASK_TARGET_PROJECT: undefined,
+  };
+
+  const originalArgv = process.argv;
 
   beforeEach(() => {
     jest.clearAllMocks();
 
-    originalArgv = process.argv;
-    originalLifecycleEvent = process.env.npm_lifecycle_event;
-    originalTargetProject = process.env.NX_TASK_TARGET_PROJECT;
-
     process.argv = ['node', 'nx', 'exec', '--', 'echo', 'hi'];
-    process.env.npm_lifecycle_event = 'hello';
-    delete process.env.NX_TASK_TARGET_PROJECT;
 
     (createProjectGraphAsync as jest.Mock).mockResolvedValue(projectGraph);
     (splitArgsIntoNxArgsAndOverrides as jest.Mock).mockReturnValue({
@@ -92,27 +97,17 @@ describe('nx exec', () => {
 
   afterEach(() => {
     process.argv = originalArgv;
-    if (originalLifecycleEvent === undefined) {
-      delete process.env.npm_lifecycle_event;
-    } else {
-      process.env.npm_lifecycle_event = originalLifecycleEvent;
-    }
-    if (originalTargetProject === undefined) {
-      delete process.env.NX_TASK_TARGET_PROJECT;
-    } else {
-      process.env.NX_TASK_TARGET_PROJECT = originalTargetProject;
-    }
   });
 
   it('should detect the package manager from the workspace root', async () => {
-    await nxExecCommand({});
+    await withEnvironmentVariables(packageScriptEnv, () => nxExecCommand({}));
 
     expect(detectPackageManager).toHaveBeenCalledWith('/root');
     expect(getPackageManagerCommand).toHaveBeenCalledWith('yarn');
   });
 
   it('should run the nx target from the workspace root', async () => {
-    await nxExecCommand({});
+    await withEnvironmentVariables(packageScriptEnv, () => nxExecCommand({}));
 
     expect(execSync).toHaveBeenCalledWith(
       expect.stringContaining('yarn nx run child:'),

--- a/packages/nx/src/command-line/exec/exec.spec.ts
+++ b/packages/nx/src/command-line/exec/exec.spec.ts
@@ -1,0 +1,122 @@
+jest.mock('child_process', () => ({
+  ...jest.requireActual('child_process'),
+  execSync: jest.fn(),
+}));
+jest.mock('fs', () => ({
+  ...jest.requireActual('fs'),
+  existsSync: jest.fn(),
+}));
+jest.mock('../../config/calculate-default-project-name', () => ({
+  calculateDefaultProjectName: jest.fn(),
+}));
+jest.mock('../../config/configuration', () => ({
+  readNxJson: jest.fn(() => ({})),
+}));
+jest.mock('../../project-graph/project-graph', () => ({
+  createProjectGraphAsync: jest.fn(),
+  readProjectsConfigurationFromProjectGraph: jest.fn(() => ({ projects: {} })),
+}));
+jest.mock('../../utils/command-line-utils', () => ({
+  splitArgsIntoNxArgsAndOverrides: jest.fn(),
+}));
+jest.mock('../../utils/fileutils', () => ({
+  readJsonFile: jest.fn(),
+}));
+jest.mock('../../utils/package-manager', () => ({
+  detectPackageManager: jest.fn(),
+  getPackageManagerCommand: jest.fn(),
+}));
+jest.mock('../../utils/workspace-root', () => ({
+  workspaceRoot: '/root',
+}));
+
+import { execSync } from 'child_process';
+import { existsSync } from 'fs';
+import { calculateDefaultProjectName } from '../../config/calculate-default-project-name';
+import { ProjectGraph } from '../../config/project-graph';
+import { createProjectGraphAsync } from '../../project-graph/project-graph';
+import { splitArgsIntoNxArgsAndOverrides } from '../../utils/command-line-utils';
+import { readJsonFile } from '../../utils/fileutils';
+import {
+  detectPackageManager,
+  getPackageManagerCommand,
+  type PackageManagerCommands,
+} from '../../utils/package-manager';
+import { nxExecCommand } from './exec';
+
+describe('nx exec', () => {
+  const projectGraph: ProjectGraph = {
+    nodes: {
+      child: {
+        name: 'child',
+        type: 'lib',
+        data: {
+          root: 'packages/child',
+          targets: { hello: {} },
+        },
+      },
+    },
+    dependencies: {},
+  };
+
+  let originalArgv: string[];
+  let originalLifecycleEvent: string | undefined;
+  let originalTargetProject: string | undefined;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    originalArgv = process.argv;
+    originalLifecycleEvent = process.env.npm_lifecycle_event;
+    originalTargetProject = process.env.NX_TASK_TARGET_PROJECT;
+
+    process.argv = ['node', 'nx', 'exec', '--', 'echo', 'hi'];
+    process.env.npm_lifecycle_event = 'hello';
+    delete process.env.NX_TASK_TARGET_PROJECT;
+
+    (createProjectGraphAsync as jest.Mock).mockResolvedValue(projectGraph);
+    (splitArgsIntoNxArgsAndOverrides as jest.Mock).mockReturnValue({
+      nxArgs: {},
+      overrides: { __overrides_unparsed__: ['echo', 'hi'] },
+    });
+    (calculateDefaultProjectName as jest.Mock).mockReturnValue('child');
+    (existsSync as jest.Mock).mockReturnValue(true);
+    (readJsonFile as jest.Mock).mockReturnValue({
+      scripts: { hello: 'nx exec -- echo hi' },
+    });
+    (detectPackageManager as jest.Mock).mockReturnValue('yarn');
+    (getPackageManagerCommand as jest.Mock).mockReturnValue({
+      exec: 'yarn',
+    } as PackageManagerCommands);
+  });
+
+  afterEach(() => {
+    process.argv = originalArgv;
+    if (originalLifecycleEvent === undefined) {
+      delete process.env.npm_lifecycle_event;
+    } else {
+      process.env.npm_lifecycle_event = originalLifecycleEvent;
+    }
+    if (originalTargetProject === undefined) {
+      delete process.env.NX_TASK_TARGET_PROJECT;
+    } else {
+      process.env.NX_TASK_TARGET_PROJECT = originalTargetProject;
+    }
+  });
+
+  it('should detect the package manager from the workspace root', async () => {
+    await nxExecCommand({});
+
+    expect(detectPackageManager).toHaveBeenCalledWith('/root');
+    expect(getPackageManagerCommand).toHaveBeenCalledWith('yarn');
+  });
+
+  it('should run the nx target from the workspace root', async () => {
+    await nxExecCommand({});
+
+    expect(execSync).toHaveBeenCalledWith(
+      expect.stringContaining('yarn nx run child:'),
+      expect.objectContaining({ cwd: '/root' })
+    );
+  });
+});

--- a/packages/nx/src/command-line/exec/exec.ts
+++ b/packages/nx/src/command-line/exec/exec.ts
@@ -22,7 +22,10 @@ import {
 import { readJsonFile } from '../../utils/fileutils';
 import { output } from '../../utils/output';
 import { PackageJson } from '../../utils/package-json';
-import { getPackageManagerCommand } from '../../utils/package-manager';
+import {
+  detectPackageManager,
+  getPackageManagerCommand,
+} from '../../utils/package-manager';
 import { workspaceRoot } from '../../utils/workspace-root';
 import { joinPathFragments } from '../../utils/path';
 import { calculateDefaultProjectName } from '../../config/calculate-default-project-name';
@@ -124,14 +127,14 @@ function runTargetOnProject(
   const extraArgs =
     providedArgs.length === argv.length ? [] : argv.slice(providedArgs.length);
 
-  const pm = getPackageManagerCommand();
+  const pm = getPackageManagerCommand(detectPackageManager(workspaceRoot));
   // `targetName` might be an npm script with `:` like: `start:dev`, `start:debug`.
   const command = `${
     pm.exec
   } nx run ${projectName}:\\\"${targetName}\\\" ${extraArgs.join(' ')}`;
   execSync(command, {
     stdio: 'inherit',
-
+    cwd: workspaceRoot,
     windowsHide: true,
   });
 }


### PR DESCRIPTION
## Current Behavior

`runTargetOnProject` re-invokes Nx as `<pm> nx run <project>:"<target>"`. It resolves both the package manager and the working directory from the current directory instead of the workspace root:

- It calls [`execSync` without a `cwd`](https://github.com/nrwl/nx/blob/7e5b452eb771d66097a1aae4192b31d9a2158789/packages/nx/src/command-line/exec/exec.ts#L132-L136), so the re-invocation inherits the directory that the wrapping package script started in.
- It calls [`getPackageManagerCommand()` with no arguments](https://github.com/nrwl/nx/blob/7e5b452eb771d66097a1aae4192b31d9a2158789/packages/nx/src/command-line/exec/exec.ts#L127). The `root` parameter already defaults to `workspaceRoot`, but the first parameter defaults to `detectPackageManager()`, whose [`dir` defaults to `''`](https://github.com/nrwl/nx/blob/7e5b452eb771d66097a1aae4192b31d9a2158789/packages/nx/src/utils/package-manager.ts#L62-L76). The lock file probe therefore runs against the cwd and falls back to `npm_config_user_agent`.

The failure appears in a Yarn Berry monorepo where `nx` is a devDependency of the root workspace only. Run a package script that wraps `nx exec` from a workspace subdirectory. `nx exec` then produces `yarn nx run <project>:"<target>"` inside that subdirectory. Berry resolves binaries per workspace, so the command fails with `Couldn't find a script named "nx".` The same script works from the workspace root. Full reproduction in #36652.

The [sibling spawn in the same file](https://github.com/nrwl/nx/blob/7e5b452eb771d66097a1aae4192b31d9a2158789/packages/nx/src/command-line/exec/exec.ts#L93-L110) already passes an explicit `cwd` derived from `workspaceRoot`.

## Expected Behavior

`nx exec` spawns the re-invocation at the workspace root and detects the package manager from the workspace root. A script that wraps `nx exec` then behaves the same from any directory in the workspace.

```diff
-  const pm = getPackageManagerCommand();
+  const pm = getPackageManagerCommand(detectPackageManager(workspaceRoot));
   const command = `${pm.exec} nx run ...`;
   execSync(command, {
     stdio: 'inherit',
+    cwd: workspaceRoot,
     windowsHide: true,
   });
```

#35116 and #35550 made the same move to workspace-root detection elsewhere in the codebase. Neither reached `command-line/exec`.

Both lines are needed. I patched an installed 23.1.1 each way against the reproduction. Passing the workspace root to `detectPackageManager` alone does not fix it, because detection still returns `yarn` and `yarn nx` still runs in the child directory. `cwd: workspaceRoot` alone does fix the failure. It still leaves `nx` free to read the package manager from one directory and run it from another, so the two belong together.

The `cwd` only moves the intermediate `<pm> nx run` process. The user's script still runs in the project directory, because `nx:run-script` sets that cwd itself. I checked this by printing `process.cwd()` from the script before and after the change.

## Related Issue(s)

Fixes #36652

## Tests

`packages/nx/src/command-line/exec/exec.spec.ts` is new, because `exec.ts` had no spec. It drives `nxExecCommand` down the `runTargetOnProject` path with the module's collaborators mocked, in the style of `packages/nx/src/utils/child-process.spec.ts`. It asserts the spawn's `cwd` and the argument that `runTargetOnProject` passes to `detectPackageManager`. Both cases fail on master and pass with this change.

`runTargetOnProject` calls `execSync` directly and offers no injection seam. The spec therefore uses module mocking rather than the `createNodes` fixtures available to the plugin call sites in #35550. If you would rather see this covered differently, or covered by an e2e case instead, say which and I will redo it.
