### PR TITLE
feat(dotnet): add evaluated MSBuild project tags

### DIFF
--- a/astro-docs/src/content/docs/technologies/dotnet/introduction.mdoc
+++ b/astro-docs/src/content/docs/technologies/dotnet/introduction.mdoc
@@ -111,6 +111,24 @@ The plugin analyzes your MSBuild project files to determine:
 - Available build targets (build, test, clean, etc.)
 - Project outputs and configuration
 
+## Define Nx project tags in MSBuild
+
+Use the evaluated `NxTags` property or `NxTag` items to add developer-authored taxonomy to a .NET project. This works with values defined in the project file or imported from `Directory.Build.props`.
+
+```xml
+<PropertyGroup>
+  <NxTags>scope:client;owner:devflow</NxTags>
+</PropertyGroup>
+
+<ItemGroup>
+  <NxTag Include="requires:emulator" />
+</ItemGroup>
+```
+
+The plugin adds a tag only when it applies to every evaluated inner build of a multi-target project. A tag conditioned on one target framework is not promoted to the Nx project. Nx project tags have no configuration-specific scope, so this feature does not model tags conditioned on `Configuration`; it reflects the configuration selected for the project graph.
+
+Use these tags for architecture and policy rules. The plugin does not infer tags from project type, language, target framework, runtime identifier, or build host. Tags emitted by `@nx/dotnet` merge with tags from `project.json` and other create-nodes plugins.
+
 ## View inferred tasks
 
 To view inferred tasks for a project, open the [project details view](/docs/features/explore-graph#explore-projects-in-your-workspace) in Nx Console or run `nx show project my-project` in the command line.

--- a/packages/dotnet/analyzer.Tests/NxTagsTests.cs
+++ b/packages/dotnet/analyzer.Tests/NxTagsTests.cs
@@ -1,0 +1,82 @@
+using System.Diagnostics;
+using System.Text.Json;
+using Xunit;
+
+namespace MsbuildAnalyzer.Tests;
+
+public class NxTagsTests
+{
+    [Fact]
+    public void EmitsOnlyTagsSharedByEveryTargetFramework()
+    {
+        var workspaceRoot = Path.Combine(Path.GetTempPath(), Path.GetRandomFileName());
+        Directory.CreateDirectory(workspaceRoot);
+        var projectPath = Path.Combine(workspaceRoot, "Tagged.csproj");
+
+        try
+        {
+            File.WriteAllText(
+                projectPath,
+                """
+                <Project Sdk="Microsoft.NET.Sdk">
+                  <PropertyGroup>
+                    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+                    <NxTags>scope:shared;owner:devflow</NxTags>
+                  </PropertyGroup>
+                  <PropertyGroup Condition="'$(TargetFramework)' == 'net8.0'">
+                    <NxTags>$(NxTags);tfm:net8.0</NxTags>
+                  </PropertyGroup>
+                  <ItemGroup>
+                    <NxTag Include="tfm:net8.0" Condition="'$(TargetFramework)' == 'net8.0'" />
+                    <NxTag Include="requires:emulator" />
+                  </ItemGroup>
+                </Project>
+                """);
+
+            using var result = RunAnalyzer(workspaceRoot, "Tagged.csproj");
+            var tags = result
+                .RootElement
+                .GetProperty("nodesByFile")
+                .GetProperty("Tagged.csproj")
+                .GetProperty("tags")
+                .EnumerateArray()
+                .Select(tag => tag.GetString())
+                .ToArray();
+
+            Assert.Equal(
+                new[] { "owner:devflow", "requires:emulator", "scope:shared" },
+                tags);
+        }
+        finally
+        {
+            Directory.Delete(workspaceRoot, recursive: true);
+        }
+    }
+
+    private static JsonDocument RunAnalyzer(
+        string workspaceRoot,
+        params string[] projectFiles)
+    {
+        var analyzerPath = Path.Combine(AppContext.BaseDirectory, "MsbuildAnalyzer.dll");
+        var startInfo = new ProcessStartInfo("dotnet")
+        {
+            RedirectStandardInput = true,
+            RedirectStandardOutput = true,
+            RedirectStandardError = true,
+        };
+        startInfo.ArgumentList.Add(analyzerPath);
+        startInfo.ArgumentList.Add(workspaceRoot);
+
+        using var process = Process.Start(startInfo)!;
+        process.StandardInput.Write(string.Join(Environment.NewLine, projectFiles));
+        process.StandardInput.Close();
+
+        var output = process.StandardOutput.ReadToEnd();
+        var error = process.StandardError.ReadToEnd();
+        process.WaitForExit();
+
+        Assert.True(process.ExitCode == 0, error);
+
+        return JsonDocument.Parse(output);
+    }
+}

--- a/packages/dotnet/analyzer/Analyzer.cs
+++ b/packages/dotnet/analyzer/Analyzer.cs
@@ -148,6 +148,13 @@ public static class Analyzer
                     // Build targets
                     var projectName = ProjectUtilities.GetProjectName(primaryNode.ProjectInstance);
                     var projectDirectory = Path.GetDirectoryName(projectPath)!;
+                    var innerBuilds = nodes
+                        .Where(node => !string.IsNullOrEmpty(
+                            node.ProjectInstance?.GetPropertyValue("TargetFramework")))
+                        .Select(node => node.ProjectInstance!)
+                        .ToList();
+                    var tags = ProjectUtilities.GetCommonNxTags(
+                        innerBuilds.Any() ? innerBuilds : nodes.Select(node => node.ProjectInstance!));
 
                     // The closest Directory.Build.* / Directory.Solution.* ancestors that exist
                     // for this project — declared as inputs on every target that already has an
@@ -176,6 +183,7 @@ public static class Analyzer
                     {
                         Name = projectName,
                         Root = projectRoot,
+                        Tags = tags,
                         Targets = targets,
                         Metadata = new Models.ProjectMetadata
                         {

--- a/packages/dotnet/analyzer/Models/ProjectNode.cs
+++ b/packages/dotnet/analyzer/Models/ProjectNode.cs
@@ -15,6 +15,8 @@ public record NxProjectGraphNode
     /// </summary>
     public string Root { get; init; } = string.Empty;
 
+    public List<string> Tags { get; init; } = new();
+
     /// <summary>
     /// Nx targets available for this project.
     /// </summary>

--- a/packages/dotnet/analyzer/Utilities/ProjectUtilities.cs
+++ b/packages/dotnet/analyzer/Utilities/ProjectUtilities.cs
@@ -58,6 +58,37 @@ public static class ProjectUtilities
         return msbuildProjectName;
     }
 
+    public static List<string> GetCommonNxTags(IEnumerable<ProjectInstance> projects)
+    {
+        HashSet<string>? commonTags = null;
+
+        foreach (var project in projects)
+        {
+            var projectTags = new HashSet<string>(StringComparer.Ordinal);
+            projectTags.UnionWith(SplitMsBuildList(project.GetPropertyValue("NxTags")));
+            projectTags.UnionWith(
+                project
+                    .GetItems("NxTag")
+                    .SelectMany(item => SplitMsBuildList(item.EvaluatedInclude)));
+
+            if (commonTags is null)
+            {
+                commonTags = projectTags;
+            }
+            else
+            {
+                commonTags.IntersectWith(projectTags);
+            }
+        }
+
+        return commonTags?
+            .OrderBy(tag => tag, StringComparer.Ordinal)
+            .ToList() ?? new List<string>();
+    }
+
+    private static IEnumerable<string> SplitMsBuildList(string value) =>
+        value.Split(';', StringSplitOptions.TrimEntries | StringSplitOptions.RemoveEmptyEntries);
+
     /// <summary>
     /// Directory.Build.props/.targets are auto-imported by Microsoft.Common.props/.targets, walking
     /// up from the project to the first ancestor that defines them. Directory.Build.rsp is read by


### PR DESCRIPTION
## Current Behavior

`@nx/dotnet` does not expose developer-authored Nx tags from evaluated MSBuild properties or items.

## Expected Behavior

`@nx/dotnet` reads explicit `NxTags` and `NxTag` values from evaluated MSBuild and emits only tags shared by every evaluated inner build. Tags remain developer-authored; target-framework-specific values are not flattened to the project, and configuration-scoped tags have no separate project-tag output.

## Related Issue(s)

Discussion #36676: https://github.com/nrwl/nx/discussions/36676