### PR TITLE
fix(core): align watcher event filtering with the file walker's ignore sources

### DIFF
--- a/astro-docs/src/content/docs/reference/nxignore.mdoc
+++ b/astro-docs/src/content/docs/reference/nxignore.mdoc
@@ -1,6 +1,6 @@
 ---
 title: .nxignore Reference
-description: Learn how to use the .nxignore file to specify files in your workspace that should be completely ignored by Nx during affected calculations.
+description: Learn how to use the .nxignore file to specify files in your workspace that Nx should ignore in file discovery and affected calculations.
 sidebar:
   order: 5
   label: .nxignore
@@ -11,6 +11,28 @@ You may optionally add an `.nxignore` file to the root. This file is used to spe
 be completely ignored by Nx.
 
 The syntax is the same as
-a [`.gitignore` file](https://git-scm.com/book/en/v2/Git-Basics-Recording-Changes-to-the-Repository#_ignoring).
+a [`.gitignore` file](https://git-scm.com/book/en/v2/Git-Basics-Recording-Changes-to-the-Repository#_ignoring),
+including negation patterns (`!pattern`). Nx also reads `.nxignore` files in nested directories; each one applies to
+the directory it lives in.
 
-**When a file is specified in the `.nxignore` file**, changes to that file are not taken into account in the `affected` calculations.
+Nx excludes ignored files from file discovery: they don't appear in the project graph's file map, they aren't part of
+task input hashes, and changes to them are not taken into account in the `affected` calculations.
+
+## Re-including ignored files
+
+A negation pattern in `.nxignore` makes Nx track a file that a `.gitignore` rule excludes. As with git, a file can't be
+re-included if one of its parent directories is excluded. To re-include a file inside an ignored directory, exclude the
+directory's contents instead of the directory itself:
+
+```text
+# .gitignore
+dist/*
+```
+
+```text
+# .nxignore
+!dist/.env.e2e
+```
+
+With `dist/` in `.gitignore`, the `!dist/.env.e2e` negation would have no effect because the `dist` directory itself is
+excluded.

--- a/packages/nx/src/daemon/server/watcher.ts
+++ b/packages/nx/src/daemon/server/watcher.ts
@@ -27,9 +27,15 @@ function dispatchWorkspaceChanges(
   events: WatchEvent[]
 ): Promise<void> | undefined {
   for (const event of events) {
-    if (event.path.endsWith('.gitignore') || event.path === '.nxignore') {
-      // If the ignore files themselves have changed we need to dynamically
-      // update our cached ignoreGlobs
+    // The watcher's filter caches every ignore file it read at startup
+    // (.gitignore, .ignore, and .nxignore files at any depth), so a change
+    // to any of them requires a restart to rebuild the filter.
+    const fileName = event.path.split(/[\\/]/).pop();
+    if (
+      fileName === '.gitignore' ||
+      fileName === '.nxignore' ||
+      fileName === '.ignore'
+    ) {
       handleServerProcessTermination({
         server: activeServer,
         reason: 'Stopping the daemon the set of ignored files changed (native)',

--- a/packages/nx/src/native/walker.rs
+++ b/packages/nx/src/native/walker.rs
@@ -364,6 +364,41 @@ nested/child-two/
     }
 
     #[test]
+    fn nxignore_negation_reincludes_at_root_but_not_under_gitignored_dir() {
+        let temp_dir = assert_fs::TempDir::new().unwrap();
+        temp_dir
+            .child(".gitignore")
+            .write_str("dist/\n.env*\n")
+            .unwrap();
+        temp_dir
+            .child(".nxignore")
+            .write_str("!.env.e2e\n")
+            .unwrap();
+        temp_dir.child(".env.e2e").write_str("x").unwrap();
+        temp_dir.child(".env.local").write_str("x").unwrap();
+        temp_dir.child("dist/.env.e2e").write_str("x").unwrap();
+        temp_dir.child("src/index.ts").write_str("x").unwrap();
+
+        let mut files: Vec<_> = nx_walker(temp_dir.path(), true)
+            .map(|f| f.normalized_path)
+            .collect();
+        files.sort();
+
+        // .nxignore's negation re-includes the root-level file, but cannot
+        // re-include a file whose parent directory is excluded (git's rule:
+        // the walk prunes dist/ and never descends into it).
+        assert_eq!(
+            files,
+            vec![
+                ".env.e2e".to_string(),
+                ".gitignore".to_string(),
+                ".nxignore".to_string(),
+                "src/index.ts".to_string()
+            ]
+        );
+    }
+
+    #[test]
     fn ignores_parent_gitignore_when_workspace_is_git_root() {
         let parent_temp = assert_fs::TempDir::new().unwrap();
         parent_temp.child(".gitignore").write_str("*").unwrap();

--- a/packages/nx/src/native/watch/git_utils.rs
+++ b/packages/nx/src/native/watch/git_utils.rs
@@ -3,38 +3,70 @@ use tracing::trace;
 
 use crate::native::utils::git::parent_gitignore_files;
 
-/// Collect .gitignore files using a simple approach that reuses walker logic
-fn collect_workspace_gitignores<P: AsRef<Path>>(root: P) -> Vec<PathBuf> {
+/// Ignore files discovered in the workspace, one Vec per source, matching
+/// the sources the walker's `WalkBuilder` reads (custom .nxignore files,
+/// .ignore files, .gitignore files).
+pub(in crate::native) struct IgnoreFiles {
+    /// .gitignore files inside the workspace.
+    pub gitignores: Vec<PathBuf>,
+    /// .gitignore files from directories above the workspace. Kept separate:
+    /// the walker registers these via `add_ignore`, which roots patterns at
+    /// the process CWD and consults them last, so they need different
+    /// compilation and ordering than workspace .gitignore files.
+    pub parent_gitignores: Vec<PathBuf>,
+    pub dot_ignores: Vec<PathBuf>,
+    pub nxignores: Vec<PathBuf>,
+}
+
+/// Collect ignore files using a simple approach that reuses walker logic
+fn collect_workspace_ignore_files<P: AsRef<Path>>(
+    root: P,
+) -> (Vec<PathBuf>, Vec<PathBuf>, Vec<PathBuf>) {
     use crate::native::walker::nx_walker_sync;
 
-    // Use our own walker to find .gitignore files, filtering out node_modules
-    let gitignore_filters = vec!["node_modules".to_string()];
+    // Use our own walker to find ignore files, filtering out node_modules
+    let ignore_filters = vec!["node_modules".to_string()];
 
     let root_path = root.as_ref();
 
-    nx_walker_sync(&root, Some(&gitignore_filters))
-        .filter_map(|relative_path| {
-            // Only process .gitignore files
-            if relative_path.file_name()?.to_str()? == ".gitignore" {
-                Some(root_path.join(&relative_path))
-            } else {
-                None
-            }
-        })
-        .collect()
-}
+    let mut gitignores = Vec::new();
+    let mut dot_ignores = Vec::new();
+    let mut nxignores = Vec::new();
 
-pub(in crate::native) fn get_gitignore_files<T: AsRef<str>>(root: T) -> Vec<PathBuf> {
-    let root_path = PathBuf::from(root.as_ref());
-
-    // Start with workspace .gitignore files
-    let mut ignore_files = collect_workspace_gitignores(&root_path);
-
-    // Add parent .gitignore files using shared logic
-    if let Some(gitignore_paths) = parent_gitignore_files(&root_path) {
-        ignore_files.extend(gitignore_paths);
+    for relative_path in nx_walker_sync(&root, Some(&ignore_filters)) {
+        let Some(file_name) = relative_path.file_name().and_then(|f| f.to_str()) else {
+            continue;
+        };
+        match file_name {
+            ".gitignore" => gitignores.push(root_path.join(&relative_path)),
+            ".ignore" => dot_ignores.push(root_path.join(&relative_path)),
+            ".nxignore" => nxignores.push(root_path.join(&relative_path)),
+            _ => {}
+        }
     }
 
-    trace!(?ignore_files, "Final ignore files list");
-    ignore_files
+    (gitignores, dot_ignores, nxignores)
+}
+
+pub(in crate::native) fn get_ignore_files<T: AsRef<str>>(root: T) -> IgnoreFiles {
+    let root_path = PathBuf::from(root.as_ref());
+
+    let (gitignores, dot_ignores, nxignores) = collect_workspace_ignore_files(&root_path);
+
+    // Add parent .gitignore files using shared logic
+    let parent_gitignores = parent_gitignore_files(&root_path).unwrap_or_default();
+
+    trace!(
+        ?gitignores,
+        ?parent_gitignores,
+        ?dot_ignores,
+        ?nxignores,
+        "Final ignore files list"
+    );
+    IgnoreFiles {
+        gitignores,
+        parent_gitignores,
+        dot_ignores,
+        nxignores,
+    }
 }

--- a/packages/nx/src/native/watch/watch_filterer.rs
+++ b/packages/nx/src/native/watch/watch_filterer.rs
@@ -2,32 +2,95 @@ use ignore::Match;
 use ignore::gitignore::{Gitignore, GitignoreBuilder};
 use notify::EventKind;
 use notify::event::{CreateKind, ModifyKind, RemoveKind};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 use tracing::trace;
 
-use crate::native::watch::git_utils::get_gitignore_files;
+use crate::native::watch::git_utils::get_ignore_files;
 use crate::native::watch::types::{RawWatchEvent, meta_is_dir};
 use crate::native::watch::utils::get_nx_ignore;
 
 #[derive(Debug)]
 pub struct WatchFilterer {
     origin: PathBuf,
+    /// The root .nxignore, consulted first in the path-level decision.
     nx_ignore: Option<Gitignore>,
-    /// Per-directory gitignore instances, sorted deepest-first (most path components first).
-    /// Each entry is (directory the .gitignore applies in, compiled Gitignore).
+    /// Path-level matchers: per-directory .gitignore instances plus the
+    /// synthetic matcher built from caller-supplied globs, sorted
+    /// deepest-first (most path components first); first non-None match wins.
     git_ignores: Vec<(PathBuf, Gitignore)>,
+    /// Matchers deciding whether the walker would descend into an ancestor
+    /// directory, in the same source order WalkBuilder resolves them:
+    /// .nxignore files, then .ignore files, then .gitignore files (each
+    /// group deepest-first), then parent .gitignore files. Caller-supplied
+    /// globs are excluded: the walker never sees them, and their negations
+    /// must keep re-including files under ignored parents (e.g. the daemon's
+    /// `!.nx/workspace-data/d/server-process.json`).
+    ancestor_ignores: Vec<(PathBuf, Gitignore)>,
+}
+
+/// Whether the walker would prune this directory and not descend into it:
+/// the first matcher with an opinion says Ignore. Each entry is checked
+/// against the directory alone (no parent walking); the caller feeds every
+/// ancestor level separately, mirroring the walker's descent. Only matchers
+/// from proper ancestors of the directory vote: the walker loads a
+/// directory's own ignore files after deciding to descend into it, so they
+/// cannot influence that decision.
+fn ancestor_ignored(entries: &[&(PathBuf, Gitignore)], dir: &Path) -> bool {
+    for (ig_dir, ig) in entries {
+        if dir == ig_dir || !dir.starts_with(ig_dir) {
+            continue;
+        }
+        match ig.matched(dir, true) {
+            Match::Whitelist(_) => return false,
+            Match::Ignore(_) => return true,
+            Match::None => {}
+        }
+    }
+    false
 }
 
 impl WatchFilterer {
-    fn filter_path(&self, path: &std::path::Path, is_dir: bool) -> bool {
+    fn filter_path(&self, path: &Path, is_dir: bool) -> bool {
         let path = dunce::simplified(path);
+        let under_origin = path.starts_with(&self.origin);
 
+        // Mirror the walker's descent: check every ancestor directory from
+        // the origin down and stop at the first ignored one. This enforces
+        // git's rule that a file cannot be re-included (e.g. by an .nxignore
+        // negation) when a parent directory is excluded. The walker prunes
+        // such a directory and never produces its files, so the watcher must
+        // not deliver events for them either.
+        if under_origin && !self.ancestor_ignores.is_empty() {
+            // Select the matchers that can apply anywhere along this path
+            // once, so the loop doesn't rescan every matcher per level.
+            let applicable: Vec<&(PathBuf, Gitignore)> = self
+                .ancestor_ignores
+                .iter()
+                .filter(|(dir, _)| path.starts_with(dir))
+                .collect();
+
+            if !applicable.is_empty() {
+                let ancestors: Vec<&Path> = path
+                    .ancestors()
+                    .skip(1)
+                    .take_while(|a| *a != self.origin && a.starts_with(&self.origin))
+                    .collect();
+                for dir in ancestors.iter().rev() {
+                    if ancestor_ignored(&applicable, dir) {
+                        trace!(?path, ?dir, "ignored parent directory - blocked");
+                        return false;
+                    }
+                }
+            }
+        }
+
+        // Path-level decision, unchanged by the descent check above.
         // .nxignore takes precedence over .gitignore. Only consult it for
-        // paths under the origin — gitignore-style matchers are scoped to
+        // paths under the origin: gitignore-style matchers are scoped to
         // the directory the ignore file lives in, so external symlink
         // targets shouldn't be matched against workspace rules.
         let nx_match = if let Some(ig) = &self.nx_ignore
-            && path.starts_with(&self.origin)
+            && under_origin
         {
             ig.matched_path_or_any_parents(path, is_dir)
         } else {
@@ -121,34 +184,66 @@ pub(super) fn create_filter(
     additional_globs: &[String],
     use_ignore: bool,
 ) -> anyhow::Result<WatchFilterer> {
-    let ignore_files = use_ignore.then(|| get_gitignore_files(origin));
+    let ignore_files = use_ignore.then(|| get_ignore_files(origin));
     let nx_ignore_path = get_nx_ignore(origin);
 
     trace!(
         ?use_ignore,
         ?additional_globs,
-        ?ignore_files,
         "Using these ignore files for the watcher"
     );
 
-    let mut git_ignores: Vec<(PathBuf, Gitignore)> = Vec::new();
+    let compile = |path: &PathBuf| -> (PathBuf, Gitignore) {
+        let (gitignore, err) = Gitignore::new(path);
+        if let Some(err) = err {
+            trace!(
+                ?err,
+                ?path,
+                "error parsing ignore file, using partial result"
+            );
+        }
+        let dir = path.parent().unwrap_or(path).to_path_buf();
+        (dir, gitignore)
+    };
 
-    // Build per-directory Gitignore instances from .gitignore files
-    if let Some(paths) = ignore_files {
-        for gitignore_path in paths {
-            let (gitignore, err) = Gitignore::new(&gitignore_path);
-            if let Some(err) = err {
-                trace!(
-                    ?err,
-                    ?gitignore_path,
-                    "error parsing gitignore, using partial result"
-                );
-            }
-            let dir = gitignore_path
-                .parent()
-                .unwrap_or(&gitignore_path)
-                .to_path_buf();
+    let mut git_ignores: Vec<(PathBuf, Gitignore)> = Vec::new();
+    // (source rank, dir, matcher); rank follows WalkBuilder's resolution
+    // order: 0 = .nxignore (custom), 1 = .ignore, 2 = .gitignore,
+    // 3 = parent .gitignore (explicit ignores, consulted last).
+    let mut ancestor_ignores: Vec<(u8, PathBuf, Gitignore)> = Vec::new();
+
+    if let Some(files) = &ignore_files {
+        for path in &files.gitignores {
+            let (dir, gitignore) = compile(path);
+            git_ignores.push((dir.clone(), gitignore.clone()));
+            ancestor_ignores.push((2, dir, gitignore));
+        }
+        // The walker registers parent .gitignore files via `add_ignore`,
+        // which compiles them rooted at the process CWD and consults them
+        // last, for every entry, farthest directory first. Mirror that in
+        // the descent check (same process, same CWD; the list arrives
+        // nearest-first, so reverse it); the path-level chain keeps the
+        // parent-rooted matcher it always had.
+        for path in &files.parent_gitignores {
+            let (dir, gitignore) = compile(path);
             git_ignores.push((dir, gitignore));
+        }
+        if let Ok(cwd) = std::env::current_dir() {
+            for path in files.parent_gitignores.iter().rev() {
+                let mut builder = GitignoreBuilder::new(&cwd);
+                builder.add(path);
+                if let Ok(gitignore) = builder.build() {
+                    ancestor_ignores.push((3, PathBuf::from(origin), gitignore));
+                }
+            }
+        }
+        for path in &files.dot_ignores {
+            let (dir, gitignore) = compile(path);
+            ancestor_ignores.push((1, dir, gitignore));
+        }
+        for path in &files.nxignores {
+            let (dir, gitignore) = compile(path);
+            ancestor_ignores.push((0, dir, gitignore));
         }
     }
 
@@ -162,6 +257,16 @@ pub(super) fn create_filter(
         git_ignores.push((PathBuf::from(origin), gitignore));
     }
 
+    // Build .nxignore. When use_ignore is false the walker applies no
+    // filtering at all, so there is no descent to mirror and the ancestor
+    // chain stays empty; the path-level .nxignore check still applies.
+    let nx_ignore = if let Some(nxignore_path) = &nx_ignore_path {
+        let (_, gitignore) = compile(nxignore_path);
+        Some(gitignore)
+    } else {
+        None
+    };
+
     // Sort deepest-first (most path components first) so deeper gitignores take priority
     git_ignores.sort_by(|(a, _), (b, _)| {
         let a_depth = a.components().count();
@@ -169,24 +274,255 @@ pub(super) fn create_filter(
         b_depth.cmp(&a_depth)
     });
 
-    // Build .nxignore
-    let nx_ignore = if let Some(nxignore_path) = nx_ignore_path {
-        let (gitignore, err) = Gitignore::new(&nxignore_path);
-        if let Some(err) = err {
-            trace!(
-                ?err,
-                ?nxignore_path,
-                "error parsing nxignore, using partial result"
-            );
-        }
-        Some(gitignore)
-    } else {
-        None
-    };
+    // Source rank first, then deepest-first within each source.
+    ancestor_ignores.sort_by(|(a_rank, a_dir, _), (b_rank, b_dir, _)| {
+        a_rank.cmp(b_rank).then_with(|| {
+            let a_depth = a_dir.components().count();
+            let b_depth = b_dir.components().count();
+            b_depth.cmp(&a_depth)
+        })
+    });
 
     Ok(WatchFilterer {
         origin: PathBuf::from(origin),
         git_ignores,
         nx_ignore,
+        ancestor_ignores: ancestor_ignores
+            .into_iter()
+            .map(|(_, dir, ig)| (dir, ig))
+            .collect(),
     })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+    use tempfile::tempdir;
+
+    fn filterer(origin: &Path) -> WatchFilterer {
+        create_filter(origin.to_str().unwrap(), &[], true).unwrap()
+    }
+
+    #[test]
+    fn nxignore_negation_does_not_reinclude_under_ignored_dir() {
+        let dir = tempdir().unwrap();
+        let origin = dir.path().canonicalize().unwrap();
+        fs::write(origin.join(".gitignore"), "dist/\n.env*\n").unwrap();
+        fs::write(origin.join(".nxignore"), "!.env.e2e\n").unwrap();
+
+        let f = filterer(&origin);
+        // git's rule: a file cannot be re-included when a parent directory is
+        // excluded. The walker prunes dist/ and never sees these paths, so the
+        // watcher must drop them too.
+        assert!(!f.filter_path(&origin.join("dist/.env.e2e"), false));
+        assert!(!f.filter_path(&origin.join("packages/a/dist/.env.e2e"), false));
+    }
+
+    #[test]
+    fn nxignore_negation_reincludes_at_root() {
+        let dir = tempdir().unwrap();
+        let origin = dir.path().canonicalize().unwrap();
+        fs::write(origin.join(".gitignore"), ".env*\n").unwrap();
+        fs::write(origin.join(".nxignore"), "!.env.e2e\n").unwrap();
+
+        let f = filterer(&origin);
+        assert!(f.filter_path(&origin.join(".env.e2e"), false));
+        assert!(!f.filter_path(&origin.join(".env.local"), false));
+    }
+
+    #[test]
+    fn nxignore_whitelisted_dir_allows_descent() {
+        let dir = tempdir().unwrap();
+        let origin = dir.path().canonicalize().unwrap();
+        fs::write(origin.join(".gitignore"), "dist/\n").unwrap();
+        fs::write(origin.join(".nxignore"), "!dist/\n").unwrap();
+
+        let f = filterer(&origin);
+        assert!(f.filter_path(&origin.join("dist/foo.txt"), false));
+    }
+
+    #[test]
+    fn gitignored_paths_are_filtered() {
+        let dir = tempdir().unwrap();
+        let origin = dir.path().canonicalize().unwrap();
+        fs::write(origin.join(".gitignore"), "dist/\n*.log\n").unwrap();
+
+        let f = filterer(&origin);
+        assert!(!f.filter_path(&origin.join("dist/main.js"), false));
+        assert!(!f.filter_path(&origin.join("dist/nested/main.js"), false));
+        assert!(!f.filter_path(&origin.join("debug.log"), false));
+        assert!(f.filter_path(&origin.join("src/index.ts"), false));
+    }
+
+    #[test]
+    fn additional_glob_negation_reincludes_under_ignored_dir() {
+        // The daemon's outputs watcher relies on this: it passes
+        // `!.nx/workspace-data/d/server-process.json` as an additional glob
+        // so a replaced daemon notices the takeover, while the hardcoded
+        // globs ignore `**/.nx/workspace-data`. Caller-supplied globs are
+        // not fs ignore files (the walker never sees them), so the negation
+        // must keep re-including the file despite the ignored parent.
+        let dir = tempdir().unwrap();
+        let origin = dir.path().canonicalize().unwrap();
+
+        let f = create_filter(
+            origin.to_str().unwrap(),
+            &[
+                "**/.nx/workspace-data".to_string(),
+                "!.nx/workspace-data/d/server-process.json".to_string(),
+            ],
+            false,
+        )
+        .unwrap();
+        assert!(f.filter_path(
+            &origin.join(".nx/workspace-data/d/server-process.json"),
+            false
+        ));
+        assert!(!f.filter_path(&origin.join(".nx/workspace-data/d/other.json"), false));
+    }
+
+    #[test]
+    fn gitignore_parent_whitelist_beats_additional_globs() {
+        // The path-level decision is first-non-None across matchers,
+        // deepest-first, with parent-derived whitelists participating: a
+        // .gitignore whitelisting dist/ wins over a caller glob ignoring its
+        // contents, exactly as before the ancestor descent check existed.
+        let dir = tempdir().unwrap();
+        let origin = dir.path().canonicalize().unwrap();
+        fs::write(origin.join(".gitignore"), "!dist/\n").unwrap();
+
+        let f = create_filter(origin.to_str().unwrap(), &["dist/**".to_string()], true).unwrap();
+        assert!(f.filter_path(&origin.join("dist/file.txt"), false));
+    }
+
+    #[test]
+    fn dot_ignore_whitelisted_dir_cancels_gitignore_prune() {
+        // .ignore files participate in the walker's descent decision with
+        // higher precedence than .gitignore: a whitelist there keeps the
+        // walker descending, so the watcher must not prune on the
+        // .gitignore alone.
+        let dir = tempdir().unwrap();
+        let origin = dir.path().canonicalize().unwrap();
+        fs::write(origin.join(".gitignore"), "dist/\n").unwrap();
+        fs::write(origin.join(".ignore"), "!dist/\n").unwrap();
+        fs::write(origin.join(".nxignore"), "!dist/keep.txt\n").unwrap();
+
+        let f = filterer(&origin);
+        assert!(f.filter_path(&origin.join("dist/keep.txt"), false));
+    }
+
+    #[test]
+    fn dot_ignored_dir_contents_are_filtered() {
+        // The walker prunes a directory ignored by an .ignore file, so the
+        // watcher must not deliver events from it either.
+        let dir = tempdir().unwrap();
+        let origin = dir.path().canonicalize().unwrap();
+        fs::write(origin.join(".ignore"), "dist/\n").unwrap();
+
+        let f = filterer(&origin);
+        assert!(!f.filter_path(&origin.join("dist/main.js"), false));
+        assert!(f.filter_path(&origin.join("src/index.ts"), false));
+    }
+
+    #[test]
+    fn nested_nxignore_whitelist_cancels_root_nxignore_prune() {
+        // The walker loads .nxignore in every directory it descends into,
+        // deepest-first: a nested whitelist masks the root's Ignore at that
+        // level, so the walker descends and the watcher must not prune.
+        let dir = tempdir().unwrap();
+        let origin = dir.path().canonicalize().unwrap();
+        fs::write(
+            origin.join(".nxignore"),
+            "sub/blocked/\n!sub/blocked/keep.txt\n",
+        )
+        .unwrap();
+        fs::create_dir_all(origin.join("sub")).unwrap();
+        fs::write(origin.join("sub/.nxignore"), "!blocked/\n").unwrap();
+
+        let f = filterer(&origin);
+        assert!(f.filter_path(&origin.join("sub/blocked/keep.txt"), false));
+    }
+
+    #[test]
+    fn ignore_file_inside_pruned_dir_cannot_cancel_its_own_prune() {
+        // The walker loads a directory's ignore files only after deciding to
+        // descend into it, so an .ignore inside dist/ cannot rescue dist/
+        // from being pruned.
+        let dir = tempdir().unwrap();
+        let origin = dir.path().canonicalize().unwrap();
+        fs::write(origin.join(".gitignore"), "dist/\n").unwrap();
+        fs::write(origin.join(".nxignore"), "!dist/keep.txt\n").unwrap();
+        fs::create_dir_all(origin.join("dist")).unwrap();
+        fs::write(origin.join("dist/.ignore"), "!*\n").unwrap();
+
+        let f = filterer(&origin);
+        assert!(!f.filter_path(&origin.join("dist/keep.txt"), false));
+    }
+
+    #[test]
+    fn no_descent_check_without_use_ignore() {
+        // With use_ignore off the walker applies no filtering, so there is
+        // no descent to mirror: the path-level decision alone applies, and
+        // there the .nxignore negation wins path-first. The daemon's outputs
+        // watcher runs in this mode.
+        let dir = tempdir().unwrap();
+        let origin = dir.path().canonicalize().unwrap();
+        fs::write(origin.join(".nxignore"), "dist/\n!dist/keep.txt\n").unwrap();
+
+        let f = create_filter(origin.to_str().unwrap(), &[], false).unwrap();
+        assert!(f.filter_path(&origin.join("dist/keep.txt"), false));
+        assert!(!f.filter_path(&origin.join("dist/other.txt"), false));
+    }
+
+    #[test]
+    fn parent_gitignore_prunes_like_the_walker() {
+        // The walker registers parent .gitignore files via `add_ignore`,
+        // which roots patterns at the process CWD: an unanchored pattern
+        // still matches by basename anywhere and prunes, while an anchored
+        // one anchors to the CWD (not the parent directory) and therefore
+        // does not match the workspace's directories.
+        let parent = tempdir().unwrap();
+        let parent_path = parent.path().canonicalize().unwrap();
+        fs::create_dir_all(parent_path.join(".git")).unwrap();
+        fs::write(parent_path.join(".gitignore"), "foo/\n/workspace/bar/\n").unwrap();
+        let origin = parent_path.join("workspace");
+        fs::create_dir_all(&origin).unwrap();
+        fs::write(origin.join(".nxignore"), "!foo/keep.txt\n!bar/keep.txt\n").unwrap();
+
+        let f = filterer(&origin);
+        assert!(!f.filter_path(&origin.join("foo/keep.txt"), false));
+        assert!(f.filter_path(&origin.join("bar/keep.txt"), false));
+    }
+
+    #[test]
+    fn farther_parent_gitignore_whitelist_wins_over_nearer_ignore() {
+        // The walker consults explicit (parent) ignore files
+        // farthest-directory-first, so a whitelist in the git root beats an
+        // ignore in a nearer parent and the walker still descends.
+        let root = tempdir().unwrap();
+        let root_path = root.path().canonicalize().unwrap();
+        fs::create_dir_all(root_path.join(".git")).unwrap();
+        fs::write(root_path.join(".gitignore"), "!foo/\n").unwrap();
+        fs::create_dir_all(root_path.join("near")).unwrap();
+        fs::write(root_path.join("near/.gitignore"), "foo/\n").unwrap();
+        let origin = root_path.join("near/workspace");
+        fs::create_dir_all(&origin).unwrap();
+        fs::write(origin.join(".nxignore"), "!foo/keep.txt\n").unwrap();
+
+        let f = filterer(&origin);
+        assert!(f.filter_path(&origin.join("foo/keep.txt"), false));
+    }
+
+    #[test]
+    fn nested_gitignore_applies_within_its_dir() {
+        let dir = tempdir().unwrap();
+        let origin = dir.path().canonicalize().unwrap();
+        fs::create_dir_all(origin.join("packages/a")).unwrap();
+        fs::write(origin.join("packages/a/.gitignore"), "generated/\n").unwrap();
+
+        let f = filterer(&origin);
+        assert!(!f.filter_path(&origin.join("packages/a/generated/out.ts"), false));
+        assert!(f.filter_path(&origin.join("packages/b/generated/out.ts"), false));
+    }
 }

--- a/packages/nx/src/native/watch/watch_filterer.rs
+++ b/packages/nx/src/native/watch/watch_filterer.rs
@@ -12,41 +12,54 @@ use crate::native::watch::utils::get_nx_ignore;
 #[derive(Debug)]
 pub struct WatchFilterer {
     origin: PathBuf,
-    /// The root .nxignore, consulted first in the path-level decision.
+    /// Whether to mirror the walker's ignore-file handling. When false the
+    /// walker applies no filtering, so `fs_ignores` stays empty and the
+    /// legacy path-level `.nxignore` check applies instead.
+    use_ignore: bool,
+    /// The root .nxignore, consulted path-first only when `use_ignore` is
+    /// false (the daemon's outputs watcher). With `use_ignore` on, .nxignore
+    /// files are part of `fs_ignores` and follow walker semantics.
     nx_ignore: Option<Gitignore>,
-    /// Path-level matchers: per-directory .gitignore instances plus the
-    /// synthetic matcher built from caller-supplied globs, sorted
-    /// deepest-first (most path components first); first non-None match wins.
-    git_ignores: Vec<(PathBuf, Gitignore)>,
-    /// Matchers deciding whether the walker would descend into an ancestor
-    /// directory, in the same source order WalkBuilder resolves them:
-    /// .nxignore files, then .ignore files, then .gitignore files (each
-    /// group deepest-first), then parent .gitignore files. Caller-supplied
-    /// globs are excluded: the walker never sees them, and their negations
-    /// must keep re-including files under ignored parents (e.g. the daemon's
-    /// `!.nx/workspace-data/d/server-process.json`).
-    ancestor_ignores: Vec<(PathBuf, Gitignore)>,
+    /// Filesystem ignore matchers in the same source order WalkBuilder
+    /// resolves them: .nxignore files, then .ignore files, then workspace
+    /// .gitignore files (each group deepest-first), then parent .gitignore
+    /// files. Used for both the descent decision and the file decision.
+    fs_ignores: Vec<(PathBuf, Gitignore)>,
+    /// Caller-supplied globs plus the always-on patterns, as one matcher
+    /// rooted at origin. Kept separate from `fs_ignores`: the walker never
+    /// sees these globs, and their negations must keep re-including files
+    /// under ignored parents (e.g. the daemon's
+    /// `!.nx/workspace-data/d/server-process.json` takeover glob, whose
+    /// negation line outranks the hardcoded `**/.nx/workspace-data` line
+    /// within the same matcher). With `use_ignore` on, applied to every
+    /// path the ignore files don't exclude, whitelisted ones included: the
+    /// walker's own hardcoded patterns apply unconditionally in
+    /// `filter_entry`, so an ignore-file whitelist must not bypass this
+    /// matcher either. In the legacy mode a root `.nxignore` match still
+    /// decides path-first.
+    additional_globs: Option<Gitignore>,
 }
 
-/// Whether the walker would prune this directory and not descend into it:
-/// the first matcher with an opinion says Ignore. Each entry is checked
-/// against the directory alone (no parent walking); the caller feeds every
-/// ancestor level separately, mirroring the walker's descent. Only matchers
-/// from proper ancestors of the directory vote: the walker loads a
-/// directory's own ignore files after deciding to descend into it, so they
-/// cannot influence that decision.
-fn ancestor_ignored(entries: &[&(PathBuf, Gitignore)], dir: &Path) -> bool {
+/// The first matcher with an opinion on this path wins, mirroring the
+/// walker's per-source resolution. Each entry is checked against the path
+/// alone (no parent walking); the caller feeds ancestor directories
+/// separately for the descent decision. Matchers vote only on paths strictly
+/// inside their directory: the walker loads a directory's own ignore files
+/// after deciding to descend into it, so they cannot influence that
+/// decision, and a file is only ever matched by ignore files at or above its
+/// parent. Returns Some(true) for Ignore, Some(false) for Whitelist.
+fn first_opinion(entries: &[&(PathBuf, Gitignore)], path: &Path, is_dir: bool) -> Option<bool> {
     for (ig_dir, ig) in entries {
-        if dir == ig_dir || !dir.starts_with(ig_dir) {
+        if path == *ig_dir || !path.starts_with(ig_dir) {
             continue;
         }
-        match ig.matched(dir, true) {
-            Match::Whitelist(_) => return false,
-            Match::Ignore(_) => return true,
+        match ig.matched(path, is_dir) {
+            Match::Whitelist(_) => return Some(false),
+            Match::Ignore(_) => return Some(true),
             Match::None => {}
         }
     }
-    false
+    None
 }
 
 impl WatchFilterer {
@@ -54,80 +67,98 @@ impl WatchFilterer {
         let path = dunce::simplified(path);
         let under_origin = path.starts_with(&self.origin);
 
-        // Mirror the walker's descent: check every ancestor directory from
-        // the origin down and stop at the first ignored one. This enforces
-        // git's rule that a file cannot be re-included (e.g. by an .nxignore
-        // negation) when a parent directory is excluded. The walker prunes
-        // such a directory and never produces its files, so the watcher must
-        // not deliver events for them either.
-        if under_origin && !self.ancestor_ignores.is_empty() {
-            // Select the matchers that can apply anywhere along this path
-            // once, so the loop doesn't rescan every matcher per level.
-            let applicable: Vec<&(PathBuf, Gitignore)> = self
-                .ancestor_ignores
-                .iter()
-                .filter(|(dir, _)| path.starts_with(dir))
-                .collect();
-
-            if !applicable.is_empty() {
-                let ancestors: Vec<&Path> = path
-                    .ancestors()
-                    .skip(1)
-                    .take_while(|a| *a != self.origin && a.starts_with(&self.origin))
+        if self.use_ignore {
+            // Mirror the walker's two decisions. Descent: check every
+            // ancestor directory from the origin down and stop at the first
+            // ignored one. This enforces git's rule that a file cannot be
+            // re-included (e.g. by an .nxignore negation) when a parent
+            // directory is excluded. File: the same ranked matchers decide
+            // the path itself. Only an Ignore ends the check here: a
+            // whitelisted file is one the walker includes, and those still
+            // go through the additional globs below.
+            if under_origin && !self.fs_ignores.is_empty() {
+                // Select the matchers that can apply anywhere along this path
+                // once, so the loops don't rescan every matcher per level.
+                let applicable: Vec<&(PathBuf, Gitignore)> = self
+                    .fs_ignores
+                    .iter()
+                    .filter(|(dir, _)| path.starts_with(dir))
                     .collect();
-                for dir in ancestors.iter().rev() {
-                    if ancestor_ignored(&applicable, dir) {
-                        trace!(?path, ?dir, "ignored parent directory - blocked");
+
+                if !applicable.is_empty() {
+                    let ancestors: Vec<&Path> = path
+                        .ancestors()
+                        .skip(1)
+                        .take_while(|a| *a != self.origin && a.starts_with(&self.origin))
+                        .collect();
+                    for dir in ancestors.iter().rev() {
+                        if first_opinion(&applicable, dir, true) == Some(true) {
+                            trace!(?path, ?dir, "ignored parent directory - blocked");
+                            return false;
+                        }
+                    }
+
+                    // Ignore files themselves skip the file-level decision:
+                    // the walker reads a directory's ignore files even when
+                    // their own paths match an ignore rule, and the daemon
+                    // restarts on their events to rebuild this filter (see
+                    // daemon/server/watcher.ts), so suppressing them would
+                    // leave the daemon holding stale rules. The descent
+                    // check above still applies: the walker never reads
+                    // ignore files inside pruned directories, so those edits
+                    // cannot change the walk. Directories named like ignore
+                    // files are not ignore files; the walker prunes them
+                    // normally.
+                    let is_control_file = !is_dir
+                        && matches!(
+                            path.file_name().and_then(|f| f.to_str()),
+                            Some(".gitignore" | ".ignore" | ".nxignore")
+                        );
+                    if !is_control_file && first_opinion(&applicable, path, is_dir) == Some(true) {
+                        trace!(?path, "ignore file match - blocked");
                         return false;
                     }
                 }
             }
-        }
-
-        // Path-level decision, unchanged by the descent check above.
-        // .nxignore takes precedence over .gitignore. Only consult it for
-        // paths under the origin: gitignore-style matchers are scoped to
-        // the directory the ignore file lives in, so external symlink
-        // targets shouldn't be matched against workspace rules.
-        let nx_match = if let Some(ig) = &self.nx_ignore
+        } else if let Some(ig) = &self.nx_ignore
             && under_origin
         {
-            ig.matched_path_or_any_parents(path, is_dir)
-        } else {
-            Match::None
-        };
-
-        match nx_match {
-            Match::Whitelist(_) => {
-                trace!(?path, "nxignore whitelist match, ignoring gitignore");
-                return true;
+            // Legacy mode: the walker applies no filtering, so there are no
+            // walker decisions to mirror. The root .nxignore applies
+            // path-first, negation included. Only consult it for paths under
+            // the origin: gitignore-style matchers are scoped to the
+            // directory the ignore file lives in, so external symlink
+            // targets shouldn't be matched against workspace rules.
+            match ig.matched_path_or_any_parents(path, is_dir) {
+                Match::Whitelist(_) => {
+                    trace!(?path, "nxignore whitelist match - allowed");
+                    return true;
+                }
+                Match::Ignore(_) => {
+                    trace!(?path, "nxignore ignore match - blocked");
+                    return false;
+                }
+                Match::None => {}
             }
-            Match::Ignore(_) => {
-                trace!(?path, "nxignore ignore match, ignoring gitignore");
-                return false;
-            }
-            Match::None => {}
         }
 
-        // Check gitignores deepest-first; first non-None match wins.
-        let git_match = self
-            .git_ignores
-            .iter()
-            .filter(|(dir, _)| path.starts_with(dir))
-            .map(|(_, ig)| ig.matched_path_or_any_parents(path, is_dir))
-            .find(|m| !matches!(m, Match::None));
-
-        match git_match {
-            Some(Match::Ignore(_)) => {
-                trace!(?path, "gitignore match - blocked");
-                false
+        if let Some(ig) = &self.additional_globs
+            && under_origin
+        {
+            match ig.matched_path_or_any_parents(path, is_dir) {
+                Match::Ignore(_) => {
+                    trace!(?path, "additional glob match - blocked");
+                    return false;
+                }
+                Match::Whitelist(_) => {
+                    trace!(?path, "additional glob whitelist match - allowed");
+                    return true;
+                }
+                Match::None => {}
             }
-            Some(Match::Whitelist(_)) => {
-                trace!(?path, "gitignore whitelist match - allowed");
-                true
-            }
-            _ => true,
         }
+
+        true
     }
 
     /// Check whether a watch event should be passed through.
@@ -206,76 +237,77 @@ pub(super) fn create_filter(
         (dir, gitignore)
     };
 
-    let mut git_ignores: Vec<(PathBuf, Gitignore)> = Vec::new();
     // (source rank, dir, matcher); rank follows WalkBuilder's resolution
     // order: 0 = .nxignore (custom), 1 = .ignore, 2 = .gitignore,
     // 3 = parent .gitignore (explicit ignores, consulted last).
-    let mut ancestor_ignores: Vec<(u8, PathBuf, Gitignore)> = Vec::new();
+    let mut fs_ignores: Vec<(u8, PathBuf, Gitignore)> = Vec::new();
 
     if let Some(files) = &ignore_files {
+        for path in &files.nxignores {
+            let (dir, gitignore) = compile(path);
+            fs_ignores.push((0, dir, gitignore));
+        }
+        // WalkBuilder probes the literal lowercase name in each directory,
+        // so on a case-insensitive filesystem the walker reads a case-variant
+        // root .nxignore (e.g. .NXIGNORE) that the name-based collection
+        // misses. Compile the probed root path when the collection did not
+        // already cover it.
+        if let Some(path) = &nx_ignore_path
+            && !files.nxignores.contains(path)
+        {
+            let (dir, gitignore) = compile(path);
+            fs_ignores.push((0, dir, gitignore));
+        }
+        for path in &files.dot_ignores {
+            let (dir, gitignore) = compile(path);
+            fs_ignores.push((1, dir, gitignore));
+        }
         for path in &files.gitignores {
             let (dir, gitignore) = compile(path);
-            git_ignores.push((dir.clone(), gitignore.clone()));
-            ancestor_ignores.push((2, dir, gitignore));
+            fs_ignores.push((2, dir, gitignore));
         }
         // The walker registers parent .gitignore files via `add_ignore`,
         // which compiles them rooted at the process CWD and consults them
-        // last, for every entry, farthest directory first. Mirror that in
-        // the descent check (same process, same CWD; the list arrives
-        // nearest-first, so reverse it); the path-level chain keeps the
-        // parent-rooted matcher it always had.
-        for path in &files.parent_gitignores {
-            let (dir, gitignore) = compile(path);
-            git_ignores.push((dir, gitignore));
-        }
+        // last, for every entry, farthest directory first. Mirror that
+        // (same process, same CWD; the list arrives nearest-first, so
+        // reverse it).
         if let Ok(cwd) = std::env::current_dir() {
             for path in files.parent_gitignores.iter().rev() {
                 let mut builder = GitignoreBuilder::new(&cwd);
                 builder.add(path);
                 if let Ok(gitignore) = builder.build() {
-                    ancestor_ignores.push((3, PathBuf::from(origin), gitignore));
+                    fs_ignores.push((3, PathBuf::from(origin), gitignore));
                 }
             }
         }
-        for path in &files.dot_ignores {
-            let (dir, gitignore) = compile(path);
-            ancestor_ignores.push((1, dir, gitignore));
-        }
-        for path in &files.nxignores {
-            let (dir, gitignore) = compile(path);
-            ancestor_ignores.push((0, dir, gitignore));
-        }
     }
 
-    // Build additional globs as a synthetic gitignore rooted at origin
-    if !additional_globs.is_empty() {
+    // Build additional globs as one matcher rooted at origin. Line order
+    // matters: caller globs come after the always-on patterns, so a caller
+    // negation can re-include a path the hardcoded lines ignore.
+    let additional_globs = if !additional_globs.is_empty() {
         let mut builder = GitignoreBuilder::new(origin);
         for glob in additional_globs {
             builder.add_line(None, glob)?;
         }
-        let gitignore = builder.build()?;
-        git_ignores.push((PathBuf::from(origin), gitignore));
-    }
+        Some(builder.build()?)
+    } else {
+        None
+    };
 
-    // Build .nxignore. When use_ignore is false the walker applies no
-    // filtering at all, so there is no descent to mirror and the ancestor
-    // chain stays empty; the path-level .nxignore check still applies.
-    let nx_ignore = if let Some(nxignore_path) = &nx_ignore_path {
+    // The root .nxignore for the legacy (use_ignore = false) mode; with
+    // use_ignore on it is already part of fs_ignores.
+    let nx_ignore = if use_ignore {
+        None
+    } else if let Some(nxignore_path) = &nx_ignore_path {
         let (_, gitignore) = compile(nxignore_path);
         Some(gitignore)
     } else {
         None
     };
 
-    // Sort deepest-first (most path components first) so deeper gitignores take priority
-    git_ignores.sort_by(|(a, _), (b, _)| {
-        let a_depth = a.components().count();
-        let b_depth = b.components().count();
-        b_depth.cmp(&a_depth)
-    });
-
     // Source rank first, then deepest-first within each source.
-    ancestor_ignores.sort_by(|(a_rank, a_dir, _), (b_rank, b_dir, _)| {
+    fs_ignores.sort_by(|(a_rank, a_dir, _), (b_rank, b_dir, _)| {
         a_rank.cmp(b_rank).then_with(|| {
             let a_depth = a_dir.components().count();
             let b_depth = b_dir.components().count();
@@ -285,9 +317,10 @@ pub(super) fn create_filter(
 
     Ok(WatchFilterer {
         origin: PathBuf::from(origin),
-        git_ignores,
+        use_ignore,
         nx_ignore,
-        ancestor_ignores: ancestor_ignores
+        additional_globs,
+        fs_ignores: fs_ignores
             .into_iter()
             .map(|(_, dir, ig)| (dir, ig))
             .collect(),
@@ -332,6 +365,25 @@ mod tests {
     }
 
     #[test]
+    fn nxignore_whitelist_reincludes_nested_gitignored_file() {
+        // Mirrors the long-standing watcher.spec.ts fixture: an .nxignore
+        // negation wins over a nested .gitignore because the walker consults
+        // the custom ignore source before .gitignore files, and an
+        // unanchored .nxignore pattern matches at any depth.
+        let dir = tempdir().unwrap();
+        let origin = dir.path().canonicalize().unwrap();
+        fs::write(origin.join(".gitignore"), ".env.local\n").unwrap();
+        fs::write(origin.join(".nxignore"), "!.env.*\nboo.txt\n").unwrap();
+        fs::create_dir_all(origin.join("inner")).unwrap();
+        fs::write(origin.join("inner/.gitignore"), ".env.inner\n").unwrap();
+
+        let f = filterer(&origin);
+        assert!(f.filter_path(&origin.join(".env.local"), false));
+        assert!(f.filter_path(&origin.join("inner/.env.inner"), false));
+        assert!(!f.filter_path(&origin.join("inner/boo.txt"), false));
+    }
+
+    #[test]
     fn nxignore_whitelisted_dir_allows_descent() {
         let dir = tempdir().unwrap();
         let origin = dir.path().canonicalize().unwrap();
@@ -353,6 +405,46 @@ mod tests {
         assert!(!f.filter_path(&origin.join("dist/nested/main.js"), false));
         assert!(!f.filter_path(&origin.join("debug.log"), false));
         assert!(f.filter_path(&origin.join("src/index.ts"), false));
+    }
+
+    #[test]
+    fn root_dot_ignore_file_pattern_filters() {
+        // The walker reads .ignore files, so a direct-file pattern there
+        // excludes the file from the cold walk and the watcher must drop it.
+        let dir = tempdir().unwrap();
+        let origin = dir.path().canonicalize().unwrap();
+        fs::write(origin.join(".ignore"), "*.tmp\n").unwrap();
+
+        let f = filterer(&origin);
+        assert!(!f.filter_path(&origin.join("scratch.tmp"), false));
+        assert!(f.filter_path(&origin.join("src/index.ts"), false));
+    }
+
+    #[test]
+    fn nested_nxignore_file_pattern_filters() {
+        // The walker loads .nxignore in every directory it descends into, so
+        // a direct-file pattern in a nested .nxignore excludes files under
+        // that directory.
+        let dir = tempdir().unwrap();
+        let origin = dir.path().canonicalize().unwrap();
+        fs::create_dir_all(origin.join("packages/a")).unwrap();
+        fs::write(origin.join("packages/a/.nxignore"), "local.txt\n").unwrap();
+
+        let f = filterer(&origin);
+        assert!(!f.filter_path(&origin.join("packages/a/local.txt"), false));
+        assert!(f.filter_path(&origin.join("packages/b/local.txt"), false));
+    }
+
+    #[test]
+    fn nested_dot_ignore_file_pattern_filters() {
+        let dir = tempdir().unwrap();
+        let origin = dir.path().canonicalize().unwrap();
+        fs::create_dir_all(origin.join("packages/a")).unwrap();
+        fs::write(origin.join("packages/a/.ignore"), "*.snap\n").unwrap();
+
+        let f = filterer(&origin);
+        assert!(!f.filter_path(&origin.join("packages/a/tests/a.snap"), false));
+        assert!(f.filter_path(&origin.join("packages/b/tests/b.snap"), false));
     }
 
     #[test]
@@ -383,17 +475,54 @@ mod tests {
     }
 
     #[test]
-    fn gitignore_parent_whitelist_beats_additional_globs() {
-        // The path-level decision is first-non-None across matchers,
-        // deepest-first, with parent-derived whitelists participating: a
-        // .gitignore whitelisting dist/ wins over a caller glob ignoring its
-        // contents, exactly as before the ancestor descent check existed.
+    fn additional_globs_filter_walker_included_files() {
+        // Additional globs are a watcher-level filter on top of the walker's
+        // visibility: a file the ignore files leave alone (even under a
+        // whitelisted directory) is still dropped when a glob matches it.
+        // The daemon relies on this to suppress vite/vitest timestamp files.
         let dir = tempdir().unwrap();
         let origin = dir.path().canonicalize().unwrap();
         fs::write(origin.join(".gitignore"), "!dist/\n").unwrap();
 
         let f = create_filter(origin.to_str().unwrap(), &["dist/**".to_string()], true).unwrap();
-        assert!(f.filter_path(&origin.join("dist/file.txt"), false));
+        assert!(!f.filter_path(&origin.join("dist/file.txt"), false));
+    }
+
+    #[test]
+    fn additional_globs_apply_even_to_whitelisted_files() {
+        // An ignore-file whitelist means the walker includes the file; it
+        // does not bypass the additional globs, just as the walker's own
+        // hardcoded patterns apply unconditionally in filter_entry.
+        let dir = tempdir().unwrap();
+        let origin = dir.path().canonicalize().unwrap();
+        fs::write(origin.join(".gitignore"), "!keep.txt\n").unwrap();
+
+        let f = create_filter(origin.to_str().unwrap(), &["*.txt".to_string()], true).unwrap();
+        assert!(!f.filter_path(&origin.join("keep.txt"), false));
+        assert!(f.filter_path(&origin.join("keep.md"), false));
+    }
+
+    #[test]
+    fn broad_dot_ignore_whitelist_cannot_admit_suppressed_files() {
+        // A blanket whitelist in an .ignore file must not defeat the
+        // watcher's always-on suppression (vite/vitest timestamp files,
+        // hardcoded directories).
+        let dir = tempdir().unwrap();
+        let origin = dir.path().canonicalize().unwrap();
+        fs::write(origin.join(".ignore"), "!*\n").unwrap();
+
+        let f = create_filter(
+            origin.to_str().unwrap(),
+            &[
+                "**/node_modules".to_string(),
+                "vite.config.ts.timestamp*.mjs".to_string(),
+            ],
+            true,
+        )
+        .unwrap();
+        assert!(!f.filter_path(&origin.join("vite.config.ts.timestamp-123.mjs"), false));
+        assert!(!f.filter_path(&origin.join("node_modules/keep.js"), false));
+        assert!(f.filter_path(&origin.join("src/index.ts"), false));
     }
 
     #[test]
@@ -512,6 +641,121 @@ mod tests {
 
         let f = filterer(&origin);
         assert!(f.filter_path(&origin.join("foo/keep.txt"), false));
+    }
+
+    #[test]
+    fn case_variant_root_nxignore_applies_on_case_insensitive_fs() {
+        // WalkBuilder probes the literal lowercase name in each directory,
+        // so on a case-insensitive filesystem the walker reads a root
+        // .NXIGNORE and the watcher must apply it too.
+        let dir = tempdir().unwrap();
+        let origin = dir.path().canonicalize().unwrap();
+        fs::write(origin.join(".NXIGNORE"), "*.log\n").unwrap();
+        if !origin.join(".nxignore").exists() {
+            // Case-sensitive filesystem: the walker does not read .NXIGNORE.
+            return;
+        }
+
+        let f = filterer(&origin);
+        assert!(!f.filter_path(&origin.join("debug.log"), false));
+        assert!(f.filter_path(&origin.join("src/index.ts"), false));
+    }
+
+    #[test]
+    fn dot_ignore_cannot_suppress_gitignore_events() {
+        // The walker reads a .gitignore even when an .ignore pattern matches
+        // its path, and the daemon restarts on .gitignore events to rebuild
+        // this filter: dropping the event would leave the daemon holding
+        // stale rules.
+        let dir = tempdir().unwrap();
+        let origin = dir.path().canonicalize().unwrap();
+        fs::write(origin.join(".ignore"), ".gitignore\n").unwrap();
+        fs::create_dir_all(origin.join("packages/a")).unwrap();
+        fs::write(origin.join("packages/a/.gitignore"), "generated/\n").unwrap();
+
+        let f = filterer(&origin);
+        assert!(f.filter_path(&origin.join(".gitignore"), false));
+        assert!(f.filter_path(&origin.join("packages/a/.gitignore"), false));
+    }
+
+    #[test]
+    fn nested_nxignore_cannot_suppress_gitignore_events() {
+        let dir = tempdir().unwrap();
+        let origin = dir.path().canonicalize().unwrap();
+        fs::create_dir_all(origin.join("packages/a")).unwrap();
+        fs::write(origin.join("packages/a/.nxignore"), ".gitignore\n").unwrap();
+        fs::write(origin.join("packages/a/.gitignore"), "generated/\n").unwrap();
+
+        let f = filterer(&origin);
+        assert!(f.filter_path(&origin.join("packages/a/.gitignore"), false));
+    }
+
+    #[test]
+    fn self_ignored_control_file_events_still_delivered() {
+        // A .gitignore listing .ignore suppresses the .ignore file itself,
+        // but the walker still reads its patterns, so edits to it must reach
+        // the daemon's restart trigger.
+        let dir = tempdir().unwrap();
+        let origin = dir.path().canonicalize().unwrap();
+        fs::write(origin.join(".gitignore"), ".ignore\n").unwrap();
+        fs::write(origin.join(".ignore"), "*.log\n").unwrap();
+
+        let f = filterer(&origin);
+        assert!(f.filter_path(&origin.join(".ignore"), false));
+    }
+
+    #[test]
+    fn control_directory_named_like_ignore_file_stays_suppressed() {
+        // A directory named .gitignore is not an ignore file: the walker
+        // prunes it like any other directory, and admitting it would let the
+        // watcher backfill children the cold walk never returns.
+        let dir = tempdir().unwrap();
+        let origin = dir.path().canonicalize().unwrap();
+        fs::write(origin.join(".ignore"), ".gitignore/\n").unwrap();
+
+        let f = filterer(&origin);
+        assert!(!f.filter_path(&origin.join(".gitignore"), true));
+    }
+
+    #[test]
+    fn control_file_under_pruned_dir_stays_suppressed() {
+        // The walker never reads ignore files inside a pruned directory, so
+        // their edits cannot change the walk and need no restart.
+        let dir = tempdir().unwrap();
+        let origin = dir.path().canonicalize().unwrap();
+        fs::write(origin.join(".gitignore"), "dist/\n").unwrap();
+
+        let f = filterer(&origin);
+        assert!(!f.filter_path(&origin.join("dist/.gitignore"), false));
+    }
+
+    #[test]
+    fn control_file_events_still_respect_additional_globs() {
+        let dir = tempdir().unwrap();
+        let origin = dir.path().canonicalize().unwrap();
+
+        let f = create_filter(
+            origin.to_str().unwrap(),
+            &["**/node_modules".to_string()],
+            true,
+        )
+        .unwrap();
+        assert!(!f.filter_path(&origin.join("node_modules/.gitignore"), false));
+    }
+
+    #[test]
+    fn suppressed_dot_ignore_still_contributes_patterns() {
+        // An .ignore file matched by a .gitignore rule is excluded from the
+        // walk results, but the walker still applies its patterns, so the
+        // watcher must too.
+        let dir = tempdir().unwrap();
+        let origin = dir.path().canonicalize().unwrap();
+        fs::write(origin.join(".gitignore"), ".ignore\n").unwrap();
+        fs::write(origin.join(".ignore"), "*.log\n").unwrap();
+
+        let f = filterer(&origin);
+        assert!(!f.filter_path(&origin.join("debug.log"), false));
+        assert!(f.filter_path(&origin.join("src/index.ts"), false));
     }
 
     #[test]

--- a/packages/nx/src/native/watch/watcher.rs
+++ b/packages/nx/src/native/watch/watcher.rs
@@ -731,6 +731,55 @@ mod tests {
     }
 
     #[test]
+    fn nxignore_negation_under_gitignored_dir_produces_no_events() {
+        // A .nxignore negation cannot re-include a file under a gitignored
+        // directory (git's rule; the walker prunes the directory), so the
+        // watcher must not deliver events for it either. Otherwise a warm
+        // daemon ends up with files in its file map that a cold start never
+        // produces. Only macOS exercises the filter here (the root watch is
+        // recursive); on other platforms the pruned dir is never watched, so
+        // the dist/ assertion holds trivially. The filter itself is pinned
+        // by the watch_filterer unit tests.
+        let dir = tempdir().expect("tempdir");
+        let canonical = dir.path().canonicalize().expect("canonicalize tempdir");
+        fs::write(canonical.join(".gitignore"), "dist/\n.env*\n").expect("gitignore");
+        fs::write(canonical.join(".nxignore"), "!.env.e2e\n").expect("nxignore");
+        fs::create_dir_all(canonical.join("dist")).expect("mkdir dist");
+
+        let mut w = Watcher::new(
+            canonical.to_str().expect("utf-8 path").to_string(),
+            None,
+            None, // use_ignore defaults to true
+        );
+        let captured: Captured = Arc::new(Mutex::new(Vec::new()));
+        let captured_for_cb = captured.clone();
+        let callback: WatchEventCallback = Box::new(move |res| {
+            if let Ok(events) = res {
+                captured_for_cb.lock().unwrap().extend(events);
+            }
+        });
+        w.watch_inner(callback).expect("start watch");
+        std::thread::sleep(Duration::from_millis(300));
+        captured.lock().unwrap().clear();
+
+        fs::write(canonical.join("dist/.env.e2e"), "x").expect("write under dist");
+        // Control: the same negation at the root is honored by walker and
+        // watcher alike, so this event must arrive, proving the watcher
+        // was live while the dist/ write was dropped.
+        fs::write(canonical.join(".env.e2e"), "x").expect("write at root");
+
+        let events = collect(&captured);
+        assert!(
+            events.iter().any(|e| e.path == ".env.e2e"),
+            "root-level negated file should produce an event; got {events:?}"
+        );
+        assert!(
+            !events.iter().any(|e| e.path == "dist/.env.e2e"),
+            "negation must not re-include a file under a gitignored dir; got {events:?}"
+        );
+    }
+
+    #[test]
     fn concurrent_force_flush_pending_callers_do_not_time_out() {
         // Regression: pre-fix the loop dropped "extra" ForceFlush
         // replies, so concurrent callers blocked on the 500 ms


### PR DESCRIPTION
## Current Behavior

The daemon's file watcher decides which events to deliver with its own path-level ignore chain, which diverges from the file walker in several ways:

- Events under directories the walker prunes are still delivered. The reported case: an `.nxignore` negation under a gitignored directory is honored by the watcher, so a warm daemon tracks a file that a cold walk excludes, and task hashes differ between warm and cold runs.
- Root and nested `.ignore` files, nested `.nxignore` files, and direct-file patterns from those sources are never consulted, while the walker honors all of them.
- Parent `.gitignore` files are compiled with different rooting than the walker uses, so their anchored patterns match differently.
- The always-on watcher globs (vite/vitest timestamp files, hardcoded directories such as `node_modules`) can be defeated by ignore-file whitelists.
- An edit to a `.gitignore`/`.ignore`/`.nxignore` file that another ignore rule matches is filtered out before the daemon's restart trigger sees it, so the daemon keeps applying stale ignore rules.

On macOS, where the watcher registers recursive watch roots, this makes the warm daemon file map and task hashes diverge from a cold run for the same workspace state.

## Expected Behavior

The watcher mirrors the walker's visibility decisions for workspace and repository ignore files. A single ranked matcher chain (`.nxignore`, then `.ignore`, then workspace `.gitignore`, then parent `.gitignore` files with the walker's rooting) drives both the pruned-directory decision and the per-file decision, with the walker's source precedence. Always-on and caller-supplied globs apply to every walker-visible path, whitelisted or not, matching the walker's unconditional hardcoded pruning. Edits to ignore files in watched directories always reach the daemon's restart trigger, which now also covers `.ignore` and nested `.nxignore` files. The outputs watcher's legacy mode (`useIgnore: false`) is unchanged. The `.nxignore` docs now cover negation patterns, nested files, and the parent-directory exclusion rule with the contents-exclusion workaround.

Behavior changes worth calling out:

- Additional watcher globs now filter a file even when an ignore-file whitelist names it or a parent directory, matching the walker's unconditional `filter_entry` pruning.
- Direct-file patterns from newly consulted sources (root/nested `.ignore`, nested `.nxignore`) now filter events.
- On macOS, events that only ever arrived because of the missing pruning stop being delivered to daemon watch consumers.
- Ignore-file events bypass the file-level ignore decision (never the pruned-directory decision or the additional globs), so the daemon restart trigger cannot be starved by rules that match an ignore file itself.

This intentionally covers workspace and repository ignore files only. Machine-local git sources (`.git/info/exclude`, global excludes) still diverge: the walker honors them and the watcher does not, so files excluded that way are still delivered warm. That divergence needs a product decision and is tracked in NXC-4796; remaining source-invalidation and event-identity gaps (case-variant ignore filenames, symlink-backed ignore files) are tracked in NXC-4797.

Per-event filtering cost in a standalone 200-gitignore stress probe is about 1.2x the previous filter (63us vs 53us per event); the previous filter was cheaper partly by skipping the sources it ignored.

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/nxc-4716-4722eece">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->