### PR TITLE
chore(linter): infer oxlint targets with the @nx/oxlint plugin

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,7 +108,7 @@ jobs:
           pnpm nx run-many -t check-imports check-lock-files check-codeowners --parallel=1 --no-dte &
           pids+=($!)
 
-          pnpm nx affected --targets=lint,test,build,e2e,e2e-ci,format-native,lint-native,gradle:build-ci,vale,run,validate-example &
+          pnpm nx affected --targets=lint,oxlint,test,build,e2e,e2e-ci,format-native,lint-native,gradle:build-ci,vale,run,validate-example &
           pids+=($!)
 
           for pid in "${pids[@]}"; do

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,40 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "plugins": ["typescript", "unicorn", "oxc"],
+  "categories": {
+    "correctness": "error"
+  },
+  "rules": {
+    "no-unused-vars": "off",
+    "unicorn/no-useless-fallback-in-spread": "off",
+    "no-useless-escape": "off",
+    "no-unused-expressions": "off",
+    "unicorn/no-useless-spread": "off",
+    "no-extra-boolean-cast": "off",
+    "no-control-regex": "off",
+    "typescript/no-wrapper-object-types": "off",
+    "no-useless-catch": "off",
+    "unicorn/no-empty-file": "off",
+    "typescript/prefer-as-const": "off",
+    "no-async-promise-executor": "off",
+    "require-yield": "off",
+    "unicorn/no-new-array": "off",
+    "unicorn/prefer-string-starts-ends-with": "off",
+    "no-unreachable": "off",
+    "unicorn/no-useless-length-check": "off",
+    "no-constant-condition": "off",
+    "no-sparse-arrays": "off",
+    "no-unassigned-vars": "off",
+    "no-unsafe-optional-chaining": "off",
+    "typescript/no-this-alias": "off",
+    "typescript/no-unnecessary-parameter-property-assignment": "off",
+    "no-constant-binary-expression": "off",
+    "no-ex-assign": "off",
+    "no-import-assign": "off",
+    "no-self-assign": "off",
+    "oxc/only-used-in-recursion": "off"
+  },
+  "env": {
+    "builtin": true
+  }
+}

--- a/nx.json
+++ b/nx.json
@@ -378,6 +378,12 @@
         "packages/angular-rspack-compiler/**",
         "packages/angular-rspack/**"
       ]
+    },
+    {
+      "plugin": "@nx/oxlint",
+      "options": {
+        "targetName": "oxlint"
+      }
     }
   ],
   "nxCloudId": "62d013ea0852fe0a2df74438",

--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "@nx/js": "23.2.0-beta.7",
     "@nx/key": "5.0.4",
     "@nx/next": "23.2.0-beta.7",
+    "@nx/oxlint": "23.2.0-beta.7",
     "@nx/playwright": "23.2.0-beta.7",
     "@nx/plugin": "23.2.0-beta.7",
     "@nx/powerpack-license": "5.0.4",

--- a/packages/oxlint/project.json
+++ b/packages/oxlint/project.json
@@ -9,36 +9,6 @@
       "inputs": ["copyReadme"],
       "outputs": ["{projectRoot}/README.md"],
       "dependsOn": ["^build", "build-base"]
-    },
-    "oxlint": {
-      "command": "oxlint .",
-      "options": {
-        "cwd": "packages/oxlint",
-        "max-warnings": 0
-      },
-      "cache": true,
-      "inputs": [
-        "default",
-        "^default",
-        {
-          "externalDependencies": ["oxlint"]
-        }
-      ],
-      "metadata": {
-        "technologies": ["oxlint"],
-        "description": "Runs Oxlint on project",
-        "help": {
-          "command": "pnpm exec oxlint --help",
-          "example": {
-            "options": {
-              "max-warnings": 0
-            }
-          }
-        }
-      }
-    },
-    "lint": {
-      "dependsOn": ["...", "oxlint"]
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -672,6 +672,9 @@ importers:
       '@nx/next':
         specifier: 23.2.0-beta.7
         version: 23.2.0-beta.7(81b2b000cd3bd5b9273e74b3fd1fb926)
+      '@nx/oxlint':
+        specifier: 23.2.0-beta.7
+        version: 23.2.0-beta.7(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@6.0.3))(@swc/cli@0.8.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(chokidar@3.6.0))(@swc/core@1.15.10(@swc/helpers@0.5.18))(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(nx@23.2.0-beta.7(@swc-node/register@1.11.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@6.0.3))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(oxlint@1.77.0)(typescript@6.0.3)(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
       '@nx/playwright':
         specifier: 23.2.0-beta.7
         version: 23.2.0-beta.7(@babel/traverse@7.29.7)(@nx/jest@23.2.0-beta.7(2d23bb01f8a4fc9d182489a6db458281))(@playwright/test@1.60.0)(@swc-node/register@1.11.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@6.0.3))(@swc/cli@0.8.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(chokidar@3.6.0))(@swc/core@1.15.10(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@9.39.4(jiti@2.7.0))(nx@23.2.0-beta.7(@swc-node/register@1.11.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@6.0.3))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
@@ -10453,6 +10456,15 @@ packages:
     resolution: {integrity: sha512-G9fftRYABk5Iqn1I6oenZc5gSlB59//m/cCOLrF12UNaPC9KjJnypj9imGlRyIhHefyZXF9GJjZRAuVKRV1axg==}
     cpu: [x64]
     os: [win32]
+
+  '@nx/oxlint@23.2.0-beta.7':
+    resolution: {integrity: sha512-WO7pdgd0PaE7/xxdcIdnPhhl1KlD5neDodaogWMjEt3Ix5h4pOV4MtVs3A7aaWboF34Z5aWL+wLedhB+md3HZw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      oxlint: ^1.43.0
+    peerDependenciesMeta:
+      oxlint:
+        optional: true
 
   '@nx/playwright@23.2.0-beta.7':
     resolution: {integrity: sha512-0VPmE1F+i3+U5PZbRvYnrRiDOZ8742jYaghkhRWzPjy6SFskuc17g5Yc87rdkRLWGhrcngvDzdS6uqD1Ijv02g==}
@@ -36007,6 +36019,27 @@ snapshots:
 
   '@nx/nx-win32-x64-msvc@23.2.0-beta.7':
     optional: true
+
+  '@nx/oxlint@23.2.0-beta.7(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@6.0.3))(@swc/cli@0.8.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(chokidar@3.6.0))(@swc/core@1.15.10(@swc/helpers@0.5.18))(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(nx@23.2.0-beta.7(@swc-node/register@1.11.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@6.0.3))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(oxlint@1.77.0)(typescript@6.0.3)(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))':
+    dependencies:
+      '@nx/devkit': 23.2.0-beta.7(nx@23.2.0-beta.7(@swc-node/register@1.11.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@6.0.3))(@swc/core@1.15.10(@swc/helpers@0.5.18)))
+      '@nx/eslint-plugin': 23.2.0-beta.7(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@6.0.3))(@swc/cli@0.8.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(chokidar@3.6.0))(@swc/core@1.15.10(@swc/helpers@0.5.18))(@typescript-eslint/parser@8.59.0(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-config-prettier@10.1.8(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))(nx@23.2.0-beta.7(@swc-node/register@1.11.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@6.0.3))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(typescript@6.0.3)(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
+      '@nx/js': 23.2.0-beta.7(@babel/traverse@7.29.7)(@swc-node/register@1.11.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@6.0.3))(@swc/cli@0.8.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(chokidar@3.6.0))(@swc/core@1.15.10(@swc/helpers@0.5.18))(nx@23.2.0-beta.7(@swc-node/register@1.11.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@6.0.3))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))
+      tslib: 2.8.1
+    optionalDependencies:
+      oxlint: 1.77.0
+    transitivePeerDependencies:
+      - '@babel/traverse'
+      - '@swc-node/register'
+      - '@swc/cli'
+      - '@swc/core'
+      - '@typescript-eslint/parser'
+      - eslint
+      - eslint-config-prettier
+      - nx
+      - supports-color
+      - typescript
+      - verdaccio
 
   '@nx/playwright@23.2.0-beta.7(@babel/traverse@7.29.7)(@nx/jest@23.2.0-beta.7(2d23bb01f8a4fc9d182489a6db458281))(@playwright/test@1.60.0)(@swc-node/register@1.11.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@6.0.3))(@swc/cli@0.8.1(@swc/core@1.15.10(@swc/helpers@0.5.18))(chokidar@3.6.0))(@swc/core@1.15.10(@swc/helpers@0.5.18))(@zkochan/js-yaml@0.0.7)(eslint@9.39.4(jiti@2.7.0))(nx@23.2.0-beta.7(@swc-node/register@1.11.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@swc/core@1.15.10(@swc/helpers@0.5.18))(@swc/types@0.1.25)(typescript@6.0.3))(@swc/core@1.15.10(@swc/helpers@0.5.18)))(verdaccio@6.3.2(encoding@0.1.13)(typanion@3.14.0))':
     dependencies:


### PR DESCRIPTION
## Current Behavior

Exactly one project in the workspace runs Oxlint: `packages/oxlint`, via a hand-written `oxlint` target in its `project.json` that duplicates what `@nx/oxlint` infers. It only runs at all because that project's `lint` target declares `dependsOn: ["...", "oxlint"]`.

The `@nx/oxlint` plugin is not installed and not registered in `nx.json`, so no other project has an Oxlint target and CI never runs one directly.

## Expected Behavior

`@nx/oxlint` is registered in `nx.json`, so **116 projects** get an inferred `oxlint` target — up from one — and CI runs it.

### Target name

The plugin's candidate names are `lint` → `oxlint` → `oxlint:lint`. `lint` belongs to `@nx/eslint/plugin` and `oxlint` was held by the hand-written target, so `@nx/oxlint:init` fell through to `oxlint:lint`. Deleting the hand-written target frees `oxlint`, which the plugin then infers with the same command, cwd, inputs, cache and metadata.

`packages/oxlint`'s `lint.dependsOn` override goes too. It existed so Oxlint ran at all back when one project had the target; CI now runs `oxlint` across the workspace directly. Dropping the override leaves `lint` depending on `build-native` / `^build-native` / `build` from `targetDefaults`, unchanged.

### Rule baseline

The root `.oxlintrc.json` disables 28 rules. `categories.correctness = error` — what `@nx/oxlint:init` scaffolds — reports **1266 errors across 84 of the 116 projects**, so this lands a baseline that passes today rather than a target that is red on arrival. The disabled set is exactly the rules that fire, so the debt is explicit in one file and can be burned down rule by rule.

| rule | hits |
| --- | --- |
| `no-unused-vars` | 902 |
| `unicorn/no-useless-fallback-in-spread` | 106 |
| `no-useless-escape` | 72 |
| `no-unused-expressions` | 40 |
| `unicorn/no-useless-spread` | 25 |
| `no-extra-boolean-cast` | 24 |
| `no-control-regex`, `typescript/no-wrapper-object-types` | 16 each |
| `no-useless-catch`, `unicorn/no-empty-file` | 9 each |
| `typescript/prefer-as-const` | 8 |
| 18 more | ≤4 each |

`no-unused-vars` alone is 902 of the 1266, and this repo's ESLint config has never enforced it — that is a policy question rather than drift. The single-digit rules at the bottom (`no-unreachable`, `no-self-assign`, `no-import-assign`, `no-unsafe-optional-chaining`, `no-async-promise-executor`) are the likely-genuine-bug ones and are the cheapest to fix and re-enable first.

That leaves **83 rules enabled** — the always-a-bug set (duplicate object keys, `no-const-assign`, `use-isnan`, `valid-typeof`, `no-invalid-regexp`, oxc's builtin-misuse rules) with essentially no style opinions.

⚠️ Some of those 83 are type-aware (`no-floating-promises`, `await-thenable`, `restrict-template-expressions`, `unbound-method`). They need `oxlint --type-aware`, which needs the `oxlint-tsgolint` package. That package is not installed and the inferred target does not pass the flag, so **those rules never fire** — the effective net is smaller than 83. Worth a follow-up.

`packages/oxlint` keeps its own stricter `.oxlintrc.json` (`suspicious: warn`, `no-console: error`). It does not extend the root, so the disabled rules do not weaken it, and it still passes.

### CI

`oxlint` is added to the existing `nx affected --targets=lint,...` list in the "Run Checks/Lint/Test/Build" step, so it distributes over DTE alongside every other target rather than adding a serial step.

### Verification

- `nx run-many -t oxlint --skip-nx-cache` → 116 projects, 0 diagnostics, ~2s
- `nx affected -t oxlint --files=packages/js/index.ts` → 69 projects, green
- `nx format:check` → clean

## Related Issue(s)

N/A

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Infer-oxlint-targets-with-the-nx-oxlint-plugin-0bcb5787">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->