### PR TITLE
fix(gradle): resolve task dependencies during configuration

### DIFF
--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/NxProjectGraphReportPlugin.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/NxProjectGraphReportPlugin.kt
@@ -1,5 +1,6 @@
 package dev.nx.gradle
 
+import dev.nx.gradle.utils.registerDependsOnCapture
 import java.util.*
 import org.gradle.api.GradleException
 import org.gradle.api.Plugin
@@ -63,6 +64,8 @@ class NxProjectGraphReportPlugin : Plugin<Project> {
 
           task.doFirst { it.logger.info("${Date()} Running nxProjectReport for ${project.name}") }
         }
+
+    registerDependsOnCapture(project) { index -> nxProjectReportTask.get().dependsOnIndex = index }
 
     // Ensure all included builds are processed only once using lazy evaluation
     project.gradle.includedBuilds.distinct().forEach { includedBuild ->

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/NxProjectReportTask.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/NxProjectReportTask.kt
@@ -1,6 +1,8 @@
 package dev.nx.gradle
 
 import com.google.gson.Gson
+import dev.nx.gradle.utils.CapturedTaskDependencies
+import dev.nx.gradle.utils.DependsOnIndex
 import dev.nx.gradle.utils.NxTracing
 import dev.nx.gradle.utils.createNodeForProject
 import java.io.File
@@ -37,6 +39,10 @@ abstract class NxProjectReportTask @Inject constructor(private val projectLayout
   @get:Internal // Prevent Gradle from caching this reference
   abstract val projectRef: Property<Project>
 
+  // Task dependencies resolved during the configuration phase; resolving them from here would
+  // deadlock the execution worker. See CapturedTaskDependencies.
+  @get:Internal internal var dependsOnIndex: DependsOnIndex = emptyMap()
+
   init {
     atomized.convention(true)
     targetNamePrefix.convention("")
@@ -58,12 +64,14 @@ abstract class NxProjectReportTask @Inject constructor(private val projectLayout
 
         val project = projectRef.get()
         val report =
-            createNodeForProject(
-                project,
-                targetNameOverrides.get(),
-                workspaceRoot.get(),
-                atomized.get(),
-                targetNamePrefix.get())
+            CapturedTaskDependencies.withIndex(dependsOnIndex) {
+              createNodeForProject(
+                  project,
+                  targetNameOverrides.get(),
+                  workspaceRoot.get(),
+                  atomized.get(),
+                  targetNamePrefix.get())
+            }
         val reportJson = gson.toJson(report)
 
         if (outputFile.exists() && outputFile.readText() == reportJson) {

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/CapturedTaskDependencies.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/CapturedTaskDependencies.kt
@@ -1,0 +1,142 @@
+package dev.nx.gradle.utils
+
+import java.util.IdentityHashMap
+import org.gradle.api.Project
+import org.gradle.api.Task
+import org.gradle.api.execution.TaskExecutionGraph
+import org.gradle.api.invocation.Gradle
+
+const val NX_PROJECT_REPORT_TASK_NAME = "nxProjectReport"
+
+const val NX_PROJECT_GRAPH_TASK_NAME = "nxProjectGraph"
+
+/** Direct dependencies of a task, keyed by task identity. */
+typealias DependsOnIndex = Map<Task, Set<Task>>
+
+/**
+ * Direct task dependencies resolved during the configuration phase and read back by
+ * [NxProjectReportTask][dev.nx.gradle.NxProjectReportTask] during execution.
+ *
+ * `task.taskDependencies.getDependencies(task)` is the only complete view of a task's direct
+ * dependencies: `task.dependsOn` holds the raw declared values (Strings, `TaskProvider`s,
+ * `TaskReference`s, file collections) and keeping only the values that happen to be literal `Task`
+ * instances drops most real edges. Resolving the rest needs the task resolver, and for a dependency
+ * naming a task in another project that routes through
+ * `AbstractBuildState.ensureProjectsConfigured` ->
+ * `DefaultBuildLifecycleController.configureProjects` -> `DefaultSynchronizer.takeOwnership`. The
+ * build lifecycle state lock cannot be granted to an execution worker, so calling it from the
+ * report task's action blocks that worker forever and the build never completes.
+ *
+ * The resolution therefore happens once per project, on the build thread, while the build is still
+ * configuring; the report task only reads the captured result.
+ */
+object CapturedTaskDependencies {
+  private val current = ThreadLocal<DependsOnIndex?>()
+
+  /** Make [index] the lookup source for [block] on the calling thread. */
+  fun <T> withIndex(index: DependsOnIndex, block: () -> T): T {
+    val previous = current.get()
+    current.set(index)
+    return try {
+      block()
+    } finally {
+      current.set(previous)
+    }
+  }
+
+  /** Captured dependencies for [task], or null when nothing was captured for it. */
+  fun lookup(task: Task): Set<Task>? = current.get()?.get(task)
+
+  /**
+   * True while a captured index is in scope, i.e. while the report task action is running on an
+   * execution worker. Callers outside that scope — tests, and any other consumer of
+   * [getDependsOnTask] — are on the build thread and can resolve dependencies directly.
+   */
+  fun isActive(): Boolean = current.get() != null
+}
+
+/**
+ * True when this build run is computing the Nx project graph. Included builds do not schedule the
+ * requested task names themselves, so the task graph is checked as well as the start parameter.
+ */
+private fun nxGraphRequested(gradle: Gradle, graph: TaskExecutionGraph): Boolean {
+  val requestedByName =
+      gradle.startParameter.taskNames.any {
+        val name = it.substringAfterLast(':')
+        name == NX_PROJECT_REPORT_TASK_NAME || name == NX_PROJECT_GRAPH_TASK_NAME
+      }
+  if (requestedByName) return true
+  return graph.allTasks.any {
+    it.name == NX_PROJECT_REPORT_TASK_NAME || it.name == NX_PROJECT_GRAPH_TASK_NAME
+  }
+}
+
+/**
+ * Resolve the direct dependencies of every task in [project], and transitively of every task those
+ * dependencies reach within the same build, into a per-build index.
+ *
+ * The transitive walk exists because the input derivation sees through opaque lifecycle tasks (e.g.
+ * `classes` -> `processResources`) and so asks for the dependencies of tasks it did not start from.
+ * The walk stops at a build boundary: resolving the dependencies of a task owned by another build
+ * would take that build's lifecycle lock from this build's thread.
+ */
+private fun captureDependsOn(project: Project): DependsOnIndex {
+  val index = sharedIndexFor(project.gradle)
+  val gradle = project.gradle
+  val queue = ArrayDeque(project.tasks.toList())
+  while (queue.isNotEmpty()) {
+    val task = queue.removeFirst()
+    if (index.containsKey(task)) continue
+    val dependencies = resolveDirectDependencies(task)
+    index[task] = dependencies
+    dependencies.forEach { dependency ->
+      if (dependency.project.gradle === gradle) queue.addLast(dependency)
+    }
+  }
+  return index
+}
+
+/**
+ * One shared index per build: every project's capture contributes to it and every project's report
+ * reads from it, so a task shared between projects is resolved once. It hangs off the root project
+ * so it dies with the build model rather than living in the daemon.
+ */
+@Suppress("UNCHECKED_CAST")
+private fun sharedIndexFor(gradle: Gradle): MutableMap<Task, Set<Task>> {
+  val extra = gradle.rootProject.extensions.extraProperties
+  val key = "dev.nx.gradle.capturedTaskDependencies"
+  if (!extra.has(key)) {
+    extra.set(key, IdentityHashMap<Task, Set<Task>>())
+  }
+  return extra.get(key) as MutableMap<Task, Set<Task>>
+}
+
+private fun resolveDirectDependencies(task: Task): Set<Task> {
+  val declared =
+      try {
+        task.dependsOn.filterIsInstance<Task>().toSet()
+      } catch (e: Exception) {
+        task.logger.info("Cannot access task.dependsOn for ${task.path}: ${e.message}")
+        emptySet()
+      }
+  val resolved =
+      try {
+        task.taskDependencies.getDependencies(task)
+      } catch (e: Exception) {
+        task.logger.info("Cannot resolve task dependencies for ${task.path}: ${e.message}")
+        emptySet()
+      }
+  return declared + resolved
+}
+
+/**
+ * Capture [project]'s task dependencies once the task graph is ready, so the report task action can
+ * read them instead of resolving them from an execution worker. Skipped entirely unless this build
+ * run is computing the Nx project graph, so an ordinary build pays nothing.
+ */
+fun registerDependsOnCapture(project: Project, applyIndex: (DependsOnIndex) -> Unit) {
+  project.gradle.taskGraph.whenReady { graph ->
+    if (!nxGraphRequested(project.gradle, graph)) return@whenReady
+    applyIndex(captureDependsOn(project))
+  }
+}

--- a/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
+++ b/packages/gradle/project-graph/src/main/kotlin/dev/nx/gradle/utils/TaskUtils.kt
@@ -616,38 +616,33 @@ fun getOutputsForTask(task: Task, projectRoot: String, workspaceRoot: String): L
   }
 }
 
+/**
+ * Direct dependencies of [task].
+ *
+ * Inside the `nxProjectReport` task action the answer comes from the index captured during the
+ * configuration phase, because resolving a task dependency from an execution worker deadlocks: see
+ * [CapturedTaskDependencies]. Anything the capture did not reach — a task belonging to another
+ * build, for instance — degrades there to the literal `Task` values on the `dependsOn` property,
+ * which needs no resolution.
+ *
+ * Every other caller runs on the build thread, where resolution is safe and gives the complete
+ * answer: `dependsOn` holds raw declared values, and keeping only the literal `Task` instances
+ * would drop edges expressed as providers, such as `jar` reaching `processResources` through the
+ * `classes` lifecycle task.
+ */
 fun getDependsOnTask(task: Task): Set<Task> {
-  // Try to safely get dependencies, with fallback for configuration cache issues
+  CapturedTaskDependencies.lookup(task)?.let { captured ->
+    task.logger.info("Dependencies for ${task.path}: ${captured.map { it.path }}")
+    return captured
+  }
   return try {
-    // First try to get dependencies from task.dependsOn property
-    val dependsOnFromProperty: Set<Task> =
-        try {
-          task.dependsOn.filterIsInstance<Task>().toSet()
-        } catch (e: Exception) {
-          task.logger.info(
-              "Cannot access task.dependsOn for ${task.path}, possibly due to configuration cache: ${e.message}")
-          emptySet()
-        }
-
-    // Then try to get dependencies from taskDependencies (more comprehensive but riskier with
-    // config cache)
-    val dependsOnFromTaskDependencies: Set<Task> =
-        try {
-          task.taskDependencies.getDependencies(task)
-        } catch (e: UnsupportedOperationException) {
-          task.logger.info(
-              "Cannot access taskDependencies for ${task.path} due to configuration cache restrictions")
-          emptySet()
-        } catch (e: Exception) {
-          task.logger.info("Error calling getDependencies for ${task.path}: ${e.message}")
-          emptySet()
-        }
-
-    val combinedDependsOn = dependsOnFromTaskDependencies.union(dependsOnFromProperty)
-
-    task.logger.info("Dependencies for ${task.path}: ${combinedDependsOn.map { it.path }}")
-
-    combinedDependsOn
+    val dependsOnFromProperty = task.dependsOn.filterIsInstance<Task>().toSet()
+    if (CapturedTaskDependencies.isActive()) {
+      task.logger.info(
+          "No captured dependencies for ${task.path}; using the dependsOn property: ${dependsOnFromProperty.map { it.path }}")
+      return dependsOnFromProperty
+    }
+    dependsOnFromProperty + task.taskDependencies.getDependencies(task)
   } catch (e: Exception) {
     task.logger.info("Unexpected error getting dependencies for ${task.path}: ${e.message}")
     emptySet()


### PR DESCRIPTION
## Current Behavior

`getDependsOnTask` (`packages/gradle/project-graph/.../utils/TaskUtils.kt`) calls `task.taskDependencies.getDependencies(task)` from inside the `nxProjectReport` task action, i.e.
during the execution phase.

When a task depends on a task in another project **declared as a task path** (`dependsOn(":other:task")`),
resolving that dependency has to look the task up, which routes through:

```
ProjectScopedTaskResolver.resolveTask
  -> BuildScopedTaskResolver.resolveTask
  -> AbstractBuildState.ensureProjectsConfigured      <-- called unconditionally
  -> DefaultBuildLifecycleController.configureProjects
  -> DefaultSynchronizer.takeOwnership                <-- blocks forever
```

The build lifecycle state lock cannot be granted during the execution phase, so the execution
worker blocks permanently and `./gradlew nxProjectGraph` never completes. Since Nx 23 materialises
the project graph before any command, every nx command in an affected workspace then fails with
`Failed to process project graph` after the plugin's timeout.

The existing `try`/`catch` does not help — a deadlock is not an exception.

The same edge declared as a `TaskProvider` already carries the task reference, so no lookup and no
project configuration is needed. That is why only some workspaces are affected.

Minimal reproduction (two subprojects, one cross-project dependency):
https://github.com/driessamyn-sparta/nx-bug-repro

## Expected Behavior

`nxProjectGraph` completes regardless of how a cross-project task dependency is declared.

This PR resolves task dependencies once while the build is still configuring, into a per-build
`IdentityHashMap<Task, Set<Task>>`, and has `NxProjectReportTask` read that index instead of
resolving from its action. Keeping live `Task` objects means the input and output derivation is
unchanged. The capture is gated on the nx graph actually being requested, so a build that merely
applies the plugin pays nothing, and anything the capture does not reach falls back to the
`dependsOn` property traversal, which needs no resolution.

Verified with an interleaved A/B on the reproduction above:

|  | result |
|---|---|
| without this change | 5/5 hung, blocked-worker stack confirmed in every thread dump |
| with this change | 5/5 passed |

On a real 35-project workspace: 3/3 clean, and the project graph retains all 93 project-to-project
dependency edges. A narrower alternative that simply drops the `getDependencies()` call also fixes
the deadlock but keeps only 59 of them, it is pushed separately as
[`fix/gradle-project-graph-execution-phase-deadlock`](https://github.com/driessamyn-sparta/nx/tree/fix/gradle-project-graph-execution-phase-deadlock)
as a proof of root cause.

Fixes https://github.com/nrwl/nx/issues/36668
