### PR TITLE
feat(misc): support vitest generation for node, nest, and express generators

### DIFF
--- a/e2e/node/src/node-vitest.test.ts
+++ b/e2e/node/src/node-vitest.test.ts
@@ -6,6 +6,17 @@ import {
   uniq,
 } from '@nx/e2e-utils';
 
+/**
+ * `Successfully ran target test` is also printed when vitest collects nothing,
+ * so every case that owns a spec asserts the passed-test count too.
+ */
+function expectTestsPassed(output: string, project: string, count: number) {
+  expect(output).toContain(
+    `Successfully ran target test for project ${project}`
+  );
+  expect(output).toMatch(new RegExp(`Tests\\s+${count} passed`));
+}
+
 describe('Node + vitest', () => {
   beforeAll(() =>
     newProject({
@@ -22,11 +33,12 @@ describe('Node + vitest', () => {
       `generate @nx/node:app apps/${app} --framework=fastify --unitTestRunner=vitest --e2eTestRunner=none --linter=eslint --no-interactive`
     );
 
-    checkFilesExist(`apps/${app}/vitest.config.mts`);
-
-    expect(runCLI(`test ${app}`)).toContain(
-      `Successfully ran target test for project ${app}`
+    checkFilesExist(
+      `apps/${app}/vitest.config.mts`,
+      `apps/${app}/src/app/app.spec.ts`
     );
+
+    expectTestsPassed(runCLI(`test ${app}`), app, 1);
   });
 
   // A node app without the fastify template ships no spec file, so the test
@@ -38,9 +50,9 @@ describe('Node + vitest', () => {
       `generate @nx/node:app apps/${app} --framework=express --unitTestRunner=vitest --e2eTestRunner=none --linter=eslint --no-interactive`
     );
 
-    expect(runCLI(`test ${app}`)).toContain(
-      `Successfully ran target test for project ${app}`
-    );
+    const output = runCLI(`test ${app}`);
+    expect(output).toContain(`Successfully ran target test for project ${app}`);
+    expect(output).toContain('No test files found');
   });
 
   it('should test a node lib with vitest', () => {
@@ -50,11 +62,12 @@ describe('Node + vitest', () => {
       `generate @nx/node:lib libs/${lib} --unitTestRunner=vitest --linter=eslint --no-interactive`
     );
 
-    checkFilesExist(`libs/${lib}/vitest.config.mts`);
-
-    expect(runCLI(`test ${lib}`)).toContain(
-      `Successfully ran target test for project ${lib}`
+    checkFilesExist(
+      `libs/${lib}/vitest.config.mts`,
+      `libs/${lib}/src/lib/${lib}.spec.ts`
     );
+
+    expectTestsPassed(runCLI(`test ${lib}`), lib, 1);
   });
 
   it('should test a nest app with vitest', () => {
@@ -66,12 +79,13 @@ describe('Node + vitest', () => {
 
     checkFilesExist(
       `apps/${app}/vitest.config.mts`,
-      `apps/${app}/src/app/app.controller.spec.ts`
+      `apps/${app}/src/app/app.controller.spec.ts`,
+      `apps/${app}/src/app/app.service.spec.ts`
     );
 
-    expect(runCLI(`test ${app}`)).toContain(
-      `Successfully ran target test for project ${app}`
-    );
+    // Nest DI needs `design:paramtypes`, which only lands if the transform
+    // honors `emitDecoratorMetadata` -- esbuild does not.
+    expectTestsPassed(runCLI(`test ${app}`), app, 2);
   });
 
   it('should test a nest lib with vitest', () => {
@@ -86,8 +100,6 @@ describe('Node + vitest', () => {
       `libs/${lib}/src/lib/${lib}.service.spec.ts`
     );
 
-    expect(runCLI(`test ${lib}`)).toContain(
-      `Successfully ran target test for project ${lib}`
-    );
+    expectTestsPassed(runCLI(`test ${lib}`), lib, 1);
   });
 });

--- a/e2e/node/src/node-vitest.test.ts
+++ b/e2e/node/src/node-vitest.test.ts
@@ -1,0 +1,93 @@
+import {
+  checkFilesExist,
+  cleanupProject,
+  newProject,
+  runCLI,
+  uniq,
+} from '@nx/e2e-utils';
+
+describe('Node + vitest', () => {
+  beforeAll(() =>
+    newProject({
+      packages: ['@nx/node', '@nx/nest', '@nx/vitest'],
+    })
+  );
+
+  afterAll(() => cleanupProject());
+
+  it('should test a node app with vitest', () => {
+    const app = uniq('nodeapp');
+
+    runCLI(
+      `generate @nx/node:app apps/${app} --framework=fastify --unitTestRunner=vitest --e2eTestRunner=none --linter=eslint --no-interactive`
+    );
+
+    checkFilesExist(`apps/${app}/vitest.config.mts`);
+
+    expect(runCLI(`test ${app}`)).toContain(
+      `Successfully ran target test for project ${app}`
+    );
+  });
+
+  // A node app without the fastify template ships no spec file, so the test
+  // target only passes if the generated config sets `passWithNoTests`.
+  it('should test a node app that has no spec files', () => {
+    const app = uniq('nodeapp');
+
+    runCLI(
+      `generate @nx/node:app apps/${app} --framework=express --unitTestRunner=vitest --e2eTestRunner=none --linter=eslint --no-interactive`
+    );
+
+    expect(runCLI(`test ${app}`)).toContain(
+      `Successfully ran target test for project ${app}`
+    );
+  });
+
+  it('should test a node lib with vitest', () => {
+    const lib = uniq('nodelib');
+
+    runCLI(
+      `generate @nx/node:lib libs/${lib} --unitTestRunner=vitest --linter=eslint --no-interactive`
+    );
+
+    checkFilesExist(`libs/${lib}/vitest.config.mts`);
+
+    expect(runCLI(`test ${lib}`)).toContain(
+      `Successfully ran target test for project ${lib}`
+    );
+  });
+
+  it('should test a nest app with vitest', () => {
+    const app = uniq('nestapp');
+
+    runCLI(
+      `generate @nx/nest:app apps/${app} --unitTestRunner=vitest --e2eTestRunner=none --linter=eslint --no-interactive`
+    );
+
+    checkFilesExist(
+      `apps/${app}/vitest.config.mts`,
+      `apps/${app}/src/app/app.controller.spec.ts`
+    );
+
+    expect(runCLI(`test ${app}`)).toContain(
+      `Successfully ran target test for project ${app}`
+    );
+  });
+
+  it('should test a nest lib with vitest', () => {
+    const lib = uniq('nestlib');
+
+    runCLI(
+      `generate @nx/nest:lib libs/${lib} --service --unitTestRunner=vitest --linter=eslint --no-interactive`
+    );
+
+    checkFilesExist(
+      `libs/${lib}/vitest.config.mts`,
+      `libs/${lib}/src/lib/${lib}.service.spec.ts`
+    );
+
+    expect(runCLI(`test ${lib}`)).toContain(
+      `Successfully ran target test for project ${lib}`
+    );
+  });
+});

--- a/packages/express/src/generators/application/application.spec.ts
+++ b/packages/express/src/generators/application/application.spec.ts
@@ -70,6 +70,16 @@ describe('app', () => {
     expect(appTree.exists('my-node-app/eslint.config.mjs')).toBeTruthy();
   });
 
+  it('should set up vitest when asked for it', async () => {
+    await applicationGenerator(appTree, {
+      directory: 'my-node-app',
+      unitTestRunner: 'vitest',
+    } as Schema);
+
+    expect(appTree.exists('my-node-app/vitest.config.mts')).toBeTruthy();
+    expect(appTree.exists('my-node-app/jest.config.cts')).toBeFalsy();
+  });
+
   it('should generate the .eslintrc.json file (eslintrc)', async () => {
     process.env.ESLINT_USE_FLAT_CONFIG = 'false';
     await applicationGenerator(appTree, {

--- a/packages/express/src/generators/application/schema.d.ts
+++ b/packages/express/src/generators/application/schema.d.ts
@@ -2,14 +2,13 @@
 // is not a dependency here, so importing it would resolve to a published
 // tarball rather than workspace source.
 import type { LinterType } from '@nx/js';
-import type { UnitTestRunner } from '../../utils/test-runners';
 
 export interface Schema {
   directory: string;
   name?: string;
   skipFormat: boolean;
   skipPackageJson: boolean;
-  unitTestRunner: UnitTestRunner;
+  unitTestRunner: 'jest' | 'vitest' | 'none';
   tags?: string;
   linter?: LinterType;
   frontendProject?: string;

--- a/packages/express/src/generators/application/schema.json
+++ b/packages/express/src/generators/application/schema.json
@@ -38,7 +38,7 @@
     },
     "unitTestRunner": {
       "type": "string",
-      "enum": ["jest", "none"],
+      "enum": ["jest", "vitest", "none"],
       "description": "Test runner to use for unit tests.",
       "default": "none",
       "x-prompt": "Which unit test runner would you like to use?"

--- a/packages/js/src/generators/library/library.spec.ts
+++ b/packages/js/src/generators/library/library.spec.ts
@@ -1630,6 +1630,26 @@ describe('lib', () => {
     });
   });
 
+  describe('--unit-test-runner vitest', () => {
+    it('should not add dependencies when --skipPackageJson', async () => {
+      const before = readJson(tree, 'package.json');
+
+      await libraryGenerator(tree, {
+        ...defaultOptions,
+        directory: 'my-lib',
+        unitTestRunner: 'vitest',
+        // `addLint` writes its own dependencies regardless of the flag.
+        linter: 'none',
+        skipPackageJson: true,
+        skipFormat: true,
+      });
+
+      // Guards against the assertion passing because the vitest setup never ran.
+      expect(tree.exists('my-lib/vitest.config.mts')).toBeTruthy();
+      expect(readJson(tree, 'package.json')).toEqual(before);
+    });
+  });
+
   describe('--bundler=esbuild', () => {
     it('should add build with esbuild', async () => {
       process.env.ESLINT_USE_FLAT_CONFIG = 'false';

--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -189,6 +189,7 @@ export async function libraryGeneratorInternal(
       testEnvironment: options.testEnvironment,
       runtimeTsconfigFileName: 'tsconfig.lib.json',
       compiler: options.compiler === 'swc' ? 'swc' : 'babel',
+      passWithNoTests: options.passWithNoTests,
       addPlugin: options.addPlugin,
     });
     tasks.push(vitestTask);

--- a/packages/js/src/generators/library/library.ts
+++ b/packages/js/src/generators/library/library.ts
@@ -190,6 +190,7 @@ export async function libraryGeneratorInternal(
       runtimeTsconfigFileName: 'tsconfig.lib.json',
       compiler: options.compiler === 'swc' ? 'swc' : 'babel',
       passWithNoTests: options.passWithNoTests,
+      skipPackageJson: options.skipPackageJson,
       addPlugin: options.addPlugin,
     });
     tasks.push(vitestTask);

--- a/packages/js/src/generators/library/schema.d.ts
+++ b/packages/js/src/generators/library/schema.d.ts
@@ -36,6 +36,11 @@ export interface LibraryGeneratorSchema {
   addPlugin?: boolean;
   useProjectJson?: boolean;
   useTscExecutor?: boolean;
+  /**
+   * Only honored by the vitest setup. For callers that delete the generated
+   * spec file, so a fresh library still has a passing `test` target.
+   */
+  passWithNoTests?: boolean;
 }
 
 export interface NormalizedLibraryGeneratorOptions

--- a/packages/js/src/generators/library/schema.d.ts
+++ b/packages/js/src/generators/library/schema.d.ts
@@ -36,10 +36,7 @@ export interface LibraryGeneratorSchema {
   addPlugin?: boolean;
   useProjectJson?: boolean;
   useTscExecutor?: boolean;
-  /**
-   * Only honored by the vitest setup. For callers that delete the generated
-   * spec file, so a fresh library still has a passing `test` target.
-   */
+  /** @internal Only honored by the vitest setup. */
   passWithNoTests?: boolean;
 }
 

--- a/packages/nest/src/generators/application/application.spec.ts
+++ b/packages/nest/src/generators/application/application.spec.ts
@@ -181,6 +181,67 @@ describe('application generator', () => {
     ).toBeTruthy();
   });
 
+  describe('vitest requires vite 8', () => {
+    const setViteVersion = (version: string) =>
+      updateJson(tree, 'package.json', (json) => {
+        json.devDependencies = { ...json.devDependencies, vite: version };
+        return json;
+      });
+
+    it.each(['^7.0.0', '7.3.6', '~6.2.0'])(
+      'should throw when vite is %s',
+      async (version) => {
+        setViteVersion(version);
+
+        await expect(
+          applicationGenerator(tree, {
+            directory: appDirectory,
+            unitTestRunner: 'vitest',
+            e2eTestRunner: 'none',
+            addPlugin: true,
+          })
+        ).rejects.toThrow(/requires Vite 8 or later/);
+      }
+    );
+
+    it('should not throw when vite is 8', async () => {
+      setViteVersion('^8.0.0');
+
+      await expect(
+        applicationGenerator(tree, {
+          directory: appDirectory,
+          unitTestRunner: 'vitest',
+          e2eTestRunner: 'none',
+          addPlugin: true,
+        })
+      ).resolves.toBeDefined();
+    });
+
+    it('should not throw when vite is not installed', async () => {
+      await expect(
+        applicationGenerator(tree, {
+          directory: appDirectory,
+          unitTestRunner: 'vitest',
+          e2eTestRunner: 'none',
+          addPlugin: true,
+        })
+      ).resolves.toBeDefined();
+    });
+
+    it('should not throw for jest on an older vite', async () => {
+      setViteVersion('^7.0.0');
+
+      await expect(
+        applicationGenerator(tree, {
+          directory: appDirectory,
+          unitTestRunner: 'jest',
+          e2eTestRunner: 'none',
+          addPlugin: true,
+        })
+      ).resolves.toBeDefined();
+    });
+  });
+
   it('should configure tsconfig correctly', async () => {
     // pin TS<6 to exercise the 'node10' branch deterministically
     updateJson(tree, 'package.json', (json) => {

--- a/packages/nest/src/generators/application/application.spec.ts
+++ b/packages/nest/src/generators/application/application.spec.ts
@@ -163,6 +163,24 @@ describe('application generator', () => {
     ).toBeTruthy();
   });
 
+  it('should generate spec files and a vitest config when unitTestRunner is vitest', async () => {
+    await applicationGenerator(tree, {
+      directory: appDirectory,
+      unitTestRunner: 'vitest',
+      e2eTestRunner: 'none',
+      addPlugin: true,
+    });
+
+    expect(tree.exists(`${appDirectory}/vitest.config.mts`)).toBeTruthy();
+    expect(tree.exists(`${appDirectory}/jest.config.cts`)).toBeFalsy();
+    expect(
+      tree.exists(`${appDirectory}/src/app/app.controller.spec.ts`)
+    ).toBeTruthy();
+    expect(
+      tree.exists(`${appDirectory}/src/app/app.service.spec.ts`)
+    ).toBeTruthy();
+  });
+
   it('should configure tsconfig correctly', async () => {
     // pin TS<6 to exercise the 'node10' branch deterministically
     updateJson(tree, 'package.json', (json) => {

--- a/packages/nest/src/generators/application/application.ts
+++ b/packages/nest/src/generators/application/application.ts
@@ -11,6 +11,7 @@ import {
 } from './lib';
 import type { ApplicationGeneratorOptions } from './schema';
 import { assertSupportedNestJsVersion } from '../../utils/assert-supported-nestjs-version';
+import { assertVitestSupported } from '../../utils/assert-vitest-supported';
 import { ensureDependencies } from '../../utils/ensure-dependencies';
 
 export async function applicationGenerator(
@@ -31,6 +32,10 @@ export async function applicationGeneratorInternal(
   assertSupportedNestJsVersion(tree);
 
   const options = await normalizeOptions(tree, rawOptions);
+
+  if (options.unitTestRunner === 'vitest') {
+    assertVitestSupported(tree);
+  }
 
   const tasks: GeneratorCallback[] = [];
   const initTask = await initGenerator(tree, {

--- a/packages/nest/src/generators/application/lib/create-files.ts
+++ b/packages/nest/src/generators/application/lib/create-files.ts
@@ -14,7 +14,7 @@ export function createFiles(tree: Tree, options: NormalizedOptions): void {
       root: options.appProjectRoot,
     }
   );
-  if (options.unitTestRunner === 'jest') {
+  if (options.unitTestRunner !== 'none') {
     generateFiles(
       tree,
       join(__dirname, '..', 'files', 'test'),

--- a/packages/nest/src/generators/application/schema.d.ts
+++ b/packages/nest/src/generators/application/schema.d.ts
@@ -8,7 +8,7 @@ export interface ApplicationGeneratorOptions {
   skipFormat?: boolean;
   skipPackageJson?: boolean;
   tags?: string;
-  unitTestRunner?: 'jest' | 'none';
+  unitTestRunner?: 'jest' | 'vitest' | 'none';
   e2eTestRunner?: 'jest' | 'none';
   enableTypedLinting?: boolean;
   /**

--- a/packages/nest/src/generators/application/schema.json
+++ b/packages/nest/src/generators/application/schema.json
@@ -42,7 +42,7 @@
     "unitTestRunner": {
       "description": "Test runner to use for unit tests.",
       "type": "string",
-      "enum": ["jest", "none"],
+      "enum": ["jest", "vitest", "none"],
       "default": "none",
       "x-prompt": "Which unit test runner would you like to use?"
     },

--- a/packages/nest/src/generators/class/schema.json
+++ b/packages/nest/src/generators/class/schema.json
@@ -34,7 +34,7 @@
     "unitTestRunner": {
       "description": "Test runner to use for unit tests.",
       "type": "string",
-      "enum": ["jest", "none"],
+      "enum": ["jest", "vitest", "none"],
       "default": "jest"
     },
     "language": {

--- a/packages/nest/src/generators/controller/schema.json
+++ b/packages/nest/src/generators/controller/schema.json
@@ -34,7 +34,7 @@
     "unitTestRunner": {
       "description": "Test runner to use for unit tests.",
       "type": "string",
-      "enum": ["jest", "none"],
+      "enum": ["jest", "vitest", "none"],
       "default": "jest"
     },
     "language": {

--- a/packages/nest/src/generators/filter/schema.json
+++ b/packages/nest/src/generators/filter/schema.json
@@ -34,7 +34,7 @@
     "unitTestRunner": {
       "description": "Test runner to use for unit tests.",
       "type": "string",
-      "enum": ["jest", "none"],
+      "enum": ["jest", "vitest", "none"],
       "default": "jest"
     },
     "language": {

--- a/packages/nest/src/generators/gateway/schema.json
+++ b/packages/nest/src/generators/gateway/schema.json
@@ -34,7 +34,7 @@
     "unitTestRunner": {
       "description": "Test runner to use for unit tests.",
       "type": "string",
-      "enum": ["jest", "none"],
+      "enum": ["jest", "vitest", "none"],
       "default": "jest"
     },
     "language": {

--- a/packages/nest/src/generators/guard/schema.json
+++ b/packages/nest/src/generators/guard/schema.json
@@ -34,7 +34,7 @@
     "unitTestRunner": {
       "description": "Test runner to use for unit tests.",
       "type": "string",
-      "enum": ["jest", "none"],
+      "enum": ["jest", "vitest", "none"],
       "default": "jest"
     },
     "language": {

--- a/packages/nest/src/generators/interceptor/schema.json
+++ b/packages/nest/src/generators/interceptor/schema.json
@@ -34,7 +34,7 @@
     "unitTestRunner": {
       "description": "Test runner to use for unit tests.",
       "type": "string",
-      "enum": ["jest", "none"],
+      "enum": ["jest", "vitest", "none"],
       "default": "jest"
     },
     "language": {

--- a/packages/nest/src/generators/library/lib/normalize-options.ts
+++ b/packages/nest/src/generators/library/lib/normalize-options.ts
@@ -87,6 +87,9 @@ export function toJsLibraryGeneratorOptions(
     tags: options.tags,
     testEnvironment: options.testEnvironment,
     unitTestRunner: options.unitTestRunner,
+    // `deleteFiles` drops the generated spec, and a library without a
+    // controller or service is left with none at all.
+    passWithNoTests: true,
     enableTypedLinting: isTypedLintingEnabled(options),
     addPlugin: options.addPlugin,
     useProjectJson: options.useProjectJson,

--- a/packages/nest/src/generators/library/library.spec.ts
+++ b/packages/nest/src/generators/library/library.spec.ts
@@ -264,6 +264,48 @@ describe('lib', () => {
     });
   });
 
+  describe('--unit-test-runner vitest', () => {
+    it('should generate a vitest configuration', async () => {
+      await libraryGenerator(tree, {
+        directory: 'my-lib',
+        unitTestRunner: 'vitest',
+      });
+
+      expect(tree.exists('my-lib/vitest.config.mts')).toBeTruthy();
+      expect(tree.exists('my-lib/jest.config.cts')).toBeFalsy();
+      expect(
+        readJson(tree, 'my-lib/tsconfig.spec.json').compilerOptions.types
+      ).toContain('vitest/globals');
+    });
+
+    // A library without a controller or service has no spec at all, since
+    // `deleteFiles` drops the one @nx/js:library generates.
+    it('should pass with no tests', async () => {
+      await libraryGenerator(tree, {
+        directory: 'my-lib',
+        unitTestRunner: 'vitest',
+      });
+
+      expect(tree.read('my-lib/vitest.config.mts', 'utf-8')).toContain(
+        'passWithNoTests: true'
+      );
+    });
+
+    it('should generate controller and service specs', async () => {
+      await libraryGenerator(tree, {
+        directory: 'my-lib',
+        unitTestRunner: 'vitest',
+        controller: true,
+        service: true,
+      });
+
+      expect(
+        tree.exists('my-lib/src/lib/my-lib.controller.spec.ts')
+      ).toBeTruthy();
+      expect(tree.exists('my-lib/src/lib/my-lib.service.spec.ts')).toBeTruthy();
+    });
+  });
+
   describe('publishable package', () => {
     it('should update package.json', async () => {
       const importPath = `@proj/myLib`;

--- a/packages/nest/src/generators/library/library.ts
+++ b/packages/nest/src/generators/library/library.ts
@@ -10,6 +10,7 @@ import {
 } from '@nx/devkit';
 import { libraryGenerator as jsLibraryGenerator } from '@nx/js';
 import { assertSupportedNestJsVersion } from '../../utils/assert-supported-nestjs-version';
+import { assertVitestSupported } from '../../utils/assert-vitest-supported';
 import { ensureDependencies } from '../../utils/ensure-dependencies';
 import initGenerator from '../init/init';
 import {
@@ -41,6 +42,10 @@ export async function libraryGeneratorInternal(
   assertSupportedNestJsVersion(tree);
 
   const options = await normalizeOptions(tree, rawOptions);
+
+  if (options.unitTestRunner === 'vitest') {
+    assertVitestSupported(tree);
+  }
 
   const jsLibraryTask = await jsLibraryGenerator(
     tree,

--- a/packages/nest/src/generators/library/schema.json
+++ b/packages/nest/src/generators/library/schema.json
@@ -36,7 +36,7 @@
     "unitTestRunner": {
       "description": "Test runner to use for unit tests.",
       "type": "string",
-      "enum": ["jest", "none"],
+      "enum": ["jest", "vitest", "none"],
       "default": "none",
       "x-prompt": "Which unit test runner would you like to use?",
       "x-priority": "important"
@@ -89,7 +89,7 @@
       "default": false
     },
     "testEnvironment": {
-      "description": "The test environment for jest, for node applications this should stay as node unless doing DOM testing.",
+      "description": "The test environment for the unit test runner. For node applications this should stay as node unless doing DOM testing.",
       "type": "string",
       "enum": ["jsdom", "node"],
       "default": "node"

--- a/packages/nest/src/generators/middleware/schema.json
+++ b/packages/nest/src/generators/middleware/schema.json
@@ -34,7 +34,7 @@
     "unitTestRunner": {
       "description": "Test runner to use for unit tests.",
       "type": "string",
-      "enum": ["jest", "none"],
+      "enum": ["jest", "vitest", "none"],
       "default": "jest"
     },
     "language": {

--- a/packages/nest/src/generators/pipe/schema.json
+++ b/packages/nest/src/generators/pipe/schema.json
@@ -34,7 +34,7 @@
     "unitTestRunner": {
       "description": "Test runner to use for unit tests.",
       "type": "string",
-      "enum": ["jest", "none"],
+      "enum": ["jest", "vitest", "none"],
       "default": "jest"
     },
     "language": {

--- a/packages/nest/src/generators/provider/schema.json
+++ b/packages/nest/src/generators/provider/schema.json
@@ -34,7 +34,7 @@
     "unitTestRunner": {
       "description": "Test runner to use for unit tests.",
       "type": "string",
-      "enum": ["jest", "none"],
+      "enum": ["jest", "vitest", "none"],
       "default": "jest"
     },
     "language": {

--- a/packages/nest/src/generators/resolver/schema.json
+++ b/packages/nest/src/generators/resolver/schema.json
@@ -34,7 +34,7 @@
     "unitTestRunner": {
       "description": "Test runner to use for unit tests.",
       "type": "string",
-      "enum": ["jest", "none"],
+      "enum": ["jest", "vitest", "none"],
       "default": "jest"
     },
     "language": {

--- a/packages/nest/src/generators/resource/schema.json
+++ b/packages/nest/src/generators/resource/schema.json
@@ -30,7 +30,7 @@
     "unitTestRunner": {
       "description": "Test runner to use for unit tests.",
       "type": "string",
-      "enum": ["jest", "none"],
+      "enum": ["jest", "vitest", "none"],
       "default": "jest"
     },
     "type": {

--- a/packages/nest/src/generators/service/schema.json
+++ b/packages/nest/src/generators/service/schema.json
@@ -34,7 +34,7 @@
     "unitTestRunner": {
       "description": "Test runner to use for unit tests.",
       "type": "string",
-      "enum": ["jest", "none"],
+      "enum": ["jest", "vitest", "none"],
       "default": "jest"
     },
     "language": {

--- a/packages/nest/src/generators/service/service.spec.ts
+++ b/packages/nest/src/generators/service/service.spec.ts
@@ -14,4 +14,19 @@ describe('service generator', () => {
       serviceGenerator(tree, { path: 'api/test' })
     ).resolves.not.toThrow();
   });
+
+  it.each(['jest', 'vitest'] as const)(
+    'should generate a spec file for %s',
+    async (unitTestRunner) => {
+      await serviceGenerator(tree, { path: 'api/test', unitTestRunner });
+
+      expect(tree.exists('api/test.service.spec.ts')).toBeTruthy();
+    }
+  );
+
+  it('should not generate a spec file when unitTestRunner is none', async () => {
+    await serviceGenerator(tree, { path: 'api/test', unitTestRunner: 'none' });
+
+    expect(tree.exists('api/test.service.spec.ts')).toBeFalsy();
+  });
 });

--- a/packages/nest/src/generators/utils/normalize-options.ts
+++ b/packages/nest/src/generators/utils/normalize-options.ts
@@ -55,5 +55,5 @@ export async function normalizeOptions(
 export function unitTestRunnerToSpec(
   unitTestRunner: UnitTestRunner | undefined
 ): boolean | undefined {
-  return unitTestRunner !== undefined ? unitTestRunner === 'jest' : undefined;
+  return unitTestRunner !== undefined ? unitTestRunner !== 'none' : undefined;
 }

--- a/packages/nest/src/generators/utils/types.ts
+++ b/packages/nest/src/generators/utils/types.ts
@@ -1,5 +1,5 @@
 export type Language = 'js' | 'ts';
-export type UnitTestRunner = 'jest' | 'none';
+export type UnitTestRunner = 'jest' | 'vitest' | 'none';
 export type NestSchematic =
   | 'class'
   | 'controller'

--- a/packages/nest/src/utils/assert-vitest-supported.ts
+++ b/packages/nest/src/utils/assert-vitest-supported.ts
@@ -1,0 +1,32 @@
+import { getDependencyVersionFromPackageJson, type Tree } from '@nx/devkit';
+import { clean, coerce, major } from 'semver';
+
+export const minSupportedViteMajorForVitest = 8;
+
+/**
+ * Nest resolves constructor dependencies from `design:paramtypes`, which only
+ * exists when the transform honors `emitDecoratorMetadata`. Vite < 8 transforms
+ * TypeScript with esbuild, which drops it, so the injector sees no dependencies
+ * and every generated spec that injects a provider fails. Vite 8's oxc transform
+ * emits it.
+ */
+export function assertVitestSupported(tree: Tree): void {
+  const declaredVersion = getDependencyVersionFromPackageJson(tree, 'vite');
+  if (!declaredVersion) {
+    // Vite isn't installed yet, so @nx/vitest will install a supported major.
+    return;
+  }
+
+  const version = clean(declaredVersion) ?? coerce(declaredVersion)?.version;
+  // An unparseable range (workspace:, catalog:, a git url) isn't evidence of an
+  // unsupported version, so don't block on it.
+  if (!version || major(version) >= minSupportedViteMajorForVitest) {
+    return;
+  }
+
+  throw new Error(
+    `Using vitest with @nx/nest requires Vite ${minSupportedViteMajorForVitest} or later, but found Vite ${version}.\n` +
+      `Nest dependency injection needs "emitDecoratorMetadata", which the esbuild transform used by Vite < ${minSupportedViteMajorForVitest} does not emit.\n` +
+      `Upgrade Vite, or generate with "--unitTestRunner=jest".`
+  );
+}

--- a/packages/node/eslint.config.mjs
+++ b/packages/node/eslint.config.mjs
@@ -36,7 +36,10 @@ export default [
           ignoredDependencies: [
             'nx',
             'typescript',
+            // Installed on demand via `ensurePackage` when the generator is
+            // asked for that bundler / unit test runner.
             '@nx/webpack',
+            '@nx/vitest',
             'express',
             'koa',
             'fastify',

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -81,7 +81,8 @@
   },
   "devDependencies": {
     "nx": "workspace:*",
-    "@nx/webpack": "workspace:*"
+    "@nx/webpack": "workspace:*",
+    "@nx/vitest": "workspace:*"
   },
   "peerDependencies": {
     "express": ">=4.0.0 <6.0.0",

--- a/packages/node/project.json
+++ b/packages/node/project.json
@@ -23,6 +23,7 @@
             "playwright",
             "webpack",
             "jest",
+            "vitest",
             "eslint",
             "docker"
           ],

--- a/packages/node/src/generators/application/application.spec.ts
+++ b/packages/node/src/generators/application/application.spec.ts
@@ -433,6 +433,70 @@ describe('app', () => {
     });
   });
 
+  describe('--unit-test-runner vitest', () => {
+    it('should generate a vitest configuration', async () => {
+      await applicationGenerator(tree, {
+        directory: 'my-node-app',
+        unitTestRunner: 'vitest',
+        e2eTestRunner: 'none',
+        addPlugin: true,
+      });
+
+      expect(tree.exists('my-node-app/vitest.config.mts')).toBeTruthy();
+      expect(tree.exists('my-node-app/jest.config.cts')).toBeFalsy();
+      expect(tree.read('my-node-app/vitest.config.mts', 'utf-8'))
+        .toMatchInlineSnapshot(`
+        "import { defineConfig } from 'vitest/config';
+        import { nxViteTsPaths } from '@nx/vite/plugins/nx-tsconfig-paths.plugin';
+        import { nxCopyAssetsPlugin } from '@nx/vite/plugins/nx-copy-assets.plugin';
+
+        export default defineConfig(() => ({
+          root: import.meta.dirname,
+          cacheDir: '../node_modules/.vite/my-node-app',
+          plugins: [nxViteTsPaths(), nxCopyAssetsPlugin(['*.md'])],
+          test: {
+            name: 'my-node-app',
+            watch: false,
+            globals: true,
+            environment: 'node',
+            include: ['{src,tests}/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+            passWithNoTests: true,
+            reporters: ['default'],
+            coverage: {
+              reportsDirectory: '../coverage/my-node-app',
+              provider: 'v8' as const,
+            },
+          },
+        }));
+        "
+      `);
+    });
+
+    it('should set up the spec tsconfig for vitest', async () => {
+      await applicationGenerator(tree, {
+        directory: 'my-node-app',
+        unitTestRunner: 'vitest',
+        e2eTestRunner: 'none',
+        addPlugin: true,
+      });
+
+      const tsConfig = readJson(tree, 'my-node-app/tsconfig.spec.json');
+      expect(tsConfig.compilerOptions.types).toContain('vitest/globals');
+    });
+
+    it('should keep the generated spec file', async () => {
+      await applicationGenerator(tree, {
+        directory: 'api',
+        framework: 'fastify',
+        unitTestRunner: 'vitest',
+        e2eTestRunner: 'none',
+        addPlugin: true,
+      });
+
+      expect(tree.exists('api/src/app/app.spec.ts')).toBeTruthy();
+    });
+  });
+
   describe('--linter', () => {
     // The lint block used to be gated on `=== 'eslint'`, so asking for oxlint
     // skipped it entirely and produced an app with no linter and no error.

--- a/packages/node/src/generators/application/application.spec.ts
+++ b/packages/node/src/generators/application/application.spec.ts
@@ -495,6 +495,20 @@ describe('app', () => {
 
       expect(tree.exists('api/src/app/app.spec.ts')).toBeTruthy();
     });
+
+    it('should not add dependencies when --skipPackageJson', async () => {
+      await applicationGenerator(tree, {
+        directory: 'my-node-app',
+        unitTestRunner: 'vitest',
+        e2eTestRunner: 'none',
+        skipPackageJson: true,
+        addPlugin: true,
+      });
+
+      const { devDependencies } = readJson(tree, 'package.json');
+      expect(devDependencies).not.toHaveProperty('vitest');
+      expect(devDependencies).not.toHaveProperty('@vitest/coverage-v8');
+    });
   });
 
   describe('--linter', () => {

--- a/packages/node/src/generators/application/application.ts
+++ b/packages/node/src/generators/application/application.ts
@@ -198,6 +198,25 @@ export async function applicationGeneratorInternal(tree: Tree, schema: Schema) {
       },
     };
     updateProjectConfiguration(tree, options.name, projectConfig);
+  } else if (options.unitTestRunner === 'vitest') {
+    ensurePackage('@nx/vitest', nxVersion);
+    // CommonJS `require` instead of dynamic ESM `import`: `ensurePackage`
+    // exposes the temp install via `Module._initPaths`, which ESM ignores.
+    // Untyped because the ambient types resolve to the published @nx/vitest.
+    const { configurationGenerator } = require('@nx/vitest/generators');
+    const vitestTask = await configurationGenerator(tree, {
+      project: options.name,
+      uiFramework: 'none',
+      coverageProvider: 'v8',
+      testEnvironment: 'node',
+      runtimeTsconfigFileName: 'tsconfig.app.json',
+      // Only the fastify template ships a spec, so the other frameworks would
+      // otherwise fail `nx test` on a freshly generated app.
+      passWithNoTests: true,
+      addPlugin: options.addPlugin,
+      skipFormat: true,
+    });
+    tasks.push(vitestTask);
   } else {
     // No need for default spec file if unit testing is not setup.
     tree.delete(

--- a/packages/node/src/generators/application/application.ts
+++ b/packages/node/src/generators/application/application.ts
@@ -214,6 +214,7 @@ export async function applicationGeneratorInternal(tree: Tree, schema: Schema) {
       // otherwise fail `nx test` on a freshly generated app.
       passWithNoTests: true,
       addPlugin: options.addPlugin,
+      skipPackageJson: options.skipPackageJson,
       skipFormat: true,
     });
     tasks.push(vitestTask);

--- a/packages/node/src/generators/application/application.ts
+++ b/packages/node/src/generators/application/application.ts
@@ -202,8 +202,9 @@ export async function applicationGeneratorInternal(tree: Tree, schema: Schema) {
     ensurePackage('@nx/vitest', nxVersion);
     // CommonJS `require` instead of dynamic ESM `import`: `ensurePackage`
     // exposes the temp install via `Module._initPaths`, which ESM ignores.
-    // Untyped because the ambient types resolve to the published @nx/vitest.
-    const { configurationGenerator } = require('@nx/vitest/generators');
+    const {
+      configurationGenerator,
+    }: typeof import('@nx/vitest/generators') = require('@nx/vitest/generators');
     const vitestTask = await configurationGenerator(tree, {
       project: options.name,
       uiFramework: 'none',

--- a/packages/node/src/generators/application/files/fastify/src/app/app.spec.ts__tmpl__
+++ b/packages/node/src/generators/application/files/fastify/src/app/app.spec.ts__tmpl__
@@ -1,4 +1,5 @@
-import Fastify, { FastifyInstance } from 'fastify';
+import Fastify from 'fastify';
+import type { FastifyInstance } from 'fastify';
 import { app } from './app';
 
 describe('GET /', () => {

--- a/packages/node/src/generators/application/files/fastify/src/app/app.ts__tmpl__
+++ b/packages/node/src/generators/application/files/fastify/src/app/app.ts__tmpl__
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import { FastifyInstance } from 'fastify';
+import type { FastifyInstance } from 'fastify';
 import AutoLoad from '@fastify/autoload';
 
 /* eslint-disable-next-line */

--- a/packages/node/src/generators/application/files/fastify/src/app/plugins/sensible.ts__tmpl__
+++ b/packages/node/src/generators/application/files/fastify/src/app/plugins/sensible.ts__tmpl__
@@ -1,4 +1,4 @@
-import { FastifyInstance } from 'fastify';
+import type { FastifyInstance } from 'fastify';
 import fp from 'fastify-plugin';
 import sensible from '@fastify/sensible';
 

--- a/packages/node/src/generators/application/files/fastify/src/app/routes/root.ts__tmpl__
+++ b/packages/node/src/generators/application/files/fastify/src/app/routes/root.ts__tmpl__
@@ -1,4 +1,4 @@
-import { FastifyInstance } from 'fastify';
+import type { FastifyInstance } from 'fastify';
 
 export default async function(fastify: FastifyInstance) {
   fastify.get('/', async function() {

--- a/packages/node/src/generators/application/schema.d.ts
+++ b/packages/node/src/generators/application/schema.d.ts
@@ -5,7 +5,7 @@ export interface Schema {
   name?: string;
   skipFormat?: boolean;
   skipPackageJson?: boolean;
-  unitTestRunner?: 'jest' | 'none';
+  unitTestRunner?: 'jest' | 'vitest' | 'none';
   e2eTestRunner?: 'jest' | 'none';
   linter?: LinterType;
   formatter?: 'none' | 'prettier';

--- a/packages/node/src/generators/application/schema.json
+++ b/packages/node/src/generators/application/schema.json
@@ -41,7 +41,7 @@
     },
     "unitTestRunner": {
       "type": "string",
-      "enum": ["jest", "none"],
+      "enum": ["jest", "vitest", "none"],
       "description": "Test runner to use for unit tests.",
       "default": "none",
       "x-priority": "important",

--- a/packages/node/src/generators/library/library.spec.ts
+++ b/packages/node/src/generators/library/library.spec.ts
@@ -315,6 +315,33 @@ describe('lib', () => {
     });
   });
 
+  describe('--unit-test-runner vitest', () => {
+    it('should generate a vitest configuration', async () => {
+      await libraryGenerator(tree, {
+        ...baseLibraryConfig,
+        unitTestRunner: 'vitest',
+      });
+
+      expect(tree.exists('my-lib/vitest.config.mts')).toBeTruthy();
+      expect(tree.exists('my-lib/jest.config.cts')).toBeFalsy();
+      expect(
+        readJson(tree, 'my-lib/tsconfig.spec.json').compilerOptions.types
+      ).toContain('vitest/globals');
+      expect(tree.read('my-lib/vitest.config.mts', 'utf-8')).toContain(
+        `environment: 'node'`
+      );
+    });
+
+    it('should keep the generated spec file', async () => {
+      await libraryGenerator(tree, {
+        ...baseLibraryConfig,
+        unitTestRunner: 'vitest',
+      });
+
+      expect(tree.exists('my-lib/src/lib/my-lib.spec.ts')).toBeTruthy();
+    });
+  });
+
   describe('buildable package', () => {
     it('should have a builder defined', async () => {
       await libraryGenerator(tree, {

--- a/packages/node/src/generators/library/schema.d.ts
+++ b/packages/node/src/generators/library/schema.d.ts
@@ -12,7 +12,6 @@ export interface Schema {
   buildable?: boolean;
   publishable?: boolean;
   importPath?: string;
-  testEnvironment?: 'jsdom' | 'node';
   rootDir?: string;
   babelJest?: boolean;
   js?: boolean;

--- a/packages/node/src/generators/library/schema.d.ts
+++ b/packages/node/src/generators/library/schema.d.ts
@@ -7,7 +7,7 @@ export interface Schema {
   skipTsConfig?: boolean;
   skipFormat?: boolean;
   tags?: string;
-  unitTestRunner?: 'jest' | 'none';
+  unitTestRunner?: 'jest' | 'vitest' | 'none';
   linter?: LinterType;
   buildable?: boolean;
   publishable?: boolean;

--- a/packages/node/src/generators/library/schema.json
+++ b/packages/node/src/generators/library/schema.json
@@ -90,12 +90,6 @@
       "type": "string",
       "description": "Sets the `rootDir` for TypeScript compilation. When not defined, it uses the project's root property, or `srcRootForCompilationRoot` if it is defined."
     },
-    "testEnvironment": {
-      "type": "string",
-      "enum": ["jsdom", "node"],
-      "description": "The test environment for the unit test runner. For node libraries this should stay as node unless doing DOM testing.",
-      "default": "jsdom"
-    },
     "babelJest": {
       "type": "boolean",
       "description": "Use `babel` instead of `ts-jest`.",

--- a/packages/node/src/generators/library/schema.json
+++ b/packages/node/src/generators/library/schema.json
@@ -41,7 +41,7 @@
     },
     "unitTestRunner": {
       "type": "string",
-      "enum": ["jest", "none"],
+      "enum": ["jest", "vitest", "none"],
       "description": "Test runner to use for unit tests.",
       "default": "none",
       "x-prompt": "Which unit test runner would you like to use?",

--- a/packages/node/src/generators/library/schema.json
+++ b/packages/node/src/generators/library/schema.json
@@ -93,7 +93,7 @@
     "testEnvironment": {
       "type": "string",
       "enum": ["jsdom", "node"],
-      "description": "The test environment to use if `unitTestRunner` is set to `jest`.",
+      "description": "The test environment for the unit test runner. For node libraries this should stay as node unless doing DOM testing.",
       "default": "jsdom"
     },
     "babelJest": {

--- a/packages/node/tsconfig.lib.json
+++ b/packages/node/tsconfig.lib.json
@@ -40,6 +40,9 @@
       "path": "../devkit/tsconfig.lib.json"
     },
     {
+      "path": "../vitest/tsconfig.lib.json"
+    },
+    {
       "path": "../webpack/tsconfig.lib.json"
     },
     {

--- a/packages/vitest/src/generators/configuration/configuration.spec.ts
+++ b/packages/vitest/src/generators/configuration/configuration.spec.ts
@@ -68,6 +68,30 @@ describe('@nx/vitest:configuration', () => {
     `);
   });
 
+  it.each([[undefined], [true]])(
+    'should emit passWithNoTests in the project config only when requested (%s)',
+    async (passWithNoTests) => {
+      setVitestVersion('~4.1.0');
+
+      await configurationGenerator(tree, {
+        project: 'mylib',
+        uiFramework: 'none',
+        coverageProvider: 'v8',
+        passWithNoTests,
+        skipPackageJson: true,
+        addPlugin: false,
+        skipFormat: true,
+      });
+
+      const config = tree.read('libs/mylib/vitest.config.mts', 'utf-8');
+      if (passWithNoTests) {
+        expect(config).toContain('passWithNoTests: true');
+      } else {
+        expect(config).not.toContain('passWithNoTests');
+      }
+    }
+  );
+
   it('should create a root vitest.workspace.mts for vitest 3', async () => {
     setVitestVersion('^3.0.0');
 

--- a/packages/vitest/src/generators/configuration/configuration.spec.ts
+++ b/packages/vitest/src/generators/configuration/configuration.spec.ts
@@ -92,6 +92,35 @@ describe('@nx/vitest:configuration', () => {
     }
   );
 
+  it('should add passWithNoTests to a pre-existing vite config', async () => {
+    setVitestVersion('~4.1.0');
+    tree.write(
+      'libs/mylib/vite.config.mts',
+      `import { defineConfig } from 'vite';
+
+export default defineConfig({
+  test: {
+    globals: true,
+  },
+});
+`
+    );
+
+    await configurationGenerator(tree, {
+      project: 'mylib',
+      uiFramework: 'none',
+      coverageProvider: 'v8',
+      passWithNoTests: true,
+      skipPackageJson: true,
+      addPlugin: false,
+      skipFormat: true,
+    });
+
+    expect(tree.read('libs/mylib/vite.config.mts', 'utf-8')).toContain(
+      `'passWithNoTests': true`
+    );
+  });
+
   it('should create a root vitest.workspace.mts for vitest 3', async () => {
     setVitestVersion('^3.0.0');
 

--- a/packages/vitest/src/generators/configuration/configuration.ts
+++ b/packages/vitest/src/generators/configuration/configuration.ts
@@ -212,6 +212,7 @@ getTestBed().initTestEnvironment(
           imports: [`import angular from '@analogjs/vite-plugin-angular'`],
           plugins: ['angular()'],
           setupFile: relativeTestSetupPath,
+          passWithNoTests: schema.passWithNoTests,
           useEsmExtension: true,
         },
         true,
@@ -240,6 +241,7 @@ getTestBed().initTestEnvironment(
             schema.coverageProvider === 'none'
               ? undefined
               : schema.coverageProvider,
+          passWithNoTests: schema.passWithNoTests,
           useEsmExtension: true,
         },
         true,

--- a/packages/vitest/src/generators/configuration/schema.d.ts
+++ b/packages/vitest/src/generators/configuration/schema.d.ts
@@ -11,6 +11,7 @@ export interface VitestGeneratorSchema {
   addPlugin?: boolean;
   runtimeTsconfigFileName?: string;
   compiler?: 'babel' | 'swc'; // default: babel
+  passWithNoTests?: boolean;
   // internal options
   projectType?: 'application' | 'library';
   viteVersion?: 5 | 6 | 7 | 8;

--- a/packages/vitest/src/generators/configuration/schema.json
+++ b/packages/vitest/src/generators/configuration/schema.json
@@ -66,6 +66,12 @@
       "description": "Do not add dependencies to `package.json`.",
       "x-priority": "internal"
     },
+    "passWithNoTests": {
+      "type": "boolean",
+      "default": false,
+      "description": "Exit with a zero status when the project has no test files.",
+      "x-priority": "internal"
+    },
     "zoneless": {
       "type": "boolean",
       "description": "Whether the Angular project is zoneless. When not provided, it is auto-detected from the project configuration.",

--- a/packages/vitest/src/utils/generator-utils.ts
+++ b/packages/vitest/src/utils/generator-utils.ts
@@ -390,6 +390,7 @@ function handleViteConfigFileExists(
     globals: true,
     environment: options.testEnvironment ?? 'jsdom',
     include: ['src/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+    ...(options.passWithNoTests ? { passWithNoTests: true } : {}),
     reporters: ['default'],
     coverage: {
       reportsDirectory: reportsDirectory,

--- a/packages/vitest/src/utils/generator-utils.ts
+++ b/packages/vitest/src/utils/generator-utils.ts
@@ -101,6 +101,7 @@ export interface ViteConfigFileOptions {
   imports?: string[];
   plugins?: string[];
   coverageProvider?: 'v8' | 'istanbul' | 'custom' | 'none';
+  passWithNoTests?: boolean;
   setupFile?: string;
   useEsmExtension?: boolean;
   port?: number;
@@ -208,6 +209,7 @@ export function createOrEditViteConfig(
     globals: true,
     environment: '${options.testEnvironment ?? 'jsdom'}',
     include: ['{src,tests}/**/*.{test,spec}.{js,mjs,cjs,ts,mts,cts,jsx,tsx}'],
+${options.passWithNoTests ? `    passWithNoTests: true,\n` : ''}\
 ${options.setupFile ? `    setupFiles: ['${options.setupFile}'],\n` : ''}\
 ${
   options.inSourceTests

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3125,6 +3125,9 @@ importers:
         specifier: catalog:typescript
         version: 2.8.1
     devDependencies:
+      '@nx/vitest':
+        specifier: workspace:*
+        version: link:../vitest
       '@nx/webpack':
         specifier: workspace:*
         version: link:../webpack
@@ -14922,6 +14925,7 @@ packages:
   '@xmldom/xmldom@0.9.10':
     resolution: {integrity: sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw==}
     engines: {node: '>=14.6'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xstate/immer@0.3.1':
     resolution: {integrity: sha512-YE+KY08IjEEmXo6XKKpeSGW4j9LfcXw+5JVixLLUO3fWQ3M95joWJ40VtGzx0w0zQSzoCNk8NgfvwWBGSbIaTA==}


### PR DESCRIPTION
## Current Behavior

`--unitTestRunner` only accepts `jest` or `none` on `@nx/node:application|library`, `@nx/nest:application|library`, the `@nx/nest` sub-generators, and `@nx/express:application`.

## Expected Behavior

`vitest` is accepted on all of them.

nest:app and express:app delegate to node:app, and nest:lib and node:lib delegate to `@nx/js:library`, which already supported vitest, so the new wiring is a vitest branch in node:app calling `@nx/vitest:configuration`.

Three things worth a reviewer's attention:

- **nest requires Vite 8.** Nest resolves constructor deps from `design:paramtypes`, which needs `emitDecoratorMetadata`. Vite < 8 transforms with esbuild, which drops it, so a generated `app.controller.spec.ts` fails with `Cannot read properties of undefined`; Vite 8's oxc emits it. nest:app and nest:lib throw a clear error when a parseable installed Vite is below 8, and stay permissive when Vite is absent or the range is unparseable. node and express are unaffected (no decorators).
- **Opt-in `passWithNoTests` on `@nx/vitest:configuration`.** Jest inherits it from the `@nx/jest:jest` targetDefaults patch, but the vitest plugin infers a command target, so a node app on any framework but fastify, and a nest lib with no controller or service, had a failing `test` target out of the box.
- **fastify templates now use `import type { FastifyInstance }`.** Vite's per-file transform cannot elide a value import of a type, so vitest failed with `Named export 'FastifyInstance' not found`.

`@nx/expo`, `@nx/react-native`, `@nx/next:application`, and `@nx/react:host|remote|federate-module` stay jest-only for now.

## Related Issue(s)

NXC-4504
