### PR TITLE
fix(core): resolve telemetry DNS in-process to avoid a getenv segfault

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -693,6 +693,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "data-encoding"
+version = "2.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
 name = "deltae"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -831,6 +837,18 @@ name = "encode_unicode"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
+
+[[package]]
+name = "enum-as-inner"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1e6a265c649f3f5979b601d26f1d05ada116434c87741c9493cb56218f76cbc"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.114",
+]
 
 [[package]]
 name = "env_filter"
@@ -1357,6 +1375,52 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hickory-proto"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8a6fe56c0038198998a6f217ca4e7ef3a5e51f46163bd6dd60b5c71ca6c6502"
+dependencies = [
+ "async-trait",
+ "cfg-if",
+ "data-encoding",
+ "enum-as-inner",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "idna",
+ "ipnet",
+ "once_cell",
+ "rand 0.9.2",
+ "ring",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.25.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc62a9a99b0bfb44d2ab95a7208ac952d31060efc16241c87eaf36406fecf87a"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-proto",
+ "ipconfig",
+ "moka",
+ "once_cell",
+ "parking_lot",
+ "rand 0.9.2",
+ "resolv-conf",
+ "smallvec",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "http"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1712,6 +1776,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7970510895cee30b3e9128319f2cefd4bde883a39f38baa279567ba3a7eb97d"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "ipconfig"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
+dependencies = [
+ "socket2",
+ "widestring",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -2173,6 +2250,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "957228ad12042ee839f93c8f257b62b4c0ab5eaae1d4fa60de53b27c9d7c5046"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
 name = "moxcms"
 version = "0.7.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2599,6 +2693,10 @@ name = "once_cell"
 version = "1.21.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "openssl-probe"
@@ -3303,6 +3401,7 @@ dependencies = [
  "base64",
  "bytes",
  "futures-core",
+ "hickory-resolver",
  "http",
  "http-body",
  "http-body-util",
@@ -3311,6 +3410,7 @@ dependencies = [
  "hyper-util",
  "js-sys",
  "log",
+ "once_cell",
  "percent-encoding",
  "pin-project-lite",
  "quinn",
@@ -3331,6 +3431,12 @@ dependencies = [
  "wasm-bindgen-futures",
  "web-sys",
 ]
+
+[[package]]
+name = "resolv-conf"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
 
 [[package]]
 name = "ring"
@@ -4162,6 +4268,12 @@ dependencies = [
  "objc2-open-directory",
  "windows",
 ]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tap"

--- a/packages/nx/Cargo.toml
+++ b/packages/nx/Cargo.toml
@@ -115,6 +115,11 @@ fs4 = "0.12.0"
 ratatui = { version = "0.30", features = ["unstable-rendered-line-info"] }
 reqwest = { version = "0.12.22", default-features = false, features = [
     "rustls-tls-native-roots",
+    # Pure-Rust DNS resolver. The default resolver calls getaddrinfo() on a
+    # tokio blocking thread; getaddrinfo reads env vars via glibc's lock-free
+    # getenv(), which segfaults when another thread mutates `environ`
+    # (process.env writes from JS). See telemetry/service.rs.
+    "hickory-dns",
 ] }
 rusqlite = { version = "0.32.1", features = ["bundled", "array", "vtab"] }
 notify = "8"

--- a/packages/nx/src/native/cache/http_remote_cache.rs
+++ b/packages/nx/src/native/cache/http_remote_cache.rs
@@ -39,7 +39,15 @@ impl HttpRemoteCache {
             header::HeaderValue::from_static("application/octet-stream"),
         );
 
-        let mut client_builder = ClientBuilder::new().default_headers(headers);
+        // Keep the system resolver here. Enabling reqwest's `hickory-dns`
+        // feature for the telemetry client flips the default for every client
+        // in the crate, and this URL is user-supplied: it may resolve through
+        // NSS rather than plain DNS (mDNS, LDAP, split-horizon corporate
+        // setups) which hickory does not consult. Only the telemetry endpoint
+        // is a fixed public hostname where that trade is safe.
+        let mut client_builder = ClientBuilder::new()
+            .no_hickory_dns()
+            .default_headers(headers);
 
         let env_accept_unauthorized = env::var("NODE_TLS_REJECT_UNAUTHORIZED");
         if let Ok(env_accept_unauthorized) = env_accept_unauthorized {

--- a/packages/nx/src/native/telemetry/service.rs
+++ b/packages/nx/src/native/telemetry/service.rs
@@ -61,7 +61,22 @@ pub struct TelemetryService {
 
 impl TelemetryService {
     pub fn new(opts: TelemetryOptions) -> Result<Self> {
+        // Resolve DNS in-process rather than through getaddrinfo(). reqwest's
+        // default resolver runs getaddrinfo on a tokio blocking thread, and
+        // getaddrinfo reads env vars (LOCALDOMAIN, RES_OPTIONS, ...) via
+        // glibc's getenv(), which takes no lock. Meanwhile the JS main thread
+        // mutates `environ` through process.env -- plugin preTasksExecution
+        // hooks, the daemon's env sync, CLI arg handling. A reader walking an
+        // environ array that setenv has just reallocated and freed segfaults;
+        // that is the intermittent CI SIGSEGV (exit 139), captured as a core
+        // dump with getenv() as frame #0.
+        //
+        // hickory speaks DNS directly and still honours /etc/hosts
+        // (ResolveHosts::Auto), so blocking this endpoint with a hosts entry
+        // keeps working. Set explicitly rather than leaning on the cargo
+        // feature default, which applies to every reqwest client in the crate.
         let client = ClientBuilder::new()
+            .hickory_dns(true)
             .build()
             .map_err(|e| Error::from_reason(format!("Failed to create HTTP client: {}", e)))?;
 


### PR DESCRIPTION
## Current Behavior

`main-linux` and e2e jobs are intermittently killed by SIGSEGV (exit 139) — roughly 23 real occurrences in a 10-day sweep, a few of them on master.

A core dump captured from the `SIGINT process cleanup` e2e loop gives the stack:

```
#0  __GI_getenv (name="LOCALDOMAIN") at ./stdlib/getenv.c:31
#1  __nscd_getai (key="www.google-analytics.com")
#2  get_nscd_addresses
#3  gaih_inet (name="www.google-analytics.com")
#4  __GI_getaddrinfo
#5  std::sys::net::…::lookup_host            ← nx.linux-x64-gnu.node
#6  std::net::socket_addr::lookup_host
#7  <(&str, u16) as ToSocketAddrs>::to_socket_addrs
#8  tokio::…::BlockingTask::poll
#11 tokio::runtime::blocking::pool::Inner::run
```

The crashing thread is a tokio blocking worker resolving the analytics endpoint. Thread 4 in the same core — the process's main thread — is inside V8's `ScanIdentifierOrKeywordInner`, i.e. running JavaScript.

### Root cause

glibc's `getenv()` walks the `environ` array and takes **no lock**. `setenv()`/`unsetenv()` reallocate and free that array. `getaddrinfo()` reads env vars (`LOCALDOMAIN`, `RES_OPTIONS`, …) internally, so any DNS lookup on a background thread is an unsynchronized reader — while the JS main thread mutates `environ` via `process.env` (plugin `preTasksExecution` hooks, the daemon's env sync, CLI arg handling).

This was reproduced in isolation: one thread calling `setenv`/`unsetenv` with fresh names, several calling `getenv`, plus malloc churn to recycle the freed arrays, segfaults within seconds with `getenv` as frame #0 — no Node, no Rust, no DNS involved.

Two details matter for anyone reproducing it:
- glibc only frees the `environ` array on the **append** path, so recycling a fixed set of variable names never triggers it.
- Reading freed-but-untouched memory returns stale-yet-valid pointers and does not fault; the crash needs the block reused and overwritten. Node/V8/tokio supply that allocator pressure in practice.

Note that Node guards `process.env` with its own mutex, so Node can never race *itself*. The only unprotected readers are the ones inside libc — which is why this shows up as ~0.7 crashes/day rather than constantly.

## Expected Behavior

The telemetry client no longer calls `getaddrinfo`, so it stops reading `environ` from a background thread and the observed crash path disappears.

## Changes

- Enable reqwest's `hickory-dns` feature and set `.hickory_dns(true)` on the telemetry client. hickory is a pure-Rust resolver: it speaks DNS directly instead of going through `getaddrinfo`.
- Explicitly set `.no_hickory_dns()` on the self-hosted remote cache client. The cargo feature changes reqwest's default resolver **crate-wide** (`hickory_dns: cfg!(feature = "hickory-dns")`), and that client's URL is user-supplied — it may resolve via NSS (mDNS, LDAP, split-horizon DNS) which hickory does not consult. Only the telemetry endpoint is a fixed public hostname where the trade is safe.

### Trade-offs

- **`/etc/hosts` is still honoured.** Verified against hickory-resolver 0.25.2: `ResolveHosts::Auto` is the default and loads `Hosts::from_system()`. Blocking `www.google-analytics.com` with a hosts entry keeps working — this would have been disqualifying for a telemetry client otherwise.
- **NSS is bypassed for this one client.** Acceptable for a fixed public hostname; explicitly avoided for the remote cache.
- **New dependencies**: `hickory-resolver`, `hickory-proto`, `moka`, `resolv-conf` and friends (+112 lockfile lines), which grows the prebuilt native binaries.
- **Side benefit**: the default resolver runs `getaddrinfo` on a `spawn_blocking` thread per lookup; hickory is async-native and caches responses per TTL.

## Scope — this is mitigation, not the fix

This removes the one crash path we have a core dump for. It does **not** address the writers, which remain hazardous to every other libc env reader (`tzset`/`localtime`, `dlopen`, `iconv`):

- `project-graph/plugins/tasks-execution-hooks.ts` — `applyProcessEnvs()` bulk-writes arbitrary plugin-provided keys immediately before task execution.
- `daemon/client/daemon-environment.ts` — `applyDaemonEnvFromClient()` adds *and deletes* env keys on every client request, in a long-lived process holding native watcher threads.
- `native/telemetry/service.rs` — `set_var("NX_ANALYTICS_SESSION_ID")`, whose `SAFETY` comment ("our Rust background thread doesn't read env vars") is falsified by this core: the reader was glibc, not our code. This one only fires after 30 minutes of telemetry idle, so it is unlikely to be the CI culprit.

A follow-up worth considering is a tripwire — flip an `AtomicBool` when the first thread spawns and assert on env writes after that — to find which writers actually fire late instead of inferring it from single core dumps.

Draft: opening for discussion on whether the dependency weight and the NSS trade are acceptable, and whether the reader-side mitigation should land ahead of the writer work.

<!-- polygraph-session-start -->
---
<p><a href="https://app.trypolygraph.com/orgs/6a061dcb561c062131116eca/sessions/Fix-SIGSEGV-in-nx-telemetry-from-glibc-getenv-race-356c18d3">View Polygraph session ↗</a></p>
<!-- polygraph-session-end -->