### PR TITLE
fix(nextjs): make built next.config load without @nx/next installed

### DIFF
--- a/e2e/next/src/next-legacy.test.ts
+++ b/e2e/next/src/next-legacy.test.ts
@@ -3,9 +3,11 @@ import {
   checkFilesExist,
   cleanupProject,
   detectPackageManager,
+  fileExists,
   getPackageManagerCommand,
   isNotWindows,
   killPort,
+  listFiles,
   newProject,
   packageManagerLockFile,
   readFile,
@@ -76,6 +78,8 @@ describe('@nx/next (legacy)', () => {
     checkFilesExist(`dist/${appName}/redirects.js`);
     checkFilesExist(`dist/${appName}/nested/headers.js`);
     checkFilesExist(`dist/${appName}/nested/headers-2.js`);
+
+    checkBuildOutputIsSelfContained(`dist/${appName}`);
   }, 120_000);
 
   it('should build and install pruned lock file', async () => {
@@ -244,11 +248,7 @@ describe('@nx/next (legacy)', () => {
       `dist/packages/${appName}/public/shared/ui/hello.txt`
     );
 
-    // Check that compiled next config does not contain bad imports
-    const nextConfigPath = `dist/packages/${appName}/next.config.js`;
-    expect(nextConfigPath).not.toContain(`require("../`); // missing relative paths
-    expect(nextConfigPath).not.toContain(`require("nx/`); // dev-only packages
-    expect(nextConfigPath).not.toContain(`require("@nx/`); // dev-only packages
+    checkBuildOutputIsSelfContained(`dist/packages/${appName}`);
 
     // Check that `nx serve <app> --prod` works with previous production build (e.g. `nx build <app>`).
     const prodServePort = await reservePort();
@@ -320,3 +320,39 @@ describe('@nx/next (legacy)', () => {
     );
   }, 300_000);
 });
+
+// The build output must run where only the app's production dependencies are
+// installed, so the rewritten next.config.js must not require dev-only packages
+// and relative requires in the copied .nx-helpers files must resolve to files
+// present in the output (nrwl/nx#36511).
+function checkBuildOutputIsSelfContained(outputPath: string): void {
+  const nextConfigContent = readFile(`${outputPath}/next.config.js`);
+  for (const badImport of ['../', 'nx/', '@nx/']) {
+    expect(nextConfigContent).not.toContain(`require("${badImport}`);
+    expect(nextConfigContent).not.toContain(`require('${badImport}`);
+  }
+
+  const helpersDir = `${outputPath}/.nx-helpers`;
+  for (const helperFile of listFiles(helpersDir).filter((f) =>
+    f.endsWith('.js')
+  )) {
+    const content = readFile(`${helpersDir}/${helperFile}`);
+    for (const match of content.matchAll(
+      /require\((?:'(\.[^']+)'|"(\.[^"]+)")\)/g
+    )) {
+      const specifier = match[1] ?? match[2];
+      const resolves = [
+        specifier,
+        `${specifier}.js`,
+        `${specifier}/index.js`,
+      ].some((candidate) =>
+        fileExists(tmpProjPath(join(helpersDir, candidate)))
+      );
+      if (!resolves) {
+        throw new Error(
+          `${helpersDir}/${helperFile} requires '${specifier}', which does not exist in the build output`
+        );
+      }
+    }
+  }
+}

--- a/packages/next/.oxlintrc.json
+++ b/packages/next/.oxlintrc.json
@@ -96,7 +96,7 @@
       }
     },
     {
-      "files": ["plugins/with-nx.ts"],
+      "files": ["plugins/with-nx.ts", "src/utils/compose-plugins.ts"],
       "rules": {
         "no-restricted-imports": [
           "error",

--- a/packages/next/.oxlintrc.json
+++ b/packages/next/.oxlintrc.json
@@ -111,6 +111,14 @@
                 "message": "Please default to native fetch instead of 'node-fetch'."
               },
               {
+                "name": "chalk",
+                "message": "Please use `picocolors` in place of `chalk` for rendering terminal colors"
+              },
+              {
+                "name": "fs-extra",
+                "message": "Please use native functionality in place of `fs-extra` for file-system interaction"
+              },
+              {
                 "name": "@nx/workspace"
               },
               {
@@ -130,7 +138,7 @@
                 "allowTypeImports": true
               },
               {
-                "group": ["./**/*"],
+                "group": [".", "..", "./**", "../**"],
                 "message": "Inline functions instead of importing relative files. Relative files are not available in dist.",
                 "allowTypeImports": true
               },
@@ -140,7 +148,7 @@
                 "allowTypeImports": true
               },
               {
-                "group": ["nx/**/*"],
+                "group": ["nx", "nx/**/*"],
                 "message": "Do not import Nx package.",
                 "allowTypeImports": true
               }

--- a/packages/next/src/utils/compose-plugins.spec.ts
+++ b/packages/next/src/utils/compose-plugins.spec.ts
@@ -29,6 +29,26 @@ describe('composePlugins', () => {
     });
   });
 
+  it('should not load the deprecation module, which is not copied into the .nx-helpers build output', async () => {
+    jest.resetModules();
+    jest.doMock('./deprecation', () => {
+      throw new Error('compose-plugins must not require ./deprecation');
+    });
+    try {
+      const {
+        composePlugins: isolatedComposePlugins,
+      } = require('./compose-plugins');
+      const { PHASE_PRODUCTION_SERVER } = require('next/constants');
+      const fn = await isolatedComposePlugins();
+      const output = await fn({ env: {} })(PHASE_PRODUCTION_SERVER, {});
+
+      expect(output).toEqual({ env: {} });
+    } finally {
+      jest.dontMock('./deprecation');
+      jest.resetModules();
+    }
+  });
+
   it('should compose plugins that return an async function', async () => {
     const nextConfig: NextConfig = {
       env: {

--- a/packages/next/src/utils/compose-plugins.ts
+++ b/packages/next/src/utils/compose-plugins.ts
@@ -4,7 +4,6 @@ import type {
   NextPlugin,
   NextPluginThatReturnsConfigFn,
 } from './config';
-import { warnComposePluginsDeprecation } from './deprecation';
 
 export function composePlugins(
   ...plugins: (NextPlugin | NextPluginThatReturnsConfigFn)[]
@@ -14,7 +13,25 @@ export function composePlugins(
       phase: string,
       context: any
     ): Promise<NextConfig> {
-      warnComposePluginsDeprecation(phase);
+      const {
+        PHASE_PRODUCTION_SERVER,
+      }: typeof import('next/constants') = require('next/constants');
+      // Copied verbatim into the build output (see create-next-config-file.ts),
+      // so this must load without @nx/next or @nx/devkit installed. Warn only on
+      // the active Nx-task path, resolved from the workspace like with-nx.ts.
+      if (
+        phase !== PHASE_PRODUCTION_SERVER &&
+        !global.NX_GRAPH_CREATION &&
+        process.env.NX_TASK_TARGET_TARGET
+      ) {
+        const { workspaceRoot } = require('@nx/devkit');
+        const { warnComposePluginsDeprecation } = require(
+          require.resolve('@nx/next/src/utils/deprecation', {
+            paths: [workspaceRoot],
+          })
+        ) as typeof import('./deprecation');
+        warnComposePluginsDeprecation(phase);
+      }
       let config = baseConfig;
       for (const plugin of plugins) {
         const fn = await plugin;


### PR DESCRIPTION
## Current Behavior

Since `@nx/next@23.0.0`, an app built with the `@nx/next:build` executor crashes at `next start` in a production container where `@nx/next` is not installed:

```
Error: Cannot find module './deprecation'
Require stack:
- <app>/.nx-helpers/compose-plugins.js
- <app>/.nx-helpers/compiled.js
- <app>/next.config.js
```

The executor copies the compiled `utils/compose-plugins.js` verbatim into `.nx-helpers`, so the output loads without `@nx/next`. The `composePlugins` deprecation warning added a top-level import of `./deprecation`. That file is not copied alongside the helper, and it requires `@nx/devkit` at load time.

## Expected Behavior

The build output is self-contained again. The copied helper has no top-level imports, so `next start` works with only the app's production dependencies installed. The deprecation warning still fires when `composePlugins` runs as part of an Nx task. Nx resolves it lazily from the workspace, behind the same phase guard `plugins/with-nx.ts` uses, so the production server phase never loads an `@nx/*` package.

## Related Issue(s)

Fixes #36511

## Implementation Notes

- The regression got past two guardrails, and both are now closed.
- The lint rule banning relative imports in the copied helpers covered only `plugins/with-nx.ts`, and missed parent-relative specifiers there. It now covers `utils/compose-plugins.ts` too, and rejects any relative or `nx` import from either file.
- The e2e bad-imports assertion compared the `next.config.js` path string, not its contents, in a test skipped since 2024. The active legacy build test now reads the contents, and resolves every relative require in the copied `.nx-helpers` files.

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/gh-36511-2943e352">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->
