### PR TITLE
fix(core): remove the daemon's nx@latest temp install on shutdown

### DIFF
--- a/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.ts
+++ b/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.ts
@@ -109,7 +109,7 @@ export async function setupAiAgentsGenerator(
       normalizedOptions,
       true
     );
-    cleanup();
+    await cleanup();
     return setupAiAgentsGeneratorResult;
   } catch (error) {
     return await setupAiAgentsGeneratorImpl(tree, normalizedOptions);

--- a/packages/nx/src/daemon/server/latest-nx.spec.ts
+++ b/packages/nx/src/daemon/server/latest-nx.spec.ts
@@ -1,0 +1,87 @@
+jest.mock('../logger', () => ({
+  serverLogger: { log: jest.fn() },
+}));
+jest.mock('../../utils/provenance', () => ({
+  ensurePackageHasProvenance: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../../utils/package-manager', () => ({
+  detectPackageManager: jest.fn().mockReturnValue('npm'),
+}));
+jest.mock('../../utils/package-json', () => ({
+  installPackageToTmpAsync: jest.fn(),
+}));
+
+describe('cleanupLatestNx', () => {
+  let getLatestNxTmpPath: typeof import('./latest-nx').getLatestNxTmpPath;
+  let cleanupLatestNx: typeof import('./latest-nx').cleanupLatestNx;
+  let installPackageToTmpAsync: jest.Mock;
+
+  beforeEach(() => {
+    // latest-nx caches the install in module-level state, so each test needs a
+    // fresh copy of the module - and of the mock it resolves against.
+    jest.resetModules();
+    jest.clearAllMocks();
+    ({ installPackageToTmpAsync } = require('../../utils/package-json'));
+    ({ getLatestNxTmpPath, cleanupLatestNx } = require('./latest-nx'));
+  });
+
+  function stubInstall(cleanup: () => Promise<void>) {
+    installPackageToTmpAsync.mockResolvedValue({
+      tempDir: '/tmp/fake-latest-nx',
+      cleanup,
+    });
+  }
+
+  it('resolves only once the installation has actually been removed', async () => {
+    let removed = false;
+    stubInstall(async () => {
+      await new Promise((res) => setTimeout(res, 10));
+      removed = true;
+    });
+
+    await getLatestNxTmpPath();
+    await cleanupLatestNx();
+
+    expect(removed).toBe(true);
+  });
+
+  it('is a no-op when nothing was installed', async () => {
+    await expect(cleanupLatestNx()).resolves.toBeUndefined();
+  });
+
+  it('removes the installation only once', async () => {
+    const cleanup = jest.fn().mockResolvedValue(undefined);
+    stubInstall(cleanup);
+
+    await getLatestNxTmpPath();
+    await cleanupLatestNx();
+    await cleanupLatestNx();
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
+  it('swallows a failing cleanup so shutdown can still proceed', async () => {
+    stubInstall(async () => {
+      throw new Error('EBUSY');
+    });
+
+    await getLatestNxTmpPath();
+
+    await expect(cleanupLatestNx()).resolves.toBeUndefined();
+  });
+
+  it('gives up on a cleanup that hangs rather than wedging shutdown', async () => {
+    stubInstall(() => new Promise<void>(() => {}));
+
+    await getLatestNxTmpPath();
+
+    jest.useFakeTimers();
+    try {
+      const pending = cleanupLatestNx();
+      jest.advanceTimersByTime(10_000);
+      await expect(pending).resolves.toBeUndefined();
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+});

--- a/packages/nx/src/daemon/server/latest-nx.spec.ts
+++ b/packages/nx/src/daemon/server/latest-nx.spec.ts
@@ -126,11 +126,21 @@ describe('cleanupLatestNx', () => {
 
     await getLatestNxTmpPath();
 
+    // Race a real timer so a broken timeout fails as an assertion rather than
+    // hanging until jest's, which would skip the `useRealTimers` below.
+    const realSetTimeout = setTimeout;
     jest.useFakeTimers();
     try {
       const pending = cleanupLatestNx();
       jest.advanceTimersByTime(10_000);
-      await expect(pending).resolves.toBeUndefined();
+      await expect(
+        Promise.race([
+          pending.then(() => 'gave up'),
+          new Promise((res) =>
+            realSetTimeout(() => res('still hanging'), 1_000).unref()
+          ),
+        ])
+      ).resolves.toBe('gave up');
     } finally {
       jest.useRealTimers();
     }

--- a/packages/nx/src/daemon/server/latest-nx.spec.ts
+++ b/packages/nx/src/daemon/server/latest-nx.spec.ts
@@ -1,30 +1,34 @@
+import type { Mock } from 'vitest';
 import { dirSync } from 'tmp';
 
-jest.mock('../logger', () => ({
-  serverLogger: { log: jest.fn() },
+vi.mock('../logger', () => ({
+  serverLogger: { log: vi.fn() },
 }));
-jest.mock('../../utils/provenance', () => ({
-  ensurePackageHasProvenance: jest.fn().mockResolvedValue(undefined),
+vi.mock('../../utils/provenance', () => ({
+  ensurePackageHasProvenance: vi.fn().mockResolvedValue(undefined),
 }));
-jest.mock('../../utils/package-manager', () => ({
-  detectPackageManager: jest.fn().mockReturnValue('npm'),
+vi.mock('../../utils/package-manager', () => ({
+  detectPackageManager: vi.fn().mockReturnValue('npm'),
 }));
-jest.mock('../../utils/package-json', () => ({
-  installPackageToTmpAsync: jest.fn(),
+vi.mock('../../utils/package-json', () => ({
+  installPackageToTmpAsync: vi.fn(),
 }));
 
 describe('cleanupLatestNx', () => {
   let getLatestNxTmpPath: typeof import('./latest-nx').getLatestNxTmpPath;
   let cleanupLatestNx: typeof import('./latest-nx').cleanupLatestNx;
-  let installPackageToTmpAsync: jest.Mock;
+  let installPackageToTmpAsync: Mock;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     // latest-nx caches the install in module-level state, so each test needs a
     // fresh copy of the module - and of the mock it resolves against.
-    jest.resetModules();
-    jest.clearAllMocks();
-    ({ installPackageToTmpAsync } = require('../../utils/package-json'));
-    ({ getLatestNxTmpPath, cleanupLatestNx } = require('./latest-nx'));
+    vi.resetModules();
+    vi.clearAllMocks();
+    ({ installPackageToTmpAsync } =
+      (await import('../../utils/package-json')) as unknown as {
+        installPackageToTmpAsync: Mock;
+      });
+    ({ getLatestNxTmpPath, cleanupLatestNx } = await import('./latest-nx'));
   });
 
   function stubInstall(cleanup: () => Promise<void>) {
@@ -52,7 +56,7 @@ describe('cleanupLatestNx', () => {
   });
 
   it('removes the installation only once', async () => {
-    const cleanup = jest.fn().mockResolvedValue(undefined);
+    const cleanup = vi.fn().mockResolvedValue(undefined);
     stubInstall(cleanup);
 
     await getLatestNxTmpPath();
@@ -81,7 +85,7 @@ describe('cleanupLatestNx', () => {
   });
 
   it('removes a re-installed copy that was pulled after an earlier cleanup', async () => {
-    const cleanup = jest.fn().mockResolvedValue(undefined);
+    const cleanup = vi.fn().mockResolvedValue(undefined);
     stubInstall(cleanup);
 
     await getLatestNxTmpPath();
@@ -104,7 +108,7 @@ describe('cleanupLatestNx', () => {
     await getLatestNxTmpPath();
     await cleanupLatestNx();
 
-    const { serverLogger } = require('../logger');
+    const { serverLogger } = await import('../logger');
     expect(serverLogger.log).toHaveBeenCalledWith(
       expect.stringContaining('could not be removed'),
       tempDir
@@ -127,12 +131,12 @@ describe('cleanupLatestNx', () => {
     await getLatestNxTmpPath();
 
     // Race a real timer so a broken timeout fails as an assertion rather than
-    // hanging until jest's, which would skip the `useRealTimers` below.
+    // hanging until vitest's, which would skip the `useRealTimers` below.
     const realSetTimeout = setTimeout;
-    jest.useFakeTimers();
+    vi.useFakeTimers();
     try {
       const pending = cleanupLatestNx();
-      jest.advanceTimersByTime(10_000);
+      vi.advanceTimersByTime(10_000);
       await expect(
         Promise.race([
           pending.then(() => 'gave up'),
@@ -142,7 +146,7 @@ describe('cleanupLatestNx', () => {
         ])
       ).resolves.toBe('gave up');
     } finally {
-      jest.useRealTimers();
+      vi.useRealTimers();
     }
   });
 });

--- a/packages/nx/src/daemon/server/latest-nx.spec.ts
+++ b/packages/nx/src/daemon/server/latest-nx.spec.ts
@@ -1,3 +1,5 @@
+import { dirSync } from 'tmp';
+
 jest.mock('../logger', () => ({
   serverLogger: { log: jest.fn() },
 }));
@@ -88,6 +90,25 @@ describe('cleanupLatestNx', () => {
     await cleanupLatestNx();
 
     expect(cleanup).toHaveBeenCalledTimes(2);
+  });
+
+  it('reports an installation that is still on disk after a cleanup that resolved', async () => {
+    const tempDir = dirSync().name;
+    installPackageToTmpAsync.mockResolvedValue({
+      tempDir,
+      // `createTempNpmDirectory` swallows its own `rm` errors, so this is what a
+      // failed removal looks like to the caller.
+      cleanup: async () => {},
+    });
+
+    await getLatestNxTmpPath();
+    await cleanupLatestNx();
+
+    const { serverLogger } = require('../logger');
+    expect(serverLogger.log).toHaveBeenCalledWith(
+      expect.stringContaining('could not be removed'),
+      tempDir
+    );
   });
 
   it('swallows a failing cleanup so shutdown can still proceed', async () => {

--- a/packages/nx/src/daemon/server/latest-nx.spec.ts
+++ b/packages/nx/src/daemon/server/latest-nx.spec.ts
@@ -60,6 +60,36 @@ describe('cleanupLatestNx', () => {
     expect(cleanup).toHaveBeenCalledTimes(1);
   });
 
+  it('makes a concurrent caller wait for the in-flight removal', async () => {
+    let removed = false;
+    stubInstall(async () => {
+      await new Promise((res) => setTimeout(res, 10));
+      removed = true;
+    });
+
+    await getLatestNxTmpPath();
+
+    // `respondWithErrorAndExit` calls `process.exit` the moment its own cleanup
+    // resolves, so a second caller resolving early kills the first one's `rm`.
+    const first = cleanupLatestNx();
+    await cleanupLatestNx();
+
+    expect(removed).toBe(true);
+    await first;
+  });
+
+  it('removes a re-installed copy that was pulled after an earlier cleanup', async () => {
+    const cleanup = jest.fn().mockResolvedValue(undefined);
+    stubInstall(cleanup);
+
+    await getLatestNxTmpPath();
+    await cleanupLatestNx();
+    await getLatestNxTmpPath();
+    await cleanupLatestNx();
+
+    expect(cleanup).toHaveBeenCalledTimes(2);
+  });
+
   it('swallows a failing cleanup so shutdown can still proceed', async () => {
     stubInstall(async () => {
       throw new Error('EBUSY');

--- a/packages/nx/src/daemon/server/latest-nx.ts
+++ b/packages/nx/src/daemon/server/latest-nx.ts
@@ -2,6 +2,7 @@
 // eagerly pulls in the task-execution subsystem and instantiates a daemon
 // client, all of which would stay resident for the daemon server's lifetime.
 import { installPackageToTmpAsync } from '../../utils/package-json';
+import { existsSync } from 'node:fs';
 import { detectPackageManager } from '../../utils/package-manager';
 import { ensurePackageHasProvenance } from '../../utils/provenance';
 import { workspaceRoot } from '../../utils/workspace-root';
@@ -96,7 +97,15 @@ async function runCleanup(): Promise<void> {
 
   try {
     await withTimeout(cleanup(), CLEANUP_TIMEOUT_MS);
-    serverLogger.log('[LATEST-NX]: Cleaned up latest Nx installation');
+    // The cleanup swallows its own `rm` errors, so resolving is not proof the
+    // directory is gone. On Windows it will not be: the temp install's loaded
+    // `.node` binding is mapped into this process and cannot be unlinked.
+    serverLogger.log(
+      existsSync(tmpPath)
+        ? '[LATEST-NX]: Latest Nx installation could not be removed, still at'
+        : '[LATEST-NX]: Cleaned up latest Nx installation from',
+      tmpPath
+    );
   } catch (e) {
     // Report the failure rather than exiting on a log line that claims a
     // cleanup which did not happen.

--- a/packages/nx/src/daemon/server/latest-nx.ts
+++ b/packages/nx/src/daemon/server/latest-nx.ts
@@ -11,6 +11,7 @@ import { serverLogger } from '../logger';
 let latestNxTmpPath: string | null = null;
 let cleanupFn: (() => Promise<void>) | null = null;
 let installPromise: Promise<string> | null = null;
+let cleanupPromise: Promise<void> | null = null;
 
 // Removing the install is ~10^4 unlinks, so it is not instant. Bound it anyway:
 // shutdown waits on this, and a wedged filesystem must not leave the daemon
@@ -46,6 +47,9 @@ export async function getLatestNxTmpPath(): Promise<string> {
       );
       latestNxTmpPath = result.tempDir;
       cleanupFn = result.cleanup;
+      // A fresh install needs its own removal, so it must not resolve against
+      // the previous one's memo.
+      cleanupPromise = null;
       serverLogger.log(
         '[LATEST-NX]: Successfully pulled latest Nx to',
         latestNxTmpPath
@@ -65,7 +69,15 @@ export async function getLatestNxTmpPath(): Promise<string> {
  * finishes, and `process.exit` discards pending work rather than draining it,
  * so an unawaited removal here leaks the whole ~60MB install every time.
  */
-export async function cleanupLatestNx(): Promise<void> {
+export function cleanupLatestNx(): Promise<void> {
+  // Concurrent callers must await the same removal. `respondWithErrorAndExit`
+  // exits as soon as its own call resolves, so a second caller that resolved
+  // early would kill the first caller's in-flight `rm`.
+  cleanupPromise ??= runCleanup();
+  return cleanupPromise;
+}
+
+async function runCleanup(): Promise<void> {
   const cleanup = cleanupFn;
   const tmpPath = latestNxTmpPath;
   // Drop the references first so nothing can hand out a directory that is in
@@ -97,6 +109,10 @@ export async function cleanupLatestNx(): Promise<void> {
 }
 
 async function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  // When the timeout wins the race nothing else is left awaiting `promise`, so
+  // a late rejection would surface as an unhandledRejection.
+  promise.catch(() => {});
+
   let timer: NodeJS.Timeout;
   try {
     return await Promise.race([

--- a/packages/nx/src/daemon/server/latest-nx.ts
+++ b/packages/nx/src/daemon/server/latest-nx.ts
@@ -9,8 +9,13 @@ import { serverLogger } from '../logger';
 
 // Module-level state - persists across invocations within daemon lifecycle
 let latestNxTmpPath: string | null = null;
-let cleanupFn: (() => void) | null = null;
+let cleanupFn: (() => Promise<void>) | null = null;
 let installPromise: Promise<string> | null = null;
+
+// Removing the install is ~10^4 unlinks, so it is not instant. Bound it anyway:
+// shutdown waits on this, and a wedged filesystem must not leave the daemon
+// undead.
+const CLEANUP_TIMEOUT_MS = 10_000;
 
 /**
  * Returns the path to a temp directory containing `nx@latest`.
@@ -55,15 +60,55 @@ export async function getLatestNxTmpPath(): Promise<string> {
 
 /**
  * Clean up the latest Nx installation on daemon shutdown.
+ *
+ * Callers must await this. The daemon calls `process.exit` once shutdown
+ * finishes, and `process.exit` discards pending work rather than draining it,
+ * so an unawaited removal here leaks the whole ~60MB install every time.
  */
-export function cleanupLatestNx(): void {
-  if (cleanupFn) {
-    serverLogger.log(
-      '[LATEST-NX]: Cleaning up latest Nx installation from',
-      latestNxTmpPath
-    );
-    cleanupFn();
-  }
+export async function cleanupLatestNx(): Promise<void> {
+  const cleanup = cleanupFn;
+  const tmpPath = latestNxTmpPath;
+  // Drop the references first so nothing can hand out a directory that is in
+  // the middle of being deleted.
   latestNxTmpPath = null;
   cleanupFn = null;
+
+  if (!cleanup) {
+    return;
+  }
+
+  serverLogger.log(
+    '[LATEST-NX]: Cleaning up latest Nx installation from',
+    tmpPath
+  );
+
+  try {
+    await withTimeout(cleanup(), CLEANUP_TIMEOUT_MS);
+    serverLogger.log('[LATEST-NX]: Cleaned up latest Nx installation');
+  } catch (e) {
+    // Report the failure rather than exiting on a log line that claims a
+    // cleanup which did not happen.
+    serverLogger.log(
+      '[LATEST-NX]: Failed to clean up latest Nx installation from',
+      tmpPath,
+      e.message
+    );
+  }
+}
+
+async function withTimeout<T>(promise: Promise<T>, ms: number): Promise<T> {
+  let timer: NodeJS.Timeout;
+  try {
+    return await Promise.race([
+      promise,
+      new Promise<never>((_, reject) => {
+        timer = setTimeout(
+          () => reject(new Error(`Timed out after ${ms}ms`)),
+          ms
+        );
+      }),
+    ]);
+  } finally {
+    clearTimeout(timer);
+  }
 }

--- a/packages/nx/src/daemon/server/shutdown-utils.spec.ts
+++ b/packages/nx/src/daemon/server/shutdown-utils.spec.ts
@@ -46,12 +46,14 @@ function createFakeInstallDir(): string {
   return dir;
 }
 
-describe('performShutdown', () => {
+describe('shutdown-utils', () => {
   let handleServerProcessTermination: typeof import('./shutdown-utils').handleServerProcessTermination;
+  let respondWithErrorAndExit: typeof import('./shutdown-utils').respondWithErrorAndExit;
   let exitSpy: jest.SpyInstance;
   let tempDir: string;
 
   const server = { close: (cb: () => void) => cb() } as any;
+  const socket = { write: (_: string, cb: () => void) => cb() } as any;
 
   beforeEach(() => {
     // Both shutdown-utils and latest-nx keep module-level state (the in-flight
@@ -71,11 +73,16 @@ describe('performShutdown', () => {
       },
     });
 
-    ({ handleServerProcessTermination } = require('./shutdown-utils'));
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+    ({
+      handleServerProcessTermination,
+      respondWithErrorAndExit,
+    } = require('./shutdown-utils'));
   });
 
   afterEach(async () => {
     exitSpy?.mockRestore();
+    jest.restoreAllMocks();
     await rm(tempDir, { recursive: true, force: true });
   });
 
@@ -131,5 +138,35 @@ describe('performShutdown', () => {
 
     expect(existedAtFirstExit()).toBe(false);
     expect(exitSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it('removes the latest Nx temp install before exiting on a failed request', async () => {
+    await primeLatestNxInstall();
+    const existedAtFirstExit = spyOnExit();
+
+    // This path exits without going through `performShutdown`, so it owns the
+    // removal itself.
+    await respondWithErrorAndExit(socket, 'a description', new Error('boom'));
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(existedAtFirstExit()).toBe(false);
+  });
+
+  it('keeps the latest Nx temp install on a project graph error, which does not exit', async () => {
+    await primeLatestNxInstall();
+    const existedAtFirstExit = spyOnExit();
+
+    const {
+      DaemonProjectGraphError,
+    } = require('../../project-graph/error-types');
+    await respondWithErrorAndExit(
+      socket,
+      'a description',
+      new DaemonProjectGraphError([new Error('boom')], {} as any, {})
+    );
+
+    expect(exitSpy).not.toHaveBeenCalled();
+    expect(existedAtFirstExit()).toBeUndefined();
+    expect(existsSync(tempDir)).toBe(true);
   });
 });

--- a/packages/nx/src/daemon/server/shutdown-utils.spec.ts
+++ b/packages/nx/src/daemon/server/shutdown-utils.spec.ts
@@ -1,0 +1,135 @@
+import { mkdirSync, existsSync, writeFileSync } from 'node:fs';
+import { rm } from 'node:fs/promises';
+import { join } from 'node:path';
+import { dirSync } from 'tmp';
+
+jest.mock('../logger', () => ({
+  serverLogger: {
+    log: jest.fn(),
+    watcherLog: jest.fn(),
+    requestLog: jest.fn(),
+  },
+}));
+jest.mock('../cache', () => ({ deleteDaemonJsonProcessCache: jest.fn() }));
+jest.mock('../../project-graph/plugins/get-plugins', () => ({
+  cleanupPlugins: jest.fn(),
+}));
+jest.mock('../../analytics', () => ({ flushAnalytics: jest.fn() }));
+jest.mock('../tmp-dir', () => ({
+  DAEMON_DIR_FOR_CURRENT_WORKSPACE: '/tmp/nx-daemon-spec',
+  DAEMON_OUTPUT_LOG_FILE: '/tmp/nx-daemon-spec/daemon.log',
+}));
+jest.mock('../../utils/provenance', () => ({
+  ensurePackageHasProvenance: jest.fn().mockResolvedValue(undefined),
+}));
+jest.mock('../../utils/package-manager', () => ({
+  detectPackageManager: jest.fn().mockReturnValue('npm'),
+}));
+jest.mock('../../utils/package-json', () => ({
+  installPackageToTmpAsync: jest.fn(),
+}));
+
+/**
+ * Builds a directory shaped like a real `nx@latest` temp install: enough files
+ * that removing it takes many syscalls, so an un-awaited or interrupted `rm`
+ * cannot finish before `process.exit` runs.
+ */
+function createFakeInstallDir(): string {
+  const dir = dirSync().name;
+  for (let pkg = 0; pkg < 40; pkg++) {
+    const nested = join(dir, 'node_modules', `pkg-${pkg}`, 'dist');
+    mkdirSync(nested, { recursive: true });
+    for (let file = 0; file < 40; file++) {
+      writeFileSync(join(nested, `file-${file}.js`), 'x'.repeat(1024));
+    }
+  }
+  return dir;
+}
+
+describe('performShutdown', () => {
+  let handleServerProcessTermination: typeof import('./shutdown-utils').handleServerProcessTermination;
+  let exitSpy: jest.SpyInstance;
+  let tempDir: string;
+
+  const server = { close: (cb: () => void) => cb() } as any;
+
+  beforeEach(() => {
+    // Both shutdown-utils and latest-nx keep module-level state (the in-flight
+    // shutdown, the cached install), so each test needs fresh copies.
+    jest.resetModules();
+    jest.clearAllMocks();
+
+    tempDir = createFakeInstallDir();
+    const { installPackageToTmpAsync } =
+      require('../../utils/package-json') as {
+        installPackageToTmpAsync: jest.Mock;
+      };
+    installPackageToTmpAsync.mockResolvedValue({
+      tempDir,
+      cleanup: async () => {
+        await rm(tempDir, { recursive: true, force: true });
+      },
+    });
+
+    ({ handleServerProcessTermination } = require('./shutdown-utils'));
+  });
+
+  afterEach(async () => {
+    exitSpy?.mockRestore();
+    await rm(tempDir, { recursive: true, force: true });
+  });
+
+  /** Seeds the daemon's cached `nx@latest` install, as a live daemon would hold. */
+  async function primeLatestNxInstall() {
+    const { getLatestNxTmpPath } = require('./latest-nx');
+    await expect(getLatestNxTmpPath()).resolves.toBe(tempDir);
+    expect(existsSync(tempDir)).toBe(true);
+  }
+
+  /** Records whether the install still existed the first time the process tried to exit. */
+  function spyOnExit(): () => boolean | undefined {
+    let existedAtFirstExit: boolean | undefined;
+    exitSpy = jest.spyOn(process, 'exit').mockImplementation(((): never => {
+      existedAtFirstExit ??= existsSync(tempDir);
+      return undefined as never;
+    }) as never);
+    return () => existedAtFirstExit;
+  }
+
+  it('finishes removing the latest Nx temp install before the process exits', async () => {
+    await primeLatestNxInstall();
+    const existedAtFirstExit = spyOnExit();
+
+    await handleServerProcessTermination({
+      server,
+      reason: 'received process SIGTERM',
+      sockets: [],
+    });
+
+    expect(exitSpy).toHaveBeenCalledWith(0);
+    expect(existedAtFirstExit()).toBe(false);
+  });
+
+  it('does not exit while a concurrent shutdown is still cleaning up', async () => {
+    await primeLatestNxInstall();
+    const existedAtFirstExit = spyOnExit();
+
+    // `nx daemon --stop` raises SIGTERM and also trips the supersede check that
+    // runs every 20ms, so two shutdowns land at essentially the same moment.
+    await Promise.all([
+      handleServerProcessTermination({
+        server,
+        reason: 'received process SIGTERM',
+        sockets: [],
+      }),
+      handleServerProcessTermination({
+        server,
+        reason: 'this process is no longer the current daemon (native)',
+        sockets: [],
+      }),
+    ]);
+
+    expect(existedAtFirstExit()).toBe(false);
+    expect(exitSpy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/nx/src/daemon/server/shutdown-utils.spec.ts
+++ b/packages/nx/src/daemon/server/shutdown-utils.spec.ts
@@ -1,32 +1,33 @@
+import type { Mock, MockInstance } from 'vitest';
 import { mkdirSync, existsSync, writeFileSync } from 'node:fs';
 import { rm } from 'node:fs/promises';
 import { join } from 'node:path';
 import { dirSync } from 'tmp';
 
-jest.mock('../logger', () => ({
+vi.mock('../logger', () => ({
   serverLogger: {
-    log: jest.fn(),
-    watcherLog: jest.fn(),
-    requestLog: jest.fn(),
+    log: vi.fn(),
+    watcherLog: vi.fn(),
+    requestLog: vi.fn(),
   },
 }));
-jest.mock('../cache', () => ({ deleteDaemonJsonProcessCache: jest.fn() }));
-jest.mock('../../project-graph/plugins/get-plugins', () => ({
-  cleanupPlugins: jest.fn(),
+vi.mock('../cache', () => ({ deleteDaemonJsonProcessCache: vi.fn() }));
+vi.mock('../../project-graph/plugins/get-plugins', () => ({
+  cleanupPlugins: vi.fn(),
 }));
-jest.mock('../../analytics', () => ({ flushAnalytics: jest.fn() }));
-jest.mock('../tmp-dir', () => ({
+vi.mock('../../analytics', () => ({ flushAnalytics: vi.fn() }));
+vi.mock('../tmp-dir', () => ({
   DAEMON_DIR_FOR_CURRENT_WORKSPACE: '/tmp/nx-daemon-spec',
   DAEMON_OUTPUT_LOG_FILE: '/tmp/nx-daemon-spec/daemon.log',
 }));
-jest.mock('../../utils/provenance', () => ({
-  ensurePackageHasProvenance: jest.fn().mockResolvedValue(undefined),
+vi.mock('../../utils/provenance', () => ({
+  ensurePackageHasProvenance: vi.fn().mockResolvedValue(undefined),
 }));
-jest.mock('../../utils/package-manager', () => ({
-  detectPackageManager: jest.fn().mockReturnValue('npm'),
+vi.mock('../../utils/package-manager', () => ({
+  detectPackageManager: vi.fn().mockReturnValue('npm'),
 }));
-jest.mock('../../utils/package-json', () => ({
-  installPackageToTmpAsync: jest.fn(),
+vi.mock('../../utils/package-json', () => ({
+  installPackageToTmpAsync: vi.fn(),
 }));
 
 /**
@@ -49,22 +50,22 @@ function createFakeInstallDir(): string {
 describe('shutdown-utils', () => {
   let handleServerProcessTermination: typeof import('./shutdown-utils').handleServerProcessTermination;
   let respondWithErrorAndExit: typeof import('./shutdown-utils').respondWithErrorAndExit;
-  let exitSpy: jest.SpyInstance;
+  let exitSpy: MockInstance;
   let tempDir: string;
 
   const server = { close: (cb: () => void) => cb() } as any;
   const socket = { write: (_: string, cb: () => void) => cb() } as any;
 
-  beforeEach(() => {
+  beforeEach(async () => {
     // Both shutdown-utils and latest-nx keep module-level state (the in-flight
     // shutdown, the cached install), so each test needs fresh copies.
-    jest.resetModules();
-    jest.clearAllMocks();
+    vi.resetModules();
+    vi.clearAllMocks();
 
     tempDir = createFakeInstallDir();
     const { installPackageToTmpAsync } =
-      require('../../utils/package-json') as {
-        installPackageToTmpAsync: jest.Mock;
+      (await import('../../utils/package-json')) as unknown as {
+        installPackageToTmpAsync: Mock;
       };
     installPackageToTmpAsync.mockResolvedValue({
       tempDir,
@@ -73,22 +74,20 @@ describe('shutdown-utils', () => {
       },
     });
 
-    jest.spyOn(console, 'error').mockImplementation(() => {});
-    ({
-      handleServerProcessTermination,
-      respondWithErrorAndExit,
-    } = require('./shutdown-utils'));
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+    ({ handleServerProcessTermination, respondWithErrorAndExit } =
+      await import('./shutdown-utils'));
   });
 
   afterEach(async () => {
     exitSpy?.mockRestore();
-    jest.restoreAllMocks();
+    vi.restoreAllMocks();
     await rm(tempDir, { recursive: true, force: true });
   });
 
   /** Seeds the daemon's cached `nx@latest` install, as a live daemon would hold. */
   async function primeLatestNxInstall() {
-    const { getLatestNxTmpPath } = require('./latest-nx');
+    const { getLatestNxTmpPath } = await import('./latest-nx');
     await expect(getLatestNxTmpPath()).resolves.toBe(tempDir);
     expect(existsSync(tempDir)).toBe(true);
   }
@@ -96,7 +95,7 @@ describe('shutdown-utils', () => {
   /** Records whether the install still existed the first time the process tried to exit. */
   function spyOnExit(): () => boolean | undefined {
     let existedAtFirstExit: boolean | undefined;
-    exitSpy = jest.spyOn(process, 'exit').mockImplementation(((): never => {
+    exitSpy = vi.spyOn(process, 'exit').mockImplementation(((): never => {
       existedAtFirstExit ??= existsSync(tempDir);
       return undefined as never;
     }) as never);
@@ -156,9 +155,8 @@ describe('shutdown-utils', () => {
     await primeLatestNxInstall();
     const existedAtFirstExit = spyOnExit();
 
-    const {
-      DaemonProjectGraphError,
-    } = require('../../project-graph/error-types');
+    const { DaemonProjectGraphError } =
+      await import('../../project-graph/error-types');
     await respondWithErrorAndExit(
       socket,
       'a description',

--- a/packages/nx/src/daemon/server/shutdown-utils.ts
+++ b/packages/nx/src/daemon/server/shutdown-utils.ts
@@ -110,7 +110,23 @@ export async function handleServerProcessTerminationWithRestart({
   await performShutdown(server, reason, sockets);
 }
 
-async function performShutdown(
+let shutdownPromise: Promise<void> | null = null;
+
+function performShutdown(
+  server: Server,
+  reason: string,
+  sockets: Iterable<Socket>
+): Promise<void> {
+  // Shutdown gets triggered more than once in practice: `nx daemon --stop`
+  // raises SIGTERM and also trips the "no longer the current daemon" check in
+  // server.ts, which runs every 20ms. Without this guard the second call walks
+  // an already-torn-down server straight to the `process.exit` in
+  // `runShutdown`, killing the first call while it is still awaiting cleanup.
+  shutdownPromise ??= runShutdown(server, reason, sockets);
+  return shutdownPromise;
+}
+
+async function runShutdown(
   server: Server,
   reason: string,
   sockets: Iterable<Socket>
@@ -143,8 +159,9 @@ async function performShutdown(
     deleteDaemonJsonProcessCache();
     cleanupPlugins();
 
-    // Clean up shared latest Nx installation
-    cleanupLatestNx();
+    // Clean up shared latest Nx installation. This must be awaited: the
+    // `process.exit` below drops pending work instead of draining it.
+    await cleanupLatestNx();
 
     // Flush analytics before exiting
     flushAnalytics();
@@ -220,6 +237,9 @@ export async function respondWithErrorAndExit(
 
   // Project Graph errors are okay. Restarting the daemon won't help with this.
   if (!(error instanceof DaemonProjectGraphError)) {
+    // This exit skips `performShutdown`, so the temp install has to be removed
+    // here or it is leaked.
+    await cleanupLatestNx();
     process.exit(1);
   }
 }

--- a/packages/nx/src/utils/package-json.ts
+++ b/packages/nx/src/utils/package-json.ts
@@ -405,7 +405,7 @@ function preparePackageInstallation(
 ) {
   const { dir: tempDir, cleanup } = createTempNpmDirectory?.() ?? {
     dir: dirSync().name,
-    cleanup: () => {},
+    cleanup: async () => {},
   };
 
   console.log(`Fetching ${pkg}...`);
@@ -491,7 +491,7 @@ export async function installPackageToTmpAsync(
   packageManager: PackageManager
 ): Promise<{
   tempDir: string;
-  cleanup: () => void;
+  cleanup: () => Promise<void>;
 }> {
   const { tempDir, cleanup, preInstallCommand, installCommand, execOptions } =
     preparePackageInstallation(pkg, requiredVersion, packageManager);

--- a/packages/nx/src/utils/package-json.ts
+++ b/packages/nx/src/utils/package-json.ts
@@ -1,6 +1,7 @@
 import { exec, execSync } from 'child_process';
 import { promisify } from 'util';
 import { existsSync, writeFileSync } from 'fs';
+import { rm } from 'fs/promises';
 import { dirname, join, resolve } from 'path';
 
 const execAsync = promisify(exec);
@@ -394,6 +395,24 @@ export function readModulePackageJson(
   };
 }
 
+function createFallbackTempDirectory(): {
+  dir: string;
+  cleanup: () => Promise<void>;
+} {
+  const dir = dirSync().name;
+  return {
+    dir,
+    cleanup: async () => {
+      try {
+        await rm(dir, { recursive: true, force: true });
+      } catch {
+        // Best effort, same as `createTempNpmDirectory`: callers treat cleanup
+        // as something that never throws.
+      }
+    },
+  };
+}
+
 /**
  * Prepares all necessary information for installing a package to a temporary directory.
  * This is used by both sync and async installation functions.
@@ -403,10 +422,8 @@ function preparePackageInstallation(
   requiredVersion: string,
   packageManager: PackageManager
 ) {
-  const { dir: tempDir, cleanup } = createTempNpmDirectory?.() ?? {
-    dir: dirSync().name,
-    cleanup: async () => {},
-  };
+  const { dir: tempDir, cleanup } =
+    createTempNpmDirectory?.() ?? createFallbackTempDirectory();
 
   console.log(`Fetching ${pkg}...`);
   const isVerbose = process.env.NX_VERBOSE_LOGGING === 'true';
@@ -467,7 +484,7 @@ export function installPackageToTmp(
   packageManager: PackageManager
 ): {
   tempDir: string;
-  cleanup: () => void;
+  cleanup: () => Promise<void>;
 } {
   const { tempDir, cleanup, preInstallCommand, installCommand, execOptions } =
     preparePackageInstallation(pkg, requiredVersion, packageManager);


### PR DESCRIPTION
## Current Behavior

The daemon installs `nx@latest` into a temp directory (~60MB) so the Nx Console and AI-agent checks can run the newest version of that logic. That directory is never actually removed, so one leaks per daemon lifetime per workspace root. On my machine: **95 such directories, 5.5GB** — and it grew to 101 / 5.9GB over a single working session, as other daemons idled out and restarted.

There are two independent defects, and the leak needs **both** fixed.

**1. The cleanup was never awaited.** `cleanupLatestNx()` invoked the async `rm` without awaiting it, and `performShutdown()` then called `process.exit(0)`, which discards pending work rather than draining it. This is not a race that sometimes loses — the removal never got a single tick. The log line was also emitted *before* the work and unconditionally, so the daemon reported a cleanup that had not happened.

**2. Shutdown fires more than once.** `nx daemon --stop` raises SIGTERM *and* trips the `getDaemonProcessIdSync() !== process.pid` check in `server.ts`, which runs unguarded every 20ms. Instrumenting a real daemon showed the second shutdown reaching `process.exit` ~4ms into the first one's `rm`:

```
14:10:08.632  performShutdown entered, count=1  reason=received process SIGTERM
14:10:08.633  [LATEST-NX]: Cleaning up ... /tmp/tmp-47329...   <- #1 starts awaiting rm
14:10:08.637  performShutdown entered, count=2  reason=no longer the current daemon
14:10:08.641  after cleanupLatestNx                             <- instant; cleanupFn already null
14:10:08.641  Server stopped -> process.exit(0)                 <- kills #1 mid-rm
```

The un-awaited cleanup had been *masking* this: nothing was ever waiting, so nothing could be interrupted. **Awaiting the cleanup alone does not fix the leak** — I verified that against a real daemon and it still leaked 59MB.

## Expected Behavior

The temp install is removed before the daemon exits, on every shutdown path, and the log reflects what actually happened.

- `cleanupLatestNx` is now `async`, awaits the removal under a 10s timeout (so a wedged filesystem cannot leave the daemon undead), and logs *after* the work.
- `performShutdown` is de-duplicated behind a single in-flight promise, so a second trigger cannot exit the process while the first is still cleaning up.
- `respondWithErrorAndExit` — a third exit path that bypasses `performShutdown` entirely — now cleans up as well.
- `installPackageToTmpAsync` declared `cleanup: () => void` while the `createTempNpmDirectory` it wraps returns an async function. That widened type is what let the missing `await` typecheck, so it and the sync no-op fallback behind it are corrected too.

## Verification

Verified end-to-end against a real daemon (published 23.1.1 with the compiled fix applied), not just at the unit level:

- `nx daemon --stop`: `CLEANED` on 3 consecutive runs (rm takes ~150ms). Before the fix: 59MB leaked every time.
- Direct `SIGTERM` to the daemon: `CLEANED`.
- The log now reads `Cleaning up latest Nx installation from …` followed by `Cleaned up latest Nx installation`.

Regression tests are at `handleServerProcessTermination`, asserting the directory is gone **at the instant `process.exit` fires** — the seam that catches both halves. Both are non-vacuous: the await test fails without the await, and the concurrency test fails with the await but without the re-entrancy guard.

Full `nx test nx`: 5132 passed. 6 pre-existing failures in `deriveRepoKey`, socket directories, and watch-before-scan — I confirmed all 6 reproduce identically on pristine `master`. Lint and build clean.

## Deliberately out of scope

- **The unconditional `nx@latest` install at daemon boot** (defect 1 in the issue) is untouched. Both consumers `require.resolve` + `import()` from that path so Nx can ship updated prompt logic to already-installed versions, so whether to keep paying a network fetch plus ~60MB per daemon boot is a product call rather than a bug fix.
- **A narrow remaining window**: if the daemon exits *during* the install, `cleanupFn` is not yet set and the partial directory still leaks. Closing it means either awaiting a network install during shutdown or reshaping `installPackageToTmpAsync` to publish its temp dir early — both arguably worse than the leak they prevent. Happy to follow up if you'd like it closed.

## Related Issue(s)

Fixes #36541

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Fix-daemon-nxlatest-temp-install-leak-nx36541-11b2f9bc">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->