### PR TITLE
fix(core): accept bun.lock lockfileVersion 2 and 3

### DIFF
--- a/packages/nx/src/plugins/js/lock-file/__fixtures__/bun/nested-overrides.bun.lock.ts
+++ b/packages/nx/src/plugins/js/lock-file/__fixtures__/bun/nested-overrides.bun.lock.ts
@@ -1,0 +1,34 @@
+export const nestedOverridesBunLock = `{
+  "lockfileVersion": 3,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "name": "nested-overrides-test",
+      "dependencies": {
+        "no-deps": "^1.0.0",
+        "one-dep": "1.0.0",
+        "one-range-dep": "1.0.0",
+      },
+    },
+  },
+  "overrides": {
+    "no-deps": "1.0.0",
+    "one-dep": {
+      "no-deps": "1.1.0",
+    },
+    "one-range-dep@1": {
+      "no-deps": "2.0.0",
+    },
+  },
+  "packages": {
+    "no-deps": ["no-deps@1.0.0", "", {}, "sha512-bZHeZtYQ1B4+5Q63vqR9g4FVFzey+1a1C5+6wl7safsxYFjbj9NmdaNVerRMe/JUphEqCYGwtPb3+KNFV43fWg=="],
+
+    "one-dep": ["one-dep@1.0.0", "", { "dependencies": { "no-deps": "^1.0.0" } }, "sha512-sGcdTtQXj1MQI8I++jPF9CGsnwspI7kT0YbTHEafsVSpZFp+egbX79nGYPRxWaQ4Fcf6kn6ICUP0HuvmqD4dmg=="],
+
+    "one-range-dep": ["one-range-dep@1.0.0", "", { "dependencies": { "no-deps": "^1.0.0" } }, "sha512-2zT16vQWDgOvIlJm6jqOtO8m/E09MsDI4/pzoiMqoZkXbjWn14L+a2vkCt5YRL8VjTWxiwNlj57/mYVTRDzQQQ=="],
+
+    "one-dep/no-deps": ["no-deps@1.1.0", "", {}, "sha512-p7NqnieYX5yUS3Ome71aXyOGaVHf0Oz/faJyqj748J0ZaOYjdcHSsfQBs1kOsTyGJ2PfQGEC4cyEQ959pKrNdw=="],
+
+    "one-range-dep/no-deps": ["no-deps@2.0.0", "", {}, "sha512-wtc9qihjbFq2L0DGZq8Vg32HUZ+qQ9Pp4kFmhZNXrhp3tHol6YwDeVciMlwtZisUMjcplXGFsewbnBixOQnlZg=="],
+  }
+}`;

--- a/packages/nx/src/plugins/js/lock-file/bun-parser.spec.ts
+++ b/packages/nx/src/plugins/js/lock-file/bun-parser.spec.ts
@@ -1278,48 +1278,77 @@ describe('Bun Parser', () => {
     });
 
     it('should validate lockfile version', () => {
-      // Test supported versions (0 and 1)
-      const version0LockFile = `{
-          "lockfileVersion": 0,
+      const lockFileWithVersion = (version: string) => `{
+          "lockfileVersion": ${version},
           "workspaces": { "": {} },
           "packages": {}
         }`;
 
-      const version1LockFile = `{
-          "lockfileVersion": 1,
-          "workspaces": { "": {} },
-          "packages": {}
-        }`;
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
-      expect(() => {
-        getBunTextLockfileNodes(version0LockFile, 'version0-hash');
-      }).not.toThrow();
+      try {
+        // Versions this parser was written against (0, 1 and 2) parse silently
+        for (const version of ['0', '1', '2']) {
+          expect(() => {
+            getBunTextLockfileNodes(
+              lockFileWithVersion(version),
+              `version${version}-hash`
+            );
+          }).not.toThrow();
+        }
+        expect(warnSpy).not.toHaveBeenCalled();
 
-      expect(() => {
-        getBunTextLockfileNodes(version1LockFile, 'version1-hash');
-      }).not.toThrow();
+        // Newer versions are parsed with a warning instead of failing
+        expect(() => {
+          getBunTextLockfileNodes(lockFileWithVersion('3'), 'version3-hash');
+        }).not.toThrow();
+        expect(warnSpy).toHaveBeenCalledTimes(1);
+        expect(warnSpy).toHaveBeenCalledWith(
+          expect.stringContaining('lockfileVersion 3')
+        );
 
-      // Test unsupported version
-      const unsupportedVersionLockFile = `{
-          "lockfileVersion": 2,
-          "workspaces": { "": {} },
-          "packages": {}
-        }`;
+        // Negative and non-integer versions are rejected
+        expect(() => {
+          getBunTextLockfileNodes(lockFileWithVersion('-1'), 'negative-hash');
+        }).toThrow('Unsupported lockfile version -1');
 
-      expect(() => {
-        getBunTextLockfileNodes(unsupportedVersionLockFile, 'unsupported-hash');
-      }).toThrow('Unsupported lockfile version 2');
+        expect(() => {
+          getBunTextLockfileNodes(lockFileWithVersion('1.5'), 'float-hash');
+        }).toThrow('Unsupported lockfile version 1.5');
 
-      // Test invalid version type
-      const invalidVersionLockFile = `{
-          "lockfileVersion": "invalid",
-          "workspaces": { "": {} },
-          "packages": {}
-        }`;
+        // Non-numeric versions are rejected
+        expect(() => {
+          getBunTextLockfileNodes(
+            lockFileWithVersion('"invalid"'),
+            'invalid-hash'
+          );
+        }).toThrow('Lockfile version must be a number');
+      } finally {
+        warnSpy.mockRestore();
+      }
+    });
 
-      expect(() => {
-        getBunTextLockfileNodes(invalidVersionLockFile, 'invalid-hash');
-      }).toThrow('Lockfile version must be a number');
+    it('should parse lockfileVersion 2 identically to lockfileVersion 1', () => {
+      const version1Nodes = getBunTextLockfileNodes(
+        basicDependenciesBunLock,
+        'basic-v1-hash'
+      );
+
+      clearCache();
+
+      const version2LockFile = basicDependenciesBunLock.replace(
+        '"lockfileVersion": 1,',
+        '"lockfileVersion": 2,'
+      );
+      expect(version2LockFile).not.toEqual(basicDependenciesBunLock);
+
+      const version2Nodes = getBunTextLockfileNodes(
+        version2LockFile,
+        'basic-v2-hash'
+      );
+
+      expect(Object.keys(version2Nodes).length).toBeGreaterThan(0);
+      expect(version2Nodes).toEqual(version1Nodes);
     });
 
     it('should handle alias dependencies', () => {

--- a/packages/nx/src/plugins/js/lock-file/bun-parser.spec.ts
+++ b/packages/nx/src/plugins/js/lock-file/bun-parser.spec.ts
@@ -10,6 +10,7 @@ import { gitDependenciesLockFile } from './__fixtures__/bun/git-dependencies.bun
 import { hoistedAndNestedBunLock } from './__fixtures__/bun/hoisted-and-nested.bun.lock';
 import { largeProjectBunLock } from './__fixtures__/bun/large-project.bun.lock';
 import { nextjsAppBunLock } from './__fixtures__/bun/nextjs-app.bun.lock';
+import { nestedOverridesBunLock } from './__fixtures__/bun/nested-overrides.bun.lock';
 import { peerDependenciesMetaLockFile } from './__fixtures__/bun/peer-dependencies-meta.bun.lock';
 import { scopedPackagesBunLock } from './__fixtures__/bun/scoped-packages.bun.lock';
 import { tarballDependenciesLockFile } from './__fixtures__/bun/tarball-dependencies.bun.lock';
@@ -43,6 +44,7 @@ const PEER_LOCK_FILE_HASH = 'peer-hash';
 const ENHANCED_LOCK_FILE_HASH = 'enhanced-hash';
 const ALIAS_LOCK_FILE_HASH = 'alias-hash';
 const HOISTED_NESTED_LOCK_FILE_HASH = 'hoisted-nested-hash';
+const NESTED_OVERRIDES_LOCK_FILE_HASH = 'nested-overrides-hash';
 
 describe('Bun Parser', () => {
   beforeEach(() => {
@@ -1287,8 +1289,8 @@ describe('Bun Parser', () => {
       const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
 
       try {
-        // Versions this parser was written against (0, 1 and 2) parse silently
-        for (const version of ['0', '1', '2']) {
+        // Versions this parser was written against (0 to 3) parse silently
+        for (const version of ['0', '1', '2', '3']) {
           expect(() => {
             getBunTextLockfileNodes(
               lockFileWithVersion(version),
@@ -1300,11 +1302,11 @@ describe('Bun Parser', () => {
 
         // Newer versions are parsed with a warning instead of failing
         expect(() => {
-          getBunTextLockfileNodes(lockFileWithVersion('3'), 'version3-hash');
+          getBunTextLockfileNodes(lockFileWithVersion('4'), 'version4-hash');
         }).not.toThrow();
         expect(warnSpy).toHaveBeenCalledTimes(1);
         expect(warnSpy).toHaveBeenCalledWith(
-          expect.stringContaining('lockfileVersion 3')
+          expect.stringContaining('lockfileVersion 4')
         );
 
         // Negative and non-integer versions are rejected
@@ -1349,6 +1351,44 @@ describe('Bun Parser', () => {
 
       expect(Object.keys(version2Nodes).length).toBeGreaterThan(0);
       expect(version2Nodes).toEqual(version1Nodes);
+    });
+
+    it('should parse lockfileVersion 3 with nested and version-scoped overrides', () => {
+      // Written by Bun with `"overrides": { "no-deps": "1.0.0", "one-dep": { "no-deps": "1.1.0" }, "one-range-dep@1": { "no-deps": "2.0.0" } }`
+      expect(nestedOverridesBunLock).toContain('"lockfileVersion": 3');
+      const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+      try {
+        const result = getBunTextLockfileNodes(
+          nestedOverridesBunLock,
+          NESTED_OVERRIDES_LOCK_FILE_HASH
+        );
+
+        expect(warnSpy).not.toHaveBeenCalled();
+        expect(Object.keys(result).sort()).toMatchInlineSnapshot(`
+          [
+            "npm:no-deps",
+            "npm:no-deps@1.0.0",
+            "npm:no-deps@1.1.0",
+            "npm:no-deps@2.0.0",
+            "npm:one-dep",
+            "npm:one-dep@1.0.0",
+            "npm:one-range-dep",
+            "npm:one-range-dep@1.0.0",
+          ]
+        `);
+
+        // the flat override decides the hoisted version, the nested ones
+        // produce the additional versions
+        expect(result['npm:no-deps'].data.version).toBe('1.0.0');
+        expect(result['npm:no-deps@1.0.0'].data.version).toBe('1.0.0');
+        expect(result['npm:no-deps@1.1.0'].data.version).toBe('1.1.0');
+        expect(result['npm:no-deps@2.0.0'].data.version).toBe('2.0.0');
+        expect(result['npm:one-dep/no-deps']).toBeUndefined();
+        expect(result['npm:one-range-dep/no-deps']).toBeUndefined();
+      } finally {
+        warnSpy.mockRestore();
+      }
     });
 
     it('should handle alias dependencies', () => {
@@ -2234,6 +2274,74 @@ describe('Bun Parser', () => {
           type: 'static',
         },
       ]);
+    });
+
+    it('should handle dependencies from a lockfileVersion 3 lockfile with nested overrides', () => {
+      const externalNodes = getBunTextLockfileNodes(
+        nestedOverridesBunLock,
+        NESTED_OVERRIDES_LOCK_FILE_HASH
+      );
+
+      const ctx: CreateDependenciesContext = {
+        projects: {
+          '': {
+            name: 'nested-overrides-test',
+            root: '',
+          },
+        },
+        externalNodes,
+        fileMap: {
+          projectFileMap: {
+            '': [
+              {
+                file: 'bun.lock',
+                hash: NESTED_OVERRIDES_LOCK_FILE_HASH,
+              },
+            ],
+          },
+          nonProjectFiles: [
+            {
+              file: 'bun.lock',
+              hash: NESTED_OVERRIDES_LOCK_FILE_HASH,
+            },
+          ],
+        },
+        filesToProcess: {
+          nonProjectFiles: [
+            {
+              file: 'bun.lock',
+              hash: NESTED_OVERRIDES_LOCK_FILE_HASH,
+            },
+          ],
+          projectFileMap: {},
+        },
+        nxJsonConfiguration: {},
+        workspaceRoot: '/root',
+      };
+
+      const result = getBunTextLockfileDependencies(
+        nestedOverridesBunLock,
+        NESTED_OVERRIDES_LOCK_FILE_HASH,
+        ctx
+      );
+
+      // Both packages declare "no-deps": "^1.0.0"; the "one-dep/no-deps" and
+      // "one-range-dep/no-deps" entries record what each one was resolved to
+      // by its override, the latter outside of the declared range.
+      expect(result).toMatchInlineSnapshot(`
+        [
+          {
+            "source": "npm:one-dep@1.0.0",
+            "target": "npm:no-deps@1.1.0",
+            "type": "static",
+          },
+          {
+            "source": "npm:one-range-dep@1.0.0",
+            "target": "npm:no-deps@2.0.0",
+            "type": "static",
+          },
+        ]
+      `);
     });
 
     it('should handle dependencies with hoisted and nested packages', () => {

--- a/packages/nx/src/plugins/js/lock-file/bun-parser.ts
+++ b/packages/nx/src/plugins/js/lock-file/bun-parser.ts
@@ -13,10 +13,16 @@ import {
 } from '../../../project-graph/project-graph-builder';
 import { parseJson } from '../../../utils/json';
 
-// Highest bun.lock version this parser has been verified against. Bun bumps
-// the version for changes to its own parse-time validation, so newer versions
-// are parsed on a best-effort basis instead of being rejected outright.
-const MAX_KNOWN_LOCKFILE_VERSION = 2;
+// Highest bun.lock version this parser has been verified against:
+// - 1: workspace packages are no longer listed with their dependencies
+// - 2: identical content, stricter validation in Bun's own reader
+// - 3: values in "overrides" may be objects holding rules scoped to a parent
+//      package (`"parent": { "child": "1.0.0" }`) and keys may carry a version
+//      selector (`"parent@1"`, `"child@<2"`). This parser never reads
+//      "overrides"; the resolved packages are listed in "packages" as before.
+// Newer versions are parsed on a best-effort basis instead of being rejected
+// outright.
+const MAX_KNOWN_LOCKFILE_VERSION = 3;
 
 const DEPENDENCY_TYPES = [
   'dependencies',
@@ -30,8 +36,16 @@ const DEPENDENCY_TYPES = [
  * Based on comprehensive analysis of bun.lock.zig source code
  */
 interface BunLockFile {
-  /** Version of the lockfile format (0, 1 or 2 as of Bun 1.4) */
+  /** Version of the lockfile format (0 to 3 as of Bun 1.4) */
   lockfileVersion: number;
+
+  /**
+   * Version rules from the root package.json "overrides"/"resolutions".
+   * Values are version specs, or (lockfileVersion 3) objects of rules scoped
+   * to the dependencies of the package named by the key. Not used by this
+   * parser: the resolutions they produce are already reflected in `packages`.
+   */
+  overrides?: Record<string, string | Record<string, string>>;
 
   /**
    * Workspaces configuration - maps workspace paths to their dependencies
@@ -997,11 +1011,12 @@ function processPackageForDependencies(
 
     const depDependencies = processDependencyEntries(
       deps,
+      packageKey,
       sourceNodeName,
+      lockFile,
       index,
       ctx,
-      workspacePackages,
-      lockFile.manifests
+      workspacePackages
     );
     dependencies.push(...depDependencies);
   }
@@ -1033,11 +1048,12 @@ function extractPackageDependencies(
 
 function processDependencyEntries(
   deps: Record<string, string>,
+  sourcePackageKey: string,
   sourceNodeName: string,
+  lockFile: BunLockFile,
   index: PackageIndex,
   ctx: CreateDependenciesContext,
-  workspacePackages: Set<string>,
-  manifests?: BunLockFile['manifests']
+  workspacePackages: Set<string>
 ): RawProjectGraphDependency[] {
   const dependencies: RawProjectGraphDependency[] = [];
   const depsEntries = Object.entries(deps);
@@ -1047,11 +1063,12 @@ function processDependencyEntries(
       const dependency = processSingleDependency(
         packageName,
         versionSpec,
+        sourcePackageKey,
         sourceNodeName,
+        lockFile,
         index,
         ctx,
-        workspacePackages,
-        manifests
+        workspacePackages
       );
 
       if (dependency) {
@@ -1068,11 +1085,12 @@ function processDependencyEntries(
 function processSingleDependency(
   packageName: string,
   versionSpec: string,
+  sourcePackageKey: string,
   sourceNodeName: string,
+  lockFile: BunLockFile,
   index: PackageIndex,
   ctx: CreateDependenciesContext,
-  workspacePackages: Set<string>,
-  manifests?: BunLockFile['manifests']
+  workspacePackages: Set<string>
 ): RawProjectGraphDependency | null {
   if (typeof packageName !== 'string' || typeof versionSpec !== 'string') {
     return null;
@@ -1090,8 +1108,19 @@ function processSingleDependency(
   let targetPackageName = packageName;
   let targetVersion = versionSpec;
 
-  const aliasTarget = resolveAliasTarget(versionSpec);
-  if (aliasTarget) {
+  // A "<parent>/<name>" entry records what this parent actually resolved the
+  // dependency to. Overrides scoped to a parent (bun.lock v3) can pick a
+  // version outside the declared range, so it takes precedence over matching
+  // the range against the versions in the lockfile.
+  const nestedVersion = resolveNestedVersion(
+    sourcePackageKey,
+    packageName,
+    lockFile
+  );
+  const aliasTarget = nestedVersion ? null : resolveAliasTarget(versionSpec);
+  if (nestedVersion) {
+    targetVersion = nestedVersion;
+  } else if (aliasTarget) {
     targetPackageName = aliasTarget.packageName;
     targetVersion = aliasTarget.version;
   } else {
@@ -1100,7 +1129,7 @@ function processSingleDependency(
       packageName,
       versionSpec,
       index,
-      manifests
+      lockFile.manifests
     );
 
     if (!resolvedVersion) {
@@ -1132,6 +1161,25 @@ function processSingleDependency(
   } catch (e) {
     return null;
   }
+}
+
+function resolveNestedVersion(
+  sourcePackageKey: string,
+  packageName: string,
+  lockFile: BunLockFile
+): string | null {
+  const nestedEntry = lockFile.packages[`${sourcePackageKey}/${packageName}`];
+  if (!Array.isArray(nestedEntry) || typeof nestedEntry[0] !== 'string') {
+    return null;
+  }
+
+  const { name, version } = getCachedSpecInfo(nestedEntry[0]);
+  // aliases ("alias@npm:real@1.0.0") are resolved to the real package by the caller
+  if (name !== packageName || !version || version.startsWith('npm:')) {
+    return null;
+  }
+
+  return version;
 }
 
 function resolveTargetNodeName(

--- a/packages/nx/src/plugins/js/lock-file/bun-parser.ts
+++ b/packages/nx/src/plugins/js/lock-file/bun-parser.ts
@@ -13,6 +13,11 @@ import {
 } from '../../../project-graph/project-graph-builder';
 import { parseJson } from '../../../utils/json';
 
+// Highest bun.lock version this parser has been verified against. Bun bumps
+// the version for changes to its own parse-time validation, so newer versions
+// are parsed on a best-effort basis instead of being rejected outright.
+const MAX_KNOWN_LOCKFILE_VERSION = 2;
+
 const DEPENDENCY_TYPES = [
   'dependencies',
   'devDependencies',
@@ -25,7 +30,7 @@ const DEPENDENCY_TYPES = [
  * Based on comprehensive analysis of bun.lock.zig source code
  */
 interface BunLockFile {
-  /** Version of the lockfile format (currently 0 or 1) */
+  /** Version of the lockfile format (0, 1 or 2 as of Bun 1.4) */
   lockfileVersion: number;
 
   /**
@@ -569,12 +574,18 @@ function parseLockFile(
         );
       }
 
-      const supportedVersions = [0, 1];
-      if (!supportedVersions.includes(result.lockfileVersion)) {
+      if (
+        !Number.isInteger(result.lockfileVersion) ||
+        result.lockfileVersion < 0
+      ) {
         throw new Error(
-          `Unsupported lockfile version ${
-            result.lockfileVersion
-          }. Supported versions: ${supportedVersions.join(', ')}`
+          `Unsupported lockfile version ${result.lockfileVersion}. Lockfile version must be a non-negative integer`
+        );
+      }
+
+      if (result.lockfileVersion > MAX_KNOWN_LOCKFILE_VERSION) {
+        console.warn(
+          `bun.lock has lockfileVersion ${result.lockfileVersion}, which is newer than the version ${MAX_KNOWN_LOCKFILE_VERSION} this version of Nx was tested with. Attempting to parse it anyway.`
         );
       }
     }


### PR DESCRIPTION
## Current Behavior

`packages/nx/src/plugins/js/lock-file/bun-parser.ts` hard-codes the accepted `bun.lock` versions to `[0, 1]`. Bun 1.4 (currently on canary, the next release after 1.3.14) writes new lockfiles with `"lockfileVersion": 2`, and `"lockfileVersion": 3` for projects that use nested overrides (oven-sh/bun#38333, also unreleased). Every workspace whose `bun.lock` is created by Bun 1.4 fails to build a project graph, and `create-nx-workspace` with `--packageManager=bun` fails outright.

Reproduced with Nx 23.1.1 and `bun@1.4.0-canary.1`:

```sh
bunx --bun create-nx-workspace@latest test2 \
  --preset=react-standalone --bundler=vite --style=css --e2eTestRunner=none \
  --unitTestRunner=vitest --nxCloud=skip --packageManager=bun --interactive=false --skipGit
```

```
Saved lockfile
 NX   Failed to parse bun lockfile
Original error: Unsupported lockfile version 2. Supported versions: 0, 1
    at parseLockFile (node_modules/nx/dist/src/plugins/js/lock-file/bun-parser.js:361:27)
    at getBunTextLockfileNodes (bun-parser.js:429:37)
    at getLockFileNodesForName (lock-file.js:88:40)
 NX   Failed to create workspace
```

The same command on Bun 1.3.14 (`lockfileVersion: 1`) works. Without `create-nx-workspace`: in any existing Nx + Bun repo, delete `bun.lock` and run `bun install` with Bun 1.4; every `nx` command then fails with the error above. (Bun keeps the version of an existing lockfile when re-saving it, so only fresh lockfiles, migrations from other package managers, and projects that add nested overrides are affected.)

## Expected Behavior

Version 2 and version 3 lockfiles parse.

### lockfileVersion 2 (oven-sh/bun#31539)

The serialized content did not change; going from v1 to v2 "only added parse-time strictness on identical content" (Bun's own reader now requires an integrity hash for off-registry npm tarballs and validates git tags). The only content difference this parser cares about is between v0 and v1, which it already handles.

### lockfileVersion 3 (oven-sh/bun#38333)

Bun stamps v3 only when the root `package.json` has overrides scoped to a parent package or to a version selector, e.g.

```json
"overrides": {
  "no-deps": "1.0.0",
  "one-dep": { "no-deps": "1.1.0" },
  "one-range-dep@1": { "no-deps": "2.0.0" }
}
```

The only difference from v2 is that values inside the lockfile's `"overrides"` section may then be objects and keys may carry a `@range` selector. `"workspaces"` and `"packages"` are unchanged, and this parser never reads `"overrides"`, so v3 needs no parsing changes: it is added to the versions that parse without a warning.

One graph fix comes along with it. A parent-scoped override can resolve a dependency to a version outside the range the dependent declares (`one-range-dep` declares `"no-deps": "^1.0.0"` but gets `2.0.0` above); the lockfile records this as a nested `"one-range-dep/no-deps"` entry. Package-to-package edges ignored those entries and matched the declared range against the versions present in the lockfile, so the edge above pointed at `no-deps@1.1.0` instead of `2.0.0`. Edges now use the `"<parent>/<name>"` entry when the lockfile has one and fall back to range matching otherwise; alias entries keep resolving to the real package as before. External nodes were already correct (one node per resolved version).

### Version handling

Because Bun bumps this number for changes on its own side, this PR stops rejecting unknown versions outright:

- any non-negative integer version is accepted;
- versions newer than the highest one this parser was written against (now 3) log a warning saying the lockfile is newer than what Nx was tested with and are parsed anyway;
- negative, non-integer and non-numeric versions are still rejected.

If you would rather keep the strict allow-list, the minimal alternative is `[0, 1]` -> `[0, 1, 2, 3]`; happy to change it, but that would need another Nx release for every future bump.

## Tests

- `'should validate lockfile version'` expects versions 0-3 to parse silently, version 4 to parse with a warning, and negative / non-integer / non-numeric versions to throw.
- A test parses the `basic-dependencies` fixture with the version changed to 2 and asserts the nodes are identical to the version 1 result.
- `__fixtures__/bun/nested-overrides.bun.lock.ts` is a real v3 `bun.lock` written by a Bun build of oven-sh/bun#38333 for the overrides shown above (installed against a throwaway local registry; the registry tarball URLs are blanked out the way Bun writes them for the default registry). Two tests parse it: one asserts the nodes (`no-deps@1.0.0`, `@1.1.0` and `@2.0.0`, hoisted `no-deps` at `1.0.0`, no nodes for the nested keys) and that no warning is logged; the other asserts the edges `one-dep -> no-deps@1.1.0` and `one-range-dep -> no-deps@2.0.0`. The second edge is `1.1.0` without the nested-entry change.

`jest -c packages/nx/jest.config.cts packages/nx/src/plugins/js/lock-file`: 168 passed (bun-parser.spec.ts: 45); `tsc -p packages/nx/tsconfig.lib.json --noEmit` clean.

## Related Issue(s)

No existing issue; searched for "Unsupported lockfile version 2" and "bun lockfileVersion". Tracked on the Bun side in oven-sh/bun#3786; v3 is introduced by oven-sh/bun#38333.

This PR was written by Claude on behalf of the Bun team; a Bun maintainer is sponsoring it and will respond to review.
