### PR TITLE
fix(devkit): reload TS config files fresh instead of serving stale cached modules

### DIFF
--- a/e2e/js/src/js-strip-types.test.ts
+++ b/e2e/js/src/js-strip-types.test.ts
@@ -1,11 +1,14 @@
 import {
   checkFilesExist,
   cleanupProject,
+  fileExists,
   newProject,
   packageInstall,
+  readFile,
   readJson,
   removeFile,
   runCLI,
+  tmpProjPath,
   uniq,
   updateFile,
 } from '@nx/e2e-utils';
@@ -389,6 +392,11 @@ export default config;
           `module.exports = { outputDir: './out-ccc' };\n`
         );
         expect(showOutputs(app)).toContain('{projectRoot}/out-ccc');
+
+        // The plugin cache must persist the fresh value under the new file
+        // hash: stop the daemon without clearing workspace data and re-read.
+        runCLI('daemon --stop', { env });
+        expect(showOutputs(app)).toContain('{projectRoot}/out-ccc');
       },
       TEN_MINS_MS
     );
@@ -436,6 +444,62 @@ export default config;
           `module.exports = { outputDir: './out-bbb' };\n`
         );
         expect(showOutputs(app)).toContain('{projectRoot}/out-bbb');
+      },
+      TEN_MINS_MS
+    );
+
+    it(
+      'should serve fresh inferred targets after editing a TS config in a workspace without tsconfig files',
+      () => {
+        // Without a sibling or root tsconfig the loader takes the
+        // tsconfig-less path, which needs the same ESM-registry routing:
+        // require() of a sync-ESM config would otherwise serve the stale
+        // registry entry on reloads.
+        const app = setupPlaywrightApp();
+        const mtsApp = setupPlaywrightApp();
+        updateFile(
+          `${app}/playwright.config.ts`,
+          `export default { outputDir: './out-aaa' };\n`
+        );
+        updateFile(
+          `${mtsApp}/playwright.config.mts`,
+          `export default { outputDir: './out-aaa' };\n`
+        );
+        const rootTsconfigs = ['tsconfig.base.json', 'tsconfig.json'].filter(
+          (f) => fileExists(tmpProjPath(f))
+        );
+        const saved = rootTsconfigs.map((f) => [f, readFile(f)] as const);
+        rootTsconfigs.forEach((f) => removeFile(f));
+        removeFile(`${app}/tsconfig.json`);
+        removeFile(`${mtsApp}/tsconfig.json`);
+        try {
+          expect(showOutputs(app)).toContain('{projectRoot}/out-aaa');
+          expect(showOutputs(mtsApp)).toContain('{projectRoot}/out-aaa');
+
+          updateFile(
+            `${app}/playwright.config.ts`,
+            `export default { outputDir: './out-bbb' };\n`
+          );
+          updateFile(
+            `${mtsApp}/playwright.config.mts`,
+            `export default { outputDir: './out-bbb' };\n`
+          );
+          expect(showOutputs(app)).toContain('{projectRoot}/out-bbb');
+          expect(showOutputs(mtsApp)).toContain('{projectRoot}/out-bbb');
+
+          // Also cover an ESM-to-CJS rewrite: without clearing the cached
+          // module first, the import() would serve the old require.cache
+          // entry.
+          updateFile(
+            `${app}/playwright.config.ts`,
+            `module.exports = { outputDir: './out-ccc' };\n`
+          );
+          expect(showOutputs(app)).toContain('{projectRoot}/out-ccc');
+        } finally {
+          for (const [f, content] of saved) {
+            updateFile(f, content);
+          }
+        }
       },
       TEN_MINS_MS
     );

--- a/e2e/js/src/js-strip-types.test.ts
+++ b/e2e/js/src/js-strip-types.test.ts
@@ -2,6 +2,7 @@ import {
   checkFilesExist,
   cleanupProject,
   newProject,
+  packageInstall,
   readJson,
   removeFile,
   runCLI,
@@ -328,6 +329,185 @@ export default config;
         removeFile(`${lib}/jest.config.mts`);
 
         expect(result).toContain('Registering ESM TypeScript loader');
+      },
+      TEN_MINS_MS
+    );
+  });
+
+  describe('config reload with a warm daemon and plugin isolation disabled', () => {
+    // With NX_ISOLATE_PLUGINS=false the plugin lives in the daemon process
+    // across graph recomputations. Restart the daemon so it runs with
+    // isolation disabled, and again afterwards for later tests.
+    const env = { NX_ISOLATE_PLUGINS: 'false' };
+
+    beforeAll(() => runCLI('reset', { env }));
+    afterAll(() => runCLI('reset'));
+
+    function setupPlaywrightApp(): string {
+      const app = uniq('app');
+      runCLI(
+        `generate @nx/web:app ${app} --unitTestRunner=none --bundler=vite --e2eTestRunner=none --style=css --no-interactive`,
+        { env }
+      );
+      runCLI(
+        `generate @nx/playwright:configuration --project ${app} --webServerCommand="echo test" --webServerAddress="http://localhost:4200"`,
+        { env }
+      );
+      // Replace the generated .mts config with a .ts one so each test
+      // controls the module shape.
+      removeFile(`${app}/playwright.config.mts`);
+      return app;
+    }
+
+    function showOutputs(app: string): string[] {
+      const project = JSON.parse(runCLI(`show project ${app} --json`, { env }));
+      return project.targets.e2e.outputs;
+    }
+
+    it(
+      'should serve fresh inferred targets after editing an ESM-shaped TS config',
+      () => {
+        // require() can load an ESM-shaped .ts as sync ESM, placing its
+        // live copy in the ESM module registry where require.cache
+        // busting can't reach it.
+        const app = setupPlaywrightApp();
+        updateFile(
+          `${app}/playwright.config.ts`,
+          `export default { outputDir: './out-aaa' };\n`
+        );
+        expect(showOutputs(app)).toContain('{projectRoot}/out-aaa');
+
+        updateFile(
+          `${app}/playwright.config.ts`,
+          `export default { outputDir: './out-bbb' };\n`
+        );
+        expect(showOutputs(app)).toContain('{projectRoot}/out-bbb');
+
+        // Also cover an ESM-to-CJS rewrite.
+        updateFile(
+          `${app}/playwright.config.ts`,
+          `module.exports = { outputDir: './out-ccc' };\n`
+        );
+        expect(showOutputs(app)).toContain('{projectRoot}/out-ccc');
+      },
+      TEN_MINS_MS
+    );
+
+    it(
+      'should serve fresh inferred targets after editing a CJS-shaped TS config',
+      () => {
+        // Must be CJS from the very first load: a path once seen as ESM
+        // reloads through dynamic import, not require.cache.
+        const app = setupPlaywrightApp();
+        updateFile(
+          `${app}/playwright.config.ts`,
+          `module.exports = { outputDir: './out-aaa' };\n`
+        );
+        expect(showOutputs(app)).toContain('{projectRoot}/out-aaa');
+
+        updateFile(
+          `${app}/playwright.config.ts`,
+          `module.exports = { outputDir: './out-bbb' };\n`
+        );
+        expect(showOutputs(app)).toContain('{projectRoot}/out-bbb');
+      },
+      TEN_MINS_MS
+    );
+
+    it(
+      'should serve fresh inferred targets after editing a local dependency of a TS config',
+      () => {
+        // Editing the helper changes the project-root hash, so createNodes
+        // re-runs; the reload must re-evaluate the config's local
+        // dependency subtree, not just the config itself.
+        const app = setupPlaywrightApp();
+        updateFile(
+          `${app}/pw-helper.js`,
+          `module.exports = { outputDir: './out-aaa' };\n`
+        );
+        updateFile(
+          `${app}/playwright.config.ts`,
+          `module.exports = require('./pw-helper.js');\n`
+        );
+        expect(showOutputs(app)).toContain('{projectRoot}/out-aaa');
+
+        updateFile(
+          `${app}/pw-helper.js`,
+          `module.exports = { outputDir: './out-bbb' };\n`
+        );
+        expect(showOutputs(app)).toContain('{projectRoot}/out-bbb');
+      },
+      TEN_MINS_MS
+    );
+
+    it(
+      'should keep inferred targets well-formed after a config attempts to prime the global ESM loader',
+      () => {
+        // TLA + enum attempts a process-wide ESM loader registration. Run
+        // after the fresh-path tests: successful registration lasts for
+        // the daemon's lifetime.
+        const primer = setupPlaywrightApp();
+        updateFile(
+          `${primer}/playwright.config.ts`,
+          `enum Mode { A = 'a' }
+const dir: string = await Promise.resolve('./out-primer');
+export default { outputDir: dir, mode: Mode.A };
+`
+        );
+        runCLI(`show project ${primer} --json`, { env, silenceError: true });
+        // Restore a valid config right away so later graph builds work
+        // without an ESM loader installed.
+        updateFile(
+          `${primer}/playwright.config.ts`,
+          `module.exports = { outputDir: './out-primer' };\n`
+        );
+
+        const app = setupPlaywrightApp();
+        updateFile(
+          `${app}/playwright.config.ts`,
+          `export default { outputDir: './out-aaa' };\n`
+        );
+        expect(showOutputs(app)).toContain('{projectRoot}/out-aaa');
+
+        updateFile(
+          `${app}/playwright.config.ts`,
+          `export default { outputDir: './out-bbb' };\n`
+        );
+        // Fresh or stale is accepted (reload freshness after a successful
+        // registration is Node-version dependent), but only the two values
+        // this test wrote; a corrupted shape would instead fall back to
+        // playwright's default test-results output dir.
+        const outEntry = showOutputs(app).find((o) => o.includes('/out-'));
+        expect(['{projectRoot}/out-aaa', '{projectRoot}/out-bbb']).toContain(
+          outEntry
+        );
+      },
+      TEN_MINS_MS
+    );
+
+    it(
+      'should recover a reload that edits an ESM-shaped config to use a CJS global',
+      () => {
+        // A path once loaded as ESM reloads through dynamic import(), where
+        // __dirname is undefined. The reload must recover through the same
+        // swc/ts-node fallback loadTsFile applies on first load instead of
+        // failing the project graph. ts-node backs that fallback here;
+        // without a transpiler the config cannot load on first load either.
+        // Runs after the primer test because the fallback also registers
+        // the process-wide ESM loader.
+        packageInstall('ts-node', undefined, '10.9.2');
+        const app = setupPlaywrightApp();
+        updateFile(
+          `${app}/playwright.config.ts`,
+          `export default { outputDir: './out-aaa' };\n`
+        );
+        expect(showOutputs(app)).toContain('{projectRoot}/out-aaa');
+
+        updateFile(
+          `${app}/playwright.config.ts`,
+          `const dir: string = __dirname;\nexport default { outputDir: './out-bbb' };\n`
+        );
+        expect(showOutputs(app)).toContain('{projectRoot}/out-bbb');
       },
       TEN_MINS_MS
     );

--- a/e2e/js/src/js-strip-types.test.ts
+++ b/e2e/js/src/js-strip-types.test.ts
@@ -465,14 +465,15 @@ export default config;
           `${mtsApp}/playwright.config.mts`,
           `export default { outputDir: './out-aaa' };\n`
         );
-        const rootTsconfigs = ['tsconfig.base.json', 'tsconfig.json'].filter(
-          (f) => fileExists(tmpProjPath(f))
-        );
-        const saved = rootTsconfigs.map((f) => [f, readFile(f)] as const);
-        rootTsconfigs.forEach((f) => removeFile(f));
-        removeFile(`${app}/tsconfig.json`);
-        removeFile(`${mtsApp}/tsconfig.json`);
+        const tsconfigs = [
+          'tsconfig.base.json',
+          'tsconfig.json',
+          `${app}/tsconfig.json`,
+          `${mtsApp}/tsconfig.json`,
+        ].filter((f) => fileExists(tmpProjPath(f)));
+        const saved = tsconfigs.map((f) => [f, readFile(f)] as const);
         try {
+          tsconfigs.forEach((f) => removeFile(f));
           expect(showOutputs(app)).toContain('{projectRoot}/out-aaa');
           expect(showOutputs(mtsApp)).toContain('{projectRoot}/out-aaa');
 

--- a/packages/devkit/src/utils/config-utils.spec.ts
+++ b/packages/devkit/src/utils/config-utils.spec.ts
@@ -1,0 +1,214 @@
+import { join } from 'path';
+import {
+  clearConfigFromRequireCache,
+  isTranspilerRecoverableError,
+  unwrapCjsInterop,
+} from './config-utils';
+
+// Jest's require.cache is not the real module cache, so the tests drive the
+// helper through its injectable cache with hand-built module graphs.
+describe('clearConfigFromRequireCache', () => {
+  let cache: NodeJS.Dict<NodeModule>;
+
+  function fakeModule(id: string, parent?: NodeModule): NodeModule {
+    const mod = {
+      id,
+      filename: id,
+      exports: {},
+      parent: parent ?? null,
+      children: [],
+    } as unknown as NodeModule;
+    if (parent) {
+      parent.children.push(mod);
+    }
+    return mod;
+  }
+
+  function register(mod: NodeModule): NodeModule {
+    cache[mod.id] = mod;
+    return mod;
+  }
+
+  beforeEach(() => {
+    cache = {};
+  });
+
+  it('should delete the config module and its local dependency subtree, leaving unrelated modules untouched', () => {
+    const config = register(fakeModule(join('/virtual', 'config.ts')));
+    const helper = register(fakeModule(join('/virtual', 'helper.ts'), config));
+    const transitive = register(
+      fakeModule(join('/virtual', 'transitive.ts'), helper)
+    );
+    const unrelated = register(fakeModule(join('/virtual', 'unrelated.ts')));
+
+    clearConfigFromRequireCache(config.id, cache);
+
+    expect(cache[config.id]).toBeUndefined();
+    expect(cache[helper.id]).toBeUndefined();
+    expect(cache[transitive.id]).toBeUndefined();
+    expect(cache[unrelated.id]).toBe(unrelated);
+  });
+
+  it('should not delete node_modules dependencies or their subtrees', () => {
+    const config = register(fakeModule(join('/virtual', 'config.ts')));
+    const dep = register(
+      fakeModule(join('/virtual', 'node_modules', 'dep', 'index.js'), config)
+    );
+    const depChild = register(
+      fakeModule(join('/virtual', 'node_modules', 'dep', 'child.js'), dep)
+    );
+
+    clearConfigFromRequireCache(config.id, cache);
+
+    expect(cache[config.id]).toBeUndefined();
+    expect(cache[dep.id]).toBe(dep);
+    expect(cache[depChild.id]).toBe(depChild);
+  });
+
+  it('should invalidate a shared dependency through both a retained older instance and the cache-current instance', () => {
+    // config A retains an older instance of the shared helper in its
+    // children, while the cache holds a newer instance (loaded by config
+    // B) with its own dependency subtree.
+    const configA = register(fakeModule(join('/virtual', 'a', 'config.ts')));
+    const helperOld = fakeModule(join('/virtual', 'shared.ts'), configA);
+    const helperNew = register(fakeModule(join('/virtual', 'shared.ts')));
+    const transitive = register(
+      fakeModule(join('/virtual', 'shared-dep.ts'), helperNew)
+    );
+
+    clearConfigFromRequireCache(configA.id, cache);
+
+    expect(helperOld.id).toBe(helperNew.id);
+    expect(cache[helperNew.id]).toBeUndefined();
+    expect(cache[transitive.id]).toBeUndefined();
+  });
+
+  it('should detach all instances of the config from the parent so repeated reloads do not accumulate them', () => {
+    const parent = fakeModule(join('/virtual', 'loader.ts'));
+    const configId = join('/virtual', 'config.ts');
+    fakeModule(configId, parent);
+    register(fakeModule(configId, parent));
+    expect(parent.children).toHaveLength(2);
+
+    clearConfigFromRequireCache(configId, cache);
+
+    expect(parent.children).toHaveLength(0);
+  });
+
+  it('should terminate on dependency cycles', () => {
+    const config = register(fakeModule(join('/virtual', 'config.ts')));
+    const helper = register(fakeModule(join('/virtual', 'helper.ts'), config));
+    helper.children.push(config);
+
+    clearConfigFromRequireCache(config.id, cache);
+
+    expect(cache[config.id]).toBeUndefined();
+    expect(cache[helper.id]).toBeUndefined();
+  });
+
+  it('should be a no-op for a module that is not cached', () => {
+    expect(() =>
+      clearConfigFromRequireCache(join('/virtual', 'missing.ts'), cache)
+    ).not.toThrow();
+  });
+});
+
+describe('isTranspilerRecoverableError', () => {
+  const tsPath = join('/virtual', 'config.ts');
+
+  const cases: Array<[Error, string, boolean]> = [
+    [
+      new ReferenceError('__dirname is not defined in ES module scope'),
+      tsPath,
+      true,
+    ],
+    [new ReferenceError('require is not defined'), tsPath, true],
+    [new ReferenceError('someGlobal is not defined'), tsPath, false],
+    [
+      new SyntaxError(
+        "The requested module './types.ts' does not provide an export named 'Foo'"
+      ),
+      tsPath,
+      true,
+    ],
+    [
+      new ReferenceError('__dirname is not defined'),
+      join('/virtual', 'config.js'),
+      false,
+    ],
+  ];
+
+  it('should classify recoverable errors with the host nx classifiers', () => {
+    for (const [err, path, expected] of cases) {
+      expect(isTranspilerRecoverableError(err, path)).toBe(expected);
+    }
+  });
+
+  it('should classify identically on a host nx that does not export the classifiers', () => {
+    // nx 23.0/23.1 recover these error classes in loadTsFile but do not
+    // re-export the classifiers from devkit-internals.
+    jest.isolateModules(() => {
+      jest.doMock('nx/src/devkit-internals', () => ({}));
+      const {
+        isTranspilerRecoverableError: withoutHostClassifiers,
+      } = require('./config-utils');
+      for (const [err, path, expected] of cases) {
+        expect(withoutHostClassifiers(err, path)).toBe(expected);
+      }
+    });
+    jest.dontMock('nx/src/devkit-internals');
+  });
+});
+
+describe('unwrapCjsInterop', () => {
+  const path = join('/virtual', 'config.ts');
+
+  function cjsShapedNamespace() {
+    return {
+      default: { __esModule: true, default: { value: 1 }, extra: 'kept' },
+    };
+  }
+
+  it('should unwrap when require.cache proves the load went through the CJS pipeline', () => {
+    const module = cjsShapedNamespace();
+    const cache = {
+      [path]: { exports: module.default } as unknown as NodeModule,
+    };
+
+    expect(unwrapCjsInterop(path, module, cache)).toBe(module.default);
+  });
+
+  it('should unwrap CJS exports that carry no __esModule marker', () => {
+    // Some loaders (observed with @swc-node/register/esm) emit CJS exports
+    // without the interop marker; the cache identity is the discriminator.
+    const module = { default: { default: { value: 1 } } };
+    const cache = {
+      [path]: { exports: module.default } as unknown as NodeModule,
+    };
+
+    expect(unwrapCjsInterop(path, module, cache)).toBe(module.default);
+  });
+
+  it('should preserve a genuine ESM module with the same shape when require.cache has no entry', () => {
+    const module = cjsShapedNamespace();
+
+    expect(unwrapCjsInterop(path, module, {})).toBe(module);
+  });
+
+  it('should preserve the module when the cached exports are a different object', () => {
+    const module = cjsShapedNamespace();
+    const cache = {
+      [path]: {
+        exports: { ...module.default },
+      } as unknown as NodeModule,
+    };
+
+    expect(unwrapCjsInterop(path, module, cache)).toBe(module);
+  });
+
+  it('should preserve a default-less ESM namespace instead of unwrapping to undefined', () => {
+    const module = { named: { value: 1 } };
+
+    expect(unwrapCjsInterop(path, module, {})).toBe(module);
+  });
+});

--- a/packages/devkit/src/utils/config-utils.spec.ts
+++ b/packages/devkit/src/utils/config-utils.spec.ts
@@ -211,4 +211,15 @@ describe('unwrapCjsInterop', () => {
 
     expect(unwrapCjsInterop(path, module, {})).toBe(module);
   });
+
+  it('should preserve a default-less namespace that require() cached', () => {
+    // require() of synchronous ESM caches the namespace itself, so an entry
+    // exists for a load the CJS pipeline never handled.
+    const module = { named: { value: 1 } };
+    const cache = {
+      [path]: { exports: module } as unknown as NodeModule,
+    };
+
+    expect(unwrapCjsInterop(path, module, cache)).toBe(module);
+  });
 });

--- a/packages/devkit/src/utils/config-utils.ts
+++ b/packages/devkit/src/utils/config-utils.ts
@@ -46,9 +46,23 @@ async function loadTypeScriptModule(
   tsconfigFileNames?: string[]
 ): Promise<any> {
   const tsConfigPath = getTypeScriptConfigPath(path, tsconfigFileNames);
+  const modulePath = resolveModulePath(path);
 
   if (!tsConfigPath) {
-    return await loadModuleByExtension(path, extension);
+    // The tsconfig-less path needs the same ESM-registry routing as below:
+    // require() of a sync-ESM .ts serves the stale registry entry on reloads.
+    if (esmRegistryPaths.has(modulePath)) {
+      // Clear first so an ESM-to-CJS rewrite re-evaluates instead of the
+      // import() serving the cached require.cache entry.
+      clearConfigFromRequireCache(modulePath);
+      return unwrapCjsInterop(path, await loadESM(path));
+    }
+    clearConfigFromRequireCache(modulePath);
+    const result = await loadModuleByExtension(path, extension);
+    if (types.isModuleNamespaceObject(result)) {
+      esmRegistryPaths.add(modulePath);
+    }
+    return result;
   }
 
   // loadTsFile was added in nx@23. @nx/devkit's peer range supports older
@@ -65,7 +79,6 @@ async function loadTypeScriptModule(
 
   // require.cache busting cannot invalidate a module the ESM registry
   // holds; reloads of known-ESM paths need a cache-busted import().
-  const modulePath = resolveModulePath(path);
   if (esmRegistryPaths.has(modulePath)) {
     return await loadTsFileViaImport(path, tsConfigPath);
   }

--- a/packages/devkit/src/utils/config-utils.ts
+++ b/packages/devkit/src/utils/config-utils.ts
@@ -1,8 +1,11 @@
 import { existsSync, readdirSync } from 'fs';
 import { pathToFileURL } from 'node:url';
+import { types } from 'node:util';
 import { workspaceRoot } from 'nx/src/devkit-exports';
 import {
   forceRegisterEsmLoader,
+  isRequireInEsmScopeError,
+  isTsEsmNamedExportLinkageError,
   loadTsFile,
   registerTsProject,
 } from 'nx/src/devkit-internals';
@@ -60,15 +63,30 @@ async function loadTypeScriptModule(
     }
   }
 
+  // require.cache busting cannot invalidate a module the ESM registry
+  // holds; reloads of known-ESM paths need a cache-busted import().
+  const modulePath = resolveModulePath(path);
+  if (esmRegistryPaths.has(modulePath)) {
+    return await loadTsFileViaImport(path, tsConfigPath);
+  }
+
+  // A CJS-shaped .ts stays in require.cache and may have changed on disk
+  // since; clear it so the reload re-reads the file.
+  clearConfigFromRequireCache(modulePath);
+
   // Both .ts and .mts go through loadTsFile first. Node 22.12+ supports
   // require() of synchronous ESM by default, and loadTsFile's lazy fallback
   // covers swc/ts-node + tsconfig-paths registration when needed (swc-node
   // hooks .cts/.mts/.ts via Module._extensions). Async-only ESM modules
   // (top-level await) throw ERR_REQUIRE_ASYNC_MODULE and fall through to
-  // dynamic import(). ERR_REQUIRE_ESM is the legacy code for the same case
-  // - kept for older Node lines.
+  // dynamic import(). ERR_REQUIRE_ESM is the legacy code for the same case,
+  // kept for older Node lines.
   try {
-    return loadTsFile(path, tsConfigPath);
+    const result = loadTsFile(path, tsConfigPath);
+    if (types.isModuleNamespaceObject(result)) {
+      esmRegistryPaths.add(modulePath);
+    }
+    return result;
   } catch (e: any) {
     if (
       e?.code !== 'ERR_REQUIRE_ESM' &&
@@ -76,41 +94,215 @@ async function loadTypeScriptModule(
     ) {
       throw e;
     }
+    return await loadTsFileViaImport(path, tsConfigPath);
+  }
+}
 
-    // The module must be loaded via dynamic import(). Register
-    // tsconfig-paths first so workspace alias imports resolve, then try a
-    // native dynamic import. Node 22.18+ LTS strips TS types on the ESM
-    // path natively, so pure-ESM TLA configs load without any swc/ts-node
-    // ESM loader. Only escalate to forceRegisterEsmLoader (which throws
-    // when neither @swc-node/register nor ts-node is installed) if the
-    // native attempt hits unsupported TS syntax.
+// Resolved paths of configs that require() loaded as synchronous ESM;
+// reloads of these route through loadTsFileViaImport. On globalThis so the
+// state survives clearRequireCache evicting this module itself (a
+// workspace-linked devkit resolves outside node_modules).
+const esmRegistryPaths: Set<string> = ((globalThis as any)[
+  Symbol.for('@nx/devkit:esmRegistryPaths')
+] ??= new Set());
+
+// Error codes from the load machinery (resolution, type stripping) that
+// warrant registering swc/ts-node + tsconfig-paths and importing again.
+// Unlisted errors propagate unchanged so a failing config is not
+// re-evaluated. A not-found error can also come from the config's own
+// dynamic import()/require() of a missing module, in which case the retry
+// re-runs its top-level side effects; accepted so that static alias and
+// extensionless imports (which fail at link time, before any user code
+// runs) stay recoverable.
+const ESM_LOAD_FALLBACK_ERROR_CODES = new Set([
+  'ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX',
+  'ERR_MODULE_NOT_FOUND',
+  'MODULE_NOT_FOUND',
+  'ERR_UNKNOWN_FILE_EXTENSION',
+]);
+
+// Code-less errors that loadTsFile recovers on first load via the swc/
+// ts-node fallback: a CJS-only global (__dirname, __filename, require) or a
+// type-only named import evaluated on the native ESM path. Reloads must
+// recover them too or an edit that introduces one turns into a hard graph
+// failure. Prefer the host nx's classifiers so the gate matches what its
+// loadTsFile recovers; nx versions that support the error classes without
+// re-exporting the classifiers fall back to local replicas of them.
+export function isTranspilerRecoverableError(
+  err: unknown,
+  path: string
+): boolean {
+  return (
+    (typeof isRequireInEsmScopeError === 'function'
+      ? isRequireInEsmScopeError(err, path)
+      : isRequireInEsmScopeErrorReplica(err, path)) ||
+    (typeof isTsEsmNamedExportLinkageError === 'function'
+      ? isTsEsmNamedExportLinkageError(err, path)
+      : isTsEsmNamedExportLinkageErrorReplica(err, path))
+  );
+}
+
+function isRequireInEsmScopeErrorReplica(
+  err: unknown,
+  filePath: string
+): boolean {
+  if (!(err instanceof ReferenceError)) {
+    return false;
+  }
+  if (!(filePath.endsWith('.ts') || filePath.endsWith('.mts'))) {
+    return false;
+  }
+  return /(require|__dirname|__filename) is not defined/.test(err.message);
+}
+
+function isTsEsmNamedExportLinkageErrorReplica(
+  err: unknown,
+  filePath: string
+): boolean {
+  if (!(err instanceof SyntaxError)) {
+    return false;
+  }
+  return (
+    (filePath.endsWith('.ts') || filePath.endsWith('.mts')) &&
+    err.message.includes('does not provide an export named')
+  );
+}
+
+// Invalidates a config module and its local CommonJS dependency subtree,
+// leaving unrelated cached modules untouched (a broad clear re-evaluates
+// them and breaks singleton identity). Walks each module's recorded
+// children AND the cache-current instance for the same id, since another
+// config may retain an older instance of a shared dependency. Detaches the
+// root from its requiring parent so repeated reloads don't accumulate
+// Module objects in the parent's children array.
+export function clearConfigFromRequireCache(
+  rootId: string,
+  cache: NodeJS.Dict<NodeModule> = require.cache
+): void {
+  const root = cache[rootId];
+  if (!root) {
+    return;
+  }
+
+  const visited = new Set<NodeModule>();
+  const idsToDelete = new Set<string>();
+  const queue: NodeModule[] = [root];
+  while (queue.length) {
+    const mod = queue.pop();
+    if (!mod || visited.has(mod)) {
+      continue;
+    }
+    visited.add(mod);
+    if (packageInstallationDirectories.some((dir) => mod.id.includes(dir))) {
+      continue;
+    }
+    idsToDelete.add(mod.id);
+    const current = cache[mod.id];
+    if (current && current !== mod) {
+      queue.push(current);
+    }
+    for (const child of mod.children) {
+      queue.push(child);
+    }
+  }
+
+  for (const id of idsToDelete) {
+    delete cache[id];
+  }
+
+  if (root.parent) {
+    root.parent.children = root.parent.children.filter(
+      (child) => child.id !== rootId
+    );
+  }
+}
+
+// Canonical key for require.cache checks and esmRegistryPaths: a symlinked
+// config's caller path differs from require's resolved filename.
+function resolveModulePath(path: string): string {
+  try {
+    return require.resolve(path);
+  } catch {
+    return path;
+  }
+}
+
+async function loadTsFileViaImport(
+  path: string,
+  tsConfigPath: string
+): Promise<any> {
+  // Clear any prior require.cache entry so an ESM-to-CJS rewrite (or a
+  // loader-classified CJS load) re-evaluates instead of serving the cached
+  // copy.
+  clearConfigFromRequireCache(resolveModulePath(path));
+
+  // Try a bare native import first: Node 22.18+ strips TS types on the ESM
+  // path natively, and registerTsProject must NOT run up front. A
+  // registered swc/ts-node ESM loader intercepts every subsequent import
+  // in the process (it cannot be unregistered) and may classify a .ts
+  // config as CommonJS, defeating loadESM's cache-busting query on
+  // reloads. Register only when the native attempt fails.
+  try {
+    return unwrapCjsInterop(path, await loadESM(path));
+  } catch (esmErr: any) {
+    if (
+      !ESM_LOAD_FALLBACK_ERROR_CODES.has(esmErr?.code) &&
+      !isTranspilerRecoverableError(esmErr, path)
+    ) {
+      throw esmErr;
+    }
     const cleanup = registerTsProject(tsConfigPath);
     try {
-      return await loadESM(path);
-    } catch (esmErr: any) {
+      return unwrapCjsInterop(path, await loadESM(path));
+    } catch (retryErr: any) {
+      if (isTranspilerRecoverableError(retryErr, path)) {
+        // A registered swc ESM loader compiles the retry to CJS, but
+        // ts-node/esm keeps the file ESM, so CJS globals stay undefined on
+        // the import path. Route through the CJS transpiler hook
+        // registerTsProject installed; it reads fresh from disk. A
+        // namespace result means no hook intercepted and require() hit the
+        // stale ESM registry, so surface the error instead.
+        const required = require(path);
+        if (!types.isModuleNamespaceObject(required)) {
+          return required;
+        }
+        throw retryErr;
+      }
       if (
-        esmErr?.code !== 'ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX' ||
+        retryErr?.code !== 'ERR_UNSUPPORTED_TYPESCRIPT_SYNTAX' ||
         typeof forceRegisterEsmLoader !== 'function'
       ) {
-        throw esmErr;
+        throw retryErr;
       }
-      // Module.register is global and one-shot per process. After this
-      // runs, every subsequent ESM import in the process is routed
-      // through the registered loader, forfeiting Node's native TS
-      // stripping for the dynamic-import path. If neither swc-node nor
-      // ts-node is installed, forceRegisterEsmLoader throws - surface the
-      // original ESM error in that case so the user sees the real
-      // problem, not a misleading "loader missing" message.
+      // Loader registration cannot be undone. Preserve the import error
+      // if registration itself fails.
       try {
         forceRegisterEsmLoader();
       } catch {
-        throw esmErr;
+        throw retryErr;
       }
-      return await loadESM(path);
+      return unwrapCjsInterop(path, await loadESM(path));
     } finally {
       cleanup();
     }
   }
+}
+
+// Some loaders emit CJS for a dynamic import, wrapping module.exports in
+// namespace.default (with or without an __esModule marker). Unwrap only when
+// require.cache proves the load went through the CJS pipeline; genuine ESM
+// never populates require.cache, so its exports are preserved. The entry
+// existence check keeps a default-less ESM namespace from matching on
+// undefined === undefined.
+export function unwrapCjsInterop(
+  path: string,
+  module: unknown,
+  cache: NodeJS.Dict<NodeModule> = require.cache
+): unknown {
+  const entry = cache[resolveModulePath(path)];
+  const cjsExports = (module as { default?: unknown } | null | undefined)
+    ?.default;
+  return entry && entry.exports === cjsExports ? cjsExports : module;
 }
 
 function getTypeScriptConfigPath(
@@ -206,7 +398,17 @@ async function loadCommonJS(path: string): Promise<any> {
   return require(path);
 }
 
+// Global monotonic counter (not Date.now()) so two reloads never share a
+// cache-busting URL, across same-millisecond loads, module reloads, and
+// devkit copies.
+const esmLoadState: { count: number } = ((globalThis as any)[
+  Symbol.for('@nx/devkit:esmLoadState')
+] ??= { count: 0 });
+
 async function loadESM(path: string): Promise<any> {
-  const pathAsFileUrl = pathToFileURL(path).pathname;
-  return await dynamicImport(`${pathAsFileUrl}?t=${Date.now()}`);
+  // Keep the full file URL (.pathname would drop a UNC authority); the
+  // unique query gives each reload a fresh ESM registry key.
+  const fileUrl = pathToFileURL(path);
+  fileUrl.searchParams.set('t', (esmLoadState.count++).toString());
+  return await dynamicImport(fileUrl.href);
 }

--- a/packages/devkit/src/utils/config-utils.ts
+++ b/packages/devkit/src/utils/config-utils.ts
@@ -112,7 +112,7 @@ async function loadTypeScriptModule(
 }
 
 // Resolved paths of configs that require() loaded as synchronous ESM;
-// reloads of these route through loadTsFileViaImport. On globalThis so the
+// reloads of these route through a cache-busted import(). On globalThis so the
 // state survives clearRequireCache evicting this module itself (a
 // workspace-linked devkit resolves outside node_modules).
 const esmRegistryPaths: Set<string> = ((globalThis as any)[
@@ -302,11 +302,9 @@ async function loadTsFileViaImport(
 }
 
 // Some loaders emit CJS for a dynamic import, wrapping module.exports in
-// namespace.default (with or without an __esModule marker). Unwrap only when
-// require.cache proves the load went through the CJS pipeline; genuine ESM
-// never populates require.cache, so its exports are preserved. The entry
-// existence check keeps a default-less ESM namespace from matching on
-// undefined === undefined.
+// namespace.default (the __esModule marker is optional), so cache identity is
+// the discriminator: a require(esm) entry holds the namespace itself, and the
+// entry check stops a default-less namespace from matching undefined.
 export function unwrapCjsInterop(
   path: string,
   module: unknown,

--- a/packages/eslint-plugin/src/resolve-workspace-rules.ts
+++ b/packages/eslint-plugin/src/resolve-workspace-rules.ts
@@ -167,13 +167,10 @@ export async function loadWorkspaceRules(
         );
       } catch (err: any) {
         // Top-level await (`ERR_REQUIRE_ASYNC_MODULE`) and ESM-only modules
-        // (`ERR_REQUIRE_ESM`) must be loaded via dynamic import(). Mirror
-        // devkit's loadTypeScriptModule: register tsconfig-paths first so
-        // workspace alias imports resolve, then try native dynamic import.
-        // Only escalate to forceRegisterEsmLoader on unsupported TS syntax
-        // (enum, runtime namespace, etc.) - surface the original ESM error
-        // if no loader can be installed. Without this the outer catch
-        // swallows the error and the lint run silently has no rules.
+        // (`ERR_REQUIRE_ESM`) must be loaded via dynamic import(). Keep
+        // CommonJS tsconfig-path resolution active during the import, and
+        // escalate to an ESM transpiler only for unsupported TS syntax;
+        // surface the original ESM error if no loader can be installed.
         if (
           err?.code !== 'ERR_REQUIRE_ESM' &&
           err?.code !== 'ERR_REQUIRE_ASYNC_MODULE'

--- a/packages/nx/src/devkit-internals.ts
+++ b/packages/nx/src/devkit-internals.ts
@@ -87,6 +87,8 @@ export {
   registerTsProject,
   loadTsFile,
   forceRegisterEsmLoader,
+  isRequireInEsmScopeError,
+  isTsEsmNamedExportLinkageError,
   requireWithTsconfigFallback,
 } from './plugins/js/utils/register';
 export { interpolate } from './tasks-runner/utils';


### PR DESCRIPTION
## Current Behavior

With the daemon running and plugin isolation disabled (`NX_ISOLATE_PLUGINS=false`), editing a TypeScript project config (e.g. `playwright.config.ts`) does not update the project's inferred targets. A CJS-shaped `.ts` config stays in `require.cache`, and an ESM-shaped `.ts` config stays in the ESM module registry where `require.cache` clearing has no effect, so `loadConfigFile` keeps returning the old module. The plugin cache then persists the stale targets under the new file hash, so they survive until `nx reset`.

## Expected Behavior

Config edits are picked up on the next graph recomputation. `loadConfigFile` invalidates the config module and its local CommonJS dependency subtree (unrelated cached modules keep their identity) before reloading CJS-shaped configs, and reloads configs held by the ESM registry through a cache-busted dynamic `import()`, with or without a tsconfig in the workspace. The import runs natively first and falls back to registering swc/ts-node on load-machinery errors and on the errors `loadTsFile` recovers on first load (a CJS-only global such as `__dirname`, a type-only named import); when the registered ESM loader keeps the file ESM, the reload retries through the CJS transpiler hook. Loads served by the CJS pipeline have their interop wrapper unwrapped so the config shape survives.

## Implementation Notes

- Cache-busting state (known-ESM paths, import counter) lives on `globalThis` so it survives `clearRequireCache` evicting devkit itself in workspace-linked setups.
- The interop unwrap is gated on `require.cache` identity evidence (loaders may omit the `__esModule` marker), so a user config exporting an `{ __esModule, default }` shape is returned as is.
- The error classifiers come from the host nx when it exports them; nx versions within the supported peer range that recover these errors without re-exporting the classifiers from devkit-internals fall back to local replicas.
- Known limitation: a local dependency of a config that lives in the ESM registry is not invalidated. An ESM-shaped `.ts` helper `require()`d from a CJS-shaped config, or statically imported from an ESM-shaped config, keeps serving its first-load value when only the helper changes. This is not fixable through the current native-loader/cache-invalidation design: Node provides no in-process eviction for those entries (a fresh resolution URL still returns the old evaluation for `require()` of sync ESM). This also happens before this change; at worst the helper edit needs `nx reset`. The config's CommonJS dependency subtree is invalidated. Tracked in NXC-4842.
- Known limitation: once a config forces a global ESM loader registration (top-level await plus syntax native stripping can't handle), reloads of other ESM configs served through that loader can be stale. This also happens before this change; the loader registration is process-global and cannot be undone.
- Known limitation: each reload of an ESM-shaped config leaves its previous evaluation in Node's ESM registry, which has no in-process eviction, so a long-running process grows by roughly 5 KiB per reload (measured at about 9 MB of heap after 2000 reloads of one config). Cache-busted imports already behaved this way for configs that only load through `import()` (top-level await); this change extends it to every ESM-shaped config, since those now reload through `import()` too. Isolated plugin workers exit with the command, so the growth only accumulates in a long-lived process such as the daemon with `NX_ISOLATE_PLUGINS=false`, and a daemon restart clears it. Keying the cache-busting query on the config's contents would bound it, at the cost of not re-evaluating a config whose own contents did not change, which is what picks up edits to its CommonJS dependencies.
- Covered by unit tests for the targeted invalidation, the interop unwrap, and the error classification (including a host nx without the classifier exports), and six e2e tests exercising a warm daemon with plugin isolation disabled, including a workspace without tsconfig files and the plugin cache contents after a daemon stop (the stale-reload tests verified red on the previous code).

Linear: NXC-4715

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/nxc-4715-1d6473da">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->

