### PR TITLE
fix(misc): clear the deterministic nightly e2e matrix failures

### DIFF
--- a/e2e/nx/src/cache-no-daemon.test.ts
+++ b/e2e/nx/src/cache-no-daemon.test.ts
@@ -774,11 +774,13 @@ console.log('Build complete');
   ) {
     const matchingProjects = [];
     const lines = actualOutput.split('\n');
+    // Cached tasks print through logCommandOutput, which prefixes the line with
+    // `::group::<icon> ` under GITHUB_ACTIONS, so match the marker anywhere.
     lines.forEach((s) => {
-      if (s.trimStart().startsWith(`> nx run`)) {
+      const marker = s.indexOf(`> nx run `);
+      if (marker > -1) {
         const projectName = s
-          .trimStart()
-          .split(`> nx run `)[1]
+          .slice(marker + `> nx run `.length)
           .split(':')[0]
           .trim();
         if (s.indexOf(cacheStatus) > -1) {

--- a/e2e/nx/src/cache.test.ts
+++ b/e2e/nx/src/cache.test.ts
@@ -817,11 +817,13 @@ console.log('Build complete');
   ) {
     const matchingProjects = [];
     const lines = actualOutput.split('\n');
+    // Cached tasks print through logCommandOutput, which prefixes the line with
+    // `::group::<icon> ` under GITHUB_ACTIONS, so match the marker anywhere.
     lines.forEach((s) => {
-      if (s.trimStart().startsWith(`> nx run`)) {
+      const marker = s.indexOf(`> nx run `);
+      if (marker > -1) {
         const projectName = s
-          .trimStart()
-          .split(`> nx run `)[1]
+          .slice(marker + `> nx run `.length)
           .split(':')[0]
           .trim();
         if (s.indexOf(cacheStatus) > -1) {

--- a/e2e/utils/command-utils.ts
+++ b/e2e/utils/command-utils.ts
@@ -23,6 +23,7 @@ import {
   getPublishedVersion,
   getStrippedEnvironmentVariables,
   getYarnMajorVersion,
+  isVerbose,
   isVerboseE2ERun,
 } from './get-env-info';
 import { logError, logInfo } from './log-utils';
@@ -365,7 +366,7 @@ export function runCLIAsync(
 ): Promise<{ stdout: string; stderr: string; combinedOutput: string }> {
   const pm = getPackageManagerCommand();
   const commandToRun = `${opts.silent ? pm.runNxSilent : pm.runNx} ${command} ${
-    (opts.verbose ?? isVerboseE2ERun()) ? ' --verbose' : ''
+    (opts.verbose ?? isVerbose()) ? ' --verbose' : ''
   }${opts.redirectStderr ? ' 2>&1' : ''}`;
 
   return runCommandAsync(commandToRun, opts);
@@ -458,7 +459,7 @@ export function runCLI(
   try {
     const pm = getPackageManagerCommand();
     const commandToRun = `${pm.runNxSilent} ${command} ${
-      (opts.verbose ?? isVerboseE2ERun()) ? ' --verbose' : ''
+      (opts.verbose ?? isVerbose()) ? ' --verbose' : ''
     }${opts.redirectStderr ? ' 2>&1' : ''}`;
     logInfo(`Run Command: ${command}`);
     const startTime = performance.now();

--- a/packages/create-nx-workspace/src/utils/package-manager.ts
+++ b/packages/create-nx-workspace/src/utils/package-manager.ts
@@ -57,7 +57,9 @@ export function getPackageManagerCommand(
       return {
         preInstall: `yarn set version ${pmVersion}`,
         install: useBerry
-          ? installCommand
+          ? // Berry turns on immutable installs whenever CI is set, which always
+            // fails here: a brand new workspace has no lockfile to be immutable about.
+            `${installCommand} --no-immutable`
           : `${installCommand} --ignore-scripts`,
         // using npx is necessary to avoid yarn classic manipulating the version detection when using berry
         exec: useBerry ? 'npx' : 'yarn',

--- a/packages/plugin/src/generators/create-package/files/e2e/__cliName__.spec.ts__tmpl__
+++ b/packages/plugin/src/generators/create-package/files/e2e/__cliName__.spec.ts__tmpl__
@@ -21,8 +21,9 @@ describe('<%= cliName %>', () => {
   it('should be installed', () => {
     projectDirectory = createTestProject();
 
-    // npm ls will fail if the package is not installed properly
-    execSync('<%= packageManagerCommands.list %> <%= pluginPackageName %>', {
+    // npm ls will fail if the package is not installed properly. npm, not the
+    // workspace's package manager: bin/index.ts creates the project with npm.
+    execSync('npm ls <%= pluginPackageName %>', {
       cwd: projectDirectory,
       stdio: 'inherit',
     });

--- a/packages/plugin/src/generators/e2e-project/e2e.ts
+++ b/packages/plugin/src/generators/e2e-project/e2e.ts
@@ -7,6 +7,7 @@ import {
   ensurePackage,
   formatFiles,
   generateFiles,
+  detectPackageManager,
   getPackageManagerCommand,
   joinPathFragments,
   names,
@@ -118,6 +119,7 @@ function addFiles(host: Tree, options: NormalizedSchema) {
     tmpl: '',
     rootTsConfigPath: getRelativePathToRootTsConfig(host, options.projectRoot),
     packageManagerCommands: getPackageManagerCommand(),
+    packageManager: detectPackageManager(host.root),
     pluginPackageName,
     simplePluginName,
   });

--- a/packages/plugin/src/generators/e2e-project/files/src/__simplePluginName__.spec.ts__tmpl__
+++ b/packages/plugin/src/generators/e2e-project/files/src/__simplePluginName__.spec.ts__tmpl__
@@ -58,7 +58,9 @@ function createTestProject() {
   });
 
   execSync(
-    `<%= packageManagerCommands.dlx %> create-nx-workspace@latest ${projectName} --preset apps --nxCloud=skip --no-interactive`,
+    // Pin the package manager: left to detection it can pick a different one
+    // than the commands above install and inspect the plugin with.
+    `<%= packageManagerCommands.dlx %> create-nx-workspace@latest ${projectName} --preset apps --nxCloud=skip --no-interactive --packageManager=<%= packageManager %>`,
     {
       cwd: dirname(projectDirectory),
       stdio: 'inherit',

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -95,7 +95,7 @@
     "react": ">=18.0.0 <20.0.0",
     "react-dom": ">=18.0.0 <20.0.0",
     "@nx/module-federation": "workspace:*",
-    "express": "^4.21.2",
+    "express": ">=4.0.0 <6.0.0",
     "http-proxy-middleware": "catalog:"
   },
   "peerDependenciesMeta": {

--- a/packages/webpack/internal.ts
+++ b/packages/webpack/internal.ts
@@ -13,4 +13,7 @@ export { resolveUserDefinedWebpackConfig } from './src/utils/webpack/resolve-use
 export { suppressWebpackComposeHelperWarnings } from './src/utils/deprecation';
 export { WebpackNxBuildCoordinationPlugin } from './src/plugins/webpack-nx-build-coordination-plugin';
 export type { WebSsrDevServerOptions } from './src/executors/ssr-dev-server/schema';
-export { default as ssrDevServerExecutor } from './src/executors/ssr-dev-server/ssr-dev-server.impl';
+// Named binding, not `export { default as … } from`: that emits a getter whose
+// body calls a helper, which Node's CJS analyzer cannot follow below 24.14, so
+// `@nx/react`'s `await import()` of this entry would get undefined.
+export { ssrDevServerExecutor } from './src/executors/ssr-dev-server/ssr-dev-server.impl';


### PR DESCRIPTION
## Current Behavior

The nightly E2E matrix has failed every night for weeks. The 2026-08-14 run had 33 failed jobs of 143, and they are deterministic: same suites, same combos, same tests each night.

## Expected Behavior

Six root causes fixed:

- **e2e-release (7 jobs)** and the `nx show target` snapshot in e2e-nx: harness verbosity no longer appends `--verbose` to commands under test.
- **e2e-react (4 jobs)**: `@nx/webpack/internal` re-exports `ssrDevServerExecutor` in a shape Node's CJS named-export analyzer can follow below 24.14, so `@nx/react`'s `await import()` gets a function again.
- **e2e-workspace-create yarn legs**: CNW passes `--no-immutable` on the berry install path.
- **e2e-workspace-create npm legs**: `@nx/react`'s optional `express` peer widened to `>=4.0.0 <6.0.0`, matching `@nx/express` and `@nx/node`.
- **e2e-plugin (3 jobs)**: generated plugin e2e uses one package manager throughout.
- **e2e-nx http remote cache**: test parser tolerates the `::group::` prefix nx adds under GitHub Actions.

Not fixed here: the rest of e2e-nx, e2e-angular ngrx (blocked on NgRx 22 stable), e2e-next, e2e-nuxt, and two infra-only failures.

## Related Issue(s)

NXC-4612

<!-- polygraph-session-start -->
---
<p><a href="https://snapshot.app.trypolygraph.com/orgs/69cdc268b6aa527e4129c2b4/sessions/keen-gecko-02547210">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->