### PR TITLE
fix(core): stop editor, package manager and git hook env vars from invalidating the daemon graph cache

### DIFF
--- a/packages/nx/src/daemon/client/daemon-environment.spec.ts
+++ b/packages/nx/src/daemon/client/daemon-environment.spec.ts
@@ -56,6 +56,42 @@ describe('daemon environment', () => {
       expect(env.COLOR).toBeUndefined();
     });
 
+    it('should exclude package-manager vars not covered by the lowercase prefixes', () => {
+      process.env.PNPM_HOME = '/home/user/.local/share/pnpm';
+      process.env.PNPM_SCRIPT_SRC_DIR = '/some/project/subdir';
+      process.env.COREPACK_ENABLE_STRICT = '0';
+      process.env.COREPACK_ROOT = '/usr/lib/node_modules/corepack';
+
+      const env = getDaemonEnv();
+
+      expect(env.PNPM_HOME).toBeUndefined();
+      expect(env.PNPM_SCRIPT_SRC_DIR).toBeUndefined();
+      expect(env.COREPACK_ENABLE_STRICT).toBeUndefined();
+      expect(env.COREPACK_ROOT).toBeUndefined();
+    });
+
+    it('should exclude the vars git sets when Nx runs from a hook', () => {
+      process.env.GIT_INDEX_FILE = '/repo/.git/index.lock';
+      process.env.GIT_PREFIX = 'packages/nx/';
+      process.env.GIT_REFLOG_ACTION = 'pull';
+      process.env.GIT_AUTHOR_DATE = '@1754990000 +0000';
+      process.env.GIT_COMMITTER_DATE = '@1754990000 +0000';
+
+      const env = getDaemonEnv();
+
+      expect(env.GIT_INDEX_FILE).toBeUndefined();
+      expect(env.GIT_PREFIX).toBeUndefined();
+      expect(env.GIT_REFLOG_ACTION).toBeUndefined();
+      expect(env.GIT_AUTHOR_DATE).toBeUndefined();
+      expect(env.GIT_COMMITTER_DATE).toBeUndefined();
+    });
+
+    it('should exclude NX_CONSOLE', () => {
+      process.env.NX_CONSOLE = 'true';
+
+      expect(getDaemonEnv().NX_CONSOLE).toBeUndefined();
+    });
+
     it('should exclude terminal identification vars', () => {
       process.env.TERM = 'xterm-ghostty';
       process.env.TERM_PROGRAM = 'vscode';
@@ -319,6 +355,36 @@ describe('daemon environment', () => {
       expect(process.env.JAVA_TOOL_OPTIONS).toBeUndefined();
       expect(process.env.ATUIN_SESSION).toBe('daemon-startup-value');
       expect(applyDaemonEnvFromClient(payload)).toEqual([]);
+    });
+
+    it('should apply PATH and NODE_PATH without reporting them as changed', () => {
+      process.env.PATH = '/from/the/daemon';
+      process.env.NODE_PATH = '/from/the/daemon/node_modules';
+
+      const changed = applyDaemonEnvFromClient({
+        ...process.env,
+        PATH: '/from/the/client',
+        NODE_PATH: '/from/the/client/node_modules',
+      });
+
+      expect(changed).toEqual([]);
+      expect(process.env.PATH).toBe('/from/the/client');
+      expect(process.env.NODE_PATH).toBe('/from/the/client/node_modules');
+    });
+
+    it('should report no changes when clients differ only in non-invalidating vars', () => {
+      process.env.JAVA_HOME = '/opt/java';
+      process.env.PATH = '/usr/bin';
+      const daemonEnv = getDaemonEnv();
+
+      // a `pnpm nx` client prepending its own bin dir and setting PNPM_HOME
+      process.env.PATH = '/repo/node_modules/.bin:/usr/bin';
+      process.env.PNPM_HOME = '/home/user/.local/share/pnpm';
+      const clientEnv = getDaemonEnv();
+
+      process.env = daemonEnv;
+
+      expect(applyDaemonEnvFromClient(clientEnv)).toEqual([]);
     });
 
     it('should not delete required settings missing from the client env', () => {

--- a/packages/nx/src/daemon/client/daemon-environment.ts
+++ b/packages/nx/src/daemon/client/daemon-environment.ts
@@ -64,6 +64,9 @@ const DAEMON_ENV_VARS_EXCLUSIONS = new Set([
   'CODEX_THREAD_ID',
   'AI_AGENT',
 
+  // Editors / IDEs
+  'NX_CONSOLE',
+
   // Shell mechanics
   '_',
   'SHLVL',
@@ -144,6 +147,18 @@ const DAEMON_ENV_VARS_EXCLUSIONS = new Set([
   // macOS internals
   '__CF_USER_TEXT_ENCODING',
   '__CFBundleIdentifier',
+
+  // Set by git per invocation when Nx runs from a hook. Exact entries rather
+  // than a GIT_ prefix, which would also swallow GIT_DIR.
+  'GIT_INDEX_FILE',
+  'GIT_PREFIX',
+  'GIT_REFLOG_ACTION',
+  'GIT_AUTHOR_NAME',
+  'GIT_AUTHOR_EMAIL',
+  'GIT_AUTHOR_DATE',
+  'GIT_COMMITTER_NAME',
+  'GIT_COMMITTER_EMAIL',
+  'GIT_COMMITTER_DATE',
 ]);
 
 /**
@@ -165,6 +180,8 @@ const DAEMON_ENV_PREFIX_EXCLUSIONS = [
   // Package managers (process-scoped)
   'npm_',
   'pnpm_',
+  'PNPM_',
+  'COREPACK_',
 
   // Nx Cloud runner/agent vars (per-worker values like NX_CLOUD_WORKER_ID
   // and NX_CLOUD_EXECUTION_ID diverge between distributed-execution workers
@@ -212,6 +229,15 @@ const DAEMON_ENV_PATTERN_EXCLUSIONS = [
   // in Electron-spawned shells); regenerated on every login
   /^EFC_\d+(_\d+)?$/,
 ];
+
+/**
+ * Vars the daemon still needs — graph construction resolves executables
+ * through them (`bun` for lockfile parsing, `mvn` for Maven inference) — but
+ * whose value must not invalidate the project graph: `nx`, `pnpm nx` and Nx
+ * Console each prepend their own entries, so reflecting the difference would
+ * recompute a graph that cannot come out any different.
+ */
+const DAEMON_ENV_NON_INVALIDATING_VARS = new Set(['PATH', 'NODE_PATH']);
 
 /**
  * Vars that match an excluded prefix but should still reach the daemon. The
@@ -299,5 +325,7 @@ export function applyDaemonEnvFromClient(newEnv: NodeJS.ProcessEnv): string[] {
       changedKeys.push(key);
     }
   }
-  return changedKeys;
+  return changedKeys.filter(
+    (key) => !DAEMON_ENV_NON_INVALIDATING_VARS.has(key)
+  );
 }


### PR DESCRIPTION
## Current Behavior

The first message each client sends to the daemon carries that client's filtered env, and `applyDaemonEnvFromClient` returns every key whose value differs from what the daemon already has. Any non-empty result invalidates the project graph cache (`Graph recompute necessary due to env variable refresh`).

#36642 excluded the volatile shell, terminal, editor and AI-harness vars. Three sources of launcher-driven churn remain, each set by *how Nx was launched* rather than by the workspace, so they differ between clients that would all compute an identical graph:

- **`nx` vs `pnpm nx`** — pnpm and corepack set `PNPM_HOME`, `PNPM_SCRIPT_SRC_DIR` and `COREPACK_*`. The existing `npm_`/`pnpm_` prefix exclusions are lowercase, and `startsWith` is case-sensitive, so none of these match.
- **Nx directly vs via the Nx Console plugin** — Nx Console sets `NX_CONSOLE`.
- **Nx from a git hook** — git sets `GIT_INDEX_FILE`, `GIT_PREFIX`, `GIT_REFLOG_ACTION` and the `GIT_AUTHOR_*`/`GIT_COMMITTER_*` pairs for the hook process.

`PATH` is the most persistent of the three: every launcher prepends its own bin directory, so it differs on essentially every switch between `nx`, `pnpm nx` and Nx Console.

Alternating between any of these — the normal state of a machine where a human, an editor and an agent all run Nx against one workspace — recomputes the whole graph on the next command, repeatedly, in both directions.

## Expected Behavior

These vars no longer participate in daemon env reflection, so switching launchers doesn't recompute the graph:

- `DAEMON_ENV_VARS_EXCLUSIONS` gains `NX_CONSOLE` plus the nine git hook vars (`GIT_INDEX_FILE`, `GIT_PREFIX`, `GIT_REFLOG_ACTION`, `GIT_AUTHOR_NAME`/`_EMAIL`/`_DATE`, `GIT_COMMITTER_NAME`/`_EMAIL`/`_DATE`).
- `DAEMON_ENV_PREFIX_EXCLUSIONS` gains `PNPM_` and `COREPACK_`.

The git vars are exact entries rather than a `GIT_` prefix, following the reasoning already established in #36642: `GIT_DIR` is a functional graph input and must keep reaching the daemon. For the same reason this PR deliberately does **not** add `MISE_`, `COPILOT_` or `CLAUDE_` prefixes — they would swallow `MISE_ENV`, `COPILOT_HOME` and `COPILOT_GITHUB_TOKEN`, and the churning cases are already covered upstream by `__MISE_`, `MISE_SHELL` and `CLAUDE_CODE_`.

`PATH` and `NODE_PATH` get different treatment. They are listed in a new `DAEMON_ENV_NON_INVALIDATING_VARS` set: still reflected into the daemon, because graph construction resolves executables through them (`bun` for lockfile parsing, `mvn` for Maven inference), but filtered out of the returned changed keys. A launcher-shim difference in `PATH` updates the daemon's value without invalidating the graph.

Extends `daemon-environment.spec.ts` with coverage for the new exclusions, and for `PATH`/`NODE_PATH` being applied without being reported as changed.

### Possible follow-ups

Worth exploring separately, and deliberately not part of this PR:

- Making the exclusion list configurable via `nx.json`, so a workspace can silence churn from a var Nx doesn't know about without waiting on a release.
- A `nx.json` option to opt out of env-driven project graph invalidation entirely.
- Inverting the model: an explicit allowlist of env vars that *may* invalidate the graph cache, rather than an ever-growing denylist.

## Related Issue(s)

No GitHub issue — found while investigating repeated graph recomputes on a workspace driven by the CLI, Nx Console and an agent harness at the same time.

Builds on #36642, which covered the shell, terminal and editor half of the same problem. Rebased onto it, so this PR is now only the remainder.
