### PR TITLE
fix(core): do not allowlist the analytics domain when analytics are off

### DIFF
--- a/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.spec.ts
+++ b/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.spec.ts
@@ -3,7 +3,7 @@ import { Tree } from '../../generators/tree';
 
 import { setupAiAgentsGenerator } from './set-up-ai-agents';
 import { SetupAiAgentsGeneratorSchema } from './schema';
-import { readJson } from '../../generators/utils/json';
+import { readJson, updateJson } from '../../generators/utils/json';
 import { getAgentRulesWrapped } from '../constants';
 import * as installedNxVersionUtils from '../../utils/installed-nx-version';
 import * as cloneModule from '../clone-ai-config-repo';
@@ -21,6 +21,10 @@ jest.mock('fs', () => {
       .mockImplementation((...args: any[]) => actual.readFileSync(...args)),
   };
 });
+
+function setAnalytics(tree: Tree, analytics: boolean) {
+  updateJson(tree, 'nx.json', (json) => ({ ...json, analytics }));
+}
 
 describe('setup-ai-agents generator', () => {
   let tree: Tree;
@@ -404,11 +408,12 @@ describe('setup-ai-agents generator', () => {
         expect(config.enabledPlugins['nx@nx-claude-plugins']).toBe(true);
       });
 
-      it('should allow analytics requests through the sandbox network filter', async () => {
+      it('should allow analytics requests through the sandbox network filter when analytics are enabled', async () => {
         const options: SetupAiAgentsGeneratorSchema = {
           directory: '.',
           agents: ['claude'],
         };
+        setAnalytics(tree, true);
 
         await setupAiAgentsGenerator(tree, options);
 
@@ -420,11 +425,103 @@ describe('setup-ai-agents generator', () => {
         ]);
       });
 
+      it('should not allow analytics requests through the sandbox network filter when analytics are disabled', async () => {
+        const options: SetupAiAgentsGeneratorSchema = {
+          directory: '.',
+          agents: ['claude'],
+        };
+        setAnalytics(tree, false);
+
+        await setupAiAgentsGenerator(tree, options);
+
+        const config = JSON.parse(
+          tree.read('.claude/settings.json')?.toString() ?? '{}'
+        );
+        expect(config.sandbox).toBeUndefined();
+      });
+
+      it('should not allow analytics requests through the sandbox network filter when no analytics preference is set', async () => {
+        const options: SetupAiAgentsGeneratorSchema = {
+          directory: '.',
+          agents: ['claude'],
+        };
+
+        await setupAiAgentsGenerator(tree, options);
+
+        const config = JSON.parse(
+          tree.read('.claude/settings.json')?.toString() ?? '{}'
+        );
+        expect(config.sandbox).toBeUndefined();
+      });
+
+      it('should leave an existing sandbox network filter untouched when analytics are disabled', async () => {
+        const options: SetupAiAgentsGeneratorSchema = {
+          directory: '.',
+          agents: ['claude'],
+        };
+        setAnalytics(tree, false);
+
+        tree.write(
+          '.claude/settings.json',
+          JSON.stringify({
+            sandbox: {
+              network: {
+                allowedDomains: ['example.com'],
+              },
+            },
+          })
+        );
+
+        await setupAiAgentsGenerator(tree, options);
+
+        const config = JSON.parse(
+          tree.read('.claude/settings.json')?.toString() ?? '{}'
+        );
+        expect(config.sandbox.network.allowedDomains).toEqual(['example.com']);
+      });
+
+      it('should report the sandbox network filter change when the analytics domain is added', async () => {
+        const options: SetupAiAgentsGeneratorSchema = {
+          directory: '.',
+          agents: ['claude'],
+        };
+        setAnalytics(tree, true);
+
+        const callback = await setupAiAgentsGenerator(tree, options);
+        const { messages } = await callback();
+
+        expect(messages.map((message) => message.title)).toContainEqual(
+          expect.stringContaining('www.google-analytics.com')
+        );
+      });
+
+      it('should not report the sandbox network filter change when the analytics domain is already allowed', async () => {
+        const options: SetupAiAgentsGeneratorSchema = {
+          directory: '.',
+          agents: ['claude'],
+        };
+        setAnalytics(tree, true);
+        tree.write(
+          '.claude/settings.json',
+          JSON.stringify({
+            sandbox: {
+              network: { allowedDomains: ['www.google-analytics.com'] },
+            },
+          })
+        );
+
+        const callback = await setupAiAgentsGenerator(tree, options);
+        const { messages } = await callback();
+
+        expect(messages).toEqual([]);
+      });
+
       it('should preserve existing sandbox allowed domains and not duplicate the analytics domain', async () => {
         const options: SetupAiAgentsGeneratorSchema = {
           directory: '.',
           agents: ['claude'],
         };
+        setAnalytics(tree, true);
 
         tree.write(
           '.claude/settings.json',

--- a/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.ts
+++ b/packages/nx/src/ai/set-up-ai-agents/set-up-ai-agents.ts
@@ -6,6 +6,8 @@ import { formatChangedFilesWithPrettierIfAvailable } from '../../generators/inte
 import { Tree } from '../../generators/tree';
 import { generateFiles } from '../../generators/utils/generate-files';
 import { readJson, updateJson, writeJson } from '../../generators/utils/json';
+import { readNxJson } from '../../generators/utils/nx-json';
+import { isAnalyticsEnabled } from '../../utils/analytics-enabled';
 import {
   canInstallNxConsoleForEditor,
   installNxConsoleForEditor,
@@ -131,6 +133,8 @@ export async function setupAiAgentsGeneratorImpl(
 ): Promise<() => Promise<ModificationResults>> {
   const hasAgent = (agent: Agent) => options.agents.includes(agent);
   const nxVersion = getInstalledNxVersion() ?? getDeclaredNxVersionOrDefault();
+  const analyticsEnabled = isAnalyticsEnabled(readNxJson(tree));
+  let addedAnalyticsDomain = false;
 
   const agentsMd = agentsMdPath(options.directory);
 
@@ -157,6 +161,12 @@ export async function setupAiAgentsGeneratorImpl(
     if (!tree.exists(claudeSettingsPath)) {
       writeJson(tree, claudeSettingsPath, {});
     }
+    const allowedDomains: string[] | undefined = readJson(
+      tree,
+      claudeSettingsPath
+    ).sandbox?.network?.allowedDomains;
+    addedAnalyticsDomain =
+      analyticsEnabled && !allowedDomains?.includes(analyticsDomain);
     updateJson(tree, claudeSettingsPath, (json) => ({
       ...json,
       extraKnownMarketplaces: {
@@ -173,21 +183,11 @@ export async function setupAiAgentsGeneratorImpl(
         ...json.enabledPlugins,
         'nx@nx-claude-plugins': true,
       },
-      // Allow Nx analytics requests through Claude Code's sandbox network filter
-      sandbox: {
-        ...json.sandbox,
-        network: {
-          ...json.sandbox?.network,
-          allowedDomains: json.sandbox?.network?.allowedDomains?.includes(
-            analyticsDomain
-          )
-            ? json.sandbox.network.allowedDomains
-            : [
-                ...(json.sandbox?.network?.allowedDomains ?? []),
-                analyticsDomain,
-              ],
-        },
-      },
+      // Widening the sandbox's egress is only justified while events are
+      // actually being sent, so it follows the workspace's analytics opt-in.
+      ...(analyticsEnabled
+        ? { sandbox: allowAnalyticsDomain(json.sandbox) }
+        : {}),
     }));
 
     // Clean up .mcp.json (nx-mcp now handled by plugin)
@@ -358,6 +358,15 @@ export async function setupAiAgentsGeneratorImpl(
   return async (check: boolean = false) => {
     const messages: CLINoteMessageConfig[] = [];
     const errors: CLIErrorMessageConfig[] = [];
+    if (addedAnalyticsDomain) {
+      messages.push({
+        title: `Allowed ${analyticsDomain} through Claude Code's sandbox network filter`,
+        bodyLines: [
+          `Nx sends analytics there because this workspace sets "analytics": true in nx.json.`,
+          `Set it to false to opt out, then remove the domain from .claude/settings.json.`,
+        ],
+      });
+    }
     if (hasAgent('copilot')) {
       try {
         if (
@@ -420,6 +429,19 @@ export async function setupAiAgentsGeneratorImpl(
       messages,
       errors,
     };
+  };
+}
+
+function allowAnalyticsDomain(sandbox: any) {
+  const allowedDomains: string[] = sandbox?.network?.allowedDomains ?? [];
+  return {
+    ...sandbox,
+    network: {
+      ...sandbox?.network,
+      allowedDomains: allowedDomains.includes(analyticsDomain)
+        ? allowedDomains
+        : [...allowedDomains, analyticsDomain],
+    },
   };
 }
 

--- a/packages/nx/src/analytics/analytics.ts
+++ b/packages/nx/src/analytics/analytics.ts
@@ -1,4 +1,5 @@
-import { type NxJsonConfiguration, readNxJson } from '../config/nx-json';
+import { readNxJson } from '../config/nx-json';
+import { isAnalyticsEnabled } from '../utils/analytics-enabled';
 import { workspaceRoot } from '../utils/workspace-root';
 import { nxVersion } from '../utils/versions';
 import { IS_WASM } from '../native';
@@ -275,10 +276,6 @@ function getPackageManagerInfo() {
     name: pm,
     version: getPackageManagerVersion(pm),
   };
-}
-
-function isAnalyticsEnabled(nxJson: NxJsonConfiguration | null): boolean {
-  return nxJson?.analytics === true;
 }
 
 // Mix workspace id in: shared Docker images (Gitpod, Cypress, etc.) bake

--- a/packages/nx/src/utils/analytics-enabled.ts
+++ b/packages/nx/src/utils/analytics-enabled.ts
@@ -1,0 +1,12 @@
+import type { NxJsonConfiguration } from '../config/nx-json';
+
+/**
+ * Analytics are opt-in: both `"analytics": false` and an unset flag mean no
+ * event is ever sent. Anything enabled for the sake of analytics (network
+ * allowlists, endpoints) gates on this, not on an explicit opt-out alone.
+ */
+export function isAnalyticsEnabled(
+  nxJson: NxJsonConfiguration | null
+): boolean {
+  return nxJson?.analytics === true;
+}


### PR DESCRIPTION
## Current Behavior

`nx configure-ai-agents --agents claude` appends `www.google-analytics.com` to `sandbox.network.allowedDomains` in `.claude/settings.json` on every run. The only guard is an idempotency check — whether the domain is already in the list — with no reference to the workspace's `analytics` setting.

A workspace with `"analytics": false` in `nx.json` still gets the egress exception written into a tracked, committed file. That entry is not scoped to Nx: allowlisting the host permits any process in that sandbox to reach it.

## Expected Behavior

The entry is written only when Nx will actually send analytics.

The gate is Nx's own rule, `isAnalyticsEnabled()` — `nxJson?.analytics === true`. That predicate moves out of `packages/nx/src/analytics/analytics.ts` into `packages/nx/src/utils/analytics-enabled.ts` so the generator and the telemetry path share one definition rather than each deciding for itself; the duplicated policy is what produced the bug. The shared module takes only a type import, since importing `analytics.ts` into a generator would pull in the native telemetry module, which runs `getEventDimensions()` at import time.

Note this gates on *enabled*, not on *explicitly disabled*. Since analytics are opt-in, an unset flag also means no event is ever sent, so gating on `analytics === false` alone would still open the egress path for the most common case.

`configure-ai-agents` now also reports the change in its output when it does add the entry, which the issue asked for.

Two deliberate limitations, both open to a maintainer's call:

- `nx init` resolves the analytics preference *after* it configures agents (`init-v2.ts`), so a workspace that opts in during `init` does not get the entry until its next `configure-ai-agents` run. This self-heals — `--check` drift detection reports the workspace outdated, because the generator would change the file — and reordering init's prompts felt like a product decision rather than part of this fix.
- An entry written by an earlier Nx version is not removed when analytics are off. Nx cannot distinguish its own entry from one the user added, and silently deleting a user's allowlist entry is the same class of surprise in reverse.

Tests cover analytics disabled, unset and enabled, an existing sandbox filter left untouched, and the output note appearing exactly once.

## Related Issue(s)

Fixes #36486

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Fix-36486---Gate-Google-Analytics-domain-on-nx.json-setting-de4f9df1">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->