### PR TITLE
fix(angular-rspack): keep sourcemaps for files the Angular transforms leave untouched

### DIFF
--- a/e2e/angular/src/projects-build-and-test.test.ts
+++ b/e2e/angular/src/projects-build-and-test.test.ts
@@ -135,15 +135,18 @@ describe('Angular Projects - Build and Test', () => {
     runCLI(`build ${app} --skip-nx-cache`, {
       env: { NGRS_CONFIG: 'development' },
     });
-    const bundleMap = JSON.parse(
-      readFile(`dist/my-dir/${app}/browser/main.js.map`)
-    );
-    const tsSources = bundleMap.sources
-      .map((source: string, index: number) => ({
-        source,
-        content: bundleMap.sourcesContent?.[index],
-      }))
-      .filter(({ source }) => source.endsWith('.ts'));
+    const readTsSources = () => {
+      const bundleMap = JSON.parse(
+        readFile(`dist/my-dir/${app}/browser/main.js.map`)
+      );
+      return bundleMap.sources
+        .map((source: string, index: number) => ({
+          source,
+          content: bundleMap.sourcesContent?.[index],
+        }))
+        .filter(({ source }) => source.endsWith('.ts'));
+    };
+    const tsSources = readTsSources();
     expect(tsSources.length).toBeGreaterThan(0);
     // The original TypeScript contains the `@Component` decorator, while the
     // intermediate Ivy JS has it compiled away into `ɵcmp`.
@@ -152,6 +155,28 @@ describe('Angular Projects - Build and Test', () => {
     );
     expect(componentSource).toBeDefined();
     expect(componentSource.content).not.toContain('ɵcmp');
+
+    // Optimized builds run the emit through the JavaScript transformer, which
+    // rewrites sourcemaps. Every source it emits must still resolve back to
+    // its TypeScript, including the files the Angular transforms left
+    // untouched (routes, application config) and therefore emitted without a
+    // sourcemap of their own.
+    updateFile(`my-dir/${app}/rspack.config.ts`, (content) =>
+      content.replace('"optimization": false,', '"optimization": true,')
+    );
+    expect(readFile(`my-dir/${app}/rspack.config.ts`)).toContain(
+      '"optimization": true,'
+    );
+    runCLI(`build ${app} --skip-nx-cache`, {
+      env: { NGRS_CONFIG: 'development' },
+    });
+    const optimizedTsSources = readTsSources();
+    expect(optimizedTsSources.length).toBeGreaterThan(0);
+    expect(
+      optimizedTsSources
+        .filter(({ content }) => !content)
+        .map(({ source }) => source)
+    ).toEqual([]);
 
     if (await runE2ETests()) {
       expect(() => runCLI(`e2e ${app}-e2e`)).not.toThrow();

--- a/packages/angular-rspack-compiler/src/compilation/setup-compilation.spec.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-compilation.spec.ts
@@ -61,6 +61,45 @@ describe('setupCompilation', () => {
     expect(compilerOptions.sourceMap).toBeUndefined();
   });
 
+  // `@angular/build` 22.1 emits raw TypeScript for isolated modules unless
+  // this option asks for the TypeScript emit, and only that emit carries a
+  // sourcemap for every file.
+  it.each([
+    [true, false, false],
+    [true, true, true],
+    [false, false, true],
+    [false, true, true],
+  ])(
+    'should request the TypeScript emit for isolatedModules: %s with sourceMap: %s',
+    async (isolatedModules, sourceMap, expected) => {
+      vi.mocked(loadCompilerCli).mockResolvedValueOnce({
+        readConfiguration: (
+          _tsconfig: string,
+          existingOptions: Record<string, unknown>
+        ) => ({
+          options: { isolatedModules, ...existingOptions, module: 99 },
+          rootNames: ['/root/src/main.ts'],
+        }),
+      } as never);
+
+      const { compilerOptions } = await setupCompilation(
+        { source: { tsconfigPath: '/root/tsconfig.json' } },
+        { ...options, sourceMap }
+      );
+
+      expect(compilerOptions['_useTypeScriptTranspilation']).toBe(expected);
+    }
+  );
+
+  it('should not request the TypeScript emit when using TS project references', async () => {
+    const { compilerOptions } = await setupCompilation(
+      { source: { tsconfigPath: '/root/tsconfig.json' } },
+      { ...options, sourceMap: true, useTsProjectReferences: true }
+    );
+
+    expect(compilerOptions['_useTypeScriptTranspilation']).toBe(false);
+  });
+
   it('should not emit TS sourcemaps when using TS project references', async () => {
     const { compilerOptions } = await setupCompilation(
       { source: { tsconfigPath: '/root/tsconfig.json' } },

--- a/packages/angular-rspack-compiler/src/compilation/setup-compilation.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-compilation.ts
@@ -153,6 +153,16 @@ export async function setupCompilation(
   ) {
     compilerOptions.customConditions = options.customConditions;
   }
+  // Requests TypeScript's emit over the raw Angular-transformed TypeScript
+  // one. Only TypeScript's carries a sourcemap for every file: the raw emit
+  // passes through files the Angular transforms left untouched, leaving them
+  // nothing to map back to. `@angular/build` 22.1 reads this option instead of
+  // deriving the emit from the sourcemap options, so setting it keeps every
+  // supported version on the same emit.
+  compilerOptions['_useTypeScriptTranspilation'] =
+    !compilerOptions.isolatedModules ||
+    !!compilerOptions.sourceMap ||
+    !!compilerOptions.inlineSourceMap;
 
   const searchDirectories = await generateSearchDirectories([options.root]);
   const postcssConfiguration =

--- a/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.spec.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.spec.ts
@@ -373,10 +373,12 @@ describe('setupCompilationWithAngularCompilation', () => {
     expect(compilerOptions.tsBuildInfoFile).toBeUndefined();
   });
 
-  // The flag must mirror the emit's own gate (isolated modules and no
-  // sourcemaps emit raw Angular-transformed TypeScript); tsconfig semantics
-  // like decorators or class fields are the swc rule's concern and must not
-  // flip the classification of what the compilation emitted.
+  // The flag must mirror the emit's own gate: `@angular/build` 22.1 reports
+  // it as `_useTypeScriptTranspilation`, which wins over every other option;
+  // older versions emit raw Angular-transformed TypeScript for isolated
+  // modules without sourcemaps. tsconfig semantics like decorators or class
+  // fields are the swc rule's concern and must not flip the classification of
+  // what the compilation emitted.
   const fastPathOptions = {
     isolatedModules: true,
     experimentalDecorators: true,
@@ -388,6 +390,20 @@ describe('setupCompilationWithAngularCompilation', () => {
     [{ isolatedModules: false }, true],
     [{ ...fastPathOptions, sourceMap: true }, true],
     [{ ...fastPathOptions, inlineSourceMap: true }, true],
+    // Reported by @angular/build 22.1+: the sourcemap options no longer
+    // switch the emit, so the raw-TS emit must not be classified as
+    // transpiled JavaScript.
+    [{ ...fastPathOptions, _useTypeScriptTranspilation: false }, false],
+    [
+      {
+        ...fastPathOptions,
+        inlineSourceMap: true,
+        _useTypeScriptTranspilation: false,
+      },
+      false,
+    ],
+    [{ ...fastPathOptions, _useTypeScriptTranspilation: true }, true],
+    [{ isolatedModules: false, _useTypeScriptTranspilation: false }, false],
     [{ ...fastPathOptions, experimentalDecorators: false }, false],
     [{ ...fastPathOptions, emitDecoratorMetadata: true }, false],
     [{ ...fastPathOptions, useDefineForClassFields: false }, false],

--- a/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.ts
+++ b/packages/angular-rspack-compiler/src/compilation/setup-with-angular-compilation.ts
@@ -176,16 +176,18 @@ export async function setupCompilationWithAngularCompilation(
   }
 
   // Only the AOT emit branches between TypeScript transpilation and raw
-  // Angular-transformed TypeScript, on this exact expression over the
-  // program's options (JIT always transpiles). The loaders classify the
-  // emitted cache entries with this flag, so it must never diverge from the
-  // emit's gate. The worker-based initialize reports only four options; the
-  // three the gate reads are among them, and any other option would be
-  // undefined here.
+  // Angular-transformed TypeScript (JIT always transpiles). The loaders
+  // classify the emitted cache entries with this flag, so it must never
+  // diverge from the emit's gate. `@angular/build` 22.1 gates on the
+  // `_useTypeScriptTranspilation` option `setupCompilation` sets and reports
+  // it back here; versions that ignore the option derive the fallback
+  // expression themselves at emit time. The worker-based initialize marshals
+  // every option read here; any other option would be undefined.
   const useTypeScriptTranspilation =
-    !initializedCompilerOptions?.isolatedModules ||
-    !!initializedCompilerOptions?.sourceMap ||
-    !!initializedCompilerOptions?.inlineSourceMap;
+    (initializedCompilerOptions?.['_useTypeScriptTranspilation'] as boolean) ??
+    (!initializedCompilerOptions?.isolatedModules ||
+      !!initializedCompilerOptions?.sourceMap ||
+      !!initializedCompilerOptions?.inlineSourceMap);
 
   return {
     angularCompilation,


### PR DESCRIPTION
## Current Behavior

With `@angular/build` 22.1+, an optimized build with script sourcemaps enabled produces a bundle sourcemap in which only Angular-rewritten files (components, directives, pipes) resolve to their TypeScript. Every other `.ts` file — `app.routes.ts`, `app.config.ts`, services, plain helpers — is listed as a source with empty `sourcesContent`, so DevTools renders it as an empty file and breakpoints have nothing to attach to.

The cause is a gate that quietly diverged from the compilation it mirrors.

`AotCompilation` chooses between two emits: TypeScript-transpiled JavaScript, or raw Angular-transformed TypeScript that the bundler transpiles itself. In the raw emit, files whose transform result is unchanged are emitted as `sourceFile.text` with no sourcemap at all; only files Angular actually rewrote are printed with an inline map.

Through `@angular/build` 22.0 that choice was made in `emitAffectedFiles`:

```ts
const useTypeScriptTranspilation =
  !compilerOptions.isolatedModules ||
  !!compilerOptions.sourceMap ||
  !!compilerOptions.inlineSourceMap;
```

22.1 moved it into `initialize` and dropped the sourcemap terms:

```ts
const useTypeScriptTranspilation =
  (compilerOptions['_useTypeScriptTranspilation'] as boolean | undefined) ??
  !compilerOptions.isolatedModules;
```

`@angular/build`'s own esbuild plugin sets that internal option in its compiler-options transformer and reads the value back out of the initialization result — it never re-derives it. `setup-with-angular-compilation.ts` did re-derive it, with the pre-22.1 expression. Since `setup-compilation.ts` turns on `inlineSourceMap` whenever script sourcemaps are requested, any app with `isolatedModules: true` (every generated app) desynchronized: Angular emitted raw TypeScript, while the loaders classified those cache entries as transpiled JavaScript and handed them to the `JavaScriptTransformer`.

In an unoptimized build that is invisible — `transformData` short-circuits and returns the data untouched, so swc still maps the original TypeScript. In an optimized build the transformer's oxc pass runs, finds no input sourcemap to chain (there is none — the file was never rewritten), and generates a fresh map over the raw TypeScript with `sources: ['<abs path>']` and no `sourcesContent`. That map is forwarded to rspack and wins over the module's own source. Components are unaffected because their printed emit carries an inline map that oxc chains through `@ampproject/remapping`, preserving `sourcesContent`.

## Expected Behavior

Every `.ts` source in the bundle sourcemap resolves back to its original TypeScript, in optimized and unoptimized builds alike, on every supported `@angular/build` version.

`setup-compilation.ts` now sets `_useTypeScriptTranspilation` to the emit Nx wants, using the same expression the emit gate used before 22.1, and `setup-with-angular-compilation.ts` reads the value the compilation reports back (`parallel-worker` marshals it), falling back to that expression for versions that ignore the option. Requesting the emit instead of guessing it keeps 22.1+ on the behavior 19–22.0 already had, so nothing changes for builds without sourcemaps: they keep taking Angular's fast raw-TS emit path.

### Verification

Built a generated-style Angular 22.1 app through `createConfig` from source, with `sourceMap.scripts: true`:

| source | before (optimized) | after (optimized) |
| --- | --- | --- |
| `src/app/app.component.ts` | 300 chars | 300 chars |
| `src/app/app.config.ts` | *empty* | 299 chars |
| `src/app/app.routes.ts` | *empty* | 112 chars |
| `src/app/util.ts` | *empty* | 74 chars |
| `src/main.ts` | *empty* | 247 chars |

Decoding the emitted map afterwards resolves generated positions to the expected original locations (`util.ts:2`, `app.routes.ts:4`, `app.component.ts:10`), and a build with sourcemaps disabled still takes the raw-TS emit path and emits no maps.

Unit tests cover the option being set for each `isolatedModules`/`sourceMap` combination (including `useTsProjectReferences`, which forces the raw emit) and the gate preferring the reported option over the fallback expression. The e2e assertion added in #36268 could not catch this — it only requires *a* `.ts` source containing `@Component` to have content, which is exactly the one file that kept working — so it now also builds with optimization enabled and asserts that no `.ts` source is left without content.

## Related Issue(s)

N/A — no linked issue; this is a regression against #36268 introduced by the upstream gate change in `@angular/build` 22.1.
